### PR TITLE
Clean up goroutines when fatal error occurs at server start

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,7 +87,7 @@ func Execute() error {
 	ctx := context.WithValue(egrpCtx, config.EgrpKey, egrp)
 	exeErr := rootCmd.ExecuteContext(ctx)
 	if exeErr != nil {
-		log.Errorln("Fatal error occurred at the start of the program. Cheanup started:", exeErr)
+		log.Errorln("Fatal error occurred at the start of the program. Cleanup started:", exeErr)
 	}
 	// Wait until all goroutines in errgroup finish their clean up
 	egrpErr := egrp.Wait()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,7 +103,6 @@ func Execute() error {
 		log.Errorln("Fatal error occurred that lead to the shutdown of the process:", egrpErr)
 		return egrpErr
 	} else {
-		fmt.Println("Pelican clean up finished")
 		return exeErr
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,7 +87,7 @@ func Execute() error {
 	ctx := context.WithValue(egrpCtx, config.EgrpKey, egrp)
 	exeErr := rootCmd.ExecuteContext(ctx)
 	if exeErr != nil {
-		log.Errorln("Fatal error occurred at the start of the program. Chean up started:", exeErr)
+		log.Errorln("Fatal error occurred at the start of the program. Cheanup started:", exeErr)
 	}
 	// Wait until all goroutines in errgroup finish their clean up
 	egrpErr := egrp.Wait()
@@ -98,7 +98,7 @@ func Execute() error {
 		fmt.Println("Restarting server...")
 		return restartProgram()
 	}
-	// Other errors we from the errogroup
+	// Other errors we got from the errogroup
 	if egrpErr != nil {
 		log.Errorln("Fatal error occurred that lead to the shutdown of the process:", egrpErr)
 		return egrpErr

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,25 +85,27 @@ func (i *uint16Value) String() string { return strconv.FormatUint(uint64(*i), 10
 func Execute() error {
 	egrp, egrpCtx := errgroup.WithContext(context.Background())
 	ctx := context.WithValue(egrpCtx, config.EgrpKey, egrp)
-	err := rootCmd.ExecuteContext(ctx)
-	if err != nil {
-		log.Errorln("Fatal error occurred at the start of the program:", err)
-		return err
+	exeErr := rootCmd.ExecuteContext(ctx)
+	if exeErr != nil {
+		log.Errorln("Fatal error occurred at the start of the program. Chean up started:", exeErr)
 	}
-	// Wait until all goroutines in errgroup return
-	err = egrp.Wait()
-	if err == launchers.ErrExitOnSignal {
+	// Wait until all goroutines in errgroup finish their clean up
+	egrpErr := egrp.Wait()
+	if egrpErr == launchers.ErrExitOnSignal {
 		fmt.Println("Pelican is safely exited")
 		return nil
-	} else if err == launchers.ErrRestart {
+	} else if egrpErr == launchers.ErrRestart {
 		fmt.Println("Restarting server...")
 		return restartProgram()
 	}
-	if err != nil {
-		log.Errorln("Fatal error occurred that lead to the shutdown of the process:", err)
-		return err
+	// Other errors we from the errogroup
+	if egrpErr != nil {
+		log.Errorln("Fatal error occurred that lead to the shutdown of the process:", egrpErr)
+		return egrpErr
+	} else {
+		fmt.Println("Pelican clean up finished")
+		return exeErr
 	}
-	return nil
 }
 
 func restartProgram() error {


### PR DESCRIPTION
Fixes #868 

There are two issues causing the bug:
1. We return immediately if `err := rootCmd.ExecuteContext(ctx); err != nil`, not waiting for error group to clean up.
2. We didn't kill daemons if the `ctx` parameter is cancelled, which is the case when there's error from server goroutines (where it will call shutdownCancel). We only did it either when receiving OS signal or the daemon expires.