### PR TITLE
Add storage volume Prometheus metrics from XRootD monitoring packets

### DIFF
--- a/metrics/xrootd_metrics_test.go
+++ b/metrics/xrootd_metrics_test.go
@@ -232,9 +232,9 @@ func TestHandlePacket(t *testing.T) {
 			Program: "xrootd",
 			Stats: []SummaryStat{
 				{
-					Id:          "sched",
-					Threads:     10,
-					ThreadsIdle: 8,
+					Id:      "sched",
+					Threads: 10,
+					Idle:    8,
 				},
 			},
 		}
@@ -265,10 +265,10 @@ func TestHandlePacket(t *testing.T) {
 			Program: "xrootd",
 			Stats: []SummaryStat{
 				{
-					Id:              "link",
-					LinkConnections: 9,
-					LinkInBytes:     99,
-					LinkOutBytes:    999,
+					Id:    "link",
+					Total: 9,
+					In:    99,
+					Out:   999,
 				},
 			},
 		}
@@ -277,10 +277,10 @@ func TestHandlePacket(t *testing.T) {
 			Program: "xrootd",
 			Stats: []SummaryStat{
 				{
-					Id:              "link",
-					LinkConnections: 10,
-					LinkInBytes:     100,
-					LinkOutBytes:    1000,
+					Id:    "link",
+					Total: 10,
+					In:    100,
+					Out:   1000,
 				},
 			},
 		}
@@ -289,10 +289,10 @@ func TestHandlePacket(t *testing.T) {
 			Program: "cmsd",
 			Stats: []SummaryStat{
 				{
-					Id:              "link",
-					LinkConnections: 2,
-					LinkInBytes:     0,
-					LinkOutBytes:    0,
+					Id:    "link",
+					Total: 2,
+					In:    0,
+					Out:   0,
 				},
 			},
 		}


### PR DESCRIPTION
Closes #495 

A note to reviewer: Although this PR implemented the metric for both origins and caches, we won't receive any metrics from cache yet as we don't have web stuff for cache implemented by the time this PR is ready (it's in a separate ticket here #309). 

I think #493 might suffer from this, as we added caches to director's service discovery endpoint but they are essentially "dead" endpoints. Director Prometheus instance might produce a bunch of "false positive" error messages 