### PR TITLE
Pelican transport fixes and generated after configs

### DIFF
--- a/client/director.go
+++ b/client/director.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pelicanplatform/pelican/config"
 	namespaces "github.com/pelicanplatform/pelican/namespaces"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -121,7 +122,7 @@ func QueryDirector(source string, directorUrl string) (resp *http.Response, err 
 	// redirect. We use the Location url elsewhere (plus we still need to do the token
 	// dance!)
 	var client *http.Client
-	tr := GetTransport()
+	tr := config.GetTransport()
 	client = &http.Client{
 		Transport: tr,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {

--- a/config/config.go
+++ b/config/config.go
@@ -270,7 +270,6 @@ func setupTransport() {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 
-	return
 }
 
 // function to get/setup the transport (only once)

--- a/namespace-registry/client_commands.go
+++ b/namespace-registry/client_commands.go
@@ -34,7 +34,6 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
-	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/director"
 	log "github.com/sirupsen/logrus"
@@ -62,8 +61,7 @@ func makeRequest(url string, method string, data map[string]interface{}, headers
 	for key, val := range headers {
 		req.Header.Set(key, val)
 	}
-
-	tr := client.GetTransport()
+	tr := config.GetTransport()
 	client := &http.Client{Transport: tr}
 
 	resp, err := client.Do(req)

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -26,7 +26,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/director"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pkg/errors"
@@ -122,7 +122,7 @@ func AdvertiseOrigin() error {
 
 	// We should switch this over to use the common transport, but for that to happen
 	// that function needs to be exported from pelican
-	tr := client.GetTransport()
+	tr := config.GetTransport()
 	client := http.Client{Transport: tr}
 
 	resp, err := client.Do(req)


### PR DESCRIPTION
Fixed an issue with common transports for some reason not getting correct value from defaults.yaml. Also addressed issue moving the common transports to the config sub-module and allowed initClient and initServer to recreate the common transport object. In addition, moved the TLSSkipVerify to only run when setupTransfer is called again (either first time `GetTransfer()` is called or `initClient()` or `initServer()` is called).