### PR TITLE
Fix wrong information in config OAuth for the registry

### DIFF
--- a/docs/pages/serving_a_federation.mdx
+++ b/docs/pages/serving_a_federation.mdx
@@ -94,17 +94,17 @@ The homepage of the registry web UI is also publicly accessible, meaning users c
 
 There are a couple of configuration parameters you could use to customize the behavior of your registry. Here we highlight the ones that are most frequently set for an admin. You may refer to the full set of registry parameters in the [Parameters page](./parameters.mdx#Registry-DbLocation).
 
-#### `Registry.AdminUsers` [Deprecated]
+#### `Server.UIAdminUsers`
 
-> `Registry.AdminUsers` is deprecated in Pelican `v7.7.0`. Use `OIDC.AdminUsers` instead.
+> `Registry.AdminUsers` is deprecated in Pelican `v7.7.0`. Use `Server.UIAdminUsers` instead.
 
 By default, Pelican registry only has one user with admin privilege, which is whoever starts the registry service and initializes the web UI with the admin password.
 
 However, Pelican also allows you to pass a list of CILogon user identities and grant them the admin privilege. This requires you have your CILogon `client_id` and `client_secret` set up. The user identity of each admin user can be found on their https://cilogon.org/ user page, under "User Attributes", `CILogon User Identifier`, which looks something like `http://cilogon.org/serverA/users/123456`. Once you have the identifiers, simply pass them as an array to `Registry.AdminUsers`:
 
 ```yaml
-Registry:
-  AdminUsers: ["http://cilogon.org/serverA/users/123456"]
+Server:
+  UIAdminUsers: ["http://cilogon.org/serverA/users/123456"]
 ```
 
 


### PR DESCRIPTION
The configuration parameter `Registry.AdminUsers` was deprecated and replaced by `Server.UIAdminUser`, but the documentation records the wrong updated param name.