### PR TITLE
Update integration test file - update stashcp source

### DIFF
--- a/tests/citests.sh
+++ b/tests/citests.sh
@@ -19,7 +19,7 @@ cp pelican stashcp
 cp pelican stash_plugin
 
 to_exit=0
-./stashcp -d /osgconnect/public/dweitzel/blast/queries/query1 ./
+./stashcp -d osdf:///ospool/uc-shared/public/OSG-Staff/validation/test.txt ./query1
 rm query1
 
 # Test the plugin interface


### PR DESCRIPTION
Just figured out the `./stashcp` source wasn't updated and the integration test keeps failing. I thought for stashcp it by default add `stash:///` to the url you provided but turned out you can directly feed `osdf:///` to use the osdf URL