### PR TITLE
Remove `Federation.NamespaceUrl`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -697,8 +697,8 @@ func InitConfig() {
 	}
 
 	if oldNsUrl := viper.GetString("Federation.NamespaceUrl"); oldNsUrl != "" {
-		log.Warningln("Federation.NamespaceUrl is deprecated and will be removed in future release. Please migrate to use Federation.RegistryUrl instead")
-		viper.SetDefault("Federation.RegistryUrl", oldNsUrl)
+		log.Errorln("Federation.NamespaceUrl is deprecated and removed from parameters. Please use Federation.RegistryUrl instead")
+		os.Exit(1)
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,11 +29,8 @@ import (
 	"time"
 
 	"github.com/pelicanplatform/pelican/param"
-	"github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var server *httptest.Server
@@ -156,38 +153,6 @@ func TestInitConfig(t *testing.T) {
 	}
 	InitConfig()
 	assert.Equal(t, "", param.Federation_DiscoveryUrl.GetString())
-}
-
-func TestDeprecateLogMessage(t *testing.T) {
-	t.Run("expect-deprecated-message-if-namespace-url-is-set", func(t *testing.T) {
-		hook := test.NewGlobal()
-		viper.Reset()
-		// The default value is set to Error, but this is a warning message
-		viper.Set("Logging.Level", "Warning")
-		viper.Set("Federation.NamespaceUrl", "https://dont-use.com")
-		InitConfig()
-
-		require.Equal(t, 1, len(hook.Entries))
-		assert.Equal(t, logrus.WarnLevel, hook.LastEntry().Level)
-		assert.Equal(t, "Federation.NamespaceUrl is deprecated and will be removed in future release. Please migrate to use Federation.RegistryUrl instead", hook.LastEntry().Message)
-		// We expect the default value of Federation.RegistryUrl is set to Federation.NamespaceUrl
-		// if Federation.NamespaceUrl is not empty for backward compatibility
-		assert.Equal(t, "https://dont-use.com", viper.GetString("Federation.RegistryUrl"))
-		hook.Reset()
-	})
-
-	t.Run("no-deprecated-message-if-namespace-url-unset", func(t *testing.T) {
-		hook := test.NewGlobal()
-		viper.Reset()
-		viper.Set("Logging.Level", "Warning")
-		viper.Set("Federation.RegistryUrl", "https://dont-use.com")
-		InitConfig()
-
-		assert.Equal(t, 0, len(hook.Entries))
-		assert.Equal(t, "https://dont-use.com", viper.GetString("Federation.RegistryUrl"))
-		assert.Equal(t, "", viper.GetString("Federation.NamespaceUrl"))
-		hook.Reset()
-	})
 }
 
 func TestEnabledServers(t *testing.T) {

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -237,17 +237,6 @@ osdf_default: Default is determined dynamically through metadata at <Federation.
 default: none
 components: ["client", "origin", "cache"]
 ---
-name: Federation.NamespaceUrl
-description: >-
-  [Deprecated] `Federation.NamespaceUrl` is deprecated and will be removed in the future release. Please migrate to use
-  `Federation.RegistryUrl` instead.
-
-  A URL indicating where the namespace registry service is hosted.
-type: url
-osdf_default: Default is determined dynamically through metadata at <Federation.DiscoveryUrl>/.well-known/pelican-configuration
-default: none
-components: ["client", "director", "origin", "cache"]
----
 name: Federation.RegistryUrl
 description: >-
   A URL indicating where the namespace registry service is hosted.

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -86,7 +86,6 @@ var (
 	Federation_DirectorUrl = StringParam{"Federation.DirectorUrl"}
 	Federation_DiscoveryUrl = StringParam{"Federation.DiscoveryUrl"}
 	Federation_JwkUrl = StringParam{"Federation.JwkUrl"}
-	Federation_NamespaceUrl = StringParam{"Federation.NamespaceUrl"}
 	Federation_RegistryUrl = StringParam{"Federation.RegistryUrl"}
 	Federation_TopologyNamespaceUrl = StringParam{"Federation.TopologyNamespaceUrl"}
 	Federation_TopologyUrl = StringParam{"Federation.TopologyUrl"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -66,7 +66,6 @@ type Config struct {
 		DirectorUrl string
 		DiscoveryUrl string
 		JwkUrl string
-		NamespaceUrl string
 		RegistryUrl string
 		TopologyNamespaceUrl string
 		TopologyReloadInterval time.Duration
@@ -290,7 +289,6 @@ type configWithType struct {
 		DirectorUrl struct { Type string; Value string }
 		DiscoveryUrl struct { Type string; Value string }
 		JwkUrl struct { Type string; Value string }
-		NamespaceUrl struct { Type string; Value string }
 		RegistryUrl struct { Type string; Value string }
 		TopologyNamespaceUrl struct { Type string; Value string }
 		TopologyReloadInterval struct { Type string; Value time.Duration }


### PR DESCRIPTION
Closes #886 

@turetske If this is merged in before 7.6 release, we should note the breaking change in the release note