### PR TITLE
Fix bug with version being "dev"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,7 +41,7 @@ builds:
     tags:
       - forceposix
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser -X config.version={{.Version}}
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser -X github.com/pelicanplatform/pelican/config.version={{.Version}}
     ignore:
       - goos: windows
         goarch: arm64

--- a/config/config.go
+++ b/config/config.go
@@ -139,7 +139,7 @@ var (
 
 	RestartFlag = make(chan any) // A channel flag to restart the server instance that launcher listens to (including cache)
 
-	// Pelican version
+	// Pelican version, this is overwritten at build time
 	version string = "dev"
 
 	MetadataTimeoutErr *MetadataErr = &MetadataErr{msg: "Timeout when querying metadata"}


### PR DESCRIPTION
Goreleaser was not setting version correctly for the 'config' package. Should work properly now.