### PR TITLE
Add Web URL in origin's advertisement message

### DIFF
--- a/director/advertise.go
+++ b/director/advertise.go
@@ -94,6 +94,10 @@ func parseServerAd(server Server, serverType ServerType) ServerAd {
 	}
 	serverAd.URL = *serverUrl
 
+	// We assume that the WebURL we get from topology is the same as the origin XRootD URL for now
+	// Would like to have a separate field for WebURL in the future
+	serverAd.WebURL = *serverUrl
+
 	return serverAd
 }
 

--- a/director/advertise.go
+++ b/director/advertise.go
@@ -94,9 +94,7 @@ func parseServerAd(server Server, serverType ServerType) ServerAd {
 	}
 	serverAd.URL = *serverUrl
 
-	// We assume that the WebURL we get from topology is the same as the origin XRootD URL for now
-	// Would like to have a separate field for WebURL in the future
-	serverAd.WebURL = *serverUrl
+	// We will leave serverAd.WebURL as empty when fetched from topology
 
 	return serverAd
 }

--- a/director/advertise_test.go
+++ b/director/advertise_test.go
@@ -22,6 +22,7 @@ func TestParseServerAd(t *testing.T) {
 	ad := parseServerAd(server, OriginType)
 	assert.Equal(t, ad.AuthURL.String(), "https://my-auth-endpoint.com")
 	assert.Equal(t, ad.URL.String(), "http://my-endpoint.com")
+	assert.Equal(t, ad.WebURL.String(), "")
 	assert.Equal(t, ad.Name, "MY_SERVER")
 	assert.True(t, ad.Type == OriginType)
 

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -47,7 +47,8 @@ type (
 	ServerAd struct {
 		Name      string
 		AuthURL   url.URL
-		URL       url.URL
+		URL       url.URL // This is server's XRootD URL for file transfer
+		WebURL    url.URL // This is server's Web interface and API
 		Type      ServerType
 		Latitude  float64
 		Longitude float64

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -42,7 +42,8 @@ import (
 type (
 	OriginAdvertise struct {
 		Name       string        `json:"name"`
-		URL        string        `json:"url"`
+		URL        string        `json:"url"`     // This is the url for origin's XRootD service and file transfer
+		WebURL     string        `json:"web_url"` // This is the url for origin's web engine and APIs
 		Namespaces []NamespaceAd `json:"namespaces"`
 	}
 )

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -42,8 +42,8 @@ import (
 type (
 	OriginAdvertise struct {
 		Name       string        `json:"name"`
-		URL        string        `json:"url"`     // This is the url for origin's XRootD service and file transfer
-		WebURL     string        `json:"web_url"` // This is the url for origin's web engine and APIs
+		URL        string        `json:"url"`               // This is the url for origin's XRootD service and file transfer
+		WebURL     string        `json:"web_url,omitempty"` // This is the url for origin's web engine and APIs
 		Namespaces []NamespaceAd `json:"namespaces"`
 	}
 )

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -338,10 +338,18 @@ func RegisterOrigin(ctx *gin.Context) {
 		return
 	}
 
+	adWebUrl, err := url.Parse(ad.WebURL)
+	if err != nil {
+		log.Warningf("Failed to parse origin Web URL %v: %v\n", ad.WebURL, err)
+		ctx.JSON(400, gin.H{"error": "Invalid origin Web URL"})
+		return
+	}
+
 	originAd := ServerAd{
 		Name:    ad.Name,
 		AuthURL: *ad_url,
 		URL:     *ad_url,
+		WebURL:  *adWebUrl,
 		Type:    OriginType,
 	}
 	RecordAd(originAd, &ad.Namespaces)

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -339,7 +339,7 @@ func RegisterOrigin(ctx *gin.Context) {
 	}
 
 	adWebUrl, err := url.Parse(ad.WebURL)
-	if err != nil {
+	if err != nil && ad.WebURL != "" { // We allow empty WebURL string for backward compatibility
 		log.Warningf("Failed to parse origin Web URL %v: %v\n", ad.WebURL, err)
 		ctx.JSON(400, gin.H{"error": "Invalid origin Web URL"})
 		return

--- a/director/redirect_test.go
+++ b/director/redirect_test.go
@@ -56,181 +56,186 @@ func TestDirectorRegistration(t *testing.T) {
 
 	viper.Reset()
 
-	// Setup httptest recorder and context for the the unit test
-	w := httptest.NewRecorder()
-	c, r := gin.CreateTestContext(w)
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		assert.Equal(t, "POST", req.Method, "Not POST Method")
-		_, err := w.Write([]byte(":)"))
-		assert.NoError(t, err)
-	}))
-	defer ts.Close()
-	c.Request = &http.Request{
-		URL: &url.URL{},
+	viper.Set("Federation.NamespaceURL", "https://get-your-tokens.org")
+
+	setupContext := func() (*gin.Context, *gin.Engine, *httptest.ResponseRecorder) {
+		// Setup httptest recorder and context for the the unit test
+		w := httptest.NewRecorder()
+		c, r := gin.CreateTestContext(w)
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			assert.Equal(t, "POST", req.Method, "Not POST Method")
+			_, err := w.Write([]byte(":)"))
+			assert.NoError(t, err)
+		}))
+		defer ts.Close()
+
+		c.Request = &http.Request{
+			URL: &url.URL{},
+		}
+		return c, r, w
 	}
 
-	// Create a private key to use for the test
-	privateKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
-	assert.NoError(t, err, "Error generating private key")
+	generateToken := func(c *gin.Context) (jwk.Key, string, url.URL) {
+		// Create a private key to use for the test
+		privateKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+		assert.NoError(t, err, "Error generating private key")
 
-	// Convert from raw ecdsa to jwk.Key
-	pKey, err := jwk.FromRaw(privateKey)
-	assert.NoError(t, err, "Unable to convert ecdsa.PrivateKey to jwk.Key")
+		// Convert from raw ecdsa to jwk.Key
+		pKey, err := jwk.FromRaw(privateKey)
+		assert.NoError(t, err, "Unable to convert ecdsa.PrivateKey to jwk.Key")
 
-	//Assign Key id to the private key
-	err = jwk.AssignKeyID(pKey)
-	assert.NoError(t, err, "Error assigning kid to private key")
+		//Assign Key id to the private key
+		err = jwk.AssignKeyID(pKey)
+		assert.NoError(t, err, "Error assigning kid to private key")
 
-	//Set an algorithm for the key
-	err = pKey.Set(jwk.AlgorithmKey, jwa.ES256)
-	assert.NoError(t, err, "Unable to set algorithm for pKey")
+		//Set an algorithm for the key
+		err = pKey.Set(jwk.AlgorithmKey, jwa.ES256)
+		assert.NoError(t, err, "Unable to set algorithm for pKey")
 
-	// Create a public key from the private key
-	publicKey, err := jwk.PublicKeyOf(pKey)
-	assert.NoError(t, err, "Error creating public key from private key")
+		issuerURL := url.URL{
+			Scheme: "https",
+			Path:   "get-your-tokens.org/namespaces/foo/bar",
+			Host:   c.Request.URL.Host,
+		}
 
-	// Create a token to be inserted
-	issuerURL := url.URL{}
-	issuerURL.Scheme = "https"
-	issuerURL.Path = "get-your-tokens.org/namespaces/foo/bar"
-	issuerURL.Host = c.Request.URL.Host
+		// Create a token to be inserted
+		tok, err := jwt.NewBuilder().
+			Issuer(issuerURL.String()).
+			Claim("scope", "pelican.advertise").
+			Audience([]string{"director.test"}).
+			Subject("origin").
+			Build()
+		assert.NoError(t, err, "Error creating token")
 
-	tok, err := jwt.NewBuilder().
-		Issuer(issuerURL.String()).
-		Claim("scope", "pelican.advertise").
-		Audience([]string{"director.test"}).
-		Subject("origin").
-		Build()
+		signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256, pKey))
+		assert.NoError(t, err, "Error signing token")
 
-	assert.NoError(t, err, "Error creating token")
+		return pKey, string(signed), issuerURL
+	}
 
-	// Sign token with previously created private key
-	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256, pKey))
-	assert.NoError(t, err, "Error signing token")
+	setupRequest := func(c *gin.Context, r *gin.Engine, bodyStr, token string) {
+		r.POST("/", RegisterOrigin)
+		c.Request, _ = http.NewRequest(http.MethodPost, "/", bytes.NewBuffer([]byte(bodyStr)))
+		c.Request.Header.Set("Authorization", "Bearer "+token)
+		c.Request.Header.Set("Content-Type", "application/json")
+		// Hard code the current min version. When this test starts failing because of new stuff in the Director,
+		// we'll know that means it's time to update the min version in redirect.go
+		c.Request.Header.Set("User-Agent", "pelican-origin/7.0.0")
+	}
 
 	// Inject into the cache, using a mock cache to avoid dealing with
 	// real namespaces
-	ar := MockCache{
-		GetFn: func(key string, keyset *jwk.Set) (jwk.Set, error) {
-			if key != "https://get-your-tokens.org/api/v1.0/registry/foo/bar/.well-known/issuer.jwks" {
-				t.Errorf("expecting: https://get-your-tokens.org/api/v1.0/registry/foo/bar/.well-known/issuer.jwks, got %q", key)
-			}
-			return *keyset, nil
-		},
-		RegisterFn: func(m *MockCache) error {
-			err := jwk.Set.AddKey(m.keyset, publicKey)
-			if err != nil {
-				t.Error(err)
-			}
-			return nil
-		},
+	setupMockCache := func(t *testing.T, publicKey jwk.Key) MockCache {
+		return MockCache{
+			GetFn: func(key string, keyset *jwk.Set) (jwk.Set, error) {
+				if key != "https://get-your-tokens.org/api/v1.0/registry/foo/bar/.well-known/issuer.jwks" {
+					t.Errorf("expecting: https://get-your-tokens.org/api/v1.0/registry/foo/bar/.well-known/issuer.jwks, got %q", key)
+				}
+				return *keyset, nil
+			},
+			RegisterFn: func(m *MockCache) error {
+				err := jwk.Set.AddKey(m.keyset, publicKey)
+				if err != nil {
+					t.Error(err)
+				}
+				return nil
+			},
+		}
 	}
 
 	// Perform injections (ar.Register will create a jwk.keyset with the publickey in it)
-	func() {
-		if err = ar.Register(issuerURL.String(), jwk.WithMinRefreshInterval(15*time.Minute)); err != nil {
+	useMockCache := func(ar MockCache, issuerURL url.URL) {
+		if err := ar.Register(issuerURL.String(), jwk.WithMinRefreshInterval(15*time.Minute)); err != nil {
 			t.Errorf("this should never happen, should actually be impossible, including check for the linter")
 		}
 		namespaceKeysMutex.Lock()
 		defer namespaceKeysMutex.Unlock()
 		namespaceKeys.Set("/foo/bar", &ar, ttlcache.DefaultTTL)
-	}()
-
-	// Set the namespaceurl
-	viper.Set("Federation.NamespaceURL", "https://get-your-tokens.org")
-
-	// Create the  request and set the headers
-	r.POST("/", RegisterOrigin)
-	c.Request, _ = http.NewRequest(http.MethodPost, "/", bytes.NewBuffer([]byte(`{"Namespaces": [{"Path": "/foo/bar", "URL": "https://get-your-tokens.org"}]}`)))
-
-	c.Request.Header.Set("Authorization", "Bearer "+string(signed))
-	c.Request.Header.Set("Content-Type", "application/json")
-	// Hard code the current min version. When this test starts failing because of new stuff in the Director,
-	// we'll know that means it's time to update the min version in redirect.go
-	c.Request.Header.Set("User-Agent", "pelican-origin/7.0.0")
-
-	r.ServeHTTP(w, c.Request)
-
-	// Check to see that the code exits with status code 200 after given it a good token
-	assert.Equal(t, 200, w.Result().StatusCode, "Expected status code of 200")
-
-	namaspaceADs := ListNamespacesFromOrigins()
-	assert.True(t, NamespaceAdContainsPath(namaspaceADs, "/foo/bar"), "Coudln't find namespace in the director cache.")
-	serverAds.DeleteAll()
-
-	// Now repeat the above test, but with an invalid token
-	// Setup httptest recorder and context for the the unit test
-	wInv := httptest.NewRecorder()
-	cInv, rInv := gin.CreateTestContext(wInv)
-	tsInv := httptest.NewServer(http.HandlerFunc(func(wInv http.ResponseWriter, req *http.Request) {
-		assert.Equal(t, "POST", req.Method, "Not POST Method")
-		_, err := wInv.Write([]byte(":)"))
-		assert.NoError(t, err)
-	}))
-	defer tsInv.Close()
-	cInv.Request = &http.Request{
-		URL: &url.URL{},
 	}
 
-	// Create a private key to use for the test
-	privateKeyInv, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
-	assert.NoError(t, err, "Error generating private key")
+	t.Run("valid-token", func(t *testing.T) {
+		c, r, w := setupContext()
+		pKey, token, issuerURL := generateToken(c)
+		publicKey, err := jwk.PublicKeyOf(pKey)
+		assert.NoError(t, err, "Error creating public key from private key")
 
-	// Convert from raw ecdsa to jwk.Key
-	pKeyInv, err := jwk.FromRaw(privateKeyInv)
-	assert.NoError(t, err, "Unable to convert ecdsa.PrivateKey to jwk.Key")
+		ar := setupMockCache(t, publicKey)
+		useMockCache(ar, issuerURL)
 
-	//Assign Key id to the private key
-	err = jwk.AssignKeyID(pKeyInv)
-	assert.NoError(t, err, "Error assigning kid to private key")
+		setupRequest(c, r, `{"Namespaces": [{"Path": "/foo/bar", "URL": "https://get-your-tokens.org"}]}`, token)
 
-	//Set an algorithm for the key
-	err = pKeyInv.Set(jwk.AlgorithmKey, jwa.ES256)
-	assert.NoError(t, err, "Unable to set algorithm for pKey")
+		r.ServeHTTP(w, c.Request)
 
-	// Create a token to be inserted
-	issuerURL.Host = cInv.Request.URL.Host
+		// Check to see that the code exits with status code 200 after given it a good token
+		assert.Equal(t, 200, w.Result().StatusCode, "Expected status code of 200")
 
-	// Sign token with previously created private key (mismatch to what's in the keyset)
-	signedInv, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256, pKeyInv))
-	assert.NoError(t, err, "Error signing token")
+		namaspaceADs := ListNamespacesFromOrigins()
+		// If the origin was successfully registed at director, we should be able to find it in director's originAds
+		assert.True(t, NamespaceAdContainsPath(namaspaceADs, "/foo/bar"), "Coudln't find namespace in the director cache.")
+		serverAds.DeleteAll()
+	})
 
-	// Create the  request and set the headers
-	rInv.POST("/", RegisterOrigin)
-	cInv.Request, _ = http.NewRequest(http.MethodPost, "/", bytes.NewBuffer([]byte(`{"Namespaces": [{"Path": "/foo/bar", "URL": "https://get-your-tokens.org"}]}`)))
+	// Now repeat the above test, but with an invalid token
+	t.Run("invalid-token", func(t *testing.T) {
+		c, r, w := setupContext()
+		wrongPrivateKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+		assert.NoError(t, err, "Error creating another private key")
+		_, token, issuerURL := generateToken(c)
 
-	cInv.Request.Header.Set("Authorization", "Bearer "+string(signedInv))
-	cInv.Request.Header.Set("Content-Type", "application/json")
-	// Hard code the current min version. When this test starts failing because of new stuff in the Director,
-	// we'll know that means it's time to update the min version in redirect.go
-	cInv.Request.Header.Set("User-Agent", "pelican-origin/7.0.0")
+		wrongPublicKey, err := jwk.PublicKeyOf(wrongPrivateKey)
+		assert.NoError(t, err, "Error creating public key from private key")
+		ar := setupMockCache(t, wrongPublicKey)
+		useMockCache(ar, issuerURL)
 
-	rInv.ServeHTTP(wInv, cInv.Request)
-	assert.Equal(t, 400, wInv.Result().StatusCode, "Expected failing status code of 400")
-	body, _ := io.ReadAll(wInv.Result().Body)
-	assert.Equal(t, `{"error":"Authorization token verification failed"}`, string(body), "Failure wasn't because token verification failed")
+		setupRequest(c, r, `{"Namespaces": [{"Path": "/foo/bar", "URL": "https://get-your-tokens.org"}]}`, token)
 
-	namaspaceADs = ListNamespacesFromOrigins()
-	assert.False(t, NamespaceAdContainsPath(namaspaceADs, "/foo/bar"), "Found namespace in the director cache even if the token validation failed.")
-	serverAds.DeleteAll()
+		r.ServeHTTP(w, c.Request)
 
-	// Now test it with WebUrl provided and it should appear in the cache
-	webUrl := "https://localhost:8844"
-	cUrl, _ := gin.CreateTestContext(w)
+		assert.Equal(t, 400, w.Result().StatusCode, "Expected failing status code of 400")
+		body, _ := io.ReadAll(w.Result().Body)
+		assert.Equal(t, `{"error":"Authorization token verification failed"}`, string(body), "Failure wasn't because token verification failed")
 
-	cUrl.Request, _ = http.NewRequest(http.MethodPost, "/", bytes.NewBuffer([]byte(`{"web_url": "https://localhost:8844","Namespaces": [{"Path": "/foo/bar", "URL": "https://get-your-tokens.org"}]}`)))
+		namaspaceADs := ListNamespacesFromOrigins()
+		assert.False(t, NamespaceAdContainsPath(namaspaceADs, "/foo/bar"), "Found namespace in the director cache even if the token validation failed.")
+		serverAds.DeleteAll()
+	})
 
-	cUrl.Request.Header.Set("Authorization", "Bearer "+string(signed))
-	cUrl.Request.Header.Set("Content-Type", "application/json")
-	// Hard code the current min version. When this test starts failing because of new stuff in the Director,
-	// we'll know that means it's time to update the min version in redirect.go
-	cUrl.Request.Header.Set("User-Agent", "pelican-origin/7.0.0")
+	t.Run("valid-token-with-web-url", func(t *testing.T) {
+		c, r, w := setupContext()
+		pKey, token, issuerURL := generateToken(c)
+		publicKey, err := jwk.PublicKeyOf(pKey)
+		assert.NoError(t, err, "Error creating public key from private key")
+		ar := setupMockCache(t, publicKey)
+		useMockCache(ar, issuerURL)
 
-	r.ServeHTTP(w, cUrl.Request)
-	assert.Equal(t, 200, w.Result().StatusCode, "Expected status code of 200")
-	assert.Equal(t, 1, len(serverAds.Keys()), "Origin fail to register at serverAds")
-	assert.Equal(t, webUrl, serverAds.Keys()[0].WebURL.String(), "WebURL in serverAds does not match data in origin registration request")
-	serverAds.DeleteAll()
+		setupRequest(c, r, `{"web_url": "https://localhost:8844","Namespaces": [{"Path": "/foo/bar", "URL": "https://get-your-tokens.org"}]}`, token)
+
+		r.ServeHTTP(w, c.Request)
+
+		assert.Equal(t, 200, w.Result().StatusCode, "Expected status code of 200")
+		assert.Equal(t, 1, len(serverAds.Keys()), "Origin fail to register at serverAds")
+		assert.Equal(t, "https://localhost:8844", serverAds.Keys()[0].WebURL.String(), "WebURL in serverAds does not match data in origin registration request")
+		serverAds.DeleteAll()
+	})
+
+	// We want to ensure backwards compatibility for WebURL
+	t.Run("valid-token-without-web-url", func(t *testing.T) {
+		c, r, w := setupContext()
+		pKey, token, issuerURL := generateToken(c)
+		publicKey, err := jwk.PublicKeyOf(pKey)
+		assert.NoError(t, err, "Error creating public key from private key")
+		ar := setupMockCache(t, publicKey)
+		useMockCache(ar, issuerURL)
+
+		setupRequest(c, r, `{"Namespaces": [{"Path": "/foo/bar", "URL": "https://get-your-tokens.org"}]}`, token)
+
+		r.ServeHTTP(w, c.Request)
+
+		assert.Equal(t, 200, w.Result().StatusCode, "Expected status code of 200")
+		assert.Equal(t, 1, len(serverAds.Keys()), "Origin fail to register at serverAds")
+		assert.Equal(t, "", serverAds.Keys()[0].WebURL.String(), "WebURL in serverAds isn't empty with no WebURL provided in registration")
+		serverAds.DeleteAll()
+	})
 }
 
 func TestGetAuthzEscaped(t *testing.T) {

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -21,6 +21,7 @@ package origin_ui
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -79,6 +80,7 @@ func AdvertiseOrigin() error {
 	// The checkdefaults func that runs before the origin is served checks for and
 	// parses the originUrl, so it should be safe to just grab it as a string here.
 	originUrl := param.Origin_Url.GetString()
+	originWebUrl := fmt.Sprintf("https://%s", config.ComputeExternalAddress())
 
 	// Here we instantiate the namespaceAd slice, but we still need to define the namespace
 	namespaceUrl, err := url.Parse(param.Federation_NamespaceUrl.GetString())
@@ -104,6 +106,7 @@ func AdvertiseOrigin() error {
 	ad := director.OriginAdvertise{
 		Name:       name,
 		URL:        originUrl,
+		WebURL:     originWebUrl,
 		Namespaces: []director.NamespaceAd{nsAd},
 	}
 


### PR DESCRIPTION
This should close #285 where we need origin's web engine URL as part of the origin advertisement so that the director can talk to origin's web api.

For reviewer, I did check that `AdvertiseOrigin()` now carries the correct port number for `WebURl`, which is `Server.Port`. I didn't add test to it because I can't get away from making errors in generating ad token in the test case and I think until we can mock the token generation function, we can't really test `AdvertiseOrigin()`.