### PR TITLE
Cleanup of pelican config files

### DIFF
--- a/cmd/config_mgr.go
+++ b/cmd/config_mgr.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/namespaces"
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
 
@@ -303,12 +302,4 @@ func init() {
 	rootConfigCmd.CompletionOptions.DisableDefaultCmd = true
 	rootConfigCmd.AddCommand(prefixCmd)
 	rootConfigCmd.AddCommand(tokenCmd)
-}
-
-func setLogging(logLevel log.Level) {
-	textFormatter := log.TextFormatter{}
-	textFormatter.DisableLevelTruncation = true
-	textFormatter.FullTimestamp = true
-	log.SetFormatter(&textFormatter)
-	log.SetLevel(logLevel)
 }

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -79,7 +79,7 @@ func stashPluginMain(args []string) {
 	client.ObjectClientOptions.ProgressBars = false
 	client.ObjectClientOptions.Version = version
 	client.ObjectClientOptions.Plugin = true
-	setLogging(log.PanicLevel)
+	config.SetLogging(log.PanicLevel)
 	methods := []string{"http"}
 	var infile, outfile, testCachePath string
 	var useOutFile bool = false
@@ -114,7 +114,7 @@ func stashPluginMain(args []string) {
 			useOutFile = true
 			log.Debugln("Outfile:", outfile)
 		} else if args[0] == "-d" {
-			setLogging(log.DebugLevel)
+			config.SetLogging(log.DebugLevel)
 		} else if args[0] == "-get-caches" {
 			if len(args) < 2 {
 				log.Errorln("-get-caches requires an argument")

--- a/config/config.go
+++ b/config/config.go
@@ -295,6 +295,7 @@ func GetTransport() *http.Transport {
 }
 
 func InitConfig() {
+	viper.SetConfigType("yaml")
 	// 1) Set up defaults.yaml
 	err := viper.MergeConfig(strings.NewReader(defaultsYaml))
 	if err != nil {
@@ -308,8 +309,8 @@ func InitConfig() {
 			cobra.CheckErr(err)
 		}
 	}
-	if viper.GetString("config") != "" {
-		viper.SetConfigFile(viper.GetString("config"))
+	if configFile := viper.GetString("config"); configFile != "" {
+		viper.SetConfigFile(configFile)
 	} else {
 		home, err := os.UserHomeDir()
 		if err != nil {
@@ -323,7 +324,7 @@ func InitConfig() {
 		viper.SetConfigName("pelican")
 	}
 
-	viper.SetEnvPrefix(GetPreferredPrefix())
+	viper.SetEnvPrefix(prefix)
 	viper.AutomaticEnv()
 	// This line allows viper to use an env var like ORIGIN_VALUE to override the viper string "Origin.Value"
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))

--- a/config/config.go
+++ b/config/config.go
@@ -311,10 +311,10 @@ func InitConfig() {
 	if viper.GetString("config") != "" {
 		viper.SetConfigFile(viper.GetString("config"))
 	} else {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		log.Warningln("No home directory found for user -- will check for configuration yaml in /etc/pelican/")
-	}
+		home, err := os.UserHomeDir()
+		if err != nil {
+			log.Warningln("No home directory found for user -- will check for configuration yaml in /etc/pelican/")
+		}
 
 		// 3) Set up pelican.yaml (has higher precedence)
 		viper.AddConfigPath(filepath.Join(home, ".config", "pelican"))
@@ -418,7 +418,6 @@ func InitServer() error {
 	} else {
 		viper.SetDefault("Origin.Url", fmt.Sprintf("https://%v", param.Server_Hostname.GetString()))
 	}
-
 
 	setupTransport()
 

--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
@@ -293,6 +294,50 @@ func GetTransport() *http.Transport {
 	return transport
 }
 
+func InitConfig() {
+	if viper.GetString("config") != "" {
+		viper.SetConfigFile(viper.GetString("config")) // TODO: bind this to a viper flag/varible in root.go and access here
+	} else {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		log.Warningln("No home directory found for user -- will check for configuration yaml in /etc/pelican/")
+	}
+		// 1) Set up defaults.yaml
+		err = viper.MergeConfig(strings.NewReader(defaultsYaml))
+		if err != nil {
+			cobra.CheckErr(err)
+		}
+		// 2) Set up osdf.yaml (if needed)
+		prefix := GetPreferredPrefix()
+		if prefix == "OSDF" {
+			err := viper.MergeConfig(strings.NewReader(osdfDefaultsYaml))
+			if err != nil {
+				cobra.CheckErr(err)
+			}
+		}
+		// 3) Set up pelican.yaml
+		viper.AddConfigPath(filepath.Join(home, ".config", "pelican"))
+		viper.AddConfigPath(filepath.Join("/etc", "pelican"))
+		viper.SetConfigType("yaml")
+		viper.SetConfigName("pelican")
+	}
+
+	viper.SetEnvPrefix(GetPreferredPrefix())
+	viper.AutomaticEnv()
+	// This line allows viper to use an env var like ORIGIN_VALUE to override the viper string "Origin.Value"
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	if err := viper.MergeInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			cobra.CheckErr(err)
+		}
+	}
+	if param.Debug.GetBool() {
+		SetLogging(log.DebugLevel)
+	} else {
+		SetLogging(log.ErrorLevel)
+	}
+}
+
 func InitServer() error {
 	configDir := viper.GetString("ConfigDir")
 	viper.SetConfigType("yaml")
@@ -366,24 +411,11 @@ func InitServer() error {
 	viper.SetDefault("Server.Hostname", hostname)
 	viper.SetDefault("Xrootd.Sitename", hostname)
 
-	err = viper.MergeConfig(strings.NewReader(defaultsYaml))
-	if err != nil {
-		return err
-	}
-
 	port := param.Xrootd_Port.GetInt()
 	if port != 443 {
 		viper.SetDefault("Origin.Url", fmt.Sprintf("https://%v:%v", param.Server_Hostname.GetString(), port))
 	} else {
 		viper.SetDefault("Origin.Url", fmt.Sprintf("https://%v", param.Server_Hostname.GetString()))
-	}
-
-	prefix := GetPreferredPrefix()
-	if prefix == "OSDF" {
-		err := viper.MergeConfig(strings.NewReader(osdfDefaultsYaml))
-		if err != nil {
-			return err
-		}
 	}
 
 	setupTransport()
@@ -508,4 +540,12 @@ func InitClient() error {
 	setupTransport()
 
 	return DiscoverFederation()
+}
+
+func SetLogging(logLevel log.Level) {
+	textFormatter := log.TextFormatter{}
+	textFormatter.DisableLevelTruncation = true
+	textFormatter.FullTimestamp = true
+	log.SetFormatter(&textFormatter)
+	log.SetLevel(logLevel)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pelicanplatform/pelican/param"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
@@ -110,4 +111,24 @@ func TestDialerTimeout(t *testing.T) {
 	}
 
 	viper.Set("Transport.Dialer.Timeout", time.Second*10)
+}
+
+func TestDefaultsYaml(t *testing.T) {
+	InitConfig() // should set up pelican.yaml and defaults.yaml
+	// create a temp config file to use
+	tempCfgFile, err := os.CreateTemp("", "pelican-*.yaml")
+	if err != nil {
+		t.Fatalf("Failed to make temp file: %v", err)
+	}
+	// Check if debug is false
+	assert.False(t, param.Debug.GetBool())
+	assert.False(t, viper.GetBool("Debug"))
+	viper.Set("Debug", true) // should write to temp config file (should have higher priority like how pelican.yaml behaves)
+	if err := viper.WriteConfigAs(tempCfgFile.Name()); err != nil {
+		t.Fatalf("Failed to write to config file: %v", err)
+	}
+	// Check if debug was set and is now true
+	assert.True(t, param.Debug.GetBool())
+	assert.True(t, viper.GetBool("Debug"))
+	viper.Reset()
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -113,22 +113,38 @@ func TestDialerTimeout(t *testing.T) {
 	viper.Set("Transport.Dialer.Timeout", time.Second*10)
 }
 
-func TestDefaultsYaml(t *testing.T) {
-	InitConfig() // should set up pelican.yaml and defaults.yaml
-	// create a temp config file to use
+func TestInitConfig(t *testing.T) {
+	// Set prefix to OSDF to ensure that config is being set
+	testingPreferredPrefix = "OSDF"
+
+	InitConfig() // Should set up pelican.yaml, osdf.yaml and defaults.yaml
+
+	// Create a temp config file to use
 	tempCfgFile, err := os.CreateTemp("", "pelican-*.yaml")
+	viper.Set("config", tempCfgFile.Name())
 	if err != nil {
 		t.Fatalf("Failed to make temp file: %v", err)
 	}
-	// Check if debug is false
-	assert.False(t, param.Debug.GetBool())
-	assert.False(t, viper.GetBool("Debug"))
-	viper.Set("Debug", true) // should write to temp config file (should have higher priority like how pelican.yaml behaves)
+
+	// Check if server address is correct by defaults.yaml
+	assert.True(t, param.Server_Address.GetString() == "0.0.0.0")
+	// Check that Federation Discovery url is correct by osdf.yaml
+	assert.True(t, param.Federation_DiscoveryUrl.GetString() == "osg-htc.org")
+
+	viper.Set("Server.Address", "1.1.1.1") // should write to temp config file
 	if err := viper.WriteConfigAs(tempCfgFile.Name()); err != nil {
 		t.Fatalf("Failed to write to config file: %v", err)
 	}
-	// Check if debug was set and is now true
-	assert.True(t, param.Debug.GetBool())
-	assert.True(t, viper.GetBool("Debug"))
 	viper.Reset()
+	viper.Set("config", tempCfgFile.Name()) // Set the temp file as the new 'pelican.yaml'
+	InitConfig()
+
+	// Check if server address overrides the default
+	assert.True(t, param.Server_Address.GetString() == "1.1.1.1")
+	viper.Reset()
+
+	//Test if prefix is not set, should not be able to find osdfYaml configuration
+	testingPreferredPrefix = ""
+	InitConfig()
+	assert.True(t, param.Federation_DiscoveryUrl.GetString() == "")
 }

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -142,6 +142,7 @@ func TestWriteOriginScitokensConfig(t *testing.T) {
 	viper.Set("Origin.SelfTest", true)
 	viper.Set("ConfigDir", config_dirname)
 	viper.Set("Xrootd.RunLocation", dirname)
+	viper.Set("Xrootd.Port", 8443)
 	viper.Set("Server.Hostname", "origin.example.com")
 	err := config.InitServer()
 	require.Nil(t, err)


### PR DESCRIPTION
Fixes issues with the 3 config files used with Pelican: defaults.yaml, osdf.yaml, and pelican.yaml. Before this fix there was a bit of a mess of where the configs are set up with viper. This fix moves InitConfig to config.go and sets up all the config files in the priority they need to be with pelican.yaml taking higher precedence than defaults.yaml. Also fixed issue in object_copy.go with some weird issues with the -d flag. Only need to check for the -d flag with stashcp since it does not go through root, any other modes are checked within root/initconfig and trigger debug mode.