### PR TITLE
Return 405 wherever it's supposed to be returned

### DIFF
--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -334,6 +334,7 @@ func GetEngine() (*gin.Engine, error) {
 			"resource": ctx.Request.URL.Path},
 		).Info("Served Request")
 	})
+	engine.HandleMethodNotAllowed = true
 	return engine, nil
 }
 


### PR DESCRIPTION
Fixes #718 

However, for registry, since we have a wildcard handler to handle all the `GET` request at `/api/v1.0/registry/*wildcard`, 405 won't be returned but rather 404