### PR TITLE
Fixed mispelled filename in .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 dist/
 README.dev.md
 param/parameters.go
-docs/parameter.json
+docs/parameters.json


### PR DESCRIPTION
This should now ignore the docs/parameters.json