### PR TITLE
Allow RSA key for TLS

### DIFF
--- a/broker/client.go
+++ b/broker/client.go
@@ -166,7 +166,7 @@ func ConnectToOrigin(ctx context.Context, brokerUrl, prefix, originName string) 
 	if err != nil {
 		return
 	}
-	caPrivateKey, err := config.LoadPrivateKey(param.Server_TLSCAKey.GetString())
+	caPrivateKey, err := config.LoadPrivateKey(param.Server_TLSCAKey.GetString(), true)
 	if err != nil {
 		return
 	}

--- a/cmd/registry_client.go
+++ b/cmd/registry_client.go
@@ -103,7 +103,7 @@ func registerANamespace(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	privateKeyRaw, err := config.LoadPrivateKey(param.IssuerKey.GetString())
+	privateKeyRaw, err := config.LoadPrivateKey(param.IssuerKey.GetString(), false)
 	if err != nil {
 		log.Error("Failed to load private key", err)
 		os.Exit(1)

--- a/config/init_server_creds_test.go
+++ b/config/init_server_creds_test.go
@@ -86,7 +86,7 @@ func generatePrivateKey(keyLocation string, encrypt string, keyFormat string) er
 }
 
 func TestLoadPrivateKey(t *testing.T) {
-	t.Run("ecdsa-key-no-error", func(t *testing.T) {
+	t.Run("ecdsa-key", func(t *testing.T) {
 		tempDir := t.TempDir()
 		keyLocation := filepath.Join(tempDir, "ecdsa.key")
 		err := generatePrivateKey(keyLocation, "ecdsa", "pkcs8")
@@ -100,7 +100,7 @@ func TestLoadPrivateKey(t *testing.T) {
 		}
 	})
 
-	t.Run("rsa-pkcs8-allow-no-error", func(t *testing.T) {
+	t.Run("rsa-pkcs8-key-allowed", func(t *testing.T) {
 		tempDir := t.TempDir()
 		keyLocation := filepath.Join(tempDir, "rsa.key")
 		err := generatePrivateKey(keyLocation, "rsa", "pkcs8")
@@ -114,7 +114,7 @@ func TestLoadPrivateKey(t *testing.T) {
 		}
 	})
 
-	t.Run("rsa-pkcs1-allow-no-error", func(t *testing.T) {
+	t.Run("rsa-pkcs1-key-allowed", func(t *testing.T) {
 		tempDir := t.TempDir()
 		keyLocation := filepath.Join(tempDir, "rsa.key")
 		err := generatePrivateKey(keyLocation, "rsa", "pkcs1")
@@ -128,7 +128,7 @@ func TestLoadPrivateKey(t *testing.T) {
 		}
 	})
 
-	t.Run("rsa-pkcs1-not-allow-error", func(t *testing.T) {
+	t.Run("rsa-pkcs1-key-not-allowed", func(t *testing.T) {
 		tempDir := t.TempDir()
 		keyLocation := filepath.Join(tempDir, "rsa.key")
 		err := generatePrivateKey(keyLocation, "rsa", "pkcs1")
@@ -139,7 +139,7 @@ func TestLoadPrivateKey(t *testing.T) {
 		require.Nil(t, privateKey)
 	})
 
-	t.Run("rsa-pkcs8-not-allow-error", func(t *testing.T) {
+	t.Run("rsa-pkcs8-key-not-allowed", func(t *testing.T) {
 		tempDir := t.TempDir()
 		keyLocation := filepath.Join(tempDir, "rsa.key")
 		err := generatePrivateKey(keyLocation, "rsa", "pkcs8")

--- a/config/init_server_creds_test.go
+++ b/config/init_server_creds_test.go
@@ -1,0 +1,152 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package config
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// encrypt should be ecdsa|rsa
+// keyFormat should be pkcs1|pkcs8
+func generatePrivateKey(keyLocation string, encrypt string, keyFormat string) error {
+	file, err := os.OpenFile(keyLocation, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0400)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create new private key file")
+	}
+	defer file.Close()
+	if encrypt == "ecdsa" {
+		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			return err
+		}
+
+		bytes, err := x509.MarshalPKCS8PrivateKey(priv)
+		if err != nil {
+			return err
+		}
+		priv_block := pem.Block{Type: "PRIVATE KEY", Bytes: bytes}
+		if err = pem.Encode(file, &priv_block); err != nil {
+			return err
+		}
+	} else if encrypt == "rsa" {
+		priv, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			return err
+		}
+		if keyFormat == "pkcs8" {
+			bytes, err := x509.MarshalPKCS8PrivateKey(priv)
+			if err != nil {
+				return err
+			}
+			priv_block := pem.Block{Type: "PRIVATE KEY", Bytes: bytes}
+			if err = pem.Encode(file, &priv_block); err != nil {
+				return err
+			}
+		} else if keyFormat == "pkcs1" {
+			bytes := x509.MarshalPKCS1PrivateKey(priv)
+			priv_block := pem.Block{Type: "RSA PRIVATE KEY", Bytes: bytes}
+			if err = pem.Encode(file, &priv_block); err != nil {
+				return err
+			}
+		} else {
+			return errors.Errorf("unsupported key format: %s", keyFormat)
+		}
+	} else {
+		return errors.Errorf("unsupported encrypt: %s", encrypt)
+	}
+	return nil
+}
+
+func TestLoadPrivateKey(t *testing.T) {
+	t.Run("ecdsa-key-no-error", func(t *testing.T) {
+		tempDir := t.TempDir()
+		keyLocation := filepath.Join(tempDir, "ecdsa.key")
+		err := generatePrivateKey(keyLocation, "ecdsa", "pkcs8")
+		require.NoError(t, err)
+		privateKey, err := LoadPrivateKey(keyLocation, false)
+		require.NoError(t, err)
+		require.NotNil(t, privateKey)
+
+		if _, ok := privateKey.(*ecdsa.PrivateKey); !ok {
+			assert.Fail(t, "loaded private key type is not *ecdsa.PrivateKey")
+		}
+	})
+
+	t.Run("rsa-pkcs8-allow-no-error", func(t *testing.T) {
+		tempDir := t.TempDir()
+		keyLocation := filepath.Join(tempDir, "rsa.key")
+		err := generatePrivateKey(keyLocation, "rsa", "pkcs8")
+		require.NoError(t, err)
+		privateKey, err := LoadPrivateKey(keyLocation, true)
+		require.NoError(t, err)
+		require.NotNil(t, privateKey)
+
+		if _, ok := privateKey.(*rsa.PrivateKey); !ok {
+			assert.Fail(t, "loaded private key type is not *rsa.PrivateKey")
+		}
+	})
+
+	t.Run("rsa-pkcs1-allow-no-error", func(t *testing.T) {
+		tempDir := t.TempDir()
+		keyLocation := filepath.Join(tempDir, "rsa.key")
+		err := generatePrivateKey(keyLocation, "rsa", "pkcs1")
+		require.NoError(t, err)
+		privateKey, err := LoadPrivateKey(keyLocation, true)
+		require.NoError(t, err)
+		require.NotNil(t, privateKey)
+
+		if _, ok := privateKey.(*rsa.PrivateKey); !ok {
+			assert.Fail(t, "loaded private key type is not *rsa.PrivateKey")
+		}
+	})
+
+	t.Run("rsa-pkcs1-not-allow-error", func(t *testing.T) {
+		tempDir := t.TempDir()
+		keyLocation := filepath.Join(tempDir, "rsa.key")
+		err := generatePrivateKey(keyLocation, "rsa", "pkcs1")
+		require.NoError(t, err)
+		privateKey, err := LoadPrivateKey(keyLocation, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "RSA type private key is not allowed for")
+		require.Nil(t, privateKey)
+	})
+
+	t.Run("rsa-pkcs8-not-allow-error", func(t *testing.T) {
+		tempDir := t.TempDir()
+		keyLocation := filepath.Join(tempDir, "rsa.key")
+		err := generatePrivateKey(keyLocation, "rsa", "pkcs8")
+		require.NoError(t, err)
+		privateKey, err := LoadPrivateKey(keyLocation, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "RSA type private key in PKCS #8 form is not allowed for")
+		require.Nil(t, privateKey)
+	})
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -170,8 +170,17 @@ func loadServerKeys() (*ecdsa.PrivateKey, error) {
 	// TODO: Reimplement the function once we switch to a minimum of 1.21
 	serverCredsLoad.Do(func() {
 		issuerFileName := param.IssuerKey.GetString()
-		serverCredsPrivKey, serverCredsErr = config.LoadPrivateKey(issuerFileName)
+		var privateKey crypto.PrivateKey
+		privateKey, serverCredsErr = config.LoadPrivateKey(issuerFileName, false)
+
+		switch key := privateKey.(type) {
+		case *ecdsa.PrivateKey:
+			serverCredsPrivKey = key
+		default:
+			serverCredsErr = errors.Errorf("unsupported key type for server issuer key: %T", key)
+		}
 	})
+
 	return serverCredsPrivKey, serverCredsErr
 }
 

--- a/registry/registry_ui_test.go
+++ b/registry/registry_ui_test.go
@@ -123,7 +123,7 @@ func TestListNamespaces(t *testing.T) {
 	viper.Set("Origin.Port", 0)
 	err := config.InitServer(ctx, config.OriginType)
 	require.NoError(t, err)
-	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256())
+	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256(), false)
 	require.NoError(t, err)
 
 	router := gin.Default()

--- a/web_ui/authentication_test.go
+++ b/web_ui/authentication_test.go
@@ -102,7 +102,7 @@ func TestCodeBasedLogin(t *testing.T) {
 	config.InitConfig()
 	err := config.InitServer(ctx, config.OriginType)
 	require.NoError(t, err)
-	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256())
+	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256(), false)
 	require.NoError(t, err)
 
 	//Invoke the code login API with the correct code, ensure we get a valid code back
@@ -159,7 +159,7 @@ func TestPasswordResetAPI(t *testing.T) {
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
 	err := config.InitServer(ctx, config.OriginType)
 	require.NoError(t, err)
-	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256())
+	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256(), false)
 	require.NoError(t, err)
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
 
@@ -384,7 +384,7 @@ func TestWhoamiAPI(t *testing.T) {
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
 	err := config.InitServer(ctx, config.OriginType)
 	require.NoError(t, err)
-	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256())
+	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256(), false)
 	require.NoError(t, err)
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
 
@@ -556,7 +556,7 @@ func TestLogoutAPI(t *testing.T) {
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
 	err := config.InitServer(ctx, config.OriginType)
 	require.NoError(t, err)
-	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256())
+	err = config.GeneratePrivateKey(param.IssuerKey.GetString(), elliptic.P256(), false)
 	require.NoError(t, err)
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
 

--- a/xrootd/origin_test.go
+++ b/xrootd/origin_test.go
@@ -79,7 +79,7 @@ func originMockup(ctx context.Context, egrp *errgroup.Group, t *testing.T) conte
 	err = config.InitServer(ctx, config.OriginType)
 	require.NoError(t, err)
 
-	err = config.GeneratePrivateKey(param.Server_TLSKey.GetString(), elliptic.P256())
+	err = config.GeneratePrivateKey(param.Server_TLSKey.GetString(), elliptic.P256(), false)
 	require.NoError(t, err)
 	err = config.GenerateCert()
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes #956 

This PR allows admin to pass RSA key in either PKCS8 or PKCS1 form as the TLSKey or TLSCAKey. Came with tests.

This PR also bypass the error reporting if only TLS cert and TLS key are present and CA cert is missing. It will instead generate a CA with its private key (mostly for xrootd and broker) and continue.