### PR TITLE
Fix federation auto-discovery bug

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -139,7 +139,7 @@ func DiscoverFederation() error {
 	}
 	log.Debugln("Federation URL:", federationStr)
 	curDirectorURL := viper.GetString("DirectorURL")
-	curNamespaceURL := viper.GetString("DirectorURL")
+	curNamespaceURL := viper.GetString("NamespaceURL")
 	if len(curDirectorURL) != 0 && len(curNamespaceURL) != 0 {
 		return nil
 	}


### PR DESCRIPTION
That I'm aware of, nobody has encountered this bug yet. I just happened to notice it when reading through the file. I'm 99% sure the previous code was incorrect and would result in autodiscovery not being run if only the "DirectorUrl" was set, resulting in no valid NamespaceUrl.