### PR TITLE
Replace `pelican` with server name for production image

### DIFF
--- a/.github/workflows/build-prod-container.yml
+++ b/.github/workflows/build-prod-container.yml
@@ -124,11 +124,12 @@ jobs:
 
           echo $GITHUB_TAG
 
-          docker_repo="pelican_platform/pelican"
+          docker_repo="pelican_platform"
+          image_name=${{ matrix.image }}
           tag_list=()
           for registry in hub.opensciencegrid.org; do
             for image_tag in "$GITHUB_TAG"; do
-              tag_list+=("$registry/$docker_repo":"$image_tag")
+              tag_list+=("$registry/$docker_repo/$image_name":"$image_tag")
             done
           done
           # This causes the tag_list array to be comma-separated below,

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -118,7 +118,7 @@ if [ $# -ne 0 ]; then
         pelican)
             # Run pelican with the rest of the arguments
             echo "Running pelican with arguments: $@"
-            exec tini /pelican/pelican "$@"
+            exec tini -- /pelican/pelican "$@"
             # we shouldn't get here
             echo >&2 "Exec of tini failed!"
             exit 1
@@ -126,7 +126,7 @@ if [ $# -ne 0 ]; then
         osdf)
             # Run osdf with the rest of the arguments
             echo "Running osdf with arguments: $@"
-            exec tini /pelican/osdf "$@"
+            exec tini -- /pelican/osdf "$@"
             # we shouldn't get here
             echo >&2 "Exec of tini failed!"
             exit 1


### PR DESCRIPTION
I think I missed changing the docker image tag from `pelican_platform/pelican` to `pelican_platform/<server-name>`. This PR attempts to address the issue.

Update:
This PR also fixed the bug where pelican arguments can't be passed to tini