### PR TITLE
Add status filter to registry API, improve Swagger docs

### DIFF
--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -363,7 +363,7 @@ func getNamespaceJwksByPrefix(prefix string, approvalRequired bool) (*jwk.Set, e
 
 func getNamespaceStatusById(id int) (RegistrationStatus, error) {
 	if id < 1 {
-		return "", errors.New("Invalid id. id must be a positive number")
+		return "", errors.New("Invalid id. id must be a positive integer")
 	}
 	adminMetadata := AdminMetadata{}
 	adminMetadataStr := ""
@@ -432,8 +432,8 @@ func getNamespaceByPrefix(prefix string) (*Namespace, error) {
 // excluding Namespace.ID, Namespace.Identity, Namespace.Pubkey, and various dates
 //
 // For filterNs.AdminMetadata.Description and filterNs.AdminMetadata.SiteName,
-// the string will be matched using `strings.Contains`. The rest of the AdminMetadata fields is
-// matched by `==`
+// the string will be matched using `strings.Contains`. This is too mimic a SQL style `like` match.
+// The rest of the AdminMetadata fields is matched by `==`
 func getNamespacesByFilter(filterNs Namespace, serverType ServerType) ([]*Namespace, error) {
 	query := `SELECT id, prefix, pubkey, identity, admin_metadata FROM namespace WHERE 1=1 `
 	if serverType == CacheType {

--- a/registry/registry_db_test.go
+++ b/registry/registry_db_test.go
@@ -144,16 +144,30 @@ func mockNamespace(prefix, pubkey, identity string, adminMetadata AdminMetadata)
 // functinos in this package. Please treat them as "constants"
 var (
 	mockNssWithOrigins []Namespace = []Namespace{
-		mockNamespace("/test1", "pubkey1", "", AdminMetadata{}),
-		mockNamespace("/test2", "pubkey2", "", AdminMetadata{}),
+		mockNamespace("/test1", "pubkey1", "", AdminMetadata{Status: Approved}),
+		mockNamespace("/test2", "pubkey2", "", AdminMetadata{Status: Approved}),
 	}
 	mockNssWithCaches []Namespace = []Namespace{
-		mockNamespace("/caches/random1", "pubkey1", "", AdminMetadata{}),
-		mockNamespace("/caches/random2", "pubkey2", "", AdminMetadata{}),
+		mockNamespace("/caches/random1", "pubkey1", "", AdminMetadata{Status: Approved}),
+		mockNamespace("/caches/random2", "pubkey2", "", AdminMetadata{Status: Approved}),
+	}
+	mockNssWithOriginsNotApproved []Namespace = []Namespace{
+		mockNamespace("/pending1", "pubkey1", "", AdminMetadata{Status: Pending}),
+		mockNamespace("/pending2", "pubkey2", "", AdminMetadata{Status: Pending}),
+	}
+	mockNssWithCachesNotApproved []Namespace = []Namespace{
+		mockNamespace("/caches/pending1", "pubkey1", "", AdminMetadata{Status: Pending}),
+		mockNamespace("/caches/pending2", "pubkey2", "", AdminMetadata{Status: Pending}),
 	}
 	mockNssWithMixed []Namespace = func() (mixed []Namespace) {
 		mixed = append(mixed, mockNssWithOrigins...)
 		mixed = append(mixed, mockNssWithCaches...)
+		return
+	}()
+
+	mockNssWithMixedNotApproved []Namespace = func() (mixed []Namespace) {
+		mixed = append(mixed, mockNssWithOriginsNotApproved...)
+		mixed = append(mixed, mockNssWithCachesNotApproved...)
 		return
 	}()
 )

--- a/registry/registry_db_test.go
+++ b/registry/registry_db_test.go
@@ -83,6 +83,19 @@ func insertMockDBData(nss []Namespace) error {
 	return tx.Commit()
 }
 
+func getLastNamespaceId() (int, error) {
+	var lastID int
+	err := db.QueryRow("SELECT id FROM namespace ORDER BY id DESC LIMIT 1").Scan(&lastID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return 0, errors.New("Empty database table.")
+		} else {
+			return 0, err
+		}
+	}
+	return lastID, nil
+}
+
 // Compares expected Namespace slice against either a slice of Namespace ptr or just Namespace
 func compareNamespaces(execpted []Namespace, returned interface{}, woPubkey bool) bool {
 	var normalizedReturned []Namespace
@@ -186,51 +199,43 @@ func TestGetNamespacesById(t *testing.T) {
 	})
 }
 
-func TestGetNamespacesByUserID(t *testing.T) {
+func TestGetNamespaceStatusById(t *testing.T) {
 	setupMockRegistryDB(t)
 	defer teardownMockNamespaceDB(t)
 
-	t.Run("empty-db-return-empty-array", func(t *testing.T) {
-		nss, err := getNamespacesByUserID("foo")
-		require.NoError(t, err)
-		assert.Equal(t, 0, len(nss))
+	t.Run("invalid-id", func(t *testing.T) {
+		_, err := getNamespaceStatusById(0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Invalid id")
 	})
 
-	t.Run("return-empty-array-with-no-userid-entries", func(t *testing.T) {
-		err := insertMockDBData(mockNssWithMixed)
-		require.NoError(t, err)
-		defer resetNamespaceDB(t)
-		nss, err := getNamespacesByUserID("foo")
-		require.NoError(t, err)
-		assert.Equal(t, 0, len(nss))
+	t.Run("db-query-error", func(t *testing.T) {
+		resetNamespaceDB(t)
+		// Simulate a DB error. You need to mock the db.QueryRow function to return an error
+		_, err := getNamespaceStatusById(1)
+		require.Error(t, err)
 	})
 
-	t.Run("return-user-namespace-with-valid-userID", func(t *testing.T) {
-		defer resetNamespaceDB(t)
-		err := insertMockDBData(mockNssWithMixed)
+	t.Run("valid-id-empty-admin-metadata", func(t *testing.T) {
+		resetNamespaceDB(t)
+		err := insertMockDBData([]Namespace{mockNamespace("/foo", "", "", AdminMetadata{})})
 		require.NoError(t, err)
-		err = insertMockDBData([]Namespace{mockNamespace("/user1", "", "user1", AdminMetadata{UserID: "user1"})})
+		lastId, err := getLastNamespaceId()
 		require.NoError(t, err)
-		nss, err := getNamespacesByUserID("user1")
+		status, err := getNamespaceStatusById(lastId)
 		require.NoError(t, err)
-		require.Equal(t, 1, len(nss))
-		assert.Equal(t, "/user1", nss[0].Prefix)
+		assert.Equal(t, Unknown, status)
 	})
 
-	t.Run("return-multiple-user-namespaces-with-valid-userID", func(t *testing.T) {
-		defer resetNamespaceDB(t)
-		err := insertMockDBData(mockNssWithMixed)
+	t.Run("valid-id-non-empty-admin-metadata", func(t *testing.T) {
+		resetNamespaceDB(t)
+		err := insertMockDBData([]Namespace{mockNamespace("/foo", "", "", AdminMetadata{Status: Approved})})
 		require.NoError(t, err)
-		err = insertMockDBData([]Namespace{mockNamespace("/user1", "", "user1", AdminMetadata{UserID: "user1"})})
+		lastId, err := getLastNamespaceId()
 		require.NoError(t, err)
-		err = insertMockDBData([]Namespace{mockNamespace("/user1-2", "", "user1", AdminMetadata{UserID: "user1"})})
+		status, err := getNamespaceStatusById(lastId)
 		require.NoError(t, err)
-		nss, err := getNamespacesByUserID("user1")
-		require.NoError(t, err)
-		require.Equal(t, 2, len(nss))
-		assert.Equal(t, "/user1", nss[0].Prefix)
-		assert.Equal(t, "/user1-2", nss[1].Prefix)
-
+		assert.Equal(t, Approved, status)
 	})
 }
 
@@ -404,8 +409,7 @@ func TestUpdateNamespaceStatusById(t *testing.T) {
 	})
 }
 
-// teardown must be called at the end of the test to close the in-memory SQLite db
-func TestGetNamespacesByServerType(t *testing.T) {
+func TestGetNamespacesByFilter(t *testing.T) {
 	_, cancel, egrp := test_utils.TestContext(context.Background(), t)
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
@@ -413,77 +417,252 @@ func TestGetNamespacesByServerType(t *testing.T) {
 	setupMockRegistryDB(t)
 	defer teardownMockNamespaceDB(t)
 
-	t.Run("wrong-server-type-gives-error", func(t *testing.T) {
+	t.Run("return-error-for-unsupported-operations", func(t *testing.T) {
+		filterNsID := Namespace{
+			ID: 123,
+		}
+
+		_, err := getNamespacesByFilter(filterNsID, "")
+		require.Error(t, err, "Should return error for filtering against unsupported field ID")
+
+		filterNsIdentity := Namespace{
+			Identity: "someIdentity",
+		}
+
+		_, err = getNamespacesByFilter(filterNsIdentity, "")
+		require.Error(t, err, "Should return error for filtering against unsupported field Identity")
+
+		filterNsPubKey := Namespace{
+			Pubkey: "somePubkey",
+		}
+
+		_, err = getNamespacesByFilter(filterNsPubKey, "")
+		require.Error(t, err, "Should return error for filtering against unsupported field PubKey")
+
+		// Now, for AdminMetadata filters to work, we need to have a valid object
 		resetNamespaceDB(t)
+		err = insertMockDBData([]Namespace{{
+			Prefix: "/bar",
+			AdminMetadata: AdminMetadata{
+				Description:           "Mock description",
+				SiteName:              "UW-Madison",
+				Institution:           "123456",
+				SecurityContactUserID: "contactUserID",
+				ApproverID:            "mockApproverID",
+				Status:                Pending,
+			},
+		}})
+		require.NoError(t, err)
 
-		rss, err := getNamespacesByServerType("")
-		require.Error(t, err, "No error returns when give empty server type")
-		assert.Nil(t, rss, "Returns data when error is expected")
+		filterNsCreateAt := Namespace{
+			AdminMetadata: AdminMetadata{
+				CreatedAt: time.Now(),
+			},
+		}
 
-		rss, err = getNamespacesByServerType("random")
-		require.Error(t, err, "No error returns when give random server type")
-		assert.Nil(t, rss, "Returns data when error is expected")
+		_, err = getNamespacesByFilter(filterNsCreateAt, "")
+		require.Error(t, err, "Should return error for filtering against unsupported field CreatedAt")
+
+		filterNsUpdateAt := Namespace{
+			AdminMetadata: AdminMetadata{
+				UpdatedAt: time.Now(),
+			},
+		}
+
+		_, err = getNamespacesByFilter(filterNsUpdateAt, "")
+		require.Error(t, err, "Should return error for filtering against unsupported field UpdatedAt")
+
+		filterNsApproveAt := Namespace{
+			AdminMetadata: AdminMetadata{
+				ApprovedAt: time.Now(),
+			},
+		}
+
+		_, err = getNamespacesByFilter(filterNsApproveAt, "")
+		require.Error(t, err, "Should return error for filtering against unsupported field ApprovedAt")
 	})
 
-	t.Run("empty-db-returns-empty-list", func(t *testing.T) {
+	t.Run("filter-by-server-type", func(t *testing.T) {
+		// Assuming mock data and insertMockDBData function exist
 		resetNamespaceDB(t)
-
-		origins, err := getNamespacesByServerType(OriginType)
+		err := insertMockDBData(append(mockNssWithOrigins, mockNssWithCaches...))
 		require.NoError(t, err)
-		assert.Equal(t, 0, len(origins))
 
-		caches, err := getNamespacesByServerType(CacheType)
+		filterNs := Namespace{}
+		nssOrigins, err := getNamespacesByFilter(filterNs, OriginType)
 		require.NoError(t, err)
-		assert.Equal(t, 0, len(caches))
+		assert.NotEmpty(t, nssOrigins, "Should return non-empty result for OriginType")
+		assert.True(t, compareNamespaces(mockNssWithOrigins, nssOrigins, true))
+
+		nssCaches, err := getNamespacesByFilter(filterNs, CacheType)
+		require.NoError(t, err)
+		assert.NotEmpty(t, nssCaches, "Should return non-empty result for CacheType")
+		assert.True(t, compareNamespaces(mockNssWithCaches, nssCaches, true))
 	})
 
-	t.Run("returns-origins-as-expected", func(t *testing.T) {
+	t.Run("filter-by-admin-metadata", func(t *testing.T) {
 		resetNamespaceDB(t)
-
-		err := insertMockDBData(mockNssWithOrigins)
+		err := insertMockDBData([]Namespace{{
+			Prefix: "/bar",
+			AdminMetadata: AdminMetadata{
+				Description:           "Mock description",
+				SiteName:              "UW-Madison",
+				UserID:                "mockUserID",
+				Institution:           "123456",
+				SecurityContactUserID: "contactUserID",
+				ApproverID:            "mockApproverID",
+				Status:                Pending,
+			},
+		}})
 		require.NoError(t, err)
 
-		origins, err := getNamespacesByServerType(OriginType)
-		require.NoError(t, err)
-		assert.Equal(t, len(mockNssWithOrigins), len(origins), "Returned namespace has wrong length")
-		assert.True(t, compareNamespaces(mockNssWithOrigins, origins, false), "Returned namespaces does not match expected")
+		filterNs := Namespace{
+			AdminMetadata: AdminMetadata{
+				Description: "description",
+			},
+		}
 
-		caches, err := getNamespacesByServerType(CacheType)
+		namespaces, err := getNamespacesByFilter(filterNs, "")
 		require.NoError(t, err)
-		assert.Equal(t, 0, len(caches), "Returned caches when only origins present in db")
+		assert.NotEmpty(t, namespaces, "Should return non-empty result for Description")
+
+		filterNs = Namespace{
+			AdminMetadata: AdminMetadata{
+				SiteName: "Madison",
+			},
+		}
+		namespaces, err = getNamespacesByFilter(filterNs, "")
+		require.NoError(t, err)
+		assert.NotEmpty(t, namespaces, "Should return non-empty result for SiteName")
+
+		filterNs = Namespace{
+			AdminMetadata: AdminMetadata{
+				Institution: "123456",
+			},
+		}
+		namespaces, err = getNamespacesByFilter(filterNs, "")
+		require.NoError(t, err)
+		assert.NotEmpty(t, namespaces, "Should return non-empty result for Institution")
+
+		filterNs = Namespace{
+			AdminMetadata: AdminMetadata{
+				SecurityContactUserID: "contactUserID",
+			},
+		}
+		namespaces, err = getNamespacesByFilter(filterNs, "")
+		require.NoError(t, err)
+		assert.NotEmpty(t, namespaces, "Should return non-empty result for SecurityContactUserID")
+
+		filterNs = Namespace{
+			AdminMetadata: AdminMetadata{
+				ApproverID: "mockApproverID",
+			},
+		}
+		namespaces, err = getNamespacesByFilter(filterNs, "")
+		require.NoError(t, err)
+		assert.NotEmpty(t, namespaces, "Should return non-empty result for ApproverID")
+
+		filterNs = Namespace{
+			AdminMetadata: AdminMetadata{
+				Status: Pending,
+			},
+		}
+		namespaces, err = getNamespacesByFilter(filterNs, "")
+		require.NoError(t, err)
+		assert.NotEmpty(t, namespaces, "Should return non-empty result for Status")
+
+		filterNs = Namespace{
+			AdminMetadata: AdminMetadata{
+				UserID: "mockUserID",
+			},
+		}
+		namespaces, err = getNamespacesByFilter(filterNs, "")
+		require.NoError(t, err)
+		assert.NotEmpty(t, namespaces, "Should return non-empty result for UserID")
 	})
 
-	t.Run("return-caches-as-expected", func(t *testing.T) {
+	t.Run("multiple-AND-match", func(t *testing.T) {
 		resetNamespaceDB(t)
-
-		err := insertMockDBData(mockNssWithCaches)
+		err := insertMockDBData([]Namespace{{
+			Prefix: "/bar",
+			AdminMetadata: AdminMetadata{
+				Description:           "Mock description",
+				SiteName:              "UW-Madison",
+				Institution:           "123456",
+				SecurityContactUserID: "contactUserID",
+				ApproverID:            "mockApproverID",
+				Status:                Pending,
+			},
+		}})
 		require.NoError(t, err)
 
-		caches, err := getNamespacesByServerType(CacheType)
+		filterNs := Namespace{
+			Prefix: "/bar",
+			AdminMetadata: AdminMetadata{
+				SecurityContactUserID: "contactUserID",
+				ApproverID:            "mockApproverID",
+				Status:                Pending,
+			},
+		}
+		namespaces, err := getNamespacesByFilter(filterNs, "")
 		require.NoError(t, err)
-		assert.Equal(t, len(mockNssWithCaches), len(caches), "Returned namespace has wrong length")
-		assert.True(t, compareNamespaces(mockNssWithCaches, caches, false), "Returned namespaces does not match expected")
-
-		origins, err := getNamespacesByServerType(OriginType)
-		require.NoError(t, err)
-		assert.Equal(t, 0, len(origins), "Returned origins when only caches present in db")
+		assert.NotEmpty(t, namespaces, "Should return non-empty result for non-empty database without condition")
 	})
 
-	t.Run("return-correctly-with-mixed-server-type", func(t *testing.T) {
+	t.Run("fully-match", func(t *testing.T) {
+		resetNamespaceDB(t)
+		mockNs := Namespace{
+			Prefix: "/bar",
+			AdminMetadata: AdminMetadata{
+				Description:           "Mock description",
+				SiteName:              "UW-Madison",
+				UserID:                "mockUserID",
+				Institution:           "123456",
+				SecurityContactUserID: "contactUserID",
+				ApproverID:            "mockApproverID",
+				Status:                Pending,
+			},
+		}
+		err := insertMockDBData([]Namespace{mockNs})
+		require.NoError(t, err)
+
+		filterNs := mockNs
+		namespaces, err := getNamespacesByFilter(filterNs, "")
+		require.NoError(t, err)
+		assert.NotEmpty(t, namespaces, "Should return non-empty result for non-empty database without condition")
+	})
+
+	t.Run("no-match", func(t *testing.T) {
+		resetNamespaceDB(t)
+		mockNs := Namespace{
+			Prefix: "/bar",
+			AdminMetadata: AdminMetadata{
+				Description:           "Mock description",
+				UserID:                "mockUserID",
+				SiteName:              "UW-Madison",
+				Institution:           "123456",
+				SecurityContactUserID: "contactUserID",
+				ApproverID:            "mockApproverID",
+				Status:                Pending,
+			},
+		}
+		err := insertMockDBData([]Namespace{mockNs})
+		require.NoError(t, err)
+
+		filterNs := mockNs
+		filterNs.AdminMetadata.Status = Denied
+		namespaces, err := getNamespacesByFilter(filterNs, "")
+		require.NoError(t, err)
+		assert.Empty(t, namespaces, "Should return non-empty result for non-empty database without condition")
+	})
+
+	t.Run("empty-db-returns-empty-results", func(t *testing.T) {
 		resetNamespaceDB(t)
 
-		err := insertMockDBData(mockNssWithMixed)
+		filterNs := Namespace{}
+		namespaces, err := getNamespacesByFilter(filterNs, "")
 		require.NoError(t, err)
-
-		caches, err := getNamespacesByServerType(CacheType)
-		require.NoError(t, err)
-		assert.Equal(t, len(mockNssWithCaches), len(caches), "Returned caches namespace has wrong length")
-		assert.True(t, compareNamespaces(mockNssWithCaches, caches, false), "Returned caches namespaces does not match expected")
-
-		origins, err := getNamespacesByServerType(OriginType)
-		require.NoError(t, err)
-		assert.Equal(t, len(mockNssWithOrigins), len(origins), "Returned origins namespace has wrong length")
-		assert.True(t, compareNamespaces(mockNssWithOrigins, origins, false), "Returned origins namespaces does not match expected")
+		assert.Empty(t, namespaces, "Should return empty result for empty database")
 	})
 }
 

--- a/registry/registry_ui_test.go
+++ b/registry/registry_ui_test.go
@@ -85,6 +85,7 @@ func TestListNamespaces(t *testing.T) {
 		serverType   string
 		expectedCode int
 		emptyDB      bool
+		notApproved  bool
 		expectedData []Namespace
 	}{
 		{
@@ -113,6 +114,13 @@ func TestListNamespaces(t *testing.T) {
 			expectedData: mockNssWithMixed,
 		},
 		{
+			description:  "unauthed-not-approved-without-type-returns-empty",
+			serverType:   "",
+			expectedCode: http.StatusOK,
+			expectedData: []Namespace{},
+			notApproved:  true,
+		},
+		{
 			description:  "invalid-request-parameters",
 			serverType:   "random_type", // some invalid query string
 			expectedCode: http.StatusBadRequest,
@@ -123,9 +131,16 @@ func TestListNamespaces(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			if !tc.emptyDB {
-				err := insertMockDBData(mockNssWithMixed)
-				if err != nil {
-					t.Fatalf("Failed to set up mock data: %v", err)
+				if tc.notApproved {
+					err := insertMockDBData(mockNssWithMixedNotApproved)
+					if err != nil {
+						t.Fatalf("Failed to set up mock data: %v", err)
+					}
+				} else {
+					err := insertMockDBData(mockNssWithMixed)
+					if err != nil {
+						t.Fatalf("Failed to set up mock data: %v", err)
+					}
 				}
 			}
 			defer func() {

--- a/web_ui/authentication.go
+++ b/web_ui/authentication.go
@@ -110,9 +110,9 @@ func configureAuthDB() error {
 	return nil
 }
 
-// Get the "subjuect" claim from the JWT that "login" cookie stores,
+// Get the "subject" claim from the JWT that "login" cookie stores,
 // where subject is set to be the username. Return empty string if no "login" cookie is present
-func getUser(ctx *gin.Context) (string, error) {
+func GetUser(ctx *gin.Context) (string, error) {
 	token, err := ctx.Cookie("login")
 	if err != nil {
 		return "", nil
@@ -181,7 +181,7 @@ func setLoginCookie(ctx *gin.Context, user string) {
 
 // Check if user is authenticated by checking if the "login" cookie is present and set the user identity to ctx
 func AuthHandler(ctx *gin.Context) {
-	user, err := getUser(ctx)
+	user, err := GetUser(ctx)
 	if err != nil || user == "" {
 		log.Errorln("Invalid user cookie or unable to parse user cookie:", err)
 		ctx.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Authentication required to perform this operation"})
@@ -296,7 +296,7 @@ func configureAuthEndpoints(ctx context.Context, router *gin.Engine, egrp *errgr
 	// Pass csrfhanlder only to the whoami route to generate CSRF token
 	// while leaving other routes free of CSRF check (we might want to do it some time in the future)
 	group.GET("/whoami", csrfHandler, func(ctx *gin.Context) {
-		if user, err := getUser(ctx); err != nil || user == "" {
+		if user, err := GetUser(ctx); err != nil || user == "" {
 			ctx.JSON(200, gin.H{"authenticated": false})
 		} else {
 			// Set header to carry CSRF token

--- a/web_ui/frontend/app/api/docs/pelican-swagger.yaml
+++ b/web_ui/frontend/app/api/docs/pelican-swagger.yaml
@@ -146,7 +146,7 @@ definitions:
         example: "/test"
       identity:
         type: string
-        description: The user identity we get from CILogon if the namespace is registered via CLI with `--identity` flag
+        description: The user identity we get from CILogon if the namespace is registered via CLI with `--with-identity` flag
       admin_metadata:
         $ref: "#/definitions/AdminMetadata"
   Institution:
@@ -445,7 +445,7 @@ paths:
             type: object
             $ref: "#/definitions/ErrorModel"
         "403":
-          description: Unauthorized request, when user is not logged in
+          description: Unauthorized request, when users are not logged in
           schema:
             type: object
             $ref: "#/definitions/ErrorModel"
@@ -473,7 +473,7 @@ paths:
                 example: "admin"
           headers:
             X-CSRF-Token:
-              description: The CSRF token that user is expected to attach as the request header for any modification requests for registry APIs (PUT/PATCH/DELETE).
+              description: The CSRF token that users are expected to attach as the request header for any modification requests for registry APIs (PUT/PATCH/DELETE).
               type: string
   /auth/loginInitialized:
     get:
@@ -504,12 +504,12 @@ paths:
         - in: query
           name: next_url
           type: string
-          description: The path to redirect user to once they successfully authenticated against CILogon
+          description: The path to redirect users to once they successfully authenticated against CILogon
       responses:
         "307":
           description: Redirect user to CILogon authentication page
         "500":
-          description: Internal server error when failed to generate CSRF cookie for the OAuth flow
+          description: Internal server error when generating CSRF cookie for OAuth flow
           schema:
             type: object
             $ref: "#/definitions/ErrorModel"
@@ -537,7 +537,7 @@ paths:
             type: object
             $ref: "#/definitions/ErrorModel"
         "500":
-          description: Internal server error when process the token and handshake with CILogon
+          description: Internal server error when processing the token and handshake with CILogon
           schema:
             type: object
             $ref: "#/definitions/ErrorModel"
@@ -626,7 +626,7 @@ paths:
             $ref: "#/definitions/NamespaceForRegistration"
         - in: header
           name: X-CSRF-Token
-          description: The CSRF token for protecting Cross-Site Request Forgery (CSRF) attack. You will get this token by requesting `/api/v1.0/auth/whoami` and read response header `X-CSRF-Token`
+          description: The CSRF token for protecting against Cross-Site Request Forgery (CSRF) attacks. Obtained by requesting `/api/v1.0/auth/whoami` and reading response header `X-CSRF-Token`
           type: string
           required: true
       responses:
@@ -743,7 +743,7 @@ paths:
         For user with admin previlege, they can update any valid namespace.
 
 
-        For non-admin users, they can only update the namespace belonging to the user, or it returns 404. They also cannot update a namespace if its `admin_metadata.status == approved`.
+        Non-admin users can update only namespaces they own and only if the approval status is `admin_metadata.status == approved`, otherwise the endpoint returns 404.
         "
       operationId: updateNamespaceById
       parameters:
@@ -760,7 +760,7 @@ paths:
             $ref: "#/definitions/NamespaceForRegistration"
         - in: header
           name: X-CSRF-Token
-          description: The CSRF token for protecting Cross-Site Request Forgery (CSRF) attack. You will get this token by requesting `/api/v1.0/auth/whoami` and read response header `X-CSRF-Token`
+          description: The CSRF token for protecting against Cross-Site Request Forgery (CSRF) attacks. Obtained by requesting `/api/v1.0/auth/whoami` and reading response header `X-CSRF-Token`
           type: string
           required: true
       consumes:
@@ -854,7 +854,7 @@ paths:
           type: integer
         - in: header
           name: X-CSRF-Token
-          description: The CSRF token for protecting Cross-Site Request Forgery (CSRF) attack. You will get this token by requesting `/api/v1.0/auth/whoami` and read response header `X-CSRF-Token`
+          description: The CSRF token for protecting against Cross-Site Request Forgery (CSRF) attacks. Obtained by requesting `/api/v1.0/auth/whoami` and reading response header `X-CSRF-Token`
           type: string
           required: true
       produces:
@@ -911,7 +911,7 @@ paths:
           type: integer
         - in: header
           name: X-CSRF-Token
-          description: The CSRF token for protecting Cross-Site Request Forgery (CSRF) attack. You will get this token by requesting `/api/v1.0/auth/whoami` and read response header `X-CSRF-Token`
+          description: The CSRF token for protecting against Cross-Site Request Forgery (CSRF) attacks. Obtained by requesting `/api/v1.0/auth/whoami` and reading response header `X-CSRF-Token`
           type: string
           required: true
       produces:

--- a/web_ui/frontend/app/api/docs/pelican-swagger.yaml
+++ b/web_ui/frontend/app/api/docs/pelican-swagger.yaml
@@ -465,6 +465,10 @@ paths:
               user:
                 type: string
                 example: "admin"
+          headers:
+            X-CSRF-Token:
+              description: The CSRF token that user is expected to attach as the request header for any modification requests for registry APIs (PUT/PATCH/DELETE).
+              type: string
   /auth/loginInitialized:
     get:
       tags:
@@ -490,12 +494,28 @@ paths:
       tags:
         - "registry_ui"
       summary: Return a list of all namespaces in the registry
-      description: A public API to get all namespaces in the registry
+      description:
+        A public API to get all namespaces in the registry. Note that `pubkey` is not included in the return data.
+
+
+        For unauthenticated users, it only returns a list of approved namespaces.
+
+        For authenticated users, it returns namespaces with any approval status.
       parameters:
         - name: server_type
           in: query
           required: false
-          description: The type of server to filter the results. The value can be either "origin" or "cache"
+          description: The type of server to filter the results. The value can be either `origin` or `cache`
+          type: string
+        - name: status
+          in: query
+          required: false
+          description:
+            The approval status of the namespaces, can be `pending`, `approved`, `denied`, or `unknown`.
+
+            If `status == unknown`, internally it will match any registration with `status == ""` or `stauts == "unknown"`
+
+            For unauthenticated users, filter with `status != approved` will result in a 403 error.
           type: string
       produces:
         - application/json
@@ -509,6 +529,11 @@ paths:
             description: An array of namespaces
         "400":
           description: Invalid request parameters
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModel"
+        "403":
+          description: Operation forbidden, when an unauthenticated user trying to filter against `status != approval`
           schema:
             type: object
             $ref: "#/definitions/ErrorModel"
@@ -547,6 +572,11 @@ paths:
           required: true
           schema:
             $ref: "#/definitions/NamespaceForRegistration"
+        - in: header
+          name: X-CSRF-Token
+          description: The CSRF token for protecting Cross-Site Request Forgery (CSRF) attack. You will get this token by requesting `/api/v1.0/auth/whoami` and read response header `X-CSRF-Token`
+          type: string
+          required: true
       responses:
         "200":
           description: OK
@@ -574,6 +604,15 @@ paths:
         - "registry_ui"
       summary: Return a list of namespaces for the currently authenticated user
       description: "`Authentication Required`"
+      parameters:
+        - name: status
+          in: query
+          required: false
+          description:
+            The approval status of the namespaces, can be `pending`, `approved`, `denied`, or `unknown`.
+
+            If `status == unknown`, internally it will match any registration with `status == ""` or `stauts == "unknown"`
+          type: string
       produces:
         - application/json
       responses:
@@ -652,7 +691,7 @@ paths:
         For user with admin previlege, they can update any valid namespace.
 
 
-        For general users, they can only update the namespace belonging to the user, or it returns 404
+        For non-admin users, they can only update the namespace belonging to the user, or it returns 404. They also cannot update a namespace if its `admin_metadata.status == approved`.
         "
       operationId: updateNamespaceById
       parameters:
@@ -667,6 +706,11 @@ paths:
           required: true
           schema:
             $ref: "#/definitions/NamespaceForRegistration"
+        - in: header
+          name: X-CSRF-Token
+          description: The CSRF token for protecting Cross-Site Request Forgery (CSRF) attack. You will get this token by requesting `/api/v1.0/auth/whoami` and read response header `X-CSRF-Token`
+          type: string
+          required: true
       consumes:
         - application/json
       produces:
@@ -756,6 +800,11 @@ paths:
           description: ID of the namespace to update status
           required: true
           type: integer
+        - in: header
+          name: X-CSRF-Token
+          description: The CSRF token for protecting Cross-Site Request Forgery (CSRF) attack. You will get this token by requesting `/api/v1.0/auth/whoami` and read response header `X-CSRF-Token`
+          type: string
+          required: true
       produces:
         - application/json
       responses:
@@ -808,6 +857,11 @@ paths:
           description: ID of the namespace to update status
           required: true
           type: integer
+        - in: header
+          name: X-CSRF-Token
+          description: The CSRF token for protecting Cross-Site Request Forgery (CSRF) attack. You will get this token by requesting `/api/v1.0/auth/whoami` and read response header `X-CSRF-Token`
+          type: string
+          required: true
       produces:
         - application/json
       responses:

--- a/web_ui/frontend/app/api/docs/pelican-swagger.yaml
+++ b/web_ui/frontend/app/api/docs/pelican-swagger.yaml
@@ -144,6 +144,9 @@ definitions:
         type: string
         description: The namespace prefix to register. Should be an absolute path.
         example: "/test"
+      identity:
+        type: string
+        description: The user identity we get from CILogon if the namespace is registered via CLI with `--identity` flag
       admin_metadata:
         $ref: "#/definitions/AdminMetadata"
   Institution:
@@ -168,6 +171,9 @@ definitions:
         type: string
         description: The namespace prefix to register. Should be an absolute path.
         example: "/test"
+      identity:
+        type: string
+        description: The user identity we get from CILogon if the namespace is registered via CLI with `--identity` flag
       pubkey:
         type: string
         description:
@@ -489,6 +495,52 @@ paths:
               initialized:
                 type: boolean
                 example: true
+  /auth/cilogon/login:
+    get:
+      tags:
+        - auth
+      summary: Redirect user to CILogon authentication page for OAuth2 third-party login
+      parameters:
+        - in: query
+          name: next_url
+          type: string
+          description: The path to redirect user to once they successfully authenticated against CILogon
+      responses:
+        "307":
+          description: Redirect user to CILogon authentication page
+        "500":
+          description: Internal server error when failed to generate CSRF cookie for the OAuth flow
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModel"
+  /auth/cilogon/callback:
+    get:
+      tags:
+        - "auth"
+      summary: The callback endpoint CILogon will call once the user has been successfully authenticated
+      description: Calling this URL with valid parameters will login the user to Pelican website
+      parameters:
+        - in: query
+          name: state
+          type: string
+          description: The CSRF token for validation and the next_url for redirect, in the form of `"<[16]byte>:<nextURL>"`
+        - in: query
+          name: code
+          type: string
+          description: The access token and refresh token returned from CILogon
+      responses:
+        "307":
+          description: Successfully log the user in, add login cookie, and direct user to `/` if `next_url` is empty; otherwise to `next_url`
+        "400":
+          description: Invalid request, when `state` or `token` query is invalid
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModel"
+        "500":
+          description: Internal server error when process the token and handshake with CILogon
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModel"
   /registry_ui/namespaces:
     get:
       tags:

--- a/web_ui/oauth2_client.go
+++ b/web_ui/oauth2_client.go
@@ -47,9 +47,8 @@ type (
 	}
 
 	oauthCallbackRequest struct {
-		State   string `form:"state"`
-		Code    string `form:"code"`
-		NextUrl string `form:"next_url,omitempty"`
+		State string `form:"state"`
+		Code  string `form:"code"`
 	}
 
 	cilogonUserInfo struct {

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -89,7 +89,7 @@ func configureWebResource(engine *gin.Engine) error {
 		}
 
 		db := authDB.Load()
-		user, err := getUser(ctx)
+		user, err := GetUser(ctx)
 
 		// Redirect initialized users from initialization pages
 		if strings.HasPrefix(path, "/initialization") && strings.HasSuffix(path, "index.html") {


### PR DESCRIPTION
Closes #606 and #591 

* Improve Swagger to include csrf token, query params, RBAC
* Refactor namespace db function to allow generic filtering
* Control ns visibility based on auth status