### PR TITLE
Always unmarshall config when /config API is called

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -482,8 +482,8 @@ func InitServer() error {
 	}
 
 	// Unmarshal Viper config into a Go struct
-	err = param.UnmarshalConfig()
-	if err != nil {
+	unmarshalledConfig, err := param.UnmarshalConfig()
+	if err != nil || unmarshalledConfig == nil {
 		return err
 	}
 
@@ -620,8 +620,8 @@ func InitClient() error {
 	setupTransport()
 
 	// Unmarshal Viper config into a Go struct
-	err = param.UnmarshalConfig()
-	if err != nil {
+	unmarshalledConfig, err := param.UnmarshalConfig()
+	if err != nil || unmarshalledConfig == nil {
 		return err
 	}
 

--- a/param/param.go
+++ b/param/param.go
@@ -2,6 +2,7 @@ package param
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/spf13/viper"
 )
@@ -10,21 +11,26 @@ import (
 
 var (
 	viperConfig *config
+	configMutex sync.RWMutex
 )
 
-// Unmarshal Viper config into a struct viperConfig
-func UnmarshalConfig() error {
+// Unmarshal Viper config into a struct viperConfig and returns it
+func UnmarshalConfig() (*config, error) {
+	configMutex.Lock()
+	defer configMutex.Unlock()
 	viperConfig = new(config)
 	err := viper.Unmarshal(viperConfig)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return viperConfig, nil
 }
 
 // Return the unmarshaled viper config struct as a pointer
 func GetUnmarshaledConfig() (*config, error) {
+	configMutex.RLock()
+	defer configMutex.RUnlock()
 	if viperConfig == nil {
 		return nil, errors.New("Config hasn't been unmarshaled yet.")
 	}


### PR DESCRIPTION
Fixes #389 

## Testing Instructions
Run `director` `registry` and `origin`, and go to origin's ui `https://localhost:8444/view/config/index.html`
Check that under Origin subheader, the value of `NamespacePrefix` is set to whatever prefix you gave to your origin and registered at registry, say `/origin1`, because this value is being set after `InitServer()` was called.