### PR TITLE
Correct the key for docker doc page

### DIFF
--- a/docs/pages/install/_meta.json
+++ b/docs/pages/install/_meta.json
@@ -3,5 +3,5 @@
   "debian": "Debian and Ubuntu",
   "alpine": "Alpine Linux",
   "macos": "macOS",
-  "dockder": "Pelican Docker Image"
+  "docker": "Pelican Docker Image"
 }


### PR DESCRIPTION
One line fix for the typo in `meta.json` for documentation page for Docker 