### PR TITLE
Have origin advertise to the director service

### DIFF
--- a/cmd/director_serve.go
+++ b/cmd/director_serve.go
@@ -5,6 +5,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/director"
 	"github.com/pelicanplatform/pelican/web_ui"
 	log "github.com/sirupsen/logrus"
@@ -15,12 +16,14 @@ func serveDirector( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	log.Info("Initializing Director GeoIP database...")
 	director.InitializeDB()
 
-	log.Info("Generating/advertising server ads...")
+	if config.GetPreferredPrefix() == "OSDF" {
+		log.Info("Generating/advertising server ads from OSG topology service...")
 
-	// Get the ads from topology, populate the cache, and keep the cache
-	// updated with fresh info
-	if err := director.AdvertiseOSDF(); err != nil {
-		panic(err)
+		// Get the ads from topology, populate the cache, and keep the cache
+		// updated with fresh info
+		if err := director.AdvertiseOSDF(); err != nil {
+			panic(err)
+		}
 	}
 	go director.PeriodicCacheReload()
 

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -517,6 +517,9 @@ func serveOrigin(/*cmd*/ *cobra.Command, /*args*/ []string) error {
 	if err = origin_ui.ConfigureOriginUI(engine); err != nil {
 		return err
 	}
+	if err = origin_ui.PeriodicAdvertiseOrigin(); err != nil {
+		return err
+	}
 
 	go web_ui.RunEngine(engine)
 

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -499,6 +499,11 @@ func launchXrootd() error {
 func serveOrigin(/*cmd*/ *cobra.Command, /*args*/ []string) error {
 	defer config.CleanupTempResources()
 
+	err := config.DiscoverFederation()
+	if err != nil {
+		log.Warningln("Failed to do service auto-discovery:", err)
+	}
+
 	monitorPort, err := pelican.ConfigureMonitoring()
 	if err != nil {
 		return err

--- a/config/config.go
+++ b/config/config.go
@@ -115,14 +115,17 @@ func GetAllPrefixes() []string {
 func DiscoverFederation() error {
 	federationStr := viper.GetString("FederationURL")
 	if len(federationStr) == 0 {
+		log.Debugln("Federation URL is unset; skipping discovery")
 		return nil
 	}
+	log.Debugln("Federation URL:", federationStr)
 	curDirectorURL := viper.GetString("DirectorURL")
 	curNamespaceURL := viper.GetString("DirectorURL")
 	if len(curDirectorURL) != 0 && len(curNamespaceURL) != 0 {
 		return nil
 	}
 
+	log.Debugln("Performing federation service discovery against endpoint", federationStr)
 	federationUrl, err := url.Parse(federationStr)
 	if err != nil {
 		return errors.Wrapf(err, "Invalid federation value %s:", federationStr)
@@ -165,9 +168,12 @@ func DiscoverFederation() error {
 		return errors.Wrapf(err, "Failure when parsing federation metadata at %s", discoveryUrl)
 	}
 	if curDirectorURL == "" {
+		log.Debugln("Federation service discovery resulted in director URL", metadata.DirectorEndpoint)
 		viper.Set("DirectorURL", metadata.DirectorEndpoint)
 	}
 	if curNamespaceURL == "" {
+		log.Debugln("Federation service discovery resulted in namespace registration URL",
+			metadata.NamespaceRegistrationEndpoint)
 		viper.Set("NamespaceURL", metadata.NamespaceRegistrationEndpoint)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -118,7 +118,8 @@ func DiscoverFederation() error {
 		return nil
 	}
 	curDirectorURL := viper.GetString("DirectorURL")
-	if len(curDirectorURL) != 0 {
+	curNamespaceURL := viper.GetString("DirectorURL")
+	if len(curDirectorURL) != 0 && len(curNamespaceURL) != 0 {
 		return nil
 	}
 
@@ -163,7 +164,12 @@ func DiscoverFederation() error {
 	if err != nil {
 		return errors.Wrapf(err, "Failure when parsing federation metadata at %s", discoveryUrl)
 	}
-	viper.Set("DirectorURL", metadata.DirectorEndpoint)
+	if curDirectorURL == "" {
+		viper.Set("DirectorURL", metadata.DirectorEndpoint)
+	}
+	if curNamespaceURL == "" {
+		viper.Set("NamespaceURL", metadata.NamespaceRegistrationEndpoint)
+	}
 
 	return nil
 }

--- a/config/resources/osdf.yaml
+++ b/config/resources/osdf.yaml
@@ -1,3 +1,4 @@
 ManagerHost: redirector.osgstorage.org
 SummaryMonitoringHost: xrd-report.osgstorage.org
 DetailedMonitoringHost: xrd-mon.osgstorage.org
+TopologyNamespaceURL: https://topology.opensciencegrid.org/stashcache/namespaces.json

--- a/director/advertise.go
+++ b/director/advertise.go
@@ -49,9 +49,9 @@ type (
 
 // Populate internal cache with origin/cache ads
 func AdvertiseOSDF() error {
-	namespaceURL := viper.GetString("NamespaceURL")
+	namespaceURL := viper.GetString("TopologyNamespaceURL")
 	if namespaceURL == "" {
-		return errors.New("NamespaceURL configuration option not set")
+		return errors.New("Topology namespaces.json configuration option (`TopologyNamespaceURL`) not set")
 	}
 
 	req, err := http.NewRequest("GET", namespaceURL, nil)

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -22,7 +22,7 @@ type (
 	OriginAdvertise struct {
 		Name string `json:"name"`
 		URL string  `json:"url"`
-		Namespace string `json:"namespace"`
+		Namespaces []NamespaceAd `json:"namespaces"`
 	}
 
 )
@@ -96,7 +96,7 @@ func VerifyAdvertiseToken(token, namespace string) (bool, error) {
 		return false, err
 	}
 
-	tok, err := jwt.Parse([]byte(token), jwt.WithKeySet(keyset))
+	tok, err := jwt.Parse([]byte(token), jwt.WithKeySet(keyset), jwt.WithValidate(true))
 	if err != nil {
 		return false, err
 	}

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -1,0 +1,134 @@
+package director
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jellydator/ttlcache/v3"
+	"github.com/lestrrat-go/jwx/jwa"
+	"github.com/lestrrat-go/jwx/jwk"
+	"github.com/lestrrat-go/jwx/jwt"
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/spf13/viper"
+)
+
+type (
+
+	OriginAdvertise struct {
+		Name string `json:"name"`
+		URL string  `json:"url"`
+		Namespace string `json:"namespace"`
+	}
+
+)
+
+var (
+	namespaceKeys = ttlcache.New[string, *jwk.AutoRefresh](ttlcache.WithTTL[string, *jwk.AutoRefresh](15 * time.Minute))
+	namespaceKeysMutex = sync.RWMutex{}
+)
+
+
+func CreateAdvertiseToken(namespace string) (string, error) {
+	key, err := config.GetOriginJWK()
+	if err != nil {
+		return "", err
+	}
+	issuer_url, err := GetIssuerURL(namespace)
+	if err != nil {
+		return "", err
+	}
+	director := viper.GetString("DirectorURL")
+	if director == "" {
+		return "", errors.New("Director URL is not known; cannot create advertise token")
+	}
+
+	tok, err := jwt.NewBuilder().
+		Claim("scope", "pelican.advertise").
+		Issuer(issuer_url).
+		Audience([]string{director}).
+		Subject("origin").
+		Expiration(time.Now().Add(time.Minute)).
+		Build()
+	if err != nil {
+		return "", err
+	}
+
+	signed, err := jwt.Sign(tok, jwa.ES512, key)
+	if err != nil {
+		return "", err
+	}
+	return string(signed), nil
+}
+
+//
+// Given a token and a location in the namespace to advertise in,
+// see if the entity is authorized to advertise an origin for the
+// namespace
+func VerifyAdvertiseToken(token, namespace string) (bool, error) {
+	issuer_url, err := GetIssuerURL(namespace)
+	if err != nil {
+		return false, err
+	}
+	var ar *jwk.AutoRefresh
+	{
+		namespaceKeysMutex.RLock()
+		defer namespaceKeysMutex.Unlock()
+		item := namespaceKeys.Get(namespace)
+		if !item.IsExpired() {
+			ar = item.Value()
+		}
+	}
+	ctx := context.Background()
+	if ar == nil {
+		ar := jwk.NewAutoRefresh(ctx)
+		ar.Configure(issuer_url, jwk.WithMinRefreshInterval(15 * time.Minute))
+		namespaceKeysMutex.Lock()
+		defer namespaceKeysMutex.Unlock()
+		namespaceKeys.Set(namespace, ar, ttlcache.DefaultTTL)
+	}
+	keyset, err := ar.Fetch(ctx, issuer_url)
+	if err != nil {
+		return false, err
+	}
+
+	tok, err := jwt.Parse([]byte(token), jwt.WithKeySet(keyset))
+	if err != nil {
+		return false, err
+	}
+
+	scope_any, present := tok.Get("scope")
+	if !present {
+		return false, errors.New("No scope is present; required to advertise to director")
+	}
+	scope, ok := scope_any.(string)
+	if !ok {
+		return false, errors.New("scope claim in token is not string-valued")
+	}
+
+	scopes := strings.Split(scope, " ")
+
+	for _, scope := range(scopes) {
+		if scope == "pelican.advertise" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func GetIssuerURL(prefix string) (string, error) {
+	namespace_url_string := viper.GetString("NamespaceURL")
+	if namespace_url_string == "" {
+		return "", errors.New("Namespace URL is not set")
+	}
+	namespace_url, err := url.Parse(namespace_url_string)
+	if err != nil {
+		return "", err
+	}
+	namespace_url.Path = path.Join(namespace_url.Path, "namespaces", prefix)
+	return namespace_url.String(), nil
+}

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -1,9 +1,14 @@
 package origin_ui
 
 import (
-	"errors"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
 
 	"github.com/pelicanplatform/pelican/director"
+	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 )
 
@@ -13,13 +18,46 @@ func AdvertiseOrigin() error {
 		return errors.New("Origin name isn't set")
 	}
 	// TODO: waiting on a different branch to merge origin URL generation
-	url := "https://localhost:8444"
+	originUrl := "https://localhost:8444"
 
 	ad := director.OriginAdvertise{
 		Name: name,
-		URL:  url,
+		URL:  originUrl,
 		Namespaces: make([]director.NamespaceAd, 0),
 	}
-	_ = ad
+
+	body, err := json.Marshal(ad)
+	if err != nil {
+		return errors.Wrap(err, "Failed to generate JSON description of origin")
+	}
+
+	directorUrlStr := viper.GetString("DirectorURL")
+	if directorUrlStr == "" {
+		return errors.New("Director endpoint URL is not known")
+	}
+	directorUrl, err := url.Parse(directorUrlStr)
+	if err != nil {
+		return errors.Wrap(err, "Failed to parse DirectorURL")
+	}
+	directorUrl.Path = "/api/v1.0/director/registerOrigin"
+
+	req, err := http.NewRequest("POST", directorUrl.String(), bytes.NewBuffer(body))
+	if err != nil {
+		return errors.Wrap(err, "Failed to create POST request for director registration")
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	client := http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "Failed to start request for director registration")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode > 299 {
+		return fmt.Errorf("Error response %v from director registration: %v", resp.StatusCode, resp.Status)
+	}
+
 	return nil
 }

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -1,0 +1,25 @@
+package origin_ui
+
+import (
+	"errors"
+
+	"github.com/pelicanplatform/pelican/director"
+	"github.com/spf13/viper"
+)
+
+func AdvertiseOrigin() error {
+	name := viper.GetString("Sitename")
+	if name == "" {
+		return errors.New("Origin name isn't set")
+	}
+	// TODO: waiting on a different branch to merge origin URL generation
+	url := "https://localhost:8444"
+
+	ad := director.OriginAdvertise{
+		Name: name,
+		URL:  url,
+		Namespaces: make([]director.NamespaceAd, 0),
+	}
+	_ = ad
+	return nil
+}

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -6,11 +6,32 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/pelicanplatform/pelican/director"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
+
+func PeriodicAdvertiseOrigin() error {
+	ticker := time.NewTicker(1 * time.Minute)
+	go func() {
+		err := AdvertiseOrigin()
+		if err != nil {
+			log.Warningln("Origin advertise failed:", err)
+		}
+		for {
+			<-ticker.C
+			err := AdvertiseOrigin()
+			if err != nil {
+				log.Warningln("Origin advertise failed:", err)
+			}
+		}
+	}()
+
+	return nil
+}
 
 func AdvertiseOrigin() error {
 	name := viper.GetString("Sitename")

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -2,6 +2,7 @@ package origin_ui
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -70,6 +71,12 @@ func AdvertiseOrigin() error {
 	req.Header.Set("Content-Type", "application/json")
 
 	client := http.Client{}
+	if viper.GetBool("TLSSkipVerify") {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client = http.Client{Transport: tr}
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return errors.Wrap(err, "Failed to start request for director registration")


### PR DESCRIPTION
This draft is the first piece of the periodic advertisement of the origin to the director service.  When complete, it'll contain:
- New APIs in the director for advertising services
- Periodic go routine in the origin code to invoke new APIs
- Bearer token generation / verification for authorizing the advertisement.

Goal is that all origins connecting to the director advertise their capabilities directly (and verified by the namespace registration service) instead of relying on OSG Topology to bootstrap the namespace.