### PR TITLE
Fix linter failure on main

### DIFF
--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -336,4 +336,3 @@ type configWithType struct {
 		SummaryMonitoringHost struct { Type string; Value string }
 	}
 }
-

--- a/web_ui/frontend/components/graphs/RateGraph.tsx
+++ b/web_ui/frontend/components/graphs/RateGraph.tsx
@@ -297,7 +297,7 @@ export default function RateGraph({boxProps, metrics, rate=new TimeDuration(30, 
                 if (updatedTime.hasSame(DateTime.now(), "day")) {
                     updatedTime = DateTime.now()
                 }
-                
+
                 return {
                     data: (await query_rate({metric, rate:_rate, duration:_duration, resolution:_resolution, time:updatedTime})),
                     ...datasetOption


### PR DESCRIPTION
The latest merge #497 causes linter failure on main branch, due to outdated local branch. This fixes the linter issue.