### PR TITLE
Match binary name by prefix, not exact match

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,9 +39,9 @@ func handleCLI(args []string) error {
 	// Being case-insensitive
 	execName = strings.ToLower(execName)
 
-	if execName == "stash_plugin" || execName == "osdf_plugin" || execName == "pelican_xfer_plugin" {
+	if strings.HasPrefix(execName, "stash_plugin") || strings.HasPrefix(execName, "osdf_plugin") || strings.HasPrefix(execName, "pelican_xfer_plugin") {
 		stashPluginMain(args[1:])
-	} else if execName == "stashcp" {
+	} else if strings.HasPrefix(execName, "stashcp") {
 		err := copyCmd.Execute()
 		if err != nil {
 			return err

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -55,7 +55,7 @@ func init() {
 	flagSet.StringP("cache-list-name", "n", "xroot", "(Deprecated) Cache list to use, currently either xroot or xroots; may be ignored")
 	flagSet.Lookup("cache-list-name").Hidden = true
 	// All the deprecated or hidden flags that are only relevant if we are in historical "stashcp mode"
-	if execName == "stashcp" {
+	if strings.HasPrefix(execName, "stashcp") {
 		copyCmd.Use = "stashcp {source ...} {destination}"
 		copyCmd.Short = "Copy a file to/from the OSDF"
 		flagSet.Lookup("cache-list-name").Hidden = false // Expose the help for this option
@@ -82,7 +82,7 @@ func copyMain(cmd *cobra.Command, args []string) {
 	client.ObjectClientOptions.Version = version
 
 	// Need to check just stashcp since it does not go through root, the other modes get checked there
-	if execName == "stashcp" {
+	if strings.HasPrefix(execName, "stashcp") {
 		if val, err := cmd.Flags().GetBool("debug"); err == nil && val {
 			config.SetLogging(log.DebugLevel)
 		} else {


### PR DESCRIPTION
This allows us to version the binary by naming it something like <prefix>-7.2.2

Closes #513 