### PR TITLE
Add JobId to X-Pelican-JobId header

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -88,6 +88,8 @@ var (
 )
 
 type (
+	classAd string
+
 	cacheItem struct {
 		url pelicanUrl
 		err error
@@ -293,6 +295,9 @@ type (
 
 const (
 	ewmaInterval = 15 * time.Second
+
+	projectName classAd = "ProjectName"
+	jobId       classAd = "GlobalJobId"
 )
 
 // The progress container object creates several
@@ -990,12 +995,15 @@ func (te *TransferEngine) runJobHandler() error {
 //
 // The returned object can be further customized as desired.
 // This function does not "submit" the job for execution.
-func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL, localPath string, upload bool, recursive bool, project string, options ...TransferOption) (tj *TransferJob, err error) {
+func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL, localPath string, upload bool, recursive bool, options ...TransferOption) (tj *TransferJob, err error) {
 
 	id, err := uuid.NewV7()
 	if err != nil {
 		return
 	}
+
+	// See if we have a projectName defined
+	project := searchJobAd(projectName)
 
 	pelicanURL, err := tc.engine.newPelicanURL(remoteUrl)
 	if err != nil {
@@ -1713,8 +1721,8 @@ func downloadHTTP(ctx context.Context, te *TransferEngine, callback TransferCall
 	// Set the headers
 	req.HTTPRequest.Header.Set("X-Transfer-Status", "true")
 	req.HTTPRequest.Header.Set("X-Pelican-Timeout", headerTimeout.Round(time.Millisecond).String())
-	if SearchJobAd(JobId) != "" {
-		req.HTTPRequest.Header.Set("X-Pelican-JobId", SearchJobAd(JobId))
+	if searchJobAd(jobId) != "" {
+		req.HTTPRequest.Header.Set("X-Pelican-JobId", searchJobAd(jobId))
 	}
 	req.HTTPRequest.Header.Set("TE", "trailers")
 	req.HTTPRequest.Header.Set("User-Agent", getUserAgent(project))
@@ -2065,8 +2073,8 @@ func uploadObject(transfer *transferFile) (transferResult TransferResults, err e
 	// Set the authorization header as well as other headers
 	request.Header.Set("Authorization", "Bearer "+transfer.token)
 	request.Header.Set("User-Agent", getUserAgent(transfer.project))
-	if SearchJobAd(JobId) != "" {
-		request.Header.Set("X-Pelican-JobId", SearchJobAd(JobId))
+	if searchJobAd(jobId) != "" {
+		request.Header.Set("X-Pelican-JobId", searchJobAd(jobId))
 	}
 	var lastKnownWritten int64
 	t := time.NewTicker(20 * time.Second)
@@ -2444,4 +2452,76 @@ func statHttp(ctx context.Context, dest *url.URL, namespace namespaces.Namespace
 		err = nil
 	}
 	return
+}
+
+// This function searches the condor job ad for a specific classad and returns the value of that classad
+func searchJobAd(classad classAd) string {
+
+	// Look for the condor job ad file
+	condorJobAd, isPresent := os.LookupEnv("_CONDOR_JOB_AD")
+	var filename string
+	if isPresent {
+		filename = condorJobAd
+	} else if _, err := os.Stat(".job.ad"); err == nil {
+		filename = ".job.ad"
+	} else {
+		return ""
+	}
+
+	b, err := os.ReadFile(filename)
+	if err != nil {
+		log.Warningln("Can not read .job.ad file", err)
+	}
+
+	switch classad {
+	// The regex sections of the code below come partially from:
+	// https://stackoverflow.com/questions/28574609/how-to-apply-regexp-to-content-in-file-go
+	case projectName:
+		// Get all matches from file
+		// Note: This appears to be invalid regex but is the only thing that appears to work. This way it successfully finds our matches
+		classadRegex, e := regexp.Compile(`^*\s*(ProjectName)\s=\s"*(.*)"*`)
+		if e != nil {
+			log.Fatal(e)
+		}
+
+		matches := classadRegex.FindAll(b, -1)
+		for _, match := range matches {
+			matchString := strings.TrimSpace(string(match))
+			if strings.HasPrefix(matchString, "ProjectName") {
+				matchParts := strings.Split(strings.TrimSpace(matchString), "=")
+
+				if len(matchParts) == 2 { // just confirm we get 2 parts of the string
+					matchValue := strings.TrimSpace(matchParts[1])
+					matchValue = strings.Trim(matchValue, "\"") //trim any "" around the match if present
+					return matchValue
+				}
+			}
+		}
+	case jobId:
+		// Get all matches from file
+		// Note: This appears to be invalid regex but is the only thing that appears to work. This way it successfully finds our matches
+		classadRegex, e := regexp.Compile(`^*\s*(GlobalJobId)\s=\s"*(.*)"*`)
+		if e != nil {
+			log.Fatal(e)
+		}
+
+		matches := classadRegex.FindAll(b, -1)
+		for _, match := range matches {
+			matchString := strings.TrimSpace(string(match))
+			if strings.HasPrefix(matchString, "GlobalJobId") {
+				matchParts := strings.Split(strings.TrimSpace(matchString), "=")
+
+				if len(matchParts) == 2 { // just confirm we get 2 parts of the string
+					matchValue := strings.TrimSpace(matchParts[1])
+					matchValue = strings.Trim(matchValue, "\"") //trim any "" around the match if present
+					return matchValue
+				}
+			}
+		}
+	default:
+		log.Errorln("Invalid classad requested")
+		return ""
+	}
+
+	return ""
 }

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1713,6 +1713,9 @@ func downloadHTTP(ctx context.Context, te *TransferEngine, callback TransferCall
 	// Set the headers
 	req.HTTPRequest.Header.Set("X-Transfer-Status", "true")
 	req.HTTPRequest.Header.Set("X-Pelican-Timeout", headerTimeout.Round(time.Millisecond).String())
+	if SearchJobAd(JobId) != "" {
+		req.HTTPRequest.Header.Set("X-Pelican-JobId", SearchJobAd(JobId))
+	}
 	req.HTTPRequest.Header.Set("TE", "trailers")
 	req.HTTPRequest.Header.Set("User-Agent", getUserAgent(project))
 	req = req.WithContext(ctx)
@@ -2059,9 +2062,12 @@ func uploadObject(transfer *transferFile) (transferResult TransferResults, err e
 		transferResult.Error = err
 		return transferResult, err
 	}
-	// Set the authorization header
+	// Set the authorization header as well as other headers
 	request.Header.Set("Authorization", "Bearer "+transfer.token)
 	request.Header.Set("User-Agent", getUserAgent(transfer.project))
+	if SearchJobAd(JobId) != "" {
+		request.Header.Set("X-Pelican-JobId", SearchJobAd(JobId))
+	}
 	var lastKnownWritten int64
 	t := time.NewTicker(20 * time.Second)
 	defer t.Stop()

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -511,6 +511,48 @@ func TestTimeoutHeaderSetForDownload(t *testing.T) {
 	viper.Reset()
 }
 
+func TestJobIdHeaderSetForDownload(t *testing.T) {
+	viper.Reset()
+	config.InitConfig()
+	require.NoError(t, config.InitClient())
+
+	// Create a test .job.ad file
+	jobAdFile, err := os.CreateTemp("", ".job.ad")
+	assert.NoError(t, err)
+
+	// Write the job ad to the file
+	_, err = jobAdFile.WriteString("GlobalJobId = 12345")
+	assert.NoError(t, err)
+	jobAdFile.Close()
+
+	os.Setenv("_CONDOR_JOB_AD", jobAdFile.Name())
+	ctx, _, _ := test_utils.TestContext(context.Background(), t)
+
+	// We have this flag because our server will get a few requests throughout its lifetime and the other
+	// requests do not contain the X-Pelican-Timeout header
+	timeoutHeaderFound := false
+
+	// Create a mock server to download from
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check if the "X-Pelican-Timeout" header is set
+		if !timeoutHeaderFound {
+			if r.Header.Get("X-Pelican-JobId") == "" {
+				t.Error("X-Pelican-JobId header is not set")
+			}
+			assert.Equal(t, "12345", r.Header.Get("X-Pelican-JobId"))
+			timeoutHeaderFound = true
+		}
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+	_, _, _, err = downloadHTTP(ctx, nil, nil, transferAttemptDetails{Url: serverURL, Proxy: false}, filepath.Join(t.TempDir(), "test.txt"), -1, "", "")
+	assert.NoError(t, err)
+	viper.Reset()
+	os.Unsetenv("_CONDOR_JOB_AD")
+}
+
 // Server test object for testing user agent
 type (
 	server_test struct {

--- a/client/main.go
+++ b/client/main.go
@@ -796,9 +796,10 @@ func getIPs(name string) []string {
 
 }
 
+// This function searches the condor job ad for a specific classad and returns the value of that classad
 func SearchJobAd(classad classAd) string {
-	//Parse the .job.ad file for the Owner (username) and ProjectName of the callee.
 
+	// Look for the condor job ad file
 	condorJobAd, isPresent := os.LookupEnv("_CONDOR_JOB_AD")
 	var filename string
 	if isPresent {
@@ -809,14 +810,14 @@ func SearchJobAd(classad classAd) string {
 		return ""
 	}
 
-	// https://stackoverflow.com/questions/28574609/how-to-apply-regexp-to-content-in-file-go
-
 	b, err := os.ReadFile(filename)
 	if err != nil {
 		log.Warningln("Can not read .job.ad file", err)
 	}
 
 	switch classad {
+	// The regex sections of the code below come partially from:
+	// https://stackoverflow.com/questions/28574609/how-to-apply-regexp-to-content-in-file-go
 	case ProjectName:
 		// Get all matches from file
 		// Note: This appears to be invalid regex but is the only thing that appears to work. This way it successfully finds our matches

--- a/client/main_test.go
+++ b/client/main_test.go
@@ -324,46 +324,6 @@ func TestCorrectURLWithUnderscore(t *testing.T) {
 	}
 }
 
-// Test that the project name is correctly extracted from the job ad file
-func TestSearchJobAd(t *testing.T) {
-	// Create a temporary file
-	tempFile, err := os.CreateTemp("", "test")
-	assert.NoError(t, err)
-	defer os.Remove(tempFile.Name())
-
-	// Write a project name and job id to the file
-	_, err = tempFile.WriteString("ProjectName = \"testProject\"\nGlobalJobId = 12345")
-	assert.NoError(t, err)
-	tempFile.Close()
-	t.Run("TestNoJobAd", func(t *testing.T) {
-		// Unset this environment var
-		os.Unsetenv("_CONDOR_JOB_AD")
-		// Call GetProjectName and check the result
-		projectName := SearchJobAd(ProjectName)
-		assert.Equal(t, "", projectName)
-	})
-
-	t.Run("TestProjectNameAd", func(t *testing.T) {
-		// Set the _CONDOR_JOB_AD environment variable to the temp file's name
-		os.Setenv("_CONDOR_JOB_AD", tempFile.Name())
-		defer os.Unsetenv("_CONDOR_JOB_AD")
-
-		// Call GetProjectName and check the result
-		projectName := SearchJobAd(ProjectName)
-		assert.Equal(t, "testProject", projectName)
-	})
-
-	t.Run("TestGlobalJobIdAd", func(t *testing.T) {
-		// Set the _CONDOR_JOB_AD environment variable to the temp file's name
-		os.Setenv("_CONDOR_JOB_AD", tempFile.Name())
-		defer os.Unsetenv("_CONDOR_JOB_AD")
-
-		// Call GetProjectName and check the result
-		jobId := SearchJobAd(JobId)
-		assert.Equal(t, "12345", jobId)
-	})
-}
-
 func TestSchemeUnderstood(t *testing.T) {
 	t.Run("TestProperSchemeOsdf", func(t *testing.T) {
 		scheme := "osdf"

--- a/client/main_test.go
+++ b/client/main_test.go
@@ -325,32 +325,42 @@ func TestCorrectURLWithUnderscore(t *testing.T) {
 }
 
 // Test that the project name is correctly extracted from the job ad file
-func TestGetProjectName(t *testing.T) {
+func TestSearchJobAd(t *testing.T) {
 	// Create a temporary file
 	tempFile, err := os.CreateTemp("", "test")
 	assert.NoError(t, err)
 	defer os.Remove(tempFile.Name())
 
-	// Write a project name to the file
-	_, err = tempFile.WriteString("ProjectName = \"testProject\"")
+	// Write a project name and job id to the file
+	_, err = tempFile.WriteString("ProjectName = \"testProject\"\nGlobalJobId = 12345")
 	assert.NoError(t, err)
 	tempFile.Close()
 	t.Run("TestNoJobAd", func(t *testing.T) {
 		// Unset this environment var
 		os.Unsetenv("_CONDOR_JOB_AD")
 		// Call GetProjectName and check the result
-		projectName := GetProjectName()
+		projectName := SearchJobAd(ProjectName)
 		assert.Equal(t, "", projectName)
 	})
 
-	t.Run("TestJobAd", func(t *testing.T) {
+	t.Run("TestProjectNameAd", func(t *testing.T) {
 		// Set the _CONDOR_JOB_AD environment variable to the temp file's name
 		os.Setenv("_CONDOR_JOB_AD", tempFile.Name())
 		defer os.Unsetenv("_CONDOR_JOB_AD")
 
 		// Call GetProjectName and check the result
-		projectName := GetProjectName()
+		projectName := SearchJobAd(ProjectName)
 		assert.Equal(t, "testProject", projectName)
+	})
+
+	t.Run("TestGlobalJobIdAd", func(t *testing.T) {
+		// Set the _CONDOR_JOB_AD environment variable to the temp file's name
+		os.Setenv("_CONDOR_JOB_AD", tempFile.Name())
+		defer os.Unsetenv("_CONDOR_JOB_AD")
+
+		// Call GetProjectName and check the result
+		jobId := SearchJobAd(JobId)
+		assert.Equal(t, "12345", jobId)
 	})
 }
 

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -446,7 +446,7 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 
 			var tj *client.TransferJob
 			urlCopy := *transfer.url
-			project := client.GetProjectName()
+			project := client.SearchJobAd(client.ProjectName)
 			tj, err = tc.NewTransferJob(context.Background(), &urlCopy, transfer.localFile, upload, recursive, project, client.WithAcquireToken(false), client.WithCaches(caches...))
 			if err != nil {
 				return errors.Wrap(err, "Failed to create new transfer job")

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -446,8 +446,7 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 
 			var tj *client.TransferJob
 			urlCopy := *transfer.url
-			project := client.SearchJobAd(client.ProjectName)
-			tj, err = tc.NewTransferJob(context.Background(), &urlCopy, transfer.localFile, upload, recursive, project, client.WithAcquireToken(false), client.WithCaches(caches...))
+			tj, err = tc.NewTransferJob(context.Background(), &urlCopy, transfer.localFile, upload, recursive, client.WithAcquireToken(false), client.WithCaches(caches...))
 			if err != nil {
 				return errors.Wrap(err, "Failed to create new transfer job")
 			}

--- a/local_cache/local_cache.go
+++ b/local_cache/local_cache.go
@@ -514,7 +514,7 @@ func (sc *LocalCache) runMux() error {
 			sourceURL := *sc.directorURL
 			sourceURL.Path = path.Join(sourceURL.Path, path.Clean(req.request.path))
 			sourceURL.Scheme = "pelican"
-			tj, err := sc.tc.NewTransferJob(req.ctx, &sourceURL, localPath, false, false, "localcache", client.WithToken(req.request.token))
+			tj, err := sc.tc.NewTransferJob(req.ctx, &sourceURL, localPath, false, false, client.WithToken(req.request.token))
 			if err != nil {
 				ds := &downloadStatus{}
 				ds.err.Store(&err)


### PR DESCRIPTION
For uploads and downloads we now can see an X-Pelican-JobId header that records the GlobalJobId from a condor classad. I also refactored the GetProjectName function to be just a SearchJobAd function to work with the two different classads we look for.