### PR TITLE
Add supervisor script to make origins servable

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -47,9 +47,10 @@ RUN useradd -o -u 10940 -g 10940 -s /bin/sh xrootd
 
 # Install dependencies
 RUN yum -y update \
-    && yum -y install xrootd xrootd-client xrdcl-http xrootd-server \
+    && yum -y install xrootd xrootd-client xrdcl-http xrootd-server xrootd-scitokens xrootd-voms \
+    xrootd-devel xrootd-client-devel xrootd-server-devel \
+    curl-devel git cmake3 gcc-c++ openssl-devel java-17-openjdk-headless \
     && yum clean all \
-    && yum install -y curl java-17-openjdk-headless \
     && rm -rf /var/cache/yum/
 
 WORKDIR /pelican

--- a/images/supervisord/pelican_origin_serve.conf
+++ b/images/supervisord/pelican_origin_serve.conf
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[program:pelican_origin_serve]
+command=/pelican/osdf-client origin serve %(ENV_OSDF_ORIGIN_ARGS)s
+autostart=false
+autorestart=true
+redirect_stderr=true

--- a/images/supervisord/pelican_origin_serve.conf
+++ b/images/supervisord/pelican_origin_serve.conf
@@ -19,3 +19,9 @@ command=/pelican/osdf-client origin serve %(ENV_OSDF_ORIGIN_ARGS)s
 autostart=false
 autorestart=true
 redirect_stderr=true
+# We can run the origin with all args configured via our pelican.yaml
+# or via individual environment variables, so this environment variable
+# need not be populated. However, if we don't give it at least an empty
+# var, supervisord won't expand it and there will be an error. Set the
+# default to empty.
+environment=OSDF_ORIGIN_ARGS=""


### PR DESCRIPTION
Now our production container can be started with "origin_serve" and the origin supervisord daemon will launch. To make the origin functional, add any origin arguments to the environment variable `OSDF_ORIGIN_ARGS`. For example, to serve an origin on port 8444 that mounts /foo to /namespace/bar in the ITB federation, you'd create the environment variable
```
OSDF_ORIGIN_ARGS="-f https://osg-htc.org/osdf/itb -v /foo:/namespace/bar -p 8444"
```