### PR TITLE
Roll back registry api from `v2.0` to `v1.0`

### DIFF
--- a/cmd/registry_client.go
+++ b/cmd/registry_client.go
@@ -80,7 +80,6 @@ func registerANamespace(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Errorf("Failed to construction registration endpoint URL: %v", err)
 	}
-	// registrationEndpoint := url.JoinPath(namespaceEndpoint, "/api/v1.0/registry/register").String()
 	if prefix == "" {
 		log.Error("Error: prefix is required")
 		os.Exit(1)

--- a/cmd/registry_client.go
+++ b/cmd/registry_client.go
@@ -76,7 +76,7 @@ func registerANamespace(cmd *cobra.Command, args []string) {
 	}
 
 	// Parse the namespace URL to make sure it's okay
-	registrationEndpointURL, err := url.JoinPath(namespaceEndpoint, "api", "v2.0", "registry")
+	registrationEndpointURL, err := url.JoinPath(namespaceEndpoint, "api", "v1.0", "registry")
 	if err != nil {
 		log.Errorf("Failed to construction registration endpoint URL: %v", err)
 	}
@@ -143,7 +143,7 @@ func deleteANamespace(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	deletionEndpointURL, err := url.JoinPath(namespaceEndpoint, "api", "v2.0", "registry", prefix)
+	deletionEndpointURL, err := url.JoinPath(namespaceEndpoint, "api", "v1.0", "registry", prefix)
 	if err != nil {
 		log.Errorf("Failed to construction deletion endpoint URL: %v", err)
 	}
@@ -168,7 +168,7 @@ func listAllNamespaces(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	listEndpoint, err := url.JoinPath(namespaceEndpoint, "api", "v2.0", "registry", "metadata")
+	listEndpoint, err := url.JoinPath(namespaceEndpoint, "api", "v1.0", "registry")
 	if err != nil {
 		log.Errorf("Failed to construction list endpoint URL: %v", err)
 	}

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -149,6 +149,8 @@ func VerifyAdvertiseToken(ctx context.Context, token, namespace string) (bool, e
 			return false, errors.Wrap(err, "failed to marshal the public keyset into JWKS JSON")
 		}
 		log.Debugln("Constructed JWKS from fetching jwks:", string(jsonbuf))
+		// This seems never get reached, as registry returns 500 for pending approval namespace
+		// and there will be HTTP error in getting jwks; thus it will always be error
 		if jsonbuf == nil {
 			adminApprovalErr = errors.New(namespace + " has not been approved by an administrator.")
 			return false, adminApprovalErr

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -269,7 +269,7 @@ func GetRegistryIssuerURL(prefix string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	namespace_url.Path, err = url.JoinPath(namespace_url.Path, "api", "v2.0", "registry", "metadata", prefix, ".well-known", "issuer.jwks")
+	namespace_url.Path, err = url.JoinPath(namespace_url.Path, "api", "v1.0", "registry", prefix, ".well-known", "issuer.jwks")
 	if err != nil {
 		return "", err
 	}

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -149,7 +149,7 @@ func VerifyAdvertiseToken(ctx context.Context, token, namespace string) (bool, e
 			return false, errors.Wrap(err, "failed to marshal the public keyset into JWKS JSON")
 		}
 		log.Debugln("Constructed JWKS from fetching jwks:", string(jsonbuf))
-		// This seems never get reached, as registry returns 500 for pending approval namespace
+		// This seems never get reached, as registry returns 403 for pending approval namespace
 		// and there will be HTTP error in getting jwks; thus it will always be error
 		if jsonbuf == nil {
 			adminApprovalErr = errors.New(namespace + " has not been approved by an administrator.")

--- a/director/origin_api_test.go
+++ b/director/origin_api_test.go
@@ -41,8 +41,8 @@ func TestVerifyAdvertiseToken(t *testing.T) {
 	kSet, err := config.GetIssuerPublicJWKS()
 	ar := MockCache{
 		GetFn: func(key string, keyset *jwk.Set) (jwk.Set, error) {
-			if key != "https://get-your-tokens.org/api/v2.0/registry/metadata/test-namespace/.well-known/issuer.jwks" {
-				t.Errorf("expecting: https://get-your-tokens.org/api/v2.0/registry/metadata/test-namespace/.well-known/issuer.jwks, got %q", key)
+			if key != "https://get-your-tokens.org/api/v1.0/registry/test-namespace/.well-known/issuer.jwks" {
+				t.Errorf("expecting: https://get-your-tokens.org/api/v1.0/registry/test-namespace/.well-known/issuer.jwks, got %q", key)
 			}
 			return *keyset, nil
 		},
@@ -164,7 +164,7 @@ func TestGetRegistryIssuerURL(t *testing.T) {
 	viper.Set("Federation.RegistryUrl", "test-path")
 	url, err = GetRegistryIssuerURL("test-prefix")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "test-path/api/v2.0/registry/metadata/test-prefix/.well-known/issuer.jwks", url)
+	assert.Equal(t, "test-path/api/v1.0/registry/test-prefix/.well-known/issuer.jwks", url)
 
 }
 

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -409,7 +409,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType ServerTy
 		ok, err := VerifyAdvertiseToken(engineCtx, token, prefix)
 		if err != nil {
 			if err == adminApprovalErr {
-				log.Warningln("Failed to verify token:", err)
+				log.Warningln("Failed to verify token. Cache was not approved:", err)
 				ctx.JSON(http.StatusForbidden, gin.H{"error": "Cache is not admin approved"})
 			} else {
 				log.Warningln("Failed to verify token:", err)

--- a/director/redirect_test.go
+++ b/director/redirect_test.go
@@ -138,8 +138,8 @@ func TestDirectorRegistration(t *testing.T) {
 	setupMockCache := func(t *testing.T, publicKey jwk.Key) MockCache {
 		return MockCache{
 			GetFn: func(key string, keyset *jwk.Set) (jwk.Set, error) {
-				if key != "https://get-your-tokens.org/api/v2.0/registry/metadata/foo/bar/.well-known/issuer.jwks" {
-					t.Errorf("expecting: https://get-your-tokens.org/api/v2.0/registry/metadata/foo/bar/.well-known/issuer.jwks, got %q", key)
+				if key != "https://get-your-tokens.org/api/v1.0/registry/foo/bar/.well-known/issuer.jwks" {
+					t.Errorf("expecting: https://get-your-tokens.org/api/v1.0/registry/foo/bar/.well-known/issuer.jwks, got %q", key)
 				}
 				return *keyset, nil
 			},

--- a/registry/client_commands_test.go
+++ b/registry/client_commands_test.go
@@ -79,7 +79,7 @@ func TestServeNamespaceRegistry(t *testing.T) {
 	require.NoError(t, err)
 
 	//Test functionality of registering a namespace (without identity)
-	err = NamespaceRegister(privKey, svr.URL+"/api/v2.0/registry", "", "/foo/bar")
+	err = NamespaceRegister(privKey, svr.URL+"/api/v1.0/registry", "", "/foo/bar")
 	require.NoError(t, err)
 
 	//Test we can list the namespace without an error
@@ -91,7 +91,7 @@ func TestServeNamespaceRegistry(t *testing.T) {
 		os.Stdout = w
 
 		//List the namespaces
-		err = NamespaceList(svr.URL + "/api/v2.0/registry")
+		err = NamespaceList(svr.URL + "/api/v1.0/registry")
 		require.NoError(t, err)
 		w.Close()
 		os.Stdout = oldStdout
@@ -110,7 +110,7 @@ func TestServeNamespaceRegistry(t *testing.T) {
 		r, w, _ := os.Pipe()
 		os.Stdout = w
 
-		err = NamespaceGet(svr.URL + "/api/v2.0/registry")
+		err = NamespaceGet(svr.URL + "/api/v1.0/registry")
 		require.NoError(t, err)
 		w.Close()
 		os.Stdout = oldStdout
@@ -123,13 +123,13 @@ func TestServeNamespaceRegistry(t *testing.T) {
 
 	t.Run("Test namespace delete", func(t *testing.T) {
 		//Test functionality of namespace delete
-		err = NamespaceDelete(svr.URL+"/api/v2.0/registry/foo/bar", "/foo/bar")
+		err = NamespaceDelete(svr.URL+"/api/v1.0/registry/foo/bar", "/foo/bar")
 		require.NoError(t, err)
 		var stdoutCapture string
 		oldStdout := os.Stdout
 		r, w, _ := os.Pipe()
 		os.Stdout = w
-		err = NamespaceGet(svr.URL + "/api/v2.0/registry")
+		err = NamespaceGet(svr.URL + "/api/v1.0/registry")
 		require.NoError(t, err)
 		w.Close()
 		os.Stdout = oldStdout
@@ -173,19 +173,19 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start by registering /foo/bar with the default key
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v2.0/registry", "", "/foo/bar")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar")
 	require.NoError(t, err)
 
 	// Perform one test with a subspace and the same key -- should succeed
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v2.0/registry", "", "/foo/bar/test")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/test")
 	require.NoError(t, err)
 
 	// For now, we simply don't allow further super/sub spacing of namespaces from topo, because how
 	// can we validate via a key if there is none?
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v2.0/registry", "", "/topo/foo/bar")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo/foo/bar")
 	require.Error(t, err)
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v2.0/registry", "", "/topo")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo")
 	require.Error(t, err)
 
 	// Now we create a new key and try to use it to register a super/sub space. These shouldn't succeed
@@ -195,28 +195,28 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 	privKey, err = config.GetIssuerPrivateJWK()
 	require.NoError(t, err)
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v2.0/registry", "", "/foo/bar/baz")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/baz")
 	require.ErrorContains(t, err, "Cannot register a namespace that is suffixed or prefixed")
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v2.0/registry", "", "/foo")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo")
 	require.ErrorContains(t, err, "Cannot register a namespace that is suffixed or prefixed")
 
 	// Make sure we can register things similar but distinct in prefix and suffix
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v2.0/registry", "", "/fo")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/fo")
 	require.NoError(t, err)
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v2.0/registry", "", "/foo/barz")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/barz")
 	require.NoError(t, err)
 
 	// Now turn off token chaining and retry -- no errors should occur
 	viper.Set("Registry.RequireKeyChaining", false)
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v2.0/registry", "", "/foo/bar/baz")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/baz")
 	require.NoError(t, err)
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v2.0/registry", "", "/foo")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo")
 	require.NoError(t, err)
 
 	// Finally, test with one value for topo
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v2.0/registry", "", "/topo")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo")
 	require.NoError(t, err)
 
 	config.SetPreferredPrefix("pelican")
@@ -246,11 +246,11 @@ func TestRegistryKeyChaining(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start by registering /foo/bar with the default key
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v2.0/registry", "", "/foo/bar")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar")
 	require.NoError(t, err)
 
 	// Perform one test with a subspace and the same key -- should succeed
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v2.0/registry", "", "/foo/bar/test")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/test")
 	require.NoError(t, err)
 
 	// Now we create a new key and try to use it to register a super/sub space. These shouldn't succeed
@@ -260,18 +260,18 @@ func TestRegistryKeyChaining(t *testing.T) {
 	privKey, err = config.GetIssuerPrivateJWK()
 	require.NoError(t, err)
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v2.0/registry", "", "/foo/bar/baz")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/baz")
 	require.ErrorContains(t, err, "Cannot register a namespace that is suffixed or prefixed")
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v2.0/registry", "", "/foo")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo")
 	require.ErrorContains(t, err, "Cannot register a namespace that is suffixed or prefixed")
 
 	// Now turn off token chaining and retry -- no errors should occur
 	viper.Set("Registry.RequireKeyChaining", false)
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v2.0/registry", "", "/foo/bar/baz")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/baz")
 	require.NoError(t, err)
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v2.0/registry", "", "/foo")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo")
 	require.NoError(t, err)
 
 	viper.Reset()

--- a/registry/client_commands_test.go
+++ b/registry/client_commands_test.go
@@ -102,25 +102,6 @@ func TestServeNamespaceRegistry(t *testing.T) {
 		assert.Contains(t, stdoutCapture, `"prefix":"/foo/bar"`)
 	})
 
-	//Test functionality of namespace get
-	t.Run("Test namespace get", func(t *testing.T) {
-		//Set up a buffer to capture stdout
-		var stdoutCapture string
-		oldStdout := os.Stdout
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-
-		err = NamespaceGet(svr.URL + "/api/v1.0/registry")
-		require.NoError(t, err)
-		w.Close()
-		os.Stdout = oldStdout
-
-		capturedOutput := make([]byte, 1024)
-		n, _ := r.Read(capturedOutput)
-		stdoutCapture = string(capturedOutput[:n])
-		assert.Contains(t, stdoutCapture, `"prefix":"/foo/bar"`)
-	})
-
 	t.Run("Test namespace delete", func(t *testing.T) {
 		//Test functionality of namespace delete
 		err = NamespaceDelete(svr.URL+"/api/v1.0/registry/foo/bar", "/foo/bar")

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -694,23 +694,20 @@ func getOpenIDConfiguration(c *gin.Context) {
 }
 */
 
-func RegisterRegistryAPI(router *gin.RouterGroup) {
-	v1registry := router.Group("/api/v1.0/registry")
-	{
-		v1registry.POST("", cliRegisterNamespace)
-		v1registry.GET("", dbGetAllNamespaces)
-		// Will handle getting jwks, openid config, and listing namespaces
-		v1registry.GET("/*wildcard", metadataHandler)
-		v1registry.DELETE("/*wildcard", dbDeleteNamespace)
-	}
+func HandleWildcard(ctx *gin.Context) {
+	if strings.HasPrefix(ctx.Request.URL.Path, "/getNamespace") {
 
-	v2registry := router.Group("/api/v2.0/registry")
+	}
+}
+
+func RegisterRegistryAPI(router *gin.RouterGroup) {
+	registryAPI := router.Group("/api/v1.0/registry")
 	{
-		v2registry.POST("", cliRegisterNamespace)
-		v2registry.GET("", dbGetAllNamespaces)
-		v2registry.GET("/getNamespace", dbGetNamespace)
+		registryAPI.POST("", cliRegisterNamespace)
+		registryAPI.GET("", dbGetAllNamespaces)
+		registryAPI.GET("/getNamespace", dbGetNamespace)
 		// Will handle getting jwks, openid config, and listing namespaces
-		v2registry.GET("/metadata/*wildcard", metadataHandler)
-		v2registry.DELETE("/*wildcard", dbDeleteNamespace)
+		registryAPI.GET("/*wildcard", metadataHandler)
+		registryAPI.DELETE("/*wildcard", dbDeleteNamespace)
 	}
 }

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -271,6 +271,22 @@ func namespaceExistsById(id int) (bool, error) {
 	return found, nil
 }
 
+func namespaceExistsByPrefix(prefix string) (bool, error) {
+	checkQuery := `SELECT prefix FROM namespace WHERE prefix = ?`
+	result, err := db.Query(checkQuery, prefix)
+	if err != nil {
+		return false, err
+	}
+	defer result.Close()
+
+	found := false
+	for result.Next() {
+		found = true
+		break
+	}
+	return found, nil
+}
+
 func namespaceBelongsToUserId(id int, userId string) (bool, error) {
 	query := `SELECT admin_metadata FROM namespace where id = ?`
 	rows, err := db.Query(query, id)
@@ -319,7 +335,7 @@ func getNamespaceJwksById(id int) (jwk.Set, error) {
 	return set, nil
 }
 
-func getNamespaceJwksByPrefix(prefix string, approvalRequired bool) (*jwk.Set, error) {
+func getNamespaceJwksByPrefix(prefix string, approvalRequired bool) (jwk.Set, error) {
 	var jwksQuery string
 	var pubkeyStr string
 	if strings.HasPrefix(prefix, "/caches/") && approvalRequired {
@@ -358,7 +374,7 @@ func getNamespaceJwksByPrefix(prefix string, approvalRequired bool) (*jwk.Set, e
 		return nil, errors.Wrap(err, "Failed to parse pubkey as a jwks")
 	}
 
-	return &set, nil
+	return set, nil
 }
 
 func getNamespaceStatusById(id int) (RegistrationStatus, error) {

--- a/registry/registry_db_test.go
+++ b/registry/registry_db_test.go
@@ -172,6 +172,26 @@ var (
 	}()
 )
 
+func TestNamespaceExistsByPrefix(t *testing.T) {
+	setupMockRegistryDB(t)
+	defer teardownMockNamespaceDB(t)
+
+	t.Run("return-false-for-prefix-dne", func(t *testing.T) {
+		found, err := namespaceExistsByPrefix("/non-existed-namespace")
+		require.NoError(t, err)
+		assert.False(t, found)
+	})
+
+	t.Run("return-true-for-existing-ns", func(t *testing.T) {
+		resetNamespaceDB(t)
+		err := insertMockDBData([]Namespace{{Prefix: "/foo"}})
+		require.NoError(t, err)
+		found, err := namespaceExistsByPrefix("/foo")
+		require.NoError(t, err)
+		assert.True(t, found)
+	})
+}
+
 func TestGetNamespacesById(t *testing.T) {
 	setupMockRegistryDB(t)
 	defer teardownMockNamespaceDB(t)

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -51,7 +51,8 @@ func TestHandleWildcard(t *testing.T) {
 		mockJWKS := jwk.NewSet()
 		mockJWKSBytes, err := json.Marshal(mockJWKS)
 		require.NoError(t, err)
-		insertMockDBData([]Namespace{{Prefix: mockPrefix, Pubkey: string(mockJWKSBytes)}})
+		err = insertMockDBData([]Namespace{{Prefix: mockPrefix, Pubkey: string(mockJWKSBytes)}})
+		require.NoError(t, err)
 		mockNs, err := getNamespaceByPrefix(mockPrefix)
 
 		require.NoError(t, err)
@@ -64,6 +65,6 @@ func TestHandleWildcard(t *testing.T) {
 
 		// Should return 200 for matched metadataHandler since the db is empty
 		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Equal(t, string(mockJWKSBytes), string(w.Body.Bytes()))
+		assert.Equal(t, string(mockJWKSBytes), w.Body.String())
 	})
 }

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,0 +1,69 @@
+package registry
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleWildcard(t *testing.T) {
+	// Set up the router
+	r := gin.New()
+	group := r.Group("/registry")
+
+	group.GET("/*wildcard", wildcardHandler)
+
+	t.Run("return-404-for-unmatched-route", func(t *testing.T) {
+		// Create a test request
+		req, _ := http.NewRequest("GET", "/registry/no-match", nil)
+		w := httptest.NewRecorder()
+
+		// Perform the request
+		r.ServeHTTP(w, req)
+
+		// Should return 404 for an unmatched route
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("match-getNamespace", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/registry/getNamespace", nil)
+		w := httptest.NewRecorder()
+
+		r.ServeHTTP(w, req)
+
+		// /getNamespace requires X-Pelican-Prefix header to be set or it will return 400
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("match-wildcard-metadataHandler", func(t *testing.T) {
+		mockPrefix := "/testnamespace/foo"
+
+		setupMockRegistryDB(t)
+		defer teardownMockNamespaceDB(t)
+
+		mockJWKS := jwk.NewSet()
+		mockJWKSBytes, err := json.Marshal(mockJWKS)
+		require.NoError(t, err)
+		insertMockDBData([]Namespace{{Prefix: mockPrefix, Pubkey: string(mockJWKSBytes)}})
+		mockNs, err := getNamespaceByPrefix(mockPrefix)
+
+		require.NoError(t, err)
+		require.NotNil(t, mockNs)
+
+		req, _ := http.NewRequest("GET", fmt.Sprintf("/registry%s/.well-known/issuer.jwks", mockPrefix), nil)
+		w := httptest.NewRecorder()
+
+		r.ServeHTTP(w, req)
+
+		// Should return 200 for matched metadataHandler since the db is empty
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, string(mockJWKSBytes), string(w.Body.Bytes()))
+	})
+}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -32,16 +32,6 @@ func TestHandleWildcard(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, w.Code)
 	})
 
-	t.Run("match-getNamespace", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/registry/getNamespace", nil)
-		w := httptest.NewRecorder()
-
-		r.ServeHTTP(w, req)
-
-		// /getNamespace requires X-Pelican-Prefix header to be set or it will return 400
-		assert.Equal(t, http.StatusBadRequest, w.Code)
-	})
-
 	t.Run("match-wildcard-metadataHandler", func(t *testing.T) {
 		mockPrefix := "/testnamespace/foo"
 

--- a/server_ui/register_namespace.go
+++ b/server_ui/register_namespace.go
@@ -138,7 +138,7 @@ func registerNamespacePrep() (key jwk.Key, prefix string, registrationEndpointUR
 		return
 	}
 
-	registrationEndpointURL, err = url.JoinPath(namespaceEndpoint, "api", "v2.0", "registry")
+	registrationEndpointURL, err = url.JoinPath(namespaceEndpoint, "api", "v1.0", "registry")
 	if err != nil {
 		err = errors.Wrap(err, "Failed to construct registration endpoint URL: %v")
 		return

--- a/server_ui/register_namespace.go
+++ b/server_ui/register_namespace.go
@@ -159,7 +159,6 @@ func keyIsRegistered(privkey jwk.Key, registryUrlStr string, prefix string) (key
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Pelican-Prefix", prefix)
 
 	OSDFResp, err := client.Do(OSDFReq)
 	if err != nil {

--- a/server_ui/register_namespace.go
+++ b/server_ui/register_namespace.go
@@ -19,8 +19,10 @@
 package server_ui
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -37,12 +39,20 @@ import (
 )
 
 type (
-	errorResp struct {
-		Error string `json:"error"`
-	}
-
 	keyStatus int
 )
+
+type checkNamespaceExistsReq struct {
+	Prefix string `json:"prefix"`
+	PubKey string `json:"pubkey"` // Pass a JWK
+}
+
+type checkNamespaceExistsRes struct {
+	PrefixExists bool   `json:"prefix_exists"`
+	KeyMatch     bool   `json:"key_match"`
+	Message      string `json:"message"`
+	Error        string `json:"error"`
+}
 
 const (
 	noKeyPresent keyStatus = iota
@@ -50,7 +60,24 @@ const (
 	keyMatch
 )
 
-func keyIsRegistered(privkey jwk.Key, url string, prefix string) (keyStatus, error) {
+// Check if a namespace private JWK with namespace prefix from the origin is registered at the given registry.
+//
+// registryUrlStr is the URL with base path to the registry's API. For Pelican registry,
+// this should be https://<registry-host>/api/v1.0/registry
+//
+// If the prefix is not found in the registry, it returns noKeyPresent with error == nil
+// If the prefix is found, but the public key of the private key doesn't match what's in the registry,
+// it will return keyMismatch with error == nil. Otherwise, it returns keyMatch
+//
+// Note that this function will first send a POST request to /api/v1.0/registry/checkNamespaceExists,
+// which is the current Pelican registry endpoint. However, OSDF registry and Pelican registry < v7.4.0 doesn't
+// have this endpoint, so if calling it returns 404, we will then check using /api/v1.0/registry/<prefix>/.well-known/issuer.jwks,
+// which should always give the jwks if it exists.
+func keyIsRegistered(privkey jwk.Key, registryUrlStr string, prefix string) (keyStatus, error) {
+	registryUrl, err := url.Parse(registryUrlStr)
+	if err != nil {
+		return noKeyPresent, errors.Wrap(err, "Error parsing registryUrlStr")
+	}
 	keyId := privkey.KeyID()
 	if keyId == "" {
 		return noKeyPresent, errors.New("Provided key is missing a key ID")
@@ -60,14 +87,27 @@ func keyIsRegistered(privkey jwk.Key, url string, prefix string) (keyStatus, err
 		return noKeyPresent, err
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	// We first check against Pelican's registry at /api/v1.0/registry/checkNamespaceExists
+	// so that the registry won't give out the public key
+	pelicanReqURL := registryUrl.JoinPath("/checkNamespaceExists")
+	pubkeyStr, err := json.Marshal(key)
+	if err != nil {
+		return noKeyPresent, err
+	}
+
+	keyCheckReq := checkNamespaceExistsReq{Prefix: prefix, PubKey: string(pubkeyStr)}
+	jsonData, err := json.Marshal(keyCheckReq)
+	if err != nil {
+		return noKeyPresent, errors.Wrap(err, "Error marshalling request to json string")
+	}
+
+	req, err := http.NewRequest("POST", pelicanReqURL.String(), bytes.NewBuffer(jsonData))
 
 	if err != nil {
 		return noKeyPresent, err
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Pelican-Prefix", prefix)
 
 	tr := config.GetTransport()
 	client := &http.Client{Transport: tr}
@@ -78,34 +118,83 @@ func keyIsRegistered(privkey jwk.Key, url string, prefix string) (keyStatus, err
 	}
 	defer resp.Body.Close()
 
-	// Check HTTP response -- should be 200, else something went wrong
 	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode == 404 || resp.StatusCode == 500 {
-		// TODO: The registry returns a 500 for unregistered namespaces instead of a 404.
-		// It would be better to have an error message in this case but we must instead assume
-		// it's an unregistered namespace.
-		return noKeyPresent, nil
-	} else if resp.StatusCode != 200 {
-		var msg errorResp
-		if err := json.Unmarshal(body, &msg); err != nil {
+
+	// For Pelican's registry at /api/v1.0/registry/checkNamespaceExists, it only returns 200, 400, and 500.
+	// If it returns 404, that means we are not hitting Pelican's registry but OSDF's registry or Pelican registry < v7.4.0
+	if resp.StatusCode != http.StatusNotFound {
+		resData := checkNamespaceExistsRes{}
+		if err := json.Unmarshal(body, &resData); err != nil {
 			log.Warningln("Failed to unmarshal error message response from namespace registry", err)
 		}
-		if msg.Error != "" {
-			return noKeyPresent, errors.Errorf("Failed to query registry for public key (status code %v): %v", resp.StatusCode, msg.Error)
+		switch resp.StatusCode {
+		case http.StatusInternalServerError:
+			return noKeyPresent, errors.Errorf("Failed to query registry for public key with server error (status code %v): %v", resp.StatusCode, resData.Error)
+		case http.StatusBadRequest:
+			return noKeyPresent, errors.Errorf("Failed to query registry for public key with a bad request (status code %v): %v", resp.StatusCode, resData.Error)
+		case http.StatusOK:
+			if !resData.PrefixExists {
+				return noKeyPresent, nil
+			}
+			if !resData.KeyMatch {
+				return keyMismatch, nil
+			} else {
+				return keyMatch, nil
+			}
+		default:
+			return noKeyPresent, errors.Errorf("Failed to query registry for public key with unknown server response (status code %v)", resp.StatusCode)
+		}
+	}
+
+	// In this case, we got 404 from the first request, so we will try to check against legacy OSDF endpoint at
+	// "/api/v1.0/registry/<prefix>/.well-known/issuer.jwks"
+	log.Warningf("Getting 404 from checking if key is registered at: %s Fall back to check issuer.jwks", pelicanReqURL.String())
+
+	OSDFReqUrl := registryUrl.JoinPath(prefix, ".well-known", "issuer.jwks")
+
+	OSDFReq, err := http.NewRequest("GET", OSDFReqUrl.String(), nil)
+
+	if err != nil {
+		return noKeyPresent, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Pelican-Prefix", prefix)
+
+	OSDFResp, err := client.Do(OSDFReq)
+	if err != nil {
+		return noKeyPresent, err
+	}
+	defer OSDFResp.Body.Close()
+
+	// Check HTTP response -- should be 200, else something went wrong
+	OSDFBody, _ := io.ReadAll(OSDFResp.Body)
+
+	// 404 is from Pelican issuer.jwks endpoint while 500 is from OSDF endpoint
+	if resp.StatusCode == 404 || resp.StatusCode == 500 {
+		return noKeyPresent, nil
+	} else if resp.StatusCode != 200 {
+		resData := checkNamespaceExistsRes{}
+		if err := json.Unmarshal(OSDFBody, &resData); err != nil {
+			log.Warningln("Failed to unmarshal error message response from namespace registry", err)
+		}
+		if resData.Error != "" {
+			return noKeyPresent, errors.Errorf("Failed to query registry for public key (status code %v): %v", resp.StatusCode, resData.Error)
 		} else {
 			return noKeyPresent, errors.Errorf("Failed to query registry for public key: status code %v", resp.StatusCode)
 		}
 	}
 
 	var ns *registry.Namespace
-	err = json.Unmarshal(body, &ns)
+	err = json.Unmarshal(OSDFBody, &ns)
 	if err != nil {
+		log.Error(fmt.Sprintf("Failed unmarshal namespace from response: %v, body: %v, response code: %v, URL: %v", err, OSDFBody, resp.StatusCode, registryUrl))
 		return noKeyPresent, errors.Errorf("Failed unmarshal namespace from response")
 	}
 
 	registrySet, err := jwk.ParseString(ns.Pubkey)
 	if err != nil {
-		log.Debugln("Failed to parse registry response:", string(body))
+		log.Debugln("Failed to parse registry response:", string(OSDFBody))
 		return noKeyPresent, errors.Wrap(err, "Failed to parse registry response as a JWKS")
 	}
 
@@ -143,12 +232,6 @@ func registerNamespacePrep() (key jwk.Key, prefix string, registrationEndpointUR
 		err = errors.Wrap(err, "Failed to construct registration endpoint URL: %v")
 		return
 	}
-	registrationCheckEndpointURL, err := url.JoinPath(registrationEndpointURL, "getNamespace")
-	if err != nil {
-		err = errors.Wrap(err, "Failed to construct registration check endpoint URL: %v")
-		return
-	}
-
 	key, err = config.GetIssuerPrivateJWK()
 	if err != nil {
 		err = errors.Wrap(err, "failed to load the origin's JWK")
@@ -160,7 +243,7 @@ func registerNamespacePrep() (key jwk.Key, prefix string, registrationEndpointUR
 			return
 		}
 	}
-	keyStatus, err := keyIsRegistered(key, registrationCheckEndpointURL, prefix)
+	keyStatus, err := keyIsRegistered(key, registrationEndpointURL, prefix)
 	if err != nil {
 		err = errors.Wrap(err, "Failed to determine whether namespace is already registered")
 		return

--- a/server_ui/register_namespace_test.go
+++ b/server_ui/register_namespace_test.go
@@ -100,13 +100,13 @@ func TestRegistration(t *testing.T) {
 	key, prefix, registerURL, isRegistered, err := registerNamespacePrep()
 	require.NoError(t, err)
 	assert.False(t, isRegistered)
-	assert.Equal(t, registerURL, svr.URL+"/api/v2.0/registry")
+	assert.Equal(t, registerURL, svr.URL+"/api/v1.0/registry")
 	assert.Equal(t, prefix, "/test123")
 	err = registerNamespaceImpl(key, prefix, registerURL)
 	require.NoError(t, err)
 
 	// Test we can query for the new key
-	req, err := http.NewRequest("GET", svr.URL+"/api/v2.0/registry", nil)
+	req, err := http.NewRequest("GET", svr.URL+"/api/v1.0/registry", nil)
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	tr := config.GetTransport()
@@ -133,7 +133,7 @@ func TestRegistration(t *testing.T) {
 	assert.True(t, jwk.Equal(registryKey, key))
 
 	// Test the functionality of the keyIsRegistered function
-	keyStatus, err := keyIsRegistered(key, svr.URL+"/api/v2.0/registry/getNamespace", "/test123")
+	keyStatus, err := keyIsRegistered(key, svr.URL+"/api/v1.0/registry/getNamespace", "/test123")
 	assert.NoError(t, err)
 	require.Equal(t, keyStatus, keyMatch)
 
@@ -145,7 +145,7 @@ func TestRegistration(t *testing.T) {
 	keyAlt, err := privKeyAlt.PublicKey()
 	require.NoError(t, err)
 	assert.NoError(t, jwk.AssignKeyID(keyAlt))
-	keyStatus, err = keyIsRegistered(keyAlt, svr.URL+"/api/v2.0/registry/getNamespace", "/test123")
+	keyStatus, err = keyIsRegistered(keyAlt, svr.URL+"/api/v1.0/registry/getNamespace", "/test123")
 	assert.NoError(t, err)
 	assert.Equal(t, keyStatus, keyMismatch)
 
@@ -156,7 +156,7 @@ func TestRegistration(t *testing.T) {
 
 	// Redo the namespace prep, ensure that isPresent is true
 	_, prefix, registerURL, isRegistered, err = registerNamespacePrep()
-	assert.Equal(t, svr.URL+"/api/v2.0/registry", registerURL)
+	assert.Equal(t, svr.URL+"/api/v1.0/registry", registerURL)
 	assert.NoError(t, err)
 	assert.Equal(t, prefix, "/test123")
 	assert.True(t, isRegistered)

--- a/server_ui/register_namespace_test.go
+++ b/server_ui/register_namespace_test.go
@@ -133,7 +133,7 @@ func TestRegistration(t *testing.T) {
 	assert.True(t, jwk.Equal(registryKey, key))
 
 	// Test the functionality of the keyIsRegistered function
-	keyStatus, err := keyIsRegistered(key, svr.URL+"/api/v1.0/registry/getNamespace", "/test123")
+	keyStatus, err := keyIsRegistered(key, svr.URL+"/api/v1.0/registry", "/test123")
 	assert.NoError(t, err)
 	require.Equal(t, keyStatus, keyMatch)
 
@@ -145,7 +145,7 @@ func TestRegistration(t *testing.T) {
 	keyAlt, err := privKeyAlt.PublicKey()
 	require.NoError(t, err)
 	assert.NoError(t, jwk.AssignKeyID(keyAlt))
-	keyStatus, err = keyIsRegistered(keyAlt, svr.URL+"/api/v1.0/registry/getNamespace", "/test123")
+	keyStatus, err = keyIsRegistered(keyAlt, svr.URL+"/api/v1.0/registry", "/test123")
 	assert.NoError(t, err)
 	assert.Equal(t, keyStatus, keyMismatch)
 


### PR DESCRIPTION
Fixes #566 

See #566 for reasoning behind this implementation.