### PR TITLE
Remove hardcoded originUrl

### DIFF
--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -57,13 +57,16 @@ func AdvertiseOrigin() error {
 	if name == "" {
 		return errors.New("Origin name isn't set")
 	}
+
 	// TODO: waiting on a different branch to merge origin URL generation
-	originUrl := "https://localhost:8444"
+	// The checkdefaults func that runs before the origin is served checks for and
+	// parses the originUrl, so it should be safe to just grab it as a string here.
+	originUrl := viper.GetString("OriginUrl")
 
 	// Here we instantiate the namespaceAd slice, but we still need to define the namespace
 	namespaceUrl, err := url.Parse(viper.GetString("NamespaceUrl"))
 	if err != nil {
-		return errors.New("Bad namespaceUrl")
+		return errors.Wrap(err, "Bad NamespaceUrl")
 	}
 	if namespaceUrl.String() == "" {
 		return errors.New("No NamespaceUrl is set")


### PR DESCRIPTION
This commit removes the hardcoded origin url and instead makes the value configurable via the pelican config file. Specifying an origin url is required to serve an origin, and the command `pelican origin serve` will fail unless the value is set. It will also fail if the configured origin url specifies a port that doesn't match the port passed via the `-p` flag.

Closes #123 