### PR TITLE
Add registry to container

### DIFF
--- a/images/supervisord/pelican_registry_serve.conf
+++ b/images/supervisord/pelican_registry_serve.conf
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+# 
+#    http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[program:pelican_registry_serve]
+command=/pelican/osdf-client registry serve -p %(ENV_OSDF_REGISTRY_PORT)s 
+autostart=false
+autorestart=true
+redirect_stderr=true


### PR DESCRIPTION
This commit adds a supervisord program that allows the container to serve a namespace registry. To serve a namespace registry, launch the container with the argument `registry_serve`.