### PR TITLE
Update GHA to allow manifest to be written to harbor

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -75,6 +75,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
 
       - name: Log in to OSG Harbor
         uses: docker/login-action@v3
@@ -94,4 +96,4 @@ jobs:
           build-args: |
             IS_PR_BUILD=${{ github.event_name == 'pull_request' }}
           cache-from: type=registry,ref=hub.opensciencegrid.org/pelican_platform/pelican:buildcache
-          cache-to: type=registry,ref=hub.opensciencegrid.org/pelican_platform/pelican:buildcache,mode=max,ignore-error=true
+          cache-to: type=registry,ref=hub.opensciencegrid.org/pelican_platform/pelican:buildcache,mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true

--- a/.github/workflows/publish-dev-container.yml
+++ b/.github/workflows/publish-dev-container.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
 
       - name: Log in to OSG Harbor
         uses: docker/login-action@v3
@@ -49,4 +51,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=registry,ref=hub.opensciencegrid.org/pelican_platform/pelican-dev:buildcache
-          cache-to: type=registry,ref=hub.opensciencegrid.org/pelican_platform/pelican-dev:buildcache,mode=max,ignore-error=true
+          cache-to: type=registry,ref=hub.opensciencegrid.org/pelican_platform/pelican-dev:buildcache,mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true


### PR DESCRIPTION
Fixes the issue where the caching didn't work for building dev and production container. According to the log, it's due to 404 when GHA tries to push docker image manifest to harbor: https://github.com/PelicanPlatform/pelican/actions/runs/7975774289/job/21774758514

The fix was found here: https://github.com/goharbor/harbor/pull/18105#issuecomment-1811951274

Also adding debug to buildx for more verbose log.