### PR TITLE
Incorporate PR #78 from old osdf-client

### DIFF
--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -210,7 +210,7 @@ func copyMain(cmd *cobra.Command, args []string) {
 		if errMsg == "" {
 			errMsg = result.Error()
 		}
-		log.Errorln("Failure downloading " + lastSrc + ": " + errMsg)
+		log.Errorln("Failure transferring " + lastSrc + ": " + errMsg)
 		if pelican.ErrorsRetryable() {
 			log.Errorln("Errors are retryable")
 			os.Exit(11)

--- a/errorAccum.go
+++ b/errorAccum.go
@@ -112,6 +112,18 @@ func IsRetryable(err error) bool {
 		}
 		return true
 	}
+	var hep *HttpErrResp
+	if errors.As(err, &hep) {
+		switch int(hep.Code) {
+		case http.StatusInternalServerError:
+		case http.StatusBadGateway:
+		case http.StatusServiceUnavailable:
+		case http.StatusGatewayTimeout:
+			return true
+		default:
+			return false
+		}
+	}
 	return false
 }
 

--- a/handle_http.go
+++ b/handle_http.go
@@ -689,7 +689,8 @@ Loop:
 	// prior attempt.
 	if resp.HTTPResponse.StatusCode != 200 && resp.HTTPResponse.StatusCode != 206 {
 		log.Debugln("Got failure status code:", resp.HTTPResponse.StatusCode)
-		return 0, errors.New("failure status code")
+		return 0, &HttpErrResp{resp.HTTPResponse.StatusCode, fmt.Sprintf("Request failed (HTTP status %d): %s",
+			resp.HTTPResponse.StatusCode, resp.Err().Error())}
 	}
 	log.Debugln("HTTP Transfer was successful")
 	return resp.BytesComplete(), nil
@@ -808,7 +809,8 @@ Loop:
 		case response := <-responseChan:
 			if response.StatusCode != 200 {
 				log.Errorln("Got failure status code:", response.StatusCode)
-				lastError = errors.New("failure status code")
+				lastError = &HttpErrResp{response.StatusCode, fmt.Sprintf("Request failed (HTTP status %d)",
+					response.StatusCode)}
 				break Loop
 			}
 			break Loop

--- a/main.go
+++ b/main.go
@@ -445,8 +445,12 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 		ns, err := namespaces.MatchNamespace(dest_url.Path)
 		if err != nil {
 			log.Errorln("Failed to get namespace information:", err)
+			AddError(err)
+			return 0, err
 		}
-		return doWriteBack(source_url.Path, dest_url, ns)
+		_, err = doWriteBack(source_url.Path, dest_url, ns)
+		AddError(err)
+		return 0, err
 	}
 
 	if dest_url.Scheme == "file" {


### PR DESCRIPTION
This PR brings to Pelican a floating PR from the old OSDF client. Its intention is to improve reporting of error messages.

Closes issue #125 