### PR TITLE
Fix duplicated server advertisement at the director

### DIFF
--- a/common/director.go
+++ b/common/director.go
@@ -68,9 +68,9 @@ type (
 	ServerAd struct {
 		Name               string
 		AuthURL            url.URL
-		BrokerURL          *url.URL // The URL of the broker service to use for this host.
-		URL                url.URL  // This is server's XRootD URL for file transfer
-		WebURL             url.URL  // This is server's Web interface and API
+		BrokerURL          url.URL // The URL of the broker service to use for this host.
+		URL                url.URL // This is server's XRootD URL for file transfer
+		WebURL             url.URL // This is server's Web interface and API
 		Type               ServerType
 		Latitude           float64
 		Longitude          float64

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -349,7 +349,7 @@ func RedirectToOrigin(ginCtx *gin.Context) {
 		for idx, ad := range originAds {
 			if ad.EnableWrite {
 				redirectURL = getRedirectURL(reqPath, originAds[idx], !namespaceAd.PublicRead)
-				if brokerUrl := originAds[idx].BrokerURL; brokerUrl != nil {
+				if brokerUrl := originAds[idx].BrokerURL; brokerUrl.String() != "" {
 					ginCtx.Header("X-Pelican-Broker", brokerUrl.String())
 				}
 				ginCtx.Redirect(http.StatusTemporaryRedirect, getFinalRedirectURL(redirectURL, authzBearerEscaped))
@@ -360,7 +360,7 @@ func RedirectToOrigin(ginCtx *gin.Context) {
 		return
 	} else { // Otherwise, we are doing a GET
 		redirectURL := getRedirectURL(reqPath, originAds[0], !namespaceAd.PublicRead)
-		if brokerUrl := originAds[0].BrokerURL; brokerUrl != nil {
+		if brokerUrl := originAds[0].BrokerURL; brokerUrl.String() != "" {
 			ginCtx.Header("X-Pelican-Broker", brokerUrl.String())
 		}
 
@@ -553,7 +553,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType common.S
 		AuthURL:            *ad_url,
 		URL:                *ad_url,
 		WebURL:             *adWebUrl,
-		BrokerURL:          brokerUrl,
+		BrokerURL:          *brokerUrl,
 		Type:               sType,
 		EnableWrite:        adV2.Caps.Write,
 		EnableFallbackRead: adV2.Caps.FallBackRead,


### PR DESCRIPTION
Fixes #851 

The cause of the issue is that in #705, when we added `brokerUrl`, we used `*url.URL` instead of `url.URL`. When broker service is turned off, `brokerUrl` is empty. When the director reads an empty url string, parses it as an empty url instance, and _pass the pointer to the empty url instance_ to the `serverAd`, the `serverAd` records the **address** of the empty `url.URL` instance, instead of just an empty url.

This causes bug because in the following registration from the same server, that address of empty url will change, resulting in a different `serverAd` than before, and all the map structure we have took it as a new key.