### PR TITLE
Added check of cookie login for prometheus

### DIFF
--- a/cmd/origin_serve_test.go
+++ b/cmd/origin_serve_test.go
@@ -21,6 +21,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,6 +29,8 @@ import (
 )
 
 func TestCreateXrootdConfig(t *testing.T) {
+	err := os.MkdirAll("/run", os.ModePerm)
+	require.NoError(t, err)
 	configPath, err := configXrootd()
 	require.NoError(t, err)
 	assert.NotNil(t, configPath)

--- a/cmd/origin_serve_test.go
+++ b/cmd/origin_serve_test.go
@@ -21,7 +21,6 @@
 package main
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,8 +28,6 @@ import (
 )
 
 func TestCreateXrootdConfig(t *testing.T) {
-	err := os.MkdirAll("/run", os.ModePerm)
-	require.NoError(t, err)
 	configPath, err := configXrootd()
 	require.NoError(t, err)
 	assert.NotNil(t, configPath)

--- a/config/config.go
+++ b/config/config.go
@@ -196,15 +196,15 @@ func DiscoverFederation() error {
 	}
 	if curDirectorURL == "" {
 		log.Debugln("Federation service discovery resulted in director URL", metadata.DirectorEndpoint)
-		viper.Set("Federation.DirectorURL", metadata.DirectorEndpoint)
+		viper.Set("Federation.DirectorUrl", metadata.DirectorEndpoint)
 	}
 	if curNamespaceURL == "" {
 		log.Debugln("Federation service discovery resulted in namespace registration URL",
 			metadata.NamespaceRegistrationEndpoint)
-		viper.Set("Federation.NamespaceURL", metadata.NamespaceRegistrationEndpoint)
+		viper.Set("Federation.NamespaceUrl", metadata.NamespaceRegistrationEndpoint)
 	}
 
-	viper.Set("FederationURI", metadata.JwksUri)
+	viper.Set("Federation.JwkUrl", metadata.JwksUri)
 
 	return nil
 }

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -88,6 +88,14 @@ osdf_default: Default is determined dynamically through metadata at <federation 
 default: none
 components: ["client", "director", "origin"]
 ---
+name: Federation.JwkUrl
+description: >-
+  A URL indicating where the JWKS for the Federation is hosted.
+type: url
+osdf_default: Default is determined dynamically through metadata at <federtion URL>/.well-known/pelican-configuration
+default: none
+components: ["client", "origin"]
+---
 
 ############################
 #   Client-Level Configs   #

--- a/origin_ui/origin.go
+++ b/origin_ui/origin.go
@@ -221,6 +221,7 @@ func setLoginCookie(ctx *gin.Context, user string) {
 	issuerURL.Host = ctx.Request.URL.Host
 	now := time.Now()
 	tok, err := jwt.NewBuilder().
+		Claim("scope", "prometheus.read").
 		Issuer(issuerURL.String()).
 		IssuedAt(now).
 		Expiration(now.Add(30 * time.Minute)).
@@ -244,7 +245,7 @@ func setLoginCookie(ctx *gin.Context, user string) {
 		return
 	}
 
-	ctx.SetCookie("login", string(signed), 30*60, "/api/v1.0/origin-ui",
+	ctx.SetCookie("login", string(signed), 30*60, "/api/v1.0",
 		ctx.Request.URL.Host, true, true)
 	ctx.SetSameSite(http.SameSiteStrictMode)
 }

--- a/web_ui/README.md
+++ b/web_ui/README.md
@@ -1,0 +1,6 @@
+A short README explaining our authorization permissions, specifically regarding tokens recieved from the URL or Header vs the login cookie.
+
+
+Tokens that are part of the HTTP Request Header e.g. `{"Authorization": "Bearer +"<token>}` and that are set in the URL Query via `Authz` are considered valid if they are signed by either the Federation jwk or the Origin jwk.
+
+However, tokens that are retrieved from the login cookie `ctx.Cookie("login")` are ONLY valid if the are signed by the Origin jwk. This can be seen in the prometheus code and how it accesses the functions in `Authorization.go`

--- a/web_ui/authorization.go
+++ b/web_ui/authorization.go
@@ -1,0 +1,136 @@
+/***************************************************************
+ *
+ * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+package web_ui
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	pelican_config "github.com/pelicanplatform/pelican/config"
+	"github.com/spf13/viper"
+)
+
+// Creates a validator that checks if a token's scope matches the given scope: matchScope
+func createScopeValidator(matchScope string) jwt.ValidatorFunc {
+	return jwt.ValidatorFunc(func(_ context.Context, tok jwt.Token) jwt.ValidationError {
+		scope_any, present := tok.Get("scope")
+		if !present {
+			return jwt.NewValidationError(errors.New("No scope is present; required for authorization"))
+		}
+		scope, ok := scope_any.(string)
+		if !ok {
+			return jwt.NewValidationError(errors.New("scope claim in token is not string-valued"))
+		}
+
+		for _, scope := range strings.Split(scope, " ") {
+			if scope == matchScope {
+				return nil
+			}
+		}
+		return jwt.NewValidationError(errors.New("Token does not contain the scope: " + matchScope))
+	})
+}
+
+// Checks that the given token was signed by the federation jwk and also checks that the token has the expected scope
+func FederationCheck(c *gin.Context, strToken string, expectedScope string) {
+	var bKey *jwk.Key
+
+	fedURL := viper.GetString("FederationURL")
+	token, err := jwt.Parse([]byte(strToken), jwt.WithVerify(false))
+
+	if err != nil {
+		return
+	}
+
+	if fedURL == token.Issuer() {
+		err := pelican_config.DiscoverFederation()
+		if err != nil {
+			return
+		}
+		fedURIFile := viper.GetString("FederationURI")
+		response, err := http.Get(fedURIFile)
+		if err != nil {
+			return
+		}
+		defer response.Body.Close()
+		contents, err := io.ReadAll(response.Body)
+		if err != nil {
+			return
+		}
+		keys, err := jwk.Parse(contents)
+		if err != nil {
+			return
+		}
+		key, ok := keys.Key(0)
+		if !ok {
+			return
+		}
+		bKey = &key
+		var raw ecdsa.PrivateKey
+		if err = (*bKey).Raw(&raw); err != nil {
+			return
+		}
+
+		parsed, err := jwt.Parse([]byte(strToken), jwt.WithKey(jwa.ES256, raw.PublicKey))
+
+		if err != nil {
+			return
+		}
+
+		scopeValidator := createScopeValidator(expectedScope)
+		if err = jwt.Validate(parsed, jwt.WithValidator(scopeValidator)); err != nil {
+			return
+		}
+
+		c.Set("User", "Federation")
+	}
+}
+
+// Checks that the given token was signed by the origin jwk and also checks that the token has the expected scope
+func OriginCheck(c *gin.Context, strToken string, expectedScope string) {
+	bKey, err := pelican_config.GetOriginJWK()
+	if err != nil {
+		return
+	}
+
+	var raw ecdsa.PrivateKey
+	if err = (*bKey).Raw(&raw); err != nil {
+		return
+	}
+
+	parsed, err := jwt.Parse([]byte(strToken), jwt.WithKey(jwa.ES256, raw.PublicKey))
+
+	if err != nil {
+		return
+	}
+
+	scopeValidator := createScopeValidator(expectedScope)
+	if err = jwt.Validate(parsed, jwt.WithValidator(scopeValidator)); err != nil {
+		return
+	}
+
+	c.Set("User", "Origin")
+}

--- a/web_ui/authorization.go
+++ b/web_ui/authorization.go
@@ -30,7 +30,7 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	pelican_config "github.com/pelicanplatform/pelican/config"
-	"github.com/spf13/viper"
+	"github.com/pelicanplatform/pelican/param"
 )
 
 // Creates a validator that checks if a token's scope matches the given scope: matchScope
@@ -58,7 +58,7 @@ func createScopeValidator(matchScope string) jwt.ValidatorFunc {
 func FederationCheck(c *gin.Context, strToken string, expectedScope string) {
 	var bKey *jwk.Key
 
-	fedURL := viper.GetString("FederationURL")
+	fedURL := param.Federation_DiscoveryUrl.GetString()
 	token, err := jwt.Parse([]byte(strToken), jwt.WithVerify(false))
 
 	if err != nil {
@@ -70,7 +70,7 @@ func FederationCheck(c *gin.Context, strToken string, expectedScope string) {
 		if err != nil {
 			return
 		}
-		fedURIFile := viper.GetString("FederationURI")
+		fedURIFile := param.Federation_JwkUrl.GetString()
 		response, err := http.Get(fedURIFile)
 		if err != nil {
 			return

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -17,10 +17,8 @@ package web_ui
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"errors"
 	"fmt"
-	"io"
 	"math"
 	"net/http"
 	"net/url"
@@ -37,9 +35,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/regexp"
-	"github.com/lestrrat-go/jwx/v2/jwa"
-	"github.com/lestrrat-go/jwx/v2/jwk"
-	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/mwitkow/go-conntrack"
 	"github.com/oklog/run"
 	pelican_config "github.com/pelicanplatform/pelican/config"
@@ -152,104 +147,27 @@ func checkPromToken(av1 *route.Router) gin.HandlerFunc {
 		req := c.Request
 
 		var strToken string
-		var token jwt.Token
 		var err error
 		if authzQuery := req.URL.Query()["authz"]; len(authzQuery) > 0 {
 			strToken = authzQuery[0]
 		} else if authzHeader := req.Header["Authorization"]; len(authzHeader) > 0 {
 			strToken = strings.TrimPrefix(authzHeader[0], "Bearer ")
+		}
+
+		FederationCheck(c, strToken, "prometheus.read")
+		OriginCheck(c, strToken, "prometheus.read")
+
+		strToken, err = c.Cookie("login")
+		if err == nil {
+			OriginCheck(c, strToken, "prometheus.read")
+		}
+
+		_, exists := c.Get("User")
+		if exists {
+			av1.ServeHTTP(c.Writer, c.Request)
 		} else {
-			c.JSON(403, gin.H{"error": "Permission Denied: Missing token"})
-			return
+			c.JSON(http.StatusForbidden, gin.H{"error": "Correct authorization required to access metrics"})
 		}
-
-		// Parsing the token (unverified) in order to get its issuer without having the jwks
-		token, err = jwt.Parse([]byte(strToken), jwt.WithVerify(false))
-
-		if err != nil {
-			c.JSON(400, gin.H{"error": "Failed to parse token"})
-		}
-
-		fedURL := param.Federation_DiscoveryUrl.GetString()
-
-		var bKey *jwk.Key
-		if fedURL == token.Issuer() {
-			err := pelican_config.DiscoverFederation()
-			if err != nil {
-				c.JSON(400, gin.H{"error": "Failed to discover the federation information"})
-			}
-			fedURIFile := param.Federation_DiscoveryUrl.GetString()
-			response, err := http.Get(fedURIFile)
-			if err != nil {
-				c.JSON(400, gin.H{"error": "Failed to get federation key file"})
-			}
-			defer response.Body.Close()
-			contents, err := io.ReadAll(response.Body)
-			if err != nil {
-				c.JSON(400, gin.H{"error": "Failed to read federation key file"})
-				return
-			}
-			keys, err := jwk.Parse(contents)
-			//key, err := jwk.ParseKey(contents, jwk.WithPEM(true))
-			if err != nil {
-				c.JSON(400, gin.H{"error": "Failed to parse Federation key file"})
-				return
-			}
-			key, ok := keys.Key(0)
-			if !ok {
-				c.JSON(400, gin.H{"error": "No key in keyset"})
-			}
-			bKey = &key
-		} else {
-			bKey, err = pelican_config.GetOriginJWK()
-			if err != nil {
-				c.JSON(400, gin.H{"error": "Failed to retrieve private key"})
-				return
-			}
-		}
-
-		var raw ecdsa.PrivateKey
-		if err = (*bKey).Raw(&raw); err != nil {
-			c.JSON(400, gin.H{"error": "Failed to extract signing key"})
-			return
-		}
-
-		parsed, err := jwt.Parse([]byte(strToken), jwt.WithKey(jwa.ES256, raw.PublicKey))
-
-		if err != nil {
-			c.JSON(403, gin.H{"error": "Permission Denied: Invalid token"})
-			return
-		}
-
-		/*
-		* The signature is verified, now we need to make sure this token actually gives us
-		* permission to access prometheus metrics
-		* NOTE: The validate function also handles checking `iat` and `exp` to make sure the token
-		*       remains valid.
-		 */
-		scopeValidator := jwt.ValidatorFunc(func(_ context.Context, tok jwt.Token) jwt.ValidationError {
-			scope_any, present := tok.Get("scope")
-			if !present {
-				return jwt.NewValidationError(errors.New("No scope is present; required for authorization"))
-			}
-			scope, ok := scope_any.(string)
-			if !ok {
-				return jwt.NewValidationError(errors.New("scope claim in token is not string-valued"))
-			}
-
-			for _, scope := range strings.Split(scope, " ") {
-				if scope == "prometheus.read" {
-					return nil
-				}
-			}
-			return jwt.NewValidationError(errors.New("Token does not contain prometheus access authorization"))
-		})
-		if err = jwt.Validate(parsed, jwt.WithValidator(scopeValidator)); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "server could not validate the provided access token"})
-			return
-		}
-
-		av1.ServeHTTP(c.Writer, c.Request)
 	}
 }
 

--- a/web_ui/prometheus_test.go
+++ b/web_ui/prometheus_test.go
@@ -1,3 +1,20 @@
+/***************************************************************
+ *
+ * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
 package web_ui
 
 import (
@@ -141,6 +158,8 @@ func TestPrometheusProtectionFederationURL(t *testing.T) {
 	c.Request.URL.RawQuery = new_query.Encode()
 
 	r.ServeHTTP(w, c.Request)
+
+	assert.Equal(t, 404, w.Result().StatusCode, "Expected status code of 404 representing failure due to minimal server setup, not token check")
 }
 
 func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
@@ -327,5 +346,54 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 
 	r.ServeHTTP(w, c.Request)
 
-	assert.Equal(t, 500, w.Result().StatusCode, "Expected status code of 500 representing failure to validate token scope")
+	assert.Equal(t, 403, w.Result().StatusCode, "Expected status code of 403 due to bad token scope")
+
+	key, err := config.GetOriginJWK()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a new Recorder and Context for the next HTTPtest call
+	w = httptest.NewRecorder()
+	c, r = gin.CreateTestContext(w)
+
+	now := time.Now()
+	tok, err = jwt.NewBuilder().
+		Issuer(issuerURL.String()).
+		Claim("scope", "prometheus.read").
+		Claim("wlcg.ver", "1.0").
+		IssuedAt(now).
+		Expiration(now.Add(30 * time.Minute)).
+		NotBefore(now).
+		Subject("user").
+		Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var raw ecdsa.PrivateKey
+	if err = (*key).Raw(&raw); err != nil {
+		t.Fatal(err)
+	}
+	signed, err = jwt.Sign(tok, jwt.WithKey(jwa.ES256, raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set the request to go through the checkPromToken function
+	r.GET("/api/v1.0/prometheus/*any", checkPromToken(av1))
+
+	http.SetCookie(w, &http.Cookie{Name: "login", Value: string(signed)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//&http.Request{Header: http.Header{"Cookie": recorder.HeaderMap["Set-Cookie"]}}
+
+	c.Request, _ = http.NewRequest(http.MethodGet, "/api/v1.0/prometheus/test", bytes.NewBuffer([]byte(`{}`)))
+	c.Request.Header.Set("Cookie", w.Header().Get("Set-Cookie"))
+
+	r.ServeHTTP(w, c.Request)
+
+	assert.Equal(t, 404, w.Result().StatusCode, "Expected status code of 404 representing failure due to minimal server setup, not token check")
 }

--- a/web_ui/prometheus_test.go
+++ b/web_ui/prometheus_test.go
@@ -143,10 +143,10 @@ func TestPrometheusProtectionFederationURL(t *testing.T) {
 	}
 
 	//Set the Federation information so as not to run through all of DiscoverFederation (that should be a tested elsewhere)
-	viper.Set("FederationURL", "https://test-http")
-	viper.Set("DirectorURL", "https://test-director")
-	viper.Set("NamespaceURL", "https://test-namesapce")
-	viper.Set("FederationURI", ts.URL)
+	viper.Set("Federation.DiscoveryUrl", "https://test-http")
+	viper.Set("Federation.DirectorUrl", "https://test-director")
+	viper.Set("Federation.NamespaceUrl", "https://test-namesapce")
+	viper.Set("Federation.JwkUrl", ts.URL)
 
 	// Set the request to run through the checkPromToken function
 	r.GET("/api/v1.0/prometheus/*any", checkPromToken(av1))

--- a/web_ui/prometheus_test.go
+++ b/web_ui/prometheus_test.go
@@ -388,8 +388,6 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	//&http.Request{Header: http.Header{"Cookie": recorder.HeaderMap["Set-Cookie"]}}
-
 	c.Request, _ = http.NewRequest(http.MethodGet, "/api/v1.0/prometheus/test", bytes.NewBuffer([]byte(`{}`)))
 	c.Request.Header.Set("Cookie", w.Header().Get("Set-Cookie"))
 


### PR DESCRIPTION
    -- Refactored origin and federation check into their own module to be used by other functions
    -- Added a README explaining which tokens is it okay to sign with the Federation and which aren't
    -- Added a check for the authorization via the login cookie