### PR TITLE
Bump the revision of xrdcl-pelican for libcurl testing

### DIFF
--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -91,7 +91,7 @@ ADD https://api.github.com/repos/PelicanPlatform/xrdcl-pelican/git/refs/heads/ma
 RUN \
     git clone https://github.com/PelicanPlatform/xrdcl-pelican.git && \
     cd xrdcl-pelican && \
-    git reset 9562795 --hard && \
+    git reset cbd6850 --hard && \
     mkdir build && cd build && \
     cmake -DLIB_INSTALL_DIR=/usr/lib64 .. && \
     make && make install


### PR DESCRIPTION
In unit tests, we've been seeing timeouts in xrdcl-pelican due to what appears overly-long delays for DNS lookups.  I believe this is due to the DNS lookup not correctly being waited on for the curl multi-wait.  This bumps the dev image to the curl testing code; if successful, we may do a similar thing for prod.