### PR TITLE
Add logrotate file

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -232,6 +232,9 @@ nfpms:
       - src: "systemd/pelican-registry.yaml"
         dst: "/etc/pelican/pelican-registry.yaml"
         type: config|noreplace
+      - src: "systemd/pelican.logrotate"
+        dst: "/etc/logrotate.d/pelican"
+        type: config|noreplace
       - dst: "/var/log/pelican"
         type: "dir"
         file_info:

--- a/systemd/pelican.logrotate
+++ b/systemd/pelican.logrotate
@@ -1,0 +1,8 @@
+/var/log/pelican/*.log {
+    compress
+    copytruncate
+    size 500M
+    missingok
+    notifempty
+    rotate 10
+}


### PR DESCRIPTION
This rotates at 500 MB, 10 times, but given that distros by default run logrotate only once a day, this just means that light days won't rotate out heavy days; we still need to be conservative about log sizes so a sudden spike won't use up all the disk.

Closes #728