### PR TITLE
Adjusted advertiseOSDF namespaceAd generation

### DIFF
--- a/director/advertise_test.go
+++ b/director/advertise_test.go
@@ -181,7 +181,7 @@ func TestAdvertiseOSDF(t *testing.T) {
 	nsAd, oAds, cAds = GetAdsForPath("/p2")
 	assert.Equal(t, "/p2", nsAd.Path)
 	assert.Equal(t, []string{"/p2/open"}, nsAd.RestrictedPath)
-	assert.Equal(t, "https://origin3-auth-endpoint.com", oAds[0].AuthURL.String())
+	assert.Contains(t, []string{"https://origin3-auth-endpoint.com", "https://origin4-auth-endpoint.com"}, oAds[0].AuthURL.String())
 	assert.Equal(t, "http://cache-endpoint.com", cAds[0].URL.String())
 	assert.Equal(t, true, nsAd.RequireToken)
 

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -35,14 +35,15 @@ import (
 
 type (
 	NamespaceAd struct {
-		RequireToken  bool         `json:"requireToken"`
-		Path          string       `json:"path"`
-		Issuer        url.URL      `json:"url"`
-		MaxScopeDepth uint         `json:"maxScopeDepth"`
-		Strategy      StrategyType `json:"strategy"`
-		BasePath      string       `json:"basePath"`
-		VaultServer   string       `json:"vaultServer"`
-		DirlistHost   string       `json:"dirlisthost"`
+		RequireToken   bool         `json:"requireToken"`
+		Path           string       `json:"path"`
+		Issuer         url.URL      `json:"url"`
+		MaxScopeDepth  uint         `json:"maxScopeDepth"`
+		Strategy       StrategyType `json:"strategy"`
+		BasePath       string       `json:"basePath"`
+		VaultServer    string       `json:"vaultServer"`
+		DirlistHost    string       `json:"dirlisthost"`
+		RestrictedPath []string     `json:"restrictedPath"`
 	}
 
 	ServerAd struct {


### PR DESCRIPTION
    -- Now uses basepaths and issuers if a token is required

Also, in the advertise_test unit testing code, I switched the `actual` vs `expected` values since they were reversed and it was annoying me.