### PR TITLE
Fix origin export options to allow Xrootd.Mount/Origin.NamespacePrefix combo

### DIFF
--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -98,8 +98,24 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (context.Canc
 		mode := param.Origin_Mode.GetString()
 		switch mode {
 		case "posix":
-			if param.Origin_ExportVolume.GetString() == "" {
-				return shutdownCancel, errors.Errorf("Origin.ExportVolume must be set in the parameters.yaml file.")
+			if param.Origin_ExportVolume.GetString() == "" && (param.Xrootd_Mount.GetString() == "" || param.Origin_NamespacePrefix.GetString() == "") {
+				return shutdownCancel, errors.Errorf(`
+	Export information was not provided.
+	Add the command line flag:
+
+		-v /mnt/foo:/bar
+
+	to export the directory /mnt/foo to the namespace prefix /bar in the data federation. Alternatively, specify Origin.ExportVolume in the parameters.yaml file:
+
+		Origin:
+			ExportVolume: /mnt/foo:/bar
+
+	Or, specify Xrootd.Mount and Origin.NamespacePrefix in the parameters.yaml file:
+
+		Xrootd:
+			Mount: /mnt/foo
+		Origin:
+			NamespacePrefix: /bar`)
 			}
 		case "s3":
 			if param.Origin_S3Bucket.GetString() == "" || param.Origin_S3Region.GetString() == "" ||

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -160,12 +160,23 @@ func CheckOriginXrootdEnv(exportPath string, uid int, gid int, groupname string)
 			mountPath := param.Xrootd_Mount.GetString()
 			namespacePrefix := param.Origin_NamespacePrefix.GetString()
 			if mountPath == "" || namespacePrefix == "" {
-				return exportPath, errors.New(`Export information was not provided.
-		Add command line flag:
+				return exportPath, errors.New(`
+	The origin should have parsed export information prior to this point, but has failed to do so.
+	Was the mount passed via the command line flag:
 
-			-v /mnt/foo:/bar
+		-v /mnt/foo:/bar
 
-		to export the directory /mnt/foo to the path /bar in the data federation`)
+	or via the parameters.yaml file:
+
+		# Option 1
+		Origin.ExportVolume: /mnt/foo:/bar
+
+		# Option 2
+		Xrootd
+			Mount: /mnt/foo
+		Origin:
+			NamespacePrefix: /bar
+				`)
 			}
 			mountPath, err := filepath.Abs(mountPath)
 			if err != nil {


### PR DESCRIPTION
To specify the local export and namespace prefix when serving an origin, both `Origin.ExportVolume` or a combination of `Xrootd.Mount` and `Origin.NamespacePrefix` are valid options. There was a bug that prevented the origin from spinning up in the case that `Origin.ExportVolume` was not directly specified, or populated via the command line volume mount flag. This fix allows either combination to work.

Closes #621