### PR TITLE
Revive codeql

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '36 11 * * 6'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'v[0-9].[0-9].*' ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [ main, 'v[0-9].[0-9].*' ]
   schedule:
     - cron: '36 11 * * 6'
 


### PR DESCRIPTION
The CodeQL GHA previously ran in the `osdf-client` repo, and this PR gets it running in Pelican. The only fundamental change is that I've also set up CodeQL to run on release branches, eg v7.0.x.

Closes issue #84 