### PR TITLE
Fix bad error message from director

### DIFF
--- a/client/director.go
+++ b/client/director.go
@@ -162,7 +162,11 @@ func QueryDirector(source string, directorUrl string) (resp *http.Response, err 
 
 	// Check HTTP response -- should be 307 (redirect), else something went wrong
 	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != 307 {
+
+	// If we get a 404, the director will hopefully tell us why. It might be that the namespace doesn't exist
+	if resp.StatusCode == 404 {
+		return nil, errors.New("404: " + string(body))
+	} else if resp.StatusCode != 307 {
 		var respErr directorResponse
 		if unmarshalErr := json.Unmarshal(body, &respErr); unmarshalErr != nil { // Error creating json
 			return nil, errors.Wrap(unmarshalErr, "Could not unmarshall the director's response")


### PR DESCRIPTION
When a client tries to `object copy` a file from a non-existant namespace, the client spits out an error of the form "Error from Director: Failure to unmarshal Director response: Unknown character N", or something like that. That's gobbeldygook, when a curl of the director clearly states "Namespace does not exist" or "No caches for that path" or something helpful. This makes the client check specifically for a 404, and in that case, it prints the body of the response, which _should_ have a helpful error message.