### PR TITLE
Remove redundant env prefix

### DIFF
--- a/images/supervisord/pelican_director_serve.conf
+++ b/images/supervisord/pelican_director_serve.conf
@@ -20,4 +20,4 @@ autostart=false
 autorestart=true
 redirect_stderr=true
 # set up a default port, assuming (for now) the director and registry won't be run at once.
-environment=ENV_OSDF_DIRECTOR_PORT=8443
+environment=OSDF_DIRECTOR_PORT=8443

--- a/images/supervisord/pelican_registry_serve.conf
+++ b/images/supervisord/pelican_registry_serve.conf
@@ -20,4 +20,4 @@ autostart=false
 autorestart=true
 redirect_stderr=true
 # set up a default port, assuming (for now) the director and registry won't be run at once.
-environment=ENV_OSDF_REGISTRY_PORT=8443
+environment=OSDF_REGISTRY_PORT=8443


### PR DESCRIPTION
Wasn't sure from the docs whether I needed the `env` prefix here, and I guessed wrong the first time. 