### PR TITLE
Move default S3 url style from defaults.yaml to config.go

### DIFF
--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -60,7 +60,6 @@ var (
 				// We specifically DON'T want the region, service-url, and url-style flags if the mode is posix
 				if viper.IsSet("Origin.S3Region") || viper.IsSet("Origin.S3ServiceUrl") || viper.IsSet("Origin.S3UrlStyle") {
 					cmd.PrintErrln("The --region, --service-url, and --url-style flags are only used when the origin is launched in S3 mode.")
-					os.Exit(1)
 				}
 			} else {
 				cmd.PrintErrln(fmt.Sprintf("The --mode flag must be either 'posix' or 's3', but you provided '%s'", ost))

--- a/config/config.go
+++ b/config/config.go
@@ -983,6 +983,10 @@ func InitServer(ctx context.Context, currentServers ServerType) error {
 	viper.SetDefault("Cache.ExportLocation", "/")
 	viper.SetDefault("Registry.RequireKeyChaining", true)
 
+	// Set up the default S3 URL style to be path-style here as opposed to in the defaults.yaml becase
+	// we want to be able to check if this is user-provided (which we can't do for defaults.yaml)
+	viper.SetDefault("S3UrlStyle", "path")
+
 	if webConfigPath := param.Server_WebConfigFile.GetString(); webConfigPath != "" {
 		err := os.MkdirAll(filepath.Dir(webConfigPath), 0700)
 		if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -985,7 +985,7 @@ func InitServer(ctx context.Context, currentServers ServerType) error {
 
 	// Set up the default S3 URL style to be path-style here as opposed to in the defaults.yaml becase
 	// we want to be able to check if this is user-provided (which we can't do for defaults.yaml)
-	viper.SetDefault("S3UrlStyle", "path")
+	viper.SetDefault("Origin.S3UrlStyle", "path")
 
 	if webConfigPath := param.Server_WebConfigFile.GetString(); webConfigPath != "" {
 		err := os.MkdirAll(filepath.Dir(webConfigPath), 0700)

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -67,7 +67,6 @@ Origin:
   SelfTest: true
   Port: 8443
   SelfTestInterval: 15s
-  S3UrlStyle: "path"
 Registry:
   InstitutionsUrlReloadMinutes: 15m
   RequireCacheApproval: false


### PR DESCRIPTION
Because we have no way to tell whether defaults in defaults.yaml are user-provided or not, the default there of `Origin.S3UrlStyle` was throwing an error meant to notify users that they have incompatible config variables set.

This moves setting of that default into config.go where we now use `viper.SetDefault`, which later on allows us to `viper.IsSet("Origin.S3UrlStyle")` without catching our own default.