### PR TITLE
Fix progress bars w/ recursive uploads and downloads

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -332,6 +332,9 @@ func download_http(sourceUrl *url.URL, destination string, payload *payloadStruc
 	results := make(chan TransferResults, len(files))
 	//tf := TransferFiles{files: files}
 
+	if ObjectClientOptions.Recursive && ObjectClientOptions.ProgressBars {
+		log.SetOutput(progressContainer)
+	}
 	// Start the workers
 	for i := 1; i <= 5; i++ {
 		wg.Add(1)
@@ -363,8 +366,9 @@ func download_http(sourceUrl *url.URL, destination string, payload *payloadStruc
 		}
 	}
 	// Make sure to close the progressContainer after all download complete
-	if ObjectClientOptions.Recursive {
+	if ObjectClientOptions.Recursive && ObjectClientOptions.ProgressBars {
 		progressContainer.Wait()
+		log.SetOutput(os.Stdout)
 	}
 	return downloaded, downloadError
 
@@ -763,6 +767,9 @@ func UploadDirectory(src string, dest *url.URL, token string, namespace namespac
 		return 0, err
 	}
 
+	if ObjectClientOptions.ProgressBars {
+		log.SetOutput(progressContainer)
+	}
 	// Upload all of our files within the proper directories
 	for _, file := range files {
 		tempDest := url.URL{}
@@ -779,6 +786,7 @@ func UploadDirectory(src string, dest *url.URL, token string, namespace namespac
 	// Close progress bar container
 	if ObjectClientOptions.ProgressBars {
 		progressContainer.Wait()
+		log.SetOutput(os.Stdout)
 	}
 	return amountDownloaded, err
 }
@@ -1026,6 +1034,7 @@ func walkDirUpload(path string, client *gowebdav.Client, destPath string) ([]str
 	if err != nil {
 		return nil, err
 	}
+	log.Debugf("Creating directory: %s", destPath+path)
 
 	// Get our list of files
 	infos, err := os.ReadDir(path)

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/namespaces"
+	"github.com/pelicanplatform/pelican/param"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -106,9 +107,9 @@ func copyMain(cmd *cobra.Command, args []string) {
 	// Set the progress bars to the command line option
 	client.ObjectClientOptions.Token, _ = cmd.Flags().GetString("token")
 
-	// Check if the program was executed from a terminal
+	// Check if the program was executed from a terminal and does not specify a log location
 	// https://rosettacode.org/wiki/Check_output_device_is_a_terminal#Go
-	if fileInfo, _ := os.Stdout.Stat(); (fileInfo.Mode() & os.ModeCharDevice) != 0 {
+	if fileInfo, _ := os.Stdout.Stat(); (fileInfo.Mode()&os.ModeCharDevice) != 0 && param.Logging_LogLocation.GetString() == "" {
 		client.ObjectClientOptions.ProgressBars = true
 	} else {
 		client.ObjectClientOptions.ProgressBars = false


### PR DESCRIPTION
The progress bars now appear below the debug log as they are running and are not duplicated. Also, disabled progress bars with specified debug log output. Figured you don't need the bars to be printed to a specific log file.