### PR TITLE
Fix director tls

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -124,8 +124,9 @@ jobs:
         # For now, only working about the linux amd64 artifact,
         # but we should probably look at building containers for
         # multiple platforms at some point...
+        # Also, set name of binary to osdf-client to run in that mode
         run: |
-          cp ~/dist/pelican_linux_amd64_v1/pelican .
+          cp ~/dist/pelican_linux_amd64_v1/pelican ./osdf-client
         working-directory: ./images 
 
       - name: Set up Docker Buildx

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -124,9 +124,8 @@ jobs:
         # For now, only working about the linux amd64 artifact,
         # but we should probably look at building containers for
         # multiple platforms at some point...
-        # Also, set name of binary to osdf-client to run in that mode
         run: |
-          cp ~/dist/pelican_linux_amd64_v1/pelican ./osdf-client
+          cp ~/dist/pelican_linux_amd64_v1/pelican .
         working-directory: ./images 
 
       - name: Set up Docker Buildx

--- a/cmd/director.go
+++ b/cmd/director.go
@@ -37,7 +37,7 @@ func init() {
 
 	// Set up flags for the command
 	directorServeCmd.Flags().StringP("port", "p", "", "Set the port to which the Director's redirect services should be bound")
-	err := viper.BindPFlag("port", directorServeCmd.Flags().Lookup("port"))
+	err := viper.BindPFlag("WebPort", directorServeCmd.Flags().Lookup("port"))
 	if err != nil {
 		panic(err)
 	}

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -19,7 +19,7 @@ RUN useradd -o -u 10940 -g 10940 -s /bin/sh xrootd
 # The build+push action that builds this dockerfile will copy the
 # linux/amd64 pelican artifact into the correct spot whenever the action
 # is triggered.
-COPY pelican /pelican/pelican
+COPY pelican /pelican/osdf-client
 COPY supervisord/supervisord.conf /etc/supervisord.conf
 
 # Eventually add more entrypoint commands and corresponding supervisor
@@ -27,7 +27,7 @@ COPY supervisord/supervisord.conf /etc/supervisord.conf
 COPY supervisord/pelican_director_serve.conf /etc/supervisord.d/pelican_director_serve.conf
 COPY entrypoint.sh /entrypoint.sh
 
-RUN chmod +x /pelican/pelican \
+RUN chmod +x /pelican/osdf-client \
     && chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -11,6 +11,10 @@ RUN yum -y update \
 
 WORKDIR /pelican
 
+# Create the xrootd user with a fixed GID/UID
+RUN groupadd -o -g 10940 xrootd
+RUN useradd -o -u 10940 -g 10940 -s /bin/sh xrootd
+
 # Copy over needed files
 # The build+push action that builds this dockerfile will copy the
 # linux/amd64 pelican artifact into the correct spot whenever the action

--- a/images/supervisord/pelican_director_serve.conf
+++ b/images/supervisord/pelican_director_serve.conf
@@ -1,4 +1,4 @@
 [program:pelican_director_serve]
-command=/pelican/pelican director serve -p %(ENV_PELICAN_DIRECTOR_PORT)s
+command=/pelican/osdf-client director serve -p %(ENV_OSDF_DIRECTOR_PORT)s
 autorestart=true
 redirect_stderr=true

--- a/images/supervisord/supervisord.conf
+++ b/images/supervisord/supervisord.conf
@@ -1,5 +1,4 @@
 [supervisord]
-nodaemon=true
 pidfile=/var/run/supervisord.pid
 logfile=/var/log/supervisord.log
 childlogdir = /var/log/supervisor

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -1,4 +1,3 @@
-
 package web_ui
 
 import (


### PR DESCRIPTION
A few minor changes -- 
- Handle the case when the required tls key and cert aren't provided by generating them
- Reconnect Director to command line argument that allows setting the webport using the `-p` flag when running `director serve`
- Change binary name in Dockerfile to reflect OSDF defaults
- Add xrootd user to Dockerfile (existence of the user is set as a requirement in the general pelican configuration, although I don't see an immediate reason we need this for the director)
- Run supervisord in daemon mode