### PR TITLE
Unit test for statHttp within Pelican Client

### DIFF
--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -436,7 +436,7 @@ func TestStatHttp(t *testing.T) {
 		objectSize, err := client.DoStat(ctx, uploadURL)
 		assert.NoError(t, err)
 		if err == nil {
-				assert.Equal(t, int64(17), int64(objectSize))
+			assert.Equal(t, int64(17), int64(objectSize))
 		}
 	})
 
@@ -462,7 +462,7 @@ func TestStatHttp(t *testing.T) {
 		objectSize, err := client.DoStat(ctx, uploadURL)
 		assert.NoError(t, err)
 		if err == nil {
-				assert.Equal(t, int64(17), int64(objectSize))
+			assert.Equal(t, int64(17), int64(objectSize))
 		}
 	})
 

--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -406,3 +406,87 @@ func TestGetPublicRead(t *testing.T) {
 		}
 	})
 }
+
+// A test that tests the statHttp function
+func TestStatHttp(t *testing.T) {
+	ctx, _, _ := test_utils.TestContext(context.Background(), t)
+	viper.Reset()
+	common.ResetOriginExports()
+
+	fed := fed_test_utils.NewFedTest(t, bothPublicOriginCfg)
+
+	t.Run("testStatHttpPelicanScheme", func(t *testing.T) {
+		testFileContent := "test file content"
+		// Drop the testFileContent into the origin directory
+		tempFile, err := os.Create(filepath.Join(((*fed.Exports)[0]).StoragePrefix, "test.txt"))
+		assert.NoError(t, err, "Error creating temp file")
+		defer os.Remove(tempFile.Name())
+		_, err = tempFile.WriteString(testFileContent)
+		assert.NoError(t, err, "Error writing to temp file")
+		tempFile.Close()
+
+		viper.Set("Logging.DisableProgressBars", true)
+
+		// Set path for object to upload/download
+		tempPath := tempFile.Name()
+		fileName := filepath.Base(tempPath)
+		uploadURL := fmt.Sprintf("pelican://%s/%s", ((*fed.Exports)[0]).FederationPrefix, fileName)
+
+		// Download the file with GET. Shouldn't need a token to succeed
+		objectSize, err := client.DoStat(ctx, uploadURL)
+		assert.NoError(t, err)
+		if err == nil {
+				assert.Equal(t, int64(17), int64(objectSize))
+		}
+	})
+
+	t.Run("testStatHttpOSDFScheme", func(t *testing.T) {
+		testFileContent := "test file content"
+		// Drop the testFileContent into the origin directory
+		tempFile, err := os.Create(filepath.Join(((*fed.Exports)[0]).StoragePrefix, "test.txt"))
+		assert.NoError(t, err, "Error creating temp file")
+		defer os.Remove(tempFile.Name())
+		_, err = tempFile.WriteString(testFileContent)
+		assert.NoError(t, err, "Error writing to temp file")
+		tempFile.Close()
+
+		viper.Set("Logging.DisableProgressBars", true)
+
+		// Set path for object to upload/download
+		tempPath := tempFile.Name()
+		fileName := filepath.Base(tempPath)
+		// Minimal fix of test as it is soon to be replaced
+		uploadURL := fmt.Sprintf("pelican://%s/%s", ((*fed.Exports)[0]).FederationPrefix, fileName)
+
+		// Download the file with GET. Shouldn't need a token to succeed
+		objectSize, err := client.DoStat(ctx, uploadURL)
+		assert.NoError(t, err)
+		if err == nil {
+				assert.Equal(t, int64(17), int64(objectSize))
+		}
+	})
+
+	t.Run("testStatHttpIncorrectScheme", func(t *testing.T) {
+		testFileContent := "test file content"
+		// Drop the testFileContent into the origin directory
+		tempFile, err := os.Create(filepath.Join(((*fed.Exports)[0]).StoragePrefix, "test.txt"))
+		assert.NoError(t, err, "Error creating temp file")
+		defer os.Remove(tempFile.Name())
+		_, err = tempFile.WriteString(testFileContent)
+		assert.NoError(t, err, "Error writing to temp file")
+		tempFile.Close()
+
+		viper.Set("Logging.DisableProgressBars", true)
+
+		// Set path for object to upload/download
+		tempPath := tempFile.Name()
+		fileName := filepath.Base(tempPath)
+		uploadURL := fmt.Sprintf("some://incorrect/scheme/%s", fileName)
+
+		// Download the file with GET. Shouldn't need a token to succeed
+		objectSize, err := client.DoStat(ctx, uploadURL)
+		assert.Error(t, err)
+		assert.Equal(t, uint64(0), objectSize)
+		assert.Contains(t, err.Error(), "Unsupported scheme requested")
+	})
+}

--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -411,7 +411,7 @@ func TestGetPublicRead(t *testing.T) {
 func TestStatHttp(t *testing.T) {
 	ctx, _, _ := test_utils.TestContext(context.Background(), t)
 	viper.Reset()
-	common.ResetOriginExports()
+	server_utils.ResetOriginExports()
 
 	fed := fed_test_utils.NewFedTest(t, bothPublicOriginCfg)
 
@@ -420,7 +420,6 @@ func TestStatHttp(t *testing.T) {
 		// Drop the testFileContent into the origin directory
 		tempFile, err := os.Create(filepath.Join(((*fed.Exports)[0]).StoragePrefix, "test.txt"))
 		assert.NoError(t, err, "Error creating temp file")
-		defer os.Remove(tempFile.Name())
 		_, err = tempFile.WriteString(testFileContent)
 		assert.NoError(t, err, "Error writing to temp file")
 		tempFile.Close()
@@ -445,7 +444,6 @@ func TestStatHttp(t *testing.T) {
 		// Drop the testFileContent into the origin directory
 		tempFile, err := os.Create(filepath.Join(((*fed.Exports)[0]).StoragePrefix, "test.txt"))
 		assert.NoError(t, err, "Error creating temp file")
-		defer os.Remove(tempFile.Name())
 		_, err = tempFile.WriteString(testFileContent)
 		assert.NoError(t, err, "Error writing to temp file")
 		tempFile.Close()
@@ -471,7 +469,6 @@ func TestStatHttp(t *testing.T) {
 		// Drop the testFileContent into the origin directory
 		tempFile, err := os.Create(filepath.Join(((*fed.Exports)[0]).StoragePrefix, "test.txt"))
 		assert.NoError(t, err, "Error creating temp file")
-		defer os.Remove(tempFile.Name())
 		_, err = tempFile.WriteString(testFileContent)
 		assert.NoError(t, err, "Error writing to temp file")
 		tempFile.Close()


### PR DESCRIPTION
Added unit test for statHttp within Pelican client. Note: this should not be merged until #884 is completed since currently statHttp only works with topology. Therefore, I expect tests to fail and I will readdress them once that PR is merged and this function is working properly.