### PR TITLE
Fixes to how param_struct is generated

### DIFF
--- a/generate/param_generator.go
+++ b/generate/param_generator.go
@@ -417,5 +417,4 @@ import (
 
 {{.GeneratedConfig}}
 
-{{.GeneratedConfigWithType}}
-`))
+{{.GeneratedConfigWithType}}`))


### PR DESCRIPTION
I was having issues with param_generator making param_struct.go have an extra new line at the bottom whenever it was generated. Go-linter does not like this so I have to `git restore` it every time I want to commit. This should fix that (hopefully it's not just me having this issue)