### PR TITLE
Fixup various cache and testing failures

### DIFF
--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -21,7 +21,6 @@ package main
 import (
 	"context"
 
-	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/spf13/cobra"
 )
@@ -45,11 +44,9 @@ var (
 )
 
 func initCache(ctx context.Context) error {
-	err := config.InitServer(ctx, config.CacheType)
-	cobra.CheckErr(err)
 	metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusCritical, "xrootd has not been started")
 	metrics.SetComponentHealthStatus(metrics.OriginCache_CMSD, metrics.StatusCritical, "cmsd has not been started")
-	return err
+	return nil
 }
 
 func init() {

--- a/cmd/fed.go
+++ b/cmd/fed.go
@@ -44,8 +44,6 @@ func init() {
 	if err := viper.BindPFlag("Server.Modules", serveCmd.Flags().Lookup("module")); err != nil {
 		panic(err)
 	}
-	serveCmd.Flags().Uint16("reg-port", 8446, "Port for the namespace registry")
-	serveCmd.Flags().Uint16("director-port", 8445, "Port for the director")
 	serveCmd.Flags().Uint16("origin-port", 8443, "Port for the origin")
 	serveCmd.Flags().Uint16("cache-port", 8442, "Port for the cache")
 }

--- a/cmd/fed_serve_test.go
+++ b/cmd/fed_serve_test.go
@@ -80,6 +80,7 @@ func TestFedServePosixOrigin(t *testing.T) {
 	viper.Set("Origin.EnableVoms", false)
 	viper.Set("TLSSkipVerify", true)
 	viper.Set("Server.EnableUI", false)
+	viper.Set("Registry.DbLocation", filepath.Join(t.TempDir(), "ns-registry.sqlite"))
 
 	err = config.InitServer(ctx, modules)
 	require.NoError(t, err)

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -215,6 +215,8 @@ func TestConfigCacheEviction(t *testing.T) {
 		ConfigTTLCache(ctx, egrp)
 		defer func() {
 			shutdownCancel()
+			err := egrp.Wait()
+			assert.NoError(t, err)
 		}()
 
 		ctx, cancelFunc := context.WithDeadline(ctx, time.Now().Add(time.Second*5))


### PR DESCRIPTION
This cleans up a deadlock in the `pelican cache serve` mode generated in #570 and fixes some race/ordering conditions I spotted which may be causing flakey unit tests also post the #570 merge.