### PR TITLE
Add depth attribute to link header in redirect response

### DIFF
--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -494,6 +494,7 @@ func TestFullUpload(t *testing.T) {
 	viper.Set("Registry.RequireCacheApproval", false)
 	viper.Set("Logging.Origin.Scitokens", "debug")
 	viper.Set("Origin.Port", 0)
+	viper.Set("Server.WebPort", 0)
 
 	err = config.InitServer(ctx, modules)
 	require.NoError(t, err)

--- a/director/redirect.go
+++ b/director/redirect.go
@@ -136,9 +136,6 @@ func getLinkDepth(filepath, prefix string) (int, error) {
 	}
 	commonPath := strings.TrimPrefix(filepath, prefix)
 	pathDepth := len(strings.Split(commonPath, "/"))
-	if pathDepth < 0 {
-		return 0, errors.New("negative depth is not allowed")
-	}
 	return pathDepth, nil
 }
 


### PR DESCRIPTION
Closes #345 

Since currently we only return the longest-prefix-match of the namespace prefix given a file path, the `depth` attribute, if exists, will be identical for all the `Link` headers in the response. We can for sure change this if we want to offer different levels of hierarchy of namespaces for a file request 