### PR TITLE
Add support for throttling plugin for xrootd cache

### DIFF
--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -625,6 +625,15 @@ type: bool
 default: false
 components: ["cache"]
 ---
+name: Cache.Concurrency
+description: >-
+  This value represents the maximum number of connections to a cache for Xrootd throttling.
+  When this value is set, it enables the xrootd throttling plugin and will set the maximum
+  number of connections to this value.
+type: int
+default: none
+components: ["cache"]
+---
 ############################
 #  Director-level configs  #
 ############################

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -169,6 +169,7 @@ var (
 )
 
 var (
+	Cache_Concurrency = IntParam{"Cache.Concurrency"}
 	Cache_Port = IntParam{"Cache.Port"}
 	Client_MinimumDownloadSpeed = IntParam{"Client.MinimumDownloadSpeed"}
 	Client_SlowTransferRampupTime = IntParam{"Client.SlowTransferRampupTime"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -8,6 +8,7 @@ import (
 
 type config struct {
 	Cache struct {
+		Concurrency int
 		DataLocation string
 		EnableVoms bool
 		ExportLocation string
@@ -224,6 +225,7 @@ type config struct {
 
 type configWithType struct {
 	Cache struct {
+		Concurrency struct { Type string; Value int }
 		DataLocation struct { Type string; Value string }
 		EnableVoms struct { Type string; Value bool }
 		ExportLocation struct { Type string; Value string }

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -56,6 +56,10 @@ pfc.prefetch 20
 pfc.writequeue 16 4
 pfc.ram 4g
 pfc.diskusage 0.90 0.95 purgeinterval 300s
+{{if .Cache.Concurrency}}
+xrootd.fslib throttle default
+throttle.throttle concurrency {{.Cache.Concurrency}}
+{{end}}
 pss.origin {{.Cache.PSSOrigin}}
 # FIXME: the oss.space meta / data only works if the meta and data directories are different physical devices.
 # Otherwise, no data space is setup and the cache simply doesn't write out data.

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -102,6 +102,7 @@ type (
 		ExportLocation string
 		DataLocation   string
 		PSSOrigin      string
+		Concurrency    int
 	}
 
 	XrootdOptions struct {


### PR DESCRIPTION
Creates a config knob that if set, enables the throttling plugin for xrootd. Also adds a simple unit test to ensure it is set in config. Settled on the name Cache.Concurrency but that can be easily changed.