### PR TITLE
Upgrade golangci GHA version and turn off caching

### DIFF
--- a/.github/workflows/pre-commit-linter.yml
+++ b/.github/workflows/pre-commit-linter.yml
@@ -36,9 +36,11 @@ jobs:
 
       # We still run this so that we can get the nice hint of gofmt issues inline
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: latest
+          skip-pkg-cache: true
+          skip-build-cache: true
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
Attempted to fix #929 based on https://github.com/golangci/golangci-lint-action/issues/135 Since folks are still reporting the issue with the fix, I can't be sure if the fix is guaranteed to be always effective and it does reduce the chance of hitting the error.