### PR TITLE
Remove use of global fed metadata within client

### DIFF
--- a/client/fed_linux_test.go
+++ b/client/fed_linux_test.go
@@ -94,6 +94,7 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 	tempFile2, err := os.CreateTemp(tempDir, "test1")
 	assert.NoError(t, err, "Error creating temp2 file")
 	innerTempFile, err := os.CreateTemp(innerTempDir, "testInner")
+	assert.NoError(t, err, "Error creating inner test file")
 	defer os.Remove(tempFile1.Name())
 	defer os.Remove(tempFile2.Name())
 	defer os.Remove(innerTempFile.Name())

--- a/client/fed_linux_test.go
+++ b/client/fed_linux_test.go
@@ -21,11 +21,9 @@
 package client_test
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -36,7 +34,6 @@ import (
 	"github.com/pelicanplatform/pelican/fed_test_utils"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_utils"
-	"github.com/pelicanplatform/pelican/test_utils"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
 	"github.com/spf13/viper"
@@ -79,25 +76,37 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 	// Make our test directories and files
 	tempDir, err := os.MkdirTemp("", "UploadDir")
 	assert.NoError(t, err)
+	innerTempDir, err := os.MkdirTemp(tempDir, "InnerUploadDir")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
 	defer os.RemoveAll(tempDir)
 	permissions := os.FileMode(0777)
 	err = os.Chmod(tempDir, permissions)
 	require.NoError(t, err)
+	err = os.Chmod(innerTempDir, permissions)
+	require.NoError(t, err)
 
 	testFileContent1 := "test file content"
 	testFileContent2 := "more test file content!"
+	innerTestFileContent := "this content is within another dir!"
 	tempFile1, err := os.CreateTemp(tempDir, "test1")
 	assert.NoError(t, err, "Error creating temp1 file")
 	tempFile2, err := os.CreateTemp(tempDir, "test1")
 	assert.NoError(t, err, "Error creating temp2 file")
+	innerTempFile, err := os.CreateTemp(innerTempDir, "testInner")
 	defer os.Remove(tempFile1.Name())
 	defer os.Remove(tempFile2.Name())
+	defer os.Remove(innerTempFile.Name())
+
 	_, err = tempFile1.WriteString(testFileContent1)
 	assert.NoError(t, err, "Error writing to temp1 file")
 	tempFile1.Close()
 	_, err = tempFile2.WriteString(testFileContent2)
 	assert.NoError(t, err, "Error writing to temp2 file")
 	tempFile2.Close()
+	_, err = innerTempFile.WriteString(innerTestFileContent)
+	assert.NoError(t, err, "Error writing to inner test file")
+	innerTempFile.Close()
 
 	t.Run("testPelicanRecursiveGetAndPutOsdfURL", func(t *testing.T) {
 		config.SetPreferredPrefix("PELICAN")
@@ -126,14 +135,15 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 			tempPath := tempDir
 			dirName := filepath.Base(tempPath)
 			uploadURL := fmt.Sprintf("pelican://%s:%s%s/%s/%s", param.Server_Hostname.GetString(), strconv.Itoa(param.Server_WebPort.GetInt()),
-				export.FederationPrefix, "osdf_osdf", dirName)
+				export.FederationPrefix, "osdf_osdf", dirName)		
 
 			// Upload the file with PUT
 			transferDetailsUpload, err := client.DoPut(fed.Ctx, tempDir, uploadURL, true, client.WithTokenLocation(tempToken.Name()))
 			assert.NoError(t, err)
-			if err == nil && len(transferDetailsUpload) == 2 {
+			if err == nil && len(transferDetailsUpload) == 3 {
 				countBytes17 := 0
 				countBytes23 := 0
+				countBytes35 := 0
 				// Verify we got the correct files back (have to do this since files upload in different orders at times)
 				for _, transfer := range transferDetailsUpload {
 					transferredBytes := transfer.TransferredBytes
@@ -144,16 +154,19 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 					case int64(23):
 						countBytes23++
 						continue
+					case int64(35):
+						countBytes35++
+						continue
 					default:
 						// We got a byte amount we are not expecting
 						t.Fatal("did not upload proper amount of bytes")
 					}
 				}
-				if countBytes17 != 1 || countBytes23 != 1 {
+				if countBytes17 != 1 || countBytes23 != 1 || countBytes35 != 1 {
 					// We would hit this case if 1 counter got hit twice for some reason
 					t.Fatal("One of the files was not uploaded correctly")
 				}
-			} else if len(transferDetailsUpload) != 2 {
+			} else if len(transferDetailsUpload) != 3 {
 				t.Fatalf("Amount of transfers results returned for upload was not correct. Transfer details returned: %d", len(transferDetailsUpload))
 			}
 
@@ -165,29 +178,34 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 				transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadURL, t.TempDir(), true, client.WithTokenLocation(tempToken.Name()))
 			}
 			assert.NoError(t, err)
-			if err == nil && len(transferDetailsUpload) == 2 {
-				countBytesUploadIdx0 := 0
-				countBytesUploadIdx1 := 0
+			if err == nil && len(transferDetailsDownload) == 3 {
+				countBytesDownloadIdx0 := 0
+				countBytesDownloadIdx1 := 0
+				countBytesDownloadIdx2 := 0
+
 				// Verify we got the correct files back (have to do this since files upload in different orders at times)
 				// In this case, we want to match them to the sizes of the uploaded files
-				for _, transfer := range transferDetailsUpload {
+				for _, transfer := range transferDetailsDownload {
 					transferredBytes := transfer.TransferredBytes
 					switch transferredBytes {
-					case transferDetailsUpload[0].TransferredBytes:
-						countBytesUploadIdx0++
+					case transferDetailsDownload[0].TransferredBytes:
+						countBytesDownloadIdx0++
 						continue
-					case transferDetailsUpload[1].TransferredBytes:
-						countBytesUploadIdx1++
+					case transferDetailsDownload[1].TransferredBytes:
+						countBytesDownloadIdx1++
+						continue
+					case transferDetailsDownload[2].TransferredBytes:
+						countBytesDownloadIdx2++
 						continue
 					default:
 						// We got a byte amount we are not expecting
 						t.Fatal("did not download proper amount of bytes")
 					}
 				}
-				if countBytesUploadIdx0 != 1 || countBytesUploadIdx1 != 1 {
+				if countBytesDownloadIdx0 != 1 || countBytesDownloadIdx1 != 1 || countBytesDownloadIdx2 != 1 {
 					// We would hit this case if 1 counter got hit twice for some reason
 					t.Fatal("One of the files was not downloaded correctly")
-				} else if len(transferDetailsDownload) != 2 {
+				} else if len(transferDetailsDownload) != 3 {
 					t.Fatalf("Amount of transfers results returned for download was not correct. Transfer details returned: %d", len(transferDetailsDownload))
 				}
 			}
@@ -200,10 +218,7 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 			// Set path for object to upload/download
 			tempPath := tempDir
 			dirName := filepath.Base(tempPath)
-			// Note: minimally fixing this test as it is soon to be replaced
-			uploadURL := fmt.Sprintf("osdf:///%s/%s/%s",
-				export.FederationPrefix, "osdf_osdf", dirName)
-
+			uploadURL := fmt.Sprintf("osdf:///%s/%s/%s", export.FederationPrefix, "osdf_osdf", dirName)
 			hostname := fmt.Sprintf("%v:%v", param.Server_WebHost.GetString(), param.Server_WebPort.GetInt())
 
 			// Set our metadata values in config since that is what this url scheme - prefix combo does in handle_http
@@ -216,9 +231,10 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 			// Upload the file with PUT
 			transferDetailsUpload, err := client.DoPut(fed.Ctx, tempDir, uploadURL, true, client.WithTokenLocation(tempToken.Name()))
 			assert.NoError(t, err)
-			if err == nil && len(transferDetailsUpload) == 2 {
+			if err == nil && len(transferDetailsUpload) == 3 {
 				countBytes17 := 0
 				countBytes23 := 0
+				countBytes35 := 0
 				// Verify we got the correct files back (have to do this since files upload in different orders at times)
 				for _, transfer := range transferDetailsUpload {
 					transferredBytes := transfer.TransferredBytes
@@ -229,16 +245,19 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 					case int64(23):
 						countBytes23++
 						continue
+					case int64(35):
+						countBytes35++
+						continue
 					default:
 						// We got a byte amount we are not expecting
 						t.Fatal("did not upload proper amount of bytes")
 					}
 				}
-				if countBytes17 != 1 || countBytes23 != 1 {
+				if countBytes17 != 1 || countBytes23 != 1 || countBytes35 != 1 {
 					// We would hit this case if 1 counter got hit twice for some reason
 					t.Fatal("One of the files was not uploaded correctly")
 				}
-			} else if len(transferDetailsUpload) != 2 {
+			} else if len(transferDetailsUpload) != 3 {
 				t.Fatalf("Amount of transfers results returned for upload was not correct. Transfer details returned: %d", len(transferDetailsUpload))
 			}
 
@@ -251,37 +270,36 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 				transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadURL, tmpDir, true, client.WithTokenLocation(tempToken.Name()))
 			}
 			assert.NoError(t, err)
-			if err == nil && len(transferDetailsDownload) == 2 {
-				countBytesUploadIdx0 := 0
-				countBytesUploadIdx1 := 0
+			if err == nil && len(transferDetailsDownload) == 3 {
+				countBytesDownloadIdx0 := 0
+				countBytesDownloadIdx1 := 0
+				countBytesDownloadIdx2 := 0
+	
 				// Verify we got the correct files back (have to do this since files upload in different orders at times)
 				// In this case, we want to match them to the sizes of the uploaded files
 				for _, transfer := range transferDetailsDownload {
 					transferredBytes := transfer.TransferredBytes
 					switch transferredBytes {
-					case transferDetailsUpload[0].TransferredBytes:
-						countBytesUploadIdx0++
+					case transferDetailsDownload[0].TransferredBytes:
+						countBytesDownloadIdx0++
 						continue
-					case transferDetailsUpload[1].TransferredBytes:
-						countBytesUploadIdx1++
+					case transferDetailsDownload[1].TransferredBytes:
+						countBytesDownloadIdx1++
+						continue
+					case transferDetailsDownload[2].TransferredBytes:
+						countBytesDownloadIdx2++
 						continue
 					default:
 						// We got a byte amount we are not expecting
 						t.Fatal("did not download proper amount of bytes")
 					}
 				}
-				if countBytesUploadIdx0 != 1 || countBytesUploadIdx1 != 1 {
+				if countBytesDownloadIdx0 != 1 || countBytesDownloadIdx1 != 1 || countBytesDownloadIdx2 != 1 {
 					// We would hit this case if 1 counter got hit twice for some reason
 					t.Fatal("One of the files was not downloaded correctly")
+				} else if len(transferDetailsDownload) != 3 {
+					t.Fatalf("Amount of transfers results returned for download was not correct. Transfer details returned: %d", len(transferDetailsDownload))
 				}
-				contents, err := os.ReadFile(filepath.Join(tmpDir, path.Join(dirName, path.Base(tempFile2.Name()))))
-				assert.NoError(t, err)
-				assert.Equal(t, testFileContent2, string(contents))
-				contents, err = os.ReadFile(filepath.Join(tmpDir, path.Join(dirName, path.Base(tempFile1.Name()))))
-				assert.NoError(t, err)
-				assert.Equal(t, testFileContent1, string(contents))
-			} else if err == nil && len(transferDetailsDownload) != 2 {
-				t.Fatalf("Number of transfers results returned for download was not correct. Transfer details returned: %d", len(transferDetailsDownload))
 			}
 		}
 	})
@@ -294,14 +312,13 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 			dirName := filepath.Base(tempPath)
 			uploadURL := fmt.Sprintf("pelican://%s:%s%s/%s/%s", param.Server_Hostname.GetString(), strconv.Itoa(param.Server_WebPort.GetInt()),
 				export.FederationPrefix, "osdf_osdf", dirName)
-
-
 			// Upload the file with PUT
 			transferDetailsUpload, err := client.DoPut(fed.Ctx, tempDir, uploadURL, true, client.WithTokenLocation(tempToken.Name()))
 			assert.NoError(t, err)
-			if err == nil && len(transferDetailsUpload) == 2 {
+			if err == nil && len(transferDetailsUpload) == 3 {
 				countBytes17 := 0
 				countBytes23 := 0
+				countBytes35 := 0
 				// Verify we got the correct files back (have to do this since files upload in different orders at times)
 				for _, transfer := range transferDetailsUpload {
 					transferredBytes := transfer.TransferredBytes
@@ -312,19 +329,21 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 					case int64(23):
 						countBytes23++
 						continue
+					case int64(35):
+						countBytes35++
+						continue
 					default:
 						// We got a byte amount we are not expecting
 						t.Fatal("did not upload proper amount of bytes")
 					}
 				}
-				if countBytes17 != 1 || countBytes23 != 1 {
+				if countBytes17 != 1 || countBytes23 != 1 || countBytes35 != 1 {
 					// We would hit this case if 1 counter got hit twice for some reason
 					t.Fatal("One of the files was not uploaded correctly")
 				}
-			} else if len(transferDetailsUpload) != 2 {
+			} else if len(transferDetailsUpload) != 3 {
 				t.Fatalf("Amount of transfers results returned for upload was not correct. Transfer details returned: %d", len(transferDetailsUpload))
 			}
-
 			// Download the files we just uploaded
 			var transferDetailsDownload []client.TransferResults
 			if export.Capabilities.PublicReads {
@@ -333,29 +352,34 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 				transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadURL, t.TempDir(), true, client.WithTokenLocation(tempToken.Name()))
 			}
 			assert.NoError(t, err)
-			if err == nil && len(transferDetailsUpload) == 2 {
-				countBytesUploadIdx0 := 0
-				countBytesUploadIdx1 := 0
+			if err == nil && len(transferDetailsDownload) == 3 {
+				countBytesDownloadIdx0 := 0
+				countBytesDownloadIdx1 := 0
+				countBytesDownloadIdx2 := 0
+
 				// Verify we got the correct files back (have to do this since files upload in different orders at times)
 				// In this case, we want to match them to the sizes of the uploaded files
-				for _, transfer := range transferDetailsUpload {
+				for _, transfer := range transferDetailsDownload {
 					transferredBytes := transfer.TransferredBytes
 					switch transferredBytes {
-					case transferDetailsUpload[0].TransferredBytes:
-						countBytesUploadIdx0++
+					case transferDetailsDownload[0].TransferredBytes:
+						countBytesDownloadIdx0++
 						continue
-					case transferDetailsUpload[1].TransferredBytes:
-						countBytesUploadIdx1++
+					case transferDetailsDownload[1].TransferredBytes:
+						countBytesDownloadIdx1++
+						continue
+					case transferDetailsDownload[2].TransferredBytes:
+						countBytesDownloadIdx2++
 						continue
 					default:
 						// We got a byte amount we are not expecting
 						t.Fatal("did not download proper amount of bytes")
 					}
 				}
-				if countBytesUploadIdx0 != 1 || countBytesUploadIdx1 != 1 {
+				if countBytesDownloadIdx0 != 1 || countBytesDownloadIdx1 != 1 || countBytesDownloadIdx2 != 1 {
 					// We would hit this case if 1 counter got hit twice for some reason
 					t.Fatal("One of the files was not downloaded correctly")
-				} else if len(transferDetailsDownload) != 2 {
+				} else if len(transferDetailsDownload) != 3 {
 					t.Fatalf("Amount of transfers results returned for download was not correct. Transfer details returned: %d", len(transferDetailsDownload))
 				}
 			}

--- a/client/fed_linux_test.go
+++ b/client/fed_linux_test.go
@@ -135,7 +135,7 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 			tempPath := tempDir
 			dirName := filepath.Base(tempPath)
 			uploadURL := fmt.Sprintf("pelican://%s:%s%s/%s/%s", param.Server_Hostname.GetString(), strconv.Itoa(param.Server_WebPort.GetInt()),
-				export.FederationPrefix, "osdf_osdf", dirName)		
+				export.FederationPrefix, "osdf_osdf", dirName)
 
 			// Upload the file with PUT
 			transferDetailsUpload, err := client.DoPut(fed.Ctx, tempDir, uploadURL, true, client.WithTokenLocation(tempToken.Name()))
@@ -274,7 +274,7 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 				countBytesDownloadIdx0 := 0
 				countBytesDownloadIdx1 := 0
 				countBytesDownloadIdx2 := 0
-	
+
 				// Verify we got the correct files back (have to do this since files upload in different orders at times)
 				// In this case, we want to match them to the sizes of the uploaded files
 				for _, transfer := range transferDetailsDownload {

--- a/client/fed_linux_test.go
+++ b/client/fed_linux_test.go
@@ -22,7 +22,6 @@ package client_test
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -111,24 +110,6 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 	assert.NoError(t, err, "Error writing to inner test file")
 	innerTempFile.Close()
 
-	t.Run("testPelicanRecursiveGetAndPutOsdfURL", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix("PELICAN")
-		assert.NoError(t, err)
-		// Set path for object to upload/download
-		tempPath := tempDir
-		dirName := filepath.Base(tempPath)
-		uploadStr := "osdf:///test/" + dirName
-		uploadURL, err := url.Parse(uploadStr)
-		assert.NoError(t, err)
-
-		// For OSDF url's, we don't want to rely on osdf metadata to be running therefore, just ensure we get correct metadata for the url:
-		pelicanUrl, err := te.NewPelicanURL(uploadURL)
-		assert.NoError(t, err)
-
-		// Check valid metadata:
-		assert.Equal(t, "https://osdf-director.osg-htc.org", pelicanUrl.DirectorUrl)
-	})
-
 	t.Run("testPelicanRecursiveGetAndPutPelicanURL", func(t *testing.T) {
 		_, err := config.SetPreferredPrefix("PELICAN")
 		assert.NoError(t, err)
@@ -176,9 +157,9 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 			// Download the files we just uploaded
 			var transferDetailsDownload []client.TransferResults
 			if export.Capabilities.PublicReads {
-				transferDetailsDownload, err = client.DoGet(te, uploadURL, t.TempDir(), true)
+				transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadURL, t.TempDir(), true)
 			} else {
-				transferDetailsDownload, err = client.DoGet(te, uploadURL, t.TempDir(), true, client.WithTokenLocation(tempToken.Name()))
+				transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadURL, t.TempDir(), true, client.WithTokenLocation(tempToken.Name()))
 			}
 			assert.NoError(t, err)
 			if err == nil && len(transferDetailsDownload) == 3 {
@@ -233,7 +214,7 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 			viper.Set("Federation.DiscoveryUrl", hostname)
 
 			// Upload the file with PUT
-			transferDetailsUpload, err := client.DoPut(te, tempDir, uploadURL, true, client.WithTokenLocation(tempToken.Name()))
+			transferDetailsUpload, err := client.DoPut(fed.Ctx, tempDir, uploadURL, true, client.WithTokenLocation(tempToken.Name()))
 			assert.NoError(t, err)
 			if err == nil && len(transferDetailsUpload) == 3 {
 				countBytes17 := 0
@@ -269,9 +250,9 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 			tmpDir := t.TempDir()
 			var transferDetailsDownload []client.TransferResults
 			if export.Capabilities.PublicReads {
-				transferDetailsDownload, err = client.DoGet(te, uploadURL, tmpDir, true)
+				transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadURL, tmpDir, true)
 			} else {
-				transferDetailsDownload, err = client.DoGet(te, uploadURL, tmpDir, true, client.WithTokenLocation(tempToken.Name()))
+				transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadURL, tmpDir, true, client.WithTokenLocation(tempToken.Name()))
 			}
 			assert.NoError(t, err)
 			if err == nil && len(transferDetailsDownload) == 3 {

--- a/client/fed_linux_test.go
+++ b/client/fed_linux_test.go
@@ -122,7 +122,7 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 				export.FederationPrefix, "osdf_osdf", dirName)
 
 			// Upload the file with PUT
-			transferDetailsUpload, err := client.DoPut(te, tempDir, uploadURL, true, client.WithTokenLocation(tempToken.Name()))
+			transferDetailsUpload, err := client.DoPut(fed.Ctx, tempDir, uploadURL, true, client.WithTokenLocation(tempToken.Name()))
 			assert.NoError(t, err)
 			if err == nil && len(transferDetailsUpload) == 3 {
 				countBytes17 := 0
@@ -300,7 +300,7 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 			uploadURL := fmt.Sprintf("pelican://%s:%s%s/%s/%s", param.Server_Hostname.GetString(), strconv.Itoa(param.Server_WebPort.GetInt()),
 				export.FederationPrefix, "osdf_osdf", dirName)
 			// Upload the file with PUT
-			transferDetailsUpload, err := client.DoPut(te, tempDir, uploadURL, true, client.WithTokenLocation(tempToken.Name()))
+			transferDetailsUpload, err := client.DoPut(fed.Ctx, tempDir, uploadURL, true, client.WithTokenLocation(tempToken.Name()))
 			assert.NoError(t, err)
 			if err == nil && len(transferDetailsUpload) == 3 {
 				countBytes17 := 0
@@ -334,9 +334,9 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 			// Download the files we just uploaded
 			var transferDetailsDownload []client.TransferResults
 			if export.Capabilities.PublicReads {
-				transferDetailsDownload, err = client.DoGet(te, uploadURL, t.TempDir(), true)
+				transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadURL, t.TempDir(), true)
 			} else {
-				transferDetailsDownload, err = client.DoGet(te, uploadURL, t.TempDir(), true, client.WithTokenLocation(tempToken.Name()))
+				transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadURL, t.TempDir(), true, client.WithTokenLocation(tempToken.Name()))
 			}
 			assert.NoError(t, err)
 			if err == nil && len(transferDetailsDownload) == 3 {

--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -30,7 +30,6 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -66,7 +66,6 @@ var (
 
 	loader = ttlcache.LoaderFunc[string, cacheItem](
 		func(c *ttlcache.Cache[string, cacheItem], key string) *ttlcache.Item[string, cacheItem] {
-			log.Errorf("Cache miss: %v+", key)
 			ctx := context.Background()
 			// Note: setting this timeout mostly for unit tests
 			ctx, cancel := context.WithTimeout(ctx, param.Transport_ResponseHeaderTimeout.GetDuration())

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -35,6 +35,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -518,9 +520,19 @@ func TestProjInUserAgent(t *testing.T) {
 }
 
 func TestNewPelicanURL(t *testing.T) {
+	// Set up our federation and context
+	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	viper.Set("Client.WorkerCount", 5)
+	te := NewTransferEngine(ctx)
+	config.InitConfig()
+
 	t.Run("TestOsdfOrStashSchemeWithOSDFPrefixNoError", func(t *testing.T) {
 		viper.Reset()
-		config.SetPreferredPrefix("OSDF")
+		_, err := config.SetPreferredPrefix("OSDF")
+		assert.NoError(t, err)
+		// Init config to get proper timeouts
+		config.InitConfig()
+
 		remoteObject := "osdf:///something/somewhere/thatdoesnotexist.txt"
 		remoteObjectURL, err := url.Parse(remoteObject)
 		assert.NoError(t, err)
@@ -530,20 +542,20 @@ func TestNewPelicanURL(t *testing.T) {
 		viper.Set("Federation.DiscoveryUrl", "someDiscoveryUrl")
 		viper.Set("Federation.RegistryUrl", "someRegistryUrl")
 
-		pelicanURL, err := NewPelicanURL(remoteObjectURL, "osdf")
+		pelicanURL, err := te.NewPelicanURL(remoteObjectURL)
 		assert.NoError(t, err)
 
 		// Check pelicanURL properly filled out
 		assert.Equal(t, "someDirectorUrl", pelicanURL.DirectorUrl)
-		assert.Equal(t, "someDiscoveryUrl", pelicanURL.DiscoveryUrl)
-		assert.Equal(t, "someRegistryUrl", pelicanURL.RegistryUrl)
-		assert.Equal(t, remoteObjectURL, pelicanURL.ObjectUrl)
 		viper.Reset()
 	})
 
 	t.Run("TestOsdfOrStashSchemeWithOSDFPrefixWithError", func(t *testing.T) {
 		viper.Reset()
-		config.SetPreferredPrefix("OSDF")
+		_, err := config.SetPreferredPrefix("OSDF")
+		assert.NoError(t, err)
+		config.InitConfig()
+
 		remoteObject := "osdf:///something/somewhere/thatdoesnotexist.txt"
 		remoteObjectURL, err := url.Parse(remoteObject)
 		assert.NoError(t, err)
@@ -552,7 +564,7 @@ func TestNewPelicanURL(t *testing.T) {
 		viper.Set("Federation.DirectorUrl", "someDirectorUrl")
 		viper.Set("Federation.DiscoveryUrl", "someDiscoveryUrl")
 
-		_, err = NewPelicanURL(remoteObjectURL, "osdf")
+		_, err = te.NewPelicanURL(remoteObjectURL)
 		// Make sure we get an error
 		assert.Error(t, err)
 		viper.Reset()
@@ -560,19 +572,18 @@ func TestNewPelicanURL(t *testing.T) {
 
 	t.Run("TestOsdfOrStashSchemeWithPelicanPrefixNoError", func(t *testing.T) {
 		viper.Reset()
-		config.SetPreferredPrefix("PELICAN")
+		_, err := config.SetPreferredPrefix("PELICAN")
+		config.InitConfig()
+		assert.NoError(t, err)
 		remoteObject := "osdf:///something/somewhere/thatdoesnotexist.txt"
 		remoteObjectURL, err := url.Parse(remoteObject)
 		assert.NoError(t, err)
 
-		pelicanURL, err := NewPelicanURL(remoteObjectURL, "osdf")
+		pelicanURL, err := te.NewPelicanURL(remoteObjectURL)
 		assert.NoError(t, err)
 
 		// Check pelicanURL properly filled out
 		assert.Equal(t, "https://osdf-director.osg-htc.org", pelicanURL.DirectorUrl)
-		assert.Equal(t, "osg-htc.org", pelicanURL.DiscoveryUrl)
-		assert.Equal(t, "https://osdf-registry.osg-htc.org", pelicanURL.RegistryUrl)
-		assert.Equal(t, remoteObjectURL, pelicanURL.ObjectUrl)
 		viper.Reset()
 		// Note: can't really test this for an error since that would require osg-htc.org to be down
 	})
@@ -580,6 +591,66 @@ func TestNewPelicanURL(t *testing.T) {
 	t.Run("TestPelicanSchemeNoError", func(t *testing.T) {
 		viper.Reset()
 		viper.Set("TLSSkipVerify", true)
+		config.InitConfig()
+		config.InitClient()
+		// Create a server that gives us a mock response
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// make our response:
+			response := config.FederationDiscovery{
+				DirectorEndpoint:              "director",
+				NamespaceRegistrationEndpoint: "registry",
+				JwksUri:                       "jwks",
+				BrokerEndpoint:                "broker",
+			}
+
+			responseJSON, err := json.Marshal(response)
+			if err != nil {
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				return
+			}
+
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write(responseJSON)
+			assert.NoError(t, err)
+		}))
+		defer server.Close()
+
+		serverURL, err := url.Parse(server.URL)
+		assert.NoError(t, err)
+
+		remoteObject := "pelican://" + serverURL.Host + "/something/somewhere/thatdoesnotexist.txt"
+		remoteObjectURL, err := url.Parse(remoteObject)
+		assert.NoError(t, err)
+
+		pelicanURL, err := te.NewPelicanURL(remoteObjectURL)
+		assert.NoError(t, err)
+
+		// Check pelicanURL properly filled out
+		assert.Equal(t, "director", pelicanURL.DirectorUrl)
+		// Check to make sure it was populated in our cache
+		assert.True(t, te.pelicanURLCache.Has("https://"+serverURL.Host))
+		viper.Reset()
+	})
+
+	t.Run("TestPelicanSchemeWithError", func(t *testing.T) {
+		viper.Reset()
+		config.InitConfig()
+
+		remoteObject := "pelican://some-host/something/somewhere/thatdoesnotexist.txt"
+		remoteObjectURL, err := url.Parse(remoteObject)
+		assert.NoError(t, err)
+
+		_, err = te.NewPelicanURL(remoteObjectURL)
+		assert.Error(t, err)
+		viper.Reset()
+	})
+
+	t.Run("TestPelicanSchemeMetadataTimeoutError", func(t *testing.T) {
+		viper.Reset()
+		viper.Set("TLSSkipVerify", true)
+		oldResponseHeaderTimeout := viper.Get("transport.ResponseHeaderTimeout")
+		viper.Set("transport.ResponseHeaderTimeout", 0.1*float64(time.Millisecond))
+		viper.Set("Client.WorkerCount", 5)
 		err := config.InitClient()
 		assert.NoError(t, err)
 		// Create a server that gives us a mock response
@@ -611,28 +682,21 @@ func TestNewPelicanURL(t *testing.T) {
 		remoteObjectURL, err := url.Parse(remoteObject)
 		assert.NoError(t, err)
 
-		pelicanURL, err := NewPelicanURL(remoteObjectURL, "pelican")
-		assert.NoError(t, err)
-
-		// Check pelicanURL properly filled out
-		assert.Equal(t, "director", pelicanURL.DirectorUrl)
-		assert.Equal(t, server.URL, pelicanURL.DiscoveryUrl)
-		assert.Equal(t, "registry", pelicanURL.RegistryUrl)
-		assert.Equal(t, remoteObjectURL, pelicanURL.ObjectUrl)
-		// Check to make sure it was populated in our cache
-		assert.True(t, PelicanURLCache.Has(pelicanURL.DiscoveryUrl))
-		viper.Reset()
+		_, err = te.NewPelicanURL(remoteObjectURL)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, config.MetadataTimeoutErr))
+		viper.Set("transport.ResponseHeaderTimeout", oldResponseHeaderTimeout)
 	})
 
-	t.Run("TestPelicanSchemeWithError", func(t *testing.T) {
-		viper.Reset()
-
-		remoteObject := "pelican://some-host/something/somewhere/thatdoesnotexist.txt"
-		remoteObjectURL, err := url.Parse(remoteObject)
-		assert.NoError(t, err)
-
-		_, err = NewPelicanURL(remoteObjectURL, "pelican")
-		assert.Error(t, err)
+	t.Cleanup(func() {
+		cancel()
+		if err := egrp.Wait(); err != nil && err != context.Canceled && err != http.ErrServerClosed {
+			require.NoError(t, err)
+		}
+		if err := te.Shutdown(); err != nil {
+			log.Errorln("Failure when shutting down transfer engine:")
+		}
+		// Throw in a viper.Reset for good measure. Keeps our env squeaky clean!
 		viper.Reset()
 	})
 }

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -592,7 +592,8 @@ func TestNewPelicanURL(t *testing.T) {
 		viper.Reset()
 		viper.Set("TLSSkipVerify", true)
 		config.InitConfig()
-		config.InitClient()
+		err := config.InitClient()
+		assert.NoError(t, err)
 		// Create a server that gives us a mock response
 		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// make our response:

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -542,11 +542,11 @@ func TestNewPelicanURL(t *testing.T) {
 		viper.Set("Federation.DiscoveryUrl", "someDiscoveryUrl")
 		viper.Set("Federation.RegistryUrl", "someRegistryUrl")
 
-		pelicanURL, err := te.NewPelicanURL(remoteObjectURL)
+		pelicanURL, err := te.newPelicanURL(remoteObjectURL)
 		assert.NoError(t, err)
 
 		// Check pelicanURL properly filled out
-		assert.Equal(t, "someDirectorUrl", pelicanURL.DirectorUrl)
+		assert.Equal(t, "someDirectorUrl", pelicanURL.directorUrl)
 		viper.Reset()
 	})
 
@@ -564,7 +564,7 @@ func TestNewPelicanURL(t *testing.T) {
 		viper.Set("Federation.DirectorUrl", "someDirectorUrl")
 		viper.Set("Federation.DiscoveryUrl", "someDiscoveryUrl")
 
-		_, err = te.NewPelicanURL(remoteObjectURL)
+		_, err = te.newPelicanURL(remoteObjectURL)
 		// Make sure we get an error
 		assert.Error(t, err)
 		viper.Reset()
@@ -579,11 +579,11 @@ func TestNewPelicanURL(t *testing.T) {
 		remoteObjectURL, err := url.Parse(remoteObject)
 		assert.NoError(t, err)
 
-		pelicanURL, err := te.NewPelicanURL(remoteObjectURL)
+		pelicanURL, err := te.newPelicanURL(remoteObjectURL)
 		assert.NoError(t, err)
 
 		// Check pelicanURL properly filled out
-		assert.Equal(t, "https://osdf-director.osg-htc.org", pelicanURL.DirectorUrl)
+		assert.Equal(t, "https://osdf-director.osg-htc.org", pelicanURL.directorUrl)
 		viper.Reset()
 		// Note: can't really test this for an error since that would require osg-htc.org to be down
 	})
@@ -623,11 +623,11 @@ func TestNewPelicanURL(t *testing.T) {
 		remoteObjectURL, err := url.Parse(remoteObject)
 		assert.NoError(t, err)
 
-		pelicanURL, err := te.NewPelicanURL(remoteObjectURL)
+		pelicanURL, err := te.newPelicanURL(remoteObjectURL)
 		assert.NoError(t, err)
 
 		// Check pelicanURL properly filled out
-		assert.Equal(t, "director", pelicanURL.DirectorUrl)
+		assert.Equal(t, "director", pelicanURL.directorUrl)
 		// Check to make sure it was populated in our cache
 		assert.True(t, te.pelicanURLCache.Has("https://"+serverURL.Host))
 		viper.Reset()
@@ -641,7 +641,7 @@ func TestNewPelicanURL(t *testing.T) {
 		remoteObjectURL, err := url.Parse(remoteObject)
 		assert.NoError(t, err)
 
-		_, err = te.NewPelicanURL(remoteObjectURL)
+		_, err = te.newPelicanURL(remoteObjectURL)
 		assert.Error(t, err)
 		viper.Reset()
 	})
@@ -683,7 +683,7 @@ func TestNewPelicanURL(t *testing.T) {
 		remoteObjectURL, err := url.Parse(remoteObject)
 		assert.NoError(t, err)
 
-		_, err = te.NewPelicanURL(remoteObjectURL)
+		_, err = te.newPelicanURL(remoteObjectURL)
 		assert.Error(t, err)
 		assert.True(t, errors.Is(err, config.MetadataTimeoutErr))
 		viper.Set("transport.ResponseHeaderTimeout", oldResponseHeaderTimeout)

--- a/client/handle_ingest.go
+++ b/client/handle_ingest.go
@@ -103,14 +103,7 @@ func DoShadowIngest(ctx context.Context, sourceFile string, originPrefix string,
 			time.Sleep(5 * time.Second)
 		}
 
-		te := NewTransferEngine(ctx)
-		defer func() {
-			if err := te.Shutdown(); err != nil {
-				log.Errorln("Failure when shutting down transfer engine:", err)
-			}
-		}()
-
-		transferResults, err := DoCopy(te, sourceFile, shadowFile, false, options...)
+		transferResults, err := DoCopy(ctx, sourceFile, shadowFile, false, options...)
 		if err != nil {
 			return 0, "", err
 		}

--- a/client/handle_ingest.go
+++ b/client/handle_ingest.go
@@ -103,7 +103,14 @@ func DoShadowIngest(ctx context.Context, sourceFile string, originPrefix string,
 			time.Sleep(5 * time.Second)
 		}
 
-		transferResults, err := DoCopy(ctx, sourceFile, shadowFile, false, options...)
+		te := NewTransferEngine(ctx)
+		defer func() {
+			if err := te.Shutdown(); err != nil {
+				log.Errorln("Failure when shutting down transfer engine:", err)
+			}
+		}()
+
+		transferResults, err := DoCopy(te, sourceFile, shadowFile, false, options...)
 		if err != nil {
 			return 0, "", err
 		}

--- a/client/main.go
+++ b/client/main.go
@@ -461,7 +461,6 @@ func DoPut(ctx context.Context, localObject string, remoteDestination string, re
 
 	remoteDestScheme, _ = getTokenName(remoteDestUrl)
 
-
 	// Check if we understand the found url scheme
 	err = schemeUnderstood(remoteDestScheme)
 	if err != nil {

--- a/client/main_test.go
+++ b/client/main_test.go
@@ -350,3 +350,36 @@ func TestGetProjectName(t *testing.T) {
 		assert.Equal(t, "testProject", projectName)
 	})
 }
+
+func TestSchemeUnderstood(t *testing.T) {
+	t.Run("TestProperSchemeOsdf", func(t *testing.T) {
+		scheme := "osdf"
+		err := schemeUnderstood(scheme)
+		assert.NoError(t, err)
+	})
+	t.Run("TestProperSchemeStash", func(t *testing.T) {
+		scheme := "stash"
+		err := schemeUnderstood(scheme)
+		assert.NoError(t, err)
+	})
+	t.Run("TestProperSchemePelican", func(t *testing.T) {
+		scheme := "pelican"
+		err := schemeUnderstood(scheme)
+		assert.NoError(t, err)
+	})
+	t.Run("TestProperSchemeFile", func(t *testing.T) {
+		scheme := "file"
+		err := schemeUnderstood(scheme)
+		assert.NoError(t, err)
+	})
+	t.Run("TestProperSchemeEmpty", func(t *testing.T) {
+		scheme := ""
+		err := schemeUnderstood(scheme)
+		assert.NoError(t, err)
+	})
+	t.Run("TestImproperScheme", func(t *testing.T) {
+		scheme := "ThisSchemeDoesNotExistAndHopefullyNeverWill"
+		err := schemeUnderstood(scheme)
+		assert.Error(t, err)
+	})
+}

--- a/client/sharing_url.go
+++ b/client/sharing_url.go
@@ -19,6 +19,7 @@
 package client
 
 import (
+	"context"
 	"net/url"
 	"strings"
 
@@ -45,7 +46,7 @@ func getDirectorFromUrl(objectUrl *url.URL) (string, error) {
 			}
 			viper.Set("Federation.DirectorUrl", "")
 			viper.Set("Federation.DiscoveryUrl", discoveryUrl.String())
-			if err := config.DiscoverFederation(); err != nil {
+			if err := config.DiscoverFederation(context.Background()); err != nil {
 				return "", errors.Wrapf(err, "Failed to discover location of the director for the federation %s", objectUrl.Host)
 			}
 			if directorUrl = param.Federation_DirectorUrl.GetString(); directorUrl == "" {
@@ -58,7 +59,7 @@ func getDirectorFromUrl(objectUrl *url.URL) (string, error) {
 			objectUrl.Host = ""
 		}
 		viper.Set("Federation.DiscoveryUrl", "https://osg-htc.org")
-		if err := config.DiscoverFederation(); err != nil {
+		if err := config.DiscoverFederation(context.Background()); err != nil {
 			return "", errors.Wrap(err, "Failed to discover director for the OSDF")
 		}
 		if directorUrl = param.Federation_DirectorUrl.GetString(); directorUrl == "" {

--- a/client/sharing_url_test.go
+++ b/client/sharing_url_test.go
@@ -153,7 +153,8 @@ func TestSharingUrl(t *testing.T) {
 	defer server.Close()
 	myUrl = server.URL
 
-	config.SetPreferredPrefix("PELICAN")
+	_, err := config.SetPreferredPrefix("PELICAN")
+	assert.NoError(t, err)
 	viper.Set("ConfigDir", t.TempDir())
 	viper.Set("Logging.Level", "debug")
 	config.InitConfig()
@@ -162,7 +163,7 @@ func TestSharingUrl(t *testing.T) {
 	defer os.Unsetenv("PELICAN_SKIP_TERMINAL_CHECK")
 	viper.Set("Federation.DirectorURL", myUrl)
 	viper.Set("ConfigDir", t.TempDir())
-	err := config.InitClient()
+	err = config.InitClient()
 	assert.NoError(t, err)
 
 	// Call QueryDirector with the test server URL and a source path

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -203,16 +203,9 @@ func copyMain(cmd *cobra.Command, args []string) {
 	var result error
 	lastSrc := ""
 
-	te := client.NewTransferEngine(ctx)
-	defer func() {
-		if err := te.Shutdown(); err != nil {
-			log.Errorln("Failure when shutting down transfer engine:", err)
-		}
-	}()
-
 	for _, src := range source {
 		isRecursive, _ := cmd.Flags().GetBool("recursive")
-		_, result = client.DoCopy(te, src, dest, isRecursive, client.WithCallback(pb.callback), client.WithTokenLocation(tokenLocation), client.WithCaches(caches...))
+		_, result = client.DoCopy(ctx, src, dest, isRecursive, client.WithCallback(pb.callback), client.WithTokenLocation(tokenLocation), client.WithCaches(caches...))
 		if result != nil {
 			lastSrc = src
 			break

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -200,6 +200,10 @@ func copyMain(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	// Start our cache for url metadata
+	go client.PelicanURLCache.Start()
+	defer client.PelicanURLCache.Stop()
+
 	var result error
 	lastSrc := ""
 	for _, src := range source {

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -200,15 +200,19 @@ func copyMain(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	// Start our cache for url metadata
-	go client.PelicanURLCache.Start()
-	defer client.PelicanURLCache.Stop()
-
 	var result error
 	lastSrc := ""
+
+	te := client.NewTransferEngine(ctx)
+	defer func() {
+		if err := te.Shutdown(); err != nil {
+			log.Errorln("Failure when shutting down transfer engine:", err)
+		}
+	}()
+
 	for _, src := range source {
 		isRecursive, _ := cmd.Flags().GetBool("recursive")
-		_, result = client.DoCopy(ctx, src, dest, isRecursive, client.WithCallback(pb.callback), client.WithTokenLocation(tokenLocation), client.WithCaches(caches...))
+		_, result = client.DoCopy(te, src, dest, isRecursive, client.WithCallback(pb.callback), client.WithTokenLocation(tokenLocation), client.WithCaches(caches...))
 		if result != nil {
 			lastSrc = src
 			break

--- a/cmd/object_get.go
+++ b/cmd/object_get.go
@@ -118,16 +118,9 @@ func getMain(cmd *cobra.Command, args []string) {
 	var result error
 	lastSrc := ""
 
-	te := client.NewTransferEngine(ctx)
-	defer func() {
-		if err := te.Shutdown(); err != nil {
-			log.Errorln("Failure when shutting down transfer engine:", err)
-		}
-	}()
-
 	for _, src := range source {
 		isRecursive, _ := cmd.Flags().GetBool("recursive")
-		_, result = client.DoGet(te, src, dest, isRecursive, client.WithCallback(pb.callback), client.WithTokenLocation(tokenLocation), client.WithCaches(caches...))
+		_, result = client.DoGet(ctx, src, dest, isRecursive, client.WithCallback(pb.callback), client.WithTokenLocation(tokenLocation), client.WithCaches(caches...))
 		if result != nil {
 			lastSrc = src
 			break

--- a/cmd/object_get.go
+++ b/cmd/object_get.go
@@ -115,6 +115,10 @@ func getMain(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	// Start our cache for url metadata
+	go client.PelicanURLCache.Start()
+	defer client.PelicanURLCache.Stop()
+
 	var result error
 	lastSrc := ""
 	for _, src := range source {

--- a/cmd/object_put.go
+++ b/cmd/object_put.go
@@ -85,6 +85,10 @@ func putMain(cmd *cobra.Command, args []string) {
 	log.Debugln("Sources:", source)
 	log.Debugln("Destination:", dest)
 
+	// Start our cache for url metadata
+	go client.PelicanURLCache.Start()
+	defer client.PelicanURLCache.Stop()
+
 	var result error
 	lastSrc := ""
 	for _, src := range source {

--- a/cmd/object_put.go
+++ b/cmd/object_put.go
@@ -88,16 +88,9 @@ func putMain(cmd *cobra.Command, args []string) {
 	var result error
 	lastSrc := ""
 
-	te := client.NewTransferEngine(ctx)
-	defer func() {
-		if err := te.Shutdown(); err != nil {
-			log.Errorln("Failure when shutting down transfer engine:", err)
-		}
-	}()
-
 	for _, src := range source {
 		isRecursive, _ := cmd.Flags().GetBool("recursive")
-		_, result = client.DoPut(te, src, dest, isRecursive, client.WithCallback(pb.callback), client.WithTokenLocation(tokenLocation))
+		_, result = client.DoPut(ctx, src, dest, isRecursive, client.WithCallback(pb.callback), client.WithTokenLocation(tokenLocation))
 		if result != nil {
 			lastSrc = src
 			break

--- a/cmd/object_put.go
+++ b/cmd/object_put.go
@@ -85,15 +85,19 @@ func putMain(cmd *cobra.Command, args []string) {
 	log.Debugln("Sources:", source)
 	log.Debugln("Destination:", dest)
 
-	// Start our cache for url metadata
-	go client.PelicanURLCache.Start()
-	defer client.PelicanURLCache.Stop()
-
 	var result error
 	lastSrc := ""
+
+	te := client.NewTransferEngine(ctx)
+	defer func() {
+		if err := te.Shutdown(); err != nil {
+			log.Errorln("Failure when shutting down transfer engine:", err)
+		}
+	}()
+
 	for _, src := range source {
 		isRecursive, _ := cmd.Flags().GetBool("recursive")
-		_, result = client.DoPut(ctx, src, dest, isRecursive, client.WithCallback(pb.callback), client.WithTokenLocation(tokenLocation))
+		_, result = client.DoPut(te, src, dest, isRecursive, client.WithCallback(pb.callback), client.WithTokenLocation(tokenLocation))
 		if result != nil {
 			lastSrc = src
 			break

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -432,7 +432,7 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 			var tj *client.TransferJob
 			urlCopy := *transfer.url
 			project := client.GetProjectName()
-			tj, err = tc.NewTransferJob(&urlCopy, transfer.localFile, upload, false, project, client.WithAcquireToken(false), client.WithCaches(caches...))
+			tj, err = tc.NewTransferJob(&urlCopy, transfer.localFile, te, upload, false, project, client.WithAcquireToken(false), client.WithCaches(caches...))
 			if err != nil {
 				return errors.Wrap(err, "Failed to create new transfer job")
 			}

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -432,7 +432,7 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 			var tj *client.TransferJob
 			urlCopy := *transfer.url
 			project := client.GetProjectName()
-			tj, err = tc.NewTransferJob(&urlCopy, transfer.localFile, te, upload, false, project, client.WithAcquireToken(false), client.WithCaches(caches...))
+			tj, err = tc.NewTransferJob(&urlCopy, transfer.localFile, upload, false, project, client.WithAcquireToken(false), client.WithCaches(caches...))
 			if err != nil {
 				return errors.Wrap(err, "Failed to create new transfer job")
 			}

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -31,7 +31,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -216,7 +215,7 @@ func TestStashPluginMain(t *testing.T) {
 		// Set path for object to upload/download
 		tempPath := tempFile.Name()
 		fileName := filepath.Base(tempPath)
-		uploadURL := fmt.Sprintf("pelican://%s:%s/test/%s", param.Server_Hostname.GetString(), strconv.Itoa(param.Server_WebPort.GetInt()), fileName)
+		uploadURL := fmt.Sprintf("pelican://%s:%d/test/%s", param.Server_Hostname.GetString(), param.Server_WebPort.GetInt(), fileName)
 
 		// Download a test file
 		args := []string{uploadURL, tempDir}
@@ -241,7 +240,7 @@ func TestStashPluginMain(t *testing.T) {
 	output := strings.Replace(stderr.String(), "\\\\", "\\", -1)
 
 	// Check captured output for successful download
-	expectedOutput := "Downloading file from pelican:///test/test.txt to " + tempDir
+	expectedOutput := "Downloading object from pelican:///test/test.txt to " + tempDir
 	assert.Contains(t, output, expectedOutput)
 	successfulDownloadMsg := "HTTP Transfer was successful"
 	assert.Contains(t, output, successfulDownloadMsg)

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -25,11 +25,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -213,7 +215,7 @@ func TestStashPluginMain(t *testing.T) {
 		// Set path for object to upload/download
 		tempPath := tempFile.Name()
 		fileName := filepath.Base(tempPath)
-		uploadURL := "pelican:///test/" + fileName
+		uploadURL := fmt.Sprintf("pelican://%s:%s/test/%s", param.Server_Hostname.GetString(), strconv.Itoa(param.Server_WebPort.GetInt()), fileName)
 
 		// Download a test file
 		args := []string{uploadURL, tempDir}
@@ -238,7 +240,7 @@ func TestStashPluginMain(t *testing.T) {
 	output := strings.Replace(stderr.String(), "\\\\", "\\", -1)
 
 	// Check captured output for successful download
-	expectedOutput := "Downloading: pelican:///test/test.txt to " + tempDir
+	expectedOutput := "Downloading file from pelican:///test/test.txt to " + tempDir
 	assert.Contains(t, output, expectedOutput)
 	successfulDownloadMsg := "HTTP Transfer was successful"
 	assert.Contains(t, output, successfulDownloadMsg)

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -187,7 +187,8 @@ func TestStashPluginMain(t *testing.T) {
 	viper.Reset()
 	server_utils.ResetOriginExports()
 
-	config.SetPreferredPrefix("STASH")
+	_, err := config.SetPreferredPrefix("STASH")
+	assert.NoError(t, err)
 
 	// Temp dir for downloads
 	tempDir := os.TempDir()
@@ -233,7 +234,7 @@ func TestStashPluginMain(t *testing.T) {
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
-	err := cmd.Run()
+	err = cmd.Run()
 	assert.NoError(t, err, stderr.String())
 
 	// changing output for "\\" since in windows there are excess "\" printed in debug logs

--- a/config/config.go
+++ b/config/config.go
@@ -364,6 +364,76 @@ func GetAllPrefixes() []string {
 	return prefixes
 }
 
+// This function is for discovering federations as specified by a url during a pelican:// transfer.
+// this does not populate global fields and is more temporary per url
+func DiscoverUrlFederation(federationDiscoveryUrl string) (metadata FederationDiscovery, err error) {
+	log.Debugln("Performing federation service discovery for specified url against endpoint", federationDiscoveryUrl)
+	federationUrl, err := url.Parse(federationDiscoveryUrl)
+	if err != nil {
+		return FederationDiscovery{}, errors.Wrapf(err, "Invalid federation value %s:", federationDiscoveryUrl)
+	}
+	federationUrl.Scheme = "https"
+	if len(federationUrl.Path) > 0 && len(federationUrl.Host) == 0 {
+		federationUrl.Host = federationUrl.Path
+		federationUrl.Path = ""
+	}
+
+	discoveryUrl, err := url.Parse(federationUrl.String())
+	if err != nil {
+		return FederationDiscovery{}, errors.Wrap(err, "unable to parse federation discovery URL")
+	}
+	discoveryUrl.Path, err = url.JoinPath(federationUrl.Path, ".well-known/pelican-configuration")
+	if err != nil {
+		return FederationDiscovery{}, errors.Wrap(err, "Unable to parse federation url because of invalid path")
+	}
+
+	httpClient := http.Client{
+		Transport: GetTransport(),
+		Timeout:   time.Second * 5,
+	}
+	req, err := http.NewRequest(http.MethodGet, discoveryUrl.String(), nil)
+	if err != nil {
+		return FederationDiscovery{}, errors.Wrapf(err, "Failure when doing federation metadata request creation for %s", discoveryUrl)
+	}
+	req.Header.Set("User-Agent", "pelican/"+version)
+
+	result, err := httpClient.Do(req)
+	if err != nil {
+		return FederationDiscovery{}, errors.Wrapf(err, "Failure when doing federation metadata lookup to %s", discoveryUrl)
+	}
+
+	if result.Body != nil {
+		defer result.Body.Close()
+	}
+
+	body, err := io.ReadAll(result.Body)
+	if err != nil {
+		return FederationDiscovery{}, errors.Wrapf(err, "Failure when doing federation metadata read to %s", discoveryUrl)
+	}
+
+	if result.StatusCode != http.StatusOK {
+		truncatedMessage := string(body)
+		if len(body) > 1000 {
+			truncatedMessage = string(body[:1000])
+			truncatedMessage += " [... remainder truncated ...]"
+		}
+		return FederationDiscovery{}, errors.Errorf("Federation metadata discovery failed with HTTP status %d.  Error message: %s", result.StatusCode, truncatedMessage)
+	}
+
+	metadata = FederationDiscovery{}
+	err = json.Unmarshal(body, &metadata)
+	if err != nil {
+		return FederationDiscovery{}, errors.Wrapf(err, "Failure when parsing federation metadata at %s", discoveryUrl)
+	}
+
+	log.Debugln("Federation service discovery resulted in director URL", metadata.DirectorEndpoint)
+	log.Debugln("Federation service discovery resulted in registry URL", metadata.NamespaceRegistrationEndpoint)
+	log.Debugln("Federation service discovery resulted in JWKS URL", metadata.JwksUri)
+	log.Debugln("Federation service discovery resulted in broker URL", metadata.BrokerEndpoint)
+
+	return metadata, nil
+}
+
 func DiscoverFederation() error {
 	federationStr := param.Federation_DiscoveryUrl.GetString()
 	externalUrlStr := param.Server_ExternalWebUrl.GetString()
@@ -396,93 +466,47 @@ func DiscoverFederation() error {
 	curRegistryURL := param.Federation_RegistryUrl.GetString()
 	curFederationJwkURL := param.Federation_JwkUrl.GetString()
 	curBrokerURL := param.Federation_BrokerUrl.GetString()
-	if len(curDirectorURL) != 0 && len(curRegistryURL) != 0 && len(curFederationJwkURL) != 0 {
+	if curDirectorURL != "" && curRegistryURL != "" && curFederationJwkURL != "" && curBrokerURL != "" {
 		return nil
 	}
 
-	log.Debugln("Performing federation service discovery against endpoint", federationStr)
 	federationUrl, err := url.Parse(federationStr)
 	if err != nil {
 		return errors.Wrapf(err, "Invalid federation value %s:", federationStr)
 	}
+
 	if federationUrl.Path != "" && federationUrl.Host != "" {
 		// If the host is nothing, then the url is fine, but if we have a host and a path then there is a problem
 		return errors.New("Invalid federation discovery url is set. No path allowed for federation discovery url. Provided url: " + federationStr)
 	}
+
 	federationUrl.Scheme = "https"
 	if len(federationUrl.Path) > 0 && len(federationUrl.Host) == 0 {
 		federationUrl.Host = federationUrl.Path
 		federationUrl.Path = ""
+		return errors.Wrap(err, "Error discovering the federation with given discovery url")
 	}
 
-	discoveryUrl, err := url.Parse(federationUrl.String())
+	metadata, err := DiscoverUrlFederation(federationStr)
 	if err != nil {
-		return errors.Wrap(err, "unable to parse federation discovery URL")
-	}
-	discoveryUrl.Path, err = url.JoinPath(federationUrl.Path, ".well-known/pelican-configuration")
-	if err != nil {
-		return errors.Wrap(err, "Unable to parse federation url because of invalid path")
+		return errors.Wrapf(err, "Invalid federation value %s:", federationStr)
 	}
 
-	httpClient := http.Client{
-		Transport: GetTransport(),
-		Timeout:   time.Second * 5,
-	}
-	req, err := http.NewRequest(http.MethodGet, discoveryUrl.String(), nil)
-	if err != nil {
-		return errors.Wrapf(err, "Failure when doing federation metadata request creation for %s", discoveryUrl)
-	}
-	req.Header.Set("User-Agent", "pelican/"+version)
-
-	result, err := httpClient.Do(req)
-	if err != nil {
-		var netErr net.Error
-		if errors.As(err, &netErr) && netErr.Timeout() {
-			return MetadataTimeoutErr.Wrap(err)
-		} else {
-			return NewMetadataError(err, "Error occured when querying for metadata")
-		}
-	}
-
-	if result.Body != nil {
-		defer result.Body.Close()
-	}
-
-	body, err := io.ReadAll(result.Body)
-	if err != nil {
-		return errors.Wrapf(err, "Failure when doing federation metadata read to %s", discoveryUrl)
-	}
-
-	if result.StatusCode != http.StatusOK {
-		truncatedMessage := string(body)
-		if len(body) > 1000 {
-			truncatedMessage = string(body[:1000])
-			truncatedMessage += " [... remainder truncated ...]"
-		}
-		return errors.Errorf("Federation metadata discovery failed with HTTP status %d.  Error message: %s", result.StatusCode, truncatedMessage)
-	}
-
-	metadata := FederationDiscovery{}
-	err = json.Unmarshal(body, &metadata)
-	if err != nil {
-		return errors.Wrapf(err, "Failure when parsing federation metadata at %s", discoveryUrl)
-	}
+	// Set our globals
 	if curDirectorURL == "" {
-		log.Debugln("Federation service discovery resulted in director URL", metadata.DirectorEndpoint)
+		log.Debugln("Setting global director url to", metadata.DirectorEndpoint)
 		viper.Set("Federation.DirectorUrl", metadata.DirectorEndpoint)
 	}
 	if curRegistryURL == "" {
-		log.Debugln("Federation service discovery resulted in registry URL",
-			metadata.NamespaceRegistrationEndpoint)
+		log.Debugln("Setting global registry url to", metadata.NamespaceRegistrationEndpoint)
 		viper.Set("Federation.RegistryUrl", metadata.NamespaceRegistrationEndpoint)
 	}
 	if curFederationJwkURL == "" {
-		log.Debugln("Federation service discovery resulted in JWKS URL",
-			metadata.JwksUri)
+		log.Debugln("Setting global jwks url to", metadata.JwksUri)
 		viper.Set("Federation.JwkUrl", metadata.JwksUri)
 	}
 	if curBrokerURL == "" && metadata.BrokerEndpoint != "" {
-		log.Debugln("Federation service discovery resulted in broker URL", metadata.BrokerEndpoint)
+		log.Debugln("Setting global broker url to", metadata.BrokerEndpoint)
 		viper.Set("Federation.BrokerUrl", metadata.BrokerEndpoint)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -156,6 +156,7 @@ var (
 		string(Pelican): true,
 		string(OSDF):    true,
 		string(Stash):   true,
+		"":              true,
 	}
 )
 

--- a/config/config.go
+++ b/config/config.go
@@ -484,7 +484,6 @@ func DiscoverFederation() error {
 	if len(federationUrl.Path) > 0 && len(federationUrl.Host) == 0 {
 		federationUrl.Host = federationUrl.Path
 		federationUrl.Path = ""
-		return errors.Wrap(err, "Error discovering the federation with given discovery url")
 	}
 
 	metadata, err := DiscoverUrlFederation(federationStr)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spf13/viper"
@@ -284,6 +285,47 @@ func TestEnabledServers(t *testing.T) {
 	})
 }
 
+// Tests the function setPreferredPrefix: ensures case-insensitivity and invalid values are handled correctly
+func TestSetPreferredPrefix(t *testing.T) {
+	t.Run("TestPelicanPreferredPrefix", func(t *testing.T) {
+		oldPref, err := SetPreferredPrefix("pelican")
+		assert.NoError(t, err)
+		if GetPreferredPrefix() != "PELICAN" {
+			t.Errorf("Expected preferred prefix to be 'PELICAN', got '%s'", GetPreferredPrefix())
+		}
+		if oldPref != "" {
+			t.Errorf("Expected old preferred prefix to be empty, got '%s'", oldPref)
+		}
+	})
+
+	t.Run("TestOSDFPreferredPrefix", func(t *testing.T) {
+		oldPref, err := SetPreferredPrefix("osdf")
+		assert.NoError(t, err)
+		if GetPreferredPrefix() != "OSDF" {
+			t.Errorf("Expected preferred prefix to be 'OSDF', got '%s'", GetPreferredPrefix())
+		}
+		if oldPref != "PELICAN" {
+			t.Errorf("Expected old preferred prefix to be 'PELICAN', got '%s'", oldPref)
+		}
+	})
+
+	t.Run("TestStashPreferredPrefix", func(t *testing.T) {
+		oldPref, err := SetPreferredPrefix("stash")
+		assert.NoError(t, err)
+		if GetPreferredPrefix() != "STASH" {
+			t.Errorf("Expected preferred prefix to be 'STASH', got '%s'", GetPreferredPrefix())
+		}
+		if oldPref != "OSDF" {
+			t.Errorf("Expected old preferred prefix to be 'osdf', got '%s'", oldPref)
+		}
+	})
+
+	t.Run("TestInvalidPreferredPrefix", func(t *testing.T) {
+		_, err := SetPreferredPrefix("invalid")
+		assert.Error(t, err)
+	})
+}
+
 func TestDiscoverFederation(t *testing.T) {
 	viper.Reset()
 	// Server to be a "mock" federation
@@ -478,33 +520,79 @@ func TestInitServerUrl(t *testing.T) {
 	})
 }
 func TestDiscoverUrlFederation(t *testing.T) {
-	// Server to be a "mock" federation
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// make our response:
-		response := FederationDiscovery{
-			DirectorEndpoint:              "director",
-			NamespaceRegistrationEndpoint: "registry",
-			JwksUri:                       "jwks",
-			BrokerEndpoint:                "broker",
-		}
+	t.Run("TestMetadataDiscoveryTimeout", func(t *testing.T) {
+		// Create a server that sleeps for a longer duration than the timeout
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(2 * time.Second)
+		}))
+		defer server.Close()
 
-		responseJSON, err := json.Marshal(response)
-		if err != nil {
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-			return
-		}
+		// Set a short timeout for the test
+		timeout := 1 * time.Second
 
-		w.WriteHeader(http.StatusOK)
-		_, err = w.Write(responseJSON)
+		// Create a context with the timeout
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+
+		// Call the function with the server URL and the context
+		_, err := DiscoverUrlFederation(ctx, server.URL)
+
+		// Assert that the error is the expected metadata timeout error
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, MetadataTimeoutErr))
+	})
+
+	t.Run("TestCanceledContext", func(t *testing.T) {
+		// Create a server that waits for the context to be canceled
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+		}))
+		defer server.Close()
+
+		// Create a context and cancel it immediately
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		// Call the function with the server URL and the canceled context
+		_, err := DiscoverUrlFederation(ctx, server.URL)
+
+		// Assert that the error is the expected context cancel error
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, context.Canceled))
+	})
+
+	t.Run("TestValidDiscovery", func(t *testing.T) {
+		// Server to be a "mock" federation
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// make our response:
+			response := FederationDiscovery{
+				DirectorEndpoint:              "director",
+				NamespaceRegistrationEndpoint: "registry",
+				JwksUri:                       "jwks",
+				BrokerEndpoint:                "broker",
+			}
+
+			responseJSON, err := json.Marshal(response)
+			if err != nil {
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				return
+			}
+
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write(responseJSON)
+			assert.NoError(t, err)
+		}))
+		defer server.Close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		metadata, err := DiscoverUrlFederation(ctx, server.URL)
 		assert.NoError(t, err)
-	}))
-	defer server.Close()
-	metadata, err := DiscoverUrlFederation(server.URL)
-	assert.NoError(t, err)
 
-	// Assert that the metadata matches expectations
-	assert.Equal(t, "director", metadata.DirectorEndpoint, "Unexpected DirectorEndpoint")
-	assert.Equal(t, "registry", metadata.NamespaceRegistrationEndpoint, "Unexpected NamespaceRegistrationEndpoint")
-	assert.Equal(t, "jwks", metadata.JwksUri, "Unexpected JwksUri")
-	assert.Equal(t, "broker", metadata.BrokerEndpoint, "Unexpected BrokerEndpoint")
+		// Assert that the metadata matches expectations
+		assert.Equal(t, "director", metadata.DirectorEndpoint, "Unexpected DirectorEndpoint")
+		assert.Equal(t, "registry", metadata.NamespaceRegistrationEndpoint, "Unexpected NamespaceRegistrationEndpoint")
+		assert.Equal(t, "jwks", metadata.JwksUri, "Unexpected JwksUri")
+		assert.Equal(t, "broker", metadata.BrokerEndpoint, "Unexpected BrokerEndpoint")
+	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -327,6 +327,7 @@ func TestSetPreferredPrefix(t *testing.T) {
 }
 
 func TestDiscoverFederation(t *testing.T) {
+
 	viper.Reset()
 	// Server to be a "mock" federation
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -350,9 +351,8 @@ func TestDiscoverFederation(t *testing.T) {
 	}))
 	defer server.Close()
 	t.Run("testInvalidDiscoveryUrlWithPath", func(t *testing.T) {
-		viper.Set("tlsskipverify", true)
 		viper.Set("Federation.DiscoveryUrl", server.URL+"/this/is/some/path")
-		err := DiscoverFederation()
+		err := DiscoverFederation(context.Background())
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "Invalid federation discovery url is set. No path allowed for federation discovery url. Provided url: ",
 			"Error returned does not contain the correct error")
@@ -360,9 +360,8 @@ func TestDiscoverFederation(t *testing.T) {
 	})
 
 	t.Run("testValidDiscoveryUrl", func(t *testing.T) {
-		viper.Set("tlsskipverify", true)
 		viper.Set("Federation.DiscoveryUrl", server.URL)
-		err := DiscoverFederation()
+		err := DiscoverFederation(context.Background())
 		assert.NoError(t, err)
 		// Assert that the metadata matches expectations
 		assert.Equal(t, "director", param.Federation_DirectorUrl.GetString(), "Unexpected DirectorEndpoint")
@@ -373,9 +372,8 @@ func TestDiscoverFederation(t *testing.T) {
 	})
 
 	t.Run("testOsgHtcUrl", func(t *testing.T) {
-		viper.Set("tlsskipverify", true)
 		viper.Set("Federation.DiscoveryUrl", "osg-htc.org")
-		err := DiscoverFederation()
+		err := DiscoverFederation(context.Background())
 		assert.NoError(t, err)
 		// Assert that the metadata matches expectations
 		assert.Equal(t, "https://osdf-director.osg-htc.org", param.Federation_DirectorUrl.GetString(), "Unexpected DirectorEndpoint")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -521,6 +521,9 @@ func TestInitServerUrl(t *testing.T) {
 }
 func TestDiscoverUrlFederation(t *testing.T) {
 	t.Run("TestMetadataDiscoveryTimeout", func(t *testing.T) {
+		viper.Set("tlsskipverify", true)
+		err := InitClient()
+		assert.NoError(t, err)
 		// Create a server that sleeps for a longer duration than the timeout
 		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			time.Sleep(2 * time.Second)
@@ -535,11 +538,12 @@ func TestDiscoverUrlFederation(t *testing.T) {
 		defer cancel()
 
 		// Call the function with the server URL and the context
-		_, err := DiscoverUrlFederation(ctx, server.URL)
+		_, err = DiscoverUrlFederation(ctx, server.URL)
 
 		// Assert that the error is the expected metadata timeout error
 		assert.Error(t, err)
 		assert.True(t, errors.Is(err, MetadataTimeoutErr))
+		viper.Reset()
 	})
 
 	t.Run("TestCanceledContext", func(t *testing.T) {
@@ -562,6 +566,9 @@ func TestDiscoverUrlFederation(t *testing.T) {
 	})
 
 	t.Run("TestValidDiscovery", func(t *testing.T) {
+		viper.Set("tlsskipverify", true)
+		err := InitClient()
+		assert.NoError(t, err)
 		// Server to be a "mock" federation
 		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// make our response:
@@ -594,5 +601,6 @@ func TestDiscoverUrlFederation(t *testing.T) {
 		assert.Equal(t, "registry", metadata.NamespaceRegistrationEndpoint, "Unexpected NamespaceRegistrationEndpoint")
 		assert.Equal(t, "jwks", metadata.JwksUri, "Unexpected JwksUri")
 		assert.Equal(t, "broker", metadata.BrokerEndpoint, "Unexpected BrokerEndpoint")
+		viper.Reset()
 	})
 }

--- a/github_scripts/get_put_test.sh
+++ b/github_scripts/get_put_test.sh
@@ -28,7 +28,6 @@ chmod 777 get_put_tmp/origin
 
 # Setup env variables needed
 export PELICAN_FEDERATION_DIRECTORURL="https://$HOSTNAME:8444"
-export PELICAN_DIRECTOR_DEFAULTRESPONSE="origins"
 export PELICAN_FEDERATION_REGISTRYURL="https://$HOSTNAME:8444"
 export PELICAN_TLSSKIPVERIFY=true
 export PELICAN_ORIGIN_ENABLEDIRECTREADS=true
@@ -124,7 +123,7 @@ do
 done
 
 # Run pelican object put
-./pelican object put input.txt pelican://$HOSTNAME:8444/test/input.txt -d -t token -l putOutput.txt
+./pelican object put ./get_put_tmp/input.txt pelican://$HOSTNAME:8444/test/input.txt -d -t get_put_tmp/test-token.jwt -l get_put_tmp/putOutput.txt
 
 # Check output of command
 if grep -q "Dumping response: HTTP/1.1 200 OK" get_put_tmp/putOutput.txt; then
@@ -135,7 +134,7 @@ else
     exit 1
 fi
 
-./pelican object get pelican://$HOSTNAME:8444/test/input.txt output.txt -d -t token -l getOutput.txt
+./pelican object get pelican://$HOSTNAME:8444/test/input.txt get_put_tmp/output.txt -d -t get_put_tmp/test-token.jwt -l get_put_tmp/getOutput.txt
 
 # Check output of command
 if grep -q "HTTP Transfer was successful" get_put_tmp/getOutput.txt; then

--- a/github_scripts/get_put_test.sh
+++ b/github_scripts/get_put_test.sh
@@ -28,6 +28,7 @@ chmod 777 get_put_tmp/origin
 
 # Setup env variables needed
 export PELICAN_FEDERATION_DIRECTORURL="https://$HOSTNAME:8444"
+export PELICAN_DIRECTOR_DEFAULTRESPONSE="origins"
 export PELICAN_FEDERATION_REGISTRYURL="https://$HOSTNAME:8444"
 export PELICAN_TLSSKIPVERIFY=true
 export PELICAN_ORIGIN_ENABLEDIRECTREADS=true
@@ -123,7 +124,7 @@ do
 done
 
 # Run pelican object put
-./pelican object put ./get_put_tmp/input.txt pelican:///test/input.txt -d -t get_put_tmp/test-token.jwt -l get_put_tmp/putOutput.txt
+./pelican object put input.txt pelican://$HOSTNAME:8444/test/input.txt -d -t token -l putOutput.txt
 
 # Check output of command
 if grep -q "Dumping response: HTTP/1.1 200 OK" get_put_tmp/putOutput.txt; then
@@ -134,7 +135,7 @@ else
     exit 1
 fi
 
-./pelican object get pelican:///test/input.txt get_put_tmp/output.txt -d -t get_put_tmp/test-token.jwt -l get_put_tmp/getOutput.txt
+./pelican object get pelican://$HOSTNAME:8444/test/input.txt output.txt -d -t token -l getOutput.txt
 
 # Check output of command
 if grep -q "HTTP Transfer was successful" get_put_tmp/getOutput.txt; then

--- a/local_cache/cache_test.go
+++ b/local_cache/cache_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/pelicanplatform/pelican/fed_test_utils"
 	local_cache "github.com/pelicanplatform/pelican/local_cache"
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/test_utils"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
 	"github.com/pelicanplatform/pelican/utils"
@@ -147,13 +148,16 @@ func TestClient(t *testing.T) {
 	viper.Reset()
 	ft := fed_test_utils.NewFedTest(t, authOriginCfg)
 
+	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	te := client.NewTransferEngine(ctx)
+
 	cacheUrl := &url.URL{
 		Scheme: "unix",
 		Path:   param.LocalCache_Socket.GetString(),
 	}
 
 	t.Run("correct-auth", func(t *testing.T) {
-		tr, err := client.DoGet(ft.Ctx, "pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt",
+		tr, err := client.DoGet(te, "pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt",
 			filepath.Join(tmpDir, "hello_world.txt"), false, client.WithToken(ft.Token), client.WithCaches(cacheUrl), client.WithAcquireToken(false))
 		assert.NoError(t, err)
 		require.Equal(t, 1, len(tr))
@@ -165,7 +169,7 @@ func TestClient(t *testing.T) {
 		assert.Equal(t, "Hello, World!", string(byteBuff))
 	})
 	t.Run("incorrect-auth", func(t *testing.T) {
-		_, err := client.DoGet(ft.Ctx, "pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt",
+		_, err := client.DoGet(te, "pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt",
 			filepath.Join(tmpDir, "hello_world.txt"), false, client.WithToken("badtoken"), client.WithCaches(cacheUrl), client.WithAcquireToken(false))
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, &client.ConnectionSetupError{})
@@ -188,10 +192,21 @@ func TestClient(t *testing.T) {
 		token, err := tokConf.CreateToken()
 		require.NoError(t, err)
 
-		_, err = client.DoGet(ft.Ctx, "pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt.1",
+		_, err = client.DoGet(te, "pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt.1",
 			filepath.Join(tmpDir, "hello_world.txt.1"), false, client.WithToken(token), client.WithCaches(cacheUrl), client.WithAcquireToken(false))
 		assert.Error(t, err)
 		assert.Equal(t, "failed to download file: transfer error: failed connection setup: server returned 404 Not Found", err.Error())
+	})
+	t.Cleanup(func() {
+		cancel()
+		if err := egrp.Wait(); err != nil && err != context.Canceled && err != http.ErrServerClosed {
+			require.NoError(t, err)
+		}
+		if err := te.Shutdown(); err != nil {
+			log.Errorln("Failure when shutting down transfer engine:", err)
+		}
+		// Throw in a viper.Reset for good measure. Keeps our env squeaky clean!
+		viper.Reset()
 	})
 }
 
@@ -256,6 +271,9 @@ func TestLargeFile(t *testing.T) {
 	viper.Set("Client.MaximumDownloadSpeed", 40*1024*1024)
 	ft := fed_test_utils.NewFedTest(t, pubOriginCfg)
 
+	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	te := client.NewTransferEngine(ctx)
+
 	cacheUrl := &url.URL{
 		Scheme: "unix",
 		Path:   param.LocalCache_Socket.GetString(),
@@ -266,12 +284,24 @@ func TestLargeFile(t *testing.T) {
 	size := writeBigBuffer(t, fp, 100)
 
 	require.NoError(t, err)
-	tr, err := client.DoGet(ft.Ctx, "pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt",
+	tr, err := client.DoGet(te, "pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt",
 		filepath.Join(tmpDir, "hello_world.txt"), false, client.WithCaches(cacheUrl))
 	assert.NoError(t, err)
 	require.Equal(t, 1, len(tr))
 	assert.Equal(t, int64(size), tr[0].TransferredBytes)
 	assert.NoError(t, tr[0].Error)
+
+	t.Cleanup(func() {
+		cancel()
+		if err := egrp.Wait(); err != nil && err != context.Canceled && err != http.ErrServerClosed {
+			require.NoError(t, err)
+		}
+		if err := te.Shutdown(); err != nil {
+			log.Errorln("Failure when shutting down transfer engine:", err)
+		}
+		// Throw in a viper.Reset for good measure. Keeps our env squeaky clean!
+		viper.Reset()
+	})
 
 }
 
@@ -283,6 +313,9 @@ func TestPurge(t *testing.T) {
 	viper.Reset()
 	viper.Set("LocalCache.Size", "5MB")
 	ft := fed_test_utils.NewFedTest(t, pubOriginCfg)
+
+	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	te := client.NewTransferEngine(ctx)
 
 	cacheUrl := &url.URL{
 		Scheme: "unix",
@@ -299,7 +332,7 @@ func TestPurge(t *testing.T) {
 	require.NotEqual(t, 0, size)
 
 	for idx := 0; idx < 5; idx++ {
-		tr, err := client.DoGet(ft.Ctx, fmt.Sprintf("pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt.%d", idx),
+		tr, err := client.DoGet(te, fmt.Sprintf("pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt.%d", idx),
 			filepath.Join(tmpDir, fmt.Sprintf("hello_world.txt.%d", idx)), false, client.WithCaches(cacheUrl))
 		assert.NoError(t, err)
 		require.Equal(t, 1, len(tr))
@@ -320,6 +353,17 @@ func TestPurge(t *testing.T) {
 			defer fp.Close()
 		}()
 	}
+	t.Cleanup(func() {
+		cancel()
+		if err := egrp.Wait(); err != nil && err != context.Canceled && err != http.ErrServerClosed {
+			require.NoError(t, err)
+		}
+		if err := te.Shutdown(); err != nil {
+			log.Errorln("Failure when shutting down transfer engine:", err)
+		}
+		// Throw in a viper.Reset for good measure. Keeps our env squeaky clean!
+		viper.Reset()
+	})
 }
 
 // Create four 1MB files (above low-water mark).  Force a purge, ensuring that the cleanup is
@@ -332,6 +376,9 @@ func TestForcePurge(t *testing.T) {
 	// Decrease the low water mark so invoking purge will result in 3 files in the cache.
 	viper.Set("LocalCache.LowWaterMarkPercentage", "80")
 	ft := fed_test_utils.NewFedTest(t, pubOriginCfg)
+
+	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	te := client.NewTransferEngine(ctx)
 
 	issuer, err := config.GetServerIssuerURL()
 	require.NoError(t, err)
@@ -365,7 +412,7 @@ func TestForcePurge(t *testing.T) {
 	require.NotEqual(t, 0, size)
 
 	for idx := 0; idx < 4; idx++ {
-		tr, err := client.DoGet(ft.Ctx, fmt.Sprintf("pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt.%d", idx),
+		tr, err := client.DoGet(te, fmt.Sprintf("pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt.%d", idx),
 			filepath.Join(tmpDir, fmt.Sprintf("hello_world.txt.%d", idx)), false, client.WithCaches(cacheUrl))
 		assert.NoError(t, err)
 		require.Equal(t, 1, len(tr))
@@ -397,4 +444,15 @@ func TestForcePurge(t *testing.T) {
 			defer fp.Close()
 		}()
 	}
+	t.Cleanup(func() {
+		cancel()
+		if err := egrp.Wait(); err != nil && err != context.Canceled && err != http.ErrServerClosed {
+			require.NoError(t, err)
+		}
+		if err := te.Shutdown(); err != nil {
+			log.Errorln("Failure when shutting down transfer engine:", err)
+		}
+		// Throw in a viper.Reset for good measure. Keeps our env squeaky clean!
+		viper.Reset()
+	})
 }

--- a/local_cache/cache_test.go
+++ b/local_cache/cache_test.go
@@ -31,6 +31,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -152,11 +153,8 @@ func TestClient(t *testing.T) {
 	}
 
 	t.Run("correct-auth", func(t *testing.T) {
-		discoveryHost := param.Federation_DiscoveryUrl.GetString()
-		discoveryUrl, err := url.Parse(discoveryHost)
-		require.NoError(t, err)
-		tr, err := client.DoGet(ft.Ctx, "pelican://"+discoveryUrl.Host+"/test/hello_world.txt", filepath.Join(tmpDir, "hello_world.txt"), false,
-			client.WithToken(ft.Token), client.WithCaches(cacheUrl), client.WithAcquireToken(false))
+		tr, err := client.DoGet(ft.Ctx, "pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt",
+			filepath.Join(tmpDir, "hello_world.txt"), false, client.WithToken(ft.Token), client.WithCaches(cacheUrl), client.WithAcquireToken(false))
 		assert.NoError(t, err)
 		require.Equal(t, 1, len(tr))
 		assert.Equal(t, int64(13), tr[0].TransferredBytes)
@@ -167,8 +165,8 @@ func TestClient(t *testing.T) {
 		assert.Equal(t, "Hello, World!", string(byteBuff))
 	})
 	t.Run("incorrect-auth", func(t *testing.T) {
-		_, err := client.DoGet(ft.Ctx, "pelican:///test/hello_world.txt", filepath.Join(tmpDir, "hello_world.txt"), false,
-			client.WithToken("badtoken"), client.WithCaches(cacheUrl), client.WithAcquireToken(false))
+		_, err := client.DoGet(ft.Ctx, "pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt",
+			filepath.Join(tmpDir, "hello_world.txt"), false, client.WithToken("badtoken"), client.WithCaches(cacheUrl), client.WithAcquireToken(false))
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, &client.ConnectionSetupError{})
 		var cse *client.ConnectionSetupError
@@ -190,8 +188,8 @@ func TestClient(t *testing.T) {
 		token, err := tokConf.CreateToken()
 		require.NoError(t, err)
 
-		_, err = client.DoGet(ft.Ctx, "pelican:///test/hello_world.txt.1", filepath.Join(tmpDir, "hello_world.txt.1"), false,
-			client.WithToken(token), client.WithCaches(cacheUrl), client.WithAcquireToken(false))
+		_, err = client.DoGet(ft.Ctx, "pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt.1",
+			filepath.Join(tmpDir, "hello_world.txt.1"), false, client.WithToken(token), client.WithCaches(cacheUrl), client.WithAcquireToken(false))
 		assert.Error(t, err)
 		assert.Equal(t, "failed to download file: transfer error: failed connection setup: server returned 404 Not Found", err.Error())
 	})
@@ -267,11 +265,9 @@ func TestLargeFile(t *testing.T) {
 	require.NoError(t, err)
 	size := writeBigBuffer(t, fp, 100)
 
-	discoveryHost := param.Federation_DiscoveryUrl.GetString()
-	discoveryUrl, err := url.Parse(discoveryHost)
 	require.NoError(t, err)
-	tr, err := client.DoGet(ft.Ctx, "pelican://"+discoveryUrl.Host+"/test/hello_world.txt", filepath.Join(tmpDir, "hello_world.txt"), false,
-		client.WithCaches(cacheUrl))
+	tr, err := client.DoGet(ft.Ctx, "pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt",
+		filepath.Join(tmpDir, "hello_world.txt"), false, client.WithCaches(cacheUrl))
 	assert.NoError(t, err)
 	require.Equal(t, 1, len(tr))
 	assert.Equal(t, int64(size), tr[0].TransferredBytes)
@@ -303,8 +299,8 @@ func TestPurge(t *testing.T) {
 	require.NotEqual(t, 0, size)
 
 	for idx := 0; idx < 5; idx++ {
-		tr, err := client.DoGet(ft.Ctx, fmt.Sprintf("pelican:///test/hello_world.txt.%d", idx), filepath.Join(tmpDir, fmt.Sprintf("hello_world.txt.%d", idx)), false,
-			client.WithCaches(cacheUrl))
+		tr, err := client.DoGet(ft.Ctx, fmt.Sprintf("pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt.%d", idx),
+			filepath.Join(tmpDir, fmt.Sprintf("hello_world.txt.%d", idx)), false, client.WithCaches(cacheUrl))
 		assert.NoError(t, err)
 		require.Equal(t, 1, len(tr))
 		assert.Equal(t, int64(size), tr[0].TransferredBytes)
@@ -369,8 +365,8 @@ func TestForcePurge(t *testing.T) {
 	require.NotEqual(t, 0, size)
 
 	for idx := 0; idx < 4; idx++ {
-		tr, err := client.DoGet(ft.Ctx, fmt.Sprintf("pelican:///test/hello_world.txt.%d", idx), filepath.Join(tmpDir, fmt.Sprintf("hello_world.txt.%d", idx)), false,
-			client.WithCaches(cacheUrl))
+		tr, err := client.DoGet(ft.Ctx, fmt.Sprintf("pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt.%d", idx),
+			filepath.Join(tmpDir, fmt.Sprintf("hello_world.txt.%d", idx)), false, client.WithCaches(cacheUrl))
 		assert.NoError(t, err)
 		require.Equal(t, 1, len(tr))
 		assert.Equal(t, int64(size), tr[0].TransferredBytes)

--- a/local_cache/local_cache.go
+++ b/local_cache/local_cache.go
@@ -507,7 +507,7 @@ func (sc *LocalCache) runMux() error {
 			sourceURL := *sc.directorURL
 			sourceURL.Path = path.Join(sourceURL.Path, path.Clean(req.request.path))
 			sourceURL.Scheme = "pelican"
-			tj, err := sc.tc.NewTransferJob(&sourceURL, localPath, false, false, "localcache", client.WithToken(req.request.token))
+			tj, err := sc.tc.NewTransferJob(&sourceURL, localPath, sc.te, false, false, "localcache", client.WithToken(req.request.token))
 			if err != nil {
 				ds := &downloadStatus{}
 				ds.err.Store(&err)

--- a/local_cache/local_cache.go
+++ b/local_cache/local_cache.go
@@ -506,6 +506,7 @@ func (sc *LocalCache) runMux() error {
 
 			sourceURL := *sc.directorURL
 			sourceURL.Path = path.Join(sourceURL.Path, path.Clean(req.request.path))
+			sourceURL.Scheme = "pelican"
 			tj, err := sc.tc.NewTransferJob(&sourceURL, localPath, false, false, "localcache", client.WithToken(req.request.token))
 			if err != nil {
 				ds := &downloadStatus{}

--- a/local_cache/local_cache.go
+++ b/local_cache/local_cache.go
@@ -507,7 +507,7 @@ func (sc *LocalCache) runMux() error {
 			sourceURL := *sc.directorURL
 			sourceURL.Path = path.Join(sourceURL.Path, path.Clean(req.request.path))
 			sourceURL.Scheme = "pelican"
-			tj, err := sc.tc.NewTransferJob(&sourceURL, localPath, sc.te, false, false, "localcache", client.WithToken(req.request.token))
+			tj, err := sc.tc.NewTransferJob(&sourceURL, localPath, false, false, "localcache", client.WithToken(req.request.token))
 			if err != nil {
 				ds := &downloadStatus{}
 				ds.err.Store(&err)

--- a/namespaces/namespaces_test.go
+++ b/namespaces/namespaces_test.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"testing"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -106,9 +105,7 @@ func TestMatchNamespace(t *testing.T) {
 	assert.NoError(t, err)
 	defer func() {
 		_, err := config.SetPreferredPrefix(oldPrefix)
-		if err != nil {
-			log.Errorln(err)
-		}
+		assert.NoError(t, err)
 	}()
 
 	viper.Reset()
@@ -259,9 +256,7 @@ func TestGetNamespaces(t *testing.T) {
 	assert.NoError(t, err)
 	defer func() {
 		_, err := config.SetPreferredPrefix(oldPrefix)
-		if err != nil {
-			log.Errorln(err)
-		}
+		assert.NoError(t, err)
 	}()
 	viper.Reset()
 	err = config.InitClient()

--- a/namespaces/namespaces_test.go
+++ b/namespaces/namespaces_test.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"testing"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -103,7 +104,12 @@ func TestMatchNamespace(t *testing.T) {
 	// Reset the prefix to get old OSDF fallback behavior.
 	oldPrefix, err := config.SetPreferredPrefix("OSDF")
 	assert.NoError(t, err)
-	defer config.SetPreferredPrefix(oldPrefix)
+	defer func() {
+		_, err := config.SetPreferredPrefix(oldPrefix)
+		if err != nil {
+			log.Errorln(err)
+		}
+	}()
 
 	viper.Reset()
 	err = config.InitClient()
@@ -251,7 +257,12 @@ func TestGetNamespaces(t *testing.T) {
 	os.Setenv("OSDF_TOPOLOGY_NAMESPACE_URL", "https://doesnotexist.org.blah/namespaces.json")
 	oldPrefix, err := config.SetPreferredPrefix("OSDF")
 	assert.NoError(t, err)
-	defer config.SetPreferredPrefix(oldPrefix)
+	defer func() {
+		_, err := config.SetPreferredPrefix(oldPrefix)
+		if err != nil {
+			log.Errorln(err)
+		}
+	}()
 	viper.Reset()
 	err = config.InitClient()
 	assert.Nil(t, err)

--- a/namespaces/namespaces_test.go
+++ b/namespaces/namespaces_test.go
@@ -101,7 +101,8 @@ func TestMatchNamespace(t *testing.T) {
 		t.Error(err)
 	}
 	// Reset the prefix to get old OSDF fallback behavior.
-	oldPrefix := config.SetPreferredPrefix("OSDF")
+	oldPrefix, err := config.SetPreferredPrefix("OSDF")
+	assert.NoError(t, err)
 	defer config.SetPreferredPrefix(oldPrefix)
 
 	viper.Reset()
@@ -248,10 +249,11 @@ func TestDownloadNamespacesFail(t *testing.T) {
 func TestGetNamespaces(t *testing.T) {
 	// Set the environment to an invalid URL, so it is forced to use the "built-in" namespaces.json
 	os.Setenv("OSDF_TOPOLOGY_NAMESPACE_URL", "https://doesnotexist.org.blah/namespaces.json")
-	oldPrefix := config.SetPreferredPrefix("OSDF")
+	oldPrefix, err := config.SetPreferredPrefix("OSDF")
+	assert.NoError(t, err)
 	defer config.SetPreferredPrefix(oldPrefix)
 	viper.Reset()
-	err := config.InitClient()
+	err = config.InitClient()
 	assert.Nil(t, err)
 	defer os.Unsetenv("OSDF_TOPOLOGY_NAMESPACE_URL")
 	namespaces, err := GetNamespaces()

--- a/registry/client_commands_test.go
+++ b/registry/client_commands_test.go
@@ -130,7 +130,8 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 	defer cancel()
 
 	viper.Reset()
-	_ = config.SetPreferredPrefix("OSDF")
+	_, err := config.SetPreferredPrefix("OSDF")
+	assert.NoError(t, err)
 	viper.Set("Federation.DirectorUrl", "https://osdf-director.osg-htc.org")
 	viper.Set("Federation.RegistryUrl", "https://osdf-registry.osg-htc.org")
 	viper.Set("Federation.JwkUrl", "https://osg-htc.org/osdf/public_signing_key.jwks")
@@ -142,7 +143,7 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 	registrySvr := registryMockup(ctx, t, "OSDFkeychaining")
 	topoSvr := topologyMockup(t, []string{"/topo/foo"})
 	viper.Set("Federation.TopologyNamespaceURL", topoSvr.URL)
-	err := createTopologyTable()
+	err = createTopologyTable()
 	require.NoError(t, err)
 	err = PopulateTopology()
 	require.NoError(t, err)
@@ -212,7 +213,8 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo")
 	require.NoError(t, err)
 
-	config.SetPreferredPrefix("pelican")
+	_, err = config.SetPreferredPrefix("pelican")
+	assert.NoError(t, err)
 	viper.Reset()
 }
 

--- a/registry/registry_db_test.go
+++ b/registry/registry_db_test.go
@@ -756,7 +756,8 @@ func TestRegistryTopology(t *testing.T) {
 	}()
 
 	// Set value so that config.GetPreferredPrefix() returns "OSDF"
-	config.SetPreferredPrefix("OSDF")
+	_, err = config.SetPreferredPrefix("OSDF")
+	assert.NoError(t, err)
 
 	//Test topology table population
 	err = createTopologyTable()

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -278,7 +279,12 @@ func TestOSDFAuthCreation(t *testing.T) {
 			}
 			oldPrefix, err := config.SetPreferredPrefix("OSDF")
 			assert.NoError(t, err)
-			defer config.SetPreferredPrefix(oldPrefix)
+			defer func() {
+				_, err := config.SetPreferredPrefix(oldPrefix)
+				if err != nil {
+					log.Errorln(err)
+				}
+			}()
 
 			err = os.WriteFile(filepath.Join(dirName, "authfile"), []byte(testInput.authIn), fs.FileMode(0600))
 			require.NoError(t, err, "Failure writing test input authfile")

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -43,7 +43,6 @@ import (
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -281,9 +280,7 @@ func TestOSDFAuthCreation(t *testing.T) {
 			assert.NoError(t, err)
 			defer func() {
 				_, err := config.SetPreferredPrefix(oldPrefix)
-				if err != nil {
-					log.Errorln(err)
-				}
+				require.NoError(t, err)
 			}()
 
 			err = os.WriteFile(filepath.Join(dirName, "authfile"), []byte(testInput.authIn), fs.FileMode(0600))

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -276,10 +276,11 @@ func TestOSDFAuthCreation(t *testing.T) {
 				viper.Set("Origin.RunLocation", dirName)
 				xrootdRun = param.Origin_RunLocation.GetString()
 			}
-			oldPrefix := config.SetPreferredPrefix("OSDF")
+			oldPrefix, err := config.SetPreferredPrefix("OSDF")
+			assert.NoError(t, err)
 			defer config.SetPreferredPrefix(oldPrefix)
 
-			err := os.WriteFile(filepath.Join(dirName, "authfile"), []byte(testInput.authIn), fs.FileMode(0600))
+			err = os.WriteFile(filepath.Join(dirName, "authfile"), []byte(testInput.authIn), fs.FileMode(0600))
 			require.NoError(t, err, "Failure writing test input authfile")
 
 			err = EmitAuthfile(testInput.server)

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -283,7 +283,7 @@ func CheckCacheXrootdEnv(exportPath string, server server_structs.XRootDServer, 
 			filepath.Dir(metaPath))
 	}
 
-	err = config.DiscoverFederation()
+	err = config.DiscoverFederation(context.Background())
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to pull information from the federation")
 	}


### PR DESCRIPTION
This is v2 of PR #798  since the merge conflicts were becoming very tedious. Therefore, I took the changes from that PR and converted it over to a new branch. You can get the changes split up a little better from that PR as well but I will do my best to list them here:

Changes include:
- Added a ttl cache for storing federation url metadata so we do not have to look up each time
- Improved unit tests for client commands, Note: for pelican prefix and osdf:// url scheme, it's hard to test since we use osg-htc.org for metadata lookup. Therefore it is hard to work with fed in a box so I just check for the proper metadata lookup
- Added function called discoverUrlFederation which discovers a federation from a url and does not populate global metadata config values
- Added a function called schemeUnderstood to take some repeated code within client into one function to check for understood url schemes
- Added unit tests for discoverUrlFederation and schemeUnderstood