### PR TITLE
Exit main process if error group goroutine returns error

### DIFF
--- a/cmd/cache_serve.go
+++ b/cmd/cache_serve.go
@@ -85,9 +85,9 @@ func serveCache(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func serveCacheInternal(ctx context.Context) error {
+func serveCacheInternal(cmdCtx context.Context) error {
 	// Use this context for any goroutines that needs to react to server shutdown
-	ctx, shutdownCancel := context.WithCancel(ctx)
+	ctx, shutdownCancel := context.WithCancel(cmdCtx)
 
 	err := config.InitServer(ctx, config.CacheType)
 	cobra.CheckErr(err)
@@ -103,9 +103,9 @@ func serveCacheInternal(ctx context.Context) error {
 		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 		select {
 		case sig := <-sigs:
-			log.Debugf("Received signal %v; will shutdown process", sig)
+			log.Infof("Received signal %v; will shutdown process", sig)
 			shutdownCancel()
-			return errors.New("Federation process has been cancelled")
+			return nil
 		case <-ctx.Done():
 			return nil
 		}
@@ -183,6 +183,5 @@ func serveCacheInternal(ctx context.Context) error {
 		return err
 	}
 
-	log.Info("Clean shutdown of the cache")
 	return nil
 }

--- a/cmd/cache_serve.go
+++ b/cmd/cache_serve.go
@@ -133,7 +133,7 @@ func serveCacheInternal(cmdCtx context.Context) error {
 
 	egrp.Go(func() error {
 		if err := web_ui.RunEngine(cmdCtx, engine, egrp); err != nil {
-			log.Panicln("Failure when running the web engine:", err)
+			log.Errorln("Failure when running the web engine:", err)
 			return err
 		} else {
 			return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,6 +83,9 @@ func Execute() error {
 		err := egrp.Wait()
 		if err != nil {
 			log.Errorln("Fatal error occured that leads to shutdown of the process:", err)
+		} else {
+			// Use Error instead of Info because our default log level is Error
+			log.Error("Pelican is safely exited")
 		}
 	}()
 	ctx := context.WithValue(egrpCtx, config.EgrpKey, egrp)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -82,7 +82,7 @@ func Execute() error {
 	defer func() {
 		err := egrp.Wait()
 		if err != nil {
-			log.Errorln("Fatal error occured that leads to shutdown of the process:", err)
+			log.Errorln("Fatal error occurred that lead to the shutdown of the process:", err)
 		} else {
 			// Use Error instead of Info because our default log level is Error
 			log.Error("Pelican is safely exited")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,18 +78,14 @@ func (i *uint16Value) Type() string {
 func (i *uint16Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
 func Execute() error {
-	egrp := errgroup.Group{}
+	egrp, egrpCtx := errgroup.WithContext(context.Background())
 	defer func() {
 		err := egrp.Wait()
 		if err != nil {
-			if err.Error() == "Federation process has been cancelled" {
-				log.Info("Process was shutdown")
-				return
-			}
-			log.Errorln("Error occurred when shutting down process:", err)
+			log.Errorln("Fatal error occured that leads to shutdown of the process:", err)
 		}
 	}()
-	ctx := context.WithValue(context.Background(), config.EgrpKey, &egrp)
+	ctx := context.WithValue(egrpCtx, config.EgrpKey, egrp)
 	return rootCmd.ExecuteContext(ctx)
 }
 

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -204,11 +204,12 @@ func ConfigTTLCache(ctx context.Context, egrp *errgroup.Group) {
 	// Put stop logic in a separate goroutine so that parent function is not blocking
 	egrp.Go(func() error {
 		<-ctx.Done()
-		log.Info("Gracefully stopping TTL cache eviction...")
+		log.Info("Gracefully stopping director TTL cache eviction...")
 		serverAds.DeleteAll()
 		serverAds.Stop()
 		namespaceKeys.DeleteAll()
 		namespaceKeys.Stop()
+		log.Info("Director TTL cache eviction has been stopped")
 		return nil
 	})
 }

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -45,6 +45,7 @@ type PromDiscoveryItem struct {
 var (
 	minClientVersion, _        = version.NewVersion("7.0.0")
 	minOriginVersion, _        = version.NewVersion("7.0.0")
+	minCacheVersion, _         = version.NewVersion("7.3.0")
 	healthTestCancelFuncs      = make(map[ServerAd]context.CancelFunc)
 	healthTestCancelFuncsMutex = sync.RWMutex{}
 )
@@ -152,6 +153,10 @@ func versionCompatCheck(ginCtx *gin.Context) error {
 		minCompatVer = minClientVersion
 	case "origin":
 		minCompatVer = minOriginVersion
+	case "cache":
+		minCompatVer = minCacheVersion
+	default:
+		return errors.Errorf("Invalid version format. The director does not support your %s version (%s).", service, reqVer.String())
 	}
 
 	if reqVer.LessThan(minCompatVer) {

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -53,7 +53,7 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (context.Canc
 		case sig := <-sigs:
 			log.Debugf("Received signal %v; will shutdown process", sig)
 			shutdownCancel()
-			return errors.New("Federation process has been cancelled")
+			return nil
 		case <-ctx.Done():
 			return nil
 		}
@@ -139,7 +139,6 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (context.Canc
 	egrp.Go(func() error {
 		if err := web_ui.RunEngine(ctx, engine, egrp); err != nil {
 			log.Errorln("Failure when running the web engine:", err)
-			shutdownCancel()
 			return err
 		}
 		log.Info("Web engine has shutdown")

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -51,7 +51,7 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (context.Canc
 		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 		select {
 		case sig := <-sigs:
-			log.Debugf("Received signal %v; will shutdown process", sig)
+			log.Warningf("Received signal %v; will shutdown process", sig)
 			shutdownCancel()
 			return nil
 		case <-ctx.Done():

--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -326,7 +326,7 @@ func ConfigureMonitoring(ctx context.Context, egrp *errgroup.Group) (int, error)
 		sessions.Stop()
 		userids.Stop()
 		transfers.Stop()
-		log.Infoln("Gracefully stopping metrics cache auto eviction...")
+		log.Infoln("Metrics cache auto eviction has been stopped")
 		return nil
 	})
 

--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -326,7 +326,7 @@ func ConfigureMonitoring(ctx context.Context, egrp *errgroup.Group) (int, error)
 		sessions.Stop()
 		userids.Stop()
 		transfers.Stop()
-		log.Infoln("Metrics cache auto eviction has been stopped")
+		log.Infoln("Xrootd metrics cache eviction has been stopped")
 		return nil
 	})
 

--- a/origin_ui/origin_api.go
+++ b/origin_ui/origin_api.go
@@ -113,7 +113,7 @@ func LaunchPeriodicDirectorTimeout(ctx context.Context, egrp *errgroup.Group) {
 				log.Debugln("Got notification from director")
 				directorTimeoutTicker.Reset(directorTimeoutDuration)
 			case <-ctx.Done():
-				log.Infoln("Gracefully terminating the director-health test timeout loop...")
+				log.Infoln("Director health test timeout loop has been terminated")
 				return nil
 			}
 		}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -332,4 +332,3 @@ type configWithType struct {
 		SummaryMonitoringHost struct { Type string; Value string }
 	}
 }
-

--- a/server_ui/advertise.go
+++ b/server_ui/advertise.go
@@ -66,6 +66,7 @@ func LaunchPeriodicAdvertise(ctx context.Context, egrp *errgroup.Group, servers 
 					metrics.SetComponentHealthStatus(metrics.OriginCache_Federation, metrics.StatusOK, "")
 				}
 			case <-ctx.Done():
+				log.Infoln("Periodic advertisement loop has been terminated")
 				return nil
 			}
 		}

--- a/server_utils/server_utils.go
+++ b/server_utils/server_utils.go
@@ -145,7 +145,7 @@ func LaunchWatcherMaintenance(ctx context.Context, dirPaths []string, descriptio
 					log.Warningf("Failure during %s routine: %v", description, err)
 				}
 			} else if chosen == 1 {
-				log.Infof("%s routine has been cancelled.  Shutting down", description)
+				log.Infof("%s routine has been cancelled. Shutting down", description)
 				return nil
 			} else if chosen == 2 { // watcher.Events
 				if !ok {

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -595,7 +595,7 @@ func ConfigureEmbeddedPrometheus(ctx context.Context, engine *gin.Engine) error 
 				// Don't forget to release the reloadReady channel so that waiting blocks can exit normally.
 				select {
 				case <-ctx.Done():
-					err := level.Warn(logger).Log("msg", "Received shutdown, exiting gracefully...")
+					err := level.Info(logger).Log("msg", "Received shutdown, exiting gracefully...")
 					_ = err
 					reloadReady.Close()
 				case <-cancel:

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -386,7 +386,7 @@ func runEngineWithListener(ctx context.Context, ln net.Listener, engine *gin.Eng
 		defer cancel()
 		err = server.Shutdown(ctx)
 		if err != nil {
-			log.Panicln("Failed to shutdown server:", err)
+			log.Errorln("Failed to shutdown server:", err)
 		}
 		return err
 	})

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -388,7 +388,7 @@ func runEngineWithListener(ctx context.Context, ln net.Listener, engine *gin.Eng
 		if err != nil {
 			log.Panicln("Failed to shutdown server:", err)
 		}
-		return nil
+		return err
 	})
 
 	if err := server.ServeTLS(ln, "", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {


### PR DESCRIPTION
Fixes #661 
* Fix the issue where Pelican won'y exit main process if error group goroutine returns error, unless an error returns in the main goroutine
* Fix the panic at the director when a cache advertise itself to the director, as we didn't have the case for cache when doing version compatibility check
* Improve logging at program exit to be consistent.
* Improve cache error group, remove duplicated exit handler that `root.go` already had.

~~However, this didn't fix the issue where when we exit the program with `ctrl+c` , xrootd reported error as it treated SIGINT similar as SIGSEGV. We might have to refactor some of the code in `daemon/launch_unix.go`. Created a separate issue for this: #672~~