### PR TITLE
Refactor registry namespace check to be compatible with OSDF topology

### DIFF
--- a/director/director.go
+++ b/director/director.go
@@ -552,8 +552,8 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 					ctx.JSON(http.StatusForbidden, gin.H{"approval_error": true, "error": fmt.Sprintf("The namespace %q was not approved by an administrator", namespace.Path)})
 					return
 				} else {
-					log.Warningln("Failed to verify token:", err)
-					ctx.JSON(http.StatusForbidden, gin.H{"error": fmt.Sprintf("Authorization token verification failed %v", err)})
+					log.Warningln("Failed to verify token: ", err)
+					ctx.JSON(http.StatusForbidden, gin.H{"error": fmt.Sprintf("Authorization token verification failed: %v", err)})
 					return
 				}
 			}

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -87,7 +87,12 @@ func checkNamespaceStatus(prefix string, registryWebUrlStr string) (bool, error)
 			log.Warningf("Request %q hit 404, either it's an OSDF registry or Pelican registry <= 7.4.0. Fallback to return true for approval status check", reqUrl.String())
 			return true, nil
 		} else {
-			return false, errors.New(fmt.Sprintf("Server error with status code %d", res.StatusCode))
+			body, err := io.ReadAll(res.Body)
+			if err != nil {
+				return false, errors.New(fmt.Sprintf("Registry returns error when checkNamespaceStatus %d and can't get the response body %v", res.StatusCode, err))
+			} else {
+				return false, errors.New(fmt.Sprintf("Registry returns error when checkNamespaceStatus %d with body %s", res.StatusCode, string(body)))
+			}
 		}
 	}
 

--- a/launcher_utils/advertise.go
+++ b/launcher_utils/advertise.go
@@ -62,6 +62,7 @@ func doAdvertise(ctx context.Context, servers []server_structs.XRootDServer) {
 
 // Launch periodic advertise of xrootd servers (origin and cache) to the director, in the errogroup
 func LaunchPeriodicAdvertise(ctx context.Context, egrp *errgroup.Group, servers []server_structs.XRootDServer) error {
+	metrics.SetComponentHealthStatus(metrics.OriginCache_Federation, metrics.StatusWarning, "First attempt to advertise to the director...")
 	doAdvertise(ctx, servers)
 
 	ticker := time.NewTicker(1 * time.Minute)
@@ -73,7 +74,7 @@ func LaunchPeriodicAdvertise(ctx context.Context, egrp *errgroup.Group, servers 
 				err := Advertise(ctx, servers)
 				if err != nil {
 					log.Warningln("XRootD server advertise failed:", err)
-					metrics.SetComponentHealthStatus(metrics.OriginCache_Federation, metrics.StatusCritical, fmt.Sprintf("XRootD server advertise failed: %v", err))
+					metrics.SetComponentHealthStatus(metrics.OriginCache_Federation, metrics.StatusCritical, fmt.Sprintf("XRootD server failed to advertise to the director: %v", err))
 				} else {
 					metrics.SetComponentHealthStatus(metrics.OriginCache_Federation, metrics.StatusOK, "")
 				}

--- a/launchers/cache_serve.go
+++ b/launchers/cache_serve.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pelicanplatform/pelican/daemon"
 	"github.com/pelicanplatform/pelican/launcher_utils"
 	"github.com/pelicanplatform/pelican/lotman"
+	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/server_utils"
@@ -114,5 +115,6 @@ func CacheServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, m
 
 // Finish configuration of the cache server.
 func CacheServeFinish(ctx context.Context, egrp *errgroup.Group) error {
+	metrics.SetComponentHealthStatus(metrics.OriginCache_Registry, metrics.StatusWarning, "Start to register namespaces for the cache server")
 	return launcher_utils.RegisterNamespaceWithRetry(ctx, egrp, "/caches/"+param.Xrootd_Sitename.GetString())
 }

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -237,7 +237,7 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (context.Canc
 
 	// Origin needs to advertise once before the cache starts
 	if modules.IsEnabled(config.CacheType) && modules.IsEnabled(config.OriginType) {
-		log.Debug("Advertise Origin")
+		log.Debug("Advertise Origin and Cache to the Director")
 		if err = launcher_utils.Advertise(ctx, servers); err != nil {
 			return shutdownCancel, err
 		}
@@ -312,7 +312,7 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (context.Canc
 	}
 
 	if modules.IsEnabled(config.OriginType) || modules.IsEnabled(config.CacheType) {
-		log.Debug("Launching periodic advertise")
+		log.Debug("Launching periodic advertise of origin/cache server to the director")
 		if err := launcher_utils.LaunchPeriodicAdvertise(ctx, egrp, servers); err != nil {
 			return shutdownCancel, err
 		}

--- a/launchers/origin_serve.go
+++ b/launchers/origin_serve.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/launcher_utils"
+	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/oa4mp"
 	"github.com/pelicanplatform/pelican/origin"
 	"github.com/pelicanplatform/pelican/param"
@@ -110,6 +111,7 @@ func OriginServeFinish(ctx context.Context, egrp *errgroup.Group) error {
 		return err
 	}
 
+	metrics.SetComponentHealthStatus(metrics.OriginCache_Registry, metrics.StatusWarning, "Start to register namespaces for the origin server")
 	for _, export := range *originExports {
 		if err := launcher_utils.RegisterNamespaceWithRetry(ctx, egrp, export.FederationPrefix); err != nil {
 			return err

--- a/metrics/health.go
+++ b/metrics/health.go
@@ -69,7 +69,8 @@ const (
 	OriginCache_XRootD        HealthStatusComponent = "xrootd"
 	OriginCache_CMSD          HealthStatusComponent = "cmsd"
 	OriginCache_Federation    HealthStatusComponent = "federation" // Advertise to the director
-	OriginCache_Director      HealthStatusComponent = "director"   // File transfer with director
+	OriginCache_Director      HealthStatusComponent = "director"   // File transfer tests with director
+	OriginCache_Registry      HealthStatusComponent = "registry"   // Register namespace at the registry
 	DirectorRegistry_Topology HealthStatusComponent = "topology"   // Fetch data from OSDF topology
 	Server_WebUI              HealthStatusComponent = "web-ui"
 )

--- a/origin/origin.go
+++ b/origin/origin.go
@@ -39,7 +39,7 @@ func RegisterOriginAPI(router *gin.Engine, ctx context.Context, egrp *errgroup.G
 		return errors.New("Origin configuration passed a nil pointer")
 	}
 
-	metrics.SetComponentHealthStatus(metrics.OriginCache_Director, metrics.StatusWarning, "Initializing origin, unknown status for director")
+	metrics.SetComponentHealthStatus(metrics.OriginCache_Director, metrics.StatusWarning, "Initializing the server, unknown status from the director file transfer test")
 	// start the timer for the director test report timeout
 	server_utils.LaunchPeriodicDirectorTimeout(ctx, egrp, notificationChan)
 

--- a/registry/client_commands.go
+++ b/registry/client_commands.go
@@ -104,18 +104,18 @@ func NamespaceRegisterWithIdentity(privateKey jwk.Key, namespaceRegistryEndpoint
 func NamespaceRegister(privateKey jwk.Key, namespaceRegistryEndpoint string, accessToken string, prefix string) error {
 	publicKey, err := privateKey.PublicKey()
 	if err != nil {
-		return errors.Wrapf(err, "Failed to generate public key for namespace registration")
+		return errors.Wrapf(err, "failed to generate public key for namespace registration")
 	}
 	err = jwk.AssignKeyID(publicKey)
 	if err != nil {
-		return errors.Wrap(err, "Failed to assign key ID to public key")
+		return errors.Wrap(err, "failed to assign key ID to public key")
 	}
 	if err = publicKey.Set("alg", "ES256"); err != nil {
-		return errors.Wrap(err, "Failed to assign signature algorithm to public key")
+		return errors.Wrap(err, "failed to assign signature algorithm to public key")
 	}
 	keySet := jwk.NewSet()
 	if err = keySet.AddKey(publicKey); err != nil {
-		return errors.Wrap(err, "Failed to add public key to new JWKS")
+		return errors.Wrap(err, "failed to add public key to new JWKS")
 	}
 
 	if log.IsLevelEnabled(log.DebugLevel) {
@@ -129,7 +129,7 @@ func NamespaceRegister(privateKey jwk.Key, namespaceRegistryEndpoint string, acc
 
 	clientNonce, err := generateNonce()
 	if err != nil {
-		return errors.Wrap(err, "Failed to generate client nonce")
+		return errors.Wrap(err, "failed to generate client nonce")
 	}
 
 	data := map[string]interface{}{
@@ -143,14 +143,14 @@ func NamespaceRegister(privateKey jwk.Key, namespaceRegistryEndpoint string, acc
 	// Handle case where there was an error encoded in the body
 	if err != nil {
 		if unmarshalErr := json.Unmarshal(resp, &respData); unmarshalErr == nil { // Error creating json
-			return errors.Wrapf(err, "Failed to make request (server message is '%v')", respData.Error)
+			return errors.Wrapf(err, "failed to make request (server message is '%v')", respData.Error)
 		}
-		return errors.Wrap(err, "Failed to make request")
+		return errors.Wrap(err, "failed to make request at "+namespaceRegistryEndpoint)
 	}
 
 	// No error
 	if err = json.Unmarshal(resp, &respData); err != nil {
-		return errors.Wrap(err, "Failure when parsing JSON response from client")
+		return errors.Wrap(err, "failure when parsing JSON response from client")
 	}
 
 	// Create client payload by concatenating client_nonce and server_nonce
@@ -159,11 +159,11 @@ func NamespaceRegister(privateKey jwk.Key, namespaceRegistryEndpoint string, acc
 	// Sign the payload
 	privateKeyRaw := &ecdsa.PrivateKey{}
 	if err = privateKey.Raw(privateKeyRaw); err != nil {
-		return errors.Wrap(err, "Failed to get an ECDSA private key")
+		return errors.Wrap(err, "failed to get an ECDSA private key")
 	}
 	signature, err := signPayload([]byte(clientPayload), privateKeyRaw)
 	if err != nil {
-		return errors.Wrap(err, "Failed to sign payload")
+		return errors.Wrap(err, "failed to sign payload")
 	}
 
 	// // Create data for the second POST request
@@ -186,14 +186,14 @@ func NamespaceRegister(privateKey jwk.Key, namespaceRegistryEndpoint string, acc
 	// Handle case where there was an error encoded in the body
 	if unmarshalErr := json.Unmarshal(resp, &respData); unmarshalErr == nil {
 		if err != nil {
-			return errors.Wrapf(err, "Failed to make request: %v", respData.Error)
+			return errors.Wrapf(err, "failed to register the namespace: %v", respData.Error)
 		}
 		fmt.Println(respData.Message)
 	} else {
 		if err != nil {
-			return errors.Wrapf(err, "Failed to make request: %s", resp)
+			return errors.Wrapf(err, "failed to register the namespace: %s", string(resp))
 		}
-		return errors.Wrapf(unmarshalErr, "Failed to unmarshall request response: %v", respData.Error)
+		return errors.Wrapf(unmarshalErr, "failed to decode the response of the request to register the namespace: %v", respData.Error)
 	}
 
 	return nil

--- a/registry/client_commands_test.go
+++ b/registry/client_commands_test.go
@@ -173,9 +173,11 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 	// we deny it
 	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo/foo/bar")
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "The namespace /topo/foo/bar already exists in the OSDF topology. To register a Pelican equivalence, you need to present your identity.")
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo/foo")
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "The namespace /topo/foo already exists in the OSDF topology. To register a Pelican equivalence, you need to present your identity.")
 
 	// Now we create a new key and try to use it to register a super/sub space. These shouldn't succeed
 	viper.Set("IssuerKey", t.TempDir()+"/keychaining")
@@ -208,9 +210,10 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo")
 	require.NoError(t, err)
 
-	// Finally, test with one value for topo
+	// However, topology check should be independent of key chaining check
 	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo")
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "The namespace /topo already exists in the OSDF topology. To register a Pelican equivalence, you need to present your identity.")
 
 	config.SetPreferredPrefix("pelican")
 	viper.Reset()

--- a/registry/client_commands_test.go
+++ b/registry/client_commands_test.go
@@ -174,11 +174,11 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 	// we deny it
 	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo/foo/bar")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "The namespace /topo/foo/bar already exists in the OSDF topology. To register a Pelican equivalence, you need to present your identity.")
+	assert.Contains(t, err.Error(), "A superspace or subspace of this namespace /topo/foo/bar already exists in the OSDF topology: /topo/foo. To register a Pelican equivalence, you need to present your identity.")
 
 	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo/foo")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "The namespace /topo/foo already exists in the OSDF topology. To register a Pelican equivalence, you need to present your identity.")
+	assert.Contains(t, err.Error(), "A superspace or subspace of this namespace /topo/foo already exists in the OSDF topology: /topo/foo. To register a Pelican equivalence, you need to present your identity.")
 
 	// Now we create a new key and try to use it to register a super/sub space. These shouldn't succeed
 	viper.Set("IssuerKey", t.TempDir()+"/keychaining")
@@ -214,7 +214,7 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 	// However, topology check should be independent of key chaining check
 	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "The namespace /topo already exists in the OSDF topology. To register a Pelican equivalence, you need to present your identity.")
+	assert.Contains(t, err.Error(), "A superspace or subspace of this namespace /topo already exists in the OSDF topology: /topo/foo. To register a Pelican equivalence, you need to present your identity.")
 
 	_, err = config.SetPreferredPrefix("pelican")
 	assert.NoError(t, err)

--- a/registry/client_commands_test.go
+++ b/registry/client_commands_test.go
@@ -169,8 +169,8 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/test")
 	require.NoError(t, err)
 
-	// For now, we simply don't allow further super/sub spacing of namespaces from topo, because how
-	// can we validate via a key if there is none?
+	// If the namespace is a subspace from the topology and is registered without the identity
+	// we deny it
 	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo/foo/bar")
 	require.Error(t, err)
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -307,7 +307,6 @@ func keySignChallengeCommit(ctx *gin.Context, data *registrationData) (bool, map
 		}
 		ns.Pubkey = string(pubkeyData)
 		ns.Identity = data.Identity
-		ns.Topology = false
 
 		if data.Identity != "" {
 			idMap := map[string]interface{}{}
@@ -856,11 +855,6 @@ func checkNamespaceStatusHandler(ctx *gin.Context) {
 		return
 	}
 	ns, err := getNamespaceByPrefix(req.Prefix)
-	if ns.Topology {
-		res := server_structs.CheckNamespaceStatusRes{Approved: true}
-		ctx.JSON(http.StatusOK, res)
-		return
-	}
 	if err != nil || ns == nil {
 		log.Errorf("Error in getNamespaceByPrefix with prefix %s. %v", req.Prefix, err)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Error getting namespace"})

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -323,11 +323,14 @@ func keySignChallengeCommit(ctx *gin.Context, data *registrationData) (bool, map
 					ns.AdminMetadata.UserID = val
 				}
 			}
+			if inTopo {
+				ns.AdminMetadata.Description = "[ Attention: Prefix exists in OSDF topology ] "
+			}
 			userName, ok := idMap["name"]
 			if ok {
 				val, ok := userName.(string)
 				if ok {
-					ns.AdminMetadata.Description = "User name: " + val + " "
+					ns.AdminMetadata.Description += "User name: " + val + " "
 				}
 			}
 			email, ok := idMap["email"]
@@ -370,7 +373,7 @@ func keySignChallengeCommit(ctx *gin.Context, data *registrationData) (bool, map
 		} else {
 			msg := fmt.Sprintf("Prefix %s successfully registered", ns.Prefix)
 			if inTopo {
-				msg = fmt.Sprintf("Prefix %s successfully registered. Note that there is an existing namespace prefix in the OSDF topology. The register admin will review your request and approve your namespace if this is expected.", ns.Prefix)
+				msg = fmt.Sprintf("Prefix %s successfully registered. Note that there is an existing namespace prefix in the OSDF topology. The registry admin will review your request and approve your namespace if this is expected.", ns.Prefix)
 			}
 			return true, map[string]interface{}{
 				"message": msg,

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -178,7 +178,7 @@ func namespaceExistsByPrefix(prefix string) (bool, error) {
 	return count > 0, nil
 }
 
-// Check if a namespace exists in the Namespace table
+// Check if a namespace exists in the Topology table
 func topologyNamespaceExistsByPrefix(prefix string) (bool, error) {
 	var count int64
 
@@ -190,9 +190,7 @@ func topologyNamespaceExistsByPrefix(prefix string) (bool, error) {
 }
 
 func namespaceSupSubChecks(prefix string) (superspaces []string, subspaces []string, inTopo bool, err error) {
-	// The very first thing we do is check if there's a match in topo -- if there is, for now
-	// we simply refuse to allow registration of a superspace or a subspace, assuming the registrant
-	// has to go through topology
+	// The very first thing we do is check if there's a match in topo. We simply flag it's in topology if so
 	if config.GetPreferredPrefix() == "OSDF" {
 		topoSuperSubQuery := `
 		SELECT prefix FROM topology WHERE (? || '/') LIKE (prefix || '/%')
@@ -206,9 +204,7 @@ func namespaceSupSubChecks(prefix string) (superspaces []string, subspaces []str
 		}
 
 		if len(results) > 0 {
-			// If we get here, there was a match -- it's a trap!
 			inTopo = true
-			return
 		}
 	}
 

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -80,7 +80,6 @@ type Namespace struct {
 	Identity      string                 `json:"identity" post:"exclude"`
 	AdminMetadata AdminMetadata          `json:"admin_metadata" gorm:"serializer:json"`
 	CustomFields  map[string]interface{} `json:"custom_fields" gorm:"serializer:json"`
-	Topology      bool                   `json:"topology" gorm:"-:all" post:"exclude"` //This field is an extra field that's not included in the db
 }
 
 type NamespaceWOPubkey struct {
@@ -168,23 +167,26 @@ func createTopologyTable() error {
 	return nil
 }
 
-// Check if a namespace exists in either Topology or Pelican registry
+// Check if a namespace exists in the Namespace table
 func namespaceExistsByPrefix(prefix string) (bool, error) {
+	var count int64
+
+	err := db.Model(&Namespace{}).Where("prefix = ?", prefix).Count(&count).Error
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// Check if a namespace exists in the Namespace table
+func topologyNamespaceExistsByPrefix(prefix string) (bool, error) {
 	var count int64
 
 	err := db.Model(&Topology{}).Where("prefix = ?", prefix).Count(&count).Error
 	if err != nil {
 		return false, err
 	}
-	if count > 0 {
-		return true, nil
-	} else {
-		err = db.Model(&Namespace{}).Where("prefix = ?", prefix).Count(&count).Error
-		if err != nil {
-			return false, err
-		}
-		return count > 0, nil
-	}
+	return count > 0, nil
 }
 
 func namespaceSupSubChecks(prefix string) (superspaces []string, subspaces []string, inTopo bool, err error) {
@@ -334,31 +336,17 @@ func getNamespaceById(id int) (*Namespace, error) {
 	return &ns, nil
 }
 
+// Get an entry from the namespace table based on the prefix
 func getNamespaceByPrefix(prefix string) (*Namespace, error) {
-	// This function will check the topology table first to see if the
-	// namespace exists there before checking the namespace table
-	// If the namespace exists in the topology table, it will be wrapped
-	// as a pelican namespace before being returned
 	if prefix == "" {
-		return nil, errors.New("Invalid prefix. Prefix must not be empty")
+		return nil, errors.New("invalid prefix. Prefix must not be empty")
 	}
-	tp := Topology{}
-	err := db.Where("prefix = ?", prefix).Last(&tp).Error
-	var ns = Namespace{}
+	ns := Namespace{}
+	err := db.Where("prefix = ? ", prefix).Last(&ns).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		err := db.Where("prefix = ? ", prefix).Last(&ns).Error
-		ns.Topology = false
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, fmt.Errorf("namespace with prefix %q not found in database", prefix)
-		} else if err != nil {
-			return nil, errors.Wrap(err, "error retrieving the namespace by its prefix")
-		}
+		return nil, fmt.Errorf("namespace with id %q not found in database", prefix)
 	} else if err != nil {
-		return nil, errors.Wrap(err, "error retrieving the namespace by its prefix")
-	} else {
-		ns.ID = tp.ID
-		ns.Prefix = tp.Prefix
-		ns.Topology = true
+		return nil, errors.Wrap(err, "error retrieving pubkey")
 	}
 
 	// By default, JSON unmarshal will convert any generic number to float

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -342,7 +342,7 @@ func getNamespaceByPrefix(prefix string) (*Namespace, error) {
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, fmt.Errorf("namespace with id %q not found in database", prefix)
 	} else if err != nil {
-		return nil, errors.Wrap(err, "error retrieving pubkey")
+		return nil, errors.Wrap(err, "error retrieving namespace registration by its prefix")
 	}
 
 	// By default, JSON unmarshal will convert any generic number to float

--- a/registry/registry_db_test.go
+++ b/registry/registry_db_test.go
@@ -732,59 +732,6 @@ func topologyMockup(t *testing.T, namespaces []string) *httptest.Server {
 	return svr
 }
 
-func TestGetNamespaceByPrefix(t *testing.T) {
-	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
-	defer func() { require.NoError(t, egrp.Wait()) }()
-	defer cancel()
-
-	viper.Reset()
-
-	topoNamespaces := []string{"/topo/foo"}
-	svr := topologyMockup(t, topoNamespaces)
-	defer svr.Close()
-
-	registryDB := t.TempDir()
-	viper.Set("Registry.DbLocation", filepath.Join(registryDB, "test.sqlite"))
-	viper.Set("Federation.TopologyNamespaceURL", svr.URL)
-	config.InitConfig()
-
-	err := InitializeDB(ctx)
-	require.NoError(t, err)
-	defer func() {
-		err := ShutdownDB()
-		assert.NoError(t, err)
-	}()
-
-	//Test topology table population
-	err = createTopologyTable()
-	require.NoError(t, err)
-	err = PopulateTopology()
-	require.NoError(t, err)
-
-	//Test that getNamespaceByPrefix wraps a pelican namespace around a topology one
-	ns, err := getNamespaceByPrefix("/topo/foo")
-	require.NoError(t, err)
-	require.True(t, ns.Topology)
-
-	// Add a test namespace so we can test that checkExists still works
-	new_ns := Namespace{
-		ID:            0,
-		Prefix:        "/regular/foo",
-		Pubkey:        "",
-		Identity:      "",
-		AdminMetadata: AdminMetadata{},
-	}
-	err = AddNamespace(&new_ns)
-	require.NoError(t, err)
-
-	//Test that getNamespaceByPrefix returns namespace with a false topology variable
-	ns_reg, err := getNamespaceByPrefix("/regular/foo")
-	require.NoError(t, err)
-	require.False(t, ns_reg.Topology)
-
-	viper.Reset()
-}
-
 func TestRegistryTopology(t *testing.T) {
 	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
 	defer func() { require.NoError(t, egrp.Wait()) }()

--- a/registry/registry_db_test.go
+++ b/registry/registry_db_test.go
@@ -765,12 +765,12 @@ func TestRegistryTopology(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check that topology namespace exists
-	exists, err := namespaceExistsByPrefix("/topo/foo")
+	exists, err := topologyNamespaceExistsByPrefix("/topo/foo")
 	require.NoError(t, err)
 	require.True(t, exists)
 
 	// Check that topology namespace exists
-	exists, err = namespaceExistsByPrefix("/topo/bar")
+	exists, err = topologyNamespaceExistsByPrefix("/topo/bar")
 	require.NoError(t, err)
 	require.True(t, exists)
 
@@ -786,9 +786,9 @@ func TestRegistryTopology(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check that the regular namespace exists
-	exists, err = namespaceExistsByPrefix("/regular/foo")
+	exists, err = topologyNamespaceExistsByPrefix("/regular/foo")
 	require.NoError(t, err)
-	require.True(t, exists)
+	require.False(t, exists)
 
 	// Check that a bad namespace doesn't exist
 	exists, err = namespaceExistsByPrefix("/bad/namespace")
@@ -810,24 +810,19 @@ func TestRegistryTopology(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check that /topo/foo still exists
-	exists, err = namespaceExistsByPrefix("/topo/foo")
+	exists, err = topologyNamespaceExistsByPrefix("/topo/foo")
 	require.NoError(t, err)
 	require.True(t, exists)
 
 	// And that /topo/baz was added
-	exists, err = namespaceExistsByPrefix("/topo/baz")
+	exists, err = topologyNamespaceExistsByPrefix("/topo/baz")
 	require.NoError(t, err)
 	require.True(t, exists)
 
 	// Check that /topo/bar is gone
-	exists, err = namespaceExistsByPrefix("/topo/bar")
+	exists, err = topologyNamespaceExistsByPrefix("/topo/bar")
 	require.NoError(t, err)
 	require.False(t, exists)
-
-	// Finally, check that /regular/foo survived
-	exists, err = namespaceExistsByPrefix("/regular/foo")
-	require.NoError(t, err)
-	require.True(t, exists)
 
 	viper.Reset()
 }

--- a/registry/registry_db_test.go
+++ b/registry/registry_db_test.go
@@ -827,3 +827,20 @@ func TestRegistryTopology(t *testing.T) {
 
 	viper.Reset()
 }
+
+func TestGetTopoPrefixString(t *testing.T) {
+	t.Run("empty-arr", func(t *testing.T) {
+		re := GetTopoPrefixString([]Topology{})
+		assert.Empty(t, re)
+	})
+
+	t.Run("one-item", func(t *testing.T) {
+		re := GetTopoPrefixString([]Topology{{Prefix: "/foo"}})
+		assert.Equal(t, "/foo", re)
+	})
+
+	t.Run("multiple-items", func(t *testing.T) {
+		re := GetTopoPrefixString([]Topology{{Prefix: "/foo"}, {Prefix: "/bar"}, {Prefix: "/barz"}})
+		assert.Equal(t, "/foo, /bar, /barz", re)
+	})
+}

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -423,7 +423,6 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 	}
 
 	ns := Namespace{}
-	ns.Topology = false
 	if ctx.ShouldBindJSON(&ns) != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid create or update namespace request"})
 		return
@@ -443,7 +442,6 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 		return
 	}
 	ns.Prefix = updated_prefix
-	ns.Topology = false
 
 	if !isUpdate {
 		// Check if prefix exists before doing anything else. Skip check if it's update operation

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -495,6 +495,9 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 		ns.AdminMetadata.UserID = user
 		// Overwrite status to Pending to filter malicious request
 		ns.AdminMetadata.Status = Pending
+		if inTopo {
+			ns.AdminMetadata.Description = "[ Attention: Prefix exists in OSDF topology ] " + ns.AdminMetadata.Description
+		}
 		if err := AddNamespace(&ns); err != nil {
 			log.Errorf("Failed to insert namespace with id %d. %v", ns.ID, err)
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Fail to insert namespace"})
@@ -502,7 +505,7 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 		}
 		msg := "success"
 		if inTopo {
-			msg = "Prefix is successfully registered. Note that there is an existing namespace prefix in the OSDF topology. The register admin will review your request and approve your namespace if this is expected."
+			msg = "Prefix is successfully registered. Note that there is an existing namespace prefix in the OSDF topology. The registry admin will review your request and approve your namespace if this is expected."
 		}
 		ctx.JSON(http.StatusOK, gin.H{"msg": msg})
 	} else { // Update

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -464,7 +464,7 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 	}
 
 	// Check if the parent or child path along the prefix has been registered
-	valErr, sysErr := validateKeyChaining(ns.Prefix, pubkey)
+	inTopo, valErr, sysErr := validateKeyChaining(ns.Prefix, pubkey)
 	if valErr != nil {
 		log.Errorln("Bad prefix when validating key chaining", valErr)
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": valErr.Error()})
@@ -500,7 +500,11 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Fail to insert namespace"})
 			return
 		}
-		ctx.JSON(http.StatusOK, gin.H{"msg": "success"})
+		msg := "success"
+		if inTopo {
+			msg = "Prefix is successfully registered. Note that there is an existing namespace prefix in the OSDF topology. The register admin will review your request and approve your namespace if this is expected."
+		}
+		ctx.JSON(http.StatusOK, gin.H{"msg": msg})
 	} else { // Update
 		// First check if the namespace exists
 		exists, err := namespaceExistsById(ns.ID)

--- a/registry/registry_ui_test.go
+++ b/registry/registry_ui_test.go
@@ -941,7 +941,7 @@ func TestCreateNamespace(t *testing.T) {
 		body, err := io.ReadAll(w.Result().Body)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, w.Result().StatusCode)
-		assert.JSONEq(t, `{"msg":"Prefix is successfully registered. Note that there is an existing namespace prefix in the OSDF topology. The registry admin will review your request and approve your namespace if this is expected."}`, string(body))
+		assert.JSONEq(t, `{"msg":"Prefix /topo/foo/bar successfully registered. Note that there is an existing superspace or subspace of the namespace in the OSDF topology: /topo/foo. The registry admin will review your request and approve your namespace if this is expected."}`, string(body))
 
 		nss, err := getAllNamespaces()
 		require.NoError(t, err)
@@ -983,7 +983,7 @@ func TestCreateNamespace(t *testing.T) {
 		body, err := io.ReadAll(w.Result().Body)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, w.Result().StatusCode)
-		assert.JSONEq(t, `{"msg":"Prefix is successfully registered. Note that there is an existing namespace prefix in the OSDF topology. The registry admin will review your request and approve your namespace if this is expected."}`, string(body))
+		assert.JSONEq(t, `{"msg":"Prefix /topo/foo successfully registered. Note that there is an existing superspace or subspace of the namespace in the OSDF topology: /topo/foo. The registry admin will review your request and approve your namespace if this is expected."}`, string(body))
 
 		nss, err := getAllNamespaces()
 		require.NoError(t, err)

--- a/registry/registry_ui_test.go
+++ b/registry/registry_ui_test.go
@@ -914,12 +914,13 @@ func TestCreateNamespace(t *testing.T) {
 	t.Run("osdf-topology-subspace-request-gives-200", func(t *testing.T) {
 		resetNamespaceDB(t)
 
-		config.SetPreferredPrefix("OSDF")
+		_, err := config.SetPreferredPrefix("OSDF")
+		require.NoError(t, err)
 		topoNamespaces := []string{"/topo/foo", "/topo/bar"}
 		svr := topologyMockup(t, topoNamespaces)
 		defer svr.Close()
 		viper.Set("Federation.TopologyNamespaceURL", svr.URL)
-		err := PopulateTopology()
+		err = PopulateTopology()
 		require.NoError(t, err)
 
 		mockInsts := []Institution{{ID: "1000"}}
@@ -955,12 +956,13 @@ func TestCreateNamespace(t *testing.T) {
 	t.Run("osdf-topology-same-prefix-request-gives-200", func(t *testing.T) {
 		resetNamespaceDB(t)
 
-		config.SetPreferredPrefix("OSDF")
+		_, err := config.SetPreferredPrefix("OSDF")
+		require.NoError(t, err)
 		topoNamespaces := []string{"/topo/foo", "/topo/bar"}
 		svr := topologyMockup(t, topoNamespaces)
 		defer svr.Close()
 		viper.Set("Federation.TopologyNamespaceURL", svr.URL)
-		err := PopulateTopology()
+		err = PopulateTopology()
 		require.NoError(t, err)
 
 		mockInsts := []Institution{{ID: "1000"}}

--- a/registry/registry_validation.go
+++ b/registry/registry_validation.go
@@ -69,15 +69,15 @@ func validatePrefix(nspath string) (string, error) {
 	return result, nil
 }
 
-func validateKeyChaining(prefix string, pubkey jwk.Key) (inTopo bool, validationError error, serverError error) {
+func validateKeyChaining(prefix string, pubkey jwk.Key) (inTopo bool, topoNss []Topology, validationError error, serverError error) {
 	// We don't check keyChaining for caches
 	if strings.HasPrefix(prefix, "/caches/") {
 		return
 	}
-	// Here, we do the check anyway but only returns error (if any)
-	// we the flag is on. This is to make sure the topology check is independent
+	// Here, we do the namespaceSupSubChecks anyway but only returns error (if any)
+	// when the Registry.RequireKeyChaining flag is on. This is to make sure the topology check is independent
 	// of key chaining check
-	superspaces, subspaces, inTopo, err := namespaceSupSubChecks(prefix)
+	superspaces, subspaces, inTopo, topoNss, err := namespaceSupSubChecks(prefix)
 	if !param.Registry_RequireKeyChaining.GetBool() {
 		return
 	} else {

--- a/registry/registry_validation.go
+++ b/registry/registry_validation.go
@@ -69,7 +69,7 @@ func validatePrefix(nspath string) (string, error) {
 	return result, nil
 }
 
-func validateKeyChaining(prefix string, pubkey jwk.Key) (validationError error, serverError error) {
+func validateKeyChaining(prefix string, pubkey jwk.Key) (inTopo bool, validationError error, serverError error) {
 	if !param.Registry_RequireKeyChaining.GetBool() {
 		return
 	}
@@ -83,11 +83,6 @@ func validateKeyChaining(prefix string, pubkey jwk.Key) (validationError error, 
 		return
 	}
 
-	// if not in OSDF mode, this will be false
-	if inTopo {
-		validationError = errors.New("Cannot register a super or subspace of a namespace already registered in topology")
-		return
-	}
 	// If we make the assumption that namespace prefixes are hierarchical, eg that the owner of /foo should own
 	// everything under /foo (/foo/bar, /foo/baz, etc), then it makes sense to check for superspaces first. If any
 	// superspace is found, they logically "own" the incoming namespace.

--- a/registry/registry_validation.go
+++ b/registry/registry_validation.go
@@ -70,17 +70,21 @@ func validatePrefix(nspath string) (string, error) {
 }
 
 func validateKeyChaining(prefix string, pubkey jwk.Key) (inTopo bool, validationError error, serverError error) {
-	if !param.Registry_RequireKeyChaining.GetBool() {
-		return
-	}
 	// We don't check keyChaining for caches
 	if strings.HasPrefix(prefix, "/caches/") {
 		return
 	}
+	// Here, we do the check anyway but only returns error (if any)
+	// we the flag is on. This is to make sure the topology check is independent
+	// of key chaining check
 	superspaces, subspaces, inTopo, err := namespaceSupSubChecks(prefix)
-	if err != nil {
-		serverError = errors.Wrap(err, "Server encountered an error checking if namespace already exists")
+	if !param.Registry_RequireKeyChaining.GetBool() {
 		return
+	} else {
+		if err != nil {
+			serverError = errors.Wrap(err, "Server encountered an error checking if namespace already exists")
+			return
+		}
 	}
 
 	// If we make the assumption that namespace prefixes are hierarchical, eg that the owner of /foo should own

--- a/registry/registry_validation_test.go
+++ b/registry/registry_validation_test.go
@@ -206,19 +206,19 @@ func TestValidateKeyChaining(t *testing.T) {
 
 	t.Run("off-param-no-check", func(t *testing.T) {
 		viper.Set("Registry.RequireKeyChaining", false)
-		validErr, serverErr := validateKeyChaining("/foo/barz", jwkFoo)
+		_, validErr, serverErr := validateKeyChaining("/foo/barz", jwkFoo)
 		assert.NoError(t, serverErr)
 		assert.NoError(t, validErr)
 	})
 
 	t.Run("on-param-does-check", func(t *testing.T) {
 		viper.Set("Registry.RequireKeyChaining", true)
-		validErr, serverErr := validateKeyChaining("/foo/barz", jwkFoo)
+		_, validErr, serverErr := validateKeyChaining("/foo/barz", jwkFoo)
 		// Same public key as /foo shouldn't give error
 		assert.NoError(t, serverErr)
 		assert.NoError(t, validErr)
 
-		validErr, serverErr = validateKeyChaining("/foo/barz", jwkMockNew)
+		_, validErr, serverErr = validateKeyChaining("/foo/barz", jwkMockNew)
 		// Same public key as /foo shouldn't give error
 		assert.NoError(t, serverErr)
 		assert.Error(t, validErr)
@@ -227,12 +227,12 @@ func TestValidateKeyChaining(t *testing.T) {
 
 	t.Run("on-param-ignore-cache", func(t *testing.T) {
 		viper.Set("Registry.RequireKeyChaining", true)
-		validErr, serverErr := validateKeyChaining("/cache/newCache", jwkCache)
+		_, validErr, serverErr := validateKeyChaining("/cache/newCache", jwkCache)
 		// Same public key as /cache/randomCache shouldn't give error
 		assert.NoError(t, serverErr)
 		assert.NoError(t, validErr)
 
-		validErr, serverErr = validateKeyChaining("/cache/newKey", jwkMockNew)
+		_, validErr, serverErr = validateKeyChaining("/cache/newKey", jwkMockNew)
 		// Different public key as /cache/randomCache shouldn't give error
 		assert.NoError(t, serverErr)
 		assert.NoError(t, validErr)

--- a/registry/registry_validation_test.go
+++ b/registry/registry_validation_test.go
@@ -206,19 +206,19 @@ func TestValidateKeyChaining(t *testing.T) {
 
 	t.Run("off-param-no-check", func(t *testing.T) {
 		viper.Set("Registry.RequireKeyChaining", false)
-		_, validErr, serverErr := validateKeyChaining("/foo/barz", jwkFoo)
+		_, _, validErr, serverErr := validateKeyChaining("/foo/barz", jwkFoo)
 		assert.NoError(t, serverErr)
 		assert.NoError(t, validErr)
 	})
 
 	t.Run("on-param-does-check", func(t *testing.T) {
 		viper.Set("Registry.RequireKeyChaining", true)
-		_, validErr, serverErr := validateKeyChaining("/foo/barz", jwkFoo)
+		_, _, validErr, serverErr := validateKeyChaining("/foo/barz", jwkFoo)
 		// Same public key as /foo shouldn't give error
 		assert.NoError(t, serverErr)
 		assert.NoError(t, validErr)
 
-		_, validErr, serverErr = validateKeyChaining("/foo/barz", jwkMockNew)
+		_, _, validErr, serverErr = validateKeyChaining("/foo/barz", jwkMockNew)
 		// Same public key as /foo shouldn't give error
 		assert.NoError(t, serverErr)
 		assert.Error(t, validErr)
@@ -227,12 +227,12 @@ func TestValidateKeyChaining(t *testing.T) {
 
 	t.Run("on-param-ignore-cache", func(t *testing.T) {
 		viper.Set("Registry.RequireKeyChaining", true)
-		_, validErr, serverErr := validateKeyChaining("/cache/newCache", jwkCache)
+		_, _, validErr, serverErr := validateKeyChaining("/cache/newCache", jwkCache)
 		// Same public key as /cache/randomCache shouldn't give error
 		assert.NoError(t, serverErr)
 		assert.NoError(t, validErr)
 
-		_, validErr, serverErr = validateKeyChaining("/cache/newKey", jwkMockNew)
+		_, _, validErr, serverErr = validateKeyChaining("/cache/newKey", jwkMockNew)
 		// Different public key as /cache/randomCache shouldn't give error
 		assert.NoError(t, serverErr)
 		assert.NoError(t, validErr)

--- a/web_ui/frontend/app/api/docs/pelican-swagger.yaml
+++ b/web_ui/frontend/app/api/docs/pelican-swagger.yaml
@@ -871,7 +871,10 @@ paths:
           required: true
       responses:
         "200":
-          description: OK
+          description: >
+            OK.
+            Note that if the registry runs in the OSDF mode,
+            the `"message"` will reflect if there's an existing namespace in the OSDF topology.
           schema:
             type: object
             $ref: "#/definitions/SuccessModel"

--- a/web_ui/frontend/components/StatusBox.tsx
+++ b/web_ui/frontend/components/StatusBox.tsx
@@ -64,7 +64,12 @@ function StatusDisplay({component, status, message}: StatusDisplayProps) {
         case "director":
             component = "Director"
             break
+        case "registry":
+            component = "Registry"
+            break
         default:
+            // Capitalize the component name by default if it has more than 1 letters
+            component = component.length > 1 ? component.charAt(0).toUpperCase() + component.slice(1) : component
     }
 
     return (


### PR DESCRIPTION
Closes #1029 

## Other fixes
* Added a `Registry` health component to the UI to should if registering namespace succeeded or not
* Better status tracking/updates of the health component overall
* Better error messages and plumbing

The updated policy is as follows (only for OSDF):

Given that a namespace exists in the topology, say `/foo`:
* If an origin server has prefix `/foo` or `/foo/**/**`, and the admin starts the server without registering the namespace at registry website, the auto-registration in the origin will _fail_, with an error message to ask them register the namespace at the registry web UI:
```
The namespace <namespace> already exists in the OSDF topology. To register a Pelican equivalence, you need to present your identity. If you are registering through Pelican CLI, try again with the flag '--with-identity' enabled. If this is an auto-registration from a Pelican origin or cache server, register your namespace or server through the Pelican registry website at <registry url> instead.
```
* If the admin attempts to register a namespace `/foo` or `/foo/**/**` via Pelican CLI (`pelican namespace register`) but without the `--with-identity` flag, the registration will also _fail_, with the same error message as above
* If the admin register the namespace /foo` or `/foo/**/**` via Pelican CLI  with `--with-identity` flag OR via the registry web UI. The registration will succeed. However, there will be a note in the registration `Description` field as `[ Attention: Prefix exists in OSDF topology ]` to warn the registry admin to pay extra attention when reviewing it.

This PR also removes topology check from `checkNamespaceExists` and function alike to maintain consistency.

**Pitfall**: This should fix all the incompatibility between Pelican namespace and OSDF legacy namespaces. However, one pitfall is that the director also fetches namespace from both OSDF and Pelican servers, and there can be two situations:
* The Pelican origin server that serves the OSDF namespace prefix has the **exactly the same** origin server advertisement as we parsed from the topology. This way, the two server advertisement will race against each other every time we update topology/origin server advertises itself to the director. The consequence is unknown
* The Pelican origin server has different fields in the origin advertisement, and we record both in the director TTL cache. Then we essentially have two servers serving the same namespace, which shouldn't be an issue, just make things a bit intertwined.

-----

## How to test

Here's the instruction to test the fix e2e:

* Configuration file (Note the `FederationPrefix`, `DbLocation`, and `Loggin.Level`

```
Origin:
  Exports:
    - StoragePrefix: /tmp/stash
      FederationPrefix: /chtc/itb/<your mock name>
      Capabilities: ["Reads", "PublicReads", "DirectReads"]
Federation:
  DiscoveryUrl: "https://<your container hostname>:8444"
  TopologyNamespaceUrl: "https://topology.opensciencegrid.org/stashcache/namespaces.json"
TLSSkipVerify: true
Logging:
  Level: "Error"
Registry:
  InstitutionsUrl: "https://topology.opensciencegrid.org/institution_ids"
  DbLocation: "<new location>/<new file>.sqlite"
```

* Build Pelican web UI by running `make web-build` in your Pelican root folder
* Run Pelican binary with `osdf` alias.
  * First, run your federation in a box with the director and the registry
  ```
   ./osdf serve --module director,registry
  ```
   * Second, run your origin. Note that you need to change the origin web port to not have a conflict
   ```
   OSDF_SERVER_WEBPORT=<YOUR PORT> ./osdf origin serve
   ```
    * You will see an error message (non-blocking though) from your origin terminal, something like:
    ```
    ERROR[2024-04-04T18:31:17Z] Failed to register with namespace service: Failed to register prefix /chtc/itb/hmtest2: failed to register the namespace: You don't have permission to register the prefix: The namespace /chtc/itb/hmtest2 already exists in the OSDF topology. To register a Pelican equivalence, you need to present your identity. If you are registering through Pelican CLI, try again with the flag '--with-identity' enabled. If this is an auto-registration from a Pelican origin or cache server, register your namespace or server through the Pelican registry website at https://6ee28c5df997:8444 instead.: The POST attempt to https://6ee28c5df997:8444/api/v1.0/registry resulted in status code 403; will automatically retry in 10 seconds 
    ```
  * As the error suggests, you will need to go to the registry web UI to register your namespace first
  * If you go to the origin's web UI, the same error message will appear at the status section, under the `Registry` component
* Before you close your origin (you don't have to though). Go to the public key endpoint and download your origin's public key at `/.well-known/issuer.jwks`
* Go to your registry web UI, should be at `https://localhost:8444`, and register a new namespace with your origin's federation prefix and the public key
* Switch to your origin terminal, wait for a minute and it should not complain about the error anymore
* Go to your origin web UI, the error in the Registry component should be gone, and the `Director` component should report OK (green color)

If you want to take one step further, you can test if a file can be transferred through this origin and the federation (I tested locally and it works for me)