### PR TITLE
Make default log level part of pelican config

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,15 +33,15 @@ func main() {
 }
 
 func handleCLI(args []string) error {
-	exec_name := filepath.Base(args[0])
+	execName := filepath.Base(args[0])
 	// Take care of our Windows users
-	exec_name = strings.TrimSuffix(exec_name, ".exe")
+	execName = strings.TrimSuffix(execName, ".exe")
 	// Being case-insensitive
-	exec_name = strings.ToLower(exec_name)
+	execName = strings.ToLower(execName)
 
-	if exec_name == "stash_plugin" || exec_name == "osdf_plugin" || exec_name == "pelican_xfer_plugin" {
+	if execName == "stash_plugin" || execName == "osdf_plugin" || execName == "pelican_xfer_plugin" {
 		stashPluginMain(args[1:])
-	} else if exec_name == "stashcp" {
+	} else if execName == "stashcp" {
 		err := copyCmd.Execute()
 		if err != nil {
 			return err

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -39,6 +39,7 @@ var (
 		Short: "Copy a file to/from a Pelican federation",
 		Run:   copyMain,
 	}
+	execName string
 )
 
 func init() {

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -39,7 +39,6 @@ var (
 		Short: "Copy a file to/from a Pelican federation",
 		Run:   copyMain,
 	}
-	execName string
 )
 
 func init() {

--- a/config/config.go
+++ b/config/config.go
@@ -336,7 +336,7 @@ func InitConfig() {
 	if param.Debug.GetBool() {
 		SetLogging(log.DebugLevel)
 	} else {
-		logLevel := param.Logging_LogLevel.GetString()
+		logLevel := param.Logging_Level.GetString()
 		level, err := log.ParseLevel(logLevel)
 		if err != nil {
 			cobra.CheckErr(err)

--- a/config/config.go
+++ b/config/config.go
@@ -336,7 +336,12 @@ func InitConfig() {
 	if param.Debug.GetBool() {
 		SetLogging(log.DebugLevel)
 	} else {
-		SetLogging(log.ErrorLevel)
+		logLevel := param.Logging_LogLevel.GetString()
+		level, err := log.ParseLevel(logLevel)
+		if err != nil {
+			cobra.CheckErr(err)
+		}
+		SetLogging(level)
 	}
 }
 

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -15,7 +15,8 @@
 #
 
 Debug: false
-
+Logging:
+  LogLevel: "Error"
 Server:
   Port: 8444
   Address: "0.0.0.0"

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -16,7 +16,7 @@
 
 Debug: false
 Logging:
-  LogLevel: "Error"
+  Level: "Error"
 Server:
   Port: 8444
   Address: "0.0.0.0"

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -110,7 +110,7 @@ name: Logging.LogLevel
 description: >-
   A string defining the log level of the client. Options include (going from most info to least): Trace, Debug, Info, Warn, Error, Fatal, Panic.
 type: string
-default: ErrorLevel
+default: Error
 components: ["*"]
 ---
 

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -104,6 +104,17 @@ components: ["client", "nsregistry", "origin"]
 ---
 
 ############################
+#     Log-Level Configs    #
+############################
+name: Logging.LogLevel
+description: >-
+  A string defining the log level of the client. Options include (going from most info to least): Trace, Debug, Info, Warn, Error, Fatal, Panic.
+type: string
+default: ErrorLevel
+components: ["*"]
+---
+
+############################
 # Federation-Level Configs #
 ############################
 name: Federation.DiscoveryUrl

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -106,7 +106,7 @@ components: ["client", "nsregistry", "origin"]
 ############################
 #     Log-Level Configs    #
 ############################
-name: Logging.LogLevel
+name: Logging.Level
 description: >-
   A string defining the log level of the client. Options include (going from most info to least): Trace, Debug, Info, Warn, Error, Fatal, Panic.
 type: string


### PR DESCRIPTION
Sets the default log level to `ErrorLevel` within `defaults.yaml`. The user is now able to modify their config file and override the default to whatever log level they would like. In addition, the -d flag functionality should remain the same and override whatever config is set. Also found a problem in `object_copy.go` which this does not work if the binary is named stashcp, should work now. Fixed some noticed snake case variable names floating around too and decided to fix them.