### PR TITLE
Rebuild OSG's xrootd RPM from source inside the dev container

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -93,3 +93,5 @@ jobs:
           tags: "${{ steps.generate-tag-list.outputs.taglist }}"
           build-args: |
             IS_PR_BUILD=${{ github.event_name == 'pull_request' }}
+          cache-from: type=registry,ref=hub.opensciencegrid.org/pelican_platform/pelican:buildcache
+          cache-to: type=registry,ref=hub.opensciencegrid.org/pelican_platform/pelican:buildcache,mode=max,ignore-error=true

--- a/.github/workflows/publish-dev-container.yml
+++ b/.github/workflows/publish-dev-container.yml
@@ -48,5 +48,5 @@ jobs:
           file: ./images/dev.Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=hub.opensciencegrid.org/pelican_platform/pelican-dev:buildcache
+          cache-to: type=registry,ref=hub.opensciencegrid.org/pelican_platform/pelican-dev:buildcache,mode=max,ignore-error=true

--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -15,8 +15,7 @@ ENV GOFLAGS="-buildvcs=false"
 RUN groupadd -o -g 10940 xrootd
 RUN useradd -o -u 10940 -g 10940 -s /bin/sh xrootd
 
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
-                   https://repo.opensciencegrid.org/osg/23-main/osg-23-main-el8-release-latest.rpm && \
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     /usr/bin/crb enable && \
     # ^^ crb enables the Code Ready Builder repository (EL9) or PowerTools (EL8), needed for some of our dependencies \
     yum clean all
@@ -33,7 +32,7 @@ gpgcheck=0' > /etc/yum.repos.d/goreleaser.repo
 RUN echo '%_topdir /usr/local/src/rpmbuild' > $HOME/.rpmmacros
 
 # Download OSG's XRootD SRPM and rebuild it. Create a yum repository to put the results in.
-RUN yum install -y yum-utils createrepo && \
+RUN yum install -y yum-utils createrepo https://repo.opensciencegrid.org/osg/23-main/osg-23-main-el8-release-latest.rpm && \
     yum-config-manager --setopt=install_weak_deps=False --save && \
     # ^^ save some space by not installing weak dependencies \
     yum-config-manager --disable osg --save && \

--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -58,7 +58,7 @@ baseurl=file:///usr/local/src/rpmbuild/RPMS/ \n\
 enabled=1 \n\
 priority=1 \n\
 gpgcheck=0' > /etc/yum.repos.d/local.repo
-    
+
 # Install goreleaser and various other packages we need
 RUN yum install -y goreleaser npm xrootd-devel xrootd-server-devel xrootd-client-devel nano xrootd-scitokens \
     xrootd-voms xrdcl-http jq procps docker make curl-devel java-17-openjdk-headless git cmake3 gcc-c++ openssl-devel \


### PR DESCRIPTION
This downloads the latest xrootd source RPM from the OSG 23 development repos, and uses rpmbuild to build it locally for the current architecture.  The resulting RPMs are put into /usr/local/src/rpmbuild/RPMS/$arch/* (where $arch is the architecture, either x86_64, noarch, or aarch64) and a yum repo is built from it. The repo has highest priority so the locally built RPMs are picked over what's in EPEL.

To save time and space, the xrootd-compat libraries are not built, and neither are the docs.  Even with that, though, it's a good 20 minutes to build on ARM.  Caching the build results might be a good idea.