### PR TITLE
Fix racing conditions in various director-related code and tests

### DIFF
--- a/director/director_api.go
+++ b/director/director_api.go
@@ -272,6 +272,8 @@ func ConfigTTLCache(ctx context.Context, wg *sync.WaitGroup) {
 	go namespaceKeys.Start()
 
 	serverAds.OnEviction(func(ctx context.Context, er ttlcache.EvictionReason, i *ttlcache.Item[ServerAd, []NamespaceAd]) {
+		healthTestCancelFuncsMutex.Lock()
+		defer healthTestCancelFuncsMutex.Unlock()
 		if cancelFunc, exists := healthTestCancelFuncs[i.Key()]; exists {
 			// Call the cancel function for the evicted originAd to end its health test
 			cancelFunc()


### PR DESCRIPTION
Fix #435 

Besides what mentioned in #435, this PR also introduced lock for the map to store cancel functions for direct-based-health-test (`healthTestCancelFuncs`)