### PR TITLE
End-to-end test for XRootD

### DIFF
--- a/cmd/cache_serve.go
+++ b/cmd/cache_serve.go
@@ -243,7 +243,8 @@ func serveCache( /*cmd*/ *cobra.Command /*args*/, []string) error {
 		return err
 	}
 
-	if err = daemon.LaunchDaemons(launchers); err != nil {
+	ctx := context.Background()
+	if err = daemon.LaunchDaemons(ctx, launchers); err != nil {
 		return err
 	}
 

--- a/cmd/cache_serve.go
+++ b/cmd/cache_serve.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -175,7 +175,8 @@ func serveOrigin( /*cmd*/ *cobra.Command /*args*/, []string) error {
 		launchers = append(launchers, oa4mp_launcher)
 	}
 
-	if err = daemon.LaunchDaemons(launchers); err != nil {
+	ctx := context.Background()
+	if err = daemon.LaunchDaemons(ctx, launchers); err != nil {
 		return err
 	}
 	log.Info("Clean shutdown of the origin")

--- a/daemon/launch_unix.go
+++ b/daemon/launch_unix.go
@@ -121,8 +121,7 @@ func (launcher DaemonLauncher) Launch(ctx context.Context) (context.Context, int
 	return ctx_result, cmd.Process.Pid, nil
 }
 
-func LaunchDaemons(launchers []Launcher) (err error) {
-	ctx := context.Background()
+func LaunchDaemons(ctx context.Context, launchers []Launcher) (err error) {
 
 	daemons := make([]launchInfo, len(launchers))
 	for idx, daemon := range launchers {

--- a/origin_ui/origin_windows.go
+++ b/origin_ui/origin_windows.go
@@ -1,4 +1,5 @@
 //go:build windows
+
 /***************************************************************
  *
  * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research

--- a/xrootd/origin_test.go
+++ b/xrootd/origin_test.go
@@ -58,7 +58,7 @@ func TestOrigin(t *testing.T) {
 	err = config.GenerateCert()
 	require.NoError(t, err)
 
-	err = CheckXrootdEnv(true)
+	err = CheckXrootdEnv(true, nil)
 	require.NoError(t, err)
 
 	err = SetUpMonitoring()
@@ -67,7 +67,7 @@ func TestOrigin(t *testing.T) {
 	configPath, err := ConfigXrootd(true)
 	require.NoError(t, err)
 
-	launchers, err := ConfigureLaunchers(false, configPath)
+	launchers, err := ConfigureLaunchers(false, configPath, false)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -78,7 +78,7 @@ func TestOrigin(t *testing.T) {
 
 	testExpiry := time.Now().Add(10 * time.Second)
 	testSuccess := false
-	for !testSuccess || time.Now().After(testExpiry) {
+	for !(testSuccess || time.Now().After(testExpiry)) {
 		time.Sleep(50 * time.Millisecond)
 		req, err := http.NewRequest("GET", param.Origin_Url.GetString(), nil)
 		require.NoError(t, err)
@@ -95,10 +95,14 @@ func TestOrigin(t *testing.T) {
 		}
 	}
 
-	url, err := origin_ui.UploadTestfile()
-	require.NoError(t, err)
-	err = origin_ui.DownloadTestfile(url)
-	require.NoError(t, err)
-	err = origin_ui.DeleteTestfile(url)
-	require.NoError(t, err)
+	if testSuccess {
+		url, err := origin_ui.UploadTestfile()
+		require.NoError(t, err)
+		err = origin_ui.DownloadTestfile(url)
+		require.NoError(t, err)
+		err = origin_ui.DeleteTestfile(url)
+		require.NoError(t, err)
+	} else {
+		t.Fatalf("Unsucessful test: timeout when trying to send request to xrootd")
+	}
 }

--- a/xrootd/origin_test.go
+++ b/xrootd/origin_test.go
@@ -1,0 +1,104 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package xrootd
+
+import (
+	"context"
+	"crypto/elliptic"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/daemon"
+	"github.com/pelicanplatform/pelican/origin_ui"
+	"github.com/pelicanplatform/pelican/param"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrigin(t *testing.T) {
+	viper.Reset()
+
+	viper.Set("Origin.ExportVolume", t.TempDir()+":/test")
+	// Disable functionality we're not using (and is difficult to make work on Mac)
+	viper.Set("Origin.EnableCmsd", false)
+	viper.Set("Origin.EnableMacaroons", false)
+	viper.Set("Origin.EnableVoms", false)
+	viper.Set("TLSSkipVerify", true)
+
+	viper.Set("ConfigDir", t.TempDir())
+	// Increase the log level; otherwise, its difficult to debug failures
+	viper.Set("Logging.Level", "Debug")
+	config.InitConfig()
+	err := config.InitServer()
+	require.NoError(t, err)
+
+	err = config.GeneratePrivateKey(param.Server_TLSKey.GetString(), elliptic.P256())
+	require.NoError(t, err)
+	err = config.GenerateCert()
+	require.NoError(t, err)
+
+	err = CheckXrootdEnv(true)
+	require.NoError(t, err)
+
+	err = SetUpMonitoring()
+	require.NoError(t, err)
+
+	configPath, err := ConfigXrootd(true)
+	require.NoError(t, err)
+
+	launchers, err := ConfigureLaunchers(false, configPath)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		_ = daemon.LaunchDaemons(ctx, launchers)
+	}()
+	defer cancel()
+
+	testExpiry := time.Now().Add(10 * time.Second)
+	testSuccess := false
+	for !testSuccess || time.Now().After(testExpiry) {
+		time.Sleep(50 * time.Millisecond)
+		req, err := http.NewRequest("GET", param.Origin_Url.GetString(), nil)
+		require.NoError(t, err)
+		httpClient := http.Client{
+			Transport: config.GetTransport(),
+			Timeout:   50 * time.Millisecond,
+		}
+		_, err = httpClient.Do(req)
+		if err != nil {
+			log.Infoln("Failed to send request to XRootD; likely, server is not up (will retry in 50ms):", err)
+		} else {
+			testSuccess = true
+			log.Debugln("XRootD server appears to be functioning; will proceed with test")
+		}
+	}
+
+	url, err := origin_ui.UploadTestfile()
+	require.NoError(t, err)
+	err = origin_ui.DownloadTestfile(url)
+	require.NoError(t, err)
+	err = origin_ui.DeleteTestfile(url)
+	require.NoError(t, err)
+}

--- a/xrootd/origin_test.go
+++ b/xrootd/origin_test.go
@@ -24,6 +24,8 @@ import (
 	"context"
 	"crypto/elliptic"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -46,11 +48,18 @@ func TestOrigin(t *testing.T) {
 	viper.Set("Origin.EnableVoms", false)
 	viper.Set("TLSSkipVerify", true)
 
-	viper.Set("ConfigDir", t.TempDir())
+	// Create our own temp directory (for some reason t.TempDir() does not play well with xrootd)
+	tmpPath := "/tmp/XRootD-Test_Origin"
+	viper.Set("ConfigDir", tmpPath)
+	viper.Set("Xrootd.RunLocation", filepath.Join(tmpPath, "xrootd"))
+	t.Cleanup(func() {
+		os.RemoveAll(tmpPath)
+	})
 	// Increase the log level; otherwise, its difficult to debug failures
 	viper.Set("Logging.Level", "Debug")
 	config.InitConfig()
 	err := config.InitServer()
+
 	require.NoError(t, err)
 
 	err = config.GeneratePrivateKey(param.Server_TLSKey.GetString(), elliptic.P256())

--- a/xrootd/origin_test_linux.go
+++ b/xrootd/origin_test_linux.go
@@ -1,5 +1,3 @@
-//go:build !windows
-
 /***************************************************************
  *
  * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research


### PR DESCRIPTION
@turetske - not sure if this is helpful but I was tinkering with testing xrootd while on the airplane and cobbled together this PR.

Now, the tests shouldn't pass for the exact same thing you're struggling with -- waiting on the new release of `scitokens-cpp`.  But perhaps the approach is interesting for you?

One item we'll need to think through: How do we want to approach Mac OS X?  The homebrew-packaged version of XRootD comes without SciTokens, meaning that maintaining a test there would be fairly difficult.