### PR TITLE
Add API at the director to return the longest prefix match given a path

### DIFF
--- a/common/director.go
+++ b/common/director.go
@@ -99,6 +99,10 @@ type (
 		EnableWrite        bool            `json:"enablewrite"`
 		EnableFallbackRead bool            `json:"enable-fallback-read"` // True if the origin will allow direct client reads when no caches are available
 	}
+
+	GetPrefixByPathRes struct {
+		Prefix string `json:"prefix"`
+	}
 )
 
 const (

--- a/director/advertise.go
+++ b/director/advertise.go
@@ -150,11 +150,11 @@ func AdvertiseOSDF() error {
 	}
 
 	for originAd, namespacesSlice := range originAdMap {
-		RecordAd(originAd, &namespacesSlice)
+		recordAd(originAd, &namespacesSlice)
 	}
 
 	for cacheAd, namespacesSlice := range cacheAdMap {
-		RecordAd(cacheAd, &namespacesSlice)
+		recordAd(cacheAd, &namespacesSlice)
 	}
 
 	return nil

--- a/director/advertise_test.go
+++ b/director/advertise_test.go
@@ -145,13 +145,13 @@ func TestAdvertiseOSDF(t *testing.T) {
 	}
 
 	// Test a few values. If they're correct, it indicates the whole process likely succeeded
-	nsAd, oAds, cAds := GetAdsForPath("/my/server/path/to/file")
+	nsAd, oAds, cAds := getAdsForPath("/my/server/path/to/file")
 	assert.Equal(t, nsAd.Path, "/my/server")
 	assert.Equal(t, nsAd.Generation[0].MaxScopeDepth, uint(3))
 	assert.Equal(t, oAds[0].AuthURL.String(), "https://origin1-auth-endpoint.com")
 	assert.Equal(t, cAds[0].URL.String(), "http://cache-endpoint.com")
 
-	nsAd, oAds, cAds = GetAdsForPath("/my/server/2/path/to/file")
+	nsAd, oAds, cAds = getAdsForPath("/my/server/2/path/to/file")
 	assert.Equal(t, nsAd.Path, "/my/server/2")
 	assert.Equal(t, nsAd.PublicRead, true)
 	assert.Equal(t, oAds[0].AuthURL.String(), "https://origin2-auth-endpoint.com")

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -39,8 +39,8 @@ var (
 	serverAdMutex = sync.RWMutex{}
 )
 
-func RecordAd(ad common.ServerAd, namespaceAds *[]common.NamespaceAdV2) {
-	if err := UpdateLatLong(&ad); err != nil {
+func recordAd(ad common.ServerAd, namespaceAds *[]common.NamespaceAdV2) {
+	if err := updateLatLong(&ad); err != nil {
 		log.Debugln("Failed to lookup GeoIP coordinates for host", ad.URL.Host)
 	}
 	serverAdMutex.Lock()
@@ -54,7 +54,7 @@ func RecordAd(ad common.ServerAd, namespaceAds *[]common.NamespaceAdV2) {
 	}
 }
 
-func UpdateLatLong(ad *common.ServerAd) error {
+func updateLatLong(ad *common.ServerAd) error {
 	if ad == nil {
 		return errors.New("Cannot provide a nil ad to UpdateLatLong")
 	}
@@ -70,7 +70,7 @@ func UpdateLatLong(ad *common.ServerAd) error {
 	if !ok {
 		return errors.New("Failed to create address object from IP")
 	}
-	lat, long, err := GetLatLong(addr)
+	lat, long, err := getLatLong(addr)
 	if err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func matchesPrefix(reqPath string, namespaceAds []common.NamespaceAdV2) *common.
 	return best
 }
 
-func GetAdsForPath(reqPath string) (originNamespace common.NamespaceAdV2, originAds []common.ServerAd, cacheAds []common.ServerAd) {
+func getAdsForPath(reqPath string) (originNamespace common.NamespaceAdV2, originAds []common.ServerAd, cacheAds []common.ServerAd) {
 	serverAdMutex.RLock()
 	defer serverAdMutex.RUnlock()
 

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -144,12 +144,12 @@ func TestGetAdsForPath(t *testing.T) {
 	o1Slice := []common.NamespaceAdV2{nsAd1}
 	o2Slice := []common.NamespaceAdV2{nsAd2, nsAd3}
 	c1Slice := []common.NamespaceAdV2{nsAd1, nsAd2}
-	RecordAd(originAd2, &o2Slice)
-	RecordAd(originAd1, &o1Slice)
-	RecordAd(cacheAd1, &c1Slice)
-	RecordAd(cacheAd2, &o1Slice)
+	recordAd(originAd2, &o2Slice)
+	recordAd(originAd1, &o1Slice)
+	recordAd(cacheAd1, &c1Slice)
+	recordAd(cacheAd2, &o1Slice)
 
-	nsAd, oAds, cAds := GetAdsForPath("/chtc")
+	nsAd, oAds, cAds := getAdsForPath("/chtc")
 	assert.Equal(t, nsAd.Path, "/chtc")
 	assert.Equal(t, len(oAds), 1)
 	assert.Equal(t, len(cAds), 2)
@@ -157,7 +157,7 @@ func TestGetAdsForPath(t *testing.T) {
 	assert.True(t, hasServerAdWithName(cAds, "cache1"))
 	assert.True(t, hasServerAdWithName(cAds, "cache2"))
 
-	nsAd, oAds, cAds = GetAdsForPath("/chtc/")
+	nsAd, oAds, cAds = getAdsForPath("/chtc/")
 	assert.Equal(t, nsAd.Path, "/chtc")
 	assert.Equal(t, len(oAds), 1)
 	assert.Equal(t, len(cAds), 2)
@@ -165,7 +165,7 @@ func TestGetAdsForPath(t *testing.T) {
 	assert.True(t, hasServerAdWithName(cAds, "cache1"))
 	assert.True(t, hasServerAdWithName(cAds, "cache2"))
 
-	nsAd, oAds, cAds = GetAdsForPath("/chtc/PUBLI")
+	nsAd, oAds, cAds = getAdsForPath("/chtc/PUBLI")
 	assert.Equal(t, nsAd.Path, "/chtc")
 	assert.Equal(t, len(oAds), 1)
 	assert.Equal(t, len(cAds), 2)
@@ -173,14 +173,14 @@ func TestGetAdsForPath(t *testing.T) {
 	assert.True(t, hasServerAdWithName(cAds, "cache1"))
 	assert.True(t, hasServerAdWithName(cAds, "cache2"))
 
-	nsAd, oAds, cAds = GetAdsForPath("/chtc/PUBLIC")
+	nsAd, oAds, cAds = getAdsForPath("/chtc/PUBLIC")
 	assert.Equal(t, nsAd.Path, "/chtc/PUBLIC")
 	assert.Equal(t, len(oAds), 1)
 	assert.Equal(t, len(cAds), 1)
 	assert.True(t, hasServerAdWithName(oAds, "origin2"))
 	assert.True(t, hasServerAdWithName(cAds, "cache1"))
 
-	nsAd, oAds, cAds = GetAdsForPath("/chtc/PUBLIC2")
+	nsAd, oAds, cAds = getAdsForPath("/chtc/PUBLIC2")
 	// since the stored path is actually /chtc/PUBLIC2/, the extra / is returned
 	assert.Equal(t, nsAd.Path, "/chtc/PUBLIC2/")
 	assert.Equal(t, len(oAds), 1)
@@ -189,7 +189,7 @@ func TestGetAdsForPath(t *testing.T) {
 
 	// Finally, let's throw in a test for a path we know shouldn't exist
 	// in the ttlcache
-	nsAd, oAds, cAds = GetAdsForPath("/does/not/exist")
+	nsAd, oAds, cAds = getAdsForPath("/does/not/exist")
 	assert.Equal(t, nsAd.Path, "")
 	assert.Equal(t, len(oAds), 0)
 	assert.Equal(t, len(cAds), 0)

--- a/director/director.go
+++ b/director/director.go
@@ -77,9 +77,9 @@ func listServers(ctx *gin.Context) {
 			ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid server type"})
 			return
 		}
-		servers = ListServerAds([]common.ServerType{common.ServerType(queryParams.ToInternalServerType())})
+		servers = listServerAds([]common.ServerType{common.ServerType(queryParams.ToInternalServerType())})
 	} else {
-		servers = ListServerAds([]common.ServerType{common.OriginType, common.CacheType})
+		servers = listServerAds([]common.ServerType{common.OriginType, common.CacheType})
 
 	}
 	resList := make([]listServerResponse, 0)

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -30,7 +30,7 @@ import (
 )
 
 // List all namespaces from origins registered at the director
-func ListNamespacesFromOrigins() []common.NamespaceAdV2 {
+func listNamespacesFromOrigins() []common.NamespaceAdV2 {
 
 	serverAdMutex.RLock()
 	defer serverAdMutex.RUnlock()
@@ -46,7 +46,7 @@ func ListNamespacesFromOrigins() []common.NamespaceAdV2 {
 }
 
 // List all serverAds in the cache that matches the serverType array
-func ListServerAds(serverTypes []common.ServerType) []common.ServerAd {
+func listServerAds(serverTypes []common.ServerType) []common.ServerAd {
 	serverAdMutex.RLock()
 	defer serverAdMutex.RUnlock()
 	ads := make([]common.ServerAd, 0)

--- a/director/director_api_test.go
+++ b/director/director_api_test.go
@@ -71,7 +71,7 @@ func TestListNamespaces(t *testing.T) {
 
 	t.Run("empty-entry", func(t *testing.T) {
 		setup()
-		ns := ListNamespacesFromOrigins()
+		ns := listNamespacesFromOrigins()
 
 		// Initially there should be 0 namespaces registered
 		assert.Equal(t, 0, len(ns), "List is not empty for empty namespace cache.")
@@ -79,7 +79,7 @@ func TestListNamespaces(t *testing.T) {
 	t.Run("one-origin-namespace-entry", func(t *testing.T) {
 		setup()
 		serverAds.Set(mockOriginServerAd, mockNamespaceAds(1, "origin1"), ttlcache.DefaultTTL)
-		ns := ListNamespacesFromOrigins()
+		ns := listNamespacesFromOrigins()
 
 		// Only one entry added
 		assert.Equal(t, 1, len(ns), "List has length not equal to 1 for namespace cache with 1 entry.")
@@ -88,7 +88,7 @@ func TestListNamespaces(t *testing.T) {
 	t.Run("multiple-origin-namespace-entries-from-same-origin", func(t *testing.T) {
 		setup()
 		serverAds.Set(mockOriginServerAd, mockNamespaceAds(10, "origin1"), ttlcache.DefaultTTL)
-		ns := ListNamespacesFromOrigins()
+		ns := listNamespacesFromOrigins()
 
 		assert.Equal(t, 10, len(ns), "List has length not equal to 10 for namespace cache with 10 entries.")
 		assert.True(t, namespaceAdContainsPath(ns, mockPathPreix+"origin1/"+fmt.Sprint(5)), "Returned namespace path does not match what's added")
@@ -103,7 +103,7 @@ func TestListNamespaces(t *testing.T) {
 		mockOriginServerAd.Name = "test-origin-server-2"
 
 		serverAds.Set(mockOriginServerAd, mockNamespaceAds(10, "origin2"), ttlcache.DefaultTTL)
-		ns := ListNamespacesFromOrigins()
+		ns := listNamespacesFromOrigins()
 
 		assert.Equal(t, 20, len(ns), "List has length not equal to 10 for namespace cache with 10 entries.")
 		assert.True(t, namespaceAdContainsPath(ns, mockPathPreix+"origin1/"+fmt.Sprint(5)), "Returned namespace path does not match what's added")
@@ -113,7 +113,7 @@ func TestListNamespaces(t *testing.T) {
 	t.Run("one-cache-namespace-entry", func(t *testing.T) {
 		setup()
 		serverAds.Set(mockCacheServerAd, mockNamespaceAds(1, "cache1"), ttlcache.DefaultTTL)
-		ns := ListNamespacesFromOrigins()
+		ns := listNamespacesFromOrigins()
 
 		// Should not show namespace from cache server
 		assert.Equal(t, 0, len(ns), "List is not empty for namespace cache with entry from cache server.")
@@ -128,7 +128,7 @@ func TestListServerAds(t *testing.T) {
 			defer serverAdMutex.Unlock()
 			serverAds.DeleteAll()
 		}()
-		ads := ListServerAds([]common.ServerType{common.OriginType, common.CacheType})
+		ads := listServerAds([]common.ServerType{common.OriginType, common.CacheType})
 		assert.Equal(t, 0, len(ads))
 	})
 
@@ -140,14 +140,14 @@ func TestListServerAds(t *testing.T) {
 		}()
 		serverAds.Set(mockOriginServerAd, []common.NamespaceAdV2{}, ttlcache.DefaultTTL)
 		serverAds.Set(mockCacheServerAd, []common.NamespaceAdV2{}, ttlcache.DefaultTTL)
-		adsAll := ListServerAds([]common.ServerType{common.OriginType, common.CacheType})
+		adsAll := listServerAds([]common.ServerType{common.OriginType, common.CacheType})
 		assert.Equal(t, 2, len(adsAll))
 
-		adsOrigin := ListServerAds([]common.ServerType{common.OriginType})
+		adsOrigin := listServerAds([]common.ServerType{common.OriginType})
 		require.Equal(t, 1, len(adsOrigin))
 		assert.True(t, adsOrigin[0] == mockOriginServerAd)
 
-		adsCache := ListServerAds([]common.ServerType{common.CacheType})
+		adsCache := listServerAds([]common.ServerType{common.CacheType})
 		require.Equal(t, 1, len(adsCache))
 		assert.True(t, adsCache[0] == mockCacheServerAd)
 	})

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -706,11 +706,18 @@ func getPrefixByPath(ctx *gin.Context) {
 	pathParam := ctx.Param("path")
 	if pathParam == "" {
 		ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Bad request. Path is empty"})
+		return
 	}
 	namespaceKeysMutex.Lock()
 	defer namespaceKeysMutex.Unlock()
 
 	originNs, _, _ := getAdsForPath(pathParam)
+
+	// If originNs.Path is an empty value, then the namespace is not found
+	if originNs.Path == "" {
+		ctx.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "Namespace prefix not found for " + pathParam})
+		return
+	}
 
 	res := common.GetPrefixByPathRes{Prefix: originNs.Path}
 	ctx.JSON(http.StatusOK, res)

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -704,8 +704,8 @@ func listNamespacesV2(ctx *gin.Context) {
 
 func getPrefixByPath(ctx *gin.Context) {
 	pathParam := ctx.Param("path")
-	if pathParam == "" {
-		ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Bad request. Path is empty"})
+	if pathParam == "" || pathParam == "/" {
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Bad request. Path is empty or '/' "})
 		return
 	}
 	namespaceKeysMutex.Lock()

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -394,7 +394,7 @@ func checkHostnameRedirects(c *gin.Context, incomingHost string) {
 
 // Middleware sends GET /foo/bar to the RedirectToCache function, as if the
 // original request had been made to /api/v1.0/director/object/foo/bar
-func shortcutMiddleware(defaultResponse string) gin.HandlerFunc {
+func ShortcutMiddleware(defaultResponse string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// If this is a request for getting public key, don't modify the path
 		// If this is a request to the Prometheus API, don't modify the path
@@ -723,8 +723,8 @@ func getPrefixByPath(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, res)
 }
 
-func RegisterDirector(ctx context.Context, router *gin.RouterGroup, defaultResponse string) {
-	directorAPIV1 := router.Group("/api/v1.0/director", shortcutMiddleware(defaultResponse))
+func RegisterDirector(ctx context.Context, router *gin.RouterGroup) {
+	directorAPIV1 := router.Group("/api/v1.0/director")
 	{
 		// Establish the routes used for cache/origin redirection
 		directorAPIV1.GET("/object/*any", redirectToCache)

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -200,7 +200,7 @@ func redirectToCache(ginCtx *gin.Context) {
 
 	authzBearerEscaped := getAuthzEscaped(ginCtx.Request)
 
-	namespaceAd, originAds, cacheAds := GetAdsForPath(reqPath)
+	namespaceAd, originAds, cacheAds := getAdsForPath(reqPath)
 	// if GetAdsForPath doesn't find any ads because the prefix doesn't exist, we should
 	// report the lack of path first -- this is most important for the user because it tells them
 	// they're trying to get an object that simply doesn't exist
@@ -221,7 +221,7 @@ func redirectToCache(ginCtx *gin.Context) {
 			return
 		}
 	} else {
-		cacheAds, err = SortServers(ipAddr, cacheAds)
+		cacheAds, err = sortServers(ipAddr, cacheAds)
 		if err != nil {
 			ginCtx.String(http.StatusInternalServerError, "Failed to determine server ordering")
 			return
@@ -307,7 +307,7 @@ func redirectToOrigin(ginCtx *gin.Context) {
 
 	authzBearerEscaped := getAuthzEscaped(ginCtx.Request)
 
-	namespaceAd, originAds, _ := GetAdsForPath(reqPath)
+	namespaceAd, originAds, _ := getAdsForPath(reqPath)
 	// if GetAdsForPath doesn't find any ads because the prefix doesn't exist, we should
 	// report the lack of path first -- this is most important for the user because it tells them
 	// they're trying to get an object that simply doesn't exist
@@ -321,7 +321,7 @@ func redirectToOrigin(ginCtx *gin.Context) {
 		return
 	}
 
-	originAds, err = SortServers(ipAddr, originAds)
+	originAds, err = sortServers(ipAddr, originAds)
 	if err != nil {
 		ginCtx.String(http.StatusInternalServerError, "Failed to determine origin ordering")
 		return
@@ -553,7 +553,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType common.S
 		EnableFallbackRead: adV2.Caps.FallBackRead,
 	}
 
-	RecordAd(sAd, &adV2.Namespaces)
+	recordAd(sAd, &adV2.Namespaces)
 
 	// Start director periodic test of origin's health status if origin AD
 	// has WebURL field AND it's not already been registered
@@ -690,7 +690,7 @@ func registerCache(ctx context.Context, gctx *gin.Context) {
 }
 
 func listNamespacesV1(ctx *gin.Context) {
-	namespaceAdsV2 := ListNamespacesFromOrigins()
+	namespaceAdsV2 := listNamespacesFromOrigins()
 
 	namespaceAdsV1 := convertNamespaceAdsV2ToV1(namespaceAdsV2)
 
@@ -698,7 +698,7 @@ func listNamespacesV1(ctx *gin.Context) {
 }
 
 func listNamespacesV2(ctx *gin.Context) {
-	namespacesAdsV2 := ListNamespacesFromOrigins()
+	namespacesAdsV2 := listNamespacesFromOrigins()
 	ctx.JSON(http.StatusOK, namespacesAdsV2)
 }
 
@@ -710,7 +710,7 @@ func getPrefixByPath(ctx *gin.Context) {
 	namespaceKeysMutex.Lock()
 	defer namespaceKeysMutex.Unlock()
 
-	originNs, _, _ := GetAdsForPath(pathParam)
+	originNs, _, _ := getAdsForPath(pathParam)
 
 	res := common.GetPrefixByPathRes{Prefix: originNs.Path}
 	ctx.JSON(http.StatusOK, res)

--- a/director/redirect_test.go
+++ b/director/redirect_test.go
@@ -152,7 +152,7 @@ func TestDirectorRegistration(t *testing.T) {
 	}
 
 	setupRequest := func(c *gin.Context, r *gin.Engine, bodyByt []byte, token string) {
-		r.POST("/", func(gctx *gin.Context) { RegisterOrigin(ctx, gctx) })
+		r.POST("/", func(gctx *gin.Context) { registerOrigin(ctx, gctx) })
 		c.Request, _ = http.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyByt))
 		c.Request.Header.Set("Authorization", "Bearer "+token)
 		c.Request.Header.Set("Content-Type", "application/json")
@@ -163,7 +163,7 @@ func TestDirectorRegistration(t *testing.T) {
 
 	// Configure the request context and Gin router to generate a redirect
 	setupRedirect := func(c *gin.Context, r *gin.Engine, object, token string) {
-		r.GET("/api/v1.0/director/origin/*any", RedirectToOrigin)
+		r.GET("/api/v1.0/director/origin/*any", redirectToOrigin)
 		c.Request, _ = http.NewRequest(http.MethodGet, "/api/v1.0/director/origin"+object, nil)
 		c.Request.Header.Set("X-Real-Ip", "1.1.1.1")
 		c.Request.Header.Set("Authorization", "Bearer "+token)
@@ -674,7 +674,7 @@ func TestDiscoverOriginCache(t *testing.T) {
 	}
 
 	r := gin.Default()
-	r.GET("/test", DiscoverOriginCache)
+	r.GET("/test", discoverOriginCache)
 
 	t.Run("no-token-should-give-401", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "/test", nil)
@@ -867,26 +867,26 @@ func TestRedirects(t *testing.T) {
 		c.Request = req
 
 		// test both APIs when in cache mode
-		ShortcutMiddleware("cache")(c)
+		shortcutMiddleware("cache")(c)
 		expectedPath := "/api/v1.0/director/origin/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
 		req = httptest.NewRequest("GET", "/api/v1.0/director/object/foo/bar", nil)
 		c.Request = req
-		ShortcutMiddleware("cache")(c)
+		shortcutMiddleware("cache")(c)
 		expectedPath = "/api/v1.0/director/object/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
 		// test both APIs when in origin mode
 		req = httptest.NewRequest("GET", "/api/v1.0/director/origin/foo/bar", nil)
 		c.Request = req
-		ShortcutMiddleware("origin")(c)
+		shortcutMiddleware("origin")(c)
 		expectedPath = "/api/v1.0/director/origin/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
 		req = httptest.NewRequest("GET", "/api/v1.0/director/object/foo/bar", nil)
 		c.Request = req
-		ShortcutMiddleware("origin")(c)
+		shortcutMiddleware("origin")(c)
 		expectedPath = "/api/v1.0/director/object/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
@@ -894,21 +894,21 @@ func TestRedirects(t *testing.T) {
 		// test that we get an origin at the base path when in origin mode
 		req = httptest.NewRequest("GET", "/foo/bar", nil)
 		c.Request = req
-		ShortcutMiddleware("origin")(c)
+		shortcutMiddleware("origin")(c)
 		expectedPath = "/api/v1.0/director/origin/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
 		// test that we get a cache at the base path when in cache mode
 		req = httptest.NewRequest("GET", "/api/v1.0/director/object/foo/bar", nil)
 		c.Request = req
-		ShortcutMiddleware("cache")(c)
+		shortcutMiddleware("cache")(c)
 		expectedPath = "/api/v1.0/director/object/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
 		// test a PUT request always goes to the origin endpoint
 		req = httptest.NewRequest("PUT", "/foo/bar", nil)
 		c.Request = req
-		ShortcutMiddleware("cache")(c)
+		shortcutMiddleware("cache")(c)
 		expectedPath = "/api/v1.0/director/origin/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
@@ -922,7 +922,7 @@ func TestRedirects(t *testing.T) {
 		req = httptest.NewRequest("GET", "/foo/bar", nil)
 		c.Request = req
 		c.Request.Header.Set("Host", "origin-hostname.com")
-		ShortcutMiddleware("cache")(c)
+		shortcutMiddleware("cache")(c)
 		expectedPath = "/api/v1.0/director/origin/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
@@ -930,7 +930,7 @@ func TestRedirects(t *testing.T) {
 		req = httptest.NewRequest("GET", "/foo/bar", nil)
 		c.Request = req
 		c.Request.Header.Set("X-Forwarded-Host", "origin-hostname.com")
-		ShortcutMiddleware("cache")(c)
+		shortcutMiddleware("cache")(c)
 		expectedPath = "/api/v1.0/director/origin/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 

--- a/director/redirect_test.go
+++ b/director/redirect_test.go
@@ -867,26 +867,26 @@ func TestRedirects(t *testing.T) {
 		c.Request = req
 
 		// test both APIs when in cache mode
-		shortcutMiddleware("cache")(c)
+		ShortcutMiddleware("cache")(c)
 		expectedPath := "/api/v1.0/director/origin/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
 		req = httptest.NewRequest("GET", "/api/v1.0/director/object/foo/bar", nil)
 		c.Request = req
-		shortcutMiddleware("cache")(c)
+		ShortcutMiddleware("cache")(c)
 		expectedPath = "/api/v1.0/director/object/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
 		// test both APIs when in origin mode
 		req = httptest.NewRequest("GET", "/api/v1.0/director/origin/foo/bar", nil)
 		c.Request = req
-		shortcutMiddleware("origin")(c)
+		ShortcutMiddleware("origin")(c)
 		expectedPath = "/api/v1.0/director/origin/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
 		req = httptest.NewRequest("GET", "/api/v1.0/director/object/foo/bar", nil)
 		c.Request = req
-		shortcutMiddleware("origin")(c)
+		ShortcutMiddleware("origin")(c)
 		expectedPath = "/api/v1.0/director/object/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
@@ -894,21 +894,21 @@ func TestRedirects(t *testing.T) {
 		// test that we get an origin at the base path when in origin mode
 		req = httptest.NewRequest("GET", "/foo/bar", nil)
 		c.Request = req
-		shortcutMiddleware("origin")(c)
+		ShortcutMiddleware("origin")(c)
 		expectedPath = "/api/v1.0/director/origin/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
 		// test that we get a cache at the base path when in cache mode
 		req = httptest.NewRequest("GET", "/api/v1.0/director/object/foo/bar", nil)
 		c.Request = req
-		shortcutMiddleware("cache")(c)
+		ShortcutMiddleware("cache")(c)
 		expectedPath = "/api/v1.0/director/object/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
 		// test a PUT request always goes to the origin endpoint
 		req = httptest.NewRequest("PUT", "/foo/bar", nil)
 		c.Request = req
-		shortcutMiddleware("cache")(c)
+		ShortcutMiddleware("cache")(c)
 		expectedPath = "/api/v1.0/director/origin/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
@@ -922,7 +922,7 @@ func TestRedirects(t *testing.T) {
 		req = httptest.NewRequest("GET", "/foo/bar", nil)
 		c.Request = req
 		c.Request.Header.Set("Host", "origin-hostname.com")
-		shortcutMiddleware("cache")(c)
+		ShortcutMiddleware("cache")(c)
 		expectedPath = "/api/v1.0/director/origin/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
@@ -930,7 +930,7 @@ func TestRedirects(t *testing.T) {
 		req = httptest.NewRequest("GET", "/foo/bar", nil)
 		c.Request = req
 		c.Request.Header.Set("X-Forwarded-Host", "origin-hostname.com")
-		shortcutMiddleware("cache")(c)
+		ShortcutMiddleware("cache")(c)
 		expectedPath = "/api/v1.0/director/origin/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 

--- a/director/redirect_test.go
+++ b/director/redirect_test.go
@@ -231,7 +231,7 @@ func TestDirectorRegistration(t *testing.T) {
 		// Check to see that the code exits with status code 200 after given it a good token
 		assert.Equal(t, 200, w.Result().StatusCode, "Expected status code of 200")
 
-		namaspaceADs := ListNamespacesFromOrigins()
+		namaspaceADs := listNamespacesFromOrigins()
 		// If the origin was successfully registed at director, we should be able to find it in director's originAds
 		assert.True(t, NamespaceAdContainsPath(namaspaceADs, "/foo/bar"), "Coudln't find namespace in the director cache.")
 		teardown()
@@ -269,7 +269,7 @@ func TestDirectorRegistration(t *testing.T) {
 		// Check to see that the code exits with status code 200 after given it a good token
 		assert.Equal(t, 200, w.Result().StatusCode, "Expected status code of 200")
 
-		namaspaceADs := ListNamespacesFromOrigins()
+		namaspaceADs := listNamespacesFromOrigins()
 		// If the origin was successfully registed at director, we should be able to find it in director's originAds
 		assert.True(t, NamespaceAdContainsPath(namaspaceADs, "/foo/bar"), "Coudln't find namespace in the director cache.")
 		teardown()
@@ -303,7 +303,7 @@ func TestDirectorRegistration(t *testing.T) {
 		body, _ := io.ReadAll(w.Result().Body)
 		assert.Equal(t, `{"error":"Authorization token verification failed"}`, string(body), "Failure wasn't because token verification failed")
 
-		namaspaceADs := ListNamespacesFromOrigins()
+		namaspaceADs := listNamespacesFromOrigins()
 		assert.False(t, NamespaceAdContainsPath(namaspaceADs, "/foo/bar"), "Found namespace in the director cache even if the token validation failed.")
 		teardown()
 	})
@@ -338,7 +338,7 @@ func TestDirectorRegistration(t *testing.T) {
 		body, _ := io.ReadAll(w.Result().Body)
 		assert.Equal(t, `{"error":"Authorization token verification failed"}`, string(body), "Failure wasn't because token verification failed")
 
-		namaspaceADs := ListNamespacesFromOrigins()
+		namaspaceADs := listNamespacesFromOrigins()
 		assert.False(t, NamespaceAdContainsPath(namaspaceADs, "/foo/bar"), "Found namespace in the director cache even if the token validation failed.")
 		teardown()
 	})

--- a/director/stat.go
+++ b/director/stat.go
@@ -161,7 +161,7 @@ func (stat *ObjectStat) sendHeadReqToOrigin(objectName string, dataUrl url.URL, 
 // Implementation of querying origins for their availability of an object.
 // It blocks until max successful requests has been received, all potential origins responded (or timeout), or cancelContext was closed
 func (stat *ObjectStat) queryOriginsForObject(objectName string, cancelContext context.Context, minimum, maximum int) ([]*objectMetadata, string, error) {
-	_, originAds, _ := GetAdsForPath(objectName)
+	_, originAds, _ := getAdsForPath(objectName)
 	minReq := param.Director_MinStatResponse.GetInt()
 	maxReq := param.Director_MaxStatResponse.GetInt()
 	if minimum > 0 {

--- a/launchers/director_serve.go
+++ b/launchers/director_serve.go
@@ -61,7 +61,8 @@ func DirectorServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group
 	rootGroup := engine.Group("/")
 	director.RegisterDirectorAuth(rootGroup)
 	director.RegisterDirectorWebAPI(rootGroup)
-	director.RegisterDirector(ctx, rootGroup, defaultResponse)
+	engine.Use(director.ShortcutMiddleware(defaultResponse))
+	director.RegisterDirector(ctx, rootGroup)
 
 	return nil
 }

--- a/launchers/director_serve.go
+++ b/launchers/director_serve.go
@@ -61,8 +61,7 @@ func DirectorServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group
 	rootGroup := engine.Group("/")
 	director.RegisterDirectorAuth(rootGroup)
 	director.RegisterDirectorWebAPI(rootGroup)
-	engine.Use(director.ShortcutMiddleware(defaultResponse))
-	director.RegisterDirector(ctx, rootGroup)
+	director.RegisterDirector(ctx, rootGroup, defaultResponse)
 
 	return nil
 }

--- a/web_ui/frontend/app/api/docs/pelican-swagger.yaml
+++ b/web_ui/frontend/app/api/docs/pelican-swagger.yaml
@@ -305,11 +305,13 @@ tags:
   - name: common
     description: Common APIs for all servers
   - name: metrics
-    description: APIs for various server metrics
+    description: APIs for server metrics
   - name: registry_ui
-    description: APIs for Registry server Web UI
+    description: APIs for the Registry server Web UI
   - name: director_ui
-    description: APIs for Director server Web UI
+    description: APIs for the Director server Web UI
+  - name: director
+    description: Non-UI facing APIs for the Director server
 paths:
   /health:
     get:
@@ -1253,6 +1255,38 @@ paths:
             $ref: "#/definitions/ErrorModel"
         "500":
           description: Server error when performing the query
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModel"
+  /director/namespaces/prefix/{path}:
+    get:
+      summary: "Get the longest matched namespace prefix of a path"
+      description: ""
+      parameters:
+        - name: path
+          in: path
+          description: "The path to an object or directory to get the namespace prefix for"
+          required: true
+          type: string
+      tags:
+        - "director"
+      responses:
+        "200":
+          description: "OK"
+          schema:
+            type: object
+            properties:
+              prefix:
+                type: string
+                example: "/test/namespace"
+                description: The longest matched namespace prefix
+        "400":
+          description: "Bad request. Path parameter is missing"
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModel"
+        "404":
+          description: "Namespace prefix not found for the path"
           schema:
             type: object
             $ref: "#/definitions/ErrorModel"


### PR DESCRIPTION
Closes #847 

The first commit and third in this PR tackles on the massive public functions inside of the director and change them to private. The most related changes to close #847 is the second commit