### PR TITLE
Renamed getOriginJWK to getServerJWK

### DIFF
--- a/cmd/origin_token.go
+++ b/cmd/origin_token.go
@@ -203,10 +203,10 @@ func CreateEncodedToken(claimsMap map[string]string, profile string, lifetime in
 		return "", errors.Wrap(err, "Failed to generate token")
 	}
 
-	// Now that we have a token, it needs signing. Note that GetOriginJWK
+	// Now that we have a token, it needs signing. Note that GetIssuerPrivateJWK
 	// will get the private key passed via the command line because that
 	// file path has already been bound to IssuerKey
-	key, err := config.GetOriginJWK()
+	key, err := config.GetIssuerPrivateJWK()
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to load signing keys. Either generate one at the default "+
 			"location by serving an origin, or provide one via the --private-key flag")

--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -399,7 +399,7 @@ func GenerateIssuerJWKS() (jwk.Set, error) {
 	return LoadPublicKey(existingJWKS, issuerKeyFile)
 }
 
-func GetOriginJWK() (jwk.Key, error) {
+func GetIssuerPrivateJWK() (jwk.Key, error) {
 	key := privateKey.Load()
 	if key == nil {
 		issuerKeyFile := param.IssuerKey.GetString()

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -137,7 +137,7 @@ func CreateDirectorSDToken() (string, error) {
 		return "", err
 	}
 
-	key, err := config.GetOriginJWK()
+	key, err := config.GetIssuerPrivateJWK()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to load the director's JWK")
 	}

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -84,7 +84,7 @@ func CreateAdvertiseToken(namespace string) (string, error) {
 		return "", err
 	}
 
-	key, err := config.GetOriginJWK()
+	key, err := config.GetIssuerPrivateJWK()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to load the origin's JWK")
 	}

--- a/director/origin_api_test.go
+++ b/director/origin_api_test.go
@@ -63,7 +63,7 @@ func TestVerifyAdvertiseToken(t *testing.T) {
 	assert.Equal(t, true, ok, "Expected scope to be 'pelican.advertise'")
 
 	//Create token without a scope - should return an error
-	key, err := config.GetOriginJWK()
+	key, err := config.GetIssuerPrivateJWK()
 	err = jwk.AssignKeyID(key)
 	assert.NoError(t, err)
 

--- a/director/redirect_test.go
+++ b/director/redirect_test.go
@@ -371,7 +371,7 @@ func TestDiscoverOrigins(t *testing.T) {
 	_, err := config.LoadPublicKey("", kfile)
 	assert.NoError(t, err, "Error generating private key")
 	// Get private key
-	privateKey, err := config.GetOriginJWK()
+	privateKey, err := config.GetIssuerPrivateJWK()
 	assert.NoError(t, err, "Error loading private key")
 
 	// Batch set up different tokens

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/jellydator/ttlcache/v3 v3.0.1
 	github.com/jsipprell/keyctl v1.0.4-0.20211208153515-36ca02672b6c
-	github.com/lestrrat-go/jwx/v2 v2.0.13
+	github.com/lestrrat-go/jwx/v2 v2.0.16
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 	github.com/oklog/run v1.1.0
 	github.com/oschwald/geoip2-golang v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -411,6 +411,8 @@ github.com/lestrrat-go/iter v1.0.2 h1:gMXo1q4c2pHmC3dn8LzRhJfP1ceCbgSiT9lUydIzlt
 github.com/lestrrat-go/iter v1.0.2/go.mod h1:Momfcq3AnRlRjI5b5O8/G5/BvpzrhoFTZcn06fEOPt4=
 github.com/lestrrat-go/jwx/v2 v2.0.13 h1:XdxzJbudGaHEoNmyJACAT8aFCB+DmviiaiMoZwuJoUo=
 github.com/lestrrat-go/jwx/v2 v2.0.13/go.mod h1:UzXMzcV99p9/xe1JsIb336NJDGXLsleR+Qj3ucEDtfI=
+github.com/lestrrat-go/jwx/v2 v2.0.16 h1:TuH3dBkYTy2giQg/9D8f20znS3JtMRuQJ372boS3lWk=
+github.com/lestrrat-go/jwx/v2 v2.0.16/go.mod h1:jBHyESp4e7QxfERM0UKkQ80/94paqNIEcdEfiUYz5zE=
 github.com/lestrrat-go/option v1.0.0/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNBEYU=
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=

--- a/namespace-registry/client_commands.go
+++ b/namespace-registry/client_commands.go
@@ -250,9 +250,9 @@ func NamespaceDelete(endpoint string, prefix string) error {
 	}
 
 	// Now that we have a token, it needs signing
-	key, err := config.GetOriginJWK()
+	key, err := config.GetIssuerPrivateJWK()
 	if err != nil {
-		return errors.Wrap(err, "failed to load the origin's JWK")
+		return errors.Wrap(err, "failed to load the registry's JWK")
 	}
 
 	// Get/assign the kid, needed for verification by the client

--- a/origin_ui/origin.go
+++ b/origin_ui/origin.go
@@ -175,7 +175,7 @@ func configureAuthDB() error {
 }
 
 func setLoginCookie(ctx *gin.Context, user string) {
-	key, err := config.GetOriginJWK()
+	key, err := config.GetIssuerPrivateJWK()
 	if err != nil {
 		log.Errorln("Failure when loading the cookie signing key:", err)
 		ctx.JSON(500, gin.H{"error": "Unable to create login cookies"})
@@ -221,7 +221,7 @@ func getUser(ctx *gin.Context) (string, error) {
 	if err != nil {
 		return "", nil
 	}
-	key, err := config.GetOriginJWK()
+	key, err := config.GetIssuerPrivateJWK()
 	if err != nil {
 		return "", err
 	}

--- a/origin_ui/register_origin.go
+++ b/origin_ui/register_origin.go
@@ -133,7 +133,7 @@ func registerNamespacePrep() (key jwk.Key, prefix string, registrationEndpointUR
 		return
 	}
 
-	key, err = config.GetOriginJWK()
+	key, err = config.GetIssuerPrivateJWK()
 	if err != nil {
 		err = errors.Wrap(err, "failed to load the origin's JWK")
 		return

--- a/origin_ui/register_origin_test.go
+++ b/origin_ui/register_origin_test.go
@@ -69,7 +69,7 @@ func TestRegistration(t *testing.T) {
 	// Ensure we have a issuer key
 	_, err = config.LoadPublicKey("", ikey)
 	require.NoError(t, err)
-	privKey, err := config.GetOriginJWK()
+	privKey, err := config.GetIssuerPrivateJWK()
 	require.NoError(t, err)
 	key, err := privKey.PublicKey()
 	require.NoError(t, err)

--- a/origin_ui/self_monitor.go
+++ b/origin_ui/self_monitor.go
@@ -69,7 +69,7 @@ func generateMonitoringScitoken() (string, error) {
 		return "", err
 	}
 
-	key, err := config.GetOriginJWK()
+	key, err := config.GetIssuerPrivateJWK()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to load the origin's JWK")
 	}

--- a/web_ui/authorization.go
+++ b/web_ui/authorization.go
@@ -109,9 +109,9 @@ func FederationCheck(c *gin.Context, strToken string, expectedScope string) {
 	}
 }
 
-// Checks that the given token was signed by the origin jwk and also checks that the token has the expected scope
-func OriginCheck(c *gin.Context, strToken string, expectedScope string) {
-	bKey, err := pelican_config.GetOriginJWK()
+// Checks that the given token was signed by the issuer jwk and also checks that the token has the expected scope
+func IssuerCheck(c *gin.Context, strToken string, expectedScope string) {
+	bKey, err := pelican_config.GetIssuerPrivateJWK()
 	if err != nil {
 		return
 	}

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -157,11 +157,11 @@ func checkPromToken(av1 *route.Router) gin.HandlerFunc {
 		}
 
 		FederationCheck(c, strToken, "prometheus.read")
-		OriginCheck(c, strToken, "prometheus.read")
+		IssuerCheck(c, strToken, "prometheus.read")
 
 		strToken, err = c.Cookie("login")
 		if err == nil {
-			OriginCheck(c, strToken, "prometheus.read")
+			IssuerCheck(c, strToken, "prometheus.read")
 		}
 
 		_, exists := c.Get("User")

--- a/web_ui/prometheus_test.go
+++ b/web_ui/prometheus_test.go
@@ -348,7 +348,7 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 
 	assert.Equal(t, 403, w.Result().StatusCode, "Expected status code of 403 due to bad token scope")
 
-	key, err := config.GetOriginJWK()
+	key, err := config.GetIssuerPrivateJWK()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Close #314 

`getOriginJWK` is a confusing name because of the overloaded `origin` term. This changes that function to `getServerJWK`. If that's not an acceptable name, vscode makes refactoring very simple, so it can also be something like `getIssuerJWK` or `getHostJWK`.