### PR TITLE
Fix null dereference bug in Director

### DIFF
--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -190,6 +190,8 @@ func GetAdsForPath(reqPath string) (originNamespace NamespaceAd, originAds []Ser
 		}
 	}
 
-	originNamespace = *best
+	if best != nil {
+		originNamespace = *best
+	}
 	return
 }

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -168,4 +168,11 @@ func TestGetAdsForPath(t *testing.T) {
 	assert.Equal(t, len(oAds), 1)
 	assert.Equal(t, len(cAds), 0)
 	assert.True(t, hasServerAdWithName(oAds, "origin2"))
+
+	// Finally, let's throw in a test for a path we know shouldn't exist
+	// in the ttlcache
+	nsAd, oAds, cAds = GetAdsForPath("/does/not/exist")
+	assert.Equal(t, nsAd.Path, "")
+	assert.Equal(t, len(oAds), 0)
+	assert.Equal(t, len(cAds), 0)
 }


### PR DESCRIPTION
The Director had a null dereference bug that occurred when it tried to find ads for non-existent namespace prefixes. This commit fixes the bug, adds a regression test to catch similar bugs in the future, and re-orders the error reporting to the client in the event that it tries to get something from a non-existent namespace.