### PR TITLE
Replace `jwks.cache` by TTL cache for namespace jwks at the director

### DIFF
--- a/director/director.go
+++ b/director/director.go
@@ -782,8 +782,6 @@ func getPrefixByPath(ctx *gin.Context) {
 		ctx.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Bad request. Path is empty or '/' "})
 		return
 	}
-	namespaceKeysMutex.Lock()
-	defer namespaceKeysMutex.Unlock()
 
 	originNs, _, _ := getAdsForPath(pathParam)
 

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -135,8 +135,6 @@ func ConfigTTLCache(ctx context.Context, egrp *errgroup.Group) {
 		log.Info("Gracefully stopping director TTL cache eviction...")
 		serverAdMutex.Lock()
 		defer serverAdMutex.Unlock()
-		namespaceKeysMutex.Lock()
-		defer namespaceKeysMutex.Unlock()
 		serverAds.DeleteAll()
 		serverAds.Stop()
 		namespaceKeys.DeleteAll()

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -284,8 +284,6 @@ func TestDirectorRegistration(t *testing.T) {
 		if err := ar.Register(issuerURL.String(), jwk.WithMinRefreshInterval(15*time.Minute)); err != nil {
 			t.Errorf("this should never happen, should actually be impossible, including check for the linter")
 		}
-		namespaceKeysMutex.Lock()
-		defer namespaceKeysMutex.Unlock()
 		namespaceKeys.Set("/foo/bar", &ar, ttlcache.DefaultTTL)
 	}
 

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -51,22 +51,6 @@ import (
 	"github.com/pelicanplatform/pelican/token_scopes"
 )
 
-type MockCache struct {
-	GetFn      func(u string, kset *jwk.Set) (jwk.Set, error)
-	RegisterFn func(*MockCache) error
-
-	keyset jwk.Set
-}
-
-func (m *MockCache) Get(ctx context.Context, u string) (jwk.Set, error) {
-	return m.GetFn(u, &m.keyset)
-}
-
-func (m *MockCache) Register(u string, options ...jwk.RegisterOption) error {
-	m.keyset = jwk.NewSet()
-	return m.RegisterFn(m)
-}
-
 func NamespaceAdContainsPath(ns []server_structs.NamespaceAdV2, path string) bool {
 	for _, v := range ns {
 		if v.Path == path {
@@ -148,12 +132,10 @@ func TestGetLinkDepth(t *testing.T) {
 	}
 }
 
+// Tests the RegisterOrigin endpoint. Specifically it creates a keypair and
+// corresponding token and invokes the registration endpoint, it then does
+// so again with an invalid token and confirms that the correct error is returned
 func TestDirectorRegistration(t *testing.T) {
-	/*
-	* Tests the RegisterOrigin endpoint. Specifically it creates a keypair and
-	* corresponding token and invokes the registration endpoint, it then does
-	* so again with an invalid token and confirms that the correct error is returned
-	 */
 	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
@@ -258,54 +240,39 @@ func TestDirectorRegistration(t *testing.T) {
 		c.Request.Header.Set("User-Agent", "pelican-origin/7.0.0")
 	}
 
-	// Inject into the cache, using a mock cache to avoid dealing with
-	// real namespaces
-	setupMockCache := func(t *testing.T, publicKey jwk.Key) MockCache {
-		return MockCache{
-			GetFn: func(key string, keyset *jwk.Set) (jwk.Set, error) {
-				expectedKey := ts.URL + "/api/v1.0/registry/foo/bar/.well-known/issuer.jwks"
-				if key != expectedKey {
-					t.Errorf("expecting: %q, got %q", expectedKey, key)
-				}
-				return *keyset, nil
-			},
-			RegisterFn: func(m *MockCache) error {
-				err := jwk.Set.AddKey(m.keyset, publicKey)
-				if err != nil {
-					t.Error(err)
-				}
-				return nil
-			},
-		}
-	}
-
-	// Perform injections (ar.Register will create a jwk.keyset with the publickey in it)
-	useMockCache := func(ar MockCache, issuerURL url.URL) {
-		if err := ar.Register(issuerURL.String(), jwk.WithMinRefreshInterval(15*time.Minute)); err != nil {
-			t.Errorf("this should never happen, should actually be impossible, including check for the linter")
-		}
-		namespaceKeys.Set("/foo/bar", &ar, ttlcache.DefaultTTL)
+	setupJwksCache := func(t *testing.T, ns string, key jwk.Key) {
+		jwks := jwk.NewSet()
+		err := jwks.AddKey(key)
+		require.NoError(t, err)
+		namespaceKeys.Set(ts.URL+"/api/v1.0/registry"+ns+"/.well-known/issuer.jwks", jwks, ttlcache.DefaultTTL)
 	}
 
 	teardown := func() {
 		serverAdMutex.Lock()
 		defer serverAdMutex.Unlock()
 		serverAds.DeleteAll()
+		namespaceKeys.DeleteAll()
 	}
 
 	t.Run("valid-token-V1", func(t *testing.T) {
 		c, r, w := setupContext()
-		pKey, token, issuerURL := generateToken()
+		pKey, token, _ := generateToken()
 		publicKey, err := jwk.PublicKeyOf(pKey)
 		assert.NoError(t, err, "Error creating public key from private key")
 
-		ar := setupMockCache(t, publicKey)
-		useMockCache(ar, issuerURL)
+		setupJwksCache(t, "/foo/bar", publicKey)
 
 		isurl := url.URL{}
 		isurl.Path = ts.URL
 
-		ad := server_structs.OriginAdvertiseV1{Name: "test", URL: "https://or-url.org", Namespaces: []server_structs.NamespaceAdV1{{Path: "/foo/bar", Issuer: isurl}}}
+		ad := server_structs.OriginAdvertiseV1{
+			Name: "test",
+			URL:  "https://or-url.org",
+			Namespaces: []server_structs.NamespaceAdV1{{
+				Path:   "/foo/bar",
+				Issuer: isurl,
+			}},
+		}
 
 		jsonad, err := json.Marshal(ad)
 		assert.NoError(t, err, "Error marshalling OriginAdvertise")
@@ -325,12 +292,11 @@ func TestDirectorRegistration(t *testing.T) {
 
 	t.Run("valid-token-V2", func(t *testing.T) {
 		c, r, w := setupContext()
-		pKey, token, issuerURL := generateToken()
+		pKey, token, _ := generateToken()
 		publicKey, err := jwk.PublicKeyOf(pKey)
 		assert.NoError(t, err, "Error creating public key from private key")
 
-		ar := setupMockCache(t, publicKey)
-		useMockCache(ar, issuerURL)
+		setupJwksCache(t, "/foo/bar", publicKey)
 
 		isurl := url.URL{}
 		isurl.Path = ts.URL
@@ -366,17 +332,24 @@ func TestDirectorRegistration(t *testing.T) {
 		c, r, w := setupContext()
 		wrongPrivateKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 		assert.NoError(t, err, "Error creating another private key")
-		_, token, issuerURL := generateToken()
+		_, token, _ := generateToken()
 
 		wrongPublicKey, err := jwk.PublicKeyOf(wrongPrivateKey)
 		assert.NoError(t, err, "Error creating public key from private key")
-		ar := setupMockCache(t, wrongPublicKey)
-		useMockCache(ar, issuerURL)
+		setupJwksCache(t, "/foo/bar", wrongPublicKey)
 
 		isurl := url.URL{}
 		isurl.Path = ts.URL
 
-		ad := server_structs.OriginAdvertiseV1{Name: "test", URL: "https://or-url.org", Namespaces: []server_structs.NamespaceAdV1{{Path: "/foo/bar", Issuer: isurl}}}
+		ad := server_structs.OriginAdvertiseV1{
+			Name: "test",
+			URL:  "https://or-url.org",
+			Namespaces: []server_structs.NamespaceAdV1{
+				{
+					Path:   "/foo/bar",
+					Issuer: isurl,
+				},
+			}}
 
 		jsonad, err := json.Marshal(ad)
 		assert.NoError(t, err, "Error marshalling OriginAdvertise")
@@ -398,12 +371,11 @@ func TestDirectorRegistration(t *testing.T) {
 		c, r, w := setupContext()
 		wrongPrivateKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 		assert.NoError(t, err, "Error creating another private key")
-		_, token, issuerURL := generateToken()
+		_, token, _ := generateToken()
 
 		wrongPublicKey, err := jwk.PublicKeyOf(wrongPrivateKey)
 		assert.NoError(t, err, "Error creating public key from private key")
-		ar := setupMockCache(t, wrongPublicKey)
-		useMockCache(ar, issuerURL)
+		setupJwksCache(t, "/foo/bar", wrongPublicKey)
 
 		isurl := url.URL{}
 		isurl.Path = ts.URL
@@ -431,16 +403,23 @@ func TestDirectorRegistration(t *testing.T) {
 
 	t.Run("valid-token-with-web-url-V1", func(t *testing.T) {
 		c, r, w := setupContext()
-		pKey, token, issuerURL := generateToken()
+		pKey, token, _ := generateToken()
 		publicKey, err := jwk.PublicKeyOf(pKey)
 		assert.NoError(t, err, "Error creating public key from private key")
-		ar := setupMockCache(t, publicKey)
-		useMockCache(ar, issuerURL)
+		setupJwksCache(t, "/foo/bar", publicKey)
 
 		isurl := url.URL{}
 		isurl.Path = ts.URL
 
-		ad := server_structs.OriginAdvertiseV1{URL: "https://or-url.org", WebURL: "https://localhost:8844", Namespaces: []server_structs.NamespaceAdV1{{Path: "/foo/bar", Issuer: isurl}}}
+		ad := server_structs.OriginAdvertiseV1{
+			URL:    "https://or-url.org",
+			WebURL: "https://localhost:8844",
+			Namespaces: []server_structs.NamespaceAdV1{
+				{
+					Path:   "/foo/bar",
+					Issuer: isurl,
+				},
+			}}
 
 		jsonad, err := json.Marshal(ad)
 		assert.NoError(t, err, "Error marshalling OriginAdvertise")
@@ -457,11 +436,10 @@ func TestDirectorRegistration(t *testing.T) {
 
 	t.Run("valid-token-with-web-url-V2", func(t *testing.T) {
 		c, r, w := setupContext()
-		pKey, token, issuerURL := generateToken()
+		pKey, token, _ := generateToken()
 		publicKey, err := jwk.PublicKeyOf(pKey)
 		assert.NoError(t, err, "Error creating public key from private key")
-		ar := setupMockCache(t, publicKey)
-		useMockCache(ar, issuerURL)
+		setupJwksCache(t, "/foo/bar", publicKey)
 
 		isurl := url.URL{}
 		isurl.Path = ts.URL
@@ -487,11 +465,10 @@ func TestDirectorRegistration(t *testing.T) {
 	// We want to ensure backwards compatibility for WebURL
 	t.Run("valid-token-without-web-url-V1", func(t *testing.T) {
 		c, r, w := setupContext()
-		pKey, token, issuerURL := generateToken()
+		pKey, token, _ := generateToken()
 		publicKey, err := jwk.PublicKeyOf(pKey)
 		assert.NoError(t, err, "Error creating public key from private key")
-		ar := setupMockCache(t, publicKey)
-		useMockCache(ar, issuerURL)
+		setupJwksCache(t, "/foo/bar", publicKey)
 
 		isurl := url.URL{}
 		isurl.Path = ts.URL
@@ -513,11 +490,10 @@ func TestDirectorRegistration(t *testing.T) {
 
 	t.Run("valid-token-without-web-url-V2", func(t *testing.T) {
 		c, r, w := setupContext()
-		pKey, token, issuerURL := generateToken()
+		pKey, token, _ := generateToken()
 		publicKey, err := jwk.PublicKeyOf(pKey)
 		assert.NoError(t, err, "Error creating public key from private key")
-		ar := setupMockCache(t, publicKey)
-		useMockCache(ar, issuerURL)
+		setupJwksCache(t, "/foo/bar", publicKey)
 
 		isurl := url.URL{}
 		isurl.Path = ts.URL
@@ -541,12 +517,11 @@ func TestDirectorRegistration(t *testing.T) {
 	// Determines if the broker URL set in the advertisement is the same one received on redirect
 	t.Run("broker-url-redirect", func(t *testing.T) {
 		c, r, w := setupContext()
-		pKey, token, issuerURL := generateToken()
+		pKey, token, _ := generateToken()
 		publicKey, err := jwk.PublicKeyOf(pKey)
 		assert.NoError(t, err, "Error creating public key from private key")
 
-		ar := setupMockCache(t, publicKey)
-		useMockCache(ar, issuerURL)
+		setupJwksCache(t, "/foo/bar", publicKey)
 
 		isurl := url.URL{}
 		isurl.Path = ts.URL

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -40,18 +40,14 @@ import (
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/token_scopes"
+	"github.com/pelicanplatform/pelican/utils"
 )
 
-// Create interface
-// Add it to namespacekeys in place of jwk.cache
-type NamespaceCache interface {
-	Register(u string, options ...jwk.RegisterOption) error
-	Get(ctx context.Context, u string) (jwk.Set, error)
-}
-
 var (
+	// namespaceKeys caches jwks from various origins.
+	// The cache key is jwks endpoint (e.g. https://example.com/path/to/issuer.jwks).
 	// TTL cache is thread-safe
-	namespaceKeys = ttlcache.New(ttlcache.WithTTL[string, NamespaceCache](15 * time.Minute))
+	namespaceKeys = ttlcache.New(ttlcache.WithTTL[string, jwk.Set](15 * time.Minute))
 
 	adminApprovalErr error
 )
@@ -122,14 +118,6 @@ func verifyAdvertiseToken(ctx context.Context, token, namespace string) (bool, e
 		return false, errors.Wrap(err, "failed to get JWKS URL from the issuer URL at "+issuerUrl)
 	}
 
-	var ar NamespaceCache
-
-	item := namespaceKeys.Get(namespace)
-	if item != nil {
-		if !item.IsExpired() {
-			ar = item.Value()
-		}
-	}
 	regUrlStr := param.Federation_RegistryUrl.GetString()
 	approved, err := checkNamespaceStatus(namespace, regUrlStr)
 	if err != nil {
@@ -139,25 +127,28 @@ func verifyAdvertiseToken(ctx context.Context, token, namespace string) (bool, e
 		adminApprovalErr = errors.New(namespace + " has not been approved by an administrator")
 		return false, adminApprovalErr
 	}
-	if ar == nil {
-		ar = jwk.NewCache(ctx)
-		client := &http.Client{Transport: config.GetTransport()}
-		if err = ar.Register(keyLoc, jwk.WithMinRefreshInterval(15*time.Minute), jwk.WithHTTPClient(client)); err != nil {
-			return false, errors.Wrap(err, fmt.Sprintf("failed to register JWKS URL %s at the JWKS cache", keyLoc))
+
+	log.Debugln("Attempting to fetch keys from ", keyLoc)
+	var keyset jwk.Set
+
+	item := namespaceKeys.Get(keyLoc)
+	if item != nil {
+		if !item.IsExpired() {
+			keyset = item.Value()
+		}
+	}
+
+	if keyset == nil {
+		keyset, err = utils.GetJwks(ctx, keyLoc)
+		if err != nil {
+			return false, errors.Wrapf(err, "failed to get jwks at %s", keyLoc)
 		}
 		customTTL := param.Director_AdvertisementTTL.GetDuration()
 		if customTTL == 0 {
-			namespaceKeys.Set(namespace, ar, ttlcache.DefaultTTL)
+			namespaceKeys.Set(keyLoc, keyset, ttlcache.DefaultTTL)
 		} else {
-			namespaceKeys.Set(namespace, ar, customTTL)
+			namespaceKeys.Set(keyLoc, keyset, customTTL)
 		}
-
-	}
-	log.Debugln("Attempting to fetch keys from ", keyLoc)
-	keyset, err := ar.Get(ctx, keyLoc)
-
-	if err != nil {
-		return false, errors.Wrap(err, "failed to fetch JWKS from JWKS cache for "+keyLoc)
 	}
 
 	tok, err := jwt.Parse([]byte(token), jwt.WithKeySet(keyset), jwt.WithValidate(true))

--- a/director/origin_api_test.go
+++ b/director/origin_api_test.go
@@ -102,8 +102,6 @@ func TestVerifyAdvertiseToken(t *testing.T) {
 		if err = ar.Register("", jwk.WithMinRefreshInterval(15*time.Minute)); err != nil {
 			t.Errorf("this should never happen, should actually be impossible, including check for the linter")
 		}
-		namespaceKeysMutex.Lock()
-		defer namespaceKeysMutex.Unlock()
 		namespaceKeys.Set("/test-namespace", &ar, ttlcache.DefaultTTL)
 	}()
 
@@ -175,8 +173,6 @@ func TestNamespaceKeysCacheEviction(t *testing.T) {
 		cancelChan := make(chan int)
 
 		go func() {
-			namespaceKeysMutex.Lock()
-			defer namespaceKeysMutex.Unlock()
 			namespaceKeys.DeleteAll()
 
 			namespaceKeys.Set(mockNamespaceKey, mockAr, time.Second*2)

--- a/utils/web_utils.go
+++ b/utils/web_utils.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/pkg/errors"
 
 	"github.com/pelicanplatform/pelican/config"
@@ -199,4 +200,35 @@ func HeaderParser(values string) (retMap map[string]string) {
 	}
 
 	return retMap
+}
+
+func GetJwks(ctx context.Context, location string) (jwk.Set, error) {
+	if location == "" {
+		return nil, errors.New("jwks location is empty")
+	}
+	client := http.Client{Transport: config.GetTransport()}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, location, nil)
+	if err != nil {
+		return nil, err
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	bodyByte, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("request failed with response code %d and response body: %s", res.StatusCode, string(bodyByte))
+	}
+	if len(bodyByte) == 0 {
+		return nil, fmt.Errorf("request failed with reponse returns 200 but with empty response body")
+	}
+	key, err := jwk.Parse(bodyByte)
+	if err != nil {
+		return nil, err
+	} else {
+		return key, nil
+	}
 }


### PR DESCRIPTION
Fixes #1108 

The issue #1108 describes in the production server is likely triggered with the following conditions:
* The registry server pod is down (for whatever reason), but visiting registry URLs gives 404 (probably due to traefik)
* When the director attempts to verify a token origin/cache server sent to advertise, it calls `server_utils.GetJWKSURLFromIssuerURL(issuerUrl)`. This function first attempts to request `issuerUrl` and get the `jwks` endpoint from `issuerUrl` response. The `issuerUrl` is `https://<registry>/path/to/issuer`, which returns 404. The function recognize the response 404 as a compatibility issue and thought it hit the legacy OSDF topology, so it instead construct the jwks endpoint by concatenating  `Federation.IssuerURL` with predefined path `/api/v1.0/registry/<namespace>/.well-known/issuer.jwks`
* Director then try `namespaceKeys` cache with the key `<namespace>`
* If the key returns a jwks cache item (ar), we call `ar.Get()` with the jwks endpoint (keyLoc) as the cache key for getting the jwks
* However, if the registry-returned jwks endpoint is different from director-constructed jwks endpoint, we will hit the issue where the jwks cache does not have one item or the other recorded.

The root cause is that `server_utils.GetJWKSURLFromIssuerURL` is not atomic in returning jwks endpoint given an issuer url. 

This PR fixes the issue by stripping off the layer of indirect and instead uses TTL cache for storing jwks, which prevents us from noting being able to get the jwks due to inconsistent jwks urls