### PR TITLE
Reformat code base with `go fmt`

### DIFF
--- a/acquire_token.go
+++ b/acquire_token.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"time"
 
+	jwt "github.com/golang-jwt/jwt"
 	config "github.com/pelicanplatform/pelican/config"
 	namespaces "github.com/pelicanplatform/pelican/namespaces"
-	log "github.com/sirupsen/logrus"
-	jwt "github.com/golang-jwt/jwt"
 	oauth2 "github.com/pelicanplatform/pelican/oauth2"
+	log "github.com/sirupsen/logrus"
 	oauth2_upstream "golang.org/x/oauth2"
 )
 
@@ -102,12 +102,12 @@ func RegisterClient(namespace namespaces.Namespace) (*config.PrefixEntry, error)
 	}
 
 	drcp := oauth2.DCRPConfig{ClientRegistrationEndpointURL: issuer.RegistrationURL, Metadata: oauth2.Metadata{
-		RedirectURIs: []string{"https://localhost/osdf-client"},
+		RedirectURIs:            []string{"https://localhost/osdf-client"},
 		TokenEndpointAuthMethod: "client_secret_basic",
-		GrantTypes: []string{"refresh_token", "urn:ietf:params:oauth:grant-type:device_code"},
-		ResponseTypes: []string{"code"},
-		ClientName: "OSDF Command Line Client",
-		Scopes: []string{"offline_access", "wlcg", "storage.read:/", "storage.modify:/", "storage.create:/"},
+		GrantTypes:              []string{"refresh_token", "urn:ietf:params:oauth:grant-type:device_code"},
+		ResponseTypes:           []string{"code"},
+		ClientName:              "OSDF Command Line Client",
+		Scopes:                  []string{"offline_access", "wlcg", "storage.read:/", "storage.modify:/", "storage.create:/"},
 	}}
 
 	resp, err := drcp.Register()
@@ -115,8 +115,8 @@ func RegisterClient(namespace namespaces.Namespace) (*config.PrefixEntry, error)
 		return nil, err
 	}
 	newEntry := config.PrefixEntry{
-		Prefix: namespace.Path,
-		ClientID: resp.ClientID,
+		Prefix:       namespace.Path,
+		ClientID:     resp.ClientID,
 		ClientSecret: resp.ClientSecret,
 	}
 	return &newEntry, nil
@@ -136,7 +136,7 @@ func AcquireToken(destination *url.URL, namespace namespaces.Namespace, isWrite 
 		return "", fmt.Errorf("Vault credential generation strategy is not supported")
 	default:
 		return "", fmt.Errorf("Unknown credential generation strategy (%s) for prefix %s",
-                                      strategy, namespace.Path)
+			strategy, namespace.Path)
 	}
 	issuer := *namespace.CredentialGen.Issuer
 	if len(issuer) == 0 {
@@ -164,7 +164,7 @@ func AcquireToken(destination *url.URL, namespace namespaces.Namespace, isWrite 
 			return "", err
 		}
 		osdfConfig.OSDF.OauthClient = append(osdfConfig.OSDF.OauthClient, *prefixEntry)
-		prefixEntry = &osdfConfig.OSDF.OauthClient[len(osdfConfig.OSDF.OauthClient) - 1]
+		prefixEntry = &osdfConfig.OSDF.OauthClient[len(osdfConfig.OSDF.OauthClient)-1]
 		newEntry = true
 	} else {
 		prefixEntry = &osdfConfig.OSDF.OauthClient[prefixIdx]
@@ -212,17 +212,17 @@ func AcquireToken(destination *url.URL, namespace namespaces.Namespace, isWrite 
 
 		// We have a reasonable token; let's try refreshing it.
 		upstreamToken := oauth2_upstream.Token{
-			AccessToken: acceptableToken.AccessToken,
+			AccessToken:  acceptableToken.AccessToken,
 			RefreshToken: acceptableToken.RefreshToken,
-			Expiry: time.Unix(0, 0),
+			Expiry:       time.Unix(0, 0),
 		}
 		issuerInfo, err := oauth2.GetIssuerMetadata(issuer)
 		if err == nil {
 			upstreamConfig := oauth2_upstream.Config{
-				ClientID: prefixEntry.ClientID,
+				ClientID:     prefixEntry.ClientID,
 				ClientSecret: prefixEntry.ClientSecret,
 				Endpoint: oauth2_upstream.Endpoint{
-					AuthURL: issuerInfo.AuthURL,
+					AuthURL:  issuerInfo.AuthURL,
 					TokenURL: issuerInfo.TokenURL,
 				}}
 			ctx := context.Background()
@@ -258,4 +258,3 @@ func AcquireToken(destination *url.URL, namespace namespaces.Namespace, isWrite 
 
 	return token.AccessToken, nil
 }
-

--- a/cmd/config_mgr.go
+++ b/cmd/config_mgr.go
@@ -17,8 +17,8 @@ import (
 var (
 	// Add the config and prefix commands
 	rootConfigCmd = &cobra.Command{
-		Use:     "credentials",
-		Short:   "Interact with the credential configuration file",
+		Use:   "credentials",
+		Short: "Interact with the credential configuration file",
 	}
 )
 
@@ -276,9 +276,9 @@ func init() {
 
 	// Define the token commands
 	tokenCmd := &cobra.Command{
-		Use: "token",
+		Use:   "token",
 		Short: "Manage the available tokens",
-		Long: "Manage the available tokens",
+		Long:  "Manage the available tokens",
 	}
 	addTokenSubcommands(tokenCmd)
 

--- a/cmd/director_serve.go
+++ b/cmd/director_serve.go
@@ -57,8 +57,8 @@ func serveDirector( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	// or to an origin
 	defaultResponse := viper.GetString("Director.DefaultResponse")
 	if !(defaultResponse == "cache" || defaultResponse == "origin") {
-		return fmt.Errorf("The director's default response must either be set to 'cache' or 'origin'," +
-		" but you provided %q. Was there a typo?", defaultResponse)
+		return fmt.Errorf("The director's default response must either be set to 'cache' or 'origin',"+
+			" but you provided %q. Was there a typo?", defaultResponse)
 	}
 	log.Debugf("The director will redirect to %ss by default", defaultResponse)
 	engine.Use(director.ShortcutMiddleware(defaultResponse))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,9 +1,8 @@
-
 package main
 
 import (
-	"path/filepath"
 	"os"
+	"path/filepath"
 )
 
 func main() {
@@ -19,4 +18,3 @@ func main() {
 		Execute()
 	}
 }
-

--- a/cmd/namespace_client.go
+++ b/cmd/namespace_client.go
@@ -4,12 +4,12 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/pelicanplatform/pelican/namespace-registry"
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/namespace-registry"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	log "github.com/sirupsen/logrus"
 )
 
 // Variables to which command line arguments will

--- a/cmd/namespace_registry.go
+++ b/cmd/namespace_registry.go
@@ -9,7 +9,7 @@ var (
 	namespaceRegistryCmd = &cobra.Command{
 		Use:   "registry",
 		Short: "Interact with a Pelican namespace registry service",
-		Long:  `Interact with a Pelican namespace registry service:
+		Long: `Interact with a Pelican namespace registry service:
 		
 		The namespace registry lies at the core of Pelican's security model
 		by serving as the central point for clients to fetch the public keys

--- a/cmd/namespace_registry_serve.go
+++ b/cmd/namespace_registry_serve.go
@@ -1,17 +1,16 @@
 package main
 
 import (
+	"github.com/pkg/errors"
 	"os"
 	"os/signal"
 	"syscall"
-	"github.com/pkg/errors"
 
 	"github.com/pelicanplatform/pelican/namespace-registry"
 	"github.com/pelicanplatform/pelican/web_ui"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
-
 
 func serveNamespaceRegistry( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	log.Info("Initializing the namespace registry's database...")

--- a/cmd/object.go
+++ b/cmd/object.go
@@ -1,4 +1,3 @@
-
 package main
 
 import (
@@ -9,5 +8,5 @@ var (
 	objectCmd = &cobra.Command{
 		Use:   "object",
 		Short: "Interact with objects in the federation",
-        }
+	}
 )

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -17,7 +17,7 @@ var (
 	copyCmd = &cobra.Command{
 		Use:   "copy {source ...} {destination}",
 		Short: "Copy a file to/from a Pelican federation",
-		Run: copyMain,
+		Run:   copyMain,
 	}
 )
 

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/origin_ui"
 	"github.com/pelicanplatform/pelican/web_ui"
 	"github.com/pelicanplatform/pelican/xrootd"
@@ -32,39 +32,36 @@ var (
 	xrootdCfg string
 	//go:embed resources/robots.txt
 	robotsTxt string
-
 )
 
 type (
+	OriginConfig struct {
+		Multiuser bool
+	}
 
-OriginConfig struct {
-	Multiuser bool
-}
-
-XrootdConfig struct {
-	Port                   int
-	ManagerHost            string
-	ManagerPort            string
-	TLSCertificate         string
-	TLSKey                 string
-	TLSCertDir             string
-	TLSCertFile            string
-	MacaroonsKeyFile       string
-	RobotsTxtFile          string
-	Sitename               string
-	SummaryMonitoringHost  string
-	SummaryMonitoringPort  int
-	DetailedMonitoringHost string
-	DetailedMonitoringPort int
-	XrootdRun              string
-	Authfile               string
-	ScitokensConfig        string
-	Mount                  string
-	NamespacePrefix        string
-	LocalMonitoringPort    int
-	Origin                 OriginConfig
-}
-
+	XrootdConfig struct {
+		Port                   int
+		ManagerHost            string
+		ManagerPort            string
+		TLSCertificate         string
+		TLSKey                 string
+		TLSCertDir             string
+		TLSCertFile            string
+		MacaroonsKeyFile       string
+		RobotsTxtFile          string
+		Sitename               string
+		SummaryMonitoringHost  string
+		SummaryMonitoringPort  int
+		DetailedMonitoringHost string
+		DetailedMonitoringPort int
+		XrootdRun              string
+		Authfile               string
+		ScitokensConfig        string
+		Mount                  string
+		NamespacePrefix        string
+		LocalMonitoringPort    int
+		Origin                 OriginConfig
+	}
 )
 
 func init() {
@@ -388,7 +385,7 @@ func configXrootd() (string, error) {
 	return configPath, nil
 }
 
-func serveOrigin(/*cmd*/ *cobra.Command, /*args*/ []string) error {
+func serveOrigin( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	defer config.CleanupTempResources()
 
 	err := config.DiscoverFederation()

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -23,8 +23,8 @@ var (
 
 	// Holds the various plugin commands
 	rootPluginCmd = &cobra.Command{
-		Use:     "plugin",
-		Short:   "Plugin management for HTCSS",
+		Use:   "plugin",
+		Short: "Plugin management for HTCSS",
 	}
 )
 
@@ -36,11 +36,11 @@ type Transfer struct {
 func init() {
 	// Define the file transfer plugin command
 	xferCmd := &cobra.Command{
-		Use:   "transfer",
-		Short: "Run pelican CLI in HTCSS file transfer plugin mode",
-		Args: cobra.ArbitraryArgs,
+		Use:                "transfer",
+		Short:              "Run pelican CLI in HTCSS file transfer plugin mode",
+		Args:               cobra.ArbitraryArgs,
 		DisableFlagParsing: true, // We have custom flag handling to match HTCSS style.
-		Run: func(_ *cobra.Command, args []string) {stashPluginMain(args)},
+		Run:                func(_ *cobra.Command, args []string) { stashPluginMain(args) },
 	}
 
 	rootPluginCmd.CompletionOptions.DisableDefaultCmd = true

--- a/cmd/plugin_stage.go
+++ b/cmd/plugin_stage.go
@@ -20,7 +20,7 @@ func init() {
 	stageCmd := &cobra.Command{
 		Use:   "stage",
 		Short: "Run pelican CLI to stage files as a HTCSS shadow plugin",
-		Run: stagePluginMain,
+		Run:   stagePluginMain,
 	}
 	stageCmd.Flags().StringP("token", "t", "", "Token file to use for reading and/or writing")
 	if err := viper.BindPFlag("StagePlugin.Token", stageCmd.Flags().Lookup("token")); err != nil {
@@ -135,16 +135,16 @@ func stagePluginMain(cmd *cobra.Command, args []string) {
 		re := regexp.MustCompile(`[,\s]+`)
 		for _, source := range re.Split(inputListStr, -1) {
 			log.Debugln("Examining transfer input file", source)
-			if (strings.HasPrefix(source, mountPrefixStr)) {
+			if strings.HasPrefix(source, mountPrefixStr) {
 				sources = append(sources, source)
 			} else {
-					// Replace the osdf:// prefix with the local mount path
+				// Replace the osdf:// prefix with the local mount path
 				source_uri, err := url.Parse(source)
 				source_uri_scheme := strings.SplitN(source_uri.Scheme, "+", 2)[0]
 				if err == nil && source_uri_scheme == "osdf" {
 					source_path := path.Clean("/" + source_uri.Host + "/" + source_uri.Path)
-					if (strings.HasPrefix(source_path, originPrefixPath)) {
-						sources = append(sources, mountPrefixStr + source_path[len(originPrefixPath):])
+					if strings.HasPrefix(source_path, originPrefixPath) {
+						sources = append(sources, mountPrefixStr+source_path[len(originPrefixPath):])
 						continue
 					}
 				}

--- a/config/encrypted.go
+++ b/config/encrypted.go
@@ -50,11 +50,11 @@ func EncryptedConfigExists() (bool, error) {
 	}
 	_, err = os.Stat(filename)
 	if os.IsNotExist(err) {
-		return false, nil;
+		return false, nil
 	} else if err != nil {
-		return false, err;
+		return false, err
 	}
-	return true, nil;
+	return true, nil
 }
 
 func GetEncryptedContents() (string, error) {
@@ -143,7 +143,7 @@ func GetPassword(newFile bool) ([]byte, error) {
 		fmt.Fprintln(os.Stderr, "The client is able to save the authorization in a local file.")
 		fmt.Fprintln(os.Stderr, "This prevents the need to reinitialize the authorization for each transfer.")
 		fmt.Fprintln(os.Stderr, "You will be asked for this password whenever a new session is started.")
-		fmt.Fprintln(os.Stderr, "Please provide a new password to encrypt the local OSDF client configuration file: ");
+		fmt.Fprintln(os.Stderr, "Please provide a new password to encrypt the local OSDF client configuration file: ")
 	} else {
 		fmt.Fprintln(os.Stderr, "The OSDF client configuration is encrypted.  Enter your password for the local OSDF client configuration file: ")
 	}
@@ -280,7 +280,7 @@ func SaveConfigContents_internal(config *OSDFConfig, forcePassword bool) error {
 	if setEmptyPassword {
 		fmt.Fprintln(os.Stderr, "WARNING: empty password provided; the credentials will be saved unencrypted on disk")
 	} else if forcePassword || len(password) == 0 || err != nil {
-		var exists bool;
+		var exists bool
 		if exists, err = EncryptedConfigExists(); err == nil && !exists {
 			password, err = GetPassword(true)
 		} else {

--- a/config/keyring_default.go
+++ b/config/keyring_default.go
@@ -12,7 +12,7 @@ func TryGetPassword() ([]byte, error) {
 	return make([]byte, 0), nil
 }
 
-func SavePassword(new_pass []byte) (error) {
+func SavePassword(new_pass []byte) error {
 	saved_password_val = new_pass
 	saved_password = true
 	return nil

--- a/config/mkdirall_default.go
+++ b/config/mkdirall_default.go
@@ -5,4 +5,3 @@ package config
 func fixRootDirectory(p string) string {
 	return p
 }
-

--- a/config/privs.go
+++ b/config/privs.go
@@ -10,18 +10,18 @@ import (
 var (
 	isRootExec bool
 
-	uidErr error
-	gidErr error
+	uidErr      error
+	gidErr      error
 	usernameErr error
-	groupErr error
+	groupErr    error
 
-	uid int
-	gid int
+	uid      int
+	gid      int
 	username string
-	group string
+	group    string
 )
 
-func init () {
+func init() {
 	userObj, err := user.Current()
 	isRootExec = err == nil && userObj.Username == "root"
 
@@ -39,7 +39,7 @@ func init () {
 		desiredUsername = "xrootd"
 		userObj, err = user.Lookup(desiredUsername)
 		if err != nil {
-			err = errors.Wrap(err, "Unable to lookup the xrootd runtime user" +
+			err = errors.Wrap(err, "Unable to lookup the xrootd runtime user"+
 				" information; does the xrootd user exist?")
 			uidErr = err
 			gidErr = err

--- a/director.go
+++ b/director.go
@@ -79,7 +79,7 @@ func CreateNsFromDirectorResp(dirResp *http.Response, namespace *namespaces.Name
 
 		strategy := xPelicanTokenGeneration["strategy"]
 		namespace.CredentialGen.Strategy = &strategy
-		
+
 		// The Director only returns a vault server if the strategy is vault.
 		if vs, exists := xPelicanTokenGeneration["vault-server"]; exists {
 			namespace.CredentialGen.VaultServer = &vs
@@ -129,7 +129,7 @@ func GetCachesFromDirectorResponse(resp *http.Response, needsToken bool) (caches
 
 		var endpoint string
 		// var rel string // "rel", as defined in the Metalink/HTTP RFC. Currently not being used by
-		// the OSDF Client, but is provided by the director. Will be useful in the future when 
+		// the OSDF Client, but is provided by the director. Will be useful in the future when
 		// we start looking at cases where we want to duplicate from caches if we're throttling
 		// connections to the origin.
 		var pri int

--- a/director/geosort.go
+++ b/director/geosort.go
@@ -12,29 +12,29 @@ func distanceOnSphere(lat1 float64, long1 float64, lat2 float64, long2 float64) 
 		return 0.0
 	}
 
-	// Convert latitude and longitude to 
+	// Convert latitude and longitude to
 	// spherical coordinates in radians.
-	degrees_to_radians := math.Pi/180.0
-        
+	degrees_to_radians := math.Pi / 180.0
+
 	// phi = 90 - latitude
-	phi1 := (90.0 - lat1)*degrees_to_radians
-	phi2 := (90.0 - lat2)*degrees_to_radians
-        
+	phi1 := (90.0 - lat1) * degrees_to_radians
+	phi2 := (90.0 - lat2) * degrees_to_radians
+
 	// theta = longitude
-	theta1 := long1*degrees_to_radians
-	theta2 := long2*degrees_to_radians
-        
+	theta1 := long1 * degrees_to_radians
+	theta2 := long2 * degrees_to_radians
+
 	// Compute spherical distance from spherical coordinates.
 
-	// For two locations in spherical coordinates 
+	// For two locations in spherical coordinates
 	// (1, theta, phi) and (1, theta, phi)
-	// cosine( arc length ) = 
+	// cosine( arc length ) =
 	//    sin phi sin phi' cos(theta-theta') + cos phi cos phi'
 	// distance = rho * arc length
-    
-	cos := (math.Sin(phi1) * math.Sin(phi2) * math.Cos(theta1 - theta2) + 
-	       math.Cos(phi1) * math.Cos(phi2))
-	arc := math.Acos( cos )
+
+	cos := (math.Sin(phi1)*math.Sin(phi2)*math.Cos(theta1-theta2) +
+		math.Cos(phi1)*math.Cos(phi2))
+	arc := math.Acos(cos)
 
 	return arc
 }

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -18,20 +18,17 @@ import (
 )
 
 type (
-
 	OriginAdvertise struct {
-		Name string `json:"name"`
-		URL string  `json:"url"`
+		Name       string        `json:"name"`
+		URL        string        `json:"url"`
 		Namespaces []NamespaceAd `json:"namespaces"`
 	}
-
 )
 
 var (
-	namespaceKeys = ttlcache.New[string, *jwk.AutoRefresh](ttlcache.WithTTL[string, *jwk.AutoRefresh](15 * time.Minute))
+	namespaceKeys      = ttlcache.New[string, *jwk.AutoRefresh](ttlcache.WithTTL[string, *jwk.AutoRefresh](15 * time.Minute))
 	namespaceKeysMutex = sync.RWMutex{}
 )
-
 
 func CreateAdvertiseToken(namespace string) (string, error) {
 	key, err := config.GetOriginJWK()
@@ -65,7 +62,6 @@ func CreateAdvertiseToken(namespace string) (string, error) {
 	return string(signed), nil
 }
 
-//
 // Given a token and a location in the namespace to advertise in,
 // see if the entity is authorized to advertise an origin for the
 // namespace
@@ -86,7 +82,7 @@ func VerifyAdvertiseToken(token, namespace string) (bool, error) {
 	ctx := context.Background()
 	if ar == nil {
 		ar := jwk.NewAutoRefresh(ctx)
-		ar.Configure(issuer_url, jwk.WithMinRefreshInterval(15 * time.Minute))
+		ar.Configure(issuer_url, jwk.WithMinRefreshInterval(15*time.Minute))
 		namespaceKeysMutex.Lock()
 		defer namespaceKeysMutex.Unlock()
 		namespaceKeys.Set(namespace, ar, ttlcache.DefaultTTL)
@@ -112,7 +108,7 @@ func VerifyAdvertiseToken(token, namespace string) (bool, error) {
 
 	scopes := strings.Split(scope, " ")
 
-	for _, scope := range(scopes) {
+	for _, scope := range scopes {
 		if scope == "pelican.advertise" {
 			return true, nil
 		}

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -166,7 +166,7 @@ func ShortcutMiddleware(defaultResponse string) gin.HandlerFunc {
 	}
 }
 
-func RegisterOrigin (ctx *gin.Context) {
+func RegisterOrigin(ctx *gin.Context) {
 	tokens, present := ctx.Request.Header["Authorization"]
 	if !present || len(tokens) == 0 {
 		ctx.JSON(401, gin.H{"error": "Bearer token not present in the 'Authorization' header"})
@@ -178,7 +178,7 @@ func RegisterOrigin (ctx *gin.Context) {
 		return
 	}
 
-	for _, namespace := range(ad.Namespaces) {
+	for _, namespace := range ad.Namespaces {
 		ok, err := VerifyAdvertiseToken(tokens[0], namespace.Path)
 		if err != nil {
 			log.Warningln("Failed to verify token:", err)

--- a/director_test.go
+++ b/director_test.go
@@ -1,13 +1,13 @@
 package pelican
 
-import(
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
 	"io"
-	"testing"
 	"net/http"
 	"net/http/httptest"
-	"bytes"
 	"os"
-	"github.com/stretchr/testify/assert"
+	"testing"
 
 	namespaces "github.com/pelicanplatform/pelican/namespaces"
 )
@@ -30,11 +30,11 @@ func TestGetCachesFromDirectorResponse(t *testing.T) {
 	directorHeaders := make(map[string][]string)
 	directorHeaders["Link"] = []string{"<my-cache.edu:8443>; rel=\"duplicate\"; pri=1, <another-cache.edu:8443>; rel=\"duplicate\"; pri=2"}
 	directorBody := []byte(`{"key": "value"}`)
-	
+
 	directorResponse := &http.Response{
 		StatusCode: 307,
-		Header: directorHeaders,
-		Body: io.NopCloser(bytes.NewReader(directorBody)),
+		Header:     directorHeaders,
+		Body:       io.NopCloser(bytes.NewReader(directorBody)),
 	}
 
 	// Call the function in question
@@ -42,7 +42,7 @@ func TestGetCachesFromDirectorResponse(t *testing.T) {
 
 	// Test for expected outputs
 	assert.NoError(t, err, "Error getting caches from the Director's response")
-	
+
 	assert.Equal(t, "my-cache.edu:8443", caches[0].EndpointUrl)
 	assert.Equal(t, 1, caches[0].Priority)
 	assert.Equal(t, true, caches[0].AuthedReq)
@@ -62,32 +62,32 @@ func TestCreateNsFromDirectorResp(t *testing.T) {
 
 	directorResponse := &http.Response{
 		StatusCode: 307,
-		Header: directorHeaders,
-		Body: io.NopCloser(bytes.NewReader(directorBody)),
+		Header:     directorHeaders,
+		Body:       io.NopCloser(bytes.NewReader(directorBody)),
 	}
 
 	// Create a namespace instance to test against
 	cache1 := namespaces.DirectorCache{
 		EndpointUrl: "my-cache.edu:8443",
-		Priority: 1,
-		AuthedReq: true,
-	} 
+		Priority:    1,
+		AuthedReq:   true,
+	}
 	cache2 := namespaces.DirectorCache{
 		EndpointUrl: "another-cache.edu:8443",
-		Priority: 2,
-		AuthedReq: true,
-	} 
+		Priority:    2,
+		AuthedReq:   true,
+	}
 
 	caches := []namespaces.DirectorCache{}
 	caches = append(caches, cache1)
 	caches = append(caches, cache2)
-	
+
 	constructedNamespace := &namespaces.Namespace{
 		SortedDirectorCaches: caches,
-		Path: "/foo/bar",
-		Issuer: "https://get-your-tokens.org",
-		ReadHTTPS: true,
-		UseTokenOnRead: true,
+		Path:                 "/foo/bar",
+		Issuer:               "https://get-your-tokens.org",
+		ReadHTTPS:            true,
+		UseTokenOnRead:       true,
 	}
 
 	// Call the function in question
@@ -111,17 +111,17 @@ func TestNewTransferDetailsUsingDirector(t *testing.T) {
 	// Cache with http
 	nonAuthCache := namespaces.DirectorCache{
 		ResourceName: "mycache",
-		EndpointUrl: "my-cache-url:8000",
-		Priority: 99,
-		AuthedReq: false,
+		EndpointUrl:  "my-cache-url:8000",
+		Priority:     99,
+		AuthedReq:    false,
 	}
 
 	// Cache with https
 	authCache := namespaces.DirectorCache{
 		ResourceName: "mycache",
-		EndpointUrl: "my-cache-url:8443",
-		Priority: 99,
-		AuthedReq: true,
+		EndpointUrl:  "my-cache-url:8443",
+		Priority:     99,
+		AuthedReq:    true,
 	}
 
 	// Case 1: cache with http

--- a/errorAccum.go
+++ b/errorAccum.go
@@ -11,7 +11,7 @@ import (
 )
 
 type TimestampedError struct {
-	err error
+	err       error
 	timestamp time.Time
 }
 
@@ -19,7 +19,7 @@ var (
 	bunchOfErrors []TimestampedError
 	mu            sync.Mutex
 	// We will generate an error string including the time since startup
-	startup       time.Time = time.Now()
+	startup time.Time = time.Now()
 )
 
 // AddError will add an accumulated error to the error stack
@@ -44,15 +44,15 @@ func GetErrors() string {
 	lastError := startup
 	var errorsFormatted []string
 	for idx, theError := range bunchOfErrors {
-		errFmt := fmt.Sprintf("Attempt #%v: %s", idx + 1, theError.err.Error())
+		errFmt := fmt.Sprintf("Attempt #%v: %s", idx+1, theError.err.Error())
 		timeElapsed := theError.timestamp.Sub(lastError)
-		timeFormat := timeElapsed.Truncate(100*time.Millisecond).String()
+		timeFormat := timeElapsed.Truncate(100 * time.Millisecond).String()
 		errFmt += " (" + timeFormat
 		if first {
 			errFmt += " since start)"
 		} else {
 			timeSinceStart := theError.timestamp.Sub(startup)
-			timeSinceStartFormat := timeSinceStart.Truncate(100*time.Millisecond).String()
+			timeSinceStartFormat := timeSinceStart.Truncate(100 * time.Millisecond).String()
 			errFmt += " elapsed, " + timeSinceStartFormat + " since start)"
 		}
 		lastError = theError.timestamp
@@ -61,7 +61,7 @@ func GetErrors() string {
 	}
 	var toReturn string
 	first = true
-	for idx := len(errorsFormatted)-1; idx >= 0; idx-- {
+	for idx := len(errorsFormatted) - 1; idx >= 0; idx-- {
 		if !first {
 			toReturn += "; "
 		}

--- a/errorAccum_test.go
+++ b/errorAccum_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//  TestErrorAccum tests simple adding and removing from the accumulator
+// TestErrorAccum tests simple adding and removing from the accumulator
 func TestErrorAccum(t *testing.T) {
 	bunchOfErrors = make([]TimestampedError, 0)
 	defer func() {

--- a/handle_http.go
+++ b/handle_http.go
@@ -32,23 +32,21 @@ import (
 var p = mpb.New()
 
 type StoppedTransferError struct {
-	Err 	string
+	Err string
 }
 
 func (e *StoppedTransferError) Error() string {
 	return e.Err
 }
 
-
 type HttpErrResp struct {
 	Code int
-	Err string
+	Err  string
 }
 
 func (e *HttpErrResp) Error() string {
 	return e.Err
 }
-
 
 // SlowTransferError is an error that is returned when a transfer takes longer than the configured timeout
 type SlowTransferError struct {
@@ -526,11 +524,11 @@ Loop:
 			}
 
 		case <-t.C:
-			
+
 			if resp.BytesComplete() == lastBytesComplete {
 				if noProgressStartTime.IsZero() {
 					noProgressStartTime = time.Now()
-				} else if time.Since(noProgressStartTime) > time.Duration(stoppedTransferTimeout) * time.Second {
+				} else if time.Since(noProgressStartTime) > time.Duration(stoppedTransferTimeout)*time.Second {
 					errMsg := "No progress for more than " + time.Since(noProgressStartTime).Truncate(time.Millisecond).String()
 					log.Errorln(errMsg)
 					return 5, &StoppedTransferError{
@@ -542,11 +540,10 @@ Loop:
 			}
 			lastBytesComplete = resp.BytesComplete()
 
-
 			// Check if we are downloading fast enough
 			if resp.BytesPerSecond() < float64(downloadLimit) {
 				// Give the download `slowTransferRampupTime` (default 120) seconds to start
-				if resp.Duration() < time.Second* time.Duration(slowTransferRampupTime) {
+				if resp.Duration() < time.Second*time.Duration(slowTransferRampupTime) {
 					continue
 				} else if startBelowLimit == 0 {
 					log.Warnln("Download speed of ", resp.BytesPerSecond(), "bytes/s", " is below the limit of", downloadLimit, "bytes/s")
@@ -576,7 +573,7 @@ Loop:
 				}
 
 				log.Errorln("Download speed of ", resp.BytesPerSecond(), "bytes/s", " is below the limit of", downloadLimit, "bytes/s")
-				
+
 				return 0, &SlowTransferError{
 					BytesTransferred: resp.BytesComplete(),
 					BytesPerSecond:   int64(resp.BytesPerSecond()),
@@ -959,7 +956,7 @@ func StatHttp(dest *url.URL, namespace namespaces.Namespace) (uint64, error) {
 		}
 
 		if scitoken_contents != "" {
-			req.Header.Set("Authorization", "Bearer " + scitoken_contents)
+			req.Header.Set("Authorization", "Bearer "+scitoken_contents)
 		}
 
 		resp, err = client.Do(req)
@@ -1000,4 +997,3 @@ func StatHttp(dest *url.URL, namespace namespaces.Namespace) (uint64, error) {
 		return 0, &HttpErrResp{resp.StatusCode, fmt.Sprintf("Request failed (HTTP status %d): %s", resp.StatusCode, string(response_b))}
 	}
 }
-

--- a/handle_ingest.go
+++ b/handle_ingest.go
@@ -47,7 +47,7 @@ func DoShadowIngest(sourceFile string, originPrefix string, shadowOriginPrefix s
 		lastRemoteSize := uint64(0)
 		lastUpdateTime := time.Now()
 		startTime := lastUpdateTime
-		maxRuntime := float64(localSize / 10*1024*1024) + 300
+		maxRuntime := float64(localSize/10*1024*1024) + 300
 		for {
 			remoteSize, err := CheckOSDF(shadowFile, methods)
 			if httpErr, ok := err.(*HttpErrResp); ok {
@@ -59,7 +59,7 @@ func DoShadowIngest(sourceFile string, originPrefix string, shadowOriginPrefix s
 			} else if err != nil {
 				return 0, "", err
 			}
-			if (localSize == remoteSize) {
+			if localSize == remoteSize {
 				return 0, shadowFile, err
 			}
 			log.Debugf("Remote file exists but it is incorrect size; actual size %v, expected %v.", remoteSize, localSize)
@@ -67,15 +67,15 @@ func DoShadowIngest(sourceFile string, originPrefix string, shadowOriginPrefix s
 			// If the remote file size is growing, then wait a bit; perhaps someone
 			// else is uploading the same file concurrently.
 			if duration_s := time.Since(lastUpdateTime).Seconds(); duration_s > 10 {
-					// Other uploader is too slow; let's do it ourselves
-				if float64(remoteSize - lastRemoteSize) / duration_s < 1024*1024 {
+				// Other uploader is too slow; let's do it ourselves
+				if float64(remoteSize-lastRemoteSize)/duration_s < 1024*1024 {
 					log.Warnln("Remote uploader is too slow; will do upload from this client")
-					break;
+					break
 				}
 				lastRemoteSize = remoteSize
 				lastUpdateTime = time.Now()
 			}
-				// Out of an abundance of caution, never wait more than 10m.
+			// Out of an abundance of caution, never wait more than 10m.
 			if time.Since(startTime).Seconds() > maxRuntime {
 				log.Warnln("Remote uploader took too long to upload file; will do upload from this client")
 				break
@@ -95,7 +95,7 @@ func DoShadowIngest(sourceFile string, originPrefix string, shadowOriginPrefix s
 		if err != nil {
 			return 0, "", err
 		}
-		if shadowFilePost == shadowFile {	
+		if shadowFilePost == shadowFile {
 			return uploadBytes, shadowFile, err
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -327,7 +327,7 @@ func correctURLWithUnderscore(sourceFile string) (string, string) {
 	if schemeIndex == -1 {
 		return sourceFile, ""
 	}
-	
+
 	originalScheme := sourceFile[:schemeIndex]
 	if strings.Contains(originalScheme, "_") {
 		scheme := strings.ReplaceAll(originalScheme, "_", ".")
@@ -361,7 +361,7 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 		return 0, err
 	}
 	source_url.Scheme = source_scheme
-	
+
 	destination, dest_scheme := correctURLWithUnderscore(destination)
 	dest_url, err := url.Parse(destination)
 	if err != nil {

--- a/metrics/health.go
+++ b/metrics/health.go
@@ -1,4 +1,3 @@
-
 package metrics
 
 import (
@@ -7,22 +6,20 @@ import (
 )
 
 type (
-
 	ComponentStatus struct {
-		Status string `json:"status"`
+		Status  string `json:"status"`
 		Message string `json:"message,omitempty"`
 	}
 
 	componentStatusInternal struct {
-		Status int
+		Status  int
 		Message string
 	}
 
 	HealthStatus struct {
-		OverallStatus string `json:"status"`
+		OverallStatus   string                     `json:"status"`
 		ComponentStatus map[string]ComponentStatus `json:"components"`
 	}
-
 )
 
 var (

--- a/namespace-registry/client_commands.go
+++ b/namespace-registry/client_commands.go
@@ -4,23 +4,23 @@ import (
 	"crypto/tls"
 	"github.com/pkg/errors"
 
+	"bufio"
+	"bytes"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
-	"net/http"
-	"bytes"
-	"bufio"
 	"math/big"
-	"encoding/base64"
+	"net/http"
+	"os"
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/spf13/viper"
 )
 
 type clientResponseData struct {
-    VerificationURL string `json:"verification_url"`
+	VerificationURL string `json:"verification_url"`
 	DeviceCode      string `json:"device_code"`
 	Status          string `json:"status"`
 	AccessToken     string `json:"access_token"`
@@ -61,16 +61,16 @@ func makeRequest(url string, method string, data map[string]interface{}) ([]byte
 	return body, nil
 }
 
-func NamespaceRegisterWithIdentity(privateKeyPath string, namespaceRegistryEndpoint string, prefix string) (error) {
+func NamespaceRegisterWithIdentity(privateKeyPath string, namespaceRegistryEndpoint string, prefix string) error {
 	identifiedPayload := map[string]interface{}{
 		"identity_required": "true",
-		"prefix": prefix,
+		"prefix":            prefix,
 		// we'll also send the prefix so we can avoid more work if
 		// it's also registered already
 
 	}
 	resp, err := makeRequest(namespaceRegistryEndpoint, "POST", identifiedPayload)
-	
+
 	var respData clientResponseData
 	// Handle case where there was an error encoded in the body
 	if err != nil {
@@ -90,7 +90,7 @@ func NamespaceRegisterWithIdentity(privateKeyPath string, namespaceRegistryEndpo
 	for !done {
 		identifiedPayload = map[string]interface{}{
 			"identity_required": "true",
-			"device_code": respData.DeviceCode,
+			"device_code":       respData.DeviceCode,
 		}
 		resp, err = makeRequest(namespaceRegistryEndpoint, "POST", identifiedPayload)
 		if err != nil {
@@ -112,7 +112,7 @@ func NamespaceRegisterWithIdentity(privateKeyPath string, namespaceRegistryEndpo
 	return NamespaceRegister(privateKeyPath, namespaceRegistryEndpoint, respData.AccessToken, prefix)
 }
 
-func NamespaceRegister(privateKeyPath string, namespaceRegistryEndpoint string, accessToken string, prefix string) (error) {
+func NamespaceRegister(privateKeyPath string, namespaceRegistryEndpoint string, accessToken string, prefix string) error {
 	publicKey, err := config.LoadPublicKey("", privateKeyPath)
 	if err != nil {
 		return errors.Wrap(err, "Failed to retrieve public key")
@@ -135,11 +135,11 @@ func NamespaceRegister(privateKeyPath string, namespaceRegistryEndpoint string, 
 
 	data := map[string]interface{}{
 		"client_nonce": clientNonce,
-		"pubkey":   fmt.Sprintf("%x", jwks["x"]),
+		"pubkey":       fmt.Sprintf("%x", jwks["x"]),
 	}
 
 	resp, err := makeRequest(namespaceRegistryEndpoint, "POST", data)
-	
+
 	var respData clientResponseData
 	// Handle case where there was an error encoded in the body
 	if err != nil {
@@ -174,11 +174,11 @@ func NamespaceRegister(privateKeyPath string, namespaceRegistryEndpoint string, 
 	}
 
 	unidentifiedPayload := map[string]interface{}{
-		"client_nonce":      clientNonce,
-		"server_nonce":      respData.ServerNonce,
-		"pubkey":        	 map[string]string{
-			"x" : new(big.Int).SetBytes(xBytes).String(),
-			"y" : new(big.Int).SetBytes(yBytes).String(),
+		"client_nonce": clientNonce,
+		"server_nonce": respData.ServerNonce,
+		"pubkey": map[string]string{
+			"x":     new(big.Int).SetBytes(xBytes).String(),
+			"y":     new(big.Int).SetBytes(yBytes).String(),
 			"curve": jwks["crv"],
 		},
 		"client_payload":    clientPayload,
@@ -205,7 +205,7 @@ func NamespaceRegister(privateKeyPath string, namespaceRegistryEndpoint string, 
 	return nil
 }
 
-func NamespaceList(endpoint string) (error) {
+func NamespaceList(endpoint string) error {
 	respData, err := makeRequest(endpoint, "GET", nil)
 	var respErr clientResponseData
 	if err != nil {
@@ -218,7 +218,7 @@ func NamespaceList(endpoint string) (error) {
 	return nil
 }
 
-func NamespaceGet(endpoint string) (error) {
+func NamespaceGet(endpoint string) error {
 	respData, err := makeRequest(endpoint, "GET", nil)
 	var respErr clientResponseData
 	if err != nil {
@@ -231,7 +231,7 @@ func NamespaceGet(endpoint string) (error) {
 	return nil
 }
 
-func NamespaceDelete(endpoint string) (error) {
+func NamespaceDelete(endpoint string) error {
 	respData, err := makeRequest(endpoint, "DELETE", nil)
 	var respErr clientResponseData
 	if err != nil {

--- a/namespace-registry/registry-db.go
+++ b/namespace-registry/registry-db.go
@@ -2,9 +2,9 @@ package nsregistry
 
 import (
 	"database/sql"
-	"path/filepath"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
@@ -20,12 +20,13 @@ type Namespace struct {
 	Identity      string
 	AdminMetadata string
 }
+
 /*
 Declare the DB handle as an unexported global so that all
 functions in the package can access it without having to
 pass it around. This simplifies the HTTP handlers, and
 the handle is already thread-safe! The approach being used
-is based off of 1.b from 
+is based off of 1.b from
 https://www.alexedwards.net/blog/organising-database-access
 */
 var db *sql.DB
@@ -53,7 +54,7 @@ func namespaceExists(prefix string) (bool, error) {
 		return false, err
 	}
 	defer result.Close()
-	
+
 	found := false
 	for result.Next() {
 		found = true
@@ -80,7 +81,7 @@ func updateNamespace(ns *Namespace) error {
 	_, err := db.Exec(query, ns.Pubkey, ns.Identity, ns.AdminMetadata, ns.Prefix)
 	return err
 }
- */
+*/
 
 func deleteNamespace(prefix string) error {
 	deleteQuery := `DELETE FROM namespace WHERE prefix = ?`
@@ -88,7 +89,7 @@ func deleteNamespace(prefix string) error {
 	if err != nil {
 		return errors.Wrap(err, "Failed to execute deletion query")
 	}
-	
+
 	return nil
 }
 
@@ -161,4 +162,3 @@ func InitializeDB() error {
 	createNamespaceTable()
 	return db.Ping()
 }
-

--- a/namespaces/namespaces.go
+++ b/namespaces/namespaces.go
@@ -45,9 +45,9 @@ type DirectorCache struct {
 
 // Credential generation information
 type CredentialGeneration struct {
-	Issuer        *string  `json:"issuer"`
-	BasePath      *string  `json:"base_path"`
-	MaxScopeDepth *int     `json:"max_scope_depth"`
+	Issuer        *string `json:"issuer"`
+	BasePath      *string `json:"base_path"`
+	MaxScopeDepth *int    `json:"max_scope_depth"`
 	Strategy      *string `json:"strategy"`
 	VaultServer   *string `json:"vault_server"`
 }
@@ -56,13 +56,13 @@ type CredentialGeneration struct {
 type Namespace struct {
 	Caches               []Cache `json:"caches"`
 	SortedDirectorCaches []DirectorCache
-	Path                 string `json:"path"`
-  CredentialGen *CredentialGeneration  `json:"credential_generation"`
-	Issuer               string `json:"issuer"`
-	ReadHTTPS            bool   `json:"readhttps"`
-	UseTokenOnRead       bool   `json:"usetokenonread"`
-	WriteBackHost        string `json:"writebackhost"`
-	DirListHost          string `json:"dirlisthost"`
+	Path                 string                `json:"path"`
+	CredentialGen        *CredentialGeneration `json:"credential_generation"`
+	Issuer               string                `json:"issuer"`
+	ReadHTTPS            bool                  `json:"readhttps"`
+	UseTokenOnRead       bool                  `json:"usetokenonread"`
+	WriteBackHost        string                `json:"writebackhost"`
+	DirListHost          string                `json:"dirlisthost"`
 }
 
 // GetCaches returns the list of caches for the namespace

--- a/oauth2/deviceauth.go
+++ b/oauth2/deviceauth.go
@@ -54,9 +54,9 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context/ctxhttp"
 	oauth2_upstream "golang.org/x/oauth2"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -150,7 +150,6 @@ func parseError(err error) string {
 	return ""
 }
 
-
 // AuthDevice returns a device auth struct which contains a device code
 // and authorization information provided for users to enter on another device.
 func (c *Config) AuthDevice(ctx context.Context) (*DeviceAuth, error) {
@@ -175,7 +174,9 @@ func newTokenRequest(tokenURL, clientID, clientSecret string, v url.Values) (*ht
 }
 
 var HTTPClient ContextKey
+
 type ContextKey struct{}
+
 func ContextClient(ctx context.Context) *http.Client {
 	if ctx != nil {
 		if hc, ok := ctx.Value(HTTPClient).(*http.Client); ok {
@@ -199,10 +200,10 @@ func RetrieveToken(ctx context.Context, clientID, clientSecret, tokenURL string,
 }
 
 type tokenJSON struct {
-	AccessToken  string         `json:"access_token"`
-	TokenType    string         `json:"token_type"`
-	RefreshToken string         `json:"refresh_token"`
-	ExpiresIn    int            `json:"expires_in"`
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
 }
 
 func doTokenRoundTrip(ctx context.Context, req *http.Request) (*oauth2_upstream.Token, error) {

--- a/oauth2/issuer_metadata.go
+++ b/oauth2/issuer_metadata.go
@@ -9,12 +9,12 @@ import (
 )
 
 type OauthIssuer struct {
-	Issuer string `json:"issuer"`
-	AuthURL string `json:"authorization_endpoint"`
-	DeviceAuthURL string `json:"device_authorization_endpoint"`
-	TokenURL string `json:"token_endpoint"`
-	RegistrationURL string `json:"registration_endpoint"`
-	GrantTypes []string `json:"grant_types_supported"`
+	Issuer          string   `json:"issuer"`
+	AuthURL         string   `json:"authorization_endpoint"`
+	DeviceAuthURL   string   `json:"device_authorization_endpoint"`
+	TokenURL        string   `json:"token_endpoint"`
+	RegistrationURL string   `json:"registration_endpoint"`
+	GrantTypes      []string `json:"grant_types_supported"`
 }
 
 func GetIssuerMetadata(issuer_url string) (*OauthIssuer, error) {

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -1,4 +1,3 @@
-
 package oauth2
 
 import (
@@ -9,9 +8,9 @@ import (
 	"path"
 	"strings"
 
-        log "github.com/sirupsen/logrus"
 	config "github.com/pelicanplatform/pelican/config"
 	namespaces "github.com/pelicanplatform/pelican/namespaces"
+	log "github.com/sirupsen/logrus"
 )
 
 func deviceCodeSupported(grantTypes *[]string) bool {
@@ -90,12 +89,12 @@ func AcquireToken(issuerUrl string, entry *config.PrefixEntry, credentialGen *na
 	log.Debugln("Requesting a credential with the following scope:", storageScope)
 
 	oauth2Config := Config{
-		ClientID: entry.ClientID,
+		ClientID:     entry.ClientID,
 		ClientSecret: entry.ClientSecret,
 		Endpoint: Endpoint{AuthURL: issuerInfo.AuthURL,
-		                   TokenURL: issuerInfo.TokenURL,
-		                   DeviceAuthURL: issuerInfo.DeviceAuthURL},
-		Scopes : []string{"wlcg", "offline_access", storageScope},
+			TokenURL:      issuerInfo.TokenURL,
+			DeviceAuthURL: issuerInfo.DeviceAuthURL},
+		Scopes: []string{"wlcg", "offline_access", storageScope},
 	}
 
 	ctx := context.Background()
@@ -123,8 +122,8 @@ func AcquireToken(issuerUrl string, entry *config.PrefixEntry, credentialGen *na
 	}
 
 	token := config.TokenEntry{
-		Expiration: upstream_token.Expiry.Unix(),
-		AccessToken: upstream_token.AccessToken,
+		Expiration:   upstream_token.Expiry.Unix(),
+		AccessToken:  upstream_token.AccessToken,
 		RefreshToken: upstream_token.RefreshToken,
 	}
 	return &token, nil

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -43,8 +43,8 @@ func AdvertiseOrigin() error {
 	originUrl := "https://localhost:8444"
 
 	ad := director.OriginAdvertise{
-		Name: name,
-		URL:  originUrl,
+		Name:       name,
+		URL:        originUrl,
 		Namespaces: make([]director.NamespaceAd, 0),
 	}
 

--- a/origin_ui/origin.go
+++ b/origin_ui/origin.go
@@ -20,9 +20,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"github.com/pelicanplatform/pelican/config"
 	"github.com/spf13/viper"
 	"github.com/tg123/go-htpasswd"
 	"golang.org/x/crypto/bcrypt"
@@ -31,7 +31,7 @@ import (
 
 type (
 	Login struct {
-		User string `form:"user"`
+		User     string `form:"user"`
 		Password string `form:"password"`
 	}
 
@@ -45,8 +45,8 @@ type (
 )
 
 var (
-	authDB atomic.Pointer[htpasswd.File]
-	currentCode atomic.Pointer[string]
+	authDB       atomic.Pointer[htpasswd.File]
+	currentCode  atomic.Pointer[string]
 	previousCode atomic.Pointer[string]
 
 	//go:embed assets/*
@@ -107,7 +107,7 @@ func WaitUntilLogin() error {
 			fmt.Println(*currentCode.Load())
 		}
 		start := time.Now()
-		for time.Since(start) < 30 * time.Second {
+		for time.Since(start) < 30*time.Second {
 			select {
 			case <-sigs:
 				return errors.New("Process terminated...")
@@ -225,7 +225,7 @@ func setLoginCookie(ctx *gin.Context, user string) {
 		return
 	}
 
-	ctx.SetCookie("login", string(signed), 30 * 60, "/api/v1.0/origin-ui",
+	ctx.SetCookie("login", string(signed), 30*60, "/api/v1.0/origin-ui",
 		ctx.Request.URL.Host, true, true)
 	ctx.SetSameSite(http.SameSiteStrictMode)
 }
@@ -305,7 +305,7 @@ func initLoginHandler(ctx *gin.Context) {
 		ctx.JSON(400, gin.H{"error": "Login code not provided"})
 		return
 	}
-	
+
 	if code.Code != *curCode && (prevCode == nil || code.Code != *prevCode) {
 		ctx.JSON(401, gin.H{"error": "Invalid login code"})
 		return
@@ -378,7 +378,7 @@ func ConfigureOriginUI(router *gin.Engine) error {
 			file,
 		)
 	})
-	router.GET("/", func (ctx *gin.Context) {
+	router.GET("/", func(ctx *gin.Context) {
 		file, _ := webAssets.ReadFile("assets/index.html")
 		ctx.Data(
 			http.StatusOK,

--- a/unique_hash_darwin.go
+++ b/unique_hash_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package pelican
@@ -13,47 +14,47 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-//   Given a local filename, create a unique identifier from filesystem
-//   metadata; anytime the file contents change, the unique identifier
-//   should also change.  The hash changes once every 24 hours to allow
-//   the shadow origin to do garbage collection.
+// Given a local filename, create a unique identifier from filesystem
+// metadata; anytime the file contents change, the unique identifier
+// should also change.  The hash changes once every 24 hours to allow
+// the shadow origin to do garbage collection.
 //
-//   The current algorithm to generate the unique identifier is to
-//   take the concatenation of the following byte buffers:
+// The current algorithm to generate the unique identifier is to
+// take the concatenation of the following byte buffers:
 //
-//   - basename of the path.
-//   - inode # as a 64-bit integer serialized to a byte buffer, represented in network order.
-//   - ctime # as a double serialized to a buffer.
-//   - Current unix epoch time, as integer, divided by 86400
+// - basename of the path.
+// - inode # as a 64-bit integer serialized to a byte buffer, represented in network order.
+// - ctime # as a double serialized to a buffer.
+// - Current unix epoch time, as integer, divided by 86400
 //
-//   and then running it through a SHA256 sum to produce a digest.
+// and then running it through a SHA256 sum to produce a digest.
 //
-//   The hex digest of the SHA256 sum is returned along with the file size
+// The hex digest of the SHA256 sum is returned along with the file size
 func unique_hash(filePath string) (string, uint64, error) {
 	log.Debugf("Creating a unique hash for filename %s", filePath)
 
 	var st syscall.Stat_t
 	if err := syscall.Stat(filePath, &st); err != nil {
 		log.Debugln("Error while stat'ing file for metadata:", err)
-		return "", 0, err;
+		return "", 0, err
 	}
 
 	buf := new(bytes.Buffer)
 	if err := binary.Write(buf, binary.BigEndian, st.Ino); err != nil {
 		log.Debugln("Error while writing inode to buffer:", err)
-		return "", 0, err;
+		return "", 0, err
 	}
 	if err := binary.Write(buf, binary.BigEndian, st.Ctimespec.Sec); err != nil {
 		log.Debugln("Error while writing ctime to buffer:", err)
-		return "", 0, err;
+		return "", 0, err
 	}
 	if err := binary.Write(buf, binary.BigEndian, st.Ctimespec.Nsec); err != nil {
 		log.Debugln("Error while writing ctime nanoseconds to buffer:", err)
-		return "", 0, err;
+		return "", 0, err
 	}
 	if err := binary.Write(buf, binary.BigEndian, time.Now().Unix()/86400); err != nil {
 		log.Debugln("Error while writing current Unix time to buffer:", err)
-		return "", 0, err;
+		return "", 0, err
 	}
 
 	digest := sha256.New()

--- a/unique_hash_linux.go
+++ b/unique_hash_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package pelican
@@ -13,47 +14,47 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-//   Given a local filename, create a unique identifier from filesystem
-//   metadata; anytime the file contents change, the unique identifier
-//   should also change.  The hash changes once every 24 hours to allow
-//   the shadow origin to do garbage collection.
+// Given a local filename, create a unique identifier from filesystem
+// metadata; anytime the file contents change, the unique identifier
+// should also change.  The hash changes once every 24 hours to allow
+// the shadow origin to do garbage collection.
 //
-//   The current algorithm to generate the unique identifier is to
-//   take the concatenation of the following byte buffers:
+// The current algorithm to generate the unique identifier is to
+// take the concatenation of the following byte buffers:
 //
-//   - basename of the path.
-//   - inode # as a 64-bit integer serialized to a byte buffer, represented in network order.
-//   - ctime # as a double serialized to a buffer.
-//   - Current unix epoch time, as integer, divided by 86400
+// - basename of the path.
+// - inode # as a 64-bit integer serialized to a byte buffer, represented in network order.
+// - ctime # as a double serialized to a buffer.
+// - Current unix epoch time, as integer, divided by 86400
 //
-//   and then running it through a SHA256 sum to produce a digest.
+// and then running it through a SHA256 sum to produce a digest.
 //
-//   The hex digest of the SHA256 sum is returned along with the file size
+// The hex digest of the SHA256 sum is returned along with the file size
 func unique_hash(filePath string) (string, uint64, error) {
 	log.Debugf("Creating a unique hash for filename %s", filePath)
 
 	var st syscall.Stat_t
 	if err := syscall.Stat(filePath, &st); err != nil {
 		log.Debugln("Error while stat'ing file for metadata:", err)
-		return "", 0, err;
+		return "", 0, err
 	}
 
 	buf := new(bytes.Buffer)
 	if err := binary.Write(buf, binary.BigEndian, st.Ino); err != nil {
 		log.Debugln("Error while writing inode to buffer:", err)
-		return "", 0, err;
+		return "", 0, err
 	}
 	if err := binary.Write(buf, binary.BigEndian, st.Ctim.Sec); err != nil {
 		log.Debugln("Error while writing ctime to buffer:", err)
-		return "", 0, err;
+		return "", 0, err
 	}
 	if err := binary.Write(buf, binary.BigEndian, st.Ctim.Nsec); err != nil {
 		log.Debugln("Error while writing ctime nanoseconds to buffer:", err)
-		return "", 0, err;
+		return "", 0, err
 	}
 	if err := binary.Write(buf, binary.BigEndian, time.Now().Unix()/86400); err != nil {
 		log.Debugln("Error while writing current Unix time to buffer:", err)
-		return "", 0, err;
+		return "", 0, err
 	}
 
 	digest := sha256.New()

--- a/unique_hash_windows.go
+++ b/unique_hash_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package pelican
@@ -13,28 +14,28 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-//   Given a local filename, create a unique identifier from filesystem
-//   metadata; anytime the file contents change, the unique identifier
-//   should also change.  The hash changes once every 24 hours to allow
-//   the shadow origin to do garbage collection.
+// Given a local filename, create a unique identifier from filesystem
+// metadata; anytime the file contents change, the unique identifier
+// should also change.  The hash changes once every 24 hours to allow
+// the shadow origin to do garbage collection.
 //
-//   The current algorithm to generate the unique identifier is to
-//   take the concatenation of the following byte buffers:
+// The current algorithm to generate the unique identifier is to
+// take the concatenation of the following byte buffers:
 //
-//   - basename of the path.
-//   - mtime # as a double string
-//   - Current unix epoch time, as integer, divided by 86400
+// - basename of the path.
+// - mtime # as a double string
+// - Current unix epoch time, as integer, divided by 86400
 //
-//   and then running it through a SHA256 sum to produce a digest.
+// and then running it through a SHA256 sum to produce a digest.
 //
-//   The hex digest of the SHA256 sum is returned along with the file size
+// The hex digest of the SHA256 sum is returned along with the file size
 func unique_hash(filePath string) (string, uint64, error) {
 	log.Debugf("Creating a unique hash for filename %s", filePath)
 
 	st, err := os.Stat(filePath)
 	if err != nil {
 		log.Debugln("Error while stat'ing file for metadata:", err)
-		return "", 0, err;
+		return "", 0, err
 	}
 
 	digest := sha256.New()
@@ -44,7 +45,7 @@ func unique_hash(filePath string) (string, uint64, error) {
 	buf := new(bytes.Buffer)
 	if err := binary.Write(buf, binary.BigEndian, time.Now().Unix()/86400); err != nil {
 		log.Debugln("Error while writing current Unix time to buffer:", err)
-		return "", 0, err;
+		return "", 0, err
 	}
 	digest.Write(buf.Bytes())
 

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -40,9 +40,9 @@ func GetEngine() (*gin.Engine, error) {
 
 		latency := time.Since(startTime)
 		webLogger.WithFields(log.Fields{"method": ctx.Request.Method,
-			"status": ctx.Writer.Status(),
-			"time": latency.String(),
-			"client": ctx.RemoteIP(),
+			"status":   ctx.Writer.Status(),
+			"time":     latency.String(),
+			"client":   ctx.RemoteIP(),
 			"resource": ctx.Request.URL.Path},
 		).Info("Served Request")
 	})

--- a/xrootd/launch.go
+++ b/xrootd/launch.go
@@ -17,20 +17,18 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 type (
+	XrootdLauncher interface {
+		Launch(ctx context.Context, daemonName string, configPath string) (context.Context, int, error)
+	}
 
-XrootdLauncher interface {
-	Launch(ctx context.Context, daemonName string, configPath string) (context.Context, int, error)
-}
+	PrivilegedXrootdLauncher struct{}
 
-PrivilegedXrootdLauncher struct {}
-
-UnprivilegedXrootdLauncher struct {}
-
+	UnprivilegedXrootdLauncher struct{}
 )
 
 func forwardCommandToLogger(ctx context.Context, daemonName string, cmdStdout io.ReadCloser, cmdStderr io.ReadCloser) {
@@ -71,7 +69,7 @@ func forwardCommandToLogger(ctx context.Context, daemonName string, cmdStdout io
 			break
 		}
 	}
-	<- ctx.Done()
+	<-ctx.Done()
 }
 
 func (UnprivilegedXrootdLauncher) Launch(ctx context.Context, daemonName string, configPath string) (context.Context, int, error) {
@@ -164,7 +162,7 @@ func LaunchXrootd(privileged bool, configPath string) (err error) {
 			}
 			xrootdExpiry = time.Now().Add(10 * time.Second)
 			cmsdExpiry = time.Now().Add(10 * time.Second)
-		case <- xrootdCtx.Done():
+		case <-xrootdCtx.Done():
 			if waitResult := context.Cause(xrootdCtx); waitResult != nil {
 				if !xrootdExpiry.IsZero() {
 					return nil

--- a/xrootd/launch_default.go
+++ b/xrootd/launch_default.go
@@ -11,4 +11,3 @@ import (
 func (PrivilegedXrootdLauncher) Launch(ctx context.Context, daemonName string, configPath string) (context.Context, int, error) {
 	return ctx, -1, errors.New("Privileged process launching not supported on this platform")
 }
-

--- a/xrootd/launch_windows.go
+++ b/xrootd/launch_windows.go
@@ -6,7 +6,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-type PrivilegedXrootdLauncher struct {}
+type PrivilegedXrootdLauncher struct{}
 
 func LaunchOrigin() error {
 	return errors.New("'origin serve' command is not supported on Windows")


### PR DESCRIPTION
While we're in a lull of PRs, let's rip off the bandaid and get things following the standard formatting.