### PR TITLE
Fix misplaced branch check in GHA

### DIFF
--- a/.github/workflows/build-prod-container.yml
+++ b/.github/workflows/build-prod-container.yml
@@ -15,6 +15,10 @@ on:
         required: false
         type: boolean
         default: true
+      tag:
+          description: 'Tag to use for the Docker image'
+          required: false
+          type: string
 
 permissions:
   contents: write
@@ -23,7 +27,25 @@ jobs:
   build-base-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # For release, the worflow call (from pre-release.yaml) is triggered by a tag push
+      # like 7.5.1 Here, we want to set the *branch* name to 7.5.x,
+      # which is the branch for a feature version
+      - name: Set Branch for Release
+        id: set_branch
+        if: ${{ inputs.from_workflow_call }}
+        run: |
+          echo "branch=${GITHUB_REF_NAME%.*}.x" >> $GITHUB_OUTPUT
+
+      - name: Checkout for release with a tag
+        uses: actions/checkout@v4
+        if: ${{ inputs.from_workflow_call }}
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.set_branch.outputs.branch }}
+
+      - name: Checkout for push to main
+        uses: actions/checkout@v4
+        if: ${{ !inputs.from_workflow_call }}
 
       - name: Cache base image
         uses: actions/cache@v4
@@ -77,23 +99,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set Branch
-        id: set_branch
-        if: ${{ inputs.from_workflow_call }}
-        run: |
-          echo "branch=${GITHUB_REF_NAME%.*}.x" >> $GITHUB_OUTPUT
-
-      - name: Checkout for release
-        uses: actions/checkout@v4
-        if: ${{ inputs.from_workflow_call }}
-        with:
-          fetch-depth: 0
-          ref: ${{ steps.set_branch.outputs.branch }}
-
-      - name: Checkout for push to main
-        uses: actions/checkout@v4
-        if: ${{ !inputs.from_workflow_call }}
-
       - name: Generate tag list
         id: generate-tag-list
         env:
@@ -167,4 +172,3 @@ jobs:
           build-args: |
             IS_PR_BUILD=${{ github.event_name == 'pull_request' }}
           cache-from: type=local,src=/tmp/.base-buildx-cache
-          cache-to: type=local,dest=/tmp/.${{ matrix.image }}-buildx-cache,mode=max

--- a/.github/workflows/build-prod-container.yml
+++ b/.github/workflows/build-prod-container.yml
@@ -99,6 +99,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # For release, the worflow call (from pre-release.yaml) is triggered by a tag push
+      # like 7.5.1 Here, we want to set the *branch* name to 7.5.x,
+      # which is the branch for a feature version
+      - name: Set Branch for Release
+        id: set_branch
+        if: ${{ inputs.from_workflow_call }}
+        run: |
+          echo "branch=${GITHUB_REF_NAME%.*}.x" >> $GITHUB_OUTPUT
+
+      - name: Checkout for release with a tag
+        uses: actions/checkout@v4
+        if: ${{ inputs.from_workflow_call }}
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.set_branch.outputs.branch }}
+
+      - name: Checkout for push to main
+        uses: actions/checkout@v4
+        if: ${{ !inputs.from_workflow_call }}
+
       - name: Generate tag list
         id: generate-tag-list
         env:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -15,6 +15,8 @@ permissions:
 jobs:
   pre-release:
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.extract_tag.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -55,12 +57,21 @@ jobs:
           git tag ${GITHUB_REF_NAME}
           git push origin --tags
 
+      - name: Extract tag name
+        id: extract_tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: echo "::set-output name=tag::${GITHUB_REF#refs/tags/}"
+
   release-container:
     needs: [pre-release]
     uses: PelicanPlatform/pelican/.github/workflows/build-prod-container.yml@main
     secrets: inherit
+    with:
+      tag: ${{ needs.pre-release.outputs.tag }}
 
   release:
     needs: [pre-release]
     uses: PelicanPlatform/pelican/.github/workflows/release.yml@main
     secrets: inherit
+    with:
+      tag: ${{ needs.pre-release.outputs.tag }}

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -194,6 +194,13 @@ COPY --from=xrootd-plugin-builder /usr/lib64/libnlohmann_json_schema_validator.a
 # Eventually add more entrypoint commands here
 COPY images/entrypoint.sh /entrypoint.sh
 
+# Copy here to reduce dependency on the pelican-build stage in the final-stage and x-base stage
+COPY --from=pelican-build /pelican/dist/pelican_linux_amd64_v1/pelican /pelican/pelican
+COPY --from=pelican-build /pelican/dist/pelican_linux_amd64_v1/pelican /pelican/osdf
+RUN chmod +x /pelican/pelican \
+    && chmod +x /pelican/osdf \
+    && chmod +x /entrypoint.sh
+
 ######################
 # Pelican base stage #
 ######################
@@ -201,10 +208,7 @@ FROM final-stage AS pelican-base
 
 WORKDIR /pelican
 
-# Copy over needed files
-COPY --from=pelican-build /pelican/dist/pelican_linux_amd64_v1/pelican /pelican/pelican
-RUN chmod +x /pelican/pelican \
-    && chmod +x /entrypoint.sh
+RUN rm -rf /pelican/osdf
 
 ######################
 # OSDF base stage #
@@ -213,10 +217,7 @@ FROM final-stage AS osdf-base
 
 WORKDIR /pelican
 
-# Copy over needed files
-COPY --from=pelican-build /pelican/dist/pelican_linux_amd64_v1/pelican /pelican/osdf
-RUN chmod +x /pelican/osdf \
-    && chmod +x /entrypoint.sh
+RUN rm -rf /pelican/pelican
 
 ####################
 # pelican/cache    #


### PR DESCRIPTION
This PR fixes the issue that for the production docker image where we didn't set the correct branch ref when checking out for building the base image.

This PR also attempts to fix the missing input argument in GHA workflow file