### PR TITLE
Fixed issue: auto-unpacking failing if dest is "."

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -493,6 +493,12 @@ func DownloadHTTP(transfer TransferDetails, dest string, token string) (int64, e
 		if err != nil {
 			return 0, err
 		}
+		if dest == "." {
+			dest, err = os.Getwd()
+			if err != nil {
+				return 0, errors.Wrap(err, "Failed to get current directory for destination")
+			}
+		}
 		unpacker = newAutoUnpacker(dest, behavior)
 		if req, err = grab.NewRequestToWriter(unpacker, transfer.Url.String()); err != nil {
 			return 0, errors.Wrap(err, "Failed to create new download request")


### PR DESCRIPTION
Within the auto-unpacking code, the dest was reading as just "." so I changed it to recognize that is the current working directory and change it manually