### PR TITLE
Create non-world-readable logfiles

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -618,13 +618,13 @@ func InitConfig() {
 	if logLocation != "" {
 		dir := filepath.Dir(logLocation)
 		if dir != "" {
-			if err := os.MkdirAll(dir, 0644); err != nil {
+			if err := os.MkdirAll(dir, 0640); err != nil {
 				log.Errorf("Failed to access/create specified directory. Error: %v", err)
 				os.Exit(1)
 			}
 		}
 		// Note: do not need to close the file, logrus does it for us
-		f, err := os.OpenFile(logLocation, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+		f, err := os.OpenFile(logLocation, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
 		if err != nil {
 			log.Errorf("Failed to access specified log file. Error: %v", err)
 			os.Exit(1)


### PR DESCRIPTION
When specifying the -l flag, log files now have permissions set to 0640 (not world readable) instead of 0644