### PR TITLE
Update various GHA actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/pre-commit-linter.yml
+++ b/.github/workflows/pre-commit-linter.yml
@@ -12,8 +12,8 @@ jobs:
     name: linter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.20'
           cache: false

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: False
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Generate tag list
         id: generate-tag-list
@@ -78,10 +78,10 @@ jobs:
           echo "::set-output name=taglist::${tag_list[*]}"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to OSG Harbor
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         if: github.event_name != 'pull_request'
         with:
           registry: hub.opensciencegrid.org
@@ -89,7 +89,7 @@ jobs:
           password: ${{ secrets.PELICAN_HARBOR_ROBOT_PASSWORD }}
 
       - name: Build and push Docker images
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./images/Dockerfile

--- a/.github/workflows/publish-dev-container.yml
+++ b/.github/workflows/publish-dev-container.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: "recursive"
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: hub.opensciencegrid.org/pelican_platform/pelican-dev
           tags: |
@@ -30,10 +30,10 @@ jobs:
             type=raw,value=sha-{{sha}}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to OSG Harbor
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         if: github.event_name != 'pull_request'
         with:
           registry: hub.opensciencegrid.org

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v4
@@ -26,11 +26,11 @@ jobs:
         run: |
           make web-build
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v5
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
       # Do fetch depth 0 here because otherwise goreleaser might not work properly:
       # https://goreleaser.com/ci/actions/?h=tag#workflow
@@ -20,7 +20,7 @@ jobs:
       with:
         node-version: 20
     - name: Cache Next.js
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.npm
@@ -31,7 +31,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
     - name: Install Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
     - name: Install Mac OS X Dependencies
@@ -50,7 +50,7 @@ jobs:
         make web-build
         go test ./...
     - name: Run GoReleaser for Non-Ubuntu
-      uses: goreleaser/goreleaser-action@v4
+      uses: goreleaser/goreleaser-action@v5
       with:
         # either 'goreleaser' (default) or 'goreleaser-pro'
         distribution: goreleaser
@@ -62,7 +62,7 @@ jobs:
       image: hub.opensciencegrid.org/pelican_platform/pelican-dev:latest-itb
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # See above for why fetch depth is 0 here
         fetch-depth: 0
@@ -76,7 +76,7 @@ jobs:
         git config --global --add safe.directory /__w/pelican/pelican
         git fetch --force --tags
     - name: Cache Next.js
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.npm
@@ -100,7 +100,7 @@ jobs:
     - name: Restore base test coverage
       id: base-coverage
       if: github.event.pull_request.base.sha != ''
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           unit-base.txt
@@ -129,7 +129,7 @@ jobs:
       if: github.event_name == 'pull_request'
       run: echo 'Code coverage ' ${{steps.cc.outputs.cc_total}}'% Prev ' ${{steps.cc_b.outputs.cc_base_total}}'%' >> $GITHUB_STEP_SUMMARY
     - name: Run GoReleaser for Ubuntu
-      uses: goreleaser/goreleaser-action@v4
+      uses: goreleaser/goreleaser-action@v5
       with:
         # either 'goreleaser' (default) or 'goreleaser-pro'
         distribution: goreleaser


### PR DESCRIPTION
Closes #697 

The warning is still there because the `pre-commit` action hasn't updated the dependent action they are using but there's a PR for that already, so it should be updated soon: https://github.com/pre-commit/action/pull/188