### PR TITLE
Fix broken URLs of namespaces from the topology at the director

### DIFF
--- a/director/advertise.go
+++ b/director/advertise.go
@@ -21,6 +21,7 @@ package director
 import (
 	"context"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -37,29 +38,35 @@ func parseServerAd(server utils.Server, serverType server_structs.ServerType) se
 	serverAd.Name = server.Resource
 
 	serverAd.Writes = param.Origin_EnableWrites.GetBool()
+	// url.Parse requires that the scheme be present before the hostname,
+	// but endpoints do not have a scheme. As such, we need to add one for the.
+	// correct parsing. Luckily, we don't use this anywhere else (it's just to
+	// make the url.Parse function behave as expected)
+	if !strings.HasPrefix(server.Endpoint, "http") { // just in case there's already an http(s) tacked in front
+		// Setting the scheme to http (and not https) in order to work with topology public caches and origins
+		server.Endpoint = "http://" + server.Endpoint
+	}
 	serverUrl, err := url.Parse(server.Endpoint)
 	if err != nil {
 		log.Warningf("Namespace JSON returned server %s with invalid unauthenticated URL %s",
 			server.Resource, server.Endpoint)
 	}
-	// Setting the scheme to http (and not https) in order to work with topology public caches and origins
-	serverUrl.Scheme = "http"
 	serverAd.URL = *serverUrl
 
 	if server.AuthEndpoint != "" {
+		if !strings.HasPrefix(server.AuthEndpoint, "http") { // just in case there's already an http(s) tacked in front
+			server.AuthEndpoint = "https://" + server.AuthEndpoint
+		}
 		serverAuthUrl, err := url.Parse(server.AuthEndpoint)
 		if err != nil {
 			log.Warningf("Namespace JSON returned server %s with invalid authenticated URL %s",
 				server.Resource, server.AuthEndpoint)
 		}
 
-		serverAuthUrl.Scheme = "https"
-
 		serverAd.AuthURL = *serverAuthUrl
 	}
 
 	// We will leave serverAd.WebURL as empty when fetched from topology
-
 	return serverAd
 }
 


### PR DESCRIPTION
The URLs for the topology namespace in director are broken. The current code gives `http:8000` as `url` or `authUrl` for namespaces from the topology (try `/api/v1.0/director_ui/severs`). The original code https://github.com/PelicanPlatform/pelican/commit/10fd09f8b803019098f5bdbaf10c91b39957f866 was correct in that `url.Parse` requires the scheme to be present, which is contrary to what I tested in the playground: https://github.com/PelicanPlatform/pelican/pull/1043#discussion_r1553705373

But since `url.Parse` documented that parsing a url without scheme is invalid, let's keep doing what we were doing to ensure nothing breaks.