### PR TITLE
Add user role icon to the side bar in UI

### DIFF
--- a/web_ui/frontend/components/layout/Sidebar.tsx
+++ b/web_ui/frontend/components/layout/Sidebar.tsx
@@ -18,16 +18,16 @@
 
 "use client"
 
-import Image from 'next/image'
 import { useRouter } from 'next/navigation'
-import {Typography, Box, Button, Snackbar, Alert, Tooltip, IconButton, Grow, Paper, BoxProps} from "@mui/material";
+import {Avatar, Box, Button, Snackbar, Alert, Tooltip, IconButton, Grow, Paper, BoxProps} from "@mui/material";
 import { ClickAwayListener } from '@mui/base';
-import {Help, HelpOutline, Description, BugReport} from "@mui/icons-material";
+import {AssignmentInd, Person, HelpOutline, Description, BugReport} from "@mui/icons-material";
 import LogoutIcon from '@mui/icons-material/Logout';
+import { grey, green } from '@mui/material/colors';
 
 import styles from "../../app/page.module.css"
 import GitHubIcon from '@mui/icons-material/GitHub';
-import React, {ReactNode, useState} from "react";
+import React, {ReactNode, useState, useEffect} from "react";
 import Link from 'next/link';
 
 interface SpeedButtonProps {
@@ -160,6 +160,7 @@ export const Sidebar = ({children}: {children: ReactNode}) => {
     const router = useRouter()
 
     const [error, setError] = useState("")
+    const [role, setRole] = useState("")
 
     const handleLogout = async (e: React.MouseEvent<HTMLElement>) => {
         try {
@@ -189,6 +190,31 @@ export const Sidebar = ({children}: {children: ReactNode}) => {
         }
     }
 
+    const getWhoami = async () => {
+        try {
+            let response = await fetch("/api/v1.0/auth/whoami", {
+                method: "GET",
+                headers: {
+                    "Content-Type": "application/json"
+                }
+            })
+
+            if(response.ok){
+                let data = await response.json()
+                setRole(data?.role)
+            } else {
+                setError("Server error with status code " + response.status)
+            }
+        } catch {
+            setError("Could not connect to server")
+        }
+    }
+
+    useEffect(() => {
+        getWhoami()
+    }, [])
+
+
     return (
         <Box>
             <Snackbar
@@ -214,6 +240,11 @@ export const Sidebar = ({children}: {children: ReactNode}) => {
                             {children}
                         </Box>
                         <Box display={"flex"} flexDirection={"column"} justifyContent={"center"} textAlign={"center"}>
+                            <Tooltip title={role === "admin" ? "Admin User" : "General User"} placement="right" arrow>
+                                <Avatar sx={{ bgcolor: role === "admin" ? green[500] : grey[500], width: 32, height: 32 }} alt="User icon" style={{margin: "0 auto 10px auto"}}>
+                                    { role === "admin" ? <AssignmentInd/>:<Person />}
+                                </Avatar>
+                            </Tooltip>
                             <Tooltip title="Logout" placement="right" arrow>
                                 <IconButton aria-label='logout' onClick={handleLogout} style={{marginBottom: 10}}>
                                     <LogoutIcon/>


### PR DESCRIPTION
Closes #629 

With admin privilege:
![Screenshot 2024-02-19 at 9 47 47 AM](https://github.com/PelicanPlatform/pelican/assets/41393704/d78e87a1-3113-4353-8233-ddb4facea25b)

Without:
![Screenshot 2024-02-19 at 9 47 54 AM](https://github.com/PelicanPlatform/pelican/assets/41393704/b00b9b75-563f-439f-b53a-4340ca4f2f9e)

I kind of hate fetching `/whoami` one more time during rendering (I believe we already did 2 or 3 times per page) but not doing that requires us using context or some state management package which seems outside of the scope for this ticket. 