### PR TITLE
Regenerate the authfile and scitokens.cfg periodically

### DIFF
--- a/cmd/cache_serve.go
+++ b/cmd/cache_serve.go
@@ -171,7 +171,7 @@ func serveCacheInternal(ctx context.Context) error {
 		return err
 	}
 
-	xrootd.LaunchXrootdMaintenance(ctx, 2*time.Minute)
+	xrootd.LaunchXrootdMaintenance(ctx, cacheServer, 2*time.Minute)
 
 	log.Info("Launching cache")
 	launchers, err := xrootd.ConfigureLaunchers(false, configPath, false)

--- a/launchers/origin_serve.go
+++ b/launchers/origin_serve.go
@@ -77,7 +77,7 @@ func OriginServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group) 
 		egrp.Go(func() error { return origin_ui.PeriodicSelfTest(ctx) })
 	}
 
-	xrootd.LaunchXrootdMaintenance(ctx, 2*time.Minute)
+	xrootd.LaunchXrootdMaintenance(ctx, originServer, 2*time.Minute)
 
 	privileged := param.Origin_Multiuser.GetBool()
 	launchers, err := xrootd.ConfigureLaunchers(privileged, configPath, param.Origin_EnableCmsd.GetBool())

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -72,3 +72,12 @@ func (server *OriginServer) CreateAdvertisement(name string, originUrl string, o
 
 	return ad, nil
 }
+
+// Return a list of paths where the origin's issuer is authoritative.
+//
+// Used to calculate the base_paths in the scitokens.cfg, for eaxmple
+func (server *OriginServer) GetAuthorizedPrefixes() []string {
+	// For now, just a single path.  In the future, we will allow
+	// multiple.
+	return []string{param.Origin_NamespacePrefix.GetString()}
+}

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -318,7 +318,7 @@ func runEngineWithListener(ctx context.Context, ln net.Listener, engine *gin.Eng
 
 	server_utils.LaunchWatcherMaintenance(
 		ctx,
-		filepath.Dir(param.Server_TLSCertificate.GetString()),
+		[]string{filepath.Dir(param.Server_TLSCertificate.GetString())},
 		"server TLS maintenance",
 		2*time.Minute,
 		func(notifyEvent bool) error {

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -156,7 +156,7 @@ func TestEmitCfg(t *testing.T) {
 
 	configTester := func(cfg *ScitokensCfg, configResult string) func(t *testing.T) {
 		return func(t *testing.T) {
-			err = EmitScitokensConfiguration(config.OriginType, cfg)
+			err = writeScitokensConfiguration(config.OriginType, cfg)
 			assert.NoError(t, err)
 
 			genCfg, err := os.ReadFile(filepath.Join(dirname, "scitokens-origin-generated.cfg"))
@@ -191,7 +191,7 @@ func TestLoadScitokensConfig(t *testing.T) {
 			cfg, err := LoadScitokensConfig(cfgFname)
 			require.NoError(t, err)
 
-			err = EmitScitokensConfiguration(config.OriginType, &cfg)
+			err = writeScitokensConfiguration(config.OriginType, &cfg)
 			assert.NoError(t, err)
 
 			genCfg, err := os.ReadFile(filepath.Join(dirname, "scitokens-origin-generated.cfg"))

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -23,15 +23,19 @@ package xrootd
 import (
 	"bytes"
 	"context"
+	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/origin_ui"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/test_utils"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -63,6 +67,99 @@ func TestXrootDCacheConfig(t *testing.T) {
 	assert.NotNil(t, configPath)
 }
 
+func TestUpdateAuth(t *testing.T) {
+	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	defer func() { require.NoError(t, egrp.Wait()) }()
+	defer cancel()
+
+	runDirname := t.TempDir()
+	configDirname := t.TempDir()
+	viper.Reset()
+	viper.Set("Logging.Level", "Debug")
+	viper.Set("Xrootd.RunLocation", runDirname)
+	viper.Set("ConfigDir", configDirname)
+	authfileName := filepath.Join(configDirname, "authfile")
+	viper.Set("Xrootd.Authfile", authfileName)
+	scitokensName := filepath.Join(configDirname, "scitokens.cfg")
+	viper.Set("Xrootd.ScitokensConfig", scitokensName)
+	viper.Set("Origin.NamespacePrefix", "/test")
+	config.InitConfig()
+
+	err := config.InitServer(ctx, config.OriginType)
+	require.NoError(t, err)
+
+	scitokensCfgDemo := `
+[Issuer DEMO]
+issuer = https://demo.scitokens.org
+base_path = /test1
+default_user = user1
+`
+	scitokensCfgDemo2 := `
+[Issuer DEMO2]
+issuer = https://demo2.scitokens.org
+base_path = /test2
+default_user = user2
+`
+
+	authfileFooter := "u * /.well-known lr\n"
+	authfileDemo := "u testing /test3 lr\n"
+	authfileDemo2 := `u testing /test4 lr`
+
+	err = os.WriteFile(scitokensName, []byte(scitokensCfgDemo), fs.FileMode(0600))
+	require.NoError(t, err)
+	err = os.WriteFile(authfileName, []byte(authfileDemo), fs.FileMode(0600))
+	require.NoError(t, err)
+
+	server := &origin_ui.OriginServer{}
+	err = EmitScitokensConfig(server)
+	require.NoError(t, err)
+
+	err = EmitAuthfile(server)
+	require.NoError(t, err)
+
+	destScitokensName := filepath.Join(param.Xrootd_RunLocation.GetString(), "scitokens-origin-generated.cfg")
+	assert.FileExists(t, destScitokensName)
+	destAuthfileName := filepath.Join(param.Xrootd_RunLocation.GetString(), "authfile-origin-generated")
+	assert.FileExists(t, destAuthfileName)
+
+	scitokensContents, err := os.ReadFile(destScitokensName)
+	require.NoError(t, err)
+	assert.True(t, strings.Contains(string(scitokensContents), scitokensCfgDemo))
+
+	authfileContents, err := os.ReadFile(destAuthfileName)
+	require.NoError(t, err)
+	assert.Equal(t, authfileDemo+authfileFooter, string(authfileContents))
+
+	LaunchXrootdMaintenance(ctx, server, 2*time.Hour)
+
+	err = os.WriteFile(scitokensName+".tmp", []byte(scitokensCfgDemo2), fs.FileMode(0600))
+	require.NoError(t, err)
+	err = os.Rename(scitokensName+".tmp", scitokensName)
+	require.NoError(t, err)
+
+	waitForCopy := func(name, sampleContents string) bool {
+		for idx := 0; idx < 10; idx++ {
+			time.Sleep(50 * time.Millisecond)
+			log.Debug("Re-reading destination file")
+			destContents, err := os.ReadFile(name)
+			require.NoError(t, err)
+			if strings.Contains(string(destContents), sampleContents) {
+				return true
+			}
+			log.Debugln("Destination contents:", string(destContents))
+		}
+		return false
+	}
+
+	assert.True(t, waitForCopy(destScitokensName, scitokensCfgDemo2))
+
+	err = os.WriteFile(authfileName+".tmp", []byte(authfileDemo2), fs.FileMode(0600))
+	require.NoError(t, err)
+	err = os.Rename(authfileName+".tmp", authfileName)
+	require.NoError(t, err)
+	assert.True(t, waitForCopy(destAuthfileName, authfileDemo2))
+}
+
 func TestCopyCertificates(t *testing.T) {
 	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
 	defer func() { require.NoError(t, egrp.Wait()) }()
@@ -81,6 +178,8 @@ func TestCopyCertificates(t *testing.T) {
 	assert.ErrorIs(t, err, errBadKeyPair)
 
 	err = config.InitServer(ctx, config.OriginType)
+	require.NoError(t, err)
+	err = config.MkdirAll(path.Dir(param.Xrootd_Authfile.GetString()), 0755, -1, -1)
 	require.NoError(t, err)
 	err = CopyXrootdCertificates()
 	require.NoError(t, err)
@@ -118,14 +217,15 @@ func TestCopyCertificates(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, bytes.Equal(firstKeyPairContents, secondKeyPairContents))
 
-	LaunchXrootdMaintenance(ctx, 2*time.Hour)
+	originServer := &origin_ui.OriginServer{}
+	LaunchXrootdMaintenance(ctx, originServer, 2*time.Hour)
 
 	// Helper function to wait for a copy of the first cert to show up
 	// in the destination
 	waitForCopy := func() bool {
 		for idx := 0; idx < 10; idx++ {
 			time.Sleep(50 * time.Millisecond)
-			logrus.Debug("Re-reading destination cert")
+			log.Debug("Re-reading destination cert")
 			destContents, err := os.ReadFile(destKeyPairName)
 			require.NoError(t, err)
 			if bytes.Equal(destContents, firstKeyPairContents) {
@@ -139,14 +239,14 @@ func TestCopyCertificates(t *testing.T) {
 	// Thus, if we only copy one, we shouldn't see any changes
 	err = os.Rename(certName+".orig", certName)
 	require.NoError(t, err)
-	logrus.Debug("Will wait to see if the new certs are not copied")
+	log.Debug("Will wait to see if the new certs are not copied")
 	assert.False(t, waitForCopy())
 
 	// Now, if we overwrite the key, the maintenance thread should notice
 	// and overwrite the destination
 	err = os.Rename(keyName+".orig", keyName)
 	require.NoError(t, err)
-	logrus.Debug("Will wait to see if the new certs are copied")
+	log.Debug("Will wait to see if the new certs are copied")
 	assert.True(t, waitForCopy())
 
 }


### PR DESCRIPTION
To replace existing OSDF caches, which rely on X509 authentication that we don't want to pull into the Pelican codebase, we'll need to merge with their authfiles (which are periodically updated).  This utilizes the Xrootd maintenance routine to regenerate authfiles and scitokens.cfg when an update occurs.

Includes unit tests.

Fixes #562