### PR TITLE
Allow reused workflows to inherit secrets

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -46,7 +46,9 @@ jobs:
   release-container:
     needs: [pre-release]
     uses: PelicanPlatform/pelican/.github/workflows/release-container.yml@main
+    secrets: inherit
 
   release:
     needs: [pre-release]
     uses: PelicanPlatform/pelican/.github/workflows/release.yml@main
+    secrets: inherit


### PR DESCRIPTION
Fixes the broken release action by allowing the reused actions ( Release, and Release Container ) to use the original workflows secrets.