### PR TITLE
Add project to Prometheus file transfer metric

### DIFF
--- a/docs/pages/prometheus.mdx
+++ b/docs/pages/prometheus.mdx
@@ -135,6 +135,10 @@ All of the Pelican servers have the following metrics:
 
   Client’s group names in a space-separated list. If no groups are present, the tag variable data is null.
 
+  #### Label: `proj`
+
+  Client’s `User-Agent` header when requesting the file. This is used to label the project name that accesses the file.
+
   #### Label: `type`
 
   Label values:

--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -580,6 +580,7 @@ func HandlePacket(packet []byte) error {
 					"dn":   "",
 					"role": "",
 					"org":  "",
+					"proj": "",
 				}
 				var oldReadvSegs uint64 = 0
 				var oldReadOps uint32 = 0
@@ -683,6 +684,7 @@ func HandlePacket(packet []byte) error {
 					"dn":   "",
 					"role": "",
 					"org":  "",
+					"proj": "",
 				}
 
 				if item != nil {

--- a/metrics/xrootd_metrics_test.go
+++ b/metrics/xrootd_metrics_test.go
@@ -582,23 +582,23 @@ func TestHandlePacket(t *testing.T) {
 		expectedTransferReadvSegs := `
 		# HELP xrootd_transfer_readv_segments_count Number of segments in readv operations
 		# TYPE xrootd_transfer_readv_segments_count counter
-		xrootd_transfer_readv_segments_count{ap="",dn="",org="",path="/",role=""} 1000
+		xrootd_transfer_readv_segments_count{ap="",dn="",org="",path="/",proj="",role=""} 1000
 		`
 
 		expectedTransferOps := `
 		# HELP xrootd_transfer_operations_count Number of transfer operations performed
 		# TYPE xrootd_transfer_operations_count counter
-		xrootd_transfer_operations_count{ap="",dn="",org="",path="/",role="",type="read"} 120
-		xrootd_transfer_operations_count{ap="",dn="",org="",path="/",role="",type="readv"} 10
-		xrootd_transfer_operations_count{ap="",dn="",org="",path="/",role="",type="write"} 30
+		xrootd_transfer_operations_count{ap="",dn="",org="",path="/",proj="",role="",type="read"} 120
+		xrootd_transfer_operations_count{ap="",dn="",org="",path="/",proj="",role="",type="readv"} 10
+		xrootd_transfer_operations_count{ap="",dn="",org="",path="/",proj="",role="",type="write"} 30
 		`
 
 		expectedTransferBytes := `
 		# HELP xrootd_transfer_bytes Bytes of transfers
 		# TYPE xrootd_transfer_bytes counter
-		xrootd_transfer_bytes{ap="",dn="",org="",path="/",role="",type="read"} 10000
-		xrootd_transfer_bytes{ap="",dn="",org="",path="/",role="",type="readv"} 20000
-		xrootd_transfer_bytes{ap="",dn="",org="",path="/",role="",type="write"} 120
+		xrootd_transfer_bytes{ap="",dn="",org="",path="/",proj="",role="",type="read"} 10000
+		xrootd_transfer_bytes{ap="",dn="",org="",path="/",proj="",role="",type="readv"} 20000
+		xrootd_transfer_bytes{ap="",dn="",org="",path="/",proj="",role="",type="write"} 120
 		`
 
 		expectedTransferReadvSegsReader := strings.NewReader(expectedTransferReadvSegs)


### PR DESCRIPTION
Closes #797 

To test, rename your `pelican` binary to `osdf` and set `Federation.DiscoveryURL` to `osg-htc.org`, and run your origin.

Login to the web UI, then go to `https://<origin-host>:<origin-port>/metrics` endpoint. Wait for a couple of minutes, refresh the page, and at the bottom of the page, you should be able to see the following metrics.

Note that now the `proj` label is available which is the `User-Agent` header from the client requesting the object.

```console
# TYPE xrootd_transfer_bytes counter
xrootd_transfer_bytes{ap="https",dn="",org="",path="/.well-known",proj="",role="",type="read"} 18709
xrootd_transfer_bytes{ap="https",dn="",org="",path="/.well-known",proj="",role="",type="readv"} 0
xrootd_transfer_bytes{ap="https",dn="",org="",path="/.well-known",proj="",role="",type="write"} 0
xrootd_transfer_bytes{ap="https",dn="",org="",path="/.well-known",proj="Go-http-client/1.1",role="",type="read"} 216
xrootd_transfer_bytes{ap="https",dn="",org="",path="/.well-known",proj="Go-http-client/1.1",role="",type="readv"} 0
xrootd_transfer_bytes{ap="https",dn="",org="",path="/.well-known",proj="Go-http-client/1.1",role="",type="write"} 0
xrootd_transfer_bytes{ap="ztn",dn="origin",org="https://0be1a304b5d7:8443",path="/pelican",proj="",role="",type="read"} 19654
xrootd_transfer_bytes{ap="ztn",dn="origin",org="https://0be1a304b5d7:8443",path="/pelican",proj="",role="",type="readv"} 0
xrootd_transfer_bytes{ap="ztn",dn="origin",org="https://0be1a304b5d7:8443",path="/pelican",proj="",role="",type="write"} 0
# HELP xrootd_transfer_operations_count Number of transfer operations performed
# TYPE xrootd_transfer_operations_count counter
xrootd_transfer_operations_count{ap="https",dn="",org="",path="/.well-known",proj="",role="",type="read"} 106
xrootd_transfer_operations_count{ap="https",dn="",org="",path="/.well-known",proj="",role="",type="readv"} 0
xrootd_transfer_operations_count{ap="https",dn="",org="",path="/.well-known",proj="",role="",type="write"} 0
xrootd_transfer_operations_count{ap="https",dn="",org="",path="/.well-known",proj="Go-http-client/1.1",role="",type="read"} 2
xrootd_transfer_operations_count{ap="https",dn="",org="",path="/.well-known",proj="Go-http-client/1.1",role="",type="readv"} 0
xrootd_transfer_operations_count{ap="https",dn="",org="",path="/.well-known",proj="Go-http-client/1.1",role="",type="write"} 0
xrootd_transfer_operations_count{ap="ztn",dn="origin",org="https://0be1a304b5d7:8443",path="/pelican",proj="",role="",type="read"} 317
xrootd_transfer_operations_count{ap="ztn",dn="origin",org="https://0be1a304b5d7:8443",path="/pelican",proj="",role="",type="readv"} 0
xrootd_transfer_operations_count{ap="ztn",dn="origin",org="https://0be1a304b5d7:8443",path="/pelican",proj="",role="",type="write"} 0
# HELP xrootd_transfer_readv_segments_count Number of segments in readv operations
# TYPE xrootd_transfer_readv_segments_count counter
xrootd_transfer_readv_segments_count{ap="https",dn="",org="",path="/.well-known",proj="",role=""} 0
xrootd_transfer_readv_segments_count{ap="https",dn="",org="",path="/.well-known",proj="Go-http-client/1.1",role=""} 0
xrootd_transfer_readv_segments_count{ap="ztn",dn="origin",org="https://0be1a304b5d7:8443",path="/pelican",proj="",role=""} 0
```