### PR TITLE
Arm-compatible Pelican container and fix 404 minio RPM

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -37,7 +37,7 @@ COPY --from=website-build /webapp/out ./web_ui/frontend/out
 
 RUN goreleaser --clean --snapshot
 
-FROM hub.opensciencegrid.org/sciauth/scitokens-oauth2-server:release-20231118-1823 AS scitokens-oauth2-server
+FROM --platform=linux/amd64 hub.opensciencegrid.org/sciauth/scitokens-oauth2-server:release-20231118-1823 AS scitokens-oauth2-server
 
 FROM --platform=linux/amd64 opensciencegrid/software-base:$BASE_OSG_SERIES-el8-$BASE_YUM_REPO
 

--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -120,9 +120,13 @@ RUN \
 
 # For S3 tests, we need the minIO server client, so we install based on detected arch
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        dnf install -y https://dl.min.io/server/minio/release/linux-amd64/minio-20231202105133.0.0.x86_64.rpm; \
+        curl -o minio.rpm https://dl.min.io/server/minio/release/linux-amd64/archive/minio-20231202105133.0.0.x86_64.rpm &&\
+        dnf install -y minio.rpm &&\
+        rm -f minio.rpm; \
     elif [ "$TARGETARCH" = "arm64" ]; then \
-        dnf install -y https://dl.min.io/server/minio/release/linux-arm64/minio-20231202105133.0.0.aarch64.rpm; \
+        curl -o minio.rpm https://dl.min.io/server/minio/release/linux-arm64/archive/minio-20231202105133.0.0.aarch64.rpm &&\
+        dnf install -y minio.rpm &&\
+        rm -f minio.rpm; \
     fi
 
 WORKDIR /app


### PR DESCRIPTION
Fixes #438 
Also fixed the current CI/CD release error with minio RPM missing by changing the package URL to archive with the pinned version.