### PR TITLE
Improve the use of the X-Pelican-* responses

### DIFF
--- a/director/redirect.go
+++ b/director/redirect.go
@@ -103,9 +103,9 @@ func RedirectToCache(ginCtx *gin.Context) {
 		if tokenGen != "" {
 			ginCtx.Writer.Header()["X-Pelican-Token-Generation"] = []string{tokenGen}
 		}
-		ginCtx.Writer.Header()["X-Pelican-Namespace"] = []string{fmt.Sprintf("namespace=%s, require-token=%v",
-			namespaceAd.Path, namespaceAd.RequireToken)}
 	}
+	ginCtx.Writer.Header()["X-Pelican-Namespace"] = []string{fmt.Sprintf("namespace=%s, require-token=%v",
+		namespaceAd.Path, namespaceAd.RequireToken)}
 
 	ginCtx.Redirect(307, redirectURL.String())
 }

--- a/director_test.go
+++ b/director_test.go
@@ -56,8 +56,8 @@ func TestCreateNsFromDirectorResp(t *testing.T) {
 	//Craft the Director's response
 	directorHeaders := make(map[string][]string)
 	directorHeaders["Link"] = []string{"<my-cache.edu:8443>; rel=\"duplicate\"; pri=1, <another-cache.edu:8443>; rel=\"duplicate\"; pri=2"}
-	directorHeaders["X-Osdf-Namespace"] = []string{"namespace=/foo/bar, readhttps=True, use-token-on-read=True"}	
-	directorHeaders["X-Osdf-Authorization"] = []string{"issuer=https://get-your-tokens.org, base-path=/foo/bar"}
+	directorHeaders["X-Pelican-Namespace"] = []string{"namespace=/foo/bar, readhttps=True, use-token-on-read=True"}
+	directorHeaders["X-Pelican-Authorization"] = []string{"issuer=https://get-your-tokens.org, base-path=/foo/bar"}
 	directorBody := []byte(`{"key": "value"}`)
 
 	directorResponse := &http.Response{

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/url"
 	"regexp"
+	"runtime/debug"
 	"strconv"
 	"strings"
 
@@ -206,7 +207,8 @@ func CheckOSDF(destination string, methods []string) (remoteSize uint64, err err
 
 	defer func() {
 		if r := recover(); r != nil {
-			log.Errorln("Panic captured while attempting to perform size check:", r)
+			log.Debugln("Panic captured while attempting to perform size check:", r)
+			log.Debugln("Panic caused by the following", string(debug.Stack()))
 			ret := fmt.Sprintf("Unrecoverable error (panic) while check file size: %v", r)
 			err = errors.New(ret)
 			remoteSize = 0
@@ -340,7 +342,8 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 	// First, create a handler for any panics that occur
 	defer func() {
 		if r := recover(); r != nil {
-			log.Errorln("Panic captured while attempting to perform transfer (DoStashCPSingle):", r)
+			log.Debugln("Panic captured while attempting to perform transfer (DoStashCPSingle):", r)
+			log.Debugln("Panic caused by the following", string(debug.Stack()))
 			ret := fmt.Sprintf("Unrecoverable error (panic) captured in DoStashCPSingle: %v", r)
 			err = errors.New(ret)
 			bytesTransferred = 0


### PR DESCRIPTION
This:

1.  Converts the client to look for `X-Pelican-*` instead of `X-Osdf-*`.
2. Has the director always set `X-Pelican-Namespace`, even when the credential generation isn't known.
3. Avoids a panic when the `X-Pelican-Namespace` header is missing.
4. Slightly improves the debugging experience when a panic is raised.