### PR TITLE
Changes to dir listings in Pelican client

### DIFF
--- a/client/director.go
+++ b/client/director.go
@@ -52,7 +52,6 @@ func CreateNsFromDirectorResp(dirResp *http.Response) (namespace namespaces.Name
 	namespace.Path = xPelicanNamespace["namespace"]
 	namespace.UseTokenOnRead, _ = strconv.ParseBool(xPelicanNamespace["require-token"])
 	namespace.ReadHTTPS, _ = strconv.ParseBool(xPelicanNamespace["readhttps"])
-	namespace.DirListHost = xPelicanNamespace["collections-url"]
 
 	xPelicanAuthorization := []string{} // map of header to x - single entry - want to create an array for issuer
 	if len(dirResp.Header.Values("X-Pelican-Authorization")) > 0 {

--- a/director/director.go
+++ b/director/director.go
@@ -382,6 +382,15 @@ func redirectToOrigin(ginCtx *gin.Context) {
 		return
 	}
 
+	// This is for a PROPFIND, for now, we will assume 1 origin but we will need to revisit
+	if ginCtx.Request.Method == "PROPFIND" {
+		ginCtx.Request.Header.Set("Depth", "1")
+		// We should only have one origin here, but we'll just take the first one
+		redirectURL := getRedirectURL(reqPath, originAds[0], !namespaceAd.PublicRead)
+		ginCtx.Redirect(http.StatusTemporaryRedirect, getFinalRedirectURL(redirectURL, authzBearerEscaped))
+		return
+	}
+
 	linkHeader := ""
 	first := true
 	for idx, ad := range originAds {

--- a/director/director.go
+++ b/director/director.go
@@ -490,6 +490,13 @@ func ShortcutMiddleware(defaultResponse string) gin.HandlerFunc {
 			checkHostnameRedirects(c, xForwardedHost[0])
 		}
 
+		// If we are doing a PROPFIND, we should always redirect to the origin
+		if c.Request.Method == "PROPFIND" {
+			redirectToOrigin(c)
+			c.Abort()
+			return
+		}
+
 		// If we're configured for cache mode or we haven't set the flag,
 		// we should use cache middleware
 		if defaultResponse == "cache" {
@@ -846,6 +853,11 @@ func RegisterDirectorAPI(ctx context.Context, router *gin.RouterGroup) {
 		directorAPIV1.GET("/namespaces/prefix/*path", getPrefixByPath)
 		directorAPIV1.GET("/healthTest/*path", getHealthTestFile)
 		directorAPIV1.HEAD("/healthTest/*path", getHealthTestFile)
+		directorAPIV1.Any("/origin", func(gctx *gin.Context) { // Need to do this for PROPFIND since gin does not support it
+			if gctx.Request.Method == "PROPFIND" {
+				redirectToOrigin(gctx)
+			}
+		})
 
 		// In the foreseeable feature, director will scrape all servers in Pelican ecosystem (including registry)
 		// so that director can be our point of contact for collecting system-level metrics.

--- a/namespaces/namespaces.go
+++ b/namespaces/namespaces.go
@@ -87,7 +87,6 @@ type Namespace struct {
 	ReadHTTPS            bool                  `json:"readhttps"`
 	UseTokenOnRead       bool                  `json:"usetokenonread"`
 	WriteBackHost        string                `json:"writebackhost"`
-	DirListHost          string                `json:"dirlisthost"`
 }
 
 // GetCaches returns the list of caches for the namespace


### PR DESCRIPTION
This removes the need for namespaces to advertise "dirlisthost" since we can get that information with a PROPFIND request to the origin through a director redirect.