### PR TITLE
Add cache for Go modules and npm packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,23 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Cache Next.js
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.npm
+          ${{ github.workspace }}/.next/cache
+        # Generate a new cache whenever packages or source files change.
+        key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+        # If source files changed but packages didn't, rebuild from a prior cache.
+        restore-keys: |
+          ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-      
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@v3
     - name: Test
       run: |
         make web-build


### PR DESCRIPTION
According to #209 , we want to add cache for tests CI to improve running time of tests. This PR added cache for both Go modules and Next.js/npm packages. Since setup-go GHA [already has caching function built-in since V4](https://github.com/actions/setup-go#v4), we only need to modify the sequence where we checkout the code. For node packages, [following the guide from Next.js](https://nextjs.org/docs/pages/building-your-application/deploying/ci-build-caching#github-actions), I added cache for it.