### PR TITLE
Add topology component to Prometheus health metric

### DIFF
--- a/cmd/director_serve.go
+++ b/cmd/director_serve.go
@@ -51,9 +51,8 @@ func serveDirector( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	log.Info("Initializing Director GeoIP database...")
 	director.InitializeDB()
 
-	metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusWarning, "Start requesting from topology, status unknown")
-
 	if config.GetPreferredPrefix() == "OSDF" {
+		metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusWarning, "Start requesting from topology, status unknown")
 		log.Info("Generating/advertising server ads from OSG topology service...")
 
 		// Get the ads from topology, populate the cache, and keep the cache

--- a/cmd/director_serve.go
+++ b/cmd/director_serve.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/director"
+	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/web_ui"
 	log "github.com/sirupsen/logrus"
@@ -49,6 +50,8 @@ func serveDirector( /*cmd*/ *cobra.Command /*args*/, []string) error {
 
 	log.Info("Initializing Director GeoIP database...")
 	director.InitializeDB()
+
+	metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusWarning, "Start requesting from topology, status unknown")
 
 	if config.GetPreferredPrefix() == "OSDF" {
 		log.Info("Generating/advertising server ads from OSG topology service...")

--- a/cmd/namespace_registry_serve.go
+++ b/cmd/namespace_registry_serve.go
@@ -28,7 +28,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pelicanplatform/pelican/config"
-	"github.com/pelicanplatform/pelican/namespace_registry"
+	"github.com/pelicanplatform/pelican/metrics"
+	nsregistry "github.com/pelicanplatform/pelican/namespace_registry"
 	"github.com/pelicanplatform/pelican/web_ui"
 )
 
@@ -42,6 +43,7 @@ func serveNamespaceRegistry( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	}
 
 	if config.GetPreferredPrefix() == "OSDF" {
+		metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusWarning, "Start requesting from topology, status unknown")
 		log.Info("Populating registry with namespaces from OSG topology service...")
 		if err := nsregistry.PopulateTopology(); err != nil {
 			panic(errors.Wrap(err, "Unable to populate topology table"))

--- a/metrics/health.go
+++ b/metrics/health.go
@@ -66,13 +66,12 @@ const statusIndexErrorMessage = "Error: status string index out of range"
 // i.e. For ""OriginCache_XRootD", it means this component is available at both
 // Origin and Cache. Please come up with the largest possible scope of the component
 const (
-	OriginCache_XRootD     HealthStatusComponent = "xrootd"
-	OriginCache_CMSD       HealthStatusComponent = "cmsd"
-	OriginCache_Federation HealthStatusComponent = "federation" // Advertise to the director
-	OriginCache_Director   HealthStatusComponent = "director"   // file transfer with director
-	// TODO: WebUI health status is only set at origin_serve for now. We will soon
-	// move this logic to all server web-ui in issue #308
-	Server_WebUI HealthStatusComponent = "web-ui"
+	OriginCache_XRootD        HealthStatusComponent = "xrootd"
+	OriginCache_CMSD          HealthStatusComponent = "cmsd"
+	OriginCache_Federation    HealthStatusComponent = "federation" // Advertise to the director
+	OriginCache_Director      HealthStatusComponent = "director"   // File transfer with director
+	DirectorRegistry_Topology HealthStatusComponent = "topology"   // Fetch data from OSDF topology
+	Server_WebUI              HealthStatusComponent = "web-ui"
 )
 
 var (

--- a/metrics/topology.go
+++ b/metrics/topology.go
@@ -1,0 +1,1 @@
+package metrics


### PR DESCRIPTION
Closes #482 

Instead of adding # of errors as a separate Prometheus metric, I took advantage of existing component health metric by adding topology as a new component. If we want to look at number of errors (Status.Critical) over time, we should use PromQL to get what we want. Something like `query=count_over_time((pelican_component_health_status{component="topology"}%20==%201)[1h:5m])` which will give you total number of critical status over the period of time.