### PR TITLE
Testing common transport timeouts

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -247,7 +247,7 @@ func getConfigBase() (string, error) {
 
 func setupTransport() {
 	//Getting timeouts and other information from defaults.yaml
-	maxIdleConns := viper.GetInt("Transport.MaxIdleIcons")
+	maxIdleConns := viper.GetInt("Transport.MaxIdleConns")
 	idleConnTimeout := viper.GetDuration("Transport.IdleConnTimeout")
 	transportTLSHandshakeTimeout := viper.GetDuration("Transport.TLSHandshakeTimeout")
 	expectContinueTimeout := viper.GetDuration("Transport.ExpectContinueTimeout")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,108 @@
+/***************************************************************
+ *
+ * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package config
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+var server *httptest.Server
+
+func TestMain(m *testing.M) {
+	// Create a test server
+	server = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// simuilate long server response
+		time.Sleep(5 * time.Second)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("Success"))
+	}))
+	// Init server to get configs initiallized
+	viper.Set("Transport.MaxIdleConns", 30)
+	viper.Set("Transport.IdleConnTimeout", time.Second*90)
+	viper.Set("Transport.TLSHandshakeTimeout", time.Second*15)
+	viper.Set("Transport.ExpectContinueTimeout", time.Second*1)
+	viper.Set("Transport.ResponseHeaderTimeout", time.Second*10)
+
+	viper.Set("Transport.Dialer.Timeout", time.Second*1)
+	viper.Set("Transport.Dialer.KeepAlive", time.Second*30)
+	viper.Set("TLSSkipVerify", true)
+	server.StartTLS()
+	defer server.Close()
+	exitCode := m.Run()
+	os.Exit(exitCode)
+}
+
+func TestResponseHeaderTimeout(t *testing.T) {
+	// Change the viper value of the timeout
+	viper.Set("Transport.ResponseHeaderTimeout", time.Millisecond*25)
+	setupTransport()
+	transport := GetTransport()
+	client := &http.Client{Transport: transport}
+	// make a request
+	req, err := http.NewRequest("GET", server.URL, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	// Perform the request and handle the timeout
+	_, err = client.Do(req)
+	if err != nil {
+		// Check if the error is a timeout error
+		assert.True(t, strings.Contains(err.Error(), "timeout awaiting response headers"))
+	} else {
+		t.Fatalf("Test returned no error when there should be")
+	}
+
+	viper.Set("Transport.ResponseHeaderTimeout", time.Second*10)
+}
+
+func TestDialerTimeout(t *testing.T) {
+	// Change the viper value of the timeout
+	viper.Set("Transport.Dialer.Timeout", time.Millisecond*25)
+	setupTransport()
+	transport := GetTransport()
+	client := &http.Client{Transport: transport}
+
+	unreachableServerURL := "http://abc123:1000"
+
+	// make a request
+	req, err := http.NewRequest("GET", unreachableServerURL, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	// Perform the request and handle the timeout
+	_, err = client.Do(req)
+	if err != nil {
+		// Check if the error is a timeout error
+		assert.True(t, strings.Contains(err.Error(), "dial tcp"))
+	} else {
+		t.Fatalf("Test returned no error when there should be")
+	}
+
+	viper.Set("Transport.Dialer.Timeout", time.Second*10)
+}


### PR DESCRIPTION
Created a unit test that tests functionality of common transport timeouts now that they can be configured. Did not include all timeouts since the test demonstrates functionality enough and it became too difficult to focus too much on.