### PR TITLE
Fix server exit status code and remove verbose log at the client

### DIFF
--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -37,6 +37,10 @@ import (
 	"github.com/pelicanplatform/pelican/web_ui"
 )
 
+var (
+	ErrExitOnSignal error = errors.New("Exit program on signal")
+)
+
 func LaunchModules(ctx context.Context, modules config.ServerType) (context.CancelFunc, error) {
 	egrp, ok := ctx.Value(config.EgrpKey).(*errgroup.Group)
 	if !ok {
@@ -53,7 +57,7 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (context.Canc
 		case sig := <-sigs:
 			log.Warningf("Received signal %v; will shutdown process", sig)
 			shutdownCancel()
-			return nil
+			return ErrExitOnSignal
 		case <-ctx.Done():
 			return nil
 		}


### PR DESCRIPTION
Fixes #715 and #732 

For reviewer, the following can be a good verification process of the fix:
* Client should not log "Pelican is safely exited"  at the end of file transfer

```
./pelican object get -f osg-htc.org /ospool/uc-shared/public/OSG-Staff/validation/test.txt /dev/null
```

* Pelican should exit with status code = 1 if there's an error
  * Spin up your origin by appending `; echo $?` at the end of your existing command. i.e `./pelican origin serve; echo $?`
  * Kill XRootD by finding your xrootd process and kill it
  * Pelican should exit with something like:
 ```
ERROR[2024-01-31T19:22:06Z] Fatal error occurred that lead to the shutdown of the process: xrootd process failed unexpectedly: signal: killed 
1
 ```
Note that `1` means the status code is 1.


Also this PR removed the error log "Pelican is safely exited" and use `fmt.Println` instead to not to cause confusion.