### PR TITLE
Import parameters.json into website

### DIFF
--- a/.github/workflows/go-generate-check.yml
+++ b/.github/workflows/go-generate-check.yml
@@ -1,0 +1,27 @@
+name: Check Go Generate Has been Run
+on:
+  pull_request:
+jobs:
+  validate-generated-files:
+    name: Check Go Generate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+
+      - name: Run Go Generate
+        run: go generate ./...
+
+      - name: Validate Generated Files are up to date
+        run: |
+          if git diff --quiet; then
+            echo "No changes found."
+          else
+            echo "Changes detected. Here are the details:"
+            git diff
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Build the website
-        run: |
-          make web-build
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,7 @@ before:
   hooks:
     - go mod tidy
     - go generate ./...
+    - make web-build
 builds:
   - env:
       - CGO_ENABLED=0

--- a/generate/param_generator.go
+++ b/generate/param_generator.go
@@ -197,6 +197,19 @@ func GenParamEnum() {
 	if err != nil {
 		panic(err)
 	}
+
+	// Skip writing the file if it is the same as the existing file
+	// This is so that the file is not updated if it is not changed making builds faster
+	if _, err := os.Stat("../docs/parameters.json"); err == nil {
+		existingJsonBytes, err := os.ReadFile("../docs/parameters.json")
+		if err != nil {
+			panic(err)
+		}
+		if bytes.Equal(existingJsonBytes, prettyJSON.Bytes()) {
+			return
+		}
+	}
+
 	// Create the json file to be generated (for the documentation website)
 	fJSON, err := os.Create("../docs/parameters.json")
 	if err != nil {

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -19,26 +19,14 @@
 ARG BASE_YUM_REPO=release
 ARG BASE_OSG_SERIES=3.6
 
-FROM node:20 AS website-build
-
-WORKDIR /webapp
-
-COPY web_ui/frontend/package.json package.json
-
-RUN npm install
-COPY web_ui/frontend ./
-
-RUN npm run build
-
 FROM goreleaser/goreleaser:v1.21.0 AS pelican-build
 ARG IS_NONRELEASE_BUILD="true"
+
+RUN apk add --update nodejs-current npm
 
 WORKDIR /pelican
 
 COPY . .
-COPY --from=website-build /webapp/out ./web_ui/frontend/out
-# Remove generate package as we already had generated structs in the repo
-RUN rm -rf ./generate
 
 ENV GOOS="linux"
 ENV GOARCH="amd64"


### PR DESCRIPTION
[Unify Build Process](https://github.com/PelicanPlatform/pelican/pull/972/commits/9a2bda35ea9c99799ce2ea98fbd3539d0f8b9763) 

Adds check that go generate has been run on the latest commit
Moves make web-build into goreleaser before which will make how we build dev binaries more similar to how we build production binaries
Rewrites the dockerfile moving the web build into the gorelease section
Doesn't needlessly update parameters.json on go generate ./..

Closes #971