### PR TITLE
Put the token acquisition workflow behind a plugin check

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -78,6 +78,7 @@ func stashPluginMain(args []string) {
 	pelican.ObjectClientOptions.Recursive = false
 	pelican.ObjectClientOptions.ProgressBars = false
 	pelican.ObjectClientOptions.Version = version
+	pelican.ObjectClientOptions.Plugin = true
 	setLogging(log.PanicLevel)
 	methods := []string{"http"}
 	var infile, outfile, testCachePath string

--- a/cmd/plugin_stage.go
+++ b/cmd/plugin_stage.go
@@ -116,6 +116,7 @@ func stagePluginMain(cmd *cobra.Command, args []string) {
 
 	// Set the progress bars to the command line option
 	pelican.ObjectClientOptions.Token = viper.GetString("StagePlugin.Token")
+	pelican.ObjectClientOptions.Plugin = true
 
 	// Check if the program was executed from a terminal
 	// https://rosettacode.org/wiki/Check_output_device_is_a_terminal#Go

--- a/main_test.go
+++ b/main_test.go
@@ -180,6 +180,11 @@ func TestGetToken(t *testing.T) {
 	err = os.Chdir(currentDir)
 	assert.NoError(t, err)
 
+	ObjectClientOptions.Plugin = true
+	_, err = getToken(url, namespace, true, "")
+	assert.EqualError(t, err, "Credential is required for osdf:///user/foo but is currently missing")
+	ObjectClientOptions.Plugin = false
+
 }
 
 // TestGetTokenName tests getTokenName


### PR DESCRIPTION
This is addressing #56 

Basically, plugin runs should be provided with the authorization that they need. So there is a new pelican variable created and set to true whenever a plugin is run. Then, during `getToken`, it will check for this guard before running `AcquireToken` if a token hasn't been found and return an error instead of running the token acquisition workflow. 

