### PR TITLE
Remove default user

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,12 +1,12 @@
 #
 # Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License"); you
 # may not use this file except in compliance with the License.  You may
 # obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -62,7 +62,5 @@ COPY images/entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /pelican/osdf-client \
     && chmod +x /entrypoint.sh
-
-USER xrootd
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
supervisord startup was failing when this was set ... let's revert for now and revisit dropping permissions in the future.

Fixes #90 