### PR TITLE
Set XRDHOST env var to server's DNS name for OSDF origins

### DIFF
--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -660,6 +660,23 @@ func ConfigXrootd(ctx context.Context, origin bool) (string, error) {
 				return "", errors.New("Origin.Multiuser is set to `true` but the command was run without sufficient privilege; was it launched as root?")
 			}
 		}
+
+		// Legacy caches may attempt to reach out to the origin using the xroot protocol, which
+		// determines the origin's host via reverse DNS. Since we don't want that, we use the
+		// XRDHOST env var at the origin to override xroot's behavior. See the following issue
+		// https://github.com/PelicanPlatform/pelican/issues/1110
+		if config.GetPreferredPrefix() == config.OsdfPrefix {
+			externalWebUrl, err := url.Parse(param.Server_ExternalWebUrl.GetString())
+			if err != nil {
+				return "", errors.Wrapf(err, "Failed to parse external web URL: %s", externalWebUrl)
+			}
+
+			// Strip the port number from the URL
+			externalWebUrl.Host = externalWebUrl.Hostname()
+			if err := os.Setenv("XRDHOST", externalWebUrl.String()); err != nil {
+				return "", err
+			}
+		}
 	} else if xrdConfig.Cache.PSSOrigin != "" {
 		// Workaround for a bug in XRootD 5.6.3: if the director URL is missing a port number, then
 		// XRootD crashes.

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -241,6 +241,56 @@ func TestXrootDOriginConfig(t *testing.T) {
 		assert.NotNil(t, configPath)
 		viper.Reset()
 	})
+
+	t.Run("TestOsdfWithXRDHOSTAndPort", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
+		require.NoError(t, err, "Failed to set preferred prefix to OSDF")
+		viper.Set("Server.ExternalWebUrl", "https://my-xrootd.com:8443")
+
+		configPath, err := ConfigXrootd(ctx, true)
+		require.NoError(t, err)
+		assert.NotNil(t, configPath)
+		assert.Equal(t, "https://my-xrootd.com", os.Getenv("XRDHOST"))
+
+		viper.Reset()
+	})
+
+	t.Run("TestOsdfWithXRDHOSTAndNoPort", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
+		require.NoError(t, err, "Failed to set preferred prefix to OSDF")
+		viper.Set("Server.ExternalWebUrl", "https://my-xrootd.com")
+
+		configPath, err := ConfigXrootd(ctx, true)
+		require.NoError(t, err)
+		assert.NotNil(t, configPath)
+		assert.Equal(t, "https://my-xrootd.com", os.Getenv("XRDHOST"))
+
+		viper.Reset()
+	})
+
+	t.Run("TestPelicanWithXRDHOST", func(t *testing.T) {
+		// We don't expect XRDHOST to be set for Pelican proper
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		_, err := config.SetPreferredPrefix(config.PelicanPrefix)
+		require.NoError(t, err, "Failed to set preferred prefix to Pelican")
+		viper.Set("Server.ExternalWebUrl", "https://my-xrootd.com:8443")
+
+		configPath, err := ConfigXrootd(ctx, true)
+		require.NoError(t, err)
+		assert.NotNil(t, configPath)
+		_, xrdhostIsSet := os.LookupEnv("XRDHOST")
+		assert.False(t, xrdhostIsSet, "XRDHOST should only be set in OSDF mode")
+
+		viper.Reset()
+	})
 }
 
 func TestXrootDCacheConfig(t *testing.T) {


### PR DESCRIPTION
Legacy OSDF caches resolve origin hostnames via reverse DNS lookup, which can result in these caches finding a different hostname for origins than what would be used by Pelican caches. This sets the XRDHOST environment variable in OSDF origins to override that behavior.

Closes #1110 