### PR TITLE
Return 404 for unregistered prefix

### DIFF
--- a/config/oidc_metadata.go
+++ b/config/oidc_metadata.go
@@ -19,6 +19,7 @@
 package config
 
 import (
+	"io/fs"
 	"os"
 	"strings"
 	"sync"
@@ -125,7 +126,11 @@ func getClientID() {
 	}
 	contents, err := os.ReadFile(clientFile)
 	if err != nil {
-		clientError = errors.Wrapf(err, "Failed reading provided OIDC.ClientIDFile %s", clientFile)
+		if errors.Is(err, fs.ErrNotExist) {
+			clientError = errors.Errorf("%s, specified in the configuration value of `OIDC.ClientIDFile`, does not exist", clientFile)
+		} else {
+			clientError = errors.Wrapf(err, "Failed reading provided OIDC.ClientIDFile %s", clientFile)
+		}
 		return
 	}
 	clientID = strings.TrimSpace(string(contents))

--- a/registry/registry_validation.go
+++ b/registry/registry_validation.go
@@ -45,6 +45,8 @@ func validatePrefix(nspath string) (string, error) {
 		return "", errors.New("Cannot register a prefix starting with '/api'")
 	} else if components[0] == "view" {
 		return "", errors.New("Cannot register a prefix starting with '/view'")
+	} else if components[0] == "caches" {
+		return "", errors.New("Cannot register a prefix starting with '/caches'")
 	} else if components[0] == "pelican" {
 		return "", errors.New("Cannot register a prefix starting with '/pelican'")
 	}


### PR DESCRIPTION
When a requested prefix doesn't exist, return a 404 instead of a 500.

This PR also adds minimal unit test coverage for the corresponding DB and API calls as well as a tangentially-related commit to clean up some error messages that I encountered while hand-testing.

Fixes #294