### PR TITLE
Rename `Federation.NamespaceUrl` to `Federation.RegistryUrl`

### DIFF
--- a/cmd/registry_client.go
+++ b/cmd/registry_client.go
@@ -21,7 +21,7 @@
 // You can access it through `./pelican namespace <command>`.
 //
 // Note that you need to have your registry server running either locally,
-// or by setting Federation.NamespaceUrl to the Url of your remote Pelican registry server
+// or by setting Federation.RegistryUrl to the Url of your remote Pelican registry server
 //
 // Example: `./pelican namespace register --prefix /test`
 
@@ -48,14 +48,14 @@ var prefix string
 var pubkeyPath string
 
 func getNamespaceEndpoint() (string, error) {
-	namespaceEndpoint := param.Federation_NamespaceUrl.GetString()
+	namespaceEndpoint := param.Federation_RegistryUrl.GetString()
 	if namespaceEndpoint == "" {
 		return "", errors.New("No namespace registry specified; either give the federation name (-f) or specify the namespace API endpoint directly (e.g., --namespace-url=https://namespace.osg-htc.org/namespaces)")
 	}
 
 	namespaceEndpointURL, err := url.Parse(namespaceEndpoint)
 	if err != nil {
-		return "", errors.Wrap(err, "Unable to parse namespace url")
+		return "", errors.Wrap(err, "Unable to parse namespace registry url")
 	}
 
 	// Return the string, as opposed to a pointer to the URL object
@@ -71,7 +71,7 @@ func registerANamespace(cmd *cobra.Command, args []string) {
 
 	namespaceEndpoint, err := getNamespaceEndpoint()
 	if err != nil {
-		log.Errorln("Failed to get NamespaceURL from config: ", err)
+		log.Errorln("Failed to get RegistryUrl from config: ", err)
 		os.Exit(1)
 	}
 
@@ -139,7 +139,7 @@ func deleteANamespace(cmd *cobra.Command, args []string) {
 
 	namespaceEndpoint, err := getNamespaceEndpoint()
 	if err != nil {
-		log.Errorln("Failed to get NamespaceURL from config: ", err)
+		log.Errorln("Failed to get RegistryUrl from config: ", err)
 		os.Exit(1)
 	}
 
@@ -164,7 +164,7 @@ func listAllNamespaces(cmd *cobra.Command, args []string) {
 
 	namespaceEndpoint, err := getNamespaceEndpoint()
 	if err != nil {
-		log.Errorln("Failed to get NamespaceURL from config: ", err)
+		log.Errorln("Failed to get RegistryUrl from config: ", err)
 		os.Exit(1)
 	}
 
@@ -192,7 +192,7 @@ func listAllNamespaces(cmd *cobra.Command, args []string) {
 // 	if jwks {
 // 		namespaceEndpoint, err := getNamespaceEndpoint()
 // 		if err != nil {
-// 			log.Errorln("Failed to get NamespaceURL from config:", err)
+// 			log.Errorln("Failed to get RegistryUrl from config:", err)
 // 			os.Exit(1)
 // 		}
 
@@ -246,9 +246,9 @@ func init() {
 	deleteCmd.Flags().StringVar(&prefix, "prefix", "", "prefix for delete namespace")
 
 	namespaceCmd.PersistentFlags().String("namespace-url", "", "Endpoint for the namespace registry")
-	// Don't override Federation.NamespaceURL if the flag value is empty
+	// Don't override Federation.RegistryUrl if the flag value is empty
 	if namespaceCmd.PersistentFlags().Lookup("namespace-url").Value.String() != "" {
-		if err := viper.BindPFlag("Federation.NamespaceURL", namespaceCmd.PersistentFlags().Lookup("namespace-url")); err != nil {
+		if err := viper.BindPFlag("Federation.RegistryUrl", namespaceCmd.PersistentFlags().Lookup("namespace-url")); err != nil {
 			panic(err)
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -219,8 +219,8 @@ func DiscoverFederation() error {
 	}
 	log.Debugln("Federation URL:", federationStr)
 	curDirectorURL := param.Federation_DirectorUrl.GetString()
-	curNamespaceURL := param.Federation_NamespaceUrl.GetString()
-	if len(curDirectorURL) != 0 && len(curNamespaceURL) != 0 {
+	curRegistryURL := param.Federation_RegistryUrl.GetString()
+	if len(curDirectorURL) != 0 && len(curRegistryURL) != 0 {
 		return nil
 	}
 
@@ -274,10 +274,10 @@ func DiscoverFederation() error {
 		log.Debugln("Federation service discovery resulted in director URL", metadata.DirectorEndpoint)
 		viper.Set("Federation.DirectorUrl", metadata.DirectorEndpoint)
 	}
-	if curNamespaceURL == "" {
-		log.Debugln("Federation service discovery resulted in namespace registration URL",
+	if curRegistryURL == "" {
+		log.Debugln("Federation service discovery resulted in namespace registry URL",
 			metadata.NamespaceRegistrationEndpoint)
-		viper.Set("Federation.NamespaceUrl", metadata.NamespaceRegistrationEndpoint)
+		viper.Set("Federation.RegistryUrl", metadata.NamespaceRegistrationEndpoint)
 	}
 
 	viper.Set("Federation.JwkUrl", metadata.JwksUri)
@@ -480,6 +480,11 @@ func InitConfig() {
 			os.Exit(1)
 		}
 		log.SetOutput(f)
+	}
+
+	if oldNsUrl := viper.GetString("Federation.NamespaceUrl"); oldNsUrl != "" {
+		log.Warningln("Federation.NamespaceUrl is deprecated and will be removed in future release. Please migrate to use Federation.RegistryUrl instead")
+		viper.SetDefault("Federation.RegistryUrl", oldNsUrl)
 	}
 }
 
@@ -719,7 +724,7 @@ func InitClient() error {
 	}
 	for _, prefix := range prefixes {
 		if val, isSet := os.LookupEnv(prefix + "_NAMESPACE_URL"); isSet {
-			viper.Set("Federation.NamespaceURL", val)
+			viper.Set("Federation.RegistryUrl", val)
 			break
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var server *httptest.Server
@@ -160,26 +161,31 @@ func TestDeprecateLogMessage(t *testing.T) {
 	t.Run("expect-deprecated-message-if-namespace-url-is-set", func(t *testing.T) {
 		hook := test.NewGlobal()
 		viper.Reset()
+		// The default value is set to Error, but this is a warning message
+		viper.Set("Logging.Level", "Warning")
 		viper.Set("Federation.NamespaceUrl", "https://dont-use.com")
 		InitConfig()
 
-		assert.Equal(t, 1, len(hook.Entries))
+		require.Equal(t, 1, len(hook.Entries))
 		assert.Equal(t, logrus.WarnLevel, hook.LastEntry().Level)
 		assert.Equal(t, "Federation.NamespaceUrl is deprecated and will be removed in future release. Please migrate to use Federation.RegistryUrl instead", hook.LastEntry().Message)
 		// We expect the default value of Federation.RegistryUrl is set to Federation.NamespaceUrl
 		// if Federation.NamespaceUrl is not empty for backward compatibility
 		assert.Equal(t, "https://dont-use.com", viper.GetString("Federation.RegistryUrl"))
+		hook.Reset()
 	})
 
 	t.Run("no-deprecated-message-if-namespace-url-unset", func(t *testing.T) {
 		hook := test.NewGlobal()
 		viper.Reset()
+		viper.Set("Logging.Level", "Warning")
 		viper.Set("Federation.RegistryUrl", "https://dont-use.com")
 		InitConfig()
 
 		assert.Equal(t, 0, len(hook.Entries))
 		assert.Equal(t, "https://dont-use.com", viper.GetString("Federation.RegistryUrl"))
 		assert.Equal(t, "", viper.GetString("Federation.NamespaceUrl"))
+		hook.Reset()
 	})
 }
 

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -261,7 +261,7 @@ func VerifyDirectorTestReportToken(strToken string) (bool, error) {
 }
 
 func GetRegistryIssuerURL(prefix string) (string, error) {
-	namespace_url_string := param.Federation_NamespaceUrl.GetString()
+	namespace_url_string := param.Federation_RegistryUrl.GetString()
 	if namespace_url_string == "" {
 		return "", errors.New("Namespace URL is not set")
 	}

--- a/director/origin_api_test.go
+++ b/director/origin_api_test.go
@@ -31,7 +31,7 @@ func TestVerifyAdvertiseToken(t *testing.T) {
 	//Setup a private key and a token
 	viper.Set("IssuerKey", kfile)
 
-	viper.Set("Federation.NamespaceURL", "https://get-your-tokens.org")
+	viper.Set("Federation.RegistryUrl", "https://get-your-tokens.org")
 	viper.Set("Federation.DirectorURL", "https://director-url.org")
 
 	kSet, err := config.GetIssuerPublicJWKS()
@@ -131,7 +131,7 @@ func TestCreateAdvertiseToken(t *testing.T) {
 	tok, err := CreateAdvertiseToken("test-namespace")
 	assert.Equal(t, "", tok)
 	assert.Equal(t, "Namespace URL is not set", err.Error())
-	viper.Set("Federation.NamespaceURL", "https://get-your-tokens.org")
+	viper.Set("Federation.RegistryUrl", "https://get-your-tokens.org")
 
 	// Test without a DirectorURL set and check to see if it returns the expected error
 	tok, err = CreateAdvertiseToken("test-namespace")
@@ -157,7 +157,7 @@ func TestGetRegistryIssuerURL(t *testing.T) {
 	assert.Equal(t, "Namespace URL is not set", err.Error())
 
 	// Test to make sure the path is as expected
-	viper.Set("Federation.NamespaceURL", "test-path")
+	viper.Set("Federation.RegistryUrl", "test-path")
 	url, err = GetRegistryIssuerURL("test-prefix")
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "test-path/api/v2.0/registry/metadata/test-prefix/.well-known/issuer.jwks", url)

--- a/director/redirect_test.go
+++ b/director/redirect_test.go
@@ -61,7 +61,7 @@ func TestDirectorRegistration(t *testing.T) {
 
 	viper.Reset()
 
-	viper.Set("Federation.NamespaceURL", "https://get-your-tokens.org")
+	viper.Set("Federation.RegistryUrl", "https://get-your-tokens.org")
 
 	setupContext := func() (*gin.Context, *gin.Engine, *httptest.ResponseRecorder) {
 		// Setup httptest recorder and context for the the unit test

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -105,7 +105,6 @@ type: duration
 default: 10s
 components: ["client", "nsregistry", "origin"]
 ---
-
 ############################
 #     Log-Level Configs    #
 ############################
@@ -123,7 +122,6 @@ type: filename
 default: none
 components: ["*"]
 ---
-
 ############################
 # Federation-Level Configs #
 ############################
@@ -157,15 +155,26 @@ description: >-
 type: url
 osdf_default: Default is determined dynamically through metadata at <federation URL>/.well-known/pelican-configuration
 default: none
-components: ["client", "origin"]
+components: ["client", "origin", "cache"]
 ---
 name: Federation.NamespaceUrl
+description: >-
+  [Deprecated] `Federation.NamespaceUrl` is deprecated and will be removed in the future release. Please migrate to use
+  `Federation.RegistryUrl` instead.
+
+  A URL indicating where the namespace registry service is hosted.
+type: url
+osdf_default: Default is determined dynamically through metadata at <federation URL>/.well-known/pelican-configuration
+default: none
+components: ["client", "director", "origin", "cache"]
+---
+name: Federation.RegistryUrl
 description: >-
   A URL indicating where the namespace registry service is hosted.
 type: url
 osdf_default: Default is determined dynamically through metadata at <federation URL>/.well-known/pelican-configuration
 default: none
-components: ["client", "director", "origin"]
+components: ["client", "director", "origin", "cache"]
 ---
 name: Federation.JwkUrl
 description: >-
@@ -175,7 +184,6 @@ osdf_default: Default is determined dynamically through metadata at <federtion U
 default: none
 components: ["client", "origin"]
 ---
-
 ############################
 #   Client-Level Configs   #
 ############################
@@ -242,7 +250,6 @@ type: int
 default: 102400
 components: ["client"]
 ---
-
 ############################
 #   Origin-level Configs   #
 ############################
@@ -414,8 +421,6 @@ type: filename
 default: none
 components: ["origin"]
 ---
-
-
 ############################
 #   Cache-level configs    #
 ############################
@@ -460,7 +465,6 @@ type: bool
 default: false
 components: ["cache"]
 ---
-
 ############################
 #  Director-level configs  #
 ############################
@@ -512,7 +516,6 @@ root_default: /var/cache/pelican/maxmind/GeoLite2-City.mmdb
 default: $ConfigBase/maxmind/GeoLite2-city.mmdb
 components: ["director"]
 ---
-
 ############################
 #  Registry-level configs  #
 ############################
@@ -533,7 +536,6 @@ type: bool
 default: true
 components: ["nsregistry"]
 ---
-
 ############################
 #   Server-level configs   #
 ############################
@@ -663,7 +665,7 @@ description: >-
   A filepath specifying where the server's web UI password file should be stored.
 type: filename
 default: $ConfigBase/server-web-passwd
-components:  ["origin", "cache", "nsregistry", "director"]
+components: ["origin", "cache", "nsregistry", "director"]
 ---
 name: Server.SessionSecretFile
 description: >-
@@ -671,11 +673,10 @@ description: >-
 
   This is only used for sending redirect request for OAuth2 authentication flow as of 11/22/2023
 type: filename
-default: $ConfigBase/session-secret 
+default: $ConfigBase/session-secret
   The default content of the file is the hash of the concatenation of "pelican" and the DER form of ${IssuerKey}
-components:  ["nsregistry", "director"]
+components: ["nsregistry", "director"]
 ---
-
 ################################
 #   Issuer's Configurations    #
 ################################
@@ -792,7 +793,6 @@ type: object
 default: []
 components: ["origin"]
 ---
-
 ###################################
 #   Server's OIDC Configuration   #
 ###################################
@@ -865,12 +865,11 @@ description: >-
   The hostname for the OIDC client redirect URL that the OIDC provider will redirect to after the user is authenticated
 
   For development use only. Useful when developing in a container and you want to expose localhost 
-  instead of container hostname to your OAuth provider 
+  instead of container hostname to your OAuth provider
 type: string
 default: none
-components:  ["nsregistry", "director"]
+components: ["nsregistry", "director"]
 ---
-
 ############################
 #   XRootD-level Configs   #
 ############################
@@ -971,7 +970,6 @@ type: string
 default: none
 components: ["origin"]
 ---
-
 ############################
 # Monitoring-level configs #
 ############################
@@ -1035,7 +1033,6 @@ type: bool
 default: true
 components: ["origin", "director", "nsregistry"]
 ---
-
 ############################
 #   Plugin-level configs   #
 ############################

--- a/registry/client_commands_test.go
+++ b/registry/client_commands_test.go
@@ -52,7 +52,7 @@ func registryMockup(t *testing.T, testName string) *httptest.Server {
 
 	//Set up a server to use for testing
 	svr := httptest.NewServer(engine)
-	viper.Set("Federation.NamespaceUrl", svr.URL)
+	viper.Set("Federation.RegistryUrl", svr.URL)
 	return svr
 }
 

--- a/server_ui/register_namespace.go
+++ b/server_ui/register_namespace.go
@@ -130,7 +130,7 @@ func registerNamespacePrep() (key jwk.Key, prefix string, registrationEndpointUR
 		return
 	}
 
-	namespaceEndpoint := param.Federation_NamespaceUrl.GetString()
+	namespaceEndpoint := param.Federation_RegistryUrl.GetString()
 	if namespaceEndpoint == "" {
 		err = errors.New("No namespace registry specified; try passing the `-f` flag specifying the federation name")
 		return

--- a/server_ui/register_namespace_test.go
+++ b/server_ui/register_namespace_test.go
@@ -84,7 +84,7 @@ func TestRegistration(t *testing.T) {
 	defer svr.CloseClientConnections()
 	defer svr.Close()
 
-	viper.Set("Federation.NamespaceUrl", svr.URL)
+	viper.Set("Federation.RegistryUrl", svr.URL)
 	viper.Set("Origin.NamespacePrefix", "/test123")
 
 	// Test registration succeeds


### PR DESCRIPTION
Closes #388 

Per request, `Federation.NamespaceUrl` is preserved but marked as deprecated. User can still use this config but a warning message will should up if `Federation.NamespaceUrl` is used instead of `Federation.RegistryUrl`