### PR TITLE
Use Server.Hostname than os.Hostname() in generating CA

### DIFF
--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -161,10 +161,7 @@ func GenerateCACert() error {
 	if err != nil {
 		return err
 	}
-	hostname, err := os.Hostname()
-	if err != nil {
-		return err
-	}
+	hostname := param.Server_Hostname.GetString()
 	notBefore := time.Now()
 	template := x509.Certificate{
 		SerialNumber: serialNumber,
@@ -278,10 +275,7 @@ func GenerateCert() error {
 	if err != nil {
 		return err
 	}
-	hostname, err := os.Hostname()
-	if err != nil {
-		return err
-	}
+	hostname := param.Server_Hostname.GetString()
 	notBefore := time.Now()
 	template := x509.Certificate{
 		SerialNumber: serialNumber,

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -488,8 +488,8 @@ components: ["origin", "director", "nsregistry"]
 ---
 name: Server.Hostname
 description: >-
-  The server's hostname
-type: url
+  The server's hostname, by default it's os.Hostname().
+type: string
 default: none
 components: ["origin", "director", "nsregistry"]
 ---


### PR DESCRIPTION
Closes #303 

With this PR merged, we should be consistently using Server.Hostname from parameters at all places. This PR also changes the param type of hostname from url to string, and noted the default value will be `os.Hostname()`

Note to the reviewer. I've tested that by changing the `Server.Hostname` from its default to `localhost`, remove existing CA file, spinning up an origin to let it generate new CA, and copy the CA file to `/etc/pelican/certificates/tlsca.crt`, and re-run the origin, the self-test works as expected.