### PR TITLE
Switched over remaining usage of http.Client to use common transport

### DIFF
--- a/director.go
+++ b/director.go
@@ -121,7 +121,7 @@ func QueryDirector(source string, directorUrl string) (resp *http.Response, err 
 	// redirect. We use the Location url elsewhere (plus we still need to do the token
 	// dance!)
 	var client *http.Client
-	tr := getTransport()
+	tr := GetTransport()
 	client = &http.Client{
 		Transport: tr,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {

--- a/handle_http.go
+++ b/handle_http.go
@@ -471,7 +471,7 @@ func setupTransport() *http.Transport {
 }
 
 // function to get/setup the transport (only once)
-func getTransport() *http.Transport {
+func GetTransport() *http.Transport {
 	onceTransport.Do(func() {
 		transport = setupTransport()
 	})
@@ -486,7 +486,7 @@ func DownloadHTTP(transfer TransferDetails, dest string, token string) (int64, e
 
 	// Create the client, request, and context
 	client := grab.NewClient()
-	transport := getTransport()
+	transport := GetTransport()
 	if !transfer.Proxy {
 		transport.Proxy = nil
 	}
@@ -829,7 +829,7 @@ Loop:
 
 }
 
-var UploadClient = &http.Client{Transport: getTransport()}
+var UploadClient = &http.Client{Transport: GetTransport()}
 
 // Actually perform the Put request to the server
 func doPut(request *http.Request, responseChan chan<- *http.Response, errorChan chan<- error) {
@@ -930,7 +930,7 @@ func walkDavDir(url *url.URL, token string, namespace namespaces.Namespace) ([]s
 	c := gowebdav.NewClient(rootUrl.String(), "", "")
 
 	// XRootD does not like keep alives and kills things, so turn them off.
-	transport = getTransport()
+	transport = GetTransport()
 	c.SetTransport(transport)
 
 	files, err := walkDir(url.Path, c)
@@ -982,7 +982,7 @@ func StatHttp(dest *url.URL, namespace namespaces.Namespace) (uint64, error) {
 
 	var resp *http.Response
 	for {
-		transport := getTransport()
+		transport := GetTransport()
 		if disableProxy {
 			log.Debugln("Performing HEAD (without proxy)", dest.String())
 			transport.Proxy = nil

--- a/namespace-registry/client_commands.go
+++ b/namespace-registry/client_commands.go
@@ -63,9 +63,8 @@ func makeRequest(url string, method string, data map[string]interface{}, headers
 		req.Header.Set(key, val)
 	}
 
-	client := &http.Client{}
 	tr := pelican.GetTransport()
-	client = &http.Client{Transport: tr}
+	client := &http.Client{Transport: tr}
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/namespace-registry/client_commands.go
+++ b/namespace-registry/client_commands.go
@@ -19,8 +19,6 @@
 package nsregistry
 
 import (
-	"crypto/tls"
-
 	"github.com/pkg/errors"
 
 	"bufio"
@@ -36,10 +34,10 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/pelicanplatform/pelican"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/director"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 type clientResponseData struct {
@@ -66,12 +64,9 @@ func makeRequest(url string, method string, data map[string]interface{}, headers
 	}
 
 	client := &http.Client{}
-	if viper.GetBool("TLSSkipVerify") {
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-		client = &http.Client{Transport: tr}
-	}
+	tr := pelican.GetTransport()
+	client = &http.Client{Transport: tr}
+
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -20,13 +20,13 @@ package origin_ui
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"time"
 
+	"github.com/pelicanplatform/pelican"
 	"github.com/pelicanplatform/pelican/director"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -122,12 +122,9 @@ func AdvertiseOrigin() error {
 	// We should switch this over to use the common transport, but for that to happen
 	// that function needs to be exported from pelican
 	client := http.Client{}
-	if viper.GetBool("TLSSkipVerify") {
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-		client = http.Client{Transport: tr}
-	}
+	tr := pelican.GetTransport()
+	client = http.Client{Transport: tr}
+
 	resp, err := client.Do(req)
 	if err != nil {
 		return errors.Wrap(err, "Failed to start request for director registration")

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -121,9 +121,8 @@ func AdvertiseOrigin() error {
 
 	// We should switch this over to use the common transport, but for that to happen
 	// that function needs to be exported from pelican
-	client := http.Client{}
 	tr := pelican.GetTransport()
-	client = http.Client{Transport: tr}
+	client := http.Client{Transport: tr}
 
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
There were a few spots in newer code looking for the TLSSkipVerify on its own. Changed them over to use the common GetTransport function. I also had to rename the function to be capital letters since that's how Go reads functions from other packages.