### PR TITLE
Allow passing key directly via CL

### DIFF
--- a/director/sort.go
+++ b/director/sort.go
@@ -96,15 +96,22 @@ func DownloadDB(localFile string) error {
 	if err != nil {
 		return err
 	}
+
+	var licenseKey string
 	keyFile := viper.GetString("MaxMindKeyFile")
-	if keyFile == "" {
-		return errors.New("No MaxMind license key found in MaxMindKeyFile config parameter")
+	keyFromEnv := viper.GetString("MAXMINDKEY")
+	if keyFile != "" {
+		contents, err := os.ReadFile(keyFile)
+		if err != nil {
+			return err
+		}
+		licenseKey = strings.TrimSpace(string(contents))
+	} else if keyFromEnv != "" {
+		licenseKey = keyFromEnv
+	} else {
+		return errors.New("A MaxMind key file must be specified in the config (MaxMindKeyFile), in the environment (PELICAN_MAXMINDKEYFILE), or the key must be provided via the environment variable PELICAN_MAXMINDKEY)")
 	}
-	contents, err := os.ReadFile(keyFile)
-	if err != nil {
-		return err
-	}
-	licenseKey := strings.TrimSpace(string(contents))
+
 	url := fmt.Sprintf(maxMindURL, licenseKey)
 	localDir := filepath.Dir(localFile)
 	fileHandle, err := os.CreateTemp(localDir, filepath.Base(localFile)+".tmp")


### PR DESCRIPTION
For the kubernetes deployment of the Director, it would be more convenient to pass the MaxMind key as an environment variable via the sealedSecret mechanism than trying to get the value safely into a configMap. 