### PR TITLE
Add pre-commit hooks for the repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+-   repo: https://github.com/golangci/golangci-lint
+    rev: v1.54.2
+    hooks:
+    -   id: golangci-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,9 @@ repos:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
+        # Multi-documents are yaml files with multiple --- separating blocks, like
+        # in our docs/parameters.yaml. We need this argument so those parse.
+        args: [--allow-multiple-documents]
     -   id: check-added-large-files
 -   repo: https://github.com/golangci/golangci-lint
     rev: v1.54.2


### PR DESCRIPTION
This introduces pre-commit configurations to run golangci before any commits occur.  Goal is to decrease the number of "fixup linter" type commit messages in the repo.

Fixes #83 