### PR TITLE
"Airplane mode" for unit tests

### DIFF
--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -129,7 +129,9 @@ func doRetrieveRequest(t *testing.T, ctx context.Context, dur time.Duration) (*h
 
 	reqReader := bytes.NewReader(reqBytes)
 
-	brokerAud, err := url.Parse(param.Federation_BrokerUrl.GetString())
+	fedInfo, err := config.GetFederation(ctx)
+	require.NoError(t, err)
+	brokerAud, err := url.Parse(fedInfo.BrokerEndpoint)
 	require.NoError(t, err)
 	brokerAud.Path = ""
 

--- a/broker/client.go
+++ b/broker/client.go
@@ -549,7 +549,12 @@ func doCallback(ctx context.Context, brokerResp reversalRequest) (listener net.L
 // closes itself.  It is the result of a successful connection reversal to
 // a cache.
 func LaunchRequestMonitor(ctx context.Context, egrp *errgroup.Group, resultChan chan any) (err error) {
-	brokerUrl := param.Federation_BrokerUrl.GetString()
+	fedInfo, err := config.GetFederation(ctx)
+	if err != nil {
+		return err
+	}
+
+	brokerUrl := fedInfo.BrokerEndpoint
 	if brokerUrl == "" {
 		return errors.New("Broker service is not set or discovered; cannot enable broker functionality.  Try setting Federation.BrokerUrl")
 	}
@@ -588,7 +593,7 @@ func LaunchRequestMonitor(ctx context.Context, egrp *errgroup.Group, resultChan 
 				req.Header.Set("Content-Type", "application/json")
 				req.Header.Set("User-Agent", "pelican-origin/"+config.GetVersion())
 
-				brokerAud, err := url.Parse(param.Federation_BrokerUrl.GetString())
+				brokerAud, err := url.Parse(fedInfo.BrokerEndpoint)
 				if err != nil {
 					log.Errorln("Failure when parsing broker URL:", err)
 					break

--- a/broker/token_utils.go
+++ b/broker/token_utils.go
@@ -29,7 +29,6 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/pelicanplatform/pelican/config"
-	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
 	"github.com/pkg/errors"
@@ -81,8 +80,11 @@ func LaunchNamespaceKeyMaintenance(ctx context.Context, egrp *errgroup.Group) {
 // Given a namespace prefix, return the value that should be used
 // by the `iss` claim in a token for this federation's registry.
 func getRegistryIssValue(prefix string) (iss string, err error) {
-	// Calculate the correct `iss` field as part of the registry service
-	namespaceUrlStr := param.Federation_RegistryUrl.GetString()
+	fedInfo, err := config.GetFederation(context.Background())
+	if err != nil {
+		return
+	}
+	namespaceUrlStr := fedInfo.NamespaceRegistrationEndpoint
 	if namespaceUrlStr == "" {
 		err = errors.New("namespace URL is not set")
 		return

--- a/broker/token_utils_test.go
+++ b/broker/token_utils_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,6 +31,8 @@ import (
 
 func TestGetCacheHostnameFromToken(t *testing.T) {
 	viper.Reset()
+	config.InitConfig()
+	require.NoError(t, config.InitClient())
 
 	viper.Set("Federation.RegistryUrl", "https://your-registry.com")
 

--- a/cache/advertise.go
+++ b/cache/advertise.go
@@ -123,12 +123,15 @@ func (server *CacheServer) GetNamespaceAdsFromDirector() error {
 	// Get the endpoint of the director
 	var respNS []server_structs.NamespaceAdV2
 
-	directorEndpoint := param.Federation_DirectorUrl.GetString()
-	if directorEndpoint == "" {
+	fedInfo, err := config.GetFederation(context.Background())
+	if err != nil {
+		return err
+	}
+	if fedInfo.DirectorEndpoint == "" {
 		return errors.New("No director specified; give the federation name (-f)")
 	}
 
-	directorEndpointURL, err := url.Parse(directorEndpoint)
+	directorEndpointURL, err := url.Parse(fedInfo.DirectorEndpoint)
 	if err != nil {
 		return errors.Wrap(err, "Unable to parse director url")
 	}
@@ -145,7 +148,7 @@ func (server *CacheServer) GetNamespaceAdsFromDirector() error {
 	respData, err := utils.MakeRequest(context.Background(), directorNSListEndpointURL, "GET", nil, nil)
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
-			directorNSListEndpointURL, err = url.JoinPath(directorEndpoint, "api", "v1.0", "director", "listNamespaces")
+			directorNSListEndpointURL, err = url.JoinPath(fedInfo.DirectorEndpoint, "api", "v1.0", "director", "listNamespaces")
 			if err != nil {
 				return err
 			}

--- a/cache/advertise_test.go
+++ b/cache/advertise_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
@@ -122,7 +123,8 @@ func TestFilterNsAdsForCache(t *testing.T) {
 
 	for _, testInput := range tests {
 		t.Run(testInput.desc, func(t *testing.T) {
-
+			err := config.InitClient()
+			require.NoError(t, err)
 			viper.Set("Federation.DirectorURL", ts.URL)
 			if testInput.permittedNS != nil {
 				viper.Set("Cache.PermittedNamespaces", testInput.permittedNS)
@@ -130,7 +132,7 @@ func TestFilterNsAdsForCache(t *testing.T) {
 			defer viper.Reset()
 
 			cacheServer.SetFilters()
-			err := cacheServer.GetNamespaceAdsFromDirector()
+			err = cacheServer.GetNamespaceAdsFromDirector()
 			require.NoError(t, err)
 			filteredNS := cacheServer.GetNamespaceAds()
 

--- a/client/director.go
+++ b/client/director.go
@@ -19,6 +19,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -111,7 +112,7 @@ func CreateNsFromDirectorResp(dirResp *http.Response) (namespace namespaces.Name
 
 // Make a request to the director for a given verb/resource; return the
 // HTTP response object only if a 307 is returned.
-func queryDirector(verb, source, directorUrl string) (resp *http.Response, err error) {
+func queryDirector(ctx context.Context, verb, source, directorUrl string) (resp *http.Response, err error) {
 	resourceUrl := directorUrl + source
 	// Here we use http.Transport to prevent the client from following the director's
 	// redirect. We use the Location url elsewhere (plus we still need to do the token
@@ -125,7 +126,7 @@ func queryDirector(verb, source, directorUrl string) (resp *http.Response, err e
 		},
 	}
 
-	req, err := http.NewRequest(verb, resourceUrl, nil)
+	req, err := http.NewRequestWithContext(ctx, verb, resourceUrl, nil)
 	if err != nil {
 		log.Errorln("Failed to create an HTTP request:", err)
 		return nil, err

--- a/client/director_test.go
+++ b/client/director_test.go
@@ -20,6 +20,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -198,7 +199,7 @@ func TestQueryDirector(t *testing.T) {
 	defer server.Close()
 
 	// Call QueryDirector with the test server URL and a source path
-	actualResp, err := queryDirector("GET", "/foo/bar", server.URL)
+	actualResp, err := queryDirector(context.Background(), "GET", "/foo/bar", server.URL)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/fed_linux_test.go
+++ b/client/fed_linux_test.go
@@ -110,8 +110,12 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 	innerTempFile.Close()
 
 	t.Run("testPelicanRecursiveGetAndPutPelicanURL", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix(config.PelicanPrefix)
+		oldPref, err := config.SetPreferredPrefix(config.PelicanPrefix)
 		assert.NoError(t, err)
+		defer func() {
+			_, err := config.SetPreferredPrefix(oldPref)
+			require.NoError(t, err)
+		}()
 
 		for _, export := range fed.Exports {
 			// Set path for object to upload/download
@@ -196,7 +200,11 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 	})
 
 	t.Run("testOsdfRecursiveGetAndPutOsdfURL", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
+		oldPref, err := config.SetPreferredPrefix(config.OsdfPrefix)
+		defer func() {
+			_, err := config.SetPreferredPrefix(oldPref)
+			require.NoError(t, err)
+		}()
 		assert.NoError(t, err)
 		for _, export := range fed.Exports {
 			// Set path for object to upload/download
@@ -289,8 +297,12 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 	})
 
 	t.Run("testOsdfRecursiveGetAndPutPelicanURL", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
+		oldPref, err := config.SetPreferredPrefix(config.OsdfPrefix)
 		assert.NoError(t, err)
+		defer func() {
+			_, err := config.SetPreferredPrefix(oldPref)
+			require.NoError(t, err)
+		}()
 
 		for _, export := range fed.Exports {
 			// Set path for object to upload/download

--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -103,7 +103,11 @@ func TestGetAndPutAuth(t *testing.T) {
 
 	// This tests object get/put with a pelican:// url
 	t.Run("testPelicanObjectPutAndGetWithPelicanUrl", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix(config.PelicanPrefix)
+		oldPref, err := config.SetPreferredPrefix(config.PelicanPrefix)
+		defer func() {
+			_, err := config.SetPreferredPrefix(oldPref)
+			require.NoError(t, err)
+		}()
 		assert.NoError(t, err)
 
 		// Set path for object to upload/download
@@ -131,8 +135,12 @@ func TestGetAndPutAuth(t *testing.T) {
 
 	// This tests object get/put with a pelican:// url
 	t.Run("testOsdfObjectPutAndGetWithPelicanUrl", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
+		oldPref, err := config.SetPreferredPrefix(config.OsdfPrefix)
 		assert.NoError(t, err)
+		defer func() {
+			_, err := config.SetPreferredPrefix(oldPref)
+			require.NoError(t, err)
+		}()
 
 		for _, export := range fed.Exports {
 			// Set path for object to upload/download
@@ -159,8 +167,12 @@ func TestGetAndPutAuth(t *testing.T) {
 
 	// This tests pelican object get/put with an osdf url
 	t.Run("testOsdfObjectPutAndGetWithOSDFUrl", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
+		oldPref, err := config.SetPreferredPrefix(config.OsdfPrefix)
 		assert.NoError(t, err)
+		defer func() {
+			_, err := config.SetPreferredPrefix(oldPref)
+			require.NoError(t, err)
+		}()
 
 		for _, export := range fed.Exports {
 			// Set path for object to upload/download
@@ -247,8 +259,12 @@ func TestCopyAuth(t *testing.T) {
 
 	// This tests object get/put with a pelican:// url
 	t.Run("testPelicanObjectCopyWithPelicanUrl", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix(config.PelicanPrefix)
+		oldPref, err := config.SetPreferredPrefix(config.PelicanPrefix)
 		assert.NoError(t, err)
+		defer func() {
+			_, err := config.SetPreferredPrefix(oldPref)
+			require.NoError(t, err)
+		}()
 
 		// Set path for object to upload/download
 		for _, export := range fed.Exports {
@@ -275,8 +291,12 @@ func TestCopyAuth(t *testing.T) {
 
 	// This tests object get/put with a pelican:// url
 	t.Run("testOsdfObjectCopyWithPelicanUrl", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
+		oldPref, err := config.SetPreferredPrefix(config.OsdfPrefix)
 		assert.NoError(t, err)
+		defer func() {
+			_, err := config.SetPreferredPrefix(oldPref)
+			require.NoError(t, err)
+		}()
 
 		for _, export := range fed.Exports {
 			// Set path for object to upload/download
@@ -303,8 +323,12 @@ func TestCopyAuth(t *testing.T) {
 
 	// This tests pelican object get/put with an osdf url
 	t.Run("testOsdfObjectCopyWithOSDFUrl", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
+		oldPref, err := config.SetPreferredPrefix(config.OsdfPrefix)
 		assert.NoError(t, err)
+		defer func() {
+			_, err := config.SetPreferredPrefix(oldPref)
+			require.NoError(t, err)
+		}()
 
 		for _, export := range fed.Exports {
 			// Set path for object to upload/download
@@ -420,8 +444,12 @@ func TestStatHttp(t *testing.T) {
 	})
 
 	t.Run("testStatHttpOSDFScheme", func(t *testing.T) {
-		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
+		oldPref, err := config.SetPreferredPrefix(config.OsdfPrefix)
 		assert.NoError(t, err)
+		defer func() {
+			_, err := config.SetPreferredPrefix(oldPref)
+			require.NoError(t, err)
+		}()
 		testFileContent := "test file content"
 		// Drop the testFileContent into the origin directory
 		tempFile, err := os.Create(filepath.Join(fed.Exports[0].StoragePrefix, "test.txt"))

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -36,7 +36,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -551,8 +550,6 @@ func TestProjInUserAgent(t *testing.T) {
 func TestNewPelicanURL(t *testing.T) {
 	// Set up our federation and context
 	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
-	viper.Set("Client.WorkerCount", 5)
-	te := NewTransferEngine(ctx)
 	config.InitConfig()
 
 	t.Run("TestOsdfOrStashSchemeWithOSDFPrefixNoError", func(t *testing.T) {
@@ -562,6 +559,11 @@ func TestNewPelicanURL(t *testing.T) {
 		// Init config to get proper timeouts
 		config.InitConfig()
 
+		te := NewTransferEngine(ctx)
+		defer func() {
+			require.NoError(t, te.Shutdown())
+		}()
+
 		remoteObject := "osdf:///something/somewhere/thatdoesnotexist.txt"
 		remoteObjectURL, err := url.Parse(remoteObject)
 		assert.NoError(t, err)
@@ -569,7 +571,6 @@ func TestNewPelicanURL(t *testing.T) {
 		// Instead of relying on osdf, let's just set our global metadata (osdf prefix does this for us)
 		viper.Set("Federation.DirectorUrl", "someDirectorUrl")
 		viper.Set("Federation.DiscoveryUrl", "someDiscoveryUrl")
-		viper.Set("Federation.RegistryUrl", "someRegistryUrl")
 
 		pelicanURL, err := te.newPelicanURL(remoteObjectURL)
 		assert.NoError(t, err)
@@ -582,15 +583,21 @@ func TestNewPelicanURL(t *testing.T) {
 	t.Run("TestOsdfOrStashSchemeWithOSDFPrefixWithError", func(t *testing.T) {
 		viper.Reset()
 		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		config.InitConfig()
+		require.NoError(t, config.InitClient())
+
+		te := NewTransferEngine(ctx)
+		require.NotNil(t, te)
+		defer func() {
+			require.NoError(t, te.Shutdown())
+		}()
 
 		remoteObject := "osdf:///something/somewhere/thatdoesnotexist.txt"
 		remoteObjectURL, err := url.Parse(remoteObject)
 		assert.NoError(t, err)
 
 		// Instead of relying on osdf, let's just set our global metadata but don't set one piece
-		viper.Set("Federation.DirectorUrl", "someDirectorUrl")
 		viper.Set("Federation.DiscoveryUrl", "someDiscoveryUrl")
 
 		_, err = te.newPelicanURL(remoteObjectURL)
@@ -601,6 +608,15 @@ func TestNewPelicanURL(t *testing.T) {
 
 	t.Run("TestOsdfOrStashSchemeWithPelicanPrefixNoError", func(t *testing.T) {
 		viper.Reset()
+
+		config.InitConfig()
+		require.NoError(t, config.InitClient())
+		te := NewTransferEngine(ctx)
+		require.NotNil(t, te)
+		defer func() {
+			require.NoError(t, te.Shutdown())
+		}()
+
 		mock.MockOSDFDiscovery(t, config.GetTransport())
 		_, err := config.SetPreferredPrefix(config.PelicanPrefix)
 		config.InitConfig()
@@ -623,6 +639,14 @@ func TestNewPelicanURL(t *testing.T) {
 		viper.Set("TLSSkipVerify", true)
 		config.InitConfig()
 		err := config.InitClient()
+		require.NoError(t, err)
+
+		te := NewTransferEngine(ctx)
+		require.NotNil(t, te)
+		defer func() {
+			require.NoError(t, te.Shutdown())
+		}()
+
 		assert.NoError(t, err)
 		// Create a server that gives us a mock response
 		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -667,6 +691,12 @@ func TestNewPelicanURL(t *testing.T) {
 		viper.Reset()
 		config.InitConfig()
 
+		te := NewTransferEngine(ctx)
+		require.NotNil(t, te)
+		defer func() {
+			require.NoError(t, te.Shutdown())
+		}()
+
 		remoteObject := "pelican://some-host/something/somewhere/thatdoesnotexist.txt"
 		remoteObjectURL, err := url.Parse(remoteObject)
 		assert.NoError(t, err)
@@ -683,7 +713,13 @@ func TestNewPelicanURL(t *testing.T) {
 		viper.Set("transport.ResponseHeaderTimeout", 0.1*float64(time.Millisecond))
 		viper.Set("Client.WorkerCount", 5)
 		err := config.InitClient()
-		assert.NoError(t, err)
+		require.NoError(t, err)
+
+		te := NewTransferEngine(ctx)
+		defer func() {
+			require.NoError(t, te.Shutdown())
+		}()
+
 		// Create a server that gives us a mock response
 		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// make our response:
@@ -723,9 +759,6 @@ func TestNewPelicanURL(t *testing.T) {
 		cancel()
 		if err := egrp.Wait(); err != nil && err != context.Canceled && err != http.ErrServerClosed {
 			require.NoError(t, err)
-		}
-		if err := te.Shutdown(); err != nil {
-			log.Errorln("Failure when shutting down transfer engine:")
 		}
 		// Throw in a viper.Reset for good measure. Keeps our env squeaky clean!
 		viper.Reset()

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/mock"
 	"github.com/pelicanplatform/pelican/namespaces"
 	"github.com/pelicanplatform/pelican/test_utils"
 )
@@ -600,6 +601,7 @@ func TestNewPelicanURL(t *testing.T) {
 
 	t.Run("TestOsdfOrStashSchemeWithPelicanPrefixNoError", func(t *testing.T) {
 		viper.Reset()
+		mock.MockOSDFDiscovery(t, config.GetTransport())
 		_, err := config.SetPreferredPrefix(config.PelicanPrefix)
 		config.InitConfig()
 		assert.NoError(t, err)

--- a/client/main_test.go
+++ b/client/main_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/mock"
 	"github.com/pelicanplatform/pelican/namespaces"
 )
 
@@ -58,13 +59,14 @@ func TestGetIps(t *testing.T) {
 
 // TestGetToken tests getToken
 func TestGetToken(t *testing.T) {
-
 	// Need a namespace for token acquisition
 	defer os.Unsetenv("PELICAN_FEDERATION_TOPOLOGYNAMESPACEURL")
 	os.Setenv("PELICAN_TOPOLOGY_NAMESPACE_URL", "https://topology.opensciencegrid.org/osdf/namespaces")
 	viper.Reset()
 	err := config.InitClient()
 	assert.Nil(t, err)
+
+	mock.MockTopology(t, config.GetTransport())
 
 	namespace, err := namespaces.MatchNamespace("/user/foo")
 	assert.NoError(t, err)

--- a/client/main_test.go
+++ b/client/main_test.go
@@ -19,6 +19,7 @@
 package client
 
 import (
+	"context"
 	"net"
 	"net/url"
 	"os"
@@ -68,7 +69,7 @@ func TestGetToken(t *testing.T) {
 
 	mock.MockTopology(t, config.GetTransport())
 
-	namespace, err := namespaces.MatchNamespace("/user/foo")
+	namespace, err := namespaces.MatchNamespace(context.Background(), "/user/foo")
 	assert.NoError(t, err)
 
 	url, err := url.Parse("osdf:///user/foo")
@@ -140,7 +141,7 @@ func TestGetToken(t *testing.T) {
 	os.Setenv("_CONDOR_CREDS", tmpDir)
 	renamedUrl, err := url.Parse("renamed+osdf:///user/ligo/frames")
 	assert.NoError(t, err)
-	renamedNamespace, err := namespaces.MatchNamespace("/user/ligo/frames")
+	renamedNamespace, err := namespaces.MatchNamespace(context.Background(), "/user/ligo/frames")
 	assert.NoError(t, err)
 	token, err = getToken(renamedUrl, renamedNamespace, false, "", "", false)
 	assert.NoError(t, err)
@@ -159,7 +160,7 @@ func TestGetToken(t *testing.T) {
 	renamedUrl, err = url.Parse("renamed.handle1+osdf:///user/ligo/frames")
 	renamedUrl.Scheme = "renamed_handle1+osdf"
 	assert.NoError(t, err)
-	renamedNamespace, err = namespaces.MatchNamespace("/user/ligo/frames")
+	renamedNamespace, err = namespaces.MatchNamespace(context.Background(), "/user/ligo/frames")
 	assert.NoError(t, err)
 	token, err = getToken(renamedUrl, renamedNamespace, false, "", "", false)
 	assert.NoError(t, err)
@@ -176,7 +177,7 @@ func TestGetToken(t *testing.T) {
 	os.Setenv("_CONDOR_CREDS", tmpDir)
 	renamedUrl, err = url.Parse("renamed.handle2+osdf:///user/ligo/frames")
 	assert.NoError(t, err)
-	renamedNamespace, err = namespaces.MatchNamespace("/user/ligo/frames")
+	renamedNamespace, err = namespaces.MatchNamespace(context.Background(), "/user/ligo/frames")
 	assert.NoError(t, err)
 	token, err = getToken(renamedUrl, renamedNamespace, false, "", "", false)
 	assert.NoError(t, err)
@@ -193,7 +194,7 @@ func TestGetToken(t *testing.T) {
 	os.Setenv("_CONDOR_CREDS", tmpDir)
 	renamedUrl, err = url.Parse("renamed.handle3+osdf:///user/ligo/frames")
 	assert.NoError(t, err)
-	renamedNamespace, err = namespaces.MatchNamespace("/user/ligo/frames")
+	renamedNamespace, err = namespaces.MatchNamespace(context.Background(), "/user/ligo/frames")
 	assert.NoError(t, err)
 	token, err = getToken(renamedUrl, renamedNamespace, false, "", "", false)
 	assert.NoError(t, err)
@@ -210,7 +211,7 @@ func TestGetToken(t *testing.T) {
 	os.Setenv("_CONDOR_CREDS", tmpDir)
 	renamedUrl, err = url.Parse("/user/ligo/frames")
 	assert.NoError(t, err)
-	renamedNamespace, err = namespaces.MatchNamespace("/user/ligo/frames")
+	renamedNamespace, err = namespaces.MatchNamespace(context.Background(), "/user/ligo/frames")
 	assert.NoError(t, err)
 	token, err = getToken(renamedUrl, renamedNamespace, false, "renamed", "", false)
 	assert.NoError(t, err)

--- a/cmd/config_mgr.go
+++ b/cmd/config_mgr.go
@@ -20,10 +20,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"net/url"
 	"os"
 	"path"
+
+	"github.com/spf13/cobra"
 
 	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
@@ -142,7 +143,7 @@ func addTokenSubcommands(tokenCmd *cobra.Command) {
 			}
 			dest := url.URL{Path: path.Clean("/" + args[1])}
 
-			namespace, err := namespaces.MatchNamespace(args[1])
+			namespace, err := namespaces.MatchNamespace(cmd.Context(), args[1])
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Failed to get namespace for path:", err)
 				os.Exit(1)

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -120,7 +120,7 @@ func copyMain(cmd *cobra.Command, args []string) {
 	}
 
 	if val, err := cmd.Flags().GetBool("namespaces"); err == nil && val {
-		namespaces, err := namespaces.GetNamespaces()
+		namespaces, err := namespaces.GetNamespaces(ctx)
 		if err != nil {
 			fmt.Println("Failed to get namespaces:", err)
 			os.Exit(1)

--- a/cmd/object_share.go
+++ b/cmd/object_share.go
@@ -64,7 +64,7 @@ func shareMain(cmd *cobra.Command, args []string) error {
 		return errors.Wrapf(err, "Failed to parse '%v' as a URL", args[0])
 	}
 
-	token, err := client.CreateSharingUrl(objectUrl, isWrite)
+	token, err := client.CreateSharingUrl(cmd.Context(), objectUrl, isWrite)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to create a sharing URL for %v", objectUrl.String())
 	}

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -195,7 +195,7 @@ func stashPluginMain(args []string) {
 	}
 
 	if getCaches {
-		urls, err := client.GetCacheHostnames(testCachePath)
+		urls, err := client.GetCacheHostnames(context.Background(), testCachePath)
 		if err != nil {
 			log.Errorln("Failed to get cache URLs:", err)
 			os.Exit(1)
@@ -680,12 +680,10 @@ func writeTransferErrorMessage(currentError string, transferUrl string, upload b
 	errMsg = "Pelican Client Error: "
 
 	errMsg += currentError
-	if transferUrl != "" {
-		if tUrl, err := url.Parse(transferUrl); err == nil {
-			prefix = tUrl.Scheme + "://" + tUrl.Host
-			urlRemainder := strings.TrimPrefix(transferUrl, prefix)
-			errMsg = strings.ReplaceAll(errMsg, urlRemainder, "(...Path...)")
-		}
+	if tUrl, err := url.Parse(transferUrl); transferUrl != "" && err == nil {
+		prefix = tUrl.Scheme + "://" + tUrl.Host
+		urlRemainder := strings.TrimPrefix(transferUrl, prefix)
+		errMsg = strings.ReplaceAll(errMsg, urlRemainder, "(...Path...)")
 	}
 	// HTCondor will already say whether it's an upload/download in its generated string;
 	// save a few characters here

--- a/cmd/registry_client.go
+++ b/cmd/registry_client.go
@@ -28,6 +28,7 @@
 package main
 
 import (
+	"context"
 	"net/url"
 	"os"
 
@@ -47,8 +48,12 @@ var withIdentity bool
 var prefix string
 var pubkeyPath string
 
-func getNamespaceEndpoint() (string, error) {
-	namespaceEndpoint := param.Federation_RegistryUrl.GetString()
+func getNamespaceEndpoint(ctx context.Context) (string, error) {
+	fedInfo, err := config.GetFederation(ctx)
+	if err != nil {
+		return "", err
+	}
+	namespaceEndpoint := fedInfo.NamespaceRegistrationEndpoint
 	if namespaceEndpoint == "" {
 		return "", errors.New("No namespace registry specified; either give the federation name (-f) or specify the namespace API endpoint directly (e.g., --namespace-url=https://namespace.osg-htc.org/namespaces)")
 	}
@@ -69,7 +74,7 @@ func registerANamespace(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	namespaceEndpoint, err := getNamespaceEndpoint()
+	namespaceEndpoint, err := getNamespaceEndpoint(cmd.Context())
 	if err != nil {
 		log.Errorln("Failed to get RegistryUrl from config: ", err)
 		os.Exit(1)
@@ -136,7 +141,7 @@ func deleteANamespace(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	namespaceEndpoint, err := getNamespaceEndpoint()
+	namespaceEndpoint, err := getNamespaceEndpoint(cmd.Context())
 	if err != nil {
 		log.Errorln("Failed to get RegistryUrl from config: ", err)
 		os.Exit(1)
@@ -161,7 +166,7 @@ func listAllNamespaces(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	namespaceEndpoint, err := getNamespaceEndpoint()
+	namespaceEndpoint, err := getNamespaceEndpoint(cmd.Context())
 	if err != nil {
 		log.Errorln("Failed to get RegistryUrl from config: ", err)
 		os.Exit(1)

--- a/config/config.go
+++ b/config/config.go
@@ -148,6 +148,14 @@ var (
 	transport     *http.Transport
 	onceTransport sync.Once
 
+	// Global discovery info.  Using the "once" allows us to delay discovery
+	// until it's first needed, avoiding a web lookup for invoking configuration
+	// Note the 'once' object is a pointer so we can reset the client multiple
+	// times during unit tests
+	fedDiscoveryOnce *sync.Once
+	globalFedInfo    FederationDiscovery
+	globalFedErr     error
+
 	// Global struct validator
 	validate *validator.Validate
 
@@ -425,7 +433,7 @@ func DiscoverUrlFederation(ctx context.Context, federationDiscoveryUrl string) (
 	log.Debugln("Performing federation service discovery for specified url against endpoint", federationDiscoveryUrl)
 	federationUrl, err := url.Parse(federationDiscoveryUrl)
 	if err != nil {
-		err = errors.Wrapf(err, "Invalid federation value %s:", federationDiscoveryUrl)
+		err = errors.Wrapf(err, "invalid federation value %s:", federationDiscoveryUrl)
 		return
 	}
 	federationUrl.Scheme = "https"
@@ -500,50 +508,46 @@ func DiscoverUrlFederation(ctx context.Context, federationDiscoveryUrl string) (
 	return metadata, nil
 }
 
-func DiscoverFederation(ctx context.Context) error {
+// Global implementation of Discover Federation, outside any caching or
+// delayed discovery
+func discoverFederationImpl(ctx context.Context) (fedInfo FederationDiscovery, err error) {
 	federationStr := param.Federation_DiscoveryUrl.GetString()
 	externalUrlStr := param.Server_ExternalWebUrl.GetString()
 	defer func() {
 		// Set default guesses if these values are still unset.
-		if param.Federation_DirectorUrl.GetString() == "" && enabledServers.IsEnabled(DirectorType) {
-			viper.Set("Federation.DirectorUrl", externalUrlStr)
+		if fedInfo.DirectorEndpoint == "" && enabledServers.IsEnabled(DirectorType) {
+			fedInfo.DirectorEndpoint = externalUrlStr
 		}
-		if param.Federation_RegistryUrl.GetString() == "" && enabledServers.IsEnabled(RegistryType) {
-			viper.Set("Federation.RegistryUrl", externalUrlStr)
+		if fedInfo.NamespaceRegistrationEndpoint == "" && enabledServers.IsEnabled(RegistryType) {
+			fedInfo.NamespaceRegistrationEndpoint = externalUrlStr
 		}
-		if param.Federation_JwkUrl.GetString() == "" && enabledServers.IsEnabled(DirectorType) {
-			viper.Set("Federation.JwkUrl", externalUrlStr+"/.well-known/issuer.jwks")
+		if fedInfo.JwksUri == "" && enabledServers.IsEnabled(DirectorType) {
+			fedInfo.JwksUri = externalUrlStr + "/.well-known/issuer.jwks"
 		}
-		if param.Federation_BrokerUrl.GetString() == "" && enabledServers.IsEnabled(BrokerType) {
-			viper.Set("Federation.BrokerUrl", externalUrlStr)
+		if fedInfo.BrokerEndpoint == "" && enabledServers.IsEnabled(BrokerType) {
+			fedInfo.BrokerEndpoint = externalUrlStr
 		}
 	}()
-	if len(federationStr) == 0 {
-		log.Debugln("Federation URL is unset; skipping discovery")
-		return nil
-	}
-	if federationStr == externalUrlStr {
-		log.Debugln("Current web engine hosts the federation; skipping auto-discovery of services")
-		return nil
-	}
 
 	log.Debugln("Federation URL:", federationStr)
-	curDirectorURL := param.Federation_DirectorUrl.GetString()
-	curRegistryURL := param.Federation_RegistryUrl.GetString()
-	curFederationJwkURL := param.Federation_JwkUrl.GetString()
-	curBrokerURL := param.Federation_BrokerUrl.GetString()
-	if curDirectorURL != "" && curRegistryURL != "" && curFederationJwkURL != "" && curBrokerURL != "" {
-		return nil
+	fedInfo.DirectorEndpoint = viper.GetString("Federation.DirectorUrl")
+	fedInfo.NamespaceRegistrationEndpoint = viper.GetString("Federation.RegistryUrl")
+	fedInfo.JwksUri = viper.GetString("Federation.JwkUrl")
+	fedInfo.BrokerEndpoint = viper.GetString("Federation.BrokerUrl")
+	if fedInfo.DirectorEndpoint != "" && fedInfo.NamespaceRegistrationEndpoint != "" && fedInfo.JwksUri != "" && fedInfo.BrokerEndpoint != "" {
+		return
 	}
 
 	federationUrl, err := url.Parse(federationStr)
 	if err != nil {
-		return errors.Wrapf(err, "Invalid federation value %s:", federationStr)
+		err = errors.Wrapf(err, "invalid federation value %s:", federationStr)
+		return
 	}
 
 	if federationUrl.Path != "" && federationUrl.Host != "" {
 		// If the host is nothing, then the url is fine, but if we have a host and a path then there is a problem
-		return errors.New("Invalid federation discovery url is set. No path allowed for federation discovery url. Provided url: " + federationStr)
+		err = errors.New("Invalid federation discovery url is set. No path allowed for federation discovery url. Provided url: " + federationStr)
+		return
 	}
 
 	federationUrl.Scheme = "https"
@@ -552,40 +556,54 @@ func DiscoverFederation(ctx context.Context) error {
 		federationUrl.Path = ""
 	}
 
-	metadata, err := DiscoverUrlFederation(ctx, federationStr)
-	if err != nil {
-		return errors.Wrapf(err, "Invalid federation value %s:", federationStr)
+	var metadata FederationDiscovery
+	if federationStr == "" {
+		log.Debugln("Federation URL is unset; skipping discovery")
+	} else if federationStr == externalUrlStr {
+		log.Debugln("Current web engine hosts the federation; skipping auto-discovery of services")
+	} else {
+		metadata, err = DiscoverUrlFederation(ctx, federationStr)
+		if err != nil {
+			err = errors.Wrapf(err, "invalid federation value (%s)", federationStr)
+			return
+		}
 	}
 
 	// Set our globals
-	if curDirectorURL == "" {
+	if fedInfo.DirectorEndpoint == "" {
 		log.Debugln("Setting global director url to", metadata.DirectorEndpoint)
-		viper.Set("Federation.DirectorUrl", metadata.DirectorEndpoint)
+		fedInfo.DirectorEndpoint = metadata.DirectorEndpoint
 	}
-	if curRegistryURL == "" {
+	if fedInfo.NamespaceRegistrationEndpoint == "" {
 		log.Debugln("Setting global registry url to", metadata.NamespaceRegistrationEndpoint)
-		viper.Set("Federation.RegistryUrl", metadata.NamespaceRegistrationEndpoint)
+		fedInfo.NamespaceRegistrationEndpoint = metadata.NamespaceRegistrationEndpoint
 	}
-	if curFederationJwkURL == "" {
+	if fedInfo.JwksUri == "" {
 		log.Debugln("Setting global jwks url to", metadata.JwksUri)
-		viper.Set("Federation.JwkUrl", metadata.JwksUri)
+		fedInfo.JwksUri = metadata.JwksUri
 	}
-	if curBrokerURL == "" && metadata.BrokerEndpoint != "" {
+	if fedInfo.BrokerEndpoint == "" && metadata.BrokerEndpoint != "" {
 		log.Debugln("Setting global broker url to", metadata.BrokerEndpoint)
-		viper.Set("Federation.BrokerUrl", metadata.BrokerEndpoint)
+		fedInfo.BrokerEndpoint = metadata.BrokerEndpoint
 	}
 
-	return nil
+	return
 }
 
-// Return a struct representing the current (global) federation metadata
-func GetFederation() FederationDiscovery {
-	return FederationDiscovery{
-		DirectorEndpoint:              param.Federation_DirectorUrl.GetString(),
-		NamespaceRegistrationEndpoint: param.Federation_RegistryUrl.GetString(),
-		JwksUri:                       param.Federation_JwkUrl.GetString(),
-		BrokerEndpoint:                param.Federation_BrokerUrl.GetString(),
+// Retrieve the federation service information from the configuration.
+//
+// The calculation of the federation info is delayed until needed.  As
+// long as this is invoked after `InitClient` / `InitServer`, it is thread-safe.
+// If invoked before things are configured, it must be done from a single-threaded
+// context.
+func GetFederation(ctx context.Context) (FederationDiscovery, error) {
+	if fedDiscoveryOnce == nil {
+		fedDiscoveryOnce = &sync.Once{}
 	}
+	fedDiscoveryOnce.Do(func() {
+		globalFedInfo, globalFedErr = discoverFederationImpl(ctx)
+	})
+	return globalFedInfo, globalFedErr
 }
 
 // Set the current global federation metadata
@@ -1280,7 +1298,14 @@ func InitServer(ctx context.Context, currentServers ServerType) error {
 	// Sets up the server log filter mechanism
 	initFilterLogging()
 
-	return DiscoverFederation(ctx)
+	// Sets (or resets) the federation info.  Unlike in clients, we do this at startup
+	// instead of deferring it
+	fedDiscoveryOnce = &sync.Once{}
+	if _, err := GetFederation(ctx); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func InitClient() error {
@@ -1406,5 +1431,8 @@ func InitClient() error {
 		return err
 	}
 
-	return DiscoverFederation(context.Background())
+	// Sets (or resets) the deferred federation lookup
+	fedDiscoveryOnce = &sync.Once{}
+
+	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -43,6 +43,20 @@ import (
 
 var server *httptest.Server
 
+// Generate a context associated with the test
+//
+// Note: Does not utilize test_utils.TestContext to avoid an import cycle
+func testConfigContext(t *testing.T) (ctx context.Context) {
+	var cancel context.CancelFunc
+	if deadline, ok := t.Deadline(); ok {
+		ctx, cancel = context.WithDeadline(context.Background(), deadline)
+	} else {
+		ctx, cancel = context.WithCancel(context.Background())
+	}
+	t.Cleanup(cancel)
+	return
+}
+
 func TestMain(m *testing.M) {
 	// Create a test server
 	server = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -328,6 +342,7 @@ func TestSetPreferredPrefix(t *testing.T) {
 }
 
 func TestDiscoverFederation(t *testing.T) {
+	ctx := testConfigContext(t)
 
 	viper.Reset()
 	// Server to be a "mock" federation
@@ -359,36 +374,47 @@ func TestDiscoverFederation(t *testing.T) {
 	})
 
 	t.Run("testInvalidDiscoveryUrlWithPath", func(t *testing.T) {
-		viper.Set("Federation.DiscoveryUrl", server.URL+"/this/is/some/path")
-		err := DiscoverFederation(context.Background())
-		assert.Error(t, err)
+		viper.Reset()
+		viper.Set("Federation.DiscoveryURL", server.URL+"/this/is/some/path")
+		InitConfig()
+		require.NoError(t, InitClient())
+		_, err := GetFederation(ctx)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "Invalid federation discovery url is set. No path allowed for federation discovery url. Provided url: ",
 			"Error returned does not contain the correct error")
 		viper.Reset()
 	})
 
 	t.Run("testValidDiscoveryUrl", func(t *testing.T) {
+		viper.Reset()
+		InitConfig()
+		require.NoError(t, InitClient())
+		transport := GetTransport()
+		transport.TLSClientConfig = server.Client().Transport.(*http.Transport).TLSClientConfig.Clone()
 		viper.Set("Federation.DiscoveryUrl", server.URL)
-		err := DiscoverFederation(context.Background())
+		fedInfo, err := GetFederation(ctx)
 		assert.NoError(t, err)
 		// Assert that the metadata matches expectations
-		assert.Equal(t, "director", param.Federation_DirectorUrl.GetString(), "Unexpected DirectorEndpoint")
-		assert.Equal(t, "registry", param.Federation_RegistryUrl.GetString(), "Unexpected NamespaceRegistrationEndpoint")
-		assert.Equal(t, "jwks", param.Federation_JwkUrl.GetString(), "Unexpected JwksUri")
-		assert.Equal(t, "broker", param.Federation_BrokerUrl.GetString(), "Unexpected BrokerEndpoint")
+		assert.Equal(t, "director", fedInfo.DirectorEndpoint, "Unexpected DirectorEndpoint")
+		assert.Equal(t, "registry", fedInfo.NamespaceRegistrationEndpoint, "Unexpected NamespaceRegistrationEndpoint")
+		assert.Equal(t, "jwks", fedInfo.JwksUri, "Unexpected JwksUri")
+		assert.Equal(t, "broker", fedInfo.BrokerEndpoint, "Unexpected BrokerEndpoint")
 		viper.Reset()
 	})
 
 	t.Run("testOsgHtcUrl", func(t *testing.T) {
+		viper.Reset()
+		InitConfig()
+		require.NoError(t, InitClient())
 		mock.MockOSDFDiscovery(t, GetTransport())
 		viper.Set("Federation.DiscoveryUrl", "osg-htc.org")
-		err := DiscoverFederation(context.Background())
+		fedInfo, err := GetFederation(ctx)
 		assert.NoError(t, err)
 		// Assert that the metadata matches expectations
-		assert.Equal(t, "https://osdf-director.osg-htc.org", param.Federation_DirectorUrl.GetString(), "Unexpected DirectorEndpoint")
-		assert.Equal(t, "https://osdf-registry.osg-htc.org", param.Federation_RegistryUrl.GetString(), "Unexpected NamespaceRegistrationEndpoint")
-		assert.Equal(t, "https://osg-htc.org/osdf/public_signing_key.jwks", param.Federation_JwkUrl.GetString(), "Unexpected JwksUri")
-		assert.Equal(t, "", param.Federation_BrokerUrl.GetString(), "Unexpected BrokerEndpoint")
+		assert.Equal(t, "https://osdf-director.osg-htc.org", fedInfo.DirectorEndpoint, "Unexpected DirectorEndpoint")
+		assert.Equal(t, "https://osdf-registry.osg-htc.org", fedInfo.NamespaceRegistrationEndpoint, "Unexpected NamespaceRegistrationEndpoint")
+		assert.Equal(t, "https://osg-htc.org/osdf/public_signing_key.jwks", fedInfo.JwksUri, "Unexpected JwksUri")
+		assert.Equal(t, "", fedInfo.BrokerEndpoint, "Unexpected BrokerEndpoint")
 		viper.Reset()
 	})
 }
@@ -505,6 +531,8 @@ func TestCheckWatermark(t *testing.T) {
 }
 
 func TestInitServerUrl(t *testing.T) {
+	ctx := testConfigContext(t)
+
 	mockHostname := "example.com"
 	mockNon443Port := 8444
 	mock443Port := 443
@@ -563,24 +591,30 @@ func TestInitServerUrl(t *testing.T) {
 		// In this case, the port is 443, so Federation_DirectorUrl = https://example.com
 		viper.Set("Server.Hostname", mockHostname)
 		viper.Set("Server.WebPort", mock443Port)
-		err := InitServer(context.Background(), DirectorType)
+		err := InitServer(ctx, DirectorType)
 		require.NoError(t, err)
-		assert.Equal(t, mockWebUrlWoPort, param.Federation_DirectorUrl.GetString())
+		fedInfo, err := GetFederation(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, mockWebUrlWoPort, fedInfo.DirectorEndpoint)
 
 		// If Server_ExternalWebUrl is explicitly set, Federation_DirectorUrl defaults to whatever it is
 		// But 443 port is stripped if provided
 		initDirectoryConfig()
 		viper.Set("Server.ExternalWebUrl", mockWebUrlW443Port)
-		err = InitServer(context.Background(), DirectorType)
+		err = InitServer(ctx, DirectorType)
 		require.NoError(t, err)
-		assert.Equal(t, mockWebUrlWoPort, param.Federation_DirectorUrl.GetString())
+		fedInfo, err = GetFederation(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, mockWebUrlWoPort, fedInfo.DirectorEndpoint)
 
 		initDirectoryConfig()
 		viper.Set("Server.ExternalWebUrl", mockWebUrlWoPort)
 		viper.Set("Federation.DirectorUrl", "https://example-director.com")
-		err = InitServer(context.Background(), DirectorType)
+		err = InitServer(ctx, DirectorType)
 		require.NoError(t, err)
-		assert.Equal(t, "https://example-director.com", param.Federation_DirectorUrl.GetString())
+		fedInfo, err = GetFederation(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "https://example-director.com", fedInfo.DirectorEndpoint)
 	})
 
 	t.Run("reg-url-default-to-web-url", func(t *testing.T) {
@@ -590,24 +624,30 @@ func TestInitServerUrl(t *testing.T) {
 		// In this case, the port is 443, so Federation_RegistryUrl = https://example.com
 		viper.Set("Server.Hostname", mockHostname)
 		viper.Set("Server.WebPort", mock443Port)
-		err := InitServer(context.Background(), RegistryType)
+		err := InitServer(ctx, RegistryType)
 		require.NoError(t, err)
-		assert.Equal(t, mockWebUrlWoPort, param.Federation_RegistryUrl.GetString())
+		fedInfo, err := GetFederation(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, mockWebUrlWoPort, fedInfo.NamespaceRegistrationEndpoint)
 
 		// If Server_ExternalWebUrl is explicitly set, Federation_RegistryUrl defaults to whatever it is
 		// But 443 port is stripped if provided
 		initConfig()
 		viper.Set("Server.ExternalWebUrl", mockWebUrlW443Port)
-		err = InitServer(context.Background(), RegistryType)
+		err = InitServer(ctx, RegistryType)
 		require.NoError(t, err)
-		assert.Equal(t, mockWebUrlWoPort, param.Federation_RegistryUrl.GetString())
+		fedInfo, err = GetFederation(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, mockWebUrlWoPort, fedInfo.NamespaceRegistrationEndpoint)
 
 		initConfig()
 		viper.Set("Server.ExternalWebUrl", mockWebUrlWoPort)
 		viper.Set("Federation.RegistryUrl", "https://example-registry.com")
-		err = InitServer(context.Background(), RegistryType)
+		err = InitServer(ctx, RegistryType)
 		require.NoError(t, err)
-		assert.Equal(t, "https://example-registry.com", param.Federation_RegistryUrl.GetString())
+		fedInfo, err = GetFederation(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "https://example-registry.com", fedInfo.NamespaceRegistrationEndpoint)
 	})
 
 	t.Run("broker-url-default-to-web-url", func(t *testing.T) {
@@ -617,24 +657,30 @@ func TestInitServerUrl(t *testing.T) {
 		// In this case, the port is 443, so Federation_BrokerUrl = https://example.com
 		viper.Set("Server.Hostname", mockHostname)
 		viper.Set("Server.WebPort", mock443Port)
-		err := InitServer(context.Background(), BrokerType)
+		err := InitServer(ctx, BrokerType)
 		require.NoError(t, err)
-		assert.Equal(t, mockWebUrlWoPort, param.Federation_BrokerUrl.GetString())
+		fedInfo, err := GetFederation(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, mockWebUrlWoPort, fedInfo.BrokerEndpoint)
 
 		// If Server_ExternalWebUrl is explicitly set, Federation_BrokerUrl defaults to whatever it is
 		// But 443 port is stripped if provided
 		initConfig()
 		viper.Set("Server.ExternalWebUrl", mockWebUrlW443Port)
-		err = InitServer(context.Background(), BrokerType)
+		err = InitServer(ctx, BrokerType)
 		require.NoError(t, err)
-		assert.Equal(t, mockWebUrlWoPort, param.Federation_BrokerUrl.GetString())
+		fedInfo, err = GetFederation(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, mockWebUrlWoPort, fedInfo.BrokerEndpoint)
 
 		initConfig()
 		viper.Set("Server.ExternalWebUrl", mockWebUrlWoPort)
 		viper.Set("Federation.BrokerUrl", "https://example-registry.com")
-		err = InitServer(context.Background(), BrokerType)
+		err = InitServer(ctx, BrokerType)
 		require.NoError(t, err)
-		assert.Equal(t, "https://example-registry.com", param.Federation_BrokerUrl.GetString())
+		fedInfo, err = GetFederation(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "https://example-registry.com", fedInfo.BrokerEndpoint)
 	})
 }
 func TestDiscoverUrlFederation(t *testing.T) {

--- a/config/net_config.go
+++ b/config/net_config.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/url"
 	"strconv"
+	"sync"
 
 	"github.com/pelicanplatform/pelican/param"
 	log "github.com/sirupsen/logrus"
@@ -42,12 +43,13 @@ func UpdateConfigFromListener(ln net.Listener) {
 				newUrlStr := "https://" + serverUrl.Hostname() + ":" + strconv.Itoa(tcpAddr.Port)
 				viper.Set("Server.WebHost", serverUrl.Hostname())
 				viper.Set("Server.ExternalWebUrl", newUrlStr)
-				if param.Federation_DirectorUrl.GetString() == serverUrlStr {
+				if viper.GetString("Federation.DirectorUrl") == serverUrlStr {
 					viper.Set("Federation.DirectorUrl", newUrlStr)
 				}
-				if param.Federation_RegistryUrl.GetString() == serverUrlStr {
+				if viper.GetString("Federation.RegistryUrl") == serverUrlStr {
 					viper.Set("Federation.RegistryUrl", newUrlStr)
 				}
+				fedDiscoveryOnce = &sync.Once{}
 				log.Debugln("Random web port used; updated external web URL to", param.Server_ExternalWebUrl.GetString())
 			} else {
 				log.Errorln("Unable to update external web URL for random port; unable to parse existing URL:", serverUrlStr)

--- a/director/discovery.go
+++ b/director/discovery.go
@@ -28,7 +28,6 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/pelicanplatform/pelican/config"
-	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
 )
 
@@ -41,8 +40,13 @@ const (
 // Director hosts a discovery endpoint at federationDiscoveryPath to provide URLs to various
 // Pelican central servers in a federation.
 func federationDiscoveryHandler(ctx *gin.Context) {
-	directorUrlStr := param.Federation_DirectorUrl.GetString()
-	if !param.Federation_DirectorUrl.IsSet() || len(directorUrlStr) == 0 {
+	fedInfo, err := config.GetFederation(ctx)
+	if err != nil {
+		log.Errorln("Bad server configuration: Federation discovery could not resolve:", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Bad server configuration: Federation discovery could not resolve"})
+	}
+	directorUrlStr := fedInfo.DirectorEndpoint
+	if directorUrlStr == "" {
 		log.Error("Bad server configuration: Federation.DirectorUrl is not set")
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Bad server configuration: director URL is not set"})
 		return
@@ -59,8 +63,8 @@ func federationDiscoveryHandler(ctx *gin.Context) {
 	if directorUrl.Port() == "443" {
 		directorUrl.Host = strings.TrimSuffix(directorUrl.Host, ":443")
 	}
-	registryUrlStr := param.Federation_RegistryUrl.GetString()
-	if !param.Federation_RegistryUrl.IsSet() || len(registryUrlStr) == 0 {
+	registryUrlStr := fedInfo.NamespaceRegistrationEndpoint
+	if registryUrlStr == "" {
 		log.Error("Bad server configuration: Federation.RegistryUrl is not set")
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Bad server configuration: registry URL is not set"})
 		return
@@ -78,7 +82,7 @@ func federationDiscoveryHandler(ctx *gin.Context) {
 		registryUrl.Host = strings.TrimSuffix(registryUrl.Host, ":443")
 	}
 
-	brokerUrl := param.Federation_BrokerUrl.GetString()
+	brokerUrl := fedInfo.BrokerEndpoint
 
 	jwksUri, err := url.JoinPath(directorUrl.String(), directorJWKSPath)
 	if err != nil {
@@ -108,8 +112,14 @@ func federationDiscoveryHandler(ctx *gin.Context) {
 // Director metadata discovery endpoint for OpenID style
 // token authentication, providing issuer endpoint and director's jwks endpoint
 func oidcDiscoveryHandler(ctx *gin.Context) {
-	directorUrlStr := param.Federation_DirectorUrl.GetString()
-	if !param.Federation_DirectorUrl.IsSet() || len(directorUrlStr) == 0 {
+	fedInfo, err := config.GetFederation(ctx)
+	if err != nil {
+		log.Error("Bad server configuration: Federation discovery could not resolve:", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Bad server configuration: Federation discovery could not resolve"})
+		return
+	}
+	directorUrlStr := fedInfo.DirectorEndpoint
+	if directorUrlStr == "" {
 		log.Error("Bad server configuration: Federation.DirectorUrl is not set")
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "Bad server configuration: director URL is not set"})
 		return

--- a/director/discovery_test.go
+++ b/director/discovery_test.go
@@ -139,6 +139,8 @@ func TestFederationDiscoveryHandler(t *testing.T) {
 			viper.Reset()
 			viper.Set("Federation.DirectorUrl", tc.dirUrl)
 			viper.Set("Federation.RegistryUrl", tc.regUrl)
+			config.InitConfig()
+			require.NoError(t, config.InitClient())
 
 			w := httptest.NewRecorder()
 			req, _ := http.NewRequest("GET", "/test", nil)
@@ -208,6 +210,8 @@ func TestOidcDiscoveryHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			viper.Reset()
 			viper.Set("Federation.DirectorUrl", tc.dirUrl)
+			config.InitConfig()
+			require.NoError(t, config.InitClient())
 
 			w := httptest.NewRecorder()
 			req, _ := http.NewRequest("GET", "/test", nil)

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -122,7 +122,7 @@ func verifyAdvertiseToken(ctx context.Context, token, namespace string) (bool, e
 	if err != nil {
 		return false, err
 	}
-	regUrlStr := fedInfo.NamespaceRegistrationEndpoint	
+	regUrlStr := fedInfo.NamespaceRegistrationEndpoint
 
 	approved, err := checkNamespaceStatus(namespace, regUrlStr)
 	if err != nil {

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -118,7 +118,12 @@ func verifyAdvertiseToken(ctx context.Context, token, namespace string) (bool, e
 		return false, errors.Wrap(err, "failed to get JWKS URL from the issuer URL at "+issuerUrl)
 	}
 
-	regUrlStr := param.Federation_RegistryUrl.GetString()
+	fedInfo, err := config.GetFederation(ctx)
+	if err != nil {
+		return false, err
+	}
+	regUrlStr := fedInfo.NamespaceRegistrationEndpoint	
+
 	approved, err := checkNamespaceStatus(namespace, regUrlStr)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to check namespace approval status")

--- a/director/origin_api_test.go
+++ b/director/origin_api_test.go
@@ -57,9 +57,6 @@ func TestVerifyAdvertiseToken(t *testing.T) {
 
 	viper.Set("Federation.DirectorURL", "https://director-url.org")
 
-	config.InitConfig()
-	err := config.InitServer(ctx, config.DirectorType)
-	require.NoError(t, err)
 	// Mock registry server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Method == "POST" && req.URL.Path == "/api/v1.0/registry/checkNamespaceStatus" {
@@ -83,6 +80,11 @@ func TestVerifyAdvertiseToken(t *testing.T) {
 
 	// Mock cached jwks
 	viper.Set("Federation.RegistryUrl", ts.URL)
+
+	config.InitConfig()
+	err := config.InitServer(ctx, config.DirectorType)
+	require.NoError(t, err)
+
 	kSet, err := config.GetIssuerPublicJWKS()
 	require.NoError(t, err)
 	namespaceKeys.Set(ts.URL+"/api/v1.0/registry/test-namespace/.well-known/issuer.jwks", kSet, ttlcache.DefaultTTL)

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -291,6 +291,7 @@ description: |+
 type: url
 osdf_default: Default is determined dynamically through metadata at <Federation.DiscoveryUrl>/.well-known/pelican-configuration
 default: none
+direct_access: false
 components: ["client", "origin", "cache"]
 ---
 name: Federation.RegistryUrl
@@ -299,6 +300,7 @@ description: |+
 type: url
 osdf_default: Default is determined dynamically through metadata at <federation URL>/.well-known/pelican-configuration
 default: none
+direct_access: false
 components: ["client", "director", "origin", "cache"]
 ---
 name: Federation.JwkUrl
@@ -307,6 +309,7 @@ description: |+
 type: url
 osdf_default: Default is determined dynamically through metadata at <Federation.DiscoveryUrl>/.well-known/pelican-configuration
 default: none
+direct_access: false
 components: ["*"]
 ---
 name: Federation.TopologyUrl
@@ -341,6 +344,7 @@ description: |+
   If left unset, it will be populated by the federation metadata discovery.
 type: url
 default: none
+direct_access: false
 components: ["origin"]
 ---
 ############################

--- a/generate/param_generator.go
+++ b/generate/param_generator.go
@@ -104,6 +104,18 @@ func GenParamEnum() {
 			}
 		}
 
+		// If `direct_access` is set to false, then we are not allowed to access the value via the
+		// param module.  Typically, this indicates there's some other mechanism in the config module
+		// that should be used instead (such as when there's a computed value).
+		if entryDirectAccess, ok := entry["direct_access"]; ok {
+			if entryVal, ok := entryDirectAccess.(bool); ok && !entryVal {
+				// direct_access = false; do not generate parameter
+				continue
+			} else if !ok {
+				panic(fmt.Sprintf("Parameter entry '%s' has direct_access set to non-boolean", entryName))
+			}
+		}
+
 		// Each document must be converted to json on it's own and then the name
 		// must be used as a key
 		jsonBytes, _ := json.Marshal(entry)

--- a/launcher_utils/advertise.go
+++ b/launcher_utils/advertise.go
@@ -134,7 +134,11 @@ func advertiseInternal(ctx context.Context, server server_structs.XRootDServer) 
 		return errors.Wrap(err, fmt.Sprintf("failed to generate JSON description of %s", server.GetServerType()))
 	}
 
-	directorUrlStr := param.Federation_DirectorUrl.GetString()
+	fedInfo, err := config.GetFederation(ctx)
+	if err != nil {
+		return err
+	}
+	directorUrlStr := fedInfo.DirectorEndpoint
 	if directorUrlStr == "" {
 		return errors.New("Director endpoint URL is not known")
 	}
@@ -148,7 +152,7 @@ func advertiseInternal(ctx context.Context, server server_structs.XRootDServer) 
 	advTokenCfg := token.NewWLCGToken()
 	advTokenCfg.Lifetime = time.Minute
 	advTokenCfg.Issuer = serverIssuer
-	advTokenCfg.AddAudiences(param.Federation_DirectorUrl.GetString())
+	advTokenCfg.AddAudiences(fedInfo.DirectorEndpoint)
 	advTokenCfg.Subject = "origin"
 	advTokenCfg.AddScopes(token_scopes.Pelican_Advertise)
 
@@ -186,7 +190,7 @@ func advertiseInternal(ctx context.Context, server server_structs.XRootDServer) 
 			return errors.Wrapf(unmarshalErr, "could not decode the director's response, which responded %v from director advertisement: %s", resp.StatusCode, string(body))
 		}
 		if respErr.ApprovalError {
-			return fmt.Errorf("the director rejected the server advertisement with error: %s. Please contact the administrators of %s for more information.", respErr.Error, param.Federation_RegistryUrl.GetString())
+			return fmt.Errorf("the director rejected the server advertisement with error: %s. Please contact the administrators of %s for more information.", respErr.Error, fedInfo.NamespaceRegistrationEndpoint)
 		}
 		return errors.Errorf("the director responded to the server advertisement request with status code %d : %v\n", resp.StatusCode, respErr.Error)
 	}

--- a/launcher_utils/advertise.go
+++ b/launcher_utils/advertise.go
@@ -192,7 +192,7 @@ func advertiseInternal(ctx context.Context, server server_structs.XRootDServer) 
 		if respErr.ApprovalError {
 			return fmt.Errorf("the director rejected the server advertisement with error: %s. Please contact the administrators of %s for more information.", respErr.Error, fedInfo.NamespaceRegistrationEndpoint)
 		}
-		return errors.Errorf("the director responded to the server advertisement request with status code %d : %v\n", resp.StatusCode, respErr.Error)
+		return errors.Errorf("error during director registration: %v", respErr.Error)
 	}
 
 	return nil

--- a/launcher_utils/register_namespace.go
+++ b/launcher_utils/register_namespace.go
@@ -196,7 +196,7 @@ func keyIsRegistered(privkey jwk.Key, registryUrlStr string, prefix string) (key
 	}
 }
 
-func registerNamespacePrep(prefix string) (key jwk.Key, registrationEndpointURL string, isRegistered bool, err error) {
+func registerNamespacePrep(ctx context.Context, prefix string) (key jwk.Key, registrationEndpointURL string, isRegistered bool, err error) {
 	// TODO: We eventually want to be able to export multiple prefixes; at that point, we'll
 	// refactor to loop around all the namespaces
 	if prefix == "" {
@@ -208,7 +208,11 @@ func registerNamespacePrep(prefix string) (key jwk.Key, registrationEndpointURL 
 		return
 	}
 
-	namespaceEndpoint := param.Federation_RegistryUrl.GetString()
+	fedInfo, err := config.GetFederation(ctx)
+	if err != nil {
+		return
+	}
+	namespaceEndpoint := fedInfo.NamespaceRegistrationEndpoint
 	if namespaceEndpoint == "" {
 		err = errors.New("No namespace registry specified; try passing the `-f` flag specifying the federation name")
 		return
@@ -264,7 +268,7 @@ func RegisterNamespaceWithRetry(ctx context.Context, egrp *errgroup.Group, prefi
 		retryInterval = 10 * time.Second
 	}
 
-	key, url, isRegistered, err := registerNamespacePrep(prefix)
+	key, url, isRegistered, err := registerNamespacePrep(ctx, prefix)
 	if err != nil {
 		return err
 	}

--- a/launcher_utils/register_namespace_test.go
+++ b/launcher_utils/register_namespace_test.go
@@ -97,9 +97,12 @@ func TestRegistration(t *testing.T) {
 	viper.Set("Federation.RegistryUrl", svr.URL)
 	viper.Set("Origin.FederationPrefix", "/test123")
 
+	// Re-run the InitServer to reflect the new RegistryUrl set above
+	require.NoError(t, config.InitServer(ctx, config.OriginType))
+
 	// Test registration succeeds
 	prefix := param.Origin_FederationPrefix.GetString()
-	key, registerURL, isRegistered, err := registerNamespacePrep(prefix)
+	key, registerURL, isRegistered, err := registerNamespacePrep(ctx, prefix)
 	require.NoError(t, err)
 	assert.False(t, isRegistered)
 	assert.Equal(t, registerURL, svr.URL+"/api/v1.0/registry")
@@ -157,7 +160,7 @@ func TestRegistration(t *testing.T) {
 
 	// Redo the namespace prep, ensure that isPresent is true
 	prefix = param.Origin_FederationPrefix.GetString()
-	_, registerURL, isRegistered, err = registerNamespacePrep(prefix)
+	_, registerURL, isRegistered, err = registerNamespacePrep(ctx, prefix)
 	assert.Equal(t, svr.URL+"/api/v1.0/registry", registerURL)
 	assert.NoError(t, err)
 	assert.True(t, isRegistered)

--- a/launcher_utils/register_namespace_test.go
+++ b/launcher_utils/register_namespace_test.go
@@ -52,12 +52,13 @@ type (
 )
 
 func TestRegistration(t *testing.T) {
+	tempConfigDir := t.TempDir()
+
 	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
 	viper.Reset()
-	tempConfigDir := t.TempDir()
 	viper.Set("ConfigDir", tempConfigDir)
 
 	config.InitConfig()

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -220,6 +220,11 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (servers []se
 		}
 	}
 
+	fedInfo, err := config.GetFederation(ctx)
+	if err != nil {
+		return
+	}
+
 	// Origin needs to advertise once before the cache starts
 	if modules.IsEnabled(config.CacheType) && modules.IsEnabled(config.OriginType) {
 		log.Debug("Advertise Origin and Cache to the Director")
@@ -246,7 +251,7 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (servers []se
 		// was being fired up, but that may be a pigeonhole. The new assumption here is that we're religious
 		// about setting Federation.DirectorUrl.
 		var directorUrl *url.URL
-		directorUrl, err = url.Parse(param.Federation_DirectorUrl.GetString())
+		directorUrl, err = url.Parse(fedInfo.DirectorEndpoint)
 		if err != nil {
 			err = errors.Wrap(err, "Failed to parse director URL when checking origin advertisements before cache launch")
 			return
@@ -288,7 +293,7 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (servers []se
 	var cacheServer server_structs.XRootDServer
 	if modules.IsEnabled(config.CacheType) {
 		// Give five seconds for the origin to finish advertising to the director
-		desiredURL := param.Federation_DirectorUrl.GetString() + "/.well-known/openid-configuration"
+		desiredURL := fedInfo.DirectorEndpoint + "/.well-known/openid-configuration"
 		if err = server_utils.WaitUntilWorking(ctx, "GET", desiredURL, "director", 200, false); err != nil {
 			log.Errorln("Director does not seem to be working:", err)
 			return

--- a/local_cache/local_cache.go
+++ b/local_cache/local_cache.go
@@ -37,6 +37,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/lestrrat-go/option"
 	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/token_scopes"
@@ -259,7 +260,11 @@ func NewLocalCache(ctx context.Context, egrp *errgroup.Group, options ...LocalCa
 	lowWater := (cacheSize / 100) * uint64(lowWaterPercentage)
 	log.Infof("Cache size is %d bytes; for purge, high water mark is %d bytes, low water mark is %d bytes", cacheSize, highWater, lowWater)
 
-	directorUrl, err := url.Parse(param.Federation_DirectorUrl.GetString())
+	fedInfo, err := config.GetFederation(ctx)
+	if err != nil {
+		return
+	}
+	directorUrl, err := url.Parse(fedInfo.DirectorEndpoint)
 	if err != nil {
 		return
 	}
@@ -707,7 +712,11 @@ func (sc *LocalCache) updateConfig() error {
 	// Get the endpoint of the director
 	var respNS []server_structs.NamespaceAdV2
 
-	directorEndpoint := param.Federation_DirectorUrl.GetString()
+	fedInfo, err := config.GetFederation(sc.ctx)
+	if err != nil {
+		return err
+	}
+	directorEndpoint := fedInfo.DirectorEndpoint
 	if directorEndpoint == "" {
 		return errors.New("No director specified; give the federation name (-f)")
 	}

--- a/mock/mockups.go
+++ b/mock/mockups.go
@@ -1,0 +1,104 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+//
+// Create mockups of various web services
+//
+// Allows unit tests to run without connecting to the various "real"
+// external web services
+//
+
+package mock
+
+import (
+	"context"
+	"crypto/tls"
+	_ "embed"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	//go:embed resources/topology-namespace.json
+	topologyMock string
+)
+
+func MockOSDFDiscovery(t *testing.T, transport *http.Transport) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{
+			"director_endpoint": "https://osdf-director.osg-htc.org",
+			"namespace_registration_endpoint": "https://osdf-registry.osg-htc.org",
+			"jwks_uri": "https://osg-htc.org/osdf/public_signing_key.jwks"
+		  }`))
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(func() {
+		server.Close()
+	})
+
+	origDialContext := transport.DialTLSContext
+	transport.DialTLSContext = func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		if addr == "osg-htc.org:443" {
+			dialer := net.Dialer{}
+			return dialer.DialContext(ctx, server.Listener.Addr().Network(), server.Listener.Addr().String())
+		}
+		if origDialContext == nil {
+			dialer := tls.Dialer{Config: transport.TLSClientConfig}
+			return dialer.DialContext(ctx, network, addr)
+		}
+		return origDialContext(ctx, network, addr)
+	}
+
+	t.Cleanup(func() {
+		transport.DialContext = origDialContext
+	})
+}
+
+func MockTopology(t *testing.T, transport *http.Transport) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(topologyMock))
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(func() {
+		server.Close()
+	})
+
+	origDialContext := transport.DialTLSContext
+	transport.DialTLSContext = func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		if addr == "topology.opensciencegrid.org:443" {
+			dialer := net.Dialer{}
+			return dialer.DialContext(ctx, server.Listener.Addr().Network(), server.Listener.Addr().String())
+		}
+		if origDialContext == nil {
+			dialer := tls.Dialer{Config: transport.TLSClientConfig}
+			return dialer.DialContext(ctx, network, addr)
+		}
+		return origDialContext(ctx, network, addr)
+	}
+
+	t.Cleanup(func() {
+		transport.DialContext = origDialContext
+	})
+}

--- a/mock/resources/topology-namespace.json
+++ b/mock/resources/topology-namespace.json
@@ -1,0 +1,26 @@
+{
+  "namespaces": [
+    {
+      "caches": [
+        {
+          "auth_endpoint": "dtn-pas.bois.nrp.internet2.edu:8443",
+          "endpoint": "dtn-pas.bois.nrp.internet2.edu:8000",
+          "resource": "BOISE_INTERNET2_OSDF_CACHE"
+        },
+        {
+          "auth_endpoint": "osdf-uw-cache.svc.osg-htc.org:8443",
+          "endpoint": "osdf-uw-cache.svc.osg-htc.org:8443",
+          "resource": "CHTC_PELICAN_CACHE"
+        }
+      ],
+      "credential_generation": null,
+      "dirlisthost": null,
+      "origins": [],
+      "path": "/user",
+      "readhttps": false,
+      "scitokens": [],
+      "usetokenonread": false,
+      "writebackhost": null
+    }
+  ]
+}

--- a/origin/advertise.go
+++ b/origin/advertise.go
@@ -19,6 +19,7 @@
 package origin
 
 import (
+	"context"
 	"net/url"
 
 	"github.com/pkg/errors"
@@ -134,7 +135,11 @@ func (server *OriginServer) CreateAdvertisement(name string, originUrlStr string
 	if len(prefixes) == 1 {
 		if param.Origin_EnableBroker.GetBool() {
 			var brokerUrl *url.URL
-			brokerUrl, err = url.Parse(param.Federation_BrokerUrl.GetString())
+			fedInfo, err := config.GetFederation(context.Background())
+			if err != nil {
+				return nil, err
+			}
+			brokerUrl, err = url.Parse(fedInfo.BrokerEndpoint)
 			if err != nil {
 				err = errors.Wrap(err, "Invalid Broker URL")
 				return nil, err

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -129,11 +129,7 @@ var (
 	Director_MaxMindKeyFile = StringParam{"Director.MaxMindKeyFile"}
 	Director_SupportContactEmail = StringParam{"Director.SupportContactEmail"}
 	Director_SupportContactUrl = StringParam{"Director.SupportContactUrl"}
-	Federation_BrokerUrl = StringParam{"Federation.BrokerUrl"}
-	Federation_DirectorUrl = StringParam{"Federation.DirectorUrl"}
 	Federation_DiscoveryUrl = StringParam{"Federation.DiscoveryUrl"}
-	Federation_JwkUrl = StringParam{"Federation.JwkUrl"}
-	Federation_RegistryUrl = StringParam{"Federation.RegistryUrl"}
 	Federation_TopologyNamespaceUrl = StringParam{"Federation.TopologyNamespaceUrl"}
 	Federation_TopologyUrl = StringParam{"Federation.TopologyUrl"}
 	IssuerKey = StringParam{"IssuerKey"}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -234,7 +234,11 @@ func keySignChallengeCommit(ctx *gin.Context, data *registrationData) (bool, map
 	if err != nil {
 		return false, nil, badRequestError{Message: err.Error()}
 	}
-	registryUrl := param.Federation_RegistryUrl.GetString()
+	fedInfo, err := config.GetFederation(ctx)
+	if err != nil {
+		return false, nil, err
+	}
+	registryUrl := fedInfo.NamespaceRegistrationEndpoint
 
 	var rawkey interface{} // This is the raw key, like *rsa.PrivateKey or *ecdsa.PrivateKey
 	if err := key.Raw(&rawkey); err != nil {

--- a/server_utils/registry.go
+++ b/server_utils/registry.go
@@ -19,6 +19,7 @@
 package server_utils
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -30,7 +31,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/pelicanplatform/pelican/config"
-	"github.com/pelicanplatform/pelican/param"
 )
 
 // For a given prefix, get the prefix's issuer URL, where we consider that the openid endpoint
@@ -40,8 +40,12 @@ func GetNSIssuerURL(prefix string) (string, error) {
 	if prefix == "" || !strings.HasPrefix(prefix, "/") {
 		return "", errors.New(fmt.Sprintf("the prefix \"%s\" is invalid", prefix))
 	}
-	registryUrlStr := param.Federation_RegistryUrl.GetString()
+	fedInfo, err := config.GetFederation(context.Background())
+	registryUrlStr := fedInfo.NamespaceRegistrationEndpoint
 	if registryUrlStr == "" {
+		if err != nil {
+			return "", err
+		}
 		return "", errors.New("federation registry URL is not set and was not discovered")
 	}
 	registryUrl, err := url.Parse(registryUrlStr)

--- a/server_utils/registry_test.go
+++ b/server_utils/registry_test.go
@@ -21,13 +21,18 @@ package server_utils
 import (
 	"testing"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/test_utils"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetNSIssuerURL(t *testing.T) {
 	viper.Reset()
+	config.InitConfig()
+	require.NoError(t, config.InitClient())
+
 	viper.Set("Federation.RegistryUrl", "https://registry.com:8446")
 	url, err := GetNSIssuerURL("/test-prefix")
 	assert.Equal(t, nil, err)
@@ -37,6 +42,9 @@ func TestGetNSIssuerURL(t *testing.T) {
 
 func TestGetJWKSURLFromIssuerURL(t *testing.T) {
 	viper.Reset()
+	config.InitConfig()
+	require.NoError(t, config.InitClient())
+
 	registry := test_utils.RegistryMockup(t, "/test-prefix")
 	defer registry.Close()
 	viper.Set("Federation.RegistryUrl", registry.URL)

--- a/test_utils/utils.go
+++ b/test_utils/utils.go
@@ -99,5 +99,6 @@ func RegistryMockup(t *testing.T, prefix string) *httptest.Server {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(jsonResponse))
 	}))
+	t.Cleanup(server.Close)
 	return server
 }

--- a/token/token_verify.go
+++ b/token/token_verify.go
@@ -78,9 +78,15 @@ func init() {
 // Checks that the given token was signed by the federation jwk and also checks that the token has the expected scope
 func (a AuthCheckImpl) checkFederationIssuer(c *gin.Context, strToken string, expectedScopes []token_scopes.TokenScope, allScopes bool) error {
 	dirFallback := false
+
+	fedInfo, err := config.GetFederation(c)
+	if err != nil {
+		return err
+	}
+
 	fedURL := param.Federation_DiscoveryUrl.GetString()
 	if fedURL == "" {
-		dirURL := param.Federation_DirectorUrl.GetString()
+		dirURL := fedInfo.DirectorEndpoint
 		if dirURL == "" {
 			return errors.New("checkFederationIssuer: Federation.DiscoveryUrl is empty. Failed to fall back to empty Federation.DirectorUrl")
 		}
@@ -102,10 +108,6 @@ func (a AuthCheckImpl) checkFederationIssuer(c *gin.Context, strToken string, ex
 		}
 	}
 
-	fedInfo, err := config.GetFederation(c)
-	if err != nil {
-		return err
-	}
 	fedURIFile := fedInfo.JwksUri
 	ctx := context.Background()
 	if federationJWK == nil {

--- a/token/token_verify.go
+++ b/token/token_verify.go
@@ -102,7 +102,11 @@ func (a AuthCheckImpl) checkFederationIssuer(c *gin.Context, strToken string, ex
 		}
 	}
 
-	fedURIFile := param.Federation_JwkUrl.GetString()
+	fedInfo, err := config.GetFederation(c)
+	if err != nil {
+		return err
+	}
+	fedURIFile := fedInfo.JwksUri
 	ctx := context.Background()
 	if federationJWK == nil {
 		client := &http.Client{Transport: config.GetTransport()}
@@ -271,7 +275,11 @@ func GetNSIssuerURL(prefix string) (string, error) {
 	if prefix == "" || !strings.HasPrefix(prefix, "/") {
 		return "", errors.New(fmt.Sprintf("the prefix \"%s\" is invalid", prefix))
 	}
-	registryUrlStr := param.Federation_RegistryUrl.GetString()
+	fedInfo, err := config.GetFederation(context.Background())
+	if err != nil {
+		return "", err
+	}
+	registryUrlStr := fedInfo.NamespaceRegistrationEndpoint
 	if registryUrlStr == "" {
 		return "", errors.New("federation registry URL is not set and was not discovered")
 	}

--- a/xrootd/authorization.go
+++ b/xrootd/authorization.go
@@ -27,6 +27,7 @@ package xrootd
 import (
 	"bufio"
 	"bytes"
+	"context"
 	_ "embed"
 	"encoding/json"
 	"io"
@@ -487,11 +488,15 @@ func GenerateOriginIssuer(exportedPaths []string) (issuer Issuer, err error) {
 
 // We have a special issuer just for director-based monitoring of the origin.
 func GenerateDirectorMonitoringIssuer() (issuer Issuer, err error) {
-	if val := param.Federation_DirectorUrl.GetString(); val == "" {
+	fedInfo, err := config.GetFederation(context.Background())
+	if err != nil {
+		return
+	}
+	if val := fedInfo.DirectorEndpoint; val == "" {
 		return
 	}
 	issuer.Name = "Director-based Monitoring"
-	issuer.Issuer = param.Federation_DirectorUrl.GetString()
+	issuer.Issuer = fedInfo.DirectorEndpoint
 	issuer.BasePaths = []string{"/pelican/monitoring"}
 	issuer.DefaultUser = "xrootd"
 

--- a/xrootd/fed_test.go
+++ b/xrootd/fed_test.go
@@ -110,8 +110,9 @@ func TestHttpOriginConfig(t *testing.T) {
 	_, err = tempToken.WriteString(token)
 	assert.NoError(t, err, "Error writing to temp token file")
 
-	fedStr := config.GetFederation().DirectorEndpoint
-	fedUrl, err := url.Parse(fedStr)
+	fedInfo, err := config.GetFederation(fed.Ctx)
+	require.NoError(t, err)
+	fedUrl, err := url.Parse(fedInfo.DirectorEndpoint)
 	require.NoError(t, err)
 
 	// Download the test file

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -289,7 +289,7 @@ func CheckCacheXrootdEnv(exportPath string, server server_structs.XRootDServer, 
 			filepath.Dir(metaPath))
 	}
 
-	err = config.DiscoverFederation(context.Background())
+	fedInfo, err := config.GetFederation(context.Background())
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to pull information from the federation")
 	}
@@ -313,8 +313,8 @@ func CheckCacheXrootdEnv(exportPath string, server server_structs.XRootDServer, 
 		}
 	}
 
-	if directorUrlStr := param.Federation_DirectorUrl.GetString(); directorUrlStr != "" {
-		directorUrl, err := url.Parse(param.Federation_DirectorUrl.GetString())
+	if directorUrlStr := fedInfo.DirectorEndpoint; directorUrlStr != "" {
+		directorUrl, err := url.Parse(directorUrlStr)
 		if err == nil {
 			log.Debugln("Parsing director URL for 'pss.origin' setting:", directorUrlStr)
 			if directorUrl.Path != "" && directorUrl.Path != "/" {


### PR DESCRIPTION
This removes unintended usage of topology (due to unit tests not reseting their original state) and allows nearly every unit test run without network connectivity (exception is the S3 unit test).

One aspect of this causing the most code churn is deferring the lookup of federation metadata until it is needed.  This allows various simple client invocations to succeed (think: `pelican help` and similar -- anything where the client config is initialized but not needed) and avoiding failures in the corresponding unit tests.