### PR TITLE
Re-enable S3 Origins

### DIFF
--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -25,15 +25,16 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_ui"
 	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/web_ui"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
-	"golang.org/x/sync/errgroup"
 )
 
 func LaunchModules(ctx context.Context, modules config.ServerType) (context.CancelFunc, error) {
@@ -96,12 +97,21 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (context.Canc
 
 	servers := make([]server_utils.XRootDServer, 0)
 	if modules.IsEnabled(config.OriginType) {
-		if param.Origin_Mode.GetString() != "posix" {
-			return shutdownCancel, errors.Errorf("Origin Mode must be set to posix, S3 is not currently supported.")
-		}
-
-		if param.Origin_ExportVolume.GetString() == "" {
-			return shutdownCancel, errors.Errorf("Origin.ExportVolume must be set in the parameters.yaml file.")
+		mode := param.Origin_Mode.GetString()
+		switch mode {
+		case "posix":
+			if param.Origin_ExportVolume.GetString() == "" {
+				return shutdownCancel, errors.Errorf("Origin.ExportVolume must be set in the parameters.yaml file.")
+			}
+		case "s3":
+			if param.Origin_S3Bucket.GetString() == "" || param.Origin_S3Region.GetString() == "" ||
+				param.Origin_S3ServiceName.GetString() == "" || param.Origin_S3ServiceUrl.GetString() == "" {
+				return shutdownCancel, errors.Errorf("The S3 origin is missing configuration options to run properly." +
+					" You must specify a bucket, a region, a service name and a service URL via the command line or via" +
+					" your configuration file.")
+			}
+		default:
+			return shutdownCancel, errors.Errorf("Currently-supported origin modes include posix and s3.")
 		}
 
 		server, err := OriginServe(ctx, engine, egrp)
@@ -110,9 +120,20 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (context.Canc
 		}
 		servers = append(servers, server)
 
-		err = server_utils.WaitUntilWorking(ctx, "GET", param.Origin_Url.GetString()+"/.well-known/openid-configuration", "Origin", http.StatusOK)
-		if err != nil {
-			return shutdownCancel, err
+		switch mode {
+		case "posix":
+			err = server_utils.WaitUntilWorking(ctx, "GET", param.Origin_Url.GetString()+"/.well-known/openid-configuration", "Origin", http.StatusOK)
+			if err != nil {
+				return shutdownCancel, err
+			}
+		case "s3":
+			// A GET on the server root should cause XRootD to reply with permission denied -- as long as the origin is
+			// running in auth mode (probably). This might need to be revisted if we set up an S3 origin without requiring
+			// tokens
+			err = server_utils.WaitUntilWorking(ctx, "GET", param.Origin_Url.GetString(), "Origin", http.StatusForbidden)
+			if err != nil {
+				return shutdownCancel, err
+			}
 		}
 	}
 


### PR DESCRIPTION
This re-enables S3 origins, but does not cover any E2E tests. I'm assuming we'll spend a good amount of development time for 7.5 working on all things E2E.