### PR TITLE
Correctly return the transfer attempt information

### DIFF
--- a/client/errorAccum.go
+++ b/client/errorAccum.go
@@ -59,11 +59,15 @@ func NewTransferErrors() *TransferErrors {
 }
 
 func (te *TransferErrors) AddError(err error) {
+	te.AddPastError(err, time.Now())
+}
+
+func (te *TransferErrors) AddPastError(err error, timestamp time.Time) {
 	if te.errors == nil {
 		te.errors = make([]error, 0)
 	}
 	if err != nil {
-		te.errors = append(te.errors, &TimestampedError{err: err, timestamp: time.Now()})
+		te.errors = append(te.errors, &TimestampedError{err: err, timestamp: timestamp})
 	}
 }
 

--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -263,14 +263,14 @@ func TestCopyAuth(t *testing.T) {
 			transferResultsUpload, err := client.DoCopy(fed.Ctx, tempFile.Name(), uploadURL, false, client.WithTokenLocation(tempToken.Name()))
 			assert.NoError(t, err)
 			if err == nil {
-				assert.Equal(t, transferResultsUpload[0].TransferredBytes, int64(17))
+				assert.Equal(t, int64(17), transferResultsUpload[0].TransferredBytes)
 			}
 
 			// Download that same file with GET
 			transferResultsDownload, err := client.DoCopy(fed.Ctx, uploadURL, t.TempDir(), false, client.WithTokenLocation(tempToken.Name()))
 			assert.NoError(t, err)
 			if err == nil {
-				assert.Equal(t, transferResultsDownload[0].TransferredBytes, transferResultsUpload[0].TransferredBytes)
+				assert.Equal(t, int64(17), transferResultsDownload[0].TransferredBytes)
 			}
 		}
 	})

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1479,12 +1479,14 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 			}
 			attempt.Error = errors.New(errorString)
 			xferErrors.AddPastError(attempt.Error, endTime)
-		} else { // Success
+		}
+		transferResults.Attempts = append(transferResults.Attempts, attempt)
+
+		if err == nil { // Success
 			log.Debugln("Downloaded bytes:", downloaded)
 			success = true
 			break
 		}
-		transferResults.Attempts = append(transferResults.Attempts, attempt)
 	}
 	transferResults.TransferredBytes = downloaded
 	if !success {

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -616,6 +616,9 @@ func writeTransferErrorMessage(currentError string, transferUrl string, upload b
 		urlRemainder := strings.TrimPrefix(transferUrl, prefix)
 		errMsg = strings.ReplaceAll(errMsg, urlRemainder, "(...Path...)")
 	}
+	// HTCondor will already say whether it's an upload/download in its generated string;
+	// save a few characters here
+	errMsg = strings.ReplaceAll(errMsg, "failed download from", "from")
 
 	errMsg += (" (Version: " + config.GetVersion())
 

--- a/local_cache/cache_test.go
+++ b/local_cache/cache_test.go
@@ -240,7 +240,7 @@ func TestClient(t *testing.T) {
 		_, err = client.DoGet(ctx, "pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt.1",
 			filepath.Join(tmpDir, "hello_world.txt.1"), false, client.WithToken(token), client.WithCaches(cacheUrl), client.WithAcquireToken(false))
 		assert.Error(t, err)
-		assert.Equal(t, "failed to download file: server returned 404 Not Found", err.Error())
+		assert.Equal(t, "failed download from local-cache: server returned 404 Not Found", err.Error())
 	})
 	t.Cleanup(func() {
 		cancel()


### PR DESCRIPTION
v7.6.x has a regression where the `downloadObject` function returns an error whenever an error occurs; rather, it's only supposed to return an error if no transfers are attempted.  That change causes the multiple attempts to not be returned to the transfer plugin -- instead, only the last one is.

This change:
- Returns all the failed attempts
- Fixes the "15s since start" in error messages by recording when the error occurred.
- Stubs out any paths in the plugin error message (since HTCSS also reports the path).
- Switches the client to golang time objects where appropriate, converting to integers (and floats) only at the plugin level.