### PR TITLE
Debug config value is remove and warnings added

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -607,6 +607,7 @@ func InitConfig() {
 	}
 	if param.Debug.GetBool() {
 		SetLogging(log.DebugLevel)
+		log.Warnln("Debug is set as a flag or in config, this will override anything set for Logging.Level within your configuration")
 	} else {
 		logLevel := param.Logging_Level.GetString()
 		level, err := log.ParseLevel(logLevel)

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-Debug: false
 Logging:
   Level: "Error"
   Cache:

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -33,6 +33,7 @@ type: filename
 name: Debug
 description: >-
   A bool indicating whether Pelican should emit debug messages in its log.
+  NOTE: this will override whatever is set within your configuration file under Logging.Level!
 type: bool
 default: false
 components: ["*"]

--- a/metrics/shoveler.go
+++ b/metrics/shoveler.go
@@ -106,7 +106,12 @@ func configShoveler(c *shoveler.Config) error {
 	}
 
 	c.DestUdp = param.Shoveler_OutputDestinations.GetStringSlice()
-	c.Debug = param.Debug.GetBool()
+	logLevel, err := log.ParseLevel(param.Logging_Level.GetString())
+	if logLevel == log.DebugLevel {
+		c.Debug = true
+	} else {
+		c.Debug = false
+	}
 	c.Verify = param.Shoveler_VerifyHeader.GetBool()
 
 	ipMappings := []ipMappingItem{}

--- a/metrics/shoveler.go
+++ b/metrics/shoveler.go
@@ -107,6 +107,9 @@ func configShoveler(c *shoveler.Config) error {
 
 	c.DestUdp = param.Shoveler_OutputDestinations.GetStringSlice()
 	logLevel, err := log.ParseLevel(param.Logging_Level.GetString())
+	if err != nil {
+		return errors.Wrap(err, "Issue parsing specified log level")
+	}
 	if logLevel == log.DebugLevel {
 		c.Debug = true
 	} else {


### PR DESCRIPTION
We now no longer set debug as a default config value and whenever it is used, we print a warning letting the user know that it is overriding anything set for Logging.Level. This is still needed however because of how our flags work with viper.