### PR TITLE
Update Pelican to not require a set $HOME in some configurations

### DIFF
--- a/cmd/director.go
+++ b/cmd/director.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -26,6 +27,10 @@ import (
 var (
 	directorCmd = &cobra.Command{
 		Use:   "director",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			err := config.InitServer()
+			return err
+		},
 		Short: "Launch a Pelican Director",
 		Long: `Launch a Pelican Director service:
 

--- a/cmd/director.go
+++ b/cmd/director.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	directorCmd = &cobra.Command{
-		Use:   "director",
+		Use: "director",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			err := config.InitServer()
 			return err

--- a/cmd/namespace_registry.go
+++ b/cmd/namespace_registry.go
@@ -19,12 +19,17 @@
 package main
 
 import (
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/spf13/cobra"
 )
 
 var (
 	namespaceRegistryCmd = &cobra.Command{
 		Use:   "registry",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			err := config.InitServer()
+			return err
+		},
 		Short: "Interact with a Pelican namespace registry service",
 		Long: `Interact with a Pelican namespace registry service:
 

--- a/cmd/namespace_registry.go
+++ b/cmd/namespace_registry.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	namespaceRegistryCmd = &cobra.Command{
-		Use:   "registry",
+		Use: "registry",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			err := config.InitServer()
 			return err

--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -30,6 +32,10 @@ var (
 	originCmd = &cobra.Command{
 		Use:   "origin",
 		Short: "Operate a Pelican origin service",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			err := initOrigin()
+			return err
+		},
 	}
 
 	originConfigCmd = &cobra.Command{
@@ -79,6 +85,17 @@ and https://github.com/WLCG-AuthZ-WG/common-jwt-profile/blob/master/profile.md, 
 func configOrigin( /*cmd*/ *cobra.Command /*args*/, []string) {
 	fmt.Println("'origin config' command is not yet implemented")
 	os.Exit(1)
+}
+
+func initOrigin() error {
+	err := config.InitServer()
+	cobra.CheckErr(err)
+	err = metrics.SetComponentHealthStatus("xrootd", "critical", "xrootd has not been started")
+	cobra.CheckErr(err)
+	err = metrics.SetComponentHealthStatus("cmsd", "critical", "cmsd has not been started")
+	cobra.CheckErr(err)
+
+	return err
 }
 
 func init() {

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -96,14 +96,6 @@ type (
 	}
 )
 
-func init() {
-	err := config.InitServer()
-	cobra.CheckErr(err)
-	err = metrics.SetComponentHealthStatus("xrootd", "critical", "xrootd has not been started")
-	cobra.CheckErr(err)
-	err = metrics.SetComponentHealthStatus("cmsd", "critical", "cmsd has not been started")
-	cobra.CheckErr(err)
-}
 
 func checkXrootdEnv() error {
 	uid, err := config.GetDaemonUID()

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -96,7 +96,6 @@ type (
 	}
 )
 
-
 func checkXrootdEnv() error {
 	uid, err := config.GetDaemonUID()
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -122,7 +122,9 @@ func initConfig() {
 		viper.SetConfigFile(cfgFile)
 	} else {
 		home, err := os.UserHomeDir()
-		cobra.CheckErr(err)
+		if err != nil {
+			log.Warningln("No home directory found for user -- will check for configuration yaml in /etc/pelican/")
+		}
 
 		viper.AddConfigPath(filepath.Join(home, ".config", "pelican"))
 		viper.AddConfigPath(filepath.Join("/etc", "pelican"))

--- a/config/config.go
+++ b/config/config.go
@@ -393,7 +393,7 @@ func InitClient() error {
 	} else {
 		configBase, err := getConfigBase()
 		if err != nil {
-			return err
+			log.Warningln("No home directory found for user -- will check for configuration yaml in /etc/pelican/")
 		}
 		viper.SetDefault("IssuerKey", filepath.Join(configBase, "issuer.jwk"))
 	}


### PR DESCRIPTION
In some remote environments like HTCondor, we can't always assume that the user has a configured $HOME directory. Previously, this was enforced in both the root command and in the `main` package's chain of `init()` functions, preventing stash_plugin from running in HTCondor even though no $HOME directory is needed in that case.

This makes an unset $HOME a non-fatal warning at the root command level, and moves `InitServer()` into a pre-run for each cobra command that is actually responsible for starting a server. In the cases of servers, we do still require $HOME.

Closes issue #226 