### PR TITLE
Fix production cache container failure at start up due to outdated xrootd

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -57,6 +57,7 @@ RUN useradd -o -u 10940 -g 10940 -s /bin/sh xrootd
 
 # Install dependencies
 RUN yum -y update \
+    && yum -y install https://repo.opensciencegrid.org/osg/23-main/osg-23-main-el8-release-latest.rpm\
     && yum -y install tini xrootd xrootd-client xrdcl-http xrootd-server xrootd-scitokens xrootd-voms curl java-17-openjdk-headless \
     && yum clean all \
     && rm -rf /var/cache/yum/

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -220,7 +220,7 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (context.Canc
 
 	if modules.IsEnabled(config.CacheType) {
 		// Give five seconds for the origin to finish advertising to the director
-		desiredURL := param.Server_ExternalWebUrl.GetString() + "/.well-known/openid-configuration"
+		desiredURL := param.Federation_DirectorUrl.GetString() + "/.well-known/openid-configuration"
 		if err = server_utils.WaitUntilWorking(ctx, "GET", desiredURL, "director", 200); err != nil {
 			log.Errorln("Director does not seem to be working:", err)
 			return shutdownCancel, err

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -211,7 +211,7 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (context.Canc
 		if err = server_ui.Advertise(ctx, servers); err != nil {
 			return shutdownCancel, err
 		}
-		desiredURL := param.Server_ExternalWebUrl.GetString() + "/api/v1.0/director/origin" + param.Origin_NamespacePrefix.GetString()
+		desiredURL := param.Federation_DirectorUrl.GetString() + "/api/v1.0/director/origin" + param.Origin_NamespacePrefix.GetString()
 		if err = server_utils.WaitUntilWorking(ctx, "GET", desiredURL, "director", 307); err != nil {
 			log.Errorln("Origin does not seem to have advertised correctly:", err)
 			return shutdownCancel, err


### PR DESCRIPTION
Fixes #917 

Also fixes the bug where we check director's endpoint to ensure director is working but we are checking against `Server.ExternalWebUrl`, which is wrong.

Building the container and running locally, I can confirm this fix will enable cache to run.