### PR TITLE
Allow recursive uploads/downloads in plugin

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -440,10 +440,7 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 				if transfer.url.Query().Get("pack") != "" {
 					transfer.localFile = filepath.Dir(transfer.localFile)
 				}
-				transfer.localFile, err = parseDestination(transfer)
-				if err != nil {
-					return err
-				}
+				transfer.localFile = parseDestination(transfer)
 			}
 
 			var tj *client.TransferJob
@@ -527,20 +524,19 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 // Gets the absolute path for the local destination. This is important
 // especially for downloaded directories so that the downloaded files end up
 // in the directory specified for download.
-func parseDestination(transfer PluginTransfer) (parsedDest string, err error) {
-	var destStat fs.FileInfo
+func parseDestination(transfer PluginTransfer) (parsedDest string) {
 	// get absolute path
 	destPath, _ := filepath.Abs(transfer.localFile)
 	// Check if path exists or if its in a folder
-	if destStat, err = os.Stat(destPath); os.IsNotExist(err) {
-		return destPath, err
+	if destStat, err := os.Stat(destPath); os.IsNotExist(err) {
+		return destPath
 	} else if destStat.IsDir() {
 		// If we are a directory, add the source filename to the destination dir
 		sourceFilename := path.Base(transfer.url.Path)
 		parsedDest = path.Join(destPath, sourceFilename)
-		return parsedDest, nil
+		return parsedDest
 	}
-	return transfer.localFile, nil
+	return transfer.localFile
 }
 
 // This function checks if we have a valid query (or no query) for the transfer URL

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -406,6 +406,7 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 	defer close(results)
 
 	jobMap := make(map[string]PluginTransfer)
+	var recursive bool
 
 	for {
 		select {
@@ -417,6 +418,12 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 				workChan = nil
 				break
 			}
+			if transfer.url.Query().Get("recursive") != "" {
+				recursive = true
+			} else {
+				recursive = false
+			}
+
 			if upload {
 				log.Debugln("Uploading:", transfer.localFile, "to", transfer.url)
 			} else {
@@ -427,12 +434,22 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 				if transfer.url.Query().Get("pack") != "" {
 					transfer.localFile = filepath.Dir(transfer.localFile)
 				}
+
+				// get absolute path
+				destPath, _ := filepath.Abs(transfer.localFile)
+				//Check if path exists or if its in a folder
+				if destStat, err := os.Stat(destPath); os.IsNotExist(err) {
+					transfer.localFile = destPath
+				} else if destStat.IsDir() {
+					sourceFilename := path.Base(transfer.url.Path)
+					transfer.localFile = path.Join(destPath, sourceFilename)
+				}
 			}
 
 			var tj *client.TransferJob
 			urlCopy := *transfer.url
 			project := client.GetProjectName()
-			tj, err = tc.NewTransferJob(context.Background(), &urlCopy, transfer.localFile, upload, false, project, client.WithAcquireToken(false), client.WithCaches(caches...))
+			tj, err = tc.NewTransferJob(context.Background(), &urlCopy, transfer.localFile, upload, recursive, project, client.WithAcquireToken(false), client.WithCaches(caches...))
 			if err != nil {
 				return errors.Wrap(err, "Failed to create new transfer job")
 			}

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -429,8 +429,7 @@ func TestParseDestination(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := parseDestination(test.transfer)
-			assert.NoError(t, err)
+			got := parseDestination(test.transfer)
 			if got != test.want {
 				t.Errorf("parseDestination() = %v, want %v", got, test.want)
 			}


### PR DESCRIPTION
Recursive uploads/downloads of directories work with the pelican plugin now! Tested with condor, it seems downloads work great however some functionality is not there for uploads when doing a transfer_output_remap. Going ahead to push this for now since it seems to be working for us. To do this, run:

stash_plugin osdf:///<some/path/to/directory>?recursive=true .

I decided to hold off on a unit test since it is not much different from our current recursive uploads/downloads tests and this can be a test ran in the condor test infastructure in the future.