### PR TITLE
Move npm path placeholder creation from GHA to Go

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,8 +23,6 @@ jobs:
       - name: Generate placeholder files
         id: generate-placeholder
         run: |
-          mkdir -p origin_ui/src/out
-          touch origin_ui/src/out/placeholder
           go generate ./...
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/generate/next_generator.go
+++ b/generate/next_generator.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+)
+
+// Generate a placeholder file under origin_ui/src/out so that
+// we can build Go without error. This is mainly for the linter
+// GitHub Action that doesn't need frontend to be built. Refer to
+// linter GHA for details.
+func GenPlaceholderPathForNext() {
+	dir := "../origin_ui/src/out"
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		log.Fatalf("error: %v", err)
+	}
+
+	filePath := filepath.Join(dir, "placeholder")
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+	file.Close()
+}

--- a/generate/param_generator.go
+++ b/generate/param_generator.go
@@ -17,6 +17,7 @@ import (
 
 func main() {
 	GenParamEnum()
+	GenPlaceholderPathForNext()
 }
 
 var requiredKeys = [4]string{"name", "description", "default", "type"}

--- a/param/param.go
+++ b/param/param.go
@@ -1,3 +1,3 @@
 package param
 
-//go:generate go run ../generate/param_generator.go
+//go:generate go run ../generate


### PR DESCRIPTION
According to #72, we want to move the "placeholder file" creation for GHA linter from the GHA to `go:generate`. I created a `generator/next_generator.go` to programmatically generate path and placeholder file to `origin_ui/src/out/placeholder`, removed the same logic in GHA, and updated the command that calls `go:generate`

However, this change, as well as #268 makes `generate` and `param` package grow out of its original scope. I suggest that we move the `main` function from `param_generator.go` to a separate file like `main.go` and potentially move the call to `go:generate` from `param/param.go` to `generate/main.go` so that the logic is more clear as we are not just generating files for params.