### PR TITLE
Ensure TTL caches evict expired item

### DIFF
--- a/cmd/cache_serve.go
+++ b/cmd/cache_serve.go
@@ -149,8 +149,11 @@ func serveCache( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 
-	defer config.CleanupTempResources()
-	defer shutdownCancel()
+	defer func() {
+		shutdownCancel()
+		wg.Wait()
+		config.CleanupTempResources()
+	}()
 
 	err := config.DiscoverFederation()
 	if err != nil {

--- a/cmd/cache_serve.go
+++ b/cmd/cache_serve.go
@@ -146,9 +146,13 @@ func advertiseCache(prefix string, nsAds []director.NamespaceAd) error {
 }
 
 func serveCache( /*cmd*/ *cobra.Command /*args*/, []string) error {
+	// Use this context for any goroutines that needs to react to server shutdown
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	// Use this wait group to ensure the goroutines can finish before the server exits/shutdown
 	var wg sync.WaitGroup
 
+	// This anonymous function ensures we cancel any context and wait for those goroutines to
+	// finish their cleanup work before the server exits
 	defer func() {
 		shutdownCancel()
 		wg.Wait()

--- a/cmd/director_serve.go
+++ b/cmd/director_serve.go
@@ -72,10 +72,6 @@ func serveDirector( /*cmd*/ *cobra.Command /*args*/, []string) error {
 		return err
 	}
 
-	// Configure Cache eviction policies. In the future, this function can also be
-	// promoted to run the actual eviction logic (cache.start())
-	director.ConfigCacheEviction()
-
 	// Configure the shortcut middleware to either redirect to a cache
 	// or to an origin
 	defaultResponse := param.Director_DefaultResponse.GetString()

--- a/cmd/director_serve.go
+++ b/cmd/director_serve.go
@@ -35,9 +35,13 @@ import (
 )
 
 func serveDirector( /*cmd*/ *cobra.Command /*args*/, []string) error {
+	// Use this context for any goroutines that needs to react to server shutdown
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	// Use this wait group to ensure the goroutines can finish before the server exits/shutdown
 	var wg sync.WaitGroup
 
+	// This anonymous function ensures we cancel any context and wait for those goroutines to
+	// finish their cleanup work before the server exits
 	defer func() {
 		shutdownCancel()
 		wg.Wait()

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -105,8 +105,11 @@ func serveOrigin( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 
-	defer config.CleanupTempResources()
-	defer shutdownCancel()
+	defer func() {
+		shutdownCancel()
+		wg.Wait()
+		config.CleanupTempResources()
+	}()
 
 	wg.Add(1)
 	err := xrootd.SetUpMonitoring(shutdownCtx, &wg)

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -102,9 +102,13 @@ func checkDefaults(origin bool, nsAds []director.NamespaceAd) error {
 }
 
 func serveOrigin( /*cmd*/ *cobra.Command /*args*/, []string) error {
+	// Use this context for any goroutines that needs to react to server shutdown
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	// Use this wait group to ensure the goroutines can finish before the server exits/shutdown
 	var wg sync.WaitGroup
 
+	// This anonymous function ensures we cancel any context and wait for those goroutines to
+	// finish their cleanup work before the server exits
 	defer func() {
 		shutdownCancel()
 		wg.Wait()

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -19,7 +19,6 @@
 package director
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -195,16 +194,4 @@ func GetAdsForPath(reqPath string) (originNamespace NamespaceAd, originAds []Ser
 		originNamespace = *best
 	}
 	return
-}
-
-func ConfigCacheEviction() {
-	serverAds.OnEviction(func(ctx context.Context, er ttlcache.EvictionReason, i *ttlcache.Item[ServerAd, []NamespaceAd]) {
-		if cancelFunc, exists := healthTestCancelFuncs[i.Key()]; exists {
-			// Call the cancel function for the evicted originAd to end its health test
-			cancelFunc()
-
-			// Remove the cancel function from the map as it's no longer needed
-			delete(healthTestCancelFuncs, i.Key())
-		}
-	})
 }

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -254,7 +254,10 @@ func TestServerAdsCacheEviction(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(1)
 		ConfigTTLCache(shutdownCtx, &wg)
-		defer shutdownCancel()
+		defer func() {
+			shutdownCancel()
+			wg.Wait()
+		}()
 
 		deletedChan := make(chan int)
 		cancelChan := make(chan int)

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -212,7 +212,16 @@ func TestConfigCacheEviction(t *testing.T) {
 		serverAds.DeleteAll()
 		// Clear the map for the new test
 		healthTestCancelFuncs = make(map[ServerAd]context.CancelFunc)
-		ConfigCacheEviction()
+
+		// Start cache eviction
+		shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+		var wg sync.WaitGroup
+		wg.Add(1)
+		ConfigTTLCache(shutdownCtx, &wg)
+		defer func() {
+			shutdownCancel()
+			wg.Wait()
+		}()
 
 		serverAds.Set(mockPelicanOriginServerAd, []NamespaceAd{mockNamespaceAd}, ttlcache.DefaultTTL)
 		ctx, cancelFunc := context.WithDeadline(context.Background(), time.Now().Add(time.Second*5))

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -21,6 +21,7 @@ package director
 import (
 	"context"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -241,5 +242,54 @@ func TestConfigCacheEviction(t *testing.T) {
 			require.False(t, true)
 		}
 		assert.True(t, healthTestCancelFuncs[mockPelicanOriginServerAd] == nil, "Evicted origin didn't clear cancelFunc in the map")
+	})
+}
+
+func TestServerAdsCacheEviction(t *testing.T) {
+	mockServerAd := ServerAd{Name: "foo", Type: OriginType, URL: url.URL{}}
+
+	t.Run("evict-after-expire-time", func(t *testing.T) {
+		// Start cache eviction
+		shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+		var wg sync.WaitGroup
+		wg.Add(1)
+		ConfigTTLCache(shutdownCtx, &wg)
+		defer shutdownCancel()
+
+		deletedChan := make(chan int)
+		cancelChan := make(chan int)
+
+		go func() {
+			serverAdMutex.Lock()
+			defer serverAdMutex.Unlock()
+			serverAds.DeleteAll()
+
+			serverAds.Set(mockServerAd, []NamespaceAd{}, time.Second*2)
+			require.True(t, serverAds.Has(mockServerAd), "Failed to register server Ad")
+		}()
+
+		// Keep checking if the cache item is present until absent or cancelled
+		go func() {
+			for {
+				select {
+				case <-cancelChan:
+					return
+				default:
+					if !serverAds.Has(mockServerAd) {
+						deletedChan <- 1
+						return
+					}
+				}
+			}
+		}()
+
+		// Wait for 3s to check if the expired cache item is evicted
+		select {
+		case <-deletedChan:
+			require.True(t, true)
+		case <-time.After(3 * time.Second):
+			cancelChan <- 1
+			require.False(t, true, "Cache didn't evict expired item")
+		}
 	})
 }

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -262,10 +262,10 @@ func CreateDirectorScrapeToken() (string, error) {
 	return string(signed), nil
 }
 
-// Configure serverAds cache to enable cache eviction and other additional logic
+// Configure TTL caches to enable cache eviction and other additional cache events handling logic
 //
-// TODO: Depending on which PR gets merged first, we want to merge ConfigCacheEviction from
-// #305 with this
+// The `ctx` is the context for listening to server shutdown event in order to cleanup internal cache eviction
+// goroutine and `wg` is the wait group to notify when the clean up goroutine finishes
 func ConfigTTLCache(ctx context.Context, wg *sync.WaitGroup) {
 	// Start automatic expired item deletion
 	go serverAds.Start()

--- a/director/origin_api_test.go
+++ b/director/origin_api_test.go
@@ -171,7 +171,12 @@ func TestNamespaceKeysCacheEviction(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(1)
 		ConfigTTLCache(shutdownCtx, &wg)
-		defer shutdownCancel()
+
+		defer func() {
+			shutdownCancel()
+			wg.Wait()
+		}()
+
 		mockNamespaceKey := "foo"
 		mockCtx := context.Background()
 		mockAr := jwk.NewCache(mockCtx)

--- a/director/origin_api_test.go
+++ b/director/origin_api_test.go
@@ -1,8 +1,10 @@
 package director
 
 import (
+	"context"
 	"crypto/elliptic"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,6 +15,7 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVerifyAdvertiseToken(t *testing.T) {
@@ -159,4 +162,54 @@ func TestGetRegistryIssuerURL(t *testing.T) {
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "test-path/api/v1.0/registry/test-prefix/.well-known/issuer.jwks", url)
 
+}
+
+func TestNamespaceKeysCacheEviction(t *testing.T) {
+	t.Run("evict-after-expire-time", func(t *testing.T) {
+		// Start cache eviction
+		shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+		var wg sync.WaitGroup
+		wg.Add(1)
+		ConfigTTLCache(shutdownCtx, &wg)
+		defer shutdownCancel()
+		mockNamespaceKey := "foo"
+		mockCtx := context.Background()
+		mockAr := jwk.NewCache(mockCtx)
+
+		deletedChan := make(chan int)
+		cancelChan := make(chan int)
+
+		go func() {
+			namespaceKeysMutex.Lock()
+			defer namespaceKeysMutex.Unlock()
+			namespaceKeys.DeleteAll()
+
+			namespaceKeys.Set(mockNamespaceKey, mockAr, time.Second*2)
+			require.True(t, namespaceKeys.Has(mockNamespaceKey), "Failed to register namespace key")
+		}()
+
+		// Keep checking if the cache item is absent or cancelled
+		go func() {
+			for {
+				select {
+				case <-cancelChan:
+					return
+				default:
+					if !namespaceKeys.Has(mockNamespaceKey) {
+						deletedChan <- 1
+						return
+					}
+				}
+			}
+		}()
+
+		// Wait for 3s to check if the expired cache item is evicted
+		select {
+		case <-deletedChan:
+			require.True(t, true)
+		case <-time.After(3 * time.Second):
+			cancelChan <- 1
+			require.False(t, true, "Cache didn't evict expired item")
+		}
+	})
 }

--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -239,6 +239,10 @@ var (
 	monitorPaths []PathList
 )
 
+// Set up listening and parsing xrootd monitoring UDP packets into prometheus
+//
+// The `ctx` is the context for listening to server shutdown event in order to cleanup internal cache eviction
+// goroutine and `wg` is the wait group to notify when the clean up goroutine finishes
 func ConfigureMonitoring(ctx context.Context, wg *sync.WaitGroup) (int, error) {
 	monitorPaths = make([]PathList, 0)
 	for _, monpath := range param.Monitoring_AggregatePrefixes.GetStringSlice() {

--- a/xrootd/origin_test_linux.go
+++ b/xrootd/origin_test_linux.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -68,7 +69,11 @@ func TestOrigin(t *testing.T) {
 	err = CheckXrootdEnv(true, nil)
 	require.NoError(t, err)
 
-	err = SetUpMonitoring()
+	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	defer shutdownCancel()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	err = SetUpMonitoring(shutdownCtx, &wg)
 	require.NoError(t, err)
 
 	configPath, err := ConfigXrootd(true)

--- a/xrootd/origin_test_linux.go
+++ b/xrootd/origin_test_linux.go
@@ -70,9 +70,14 @@ func TestOrigin(t *testing.T) {
 	require.NoError(t, err)
 
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
-	defer shutdownCancel()
 	var wg sync.WaitGroup
 	wg.Add(1)
+
+	defer func() {
+		shutdownCancel()
+		wg.Wait()
+	}()
+
 	err = SetUpMonitoring(shutdownCtx, &wg)
 	require.NoError(t, err)
 

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -401,6 +401,10 @@ func ConfigXrootd(origin bool) (string, error) {
 	return configPath, nil
 }
 
+// Set up xrootd monitoring
+//
+// The `ctx` is the context for listening to server shutdown event in order to cleanup internal cache eviction
+// goroutine and `wg` is the wait group to notify when the clean up goroutine finishes
 func SetUpMonitoring(ctx context.Context, wg *sync.WaitGroup) error {
 	monitorPort, err := metrics.ConfigureMonitoring(ctx, wg)
 	if err != nil {

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -2,6 +2,7 @@ package xrootd
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	_ "embed"
 	"encoding/base64"
@@ -10,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 	"text/template"
 
 	"github.com/pelicanplatform/pelican/config"
@@ -399,8 +401,8 @@ func ConfigXrootd(origin bool) (string, error) {
 	return configPath, nil
 }
 
-func SetUpMonitoring() error {
-	monitorPort, err := metrics.ConfigureMonitoring()
+func SetUpMonitoring(ctx context.Context, wg *sync.WaitGroup) error {
+	monitorPort, err := metrics.ConfigureMonitoring(ctx, wg)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #330 

The added unit tests to director's `serverAds` cache and `namespaceKeys` cache suggest that expired cache item won't be evicted with existing code, so this PR added `cache.Start()` to all TTL cache instances to ensure they work as expected.

The part I'm not sure about is whether we should call `cache.Stop()` at the shutdown of the program. I called `Stop()` for now but I don't know if this is redundant or not.