### PR TITLE
Fix Prometheus token expires

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -795,9 +795,9 @@ func InitServer(ctx context.Context, currentServers ServerType) error {
 	tokenExpiresIn := param.Monitoring_TokenExpiresIn.GetDuration()
 
 	if tokenExpiresIn == 0 || tokenRefreshInterval == 0 || tokenRefreshInterval > tokenExpiresIn {
-		viper.Set("Monitoring.TokenRefreshInterval", time.Minute*59)
+		viper.Set("Monitoring.TokenRefreshInterval", time.Minute*5)
 		viper.Set("Monitoring.TokenExpiresIn", time.Hour*1)
-		log.Warningln("Invalid Monitoring.TokenRefreshInterval or Monitoring.TokenExpiresIn. Fallback to 59m for refresh interval and 1h for valid interval")
+		log.Warningln("Invalid Monitoring.TokenRefreshInterval or Monitoring.TokenExpiresIn. Fallback to 5m for refresh interval and 1h for valid interval")
 	}
 
 	if currentServers.IsEnabled(DirectorType) {

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -62,7 +62,7 @@ Monitoring:
   PortLower: 9930
   PortHigher: 9999
   TokenExpiresIn: 1h
-  TokenRefreshInterval: 59m
+  TokenRefreshInterval: 5m
   MetricAuthorization: true
   AggregatePrefixes: ["/*"]
 Shoveler:

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1379,7 +1379,7 @@ description: >-
   The tokens that are affected by this config are the same as the one in Monitoring.TokenExpiresIn.
   This value must be less than Monitoring.TokenExpiresIn.
 type: duration
-default: 59m
+default: 5m
 components: ["origin", "director", "registry"]
 ---
 name: Monitoring.MetricAuthorization

--- a/go.sum
+++ b/go.sum
@@ -78,7 +78,9 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bsm/ginkgo/v2 v2.5.0 h1:aOAnND1T40wEdAtkGSkvSICWeQ8L3UASX7YVCqQx+eQ=
+github.com/bsm/ginkgo/v2 v2.5.0/go.mod h1:AiKlXPm7ItEHNc/2+OkrNG4E0ITzojb9/xWzvQ9XZ9w=
 github.com/bsm/gomega v1.20.0 h1:JhAwLmtRzXFTx2AkALSLa8ijZafntmhSoU63Ok18Uq8=
+github.com/bsm/gomega v1.20.0/go.mod h1:JifAceMQ4crZIWYUKrlGcmbN3bqHogVTADMD2ATsbwk=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.9.1 h1:6iJ6NqdoxCDr6mbY8h18oSO+cShGSMRGCEo7F2h0x8s=
 github.com/bytedance/sonic v1.9.1/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZXU064P/U=


### PR DESCRIPTION
Fixes #787 

The cause of the issue was that only the self-scraper config and service discovery config are reloaded. The origin/cache scraper never gets reloaded.

This PR also reduced the token refresh time to 5m to ensure we won't wait until another 59m if the token update wasn't successful.

To test, set the following config for faster expire/refresh cycle:

```yaml
Monitoring:
  TokenExpiresIn: 2m
  TokenRefreshInterval: 1m
```

Also make sure you have `Federation.DiscoveryUrl`  set to your director address.

I'd suggest spin up your servers individually in separate terminals in the order of `director`, `registry`, and `origin`. It also works for fed-in-a-box, but you'll see much more verbose log.

And you should see `200` for all `/metrics` request at the **origin** server (your log level should be at at least `INFO`):

```console
INFO Served Request  daemon=gin fields.time=1.991334ms method=GET resource=/metrics status=200
```