### PR TITLE
Prevent TLSSkipVerify from being overwritten

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -276,7 +276,12 @@ func setupTransport() {
 		systemPool, err := x509.SystemCertPool()
 		if err == nil {
 			systemPool.AddCert(caCert)
-			transport.TLSClientConfig = &tls.Config{RootCAs: systemPool}
+			// Ensure that we don't override the InsecureSkipVerify if it's present
+			if transport.TLSClientConfig == nil {
+				transport.TLSClientConfig = &tls.Config{RootCAs: systemPool}
+			} else {
+				transport.TLSClientConfig.RootCAs = systemPool
+			}
 		}
 	}
 }


### PR DESCRIPTION
This fix should close #229 by preventing TLSSkipVerify param from being overwritten by the CA cert param.