### PR TITLE
Fix director default response and add HEAD as allowed verb

### DIFF
--- a/director/director.go
+++ b/director/director.go
@@ -490,7 +490,7 @@ func ShortcutMiddleware(defaultResponse string) gin.HandlerFunc {
 		// If we're configured for cache mode or we haven't set the flag,
 		// we should use cache middleware
 		if defaultResponse == "cache" {
-			if !strings.HasPrefix(c.Request.URL.Path, "/api/v1.0/director/") {
+			if !strings.HasPrefix(c.Request.URL.Path, "/api/v1.0/director/") && (c.Request.Method == "GET" || c.Request.Method == "HEAD") {
 				c.Request.URL.Path = "/api/v1.0/director/object" + c.Request.URL.Path
 				redirectToCache(c)
 				c.Abort()
@@ -500,7 +500,7 @@ func ShortcutMiddleware(defaultResponse string) gin.HandlerFunc {
 			// If the path starts with the correct prefix, continue with the next handler
 			c.Next()
 		} else if defaultResponse == "origin" {
-			if !strings.HasPrefix(c.Request.URL.Path, "/api/v1.0/director/") {
+			if !strings.HasPrefix(c.Request.URL.Path, "/api/v1.0/director/") && (c.Request.Method == "GET" || c.Request.Method == "HEAD") {
 				c.Request.URL.Path = "/api/v1.0/director/origin" + c.Request.URL.Path
 				redirectToOrigin(c)
 				c.Abort()
@@ -828,7 +828,9 @@ func RegisterDirectorAPI(ctx context.Context, router *gin.RouterGroup) {
 	{
 		// Establish the routes used for cache/origin redirection
 		directorAPIV1.GET("/object/*any", redirectToCache)
+		directorAPIV1.HEAD("/object/*any", redirectToCache)
 		directorAPIV1.GET("/origin/*any", redirectToOrigin)
+		directorAPIV1.HEAD("/origin/*any", redirectToOrigin)
 		directorAPIV1.PUT("/origin/*any", redirectToOrigin)
 		directorAPIV1.POST("/registerOrigin", func(gctx *gin.Context) { registerServeAd(ctx, gctx, server_structs.OriginType) })
 		directorAPIV1.POST("/registerCache", func(gctx *gin.Context) { registerServeAd(ctx, gctx, server_structs.CacheType) })

--- a/launchers/director_serve.go
+++ b/launchers/director_serve.go
@@ -23,12 +23,13 @@ import (
 	"fmt"
 
 	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/director"
 	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/param"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
 )
 
 func DirectorServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group) error {

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -110,7 +110,7 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (context.Canc
 
 	if modules.IsEnabled(config.DirectorType) {
 
-		viper.Set("Director.DefaultResponse", "cache")
+		viper.Set("Director.DefaultResponse", param.Director_DefaultResponse.GetString())
 
 		viper.Set("Federation.DirectorURL", param.Server_ExternalWebUrl.GetString())
 

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -109,9 +109,7 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (context.Canc
 	}
 
 	if modules.IsEnabled(config.DirectorType) {
-
-		viper.Set("Director.DefaultResponse", param.Director_DefaultResponse.GetString())
-
+		viper.SetDefault("Director.DefaultResponse", "cache")
 		viper.Set("Federation.DirectorURL", param.Server_ExternalWebUrl.GetString())
 
 		if err = DirectorServe(ctx, engine, egrp); err != nil {


### PR DESCRIPTION
Short and sweet, this should allow us to issue HEAD requests against the API the `/api/v1.0/director/<origin or object>` endpoints. The tagged issue also mentioned making this compatible with our shortcut middleware in the director, but it looks like it already was -- the middleware was agnostic of verbs that weren't `PUT`. My addition to the middleware here explicitly ties `GET/HEAD` requests to the appropriate redirect functions so that other verbs we don't anticipate don't creep in.

One thing to note is that if a client who issues a `HEAD` for some resource chooses to follow the redirect, XRootD appears to hang with an open connection. Since that's in XRootD land, I'm considering it outside the scope of this small fix.

Closes #754