### PR TITLE
Add authorization to Prometheus /metrics endpoint

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -470,6 +470,13 @@ func InitServer() error {
 
 	setupTransport()
 
+	tokenRefreshInterval := param.Monitoring_TokenRefreshInterval.GetDuration()
+	tokenExpiresIn := param.Monitoring_TokenExpiresIn.GetDuration()
+
+	if tokenExpiresIn == 0 || tokenRefreshInterval == 0 || tokenRefreshInterval > tokenExpiresIn {
+		return errors.New("Invalida Monitoring.TokenRefreshInterval or Monitoring.TokenExpiresIn. Must be non-zero value and valid time must be greater than the refresh interval")
+	}
+
 	// Unmarshal Viper config into a Go struct
 	err = param.UnmarshalConfig()
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -474,7 +474,7 @@ func InitServer() error {
 	tokenExpiresIn := param.Monitoring_TokenExpiresIn.GetDuration()
 
 	if tokenExpiresIn == 0 || tokenRefreshInterval == 0 || tokenRefreshInterval > tokenExpiresIn {
-		return errors.New("Invalida Monitoring.TokenRefreshInterval or Monitoring.TokenExpiresIn. Must be non-zero value and valid time must be greater than the refresh interval")
+		log.Warningln("Invalid Monitoring.TokenRefreshInterval or Monitoring.TokenExpiresIn. Value may be zero or valid time <= refresh interval. You may experience intermittent authorization failure for requests with these token")
 	}
 
 	// Unmarshal Viper config into a Go struct

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -32,6 +32,8 @@ Origin:
 Monitoring:
   PortLower: 9930
   PortHigher: 9999
+  TokenExpiresIn: 1h
+  TokenRefreshInterval: 59m
 Xrootd:
   Port: 8443
   Mount: ""

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -34,6 +34,7 @@ Monitoring:
   PortHigher: 9999
   TokenExpiresIn: 1h
   TokenRefreshInterval: 59m
+  MetricAuthorization: true
 Xrootd:
   Port: 8443
   Mount: ""

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -247,7 +247,7 @@ func CreateDirectorScrapeToken() (string, error) {
 		return "", err
 	}
 
-	key, err := config.GetOriginJWK()
+	key, err := config.GenerateIssuerJWKS()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to load the director's private JWK")
 	}

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -145,13 +145,14 @@ func CreateDirectorSDToken() (string, error) {
 	if directorURL == "" {
 		return "", errors.New("Director URL is not known; cannot create director service discovery token")
 	}
+	tokenExpireTime := param.Monitoring_TokenExpiresIn.GetDuration()
 
 	tok, err := jwt.NewBuilder().
 		Claim("scope", "pelican.directorSD").
 		Issuer(directorURL).
 		Audience([]string{directorURL}).
 		Subject("director").
-		Expiration(time.Now().Add(time.Hour)).
+		Expiration(time.Now().Add(tokenExpireTime)).
 		Build()
 	if err != nil {
 		return "", err
@@ -224,6 +225,7 @@ func CreateDirectorScrapeToken() (string, error) {
 	// We assume this function is only called on a director server,
 	// the external address of which should be the director's URL
 	directorURL := config.ComputeExternalAddress()
+	tokenExpireTime := param.Monitoring_TokenExpiresIn.GetDuration()
 
 	ads := ListServerAds([]ServerType{OriginType, CacheType})
 	aud := make([]string, 0)
@@ -239,7 +241,7 @@ func CreateDirectorScrapeToken() (string, error) {
 		// The audience of this token is all origins/caches that have WebURL set in their serverAds
 		Audience(aud).
 		Subject("director").
-		Expiration(time.Now().Add(time.Hour)).
+		Expiration(time.Now().Add(tokenExpireTime)).
 		Build()
 	if err != nil {
 		return "", err

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -722,6 +722,13 @@ type: duration
 default: 59m
 components: ["origin", "director", "nsregistry"]
 ---
+name: Monitoring.MetricAuthorization
+description: >-
+  If authorization (Bearer token) is required for accesing /metrics endpoint
+type: bool
+default: true
+components: ["origin", "director", "nsregistry"]
+---
 
 ############################
 #   Plugin-level configs   #

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -701,6 +701,27 @@ type: int
 default: 9999
 components: ["origin"]
 ---
+name: Monitoring.TokenExpiresIn
+description: >-
+  The duration of which the tokens for various Prometheus endpoints expire.
+
+  This includes tokens for director's Prometheus origin discovery endpoint, 
+  director's origin scraper, and server's self-scraper
+type: duration
+default: 1h
+components: ["origin", "director", "nsregistry"]
+---
+name: Monitoring.TokenRefreshInterval
+description: >-
+  The interval of which the token issuer for various Prometheus endpoints
+  refreshes the token for monitoring. 
+  
+  The tokens that are affected by this config are the same as the one in Monitoring.TokenExpiresIn.
+  This value must be less than Monitoring.TokenExpiresIn.
+type: duration
+default: 59m
+components: ["origin", "director", "nsregistry"]
+---
 
 ############################
 #   Plugin-level configs   #

--- a/origin_ui/origin.go
+++ b/origin_ui/origin.go
@@ -187,6 +187,8 @@ func setLoginCookie(ctx *gin.Context, user string) {
 	issuerURL.Host = ctx.Request.URL.Host
 	now := time.Now()
 	tok, err := jwt.NewBuilder().
+		// TODO: We might want to come up with some names broader than this for a
+		// generic token for Web APIs, like web_ui.access
 		Claim("scope", "prometheus.read").
 		Issuer(issuerURL.String()).
 		IssuedAt(now).

--- a/origin_ui/origin.go
+++ b/origin_ui/origin.go
@@ -184,7 +184,7 @@ func setLoginCookie(ctx *gin.Context, user string) {
 
 	issuerURL := url.URL{}
 	issuerURL.Scheme = "https"
-	issuerURL.Host = ctx.Request.URL.Host
+	issuerURL.Host = config.ComputeExternalAddress()
 	now := time.Now()
 	tok, err := jwt.NewBuilder().
 		// TODO: We might want to come up with some names broader than this for a
@@ -214,6 +214,9 @@ func setLoginCookie(ctx *gin.Context, user string) {
 	}
 
 	ctx.SetCookie("login", string(signed), 30*60, "/api/v1.0",
+		ctx.Request.URL.Host, true, true)
+	// Explicitly set Cookie for /metrics endpoint as they are in different paths
+	ctx.SetCookie("login", string(signed), 30*60, "/metrics",
 		ctx.Request.URL.Host, true, true)
 	ctx.SetSameSite(http.SameSiteStrictMode)
 }

--- a/web_ui/authorization.go
+++ b/web_ui/authorization.go
@@ -282,9 +282,11 @@ func checkAPIToken(ctx *gin.Context, anyScopes []string) bool {
 
 	strToken, err = ctx.Cookie("login")
 	if err == nil {
-		IssuerCheck(ctx, strToken, anyScopes)
+		if err = IssuerCheck(ctx, strToken, anyScopes); err != nil {
+			log.Info("Issuer check from cookie's token failed: ", err)
+		}
 	} else {
-		log.Info("Cookie token issuer check failed: ", err)
+		log.Info("Issuer check from cookie's token failed: ", err)
 	}
 
 	// It will only check if the token is valid and set this context key-pair.

--- a/web_ui/authorization.go
+++ b/web_ui/authorization.go
@@ -142,12 +142,14 @@ func OriginCheck(c *gin.Context, strToken string, expectedScope string) {
 func CreatePromMetricToken() (string, error) {
 	serverURL := config.ComputeExternalAddress()
 
+	tokenExpireTime := param.Monitoring_TokenExpiresIn.GetDuration()
+
 	tok, err := jwt.NewBuilder().
 		Claim("scope", "pelican.promMetric").
 		Issuer(serverURL).
 		Audience([]string{serverURL}).
 		Subject(serverURL).
-		Expiration(time.Now().Add(time.Hour)).
+		Expiration(time.Now().Add(tokenExpireTime)).
 		Build()
 	if err != nil {
 		return "", err

--- a/web_ui/authorization.go
+++ b/web_ui/authorization.go
@@ -315,16 +315,3 @@ func promMetricAuthHandler(ctx *gin.Context) {
 	// We don't care about other routes for this handler
 	ctx.Next()
 }
-
-// Handles generic authentication to the internal API endpoints as well as
-// Web APIs as a middleware that doesn't require any scope for the token
-func webAPIAuthHandler(ctx *gin.Context) {
-	// We don't check scopes for now for web APIs, which as of 11/2023 are only
-	// /api/v1.0/health and /api/v1.0/config
-	valid := checkAPIToken(ctx, []string{})
-	if !valid {
-		ctx.AbortWithStatusJSON(401, gin.H{"error": "Authentication required to access this endpoint."})
-	}
-	// Valid request, pass to the next handler
-	ctx.Next()
-}

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -175,7 +175,9 @@ func configDirectorPromScraper() (*config.ScrapeConfig, error) {
 	scrapeConfig.Scheme = "https"
 	scraperHttpClientConfig := common_config.HTTPClientConfig{
 		TLSConfig: common_config.TLSConfig{
-			InsecureSkipVerify: true,
+			// For the scraper to origins' metrics, we get TLSSkipVerify from config
+			// As this request is to external address
+			InsecureSkipVerify: param.TLSSkipVerify.GetBool(),
 		},
 		// We add token auth for scraping all origin/cache servers
 		Authorization: &common_config.Authorization{
@@ -187,6 +189,8 @@ func configDirectorPromScraper() (*config.ScrapeConfig, error) {
 	scrapeConfig.ServiceDiscoveryConfigs = make([]discovery.Config, 1)
 	sdHttpClientConfig := common_config.HTTPClientConfig{
 		TLSConfig: common_config.TLSConfig{
+			// Service discovery is internal only to the director, so there's
+			// no need to enforce TLS check
 			InsecureSkipVerify: true,
 		},
 		Authorization: &common_config.Authorization{
@@ -274,6 +278,7 @@ func ConfigureEmbeddedPrometheus(engine *gin.Engine, isDirector bool) error {
 	scrapeConfig.Scheme = "https"
 	scraperHttpClientConfig := common_config.HTTPClientConfig{
 		TLSConfig: common_config.TLSConfig{
+			// This is the self-scrape, so no need to enforce the TLS check
 			InsecureSkipVerify: true,
 		},
 		// We add token auth for scraping all origin/cache servers
@@ -592,6 +597,7 @@ func ConfigureEmbeddedPrometheus(engine *gin.Engine, isDirector bool) error {
 							newScrapeConfig.Scheme = oldScrapeCfg.Scheme
 							scraperHttpClientConfig := common_config.HTTPClientConfig{
 								TLSConfig: common_config.TLSConfig{
+									// This is the self-scrape, so no need to enforce TLS check
 									InsecureSkipVerify: true,
 								},
 								Authorization: &common_config.Authorization{

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -576,9 +576,8 @@ func ConfigureEmbeddedPrometheus(engine *gin.Engine, isDirector bool) error {
 		cancel := make(chan struct{})
 		g.Add(
 			func() error {
-				// Coordinate exact refresh time with the token life time at
-				// director/director_api.go CreateDirectorSDToken()
-				ticker := time.NewTicker(50 * time.Minute)
+				refreshInterval := param.Monitoring_TokenRefreshInterval.GetDuration()
+				ticker := time.NewTicker(refreshInterval)
 				for {
 					select {
 					case <-cancel:

--- a/web_ui/prometheus_test.go
+++ b/web_ui/prometheus_test.go
@@ -148,8 +148,8 @@ func TestPrometheusProtectionFederationURL(t *testing.T) {
 	viper.Set("Federation.NamespaceUrl", "https://test-namesapce")
 	viper.Set("Federation.JwkUrl", ts.URL)
 
-	// Set the request to run through the checkPromToken function
-	r.GET("/api/v1.0/prometheus/*any", checkPromToken(av1))
+	// Set the request to run through the promQueryEngineAuthHandler function
+	r.GET("/api/v1.0/prometheus/*any", promQueryEngineAuthHandler(av1))
 	c.Request, _ = http.NewRequest(http.MethodGet, "/api/v1.0/prometheus/test", bytes.NewBuffer([]byte(`{}`)))
 
 	// Puts the token within the URL
@@ -171,6 +171,8 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 	 */
 
 	viper.Reset()
+	viper.Set("Server.Hostname", "test-https")
+	viper.Set("Server.Port", "8444")
 
 	av1 := route.New().WithPrefix("/api/v1.0/prometheus")
 
@@ -203,8 +205,8 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 
 	// Create a token
 	issuerURL := url.URL{}
+	issuerURL.Host = config.ComputeExternalAddress()
 	issuerURL.Scheme = "https"
-	issuerURL.Host = "test-http"
 
 	jti_bytes := make([]byte, 16)
 	_, err = rand.Read(jti_bytes)
@@ -235,8 +237,8 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Set the request to go through the checkPromToken function
-	r.GET("/api/v1.0/prometheus/*any", checkPromToken(av1))
+	// Set the request to go through the promQueryEngineAuthHandler function
+	r.GET("/api/v1.0/prometheus/*any", promQueryEngineAuthHandler(av1))
 	c.Request, _ = http.NewRequest(http.MethodGet, "/api/v1.0/prometheus/test", bytes.NewBuffer([]byte(`{}`)))
 
 	// Put the signed token within the header
@@ -296,7 +298,7 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 	signed, err = jwt.Sign(tok, jwt.WithKey(jwa.ES256, pKey))
 	assert.NoError(t, err, "Error signing token")
 
-	r.GET("/api/v1.0/prometheus/*any", checkPromToken(av1))
+	r.GET("/api/v1.0/prometheus/*any", promQueryEngineAuthHandler(av1))
 	c.Request, _ = http.NewRequest(http.MethodGet, "/api/v1.0/prometheus/test", bytes.NewBuffer([]byte(`{}`)))
 
 	c.Request.Header.Set("Authorization", "Bearer "+string(signed))
@@ -336,8 +338,8 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Set the request to go through the checkPromToken function
-	r.GET("/api/v1.0/prometheus/*any", checkPromToken(av1))
+	// Set the request to go through the promQueryEngineAuthHandler function
+	r.GET("/api/v1.0/prometheus/*any", promQueryEngineAuthHandler(av1))
 	c.Request, _ = http.NewRequest(http.MethodGet, "/api/v1.0/prometheus/test", bytes.NewBuffer([]byte(`{}`)))
 
 	// Put the signed token within the header
@@ -380,8 +382,8 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Set the request to go through the checkPromToken function
-	r.GET("/api/v1.0/prometheus/*any", checkPromToken(av1))
+	// Set the request to go through the promQueryEngineAuthHandler function
+	r.GET("/api/v1.0/prometheus/*any", promQueryEngineAuthHandler(av1))
 
 	http.SetCookie(w, &http.Cookie{Name: "login", Value: string(signed)})
 	if err != nil {

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -31,6 +31,9 @@ import (
 )
 
 func ConfigureMetrics(engine *gin.Engine, isDirector bool) error {
+	// Add authorization to /metric endpoint
+	engine.Use(promMetricAuthHandler)
+
 	err := ConfigureEmbeddedPrometheus(engine, isDirector)
 	if err != nil {
 		return err


### PR DESCRIPTION
Closes #291 

* Added Bearer authorization to Prometheus `/metrics` endpoint and issue token for the scraper of both director and server itself, with periodic reloading.
* Refactored authorization logic in `web_ui` to make it more flexible, clear, and reusable.
* Changed LoadDirectorPublicKey to return key, not pointer to the key

## Testing Instructions
* Spin up `director` and you should expect `/metrics` requests are all successful, and their frequency should be around 15s.
* Change `Monitoring.TokenExpiresIn` and `Monitoring.TokenRefreshInterval` to smaller value to ensure token refreshment is successful
* Run `director`, `registry` and `origin`. At `origin` end, confirm that its `/metrics` requests are also all successful.
* Go to origin's web APIs and check auth works as expected. i.e. `/api/v1.0/prometheus` as well as `/metrics` (You should be able to see it through web only when you logged in)