### PR TITLE
Allow Pelican to use path-style URLs for S3 origins

### DIFF
--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -133,6 +133,7 @@ func init() {
 	originServeCmd.Flags().String("service-url", "", "Specify the S3 service-url. Only used when an origin is launched in S3 mode.")
 	originServeCmd.Flags().String("bucket-access-keyfile", "", "Specify a filepath to use for configuring the bucket's access key.")
 	originServeCmd.Flags().String("bucket-secret-keyfile", "", "Specify a filepath to use for configuring the bucket's access key.")
+	originServeCmd.Flags().String("url-style", "", "Specify the S3 url-style. Only used when an origin is launched in S3 mode, and can be either 'path' (default) or 'virtual.")
 	if err := viper.BindPFlag("Origin.S3ServiceName", originServeCmd.Flags().Lookup("service-name")); err != nil {
 		panic(err)
 	}
@@ -151,6 +152,12 @@ func init() {
 	if err := viper.BindPFlag("Origin.S3SecretKeyfile", originServeCmd.Flags().Lookup("bucket-secret-keyfile")); err != nil {
 		panic(err)
 	}
+	if err := viper.BindPFlag("Origin.S3UrlStyle", originServeCmd.Flags().Lookup("url-style")); err != nil {
+		panic(err)
+	}
+	if viper.IsSet("Origin.S3UrlStyle") && viper.GetString("Origin.S3UrlStyle") != "path" && viper.GetString("Origin.S3UrlStyle") != "virtual" {
+		panic("The --url-style flag must be either 'path' or 'virtual'")
+	}
 
 	// Would be nice to make these mutually exclusive to mode=posix instead of to --volume, but cobra
 	// doesn't seem to have something that can make the value of a flag exclusive to other flags
@@ -161,6 +168,7 @@ func init() {
 	originServeCmd.MarkFlagsMutuallyExclusive("volume", "service-url")
 	originServeCmd.MarkFlagsMutuallyExclusive("volume", "bucket-access-keyfile")
 	originServeCmd.MarkFlagsMutuallyExclusive("volume", "bucket-secret-keyfile")
+	originServeCmd.MarkFlagsMutuallyExclusive("volume", "url-style")
 	// We don't require the bucket access and secret keyfiles as they're not needed for unauthenticated buckets
 	originServeCmd.MarkFlagsRequiredTogether("service-name", "region", "service-url")
 	originServeCmd.MarkFlagsRequiredTogether("bucket-access-keyfile", "bucket-secret-keyfile")

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -57,6 +57,7 @@ Origin:
   SelfTest: true
   Port: 8443
   SelfTestInterval: 15s
+  S3UrlStyle: "path"
 Registry:
   InstitutionsUrlReloadMinutes: 15m
   RequireCacheApproval: false

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -588,6 +588,14 @@ type: filename
 default: none
 components: ["origin"]
 ---
+name: Origin.S3UrlStyle
+description: >-
+  The style of S3 urls used by the service URL host. This can be either "path" if objects are fetched at <service-url>/<bucket>/<object>
+  or "virtual" if objects are fetched at <bucket>.<service-url>/<object>
+type: string
+default: path
+components: ["origin"]
+---
 ############################
 #   Cache-level configs    #
 ############################

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -126,6 +126,7 @@ var (
 	Origin_S3SecretKeyfile = StringParam{"Origin.S3SecretKeyfile"}
 	Origin_S3ServiceName = StringParam{"Origin.S3ServiceName"}
 	Origin_S3ServiceUrl = StringParam{"Origin.S3ServiceUrl"}
+	Origin_S3UrlStyle = StringParam{"Origin.S3UrlStyle"}
 	Origin_ScitokensDefaultUser = StringParam{"Origin.ScitokensDefaultUser"}
 	Origin_ScitokensNameMapFile = StringParam{"Origin.ScitokensNameMapFile"}
 	Origin_ScitokensUsernameClaim = StringParam{"Origin.ScitokensUsernameClaim"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -145,6 +145,7 @@ type Config struct {
 		S3SecretKeyfile string
 		S3ServiceName string
 		S3ServiceUrl string
+		S3UrlStyle string
 		ScitokensDefaultUser string
 		ScitokensMapSubject bool
 		ScitokensNameMapFile string
@@ -365,6 +366,7 @@ type configWithType struct {
 		S3SecretKeyfile struct { Type string; Value string }
 		S3ServiceName struct { Type string; Value string }
 		S3ServiceUrl struct { Type string; Value string }
+		S3UrlStyle struct { Type string; Value string }
 		ScitokensDefaultUser struct { Type string; Value string }
 		ScitokensMapSubject struct { Type string; Value bool }
 		ScitokensNameMapFile struct { Type string; Value string }

--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -56,6 +56,7 @@ oss.localroot {{.Xrootd.Mount}}
 ofs.osslib libXrdS3.so
 # The S3 plugin doesn't currently support async mode
 xrootd.async off
+s3.url_style {{.Origin.S3UrlStyle}}
 s3.service_name {{.Origin.S3ServiceName}}
 s3.region {{.Origin.S3Region}}
 s3.service_url {{.Origin.S3ServiceUrl}}

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -93,6 +93,7 @@ type (
 		S3ServiceUrl     string
 		S3AccessKeyfile  string
 		S3SecretKeyfile  string
+		S3UrlStyle       string
 	}
 
 	CacheConfig struct {
@@ -609,6 +610,13 @@ func ConfigXrootd(ctx context.Context, origin bool) (string, error) {
 	xrdConfig.Xrootd.LocalMonitoringPort = -1
 	if err := viper.Unmarshal(&xrdConfig); err != nil {
 		return "", err
+	}
+
+	// If the S3 URL style is configured via yaml, the CLI check in cmd/origin.go won't catch invalid values.
+	if urlStyle := xrdConfig.Origin.S3UrlStyle; urlStyle != "" {
+		if urlStyle != "path" && urlStyle != "virtual" {
+			return "", errors.Errorf("Invalid S3UrlStyle: %v. Must be either 'path' or 'virtual'", urlStyle)
+		}
 	}
 
 	// Map out xrootd logs


### PR DESCRIPTION
This adds all the plumbing we need for Pelican origins to turn the S3 url style knob.

Closes #871 