### PR TITLE
Allow plugin to work w/ non-url/localfile classads

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -641,12 +641,17 @@ func readMultiTransfers(stdin bufio.Reader) (transfers []PluginTransfer, err err
 		if err != nil {
 			return nil, err
 		}
+
+		if adUrlStr == nil {
+			// If we don't find a URL, we are assuming it is a classad used for other purposes
+			// so keep searching for URL
+			log.Debugln("Url attribute not set for transfer, skipping...")
+			continue
+		}
+
 		adUrl, err := url.Parse(adUrlStr.(string))
 		if err != nil {
 			return nil, err
-		}
-		if adUrl == nil {
-			return nil, errors.New("Url attribute not set for transfer")
 		}
 
 		destination, err := ad.Get("LocalFileName")
@@ -654,9 +659,15 @@ func readMultiTransfers(stdin bufio.Reader) (transfers []PluginTransfer, err err
 			return nil, err
 		}
 		if destination == nil {
-			return nil, errors.New("LocalFileName attribute not set for transfer")
+			// If we don't find a local filename, we are assuming it is a classad used for other purposes
+			// so keep searching for local filename
+			log.Debugln("LocalFileName attribute not set for transfer, skipping...")
+			continue
 		}
 		transfers = append(transfers, PluginTransfer{url: adUrl, localFile: destination.(string)})
+	}
+	if len(transfers) == 0 {
+		return nil, errors.New("No transfers found in infile")
 	}
 
 	return transfers, nil
@@ -668,10 +679,12 @@ func writeTransferErrorMessage(currentError string, transferUrl string, upload b
 	errMsg = "Pelican Client Error: "
 
 	errMsg += currentError
-	if tUrl, err := url.Parse(transferUrl); err == nil {
-		prefix = tUrl.Scheme + "://" + tUrl.Host
-		urlRemainder := strings.TrimPrefix(transferUrl, prefix)
-		errMsg = strings.ReplaceAll(errMsg, urlRemainder, "(...Path...)")
+	if transferUrl != "" {
+		if tUrl, err := url.Parse(transferUrl); err == nil {
+			prefix = tUrl.Scheme + "://" + tUrl.Host
+			urlRemainder := strings.TrimPrefix(transferUrl, prefix)
+			errMsg = strings.ReplaceAll(errMsg, urlRemainder, "(...Path...)")
+		}
 	}
 	// HTCondor will already say whether it's an upload/download in its generated string;
 	// save a few characters here


### PR DESCRIPTION
The plugin now works if it receives classads in the infile that are not the url or LocalFileName as long as the infile contains them at some point. This is useful for HTCSS devs as they will eventually pass things to the plugin through the infile and for now we don't fail when that happens. Updated unit test and fixed bug in writing the error message to check that we have a url (string) before parsing it (in cases of panic we don't pass a url).

This was a request from TJ and other HTCSS devs