### PR TITLE
Stash_plugin uploads now record bytes transferred

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -506,9 +506,9 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 			AddError(err)
 			return 0, err
 		}
-		_, err = doWriteBack(source_url.Path, dest_url, ns, recursive)
+		uploadedBytes, err := doWriteBack(source_url.Path, dest_url, ns, recursive)
 		AddError(err)
-		return 0, err
+		return uploadedBytes, err
 	}
 
 	if dest_url.Scheme == "file" {


### PR DESCRIPTION
When dostashcpsingle is called and detects a writeback, it will now return the uploaded bytes instead of just an error