### PR TITLE
Removed unused input tag in `release.yml`

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -73,5 +73,3 @@ jobs:
     needs: [pre-release]
     uses: PelicanPlatform/pelican/.github/workflows/release.yml@main
     secrets: inherit
-    with:
-      tag: ${{ needs.pre-release.outputs.tag }}


### PR DESCRIPTION
Fix GHA linter error in releasing where the `tag` input feed from `pre-release.yml` is not used in `release.yml`, which is true. So this PR removes the tag input.