### PR TITLE
Remove Testing Code

### DIFF
--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -874,6 +874,7 @@ description: >-
   number of connections to this value.
 type: int
 default: none
+components: ["cache"]
 ---
 name: Cache.EnableLotman
 description: >-

--- a/web_ui/frontend/app/config/page.tsx
+++ b/web_ui/frontend/app/config/page.tsx
@@ -368,7 +368,7 @@ function Config() {
         const filteredConfig: Config = structuredClone(config)
         Object.entries(configMetadata).forEach(([key, value]) => {
 
-            if([...enabledServers, "*", "cache"].filter(i => value.components.includes(i)).length === 0) {
+            if([...enabledServers, "*"].filter(i => value.components.includes(i)).length === 0) {
                 deleteKey(filteredConfig, key.split("."))
             } else {
                 updateValue(filteredConfig, key.split("."), configMetadata[key])


### PR DESCRIPTION
Added a 'cache' string [here](https://github.com/PelicanPlatform/pelican/pull/889/files#diff-e64181cce5ce490155a33cdffaa48b7eea8d1f07e4c7f0aef3ae447f720e7641) so that I could view the cache only `Lotman` configuration. 

This is to remove that leaked testing code. 