### PR TITLE
Fix director responses

### DIFF
--- a/director.go
+++ b/director.go
@@ -63,7 +63,7 @@ func CreateNsFromDirectorResp(dirResp *http.Response, namespace *namespaces.Name
 	}
 	xPelicanNamespace := HeaderParser(pelicanNamespaceHdr[0])
 	namespace.Path = xPelicanNamespace["namespace"]
-	namespace.UseTokenOnRead, _ = strconv.ParseBool(xPelicanNamespace["use-token-on-read"])
+	namespace.UseTokenOnRead, _ = strconv.ParseBool(xPelicanNamespace["require-token"])
 	namespace.ReadHTTPS, _ = strconv.ParseBool(xPelicanNamespace["readhttps"])
 
 	var xPelicanAuthorization map[string]string

--- a/director/advertise.go
+++ b/director/advertise.go
@@ -148,10 +148,7 @@ func AdvertiseOSDF() error {
 			}
 			originAd.URL = *originURL
 
-			originNS := NamespaceAd{}
-			originNS.Path = ns.Path
-			originNS.RequireToken = ns.UseTokenOnRead
-			originAdMap[originAd] = append(originAdMap[originAd], originNS)
+			originAdMap[originAd] = append(originAdMap[originAd], nsAd)
 		}
 
 		for _, cache := range ns.Caches {

--- a/director_test.go
+++ b/director_test.go
@@ -74,7 +74,7 @@ func TestCreateNsFromDirectorResp(t *testing.T) {
 	//Craft the Director's response
 	directorHeaders := make(map[string][]string)
 	directorHeaders["Link"] = []string{"<my-cache.edu:8443>; rel=\"duplicate\"; pri=1, <another-cache.edu:8443>; rel=\"duplicate\"; pri=2"}
-	directorHeaders["X-Pelican-Namespace"] = []string{"namespace=/foo/bar, readhttps=True, use-token-on-read=True"}
+	directorHeaders["X-Pelican-Namespace"] = []string{"namespace=/foo/bar, readhttps=True, require-token=True"}
 	directorHeaders["X-Pelican-Authorization"] = []string{"issuer=https://get-your-tokens.org, base-path=/foo/bar"}
 	directorBody := []byte(`{"key": "value"}`)
 


### PR DESCRIPTION
This fixes up the header generation for the director response.  Now, when I try the command from @jhiemstrawisc in #68, I get the following in the response headers:

```
...
< location: https://dtn-pas.cinc.nrp.internet2.edu:8443/ospool/PROTECTED/justin.hiemstra
< x-pelican-authorization: issuer=https://osg-htc.org/ospool
< x-pelican-namespace: namespace=/ospool/PROTECTED, require-token=true
< x-pelican-token-generation: issuer=https://osg-htc.org/ospool, max-scope-depth=4, strategy=OAuth2
```

Fixes #68