### PR TITLE
Fix issue with progress bar panic on download

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -557,8 +557,10 @@ Loop:
 				} else if time.Since(noProgressStartTime) > time.Duration(stoppedTransferTimeout)*time.Second {
 					errMsg := "No progress for more than " + time.Since(noProgressStartTime).Truncate(time.Millisecond).String()
 					log.Errorln(errMsg)
-					progressBar.Abort(true)
-					progressBar.Wait()
+					if ObjectClientOptions.ProgressBars {
+						progressBar.Abort(true)
+						progressBar.Wait()
+					}
 					return 5, &StoppedTransferError{
 						Err: errMsg,
 					}

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -557,6 +557,8 @@ Loop:
 				} else if time.Since(noProgressStartTime) > time.Duration(stoppedTransferTimeout)*time.Second {
 					errMsg := "No progress for more than " + time.Since(noProgressStartTime).Truncate(time.Millisecond).String()
 					log.Errorln(errMsg)
+					progressBar.Abort(true)
+					progressBar.Wait()
 					return 5, &StoppedTransferError{
 						Err: errMsg,
 					}
@@ -611,10 +613,13 @@ Loop:
 				downloadError := resp.Err()
 				if downloadError != nil {
 					log.Errorln(downloadError.Error())
+					progressBar.Abort(true)
+					progressBar.Wait()
+				} else {
+					progressBar.SetTotal(contentLength, true)
+					// call wait here for the bar to complete and flush
+					p.Wait()
 				}
-				progressBar.SetTotal(contentLength, true)
-				// call wait here for the bar to complete and flush
-				p.Wait()
 			}
 			break Loop
 		}


### PR DESCRIPTION
Fixes issue where if the cache sends a `permission denied` error, the next download tries to utilize the completed bar and panic. Now on failure it calls abort and removes the bar instance.