### PR TITLE
Remove `generate` package when releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.21"
+      - name: Remove Generate folder
+        run: |
+          rm -rf generate
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -37,6 +37,8 @@ WORKDIR /pelican
 
 COPY . .
 COPY --from=website-build /webapp/out ./web_ui/frontend/out
+# Remove generate package as we already had generated structs in the repo
+RUN rm -rf ./generate
 
 ENV GOOS="linux"
 ENV GOARCH="amd64"


### PR DESCRIPTION
Closes #459 

I tested locally that removing the whole `generate` package locally won't cause build to fail, and the docker container I built with that runs as expected.