### PR TITLE
Fix dev container build failure by specify base image platform

### DIFF
--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -1,5 +1,7 @@
 
-FROM hub.opensciencegrid.org/sciauth/scitokens-oauth2-server:release AS scitokens-oauth2-server
+# We specify the platform as scitokens-oauth2-server didn't publish arm version and we don't want to
+# fail on building this container on arm machine
+FROM --platform=linux/amd64 hub.opensciencegrid.org/sciauth/scitokens-oauth2-server:release AS scitokens-oauth2-server
 
 FROM almalinux:8
 


### PR DESCRIPTION
Hot fix for the latest build-dev-container GHA failure on main branch as `scitokens-oauth2-server` base image isn't built for arm platform. Fix by specifying `--platform` on base image as `amd64`.