### PR TITLE
 Add pelican-osdf-compat package

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -98,3 +98,97 @@ nfpms:
             file_info:
               mode: 0644
             type: doc
+  # end package pelican
+
+  - package_name: pelican-osdf-compat
+    builds: []
+    # file_name_template: '{{ .PackageName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    file_name_template: "{{ .ConventionalFileName }}"
+    id: pelican-osdf-compat
+    vendor: OSG Consortium
+    homepage: https://github.com/PelicanPlatform/pelican
+    maintainer: Brian Bockelman <bbockelman@morgridge.org>
+    description: OSDF compatibility files for Pelican
+    license: ASL 2.0
+    meta: true
+    formats:
+      - apk
+      - deb
+      - rpm
+    # bindir: /usr/bin
+    release: 1
+    section: default
+    priority: extra
+    dependencies:
+      - pelican
+    provides:
+      ## does not work: {{ .Version }} doesn't get substituted in this list
+      # - osdf-client = {{ .Version }}
+      # - stashcp = {{ .Version }}
+      # - condor-stash-plugin = {{ .Version }}
+      - "osdf-client = 7"
+      - "stashcp = 7"
+      - "condor-stash-plugin = 7"
+    overrides:
+      apk:
+        contents:
+          - src: "./pelican"
+            dst: "/usr/bin/osdf"
+            type: symlink
+          - src: "./pelican"
+            dst: "/usr/bin/stashcp"
+            type: symlink
+      rpm:
+        contents:
+          - src: "./pelican"
+            dst: "/usr/bin/osdf"
+            type: symlink
+          - src: "./pelican"
+            dst: "/usr/bin/stashcp"
+            type: symlink
+          - src: "../../bin/pelican"
+            dst: "/usr/libexec/condor/stash_plugin"
+            type: symlink
+          - src: "client/resources/10-stash-plugin.conf"
+            dst: "/etc/condor/config.d/10-stash-plugin.conf"
+            type: config|noreplace
+        replaces:
+          - "osdf-client < 7"
+          - "stashcp < 7"
+          - "condor-stash-plugin < 7"
+        ## rpm specific syntax:
+        ## also does not work: %{version} doesn't get expanded
+        # provides:
+        #   - "osdf-client = %{version}"
+        #   - "stashcp = %{version}"
+        #   - "condor-stash-plugin = %{version}"
+        # file_name_template: >-
+        #   {{ .PackageName }}-{{ .Version }}-{{ .Release }}.{{ if eq .Arch "amd64" }}x86_64{{ else }}{{ .Arch }}{{ end }}
+      deb:
+        # file_name_template: "{{ .PackageName }}-{{ .Version }}-{{ .Release }}_{{ .Arch }}"
+        contents:
+          - src: "./pelican"
+            dst: "/usr/bin/osdf"
+            type: symlink
+          - src: "./pelican"
+            dst: "/usr/bin/stashcp"
+            type: symlink
+          - src: "../../bin/pelican"
+            dst: "/usr/libexec/condor/stash_plugin"
+            type: symlink
+          - src: "../../../libexec/condor/stash_plugin"
+            dst: "/usr/lib/condor/libexec/stash_plugin"
+            type: symlink
+          - src: "client/resources/10-stash-plugin.conf"
+            dst: "/etc/condor/config.d/10-stash-plugin.conf"
+            type: config|noreplace
+        # deb has different syntax
+        provides:
+          - "osdf-client (= 7)"
+          - "stashcp (= 7)"
+          - "condor-stash-plugin (= 7)"
+        replaces:
+          - "osdf-client (<< 7)"
+          - "stashcp (<< 7)"
+          - "condor-stash-plugin (<< 7)"
+  # end package pelican-osdf-compet

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,7 +55,7 @@ nfpms:
   - package_name: pelican
     builds:
       - pelican
-    file_name_template: '{{ .PackageName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    file_name_template: "{{ .ConventionalFileName }}"
     id: pelican
     vendor: OSG Consortium
     homepage: https://github.com/PelicanPlatform/pelican
@@ -83,10 +83,7 @@ nfpms:
             file_info:
               mode: 0644
             type: doc
-        file_name_template: >-
-          {{ .PackageName }}-{{ .Version }}-{{ .Release }}.{{ if eq .Arch "amd64" }}x86_64{{ else }}{{ .Arch }}{{ end }}
       deb:
-        file_name_template: "{{ .PackageName }}-{{ .Version }}-{{ .Release }}_{{ .Arch }}"
         contents:
           - src: LICENSE
             dst: "/usr/share/doc/{{ .PackageName }}/LICENSE.txt"
@@ -102,7 +99,6 @@ nfpms:
 
   - package_name: pelican-osdf-compat
     builds: []
-    # file_name_template: '{{ .PackageName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     file_name_template: "{{ .ConventionalFileName }}"
     id: pelican-osdf-compat
     vendor: OSG Consortium
@@ -162,10 +158,7 @@ nfpms:
         #   - "osdf-client = %{version}"
         #   - "stashcp = %{version}"
         #   - "condor-stash-plugin = %{version}"
-        # file_name_template: >-
-        #   {{ .PackageName }}-{{ .Version }}-{{ .Release }}.{{ if eq .Arch "amd64" }}x86_64{{ else }}{{ .Arch }}{{ end }}
       deb:
-        # file_name_template: "{{ .PackageName }}-{{ .Version }}-{{ .Release }}_{{ .Arch }}"
         contents:
           - src: "./pelican"
             dst: "/usr/bin/osdf"


### PR DESCRIPTION
This adds compat symlinks for `/usr/bin/stashcp`, `/usr/bin/osdf`, and `condor-stash-plugin` to use the `pelican` binary isntead, and a condor configuration for enabling the condor-stash-plugin.  This allows pelican to replace the old "stashcp" and "condor-stash-plugin" RPMs.

The appropriate `obsoletes` (`replaces` for Deb) and `provides` clauses are included, with the caveat that pelican-osdf-compat provides version "7" of the packages it's replacing, as opposed to whatever specific version the pelican-osdf-compat package itself is.  This is because GoReleaser doesn't expand templates inside `replaces` and `provides` lists so the value has to be hardcoded.

Deb, RPM, and APK use different syntax for specifying versions clauses:
- APK does not use `replaces` (`provides` is sufficient for replacing a package).
- Deb puts parens around the version restriction (so `stashcp (= 7)`   whereas RPM and APK use `stashcp = 7`).
- Deb uses `<<` instead of `<` as the strictly-less-than operator.

The APK doesn't have a symlink and config file for condor-stash-plugin because condor is not available on Alpine.

See #246
