### PR TITLE
Add --version flag to pelican-client

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,20 +19,42 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
 
 func main() {
-	exec_name := filepath.Base(os.Args[0])
+	err := handleCLI(os.Args)
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func handleCLI(args []string) error {
+	exec_name := filepath.Base(args[0])
 	if exec_name == "stash_plugin" || exec_name == "osdf_plugin" || exec_name == "pelican_xfer_plugin" {
-		stashPluginMain(os.Args[1:])
+		stashPluginMain(args[1:])
 	} else if exec_name == "stashcp" {
 		err := copyCmd.Execute()
 		if err != nil {
-			os.Exit(1)
+			return err
 		}
 	} else {
+		// * We assume that os.Args should have minimum length of 1, so skipped empty check
+		// * Version flag is captured manually to ensure it's available to all the commands and subcommands
+		// 		This is becuase there's no gracefuly way to do it through Cobra
+		// * Note that append "--version" to CLI as the last argument will give the
+		// version info regardless of the commands and whether they are defined
+		// * Remove the -v shorthand since in "origin serve" flagset it's already used for "volume" flag
+		if args[len(args)-1] == "--version" {
+			fmt.Println("Version:", version)
+			fmt.Println("Build Date:", date)
+			fmt.Println("Build Commit:", commit)
+			fmt.Println("Built By:", builtBy)
+			return nil
+		}
 		Execute()
 	}
+	return nil
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -18,6 +18,7 @@ func TestHandleCLIVersionFlag(t *testing.T) {
 	builtBy = "goreleaser"
 
 	// Reset os.Args to ensure Windows doesn't do weird things to the test
+	oldArgs := os.Args
 	os.Args = []string{os.Args[0]}
 
 	mockVersionOutput := fmt.Sprintf(
@@ -94,4 +95,7 @@ func TestHandleCLIVersionFlag(t *testing.T) {
 			batchTest(t, tc.args, tc.expected)
 		})
 	}
+
+	// Restore the args back when test finished
+	os.Args = oldArgs
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandleCLIVersionFlag(t *testing.T) {
+	version = "0.0.1"
+	date = "2023-10-06T15:26:50Z"
+	commit = "f0f94a3edf6641c2472345819a0d5453fc9e68d1"
+	builtBy = "goreleaser"
+
+	// Reset os.Args to ensure Windows doesn't do weird things to the test
+	os.Args = []string{os.Args[0]}
+
+	mockVersionOutput := fmt.Sprintf(
+		"Version: %s\nBuild Date: %s\nBuild Commit: %s\nBuilt By: %s",
+		version, date, commit, builtBy,
+	)
+
+	testCases := []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		// The choice of Long and Short is based on the current pattern we have
+		// that only root command has Long description and Short description
+		// for the rest of the subcommands
+		{
+			"no-flag-on-root-command",
+			[]string{"pelican"},
+			rootCmd.Long,
+		},
+		{
+			"no-flag-on-subcommand",
+			[]string{"pelican", "origin"},
+			originCmd.Short,
+		},
+		{
+			"flag-on-root-command",
+			[]string{"pelican", "--version"},
+			mockVersionOutput,
+		},
+		{
+			"flag-on-subcommand",
+			[]string{"pelican", "origin", "--version"},
+			mockVersionOutput,
+		},
+		{
+			"flag-on-second-layer-subcommand",
+			[]string{"pelican", "origin", "get", "--version"},
+			mockVersionOutput,
+		},
+		{
+			"other-flag-on-root-command",
+			[]string{"pelican", "--help"},
+			rootCmd.Long,
+		},
+	}
+
+	batchTest := func(t *testing.T, arguments []string, expected string) {
+		// Redirect output to a pip
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		err := handleCLI(arguments)
+
+		// Close the write of pip and redirect output back to stdout
+		w.Close()
+		out, _ := io.ReadAll(r)
+		os.Stdout = oldStdout
+
+		got := strings.TrimSpace(string(out))
+		assert.NoError(t, err, "Should not have error running the function")
+		if expected != mockVersionOutput {
+			// If the expected string is not the version output, use Contains to check
+			// This is mainly for checking against command help output
+			assert.Contains(t, got, expected, "Output does not match expectation")
+		} else {
+			assert.Equal(t, expected, got, "Output does not match expectation")
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			batchTest(t, tc.args, tc.expected)
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,7 +87,6 @@ func Execute() {
 func init() {
 
 	cobra.OnInitialize(initConfig)
-
 	rootCmd.AddCommand(objectCmd)
 	objectCmd.CompletionOptions.DisableDefaultCmd = true
 	rootCmd.AddCommand(directorCmd)
@@ -107,6 +106,11 @@ func init() {
 	if err := viper.BindPFlag("FederationURL", rootCmd.PersistentFlags().Lookup("federation")); err != nil {
 		panic(err)
 	}
+
+	// Register the version flag here just so --help will show this flag
+	// Actual checking is executed at main.go
+	// Remove the shorthand -v since in "origin serve" flagset it's already used for "volume" flag
+	rootCmd.PersistentFlags().BoolP("version", "", false, "Print the version and exit")
 
 	rootCmd.PersistentFlags().BoolVarP(&outputJSON, "json", "", false, "output results in JSON format")
 	rootCmd.CompletionOptions.DisableDefaultCmd = true


### PR DESCRIPTION
According to issue #150 , we want to expose `--version` flag for pelican-client and display the version/build info to the user in a similar behavior as `stashcp` did. This PR addressed this issue but in a bit hacky way under various constraints from cobra.
* In order for all commands and subcommands to respond to a flag, we need to add logic to each individual command/subcommand in cobra. This can be done in a batch using `PersistentPreRun` [function](https://github.com/spf13/cobra/blob/main/site/content/user_guide.md#prerun-and-postrun-hooks), to add one handler for the root command and its child subcommands. However, cobra will not execute `PersistentPreRun` function for the command if the `Run` function of the command is not defined. See issue [2039](https://github.com/spf13/cobra/issues/2039). For us, many subcommands are only a level of hierarchy and won't handle any command logic themselves, such as `origin`. Adding `Run` functions will break it.
* One workaround is to handle the flag logic inside the `main` function of the command, i.e. in `root.go`. [However, the flag value won't be evaluated until `Execute()` function is called](https://github.com/spf13/cobra/issues/1066#issuecomment-604220701), which means we can't do anything using cobra in `root.go`
* This leads to the final solution this PR picked, which is to manually handle `--version` logic in `main.go` by reading the last command line argument. This means that for any command ending with `--version`, the version info will be popped up no matter what command/argument/flag before it was. This should be the expected behavior for the `--version` flag.
* I registered the flag in cobra so that the `--help` command will it as a global flag to users, but cobra didn't handle any of the actual logic.
* Also, `-v` shorthand was disabled because we had one reserved for `origin serve` where `-v` means the volume to attach to the origin server.

Another note for those who want to improve the test coverage for the `cmd` package. You might want to clear the `os.Args` before your test logic and restore it afterwards if you are not testing cobra but just the manually-added CLI logic. I had this issue with the test case in CI for Windows OS where the test will pass some weird arguments to my `main.go` (which wasn't even part of my testing code) and cause the test case fail by exiting the program with `command not found` error.