### PR TITLE
Send token and namespace ad to director

### DIFF
--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -20,7 +20,9 @@ package director
 
 import (
 	"context"
-	"errors"
+	"crypto/tls"
+	"encoding/json"
+	"net/http"
 	"net/url"
 	"path"
 	"strings"
@@ -32,6 +34,8 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -49,11 +53,10 @@ var (
 )
 
 func CreateAdvertiseToken(namespace string) (string, error) {
-	key, err := config.GetOriginJWK()
-	if err != nil {
-		return "", err
-	}
-	issuer_url, err := GetIssuerURL(namespace)
+	// TODO: Need to come back and carefully consider a few naming practices.
+	//       Here, issuerUrl is actually the registry database url, and not
+	//       the token issuer url for this namespace
+	issuerUrl, err := GetIssuerURL(namespace)
 	if err != nil {
 		return "", err
 	}
@@ -64,7 +67,7 @@ func CreateAdvertiseToken(namespace string) (string, error) {
 
 	tok, err := jwt.NewBuilder().
 		Claim("scope", "pelican.advertise").
-		Issuer(issuer_url).
+		Issuer(issuerUrl).
 		Audience([]string{director}).
 		Subject("origin").
 		Expiration(time.Now().Add(time.Minute)).
@@ -73,7 +76,20 @@ func CreateAdvertiseToken(namespace string) (string, error) {
 		return "", err
 	}
 
-	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES512, key))
+	key, err := config.GetOriginJWK()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to load the origin's JWK")
+	}
+
+	// Get/assign the kid, needed for verification of the token by the director
+	// TODO: Create more generic "tokenCreate" functions so we don't have to do
+	//       this by hand all the time
+	err = jwk.AssignKeyID(*key)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to assign kid to the token")
+	}
+
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES512, *key))
 	if err != nil {
 		return "", err
 	}
@@ -84,7 +100,7 @@ func CreateAdvertiseToken(namespace string) (string, error) {
 // see if the entity is authorized to advertise an origin for the
 // namespace
 func VerifyAdvertiseToken(token, namespace string) (bool, error) {
-	issuer_url, err := GetIssuerURL(namespace)
+	issuerUrl, err := GetIssuerURL(namespace)
 	if err != nil {
 		return false, err
 	}
@@ -105,14 +121,33 @@ func VerifyAdvertiseToken(token, namespace string) (bool, error) {
 	ctx := context.Background()
 	if ar == nil {
 		ar = jwk.NewCache(ctx)
-		if err = ar.Register(issuer_url, jwk.WithMinRefreshInterval(15*time.Minute)); err != nil {
+		// This should be switched to use the common transport, but that must first be exported
+		client := &http.Client{}
+		if viper.GetBool("TLSSkipVerify") {
+			tr := &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			}
+			client = &http.Client{Transport: tr}
+		}
+		if err = ar.Register(issuerUrl, jwk.WithMinRefreshInterval(15*time.Minute), jwk.WithHTTPClient(client)); err != nil {
 			return false, err
 		}
 		namespaceKeysMutex.Lock()
 		defer namespaceKeysMutex.Unlock()
 		namespaceKeys.Set(namespace, ar, ttlcache.DefaultTTL)
 	}
-	keyset, err := ar.Get(ctx, issuer_url)
+	log.Debugln("Attempting to fetch keys from ", issuerUrl)
+	keyset, err := ar.Get(ctx, issuerUrl)
+
+	if log.IsLevelEnabled(log.DebugLevel) {
+		// Let's check that we can convert to JSON and get the right thing...
+		jsonbuf, err := json.Marshal(keyset)
+		if err != nil {
+			return false, errors.Wrap(err, "failed to marshal the public keyset into JWKS JSON")
+		}
+		log.Debugln("Constructed JWKS from fetching jwks:", string(jsonbuf))
+	}
+
 	if err != nil {
 		return false, err
 	}
@@ -150,6 +185,6 @@ func GetIssuerURL(prefix string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	namespace_url.Path = path.Join(namespace_url.Path, "namespaces", prefix)
+	namespace_url.Path = path.Join(namespace_url.Path, "api", "v1.0", "registry", prefix, ".well-known", "issuer.jwks")
 	return namespace_url.String(), nil
 }

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -108,7 +108,7 @@ func VerifyAdvertiseToken(token, namespace string) (bool, error) {
 
 	// defer statements are scoped to function, not lexical enclosure,
 	// which is why we wrap these defer statements in anon funcs
-	func () {
+	func() {
 		namespaceKeysMutex.RLock()
 		defer namespaceKeysMutex.RUnlock()
 		item := namespaceKeys.Get(namespace)

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -229,7 +229,9 @@ func RegisterOrigin(ctx *gin.Context) {
 	}
 
 	for _, namespace := range ad.Namespaces {
-		ok, err := VerifyAdvertiseToken(tokens[0], namespace.Path)
+		// We're assuming there's only one token in the slice
+		token := strings.TrimPrefix(tokens[0], "Bearer ")
+		ok, err := VerifyAdvertiseToken(token, namespace.Path)
 		if err != nil {
 			log.Warningln("Failed to verify token:", err)
 			ctx.JSON(400, gin.H{"error": "Authorization token verification failed"})

--- a/namespace-registry/registry-db.go
+++ b/namespace-registry/registry-db.go
@@ -82,7 +82,7 @@ func namespaceExists(prefix string) (bool, error) {
 	return found, nil
 }
 
-func getPrefixJwks(prefix string) (*jwk.Set, error) {
+func dbGetPrefixJwks(prefix string) (*jwk.Set, error) {
 	jwksQuery := `SELECT pubkey FROM namespace WHERE prefix = ?`
 	var pubkeyStr string
 	err := db.QueryRow(jwksQuery, prefix).Scan(&pubkeyStr)

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -78,13 +78,12 @@ func AdvertiseOrigin() error {
 		Path:          prefix,
 		Issuer:        *namespaceUrl,
 		MaxScopeDepth: 3,
-		Strategy:     "OAuth2",
+		Strategy:      "OAuth2",
 		BasePath:      "/",
 	}
 	ad := director.OriginAdvertise{
 		Name:       name,
 		URL:        originUrl,
-		// Namespaces: make([]director.NamespaceAd, 0),
 		Namespaces: []director.NamespaceAd{nsAd},
 	}
 
@@ -104,6 +103,9 @@ func AdvertiseOrigin() error {
 	directorUrl.Path = "/api/v1.0/director/registerOrigin"
 
 	token, err := director.CreateAdvertiseToken(prefix)
+	if err != nil {
+		return errors.Wrap(err, "Failed to generate advertise token")
+	}
 	log.Debugln("Signed advertise token:", token)
 
 	req, err := http.NewRequest("POST", directorUrl.String(), bytes.NewBuffer(body))
@@ -112,8 +114,10 @@ func AdvertiseOrigin() error {
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer " + token)
+	req.Header.Set("Authorization", "Bearer "+token)
 
+	// We should switch this over to use the common transport, but for that to happen
+	// that function needs to be exported from pelican
 	client := http.Client{}
 	if viper.GetBool("TLSSkipVerify") {
 		tr := &http.Transport{

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -54,8 +54,6 @@ func PeriodicAdvertiseOrigin() error {
 
 func AdvertiseOrigin() error {
 	name := viper.GetString("Sitename")
-
-	fmt.Printf("\n\n\nORIGIN SITENAME: %s\n\n\n", name)
 	if name == "" {
 		return errors.New("Origin name isn't set")
 	}

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -74,7 +74,7 @@ func AdvertiseOrigin() error {
 	// TODO: Need to figure out where to get some of these values
 	// 		 so that they aren't hardcoded...
 	nsAd := director.NamespaceAd{
-		RequireToken:  false,
+		RequireToken:  true,
 		Path:          prefix,
 		Issuer:        *namespaceUrl,
 		MaxScopeDepth: 3,


### PR DESCRIPTION
I'm leaving this in draft mode for the moment because I haven't gotten through the whole process yet, and I suspect there are still bugs.

The part I'm getting stuck on is in `director/origin_api.go`, line 115 in my changed files where we do `ar.Get(ctx, issuer_url)`. It looks like under the hood, `ar.Get` instantiates an `http.Client` and tries to get the `issuer.jwks` from the `issuer_url`. Of course, testing locally I don't have a valid TLS setup, and I can't figure out how to bypass that issue through the jwk library because the x509 certificate is obviously not signed by a known authority.

Otherwise, a few bugs I think I've nailed out:

1. The origin now sends a token to the director for verification (before no token was sent)
2. There were issues with the ttlcache mutex in `director/origin_api.go`, both in terms of the types of lock being set and an improperly scoped `defer` statement.
3. The origin now sends a slice of namespace ads to the director, with its own namespace ad as the only item. This should be reviewed because I'm hard coding things in the ad like "RequireToken", "MaxScopeDepth", "Strategy", and "BasePath". Currently I'm unsure of where these variables should be coming from or whether there are config variables that can be obtained through viper