### PR TITLE
Strip "Bearer " from authz query and header if they're present

### DIFF
--- a/director/redirect.go
+++ b/director/redirect.go
@@ -81,8 +81,8 @@ func getAuthzEscaped(req *http.Request) (authzEscaped string) {
 		// even though it's coming via a URL
 		authzEscaped = strings.TrimPrefix(authzEscaped, "Bearer ")
 	} else if authzHeader := req.Header["Authorization"]; len(authzHeader) > 0 {
-		authzEscaped = url.QueryEscape(authzHeader[0])
-		authzEscaped = strings.TrimPrefix(authzEscaped, "Bearer ")
+		authzEscaped = strings.TrimPrefix(authzHeader[0], "Bearer ")
+		authzEscaped = url.QueryEscape(authzEscaped)
 	}
 	return
 }

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -77,8 +77,12 @@ func getRealIP(ginCtx *gin.Context) (ipAddr netip.Addr, err error) {
 func getAuthzEscaped(req *http.Request) (authzEscaped string) {
 	if authzQuery := req.URL.Query()["authz"]; len(authzQuery) > 0 {
 		authzEscaped = authzQuery[0]
+		// if the authz URL query is coming from XRootD, it probably has a "Bearer " tacked in front
+		// even though it's coming via a URL
+		authzEscaped = strings.TrimPrefix(authzEscaped, "Bearer ")
 	} else if authzHeader := req.Header["Authorization"]; len(authzHeader) > 0 {
 		authzEscaped = url.QueryEscape(authzHeader[0])
+		authzEscaped = strings.TrimPrefix(authzEscaped, "Bearer ")
 	}
 	return
 }


### PR DESCRIPTION
I noticed while testing XRootD's ability to use a Pelican director as its redirector (defined via the `pss.origin` directive), that XRootD will take a token passed to it via an Authorization header and convert it directly into an authz URL query that gets passed to the director. For the director to return a valid redirect URL, the "Bearer " prefix must be stripped.