### PR TITLE
Pelican cache with auth

### DIFF
--- a/cache_ui/advertise.go
+++ b/cache_ui/advertise.go
@@ -1,0 +1,35 @@
+/***************************************************************
+ *
+ * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package cache_ui
+
+import (
+	"github.com/pelicanplatform/pelican/director"
+	server_struct "github.com/pelicanplatform/pelican/server_utils"
+)
+
+func CreateCacheAdvertisement(name string, originUrl string, originWebUrl string, server server_struct.XRootDServer) (director.OriginAdvertise, error) {
+	ad := director.OriginAdvertise{
+		Name:       name,
+		URL:        originUrl,
+		WebURL:     originWebUrl,
+		Namespaces: server.NameSpaceAds,
+	}
+
+	return ad, nil
+}

--- a/cache_ui/advertise.go
+++ b/cache_ui/advertise.go
@@ -19,17 +19,28 @@
 package cache_ui
 
 import (
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/director"
-	server_struct "github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/server_utils"
 )
 
-func CreateCacheAdvertisement(name string, originUrl string, originWebUrl string, server server_struct.XRootDServer) (director.OriginAdvertise, error) {
+type (
+	CacheServer struct {
+		server_utils.NamespaceHolder
+	}
+)
+
+func (server *CacheServer) CreateAdvertisement(name string, originUrl string, originWebUrl string) (director.OriginAdvertise, error) {
 	ad := director.OriginAdvertise{
 		Name:       name,
 		URL:        originUrl,
 		WebURL:     originWebUrl,
-		Namespaces: server.NameSpaceAds,
+		Namespaces: server.GetNamespaceAds(),
 	}
 
 	return ad, nil
+}
+
+func (server *CacheServer) GetServerType() config.ServerType {
+	return config.CacheType
 }

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -268,24 +268,11 @@ func download_http(source string, destination string, payload *payloadStruct, na
 	// Check the env var "USE_OSDF_DIRECTOR" and decide if ordered caches should come from director
 	var transfers []TransferDetails
 	var files []string
-	var closestNamespaceCaches []CacheInterface
-	if OSDFDirectorUrl != "" {
-		log.Debugln("Using OSDF Director at ", OSDFDirectorUrl)
-		closestNamespaceCaches = make([]CacheInterface, len(namespace.SortedDirectorCaches))
-		for i, v := range namespace.SortedDirectorCaches {
-			closestNamespaceCaches[i] = v
-		}
-	} else {
-		tmpCaches, err := GetCachesFromNamespace(namespace)
-		if err != nil {
-			log.Errorln("Failed to get namespaced caches (treated as non-fatal):", err)
-		}
-
-		closestNamespaceCaches = make([]CacheInterface, len(tmpCaches))
-		for i, v := range tmpCaches {
-			closestNamespaceCaches[i] = v
-		}
+	closestNamespaceCaches, err := GetCachesFromNamespace(namespace, OSDFDirectorUrl != "")
+	if err != nil {
+		log.Errorln("Failed to get namespaced caches (treated as non-fatal):", err)
 	}
+
 	log.Debugln("Matched caches:", closestNamespaceCaches)
 
 	// Make sure we only try as many caches as we have

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -20,7 +20,6 @@ package client
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -38,6 +37,7 @@ import (
 	"time"
 
 	grab "github.com/cavaliercoder/grab"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/studio-b12/gowebdav"
 	"github.com/vbauerster/mpb/v8"
@@ -487,6 +487,7 @@ func DownloadHTTP(transfer TransferDetails, dest string, token string) (int64, e
 		headResponse, err := headClient.Do(headRequest)
 		if err != nil {
 			log.Errorln("Could not successfully get response for HEAD request")
+			return 0, errors.Wrap(err, "Could not determine the size of the remote object")
 		}
 		defer headResponse.Body.Close()
 		contentLengthStr := headResponse.Header.Get("Content-Length")

--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -43,7 +43,7 @@ var (
 )
 
 func initCache() error {
-	err := config.InitServer()
+	err := config.InitServer(config.CacheType)
 	cobra.CheckErr(err)
 	metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusCritical, "xrootd has not been started")
 	metrics.SetComponentHealthStatus(metrics.OriginCache_CMSD, metrics.StatusCritical, "cmsd has not been started")

--- a/cmd/cache_serve.go
+++ b/cmd/cache_serve.go
@@ -32,21 +32,12 @@ import (
 	"github.com/pelicanplatform/pelican/director"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_ui"
-	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/utils"
 	"github.com/pelicanplatform/pelican/xrootd"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-)
-
-var (
-	CacheServer = server_utils.XRootDServer{
-		ServerType:          string(server_utils.CacheType),
-		NameSpaceAds:        []director.NamespaceAd{},
-		CreateAdvertisement: cache_ui.CreateCacheAdvertisement,
-	}
 )
 
 func getNSAdsFromDirector() ([]director.NamespaceAd, error) {
@@ -104,8 +95,9 @@ func serveCache( /*cmd*/ *cobra.Command /*args*/, []string) error {
 		return err
 	}
 
-	CacheServer.NameSpaceAds = nsAds
-	err = server_ui.CheckDefaults(CacheServer)
+	cacheServer := &cache_ui.CacheServer{}
+	cacheServer.SetNamespaceAds(nsAds)
+	err = server_ui.CheckDefaults(cacheServer)
 	if err != nil {
 		return err
 	}
@@ -118,7 +110,7 @@ func serveCache( /*cmd*/ *cobra.Command /*args*/, []string) error {
 		return err
 	}
 
-	if err = server_ui.PeriodicAdvertise(CacheServer); err != nil {
+	if err = server_ui.PeriodicAdvertise(cacheServer); err != nil {
 		return err
 	}
 

--- a/cmd/cache_serve.go
+++ b/cmd/cache_serve.go
@@ -93,13 +93,8 @@ func serveCache( /*cmd*/ *cobra.Command /*args*/, []string) error {
 		config.CleanupTempResources()
 	}()
 
-	err := config.DiscoverFederation()
-	if err != nil {
-		log.Warningln("Failed to do service auto-discovery:", err)
-	}
-
 	wg.Add(1)
-	err = xrootd.SetUpMonitoring(shutdownCtx, &wg)
+	err := xrootd.SetUpMonitoring(shutdownCtx, &wg)
 	if err != nil {
 		return err
 	}
@@ -110,7 +105,7 @@ func serveCache( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	}
 
 	CacheServer.NameSpaceAds = nsAds
-	err = checkDefaults(false, nsAds)
+	err = server_ui.CheckDefaults(CacheServer)
 	if err != nil {
 		return err
 	}

--- a/cmd/director.go
+++ b/cmd/director.go
@@ -71,7 +71,7 @@ func getDirectorEndpoint() (string, error) {
 }
 
 func initDirector() error {
-	err := config.InitServer()
+	err := config.InitServer(config.DirectorType)
 	cobra.CheckErr(err)
 
 	return err

--- a/cmd/namespace_registry.go
+++ b/cmd/namespace_registry.go
@@ -56,7 +56,7 @@ var (
 )
 
 func initRegistry() error {
-	err := config.InitServer()
+	err := config.InitServer(config.RegistryType)
 	cobra.CheckErr(err)
 
 	return err

--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -99,7 +99,7 @@ func configOrigin( /*cmd*/ *cobra.Command /*args*/, []string) {
 }
 
 func initOrigin() error {
-	err := config.InitServer()
+	err := config.InitServer(config.OriginType)
 	cobra.CheckErr(err)
 	metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusCritical, "xrootd has not been started")
 	metrics.SetComponentHealthStatus(metrics.OriginCache_CMSD, metrics.StatusCritical, "cmsd has not been started")

--- a/cmd/origin_reset_password_test.go
+++ b/cmd/origin_reset_password_test.go
@@ -36,7 +36,7 @@ func TestResetPassword(t *testing.T) {
 	dirName := t.TempDir()
 	viper.Reset()
 	viper.Set("ConfigDir", dirName)
-	err := config.InitServer()
+	err := config.InitServer(config.OriginType)
 	require.NoError(t, err)
 
 	rootCmd.SetArgs([]string{"origin", "web-ui", "reset-password", "--stdin"})

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -23,15 +23,10 @@ package main
 import (
 	"context"
 	_ "embed"
-	"fmt"
-	"net/url"
-	"os"
 	"sync"
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/daemon"
-	"github.com/pelicanplatform/pelican/director"
-	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/oa4mp"
 	"github.com/pelicanplatform/pelican/origin_ui"
 	"github.com/pelicanplatform/pelican/param"
@@ -39,10 +34,8 @@ import (
 	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/web_ui"
 	"github.com/pelicanplatform/pelican/xrootd"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -52,64 +45,6 @@ var (
 		CreateAdvertisement: origin_ui.CreateOriginAdvertisement,
 	}
 )
-
-func checkConfigFileReadable(fileName string, errMsg string) error {
-	if _, err := os.Open(fileName); errors.Is(err, os.ErrNotExist) {
-		return errors.New(fmt.Sprintf("%v: the specified path in the configuration (%v) "+
-			"does not exist", errMsg, fileName))
-	} else if err != nil {
-		return errors.New(fmt.Sprintf("%v; an error occurred when reading %v: %v", errMsg,
-			fileName, err.Error()))
-	}
-	return nil
-}
-
-func checkDefaults(origin bool, nsAds []director.NamespaceAd) error {
-	requiredConfigs := []param.StringParam{param.Server_TLSCertificate, param.Server_TLSKey, param.Xrootd_RunLocation, param.Xrootd_RobotsTxtFile}
-	for _, configName := range requiredConfigs {
-		mgr := configName.GetString()
-		if mgr == "" {
-			return errors.New(fmt.Sprintf("Required value of '%v' is not set in config",
-				configName))
-		}
-	}
-
-	if managerHost := param.Xrootd_ManagerHost.GetString(); managerHost == "" {
-		log.Debug("No manager host specified for the cmsd process in origin; assuming no xrootd protocol support")
-		viper.SetDefault("Origin.EnableCmsd", false)
-		metrics.DeleteComponentHealthStatus("cmsd")
-	} else {
-		viper.SetDefault("Origin.EnableCmsd", true)
-	}
-
-	// TODO: Could upgrade this to a check for a cert in the file...
-	if err := checkConfigFileReadable(param.Server_TLSCertificate.GetString(),
-		"A TLS certificate is required to serve HTTPS"); err != nil {
-		return err
-	}
-	if err := checkConfigFileReadable(param.Server_TLSKey.GetString(),
-		"A TLS key is required to serve HTTPS"); err != nil {
-		return err
-	}
-
-	if err := xrootd.CheckXrootdEnv(origin, nsAds); err != nil {
-		return err
-	}
-
-	// Check that OriginUrl is defined in the config file. Make sure it parses.
-	// Fail if either condition isn't met, although note that url.Parse doesn't
-	// generate errors for many things that are not recognizable urls.
-	originUrlStr := param.Origin_Url.GetString()
-	if originUrlStr == "" {
-		return errors.New("OriginUrl must be configured to serve an origin")
-	}
-
-	if _, err := url.Parse(originUrlStr); err != nil {
-		return errors.Wrapf(err, "Could not parse the provided OriginUrl (%v)", originUrlStr)
-	}
-
-	return nil
-}
 
 func serveOrigin( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	// Use this context for any goroutines that needs to react to server shutdown
@@ -131,7 +66,7 @@ func serveOrigin( /*cmd*/ *cobra.Command /*args*/, []string) error {
 		return err
 	}
 
-	err = checkDefaults(true, nil)
+	err = server_ui.CheckDefaults(OriginServer)
 	if err != nil {
 		return err
 	}

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -35,12 +35,22 @@ import (
 	"github.com/pelicanplatform/pelican/oa4mp"
 	"github.com/pelicanplatform/pelican/origin_ui"
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_ui"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/web_ui"
 	"github.com/pelicanplatform/pelican/xrootd"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+)
+
+var (
+	OriginServer = server_utils.XRootDServer{
+		ServerType:          string(server_utils.OriginType),
+		NameSpaceAds:        nil,
+		CreateAdvertisement: origin_ui.CreateOriginAdvertisement,
+	}
 )
 
 func checkConfigFileReadable(fileName string, errMsg string) error {
@@ -148,7 +158,7 @@ func serveOrigin( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	if err = origin_ui.RegisterNamespaceWithRetry(); err != nil {
 		return err
 	}
-	if err = origin_ui.PeriodicAdvertiseOrigin(); err != nil {
+	if err = server_ui.PeriodicAdvertise(OriginServer); err != nil {
 		return err
 	}
 	if param.Origin_EnableIssuer.GetBool() {

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -155,7 +155,7 @@ func serveOrigin( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	if err = origin_ui.ConfigureOriginAPI(engine); err != nil {
 		return err
 	}
-	if err = origin_ui.RegisterNamespaceWithRetry(); err != nil {
+	if err = server_ui.RegisterNamespaceWithRetry(); err != nil {
 		return err
 	}
 	if err = server_ui.PeriodicAdvertise(OriginServer); err != nil {

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -31,19 +31,10 @@ import (
 	"github.com/pelicanplatform/pelican/origin_ui"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_ui"
-	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/web_ui"
 	"github.com/pelicanplatform/pelican/xrootd"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-)
-
-var (
-	OriginServer = server_utils.XRootDServer{
-		ServerType:          string(server_utils.OriginType),
-		NameSpaceAds:        nil,
-		CreateAdvertisement: origin_ui.CreateOriginAdvertisement,
-	}
 )
 
 func serveOrigin( /*cmd*/ *cobra.Command /*args*/, []string) error {
@@ -66,7 +57,8 @@ func serveOrigin( /*cmd*/ *cobra.Command /*args*/, []string) error {
 		return err
 	}
 
-	err = server_ui.CheckDefaults(OriginServer)
+	originServer := &origin_ui.OriginServer{}
+	err = server_ui.CheckDefaults(originServer)
 	if err != nil {
 		return err
 	}
@@ -93,7 +85,7 @@ func serveOrigin( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	if err = server_ui.RegisterNamespaceWithRetry(); err != nil {
 		return err
 	}
-	if err = server_ui.PeriodicAdvertise(OriginServer); err != nil {
+	if err = server_ui.PeriodicAdvertise(originServer); err != nil {
 		return err
 	}
 	if param.Origin_EnableIssuer.GetBool() {

--- a/config/privs.go
+++ b/config/privs.go
@@ -135,6 +135,10 @@ func GetDaemonUser() (string, error) {
 	return xrootdUser.Username, xrootdUser.err
 }
 
+func GetDaemonUserInfo() (User, error) {
+	return xrootdUser, xrootdUser.err
+}
+
 func GetDaemonGID() (int, error) {
 	return xrootdUser.Gid, xrootdUser.err
 }

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -22,6 +22,8 @@ Server:
   WebHost: "0.0.0.0"
 Director:
   DefaultResponse: cache
+Cache:
+  Port: 8447
 Origin:
   NamespacePrefix: ""
   Multiuser: false

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -27,7 +27,7 @@ Cache:
 Origin:
   NamespacePrefix: ""
   Multiuser: false
-  EnableMacaroons: true
+  EnableMacaroons: false
   EnableVoms: true
   SelfTest: true
   EnableUI: true

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -23,7 +23,7 @@ Server:
 Director:
   DefaultResponse: cache
 Cache:
-  Port: 8447
+  Port: 8443
 Origin:
   NamespacePrefix: ""
   Multiuser: false

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -339,6 +339,16 @@ type: string
 default: origin
 components: ["origin"]
 ---
+name: Origin.EnableVoms
+description: >-
+  Enable X.509 / VOMS-based authentication.  This allows HTTP clients to
+  present X.509 client credentials in order to authenticate.  The configuration
+  of the authorization for these clients must be done by the admin; Pelican
+  does not support automatic VOMS authorization configuration.
+type: bool
+default: true
+components: ["origin"]
+---
 
 ############################
 #   Cache-level configs    #
@@ -372,6 +382,16 @@ description: >-
   The port over which the xrootd cache should be made available (this will overwrite Xrootd.Port)
 type: int
 default: 8447
+components: ["cache"]
+---
+name: Cache.EnableVoms
+description: >-
+  Enable X.509 / VOMS-based authentication for the cache.  This allows HTTP clients
+  to present X.509 client credentials in order to authenticate.  The configuration
+  of the authorization for these clients must be done by the admin; Pelican
+  does not support automatic VOMS authorization configuration.
+type: bool
+default: false
 components: ["cache"]
 ---
 

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -332,6 +332,13 @@ type: string
 default: none
 components: ["origin"]
 ---
+name: Origin.XRootDPrefix
+description: >-
+  The directory prefix for the xrootd origin configuration files.
+type: string
+default: origin
+components: ["origin"]
+---
 
 ############################
 #   Cache-level configs    #
@@ -351,6 +358,20 @@ description: >-
   relative to the mount location.
 type: string
 default: /
+components: ["cache"]
+---
+name: Cache.XRootDPrefix
+description: >-
+  The directory prefix for the xrootd cache configuration files.
+type: string
+default: cache
+components: ["cache"]
+---
+name: Cache.Port
+description: >-
+  The port over which the xrootd cache should be made available (this will overwrite Xrootd.Port)
+type: int
+default: 8447
 components: ["cache"]
 ---
 
@@ -601,19 +622,19 @@ description: >-
   The port over which XRootD should be made available.
 type: int
 default: 8443
-components: ["origin"]
+components: ["origin", "cache"]
 ---
 name: Xrootd.RunLocation
 description: >-
   A directory where temporary configurations will be stored for the xrootd daemon
-  started by the origin.
+  started by the origin or cache.
 
   For non-root servers, if $XDG_RUNTIME_DIR is not set, a temporary directory will
   be created (and removed on shutdown)
 type: filename
 root_default: /run/pelican/xrootd
 default: $XDG_RUNTIME_DIR/pelican
-components: ["origin"]
+components: ["origin", "cache"]
 ---
 name: Xrootd.RobotsTxtFile
 description: >-

--- a/namespace_registry/client_commands_test.go
+++ b/namespace_registry/client_commands_test.go
@@ -40,7 +40,7 @@ func TestServeNamespaceRegistry(t *testing.T) {
 	ikey := filepath.Join(issuerTempDir, "issuer.jwk")
 	viper.Set("IssuerKey", ikey)
 	viper.Set("Registry.DbLocation", filepath.Join(issuerTempDir, "test.sql"))
-	err := config.InitServer()
+	err := config.InitServer(config.RegistryType)
 	require.NoError(t, err)
 
 	err = InitializeDB()

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -22,13 +22,24 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/director"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pkg/errors"
 )
 
-func CreateOriginAdvertisement(name string, originUrl string, originWebUrl string, server server_utils.XRootDServer) (director.OriginAdvertise, error) {
+type (
+	OriginServer struct {
+		server_utils.NamespaceHolder
+	}
+)
+
+func (server *OriginServer) GetServerType() config.ServerType {
+	return config.OriginType
+}
+
+func (server *OriginServer) CreateAdvertisement(name string, originUrl string, originWebUrl string) (director.OriginAdvertise, error) {
 	ad := director.OriginAdvertise{}
 
 	// Here we instantiate the namespaceAd slice, but we still need to define the namespace

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -21,6 +21,7 @@ package origin_ui
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -75,12 +76,12 @@ func AdvertiseOrigin() error {
 	originWebUrl := param.Server_ExternalWebUrl.GetString()
 
 	// Here we instantiate the namespaceAd slice, but we still need to define the namespace
-	namespaceUrl, err := url.Parse(param.Federation_NamespaceUrl.GetString())
-	if err != nil {
-		return errors.Wrap(err, "Bad NamespaceUrl")
-	}
-	if namespaceUrl.String() == "" {
-		return errors.New("No NamespaceUrl is set")
+	issuerUrl := url.URL{}
+	issuerUrl.Scheme = "https"
+	issuerUrl.Host = fmt.Sprintf("%v:%v", param.Server_Hostname.GetString(), param.Xrootd_Port.GetInt())
+
+	if issuerUrl.String() == "" {
+		return errors.New("No IssuerUrl is set")
 	}
 
 	prefix := param.Origin_NamespacePrefix.GetString()
@@ -90,10 +91,10 @@ func AdvertiseOrigin() error {
 	nsAd := director.NamespaceAd{
 		RequireToken:  true,
 		Path:          prefix,
-		Issuer:        *namespaceUrl,
+		Issuer:        issuerUrl,
 		MaxScopeDepth: 3,
 		Strategy:      "OAuth2",
-		BasePath:      "/",
+		BasePath:      prefix,
 	}
 	ad := director.OriginAdvertise{
 		Name:       name,

--- a/origin_ui/register_origin_test.go
+++ b/origin_ui/register_origin_test.go
@@ -56,7 +56,7 @@ func TestRegistration(t *testing.T) {
 	ikey := filepath.Join(issuerTempDir, "issuer.jwk")
 	viper.Set("IssuerKey", ikey)
 	viper.Set("Registry.DbLocation", filepath.Join(issuerTempDir, "test.sql"))
-	err := config.InitServer()
+	err := config.InitServer(config.OriginType)
 	require.NoError(t, err)
 
 	err = nsregistry.InitializeDB()

--- a/server_ui/advertise.go
+++ b/server_ui/advertise.go
@@ -1,0 +1,139 @@
+/***************************************************************
+ *
+ * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package server_ui
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/director"
+	"github.com/pelicanplatform/pelican/metrics"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+type directorResponse struct {
+	Error string `json:"error"`
+}
+
+func PeriodicAdvertise(server server_utils.XRootDServer) error {
+	ticker := time.NewTicker(1 * time.Minute)
+	go func() {
+		err := Advertise(server)
+		if err != nil {
+			log.Warningln(fmt.Sprintf("%s advertise failed:", server.ServerType), err)
+			metrics.SetComponentHealthStatus(metrics.OriginCache_Federation, metrics.StatusCritical, fmt.Sprintf("Error advertising %s to federation", server.ServerType))
+		} else {
+			metrics.SetComponentHealthStatus(metrics.OriginCache_Federation, metrics.StatusOK, "")
+		}
+
+		for {
+			<-ticker.C
+			err := Advertise(server)
+			if err != nil {
+				log.Warningln(fmt.Sprintf("%s advertise failed:", server.ServerType), err)
+				metrics.SetComponentHealthStatus(metrics.OriginCache_Federation, metrics.StatusCritical, fmt.Sprintf("Error advertising %s to federation", server.ServerType))
+			} else {
+				metrics.SetComponentHealthStatus(metrics.OriginCache_Federation, metrics.StatusOK, "")
+			}
+		}
+	}()
+
+	return nil
+}
+
+func Advertise(server server_utils.XRootDServer) error {
+	name := param.Xrootd_Sitename.GetString()
+	if name == "" {
+		return errors.New(fmt.Sprintf("%s name isn't set", server.ServerType))
+	}
+
+	originUrl := param.Origin_Url.GetString()
+	originWebUrl := param.Server_ExternalWebUrl.GetString()
+
+	ad, err := server.CreateAdvertisement(name, originUrl, originWebUrl, server)
+	if err != nil {
+		return err
+	}
+
+	body, err := json.Marshal(ad)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("Failed to generate JSON description of %s", server.ServerType))
+	}
+
+	directorUrlStr := param.Federation_DirectorUrl.GetString()
+	if directorUrlStr == "" {
+		return errors.New("Director endpoint URL is not known")
+	}
+	directorUrl, err := url.Parse(directorUrlStr)
+	if err != nil {
+		return errors.Wrap(err, "Failed to parse Federation.DirectorURL")
+	}
+
+	directorUrl.Path = "/api/v1.0/director/register" + server.ServerType
+
+	prefix := param.Origin_NamespacePrefix.GetString()
+
+	token, err := director.CreateAdvertiseToken(prefix)
+	if err != nil {
+		return errors.Wrap(err, "Failed to generate advertise token")
+	}
+
+	req, err := http.NewRequest("POST", directorUrl.String(), bytes.NewBuffer(body))
+	if err != nil {
+		return errors.Wrap(err, "Failed to create POST request for director registration")
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	userAgent := "pelican-" + strings.ToLower(server.ServerType) + "/" + client.ObjectClientOptions.Version
+	req.Header.Set("User-Agent", userAgent)
+
+	// We should switch this over to use the common transport, but for that to happen
+	// that function needs to be exported from pelican
+	tr := config.GetTransport()
+	client := http.Client{Transport: tr}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "Failed to start request for director registration")
+	}
+	defer resp.Body.Close()
+
+	body, _ = io.ReadAll(resp.Body)
+	if resp.StatusCode > 299 {
+		var respErr directorResponse
+		if unmarshalErr := json.Unmarshal(body, &respErr); unmarshalErr != nil { // Error creating json
+			return errors.Wrapf(unmarshalErr, "Could not unmarshall the director's response, which responded %v from director registration: %v", resp.StatusCode, resp.Status)
+		}
+		return errors.Errorf("Error during director registration: %v\n", respErr.Error)
+	}
+
+	return nil
+}

--- a/server_ui/register_namespace.go
+++ b/server_ui/register_namespace.go
@@ -16,7 +16,7 @@
  *
  ***************************************************************/
 
-package origin_ui
+package server_ui
 
 import (
 	"encoding/json"

--- a/server_ui/register_namespace_test.go
+++ b/server_ui/register_namespace_test.go
@@ -16,7 +16,7 @@
  *
  ***************************************************************/
 
-package origin_ui
+package server_ui
 
 import (
 	"crypto/ecdsa"

--- a/server_ui/xrootd_servers.go
+++ b/server_ui/xrootd_servers.go
@@ -1,0 +1,91 @@
+/***************************************************************
+ *
+ * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package server_ui
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+
+	"github.com/pelicanplatform/pelican/metrics"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/xrootd"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+func checkConfigFileReadable(fileName string, errMsg string) error {
+	if _, err := os.Open(fileName); errors.Is(err, os.ErrNotExist) {
+		return errors.New(fmt.Sprintf("%v: the specified path in the configuration (%v) "+
+			"does not exist", errMsg, fileName))
+	} else if err != nil {
+		return errors.New(fmt.Sprintf("%v; an error occurred when reading %v: %v", errMsg,
+			fileName, err.Error()))
+	}
+	return nil
+}
+
+func CheckDefaults(server server_utils.XRootDServer) error {
+	requiredConfigs := []param.StringParam{param.Server_TLSCertificate, param.Server_TLSKey, param.Xrootd_RunLocation, param.Xrootd_RobotsTxtFile}
+	for _, configName := range requiredConfigs {
+		mgr := configName.GetString()
+		if mgr == "" {
+			return errors.New(fmt.Sprintf("Required value of '%v' is not set in config",
+				configName))
+		}
+	}
+
+	if managerHost := param.Xrootd_ManagerHost.GetString(); managerHost == "" {
+		log.Debug("No manager host specified for the cmsd process in origin; assuming no xrootd protocol support")
+		viper.SetDefault("Origin.EnableCmsd", false)
+		metrics.DeleteComponentHealthStatus("cmsd")
+	} else {
+		viper.SetDefault("Origin.EnableCmsd", true)
+	}
+
+	// TODO: Could upgrade this to a check for a cert in the file...
+	if err := checkConfigFileReadable(param.Server_TLSCertificate.GetString(),
+		"A TLS certificate is required to serve HTTPS"); err != nil {
+		return err
+	}
+	if err := checkConfigFileReadable(param.Server_TLSKey.GetString(),
+		"A TLS key is required to serve HTTPS"); err != nil {
+		return err
+	}
+
+	if err := xrootd.CheckXrootdEnv(server); err != nil {
+		return err
+	}
+
+	// Check that OriginUrl is defined in the config file. Make sure it parses.
+	// Fail if either condition isn't met, although note that url.Parse doesn't
+	// generate errors for many things that are not recognizable urls.
+	originUrlStr := param.Origin_Url.GetString()
+	if originUrlStr == "" {
+		return errors.New("OriginUrl must be configured to serve an origin")
+	}
+
+	if _, err := url.Parse(originUrlStr); err != nil {
+		return errors.Wrapf(err, "Could not parse the provided OriginUrl (%v)", originUrlStr)
+	}
+
+	return nil
+}

--- a/server_utils/server_struct.go
+++ b/server_utils/server_struct.go
@@ -1,0 +1,36 @@
+/***************************************************************
+ *
+ * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package server_utils
+
+import "github.com/pelicanplatform/pelican/director"
+
+type (
+	XRootDServer struct {
+		ServerType          string
+		NameSpaceAds        []director.NamespaceAd
+		CreateAdvertisement func(string, string, string, XRootDServer) (director.OriginAdvertise, error)
+	}
+
+	ServerType string
+)
+
+const (
+	CacheType  ServerType = "Cache"
+	OriginType ServerType = "Origin"
+)

--- a/server_utils/server_struct.go
+++ b/server_utils/server_struct.go
@@ -18,19 +18,26 @@
 
 package server_utils
 
+import "github.com/pelicanplatform/pelican/config"
 import "github.com/pelicanplatform/pelican/director"
 
 type (
-	XRootDServer struct {
-		ServerType          string
-		NameSpaceAds        []director.NamespaceAd
-		CreateAdvertisement func(string, string, string, XRootDServer) (director.OriginAdvertise, error)
+	XRootDServer interface {
+		GetServerType() config.ServerType
+		SetNamespaceAds([]director.NamespaceAd)
+		GetNamespaceAds() []director.NamespaceAd
+		CreateAdvertisement(name string, serverUrl string, serverWebUrl string) (director.OriginAdvertise, error)
 	}
 
-	ServerType string
+	NamespaceHolder struct {
+		namespaceAds []director.NamespaceAd
+	}
 )
 
-const (
-	CacheType  ServerType = "Cache"
-	OriginType ServerType = "Origin"
-)
+func (ns *NamespaceHolder) SetNamespaceAds(ads []director.NamespaceAd) {
+	ns.namespaceAds = ads
+}
+
+func (ns *NamespaceHolder) GetNamespaceAds() []director.NamespaceAd {
+	return ns.namespaceAds
+}

--- a/web_ui/ui_test.go
+++ b/web_ui/ui_test.go
@@ -71,7 +71,7 @@ func TestMain(m *testing.M) {
 
 	// Ensure we load up the default configs.
 	config.InitConfig()
-	if err := config.InitServer(); err != nil {
+	if err := config.InitServer(config.OriginType); err != nil {
 		fmt.Println("Failed to configure the test module")
 		os.Exit(1)
 	}
@@ -104,7 +104,7 @@ func TestWaitUntilLogin(t *testing.T) {
 	viper.Reset()
 	viper.Set("ConfigDir", dirName)
 	config.InitConfig()
-	err := config.InitServer()
+	err := config.InitServer(config.OriginType)
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -151,7 +151,7 @@ func TestCodeBasedLogin(t *testing.T) {
 	viper.Reset()
 	viper.Set("ConfigDir", dirName)
 	config.InitConfig()
-	err := config.InitServer()
+	err := config.InitServer(config.OriginType)
 	require.NoError(t, err)
 	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256())
 	require.NoError(t, err)
@@ -203,7 +203,7 @@ func TestPasswordResetAPI(t *testing.T) {
 	viper.Reset()
 	viper.Set("ConfigDir", dirName)
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
-	err := config.InitServer()
+	err := config.InitServer(config.OriginType)
 	require.NoError(t, err)
 	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256())
 	require.NoError(t, err)
@@ -306,7 +306,7 @@ func TestPasswordBasedLoginAPI(t *testing.T) {
 	viper.Reset()
 	config.InitConfig()
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
-	err := config.InitServer()
+	err := config.InitServer(config.OriginType)
 	require.NoError(t, err)
 
 	///////////////////////////SETUP///////////////////////////////////
@@ -420,7 +420,7 @@ func TestWhoamiAPI(t *testing.T) {
 	config.InitConfig()
 	viper.Set("ConfigDir", dirName)
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
-	err := config.InitServer()
+	err := config.InitServer(config.OriginType)
 	require.NoError(t, err)
 	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256())
 	require.NoError(t, err)

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -121,7 +121,7 @@ func TestGenerateConfig(t *testing.T) {
 	assert.Equal(t, issuer.Name, "")
 
 	viper.Set("Origin.SelfTest", true)
-	err = config.InitServer()
+	err = config.InitServer(config.OriginType)
 	require.NoError(t, err)
 	issuer, err = GenerateMonitoringIssuer()
 	require.NoError(t, err)
@@ -135,7 +135,7 @@ func TestGenerateConfig(t *testing.T) {
 	viper.Set("Origin.SelfTest", false)
 	viper.Set("Origin.ScitokensDefaultUser", "user1")
 	viper.Set("Origin.ScitokensMapSubject", true)
-	err = config.InitServer()
+	err = config.InitServer(config.OriginType)
 	require.NoError(t, err)
 	issuer, err = GenerateOriginIssuer([]string{"/foo/bar/baz", "/another/exported/path"})
 	require.NoError(t, err)
@@ -160,7 +160,7 @@ func TestWriteOriginScitokensConfig(t *testing.T) {
 	viper.Set("Xrootd.RunLocation", dirname)
 	viper.Set("Xrootd.Port", 8443)
 	viper.Set("Server.Hostname", "origin.example.com")
-	err := config.InitServer()
+	err := config.InitServer(config.OriginType)
 	require.Nil(t, err)
 
 	scitokensCfg := param.Xrootd_ScitokensConfig.GetString()

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -23,11 +23,13 @@ package xrootd
 import (
 	_ "embed"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/director"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -52,6 +54,12 @@ var (
 
 	//go:embed resources/test-scitokens-monitoring.cfg
 	monitoringOutput string
+
+	//go:embed resources/test-scitokens-cache-issuer.cfg
+	cacheSciOutput string
+
+	//go:embed resources/test-scitokens-cache-empty.cfg
+	cacheEmptyOutput string
 )
 
 func TestEmitCfg(t *testing.T) {
@@ -148,13 +156,76 @@ func TestGenerateConfig(t *testing.T) {
 	assert.Equal(t, issuer.MapSubject, true)
 }
 
+func TestWriteCacheAuthFiles(t *testing.T) {
+
+	cacheAuthTester := func(nsAds []director.NamespaceAd, sciTokenResult string, authResult string) func(t *testing.T) {
+		return func(t *testing.T) {
+
+			dirname := t.TempDir()
+			viper.Reset()
+			viper.Set("Xrootd.RunLocation", dirname)
+			viper.Set("Xrootd.ScitokensConfig", filepath.Join(dirname, "scitokens-generated.cfg"))
+			viper.Set("Xrootd.Authfile", filepath.Join(dirname, "authfile-generated"))
+			authFile := param.Xrootd_Authfile.GetString()
+			err := os.WriteFile(authFile, []byte(""), 0600)
+			assert.NoError(t, err)
+
+			err = WriteCacheScitokensConfig(nsAds)
+			assert.NoError(t, err)
+
+			sciFile := param.Xrootd_ScitokensConfig.GetString()
+			genSciToken, err := os.ReadFile(sciFile)
+			assert.NoError(t, err)
+
+			assert.Equal(t, string(genSciToken), sciTokenResult)
+
+			err = EmitAuthfile(nsAds)
+			assert.NoError(t, err)
+
+			authGen, err := os.ReadFile(authFile)
+			assert.NoError(t, err)
+			assert.Equal(t, string(authGen), authResult)
+		}
+	}
+
+	issuer1URL := url.URL{}
+	issuer1URL.Scheme = "https"
+	issuer1URL.Host = "issuer1.com"
+
+	issuer2URL := url.URL{}
+	issuer2URL.Scheme = "https"
+	issuer2URL.Host = "issuer2.com"
+
+	issuer3URL := url.URL{}
+	issuer3URL.Scheme = "https"
+	issuer3URL.Host = "issuer3.com"
+
+	issuer4URL := url.URL{}
+	issuer4URL.Scheme = "https"
+	issuer4URL.Host = "issuer4.com"
+
+	nsAds := []director.NamespaceAd{
+		{RequireToken: true, Issuer: issuer1URL, BasePath: "/p1"},
+		{RequireToken: true, Issuer: issuer2URL, BasePath: "/p2/path"},
+		{RequireToken: false, Issuer: issuer3URL, BasePath: "/p3"},
+		{RequireToken: true, Issuer: issuer1URL, BasePath: "/p1_again"},
+		{RequireToken: false, Issuer: issuer4URL, BasePath: "/p4/depth"},
+		{RequireToken: false, Issuer: issuer2URL, BasePath: "/p2_noauth"},
+	}
+
+	t.Run("MultiIssuer", cacheAuthTester(nsAds, cacheSciOutput, "u * /p3 lr /p4/depth lr /p2_noauth lr "))
+
+	nsAds = []director.NamespaceAd{}
+
+	t.Run("EmptyNS", cacheAuthTester(nsAds, cacheEmptyOutput, ""))
+}
+
 func TestWriteOriginScitokensConfig(t *testing.T) {
 	viper.Reset()
 	dirname := t.TempDir()
 	os.Setenv("PELICAN_XROOTD_RUNLOCATION", dirname)
 	defer os.Unsetenv("PELICAN_XROOTD_RUNLOCATION")
 	config_dirname := t.TempDir()
-	viper.Reset()
 	viper.Set("Origin.SelfTest", true)
 	viper.Set("ConfigDir", config_dirname)
 	viper.Set("Xrootd.RunLocation", dirname)

--- a/xrootd/origin_test_linux.go
+++ b/xrootd/origin_test_linux.go
@@ -30,8 +30,10 @@ import (
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/daemon"
+	"github.com/pelicanplatform/pelican/director"
 	"github.com/pelicanplatform/pelican/origin_ui"
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
@@ -39,6 +41,12 @@ import (
 
 func TestOrigin(t *testing.T) {
 	viper.Reset()
+
+	OriginServer := server_utils.XRootDServer{
+		ServerType:          string(server_utils.OriginType),
+		NameSpaceAds:        []director.NamespaceAd{},
+		CreateAdvertisement: origin_ui.CreateOriginAdvertisement,
+	}
 
 	viper.Set("Origin.ExportVolume", t.TempDir()+":/test")
 	// Disable functionality we're not using (and is difficult to make work on Mac)
@@ -66,7 +74,7 @@ func TestOrigin(t *testing.T) {
 	err = config.GenerateCert()
 	require.NoError(t, err)
 
-	err = CheckXrootdEnv(true, nil)
+	err = CheckXrootdEnv(OriginServer)
 	require.NoError(t, err)
 
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())

--- a/xrootd/origin_test_linux.go
+++ b/xrootd/origin_test_linux.go
@@ -30,10 +30,8 @@ import (
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/daemon"
-	"github.com/pelicanplatform/pelican/director"
 	"github.com/pelicanplatform/pelican/origin_ui"
 	"github.com/pelicanplatform/pelican/param"
-	"github.com/pelicanplatform/pelican/server_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
@@ -42,11 +40,7 @@ import (
 func TestOrigin(t *testing.T) {
 	viper.Reset()
 
-	OriginServer := server_utils.XRootDServer{
-		ServerType:          string(server_utils.OriginType),
-		NameSpaceAds:        []director.NamespaceAd{},
-		CreateAdvertisement: origin_ui.CreateOriginAdvertisement,
-	}
+	originServer := &origin_ui.OriginServer{}
 
 	viper.Set("Origin.ExportVolume", t.TempDir()+":/test")
 	// Disable functionality we're not using (and is difficult to make work on Mac)
@@ -74,7 +68,7 @@ func TestOrigin(t *testing.T) {
 	err = config.GenerateCert()
 	require.NoError(t, err)
 
-	err = CheckXrootdEnv(OriginServer)
+	err = CheckXrootdEnv(originServer)
 	require.NoError(t, err)
 
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())

--- a/xrootd/origin_test_linux.go
+++ b/xrootd/origin_test_linux.go
@@ -57,7 +57,7 @@ func TestOrigin(t *testing.T) {
 	// Increase the log level; otherwise, its difficult to debug failures
 	viper.Set("Logging.Level", "Debug")
 	config.InitConfig()
-	err := config.InitServer()
+	err := config.InitServer(config.OriginType)
 
 	require.NoError(t, err)
 

--- a/xrootd/resources/test-scitokens-cache-empty.cfg
+++ b/xrootd/resources/test-scitokens-cache-empty.cfg
@@ -19,28 +19,6 @@
 # It will be overwritten on the next startup of pelican.
 #
 
-{{if .Global.Audience}}[Global]
-audience_json = {{JSONify .Global.Audience}}{{end}}
 
-{{range $key, $value := .IssuerMap -}}
-[Issuer {{.Name}}]
-issuer = {{.Issuer}}
-base_path = {{ StringsJoin .BasePaths ", " }}
-{{- if .RestrictedPaths}}
-restricted_path = {{ StringsJoin .RestrictedPaths ", "}}
-{{- end}}
-{{- if .MapSubject}}
-map_subject = {{.MapSubject}}
-{{- end}}
-{{- if .DefaultUser}}
-default_user = {{.DefaultUser}}
-{{- end}}
-{{- if .NameMapfile}}
-name_mapfile = {{.NameMapfile}}
-{{- end}}
-{{- if .UsernameClaim}}
-username_claim = {{.UsernameClaim}}
-{{- end}}
 
-{{end -}}
 # End of config

--- a/xrootd/resources/test-scitokens-cache-issuer.cfg
+++ b/xrootd/resources/test-scitokens-cache-issuer.cfg
@@ -19,28 +19,15 @@
 # It will be overwritten on the next startup of pelican.
 #
 
-{{if .Global.Audience}}[Global]
-audience_json = {{JSONify .Global.Audience}}{{end}}
+[Global]
+audience_json = ["https://issuer1.com","https://issuer2.com"]
 
-{{range $key, $value := .IssuerMap -}}
-[Issuer {{.Name}}]
-issuer = {{.Issuer}}
-base_path = {{ StringsJoin .BasePaths ", " }}
-{{- if .RestrictedPaths}}
-restricted_path = {{ StringsJoin .RestrictedPaths ", "}}
-{{- end}}
-{{- if .MapSubject}}
-map_subject = {{.MapSubject}}
-{{- end}}
-{{- if .DefaultUser}}
-default_user = {{.DefaultUser}}
-{{- end}}
-{{- if .NameMapfile}}
-name_mapfile = {{.NameMapfile}}
-{{- end}}
-{{- if .UsernameClaim}}
-username_claim = {{.UsernameClaim}}
-{{- end}}
+[Issuer https://issuer1.com]
+issuer = https://issuer1.com
+base_path = /p1, /p1_again
 
-{{end -}}
+[Issuer https://issuer2.com]
+issuer = https://issuer2.com
+base_path = /p2/path
+
 # End of config

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -27,9 +27,6 @@ xrd.tlsca certdir {{.Server.TLSCACertificateDirectory}}
 xrd.tlsca certfile {{.Server.TLSCACertificateFile}}
 {{end}}
 http.header2cgi Authorization authz
-{{if .Origin.EnableVoms}}
-http.secxtractor /usr/lib64/libXrdVoms.so
-{{end}}
 http.staticpreload http://static/robots.txt {{.Xrootd.RobotsTxtFile}}
 {{if .Xrootd.Sitename}}
 all.sitename {{.Xrootd.Sitename}}

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -41,6 +41,12 @@ xrootd.monitor all auth flush 30s window 5s fstat 60 lfn ops xfr 5 {{if .Xrootd.
 all.adminpath {{.Xrootd.RunLocation}}
 all.pidpath {{.Xrootd.RunLocation}}
 oss.localroot {{.Xrootd.Mount}}
+xrootd.seclib libXrdSec.so
+sec.protocol ztn
+ofs.authorize 1
+acc.audit deny grant
+acc.authdb {{.Xrootd.RunLocation}}/authfile-generated
+ofs.authlib ++ libXrdAccSciTokens.so config={{.Xrootd.RunLocation}}/scitokens-generated.cfg
 all.export {{.Cache.ExportLocation}}
 xrootd.chksum max 2 md5 adler32 crc32
 xrootd.trace emsg login stall redirect

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -40,7 +40,6 @@ xrd.report {{.Xrootd.SummaryMonitoringHost}}:{{.Xrootd.SummaryMonitoringPort}},1
 xrootd.monitor all auth flush 30s window 5s fstat 60 lfn ops xfr 5 {{if .Xrootd.DetailedMonitoringHost -}} dest redir fstat info files user pfc tcpmon ccm {{.Xrootd.DetailedMonitoringHost}}:{{.Xrootd.DetailedMonitoringPort}} {{- end}} dest redir fstat info files user pfc tcpmon ccm 127.0.0.1:{{.Xrootd.LocalMonitoringPort}}
 all.adminpath {{.Xrootd.RunLocation}}
 all.pidpath {{.Xrootd.RunLocation}}
-oss.localroot {{.Xrootd.Mount}}
 xrootd.seclib libXrdSec.so
 sec.protocol ztn
 ofs.authorize 1
@@ -58,9 +57,12 @@ pfc.writequeue 16 4
 pfc.ram 4g
 pfc.diskusage 0.90 0.95 purgeinterval 300s
 pss.origin {{.Cache.DirectorUrl}}
-pfc.spaces data meta
-oss.space meta {{.Cache.DataLocation}}/meta*
-oss.space data {{.Cache.DataLocation}}/data*
+# FIXME: the oss.space meta / data only works if the meta and data directories are different physical devices.
+# Otherwise, no data space is setup and the cache simply doesn't write out data.
+oss.localroot {{.Cache.DataLocation}}
+#pfc.spaces data meta
+#oss.space meta {{.Cache.DataLocation}}/meta*
+#oss.space data {{.Cache.DataLocation}}/data*
 pss.debug
 pss.setopt DebugLevel 3
 pss.trace all

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -27,6 +27,9 @@ xrd.tlsca certdir {{.Server.TLSCACertificateDirectory}}
 xrd.tlsca certfile {{.Server.TLSCACertificateFile}}
 {{end}}
 http.header2cgi Authorization authz
+{{if .Cache.EnableVoms}}
+http.secxtractor /usr/lib64/libXrdVoms.so
+{{end}}
 http.staticpreload http://static/robots.txt {{.Xrootd.RobotsTxtFile}}
 {{if .Xrootd.Sitename}}
 all.sitename {{.Xrootd.Sitename}}

--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -69,3 +69,4 @@ xrootd.trace emsg login stall redirect
 pfc.trace info
 pss.setopt DebugLevel 1
 xrootd.tls all
+scitokens.trace all

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -292,10 +292,10 @@ func CheckXrootdEnv(server server_utils.XRootDServer) error {
 		}
 	}
 
-	if server.ServerType == string(server_utils.OriginType) {
+	if server.GetServerType().IsSet(config.OriginType) {
 		exportPath, err = CheckOriginXrootdEnv(exportPath, uid, gid, groupname)
 	} else {
-		exportPath, err = CheckCacheXrootdEnv(exportPath, uid, gid, server.NameSpaceAds)
+		exportPath, err = CheckCacheXrootdEnv(exportPath, uid, gid, server.GetNamespaceAds())
 	}
 	if err != nil {
 		return err
@@ -346,7 +346,7 @@ func CheckXrootdEnv(server server_utils.XRootDServer) error {
 			" to desired daemon group %v", authfile, groupname)
 	}
 
-	if err := EmitAuthfile(server.NameSpaceAds); err != nil {
+	if err := EmitAuthfile(server.GetNamespaceAds()); err != nil {
 		return err
 	}
 

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -46,6 +46,7 @@ type (
 
 	CacheConfig struct {
 		UseCmsd        bool
+		EnableVoms     bool
 		ExportLocation string
 		DataLocation   string
 		DirectorUrl    string

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -350,7 +350,7 @@ func CheckXrootdEnv(server server_utils.XRootDServer) error {
 			" to desired daemon group %v", authfile, groupname)
 	}
 
-	if err := EmitAuthfile(server.GetNamespaceAds()); err != nil {
+	if err := EmitAuthfile(server); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Adds authentication to the pelican cache

-- Adds scitokens authenticated to the pelican cache
-- Fixes some errors that were in the namespace registration
-- Does a refactor to move common code out of origin specific folders/functions to be used by both the cache and origin


For ease of understanding, the first 6 commits (up through https://github.com/PelicanPlatform/pelican/pull/423/commits/b0606ce22f6f9ddd5648b94ea2886c965d12ad6d) are the actual cache with auth functionality and all the commits afterwards are the refactor.