### PR TITLE
`pelican object get` and `pelican object put`

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -264,7 +264,7 @@ func GenerateTransferDetailsUsingCache(cache CacheInterface, opts TransferDetail
 	return nil
 }
 
-func download_http(sourceUrl *url.URL, destination string, payload *payloadStruct, namespace namespaces.Namespace, recursive bool, tokenName string, OSDFDirectorUrl string) (bytesTransferred int64, err error) {
+func download_http(sourceUrl *url.URL, destination string, payload *payloadStruct, namespace namespaces.Namespace, recursive bool, tokenName string) (bytesTransferred int64, err error) {
 
 	// First, create a handler for any panics that occur
 	defer func() {
@@ -298,7 +298,8 @@ func download_http(sourceUrl *url.URL, destination string, payload *payloadStruc
 	// Check the env var "USE_OSDF_DIRECTOR" and decide if ordered caches should come from director
 	var transfers []TransferDetails
 	var files []string
-	closestNamespaceCaches, err := GetCachesFromNamespace(namespace, OSDFDirectorUrl != "")
+	directorUrl := param.Federation_DirectorUrl.GetString()
+	closestNamespaceCaches, err := GetCachesFromNamespace(namespace, directorUrl != "")
 	if err != nil {
 		log.Errorln("Failed to get namespaced caches (treated as non-fatal):", err)
 	}

--- a/client/main.go
+++ b/client/main.go
@@ -510,6 +510,15 @@ func DoPut(localObject string, remoteDestination string, recursive bool) (bytesT
 				log.Errorln("Failed to join remote destination url path:", err)
 				return 0, err
 			}
+		} else if remoteDestUrl.Scheme == "pelican" {
+			federationUrl, _ := url.Parse(remoteDestUrl.String())
+			federationUrl.Scheme = "https"
+			federationUrl.Path = ""
+			viper.Set("Federation.DiscoveryUrl", federationUrl.String())
+			err = config.DiscoverFederation()
+			if err != nil {
+				return 0, err
+			}
 		}
 	}
 	remoteDestScheme, _ = getTokenName(remoteDestUrl)
@@ -578,6 +587,15 @@ func DoGet(remoteObject string, localDestination string, recursive bool) (bytesT
 			remoteObjectUrl.Path, err = url.JoinPath(remoteObjectUrl.Host, remoteObjectUrl.Path)
 			if err != nil {
 				log.Errorln("Failed to join source url path:", err)
+				return 0, err
+			}
+		} else if remoteObjectUrl.Scheme == "pelican" {
+			federationUrl, _ := url.Parse(remoteObjectUrl.String())
+			federationUrl.Scheme = "https"
+			federationUrl.Path = ""
+			viper.Set("Federation.DiscoveryUrl", federationUrl.String())
+			err = config.DiscoverFederation()
+			if err != nil {
 				return 0, err
 			}
 		}
@@ -702,12 +720,31 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 	if source_url.Host != "" {
 		if source_url.Scheme == "osdf" || source_url.Scheme == "stash" {
 			source_url.Path = "/" + path.Join(source_url.Host, source_url.Path)
+		} else if source_url.Scheme == "pelican" {
+			fmt.Printf("\n\n\nHERE\n\n\n")
+			federationUrl, _ := url.Parse(source_url.String())
+			federationUrl.Scheme = "https"
+			federationUrl.Path = ""
+			viper.Set("Federation.DiscoveryUrl", federationUrl.String())
+			err = config.DiscoverFederation()
+			if err != nil {
+				return 0, err
+			}
 		}
 	}
 
 	if dest_url.Host != "" {
 		if dest_url.Scheme == "osdf" || dest_url.Scheme == "stash" {
 			dest_url.Path = "/" + path.Join(dest_url.Host, dest_url.Path)
+		} else if dest_url.Scheme == "pelican" {
+			federationUrl, _ := url.Parse(dest_url.String())
+			federationUrl.Scheme = "https"
+			federationUrl.Path = ""
+			viper.Set("Federation.DiscoveryUrl", federationUrl.String())
+			err = config.DiscoverFederation()
+			if err != nil {
+				return 0, err
+			}
 		}
 	}
 

--- a/client/main.go
+++ b/client/main.go
@@ -721,7 +721,6 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 		if source_url.Scheme == "osdf" || source_url.Scheme == "stash" {
 			source_url.Path = "/" + path.Join(source_url.Host, source_url.Path)
 		} else if source_url.Scheme == "pelican" {
-			fmt.Printf("\n\n\nHERE\n\n\n")
 			federationUrl, _ := url.Parse(source_url.String())
 			federationUrl.Scheme = "https"
 			federationUrl.Path = ""

--- a/cmd/object_get.go
+++ b/cmd/object_get.go
@@ -45,7 +45,6 @@ func init() {
 	flagSet.Lookup("cache-list-name").Hidden = true
 	flagSet.String("caches", "", "A JSON file containing the list of caches")
 	objectCmd.AddCommand(getCmd)
-
 }
 
 func getMain(cmd *cobra.Command, args []string) {
@@ -135,5 +134,4 @@ func getMain(cmd *cobra.Command, args []string) {
 		}
 		os.Exit(1)
 	}
-
 }

--- a/cmd/object_get.go
+++ b/cmd/object_get.go
@@ -1,0 +1,140 @@
+/***************************************************************
+*
+* Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
+
+package main
+
+import (
+	"os"
+
+	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/config"
+	//"github.com/pelicanplatform/pelican/namespaces" maybe wanna have the namespaces bool still?
+	"github.com/pelicanplatform/pelican/param"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	getCmd = &cobra.Command{
+		Use:   "get {source ...} {destination}",
+		Short: "get a file from a Pelican federation",
+		Run:   getMain,
+	}
+)
+
+func init() {
+	flagSet := getCmd.Flags()
+	flagSet.StringP("cache", "c", "", "Cache to use")
+	flagSet.StringP("token", "t", "", "Token file to use for transfer")
+	flagSet.BoolP("recursive", "r", false, "Recursively download a directory.  Forces methods to only be http to get the freshest directory contents")
+	flagSet.StringP("cache-list-name", "n", "xroot", "(Deprecated) Cache list to use, currently either xroot or xroots; may be ignored")
+	flagSet.Lookup("cache-list-name").Hidden = true
+	flagSet.String("caches", "", "A JSON file containing the list of caches")
+	objectCmd.AddCommand(getCmd)
+
+}
+
+func getMain(cmd *cobra.Command, args []string) {
+
+	client.ObjectClientOptions.Version = version
+
+	err := config.InitClient()
+	if err != nil {
+		log.Errorln(err)
+		os.Exit(1)
+	}
+
+	// Set the progress bars to the command line option
+	client.ObjectClientOptions.Token, _ = cmd.Flags().GetString("token")
+
+	// Check if the program was executed from a terminal
+	// https://rosettacode.org/wiki/Check_output_device_is_a_terminal#Go
+	if fileInfo, _ := os.Stdout.Stat(); (fileInfo.Mode()&os.ModeCharDevice) != 0 && param.Logging_LogLocation.GetString() == "" {
+		client.ObjectClientOptions.ProgressBars = true
+	} else {
+		client.ObjectClientOptions.ProgressBars = false
+	}
+
+	log.Debugln("Len of source:", len(args))
+	if len(args) < 2 {
+		log.Errorln("No Source or Destination")
+		err = cmd.Help()
+		if err != nil {
+			log.Errorln("Failed to print out help:", err)
+		}
+		os.Exit(1)
+	}
+	source := args[:len(args)-1]
+	dest := args[len(args)-1]
+
+	log.Debugln("Sources:", source)
+	log.Debugln("Destination:", dest)
+
+	// Check for manually entered cache to use ??
+	nearestCache, nearestCacheIsPresent := os.LookupEnv("NEAREST_CACHE")
+
+	if nearestCacheIsPresent {
+		client.NearestCache = nearestCache
+		client.NearestCacheList = append(client.NearestCacheList, client.NearestCache)
+		client.CacheOverride = true
+	} else if cache, _ := cmd.Flags().GetString("cache"); cache != "" {
+		client.NearestCache = cache
+		client.NearestCacheList = append(client.NearestCacheList, cache)
+		client.CacheOverride = true
+	}
+
+	if len(source) > 1 {
+		if destStat, err := os.Stat(dest); err != nil && destStat.IsDir() {
+			log.Errorln("Destination is not a directory")
+			os.Exit(1)
+		}
+	}
+
+	var result error
+	var downloaded int64 = 0
+	lastSrc := ""
+	for _, src := range source {
+		var tmpDownloaded int64
+		isRecursive, _ := cmd.Flags().GetBool("recursive")
+		client.ObjectClientOptions.Recursive = isRecursive
+		tmpDownloaded, result = client.DoGet(src, dest, isRecursive)
+		downloaded += tmpDownloaded
+		if result != nil {
+			lastSrc = src
+			break
+		} else {
+			client.ClearErrors()
+		}
+	}
+
+	// Exit with failure
+	if result != nil {
+		// Print the list of errors
+		errMsg := client.GetErrors()
+		if errMsg == "" {
+			errMsg = result.Error()
+		}
+		log.Errorln("Failure getting " + lastSrc + ": " + errMsg)
+		if client.ErrorsRetryable() {
+			log.Errorln("Errors are retryable")
+			os.Exit(11)
+		}
+		os.Exit(1)
+	}
+
+}

--- a/cmd/object_put.go
+++ b/cmd/object_put.go
@@ -29,26 +29,26 @@ import (
 )
 
 var (
-	getCmd = &cobra.Command{
-		Use:   "get {source ...} {destination}",
-		Short: "Get a file from a Pelican federation",
-		Run:   getMain,
+	putCmd = &cobra.Command{
+		Use:   "put {source ...} {destination}",
+		Short: "Send a file to a Pelican federation",
+		Run:   putMain,
 	}
 )
 
 func init() {
-	flagSet := getCmd.Flags()
+	flagSet := putCmd.Flags()
 	flagSet.StringP("cache", "c", "", "Cache to use")
 	flagSet.StringP("token", "t", "", "Token file to use for transfer")
-	flagSet.BoolP("recursive", "r", false, "Recursively download a directory.  Forces methods to only be http to get the freshest directory contents")
+	flagSet.BoolP("recursive", "r", false, "Recursively upload a directory.  Forces methods to only be http to get the freshest directory contents")
 	flagSet.StringP("cache-list-name", "n", "xroot", "(Deprecated) Cache list to use, currently either xroot or xroots; may be ignored")
 	flagSet.Lookup("cache-list-name").Hidden = true
 	flagSet.String("caches", "", "A JSON file containing the list of caches")
-	objectCmd.AddCommand(getCmd)
+	objectCmd.AddCommand(putCmd)
 
 }
 
-func getMain(cmd *cobra.Command, args []string) {
+func putMain(cmd *cobra.Command, args []string) {
 
 	client.ObjectClientOptions.Version = version
 
@@ -111,7 +111,7 @@ func getMain(cmd *cobra.Command, args []string) {
 		var tmpDownloaded int64
 		isRecursive, _ := cmd.Flags().GetBool("recursive")
 		client.ObjectClientOptions.Recursive = isRecursive
-		tmpDownloaded, result = client.DoGet(src, dest, isRecursive)
+		tmpDownloaded, result = client.DoPut(src, dest, isRecursive)
 		downloaded += tmpDownloaded
 		if result != nil {
 			lastSrc = src
@@ -128,7 +128,7 @@ func getMain(cmd *cobra.Command, args []string) {
 		if errMsg == "" {
 			errMsg = result.Error()
 		}
-		log.Errorln("Failure getting " + lastSrc + ": " + errMsg)
+		log.Errorln("Failure putting " + lastSrc + ": " + errMsg)
 		if client.ErrorsRetryable() {
 			log.Errorln("Errors are retryable")
 			os.Exit(11)

--- a/cmd/object_put.go
+++ b/cmd/object_put.go
@@ -38,14 +38,9 @@ var (
 
 func init() {
 	flagSet := putCmd.Flags()
-	flagSet.StringP("cache", "c", "", "Cache to use")
 	flagSet.StringP("token", "t", "", "Token file to use for transfer")
 	flagSet.BoolP("recursive", "r", false, "Recursively upload a directory.  Forces methods to only be http to get the freshest directory contents")
-	flagSet.StringP("cache-list-name", "n", "xroot", "(Deprecated) Cache list to use, currently either xroot or xroots; may be ignored")
-	flagSet.Lookup("cache-list-name").Hidden = true
-	flagSet.String("caches", "", "A JSON file containing the list of caches")
 	objectCmd.AddCommand(putCmd)
-
 }
 
 func putMain(cmd *cobra.Command, args []string) {
@@ -83,19 +78,6 @@ func putMain(cmd *cobra.Command, args []string) {
 
 	log.Debugln("Sources:", source)
 	log.Debugln("Destination:", dest)
-
-	// Check for manually entered cache to use ??
-	nearestCache, nearestCacheIsPresent := os.LookupEnv("NEAREST_CACHE")
-
-	if nearestCacheIsPresent {
-		client.NearestCache = nearestCache
-		client.NearestCacheList = append(client.NearestCacheList, client.NearestCache)
-		client.CacheOverride = true
-	} else if cache, _ := cmd.Flags().GetString("cache"); cache != "" {
-		client.NearestCache = cache
-		client.NearestCacheList = append(client.NearestCacheList, cache)
-		client.CacheOverride = true
-	}
 
 	if len(source) > 1 {
 		if destStat, err := os.Stat(dest); err != nil && destStat.IsDir() {


### PR DESCRIPTION
The command `pelican object get` and `pelican object put` separated out from `pelican object copy`.