### PR TITLE
Expose director's public key via Open ID style URLs

### DIFF
--- a/cmd/namespace_registry_serve.go
+++ b/cmd/namespace_registry_serve.go
@@ -34,6 +34,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func generateTLSCertIfNeeded() error {
+	// As necessary, generate a private key and corresponding cert
+	if err := config.GeneratePrivateKey(param.Server_TLSKey.GetString(), elliptic.P256()); err != nil {
+		return err
+	}
+	if err := config.GenerateCert(); err != nil {
+		return err
+	}
+	return nil
+}
+
 func serveNamespaceRegistry( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	log.Info("Initializing the namespace registry's database...")
 
@@ -43,7 +54,6 @@ func serveNamespaceRegistry( /*cmd*/ *cobra.Command /*args*/, []string) error {
 		return errors.Wrap(err, "Unable to initialize the namespace registry database")
 	}
 
-	// function defined in director_serve
 	err = generateTLSCertIfNeeded()
 	if err != nil {
 		return errors.Wrap(err, "Failed to generate TLS certificate")

--- a/director/authentication.go
+++ b/director/authentication.go
@@ -1,0 +1,61 @@
+package director
+
+import (
+	"encoding/json"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
+	log "github.com/sirupsen/logrus"
+)
+
+type DiscoveryResponse struct {
+	JwksUri string `json:"jwks_uri"`
+}
+
+// Returns links related to director's authentication, including the link
+// to get the public key from the director
+func discoveryHandler(ctx *gin.Context) {
+	directorUrl := param.Federation_DirectorUrl.GetString()
+	if len(directorUrl) == 0 {
+		ctx.JSON(500, gin.H{"error": "Bad server configuration: Director URL is not set"})
+		return
+	}
+	rs := DiscoveryResponse{
+		JwksUri: directorUrl + "/.well-known/public-signing-key.jwks",
+	}
+	jsonData, err := json.MarshalIndent(rs, "", "  ")
+	if err != nil {
+		ctx.JSON(500, gin.H{"error": "Failed to marshal director's discovery response"})
+		return
+	}
+	// Append a new line to the JSON data
+	jsonData = append(jsonData, '\n')
+	ctx.Header("Content-Disposition", "attachment; filename=pelican-director-configuration.json")
+	ctx.Data(200, "application/json", jsonData)
+}
+
+// Returns director's public key
+func jwksHandler(ctx *gin.Context) {
+	issuerKeyfile := param.IssuerKey.GetString()
+	key, err := config.LoadPublicKey("", issuerKeyfile)
+	if err != nil {
+		log.Errorf("Failed to load director's public key: %v", err)
+		ctx.JSON(500, gin.H{"error": "Failed to load director's public key"})
+	} else {
+		jsonData, err := json.MarshalIndent(key, "", "  ")
+		if err != nil {
+			ctx.JSON(500, gin.H{"error": "Failed to marshal director's public key"})
+			return
+		}
+		// Append a new line to the JSON data
+		jsonData = append(jsonData, '\n')
+		ctx.Header("Content-Disposition", "attachment; filename=public-signing-key.jwks")
+		ctx.Data(200, "application/json", jsonData)
+	}
+}
+
+func RegisterDirectorAuth(router *gin.RouterGroup) {
+	router.GET("/.well-known/pelican-configuration", discoveryHandler)
+	router.GET("/.well-known/public-signing-key.jwks", jwksHandler)
+}

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -265,6 +265,11 @@ func RedirectToOrigin(ginCtx *gin.Context) {
 // original request had been made to /api/v1.0/director/object/foo/bar
 func ShortcutMiddleware(defaultResponse string) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// If this is a request for getting public key, don't modify the path
+		if strings.HasPrefix(c.Request.URL.Path, "/.well-known") {
+			c.Next()
+			return
+		}
 		// If we're configured for cache mode or we haven't set the flag,
 		// we should use cache middleware
 		if defaultResponse == "cache" {


### PR DESCRIPTION
* Generate private/public key pair for director at the director's start
* Expose director's discovery url at `<directorURL>/.well-known/pelican-configuration` which contains the `jwks_uri` attribute for accessing the public keyset
* Expose director's public keyset uri at `<directorURL>/.well-known/public_signing_key.jwks`
* Added an API in `director_api.go` `LoadDirectorPublicKey` to access director's public key from anywhere in the application