### PR TITLE
Fix bug for no ns for path on uploads

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1044,6 +1044,7 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 	if err != nil {
 		log.Errorln(err)
 		err = errors.Wrapf(err, "failed to get namespace information for remote URL %s", remoteUrl.String())
+		return
 	}
 	tj.namespace = ns
 


### PR DESCRIPTION
Added a return which fixes not getting 404 no namespace found for path for uploads when trying to upload to an unregistered namespace.