### PR TITLE
Always generate a CA if no host certificate present

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,6 @@
 package config
 
 import (
-	"crypto/elliptic"
 	"crypto/tls"
 	"crypto/x509"
 	_ "embed"
@@ -481,10 +480,8 @@ func InitServer() error {
 	if err != nil {
 		return err
 	}
-	err = GeneratePrivateKey(param.Server_TLSKey.GetString(), elliptic.P256())
-	if err != nil {
-		return err
-	}
+
+	// Check if we have required files in place to set up TLS, or we will generate them
 	err = GenerateCert()
 	if err != nil {
 		return err

--- a/config/config_default.go
+++ b/config/config_default.go
@@ -29,9 +29,9 @@ import (
 
 func InitServerOSDefaults() error {
 	// Windows / Mac don't have a default set of CAs installed at
-	// a well-known location as is expected by XRootD.  Hook up a
-	// fake one instead.
-
+	// a well-known location as is expected by XRootD. We want to always generate our own CA
+	// if Server_TLSCertificate (host certificate) is not explicitly set so that
+	// we can sign our host cert by our CA instead of self-signing
 	tlscaFile := filepath.Join(viper.GetString("ConfigDir"), "certificates", "tlsca.pem")
 	viper.SetDefault("Server.TLSCACertificateFile", tlscaFile)
 

--- a/config/config_linux.go
+++ b/config/config_linux.go
@@ -21,49 +21,16 @@
 package config
 
 import (
-	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 )
 
-// Different distros have different default CACertificate locations. Instead of trying to figure out
-// the version of linux we use, check all the well-known places until we find one that exists.
-func findLinuxCACert() (string, error) {
-	// These values pulled from the same place x509 package looks:
-	// https://go.dev/src/crypto/x509/root_linux.go
-	certFileLocations := []string{
-		"/etc/ssl/certs/ca-certificates.crt",                // Debian/Ubuntu/Gentoo etc.
-		"/etc/pki/tls/cert.pem",                             // One RHEL-based possibility
-		"/etc/pki/tls/certs/ca-bundle.crt",                  // Another RHEL-based possibility
-		"/etc/ssl/ca-bundle.pem",                            // OpenSUSE
-		"/etc/pki/tls/cacert.pem",                           // OpenELEC
-		"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // Often the think previous RHEL options symlink to
-		"/etc/ssl/cert.pem",                                 // Alpine Linux
-	}
-
-	for _, certLoc := range certFileLocations {
-		if file, err := os.Open(certLoc); err == nil {
-			file.Close()
-			return certLoc, nil
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return "", err
-		}
-	}
-
-	// If we didn't find a cert in a well-known location, we'll wind up creating one later.
-	// In that case, we need to make sure it's someplace we have permission to write to, so we'll
-	// put it where we put other Pelican certs
-	configDir := viper.GetString("ConfigDir")
-	return filepath.Join(configDir, "certificates", "cert.pem"), nil
-}
-
 func InitServerOSDefaults() error {
-	if certLoc, err := findLinuxCACert(); err == nil {
-		viper.SetDefault("Server.TLSCACertificateFile", certLoc)
-		return nil
-	} else {
-		return err
-	}
+	// For Linux, even if we have well-known system CAs, we don't want to
+	// use them, because we want to always generate our own CA if Server_TLSCertificate (host certificate)
+	// is not explicitly set so that we can sign our host cert by our CA instead of self-signing
+	configDir := viper.GetString("ConfigDir")
+	viper.SetDefault("Server.TLSCACertificateFile", filepath.Join(configDir, "certificates", "tlsca.pem"))
+	return nil
 }

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -435,6 +435,9 @@ name: Server.TLSCertificate
 description: >-
   A filepath to a file containing an X.509 host certificate to use for TLS
   authentication when running server components of Pelican.
+
+  If you override this filepath, you need to provide the matched-pair private key
+  via Server.TLSKey and a Certificate Authority (CA) certificate via Server.TLSCACertificateFile
 type: filename
 root_default: /etc/pelican/certificates/tls.crt
 default: "$ConfigBase/certificates/tls.crt"
@@ -444,6 +447,8 @@ name: Server.TLSCACertificateFile
 description: >-
   A filepath to the TLS Certificate Authority (CA) certificate file, to be used by XRootD 
   and internal HTTP client requests.
+
+  Do not override this filepath unless you want to provide your TLS host certifacte
 type: filename
 root_default: /etc/pelican/certificates/tlsca.pem
 default: "$ConfigBase/certificates/tlsca.pem"

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -433,7 +433,7 @@ components: ["nsregistry"]
 ############################
 name: Server.TLSCertificate
 description: >-
-  The name of a file containing an X.509 host certificate to use for TLS
+  A filepath to a file containing an X.509 host certificate to use for TLS
   authentication when running server components of Pelican.
 type: filename
 root_default: /etc/pelican/certificates/tls.crt
@@ -442,17 +442,23 @@ components: ["origin", "nsregistry", "director"]
 ---
 name: Server.TLSCACertificateFile
 description: >-
-  A filepath for a TLS certificate to be used by XRootD.
-type: string
-default: /etc/pki/tls/cert.pem
-components: ["origin"]
+  A filepath to the TLS Certificate Authority (CA) certificate file, to be used by XRootD 
+  and internal HTTP client requests.
+type: filename
+root_default: /etc/pelican/certificates/tlsca.pem
+default: "$ConfigBase/certificates/tlsca.pem"
+components: ["origin", "nsregistry", "director"]
 ---
 name: Server.TLSCACertificateDirectory
 description: >-
-  A filepath to the directory used for storing TLS certificates
-type: filename
+  A filepath to the directory used for storing TLS Certificate Authority (CA) certificate 
+  to be used by XRootD only.
+
+  This is exclusive with Server.TLSCACertificateFile for XRootD and this value takes priority
+  over Server.TLSCACertificateFile
+type: string
 default: none
-components: ["origin"]
+components: ["origin", "nsregistry", "director"]
 ---
 name: Server.TLSCAKey
 description: >-


### PR DESCRIPTION
Closes #301 

Since `SciToken` doesn't like self-signed host certificate, we want to always generate our own CA at pelican config directory when there is no host certificate present, so that we can sign our generated host certificate by the certificate and private key of our generated CA.

This PR also introduced more robust checking of required files to set up TLS. It now checks that:
1. A valid TLS host certificate is present (via Server.TLSCertificate)
2. The private key of TLS cert if present (via Server.TLSKey)
3. A valid CA certificate is present (via Server.TLSCACertificateFile)

Or it will generate a new host certificate, and in this process, it will need a CA cert/private key to sign the host certificate (to avoid self-signed host cert). It will check if:

1. A valid TLS CA certificate is present (via Server.TLSCACertificateFile)
2. The private key of TLS CA cert is present (via Server.TLSCAKey) (This is very rare situation as no CA wants to provide its private key to anyone else, but we leave the option here to be flexible)

And if the check passes, it will grab the CA cert and private key as provided to proceed, or it will generate new CA cert and its private key instead.

## Testing Instructions

* Make sure you have patched your XRootD and Scitoken plugin following #167, with XRootD `version >= 5.6.3` and SciToken `version >= 1.1.0`
* In your `pelican.yaml` file, remove previously set `Server.TLSCACertificate` value
* Run `cd /etc/pelican/` and `rm -rf ./certificates` to remove already generated certificates
* Run `director` `registry` and `origin`
* Note that origin self-test works as expected, no 401 or 403 reported for any file trasnfers.

