### PR TITLE
Output pelican config to stderr at server start

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -803,6 +803,24 @@ func setXrootdRunLocations(currentServers ServerType, dir string) error {
 	return nil
 }
 
+// Print Pelican configuration to stderr
+func PrintConfig() error {
+	rawConfig, err := param.UnmarshalConfig()
+	if err != nil {
+		return err
+	}
+	bytes, err := json.MarshalIndent(*rawConfig, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stderr,
+		"================ Pelican Configuration ================\n",
+		string(bytes),
+		"\n",
+		"============= End of Pelican Configuration ============")
+	return nil
+}
+
 // Initialize Pelican server instance. Pass a bit mask of `currentServers` if you want to enable multiple services.
 // Note not all configurations are supported: currently, if you enable both cache and origin then an error
 // is thrown

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -58,6 +58,13 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (context.Canc
 
 	ctx, shutdownCancel := context.WithCancel(ctx)
 
+	// Print Pelican config at server start if it's in debug or info level
+	if log.GetLevel() >= log.InfoLevel {
+		if err := config.PrintConfig(); err != nil {
+			return shutdownCancel, err
+		}
+	}
+
 	egrp.Go(func() error {
 		_ = config.RestartFlag
 		log.Debug("Will shutdown process on signal")


### PR DESCRIPTION
Closes #953 

To not to confuse user when they spin up the server instance without the intension to see the config file, this feature only turned on if logging level is set to debug or info. Also the output it directed to stderr instead of stdout to exclude it from other server output.