### PR TITLE
Fix log color loss and `LogLocation` not working

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -681,15 +681,6 @@ func InitConfig() {
 			cobra.CheckErr(err)
 		}
 	}
-	if param.Debug.GetBool() {
-		SetLogging(log.DebugLevel)
-		log.Warnln("Debug is set as a flag or in config, this will override anything set for Logging.Level within your configuration")
-	} else {
-		logLevel := param.Logging_Level.GetString()
-		level, err := log.ParseLevel(logLevel)
-		cobra.CheckErr(err)
-		SetLogging(level)
-	}
 
 	logLocation := param.Logging_LogLocation.GetString()
 	if logLocation != "" {
@@ -706,7 +697,18 @@ func InitConfig() {
 			log.Errorf("Failed to access specified log file. Error: %v", err)
 			os.Exit(1)
 		}
+		fmt.Printf("Logging.LogLocation is set to %s. All logs are redirected to the log file.\n", logLocation)
 		log.SetOutput(f)
+	}
+
+	if param.Debug.GetBool() {
+		SetLogging(log.DebugLevel)
+		log.Warnln("Debug is set as a flag or in config, this will override anything set for Logging.Level within your configuration")
+	} else {
+		logLevel := param.Logging_Level.GetString()
+		level, err := log.ParseLevel(logLevel)
+		cobra.CheckErr(err)
+		SetLogging(level)
 	}
 
 	if oldNsUrl := viper.GetString("Federation.NamespaceUrl"); oldNsUrl != "" {
@@ -1163,12 +1165,4 @@ func InitClient() error {
 	}
 
 	return DiscoverFederation()
-}
-
-func SetLogging(logLevel log.Level) {
-	textFormatter := log.TextFormatter{}
-	textFormatter.DisableLevelTruncation = true
-	textFormatter.FullTimestamp = true
-	log.SetFormatter(&textFormatter)
-	log.SetLevel(logLevel)
 }

--- a/config/logging.go
+++ b/config/logging.go
@@ -24,6 +24,7 @@ import (
 	"regexp"
 	"sync/atomic"
 
+	"github.com/go-kit/log/term"
 	log "github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/writer"
 )
@@ -131,8 +132,10 @@ func initFilterLogging() {
 	if !addedGlobalFilters {
 		log.AddHook(&globalFilters)
 		addedGlobalFilters = true
-		log.SetOutput(io.Discard)
+		// Set the writer to what logrus has
+		globalTransform.hook.Writer = log.StandardLogger().Out
 		globalTransform.hook.LogLevels = hookLevel
+		log.SetOutput(io.Discard)
 		log.AddHook(globalTransform)
 	}
 }
@@ -158,4 +161,16 @@ func RemoveFilter(name string) {
 		}
 	}
 	globalFilters.filters.Store(&result)
+}
+
+func SetLogging(logLevel log.Level) {
+	textFormatter := log.TextFormatter{}
+	textFormatter.DisableLevelTruncation = true
+	textFormatter.FullTimestamp = true
+	// Since we redirect log.Out to io.Discard, logrus will treat the output as non-terminal
+	// and won't format logs with color. Here we bypass logrus check by forcing the color
+	// and provide our check. Note that when calling SetLogging, io.Out hasn't been changed yet.
+	textFormatter.ForceColors = term.IsTerminal(log.StandardLogger().Out)
+	log.SetFormatter(&textFormatter)
+	log.SetLevel(logLevel)
 }

--- a/config/logging.go
+++ b/config/logging.go
@@ -83,7 +83,7 @@ func (fh *RegexpFilterHook) Levels() []log.Level {
 }
 
 func (rt *regexpTransformHook) Levels() []log.Level {
-	return log.AllLevels
+	return rt.hook.LogLevels
 }
 
 // Process a single log entry coming from logrus; iterate through the

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/jellydator/ttlcache/v3 v3.1.0
 	github.com/jsipprell/keyctl v1.0.4-0.20211208153515-36ca02672b6c
-	github.com/lestrrat-go/httprc v1.0.4
 	github.com/lestrrat-go/jwx/v2 v2.0.20
 	github.com/minio/minio-go/v7 v7.0.65
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f


### PR DESCRIPTION
Fixes #918 

Second attempt to fix the logging bug where log color are lost in a TTY terminal and `LogLocation` is not working.

This PR also fixes the bug where `Logging.Level` was not respected.

@turetske  Marking this as critical and putting it under 7.6 because the bug causes trouble at deployment/monitoring side. We can backport it in 7.6.1 if this can't be merged in before 7.6 release.