### PR TITLE
Web-based config change - backend support

### DIFF
--- a/cmd/cache_serve.go
+++ b/cmd/cache_serve.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pelicanplatform/pelican/cache_ui"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/daemon"
+	"github.com/pelicanplatform/pelican/launchers"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_ui"
 	"github.com/pelicanplatform/pelican/server_utils"
@@ -74,7 +75,11 @@ func serveCacheInternal(cmdCtx context.Context) (context.CancelFunc, error) {
 		case sig := <-sigs:
 			log.Warningf("Received signal %v; will shutdown process", sig)
 			shutdownCancel()
-			return nil
+			return launchers.ErrExitOnSignal
+		case <-config.RestartFlag:
+			log.Warningf("Received restart request; will restart the process")
+			shutdownCancel()
+			return launchers.ErrRestart
 		case <-ctx.Done():
 			return nil
 		}

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1037,6 +1037,14 @@ type: int
 default: 1
 components: ["*"]
 ---
+name: Server.WebConfigFile
+description: >-
+  A filepath to the file where web-based configuration changes are stored
+type: filename
+root_default: /etc/pelican/web-config.yaml
+default: "$ConfigBase/web-config.yaml"
+components: ["*"]
+---
 ################################
 #   Issuer's Configurations    #
 ################################

--- a/generate/param_generator.go
+++ b/generate/param_generator.go
@@ -312,7 +312,7 @@ func GenParamStruct() {
 	}
 
 	data := TemplateData{
-		GeneratedConfig:         `type config` + generateGoStructCode(root, ""),
+		GeneratedConfig:         `type Config` + generateGoStructCode(root, ""),
 		GeneratedConfigWithType: `type configWithType` + generateGoStructWithTypeCode(root, ""),
 	}
 

--- a/param/param.go
+++ b/param/param.go
@@ -9,15 +9,15 @@ import (
 )
 
 var (
-	viperConfig *config
+	viperConfig *Config
 	configMutex sync.RWMutex
 )
 
 // Unmarshal Viper config into a struct viperConfig and returns it
-func UnmarshalConfig() (*config, error) {
+func UnmarshalConfig() (*Config, error) {
 	configMutex.Lock()
 	defer configMutex.Unlock()
-	viperConfig = new(config)
+	viperConfig = new(Config)
 	err := viper.Unmarshal(viperConfig)
 	if err != nil {
 		return nil, err
@@ -27,7 +27,7 @@ func UnmarshalConfig() (*config, error) {
 }
 
 // Return the unmarshaled viper config struct as a pointer
-func GetUnmarshaledConfig() (*config, error) {
+func GetUnmarshaledConfig() (*Config, error) {
 	configMutex.RLock()
 	defer configMutex.RUnlock()
 	if viperConfig == nil {
@@ -95,7 +95,7 @@ func convertStruct(srcVal, destVal reflect.Value) {
 }
 
 // Convert a config struct to configWithType struct
-func ConvertToConfigWithType(rawConfig *config) *configWithType {
+func ConvertToConfigWithType(rawConfig *Config) *configWithType {
 	typedConfig := configWithType{}
 
 	srcVal := reflect.ValueOf(rawConfig).Elem()

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -130,6 +130,7 @@ var (
 	Server_TLSKey = StringParam{"Server.TLSKey"}
 	Server_UIActivationCodeFile = StringParam{"Server.UIActivationCodeFile"}
 	Server_UIPasswordFile = StringParam{"Server.UIPasswordFile"}
+	Server_WebConfigFile = StringParam{"Server.WebConfigFile"}
 	Server_WebHost = StringParam{"Server.WebHost"}
 	Shoveler_AMQPExchange = StringParam{"Shoveler.AMQPExchange"}
 	Shoveler_AMQPTokenLocation = StringParam{"Shoveler.AMQPTokenLocation"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-type config struct {
+type Config struct {
 	Cache struct {
 		DataLocation string
 		EnableVoms bool
@@ -168,6 +168,7 @@ type config struct {
 		UIActivationCodeFile string
 		UILoginRateLimit int
 		UIPasswordFile string
+		WebConfigFile string
 		WebHost string
 		WebPort int
 	}
@@ -384,6 +385,7 @@ type configWithType struct {
 		UIActivationCodeFile struct { Type string; Value string }
 		UILoginRateLimit struct { Type string; Value int }
 		UIPasswordFile struct { Type string; Value string }
+		WebConfigFile struct { Type string; Value string }
 		WebHost struct { Type string; Value string }
 		WebPort struct { Type string; Value int }
 	}

--- a/web_ui/frontend/app/api/docs/pelican-swagger.yaml
+++ b/web_ui/frontend/app/api/docs/pelican-swagger.yaml
@@ -375,6 +375,66 @@ paths:
                   Value: ""
         "401":
           description: Unauthorized
+    patch:
+      tags:
+        - "common"
+      summary: Update the server configuration with user-provided changes
+      description:
+        "`Authentication Required` `Admin Previlege Required`
+
+
+        The server will restart promptly after a  successful request. You may query against
+        `/health` endpoint to check if the server is back online.
+
+
+        Note that the endpoint will update the value of **all parameters provided**, no matter the value is in default or not (`0`, `null`,`undefined`, etc).
+
+
+        This means you want to eliminate parameters from the request body that are untouched."
+      parameters:
+        - in: body
+          name: config
+          required: true
+          description:
+            The config value to update.
+            It must be a JSON object with keys/values that match config parameters' name and data type.
+            Parameter names are case-insensitive.
+          schema:
+            type: object
+            example:
+              Logging:
+                Cache:
+                  Scitokens: "info"
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: Successfully updated the config. Server is restarting.
+          schema:
+            type: object
+            $ref: "#/definitions/SuccessModel"
+        "400":
+          description: Bad request. The requested changes of config value are invalid.
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModel"
+        "401":
+          description: Unauthorized. You need you login to take this action.
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModel"
+        "403":
+          description: Forbidden. You need admin previlege to take this action.
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModel"
+        "500":
+          description: Server error. Can't update the config due to internal server error.
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModel"
   /servers:
     get:
       tags:

--- a/web_ui/frontend/app/api/docs/pelican-swagger.yaml
+++ b/web_ui/frontend/app/api/docs/pelican-swagger.yaml
@@ -416,17 +416,17 @@ paths:
             type: object
             $ref: "#/definitions/SuccessModel"
         "400":
-          description: Bad request. The requested changes of config value are invalid.
+          description: Bad request. The requested changes of config values are invalid.
           schema:
             type: object
             $ref: "#/definitions/ErrorModel"
         "401":
-          description: Unauthorized. You need you login to take this action.
+          description: Unauthorized. You need to login to take this action.
           schema:
             type: object
             $ref: "#/definitions/ErrorModel"
         "403":
-          description: Forbidden. You need admin previlege to take this action.
+          description: Forbidden. You need admin privileges to take this action.
           schema:
             type: object
             $ref: "#/definitions/ErrorModel"

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -77,7 +77,7 @@ func updateConfigValues(ctx *gin.Context) {
 	updatedConfig := param.Config{}
 	updatedConfigMap := map[string]interface{}{}
 
-	// Check if the request data is valid config params
+	// Check if the request data is a valid config
 	if err := ctx.ShouldBindBodyWith(&updatedConfig, binding.JSON); err != nil {
 		ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Failed to bind the request. Invalid request data format: " + err.Error()})
 		return

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -241,7 +241,7 @@ func configureWebResource(engine *gin.Engine) error {
 // Configure common endpoint available to all server web UI which are located at /api/v1.0/*
 func configureCommonEndpoints(engine *gin.Engine) error {
 	engine.GET("/api/v1.0/config", AuthHandler, getConfigValues)
-	engine.POST("/api/v1.0/config", AuthHandler, AdminAuthHandler, updateConfigValues)
+	engine.PATCH("/api/v1.0/config", AuthHandler, AdminAuthHandler, updateConfigValues)
 	engine.GET("/api/v1.0/servers", getEnabledServers)
 	// Health check endpoint for web engine
 	engine.GET("/api/v1.0/health", func(ctx *gin.Context) {


### PR DESCRIPTION
This should close part of the ticket #753 with all necessary backend support added.

Test is a bit tricky and a bit complicated:

1. Build and spin up one of your server (I used registry as the example below but it work for all servers)
2. Login to your server web ui **with your admin account** (You may test with a general user account but the API will return 403)

If you are using [postman](https://www.postman.com/downloads/), here is the instruction:
1. After login, `inspect` the current page in your browser (cmd+opt+i for Chrome) 
2. Go to `Application` tab
3. Find on the left side `Cookie` and go to the domain where your server is hosted (likely `localhost:xxxx`

<img width="1920" alt="Screenshot 2024-02-20 at 7 29 36 PM" src="https://github.com/PelicanPlatform/pelican/assets/41393704/3335b51a-bdd7-4470-99c5-a159fcd84e67">

4. Copy the value of the `login` cookie 
5. Go to postman and create a new HTTP session with `PATCH` action and `https://localhost:<port>/api/v1.0/config`
6. Paste the copied value as a new cookie named `login` in the http session.
7. For request body, go to `Body` tab under the request URL and select `raw` with `JSON`
8. Input your test request in JSON form
9. Hit `Send`
10. If succeeded, your service should be automatically restarted, and when you go to the config page of the UI, the changes should be reflected.

Or if you prefer using `curl`, here is the instruction:
1. Similar to the Postman section, grab the `login` cookie and paste it to your curl request as the cookie value.
2. You may find it very difficult to send JSON body via curl, but you can prepare the data in [online JSON serializer](https://codebeautify.org/json-serialize-online) first

