### PR TITLE
Removed the setting of an AuthURL for Pelican serverAds

### DIFF
--- a/director/advertise.go
+++ b/director/advertise.go
@@ -42,18 +42,20 @@ func parseServerAd(server utils.Server, serverType server_structs.ServerType) se
 	// but endpoints do not have a scheme. As such, we need to add one for the.
 	// correct parsing. Luckily, we don't use this anywhere else (it's just to
 	// make the url.Parse function behave as expected)
-	if !strings.HasPrefix(server.AuthEndpoint, "http") { // just in case there's already an http(s) tacked in front
-		server.AuthEndpoint = "https://" + server.AuthEndpoint
-	}
 	if !strings.HasPrefix(server.Endpoint, "http") { // just in case there's already an http(s) tacked in front
 		server.Endpoint = "http://" + server.Endpoint
 	}
-	serverAuthUrl, err := url.Parse(server.AuthEndpoint)
-	if err != nil {
-		log.Warningf("Namespace JSON returned server %s with invalid authenticated URL %s",
-			server.Resource, server.AuthEndpoint)
+	if server.AuthEndpoint != "" {
+		if !strings.HasPrefix(server.AuthEndpoint, "http") { // just in case there's already an http(s) tacked in front
+			server.AuthEndpoint = "https://" + server.AuthEndpoint
+		}
+		serverAuthUrl, err := url.Parse(server.AuthEndpoint)
+		if err != nil {
+			log.Warningf("Namespace JSON returned server %s with invalid authenticated URL %s",
+				server.Resource, server.AuthEndpoint)
+		}
+		serverAd.AuthURL = *serverAuthUrl
 	}
-	serverAd.AuthURL = *serverAuthUrl
 
 	serverUrl, err := url.Parse(server.Endpoint)
 	if err != nil {

--- a/director/advertise.go
+++ b/director/advertise.go
@@ -37,15 +37,12 @@ func parseServerAd(server utils.Server, serverType server_structs.ServerType) se
 	serverAd.Name = server.Resource
 
 	serverAd.Writes = param.Origin_EnableWrites.GetBool()
-	// url.Parse requires that the scheme be present before the hostname,
-	// but endpoints do not have a scheme. As such, we need to add one for the.
-	// correct parsing. Luckily, we don't use this anywhere else (it's just to
-	// make the url.Parse function behave as expected)
 	serverUrl, err := url.Parse(server.Endpoint)
 	if err != nil {
 		log.Warningf("Namespace JSON returned server %s with invalid unauthenticated URL %s",
 			server.Resource, server.Endpoint)
 	}
+	// Setting the scheme to http (and not https) in order to work with topology public caches and origins
 	serverUrl.Scheme = "http"
 	serverAd.URL = *serverUrl
 

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -91,10 +91,6 @@ func TestGetAdsForPath(t *testing.T) {
 
 	cacheAd1 := server_structs.ServerAd{
 		Name: "cache1",
-		AuthURL: url.URL{
-			Scheme: "https",
-			Host:   "wisc.edu",
-		},
 		URL: url.URL{
 			Scheme: "https",
 			Host:   "wisc.edu",
@@ -104,10 +100,6 @@ func TestGetAdsForPath(t *testing.T) {
 
 	cacheAd2 := server_structs.ServerAd{
 		Name: "cache2",
-		AuthURL: url.URL{
-			Scheme: "https",
-			Host:   "wisc.edu",
-		},
 		URL: url.URL{
 			Scheme: "https",
 			Host:   "wisc.edu",
@@ -117,10 +109,6 @@ func TestGetAdsForPath(t *testing.T) {
 
 	originAd1 := server_structs.ServerAd{
 		Name: "origin1",
-		AuthURL: url.URL{
-			Scheme: "https",
-			Host:   "wisc.edu",
-		},
 		URL: url.URL{
 			Scheme: "https",
 			Host:   "wisc.edu",
@@ -130,10 +118,6 @@ func TestGetAdsForPath(t *testing.T) {
 
 	originAd2 := server_structs.ServerAd{
 		Name: "origin2",
-		AuthURL: url.URL{
-			Scheme: "https",
-			Host:   "wisc.edu",
-		},
 		URL: url.URL{
 			Scheme: "https",
 			Host:   "wisc.edu",

--- a/director/director.go
+++ b/director/director.go
@@ -89,7 +89,7 @@ var (
 
 func getRedirectURL(reqPath string, ad server_structs.ServerAd, requiresAuth bool) (redirectURL url.URL) {
 	var serverURL url.URL
-	if requiresAuth {
+	if requiresAuth && ad.AuthURL.String() != "" {
 		serverURL = ad.AuthURL
 		if ad.AuthURL == (url.URL{}) {
 			serverURL = ad.URL

--- a/director/director.go
+++ b/director/director.go
@@ -91,6 +91,9 @@ func getRedirectURL(reqPath string, ad server_structs.ServerAd, requiresAuth boo
 	var serverURL url.URL
 	if requiresAuth {
 		serverURL = ad.AuthURL
+		if ad.AuthURL == (url.URL{}) {
+			serverURL = ad.URL
+		}
 	} else {
 		serverURL = ad.URL
 	}
@@ -310,10 +313,10 @@ func redirectToCache(ginCtx *gin.Context) {
 	}
 
 	var colUrl string
-	if namespaceAd.PublicRead {
-		colUrl = originAds[0].URL.String()
-	} else {
+	if !namespaceAd.PublicRead && originAds[0].AuthURL != (url.URL{}) {
 		colUrl = originAds[0].AuthURL.String()
+	} else {
+		colUrl = originAds[0].URL.String()
 	}
 	ginCtx.Writer.Header()["X-Pelican-Namespace"] = []string{fmt.Sprintf("namespace=%s, require-token=%v, collections-url=%s",
 		namespaceAd.Path, !namespaceAd.PublicRead, colUrl)}
@@ -393,10 +396,10 @@ func redirectToOrigin(ginCtx *gin.Context) {
 	ginCtx.Writer.Header()["Link"] = []string{linkHeader}
 
 	var colUrl string
-	if namespaceAd.PublicRead {
-		colUrl = originAds[0].URL.String()
-	} else {
+	if !namespaceAd.PublicRead && originAds[0].AuthURL != (url.URL{}) {
 		colUrl = originAds[0].AuthURL.String()
+	} else {
+		colUrl = originAds[0].URL.String()
 	}
 	ginCtx.Writer.Header()["X-Pelican-Namespace"] = []string{fmt.Sprintf("namespace=%s, require-token=%v, collections-url=%s",
 		namespaceAd.Path, !namespaceAd.PublicRead, colUrl)}
@@ -608,7 +611,6 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 
 	sAd := server_structs.ServerAd{
 		Name:        adV2.Name,
-		AuthURL:     *ad_url,
 		URL:         *ad_url,
 		WebURL:      *adWebUrl,
 		BrokerURL:   *brokerUrl,
@@ -731,12 +733,18 @@ func discoverOriginCache(ctx *gin.Context) {
 			// don't have a WebURL
 			continue
 		}
+		var auth_url string
+		if ad.AuthURL == (url.URL{}) {
+			auth_url = ad.URL.String()
+		} else {
+			auth_url = ad.AuthURL.String()
+		}
 		promDiscoveryRes = append(promDiscoveryRes, PromDiscoveryItem{
 			Targets: []string{ad.WebURL.Hostname() + ":" + ad.WebURL.Port()},
 			Labels: map[string]string{
 				"server_type":     string(ad.Type),
 				"server_name":     ad.Name,
-				"server_auth_url": ad.AuthURL.String(),
+				"server_auth_url": auth_url,
 				"server_url":      ad.URL.String(),
 				"server_web_url":  ad.WebURL.String(),
 				"server_lat":      fmt.Sprintf("%.4f", ad.Latitude),

--- a/director/director_api_test.go
+++ b/director/director_api_test.go
@@ -31,7 +31,6 @@ import (
 
 var mockOriginServerAd server_structs.ServerAd = server_structs.ServerAd{
 	Name:      "test-origin-server",
-	AuthURL:   url.URL{},
 	URL:       url.URL{},
 	Type:      server_structs.OriginType,
 	Latitude:  123.05,
@@ -40,7 +39,6 @@ var mockOriginServerAd server_structs.ServerAd = server_structs.ServerAd{
 
 var mockCacheServerAd server_structs.ServerAd = server_structs.ServerAd{
 	Name:      "test-cache-server",
-	AuthURL:   url.URL{},
 	URL:       url.URL{},
 	Type:      server_structs.CacheType,
 	Latitude:  45.67,

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -628,8 +628,7 @@ func TestGetAuthzEscaped(t *testing.T) {
 
 func TestDiscoverOriginCache(t *testing.T) {
 	mockPelicanOriginServerAd := server_structs.ServerAd{
-		Name:    "1-test-origin-server",
-		AuthURL: url.URL{},
+		Name: "1-test-origin-server",
 		URL: url.URL{
 			Scheme: "https",
 			Host:   "fake-origin.org:8443",
@@ -644,8 +643,7 @@ func TestDiscoverOriginCache(t *testing.T) {
 	}
 
 	mockTopoOriginServerAd := server_structs.ServerAd{
-		Name:    "test-topology-origin-server",
-		AuthURL: url.URL{},
+		Name: "test-topology-origin-server",
 		URL: url.URL{
 			Scheme: "https",
 			Host:   "fake-topology-origin.org:8443",
@@ -656,8 +654,7 @@ func TestDiscoverOriginCache(t *testing.T) {
 	}
 
 	mockCacheServerAd := server_structs.ServerAd{
-		Name:    "2-test-cache-server",
-		AuthURL: url.URL{},
+		Name: "2-test-cache-server",
 		URL: url.URL{
 			Scheme: "https",
 			Host:   "fake-cache.org:8443",
@@ -825,7 +822,7 @@ func TestDiscoverOriginCache(t *testing.T) {
 			Labels: map[string]string{
 				"server_type":     string(mockCacheServerAd.Type),
 				"server_name":     mockCacheServerAd.Name,
-				"server_auth_url": mockCacheServerAd.AuthURL.String(),
+				"server_auth_url": mockCacheServerAd.URL.String(),
 				"server_url":      mockCacheServerAd.URL.String(),
 				"server_web_url":  mockCacheServerAd.WebURL.String(),
 				"server_lat":      fmt.Sprintf("%.4f", mockCacheServerAd.Latitude),
@@ -836,7 +833,7 @@ func TestDiscoverOriginCache(t *testing.T) {
 			Labels: map[string]string{
 				"server_type":     string(mockPelicanOriginServerAd.Type),
 				"server_name":     mockPelicanOriginServerAd.Name,
-				"server_auth_url": mockPelicanOriginServerAd.AuthURL.String(),
+				"server_auth_url": mockPelicanOriginServerAd.URL.String(),
 				"server_url":      mockPelicanOriginServerAd.URL.String(),
 				"server_web_url":  mockPelicanOriginServerAd.WebURL.String(),
 				"server_lat":      fmt.Sprintf("%.4f", mockPelicanOriginServerAd.Latitude),
@@ -881,7 +878,7 @@ func TestDiscoverOriginCache(t *testing.T) {
 			Labels: map[string]string{
 				"server_type":     string(mockPelicanOriginServerAd.Type),
 				"server_name":     mockPelicanOriginServerAd.Name,
-				"server_auth_url": mockPelicanOriginServerAd.AuthURL.String(),
+				"server_auth_url": mockPelicanOriginServerAd.URL.String(),
 				"server_url":      mockPelicanOriginServerAd.URL.String(),
 				"server_web_url":  mockPelicanOriginServerAd.WebURL.String(),
 				"server_lat":      fmt.Sprintf("%.4f", mockPelicanOriginServerAd.Latitude),

--- a/director/director_ui.go
+++ b/director/director_ui.go
@@ -20,6 +20,7 @@ package director
 
 import (
 	"net/http"
+	"net/url"
 	"path"
 	"strings"
 
@@ -98,10 +99,16 @@ func listServers(ctx *gin.Context) {
 			healthStatus = healthUtil.Status
 		}
 		filtered, ft := checkFilter(server.Name)
+		var auth_url string
+		if server.AuthURL == (url.URL{}) {
+			auth_url = server.URL.String()
+		} else {
+			auth_url = server.AuthURL.String()
+		}
 		res := listServerResponse{
 			Name:         server.Name,
 			BrokerURL:    server.BrokerURL.String(),
-			AuthURL:      server.AuthURL.String(),
+			AuthURL:      auth_url,
 			URL:          server.URL.String(),
 			WebURL:       server.WebURL.String(),
 			Type:         server.Type,

--- a/director/director_ui_test.go
+++ b/director/director_ui_test.go
@@ -48,7 +48,7 @@ func TestListServers(t *testing.T) {
 	mocklistOriginRes := listServerResponse{
 		Name:        mockOriginServerAd.Name,
 		BrokerURL:   mockOriginServerAd.BrokerURL.String(),
-		AuthURL:     mockOriginServerAd.AuthURL.String(),
+		AuthURL:     mockOriginServerAd.URL.String(),
 		URL:         mockOriginServerAd.URL.String(),
 		WebURL:      mockOriginServerAd.WebURL.String(),
 		Type:        mockOriginServerAd.Type,
@@ -61,7 +61,7 @@ func TestListServers(t *testing.T) {
 	mocklistCacheRes := listServerResponse{
 		Name:        mockCacheServerAd.Name,
 		BrokerURL:   mockCacheServerAd.BrokerURL.String(),
-		AuthURL:     mockCacheServerAd.AuthURL.String(),
+		AuthURL:     mockCacheServerAd.URL.String(),
 		URL:         mockCacheServerAd.URL.String(),
 		WebURL:      mockCacheServerAd.WebURL.String(),
 		Type:        mockCacheServerAd.Type,


### PR DESCRIPTION

Because osdf origins and caches still have separate AuthURLs, this PR doesn't remove them fully from ServerAds. Rather, if it is a Pelican ServerAd, the AuthURL isn't set.

The director has been changed so that if an AuthURL isn't set, it will return the regular url instead when an AuthURL is needed and an AuthURL otherwise.