### PR TITLE
Unpublish Go package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/pelicanplatform/pelican
 
+retract v1.0.4 // Unpublish Go package
+
 go 1.20
 
 require (


### PR DESCRIPTION
Closes #505 

Note that once this PR is merged, someone needs to "push" the change to Go package repository. On the main branch of the central repository (not your fork), run `GOPROXY=proxy.golang.org go list -m github.com/pelicanplatform/pelican@v1.0.4`

This way, we should be able to retract our modules from Go.