### PR TITLE
Add swagger spec and include auth APIs and common APIs

### DIFF
--- a/swagger/pelican-swagger.yaml
+++ b/swagger/pelican-swagger.yaml
@@ -1,0 +1,282 @@
+swagger: '2.0'
+info:
+  title: Pelican Server APIs
+  description: "[Pelican](https://pelicanplatform.org/) provides an open-source software platform for federating 
+      dataset repositories together and delivering the objects to computing capacity such as the [OSPool](https://osg-htc.org/services/open_science_pool.html)
+
+
+      This is the API documentation for various APIs in Pelican servers (director, registry, origin, etc) 
+      to communicate with each other and in-between users accessing the servers. 
+      
+
+      For how to set up Pelican servers, please refer to the documentation at [docs.pelicanplatform.org](https://docs.pelicanplatform.org/)"
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0
+  contact:
+    name: API Support via Pelican GitHub Issue
+    url: https://github.com/PelicanPlatform/pelican/issues
+  version: '1.0'
+basePath: /api/v1.0/
+consumes:
+  - application/json
+produces:
+  - application/json
+schemes:
+  - https
+securityDefinitions:
+  # This is a hacky way to specify Bearer token auth here because it's not actually an "apikey"
+  Bearer:
+    type: apiKey
+    name: Authorization
+    in: header
+    description: >-
+      Enter the JWT with the `Bearer` prefix, e.g. "Bearer abcde12345".
+definitions:
+  HealthStatus:
+    type: object
+    description: The health status of a server component
+    properties: 
+      status:
+        type: string
+        description: The status of the component, can be one of "unknown", "warning", "ok", and "critical"
+        example: warning
+      message:
+        type: string
+        description: Optional message to describe the status
+        example: ""
+      last_update:
+        type: integer
+        description: Int64 unix time of the last status update
+        example: 1700594867
+    readOnly: true
+  ErrorModel:
+    type: object
+    description: The error reponse of a request
+    properties: 
+      error:
+        type: string
+        description: The detail error message
+        example: Authentication required to perform this operation
+  SuccessModel:
+    type: object
+    description: The successful reponse of a request
+    properties: 
+      msg:
+        type: string
+        description: The detail success message
+        example: Success
+tags:
+  - name: origin
+    description: APIs for the origin server
+  - name: common
+    description: Common APIs for all servers
+paths:
+  /heath:
+    get:
+      tags:
+        - common
+      summary: Returns the health status of server components
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                description: The overall health status of the server
+              components:
+                type: object
+                description: The health status of each server components
+                properties: 
+                  cmsd:
+                    $ref: '#/definitions/HealthStatus'
+                  federation:
+                    $ref: '#/definitions/HealthStatus'
+                  web-ui:
+                    $ref: '#/definitions/HealthStatus'
+                  xrootd:
+                    $ref: '#/definitions/HealthStatus'
+  /config:
+    get:
+      tags:
+        - common    
+      summary: Return the configuration values of the server
+      produces:
+      - application/json
+      security:
+        - Bearer: []
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: object
+            description: The JSON object output from viper with all config values in the current server
+        '401':
+          description: Unauthorized
+  # To be changed to /auth/login when #398 is merged
+  /origin_ui/login:
+    post:
+      tags:
+        - origin    
+      summary: Login with username and password to Pelican web UI
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+        - in: body
+          name: userCredential
+          description: The username and password to authenticate
+          schema:
+            type: object
+            required:
+              - user
+              - password
+            properties: 
+              user:
+                type: string
+              password:
+                type: string
+      responses:
+        '200':
+          description: Login succeed
+          schema:
+            type: object
+            $ref: "#/definitions/SuccessModel"          
+        '400':
+          description: Invalid request, when username or password is missing
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModel"          
+        '401':
+          description: Login failed, when username or password doesn't match the record
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModel"
+  /origin_ui/initLogin:
+    post:
+      tags:
+        - origin        
+      summary: Login with one-time activation code to initialize web UI
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+        - in: body
+          name: activationCode
+          description: The 6-digit code used to initialize web UI
+          schema:
+            type: object
+            required:
+              - code
+            properties: 
+              code:
+                type: string
+                example: "123456"
+      responses:
+        '200':
+          description: Login succeed
+          schema:
+            type: object
+            $ref: "#/definitions/SuccessModel"          
+        '400':
+          description: Invalid request, when authentication is already initialized, 
+            code-based login is not available, or login code is not provided
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModel"          
+        '401':
+          description: Login failed, when code is not valid
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModel"
+  /origin_ui/resetLogin:
+    post:
+      tags:
+        - origin        
+      summary: Reset the password for the user
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      security:
+        - Bearer: []
+      parameters:
+        - in: body
+          name: newPassword
+          description: The new password to reset to
+          schema:
+            type: object
+            required:
+              - password
+            properties: 
+              password:
+                type: string
+                description: The new password to reset to
+                example: ""
+      responses:
+        '200':
+          description: Reset succeed
+          schema:
+            type: object
+            $ref: "#/definitions/SuccessModel"          
+        '400':
+          description: Invalid request request, when password is missing
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModel"          
+        '500':
+          description: Server-side error, when failed to write the new password to auth file
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModel"            
+        '403':
+          description: Unauthorized request, when user is not logged in
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModel"
+  /origin_ui/whoami:
+    get:
+      tags:
+        - origin    
+      summary: Return the authentication status of the web ui
+      produces:
+      - application/json
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: object
+            description: The authentication status and username, if any. "user" field is omitted
+              when "authenticated" is false
+            properties: 
+              authenticated:
+                type: boolean
+                example: true
+              user:
+                type: string
+                example: "admin"
+  /origin_ui/loginInitialized:
+    get:
+      tags:
+        - origin    
+      summary: Return the status of web UI initialization
+      description: The initialization depends on if the user has used the one-time activation
+        code to set up the password for the admin user
+      produces:
+      - application/json
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: object
+            description: The initialization status
+            properties: 
+              initialized:
+                type: boolean
+                example: true


### PR DESCRIPTION
Closes #352 

This is a hand-coded Swagger specification of APIs in Pelican servers. For now, I included APIs for authentication and common APIs (/config, /health, etc.)

As a next step, we might want to programmatically generate this spec using annotations on handler functions, and there's existing Go package to handle spec generation for us: [swaggo/swag](https://github.com/swaggo/swag)

If you are using VSCode as your IDE, you can render the Swagger UI from this `.yaml` file by installing the [OpenAPI (Swagger) Editor](https://marketplace.visualstudio.com/items?itemName=42Crunch.vscode-openapi)