### PR TITLE
Create hidden pelican serve mode

### DIFF
--- a/cmd/cache_serve.go
+++ b/cmd/cache_serve.go
@@ -73,6 +73,15 @@ func getNSAdsFromDirector() ([]director.NamespaceAd, error) {
 }
 
 func serveCache( /*cmd*/ *cobra.Command /*args*/, []string) error {
+	err := serveCacheInternal()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func serveCacheInternal() error {
 	// Use this context for any goroutines that needs to react to server shutdown
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	// Use this wait group to ensure the goroutines can finish before the server exits/shutdown

--- a/cmd/director_serve.go
+++ b/cmd/director_serve.go
@@ -36,6 +36,15 @@ import (
 )
 
 func serveDirector( /*cmd*/ *cobra.Command /*args*/, []string) error {
+	err := serveDirectorInternal()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func serveDirectorInternal() error {
 	// Use this context for any goroutines that needs to react to server shutdown
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	// Use this wait group to ensure the goroutines can finish before the server exits/shutdown
@@ -60,8 +69,8 @@ func serveDirector( /*cmd*/ *cobra.Command /*args*/, []string) error {
 		if err := director.AdvertiseOSDF(); err != nil {
 			panic(err)
 		}
+		go director.PeriodicCacheReload()
 	}
-	go director.PeriodicCacheReload()
 
 	director.ConfigTTLCache(shutdownCtx, &wg)
 	wg.Add(1) // Add to wait group after ConfigTTLCache finishes to avoid deadlock

--- a/cmd/fed.go
+++ b/cmd/fed.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -33,13 +34,16 @@ var (
 		 If the director or namespace registry are enabled, then ensure there is a corresponding url in the
 		 pelican.yaml file.
 
-		 NOTE: This currently doesn't guarantee support for the web UIs`,
+		 This feature doesn't currently support the web UIs`,
 		RunE: fedServeStart,
 	}
 )
 
 func init() {
-	serveCmd.Flags().StringSlice("modules", []string{}, "Modules to be started.")
+	serveCmd.Flags().StringSlice("module", []string{}, "Modules to be started.")
+	if err := viper.BindPFlag("Server.Modules", serveCmd.Flags().Lookup("module")); err != nil {
+		panic(err)
+	}
 	serveCmd.Flags().Uint16("reg-port", 8446, "Port for the namespace registry")
 	serveCmd.Flags().Uint16("director-port", 8445, "Port for the director")
 	serveCmd.Flags().Uint16("origin-port", 8443, "Port for the origin")

--- a/cmd/fed.go
+++ b/cmd/fed.go
@@ -1,0 +1,47 @@
+/***************************************************************
+ *
+ * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	serveCmd = &cobra.Command{
+		Use:    "serve",
+		Hidden: true,
+		Short:  "Starts pelican with a list of enabled modules",
+		Long: `Starts pelican with a list of enabled modules [registry, director, cache, origin] to enable better
+		 end-to-end and integration testing.
+
+		 If the director or namespace registry are enabled, then ensure there is a corresponding url in the
+		 pelican.yaml file.
+
+		 NOTE: This currently doesn't guarantee support for the web UIs`,
+		RunE: fedServeStart,
+	}
+)
+
+func init() {
+	serveCmd.Flags().StringSlice("modules", []string{}, "Modules to be started.")
+	serveCmd.Flags().Uint16("reg-port", 8446, "Port for the namespace registry")
+	serveCmd.Flags().Uint16("director-port", 8445, "Port for the director")
+	serveCmd.Flags().Uint16("origin-port", 8443, "Port for the origin")
+	serveCmd.Flags().Uint16("cache-port", 8442, "Port for the cache")
+}

--- a/cmd/fed_serve.go
+++ b/cmd/fed_serve.go
@@ -27,119 +27,92 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-var currentModules = map[string]string{"registry": "", "director": "", "origin": ""}
-var cModsStringList = "registry, director, origin"
-
-func fedCheckWorking(reqUrl string, server string) error {
-	expiry := time.Now().Add(10 * time.Second)
-	success := false
-	for !(success || time.Now().After(expiry)) {
-		time.Sleep(50 * time.Millisecond)
-		req, err := http.NewRequest("GET", reqUrl, nil)
-		if err != nil {
-			return err
-		}
-		httpClient := http.Client{
-			Transport: config.GetTransport(),
-			Timeout:   50 * time.Millisecond,
-		}
-		_, err = httpClient.Do(req)
-		if err != nil {
-			log.Infoln("Failed to send request to "+server+"; likely server is not up (will retry in 50ms):", err)
-		} else {
-			success = true
-			log.Debugln(server + " server appears to be functioning")
-		}
-	}
-
-	return nil
+type modulePorts struct {
+	Registry uint16
+	Director uint16
+	Origin   uint16
 }
 
 func fedServeStart(cmd *cobra.Command, args []string) error {
-	moduleSlice, err := cmd.Flags().GetStringSlice("modules")
-	if err != nil {
-		return errors.Wrap(err, "Failed to load modules passed via --module flag")
+	moduleSlice := param.Server_Modules.GetStringSlice()
+	if len(moduleSlice) == 0 {
+		return errors.New("No modules are enabled; pass the --module flag or set the Server.Modules parameter")
 	}
-	// Faking a set of certain values
-	var moduleMap map[string]uint16 = map[string]uint16{}
-	for _, mod := range moduleSlice {
-		if _, ok := currentModules[mod]; ok {
-			switch mod {
-			case "registry":
-				port, err := cmd.Flags().GetUint16("reg-port")
-				if err != nil {
-					return errors.Wrap(err, "Failed to parse registry port")
-				}
-				moduleMap[mod] = port
-			case "director":
-				port, err := cmd.Flags().GetUint16("director-port")
-				if err != nil {
-					return errors.Wrap(err, "Failed to parse director port")
-				}
-				moduleMap[mod] = port
-			case "origin":
-				port, err := cmd.Flags().GetUint16("origin-port")
-				if err != nil {
-					return errors.Wrap(err, "Failed to parse origin port")
-				}
-				moduleMap[mod] = port
-			default:
-				moduleMap[mod] = 0 //Should never happen
-			}
-		} else {
-			return errors.New(fmt.Sprintf("Unknown module %s: Modules must be one of %s", mod, cModsStringList))
+	modules := config.NewServerType()
+	for _, module := range moduleSlice {
+		if !modules.SetString(module) {
+			return errors.Errorf("Unknown module name: %s", module)
+		}
+	}
+	if modules.IsEnabled(config.CacheType) {
+		return errors.New("`pelican serve` does not support the cache module")
+	}
+	ports := modulePorts{}
+	var err error
+	if modules.IsEnabled(config.RegistryType) {
+		ports.Registry, err = cmd.Flags().GetUint16("reg-port")
+		if err != nil {
+			return errors.Wrap(err, "Failed to parse registry port")
+		}
+	}
+	if modules.IsEnabled(config.DirectorType) {
+		ports.Director, err = cmd.Flags().GetUint16("director-port")
+		if err != nil {
+			return errors.Wrap(err, "Failed to parse director port")
+		}
+	}
+	if modules.IsEnabled(config.OriginType) {
+		ports.Origin, err = cmd.Flags().GetUint16("origin-port")
+		if err != nil {
+			return errors.Wrap(err, "Failed to parse origin port")
 		}
 	}
 	ctx := cmd.Context()
-	return fedServeInternal(ctx, moduleMap)
+	return fedServeInternal(ctx, ports)
 }
 
-func fedServeInternal(ctx context.Context, moduleMap map[string]uint16) error {
+func fedServeInternal(ctx context.Context, ports modulePorts) error {
 
-	hostname, err := os.Hostname()
-	if err != nil {
-		return errors.Wrap(err, "Failed to get hostname from os")
-	}
+	hostname := param.Server_Hostname.GetString()
 
-	if regPort, ok := moduleMap["registry"]; ok {
-		err = initRegistry()
+	if ports.Registry != 0 {
+		err := initRegistry()
 		if err != nil {
-			return errors.Wrap(err, "Failure when initializing for registry")
+			return errors.Wrap(err, "Failure when initializing the registry")
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())
-		viper.Set("Server.WebPort", regPort)
+		viper.Set("Server.WebPort", ports.Registry)
 
-		registryUrl := "https://" + hostname + ":" + fmt.Sprint(regPort)
+		registryUrl := "https://" + hostname + ":" + fmt.Sprint(ports.Registry)
 		viper.Set("Federation.NamespaceURL", registryUrl)
 
 		go func() {
-			err = serveNamespaceRegistryInternal(ctx)
+			err = serveRegistryInternal(ctx)
 			if err != nil {
 				return
 			}
 		}()
 		defer cancel()
 
-		err = fedCheckWorking(param.Federation_NamespaceUrl.GetString()+"/api/v1.0/registry", "Registry")
+		err = server_utils.WaitUntilWorking("GET", param.Federation_NamespaceUrl.GetString()+"/api/v1.0/registry", "Registry", http.StatusOK)
 		if err != nil {
 			return err
 		}
 	}
 
-	if directorPort, ok := moduleMap["director"]; ok {
+	if ports.Director != 0 {
 
-		err = initDirector()
+		err := initDirector()
 		if err != nil {
 			return errors.Wrap(err, "Failure when initializing for director")
 		}
@@ -147,9 +120,9 @@ func fedServeInternal(ctx context.Context, moduleMap map[string]uint16) error {
 		viper.Set("Director.DefaultResponse", "cache")
 
 		ctx, cancel := context.WithCancel(context.Background())
-		viper.Set("Server.WebPort", directorPort)
+		viper.Set("Server.WebPort", ports.Director)
 
-		directorUrl := "https://" + hostname + ":" + fmt.Sprint(directorPort)
+		directorUrl := "https://" + hostname + ":" + fmt.Sprint(ports.Director)
 		viper.Set("Federation.DirectorURL", directorUrl)
 
 		go func() {
@@ -160,14 +133,19 @@ func fedServeInternal(ctx context.Context, moduleMap map[string]uint16) error {
 		}()
 		defer cancel()
 
-		err = fedCheckWorking(param.Federation_DirectorUrl.GetString()+"/api/v1.0/director/listNamespaces", "Director")
+		err = server_utils.WaitUntilWorking(
+			"GET",
+			param.Federation_DirectorUrl.GetString()+"/api/v1.0/director/listNamespaces",
+			"Director",
+			http.StatusOK,
+		)
 		if err != nil {
 			return err
 		}
 	}
 
-	if originPort, ok := moduleMap["origin"]; ok {
-		err = initOrigin()
+	if ports.Origin != 0 {
+		err := initOrigin()
 		if err != nil {
 			return errors.Wrap(err, "Failure when initializing for origin")
 		}
@@ -182,10 +160,10 @@ func fedServeInternal(ctx context.Context, moduleMap map[string]uint16) error {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		viper.Set("Server.WebPort", 8444) //TODO remove hard coding once we add web support
-		viper.Set("Xrootd.Port", originPort)
+		viper.Set("Xrootd.Port", ports.Origin)
 
 		originUrl := "https://" + hostname + ":8444" //TODO remove hard coding once we add web support
-		issuerUrl := "https://" + hostname + ":" + fmt.Sprint(originPort)
+		issuerUrl := "https://" + hostname + ":" + fmt.Sprint(ports.Origin)
 		viper.Set("OriginURL", originUrl)
 		viper.Set("Server.IssuerUrl", issuerUrl)
 		viper.Set("Server.ExternalWebUrl", originUrl)
@@ -198,7 +176,7 @@ func fedServeInternal(ctx context.Context, moduleMap map[string]uint16) error {
 		}()
 		defer cancel()
 
-		err = fedCheckWorking(param.Origin_Url.GetString(), "Origin")
+		err = server_utils.WaitUntilWorking("GET", param.Origin_Url.GetString()+"/.well-known/openid-configuration", "Origin", http.StatusOK)
 		if err != nil {
 			return err
 		}

--- a/cmd/fed_serve.go
+++ b/cmd/fed_serve.go
@@ -1,0 +1,213 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var currentModules = map[string]string{"registry": "", "director": "", "origin": ""}
+var cModsStringList = "registry, director, origin"
+
+func fedCheckWorking(reqUrl string, server string) error {
+	expiry := time.Now().Add(10 * time.Second)
+	success := false
+	for !(success || time.Now().After(expiry)) {
+		time.Sleep(50 * time.Millisecond)
+		req, err := http.NewRequest("GET", reqUrl, nil)
+		if err != nil {
+			return err
+		}
+		httpClient := http.Client{
+			Transport: config.GetTransport(),
+			Timeout:   50 * time.Millisecond,
+		}
+		_, err = httpClient.Do(req)
+		if err != nil {
+			log.Infoln("Failed to send request to "+server+"; likely server is not up (will retry in 50ms):", err)
+		} else {
+			success = true
+			log.Debugln(server + " server appears to be functioning")
+		}
+	}
+
+	return nil
+}
+
+func fedServeStart(cmd *cobra.Command, args []string) error {
+	moduleSlice, err := cmd.Flags().GetStringSlice("modules")
+	if err != nil {
+		return errors.Wrap(err, "Failed to load modules passed via --module flag")
+	}
+	// Faking a set of certain values
+	var moduleMap map[string]uint16 = map[string]uint16{}
+	for _, mod := range moduleSlice {
+		if _, ok := currentModules[mod]; ok {
+			switch mod {
+			case "registry":
+				port, err := cmd.Flags().GetUint16("reg-port")
+				if err != nil {
+					return errors.Wrap(err, "Failed to parse registry port")
+				}
+				moduleMap[mod] = port
+			case "director":
+				port, err := cmd.Flags().GetUint16("director-port")
+				if err != nil {
+					return errors.Wrap(err, "Failed to parse director port")
+				}
+				moduleMap[mod] = port
+			case "origin":
+				port, err := cmd.Flags().GetUint16("origin-port")
+				if err != nil {
+					return errors.Wrap(err, "Failed to parse origin port")
+				}
+				moduleMap[mod] = port
+			default:
+				moduleMap[mod] = 0 //Should never happen
+			}
+		} else {
+			return errors.New(fmt.Sprintf("Unknown module %s: Modules must be one of %s", mod, cModsStringList))
+		}
+	}
+	ctx := cmd.Context()
+	return fedServeInternal(ctx, moduleMap)
+}
+
+func fedServeInternal(ctx context.Context, moduleMap map[string]uint16) error {
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return errors.Wrap(err, "Failed to get hostname from os")
+	}
+
+	if regPort, ok := moduleMap["registry"]; ok {
+		err = initRegistry()
+		if err != nil {
+			return errors.Wrap(err, "Failure when initializing for registry")
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		viper.Set("Server.WebPort", regPort)
+
+		registryUrl := "https://" + hostname + ":" + fmt.Sprint(regPort)
+		viper.Set("Federation.NamespaceURL", registryUrl)
+
+		go func() {
+			err = serveNamespaceRegistryInternal(ctx)
+			if err != nil {
+				return
+			}
+		}()
+		defer cancel()
+
+		err = fedCheckWorking(param.Federation_NamespaceUrl.GetString()+"/api/v1.0/registry", "Registry")
+		if err != nil {
+			return err
+		}
+	}
+
+	if directorPort, ok := moduleMap["director"]; ok {
+
+		err = initDirector()
+		if err != nil {
+			return errors.Wrap(err, "Failure when initializing for director")
+		}
+
+		viper.Set("Director.DefaultResponse", "cache")
+
+		ctx, cancel := context.WithCancel(context.Background())
+		viper.Set("Server.WebPort", directorPort)
+
+		directorUrl := "https://" + hostname + ":" + fmt.Sprint(directorPort)
+		viper.Set("Federation.DirectorURL", directorUrl)
+
+		go func() {
+			err = serveDirectorInternal(ctx)
+			if err != nil {
+				return
+			}
+		}()
+		defer cancel()
+
+		err = fedCheckWorking(param.Federation_DirectorUrl.GetString()+"/api/v1.0/director/listNamespaces", "Director")
+		if err != nil {
+			return err
+		}
+	}
+
+	if originPort, ok := moduleMap["origin"]; ok {
+		err = initOrigin()
+		if err != nil {
+			return errors.Wrap(err, "Failure when initializing for origin")
+		}
+
+		if param.Origin_Mode.GetString() != "posix" {
+			return errors.Errorf("Origin Mode must be set to posix, S3 is not currently supported.")
+		}
+
+		if param.Origin_ExportVolume.GetString() == "" {
+			return errors.Errorf("Origin.ExportVolume must be set in the parameters.yaml file.")
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		viper.Set("Server.WebPort", 8444) //TODO remove hard coding once we add web support
+		viper.Set("Xrootd.Port", originPort)
+
+		originUrl := "https://" + hostname + ":8444" //TODO remove hard coding once we add web support
+		issuerUrl := "https://" + hostname + ":" + fmt.Sprint(originPort)
+		viper.Set("OriginURL", originUrl)
+		viper.Set("Server.IssuerUrl", issuerUrl)
+		viper.Set("Server.ExternalWebUrl", originUrl)
+
+		go func() {
+			err = serveOriginInternal(ctx)
+			if err != nil {
+				return
+			}
+		}()
+		defer cancel()
+
+		err = fedCheckWorking(param.Origin_Url.GetString(), "Origin")
+		if err != nil {
+			return err
+		}
+	}
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	sig := <-sigs
+	_ = sig
+
+	return nil
+}

--- a/cmd/fed_serve_test.go
+++ b/cmd/fed_serve_test.go
@@ -1,0 +1,88 @@
+/***************************************************************
+ *
+ * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFedServePosixOrigin(t *testing.T) {
+	viper.Reset()
+	moduleMap := map[string]uint16{"registry": 8446, "director": 8445, "origin": 8443}
+
+	// Create our own temp directory (for some reason t.TempDir() does not play well with xrootd)
+	tmpPathPattern := "XRootD-Test_Origin*"
+	tmpPath, err := os.MkdirTemp("", tmpPathPattern)
+	require.NoError(t, err)
+
+	// Need to set permissions or the xrootd process we spawn won't be able to write PID/UID files
+	permissions := os.FileMode(0777)
+	err = os.Chmod(tmpPath, permissions)
+	require.NoError(t, err)
+
+	viper.Set("ConfigDir", tmpPath)
+	viper.Set("Xrootd.RunLocation", filepath.Join(tmpPath, "xrootd"))
+	t.Cleanup(func() {
+		os.RemoveAll(tmpPath)
+	})
+
+	// Increase the log level; otherwise, its difficult to debug failures
+	viper.Set("Logging.Level", "Debug")
+	config.InitConfig()
+
+	viper.Set("Origin.ExportVolume", t.TempDir()+":/test")
+	viper.Set("Origin.Mode", "posix")
+	// Disable functionality we're not using (and is difficult to make work on Mac)
+	viper.Set("Origin.EnableCmsd", false)
+	viper.Set("Origin.EnableMacaroons", false)
+	viper.Set("Origin.EnableVoms", false)
+	viper.Set("TLSSkipVerify", true)
+	viper.Set("Server.EnableUI", false)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		err = fedServeInternal(ctx, moduleMap)
+		require.NoError(t, err)
+	}()
+	defer cancel()
+
+	time.Sleep(2 * time.Second)
+	hostname, err := os.Hostname()
+	require.NoError(t, err)
+
+	curlString := "https://" + hostname + ":8445/.well-known/openid-configuration"
+
+	curl := exec.Command("curl", "-v", "-k", curlString)
+	out, err := curl.Output()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "jwks_uri")
+
+	viper.Reset()
+}

--- a/cmd/fed_serve_windows.go
+++ b/cmd/fed_serve_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package main
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func fedServeStart( /*cmd*/ *cobra.Command /*args*/, []string) error {
+	return errors.New("'origin serve' command is not supported on Windows")
+}

--- a/cmd/fed_serve_windows.go
+++ b/cmd/fed_serve_windows.go
@@ -26,5 +26,5 @@ import (
 )
 
 func fedServeStart( /*cmd*/ *cobra.Command /*args*/, []string) error {
-	return errors.New("'origin serve' command is not supported on Windows")
+	return errors.New("'serve' command is not supported on Windows")
 }

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -38,8 +38,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func serveOrigin( /*cmd*/ *cobra.Command /*args*/, []string) error {
-	err := serveOriginInternal()
+func serveOrigin(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	err := serveOriginInternal(ctx)
 	if err != nil {
 		return err
 	}
@@ -47,7 +48,7 @@ func serveOrigin( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	return nil
 }
 
-func serveOriginInternal() error {
+func serveOriginInternal(ctx context.Context) error {
 	// Use this context for any goroutines that needs to react to server shutdown
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	// Use this wait group to ensure the goroutines can finish before the server exits/shutdown
@@ -78,7 +79,7 @@ func serveOriginInternal() error {
 		return err
 	}
 
-	if param.Origin_EnableUI.GetBool() {
+	if param.Server_EnableUI.GetBool() {
 		// Set up necessary APIs to support Web UI, including auth and metrics
 		if err := web_ui.ConfigureServerWebAPI(engine); err != nil {
 			return err
@@ -118,7 +119,7 @@ func serveOriginInternal() error {
 		shutdownCancel()
 	}()
 
-	if param.Origin_EnableUI.GetBool() {
+	if param.Server_EnableUI.GetBool() {
 		go web_ui.InitServerWebLogin()
 	}
 
@@ -147,7 +148,6 @@ func serveOriginInternal() error {
 		launchers = append(launchers, oa4mp_launcher)
 	}
 
-	ctx := context.Background()
 	if err = daemon.LaunchDaemons(ctx, launchers); err != nil {
 		return err
 	}

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -39,6 +39,15 @@ import (
 )
 
 func serveOrigin( /*cmd*/ *cobra.Command /*args*/, []string) error {
+	err := serveOriginInternal()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func serveOriginInternal() error {
 	// Use this context for any goroutines that needs to react to server shutdown
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	// Use this wait group to ensure the goroutines can finish before the server exits/shutdown

--- a/cmd/registry_serve.go
+++ b/cmd/registry_serve.go
@@ -35,6 +35,15 @@ import (
 )
 
 func serveRegistry( /*cmd*/ *cobra.Command /*args*/, []string) error {
+	err := serveRegistryInternal()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func serveRegistryInternal() error {
 	log.Info("Initializing the namespace registry's database...")
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	defer shutdownCancel()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -94,6 +94,7 @@ func init() {
 	rootCmd.AddCommand(namespaceCmd)
 	rootCmd.AddCommand(rootConfigCmd)
 	rootCmd.AddCommand(rootPluginCmd)
+	rootCmd.AddCommand(serveCmd)
 	preferredPrefix := config.GetPreferredPrefix()
 	rootCmd.Use = strings.ToLower(preferredPrefix)
 

--- a/config/config.go
+++ b/config/config.go
@@ -164,6 +164,11 @@ func IsServerEnabled(testServer ServerType) bool {
 	return enabledServers.IsEnabled(testServer)
 }
 
+// Create a new, empty ServerType bitmask
+func NewServerType() ServerType {
+	return ServerType(0)
+}
+
 func (sType ServerType) String() string {
 	switch sType {
 	case CacheType:
@@ -176,6 +181,24 @@ func (sType ServerType) String() string {
 		return "Registry"
 	}
 	return "Unknown"
+}
+
+func (sType *ServerType) SetString(name string) bool {
+	switch strings.ToLower(name) {
+	case "cache":
+		*sType |= CacheType
+		return true
+	case "origin":
+		*sType |= OriginType
+		return true
+	case "director":
+		*sType |= DirectorType
+		return true
+	case "registry":
+		*sType |= RegistryType
+		return true
+	}
+	return false
 }
 
 // Based on the name of the current binary, determine the preferred "style"

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -30,6 +30,7 @@ Origin:
   Multiuser: false
   EnableMacaroons: false
   EnableVoms: true
+  EnableUI: true
   SelfTest: true
 Monitoring:
   PortLower: 9930

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -20,6 +20,7 @@ Logging:
 Server:
   WebPort: 8444
   WebHost: "0.0.0.0"
+  EnableUI: true
 Director:
   DefaultResponse: cache
 Cache:
@@ -30,7 +31,6 @@ Origin:
   EnableMacaroons: false
   EnableVoms: true
   SelfTest: true
-  EnableUI: true
 Monitoring:
   PortLower: 9930
   PortHigher: 9999

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -298,13 +298,6 @@ type: bool
 default: true
 components: ["origin"]
 ---
-name: Origin.EnableUI
-description: >-
-  Indicate whether the origin should enable its web UI.
-type: bool
-default: true
-components: ["origin"]
----
 name: Origin.EnableIssuer
 description: >-
   Enable the built-in issuer daemon for the origin.
@@ -590,6 +583,13 @@ type: filename
 root_default: /etc/pelican/certificates/tls.key
 default: "$ConfigBase/certificates/tls.key"
 components: ["origin", "nsregistry", "director"]
+---
+name: Server.EnableUI
+description: >-
+  Indicate whether a server should enable its web UI.
+type: bool
+default: true
+components: ["origin", "nsregistry", "director", "cache"]
 ---
 name: Server.WebPort
 description: >-

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -298,6 +298,13 @@ type: bool
 default: true
 components: ["origin"]
 ---
+name: Origin.EnableUI
+description: >-
+  Indicate whether the origin should enable its web UI.
+type: bool
+default: true
+components: ["origin"]
+---
 name: Origin.EnableIssuer
 description: >-
   Enable the built-in issuer daemon for the origin.
@@ -651,6 +658,12 @@ description: >-
 type: string
 default: none
 components: ["origin", "director", "nsregistry"]
+---
+name: Server.Modules
+description: >-
+  A list of modules to enable when running pelican in `pelican serve` mode.
+type: stringSlice
+default: []
 ---
 name: Server.UIActivationCodeFile
 description: >-

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -141,6 +141,7 @@ var (
 	Issuer_GroupRequirements = StringSliceParam{"Issuer.GroupRequirements"}
 	Monitoring_AggregatePrefixes = StringSliceParam{"Monitoring.AggregatePrefixes"}
 	Origin_ScitokensRestrictedPaths = StringSliceParam{"Origin.ScitokensRestrictedPaths"}
+	Server_Modules = StringSliceParam{"Server.Modules"}
 )
 
 var (
@@ -175,6 +176,7 @@ var (
 	Origin_ScitokensMapSubject = BoolParam{"Origin.ScitokensMapSubject"}
 	Origin_SelfTest = BoolParam{"Origin.SelfTest"}
 	Registry_RequireKeyChaining = BoolParam{"Registry.RequireKeyChaining"}
+	Server_EnableUI = BoolParam{"Server.EnableUI"}
 	StagePlugin_Hook = BoolParam{"StagePlugin.Hook"}
 	TLSSkipVerify = BoolParam{"TLSSkipVerify"}
 )

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -113,12 +113,14 @@ type config struct {
 		RequireKeyChaining bool
 	}
 	Server struct {
+		EnableUI bool
 		ExternalWebUrl string
 		Hostname string
 		IssuerHostname string
 		IssuerJwks string
 		IssuerPort int
 		IssuerUrl string
+		Modules []string
 		SessionSecretFile string
 		TLSCACertificateDirectory string
 		TLSCACertificateFile string

--- a/web_ui/ui_test.go
+++ b/web_ui/ui_test.go
@@ -183,7 +183,7 @@ func TestCodeBasedLogin(t *testing.T) {
 
 	//Invoke the code login with the wrong code, ensure we get a 401
 	t.Run("With invalid code", func(t *testing.T) {
-		require.True(t, param.Origin_EnableUI.GetBool())
+		require.True(t, param.Server_EnableUI.GetBool())
 		req, err := http.NewRequest("POST", "/api/v1.0/auth/initLogin", strings.NewReader(`{"code": "20"}`))
 		assert.NoError(t, err)
 


### PR DESCRIPTION
Close #172 

Adds a hidden command "pelican serve" which starts up multiple modules as a "federation in a box" to be used for development.

The details on how to use it can be found in the pelican google drive under Development Notes.

It currently doesn't allow for enabling web ui, caches, or origins in s3 mode. Separate issues have been created for all three of these enhancements.