### PR TITLE
gorelease with snapshotting unless there are tags for Issue #681

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -95,4 +95,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: "${{ steps.generate-tag-list.outputs.taglist }}"
           build-args: |
-            IS_NONRELEASE_BUILD=${{ steps.generate-tag-list.outputs.taglist == '' }}
+            IS_NONRELEASE_BUILD=${{ inputs.tag == '' }}

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -95,4 +95,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: "${{ steps.generate-tag-list.outputs.taglist }}"
           build-args: |
-            IS_PR_BUILD=${{ github.event_name == 'pull_request' }}
+            IS_NONRELEASE_BUILD=${{ steps.generate-tag-list.outputs.taglist == '' }}

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -29,7 +29,7 @@ COPY web_ui/frontend ./
 RUN npm run build
 
 FROM goreleaser/goreleaser:v1.21.0 AS pelican-build
-ARG IS_PR_BUILD="true"
+ARG IS_NONRELEASE_BUILD="true"
 
 WORKDIR /pelican
 
@@ -37,7 +37,7 @@ COPY . .
 COPY --from=website-build /webapp/out ./web_ui/frontend/out
 
 RUN\
-    if $IS_PR_BUILD;\
+    if $IS_NONRELEASE_BUILD;\
         then goreleaser build --clean --snapshot;\
     else goreleaser build --clean;\
     fi


### PR DESCRIPTION
Change release-container action to have build use goreleaser with snapshotting if  input.tags is empty, and only use goreleaser without snapshotting if input.tags contains a tag.