### PR TITLE
Reject unapproved origin/caches based on config and more robust director error response

### DIFF
--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -474,8 +474,8 @@ func TestFullUpload(t *testing.T) {
 	viper.Set("Server.EnableUI", false)
 	viper.Set("Registry.DbLocation", filepath.Join(t.TempDir(), "ns-registry.sqlite"))
 	viper.Set("Xrootd.RunLocation", tmpPath)
-	viper.Set("Registry.OriginApprovedOnly", false)
-	viper.Set("Registry.CacheApprovedOnly", false)
+	viper.Set("Registry.RequireOriginApproval", false)
+	viper.Set("Registry.RequireCacheApproval", false)
 
 	err = config.InitServer(ctx, modules)
 	require.NoError(t, err)

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -474,6 +474,8 @@ func TestFullUpload(t *testing.T) {
 	viper.Set("Server.EnableUI", false)
 	viper.Set("Registry.DbLocation", filepath.Join(t.TempDir(), "ns-registry.sqlite"))
 	viper.Set("Xrootd.RunLocation", tmpPath)
+	viper.Set("Registry.OriginApprovedOnly", false)
+	viper.Set("Registry.CacheApprovedOnly", false)
 
 	err = config.InitServer(ctx, modules)
 	require.NoError(t, err)

--- a/cmd/fed_serve_test.go
+++ b/cmd/fed_serve_test.go
@@ -83,6 +83,8 @@ func TestFedServePosixOrigin(t *testing.T) {
 	viper.Set("TLSSkipVerify", true)
 	viper.Set("Server.EnableUI", false)
 	viper.Set("Registry.DbLocation", filepath.Join(t.TempDir(), "ns-registry.sqlite"))
+	viper.Set("Registry.OriginApprovedOnly", false)
+	viper.Set("Registry.CacheApprovedOnly", false)
 
 	err = config.InitServer(ctx, modules)
 	require.NoError(t, err)

--- a/cmd/fed_serve_test.go
+++ b/cmd/fed_serve_test.go
@@ -83,8 +83,8 @@ func TestFedServePosixOrigin(t *testing.T) {
 	viper.Set("TLSSkipVerify", true)
 	viper.Set("Server.EnableUI", false)
 	viper.Set("Registry.DbLocation", filepath.Join(t.TempDir(), "ns-registry.sqlite"))
-	viper.Set("Registry.OriginApprovedOnly", false)
-	viper.Set("Registry.CacheApprovedOnly", false)
+	viper.Set("Registry.RequireOriginApproval", false)
+	viper.Set("Registry.RequireCacheApproval", false)
 
 	err = config.InitServer(ctx, modules)
 	require.NoError(t, err)

--- a/cmd/object_get_put_test.go
+++ b/cmd/object_get_put_test.go
@@ -99,6 +99,9 @@ func TestGetAndPut(t *testing.T) {
 	err = config.InitServer(ctx, modules)
 	require.NoError(t, err)
 
+	viper.Set("Registry.OriginApprovedOnly", false)
+	viper.Set("Registry.CacheApprovedOnly", false)
+
 	fedCancel, err := launchers.LaunchModules(ctx, modules)
 	if err != nil {
 		t.Fatalf("Failure in fedServeInternal: %v", err)

--- a/cmd/object_get_put_test.go
+++ b/cmd/object_get_put_test.go
@@ -99,8 +99,8 @@ func TestGetAndPut(t *testing.T) {
 	err = config.InitServer(ctx, modules)
 	require.NoError(t, err)
 
-	viper.Set("Registry.OriginApprovedOnly", false)
-	viper.Set("Registry.CacheApprovedOnly", false)
+	viper.Set("Registry.RequireOriginApproval", false)
+	viper.Set("Registry.RequireCacheApproval", false)
 
 	fedCancel, err := launchers.LaunchModules(ctx, modules)
 	if err != nil {

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -38,6 +38,8 @@ Origin:
   SelfTest: true
 Registry:
   InstitutionsUrlReloadMinutes: 15m
+  CacheApprovedOnly: false
+  OriginApprovedOnly: false
 Monitoring:
   PortLower: 9930
   PortHigher: 9999

--- a/config/resources/osdf.yaml
+++ b/config/resources/osdf.yaml
@@ -22,3 +22,6 @@ Federation:
   DiscoveryUrl: osg-htc.org
   TopologyNamespaceURL: https://topology.opensciencegrid.org/osdf/namespaces
   TopologyReloadInterval: 10
+Registry:
+  CacheApprovedOnly: true
+  OriginApprovedOnly: true

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -189,8 +189,8 @@ func VerifyAdvertiseToken(ctx context.Context, token, namespace string) (bool, e
 			}
 		}
 	}()
-	namespace_url_string := param.Federation_RegistryUrl.GetString()
-	approved, err := checkNamespaceStatus(namespace, namespace_url_string)
+	regUrlStr := param.Federation_RegistryUrl.GetString()
+	approved, err := checkNamespaceStatus(namespace, regUrlStr)
 	if err != nil {
 		return false, errors.Wrap(err, "Failed to check namespace approval status")
 	}

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -429,7 +429,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType ServerTy
 			ok, err := VerifyAdvertiseToken(engineCtx, token, namespace.Path)
 			if err != nil {
 				if err == adminApprovalErr {
-					log.Warningf("Failed to verify token. Namespace %q was not approved", namespace.Path)
+					log.Warningf("Failed to verify advertise token. Namespace %q requires administrator approval", namespace.Path)
 					ctx.JSON(http.StatusForbidden, gin.H{"approval_error": true, "error": fmt.Sprintf("The namespace %q was not approved by an administrator", namespace.Path)})
 					return
 				} else {

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -434,7 +434,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType ServerTy
 					return
 				} else {
 					log.Warningln("Failed to verify token:", err)
-					ctx.JSON(http.StatusForbidden, gin.H{"error": "Authorization token verification failed."})
+					ctx.JSON(http.StatusForbidden, gin.H{"error": "Authorization token verification failed"})
 					return
 				}
 			}

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -430,7 +430,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType ServerTy
 			if err != nil {
 				if err == adminApprovalErr {
 					log.Warningf("Failed to verify token. Namespace %q was not approved", namespace.Path)
-					ctx.JSON(http.StatusForbidden, gin.H{"error": fmt.Sprintf("The namespace %q was not approved by an administrator", namespace.Path)})
+					ctx.JSON(http.StatusForbidden, gin.H{"approval_error": true, "error": fmt.Sprintf("The namespace %q was not approved by an administrator", namespace.Path)})
 					return
 				} else {
 					log.Warningln("Failed to verify token:", err)
@@ -452,7 +452,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType ServerTy
 		if err != nil {
 			if err == adminApprovalErr {
 				log.Warningf("Failed to verify token. Cache %q was not approved", ad.Name)
-				ctx.JSON(http.StatusForbidden, gin.H{"error": fmt.Sprintf("Cache %q was not approved by an administrator", ad.Name)})
+				ctx.JSON(http.StatusForbidden, gin.H{"approval_error": true, "error": fmt.Sprintf("Cache %q was not approved by an administrator", ad.Name)})
 				return
 			} else {
 				log.Warningln("Failed to verify token:", err)

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -662,6 +662,25 @@ type: duration
 default: 15m
 components: ["nsregistry"]
 ---
+name: Registry.CacheApprovedOnly
+description: >-
+  Only allow approved caches to join the federation and serve files. If set to true, caches can
+  successfully self-register or registered via registry, but director won't direct traffic to the cache.
+type: bool
+default: false
+osdf_default: true
+components: ["nsregistry"]
+---
+name: Registry.OriginApprovedOnly
+description: >-
+  Only allow approved origins to join the federation and serve files. If set to true, origins can
+  successfully self-register or registered via registry, but director won't direct traffic to the origin,
+  nor would files on the origin show up in the federation.
+type: bool
+default: false
+osdf_default: true
+components: ["nsregistry"]
+---
 ############################
 #   Server-level configs   #
 ############################

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -662,7 +662,7 @@ type: duration
 default: 15m
 components: ["nsregistry"]
 ---
-name: Registry.CacheApprovedOnly
+name: Registry.RequireCacheApproval
 description: >-
   Only allow approved caches to join the federation and serve files. If set to true, caches can
   successfully self-register or registered via registry, but director won't direct traffic to the cache.
@@ -671,7 +671,7 @@ default: false
 osdf_default: true
 components: ["nsregistry"]
 ---
-name: Registry.OriginApprovedOnly
+name: Registry.RequireOriginApproval
 description: >-
   Only allow approved origins to join the federation and serve files. If set to true, origins can
   successfully self-register or registered via registry, but director won't direct traffic to the origin,

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -180,6 +180,8 @@ var (
 	Origin_Multiuser = BoolParam{"Origin.Multiuser"}
 	Origin_ScitokensMapSubject = BoolParam{"Origin.ScitokensMapSubject"}
 	Origin_SelfTest = BoolParam{"Origin.SelfTest"}
+	Registry_CacheApprovedOnly = BoolParam{"Registry.CacheApprovedOnly"}
+	Registry_OriginApprovedOnly = BoolParam{"Registry.OriginApprovedOnly"}
 	Registry_RequireKeyChaining = BoolParam{"Registry.RequireKeyChaining"}
 	Server_EnableUI = BoolParam{"Server.EnableUI"}
 	StagePlugin_Hook = BoolParam{"StagePlugin.Hook"}

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -180,9 +180,9 @@ var (
 	Origin_Multiuser = BoolParam{"Origin.Multiuser"}
 	Origin_ScitokensMapSubject = BoolParam{"Origin.ScitokensMapSubject"}
 	Origin_SelfTest = BoolParam{"Origin.SelfTest"}
-	Registry_CacheApprovedOnly = BoolParam{"Registry.CacheApprovedOnly"}
-	Registry_OriginApprovedOnly = BoolParam{"Registry.OriginApprovedOnly"}
+	Registry_RequireCacheApproval = BoolParam{"Registry.RequireCacheApproval"}
 	Registry_RequireKeyChaining = BoolParam{"Registry.RequireKeyChaining"}
+	Registry_RequireOriginApproval = BoolParam{"Registry.RequireOriginApproval"}
 	Server_EnableUI = BoolParam{"Server.EnableUI"}
 	StagePlugin_Hook = BoolParam{"StagePlugin.Hook"}
 	TLSSkipVerify = BoolParam{"TLSSkipVerify"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -116,10 +116,12 @@ type config struct {
 	}
 	Registry struct {
 		AdminUsers []string
+		CacheApprovedOnly bool
 		DbLocation string
 		Institutions interface{}
 		InstitutionsUrl string
 		InstitutionsUrlReloadMinutes time.Duration
+		OriginApprovedOnly bool
 		RequireKeyChaining bool
 	}
 	Server struct {
@@ -286,10 +288,12 @@ type configWithType struct {
 	}
 	Registry struct {
 		AdminUsers struct { Type string; Value []string }
+		CacheApprovedOnly struct { Type string; Value bool }
 		DbLocation struct { Type string; Value string }
 		Institutions struct { Type string; Value interface{} }
 		InstitutionsUrl struct { Type string; Value string }
 		InstitutionsUrlReloadMinutes struct { Type string; Value time.Duration }
+		OriginApprovedOnly struct { Type string; Value bool }
 		RequireKeyChaining struct { Type string; Value bool }
 	}
 	Server struct {

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -116,13 +116,13 @@ type config struct {
 	}
 	Registry struct {
 		AdminUsers []string
-		CacheApprovedOnly bool
 		DbLocation string
 		Institutions interface{}
 		InstitutionsUrl string
 		InstitutionsUrlReloadMinutes time.Duration
-		OriginApprovedOnly bool
+		RequireCacheApproval bool
 		RequireKeyChaining bool
+		RequireOriginApproval bool
 	}
 	Server struct {
 		EnableUI bool
@@ -288,13 +288,13 @@ type configWithType struct {
 	}
 	Registry struct {
 		AdminUsers struct { Type string; Value []string }
-		CacheApprovedOnly struct { Type string; Value bool }
 		DbLocation struct { Type string; Value string }
 		Institutions struct { Type string; Value interface{} }
 		InstitutionsUrl struct { Type string; Value string }
 		InstitutionsUrlReloadMinutes struct { Type string; Value time.Duration }
-		OriginApprovedOnly struct { Type string; Value bool }
+		RequireCacheApproval struct { Type string; Value bool }
 		RequireKeyChaining struct { Type string; Value bool }
+		RequireOriginApproval struct { Type string; Value bool }
 	}
 	Server struct {
 		EnableUI struct { Type string; Value bool }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -682,13 +682,13 @@ func wildcardHandler(ctx *gin.Context) {
 		}
 		if adminMetadata != nil && adminMetadata.Status != Approved {
 			if strings.HasPrefix(prefix, "/caches/") { // Caches
-				if param.Registry_CacheApprovedOnly.GetBool() {
+				if param.Registry_RequireCacheApproval.GetBool() {
 					// Use 403 to distinguish between server error
 					ctx.JSON(http.StatusForbidden, gin.H{"error": "The cache has not been approved by federation administrator"})
 					return
 				}
 			} else { // Origins
-				if param.Registry_OriginApprovedOnly.GetBool() {
+				if param.Registry_RequireOriginApproval.GetBool() {
 					// Use 403 to distinguish between server error
 					ctx.JSON(http.StatusForbidden, gin.H{"error": "The origin has not been approved by federation administrator"})
 					return
@@ -788,21 +788,21 @@ func checkNamespaceStatusHandler(ctx *gin.Context) {
 		return
 	}
 	emptyMetadata := AdminMetadata{}
-	// If Registry.CacheApprovedOnly or Registry.OriginApprovedOnly is false
+	// If Registry.RequireCacheApproval or Registry.RequireOriginApproval is false
 	// we return Approved == true
 	if ns.AdminMetadata != emptyMetadata {
 		// Caches
-		if strings.HasPrefix(req.Prefix, "/caches") && param.Registry_CacheApprovedOnly.GetBool() {
+		if strings.HasPrefix(req.Prefix, "/caches") && param.Registry_RequireCacheApproval.GetBool() {
 			res := checkStatusRes{Approved: ns.AdminMetadata.Status == Approved}
 			ctx.JSON(http.StatusOK, res)
 			return
-		} else if !param.Registry_CacheApprovedOnly.GetBool() {
+		} else if !param.Registry_RequireCacheApproval.GetBool() {
 			res := checkStatusRes{Approved: true}
 			ctx.JSON(http.StatusOK, res)
 			return
 		} else {
 			// Origins
-			if param.Registry_OriginApprovedOnly.GetBool() {
+			if param.Registry_RequireOriginApproval.GetBool() {
 				res := checkStatusRes{Approved: ns.AdminMetadata.Status == Approved}
 				ctx.JSON(http.StatusOK, res)
 				return

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -335,46 +335,34 @@ func getNamespaceJwksById(id int) (jwk.Set, error) {
 	return set, nil
 }
 
-func getNamespaceJwksByPrefix(prefix string, approvalRequired bool) (jwk.Set, error) {
-	var jwksQuery string
+func getNamespaceJwksByPrefix(prefix string) (jwk.Set, *AdminMetadata, error) {
 	var pubkeyStr string
-	if strings.HasPrefix(prefix, "/caches/") && approvalRequired {
-		adminMetadataStr := ""
-		jwksQuery = `SELECT pubkey, admin_metadata FROM namespace WHERE prefix = ?`
-		err := db.QueryRow(jwksQuery, prefix).Scan(&pubkeyStr, &adminMetadataStr)
-		if err != nil {
-			if err == sql.ErrNoRows {
-				return nil, errors.New("prefix not found in database")
-			}
-			return nil, errors.Wrap(err, "error performing cache pubkey query")
+	var adminMetadataStr string
+
+	jwksQuery := `SELECT pubkey, admin_metadata FROM namespace WHERE prefix = ?`
+	err := db.QueryRow(jwksQuery, prefix).Scan(&pubkeyStr, &adminMetadataStr)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil, errors.New("prefix not found in database")
 		}
-		if adminMetadataStr != "" { // Older version didn't have admin_metadata populated, skip checking
-			adminMetadata := AdminMetadata{}
-			if err = json.Unmarshal([]byte(adminMetadataStr), &adminMetadata); err != nil {
-				return nil, errors.Wrap(err, "Failed to unmarshall admin_metadata")
-			}
-			// TODO: Move this to upper functions that handles business logic to keep db access functions simple
-			if adminMetadata.Status != Approved {
-				return nil, serverCredsErr
-			}
-		}
-	} else {
-		jwksQuery := `SELECT pubkey FROM namespace WHERE prefix = ?`
-		err := db.QueryRow(jwksQuery, prefix).Scan(&pubkeyStr)
-		if err != nil {
-			if err == sql.ErrNoRows {
-				return nil, errors.New("prefix not found in database")
-			}
-			return nil, errors.Wrap(err, "error performing origin pubkey query")
+		return nil, nil, errors.Wrap(err, "error performing origin pubkey query")
+	}
+
+	adminMetadata := AdminMetadata{}
+
+	// For backward compatibility, if adminMetadata is an empty string, don't unmarshall json
+	if adminMetadataStr != "" {
+		if err := json.Unmarshal([]byte(adminMetadataStr), &adminMetadata); err != nil {
+			return nil, nil, errors.Wrap(err, "error parsing admin metadata")
 		}
 	}
 
 	set, err := jwk.ParseString(pubkeyStr)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to parse pubkey as a jwks")
+		return nil, nil, errors.Wrap(err, "Failed to parse pubkey as a jwks")
 	}
 
-	return set, nil
+	return set, &adminMetadata, nil
 }
 
 func getNamespaceStatusById(id int) (RegistrationStatus, error) {

--- a/registry/registry_db_test.go
+++ b/registry/registry_db_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -245,7 +246,6 @@ func TestGetNamespaceStatusById(t *testing.T) {
 
 	t.Run("db-query-error", func(t *testing.T) {
 		resetNamespaceDB(t)
-		// Simulate a DB error. You need to mock the db.QueryRow function to return an error
 		_, err := getNamespaceStatusById(1)
 		require.Error(t, err)
 	})
@@ -700,6 +700,43 @@ func TestGetNamespacesByFilter(t *testing.T) {
 	})
 }
 
+func TestGetNamespaceJwksByPrefix(t *testing.T) {
+	setupMockRegistryDB(t)
+	defer teardownMockNamespaceDB(t)
+
+	t.Run("db-query-error", func(t *testing.T) {
+		resetNamespaceDB(t)
+		_, _, err := getNamespaceJwksByPrefix("/")
+		require.Error(t, err)
+	})
+
+	t.Run("valid-prefix-empty-admin-metadata", func(t *testing.T) {
+		resetNamespaceDB(t)
+		mockJwks := jwk.NewSet()
+		jwksByte, err := json.Marshal(mockJwks)
+		require.NoError(t, err)
+
+		err = insertMockDBData([]Namespace{mockNamespace("/foo", string(jwksByte), "", AdminMetadata{})})
+		require.NoError(t, err)
+		_, admin_meta, err := getNamespaceJwksByPrefix("/foo")
+		require.NoError(t, err)
+		assert.Equal(t, AdminMetadata{}, *admin_meta)
+	})
+
+	t.Run("valid-prefix-non-empty-admin-metadata", func(t *testing.T) {
+		resetNamespaceDB(t)
+		mockJwks := jwk.NewSet()
+		jwksByte, err := json.Marshal(mockJwks)
+		require.NoError(t, err)
+
+		err = insertMockDBData([]Namespace{mockNamespace("/foo", string(jwksByte), "", AdminMetadata{Status: Approved})})
+		require.NoError(t, err)
+		_, admin_meta, err := getNamespaceJwksByPrefix("/foo")
+		require.NoError(t, err)
+		assert.Equal(t, Approved, admin_meta.Status)
+	})
+}
+
 func topologyMockup(t *testing.T, namespaces []string) *httptest.Server {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var namespaceList []map[string]string
@@ -814,107 +851,6 @@ func TestRegistryTopology(t *testing.T) {
 	exists, err = namespaceExists("/regular/foo")
 	require.NoError(t, err)
 	require.True(t, exists)
-
-	viper.Reset()
-}
-
-func TestCacheAdminTrue(t *testing.T) {
-	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
-	defer func() { require.NoError(t, egrp.Wait()) }()
-	defer cancel()
-
-	registryDBDir := t.TempDir()
-	viper.Set("Registry.DbLocation", registryDBDir)
-
-	err := InitializeDB(ctx)
-	defer func() {
-		err := ShutdownDB()
-		assert.NoError(t, err)
-	}()
-
-	require.NoError(t, err, "error initializing registry database")
-
-	adminTester := func(ns Namespace) func(t *testing.T) {
-		return func(t *testing.T) {
-			err = addNamespace(&ns)
-
-			require.NoError(t, err, "error adding test cache to registry database")
-
-			// This will return a serverCredsError if the AdminMetadata.Status != Approved, which we don't want to happen
-			// For these tests, otherwise it will get a key parsing error as ns.Pubkey isn't a real jwk
-			_, err = getNamespaceJwksByPrefix(ns.Prefix, true)
-			require.NotErrorIsf(t, err, serverCredsErr, "error chain contains serverCredErr")
-
-			require.ErrorContainsf(t, err, "Failed to parse pubkey as a jwks: failed to unmarshal JWK set: invalid character 'k' in literal true (expecting 'r')", "error doesn't contain jwks parsing error")
-		}
-	}
-
-	var ns Namespace
-	ns.Prefix = "/caches/test3"
-	ns.Identity = "testident3"
-	ns.Pubkey = "tkey"
-	ns.AdminMetadata.Status = Approved
-
-	t.Run("WithApproval", adminTester(ns))
-
-	ns.Prefix = "/orig/test1"
-	ns.Identity = "testident4"
-	ns.Pubkey = "tkey"
-	ns.AdminMetadata.Status = Pending
-
-	t.Run("OriginNoApproval", adminTester(ns))
-
-	ns.Prefix = "/orig/test2"
-	ns.Identity = "testident5"
-	ns.Pubkey = "tkey"
-	ns.AdminMetadata = AdminMetadata{}
-
-	t.Run("OriginEmptyApproval", adminTester(ns))
-
-	viper.Reset()
-}
-
-func TestCacheAdminFalse(t *testing.T) {
-	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
-	defer func() { require.NoError(t, egrp.Wait()) }()
-	defer cancel()
-
-	registryDBDir := t.TempDir()
-	viper.Set("Registry.DbLocation", registryDBDir)
-
-	err := InitializeDB(ctx)
-	defer func() {
-		err := ShutdownDB()
-		assert.NoError(t, err)
-	}()
-
-	require.NoError(t, err, "error initializing registry database")
-
-	adminTester := func(ns Namespace) func(t *testing.T) {
-		return func(t *testing.T) {
-			err = addNamespace(&ns)
-			require.NoError(t, err, "error adding test cache to registry database")
-
-			// This will return a serverCredsError if the admin_approval == false check is triggered, which we want to happen
-			_, err = getNamespaceJwksByPrefix(ns.Prefix, true)
-
-			require.ErrorIs(t, err, serverCredsErr)
-		}
-	}
-
-	var ns Namespace
-	ns.Prefix = "/caches/test1"
-	ns.Identity = "testident1"
-	ns.Pubkey = "tkey"
-	ns.AdminMetadata.Status = Pending
-
-	t.Run("NoAdmin", adminTester(ns))
-
-	ns.Prefix = "/caches/test2"
-	ns.Identity = "testident2"
-	ns.AdminMetadata = AdminMetadata{}
-
-	t.Run("EmptyAdmin", adminTester(ns))
 
 	viper.Reset()
 }

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -55,7 +55,7 @@ func TestHandleWildcard(t *testing.T) {
 
 		r.ServeHTTP(w, req)
 
-		// Return 200 as by default Registry.OriginApprovedOnly == false
+		// Return 200 as by default Registry.RequireOriginApproval == false
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, string(mockJWKSBytes), w.Body.String())
 	})
@@ -105,8 +105,8 @@ func TestHandleWildcard(t *testing.T) {
 	for _, tc := range mockApprovalTcs {
 		t.Run(tc.Name, func(t *testing.T) {
 			viper.Reset()
-			viper.Set("Registry.CacheApprovedOnly", tc.CacheApprovedOnly)
-			viper.Set("Registry.OriginApprovedOnly", tc.OriginApprovedOnly)
+			viper.Set("Registry.RequireCacheApproval", tc.CacheApprovedOnly)
+			viper.Set("Registry.RequireOriginApproval", tc.OriginApprovedOnly)
 
 			mockPrefix := "/testnamespace/foo"
 			if tc.IsCache {

--- a/server_ui/advertise.go
+++ b/server_ui/advertise.go
@@ -149,10 +149,10 @@ func advertiseInternal(ctx context.Context, server server_utils.XRootDServer) er
 	if resp.StatusCode > 299 {
 		var respErr directorResponse
 		if unmarshalErr := json.Unmarshal(body, &respErr); unmarshalErr != nil { // Error creating json
-			return errors.Wrapf(unmarshalErr, "Could not unmarshall the director's response, which responded %v from director registration: %v", resp.StatusCode, resp.Status)
+			return errors.Wrapf(unmarshalErr, "Could not unmarshal the director's response, which responded %v from director registration: %v", resp.StatusCode, resp.Status)
 		}
 		if respErr.ApprovalError {
-			return errors.Errorf("Your namespace has not been approved by an administrator.")
+			return fmt.Errorf("The namespace %q requires administrator approval. Please contact the administrators of %s for more information.", param.Origin_NamespacePrefix.GetString(), param.Federation_RegistryUrl.GetString())
 		}
 		return errors.Errorf("Error during director registration: %v\n", respErr.Error)
 	}

--- a/server_ui/advertise.go
+++ b/server_ui/advertise.go
@@ -151,7 +151,7 @@ func advertiseInternal(ctx context.Context, server server_utils.XRootDServer) er
 			return errors.Wrapf(unmarshalErr, "Could not unmarshall the director's response, which responded %v from director registration: %v", resp.StatusCode, resp.Status)
 		}
 		if resp.StatusCode == http.StatusForbidden {
-			return errors.Errorf("Error during director advertisement: Cache has not been approved by administrator.")
+			return errors.Errorf("Error during director advertisement: Your namespace has not been approved by an administrator.")
 		}
 		return errors.Errorf("Error during director registration: %v\n", respErr.Error)
 	}

--- a/server_ui/advertise.go
+++ b/server_ui/advertise.go
@@ -40,7 +40,8 @@ import (
 )
 
 type directorResponse struct {
-	Error string `json:"error"`
+	Error         string `json:"error"`
+	ApprovalError bool   `json:"approval_error"`
 }
 
 func LaunchPeriodicAdvertise(ctx context.Context, egrp *errgroup.Group, servers []server_utils.XRootDServer) error {
@@ -150,8 +151,8 @@ func advertiseInternal(ctx context.Context, server server_utils.XRootDServer) er
 		if unmarshalErr := json.Unmarshal(body, &respErr); unmarshalErr != nil { // Error creating json
 			return errors.Wrapf(unmarshalErr, "Could not unmarshall the director's response, which responded %v from director registration: %v", resp.StatusCode, resp.Status)
 		}
-		if resp.StatusCode == http.StatusForbidden {
-			return errors.Errorf("Error during director advertisement: Your namespace has not been approved by an administrator.")
+		if respErr.ApprovalError {
+			return errors.Errorf("Your namespace has not been approved by an administrator.")
 		}
 		return errors.Errorf("Error during director registration: %v\n", respErr.Error)
 	}


### PR DESCRIPTION
Closes #680 and fixes #633 

This PR gives the option for admin user to control whether the caches and origins should be approved before joining the federation. There are two config knobs to turn `Registry.CacheApprovedOnly` and `Registry.OriginApprovedOnly`.

This PR also fixes the bug where the director returns wrong error message if the server wasn't approved. As well as the bug where origin/cache returns "not approved" error on every 403 response it gets from the director