### PR TITLE
Fixed non running e2e test

### DIFF
--- a/xrootd/origin_test.go
+++ b/xrootd/origin_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /***************************************************************
  *
  * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research


### PR DESCRIPTION
Changed the name of `xrootd/origin_test_linux.go` to `xrootd/origin_test.go` so it will run as a unit test