### PR TITLE
Match routes before redirect request in director

### DIFF
--- a/cmd/director_serve.go
+++ b/cmd/director_serve.go
@@ -84,11 +84,11 @@ func serveDirector( /*cmd*/ *cobra.Command /*args*/, []string) error {
 			" but you provided %q. Was there a typo?", defaultResponse)
 	}
 	log.Debugf("The director will redirect to %ss by default", defaultResponse)
-	engine.Use(director.ShortcutMiddleware(defaultResponse))
 	rootGroup := engine.Group("/")
-	director.RegisterDirector(rootGroup)
 	director.RegisterDirectorAuth(rootGroup)
 	director.RegisterDirectorWebAPI(rootGroup)
+	engine.Use(director.ShortcutMiddleware(defaultResponse))
+	director.RegisterDirector(rootGroup)
 
 	log.Info("Starting web engine...")
 	go web_ui.RunEngine(engine)


### PR DESCRIPTION
Moved the `director.RegisterDirectorAuth(rootGroup)` `director.RegisterDirectorWebAPI(rootGroup)` before the ShortcutMiddleware Call

This is the last bit to close #300 