### PR TITLE
Have UI always use TLS

### DIFF
--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"net/http"
 	"path"
 	"path/filepath"
 	"strings"
@@ -20,13 +19,13 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/pelicanplatform/pelican"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/origin_ui"
+	"github.com/pelicanplatform/pelican/web_ui"
 	"github.com/pkg/errors"
 )
 
@@ -510,44 +509,21 @@ func serve(/*cmd*/ *cobra.Command, /*args*/ []string) error {
 		return err
 	}
 
-	gin.SetMode(gin.ReleaseMode)
-	engine := gin.New()
-	engine.Use(gin.Recovery())
-	webLogger := log.WithFields(log.Fields{"daemon": "gin"})
-	engine.Use(func(ctx *gin.Context) {
-		startTime := time.Now()
-
-		ctx.Next()
-
-		latency := time.Since(startTime)
-		webLogger.WithFields(log.Fields{"method": ctx.Request.Method,
-			"status": ctx.Writer.Status(),
-			"time": latency.String(),
-			"client": ctx.RemoteIP(),
-			"resource": ctx.Request.URL.Path},
-		).Info("Served Request")
-	})
-	if err = pelican.ConfigureMetrics(engine); err != nil {
+	engine, err := web_ui.GetEngine()
+	if err != nil {
 		return err
 	}
 	if err = origin_ui.ConfigureOriginUI(engine); err != nil {
 		return err
 	}
 
-	engine.GET("/api/v1.0/health", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{"status": "healthy"})
-	})
-
-	go func() {
-		err = engine.Run()
-		if err != nil {
-			panic(err)
-		}
-	}()
+	go web_ui.RunEngine(engine)
 
 	// Ensure we wait until the origin has been initialized
 	// before launching XRootD.
-	origin_ui.WaitUntilLogin()
+	if err = origin_ui.WaitUntilLogin(); err != nil {
+		return err
+	}
 
 	err = launchXrootd()
 	if err != nil {

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"bufio"
+	"crypto/elliptic"
 	"crypto/rand"
 	_ "embed"
 	"encoding/base64"
@@ -310,7 +311,7 @@ func checkDefaults() error {
 	}
 
 	// As necessary, generate a private key and corresponding cert
-	if err := config.GeneratePrivateKey(viper.GetString("TLSKey")); err != nil {
+	if err := config.GeneratePrivateKey(viper.GetString("TLSKey"), elliptic.P256()); err != nil {
 		return err
 	}
 	if err := config.GenerateCert(); err != nil {

--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -119,7 +119,7 @@ func GenerateCert() error {
 	return nil
 }
 
-func GeneratePrivateKey(keyLocation string) error {
+func GeneratePrivateKey(keyLocation string, curve elliptic.Curve) error {
 	gid, err := GetDaemonGID()
 	if err != nil {
 		return err
@@ -145,7 +145,7 @@ func GeneratePrivateKey(keyLocation string) error {
 		return err
 	}
 	defer file.Close()
-	priv, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	priv, err := ecdsa.GenerateKey(curve, rand.Reader)
 	if err != nil {
 		return err
 	}
@@ -177,7 +177,7 @@ func GenerateIssuerJWKS() (*jwk.Set, error) {
 		}
 	}
 	issuerKeyFile := viper.GetString("IssuerKey")
-	if err := GeneratePrivateKey(issuerKeyFile); err != nil {
+	if err := GeneratePrivateKey(issuerKeyFile, elliptic.P521()); err != nil {
 		return nil, err
 	}
 	contents, err := os.ReadFile(issuerKeyFile)

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -1,4 +1,6 @@
 Port: 8443
+WebPort: 8444
+WebAddress: "0.0.0.0"
 ManagerPort: 1213
 SummaryMonitoringPort: 9931
 DetailedMonitoringPort: 9930

--- a/metrics.go
+++ b/metrics.go
@@ -11,14 +11,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/jellydator/ttlcache/v3"
         "github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
         log "github.com/sirupsen/logrus"
         "github.com/spf13/viper"
-	"github.com/zsais/go-gin-prometheus"
 )
 
 type (
@@ -182,17 +180,6 @@ func ConfigureMonitoring() (int, error) {
 
 	return addr.Port, nil
 }
-
-func ConfigureMetrics(engine *gin.Engine) error {
-	prometheusMonitor := ginprometheus.NewPrometheus("gin")
-	prometheusMonitor.Use(engine)
-	/*handler := promhttp.Handler()
-	engine.GET("/metrics", func(context *gin.Context) {
-		handler.ServeHTTP(context.Writer, context.Request)
-	})*/
-	return nil
-}
-
 
 
 func ComputePrefix(inputPath string) string {

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -1,0 +1,52 @@
+
+package web_ui
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
+	"github.com/zsais/go-gin-prometheus"
+)
+
+func ConfigureMetrics(engine *gin.Engine) error {
+	prometheusMonitor := ginprometheus.NewPrometheus("gin")
+	prometheusMonitor.Use(engine)
+
+	engine.GET("/api/v1.0/health", func(ctx *gin.Context) {
+		ctx.JSON(http.StatusOK, gin.H{"status": "healthy"})
+	})
+	return nil
+}
+
+func GetEngine() (*gin.Engine, error) {
+	gin.SetMode(gin.ReleaseMode)
+	engine := gin.New()
+	engine.Use(gin.Recovery())
+	webLogger := log.WithFields(log.Fields{"daemon": "gin"})
+	engine.Use(func(ctx *gin.Context) {
+		startTime := time.Now()
+
+		ctx.Next()
+
+		latency := time.Since(startTime)
+		webLogger.WithFields(log.Fields{"method": ctx.Request.Method,
+			"status": ctx.Writer.Status(),
+			"time": latency.String(),
+			"client": ctx.RemoteIP(),
+			"resource": ctx.Request.URL.Path},
+		).Info("Served Request")
+	})
+	if err := ConfigureMetrics(engine); err != nil {
+		return nil, err
+	}
+	return engine, nil
+}
+
+func RunEngine(engine *gin.Engine) {
+	err := engine.Run()
+	if err != nil {
+		panic(err)
+	}
+}

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -2,11 +2,13 @@
 package web_ui
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 	"github.com/zsais/go-gin-prometheus"
 )
 
@@ -45,7 +47,12 @@ func GetEngine() (*gin.Engine, error) {
 }
 
 func RunEngine(engine *gin.Engine) {
-	err := engine.Run()
+	certFile := viper.GetString("TLSCertificate")
+	keyFile := viper.GetString("TLSKey")
+
+	addr := fmt.Sprintf("%v:%v", viper.GetString("WebAddress"), viper.GetInt("WebPort"))
+
+	err := engine.RunTLS(addr, certFile, keyFile)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- Factor out the engine launching code into a common `web_ui` module.
- Fix the generation of the host certificate to use a key compatible with Chrome (issuer key is unchanged).
- Change the Gin engine startup to always run with TLS.