### PR TITLE
Remove bucket requirement for S3 origins

### DIFF
--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -162,7 +162,7 @@ func init() {
 	originServeCmd.MarkFlagsMutuallyExclusive("volume", "bucket-access-keyfile")
 	originServeCmd.MarkFlagsMutuallyExclusive("volume", "bucket-secret-keyfile")
 	// We don't require the bucket access and secret keyfiles as they're not needed for unauthenticated buckets
-	originServeCmd.MarkFlagsRequiredTogether("service-name", "region", "bucket", "service-url")
+	originServeCmd.MarkFlagsRequiredTogether("service-name", "region", "service-url")
 	originServeCmd.MarkFlagsRequiredTogether("bucket-access-keyfile", "bucket-secret-keyfile")
 
 	// The port any web UI stuff will be served on

--- a/go.sum
+++ b/go.sum
@@ -78,7 +78,9 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bsm/ginkgo/v2 v2.5.0 h1:aOAnND1T40wEdAtkGSkvSICWeQ8L3UASX7YVCqQx+eQ=
+github.com/bsm/ginkgo/v2 v2.5.0/go.mod h1:AiKlXPm7ItEHNc/2+OkrNG4E0ITzojb9/xWzvQ9XZ9w=
 github.com/bsm/gomega v1.20.0 h1:JhAwLmtRzXFTx2AkALSLa8ijZafntmhSoU63Ok18Uq8=
+github.com/bsm/gomega v1.20.0/go.mod h1:JifAceMQ4crZIWYUKrlGcmbN3bqHogVTADMD2ATsbwk=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.9.1 h1:6iJ6NqdoxCDr6mbY8h18oSO+cShGSMRGCEo7F2h0x8s=
 github.com/bytedance/sonic v1.9.1/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZXU064P/U=

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -133,10 +133,10 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (context.Canc
 			NamespacePrefix: /bar`)
 			}
 		case "s3":
-			if param.Origin_S3Bucket.GetString() == "" || param.Origin_S3Region.GetString() == "" ||
-				param.Origin_S3ServiceName.GetString() == "" || param.Origin_S3ServiceUrl.GetString() == "" {
+			if param.Origin_S3Region.GetString() == "" || param.Origin_S3ServiceName.GetString() == "" ||
+				param.Origin_S3ServiceUrl.GetString() == "" {
 				return shutdownCancel, errors.Errorf("The S3 origin is missing configuration options to run properly." +
-					" You must specify a bucket, a region, a service name and a service URL via the command line or via" +
+					" You must specify a region, a service name and a service URL via the command line or via" +
 					" your configuration file.")
 			}
 		default:


### PR DESCRIPTION
It was a mistake to require that S3 origins be configured with a bucket. In the case of AWS public data, for example, it would be nice to have a single origin that exports all public buckets from `s3.amazonaws.com`. Under the old scheme, this would require an origin per bucket -- whoops!

# Testing notes for this one:
- Spin up a registry/director.

## Testing a public origin with a single bucket
- Serve a public origin (`Origin.EnablePublicReads: true`) that exports a single bucket from AWS open data -- we do still want this to work, even if we no longer require it:
`pelican origin serve --mode s3 --port 8444 --service-name "s3.amazonaws.com" --region "us-east-1" --bucket "noaa-wod-pds" --service-url https://s3.us-east-1.amazonaws.com -d`
- Now curl a test file from the origin: `curl -v -k https://<origin hostname>:<origin port>/s3.amazonaws.com/us-east-1/noaa-wod-pds/MD5SUMS`. You should see a small md5 sum file print to terminal

## Testing a public origin with no bucket specified
Now we basically want to serve the same origin, but without pinning the bucket. We can still use the same bucket for testing, but the difference is that if this works with the unpinned `noaa-wod-pds` bucket, it will also work for any bucket under `s3.amazonaws.com/us-east-`.
 - Serve a public origin (`Origin.EnablePublicReads: true`):
`pelican origin serve --mode s3 --port 8444 --service-name "s3.amazonaws.com" --region "us-east-1" --service-url https://s3.us-east-1.amazonaws.com -d`
- Now curl a test file from the origin: `curl -v -k https://<origin hostname>:<origin port>/s3.amazonaws.com/us-east-1/noaa-wod-pds/MD5SUMS`. You should see a small md5 sum file print to terminal

Both of those origin configurations should work.

Closes #811 