### PR TITLE
Make the local cache location unique for each test run

### DIFF
--- a/fed_test_utils/fed.go
+++ b/fed_test_utils/fed.go
@@ -134,6 +134,8 @@ func NewFedTest(t *testing.T, originConfig string) (ft *FedTest) {
 	viper.Set("Origin.Port", 0)
 	viper.Set("Server.WebPort", 0)
 	viper.Set("Origin.RunLocation", tmpPath)
+	viper.Set("Origin.RunLocation", filepath.Join(tmpPath, "origin"))
+	viper.Set("LocalCache.RunLocation", filepath.Join(tmpPath, "local-cache"))
 	viper.Set("Registry.RequireOriginApproval", false)
 	viper.Set("Registry.RequireCacheApproval", false)
 


### PR DESCRIPTION
We saw some failures in the unit tests (which may-or-may-not be false positives) that complained about some other process listening on the common Unix socket.

Ensure that each federation test case will use a unique socket name, hopefully making the tests more robust.