### PR TITLE
Added error when discovery-url contains a path

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -397,7 +397,10 @@ func DiscoverFederation() error {
 		return errors.Wrapf(err, "Invalid federation value %s:", federationStr)
 	}
 	if federationUrl.Path != "" {
-		return errors.New("Invalid federation discovery url is set. No path allowed for federation discovery url")
+		// If the host is nothing, then the url is fine, but if we have a host and a path then there is a problem
+		if federationUrl.Host != "" {
+			return errors.New("Invalid federation discovery url is set. No path allowed for federation discovery url. Provided url: " + federationStr)
+		}
 	}
 	federationUrl.Scheme = "https"
 	if len(federationUrl.Path) > 0 && len(federationUrl.Host) == 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -396,11 +396,9 @@ func DiscoverFederation() error {
 	if err != nil {
 		return errors.Wrapf(err, "Invalid federation value %s:", federationStr)
 	}
-	if federationUrl.Path != "" {
+	if federationUrl.Path != "" && federationUrl.Host != "" {
 		// If the host is nothing, then the url is fine, but if we have a host and a path then there is a problem
-		if federationUrl.Host != "" {
-			return errors.New("Invalid federation discovery url is set. No path allowed for federation discovery url. Provided url: " + federationStr)
-		}
+		return errors.New("Invalid federation discovery url is set. No path allowed for federation discovery url. Provided url: " + federationStr)
 	}
 	federationUrl.Scheme = "https"
 	if len(federationUrl.Path) > 0 && len(federationUrl.Host) == 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -396,6 +396,9 @@ func DiscoverFederation() error {
 	if err != nil {
 		return errors.Wrapf(err, "Invalid federation value %s:", federationStr)
 	}
+	if federationUrl.Path != "" {
+		return errors.New("Invalid federation discovery url is set. No path allowed for federation discovery url")
+	}
 	federationUrl.Scheme = "https"
 	if len(federationUrl.Path) > 0 && len(federationUrl.Host) == 0 {
 		federationUrl.Host = federationUrl.Path

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -291,6 +291,8 @@ func TestDiscoverFederation(t *testing.T) {
 		viper.Set("Federation.DiscoveryUrl", server.URL+"/this/is/some/path")
 		err := DiscoverFederation()
 		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Invalid federation discovery url is set. No path allowed for federation discovery url. Provided url: ",
+			"Error returned does not contain the correct error")
 		viper.Reset()
 	})
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,6 +19,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -259,5 +260,50 @@ func TestEnabledServers(t *testing.T) {
 		assert.True(t, IsServerEnabled(CacheType))
 		assert.False(t, IsServerEnabled(DirectorType))
 		assert.False(t, IsServerEnabled(RegistryType))
+	})
+}
+
+func TestDiscoverFederation(t *testing.T) {
+	viper.Reset()
+	// Server to be a "mock" federation
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// make our response:
+		response := FederationDiscovery{
+			DirectorEndpoint:              "director",
+			NamespaceRegistrationEndpoint: "registry",
+			JwksUri:                       "jwks",
+			BrokerEndpoint:                "broker",
+		}
+
+		responseJSON, err := json.Marshal(response)
+		if err != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write(responseJSON)
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+	t.Run("testInvalidDiscoveryUrlWithPath", func(t *testing.T) {
+		viper.Set("tlsskipverify", true)
+		viper.Set("Federation.DiscoveryUrl", server.URL+"/this/is/some/path")
+		err := DiscoverFederation()
+		assert.Error(t, err)
+		viper.Reset()
+	})
+
+	t.Run("testValidDiscoveryUrl", func(t *testing.T) {
+		viper.Set("tlsskipverify", true)
+		viper.Set("Federation.DiscoveryUrl", server.URL)
+		err := DiscoverFederation()
+		assert.NoError(t, err)
+		// Assert that the metadata matches expectations
+		assert.Equal(t, "director", param.Federation_DirectorUrl.GetString(), "Unexpected DirectorEndpoint")
+		assert.Equal(t, "registry", param.Federation_RegistryUrl.GetString(), "Unexpected NamespaceRegistrationEndpoint")
+		assert.Equal(t, "jwks", param.Federation_JwkUrl.GetString(), "Unexpected JwksUri")
+		assert.Equal(t, "broker", param.Federation_BrokerUrl.GetString(), "Unexpected BrokerEndpoint")
+		viper.Reset()
 	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -306,4 +306,17 @@ func TestDiscoverFederation(t *testing.T) {
 		assert.Equal(t, "broker", param.Federation_BrokerUrl.GetString(), "Unexpected BrokerEndpoint")
 		viper.Reset()
 	})
+
+	t.Run("testOsgHtcUrl", func(t *testing.T) {
+		viper.Set("tlsskipverify", true)
+		viper.Set("Federation.DiscoveryUrl", "osg-htc.org")
+		err := DiscoverFederation()
+		assert.NoError(t, err)
+		// Assert that the metadata matches expectations
+		assert.Equal(t, "https://osdf-director.osg-htc.org", param.Federation_DirectorUrl.GetString(), "Unexpected DirectorEndpoint")
+		assert.Equal(t, "https://osdf-registry.osg-htc.org", param.Federation_RegistryUrl.GetString(), "Unexpected NamespaceRegistrationEndpoint")
+		assert.Equal(t, "https://osg-htc.org/osdf/public_signing_key.jwks", param.Federation_JwkUrl.GetString(), "Unexpected JwksUri")
+		assert.Equal(t, "", param.Federation_BrokerUrl.GetString(), "Unexpected BrokerEndpoint")
+		viper.Reset()
+	})
 }

--- a/docs/pages/client-usage.mdx
+++ b/docs/pages/client-usage.mdx
@@ -23,6 +23,8 @@ which should output a path to the executable. If there is no output to this comm
 **Federations:**
 Objects in Pelican belong to *federations*, which are aggregations of data that are exposed to other individuals in the federation. Each Pelican federation constitutes its own global namespace of objects and each object within a federation has its own path, much like files on a computer. Fetching any object from a federation requires at minimum two pieces of information; a URL indicating the object's federation and the path to the object within that federation (there is the potential that some objects require access tokens as well, but more on that later). For example, the Open Science Data Federation's (OSDF) central URL is https://osg-htc.org and an example object from the federation can be found at
 
+**Note:** When you set a federation discovery url within a `pelican://` url, within configuration files, or with the `-f` flag, do not expect the client to work if the disovery url contains a path (e.g. `osg-htc.org/PathToMyFederation`). The client will assume that the path provided is the namespace prefix for the object which will end in failure.
+
 ```console
 /ospool/uc-shared/public/OSG-Staff/validation/test.txt
 ```

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -225,6 +225,7 @@ components: ["origin"]
 name: Federation.DiscoveryUrl
 description: >-
   A URL pointing to the federation's metadata discovery host.
+  NOTE: this does not work if the url contains a path!
 type: url
 default: none
 components: ["*"]


### PR DESCRIPTION
When a discovery-url contains a path (when set in config or with `-f`), we will throw an error when we call DiscoverFederation on that url. If it is contained within a `pelican://` url however, we cannot really catch that specific error since we will assume any paths added to the discovery-url to be the namespace-prefix and so on. Therefore, I added a few notes to the documentation alerting that this will fail.

Note: I realize the client-usage docs are out of date but I added this for when we refresh the docs