### PR TITLE
Overhaul config names

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
         HEAD=$(git rev-parse HEAD)
         git reset --hard ${{ github.event.pull_request.base.sha }}
         make web-build
+        go generate ./...
         go test -coverpkg=./... -coverprofile=base_coverage.out -covermode=count ./...
         go tool cover -func=base_coverage.out > unit-base.txt
         git reset --hard $HEAD

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -44,7 +44,7 @@ import (
 	"github.com/vbauerster/mpb/v8/decor"
 
 	"github.com/pelicanplatform/pelican/config"
-	namespaces "github.com/pelicanplatform/pelican/namespaces"
+	"github.com/pelicanplatform/pelican/namespaces"
 	"github.com/pelicanplatform/pelican/param"
 )
 

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -44,8 +44,7 @@ import (
 	"github.com/vbauerster/mpb/v8/decor"
 
 	"github.com/pelicanplatform/pelican/config"
-	"github.com/pelicanplatform/pelican/namespaces"
-	"github.com/pelicanplatform/pelican/namespaces"
+	namespaces "github.com/pelicanplatform/pelican/namespaces"
 	"github.com/pelicanplatform/pelican/param"
 )
 

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -107,7 +107,7 @@ func IsProxyEnabled() bool {
 	if _, isSet := os.LookupEnv("http_proxy"); !isSet {
 		return false
 	}
-	if viper.IsSet("DisableHttpProxy") {
+	if param.Client_DisableHttpProxy.GetBool() {
 		return false
 	}
 	return true
@@ -115,7 +115,7 @@ func IsProxyEnabled() bool {
 
 // Determine whether we are allowed to skip the proxy as a fallback
 func CanDisableProxy() bool {
-	return !viper.IsSet("DisableProxyFallback")
+	return !param.Client_DisableProxyFallback.GetBool()
 }
 
 // ConnectionSetupError is an error that is returned when a connection to the remote server fails
@@ -469,7 +469,7 @@ func DownloadHTTP(transfer TransferDetails, dest string, token string) (int64, e
 	// Progress ticker
 	progressTicker := time.NewTicker(500 * time.Millisecond)
 	defer progressTicker.Stop()
-	downloadLimit := viper.GetInt("MinimumDownloadSpeed")
+	downloadLimit := param.Client_MinimumDownloadSpeed.GetInt()
 
 	// If we are doing a recursive, decrease the download limit by the number of likely workers ~5
 	if ObjectClientOptions.Recursive {
@@ -506,9 +506,9 @@ func DownloadHTTP(transfer TransferDetails, dest string, token string) (int64, e
 		)
 	}
 
-	stoppedTransferTimeout := viper.GetInt64("StoppedTransferTimeout")
-	slowTransferRampupTime := viper.GetInt64("SlowTransferRampupTime")
-	slowTransferWindow := viper.GetInt64("SlowTransferWindow")
+	stoppedTransferTimeout := int64(param.Client_StoppedTransferTimeout.GetInt())
+	slowTransferRampupTime := int64(param.Client_SlowTransferRampupTime.GetInt())
+	slowTransferWindow := int64(param.Client_SlowTransferWindow.GetInt())
 	var previousCompletedBytes int64 = 0
 	var startBelowLimit int64 = 0
 	var previousCompletedTime = time.Now()

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -39,13 +39,14 @@ import (
 
 	grab "github.com/cavaliercoder/grab"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	"github.com/studio-b12/gowebdav"
 	"github.com/vbauerster/mpb/v8"
 	"github.com/vbauerster/mpb/v8/decor"
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/namespaces"
+	"github.com/pelicanplatform/pelican/namespaces"
+	"github.com/pelicanplatform/pelican/param"
 )
 
 var p = mpb.New()

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -138,8 +138,8 @@ func TestNewTransferDetailsEnv(t *testing.T) {
 
 func TestSlowTransfers(t *testing.T) {
 	// Adjust down some timeouts to speed up the test
-	viper.Set("SlowTransferWindow", 5)
-	viper.Set("SlowTransferRampupTime", 10)
+	viper.Set("Client.SlowTransferWindow", 5)
+	viper.Set("Client.SlowTransferRampupTime", 10)
 
 	channel := make(chan bool)
 	slowDownload := 1024 * 10 // 10 KiB/s < 100 KiB/s
@@ -201,8 +201,8 @@ func TestSlowTransfers(t *testing.T) {
 // Test stopped transfer
 func TestStoppedTransfer(t *testing.T) {
 	// Adjust down the timeouts
-	viper.Set("StoppedTransferTimeout", 3)
-	viper.Set("SlowTransferRampupTime", 100)
+	viper.Set("Client.StoppedTransferTimeout", 3)
+	viper.Set("Client.SlowTransferRampupTime", 100)
 
 	channel := make(chan bool)
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/client/main.go
+++ b/client/main.go
@@ -267,7 +267,7 @@ func CheckOSDF(destination string, methods []string) (remoteSize uint64, err err
 		federationUrl, _ := url.Parse(dest_uri.String())
 		federationUrl.Scheme = "https"
 		federationUrl.Path = ""
-		viper.Set("FederationURL", federationUrl.String())
+		viper.Set("Federation.DiscoveryUrl", federationUrl.String())
 		err = config.DiscoverFederation()
 		if err != nil {
 			return 0, err
@@ -405,7 +405,7 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 			federationUrl, _ := url.Parse(source_url.String())
 			federationUrl.Scheme = "https"
 			federationUrl.Path = ""
-			viper.Set("FederationURL", federationUrl.String())
+			viper.Set("Federation.DiscoveryUrl", federationUrl.String())
 			err = config.DiscoverFederation()
 			if err != nil {
 				return 0, err
@@ -420,7 +420,7 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 			federationUrl, _ := url.Parse(dest_url.String())
 			federationUrl.Scheme = "https"
 			federationUrl.Path = ""
-			viper.Set("FederationURL", federationUrl.String())
+			viper.Set("Federation.DiscoveryUrl", federationUrl.String())
 			err = config.DiscoverFederation()
 			if err != nil {
 				return 0, err
@@ -474,8 +474,8 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 		sourceFile = "/" + sourceFile
 	}
 
-	OSDFDirectorUrl := param.DirectorUrl.GetString()
-	useOSDFDirector := viper.IsSet("DirectorURL")
+	OSDFDirectorUrl := param.Federation_DirectorUrl.GetString()
+	useOSDFDirector := viper.IsSet("Federation.DirectorURL")
 
 	var ns namespaces.Namespace
 	if useOSDFDirector {

--- a/client/main_test.go
+++ b/client/main_test.go
@@ -60,7 +60,7 @@ func TestGetIps(t *testing.T) {
 func TestGetToken(t *testing.T) {
 
 	// Need a namespace for token acquisition
-	defer os.Unsetenv("PELICAN_TOPOLOGYNAMESPACEURL")
+	defer os.Unsetenv("PELICAN_FEDERATION_TOPOLOGYNAMESPACEURL")
 	os.Setenv("PELICAN_TOPOLOGY_NAMESPACE_URL", "https://topology.opensciencegrid.org/osdf/namespaces")
 	viper.Reset()
 	err := config.InitClient()

--- a/cmd/director_serve.go
+++ b/cmd/director_serve.go
@@ -36,7 +36,7 @@ import (
 func generateTLSCertIfNeeded() error {
 
 	// As necessary, generate a private key and corresponding cert
-	if err := config.GeneratePrivateKey(param.TLSKey.GetString(), elliptic.P256()); err != nil {
+	if err := config.GeneratePrivateKey(param.Server_TLSKey.GetString(), elliptic.P256()); err != nil {
 		return err
 	}
 	if err := config.GenerateCert(); err != nil {

--- a/cmd/namespace_client.go
+++ b/cmd/namespace_client.go
@@ -39,7 +39,7 @@ var pubkeyPath string
 var privkeyPath string
 
 func getNamespaceEndpoint() (string, error) {
-	namespaceEndpoint := param.NamespaceUrl.GetString()
+	namespaceEndpoint := param.Federation_NamespaceUrl.GetString()
 	if namespaceEndpoint == "" {
 		return "", errors.New("No namespace registry specified; either give the federation name (-f) or specify the namespace API endpoint directly (e.g., --namespace-url=https://namespace.osg-htc.org/namespaces)")
 	}

--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -85,7 +85,7 @@ func init() {
 	originCmd.AddCommand(originConfigCmd)
 	originCmd.AddCommand(originServeCmd)
 	originServeCmd.Flags().StringP("volume", "v", "", "Setting the volue to /SRC:/DEST will export the contents of /SRC as /DEST in the Pelican federation")
-	if err := viper.BindPFlag("ExportVolume", originServeCmd.Flags().Lookup("volume")); err != nil {
+	if err := viper.BindPFlag("Origin.ExportVolume", originServeCmd.Flags().Lookup("volume")); err != nil {
 		panic(err)
 	}
 	originServeCmd.Flags().AddFlag(portFlag)

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -83,8 +83,8 @@ type (
 	}
 
 	ServerConfig struct {
-		TLSCertificate          string
-		TLSKey                  string
+		TLSCertificate            string
+		TLSKey                    string
 		TLSCACertificateDirectory string
 		TLSCACertificateFile      string
 	}

--- a/cmd/resources/xrootd.cfg
+++ b/cmd/resources/xrootd.cfg
@@ -15,46 +15,46 @@
 #
 
 {{if .Origin.UseCmsd}}
-all.manager {{.ManagerHost}}+ {{.ManagerPort}}
-{{end}}
+all.manager {{.Xrootd.ManagerHost}}+ {{.Xrootd.ManagerPort}}{{end}}
 all.role server
 if exec xrootd
-  xrd.port {{.Port}}
-  xrd.protocol http:{{.Port}} libXrdHttp.so
+  xrd.port {{.Xrootd.Port}}
+  xrd.protocol http:{{.Xrootd.Port}} libXrdHttp.so
 fi
-xrd.tls {{.TLSCertificate}} {{.TLSKey}}
-{{if .TLSCertDir}}
-xrd.tlsca certdir {{.TLSCertDir}}
+xrd.tls {{.Server.TLSCertificate}} {{.Server.TLSKey}}
+{{if .Xrootd.TLSCertDir}}
+xrd.tlsca certdir {{.Xrootd.TLSCertDir}}
 {{else}}
-xrd.tlsca certfile {{.TLSCACertFile}}
+xrd.tlsca certfile {{.Xrootd.TLSCertFile}}
 {{end}}
 {{if .Origin.UseMacaroons}}
 http.exthandler xrdmacaroons libXrdMacaroons.so
-macaroons.secretkey {{.MacaroonsKeyFile}}
+macaroons.secretkey {{.Xrootd.MacaroonsKeyFile}}
 ofs.authlib ++ libXrdMacaroons.so
 {{end}}
 http.header2cgi Authorization authz
 {{if .Origin.UseVoms}}
 http.secxtractor /usr/lib64/libXrdVoms.so
+http.staticpreload http://static/robots.txt {{.Xrootd.RobotsTxtFile}}
+{{if .Xrootd.Sitename}}
+all.sitename {{.Xrootd.Sitename}}
 {{end}}
-http.staticpreload http://static/robots.txt {{.RobotsTxtFile}}
-{{if .Sitename}}
-all.sitename {{.Sitename}}
+{{if .Xrootd.SummaryMonitoringHost}}
+xrd.report {{.Xrootd.SummaryMonitoringHost}}:{{.Xrootd.SummaryMonitoringPort}},127.0.0.1:{{.Xrootd.LocalMonitoringPort}} every 30s
 {{end}}
-{{if .SummaryMonitoringHost}}
-xrd.report {{.SummaryMonitoringHost}}:{{.SummaryMonitoringPort}},127.0.0.1:{{.LocalMonitoringPort}} every 30s
+{{if .Xrootd.DetailedMonitoringHost}}
+xrootd.monitor all auth flush 30s window 5s fstat 60 lfn ops xfr 5 {{if .Xrootd.DetailedMonitoringHost -}} dest redir fstat info files user pfc tcpmon ccm {{.Xrootd.DetailedMonitoringHost}}:{{.Xrootd.DetailedMonitoringPort}} {{-end}} dest redir fstat info files user pfc tcpmon ccm 127.0.0.1:{{.Xrootd.LocalMonitoringPort}}
 {{end}}
-xrootd.monitor all auth flush 30s window 5s fstat 60 lfn ops xfr 5 {{if .DetailedMonitoringHost -}} dest redir fstat info files user pfc tcpmon ccm {{.DetailedMonitoringHost}}:{{.DetailedMonitoringPort}} {{-end}} dest redir fstat info files user pfc tcpmon ccm 127.0.0.1:{{.LocalMonitoringPort}}
-all.adminpath {{.XrootdRun}}
-all.pidpath {{.XrootdRun}}
-oss.localroot {{.Mount}}
+all.adminpath {{.Xrootd.RunLocation}}
+all.pidpath {{.Xrootd.RunLocation}}
+oss.localroot {{.Xrootd.Mount}}
 xrootd.seclib libXrdSec.so
 sec.protocol ztn
 ofs.authorize 1
 acc.audit deny grant
-acc.authdb {{.XrootdRun}}/authfile-generated
-ofs.authlib ++ libXrdAccSciTokens.so config={{.XrootdRun}}/scitokens-generated.cfg
-all.export {{.NamespacePrefix}}
+acc.authdb {{.Xrootd.RunLocation}}/authfile-generated
+ofs.authlib ++ libXrdAccSciTokens.so config={{.Xrootd.RunLocation}}/scitokens-generated.cfg
+all.export {{.Origin.NamespacePrefix}}
 {{if .Origin.SelfTest}}
 # Note we don't want to export this via cmsd; only for self-test
 xrootd.export /pelican/monitoring

--- a/cmd/resources/xrootd.cfg
+++ b/cmd/resources/xrootd.cfg
@@ -15,17 +15,18 @@
 #
 
 {{if .Origin.UseCmsd}}
-all.manager {{.Xrootd.ManagerHost}}+ {{.Xrootd.ManagerPort}}{{end}}
+all.manager {{.Xrootd.ManagerHost}}+ {{.Xrootd.ManagerPort}}
+{{end}}
 all.role server
 if exec xrootd
   xrd.port {{.Xrootd.Port}}
   xrd.protocol http:{{.Xrootd.Port}} libXrdHttp.so
 fi
 xrd.tls {{.Server.TLSCertificate}} {{.Server.TLSKey}}
-{{if .Xrootd.TLSCertDir}}
-xrd.tlsca certdir {{.Xrootd.TLSCertDir}}
+{{if .Server.TLSCACertificateDirectory}}
+xrd.tlsca certdir {{.Server.TLSCACertificateDirectory}}
 {{else}}
-xrd.tlsca certfile {{.Xrootd.TLSCertFile}}
+xrd.tlsca certfile {{.Server.TLSCACertificateFile}}
 {{end}}
 {{if .Origin.UseMacaroons}}
 http.exthandler xrdmacaroons libXrdMacaroons.so
@@ -35,6 +36,7 @@ ofs.authlib ++ libXrdMacaroons.so
 http.header2cgi Authorization authz
 {{if .Origin.UseVoms}}
 http.secxtractor /usr/lib64/libXrdVoms.so
+{{end}}
 http.staticpreload http://static/robots.txt {{.Xrootd.RobotsTxtFile}}
 {{if .Xrootd.Sitename}}
 all.sitename {{.Xrootd.Sitename}}
@@ -42,9 +44,7 @@ all.sitename {{.Xrootd.Sitename}}
 {{if .Xrootd.SummaryMonitoringHost}}
 xrd.report {{.Xrootd.SummaryMonitoringHost}}:{{.Xrootd.SummaryMonitoringPort}},127.0.0.1:{{.Xrootd.LocalMonitoringPort}} every 30s
 {{end}}
-{{if .Xrootd.DetailedMonitoringHost}}
-xrootd.monitor all auth flush 30s window 5s fstat 60 lfn ops xfr 5 {{if .Xrootd.DetailedMonitoringHost -}} dest redir fstat info files user pfc tcpmon ccm {{.Xrootd.DetailedMonitoringHost}}:{{.Xrootd.DetailedMonitoringPort}} {{-end}} dest redir fstat info files user pfc tcpmon ccm 127.0.0.1:{{.Xrootd.LocalMonitoringPort}}
-{{end}}
+xrootd.monitor all auth flush 30s window 5s fstat 60 lfn ops xfr 5 {{if .Xrootd.DetailedMonitoringHost -}} dest redir fstat info files user pfc tcpmon ccm {{.Xrootd.DetailedMonitoringHost}}:{{.Xrootd.DetailedMonitoringPort}} {{- end}} dest redir fstat info files user pfc tcpmon ccm 127.0.0.1:{{.Xrootd.LocalMonitoringPort}}
 all.adminpath {{.Xrootd.RunLocation}}
 all.pidpath {{.Xrootd.RunLocation}}
 oss.localroot {{.Xrootd.Mount}}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -104,7 +105,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Enable debug logs")
 
 	rootCmd.PersistentFlags().StringP("federation", "f", "", "Pelican federation to utilize")
-	if err := viper.BindPFlag("FederationURL", rootCmd.PersistentFlags().Lookup("federation")); err != nil {
+	if err := viper.BindPFlag("Federation.DiscoveryUrl", rootCmd.PersistentFlags().Lookup("federation")); err != nil {
 		panic(err)
 	}
 
@@ -127,7 +128,7 @@ func initConfig() {
 	if err := viper.BindPFlag("Debug", rootCmd.PersistentFlags().Lookup("debug")); err != nil {
 		panic(err)
 	}
-	if err := viper.BindPFlag("WebPort", portFlag); err != nil {
+	if err := viper.BindPFlag("Server.WebPort", portFlag); err != nil {
 		panic(err)
 	}
 
@@ -142,7 +143,7 @@ func initConfig() {
 	}
 
 	setLogging(log.ErrorLevel)
-	if viper.GetBool("Debug") {
+	if param.Debug.GetBool() {
 		setLogging(log.DebugLevel)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,7 +46,7 @@ with data federations, enabling the sharing of objects and collections
 across multiple dataset providers.`,
 	}
 
-	// We want the value of this port flag to correspond to the WebPort viper key.
+	// We want the value of this port flag to correspond to the Port viper key.
 	// However, only one flag pointer can correspond to the key.  If we define this
 	// in `pelican registry serve` and `pelican director serve`, then whatever init()
 	// function is run second will be the only one that is set (the first definition
@@ -128,7 +128,7 @@ func initConfig() {
 	if err := viper.BindPFlag("Debug", rootCmd.PersistentFlags().Lookup("debug")); err != nil {
 		panic(err)
 	}
-	if err := viper.BindPFlag("Server.WebPort", portFlag); err != nil {
+	if err := viper.BindPFlag("Server.Port", portFlag); err != nil {
 		panic(err)
 	}
 

--- a/config/config_default.go
+++ b/config/config_default.go
@@ -33,10 +33,10 @@ func InitServerOSDefaults() error {
 	// fake one instead.
 
 	tlscaFile := filepath.Join(viper.GetString("ConfigDir"), "certificates", "tlsca.pem")
-	viper.SetDefault("TLSCACertFile", tlscaFile)
+	viper.SetDefault("Server.TLSCACertificateFile", tlscaFile)
 
 	tlscaKeyFile := filepath.Join(viper.GetString("ConfigDir"), "certificates", "tlscakey.pem")
-	viper.SetDefault("TLSCACertFile", tlscaKeyFile)
+	viper.SetDefault("Server.TLSCACertificateFile", tlscaKeyFile)
 
 	if err := os.MkdirAll(filepath.Dir(tlscaFile), 0755); err != nil {
 		return err

--- a/config/config_linux.go
+++ b/config/config_linux.go
@@ -25,6 +25,6 @@ import (
 )
 
 func InitServerOSDefaults() error {
-	viper.SetDefault("TLSCACertFile", "/etc/pki/tls/cert.pem")
+	viper.SetDefault("Server.TLSCACertificateFile", "/etc/pki/tls/cert.pem")
 	return nil
 }

--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -233,7 +233,7 @@ func GenerateCert() error {
 		return err
 	}
 
-	tlsCert := param.TLSCertificate.GetString()
+	tlsCert := param.Server_TLSCertificate.GetString()
 	if file, err := os.Open(tlsCert); err == nil {
 		file.Close()
 		return nil
@@ -255,7 +255,7 @@ func GenerateCert() error {
 		return err
 	}
 
-	tlsKey := param.TLSKey.GetString()
+	tlsKey := param.Server_TLSKey.GetString()
 	privateKey, err := LoadPrivateKey(tlsKey)
 	if err != nil {
 		return err
@@ -385,7 +385,7 @@ func GeneratePrivateKey(keyLocation string, curve elliptic.Curve) error {
 }
 
 func GenerateIssuerJWKS() (*jwk.Set, error) {
-	existingJWKS := viper.GetString("IssuerJWKS")
+	existingJWKS := param.Server_IssuerJwks.GetString()
 	issuerKeyFile := param.IssuerKey.GetString()
 	return LoadPublicKey(existingJWKS, issuerKeyFile)
 }

--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -39,7 +39,6 @@ import (
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -130,7 +129,7 @@ func GenerateCACert() error {
 		return err
 	}
 
-	tlsCert := viper.GetString("TLSCACertFile")
+	tlsCert := param.Server_TLSCACertificateFile.GetString()
 	if file, err := os.Open(tlsCert); err == nil {
 		file.Close()
 		return nil
@@ -142,7 +141,7 @@ func GenerateCACert() error {
 		return err
 	}
 
-	tlsKey := viper.GetString("TLSCAKey")
+	tlsKey := param.Server_TLSCAKey.GetString()
 	if err := GeneratePrivateKey(tlsKey, elliptic.P256()); err != nil {
 		return err
 	}
@@ -245,7 +244,7 @@ func GenerateCert() error {
 	if err := GenerateCACert(); err != nil {
 		return err
 	}
-	caCert, err := LoadCertficate(viper.GetString("TLSCACertFile"))
+	caCert, err := LoadCertficate(param.Server_TLSCACertificateFile.GetString())
 	if err != nil {
 		return err
 	}
@@ -263,7 +262,7 @@ func GenerateCert() error {
 
 	// Note: LoadPrivateKey will return nil for the private key if the file
 	// doesn't exist.  In that case, we'll do a self-signed certificate
-	caPrivateKey, err := LoadPrivateKey(viper.GetString("TLSCAKey"))
+	caPrivateKey, err := LoadPrivateKey(param.Server_TLSCAKey.GetString())
 	if err != nil {
 		return err
 	}

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -15,9 +15,10 @@
 #
 
 Debug: false
-WebAddress: "0.0.0.0"
+
 Server:
-  WebPort: 8444
+  Port: 8444
+  Address: "0.0.0.0"
 Director:
   DefaultResponse: cache
 Origin:
@@ -26,9 +27,9 @@ Origin:
   UseMacaroons: true
   UseVoms: true
   SelfTest: true
-Prometheus:
-  MonitoringPortLower: 9930
-  MonitoringPortHigher: 9999
+Monitoring:
+  PortLower: 9930
+  PortHigher: 9999
 Xrootd:
   Port: 8443
   Mount: ""

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -14,24 +14,27 @@
 # limitations under the License.
 #
 
-Port: 8443
-WebPort: 8444
-WebAddress: "0.0.0.0"
-ManagerPort: 1213
-SummaryMonitoringPort: 9931
-DetailedMonitoringPort: 9930
-MonitoringPortLower: 9930
-MonitoringPortHigher: 9999
-Mount: ""
-NamespacePrefix: ""
 Debug: false
+WebAddress: "0.0.0.0"
+Server:
+  WebPort: 8444
 Director:
   DefaultResponse: cache
 Origin:
+  NamespacePrefix: ""
   Multiuser: false
   UseMacaroons: true
   UseVoms: true
   SelfTest: true
+Prometheus:
+  MonitoringPortLower: 9930
+  MonitoringPortHigher: 9999
+Xrootd:
+  Port: 8443
+  Mount: ""
+  ManagerPort: 1213
+  DetailedMonitoringPort: 9930
+  SummaryMonitoringPort: 9931
 Transport:
   Dialer:
     Timeout: 10s

--- a/config/resources/osdf.yaml
+++ b/config/resources/osdf.yaml
@@ -14,8 +14,10 @@
 # limitations under the License.
 #
 
-ManagerHost: redirector.osgstorage.org
-SummaryMonitoringHost: xrd-report.osgstorage.org
-DetailedMonitoringHost: xrd-mon.osgstorage.org
-TopologyNamespaceURL: https://topology.opensciencegrid.org/stashcache/namespaces.json
-FederationURL: osg-htc.org
+Xrootd:
+  ManagerHost: redirector.osgstorage.org
+  SummaryMonitoringHost: xrd-report.osgstorage.org
+  DetailedMonitoringHost: xrd-mon.osgstorage.org
+Federation:
+  DiscoveryUrl: osg-htc.org
+  TopologyNamespaceURL: https://topology.opensciencegrid.org/stashcache/namespaces.json

--- a/director/advertise.go
+++ b/director/advertise.go
@@ -67,12 +67,12 @@ type (
 
 // Populate internal cache with origin/cache ads
 func AdvertiseOSDF() error {
-	namespaceURL := param.TopologyNamespaceURL.GetString()
-	if namespaceURL == "" {
-		return errors.New("Topology namespaces.json configuration option (`TopologyNamespaceURL`) not set")
+	topoNamespaceUrl := param.Federation_TopologyNamespaceUrl.GetString()
+	if topoNamespaceUrl == "" {
+		return errors.New("Topology namespaces.json configuration option (`Federation.TopologyNamespaceURL`) not set")
 	}
 
-	req, err := http.NewRequest("GET", namespaceURL, nil)
+	req, err := http.NewRequest("GET", topoNamespaceUrl, nil)
 	if err != nil {
 		return errors.Wrap(err, "Failure when getting OSDF namespace data from topology")
 	}
@@ -97,7 +97,7 @@ func AdvertiseOSDF() error {
 
 	var namespaces NamespaceJSON
 	if err = json.Unmarshal(respBytes, &namespaces); err != nil {
-		return errors.Wrapf(err, "Failure when parsing JSON response from topology URL %v", namespaceURL)
+		return errors.Wrapf(err, "Failure when parsing JSON response from topology URL %v", topoNamespaceUrl)
 	}
 
 	cacheAdMap := make(map[ServerAd][]NamespaceAd)

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -67,7 +67,7 @@ func CreateAdvertiseToken(namespace string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	director := param.DirectorUrl.GetString()
+	director := param.Federation_DirectorUrl.GetString()
 	if director == "" {
 		return "", errors.New("Director URL is not known; cannot create advertise token")
 	}
@@ -185,7 +185,7 @@ func VerifyAdvertiseToken(token, namespace string) (bool, error) {
 }
 
 func GetRegistryIssuerURL(prefix string) (string, error) {
-	namespace_url_string := param.NamespaceUrl.GetString()
+	namespace_url_string := param.Federation_NamespaceUrl.GetString()
 	if namespace_url_string == "" {
 		return "", errors.New("Namespace URL is not set")
 	}

--- a/director/origin_api_test.go
+++ b/director/origin_api_test.go
@@ -155,7 +155,7 @@ func TestGetRegistryIssuerURL(t *testing.T) {
 
 	// Test to make sure the path is as expected
 	viper.Set("Federation.NamespaceURL", "test-path")
-	url, err = GetIssuerURL("test-prefix")
+	url, err = GetRegistryIssuerURL("test-prefix")
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "test-path/api/v1.0/registry/test-prefix/.well-known/issuer.jwks", url)
 

--- a/director/origin_api_test.go
+++ b/director/origin_api_test.go
@@ -28,8 +28,8 @@ func TestVerifyAdvertiseToken(t *testing.T) {
 	//Setup a private key and a token
 	viper.Set("IssuerKey", kfile)
 
-	viper.Set("NamespaceURL", "https://get-your-tokens.org")
-	viper.Set("DirectorURL", "https://director-url.org")
+	viper.Set("Federation.NamespaceURL", "https://get-your-tokens.org")
+	viper.Set("Federation.DirectorURL", "https://director-url.org")
 
 	kSet, err := config.LoadPublicKey("", kfile)
 	ar := MockCache{
@@ -128,13 +128,13 @@ func TestCreateAdvertiseToken(t *testing.T) {
 	tok, err := CreateAdvertiseToken("test-namespace")
 	assert.Equal(t, "", tok)
 	assert.Equal(t, "Namespace URL is not set", err.Error())
-	viper.Set("NamespaceURL", "https://get-your-tokens.org")
+	viper.Set("Federation.NamespaceURL", "https://get-your-tokens.org")
 
 	// Test without a DirectorURL set and check to see if it returns the expected error
 	tok, err = CreateAdvertiseToken("test-namespace")
 	assert.Equal(t, "", tok)
 	assert.Equal(t, "Director URL is not known; cannot create advertise token", err.Error())
-	viper.Set("DirectorURL", "https://director-url.org")
+	viper.Set("Federation.DirectorURL", "https://director-url.org")
 
 	// Test the CreateAdvertiseToken with good values and test that it returns a non-nil token value and no error
 	tok, err = CreateAdvertiseToken("test-namespace")
@@ -154,8 +154,8 @@ func TestGetRegistryIssuerURL(t *testing.T) {
 	assert.Equal(t, "Namespace URL is not set", err.Error())
 
 	// Test to make sure the path is as expected
-	viper.Set("NamespaceURL", "test-path")
-	url, err = GetRegistryIssuerURL("test-prefix")
+	viper.Set("Federation.NamespaceURL", "test-path")
+	url, err = GetIssuerURL("test-prefix")
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "test-path/api/v1.0/registry/test-prefix/.well-known/issuer.jwks", url)
 

--- a/director/redirect_test.go
+++ b/director/redirect_test.go
@@ -137,7 +137,7 @@ func TestDirectorRegistration(t *testing.T) {
 	}()
 
 	// Set the namespaceurl
-	viper.Set("NamespaceURL", "https://get-your-tokens.org")
+	viper.Set("Federation.NamespaceURL", "https://get-your-tokens.org")
 
 	// Create the  request and set the headers
 	r.POST("/", RegisterOrigin)

--- a/director/redirect_test.go
+++ b/director/redirect_test.go
@@ -213,35 +213,4 @@ func TestDirectorRegistration(t *testing.T) {
 	namaspaceADs = ListNamespacesFromOrigins()
 	assert.False(t, NamespaceAdContainsPath(namaspaceADs, "/foo/bar"), "Found namespace in the director cache even if the token validation failed.")
 	serverAds.DeleteAll()
-
-	// Repeat again but with bad origin version
-	wInv = httptest.NewRecorder()
-	cInv, rInv = gin.CreateTestContext(wInv)
-	tsInv = httptest.NewServer(http.HandlerFunc(func(wInv http.ResponseWriter, req *http.Request) {
-		assert.Equal(t, "POST", req.Method, "Not POST Method")
-		_, err := wInv.Write([]byte(":)"))
-		assert.NoError(t, err)
-	}))
-	defer tsInv.Close()
-	cInv.Request = &http.Request{
-		URL: &url.URL{},
-	}
-
-	// Sign token with the good key
-	signedInv, err = jwt.Sign(tok, jwt.WithKey(jwa.ES512, pKey))
-	assert.NoError(t, err, "Error signing token")
-
-	// Create the request and set the headers
-	rInv.POST("/", RegisterOrigin)
-	cInv.Request, _ = http.NewRequest(http.MethodPost, "/", bytes.NewBuffer([]byte(`{"Namespaces": [{"Path": "/foo/bar", "URL": "https://get-your-tokens.org"}]}`)))
-
-	cInv.Request.Header.Set("Authorization", "Bearer "+string(signedInv))
-	cInv.Request.Header.Set("Content-Type", "application/json")
-	cInv.Request.Header.Set("User-Agent", "pelican-origin/6.0.0")
-
-	rInv.ServeHTTP(wInv, cInv.Request)
-	assert.Equal(t, 500, wInv.Result().StatusCode, "Expected failing status code of 500")
-	body, _ = io.ReadAll(wInv.Result().Body)
-	assert.Equal(t, `{"error":"Incompatible versions detected: The director does not support your origin version (6.0.0). Please update to 7.0.0 or newer."}`,
-		string(body), "Failure wasn't because of version incompatibility")
 }

--- a/director/sort.go
+++ b/director/sort.go
@@ -117,7 +117,7 @@ func DownloadDB(localFile string) error {
 	}
 
 	var licenseKey string
-	keyFile := param.MaxMindKeyFile.GetString()
+	keyFile := param.Director_MaxMindKeyFile.GetString()
 	keyFromEnv := viper.GetString("MAXMINDKEY")
 	if keyFile != "" {
 		contents, err := os.ReadFile(keyFile)
@@ -128,7 +128,7 @@ func DownloadDB(localFile string) error {
 	} else if keyFromEnv != "" {
 		licenseKey = keyFromEnv
 	} else {
-		return errors.New("A MaxMind key file must be specified in the config (MaxMindKeyFile), in the environment (PELICAN_MAXMINDKEYFILE), or the key must be provided via the environment variable PELICAN_MAXMINDKEY)")
+		return errors.New("A MaxMind key file must be specified in the config (Director.MaxMindKeyFile), in the environment (PELICAN_DIRECTOR_MAXMINDKEYFILE), or the key must be provided via the environment variable PELICAN_MAXMINDKEY)")
 	}
 
 	url := fmt.Sprintf(maxMindURL, licenseKey)
@@ -185,7 +185,7 @@ func PeriodicMaxMindReload() {
 	for {
 		// Update once every other day
 		time.Sleep(time.Hour * 48)
-		localFile := param.GeoIPLocation.GetString()
+		localFile := param.Director_GeoIPLocation.GetString()
 		if err := DownloadDB(localFile); err != nil {
 			log.Warningln("Failed to download GeoIP database:", err)
 		} else {
@@ -201,7 +201,7 @@ func PeriodicMaxMindReload() {
 
 func InitializeDB() {
 	go PeriodicMaxMindReload()
-	localFile := param.GeoIPLocation.GetString()
+	localFile := param.Director_GeoIPLocation.GetString()
 	localReader, err := geoip2.Open(localFile)
 	if err != nil {
 		log.Warningln("Local GeoIP database file not present; will attempt a download.", err)

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -52,13 +52,6 @@ root_default: /etc/pelican/issuer.jwk
 default: $ConfigBase/issuer.jwk
 components: ["client", "nsregistry", "director"]
 ---
-name: WebAddress
-description: >-
-  A string-encoded IP address that the origin is configured to listen on.
-type: string
-default: 0.0.0.0
-components: ["origin"]
----
 
 ############################
 # Federation-Level Configs #
@@ -127,9 +120,23 @@ type: bool
 default: false
 components: ["client"]
 ---
+name: DisableHttpProxy
+description: >-
+  A legacy configuration for disabling the client's HTTP proxy. See Client.DisableHttpProxy for new config.
+type: bool
+default: false
+components: ["client"]
+---
 name: Client.DisableProxyFallback
 description: >-
   A bool indicating whether the a proxy fallback should be used by the client.
+type: bool
+default: false
+components: ["client"]
+---
+name: DisableProxyFallback
+description: >-
+  A legacy configuration for disabling the client's proxy fallback. See Client.DisableProxyFallback for new config.
 type: bool
 default: false
 components: ["client"]
@@ -141,10 +148,24 @@ type: int
 default: 102400
 components: ["client"]
 ---
+name: MinimumDownloadSpeed
+description: >-
+  A legacy configuration for setting the client's minimum download speed. See Client.MinimumDownloadSpeed for new config.
+type: int
+default: 102400
+components: ["client"]
+---
 
 ############################
 #   Origin-level Configs   #
 ############################
+name: Origin.Url
+description: >-
+  The origin's configured URL, as reported to XRootD.
+type: string
+default: Hostname
+components: ["origin"]
+---
 name: Origin.ExportVolume
 description: >-
   A path to the volume exported by an origin.
@@ -167,11 +188,25 @@ root_default: true
 default: false
 components: ["origin"]
 ---
+name: Origin.UseCmsd
+description: >-
+  A bool indicating whether the origin should use CMSD.
+type: bool
+default: true
+components: ["origin"]
+---
 name: Origin.UIPasswordFile
 description: >-
   A filepath specifying where the Origin UI password file should be stored.
 type: string
 default: $ConfigBase/origin-ui-passwd
+components: ["origin"]
+---
+name: Origin.SelfTest
+description: >-
+  A bool indicating whether the origin should perform self health checks.
+type: bool
+default: true
 components: ["origin"]
 ---
 
@@ -218,48 +253,6 @@ root_default: /var/lib/pelican/registry.sqlite
 default: $ConfigBase/ns-registry.sqlite
 components: ["nsregistry"]
 ---
-name: Registry.OIDCClientIDFile
-description: >-
-  A filepath to a file containing an OIDC Client ID. This is used by the namespace registry to establish OIDC information
-  for authenticated registration.
-type: filename
-root_default: /etc/pelican/oidc-client-id
-default: $ConfigBase/oidc-client-id
-components: ["nsregistry"]
----
-name: Registry.OIDCClientSecretFile
-description: >-
-  A filepath to a file containing an OIDC Client Secret. This is used by the namespace registry to establish OIDC information
-  for authenticated registration.
-type: filename
-root_default: /etc/pelican/oidc-client-secret
-default: $ConfigBase/oidc-client-secret
-components: ["nsregistry"]
----
-name: Registry.OIDCDeviceAuthEndpoint
-description: >-
-  A URL describing an OIDC Device Auth Endpoint. This is used by the namespace registry to establish OIDC information
-  for authenticated registration.
-type: url
-default: none
-components: ["nsregistry"]
----
-name: Registry.OIDCTokenEndpoint
-description: >-
-  A URL describing an OIDC Token Endpoint. This is used by the namespace registry to establish OIDC information
-  for authenticated registration.
-type: url
-default: none
-components: ["nsregistry"]
----
-name: Registry.OIDCUserInfoEndpoint
-description: >-
-  A URL describing an OIDC User Info Endpoint. This is used by the namespace registry to establish OIDC information
-  for authenticated registration.
-type: url
-default: none
-components: ["nsregistry"]
----
 
 ############################
 #   Server-level configs   #
@@ -273,6 +266,29 @@ root_default: /etc/pelican/certificates/tls.crt
 default: "$ConfigBase/certificates/tls.crt"
 components: ["origin", "nsregistry", "director"]
 ---
+name: Server.TLSCACertificateFile
+description: >-
+  A filepath for a TLS certificate to be used by XRootD.
+type: string
+default: /etc/pki/tls/cert.pem
+components: ["origin"]
+---
+name: Server.TLSCACertificateDirectory
+description: >-
+  A filepath to the directory used for storing TLS certificates
+type: string
+default: /etc/pki/tls/cert.pem
+components: ["origin"]
+---
+name: Server.TLSCAKey
+description: >-
+  The name of a file containing a private key corresponding to the TLSCACertificate.
+  Used when running server components of Pelican.
+type: filename
+root_default: /etc/pelican/certificates/tlsca.key
+default: "$ConfigBase/certificates/tlsca.key"
+components: ["origin", "nsregistry", "director"]
+---
 name: Server.TLSKey
 description: >-
   The name of a file containing a private key corresponding to the TLSCertificate.
@@ -282,12 +298,19 @@ root_default: /etc/pelican/certificates/tls.key
 default: "$ConfigBase/certificates/tls.key"
 components: ["origin", "nsregistry", "director"]
 ---
-name: Server.WebPort
+name: Server.Port
 description: >-
   The port number the Pelican web interface will be bound to.
 type: int
 default: 8444
 components: ["nsregistry", "director", "origin"]
+---
+name: Server.Address
+description: >-
+  A string-encoded IP address that the origin is configured to listen on.
+type: string
+default: 0.0.0.0
+components: ["origin"]
 ---
 name: Server.ExternalAddress
 description: >-
@@ -311,9 +334,62 @@ default: none
 components: ["origin", "director", "nsregistry"]
 ---
 
+
+
+
+name: OIDC.ClientIDFile
+description: >-
+  A filepath to a file containing an OIDC Client ID. This is used by the namespace registry to establish OIDC information
+  for authenticated registration.
+type: filename
+root_default: /etc/pelican/oidc-client-id
+default: $ConfigBase/oidc-client-id
+components: ["nsregistry"]
+---
+name: OIDC.ClientSecretFile
+description: >-
+  A filepath to a file containing an OIDC Client Secret. This is used by the namespace registry to establish OIDC information
+  for authenticated registration.
+type: filename
+root_default: /etc/pelican/oidc-client-secret
+default: $ConfigBase/oidc-client-secret
+components: ["nsregistry"]
+---
+name: OIDC.DeviceAuthEndpoint
+description: >-
+  A URL describing an OIDC Device Auth Endpoint. This is used by the namespace registry to establish OIDC information
+  for authenticated registration.
+type: url
+default: none
+components: ["nsregistry"]
+---
+name: OIDC.TokenEndpoint
+description: >-
+  A URL describing an OIDC Token Endpoint. This is used by the namespace registry to establish OIDC information
+  for authenticated registration.
+type: url
+default: none
+components: ["nsregistry"]
+---
+name: OIDC.UserInfoEndpoint
+description: >-
+  A URL describing an OIDC User Info Endpoint. This is used by the namespace registry to establish OIDC information
+  for authenticated registration.
+type: url
+default: none
+components: ["nsregistry"]
+---
+
 ############################
 #   XRootD-level Configs   #
 ############################
+name: Xrootd.Port
+description: >-
+  The port over which XRootD should be made available.
+type: int
+default: 8443
+components: ["origin"]
+---
 name: Xrootd.RunLocation
 description: >-
   A directory where temporary configurations will be stored for the xrootd daemon
@@ -397,13 +473,6 @@ type: url
 default: none
 components: ["origin"]
 ---
-name: Xrootd.TLSCertFile
-description: >-
-  A filepath for a TLS certificate to be used by XRootD.
-type: string
-default: /etc/pki/tls/cert.pem
-components: ["origin"]
----
 name: Xrootd.Sitename
 description: >-
   The sitename, as configured for XRootD.
@@ -413,9 +482,9 @@ components: ["origin"]
 ---
 
 ############################
-# Prometheus-level configs #
+# Monitoring-level configs #
 ############################
-name: Prometheus.MonitoringData
+name: Monitoring.DataLocation
 description: >-
   A filepath where Prometheus should host its monitoring data.
 type: string
@@ -423,14 +492,14 @@ root_default: /var/lib/pelican/monitoring/data
 default: $ConfigBase/monitoring/data
 components: ["origin"]
 ---
-name: Prometheus.MonitoringPortLower
+name: Monitoring.PortLower
 description: >-
   The lower end of a range of monitoring ports for Prometheus configuration.
 type: int
 default: 9930
 components: ["origin"]
 ---
-name: Prometheus.MonitoringPortHigher
+name: Monitoring.PortHigher
 description: >-
   The lower end of a range of monitoring ports for Prometheus configuration.
 type: int

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -17,6 +17,10 @@
 # This file contains structured documentation about the Pelican parameters.
 # While it is somewhat human-readable, it is meant to help with the documentation
 # generation.
+
+############################
+#     Top-Level Configs    #
+############################
 ---
 name: ConfigBase
 description: >-
@@ -26,23 +30,12 @@ default: "~/.config/pelican"
 components: ["*"]
 type: filename
 ---
-name: TLSCertificate
+name: Debug
 description: >-
-  The name of a file containing an X.509 host certificate to use for TLS
-  authentication when running server components of Pelican.
-type: filename
-root_default: /etc/pelican/certificates/tls.crt
-default: "$ConfigBase/certificates/tls.crt"
-components: ["origin", "nsregistry", "director"]
----
-name: TLSKey
-description: >-
-  The name of a file containing a private key corresponding to the TLSCertificate.
-  Used when running server components of Pelican.
-type: filename
-root_default: /etc/pelican/certificates/tls.key
-default: "$ConfigBase/certificates/tls.key"
-components: ["origin", "nsregistry", "director"]
+  A bool indicating whether Pelican should emit debug messages in its log.
+type: bool
+default: false
+components: ["*"]
 ---
 name: TLSSkipVerify
 description: >-
@@ -51,7 +44,277 @@ type: bool
 default: false
 components: ["origin", "nsregistry", "director"]
 ---
-name: XrootdRun
+name: IssuerKey
+description: >-
+  The name of the file containing a service's private `issuer.jwk` key.
+type: filename
+root_default: /etc/pelican/issuer.jwk
+default: $ConfigBase/issuer.jwk
+components: ["client", "nsregistry", "director"]
+---
+name: WebAddress
+description: >-
+  A string-encoded IP address that the origin is configured to listen on.
+type: string
+default: 0.0.0.0
+components: ["origin"]
+---
+
+############################
+# Federation-Level Configs #
+############################
+name: Federation.DiscoveryUrl
+description: >-
+  A URL pointing to the federation's metadata discovery host.
+type: url
+default: none
+components: ["*"]
+---
+name: Federation.TopologyNamespaceUrl
+description: >-
+  A URL containing namespace information for origins and caches configured via the OSG Topology application (a legacy integration). The URL
+  should point to the hosted namespace.json.
+type: url
+osdf_default: https://topology.opensciencegrid.org/stashcache/namespaces.json
+default: none
+components: ["director"]
+---
+name: Federation.DirectorUrl
+description: >-
+  A URL indicating where a director service is hosted.
+type: url
+osdf_default: Default is determined dynamically through metadata at <federation URL>/.well-known/pelican-configuration
+default: none
+components: ["client", "origin"]
+---
+name: Federation.NamespaceUrl
+description: >-
+  A URL indicating where the namespace registry service is hosted.
+type: url
+osdf_default: Default is determined dynamically through metadata at <federation URL>/.well-known/pelican-configuration
+default: none
+components: ["client", "director", "origin"]
+---
+
+############################
+#   Client-Level Configs   #
+############################
+name: Client.StoppedTransferTimeout
+description: >-
+  A timeout indicating when a "stopped transfer" event should be triggered.
+type: int
+default: 100
+components: ["client"]
+---
+name: Client.SlowTransferRampupTime
+description: >-
+  A duration indicating the rampup period for a slow transfer.
+type: int
+default: 30
+components: ["client"]
+---
+name: Client.SlowTransferWindow
+description: >-
+  A duration indicating the sliding window over which to consider transfer speeds for slow transfers.
+type: int
+default: 30
+components: ["client"]
+---
+name: Client.DisableHttpProxy
+description: >-
+  A bool indicating whether the client's HTTP proxy should be disabled.
+type: bool
+default: false
+components: ["client"]
+---
+name: Client.DisableProxyFallback
+description: >-
+  A bool indicating whether the a proxy fallback should be used by the client.
+type: bool
+default: false
+components: ["client"]
+---
+name: Client.MinimumDownloadSpeed
+description: >-
+  The minimum speed allowed for a client download before an error is thrown.
+type: int
+default: 102400
+components: ["client"]
+---
+
+############################
+#   Origin-level Configs   #
+############################
+name: Origin.ExportVolume
+description: >-
+  A path to the volume exported by an origin.
+type: string
+default: none
+components: ["origin"]
+---
+name: Origin.NamespacePrefix
+description: >-
+  The filepath prefix at which an origin's contents are made globally available, eg /pelican/PUBLIC.
+type: string
+default: none
+components: ["origin"]
+---
+name: Origin.Multiuser
+description: >-
+  A bool indicating whether an origin is "multiuser", ie whether the underlying XRootD instance must be configured in multi user mode.
+type: bool
+root_default: true
+default: false
+components: ["origin"]
+---
+name: Origin.UIPasswordFile
+description: >-
+  A filepath specifying where the Origin UI password file should be stored.
+type: string
+default: $ConfigBase/origin-ui-passwd
+components: ["origin"]
+---
+
+############################
+#  Director-level configs  #
+############################
+name: Director.DefaultResponse
+description: >-
+  The default response type of a redirect for a director instance. Can be either "cache" or "origin". If a director
+  is hosted at https://director.com, then a GET request to https://director.com/foo/bar.txt will either redirect to
+  the nearest cache for namespace /foo if Director.DefaultResponse is set to "cache" or to the origin for /foo if
+  it is set to "origin".
+type: string
+default: cache
+components: ["director"]
+---
+name: Director.MaxMindKeyFile
+description: >-
+  A filepath to a MaxMind API key. The director service uses the MaxMind GeoLite City database (available [here](https://dev.maxmind.com/geoip/docs/databases/city-and-country))
+  to determine which cache is nearest to a client's IP address. The database, if not already found, will be downloaded
+  automatically when a director is served and a valid key is present.
+type: url
+default: none
+components: ["director"]
+---
+name: Director.GeoIPLocation
+description: >-
+  A filepath to the intended location of the MaxMind GeoLite City database. This option can be used either to load
+  an existing database, or to configure the preferred download location if Pelican has a MaxMind API key.
+type: filename
+root_default: /var/cache/pelican/maxmind/GeoLite2-City.mmdb
+default: $ConfigBase/maxmind/GeoLite2-city.mmdb
+components: ["director"]
+---
+
+############################
+#  Registry-level configs  #
+############################
+name: Registry.DbLocation
+description: >-
+  A filepath to the intended location of the namespace registry's database.
+type: filename
+root_default: /var/lib/pelican/registry.sqlite
+default: $ConfigBase/ns-registry.sqlite
+components: ["nsregistry"]
+---
+name: Registry.OIDCClientIDFile
+description: >-
+  A filepath to a file containing an OIDC Client ID. This is used by the namespace registry to establish OIDC information
+  for authenticated registration.
+type: filename
+root_default: /etc/pelican/oidc-client-id
+default: $ConfigBase/oidc-client-id
+components: ["nsregistry"]
+---
+name: Registry.OIDCClientSecretFile
+description: >-
+  A filepath to a file containing an OIDC Client Secret. This is used by the namespace registry to establish OIDC information
+  for authenticated registration.
+type: filename
+root_default: /etc/pelican/oidc-client-secret
+default: $ConfigBase/oidc-client-secret
+components: ["nsregistry"]
+---
+name: Registry.OIDCDeviceAuthEndpoint
+description: >-
+  A URL describing an OIDC Device Auth Endpoint. This is used by the namespace registry to establish OIDC information
+  for authenticated registration.
+type: url
+default: none
+components: ["nsregistry"]
+---
+name: Registry.OIDCTokenEndpoint
+description: >-
+  A URL describing an OIDC Token Endpoint. This is used by the namespace registry to establish OIDC information
+  for authenticated registration.
+type: url
+default: none
+components: ["nsregistry"]
+---
+name: Registry.OIDCUserInfoEndpoint
+description: >-
+  A URL describing an OIDC User Info Endpoint. This is used by the namespace registry to establish OIDC information
+  for authenticated registration.
+type: url
+default: none
+components: ["nsregistry"]
+---
+
+############################
+#   Server-level configs   #
+############################
+name: Server.TLSCertificate
+description: >-
+  The name of a file containing an X.509 host certificate to use for TLS
+  authentication when running server components of Pelican.
+type: filename
+root_default: /etc/pelican/certificates/tls.crt
+default: "$ConfigBase/certificates/tls.crt"
+components: ["origin", "nsregistry", "director"]
+---
+name: Server.TLSKey
+description: >-
+  The name of a file containing a private key corresponding to the TLSCertificate.
+  Used when running server components of Pelican.
+type: filename
+root_default: /etc/pelican/certificates/tls.key
+default: "$ConfigBase/certificates/tls.key"
+components: ["origin", "nsregistry", "director"]
+---
+name: Server.WebPort
+description: >-
+  The port number the Pelican web interface will be bound to.
+type: int
+default: 8444
+components: ["nsregistry", "director", "origin"]
+---
+name: Server.ExternalAddress
+description: >-
+  A URL indicating the server's address as it appears externally.
+type: url
+default: none
+components: ["origin", "director", "nsregistry"]
+---
+name: Server.Hostname
+description: >-
+  The server's hostname
+type: url
+default: none
+components: ["origin", "director", "nsregistry"]
+---
+name: Server.IssuerJwks
+description: >-
+  A filepath indicating where the server's public JSON web keyset can be found.
+type: string
+default: none
+components: ["origin", "director", "nsregistry"]
+---
+
+############################
+#   XRootD-level Configs   #
+############################
+name: Xrootd.RunLocation
 description: >-
   A directory where temporary configurations will be stored for the xrootd daemon
   started by the origin.
@@ -63,7 +326,7 @@ root_default: /run/pelican/xrootd
 default: $XDG_RUNTIME_DIR/pelican
 components: ["origin"]
 ---
-name: RobotsTxtFile
+name: Xrootd.RobotsTxtFile
 description: >-
   Origins may be indexed by web search engines; to control the behavior of search
   engines, one may provide local policy via a [robots.txt file](https://en.wikipedia.org/wiki/Robots.txt).
@@ -75,7 +338,7 @@ root_default: /etc/pelican/robots.txt
 default: $ConfigBase/robots.txt
 components: ["origin"]
 ---
-name: ScitokensConfig
+name: Xrootd.ScitokensConfig
 description: >-
   The location of a file configuring xrootd's
   [token-based authorization subsystem](https://github.com/xrootd/xrootd/blob/master/src/XrdSciTokens/README.md).
@@ -85,120 +348,91 @@ type: filename
 root_default: /etc/pelican/xrootd/scitokens.cfg
 default: $ConfigBase/xrootd/scitokens.cfg
 ---
-name: Director.DefaultResponse
+name: Xrootd.Mount
 description: >-
-  The default response type of a redirect for a director instance. Can be either "cache" or "origin". If a director
-  is hosted at https://director.com, then a GET request to https://director.com/foo/bar.txt will either redirect to
-  the nearest cache for namespace /foo if Director.DefaultResponse is set to "cache" or to the origin for /foo if
-  it is set to "origin".
+  The mount path for an instance of XRootD.
 type: string
-default: cache
-components: ["director"]
----
-name: TopologyNamespaceURL
-description: >-
-  A URL containing namespace information for origins and caches configured via the OSG Topology application (a legacy integration). The URL
-  should point to the hosted namespace.json.
-type: url
-osdf_default: https://topology.opensciencegrid.org/stashcache/namespaces.json
 default: none
-components: ["director"]
+components: ["origin"]
 ---
-name: MaxMindKeyFile
+name: Xrootd.MacaroonsKeyFile
 description: >-
-  A filepath to a MaxMind API key. The director service uses the MaxMind GeoLite City database (available [here](https://dev.maxmind.com/geoip/docs/databases/city-and-country))
-  to determine which cache is nearest to a client's IP address. The database, if not already found, will be downloaded
-  automatically when a director is served and a valid key is present.
-type: url
+  The filepath to a Macaroons key for setting up authorization in XRootD.
+type: string
 default: none
-components: ["director"]
+components: ["origin"]
 ---
-name: GeoIPLocation
+name: Xrootd.Authfile
 description: >-
-  A filepath to the intended location of the MaxMind GeoLite City database. This option can be used either to load
-  an existing database, or to configure the preferred download location if Pelican has a MaxMind API key.
-type: filename
-root_default: /var/cache/pelican/maxmind/GeoLite2-City.mmdb
-default: $ConfigBase/maxmind/GeoLite2-city.mmdb
-components: ["director"]
----
-name: DirectorUrl
-description: >-
-  A URL indicating where a director service is hosted.
-type: url
-osdf_default: Default is determined dynamically through metadata at <federation URL>/.well-known/pelican-configuration
+  The filepath to an auth file for setting up authorization in XRootD.
+type: string
 default: none
-components: ["client", "origin"]
+components: ["origin"]
 ---
-name: NamespaceUrl
+name: Xrootd.ManagerHost
 description: >-
-  A URL indicating where the namespace registry service is hosted.
-type: url
-osdf_default: Default is determined dynamically through metadata at <federation URL>/.well-known/pelican-configuration
-default: none
-components: ["client", "director", "origin"]
----
-name: IssuerKey
-description: >-
-  The name of the file containing a service's private `issuer.jwk` key.
-type: filename
-root_default: /etc/pelican/issuer.jwk
-default: $ConfigBase/issuer.jwk
-components: ["client", "nsregistry", "director"]
----
-name: NSRegistryLocation
-description: >-
-  A filepath to the intended location of the namespace registry's database.
-type: filename
-root_default: /var/lib/pelican/registry.sqlite
-default: $ConfigBase/ns-registry.sqlite
-components: ["nsregistry"]
----
-name: OIDC.ClientIDFile
-description: >-
-  A filepath to a file containing an OIDC Client ID. This is used by the namespace registry to establish OIDC information
-  for authenticated registration.
-type: filename
-root_default: /etc/pelican/oidc-client-id
-default: $ConfigBase/oidc-client-id
-components: ["nsregistry"]
----
-name: OIDC.ClientSecretFile
-description: >-
-  A filepath to a file containing an OIDC Client Secret. This is used by the namespace registry to establish OIDC information
-  for authenticated registration.
-type: filename
-root_default: /etc/pelican/oidc-client-secret
-default: $ConfigBase/oidc-client-secret
-components: ["nsregistry"]
----
-name: OIDC.DeviceAuthEndpoint
-description: >-
-  A URL describing an OIDC Device Auth Endpoint. This is used by the namespace registry to establish OIDC information
-  for authenticated registration.
+  A URL pointing toward the XRootD instance's Manager Host.
 type: url
 default: none
-components: ["nsregistry"]
+components: ["origin"]
 ---
-name: OIDC.TokenEndpoint
+name: Xrootd.SummaryMonitoringHost
 description: >-
-  A URL describing an OIDC Token Endpoint. This is used by the namespace registry to establish OIDC information
-  for authenticated registration.
+  A URL pointing toward the XRootD instance's Summary Monitoring Host.
 type: url
 default: none
-components: ["nsregistry"]
+components: ["origin"]
 ---
-name: OIDC.UserInfoEndpoint
+name: Xrootd.DetailedMonitoringHost
 description: >-
-  A URL describing an OIDC User Info Endpoint. This is used by the namespace registry to establish OIDC information
-  for authenticated registration.
+  A URL pointing toward the XRootD instance's Detailed Monitoring Host.
 type: url
 default: none
-components: ["nsregistry"]
+components: ["origin"]
 ---
-name: WebPort
+name: Xrootd.LocalMonitoringHost
 description: >-
-  The port number the Pelican web interface will be bound to.
+  A URL pointing toward the XRootD instance's Local Monitoring Host.
+type: url
+default: none
+components: ["origin"]
+---
+name: Xrootd.TLSCertFile
+description: >-
+  A filepath for a TLS certificate to be used by XRootD.
+type: string
+default: /etc/pki/tls/cert.pem
+components: ["origin"]
+---
+name: Xrootd.Sitename
+description: >-
+  The sitename, as configured for XRootD.
+type: string
+default: none
+components: ["origin"]
+---
+
+############################
+# Prometheus-level configs #
+############################
+name: Prometheus.MonitoringData
+description: >-
+  A filepath where Prometheus should host its monitoring data.
+type: string
+root_default: /var/lib/pelican/monitoring/data
+default: $ConfigBase/monitoring/data
+components: ["origin"]
+---
+name: Prometheus.MonitoringPortLower
+description: >-
+  The lower end of a range of monitoring ports for Prometheus configuration.
 type: int
-default: 8444
-components: ["nsregistry", "director", "origin"]
+default: 9930
+components: ["origin"]
+---
+name: Prometheus.MonitoringPortHigher
+description: >-
+  The lower end of a range of monitoring ports for Prometheus configuration.
+type: int
+default: 9999
+components: ["origin"]

--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -30,11 +30,11 @@ import (
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
+	"github.com/pelicanplatform/pelican/param"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 type (
@@ -154,8 +154,8 @@ var (
 )
 
 func ConfigureMonitoring() (int, error) {
-	lower := viper.GetInt("MonitoringPortLower")
-	higher := viper.GetInt("MonitoringPortHigher")
+	lower := param.Prometheus_MonitoringPortLower.GetInt()
+	higher := param.Prometheus_MonitoringPortHigher.GetInt()
 
 	addr := net.UDPAddr{IP: net.ParseIP("127.0.0.1")}
 	var conn *net.UDPConn

--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -154,8 +154,8 @@ var (
 )
 
 func ConfigureMonitoring() (int, error) {
-	lower := param.Prometheus_MonitoringPortLower.GetInt()
-	higher := param.Prometheus_MonitoringPortHigher.GetInt()
+	lower := param.Monitoring_PortLower.GetInt()
+	higher := param.Monitoring_PortHigher.GetInt()
 
 	addr := net.UDPAddr{IP: net.ParseIP("127.0.0.1")}
 	var conn *net.UDPConn

--- a/namespace-registry/registry-db.go
+++ b/namespace-registry/registry-db.go
@@ -166,7 +166,7 @@ func getAllNamespaces() ([]*Namespace, error) {
 }
 
 func InitializeDB() error {
-	dbPath := param.NSRegistryLocation.GetString()
+	dbPath := param.Registry_DbLocation.GetString()
 	if dbPath == "" {
 		err := errors.New("Could not get path for the namespace registry database.")
 		log.Fatal(err)

--- a/namespace-registry/registry.go
+++ b/namespace-registry/registry.go
@@ -137,23 +137,23 @@ func loadServerKeys() (*ecdsa.PrivateKey, error) {
 
 func loadOIDC() error {
 	// Load OIDC.ClientID
-	OIDCClientIDFile := param.Registry_OIDCClientIDFile.GetString()
+	OIDCClientIDFile := param.OIDC_ClientIDFile.GetString()
 	OIDCClientIDFromEnv := viper.GetString("OIDCCLIENTID")
 	if OIDCClientIDFile != "" {
 		contents, err := os.ReadFile(OIDCClientIDFile)
 		if err != nil {
-			return errors.Wrapf(err, "Failed reading provided Registry.OIDCClientIDFile %s", OIDCClientIDFile)
+			return errors.Wrapf(err, "Failed reading provided OIDC.ClientIDFile %s", OIDCClientIDFile)
 		}
 		OIDC.ClientID = strings.TrimSpace(string(contents))
 	} else if OIDCClientIDFromEnv != "" {
 		OIDC.ClientID = OIDCClientIDFromEnv
 	} else {
-		return errors.New("An OIDC Client Identity file must be specified in the config (Registry.OIDCClientIDFile)," +
+		return errors.New("An OIDC Client Identity file must be specified in the config (OIDC.ClientIDFile)," +
 			" or the identity must be provided via the environment variable PELICAN_OIDCCLIENTID")
 	}
 
 	// load OIDC.ClientSecret
-	OIDCClientSecretFile := param.Registry_OIDCClientSecretFile.GetString()
+	OIDCClientSecretFile := param.OIDC_ClientSecretFile.GetString()
 	OIDCClientSecretFromEnv := viper.GetString("OIDCCLIENTSECRET")
 	if OIDCClientSecretFile != "" {
 		contents, err := os.ReadFile(OIDCClientSecretFile)
@@ -164,40 +164,40 @@ func loadOIDC() error {
 	} else if OIDCClientSecretFromEnv != "" {
 		OIDC.ClientSecret = OIDCClientSecretFromEnv
 	} else {
-		return errors.New("An OIDC Client Secret file must be specified in the config (Registry.OIDCClientSecretFile)," +
+		return errors.New("An OIDC Client Secret file must be specified in the config (OIDC.ClientSecretFile)," +
 			" or the secret must be provided via the environment variable PELICAN_OIDCCLIENTSECRET")
 	}
 
 	// Load OIDC.DeviceAuthEndpoint
-	deviceAuthEndpoint := param.Registry_OIDCDeviceAuthEndpoint.GetString()
+	deviceAuthEndpoint := param.OIDC_DeviceAuthEndpoint.GetString()
 	if deviceAuthEndpoint == "" {
-		return errors.New("Nothing set for config parameter Registry.OIDCDeviceAuthEndpoint, so registration with identity not supported")
+		return errors.New("Nothing set for config parameter OIDC.DeviceAuthEndpoint, so registration with identity not supported")
 	}
 	deviceAuthEndpointURL, err := url.Parse(deviceAuthEndpoint)
 	if err != nil {
-		return errors.New("Failed to parse URL for parameter Registry.OIDCDeviceAuthEndpoint")
+		return errors.New("Failed to parse URL for parameter OIDC.DeviceAuthEndpoint")
 	}
 	OIDC.DeviceAuthEndpoint = deviceAuthEndpointURL.String()
 
 	// Load OIDC.TokenEndpoint
-	tokenEndpoint := param.Registry_OIDCTokenEndpoint.GetString()
+	tokenEndpoint := param.OIDC_TokenEndpoint.GetString()
 	if tokenEndpoint == "" {
-		return errors.New("Nothing set for config parameter Registry.OIDCTokenEndpoint, so registration with identity not supported")
+		return errors.New("Nothing set for config parameter OIDC.TokenEndpoint, so registration with identity not supported")
 	}
 	tokenAuthEndpointURL, err := url.Parse(tokenEndpoint)
 	if err != nil {
-		return errors.New("Failed to parse URL for parameter Registry.OIDCTokenEndpoint")
+		return errors.New("Failed to parse URL for parameter OIDC.TokenEndpoint")
 	}
 	OIDC.TokenEndpoint = tokenAuthEndpointURL.String()
 
 	// Load OIDC.UserInfoEndpoint
-	userInfoEndpoint := param.Registry_OIDCTokenEndpoint.GetString()
+	userInfoEndpoint := param.OIDC_TokenEndpoint.GetString()
 	if userInfoEndpoint == "" {
-		return errors.New("Nothing set for config parameter Registry.OIDCUserInfoEndpoint, so registration with identity not supported")
+		return errors.New("Nothing set for config parameter OIDC.UserInfoEndpoint, so registration with identity not supported")
 	}
 	userInfoEndpointURL, err := url.Parse(userInfoEndpoint)
 	if err != nil {
-		return errors.New("Failed to parse URL for parameter Registry.OIDCUserInfoEndpoint")
+		return errors.New("Failed to parse URL for parameter OIDC.UserInfoEndpoint")
 	}
 	OIDC.UserInfoEndpoint = userInfoEndpointURL.String()
 

--- a/namespace-registry/registry.go
+++ b/namespace-registry/registry.go
@@ -137,23 +137,23 @@ func loadServerKeys() (*ecdsa.PrivateKey, error) {
 
 func loadOIDC() error {
 	// Load OIDC.ClientID
-	OIDCClientIDFile := param.OIDC_ClientIDFile.GetString()
+	OIDCClientIDFile := param.Registry_OIDCClientIDFile.GetString()
 	OIDCClientIDFromEnv := viper.GetString("OIDCCLIENTID")
 	if OIDCClientIDFile != "" {
 		contents, err := os.ReadFile(OIDCClientIDFile)
 		if err != nil {
-			return errors.Wrapf(err, "Failed reading provided OIDC.ClientIDFile %s", OIDCClientIDFile)
+			return errors.Wrapf(err, "Failed reading provided Registry.OIDCClientIDFile %s", OIDCClientIDFile)
 		}
 		OIDC.ClientID = strings.TrimSpace(string(contents))
 	} else if OIDCClientIDFromEnv != "" {
 		OIDC.ClientID = OIDCClientIDFromEnv
 	} else {
-		return errors.New("An OIDC Client Identity file must be specified in the config (OIDC.ClientIDFile)," +
+		return errors.New("An OIDC Client Identity file must be specified in the config (Registry.OIDCClientIDFile)," +
 			" or the identity must be provided via the environment variable PELICAN_OIDCCLIENTID")
 	}
 
 	// load OIDC.ClientSecret
-	OIDCClientSecretFile := param.OIDC_ClientSecretFile.GetString()
+	OIDCClientSecretFile := param.Registry_OIDCClientSecretFile.GetString()
 	OIDCClientSecretFromEnv := viper.GetString("OIDCCLIENTSECRET")
 	if OIDCClientSecretFile != "" {
 		contents, err := os.ReadFile(OIDCClientSecretFile)
@@ -164,40 +164,40 @@ func loadOIDC() error {
 	} else if OIDCClientSecretFromEnv != "" {
 		OIDC.ClientSecret = OIDCClientSecretFromEnv
 	} else {
-		return errors.New("An OIDC Client Secret file must be specified in the config (OIDC.ClientSecretFile)," +
+		return errors.New("An OIDC Client Secret file must be specified in the config (Registry.OIDCClientSecretFile)," +
 			" or the secret must be provided via the environment variable PELICAN_OIDCCLIENTSECRET")
 	}
 
 	// Load OIDC.DeviceAuthEndpoint
-	deviceAuthEndpoint := param.OIDC_DeviceAuthEndpoint.GetString()
+	deviceAuthEndpoint := param.Registry_OIDCDeviceAuthEndpoint.GetString()
 	if deviceAuthEndpoint == "" {
-		return errors.New("Nothing set for config parameter OIDC.DeviceAuthEndpoint, so registration with identity not supported")
+		return errors.New("Nothing set for config parameter Registry.OIDCDeviceAuthEndpoint, so registration with identity not supported")
 	}
 	deviceAuthEndpointURL, err := url.Parse(deviceAuthEndpoint)
 	if err != nil {
-		return errors.New("Failed to parse URL for parameter OIDC.DeviceAuthEndpoint")
+		return errors.New("Failed to parse URL for parameter Registry.OIDCDeviceAuthEndpoint")
 	}
 	OIDC.DeviceAuthEndpoint = deviceAuthEndpointURL.String()
 
 	// Load OIDC.TokenEndpoint
-	tokenEndpoint := param.OIDC_TokenEndpoint.GetString()
+	tokenEndpoint := param.Registry_OIDCTokenEndpoint.GetString()
 	if tokenEndpoint == "" {
-		return errors.New("Nothing set for config parameter OIDC.TokenEndpoint, so registration with identity not supported")
+		return errors.New("Nothing set for config parameter Registry.OIDCTokenEndpoint, so registration with identity not supported")
 	}
 	tokenAuthEndpointURL, err := url.Parse(tokenEndpoint)
 	if err != nil {
-		return errors.New("Failed to parse URL for parameter OIDC.TokenEndpoint")
+		return errors.New("Failed to parse URL for parameter Registry.OIDCTokenEndpoint")
 	}
 	OIDC.TokenEndpoint = tokenAuthEndpointURL.String()
 
 	// Load OIDC.UserInfoEndpoint
-	userInfoEndpoint := param.OIDC_TokenEndpoint.GetString()
+	userInfoEndpoint := param.Registry_OIDCTokenEndpoint.GetString()
 	if userInfoEndpoint == "" {
-		return errors.New("Nothing set for config parameter OIDC.UserInfoEndpoint, so registration with identity not supported")
+		return errors.New("Nothing set for config parameter Registry.OIDCUserInfoEndpoint, so registration with identity not supported")
 	}
 	userInfoEndpointURL, err := url.Parse(userInfoEndpoint)
 	if err != nil {
-		return errors.New("Failed to parse URL for parameter OIDC.UserInfoEndpoint")
+		return errors.New("Failed to parse URL for parameter Registry.OIDCUserInfoEndpoint")
 	}
 	OIDC.UserInfoEndpoint = userInfoEndpointURL.String()
 

--- a/namespaces/namespaces.go
+++ b/namespaces/namespaces.go
@@ -182,12 +182,12 @@ func GetNamespaces() ([]Namespace, error) {
 // downloadNamespace downloads the namespace information with timeouts
 func downloadNamespace() ([]byte, error) {
 	// Get the namespace url from the environment
-	namespaceUrl := param.TopologyNamespaceURL.GetString()
-	if len(namespaceUrl) == 0 {
-		return nil, errors.New("NamespaceURL is not set; unable to locate valid caches")
+	topoNamespaceUrl := param.Federation_TopologyNamespaceUrl.GetString()
+	if len(topoNamespaceUrl) == 0 {
+		return nil, errors.New("Federation.TopologyNamespaceUrl is not set; unable to locate valid caches")
 	}
-	log.Debugln("Downloading namespaces information from", namespaceUrl)
-	resp, err := http.Get(namespaceUrl)
+	log.Debugln("Downloading namespaces information from", topoNamespaceUrl)
+	resp, err := http.Get(topoNamespaceUrl)
 	if err != nil {
 		return nil, err
 	}

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -26,13 +26,11 @@ import (
 	"net/url"
 	"time"
 
-	client "github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/director"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 type directorResponse struct {
@@ -67,7 +65,7 @@ func AdvertiseOrigin() error {
 	// TODO: waiting on a different branch to merge origin URL generation
 	// The checkdefaults func that runs before the origin is served checks for and
 	// parses the originUrl, so it should be safe to just grab it as a string here.
-	originUrl := viper.GetString("OriginUrl")
+	originUrl := param.Origin_Url.GetString()
 
 	// Here we instantiate the namespaceAd slice, but we still need to define the namespace
 	namespaceUrl, err := url.Parse(param.Federation_NamespaceUrl.GetString())

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/director"
 	"github.com/pelicanplatform/pelican/param"

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -59,7 +59,7 @@ func PeriodicAdvertiseOrigin() error {
 }
 
 func AdvertiseOrigin() error {
-	name := viper.GetString("Sitename")
+	name := param.Xrootd_Sitename.GetString()
 	if name == "" {
 		return errors.New("Origin name isn't set")
 	}
@@ -70,7 +70,7 @@ func AdvertiseOrigin() error {
 	originUrl := viper.GetString("OriginUrl")
 
 	// Here we instantiate the namespaceAd slice, but we still need to define the namespace
-	namespaceUrl, err := url.Parse(param.NamespaceUrl.GetString())
+	namespaceUrl, err := url.Parse(param.Federation_NamespaceUrl.GetString())
 	if err != nil {
 		return errors.Wrap(err, "Bad NamespaceUrl")
 	}
@@ -78,7 +78,7 @@ func AdvertiseOrigin() error {
 		return errors.New("No NamespaceUrl is set")
 	}
 
-	prefix := viper.GetString("NamespacePrefix")
+	prefix := param.Origin_NamespacePrefix.GetString()
 
 	// TODO: Need to figure out where to get some of these values
 	// 		 so that they aren't hardcoded...
@@ -101,13 +101,13 @@ func AdvertiseOrigin() error {
 		return errors.Wrap(err, "Failed to generate JSON description of origin")
 	}
 
-	directorUrlStr := param.DirectorUrl.GetString()
+	directorUrlStr := param.Federation_DirectorUrl.GetString()
 	if directorUrlStr == "" {
 		return errors.New("Director endpoint URL is not known")
 	}
 	directorUrl, err := url.Parse(directorUrlStr)
 	if err != nil {
-		return errors.Wrap(err, "Failed to parse DirectorURL")
+		return errors.Wrap(err, "Failed to parse Federation.DirectorURL")
 	}
 	directorUrl.Path = "/api/v1.0/director/registerOrigin"
 

--- a/origin_ui/origin.go
+++ b/origin_ui/origin.go
@@ -43,7 +43,6 @@ import (
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	"github.com/tg123/go-htpasswd"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/term"
@@ -103,8 +102,8 @@ func WaitUntilLogin() error {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
-	hostname := viper.GetString("Hostname")
-	webPort := param.WebPort.GetInt()
+	hostname := param.Server_Hostname.GetString()
+	webPort := param.Server_WebPort.GetInt()
 	isTTY := false
 	if term.IsTerminal(int(os.Stdout.Fd())) {
 		isTTY = true
@@ -142,7 +141,7 @@ func WaitUntilLogin() error {
 }
 
 func writePasswordEntry(user, password string) error {
-	fileName := viper.GetString("OriginUI.PasswordFile")
+	fileName := param.Origin_UIPasswordFile.GetString()
 	passwordBytes := []byte(password)
 	if len(passwordBytes) > 72 {
 		return errors.New("Password too long")
@@ -177,7 +176,7 @@ func writePasswordEntry(user, password string) error {
 }
 
 func configureAuthDB() error {
-	fileName := viper.GetString("OriginUI.PasswordFile")
+	fileName := param.Origin_UIPasswordFile.GetString()
 	if fileName == "" {
 		return errors.New("Location of password file not set")
 	}

--- a/origin_ui/origin.go
+++ b/origin_ui/origin.go
@@ -103,7 +103,7 @@ func WaitUntilLogin() error {
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
 	hostname := param.Server_Hostname.GetString()
-	webPort := param.Server_WebPort.GetInt()
+	port := param.Server_Port.GetInt()
 	isTTY := false
 	if term.IsTerminal(int(os.Stdout.Fd())) {
 		isTTY = true
@@ -119,10 +119,10 @@ func WaitUntilLogin() error {
 			fmt.Printf("\033[2K\n")
 			fmt.Printf("\033[2K\rPelican admin interface is not initialized\n\033[2KTo initialize, "+
 				"login at \033[1;34mhttps://%v:%v/view/initialization/code/\033[0m with the following code:\n",
-				hostname, webPort)
+				hostname, port)
 			fmt.Printf("\033[2K\r\033[1;34m%v\033[0m\n", *currentCode.Load())
 		} else {
-			fmt.Printf("Pelican admin interface is not initialized\n To initialize, login at https://%v:%v/view/initialization/code/ with the following code:\n", hostname, webPort)
+			fmt.Printf("Pelican admin interface is not initialized\n To initialize, login at https://%v:%v/view/initialization/code/ with the following code:\n", hostname, port)
 			fmt.Println(*currentCode.Load())
 		}
 		start := time.Now()

--- a/origin_ui/origin_test.go
+++ b/origin_ui/origin_test.go
@@ -50,7 +50,7 @@ func TestMain(m *testing.M) {
 	}
 	tempPasswdFile = tempFile
 	//Override viper default for testing
-	viper.Set("OriginUI.PasswordFile", tempPasswdFile.Name())
+	viper.Set("Origin.UIPasswordFile", tempPasswdFile.Name())
 
 	//Make a testing issuer.jwk file to get a cookie
 	tempJWKDir, err := os.MkdirTemp("", "tempDir")

--- a/origin_ui/self_monitor.go
+++ b/origin_ui/self_monitor.go
@@ -34,9 +34,9 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/metrics"
+	"github.com/pelicanplatform/pelican/param"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -44,7 +44,7 @@ var (
 )
 
 func generateMonitoringScitoken() (string, error) {
-	originUrl := viper.GetString("OriginUrl")
+	originUrl := param.Origin_Url.GetString()
 	if originUrl == "" {
 		return "", errors.New("Internal error: the Pelican origin does not know its own URL")
 	}
@@ -128,7 +128,7 @@ func UploadTestfile() (string, error) {
 		return "", errors.Wrap(err, "Failed to create a token for the internal monitoring upload")
 	}
 
-	uploadURL, err := url.Parse(viper.GetString("OriginUrl"))
+	uploadURL, err := url.Parse(param.Origin_Url.GetString())
 	if err != nil {
 		return "", errors.Wrap(err, "The origin URL is not parseable as a URL")
 	}
@@ -186,7 +186,7 @@ func DeleteTestfile(url string) error {
 }
 
 func ConfigureXrootdMonitoringDir() error {
-	pelicanMonitoringPath := filepath.Join(viper.GetString("XrootdRun"),
+	pelicanMonitoringPath := filepath.Join(param.Xrootd_RunLocation.GetString(),
 		"export", "pelican", "monitoring")
 
 	uid, err := config.GetDaemonUID()

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -256,9 +256,9 @@ func checkPromToken(av1 *route.Router) gin.HandlerFunc {
 func ConfigureEmbeddedPrometheus(engine *gin.Engine) error {
 
 	cfg := flagConfig{}
-	ListenAddress := fmt.Sprintf("0.0.0.0:%v", param.Server_WebPort.GetInt())
+	ListenAddress := fmt.Sprintf("0.0.0.0:%v", param.Server_Port.GetInt())
 	cfg.webTimeout = model.Duration(5 * time.Minute)
-	cfg.serverStoragePath = param.Prometheus_MonitoringData.GetString()
+	cfg.serverStoragePath = param.Monitoring_DataLocation.GetString()
 	cfg.tsdb.MinBlockDuration = model.Duration(2 * time.Hour)
 	cfg.tsdb.NoLockfile = false
 	cfg.tsdb.WALCompression = true

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -48,7 +48,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/version"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	"go.uber.org/atomic"
 
 	common_config "github.com/prometheus/common/config"
@@ -257,9 +256,9 @@ func checkPromToken(av1 *route.Router) gin.HandlerFunc {
 func ConfigureEmbeddedPrometheus(engine *gin.Engine) error {
 
 	cfg := flagConfig{}
-	ListenAddress := fmt.Sprintf("0.0.0.0:%v", param.WebPort.GetInt())
+	ListenAddress := fmt.Sprintf("0.0.0.0:%v", param.Server_WebPort.GetInt())
 	cfg.webTimeout = model.Duration(5 * time.Minute)
-	cfg.serverStoragePath = viper.GetString("MonitoringData")
+	cfg.serverStoragePath = param.Prometheus_MonitoringData.GetString()
 	cfg.tsdb.MinBlockDuration = model.Duration(2 * time.Hour)
 	cfg.tsdb.NoLockfile = false
 	cfg.tsdb.WALCompression = true

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -170,7 +170,7 @@ func checkPromToken(av1 *route.Router) gin.HandlerFunc {
 			c.JSON(400, gin.H{"error": "Failed to parse token"})
 		}
 
-		fedURL := viper.GetString("FederationURL")
+		fedURL := param.Federation_DiscoveryUrl.GetString()
 
 		var bKey *jwk.Key
 		if fedURL == token.Issuer() {
@@ -178,7 +178,7 @@ func checkPromToken(av1 *route.Router) gin.HandlerFunc {
 			if err != nil {
 				c.JSON(400, gin.H{"error": "Failed to discover the federation information"})
 			}
-			fedURIFile := viper.GetString("FederationURI")
+			fedURIFile := param.Federation_DiscoveryUrl.GetString()
 			response, err := http.Get(fedURIFile)
 			if err != nil {
 				c.JSON(400, gin.H{"error": "Failed to get federation key file"})

--- a/web_ui/prometheus_test.go
+++ b/web_ui/prometheus_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
 	"github.com/prometheus/common/route"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -49,7 +49,7 @@ func TestPrometheusProtectionFederationURL(t *testing.T) {
 	c, r := gin.CreateTestContext(w)
 	// Note, this handler function intercepts the "http.Get call to the federation uri
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		issuerKeyFile := viper.GetString("IssuerKey")
+		issuerKeyFile := param.IssuerKey.GetString()
 		contents, err := os.ReadFile(issuerKeyFile)
 		if err != nil {
 			t.Fatal(err)
@@ -101,7 +101,7 @@ func TestPrometheusProtectionFederationURL(t *testing.T) {
 	}
 	jti := base64.RawURLEncoding.EncodeToString(jti_bytes)
 
-	originUrl := viper.GetString("OriginURL")
+	originUrl := param.Origin_Url.GetString
 	tok, err := jwt.NewBuilder().
 		Claim("scope", "prometheus.read").
 		Claim("wlcg.ver", "1.0").
@@ -193,7 +193,7 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 	}
 	jti := base64.RawURLEncoding.EncodeToString(jti_bytes)
 
-	originUrl := viper.GetString("OriginURL")
+	originUrl := param.Origin_Url.GetString
 	tok, err := jwt.NewBuilder().
 		Claim("scope", "prometheus.read").
 		Claim("wlcg.ver", "1.0").

--- a/web_ui/prometheus_test.go
+++ b/web_ui/prometheus_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/prometheus/common/route"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -101,7 +102,7 @@ func TestPrometheusProtectionFederationURL(t *testing.T) {
 	}
 	jti := base64.RawURLEncoding.EncodeToString(jti_bytes)
 
-	originUrl := param.Origin_Url.GetString
+	originUrl := param.Origin_Url.GetString()
 	tok, err := jwt.NewBuilder().
 		Claim("scope", "prometheus.read").
 		Claim("wlcg.ver", "1.0").
@@ -193,7 +194,7 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 	}
 	jti := base64.RawURLEncoding.EncodeToString(jti_bytes)
 
-	originUrl := param.Origin_Url.GetString
+	originUrl := param.Origin_Url.GetString()
 	tok, err := jwt.NewBuilder().
 		Claim("scope", "prometheus.read").
 		Claim("wlcg.ver", "1.0").

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -74,7 +74,7 @@ func RunEngine(engine *gin.Engine) {
 	certFile := param.Server_TLSCertificate.GetString()
 	keyFile := param.Server_TLSKey.GetString()
 
-	addr := fmt.Sprintf("%v:%v", param.WebAddress.GetString(), param.Server_WebPort.GetInt())
+	addr := fmt.Sprintf("%v:%v", param.Server_Address.GetString(), param.Server_Port.GetInt())
 
 	log.Debugln("Starting web engine at address", addr)
 	err := engine.RunTLS(addr, certFile, keyFile)

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/param"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	ginprometheus "github.com/zsais/go-gin-prometheus"
 )
 
@@ -72,10 +71,10 @@ func GetEngine() (*gin.Engine, error) {
 }
 
 func RunEngine(engine *gin.Engine) {
-	certFile := param.TLSCertificate.GetString()
-	keyFile := param.TLSKey.GetString()
+	certFile := param.Server_TLSCertificate.GetString()
+	keyFile := param.Server_TLSKey.GetString()
 
-	addr := fmt.Sprintf("%v:%v", viper.GetString("WebAddress"), param.WebPort.GetInt())
+	addr := fmt.Sprintf("%v:%v", param.WebAddress.GetString(), param.Server_WebPort.GetInt())
 
 	log.Debugln("Starting web engine at address", addr)
 	err := engine.RunTLS(addr, certFile, keyFile)

--- a/xrootd/authorization.go
+++ b/xrootd/authorization.go
@@ -94,7 +94,7 @@ func EmitScitokensConfiguration(cfg *ScitokensCfg) error {
 		return err
 	}
 
-	xrootdRun := param.XrootdRun.GetString()
+	xrootdRun := param.Xrootd_RunLocation.GetString()
 	configPath := filepath.Join(xrootdRun, "scitokens-generated.cfg.tmp")
 	file, err := os.OpenFile(configPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
 	if err != nil {
@@ -256,7 +256,7 @@ func WriteOriginScitokensConfig() error {
 	}
 
 	// Create the scitokens.cfg file if it's not already present
-	scitokensCfg := param.ScitokensConfig.GetString()
+	scitokensCfg := param.Xrootd_ScitokensConfig.GetString()
 	err = config.MkdirAll(filepath.Dir(scitokensCfg), 0755, -1, gid)
 	if err != nil {
 		return errors.Wrapf(err, "Unable to create directory %v",

--- a/xrootd/authorization.go
+++ b/xrootd/authorization.go
@@ -39,7 +39,6 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
 )
 
 type (
@@ -124,7 +123,7 @@ func EmitScitokensConfiguration(cfg *ScitokensCfg) error {
 // Parse the input xrootd authfile, add any default configurations, and then save it
 // into the xrootd runtime directory
 func EmitAuthfile() error {
-	authfile := viper.GetString("Authfile")
+	authfile := param.Xrootd_Authfile.GetString()
 	contents, err := os.ReadFile(authfile)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to read xrootd authfile from %s", authfile)
@@ -152,7 +151,7 @@ func EmitAuthfile() error {
 		return err
 	}
 
-	xrootdRun := viper.GetString("XrootdRun")
+	xrootdRun := param.Xrootd_RunLocation.GetString()
 	finalAuthPath := filepath.Join(xrootdRun, "authfile-generated")
 	file, err := os.OpenFile(finalAuthPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
 	if err != nil {
@@ -236,11 +235,11 @@ func LoadScitokensConfig(fileName string) (cfg ScitokensCfg, err error) {
 
 // We have a special issuer just for self-monitoring the origin.
 func GenerateMonitoringIssuer() (issuer Issuer, err error) {
-	if val := viper.GetBool("Origin.SelfTest"); !val {
+	if val := param.Origin_SelfTest.GetBool(); !val {
 		return
 	}
 	issuer.Name = "Built-in Monitoring"
-	issuer.Issuer = viper.GetString("OriginUrl")
+	issuer.Issuer = param.Origin_Url.GetString()
 	issuer.BasePaths = []string{"/pelican/monitoring"}
 	issuer.DefaultUser = "xrootd"
 
@@ -322,7 +321,7 @@ func EmitIssuerMetadata(exportPath string) error {
 	}
 	defer openidFile.Close()
 
-	originUrlStr := viper.GetString("OriginUrl")
+	originUrlStr := param.Origin_Url.GetString()
 	jwksUrl, err := url.Parse(originUrlStr)
 	if err != nil {
 		return err
@@ -330,7 +329,7 @@ func EmitIssuerMetadata(exportPath string) error {
 	jwksUrl.Path = "/.well-known/issuer.jwks"
 
 	cfg := openIdConfig{
-		Issuer:  viper.GetString("OriginUrl"),
+		Issuer:  param.Origin_Url.GetString(),
 		JWKSURI: jwksUrl.String(),
 	}
 	buf, err = json.MarshalIndent(cfg, "", " ")

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -125,8 +125,7 @@ func TestGenerateConfig(t *testing.T) {
 	issuer, err = GenerateMonitoringIssuer()
 	require.NoError(t, err)
 	assert.Equal(t, issuer.Name, "Built-in Monitoring")
-
-	assert.Equal(t, issuer.Issuer, "https://"+param.Server_Hostname.GetString()+":"+fmt.Sprint(param.Server_WebPort.GetInt()))
+	assert.Equal(t, issuer.Issuer, "https://"+param.Server_Hostname.GetString()+":"+fmt.Sprint(param.Xrootd_Port.GetInt()))
 	require.Equal(t, len(issuer.BasePaths), 1)
 	assert.Equal(t, issuer.BasePaths[0], "/pelican/monitoring")
 	assert.Equal(t, issuer.DefaultUser, "xrootd")

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -56,9 +56,8 @@ var (
 
 func TestEmitCfg(t *testing.T) {
 	dirname := t.TempDir()
-	os.Setenv("PELICAN_XROOTDRUN", dirname)
-	defer os.Unsetenv("PELICAN_XROOTDRUN")
 	viper.Reset()
+	viper.Set("Xrootd.RunLocation", dirname)
 	err := config.InitClient()
 	assert.Nil(t, err)
 
@@ -85,9 +84,8 @@ func TestEmitCfg(t *testing.T) {
 
 func TestLoadScitokensConfig(t *testing.T) {
 	dirname := t.TempDir()
-	os.Setenv("PELICAN_XROOTDRUN", dirname)
-	defer os.Unsetenv("PELICAN_XROOTDRUN")
 	viper.Reset()
+	viper.Set("Xrootd.RunLocation", dirname)
 	err := config.InitClient()
 	assert.Nil(t, err)
 
@@ -127,7 +125,8 @@ func TestGenerateConfig(t *testing.T) {
 	issuer, err = GenerateMonitoringIssuer()
 	require.NoError(t, err)
 	assert.Equal(t, issuer.Name, "Built-in Monitoring")
-	assert.Equal(t, issuer.Issuer, "https://"+viper.GetString("Hostname")+":"+fmt.Sprint(viper.GetInt("Port")))
+
+	assert.Equal(t, issuer.Issuer, "https://"+param.Server_Hostname.GetString()+":"+fmt.Sprint(param.Server_WebPort.GetInt()))
 	require.Equal(t, len(issuer.BasePaths), 1)
 	assert.Equal(t, issuer.BasePaths[0], "/pelican/monitoring")
 	assert.Equal(t, issuer.DefaultUser, "xrootd")
@@ -135,18 +134,18 @@ func TestGenerateConfig(t *testing.T) {
 
 func TestWriteOriginScitokensConfig(t *testing.T) {
 	dirname := t.TempDir()
-	os.Setenv("PELICAN_XROOTDRUN", dirname)
-	defer os.Unsetenv("PELICAN_XROOTDRUN")
+	os.Setenv("PELICAN_XROOTD_RUNLOCATION", dirname)
+	defer os.Unsetenv("PELICAN_XROOTD_RUNLOCATION")
 	config_dirname := t.TempDir()
 	viper.Reset()
 	viper.Set("Origin.SelfTest", true)
 	viper.Set("ConfigDir", config_dirname)
-	viper.Set("XrootdRun", dirname)
-	viper.Set("Hostname", "origin.example.com")
+	viper.Set("Xrootd.RunLocation", dirname)
+	viper.Set("Server.Hostname", "origin.example.com")
 	err := config.InitServer()
 	require.Nil(t, err)
 
-	scitokensCfg := param.ScitokensConfig.GetString()
+	scitokensCfg := param.Xrootd_ScitokensConfig.GetString()
 	err = config.MkdirAll(filepath.Dir(scitokensCfg), 0755, -1, -1)
 	require.NoError(t, err)
 	err = os.WriteFile(scitokensCfg, []byte(toMergeOutput), 0640)

--- a/xrootd/launch.go
+++ b/xrootd/launch.go
@@ -37,7 +37,6 @@ import (
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 type (
@@ -153,7 +152,7 @@ func LaunchXrootd(privileged bool, configPath string) (err error) {
 
 	cmsdCtx := context.Background()
 	cmsdPid := -1
-	if viper.GetBool("Origin.UseCmsd") {
+	if param.Origin_UseCmsd.GetBool() {
 		cmsdCtx, cmsdPid, err = launcher.Launch(ctx, "cmsd", configPath)
 		if err != nil {
 			return errors.Wrap(err, "Failed to launch cmsd daemon")

--- a/xrootd/launch.go
+++ b/xrootd/launch.go
@@ -92,7 +92,7 @@ func forwardCommandToLogger(ctx context.Context, daemonName string, cmdStdout io
 }
 
 func (UnprivilegedXrootdLauncher) Launch(ctx context.Context, daemonName string, configPath string) (context.Context, int, error) {
-	xrootdRun := param.XrootdRun.GetString()
+	xrootdRun := param.Xrootd_RunLocation.GetString()
 	pidFile := filepath.Join(xrootdRun, "xrootd.pid")
 
 	cmd := exec.CommandContext(ctx, daemonName, "-f", "-s", pidFile, "-c", configPath)

--- a/xrootd/launch_linux.go
+++ b/xrootd/launch_linux.go
@@ -81,7 +81,7 @@ func (PrivilegedXrootdLauncher) Launch(ctx context.Context, daemonName string, c
 		return ctx, -1, errors.Wrapf(err, "Unable to create stderr pipe for %s", daemonName)
 	}
 
-	xrootdRun := param.XrootdRun.GetString()
+	xrootdRun := param.Xrootd_RunLocation.GetString()
 	pidFile := filepath.Join(xrootdRun, "xrootd.pid")
 
 	executable, err := findDaemon(daemonName)


### PR DESCRIPTION
In issue #130 we discussed making config variables hierarchical, such that each variable describes which service it affects. One goal was to keep the hierarchies flat (<= 2 layers). This PR breaks out the config variables and assigns them to various parent services. It also adds many new viper config variables to `docs/parameters.yaml` so that users can figure out which components of Pelican they have control over.