### PR TITLE
Improved plugin error messaging

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -610,25 +610,25 @@ func readMultiTransfers(stdin bufio.Reader) (transfers []PluginTransfer, err err
 
 // This function wraps the transfer error message into a more readable and user-friendly format.
 func writeTransferErrorMessage(currentError string, transferUrl string, upload bool) (errMsg string) {
-	errMsg = "PELICAN CLIENT ERROR: " + currentError
+	errMsg = "PELICAN CLIENT ERROR: "
 
 	// TransferUrl will be blank if this occurs before transfer has started.
 	if transferUrl != "" {
 		if upload {
-			errMsg += " uploading "
+			errMsg += "failure uploading "
 		} else {
-			errMsg += " downloading "
+			errMsg += "failure downloading "
 		}
-		errMsg += transferUrl
+		errMsg += transferUrl + ": "
 	}
-	hostname, err := os.Hostname()
-	if err != nil {
-		log.Warningln("Could not get hostname", err)
-	}
-	errMsg += " HOSTNAME: " + hostname
+	errMsg += currentError
+	errMsg += (" (PELICAN VERSION: " + config.GetVersion())
+
 	siteName := parseMachineAd()
 	if siteName != "" {
-		errMsg += " GLIDEIN_SITE: " + siteName
+		errMsg += " SITE: " + siteName + ")"
+	} else {
+		errMsg += ")"
 	}
 
 	return

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -610,23 +610,23 @@ func readMultiTransfers(stdin bufio.Reader) (transfers []PluginTransfer, err err
 
 // This function wraps the transfer error message into a more readable and user-friendly format.
 func writeTransferErrorMessage(currentError string, transferUrl string, upload bool) (errMsg string) {
-	errMsg = "PELICAN CLIENT ERROR: "
+	errMsg = "Pelican Client Error: "
 
 	// TransferUrl will be blank if this occurs before transfer has started.
 	if transferUrl != "" {
 		if upload {
-			errMsg += "failure uploading "
+			errMsg += "uploading "
 		} else {
-			errMsg += "failure downloading "
+			errMsg += "downloading "
 		}
 		errMsg += transferUrl + ": "
 	}
 	errMsg += currentError
-	errMsg += (" (PELICAN VERSION: " + config.GetVersion())
+	errMsg += (" (Pelican Version: " + config.GetVersion())
 
 	siteName := parseMachineAd()
 	if siteName != "" {
-		errMsg += " SITE: " + siteName + ")"
+		errMsg += "; Site: " + siteName + ")"
 	} else {
 		errMsg += ")"
 	}


### PR DESCRIPTION
After talks with some facilitators, they told us ways to improve error messaging from the plugin. Now, all errors from the plugin now begin with PELICAN CLIENT ERROR as well as end with HOSTNAME and GLIDEIN_SITE

Before:
```
Transfer input files failure at the execution point using protocol osdf. Details: Error from 
slot1_7@glidein_253984_295706592@uct2-c516.mwt2.org: FILETRANSFER:1:non-zero exit (1) from 
/var/lib/condor/execute/dir_253982/glide_YoREfU/stash_plugin. |Error:  Failure downloading 
osdf:///chtc/staging/jrreuss/foo-v1.txt: failed connection setup: server returned 403 Forbidden 
( URL file = osdf:///chtc/staging/jrreuss/foo-v1.txt )|
```

After:
```
Transfer input files failure at the execution point using protocol osdf. Details: Error from 
slot1_6@glidein_3084899_80207786@build4002.chtc.wisc.edu: FILETRANSFER:1:non-zero exit (1) from stash_plugin. 
|Error:  PELICAN CLIENT ERROR downloading osdf:///chtc/staging/jrreuss/foo-v1.txt: failed connection setup: 
server returned 403 Forbidden HOSTNAME: build4002 GLIDEIN_SITE: Wisconsin ( URL file = osdf:///chtc/staging/jrreuss/foo-v1.txt )|
```