### PR TITLE
More error tolerant web ui check

### DIFF
--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -178,7 +178,7 @@ func TestBroker(t *testing.T) {
 	// Run the web engine, wait for it to be online.
 	err = web_ui.RunEngineRoutine(ctx, engine, egrp, false)
 	require.NoError(t, err)
-	err = server_utils.WaitUntilWorking(ctx, "GET", param.Server_ExternalWebUrl.GetString()+"/", "Web UI", http.StatusNotFound)
+	err = server_utils.WaitUntilWorking(ctx, "GET", param.Server_ExternalWebUrl.GetString()+"/", "Web UI", http.StatusNotFound, false)
 	require.NoError(t, err)
 
 	// Create a HTTP server we'll use to serve up the reversed connection
@@ -291,7 +291,7 @@ func TestRetrieveTimeout(t *testing.T) {
 	// Run the web engine, wait for it to be online.
 	err = web_ui.RunEngineRoutine(ctx, engine, egrp, false)
 	require.NoError(t, err)
-	err = server_utils.WaitUntilWorking(ctx, "GET", param.Server_ExternalWebUrl.GetString()+"/", "Web UI", http.StatusNotFound)
+	err = server_utils.WaitUntilWorking(ctx, "GET", param.Server_ExternalWebUrl.GetString()+"/", "Web UI", http.StatusNotFound, false)
 	require.NoError(t, err)
 
 	viper.Set("Federation.BrokerUrl", param.Server_ExternalWebUrl.GetString())

--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -156,7 +156,7 @@ func TestFullUpload(t *testing.T) {
 	}
 
 	desiredURL := param.Server_ExternalWebUrl.GetString() + "/api/v1.0/health"
-	err = server_utils.WaitUntilWorking(ctx, "GET", desiredURL, "director", 200)
+	err = server_utils.WaitUntilWorking(ctx, "GET", desiredURL, "director", 200, false)
 	require.NoError(t, err)
 
 	httpc := http.Client{

--- a/cmd/fed_serve_cache_test.go
+++ b/cmd/fed_serve_cache_test.go
@@ -118,7 +118,7 @@ func TestFedServeCache(t *testing.T) {
 	}
 
 	// In this case 403 means the cache is running
-	err = server_utils.WaitUntilWorking(ctx, "GET", param.Cache_Url.GetString(), "xrootd", 403)
+	err = server_utils.WaitUntilWorking(ctx, "GET", param.Cache_Url.GetString(), "xrootd", 403, false)
 	require.NoError(t, err)
 
 	fileTests := server_utils.TestFileTransferImpl{}

--- a/cmd/fed_serve_test.go
+++ b/cmd/fed_serve_test.go
@@ -101,7 +101,7 @@ func TestFedServePosixOrigin(t *testing.T) {
 	}
 
 	desiredURL := param.Server_ExternalWebUrl.GetString() + "/.well-known/openid-configuration"
-	err = server_utils.WaitUntilWorking(ctx, "GET", desiredURL, "director", 200)
+	err = server_utils.WaitUntilWorking(ctx, "GET", desiredURL, "director", 200, false)
 	require.NoError(t, err)
 
 	httpc := http.Client{

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -147,7 +147,7 @@ func (f *FedTest) Spinup() {
 	}
 
 	desiredURL := param.Server_ExternalWebUrl.GetString() + "/.well-known/openid-configuration"
-	err = server_utils.WaitUntilWorking(ctx, "GET", desiredURL, "director", 200)
+	err = server_utils.WaitUntilWorking(ctx, "GET", desiredURL, "director", 200, false)
 	require.NoError(f.T, err)
 
 	httpc := http.Client{

--- a/fed_test_utils/fed.go
+++ b/fed_test_utils/fed.go
@@ -143,7 +143,7 @@ func NewFedTest(t *testing.T, originConfig string) (ft *FedTest) {
 	require.NoError(t, err)
 
 	desiredURL := param.Server_ExternalWebUrl.GetString() + "/api/v1.0/health"
-	err = server_utils.WaitUntilWorking(ctx, "GET", desiredURL, "director", 200)
+	err = server_utils.WaitUntilWorking(ctx, "GET", desiredURL, "director", 200, false)
 	require.NoError(t, err)
 
 	httpc := http.Client{

--- a/server_utils/server_utils.go
+++ b/server_utils/server_utils.go
@@ -41,7 +41,7 @@ import (
 
 // Wait until given `reqUrl` returns a HTTP 200.
 // Logging messages emitted will refer to `server` (e.g., origin, cache, director)
-// Pass true to statusMismatch to allow a mismatch of expected status code and what's returned not fail immediatelys
+// Pass true to statusMismatch to allow a mismatch of expected status code and what's returned not fail immediately
 func WaitUntilWorking(ctx context.Context, method, reqUrl, server string, expectedStatus int, statusMismatch bool) error {
 	expiry := time.Now().Add(10 * time.Second)
 	ctx, cancel := context.WithDeadline(ctx, expiry)
@@ -82,7 +82,7 @@ func WaitUntilWorking(ctx context.Context, method, reqUrl, server string, expect
 					statusError = errors.Errorf("Received bad status code in reply to server ping at %s: %d. Expected %d. Can't read response body with error %v.", reqUrl, resp.StatusCode, expectedStatus, err)
 					if statusMismatch {
 						if !statusErrLogged {
-							log.Info(statusError, "Will retry until timeedout")
+							log.Info(statusError, "Will retry until timeout")
 							statusErrLogged = true
 						}
 					} else {
@@ -94,7 +94,7 @@ func WaitUntilWorking(ctx context.Context, method, reqUrl, server string, expect
 						statusError = errors.Errorf("Received bad status code in reply to server ping at %s: %d. Expected %d. Response body: %s", reqUrl, resp.StatusCode, expectedStatus, string(bytes))
 						if statusMismatch {
 							if !statusErrLogged {
-								log.Info(statusError, "Will retry until timeedout")
+								log.Info(statusError, "Will retry until timeout")
 								statusErrLogged = true
 							}
 						} else {
@@ -105,7 +105,7 @@ func WaitUntilWorking(ctx context.Context, method, reqUrl, server string, expect
 						statusError = errors.Errorf("Received bad status code in reply to server ping at %s: %d. Expected %d. Response body is empty.", reqUrl, resp.StatusCode, expectedStatus)
 						if statusMismatch {
 							if !statusErrLogged {
-								log.Info(statusError, "Will retry until timeedout")
+								log.Info(statusError, "Will retry until timeout")
 								statusErrLogged = true
 							}
 						} else {

--- a/server_utils/server_utils.go
+++ b/server_utils/server_utils.go
@@ -41,13 +41,17 @@ import (
 
 // Wait until given `reqUrl` returns a HTTP 200.
 // Logging messages emitted will refer to `server` (e.g., origin, cache, director)
-func WaitUntilWorking(ctx context.Context, method, reqUrl, server string, expectedStatus int) error {
+// Pass true to statusMismatch to allow a mismatch of expected status code and what's returned not fail immediatelys
+func WaitUntilWorking(ctx context.Context, method, reqUrl, server string, expectedStatus int, statusMismatch bool) error {
 	expiry := time.Now().Add(10 * time.Second)
 	ctx, cancel := context.WithDeadline(ctx, expiry)
 	defer cancel()
 	ticker := time.NewTicker(50 * time.Millisecond)
 	success := false
 	logged := false
+	var statusError error
+	statusErrLogged := false
+
 	for !(success || time.Now().After(expiry)) {
 		select {
 		case <-ticker.C:
@@ -75,24 +79,55 @@ func WaitUntilWorking(ctx context.Context, method, reqUrl, server string, expect
 				}
 				bytes, err := io.ReadAll(resp.Body)
 				if err != nil {
-					// We didn't get the expected status
-					return errors.Errorf("Received bad status code in reply to server ping at %s: %d. Expected %d. Can't read response body with error %v.", reqUrl, resp.StatusCode, expectedStatus, err)
+					statusError = errors.Errorf("Received bad status code in reply to server ping at %s: %d. Expected %d. Can't read response body with error %v.", reqUrl, resp.StatusCode, expectedStatus, err)
+					if statusMismatch {
+						if !statusErrLogged {
+							log.Info(statusError, "Will retry until timeedout")
+							statusErrLogged = true
+						}
+					} else {
+						// We didn't get the expected status
+						return statusError
+					}
 				} else {
 					if len(bytes) != 0 {
-						// We didn't get the expected status
-						return errors.Errorf("Received bad status code in reply to server ping at %s: %d. Expected %d. Response body: %s", reqUrl, resp.StatusCode, expectedStatus, string(bytes))
+						statusError = errors.Errorf("Received bad status code in reply to server ping at %s: %d. Expected %d. Response body: %s", reqUrl, resp.StatusCode, expectedStatus, string(bytes))
+						if statusMismatch {
+							if !statusErrLogged {
+								log.Info(statusError, "Will retry until timeedout")
+								statusErrLogged = true
+							}
+						} else {
+							// We didn't get the expected status
+							return statusError
+						}
 					} else {
-						return errors.Errorf("Received bad status code in reply to server ping at %s: %d. Expected %d. Response body is empty.", reqUrl, resp.StatusCode, expectedStatus)
+						statusError = errors.Errorf("Received bad status code in reply to server ping at %s: %d. Expected %d. Response body is empty.", reqUrl, resp.StatusCode, expectedStatus)
+						if statusMismatch {
+							if !statusErrLogged {
+								log.Info(statusError, "Will retry until timeedout")
+								statusErrLogged = true
+							}
+						} else {
+							return statusError
+						}
 					}
 				}
 
 			}
 		case <-ctx.Done():
+			if statusError != nil {
+				return errors.Wrapf(statusError, "url %s didn't respond with the expected status code %d within 10s", reqUrl, expectedStatus)
+			}
 			return ctx.Err()
 		}
 	}
 
-	return errors.Errorf("Server %s at %s did not startup after 10s of waiting", server, reqUrl)
+	if statusError != nil {
+		return errors.Wrapf(statusError, "url %s didn't respond with the expected status code %d within 10s", reqUrl, expectedStatus)
+	} else {
+		return errors.Errorf("Server %s at %s did not startup after 10s of waiting", server, reqUrl)
+	}
 }
 
 // For calling from within the server. Returns the server's issuer URL/port

--- a/server_utils/server_utils_test.go
+++ b/server_utils/server_utils_test.go
@@ -48,7 +48,7 @@ func TestWaitUntilWorking(t *testing.T) {
 		}))
 		defer server.Close()
 
-		err := WaitUntilWorking(ctx, "GET", server.URL, "testServer", http.StatusOK)
+		err := WaitUntilWorking(ctx, "GET", server.URL, "testServer", http.StatusOK, false)
 		require.NoError(t, err)
 
 		assert.Equal(t, logrus.DebugLevel, hook.LastEntry().Level)
@@ -62,7 +62,7 @@ func TestWaitUntilWorking(t *testing.T) {
 		}))
 		defer server.Close()
 
-		err := WaitUntilWorking(ctx, "GET", server.URL, "testServer", http.StatusOK)
+		err := WaitUntilWorking(ctx, "GET", server.URL, "testServer", http.StatusOK, false)
 		require.Error(t, err)
 		expectedErrorMsg := fmt.Sprintf("Received bad status code in reply to server ping at %s: %d. Expected %d. Response body is empty.", server.URL, 500, 200)
 		assert.Contains(t, err.Error(), expectedErrorMsg)
@@ -76,7 +76,7 @@ func TestWaitUntilWorking(t *testing.T) {
 		}))
 		defer server.Close()
 
-		err := WaitUntilWorking(ctx, "GET", server.URL, "testServer", http.StatusOK)
+		err := WaitUntilWorking(ctx, "GET", server.URL, "testServer", http.StatusOK, false)
 		require.Error(t, err)
 		expectedErrorMsg := fmt.Sprintf("Received bad status code in reply to server ping at %s: %d. Expected %d. Response body: %s", server.URL, 404, 200, "404 page not found")
 		assert.Equal(t, expectedErrorMsg, err.Error())
@@ -94,7 +94,7 @@ func TestWaitUntilWorking(t *testing.T) {
 		}))
 		defer server.Close()
 
-		err = WaitUntilWorking(ctx, "GET", server.URL, "testServer", http.StatusOK)
+		err = WaitUntilWorking(ctx, "GET", server.URL, "testServer", http.StatusOK, false)
 		require.Error(t, err)
 		expectedErrorMsg := fmt.Sprintf("Received bad status code in reply to server ping at %s: %d. Expected %d. Response body: %s", server.URL, 400, 200, string(jsonBytes))
 		assert.Equal(t, expectedErrorMsg, err.Error())
@@ -107,7 +107,7 @@ func TestWaitUntilWorking(t *testing.T) {
 			<-time.After(200 * time.Millisecond)
 			earlyCancel()
 		}()
-		err := WaitUntilWorking(earlyCancelCtx, "GET", "https://noserverexists.com", "testServer", http.StatusOK)
+		err := WaitUntilWorking(earlyCancelCtx, "GET", "https://noserverexists.com", "testServer", http.StatusOK, false)
 		require.Error(t, err)
 		expectedErrorMsg := fmt.Sprintf("Failed to send request to testServer at %s; likely server is not up (will retry in 50ms):", "https://noserverexists.com")
 		assert.Equal(t, logrus.InfoLevel, hook.LastEntry().Level)
@@ -128,7 +128,7 @@ func TestWaitUntilWorking(t *testing.T) {
 		}))
 		defer server.Close()
 
-		err := WaitUntilWorking(earlyCancelCtx, "GET", server.URL, "testServer", http.StatusOK)
+		err := WaitUntilWorking(earlyCancelCtx, "GET", server.URL, "testServer", http.StatusOK, false)
 		require.Error(t, err)
 		expectedErrorMsg := fmt.Sprintf("Failed to send request to testServer at %s; likely server is not up (will retry in 50ms):", server.URL)
 		assert.Equal(t, logrus.InfoLevel, hook.LastEntry().Level)

--- a/xrootd/origin_test.go
+++ b/xrootd/origin_test.go
@@ -162,7 +162,7 @@ func TestOrigin(t *testing.T) {
 	defer mockupCancel()
 
 	// In this case a 403 means its running
-	err := server_utils.WaitUntilWorking(ctx, "GET", param.Origin_Url.GetString(), "xrootd", 403)
+	err := server_utils.WaitUntilWorking(ctx, "GET", param.Origin_Url.GetString(), "xrootd", 403, false)
 	if err != nil {
 		t.Fatalf("Unsuccessful test: Server encountered an error: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestMultiExportOrigin(t *testing.T) {
 	defer mockupCancel()
 
 	// In this case a 403 means its running
-	err = server_utils.WaitUntilWorking(ctx, "GET", param.Origin_Url.GetString(), "xrootd", 403)
+	err = server_utils.WaitUntilWorking(ctx, "GET", param.Origin_Url.GetString(), "xrootd", 403, false)
 	if err != nil {
 		t.Fatalf("Unsuccessful test: Server encountered an error: %v", err)
 	}
@@ -255,7 +255,7 @@ func TestS3OriginConfig(t *testing.T) {
 	// Check if MinIO is running (by default at localhost:9000)
 	endpoint := "localhost:9000"
 	// Expect a 403 from this endpoint -- that means it's running
-	err = server_utils.WaitUntilWorking(ctx, "GET", fmt.Sprintf("http://%s", endpoint), "xrootd", 403)
+	err = server_utils.WaitUntilWorking(ctx, "GET", fmt.Sprintf("http://%s", endpoint), "xrootd", 403, false)
 	if err != nil {
 		t.Fatalf("Unsuccessful test: Server encountered an error: %v", err)
 	}
@@ -332,7 +332,7 @@ func TestS3OriginConfig(t *testing.T) {
 	originEndpoint := fmt.Sprintf("%s/%s/%s/%s/%s", param.Origin_Url.GetString(), serviceName, regionName, bucketName, objectName)
 	// Until we sort out the things we mentioned above, we should expect a 403 because we don't try to pass tokens
 	// and we don't actually export any keys for token validation.
-	err = server_utils.WaitUntilWorking(ctx, "GET", originEndpoint, "xrootd", 403)
+	err = server_utils.WaitUntilWorking(ctx, "GET", originEndpoint, "xrootd", 403, false)
 	if err != nil {
 		t.Fatalf("Unsucessful test: Server encountered an error: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestS3OriginConfig(t *testing.T) {
 	defer cancel()
 	defer mockupCancel()
 
-	err = server_utils.WaitUntilWorking(ctx, "GET", originEndpoint, "xrootd", 403)
+	err = server_utils.WaitUntilWorking(ctx, "GET", originEndpoint, "xrootd", 403, false)
 	if err != nil {
 		t.Fatalf("Unsucessful test: Server encountered an error: %v", err)
 	}


### PR DESCRIPTION
Should fix #1033 

The suspicion is that there's a racing condition at the registry start somehow, and the web engine is not "ready-ready" to serve requests, although it could be other issues. However, this PR will make the web ui check more robust in case of the error code returned