### PR TITLE
Put default logfiles in /var/log/pelican; create /var/log/pelican non-world-readable in the RPM

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -232,6 +232,13 @@ nfpms:
       - src: "systemd/pelican-registry.yaml"
         dst: "/etc/pelican/pelican-registry.yaml"
         type: config|noreplace
+      - dst: "/var/log/pelican"
+        type: "dir"
+        file_info:
+          owner: root
+          group: root
+          mode: 0700
+
     overrides:
       rpm:
         dependencies:

--- a/systemd/osdf-cache.yaml
+++ b/systemd/osdf-cache.yaml
@@ -1,7 +1,7 @@
 ## Enable Debug to send detailed logs, including XRootD logs, to the log file
 # Debug: false
 Logging:
-  LogLocation: /var/log/osdf-cache.log
+  LogLocation: /var/log/pelican/osdf-cache.log
   ## Valid Levels are Trace, Debug, Info, Warning, Error, Fatal and Panic.
   # Level: "Error"
 Federation:

--- a/systemd/osdf-director.yaml
+++ b/systemd/osdf-director.yaml
@@ -1,7 +1,7 @@
 ## Enable Debug to send detailed logs to the log file
 # Debug: false
 Logging:
-  LogLocation: /var/log/osdf-director.log
+  LogLocation: /var/log/pelican/osdf-director.log
   ## Valid Levels are Trace, Debug, Info, Warning, Error, Fatal and Panic.
   # Level: "Error"
 Server:

--- a/systemd/osdf-origin.yaml
+++ b/systemd/osdf-origin.yaml
@@ -1,7 +1,7 @@
 ## Enable Debug to send detailed logs, including XRootD logs, to the log file
 # Debug: false
 Logging:
-  LogLocation: /var/log/osdf-origin.log
+  LogLocation: /var/log/pelican/osdf-origin.log
   ## Valid Levels are Trace, Debug, Info, Warning, Error, Fatal and Panic.
   # Level: "Error"
 Server:

--- a/systemd/osdf-registry.yaml
+++ b/systemd/osdf-registry.yaml
@@ -1,7 +1,7 @@
 ## Enable Debug to send detailed logs to the log file
 # Debug: false
 Logging:
-  LogLocation: /var/log/osdf-registry.log
+  LogLocation: /var/log/pelican/osdf-registry.log
   ## Valid Levels are Trace, Debug, Info, Warning, Error, Fatal and Panic.
   # Level: "Error"
 Server:

--- a/systemd/pelican-cache.yaml
+++ b/systemd/pelican-cache.yaml
@@ -1,7 +1,7 @@
 ## Enable Debug to send detailed logs, including XRootD logs, to the log file
 # Debug: false
 Logging:
-  LogLocation: /var/log/pelican-cache.log
+  LogLocation: /var/log/pelican/pelican-cache.log
   ## Valid Levels are Trace, Debug, Info, Warning, Error, Fatal and Panic.
   # Level: "Error"
 Federation:

--- a/systemd/pelican-director.yaml
+++ b/systemd/pelican-director.yaml
@@ -1,7 +1,7 @@
 ## Enable Debug to send detailed logs, including XRootD logs, to the log file
 # Debug: false
 Logging:
-  LogLocation: /var/log/pelican-director.log
+  LogLocation: /var/log/pelican/pelican-director.log
   ## Valid Levels are Trace, Debug, Info, Warning, Error, Fatal and Panic.
   # Level: "Error"
 Federation:

--- a/systemd/pelican-origin.yaml
+++ b/systemd/pelican-origin.yaml
@@ -1,7 +1,7 @@
 ## Enable Debug to send detailed logs, including XRootD logs, to the log file
 # Debug: false
 Logging:
-  LogLocation: /var/log/pelican-origin.log
+  LogLocation: /var/log/pelican/pelican-origin.log
   ## Valid Levels are Trace, Debug, Info, Warning, Error, Fatal and Panic.
   # Level: "Error"
 Federation:

--- a/systemd/pelican-registry.yaml
+++ b/systemd/pelican-registry.yaml
@@ -1,7 +1,7 @@
 ## Enable Debug to send detailed logs, including XRootD logs, to the log file
 # Debug: false
 Logging:
-  LogLocation: /var/log/pelican-registry.log
+  LogLocation: /var/log/pelican/pelican-registry.log
   ## Valid Levels are Trace, Debug, Info, Warning, Error, Fatal and Panic.
   # Level: "Error"
 Federation:


### PR DESCRIPTION
This is a workaround for #782 to avoid exposing sensitive data in world-readable logs, though it might be worth keeping around even after that issue is fixed, as an extra layer of safety.