### PR TITLE
Configure 'sec.protbind' for public origins

### DIFF
--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -30,9 +30,9 @@ type Config struct {
 		EnableVoms bool
 		ExportLocation string
 		Port int
+		RunLocation string
 		SelfTest bool
 		SelfTestInterval time.Duration
-		RunLocation string
 		Url string
 		XRootDPrefix string
 	}
@@ -256,9 +256,9 @@ type configWithType struct {
 		EnableVoms struct { Type string; Value bool }
 		ExportLocation struct { Type string; Value string }
 		Port struct { Type string; Value int }
+		RunLocation struct { Type string; Value string }
 		SelfTest struct { Type string; Value bool }
 		SelfTestInterval struct { Type string; Value time.Duration }
-		RunLocation struct { Type string; Value string }
 		Url struct { Type string; Value string }
 		XRootDPrefix struct { Type string; Value string }
 	}

--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -31,6 +31,9 @@ xrd.tlsca certfile {{.Server.TLSCACertificateFile}}
 {{if eq .Origin.EnableDirListing false}}
 http.listingdeny true
 {{end}}
+{{if eq .Origin.EnablePublicReads true}}
+sec.protbind * none
+{{end}}
 {{if .Origin.EnableMacaroons}}
 http.exthandler xrdmacaroons libXrdMacaroons.so
 macaroons.secretkey {{.Xrootd.MacaroonsKeyFile}}

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -79,23 +79,24 @@ enable = true
 
 type (
 	OriginConfig struct {
-		Multiuser        bool
-		EnableCmsd       bool
-		EnableMacaroons  bool
-		EnableVoms       bool
-		EnableDirListing bool
-		SelfTest         bool
-		CalculatedPort   string
-		NamespacePrefix  string
-		RunLocation      string
-		Mode             string
-		S3Bucket         string
-		S3Region         string
-		S3ServiceName    string
-		S3ServiceUrl     string
-		S3AccessKeyfile  string
-		S3SecretKeyfile  string
-		S3UrlStyle       string
+		Multiuser         bool
+		EnableCmsd        bool
+		EnableMacaroons   bool
+		EnableVoms        bool
+		EnablePublicReads bool
+		EnableDirListing  bool
+		SelfTest          bool
+		CalculatedPort    string
+		NamespacePrefix   string
+		RunLocation       string
+		Mode              string
+		S3Bucket          string
+		S3Region          string
+		S3ServiceName     string
+		S3ServiceUrl      string
+		S3AccessKeyfile   string
+		S3SecretKeyfile   string
+		S3UrlStyle        string
 	}
 
 	CacheConfig struct {


### PR DESCRIPTION
Legacy caches won't work with public pelican origins without the ability to fallback to xroot protocol. This adds `sec.protbind * none` to the origin config if the origin is run with `Origin.EnablePublicReads: true`. Note that when we have multi-exports origins configured from #858, we'll have to handle this more carefully.

So that the reviewer doesn't have to hunt, the addition to the struct in `xrootd/xrootd_config` is `EnablePublicReads`. I had to adjust spacing to make the linter happy, and it buried the change.

To test, try running an origin with `Origin.EnablePublicReads` set to true and then to false. You should see the `sec.protbind * none` line appear in the xrootd config for public, and be absent for non-public.