### PR TITLE
Match ns prefix by longest match, not first match

### DIFF
--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -133,7 +133,7 @@ func matchesPrefix(reqPath string, namespaceAds []NamespaceAd) *NamespaceAd {
 			}
 		}
 
-		// Make the len comparison with tmpBest, becasue serverPath is one char longer now
+		// Make the len comparison with tmpBest, because serverPath is one char longer now
 		if strings.HasPrefix(reqPath, serverPath) && len(serverPath) > len(tmpBest) {
 			if best == nil {
 				best = new(NamespaceAd)

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -163,8 +163,7 @@ func GetAdsForPath(reqPath string) (originNamespace NamespaceAd, originAds []Ser
 		}
 		serverAd := item.Key()
 		if serverAd.Type == OriginType {
-			ns := matchesPrefix(reqPath, item.Value())
-			if ns != nil {
+			if ns := matchesPrefix(reqPath, item.Value()); ns != nil {
 				if best == nil || len(ns.Path) > len(best.Path) {
 					best = ns
 					// If anything was previously set by a namespace that constituted a shorter

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -1,0 +1,171 @@
+/***************************************************************
+ *
+ * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package director
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func hasServerAdWithName(serverAds []ServerAd, name string) bool {
+	for _, serverAd := range serverAds {
+		if serverAd.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// Test getAdsForPath to make sure various nuanced cases work. Under the hood
+// this really tests matchesPrefix, but we test this higher level function to
+// avoid having to mess with the cache.
+func TestGetAdsForPath(t *testing.T) {
+	/*
+		FLOW:
+			- Set up a few dummy namespaces, origin, and cache ads
+			- Record the ads
+			- Query for a few paths and make sure the correct ads are returned
+	*/
+	nsAd1 := NamespaceAd{
+		RequireToken: true,
+		Path:         "/chtc",
+		Issuer: url.URL{
+			Scheme: "https",
+			Host:   "wisc.edu",
+		},
+	}
+
+	nsAd2 := NamespaceAd{
+		RequireToken: false,
+		Path:         "/chtc/PUBLIC",
+		Issuer: url.URL{
+			Scheme: "https",
+			Host:   "wisc.edu",
+		},
+	}
+
+	nsAd3 := NamespaceAd{
+		RequireToken: false,
+		Path:         "/chtc/PUBLIC2/",
+		Issuer: url.URL{
+			Scheme: "https",
+			Host:   "wisc.edu",
+		},
+	}
+
+	cacheAd1 := ServerAd{
+		Name: "cache1",
+		AuthURL: url.URL{
+			Scheme: "https",
+			Host:   "wisc.edu",
+		},
+		URL: url.URL{
+			Scheme: "https",
+			Host:   "wisc.edu",
+		},
+		Type: CacheType,
+	}
+
+	cacheAd2 := ServerAd{
+		Name: "cache2",
+		AuthURL: url.URL{
+			Scheme: "https",
+			Host:   "wisc.edu",
+		},
+		URL: url.URL{
+			Scheme: "https",
+			Host:   "wisc.edu",
+		},
+		Type: CacheType,
+	}
+
+	originAd1 := ServerAd{
+		Name: "origin1",
+		AuthURL: url.URL{
+			Scheme: "https",
+			Host:   "wisc.edu",
+		},
+		URL: url.URL{
+			Scheme: "https",
+			Host:   "wisc.edu",
+		},
+		Type: OriginType,
+	}
+
+	originAd2 := ServerAd{
+		Name: "origin2",
+		AuthURL: url.URL{
+			Scheme: "https",
+			Host:   "wisc.edu",
+		},
+		URL: url.URL{
+			Scheme: "https",
+			Host:   "wisc.edu",
+		},
+		Type: OriginType,
+	}
+
+	o1Slice := []NamespaceAd{nsAd1}
+	o2Slice := []NamespaceAd{nsAd2, nsAd3}
+	c1Slice := []NamespaceAd{nsAd1, nsAd2}
+	RecordAd(originAd2, &o2Slice)
+	RecordAd(originAd1, &o1Slice)
+	RecordAd(cacheAd1, &c1Slice)
+	RecordAd(cacheAd2, &o1Slice)
+
+	nsAd, oAds, cAds := GetAdsForPath("/chtc")
+	assert.Equal(t, nsAd.Path, "/chtc")
+	assert.Equal(t, len(oAds), 1)
+	assert.Equal(t, len(cAds), 2)
+	assert.True(t, hasServerAdWithName(oAds, "origin1"))
+	assert.True(t, hasServerAdWithName(cAds, "cache1"))
+	assert.True(t, hasServerAdWithName(cAds, "cache2"))
+
+	nsAd, oAds, cAds = GetAdsForPath("/chtc/")
+	assert.Equal(t, nsAd.Path, "/chtc")
+	assert.Equal(t, len(oAds), 1)
+	assert.Equal(t, len(cAds), 2)
+	assert.True(t, hasServerAdWithName(oAds, "origin1"))
+	assert.True(t, hasServerAdWithName(cAds, "cache1"))
+	assert.True(t, hasServerAdWithName(cAds, "cache2"))
+
+	nsAd, oAds, cAds = GetAdsForPath("/chtc/PUBLI")
+	assert.Equal(t, nsAd.Path, "/chtc")
+	assert.Equal(t, len(oAds), 1)
+	assert.Equal(t, len(cAds), 2)
+	assert.True(t, hasServerAdWithName(oAds, "origin1"))
+	assert.True(t, hasServerAdWithName(cAds, "cache1"))
+	assert.True(t, hasServerAdWithName(cAds, "cache2"))
+
+	nsAd, oAds, cAds = GetAdsForPath("/chtc/PUBLIC")
+	assert.Equal(t, nsAd.Path, "/chtc/PUBLIC")
+	assert.Equal(t, len(oAds), 1)
+	assert.Equal(t, len(cAds), 1)
+	assert.True(t, hasServerAdWithName(oAds, "origin2"))
+	assert.True(t, hasServerAdWithName(cAds, "cache1"))
+
+	nsAd, oAds, cAds = GetAdsForPath("/chtc/PUBLIC2")
+	// since the stored path is actually /chtc/PUBLIC2/, the extra / is returned
+	assert.Equal(t, nsAd.Path, "/chtc/PUBLIC2/")
+	assert.Equal(t, len(oAds), 1)
+	assert.Equal(t, len(cAds), 0)
+	assert.True(t, hasServerAdWithName(oAds, "origin2"))
+}


### PR DESCRIPTION
Previously, when two namespaces like /chtc and /chtc/PUBLIC existed in the cache, the matchPrefix function wound up matching whichever happened to be read first. Now it matches against the longest prefix, so a request for path /chtc/PUBLIC/foo/bar will always match /chtc/PUBLIC.

Closes issue #140