### PR TITLE
Simple refactoring of director module

### DIFF
--- a/cache_ui/advertise.go
+++ b/cache_ui/advertise.go
@@ -30,8 +30,8 @@ type (
 	}
 )
 
-func (server *CacheServer) CreateAdvertisement(name string, originUrl string, originWebUrl string) (director.OriginAdvertise, error) {
-	ad := director.OriginAdvertise{
+func (server *CacheServer) CreateAdvertisement(name string, originUrl string, originWebUrl string) (director.ServerAdvertise, error) {
+	ad := director.ServerAdvertise{
 		Name:       name,
 		URL:        originUrl,
 		WebURL:     originWebUrl,

--- a/director/director.go
+++ b/director/director.go
@@ -41,7 +41,7 @@ type (
 	}
 )
 
-func (req listServerRequest) ToInternalServerType() ServerType {
+func (req listServerRequest) toInternalServerType() ServerType {
 	if req.ServerType == "cache" {
 		return CacheType
 	}
@@ -57,15 +57,15 @@ func listServers(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid query parameters"})
 		return
 	}
-	var servers []ServerAd
+	var servers []serverDesc
 	if queryParams.ServerType != "" {
 		if !strings.EqualFold(queryParams.ServerType, string(OriginType)) && !strings.EqualFold(queryParams.ServerType, string(CacheType)) {
 			ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid server type"})
 			return
 		}
-		servers = ListServerAds([]ServerType{ServerType(queryParams.ToInternalServerType())})
+		servers = listServerAds([]ServerType{ServerType(queryParams.toInternalServerType())})
 	} else {
-		servers = ListServerAds([]ServerType{OriginType, CacheType})
+		servers = listServerAds([]ServerType{OriginType, CacheType})
 
 	}
 	resList := make([]listServerResponse, 0)

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -35,7 +35,7 @@ import (
 )
 
 // List all namespaces from origins registered at the director
-func ListNamespacesFromOrigins() []NamespaceAd {
+func listNamespacesFromOrigins() []NamespaceAd {
 
 	serverAdMutex.RLock()
 	defer serverAdMutex.RUnlock()
@@ -51,10 +51,10 @@ func ListNamespacesFromOrigins() []NamespaceAd {
 }
 
 // List all serverAds in the cache that matches the serverType array
-func ListServerAds(serverTypes []ServerType) []ServerAd {
+func listServerAds(serverTypes []ServerType) []serverDesc {
 	serverAdMutex.RLock()
 	defer serverAdMutex.RUnlock()
-	ads := make([]ServerAd, 0)
+	ads := make([]serverDesc, 0)
 	for _, ad := range serverAds.Keys() {
 		for _, serverType := range serverTypes {
 			if ad.Type == serverType {
@@ -104,7 +104,7 @@ func CreateDirectorSDToken() (string, error) {
 // Verify that a token received is a valid token from director and has
 // correct scope for accessing the service discovery endpoint. This function
 // is intended to be called on the same director server that issues the token.
-func VerifyDirectorSDToken(strToken string) (bool, error) {
+func verifyDirectorSDToken(strToken string) (bool, error) {
 	// This token is essentialled an "issuer"/server itself issued token and
 	// the server happended to be a director. This allows us to just follow
 	// IssuerCheck logic for this token
@@ -189,7 +189,7 @@ func ConfigTTLCache(ctx context.Context, egrp *errgroup.Group) {
 	go serverAds.Start()
 	go namespaceKeys.Start()
 
-	serverAds.OnEviction(func(ctx context.Context, er ttlcache.EvictionReason, i *ttlcache.Item[ServerAd, []NamespaceAd]) {
+	serverAds.OnEviction(func(ctx context.Context, er ttlcache.EvictionReason, i *ttlcache.Item[serverDesc, []NamespaceAd]) {
 		healthTestCancelFuncsMutex.Lock()
 		defer healthTestCancelFuncsMutex.Unlock()
 		if cancelFunc, exists := healthTestCancelFuncs[i.Key()]; exists {

--- a/director/director_api_test.go
+++ b/director/director_api_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var mockOriginServerAd ServerAd = ServerAd{
+var mockOriginServerAd serverDesc = serverDesc{
 	Name:      "test-origin-server",
 	AuthURL:   url.URL{},
 	URL:       url.URL{},
@@ -19,7 +19,7 @@ var mockOriginServerAd ServerAd = ServerAd{
 	Longitude: 456.78,
 }
 
-var mockCacheServerAd ServerAd = ServerAd{
+var mockCacheServerAd serverDesc = serverDesc{
 	Name:      "test-cache-server",
 	AuthURL:   url.URL{},
 	URL:       url.URL{},
@@ -64,7 +64,7 @@ func TestListNamespaces(t *testing.T) {
 
 	t.Run("empty-entry", func(t *testing.T) {
 		setup()
-		ns := ListNamespacesFromOrigins()
+		ns := listNamespacesFromOrigins()
 
 		// Initially there should be 0 namespaces registered
 		assert.Equal(t, 0, len(ns), "List is not empty for empty namespace cache.")
@@ -72,7 +72,7 @@ func TestListNamespaces(t *testing.T) {
 	t.Run("one-origin-namespace-entry", func(t *testing.T) {
 		setup()
 		serverAds.Set(mockOriginServerAd, mockNamespaceAds(1, "origin1"), ttlcache.DefaultTTL)
-		ns := ListNamespacesFromOrigins()
+		ns := listNamespacesFromOrigins()
 
 		// Only one entry added
 		assert.Equal(t, 1, len(ns), "List has length not equal to 1 for namespace cache with 1 entry.")
@@ -81,7 +81,7 @@ func TestListNamespaces(t *testing.T) {
 	t.Run("multiple-origin-namespace-entries-from-same-origin", func(t *testing.T) {
 		setup()
 		serverAds.Set(mockOriginServerAd, mockNamespaceAds(10, "origin1"), ttlcache.DefaultTTL)
-		ns := ListNamespacesFromOrigins()
+		ns := listNamespacesFromOrigins()
 
 		assert.Equal(t, 10, len(ns), "List has length not equal to 10 for namespace cache with 10 entries.")
 		assert.True(t, namespaceAdContainsPath(ns, mockPathPreix+"origin1/"+fmt.Sprint(5)), "Returned namespace path does not match what's added")
@@ -96,7 +96,7 @@ func TestListNamespaces(t *testing.T) {
 		mockOriginServerAd.Name = "test-origin-server-2"
 
 		serverAds.Set(mockOriginServerAd, mockNamespaceAds(10, "origin2"), ttlcache.DefaultTTL)
-		ns := ListNamespacesFromOrigins()
+		ns := listNamespacesFromOrigins()
 
 		assert.Equal(t, 20, len(ns), "List has length not equal to 10 for namespace cache with 10 entries.")
 		assert.True(t, namespaceAdContainsPath(ns, mockPathPreix+"origin1/"+fmt.Sprint(5)), "Returned namespace path does not match what's added")
@@ -106,7 +106,7 @@ func TestListNamespaces(t *testing.T) {
 	t.Run("one-cache-namespace-entry", func(t *testing.T) {
 		setup()
 		serverAds.Set(mockCacheServerAd, mockNamespaceAds(1, "cache1"), ttlcache.DefaultTTL)
-		ns := ListNamespacesFromOrigins()
+		ns := listNamespacesFromOrigins()
 
 		// Should not show namespace from cache server
 		assert.Equal(t, 0, len(ns), "List is not empty for namespace cache with entry from cache server.")
@@ -121,7 +121,7 @@ func TestListServerAds(t *testing.T) {
 			defer serverAdMutex.Unlock()
 			serverAds.DeleteAll()
 		}()
-		ads := ListServerAds([]ServerType{OriginType, CacheType})
+		ads := listServerAds([]ServerType{OriginType, CacheType})
 		assert.Equal(t, 0, len(ads))
 	})
 
@@ -133,14 +133,14 @@ func TestListServerAds(t *testing.T) {
 		}()
 		serverAds.Set(mockOriginServerAd, []NamespaceAd{}, ttlcache.DefaultTTL)
 		serverAds.Set(mockCacheServerAd, []NamespaceAd{}, ttlcache.DefaultTTL)
-		adsAll := ListServerAds([]ServerType{OriginType, CacheType})
+		adsAll := listServerAds([]ServerType{OriginType, CacheType})
 		assert.Equal(t, 2, len(adsAll))
 
-		adsOrigin := ListServerAds([]ServerType{OriginType})
+		adsOrigin := listServerAds([]ServerType{OriginType})
 		require.Equal(t, 1, len(adsOrigin))
 		assert.True(t, adsOrigin[0] == mockOriginServerAd)
 
-		adsCache := ListServerAds([]ServerType{CacheType})
+		adsCache := listServerAds([]ServerType{CacheType})
 		require.Equal(t, 1, len(adsCache))
 		assert.True(t, adsCache[0] == mockCacheServerAd)
 	})

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -39,16 +39,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type (
-	OriginAdvertise struct {
-		Name         string        `json:"name"`
-		URL          string        `json:"url"`               // This is the url for origin's XRootD service and file transfer
-		WebURL       string        `json:"web_url,omitempty"` // This is the url for origin's web engine and APIs
-		Namespaces   []NamespaceAd `json:"namespaces"`
-		WriteEnabled bool          `json:"writeenabled"`
-	}
-)
-
 // Create interface
 // Add it to namespacekeys in place of jwk.cache
 type NamespaceCache interface {
@@ -110,7 +100,7 @@ func CreateAdvertiseToken(namespace string) (string, error) {
 // Given a token and a location in the namespace to advertise in,
 // see if the entity is authorized to advertise an origin for the
 // namespace
-func VerifyAdvertiseToken(ctx context.Context, token, namespace string) (bool, error) {
+func verifyAdvertiseToken(ctx context.Context, token, namespace string) (bool, error) {
 	issuerUrl, err := GetRegistryIssuerURL(namespace)
 	if err != nil {
 		return false, err
@@ -188,7 +178,7 @@ func VerifyAdvertiseToken(ctx context.Context, token, namespace string) (bool, e
 
 // Create a token for director to report the health status to the
 // origin
-func CreateDirectorTestReportToken(originWebUrl string) (string, error) {
+func createDirectorTestReportToken(originWebUrl string) (string, error) {
 	directorURL := param.Federation_DirectorUrl.GetString()
 	if directorURL == "" {
 		return "", errors.New("Director URL is not known; cannot create director test report token")

--- a/director/origin_api_test.go
+++ b/director/origin_api_test.go
@@ -65,7 +65,7 @@ func TestVerifyAdvertiseToken(t *testing.T) {
 	// A verified token with a the correct scope - should return no error
 	tok, err := CreateAdvertiseToken("test-namespace")
 	assert.NoError(t, err)
-	ok, err := VerifyAdvertiseToken(ctx, tok, "test-namespace")
+	ok, err := verifyAdvertiseToken(ctx, tok, "test-namespace")
 	assert.NoError(t, err)
 	assert.Equal(t, true, ok, "Expected scope to be 'pelican.advertise'")
 
@@ -82,7 +82,7 @@ func TestVerifyAdvertiseToken(t *testing.T) {
 
 	signed, err := jwt.Sign(scopelessTok, jwt.WithKey(jwa.ES256, key))
 
-	ok, err = VerifyAdvertiseToken(ctx, string(signed), "test-namespace")
+	ok, err = verifyAdvertiseToken(ctx, string(signed), "test-namespace")
 	assert.Equal(t, false, ok)
 	assert.Equal(t, "No scope is present; required to advertise to director", err.Error())
 
@@ -96,7 +96,7 @@ func TestVerifyAdvertiseToken(t *testing.T) {
 
 	signed, err = jwt.Sign(nonStrScopeTok, jwt.WithKey(jwa.ES256, key))
 
-	ok, err = VerifyAdvertiseToken(ctx, string(signed), "test-namespace")
+	ok, err = verifyAdvertiseToken(ctx, string(signed), "test-namespace")
 	assert.Equal(t, false, ok)
 	assert.Equal(t, "scope claim in token is not string-valued", err.Error())
 
@@ -110,7 +110,7 @@ func TestVerifyAdvertiseToken(t *testing.T) {
 
 	signed, err = jwt.Sign(wrongScopeTok, jwt.WithKey(jwa.ES256, key))
 
-	ok, err = VerifyAdvertiseToken(ctx, string(signed), "test-namespace")
+	ok, err = verifyAdvertiseToken(ctx, string(signed), "test-namespace")
 	assert.Equal(t, false, ok, "Should fail due to incorrect scope name")
 	assert.NoError(t, err, "Incorrect scope name should not throw and error")
 }

--- a/director/origin_monitor.go
+++ b/director/origin_monitor.go
@@ -45,7 +45,7 @@ type (
 
 // Report the health status of test file transfer to origin
 func reportStatusToOrigin(ctx context.Context, originWebUrl string, status string, message string) error {
-	tkn, err := CreateDirectorTestReportToken(originWebUrl)
+	tkn, err := createDirectorTestReportToken(originWebUrl)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create a token for the diretor test upload")
 	}
@@ -106,7 +106,7 @@ func reportStatusToOrigin(ctx context.Context, originWebUrl string, status strin
 
 // Run a periodic test file transfer against an origin to ensure
 // it's talking to the director
-func LaunchPeriodicDirectorTest(ctx context.Context, originAd ServerAd) {
+func launchPeriodicDirectorTest(ctx context.Context, originAd serverDesc) {
 	originName := originAd.Name
 	originUrl := originAd.URL.String()
 	originWebUrl := originAd.WebURL.String()

--- a/director/osdf_advertise.go
+++ b/director/osdf_advertise.go
@@ -31,8 +31,8 @@ import (
 	"github.com/pelicanplatform/pelican/utils"
 )
 
-func parseServerAd(server utils.Server, serverType ServerType) ServerAd {
-	serverAd := ServerAd{}
+func parseServerAd(server utils.Server, serverType ServerType) serverDesc {
+	serverAd := serverDesc{}
 	serverAd.Type = serverType
 	serverAd.Name = server.Resource
 
@@ -73,8 +73,8 @@ func AdvertiseOSDF() error {
 		return errors.Wrapf(err, "Failed to get topology JSON")
 	}
 
-	cacheAdMap := make(map[ServerAd][]NamespaceAd)
-	originAdMap := make(map[ServerAd][]NamespaceAd)
+	cacheAdMap := make(map[serverDesc][]NamespaceAd)
+	originAdMap := make(map[serverDesc][]NamespaceAd)
 	for _, ns := range namespaces.Namespaces {
 		nsAd := NamespaceAd{}
 		nsAd.RequireToken = ns.UseTokenOnRead
@@ -107,11 +107,11 @@ func AdvertiseOSDF() error {
 	}
 
 	for originAd, namespacesSlice := range originAdMap {
-		RecordAd(originAd, &namespacesSlice)
+		recordAd(originAd, &namespacesSlice)
 	}
 
 	for cacheAd, namespacesSlice := range cacheAdMap {
-		RecordAd(cacheAd, &namespacesSlice)
+		recordAd(cacheAd, &namespacesSlice)
 	}
 
 	return nil

--- a/director/osdf_advertise_test.go
+++ b/director/osdf_advertise_test.go
@@ -118,13 +118,13 @@ func TestAdvertiseOSDF(t *testing.T) {
 	}
 
 	// Test a few values. If they're correct, it indicates the whole process likely succeeded
-	nsAd, oAds, cAds := GetAdsForPath("/my/server/path/to/file")
+	nsAd, oAds, cAds := getAdsForPath("/my/server/path/to/file")
 	assert.Equal(t, nsAd.Path, "/my/server")
 	assert.Equal(t, nsAd.MaxScopeDepth, uint(3))
 	assert.Equal(t, oAds[0].AuthURL.String(), "https://origin1-auth-endpoint.com")
 	assert.Equal(t, cAds[0].URL.String(), "http://cache-endpoint.com")
 
-	nsAd, oAds, cAds = GetAdsForPath("/my/server/2/path/to/file")
+	nsAd, oAds, cAds = getAdsForPath("/my/server/2/path/to/file")
 	assert.Equal(t, nsAd.Path, "/my/server/2")
 	assert.Equal(t, nsAd.RequireToken, false)
 	assert.Equal(t, oAds[0].AuthURL.String(), "https://origin2-auth-endpoint.com")

--- a/director/redirect_test.go
+++ b/director/redirect_test.go
@@ -181,7 +181,7 @@ func TestDirectorRegistration(t *testing.T) {
 		isurl := url.URL{}
 		isurl.Path = "https://get-your-tokens.org"
 
-		ad := OriginAdvertise{Name: "test", URL: "https://or-url.org", Namespaces: []NamespaceAd{{Path: "/foo/bar", Issuer: isurl}}}
+		ad := ServerAdvertise{Name: "test", URL: "https://or-url.org", Namespaces: []NamespaceAd{{Path: "/foo/bar", Issuer: isurl}}}
 
 		jsonad, err := json.Marshal(ad)
 		assert.NoError(t, err, "Error marshalling OriginAdvertise")
@@ -193,7 +193,7 @@ func TestDirectorRegistration(t *testing.T) {
 		// Check to see that the code exits with status code 200 after given it a good token
 		assert.Equal(t, 200, w.Result().StatusCode, "Expected status code of 200")
 
-		namaspaceADs := ListNamespacesFromOrigins()
+		namaspaceADs := listNamespacesFromOrigins()
 		// If the origin was successfully registed at director, we should be able to find it in director's originAds
 		assert.True(t, NamespaceAdContainsPath(namaspaceADs, "/foo/bar"), "Coudln't find namespace in the director cache.")
 		teardown()
@@ -214,7 +214,7 @@ func TestDirectorRegistration(t *testing.T) {
 		isurl := url.URL{}
 		isurl.Path = "https://get-your-tokens.org"
 
-		ad := OriginAdvertise{Name: "test", URL: "https://or-url.org", Namespaces: []NamespaceAd{{Path: "/foo/bar", Issuer: isurl}}}
+		ad := ServerAdvertise{Name: "test", URL: "https://or-url.org", Namespaces: []NamespaceAd{{Path: "/foo/bar", Issuer: isurl}}}
 
 		jsonad, err := json.Marshal(ad)
 		assert.NoError(t, err, "Error marshalling OriginAdvertise")
@@ -227,7 +227,7 @@ func TestDirectorRegistration(t *testing.T) {
 		body, _ := io.ReadAll(w.Result().Body)
 		assert.Equal(t, `{"error":"Authorization token verification failed"}`, string(body), "Failure wasn't because token verification failed")
 
-		namaspaceADs := ListNamespacesFromOrigins()
+		namaspaceADs := listNamespacesFromOrigins()
 		assert.False(t, NamespaceAdContainsPath(namaspaceADs, "/foo/bar"), "Found namespace in the director cache even if the token validation failed.")
 		teardown()
 	})
@@ -243,7 +243,7 @@ func TestDirectorRegistration(t *testing.T) {
 		isurl := url.URL{}
 		isurl.Path = "https://get-your-tokens.org"
 
-		ad := OriginAdvertise{WebURL: "https://localhost:8844", Namespaces: []NamespaceAd{{Path: "/foo/bar", Issuer: isurl}}}
+		ad := ServerAdvertise{WebURL: "https://localhost:8844", Namespaces: []NamespaceAd{{Path: "/foo/bar", Issuer: isurl}}}
 
 		jsonad, err := json.Marshal(ad)
 		assert.NoError(t, err, "Error marshalling OriginAdvertise")
@@ -270,7 +270,7 @@ func TestDirectorRegistration(t *testing.T) {
 		isurl := url.URL{}
 		isurl.Path = "https://get-your-tokens.org"
 
-		ad := OriginAdvertise{Namespaces: []NamespaceAd{{Path: "/foo/bar", Issuer: isurl}}}
+		ad := ServerAdvertise{Namespaces: []NamespaceAd{{Path: "/foo/bar", Issuer: isurl}}}
 
 		jsonad, err := json.Marshal(ad)
 		assert.NoError(t, err, "Error marshalling OriginAdvertise")
@@ -321,7 +321,7 @@ func TestGetAuthzEscaped(t *testing.T) {
 }
 
 func TestDiscoverOriginCache(t *testing.T) {
-	mockPelicanOriginServerAd := ServerAd{
+	mockPelicanOriginServerAd := serverDesc{
 		Name:    "1-test-origin-server",
 		AuthURL: url.URL{},
 		URL: url.URL{
@@ -337,7 +337,7 @@ func TestDiscoverOriginCache(t *testing.T) {
 		Longitude: 456.78,
 	}
 
-	mockTopoOriginServerAd := ServerAd{
+	mockTopoOriginServerAd := serverDesc{
 		Name:    "test-topology-origin-server",
 		AuthURL: url.URL{},
 		URL: url.URL{
@@ -349,7 +349,7 @@ func TestDiscoverOriginCache(t *testing.T) {
 		Longitude: 456.78,
 	}
 
-	mockCacheServerAd := ServerAd{
+	mockCacheServerAd := serverDesc{
 		Name:    "2-test-cache-server",
 		AuthURL: url.URL{},
 		URL: url.URL{
@@ -448,7 +448,7 @@ func TestDiscoverOriginCache(t *testing.T) {
 	}
 
 	r := gin.Default()
-	r.GET("/test", DiscoverOriginCache)
+	r.GET("/test", discoverOriginCache)
 
 	t.Run("no-token-should-give-401", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "/test", nil)

--- a/director/register.go
+++ b/director/register.go
@@ -1,0 +1,161 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package director
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
+)
+
+type (
+	// Wire format for advertising a server (cache, origin) to the director.
+	ServerAdvertise struct {
+		Name         string        `json:"name"`
+		URL          string        `json:"url"`               // This is the url for origin's XRootD service and file transfer
+		WebURL       string        `json:"web_url,omitempty"` // This is the url for origin's web engine and APIs
+		Namespaces   []NamespaceAd `json:"namespaces"`
+		WriteEnabled bool          `json:"writeenabled"`
+	}
+
+	// Wire format describing a namespace that a (cache, origin) server is willing
+	// to service.
+	NamespaceAd struct {
+		RequireToken  bool         `json:"requireToken"`
+		Path          string       `json:"path"`
+		Issuer        url.URL      `json:"url"`
+		MaxScopeDepth uint         `json:"maxScopeDepth"`
+		Strategy      StrategyType `json:"strategy"`
+		BasePath      string       `json:"basePath"`
+		VaultServer   string       `json:"vaultServer"`
+		DirlistHost   string       `json:"dirlisthost"`
+	}
+)
+
+func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType ServerType) {
+	tokens, present := ctx.Request.Header["Authorization"]
+	if !present || len(tokens) == 0 {
+		ctx.JSON(http.StatusForbidden, gin.H{"error": "Bearer token not present in the 'Authorization' header"})
+		return
+	}
+
+	err := versionCompatCheck(ctx)
+	if err != nil {
+		log.Debugf("A version incompatibility was encountered while registering %s and no response was served: %v", sType, err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Incompatible versions detected: " + fmt.Sprintf("%v", err)})
+		return
+	}
+
+	ad := ServerAdvertise{}
+	if ctx.ShouldBind(&ad) != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid " + sType + " registration"})
+		return
+	}
+
+	if sType == OriginType {
+		for _, namespace := range ad.Namespaces {
+			// We're assuming there's only one token in the slice
+			token := strings.TrimPrefix(tokens[0], "Bearer ")
+			ok, err := verifyAdvertiseToken(engineCtx, token, namespace.Path)
+			if err != nil {
+				log.Warningln("Failed to verify token:", err)
+				ctx.JSON(http.StatusForbidden, gin.H{"error": "Authorization token verification failed"})
+				return
+			}
+			if !ok {
+				log.Warningf("%s %v advertised to namespace %v without valid registration\n",
+					sType, ad.Name, namespace.Path)
+				ctx.JSON(http.StatusForbidden, gin.H{"error": sType + " not authorized to advertise to this namespace"})
+				return
+			}
+		}
+	} else {
+		token := strings.TrimPrefix(tokens[0], "Bearer ")
+		prefix := path.Join("caches", ad.Name)
+		ok, err := verifyAdvertiseToken(engineCtx, token, prefix)
+		if err != nil {
+			if err == adminApprovalErr {
+				log.Warningln("Failed to verify token. Cache was not approved:", err)
+				ctx.JSON(http.StatusForbidden, gin.H{"error": "Cache is not admin approved"})
+			} else {
+				log.Warningln("Failed to verify token:", err)
+				ctx.JSON(http.StatusForbidden, gin.H{"error": "Authorization token verification failed"})
+			}
+			return
+		}
+		if !ok {
+			log.Warningf("%s %v advertised to namespace %v without valid registration\n",
+				sType, ad.Name, prefix)
+			ctx.JSON(http.StatusForbidden, gin.H{"error": sType + " not authorized to advertise to this namespace"})
+			return
+		}
+	}
+
+	ad_url, err := url.Parse(ad.URL)
+	if err != nil {
+		log.Warningf("Failed to parse %s URL %v: %v\n", sType, ad.URL, err)
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid " + sType + " URL"})
+		return
+	}
+
+	adWebUrl, err := url.Parse(ad.WebURL)
+	if err != nil && ad.WebURL != "" { // We allow empty WebURL string for backward compatibility
+		log.Warningf("Failed to parse origin Web URL %v: %v\n", ad.WebURL, err)
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid origin Web URL"})
+		return
+	}
+
+	sAd := serverDesc{
+		Name:         ad.Name,
+		AuthURL:      *ad_url,
+		URL:          *ad_url,
+		WebURL:       *adWebUrl,
+		Type:         sType,
+		WriteEnabled: ad.WriteEnabled,
+	}
+
+	hasOriginAdInCache := serverAds.Has(sAd)
+	recordAd(sAd, &ad.Namespaces)
+
+	// Start director periodic test of origin's health status if origin AD
+	// has WebURL field AND it's not already been registered
+	healthTestCancelFuncsMutex.Lock()
+	defer healthTestCancelFuncsMutex.Unlock()
+	if ad.WebURL != "" && !hasOriginAdInCache {
+		ctx, cancel := context.WithCancel(context.Background())
+		healthTestCancelFuncs[sAd] = cancel
+		launchPeriodicDirectorTest(ctx, sAd)
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"msg": "Successful registration"})
+}
+
+func RegisterOrigin(ctx context.Context, gctx *gin.Context) {
+	registerServeAd(ctx, gctx, OriginType)
+}
+
+func RegisterCache(ctx context.Context, gctx *gin.Context) {
+	registerServeAd(ctx, gctx, CacheType)
+}

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -39,8 +39,8 @@ func (server *OriginServer) GetServerType() config.ServerType {
 	return config.OriginType
 }
 
-func (server *OriginServer) CreateAdvertisement(name string, originUrl string, originWebUrl string) (director.OriginAdvertise, error) {
-	ad := director.OriginAdvertise{}
+func (server *OriginServer) CreateAdvertisement(name string, originUrl string, originWebUrl string) (director.ServerAdvertise, error) {
+	ad := director.ServerAdvertise{}
 
 	// Here we instantiate the namespaceAd slice, but we still need to define the namespace
 	issuerUrl := url.URL{}
@@ -64,7 +64,7 @@ func (server *OriginServer) CreateAdvertisement(name string, originUrl string, o
 		Strategy:      "OAuth2",
 		BasePath:      prefix,
 	}
-	ad = director.OriginAdvertise{
+	ad = director.ServerAdvertise{
 		Name:         name,
 		URL:          originUrl,
 		WebURL:       originWebUrl,

--- a/server_utils/server_struct.go
+++ b/server_utils/server_struct.go
@@ -28,7 +28,7 @@ type (
 		GetServerType() config.ServerType
 		SetNamespaceAds([]director.NamespaceAd)
 		GetNamespaceAds() []director.NamespaceAd
-		CreateAdvertisement(name string, serverUrl string, serverWebUrl string) (director.OriginAdvertise, error)
+		CreateAdvertisement(name string, serverUrl string, serverWebUrl string) (director.ServerAdvertise, error)
 	}
 
 	NamespaceHolder struct {


### PR DESCRIPTION
- Do not export internal methods or types
- Rename `advertise` to make it clear it's only for OSDF
- Break out the registration functions from redirect.go

Do not merge until after 7.4.0 release.  There should be no functional changes, just renames and hiding symbols from outside the director package.