### PR TITLE
Fixes to the shutdown / error sequence

### DIFF
--- a/cmd/director_serve.go
+++ b/cmd/director_serve.go
@@ -25,6 +25,10 @@ import (
 )
 
 func serveDirector(cmd *cobra.Command, args []string) error {
-	_, err := launchers.LaunchModules(cmd.Context(), config.DirectorType)
+	cancel, err := launchers.LaunchModules(cmd.Context(), config.DirectorType)
+	if err != nil {
+		cancel()
+	}
+
 	return err
 }

--- a/cmd/fed_serve.go
+++ b/cmd/fed_serve.go
@@ -43,6 +43,10 @@ func fedServeStart(cmd *cobra.Command, args []string) error {
 		return errors.New("`pelican serve` does not support the cache module")
 	}
 
-	_, err := launchers.LaunchModules(cmd.Context(), modules)
+	cancel, err := launchers.LaunchModules(cmd.Context(), modules)
+	if err != nil {
+		cancel()
+	}
+
 	return err
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -60,7 +60,10 @@ func handleCLI(args []string) error {
 			fmt.Println("Built By:", builtBy)
 			return nil
 		}
-		Execute()
+		err := Execute()
+		if err != nil {
+			os.Exit(1)
+		}
 	}
 	return nil
 }

--- a/cmd/origin_serve.go
+++ b/cmd/origin_serve.go
@@ -29,6 +29,10 @@ import (
 )
 
 func serveOrigin(cmd *cobra.Command, args []string) error {
-	_, err := launchers.LaunchModules(cmd.Context(), config.OriginType)
+	cancel, err := launchers.LaunchModules(cmd.Context(), config.OriginType)
+	if err != nil {
+		cancel()
+	}
+
 	return err
 }

--- a/cmd/registry_serve.go
+++ b/cmd/registry_serve.go
@@ -26,6 +26,10 @@ import (
 )
 
 func serveRegistry(cmd *cobra.Command, _ []string) error {
-	_, err := launchers.LaunchModules(cmd.Context(), config.RegistryType)
+	cancel, err := launchers.LaunchModules(cmd.Context(), config.RegistryType)
+	if err != nil {
+		cancel()
+	}
+
 	return err
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,6 @@ package main
 
 import (
 	"context"
-	"os"
 	"strconv"
 	"strings"
 
@@ -78,7 +77,7 @@ func (i *uint16Value) Type() string {
 
 func (i *uint16Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
-func Execute() {
+func Execute() error {
 	egrp := errgroup.Group{}
 	defer func() {
 		err := egrp.Wait()
@@ -87,10 +86,7 @@ func Execute() {
 		}
 	}()
 	ctx := context.WithValue(context.Background(), config.EgrpKey, &egrp)
-	err := rootCmd.ExecuteContext(ctx)
-	if err != nil {
-		os.Exit(1)
-	}
+	return rootCmd.ExecuteContext(ctx)
 }
 
 func init() {

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -68,11 +68,9 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (context.Canc
 		return shutdownCancel, errors.Wrap(err, "Failure when configuring the server")
 	}
 
-	if param.Server_EnableUI.GetBool() {
-		// Set up necessary APIs to support Web UI, including auth and metrics
-		if err := web_ui.ConfigureServerWebAPI(ctx, engine, egrp); err != nil {
-			return shutdownCancel, err
-		}
+	// Set up necessary APIs to support Web UI, including auth and metrics
+	if err := web_ui.ConfigureServerWebAPI(ctx, engine, egrp); err != nil {
+		return shutdownCancel, err
 	}
 
 	if modules.IsEnabled(config.RegistryType) {
@@ -149,8 +147,9 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (context.Canc
 		return nil
 	})
 
-	if err = server_utils.WaitUntilWorking(ctx, "GET", param.Server_ExternalWebUrl.GetString()+"/view", "Web UI", http.StatusOK); err != nil {
+	if err = server_utils.WaitUntilWorking(ctx, "GET", param.Server_ExternalWebUrl.GetString()+"/api/v1.0/servers", "Web UI", http.StatusOK); err != nil {
 		log.Errorln("Web engine startup appears to have failed:", err)
+		return shutdownCancel, err
 	}
 
 	if modules.IsEnabled(config.OriginType) {

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -23,7 +23,6 @@ import (
 	"crypto/tls"
 	"embed"
 	"fmt"
-	"github.com/pelicanplatform/pelican/config"
 	"math/rand"
 	"mime"
 	"net"
@@ -34,6 +33,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/pelicanplatform/pelican/config"
 
 	"github.com/gin-gonic/gin"
 	"github.com/pelicanplatform/pelican/metrics"
@@ -247,18 +248,21 @@ func waitUntilLogin(ctx context.Context) error {
 //
 // You need to mount the static resources for UI in a separate function
 func ConfigureServerWebAPI(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group) error {
-	if err := configureAuthEndpoints(ctx, engine, egrp); err != nil {
-		return err
-	}
 	if err := configureCommonEndpoints(engine); err != nil {
-		return err
-	}
-	if err := configureWebResource(engine); err != nil {
 		return err
 	}
 	if err := configureMetrics(ctx, engine); err != nil {
 		return err
 	}
+	if param.Server_EnableUI.GetBool() {
+		if err := configureAuthEndpoints(ctx, engine, egrp); err != nil {
+			return err
+		}
+		if err := configureWebResource(engine); err != nil {
+			return err
+		}
+	}
+
 	// Redirect root to /view for web UI
 	engine.GET("/", func(c *gin.Context) {
 		c.Redirect(http.StatusFound, "/view/")


### PR DESCRIPTION
When an error occurred, ensure we always cancel the context and then wait for cleanup to finish.  Without this PR, we are leaking xrootd processes because neither occurs.

Further, this makes the `/api/v1.0/servers` API always-on to make the test for the web engine functionality more reliably succeed.