### PR TITLE
Origins now advertise themselves as writebackhosts

### DIFF
--- a/client/director.go
+++ b/client/director.go
@@ -74,7 +74,7 @@ func CreateNsFromDirectorResp(dirResp *http.Response) (namespace namespaces.Name
 	namespace.UseTokenOnRead, _ = strconv.ParseBool(xPelicanNamespace["require-token"])
 	namespace.ReadHTTPS, _ = strconv.ParseBool(xPelicanNamespace["readhttps"])
 	namespace.DirListHost = xPelicanNamespace["collections-url"]
-	namespace.WritebackHost = xPelicanNamespace["writebackhost"]
+	namespace.PutEndpoint = xPelicanNamespace["putendpoint"]
 
 	var xPelicanAuthorization map[string]string
 	if len(dirResp.Header.Values("X-Pelican-Authorization")) > 0 {

--- a/client/director.go
+++ b/client/director.go
@@ -74,6 +74,7 @@ func CreateNsFromDirectorResp(dirResp *http.Response) (namespace namespaces.Name
 	namespace.UseTokenOnRead, _ = strconv.ParseBool(xPelicanNamespace["require-token"])
 	namespace.ReadHTTPS, _ = strconv.ParseBool(xPelicanNamespace["readhttps"])
 	namespace.DirListHost = xPelicanNamespace["collections-url"]
+	namespace.WritebackHost = xPelicanNamespace["writebackhost"]
 
 	var xPelicanAuthorization map[string]string
 	if len(dirResp.Header.Values("X-Pelican-Authorization")) > 0 {
@@ -125,7 +126,11 @@ func CreateNsFromDirectorResp(dirResp *http.Response) (namespace namespaces.Name
 }
 
 func QueryDirector(source string, directorUrl string) (resp *http.Response, err error) {
-	resourceUrl := directorUrl + source
+	resourceUrl, err := url.JoinPath(directorUrl, source)
+	if err != nil {
+		return nil, err
+	}
+
 	// Here we use http.Transport to prevent the client from following the director's
 	// redirect. We use the Location url elsewhere (plus we still need to do the token
 	// dance!)

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -835,7 +835,7 @@ func UploadFile(src string, origDest *url.URL, token string, namespace namespace
 	}
 
 	// Parse the writeback host as a URL
-	writebackhostUrl, err := url.Parse(namespace.WriteBackHost)
+	writebackhostUrl, err := url.Parse(namespace.WritebackHost)
 	if err != nil {
 		return 0, err
 	}
@@ -1089,7 +1089,7 @@ func StatHttp(dest *url.URL, namespace namespaces.Namespace) (uint64, error) {
 	}
 
 	// Parse the writeback host as a URL
-	writebackhostUrl, err := url.Parse(namespace.WriteBackHost)
+	writebackhostUrl, err := url.Parse(namespace.WritebackHost)
 	if err != nil {
 		return 0, err
 	}

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -835,13 +835,13 @@ func UploadFile(src string, origDest *url.URL, token string, namespace namespace
 	}
 
 	// Parse the writeback host as a URL
-	writebackhostUrl, err := url.Parse(namespace.WritebackHost)
+	putEndpointUrl, err := url.Parse(namespace.PutEndpoint)
 	if err != nil {
 		return 0, err
 	}
 
 	dest := &url.URL{
-		Host:   writebackhostUrl.Host,
+		Host:   putEndpointUrl.Host,
 		Scheme: "https",
 		Path:   origDest.Path,
 	}
@@ -1089,11 +1089,11 @@ func StatHttp(dest *url.URL, namespace namespaces.Namespace) (uint64, error) {
 	}
 
 	// Parse the writeback host as a URL
-	writebackhostUrl, err := url.Parse(namespace.WritebackHost)
+	putEndpointUrl, err := url.Parse(namespace.PutEndpoint)
 	if err != nil {
 		return 0, err
 	}
-	dest.Host = writebackhostUrl.Host
+	dest.Host = putEndpointUrl.Host
 	dest.Scheme = "https"
 
 	canDisableProxy := CanDisableProxy()

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -389,7 +389,7 @@ func TestFullUpload(t *testing.T) {
 	testURL, err := url.Parse(ts.URL)
 	assert.NoError(t, err, "Error parsing test URL")
 	testNamespace := namespaces.Namespace{
-		WritebackHost: "https://" + testURL.Host,
+		PutEndpoint: "https://" + testURL.Host,
 	}
 
 	// Upload the file

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -389,7 +389,7 @@ func TestFullUpload(t *testing.T) {
 	testURL, err := url.Parse(ts.URL)
 	assert.NoError(t, err, "Error parsing test URL")
 	testNamespace := namespaces.Namespace{
-		WriteBackHost: "https://" + testURL.Host,
+		WritebackHost: "https://" + testURL.Host,
 	}
 
 	// Upload the file

--- a/client/main.go
+++ b/client/main.go
@@ -501,13 +501,14 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 	OSDFDirectorUrl := param.Federation_DirectorUrl.GetString()
 	useOSDFDirector := viper.IsSet("Federation.DirectorURL")
 
-	var ns namespaces.Namespace
-
 	if destScheme == "stash" || destScheme == "osdf" || destScheme == "pelican" {
 		log.Debugln("Detected writeback")
+		if !strings.HasPrefix(destination, "/") {
+			destination = strings.TrimPrefix(destination, destScheme+"://")
+		}
+		var ns namespaces.Namespace
 		// If we have a director set, go through that for namespace info, otherwise use topology
 		if useOSDFDirector {
-			destination = strings.TrimPrefix(destination, destScheme+"://")
 			dirResp, err := QueryDirector(destination, OSDFDirectorUrl)
 			if err != nil {
 				log.Errorln("Error while querying the Director:", err)
@@ -542,6 +543,8 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 	if string(sourceFile[0]) != "/" {
 		sourceFile = "/" + sourceFile
 	}
+
+	var ns namespaces.Namespace
 	// If we have a director set, go through that for namespace info, otherwise use topology
 	if useOSDFDirector {
 		dirResp, err := QueryDirector(sourceFile, OSDFDirectorUrl)

--- a/cmd/director_serve.go
+++ b/cmd/director_serve.go
@@ -60,8 +60,8 @@ func serveDirector( /*cmd*/ *cobra.Command /*args*/, []string) error {
 		if err := director.AdvertiseOSDF(); err != nil {
 			panic(err)
 		}
+		go director.PeriodicCacheReload()
 	}
-	go director.PeriodicCacheReload()
 
 	director.ConfigTTLCache(shutdownCtx, &wg)
 	wg.Add(1) // Add to wait group after ConfigTTLCache finishes to avoid deadlock

--- a/director/advertise.go
+++ b/director/advertise.go
@@ -78,6 +78,7 @@ func AdvertiseOSDF() error {
 		nsAd.RequireToken = ns.UseTokenOnRead
 		nsAd.Path = ns.Path
 		nsAd.DirlistHost = ns.DirlistHost
+		nsAd.WritebackHost = ns.WritebackHost
 		issuerURL, err := url.Parse(ns.CredentialGeneration.Issuer)
 		if err != nil {
 			log.Warningf("Invalid URL %v when parsing topology response: %v\n", ns.CredentialGeneration.Issuer, err)

--- a/director/advertise.go
+++ b/director/advertise.go
@@ -78,7 +78,7 @@ func AdvertiseOSDF() error {
 		nsAd.RequireToken = ns.UseTokenOnRead
 		nsAd.Path = ns.Path
 		nsAd.DirlistHost = ns.DirlistHost
-		nsAd.WritebackHost = ns.WritebackHost
+		nsAd.PutEndpoint = ns.PutEndpoint
 		issuerURL, err := url.Parse(ns.CredentialGeneration.Issuer)
 		if err != nil {
 			log.Warningf("Invalid URL %v when parsing topology response: %v\n", ns.CredentialGeneration.Issuer, err)

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -43,6 +43,7 @@ type (
 		BasePath      string       `json:"basePath"`
 		VaultServer   string       `json:"vaultServer"`
 		DirlistHost   string       `json:"dirlisthost"`
+		WritebackHost string       `json:"writebackhost"`
 	}
 
 	ServerAd struct {

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -43,7 +43,7 @@ type (
 		BasePath      string       `json:"basePath"`
 		VaultServer   string       `json:"vaultServer"`
 		DirlistHost   string       `json:"dirlisthost"`
-		WritebackHost string       `json:"writebackhost"`
+		PutEndpoint   string       `json:"writebackhost"`
 	}
 
 	ServerAd struct {

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -227,8 +227,8 @@ func RedirectToCache(ginCtx *gin.Context) {
 			ginCtx.Writer.Header()["X-Pelican-Token-Generation"] = []string{tokenGen}
 		}
 	}
-	ginCtx.Writer.Header()["X-Pelican-Namespace"] = []string{fmt.Sprintf("namespace=%s, require-token=%v, collections-url=%s, writebackhost=%s",
-		namespaceAd.Path, namespaceAd.RequireToken, namespaceAd.DirlistHost, namespaceAd.WritebackHost)}
+	ginCtx.Writer.Header()["X-Pelican-Namespace"] = []string{fmt.Sprintf("namespace=%s, require-token=%v, collections-url=%s, putendpoint=%s",
+		namespaceAd.Path, namespaceAd.RequireToken, namespaceAd.DirlistHost, namespaceAd.PutEndpoint)}
 
 	// Note we only append the `authz` query parameter in the case of the redirect response and not the
 	// duplicate link metadata above.  This is purposeful: the Link header might get too long if we repeat

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -227,8 +227,8 @@ func RedirectToCache(ginCtx *gin.Context) {
 			ginCtx.Writer.Header()["X-Pelican-Token-Generation"] = []string{tokenGen}
 		}
 	}
-	ginCtx.Writer.Header()["X-Pelican-Namespace"] = []string{fmt.Sprintf("namespace=%s, require-token=%v, collections-url=%s",
-		namespaceAd.Path, namespaceAd.RequireToken, namespaceAd.DirlistHost)}
+	ginCtx.Writer.Header()["X-Pelican-Namespace"] = []string{fmt.Sprintf("namespace=%s, require-token=%v, collections-url=%s, writebackhost=%s",
+		namespaceAd.Path, namespaceAd.RequireToken, namespaceAd.DirlistHost, namespaceAd.WritebackHost)}
 
 	// Note we only append the `authz` query parameter in the case of the redirect response and not the
 	// duplicate link metadata above.  This is purposeful: the Link header might get too long if we repeat

--- a/namespaces/namespaces.go
+++ b/namespaces/namespaces.go
@@ -86,7 +86,7 @@ type Namespace struct {
 	Issuer               string                `json:"issuer"`
 	ReadHTTPS            bool                  `json:"readhttps"`
 	UseTokenOnRead       bool                  `json:"usetokenonread"`
-	WriteBackHost        string                `json:"writebackhost"`
+	WritebackHost        string                `json:"writebackhost"`
 	DirListHost          string                `json:"dirlisthost"`
 }
 

--- a/namespaces/namespaces.go
+++ b/namespaces/namespaces.go
@@ -86,7 +86,7 @@ type Namespace struct {
 	Issuer               string                `json:"issuer"`
 	ReadHTTPS            bool                  `json:"readhttps"`
 	UseTokenOnRead       bool                  `json:"usetokenonread"`
-	WritebackHost        string                `json:"writebackhost"`
+	PutEndpoint          string                `json:"writebackhost"`
 	DirListHost          string                `json:"dirlisthost"`
 }
 

--- a/namespaces/namespaces_test.go
+++ b/namespaces/namespaces_test.go
@@ -175,7 +175,7 @@ func TestFullNamespace(t *testing.T) {
 	assert.Equal(t, true, ns.ReadHTTPS)
 	assert.Equal(t, true, ns.UseTokenOnRead)
 	assert.Equal(t, "/ospool/PROTECTED", ns.Path)
-	assert.Equal(t, "https://origin-auth2001.chtc.wisc.edu:1095", ns.WriteBackHost)
+	assert.Equal(t, "https://origin-auth2001.chtc.wisc.edu:1095", ns.WritebackHost)
 
 }
 

--- a/namespaces/namespaces_test.go
+++ b/namespaces/namespaces_test.go
@@ -175,7 +175,7 @@ func TestFullNamespace(t *testing.T) {
 	assert.Equal(t, true, ns.ReadHTTPS)
 	assert.Equal(t, true, ns.UseTokenOnRead)
 	assert.Equal(t, "/ospool/PROTECTED", ns.Path)
-	assert.Equal(t, "https://origin-auth2001.chtc.wisc.edu:1095", ns.WritebackHost)
+	assert.Equal(t, "https://origin-auth2001.chtc.wisc.edu:1095", ns.PutEndpoint)
 
 }
 

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -62,6 +62,8 @@ func (server *OriginServer) CreateAdvertisement(name string, originUrl string, o
 		MaxScopeDepth: 3,
 		Strategy:      "OAuth2",
 		BasePath:      prefix,
+		// TODO: This is set to the origin for now needs to become configurable
+		WritebackHost: originUrl,
 	}
 	ad = director.OriginAdvertise{
 		Name:       name,

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -63,7 +63,7 @@ func (server *OriginServer) CreateAdvertisement(name string, originUrl string, o
 		Strategy:      "OAuth2",
 		BasePath:      prefix,
 		// TODO: This is set to the origin for now needs to become configurable
-		WritebackHost: originUrl,
+		PutEndpoint: originUrl,
 	}
 	ad = director.OriginAdvertise{
 		Name:       name,

--- a/utils/web_utils.go
+++ b/utils/web_utils.go
@@ -56,7 +56,7 @@ type (
 		Path                 string               `json:"path"`
 		ReadHTTPS            bool                 `json:"readhttps"`
 		UseTokenOnRead       bool                 `json:"usetokenonread"`
-		WritebackHost        string               `json:"writebackhost"`
+		PutEndpoint          string               `json:"writebackhost"`
 	}
 
 	TopologyNamespacesJSON struct {


### PR DESCRIPTION
This is a bandaid fix for now to allow origins to show themselves as writeback hosts to allow for puts. This helps seperate them from relying on topology to get this information. This is just a band-aid for now, as we should make the writebackhost configurable and able to be set or not set when an origin is spun up.