### PR TITLE
Dockerize

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,0 +1,141 @@
+
+name: Release, Build, and Push
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+    branches:
+      - main
+  repository_dispatch:
+    types:
+      - dispatch-build
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.19
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro'
+          distribution: goreleaser
+          version: latest
+          # Switch this to release by removing snapshot later
+          args: release --clean --snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
+          # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+
+      - name: Upload GoReleaser artifacts
+        uses: actions/upload-artifact@v3
+        with: 
+          name: pelican-artifacts
+          path: dist/
+
+  make-date-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      dtag: ${{ steps.mkdatetag.outputs.dtag }}
+    steps:
+      - name: make date tag
+        id: mkdatetag
+        run: echo "dtag=$(date +%Y%m%d-%H%M)" >> $GITHUB_OUTPUT
+        #run: echo "::set-output name=dtag::$(date +%Y%m%d-%H%M)"
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [goreleaser, make-date-tag]
+    strategy:
+      fail-fast: False
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download GoReleaser Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: pelican-artifacts
+          path: ~/dist
+
+      - name: Generate tag list
+        id: generate-tag-list
+        env:
+          TIMESTAMP: ${{ needs.make-date-tag.outputs.dtag }}
+        # Here, we either tag the container with the "latest" tag if
+        # the commit that triggered this action doesn't have a tag,
+        # or we tag it with the commit's tag if one exists
+        run: |
+          # Check if we're working with a tagged version
+          if [ -z "${{ inputs.tag }}" ]
+          then
+            # Use regex to check for a semver tag match
+            if [[ ${GITHUB_REF##*/} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]
+            then
+              GITHUB_TAG=${GITHUB_REF##*/}
+            else
+              GITHUB_TAG="latest"
+            fi
+          else
+            GITHUB_TAG=${{ inputs.tag }}
+          fi
+
+          echo "Master SHA:"
+          echo $(git rev-parse $GITHUB_REF_NAME)
+
+          echo "Current SHA:"
+          echo $(git rev-parse HEAD)
+
+          echo $GITHUB_TAG
+
+          docker_repo="pelican_platform/pelican"
+          tag_list=()
+          for registry in hub.opensciencegrid.org; do
+            for image_tag in "$GITHUB_TAG"; do
+              tag_list+=("$registry/$docker_repo":"$image_tag")
+            done
+          done
+          # This causes the tag_list array to be comma-separated below,
+          # which is required for build-push-action
+          IFS=,
+          echo "::set-output name=taglist::${tag_list[*]}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to OSG Harbor
+        uses: docker/login-action@v1
+        with:
+          registry: hub.opensciencegrid.org
+          username: ${{ secrets.PELICAN_HARBOR_ROBOT_USER }}
+          password: ${{ secrets.PELICAN_HARBOR_ROBOT_PASSWORD }}
+          
+      - name: Copy GoReleaser Artifact into Docker context
+        # For now, only working about the linux amd64 artifact,
+        # but we should probably look at building containers for
+        # multiple platforms at some point...
+        run: |
+          cp ~/dist/pelican_linux_amd64_v1/pelican .
+        working-directory: ./images 
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v2.2.0
+        with:
+          context: .
+          file: ./images/Dockerfile
+          push: true
+          tags: "${{ steps.generate-tag-list.outputs.taglist }}"

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -56,7 +56,6 @@ jobs:
       - name: make date tag
         id: mkdatetag
         run: echo "dtag=$(date +%Y%m%d-%H%M)" >> $GITHUB_OUTPUT
-        #run: echo "::set-output name=dtag::$(date +%Y%m%d-%H%M)"
 
   build:
     runs-on: ubuntu-latest

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,0 +1,30 @@
+ARG BASE_YUM_REPO=release
+ARG BASE_OSG_SERIES=3.6
+
+FROM opensciencegrid/software-base:$BASE_OSG_SERIES-el7-$BASE_YUM_REPO
+
+# Install dependencies
+RUN yum -y update \
+    && yum -y install golang \
+    && yum clean all \
+    && rm -rf /var/cache/yum/
+
+WORKDIR /pelican
+
+# Copy over needed files
+# The build+push action that builds this dockerfile will copy the
+# linux/amd64 pelican artifact into the correct spot whenever the action
+# is triggered.
+COPY pelican /pelican
+COPY supervisord/supervisord.conf /etc/supervisord.conf
+
+# Eventually add more entrypoint commands and corresponding supervisor
+# daemons here
+COPY supervisord/pelican_director_serve.conf /etc/supervisord.d/pelican_director_serve.conf
+COPY entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh \
+    && chmod +x /pelican/pelican \
+
+ENTRYPOINT ["/entrypoint.sh"]
+

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+supervisord -c /etc/supervisord.conf
+
+# grab whatever arg is passed to container run command
+# and use it to launch the corresponding pelican_X daemon
+# (eg running the container with the arg director_serve will
+# launch the pelican_director_serve daemon through supervisord)
+if [ "$1" ]; then
+  supervisorctl start "pelican_$1"
+  # Keep the container running
+  tail -f /dev/null
+else
+  echo "A command must be provided"
+fi
+
+

--- a/images/supervisord/pelican_director_serve.conf
+++ b/images/supervisord/pelican_director_serve.conf
@@ -1,0 +1,4 @@
+[program:pelican_director_serve]
+command=/pelican/pelican director serve -p %(ENV_PELICAN_DIRECTOR_PORT)s
+autorestart=true
+redirect_stderr=true

--- a/images/supervisord/supervisord.conf
+++ b/images/supervisord/supervisord.conf
@@ -1,0 +1,19 @@
+[supervisord]
+nodaemon=true
+pidfile=/var/run/supervisord.pid
+logfile=/var/log/supervisord.log
+childlogdir = /var/log/supervisor
+
+[unix_http_server]
+file=/tmp/supervisor.sock   ; (the path to the socket file)
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock         ; use a unix:// URL  for a unix socket
+loglevel=debug
+
+[include]
+files=/etc/supervisord.d/*.conf
+


### PR DESCRIPTION
Two related pieces in this PR:

First, the contents in the new `/images` are what I've cooked up for building a container that enters in the `entrypoint.sh` script. The idea is that a kubernetes deployment can launch the pod with an argument like "director_serve" and this will cause the entrypoint script to launch the `pelican_director_serve` daemon through supervisord on the specified port. I haven't added supervisord configurations for the namespace registry or the origin because I thought those would be best added by the people most familiar with them. 

Second, the new build+push action will trigger whenever there's a push to main or a tag that matches v[0-9]+.[0-9]+.[0-9]+. This will cause goreleaser to run and generate its release artifacts. In particular, the release binary artifact for linux/amd64 will be used later to build the container (at some point it would be good to think about other architectures, but let's walk before we run). The action should then push the container to harbor with a tag that's either "latest" in the event that the action was triggered by a regular push, or a tag matching the commit's tag if the commit has a tag. I thought this might be a nice way to handle keeping tagged stable versions and development versions of the container organized in harbor.