### PR TITLE
Refactor `config.ServerType` to provide a globally accessible source for server(s) enabled

### DIFF
--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -43,7 +43,7 @@ var (
 )
 
 func initCache() error {
-	err := config.InitServer([]config.ServerType{config.CacheType})
+	err := config.InitServer([]config.ServerType{config.CacheType}, config.CacheType)
 	cobra.CheckErr(err)
 	metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusCritical, "xrootd has not been started")
 	metrics.SetComponentHealthStatus(metrics.OriginCache_CMSD, metrics.StatusCritical, "cmsd has not been started")

--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -43,7 +43,7 @@ var (
 )
 
 func initCache() error {
-	err := config.InitServer(config.CacheType)
+	err := config.InitServer([]config.ServerType{config.CacheType})
 	cobra.CheckErr(err)
 	metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusCritical, "xrootd has not been started")
 	metrics.SetComponentHealthStatus(metrics.OriginCache_CMSD, metrics.StatusCritical, "cmsd has not been started")

--- a/cmd/director.go
+++ b/cmd/director.go
@@ -71,7 +71,7 @@ func getDirectorEndpoint() (string, error) {
 }
 
 func initDirector() error {
-	err := config.InitServer([]config.ServerType{config.DirectorType})
+	err := config.InitServer([]config.ServerType{config.DirectorType}, config.DirectorType)
 	cobra.CheckErr(err)
 
 	return err

--- a/cmd/director.go
+++ b/cmd/director.go
@@ -71,7 +71,7 @@ func getDirectorEndpoint() (string, error) {
 }
 
 func initDirector() error {
-	err := config.InitServer(config.DirectorType)
+	err := config.InitServer([]config.ServerType{config.DirectorType})
 	cobra.CheckErr(err)
 
 	return err

--- a/cmd/director_serve.go
+++ b/cmd/director_serve.go
@@ -72,7 +72,7 @@ func serveDirector( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	// We configure Prometheus differently for director than for the rest servers,
 	// although in the future we probably want to pass the server type to the
 	// metric config function just because each server may have different config
-	if err := web_ui.ConfigureServerWebAPI(engine, true); err != nil {
+	if err := web_ui.ConfigureServerWebAPI(engine); err != nil {
 		return err
 	}
 

--- a/cmd/namespace_registry.go
+++ b/cmd/namespace_registry.go
@@ -56,7 +56,7 @@ var (
 )
 
 func initRegistry() error {
-	err := config.InitServer(config.RegistryType)
+	err := config.InitServer([]config.ServerType{config.RegistryType})
 	cobra.CheckErr(err)
 
 	return err

--- a/cmd/namespace_registry_serve.go
+++ b/cmd/namespace_registry_serve.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pelicanplatform/pelican/config"
-	"github.com/pelicanplatform/pelican/namespace_registry"
+	nsregistry "github.com/pelicanplatform/pelican/namespace_registry"
 	"github.com/pelicanplatform/pelican/web_ui"
 )
 
@@ -56,7 +56,7 @@ func serveNamespaceRegistry( /*cmd*/ *cobra.Command /*args*/, []string) error {
 		return err
 	}
 
-	if err := web_ui.ConfigureServerWebAPI(engine, false); err != nil {
+	if err := web_ui.ConfigureServerWebAPI(engine); err != nil {
 		return err
 	}
 	rootRouterGroup := engine.Group("/")

--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -99,7 +99,7 @@ func configOrigin( /*cmd*/ *cobra.Command /*args*/, []string) {
 }
 
 func initOrigin() error {
-	err := config.InitServer(config.OriginType)
+	err := config.InitServer([]config.ServerType{config.OriginType})
 	cobra.CheckErr(err)
 	metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusCritical, "xrootd has not been started")
 	metrics.SetComponentHealthStatus(metrics.OriginCache_CMSD, metrics.StatusCritical, "cmsd has not been started")

--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -99,7 +99,7 @@ func configOrigin( /*cmd*/ *cobra.Command /*args*/, []string) {
 }
 
 func initOrigin() error {
-	err := config.InitServer([]config.ServerType{config.OriginType})
+	err := config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
 	cobra.CheckErr(err)
 	metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusCritical, "xrootd has not been started")
 	metrics.SetComponentHealthStatus(metrics.OriginCache_CMSD, metrics.StatusCritical, "cmsd has not been started")

--- a/cmd/origin_reset_password_test.go
+++ b/cmd/origin_reset_password_test.go
@@ -36,7 +36,7 @@ func TestResetPassword(t *testing.T) {
 	dirName := t.TempDir()
 	viper.Reset()
 	viper.Set("ConfigDir", dirName)
-	err := config.InitServer(config.OriginType)
+	err := config.InitServer([]config.ServerType{config.OriginType})
 	require.NoError(t, err)
 
 	rootCmd.SetArgs([]string{"origin", "web-ui", "reset-password", "--stdin"})

--- a/cmd/origin_reset_password_test.go
+++ b/cmd/origin_reset_password_test.go
@@ -36,7 +36,7 @@ func TestResetPassword(t *testing.T) {
 	dirName := t.TempDir()
 	viper.Reset()
 	viper.Set("ConfigDir", dirName)
-	err := config.InitServer([]config.ServerType{config.OriginType})
+	err := config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
 	require.NoError(t, err)
 
 	rootCmd.SetArgs([]string{"origin", "web-ui", "reset-password", "--stdin"})

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -70,7 +70,7 @@ func serveOrigin( /*cmd*/ *cobra.Command /*args*/, []string) error {
 
 	if param.Origin_EnableUI.GetBool() {
 		// Set up necessary APIs to support Web UI, including auth and metrics
-		if err := web_ui.ConfigureServerWebAPI(engine, false); err != nil {
+		if err := web_ui.ConfigureServerWebAPI(engine); err != nil {
 			return err
 		}
 	}

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -56,7 +56,7 @@ var (
 )
 
 func initRegistry() error {
-	err := config.InitServer([]config.ServerType{config.RegistryType})
+	err := config.InitServer([]config.ServerType{config.RegistryType}, config.RegistryType)
 	cobra.CheckErr(err)
 
 	return err

--- a/config/config.go
+++ b/config/config.go
@@ -117,14 +117,12 @@ var (
 	transport     *http.Transport
 	onceTransport sync.Once
 
-	// A global variable to be set and access to obtain enabled Pelican servers in the current process
+	// A variable indicating enabled Pelican servers in the current process
 	enabledServers ServerType
 	setServerOnce  sync.Once
 )
 
 // Set sets a list of newServers to ServerType instance
-//
-// DON'T call this function on EnabledServers but call setEnabledServer instead
 func (sType *ServerType) Set(newServers []ServerType) {
 	for _, server := range newServers {
 		*sType |= server
@@ -378,7 +376,7 @@ func parseServerIssuerURL() error {
 		return errors.New("If Server.IssuerHostname is configured, you must provide a valid port")
 	}
 
-	if enabledServers.IsEnabled(OriginType) {
+	if IsServerEnabled(OriginType) {
 		// If Origin.Mode is set to anything that isn't "posix" or "", assume we're running a plugin and
 		// that the origin's issuer URL actually uses the same port as OriginUI instead of XRootD. This is
 		// because under that condition, keys are being served by the Pelican process instead of by XRootD
@@ -510,9 +508,9 @@ func InitServer(servers []ServerType) error {
 	setEnabledServer(servers)
 
 	xrootdPrefix := ""
-	if enabledServers.IsEnabled(OriginType) {
+	if IsServerEnabled(OriginType) {
 		xrootdPrefix = "origin"
-	} else if enabledServers.IsEnabled(CacheType) {
+	} else if IsServerEnabled(CacheType) {
 		xrootdPrefix = "cache"
 	}
 	configDir := viper.GetString("ConfigDir")
@@ -586,7 +584,7 @@ func InitServer(servers []ServerType) error {
 	// they have overridden the defaults.
 	hostname = viper.GetString("Server.Hostname")
 
-	if enabledServers.IsEnabled(CacheType) {
+	if IsServerEnabled(CacheType) {
 		viper.Set("Xrootd.Port", param.Cache_Port.GetInt())
 	}
 	xrootdPort := param.Xrootd_Port.GetInt()

--- a/config/config.go
+++ b/config/config.go
@@ -584,7 +584,7 @@ func InitServer(enabledServers []ServerType, currentServer ServerType) error {
 	// they have overridden the defaults.
 	hostname = viper.GetString("Server.Hostname")
 
-	if IsServerEnabled(CacheType) {
+	if currentServer == CacheType {
 		viper.Set("Xrootd.Port", param.Cache_Port.GetInt())
 	}
 	xrootdPort := param.Xrootd_Port.GetInt()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -159,7 +159,7 @@ func TestEnabledServers(t *testing.T) {
 	t.Run("no-value-set", func(t *testing.T) {
 		enabledServers = 0
 		for _, server := range allServerTypes {
-			assert.False(t, enabledServers.IsEnabled(server))
+			assert.False(t, IsServerEnabled(server))
 		}
 	})
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -153,3 +153,42 @@ func TestInitConfig(t *testing.T) {
 	InitConfig()
 	assert.Equal(t, "", param.Federation_DiscoveryUrl.GetString())
 }
+
+func TestEnabledServers(t *testing.T) {
+	allServerTypes := []ServerType{OriginType, CacheType, DirectorType, RegistryType}
+	t.Run("no-value-set", func(t *testing.T) {
+		enabledServers = 0
+		for _, server := range allServerTypes {
+			assert.False(t, enabledServers.IsEnabled(server))
+		}
+	})
+
+	t.Run("enable-one-server", func(t *testing.T) {
+		for _, server := range allServerTypes {
+			enabledServers = 0
+			// We didn't call setEnabledServer as it will only set once per process
+			enabledServers.Set([]ServerType{server})
+			assert.True(t, IsServerEnabled(server))
+		}
+	})
+
+	t.Run("enable-multiple-servers", func(t *testing.T) {
+		enabledServers = 0
+		enabledServers.Set([]ServerType{OriginType, CacheType})
+		assert.True(t, IsServerEnabled(OriginType))
+		assert.True(t, IsServerEnabled(CacheType))
+	})
+
+	t.Run("setEnabledServer-only-set-once", func(t *testing.T) {
+		enabledServers = 0
+		setEnabledServer([]ServerType{OriginType, CacheType})
+		assert.True(t, IsServerEnabled(OriginType))
+		assert.True(t, IsServerEnabled(CacheType))
+
+		setEnabledServer([]ServerType{DirectorType, RegistryType})
+		assert.True(t, IsServerEnabled(OriginType))
+		assert.True(t, IsServerEnabled(CacheType))
+		assert.False(t, IsServerEnabled(DirectorType))
+		assert.False(t, IsServerEnabled(RegistryType))
+	})
+}

--- a/namespace_registry/client_commands_test.go
+++ b/namespace_registry/client_commands_test.go
@@ -38,7 +38,7 @@ func registryMockup(t *testing.T, testName string) *httptest.Server {
 	ikey := filepath.Join(issuerTempDir, "issuer.jwk")
 	viper.Set("IssuerKey", ikey)
 	viper.Set("Registry.DbLocation", filepath.Join(issuerTempDir, "test.sql"))
-	err := config.InitServer(config.RegistryType)
+	err := config.InitServer([]config.ServerType{config.RegistryType})
 	require.NoError(t, err)
 
 	err = InitializeDB()

--- a/registry/client_commands_test.go
+++ b/registry/client_commands_test.go
@@ -38,7 +38,7 @@ func registryMockup(t *testing.T, testName string) *httptest.Server {
 	ikey := filepath.Join(issuerTempDir, "issuer.jwk")
 	viper.Set("IssuerKey", ikey)
 	viper.Set("Registry.DbLocation", filepath.Join(issuerTempDir, "test.sql"))
-	err := config.InitServer([]config.ServerType{config.RegistryType})
+	err := config.InitServer([]config.ServerType{config.RegistryType}, config.RegistryType)
 	require.NoError(t, err)
 
 	err = InitializeDB()

--- a/server_ui/register_namespace_test.go
+++ b/server_ui/register_namespace_test.go
@@ -56,7 +56,7 @@ func TestRegistration(t *testing.T) {
 	ikey := filepath.Join(issuerTempDir, "issuer.jwk")
 	viper.Set("IssuerKey", ikey)
 	viper.Set("Registry.DbLocation", filepath.Join(issuerTempDir, "test.sql"))
-	err := config.InitServer([]config.ServerType{config.OriginType})
+	err := config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
 	require.NoError(t, err)
 
 	err = registry.InitializeDB()

--- a/server_ui/register_namespace_test.go
+++ b/server_ui/register_namespace_test.go
@@ -56,7 +56,7 @@ func TestRegistration(t *testing.T) {
 	ikey := filepath.Join(issuerTempDir, "issuer.jwk")
 	viper.Set("IssuerKey", ikey)
 	viper.Set("Registry.DbLocation", filepath.Join(issuerTempDir, "test.sql"))
-	err := config.InitServer(config.OriginType)
+	err := config.InitServer([]config.ServerType{config.OriginType})
 	require.NoError(t, err)
 
 	err = nsregistry.InitializeDB()

--- a/server_utils/server_struct.go
+++ b/server_utils/server_struct.go
@@ -18,8 +18,10 @@
 
 package server_utils
 
-import "github.com/pelicanplatform/pelican/config"
-import "github.com/pelicanplatform/pelican/director"
+import (
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/director"
+)
 
 type (
 	XRootDServer interface {

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -36,6 +36,7 @@ import (
 	"github.com/grafana/regexp"
 	"github.com/mwitkow/go-conntrack"
 	"github.com/oklog/run"
+	pelican_config "github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/director"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/utils"
@@ -271,7 +272,8 @@ func (a LogrusAdapter) Log(keyvals ...interface{}) error {
 	return nil
 }
 
-func ConfigureEmbeddedPrometheus(engine *gin.Engine, isDirector bool) error {
+func ConfigureEmbeddedPrometheus(engine *gin.Engine) error {
+	isDirector := pelican_config.IsServerEnabled(pelican_config.DirectorType)
 	cfg := flagConfig{}
 	ListenAddress := fmt.Sprintf("0.0.0.0:%v", param.Server_WebPort.GetInt())
 	cfg.webTimeout = model.Duration(5 * time.Minute)

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -273,6 +273,9 @@ func (a LogrusAdapter) Log(keyvals ...interface{}) error {
 }
 
 func ConfigureEmbeddedPrometheus(engine *gin.Engine) error {
+	// This is fine if each process has only one server enabled
+	// Since the "federation-in-the-box" feature won't include any web components
+	// we can assume that this is the only server to enable
 	isDirector := pelican_config.IsServerEnabled(pelican_config.DirectorType)
 	cfg := flagConfig{}
 	ListenAddress := fmt.Sprintf("0.0.0.0:%v", param.Server_WebPort.GetInt())

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -143,11 +143,11 @@ func configureCommonEndpoints(engine *gin.Engine) error {
 }
 
 // Configure metrics related endpoints, including Prometheus and /health API
-func configureMetrics(engine *gin.Engine, isDirector bool) error {
+func configureMetrics(engine *gin.Engine) error {
 	// Add authorization to /metric endpoint
 	engine.Use(promMetricAuthHandler)
 
-	err := ConfigureEmbeddedPrometheus(engine, isDirector)
+	err := ConfigureEmbeddedPrometheus(engine)
 	if err != nil {
 		return err
 	}
@@ -226,7 +226,7 @@ func waitUntilLogin(ctx context.Context) error {
 // specific paths but just redirect root path to /view.
 //
 // You need to mount the static resources for UI in a separate function
-func ConfigureServerWebAPI(engine *gin.Engine, isDirector bool) error {
+func ConfigureServerWebAPI(engine *gin.Engine) error {
 	if err := configureAuthEndpoints(engine); err != nil {
 		return err
 	}
@@ -236,7 +236,7 @@ func ConfigureServerWebAPI(engine *gin.Engine, isDirector bool) error {
 	if err := configureWebResource(engine); err != nil {
 		return err
 	}
-	if err := configureMetrics(engine, isDirector); err != nil {
+	if err := configureMetrics(engine); err != nil {
 		return err
 	}
 	// Redirect root to /view for web UI

--- a/web_ui/ui_test.go
+++ b/web_ui/ui_test.go
@@ -71,7 +71,7 @@ func TestMain(m *testing.M) {
 
 	// Ensure we load up the default configs.
 	config.InitConfig()
-	if err := config.InitServer([]config.ServerType{config.OriginType}); err != nil {
+	if err := config.InitServer([]config.ServerType{config.OriginType}, config.OriginType); err != nil {
 		fmt.Println("Failed to configure the test module")
 		os.Exit(1)
 	}
@@ -104,7 +104,7 @@ func TestWaitUntilLogin(t *testing.T) {
 	viper.Reset()
 	viper.Set("ConfigDir", dirName)
 	config.InitConfig()
-	err := config.InitServer([]config.ServerType{config.OriginType})
+	err := config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -151,7 +151,7 @@ func TestCodeBasedLogin(t *testing.T) {
 	viper.Reset()
 	viper.Set("ConfigDir", dirName)
 	config.InitConfig()
-	err := config.InitServer([]config.ServerType{config.OriginType})
+	err := config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
 	require.NoError(t, err)
 	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256())
 	require.NoError(t, err)
@@ -203,7 +203,7 @@ func TestPasswordResetAPI(t *testing.T) {
 	viper.Reset()
 	viper.Set("ConfigDir", dirName)
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
-	err := config.InitServer([]config.ServerType{config.OriginType})
+	err := config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
 	require.NoError(t, err)
 	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256())
 	require.NoError(t, err)
@@ -306,7 +306,7 @@ func TestPasswordBasedLoginAPI(t *testing.T) {
 	viper.Reset()
 	config.InitConfig()
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
-	err := config.InitServer([]config.ServerType{config.OriginType})
+	err := config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
 	require.NoError(t, err)
 
 	///////////////////////////SETUP///////////////////////////////////
@@ -420,7 +420,7 @@ func TestWhoamiAPI(t *testing.T) {
 	config.InitConfig()
 	viper.Set("ConfigDir", dirName)
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
-	err := config.InitServer([]config.ServerType{config.OriginType})
+	err := config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
 	require.NoError(t, err)
 	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256())
 	require.NoError(t, err)

--- a/web_ui/ui_test.go
+++ b/web_ui/ui_test.go
@@ -71,7 +71,7 @@ func TestMain(m *testing.M) {
 
 	// Ensure we load up the default configs.
 	config.InitConfig()
-	if err := config.InitServer(config.OriginType); err != nil {
+	if err := config.InitServer([]config.ServerType{config.OriginType}); err != nil {
 		fmt.Println("Failed to configure the test module")
 		os.Exit(1)
 	}
@@ -85,7 +85,7 @@ func TestMain(m *testing.M) {
 	router = gin.Default()
 
 	//Configure Web API
-	err = ConfigureServerWebAPI(router, false)
+	err = ConfigureServerWebAPI(router)
 	if err != nil {
 		fmt.Println("Error configuring web UI")
 		os.Exit(1)
@@ -104,7 +104,7 @@ func TestWaitUntilLogin(t *testing.T) {
 	viper.Reset()
 	viper.Set("ConfigDir", dirName)
 	config.InitConfig()
-	err := config.InitServer(config.OriginType)
+	err := config.InitServer([]config.ServerType{config.OriginType})
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -151,7 +151,7 @@ func TestCodeBasedLogin(t *testing.T) {
 	viper.Reset()
 	viper.Set("ConfigDir", dirName)
 	config.InitConfig()
-	err := config.InitServer(config.OriginType)
+	err := config.InitServer([]config.ServerType{config.OriginType})
 	require.NoError(t, err)
 	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256())
 	require.NoError(t, err)
@@ -203,7 +203,7 @@ func TestPasswordResetAPI(t *testing.T) {
 	viper.Reset()
 	viper.Set("ConfigDir", dirName)
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
-	err := config.InitServer(config.OriginType)
+	err := config.InitServer([]config.ServerType{config.OriginType})
 	require.NoError(t, err)
 	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256())
 	require.NoError(t, err)
@@ -306,7 +306,7 @@ func TestPasswordBasedLoginAPI(t *testing.T) {
 	viper.Reset()
 	config.InitConfig()
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
-	err := config.InitServer(config.OriginType)
+	err := config.InitServer([]config.ServerType{config.OriginType})
 	require.NoError(t, err)
 
 	///////////////////////////SETUP///////////////////////////////////
@@ -420,7 +420,7 @@ func TestWhoamiAPI(t *testing.T) {
 	config.InitConfig()
 	viper.Set("ConfigDir", dirName)
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
-	err := config.InitServer(config.OriginType)
+	err := config.InitServer([]config.ServerType{config.OriginType})
 	require.NoError(t, err)
 	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256())
 	require.NoError(t, err)

--- a/xrootd/authorization.go
+++ b/xrootd/authorization.go
@@ -148,7 +148,7 @@ func EmitAuthfile(server server_utils.XRootDServer) error {
 		words := strings.Fields(lineContents)
 		// There exists a public access already in the authfile
 		if len(words) >= 2 && words[0] == "u" && words[1] == "*" {
-			if server.GetServerType().IsSet(config.OriginType) {
+			if server.GetServerType().IsEnabled(config.OriginType) {
 				// If Origin, add the ./well-known to the authfile
 				output.Write([]byte("u * /.well-known lr " + strings.Join(words[2:], " ") + "\n"))
 			} else {
@@ -158,13 +158,13 @@ func EmitAuthfile(server server_utils.XRootDServer) error {
 		}
 	}
 	// If Origin and no authfile already exists, add the ./well-know to the authfile
-	if !foundPublicLine && server.GetServerType().IsSet(config.OriginType) {
+	if !foundPublicLine && server.GetServerType().IsEnabled(config.OriginType) {
 
 		output.Write([]byte("u * /.well-known lr\n"))
 	}
 
 	// For the cache, add the public namespaces
-	if server.GetServerType().IsSet(config.CacheType) {
+	if server.GetServerType().IsEnabled(config.CacheType) {
 		// If nothing has been written to the output yet
 		var outStr string
 		if !foundPublicLine {

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -131,7 +131,7 @@ func TestGenerateConfig(t *testing.T) {
 	assert.Equal(t, issuer.Name, "")
 
 	viper.Set("Origin.SelfTest", true)
-	err = config.InitServer(config.OriginType)
+	err = config.InitServer([]config.ServerType{config.OriginType})
 	require.NoError(t, err)
 	issuer, err = GenerateMonitoringIssuer()
 	require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestGenerateConfig(t *testing.T) {
 	viper.Set("Origin.SelfTest", false)
 	viper.Set("Origin.ScitokensDefaultUser", "user1")
 	viper.Set("Origin.ScitokensMapSubject", true)
-	err = config.InitServer(config.OriginType)
+	err = config.InitServer([]config.ServerType{config.OriginType})
 	require.NoError(t, err)
 	issuer, err = GenerateOriginIssuer([]string{"/foo/bar/baz", "/another/exported/path"})
 	require.NoError(t, err)
@@ -237,7 +237,7 @@ func TestWriteOriginScitokensConfig(t *testing.T) {
 	viper.Set("Xrootd.RunLocation", dirname)
 	viper.Set("Xrootd.Port", 8443)
 	viper.Set("Server.Hostname", "origin.example.com")
-	err := config.InitServer(config.OriginType)
+	err := config.InitServer([]config.ServerType{config.OriginType})
 	require.Nil(t, err)
 
 	scitokensCfg := param.Xrootd_ScitokensConfig.GetString()

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -131,7 +131,7 @@ func TestGenerateConfig(t *testing.T) {
 	assert.Equal(t, issuer.Name, "")
 
 	viper.Set("Origin.SelfTest", true)
-	err = config.InitServer([]config.ServerType{config.OriginType})
+	err = config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
 	require.NoError(t, err)
 	issuer, err = GenerateMonitoringIssuer()
 	require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestGenerateConfig(t *testing.T) {
 	viper.Set("Origin.SelfTest", false)
 	viper.Set("Origin.ScitokensDefaultUser", "user1")
 	viper.Set("Origin.ScitokensMapSubject", true)
-	err = config.InitServer([]config.ServerType{config.OriginType})
+	err = config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
 	require.NoError(t, err)
 	issuer, err = GenerateOriginIssuer([]string{"/foo/bar/baz", "/another/exported/path"})
 	require.NoError(t, err)
@@ -237,7 +237,7 @@ func TestWriteOriginScitokensConfig(t *testing.T) {
 	viper.Set("Xrootd.RunLocation", dirname)
 	viper.Set("Xrootd.Port", 8443)
 	viper.Set("Server.Hostname", "origin.example.com")
-	err := config.InitServer([]config.ServerType{config.OriginType})
+	err := config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
 	require.Nil(t, err)
 
 	scitokensCfg := param.Xrootd_ScitokensConfig.GetString()

--- a/xrootd/origin_test.go
+++ b/xrootd/origin_test.go
@@ -70,7 +70,7 @@ func originMockup(t *testing.T) context.CancelFunc {
 	// Increase the log level; otherwise, its difficult to debug failures
 	viper.Set("Logging.Level", "Debug")
 	config.InitConfig()
-	err = config.InitServer(config.OriginType)
+	err = config.InitServer([]config.ServerType{config.OriginType})
 	require.NoError(t, err)
 
 	err = config.GeneratePrivateKey(param.Server_TLSKey.GetString(), elliptic.P256())

--- a/xrootd/origin_test.go
+++ b/xrootd/origin_test.go
@@ -70,7 +70,7 @@ func originMockup(t *testing.T) context.CancelFunc {
 	// Increase the log level; otherwise, its difficult to debug failures
 	viper.Set("Logging.Level", "Debug")
 	config.InitConfig()
-	err = config.InitServer([]config.ServerType{config.OriginType})
+	err = config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
 	require.NoError(t, err)
 
 	err = config.GeneratePrivateKey(param.Server_TLSKey.GetString(), elliptic.P256())

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -313,7 +313,7 @@ func CheckXrootdEnv(server server_utils.XRootDServer) error {
 		}
 	}
 
-	if server.GetServerType().IsSet(config.OriginType) {
+	if server.GetServerType().IsEnabled(config.OriginType) {
 		exportPath, err = CheckOriginXrootdEnv(exportPath, uid, gid, groupname)
 	} else {
 		exportPath, err = CheckCacheXrootdEnv(exportPath, uid, gid, server.GetNamespaceAds())


### PR DESCRIPTION
Closes #501 

Now you can use `config.IsServerEnabled` anywhere in the server code to test if a server is enabled. A private function `setEnabledServer` is called in `initServer()` to indicate which server(s) are enabled.

This would be a necessary step for UI to redirect server web UI user to correct server UI landing page.

This can also be used in #172

When browsing through places where we used ServerType, it seems that we had a `XrootDServer` interface that relies on implementation to tell which server is running. I didn't touch that part of the code in this refactoring but if we want I can remove `GetServerType()` from `XrootDServer` interface and replace existing ones to `config.IsServerEnabled`. I'm fine either way. @turetske 