### PR TITLE
Enable `go fmt` as one of the linters

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,23 +16,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest
-
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
-
-          # Optional: if set to true then the action will use pre-installed Go.
-          # skip-go-installation: true
-
-          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
-          # skip-pkg-cache: true
-
-          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
-          # skip-build-cache: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,9 @@
+
+run:
+  # Pelican has gotten large enough that the GitHub Action sometimes
+  # times out on a cold cache
+  timeout: 2m
+
+linters:
+  enable:
+  - gofmt

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -189,7 +189,7 @@ func ConfigureEmbeddedPrometheus(engine *gin.Engine) error {
 	scrapeConfig.ServiceDiscoveryConfigs = make([]discovery.Config, 1)
 	scrapeConfig.ServiceDiscoveryConfigs[0] = discovery.StaticConfig{
 		&targetgroup.Group{
-			Targets: []model.LabelSet{model.LabelSet{
+			Targets: []model.LabelSet{{
 				model.AddressLabel: model.LabelValue(pelican_config.ComputeExternalAddress()),
 			}},
 		},


### PR DESCRIPTION
Go has a reference source code formatting - and the VS code defaults seem to like auto-formatting to it.  We might as well enable it in the linters just to keep things consistent.

Note this disables reporting all linter issues as there's a codebase-wide reformat that should be done as a separate branch once some other pending work lands.