### PR TITLE
Reload TLS certificates as needed

### DIFF
--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -43,7 +43,7 @@ var (
 )
 
 func initCache() error {
-	err := config.InitServer([]config.ServerType{config.CacheType}, config.CacheType)
+	err := config.InitServer(config.CacheType)
 	cobra.CheckErr(err)
 	metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusCritical, "xrootd has not been started")
 	metrics.SetComponentHealthStatus(metrics.OriginCache_CMSD, metrics.StatusCritical, "cmsd has not been started")

--- a/cmd/cache_serve.go
+++ b/cmd/cache_serve.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/pelicanplatform/pelican/cache_ui"
 	"github.com/pelicanplatform/pelican/config"
@@ -132,6 +133,8 @@ func serveCache( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	if err != nil {
 		return err
 	}
+
+	xrootd.LaunchXrootdMaintenance(shutdownCtx, 2*time.Minute)
 
 	log.Info("Launching cache")
 	launchers, err := xrootd.ConfigureLaunchers(false, configPath, false)

--- a/cmd/cache_serve.go
+++ b/cmd/cache_serve.go
@@ -126,7 +126,12 @@ func serveCache( /*cmd*/ *cobra.Command /*args*/, []string) error {
 		return err
 	}
 
-	go web_ui.RunEngine(engine)
+	go func() {
+		if err := web_ui.RunEngine(shutdownCtx, engine); err != nil {
+			log.Panicln("Failure when running the web engine:", err)
+		}
+		shutdownCancel()
+	}()
 	go web_ui.InitServerWebLogin()
 
 	configPath, err := xrootd.ConfigXrootd(false)

--- a/cmd/director.go
+++ b/cmd/director.go
@@ -71,7 +71,7 @@ func getDirectorEndpoint() (string, error) {
 }
 
 func initDirector() error {
-	err := config.InitServer([]config.ServerType{config.DirectorType}, config.DirectorType)
+	err := config.InitServer(config.DirectorType)
 	cobra.CheckErr(err)
 
 	return err

--- a/cmd/director_serve.go
+++ b/cmd/director_serve.go
@@ -82,7 +82,7 @@ func serveDirector( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	// or to an origin
 	defaultResponse := param.Director_DefaultResponse.GetString()
 	if !(defaultResponse == "cache" || defaultResponse == "origin") {
-		return fmt.Errorf("The director's default response must either be set to 'cache' or 'origin',"+
+		return fmt.Errorf("the director's default response must either be set to 'cache' or 'origin',"+
 			" but you provided %q. Was there a typo?", defaultResponse)
 	}
 	log.Debugf("The director will redirect to %ss by default", defaultResponse)
@@ -93,7 +93,12 @@ func serveDirector( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	director.RegisterDirector(rootGroup)
 
 	log.Info("Starting web engine...")
-	go web_ui.RunEngine(engine)
+	go func() {
+		if err := web_ui.RunEngine(shutdownCtx, engine); err != nil {
+			log.Panicln("Failure when running the web engine:", err)
+		}
+		shutdownCancel()
+	}()
 
 	go web_ui.InitServerWebLogin()
 

--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -99,7 +99,7 @@ func configOrigin( /*cmd*/ *cobra.Command /*args*/, []string) {
 }
 
 func initOrigin() error {
-	err := config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
+	err := config.InitServer(config.OriginType)
 	cobra.CheckErr(err)
 	metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusCritical, "xrootd has not been started")
 	metrics.SetComponentHealthStatus(metrics.OriginCache_CMSD, metrics.StatusCritical, "cmsd has not been started")

--- a/cmd/origin_reset_password_test.go
+++ b/cmd/origin_reset_password_test.go
@@ -36,7 +36,7 @@ func TestResetPassword(t *testing.T) {
 	dirName := t.TempDir()
 	viper.Reset()
 	viper.Set("ConfigDir", dirName)
-	err := config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
+	err := config.InitServer(config.OriginType)
 	require.NoError(t, err)
 
 	rootCmd.SetArgs([]string{"origin", "web-ui", "reset-password", "--stdin"})

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -102,7 +102,12 @@ func serveOrigin( /*cmd*/ *cobra.Command /*args*/, []string) error {
 		}
 	}
 
-	go web_ui.RunEngine(engine)
+	go func() {
+		if err := web_ui.RunEngine(shutdownCtx, engine); err != nil {
+			log.Panicln("Failure when running the web engine:", err)
+		}
+		shutdownCancel()
+	}()
 
 	if param.Origin_EnableUI.GetBool() {
 		go web_ui.InitServerWebLogin()

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	_ "embed"
 	"sync"
+	"time"
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/daemon"
@@ -115,6 +116,8 @@ func serveOrigin( /*cmd*/ *cobra.Command /*args*/, []string) error {
 	if param.Origin_SelfTest.GetBool() {
 		go origin_ui.PeriodicSelfTest()
 	}
+
+	xrootd.LaunchXrootdMaintenance(shutdownCtx, 2*time.Minute)
 
 	privileged := param.Origin_Multiuser.GetBool()
 	launchers, err := xrootd.ConfigureLaunchers(privileged, configPath, param.Origin_EnableCmsd.GetBool())

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -56,7 +56,7 @@ var (
 )
 
 func initRegistry() error {
-	err := config.InitServer([]config.ServerType{config.RegistryType}, config.RegistryType)
+	err := config.InitServer(config.RegistryType)
 	cobra.CheckErr(err)
 
 	return err

--- a/config/config.go
+++ b/config/config.go
@@ -123,10 +123,16 @@ var (
 )
 
 // Set sets a list of newServers to ServerType instance
-func (sType *ServerType) Set(newServers []ServerType) {
+func (sType *ServerType) SetList(newServers []ServerType) {
 	for _, server := range newServers {
 		*sType |= server
 	}
+}
+
+// Enable a single server type in the bitmask
+func (sType *ServerType) Set(server ServerType) ServerType {
+	*sType |= server
+	return *sType
 }
 
 // IsEnabled checks if a testServer is in the ServerType instance
@@ -134,12 +140,17 @@ func (sType ServerType) IsEnabled(testServer ServerType) bool {
 	return sType&testServer == testServer
 }
 
+// Clear all values in a server type
+func (sType *ServerType) Clear() {
+	*sType = ServerType(0)
+}
+
 // setEnabledServer sets the global variable config.EnabledServers to include newServers.
 // Since this function should only be called in config package, we mark it "private" to avoid
 // reset value in other pacakge
 //
 // This will only be called once in a single process
-func setEnabledServer(newServers []ServerType) {
+func setEnabledServer(newServers ServerType) {
 	setServerOnce.Do(func() {
 		// For each process, we only want to set enabled servers once
 		enabledServers.Set(newServers)
@@ -376,7 +387,7 @@ func parseServerIssuerURL(sType ServerType) error {
 		return errors.New("If Server.IssuerHostname is configured, you must provide a valid port")
 	}
 
-	if sType == OriginType {
+	if sType.IsEnabled(OriginType) {
 		// If Origin.Mode is set to anything that isn't "posix" or "", assume we're running a plugin and
 		// that the origin's issuer URL actually uses the same port as OriginUI instead of XRootD. This is
 		// because under that condition, keys are being served by the Pelican process instead of by XRootD
@@ -505,20 +516,23 @@ func initConfigDir() error {
 	return nil
 }
 
-// Initialize Pelican server instance. Pass a list of "enabledServers" if you want to enable multiple servers,
-// and pass your "current" server to instantiate through "currentServer" so that the functions
-// knows which server it's being evoked for
-func InitServer(enabledServers []ServerType, currentServer ServerType) error {
+// Initialize Pelican server instance. Pass a list of `enabledServices` if you want to enable multiple services.
+// Note not all configurations are supported: currently, if you enable both cache and origin then an error
+// is thrown
+func InitServer(enabledServices ServerType) error {
 	if err := initConfigDir(); err != nil {
 		return errors.Wrap(err, "Failed to initialize the server configuration")
 	}
+	if enabledServices.IsEnabled(OriginType) && enabledServices.IsEnabled(CacheType) {
+		return errors.New("A cache and origin cannot both be enabled in the same instance")
+	}
 
-	setEnabledServer(enabledServers)
+	setEnabledServer(enabledServices)
 
 	xrootdPrefix := ""
-	if currentServer == OriginType {
+	if enabledServices.IsEnabled(OriginType) {
 		xrootdPrefix = "origin"
-	} else if currentServer == CacheType {
+	} else if enabledServices.IsEnabled(CacheType) {
 		xrootdPrefix = "cache"
 	}
 	configDir := viper.GetString("ConfigDir")
@@ -590,7 +604,7 @@ func InitServer(enabledServers []ServerType, currentServer ServerType) error {
 	// they have overridden the defaults.
 	hostname = viper.GetString("Server.Hostname")
 
-	if currentServer == CacheType {
+	if enabledServices.IsEnabled(CacheType) {
 		viper.Set("Xrootd.Port", param.Cache_Port.GetInt())
 	}
 	xrootdPort := param.Xrootd_Port.GetInt()
@@ -650,7 +664,7 @@ func InitServer(enabledServers []ServerType, currentServer ServerType) error {
 
 	// Set up the server's issuer URL so we can access that data wherever we need to find keys and whatnot
 	// This populates Server.IssuerUrl, and can be safely fetched using server_utils.GetServerIssuerURL()
-	err = parseServerIssuerURL(currentServer)
+	err = parseServerIssuerURL(enabledServices)
 	if err != nil {
 		return err
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -202,25 +202,30 @@ func TestEnabledServers(t *testing.T) {
 		for _, server := range allServerTypes {
 			enabledServers = 0
 			// We didn't call setEnabledServer as it will only set once per process
-			enabledServers.Set([]ServerType{server})
+			enabledServers.SetList([]ServerType{server})
 			assert.True(t, IsServerEnabled(server))
 		}
 	})
 
 	t.Run("enable-multiple-servers", func(t *testing.T) {
 		enabledServers = 0
-		enabledServers.Set([]ServerType{OriginType, CacheType})
+		enabledServers.SetList([]ServerType{OriginType, CacheType})
 		assert.True(t, IsServerEnabled(OriginType))
 		assert.True(t, IsServerEnabled(CacheType))
 	})
 
 	t.Run("setEnabledServer-only-set-once", func(t *testing.T) {
 		enabledServers = 0
-		setEnabledServer([]ServerType{OriginType, CacheType})
+		sType := OriginType
+		sType.Set(CacheType)
+		setEnabledServer(sType)
 		assert.True(t, IsServerEnabled(OriginType))
 		assert.True(t, IsServerEnabled(CacheType))
 
-		setEnabledServer([]ServerType{DirectorType, RegistryType})
+		sType.Clear()
+		sType.Set(DirectorType)
+		sType.Set(RegistryType)
+		setEnabledServer(sType)
 		assert.True(t, IsServerEnabled(OriginType))
 		assert.True(t, IsServerEnabled(CacheType))
 		assert.False(t, IsServerEnabled(DirectorType))

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
-	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/fsnotify/fsnotify v1.6.0
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/gin-contrib/sessions v0.0.5
 	github.com/gin-contrib/sse v0.1.0 // indirect

--- a/registry/client_commands_test.go
+++ b/registry/client_commands_test.go
@@ -38,7 +38,7 @@ func registryMockup(t *testing.T, testName string) *httptest.Server {
 	ikey := filepath.Join(issuerTempDir, "issuer.jwk")
 	viper.Set("IssuerKey", ikey)
 	viper.Set("Registry.DbLocation", filepath.Join(issuerTempDir, "test.sql"))
-	err := config.InitServer([]config.ServerType{config.RegistryType}, config.RegistryType)
+	err := config.InitServer(config.RegistryType)
 	require.NoError(t, err)
 
 	err = InitializeDB()

--- a/server_ui/register_namespace_test.go
+++ b/server_ui/register_namespace_test.go
@@ -55,7 +55,7 @@ func TestRegistration(t *testing.T) {
 
 	config.InitConfig()
 	viper.Set("Registry.DbLocation", filepath.Join(tempConfigDir, "test.sql"))
-	err := config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
+	err := config.InitServer(config.OriginType)
 	require.NoError(t, err)
 
 	err = registry.InitializeDB()

--- a/server_utils/server_utils.go
+++ b/server_utils/server_utils.go
@@ -19,10 +19,15 @@
 package server_utils
 
 import (
+	"context"
 	"net/url"
+	"reflect"
+	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 // For calling from within the server. Returns the server's issuer URL/port
@@ -37,4 +42,77 @@ func GetServerIssuerURL() (*url.URL, error) {
 	}
 
 	return issuerUrl, nil
+}
+
+// Launch a maintenance goroutine.
+// The maintenance routine will watch the directory `dirPath`, invoking `maintenanceFunc` whenever
+// an event occurs in the directory.  Note the behavior of directory watching differs across platforms;
+// for example, an atomic rename might be one or two events for the destination file depending on Mac OS X or Linux.
+//
+// Even if the filesystem watcher fails, this will invoke `maintenanceFunc` every `sleepTime` duration.
+// The maintenance function will be called with `true` if invoked due to a directory change, false otherwise
+// When generating error messages, `description` will be used to describe the task.
+func LaunchWatcherMaintenance(ctx context.Context, dirPath string, description string, sleepTime time.Duration, maintenanceFunc func(notifyEvent bool) error) {
+	select_count := 4
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Warningf("%s routine failed to create new watcher", description)
+		select_count -= 2
+	} else if err = watcher.Add(dirPath); err != nil {
+		log.Warningf("%s routine failed to add directory %s to watch: %v", description, dirPath, err)
+		select_count -= 2
+	}
+	cases := make([]reflect.SelectCase, select_count)
+	ticker := time.NewTicker(sleepTime)
+	cases[0].Dir = reflect.SelectRecv
+	cases[0].Chan = reflect.ValueOf(ticker.C)
+	cases[1].Dir = reflect.SelectRecv
+	cases[1].Chan = reflect.ValueOf(ctx.Done())
+	if err == nil {
+		cases[2].Dir = reflect.SelectRecv
+		cases[2].Chan = reflect.ValueOf(watcher.Events)
+		cases[3].Dir = reflect.SelectRecv
+		cases[3].Chan = reflect.ValueOf(watcher.Errors)
+	}
+	go func() {
+		defer watcher.Close()
+		for {
+			chosen, recv, ok := reflect.Select(cases)
+			if chosen == 0 {
+				if !ok {
+					log.Panicf("Ticker failed in the %s routine; exiting", description)
+				}
+				err := maintenanceFunc(false)
+				if err != nil {
+					log.Warningf("Failure during %s routine: %v", description, err)
+				}
+			} else if chosen == 1 {
+				log.Infof("%s routine has been cancelled.  Shutting down", description)
+				return
+			} else if chosen == 2 { // watcher.Events
+				if !ok {
+					log.Panicf("Watcher events failed in %s routine; exiting", description)
+				}
+				if event, ok := recv.Interface().(fsnotify.Event); ok {
+					log.Debugf("Got filesystem event (%v); will run %s", event, description)
+					err := maintenanceFunc(true)
+					if err != nil {
+						log.Warningf("Failure during %s routine: %v", description, err)
+					}
+				} else {
+					log.Panicln("Watcher returned an unknown event")
+				}
+			} else if chosen == 3 { // watcher.Errors
+				if !ok {
+					log.Panicf("Watcher error channel closed in %s routine; exiting", description)
+				}
+				if err, ok := recv.Interface().(error); ok {
+					log.Errorf("Watcher failure in the %s routine: %v", description, err)
+				} else {
+					log.Panicln("Watcher error channel has internal error; exiting")
+				}
+				time.Sleep(time.Second)
+			}
+		}
+	}()
 }

--- a/utils/ca_utils.go
+++ b/utils/ca_utils.go
@@ -89,10 +89,12 @@ func PeriodicWriteCABundle(filename string, sleepTime time.Duration) (count int,
 	}
 
 	go func() {
-		time.Sleep(sleepTime)
-		_, err := WriteCABundle(filename)
-		if err != nil {
-			log.Warningln("Failure during periodic CA bundle update:", err)
+		for {
+			time.Sleep(sleepTime)
+			_, err := WriteCABundle(filename)
+			if err != nil {
+				log.Warningln("Failure during periodic CA bundle update:", err)
+			}
 		}
 	}()
 

--- a/web_ui/engine_test.go
+++ b/web_ui/engine_test.go
@@ -1,0 +1,181 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package web_ui
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Setup a gin engine that will serve up a /ping endpoint on a Unix domain socket.
+func setupPingEngine(t *testing.T) (chan bool, context.CancelFunc, string) {
+	dirname := t.TempDir()
+	viper.Reset()
+	viper.Set("Logging.Level", "Debug")
+	viper.Set("ConfigDir", dirname)
+	viper.Set("Server.WebPort", 0)
+	config.InitConfig()
+	err := config.InitServer(config.OriginType)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	engine, err := GetEngine()
+	require.NoError(t, err)
+
+	engine.GET("/ping", func(ctx *gin.Context) {
+		ctx.Data(http.StatusOK, "text/plain; charset=utf-8", []byte("pong"))
+	})
+
+	// Setup a domain socket instead of listening on TCP
+	socketLocation := filepath.Join(dirname, "engine.sock")
+	ln, err := net.Listen("unix", socketLocation)
+	require.NoError(t, err)
+
+	doneChan := make(chan bool)
+	go func() {
+		err = runEngineWithListener(ctx, ln, engine)
+		require.NoError(t, err)
+		doneChan <- true
+	}()
+
+	transport := *config.GetTransport()
+	transport.DialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
+		return net.Dial("unix", socketLocation)
+	}
+	httpc := http.Client{
+		Transport: &transport,
+	}
+
+	engineReady := false
+	for idx := 0; idx < 20; idx++ {
+		time.Sleep(10 * time.Millisecond)
+		log.Debug("Checking for engine ready")
+
+		var resp *http.Response
+		resp, err = httpc.Get("https://" + param.Server_Hostname.GetString() + "/ping")
+		if err != nil {
+			continue
+		}
+		assert.Equal(t, "200 OK", resp.Status)
+		var body []byte
+		body, err = io.ReadAll(resp.Body)
+		assert.Equal(t, string(body), "pong")
+	}
+	if !engineReady {
+		require.NoError(t, err)
+	}
+
+	return doneChan, cancel, socketLocation
+}
+
+// Test the engine startup, serving a single request using
+// TLS validation, then a clean shutdown.
+func TestRunEngine(t *testing.T) {
+	doneChan, cancel, _ := setupPingEngine(t)
+
+	// Shutdown the engine
+	cancel()
+	timeout := time.Tick(3 * time.Second)
+	select {
+	case ok := <-doneChan:
+		require.True(t, ok)
+	case <-timeout:
+		require.Fail(t, "Timeout when shutting down the engine")
+	}
+}
+
+// Ensure that if the TLS certificate is updated on disk then new
+// connections will use the new version.
+func TestUpdateCert(t *testing.T) {
+	_, cancel, socketLocation := setupPingEngine(t)
+	defer cancel()
+
+	getCurrentFingerprint := func() [sha256.Size]byte {
+
+		conn, err := net.Dial("unix", socketLocation)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		tlsConfig := &tls.Config{
+			InsecureSkipVerify: true,
+			ServerName:         param.Server_WebHost.GetString(),
+		}
+		tlsConn := tls.Client(conn, tlsConfig)
+		err = tlsConn.Handshake()
+		require.NoError(t, err)
+
+		currentCert := tlsConn.ConnectionState().PeerCertificates[0]
+		return sha256.Sum256(currentCert.Raw)
+	}
+
+	// First, compare the current fingerprint against that on disk
+	currentFingerprint := getCurrentFingerprint()
+
+	certFile := param.Server_TLSCertificate.GetString()
+	keyFile := param.Server_TLSKey.GetString()
+	getDiskFingerprint := func() [sha256.Size]byte {
+		diskCert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		require.NoError(t, err)
+		return sha256.Sum256(diskCert.Certificate[0])
+	}
+
+	diskFingerprint := getDiskFingerprint()
+	assert.Equal(t, currentFingerprint, diskFingerprint)
+
+	// Next, trigger a reload of the cert
+	require.NoError(t, os.Remove(certFile))
+	require.NoError(t, os.Remove(keyFile))
+	require.NoError(t, config.InitServer(config.OriginType))
+
+	newDiskFingerprint := getDiskFingerprint()
+	assert.NotEqual(t, diskFingerprint, newDiskFingerprint)
+
+	log.Debugln("Will look for updated TLS certificate")
+	sawUpdate := false
+	for idx := 0; idx < 10; idx++ {
+		time.Sleep(50 * time.Millisecond)
+		log.Debugln("Checking current fingerprint")
+		currentFingerprint := getCurrentFingerprint()
+		if currentFingerprint == newDiskFingerprint {
+			sawUpdate = true
+			break
+		} else {
+			require.Equal(t, currentFingerprint, diskFingerprint)
+		}
+	}
+	assert.True(t, sawUpdate)
+}

--- a/web_ui/ui_test.go
+++ b/web_ui/ui_test.go
@@ -71,7 +71,7 @@ func TestMain(m *testing.M) {
 
 	// Ensure we load up the default configs.
 	config.InitConfig()
-	if err := config.InitServer([]config.ServerType{config.OriginType}, config.OriginType); err != nil {
+	if err := config.InitServer(config.OriginType); err != nil {
 		fmt.Println("Failed to configure the test module")
 		os.Exit(1)
 	}
@@ -104,7 +104,7 @@ func TestWaitUntilLogin(t *testing.T) {
 	viper.Reset()
 	viper.Set("ConfigDir", dirName)
 	config.InitConfig()
-	err := config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
+	err := config.InitServer(config.OriginType)
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -151,7 +151,7 @@ func TestCodeBasedLogin(t *testing.T) {
 	viper.Reset()
 	viper.Set("ConfigDir", dirName)
 	config.InitConfig()
-	err := config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
+	err := config.InitServer(config.OriginType)
 	require.NoError(t, err)
 	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256())
 	require.NoError(t, err)
@@ -203,7 +203,7 @@ func TestPasswordResetAPI(t *testing.T) {
 	viper.Reset()
 	viper.Set("ConfigDir", dirName)
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
-	err := config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
+	err := config.InitServer(config.OriginType)
 	require.NoError(t, err)
 	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256())
 	require.NoError(t, err)
@@ -306,7 +306,7 @@ func TestPasswordBasedLoginAPI(t *testing.T) {
 	viper.Reset()
 	config.InitConfig()
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
-	err := config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
+	err := config.InitServer(config.OriginType)
 	require.NoError(t, err)
 
 	///////////////////////////SETUP///////////////////////////////////
@@ -420,7 +420,7 @@ func TestWhoamiAPI(t *testing.T) {
 	config.InitConfig()
 	viper.Set("ConfigDir", dirName)
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
-	err := config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
+	err := config.InitServer(config.OriginType)
 	require.NoError(t, err)
 	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256())
 	require.NoError(t, err)

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -131,7 +131,7 @@ func TestGenerateConfig(t *testing.T) {
 	assert.Equal(t, issuer.Name, "")
 
 	viper.Set("Origin.SelfTest", true)
-	err = config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
+	err = config.InitServer(config.OriginType)
 	require.NoError(t, err)
 	issuer, err = GenerateMonitoringIssuer()
 	require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestGenerateConfig(t *testing.T) {
 	viper.Set("Origin.SelfTest", false)
 	viper.Set("Origin.ScitokensDefaultUser", "user1")
 	viper.Set("Origin.ScitokensMapSubject", true)
-	err = config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
+	err = config.InitServer(config.OriginType)
 	require.NoError(t, err)
 	issuer, err = GenerateOriginIssuer([]string{"/foo/bar/baz", "/another/exported/path"})
 	require.NoError(t, err)
@@ -237,7 +237,7 @@ func TestWriteOriginScitokensConfig(t *testing.T) {
 	viper.Set("Xrootd.RunLocation", dirname)
 	viper.Set("Xrootd.Port", 8443)
 	viper.Set("Server.Hostname", "origin.example.com")
-	err := config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
+	err := config.InitServer(config.OriginType)
 	require.Nil(t, err)
 
 	scitokensCfg := param.Xrootd_ScitokensConfig.GetString()

--- a/xrootd/origin_test.go
+++ b/xrootd/origin_test.go
@@ -70,7 +70,7 @@ func originMockup(t *testing.T) context.CancelFunc {
 	// Increase the log level; otherwise, its difficult to debug failures
 	viper.Set("Logging.Level", "Debug")
 	config.InitConfig()
-	err = config.InitServer([]config.ServerType{config.OriginType}, config.OriginType)
+	err = config.InitServer(config.OriginType)
 	require.NoError(t, err)
 
 	err = config.GeneratePrivateKey(param.Server_TLSKey.GetString(), elliptic.P256())

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -20,7 +20,7 @@ if exec xrootd
 fi
 ofs.osslib libXrdPss.so
 pss.cachelib libXrdPfc.so
-xrd.tls {{.Server.TLSCertificate}} {{.Server.TLSKey}}
+xrd.tls {{.Xrootd.RunLocation}}/copied-tls-creds.crt {{.Xrootd.RunLocation}}/copied-tls-creds.crt
 {{if .Server.TLSCACertificateDirectory}}
 xrd.tlsca certdir {{.Server.TLSCACertificateDirectory}}
 {{else}}

--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -22,7 +22,7 @@ if exec xrootd
   xrd.port {{.Xrootd.Port}}
   xrd.protocol http:{{.Xrootd.Port}} libXrdHttp.so
 fi
-xrd.tls {{.Server.TLSCertificate}} {{.Server.TLSKey}}
+xrd.tls {{.Xrootd.RunLocation}}/copied-tls-creds.crt {{.Xrootd.RunLocation}}/copied-tls-creds.crt
 {{if .Server.TLSCACertificateDirectory}}
 xrd.tlsca certdir {{.Server.TLSCACertificateDirectory}}
 {{else}}


### PR DESCRIPTION
We want to provide for clean updates of the TLS certificate for production services.  This PR does two things:

1.  Makes a copy of the TLS certificates for XRootD, avoiding file permission issues that tend to hit Kubernetes.  Adds a goroutine that periodically updates XRootD's copy of the certificate.  Uses a combination of fsnotify and polling for updates.
2. Using the same update approach, pull in new certificates in the pelican web UI.

Includes unit tests for both items.