### PR TITLE
Failure to get metadata is now retryable error

### DIFF
--- a/client/errorAccum.go
+++ b/client/errorAccum.go
@@ -128,7 +128,7 @@ func IsRetryable(err error) bool {
 	if errors.Is(err, grab.ErrBadLength) {
 		return false
 	}
-	if errors.Is(err, &config.MetaDataErr{}) {
+	if errors.Is(err, config.MetadataTimeoutErr) {
 		return true
 	}
 	var cse *ConnectionSetupError

--- a/client/errorAccum.go
+++ b/client/errorAccum.go
@@ -27,7 +27,6 @@ import (
 
 	grab "github.com/opensaucerer/grab/v3"
 	"github.com/pelicanplatform/pelican/config"
-	log "github.com/sirupsen/logrus"
 )
 
 type (
@@ -171,10 +170,6 @@ func (te *TransferErrors) AllErrorsRetryable() bool {
 		if !IsRetryable(err) {
 			return false
 		}
-	}
-	if len(bunchOfErrors) == 0 {
-		log.Debugln("No errors sent to client for checking")
-		return false
 	}
 	return true
 }

--- a/client/errorAccum.go
+++ b/client/errorAccum.go
@@ -26,6 +26,8 @@ import (
 	"time"
 
 	grab "github.com/opensaucerer/grab/v3"
+	"github.com/pelicanplatform/pelican/config"
+	log "github.com/sirupsen/logrus"
 )
 
 type (
@@ -126,6 +128,9 @@ func IsRetryable(err error) bool {
 	if errors.Is(err, grab.ErrBadLength) {
 		return false
 	}
+	if errors.Is(err, &config.MetaDataErr{}) {
+		return true
+	}
 	var cse *ConnectionSetupError
 	if errors.As(err, &cse) {
 		if sce, ok := cse.Unwrap().(grab.StatusCodeError); ok {
@@ -166,6 +171,10 @@ func (te *TransferErrors) AllErrorsRetryable() bool {
 		if !IsRetryable(err) {
 			return false
 		}
+	}
+	if len(bunchOfErrors) == 0 {
+		log.Debugln("No errors sent to client for checking")
+		return false
 	}
 	return true
 }

--- a/client/main.go
+++ b/client/main.go
@@ -217,7 +217,6 @@ func DoStat(ctx context.Context, destination string, options ...TransferOption) 
 		viper.Set("Federation.DiscoveryUrl", federationUrl.String())
 		err = config.DiscoverFederation()
 		if err != nil {
-			AddError(err)
 			return 0, err
 		}
 	}
@@ -475,7 +474,6 @@ func DoPut(ctx context.Context, localObject string, remoteDestination string, re
 			viper.Set("Federation.DiscoveryUrl", federationUrl.String())
 			err = config.DiscoverFederation()
 			if err != nil {
-				AddError(err)
 				return nil, err
 			}
 		}
@@ -560,7 +558,6 @@ func DoGet(ctx context.Context, remoteObject string, localDestination string, re
 			viper.Set("Federation.DiscoveryUrl", federationUrl.String())
 			err = config.DiscoverFederation()
 			if err != nil {
-				AddError(err)
 				return nil, err
 			}
 		}
@@ -710,7 +707,6 @@ func DoCopy(ctx context.Context, sourceFile string, destination string, recursiv
 			viper.Set("Federation.DiscoveryUrl", federationUrl.String())
 			err = config.DiscoverFederation()
 			if err != nil {
-				AddError(err)
 				return nil, err
 			}
 		}
@@ -727,7 +723,6 @@ func DoCopy(ctx context.Context, sourceFile string, destination string, recursiv
 			viper.Set("Federation.DiscoveryUrl", federationUrl.String())
 			err = config.DiscoverFederation()
 			if err != nil {
-				AddError(err)
 				return nil, err
 			}
 		}

--- a/client/main.go
+++ b/client/main.go
@@ -217,6 +217,7 @@ func DoStat(ctx context.Context, destination string, options ...TransferOption) 
 		viper.Set("Federation.DiscoveryUrl", federationUrl.String())
 		err = config.DiscoverFederation()
 		if err != nil {
+			AddError(err)
 			return 0, err
 		}
 	}
@@ -474,6 +475,7 @@ func DoPut(ctx context.Context, localObject string, remoteDestination string, re
 			viper.Set("Federation.DiscoveryUrl", federationUrl.String())
 			err = config.DiscoverFederation()
 			if err != nil {
+				AddError(err)
 				return nil, err
 			}
 		}
@@ -558,6 +560,7 @@ func DoGet(ctx context.Context, remoteObject string, localDestination string, re
 			viper.Set("Federation.DiscoveryUrl", federationUrl.String())
 			err = config.DiscoverFederation()
 			if err != nil {
+				AddError(err)
 				return nil, err
 			}
 		}
@@ -707,6 +710,7 @@ func DoCopy(ctx context.Context, sourceFile string, destination string, recursiv
 			viper.Set("Federation.DiscoveryUrl", federationUrl.String())
 			err = config.DiscoverFederation()
 			if err != nil {
+				AddError(err)
 				return nil, err
 			}
 		}
@@ -723,6 +727,7 @@ func DoCopy(ctx context.Context, sourceFile string, destination string, recursiv
 			viper.Set("Federation.DiscoveryUrl", federationUrl.String())
 			err = config.DiscoverFederation()
 			if err != nil {
+				AddError(err)
 				return nil, err
 			}
 		}

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -94,9 +94,8 @@ func copyMain(cmd *cobra.Command, args []string) {
 	err := config.InitClient()
 	if err != nil {
 		log.Errorln(err)
-		client.AddError(err)
 
-		if client.ErrorsRetryable() {
+		if client.IsRetryable(err) {
 			log.Errorln("Errors are retryable")
 			os.Exit(11)
 		} else {

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -94,7 +94,14 @@ func copyMain(cmd *cobra.Command, args []string) {
 	err := config.InitClient()
 	if err != nil {
 		log.Errorln(err)
-		os.Exit(1)
+		client.AddError(err)
+
+		if client.ErrorsRetryable() {
+			log.Errorln("Errors are retryable")
+			os.Exit(11)
+		} else {
+			os.Exit(1)
+		}
 	}
 
 	if val, err := cmd.Flags().GetBool("version"); err == nil && val {

--- a/cmd/object_get.go
+++ b/cmd/object_get.go
@@ -55,7 +55,14 @@ func getMain(cmd *cobra.Command, args []string) {
 	err := config.InitClient()
 	if err != nil {
 		log.Errorln(err)
-		os.Exit(1)
+		client.AddError(err)
+
+		if client.ErrorsRetryable() {
+			log.Errorln("Errors are retryable")
+			os.Exit(11)
+		} else {
+			os.Exit(1)
+		}
 	}
 
 	tokenLocation, _ := cmd.Flags().GetString("token")

--- a/cmd/object_get.go
+++ b/cmd/object_get.go
@@ -55,9 +55,8 @@ func getMain(cmd *cobra.Command, args []string) {
 	err := config.InitClient()
 	if err != nil {
 		log.Errorln(err)
-		client.AddError(err)
 
-		if client.ErrorsRetryable() {
+		if client.IsRetryable(err) {
 			log.Errorln("Errors are retryable")
 			os.Exit(11)
 		} else {

--- a/cmd/object_put.go
+++ b/cmd/object_put.go
@@ -50,8 +50,7 @@ func putMain(cmd *cobra.Command, args []string) {
 	err := config.InitClient()
 	if err != nil {
 		log.Errorln(err)
-		client.AddError(err)
-		if client.ErrorsRetryable() {
+		if client.IsRetryable(err) {
 			log.Errorln("Errors are retryable")
 			os.Exit(11)
 		} else {

--- a/cmd/object_put.go
+++ b/cmd/object_put.go
@@ -50,7 +50,13 @@ func putMain(cmd *cobra.Command, args []string) {
 	err := config.InitClient()
 	if err != nil {
 		log.Errorln(err)
-		os.Exit(1)
+		client.AddError(err)
+		if client.ErrorsRetryable() {
+			log.Errorln("Errors are retryable")
+			os.Exit(11)
+		} else {
+			os.Exit(1)
+		}
 	}
 
 	// Set the progress bars to the command line option

--- a/config/config.go
+++ b/config/config.go
@@ -162,9 +162,9 @@ func (e *MetadataErr) Is(target error) bool {
 }
 
 func (e *MetadataErr) Wrap(err error) *MetadataErr {
-	return &MetadataErr {
+	return &MetadataErr{
 		InnerErr: err,
-		Msg: fmt.Sprintf("%s", e.Msg),
+		Msg:      e.Msg,
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -88,6 +88,10 @@ type (
 	ServerType int // ServerType is a bit mask indicating which Pelican server(s) are running in the current process
 
 	ContextKey string
+
+	MetaDataErr struct {
+		Err string
+	}
 )
 
 const (
@@ -137,6 +141,15 @@ var (
 	// Pelican version
 	version string = "dev"
 )
+
+func (e *MetaDataErr) Error() string {
+	return e.Err
+}
+
+func (e *MetaDataErr) Is(target error) bool {
+	_, ok := target.(*MetaDataErr)
+	return ok
+}
 
 func init() {
 	validate = validator.New(validator.WithRequiredStructEnabled())
@@ -381,7 +394,10 @@ func DiscoverFederation() error {
 
 	result, err := httpClient.Do(req)
 	if err != nil {
-		return errors.Wrapf(err, "Failure when doing federation metadata lookup to %s", discoveryUrl)
+		errMsg := errors.Wrapf(err, "Failure when doing federation metadata lookup to %s", discoveryUrl)
+		return &MetaDataErr{
+			Err: errMsg.Error(),
+		}
 	}
 
 	if result.Body != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -146,7 +146,7 @@ var (
 
 // This function creates a new MetadataError by wrapping the previous error
 func NewMetadataError(err error, msg string) *MetadataErr {
-	return &MetadataErr {
+	return &MetadataErr{
 		err: fmt.Sprintf("%s: %v", msg, err),
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -148,14 +148,14 @@ var (
 // This function creates a new MetadataError by wrapping the previous error
 func NewMetadataError(err error, msg string) *MetadataErr {
 	return &MetadataErr{
-		msg: fmt.Sprintf("%s: %v", msg, err),
+		msg: msg,
 	}
 }
 
 func (e *MetadataErr) Error() string {
 	// If the inner error is nil, we don't want to print out "<nil>"
 	if e.innerErr != nil {
-		return fmt.Sprintf("%v: %s", e.innerErr, e.msg)
+		return fmt.Sprintf("%s: %v", e.msg, e.innerErr)
 	} else {
 		return e.msg
 	}
@@ -164,12 +164,12 @@ func (e *MetadataErr) Error() string {
 func (e *MetadataErr) Is(target error) bool {
 	// We want to verify we have a timeout error
 	if _, ok := target.(*MetadataErr); ok {
-		return e.msg == "Timeout when querying metadata"
+		return e.msg == target.Error()
 	}
 	return false
 }
 
-func (e *MetadataErr) Wrap(err error) *MetadataErr {
+func (e *MetadataErr) Wrap(err error) error {
 	return &MetadataErr{
 		innerErr: err,
 		msg:      e.msg,

--- a/config/config.go
+++ b/config/config.go
@@ -163,8 +163,8 @@ func (e *MetadataErr) Error() string {
 
 func (e *MetadataErr) Is(target error) bool {
 	// We want to verify we have a timeout error
-	if _, ok := target.(*MetadataErr); ok {
-		return e.msg == target.Error()
+	if target, ok := target.(*MetadataErr); ok {
+		return e.msg == target.msg
 	}
 	return false
 }


### PR DESCRIPTION
Adds and error to config so that if there is a timeout getting the metadata response, we mark as retryable and exit(11). In addition, found that we were marking things as retryable even when the client has no errors in its checked error stack array, so check for that now and return false for retryable if that array is empty.