### PR TITLE
Bump linter timeout to 3m

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,7 +2,7 @@
 run:
   # Pelican has gotten large enough that the GitHub Action sometimes
   # times out on a cold cache
-  timeout: 2m
+  timeout: 3m
 
 linters:
   enable:


### PR DESCRIPTION
After timeouts at 2m, we're going to try bumping the linter timeout to 3m

Fixes issue #136 