### PR TITLE
Fix some issues with Pelican RPMs

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,10 +58,10 @@ nfpms:
     file_name_template: '{{ .PackageName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     id: pelican
     vendor: OSG Consortium
-    homepage: https://github.com/PelicanProject/pelican
+    homepage: https://github.com/PelicanPlatform/pelican
     maintainer: Brian Bockelman <bbockelman@morgridge.org>
     description: Command-line copy tool for the Open Science Data Federation
-    license: Apache 2.0
+    license: ASL 2.0
     formats:
       - apk
       - deb
@@ -74,15 +74,23 @@ nfpms:
       rpm:
         contents:
           - src: LICENSE
-            dst: "/usr/share/doc/{{ .PackageName }}-{{ .Version }}/LICENSE.txt"
+            dst: "usr/share/doc/{{ .PackageName }}-{{ .Version }}/LICENSE.txt"
+            file_info:
+              mode: 0644
           - src: README.md
-            dst: "/usr/share/doc/{{ .PackageName }}-{{ .Version }}/README.md"
+            dst: "usr/share/doc/{{ .PackageName }}-{{ .Version }}/README.md"
+            file_info:
+              mode: 0644
         file_name_template: >-
           {{ .PackageName }}-{{ .Version }}-{{ .Release }}.{{ if eq .Arch "amd64" }}x86_64{{ else }}{{ .Arch }}{{ end }}
       deb:
         file_name_template: "{{ .PackageName }}-{{ .Version }}-{{ .Release }}_{{ .Arch }}"
         contents:
           - src: LICENSE
-            dst: "/usr/share/doc/{{ .PackageName }}/LICENSE.txt"
+            dst: "usr/share/doc/{{ .PackageName }}/LICENSE.txt"
+            file_info:
+              mode: 0644
           - src: README.md
-            dst: "/usr/share/doc/{{ .PackageName }}/README.md"
+            dst: "usr/share/doc/{{ .PackageName }}/README.md"
+            file_info:
+              mode: 0644

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -77,10 +77,12 @@ nfpms:
             dst: "usr/share/doc/{{ .PackageName }}-{{ .Version }}/LICENSE.txt"
             file_info:
               mode: 0644
+            type: doc
           - src: README.md
             dst: "usr/share/doc/{{ .PackageName }}-{{ .Version }}/README.md"
             file_info:
               mode: 0644
+            type: doc
         file_name_template: >-
           {{ .PackageName }}-{{ .Version }}-{{ .Release }}.{{ if eq .Arch "amd64" }}x86_64{{ else }}{{ .Arch }}{{ end }}
       deb:
@@ -90,7 +92,9 @@ nfpms:
             dst: "usr/share/doc/{{ .PackageName }}/LICENSE.txt"
             file_info:
               mode: 0644
+            type: doc
           - src: README.md
             dst: "usr/share/doc/{{ .PackageName }}/README.md"
             file_info:
               mode: 0644
+            type: doc

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,12 +74,12 @@ nfpms:
       rpm:
         contents:
           - src: LICENSE
-            dst: "usr/share/doc/{{ .PackageName }}-{{ .Version }}/LICENSE.txt"
+            dst: "/usr/share/doc/{{ .PackageName }}-{{ .Version }}/LICENSE.txt"
             file_info:
               mode: 0644
             type: doc
           - src: README.md
-            dst: "usr/share/doc/{{ .PackageName }}-{{ .Version }}/README.md"
+            dst: "/usr/share/doc/{{ .PackageName }}-{{ .Version }}/README.md"
             file_info:
               mode: 0644
             type: doc
@@ -89,12 +89,12 @@ nfpms:
         file_name_template: "{{ .PackageName }}-{{ .Version }}-{{ .Release }}_{{ .Arch }}"
         contents:
           - src: LICENSE
-            dst: "usr/share/doc/{{ .PackageName }}/LICENSE.txt"
+            dst: "/usr/share/doc/{{ .PackageName }}/LICENSE.txt"
             file_info:
               mode: 0644
             type: doc
           - src: README.md
-            dst: "usr/share/doc/{{ .PackageName }}/README.md"
+            dst: "/usr/share/doc/{{ .PackageName }}/README.md"
             file_info:
               mode: 0644
             type: doc


### PR DESCRIPTION
Fixes only some of the issues with Pelican RPMs. The issues fixed are that the LICENSE and the README were world writable, so I made them read only. There was a typo with the homepage, and the license was changed to an accepted format for Apache 2.0.