### PR TITLE
Add cl flag to make default endpoint serve caches or origins

### DIFF
--- a/cmd/director.go
+++ b/cmd/director.go
@@ -41,4 +41,10 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+
+	directorServeCmd.Flags().StringP("default-endpoint", "e", "", "Set whether the default endpoint should redirect to caches or origins")
+	err = viper.BindPFlag("DirectorDefaultEndpoint", directorServeCmd.Flags().Lookup("default-endpoint"))
+	if err != nil {
+		panic(err)
+	}
 }

--- a/cmd/director.go
+++ b/cmd/director.go
@@ -42,8 +42,8 @@ func init() {
 		panic(err)
 	}
 
-	directorServeCmd.Flags().StringP("default-endpoint", "e", "", "Set whether the default endpoint should redirect to caches or origins")
-	err = viper.BindPFlag("DirectorDefaultEndpoint", directorServeCmd.Flags().Lookup("default-endpoint"))
+	directorServeCmd.Flags().StringP("default-response", "", "", "Set whether the default endpoint should redirect clients to caches or origins")
+	err = viper.BindPFlag("Director.DefaultResponse", directorServeCmd.Flags().Lookup("default-response"))
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/director_serve.go
+++ b/cmd/director_serve.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"crypto/elliptic"
-	"errors"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -55,12 +55,13 @@ func serveDirector( /*cmd*/ *cobra.Command /*args*/, []string) error {
 
 	// Configure the shortcut middleware to either redirect to a cache
 	// or to an origin
-	defaultEndpoint := viper.GetString("DirectorDefaultEndpoint")
-	if !(defaultEndpoint == "cache" || defaultEndpoint == "origin" || defaultEndpoint == "") {
-		return errors.New("The director's default endpoint must either be set to 'cache' or 'origin'." +
-		" Was there a typo?")
+	defaultResponse := viper.GetString("Director.DefaultResponse")
+	if !(defaultResponse == "cache" || defaultResponse == "origin") {
+		return fmt.Errorf("The director's default response must either be set to 'cache' or 'origin'," +
+		" but you provided %q. Was there a typo?", defaultResponse)
 	}
-	engine.Use(director.ShortcutMiddleware(defaultEndpoint))
+	log.Debugf("The director will redirect to %ss by default", defaultResponse)
+	engine.Use(director.ShortcutMiddleware(defaultResponse))
 	director.RegisterDirector(engine.Group("/"))
 
 	log.Info("Starting web engine...")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,6 +79,8 @@ func initConfig() {
 
 	viper.SetEnvPrefix(config.GetPreferredPrefix())
 	viper.AutomaticEnv()
+	// This line allows viper to use an env var like ORIGIN_VALUE to override the viper string "Origin.Value"
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	if err := viper.MergeInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
 			cobra.CheckErr(err)

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -9,3 +9,5 @@ MonitoringPortHigher: 9999
 Mount: ""
 NamespacePrefix: ""
 Debug: false
+Director:
+  DefaultResponse: cache

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -140,11 +140,11 @@ func RedirectToOrigin(ginCtx *gin.Context) {
 
 // Middleware sends GET /foo/bar to the RedirectToCache function, as if the
 // original request had been made to /api/v1.0/director/object/foo/bar
-func ShortcutMiddleware(defaultEndpoint string) gin.HandlerFunc {
+func ShortcutMiddleware(defaultResponse string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// If we're configured for cache mode or we haven't set the flag,
 		// we should use cache middleware
-		if defaultEndpoint == "cache" || defaultEndpoint == "" {
+		if defaultResponse == "cache" {
 			if !strings.HasPrefix(c.Request.URL.Path, "/api/v1.0/director") {
 				c.Request.URL.Path = "/api/v1.0/director/object" + c.Request.URL.Path
 				RedirectToCache(c)
@@ -154,7 +154,7 @@ func ShortcutMiddleware(defaultEndpoint string) gin.HandlerFunc {
 
 			// If the path starts with the correct prefix, continue with the next handler
 			c.Next()
-		} else if defaultEndpoint == "origin" {
+		} else if defaultResponse == "origin" {
 			if !strings.HasPrefix(c.Request.URL.Path, "/api/v1.0/director") {
 				c.Request.URL.Path = "/api/v1.0/director/origin" + c.Request.URL.Path
 				RedirectToOrigin(c)

--- a/images/supervisord/pelican_director_serve.conf
+++ b/images/supervisord/pelican_director_serve.conf
@@ -1,5 +1,5 @@
 [program:pelican_director_serve]
-command=/pelican/osdf-client director serve -p %(ENV_OSDF_DIRECTOR_PORT)s
+command=/pelican/osdf-client director serve -p %(ENV_OSDF_DIRECTOR_PORT)s -e %(ENV_OSDF_DIRECTOR_DEFAULT_ENDPOINT)s
 autostart=false
 autorestart=true
 redirect_stderr=true

--- a/images/supervisord/pelican_director_serve.conf
+++ b/images/supervisord/pelican_director_serve.conf
@@ -1,5 +1,5 @@
 [program:pelican_director_serve]
-command=/pelican/osdf-client director serve -p %(ENV_OSDF_DIRECTOR_PORT)s -e %(ENV_OSDF_DIRECTOR_DEFAULT_ENDPOINT)s
+command=/pelican/osdf-client director serve -p %(ENV_OSDF_DIRECTOR_PORT)s 
 autostart=false
 autorestart=true
 redirect_stderr=true


### PR DESCRIPTION
We need a way to redirect xrootd caches to origins, but as of the time of this PR, setting:
`pss.origin <director-domain>:443/api/v1.0/director/origin`
results in xrootd crashing after it's unable to parse the URL. 

This PR adds a command line option to set whether the default behavior is to serve caches or origins. Now a user can run:
`pelican director serve -p 443 -e <origin/cache>`
and the director will select the appropriate default endpoint redirection middleware.

As far as xrootd caches go, this should make it possible to set the `pss.origin` correctly