### PR TITLE
cache directorUrl fix for pss.origin

### DIFF
--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -325,7 +325,7 @@ func CheckCacheXrootdEnv(exportPath string, server server_utils.XRootDServer, ui
 				discoveryUrl.Host = discoveryUrl.Path
 				discoveryUrl.Path = ""
 			} else if discoveryUrl.Path != "" && discoveryUrl.Path != "/" {
-				return "", errors.New("The discoveryUrl Path is non-empty, ensure the Federation.DiscoveryUrl has the format <host>:<port>")
+				return "", errors.New("The Federation.DiscoveryUrl's path is non-empty, ensure the Federation.DiscoveryUrl has the format <host>:<port>")
 			}
 			discoveryUrl.Scheme = "pelican"
 			discoveryUrl.Path = ""

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -341,7 +341,7 @@ func CheckCacheXrootdEnv(exportPath string, server server_utils.XRootDServer, ui
 		if err == nil {
 			log.Debugln("Parsing director URL for 'pss.origin' setting:", directorUrlStr)
 			if directorUrl.Path != "" && directorUrl.Path != "/" {
-				return "", errors.New("The directorUrl Path is non-empty, ensure the Federation.DirectorUrl has the format <host>:<port>")
+				return "", errors.New("The Federation.DirectorUrl's path is non-empty, ensure the Federation.DirectorUrl has the format <host>:<port>")
 			}
 			directorUrl.Scheme = "pelican"
 			viper.Set("Cache.PSSOrigin", directorUrl.String())


### PR DESCRIPTION
Fixed an issue where the pss.origin wasn't being generated properly from the Federation.DirectorUrl

Note: I did do an end-to-end cache test where I curled the cache and was able to get a file served from a local origin.