### PR TITLE
Introduce enum for health status and component names for SetComponentHealthStatus

### DIFF
--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -45,11 +45,8 @@ var (
 func initCache() error {
 	err := config.InitServer()
 	cobra.CheckErr(err)
-	err = metrics.SetComponentHealthStatus("xrootd", "critical", "xrootd has not been started")
-	cobra.CheckErr(err)
-	err = metrics.SetComponentHealthStatus("cmsd", "critical", "cmsd has not been started")
-	cobra.CheckErr(err)
-
+	metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusCritical, "xrootd has not been started")
+	metrics.SetComponentHealthStatus(metrics.OriginCache_CMSD, metrics.StatusCritical, "cmsd has not been started")
 	return err
 }
 

--- a/cmd/cache_serve.go
+++ b/cmd/cache_serve.go
@@ -55,11 +55,9 @@ func periodicAdvertiseCache(prefix string, nsAds []director.NamespaceAd) error {
 		err := advertiseCache(prefix, nsAds)
 		if err != nil {
 			log.Warningln("Cache advertise failed:", err)
-			if err = metrics.SetComponentHealthStatus("federation", "critical", "Error advertising cache to federation"); err != nil {
-				log.Warningln("Failed to update internal component health status:", err)
-			}
-		} else if err = metrics.SetComponentHealthStatus("federation", "ok", ""); err != nil {
-			log.Warningln("Failed to update internal component health status:", err)
+			metrics.SetComponentHealthStatus(metrics.OriginCache_Federation, metrics.StatusCritical, "Error advertising cache to federation")
+		} else {
+			metrics.SetComponentHealthStatus(metrics.OriginCache_Federation, metrics.StatusOK, "")
 		}
 
 		for {
@@ -67,11 +65,9 @@ func periodicAdvertiseCache(prefix string, nsAds []director.NamespaceAd) error {
 			err := advertiseCache(prefix, nsAds)
 			if err != nil {
 				log.Warningln("Cache advertise failed:", err)
-				if err = metrics.SetComponentHealthStatus("federation", "critical", "Error advertising origin to federation"); err != nil {
-					log.Warningln("Failed to update internal component health status:", err)
-				}
-			} else if err = metrics.SetComponentHealthStatus("federation", "ok", ""); err != nil {
-				log.Warningln("Failed to update internal component health status:", err)
+				metrics.SetComponentHealthStatus(metrics.OriginCache_Federation, metrics.StatusCritical, "Error advertising origin to federation")
+			} else {
+				metrics.SetComponentHealthStatus(metrics.OriginCache_Federation, metrics.StatusOK, "")
 			}
 		}
 	}()

--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -101,11 +101,8 @@ func configOrigin( /*cmd*/ *cobra.Command /*args*/, []string) {
 func initOrigin() error {
 	err := config.InitServer()
 	cobra.CheckErr(err)
-	err = metrics.SetComponentHealthStatus("xrootd", "critical", "xrootd has not been started")
-	cobra.CheckErr(err)
-	err = metrics.SetComponentHealthStatus("cmsd", "critical", "cmsd has not been started")
-	cobra.CheckErr(err)
-
+	metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusCritical, "xrootd has not been started")
+	metrics.SetComponentHealthStatus(metrics.OriginCache_CMSD, metrics.StatusCritical, "cmsd has not been started")
 	return err
 }
 

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -101,10 +101,7 @@ func checkDefaults(origin bool, nsAds []director.NamespaceAd) error {
 }
 
 func webUiInitialize() {
-	if err := metrics.SetComponentHealthStatus("web-ui", "warning", "Authentication not initialized"); err != nil {
-		log.Errorln("Failed to set web UI's component health status:", err)
-		return
-	}
+	metrics.SetComponentHealthStatus(metrics.Server_WebUI, metrics.StatusWarning, "Authentication not initialized")
 
 	// Ensure we wait until the origin has been initialized
 	// before launching XRootD.
@@ -112,10 +109,7 @@ func webUiInitialize() {
 		log.Errorln("Failure when waiting for web UI to be initialized:", err)
 		return
 	}
-	if err := metrics.SetComponentHealthStatus("web-ui", "ok", ""); err != nil {
-		log.Errorln("Failed to set web UI's component health status:", err)
-		return
-	}
+	metrics.SetComponentHealthStatus(metrics.Server_WebUI, metrics.StatusOK, "")
 }
 
 func serveOrigin( /*cmd*/ *cobra.Command /*args*/, []string) error {

--- a/metrics/health.go
+++ b/metrics/health.go
@@ -57,6 +57,8 @@ const (
 	StatusUnknown // Do not abuse this enum. Use others when possible
 )
 
+const statusIndexErrorMessage = "Error: status string index out of range"
+
 // Naming convention for components:
 //
 //	ServiceName1Name2_ComponentName
@@ -86,8 +88,16 @@ var (
 	}, []string{"component"})
 )
 
+// Unfortunately we don't have a better way to ensure the enum constants always have
+// matched string representation, so we will return "Error: status string index out of range"
+// as an indicator
 func (status HealthStatusEnum) String() string {
-	return [...]string{"critical", "warning", "ok"}[status-1]
+	strings := [...]string{"critical", "warning", "ok", "unknown"}
+
+	if int(status) < 1 || int(status) > len(strings) {
+		return statusIndexErrorMessage
+	}
+	return strings[status-1]
 }
 
 func (component HealthStatusComponent) String() string {

--- a/metrics/health.go
+++ b/metrics/health.go
@@ -19,7 +19,6 @@
 package metrics
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -28,6 +27,7 @@ import (
 )
 
 type (
+	// This is for API response so we want to display string representation of status
 	ComponentStatus struct {
 		Status     string `json:"status"`
 		Message    string `json:"message,omitempty"`
@@ -35,7 +35,7 @@ type (
 	}
 
 	componentStatusInternal struct {
-		Status     int
+		Status     HealthStatusEnum
 		Message    string
 		LastUpdate time.Time
 	}
@@ -44,6 +44,32 @@ type (
 		OverallStatus   string                     `json:"status"`
 		ComponentStatus map[string]ComponentStatus `json:"components"`
 	}
+
+	HealthStatusEnum int
+
+	HealthStatusComponent string
+)
+
+const (
+	StatusCritical HealthStatusEnum = iota + 1
+	StatusWarning
+	StatusOK
+	StatusUnknown // Do not abuse this enum. Use others when possible
+)
+
+// Naming convention for components:
+//
+//	ServiceName1Name2_ComponentName
+//
+// i.e. For ""OriginCache_XRootD", it means this component is available at both
+// Origin and Cache. Please come up with the largest possible scope of the component
+const (
+	OriginCache_XRootD     HealthStatusComponent = "xrootd"
+	OriginCache_CMSD       HealthStatusComponent = "cmsd"
+	OriginCache_Federation HealthStatusComponent = "federation" // Advertise to the director
+	// TODO: WebUI health status is only set at origin_serve for now. We will soon
+	// move this logic to all server web-ui in issue #308
+	Server_WebUI HealthStatusComponent = "web-ui"
 )
 
 var (
@@ -60,56 +86,38 @@ var (
 	}, []string{"component"})
 )
 
-func statusToInt(status string) (int, error) {
-	switch status {
-	case "ok":
-		return 3, nil
-	case "warning":
-		return 2, nil
-	case "critical":
-		return 1, nil
-	}
-	return 0, fmt.Errorf("Unknown component status: %v", status)
+func (status HealthStatusEnum) String() string {
+	return [...]string{"critical", "warning", "ok"}[status-1]
 }
 
-func intToStatus(statusInt int) string {
-	switch statusInt {
-	case 3:
-		return "ok"
-	case 2:
-		return "warning"
-	case 1:
-		return "critical"
-	}
-	return "unknown"
+func (component HealthStatusComponent) String() string {
+	return string(component)
 }
 
-func SetComponentHealthStatus(name, state, msg string) error {
-	statusInt, err := statusToInt(state)
-	if err != nil {
-		return err
-	}
+// Add/update the component health status. If you have a new component to record,
+// please go to metrics/health and register your component as a new constant of
+// type HealthStatusComponent. Also note that StatusUnknown is mostly for internal
+// use only, please try to avoid setting this as your component status
+func SetComponentHealthStatus(name HealthStatusComponent, state HealthStatusEnum, msg string) {
 	now := time.Now()
-	healthStatus.Store(name, componentStatusInternal{statusInt, msg, now})
+	healthStatus.Store(name.String(), componentStatusInternal{state, msg, now})
 
 	PelicanHealthStatus.With(
-		prometheus.Labels{"component": name}).
-		Set(float64(statusInt))
+		prometheus.Labels{"component": name.String()}).
+		Set(float64(state))
 
-	PelicanHealthLastUpdate.With(prometheus.Labels{"component": name}).
+	PelicanHealthLastUpdate.With(prometheus.Labels{"component": name.String()}).
 		SetToCurrentTime()
-
-	return nil
 }
 
-func DeleteComponentHealthStatus(name string) {
-	healthStatus.Delete(name)
+func DeleteComponentHealthStatus(name HealthStatusComponent) {
+	healthStatus.Delete(name.String())
 }
 
 func GetHealthStatus() HealthStatus {
 	status := HealthStatus{}
-	status.OverallStatus = "unknown"
-	overallStatus := 4
+	status.OverallStatus = StatusUnknown.String()
+	overallStatus := StatusUnknown
 	healthStatus.Range(func(component, compstat any) bool {
 		componentStatus, ok := compstat.(componentStatusInternal)
 		if !ok {
@@ -123,7 +131,7 @@ func GetHealthStatus() HealthStatus {
 			status.ComponentStatus = make(map[string]ComponentStatus)
 		}
 		status.ComponentStatus[componentString] = ComponentStatus{
-			intToStatus(componentStatus.Status),
+			componentStatus.Status.String(),
 			componentStatus.Message,
 			componentStatus.LastUpdate.Unix(),
 		}
@@ -132,6 +140,6 @@ func GetHealthStatus() HealthStatus {
 		}
 		return true
 	})
-	status.OverallStatus = intToStatus(overallStatus)
+	status.OverallStatus = overallStatus.String()
 	return status
 }

--- a/metrics/health_test.go
+++ b/metrics/health_test.go
@@ -1,0 +1,20 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthStatusString(t *testing.T) {
+	expectedStrings := [...]string{"critical", "warning", "ok", "unknown"}
+
+	t.Run("health-status-string-handles-out-of-range-index", func(t *testing.T) {
+		invalidIndex := len(expectedStrings) + 1
+		for idx := range expectedStrings {
+			assert.Equal(t, expectedStrings[idx], HealthStatusEnum(idx+1).String())
+		}
+		require.Equal(t, statusIndexErrorMessage, HealthStatusEnum(invalidIndex).String())
+	})
+}

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -46,11 +46,9 @@ func PeriodicAdvertiseOrigin() error {
 		err := AdvertiseOrigin()
 		if err != nil {
 			log.Warningln("Origin advertise failed:", err)
-			if err = metrics.SetComponentHealthStatus("federation", "critical", "Error advertising origin to federation"); err != nil {
-				log.Warningln("Failed to update internal component health status:", err)
-			}
-		} else if err = metrics.SetComponentHealthStatus("federation", "ok", ""); err != nil {
-			log.Warningln("Failed to update internal component health status:", err)
+			metrics.SetComponentHealthStatus(metrics.OriginCache_Federation, metrics.StatusCritical, "Error advertising origin to federation")
+		} else {
+			metrics.SetComponentHealthStatus(metrics.OriginCache_Federation, metrics.StatusOK, "")
 		}
 
 		for {
@@ -58,11 +56,9 @@ func PeriodicAdvertiseOrigin() error {
 			err := AdvertiseOrigin()
 			if err != nil {
 				log.Warningln("Origin advertise failed:", err)
-				if err = metrics.SetComponentHealthStatus("federation", "critical", "Error advertising origin to federation"); err != nil {
-					log.Warningln("Failed to update internal component health status:", err)
-				}
-			} else if err = metrics.SetComponentHealthStatus("federation", "ok", ""); err != nil {
-				log.Warningln("Failed to update internal component health status:", err)
+				metrics.SetComponentHealthStatus(metrics.OriginCache_Federation, metrics.StatusCritical, "Error advertising origin to federation")
+			} else {
+				metrics.SetComponentHealthStatus(metrics.OriginCache_Federation, metrics.StatusOK, "")
 			}
 		}
 	}()

--- a/origin_ui/register_origin.go
+++ b/origin_ui/register_origin.go
@@ -170,9 +170,7 @@ func registerNamespaceImpl(key jwk.Key, prefix string, registrationEndpointURL s
 }
 
 func RegisterNamespaceWithRetry() error {
-	if err := metrics.SetComponentHealthStatus("federation", "critical", "Origin not registered with federation"); err != nil {
-		return err
-	}
+	metrics.SetComponentHealthStatus(metrics.OriginCache_Federation, metrics.StatusCritical, "Origin not registered with federation")
 
 	key, prefix, url, isRegistered, err := registerNamespacePrep()
 	if err != nil {

--- a/origin_ui/self_monitor.go
+++ b/origin_ui/self_monitor.go
@@ -231,18 +231,14 @@ func PeriodicSelfTest() {
 		url, err := UploadTestfile()
 		if err != nil {
 			log.Warningln("Self-test monitoring cycle failed during test upload:", err)
-			if err := metrics.SetComponentHealthStatus("xrootd", "critical", "Self-test monitoring cycle failed during test upload: "+err.Error()); err != nil {
-				log.Errorln("Failed to update internal component health status:", err)
-			}
+			metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusCritical, "Self-test monitoring cycle failed during test upload: "+err.Error())
 			continue
 		}
 
 		downloadFailed := false
 		if err = DownloadTestfile(url); err != nil {
 			log.Warningln("Self-test monitoring cycle failed during test download:", err)
-			if err := metrics.SetComponentHealthStatus("xrootd", "critical", "Self-test monitoring cycle failed during test download: "+err.Error()); err != nil {
-				log.Errorln("Failed to update internal component health status:", err)
-			}
+			metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusCritical, "Self-test monitoring cycle failed during test download: "+err.Error())
 			downloadFailed = true
 			// Note we don't `continue` here; we want to attempt to delete the file!
 		}
@@ -253,17 +249,12 @@ func PeriodicSelfTest() {
 				continue
 			}
 			log.Warningln("Self-test monitoring cycle failed during test deletion:", err)
-			if err := metrics.SetComponentHealthStatus("xrootd", "critical", "Self-test monitoring cycle failed during test deletion: "+err.Error()); err != nil {
-				log.Errorln("Failed to update internal component health status:", err)
-			}
+			metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusCritical, "Self-test monitoring cycle failed during test deletion: "+err.Error())
 			continue
 		}
 
 		// All is good - note it in the health status!
 		log.Debugln("Self-test monitoring cycle succeeded at", time.Now().Format(time.UnixDate))
-		if err := metrics.SetComponentHealthStatus("xrootd", "ok", "Self-test monitoring cycle succeeded at "+time.Now().Format(time.RFC3339)); err != nil {
-			log.Errorln("Failed to update internal component health status:", err)
-		}
-
+		metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusOK, "Self-test monitoring cycle succeeded at "+time.Now().Format(time.RFC3339))
 	}
 }


### PR DESCRIPTION
Closes #351 

We want to be more robust in setting component health status. This PR introduces enum for both the health status and the component name to record. Related code are updated to adhere to this new convention.

I manually tested that `SetComponentHealthStatus` work without causing errors at `origin` side where the web ui dashboard can correctly display health status of all existing components, and when there's an error from a component, the health status updates as expected.

For reviewer, I recommend spinning up your `origin` and go to `/view` and check that all status on top right side is expected. You can then turn off your `director` and wait for the next origin advertisement to fail to see if that's correctly displayed.