### PR TITLE
Integrate component health status to Prometheus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/oschwald/geoip2-golang v1.9.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
+	github.com/prometheus/client_model v0.4.0
 	github.com/prometheus/common v0.44.0
 	github.com/prometheus/prometheus v0.46.0
 	github.com/sirupsen/logrus v1.8.1
@@ -120,7 +121,6 @@ require (
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/alertmanager v0.25.0 // indirect
-	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common/assets v0.2.0 // indirect
 	github.com/prometheus/common/sigv4 v0.1.0 // indirect
 	github.com/prometheus/exporter-toolkit v0.10.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/oschwald/geoip2-golang v1.9.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
-	github.com/prometheus/client_model v0.4.0
 	github.com/prometheus/common v0.44.0
 	github.com/prometheus/prometheus v0.46.0
 	github.com/sirupsen/logrus v1.8.1
@@ -121,6 +120,7 @@ require (
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/alertmanager v0.25.0 // indirect
+	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common/assets v0.2.0 // indirect
 	github.com/prometheus/common/sigv4 v0.1.0 // indirect
 	github.com/prometheus/exporter-toolkit v0.10.0 // indirect

--- a/metrics/health.go
+++ b/metrics/health.go
@@ -51,12 +51,12 @@ var (
 	healthStatus = sync.Map{}
 
 	PelicanHealthStatus = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "component_health_status",
+		Name: "pelican_component_health_status",
 		Help: "The health status of various components",
 	}, []string{"component"})
 
 	PelicanHealthLastUpdate = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "component_health_status_last_update",
+		Name: "pelican_component_health_status_last_update",
 		Help: "Last update timestamp of components health status",
 	}, []string{"component"})
 )

--- a/metrics/health.go
+++ b/metrics/health.go
@@ -51,7 +51,7 @@ var (
 	PromHealthStatusLastUpdate = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "last_update_component_health_status",
 		Help: "Last update of components health status",
-	}, []string{"component", "status"})
+	}, []string{"component", "status", "message"})
 )
 
 func statusToInt(status string) (int, error) {
@@ -83,10 +83,12 @@ func SetComponentHealthStatus(name, state, msg string) error {
 	if err != nil {
 		return err
 	}
-	healthStatus.Store(name, componentStatusInternal{statusInt, msg, time.Now()})
+	now := time.Now()
+	healthStatus.Store(name, componentStatusInternal{statusInt, msg, now})
 
-	now := time.Now().Unix()
-	PromHealthStatusLastUpdate.With(prometheus.Labels{"component": name, "status": state}).Set(float64(now))
+	PromHealthStatusLastUpdate.With(
+		prometheus.Labels{"component": name, "status": state, "message": msg}).
+		Set(float64(now.UnixMicro()))
 	return nil
 }
 


### PR DESCRIPTION
* Added a new Prometheus Gauge metric `last_update_component_health_status` with labels `component`, `status`, `message`, similar to existing in-memory data structure, and the value is Unix time in micro seconds
* This function is tested visually/using integrate test by calling `/query` API and verify the metric value can be distinguished between very small updates. Unit test for this function is a bit tricky and redundant given that 1. we can't mock the time value effectively. 2.Prometheus testutil only supports compare the result from a collector against an io stream but the times never match
