### PR TITLE
Add default port to supervisord daemons

### DIFF
--- a/images/supervisord/pelican_director_serve.conf
+++ b/images/supervisord/pelican_director_serve.conf
@@ -19,3 +19,5 @@ command=/pelican/osdf-client director serve -p %(ENV_OSDF_DIRECTOR_PORT)s
 autostart=false
 autorestart=true
 redirect_stderr=true
+# set up a default port, assuming (for now) the director and registry won't be run at once.
+environment=ENV_OSDF_DIRECTOR_PORT=8443

--- a/images/supervisord/pelican_registry_serve.conf
+++ b/images/supervisord/pelican_registry_serve.conf
@@ -19,3 +19,5 @@ command=/pelican/osdf-client registry serve -p %(ENV_OSDF_REGISTRY_PORT)s
 autostart=false
 autorestart=true
 redirect_stderr=true
+# set up a default port, assuming (for now) the director and registry won't be run at once.
+environment=ENV_OSDF_REGISTRY_PORT=8443


### PR DESCRIPTION
Another review bypass. The deployments for the registry/director don't seem to like not having ports defined for the registry/director daemons, even if they aren't initialized with `supervisorctl start`