### PR TITLE
Revert changes that remove `generate` package

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -19,7 +19,7 @@ jobs:
       tag: ${{ steps.extract_tag.outputs.tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,16 +30,13 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.21"
-      - name: Remove Generate folder
-        run: |
-          rm -rf generate
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution


### PR DESCRIPTION
In #937, the `generate` package was removed before we call goreleaser, but it causes our changes in git which goreleaser doesn't like. This PR revert the removal of `generate` package to allow goreleaser pass the validation check. There seems to be no apparent alternative to this approach.