### PR TITLE
Create a single `--port` flag object

### DIFF
--- a/cmd/director.go
+++ b/cmd/director.go
@@ -36,14 +36,10 @@ func init() {
 	directorCmd.AddCommand(directorServeCmd)
 
 	// Set up flags for the command
-	directorServeCmd.Flags().StringP("port", "p", "", "Set the port to which the Director's redirect services should be bound")
-	err := viper.BindPFlag("WebPort", directorServeCmd.Flags().Lookup("port"))
-	if err != nil {
-		panic(err)
-	}
+	directorServeCmd.Flags().AddFlag(portFlag)
 
 	directorServeCmd.Flags().StringP("default-response", "", "", "Set whether the default endpoint should redirect clients to caches or origins")
-	err = viper.BindPFlag("Director.DefaultResponse", directorServeCmd.Flags().Lookup("default-response"))
+	err := viper.BindPFlag("Director.DefaultResponse", directorServeCmd.Flags().Lookup("default-response"))
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/namespace_registry.go
+++ b/cmd/namespace_registry.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -36,11 +35,6 @@ var (
 func init() {
 	// Tie the registryServe command to the root CLI command
 	namespaceRegistryCmd.AddCommand(registryServeCmd)
-
 	// Set up flags for the command
-	registryServeCmd.Flags().StringP("port", "p", "", "Set the port at which the namespace registry should be accessible.")
-	err := viper.BindPFlag("WebPort", registryServeCmd.Flags().Lookup("port"))
-	if err != nil {
-		panic(err)
-	}
+	registryServeCmd.Flags().AddFlag(portFlag)
 }

--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -40,4 +40,5 @@ func init() {
 	if err := viper.BindPFlag("ExportVolume", originServeCmd.Flags().Lookup("volume")); err != nil {
 		panic(err)
 	}
+	originServeCmd.Flags().AddFlag(portFlag)
 }

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/prometheus/prometheus v0.46.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.7.0
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0
 	github.com/stretchr/testify v1.8.4
 	github.com/studio-b12/gowebdav v0.9.0
@@ -131,7 +132,6 @@ require (
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -58,6 +58,7 @@ func RunEngine(engine *gin.Engine) {
 
 	addr := fmt.Sprintf("%v:%v", viper.GetString("WebAddress"), viper.GetInt("WebPort"))
 
+	log.Debugln("Starting web engine at address", addr)
 	err := engine.RunTLS(addr, certFile, keyFile)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
When a flag is bound to the viper key (such as binding the `--port` flag object to the `WebPort` key), it's a global.  If you do this multiple times with multiple pointers, only the last one is used.

That means, if we invoke `cmd.Flags().StringP(...)` in multiple sub-commands, only one will actually set `WebPort`.

The solution for this is to create the flag once globally, then add the global object to multiple commands.  Note that I didn't use a parent-level "persistent flag" as that would also make `--port` usage strings appear for the `object` sub-command (which doesn't have an embedded webserver).

Fixes #63.