### PR TITLE
Replace `xrd-http` plugin by `xrdcl-pelican` plugin in dev-container

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -62,7 +62,7 @@ RUN \
     git clone https://github.com/PelicanPlatform/xrdcl-pelican.git && \
     cd xrdcl-pelican && \
     mkdir build && cd build && \
-    cmake .. && \
+    cmake -DLIB_INSTALL_DIR=/usr/lib64 .. && \
     make && make install
 # Install the S3 and HTTP server plugins for XRootD. For now we do this from source
 # until we can sort out the RPMs.
@@ -70,7 +70,7 @@ RUN \
     git clone https://github.com/PelicanPlatform/xrootd-s3-http.git && \
     cd xrootd-s3-http && \
     mkdir build && cd build && \
-    cmake .. && \
+    cmake -DLIB_INSTALL_DIR=/usr/lib64 .. && \
     make install
 
 FROM dependency-build AS final-stage
@@ -144,18 +144,13 @@ ENV JAVA_HOME=/usr/lib/jvm/jre \
     QDL_HOME="/opt/qdl" \
     PATH="${ST_HOME}/bin:${QDL_HOME}/bin:${PATH}"
 
-# Copy built xrdcl-pelican plugin library and config from build
+# Copy xrdcl-pelican plugin config
 COPY --from=xrootd-plugin-builder /usr/local/etc/xrootd/client.plugins.d/pelican-plugin.conf /etc/xrootd/client.plugins.d/pelican-plugin.conf
-COPY --from=xrootd-plugin-builder /usr/local/lib/libXrdClPelican-5.so /usr/local/lib/libXrdClPelican-5.so
 # Remove http plugin to use pelican plugin
 RUN rm -f /etc/xrootd/client.plugins.d/xrdcl-http-plugin.conf
 
-# Copy built s3 plugin library from build
-COPY --from=xrootd-plugin-builder /usr/local/lib/libXrdS3-5.so /usr/local/lib/libXrdS3-5.so
-COPY --from=xrootd-plugin-builder /usr/local/lib/libXrdHTTPServer-5.so /usr/local/lib/libXrdHTTPServer-5.so
-# For now, until the RPM is set up, we install the libraries here, but
-# we need to add to LD_LIBRARY_PATH so XRootD knows where to look
-RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/xrdplugins.conf && ldconfig
+# Copy built s3 plugin library and xrdcl-pelican plugin library from build
+COPY --from=xrootd-plugin-builder /usr/lib64/libXrdS3-5.so /usr/lib64/libXrdHTTPServer-5.so /usr/lib64/libXrdClPelican-5.so /usr/lib64
 
 RUN chmod +x /pelican/osdf-client \
     && chmod +x /entrypoint.sh

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -39,7 +39,7 @@ RUN goreleaser --clean --snapshot
 
 FROM --platform=linux/amd64 hub.opensciencegrid.org/sciauth/scitokens-oauth2-server:release-20231118-1823 AS scitokens-oauth2-server
 
-FROM --platform=linux/amd64 opensciencegrid/software-base:$BASE_OSG_SERIES-el8-$BASE_YUM_REPO
+FROM --platform=linux/amd64 opensciencegrid/software-base:$BASE_OSG_SERIES-el8-$BASE_YUM_REPO AS dependency-build
 
 # Create the xrootd user with a fixed GID/UID
 RUN groupadd -o -g 10940 xrootd
@@ -47,11 +47,33 @@ RUN useradd -o -u 10940 -g 10940 -s /bin/sh xrootd
 
 # Install dependencies
 RUN yum -y update \
-    && yum -y install xrootd xrootd-client xrdcl-http xrootd-server xrootd-scitokens xrootd-voms \
-    xrootd-devel xrootd-client-devel xrootd-server-devel \
-    curl-devel git cmake3 gcc-c++ openssl-devel java-17-openjdk-headless \
+    && yum -y install xrootd xrootd-client xrdcl-http xrootd-server xrootd-scitokens xrootd-voms curl java-17-openjdk-headless \
     && yum clean all \
     && rm -rf /var/cache/yum/
+
+####
+# Start building xrootd plugins (xrdcl-pelican and s3)
+####
+FROM dependency-build AS xrootd-plugin-builder
+# Install necessary build dependencies
+RUN  yum install -y xrootd-devel xrootd-server-devel xrootd-client-devel curl-devel openssl-devel git cmake3 gcc-c++ 
+# Install xrdcl-pelican plugin and replace the xrdcl-http plugin
+RUN \
+    git clone https://github.com/PelicanPlatform/xrdcl-pelican.git && \
+    cd xrdcl-pelican && \
+    mkdir build && cd build && \
+    cmake .. && \
+    make && make install
+# Install the S3 and HTTP server plugins for XRootD. For now we do this from source
+# until we can sort out the RPMs.
+RUN \
+    git clone https://github.com/PelicanPlatform/xrootd-s3-http.git && \
+    cd xrootd-s3-http && \
+    mkdir build && cd build && \
+    cmake .. && \
+    make install
+
+FROM dependency-build AS final-stage
 
 WORKDIR /pelican
 
@@ -122,17 +144,18 @@ ENV JAVA_HOME=/usr/lib/jvm/jre \
     QDL_HOME="/opt/qdl" \
     PATH="${ST_HOME}/bin:${QDL_HOME}/bin:${PATH}"
 
-# Install the S3 and HTTP server plugins for XRootD. For now we do this from source
-# until we can sort out the RPMs.
-RUN \
-    git clone https://github.com/PelicanPlatform/xrootd-s3-http.git && \
-    cd xrootd-s3-http && \
-    mkdir build && cd build && \
-    cmake .. && \
-    make install && \
-    # For now, until the RPM is set up, we install the libraries here, but
-    # we need to add to LD_LIBRARY_PATH so XRootD knows where to look
-    echo "/usr/local/lib" > /etc/ld.so.conf.d/xrdplugins.conf && ldconfig
+# Copy built xrdcl-pelican plugin library and config from build
+COPY --from=xrootd-plugin-builder /usr/local/etc/xrootd/client.plugins.d/pelican-plugin.conf /etc/xrootd/client.plugins.d/pelican-plugin.conf
+COPY --from=xrootd-plugin-builder /usr/local/lib/libXrdClPelican-5.so /usr/local/lib/libXrdClPelican-5.so
+# Remove http plugin to use pelican plugin
+RUN rm -f /etc/xrootd/client.plugins.d/xrdcl-http-plugin.conf
+
+# Copy built s3 plugin library from build
+COPY --from=xrootd-plugin-builder /usr/local/lib/libXrdS3-5.so /usr/local/lib/libXrdS3-5.so
+COPY --from=xrootd-plugin-builder /usr/local/lib/libXrdHTTPServer-5.so /usr/local/lib/libXrdHTTPServer-5.so
+# For now, until the RPM is set up, we install the libraries here, but
+# we need to add to LD_LIBRARY_PATH so XRootD knows where to look
+RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/xrdplugins.conf && ldconfig
 
 RUN chmod +x /pelican/osdf-client \
     && chmod +x /entrypoint.sh

--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -3,7 +3,7 @@
 # fail on building this container on arm machine
 FROM --platform=linux/amd64 hub.opensciencegrid.org/sciauth/scitokens-oauth2-server:release-20231118-1823 AS scitokens-oauth2-server
 
-FROM almalinux:8 as builder
+FROM almalinux:8
 
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 ARG TARGETARCH
@@ -26,20 +26,16 @@ enabled=1 \n\
 gpgcheck=0' > /etc/yum.repos.d/goreleaser.repo
 
 # Install goreleaser and various other packages we need
-RUN yum install -y goreleaser npm xrootd xrootd-server xrootd-client nano xrootd-scitokens \
-    xrootd-voms xrdcl-http jq procps docker make curl java-17-openjdk-headless \
+RUN yum install -y goreleaser npm xrootd-devel xrootd-server-devel xrootd-client-devel nano xrootd-scitokens \
+    xrootd-voms xrdcl-http jq procps docker make curl-devel java-17-openjdk-headless git cmake3 gcc-c++ openssl-devel \
     && yum clean all
 
-# Fork from previous environment to build xrootd plugin
-FROM builder AS xrootd-plugin-builder
-# Install necessary build dependencies
-RUN yum install -y xrootd-devel xrootd-server-devel xrootd-client-devel curl-devel openssl-devel git cmake3 gcc-c++ 
 # Install xrdcl-pelican plugin and replace the xrdcl-http plugin
 RUN \
     git clone https://github.com/PelicanPlatform/xrdcl-pelican.git && \
     cd xrdcl-pelican && \
     mkdir build && cd build && \
-    cmake .. && \
+    cmake -DLIB_INSTALL_DIR=/usr/lib64 .. && \
     make && make install
 # Install the S3 and HTTP server plugins for XRootD. For now we do this from source
 # until we can sort out the RPMs.
@@ -47,25 +43,13 @@ RUN \
     git clone https://github.com/PelicanPlatform/xrootd-s3-http.git && \
     cd xrootd-s3-http && \
     mkdir build && cd build && \
-    cmake .. && \
+    cmake -DLIB_INSTALL_DIR=/usr/lib64 .. && \
     make install
 
-
-# Fork from previous environment to continue building the rest of the container
-FROM builder AS main
-
-# Copy built xrdcl-pelican plugin library and config from build
-COPY --from=xrootd-plugin-builder /usr/local/etc/xrootd/client.plugins.d/pelican-plugin.conf /etc/xrootd/client.plugins.d/pelican-plugin.conf
-COPY --from=xrootd-plugin-builder /usr/local/lib/libXrdClPelican-5.so /usr/local/lib/libXrdClPelican-5.so
-# Remove http plugin to use pelican plugin
-RUN rm -f /etc/xrootd/client.plugins.d/xrdcl-http-plugin.conf
-
-# Copy built s3 plugin library from build
-COPY --from=xrootd-plugin-builder /usr/local/lib/libXrdS3-5.so /usr/local/lib/libXrdS3-5.so
-COPY --from=xrootd-plugin-builder /usr/local/lib/libXrdHTTPServer-5.so /usr/local/lib/libXrdHTTPServer-5.so
-# For now, until the RPM is set up, we install the libraries here, but
-# we need to add to LD_LIBRARY_PATH so XRootD knows where to look
-RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/xrdplugins.conf && ldconfig
+# Copy xrdcl-pelican plugin config and remove http plugin to use pelican plugin
+RUN \
+    cp /usr/local/etc/xrootd/client.plugins.d/pelican-plugin.conf /etc/xrootd/client.plugins.d/pelican-plugin.conf && \
+    rm -f /etc/xrootd/client.plugins.d/xrdcl-http-plugin.conf
 
 # Install proper version of nodejs so that make web-build works
 RUN \
@@ -147,11 +131,11 @@ COPY images/dev-config.yaml /etc/pelican/pelican.yaml
 
 # For S3 tests, we need the minIO server client, so we install based on detected arch
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        curl -o minio.rpm https://dl.min.io/server/minio/release/linux-amd64/archive/minio-20231202105133.0.0.x86_64.rpm &&\
+        curl -o minio.rpm https://dl.min.io/server/minio/release/linux-amd64/archive/minio-20231214185157.0.0-1.x86_64.rpm &&\
         dnf install -y minio.rpm &&\
         rm -f minio.rpm; \
     elif [ "$TARGETARCH" = "arm64" ]; then \
-        curl -o minio.rpm https://dl.min.io/server/minio/release/linux-arm64/archive/minio-20231202105133.0.0.aarch64.rpm &&\
+        curl -o minio.rpm https://dl.min.io/server/minio/release/linux-arm64/archive/minio-20231214185157.0.0-1.aarch64.rpm &&\
         dnf install -y minio.rpm &&\
         rm -f minio.rpm; \
     fi


### PR DESCRIPTION
Closes #485 
@bbockelm It seems that testing the production container requires supervisord and it can't run without it, but I can confirm that dev container now uses `xrdcl-pelican` plugin. Although I tried to build plugins in a separate stage, the final size of the image is still ~2.3GB. Not sure what's wrong.