### PR TITLE
Fixes to xrootd logging config

### DIFF
--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -18,17 +18,16 @@ Logging:
   Level: "Error"
   Origin:
     Cms: "error"
-    Pfc: "info"
-    Pss: "error"
     Scitokens: "fatal"
     Xrd: "error"
     Xrootd: "info"
   Cache:
-    Ofs: error
-    Pss: error
-    Scitokens: fatal
-    Xrd: error
-    Xrootd: error
+    Ofs: "error"
+    Pfc: "info"
+    Pss: "error"
+    Scitokens: "fatal"
+    Xrd: "error"
+    Xrootd: "error"
 Client:
   WorkerCount: 5
 Server:

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -16,17 +16,19 @@
 
 Logging:
   Level: "Error"
-  Cache:
-    Scitokens: error
-    Pss: error
-    Ofs: error
-    Xrd: error
   Origin:
-    Scitokens: error
+    Cms: "error"
+    Pfc: "info"
+    Pss: "error"
+    Scitokens: "fatal"
+    Xrd: "error"
+    Xrootd: "info"
+  Cache:
+    Ofs: error
     Pss: error
-    Cms: error
-    Pfc: info
-    Xrootd: emsg login stall redirect
+    Scitokens: fatal
+    Xrd: error
+    Xrootd: error
 Client:
   WorkerCount: 5
 Server:

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -165,23 +165,6 @@ type: string
 default: error
 components: ["origin"]
 ---
-name: Logging.Origin.Pfc
-description: >-
-  Trace level of Xrootd Proxy File Cache (XCache), the caching mechanism used by Xrootd. This component
-  entails information for caches/caching within Xrootd. This component instantiates its own Open Storage
-  System (OSS) to write local files to.
-type: string
-default: info
-components: ["origin"]
----
-name: Logging.Origin.Pss
-description: >-
-  Trace level of Xrootd Proxy System Service. Variables this component reports include: number of remotes file opens,
-  number of opens that failed, number of remote file closes, and number of closes that failed.
-type: string
-default: error
-components: ["origin"]
----
 name: Logging.Origin.Scitokens
 description: >-
   Trace level of scitokens debug output within Xrootd configuration. This entails token management
@@ -214,6 +197,15 @@ description: >-
   writes for files and directories.
 type: string
 default: error
+components: ["cache"]
+---
+name: Logging.Cache.Pfc
+description: >-
+  Trace level of Xrootd Proxy File Cache (XCache), the caching mechanism used by Xrootd. This component
+  entails information for caches/caching within Xrootd. This component instantiates its own Open Storage
+  System (OSS) to write local files to.
+type: string
+default: info
 components: ["cache"]
 ---
 name: Logging.Cache.Pss

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -157,77 +157,95 @@ components: ["Client"]
 ---
 name: Logging.Origin.Cms
 description: >-
-  Trace level of Xrootd cluster management service.
+  Trace level of Xrootd cluster management service, one of the main xrootd executables.
+  Cms basically is a file (or asset) discovery service. Each server has a cmsd daemon which
+  connect to a master one informing it if a server is available. Xrootd asks cms where a file
+  could be found and cms works to report back the server for where the file is located.
 type: string
 default: error
 components: ["origin"]
 ---
 name: Logging.Origin.Pfc
 description: >-
-  Trace level of Xrootd Proxy File Cache, the caching mechanism used by Xrootd.
+  Trace level of Xrootd Proxy File Cache (XCache), the caching mechanism used by Xrootd. This component
+  entails information for caches/caching within Xrootd. This component instantiates its own Open Storage
+  System (OSS) to write local files to.
 type: string
 default: info
 components: ["origin"]
 ---
 name: Logging.Origin.Pss
 description: >-
-  Trace level of Xrootd Proxy System Service.
+  Trace level of Xrootd Proxy System Service. Variables this component reports include: number of remotes file opens,
+  number of opens that failed, number of remote file closes, and number of closes that failed.
 type: string
 default: error
 components: ["origin"]
 ---
 name: Logging.Origin.Scitokens
 description: >-
-  Trace level of scitokens debug output within Xrootd configuration.
+  Trace level of scitokens debug output within Xrootd configuration. This entails token management
+  and security credentials within Xrootd.
 type: string
 default: error
 components: ["origin"]
 ---
 name: Logging.Origin.Xrd
 description: >-
-  Trace level of the eXtended Request Daemon within Xrootd.
+  Trace level of the eXtended Request Daemon within Xrootd, another main xrootd executable. This reports information
+  the xrootd protocol and works with cms.
 type: string
 default: error
 components: ["origin"]
 ---
 name: Logging.Origin.Xrootd
 description: >-
-  Trace options for Xrootd debug output within Xrootd configuration.
+  Trace options for Xrootd debug output within Xrootd configuration. This prefix is reserved for the xroot protocol,
+  which is the component that sits on sockets and talks to clients as they query file-system info, open files, and read data.
+  This is the protocol for xrootd (like http) and handles connections and requests.
 type: string
 default: info
 components: ["origin"]
 ---
 name: Logging.Cache.Ofs
 description: >-
-  Trace level of Xrootd's Open File System.
+  Trace level of Xrootd's Open File System. This component cares about files and directories from the administrative perspective.
+  This component is build on top of the Open Storage System component, which deals with things like file creation and reads and
+  writes for files and directories.
 type: string
 default: error
 components: ["cache"]
 ---
 name: Logging.Cache.Pss
 description: >-
-  Trace level of Xrootd's Proxy System Service.
+  Trace level of Xrootd Proxy System Service. Variables this component reports include: number of remotes file opens,
+  number of opens that failed, number of remote file closes, and number of closes that failed.
 type: string
 default: error
 components: ["cache"]
 ---
 name: Logging.Cache.Scitokens
 description: >-
-  Trace level of scitokens debug output within Xrootd configuration.
+  Trace level of scitokens debug output within Xrootd configuration. This entails token management
+  and security credentials within Xrootd.
 type: string
 default: error
 components: ["cache"]
 ---
 name: Logging.Cache.Xrd
 description: >-
-  Trace level of the eXtended Request Daemon within Xrootd.
+  Trace level of the eXtended Request Daemon within Xrootd, another main xrootd executable. This reports information
+  the xrootd protocol and works with cms.
 type: string
 default: error
 components: ["cache"]
 ---
 name: Logging.Cache.Xrootd
 description: >-
-  Trace options for Xrootd debug output within Xrootd configuration.
+  Trace options for Xrootd debug output within Xrootd configuration. This prefix is reserved for the xroot protocol,
+  which is the component that sits on sockets and talks to clients as they query file-system info, open files, and read data.
+  This is the protocol for xrootd (like http) and handles connections and requests
+
 type: string
 default: error
 components: ["cache"]

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -155,69 +155,82 @@ type: bool
 default: false
 components: ["Client"]
 ---
-name: Logging.Cache.Scitokens
-description: >-
-  Trace level of scitokens debug output within Xrootd configuration. Values include: debug, info, error (default of error/none)
-type: string
-default: error
-components: ["cache"]
----
-name: Logging.Cache.Pss
-description: >-
-  Logging level of pss and pssSetOptCache within Xrootd configuration values include: debug, info, error (default of error/off/Debug Level 1)
-type: string
-default: error
-components: ["cache"]
----
-name: Logging.Cache.Ofs
-description: >-
-  Trace level of ofs debug output within Xrootd configuration. Values include: debug, info, error (default of error/-all)
-type: string
-default: error
-components: ["cache"]
----
-name: Logging.Cache.Xrd
-description: >-
-  Trace options for Xrootd debug output (xrd) within Xrootd configuration. Values include: debug, info, error (default of error/-all)
-type: string
-default: error
-components: ["cache"]
----
-name: Logging.Origin.Scitokens
-description: >-
-  Trace level of scitokens debug output within Xrootd configuration. Values include: debug, info, error (default of error/none)
-type: string
-default: error
-components: ["origin"]
----
-name: Logging.Origin.Pss
-description: >-
-  Logging level of pss and pssSetOptOrigin within Xrootd configuration values include: debug, info, error (default of error/off/Debug Level 1)
-type: string
-default: error
-components: ["origin"]
----
 name: Logging.Origin.Cms
 description: >-
-  Trace level of cms debug output within Xrootd configuration. Values include: debug, info, error (default of error/-all)
+  Trace level of Xrootd cluster management service.
 type: string
 default: error
 components: ["origin"]
 ---
 name: Logging.Origin.Pfc
 description: >-
-  Trace level of pfc debug output within Xrootd configuration. Values include: debug, info, error (default of info/info)
+  Trace level of Xrootd Proxy File Cache, the caching mechanism used by Xrootd.
 type: string
 default: info
 components: ["origin"]
 ---
+name: Logging.Origin.Pss
+description: >-
+  Trace level of Xrootd Proxy System Service.
+type: string
+default: error
+components: ["origin"]
+---
+name: Logging.Origin.Scitokens
+description: >-
+  Trace level of scitokens debug output within Xrootd configuration.
+type: string
+default: error
+components: ["origin"]
+---
+name: Logging.Origin.Xrd
+description: >-
+  Trace level of the eXtended Request Daemon within Xrootd.
+type: string
+default: error
+components: ["origin"]
+---
 name: Logging.Origin.Xrootd
 description: >-
-  Trace options for Xrootd debug output within Xrootd configuration. Values include: all, auth, debug, emsg, fs, fsaio, fsio, login, mem, off,
-  pgcserr, redirect, request, response, stall
+  Trace options for Xrootd debug output within Xrootd configuration.
 type: string
-default: emsg login stall redirect # Not sure how to do defaults for this one since ours/osg's are so specific
+default: info
 components: ["origin"]
+---
+name: Logging.Cache.Ofs
+description: >-
+  Trace level of Xrootd's Open File System.
+type: string
+default: error
+components: ["cache"]
+---
+name: Logging.Cache.Pss
+description: >-
+  Trace level of Xrootd's Proxy System Service.
+type: string
+default: error
+components: ["cache"]
+---
+name: Logging.Cache.Scitokens
+description: >-
+  Trace level of scitokens debug output within Xrootd configuration.
+type: string
+default: error
+components: ["cache"]
+---
+name: Logging.Cache.Xrd
+description: >-
+  Trace level of the eXtended Request Daemon within Xrootd.
+type: string
+default: error
+components: ["cache"]
+---
+name: Logging.Cache.Xrootd
+description: >-
+  Trace options for Xrootd debug output within Xrootd configuration.
+type: string
+default: error
+components: ["cache"]
 ---
 ############################
 # Federation-Level Configs #

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -102,12 +102,14 @@ var (
 	Logging_Cache_Pss = StringParam{"Logging.Cache.Pss"}
 	Logging_Cache_Scitokens = StringParam{"Logging.Cache.Scitokens"}
 	Logging_Cache_Xrd = StringParam{"Logging.Cache.Xrd"}
+	Logging_Cache_Xrootd = StringParam{"Logging.Cache.Xrootd"}
 	Logging_Level = StringParam{"Logging.Level"}
 	Logging_LogLocation = StringParam{"Logging.LogLocation"}
 	Logging_Origin_Cms = StringParam{"Logging.Origin.Cms"}
 	Logging_Origin_Pfc = StringParam{"Logging.Origin.Pfc"}
 	Logging_Origin_Pss = StringParam{"Logging.Origin.Pss"}
 	Logging_Origin_Scitokens = StringParam{"Logging.Origin.Scitokens"}
+	Logging_Origin_Xrd = StringParam{"Logging.Origin.Xrd"}
 	Logging_Origin_Xrootd = StringParam{"Logging.Origin.Xrootd"}
 	Monitoring_DataLocation = StringParam{"Monitoring.DataLocation"}
 	OIDC_AuthorizationEndpoint = StringParam{"OIDC.AuthorizationEndpoint"}

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -99,6 +99,7 @@ var (
 	Issuer_ScitokensServerLocation = StringParam{"Issuer.ScitokensServerLocation"}
 	Issuer_TomcatLocation = StringParam{"Issuer.TomcatLocation"}
 	Logging_Cache_Ofs = StringParam{"Logging.Cache.Ofs"}
+	Logging_Cache_Pfc = StringParam{"Logging.Cache.Pfc"}
 	Logging_Cache_Pss = StringParam{"Logging.Cache.Pss"}
 	Logging_Cache_Scitokens = StringParam{"Logging.Cache.Scitokens"}
 	Logging_Cache_Xrd = StringParam{"Logging.Cache.Xrd"}
@@ -106,8 +107,6 @@ var (
 	Logging_Level = StringParam{"Logging.Level"}
 	Logging_LogLocation = StringParam{"Logging.LogLocation"}
 	Logging_Origin_Cms = StringParam{"Logging.Origin.Cms"}
-	Logging_Origin_Pfc = StringParam{"Logging.Origin.Pfc"}
-	Logging_Origin_Pss = StringParam{"Logging.Origin.Pss"}
 	Logging_Origin_Scitokens = StringParam{"Logging.Origin.Scitokens"}
 	Logging_Origin_Xrd = StringParam{"Logging.Origin.Xrd"}
 	Logging_Origin_Xrootd = StringParam{"Logging.Origin.Xrootd"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -89,6 +89,7 @@ type Config struct {
 	Logging struct {
 		Cache struct {
 			Ofs string
+			Pfc string
 			Pss string
 			Scitokens string
 			Xrd string
@@ -99,8 +100,6 @@ type Config struct {
 		LogLocation string
 		Origin struct {
 			Cms string
-			Pfc string
-			Pss string
 			Scitokens string
 			Xrd string
 			Xrootd string
@@ -315,6 +314,7 @@ type configWithType struct {
 	Logging struct {
 		Cache struct {
 			Ofs struct { Type string; Value string }
+			Pfc struct { Type string; Value string }
 			Pss struct { Type string; Value string }
 			Scitokens struct { Type string; Value string }
 			Xrd struct { Type string; Value string }
@@ -325,8 +325,6 @@ type configWithType struct {
 		LogLocation struct { Type string; Value string }
 		Origin struct {
 			Cms struct { Type string; Value string }
-			Pfc struct { Type string; Value string }
-			Pss struct { Type string; Value string }
 			Scitokens struct { Type string; Value string }
 			Xrd struct { Type string; Value string }
 			Xrootd struct { Type string; Value string }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -92,6 +92,7 @@ type Config struct {
 			Pss string
 			Scitokens string
 			Xrd string
+			Xrootd string
 		}
 		DisableProgressBars bool
 		Level string
@@ -101,6 +102,7 @@ type Config struct {
 			Pfc string
 			Pss string
 			Scitokens string
+			Xrd string
 			Xrootd string
 		}
 	}
@@ -316,6 +318,7 @@ type configWithType struct {
 			Pss struct { Type string; Value string }
 			Scitokens struct { Type string; Value string }
 			Xrd struct { Type string; Value string }
+			Xrootd struct { Type string; Value string }
 		}
 		DisableProgressBars struct { Type string; Value bool }
 		Level struct { Type string; Value string }
@@ -325,6 +328,7 @@ type configWithType struct {
 			Pfc struct { Type string; Value string }
 			Pss struct { Type string; Value string }
 			Scitokens struct { Type string; Value string }
+			Xrd struct { Type string; Value string }
 			Xrootd struct { Type string; Value string }
 		}
 	}

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -68,6 +68,7 @@ oss.localroot {{.Cache.DataLocation}}
 #oss.space meta {{.Cache.DataLocation}}/meta*
 #oss.space data {{.Cache.DataLocation}}/data*
 pss.debug
+pfc.trace {{.Logging.CachePfc}}
 pss.setopt {{.Logging.PssSetOptCache}}
 pss.trace {{.Logging.CachePss}}
 ofs.trace {{.Logging.CacheOfs}}

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -72,4 +72,5 @@ pss.setopt {{.Logging.PssSetOptCache}}
 pss.trace {{.Logging.CachePss}}
 ofs.trace {{.Logging.CacheOfs}}
 xrd.trace {{.Logging.CacheXrd}}
+xrootd.trace {{.Logging.CacheXrootd}}
 scitokens.trace {{.Logging.CacheScitokens}}

--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -85,6 +85,7 @@ ofs.ckslib * libXrdMultiuser.so
 {{end}}
 xrootd.chksum max 2 md5 adler32 crc32
 xrootd.trace {{.Logging.OriginXrootd}}
+xrd.trace {{.Logging.OriginXrd}}
 pfc.trace {{.Logging.OriginPfc}}
 pss.trace {{.Logging.OriginPss}}
 pss.setopt {{.Logging.PssSetOptOrigin}}

--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -86,9 +86,6 @@ ofs.ckslib * libXrdMultiuser.so
 xrootd.chksum max 2 md5 adler32 crc32
 xrootd.trace {{.Logging.OriginXrootd}}
 xrd.trace {{.Logging.OriginXrd}}
-pfc.trace {{.Logging.OriginPfc}}
-pss.trace {{.Logging.OriginPss}}
-pss.setopt {{.Logging.PssSetOptOrigin}}
 cms.trace {{.Logging.OriginCms}}
 xrootd.tls all
 scitokens.trace {{.Logging.OriginScitokens}}

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -135,13 +135,12 @@ type (
 
 	LoggingConfig struct {
 		OriginCms       string
-		OriginPfc       string
-		OriginPss       string
 		PssSetOptOrigin string
 		OriginScitokens string
 		OriginXrd       string
 		OriginXrootd    string
 		CacheOfs        string
+		CachePfc        string
 		CachePss        string
 		PssSetOptCache  string
 		CacheScitokens  string
@@ -825,49 +824,6 @@ func mapXrootdLogLevels(xrdConfig *XrootdConfig) error {
 		return errors.Wrap(err, "Error parsing specified log level for Origin_Cms")
 	}
 
-	// Origin Pfc
-	// https://xrootd.slac.stanford.edu/doc/dev56/pss_config.htm
-	xrdConfig.Logging.OriginPfc, err = genLoggingConfig("pfc", xrdConfig, param.Logging_Origin_Pfc.GetString(), loggingMap{
-		Trace: "dump",
-		Debug: "debug",
-		Info:  "info",
-		Warn:  "warning",
-		Error: "error",
-		Fatal: "none",
-	})
-	if err != nil {
-		return errors.Wrap(err, "Error parsing specified log level for Origin_Pfc")
-	}
-
-	// pssSetOptOrigin and pssOrigin
-	// https://xrootd.slac.stanford.edu/doc/dev56/pss_config.htm
-	// Note: pss has interesting config options:
-	// all     informational events.
-	// on      warning events.
-	// debug   error events.
-	// Therefore the following pss.trace I came up with is what follows:
-	xrdConfig.Logging.OriginPss, err = genLoggingConfig("pss", xrdConfig, param.Logging_Origin_Pss.GetString(), loggingMap{
-		Trace: "all",
-		Info:  "on",
-		Warn:  "debug",
-		Error: "off",
-	})
-	if err != nil {
-		return errors.Wrap(err, "Error parsing specified log level for Origin_Pss")
-	}
-
-	// Setopt:
-	xrdConfig.Logging.PssSetOptOrigin, err = genLoggingConfig("pss", xrdConfig, param.Logging_Origin_Pss.GetString(), loggingMap{
-		Trace: "DebugLevel 4",
-		Info:  "DebugLevel 3",
-		Warn:  "DebugLevel 2",
-		Error: "DebugLevel 1",
-		Fatal: "DebugLevel 0",
-	})
-	if err != nil {
-		return errors.Wrap(err, "Error parsing specified log level for Origin_Pss")
-	}
-
 	// Origin Scitokens
 	// https://github.com/xrootd/xrootd/blob/8f8498d66aa583c54c0875bb1cfe432f4be040f4/src/XrdSciTokens/XrdSciTokensAccess.cc#L951-L963
 	xrdConfig.Logging.OriginScitokens, err = genLoggingConfig("scitokens", xrdConfig, param.Logging_Origin_Scitokens.GetString(), loggingMap{
@@ -918,6 +874,20 @@ func mapXrootdLogLevels(xrdConfig *XrootdConfig) error {
 	})
 	if err != nil {
 		return errors.Wrap(err, "Error parsing specified log level for Cache_Ofs")
+	}
+
+	// Cache Pfc
+	// https://xrootd.slac.stanford.edu/doc/dev56/pss_config.htm
+	xrdConfig.Logging.CachePfc, err = genLoggingConfig("pfc", xrdConfig, param.Logging_Cache_Pfc.GetString(), loggingMap{
+		Trace: "dump",
+		Debug: "debug",
+		Info:  "info",
+		Warn:  "warning",
+		Error: "error",
+		Fatal: "none",
+	})
+	if err != nil {
+		return errors.Wrap(err, "Error parsing specified log level for Cache_Pfc")
 	}
 
 	// Cache PssSetOptCache and Cache Pss

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -830,13 +830,13 @@ func mapXrootdLogLevels(xrdConfig *XrootdConfig) error {
 		xrdConfig.Logging.PssSetOptOrigin = "DebugLevel 2"
 		xrdConfig.Logging.OriginPss = "debug"
 	case log.InfoLevel:
-		xrdConfig.Logging.PssSetOptOrigin = "DebugLevel 2"
+		xrdConfig.Logging.PssSetOptOrigin = "DebugLevel 3"
 		xrdConfig.Logging.OriginPss = "on"
 	case log.DebugLevel:
-		xrdConfig.Logging.PssSetOptOrigin = "DebugLevel 3"
+		xrdConfig.Logging.PssSetOptOrigin = "DebugLevel 4"
 		xrdConfig.Logging.OriginPss = "all"
 	case log.TraceLevel:
-		xrdConfig.Logging.PssSetOptOrigin = "DebugLevel 3"
+		xrdConfig.Logging.PssSetOptOrigin = "DebugLevel 4"
 		xrdConfig.Logging.OriginPss = "all"
 	default:
 		return errors.New("Improper xrootd logging config for Origin_Pss, proper values include: panic, fatal, error, warn, info, debug, trace")
@@ -968,13 +968,13 @@ func mapXrootdLogLevels(xrdConfig *XrootdConfig) error {
 		xrdConfig.Logging.PssSetOptCache = "DebugLevel 2"
 		xrdConfig.Logging.CachePss = "debug"
 	case log.InfoLevel:
-		xrdConfig.Logging.PssSetOptCache = "DebugLevel 2"
+		xrdConfig.Logging.PssSetOptCache = "DebugLevel 3"
 		xrdConfig.Logging.CachePss = "on"
 	case log.DebugLevel:
-		xrdConfig.Logging.PssSetOptCache = "DebugLevel 3"
+		xrdConfig.Logging.PssSetOptCache = "DebugLevel 4"
 		xrdConfig.Logging.CachePss = "all"
 	case log.TraceLevel:
-		xrdConfig.Logging.PssSetOptCache = "DebugLevel 3"
+		xrdConfig.Logging.PssSetOptCache = "DebugLevel 4"
 		xrdConfig.Logging.CachePss = "all"
 	default:
 		return errors.New("Improper xrootd logging config for Cache_Pss, proper values include: panic, fatal, error, warn, info, debug, trace")

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -66,9 +66,258 @@ func TestXrootDOriginConfig(t *testing.T) {
 	dirname := t.TempDir()
 	viper.Reset()
 	viper.Set("Origin.RunLocation", dirname)
+	viper.Set("Xrootd.RunLocation", dirname)
+	config.InitConfig()
 	configPath, err := ConfigXrootd(ctx, true)
 	require.NoError(t, err)
 	assert.NotNil(t, configPath)
+
+	t.Run("TestOriginCmsCorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Origin.Cms", "debug")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, true)
+		require.NoError(t, err)
+		assert.NotNil(t, configPath)
+
+		// Verify the output
+		file, err := os.Open(configPath)
+		assert.NoError(t, err)
+		defer file.Close()
+
+		content, err := io.ReadAll(file)
+		assert.NoError(t, err)
+		assert.Contains(t, string(content), "cms.trace debug")
+		viper.Reset()
+	})
+
+	t.Run("TestOriginCmsIncorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Origin.Cms", "degub")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, true)
+		require.Error(t, err)
+		assert.NotNil(t, configPath)
+		viper.Reset()
+	})
+
+	t.Run("TestOriginPfcCorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Origin.Pfc", "debug")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, true)
+		require.NoError(t, err)
+		assert.NotNil(t, configPath)
+
+		// Verify the output
+		file, err := os.Open(configPath)
+		assert.NoError(t, err)
+		defer file.Close()
+
+		content, err := io.ReadAll(file)
+		assert.NoError(t, err)
+		assert.Contains(t, string(content), "pfc.trace debug")
+		viper.Reset()
+	})
+
+	t.Run("TestOriginPfcIncorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Origin.Pfc", "degub")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, true)
+		require.Error(t, err)
+		assert.NotNil(t, configPath)
+		viper.Reset()
+	})
+
+	t.Run("TestOriginPssCorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Origin.Pss", "debug")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, true)
+		require.NoError(t, err)
+		assert.NotNil(t, configPath)
+
+		// Verify the output
+		file, err := os.Open(configPath)
+		assert.NoError(t, err)
+		defer file.Close()
+
+		content, err := io.ReadAll(file)
+		assert.NoError(t, err)
+		assert.Contains(t, string(content), "pss.trace all")
+		assert.Contains(t, string(content), "pss.setopt DebugLevel 3")
+		viper.Reset()
+	})
+
+	t.Run("TestOriginPssIncorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Origin.Pfc", "degub")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, true)
+		require.Error(t, err)
+		assert.NotNil(t, configPath)
+		viper.Reset()
+	})
+
+	t.Run("TestOriginScitokensCorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Origin.Scitokens", "debug")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, true)
+		require.NoError(t, err)
+		assert.NotNil(t, configPath)
+
+		// Verify the output
+		file, err := os.Open(configPath)
+		assert.NoError(t, err)
+		defer file.Close()
+
+		content, err := io.ReadAll(file)
+		assert.NoError(t, err)
+		assert.Contains(t, string(content), "scitokens.trace debug")
+		viper.Reset()
+	})
+
+	t.Run("TestOriginScitokensIncorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Origin.Scitokens", "degub")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, true)
+		require.Error(t, err)
+		assert.NotNil(t, configPath)
+		viper.Reset()
+	})
+
+	t.Run("TestOriginXrdCorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Origin.Xrd", "debug")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, true)
+		require.NoError(t, err)
+		assert.NotNil(t, configPath)
+
+		// Verify the output
+		file, err := os.Open(configPath)
+		assert.NoError(t, err)
+		defer file.Close()
+
+		content, err := io.ReadAll(file)
+		assert.NoError(t, err)
+		assert.Contains(t, string(content), "xrd.trace debug")
+		viper.Reset()
+	})
+
+	t.Run("TestOriginXrdIncorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Origin.Xrd", "degub")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, true)
+		require.Error(t, err)
+		assert.NotNil(t, configPath)
+		viper.Reset()
+	})
+
+	t.Run("TestOriginXrootdCorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Origin.Xrootd", "debug")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, true)
+		require.NoError(t, err)
+		assert.NotNil(t, configPath)
+
+		// Verify the output
+		file, err := os.Open(configPath)
+		assert.NoError(t, err)
+		defer file.Close()
+
+		content, err := io.ReadAll(file)
+		assert.NoError(t, err)
+		assert.Contains(t, string(content), "xrootd.trace debug")
+		viper.Reset()
+	})
+
+	t.Run("TestOriginXrootdIncorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Origin.Xrootd", "degub")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, true)
+		require.Error(t, err)
+		assert.NotNil(t, configPath)
+		viper.Reset()
+	})
 }
 
 func TestXrootDCacheConfig(t *testing.T) {
@@ -134,6 +383,207 @@ func TestXrootDCacheConfig(t *testing.T) {
 		assert.NotContains(t, string(content), "throttle.throttle concurrency")
 		viper.Reset()
 
+	})
+
+	t.Run("TestCacheOfsCorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Cache.Concurrency", 10)
+		viper.Set("Logging.Cache.Ofs", "debug")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, false)
+		require.NoError(t, err)
+		assert.NotNil(t, configPath)
+
+		// Verify the output
+		file, err := os.Open(configPath)
+		assert.NoError(t, err)
+		defer file.Close()
+
+		content, err := io.ReadAll(file)
+		assert.NoError(t, err)
+		assert.Contains(t, string(content), "ofs.trace debug")
+		viper.Reset()
+	})
+
+	t.Run("TestCacheOfsIncorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Cache.Ofs", "degub")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, false)
+		require.Error(t, err)
+		assert.NotNil(t, configPath)
+	})
+
+	t.Run("TestCachePssCorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Cache.Pss", "debug")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, false)
+		require.NoError(t, err)
+		assert.NotNil(t, configPath)
+
+		// Verify the output
+		file, err := os.Open(configPath)
+		assert.NoError(t, err)
+		defer file.Close()
+
+		content, err := io.ReadAll(file)
+		assert.NoError(t, err)
+		assert.Contains(t, string(content), "pss.setopt DebugLevel 3")
+		viper.Reset()
+	})
+
+	t.Run("TestCachePssIncorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Cache.Pss", "degub")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, false)
+		require.Error(t, err)
+		assert.NotNil(t, configPath)
+	})
+
+	t.Run("TestCacheScitokensCorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Cache.Scitokens", "debug")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, false)
+		require.NoError(t, err)
+		assert.NotNil(t, configPath)
+
+		// Verify the output
+		file, err := os.Open(configPath)
+		assert.NoError(t, err)
+		defer file.Close()
+
+		content, err := io.ReadAll(file)
+		assert.NoError(t, err)
+		assert.Contains(t, string(content), "scitokens.trace debug")
+		viper.Reset()
+	})
+
+	t.Run("TestCacheScitokensIncorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Cache.Scitokens", "degub")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, false)
+		require.Error(t, err)
+		assert.NotNil(t, configPath)
+	})
+
+	t.Run("TestCacheXrdCorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Cache.Xrd", "debug")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, false)
+		require.NoError(t, err)
+		assert.NotNil(t, configPath)
+
+		// Verify the output
+		file, err := os.Open(configPath)
+		assert.NoError(t, err)
+		defer file.Close()
+
+		content, err := io.ReadAll(file)
+		assert.NoError(t, err)
+		assert.Contains(t, string(content), "xrd.trace debug")
+		viper.Reset()
+	})
+
+	t.Run("TestCacheXrdIncorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Cache.Xrd", "degub")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, false)
+		require.Error(t, err)
+		assert.NotNil(t, configPath)
+	})
+
+	t.Run("TestCacheXrootdCorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Cache.Xrootd", "debug")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, false)
+		require.NoError(t, err)
+		assert.NotNil(t, configPath)
+
+		// Verify the output
+		file, err := os.Open(configPath)
+		assert.NoError(t, err)
+		defer file.Close()
+
+		content, err := io.ReadAll(file)
+		assert.NoError(t, err)
+		assert.Contains(t, string(content), "xrootd.trace debug")
+		viper.Reset()
+	})
+
+	t.Run("TestCacheXrootdIncorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Cache.Xrootd", "degub")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, false)
+		require.Error(t, err)
+		assert.NotNil(t, configPath)
 	})
 }
 

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -113,89 +113,6 @@ func TestXrootDOriginConfig(t *testing.T) {
 		viper.Reset()
 	})
 
-	t.Run("TestOriginPfcCorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Origin.Pfc", "debug")
-		dirname := t.TempDir()
-		viper.Set("Xrootd.RunLocation", dirname)
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, true)
-		require.NoError(t, err)
-		assert.NotNil(t, configPath)
-
-		// Verify the output
-		file, err := os.Open(configPath)
-		assert.NoError(t, err)
-		defer file.Close()
-
-		content, err := io.ReadAll(file)
-		assert.NoError(t, err)
-		assert.Contains(t, string(content), "pfc.trace debug")
-		viper.Reset()
-	})
-
-	t.Run("TestOriginPfcIncorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Origin.Pfc", "degub")
-		dirname := t.TempDir()
-		viper.Set("Xrootd.RunLocation", dirname)
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, true)
-		require.Error(t, err)
-		assert.NotNil(t, configPath)
-		viper.Reset()
-	})
-
-	t.Run("TestOriginPssCorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Origin.Pss", "debug")
-		dirname := t.TempDir()
-		viper.Set("Xrootd.RunLocation", dirname)
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, true)
-		require.NoError(t, err)
-		assert.NotNil(t, configPath)
-
-		// Verify the output
-		file, err := os.Open(configPath)
-		assert.NoError(t, err)
-		defer file.Close()
-
-		content, err := io.ReadAll(file)
-		assert.NoError(t, err)
-		assert.Contains(t, string(content), "pss.trace all")
-		assert.Contains(t, string(content), "pss.setopt DebugLevel 4")
-		viper.Reset()
-	})
-
-	t.Run("TestOriginPssIncorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Origin.Pfc", "degub")
-		dirname := t.TempDir()
-		viper.Set("Xrootd.RunLocation", dirname)
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, true)
-		require.Error(t, err)
-		assert.NotNil(t, configPath)
-		viper.Reset()
-	})
-
 	t.Run("TestOriginScitokensCorrectConfig", func(t *testing.T) {
 		xrootd := xrootdTest{T: t}
 		xrootd.setup()
@@ -424,6 +341,47 @@ func TestXrootDCacheConfig(t *testing.T) {
 		configPath, err := ConfigXrootd(ctx, false)
 		require.Error(t, err)
 		assert.NotNil(t, configPath)
+	})
+
+	t.Run("TestCachePfcCorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Cache.Pfc", "debug")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, false)
+		require.NoError(t, err)
+		assert.NotNil(t, configPath)
+
+		// Verify the output
+		file, err := os.Open(configPath)
+		assert.NoError(t, err)
+		defer file.Close()
+
+		content, err := io.ReadAll(file)
+		assert.NoError(t, err)
+		assert.Contains(t, string(content), "pfc.trace debug")
+		viper.Reset()
+	})
+
+	t.Run("TestCachePfcIncorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Logging.Cache.Pfc", "degub")
+		dirname := t.TempDir()
+		viper.Set("Xrootd.RunLocation", dirname)
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, true)
+		require.Error(t, err)
+		assert.NotNil(t, configPath)
+		viper.Reset()
 	})
 
 	t.Run("TestCachePssCorrectConfig", func(t *testing.T) {

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -176,7 +176,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "pss.trace all")
-		assert.Contains(t, string(content), "pss.setopt DebugLevel 3")
+		assert.Contains(t, string(content), "pss.setopt DebugLevel 4")
 		viper.Reset()
 	})
 
@@ -447,7 +447,7 @@ func TestXrootDCacheConfig(t *testing.T) {
 
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
-		assert.Contains(t, string(content), "pss.setopt DebugLevel 3")
+		assert.Contains(t, string(content), "pss.setopt DebugLevel 4")
 		viper.Reset()
 	})
 


### PR DESCRIPTION
Changes include:
- Xrootd logging now uses the standard logrus logging values
- Instead of string comparisons for mapping, we now use log.ParseLevel and compare the levels (which are unsigned ints)
- The program now exits when there is an improper config value and returns a proper error
- Anywhere these configs are listed, they are all listed alphabetically for consistency and an easier time finding each option
- Unit tests for the generation of the xrootd config file