### PR TITLE
Replaced some remaining viper.Get* calls with the appropriate param.GetString() call

### DIFF
--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -51,9 +51,9 @@ func checkConfigFileReadable(fileName string, errMsg string) error {
 }
 
 func checkDefaults() error {
-	requiredConfigs := []string{"Server.TLSCertificate", "Server.TLSKey", "Xrootd.RunLocation", "Xrootd.RobotsTxtFile"}
+	requiredConfigs := []param.StringParam{param.Server_TLSCertificate, param.Server_TLSKey, param.Xrootd_RunLocation, param.Xrootd_RobotsTxtFile}
 	for _, configName := range requiredConfigs {
-		mgr := viper.GetString(configName) // TODO: Remove direct access once all parameters are generated
+		mgr := configName.GetString()
 		if mgr == "" {
 			return errors.New(fmt.Sprintf("Required value of '%v' is not set in config",
 				configName))

--- a/config/config.go
+++ b/config/config.go
@@ -492,17 +492,17 @@ func InitClient() error {
 		break
 	}
 	if viper.IsSet("MinimumDownloadSpeed") {
-		viper.SetDefault("Client.MinimumDownloadSpeed", viper.GetString("MinimumDownloadSpeed"))
+		viper.SetDefault("Client.MinimumDownloadSpeed", param.MinimumDownloadSpeed.GetInt())
 	} else {
 		viper.Set("Client.MinimumDownloadSpeed", downloadLimit)
 	}
 
 	// Handle more legacy config options
 	if viper.IsSet("DisableProxyFallback") {
-		viper.SetDefault("Client.DisableProxyFallback", viper.GetString("DisableProxyFallback"))
+		viper.SetDefault("Client.DisableProxyFallback", param.DisableProxyFallback.GetBool())
 	}
 	if viper.IsSet("DisableHttpProxy") {
-		viper.SetDefault("Client.DisableHttpProxy", viper.GetString("DisableHttpProxy"))
+		viper.SetDefault("Client.DisableHttpProxy", param.DisableHttpProxy.GetBool())
 	}
 
 	setupTransport()


### PR DESCRIPTION
Just some replacements to viper.Get* that didn't occur before. Should be a very quick review.