### PR TITLE
Isolate bevy of tests so they don't inherit from system pelican.yaml

### DIFF
--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -555,6 +555,7 @@ func TestNewPelicanURL(t *testing.T) {
 	t.Run("TestOsdfOrStashSchemeWithOSDFPrefixNoError", func(t *testing.T) {
 		viper.Reset()
 		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
+		viper.Set("ConfigDir", t.TempDir())
 		assert.NoError(t, err)
 		// Init config to get proper timeouts
 		config.InitConfig()
@@ -583,6 +584,7 @@ func TestNewPelicanURL(t *testing.T) {
 	t.Run("TestOsdfOrStashSchemeWithOSDFPrefixWithError", func(t *testing.T) {
 		viper.Reset()
 		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
+		viper.Set("ConfigDir", t.TempDir())
 		require.NoError(t, err)
 		config.InitConfig()
 		require.NoError(t, config.InitClient())
@@ -608,7 +610,7 @@ func TestNewPelicanURL(t *testing.T) {
 
 	t.Run("TestOsdfOrStashSchemeWithPelicanPrefixNoError", func(t *testing.T) {
 		viper.Reset()
-
+		viper.Set("ConfigDir", t.TempDir())
 		config.InitConfig()
 		require.NoError(t, config.InitClient())
 		te := NewTransferEngine(ctx)
@@ -637,6 +639,7 @@ func TestNewPelicanURL(t *testing.T) {
 	t.Run("TestPelicanSchemeNoError", func(t *testing.T) {
 		viper.Reset()
 		viper.Set("TLSSkipVerify", true)
+		viper.Set("ConfigDir", t.TempDir())
 		config.InitConfig()
 		err := config.InitClient()
 		require.NoError(t, err)
@@ -689,6 +692,7 @@ func TestNewPelicanURL(t *testing.T) {
 
 	t.Run("TestPelicanSchemeWithError", func(t *testing.T) {
 		viper.Reset()
+		viper.Set("ConfigDir", t.TempDir())
 		config.InitConfig()
 
 		te := NewTransferEngine(ctx)
@@ -709,6 +713,7 @@ func TestNewPelicanURL(t *testing.T) {
 	t.Run("TestPelicanSchemeMetadataTimeoutError", func(t *testing.T) {
 		viper.Reset()
 		viper.Set("TLSSkipVerify", true)
+		viper.Set("ConfigDir", t.TempDir())
 		oldResponseHeaderTimeout := viper.Get("transport.ResponseHeaderTimeout")
 		viper.Set("transport.ResponseHeaderTimeout", 0.1*float64(time.Millisecond))
 		viper.Set("Client.WorkerCount", 5)

--- a/client/sharing_url_test.go
+++ b/client/sharing_url_test.go
@@ -63,6 +63,7 @@ func TestDirectorGeneration(t *testing.T) {
 
 	// Discovery works to get URL
 	viper.Reset()
+	viper.Set("ConfigDir", t.TempDir())
 	config.InitConfig()
 	viper.Set("TLSSkipVerify", true)
 	require.NoError(t, config.InitClient())
@@ -74,6 +75,7 @@ func TestDirectorGeneration(t *testing.T) {
 
 	// Discovery URL overrides the federation config.
 	viper.Reset()
+	viper.Set("ConfigDir", t.TempDir())
 	config.InitConfig()
 	viper.Set("TLSSkipVerify", true)
 	require.NoError(t, config.InitClient())
@@ -84,6 +86,7 @@ func TestDirectorGeneration(t *testing.T) {
 
 	// Fallback to configuration if no discovery present
 	viper.Reset()
+	viper.Set("ConfigDir", t.TempDir())
 	config.InitConfig()
 	require.NoError(t, config.InitClient())
 	viper.Set("Federation.DirectorURL", "https://location2.example.com")
@@ -94,6 +97,7 @@ func TestDirectorGeneration(t *testing.T) {
 
 	// Error if server has an error
 	viper.Reset()
+	viper.Set("ConfigDir", t.TempDir())
 	config.InitConfig()
 	viper.Set("TLSSkipVerify", true)
 	require.NoError(t, config.InitClient())
@@ -104,6 +108,7 @@ func TestDirectorGeneration(t *testing.T) {
 
 	// Error if neither config nor hostname provided.
 	viper.Reset()
+	viper.Set("ConfigDir", t.TempDir())
 	config.InitConfig()
 	require.NoError(t, config.InitClient())
 	objectUrl.Host = ""
@@ -112,6 +117,7 @@ func TestDirectorGeneration(t *testing.T) {
 
 	// Error on unknown scheme
 	viper.Reset()
+	viper.Set("ConfigDir", t.TempDir())
 	config.InitConfig()
 	require.NoError(t, config.InitClient())
 	objectUrl.Scheme = "buzzard"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -375,6 +375,7 @@ func TestDiscoverFederation(t *testing.T) {
 
 	t.Run("testInvalidDiscoveryUrlWithPath", func(t *testing.T) {
 		viper.Reset()
+		viper.Set("ConfigDir", t.TempDir())
 		viper.Set("Federation.DiscoveryURL", server.URL+"/this/is/some/path")
 		InitConfig()
 		require.NoError(t, InitClient())
@@ -387,6 +388,7 @@ func TestDiscoverFederation(t *testing.T) {
 
 	t.Run("testValidDiscoveryUrl", func(t *testing.T) {
 		viper.Reset()
+		viper.Set("ConfigDir", t.TempDir())
 		InitConfig()
 		require.NoError(t, InitClient())
 		transport := GetTransport()
@@ -404,6 +406,7 @@ func TestDiscoverFederation(t *testing.T) {
 
 	t.Run("testOsgHtcUrl", func(t *testing.T) {
 		viper.Reset()
+		viper.Set("ConfigDir", t.TempDir())
 		InitConfig()
 		require.NoError(t, InitClient())
 		mock.MockOSDFDiscovery(t, GetTransport())

--- a/xrootd/fed_test.go
+++ b/xrootd/fed_test.go
@@ -49,6 +49,7 @@ var (
 
 func TestHttpOriginConfig(t *testing.T) {
 	viper.Reset()
+	viper.Set("ConfigDir", t.TempDir())
 	server_utils.ResetOriginExports()
 	defer viper.Reset()
 	defer server_utils.ResetOriginExports()


### PR DESCRIPTION
It has been frustrating me for a long time that a number of our unit tests were picking up values in my `pelican.yaml`, which was causing failures. Unit tests should really never look at the system pelican config, because the presumption is that each test is setting up its own configuration.

That being said, since the config directory is configured with viper, I couldn't immediately come up with a good way to uniformly enforce this across tests, or even with tests that toggle `viper.Reset()` between small test runs. For now, it's on us developers to remember that isolating our tests is a good practice.

Finally, there may be tests I missed. I found the tests covered in this PR by running `go test ./...` from the repo's root with an entire test federation configured in `/etc/pelican/pelican.yaml`. These were the tests that failed because of my system config.

Closees #712 