### PR TITLE
Adding debug output to try to understand flaky test

### DIFF
--- a/director/redirect_test.go
+++ b/director/redirect_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -239,6 +240,7 @@ func TestDirectorRegistration(t *testing.T) {
 
 		ad := common.OriginAdvertiseV1{Name: "test", URL: "https://or-url.org", Namespaces: []common.NamespaceAdV1{{Path: "/foo/bar", Issuer: isurl}}}
 
+		log.Debugln("Checking V1 Ad", ad)
 		jsonad, err := json.Marshal(ad)
 		assert.NoError(t, err, "Error marshalling OriginAdvertise")
 
@@ -246,6 +248,7 @@ func TestDirectorRegistration(t *testing.T) {
 
 		r.ServeHTTP(w, c.Request)
 
+		log.Debugln("Checking Result", w.Result().Body)
 		// Check to see that the code exits with status code 200 after given it a good token
 		assert.Equal(t, 200, w.Result().StatusCode, "Expected status code of 200")
 


### PR DESCRIPTION
This is just a PR to find and see a flaky test in redirect_test.go, not expected to merge.