### PR TITLE
Standardize server init and cleanup a few other small items

### DIFF
--- a/cmd/director.go
+++ b/cmd/director.go
@@ -32,7 +32,7 @@ var (
 	directorCmd = &cobra.Command{
 		Use: "director",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			err := config.InitServer()
+			err := initDirector()
 			return err
 		},
 		Short: "Launch a Pelican Director",
@@ -68,6 +68,13 @@ func getDirectorEndpoint() (string, error) {
 
 	// Return the string, as opposed to a pointer to the URL object
 	return directorEndpointURL.String(), nil
+}
+
+func initDirector() error {
+	err := config.InitServer()
+	cobra.CheckErr(err)
+
+	return err
 }
 
 func init() {

--- a/cmd/namespace_registry.go
+++ b/cmd/namespace_registry.go
@@ -27,7 +27,7 @@ var (
 	namespaceRegistryCmd = &cobra.Command{
 		Use: "registry",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			err := config.InitServer()
+			err := initRegistry()
 			return err
 		},
 		Short: "Interact with a Pelican namespace registry service",
@@ -54,6 +54,13 @@ var (
 		SilenceUsage: true,
 	}
 )
+
+func initRegistry() error {
+	err := config.InitServer()
+	cobra.CheckErr(err)
+
+	return err
+}
 
 func init() {
 	// Tie the registryServe command to the root CLI command

--- a/cmd/namespace_registry_serve.go
+++ b/cmd/namespace_registry_serve.go
@@ -19,16 +19,13 @@
 package main
 
 import (
-	"crypto/elliptic"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/pkg/errors"
 
-	"github.com/pelicanplatform/pelican/config"
 	nsregistry "github.com/pelicanplatform/pelican/namespace-registry"
-	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/web_ui"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -41,17 +38,6 @@ func serveNamespaceRegistry( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	err := nsregistry.InitializeDB()
 	if err != nil {
 		return errors.Wrap(err, "Unable to initialize the namespace registry database")
-	}
-
-	// The registry needs its own private key. If one doesn't exist, this will generate it
-	issuerKeyFile := param.IssuerKey.GetString()
-	err = config.GeneratePrivateKey(issuerKeyFile, elliptic.P256())
-	if err != nil {
-		return errors.Wrap(err, "Failed to generate registry private key")
-	}
-
-	if err := config.GenerateCert(); err != nil {
-		return errors.Wrap(err, "Failed to generate TLS certificate")
 	}
 
 	engine, err := web_ui.GetEngine()

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -22,7 +22,6 @@ package main
 
 import (
 	"context"
-	"crypto/elliptic"
 	_ "embed"
 	"fmt"
 	"net/url"
@@ -70,14 +69,6 @@ func checkDefaults(origin bool, nsAds []director.NamespaceAd) error {
 		metrics.DeleteComponentHealthStatus("cmsd")
 	} else {
 		viper.SetDefault("Origin.EnableCmsd", true)
-	}
-
-	// As necessary, generate a private key and corresponding cert
-	if err := config.GeneratePrivateKey(param.Server_TLSKey.GetString(), elliptic.P256()); err != nil {
-		return err
-	}
-	if err := config.GenerateCert(); err != nil {
-		return err
 	}
 
 	// TODO: Could upgrade this to a check for a cert in the file...
@@ -130,12 +121,7 @@ func webUiInitialize() {
 func serveOrigin( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	defer config.CleanupTempResources()
 
-	err := config.DiscoverFederation()
-	if err != nil {
-		log.Warningln("Failed to do service auto-discovery:", err)
-	}
-
-	err = xrootd.SetUpMonitoring()
+	err := xrootd.SetUpMonitoring()
 	if err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -469,16 +469,15 @@ func InitServer() error {
 		viper.SetDefault("Origin.Url", fmt.Sprintf("https://%v", param.Server_Hostname.GetString()))
 	}
 
-	setupTransport()
-
 	// Unmarshal Viper config into a Go struct
 	err = param.UnmarshalConfig()
 	if err != nil {
 		return err
 	}
 
-	// As necessary, generate a private keys and corresponding certs
-	err = GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256())
+	// As necessary, generate a private keys, JWKS and corresponding certs
+	// Note: GenerateIssuerJWKS will also generate a private key in the location stored by the viper var "IssuerKey"
+	_, err = GenerateIssuerJWKS()
 	if err != nil {
 		return err
 	}
@@ -491,6 +490,8 @@ func InitServer() error {
 		return err
 	}
 
+	// After we know we have the certs we need, call setupTransport (which uses those certs for its TLSConfig)
+	setupTransport()
 	return DiscoverFederation()
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@
 package config
 
 import (
+	"crypto/elliptic"
 	"crypto/tls"
 	"crypto/x509"
 	_ "embed"
@@ -476,7 +477,21 @@ func InitServer() error {
 		return err
 	}
 
-	return nil
+	// As necessary, generate a private keys and corresponding certs
+	err = GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256())
+	if err != nil {
+		return err
+	}
+	err = GeneratePrivateKey(param.Server_TLSKey.GetString(), elliptic.P256())
+	if err != nil {
+		return err
+	}
+	err = GenerateCert()
+	if err != nil {
+		return err
+	}
+
+	return DiscoverFederation()
 }
 
 func InitClient() error {

--- a/config/config_default.go
+++ b/config/config_default.go
@@ -36,7 +36,7 @@ func InitServerOSDefaults() error {
 	viper.SetDefault("Server.TLSCACertificateFile", tlscaFile)
 
 	tlscaKeyFile := filepath.Join(viper.GetString("ConfigDir"), "certificates", "tlscakey.pem")
-	viper.SetDefault("Server.TLSCACertificateFile", tlscaKeyFile)
+	viper.SetDefault("Server.TLSCAKey", tlscaKeyFile)
 
 	if err := os.MkdirAll(filepath.Dir(tlscaFile), 0755); err != nil {
 		return err

--- a/config/config_linux.go
+++ b/config/config_linux.go
@@ -21,10 +21,49 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 )
 
+// Different distros have different default CACertificate locations. Instead of trying to figure out
+// the version of linux we use, check all the well-known places until we find one that exists.
+func findLinuxCACert() (string, error) {
+	// These values pulled from the same place x509 package looks:
+	// https://go.dev/src/crypto/x509/root_linux.go
+	certFileLocations := []string{
+		"/etc/ssl/certs/ca-certificates.crt",                // Debian/Ubuntu/Gentoo etc.
+		"/etc/pki/tls/cert.pem",                             // One RHEL-based possibility
+		"/etc/pki/tls/certs/ca-bundle.crt",                  // Another RHEL-based possibility
+		"/etc/ssl/ca-bundle.pem",                            // OpenSUSE
+		"/etc/pki/tls/cacert.pem",                           // OpenELEC
+		"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // Often the think previous RHEL options symlink to
+		"/etc/ssl/cert.pem",                                 // Alpine Linux
+	}
+
+	for _, certLoc := range certFileLocations {
+		if file, err := os.Open(certLoc); err == nil {
+			file.Close()
+			return certLoc, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+	}
+
+	// If we didn't find a cert in a well-known location, we'll wind up creating one later.
+	// In that case, we need to make sure it's someplace we have permission to write to, so we'll
+	// put it where we put other Pelican certs
+	configDir := viper.GetString("ConfigDir")
+	return filepath.Join(configDir, "certificates", "cert.pem"), nil
+}
+
 func InitServerOSDefaults() error {
-	viper.SetDefault("Server.TLSCACertificateFile", "/etc/pki/tls/cert.pem")
-	return nil
+	if certLoc, err := findLinuxCACert(); err == nil {
+		viper.SetDefault("Server.TLSCACertificateFile", certLoc)
+		return nil
+	} else {
+		return err
+	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -127,9 +127,9 @@ func TestInitConfig(t *testing.T) {
 	InitConfig() // Should set up pelican.yaml, osdf.yaml and defaults.yaml
 
 	// Check if server address is correct by defaults.yaml
-	assert.True(t, param.Server_Address.GetString() == "0.0.0.0")
+	assert.Equal(t, "0.0.0.0", param.Server_Address.GetString())
 	// Check that Federation Discovery url is correct by osdf.yaml
-	assert.True(t, param.Federation_DiscoveryUrl.GetString() == "osg-htc.org")
+	assert.Equal(t, "osg-htc.org", param.Federation_DiscoveryUrl.GetString())
 
 	viper.Set("Server.Address", "1.1.1.1") // should write to temp config file
 	if err := viper.WriteConfigAs(tempCfgFile.Name()); err != nil {
@@ -140,7 +140,7 @@ func TestInitConfig(t *testing.T) {
 	InitConfig()
 
 	// Check if server address overrides the default
-	assert.True(t, param.Server_Address.GetString() == "1.1.1.1")
+	assert.Equal(t, "1.1.1.1", param.Server_Address.GetString())
 	viper.Reset()
 
 	//Test if prefix is not set, should not be able to find osdfYaml configuration
@@ -151,5 +151,5 @@ func TestInitConfig(t *testing.T) {
 		t.Fatalf("Failed to make temp file: %v", err)
 	}
 	InitConfig()
-	assert.True(t, param.Federation_DiscoveryUrl.GetString() == "")
+	assert.Equal(t, "", param.Federation_DiscoveryUrl.GetString())
 }

--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -133,6 +133,10 @@ func GenerateCACert() error {
 	if err != nil {
 		return err
 	}
+	user, err := GetDaemonUser()
+	if err != nil {
+		return err
+	}
 
 	tlsCert := param.Server_TLSCACertificateFile.GetString()
 	if file, err := os.Open(tlsCert); err == nil {
@@ -189,9 +193,21 @@ func GenerateCACert() error {
 		return err
 	}
 	defer file.Close()
-	if err = os.Chown(tlsCert, -1, gid); err != nil {
-		return errors.Wrapf(err, "Failed to chown generated certificate %v to daemon group %v",
+
+	// Windows does not have "chown", has to work differently
+	currentOS := runtime.GOOS
+	if currentOS == "windows" {
+		cmd := exec.Command("icacls", tlsCert, "/grant", user+":F")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return errors.Wrapf(err, "Failed to chown generated key %v to daemon group %v: %s",
+				tlsCert, groupname, string(output))
+		}
+	} else { // Else we are running on linux/mac
+		if err = os.Chown(tlsCert, -1, gid); err != nil {
+			return errors.Wrapf(err, "Failed to chown generated key %v to daemon group %v",
 			tlsCert, groupname)
+		}
 	}
 
 	if err = pem.Encode(file, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
@@ -233,6 +249,10 @@ func GenerateCert() error {
 		return err
 	}
 	groupname, err := GetDaemonGroup()
+	if err != nil {
+		return err
+	}
+	user, err := GetDaemonUser()
 	if err != nil {
 		return err
 	}
@@ -315,9 +335,21 @@ func GenerateCert() error {
 		return err
 	}
 	defer file.Close()
-	if err = os.Chown(tlsCert, -1, gid); err != nil {
-		return errors.Wrapf(err, "Failed to chown generated certificate %v to daemon group %v",
+
+	// Windows does not have "chown", has to work differently
+	currentOS := runtime.GOOS
+	if currentOS == "windows" {
+		cmd := exec.Command("icacls", tlsCert, "/grant", user+":F")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return errors.Wrapf(err, "Failed to chown generated key %v to daemon group %v: %s",
+				tlsCert, groupname, string(output))
+		}
+	} else { // Else we are running on linux/mac
+		if err = os.Chown(tlsCert, -1, gid); err != nil {
+			return errors.Wrapf(err, "Failed to chown generated key %v to daemon group %v",
 			tlsCert, groupname)
+		}
 	}
 
 	if err = pem.Encode(file, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {

--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -206,7 +206,7 @@ func GenerateCACert() error {
 	} else { // Else we are running on linux/mac
 		if err = os.Chown(tlsCert, -1, gid); err != nil {
 			return errors.Wrapf(err, "Failed to chown generated key %v to daemon group %v",
-			tlsCert, groupname)
+				tlsCert, groupname)
 		}
 	}
 
@@ -348,7 +348,7 @@ func GenerateCert() error {
 	} else { // Else we are running on linux/mac
 		if err = os.Chown(tlsCert, -1, gid); err != nil {
 			return errors.Wrapf(err, "Failed to chown generated key %v to daemon group %v",
-			tlsCert, groupname)
+				tlsCert, groupname)
 		}
 	}
 

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -451,7 +451,7 @@ name: Server.TLSCACertificateDirectory
 description: >-
   A filepath to the directory used for storing TLS certificates
 type: filename
-default: /etc/pki/tls/
+default: none
 components: ["origin"]
 ---
 name: Server.TLSCAKey

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -450,8 +450,8 @@ components: ["origin"]
 name: Server.TLSCACertificateDirectory
 description: >-
   A filepath to the directory used for storing TLS certificates
-type: string
-default: /etc/pki/tls/cert.pem
+type: filename
+default: /etc/pki/tls/
 components: ["origin"]
 ---
 name: Server.TLSCAKey

--- a/go.sum
+++ b/go.sum
@@ -409,8 +409,6 @@ github.com/lestrrat-go/httprc v1.0.4 h1:bAZymwoZQb+Oq8MEbyipag7iSq6YIga8Wj6GOiJG
 github.com/lestrrat-go/httprc v1.0.4/go.mod h1:mwwz3JMTPBjHUkkDv/IGJ39aALInZLrhBp0X7KGUZlo=
 github.com/lestrrat-go/iter v1.0.2 h1:gMXo1q4c2pHmC3dn8LzRhJfP1ceCbgSiT9lUydIzltI=
 github.com/lestrrat-go/iter v1.0.2/go.mod h1:Momfcq3AnRlRjI5b5O8/G5/BvpzrhoFTZcn06fEOPt4=
-github.com/lestrrat-go/jwx/v2 v2.0.13 h1:XdxzJbudGaHEoNmyJACAT8aFCB+DmviiaiMoZwuJoUo=
-github.com/lestrrat-go/jwx/v2 v2.0.13/go.mod h1:UzXMzcV99p9/xe1JsIb336NJDGXLsleR+Qj3ucEDtfI=
 github.com/lestrrat-go/jwx/v2 v2.0.16 h1:TuH3dBkYTy2giQg/9D8f20znS3JtMRuQJ372boS3lWk=
 github.com/lestrrat-go/jwx/v2 v2.0.16/go.mod h1:jBHyESp4e7QxfERM0UKkQ80/94paqNIEcdEfiUYz5zE=
 github.com/lestrrat-go/option v1.0.0/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
@@ -638,7 +636,6 @@ golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -809,7 +806,6 @@ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -817,7 +813,6 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 golang.org/x/term v0.8.0/go.mod h1:xPskH00ivmX89bAKVGSKKtLOWNx2+17Eiy94tnKShWo=
-golang.org/x/term v0.12.0/go.mod h1:owVbMEjm3cBLCHdkQu9b1opXd4ETQWc3BhuQGKgXgvU=
 golang.org/x/term v0.13.0 h1:bb+I9cTfFazGW51MZqBVmZy7+JEJMouUHTUSKVQLBek=
 golang.org/x/term v0.13.0/go.mod h1:LTmsnFJwVN6bCy1rVCoS+qHT1HhALEFxKncY3WNNh4U=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
The big part of this PR is standardizing some of how servers are initialized. Importantly, this moves federation discovery and some key creation from the various `*_serve.go` files into `InitServer()`.

In the process of putting this together, I noticed a few other cleanup items. One was changing a parameter.yaml default value and type to match the description. Another was modifying config_test to use `assert.Equal` instead of `assert.True` so that if the test fails, it prints out what the expected and actual values are.