### PR TITLE
Improved common Web API endpoint

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -179,11 +180,42 @@ func IsServerEnabled(testServer ServerType) bool {
 	return enabledServers.IsEnabled(testServer)
 }
 
+// Get a string slice of currently enabled servers, sorted by alphabetical order.
+// By default, it calls String method of each enabled server.
+// To get strings in lowerCase, set lowerCase = true.
+func GetEnabledServerString(lowerCase bool) []string {
+	servers := make([]string, 0)
+	if enabledServers.IsEnabled(CacheType) {
+		servers = append(servers, CacheType.String())
+	}
+	if enabledServers.IsEnabled(OriginType) {
+		servers = append(servers, OriginType.String())
+	}
+	if enabledServers.IsEnabled(DirectorType) {
+		servers = append(servers, DirectorType.String())
+	}
+	if enabledServers.IsEnabled(RegistryType) {
+		servers = append(servers, RegistryType.String())
+	}
+	sort.Strings(servers)
+	if lowerCase {
+		for i, serverStr := range servers {
+			servers[i] = strings.ToLower(serverStr)
+		}
+		return servers
+	} else {
+		return servers
+	}
+}
+
 // Create a new, empty ServerType bitmask
 func NewServerType() ServerType {
 	return ServerType(0)
 }
 
+// Get the string representation of a ServerType instance. This is intended
+// for getting the string form of a single ServerType contant, such as CacheType
+// OriginType, etc. To get a string slice of enabled servers, use EnabledServerString()
 func (sType ServerType) String() string {
 	switch sType {
 	case CacheType:
@@ -196,23 +228,6 @@ func (sType ServerType) String() string {
 		return "Registry"
 	}
 	return "Unknown"
-}
-
-func EnabledServers() []string {
-	servers := make([]string, 0)
-	if enabledServers.IsEnabled(CacheType) {
-		servers = append(servers, "cache")
-	}
-	if enabledServers.IsEnabled(OriginType) {
-		servers = append(servers, "origin")
-	}
-	if enabledServers.IsEnabled(DirectorType) {
-		servers = append(servers, "director")
-	}
-	if enabledServers.IsEnabled(RegistryType) {
-		servers = append(servers, "registry")
-	}
-	return servers
 }
 
 func (sType *ServerType) SetString(name string) bool {

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -147,7 +147,7 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (context.Canc
 		return nil
 	})
 
-	if err = server_utils.WaitUntilWorking(ctx, "GET", param.Server_ExternalWebUrl.GetString()+"/api/v1.0/servers", "Web UI", http.StatusOK); err != nil {
+	if err = server_utils.WaitUntilWorking(ctx, "GET", param.Server_ExternalWebUrl.GetString()+"/api/v1.0/health", "Web UI", http.StatusOK); err != nil {
 		log.Errorln("Web engine startup appears to have failed:", err)
 		return shutdownCancel, err
 	}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -332,3 +332,4 @@ type configWithType struct {
 		SummaryMonitoringHost struct { Type string; Value string }
 	}
 }
+

--- a/web_ui/frontend/app/(landing)/page.tsx
+++ b/web_ui/frontend/app/(landing)/page.tsx
@@ -51,7 +51,7 @@ export default function Home() {
             try {
                 const res = await fetch("/api/v1.0/servers")
                 const data = await res.json()
-                setEnabledServers(data)
+                setEnabledServers(data?.servers)
             } catch {
                 setEnabledServers(["origin", "director", "registry"])
             }

--- a/web_ui/frontend/app/(login)/login/page.tsx
+++ b/web_ui/frontend/app/(login)/login/page.tsx
@@ -39,7 +39,7 @@ export default function Home() {
             const response = await fetch("/api/v1.0/servers")
             if (response.ok) {
                 const data = await response.json()
-                setEnabledServers(data)
+                setEnabledServers(data?.servers)
             }
         })()
     }, []);

--- a/web_ui/frontend/app/api/docs/pelican-swagger.yaml
+++ b/web_ui/frontend/app/api/docs/pelican-swagger.yaml
@@ -247,38 +247,19 @@ tags:
     description: Authentication APIs for all servers
   - name: common
     description: Common APIs for all servers
+  - name: metrics
+    description: APIs for various server metrics
   - name: registry_ui
     description: APIs for Registry server Web UI
 paths:
   /health:
     get:
       tags:
-        - common
-      summary: Returns the health status of server components
-      description: "`Authentication Required`"
-      produces:
-        - application/json
+        - "common"
+      summary: Health check endpoint for server Web engine
       responses:
         "200":
-          description: OK
-          schema:
-            type: object
-            properties:
-              status:
-                type: string
-                description: The overall health status of the server
-              components:
-                type: object
-                description: The health status of each server components
-                properties:
-                  cmsd:
-                    $ref: "#/definitions/HealthStatus"
-                  federation:
-                    $ref: "#/definitions/HealthStatus"
-                  web-ui:
-                    $ref: "#/definitions/HealthStatus"
-                  xrootd:
-                    $ref: "#/definitions/HealthStatus"
+          description: "Server Web engine is running and taking requests"
   /config:
     get:
       tags:
@@ -332,21 +313,58 @@ paths:
       tags:
         - common
       summary: Returns a list of enabled servers
+      description: "`Authentication Required`
+
+        Server names are in lower-case, sorted in alphabetical order.
+        "
       produces:
         - application/json
       responses:
         "200":
           description: OK
           schema:
-            type: array
-            items:
-              type: string
-              minItems: 1
+            type: object
+            properties:
+              servers:
+                type: array
+                items:
+                  type: string
+                  minItems: 1
+                example: ["director", "origin", "registry"]
         "500":
           description: Server encountered error in reading institution configuration
           schema:
             type: object
             $ref: "#/definitions/ErrorModel"
+  /metrics/health:
+    get:
+      tags:
+        - metrics
+      summary: Returns the health status of server components
+      description: "`Authentication Required`"
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                description: The overall health status of the server
+              components:
+                type: object
+                description: The health status of each server components
+                properties:
+                  cmsd:
+                    $ref: "#/definitions/HealthStatus"
+                  federation:
+                    $ref: "#/definitions/HealthStatus"
+                  web-ui:
+                    $ref: "#/definitions/HealthStatus"
+                  xrootd:
+                    $ref: "#/definitions/HealthStatus"
   /auth/login:
     post:
       tags:

--- a/web_ui/frontend/app/api/docs/pelican-swagger.yaml
+++ b/web_ui/frontend/app/api/docs/pelican-swagger.yaml
@@ -257,9 +257,17 @@ paths:
       tags:
         - "common"
       summary: Health check endpoint for server Web engine
+      produces:
+        - application/json
       responses:
         "200":
           description: "Server Web engine is running and taking requests"
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: "Web Engine Running. Time: 2024-01-10 22:32:59.637471175 +0000 UTC m=+35.515010725"
   /config:
     get:
       tags:

--- a/web_ui/frontend/app/config/page.tsx
+++ b/web_ui/frontend/app/config/page.tsx
@@ -311,7 +311,7 @@ export default function Config() {
         try {
             const res = await fetch("/api/v1.0/servers")
             const data = await res.json()
-            setEnabledServers(data)
+            setEnabledServers(data?.servers)
         } catch {
             setEnabledServers(["origin", "director", "registry"])
         }

--- a/web_ui/frontend/components/StatusBox.tsx
+++ b/web_ui/frontend/components/StatusBox.tsx
@@ -94,7 +94,7 @@ export default function StatusBox() {
     const [error, setError] = useState<string | undefined>(undefined)
 
     let getStatus = async () => {
-        let response = await fetch("/api/v1.0/health")
+        let response = await fetch("/api/v1.0/metrics/health")
 
         if(response.ok) {
             let data = await response.json()


### PR DESCRIPTION
Fixes #588 by renaming the function `EnabledServers` to `GetEnabledServerString`. Preserved the *ServerType.String() function to return the string representation of a single ServerType enum. Added function comment to explain.

* Put `/server` api behind the auth, as well as restructured the return value from array to json object with `{servers: []}`. Updated UI accordingly
* The above change breaks the server self check at launch time, as it depends on `/server` to tell if the web engine is working, so changed that to check `/health` instead
* However, `/health` was used to get the server component health status, so renamed original `/health` endpoint to `/metrics/health` and use `/health` to only provide a public health check  endpoint of web engine.

