### PR TITLE
Fix PSS debug level

### DIFF
--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -810,7 +810,7 @@ func mapXrootdLogLevels(xrdConfig *XrootdConfig) {
 	// Cache PssSetOptCache and Cache Pss
 	cachePssConfig := param.Logging_Cache_Pss.GetString()
 	if cachePssConfig == "debug" {
-		xrdConfig.Logging.PssSetOptCache = "DebugLevel 3"
+		xrdConfig.Logging.PssSetOptCache = "DebugLevel 4"
 		xrdConfig.Logging.CachePss = "all"
 	} else if cachePssConfig == "info" {
 		xrdConfig.Logging.PssSetOptCache = "DebugLevel 2"


### PR DESCRIPTION
In XRootD, PSS debug level is the integer "4"; this makes the generated config match the XRootD code.

Only backporting to v7.5.x branch because @joereuss12 has a larger overhaul in progress for main.