### PR TITLE
Made Pelican logging able to output to file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -107,7 +107,7 @@ func init() {
 	}
 
 	rootCmd.PersistentFlags().StringP("log", "l", "", "Specified log output file")
-	if err := viper.BindPFlag("Logging.File", rootCmd.PersistentFlags().Lookup("log")); err != nil {
+	if err := viper.BindPFlag("Logging.LogLocation", rootCmd.PersistentFlags().Lookup("log")); err != nil {
 		panic(err)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -106,6 +106,11 @@ func init() {
 		panic(err)
 	}
 
+	rootCmd.PersistentFlags().StringP("log", "l", "", "Specified log output file")
+	if err := viper.BindPFlag("Logging.File", rootCmd.PersistentFlags().Lookup("log")); err != nil {
+		panic(err)
+	}
+
 	// Register the version flag here just so --help will show this flag
 	// Actual checking is executed at main.go
 	// Remove the shorthand -v since in "origin serve" flagset it's already used for "volume" flag

--- a/config/config.go
+++ b/config/config.go
@@ -353,9 +353,7 @@ func InitConfig() {
 	} else {
 		logLevel := param.Logging_Level.GetString()
 		level, err := log.ParseLevel(logLevel)
-		if err != nil {
-			cobra.CheckErr(err)
-		}
+		cobra.CheckErr(err)
 		SetLogging(level)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -357,12 +357,20 @@ func InitConfig() {
 		SetLogging(level)
 	}
 
-	logLocation := param.Logging_File.GetString()
+	logLocation := param.Logging_LogLocation.GetString()
 	if logLocation != "" {
+		dir := filepath.Dir(logLocation)
+		if dir != "" {
+			if err := os.MkdirAll(dir, 0644); err != nil {
+				log.Errorf("Failed to access/create specified directory. Error: %v", err)
+				os.Exit(1)
+			}
+		}
 		// Note: do not need to close the file, logrus does it for us
 		f, err := os.OpenFile(logLocation, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 		if err != nil {
-			cobra.CheckErr(err)
+			log.Errorf("Failed to access specified log file. Error: %v", err)
+			os.Exit(1)
 		}
 		log.SetOutput(f)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -358,6 +358,16 @@ func InitConfig() {
 		}
 		SetLogging(level)
 	}
+
+	logLocation := param.Logging_File.GetString()
+	if logLocation != "" {
+		// Note: do not need to close the file, logrus does it for us
+		f, err := os.OpenFile(logLocation, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+		if err != nil {
+			cobra.CheckErr(err)
+		}
+		log.SetOutput(f)
+	}
 }
 
 func initConfigDir() error {

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -113,7 +113,7 @@ type: string
 default: Error
 components: ["*"]
 ---
-name: Logging.File
+name: Logging.LogLocation
 description: >-
   A string defining a file to write log outputs to, if the user desires.
 type: string

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -113,6 +113,13 @@ type: string
 default: Error
 components: ["*"]
 ---
+name: Logging.File
+description: >-
+  A string defining a file to write log outputs to, if the user desires.
+type: string
+default: none
+components: ["*"]
+---
 
 ############################
 # Federation-Level Configs #

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -115,8 +115,8 @@ components: ["*"]
 ---
 name: Logging.LogLocation
 description: >-
-  A string defining a file to write log outputs to, if the user desires.
-type: string
+  A filename defining a file to write log outputs to, if the user desires.
+type: filename
 default: none
 components: ["*"]
 ---


### PR DESCRIPTION
Added an option for Pelican logs to output to a specified file rather than stdout. This is used with either the `-l` flag or by specifying Logging.File within the Pelican config.