### PR TITLE
Remove use of global fed metadata within client

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -275,7 +275,7 @@ func GenerateTransferDetailsUsingCache(cache CacheInterface, opts TransferDetail
 	return nil
 }
 
-func download_http(sourceUrl *url.URL, destination string, payload *payloadStruct, namespace namespaces.Namespace, recursive bool, tokenName string) (transferResults []TransferResults, err error) {
+func download_http(sourceUrl *url.URL, destination string, metadata UrlMetadata, payload *payloadStruct, namespace namespaces.Namespace, recursive bool, tokenName string) (transferResults []TransferResults, err error) {
 	// First, create a handler for any panics that occur
 	defer func() {
 		if r := recover(); r != nil {
@@ -307,7 +307,7 @@ func download_http(sourceUrl *url.URL, destination string, payload *payloadStruc
 	// Check the env var "USE_OSDF_DIRECTOR" and decide if ordered caches should come from director
 	var transfers []TransferDetails
 	var files []string
-	directorUrl := param.Federation_DirectorUrl.GetString()
+	directorUrl := metadata.directorUrl
 	closestNamespaceCaches, err := GetCachesFromNamespace(namespace, directorUrl != "")
 	if err != nil {
 		log.Errorln("Failed to get namespaced caches (treated as non-fatal):", err)

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -571,7 +571,7 @@ func TestObjectCopyAuth(t *testing.T) {
 	assert.NoError(t, err, "Error writing to temp token file")
 	tempToken.Close()
 	// Disable progress bars to not reuse the same mpb instance
-	viper.Set("Logging.DisableProgressBars", true)
+	ObjectClientOptions.ProgressBars = false
 
 	// This tests pelican object get/put with a pelican:// url
 	t.Run("testPelicanObjectCopyWithPelicanUrl", func(t *testing.T) {
@@ -581,7 +581,7 @@ func TestObjectCopyAuth(t *testing.T) {
 		fileName := filepath.Base(tempPath)
 		hostname, err := os.Hostname()
 		assert.NoError(t, err)
-		uploadURL := "pelican://"+ hostname + ":8444/test/" + fileName
+		uploadURL := "pelican://" + hostname + ":8444/test/" + fileName
 
 		// Upload the file with PUT
 		ObjectClientOptions.Token = tempToken.Name()
@@ -611,13 +611,13 @@ func TestObjectCopyAuth(t *testing.T) {
 		assert.NoError(t, err)
 
 		// For OSDF url's, we don't want to rely on osdf metadata to be running therefore, just ensure we get correct metadata for the url:
-		metadata, err := getUrlMetadata(uploadURL, "osdf")
+		pelicanURL, err := newPelicanURL(uploadURL, "osdf")
 		assert.NoError(t, err)
 
 		// Check valid metadata:
-		assert.Equal(t, "https://osdf-director.osg-htc.org", metadata.directorUrl)
-		assert.Equal(t, "https://osdf-registry.osg-htc.org", metadata.registryUrl)
-		assert.Equal(t, "osg-htc.org", metadata.discoveryUrl)
+		assert.Equal(t, "https://osdf-director.osg-htc.org", pelicanURL.directorUrl)
+		assert.Equal(t, "https://osdf-registry.osg-htc.org", pelicanURL.registryUrl)
+		assert.Equal(t, "osg-htc.org", pelicanURL.discoveryUrl)
 	})
 
 	// This tests osdf object copy with a pelican:// url
@@ -628,7 +628,7 @@ func TestObjectCopyAuth(t *testing.T) {
 		fileName := filepath.Base(tempPath)
 		hostname, err := os.Hostname()
 		assert.NoError(t, err)
-		uploadURL := "pelican://"+ hostname + ":8444/test/" + fileName
+		uploadURL := "pelican://" + hostname + ":8444/test/" + fileName
 
 		// Upload the file with PUT
 		ObjectClientOptions.Token = tempToken.Name()
@@ -648,7 +648,7 @@ func TestObjectCopyAuth(t *testing.T) {
 	})
 
 	// This tests osdf object copy with an osdf url
-	// NOTE: this test MUST be last since we need to reset a good amount of config values to get osdf defaults
+	// NOTE: this test MUST be last since we need to reset a good amount of config values to get osdf defaults as well as re-init config and client
 	t.Run("testOsdfObjectCopyWithOSDFUrl", func(t *testing.T) {
 		viper.Reset()
 		config.SetPreferredPrefix("OSDF")
@@ -662,13 +662,13 @@ func TestObjectCopyAuth(t *testing.T) {
 		assert.NoError(t, err)
 
 		// For OSDF url's, we don't want to rely on osdf metadata to be running therefore, just ensure we get correct metadata for the url:
-		metadata, err := getUrlMetadata(uploadURL, "osdf")
+		pelicanURL, err := newPelicanURL(uploadURL, "osdf")
 		assert.NoError(t, err)
 
 		// Check valid metadata:
-		assert.Equal(t, "https://osdf-director.osg-htc.org", metadata.directorUrl)
-		assert.Equal(t, "https://osdf-registry.osg-htc.org", metadata.registryUrl)
-		assert.Equal(t, "osg-htc.org", metadata.discoveryUrl)
+		assert.Equal(t, "https://osdf-director.osg-htc.org", pelicanURL.directorUrl)
+		assert.Equal(t, "https://osdf-registry.osg-htc.org", pelicanURL.registryUrl)
+		assert.Equal(t, "osg-htc.org", pelicanURL.discoveryUrl)
 	})
 }
 
@@ -720,7 +720,7 @@ func TestGetAndPutAuth(t *testing.T) {
 	assert.NoError(t, err, "Error writing to temp token file")
 	tempToken.Close()
 	// Disable progress bars to not reuse the same mpb instance
-	viper.Set("Logging.DisableProgressBars", true)
+	ObjectClientOptions.ProgressBars = false
 
 	// This tests pelican object get/put with a pelican:// url
 	t.Run("testPelicanObjectPutAndGetWithPelicanUrl", func(t *testing.T) {
@@ -730,7 +730,7 @@ func TestGetAndPutAuth(t *testing.T) {
 		fileName := filepath.Base(tempPath)
 		hostname, err := os.Hostname()
 		assert.NoError(t, err)
-		uploadURL := "pelican://"+ hostname + ":8444/test/" + fileName
+		uploadURL := "pelican://" + hostname + ":8444/test/" + fileName
 
 		// Upload the file with PUT
 		ObjectClientOptions.Token = tempToken.Name()
@@ -760,13 +760,13 @@ func TestGetAndPutAuth(t *testing.T) {
 		assert.NoError(t, err)
 
 		// For OSDF url's, we don't want to rely on osdf metadata to be running therefore, just ensure we get correct metadata for the url:
-		metadata, err := getUrlMetadata(uploadURL, "osdf")
+		pelicanURL, err := newPelicanURL(uploadURL, "osdf")
 		assert.NoError(t, err)
 
 		// Check valid metadata:
-		assert.Equal(t, "https://osdf-director.osg-htc.org", metadata.directorUrl)
-		assert.Equal(t, "https://osdf-registry.osg-htc.org", metadata.registryUrl)
-		assert.Equal(t, "osg-htc.org", metadata.discoveryUrl)
+		assert.Equal(t, "https://osdf-director.osg-htc.org", pelicanURL.directorUrl)
+		assert.Equal(t, "https://osdf-registry.osg-htc.org", pelicanURL.registryUrl)
+		assert.Equal(t, "osg-htc.org", pelicanURL.discoveryUrl)
 	})
 
 	// This tests object get/put with a pelican:// url
@@ -777,7 +777,7 @@ func TestGetAndPutAuth(t *testing.T) {
 		fileName := filepath.Base(tempPath)
 		hostname, err := os.Hostname()
 		assert.NoError(t, err)
-		uploadURL := "pelican://"+ hostname + ":8444/test/" + fileName
+		uploadURL := "pelican://" + hostname + ":8444/test/" + fileName
 
 		// Upload the file with PUT
 		ObjectClientOptions.Token = tempToken.Name()
@@ -797,7 +797,7 @@ func TestGetAndPutAuth(t *testing.T) {
 	})
 
 	// This tests pelican object get/put with an osdf url
-	// NOTE: this test MUST be last since we need to reset a good amount of config values to get osdf defaults
+	// NOTE: this test MUST be last since we need to reset a good amount of config values to get osdf defaults as well as re-init config and client
 	t.Run("testOsdfObjectPutAndGetWithOSDFUrl", func(t *testing.T) {
 		viper.Reset()
 		config.SetPreferredPrefix("OSDF")
@@ -811,13 +811,13 @@ func TestGetAndPutAuth(t *testing.T) {
 		assert.NoError(t, err)
 
 		// For OSDF url's, we don't want to rely on osdf metadata to be running therefore, just ensure we get correct metadata for the url:
-		metadata, err := getUrlMetadata(uploadURL, "osdf")
+		pelicanURL, err := newPelicanURL(uploadURL, "osdf")
 		assert.NoError(t, err)
 
 		// Check valid metadata:
-		assert.Equal(t, "https://osdf-director.osg-htc.org", metadata.directorUrl)
-		assert.Equal(t, "https://osdf-registry.osg-htc.org", metadata.registryUrl)
-		assert.Equal(t, "osg-htc.org", metadata.discoveryUrl)
+		assert.Equal(t, "https://osdf-director.osg-htc.org", pelicanURL.directorUrl)
+		assert.Equal(t, "https://osdf-registry.osg-htc.org", pelicanURL.registryUrl)
+		assert.Equal(t, "osg-htc.org", pelicanURL.discoveryUrl)
 		viper.Reset()
 	})
 }
@@ -832,20 +832,20 @@ func TestGetPublicRead(t *testing.T) {
 	t.Run("testPubObjGet", func(t *testing.T) {
 		testFileContent := "test file content"
 		// Drop the testFileContent into the origin directory
-		tempFile, err := os.Create(filepath.Join(fed.OriginDir, "test.txt"))
+		tempFile, err := os.Create(filepath.Join(fed.OriginDir, "test1234.txt"))
 		assert.NoError(t, err, "Error creating temp file")
 		defer os.Remove(tempFile.Name())
 		_, err = tempFile.WriteString(testFileContent)
 		assert.NoError(t, err, "Error writing to temp file")
 		tempFile.Close()
 
-		viper.Set("Logging.DisableProgressBars", true)
+		ObjectClientOptions.ProgressBars = false
 
 		// Set path for object to upload/download
 		tempPath := tempFile.Name()
 		hostname, err := os.Hostname()
 		fileName := filepath.Base(tempPath)
-		uploadURL := "pelican://"+ hostname + ":8444/test/" + fileName
+		uploadURL := "pelican://" + hostname + ":8444/test/" + fileName
 
 		// Download the file with GET. Shouldn't need a token to succeed
 		transferResults, err := DoGet(uploadURL, t.TempDir(), false)
@@ -894,7 +894,7 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 	tempToken.Close()
 
 	// Disable progress bars to not reuse the same mpb instance
-	viper.Set("Logging.DisableProgressBars", true)
+	ObjectClientOptions.ProgressBars = false
 
 	// Make our test directories and files
 	tempDir, err := os.MkdirTemp("", "UploadDir")
@@ -929,13 +929,13 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 		assert.NoError(t, err)
 
 		// For OSDF url's, we don't want to rely on osdf metadata to be running therefore, just ensure we get correct metadata for the url:
-		metadata, err := getUrlMetadata(uploadURL, "osdf")
+		pelicanURL, err := newPelicanURL(uploadURL, "osdf")
 		assert.NoError(t, err)
 
 		// Check valid metadata:
-		assert.Equal(t, "https://osdf-director.osg-htc.org", metadata.directorUrl)
-		assert.Equal(t, "https://osdf-registry.osg-htc.org", metadata.registryUrl)
-		assert.Equal(t, "osg-htc.org", metadata.discoveryUrl)
+		assert.Equal(t, "https://osdf-director.osg-htc.org", pelicanURL.directorUrl)
+		assert.Equal(t, "https://osdf-registry.osg-htc.org", pelicanURL.registryUrl)
+		assert.Equal(t, "osg-htc.org", pelicanURL.discoveryUrl)
 	})
 
 	t.Run("testPelicanRecursiveGetAndPutPelicanURL", func(t *testing.T) {
@@ -946,7 +946,7 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 		dirName := filepath.Base(tempPath)
 		hostname, err := os.Hostname()
 		assert.NoError(t, err)
-		uploadURL := "pelican://"+ hostname + ":8444/test/" + dirName
+		uploadURL := "pelican://" + hostname + ":8444/test/" + dirName
 
 		//////////////////////////////////////////////////////////
 
@@ -1019,7 +1019,7 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 		dirName := filepath.Base(tempPath)
 		hostname, err := os.Hostname()
 		assert.NoError(t, err)
-		uploadURL := "pelican://"+ hostname + ":8444/test/" + dirName
+		uploadURL := "pelican://" + hostname + ":8444/test/" + dirName
 
 		//////////////////////////////////////////////////////////
 
@@ -1098,12 +1098,12 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 		assert.NoError(t, err)
 
 		// For OSDF url's, we don't want to rely on osdf metadata to be running therefore, just ensure we get correct metadata for the url:
-		metadata, err := getUrlMetadata(uploadURL, "osdf")
+		pelicanURL, err := newPelicanURL(uploadURL, "osdf")
 		assert.NoError(t, err)
 
 		// Check valid metadata:
-		assert.Equal(t, "https://osdf-director.osg-htc.org", metadata.directorUrl)
-		assert.Equal(t, "https://osdf-registry.osg-htc.org", metadata.registryUrl)
-		assert.Equal(t, "osg-htc.org", metadata.discoveryUrl)
+		assert.Equal(t, "https://osdf-director.osg-htc.org", pelicanURL.directorUrl)
+		assert.Equal(t, "https://osdf-registry.osg-htc.org", pelicanURL.registryUrl)
+		assert.Equal(t, "osg-htc.org", pelicanURL.discoveryUrl)
 	})
 }

--- a/client/main.go
+++ b/client/main.go
@@ -624,6 +624,9 @@ func DoPut(localObject string, remoteDestination string, recursive bool) (transf
 		return nil, err
 	}
 
+	remoteDestUrl.Scheme = remoteDestScheme
+
+	// This is for condor cases:
 	remoteDestScheme, _ = getTokenName(remoteDestUrl)
 
 	// Check if we understand the found url scheme
@@ -632,7 +635,6 @@ func DoPut(localObject string, remoteDestination string, recursive bool) (transf
 		return nil, err
 	}
 
-	remoteDestUrl.Scheme = remoteDestScheme
 	pelicanURL, err := newPelicanURL(remoteDestUrl, remoteDestScheme)
 	if err != nil {
 		return nil, fmt.Errorf("%v: error generating metadata for specified url", err)

--- a/client/main_test.go
+++ b/client/main_test.go
@@ -400,7 +400,8 @@ func TestNewPelicanURL(t *testing.T) {
 	t.Run("TestPelicanSchemeNoError", func(t *testing.T) {
 		viper.Reset()
 		viper.Set("TLSSkipVerify", true)
-		config.InitClient()
+		err := config.InitClient()
+		assert.NoError(t, err)
 		// Create a server that gives us a mock response
 		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// make our response:
@@ -418,7 +419,8 @@ func TestNewPelicanURL(t *testing.T) {
 			}
 
 			w.WriteHeader(http.StatusOK)
-			w.Write(responseJSON)
+			_, err = w.Write(responseJSON)
+			assert.NoError(t, err)
 		}))
 		defer server.Close()
 

--- a/client/main_test.go
+++ b/client/main_test.go
@@ -438,7 +438,7 @@ func TestNewPelicanURL(t *testing.T) {
 		assert.Equal(t, "registry", pelicanURL.registryUrl)
 		assert.Equal(t, remoteObjectURL, pelicanURL.objectUrl)
 		// Check to make sure it was populated in our cache
-		assert.True(t, pelicanURLCache.Has(pelicanURL.discoveryUrl))
+		assert.True(t, PelicanURLCache.Has(pelicanURL.discoveryUrl))
 		viper.Reset()
 	})
 

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -197,6 +197,9 @@ func copyMain(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	// Start our cache for url metadata
+	go client.PelicanURLCache.Start()
+
 	var result error
 	lastSrc := ""
 	for _, src := range source {
@@ -211,6 +214,7 @@ func copyMain(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	client.PelicanURLCache.Stop()
 	// Exit with failure
 	if result != nil {
 		// Print the list of errors

--- a/cmd/object_get.go
+++ b/cmd/object_get.go
@@ -103,6 +103,9 @@ func getMain(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	// Start our cache for url metadata
+	go client.PelicanURLCache.Start()
+
 	var result error
 	lastSrc := ""
 	for _, src := range source {
@@ -116,7 +119,7 @@ func getMain(cmd *cobra.Command, args []string) {
 			client.ClearErrors()
 		}
 	}
-
+	client.PelicanURLCache.Stop()
 	// Exit with failure
 	if result != nil {
 		// Print the list of errors

--- a/cmd/object_put.go
+++ b/cmd/object_put.go
@@ -79,6 +79,9 @@ func putMain(cmd *cobra.Command, args []string) {
 	log.Debugln("Sources:", source)
 	log.Debugln("Destination:", dest)
 
+	// Start our cache for url metadata
+	go client.PelicanURLCache.Start()
+
 	var result error
 	lastSrc := ""
 	for _, src := range source {
@@ -93,6 +96,7 @@ func putMain(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	client.PelicanURLCache.Stop()
 	// Exit with failure
 	if result != nil {
 		// Print the list of errors

--- a/config/config.go
+++ b/config/config.go
@@ -301,7 +301,7 @@ func GetAllPrefixes() []string {
 
 // This function is for discovering federations as specified by a url during a pelican:// transfer.
 // this does not populate global fields and is more temporary per url
-func DiscoverUrlFederation(federationDiscoveryUrl string) (FederationDiscovery, error) {
+func DiscoverUrlFederation(federationDiscoveryUrl string) (metadata FederationDiscovery, err error) {
 	log.Debugln("Performing federation service discovery for specified url against endpoint", federationDiscoveryUrl)
 	federationUrl, err := url.Parse(federationDiscoveryUrl)
 	if err != nil {
@@ -355,7 +355,7 @@ func DiscoverUrlFederation(federationDiscoveryUrl string) (FederationDiscovery, 
 		return FederationDiscovery{}, errors.Errorf("Federation metadata discovery failed with HTTP status %d.  Error message: %s", result.StatusCode, truncatedMessage)
 	}
 
-	metadata := FederationDiscovery{}
+	metadata = FederationDiscovery{}
 	err = json.Unmarshal(body, &metadata)
 	if err != nil {
 		return FederationDiscovery{}, errors.Wrapf(err, "Failure when parsing federation metadata at %s", discoveryUrl)
@@ -401,7 +401,7 @@ func DiscoverFederation() error {
 	curRegistryURL := param.Federation_RegistryUrl.GetString()
 	curFederationJwkURL := param.Federation_JwkUrl.GetString()
 	curBrokerURL := param.Federation_BrokerUrl.GetString()
-	if len(curDirectorURL) != 0 && len(curRegistryURL) != 0 && len(curFederationJwkURL) != 0 {
+	if curDirectorURL != "" && curRegistryURL != "" && curFederationJwkURL != "" && curBrokerURL != "" {
 		return nil
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -281,7 +281,8 @@ func TestDiscoverUrlFederation(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		w.Write(responseJSON)
+		_, err = w.Write(responseJSON)
+		assert.NoError(t, err)
 	}))
 	defer server.Close()
 	metadata, err := DiscoverUrlFederation(server.URL)
@@ -314,7 +315,8 @@ func TestDiscoverFederation(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		w.Write(responseJSON)
+		_, err = w.Write(responseJSON)
+		assert.NoError(t, err)
 	}))
 	defer server.Close()
 	viper.Set("Federation.DiscoveryUrl", server.URL)

--- a/github_scripts/get_put_test.sh
+++ b/github_scripts/get_put_test.sh
@@ -21,6 +21,7 @@
 # Setup env variables needed
 to_exit=0
 export PELICAN_FEDERATION_DIRECTORURL="https://$HOSTNAME:8444"
+export PELICAN_DIRECTOR_DEFAULTRESPONSE="origins"
 export PELICAN_FEDERATION_REGISTRYURL="https://$HOSTNAME:8444"
 export PELICAN_TLSSKIPVERIFY=true
 export PELICAN_ORIGIN_ENABLEFALLBACKREAD=true
@@ -96,7 +97,7 @@ do
 done
 
 # Run pelican object put
-./pelican object put input.txt osdf:///test/input.txt -d -t token -l putOutput.txt
+./pelican object put input.txt pelican://$HOSTNAME:8444/test/input.txt -d -t token -l putOutput.txt
 
 # Check output of command
 if grep -q "Uploaded bytes: 47" putOutput.txt; then
@@ -107,7 +108,7 @@ else
     to_exit=1
 fi
 
-./pelican object get osdf:///test/input.txt output.txt -d -t token -l getOutput.txt
+./pelican object get pelican://$HOSTNAME:8444/test/input.txt output.txt -d -t token -l getOutput.txt
 
 # Check output of command
 if grep -q "Downloaded bytes: 47" getOutput.txt; then


### PR DESCRIPTION
Changes include:
- Created a local metadata object that store federation metadata per url.
- Changed a lot of tests on client commands, we no longer rely on osdf for tests to pass
- Made a function in config that discovers a federation but does not populate global config values