### PR TITLE
Use lestrrat jwks instead of custom structs in NS Registry

### DIFF
--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"math/big"
@@ -232,31 +231,4 @@ func GetOriginJWK() (*jwk.Key, error) {
 		key = &newKey
 	}
 	return key, nil
-}
-
-func JWKSMap(jwks *jwk.Set) (map[string]string, error) {
-	// Marshal the set into JSON
-	jsonBytes, err := json.MarshalIndent(jwks, "", "  ")
-	if err != nil {
-		return nil, err
-	}
-
-	// Parse the JSON into a structure we can manipulate
-	var parsed map[string][]map[string]interface{}
-	err = json.Unmarshal(jsonBytes, &parsed)
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert the map[string]interface{} to map[string]string
-	stringMaps := make([]map[string]string, len(parsed["keys"]))
-	for i, m := range parsed["keys"] {
-		stringMap := make(map[string]string)
-		for k, v := range m {
-			stringMap[k] = fmt.Sprintf("%v", v)
-		}
-		stringMaps[i] = stringMap
-	}
-
-	return stringMaps[0], nil
 }


### PR DESCRIPTION
There were missing key values in the registry database (like kty, kid, etc) because of the custom structs being used to create the jwks that got stored. By using lestrrat's jwk package, we get those values for free.

One thing to note about the PR is that while the registration pubkey verification dance works when using the client in its current form, this won't work for a jwks with multiple keys in it. I didn't try to tackle that problem in this commit because I'm not sure where those other key pairs are coming from, so I wasn't sure how load them into the key set. 

Fixes #54 