### PR TITLE
Put prometheus metrics behind federation/origin token

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -204,6 +204,8 @@ func DiscoverFederation() error {
 		viper.Set("NamespaceURL", metadata.NamespaceRegistrationEndpoint)
 	}
 
+	viper.Set("FederationURI", metadata.JwksUri)
+
 	return nil
 }
 

--- a/director/redirect_test.go
+++ b/director/redirect_test.go
@@ -183,7 +183,7 @@ func TestDirectorRegistration(t *testing.T) {
 	rInv.POST("/", RegisterOrigin)
 	cInv.Request, _ = http.NewRequest(http.MethodPost, "/", bytes.NewBuffer([]byte(`{"Namespaces": [{"Path": "/foo/bar", "URL": "https://get-your-tokens.org"}]}`)))
 
-	cInv.Request.Header.Set("Authorization", string(signedInv))
+	cInv.Request.Header.Set("Authorization", "Bearer "+string(signedInv))
 	cInv.Request.Header.Set("Content-Type", "application/json")
 
 	rInv.ServeHTTP(wInv, cInv.Request)

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -17,6 +17,7 @@ package web_ui
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"errors"
 	"fmt"
 	"math"
@@ -35,6 +36,8 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/regexp"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/mwitkow/go-conntrack"
 	"github.com/oklog/run"
 	pelican_config "github.com/pelicanplatform/pelican/config"
@@ -136,6 +139,51 @@ func (h *ReadyHandler) testReady(f http.HandlerFunc) http.HandlerFunc {
 
 func runtimeInfo() (api_v1.RuntimeInfo, error) {
 	return api_v1.RuntimeInfo{}, nil
+}
+
+func checkPromToken(av1 *route.Router) gin.HandlerFunc {
+	/* A function which wraps around the av1 router to force a jwk token check using
+	 * the origin's private key. It will check the request's URL and Header for a token
+	 * and if found it will then attempt to validate the token. If valid, it will continue
+	 * the routing as normal, otherwise it will return an error"
+	 */
+	return func(c *gin.Context) {
+		req := c.Request
+		var token string
+		if authzQuery := req.URL.Query()["authz"]; len(authzQuery) > 0 {
+			token = authzQuery[0]
+		} else if authzHeader := req.Header["Authorization"]; len(authzHeader) > 0 {
+			token = strings.TrimPrefix(authzHeader[0], "Bearer ")
+		} else {
+			c.JSON(403, gin.H{"error": "Permission Denied: Missing token"})
+		}
+
+		privKey, err := pelican_config.GetOriginJWK()
+		if err != nil {
+			c.JSON(400, gin.H{"error": "Failed to retrieve private key"})
+			return
+		}
+
+		var raw ecdsa.PrivateKey
+		if err = (*privKey).Raw(&raw); err != nil {
+			c.JSON(400, gin.H{"error": "Failed to extract signing key"})
+			return
+		}
+
+		if err != nil {
+			c.JSON(400, gin.H{"error": "Private Key Retrieval Failed"})
+			return
+		}
+
+		_, err = jwt.Parse([]byte(token), jwt.WithKey(jwa.ES512, raw.PublicKey), jwt.WithValidate(true))
+
+		if err != nil {
+			c.JSON(403, gin.H{"error": "Permission Denied: Invalid token"})
+			return
+		}
+
+		av1.ServeHTTP(c.Writer, c.Request)
+	}
 }
 
 func ConfigureEmbeddedPrometheus(engine *gin.Engine) error {
@@ -341,7 +389,7 @@ func ConfigureEmbeddedPrometheus(engine *gin.Engine) error {
 	//WithInstrumentation(setPathWithPrefix("/api/v1"))
 	apiV1.Register(av1)
 
-	engine.GET("/api/v1.0/prometheus/*any", gin.WrapH(av1))
+	engine.GET("/api/v1.0/prometheus/*any", checkPromToken(av1))
 
 	reloaders := []reloader{
 		{

--- a/web_ui/prometheus_test.go
+++ b/web_ui/prometheus_test.go
@@ -1,0 +1,183 @@
+package web_ui
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/prometheus/common/route"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrometheusProtection(t *testing.T) {
+
+	/*
+	* Tests that prometheus metrics are behind the origin's token. Specifically it signs a token
+	* with the origin's keyand invokes a prometheus GET endpoint with both URL and Header authorization,
+	* it then does so again with an invalid token and confirms that the correct error is returned
+	 */
+
+	// Setup httptest recorder and context for the the unit test
+	viper.Reset()
+
+	av1 := route.New().WithPrefix("/api/v1.0/prometheus")
+
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "GET", req.Method, "Not GET Method")
+		_, err := w.Write([]byte(":)"))
+		assert.NoError(t, err)
+	}))
+	defer ts.Close()
+	c.Request = &http.Request{
+		URL: &url.URL{},
+	}
+
+	// Create temp dir for the origin key file
+	tDir := t.TempDir()
+	kfile := filepath.Join(tDir, "testKey")
+
+	//Setup a private key and a token
+	viper.Set("IssuerKey", kfile)
+
+	viper.Set("NamespaceURL", "https://get-your-tokens.org")
+	viper.Set("DirectorURL", "https://director-url.org")
+
+	// Generate the origin private and public keys
+	_, err := config.LoadPublicKey("", kfile)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privKey, err := config.LoadPrivateKey(kfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a token
+	issuerURL := url.URL{}
+	issuerURL.Scheme = "https"
+	issuerURL.Host = "test-host"
+	now := time.Now()
+	tok, err := jwt.NewBuilder().
+		Issuer(issuerURL.String()).
+		IssuedAt(now).
+		Expiration(now.Add(30 * time.Minute)).
+		NotBefore(now).
+		Build()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sign the token with the origin private key
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES512, privKey))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set the request to run through the checkPromToken function
+	r.GET("/api/v1.0/prometheus/*any", checkPromToken(av1))
+	c.Request, _ = http.NewRequest(http.MethodGet, "/api/v1.0/prometheus/test", bytes.NewBuffer([]byte(`{}`)))
+
+	// Puts the token within the URL
+	new_query := c.Request.URL.Query()
+	new_query.Add("authz", string(signed))
+	c.Request.URL.RawQuery = new_query.Encode()
+
+	r.ServeHTTP(w, c.Request)
+
+	// Check to see that the code exits with status code 404 after giving it a good token
+	assert.Equal(t, 404, w.Result().StatusCode, "Expected status code of 404 representing failure due to minimal server setup, not token check")
+
+	// Create a new Recorder and Context for the next HTTPtest call
+	wH := httptest.NewRecorder()
+	cH, rH := gin.CreateTestContext(wH)
+	tsH := httptest.NewServer(http.HandlerFunc(func(wH http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "GET", req.Method, "Not GET Method")
+		_, err := wH.Write([]byte(":)"))
+		assert.NoError(t, err)
+	}))
+	defer tsH.Close()
+
+	// Set the request to go through the checkPromToken function
+	rH.GET("/api/v1.0/prometheus/*any", checkPromToken(av1))
+	cH.Request, _ = http.NewRequest(http.MethodGet, "/api/v1.0/prometheus/test", bytes.NewBuffer([]byte(`{}`)))
+
+	// Put the signed token within the header
+	cH.Request.Header.Set("Authorization", "Bearer "+string(signed))
+	cH.Request.Header.Set("Content-Type", "application/json")
+
+	rH.ServeHTTP(wH, cH.Request)
+	// Check to see that the code exits with status code 404 after given it a good token
+	assert.Equal(t, 404, wH.Result().StatusCode, "Expected status code of 404 representing failure due to minimal server setup, not token check")
+
+	// Create a new Recorder and Context for testing an invalid token
+	wI := httptest.NewRecorder()
+	cI, rI := gin.CreateTestContext(wI)
+	tsI := httptest.NewServer(http.HandlerFunc(func(wI http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "GET", req.Method, "Not GET Method")
+		_, err := wI.Write([]byte(":)"))
+		assert.NoError(t, err)
+	}))
+	defer tsI.Close()
+	c.Request = &http.Request{
+		URL: &url.URL{},
+	}
+
+	// Create a private key to use for the test
+	privateKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	assert.NoError(t, err, "Error generating private key")
+
+	// Convert from raw ecdsa to jwk.Key
+	pKey, err := jwk.FromRaw(privateKey)
+	assert.NoError(t, err, "Unable to convert ecdsa.PrivateKey to jwk.Key")
+
+	//Assign Key id to the private key
+	err = jwk.AssignKeyID(pKey)
+	assert.NoError(t, err, "Error assigning kid to private key")
+
+	//Set an algorithm for the key
+	err = pKey.Set(jwk.AlgorithmKey, jwa.ES512)
+	assert.NoError(t, err, "Unable to set algorithm for pKey")
+
+	// Create a new token to be used
+	tok, err = jwt.NewBuilder().
+		Issuer(issuerURL.String()).
+		IssuedAt(now).
+		Expiration(now.Add(30 * time.Minute)).
+		NotBefore(now).
+		Build()
+
+	assert.NoError(t, err, "Error creating token")
+
+	// Sign token with private key (not the origin)
+	signed, err = jwt.Sign(tok, jwt.WithKey(jwa.ES512, pKey))
+	assert.NoError(t, err, "Error signing token")
+
+	rI.GET("/api/v1.0/prometheus/*any", checkPromToken(av1))
+	cI.Request, _ = http.NewRequest(http.MethodGet, "/api/v1.0/prometheus/test", bytes.NewBuffer([]byte(`{}`)))
+
+	cI.Request.Header.Set("Authorization", "Bearer "+string(signed))
+	cI.Request.Header.Set("Content-Type", "application/json")
+
+	rI.ServeHTTP(wI, cI.Request)
+	// Assert that it gets the correct Permission Denied 403 code
+	assert.Equal(t, 403, wI.Result().StatusCode, "Expected failing status code of 403: Permission Denied")
+}

--- a/web_ui/prometheus_test.go
+++ b/web_ui/prometheus_test.go
@@ -5,6 +5,8 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -23,20 +25,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPrometheusProtection(t *testing.T) {
+func TestPrometheusProtectionFederationURL(t *testing.T) {
 
 	/*
-	* Tests that prometheus metrics are behind the origin's and federation's token. Specifically it signs a token
-	* with the origin's key and invokes a prometheus GET endpoint with both URL and Header authorization, with the
-	* URL authorization, it mimics matching the Federation URL to ensure that check is done, but intercepts with
-	* returning the origin jwk for testing purposes.
-	* This then does so again with an invalid token and confirms that the correct error is returned
+	* Tests that prometheus metrics are behind federation's token. Specifically it signs a token
+	* with the a generated key o prometheus GET endpoint with both URL. It mimics matching the Federation URL
+	* to ensure that check is done, but intercepts with returning a generated jwk for testing purposes
 	 */
 
 	// Setup httptest recorder and context for the the unit test
 	viper.Reset()
 
 	av1 := route.New().WithPrefix("/api/v1.0/prometheus")
+
+	// Create temp dir for the origin key file
+	tDir := t.TempDir()
+	kfile := filepath.Join(tDir, "testKey")
+
+	//Setup a private key and a token
+	viper.Set("IssuerKey", kfile)
 
 	w := httptest.NewRecorder()
 	c, r := gin.CreateTestContext(w)
@@ -57,21 +64,27 @@ func TestPrometheusProtection(t *testing.T) {
 		URL: &url.URL{},
 	}
 
-	// Create temp dir for the origin key file
-	tDir := t.TempDir()
-	kfile := filepath.Join(tDir, "testKey")
+	privateKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	assert.NoError(t, err, "Error generating private key")
 
-	//Setup a private key and a token
-	viper.Set("IssuerKey", kfile)
+	// Convert from raw ecdsa to jwk.Key
+	pKey, err := jwk.FromRaw(privateKey)
+	assert.NoError(t, err, "Unable to convert ecdsa.PrivateKey to jwk.Key")
 
-	// Generate the origin private and public keys
-	_, err := config.LoadPublicKey("", kfile)
+	//Assign Key id to the private key
+	err = jwk.AssignKeyID(pKey)
+	assert.NoError(t, err, "Error assigning kid to private key")
 
+	//Set an algorithm for the key
+	err = pKey.Set(jwk.AlgorithmKey, jwa.ES512)
+	assert.NoError(t, err, "Unable to set algorithm for pKey")
+
+	buf, err := json.MarshalIndent(pKey, "", " ")
 	if err != nil {
 		t.Fatal(err)
 	}
+	err = os.WriteFile(kfile, buf, 0644)
 
-	privKey, err := config.LoadPrivateKey(kfile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,12 +93,24 @@ func TestPrometheusProtection(t *testing.T) {
 	issuerURL := url.URL{}
 	issuerURL.Scheme = "https"
 	issuerURL.Host = "test-http"
-	now := time.Now()
+
+	jti_bytes := make([]byte, 16)
+	_, err = rand.Read(jti_bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jti := base64.RawURLEncoding.EncodeToString(jti_bytes)
+
+	originUrl := viper.GetString("OriginURL")
 	tok, err := jwt.NewBuilder().
+		Claim("scope", "prometheus.read").
+		Claim("wlcg.ver", "1.0").
+		JwtID(jti).
 		Issuer(issuerURL.String()).
-		IssuedAt(now).
-		Expiration(now.Add(30 * time.Minute)).
-		NotBefore(now).
+		Audience([]string{originUrl}).
+		Subject("sub").
+		Expiration(time.Now().Add(time.Minute)).
+		IssuedAt(time.Now()).
 		Build()
 
 	if err != nil {
@@ -93,7 +118,7 @@ func TestPrometheusProtection(t *testing.T) {
 	}
 
 	// Sign the token with the origin private key
-	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES512, privKey))
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256, pKey))
 
 	if err != nil {
 		t.Fatal(err)
@@ -115,31 +140,96 @@ func TestPrometheusProtection(t *testing.T) {
 	c.Request.URL.RawQuery = new_query.Encode()
 
 	r.ServeHTTP(w, c.Request)
+}
 
-	// Check to see that the code exits with status code 404 after giving it a good token
+func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
+	/*
+	* Tests that the prometheus protections are behind the origin's token and tests that the token is accessable from
+	* the header function. It signs a token with the origin's jwks key and adds it to the header before attempting
+	* to access the prometheus metrics. It then attempts to access the metrics with a token with an invalid scope.
+	* It attempts to do so again with a token signed by a bad key. Both these are expected to fail.
+	 */
+
+	viper.Reset()
+
+	av1 := route.New().WithPrefix("/api/v1.0/prometheus")
+
+	// Create temp dir for the origin key file
+	tDir := t.TempDir()
+	kfile := filepath.Join(tDir, "testKey")
+
+	//Setup a private key and a token
+	viper.Set("IssuerKey", kfile)
+
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+
+	c.Request = &http.Request{
+		URL: &url.URL{},
+	}
+
+	// Generate the origin private and public keys
+	_, err := config.LoadPublicKey("", kfile)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Load the private key
+	privKey, err := config.LoadPrivateKey(kfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a token
+	issuerURL := url.URL{}
+	issuerURL.Scheme = "https"
+	issuerURL.Host = "test-http"
+
+	jti_bytes := make([]byte, 16)
+	_, err = rand.Read(jti_bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jti := base64.RawURLEncoding.EncodeToString(jti_bytes)
+
+	originUrl := viper.GetString("OriginURL")
+	tok, err := jwt.NewBuilder().
+		Claim("scope", "prometheus.read").
+		Claim("wlcg.ver", "1.0").
+		JwtID(jti).
+		Issuer(issuerURL.String()).
+		Audience([]string{originUrl}).
+		Subject("sub").
+		Expiration(time.Now().Add(time.Minute)).
+		IssuedAt(time.Now()).
+		Build()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sign the token with the origin private key
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256, privKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set the request to go through the checkPromToken function
+	r.GET("/api/v1.0/prometheus/*any", checkPromToken(av1))
+	c.Request, _ = http.NewRequest(http.MethodGet, "/api/v1.0/prometheus/test", bytes.NewBuffer([]byte(`{}`)))
+
+	// Put the signed token within the header
+	c.Request.Header.Set("Authorization", "Bearer "+string(signed))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	r.ServeHTTP(w, c.Request)
+
 	assert.Equal(t, 404, w.Result().StatusCode, "Expected status code of 404 representing failure due to minimal server setup, not token check")
 
 	// Create a new Recorder and Context for the next HTTPtest call
-	wH := httptest.NewRecorder()
-	cH, rH := gin.CreateTestContext(wH)
-
-	// Set the request to go through the checkPromToken function
-	rH.GET("/api/v1.0/prometheus/*any", checkPromToken(av1))
-	cH.Request, _ = http.NewRequest(http.MethodGet, "/api/v1.0/prometheus/test", bytes.NewBuffer([]byte(`{}`)))
-
-	// Put the signed token within the header
-	cH.Request.Header.Set("Authorization", "Bearer "+string(signed))
-	cH.Request.Header.Set("Content-Type", "application/json")
-
-	viper.Set("FederationURL", "")
-
-	rH.ServeHTTP(wH, cH.Request)
-	// Check to see that the code exits with status code 404 after given it a good token
-	assert.Equal(t, 404, wH.Result().StatusCode, "Expected status code of 404 representing failure due to minimal server setup, not token check")
-
-	// Create a new Recorder and Context for testing an invalid token
-	wI := httptest.NewRecorder()
-	cI, rI := gin.CreateTestContext(wI)
+	w = httptest.NewRecorder()
+	c, r = gin.CreateTestContext(w)
 
 	c.Request = &http.Request{
 		URL: &url.URL{},
@@ -158,30 +248,83 @@ func TestPrometheusProtection(t *testing.T) {
 	assert.NoError(t, err, "Error assigning kid to private key")
 
 	//Set an algorithm for the key
-	err = pKey.Set(jwk.AlgorithmKey, jwa.ES512)
+	err = pKey.Set(jwk.AlgorithmKey, jwa.ES256)
 	assert.NoError(t, err, "Unable to set algorithm for pKey")
+
+	jti_bytes = make([]byte, 16)
+	_, err = rand.Read(jti_bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jti = base64.RawURLEncoding.EncodeToString(jti_bytes)
 
 	// Create a new token to be used
 	tok, err = jwt.NewBuilder().
+		Claim("scope", "prometheus.read").
+		Claim("wlcg.ver", "1.0").
+		JwtID(jti).
 		Issuer(issuerURL.String()).
-		IssuedAt(now).
-		Expiration(now.Add(30 * time.Minute)).
-		NotBefore(now).
+		Audience([]string{originUrl}).
+		Subject("sub").
+		Expiration(time.Now().Add(time.Minute)).
+		IssuedAt(time.Now()).
 		Build()
 
 	assert.NoError(t, err, "Error creating token")
 
 	// Sign token with private key (not the origin)
-	signed, err = jwt.Sign(tok, jwt.WithKey(jwa.ES512, pKey))
+	signed, err = jwt.Sign(tok, jwt.WithKey(jwa.ES256, pKey))
 	assert.NoError(t, err, "Error signing token")
 
-	rI.GET("/api/v1.0/prometheus/*any", checkPromToken(av1))
-	cI.Request, _ = http.NewRequest(http.MethodGet, "/api/v1.0/prometheus/test", bytes.NewBuffer([]byte(`{}`)))
+	r.GET("/api/v1.0/prometheus/*any", checkPromToken(av1))
+	c.Request, _ = http.NewRequest(http.MethodGet, "/api/v1.0/prometheus/test", bytes.NewBuffer([]byte(`{}`)))
 
-	cI.Request.Header.Set("Authorization", "Bearer "+string(signed))
-	cI.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("Authorization", "Bearer "+string(signed))
+	c.Request.Header.Set("Content-Type", "application/json")
 
-	rI.ServeHTTP(wI, cI.Request)
+	r.ServeHTTP(w, c.Request)
 	// Assert that it gets the correct Permission Denied 403 code
-	assert.Equal(t, 403, wI.Result().StatusCode, "Expected failing status code of 403: Permission Denied")
+	assert.Equal(t, 403, w.Result().StatusCode, "Expected failing status code of 403: Permission Denied")
+
+	// Create a new Recorder and Context for the next HTTPtest call
+	w = httptest.NewRecorder()
+	c, r = gin.CreateTestContext(w)
+
+	c.Request = &http.Request{
+		URL: &url.URL{},
+	}
+
+	// Create a new token to be used
+	tok, err = jwt.NewBuilder().
+		Claim("scope", "not.prometheus").
+		Claim("wlcg.ver", "1.0").
+		JwtID(jti).
+		Issuer(issuerURL.String()).
+		Audience([]string{originUrl}).
+		Subject("sub").
+		Expiration(time.Now().Add(time.Minute)).
+		IssuedAt(time.Now()).
+		Build()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sign the token with the origin private key
+	signed, err = jwt.Sign(tok, jwt.WithKey(jwa.ES256, privKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set the request to go through the checkPromToken function
+	r.GET("/api/v1.0/prometheus/*any", checkPromToken(av1))
+	c.Request, _ = http.NewRequest(http.MethodGet, "/api/v1.0/prometheus/test", bytes.NewBuffer([]byte(`{}`)))
+
+	// Put the signed token within the header
+	c.Request.Header.Set("Authorization", "Bearer "+string(signed))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	r.ServeHTTP(w, c.Request)
+
+	assert.Equal(t, 500, w.Result().StatusCode, "Expected status code of 500 representing failure to validate token scope")
 }


### PR DESCRIPTION
This addresses issue Issue #6 and puts the accessing of prometheus metrics behind the federation or origin token.