### PR TITLE
Stash plugin calls init-config & added unit test

### DIFF
--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -68,7 +68,7 @@ func TestStashPluginMain(t *testing.T) {
 	// Parts of test adapted from: https://stackoverflow.com/questions/26225513/how-to-test-os-exit-scenarios-in-go
 	if os.Getenv("RUN_STASHPLUGIN") == "1" {
 		// Download a test file
-		args := []string{"osdf:///osgconnect/public/osg/testfile.txt", tempDir}
+		args := []string{"pelican://pelican.example.com/osgconnect/public/osg/testfile.txt", tempDir}
 		stashPluginMain(args)
 		os.Unsetenv("STASH_LOGGING_LEVEL")
 		os.Unsetenv("RUN_STASHPLUGIN")
@@ -84,11 +84,11 @@ func TestStashPluginMain(t *testing.T) {
 	cmd.Stderr = &stderr
 
 	err := cmd.Run()
-	assert.NoError(t, err, stderr.String())
+	assert.Error(t, err, stderr.String())
 
 	// changing output for "\\" since in windows there are excess "\" printed in debug logs
 	output := strings.Replace(stderr.String(), "\\\\", "\\", -1)
 
-	expectedOutput := "Downloading: osdf:///osgconnect/public/osg/testfile.txt to " + tempDir
+	expectedOutput := "Downloading: pelican://pelican.example.com/osgconnect/public/osg/testfile.txt to " + tempDir
 	assert.Contains(t, output, expectedOutput)
 }

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -20,9 +20,15 @@ package main
 
 import (
 	"bufio"
+	"bytes"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
+	"github.com/pelicanplatform/pelican/config"
+
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -49,4 +55,40 @@ func TestReadMultiTransfer(t *testing.T) {
 	assert.Equal(t, 1, len(transfers))
 	assert.Equal(t, "url://server/some/directory//blah", transfers[0].url)
 	assert.Equal(t, "/path/to/local/copy/of/blah", transfers[0].localFile)
+}
+
+func TestStashPluginMain(t *testing.T) {
+	viper.Reset()
+	config.SetPreferredPrefix("STASH")
+
+	// Temp dir for downloads
+	tempDir := os.TempDir()
+	defer os.Remove(tempDir)
+
+	// Parts of test adapted from: https://stackoverflow.com/questions/26225513/how-to-test-os-exit-scenarios-in-go
+	if os.Getenv("RUN_STASHPLUGIN") == "1" {
+		// Download a test file
+		args := []string{"osdf:///osgconnect/public/osg/testfile.txt", tempDir}
+		stashPluginMain(args)
+		os.Unsetenv("STASH_LOGGING_LEVEL")
+		os.Unsetenv("RUN_STASHPLUGIN")
+		return
+	}
+
+	// Create a process to run the command (since stashPluginMain calls os.Exit(0))
+	cmd := exec.Command(os.Args[0], "-test.run=TestStashPluginMain")
+	cmd.Env = append(os.Environ(), "RUN_STASHPLUGIN=1", "STASH_LOGGING_LEVEL=debug")
+
+	// Create buffers for stderr (the output we want for test)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	assert.NoError(t, err, stderr.String())
+
+	// changing output for "\\" since in windows there are excess "\" printed in debug logs
+	output := strings.Replace(stderr.String(), "\\\\", "\\", -1)
+
+	expectedOutput := "Downloading: osdf:///osgconnect/public/osg/testfile.txt to " + tempDir
+	assert.Contains(t, output, expectedOutput)
 }


### PR DESCRIPTION
Stash plugin will now call init-config on startup so it can get the configured timeouts and log levels as well as any other default/environment configuration. Added a unit test to test functionality of stashPluginMain as well as this new fix.