### PR TITLE
Topology authfile generation

### DIFF
--- a/config/resources/osdf.yaml
+++ b/config/resources/osdf.yaml
@@ -20,6 +20,7 @@ Xrootd:
   DetailedMonitoringHost: xrd-mon.osgstorage.org
 Federation:
   DiscoveryUrl: osg-htc.org
+  TopologyURL: https://topology.opensciencegrid.org
   TopologyNamespaceURL: https://topology.opensciencegrid.org/osdf/namespaces
   TopologyReloadInterval: 10
 Registry:

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -199,6 +199,14 @@ osdf_default: Default is determined dynamically through metadata at <Federation.
 default: none
 components: ["*"]
 ---
+name: Federation.TopologyUrl
+description: >-
+  A URL for the top level OSG Topology location (a legacy integration). This URL is needed to retrieve authorization file information.
+type: url
+osdf_default: "https://topology.opensciencegrid.org"
+default: none
+components: ["origin", "cache"]
+---
 name: Federation.TopologyNamespaceUrl
 description: >-
   A URL containing namespace information for origins and caches configured via the OSG Topology application (a legacy integration). The URL

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -69,6 +69,7 @@ var (
 	Federation_NamespaceUrl = StringParam{"Federation.NamespaceUrl"}
 	Federation_RegistryUrl = StringParam{"Federation.RegistryUrl"}
 	Federation_TopologyNamespaceUrl = StringParam{"Federation.TopologyNamespaceUrl"}
+	Federation_TopologyUrl = StringParam{"Federation.TopologyUrl"}
 	IssuerKey = StringParam{"IssuerKey"}
 	Issuer_AuthenticationSource = StringParam{"Issuer.AuthenticationSource"}
 	Issuer_GroupFile = StringParam{"Issuer.GroupFile"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -43,6 +43,7 @@ type config struct {
 		RegistryUrl string
 		TopologyNamespaceUrl string
 		TopologyReloadInterval time.Duration
+		TopologyUrl string
 	}
 	GeoIPOverrides interface{}
 	Issuer struct {
@@ -217,6 +218,7 @@ type configWithType struct {
 		RegistryUrl struct { Type string; Value string }
 		TopologyNamespaceUrl struct { Type string; Value string }
 		TopologyReloadInterval struct { Type string; Value time.Duration }
+		TopologyUrl struct { Type string; Value string }
 	}
 	GeoIPOverrides struct { Type string; Value interface{} }
 	Issuer struct {

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -161,7 +161,8 @@ func TestOSDFAuthCreation(t *testing.T) {
 				viper.Set("Server.Hostname", "sc-cache.chtc.wisc.edu")
 			}
 			viper.Set("Xrootd.RunLocation", dirName)
-			config.SetPreferredPrefix("OSDF")
+			oldPrefix := config.SetPreferredPrefix("OSDF")
+			defer config.SetPreferredPrefix(oldPrefix)
 
 			err := os.WriteFile(filepath.Join(dirName, "authfile"), []byte(testInput.authIn), fs.FileMode(0600))
 			require.NoError(t, err, "Failure writing test input authfile")


### PR DESCRIPTION
OSDF origins and caches now pull permissions from topology. This is to get around x509 legacy issues in OSDF.