### PR TITLE
Fix missing CILogon login option

### DIFF
--- a/web_ui/frontend/app/api/docs/pelican-swagger.yaml
+++ b/web_ui/frontend/app/api/docs/pelican-swagger.yaml
@@ -366,10 +366,7 @@ paths:
       tags:
         - common
       summary: Returns a list of enabled servers
-      description: "`Authentication Required`
-
-        Server names are in lower-case, sorted in alphabetical order.
-        "
+      description: Server names are in lower-case, sorted in alphabetical order.
       produces:
         - application/json
       responses:

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -193,7 +193,7 @@ func configureWebResource(engine *gin.Engine) error {
 // Configure common endpoint available to all server web UI which are located at /api/v1.0/*
 func configureCommonEndpoints(engine *gin.Engine) error {
 	engine.GET("/api/v1.0/config", AuthHandler, getConfigValues)
-	engine.GET("/api/v1.0/servers", AuthHandler, getEnabledServers)
+	engine.GET("/api/v1.0/servers", getEnabledServers)
 	// Health check endpoint for web engine
 	engine.GET("/api/v1.0/health", func(ctx *gin.Context) {
 		ctx.JSON(http.StatusOK, gin.H{"message": fmt.Sprintf("Web Engine Running. Time: %s", time.Now().String())})


### PR DESCRIPTION
Fixes #749 

To test, run

```shell
make web-build
```

And then your goreleaser.

Start your registry server, and go to `https://<hostname>/view/login/`

And you are supposed to see the option "Login with CILogon" button