### PR TITLE
Using common transport for https based writes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -394,7 +394,7 @@ func InitClient() error {
 		}
 	}
 	for _, prefix := range prefixes {
-		if val, isSet := os.LookupEnv(prefix + "_TOPOLOGYNAMESPACEURL"); isSet {
+		if val, isSet := os.LookupEnv(prefix + "_TOPOLOGY_NAMESPACE_URL"); isSet {
 			viper.Set("TopologyNamespaceURL", val)
 			break
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -393,6 +393,12 @@ func InitClient() error {
 			break
 		}
 	}
+	for _, prefix := range prefixes {
+		if val, isSet := os.LookupEnv(prefix + "_TOPOLOGYNAMESPACEURL"); isSet {
+			viper.Set("TopologyNamespaceURL", val)
+			break
+		}
+	}
 
 	// Check the environment variable STASHCP_MINIMUM_DOWNLOAD_SPEED (and all the prefix variants)
 	var downloadLimit int64 = 1024 * 100

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -29,3 +29,12 @@ Director:
   DefaultResponse: cache
 Origin:
   Multiuser: false
+Transport:
+  Dialer:
+    Timeout: 10s
+    KeepAlive: 30s
+  MaxIdleConns: 30
+  IdleConnTimeout: 90s
+  TLSHandshakeTimeout: 15s
+  ExpectContinueTimeout: 1s
+  ResponseHeaderTimeout: 10s

--- a/director.go
+++ b/director.go
@@ -19,7 +19,6 @@
 package pelican
 
 import (
-	"crypto/tls"
 	"net/http"
 	"net/url"
 	"sort"
@@ -29,7 +28,6 @@ import (
 	namespaces "github.com/pelicanplatform/pelican/namespaces"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 // Simple parser to that takes a "values" string from a header and turns it
@@ -123,22 +121,12 @@ func QueryDirector(source string, directorUrl string) (resp *http.Response, err 
 	// redirect. We use the Location url elsewhere (plus we still need to do the token
 	// dance!)
 	var client *http.Client
-	if viper.GetBool("TLSSkipVerify") {
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-		client = &http.Client{
-			Transport: tr,
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
-				return http.ErrUseLastResponse
-			},
-		}
-	} else {
-		client = &http.Client{
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
-				return http.ErrUseLastResponse
-			},
-		}
+	tr := getTransport()
+	client = &http.Client{
+		Transport: tr,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
 
 	log.Debugln("Querying OSDF Director at", resourceUrl)

--- a/director.go
+++ b/director.go
@@ -19,6 +19,7 @@
 package pelican
 
 import (
+	"crypto/tls"
 	"net/http"
 	"net/url"
 	"sort"
@@ -28,6 +29,7 @@ import (
 	namespaces "github.com/pelicanplatform/pelican/namespaces"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 // Simple parser to that takes a "values" string from a header and turns it
@@ -117,12 +119,26 @@ func CreateNsFromDirectorResp(dirResp *http.Response, namespace *namespaces.Name
 
 func QueryDirector(source string, directorUrl string) (resp *http.Response, err error) {
 	resourceUrl := directorUrl + source
-
-	// Prevent following the Director's redirect
-	client := &http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
+	// Here we use http.Transport to prevent the client from following the director's
+	// redirect. We use the Location url elsewhere (plus we still need to do the token
+	// dance!)
+	var client *http.Client
+	if viper.GetBool("TLSSkipVerify") {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client = &http.Client{
+			Transport: tr,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+	} else {
+		client = &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
 	}
 
 	log.Debugln("Querying OSDF Director at", resourceUrl)

--- a/handle_http.go
+++ b/handle_http.go
@@ -20,6 +20,7 @@ package pelican
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -36,7 +37,6 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
-	"crypto/tls"
 
 	grab "github.com/cavaliercoder/grab"
 	log "github.com/sirupsen/logrus"
@@ -829,8 +829,7 @@ Loop:
 
 }
 
-//transport = getTransport()
-var UploadClient = &http.Client{Transport: transport} //Global: Used by handle_http_test.go but nothing else
+var UploadClient = &http.Client{Transport: getTransport()}
 
 // Actually perform the Put request to the server
 func doPut(request *http.Request, responseChan chan<- *http.Response, errorChan chan<- error) {

--- a/handle_http.go
+++ b/handle_http.go
@@ -450,15 +450,15 @@ func setupTransport() http.Transport {
 	transportKeepAlive := viper.GetDuration("Transport.Dialer.KeepAlive")
 
 	//Set up the transport
-	transport := http.Transport {
+	transport := http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
-			Timeout: transportDialerTimeout,
+			Timeout:   transportDialerTimeout,
 			KeepAlive: transportKeepAlive,
 		}).DialContext,
-		MaxIdleConns: maxIdleConns,
-		IdleConnTimeout: idleConnTimeout,
-		TLSHandshakeTimeout: transportTLSHandshakeTimeout,
+		MaxIdleConns:          maxIdleConns,
+		IdleConnTimeout:       idleConnTimeout,
+		TLSHandshakeTimeout:   transportTLSHandshakeTimeout,
 		ExpectContinueTimeout: expectContinueTimeout,
 		ResponseHeaderTimeout: responseHeaderTimeout,
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -60,8 +60,8 @@ func TestGetIps(t *testing.T) {
 func TestGetToken(t *testing.T) {
 
 	// Need a namespace for token acquisition
-	defer os.Unsetenv("PELICAN_NAMESPACE_URL")
-	os.Setenv("PELICAN_NAMESPACE_URL", "https://topology.opensciencegrid.org/osdf/namespaces")
+	defer os.Unsetenv("PELICAN_TOPOLOGYNAMESPACEURL")
+	os.Setenv("PELICAN_TOPOLOGYNAMESPACEURL", "https://topology.opensciencegrid.org/osdf/namespaces")
 	viper.Reset()
 	err := config.InitClient()
 	assert.Nil(t, err)

--- a/main_test.go
+++ b/main_test.go
@@ -61,7 +61,7 @@ func TestGetToken(t *testing.T) {
 
 	// Need a namespace for token acquisition
 	defer os.Unsetenv("PELICAN_TOPOLOGYNAMESPACEURL")
-	os.Setenv("PELICAN_TOPOLOGYNAMESPACEURL", "https://topology.opensciencegrid.org/osdf/namespaces")
+	os.Setenv("PELICAN_TOPOLOGY_NAMESPACE_URL", "https://topology.opensciencegrid.org/osdf/namespaces")
 	viper.Reset()
 	err := config.InitClient()
 	assert.Nil(t, err)

--- a/namespaces/namespaces.go
+++ b/namespaces/namespaces.go
@@ -182,7 +182,7 @@ func GetNamespaces() ([]Namespace, error) {
 // downloadNamespace downloads the namespace information with timeouts
 func downloadNamespace() ([]byte, error) {
 	// Get the namespace url from the environment
-	namespaceUrl := viper.GetString("NamespaceURL")
+	namespaceUrl := viper.GetString("TopologyNamespaceURL")
 	if len(namespaceUrl) == 0 {
 		return nil, errors.New("NamespaceURL is not set; unable to locate valid caches")
 	}

--- a/namespaces/namespaces_test.go
+++ b/namespaces/namespaces_test.go
@@ -85,7 +85,7 @@ func TestMatchNamespace(t *testing.T) {
 }
 `)
 
-	err := os.Setenv("PELICAN_TOPOLOGYNAMESPACEURL", "https://doesnotexist.edu/blah/nope")
+	err := os.Setenv("PELICAN_TOPOLOGY_NAMESPACE_URL", "https://doesnotexist.edu/blah/nope")
 	if err != nil {
 		t.Error(err)
 	}
@@ -181,11 +181,11 @@ func TestFullNamespace(t *testing.T) {
 
 // TestDownloadNamespaces tests the download of the namespaces JSON
 func TestDownloadNamespaces(t *testing.T) {
-	os.Setenv("PELICAN_TOPOLOGYNAMESPACEURL", "https://topology-itb.opensciencegrid.org/stashcache/namespaces")
+	os.Setenv("PELICAN_TOPOLOGY_NAMESPACE_URL", "https://topology-itb.opensciencegrid.org/stashcache/namespaces")
 	viper.Reset()
 	err := config.InitClient()
 	assert.Nil(t, err)
-	defer os.Unsetenv("PELICAN_TOPOLOGYNAMESPACEURL")
+	defer os.Unsetenv("PELICAN_TOPOLOGY_NAMESPACE_URL")
 	namespaceBytes, err := downloadNamespace()
 	assert.NoError(t, err, "Failed to download namespaces")
 	assert.NotNil(t, namespaceBytes, "Namespace bytes is nil")
@@ -193,11 +193,11 @@ func TestDownloadNamespaces(t *testing.T) {
 }
 
 func TestDownloadNamespacesFail(t *testing.T) {
-	os.Setenv("PELICAN_TOPOLOGYNAMESPACEURL", "https://doesnotexist.org.blah/namespaces.json")
+	os.Setenv("PELICAN_TOPOLOGY_NAMESPACE_URL", "https://doesnotexist.org.blah/namespaces.json")
 	viper.Reset()
 	err := config.InitClient()
 	assert.Nil(t, err)
-	defer os.Unsetenv("PELICAN_TOPOLOGYNAMESPACEURL")
+	defer os.Unsetenv("PELICAN_TOPOLOGY_NAMESPACE_URL")
 	namespaceBytes, err := downloadNamespace()
 	assert.Error(t, err, "Failed to download namespaces")
 	assert.Nil(t, namespaceBytes, "Namespace bytes is nil")
@@ -205,13 +205,13 @@ func TestDownloadNamespacesFail(t *testing.T) {
 
 func TestGetNamespaces(t *testing.T) {
 	// Set the environment to an invalid URL, so it is forced to use the "built-in" namespaces.json
-	os.Setenv("OSDF_TOPOLOGYNAMESPACEURL", "https://doesnotexist.org.blah/namespaces.json")
+	os.Setenv("OSDF_TOPOLOGY_NAMESPACE_URL", "https://doesnotexist.org.blah/namespaces.json")
 	oldPrefix := config.SetPreferredPrefix("OSDF")
 	defer config.SetPreferredPrefix(oldPrefix)
 	viper.Reset()
 	err := config.InitClient()
 	assert.Nil(t, err)
-	defer os.Unsetenv("OSDF_TOPOLOGYNAMESPACEURL")
+	defer os.Unsetenv("OSDF_TOPOLOGY_NAMESPACE_URL")
 	namespaces, err := GetNamespaces()
 	assert.NoError(t, err, "Failed to get namespaces")
 	assert.NotNil(t, namespaces, "Namespaces is nil")

--- a/namespaces/namespaces_test.go
+++ b/namespaces/namespaces_test.go
@@ -85,7 +85,7 @@ func TestMatchNamespace(t *testing.T) {
 }
 `)
 
-	err := os.Setenv("PELICAN_NAMESPACE_URL", "https://doesnotexist.edu/blah/nope")
+	err := os.Setenv("PELICAN_TOPOLOGYNAMESPACEURL", "https://doesnotexist.edu/blah/nope")
 	if err != nil {
 		t.Error(err)
 	}
@@ -181,11 +181,11 @@ func TestFullNamespace(t *testing.T) {
 
 // TestDownloadNamespaces tests the download of the namespaces JSON
 func TestDownloadNamespaces(t *testing.T) {
-	os.Setenv("PELICAN_NAMESPACE_URL", "https://topology-itb.opensciencegrid.org/stashcache/namespaces")
+	os.Setenv("PELICAN_TOPOLOGYNAMESPACEURL", "https://topology-itb.opensciencegrid.org/stashcache/namespaces")
 	viper.Reset()
 	err := config.InitClient()
 	assert.Nil(t, err)
-	defer os.Unsetenv("PELICAN_NAMESPACE_URL")
+	defer os.Unsetenv("PELICAN_TOPOLOGYNAMESPACEURL")
 	namespaceBytes, err := downloadNamespace()
 	assert.NoError(t, err, "Failed to download namespaces")
 	assert.NotNil(t, namespaceBytes, "Namespace bytes is nil")
@@ -193,11 +193,11 @@ func TestDownloadNamespaces(t *testing.T) {
 }
 
 func TestDownloadNamespacesFail(t *testing.T) {
-	os.Setenv("PELICAN_NAMESPACE_URL", "https://doesnotexist.org.blah/namespaces.json")
+	os.Setenv("PELICAN_TOPOLOGYNAMESPACEURL", "https://doesnotexist.org.blah/namespaces.json")
 	viper.Reset()
 	err := config.InitClient()
 	assert.Nil(t, err)
-	defer os.Unsetenv("PELICAN_NAMESPACE_URL")
+	defer os.Unsetenv("PELICAN_TOPOLOGYNAMESPACEURL")
 	namespaceBytes, err := downloadNamespace()
 	assert.Error(t, err, "Failed to download namespaces")
 	assert.Nil(t, namespaceBytes, "Namespace bytes is nil")
@@ -205,13 +205,13 @@ func TestDownloadNamespacesFail(t *testing.T) {
 
 func TestGetNamespaces(t *testing.T) {
 	// Set the environment to an invalid URL, so it is forced to use the "built-in" namespaces.json
-	os.Setenv("OSDF_NAMESPACE_URL", "https://doesnotexist.org.blah/namespaces.json")
+	os.Setenv("OSDF_TOPOLOGYNAMESPACEURL", "https://doesnotexist.org.blah/namespaces.json")
 	oldPrefix := config.SetPreferredPrefix("OSDF")
 	defer config.SetPreferredPrefix(oldPrefix)
 	viper.Reset()
 	err := config.InitClient()
 	assert.Nil(t, err)
-	defer os.Unsetenv("OSDF_NAMESPACE_URL")
+	defer os.Unsetenv("OSDF_TOPOLOGYNAMESPACEURL")
 	namespaces, err := GetNamespaces()
 	assert.NoError(t, err, "Failed to get namespaces")
 	assert.NotNil(t, namespaces, "Namespaces is nil")


### PR DESCRIPTION
This commit creates one common create transport function for https based writes, rather than having duplicating code. In addition, the timeouts for these transports are created in defaults.yaml so they can be changed easily. 
Other changes include:
1. Adding TLSSkipVerify to client's director query, which is a useful feature for testing for us when using a running director locally.
2. Found a bug in namespaces.go, where NamespaceURL was used when TopologyNamespaceURL should be used instead.