### PR TITLE
Fix wrong parameter names for default and osdf config files

### DIFF
--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -57,8 +57,8 @@ Origin:
   SelfTestInterval: 15s
 Registry:
   InstitutionsUrlReloadMinutes: 15m
-  CacheApprovedOnly: false
-  OriginApprovedOnly: false
+  RequireCacheApproval: false
+  RequireOriginApproval: false
 Monitoring:
   PortLower: 9930
   PortHigher: 9999

--- a/config/resources/osdf.yaml
+++ b/config/resources/osdf.yaml
@@ -24,5 +24,5 @@ Federation:
   TopologyNamespaceURL: https://topology.opensciencegrid.org/osdf/namespaces
   TopologyReloadInterval: 10m
 Registry:
-  CacheApprovedOnly: true
-  OriginApprovedOnly: true
+  RequireCacheApproval: true
+  RequireOriginApproval: true


### PR DESCRIPTION
The correct parameter name for requiring admin approval for origins and caches are `RequireOriginApproval` and `RequireCacheApproval`. But what we had in the default.yaml and osdf.yaml are the outdated names. This PR is to fix it.

To test, change your origin prefix to a new name you haven't registered in your registry, run your fed-in-a-box in OSDF mode and you should see something like: 

```
INFO[2024-02-20T18:52:15Z] Served Request                                client=172.17.0.2 daemon=gin fields.time="286.125µs" method=POST resource=/api/v1.0/registry/checkNamespaceStatus status=200
WARNING[2024-02-20T18:52:15Z] Failed to verify advertise token. Namespace "/haoming/testorigin5" requires administrator approval 
INFO[2024-02-20T18:52:15Z] Served Request                                client=172.17.0.2 daemon=gin fields.time=1.974584ms method=POST resource=/api/v1.0/director/registerOrigin status=403
WARNING[2024-02-20T18:52:15Z] XRootD server advertise failed: The namespace "/haoming/testorigin5" requires administrator approval. Please contact the administrators of https://0be1a304b5d7:8444 for more information. 
```