### PR TITLE
Fix executable alias not working on Windows

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func main() {
@@ -33,6 +34,11 @@ func main() {
 
 func handleCLI(args []string) error {
 	exec_name := filepath.Base(args[0])
+	// Take care of our Windows users
+	exec_name = strings.TrimSuffix(exec_name, ".exe")
+	// Being case-insensitive
+	exec_name = strings.ToLower(exec_name)
+
 	if exec_name == "stash_plugin" || exec_name == "osdf_plugin" || exec_name == "pelican_xfer_plugin" {
 		stashPluginMain(args[1:])
 	} else if exec_name == "stashcp" {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -105,7 +105,10 @@ func TestHandleCLIVersionFlag(t *testing.T) {
 func TestHandleCLIExecutableAlias(t *testing.T) {
 	// If we're in the process started by exec.Command, run the handleCLI function.
 	if os.Getenv("BE_CRASHER") == "1" {
-		handleCLI(os.Args[1:])
+		err := handleCLI(os.Args[1:])
+		if err != nil {
+			t.Fatalf("Function returns error")
+		}
 		return
 	}
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"testing"
@@ -193,20 +194,30 @@ func TestHandleCLIExecutableAlias(t *testing.T) {
 		}
 	}
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			batchTest(t, tc.args, tc.expected)
-		})
-		t.Run(tc.name+"-windows", func(t *testing.T) {
-			preserve := tc.args[0]
-			tc.args[0] = preserve + ".exe"
-			batchTest(t, tc.args, tc.expected)
-			tc.args[0] = preserve
-		})
-		t.Run(tc.name+"-mixedCase", func(t *testing.T) {
-			preserve := tc.args[0]
-			tc.args[0] = strings.ToUpper(preserve)
-			batchTest(t, tc.args, tc.expected)
-			tc.args[0] = preserve
-		})
+		if os := runtime.GOOS; os == "windows" {
+			// On Windows, you can only do *.exe
+			t.Run(tc.name+"-windows", func(t *testing.T) {
+				preserve := tc.args[0]
+				tc.args[0] = preserve + ".exe"
+				batchTest(t, tc.args, tc.expected)
+				tc.args[0] = preserve
+			})
+		} else {
+			t.Run(tc.name, func(t *testing.T) {
+				batchTest(t, tc.args, tc.expected)
+			})
+			t.Run(tc.name+"-windows", func(t *testing.T) {
+				preserve := tc.args[0]
+				tc.args[0] = preserve + ".exe"
+				batchTest(t, tc.args, tc.expected)
+				tc.args[0] = preserve
+			})
+			t.Run(tc.name+"-mixedCase", func(t *testing.T) {
+				preserve := tc.args[0]
+				tc.args[0] = strings.ToUpper(preserve)
+				batchTest(t, tc.args, tc.expected)
+				tc.args[0] = preserve
+			})
+		}
 	}
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -182,8 +182,6 @@ func TestHandleCLIExecutableAlias(t *testing.T) {
 			if !ok {
 				t.Fatal("Failed to cast error as *exec.ExitError")
 			}
-			// Here you might want to check the exit code if it's relevant to your test.
-			// exitCode := exitError.ExitCode()
 		}
 		// Apparently both stashcp and *_plug will trigger Exit(1) with error if
 		// the arguments are not enough/solid

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -41,6 +41,10 @@ var (
 
 func init() {
 	exec_name := filepath.Base(os.Args[0])
+	// Take care of our Windows users
+	exec_name = strings.TrimSuffix(exec_name, ".exe")
+	// Being case-insensitive
+	exec_name = strings.ToLower(exec_name)
 	flagSet := copyCmd.Flags()
 	flagSet.StringP("cache", "c", "", "Cache to use")
 	flagSet.StringP("token", "t", "", "Token file to use for transfer")


### PR DESCRIPTION
This PR closes #124 where it supports `.exe` extension from windows and different uppercase/lowercase for the executable name and is able to distinguish between different executable alias.