### PR TITLE
Parse cache hit/miss into Prometheus metric

### DIFF
--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -34,9 +34,7 @@ http.staticpreload http://static/robots.txt {{.Xrootd.RobotsTxtFile}}
 {{if .Xrootd.Sitename}}
 all.sitename {{.Xrootd.Sitename}}
 {{end}}
-{{if .Xrootd.SummaryMonitoringHost}}
-xrd.report {{.Xrootd.SummaryMonitoringHost}}:{{.Xrootd.SummaryMonitoringPort}},127.0.0.1:{{.Xrootd.LocalMonitoringPort}} every 30s
-{{end}}
+xrd.report {{if .Xrootd.SummaryMonitoringHost -}}{{.Xrootd.SummaryMonitoringHost}}:{{.Xrootd.SummaryMonitoringPort}},{{- end}}127.0.0.1:{{.Xrootd.LocalMonitoringPort}} every 30s
 xrootd.monitor all auth flush 30s window 5s fstat 60 lfn ops xfr 5 {{if .Xrootd.DetailedMonitoringHost -}} dest redir fstat info files user pfc tcpmon ccm {{.Xrootd.DetailedMonitoringHost}}:{{.Xrootd.DetailedMonitoringPort}} {{- end}} dest redir fstat info files user pfc tcpmon ccm 127.0.0.1:{{.Xrootd.LocalMonitoringPort}}
 all.adminpath {{.Cache.RunLocation}}
 all.pidpath {{.Cache.RunLocation}}


### PR DESCRIPTION
Closes #944 

Reading from cache data from summary packet, specifically `rd.hits` and `rd.miss`, I got 0 for both values even if requested multiple files through my cache-origin federation (with `EnableFallbackRead` set to false). Skimming through xrootd source code, it seems that the two values are only updated for `rmc` type cache (read? memory cache), but I only got `pfc` type cache in the monitoring packets.

@bbockelm Is this value the one we want to parse? Or it's something else?