### PR TITLE
Cache now gets the namespaceads from the director every time it re-adv…

### DIFF
--- a/cmd/cache_serve.go
+++ b/cmd/cache_serve.go
@@ -22,24 +22,18 @@ package main
 
 import (
 	"context"
-	"encoding/json"
-	"net/url"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
 	"github.com/pelicanplatform/pelican/broker"
 	"github.com/pelicanplatform/pelican/cache_ui"
-	"github.com/pelicanplatform/pelican/common"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/daemon"
-	"github.com/pelicanplatform/pelican/director"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_ui"
 	"github.com/pelicanplatform/pelican/server_utils"
-	"github.com/pelicanplatform/pelican/utils"
 	"github.com/pelicanplatform/pelican/web_ui"
 	"github.com/pelicanplatform/pelican/xrootd"
 	"github.com/pkg/errors"
@@ -48,53 +42,6 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
 )
-
-func getNSAdsFromDirector() ([]common.NamespaceAdV2, error) {
-	// Get the endpoint of the director
-	var respNS []common.NamespaceAdV2
-	directorEndpoint, err := getDirectorEndpoint()
-	if err != nil {
-		return respNS, errors.Wrapf(err, "Failed to get DirectorURL from config: %v", err)
-	}
-
-	// Create the listNamespaces url
-	directorNSListEndpointURL, err := url.JoinPath(directorEndpoint, "api", "v2.0", "director", "listNamespaces")
-	if err != nil {
-		return respNS, err
-	}
-
-	// Attempt to get data from the 2.0 endpoint, if that returns a 404 error, then attempt to get data
-	// from the 1.0 endpoint and convert from V1 to V2
-
-	respData, err := utils.MakeRequest(directorNSListEndpointURL, "GET", nil, nil)
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			directorNSListEndpointURL, err = url.JoinPath(directorEndpoint, "api", "v1.0", "director", "listNamespaces")
-			if err != nil {
-				return respNS, err
-			}
-			respData, err = utils.MakeRequest(directorNSListEndpointURL, "GET", nil, nil)
-			var respNSV1 []common.NamespaceAdV1
-			if err != nil {
-				return respNS, errors.Wrap(err, "Failed to make request")
-			} else {
-				if jsonErr := json.Unmarshal(respData, &respNSV1); jsonErr == nil { // Error creating json
-					return respNS, errors.Wrapf(err, "Failed to make request: %v", err)
-				}
-				respNS = director.ConvertNamespaceAdsV1ToV2(respNSV1, nil)
-			}
-		} else {
-			return respNS, errors.Wrap(err, "Failed to make request")
-		}
-	} else {
-		err = json.Unmarshal(respData, &respNS)
-		if err != nil {
-			return respNS, errors.Wrapf(err, "Failed to marshal response in to JSON: %v", err)
-		}
-	}
-
-	return respNS, nil
-}
 
 func serveCache(cmd *cobra.Command, _ []string) error {
 	cancel, err := serveCacheInternal(cmd.Context())
@@ -138,13 +85,15 @@ func serveCacheInternal(cmdCtx context.Context) (context.CancelFunc, error) {
 		return shutdownCancel, err
 	}
 
-	nsAds, err := getNSAdsFromDirector()
 	if err != nil {
 		return shutdownCancel, err
 	}
 
 	cacheServer := &cache_ui.CacheServer{}
-	cacheServer.SetNamespaceAds(nsAds)
+	err = cacheServer.GetNamespaceAdsFromDirector()
+	if err != nil {
+		return shutdownCancel, err
+	}
 	err = server_ui.CheckDefaults(cacheServer)
 	if err != nil {
 		return shutdownCancel, err

--- a/cmd/director.go
+++ b/cmd/director.go
@@ -19,10 +19,6 @@
 package main
 
 import (
-	"net/url"
-
-	"github.com/pelicanplatform/pelican/param"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -49,21 +45,6 @@ var (
 		SilenceUsage: true,
 	}
 )
-
-func getDirectorEndpoint() (string, error) {
-	directorEndpoint := param.Federation_DirectorUrl.GetString()
-	if directorEndpoint == "" {
-		return "", errors.New("No director specified; give the federation name (-f)")
-	}
-
-	directorEndpointURL, err := url.Parse(directorEndpoint)
-	if err != nil {
-		return "", errors.Wrap(err, "Unable to parse director url")
-	}
-
-	// Return the string, as opposed to a pointer to the URL object
-	return directorEndpointURL.String(), nil
-}
 
 func init() {
 	// Tie the directorServe command to the root CLI command

--- a/origin_ui/advertise.go
+++ b/origin_ui/advertise.go
@@ -39,6 +39,10 @@ func (server *OriginServer) GetServerType() config.ServerType {
 	return config.OriginType
 }
 
+func (server *OriginServer) GetNamespaceAdsFromDirector() error {
+	return nil
+}
+
 func (server *OriginServer) CreateAdvertisement(name string, originUrlStr string, originWebUrl string) (ad common.OriginAdvertiseV2, err error) {
 	// Here we instantiate the namespaceAd slice, but we still need to define the namespace
 	issuerUrl := url.URL{}

--- a/server_ui/advertise.go
+++ b/server_ui/advertise.go
@@ -96,6 +96,11 @@ func advertiseInternal(ctx context.Context, server server_utils.XRootDServer) er
 		return errors.New(fmt.Sprintf("%s name isn't set", server.GetServerType()))
 	}
 
+	err := server.GetNamespaceAdsFromDirector()
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("%s failed to get namespaceAds from the director", server.GetServerType()))
+	}
+
 	originUrl := param.Origin_Url.GetString()
 	originWebUrl := param.Server_ExternalWebUrl.GetString()
 

--- a/server_utils/server_struct.go
+++ b/server_utils/server_struct.go
@@ -29,6 +29,7 @@ type (
 		SetNamespaceAds([]common.NamespaceAdV2)
 		GetNamespaceAds() []common.NamespaceAdV2
 		CreateAdvertisement(name string, serverUrl string, serverWebUrl string) (common.OriginAdvertiseV2, error)
+		GetNamespaceAdsFromDirector() error
 	}
 
 	NamespaceHolder struct {


### PR DESCRIPTION
…ertises

	-- Added a server function to get namespace ads from the director
	-- Does nothing if server is an origin
	-- During advertise, the server calls this function
	
	
To test:

1. Spin up a local director and registry.
2. Serve an origin with a namespace <ns1>
3. Serve a cache and check /run/pelican/xrootd/cache/scitokens-cache-generated.cfg to ensure the origin is there.
4. Serve another origin with a namespace <ns2>
5. Wait 2 minutes for the cache advertisement to refresh.
6. Recheck the scitokens-cache-generated.cfg to ensure the new origin is there

Note: There is a known issue with duplicated base paths in scitokens that is not introduced in this PR.
	