### PR TITLE
Refactor `generate` package

### DIFF
--- a/generate/main.go
+++ b/generate/main.go
@@ -1,0 +1,13 @@
+package main
+
+//go:generate go run ../generate
+
+// This should not be included in any release of pelican
+
+// Include more generator functions here but keep them encapsulated
+// in their separate files under `generate` package
+func main() {
+	GenParamEnum()
+	GenParamStruct()
+	GenPlaceholderPathForNext()
+}

--- a/generate/next_generator.go
+++ b/generate/next_generator.go
@@ -1,5 +1,7 @@
 package main
 
+// This should not be included in any release of pelican
+
 import (
 	"log"
 	"os"

--- a/generate/param_generator.go
+++ b/generate/param_generator.go
@@ -25,12 +25,6 @@ type TemplateData struct {
 	GeneratedCode string
 }
 
-func main() {
-	GenParamEnum()
-	GenParamStruct()
-	GenPlaceholderPathForNext()
-}
-
 var requiredKeys = [3]string{"description", "default", "type"}
 
 func GenParamEnum() {

--- a/param/param.go
+++ b/param/param.go
@@ -7,8 +7,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-//go:generate go run ../generate
-
 var (
 	viperConfig *config
 	configMutex sync.RWMutex


### PR DESCRIPTION
Close #304 

One question for the reviewer is that do we _actually_  want to exclude the generator files for the release? I tried to use `//go:build ignore` in the `generate` package but that will make `go generate` malfunction with missing function import in between Go files.