### PR TITLE
Refactor Get/SetPreferredPrefix ConfigPrefix type

### DIFF
--- a/client/fed_linux_test.go
+++ b/client/fed_linux_test.go
@@ -110,7 +110,7 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 	innerTempFile.Close()
 
 	t.Run("testPelicanRecursiveGetAndPutPelicanURL", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix("PELICAN")
+		_, err := config.SetPreferredPrefix(config.PelicanPrefix)
 		assert.NoError(t, err)
 
 		for _, export := range fed.Exports {
@@ -196,7 +196,7 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 	})
 
 	t.Run("testOsdfRecursiveGetAndPutOsdfURL", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix("OSDF")
+		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
 		assert.NoError(t, err)
 		for _, export := range fed.Exports {
 			// Set path for object to upload/download
@@ -289,7 +289,7 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 	})
 
 	t.Run("testOsdfRecursiveGetAndPutPelicanURL", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix("OSDF")
+		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
 		assert.NoError(t, err)
 
 		for _, export := range fed.Exports {

--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -103,7 +103,7 @@ func TestGetAndPutAuth(t *testing.T) {
 
 	// This tests object get/put with a pelican:// url
 	t.Run("testPelicanObjectPutAndGetWithPelicanUrl", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix("PELICAN")
+		_, err := config.SetPreferredPrefix(config.PelicanPrefix)
 		assert.NoError(t, err)
 
 		// Set path for object to upload/download
@@ -131,7 +131,7 @@ func TestGetAndPutAuth(t *testing.T) {
 
 	// This tests object get/put with a pelican:// url
 	t.Run("testOsdfObjectPutAndGetWithPelicanUrl", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix("OSDF")
+		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
 		assert.NoError(t, err)
 
 		for _, export := range fed.Exports {
@@ -159,7 +159,7 @@ func TestGetAndPutAuth(t *testing.T) {
 
 	// This tests pelican object get/put with an osdf url
 	t.Run("testOsdfObjectPutAndGetWithOSDFUrl", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix("OSDF")
+		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
 		assert.NoError(t, err)
 
 		for _, export := range fed.Exports {
@@ -247,7 +247,7 @@ func TestCopyAuth(t *testing.T) {
 
 	// This tests object get/put with a pelican:// url
 	t.Run("testPelicanObjectCopyWithPelicanUrl", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix("PELICAN")
+		_, err := config.SetPreferredPrefix(config.PelicanPrefix)
 		assert.NoError(t, err)
 
 		// Set path for object to upload/download
@@ -275,7 +275,7 @@ func TestCopyAuth(t *testing.T) {
 
 	// This tests object get/put with a pelican:// url
 	t.Run("testOsdfObjectCopyWithPelicanUrl", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix("OSDF")
+		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
 		assert.NoError(t, err)
 
 		for _, export := range fed.Exports {
@@ -303,7 +303,7 @@ func TestCopyAuth(t *testing.T) {
 
 	// This tests pelican object get/put with an osdf url
 	t.Run("testOsdfObjectCopyWithOSDFUrl", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix("OSDF")
+		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
 		assert.NoError(t, err)
 
 		for _, export := range fed.Exports {
@@ -420,7 +420,7 @@ func TestStatHttp(t *testing.T) {
 	})
 
 	t.Run("testStatHttpOSDFScheme", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix("OSDF")
+		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
 		assert.NoError(t, err)
 		testFileContent := "test file content"
 		// Drop the testFileContent into the origin directory

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -480,14 +480,14 @@ func (te *TransferEngine) newPelicanURL(remoteUrl *url.URL) (pelicanURL pelicanU
 	// With an osdf:// url scheme, we assume the user will be using the OSDF so load in our osdf metadata for our url
 	if scheme == "osdf" {
 		// If we are using an osdf/stash binary, we discovered the federation already --> load into local url metadata
-		if config.GetPreferredPrefix() == "OSDF" {
+		if config.GetPreferredPrefix() == config.OsdfPrefix {
 			log.Debugln("In OSDF mode with osdf:// url; populating metadata with OSDF defaults")
 			if param.Federation_DirectorUrl.GetString() == "" || param.Federation_DiscoveryUrl.GetString() == "" || param.Federation_RegistryUrl.GetString() == "" {
 				return pelicanUrl{}, fmt.Errorf("OSDF default metadata is not populated in config")
 			} else {
 				pelicanURL.directorUrl = param.Federation_DirectorUrl.GetString()
 			}
-		} else if config.GetPreferredPrefix() == "PELICAN" {
+		} else if config.GetPreferredPrefix() == config.PelicanPrefix {
 			// We hit this case when we are using a pelican binary but an osdf:// url, therefore we need to disover the osdf federation
 			log.Debugln("In Pelican mode with an osdf:// url, populating metadata with OSDF defaults")
 			// Check if cache has key of federationURL, if not, loader will add it:

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -555,7 +555,7 @@ func TestNewPelicanURL(t *testing.T) {
 
 	t.Run("TestOsdfOrStashSchemeWithOSDFPrefixNoError", func(t *testing.T) {
 		viper.Reset()
-		_, err := config.SetPreferredPrefix("OSDF")
+		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
 		assert.NoError(t, err)
 		// Init config to get proper timeouts
 		config.InitConfig()
@@ -579,7 +579,7 @@ func TestNewPelicanURL(t *testing.T) {
 
 	t.Run("TestOsdfOrStashSchemeWithOSDFPrefixWithError", func(t *testing.T) {
 		viper.Reset()
-		_, err := config.SetPreferredPrefix("OSDF")
+		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
 		assert.NoError(t, err)
 		config.InitConfig()
 
@@ -599,7 +599,7 @@ func TestNewPelicanURL(t *testing.T) {
 
 	t.Run("TestOsdfOrStashSchemeWithPelicanPrefixNoError", func(t *testing.T) {
 		viper.Reset()
-		_, err := config.SetPreferredPrefix("PELICAN")
+		_, err := config.SetPreferredPrefix(config.PelicanPrefix)
 		config.InitConfig()
 		assert.NoError(t, err)
 		remoteObject := "osdf:///something/somewhere/thatdoesnotexist.txt"

--- a/client/sharing_url_test.go
+++ b/client/sharing_url_test.go
@@ -153,7 +153,7 @@ func TestSharingUrl(t *testing.T) {
 	defer server.Close()
 	myUrl = server.URL
 
-	_, err := config.SetPreferredPrefix("PELICAN")
+	_, err := config.SetPreferredPrefix(config.PelicanPrefix)
 	assert.NoError(t, err)
 	viper.Set("ConfigDir", t.TempDir())
 	viper.Set("Logging.Level", "debug")
@@ -169,10 +169,10 @@ func TestSharingUrl(t *testing.T) {
 	// Call QueryDirector with the test server URL and a source path
 	testUrl, err := url.Parse("/test/foo/bar")
 	require.NoError(t, err)
-	os.Setenv(config.GetPreferredPrefix()+"_SKIP_TERMINAL_CHECK", "true")
+	os.Setenv(config.GetPreferredPrefix().String()+"_SKIP_TERMINAL_CHECK", "true")
 	token, err := CreateSharingUrl(testUrl, true)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, token)
 	fmt.Println(token)
-	os.Unsetenv(config.GetPreferredPrefix() + "_SKIP_TERMINAL_CHECK")
+	os.Unsetenv(config.GetPreferredPrefix().String() + "_SKIP_TERMINAL_CHECK")
 }

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -191,7 +191,7 @@ func TestStashPluginMain(t *testing.T) {
 	viper.Reset()
 	server_utils.ResetOriginExports()
 
-	_, err := config.SetPreferredPrefix("STASH")
+	_, err := config.SetPreferredPrefix(config.StashPrefix)
 	assert.NoError(t, err)
 
 	// Temp dir for downloads

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -134,7 +134,7 @@ func init() {
 	rootCmd.AddCommand(rootPluginCmd)
 	rootCmd.AddCommand(serveCmd)
 	preferredPrefix := config.GetPreferredPrefix()
-	rootCmd.Use = strings.ToLower(preferredPrefix)
+	rootCmd.Use = strings.ToLower(preferredPrefix.String())
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.config/pelican/pelican.yaml)")
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -288,9 +288,9 @@ func TestEnabledServers(t *testing.T) {
 // Tests the function setPreferredPrefix: ensures case-insensitivity and invalid values are handled correctly
 func TestSetPreferredPrefix(t *testing.T) {
 	t.Run("TestPelicanPreferredPrefix", func(t *testing.T) {
-		oldPref, err := SetPreferredPrefix("pelican")
+		oldPref, err := SetPreferredPrefix(PelicanPrefix)
 		assert.NoError(t, err)
-		if GetPreferredPrefix() != "PELICAN" {
+		if GetPreferredPrefix() != PelicanPrefix {
 			t.Errorf("Expected preferred prefix to be 'PELICAN', got '%s'", GetPreferredPrefix())
 		}
 		if oldPref != "" {
@@ -299,23 +299,23 @@ func TestSetPreferredPrefix(t *testing.T) {
 	})
 
 	t.Run("TestOSDFPreferredPrefix", func(t *testing.T) {
-		oldPref, err := SetPreferredPrefix("osdf")
+		oldPref, err := SetPreferredPrefix(OsdfPrefix)
 		assert.NoError(t, err)
-		if GetPreferredPrefix() != "OSDF" {
+		if GetPreferredPrefix() != OsdfPrefix {
 			t.Errorf("Expected preferred prefix to be 'OSDF', got '%s'", GetPreferredPrefix())
 		}
-		if oldPref != "PELICAN" {
+		if oldPref != PelicanPrefix {
 			t.Errorf("Expected old preferred prefix to be 'PELICAN', got '%s'", oldPref)
 		}
 	})
 
 	t.Run("TestStashPreferredPrefix", func(t *testing.T) {
-		oldPref, err := SetPreferredPrefix("stash")
+		oldPref, err := SetPreferredPrefix(StashPrefix)
 		assert.NoError(t, err)
-		if GetPreferredPrefix() != "STASH" {
+		if GetPreferredPrefix() != StashPrefix {
 			t.Errorf("Expected preferred prefix to be 'STASH', got '%s'", GetPreferredPrefix())
 		}
-		if oldPref != "OSDF" {
+		if oldPref != OsdfPrefix {
 			t.Errorf("Expected old preferred prefix to be 'osdf', got '%s'", oldPref)
 		}
 	})

--- a/config/encrypted.go
+++ b/config/encrypted.go
@@ -44,7 +44,7 @@ var setEmptyPassword = false
 
 func GetEncryptedConfigName() (string, error) {
 	configDir := viper.GetString("ConfigDir")
-	if GetPreferredPrefix() == "PELICAN" || IsRootExecution() {
+	if GetPreferredPrefix() == PelicanPrefix || IsRootExecution() {
 		return filepath.Join(configDir, "credentials", "client-credentials.pem"), nil
 	}
 	configLocation := filepath.Join("osdf-client", "oauth2-client.pem")

--- a/launchers/director_serve.go
+++ b/launchers/director_serve.go
@@ -39,7 +39,7 @@ func DirectorServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group
 	log.Info("Initializing Director GeoIP database...")
 	director.InitializeDB(ctx)
 
-	if config.GetPreferredPrefix() == "OSDF" {
+	if config.GetPreferredPrefix() == config.OsdfPrefix {
 		metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusWarning, "Start requesting from topology, status unknown")
 		log.Info("Generating/advertising server ads from OSG topology service...")
 

--- a/launchers/registry_serve.go
+++ b/launchers/registry_serve.go
@@ -46,7 +46,7 @@ func RegistryServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group
 		return err
 	}
 
-	if config.GetPreferredPrefix() == "OSDF" {
+	if config.GetPreferredPrefix() == config.OsdfPrefix {
 		metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusWarning, "Start requesting from topology, status unknown")
 		log.Info("Populating registry with namespaces from OSG topology service...")
 		if err := registry.PopulateTopology(); err != nil {

--- a/namespaces/namespaces.go
+++ b/namespaces/namespaces.go
@@ -160,7 +160,7 @@ func GetNamespaces() ([]Namespace, error) {
 	namespacesFromUrl, err := downloadNamespace()
 	if err != nil {
 		log.Debugf("Failed to download namespaces: %s", err)
-		if config.GetPreferredPrefix() == "PELICAN" {
+		if config.GetPreferredPrefix() == config.PelicanPrefix {
 			return nil, err
 		} else {
 			log.Debug("Continuing using built-in namespace configuration")

--- a/namespaces/namespaces_test.go
+++ b/namespaces/namespaces_test.go
@@ -101,7 +101,7 @@ func TestMatchNamespace(t *testing.T) {
 		t.Error(err)
 	}
 	// Reset the prefix to get old OSDF fallback behavior.
-	oldPrefix, err := config.SetPreferredPrefix("OSDF")
+	oldPrefix, err := config.SetPreferredPrefix(config.OsdfPrefix)
 	assert.NoError(t, err)
 	defer func() {
 		_, err := config.SetPreferredPrefix(oldPrefix)
@@ -252,7 +252,7 @@ func TestDownloadNamespacesFail(t *testing.T) {
 func TestGetNamespaces(t *testing.T) {
 	// Set the environment to an invalid URL, so it is forced to use the "built-in" namespaces.json
 	os.Setenv("OSDF_TOPOLOGY_NAMESPACE_URL", "https://doesnotexist.org.blah/namespaces.json")
-	oldPrefix, err := config.SetPreferredPrefix("OSDF")
+	oldPrefix, err := config.SetPreferredPrefix(config.OsdfPrefix)
 	assert.NoError(t, err)
 	defer func() {
 		_, err := config.SetPreferredPrefix(oldPrefix)

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -66,7 +66,7 @@ func trimPath(pathName string, maxDepth int) string {
 
 func AcquireToken(issuerUrl string, entry *config.PrefixEntry, credentialGen *namespaces.CredentialGeneration, osdfPath string, opts config.TokenGenerationOpts) (*config.TokenEntry, error) {
 
-	if fileInfo, _ := os.Stdout.Stat(); (len(os.Getenv(config.GetPreferredPrefix()+"_SKIP_TERMINAL_CHECK")) == 0) && ((fileInfo.Mode() & os.ModeCharDevice) == 0) {
+	if fileInfo, _ := os.Stdout.Stat(); (len(os.Getenv(config.GetPreferredPrefix().String()+"_SKIP_TERMINAL_CHECK")) == 0) && ((fileInfo.Mode() & os.ModeCharDevice) == 0) {
 		return nil, errors.New("This program must be run in a terminal to acquire a new token")
 	}
 

--- a/registry/client_commands_test.go
+++ b/registry/client_commands_test.go
@@ -130,7 +130,7 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 	defer cancel()
 
 	viper.Reset()
-	_, err := config.SetPreferredPrefix("OSDF")
+	_, err := config.SetPreferredPrefix(config.OsdfPrefix)
 	assert.NoError(t, err)
 	viper.Set("Federation.DirectorUrl", "https://osdf-director.osg-htc.org")
 	viper.Set("Federation.RegistryUrl", "https://osdf-registry.osg-htc.org")
@@ -216,7 +216,7 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "A superspace or subspace of this namespace /topo already exists in the OSDF topology: /topo/foo. To register a Pelican equivalence, you need to present your identity.")
 
-	_, err = config.SetPreferredPrefix("pelican")
+	_, err = config.SetPreferredPrefix(config.PelicanPrefix)
 	assert.NoError(t, err)
 	viper.Reset()
 }

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -202,7 +202,7 @@ func topologyNamespaceExistsByPrefix(prefix string) (bool, error) {
 
 func namespaceSupSubChecks(prefix string) (superspaces []string, subspaces []string, inTopo bool, topoNss []Topology, err error) {
 	// The very first thing we do is check if there's a match in topo. We simply flag it's in topology if so
-	if config.GetPreferredPrefix() == "OSDF" {
+	if config.GetPreferredPrefix() == config.OsdfPrefix {
 		topoSuperSubQuery := `
 		SELECT prefix FROM topology WHERE (? || '/') LIKE (prefix || '/%')
 		UNION

--- a/registry/registry_db_test.go
+++ b/registry/registry_db_test.go
@@ -756,7 +756,7 @@ func TestRegistryTopology(t *testing.T) {
 	}()
 
 	// Set value so that config.GetPreferredPrefix() returns "OSDF"
-	_, err = config.SetPreferredPrefix("OSDF")
+	_, err = config.SetPreferredPrefix(config.OsdfPrefix)
 	assert.NoError(t, err)
 
 	//Test topology table population

--- a/registry/registry_ui_test.go
+++ b/registry/registry_ui_test.go
@@ -914,7 +914,7 @@ func TestCreateNamespace(t *testing.T) {
 	t.Run("osdf-topology-subspace-request-gives-200", func(t *testing.T) {
 		resetNamespaceDB(t)
 
-		_, err := config.SetPreferredPrefix("OSDF")
+		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
 		require.NoError(t, err)
 		topoNamespaces := []string{"/topo/foo", "/topo/bar"}
 		svr := topologyMockup(t, topoNamespaces)
@@ -956,7 +956,7 @@ func TestCreateNamespace(t *testing.T) {
 	t.Run("osdf-topology-same-prefix-request-gives-200", func(t *testing.T) {
 		resetNamespaceDB(t)
 
-		_, err := config.SetPreferredPrefix("OSDF")
+		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
 		require.NoError(t, err)
 		topoNamespaces := []string{"/topo/foo", "/topo/bar"}
 		svr := topologyMockup(t, topoNamespaces)

--- a/xrootd/authorization.go
+++ b/xrootd/authorization.go
@@ -269,7 +269,7 @@ func EmitAuthfile(server server_structs.XRootDServer) error {
 
 	output := new(bytes.Buffer)
 	foundPublicLine := false
-	if config.GetPreferredPrefix() == "OSDF" {
+	if config.GetPreferredPrefix() == config.OsdfPrefix {
 		log.Debugln("Retrieving OSDF Authfile for server")
 		bytes, err := getOSDFAuthFiles(server)
 		if err != nil {

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -278,7 +278,7 @@ func TestOSDFAuthCreation(t *testing.T) {
 			}
 			viper.Set("Origin.FederationPrefix", "/")
 			viper.Set("Origin.StoragePrefix", "/")
-			oldPrefix, err := config.SetPreferredPrefix("OSDF")
+			oldPrefix, err := config.SetPreferredPrefix(config.OsdfPrefix)
 			assert.NoError(t, err)
 			defer func() {
 				_, err := config.SetPreferredPrefix(oldPrefix)


### PR DESCRIPTION
Refactored the functionality of Get/SetPreferredPrefix to utilize the ConfigPrefix type to further ensure whatever prefixes we get/set are correct.