### PR TITLE
Updated Pelican release.yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.19
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4


### PR DESCRIPTION
Updated for the upcoming Pelican release. Only change needed was to upgrade Go version from 1.18 to 1.19. This GHA includes RPM and the binaries within the release tag. Below is a list of all the files within the release when a git tag is created when tested in my throw away repo:
![release](https://github.com/PelicanPlatform/pelican/assets/71942931/844c9d56-1082-43e3-8b12-add99af4b72a)

Let me know if any more changes need to be made!