### PR TITLE
Fix error in retracting pkg with not including previous versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/pelicanplatform/pelican
 
-retract v1.0.4 // Unpublish Go package
+// Unpublish Go package as we are not intended to allow users us import our packages for now
+retract [v1.0.0, v1.0.5]
 
 go 1.20
 


### PR DESCRIPTION
I only did it half-right in the previous PR #540 where I created a higher version for go (v.1.0.4) but forget to retract all previous version (v1.0.0-v1.0.3) so that the retract is void. I found this error while already pushed the new 1.0.4 tag.

Added all the previous versions in this PR, I need to build a new tag and push it again. Sorry about adding unhelpful tags to the repo.