### PR TITLE
Pelican authfile fix

### DIFF
--- a/cmd/director_serve.go
+++ b/cmd/director_serve.go
@@ -58,8 +58,8 @@ func serveDirector( /*cmd*/ *cobra.Command /*args*/, []string) error {
 		if err := director.AdvertiseOSDF(); err != nil {
 			panic(err)
 		}
+		go director.PeriodicCacheReload()
 	}
-	go director.PeriodicCacheReload()
 
 	director.ConfigTTLCache(shutdownCtx, &wg)
 	wg.Add(1) // Add to wait group after ConfigTTLCache finishes to avoid deadlock

--- a/config/config.go
+++ b/config/config.go
@@ -484,10 +484,6 @@ func InitServer(sType ServerType) error {
 	viper.SetDefault("Server.TLSCertificate", filepath.Join(configDir, "certificates", "tls.crt"))
 	viper.SetDefault("Server.TLSKey", filepath.Join(configDir, "certificates", "tls.key"))
 	viper.SetDefault("Server.TLSCAKey", filepath.Join(configDir, "certificates", "tlsca.key"))
-	viper.SetDefault("Xrootd.RobotsTxtFile", filepath.Join(configDir, "robots.txt"))
-	viper.SetDefault("Xrootd.ScitokensConfig", filepath.Join(configDir, "xrootd", "scitokens.cfg"))
-	viper.SetDefault("Xrootd.Authfile", filepath.Join(configDir, "xrootd", "authfile"))
-	viper.SetDefault("Xrootd.MacaroonsKeyFile", filepath.Join(configDir, "macaroons-secret"))
 	viper.SetDefault("IssuerKey", filepath.Join(configDir, "issuer.jwk"))
 	viper.SetDefault("Server.UIPasswordFile", filepath.Join(configDir, "server-web-passwd"))
 	viper.SetDefault("Server.UIActivationCodeFile", filepath.Join(configDir, "server-web-activation-code"))
@@ -526,6 +522,13 @@ func InitServer(sType ServerType) error {
 		}
 		viper.SetDefault("Origin.Multiuser", false)
 	}
+
+	xrootdRunDir := param.Xrootd_RunLocation.GetString()
+	viper.SetDefault("Xrootd.RobotsTxtFile", filepath.Join(xrootdRunDir, "robots.txt"))
+	viper.SetDefault("Xrootd.ScitokensConfig", filepath.Join(xrootdRunDir, "scitokens.cfg"))
+	viper.SetDefault("Xrootd.Authfile", filepath.Join(xrootdRunDir, "authfile-generated"))
+	viper.SetDefault("Xrootd.MacaroonsKeyFile", filepath.Join(xrootdRunDir, "macaroons-secret"))
+
 	// Any platform-specific paths should go here
 	err := InitServerOSDefaults()
 	if err != nil {


### PR DESCRIPTION
Two fixes, one which fixes the xrootd run file locations and one which moves the topology PeriodicReload to be behind the OSDF flag.