### PR TITLE
Fix bad error message (bad content length)

### DIFF
--- a/errorAccum.go
+++ b/errorAccum.go
@@ -76,6 +76,9 @@ func IsRetryable(err error) bool {
 	if errors.Is(err, &SlowTransferError{}) {
 		return true
 	}
+	if errors.Is(err, grab.ErrBadLength) {
+		return false
+	}
 	var cse *ConnectionSetupError
 	if errors.As(err, &cse) {
 		if sce, ok := cse.Unwrap().(grab.StatusCodeError); ok {

--- a/handle_http.go
+++ b/handle_http.go
@@ -478,6 +478,10 @@ func DownloadHTTP(transfer TransferDetails, dest string, token string) (int64, e
 	// Check the error real quick
 	if resp.IsComplete() {
 		if err := resp.Err(); err != nil {
+			if errors.Is(err, grab.ErrBadLength) {
+				grab.ErrBadLength = errors.New("Local copy of file is larger than remote copy")
+				err = grab.ErrBadLength
+			}
 			log.Errorln("Failed to download:", err)
 			return 0, &ConnectionSetupError{Err: err}
 		}

--- a/handle_http.go
+++ b/handle_http.go
@@ -479,8 +479,7 @@ func DownloadHTTP(transfer TransferDetails, dest string, token string) (int64, e
 	if resp.IsComplete() {
 		if err := resp.Err(); err != nil {
 			if errors.Is(err, grab.ErrBadLength) {
-				grab.ErrBadLength = errors.New("Local copy of file is larger than remote copy")
-				err = grab.ErrBadLength
+				err = fmt.Errorf("Local copy of file is larger than remote copy %w", grab.ErrBadLength)
 			}
 			log.Errorln("Failed to download:", err)
 			return 0, &ConnectionSetupError{Err: err}


### PR DESCRIPTION
The error message 'bad content length' was given when the local copy of a file is larger than the remote server copy when downloading a file. The error message now reads 'Local copy of file is larger than remote copy' which I believe is much clearer. In addition, fixed the bug stating the error is retryable. It no longer states this type of error is retryable. This fixed issue #52 in htcondor/osdf-client