### PR TITLE
Project name added to user-agent

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -513,7 +513,9 @@ func DownloadHTTP(transfer TransferDetails, dest string, token string, payload *
 	// Set the headers
 	req.HTTPRequest.Header.Set("X-Transfer-Status", "true")
 	req.HTTPRequest.Header.Set("TE", "trailers")
-	req.HTTPRequest.Header.Set("User-Agent", payload.ProjectName)
+	if payload != nil && payload.ProjectName != "" {
+		req.HTTPRequest.Header.Set("User-Agent", payload.ProjectName)
+	}
 	req.WithContext(ctx)
 
 	// Test the transfer speed every 5 seconds

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -781,7 +781,7 @@ func (pr *ProgressReader) Size() int64 {
 }
 
 // Recursively uploads a directory with all files and nested dirs, keeping file structure on server side
-func UploadDirectory(src string, dest *url.URL, token string, namespace namespaces.Namespace) (int64, error) {
+func UploadDirectory(src string, dest *url.URL, token string, namespace namespaces.Namespace, projectName string) (int64, error) {
 	var files []string
 	var amountDownloaded int64
 	srcUrl := url.URL{Path: src}
@@ -801,7 +801,7 @@ func UploadDirectory(src string, dest *url.URL, token string, namespace namespac
 		if err != nil {
 			return 0, err
 		}
-		downloaded, err := UploadFile(file, &tempDest, token, namespace)
+		downloaded, err := UploadFile(file, &tempDest, token, namespace, projectName)
 		if err != nil {
 			return 0, err
 		}
@@ -816,7 +816,7 @@ func UploadDirectory(src string, dest *url.URL, token string, namespace namespac
 }
 
 // UploadFile Uploads a file using HTTP
-func UploadFile(src string, origDest *url.URL, token string, namespace namespaces.Namespace) (int64, error) {
+func UploadFile(src string, origDest *url.URL, token string, namespace namespaces.Namespace, projectName string) (int64, error) {
 
 	log.Debugln("In UploadFile")
 	log.Debugln("Dest", origDest.String())
@@ -891,6 +891,9 @@ func UploadFile(src string, origDest *url.URL, token string, namespace namespace
 	}
 	// Set the authorization header
 	request.Header.Set("Authorization", "Bearer "+token)
+	if projectName != "" {
+		request.Header.Set("User-Agent", projectName)
+	}
 	var lastKnownWritten int64
 	t := time.NewTicker(20 * time.Second)
 	defer t.Stop()

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -193,7 +193,7 @@ func TestSlowTransfers(t *testing.T) {
 	var err error
 	// Do a quick timeout
 	go func() {
-		_, err = DownloadHTTP(transfers[0], filepath.Join(t.TempDir(), "test.txt"), "")
+		_, err = DownloadHTTP(transfers[0], filepath.Join(t.TempDir(), "test.txt"), "", nil)
 		finishedChannel <- true
 	}()
 
@@ -256,7 +256,7 @@ func TestStoppedTransfer(t *testing.T) {
 	var err error
 
 	go func() {
-		_, err = DownloadHTTP(transfers[0], filepath.Join(t.TempDir(), "test.txt"), "")
+		_, err = DownloadHTTP(transfers[0], filepath.Join(t.TempDir(), "test.txt"), "", nil)
 		finishedChannel <- true
 	}()
 
@@ -286,7 +286,7 @@ func TestConnectionError(t *testing.T) {
 	addr := l.Addr().String()
 	l.Close()
 
-	_, err = DownloadHTTP(TransferDetails{Url: url.URL{Host: addr, Scheme: "http"}, Proxy: false}, filepath.Join(t.TempDir(), "test.txt"), "")
+	_, err = DownloadHTTP(TransferDetails{Url: url.URL{Host: addr, Scheme: "http"}, Proxy: false}, filepath.Join(t.TempDir(), "test.txt"), "", nil)
 
 	assert.IsType(t, &ConnectionSetupError{}, err)
 
@@ -319,7 +319,7 @@ func TestTrailerError(t *testing.T) {
 	assert.Equal(t, svr.URL, transfers[0].Url.String())
 
 	// Call DownloadHTTP and check if the error is returned correctly
-	_, err := DownloadHTTP(transfers[0], filepath.Join(t.TempDir(), "test.txt"), "")
+	_, err := DownloadHTTP(transfers[0], filepath.Join(t.TempDir(), "test.txt"), "", nil)
 
 	assert.NotNil(t, err)
 	assert.EqualError(t, err, "transfer error: Unable to read test.txt; input/output error")

--- a/client/main.go
+++ b/client/main.go
@@ -938,6 +938,7 @@ func parse_job_ad(payload *payloadStruct) {
 	}
 
 	// Get all matches from file
+	// Note: This appears to be invalid regex but is the only thing that appears to work. This way it successfully finds our matches
 	classadRegex, e := regexp.Compile(`^*\s*(Owner|ProjectName)\s=\s"(.*)"`)
 	if e != nil {
 		log.Fatal(e)

--- a/client/main_test.go
+++ b/client/main_test.go
@@ -331,5 +331,5 @@ func TestParseNoJobAd(t *testing.T) {
 	os.Setenv("_CONDOR_JOB_AD", path)
 
 	payload := payloadStruct{}
-	parse_job_ad(payload)
+	parse_job_ad(&payload)
 }


### PR DESCRIPTION
For downloads, if the `ProjectName` is present in a job ad for the plugin, it is added to the user-agent in the http request header.