### PR TITLE
Fixed issue with added new line in cache authfile

### DIFF
--- a/xrootd/authorization.go
+++ b/xrootd/authorization.go
@@ -294,7 +294,7 @@ func EmitAuthfile(server server_utils.XRootDServer) error {
 				}
 				output.Write([]byte(outStr + strings.Join(words[2:], " ") + "\n"))
 			} else {
-				output.Write([]byte(lineContents + "\n"))
+				output.Write([]byte(lineContents + " "))
 			}
 			foundPublicLine = true
 		} else {

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -125,7 +125,7 @@ g /xenon.biggrid.nl/* /nrp/protected/xenon-biggrid-nl/ rl
 u eeccb14b.0 /nrp/protected/xenon-biggrid-nl/ rl
 `
 
-	cacheMergedAuthfileEntries = cacheAuthfileEntries + "u * /user/ligo -rl /Gluex rl /NSG/PUBLIC rl /VDC/PUBLIC rl\n"
+	cacheMergedAuthfileEntries = cacheAuthfileEntries + "u * /user/ligo -rl /Gluex rl /NSG/PUBLIC rl /VDC/PUBLIC rl "
 )
 
 func TestOSDFAuthRetrieval(t *testing.T) {


### PR DESCRIPTION
    -- Removed extra newline when generating an authfile with a
       provided authfile with a plublic line
    -- Adjusted an authfile test to catch this