### PR TITLE
Lock NextJS to 14.0.3

### DIFF
--- a/web_ui/frontend/package.json
+++ b/web_ui/frontend/package.json
@@ -25,7 +25,7 @@
     "eslint": "8.45.0",
     "eslint-config-next": "13.4.12",
     "luxon": "^3.4.3",
-    "next": "^14.0.1",
+    "next": "14.0.3",
     "react": "18.2.0",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
14.0.4 breaks the website build so lock it to 14.0.3