### PR TITLE
Update goreleaser command in test CI and enable --single-target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,13 +57,22 @@ jobs:
     - name: Add coverage information to action summary
       if: matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request'
       run: echo 'Code coverage ' ${{steps.cc.outputs.cc_total}}'% Prev ' ${{steps.cc_b.outputs.cc_base_total}}'%' >> $GITHUB_STEP_SUMMARY
-    - name: Run GoReleaser
+    - name: Run GoReleaser for Non-Ubuntu
       uses: goreleaser/goreleaser-action@v4
+      if: runner.os != 'Linux'
       with:
         # either 'goreleaser' (default) or 'goreleaser-pro'
         distribution: goreleaser
         version: latest
-        args: build --rm-dist --snapshot
+        args: build --single-target --clean --snapshot
+    - name: Run GoReleaser for Ubuntu
+      uses: goreleaser/goreleaser-action@v4
+      if: runner.os == 'Linux'
+      with:
+        # either 'goreleaser' (default) or 'goreleaser-pro'
+        distribution: goreleaser
+        version: latest
+        args: --clean --snapshot
     - name: Copy files (Ubuntu)
       if: matrix.os == 'ubuntu-latest'
       run: |


### PR DESCRIPTION
* Replace `--rm-dist` by `--clean` in goreleaser command in Test CI as it's deprecated.
* Use `build` command with `--single-target` for Windows and Mac runners to only build one executable for their platform, keeping Ubuntu runner to build everything for platform coverage

Testing:
Reference GHA job: https://github.com/Techming/pelican/actions/runs/6485485842 See "Run GoReleaser for Non-Ubuntu" or "Run GoReleaser for Ubuntu" step log for details.
* Visually confirmed that the deprecated warning sign disappeared with this PR
* Visually confirmed that Mac OS and Windows runners will only build one artifact while Ubuntu runner will build all.