### PR TITLE
Include cache in director's service discovery endpoint

### DIFF
--- a/director/redirect_test.go
+++ b/director/redirect_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type MockCache struct {
@@ -314,9 +315,9 @@ func TestGetAuthzEscaped(t *testing.T) {
 	assert.Equal(t, escapedToken, "tokenstring")
 }
 
-func TestDiscoverOrigins(t *testing.T) {
+func TestDiscoverOriginCache(t *testing.T) {
 	mockPelicanOriginServerAd := ServerAd{
-		Name:    "test-origin-server",
+		Name:    "1-test-origin-server",
 		AuthURL: url.URL{},
 		URL: url.URL{
 			Scheme: "https",
@@ -332,11 +333,11 @@ func TestDiscoverOrigins(t *testing.T) {
 	}
 
 	mockTopoOriginServerAd := ServerAd{
-		Name:    "test-origin-server",
+		Name:    "test-topology-origin-server",
 		AuthURL: url.URL{},
 		URL: url.URL{
 			Scheme: "https",
-			Host:   "fake-origin.org:8443",
+			Host:   "fake-topology-origin.org:8443",
 		},
 		Type:      OriginType,
 		Latitude:  123.05,
@@ -344,9 +345,13 @@ func TestDiscoverOrigins(t *testing.T) {
 	}
 
 	mockCacheServerAd := ServerAd{
-		Name:    "test-cache-server",
+		Name:    "2-test-cache-server",
 		AuthURL: url.URL{},
 		URL: url.URL{
+			Scheme: "https",
+			Host:   "fake-cache.org:8443",
+		},
+		WebURL: url.URL{
 			Scheme: "https",
 			Host:   "fake-cache.org:8444",
 		},
@@ -412,8 +417,33 @@ func TestDiscoverOrigins(t *testing.T) {
 		return signed
 	}
 
+	areSlicesEqualIgnoreOrder := func(slice1, slice2 []PromDiscoveryItem) bool {
+		if len(slice1) != len(slice2) {
+			return false
+		}
+
+		counts := make(map[string]int)
+
+		for _, item := range slice1 {
+			bytes, err := json.Marshal(item)
+			require.NoError(t, err)
+			counts[string(bytes)]++
+		}
+
+		for _, item := range slice2 {
+			bytes, err := json.Marshal(item)
+			require.NoError(t, err)
+			counts[string(bytes)]--
+			if counts[string(bytes)] < 0 {
+				return false
+			}
+		}
+
+		return true
+	}
+
 	r := gin.Default()
-	r.GET("/test", DiscoverOrigins)
+	r.GET("/test", DiscoverOriginCache)
 
 	t.Run("no-token-should-give-401", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "/test", nil)
@@ -455,41 +485,58 @@ func TestDiscoverOrigins(t *testing.T) {
 		assert.Equal(t, 200, w.Code)
 		assert.Equal(t, `[]`, w.Body.String())
 	})
-	t.Run("response-origin-should-match-cache", func(t *testing.T) {
+	t.Run("response-should-match-serverAds", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "/test", nil)
 		if err != nil {
 			t.Fatalf("Could not make a GET request: %v", err)
 		}
 
-		serverAdMutex.Lock()
-		serverAds.Set(mockPelicanOriginServerAd, []NamespaceAd{mockNamespaceAd}, ttlcache.DefaultTTL)
-		// Server fetched from topology should not be present in SD response
-		serverAds.Set(mockTopoOriginServerAd, []NamespaceAd{mockNamespaceAd}, ttlcache.DefaultTTL)
-		serverAds.Set(mockCacheServerAd, []NamespaceAd{mockNamespaceAd}, ttlcache.DefaultTTL)
-		serverAdMutex.Unlock()
+		func() {
+			serverAdMutex.Lock()
+			defer serverAdMutex.Unlock()
+			serverAds.DeleteAll()
+			serverAds.Set(mockPelicanOriginServerAd, []NamespaceAd{mockNamespaceAd}, ttlcache.DefaultTTL)
+			// Server fetched from topology should not be present in SD response
+			serverAds.Set(mockTopoOriginServerAd, []NamespaceAd{mockNamespaceAd}, ttlcache.DefaultTTL)
+			serverAds.Set(mockCacheServerAd, []NamespaceAd{mockNamespaceAd}, ttlcache.DefaultTTL)
+		}()
 
 		expectedRes := []PromDiscoveryItem{{
+			Targets: []string{mockCacheServerAd.WebURL.Hostname() + ":" + mockCacheServerAd.WebURL.Port()},
+			Labels: map[string]string{
+				"server_type":     string(mockCacheServerAd.Type),
+				"server_name":     mockCacheServerAd.Name,
+				"server_auth_url": mockCacheServerAd.AuthURL.String(),
+				"server_url":      mockCacheServerAd.URL.String(),
+				"server_web_url":  mockCacheServerAd.WebURL.String(),
+				"server_lat":      fmt.Sprintf("%.4f", mockCacheServerAd.Latitude),
+				"server_long":     fmt.Sprintf("%.4f", mockCacheServerAd.Longitude),
+			},
+		}, {
 			Targets: []string{mockPelicanOriginServerAd.WebURL.Hostname() + ":" + mockPelicanOriginServerAd.WebURL.Port()},
 			Labels: map[string]string{
-				"origin_name":     mockPelicanOriginServerAd.Name,
-				"origin_auth_url": mockPelicanOriginServerAd.AuthURL.String(),
-				"origin_url":      mockPelicanOriginServerAd.URL.String(),
-				"origin_web_url":  mockPelicanOriginServerAd.WebURL.String(),
-				"origin_lat":      fmt.Sprintf("%.4f", mockPelicanOriginServerAd.Latitude),
-				"origin_long":     fmt.Sprintf("%.4f", mockPelicanOriginServerAd.Longitude),
+				"server_type":     string(mockPelicanOriginServerAd.Type),
+				"server_name":     mockPelicanOriginServerAd.Name,
+				"server_auth_url": mockPelicanOriginServerAd.AuthURL.String(),
+				"server_url":      mockPelicanOriginServerAd.URL.String(),
+				"server_web_url":  mockPelicanOriginServerAd.WebURL.String(),
+				"server_lat":      fmt.Sprintf("%.4f", mockPelicanOriginServerAd.Latitude),
+				"server_long":     fmt.Sprintf("%.4f", mockPelicanOriginServerAd.Longitude),
 			},
 		}}
-
-		resStr, err := json.Marshal(expectedRes)
-		assert.NoError(t, err, "Could not marshal json response")
 
 		req.Header.Set("Authorization", "Bearer "+string(setupToken("")))
 
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)
 
-		assert.Equal(t, 200, w.Code)
-		assert.Equal(t, string(resStr), w.Body.String(), "Reponse doesn't match expected")
+		require.Equal(t, 200, w.Code)
+
+		var resMarshalled []PromDiscoveryItem
+		err = json.Unmarshal(w.Body.Bytes(), &resMarshalled)
+		require.NoError(t, err, "Error unmarshall response to json")
+
+		assert.True(t, areSlicesEqualIgnoreOrder(expectedRes, resMarshalled))
 	})
 
 	t.Run("no-duplicated-origins", func(t *testing.T) {
@@ -498,25 +545,28 @@ func TestDiscoverOrigins(t *testing.T) {
 			t.Fatalf("Could not make a GET request: %v", err)
 		}
 
-		serverAdMutex.Lock()
-		// Add multiple same serverAds
-		serverAds.Set(mockPelicanOriginServerAd, []NamespaceAd{mockNamespaceAd}, ttlcache.DefaultTTL)
-		serverAds.Set(mockPelicanOriginServerAd, []NamespaceAd{mockNamespaceAd}, ttlcache.DefaultTTL)
-		serverAds.Set(mockPelicanOriginServerAd, []NamespaceAd{mockNamespaceAd}, ttlcache.DefaultTTL)
-		// Server fetched from topology should not be present in SD response
-		serverAds.Set(mockTopoOriginServerAd, []NamespaceAd{mockNamespaceAd}, ttlcache.DefaultTTL)
-		serverAds.Set(mockCacheServerAd, []NamespaceAd{mockNamespaceAd}, ttlcache.DefaultTTL)
-		serverAdMutex.Unlock()
+		func() {
+			serverAdMutex.Lock()
+			defer serverAdMutex.Unlock()
+			serverAds.DeleteAll()
+			// Add multiple same serverAds
+			serverAds.Set(mockPelicanOriginServerAd, []NamespaceAd{mockNamespaceAd}, ttlcache.DefaultTTL)
+			serverAds.Set(mockPelicanOriginServerAd, []NamespaceAd{mockNamespaceAd}, ttlcache.DefaultTTL)
+			serverAds.Set(mockPelicanOriginServerAd, []NamespaceAd{mockNamespaceAd}, ttlcache.DefaultTTL)
+			// Server fetched from topology should not be present in SD response
+			serverAds.Set(mockTopoOriginServerAd, []NamespaceAd{mockNamespaceAd}, ttlcache.DefaultTTL)
+		}()
 
 		expectedRes := []PromDiscoveryItem{{
 			Targets: []string{mockPelicanOriginServerAd.WebURL.Hostname() + ":" + mockPelicanOriginServerAd.WebURL.Port()},
 			Labels: map[string]string{
-				"origin_name":     mockPelicanOriginServerAd.Name,
-				"origin_auth_url": mockPelicanOriginServerAd.AuthURL.String(),
-				"origin_url":      mockPelicanOriginServerAd.URL.String(),
-				"origin_web_url":  mockPelicanOriginServerAd.WebURL.String(),
-				"origin_lat":      fmt.Sprintf("%.4f", mockPelicanOriginServerAd.Latitude),
-				"origin_long":     fmt.Sprintf("%.4f", mockPelicanOriginServerAd.Longitude),
+				"server_type":     string(mockPelicanOriginServerAd.Type),
+				"server_name":     mockPelicanOriginServerAd.Name,
+				"server_auth_url": mockPelicanOriginServerAd.AuthURL.String(),
+				"server_url":      mockPelicanOriginServerAd.URL.String(),
+				"server_web_url":  mockPelicanOriginServerAd.WebURL.String(),
+				"server_lat":      fmt.Sprintf("%.4f", mockPelicanOriginServerAd.Latitude),
+				"server_long":     fmt.Sprintf("%.4f", mockPelicanOriginServerAd.Longitude),
 			},
 		}}
 

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -158,7 +158,7 @@ func configDirectorPromScraper() (*config.ScrapeConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to generate token for director scraper at start: %v", err)
 	}
-	serverDiscoveryUrl.Path = "/api/v1.0/director/discoverOrigins"
+	serverDiscoveryUrl.Path = "/api/v1.0/director/discoverServers"
 	scrapeConfig := config.DefaultScrapeConfig
 	scrapeConfig.JobName = "origin_cache_servers"
 	scrapeConfig.Scheme = "https"

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -144,9 +144,9 @@ func runtimeInfo() (api_v1.RuntimeInfo, error) {
 	return api_v1.RuntimeInfo{}, nil
 }
 
-// Configure director's Prometheus scraper to use HTTP service discovery for origins
+// Configure director's Prometheus scraper to use HTTP service discovery for origins/caches
 func configDirectorPromScraper() (*config.ScrapeConfig, error) {
-	originDiscoveryUrl, err := url.Parse(param.Server_ExternalWebUrl.GetString())
+	serverDiscoveryUrl, err := url.Parse(param.Server_ExternalWebUrl.GetString())
 	if err != nil {
 		return nil, fmt.Errorf("parse external URL %v: %w", param.Server_ExternalWebUrl.GetString(), err)
 	}
@@ -158,9 +158,9 @@ func configDirectorPromScraper() (*config.ScrapeConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to generate token for director scraper at start: %v", err)
 	}
-	originDiscoveryUrl.Path = "/api/v1.0/director/discoverOrigins"
+	serverDiscoveryUrl.Path = "/api/v1.0/director/discoverOrigins"
 	scrapeConfig := config.DefaultScrapeConfig
-	scrapeConfig.JobName = "origins"
+	scrapeConfig.JobName = "origin_cache_servers"
 	scrapeConfig.Scheme = "https"
 
 	// This will cause the director to maintain a CA bundle, including the custom CA, at
@@ -173,7 +173,7 @@ func configDirectorPromScraper() (*config.ScrapeConfig, error) {
 
 	scraperHttpClientConfig := common_config.HTTPClientConfig{
 		TLSConfig: common_config.TLSConfig{
-			// For the scraper to origins' metrics, we get TLSSkipVerify from config
+			// For the scraper to origin/caches' metrics, we get TLSSkipVerify from config
 			// As this request is to external address
 			InsecureSkipVerify: param.TLSSkipVerify.GetBool(),
 		},
@@ -201,7 +201,7 @@ func configDirectorPromScraper() (*config.ScrapeConfig, error) {
 		},
 	}
 	scrapeConfig.ServiceDiscoveryConfigs[0] = &prom_http.SDConfig{
-		URL:              originDiscoveryUrl.String(),
+		URL:              serverDiscoveryUrl.String(),
 		RefreshInterval:  model.Duration(15 * time.Second),
 		HTTPClientConfig: sdHttpClientConfig,
 	}
@@ -366,7 +366,7 @@ func ConfigureEmbeddedPrometheus(engine *gin.Engine, isDirector bool) error {
 	}
 	promCfg.ScrapeConfigs[0] = &scrapeConfig
 
-	// Add origins monitoring to director's prometheus instance
+	// Add origins/caches monitoring to director's prometheus instance
 	if isDirector {
 		dirPromScraperConfig, err := configDirectorPromScraper()
 		if err != nil {
@@ -701,7 +701,7 @@ func ConfigureEmbeddedPrometheus(engine *gin.Engine, isDirector bool) error {
 							if isDirector {
 								// Refresh service discovery token by re-configure scraper
 								if len(promCfg.ScrapeConfigs) < 2 {
-									return errors.New("Prometheus scraper config didn't include origins HTTP SD config. Length of configs less than 2.")
+									return errors.New("Prometheus scraper config didn't include origin/cache HTTP SD config. Length of configs less than 2.")
 								}
 								// Index 0 is the default config for servers
 								// Create new director-scrap token & service discovery token


### PR DESCRIPTION
Closes #481 

## Testing Instructions
* Spin up your `director` `registry` `origin` and `cache`
* Go to your director's Prometheus query engine endpoint for discovered servers, i.e. `/api/v1.0/prometheus/query?query=up`
* You should be able to see your cache and origin in the list
* Go to an arbitrary metric and both origin and cache shared, say `xrootd_monitoring_packets_received`, i.e. `/api/v1.0/prometheus/query?query=xrootd_monitoring_packets_received`, you should be able to see the metric from both your origin and cache, distinguished by their label.