### PR TITLE
Refactor `checkAPIToken` to be more generic and less verbose

### DIFF
--- a/director/director_api.go
+++ b/director/director_api.go
@@ -20,28 +20,17 @@ package director
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"net/http"
-	"net/url"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
-	"github.com/lestrrat-go/httprc"
 	"github.com/lestrrat-go/jwx/v2/jwa"
-	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-)
-
-var (
-	directorJWK      *jwk.Cache
-	directorMetadata *httprc.Cache
 )
 
 // List all namespaces from origins registered at the director
@@ -73,67 +62,6 @@ func ListServerAds(serverTypes []ServerType) []ServerAd {
 		}
 	}
 	return ads
-}
-
-// Return director's public JWK for token verification. This function can be called
-// on any server (director/origin/registry) as long as the Federation_DirectorUrl is set
-//
-// The director's metadata discovery endpoint and JWKS endpoint are cached
-func LoadDirectorPublicKey() (jwk.Key, error) {
-	directorDiscoveryUrlStr := param.Federation_DirectorUrl.GetString()
-	if len(directorDiscoveryUrlStr) == 0 {
-		return nil, errors.Errorf("Director URL is unset; Can't load director's public key")
-	}
-	log.Debugln("Director's discovery URL:", directorDiscoveryUrlStr)
-	directorDiscoveryUrl, err := url.Parse(directorDiscoveryUrlStr)
-	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintln("Invalid director URL:", directorDiscoveryUrlStr))
-	}
-	directorDiscoveryUrl.Scheme = "https"
-	directorDiscoveryUrl.Path = directorDiscoveryUrl.Path + directorDiscoveryPath
-
-	directorMetadataCtx := context.Background()
-	if directorMetadata == nil {
-		client := &http.Client{Transport: config.GetTransport()}
-		directorMetadata = httprc.NewCache(directorMetadataCtx)
-		if err := directorMetadata.Register(directorDiscoveryUrl.String(), httprc.WithMinRefreshInterval(15*time.Minute), httprc.WithHTTPClient(client)); err != nil {
-			return nil, errors.Wrap(err, "Failed to register cache for director's metadata")
-		}
-	}
-
-	payload, err := directorMetadata.Get(directorMetadataCtx, directorDiscoveryUrl.String())
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get director's metadata")
-	}
-
-	metadata := DiscoveryResponse{}
-
-	err = json.Unmarshal(payload.([]byte), &metadata)
-	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintln("Failure when parsing director metadata at: ", directorDiscoveryUrl))
-	}
-
-	jwksUri := metadata.JwksUri
-
-	directorJwkCtx := context.Background()
-	if directorJWK == nil {
-		client := &http.Client{Transport: config.GetTransport()}
-		directorJWK = jwk.NewCache(directorJwkCtx)
-		if err := directorJWK.Register(jwksUri, jwk.WithRefreshInterval(15*time.Minute), jwk.WithHTTPClient(client)); err != nil {
-			return nil, errors.Wrap(err, "Failed to register cache for director's public JWKS")
-		}
-	}
-
-	jwks, err := directorJWK.Get(directorJwkCtx, jwksUri)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get director's public JWKS")
-	}
-	key, ok := jwks.Key(0)
-	if !ok {
-		return nil, errors.Wrap(err, fmt.Sprintln("Failure when getting director's first public key: ", jwksUri))
-	}
-
-	return key, nil
 }
 
 // Create a token for director's Prometheus instance to access

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -237,7 +237,7 @@ func CreateDirectorScrapeToken() (string, error) {
 	}
 
 	tok, err := jwt.NewBuilder().
-		Claim("scope", "pelican.directorScrape").
+		Claim("scope", "monitoring.scrape").
 		Issuer(directorURL).
 		// The audience of this token is all origins/caches that have WebURL set in their serverAds
 		Audience(aud).

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -34,6 +34,7 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/utils"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -225,7 +226,7 @@ func VerifyDirectorTestReportToken(strToken string) (bool, error) {
 		return false, errors.Errorf("Token issuer is not a director")
 	}
 
-	key, err := LoadDirectorPublicKey()
+	key, err := utils.LoadDirectorPublicKey()
 	if err != nil {
 		return false, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/jellydator/ttlcache/v3 v3.1.0
 	github.com/jsipprell/keyctl v1.0.4-0.20211208153515-36ca02672b6c
+	github.com/lestrrat-go/httprc v1.0.4
 	github.com/lestrrat-go/jwx/v2 v2.0.16
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 	github.com/oklog/run v1.1.0
@@ -100,7 +101,6 @@ require (
 	github.com/leodido/go-urn v1.2.4 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.2 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
-	github.com/lestrrat-go/httprc v1.0.4 // indirect
 	github.com/lestrrat-go/iter v1.0.2 // indirect
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/utils/server_auth.go
+++ b/utils/server_auth.go
@@ -1,0 +1,342 @@
+/***************************************************************
+ *
+ * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+package utils
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/director"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+type (
+	TokenSource int
+	TokenIssuer int
+	AuthOption  struct {
+		Sources []TokenSource
+		Issuers []TokenIssuer
+		Scopes  []string
+	}
+	AuthChecker interface {
+		FederationCheck(ctx *gin.Context, token string, scopes []string) error
+		DirectorCheck(ctx *gin.Context, token string, scopes []string) error
+		IssuerCheck(ctx *gin.Context, token string, scopes []string) error
+	}
+	AuthCheckImpl struct{}
+)
+
+const (
+	Header TokenSource = iota // "Authorization" header
+	Cookie                    // "login" cookie
+	Authz                     // "authz" query parameter
+)
+
+const (
+	Federation TokenIssuer = iota
+	Director
+	Issuer
+)
+
+var (
+	federationJWK *jwk.Cache
+	authChecker   AuthChecker
+)
+
+func init() {
+	authChecker = &AuthCheckImpl{}
+}
+
+// Return if desiredScopes contains the tokenScope and it's case-insensitive
+func scopeContains(tokenScope string, desiredScopes []string) bool {
+	for _, sc := range desiredScopes {
+		if strings.EqualFold(sc, tokenScope) {
+			return true
+		}
+	}
+	return false
+}
+
+// Creates a validator that checks if a token's scope matches the given scope: matchScope.
+// Will pass the check if no "anyScopes".
+// Will pass the check if one token scope matches ANY item in "anyScopes"
+func createScopeValidator(anyScopes []string) jwt.ValidatorFunc {
+
+	return jwt.ValidatorFunc(func(_ context.Context, tok jwt.Token) jwt.ValidationError {
+		// If no scope is present, always return true
+		if len(anyScopes) == 0 {
+			return nil
+		}
+		scope_any, present := tok.Get("scope")
+		if !present {
+			return jwt.NewValidationError(errors.New("No scope is present; required for authorization"))
+		}
+		scope, ok := scope_any.(string)
+		if !ok {
+			return jwt.NewValidationError(errors.New("scope claim in token is not string-valued"))
+		}
+
+		for _, tokenScope := range strings.Split(scope, " ") {
+			// As long as there's one scope in the token that matches the pool of desriedScopes
+			// we say it's valid
+			if scopeContains(tokenScope, anyScopes) {
+				return nil
+			}
+		}
+		return jwt.NewValidationError(errors.New(fmt.Sprint("Token does not contain any of the scopes: ", anyScopes)))
+	})
+}
+
+// Checks that the given token was signed by the federation jwk and also checks that the token has the expected scope
+func (a AuthCheckImpl) FederationCheck(c *gin.Context, strToken string, anyOfTheScopes []string) error {
+	var bKey *jwk.Key
+
+	fedURL := param.Federation_DiscoveryUrl.GetString()
+	token, err := jwt.Parse([]byte(strToken), jwt.WithVerify(false))
+
+	if err != nil {
+		return err
+	}
+
+	if fedURL != token.Issuer() {
+		return errors.New(fmt.Sprint("Issuer is not a federation: ", token.Issuer()))
+	}
+
+	fedURIFile := param.Federation_JwkUrl.GetString()
+	ctx := context.Background()
+	if federationJWK == nil {
+		client := &http.Client{Transport: config.GetTransport()}
+		federationJWK = jwk.NewCache(ctx)
+		if err := federationJWK.Register(fedURIFile, jwk.WithRefreshInterval(15*time.Minute), jwk.WithHTTPClient(client)); err != nil {
+			return errors.Wrap(err, "Failed to register cache for federation's public JWKS")
+		}
+	}
+
+	jwks, err := federationJWK.Get(ctx, fedURIFile)
+	if err != nil {
+		return errors.Wrap(err, "Failed to get federation's public JWKS")
+	}
+	key, ok := jwks.Key(0)
+	if !ok {
+		return errors.Wrap(err, "Failed to get the first key of federation's public JWKS")
+	}
+	bKey = &key
+	var raw ecdsa.PrivateKey
+	if err = (*bKey).Raw(&raw); err != nil {
+		return errors.Wrap(err, "Failed to get raw key of the federation JWK")
+	}
+
+	parsed, err := jwt.Parse([]byte(strToken), jwt.WithKey(jwa.ES256, raw.PublicKey))
+
+	if err != nil {
+		return errors.Wrap(err, "Failed to verify JWT by federation's key")
+	}
+
+	scopeValidator := createScopeValidator(anyOfTheScopes)
+	if err = jwt.Validate(parsed, jwt.WithValidator(scopeValidator)); err != nil {
+		return errors.Wrap(err, "Failed to verify the scope of the token")
+	}
+
+	c.Set("User", "Federation")
+	return nil
+}
+
+// Checks that the given token was signed by the issuer jwk (the one from the server itself) and also checks that
+// the token has the expected scope
+func (a AuthCheckImpl) IssuerCheck(c *gin.Context, strToken string, anyOfTheScopes []string) error {
+	token, err := jwt.Parse([]byte(strToken), jwt.WithVerify(false))
+	if err != nil {
+		return errors.Wrap(err, "Invalid JWT")
+	}
+
+	serverURL := param.Server_ExternalWebUrl.GetString()
+	if serverURL != token.Issuer() {
+		if param.Origin_Url.GetString() == token.Issuer() {
+			return errors.New(fmt.Sprint("Wrong issuer; expect the issuer to be the server's web address but got Origin.URL, " + token.Issuer()))
+		} else {
+			return errors.New(fmt.Sprint("Issuer is not server itself: ", token.Issuer()))
+		}
+	}
+
+	bKey, err := config.GetIssuerPrivateJWK()
+	if err != nil {
+		return errors.Wrap(err, "Failed to load issuer server's private key")
+	}
+
+	var raw ecdsa.PrivateKey
+	if err = bKey.Raw(&raw); err != nil {
+		return errors.Wrap(err, "Failed to get raw key of the issuer's JWK")
+	}
+
+	parsed, err := jwt.Parse([]byte(strToken), jwt.WithKey(jwa.ES256, raw.PublicKey))
+
+	if err != nil {
+		return errors.Wrap(err, "Failed to verify JWT by issuer's key")
+	}
+
+	scopeValidator := createScopeValidator(anyOfTheScopes)
+	if err = jwt.Validate(parsed, jwt.WithValidator(scopeValidator)); err != nil {
+		return errors.Wrap(err, "Failed to verify the scope of the token")
+	}
+
+	c.Set("User", "Origin")
+	return nil
+}
+
+// Check if a JWT string was issued by the director and has the correct scope
+func (a AuthCheckImpl) DirectorCheck(c *gin.Context, strToken string, anyOfTheScopes []string) error {
+	directorURL := param.Federation_DirectorUrl.GetString()
+	if directorURL == "" {
+		return errors.New("Failed to check director; director URL is empty")
+	}
+	token, err := jwt.Parse([]byte(strToken), jwt.WithVerify(false))
+	if err != nil {
+		return errors.Wrap(err, "Invalid JWT")
+	}
+
+	if directorURL != token.Issuer() {
+		return errors.New(fmt.Sprint("Issuer is not a director: ", token.Issuer()))
+	}
+
+	key, err := director.LoadDirectorPublicKey()
+	if err != nil {
+		return errors.Wrap(err, "Failed to load director's public JWK")
+	}
+	tok, err := jwt.Parse([]byte(strToken), jwt.WithKey(jwa.ES256, key), jwt.WithValidate(true))
+	if err != nil {
+		return errors.Wrap(err, "Failed to verify JWT by director's key")
+	}
+
+	scopeValidator := createScopeValidator(anyOfTheScopes)
+	if err = jwt.Validate(tok, jwt.WithValidator(scopeValidator)); err != nil {
+		return errors.Wrap(err, "Failed to verify the scope of the token")
+	}
+
+	c.Set("User", "Director")
+	return nil
+}
+
+// Check token authentication with token obtained from authOption.Sources, found the first
+// token available and proceed to check against a list of authOption.Issuers with
+// authOption.Scopes, return true and set "User" context to the issuer if any of the issuer check succeed
+//
+// Scope check will pass if your token has ANY of the scopes in authOption.Scopes
+func CheckAnyAuth(ctx *gin.Context, authOption AuthOption) bool {
+	token := ""
+	errMsg := ""
+	// Find token from the provided sources list, stop when found the first token
+	tokenFound := false
+	for _, opt := range authOption.Sources {
+		if tokenFound {
+			break
+		}
+		switch opt {
+		case Cookie:
+			cookieToken, err := ctx.Cookie("login")
+			if err != nil || cookieToken == "" {
+				errMsg += fmt.Sprintln("No 'login' cookie present: ", err)
+				continue
+			} else {
+				token = cookieToken
+				tokenFound = true
+				break
+			}
+		case Header:
+			headerToken := ctx.Request.Header["Authorization"]
+			if len(headerToken) <= 0 {
+				errMsg += fmt.Sprintln("No Authorization header present")
+				continue
+			} else {
+				token = strings.TrimPrefix(headerToken[0], "Bearer ")
+				tokenFound = true
+				break
+			}
+		case Authz:
+			authzToken := ctx.Request.URL.Query()["authz"]
+			if len(authzToken) <= 0 {
+				errMsg += fmt.Sprintln("No Authz query parameter present")
+				continue
+			} else {
+				token = authzToken[0]
+				tokenFound = true
+				break
+			}
+		default:
+			log.Info("Authentication failed. Invalid/unsupported token source")
+			return false
+		}
+	}
+
+	if token == "" {
+		log.Info("Authentication failed. No token is present from the list of potential token positions")
+		return false
+	}
+
+	for _, iss := range authOption.Issuers {
+		switch iss {
+		case Federation:
+			err := authChecker.FederationCheck(ctx, token, authOption.Scopes)
+			if _, exists := ctx.Get("User"); err != nil || !exists {
+				errMsg += fmt.Sprintln("Federation Check failed: ", err)
+				log.Debug("Federation Check failed: ", err)
+				break
+			} else {
+				log.Debug("Federation Check succeed")
+				return exists
+			}
+		case Director:
+			err := authChecker.DirectorCheck(ctx, token, authOption.Scopes)
+			if _, exists := ctx.Get("User"); err != nil || !exists {
+				errMsg += fmt.Sprintln("Director Check failed: ", err)
+				log.Debug("Director Check failed: ", err)
+				break
+			} else {
+				log.Debug("Director Check succeed")
+				return exists
+			}
+		case Issuer:
+			err := authChecker.IssuerCheck(ctx, token, authOption.Scopes)
+			if _, exists := ctx.Get("User"); err != nil || !exists {
+				errMsg += fmt.Sprintln("Issuer Check failed: ", err)
+				log.Debug("Issuer Check failed: ", err)
+				break
+			} else {
+				log.Debug("Issuer Check succeed")
+				return exists
+			}
+		default:
+			log.Info("Authentication failed. Invalid/unsupported token issuer")
+			return false
+		}
+	}
+
+	// If the function reaches here, it means no token check passed
+	log.Info("Authentication failed. Didn't pass the chain of checking:\n", errMsg)
+	return false
+}

--- a/utils/server_auth_test.go
+++ b/utils/server_auth_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -54,7 +55,41 @@ func createContextWithToken(cookieToken, headerToken, queryToken string) *gin.Co
 }
 
 func TestScopeContains(t *testing.T) {
+	tests := []struct {
+		name           string
+		tokenScopes    []string
+		expectedScopes []string
+		all            bool
+		want           bool
+	}{
+		{"empty-scopes", []string{}, []string{}, false, false},
+		{"single-match", []string{"read"}, []string{"read"}, false, true},
+		{"no-match", []string{"read"}, []string{"write"}, false, false},
+		{"multiple-matches", []string{"read", "write"}, []string{"read", "write"}, false, true},
+		{"partial-match-all-false", []string{"read", "write"}, []string{"read"}, false, true},
+		{"partial-match-all-true", []string{"read", "write"}, []string{"read"}, true, false},
+		{"case-insensitivity", []string{"Read"}, []string{"read"}, false, true},
+		{"different-lengths-all-true", []string{"read", "write"}, []string{"read"}, true, false},
+		{"exact-match-all-true", []string{"read", "write"}, []string{"write", "read"}, true, true},
+		{"large-input-sets", largeInputSet(), largeInputSet(), false, true},
+		{"nil-inputs", nil, nil, false, false},
+	}
 
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := scopeContains(tt.tokenScopes, tt.expectedScopes, tt.all); got != tt.want {
+				t.Errorf("scopeContains() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func largeInputSet() []string {
+	var scopes []string
+	for i := 0; i < 1000; i++ {
+		scopes = append(scopes, "scope"+strconv.Itoa(i))
+	}
+	return scopes
 }
 
 func TestCheckAnyAuth(t *testing.T) {

--- a/utils/server_auth_test.go
+++ b/utils/server_auth_test.go
@@ -54,9 +54,11 @@ func createContextWithToken(cookieToken, headerToken, queryToken string) *gin.Co
 }
 
 func TestCheckAnyAuth(t *testing.T) {
+	// Use a mock instance of authChecker to simplify testing
 	originalAuthChecker := authChecker
 	defer func() { authChecker = originalAuthChecker }()
 
+	// Create the mock for varioud checkers
 	mock := &MockAuthChecker{
 		FederationCheckFunc: func(ctx *gin.Context, token string, scopes []string) error {
 			if token != "" {
@@ -86,6 +88,7 @@ func TestCheckAnyAuth(t *testing.T) {
 
 	authChecker = mock
 
+	// Batch-create test cases, see "name" section for the purpose of each test case
 	tests := []struct {
 		name       string
 		setupMock  func()
@@ -272,9 +275,12 @@ func TestCheckAnyAuth(t *testing.T) {
 		},
 	}
 
+	// Batch-run the test cases
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.setupMock != nil {
+				// We might have different mocks to the checker function,
+				// so we have this flexibility by calling setupmock if there is such function
 				tc.setupMock()
 			}
 			require.NotNil(t, tc.tokenSetup, "tokenSetup function can't be nil")

--- a/utils/server_auth_test.go
+++ b/utils/server_auth_test.go
@@ -1,0 +1,290 @@
+package utils
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// MockAuthChecker is the mock implementation of AuthChecker.
+type MockAuthChecker struct {
+	FederationCheckFunc func(ctx *gin.Context, token string, scopes []string) error
+	DirectorCheckFunc   func(ctx *gin.Context, token string, scopes []string) error
+	IssuerCheckFunc     func(ctx *gin.Context, token string, scopes []string) error
+}
+
+func (m *MockAuthChecker) FederationCheck(ctx *gin.Context, token string, scopes []string) error {
+	return m.FederationCheckFunc(ctx, token, scopes)
+}
+
+func (m *MockAuthChecker) DirectorCheck(ctx *gin.Context, token string, scopes []string) error {
+	return m.DirectorCheckFunc(ctx, token, scopes)
+}
+
+func (m *MockAuthChecker) IssuerCheck(ctx *gin.Context, token string, scopes []string) error {
+	return m.IssuerCheckFunc(ctx, token, scopes)
+}
+
+// Helper function to create a gin context with different token sources
+func createContextWithToken(cookieToken, headerToken, queryToken string) *gin.Context {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	if cookieToken != "" {
+		r.AddCookie(&http.Cookie{Name: "login", Value: cookieToken})
+	}
+	if headerToken != "" {
+		r.Header.Add("Authorization", "Bearer "+headerToken)
+	}
+	if queryToken != "" {
+		q := r.URL.Query()
+		q.Add("authz", queryToken)
+		r.URL.RawQuery = q.Encode()
+	}
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = r
+
+	return ctx
+}
+
+func TestCheckAnyAuth(t *testing.T) {
+	originalAuthChecker := authChecker
+	defer func() { authChecker = originalAuthChecker }()
+
+	mock := &MockAuthChecker{
+		FederationCheckFunc: func(ctx *gin.Context, token string, scopes []string) error {
+			if token != "" {
+				ctx.Set("User", "Federation")
+				return nil
+			} else {
+				return errors.New("No token is present")
+			}
+		},
+		DirectorCheckFunc: func(ctx *gin.Context, token string, scopes []string) error {
+			if token != "" {
+				ctx.Set("User", "Director")
+				return nil
+			} else {
+				return errors.New("No token is present")
+			}
+		},
+		IssuerCheckFunc: func(ctx *gin.Context, token string, scopes []string) error {
+			if token != "" {
+				ctx.Set("User", "Issuer")
+				return nil
+			} else {
+				return errors.New("No token is present")
+			}
+		},
+	}
+
+	authChecker = mock
+
+	tests := []struct {
+		name       string
+		setupMock  func()
+		tokenSetup func() *gin.Context
+		authOption AuthOption
+		want       bool
+	}{
+		{
+			name: "valid-token-from-cookie-source",
+			authOption: AuthOption{
+				Sources: []TokenSource{Cookie},
+				Issuers: []TokenIssuer{Federation},
+			},
+			tokenSetup: func() *gin.Context {
+				return createContextWithToken("valid-cookie-token", "", "")
+			},
+			want: true,
+		},
+		{
+			name: "valid-token-from-header-source",
+			authOption: AuthOption{
+				Sources: []TokenSource{Header},
+				Issuers: []TokenIssuer{Federation},
+			},
+			tokenSetup: func() *gin.Context {
+				return createContextWithToken("", "valid-header-token", "")
+			},
+			want: true,
+		},
+		{
+			name: "valid-token-from-authz-query-parameter",
+			authOption: AuthOption{
+				Sources: []TokenSource{Authz},
+				Issuers: []TokenIssuer{Federation},
+			},
+			tokenSetup: func() *gin.Context {
+				return createContextWithToken("", "", "valid-query-token")
+			},
+			want: true,
+		},
+		{
+			name: "no-token-present",
+			authOption: AuthOption{
+				Sources: []TokenSource{Cookie, Header, Authz},
+				Issuers: []TokenIssuer{},
+			},
+			tokenSetup: func() *gin.Context {
+				return createContextWithToken("", "", "")
+			},
+			want: false,
+		},
+		{
+			name: "get-first-available-token-from-multiple-sources",
+			authOption: AuthOption{
+				Sources: []TokenSource{Cookie, Header, Authz},
+				Issuers: []TokenIssuer{Federation},
+			},
+			setupMock: func() {
+				mock.FederationCheckFunc = func(ctx *gin.Context, token string, scopes []string) error {
+					if token == "valid-cookie" {
+						ctx.Set("User", "Federation")
+						return nil
+					}
+					return errors.New(fmt.Sprint("Token is not from cookie: ", token))
+				}
+			},
+			tokenSetup: func() *gin.Context {
+				// Set token in both cookie and header, but function should stop at the first valid source
+				return createContextWithToken("valid-cookie", "valid-header", "valid-authz")
+			},
+			want: true,
+		},
+		{
+			name: "valid-token-with-single-issuer",
+			authOption: AuthOption{
+				Sources: []TokenSource{Cookie},
+				Issuers: []TokenIssuer{Federation},
+			},
+			setupMock: func() {
+				mock.FederationCheckFunc = func(ctx *gin.Context, token string, scopes []string) error {
+					if token == "valid-cookie" {
+						ctx.Set("User", "Federation")
+						return nil
+					}
+					return errors.New(fmt.Sprint("Token is not from cookie: ", token))
+				}
+			},
+			tokenSetup: func() *gin.Context {
+				// Set token in both cookie and header, but function should stop at the first valid source
+				return createContextWithToken("valid-cookie", "", "")
+			},
+			want: true,
+		},
+		{
+			name: "invalid-token-with-single-issuer",
+			authOption: AuthOption{
+				Sources: []TokenSource{Cookie},
+				Issuers: []TokenIssuer{Federation},
+			},
+			setupMock: func() {
+				mock.FederationCheckFunc = func(ctx *gin.Context, token string, scopes []string) error {
+					if token == "valid-cookie" {
+						ctx.Set("User", "Federation")
+						return nil
+					}
+					return errors.New(fmt.Sprint("Invalid token: ", token))
+				}
+			},
+			tokenSetup: func() *gin.Context {
+				// Set token in both cookie and header, but function should stop at the first valid source
+				return createContextWithToken("invalid-cookie", "", "")
+			},
+			want: false,
+		},
+		{
+			name: "valid-token-with-multiple-issuer",
+			authOption: AuthOption{
+				Sources: []TokenSource{Cookie},
+				Issuers: []TokenIssuer{Federation, Director, Issuer},
+			},
+			setupMock: func() {
+				mock.FederationCheckFunc = func(ctx *gin.Context, token string, scopes []string) error {
+					if token == "for-federation" {
+						ctx.Set("User", "Federation")
+						return nil
+					}
+					return errors.New(fmt.Sprint("Invalid Token: ", token))
+				}
+				mock.DirectorCheckFunc = func(ctx *gin.Context, token string, scopes []string) error {
+					if token == "for-director" {
+						ctx.Set("User", "Director")
+						return nil
+					}
+					return errors.New(fmt.Sprint("Invalid Token: ", token))
+				}
+				mock.IssuerCheckFunc = func(ctx *gin.Context, token string, scopes []string) error {
+					if token == "for-issuer" {
+						ctx.Set("User", "Issuer")
+						return nil
+					}
+					return errors.New(fmt.Sprint("Invalid Token: ", token))
+				}
+			},
+			tokenSetup: func() *gin.Context {
+				// Set token in both cookie and header, but function should stop at the first valid source
+				return createContextWithToken("for-issuer", "", "")
+			},
+			want: true,
+		},
+		{
+			name: "invalid-token-with-multiple-issuer",
+			authOption: AuthOption{
+				Sources: []TokenSource{Cookie},
+				Issuers: []TokenIssuer{Federation, Director, Issuer},
+			},
+			setupMock: func() {
+				mock.FederationCheckFunc = func(ctx *gin.Context, token string, scopes []string) error {
+					if token == "for-federation" {
+						ctx.Set("User", "Federation")
+						return nil
+					}
+					return errors.New(fmt.Sprint("Invalid Token: ", token))
+				}
+				mock.DirectorCheckFunc = func(ctx *gin.Context, token string, scopes []string) error {
+					if token == "for-director" {
+						ctx.Set("User", "Director")
+						return nil
+					}
+					return errors.New(fmt.Sprint("Invalid Token: ", token))
+				}
+				mock.IssuerCheckFunc = func(ctx *gin.Context, token string, scopes []string) error {
+					if token == "for-issuer" {
+						ctx.Set("User", "Issuer")
+						return nil
+					}
+					return errors.New(fmt.Sprint("Invalid Token: ", token))
+				}
+			},
+			tokenSetup: func() *gin.Context {
+				// Set token in both cookie and header, but function should stop at the first valid source
+				return createContextWithToken("for-nobody", "", "")
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setupMock != nil {
+				tc.setupMock()
+			}
+			require.NotNil(t, tc.tokenSetup, "tokenSetup function can't be nil")
+
+			ctx := tc.tokenSetup()
+
+			if got := CheckAnyAuth(ctx, tc.authOption); got != tc.want {
+				t.Errorf("CheckAnyAuth() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+}

--- a/web_ui/authentication.go
+++ b/web_ui/authentication.go
@@ -142,7 +142,7 @@ func setLoginCookie(ctx *gin.Context, user string) {
 	tok, err := jwt.NewBuilder().
 		// TODO: We might want to come up with some names broader than this for a
 		// generic token for Web APIs, like web_ui.access
-		Claim("scope", "prometheus.read").
+		Claim("scope", []string{"monitoring.query", "monitoring.scrape"}).
 		Issuer(param.Server_ExternalWebUrl.GetString()).
 		IssuedAt(now).
 		Expiration(now.Add(30 * time.Minute)).

--- a/web_ui/authentication.go
+++ b/web_ui/authentication.go
@@ -140,9 +140,9 @@ func setLoginCookie(ctx *gin.Context, user string) {
 
 	now := time.Now()
 	tok, err := jwt.NewBuilder().
-		// TODO: We might want to come up with some names broader than this for a
-		// generic token for Web APIs, like web_ui.access
-		Claim("scope", []string{"monitoring.query", "monitoring.scrape"}).
+		// The value of the "scope" claim is a JSON string containing a space-separated
+		// list of scopes associated with the token
+		Claim("scope", "monitoring.query monitoring.scrape").
 		Issuer(param.Server_ExternalWebUrl.GetString()).
 		IssuedAt(now).
 		Expiration(now.Add(30 * time.Minute)).

--- a/web_ui/authorization.go
+++ b/web_ui/authorization.go
@@ -215,7 +215,7 @@ func CreatePromMetricToken() (string, error) {
 	tokenExpireTime := param.Monitoring_TokenExpiresIn.GetDuration()
 
 	tok, err := jwt.NewBuilder().
-		Claim("scope", "pelican.promMetric").
+		Claim("scope", "monitoring.scrape").
 		Issuer(serverURL).
 		Audience([]string{serverURL}).
 		Subject(serverURL).
@@ -312,7 +312,7 @@ func promMetricAuthHandler(ctx *gin.Context) {
 		}
 		// For /metrics endpoint, auth is granted if the request is from either
 		// 1.director scraper 2.server scraper 3.authenticated user (through web)
-		valid := checkAPIToken(ctx, []string{"pelican.directorScrape", "pelican.promMetric", "prometheus.read"})
+		valid := checkAPIToken(ctx, []string{"monitoring.scrape"})
 		if !valid {
 			ctx.AbortWithStatusJSON(403, gin.H{"error": "Authentication required to access this endpoint."})
 		}

--- a/web_ui/authorization.go
+++ b/web_ui/authorization.go
@@ -18,195 +18,19 @@
 package web_ui
 
 import (
-	"context"
-	"crypto/ecdsa"
-	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/lestrrat-go/jwx/v2/jwa"
-	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/pelicanplatform/pelican/config"
-	pelican_config "github.com/pelicanplatform/pelican/config"
-	"github.com/pelicanplatform/pelican/director"
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/utils"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
+	"github.com/prometheus/common/route"
 )
-
-var federationJWK *jwk.Cache
-
-// Return if desiredScopes contains the tokenScope and it's case-insensitive
-func scopeContains(tokenScope string, desiredScopes []string) bool {
-	for _, sc := range desiredScopes {
-		if strings.EqualFold(sc, tokenScope) {
-			return true
-		}
-	}
-	return false
-}
-
-// Creates a validator that checks if a token's scope matches the given scope: matchScope.
-// Will pass the check if no "anyScopes".
-// Will pass the check if one token scope matches ANY item in "anyScopes"
-func createScopeValidator(anyScopes []string) jwt.ValidatorFunc {
-
-	return jwt.ValidatorFunc(func(_ context.Context, tok jwt.Token) jwt.ValidationError {
-		// If no scope is present, always return true
-		if len(anyScopes) == 0 {
-			return nil
-		}
-		scope_any, present := tok.Get("scope")
-		if !present {
-			return jwt.NewValidationError(errors.New("No scope is present; required for authorization"))
-		}
-		scope, ok := scope_any.(string)
-		if !ok {
-			return jwt.NewValidationError(errors.New("scope claim in token is not string-valued"))
-		}
-
-		for _, tokenScope := range strings.Split(scope, " ") {
-			// As long as there's one scope in the token that matches the pool of desriedScopes
-			// we say it's valid
-			if scopeContains(tokenScope, anyScopes) {
-				return nil
-			}
-		}
-		return jwt.NewValidationError(errors.New(fmt.Sprint("Token does not contain any of the scopes: ", anyScopes)))
-	})
-}
-
-// Checks that the given token was signed by the federation jwk and also checks that the token has the expected scope
-func FederationCheck(c *gin.Context, strToken string, anyOfTheScopes []string) error {
-	var bKey *jwk.Key
-
-	fedURL := param.Federation_DiscoveryUrl.GetString()
-	token, err := jwt.Parse([]byte(strToken), jwt.WithVerify(false))
-
-	if err != nil {
-		return err
-	}
-
-	if fedURL != token.Issuer() {
-		return errors.New(fmt.Sprint("Issuer is not a federation: ", token.Issuer()))
-	}
-
-	fedURIFile := param.Federation_JwkUrl.GetString()
-	ctx := context.Background()
-	if federationJWK == nil {
-		client := &http.Client{Transport: config.GetTransport()}
-		federationJWK = jwk.NewCache(ctx)
-		if err := federationJWK.Register(fedURIFile, jwk.WithRefreshInterval(15*time.Minute), jwk.WithHTTPClient(client)); err != nil {
-			return errors.Wrap(err, "Failed to register cache for federation's public JWKS")
-		}
-	}
-
-	jwks, err := federationJWK.Get(ctx, fedURIFile)
-	if err != nil {
-		return errors.Wrap(err, "Failed to get federation's public JWKS")
-	}
-	key, ok := jwks.Key(0)
-	if !ok {
-		return errors.Wrap(err, "Failed to get the first key of federation's public JWKS")
-	}
-	bKey = &key
-	var raw ecdsa.PrivateKey
-	if err = (*bKey).Raw(&raw); err != nil {
-		return errors.Wrap(err, "Failed to get raw key of the federation JWK")
-	}
-
-	parsed, err := jwt.Parse([]byte(strToken), jwt.WithKey(jwa.ES256, raw.PublicKey))
-
-	if err != nil {
-		return errors.Wrap(err, "Failed to verify JWT by federation's key")
-	}
-
-	scopeValidator := createScopeValidator(anyOfTheScopes)
-	if err = jwt.Validate(parsed, jwt.WithValidator(scopeValidator)); err != nil {
-		return errors.Wrap(err, "Failed to verify the scope of the token")
-	}
-
-	c.Set("User", "Federation")
-	return nil
-}
-
-// Checks that the given token was signed by the issuer jwk (the one from the server itself) and also checks that
-// the token has the expected scope
-func IssuerCheck(c *gin.Context, strToken string, anyOfTheScopes []string) error {
-	token, err := jwt.Parse([]byte(strToken), jwt.WithVerify(false))
-	if err != nil {
-		return errors.Wrap(err, "Invalid JWT")
-	}
-
-	serverURL := param.Server_ExternalWebUrl.GetString()
-	if serverURL != token.Issuer() {
-		if param.Origin_Url.GetString() == token.Issuer() {
-			return errors.New(fmt.Sprint("Wrong issuer; expect the issuer to be the server's web address but got Origin.URL, " + token.Issuer()))
-		} else {
-			return errors.New(fmt.Sprint("Issuer is not server itself: ", token.Issuer()))
-		}
-	}
-
-	bKey, err := pelican_config.GetIssuerPrivateJWK()
-	if err != nil {
-		return errors.Wrap(err, "Failed to load issuer server's private key")
-	}
-
-	var raw ecdsa.PrivateKey
-	if err = bKey.Raw(&raw); err != nil {
-		return errors.Wrap(err, "Failed to get raw key of the issuer's JWK")
-	}
-
-	parsed, err := jwt.Parse([]byte(strToken), jwt.WithKey(jwa.ES256, raw.PublicKey))
-
-	if err != nil {
-		return errors.Wrap(err, "Failed to verify JWT by issuer's key")
-	}
-
-	scopeValidator := createScopeValidator(anyOfTheScopes)
-	if err = jwt.Validate(parsed, jwt.WithValidator(scopeValidator)); err != nil {
-		return errors.Wrap(err, "Failed to verify the scope of the token")
-	}
-
-	c.Set("User", "Origin")
-	return nil
-}
-
-// Check if a JWT string was issued by the director and has the correct scope
-func DirectorCheck(c *gin.Context, strToken string, anyOfTheScopes []string) error {
-	directorURL := param.Federation_DirectorUrl.GetString()
-	if directorURL == "" {
-		return errors.New("Failed to check director; director URL is empty")
-	}
-	token, err := jwt.Parse([]byte(strToken), jwt.WithVerify(false))
-	if err != nil {
-		return errors.Wrap(err, "Invalid JWT")
-	}
-
-	if directorURL != token.Issuer() {
-		return errors.New(fmt.Sprint("Issuer is not a director: ", token.Issuer()))
-	}
-
-	key, err := director.LoadDirectorPublicKey()
-	if err != nil {
-		return errors.Wrap(err, "Failed to load director's public JWK")
-	}
-	tok, err := jwt.Parse([]byte(strToken), jwt.WithKey(jwa.ES256, key), jwt.WithValidate(true))
-	if err != nil {
-		return errors.Wrap(err, "Failed to verify JWT by director's key")
-	}
-
-	scopeValidator := createScopeValidator(anyOfTheScopes)
-	if err = jwt.Validate(tok, jwt.WithValidator(scopeValidator)); err != nil {
-		return errors.Wrap(err, "Failed to verify the scope of the token")
-	}
-
-	c.Set("User", "Director")
-	return nil
-}
 
 // Create a token for accessing Prometheus /metrics endpoint on
 // the server itself
@@ -237,70 +61,6 @@ func CreatePromMetricToken() (string, error) {
 	return string(signed), nil
 }
 
-// Check if a valid token is present for most of the server's internal
-// API endpoints and Web API endpoints. It checkes if a JWT is present in
-// either authz query param, Authorization header (Bearer), and cookie's "login" key
-// and was issued by either the federation/director/or a server itself
-// For token scopes, it checks if the token has ANY of the scopes provided in anyScopes
-func checkAPIToken(ctx *gin.Context, anyScopes []string) bool {
-	strToken := ""
-	errMsg := ""
-
-	if authzQuery := ctx.Request.URL.Query()["authz"]; len(authzQuery) > 0 {
-		strToken = authzQuery[0]
-	} else if authzHeader := ctx.Request.Header["Authorization"]; len(authzHeader) > 0 {
-		strToken = strings.TrimPrefix(authzHeader[0], "Bearer ")
-	}
-
-	hasCredential := false
-	if strToken != "" {
-		hasCredential = true
-		err := FederationCheck(ctx, strToken, anyScopes)
-		if _, exists := ctx.Get("User"); err != nil || !exists {
-			errMsg += fmt.Sprintln("Federation Check failed; continue to issuer check: ", err)
-			log.Debug("Federation Check failed; continue to issuer check: ", err)
-		} else {
-			log.Debug("Federation Check succeed")
-			return exists
-		}
-		err = IssuerCheck(ctx, strToken, anyScopes)
-		if _, exists := ctx.Get("User"); err != nil || !exists {
-			errMsg += fmt.Sprintln("Issuer Check failed; continue to director check: ", err)
-			log.Debug("Issuer Check failed; continue to director check: ", err)
-		} else {
-			log.Debug("Issuer Check succeed")
-			return exists
-		}
-		err = DirectorCheck(ctx, strToken, anyScopes)
-		if _, exists := ctx.Get("User"); err != nil || !exists {
-			errMsg += fmt.Sprintln("Director Check failed; continue to see if token is for user login: ", err)
-			log.Debug("Director Check failed; continue to see if token is for user login: ", err)
-		} else {
-			log.Debug("Director Check succeed")
-			return exists
-		}
-	}
-
-	strToken, err := ctx.Cookie("login")
-	if err == nil && strToken != "" {
-		hasCredential = true
-		if err = IssuerCheck(ctx, strToken, anyScopes); err != nil {
-			errMsg += fmt.Sprintln("Issuer check from cookie's token failed: ", err)
-			log.Debug("Issuer check from cookie's token failed: ", err)
-		}
-	} else {
-		errMsg += fmt.Sprintln("No cookie present for token: ", err)
-	}
-
-	// It will only check if the token is valid and set this context key-pair.
-	// Futher steps requried to finish the auth process (i.e. return 401)
-	_, exists := ctx.Get("User")
-	if !exists && hasCredential {
-		log.Info("Authentication failed. Didn't pass chain of checking:\n", errMsg)
-	}
-	return exists
-}
-
 // Handle the authorization of Prometheus /metrics endpoint by checking
 // if a valid token is present with correct scope
 func promMetricAuthHandler(ctx *gin.Context) {
@@ -310,9 +70,14 @@ func promMetricAuthHandler(ctx *gin.Context) {
 			ctx.Next()
 			return
 		}
-		// For /metrics endpoint, auth is granted if the request is from either
-		// 1.director scraper 2.server scraper 3.authenticated user (through web)
-		valid := checkAPIToken(ctx, []string{"monitoring.scrape"})
+		// Auth is granted if the request is from either
+		// 1.director scraper 2.server (self) scraper 3.authenticated web user (via cookie)
+		authOption := utils.AuthOption{
+			Sources: []utils.TokenSource{utils.Header, utils.Cookie},
+			Issuers: []utils.TokenIssuer{utils.Director, utils.Issuer},
+			Scopes:  []string{"monitoring.scrape"}}
+
+		valid := utils.CheckAnyAuth(ctx, authOption)
 		if !valid {
 			ctx.AbortWithStatusJSON(403, gin.H{"error": "Authentication required to access this endpoint."})
 		}
@@ -321,4 +86,24 @@ func promMetricAuthHandler(ctx *gin.Context) {
 	}
 	// We don't care about other routes for this handler
 	ctx.Next()
+}
+
+// Handle the authorization of Prometheus query engine endpoint at `/api/v1.0/prometheus`.
+// For now we only allow web user to access the engine
+func promQueryEngineAuthHandler(av1 *route.Router) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authOption := utils.AuthOption{
+			// Only allow web user to access for now, can add "Header" later if we
+			// want grafana to access it
+			Sources: []utils.TokenSource{utils.Cookie},
+			Issuers: []utils.TokenIssuer{utils.Issuer},
+			Scopes:  []string{"monitoring.query"}}
+
+		exists := utils.CheckAnyAuth(c, authOption)
+		if exists {
+			av1.ServeHTTP(c.Writer, c.Request)
+		} else {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Correct authorization required to access Prometheus query engine APIs"})
+		}
+	}
 }

--- a/web_ui/authorization.go
+++ b/web_ui/authorization.go
@@ -88,14 +88,12 @@ func promMetricAuthHandler(ctx *gin.Context) {
 	ctx.Next()
 }
 
-// Handle the authorization of Prometheus query engine endpoint at `/api/v1.0/prometheus`.
-// For now we only allow web user to access the engine
+// Handle the authorization of Prometheus query engine endpoint at `/api/v1.0/prometheus`
 func promQueryEngineAuthHandler(av1 *route.Router) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		authOption := utils.AuthOption{
-			// Only allow web user to access for now, can add "Header" later if we
-			// want grafana to access it
-			Sources: []utils.TokenSource{utils.Cookie},
+			// Cookie for web user access and header for external service like Grafana to access
+			Sources: []utils.TokenSource{utils.Cookie, utils.Header},
 			Issuers: []utils.TokenIssuer{utils.Issuer},
 			Scopes:  []string{"monitoring.query"}}
 

--- a/web_ui/authorization.go
+++ b/web_ui/authorization.go
@@ -34,7 +34,7 @@ import (
 
 // Create a token for accessing Prometheus /metrics endpoint on
 // the server itself
-func CreatePromMetricToken() (string, error) {
+func createPromMetricToken() (string, error) {
 	serverURL := param.Server_ExternalWebUrl.GetString()
 	tokenExpireTime := param.Monitoring_TokenExpiresIn.GetDuration()
 

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -144,22 +144,6 @@ func runtimeInfo() (api_v1.RuntimeInfo, error) {
 	return api_v1.RuntimeInfo{}, nil
 }
 
-func promQueryEngineAuthHandler(av1 *route.Router) gin.HandlerFunc {
-	/* A function which wraps around the av1 router to force a jwk token check using
-	 * the origin's private key. It will check the request's URL and Header for a token
-	 * and if found it will then attempt to validate the token. If valid, it will continue
-	 * the routing as normal, otherwise it will return an error
-	 */
-	return func(c *gin.Context) {
-		exists := checkAPIToken(c, []string{"monitoring.query"})
-		if exists {
-			av1.ServeHTTP(c.Writer, c.Request)
-		} else {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Correct authorization required to access Prometheus query engine APIs"})
-		}
-	}
-}
-
 // Configure director's Prometheus scraper to use HTTP service discovery for origins
 func configDirectorPromScraper() (*config.ScrapeConfig, error) {
 	originDiscoveryUrl, err := url.Parse(param.Server_ExternalWebUrl.GetString())

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -151,7 +151,7 @@ func promQueryEngineAuthHandler(av1 *route.Router) gin.HandlerFunc {
 	 * the routing as normal, otherwise it will return an error
 	 */
 	return func(c *gin.Context) {
-		exists := checkAPIToken(c, []string{"prometheus.read"})
+		exists := checkAPIToken(c, []string{"monitoring.query"})
 		if exists {
 			av1.ServeHTTP(c.Writer, c.Request)
 		} else {

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -334,7 +334,7 @@ func ConfigureEmbeddedPrometheus(engine *gin.Engine, isDirector bool) error {
 		ScrapeConfigs: make([]*config.ScrapeConfig, 1),
 	}
 
-	selfScraperToken, err := CreatePromMetricToken()
+	selfScraperToken, err := createPromMetricToken()
 	if err != nil {
 		return fmt.Errorf("Failed to generate token for self-scraper at start: %v", err)
 	}
@@ -647,7 +647,7 @@ func ConfigureEmbeddedPrometheus(engine *gin.Engine, isDirector bool) error {
 							globalConfigMtx.Lock()
 							defer globalConfigMtx.Unlock()
 							// Create a new self-scrape token
-							selfScraperToken, err := CreatePromMetricToken()
+							selfScraperToken, err := createPromMetricToken()
 							if err != nil {
 								return fmt.Errorf("Failed to generate token for self-scraper at start: %v", err)
 							}

--- a/web_ui/prometheus_test.go
+++ b/web_ui/prometheus_test.go
@@ -23,11 +23,9 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/base64"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -41,7 +39,6 @@ import (
 	"github.com/prometheus/common/route"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestPrometheusProtectionFederationURL(t *testing.T) {
@@ -60,75 +57,33 @@ func TestPrometheusProtectionFederationURL(t *testing.T) {
 	// Create temp dir for the origin key file
 	tDir := t.TempDir()
 	kfile := filepath.Join(tDir, "testKey")
-
-	//Setup a private key and a token
+	//Setup a private key
 	viper.Set("IssuerKey", kfile)
-	config.InitConfig()
-	require.NoError(t, config.InitServer(), "Error calling InitServer")
 
 	w := httptest.NewRecorder()
 	c, r := gin.CreateTestContext(w)
-	// Note, this handler function intercepts the "http.Get call to the federation uri
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		issuerKeyFile := param.IssuerKey.GetString()
-		contents, err := os.ReadFile(issuerKeyFile)
-		if err != nil {
-			t.Fatal(err)
-		}
-		_, err = w.Write(contents)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}))
-	defer ts.Close()
+
+	// Set ExternalWebUrl so that IssuerCheck can pass
+	viper.Set("Server.ExternalWebUrl", "https://test-origin.org:8444")
+
 	c.Request = &http.Request{
 		URL: &url.URL{},
 	}
 
-	privateKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
-	assert.NoError(t, err, "Error generating private key")
-
-	// Convert from raw ecdsa to jwk.Key
-	pKey, err := jwk.FromRaw(privateKey)
-	assert.NoError(t, err, "Unable to convert ecdsa.PrivateKey to jwk.Key")
-
-	//Assign Key id to the private key
-	err = jwk.AssignKeyID(pKey)
-	assert.NoError(t, err, "Error assigning kid to private key")
-
-	//Set an algorithm for the key
-	err = pKey.Set(jwk.AlgorithmKey, jwa.ES512)
-	assert.NoError(t, err, "Unable to set algorithm for pKey")
-
-	buf, err := json.MarshalIndent(pKey, "", " ")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = os.WriteFile(kfile, buf, 0644)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Create a token
-	issuerURL := url.URL{}
-	issuerURL.Scheme = "https"
-	issuerURL.Host = "test-http"
-
 	jti_bytes := make([]byte, 16)
-	_, err = rand.Read(jti_bytes)
+	_, err := rand.Read(jti_bytes)
 	if err != nil {
 		t.Fatal(err)
 	}
 	jti := base64.RawURLEncoding.EncodeToString(jti_bytes)
 
-	originUrl := param.Origin_Url.GetString()
+	issuerUrl := param.Server_ExternalWebUrl.GetString()
 	tok, err := jwt.NewBuilder().
 		Claim("scope", "monitoring.query").
 		Claim("wlcg.ver", "1.0").
 		JwtID(jti).
-		Issuer(issuerURL.String()).
-		Audience([]string{originUrl}).
+		Issuer(issuerUrl).
+		Audience([]string{issuerUrl}).
 		Subject("sub").
 		Expiration(time.Now().Add(time.Minute)).
 		IssuedAt(time.Now()).
@@ -138,18 +93,17 @@ func TestPrometheusProtectionFederationURL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Sign the token with the origin private key
-	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256, pKey))
-
+	pkey, err := config.GetIssuerPrivateJWK()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	//Set the Federation information so as not to run through all of DiscoverFederation (that should be a tested elsewhere)
-	viper.Set("Federation.DiscoveryUrl", "https://test-http")
-	viper.Set("Federation.DirectorUrl", "https://test-director")
-	viper.Set("Federation.NamespaceUrl", "https://test-namesapce")
-	viper.Set("Federation.JwkUrl", ts.URL)
+	// Sign the token with the origin private key
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256, pkey))
+
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Set the request to run through the promQueryEngineAuthHandler function
 	r.GET("/api/v1.0/prometheus/*any", promQueryEngineAuthHandler(av1))
@@ -172,8 +126,7 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 	 */
 
 	viper.Reset()
-	viper.Set("Server.Hostname", "test-https")
-	viper.Set("Server.WebPort", "8444")
+	viper.Set("Server.ExternalWebUrl", "https://test-origin.org:8444")
 
 	av1 := route.New().WithPrefix("/api/v1.0/prometheus")
 
@@ -191,15 +144,8 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 		URL: &url.URL{},
 	}
 
-	// Generate the origin private and public keys
-	_, err := config.GetIssuerPublicJWKS()
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Load the private key
-	privKey, err := config.LoadPrivateKey(kfile)
+	privKey, err := config.GetIssuerPrivateJWK()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,13 +158,13 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 	}
 	jti := base64.RawURLEncoding.EncodeToString(jti_bytes)
 
-	originUrl := param.Origin_Url.GetString()
+	issuerUrl := param.Server_ExternalWebUrl.GetString()
 	tok, err := jwt.NewBuilder().
 		Claim("scope", "monitoring.query").
 		Claim("wlcg.ver", "1.0").
 		JwtID(jti).
-		Issuer(param.Server_ExternalWebUrl.GetString()).
-		Audience([]string{originUrl}).
+		Issuer(issuerUrl).
+		Audience([]string{issuerUrl}).
 		Subject("sub").
 		Expiration(time.Now().Add(time.Minute)).
 		IssuedAt(time.Now()).
@@ -282,8 +228,8 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 		Claim("scope", "monitoring.query").
 		Claim("wlcg.ver", "1.0").
 		JwtID(jti).
-		Issuer(param.Server_ExternalWebUrl.GetString()).
-		Audience([]string{originUrl}).
+		Issuer(issuerUrl).
+		Audience([]string{issuerUrl}).
 		Subject("sub").
 		Expiration(time.Now().Add(time.Minute)).
 		IssuedAt(time.Now()).
@@ -318,8 +264,8 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 		Claim("scope", "not.prometheus").
 		Claim("wlcg.ver", "1.0").
 		JwtID(jti).
-		Issuer(param.Server_ExternalWebUrl.GetString()).
-		Audience([]string{originUrl}).
+		Issuer(issuerUrl).
+		Audience([]string{issuerUrl}).
 		Subject("sub").
 		Expiration(time.Now().Add(time.Minute)).
 		IssuedAt(time.Now()).
@@ -358,7 +304,7 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 
 	now := time.Now()
 	tok, err = jwt.NewBuilder().
-		Issuer(param.Server_ExternalWebUrl.GetString()).
+		Issuer(issuerUrl).
 		Claim("scope", "monitoring.query").
 		Claim("wlcg.ver", "1.0").
 		IssuedAt(now).

--- a/web_ui/prometheus_test.go
+++ b/web_ui/prometheus_test.go
@@ -121,7 +121,7 @@ func TestPrometheusProtectionFederationURL(t *testing.T) {
 
 	originUrl := param.Origin_Url.GetString()
 	tok, err := jwt.NewBuilder().
-		Claim("scope", "prometheus.read").
+		Claim("scope", "monitoring.query").
 		Claim("wlcg.ver", "1.0").
 		JwtID(jti).
 		Issuer(issuerURL.String()).
@@ -213,7 +213,7 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 
 	originUrl := param.Origin_Url.GetString()
 	tok, err := jwt.NewBuilder().
-		Claim("scope", "prometheus.read").
+		Claim("scope", "monitoring.query").
 		Claim("wlcg.ver", "1.0").
 		JwtID(jti).
 		Issuer(param.Server_ExternalWebUrl.GetString()).
@@ -278,7 +278,7 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 
 	// Create a new token to be used
 	tok, err = jwt.NewBuilder().
-		Claim("scope", "prometheus.read").
+		Claim("scope", "monitoring.query").
 		Claim("wlcg.ver", "1.0").
 		JwtID(jti).
 		Issuer(param.Server_ExternalWebUrl.GetString()).
@@ -358,7 +358,7 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 	now := time.Now()
 	tok, err = jwt.NewBuilder().
 		Issuer(param.Server_ExternalWebUrl.GetString()).
-		Claim("scope", "prometheus.read").
+		Claim("scope", "monitoring.query").
 		Claim("wlcg.ver", "1.0").
 		IssuedAt(now).
 		Expiration(now.Add(30 * time.Minute)).


### PR DESCRIPTION
Closes #405 

* Refactored out `checkAPIToken` as `CheckAnyAuth` into `utils` package and migrate dependency functions to `utils` as well
* Rename Prometheus token scopes
* Use cache for JWKS