### PR TITLE
Fixes to origin/director advertise to client

### DIFF
--- a/client/director.go
+++ b/client/director.go
@@ -124,7 +124,9 @@ func CreateNsFromDirectorResp(dirResp *http.Response) (namespace namespaces.Name
 	return
 }
 
-func QueryDirector(source string, directorUrl string) (resp *http.Response, err error) {
+// Make a request to the director for a given verb/resource; return the
+// HTTP response object only if a 307 is returned.
+func queryDirector(verb, source, directorUrl string) (resp *http.Response, err error) {
 	resourceUrl := directorUrl + source
 	// Here we use http.Transport to prevent the client from following the director's
 	// redirect. We use the Location url elsewhere (plus we still need to do the token
@@ -138,7 +140,7 @@ func QueryDirector(source string, directorUrl string) (resp *http.Response, err 
 		},
 	}
 
-	req, err := http.NewRequest("GET", resourceUrl, nil)
+	req, err := http.NewRequest(verb, resourceUrl, nil)
 	if err != nil {
 		log.Errorln("Failed to create an HTTP request:", err)
 		return nil, err
@@ -172,7 +174,7 @@ func QueryDirector(source string, directorUrl string) (resp *http.Response, err 
 		if unmarshalErr := json.Unmarshal(body, &respErr); unmarshalErr != nil { // Error creating json
 			return nil, errors.Wrap(unmarshalErr, "Could not unmarshall the director's response")
 		}
-		return nil, errors.Errorf("The director reported an error: %s\n", respErr.Error)
+		return resp, errors.Errorf("The director reported an error: %s", respErr.Error)
 	}
 
 	return

--- a/client/director_test.go
+++ b/client/director_test.go
@@ -20,12 +20,13 @@ package client
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	namespaces "github.com/pelicanplatform/pelican/namespaces"
 )
@@ -194,7 +195,7 @@ func TestQueryDirector(t *testing.T) {
 	defer server.Close()
 
 	// Call QueryDirector with the test server URL and a source path
-	actualResp, err := QueryDirector("/foo/bar", server.URL)
+	actualResp, err := queryDirector("GET", "/foo/bar", server.URL)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -19,7 +19,6 @@
 package client
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -849,40 +848,16 @@ func UploadFile(src string, origDest *url.URL, token string, namespace namespace
 		nonZeroSize = fileInfo.Size() > 0
 	}
 
-	// call a GET on the director, director will respond with our endpoint
-	directorUrlStr := param.Federation_DirectorUrl.GetString()
-	directorUrl, err := url.Parse(directorUrlStr)
+	// Parse the writeback host as a URL
+	writebackhostUrl, err := url.Parse(namespace.WriteBackHost)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to parse director url")
-	}
-	directorUrl.Path, err = url.JoinPath("/api/v1.0/director/origin", origDest.Path)
-	if err != nil {
-		return 0, errors.Wrap(err, "failed to parse director path for upload")
+		return 0, err
 	}
 
-	payload := []byte("forPUT")
-	req, err := http.NewRequest("GET", directorUrl.String(), bytes.NewBuffer(payload))
-	if err != nil {
-		return 0, errors.Wrap(err, "failed to construct request for director-origin query")
-	}
-
-	client := &http.Client{
-		Transport: config.GetTransport(),
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return 0, errors.Wrap(err, "failed to send request to director to obtain upload endpoint")
-	}
-	if resp.StatusCode == 405 {
-		return 0, errors.New("Error 405: No writeable origins were found")
-	}
-	defer resp.Body.Close()
-	dest, err := url.Parse(resp.Header.Get("Location"))
-	if err != nil {
-		return 0, errors.Wrap(err, "failed to parse location header from director response")
+	dest := &url.URL{
+		Host:   writebackhostUrl.Host,
+		Scheme: "https",
+		Path:   origDest.Path,
 	}
 
 	// Create the wrapped reader and send it to the request

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -469,7 +469,7 @@ func TestFullUpload(t *testing.T) {
 	viper.Set("Origin.EnableCmsd", false)
 	viper.Set("Origin.EnableMacaroons", false)
 	viper.Set("Origin.EnableVoms", false)
-	viper.Set("Origin.WriteEnabled", true)
+	viper.Set("Origin.EnableWrite", true)
 	viper.Set("TLSSkipVerify", true)
 	viper.Set("Server.EnableUI", false)
 	viper.Set("Registry.DbLocation", filepath.Join(t.TempDir(), "ns-registry.sqlite"))

--- a/client/sharing_url.go
+++ b/client/sharing_url.go
@@ -84,7 +84,7 @@ func CreateSharingUrl(objectUrl *url.URL, isWrite bool) (string, error) {
 	objectUrl.Path = "/" + strings.TrimPrefix(objectUrl.Path, "/")
 
 	log.Debugln("Will query director for path", objectUrl.Path)
-	dirResp, err := QueryDirector(objectUrl.Path, directorUrl)
+	dirResp, err := queryDirector("GET", objectUrl.Path, directorUrl)
 	if err != nil {
 		log.Errorln("Error while querying the Director:", err)
 		return "", errors.Wrapf(err, "Error while querying the director at %s", directorUrl)

--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -122,7 +122,7 @@ func init() {
 
 	// The -w flag is used if we want the origin to be writeable.
 	originServeCmd.Flags().BoolP("writeable", "", true, "Allow/disable writting to the origin")
-	if err := viper.BindPFlag("Origin.WriteEnabled", originServeCmd.Flags().Lookup("writeable")); err != nil {
+	if err := viper.BindPFlag("Origin.EnableWrite", originServeCmd.Flags().Lookup("writeable")); err != nil {
 		panic(err)
 	}
 

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -31,6 +31,7 @@ Origin:
   EnableMacaroons: false
   EnableVoms: true
   EnableUI: true
+  EnableWrite: true
   SelfTest: true
 Monitoring:
   PortLower: 9930

--- a/director/advertise.go
+++ b/director/advertise.go
@@ -36,7 +36,7 @@ func parseServerAd(server utils.Server, serverType ServerType) ServerAd {
 	serverAd.Type = serverType
 	serverAd.Name = server.Resource
 
-	serverAd.WriteEnabled = param.Origin_WriteEnabled.GetBool()
+	serverAd.EnableWrite = param.Origin_EnableWrite.GetBool()
 	// url.Parse requires that the scheme be present before the hostname,
 	// but endpoints do not have a scheme. As such, we need to add one for the.
 	// correct parsing. Luckily, we don't use this anywhere else (it's just to

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -46,14 +46,15 @@ type (
 	}
 
 	ServerAd struct {
-		Name        string
-		AuthURL     url.URL
-		URL         url.URL // This is server's XRootD URL for file transfer
-		WebURL      url.URL // This is server's Web interface and API
-		Type        ServerType
-		Latitude    float64
-		Longitude   float64
-		EnableWrite bool
+		Name               string
+		AuthURL            url.URL
+		URL                url.URL // This is server's XRootD URL for file transfer
+		WebURL             url.URL // This is server's Web interface and API
+		Type               ServerType
+		Latitude           float64
+		Longitude          float64
+		EnableWrite        bool
+		EnableFallbackRead bool // True if reads from the origin are permitted when no cache is available
 	}
 
 	ServerType   string

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -53,7 +53,7 @@ type (
 		Type         ServerType
 		Latitude     float64
 		Longitude    float64
-		WriteEnabled bool
+		EnableWrite  bool
 	}
 
 	ServerType   string

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -46,14 +46,14 @@ type (
 	}
 
 	ServerAd struct {
-		Name         string
-		AuthURL      url.URL
-		URL          url.URL // This is server's XRootD URL for file transfer
-		WebURL       url.URL // This is server's Web interface and API
-		Type         ServerType
-		Latitude     float64
-		Longitude    float64
-		EnableWrite  bool
+		Name        string
+		AuthURL     url.URL
+		URL         url.URL // This is server's XRootD URL for file transfer
+		WebURL      url.URL // This is server's Web interface and API
+		Type        ServerType
+		Latitude    float64
+		Longitude   float64
+		EnableWrite bool
 	}
 
 	ServerType   string

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -45,7 +45,7 @@ type (
 		URL          string        `json:"url"`               // This is the url for origin's XRootD service and file transfer
 		WebURL       string        `json:"web_url,omitempty"` // This is the url for origin's web engine and APIs
 		Namespaces   []NamespaceAd `json:"namespaces"`
-		WriteEnabled bool          `json:"writeenabled"`
+		EnableWrite  bool          `json:"enablewrite"`
 	}
 )
 

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -41,11 +41,11 @@ import (
 
 type (
 	OriginAdvertise struct {
-		Name         string        `json:"name"`
-		URL          string        `json:"url"`               // This is the url for origin's XRootD service and file transfer
-		WebURL       string        `json:"web_url,omitempty"` // This is the url for origin's web engine and APIs
-		Namespaces   []NamespaceAd `json:"namespaces"`
-		EnableWrite  bool          `json:"enablewrite"`
+		Name        string        `json:"name"`
+		URL         string        `json:"url"`               // This is the url for origin's XRootD service and file transfer
+		WebURL      string        `json:"web_url,omitempty"` // This is the url for origin's web engine and APIs
+		Namespaces  []NamespaceAd `json:"namespaces"`
+		EnableWrite bool          `json:"enablewrite"`
 	}
 )
 

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -41,11 +41,12 @@ import (
 
 type (
 	OriginAdvertise struct {
-		Name        string        `json:"name"`
-		URL         string        `json:"url"`               // This is the url for origin's XRootD service and file transfer
-		WebURL      string        `json:"web_url,omitempty"` // This is the url for origin's web engine and APIs
-		Namespaces  []NamespaceAd `json:"namespaces"`
-		EnableWrite bool          `json:"enablewrite"`
+		Name               string        `json:"name"`
+		URL                string        `json:"url"`               // This is the url for origin's XRootD service and file transfer
+		WebURL             string        `json:"web_url,omitempty"` // This is the url for origin's web engine and APIs
+		Namespaces         []NamespaceAd `json:"namespaces"`
+		EnableWrite        bool          `json:"enablewrite"`
+		EnableFallbackRead bool          `json:"enable-fallback-read"` // True if the origin will allow direct client reads when no caches are available
 	}
 )
 

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -455,12 +455,12 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType ServerTy
 	}
 
 	sAd := ServerAd{
-		Name:         ad.Name,
-		AuthURL:      *ad_url,
-		URL:          *ad_url,
-		WebURL:       *adWebUrl,
-		Type:         sType,
-		EnableWrite:  ad.EnableWrite,
+		Name:        ad.Name,
+		AuthURL:     *ad_url,
+		URL:         *ad_url,
+		WebURL:      *adWebUrl,
+		Type:        sType,
+		EnableWrite: ad.EnableWrite,
 	}
 
 	hasOriginAdInCache := serverAds.Has(sAd)

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -344,6 +344,13 @@ func ShortcutMiddleware(defaultResponse string) gin.HandlerFunc {
 			c.Next()
 			return
 		}
+		// Regardless of the remainder of the settings, we currently handle a PUT as a query to the origin endpoint
+		if c.Request.Method == "PUT" {
+			c.Request.URL.Path = "/api/v1.0/director/origin" + c.Request.URL.Path
+			RedirectToOrigin(c)
+			c.Abort()
+			return
+		}
 
 		// We grab the host and x-forwarded-host headers, which can be set by a client with the intent of changing the
 		// Director's default behavior (eg the director normally forwards to caches, but if it receives a request with

--- a/director/redirect_test.go
+++ b/director/redirect_test.go
@@ -679,6 +679,13 @@ func TestRedirects(t *testing.T) {
 		expectedPath = "/api/v1.0/director/object/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
+		// test a PUT request always goes to the origin endpoint
+		req = httptest.NewRequest("PUT", "/foo/bar", nil)
+		c.Request = req
+		ShortcutMiddleware("cache")(c)
+		expectedPath = "/api/v1.0/director/origin/foo/bar"
+		assert.Equal(t, expectedPath, c.Request.URL.Path)
+
 		// Host-aware tests
 		// Test that we can turn on host-aware redirects and get one appropriate redirect from each
 		// type of header (as we've already tested that hostname redirects function)

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -309,6 +309,14 @@ type: bool
 default: true
 components: ["origin"]
 ---
+name: Origin.EnableFallbackRead
+description: >-
+  Set to `true` if the origin permits clients to directly read from it
+  when no cache service is available
+type: bool
+default: false
+components: ["origin"]
+---
 name: Origin.Multiuser
 description: >-
   A bool indicating whether an origin is "multiuser", ie whether the underlying XRootD instance must be configured in multi user mode.

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -302,9 +302,9 @@ type: string
 default: none
 components: ["origin"]
 ---
-name: Origin.WriteEnabled
+name: Origin.EnableWrite
 description: >-
-  A boolean indicating if an origin is writeable on startup
+  A boolean indicating if an origin allows write access
 type: bool
 default: true
 components: ["origin"]

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -65,11 +65,11 @@ func (server *OriginServer) CreateAdvertisement(name string, originUrl string, o
 		BasePath:      prefix,
 	}
 	ad = director.OriginAdvertise{
-		Name:         name,
-		URL:          originUrl,
-		WebURL:       originWebUrl,
-		Namespaces:   []director.NamespaceAd{nsAd},
-		EnableWrite:  enableWrite,
+		Name:        name,
+		URL:         originUrl,
+		WebURL:      originWebUrl,
+		Namespaces:  []director.NamespaceAd{nsAd},
+		EnableWrite: enableWrite,
 	}
 
 	return ad, nil

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -53,7 +53,6 @@ func (server *OriginServer) CreateAdvertisement(name string, originUrl string, o
 
 	prefix := param.Origin_NamespacePrefix.GetString()
 
-	enableWrite := param.Origin_EnableWrite.GetBool()
 	// TODO: Need to figure out where to get some of these values
 	// 		 so that they aren't hardcoded...
 	nsAd := director.NamespaceAd{
@@ -65,11 +64,12 @@ func (server *OriginServer) CreateAdvertisement(name string, originUrl string, o
 		BasePath:      prefix,
 	}
 	ad = director.OriginAdvertise{
-		Name:        name,
-		URL:         originUrl,
-		WebURL:      originWebUrl,
-		Namespaces:  []director.NamespaceAd{nsAd},
-		EnableWrite: enableWrite,
+		Name:               name,
+		URL:                originUrl,
+		WebURL:             originWebUrl,
+		Namespaces:         []director.NamespaceAd{nsAd},
+		EnableWrite:        param.Origin_EnableWrite.GetBool(),
+		EnableFallbackRead: param.Origin_EnableFallbackRead.GetBool(),
 	}
 
 	return ad, nil

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -53,7 +53,7 @@ func (server *OriginServer) CreateAdvertisement(name string, originUrl string, o
 
 	prefix := param.Origin_NamespacePrefix.GetString()
 
-	writeEnabled := param.Origin_WriteEnabled.GetBool()
+	enableWrite := param.Origin_EnableWrite.GetBool()
 	// TODO: Need to figure out where to get some of these values
 	// 		 so that they aren't hardcoded...
 	nsAd := director.NamespaceAd{
@@ -69,7 +69,7 @@ func (server *OriginServer) CreateAdvertisement(name string, originUrl string, o
 		URL:          originUrl,
 		WebURL:       originWebUrl,
 		Namespaces:   []director.NamespaceAd{nsAd},
-		WriteEnabled: writeEnabled,
+		EnableWrite:  enableWrite,
 	}
 
 	return ad, nil

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -170,6 +170,7 @@ var (
 	Monitoring_MetricAuthorization = BoolParam{"Monitoring.MetricAuthorization"}
 	Origin_EnableCmsd = BoolParam{"Origin.EnableCmsd"}
 	Origin_EnableDirListing = BoolParam{"Origin.EnableDirListing"}
+	Origin_EnableFallbackRead = BoolParam{"Origin.EnableFallbackRead"}
 	Origin_EnableIssuer = BoolParam{"Origin.EnableIssuer"}
 	Origin_EnableUI = BoolParam{"Origin.EnableUI"}
 	Origin_EnableVoms = BoolParam{"Origin.EnableVoms"}

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -173,10 +173,10 @@ var (
 	Origin_EnableIssuer = BoolParam{"Origin.EnableIssuer"}
 	Origin_EnableUI = BoolParam{"Origin.EnableUI"}
 	Origin_EnableVoms = BoolParam{"Origin.EnableVoms"}
+	Origin_EnableWrite = BoolParam{"Origin.EnableWrite"}
 	Origin_Multiuser = BoolParam{"Origin.Multiuser"}
 	Origin_ScitokensMapSubject = BoolParam{"Origin.ScitokensMapSubject"}
 	Origin_SelfTest = BoolParam{"Origin.SelfTest"}
-	Origin_WriteEnabled = BoolParam{"Origin.WriteEnabled"}
 	Registry_RequireKeyChaining = BoolParam{"Registry.RequireKeyChaining"}
 	Server_EnableUI = BoolParam{"Server.EnableUI"}
 	StagePlugin_Hook = BoolParam{"StagePlugin.Hook"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -84,6 +84,7 @@ type config struct {
 	Origin struct {
 		EnableCmsd bool
 		EnableDirListing bool
+		EnableFallbackRead bool
 		EnableIssuer bool
 		EnableUI bool
 		EnableVoms bool
@@ -247,6 +248,7 @@ type configWithType struct {
 	Origin struct {
 		EnableCmsd struct { Type string; Value bool }
 		EnableDirListing struct { Type string; Value bool }
+		EnableFallbackRead struct { Type string; Value bool }
 		EnableIssuer struct { Type string; Value bool }
 		EnableUI struct { Type string; Value bool }
 		EnableVoms struct { Type string; Value bool }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -87,6 +87,7 @@ type config struct {
 		EnableIssuer bool
 		EnableUI bool
 		EnableVoms bool
+		EnableWrite bool
 		ExportVolume string
 		Mode string
 		Multiuser bool
@@ -104,7 +105,6 @@ type config struct {
 		ScitokensUsernameClaim string
 		SelfTest bool
 		Url string
-		WriteEnabled bool
 		XRootDPrefix string
 	}
 	Plugin struct {
@@ -250,6 +250,7 @@ type configWithType struct {
 		EnableIssuer struct { Type string; Value bool }
 		EnableUI struct { Type string; Value bool }
 		EnableVoms struct { Type string; Value bool }
+		EnableWrite struct { Type string; Value bool }
 		ExportVolume struct { Type string; Value string }
 		Mode struct { Type string; Value string }
 		Multiuser struct { Type string; Value bool }
@@ -267,7 +268,6 @@ type configWithType struct {
 		ScitokensUsernameClaim struct { Type string; Value string }
 		SelfTest struct { Type string; Value bool }
 		Url struct { Type string; Value string }
-		WriteEnabled struct { Type string; Value bool }
 		XRootDPrefix struct { Type string; Value string }
 	}
 	Plugin struct {


### PR DESCRIPTION
These fixes are for PR #622 which helps reinstate backwards compatibility. Changes include:
- Returning `UploadFile` to its original state
- Running a PUT on the director to get PUT endpoint instead of a GET
   - Moved this logic to `client/main.go` when we gather ns info
- Moved the gathering of ns info to a separate function