### PR TITLE
OSDF configs: use more system-ish default locations for the TLS cert and key

### DIFF
--- a/systemd/osdf-cache.yaml
+++ b/systemd/osdf-cache.yaml
@@ -8,8 +8,8 @@ Federation:
   # We need the "origins" director to find origins instead of the default ("caches" director)
   DirectorUrl: https://osdf-director-origins.osg-htc.org
 Server:
-  TLSCertificate: /etc/grid-security/xrd/xrdcert.pem
-  TLSKey: /etc/grid-security/xrd/xrdkey.pem
+  TLSCertificate: /etc/pki/tls/certs/pelican.crt
+  TLSKey: /etc/pki/tls/private/pelican.key
   ## Use TLSCACertificateDirectory instead of TLSCACertificateFile to support auth from grid clients
   TLSCACertificateFile: /etc/pki/tls/certs/ca-bundle.crt
   # TLSCACertificateDirectory: /etc/grid-security/certificates

--- a/systemd/osdf-director.yaml
+++ b/systemd/osdf-director.yaml
@@ -5,6 +5,6 @@ Logging:
   ## Valid Levels are Trace, Debug, Info, Warning, Error, Fatal and Panic.
   # Level: "Error"
 Server:
-  TLSCertificate: /etc/grid-security/xrd/xrdcert.pem
-  TLSKey: /etc/grid-security/xrd/xrdkey.pem
+  TLSCertificate: /etc/pki/tls/certs/pelican.crt
+  TLSKey: /etc/pki/tls/private/pelican.key
   TLSCACertificateFile: /etc/pki/tls/certs/ca-bundle.crt

--- a/systemd/osdf-origin.yaml
+++ b/systemd/osdf-origin.yaml
@@ -5,8 +5,8 @@ Logging:
   ## Valid Levels are Trace, Debug, Info, Warning, Error, Fatal and Panic.
   # Level: "Error"
 Server:
-  TLSCertificate: /etc/grid-security/xrd/xrdcert.pem
-  TLSKey: /etc/grid-security/xrd/xrdkey.pem
+  TLSCertificate: /etc/pki/tls/certs/pelican.crt
+  TLSKey: /etc/pki/tls/private/pelican.key
   ## Use TLSCACertificateDirectory instead of TLSCACertificateFile to support auth from grid clients
   TLSCACertificateFile: /etc/pki/tls/certs/ca-bundle.crt
   # TLSCACertificateDirectory: /etc/grid-security/certificates

--- a/systemd/osdf-registry.yaml
+++ b/systemd/osdf-registry.yaml
@@ -5,6 +5,6 @@ Logging:
   ## Valid Levels are Trace, Debug, Info, Warning, Error, Fatal and Panic.
   # Level: "Error"
 Server:
-  TLSCertificate: /etc/grid-security/xrd/xrdcert.pem
-  TLSKey: /etc/grid-security/xrd/xrdkey.pem
+  TLSCertificate: /etc/pki/tls/certs/pelican.crt
+  TLSKey: /etc/pki/tls/private/pelican.key
   TLSCACertificateFile: /etc/pki/tls/certs/ca-bundle.crt


### PR DESCRIPTION
According to https://www.getpagespeed.com/server-setup/ssl-directory, the correct locations of the cert and key (for RHEL-based systems) is `/etc/pki/tls/certs/$hostname.crt` and `/etc/pki/tls/private/$hostname.key`.

We don't know the hostname when building the RPM so just call them `pelican.crt` and `pelican.key`.

Debian/Ubuntu uses `/etc/ssl` instead of `/etc/pki/tls` but I don't want to make two default configs.