### PR TITLE
Populate StartdAttrs in plugin -classad output

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -133,6 +133,7 @@ func stashPluginMain(args []string) {
 			fmt.Println("PluginType = \"FileTransfer\"")
 			fmt.Println("ProtocolVersion = 2")
 			fmt.Println("SupportedMethods = \"stash, osdf\"")
+			fmt.Println("StartdAttrs = \"PluginVersion\"")
 			os.Exit(0)
 		} else if args[0] == "-version" || args[0] == "-v" {
 			config.PrintPelicanVersion()

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -129,11 +129,11 @@ func stashPluginMain(args []string) {
 		if args[0] == "-classad" {
 			// Print classad and exit
 			fmt.Println("MultipleFileSupport = true")
-			fmt.Println("PluginVersion = \"" + config.GetVersion() + "\"")
+			fmt.Println("PelicanPluginVersion = \"" + config.GetVersion() + "\"")
 			fmt.Println("PluginType = \"FileTransfer\"")
 			fmt.Println("ProtocolVersion = 2")
 			fmt.Println("SupportedMethods = \"stash, osdf\"")
-			fmt.Println("StartdAttrs = \"PluginVersion\"")
+			fmt.Println("StartdAttrs = \"PelicanPluginVersion\"")
 			os.Exit(0)
 		} else if args[0] == "-version" || args[0] == "-v" {
 			config.PrintPelicanVersion()


### PR DESCRIPTION
Added the PluginVersion to the StartdAttrs so that it can show up as a starter ad.

Jira ticket: https://opensciencegrid.atlassian.net/browse/HTCONDOR-1051
Pelican ticket: https://github.com/PelicanPlatform/pelican/issues/1112
