### PR TITLE
Namespace client cleanup

### DIFF
--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"errors"
 	"os"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -11,26 +14,58 @@ import (
 
 var withIdentity bool
 var prefix string
-var host string
+var namespaceURL string
 var jwks bool
 var pubkeyPath string
 var privkeyPath string
 
+func getNamespaceEndpoint() (string, error) {
+	namespaceEndpoint := namespaceURL
+	if namespaceEndpoint == "" {
+		namespaceEndpoint = viper.GetString("NamespaceURL")
+	}
+	if namespaceEndpoint == "" {
+		return "", errors.New("No namespace registry specified; either give the federation name (-f) or specify the namespace API endpoint directly (e.g., --namespace-url=https://namespace.osg-htc.org/namespaces)")
+	}
+	return namespaceEndpoint, nil
+}
+
 func registerANamespace(cmd *cobra.Command, args []string) {
-	endpoint := host + "/registry"
+	err := config.InitClient()
+	if err != nil {
+		log.Error(err)
+		os.Exit(1)
+	}
+
+	privkey := privkeyPath
+	if privkey == "" {
+		privkey = viper.GetString("IssuerKey")
+	}
+	if privkey == "" {
+		log.Error("Private key file is not set; specify its location with the --privkey option or by setting the IssuerKey configuration variable")
+		os.Exit(1)
+	}
+
+	namespaceEndpoint, err := getNamespaceEndpoint()
+	if err != nil {
+		log.Error(err)
+		os.Exit(1)
+	}
+
+	endpoint := namespaceEndpoint + "/registry"
 	if prefix == "" {
 		log.Error("Error: prefix is required")
 		os.Exit(1)
 	}
 
 	if withIdentity {
-		err := namespace_register_with_identity(pubkeyPath, privkeyPath, endpoint, prefix)
+		err := namespace_register_with_identity(privkey, endpoint, prefix)
 		if err != nil {
 			log.Error(err)
 			os.Exit(1)
 		}
 	} else {
-		err := namespace_register(pubkeyPath, privkeyPath, endpoint, "", prefix)
+		err := namespace_register(privkey, endpoint, "", prefix)
 		if err != nil {
 			log.Error(err)
 			os.Exit(1)
@@ -39,8 +74,19 @@ func registerANamespace(cmd *cobra.Command, args []string) {
 }
 
 func deleteANamespace(cmd *cobra.Command, args []string) {
-	endpoint := host + "/" + prefix
-	err := delete_namespace(endpoint)
+	err := config.InitClient()
+	if err != nil {
+		log.Error(err)
+		os.Exit(1)
+	}
+	namespaceEndpoint, err := getNamespaceEndpoint()
+	if err != nil {
+		log.Error(err)
+		os.Exit(1)
+	}
+
+	endpoint := namespaceEndpoint + "/" + prefix
+	err = delete_namespace(endpoint)
 	if err != nil {
 		log.Error(err)
 		os.Exit(1)
@@ -48,8 +94,19 @@ func deleteANamespace(cmd *cobra.Command, args []string) {
 }
 
 func listAllNamespaces(cmd *cobra.Command, args []string) {
-	endpoint := host
-	err := list_namespaces(endpoint)
+	err := config.InitClient()
+	if err != nil {
+		log.Error(err)
+		os.Exit(1)
+	}
+	namespaceEndpoint, err := getNamespaceEndpoint()
+	if err != nil {
+		log.Error(err)
+		os.Exit(1)
+	}
+
+	endpoint := namespaceEndpoint
+	err = list_namespaces(endpoint)
 	if err != nil {
 		log.Error(err)
 		os.Exit(1)
@@ -57,9 +114,21 @@ func listAllNamespaces(cmd *cobra.Command, args []string) {
 }
 
 func getNamespace(cmd *cobra.Command, args []string) {
+	err := config.InitClient()
+	if err != nil {
+		log.Error(err)
+		os.Exit(1)
+	}
+
 	if jwks {
-		endpoint := host + "/" + prefix + "/issuer.jwks"
-		err := get_namespace(endpoint)
+		namespaceEndpoint, err := getNamespaceEndpoint()
+		if err != nil {
+			log.Error(err)
+			os.Exit(1)
+		}
+
+		endpoint := namespaceEndpoint + "/" + prefix + "/issuer.jwks"
+		err = get_namespace(endpoint)
 		if err != nil {
 			log.Error(err)
 			os.Exit(1)
@@ -106,9 +175,9 @@ func init() {
 	getCmd.Flags().BoolVar(&jwks, "jwks", false, "Get the jwks of the namespace")
 	deleteCmd.Flags().StringVar(&prefix, "prefix", "", "prefix for delete namespace")
 
-	namespaceCmd.PersistentFlags().StringVar(&host, "host", "http://localhost:8443/cli-namespaces", "Host of the namespace registry")
-	namespaceCmd.PersistentFlags().StringVar(&pubkeyPath, "pubkey", "/usr/src/app/pelican/cmd/cert/.well-known/client.jwks", "Path to the public key")
-	namespaceCmd.PersistentFlags().StringVar(&privkeyPath, "privkey", "/usr/src/app/pelican/cmd/cert/client.key", "Path to the private key")
+	namespaceCmd.PersistentFlags().StringVar(&namespaceURL, "namespace-url", "", "Endpoint for the namespace registry")
+	namespaceCmd.PersistentFlags().StringVar(&pubkeyPath, "pubkey", "", "Path to the public key")
+	namespaceCmd.PersistentFlags().StringVar(&privkeyPath, "privkey", "", "Path to the private key")
 	namespaceCmd.AddCommand(registerCmd)
 	namespaceCmd.AddCommand(deleteCmd)
 	namespaceCmd.AddCommand(listCmd)

--- a/cmd/namespace_registry.go
+++ b/cmd/namespace_registry.go
@@ -69,7 +69,7 @@ func resp_to_json(body []byte) (map[string]string) {
 	return respData
 }
 
-func namespace_register_with_identity(publicKeyPath string, privateKeyPath string, namespaceRegistryEndpoint string, prefix string) (error) {
+func namespace_register_with_identity(privateKeyPath string, namespaceRegistryEndpoint string, prefix string) (error) {
 	data := map[string]interface{}{
 		"identity_required": "true",
 	}
@@ -106,13 +106,13 @@ func namespace_register_with_identity(publicKeyPath string, privateKeyPath strin
 	}
 	access_token := respData["access_token"]
 	fmt.Printf("Access token: %s\n", access_token)
-	return namespace_register(publicKeyPath, privateKeyPath, namespaceRegistryEndpoint, access_token, prefix)
+	return namespace_register(privateKeyPath, namespaceRegistryEndpoint, access_token, prefix)
 }
 
-func namespace_register(publicKeyPath string, privateKeyPath string, namespaceRegistryEndpoint string, access_token string, prefix string) (error) {
-	publicKey, err := config.LoadPublicKey(publicKeyPath, privateKeyPath)
+func namespace_register(privateKeyPath string, namespaceRegistryEndpoint string, access_token string, prefix string) (error) {
+	publicKey, err := config.LoadPublicKey("", privateKeyPath)
 	if err != nil {
-		return fmt.Errorf("Failed to load public key: %v\n", err)
+		return fmt.Errorf("Failed to retrieve public key: %v\n", err)
 	}
 
 	jwks, err := config.JWKSMap(publicKey)

--- a/config/config.go
+++ b/config/config.go
@@ -296,7 +296,7 @@ func InitClient() error {
 	viper.SetDefault("SlowTransferWindow", 30)
 
 	if upper_prefix == "OSDF" || upper_prefix == "STASH" {
-		viper.SetDefault("NamespaceURL", "https://topology.opensciencegrid.org/osdf/namespaces")
+		viper.SetDefault("TopologyNamespaceURL", "https://topology.opensciencegrid.org/osdf/namespaces")
 	}
 
 	viper.SetEnvPrefix(upper_prefix)

--- a/config/config.go
+++ b/config/config.go
@@ -199,6 +199,15 @@ func CleanupTempResources() {
 	})
 }
 
+func getConfigBase() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(home, ".config", "pelican"), nil
+}
+
 func InitServer() error {
 	viper.SetConfigType("yaml")
 	if IsRootExecution() {
@@ -214,12 +223,10 @@ func InitServer() error {
 		viper.SetDefault("XrootdMultiuser", true)
 		viper.SetDefault("GeoIPLocation", "/var/cache/pelican/maxmind/GeoLite2-City.mmdb")
 	} else {
-		home, err := os.UserHomeDir()
+		configBase, err := getConfigBase()
 		if err != nil {
 			return err
 		}
-
-		configBase := filepath.Join(home, ".config", "pelican")
 		viper.SetDefault("TLSCertificate", filepath.Join(configBase, "certificates", "tls.crt"))
 		viper.SetDefault("TLSKey", filepath.Join(configBase, "certificates", "tls.key"))
 		viper.SetDefault("RobotsTxtFile", filepath.Join(configBase, "robots.txt"))
@@ -271,6 +278,16 @@ func InitServer() error {
 }
 
 func InitClient() error {
+	if IsRootExecution() {
+		viper.SetDefault("IssuerKey", "/etc/pelican/issuer.jwk")
+	} else {
+		configBase, err := getConfigBase()
+		if err != nil {
+			return err
+		}
+		viper.SetDefault("IssuerKey", filepath.Join(configBase, "issuer.jwk"))
+	}
+
 	upper_prefix := GetPreferredPrefix()
 	lower_prefix := strings.ToLower(upper_prefix)
 

--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -67,7 +67,7 @@ func LoadPublicKey(existingJWKS string, issuerKeyFile string) (*jwk.Set, error) 
 	}
 	
 	if err := GeneratePrivateKey(issuerKeyFile, elliptic.P521()); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to generate new private key")
 	}
 	contents, err := os.ReadFile(issuerKeyFile)
 	if err != nil {
@@ -83,7 +83,7 @@ func LoadPublicKey(existingJWKS string, issuerKeyFile string) (*jwk.Set, error) 
 	}
 	err = jwk.AssignKeyID(pkey)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to assign key ID to public key")
 	}
 	jwks.Add(pkey)
 	return &jwks, nil
@@ -176,7 +176,7 @@ func GeneratePrivateKey(keyLocation string, curve elliptic.Curve) error {
 		file.Close()
 		return nil
 	} else if !errors.Is(err, os.ErrNotExist) {
-		return err
+		return errors.Wrap(err, "Failed to load private key due to I/O error")
 	}
 	keyDir := filepath.Dir(keyLocation)
 	if err := os.MkdirAll(keyDir, 0750); err != nil {
@@ -185,7 +185,7 @@ func GeneratePrivateKey(keyLocation string, curve elliptic.Curve) error {
 	// In this case, the private key file doesn't exist.
 	file, err := os.OpenFile(keyLocation, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Failed to create new private key file")
 	}
 	defer file.Close()
 	priv, err := ecdsa.GenerateKey(curve, rand.Reader)

--- a/config/resources/osdf.yaml
+++ b/config/resources/osdf.yaml
@@ -2,3 +2,4 @@ ManagerHost: redirector.osgstorage.org
 SummaryMonitoringHost: xrd-report.osgstorage.org
 DetailedMonitoringHost: xrd-mon.osgstorage.org
 TopologyNamespaceURL: https://topology.opensciencegrid.org/stashcache/namespaces.json
+FederationURL: osg-htc.org


### PR DESCRIPTION
This implements small changes to the namespace client to simplify the registration process, including:
- Use federation auto-discovery to find the namespace API endpoint.
- Use the default config file location of the private key.
- Generate the public key in-memory instead of requiring it at the CLI.

Example commands that now work:
```
$ pelican -f osg-htc.org namespace register --prefix /test_bbockelm
```

and

```
$ osdf namespace list
```