### PR TITLE
Fix work deadlock

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -532,7 +532,7 @@ func (te *TransferEngine) newPelicanURL(remoteUrl *url.URL) (pelicanURL pelicanU
 func NewTransferEngine(ctx context.Context) *TransferEngine {
 	ctx, cancel := context.WithCancel(ctx)
 	egrp, _ := errgroup.WithContext(ctx)
-	work := make(chan *clientTransferJob)
+	work := make(chan *clientTransferJob, 5)
 	files := make(chan *clientTransferFile)
 	results := make(chan *clientTransferResults, 5)
 	suppressedLoader := ttlcache.NewSuppressedLoader(loader, new(singleflight.Group))
@@ -554,7 +554,7 @@ func NewTransferEngine(ctx context.Context) *TransferEngine {
 		results:         results,
 		resultsMap:      make(map[uuid.UUID]chan *TransferResults),
 		workMap:         make(map[uuid.UUID]chan *TransferJob),
-		jobLookupDone:   make(chan *clientTransferJob),
+		jobLookupDone:   make(chan *clientTransferJob, 5),
 		notifyChan:      make(chan bool),
 		closeChan:       make(chan bool),
 		closeDoneChan:   make(chan bool),
@@ -691,7 +691,6 @@ func (te *TransferEngine) Close() {
 // transfer results are routed back to their requesting
 // channels
 func (te *TransferEngine) runMux() error {
-
 	tmpResults := make(map[uuid.UUID][]*TransferResults)
 	activeJobs := make(map[uuid.UUID][]*TransferJob)
 	var clientJob *clientTransferJob

--- a/client/main.go
+++ b/client/main.go
@@ -135,7 +135,7 @@ func getToken(destination *url.URL, namespace namespaces.Namespace, isWrite bool
 			err = errors.New("failed to find or generate a token as required for " + destination.String())
 			return "", err
 		} else {
-			log.Errorln("Credential is required, but currently mssing")
+			log.Errorln("Credential is required, but currently missing")
 			err := errors.New("Credential is required for " + destination.String() + " but is currently missing")
 			return "", err
 		}

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -645,10 +645,16 @@ func readMultiTransfers(stdin bufio.Reader) (transfers []PluginTransfer, err err
 		if err != nil {
 			return nil, err
 		}
+		if adUrl == nil {
+			return nil, errors.New("Url attribute not set for transfer")
+		}
 
 		destination, err := ad.Get("LocalFileName")
 		if err != nil {
 			return nil, err
+		}
+		if destination == nil {
+			return nil, errors.New("LocalFileName attribute not set for transfer")
 		}
 		transfers = append(transfers, PluginTransfer{url: adUrl, localFile: destination.(string)})
 	}

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -27,14 +27,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,6 +45,7 @@ import (
 
 	"github.com/pelicanplatform/pelican/classads"
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/fed_test_utils"
 	"github.com/pelicanplatform/pelican/launchers"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_utils"
@@ -247,6 +251,71 @@ func TestStashPluginMain(t *testing.T) {
 	assert.Contains(t, output, successfulDownloadMsg)
 	amountDownloaded := "Downloaded bytes: 17"
 	assert.Contains(t, output, amountDownloaded)
+}
+
+// Test multiple downloads from the plugin
+func TestPluginMulti(t *testing.T) {
+	viper.Reset()
+	server_utils.ResetOriginExports()
+
+	dirName := t.TempDir()
+
+	viper.Set("Logging.Level", "debug")
+	viper.Set("Origin.StorageType", "posix")
+	viper.Set("Origin.ExportVolumes", "/test")
+	viper.Set("Origin.EnablePublicReads", true)
+	fed := fed_test_utils.NewFedTest(t, "")
+	host := param.Server_Hostname.GetString() + ":" + strconv.Itoa(param.Server_WebPort.GetInt())
+
+	// Drop the testFileContent into the origin directory
+	destDir := filepath.Join(fed.Exports[0].StoragePrefix, "test")
+	require.NoError(t, os.MkdirAll(destDir, os.FileMode(0700)))
+	log.Debugln("Will create origin file at", destDir)
+	err := os.WriteFile(filepath.Join(destDir, "test.txt"), []byte("test file content"), fs.FileMode(0600))
+	require.NoError(t, err)
+	downloadUrl1 := url.URL{
+		Scheme: "pelican",
+		Host:   host,
+		Path:   "/test/test/test.txt",
+	}
+	localPath1 := filepath.Join(dirName, "test.txt")
+	err = os.WriteFile(filepath.Join(destDir, "test2.txt"), []byte("second test file content"), fs.FileMode(0600))
+	require.NoError(t, err)
+	downloadUrl2 := url.URL{
+		Scheme: "pelican",
+		Host:   host,
+		Path:   "/test/test/test2.txt",
+	}
+	localPath2 := filepath.Join(dirName, "test2.txt")
+
+	workChan := make(chan PluginTransfer, 2)
+	workChan <- PluginTransfer{url: &downloadUrl1, localFile: localPath1}
+	workChan <- PluginTransfer{url: &downloadUrl2, localFile: localPath2}
+	close(workChan)
+
+	results := make(chan *classads.ClassAd, 5)
+	fed.Egrp.Go(func() error {
+		return runPluginWorker(fed.Ctx, false, workChan, results)
+	})
+
+	done := false
+	for !done {
+		select {
+		case <-fed.Ctx.Done():
+			break
+		case resultAd, ok := <-results:
+			if !ok {
+				done = true
+				break
+			}
+			// Process results as soon as we get them
+			transferSuccess, err := resultAd.Get("TransferSuccess")
+			assert.NoError(t, err)
+			boolVal, ok := transferSuccess.(bool)
+			require.True(t, ok)
+			assert.True(t, boolVal)
+		}
+	}
 }
 
 func TestWriteOutfile(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -379,11 +379,12 @@ func GetPreferredPrefix() string {
 	arg0 := strings.ToUpper(filepath.Base(os.Args[0]))
 	underscore_idx := strings.Index(arg0, "_")
 	if underscore_idx != -1 {
-		return string(ConfigPrefix(arg0[0:underscore_idx]))
+		prefix := string(ConfigPrefix(arg0[0:underscore_idx]))
+		if prefix == "STASH" {
+			return "OSDF"
+		}
 	}
-	if strings.HasPrefix(arg0, "STASH") {
-		return "STASH"
-	} else if strings.HasPrefix(arg0, "OSDF") {
+	if strings.HasPrefix(arg0, "STASH") || strings.HasPrefix(arg0, "OSDF") {
 		return "OSDF"
 	}
 	return "PELICAN"


### PR DESCRIPTION
This PR fixes an observed deadlock when the job-to-file routine is writing to the runMux routine while the runMux routine is blocked writing to the job-to-file routine.  The fix is to only accept more work (which is what triggers the runMux writing) when there's nothing buffered for job-to-file.

This was observed in the wild when running in "STASH" mode which we likely don't need anymore; the PR eliminates the STASH mode as well.

For good measure, this also:
- Fixes up a few error messages observed.
- Adds small buffering to both of the queues that were blocked.