### PR TITLE
Don't include scheme when setting XRDHOST for osdf origins

### DIFF
--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -671,7 +671,7 @@ func ConfigXrootd(ctx context.Context, origin bool) (string, error) {
 				return "", errors.Wrapf(err, "Failed to parse external web URL: %s", externalWebUrl)
 			}
 
-			// Strip the port number from the URL and set to XRDHOST
+			// Strip the scheme and port number from the URL and use to set XRDHOST
 			if err := os.Setenv("XRDHOST", externalWebUrl.Hostname()); err != nil {
 				return "", err
 			}

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -671,9 +671,8 @@ func ConfigXrootd(ctx context.Context, origin bool) (string, error) {
 				return "", errors.Wrapf(err, "Failed to parse external web URL: %s", externalWebUrl)
 			}
 
-			// Strip the port number from the URL
-			externalWebUrl.Host = externalWebUrl.Hostname()
-			if err := os.Setenv("XRDHOST", externalWebUrl.String()); err != nil {
+			// Strip the port number from the URL and set to XRDHOST
+			if err := os.Setenv("XRDHOST", externalWebUrl.Hostname()); err != nil {
 				return "", err
 			}
 		}

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -254,7 +254,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		configPath, err := ConfigXrootd(ctx, true)
 		require.NoError(t, err)
 		assert.NotNil(t, configPath)
-		assert.Equal(t, "https://my-xrootd.com", os.Getenv("XRDHOST"))
+		assert.Equal(t, "my-xrootd.com", os.Getenv("XRDHOST"))
 
 		viper.Reset()
 	})
@@ -271,7 +271,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		configPath, err := ConfigXrootd(ctx, true)
 		require.NoError(t, err)
 		assert.NotNil(t, configPath)
-		assert.Equal(t, "https://my-xrootd.com", os.Getenv("XRDHOST"))
+		assert.Equal(t, "my-xrootd.com", os.Getenv("XRDHOST"))
 
 		viper.Reset()
 	})


### PR DESCRIPTION
PR #1143 had a mistake in that it set a scheme for the XRDHOST env var. This PR removes the scheme and updates the tests to check the correct thing.