### PR TITLE
Federation component health status

### DIFF
--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/director"
+	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -44,12 +45,23 @@ func PeriodicAdvertiseOrigin() error {
 		err := AdvertiseOrigin()
 		if err != nil {
 			log.Warningln("Origin advertise failed:", err)
+			if err = metrics.SetComponentHealthStatus("federation", "critical", "Error advertising origin to federation"); err != nil {
+				log.Warningln("Failed to update internal component health status:", err)
+			}
+		} else if err = metrics.SetComponentHealthStatus("federation", "ok", ""); err != nil {
+			log.Warningln("Failed to update internal component health status:", err)
 		}
+
 		for {
 			<-ticker.C
 			err := AdvertiseOrigin()
 			if err != nil {
 				log.Warningln("Origin advertise failed:", err)
+				if err = metrics.SetComponentHealthStatus("federation", "critical", "Error advertising origin to federation"); err != nil {
+					log.Warningln("Failed to update internal component health status:", err)
+				}
+			} else if err = metrics.SetComponentHealthStatus("federation", "ok", ""); err != nil {
+				log.Warningln("Failed to update internal component health status:", err)
 			}
 		}
 	}()


### PR DESCRIPTION
In #173, we want to monitor the advertising to federation status for origin. I added the "federation" component to the health status monitoring and mark it as "critical" if there's an error advertising to the federation, or "ok" otherwise.

I can confirm from visually testing the added metric with the origin UI running and that the federation status is returned by the `/health` api.

This PR did not come with a unit test as it requires us to mock "PeriodicAdvertiseOrigin" function but I can't do it without refactoring code and structure of `advertise.go` in origin_ui package, by adding interface and struct in that file, which will also cause refactors of code who imports those functions. Enable mocking functions in `advertise.go` can be a separate issue if we do want to improve test coverage for `origin_serve.go`.