### PR TITLE
Add unit tests to XRootD monitoring handler

### DIFF
--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -42,6 +42,15 @@ type (
 		Id uint32
 	}
 
+	// userid as in XRootD message info field
+	XrdUserId struct {
+		Prot string
+		User string
+		Pid  string
+		Sid  string
+		Host string
+	}
+
 	UserRecord struct {
 		AuthenticationProtocol string
 		DN                     string

--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -254,7 +254,7 @@ func GetSIDRest(info []byte) (UserId, string, error) {
 	if err != nil {
 		return UserId{}, "", err
 	}
-	return UserId{Id: uint32(sid)}, string(info[1]), nil
+	return UserId{Id: uint32(sid)}, string(infoSplit[1]), nil
 }
 
 func ParseFileHeader(packet []byte) (XrdXrootdMonFileHdr, error) {

--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -73,7 +73,13 @@ type (
 		Code byte
 		Pseq byte
 		Plen uint16
-		Stod uint32
+		Stod int32
+	}
+
+	XrdXrootdMonMap struct {
+		Hdr    XrdXrootdMonHeader
+		Dictid uint32
+		Info   []byte
 	}
 
 	XrdXrootdMonFileHdr struct {
@@ -91,6 +97,53 @@ type (
 		Beg int32
 		End int32
 		SID int64
+	}
+
+	XrdXrootdMonFileLFN struct {
+		User uint32
+		Lfn  [1032]byte
+	}
+
+	XrdXrootdMonFileOPN struct {
+		Hdr XrdXrootdMonFileHdr
+		fsz int64
+		Ufn XrdXrootdMonFileLFN
+	}
+
+	XrdXrootdMonStatOPS struct {
+		Read  int   // Number of read() calls
+		Readv int   // Number of readv() calls
+		Write int   // Number of write() calls
+		RsMin int16 // Smallest readv() segment count
+		RsMax int16 // Largest readv() segment count
+		Rsegs int64 // Number of readv() segments
+		RdMin int   // Smallest read() request size
+		RdMax int   // Largest read() request size
+		RvMin int   // Smallest readv() request size
+		RvMax int   // Largest readv() request size
+		WrMin int   // Smallest write() request size
+		WrMax int   // Largest write() request size
+	}
+
+	XrdXrootdMonDouble struct {
+		Dlong int64   // Represents a long long
+		Dreal float64 // Represents a double
+	}
+
+	XrdXrootdMonStatXFR struct {
+		Read  int64 // Bytes read from file using read()
+		Readv int64 // Bytes read from file using readv()
+		Write int64 // Bytes written to file
+	}
+
+	// XrdXrootdMonFileCLS represents a variable length structure and
+	// includes other structures that are "Always present" or "OPTIONAL".
+	// The OPTIONAL parts are not included here as they require more context.
+	XrdXrootdMonFileCLS struct {
+		Hdr XrdXrootdMonFileHdr // Always present
+		Xfr XrdXrootdMonStatXFR // Always present
+		Ops XrdXrootdMonStatOPS // OPTIONAL
+		// Ssq XrdXrootdMonStatSSQ // OPTIONAL
 	}
 
 	SummaryStat struct {
@@ -294,7 +347,7 @@ func HandlePacket(packet []byte) error {
 	header.Code = packet[0]
 	header.Pseq = packet[1]
 	header.Plen = binary.BigEndian.Uint16(packet[2:4])
-	header.Stod = binary.BigEndian.Uint32(packet[4:8])
+	header.Stod = int32(binary.BigEndian.Uint32(packet[4:8]))
 
 	switch header.Code {
 	case 'd':

--- a/metrics/xrootd_metrics_serializer.go
+++ b/metrics/xrootd_metrics_serializer.go
@@ -1,0 +1,295 @@
+/***************************************************************
+ *
+ * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package metrics
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+func (monHeader *XrdXrootdMonHeader) Serialize() ([]byte, error) {
+	var buf bytes.Buffer
+	// Writing the Header
+	err := binary.Write(&buf, binary.BigEndian, monHeader.Code)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprint("binary.Write failed for Code:", err))
+	}
+	err = binary.Write(&buf, binary.BigEndian, monHeader.Pseq)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprint("binary.Write failed for Pseq:", err))
+	}
+	err = binary.Write(&buf, binary.BigEndian, monHeader.Plen)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprint("binary.Write failed for Plen:", err))
+	}
+	err = binary.Write(&buf, binary.BigEndian, monHeader.Stod)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprint("binary.Write failed for Stod:", err))
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (monMap XrdXrootdMonMap) Serialize() ([]byte, error) {
+	var buf bytes.Buffer
+
+	// Writing the Header
+	headerBytes, err := monMap.Hdr.Serialize()
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprint("Failed to serialize monitor header:", err))
+	}
+	err = binary.Write(&buf, binary.BigEndian, headerBytes)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprint("binary.Write failed for Header:", err))
+	}
+
+	// Writing the Dictid
+	err = binary.Write(&buf, binary.BigEndian, monMap.Dictid)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprint("binary.Write failed for Dictid:", err))
+	}
+
+	// Writing the Info slice directly
+	err = binary.Write(&buf, binary.BigEndian, monMap.Info)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprint("binary.Write failed for Info:", err))
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (hdr *XrdXrootdMonFileHdr) Serialize() ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	// Serialize RecType
+	buf.WriteByte(byte(hdr.RecType))
+	// Serialize RecFlag
+	buf.WriteByte(hdr.RecFlag)
+	// Serialize RecSize
+	if err := binary.Write(buf, binary.BigEndian, hdr.RecSize); err != nil {
+		return nil, err
+	}
+
+	// Serialize the union field based on RecType
+	switch hdr.RecType {
+	case isTime:
+		// Serialize NRecs0 and NRecs1
+		if err := binary.Write(buf, binary.BigEndian, hdr.NRecs0); err != nil {
+			return nil, err
+		}
+		if err := binary.Write(buf, binary.BigEndian, hdr.NRecs1); err != nil {
+			return nil, err
+		}
+	case isDisc:
+		// Serialize UserID
+		if err := binary.Write(buf, binary.BigEndian, hdr.UserId); err != nil {
+			return nil, err
+		}
+	default:
+		// Serialize FileID for all other cases (isClose, isOpen, isXFR)
+		if err := binary.Write(buf, binary.BigEndian, hdr.FileId); err != nil {
+			return nil, err
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (ftod *XrdXrootdMonFileTOD) Serialize() ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	// First serialize the header
+	headerBytes, err := ftod.Hdr.Serialize()
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(headerBytes)
+
+	// Serialize TBeg
+	if err := binary.Write(buf, binary.BigEndian, ftod.TBeg); err != nil {
+		return nil, err
+	}
+	// Serialize TEnd
+	if err := binary.Write(buf, binary.BigEndian, ftod.TEnd); err != nil {
+		return nil, err
+	}
+	// Serialize SID
+	if err := binary.Write(buf, binary.BigEndian, ftod.SID); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (lfn *XrdXrootdMonFileLFN) Serialize() ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	// Serialize User
+	if err := binary.Write(buf, binary.BigEndian, lfn.User); err != nil {
+		return nil, err
+	}
+	// Serialize Lfn
+	// Here we don't need to handle endianness since it's a byte array
+	buf.Write(lfn.Lfn[:])
+
+	return buf.Bytes(), nil
+}
+
+func (opn *XrdXrootdMonFileOPN) Serialize() ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	// Serialize the header
+	headerBytes, err := opn.Hdr.Serialize()
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(headerBytes)
+
+	// Serialize Fsz
+	if err := binary.Write(buf, binary.BigEndian, opn.Fsz); err != nil {
+		return nil, err
+	}
+
+	// Serialize Ufn
+	lfnBytes, err := opn.Ufn.Serialize()
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(lfnBytes)
+
+	return buf.Bytes(), nil
+}
+
+func (xfr *XrdXrootdMonStatXFR) Serialize() ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	// Serialize Read
+	if err := binary.Write(buf, binary.BigEndian, xfr.Read); err != nil {
+		return nil, err
+	}
+	// Serialize Readv
+	if err := binary.Write(buf, binary.BigEndian, xfr.Readv); err != nil {
+		return nil, err
+	}
+	// Serialize Write
+	if err := binary.Write(buf, binary.BigEndian, xfr.Write); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (fileXFR *XrdXrootdMonFileXFR) Serialize() ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	// Serialize the header
+	headerBytes, err := fileXFR.Hdr.Serialize()
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(headerBytes)
+
+	// Serialize the Xfr stats
+	xfrBytes, err := fileXFR.Xfr.Serialize()
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(xfrBytes)
+
+	return buf.Bytes(), nil
+}
+
+func (ops *XrdXrootdMonStatOPS) Serialize() ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	// Serialize each field using binary.Write which encodes according to the specified endianness
+	if err := binary.Write(buf, binary.BigEndian, ops.Read); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, ops.Readv); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, ops.Write); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, ops.RsMin); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, ops.RsMax); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, ops.Rsegs); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, ops.RdMin); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, ops.RdMax); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, ops.RvMin); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, ops.RvMax); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, ops.WrMin); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.BigEndian, ops.WrMax); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// Serialize converts XrdXrootdMonFileCLS to a byte array
+func (cls *XrdXrootdMonFileCLS) Serialize() ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	// Serialize the header
+	headerBytes, err := cls.Hdr.Serialize()
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(headerBytes)
+
+	// Serialize the Xfr stats
+	xfrBytes, err := cls.Xfr.Serialize()
+	if err != nil {
+		return nil, err
+	}
+	buf.Write(xfrBytes)
+
+	// Conditionally serialize Ops if hasOPS flag is set
+	if cls.Hdr.RecFlag&0x02 == 0x02 {
+		opsBytes, err := cls.Ops.Serialize()
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(opsBytes)
+	}
+
+	// Note: Ssq field is not implemented and thus not serialized
+
+	return buf.Bytes(), nil
+}

--- a/metrics/xrootd_metrics_test.go
+++ b/metrics/xrootd_metrics_test.go
@@ -9,8 +9,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func getAuthInfoString(user UserRecord) string {
@@ -21,7 +23,201 @@ func getUserIdString(userId XrdUserId) string {
 	return fmt.Sprintf("%s/%s.%s:%s@%s", userId.Prot, userId.User, userId.Pid, userId.Sid, userId.Host)
 }
 
+func mockFileOpenPacket(pseq int, fileId, userId uint32, SID int64, path string) ([]byte, error) {
+	// f-stream file open event
+	mockMonHeader := XrdXrootdMonHeader{ // 8B
+		Code: 'f',
+		Pseq: byte(pseq),
+		Plen: uint16(8), // to change
+		Stod: int32(time.Now().Unix()),
+	}
+	mockMonFileTOD := XrdXrootdMonFileTOD{
+		Hdr: XrdXrootdMonFileHdr{ // 8B
+			RecType: isTime,
+			RecFlag: 1, // hasSID
+			RecSize: int16(24),
+			NRecs0:  0, // isTime: nRecs[0] == isXfr recs
+			NRecs1:  1, // nRecs[1] == total recs
+		},
+		TBeg: int32(time.Now().Unix()),                  // 4B
+		TEnd: int32(time.Now().Add(time.Second).Unix()), // 4B
+		SID:  SID,                                       // 8B
+	}
+	lfnByteSlice := []byte(path)
+	lfnByteSlice = append(lfnByteSlice, '\x00') // Add null byte to end the string
+
+	mockMonFileOpn := XrdXrootdMonFileOPN{
+		Hdr: XrdXrootdMonFileHdr{ // 8B
+			RecType: isOpen,
+			RecFlag: 3,      // hasLFN hasRW
+			RecSize: 0,      // to change
+			FileId:  fileId, // dictid if recType != isTime
+		},
+		Fsz: 10000, // 8B
+		Ufn: XrdXrootdMonFileLFN{ // 4B + len(lfn)
+			User: userId, // dictid for the user
+		},
+	}
+	copy(mockMonFileOpn.Ufn.Lfn[:], lfnByteSlice)
+	mockMonFileOpn.Hdr.RecSize = int16(16 + 4 + len(lfnByteSlice))
+	mockMonHeader.Plen = uint16(8 + mockMonFileTOD.Hdr.RecSize + mockMonFileOpn.Hdr.RecSize)
+
+	monHeader, err := mockMonHeader.Serialize()
+	if err != nil {
+		return nil, errors.Wrap(err, "Error serialize monitor header")
+	}
+	fileTod, err := mockMonFileTOD.Serialize()
+	if err != nil {
+		return nil, errors.Wrap(err, "Error serialize FileTOD")
+	}
+	fileOpn, err := mockMonFileOpn.Serialize()
+	if err != nil {
+		return nil, errors.Wrap(err, "Error serialize FileOPN")
+	}
+
+	buf := new(bytes.Buffer)
+	buf.Write(monHeader[:])
+	buf.Write(fileTod[:])
+	buf.Write(fileOpn[:])
+
+	bytePacket := buf.Bytes()
+	return bytePacket, nil
+}
+
+func mockFileXfrPacket(pseq int, fileId uint32, SID int64, read, readv, wrtie int64) ([]byte, error) {
+	// f-stream file transfer event
+	mockMonHeader := XrdXrootdMonHeader{ // 8B
+		Code: 'f',
+		Pseq: byte(pseq),
+		Plen: uint16(8), // to change
+		Stod: int32(time.Now().Unix()),
+	}
+	mockMonFileTOD := XrdXrootdMonFileTOD{
+		Hdr: XrdXrootdMonFileHdr{ // 8B
+			RecType: isTime,
+			RecFlag: 1, // hasSID
+			RecSize: int16(24),
+			NRecs0:  0, // isTime: nRecs[0] == isXfr recs
+			NRecs1:  1, // nRecs[1] == total recs
+		},
+		TBeg: int32(time.Now().Unix()),                  // 4B
+		TEnd: int32(time.Now().Add(time.Second).Unix()), // 4B
+		SID:  SID,                                       // 8B
+	}
+	mockMonFileXfr := XrdXrootdMonFileXFR{
+		Hdr: XrdXrootdMonFileHdr{ // 8B
+			RecType: isXfr,
+			RecFlag: 0,
+			RecSize: 32,     // to change
+			FileId:  fileId, // dictid if recType != isTime
+		},
+		Xfr: XrdXrootdMonStatXFR{ // 24B
+			Read:  read,
+			Readv: readv,
+			Write: wrtie,
+		},
+	}
+	mockMonHeader.Plen = uint16(8 + mockMonFileTOD.Hdr.RecSize + mockMonFileXfr.Hdr.RecSize)
+
+	monHeader, err := mockMonHeader.Serialize()
+	if err != nil {
+		return nil, errors.Wrap(err, "Error serialize monitor header")
+	}
+	fileTod, err := mockMonFileTOD.Serialize()
+	if err != nil {
+		return nil, errors.Wrap(err, "Error serialize FileTOD")
+	}
+	fileXfr, err := mockMonFileXfr.Serialize()
+	if err != nil {
+		return nil, errors.Wrap(err, "Error serialize FileOPN")
+	}
+
+	buf := new(bytes.Buffer)
+	buf.Write(monHeader[:])
+	buf.Write(fileTod[:])
+	buf.Write(fileXfr[:])
+
+	bytePacket := buf.Bytes()
+	return bytePacket, nil
+}
+
+func mockStatOps(read, readv, write int32, rsegs int64) *XrdXrootdMonStatOPS {
+	monOps := XrdXrootdMonStatOPS{ // 48B
+		Read:  read,
+		Readv: readv,
+		Write: write,
+		Rsegs: rsegs,
+	}
+
+	return &monOps
+}
+
+func mockFileClosePacket(pseq int, fileId uint32, SID int64, statOps *XrdXrootdMonStatOPS, read, readv, write int64) ([]byte, error) {
+	// f-stream file close event
+	mockMonHeader := XrdXrootdMonHeader{ // 8B
+		Code: 'f',
+		Pseq: byte(pseq),
+		Plen: uint16(8), // to change
+		Stod: int32(time.Now().Unix()),
+	}
+	mockMonFileTOD := XrdXrootdMonFileTOD{
+		Hdr: XrdXrootdMonFileHdr{ // 8B
+			RecType: isTime,
+			RecFlag: 0x01, // hasSID
+			RecSize: int16(24),
+			NRecs0:  0, // isTime: nRecs[0] == isXfr recs
+			NRecs1:  1, // nRecs[1] == total recs
+		},
+		TBeg: int32(time.Now().Unix()),                  // 4B
+		TEnd: int32(time.Now().Add(time.Second).Unix()), // 4B
+		SID:  SID,                                       // 8B
+	}
+	mockFileClose := XrdXrootdMonFileCLS{
+		Hdr: XrdXrootdMonFileHdr{ // 8B
+			RecType: isClose,
+			RecFlag: 0x02,   // hasOPS
+			RecSize: 80,     // to change
+			FileId:  fileId, // dictid if recType != isTime
+		},
+		Xfr: XrdXrootdMonStatXFR{ // 24B
+			Read:  read,
+			Readv: readv,
+			Write: write,
+		},
+		Ops: *statOps, // 48B
+	}
+
+	mockMonHeader.Plen = uint16(8 + mockMonFileTOD.Hdr.RecSize + mockFileClose.Hdr.RecSize)
+
+	monHeader, err := mockMonHeader.Serialize()
+	if err != nil {
+		return nil, errors.Wrap(err, "Error serialize monitor header")
+	}
+	fileTod, err := mockMonFileTOD.Serialize()
+	if err != nil {
+		return nil, errors.Wrap(err, "Error serialize FileTOD")
+	}
+	fileClose, err := mockFileClose.Serialize()
+	if err != nil {
+		return nil, errors.Wrap(err, "Error serialize FileCLS")
+	}
+
+	buf := new(bytes.Buffer)
+	buf.Write(monHeader[:])
+	buf.Write(fileTod[:])
+	buf.Write(fileClose[:])
+
+	return buf.Bytes(), nil
+}
+
 func TestHandlePacket(t *testing.T) {
+	mockFileID := uint32(999)
+	mockSID := int64(143152967831384)
+	mockUserID := uint32(10)
+	mockRead := int64(10000)
+	mockReadV := int64(20000)
+	mockWrite := int64(120)
+
 	t.Run("an-empty-detail-packet-should-return-error", func(t *testing.T) {
 		err := HandlePacket([]byte{})
 		assert.Error(t, err, "No error reported with an empty detail packet")
@@ -39,8 +235,11 @@ func TestHandlePacket(t *testing.T) {
 				},
 			},
 		}
+
+		Threads.Reset()
+
 		mockShedSummaryBytes, err := xml.Marshal(mockShedSummary)
-		assert.NoError(t, err, "Error Marshal Summary packet")
+		require.NoError(t, err, "Error Marshal Summary packet")
 
 		mockPromThreads := `
 		# HELP xrootd_sched_thread_count Number of scheduler threads
@@ -51,9 +250,9 @@ func TestHandlePacket(t *testing.T) {
 		expectedReader := strings.NewReader(mockPromThreads)
 
 		err = HandlePacket(mockShedSummaryBytes)
-		assert.NoError(t, err, "Error handling the packet")
+		require.NoError(t, err, "Error handling the packet")
 		if err := testutil.CollectAndCompare(Threads, expectedReader, "xrootd_sched_thread_count"); err != nil {
-			assert.NoError(t, err, "Collected metric is different from expected")
+			require.NoError(t, err, "Collected metric is different from expected")
 		}
 	})
 
@@ -94,12 +293,16 @@ func TestHandlePacket(t *testing.T) {
 				},
 			},
 		}
+
+		BytesXfer.Reset()
+		Threads.Reset()
+
 		mockLinkSummaryBaseBytes, err := xml.Marshal(mockLinkSummaryBase)
-		assert.NoError(t, err, "Error Marshal Summary packet")
+		require.NoError(t, err, "Error Marshal Summary packet")
 		mockLinkSummaryIncBaseBytes, err := xml.Marshal(mockLinkSummaryInc)
-		assert.NoError(t, err, "Error Marshal Summary packet")
+		require.NoError(t, err, "Error Marshal Summary packet")
 		mockLinkSummaryCMSDBaseBytes, err := xml.Marshal(mockLinkSummaryCMSD)
-		assert.NoError(t, err, "Error Marshal Summary packet")
+		require.NoError(t, err, "Error Marshal Summary packet")
 
 		mockPromLinkConnectBase := `
 		# HELP xrootd_server_connection_count Aggregate number of server connections
@@ -136,12 +339,12 @@ func TestHandlePacket(t *testing.T) {
 
 		// First time received a summmary packet
 		err = HandlePacket(mockLinkSummaryBaseBytes)
-		assert.NoError(t, err, "Error handling the packet")
+		require.NoError(t, err, "Error handling the packet")
 		if err := testutil.CollectAndCompare(Connections, expectedLinkConnectBase, "xrootd_server_connection_count"); err != nil {
-			assert.NoError(t, err, "Collected metric is different from expected")
+			require.NoError(t, err, "Collected metric is different from expected")
 		}
 		if err := testutil.CollectAndCompare(BytesXfer, expectedLinkByteXferBase, "xrootd_server_bytes"); err != nil {
-			assert.NoError(t, err, "Collected metric is different from expected")
+			require.NoError(t, err, "Collected metric is different from expected")
 		}
 
 		// Second time received a summmary packet, with numbers more than first time
@@ -149,30 +352,30 @@ func TestHandlePacket(t *testing.T) {
 
 		// Have one CMSD summary packets which should be ignored
 		err = HandlePacket(mockLinkSummaryCMSDBaseBytes)
-		assert.NoError(t, err, "Error handling the packet")
+		require.NoError(t, err, "Error handling the packet")
 		// Have one CMSD summary packets which should be ignored
 		err = HandlePacket(mockLinkSummaryCMSDBaseBytes)
-		assert.NoError(t, err, "Error handling the packet")
+		require.NoError(t, err, "Error handling the packet")
 
 		err = HandlePacket(mockLinkSummaryIncBaseBytes)
-		assert.NoError(t, err, "Error handling the packet")
+		require.NoError(t, err, "Error handling the packet")
 
 		if err := testutil.CollectAndCompare(Connections, expectedLinkConnectInc, "xrootd_server_connection_count"); err != nil {
-			assert.NoError(t, err, "Collected metric is different from expected")
+			require.NoError(t, err, "Collected metric is different from expected")
 		}
 		if err := testutil.CollectAndCompare(BytesXfer, expectedLinkByteXferInc, "xrootd_server_bytes"); err != nil {
-			assert.NoError(t, err, "Collected metric is different from expected")
+			require.NoError(t, err, "Collected metric is different from expected")
 		}
 
 		// Summary data sent to CMSD shouldn't be recorded into the metrics
 		err = HandlePacket(mockLinkSummaryCMSDBaseBytes)
-		assert.NoError(t, err, "Error handling the packet")
+		require.NoError(t, err, "Error handling the packet")
 
 		if err := testutil.CollectAndCompare(Connections, expectedLinkConnectIncDup, "xrootd_server_connection_count"); err != nil {
-			assert.NoError(t, err, "Collected metric is different from expected")
+			require.NoError(t, err, "Collected metric is different from expected")
 		}
 		if err := testutil.CollectAndCompare(BytesXfer, expectedLinkByteXferIncDup, "xrootd_server_bytes"); err != nil {
-			assert.NoError(t, err, "Collected metric is different from expected")
+			require.NoError(t, err, "Collected metric is different from expected")
 		}
 	})
 
@@ -206,14 +409,14 @@ func TestHandlePacket(t *testing.T) {
 		sessions.DeleteAll()
 
 		buf, err := mockMonMap.Serialize()
-		assert.NoError(t, err, "Error serializing monitor packet")
+		require.NoError(t, err, "Error serializing monitor packet")
 		err = HandlePacket(buf)
-		assert.NoError(t, err, "Error handling packet")
+		require.NoError(t, err, "Error handling packet")
 
-		assert.Equal(t, 1, len(sessions.Keys()), "Session cache didn't update")
+		require.Equal(t, 1, len(sessions.Keys()), "Session cache didn't update")
 
 		sidInt, err := strconv.Atoi(mockXrdUserId.Sid)
-		assert.NoError(t, err, "Error parsing SID to int64")
+		require.NoError(t, err, "Error parsing SID to int64")
 		// The ID seems to be wrong. The length of sid is kXR_int64 while the user id in file hdr is kXR_unt32
 		// Aren't the user id supposed to be the dictid instead of sid?
 		assert.Equal(t, uint32(sidInt), sessions.Keys()[0].Id, "Id in session cache entry doesn't match expected")
@@ -250,13 +453,13 @@ func TestHandlePacket(t *testing.T) {
 		}
 
 		buf, err := mockMonMap.Serialize()
-		assert.NoError(t, err, "Error serializing monitor packet")
+		require.NoError(t, err, "Error serializing monitor packet")
 
 		transfers.DeleteAll()
 
 		err = HandlePacket(buf)
-		assert.NoError(t, err, "Error handling packet")
-		assert.Equal(t, 1, len(transfers.Keys()), "Transfer cache didn't update")
+		require.NoError(t, err, "Error handling packet")
+		require.Equal(t, 1, len(transfers.Keys()), "Transfer cache didn't update")
 		assert.Equal(t, uint32(10), transfers.Keys()[0].Id, "Id in session cache entry doesn't match expected")
 		transferEntry := transfers.Get(transfers.Keys()[0]).Value()
 		// I'm not sure the intent of the Path attribute and looking at ComputePrefix,
@@ -265,75 +468,20 @@ func TestHandlePacket(t *testing.T) {
 		assert.Equal(t, "/", transferEntry.Path, "Path in transfer cache entry doesn't match expected")
 
 		sidInt, err := strconv.Atoi(mockXrdUserId.Sid)
-		assert.NoError(t, err, "Error parsing SID to int64")
+		require.NoError(t, err, "Error parsing SID to int64")
 		assert.Equal(t, uint32(sidInt), transferEntry.UserId.Id, "UserID in transfer cache entry doesn't match expected")
+		transfers.DeleteAll()
 	})
 
 	t.Run("f-stream-file-open-event-should-register-correctly", func(t *testing.T) {
-		mockFileID := uint32(999)
-		mockSID := int64(143152967831384)
-		mockUserID := uint32(10)
-
-		// f-stream file open event
-		mockMonHeader := XrdXrootdMonHeader{ // 8B
-			Code: 'f',
-			Pseq: 1,
-			Plen: uint16(8), // to change
-			Stod: int32(time.Now().Unix()),
-		}
-		mockMonFileTOD := XrdXrootdMonFileTOD{
-			Hdr: XrdXrootdMonFileHdr{ // 8B
-				RecType: isTime,
-				RecFlag: 1, // hasSID
-				RecSize: int16(24),
-				NRecs0:  0, // isTime: nRecs[0] == isXfr recs
-				NRecs1:  1, // nRecs[1] == total recs
-			},
-			TBeg: int32(time.Now().Unix()),                  // 4B
-			TEnd: int32(time.Now().Add(time.Second).Unix()), // 4B
-			SID:  mockSID,                                   // 8B
-		}
-		lfnStr := "/full/path/to/file.txt"
-		lfnByteSlice := []byte(lfnStr)
-		lfnByteSlice = append(lfnByteSlice, '\x00') // Add null byte to end the string
-
-		mockMonFileOpn := XrdXrootdMonFileOPN{
-			Hdr: XrdXrootdMonFileHdr{ // 8B
-				RecType: isOpen,
-				RecFlag: 3,          // hasLFN hasRW
-				RecSize: 0,          // to change
-				FileId:  mockFileID, // dictid if recType != isTime
-			},
-			Fsz: 10000, // 8B
-			Ufn: XrdXrootdMonFileLFN{ // 4B + len(lfn)
-				User: mockUserID, // dictid for the user
-			},
-		}
-		copy(mockMonFileOpn.Ufn.Lfn[:], lfnByteSlice)
-		mockMonFileOpn.Hdr.RecSize = int16(16 + 4 + len(lfnByteSlice))
-		mockMonHeader.Plen = uint16(8 + mockMonFileTOD.Hdr.RecSize + mockMonFileOpn.Hdr.RecSize)
-
-		monHeader, err := mockMonHeader.Serialize()
-		assert.NoError(t, err, "Error serialize monitor header")
-		fileTod, err := mockMonFileTOD.Serialize()
-		assert.NoError(t, err, "Error serialize FileTOD")
-		fileOpn, err := mockMonFileOpn.Serialize()
-		assert.NoError(t, err, "Error serialize FileOPN")
-
-		buf := new(bytes.Buffer)
-		buf.Write(monHeader[:])
-		buf.Write(fileTod[:])
-		buf.Write(fileOpn[:])
-
-		bytePacket := buf.Bytes()
+		bytePacket, err := mockFileOpenPacket(0, mockFileID, mockUserID, mockSID, "/full/path/to/file.txt")
+		require.NoError(t, err, "Error generating mock file open packet")
 
 		transfers.DeleteAll()
 
 		err = HandlePacket(bytePacket)
-		assert.NoError(t, err, "Error handling the packet")
-
-		assert.NoError(t, err, "Error handling packet")
-		assert.Equal(t, 1, len(transfers.Keys()), "Transfer cache didn't update")
+		require.NoError(t, err, "Error handling the packet")
+		require.Equal(t, 1, len(transfers.Keys()), "Transfer cache didn't update")
 		assert.Equal(t, mockFileID, transfers.Keys()[0].Id, "Id in session cache entry doesn't match expected")
 		transferEntry := transfers.Get(transfers.Keys()[0]).Value()
 		// I'm not sure the intent of the Path attribute and looking at ComputePrefix,
@@ -344,5 +492,132 @@ func TestHandlePacket(t *testing.T) {
 		// but for other tests to run, just change to what returns to me for now
 		assert.Equal(t, mockUserID, transferEntry.UserId.Id, "UserID in transfer cache entry doesn't match expected")
 		transfers.DeleteAll()
+	})
+
+	t.Run("f-stream-file-xfr-event-should-register-correctly", func(t *testing.T) {
+		bytePacket, err := mockFileXfrPacket(0, mockFileID, mockSID, mockRead, mockReadV, mockWrite)
+		require.NoError(t, err, "Error generating mock file open packet")
+
+		transfers.DeleteAll()
+
+		err = HandlePacket(bytePacket)
+		require.NoError(t, err, "Error handling the packet")
+		require.Equal(t, 1, len(transfers.Keys()), "Transfer cache didn't update")
+		assert.Equal(t, mockFileID, transfers.Keys()[0].Id, "Id in session cache entry doesn't match expected")
+		transferEntry := transfers.Get(transfers.Keys()[0]).Value()
+		assert.Equal(t, mockRead, int64(transferEntry.ReadBytes))
+		assert.Equal(t, mockReadV, int64(transferEntry.ReadvBytes))
+		assert.Equal(t, mockWrite, int64(transferEntry.WriteBytes))
+
+		transfers.DeleteAll()
+	})
+
+	t.Run("f-stream-file-open-xfr-event-should-register-correctly", func(t *testing.T) {
+		openPacket, err := mockFileOpenPacket(0, mockFileID, mockUserID, mockSID, "/full/path/to/file.txt")
+		require.NoError(t, err, "Error generating mock file open packet")
+		xftPacket, err := mockFileXfrPacket(1, mockFileID, mockSID, mockRead, mockReadV, mockWrite)
+		require.NoError(t, err, "Error generating mock file transfer packet")
+
+		transfers.DeleteAll()
+
+		err = HandlePacket(openPacket)
+		require.NoError(t, err, "Error handling the file open packet")
+
+		err = HandlePacket(xftPacket)
+		require.NoError(t, err, "Error handling the file transfer packet")
+
+		require.Equal(t, 1, len(transfers.Keys()), "Transfer cache didn't update")
+		assert.Equal(t, mockFileID, transfers.Keys()[0].Id, "Id in session cache entry doesn't match expected")
+		transferEntry := transfers.Get(transfers.Keys()[0]).Value()
+		assert.Equal(t, mockRead, int64(transferEntry.ReadBytes))
+		assert.Equal(t, mockReadV, int64(transferEntry.ReadvBytes))
+		assert.Equal(t, mockWrite, int64(transferEntry.WriteBytes))
+		assert.Equal(t, "/", transferEntry.Path, "Path in transfer cache entry doesn't match expected")
+		// TODO: Figure out why there's such discrepency here and the d-stream (where userid == sid),
+		// but for other tests to run, just change to what returns to me for now
+		assert.Equal(t, mockUserID, transferEntry.UserId.Id, "UserID in transfer cache entry doesn't match expected")
+		transfers.DeleteAll()
+	})
+
+	// Testing against close event is less meaningfult than do a full-run
+	// as the close event require user/transfer info to work as expected. Although
+	// adding another test case with file-close event only to check the edge cases is
+	// also highly recommended
+	t.Run("f-stream-file-open-xfr-close-events-should-register-correctly", func(t *testing.T) {
+		mockReadCalls := int32(120)
+		mockReadVCalls := int32(10)
+		mockWriteCalls := int32(30)
+		mockReadVSegments := int64(1000)
+
+		TransferReadvSegs.Reset()
+		TransferOps.Reset()
+		TransferBytes.Reset()
+
+		openPacket, err := mockFileOpenPacket(0, mockFileID, mockUserID, mockSID, "/full/path/to/file.txt")
+		require.NoError(t, err, "Error generating mock file open packet")
+		xftPacket, err := mockFileXfrPacket(1, mockFileID, mockSID, mockRead, mockReadV, mockWrite)
+		require.NoError(t, err, "Error generating mock file transfer packet")
+		opsState := mockStatOps(mockReadCalls, mockReadVCalls, mockWriteCalls, mockReadVSegments)
+		clsPacket, err := mockFileClosePacket(2, mockFileID, mockSID, opsState, mockRead, mockReadV, mockWrite)
+		require.NoError(t, err, "Error generating mock file close packet")
+
+		transfers.DeleteAll()
+		sessions.DeleteAll()
+
+		err = HandlePacket(openPacket)
+		require.NoError(t, err, "Error handling the file open packet")
+
+		require.Equal(t, 1, len(transfers.Keys()), "Transfer cache didn't update")
+		assert.Equal(t, mockFileID, transfers.Keys()[0].Id, "Id in session cache entry doesn't match expected")
+		transferEntry := transfers.Get(transfers.Keys()[0]).Value()
+		assert.Equal(t, "/", transferEntry.Path, "Path in transfer cache entry doesn't match expected")
+		assert.Equal(t, mockUserID, transferEntry.UserId.Id, "UserID in transfer cache entry doesn't match expected")
+
+		err = HandlePacket(xftPacket)
+		require.NoError(t, err, "Error handling the file transfer packet")
+
+		err = HandlePacket(clsPacket)
+		require.NoError(t, err, "Error handling the file close packet")
+
+		// Trasnfer item should be deleted on file close
+		require.Equal(t, 0, len(transfers.Keys()), "Transfer cache didn't update")
+
+		expectedTransferReadvSegs := `
+		# HELP xrootd_transfer_readv_segments_count Number of segments in readv operations
+		# TYPE xrootd_transfer_readv_segments_count counter
+		xrootd_transfer_readv_segments_count{ap="",dn="",org="",path="/",role=""} 1000
+		`
+
+		expectedTransferOps := `
+		# HELP xrootd_transfer_operations_count Number of transfer operations performed
+		# TYPE xrootd_transfer_operations_count counter
+		xrootd_transfer_operations_count{ap="",dn="",org="",path="/",role="",type="read"} 120
+		xrootd_transfer_operations_count{ap="",dn="",org="",path="/",role="",type="readv"} 10
+		xrootd_transfer_operations_count{ap="",dn="",org="",path="/",role="",type="write"} 30
+		`
+
+		expectedTransferBytes := `
+		# HELP xrootd_transfer_bytes Bytes of transfers
+		# TYPE xrootd_transfer_bytes counter
+		xrootd_transfer_bytes{ap="",dn="",org="",path="/",role="",type="read"} 10000
+		xrootd_transfer_bytes{ap="",dn="",org="",path="/",role="",type="readv"} 20000
+		xrootd_transfer_bytes{ap="",dn="",org="",path="/",role="",type="write"} 120
+		`
+
+		expectedTransferReadvSegsReader := strings.NewReader(expectedTransferReadvSegs)
+		expectedTransferOpsReader := strings.NewReader(expectedTransferOps)
+		expectedTransferBytesReader := strings.NewReader(expectedTransferBytes)
+
+		if err := testutil.CollectAndCompare(TransferReadvSegs, expectedTransferReadvSegsReader, "xrootd_transfer_readv_segments_count"); err != nil {
+			require.NoError(t, err, "Collected metric is different from expected")
+		}
+
+		if err := testutil.CollectAndCompare(TransferOps, expectedTransferOpsReader, "xrootd_transfer_operations_count"); err != nil {
+			require.NoError(t, err, "Collected metric is different from expected")
+		}
+
+		if err := testutil.CollectAndCompare(TransferBytes, expectedTransferBytesReader, "xrootd_transfer_bytes"); err != nil {
+			require.NoError(t, err, "Collected metric is different from expected")
+		}
 	})
 }

--- a/metrics/xrootd_metrics_test.go
+++ b/metrics/xrootd_metrics_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jellydator/ttlcache/v3"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -20,34 +19,6 @@ func getAuthInfoString(user UserRecord) string {
 
 func getUserIdString(userId XrdUserId) string {
 	return fmt.Sprintf("%s/%s.%s:%s@%s", userId.Prot, userId.User, userId.Pid, userId.Sid, userId.Host)
-}
-
-func TestCacheMerge(t *testing.T) {
-	t.Run("same-key-will-override-item-not-merge", func(t *testing.T) {
-		transfers.DeleteAll()
-		mockFileId := FileId{Id: 147927}
-		mockInitRecord := FileRecord{
-			UserId: UserId{Id: 123},
-			Path:   "/foo/bar",
-		}
-		mockSecondRecord := FileRecord{
-			WriteOps:   1,
-			ReadOps:    2,
-			WriteBytes: 100,
-			ReadBytes:  100,
-		}
-
-		transfers.Set(mockFileId, mockInitRecord, ttlcache.DefaultTTL)
-		transfers.Set(mockFileId, mockSecondRecord, ttlcache.DefaultTTL)
-
-		assert.Equal(t, 1, len(transfers.Items()), "Lenght of items in cache doesn't match")
-		transferValue := transfers.Items()[mockFileId].Value()
-
-		assert.Equal(t, mockSecondRecord.UserId, transferValue.UserId)
-		assert.Equal(t, mockSecondRecord.Path, transferValue.Path)
-		assert.Equal(t, mockSecondRecord.WriteOps, transferValue.WriteOps)
-		assert.Equal(t, mockSecondRecord.ReadOps, transferValue.ReadOps)
-	})
 }
 
 func TestHandlePacket(t *testing.T) {

--- a/metrics/xrootd_metrics_test.go
+++ b/metrics/xrootd_metrics_test.go
@@ -1,0 +1,166 @@
+package metrics
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandlePacket(t *testing.T) {
+	t.Run("an-empty-detail-packet-should-return-error", func(t *testing.T) {
+		err := HandlePacket([]byte{})
+		assert.Error(t, err, "No error reported with an empty detail packet")
+	})
+
+	t.Run("record-correct-threads-from-summary-packet", func(t *testing.T) {
+		mockShedSummary := SummaryStatistics{
+			Version: "0.0",
+			Program: "xrootd",
+			Stats: []SummaryStat{
+				{
+					Id:          "sched",
+					Threads:     10,
+					ThreadsIdle: 8,
+				},
+			},
+		}
+		mockShedSummaryBytes, err := xml.Marshal(mockShedSummary)
+		assert.NoError(t, err, "Error Marshal Summary packet")
+
+		mockPromThreads := `
+		# HELP xrootd_sched_thread_count Number of scheduler threads
+		# TYPE xrootd_sched_thread_count gauge
+		xrootd_sched_thread_count{state="idle"} 8
+		xrootd_sched_thread_count{state="running"} 2
+		`
+		expectedReader := strings.NewReader(mockPromThreads)
+
+		err = HandlePacket(mockShedSummaryBytes)
+		assert.NoError(t, err, "Error handling the packet")
+		if err := testutil.CollectAndCompare(Threads, expectedReader, "xrootd_sched_thread_count"); err != nil {
+			assert.NoError(t, err, "Collected metric is different from expected")
+		}
+	})
+
+	t.Run("record-correct-link-from-summary-packet", func(t *testing.T) {
+		mockLinkSummaryBase := SummaryStatistics{
+			Version: "0.0",
+			Program: "xrootd",
+			Stats: []SummaryStat{
+				{
+					Id:              "link",
+					LinkConnections: 9,
+					LinkInBytes:     99,
+					LinkOutBytes:    999,
+				},
+			},
+		}
+		mockLinkSummaryInc := SummaryStatistics{
+			Version: "0.0",
+			Program: "xrootd",
+			Stats: []SummaryStat{
+				{
+					Id:              "link",
+					LinkConnections: 10,
+					LinkInBytes:     100,
+					LinkOutBytes:    1000,
+				},
+			},
+		}
+		mockLinkSummaryCMSD := SummaryStatistics{
+			Version: "0.0",
+			Program: "cmsd",
+			Stats: []SummaryStat{
+				{
+					Id:              "link",
+					LinkConnections: 2,
+					LinkInBytes:     0,
+					LinkOutBytes:    0,
+				},
+			},
+		}
+		mockLinkSummaryBaseBytes, err := xml.Marshal(mockLinkSummaryBase)
+		assert.NoError(t, err, "Error Marshal Summary packet")
+		mockLinkSummaryIncBaseBytes, err := xml.Marshal(mockLinkSummaryInc)
+		assert.NoError(t, err, "Error Marshal Summary packet")
+		mockLinkSummaryCMSDBaseBytes, err := xml.Marshal(mockLinkSummaryCMSD)
+		assert.NoError(t, err, "Error Marshal Summary packet")
+
+		mockPromLinkConnectBase := `
+		# HELP xrootd_server_connection_count Aggregate number of server connections
+		# TYPE xrootd_server_connection_count counter
+		xrootd_server_connection_count 9
+		`
+
+		mockPromLinkByteXferBase := `
+		# HELP xrootd_server_bytes Number of bytes read into the server
+		# TYPE xrootd_server_bytes counter
+		xrootd_server_bytes{direction="rx"} 99
+		xrootd_server_bytes{direction="tx"} 999
+		`
+
+		mockPromLinkConnectInc := `
+		# HELP xrootd_server_connection_count Aggregate number of server connections
+		# TYPE xrootd_server_connection_count counter
+		xrootd_server_connection_count 10
+		`
+
+		mockPromLinkByteXferInc := `
+		# HELP xrootd_server_bytes Number of bytes read into the server
+		# TYPE xrootd_server_bytes counter
+		xrootd_server_bytes{direction="rx"} 100
+		xrootd_server_bytes{direction="tx"} 1000
+		`
+
+		expectedLinkConnectBase := strings.NewReader(mockPromLinkConnectBase)
+		expectedLinkByteXferBase := strings.NewReader(mockPromLinkByteXferBase)
+		expectedLinkConnectInc := strings.NewReader(mockPromLinkConnectInc)
+		expectedLinkByteXferInc := strings.NewReader(mockPromLinkByteXferInc)
+		expectedLinkConnectIncDup := strings.NewReader(mockPromLinkConnectInc)
+		expectedLinkByteXferIncDup := strings.NewReader(mockPromLinkByteXferInc)
+
+		// First time received a summmary packet
+		err = HandlePacket(mockLinkSummaryBaseBytes)
+		assert.NoError(t, err, "Error handling the packet")
+		if err := testutil.CollectAndCompare(Connections, expectedLinkConnectBase, "xrootd_server_connection_count"); err != nil {
+			assert.NoError(t, err, "Collected metric is different from expected")
+		}
+		if err := testutil.CollectAndCompare(BytesXfer, expectedLinkByteXferBase, "xrootd_server_bytes"); err != nil {
+			assert.NoError(t, err, "Collected metric is different from expected")
+		}
+
+		// Second time received a summmary packet, with numbers more than first time
+		// And metrics should be updated to the max number
+
+		// Have one CMSD summary packets which should be ignored
+		err = HandlePacket(mockLinkSummaryCMSDBaseBytes)
+		assert.NoError(t, err, "Error handling the packet")
+		// Have one CMSD summary packets which should be ignored
+		err = HandlePacket(mockLinkSummaryCMSDBaseBytes)
+		assert.NoError(t, err, "Error handling the packet")
+
+		err = HandlePacket(mockLinkSummaryIncBaseBytes)
+		assert.NoError(t, err, "Error handling the packet")
+
+		if err := testutil.CollectAndCompare(Connections, expectedLinkConnectInc, "xrootd_server_connection_count"); err != nil {
+			assert.NoError(t, err, "Collected metric is different from expected")
+		}
+		if err := testutil.CollectAndCompare(BytesXfer, expectedLinkByteXferInc, "xrootd_server_bytes"); err != nil {
+			assert.NoError(t, err, "Collected metric is different from expected")
+		}
+
+		// Summary data sent to CMSD shouldn't be recorded into the metrics
+		err = HandlePacket(mockLinkSummaryCMSDBaseBytes)
+		assert.NoError(t, err, "Error handling the packet")
+
+		if err := testutil.CollectAndCompare(Connections, expectedLinkConnectIncDup, "xrootd_server_connection_count"); err != nil {
+			assert.NoError(t, err, "Collected metric is different from expected")
+		}
+		if err := testutil.CollectAndCompare(BytesXfer, expectedLinkByteXferIncDup, "xrootd_server_bytes"); err != nil {
+			assert.NoError(t, err, "Collected metric is different from expected")
+		}
+	})
+}


### PR DESCRIPTION
Closes #129 

A couple of lingering questions regarding the handler code, which will affect how I write the test code, see `TODO` and other comments in the code:
* Why we want to use SID as user id for u-stream and record it in our sessions cache? `SID` is an `int64` value per xrootd documentation while the `UserID.Id` is a `uint32` value, which can't hold `SID`.
* What `ComputePrefix` function is doing? It looks buggy because it will only return "/" no matter what

Besides, I fixed some bugs in the handler code as I write the tests. See code and comments below for details.

Finally, this PR introduced a considerable amount of code to serialize xrootd monitoring struct as well as adding such structs to our project. For the serializers, they look a bit redundant but I don't think reflection can help as it can't preserve the order of the fields in the structs. 