### PR TITLE
Director Prometheus scraper of origins' metrics

### DIFF
--- a/cmd/director_serve.go
+++ b/cmd/director_serve.go
@@ -73,6 +73,13 @@ func serveDirector( /*cmd*/ *cobra.Command /*args*/, []string) error {
 		return err
 	}
 
+	// We configure Prometheus differently for director than for the rest servers,
+	// although in the future we probably want to pass the server type to the
+	// metric config function just because each server may have different config
+	if err := web_ui.ConfigureMetrics(engine, true); err != nil {
+		return err
+	}
+
 	// Configure the shortcut middleware to either redirect to a cache
 	// or to an origin
 	defaultResponse := param.Director_DefaultResponse.GetString()

--- a/cmd/director_serve.go
+++ b/cmd/director_serve.go
@@ -56,6 +56,13 @@ func serveDirector( /*cmd*/ *cobra.Command /*args*/, []string) error {
 		return errors.Wrap(err, "Failed to generate director private key")
 	}
 
+	// Since director will provide a public JWK for token authentication
+	// We need to initialize public JWK and private JWK at the start
+	_, err = config.GenerateIssuerJWKS()
+	if err != nil {
+		return errors.Wrap(err, "Failed to load director's public and private jwk")
+	}
+
 	// Generate a TLS certificate if needed
 	if err := config.GenerateCert(); err != nil {
 		return err

--- a/cmd/namespace_registry_serve.go
+++ b/cmd/namespace_registry_serve.go
@@ -70,6 +70,10 @@ func serveNamespaceRegistry( /*cmd*/ *cobra.Command /*args*/, []string) error {
 		return err
 	}
 
+	if err := web_ui.ConfigureMetrics(engine, false); err != nil {
+		return err
+	}
+
 	// Call out to nsregistry to establish routes for the gin engine
 	nsregistry.RegisterNamespaceRegistry(engine.Group("/"))
 	log.Info("Starting web engine...")

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -148,6 +148,11 @@ func serveOrigin( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	if err != nil {
 		return err
 	}
+
+	if err := web_ui.ConfigureMetrics(engine, false); err != nil {
+		return err
+	}
+
 	if err = origin_ui.ConfigureOriginUI(engine); err != nil {
 		return err
 	}

--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -105,14 +105,16 @@ func LoadPublicKey(existingJWKS string, issuerKeyFile string) (*jwk.Set, error) 
 		return nil, errors.Wrap(err, "Failed to add alg specification to key header")
 	}
 
+	err = jwk.AssignKeyID(key)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to assign key ID to private key")
+	}
+
 	pkey, err := jwk.PublicKeyOf(key)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to generate public key from file %v", issuerKeyFile)
 	}
-	err = jwk.AssignKeyID(pkey)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to assign key ID to public key")
-	}
+
 	if err = jwks.AddKey(pkey); err != nil {
 		return nil, errors.Wrap(err, "Failed to add public key to new JWKS")
 	}

--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -104,6 +104,9 @@ func LoadPublicKey(existingJWKS string, issuerKeyFile string) (*jwk.Set, error) 
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to add alg specification to key header")
 	}
+	// Store the private key to global var for access
+	// The key has kid attached
+	privateKey.Store(&key)
 
 	err = jwk.AssignKeyID(key)
 	if err != nil {

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -142,11 +142,6 @@ func CreateDirectorSDToken() (string, error) {
 		return "", errors.Wrap(err, "failed to load the director's JWK")
 	}
 
-	err = jwk.AssignKeyID(*key)
-	if err != nil {
-		return "", errors.Wrap(err, "Failed to assign kid to the token")
-	}
-
 	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256, *key))
 	if err != nil {
 		return "", err

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -24,8 +24,12 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
+	"time"
 
+	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pkg/errors"
@@ -111,4 +115,86 @@ func LoadDirectorPublicKey() (*jwk.Key, error) {
 	}
 
 	return &key, nil
+}
+
+// Create a token for director's Prometheus instance to access
+// director's origins service discovery endpoint. This function is intended
+// to be called on a director server
+func CreateDirectorSDToken() (string, error) {
+	directorURL := param.Federation_DirectorUrl.GetString()
+	if directorURL == "" {
+		return "", errors.New("Director URL is not known; cannot create director service discovery token")
+	}
+
+	tok, err := jwt.NewBuilder().
+		Claim("scope", "pelican.directorSD").
+		Issuer(directorURL).
+		Audience([]string{directorURL}).
+		Subject("director").
+		Expiration(time.Now().Add(time.Hour)).
+		Build()
+	if err != nil {
+		return "", err
+	}
+
+	key, err := config.GetOriginJWK()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to load the director's JWK")
+	}
+
+	err = jwk.AssignKeyID(*key)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to assign kid to the token")
+	}
+
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256, *key))
+	if err != nil {
+		return "", err
+	}
+	return string(signed), nil
+}
+
+// Verify that a token received is a valid token from director and has
+// correct scope for accessing the service discovery endpoint. This function
+// is intended to be called on the same director server that issues the token.
+func VerifyDirectorSDToken(strToken string) (bool, error) {
+	directorURL := param.Federation_DirectorUrl.GetString()
+	token, err := jwt.Parse([]byte(strToken), jwt.WithVerify(false))
+	if err != nil {
+		return false, err
+	}
+
+	if directorURL != token.Issuer() {
+		return false, errors.Errorf("Token issuer is not a director")
+	}
+	// Given that this function is intended to be called on the same director server
+	// that issues the token. so it's safe to skip getting the public key
+	// from director's discovery URL.
+	issuerKeyfile := param.IssuerKey.GetString()
+	key, err := config.LoadPublicKey("", issuerKeyfile)
+	if err != nil {
+		return false, err
+	}
+	tok, err := jwt.Parse([]byte(strToken), jwt.WithKeySet(*key), jwt.WithValidate(true))
+	if err != nil {
+		return false, err
+	}
+
+	scope_any, present := tok.Get("scope")
+	if !present {
+		return false, errors.New("No scope is present; required to advertise to director")
+	}
+	scope, ok := scope_any.(string)
+	if !ok {
+		return false, errors.New("scope claim in token is not string-valued")
+	}
+
+	scopes := strings.Split(scope, " ")
+
+	for _, scope := range scopes {
+		if scope == "pelican.directorSD" {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -394,13 +394,18 @@ func DiscoverOrigins(ctx *gin.Context) {
 		if ad.Type != OriginType {
 			continue
 		}
+		if ad.WebURL.String() == "" {
+			// Oririgns fetched from topology can't be scraped as they
+			// don't have a WebURL
+			continue
+		}
 		promDiscoveryRes = append(promDiscoveryRes, PromDiscoveryItem{
-			// TODO: change to ad.WebURL when #285 is ready
-			Targets: []string{ad.URL.Hostname() + ":" + ad.URL.Port()},
+			Targets: []string{ad.WebURL.Hostname() + ":" + ad.WebURL.Port()},
 			Labels: map[string]string{
 				"origin_name":     ad.Name,
 				"origin_auth_url": ad.AuthURL.String(),
 				"origin_url":      ad.URL.String(),
+				"origin_web_url":  ad.WebURL.String(),
 				"origin_lat":      fmt.Sprintf("%.4f", ad.Latitude),
 				"origin_long":     fmt.Sprintf("%.4f", ad.Longitude),
 			},

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -271,7 +271,9 @@ func RedirectToOrigin(ginCtx *gin.Context) {
 func ShortcutMiddleware(defaultResponse string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// If this is a request for getting public key, don't modify the path
-		if strings.HasPrefix(c.Request.URL.Path, "/.well-known") {
+		// If this is a request to the Prometheus API, don't modify the path
+		if strings.HasPrefix(c.Request.URL.Path, "/.well-known") ||
+			strings.HasPrefix(c.Request.URL.Path, "/api/v1.0/prometheus") {
 			c.Next()
 			return
 		}

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -537,7 +537,7 @@ func ConfigureEmbeddedPrometheus(engine *gin.Engine, isDirector bool) error {
 		)
 	}
 	{
-		// Periodic srcaper config reload to refresh service discovery token
+		// Periodic scraper config reload to refresh service discovery token
 		// Only effective when the server instance is a director
 		cancel := make(chan struct{})
 		g.Add(

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -171,8 +171,7 @@ func checkPromToken(av1 *route.Router) gin.HandlerFunc {
 	}
 }
 
-func ConfigureEmbeddedPrometheus(engine *gin.Engine) error {
-
+func ConfigureEmbeddedPrometheus(engine *gin.Engine, isDirector bool) error {
 	cfg := flagConfig{}
 	ListenAddress := fmt.Sprintf("0.0.0.0:%v", param.Server_Port.GetInt())
 	cfg.webTimeout = model.Duration(5 * time.Minute)

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -19,11 +19,8 @@
 package web_ui
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
-	"runtime"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -50,15 +47,6 @@ func ConfigureMetrics(engine *gin.Engine, isDirector bool) error {
 }
 
 func GetEngine() (*gin.Engine, error) {
-	pc, _, _, ok := runtime.Caller(1)
-	if !ok {
-		return nil, errors.New(fmt.Sprintln("Failed to retrieve caller information"))
-	}
-
-	callerChain := strings.Split(runtime.FuncForPC(pc).Name(), ".") // get the function name
-	// We only care about one level up caller
-	callerName := callerChain[len(callerChain)-1]
-
 	gin.SetMode(gin.ReleaseMode)
 	engine := gin.New()
 	engine.Use(gin.Recovery())
@@ -76,12 +64,6 @@ func GetEngine() (*gin.Engine, error) {
 			"resource": ctx.Request.URL.Path},
 		).Info("Served Request")
 	})
-	// We configure Prometheus differently for director than for the rest servers,
-	// although in the future we probably want to pass the server type to the
-	// metric config function just because each server may have different config
-	if err := ConfigureMetrics(engine, callerName == "serveDirector"); err != nil {
-		return nil, err
-	}
 	return engine, nil
 }
 


### PR DESCRIPTION
## Testing Instructions

Since our current Prometheus setup has a fixed datastore location, it is very difficult to get more than one instance of service (director/origin/registry) to run Prometheus at the same time. To test this PR locally, you need to have some local patches to make it work. Here is how you can do it:

### Code modification

First, make sure you specify the director's URL:

```yaml
Federation:
  DirectorUrl: "https://localhost:8888"
```

Next, in `web_ui/prometheus.go`, `ConfigureEmbeddedPrometheus()` around line 218, you want to uncomment the code:

```go
if isDirector {
    err := os.MkdirAll("/var/lib/pelican/director-monitoring/data", 0750)
if err != nil {
    return errors.New("Failure when creating a directory for the monitoring data")
}
    cfg.serverStoragePath = "/var/lib/pelican/director-monitoring/data"
} else {
    cfg.serverStoragePath = param.Monitoring_DataLocation.GetString()
}
```

This is to make a separate directory for the director's Prometheus datastore location.

With this done, you can go ahead and build the program.

### Orchestrating services

Another special sauce to make it work locally is the order of running the programs. **You want to run `director` first, `registry` second, `origin` last (this is important). After three services running, you want to kill `registry`, kill `origin` and finally run `origin` again.** It's a bit counter-intuitive but the reason is that we want to ensure we can successfully register our origin at  director first. As I tested, if we lunch `origin` prior to the `registry`, we will get this error when the director tries to fetch public keys from registry: 

```bash
DEBUG[2023-10-27T15:37:47Z] Attempting to fetch keys from  https://localhost:9999/api/v1.0/registry/origin1/.well-known/issuer.jwks 
DEBUG[2023-10-27T15:37:47Z] Constructed JWKS from fetching jwks: null    
WARNING[2023-10-27T15:37:47Z] Failed to verify token: cached object is not a Set (was <nil>) 
```

This error only appears if you run services in the order of `director` `origin` `registry`.  Might worth another PR to further investigate.

Also, since `registry` process will lock the Prometheus datastore when it's running, when we then ran `origin`, `origin` Prometheus instance will fail to start, and we can't scrape anything from it. So after `origin` successfully registered at `director`, we can turn off `registry` to release the datastore and then reboot `origin`.

With `director` and `origin` running, switch to the terminal where you ran `director` and confirm that the origin has been successfully registered (You may need to scroll up a bit). (You should be able to see something like: 
`INFO[2023-10-27T15:19:41Z] Served Request   client=127.0.0.1 daemon=gin fields.time=5.640583ms method=POST resource=/api/v1.0/director/registerOrigin status=200`)

This is the end of the setup.

You want to test that you are able to access origin's prometheus endpoint first, say `https://localhost:<origin-web-port>/metrics` and it should return metrics, not 503 (that means the origin's datastore is locked).

Now you should be able to go to director's Prometheus querying endpoint to verify that director is scraping metrics from origins:

`https://localhost:8888/api/v1.0/prometheus/query?query=up`

Or refer to a list of labels available by going to `https://localhost:8888/api/v1.0/prometheus/label/__name__/values`

`https://localhost:8888/api/v1.0/prometheus/query?query=xrootd_monitoring_packets_received`

The "job" label of the returned data should be the hostname of the origin, and the "instance" label should be origin's web URL.

```json
{
  "status": "success",
  "data": {
    "resultType": "vector",
    "result": [
      {
        "metric": {
          "__name__": "xrootd_monitoring_packets_received",
          "instance": "localhost:8444",
          "job": "origins",
          "origin_auth_url": "https://localhost:8444",
          "origin_lat": "0.0000",
          "origin_long": "0.0000",
          "origin_name": "fae8c2865de4",
          "origin_url": "https://localhost:8444"
        },
        "value": [
          1698432545.437,
          "24"
        ]
      }
    ]
  }
}
```

I set a couple of labels for origin's SD response which are shown above `"origin_*"`. Do you think we want to make all of them visible to the query? Or you want to hide some labels as internal only `"__meta_origin_*"`? @bbockelm 

Also, the current service discovery token has a relatively long life time, 1 hour, and the token will be refreshed at Prometheus for every 50 min. If you want to test the end-to-end token refresh mechanism, you may change the code at `director/director_api.go` around line 134 for the token life time, and `web_ui/prometheus.go` line 547 for the refresh interval. Don't forget to rebuild before running.