### PR TITLE
Change /health API components data from map to array

### DIFF
--- a/metrics/health.go
+++ b/metrics/health.go
@@ -29,6 +29,7 @@ import (
 
 type (
 	ComponentStatus struct {
+		Name       string `json:"name"`
 		Status     string `json:"status"`
 		Message    string `json:"message,omitempty"`
 		LastUpdate int64  `json:"last_update"`
@@ -41,8 +42,8 @@ type (
 	}
 
 	HealthStatus struct {
-		OverallStatus   string                     `json:"status"`
-		ComponentStatus map[string]ComponentStatus `json:"components"`
+		OverallStatus   string            `json:"status"`
+		ComponentStatus []ComponentStatus `json:"components"`
 	}
 )
 
@@ -120,13 +121,15 @@ func GetHealthStatus() HealthStatus {
 			return true
 		}
 		if status.ComponentStatus == nil {
-			status.ComponentStatus = make(map[string]ComponentStatus)
+			status.ComponentStatus = make([]ComponentStatus, 0)
 		}
-		status.ComponentStatus[componentString] = ComponentStatus{
-			intToStatus(componentStatus.Status),
-			componentStatus.Message,
-			componentStatus.LastUpdate.Unix(),
-		}
+		status.ComponentStatus = append(status.ComponentStatus,
+			ComponentStatus{
+				componentString,
+				intToStatus(componentStatus.Status),
+				componentStatus.Message,
+				componentStatus.LastUpdate.Unix(),
+			})
 		if componentStatus.Status < overallStatus {
 			overallStatus = componentStatus.Status
 		}

--- a/metrics/health_test.go
+++ b/metrics/health_test.go
@@ -1,0 +1,79 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetHealthStatus(t *testing.T) {
+	type mock struct {
+		Name       string
+		Status     int
+		Message    string
+		LastUpdate time.Time
+	}
+	mockData := []mock{
+		{
+			Name:       "xrootd",
+			Status:     1,
+			Message:    "Error message",
+			LastUpdate: time.Now(),
+		},
+		{
+			Name:       "federation",
+			Status:     3,
+			Message:    "",
+			LastUpdate: time.Now(),
+		},
+		{
+			Name:       "director",
+			Status:     2,
+			Message:    "",
+			LastUpdate: time.Now(),
+		},
+	}
+
+	setup := func() {
+		for _, data := range mockData {
+			healthStatus.Store(data.Name, componentStatusInternal{data.Status, data.Message, data.LastUpdate})
+		}
+
+	}
+
+	teardown := func() {
+		healthStatus.Range(func(key interface{}, value interface{}) bool {
+			healthStatus.Delete(key)
+			return true
+		})
+	}
+
+	containsName := func(mockData []mock, name string) bool {
+		for _, mockElement := range mockData {
+			if mockElement.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("empty-map-returns-empty-list", func(t *testing.T) {
+		// clear the map first
+		teardown()
+		result := GetHealthStatus()
+		assert.Equal(t, len(result.ComponentStatus), 0, "Empty health map returns non-empty array")
+		assert.Equal(t, result.OverallStatus, "unknown", "Empty health map returns overall status that is not \"unknown\"")
+	})
+	t.Run("populated-map-works-as-expected", func(t *testing.T) {
+		setup()
+		defer teardown()
+		result := GetHealthStatus()
+		assert.Equal(t, len(result.ComponentStatus), len(mockData), "Health map returns array that has different size as expected")
+		assert.Equal(t, result.OverallStatus, "critical", "Overall status didn't reflect the worst component health status")
+		for _, ele := range result.ComponentStatus {
+			assert.True(t, containsName(mockData, ele.Name), "Returned value doesn't exist in map")
+		}
+	})
+
+}


### PR DESCRIPTION
This PR should close #231 which changes the return value of `/health` API to make it more robust. The `components` field is changed from a map of components health status `"componentName": {}`, to an array of component health status: 

```json
"components": [
      {
          "name": "cmsd",
          "status": "ok",
          "last_update": 1698087191
      },
      {
          "name": "federation",
          "status": "critical",
          "message": "Error advertising origin to federation",
          "last_update": 1698087191
      }
]
```

In hope by doing this, we can eliminate errors from missing component health status at the front end.

**This PR should be merged jointly with the PR for #232.**