### PR TITLE
Remove chmod on user-provided xrootd config files

### DIFF
--- a/xrootd/authorization.go
+++ b/xrootd/authorization.go
@@ -336,18 +336,13 @@ func makeSciTokensCfg() (cfg ScitokensCfg, err error) {
 		return cfg, errors.Wrapf(err, "Unable to create directory %v",
 			filepath.Dir(scitokensCfg))
 	}
-
+	// We only open the file without chmod to daemon group as we will make
+	// a copy of this file and save it into xrootd run location
 	if file, err := os.OpenFile(scitokensCfg, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0640); err == nil {
 		file.Close()
 	} else if !errors.Is(err, os.ErrExist) {
 		return cfg, err
 	}
-
-	if err = os.Chown(scitokensCfg, -1, gid); err != nil {
-		return cfg, errors.Wrapf(err, "Unable to change ownership of scitokens config %v"+
-			" to desired daemon group %v", scitokensCfg, gid)
-	}
-
 	cfg, err = LoadScitokensConfig(scitokensCfg)
 	if err != nil {
 		return cfg, errors.Wrapf(err, "Failed to load scitokens configuration at %s", scitokensCfg)

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -350,23 +350,20 @@ func CheckXrootdEnv(server server_utils.XRootDServer) error {
 		}
 	}
 
-	// If the authfile does not exist, create one
+	// If the authfile does not exist, create one.
 	authfile := param.Xrootd_Authfile.GetString()
 	err = config.MkdirAll(path.Dir(authfile), 0755, -1, gid)
 	if err != nil {
 		return errors.Wrapf(err, "Unable to create directory %v",
 			path.Dir(authfile))
 	}
+	// For user-provided authfile, we don't chmod to daemon group as EmitAuthfile will
+	// make a copy of it and save it to xrootd run location
 	if file, err := os.OpenFile(authfile, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0640); err == nil {
 		file.Close()
 	} else if !errors.Is(err, os.ErrExist) {
 		return err
 	}
-	if err = os.Chown(authfile, -1, gid); err != nil {
-		return errors.Wrapf(err, "Unable to change ownership of authfile %v"+
-			" to desired daemon group %v", authfile, groupname)
-	}
-
 	if err := EmitAuthfile(server); err != nil {
 		return err
 	}


### PR DESCRIPTION
When user provide xrootd config files i.e. `authfile` and `scitokens.cfg` by mounting them through docker/kubernetes in read-only mode, there will be a failure in origin/cache at the start, where Pelican will try to change the user group of both files to the daemon name (xrootd in most case), which is not allowed. 

This chmod is redundant as we eventually copy the two files, make some changes, and save them as final files to xrootd run location, so we only need to be able to read those files.