### PR TITLE
Refactor and move token create logic to utils

### DIFF
--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/metrics"
+	"github.com/pelicanplatform/pelican/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -83,13 +84,13 @@ https://jwt.io/introduction.
 Additional profiles that expand on JWT are supported. They include scitokens2 and
 wlcg. For more information about these profiles, see https://scitokens.org/technical_docs/Claims
 and https://github.com/WLCG-AuthZ-WG/common-jwt-profile/blob/master/profile.md, respectively`,
-		RunE: cliTokenCreate,
+		RunE: utils.CliTokenCreate,
 	}
 
 	originTokenVerifyCmd = &cobra.Command{
 		Use:   "verify",
 		Short: "Verify a Pelican origin token",
-		RunE:  verifyToken,
+		RunE:  utils.VerifyToken,
 	}
 )
 

--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/metrics"
-	"github.com/pelicanplatform/pelican/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -84,13 +83,13 @@ https://jwt.io/introduction.
 Additional profiles that expand on JWT are supported. They include scitokens2 and
 wlcg. For more information about these profiles, see https://scitokens.org/technical_docs/Claims
 and https://github.com/WLCG-AuthZ-WG/common-jwt-profile/blob/master/profile.md, respectively`,
-		RunE: utils.CliTokenCreate,
+		RunE: cliTokenCreate,
 	}
 
 	originTokenVerifyCmd = &cobra.Command{
 		Use:   "verify",
 		Short: "Verify a Pelican origin token",
-		RunE:  utils.VerifyToken,
+		RunE:  verifyToken,
 	}
 )
 

--- a/cmd/origin_token.go
+++ b/cmd/origin_token.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pelicanplatform/pelican/utils"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// Take an input slice and append its claim name
+func parseInputSlice(rawSlice *[]string, claimPrefix string) []string {
+	if len(*rawSlice) == 0 {
+		return nil
+	}
+	slice := []string{}
+	for _, val := range *rawSlice {
+		slice = append(slice, claimPrefix+"="+val)
+	}
+
+	return slice
+}
+
+func parseClaims(claims []string) (map[string]string, error) {
+	claimsMap := make(map[string]string)
+	for _, claim := range claims {
+		// Split by the first "=" delimiter
+		parts := strings.SplitN(claim, "=", 2)
+		if len(parts) < 2 {
+			errMsg := "The claim '" + claim + "' is invalid. Did you forget an '='?"
+			return nil, errors.New(errMsg)
+		}
+		key := parts[0]
+		val := parts[1]
+
+		if existingVal, exists := claimsMap[key]; exists {
+			claimsMap[key] = existingVal + " " + val
+		} else {
+			claimsMap[key] = val
+		}
+	}
+	return claimsMap, nil
+}
+
+func cliTokenCreate(cmd *cobra.Command, args []string) error {
+	// Additional claims can be passed via the --claims flag, or
+	// they can be passed as args. We join those two slices here
+	claimsSlice, err := cmd.Flags().GetStringSlice("claim")
+	if err != nil {
+		return errors.Wrap(err, "Failed to load claims passed via --claim flag")
+	}
+	args = append(args, claimsSlice...)
+
+	// Similarly for scopes. Scopes could be passed like --scope "read:/storage write:/storage"
+	// or they could be pased like --scope read:/storage --scope write:/storage. However, because
+	// we already know the name of these claims and don't expect naming via the cli, we parse the
+	// claims to name them here
+	rawScopesSlice, err := cmd.Flags().GetStringSlice("scope")
+	if err != nil {
+		return errors.Wrap(err, "Failed to load scopes passed via --scope flag")
+	}
+	scopesSlice := parseInputSlice(&rawScopesSlice, "scope")
+	if len(scopesSlice) > 0 {
+		args = append(args, scopesSlice...)
+	}
+
+	// Like scopes, we allow multiple audiences and we need to add the claim name.
+	rawAudSlice, err := cmd.Flags().GetStringSlice("audience")
+	if err != nil {
+		return errors.Wrap(err, "Failed to load audience passed via --audience flag")
+	}
+	audSlice := parseInputSlice(&rawAudSlice, "aud")
+	if len(audSlice) > 0 {
+		args = append(args, audSlice...)
+	}
+
+	claimsMap, err := parseClaims(args)
+	if err != nil {
+		return errors.Wrap(err, "Failed to parse token claims")
+	}
+
+	// Get flags used for auxiliary parts of token creation that can't be fed directly to claimsMap
+	profile, err := cmd.Flags().GetString("profile")
+	if err != nil {
+		return errors.Wrapf(err, "Failed to get profile '%s' from input", profile)
+	}
+
+	lifetime, err := cmd.Flags().GetInt("lifetime")
+	if err != nil {
+		return errors.Wrapf(err, "Failed to get lifetime '%d' from input", lifetime)
+	}
+
+	// Flags to populate claimsMap
+	// Note that we don't get the issuer here, because that's bound to viper
+	subject, err := cmd.Flags().GetString("subject")
+	if err != nil {
+		return errors.Wrapf(err, "Failed to get subject '%s' from input", subject)
+	}
+	if subject != "" {
+		claimsMap["sub"] = subject
+	}
+
+	// Finally, create the token
+	token, err := utils.CreateEncodedToken(claimsMap, utils.TokenProfile(profile), lifetime)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create the token")
+	}
+
+	fmt.Println(token)
+	return nil
+}
+
+func verifyToken(cmd *cobra.Command, args []string) error {
+	return errors.New("Token verification not yet implemented")
+}

--- a/cmd/origin_token_test.go
+++ b/cmd/origin_token_test.go
@@ -1,0 +1,54 @@
+/***************************************************************
+ *
+ * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseClaims(t *testing.T) {
+	// Give it something valid
+	claims := []string{"foo=boo", "bar=baz"}
+	claimsMap, err := parseClaims(claims)
+	assert.NoError(t, err)
+	assert.Equal(t, claimsMap["foo"], "boo")
+	assert.Equal(t, claimsMap["bar"], "baz")
+	assert.Equal(t, len(claimsMap), 2)
+
+	// Give it something with multiple of the same claim key
+	claims = []string{"foo=boo", "foo=baz"}
+	claimsMap, err = parseClaims(claims)
+	assert.NoError(t, err)
+	assert.Equal(t, claimsMap["foo"], "boo baz")
+	assert.Equal(t, len(claimsMap), 1)
+
+	// Give it something without = delimiter
+	claims = []string{"foo=boo", "barbaz"}
+	_, err = parseClaims(claims)
+	assert.EqualError(t, err, "The claim 'barbaz' is invalid. Did you forget an '='?")
+}
+
+func TestParseInputSlice(t *testing.T) {
+	// A quick test, just to make sure this gets what it needs to
+	rawSlice := []string{"https://my-issuer.com"}
+	parsedSlice := parseInputSlice(&rawSlice, "iss")
+	assert.Equal(t, parsedSlice, []string{"iss=https://my-issuer.com"})
+}

--- a/utils/token_utils.go
+++ b/utils/token_utils.go
@@ -40,13 +40,13 @@ type (
 	TokenProfile string
 	TokenConfig  struct {
 		TokenProfile TokenProfile
-		Lifetime     time.Duration      // Lifetime is used to set 'exp' claim from now
-		Issuer       string             // Issuer is 'iss' claim
-		Audience     []string           // Audience is 'aud' claim
-		Scope        string             // Scope is a space separated list of scopes
-		Version      string             // Version is the version for different profiles. 'wlcg.ver' for WLCG profile and 'ver' for scitokens2
-		Subject      string             // Subject is 'sub' claim
-		Claims       *map[string]string // Additional claims
+		Lifetime     time.Duration     // Lifetime is used to set 'exp' claim from now
+		Issuer       string            // Issuer is 'iss' claim
+		Audience     []string          // Audience is 'aud' claim
+		Scope        string            // Scope is a space separated list of scopes
+		Version      string            // Version is the version for different profiles. 'wlcg.ver' for WLCG profile and 'ver' for scitokens2
+		Subject      string            // Subject is 'sub' claim
+		Claims       map[string]string // Additional claims
 	}
 )
 
@@ -374,7 +374,7 @@ func (tokenConfig *TokenConfig) CreateToken() (string, error) {
 	}
 
 	if tokenConfig.Claims != nil {
-		for key, val := range *tokenConfig.Claims {
+		for key, val := range tokenConfig.Claims {
 			builder.Claim(key, val)
 		}
 	}

--- a/utils/token_utils.go
+++ b/utils/token_utils.go
@@ -21,7 +21,6 @@ package utils
 import (
 	"crypto/rand"
 	"encoding/base64"
-	"fmt"
 	"net/url"
 	"regexp"
 	"strings"
@@ -31,11 +30,21 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/pelicanplatform/pelican/config"
 )
+
+type TokenProfile string
+
+const (
+	WLCG       TokenProfile = "wlcg"
+	Scitokens2 TokenProfile = "scitokens2"
+)
+
+func (p TokenProfile) String() string {
+	return string(p)
+}
 
 // The verifyCreate* funcs only act on the provided claims maps, because they attempt
 // to verify certain aspects of the token before it is created for simplicity. To verify
@@ -123,42 +132,21 @@ func verifyCreateWLCG(claimsMap *map[string]string) error {
 	return nil
 }
 
-func parseClaims(claims []string) (map[string]string, error) {
-	claimsMap := make(map[string]string)
-	for _, claim := range claims {
-		// Split by the first "=" delimiter
-		parts := strings.SplitN(claim, "=", 2)
-		if len(parts) < 2 {
-			errMsg := "The claim '" + claim + "' is invalid. Did you forget an '='?"
-			return nil, errors.New(errMsg)
-		}
-		key := parts[0]
-		val := parts[1]
-
-		if existingVal, exists := claimsMap[key]; exists {
-			claimsMap[key] = existingVal + " " + val
-		} else {
-			claimsMap[key] = val
-		}
-	}
-	return claimsMap, nil
-}
-
-func CreateEncodedToken(claimsMap map[string]string, profile string, lifetime int) (string, error) {
+func CreateEncodedToken(claimsMap map[string]string, profile TokenProfile, lifetime int) (string, error) {
 	var err error
 	if profile != "" {
-		if profile == "scitokens2" {
+		if profile == Scitokens2 {
 			err = verifyCreateSciTokens2(&claimsMap)
 			if err != nil {
 				return "", errors.Wrap(err, "Token does not conform to scitokens2 requirements")
 			}
-		} else if profile == "wlcg" {
+		} else if profile == WLCG {
 			err = verifyCreateWLCG(&claimsMap)
 			if err != nil {
 				return "", errors.Wrap(err, "Token does not conform to wlcg requirements")
 			}
 		} else {
-			errMsg := "The provided profile '" + profile +
+			errMsg := "The provided profile '" + profile.String() +
 				"' is not recognized. Valid options are 'scitokens2' or 'wlcg'"
 			return "", errors.New(errMsg)
 		}
@@ -242,89 +230,4 @@ func CreateEncodedToken(claimsMap map[string]string, profile string, lifetime in
 	}
 
 	return string(signed), nil
-}
-
-// Take an input slice and append its claim name
-func parseInputSlice(rawSlice *[]string, claimPrefix string) []string {
-	if len(*rawSlice) == 0 {
-		return nil
-	}
-	slice := []string{}
-	for _, val := range *rawSlice {
-		slice = append(slice, claimPrefix+"="+val)
-	}
-
-	return slice
-}
-
-func CliTokenCreate(cmd *cobra.Command, args []string) error {
-	// Additional claims can be passed via the --claims flag, or
-	// they can be passed as args. We join those two slices here
-	claimsSlice, err := cmd.Flags().GetStringSlice("claim")
-	if err != nil {
-		return errors.Wrap(err, "Failed to load claims passed via --claim flag")
-	}
-	args = append(args, claimsSlice...)
-
-	// Similarly for scopes. Scopes could be passed like --scope "read:/storage write:/storage"
-	// or they could be pased like --scope read:/storage --scope write:/storage. However, because
-	// we already know the name of these claims and don't expect naming via the cli, we parse the
-	// claims to name them here
-	rawScopesSlice, err := cmd.Flags().GetStringSlice("scope")
-	if err != nil {
-		return errors.Wrap(err, "Failed to load scopes passed via --scope flag")
-	}
-	scopesSlice := parseInputSlice(&rawScopesSlice, "scope")
-	if len(scopesSlice) > 0 {
-		args = append(args, scopesSlice...)
-	}
-
-	// Like scopes, we allow multiple audiences and we need to add the claim name.
-	rawAudSlice, err := cmd.Flags().GetStringSlice("audience")
-	if err != nil {
-		return errors.Wrap(err, "Failed to load audience passed via --audience flag")
-	}
-	audSlice := parseInputSlice(&rawAudSlice, "aud")
-	if len(audSlice) > 0 {
-		args = append(args, audSlice...)
-	}
-
-	claimsMap, err := parseClaims(args)
-	if err != nil {
-		return errors.Wrap(err, "Failed to parse token claims")
-	}
-
-	// Get flags used for auxiliary parts of token creation that can't be fed directly to claimsMap
-	profile, err := cmd.Flags().GetString("profile")
-	if err != nil {
-		return errors.Wrapf(err, "Failed to get profile '%s' from input", profile)
-	}
-
-	lifetime, err := cmd.Flags().GetInt("lifetime")
-	if err != nil {
-		return errors.Wrapf(err, "Failed to get lifetime '%d' from input", lifetime)
-	}
-
-	// Flags to populate claimsMap
-	// Note that we don't get the issuer here, because that's bound to viper
-	subject, err := cmd.Flags().GetString("subject")
-	if err != nil {
-		return errors.Wrapf(err, "Failed to get subject '%s' from input", subject)
-	}
-	if subject != "" {
-		claimsMap["sub"] = subject
-	}
-
-	// Finally, create the token
-	token, err := CreateEncodedToken(claimsMap, profile, lifetime)
-	if err != nil {
-		return errors.Wrap(err, "Failed to create the token")
-	}
-
-	fmt.Println(token)
-	return nil
-}
-
-func VerifyToken(cmd *cobra.Command, args []string) error {
-	return errors.New("Token verification not yet implemented")
 }

--- a/utils/token_utils.go
+++ b/utils/token_utils.go
@@ -1,4 +1,22 @@
-package main
+/***************************************************************
+ *
+ * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package utils
 
 import (
 	"crypto/rand"
@@ -239,7 +257,7 @@ func parseInputSlice(rawSlice *[]string, claimPrefix string) []string {
 	return slice
 }
 
-func cliTokenCreate(cmd *cobra.Command, args []string) error {
+func CliTokenCreate(cmd *cobra.Command, args []string) error {
 	// Additional claims can be passed via the --claims flag, or
 	// they can be passed as args. We join those two slices here
 	claimsSlice, err := cmd.Flags().GetStringSlice("claim")
@@ -307,6 +325,6 @@ func cliTokenCreate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func verifyToken(cmd *cobra.Command, args []string) error {
+func VerifyToken(cmd *cobra.Command, args []string) error {
 	return errors.New("Token verification not yet implemented")
 }

--- a/utils/token_utils_test.go
+++ b/utils/token_utils_test.go
@@ -95,28 +95,6 @@ func TestVerifyCreateWLCG(t *testing.T) {
 	assert.Equal(t, claimsMap["anotherClaim"], "bar")
 }
 
-func TestParseClaims(t *testing.T) {
-	// Give it something valid
-	claims := []string{"foo=boo", "bar=baz"}
-	claimsMap, err := parseClaims(claims)
-	assert.NoError(t, err)
-	assert.Equal(t, claimsMap["foo"], "boo")
-	assert.Equal(t, claimsMap["bar"], "baz")
-	assert.Equal(t, len(claimsMap), 2)
-
-	// Give it something with multiple of the same claim key
-	claims = []string{"foo=boo", "foo=baz"}
-	claimsMap, err = parseClaims(claims)
-	assert.NoError(t, err)
-	assert.Equal(t, claimsMap["foo"], "boo baz")
-	assert.Equal(t, len(claimsMap), 1)
-
-	// Give it something without = delimiter
-	claims = []string{"foo=boo", "barbaz"}
-	_, err = parseClaims(claims)
-	assert.EqualError(t, err, "The claim 'barbaz' is invalid. Did you forget an '='?")
-}
-
 func TestCreateEncodedToken(t *testing.T) {
 	// Some viper pre-requisites
 	viper.Reset()
@@ -180,11 +158,4 @@ func TestCreateEncodedToken(t *testing.T) {
 	_, err = CreateEncodedToken(claims, "wlcg", 1200)
 	assert.EqualError(t, err, "No issuer was found in the configuration file, "+
 		"and none was provided as a claim")
-}
-
-func TestParseInputSlice(t *testing.T) {
-	// A quick test, just to make sure this gets what it needs to
-	rawSlice := []string{"https://my-issuer.com"}
-	parsedSlice := parseInputSlice(&rawSlice, "iss")
-	assert.Equal(t, parsedSlice, []string{"iss=https://my-issuer.com"})
 }

--- a/utils/token_utils_test.go
+++ b/utils/token_utils_test.go
@@ -125,7 +125,7 @@ func TestCreateToken(t *testing.T) {
 	assert.EqualError(t, err, "Invalid tokenConfig: Unsupported token profile: unknown")
 
 	// Test that additional claims can be passed into the token
-	tokenConfig = TokenConfig{TokenProfile: WLCG, Audience: []string{"foo"}, Subject: "bar", Lifetime: time.Minute * 10, Claims: &map[string]string{"foo": "bar"}}
+	tokenConfig = TokenConfig{TokenProfile: WLCG, Audience: []string{"foo"}, Subject: "bar", Lifetime: time.Minute * 10, Claims: map[string]string{"foo": "bar"}}
 	token, err := tokenConfig.CreateToken()
 	require.NoError(t, err)
 	jwt, err := jwt.ParseString(token, jwt.WithVerify(false))

--- a/utils/token_utils_test.go
+++ b/utils/token_utils_test.go
@@ -16,7 +16,7 @@
  *
  ***************************************************************/
 
-package main
+package utils
 
 import (
 	"path/filepath"


### PR DESCRIPTION
Instead of passing a `claimMap` to create a token, now you can config your token by constructing `TokenConfig` and call `CreateToken` off this instance.
* Replaced `CreateEncodedToken` by `CreateToken`
* Ran regression tests and ensure existing code are not affected