### PR TITLE
Allow GeoIP overrides and fix server geoip randomization

### DIFF
--- a/director/resources/geoip_overrides.yaml
+++ b/director/resources/geoip_overrides.yaml
@@ -1,0 +1,60 @@
+#/***************************************************************
+# *
+# * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License"); you
+# * may not use this file except in compliance with the License.  You may
+# * obtain a copy of the License at
+# *
+# *    http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+# ***************************************************************/
+
+# Configuration options used to test Geo Overrides in sort_test.go
+GeoIPOverrides:
+  # Valid IPv4
+  - IP: "192.168.0.1"
+    Coordinate:
+      Lat: 123.4
+      Long: 987.6
+  # Valid IPv4 CIDR
+  - IP: "10.0.0.0/24"
+    Coordinate:
+      Lat: 43.073904
+      Long: -89.384859
+  # Malformed IPv4
+  - IP: "192.168.0"
+    Coordinate:
+      Lat: 1000.0
+      Long: 2000.0
+  # Malformed IPv4 CIDR
+  - IP: "10.0.0./24"
+    Coordinate:
+      Lat: 1000.0
+      Long: 2000.0
+  # Valid IPv6
+  - IP: "FC00:0000:0000:0000:0000:0000:0000:0001"
+    Coordinate:
+      Lat: 123.4
+      Long: 987.6
+  # Valid IPv6
+  - IP: "FD00::FAB2/112"
+    Coordinate:
+      Lat: 43.073904
+      Long: -89.384859
+  # Malformed IPv6
+  - IP: "FD00::000G"
+    Coordinate:
+      Lat: 1000.0
+      Long: 2000.0
+  # Malformed IPv6
+  - IP: "FD00::000F/11S"
+    Coordinate:
+      Lat: 1000.0
+      Long: 2000.0

--- a/director/sort.go
+++ b/director/sort.go
@@ -93,7 +93,10 @@ func (me SwapMaps) Swap(left, right int) {
 func checkOverrides(addr net.IP) (coordinate *Coordinate) {
 	// Unmarshal the values, but only the first time we run through this block
 	if geoIPOverrides == nil {
-		_ = param.GeoIPOverrides.Unmarshal(&geoIPOverrides)
+		err := param.GeoIPOverrides.Unmarshal(&geoIPOverrides)
+		if err != nil {
+			log.Warningf("Error while unmarshaling GeoIP Overrides: %v", err)
+		}
 	}
 
 	for _, geoIPOverride := range geoIPOverrides {

--- a/director/sort.go
+++ b/director/sort.go
@@ -21,7 +21,6 @@ package director
 import (
 	"archive/tar"
 	"compress/gzip"
-	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -37,9 +36,11 @@ import (
 	"time"
 
 	"github.com/oschwald/geoip2-golang"
-	"github.com/pelicanplatform/pelican/param"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+
+	"github.com/pelicanplatform/pelican/param"
 )
 
 const (
@@ -59,6 +60,19 @@ type (
 	SwapMaps []SwapMap
 )
 
+type Coordinate struct {
+	Lat  float64 `mapstructure:"lat"`
+	Long float64 `mapstructure:"long"`
+}
+
+type GeoIPOverride struct {
+	IP         string     `mapstructure:"IP"`
+	Coordinate Coordinate `mapstructure:"Coordinate"`
+}
+
+var invalidOverrideLogOnce = map[string]bool{}
+var geoIPOverrides []GeoIPOverride
+
 func (me SwapMaps) Len() int {
 	return len(me)
 }
@@ -71,8 +85,61 @@ func (me SwapMaps) Swap(left, right int) {
 	me[left], me[right] = me[right], me[left]
 }
 
+// Check for any pre-configured IP-to-lat/long overrides. If the passed address
+// matches an override IP (either directly or via CIDR masking), then we use the
+// configured lat/long from the override instead of relying on MaxMind.
+// NOTE: We don't return an error because if checkOverrides encounters an issue,
+// we still have GeoIP to fall back on.
+func checkOverrides(addr net.IP) (coordinate *Coordinate) {
+	// Unmarshal the values, but only the first time we run through this block
+	if geoIPOverrides == nil {
+		_ = param.GeoIPOverrides.Unmarshal(&geoIPOverrides)
+	}
+
+	for _, geoIPOverride := range geoIPOverrides {
+		// Check for regular IP addresses before CIDR
+		overrideIP := net.ParseIP(geoIPOverride.IP)
+		if overrideIP == nil {
+			// The IP is malformed
+			if !invalidOverrideLogOnce[geoIPOverride.IP] && !strings.Contains(geoIPOverride.IP, "/") {
+				// Don't return here, because we have more to check.
+				// Do provide a notice to the user, however.
+				log.Warningf("Failed to parse configured GeoIPOverride address (%s). Unable to use for GeoIP resolution!", geoIPOverride.IP)
+				invalidOverrideLogOnce[geoIPOverride.IP] = true
+			}
+		}
+		if overrideIP.Equal(addr) {
+			return &geoIPOverride.Coordinate
+		}
+
+		// Alternatively, we can match by CIDR blocks
+		if strings.Contains(geoIPOverride.IP, "/") {
+			_, ipNet, err := net.ParseCIDR(geoIPOverride.IP)
+			if err != nil {
+				if !invalidOverrideLogOnce[geoIPOverride.IP] {
+					// Same reason as above for not returning.
+					log.Warningf("Failed to parse configured GeoIPOverride CIDR address (%s): %v. Unable to use for GeoIP resolution!", geoIPOverride.IP, err)
+					invalidOverrideLogOnce[geoIPOverride.IP] = true
+				}
+				continue
+			}
+			if ipNet.Contains(addr) {
+				return &geoIPOverride.Coordinate
+			}
+		}
+	}
+
+	return nil
+}
+
 func GetLatLong(addr netip.Addr) (lat float64, long float64, err error) {
 	ip := net.IP(addr.AsSlice())
+	override := checkOverrides(ip)
+	if override != nil {
+		log.Infof("Overriding Geolocation of detected IP (%s) to lat:long %f:%f based on configured overrides", ip.String(), (override.Lat), override.Long)
+		return override.Lat, override.Long, nil
+	}
+
 	reader := maxMindReader.Load()
 	if reader == nil {
 		err = errors.New("No GeoIP database is available")
@@ -84,13 +151,19 @@ func GetLatLong(addr netip.Addr) (lat float64, long float64, err error) {
 	}
 	lat = record.Location.Latitude
 	long = record.Location.Longitude
+
+	if lat == 0 && long == 0 {
+		log.Infof("GeoIP Resolution of the address %s resulted in the nul lat/long.", ip.String())
+	}
 	return
 }
 
 func SortServers(addr netip.Addr, ads []ServerAd) ([]ServerAd, error) {
 	distances := make(SwapMaps, len(ads))
 	lat, long, err := GetLatLong(addr)
-	isInvalid := err != nil
+	// If we don't get a valid coordinate set for the incoming address, either because
+	// of an error or the null address, we randomize the output
+	isInvalid := (err != nil || (lat == 0 && long == 0))
 	for idx, ad := range ads {
 		if isInvalid || (ad.Latitude == 0 && ad.Longitude == 0) {
 			// Unable to compute distances for this server; just do random distances.

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -1,0 +1,149 @@
+package director
+
+import (
+	"bytes"
+	"net"
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckOverrides(t *testing.T) {
+	viper.Reset()
+
+	// We'll also check that our logging feature responsibly reports
+	// what Pelican is telling the user.
+	logOutput := &(bytes.Buffer{})
+	log.SetOutput(logOutput)
+	log.SetLevel(log.DebugLevel)
+
+	// Mockup of the YAML we need to kick off the tests. Note that if you mess with it, you need to
+	// make sure the indentations are spaces.
+	yamlMockup := `
+GeoIPOverrides:
+  # Valid IPv4
+  - IP: "192.168.0.1"
+    Coordinate:
+      Lat: 123.4
+      Long: 987.6
+  # Valid IPv4 CIDR
+  - IP: "10.0.0.0/24"
+    Coordinate:
+      Lat: 43.073904
+      Long: -89.384859
+  # Malformed IPv4
+  - IP: "192.168.0"
+    Coordinate:
+      Lat: 1000.0
+      Long: 2000.0
+  # Malformed IPv4 CIDR
+  - IP: "10.0.0./24"
+    Coordinate:
+      Lat: 1000.0
+      Long: 2000.0
+  # Valid IPv6
+  - IP: "FC00:0000:0000:0000:0000:0000:0000:0001"
+    Coordinate:
+      Lat: 123.4
+      Long: 987.6
+  # Valid IPv6
+  - IP: "FD00::FAB2/112"
+    Coordinate:
+      Lat: 43.073904
+      Long: -89.384859
+  # Malformed IPv6
+  - IP: "FD00::000G"
+    Coordinate:
+      Lat: 1000.0
+      Long: 2000.0
+  # Malformed IPv6
+  - IP: "FD00::000F/11S"
+    Coordinate:
+      Lat: 1000.0
+      Long: 2000.0
+`
+
+	viper.SetConfigType("yaml")
+	err := viper.ReadConfig(strings.NewReader(yamlMockup))
+	if err != nil {
+		t.Fatalf("Error reading config: %v", err)
+	}
+
+	t.Run("test-no-ipv4-match", func(t *testing.T) {
+		// In the event that no override is detected, `checkOverrides` should return a nil override
+		addr := net.ParseIP("192.168.0.2")
+		coordinate := checkOverrides(addr)
+		require.Nil(t, coordinate)
+	})
+
+	t.Run("test-no-ipv6-match", func(t *testing.T) {
+		addr := net.ParseIP("ABCD::0123")
+		coordinate := checkOverrides(addr)
+		require.Nil(t, coordinate)
+	})
+
+	t.Run("test-log-output", func(t *testing.T) {
+		// Check that the log caught our malformed IP and CIDR. We only need to test this once, because it is only logged the very first time.
+		require.Contains(t, logOutput.String(), "Failed to parse configured GeoIPOverride address (192.168.0). Unable to use for GeoIP resolution!")
+		require.Contains(t, logOutput.String(), "Failed to parse configured GeoIPOverride CIDR address (10.0.0./24): invalid CIDR address: 10.0.0./24."+
+			" Unable to use for GeoIP resolution!")
+		require.Contains(t, logOutput.String(), "Failed to parse configured GeoIPOverride address (FD00::000G). Unable to use for GeoIP resolution!")
+		require.Contains(t, logOutput.String(), "Failed to parse configured GeoIPOverride CIDR address (FD00::000F/11S): invalid CIDR address: FD00::000F/11S."+
+			" Unable to use for GeoIP resolution!")
+	})
+
+	t.Run("test-ipv4-match", func(t *testing.T) {
+		// When we match against a regular IPv4, we expect a non-nil coordinate
+		expectedCoordinate := Coordinate{
+			Lat:  123.4,
+			Long: 987.6,
+		}
+
+		addr := net.ParseIP("192.168.0.1")
+		coordinate := checkOverrides(addr)
+		require.Equal(t, expectedCoordinate.Lat, coordinate.Lat)
+		require.Equal(t, expectedCoordinate.Long, coordinate.Long)
+	})
+
+	t.Run("test-ipv4-CIDR-match", func(t *testing.T) {
+		// Same goes for CIDR matches
+		expectedCoordinate := Coordinate{
+			Lat:  43.073904,
+			Long: -89.384859,
+		}
+
+		addr := net.ParseIP("10.0.0.136")
+		coordinate := checkOverrides(addr)
+		require.Equal(t, expectedCoordinate.Lat, coordinate.Lat)
+		require.Equal(t, expectedCoordinate.Long, coordinate.Long)
+	})
+
+	t.Run("test-ipv6-match", func(t *testing.T) {
+		expectedCoordinate := Coordinate{
+			Lat:  123.4,
+			Long: 987.6,
+		}
+
+		addr := net.ParseIP("FC00::0001")
+		coordinate := checkOverrides(addr)
+		require.Equal(t, expectedCoordinate.Lat, coordinate.Lat)
+		require.Equal(t, expectedCoordinate.Long, coordinate.Long)
+	})
+
+	t.Run("test-ipv6-CIDR-match", func(t *testing.T) {
+		expectedCoordinate := Coordinate{
+			Lat:  43.073904,
+			Long: -89.384859,
+		}
+
+		addr := net.ParseIP("FD00::FA1B")
+		coordinate := checkOverrides(addr)
+		require.Equal(t, expectedCoordinate.Lat, coordinate.Lat)
+		require.Equal(t, expectedCoordinate.Long, coordinate.Long)
+	})
+
+	viper.Reset()
+}

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -2,6 +2,7 @@ package director
 
 import (
 	"bytes"
+	_ "embed"
 	"net"
 	"strings"
 	"testing"
@@ -11,6 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Geo Override Yaml mockup
+//
+//go:embed resources/geoip_overrides.yaml
+var yamlMockup string
+
 func TestCheckOverrides(t *testing.T) {
 	viper.Reset()
 
@@ -19,52 +25,6 @@ func TestCheckOverrides(t *testing.T) {
 	logOutput := &(bytes.Buffer{})
 	log.SetOutput(logOutput)
 	log.SetLevel(log.DebugLevel)
-
-	// Mockup of the YAML we need to kick off the tests. Note that if you mess with it, you need to
-	// make sure the indentations are spaces.
-	yamlMockup := `
-GeoIPOverrides:
-  # Valid IPv4
-  - IP: "192.168.0.1"
-    Coordinate:
-      Lat: 123.4
-      Long: 987.6
-  # Valid IPv4 CIDR
-  - IP: "10.0.0.0/24"
-    Coordinate:
-      Lat: 43.073904
-      Long: -89.384859
-  # Malformed IPv4
-  - IP: "192.168.0"
-    Coordinate:
-      Lat: 1000.0
-      Long: 2000.0
-  # Malformed IPv4 CIDR
-  - IP: "10.0.0./24"
-    Coordinate:
-      Lat: 1000.0
-      Long: 2000.0
-  # Valid IPv6
-  - IP: "FC00:0000:0000:0000:0000:0000:0000:0001"
-    Coordinate:
-      Lat: 123.4
-      Long: 987.6
-  # Valid IPv6
-  - IP: "FD00::FAB2/112"
-    Coordinate:
-      Lat: 43.073904
-      Long: -89.384859
-  # Malformed IPv6
-  - IP: "FD00::000G"
-    Coordinate:
-      Lat: 1000.0
-      Long: 2000.0
-  # Malformed IPv6
-  - IP: "FD00::000F/11S"
-    Coordinate:
-      Lat: 1000.0
-      Long: 2000.0
-`
 
 	viper.SetConfigType("yaml")
 	err := viper.ReadConfig(strings.NewReader(yamlMockup))

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -105,6 +105,32 @@ type: duration
 default: 10s
 components: ["client", "nsregistry", "origin"]
 ---
+name: GeoIPOverrides
+description: >-
+  A list of IP addresses whose GeoIP resolution should be overridden with the supplied Lat/Long coordinates (in decimal form). This affects
+  both server ads (for determining the location of origins and caches) and incoming client requests (for determing where a client request is
+  coming from).
+
+  Configuration takes an IP address (both regular and CIDR) and a Coordinate made up of a lat/long pair in decimal format. For example:
+  ```
+  GeoIPOverrides:
+    - IP: "123.234.123.234"
+      Coordinate:
+        Lat: 43.073904
+        Long: -89.384859
+    - IP: "ABCD::1234/112"
+      Coordinate:
+        Lat: 39.8281
+        Long: -98.5795
+  ```
+
+  will result in the IP address "123.234.123.234" being mapped to Madison, WI, and IP addresses in the range ABCD::0000-FFFF will be mapped
+  to a field in Kansas.
+type: object
+default: none
+components: ["director"]
+---
+
 ############################
 #     Log-Level Configs    #
 ############################


### PR DESCRIPTION
First and foremost, this allows a director to configure IP blocks that we want to directly map to a lat/long pair. Valid IPs include IPv4 and IPv6, both masked and unmasked. In the event that MaxMind either doesn't contain a coordinate for an IP or we just don't like the coordinate it returns, we can now set where we want a director to think the server is. Note that this affects both servers (origins/caches) as well as clients, because we update server coordinates at ad recording time, and we get client coordinates at redirect time.

One small change is that we now log at the Director when an IP address results in the null coordinate. This should allow us to filter such requests in the logs when we're collecting metrics.

This also fixes another small bug that's been annoying me -- we don't treat the null address as a "bad" coordinate, which means that if MaxMind can't resolve a lat/long for a particular incoming client request, we send them to null island. Instead, the change in this commit that checks for lat/long == (0,0) in SortServers will cause a client IP resolving to the null coordinate to be redirected to a randomly-ordered list of caches.

One thing to note is that I don't test some of the functions I modify if those functions require access to a MaxMind database. That's definitely something we want to figure out at some point, and while we could create an API key for caching the database in our GH runners, we'd also want to set up the tests to skip if no database/key are present. That seems like it's outside the scope of what I'm trying to do here.