### PR TITLE
Fix pelican plugin bug `no valid classads...`

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -432,10 +432,10 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 			var tj *client.TransferJob
 			urlCopy := *transfer.url
 			tj, err = tc.NewTransferJob(&urlCopy, transfer.localFile, upload, false, client.WithAcquireToken(false), client.WithCaches(caches...))
-			jobMap[tj.ID()] = transfer
 			if err != nil {
 				return errors.Wrap(err, "Failed to create new transfer job")
 			}
+			jobMap[tj.ID()] = transfer
 
 			if err = tc.Submit(tj); err != nil {
 				return err
@@ -460,7 +460,7 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 				developerData[fmt.Sprintf("ServerVersion%d", attempt.Number)] = attempt.ServerVersion
 				developerData[fmt.Sprintf("TransferTime%d", attempt.Number)] = attempt.TransferTime
 				if attempt.Error != nil {
-					developerData[fmt.Sprintf("TransferError%d", attempt.Number)] = attempt.Error
+					developerData[fmt.Sprintf("TransferError%d", attempt.Number)] = attempt.Error.Error()
 				}
 			}
 


### PR DESCRIPTION
This fixes the bug we were getting with the pelican plugin where we would see the plugin exiting 0 but sending out `no valid classads`. The issue was an error type being written out and bypassing strconv.QuoteToASCII which would remove any inside quotes.

Also found a spot where we were getting a nil pointer dereference because we were accessing data before an error check, fixed as well