### PR TITLE
Fix naming of oidc config vars

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -250,8 +250,8 @@ func InitServer() error {
 		viper.SetDefault("XrootdMultiuser", true)
 		viper.SetDefault("GeoIPLocation", "/var/cache/pelican/maxmind/GeoLite2-City.mmdb")
 		viper.SetDefault("NSRegistryLocation", "/var/lib/pelican/registry.sqlite")
-		viper.SetDefault("OIDCClientIDFile", "/etc/pelican/oidc-client-id")
-		viper.SetDefault("OIDCClientSecretFile", "/etc/pelican/oidc-client-secret")
+		viper.SetDefault("OIDC.ClientIDFile", "/etc/pelican/oidc-client-id")
+		viper.SetDefault("OIDC.ClientSecretFile", "/etc/pelican/oidc-client-secret")
 		viper.SetDefault("MonitoringData", "/var/lib/pelican/monitoring/data")
 	} else {
 		configBase, err := getConfigBase()
@@ -268,8 +268,8 @@ func InitServer() error {
 		viper.SetDefault("OriginUI.PasswordFile", filepath.Join(configBase, "origin-ui-passwd"))
 		viper.SetDefault("GeoIPLocation", filepath.Join(configBase, "maxmind", "GeoLite2-City.mmdb"))
 		viper.SetDefault("NSRegistryLocation", filepath.Join(configBase, "ns-registry.sqlite"))
-		viper.SetDefault("OIDCClientIDFile", filepath.Join(configBase, "oidc-client-id"))
-		viper.SetDefault("OIDCClientSecretFile", filepath.Join(configBase, "oidc-client-secret"))
+		viper.SetDefault("OIDC.ClientIDFile", filepath.Join(configBase, "oidc-client-id"))
+		viper.SetDefault("OIDC.ClientSecretFile", filepath.Join(configBase, "oidc-client-secret"))
 		viper.SetDefault("MonitoringData", filepath.Join(configBase, "monitoring/data"))
 
 		if userRuntimeDir := os.Getenv("XDG_RUNTIME_DIR"); userRuntimeDir != "" {

--- a/namespace-registry/registry.go
+++ b/namespace-registry/registry.go
@@ -151,7 +151,7 @@ func loadOIDC() error {
 	}
 
 	// load OIDC.ClientSecret
-	OIDCClientSecretFile := viper.GetString("OIDCClientSecretFile")
+	OIDCClientSecretFile := viper.GetString("OIDC.ClientSecretFile")
 	OIDCClientSecretFromEnv := viper.GetString("OIDCCLIENTSECRET")
 	if OIDCClientSecretFile != "" {
 		contents, err := os.ReadFile(OIDCClientSecretFile)


### PR DESCRIPTION
Also going to bypass restrictions on this one. A few of the configuration variables were named without taking into account nesting, and this was causing problems in the namespace registry deployment when registering with identity.