### PR TITLE
Update ns key discovery to follow openid-style lookups

### DIFF
--- a/director/origin_api_test.go
+++ b/director/origin_api_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"testing"
 	"time"
@@ -13,13 +14,34 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
-	"github.com/pelicanplatform/pelican/config"
-	"github.com/pelicanplatform/pelican/test_utils"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/test_utils"
 )
+
+// For these tests, we only need to lookup key locations. Create a dummy registry that only
+// the jwks_uri location for the given key. Once a server is instantiated, it will only return
+// locations for the provided prefix. To change prefixes, create a new registry mockup.
+func registryMockup(t *testing.T, prefix string) *httptest.Server {
+	registryUrl, _ := url.Parse("https://registry.com:8446")
+	path, err := url.JoinPath("/api/v1.0/registry", prefix, ".well-known/issuer.jwks")
+	if err != nil {
+		t.Fatalf("Failed to parse key path for prefix %s", prefix)
+	}
+	registryUrl.Path = path
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse := `{"jwks_uri": "` + registryUrl.String() + `"}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(jsonResponse))
+	}))
+	return server
+}
 
 func TestVerifyAdvertiseToken(t *testing.T) {
 	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
@@ -160,11 +182,14 @@ func TestCreateAdvertiseToken(t *testing.T) {
 	viper.Set("Federation.RegistryUrl", "")
 	viper.Set("Federation.DirectorURL", "")
 
-	// Test without a namsepace set and check to see if it returns the expected error
+	registry := registryMockup(t, "/test-namespace")
+	defer registry.Close()
+
+	// Test without a registry URL set and check to see if it returns the expected error
 	tok, err := CreateAdvertiseToken("/test-namespace")
 	assert.Equal(t, "", tok)
-	assert.Equal(t, "Namespace URL is not set", err.Error())
-	viper.Set("Federation.RegistryUrl", "https://get-your-tokens.org")
+	assert.Equal(t, "federation registry URL is not set and was not discovered", err.Error())
+	viper.Set("Federation.RegistryUrl", registry.URL)
 
 	// Test without a DirectorURL set and check to see if it returns the expected error
 	tok, err = CreateAdvertiseToken("/test-namespace")
@@ -178,23 +203,25 @@ func TestCreateAdvertiseToken(t *testing.T) {
 	assert.NotEqual(t, "", tok)
 }
 
-func TestGetRegistryIssuerURL(t *testing.T) {
-	/*
-	* Runs unit tests on the GetRegistryIssuerURL function
-	 */
+func TestGetNSIssuerURL(t *testing.T) {
 	viper.Reset()
 
+	emptyRegistry := registryMockup(t, "")
+	defer emptyRegistry.Close()
+
+	viper.Set("Federation.RegistryUrl", emptyRegistry.URL)
 	// No namespace url has been set, so an error is expected
-	url, err := GetRegistryIssuerURL("")
+	url, err := GetNSIssuerURL("")
+	assert.Equal(t, "the prefix \"\" is invalid", err.Error())
 	assert.Equal(t, "", url)
-	assert.Equal(t, "Namespace URL is not set", err.Error())
 
 	// Test to make sure the path is as expected
-	viper.Set("Federation.RegistryUrl", "test-path")
-	url, err = GetRegistryIssuerURL("test-prefix")
+	registry := registryMockup(t, "/test-prefix")
+	defer registry.Close()
+	viper.Set("Federation.RegistryUrl", registry.URL)
+	url, err = GetNSIssuerURL("/test-prefix")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "test-path/api/v1.0/registry/test-prefix/.well-known/issuer.jwks", url)
-
+	assert.Equal(t, "https://registry.com:8446/api/v1.0/registry/test-prefix/.well-known/issuer.jwks", url)
 }
 
 func TestNamespaceKeysCacheEviction(t *testing.T) {

--- a/director/origin_api_test.go
+++ b/director/origin_api_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pelicanplatform/pelican/test_utils"
 )
 
-// For these tests, we only need to lookup key locations. Create a dummy registry that only
+// For these tests, we only need to lookup key locations. Create a dummy registry that only returns
 // the jwks_uri location for the given key. Once a server is instantiated, it will only return
 // locations for the provided prefix. To change prefixes, create a new registry mockup.
 func registryMockup(t *testing.T, prefix string) *httptest.Server {

--- a/director/redirect_test.go
+++ b/director/redirect_test.go
@@ -21,12 +21,13 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
-	"github.com/pelicanplatform/pelican/config"
-	"github.com/pelicanplatform/pelican/test_utils"
-	"github.com/pelicanplatform/pelican/token_scopes"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/test_utils"
+	"github.com/pelicanplatform/pelican/token_scopes"
 )
 
 type MockCache struct {

--- a/registry/client_commands.go
+++ b/registry/client_commands.go
@@ -233,9 +233,9 @@ func NamespaceDelete(endpoint string, prefix string) error {
 	// TODO: We might consider moving widely-useful functions like `GetRegistryIssuerURL`
 	//       to a more generic `pelican/utils` package so that they're easier to find
 	//       and more likely to be used.
-	issuerURL, err := director.GetRegistryIssuerURL(prefix)
+	issuerURL, err := director.GetNSIssuerURL(prefix)
 	if err != nil {
-		return errors.Wrap(err, "Failed to determine issuer URL for creating deletion token")
+		return errors.Wrap(err, "Failed to determine prefix's issuer/pubkey URL for creating deletion token")
 	}
 
 	// TODO: Eventually we should think about a naming scheme for


### PR DESCRIPTION
Previously, namespace keys were fetched by hardcoding the issuer jwks relative to the namespace.
Now we conform to openid-style lookups by fetching the JSON located at
<registry url>/api/v2.0/registry/metadata/<namespace>/.well-known/namespace-configuration
and following the URL associated with the `jwks_uri` key. Currently this is still the same key path
in all instances that I'm aware of, but in theory this could be expanded to point to other locations.
We can also expand this namespace-configuration JSON to include additional information as needed.

The architecture of this PR is that a GET request to the namespace-configuration url mentioned above
should dynamically generate the JSON with `jwks_uri` key and associated value. The value is used throughout
and assigned the issuer URL in various places where we need to create a token on behalf of themnamespace.