### PR TITLE
Fix bug where project name not set in user-agent

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1474,9 +1474,7 @@ func downloadHTTP(ctx context.Context, te *TransferEngine, callback TransferCall
 	req.HTTPRequest.Header.Set("X-Transfer-Status", "true")
 	req.HTTPRequest.Header.Set("X-Pelican-Timeout", param.Transport_ResponseHeaderTimeout.GetDuration().String())
 	req.HTTPRequest.Header.Set("TE", "trailers")
-	if project != "" {
-		req.HTTPRequest.Header.Set("User-Agent", getUserAgent(project))
-	}
+	req.HTTPRequest.Header.Set("User-Agent", getUserAgent(project))
 	req = req.WithContext(ctx)
 
 	// Test the transfer speed every 5 seconds

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1414,6 +1414,7 @@ func downloadHTTP(ctx context.Context, te *TransferEngine, callback TransferCall
 
 	// Create the client, request, and context
 	client := grab.NewClient()
+	client.UserAgent = getUserAgent(project)
 	transport := config.GetTransport()
 	if !transfer.Proxy {
 		transport.Proxy = nil

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -187,7 +187,7 @@ func TestSlowTransfers(t *testing.T) {
 	var err error
 	// Do a quick timeout
 	go func() {
-		_, _, _, err = downloadHTTP(ctx, nil, nil, transfers[0], filepath.Join(t.TempDir(), "test.txt"), -1, "", nil)
+		_, _, _, err = downloadHTTP(ctx, nil, nil, transfers[0], filepath.Join(t.TempDir(), "test.txt"), -1, "", "")
 		finishedChannel <- true
 	}()
 
@@ -258,7 +258,7 @@ func TestStoppedTransfer(t *testing.T) {
 	var err error
 
 	go func() {
-		_, _, _, err = downloadHTTP(ctx, nil, nil, transfers[0], filepath.Join(t.TempDir(), "test.txt"), -1, "", nil)
+		_, _, _, err = downloadHTTP(ctx, nil, nil, transfers[0], filepath.Join(t.TempDir(), "test.txt"), -1, "", "")
 		finishedChannel <- true
 	}()
 
@@ -290,7 +290,7 @@ func TestConnectionError(t *testing.T) {
 	addr := l.Addr().String()
 	l.Close()
 
-	_, _, _, err = downloadHTTP(ctx, nil, nil, transferAttemptDetails{Url: &url.URL{Host: addr, Scheme: "http"}, Proxy: false}, filepath.Join(t.TempDir(), "test.txt"), -1, "", nil)
+	_, _, _, err = downloadHTTP(ctx, nil, nil, transferAttemptDetails{Url: &url.URL{Host: addr, Scheme: "http"}, Proxy: false}, filepath.Join(t.TempDir(), "test.txt"), -1, "", "")
 
 	assert.IsType(t, &ConnectionSetupError{}, err)
 
@@ -325,7 +325,7 @@ func TestTrailerError(t *testing.T) {
 	assert.Equal(t, svr.URL, transfers[0].Url.String())
 
 	// Call DownloadHTTP and check if the error is returned correctly
-	_, _, _, err := downloadHTTP(ctx, nil, nil, transfers[0], filepath.Join(t.TempDir(), "test.txt"), -1, "", nil)
+	_, _, _, err := downloadHTTP(ctx, nil, nil, transfers[0], filepath.Join(t.TempDir(), "test.txt"), -1, "", "")
 
 	assert.NotNil(t, err)
 	assert.EqualError(t, err, "transfer error: Unable to read test.txt; input/output error")
@@ -475,7 +475,43 @@ func TestTimeoutHeaderSetForDownload(t *testing.T) {
 
 	serverURL, err := url.Parse(server.URL)
 	assert.NoError(t, err)
-	_, _, _, err = downloadHTTP(ctx, nil, nil, transferAttemptDetails{Url: serverURL, Proxy: false}, filepath.Join(t.TempDir(), "test.txt"), -1, "", nil)
+	_, _, _, err = downloadHTTP(ctx, nil, nil, transferAttemptDetails{Url: serverURL, Proxy: false}, filepath.Join(t.TempDir(), "test.txt"), -1, "", "")
 	assert.NoError(t, err)
 	viper.Reset()
+}
+
+// Server test object for testing user agent
+type (
+	server_test struct {
+		server     *httptest.Server
+		user_agent *string
+	}
+)
+
+// Test to ensure the user-agent header is being updating in the request made within DownloadHTTP()
+func TestProjInUserAgent(t *testing.T) {
+	ctx, _, _ := test_utils.TestContext(context.Background(), t)
+
+	server_test := server_test{}
+	// Create a mock server to download from
+	server_test.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Note: we check for this HEAD request because within DownloadHTTP() we make a HEAD request to get the content length
+		// This request is a different user-agent header (and different request) so we need to ignore it so server_test.user_agent is not overwritten
+		if r.Method == "HEAD" {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		userAgent := r.UserAgent()
+		server_test.user_agent = &userAgent
+	}))
+	defer server_test.server.Close()
+	defer server_test.server.CloseClientConnections()
+
+	serverURL, err := url.Parse(server_test.server.URL)
+	assert.NoError(t, err)
+	_, _, _, err = downloadHTTP(ctx, nil, nil, transferAttemptDetails{Url: serverURL, Proxy: false}, filepath.Join(t.TempDir(), "test.txt"), -1, "", "test")
+	assert.NoError(t, err)
+
+	// Test the user-agent header is what we expect it to be
+	assert.Equal(t, "pelican-client/"+config.GetVersion()+" project/test", *server_test.user_agent)
 }

--- a/client/main.go
+++ b/client/main.go
@@ -879,7 +879,7 @@ func GetProjectName() string {
 
 	// Get all matches from file
 	// Note: This appears to be invalid regex but is the only thing that appears to work. This way it successfully finds our matches
-	classadRegex, e := regexp.Compile(`^*\s*(ProjectName)\s=\s"(.*)"`)
+	classadRegex, e := regexp.Compile(`^*\s*(ProjectName)\s=\s"*(.*)"*`)
 	if e != nil {
 		log.Fatal(e)
 	}

--- a/client/main_test.go
+++ b/client/main_test.go
@@ -321,12 +321,32 @@ func TestCorrectURLWithUnderscore(t *testing.T) {
 	}
 }
 
-func TestParseNoJobAd(t *testing.T) {
-	// Job ad file does not exist
-	tempDir := t.TempDir()
-	path := filepath.Join(tempDir, ".job.ad")
-	os.Setenv("_CONDOR_JOB_AD", path)
+// Test that the project name is correctly extracted from the job ad file
+func TestGetProjectName(t *testing.T) {
+	// Create a temporary file
+	tempFile, err := os.CreateTemp("", "test")
+	assert.NoError(t, err)
+	defer os.Remove(tempFile.Name())
 
-	payload := payloadStruct{}
-	parseJobAd(&payload)
+	// Write a project name to the file
+	_, err = tempFile.WriteString("ProjectName = \"testProject\"")
+	assert.NoError(t, err)
+	tempFile.Close()
+	t.Run("TestNoJobAd", func(t *testing.T) {
+		// Unset this environment var
+		os.Unsetenv("_CONDOR_JOB_AD")
+		// Call GetProjectName and check the result
+		projectName := GetProjectName()
+		assert.Equal(t, "", projectName)
+	})
+
+	t.Run("TestJobAd", func(t *testing.T) {
+		// Set the _CONDOR_JOB_AD environment variable to the temp file's name
+		os.Setenv("_CONDOR_JOB_AD", tempFile.Name())
+		defer os.Unsetenv("_CONDOR_JOB_AD")
+
+		// Call GetProjectName and check the result
+		projectName := GetProjectName()
+		assert.Equal(t, "testProject", projectName)
+	})
 }

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -431,7 +431,8 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 
 			var tj *client.TransferJob
 			urlCopy := *transfer.url
-			tj, err = tc.NewTransferJob(&urlCopy, transfer.localFile, upload, false, client.WithAcquireToken(false), client.WithCaches(caches...))
+			project := client.GetProjectName()
+			tj, err = tc.NewTransferJob(&urlCopy, transfer.localFile, upload, false, project, client.WithAcquireToken(false), client.WithCaches(caches...))
 			if err != nil {
 				return errors.Wrap(err, "Failed to create new transfer job")
 			}

--- a/local_cache/local_cache.go
+++ b/local_cache/local_cache.go
@@ -506,7 +506,7 @@ func (sc *LocalCache) runMux() error {
 
 			sourceURL := *sc.directorURL
 			sourceURL.Path = path.Join(sourceURL.Path, path.Clean(req.request.path))
-			tj, err := sc.tc.NewTransferJob(&sourceURL, localPath, false, false, client.WithToken(req.request.token))
+			tj, err := sc.tc.NewTransferJob(&sourceURL, localPath, false, false, "", client.WithToken(req.request.token))
 			if err != nil {
 				ds := &downloadStatus{}
 				ds.err.Store(&err)

--- a/local_cache/local_cache.go
+++ b/local_cache/local_cache.go
@@ -506,7 +506,7 @@ func (sc *LocalCache) runMux() error {
 
 			sourceURL := *sc.directorURL
 			sourceURL.Path = path.Join(sourceURL.Path, path.Clean(req.request.path))
-			tj, err := sc.tc.NewTransferJob(&sourceURL, localPath, false, false, "", client.WithToken(req.request.token))
+			tj, err := sc.tc.NewTransferJob(&sourceURL, localPath, false, false, "localcache", client.WithToken(req.request.token))
 			if err != nil {
 				ds := &downloadStatus{}
 				ds.err.Store(&err)


### PR DESCRIPTION
Project name, if set, will now show up in the user-agent header for requests. This PR also removes some old unused legacy code of the "payload" object (the only piece of the object still used was the project name). Also includes a unit test checking that the client properly sets this header.