### PR TITLE
Upgrade remainder of the code to lestrrat-go v2

### DIFF
--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -85,7 +85,9 @@ func LoadPublicKey(existingJWKS string, issuerKeyFile string) (*jwk.Set, error) 
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to assign key ID to public key")
 	}
-	jwks.AddKey(pkey)
+	if err = jwks.AddKey(pkey); err != nil {
+		return nil, errors.Wrap(err, "Failed to add public key to new JWKS")
+	}
 	return &jwks, nil
 }
 

--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -15,7 +15,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/lestrrat-go/jwx/jwk"
+	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 )
@@ -85,7 +85,7 @@ func LoadPublicKey(existingJWKS string, issuerKeyFile string) (*jwk.Set, error) 
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to assign key ID to public key")
 	}
-	jwks.Add(pkey)
+	jwks.AddKey(pkey)
 	return &jwks, nil
 }
 

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -82,7 +82,9 @@ func VerifyAdvertiseToken(token, namespace string) (bool, error) {
 	ctx := context.Background()
 	if ar == nil {
 		ar := jwk.NewCache(ctx)
-		ar.Register(issuer_url, jwk.WithMinRefreshInterval(15*time.Minute))
+		if err = ar.Register(issuer_url, jwk.WithMinRefreshInterval(15*time.Minute)); err != nil {
+			return false, err
+		}
 		namespaceKeysMutex.Lock()
 		defer namespaceKeysMutex.Unlock()
 		namespaceKeys.Set(namespace, ar, ttlcache.DefaultTTL)

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
-	"github.com/lestrrat-go/jwx/jwa"
-	"github.com/lestrrat-go/jwx/jwk"
-	"github.com/lestrrat-go/jwx/jwt"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/spf13/viper"
 )
@@ -26,7 +26,7 @@ type (
 )
 
 var (
-	namespaceKeys      = ttlcache.New[string, *jwk.AutoRefresh](ttlcache.WithTTL[string, *jwk.AutoRefresh](15 * time.Minute))
+	namespaceKeys      = ttlcache.New[string, *jwk.Cache](ttlcache.WithTTL[string, *jwk.Cache](15 * time.Minute))
 	namespaceKeysMutex = sync.RWMutex{}
 )
 
@@ -55,7 +55,7 @@ func CreateAdvertiseToken(namespace string) (string, error) {
 		return "", err
 	}
 
-	signed, err := jwt.Sign(tok, jwa.ES512, key)
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES512, key))
 	if err != nil {
 		return "", err
 	}
@@ -70,7 +70,7 @@ func VerifyAdvertiseToken(token, namespace string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	var ar *jwk.AutoRefresh
+	var ar *jwk.Cache
 	{
 		namespaceKeysMutex.RLock()
 		defer namespaceKeysMutex.Unlock()
@@ -81,13 +81,13 @@ func VerifyAdvertiseToken(token, namespace string) (bool, error) {
 	}
 	ctx := context.Background()
 	if ar == nil {
-		ar := jwk.NewAutoRefresh(ctx)
-		ar.Configure(issuer_url, jwk.WithMinRefreshInterval(15*time.Minute))
+		ar := jwk.NewCache(ctx)
+		ar.Register(issuer_url, jwk.WithMinRefreshInterval(15*time.Minute))
 		namespaceKeysMutex.Lock()
 		defer namespaceKeysMutex.Unlock()
 		namespaceKeys.Set(namespace, ar, ttlcache.DefaultTTL)
 	}
-	keyset, err := ar.Fetch(ctx, issuer_url)
+	keyset, err := ar.Get(ctx, issuer_url)
 	if err != nil {
 		return false, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd
 	github.com/jellydator/ttlcache/v3 v3.0.1
 	github.com/jsipprell/keyctl v1.0.4-0.20211208153515-36ca02672b6c
-	github.com/lestrrat-go/jwx v1.2.26
 	github.com/lestrrat-go/jwx/v2 v2.0.11
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 	github.com/oklog/run v1.1.0
@@ -97,7 +96,6 @@ require (
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect
-	github.com/lestrrat-go/backoff/v2 v2.0.8 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.1 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
 	github.com/lestrrat-go/httprc v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -397,8 +397,6 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.2.4 h1:XlAE/cm/ms7TE/VMVoduSpNBoyc2dOxHs5MZSwAN63Q=
 github.com/leodido/go-urn v1.2.4/go.mod h1:7ZrI8mTSeBSHl/UaRyKQW1qZeMgak41ANeCNaVckg+4=
-github.com/lestrrat-go/backoff/v2 v2.0.8 h1:oNb5E5isby2kiro9AgdHLv5N5tint1AnDVVf2E2un5A=
-github.com/lestrrat-go/backoff/v2 v2.0.8/go.mod h1:rHP/q/r9aT27n24JQLa7JhSQZCKBBOiM/uP402WwN8Y=
 github.com/lestrrat-go/blackmagic v1.0.1 h1:lS5Zts+5HIC/8og6cGHb0uCcNCa3OUt1ygh3Qz2Fe80=
 github.com/lestrrat-go/blackmagic v1.0.1/go.mod h1:UrEqBzIR2U6CnzVyUtfM6oZNMt/7O7Vohk2J0OGSAtU=
 github.com/lestrrat-go/httpcc v1.0.1 h1:ydWCStUeJLkpYyjLDHihupbn2tYmZ7m22BGkcvZZrIE=
@@ -407,8 +405,6 @@ github.com/lestrrat-go/httprc v1.0.4 h1:bAZymwoZQb+Oq8MEbyipag7iSq6YIga8Wj6GOiJG
 github.com/lestrrat-go/httprc v1.0.4/go.mod h1:mwwz3JMTPBjHUkkDv/IGJ39aALInZLrhBp0X7KGUZlo=
 github.com/lestrrat-go/iter v1.0.2 h1:gMXo1q4c2pHmC3dn8LzRhJfP1ceCbgSiT9lUydIzltI=
 github.com/lestrrat-go/iter v1.0.2/go.mod h1:Momfcq3AnRlRjI5b5O8/G5/BvpzrhoFTZcn06fEOPt4=
-github.com/lestrrat-go/jwx v1.2.26 h1:4iFo8FPRZGDYe1t19mQP0zTRqA7n8HnJ5lkIiDvJcB0=
-github.com/lestrrat-go/jwx v1.2.26/go.mod h1:MaiCdGbn3/cckbOFSCluJlJMmp9dmZm5hDuIkx8ftpQ=
 github.com/lestrrat-go/jwx/v2 v2.0.11 h1:ViHMnaMeaO0qV16RZWBHM7GTrAnX2aFLVKofc7FuKLQ=
 github.com/lestrrat-go/jwx/v2 v2.0.11/go.mod h1:ZtPtMFlrfDrH2Y0iwfa3dRFn8VzwBrB+cyrm3IBWdDg=
 github.com/lestrrat-go/option v1.0.0/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=


### PR DESCRIPTION
The library we use for JWKs and JWTs has both a v1 and v2 API.  As the various Pelican pieces were independently developed, some modules used V1 and others V2.  This brings up all the code to use V2, dropping V1 as a dependency.

Fixes #61.