### PR TITLE
Plugin recursive download errors returned properly

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -944,10 +944,6 @@ func (te *TransferEngine) runMux() error {
 			// If no transfers were created and we have an error, the job is no
 			// longer active
 			if job.job.lookupErr != nil && job.job.totalXfer == 0 {
-				// Make sure we update results of this error
-				log.Errorln(job.job.lookupErr)
-				results := &TransferResults{jobId: job.job.uuid, job: job.job, Error: job.job.lookupErr, Scheme: job.job.remoteURL.Scheme}
-				te.resultsMap[job.uuid] <- results
 				// Remove this job from the list of active jobs for the client.
 				activeJobs[job.uuid] = slices.DeleteFunc(activeJobs[job.uuid], func(oldJob *TransferJob) bool {
 					return oldJob.uuid == job.job.uuid

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -367,6 +367,8 @@ func TestPluginMulti(t *testing.T) {
 // Test multiple downloads from the plugin
 func TestPluginDirectRead(t *testing.T) {
 	viper.Reset()
+	defer viper.Reset()
+	defer server_utils.ResetOriginExports()
 	server_utils.ResetOriginExports()
 
 	dirName := t.TempDir()

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -569,6 +569,178 @@ func TestFailTransfer(t *testing.T) {
 	})
 }
 
+// Test recursive downloads from the plugin
+func TestPluginRecursiveDownload(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+	defer server_utils.ResetOriginExports()
+	server_utils.ResetOriginExports()
+
+	dirName := t.TempDir()
+
+	viper.Set("Logging.Level", "debug")
+	viper.Set("Origin.StorageType", "posix")
+	viper.Set("Origin.FederationPrefix", "/test")
+	viper.Set("Origin.StoragePrefix", "/<THIS WILL BE OVERRIDDEN>")
+	viper.Set("Origin.EnablePublicReads", true)
+	fed := fed_test_utils.NewFedTest(t, "")
+	host := param.Server_Hostname.GetString() + ":" + strconv.Itoa(param.Server_WebPort.GetInt())
+
+	// Drop the testFileContent into the origin directory
+	destDir := filepath.Join(fed.Exports[0].StoragePrefix, "test")
+	require.NoError(t, os.MkdirAll(destDir, os.FileMode(0755)))
+	log.Debugln("Will create origin file at", destDir)
+	err := os.WriteFile(filepath.Join(destDir, "test.txt"), []byte("test file content"), fs.FileMode(0644))
+	require.NoError(t, err)
+	downloadUrl1 := url.URL{
+		Scheme:   "pelican",
+		Host:     host,
+		Path:     "/test/test",
+		RawQuery: "recursive=true",
+	}
+	localPath1 := filepath.Join(dirName, "test.txt")
+	err = os.WriteFile(filepath.Join(destDir, "test2.txt"), []byte("second test file content"), fs.FileMode(0644))
+	require.NoError(t, err)
+
+	// Test recursive download succeeds
+	t.Run("TestRecursiveSuccess", func(t *testing.T) {
+		workChan := make(chan PluginTransfer, 1)
+		workChan <- PluginTransfer{url: &downloadUrl1, localFile: localPath1}
+		//workChan <- PluginTransfer{url: &downloadUrl2, localFile: localPath2}
+		close(workChan)
+
+		results := make(chan *classads.ClassAd, 5)
+		fed.Egrp.Go(func() error {
+			return runPluginWorker(fed.Ctx, false, workChan, results)
+		})
+
+		resultAds := []*classads.ClassAd{}
+		done := false
+		for !done {
+			select {
+			case <-fed.Ctx.Done():
+				break
+			case resultAd, ok := <-results:
+				if !ok {
+					done = true
+					break
+				}
+				// Process results as soon as we get them
+				transferSuccess, err := resultAd.Get("TransferSuccess")
+				assert.NoError(t, err)
+				boolVal, ok := transferSuccess.(bool)
+				require.True(t, ok)
+				assert.True(t, boolVal)
+				resultAds = append(resultAds, resultAd)
+			}
+		}
+		// Check we get 2 result ads back (each file has been downloaded)
+		assert.Equal(t, 2, len(resultAds))
+	})
+
+	// Check to make sure the plugin properly fails when setting recursive=true on a file
+	// instead of a directory
+	t.Run("TestRecursiveFailureOnRecursiveSetForFile", func(t *testing.T) {
+		// Change the downloadUrl to be a path to a file instead of a directory
+		downloadUrl1 := url.URL{
+			Scheme:   "pelican",
+			Host:     host,
+			Path:     "/test/test/test.txt",
+			RawQuery: "recursive=true",
+		}
+
+		workChan := make(chan PluginTransfer, 1)
+		workChan <- PluginTransfer{url: &downloadUrl1, localFile: localPath1}
+		close(workChan)
+
+		results := make(chan *classads.ClassAd, 5)
+		fed.Egrp.Go(func() error {
+			return runPluginWorker(fed.Ctx, false, workChan, results)
+		})
+
+		resultAds := []*classads.ClassAd{}
+		done := false
+		for !done {
+			select {
+			case <-fed.Ctx.Done():
+				break
+			case resultAd, ok := <-results:
+				if !ok {
+					done = true
+					break
+				}
+				// Process results as soon as we get them
+				transferSuccess, err := resultAd.Get("TransferSuccess")
+				assert.NoError(t, err)
+				boolVal, ok := transferSuccess.(bool)
+				require.True(t, ok)
+				assert.False(t, boolVal)
+				resultAds = append(resultAds, resultAd)
+
+				// Check our error message is returned and correct
+				transferError, err := resultAd.Get("TransferError")
+				assert.NoError(t, err)
+				strVal, ok := transferError.(string)
+				require.True(t, ok)
+				assert.Contains(t, strVal, "Pelican Client Error: failed to read remote directory: PROPFIND /test/test/test.txt/: 500")
+			}
+		}
+		// Check we get 1 result ad back (we should fail after first file)
+		assert.Equal(t, 1, len(resultAds))
+
+	})
+
+	t.Run("TestRecursiveFailureDirNotFound", func(t *testing.T) {
+		// Change the downloadUrl to be a path to a file instead of a directory
+		downloadUrl1 := url.URL{
+			Scheme:   "pelican",
+			Host:     host,
+			Path:     "/test/SomeDirectoryThatDoesNotExist:)",
+			RawQuery: "recursive=true",
+		}
+
+		workChan := make(chan PluginTransfer, 1)
+		workChan <- PluginTransfer{url: &downloadUrl1, localFile: localPath1}
+		close(workChan)
+
+		results := make(chan *classads.ClassAd, 5)
+		fed.Egrp.Go(func() error {
+			return runPluginWorker(fed.Ctx, false, workChan, results)
+		})
+
+		resultAds := []*classads.ClassAd{}
+		done := false
+		for !done {
+			select {
+			case <-fed.Ctx.Done():
+				break
+			case resultAd, ok := <-results:
+				if !ok {
+					done = true
+					break
+				}
+				// Process results as soon as we get them
+				transferSuccess, err := resultAd.Get("TransferSuccess")
+				assert.NoError(t, err)
+				boolVal, ok := transferSuccess.(bool)
+				require.True(t, ok)
+				assert.False(t, boolVal)
+				resultAds = append(resultAds, resultAd)
+
+				// Check our error message is returned and correct
+				transferError, err := resultAd.Get("TransferError")
+				assert.NoError(t, err)
+				strVal, ok := transferError.(string)
+				require.True(t, ok)
+				assert.Contains(t, strVal, "failed to read remote directory: PROPFIND /test/SomeDirectoryThatDoesNotExist:)/: 404")
+			}
+		}
+		// Check we get 1 result ad back (we should fail after first file)
+		assert.Equal(t, 1, len(resultAds))
+
+	})
+}
+
 func TestWriteOutfile(t *testing.T) {
 	t.Run("TestOutfileSuccess", func(t *testing.T) {
 		// Drop the testFileContent into the origin directory


### PR DESCRIPTION
There was a bug with the plugin when doing recursive downloads. If some error happened such as a 404 on the directory we are requesting or a 500 which is doing the ?recursive query on a file instead of a directory, PROPFIND would fail and the error was not making it back to the plugin. Now, when we discover this error (eventually makes its way to RunMux() in client/handle_http.go) we populate the results channel with the failed result before closing it. This way, the plugin can see the results and record the failure.

In addition, I added some unit tests toward these failures as well as for recusive downloads for plugin in general.


To test: run `stash_plugin pelican://path/to/some/file?recursive=true .` and see that we get classads returned that record a TranferError as well as other classads. Feel free to run the unit tests as well as any other hand tests that you feel might break this.