### PR TITLE
Fix bug with common transport TLSSkipVerify

### DIFF
--- a/handle_http.go
+++ b/handle_http.go
@@ -474,10 +474,10 @@ func setupTransport() *http.Transport {
 func getTransport() *http.Transport {
 	onceTransport.Do(func() {
 		transport = setupTransport()
-		if viper.GetBool("TLSSkipVerify") {
-			transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-		}
 	})
+	if viper.GetBool("TLSSkipVerify") {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
 	return transport
 }
 


### PR DESCRIPTION
I found a bug with setting up TLSSkipVerify from the common transports. Looks like I put checking for that within the creation of the transport that only happens once. Therefore, if the transport is created, then it will never check again if TLSSkipVerify is set. From running my own tests by hand it seems to be working now.