### PR TITLE
Fixup merging of authfiles

### DIFF
--- a/xrootd/authorization.go
+++ b/xrootd/authorization.go
@@ -218,7 +218,7 @@ func EmitAuthfile(server server_utils.XRootDServer) error {
 		if len(words) >= 2 && words[0] == "u" && words[1] == "*" {
 			// There exists a public access already in the authfile
 			if server.GetServerType().IsEnabled(config.OriginType) {
-				// If Origin, add the ./well-known to the authfile
+				// If Origin, add the /.well-known to the authfile
 				output.Write([]byte("u * /.well-known lr " + strings.Join(words[2:], " ") + "\n"))
 			} else {
 				output.Write([]byte(lineContents + "\n"))

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -82,7 +82,18 @@ u * /user/ligo -rl \
 /NSG/PUBLIC rl \
 /VDC/PUBLIC rl`
 
-	cacheAuthfileOutput = "u * /user/ligo -rl /Gluex rl /NSG/PUBLIC rl /VDC/PUBLIC rl "
+	cacheAuthfileOutput = "u * /.well-known lr /user/ligo -rl /Gluex rl /NSG/PUBLIC rl /VDC/PUBLIC rl\n"
+
+	// Actual authfile entries here are from the bug report #568
+	otherAuthfileEntries = `# DN: /CN=sc-origin.chtc.wisc.edu
+u 5a42185a.0 /chtc/PROTECTED/sc-origin lr
+# DN: /DC=org/DC=incommon/C=US/ST=California/O=University of California, San Diego/CN=osg-stash-sfu-computecanada-ca.nationalresearchplatform.org
+u 4ff08838.0 /chtc/PROTECTED/sc-origin lr
+# DN: /DC=org/DC=incommon/C=US/ST=Georgia/O=Georgia Institute of Technology/OU=Office of Information Technology/CN=osg-gftp2.pace.gatech.edu
+u 3af6a420.0 /chtc/PROTECTED/sc-origin lr
+`
+
+	mergedAuthfileEntries = otherAuthfileEntries + "u * /.well-known lr\n"
 )
 
 func TestAuthfileMultiline(t *testing.T) {
@@ -98,22 +109,42 @@ func TestAuthfileMultiline(t *testing.T) {
 }
 
 func TestEmitAuthfile(t *testing.T) {
-	dirName := t.TempDir()
-	viper.Reset()
-	viper.Set("Xrootd.Authfile", filepath.Join(dirName, "authfile"))
-	viper.Set("Xrootd.RunLocation", dirName)
-	server := &cache_ui.CacheServer{}
+	tests := []struct {
+		desc    string
+		authIn  string
+		authOut string
+	}{
+		{
+			desc:    "merge-multi-lines",
+			authIn:  cacheAuthfileMultilineInput,
+			authOut: cacheAuthfileOutput,
+		},
+		{
+			desc:    "merge-other-entries",
+			authIn:  otherAuthfileEntries,
+			authOut: mergedAuthfileEntries,
+		},
+	}
+	for _, testInput := range tests {
+		t.Run(testInput.desc, func(t *testing.T) {
+			dirName := t.TempDir()
+			viper.Reset()
+			viper.Set("Xrootd.Authfile", filepath.Join(dirName, "authfile"))
+			viper.Set("Xrootd.RunLocation", dirName)
+			server := &origin_ui.OriginServer{}
 
-	err := os.WriteFile(filepath.Join(dirName, "authfile"), []byte(cacheAuthfileMultilineInput), fs.FileMode(0600))
-	require.NoError(t, err)
+			err := os.WriteFile(filepath.Join(dirName, "authfile"), []byte(testInput.authIn), fs.FileMode(0600))
+			require.NoError(t, err)
 
-	err = EmitAuthfile(server)
-	require.NoError(t, err)
+			err = EmitAuthfile(server)
+			require.NoError(t, err)
 
-	contents, err := os.ReadFile(filepath.Join(dirName, "authfile-cache-generated"))
-	require.NoError(t, err)
+			contents, err := os.ReadFile(filepath.Join(dirName, "authfile-origin-generated"))
+			require.NoError(t, err)
 
-	assert.Equal(t, cacheAuthfileOutput, string(contents))
+			assert.Equal(t, testInput.authOut, string(contents))
+		})
+	}
 }
 
 func TestEmitCfg(t *testing.T) {
@@ -317,7 +348,7 @@ func TestWriteCacheAuthFiles(t *testing.T) {
 	cacheServer := &cache_ui.CacheServer{}
 	cacheServer.SetNamespaceAds(nsAds)
 
-	t.Run("MultiIssuer", cacheAuthTester(cacheServer, cacheSciOutput, "u * /p3 lr /p4/depth lr /p2_noauth lr "))
+	t.Run("MultiIssuer", cacheAuthTester(cacheServer, cacheSciOutput, "u * /p3 lr /p4/depth lr /p2_noauth lr \n"))
 
 	nsAds = []director.NamespaceAd{}
 	cacheServer.SetNamespaceAds(nsAds)


### PR DESCRIPTION
The first commit handles line continuation characters, allowing the current syntax generated by topology to be used.

The second commit ensures we merge in lines that _aren't_ public lines.  This is needed for VOMS/X509-based authentication.

Fixes #567 
Fixes #568 