### PR TITLE
Use `pelican://` protocol for pss.origin setting in the cache

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
     rev: v3.2.0
     hooks:
     -   id: trailing-whitespace
+        exclude: github_scripts/pelican_protocol.patch
     -   id: end-of-file-fixer
     -   id: check-yaml
         # Multi-documents are yaml files with multiple --- separating blocks, like

--- a/cmd/cache_serve.go
+++ b/cmd/cache_serve.go
@@ -176,7 +176,7 @@ func serveCacheInternal(cmdCtx context.Context) (context.CancelFunc, error) {
 	xrootd.LaunchXrootdMaintenance(ctx, cacheServer, 2*time.Minute)
 
 	log.Info("Launching cache")
-	launchers, err := xrootd.ConfigureLaunchers(false, configPath, false)
+	launchers, err := xrootd.ConfigureLaunchers(false, configPath, false, true)
 	if err != nil {
 		return shutdownCancel, err
 	}

--- a/daemon/launch.go
+++ b/daemon/launch.go
@@ -32,6 +32,7 @@ type (
 		Args       []string
 		Uid        int
 		Gid        int
+		ExtraEnv   []string
 	}
 )
 

--- a/github_scripts/osx_install.sh
+++ b/github_scripts/osx_install.sh
@@ -68,7 +68,7 @@ cd build
 cmake .. -GNinja
 ninja libXrdAccSciTokens-5.so libXrdPss-5.so
 sudo ln -s $PWD/src/libXrdAccSciTokens-5.so $xrootd_libdir
-sudo ln -s $PWD/src/libXrdPss-5.so $xrootd_libdir
+sudo ln -sf $PWD/src/libXrdPss-5.so $xrootd_libdir
 popd
 
 popd

--- a/github_scripts/osx_install.sh
+++ b/github_scripts/osx_install.sh
@@ -19,6 +19,8 @@
 # Mac OS X instance in GitHub.
 #
 
+scriptdir=`dirname $0`
+
 brew install minio xrootd ninja
 
 mkdir dependencies
@@ -60,11 +62,13 @@ popd
 
 git clone --depth=1 https://github.com/xrootd/xrootd.git
 pushd xrootd
+patch -p1 $scriptdir/pelican_protocol.patch
 mkdir build
 cd build
 cmake .. -GNinja
-ninja libXrdAccSciTokens-5.so
+ninja libXrdAccSciTokens-5.so libXrdPss-5.so
 sudo ln -s $PWD/src/libXrdAccSciTokens-5.so $xrootd_libdir
+sudo ln -s $PWD/src/libXrdPss-5.so $xrootd_libdir
 popd
 
 popd

--- a/github_scripts/pelican_protocol.patch
+++ b/github_scripts/pelican_protocol.patch
@@ -1,0 +1,77 @@
+From 5b7357cb59a1ffe2fb99b68c1dc5796fd063acdb Mon Sep 17 00:00:00 2001
+From: Brian Bockelman <bbockelman@morgridge.org>
+Date: Thu, 25 Jan 2024 09:46:39 -0600
+Subject: [PATCH] Add support for pelican:// protocol
+
+In https://github.com/PelicanPlatform/xrdcl-pelican, we are developing
+a XrdCl plugin that can talk to the infrastructure for a new project,
+christening the URL scheme `pelican://`.
+
+This commit adds the new schema so it can be utilized from both
+xrdcp (primarily for testing) and XCache.
+---
+ src/XrdApps/XrdCpConfig.cc | 2 ++
+ src/XrdApps/XrdCpFile.cc   | 1 +
+ src/XrdApps/XrdCpFile.hh   | 2 +-
+ src/XrdPss/XrdPssUtils.cc  | 3 ++-
+ 4 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/XrdApps/XrdCpConfig.cc b/src/XrdApps/XrdCpConfig.cc
+index 890f80198cc..7f8e8702efa 100644
+--- a/src/XrdApps/XrdCpConfig.cc
++++ b/src/XrdApps/XrdCpConfig.cc
+@@ -385,6 +385,7 @@ do{while(optind < Argc && Legacy(optind)) {}
+      if (dstFile->Protocol != XrdCpFile::isFile
+      &&  dstFile->Protocol != XrdCpFile::isStdIO
+      &&  dstFile->Protocol != XrdCpFile::isXroot
++     &&  dstFile->Protocol != XrdCpFile::isPelican
+      &&  (!Want(DoAllowHttp) && ((dstFile->Protocol == XrdCpFile::isHttp) ||
+                                  (dstFile->Protocol == XrdCpFile::isHttps))))
+         {FMSG(dstFile->ProtName <<"file protocol is not supported.", 22)}
+@@ -903,6 +904,7 @@ void XrdCpConfig::ProcFile(const char *fname)
+             }
+     else if (!((pFile->Protocol == XrdCpFile::isXroot) ||
+                (pFile->Protocol == XrdCpFile::isXroots) ||
++               (pFile->Protocol == XrdCpFile::isPelican) ||
+                (Want(DoAllowHttp) && ((pFile->Protocol == XrdCpFile::isHttp) ||
+                                       (pFile->Protocol == XrdCpFile::isHttps)))))
+                {FMSG(pFile->ProtName <<" file protocol is not supported.", 22)}
+diff --git a/src/XrdApps/XrdCpFile.cc b/src/XrdApps/XrdCpFile.cc
+index a6f8a6496e2..e1e5dc98086 100644
+--- a/src/XrdApps/XrdCpFile.cc
++++ b/src/XrdApps/XrdCpFile.cc
+@@ -56,6 +56,7 @@ XrdCpFile::XrdCpFile(const char *FSpec, int &badURL)
+                            {"root://",   7, isXroot},
+                            {"roots://",  8, isXroots},
+                            {"http://",   7, isHttp},
++                           {"pelican://",  10, isPelican},
+                            {"https://",  8, isHttps}
+                           };
+    static int pTnum = sizeof(pTab)/sizeof(struct proto);
+diff --git a/src/XrdApps/XrdCpFile.hh b/src/XrdApps/XrdCpFile.hh
+index ef09301b56c..03972c360d8 100644
+--- a/src/XrdApps/XrdCpFile.hh
++++ b/src/XrdApps/XrdCpFile.hh
+@@ -38,7 +38,7 @@ class XrdCpFile
+ public:
+ 
+ enum PType {isOther = 0, isDir,    isFile, isStdIO,
+-            isXroot,     isXroots, isHttp, isHttps, isDevNull, isDevZero
++            isXroot,     isXroots, isHttp, isHttps, isPelican, isDevNull, isDevZero
+            };
+ 
+ XrdCpFile        *Next;         // -> Next file in list
+diff --git a/src/XrdPss/XrdPssUtils.cc b/src/XrdPss/XrdPssUtils.cc
+index be14fa55c9a..42f37534f14 100644
+--- a/src/XrdPss/XrdPssUtils.cc
++++ b/src/XrdPss/XrdPssUtils.cc
+@@ -42,7 +42,8 @@ namespace
+    struct pEnt {const char *pname; int pnlen;} pTab[] =
+                {{ "https://", 8},  { "http://", 7},
+                 { "roots://", 8},  { "root://", 7},
+-                {"xroots://", 9},  {"xroot://", 8}
++                {"xroots://", 9},  {"xroot://", 8},
++                {"pelican://", 10}
+                };
+    int pTNum = sizeof(pTab)/sizeof(pEnt);
+    int xrBeg = 2;

--- a/launchers/origin_serve.go
+++ b/launchers/origin_serve.go
@@ -80,7 +80,7 @@ func OriginServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group) 
 	xrootd.LaunchXrootdMaintenance(ctx, originServer, 2*time.Minute)
 
 	privileged := param.Origin_Multiuser.GetBool()
-	launchers, err := xrootd.ConfigureLaunchers(privileged, configPath, param.Origin_EnableCmsd.GetBool())
+	launchers, err := xrootd.ConfigureLaunchers(privileged, configPath, param.Origin_EnableCmsd.GetBool(), false)
 	if err != nil {
 		return nil, err
 	}

--- a/xrootd/launch.go
+++ b/xrootd/launch.go
@@ -44,7 +44,7 @@ func (launcher PrivilegedXrootdLauncher) Name() string {
 	return launcher.daemonName
 }
 
-func makeUnprivilegedXrootdLauncher(daemonName string, configPath string) (result UnprivilegedXrootdLauncher, err error) {
+func makeUnprivilegedXrootdLauncher(daemonName string, configPath string, isCache bool) (result UnprivilegedXrootdLauncher, err error) {
 	result.DaemonName = daemonName
 	result.Uid = -1
 	result.Gid = -1
@@ -62,10 +62,14 @@ func makeUnprivilegedXrootdLauncher(daemonName string, configPath string) (resul
 			return
 		}
 	}
+
+	if isCache {
+		result.ExtraEnv = []string{"XRD_PLUGINCONFDIR=" + filepath.Join(xrootdRun, "cache-client.plugins.d")}
+	}
 	return
 }
 
-func ConfigureLaunchers(privileged bool, configPath string, useCMSD bool) (launchers []daemon.Launcher, err error) {
+func ConfigureLaunchers(privileged bool, configPath string, useCMSD bool, enableCache bool) (launchers []daemon.Launcher, err error) {
 	if privileged {
 		launchers = append(launchers, PrivilegedXrootdLauncher{"xrootd", configPath})
 		if useCMSD {
@@ -73,13 +77,13 @@ func ConfigureLaunchers(privileged bool, configPath string, useCMSD bool) (launc
 		}
 	} else {
 		var result UnprivilegedXrootdLauncher
-		result, err = makeUnprivilegedXrootdLauncher("xrootd", configPath)
+		result, err = makeUnprivilegedXrootdLauncher("xrootd", configPath, enableCache)
 		if err != nil {
 			return
 		}
 		launchers = append(launchers, result)
 		if useCMSD {
-			result, err = makeUnprivilegedXrootdLauncher("cmsd", configPath)
+			result, err = makeUnprivilegedXrootdLauncher("cmsd", configPath, false)
 			if err != nil {
 				return
 			}

--- a/xrootd/origin_test.go
+++ b/xrootd/origin_test.go
@@ -87,7 +87,7 @@ func originMockup(ctx context.Context, egrp *errgroup.Group, t *testing.T) conte
 	configPath, err := ConfigXrootd(shutdownCtx, true)
 	require.NoError(t, err)
 
-	launchers, err := ConfigureLaunchers(false, configPath, false)
+	launchers, err := ConfigureLaunchers(false, configPath, false, false)
 	require.NoError(t, err)
 
 	err = daemon.LaunchDaemons(shutdownCtx, launchers, egrp)

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -56,7 +56,7 @@ pfc.prefetch 20
 pfc.writequeue 16 4
 pfc.ram 4g
 pfc.diskusage 0.90 0.95 purgeinterval 300s
-pss.origin {{.Cache.DirectorUrl}}
+pss.origin {{.Cache.PSSOrigin}}
 # FIXME: the oss.space meta / data only works if the meta and data directories are different physical devices.
 # Otherwise, no data space is setup and the cache simply doesn't write out data.
 oss.localroot {{.Cache.DataLocation}}

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -294,6 +294,11 @@ func CheckCacheXrootdEnv(exportPath string, uid int, gid int, nsAds []director.N
 	if discoveryUrlStr := param.Federation_DiscoveryUrl.GetString(); discoveryUrlStr != "" {
 		discoveryUrl, err := url.Parse(discoveryUrlStr)
 		if err == nil {
+			log.Debugln("Parsing discovery URL for 'pss.origin' setting:", discoveryUrlStr)
+			if len(discoveryUrl.Path) > 0 && len(discoveryUrl.Host) == 0 {
+				discoveryUrl.Host = discoveryUrl.Path
+				discoveryUrl.Path = ""
+			}
 			discoveryUrl.Scheme = "pelican"
 			discoveryUrl.Path = ""
 			discoveryUrl.RawQuery = ""
@@ -362,9 +367,9 @@ func CheckXrootdEnv(server server_utils.XRootDServer) error {
 			return errors.Wrap(err, "Unable to create cache client plugins directory")
 		}
 		if runtime.GOOS == "darwin" {
-			err = os.WriteFile(filepath.Join(clientPluginsDir, "pelican-plugin.conf"), []byte(clientPluginDefault), os.FileMode(0644))
-		} else {
 			err = os.WriteFile(filepath.Join(clientPluginsDir, "pelican-plugin.conf"), []byte(clientPluginMac), os.FileMode(0644))
+		} else {
+			err = os.WriteFile(filepath.Join(clientPluginsDir, "pelican-plugin.conf"), []byte(clientPluginDefault), os.FileMode(0644))
 		}
 		if err != nil {
 			return errors.Wrap(err, "Unable to configure cache client plugin")

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -33,6 +33,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"text/template"
 	"time"
@@ -61,6 +62,20 @@ var (
 	errBadKeyPair error = errors.New("Bad X509 keypair")
 )
 
+const (
+	clientPluginDefault = `
+url = pelican://*
+lib = libXrdClPelican.so
+enable = true
+`
+
+	clientPluginMac = `
+url = pelican://*
+lib = libXrdClPelican.dylib
+enable = true
+`
+)
+
 type (
 	OriginConfig struct {
 		Multiuser        bool
@@ -84,7 +99,7 @@ type (
 		EnableVoms     bool
 		ExportLocation string
 		DataLocation   string
-		DirectorUrl    string
+		PSSOrigin      string
 	}
 
 	XrootdOptions struct {
@@ -275,7 +290,18 @@ func CheckCacheXrootdEnv(exportPath string, uid int, gid int, nsAds []director.N
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to pull information from the federation")
 	}
-	viper.Set("Cache.DirectorUrl", param.Federation_DirectorUrl.GetString())
+	viper.Set("Cache.PSSOrigin", param.Federation_DirectorUrl.GetString())
+	if discoveryUrlStr := param.Federation_DiscoveryUrl.GetString(); discoveryUrlStr != "" {
+		discoveryUrl, err := url.Parse(discoveryUrlStr)
+		if err == nil {
+			discoveryUrl.Scheme = "pelican"
+			discoveryUrl.Path = ""
+			discoveryUrl.RawQuery = ""
+			viper.Set("Cache.PSSOrigin", discoveryUrl.String())
+		} else {
+			return "", errors.Wrapf(err, "Failed to parse discovery URL %s", discoveryUrlStr)
+		}
+	}
 
 	if err := WriteCacheScitokensConfig(nsAds); err != nil {
 		return "", errors.Wrap(err, "Failed to create scitokens configuration for the cache")
@@ -328,6 +354,21 @@ func CheckXrootdEnv(server server_utils.XRootDServer) error {
 	}
 	if err = os.Setenv("XDG_CACHE_HOME", cacheDir); err != nil {
 		return errors.Wrap(err, "Unable to set $XDG_CACHE_HOME for scitokens library")
+	}
+
+	if server.GetServerType().IsEnabled(config.CacheType) {
+		clientPluginsDir := filepath.Join(runtimeDir, "cache-client.plugins.d")
+		if err = os.MkdirAll(clientPluginsDir, os.FileMode(0755)); err != nil {
+			return errors.Wrap(err, "Unable to create cache client plugins directory")
+		}
+		if runtime.GOOS == "darwin" {
+			err = os.WriteFile(filepath.Join(clientPluginsDir, "pelican-plugin.conf"), []byte(clientPluginDefault), os.FileMode(0644))
+		} else {
+			err = os.WriteFile(filepath.Join(clientPluginsDir, "pelican-plugin.conf"), []byte(clientPluginMac), os.FileMode(0644))
+		}
+		if err != nil {
+			return errors.Wrap(err, "Unable to configure cache client plugin")
+		}
 	}
 
 	exportPath := filepath.Join(runtimeDir, "export")
@@ -533,12 +574,12 @@ func ConfigXrootd(ctx context.Context, origin bool) (string, error) {
 				return "", errors.New("Origin.Multiuser is set to `true` but the command was run without sufficient privilege; was it launched as root?")
 			}
 		}
-	} else if xrdConfig.Cache.DirectorUrl != "" {
+	} else if xrdConfig.Cache.PSSOrigin != "" {
 		// Workaround for a bug in XRootD 5.6.3: if the director URL is missing a port number, then
 		// XRootD crashes.
-		urlParsed, err := url.Parse(xrdConfig.Cache.DirectorUrl)
+		urlParsed, err := url.Parse(xrdConfig.Cache.PSSOrigin)
 		if err != nil {
-			return "", errors.Errorf("Director URL (%s) does not parse as a URL", xrdConfig.Cache.DirectorUrl)
+			return "", errors.Errorf("Director URL (%s) does not parse as a URL", xrdConfig.Cache.PSSOrigin)
 		}
 		if !strings.Contains(urlParsed.Host, ":") {
 			switch urlParsed.Scheme {
@@ -546,10 +587,12 @@ func ConfigXrootd(ctx context.Context, origin bool) (string, error) {
 				urlParsed.Host += ":80"
 			case "https":
 				urlParsed.Host += ":443"
+			case "pelican":
+				urlParsed.Host += ":443"
 			default:
-				log.Warningf("The Director URL (%s) does not contain an explicit port number; XRootD 5.6.3 and earlier are known to segfault in thie case", xrdConfig.Cache.DirectorUrl)
+				log.Warningf("The Director URL (%s) does not contain an explicit port number; XRootD 5.6.3 and earlier are known to segfault in thie case", xrdConfig.Cache.PSSOrigin)
 			}
-			xrdConfig.Cache.DirectorUrl = urlParsed.String()
+			xrdConfig.Cache.PSSOrigin = urlParsed.String()
 		}
 	}
 


### PR DESCRIPTION
This enables the `pelican://` protocol for the cache's `pss.origin` setting.

Contains four parts:
- Setting the `pss.origin` xrootd configuration variable directly
- To avoid having to touch system files, creating a separate client plugins directory and point the cache at the new directory via environment variable.
- Extending the "launcher" setup to take environment variable overrides
- Updating the OSX GitHub builder scripts to patch in `pelican://` support for XRootD.  For Linux, I assume we'll pull in the patched version via the OSG build.