### PR TITLE
Expanding plugin error reporting from plugin to starter

### DIFF
--- a/classads/classads.go
+++ b/classads/classads.go
@@ -65,6 +65,16 @@ func (c *ClassAd) String() string {
 			newVal := strings.Replace(v, "\"", "\\\"", -1)
 			buffer.WriteString(newVal)
 			buffer.WriteString("\"")
+		case map[string]interface{}:
+			buffer.WriteString("[")
+			for key, value := range v {
+				buffer.WriteString(key)
+				buffer.WriteString(" = ")
+				buffer.WriteString("\"")
+				buffer.WriteString(fmt.Sprintf("%v", value))
+				buffer.WriteString("\"; ")
+			}
+			buffer.WriteString("]")
 		default:
 			buffer.WriteString(fmt.Sprintf("%v", value))
 		}

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -275,7 +275,6 @@ func GenerateTransferDetailsUsingCache(cache CacheInterface, opts TransferDetail
 	return nil
 }
 
-// func download_http(sourceUrl *url.URL, destination string, payload *payloadStruct, namespace namespaces.Namespace, recursive bool, tokenName string) (bytesTransferred int64, err error, attempts []Attempt) {
 func download_http(sourceUrl *url.URL, destination string, payload *payloadStruct, namespace namespaces.Namespace, recursive bool, tokenName string) (transferResults []TransferResults, err error) {
 	// First, create a handler for any panics that occur
 	defer func() {

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -570,7 +570,6 @@ func DownloadHTTP(transfer TransferDetails, dest string, token string, payload *
 	log.Debugln("Starting the HTTP transfer...")
 	filename := path.Base(dest)
 	resp := client.Do(req)
-	serverVersion := resp.HTTPResponse.Header.Get("Server")
 	downloadStart := time.Now()
 	// Check the error real quick
 	if resp.IsComplete() {
@@ -579,9 +578,10 @@ func DownloadHTTP(transfer TransferDetails, dest string, token string, payload *
 				err = fmt.Errorf("Local copy of file is larger than remote copy %w", grab.ErrBadLength)
 			}
 			log.Errorln("Failed to download:", err)
-			return 0, 0, serverVersion, &ConnectionSetupError{Err: err}
+			return 0, 0, "", &ConnectionSetupError{Err: err}
 		}
 	}
+	serverVersion := resp.HTTPResponse.Header.Get("Server")
 
 	// Size of the download
 	contentLength := resp.Size()
@@ -736,7 +736,7 @@ Loop:
 		if errors.Is(err, syscall.ECONNREFUSED) ||
 			errors.Is(err, syscall.ECONNRESET) ||
 			errors.Is(err, syscall.ECONNABORTED) {
-			return 0, 0, serverVersion, &ConnectionSetupError{URL: resp.Request.URL().String()}
+			return 0, 0, "", &ConnectionSetupError{URL: resp.Request.URL().String()}
 		}
 		log.Debugln("Got error from HTTP download", err)
 		return 0, 0, serverVersion, err

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -190,7 +190,7 @@ func TestSlowTransfers(t *testing.T) {
 	var err error
 	// Do a quick timeout
 	go func() {
-		_, err = DownloadHTTP(transfers[0], filepath.Join(t.TempDir(), "test.txt"), "", nil)
+		_, _, err = DownloadHTTP(transfers[0], filepath.Join(t.TempDir(), "test.txt"), "", nil)
 		finishedChannel <- true
 	}()
 
@@ -253,7 +253,7 @@ func TestStoppedTransfer(t *testing.T) {
 	var err error
 
 	go func() {
-		_, err = DownloadHTTP(transfers[0], filepath.Join(t.TempDir(), "test.txt"), "", nil)
+		_, _, err = DownloadHTTP(transfers[0], filepath.Join(t.TempDir(), "test.txt"), "", nil)
 		finishedChannel <- true
 	}()
 
@@ -283,7 +283,7 @@ func TestConnectionError(t *testing.T) {
 	addr := l.Addr().String()
 	l.Close()
 
-	_, err = DownloadHTTP(TransferDetails{Url: url.URL{Host: addr, Scheme: "http"}, Proxy: false}, filepath.Join(t.TempDir(), "test.txt"), "", nil)
+	_, _, err = DownloadHTTP(TransferDetails{Url: url.URL{Host: addr, Scheme: "http"}, Proxy: false}, filepath.Join(t.TempDir(), "test.txt"), "", nil)
 
 	assert.IsType(t, &ConnectionSetupError{}, err)
 
@@ -316,7 +316,7 @@ func TestTrailerError(t *testing.T) {
 	assert.Equal(t, svr.URL, transfers[0].Url.String())
 
 	// Call DownloadHTTP and check if the error is returned correctly
-	_, err := DownloadHTTP(transfers[0], filepath.Join(t.TempDir(), "test.txt"), "", nil)
+	_, _, err := DownloadHTTP(transfers[0], filepath.Join(t.TempDir(), "test.txt"), "", nil)
 
 	assert.NotNil(t, err)
 	assert.EqualError(t, err, "transfer error: Unable to read test.txt; input/output error")
@@ -529,16 +529,16 @@ func TestFullUpload(t *testing.T) {
 		uploadURL := "stash:///test/" + fileName
 
 		methods := []string{"http"}
-		uploaded, err := DoStashCPSingle(tempFile.Name(), uploadURL, methods, false)
+		transferResults, err := DoStashCPSingle(tempFile.Name(), uploadURL, methods, false)
 		assert.NoError(t, err, "Error uploading file")
-		assert.Equal(t, int64(len(testFileContent)), uploaded, "Uploaded file size does not match")
+		assert.Equal(t, int64(len(testFileContent)), transferResults[0].TransferedBytes, "Uploaded file size does not match")
 
 		// Upload an osdf file
 		uploadURL = "osdf:///test/stuff/blah.txt"
 		assert.NoError(t, err, "Error parsing upload URL")
-		uploaded, err = DoStashCPSingle(tempFile.Name(), uploadURL, methods, false)
+		transferResults, err = DoStashCPSingle(tempFile.Name(), uploadURL, methods, false)
 		assert.NoError(t, err, "Error uploading file")
-		assert.Equal(t, int64(len(testFileContent)), uploaded, "Uploaded file size does not match")
+		assert.Equal(t, int64(len(testFileContent)), transferResults[0].TransferedBytes, "Uploaded file size does not match")
 	})
 	t.Cleanup(func() {
 		ObjectClientOptions.Token = ""

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -190,7 +190,7 @@ func TestSlowTransfers(t *testing.T) {
 	var err error
 	// Do a quick timeout
 	go func() {
-		_, _, err = DownloadHTTP(transfers[0], filepath.Join(t.TempDir(), "test.txt"), "", nil)
+		_, _, _, err = DownloadHTTP(transfers[0], filepath.Join(t.TempDir(), "test.txt"), "", nil)
 		finishedChannel <- true
 	}()
 
@@ -253,7 +253,7 @@ func TestStoppedTransfer(t *testing.T) {
 	var err error
 
 	go func() {
-		_, _, err = DownloadHTTP(transfers[0], filepath.Join(t.TempDir(), "test.txt"), "", nil)
+		_, _, _, err = DownloadHTTP(transfers[0], filepath.Join(t.TempDir(), "test.txt"), "", nil)
 		finishedChannel <- true
 	}()
 
@@ -283,7 +283,7 @@ func TestConnectionError(t *testing.T) {
 	addr := l.Addr().String()
 	l.Close()
 
-	_, _, err = DownloadHTTP(TransferDetails{Url: url.URL{Host: addr, Scheme: "http"}, Proxy: false}, filepath.Join(t.TempDir(), "test.txt"), "", nil)
+	_, _, _, err = DownloadHTTP(TransferDetails{Url: url.URL{Host: addr, Scheme: "http"}, Proxy: false}, filepath.Join(t.TempDir(), "test.txt"), "", nil)
 
 	assert.IsType(t, &ConnectionSetupError{}, err)
 
@@ -316,7 +316,7 @@ func TestTrailerError(t *testing.T) {
 	assert.Equal(t, svr.URL, transfers[0].Url.String())
 
 	// Call DownloadHTTP and check if the error is returned correctly
-	_, _, err := DownloadHTTP(transfers[0], filepath.Join(t.TempDir(), "test.txt"), "", nil)
+	_, _, _, err := DownloadHTTP(transfers[0], filepath.Join(t.TempDir(), "test.txt"), "", nil)
 
 	assert.NotNil(t, err)
 	assert.EqualError(t, err, "transfer error: Unable to read test.txt; input/output error")

--- a/client/handle_ingest.go
+++ b/client/handle_ingest.go
@@ -103,7 +103,7 @@ func DoShadowIngest(sourceFile string, originPrefix string, shadowOriginPrefix s
 			time.Sleep(5 * time.Second)
 		}
 
-		uploadBytes, err := DoStashCPSingle(sourceFile, shadowFile, methods, false)
+		transferResults, err := DoStashCPSingle(sourceFile, shadowFile, methods, false)
 		if err != nil {
 			return 0, "", err
 		}
@@ -114,7 +114,7 @@ func DoShadowIngest(sourceFile string, originPrefix string, shadowOriginPrefix s
 			return 0, "", err
 		}
 		if shadowFilePost == shadowFile {
-			return uploadBytes, shadowFile, err
+			return transferResults[0].TransferedBytes, shadowFile, err
 		}
 	}
 	return 0, "", errors.New("After 10 upload attempts, file was still being modified during ingest.")

--- a/client/main.go
+++ b/client/main.go
@@ -30,16 +30,11 @@ import (
 	"strconv"
 	"strings"
 
-	//"net/http"
 	"math/rand"
 	"os"
 	"path"
 	"path/filepath"
 	"time"
-
-	// "crypto/sha1"
-	// "encoding/hex"
-	// "strings"
 
 	log "github.com/sirupsen/logrus"
 
@@ -104,16 +99,18 @@ func getTokenName(destination *url.URL) (scheme, tokenName string) {
 }
 
 // Do writeback to stash using SciTokens
-func doWriteBack(source string, destination *url.URL, namespace namespaces.Namespace, recursive bool, projectName string) (int64, error) {
+func doWriteBack(source string, destination *url.URL, namespace namespaces.Namespace, recursive bool, projectName string) (transferResults []TransferResults, err error) {
 
 	scitoken_contents, err := getToken(destination, namespace, true, "")
 	if err != nil {
-		return 0, err
+		return nil, fmt.Errorf("Failed to get token for write-back: %v", err)
 	}
 	if recursive {
 		return UploadDirectory(source, destination, scitoken_contents, namespace, projectName)
 	} else {
-		return UploadFile(source, destination, scitoken_contents, namespace, projectName)
+		transferResult, err := UploadFile(source, destination, scitoken_contents, namespace, projectName)
+		transferResults = append(transferResults, transferResult)
+		return transferResults, err
 	}
 }
 
@@ -472,7 +469,7 @@ localObject: the source file/directory you would like to upload
 remoteDestination: the end location of the upload
 recursive: a boolean indicating if the source is a directory or not
 */
-func DoPut(localObject string, remoteDestination string, recursive bool) (bytesTransferred int64, err error) {
+func DoPut(localObject string, remoteDestination string, recursive bool) (transferResults []TransferResults, err error) {
 	isPut := true
 	// First, create a handler for any panics that occur
 	defer func() {
@@ -481,7 +478,6 @@ func DoPut(localObject string, remoteDestination string, recursive bool) (bytesT
 			log.Debugln("Panic caused by the following", string(debug.Stack()))
 			ret := fmt.Sprintf("Unrecoverable error (panic) captured in DoPut: %v", r)
 			err = errors.New(ret)
-			bytesTransferred = 0
 
 			// Attempt to add the panic to the error accumulator
 			AddError(errors.New(ret))
@@ -492,14 +488,14 @@ func DoPut(localObject string, remoteDestination string, recursive bool) (bytesT
 	localObjectUrl, err := url.Parse(localObject)
 	if err != nil {
 		log.Errorln("Failed to parse source URL:", err)
-		return 0, err
+		return nil, err
 	}
 
 	remoteDestination, remoteDestScheme := correctURLWithUnderscore(remoteDestination)
 	remoteDestUrl, err := url.Parse(remoteDestination)
 	if err != nil {
 		log.Errorln("Failed to parse remote destination URL:", err)
-		return 0, err
+		return nil, err
 	}
 	remoteDestUrl.Scheme = remoteDestScheme
 
@@ -508,7 +504,7 @@ func DoPut(localObject string, remoteDestination string, recursive bool) (bytesT
 			remoteDestUrl.Path, err = url.JoinPath(remoteDestUrl.Host, remoteDestUrl.Path)
 			if err != nil {
 				log.Errorln("Failed to join remote destination url path:", err)
-				return 0, err
+				return nil, err
 			}
 		} else if remoteDestUrl.Scheme == "pelican" {
 			federationUrl, _ := url.Parse(remoteDestUrl.String())
@@ -517,7 +513,7 @@ func DoPut(localObject string, remoteDestination string, recursive bool) (bytesT
 			viper.Set("Federation.DiscoveryUrl", federationUrl.String())
 			err = config.DiscoverFederation()
 			if err != nil {
-				return 0, err
+				return nil, err
 			}
 		}
 	}
@@ -527,7 +523,7 @@ func DoPut(localObject string, remoteDestination string, recursive bool) (bytesT
 
 	_, foundDest := Find(understoodSchemes, remoteDestScheme)
 	if !foundDest {
-		return 0, fmt.Errorf("Do not understand the destination scheme: %s. Permitted values are %s",
+		return nil, fmt.Errorf("Do not understand the destination scheme: %s. Permitted values are %s",
 			remoteDestUrl.Scheme, strings.Join(understoodSchemes, ", "))
 	}
 
@@ -541,7 +537,7 @@ func DoPut(localObject string, remoteDestination string, recursive bool) (bytesT
 	ns, err := getNamespaceInfo(remoteDestination, directorUrl, isPut)
 	if err != nil {
 		log.Errorln(err)
-		return 0, errors.New("Failed to get namespace information from source")
+		return nil, errors.New("Failed to get namespace information from source")
 	}
 	uploadedBytes, err := doWriteBack(localObjectUrl.Path, remoteDestUrl, ns, recursive, "")
 	AddError(err)
@@ -556,7 +552,7 @@ remoteObject: the source file/directory you would like to upload
 localDestination: the end location of the upload
 recursive: a boolean indicating if the source is a directory or not
 */
-func DoGet(remoteObject string, localDestination string, recursive bool) (bytesTransferred int64, err error) {
+func DoGet(remoteObject string, localDestination string, recursive bool) (transferResults []TransferResults, err error) {
 	isPut := false
 	// First, create a handler for any panics that occur
 	defer func() {
@@ -565,7 +561,6 @@ func DoGet(remoteObject string, localDestination string, recursive bool) (bytesT
 			log.Debugln("Panic caused by the following", string(debug.Stack()))
 			ret := fmt.Sprintf("Unrecoverable error (panic) captured in DoGet: %v", r)
 			err = errors.New(ret)
-			bytesTransferred = 0
 
 			// Attempt to add the panic to the error accumulator
 			AddError(errors.New(ret))
@@ -577,7 +572,7 @@ func DoGet(remoteObject string, localDestination string, recursive bool) (bytesT
 	remoteObjectUrl, err := url.Parse(remoteObject)
 	if err != nil {
 		log.Errorln("Failed to parse source URL:", err)
-		return 0, err
+		return nil, err
 	}
 	remoteObjectUrl.Scheme = remoteObjectScheme
 
@@ -587,7 +582,7 @@ func DoGet(remoteObject string, localDestination string, recursive bool) (bytesT
 			remoteObjectUrl.Path, err = url.JoinPath(remoteObjectUrl.Host, remoteObjectUrl.Path)
 			if err != nil {
 				log.Errorln("Failed to join source url path:", err)
-				return 0, err
+				return nil, err
 			}
 		} else if remoteObjectUrl.Scheme == "pelican" {
 			federationUrl, _ := url.Parse(remoteObjectUrl.String())
@@ -596,7 +591,7 @@ func DoGet(remoteObject string, localDestination string, recursive bool) (bytesT
 			viper.Set("Federation.DiscoveryUrl", federationUrl.String())
 			err = config.DiscoverFederation()
 			if err != nil {
-				return 0, err
+				return nil, err
 			}
 		}
 	}
@@ -607,7 +602,7 @@ func DoGet(remoteObject string, localDestination string, recursive bool) (bytesT
 
 	_, foundSource := Find(understoodSchemes, remoteObjectScheme)
 	if !foundSource {
-		return 0, fmt.Errorf("Do not understand the source scheme: %s. Permitted values are %s",
+		return nil, fmt.Errorf("Do not understand the source scheme: %s. Permitted values are %s",
 			remoteObjectUrl.Scheme, strings.Join(understoodSchemes, ", "))
 	}
 
@@ -624,7 +619,7 @@ func DoGet(remoteObject string, localDestination string, recursive bool) (bytesT
 	ns, err := getNamespaceInfo(remoteObject, directorUrl, isPut)
 	if err != nil {
 		log.Errorln(err)
-		return 0, errors.New("Failed to get namespace information from source")
+		return nil, errors.New("Failed to get namespace information from source")
 	}
 
 	// get absolute path
@@ -655,7 +650,7 @@ func DoGet(remoteObject string, localDestination string, recursive bool) (bytesT
 	_, token_name := getTokenName(remoteObjectUrl)
 
 	var downloaded int64
-	if downloaded, err = download_http(remoteObjectUrl, localDestination, &payload, ns, recursive, token_name); err == nil {
+	if transferResults, err = download_http(remoteObjectUrl, localDestination, &payload, ns, recursive, token_name); err == nil {
 		success = true
 	}
 
@@ -676,14 +671,14 @@ func DoGet(remoteObject string, localDestination string, recursive bool) (bytesT
 	}
 
 	if !success {
-		return downloaded, errors.New("failed to download file")
+		return nil, errors.New("failed to download file")
 	} else {
-		return downloaded, nil
+		return transferResults, err
 	}
 }
 
 // Start the transfer, whether read or write back. Primarily used for backwards compatibility
-func DoStashCPSingle(sourceFile string, destination string, methods []string, recursive bool) (bytesTransferred int64, err error) {
+func DoStashCPSingle(sourceFile string, destination string, methods []string, recursive bool) (transferResults []TransferResults, err error) {
 
 	// First, create a handler for any panics that occur
 	defer func() {
@@ -692,7 +687,6 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 			log.Debugln("Panic caused by the following", string(debug.Stack()))
 			ret := fmt.Sprintf("Unrecoverable error (panic) captured in DoStashCPSingle: %v", r)
 			err = errors.New(ret)
-			bytesTransferred = 0
 
 			// Attempt to add the panic to the error accumulator
 			AddError(errors.New(ret))
@@ -704,7 +698,7 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 	source_url, err := url.Parse(sourceFile)
 	if err != nil {
 		log.Errorln("Failed to parse source URL:", err)
-		return 0, err
+		return nil, err
 	}
 	source_url.Scheme = source_scheme
 
@@ -712,7 +706,7 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 	dest_url, err := url.Parse(destination)
 	if err != nil {
 		log.Errorln("Failed to parse destination URL:", err)
-		return 0, err
+		return nil, err
 	}
 	dest_url.Scheme = dest_scheme
 
@@ -727,7 +721,7 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 			viper.Set("Federation.DiscoveryUrl", federationUrl.String())
 			err = config.DiscoverFederation()
 			if err != nil {
-				return 0, err
+				return nil, err
 			}
 		}
 	}
@@ -742,7 +736,7 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 			viper.Set("Federation.DiscoveryUrl", federationUrl.String())
 			err = config.DiscoverFederation()
 			if err != nil {
-				return 0, err
+				return nil, err
 			}
 		}
 	}
@@ -755,13 +749,13 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 	_, foundSource := Find(understoodSchemes, sourceScheme)
 	if !foundSource {
 		log.Errorln("Do not understand source scheme:", source_url.Scheme)
-		return 0, errors.New("Do not understand source scheme")
+		return nil, errors.New("Do not understand source scheme")
 	}
 
 	_, foundDest := Find(understoodSchemes, destScheme)
 	if !foundDest {
 		log.Errorln("Do not understand destination scheme:", source_url.Scheme)
-		return 0, errors.New("Do not understand destination scheme")
+		return nil, errors.New("Do not understand destination scheme")
 	}
 
 	payload := payloadStruct{}
@@ -779,11 +773,11 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 		ns, err := getNamespaceInfo(dest_url.Path, OSDFDirectorUrl, isPut)
 		if err != nil {
 			log.Errorln(err)
-			return 0, errors.New("Failed to get namespace information from destination")
+			return nil, errors.New("Failed to get namespace information from destination")
 		}
-		uploadedBytes, err := doWriteBack(source_url.Path, dest_url, ns, recursive, payload.ProjectName)
+		transferResults, err := doWriteBack(source_url.Path, dest_url, ns, recursive, payload.ProjectName) //TODO dowriteback transferResults!!!!!
 		AddError(err)
-		return uploadedBytes, err
+		return transferResults, err
 	}
 
 	if dest_url.Scheme == "file" {
@@ -801,7 +795,7 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 	ns, err := getNamespaceInfo(sourceFile, OSDFDirectorUrl, isPut)
 	if err != nil {
 		log.Errorln(err)
-		return 0, errors.New("Failed to get namespace information from source")
+		return nil, errors.New("Failed to get namespace information from source")
 	}
 
 	// get absolute path
@@ -842,7 +836,7 @@ Loop:
 		switch method {
 		case "http":
 			log.Info("Trying HTTP...")
-			if downloaded, err = download_http(source_url, destination, &payload, ns, recursive, token_name); err == nil {
+			if transferResults, err = download_http(source_url, destination, &payload, ns, recursive, token_name); err == nil {
 				success = true
 				break Loop
 			}
@@ -863,10 +857,10 @@ Loop:
 		// Get the final size of the download file
 		payload.fileSize = downloaded
 		payload.downloadSize = downloaded
-		return downloaded, nil
+		return transferResults, nil
 	} else {
 		payload.status = "Fail"
-		return downloaded, errors.New("All methods failed! Unable to download file.")
+		return transferResults, errors.New("All methods failed! Unable to download file.")
 	}
 }
 

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -198,14 +198,11 @@ func copyMain(cmd *cobra.Command, args []string) {
 	}
 
 	var result error
-	var downloaded int64 = 0
 	lastSrc := ""
 	for _, src := range source {
-		var tmpDownloaded int64
 		isRecursive, _ := cmd.Flags().GetBool("recursive")
 		client.ObjectClientOptions.Recursive = isRecursive
-		tmpDownloaded, result = client.DoStashCPSingle(src, dest, splitMethods, isRecursive)
-		downloaded += tmpDownloaded
+		_, result = client.DoStashCPSingle(src, dest, splitMethods, isRecursive)
 		if result != nil {
 			lastSrc = src
 			break

--- a/cmd/object_get.go
+++ b/cmd/object_get.go
@@ -104,14 +104,11 @@ func getMain(cmd *cobra.Command, args []string) {
 	}
 
 	var result error
-	var downloaded int64 = 0
 	lastSrc := ""
 	for _, src := range source {
-		var tmpDownloaded int64
 		isRecursive, _ := cmd.Flags().GetBool("recursive")
 		client.ObjectClientOptions.Recursive = isRecursive
-		tmpDownloaded, result = client.DoGet(src, dest, isRecursive)
-		downloaded += tmpDownloaded
+		_, result = client.DoGet(src, dest, isRecursive)
 		if result != nil {
 			lastSrc = src
 			break

--- a/cmd/object_put.go
+++ b/cmd/object_put.go
@@ -87,14 +87,11 @@ func putMain(cmd *cobra.Command, args []string) {
 	}
 
 	var result error
-	var downloaded int64 = 0
 	lastSrc := ""
 	for _, src := range source {
-		var tmpDownloaded int64
 		isRecursive, _ := cmd.Flags().GetBool("recursive")
 		client.ObjectClientOptions.Recursive = isRecursive
-		tmpDownloaded, result = client.DoPut(src, dest, isRecursive)
-		downloaded += tmpDownloaded
+		_, result = client.DoPut(src, dest, isRecursive)
 		if result != nil {
 			lastSrc = src
 			break

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -319,19 +319,24 @@ func moveObjects(source []string, methods []string, upload bool, wg *sync.WaitGr
 				developerData[fmt.Sprintf("TransferFileBytes%d", attempt.Number)] = attempt.TransferFileBytes
 				developerData[fmt.Sprintf("TimeToFirstByte%d", attempt.Number)] = attempt.TimeToFirstByte
 				developerData[fmt.Sprintf("Endpoint%d", attempt.Number)] = attempt.Endpoint
+				developerData[fmt.Sprintf("TransferEndTime%d", attempt.Number)] = attempt.TransferEndTime
+				developerData[fmt.Sprintf("ServerVersion%d", attempt.Number)] = attempt.ServerVersion
 				if attempt.Error != nil {
 					developerData[fmt.Sprintf("TransferError%d", attempt.Number)] = attempt.Error
 				}
 			}
-		} else if len(transferResults) != 0 && upload {
-			developerData["Attempts"] = 0
+		} else if len(transferResults) != 0 && upload { // For uploads, we only care about idx 0 since there is only 1 Attempt and 1 TransferResult
 			developerData["TransferFileBytes"] = transferResults[0].TransferedBytes
+			if len(transferResults[0].Attempts) != 0 { // Should be fine but check to be sure so we don't go out of bounds
+				developerData["Endpoint"] = transferResults[0].Attempts[0].Endpoint
+				developerData["TransferEndTime"] = transferResults[0].Attempts[0].TransferEndTime
+				developerData["ServerVersion"] = transferResults[0].Attempts[0].ServerVersion
+				developerData["TimeToFirstByte"] = transferResults[0].Attempts[0].TimeToFirstByte
+			}
 			if transferResults[0].Error != nil {
 				developerData["TransferError"] = transferResults[0].Error
 			}
 		}
-		// TODO: more classAds...
-		//...
 
 		resultAd.Set("DeveloperData", developerData)
 


### PR DESCRIPTION
This is a work in progress still but current changes include:
- Populating the new `DeveloperData` classad created by Todd M with most of the fields specified in the document of the issue
- Changing some inner-workings of the client, so that we can pass all relevant information back to the plugin
- Classads package can now decipher types of map[string]interface{} for nested classAds

Work still needed:
- Still need to add a few more classads with more info on each attempt
- More testing by hand is needed, to ensure functionality and backwards compatibility
- Testing with Todd M's latest merge to HTCondor to ensure functionality there
- Need to figure out how/what to return for classads on uploads