### PR TITLE
Directory listing changes in Pelican client

### DIFF
--- a/client/director.go
+++ b/client/director.go
@@ -37,12 +37,6 @@ import (
 	"github.com/pelicanplatform/pelican/utils"
 )
 
-// Origin information from the Director service
-type DirectorOrigin struct {
-	EndpointUrl *url.URL
-	Priority    int
-}
-
 type directorResponse struct {
 	Error string `json:"error"`
 }
@@ -106,7 +100,7 @@ func CreateNsFromDirectorResp(dirResp *http.Response) (namespace namespaces.Name
 	}
 
 	// Create the caches slice
-	namespace.SortedDirectorCaches, err = GetCachesFromDirectorResponse(dirResp, namespace.UseTokenOnRead || namespace.ReadHTTPS)
+	namespace.SortedDirectorCaches, err = getCachesFromDirectorResponse(dirResp, namespace.UseTokenOnRead || namespace.ReadHTTPS)
 	if err != nil {
 		log.Errorln("Unable to construct ordered cache list:", err)
 		return
@@ -174,52 +168,7 @@ func queryDirector(ctx context.Context, verb, source, directorUrl string) (resp 
 	return
 }
 
-func GetOriginsFromDirectorResponse(resp *http.Response) (origins []DirectorOrigin) {
-	// Get the Link header
-	linkHeader := resp.Header.Values("Link")
-	if len(linkHeader) == 0 {
-		return
-	}
-
-	for _, linksStr := range strings.Split(linkHeader[0], ",") {
-		links := strings.Split(strings.ReplaceAll(linksStr, " ", ""), ";")
-
-		var endpoint string
-
-		var pri int
-		for _, val := range links {
-			if strings.HasPrefix(val, "<") {
-				endpoint = val[1 : len(val)-1]
-			} else if strings.HasPrefix(val, "pri") {
-				pri, _ = strconv.Atoi(val[4:])
-			}
-		}
-
-		endpointUrl, err := url.Parse(endpoint)
-		if err != nil {
-			return
-		}
-
-		// Construct the origin objects, getting endpoint from director
-		var origin DirectorOrigin
-		origin.EndpointUrl = endpointUrl
-		origin.Priority = pri
-		origins = append(origins, origin)
-	}
-
-	// Making the assumption that the Link header doesn't already provide the origins
-	// in order (even though it probably does). This sorts the origins and ensures
-	// we're using the "pri" tag to order them
-	sort.Slice(origins, func(i, j int) bool {
-		val1 := origins[i].Priority
-		val2 := origins[j].Priority
-		return val1 < val2
-	})
-
-	return origins
-}
-
-func GetCachesFromDirectorResponse(resp *http.Response, needsToken bool) (caches []namespaces.DirectorCache, err error) {
+func getCachesFromDirectorResponse(resp *http.Response, needsToken bool) (caches []namespaces.DirectorCache, err error) {
 	// Get the Link header
 	linkHeader := resp.Header.Values("Link")
 	if len(linkHeader) == 0 {

--- a/client/director.go
+++ b/client/director.go
@@ -154,6 +154,9 @@ func queryDirector(ctx context.Context, verb, source, directorUrl string) (resp 
 	// If we get a 404, the director will hopefully tell us why. It might be that the namespace doesn't exist
 	if resp.StatusCode == 404 {
 		return nil, errors.New("404: " + string(body))
+	} else if resp.StatusCode == http.StatusMethodNotAllowed && verb == "PROPFIND" {
+		// If we get a 405 with a PROPFIND, the client will handle it
+		return
 	} else if resp.StatusCode != 307 {
 		var respErr directorResponse
 		if unmarshalErr := json.Unmarshal(body, &respErr); unmarshalErr != nil { // Error creating json

--- a/client/director_test.go
+++ b/client/director_test.go
@@ -47,7 +47,7 @@ func TestGetCachesFromDirectorResponse(t *testing.T) {
 	}
 
 	// Call the function in question
-	caches, err := GetCachesFromDirectorResponse(directorResponse, true)
+	caches, err := getCachesFromDirectorResponse(directorResponse, true)
 
 	// Test for expected outputs
 	assert.NoError(t, err, "Error getting caches from the Director's response")

--- a/client/errorAccum.go
+++ b/client/errorAccum.go
@@ -145,6 +145,11 @@ func IsRetryable(err error) bool {
 	if errors.Is(err, &allocateMemoryError{}) {
 		return true
 	}
+	if errors.Is(err, &dirListingNotSupportedError{}) {
+		// false because we cannot automatically retry, the user must change the url to use a different origin/namespace
+		// that enables dirlistings or the admin must enable dirlistings on the origin/namespace
+		return false
+	}
 	var cse *ConnectionSetupError
 	if errors.As(err, &cse) {
 		if sce, ok := cse.Unwrap().(grab.StatusCodeError); ok {

--- a/client/errorAccum_test.go
+++ b/client/errorAccum_test.go
@@ -48,13 +48,20 @@ func TestErrorsRetryableFalse(t *testing.T) {
 	te.AddError(&SlowTransferError{})
 	te.AddError(&SlowTransferError{})
 	assert.True(t, te.AllErrorsRetryable(), "ErrorsRetryable should be true")
+	te.resetErrors()
 
 	te.AddError(&ConnectionSetupError{})
 	assert.True(t, te.AllErrorsRetryable(), "ErrorsRetryable should be true")
+	te.resetErrors()
 
 	// Now add a non-retryable error
 	te.AddError(errors.New("Non retryable error"))
 	assert.False(t, te.AllErrorsRetryable(), "ErrorsRetryable should be false")
+	te.resetErrors()
+
+	te.AddError(&dirListingNotSupportedError{})
+	assert.False(t, te.AllErrorsRetryable(), "ErrorsRetryable should be false")
+	te.resetErrors()
 
 }
 

--- a/client/fed_linux_test.go
+++ b/client/fed_linux_test.go
@@ -395,7 +395,7 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 }
 
 // This tests that is origins disable listings, we should fail the download
-// Note: origins disabling listings override the existance of dirlisthost, causing a failure
+// Note: origins disabling listings override the existence of dirlisthost, causing a failure
 func TestFailureOnOriginDisablingListings(t *testing.T) {
 	viper.Reset()
 	server_utils.ResetOriginExports()

--- a/client/fed_linux_test.go
+++ b/client/fed_linux_test.go
@@ -412,10 +412,10 @@ func TestFailureOnOriginDisablingListings(t *testing.T) {
 	log.Debugln("Will create origin file at", destDir)
 	err := os.WriteFile(filepath.Join(destDir, "test.txt"), []byte("test file content"), fs.FileMode(0644))
 	require.NoError(t, err)
-	uploadURL := fmt.Sprintf("pelican://%s:%s%s/%s", param.Server_Hostname.GetString(), strconv.Itoa(param.Server_WebPort.GetInt()),
+	downloadURL := fmt.Sprintf("pelican://%s:%s%s/%s", param.Server_Hostname.GetString(), strconv.Itoa(param.Server_WebPort.GetInt()),
 		fed.Exports[0].FederationPrefix, "test")
 
-	_, err = client.DoGet(fed.Ctx, uploadURL, t.TempDir(), true)
+	_, err = client.DoGet(fed.Ctx, downloadURL, t.TempDir(), true)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "Origin and/or namespace does not support directory listings")
+	assert.Contains(t, err.Error(), "origin and/or namespace does not support directory listings")
 }

--- a/client/resources/both-auth.yml
+++ b/client/resources/both-auth.yml
@@ -9,7 +9,7 @@ Origin:
     - StoragePrefix: /<SHOULD BE OVERRIDDEN>
       FederationPrefix: /first/namespace
       # Don't set Reads -- it should be toggled true by setting PublicReads
-      Capabilities: ["Reads", "Writes", "DirectReads"]
+      Capabilities: ["Reads", "Writes", "DirectReads", "Listings"]
     - StoragePrefix: /<SHOULD BE OVERRIDDEN>
       FederationPrefix: /second/namespace
-      Capabilities: ["Reads", "Writes", "DirectReads"]
+      Capabilities: ["Reads", "Writes", "DirectReads", "Listings"]

--- a/client/resources/both-public.yml
+++ b/client/resources/both-public.yml
@@ -9,7 +9,7 @@ Origin:
     - StoragePrefix: /<SHOULD BE OVERRIDDEN>
       FederationPrefix: /first/namespace
       # Don't set Reads -- it should be toggled true by setting PublicReads
-      Capabilities: ["PublicReads", "Writes", "DirectReads"]
+      Capabilities: ["PublicReads", "Writes", "DirectReads", "Listings"]
     - StoragePrefix: /<SHOULD BE OVERRIDDEN>
       FederationPrefix: /second/namespace
-      Capabilities: ["PublicReads", "Writes", "DirectReads"]
+      Capabilities: ["PublicReads", "Writes", "DirectReads", "Listings"]

--- a/client/resources/one-pub-one-auth.yml
+++ b/client/resources/one-pub-one-auth.yml
@@ -9,7 +9,7 @@ Origin:
     - StoragePrefix: /<SHOULD BE OVERRIDDEN>
       FederationPrefix: /first/namespace
       # Don't set Reads -- it should be toggled true by setting PublicReads
-      Capabilities: ["PublicReads", "Writes", "DirectReads"]
+      Capabilities: ["PublicReads", "Writes", "DirectReads", "Listings"]
     - StoragePrefix: /<SHOULD BE OVERRIDDEN>
       FederationPrefix: /second/namespace
-      Capabilities: ["Reads", "Writes", "DirectReads"]
+      Capabilities: ["Reads", "Writes", "DirectReads", "Listings"]

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -66,7 +66,7 @@ Origin:
   EnablePublicReads: false
   EnableReads: true
   EnableWrites: true
-  EnableListings: false
+  EnableListings: true
   EnableDirectReads: false
   SelfTest: true
   Port: 8443

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -986,6 +986,19 @@ func TestRedirects(t *testing.T) {
 		expectedPath = "/api/v1.0/director/origin/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
+		// Test PROPFIND works for both base path and API path
+		req = httptest.NewRequest("PROPFIND", "/foo/bar", nil)
+		c.Request = req
+		ShortcutMiddleware("origin")(c)
+		expectedPath = "/api/v1.0/director/origin/foo/bar"
+		assert.Equal(t, expectedPath, c.Request.URL.Path)
+
+		req = httptest.NewRequest("PROPFIND", "/api/v1.0/director/origin/foo/bar", nil)
+		c.Request = req
+		ShortcutMiddleware("origin")(c)
+		expectedPath = "/api/v1.0/director/origin/foo/bar"
+		assert.Equal(t, expectedPath, c.Request.URL.Path)
+
 		// Host-aware tests
 		// Test that we can turn on host-aware redirects and get one appropriate redirect from each
 		// type of header (as we've already tested that hostname redirects function)

--- a/director/director_ui.go
+++ b/director/director_ui.go
@@ -48,7 +48,7 @@ type (
 		Longitude    float64                   `json:"longitude"`
 		Writes       bool                      `json:"enableWrite"`
 		DirectReads  bool                      `json:"enableFallbackRead"`
-		Listings     bool                      `json:"enableListings"`
+		Listings     bool                      `json:"enableListing"`
 		Filtered     bool                      `json:"filtered"`
 		FilteredType filterType                `json:"filteredType"`
 		Status       HealthTestStatus          `json:"status"`

--- a/director/director_ui.go
+++ b/director/director_ui.go
@@ -48,6 +48,7 @@ type (
 		Longitude    float64                   `json:"longitude"`
 		Writes       bool                      `json:"enableWrite"`
 		DirectReads  bool                      `json:"enableFallbackRead"`
+		Listings     bool                      `json:"enableListings"`
 		Filtered     bool                      `json:"filtered"`
 		FilteredType filterType                `json:"filteredType"`
 		Status       HealthTestStatus          `json:"status"`
@@ -129,6 +130,7 @@ func listServers(ctx *gin.Context) {
 			Longitude:    server.Longitude,
 			Writes:       server.Writes,
 			DirectReads:  server.DirectReads,
+			Listings:     server.Listings,
 			Filtered:     filtered,
 			FilteredType: ft,
 			Status:       healthStatus,

--- a/director/director_ui_test.go
+++ b/director/director_ui_test.go
@@ -60,6 +60,7 @@ func TestListServers(t *testing.T) {
 		Longitude:   mockOriginServerAd.Longitude,
 		Writes:      mockOriginServerAd.Writes,
 		DirectReads: mockOriginServerAd.DirectReads,
+		Listings:    mockOriginServerAd.Listings,
 		Status:      HealthStatusUnknown,
 	}
 	mocklistCacheRes := listServerResponse{

--- a/origin/advertise.go
+++ b/origin/advertise.go
@@ -98,6 +98,7 @@ func (server *OriginServer) CreateAdvertisement(name string, originUrlStr string
 				PublicReads: export.Capabilities.PublicReads,
 				Reads:       reads,
 				Writes:      export.Capabilities.Writes,
+				Listings:    export.Capabilities.Listings,
 			},
 			Path: export.FederationPrefix,
 			Generation: []server_structs.TokenGen{{
@@ -125,6 +126,7 @@ func (server *OriginServer) CreateAdvertisement(name string, originUrlStr string
 			Reads:       reads,
 			Writes:      param.Origin_EnableWrites.GetBool(),
 			DirectReads: param.Origin_EnableDirectReads.GetBool(),
+			Listings:    param.Origin_EnableListings.GetBool(),
 		},
 		Issuer: []server_structs.TokenIssuer{{
 			BasePaths: prefixes,

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -76,6 +76,7 @@ type (
 		Latitude     float64    `json:"latitude"`
 		Longitude    float64    `json:"longitude"`
 		Writes       bool       `json:"enable_write"`
+		Listings     bool       `json:"Listing"`              // True if the origin allows directory listings
 		DirectReads  bool       `json:"enable_fallback_read"` // True if reads from the origin are permitted when no cache is available
 		FromTopology bool       `json:"from_topology"`
 	}

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -76,7 +76,7 @@ type (
 		Latitude     float64    `json:"latitude"`
 		Longitude    float64    `json:"longitude"`
 		Writes       bool       `json:"enable_write"`
-		Listings     bool       `json:"Listing"`              // True if the origin allows directory listings
+		Listings     bool       `json:"enable_listing"`       // True if the origin allows directory listings
 		DirectReads  bool       `json:"enable_fallback_read"` // True if reads from the origin are permitted when no cache is available
 		FromTopology bool       `json:"from_topology"`
 	}


### PR DESCRIPTION
This is a different approach to the change of directory listings. Now, for recursive downloads, we will query the director for a PROPFIND to get the location of our "dirlisthost" (or origin). Then procede with the normal recursive download code. If we receive a 405 from the director doing this PROPFIND, we will revert back to the old way of doing things