### PR TITLE
Clear/correct logging at program exit

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -82,6 +82,10 @@ func Execute() error {
 	defer func() {
 		err := egrp.Wait()
 		if err != nil {
+			if err.Error() == "Federation process has been cancelled" {
+				log.Info("Process was shutdown")
+				return
+			}
 			log.Errorln("Error occurred when shutting down process:", err)
 		}
 	}()


### PR DESCRIPTION
Fixes #598 
Partially make #644 a bit easier to debug but not a direct fix.

Give a clearer log message at the program exit, by outputting daemon names to log message
Also fix the error "Federation is Cancelled" at the exit but in fact a no-error message.