### PR TITLE
Take a URL from config value to fetch institution list for Registry 

### DIFF
--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -33,6 +33,8 @@ Origin:
   EnableUI: true
   EnableWrite: true
   SelfTest: true
+Registry:
+  InstitutionsUrlReloadMinutes: 15m
 Monitoring:
   PortLower: 9930
   PortHigher: 9999
@@ -55,7 +57,7 @@ Transport:
   ExpectContinueTimeout: 1s
   ResponseHeaderTimeout: 10s
 OIDC:
-  AuthorizationEndpoint:  "https://cilogon.org/authorize"
+  AuthorizationEndpoint: "https://cilogon.org/authorize"
   DeviceAuthEndpoint: "https://cilogon.org/oauth2/device_authorization"
   TokenEndpoint: "https://cilogon.org/oauth2/token"
   UserInfoEndpoint: "https://cilogon.org/oauth2/userinfo"

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -606,7 +606,7 @@ components: ["nsregistry"]
 ---
 name: Registry.InstitutionsUrl
 description: >-
-  A url to get a list of available institutions for users to regiter their namespaces to. 
+  A url to get a list of available institutions for users to register their namespaces to.
   The url must accept a GET request with 200 response in JSON/YAML content with the following format:
 
   JSON:

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -130,7 +130,6 @@ type: object
 default: none
 components: ["director"]
 ---
-
 ############################
 #     Log-Level Configs    #
 ############################
@@ -206,7 +205,7 @@ name: Federation.TopologyReloadInterval
 description: >-
   The frequency, in minutes, that topology should be reloaded.
 type: duration
-osdf_default: 10
+osdf_default: 10m
 default: none
 components: ["director", "nsregistry"]
 ---
@@ -600,8 +599,46 @@ description: >-
     id: https://osg-htc.org/iid/01y2jtd41
   ```
 
+  Note that this value will take precedence over Registry.InstitutionsUrl if both are set
 type: object
 default: none
+components: ["nsregistry"]
+---
+name: Registry.InstitutionsUrl
+description: >-
+  A url to get a list of available institutions for users to regiter their namespaces to. 
+  The url must accept a GET request with 200 response in JSON/YAML content with the following format:
+
+  JSON:
+  ```JSON
+    [
+      {
+        "name": "University of Wisconsin - Madison",
+        "id": " https://osg-htc.org/iid/01y2jtd41"
+      }
+    ]
+  ```
+
+  YAML:
+  ```yaml
+    ---
+    - name: University of Wisconsin - Madison
+      id: " https://osg-htc.org/iid/01y2jtd41"
+  ```
+
+  where the id field will be stored in registry database and must be unique, and name field will be displayed in UI as the option.
+
+  Note that Pelican will cache the response of the url in a TTL cache with default refresh time of 15 minutes.
+  Also note that Registry.Institutions will take precedence over this value if both are set.
+type: url
+default: none
+components: ["nsregistry"]
+---
+name: Registry.InstitutionsUrlReloadMinutes
+description: >-
+  Number of minutes that the Registry.InstitutionsUrl will be reloaded into the TTL cache.
+type: duration
+default: 15m
 components: ["nsregistry"]
 ---
 ############################

--- a/launchers/registry_serve.go
+++ b/launchers/registry_serve.go
@@ -57,7 +57,7 @@ func RegistryServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group
 		if err := web_ui.ConfigOAuthClientAPIs(engine); err != nil {
 			return err
 		}
-		if err := registry.InitInstConfig(); err != nil {
+		if err := registry.InitInstConfig(ctx, egrp); err != nil {
 			return err
 		}
 	}

--- a/launchers/registry_serve.go
+++ b/launchers/registry_serve.go
@@ -57,6 +57,9 @@ func RegistryServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group
 		if err := web_ui.ConfigOAuthClientAPIs(engine); err != nil {
 			return err
 		}
+		if err := registry.InitInstConfig(); err != nil {
+			return err
+		}
 	}
 
 	rootRouterGroup := engine.Group("/")

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -105,6 +105,7 @@ var (
 	Origin_XRootDPrefix = StringParam{"Origin.XRootDPrefix"}
 	Plugin_Token = StringParam{"Plugin.Token"}
 	Registry_DbLocation = StringParam{"Registry.DbLocation"}
+	Registry_InstitutionsUrl = StringParam{"Registry.InstitutionsUrl"}
 	Server_ExternalWebUrl = StringParam{"Server.ExternalWebUrl"}
 	Server_Hostname = StringParam{"Server.Hostname"}
 	Server_IssuerHostname = StringParam{"Server.IssuerHostname"}
@@ -188,6 +189,7 @@ var (
 	Federation_TopologyReloadInterval = DurationParam{"Federation.TopologyReloadInterval"}
 	Monitoring_TokenExpiresIn = DurationParam{"Monitoring.TokenExpiresIn"}
 	Monitoring_TokenRefreshInterval = DurationParam{"Monitoring.TokenRefreshInterval"}
+	Registry_InstitutionsUrlReloadMinutes = DurationParam{"Registry.InstitutionsUrlReloadMinutes"}
 	Transport_DialerKeepAlive = DurationParam{"Transport.DialerKeepAlive"}
 	Transport_DialerTimeout = DurationParam{"Transport.DialerTimeout"}
 	Transport_ExpectContinueTimeout = DurationParam{"Transport.ExpectContinueTimeout"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -115,6 +115,8 @@ type config struct {
 		AdminUsers []string
 		DbLocation string
 		Institutions interface{}
+		InstitutionsUrl string
+		InstitutionsUrlReloadMinutes time.Duration
 		RequireKeyChaining bool
 	}
 	Server struct {
@@ -279,6 +281,8 @@ type configWithType struct {
 		AdminUsers struct { Type string; Value []string }
 		DbLocation struct { Type string; Value string }
 		Institutions struct { Type string; Value interface{} }
+		InstitutionsUrl struct { Type string; Value string }
+		InstitutionsUrlReloadMinutes struct { Type string; Value time.Duration }
 		RequireKeyChaining struct { Type string; Value bool }
 	}
 	Server struct {

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -61,7 +61,7 @@ type (
 
 	Institution struct {
 		Name string `mapstructure:"name" json:"name" yaml:"name"`
-		ID   string `mapstructure:"id" json:"id" yaml:"name"`
+		ID   string `mapstructure:"id" json:"id" yaml:"id"`
 	}
 )
 

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -731,7 +731,7 @@ func InitInstConfig(ctx context.Context, egrp *errgroup.Group) error {
 		// Try to populate the cache at the server start. If error occured, it's non-blocking
 		cachedInsts, intErr, _ := getCachedInstitutions()
 		if intErr != nil {
-			log.Warning("Failed to populate institution cache. It's non-blocking. Error: ", intErr)
+			log.Warning("Failed to populate institution cache. Error: ", intErr)
 		} else {
 			if !checkUniqueInstitutions(cachedInsts) {
 				return errors.Errorf("Institution IDs read from config are not unique")

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -21,16 +21,21 @@ package registry
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jellydator/ttlcache/v3"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/web_ui"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -53,8 +58,8 @@ type (
 	}
 
 	Institution struct {
-		Name string `mapstructure:"name" json:"name"`
-		ID   string `mapstructure:"id" json:"id"`
+		Name string `mapstructure:"name" json:"name" yaml:"name"`
+		ID   string `mapstructure:"id" json:"id" yaml:"name"`
 	}
 )
 
@@ -66,7 +71,9 @@ const (
 )
 
 var (
-	registrationFields []registrationField
+	registrationFields     []registrationField
+	institutionsCache      *ttlcache.Cache[string, []Institution]
+	institutionsCacheMutex = sync.RWMutex{}
 )
 
 func init() {
@@ -166,6 +173,88 @@ func excludePubKey(nss []*Namespace) (nssNew []NamespaceWOPubkey) {
 	}
 
 	return
+}
+
+func checkUniqueInstitutions(insts []Institution) bool {
+	repeatMap := make(map[string]bool)
+	for _, inst := range insts {
+		if repeatMap[inst.ID] {
+			return false
+		} else {
+			repeatMap[inst.ID] = true
+		}
+	}
+	return true
+}
+
+func getCachedInstitutions() (inst []Institution, intError error, extError error) {
+	if institutionsCache == nil {
+		return nil, errors.New("institutionsCache isn't initialized"), errors.New("Internal institution cache wasn't initialized")
+	}
+	instUrlStr := param.Registry_InstitutionsUrl.GetString()
+	if instUrlStr == "" {
+		intError = errors.New("Bad server configuration. Registry.InstitutionsUrl is unset")
+		extError = errors.New("Bad server configuration. Registry.InstitutionsUrl is unset")
+		return
+	}
+	instUrl, err := url.Parse(instUrlStr)
+	if err != nil {
+		intError = errors.Wrap(err, "Bad server configuration. Registry.InstitutionsUrl is invalid")
+		extError = errors.New("Bad server configuration. Registry.InstitutionsUrl is invalid")
+		return
+	}
+	if !institutionsCache.Has(instUrl.String()) {
+		log.Info("Cache miss for institutions TTL cache. Will fetch from source.")
+		client := &http.Client{Transport: config.GetTransport()}
+		req, err := http.NewRequest("GET", instUrl.String(), nil)
+		if err != nil {
+			intError = errors.Wrap(err, "Error making a request when fetching institution list")
+			extError = errors.New("Error when creating a request to fetch institution from remote url.")
+			return
+		}
+		res, err := client.Do(req)
+		if err != nil {
+			intError = errors.Wrap(err, "Error response when fetching institution list")
+			extError = errors.New("Error from response when fetching institution from remote url.")
+			return
+		}
+		if res.StatusCode != 200 {
+			intError = errors.Wrap(err, fmt.Sprintf("Error response when fetching institution list with code %d", res.StatusCode))
+			extError = errors.New(fmt.Sprint("Error when fetching institution from remote url, remote server error with code: ", res.StatusCode))
+			return
+		}
+		resBody, err := io.ReadAll(res.Body)
+		if err != nil {
+			intError = errors.Wrap(err, "Error reading response body when fetching institution list")
+			extError = errors.New("Error read response when fetching institution from remote url.")
+			return
+		}
+		institutions := []Institution{}
+		if err = json.Unmarshal(resBody, &institutions); err != nil {
+			intError = errors.Wrap(err, "Error parsing response body when fetching institution list")
+			extError = errors.New("Error parsing response when fetching institution from remote url.")
+			return
+		}
+		institutionsCacheMutex.Lock()
+		defer institutionsCacheMutex.Unlock()
+		institutionsCache.Set(instUrl.String(), institutions, ttlcache.DefaultTTL)
+		return institutions, nil, nil
+	} else {
+		institutionsCacheMutex.RLock()
+		defer institutionsCacheMutex.RUnlock()
+		institutions := institutionsCache.Get(instUrl.String())
+		if institutions.Value() == nil {
+			intError = errors.New(fmt.Sprint("Fail to get institutions from internal TTL cache, value is nil from key: ", instUrl))
+			extError = errors.New("Fail to get institutions from internal TTL cache")
+			return
+		}
+		if institutions.IsExpired() {
+			intError = errors.New(fmt.Sprintf("Cached institution with key %q is expired at %v", institutions.Key(), institutions.ExpiresAt()))
+			extError = errors.New("Expired institution cache")
+			return
+		}
+		return institutions.Value(), nil, nil
+	}
 }
 
 // List all namespaces in the registry.
@@ -522,6 +611,22 @@ func getNamespaceJWKS(ctx *gin.Context) {
 }
 
 func listInstitutions(ctx *gin.Context) {
+	// When Registry.InstitutionsUrl is set and Registry.Institutions is unset
+	if institutionsCache != nil {
+		insts, intErr, extErr := getCachedInstitutions()
+		if intErr != nil || extErr != nil {
+			if intErr != nil {
+				log.Error(intErr)
+			}
+			if extErr != nil {
+				ctx.JSON(http.StatusInternalServerError, gin.H{"error": extErr.Error()})
+			}
+			return
+		}
+		ctx.JSON(http.StatusOK, insts)
+		return
+	}
+	// When Registry.Institutions is set
 	institutions := []Institution{}
 	if err := param.Registry_Institutions.Unmarshal(&institutions); err != nil {
 		log.Error("Fail to read server configuration of institutions", err)
@@ -573,5 +678,53 @@ func RegisterRegistryWebAPI(router *gin.RouterGroup) error {
 	{
 		registryWebAPI.GET("/institutions", web_ui.AuthHandler, listInstitutions)
 	}
+	return nil
+}
+
+// Initialize institutions list
+func InitInstConfig() error {
+	institutions := []Institution{}
+	if err := param.Registry_Institutions.Unmarshal(&institutions); err != nil {
+		log.Error("Fail to read Registry.Institutions. Make sure you had the correct format", err)
+		return errors.Wrap(err, "Fail to read Registry.Institutions. Make sure you had the correct format")
+	}
+
+	if param.Registry_InstitutionsUrl.GetString() != "" {
+		// Read from Registry.Institutions if Registry.InstitutionsUrl is empty
+		// or Registry.Institutions and Registry.InstitutionsUrl are both set
+		if len(institutions) > 0 {
+			log.Warning("Registry.Institutions and Registry.InstitutionsUrl are both set. Registry.InstitutionsUrl is ignored")
+			if !checkUniqueInstitutions(institutions) {
+				return errors.Errorf("Institution IDs read from config are not unique")
+			}
+			// return here so that we don't init the institution url cache
+			return nil
+		}
+
+		_, err := url.Parse(param.Registry_InstitutionsUrl.GetString())
+		if err != nil {
+			log.Error("Invalid Registry.InstitutionsUrl: ", err)
+			return errors.Wrap(err, "Invalid Registry.InstitutionsUrl")
+		}
+		instCacheTTL := param.Registry_InstitutionsUrlReloadMinutes.GetDuration()
+
+		institutionsCache = ttlcache.New[string, []Institution](ttlcache.WithTTL[string, []Institution](instCacheTTL))
+
+		go func() {
+			institutionsCache.Start()
+		}()
+
+		// Try to populate the cache at the server start. If error occured, it's non-blocking
+		cachedInsts, intErr, _ := getCachedInstitutions()
+		if intErr != nil {
+			log.Warning("Failed to populate institution cache. It's non-blocking", intErr)
+		} else {
+			if !checkUniqueInstitutions(cachedInsts) {
+				return errors.Errorf("Institution IDs read from config are not unique")
+			}
+			log.Infof("Successfully populated institution TTL cache with %d entries", len(institutionsCache.Get(institutionsCache.Keys()[0]).Value()))
+		}
+	}
+	// Else we will read from Registry.Institutions. No extra action needed.
 	return nil
 }

--- a/registry/registry_ui_test.go
+++ b/registry/registry_ui_test.go
@@ -558,7 +558,7 @@ func TestInitInstConfig(t *testing.T) {
 		// No error should return, this is non-blcoking
 		require.NoError(t, err)
 		require.Equal(t, 1, len(hook.Entries))
-		assert.Contains(t, hook.LastEntry().Message, "Failed to populate institution cache. It's non-blocking")
+		assert.Contains(t, hook.LastEntry().Message, "Failed to populate institution cache.")
 		assert.NotNil(t, institutionsCache)
 	})
 


### PR DESCRIPTION
Fixes #635 and Closes #648 

To test locally, you may use the topology URL which gives valid institution list for OSDF: https://topology.opensciencegrid.org/institution_ids