### PR TITLE
Fix small bugs in DiscoverFederation()

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -178,7 +178,10 @@ func DiscoverFederation() error {
 	}
 
 	discoveryUrl, _ := url.Parse(federationUrl.String())
-	discoveryUrl.Path = path.Join(".well-known/pelican-configuration", federationUrl.Path)
+	discoveryUrl.Path, err = url.JoinPath(federationUrl.Path, ".well-known/pelican-configuration")
+	if err != nil {
+		return errors.Wrap(err, "Unable to parse federation url because of invalid path")
+	}
 
 	httpClient := http.Client{
 		Transport: GetTransport(),


### PR DESCRIPTION
Previously, running pelican with `-f foo.com/a/path` would result in DiscoverFederation() trying to get metadata from `foo.com/.well-known/pelican-configuration/a/path` instead of the correct `foo.com/a/path/.well-known/pelican-configuration`. This fixes that.

It also uses the `url.JoinPath()` method for parsing URL paths instead of `path.Join()`. We never really do much with Windows, but if we did, that would prevent federation discovery from working, because it would try to use \ as a path separator in a URL. Whoops.

Closes issue #399 