### PR TITLE
Purge topology origin servers when there is a duplicated server from Pelican

### DIFF
--- a/director/advertise.go
+++ b/director/advertise.go
@@ -130,11 +130,12 @@ func AdvertiseOSDF() error {
 			Writes:      write,
 		}
 		nsAd := server_structs.NamespaceAdV2{
-			Path:       ns.Path,
-			PublicRead: !ns.UseTokenOnRead,
-			Caps:       caps,
-			Generation: []server_structs.TokenGen{tGen},
-			Issuer:     tokenIssuers,
+			Path:         ns.Path,
+			PublicRead:   !ns.UseTokenOnRead,
+			Caps:         caps,
+			Generation:   []server_structs.TokenGen{tGen},
+			Issuer:       tokenIssuers,
+			FromTopology: true,
 		}
 
 		// We assume each namespace may have multiple origins, although most likely will not
@@ -143,11 +144,13 @@ func AdvertiseOSDF() error {
 		// same useless origin ad, resulting in a 404 for queries to those namespaces
 		for _, origin := range ns.Origins {
 			originAd := parseServerAd(origin, server_structs.OriginType)
+			originAd.FromTopology = true
 			originAdMap[originAd] = append(originAdMap[originAd], nsAd)
 		}
 
 		for _, cache := range ns.Caches {
 			cacheAd := parseServerAd(cache, server_structs.CacheType)
+			cacheAd.FromTopology = true
 			cacheAdMap[cacheAd] = append(cacheAdMap[cacheAd], nsAd)
 		}
 	}

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -129,8 +129,7 @@ func matchesPrefix(reqPath string, namespaceAds []server_structs.NamespaceAdV2) 
 }
 
 func getAdsForPath(reqPath string) (originNamespace server_structs.NamespaceAdV2, originAds []server_structs.ServerAd, cacheAds []server_structs.ServerAd) {
-	serverAdMutex.RLock()
-	defer serverAdMutex.RUnlock()
+	skippedServers := []server_structs.ServerAd{}
 
 	// Clean the path, but re-append a trailing / to deal with some namespaces
 	// from topo that have a trailing /
@@ -141,36 +140,60 @@ func getAdsForPath(reqPath string) (originNamespace server_structs.NamespaceAdV2
 	// is the server ad itself (either cache or origin), and the value
 	// is a slice of namespace prefixes are supported by that server
 	var best *server_structs.NamespaceAdV2
-	for _, item := range serverAds.Items() {
-		if item == nil {
+	ads := serverAds.Keys()
+	sortedAds := sortServerAdsOnTopo(ads)
+	for _, serverAd := range sortedAds {
+		var namespaces []server_structs.NamespaceAdV2
+		if serverAds.Has(serverAd) {
+			namespaces = serverAds.Get(serverAd).Value()
+		} else {
 			continue
 		}
-		serverAd := item.Key()
 		if filtered, ft := checkFilter(serverAd.Name); filtered {
 			log.Debugf("Skipping %s server %s as it's in the filtered server list with type %s", serverAd.Type, serverAd.Name, ft)
 			continue
 		}
-		if serverAd.Type == server_structs.OriginType {
-			if ns := matchesPrefix(reqPath, item.Value()); ns != nil {
-				if best == nil || len(ns.Path) > len(best.Path) {
-					best = ns
-					// If anything was previously set by a namespace that constituted a shorter
-					// prefix, we overwrite that here because we found a better ns. We also clear
-					// the other slice of server ads, because we know those aren't good anymore
-					originAds = append(originAds[:0], serverAd)
+		if ns := matchesPrefix(reqPath, namespaces); ns != nil {
+			if best == nil || len(ns.Path) > len(best.Path) {
+				best = ns
+				// If anything was previously set by a namespace that constituted a shorter
+				// prefix, we overwrite that here because we found a better ns. We also clear
+				// the other slice of server ads, because we know those aren't good anymore
+				if serverAd.Type == server_structs.OriginType {
+					originAds = []server_structs.ServerAd{serverAd}
 					cacheAds = []server_structs.ServerAd{}
-				} else if ns.Path == best.Path {
-					originAds = append(originAds, serverAd)
-				}
-			}
-			continue
-		} else if serverAd.Type == server_structs.CacheType {
-			if ns := matchesPrefix(reqPath, item.Value()); ns != nil {
-				if best == nil || len(ns.Path) > len(best.Path) {
-					best = ns
-					cacheAds = append(cacheAds[:0], serverAd)
+				} else if serverAd.Type == server_structs.CacheType {
 					originAds = []server_structs.ServerAd{}
-				} else if ns.Path == best.Path {
+					cacheAds = []server_structs.ServerAd{serverAd}
+				}
+			} else if ns.Path == best.Path {
+				// If the current is from Pelican but the best is from topology
+				// then replace the topology best by Pelican best
+				if !ns.FromTopology && best.FromTopology {
+					best = ns
+				}
+				// We treat serverAds differently from namespace
+				if serverAd.Type == server_structs.OriginType {
+					// For origin, if there's no origin in the list yet, and there's a matched one from topology, then add it
+					// However, if the first one is from Topology but the second matched one is from Pelican, replace it (repeat this process)
+					if len(originAds) == 0 {
+						originAds = append(originAds, serverAd)
+					} else {
+						if originAds[len(originAds)-1].FromTopology == serverAd.FromTopology {
+							originAds = append(originAds, serverAd)
+						} else if !serverAd.FromTopology {
+							// Incoming ad is from Pelican and current last item in originAd is from Topology:
+							// clear originAds and put Pelican server in
+							skippedServers = append(skippedServers, originAds...)
+							originAds = []server_structs.ServerAd{serverAd}
+						} else {
+							// Incoming ad is from Topology but current last item in originAd is from Pelican: skip
+							skippedServers = append(skippedServers, serverAd)
+							continue
+						}
+					}
+				} else if serverAd.Type == server_structs.CacheType {
+					// For caches, we allow both server from Topology and Pelican to serve the same namespace
 					cacheAds = append(cacheAds, serverAd)
 				}
 			}
@@ -179,6 +202,13 @@ func getAdsForPath(reqPath string) (originNamespace server_structs.NamespaceAdV2
 
 	if best != nil {
 		originNamespace = *best
+	}
+	if len(skippedServers) > 0 {
+		log.Debugf(
+			"getAdsForPath: The following matched servers from OSDF topology are skipped for the request path %s: %s",
+			reqPath,
+			server_structs.ServerAdsToServerNameURL(skippedServers),
+		)
 	}
 	return
 }

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -89,6 +89,20 @@ func TestGetAdsForPath(t *testing.T) {
 		},
 	}
 
+	nsAdTopo1 := server_structs.NamespaceAdV2{
+		PublicRead:   true,
+		Caps:         server_structs.Capabilities{PublicReads: true},
+		Path:         "/chtc",
+		FromTopology: true,
+		Issuer: []server_structs.TokenIssuer{{
+			IssuerUrl: url.URL{
+				Scheme: "https",
+				Host:   "wisc.edu",
+			},
+		},
+		},
+	}
+
 	cacheAd1 := server_structs.ServerAd{
 		Name: "cache1",
 		URL: url.URL{
@@ -125,58 +139,77 @@ func TestGetAdsForPath(t *testing.T) {
 		Type: server_structs.OriginType,
 	}
 
+	originAdTopo1 := server_structs.ServerAd{
+		Name: "topology origin 1",
+		URL: url.URL{
+			Scheme: "https",
+			Host:   "wisc.edu",
+		},
+		Type:         server_structs.OriginType,
+		FromTopology: true,
+	}
+
 	o1Slice := []server_structs.NamespaceAdV2{nsAd1}
 	o2Slice := []server_structs.NamespaceAdV2{nsAd2, nsAd3}
 	c1Slice := []server_structs.NamespaceAdV2{nsAd1, nsAd2}
+	topoSlice := []server_structs.NamespaceAdV2{nsAdTopo1}
 	recordAd(originAd2, &o2Slice)
 	recordAd(originAd1, &o1Slice)
+	// Add a server from Topology that serves /chtc namespace
+	recordAd(originAdTopo1, &topoSlice)
 	recordAd(cacheAd1, &c1Slice)
 	recordAd(cacheAd2, &o1Slice)
 
+	// If /chtc is served both from topology and Pelican, the Topology server/namespace should be ignored
 	nsAd, oAds, cAds := getAdsForPath("/chtc")
-	assert.Equal(t, nsAd.Path, "/chtc")
-	assert.Equal(t, len(oAds), 1)
-	assert.Equal(t, len(cAds), 2)
+	assert.Equal(t, "/chtc", nsAd.Path)
+	// Make sure it's not from Topology
+	assert.False(t, nsAd.FromTopology)
+	assert.False(t, nsAd.PublicRead) // Topology one has public read turned on while Pelican one doesn't
+
+	assert.Equal(t, 1, len(oAds))
+	assert.Equal(t, 2, len(cAds))
 	assert.True(t, hasServerAdWithName(oAds, "origin1"))
 	assert.True(t, hasServerAdWithName(cAds, "cache1"))
 	assert.True(t, hasServerAdWithName(cAds, "cache2"))
+	assert.False(t, oAds[0].FromTopology)
 
 	nsAd, oAds, cAds = getAdsForPath("/chtc/")
-	assert.Equal(t, nsAd.Path, "/chtc")
-	assert.Equal(t, len(oAds), 1)
-	assert.Equal(t, len(cAds), 2)
+	assert.Equal(t, "/chtc", nsAd.Path)
+	assert.Equal(t, 1, len(oAds))
+	assert.Equal(t, 2, len(cAds))
 	assert.True(t, hasServerAdWithName(oAds, "origin1"))
 	assert.True(t, hasServerAdWithName(cAds, "cache1"))
 	assert.True(t, hasServerAdWithName(cAds, "cache2"))
 
 	nsAd, oAds, cAds = getAdsForPath("/chtc/PUBLI")
-	assert.Equal(t, nsAd.Path, "/chtc")
-	assert.Equal(t, len(oAds), 1)
-	assert.Equal(t, len(cAds), 2)
+	assert.Equal(t, "/chtc", nsAd.Path)
+	assert.Equal(t, 1, len(oAds))
+	assert.Equal(t, 2, len(cAds))
 	assert.True(t, hasServerAdWithName(oAds, "origin1"))
 	assert.True(t, hasServerAdWithName(cAds, "cache1"))
 	assert.True(t, hasServerAdWithName(cAds, "cache2"))
 
 	nsAd, oAds, cAds = getAdsForPath("/chtc/PUBLIC")
-	assert.Equal(t, nsAd.Path, "/chtc/PUBLIC")
-	assert.Equal(t, len(oAds), 1)
-	assert.Equal(t, len(cAds), 1)
+	assert.Equal(t, "/chtc/PUBLIC", nsAd.Path)
+	assert.Equal(t, 1, len(oAds))
+	assert.Equal(t, 1, len(cAds))
 	assert.True(t, hasServerAdWithName(oAds, "origin2"))
 	assert.True(t, hasServerAdWithName(cAds, "cache1"))
 
 	nsAd, oAds, cAds = getAdsForPath("/chtc/PUBLIC2")
 	// since the stored path is actually /chtc/PUBLIC2/, the extra / is returned
-	assert.Equal(t, nsAd.Path, "/chtc/PUBLIC2/")
-	assert.Equal(t, len(oAds), 1)
-	assert.Equal(t, len(cAds), 0)
+	assert.Equal(t, "/chtc/PUBLIC2/", nsAd.Path)
+	assert.Equal(t, 1, len(oAds))
+	assert.Equal(t, 0, len(cAds))
 	assert.True(t, hasServerAdWithName(oAds, "origin2"))
 
 	// Finally, let's throw in a test for a path we know shouldn't exist
 	// in the ttlcache
 	nsAd, oAds, cAds = getAdsForPath("/does/not/exist")
-	assert.Equal(t, nsAd.Path, "")
-	assert.Equal(t, len(oAds), 0)
-	assert.Equal(t, len(cAds), 0)
+	assert.Equal(t, "", nsAd.Path)
+	assert.Equal(t, 0, len(oAds))
+	assert.Equal(t, 0, len(cAds))
 
 	// Filtered server should not be included
 	filteredServersMutex.Lock()
@@ -189,10 +222,12 @@ func TestGetAdsForPath(t *testing.T) {
 		filteredServersMutex.Unlock()
 	}()
 
+	// /chtc has two servers, one is from topology the other is from Pelican
 	nsAd, oAds, cAds = getAdsForPath("/chtc")
-	assert.Equal(t, nsAd.Path, "/chtc")
-	assert.Equal(t, len(oAds), 0)
-	assert.Equal(t, len(cAds), 1)
+	assert.Equal(t, "/chtc", nsAd.Path)
+	assert.Equal(t, 1, len(cAds))
+	require.Equal(t, 1, len(oAds))
+	assert.True(t, oAds[0].FromTopology)
 	assert.False(t, hasServerAdWithName(oAds, "origin1"))
 	assert.False(t, hasServerAdWithName(cAds, "cache1"))
 	assert.True(t, hasServerAdWithName(cAds, "cache2"))

--- a/director/director.go
+++ b/director/director.go
@@ -236,9 +236,6 @@ func redirectToCache(ginCtx *gin.Context) {
 	authzBearerEscaped := getAuthzEscaped(ginCtx.Request)
 
 	namespaceAd, originAds, cacheAds := getAdsForPath(reqPath)
-	log.Error("Origin Ads: ", server_structs.ServerAdsToServerNameURL(originAds))
-	log.Error("Cache Ads: ", server_structs.ServerAdsToServerNameURL(cacheAds))
-	log.Error("NamespaceAds: ", namespaceAd)
 	// if GetAdsForPath doesn't find any ads because the prefix doesn't exist, we should
 	// report the lack of path first -- this is most important for the user because it tells them
 	// they're trying to get an object that simply doesn't exist

--- a/director/director.go
+++ b/director/director.go
@@ -236,6 +236,9 @@ func redirectToCache(ginCtx *gin.Context) {
 	authzBearerEscaped := getAuthzEscaped(ginCtx.Request)
 
 	namespaceAd, originAds, cacheAds := getAdsForPath(reqPath)
+	log.Error("Origin Ads: ", server_structs.ServerAdsToServerNameURL(originAds))
+	log.Error("Cache Ads: ", server_structs.ServerAdsToServerNameURL(cacheAds))
+	log.Error("NamespaceAds: ", namespaceAd)
 	// if GetAdsForPath doesn't find any ads because the prefix doesn't exist, we should
 	// report the lack of path first -- this is most important for the user because it tells them
 	// they're trying to get an object that simply doesn't exist
@@ -262,7 +265,7 @@ func redirectToCache(ginCtx *gin.Context) {
 			return
 		}
 	} else {
-		cacheAds, err = sortServers(ipAddr, cacheAds)
+		cacheAds, err = sortServerAdsOnIP(ipAddr, cacheAds)
 		if err != nil {
 			log.Error("Error determining server ordering for cacheAds: ", err)
 			ginCtx.String(http.StatusInternalServerError, "Failed to determine server ordering")
@@ -375,7 +378,7 @@ func redirectToOrigin(ginCtx *gin.Context) {
 		log.Errorf("Failed to get depth attribute for the redirecting request to %q, with best match namespace prefix %q", reqPath, namespaceAd.Path)
 	}
 
-	originAds, err = sortServers(ipAddr, originAds)
+	originAds, err = sortServerAdsOnIP(ipAddr, originAds)
 	if err != nil {
 		log.Error("Error determining server ordering for originAds: ", err)
 		ginCtx.String(http.StatusInternalServerError, "Failed to determine origin ordering")

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -25,8 +25,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pelicanplatform/pelican/server_structs"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -124,4 +126,38 @@ func TestCheckOverrides(t *testing.T) {
 	})
 
 	viper.Reset()
+}
+
+func TestSortServerAdsByTopo(t *testing.T) {
+	mock1 := server_structs.ServerAd{
+		FromTopology: true,
+		Name:         "alpha",
+	}
+	mock2 := server_structs.ServerAd{
+		FromTopology: true,
+		Name:         "bravo",
+	}
+	mock3 := server_structs.ServerAd{
+		FromTopology: true,
+		Name:         "charlie",
+	}
+	mock4 := server_structs.ServerAd{
+		FromTopology: false,
+		Name:         "alpha",
+	}
+	mock5 := server_structs.ServerAd{
+		FromTopology: false,
+		Name:         "bravo",
+	}
+	mock6 := server_structs.ServerAd{
+		FromTopology: false,
+		Name:         "charlie",
+	}
+
+	randomList := []server_structs.ServerAd{mock6, mock1, mock2, mock4, mock5, mock3}
+	expectedList := []server_structs.ServerAd{mock4, mock5, mock6, mock1, mock2, mock3}
+
+	sortedList := sortServerAdsOnTopo(randomList)
+
+	assert.EqualValues(t, expectedList, sortedList)
 }

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -47,11 +47,12 @@ type (
 	}
 
 	NamespaceAdV2 struct {
-		PublicRead bool
-		Caps       Capabilities  // Namespace capabilities should be considered independently of the origin’s capabilities.
-		Path       string        `json:"path"`
-		Generation []TokenGen    `json:"token-generation"`
-		Issuer     []TokenIssuer `json:"token-issuer"`
+		PublicRead   bool
+		Caps         Capabilities  // Namespace capabilities should be considered independently of the origin’s capabilities.
+		Path         string        `json:"path"`
+		Generation   []TokenGen    `json:"token-generation"`
+		Issuer       []TokenIssuer `json:"token-issuer"`
+		FromTopology bool          `json:"from-topology"`
 	}
 
 	NamespaceAdV1 struct {
@@ -66,16 +67,17 @@ type (
 	}
 
 	ServerAd struct {
-		Name        string
-		AuthURL     url.URL
-		BrokerURL   url.URL // The URL of the broker service to use for this host.
-		URL         url.URL // This is server's XRootD URL for file transfer
-		WebURL      url.URL // This is server's Web interface and API
-		Type        ServerType
-		Latitude    float64
-		Longitude   float64
-		Writes      bool
-		DirectReads bool // True if reads from the origin are permitted when no cache is available
+		Name         string     `json:"name"`
+		AuthURL      url.URL    `json:"auth_url"`
+		BrokerURL    url.URL    `json:"broker_url"` // The URL of the broker service to use for this host.
+		URL          url.URL    `json:"url"`        // This is server's XRootD URL for file transfer
+		WebURL       url.URL    `json:"web_url"`    // This is server's Web interface and API
+		Type         ServerType `json:"type"`
+		Latitude     float64    `json:"latitude"`
+		Longitude    float64    `json:"longitude"`
+		Writes       bool       `json:"enable_write"`
+		DirectReads  bool       `json:"enable_fallback_read"` // True if reads from the origin are permitted when no cache is available
+		FromTopology bool       `json:"from_topology"`
 	}
 
 	ServerType   string
@@ -120,29 +122,21 @@ const (
 	VaultStrategy StrategyType = "Vault"
 )
 
-func (ad ServerAd) MarshalJSON() ([]byte, error) {
-	baseAd := struct {
-		Name        string     `json:"name"`
-		AuthURL     string     `json:"auth_url"`
-		URL         string     `json:"url"`
-		WebURL      string     `json:"web_url"`
-		Type        ServerType `json:"type"`
-		Latitude    float64    `json:"latitude"`
-		Longitude   float64    `json:"longitude"`
-		Writes      bool       `json:"enable_write"`
-		DirectReads bool       `json:"enable_fallback_read"`
+func (ad *ServerAd) MarshalJSON() ([]byte, error) {
+	type Alias ServerAd
+	return json.Marshal(&struct {
+		AuthURL   string `json:"auth_url"`
+		BrokerURL string `json:"broker_url"`
+		URL       string `json:"url"`
+		WebURL    string `json:"web_url"`
+		*Alias
 	}{
-		Name:        ad.Name,
-		AuthURL:     ad.AuthURL.String(),
-		URL:         ad.URL.String(),
-		WebURL:      ad.WebURL.String(),
-		Type:        ad.Type,
-		Latitude:    ad.Latitude,
-		Longitude:   ad.Longitude,
-		Writes:      ad.Writes,
-		DirectReads: ad.DirectReads,
-	}
-	return json.Marshal(baseAd)
+		AuthURL:   ad.AuthURL.String(),
+		BrokerURL: ad.BrokerURL.String(),
+		URL:       ad.URL.String(),
+		WebURL:    ad.WebURL.String(),
+		Alias:     (*Alias)(ad),
+	})
 }
 
 func ConvertNamespaceAdsV2ToV1(nsV2 []NamespaceAdV2) []NamespaceAdV1 {
@@ -331,4 +325,11 @@ func ConvertOriginAdV1ToV2(oAd1 OriginAdvertiseV1) OriginAdvertiseV2 {
 		Issuer:     tokIssuers,
 	}
 	return oAd2
+}
+
+func ServerAdsToServerNameURL(ads []ServerAd) (output string) {
+	for _, ad := range ads {
+		output += ad.Name + ":" + ad.URL.String() + "\n"
+	}
+	return
 }


### PR DESCRIPTION
Closes #1104 

The core idea of this PR is as follows:
* For all `serverAd`-s and their namespaces, we store as as-is, no matter they are from Topology or Pelican. We mark the ones from Topology with a new field `FromTopology`
* When direct received an object request, it will go over the `serverAds` and when doing match-making (related code is in `getAdsForPath` in `director/cache_ads.go`:
  * if origin candidate list is empty, set the matched origin server to the list, no matter from topology or not
  * if origin list is not empty, and the LAST item and the next matched origin ad are from the same source, simple add the next matched origin to the list
  * If they are different, then
    * If the next matched one is from topology, then ignore it (meaning existing candidates are all from Pelican)
    * If the next matched one is from Pelican, then remove the existing candidates and put the Pelican one into the list
  * For cache servers, as long as they matched the namespace, set them to the cache candidate list

What this PR hasn't covered yet, is the list of namespaces and their servers the director sends to the _cache_ for generating scitokens/authfile. We should do the same check ands filter out the duplicated topology server. Not sure if I should include this aspect in this PR or make it a separate one.

This PR also make sure we stable-sort the `serverAd` first in `getAdsForPath` and always generate the stable result (the current code gives random result depending on serverAds ordering of its `Items()` which is random ordering).