### PR TITLE
Added support for Grafana

### DIFF
--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -65,6 +65,7 @@ Monitoring:
   TokenExpiresIn: 1h
   TokenRefreshInterval: 5m
   MetricAuthorization: true
+  PromQLAuthorization: true
   AggregatePrefixes: ["/*"]
 Shoveler:
   MessageQueueProtocol: amqp

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1395,7 +1395,14 @@ description: >-
   If authorization (Bearer token) is required for accesing /metrics endpoint
 type: bool
 default: true
-components: ["origin", "director", "registry"]
+components: ["origin", "cache", "director", "registry"]
+---
+name: Monitoring.PromQLAuthorization
+description: >-
+  If authorization (Bearer token or cookie) is required for accesing /prometheus/query endpoint
+type: bool
+default: true
+components: ["origin", "cache", "director", "registry"]
 ---
 ############################
 #   Shoveler-level configs   #

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -200,6 +200,7 @@ var (
 	DisableProxyFallback = BoolParam{"DisableProxyFallback"}
 	Logging_DisableProgressBars = BoolParam{"Logging.DisableProgressBars"}
 	Monitoring_MetricAuthorization = BoolParam{"Monitoring.MetricAuthorization"}
+	Monitoring_PromQLAuthorization = BoolParam{"Monitoring.PromQLAuthorization"}
 	Origin_EnableBroker = BoolParam{"Origin.EnableBroker"}
 	Origin_EnableCmsd = BoolParam{"Origin.EnableCmsd"}
 	Origin_EnableDirListing = BoolParam{"Origin.EnableDirListing"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -90,6 +90,7 @@ type config struct {
 		MetricAuthorization bool
 		PortHigher int
 		PortLower int
+		PromQLAuthorization bool
 		TokenExpiresIn time.Duration
 		TokenRefreshInterval time.Duration
 	}
@@ -306,6 +307,7 @@ type configWithType struct {
 		MetricAuthorization struct { Type string; Value bool }
 		PortHigher struct { Type string; Value int }
 		PortLower struct { Type string; Value int }
+		PromQLAuthorization struct { Type string; Value bool }
 		TokenExpiresIn struct { Type string; Value time.Duration }
 		TokenRefreshInterval struct { Type string; Value time.Duration }
 	}

--- a/web_ui/prometheus_test.go
+++ b/web_ui/prometheus_test.go
@@ -49,6 +49,7 @@ func TestPrometheusProtectionCookieAuth(t *testing.T) {
 	defer cancel()
 
 	viper.Reset()
+	viper.Set("Monitoring.PromQLAuthorization", true)
 
 	av1 := route.New().WithPrefix("/api/v1.0/prometheus")
 
@@ -108,6 +109,7 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 
 	viper.Reset()
 	viper.Set("Server.ExternalWebUrl", "https://test-origin.org:8444")
+	viper.Set("Monitoring.PromQLAuthorization", true)
 
 	av1 := route.New().WithPrefix("/api/v1.0/prometheus")
 


### PR DESCRIPTION
Closes #839 

The PR finished the first and third point in the ticket. A token generation recipe should best be located in the documentation world rather than in this PR. It would also be beneficial to have instructions on how to set up a Grafana visualization of Pelican server metrics, but that should also go to the docs world.

To test, I managed to run a local Grafana and build a dashboard for origin server for reference:

![Screenshot 2024-02-22 at 8 47 29 AM](https://github.com/PelicanPlatform/pelican/assets/41393704/88c41304-00e1-4a6e-9b7b-2dfb04b954bb)
