### PR TITLE
Fix small bug in ns-registry auto creation

### DIFF
--- a/namespace-registry/registry-db.go
+++ b/namespace-registry/registry-db.go
@@ -141,19 +141,10 @@ func InitializeDB() error {
 		return errors.Wrap(err, "Failed to create directory for namespace registry database")
 	}
 
-	fileInfo, err := os.Stat(dbPath)
-	if err != nil {
-		return errors.Wrap(err, "Error checking NSRegistryLocation filepath information")
-	}
-
-	// Check if it's a directory
-	if fileInfo.IsDir() { // if directory, we add the filename to it
-		dbPath = filepath.Join(dbPath, "nsregistry.sqlite")
-	}
-
-	if len(filepath.Ext(dbPath)) == 0 { // No fp extension, let's add .sqlite
+	if len(filepath.Ext(dbPath)) == 0 { // No fp extension, let's add .sqlite so it's obvious what the file is
 		dbPath += ".sqlite"
 	}
+
 	db, err = sql.Open("sqlite", dbPath)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to open the database with path: %s", dbPath)


### PR DESCRIPTION
We talked this morning about config variables that specify "Location" and how they should specify the actual filename. I had previously tried to implement some logic that if a file location was passed such as `/foo/bar/`, the namespace registry would auto create the registry database as `/foo/bar/ns-registry.sqlite`. Instead of fixing the bug in that logic, let's just say whatever is passed should be considered the file name. A side effect of this is that if the user configures `NSRegistryLocation = /foo/bar/`, the file will be created as `/foo/bar/.sqlite` because the code automatically adds a file extension when none is provided and in this case, the actual filename is empty.

This fixes #67 