### PR TITLE
Only create topology table at server start and update topology table 10m instead of 10ms

### DIFF
--- a/config/resources/osdf.yaml
+++ b/config/resources/osdf.yaml
@@ -22,7 +22,7 @@ Federation:
   DiscoveryUrl: osg-htc.org
   TopologyURL: https://topology.opensciencegrid.org
   TopologyNamespaceURL: https://topology.opensciencegrid.org/osdf/namespaces
-  TopologyReloadInterval: 10
+  TopologyReloadInterval: 10m
 Registry:
   CacheApprovedOnly: true
   OriginApprovedOnly: true

--- a/registry/client_commands_test.go
+++ b/registry/client_commands_test.go
@@ -136,7 +136,9 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 	registrySvr := registryMockup(ctx, t, "OSDFkeychaining")
 	topoSvr := topologyMockup(t, []string{"/topo/foo"})
 	viper.Set("Federation.TopologyNamespaceURL", topoSvr.URL)
-	err := PopulateTopology()
+	err := createTopologyTable()
+	require.NoError(t, err)
+	err = PopulateTopology()
 	require.NoError(t, err)
 
 	defer func() {

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -141,7 +141,7 @@ func IsValidRegStatus(s string) bool {
 	return s == "Pending" || s == "Approved" || s == "Denied" || s == "Unknown"
 }
 
-func createNamespaceTable() {
+func createNamespaceTable() error {
 	//We put a size limit on admin_metadata to guard against potentially future
 	//malicious large inserts
 	query := `
@@ -156,7 +156,7 @@ func createNamespaceTable() {
 
 	_, err := db.Exec(query)
 	if err != nil {
-		log.Fatalf("Failed to create namespace table: %v", err)
+		return fmt.Errorf("Failed to create namespace table: %v", err)
 	}
 
 	// Run a manual migration to add "custom_fields" field
@@ -165,7 +165,7 @@ func createNamespaceTable() {
 	columnExists := false
 	rows, err := db.Query(`PRAGMA table_info(namespace);`)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	defer rows.Close()
 
@@ -180,7 +180,7 @@ func createNamespaceTable() {
 		)
 		err = rows.Scan(&cid, &name, &ctype, &notnull, &dfltValue, &pk)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		if name == "custom_fields" {
 			columnExists = true
@@ -192,16 +192,16 @@ func createNamespaceTable() {
 	if !columnExists {
 		_, err = db.Exec(`ALTER TABLE namespace ADD COLUMN custom_fields TEXT DEFAULT ''`)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		log.Info("Column 'custom_fields' added.")
 	} else {
 		log.Info("Column 'custom_fields' already exists.")
 	}
-
+	return nil
 }
 
-func createTopologyTable() {
+func createTopologyTable() error {
 	query := `
     CREATE TABLE IF NOT EXISTS topology (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -210,8 +210,9 @@ func createTopologyTable() {
 
 	_, err := db.Exec(query)
 	if err != nil {
-		log.Fatalf("Failed to create topology table: %v", err)
+		return fmt.Errorf("Failed to create topology table: %v", err)
 	}
+	return nil
 }
 
 func namespaceExists(prefix string) (bool, error) {
@@ -825,7 +826,15 @@ func InitializeDB(ctx context.Context) error {
 		return errors.Wrapf(err, "Failed to open the database with path: %s", dbPath)
 	}
 
-	createNamespaceTable()
+	if err := createNamespaceTable(); err != nil {
+		return err
+	}
+	if config.GetPreferredPrefix() == "OSDF" {
+		// Create the toplogy table
+		if err := createTopologyTable(); err != nil {
+			return err
+		}
+	}
 	return db.Ping()
 }
 
@@ -876,9 +885,6 @@ func modifyTopologyTable(prefixes []string, mode string) error {
 
 // Create a table in the registry to store namespace prefixes from topology
 func PopulateTopology() error {
-	// Create the toplogy table
-	createTopologyTable()
-
 	// The topology table may already exist from before, it may not. Because of this
 	// we need to add to the table any prefixes that are in topology, delete from the
 	// table any that aren't in topology, and skip any that exist in both.

--- a/registry/registry_db_test.go
+++ b/registry/registry_db_test.go
@@ -45,8 +45,10 @@ func setupMockRegistryDB(t *testing.T) {
 	mockDB, err := sql.Open("sqlite", ":memory:")
 	db = mockDB
 	require.NoError(t, err, "Error setting up mock namespace DB")
-	createNamespaceTable()
-	createTopologyTable()
+	err = createNamespaceTable()
+	require.NoError(t, err, "Error creating namespace table")
+	err = createTopologyTable()
+	require.NoError(t, err, "Error creating topology table")
 }
 
 func resetNamespaceDB(t *testing.T) {

--- a/registry/registry_db_test.go
+++ b/registry/registry_db_test.go
@@ -809,6 +809,8 @@ func TestRegistryTopology(t *testing.T) {
 	config.SetPreferredPrefix("OSDF")
 
 	//Test topology table population
+	err = createTopologyTable()
+	require.NoError(t, err)
 	err = PopulateTopology()
 	require.NoError(t, err)
 


### PR DESCRIPTION
Should fix #789 

* From ITB registry log, the registry was killed with the following log message

```console
time="2024-02-08T17:08:39Z" level=fatal msg="Failed to create topology table: database is locked (5) (SQLITE_BUSY)"
```

Looks like there's race condition in DB write access, which makes sense because the error occurs every time someone tries to update/create a new registration

Looking at the code, we call `log.fatal` when we failed create the topology table, and we create the table every "topology update" cycle. The update interval was supposed to set to 10min but the value is `10` which was recognized by viper as **10 milliseconds** and it keep creating the table, doing a bunch of topology update, every 10ms.

This also fixes `504` error we sometimes get from topology, as we basically DDOS-ed topology endpoint.