### PR TITLE
Remove the collector from federation discovery

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -72,7 +72,6 @@ type OSDFConfig struct {
 type FederationDiscovery struct {
 	DirectorEndpoint              string `json:"director_endpoint"`
 	NamespaceRegistrationEndpoint string `json:"namespace_registration_endpoint"`
-	CollectorEndpoint             string `json:"collector_endpoint"`
 	JwksUri                       string `json:"jwks_uri"`
 }
 


### PR DESCRIPTION
We haven't used an HTCondor collector for some time now. Let's finish removing it.