### PR TITLE
Do not create key with group read permissions

### DIFF
--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -140,7 +140,7 @@ func GeneratePrivateKey(keyLocation string, curve elliptic.Curve) error {
 		return err
 	}
 	// In this case, the private key file doesn't exist.
-	file, err := os.OpenFile(keyLocation, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0640)
+	file, err := os.OpenFile(keyLocation, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
XRootD is picky about the generated key being mode 0600; decrease permissions to make it happy.