### PR TITLE
Improve site name handling

### DIFF
--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -95,14 +95,14 @@ func Setup(t *testing.T, ctx context.Context, egrp *errgroup.Group) {
 	keysetBytes, err := json.Marshal(keyset)
 	require.NoError(t, err)
 
-	err = registry.AddNamespace(&registry.Namespace{
+	err = registry.AddNamespace(&server_structs.Namespace{
 		ID:       1,
 		Prefix:   "/caches/" + param.Server_Hostname.GetString(),
 		Pubkey:   string(keysetBytes),
 		Identity: "test_data",
 	})
 	require.NoError(t, err)
-	err = registry.AddNamespace(&registry.Namespace{
+	err = registry.AddNamespace(&server_structs.Namespace{
 		ID:       2,
 		Prefix:   "/foo",
 		Pubkey:   string(keysetBytes),

--- a/config/config.go
+++ b/config/config.go
@@ -590,6 +590,12 @@ func discoverFederationImpl(ctx context.Context) (fedInfo FederationDiscovery, e
 	return
 }
 
+// Reset the fedDiscoveryOnce to update federation metadata values for GetFederation().
+// Should only used for unit tests
+func ResetFederationForTest() {
+	fedDiscoveryOnce = &sync.Once{}
+}
+
 // Retrieve the federation service information from the configuration.
 //
 // The calculation of the federation info is delayed until needed.  As

--- a/director/director.go
+++ b/director/director.go
@@ -566,12 +566,12 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 	ctx.Set("serverName", adV2.Name)
 	ctx.Set("serverWebUrl", adV2.WebURL)
 
-	ad_url, err := url.Parse(adV2.DataURL)
+	adUrl, err := url.Parse(adV2.DataURL)
 	if err != nil {
 		log.Warningf("Failed to parse %s URL %v: %v\n", sType, adV2.DataURL, err)
 		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("Invalid %s registration", sType),
+			Msg:    fmt.Sprintf("Invalid %s registration. DataURL %s is not a valid URL", sType, adV2.DataURL),
 		})
 		return
 	}
@@ -581,7 +581,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 		log.Warningf("Failed to parse server Web URL %v: %v\n", adV2.WebURL, err)
 		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
-			Msg:    "Invalid server Web URL",
+			Msg:    fmt.Sprintf("Invalid %s registration. WebURL %s is not a valid URL", sType, adV2.WebURL),
 		})
 		return
 	}
@@ -591,7 +591,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 		log.Warningf("Failed to parse broker URL %s: %s", adV2.BrokerURL, err)
 		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
-			Msg:    "Invalid broker URL",
+			Msg:    fmt.Sprintf("Invalid %s registration. BrokerURL %s is not a valid URL", sType, adV2.BrokerURL),
 		})
 	}
 
@@ -627,7 +627,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 	} else {
 		token := strings.TrimPrefix(tokens[0], "Bearer ")
 		// Use hostname from adv2.DataUrl instead of adv2.Name as Name is the site name
-		hostname := ad_url.Hostname()
+		hostname := adUrl.Hostname()
 
 		prefix := path.Join("/caches", hostname)
 		ok, err := verifyAdvertiseToken(engineCtx, token, prefix)
@@ -657,7 +657,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 
 	sAd := server_structs.ServerAd{
 		Name:        adV2.Name,
-		URL:         *ad_url,
+		URL:         *adUrl,
 		WebURL:      *adWebUrl,
 		BrokerURL:   *brokerUrl,
 		Type:        sType,

--- a/director/director.go
+++ b/director/director.go
@@ -571,7 +571,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 		log.Warningf("Failed to parse %s URL %v: %v\n", sType, adV2.DataURL, err)
 		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("Invalid %s registration. DataURL %s is not a valid URL", sType, adV2.DataURL),
+			Msg:    fmt.Sprintf("Invalid %s registration. %s.URL %s is not a valid URL", sType, sType, adV2.DataURL), // Origin.URL / Cache.URL
 		})
 		return
 	}
@@ -581,7 +581,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 		log.Warningf("Failed to parse server Web URL %v: %v\n", adV2.WebURL, err)
 		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("Invalid %s registration. WebURL %s is not a valid URL", sType, adV2.WebURL),
+			Msg:    fmt.Sprintf("Invalid %s registration. Server.ExternalWebUrl %s is not a valid URL", sType, adV2.WebURL),
 		})
 		return
 	}

--- a/launcher_utils/advertise.go
+++ b/launcher_utils/advertise.go
@@ -111,6 +111,10 @@ func getSitenameFromReg(ctx context.Context, prefix string) (sitename string, er
 	if err != nil {
 		return
 	}
+	if fed.NamespaceRegistrationEndpoint == "" {
+		err = fmt.Errorf("unable to fetch site name from the registry. Federation.RegistryUrl is unset")
+		return
+	}
 	requestUrl, err := url.JoinPath(fed.NamespaceRegistrationEndpoint, "api/v1.0/registry", prefix)
 	if err != nil {
 		return
@@ -131,13 +135,13 @@ func getSitenameFromReg(ctx context.Context, prefix string) (sitename string, er
 func advertiseInternal(ctx context.Context, server server_structs.XRootDServer) error {
 	name := ""
 	var err error
-	// Fetch site name from the registy, if not, fall back to Xrootd.Sitename.
+	// Fetch site name from the registry, if not, fall back to Xrootd.Sitename.
 	// However, currently the registry only supports registering namespaces, not origins.
 	// If multiple namespaces fall under the same origin, we will use the first namespace to fetch the site name
 	if server.GetServerType().IsEnabled(config.OriginType) {
 		originExports, err := server_utils.GetOriginExports()
 		if err != nil {
-			log.Errorf("Failed to get request sitename from the registery. Failed to get exports from the origin server. Will fallback to use Xrootd.Sitename: %v", err)
+			log.Errorf("Failed to get request sitename from the registry. Failed to get exports from the origin server. Will fall back to use Xrootd.Sitename: %v", err)
 		}
 		if len(originExports) != 0 {
 			if len(originExports) > 1 {

--- a/launcher_utils/advertise.go
+++ b/launcher_utils/advertise.go
@@ -41,8 +41,10 @@ import (
 	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
+	"github.com/pelicanplatform/pelican/utils"
 )
 
 type directorResponse struct {
@@ -103,14 +105,73 @@ func Advertise(ctx context.Context, servers []server_structs.XRootDServer) error
 	return firstErr
 }
 
+// Get the site name from the registry given a namespace prefix
+func getSitenameFromReg(ctx context.Context, prefix string) (sitename string, err error) {
+	fed, err := config.GetFederation(ctx)
+	if err != nil {
+		return
+	}
+	requestUrl, err := url.JoinPath(fed.NamespaceRegistrationEndpoint, "api/v1.0/registry", prefix)
+	if err != nil {
+		return
+	}
+	res, err := utils.MakeRequest(context.Background(), requestUrl, http.MethodGet, nil, nil)
+	if err != nil {
+		return
+	}
+	ns := server_structs.Namespace{}
+	err = json.Unmarshal(res, &ns)
+	if err != nil {
+		return
+	}
+	sitename = ns.AdminMetadata.SiteName
+	return
+}
+
 func advertiseInternal(ctx context.Context, server server_structs.XRootDServer) error {
-	name := param.Xrootd_Sitename.GetString()
+	name := ""
+	var err error
+	// Fetch site name from the registy, if not, fall back to Xrootd.Sitename.
+	// However, currently the registry only supports registering namespaces, not origins.
+	// If multiple namespaces fall under the same origin, we will use the first namespace to fetch the site name
+	if server.GetServerType().IsEnabled(config.OriginType) {
+		originExports, err := server_utils.GetOriginExports()
+		if err != nil {
+			log.Errorf("Failed to get request sitename from the registery. Failed to get exports from the origin server. Will fallback to use Xrootd.Sitename: %v", err)
+		}
+		if len(originExports) != 0 {
+			if len(originExports) > 1 {
+				log.Warningf("The origin has multiple exports. The sitename will be fetched from the registry using the FederationPrefix of the first export: %s.", originExports[0].FederationPrefix)
+			}
+			prefix := originExports[0].FederationPrefix
+			name, err = getSitenameFromReg(ctx, prefix)
+			if err != nil {
+				log.Errorf("Failed to get sitename from the registry. Will fallback to use Xrootd.Sitename: %v", err)
+			}
+		} else {
+			log.Errorf("Failed to get sitename from the registry. The namespace is empty for the %s server. Will fallback to use Xrootd.Sitename", server.GetServerType().String())
+		}
+	}
+	// For caches, it's trickier because director uases the server name to fetch jwks from the registry
+	// If the server name is different from what cache used to register at the registry (hostname)
+	// Director advertisement will fail
+	// } else if server.GetServerType().IsEnabled(config.CacheType) {
+	// 	cachePrefix := "/caches/" + param.Xrootd_Sitename.GetString()
+	// 	name, err = getSitenameFromReg(ctx, cachePrefix)
+	// 	if err != nil {
+	// 		log.Errorf("Failed to get sitename from the registry for the cache. Will fallback to use Xrootd.Sitename: %v", err)
+	// 	}
+	// }
+
 	if name == "" {
-		return errors.New(fmt.Sprintf("%s name isn't set", server.GetServerType()))
+		log.Infof("Sitename from the registry is empty, fall back to Xrootd.Sitename: %s", param.Xrootd_Sitename.GetString())
+		name = param.Xrootd_Sitename.GetString()
+	}
+	if name == "" {
+		return errors.New(fmt.Sprintf("%s name isn't set. Please set the name via Xrootd.Sitename", server.GetServerType()))
 	}
 
-	err := server.GetNamespaceAdsFromDirector()
-	if err != nil {
+	if err = server.GetNamespaceAdsFromDirector(); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("%s failed to get namespaceAds from the director", server.GetServerType()))
 	}
 	serverUrl := param.Origin_Url.GetString()

--- a/launcher_utils/advertise.go
+++ b/launcher_utils/advertise.go
@@ -16,7 +16,7 @@
  *
  ***************************************************************/
 
-// Package launcher_utils contains utility functions for the [github.com/pelicanplatform/pelican/launcher_utils] package.
+// Package launcher_utils contains utility functions for the [github.com/pelicanplatform/pelican/launcher] package.
 //
 // It should only be imported by the launchers package
 // It should NOT be imported to any server pacakges (origin/cache/registry) or other lower level packages (config/utils/etc)
@@ -112,7 +112,7 @@ func getSitenameFromReg(ctx context.Context, prefix string) (sitename string, er
 		return
 	}
 	if fed.NamespaceRegistrationEndpoint == "" {
-		err = fmt.Errorf("unable to fetch site name from the registry. Federation.RegistryUrl is unset")
+		err = fmt.Errorf("unable to fetch site name from the registry. Federation.RegistryUrl or Federation.DiscoveryUrl is unset")
 		return
 	}
 	requestUrl, err := url.JoinPath(fed.NamespaceRegistrationEndpoint, "api/v1.0/registry", prefix)

--- a/launcher_utils/advertise.go
+++ b/launcher_utils/advertise.go
@@ -155,17 +155,13 @@ func advertiseInternal(ctx context.Context, server server_structs.XRootDServer) 
 		} else {
 			log.Errorf("Failed to get sitename from the registry. The namespace is empty for the %s server. Will fallback to use Xrootd.Sitename", server.GetServerType().String())
 		}
+	} else if server.GetServerType().IsEnabled(config.CacheType) {
+		cachePrefix := "/caches/" + param.Xrootd_Sitename.GetString()
+		name, err = getSitenameFromReg(ctx, cachePrefix)
+		if err != nil {
+			log.Errorf("Failed to get sitename from the registry for the cache. Will fallback to use Xrootd.Sitename: %v", err)
+		}
 	}
-	// For caches, it's trickier because director uases the server name to fetch jwks from the registry
-	// If the server name is different from what cache used to register at the registry (hostname)
-	// Director advertisement will fail
-	// } else if server.GetServerType().IsEnabled(config.CacheType) {
-	// 	cachePrefix := "/caches/" + param.Xrootd_Sitename.GetString()
-	// 	name, err = getSitenameFromReg(ctx, cachePrefix)
-	// 	if err != nil {
-	// 		log.Errorf("Failed to get sitename from the registry for the cache. Will fallback to use Xrootd.Sitename: %v", err)
-	// 	}
-	// }
 
 	if name == "" {
 		log.Infof("Sitename from the registry is empty, fall back to Xrootd.Sitename: %s", param.Xrootd_Sitename.GetString())

--- a/launcher_utils/advertise_test.go
+++ b/launcher_utils/advertise_test.go
@@ -1,0 +1,82 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package launcher_utils
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSitenameFromReg(t *testing.T) {
+	t.Run("no-registry-url", func(t *testing.T) {
+		viper.Reset()
+		config.ResetFederationForTest()
+		config.SetFederation(config.FederationDiscovery{})
+		sitename, err := getSitenameFromReg(context.Background(), "/foo")
+		require.Error(t, err)
+		assert.Equal(t, "unable to fetch site name from the registry. Federation.RegistryUrl is unset", err.Error())
+		assert.Empty(t, sitename)
+	})
+
+	t.Run("registry-returns-404", func(t *testing.T) {
+		viper.Reset()
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer ts.Close()
+		config.ResetFederationForTest()
+		config.SetFederation(config.FederationDiscovery{NamespaceRegistrationEndpoint: ts.URL})
+		sitename, err := getSitenameFromReg(context.Background(), "/foo")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "replied with status code 404")
+		assert.Empty(t, sitename)
+	})
+
+	t.Run("registry-returns-correct-object", func(t *testing.T) {
+		viper.Reset()
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if strings.HasPrefix(req.URL.Path, "/api/v1.0/registry") {
+				prefix := strings.TrimPrefix(req.URL.Path, "/api/v1.0/registry")
+				ns := server_structs.Namespace{Prefix: prefix, ID: 1, AdminMetadata: server_structs.AdminMetadata{SiteName: "bar"}}
+				bytes, err := json.Marshal(ns)
+				require.NoError(t, err)
+				_, err = w.Write(bytes)
+				require.NoError(t, err)
+			} else {
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer ts.Close()
+		config.ResetFederationForTest()
+		config.SetFederation(config.FederationDiscovery{NamespaceRegistrationEndpoint: ts.URL})
+		sitename, err := getSitenameFromReg(context.Background(), "/foo")
+		require.NoError(t, err)
+		assert.Equal(t, "bar", sitename)
+	})
+}

--- a/launcher_utils/advertise_test.go
+++ b/launcher_utils/advertise_test.go
@@ -26,21 +26,25 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pelicanplatform/pelican/config"
-	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/server_structs"
 )
 
 func TestGetSitenameFromReg(t *testing.T) {
-	t.Run("no-registry-url", func(t *testing.T) {
+	t.Cleanup(func() {
 		viper.Reset()
+	})
+
+	t.Run("no-registry-url", func(t *testing.T) {
 		config.ResetFederationForTest()
 		config.SetFederation(config.FederationDiscovery{})
 		sitename, err := getSitenameFromReg(context.Background(), "/foo")
 		require.Error(t, err)
-		assert.Equal(t, "unable to fetch site name from the registry. Federation.RegistryUrl is unset", err.Error())
+		assert.Equal(t, "unable to fetch site name from the registry. Federation.RegistryUrl or Federation.DiscoveryUrl is unset", err.Error())
 		assert.Empty(t, sitename)
 	})
 

--- a/launcher_utils/register_namespace.go
+++ b/launcher_utils/register_namespace.go
@@ -28,15 +28,16 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/registry"
 	"github.com/pelicanplatform/pelican/server_structs"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
 )
 
 type (
@@ -173,7 +174,7 @@ func keyIsRegistered(privkey jwk.Key, registryUrlStr string, prefix string) (key
 		}
 	}
 
-	var ns *registry.Namespace
+	var ns *server_structs.Namespace
 	err = json.Unmarshal(OSDFBody, &ns)
 	if err != nil {
 		log.Error(fmt.Sprintf("Failed unmarshal namespace from response: %v, body: %v, response code: %v, URL: %v", err, OSDFBody, resp.StatusCode, registryUrl))

--- a/registry/custom_reg_fields.go
+++ b/registry/custom_reg_fields.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/utils"
 )
 
@@ -168,7 +169,7 @@ func convertCustomRegFields(configFields []customRegFieldsConfig) []registration
 }
 
 // Helper function to exclude pubkey field from marshaling into json
-func excludePubKey(nss []*Namespace) (nssNew []NamespaceWOPubkey) {
+func excludePubKey(nss []*server_structs.Namespace) (nssNew []NamespaceWOPubkey) {
 	nssNew = make([]NamespaceWOPubkey, 0)
 	for _, ns := range nss {
 		nsNew := NamespaceWOPubkey{

--- a/registry/registry_db_test.go
+++ b/registry/registry_db_test.go
@@ -36,6 +36,7 @@ import (
 	"path/filepath"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/test_utils"
 	"github.com/spf13/viper"
 )
@@ -44,14 +45,14 @@ func setupMockRegistryDB(t *testing.T) {
 	mockDB, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	db = mockDB
 	require.NoError(t, err, "Error setting up mock namespace DB")
-	err = db.AutoMigrate(&Namespace{})
+	err = db.AutoMigrate(&server_structs.Namespace{})
 	require.NoError(t, err, "Failed to migrate DB for namespace table")
 	err = createTopologyTable()
 	require.NoError(t, err, "Error creating topology table")
 }
 
 func resetNamespaceDB(t *testing.T) {
-	err := db.Where("1 = 1").Delete(&Namespace{}).Error
+	err := db.Where("1 = 1").Delete(&server_structs.Namespace{}).Error
 	require.NoError(t, err, "Error resetting namespace DB")
 	err = db.Where("1 = 1").Delete(&Topology{}).Error
 	require.NoError(t, err, "Error resetting topology DB")
@@ -62,12 +63,12 @@ func teardownMockNamespaceDB(t *testing.T) {
 	require.NoError(t, err, "Error tearing down mock namespace DB")
 }
 
-func insertMockDBData(nss []Namespace) error {
+func insertMockDBData(nss []server_structs.Namespace) error {
 	return db.Create(&nss).Error
 }
 
 func getLastNamespaceId() (int, error) {
-	var namespace Namespace
+	var namespace server_structs.Namespace
 	result := db.Select("id").Order("id DESC").First(&namespace)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
@@ -80,19 +81,19 @@ func getLastNamespaceId() (int, error) {
 }
 
 // Compares expected Namespace slice against either a slice of Namespace ptr or just Namespace
-func compareNamespaces(execpted []Namespace, returned interface{}, woPubkey bool) bool {
-	var normalizedReturned []Namespace
+func compareNamespaces(execpted []server_structs.Namespace, returned interface{}, woPubkey bool) bool {
+	var normalizedReturned []server_structs.Namespace
 
 	switch v := returned.(type) {
-	case []Namespace:
+	case []server_structs.Namespace:
 		normalizedReturned = v
-	case []*Namespace:
+	case []*server_structs.Namespace:
 		for _, ptr := range v {
 			if ptr != nil {
 				normalizedReturned = append(normalizedReturned, *ptr)
 			} else {
 				// Handle nil pointers if necessary
-				normalizedReturned = append(normalizedReturned, Namespace{}) // or some default value
+				normalizedReturned = append(normalizedReturned, server_structs.Namespace{}) // or some default value
 			}
 		}
 	default:
@@ -114,8 +115,8 @@ func compareNamespaces(execpted []Namespace, returned interface{}, woPubkey bool
 	return true
 }
 
-func mockNamespace(prefix, pubkey, identity string, adminMetadata AdminMetadata) Namespace {
-	return Namespace{
+func mockNamespace(prefix, pubkey, identity string, adminMetadata server_structs.AdminMetadata) server_structs.Namespace {
+	return server_structs.Namespace{
 		Prefix:        prefix,
 		Pubkey:        pubkey,
 		Identity:      identity,
@@ -126,29 +127,29 @@ func mockNamespace(prefix, pubkey, identity string, adminMetadata AdminMetadata)
 // Some genertic mock data function to be shared with other test
 // functinos in this package. Please treat them as "constants"
 var (
-	mockNssWithOrigins []Namespace = []Namespace{
-		mockNamespace("/test1", "pubkey1", "", AdminMetadata{Status: Approved}),
-		mockNamespace("/test2", "pubkey2", "", AdminMetadata{Status: Approved}),
+	mockNssWithOrigins []server_structs.Namespace = []server_structs.Namespace{
+		mockNamespace("/test1", "pubkey1", "", server_structs.AdminMetadata{Status: server_structs.RegApproved}),
+		mockNamespace("/test2", "pubkey2", "", server_structs.AdminMetadata{Status: server_structs.RegApproved}),
 	}
-	mockNssWithCaches []Namespace = []Namespace{
-		mockNamespace("/caches/random1", "pubkey1", "", AdminMetadata{Status: Approved}),
-		mockNamespace("/caches/random2", "pubkey2", "", AdminMetadata{Status: Approved}),
+	mockNssWithCaches []server_structs.Namespace = []server_structs.Namespace{
+		mockNamespace("/caches/random1", "pubkey1", "", server_structs.AdminMetadata{Status: server_structs.RegApproved}),
+		mockNamespace("/caches/random2", "pubkey2", "", server_structs.AdminMetadata{Status: server_structs.RegApproved}),
 	}
-	mockNssWithOriginsNotApproved []Namespace = []Namespace{
-		mockNamespace("/pending1", "pubkey1", "", AdminMetadata{Status: Pending}),
-		mockNamespace("/pending2", "pubkey2", "", AdminMetadata{Status: Pending}),
+	mockNssWithOriginsNotApproved []server_structs.Namespace = []server_structs.Namespace{
+		mockNamespace("/pending1", "pubkey1", "", server_structs.AdminMetadata{Status: server_structs.RegPending}),
+		mockNamespace("/pending2", "pubkey2", "", server_structs.AdminMetadata{Status: server_structs.RegPending}),
 	}
-	mockNssWithCachesNotApproved []Namespace = []Namespace{
-		mockNamespace("/caches/pending1", "pubkey1", "", AdminMetadata{Status: Pending}),
-		mockNamespace("/caches/pending2", "pubkey2", "", AdminMetadata{Status: Pending}),
+	mockNssWithCachesNotApproved []server_structs.Namespace = []server_structs.Namespace{
+		mockNamespace("/caches/pending1", "pubkey1", "", server_structs.AdminMetadata{Status: server_structs.RegPending}),
+		mockNamespace("/caches/pending2", "pubkey2", "", server_structs.AdminMetadata{Status: server_structs.RegPending}),
 	}
-	mockNssWithMixed []Namespace = func() (mixed []Namespace) {
+	mockNssWithMixed []server_structs.Namespace = func() (mixed []server_structs.Namespace) {
 		mixed = append(mixed, mockNssWithOrigins...)
 		mixed = append(mixed, mockNssWithCaches...)
 		return
 	}()
 
-	mockNssWithMixedNotApproved []Namespace = func() (mixed []Namespace) {
+	mockNssWithMixedNotApproved []server_structs.Namespace = func() (mixed []server_structs.Namespace) {
 		mixed = append(mixed, mockNssWithOriginsNotApproved...)
 		mixed = append(mixed, mockNssWithCachesNotApproved...)
 		return
@@ -180,9 +181,9 @@ func TestGetNamespaceById(t *testing.T) {
 
 	t.Run("return-namespace-with-correct-id", func(t *testing.T) {
 		defer resetNamespaceDB(t)
-		mockNs := mockNamespace("/test", "", "", AdminMetadata{UserID: "foo"})
+		mockNs := mockNamespace("/test", "", "", server_structs.AdminMetadata{UserID: "foo"})
 		mockNs.CustomFields = mockCustomFields
-		err := insertMockDBData([]Namespace{mockNs})
+		err := insertMockDBData([]server_structs.Namespace{mockNs})
 		require.NoError(t, err)
 		nss, err := getAllNamespaces()
 		require.NoError(t, err)
@@ -221,24 +222,24 @@ func TestGetNamespaceStatusById(t *testing.T) {
 
 	t.Run("valid-id-empty-admin-metadata", func(t *testing.T) {
 		resetNamespaceDB(t)
-		err := insertMockDBData([]Namespace{mockNamespace("/foo", "", "", AdminMetadata{})})
+		err := insertMockDBData([]server_structs.Namespace{mockNamespace("/foo", "", "", server_structs.AdminMetadata{})})
 		require.NoError(t, err)
 		lastId, err := getLastNamespaceId()
 		require.NoError(t, err)
 		status, err := getNamespaceStatusById(lastId)
 		require.NoError(t, err)
-		assert.Equal(t, Unknown, status)
+		assert.Equal(t, server_structs.RegUnknown, status)
 	})
 
 	t.Run("valid-id-non-empty-admin-metadata", func(t *testing.T) {
 		resetNamespaceDB(t)
-		err := insertMockDBData([]Namespace{mockNamespace("/foo", "", "", AdminMetadata{Status: Approved})})
+		err := insertMockDBData([]server_structs.Namespace{mockNamespace("/foo", "", "", server_structs.AdminMetadata{Status: server_structs.RegApproved})})
 		require.NoError(t, err)
 		lastId, err := getLastNamespaceId()
 		require.NoError(t, err)
 		status, err := getNamespaceStatusById(lastId)
 		require.NoError(t, err)
-		assert.Equal(t, Approved, status)
+		assert.Equal(t, server_structs.RegApproved, status)
 	})
 }
 
@@ -248,7 +249,7 @@ func TestAddNamespace(t *testing.T) {
 
 	t.Run("set-default-fields", func(t *testing.T) {
 		defer resetNamespaceDB(t)
-		mockNs := mockNamespace("/test", "pubkey", "identity", AdminMetadata{UserID: "someone"})
+		mockNs := mockNamespace("/test", "pubkey", "identity", server_structs.AdminMetadata{UserID: "someone"})
 		err := AddNamespace(&mockNs)
 		require.NoError(t, err)
 		got, err := getAllNamespaces()
@@ -266,7 +267,7 @@ func TestAddNamespace(t *testing.T) {
 		defer resetNamespaceDB(t)
 		mockCreateAt := time.Now().Add(time.Hour * 10)
 		mockUpdatedAt := time.Now().Add(time.Minute * 20)
-		mockNs := mockNamespace("/test", "pubkey", "identity", AdminMetadata{UserID: "someone", CreatedAt: mockCreateAt, UpdatedAt: mockUpdatedAt})
+		mockNs := mockNamespace("/test", "pubkey", "identity", server_structs.AdminMetadata{UserID: "someone", CreatedAt: mockCreateAt, UpdatedAt: mockUpdatedAt})
 		err := AddNamespace(&mockNs)
 		require.NoError(t, err)
 		got, err := getAllNamespaces()
@@ -285,7 +286,16 @@ func TestAddNamespace(t *testing.T) {
 
 	t.Run("insert-data-integrity", func(t *testing.T) {
 		defer resetNamespaceDB(t)
-		mockNs := mockNamespace("/test", "pubkey", "identity", AdminMetadata{UserID: "someone", Description: "Some description", SiteName: "OSG", SecurityContactUserID: "security-001"})
+		mockNs := mockNamespace(
+			"/test",
+			"pubkey",
+			"identity",
+			server_structs.AdminMetadata{
+				UserID:                "someone",
+				Description:           "Some description",
+				SiteName:              "OSG",
+				SecurityContactUserID: "security-001",
+			})
 		mockNs.CustomFields = mockCustomFields
 		err := AddNamespace(&mockNs)
 		require.NoError(t, err)
@@ -308,15 +318,15 @@ func TestUpdateNamespace(t *testing.T) {
 
 	t.Run("update-on-dne-entry-returns-error", func(t *testing.T) {
 		defer resetNamespaceDB(t)
-		mockNs := mockNamespace("/test", "", "", AdminMetadata{})
+		mockNs := mockNamespace("/test", "", "", server_structs.AdminMetadata{})
 		err := updateNamespace(&mockNs)
 		assert.Error(t, err)
 	})
 
 	t.Run("update-preserve-internal-fields", func(t *testing.T) {
 		defer resetNamespaceDB(t)
-		mockNs := mockNamespace("/test", "", "", AdminMetadata{UserID: "foo"})
-		err := insertMockDBData([]Namespace{mockNs})
+		mockNs := mockNamespace("/test", "", "", server_structs.AdminMetadata{UserID: "foo"})
+		err := insertMockDBData([]server_structs.Namespace{mockNs})
 		require.NoError(t, err)
 		initialNss, err := getAllNamespaces()
 		require.NoError(t, err)
@@ -326,7 +336,7 @@ func TestUpdateNamespace(t *testing.T) {
 		initialNs.AdminMetadata.UserID = "bar"
 		initialNs.AdminMetadata.CreatedAt = time.Now().Add(10 * time.Hour)
 		initialNs.AdminMetadata.UpdatedAt = time.Now().Add(10 * time.Hour)
-		initialNs.AdminMetadata.Status = Approved
+		initialNs.AdminMetadata.Status = server_structs.RegApproved
 		initialNs.AdminMetadata.ApproverID = "hacker"
 		initialNs.AdminMetadata.ApprovedAt = time.Now().Add(10 * time.Hour)
 		err = updateNamespace(initialNs)
@@ -353,41 +363,41 @@ func TestUpdateNamespaceStatusById(t *testing.T) {
 		defer resetNamespaceDB(t)
 		err := insertMockDBData(mockNssWithOrigins)
 		require.NoError(t, err)
-		err = updateNamespaceStatusById(100, Approved, "random")
+		err = updateNamespaceStatusById(100, server_structs.RegApproved, "random")
 		assert.Error(t, err)
 	})
 
 	t.Run("return-error-if-invalid-approver-userId", func(t *testing.T) {
 		defer resetNamespaceDB(t)
 
-		mockNs := mockNamespace("/test", "pubkey", "identity", AdminMetadata{UserID: "someone"})
-		err := insertMockDBData([]Namespace{mockNs})
+		mockNs := mockNamespace("/test", "pubkey", "identity", server_structs.AdminMetadata{UserID: "someone"})
+		err := insertMockDBData([]server_structs.Namespace{mockNs})
 		require.NoError(t, err)
 		got, err := getAllNamespaces()
 		require.NoError(t, err)
 		require.Equal(t, 1, len(got))
 		assert.Equal(t, mockNs.Prefix, got[0].Prefix)
-		err = updateNamespaceStatusById(got[0].ID, Approved, "")
+		err = updateNamespaceStatusById(got[0].ID, server_structs.RegApproved, "")
 		assert.Error(t, err)
 	})
 
 	t.Run("update-status-with-valid-input-for-approval", func(t *testing.T) {
 		defer resetNamespaceDB(t)
 
-		mockNs := mockNamespace("/test", "pubkey", "identity", AdminMetadata{UserID: "someone"})
-		err := insertMockDBData([]Namespace{mockNs})
+		mockNs := mockNamespace("/test", "pubkey", "identity", server_structs.AdminMetadata{UserID: "someone"})
+		err := insertMockDBData([]server_structs.Namespace{mockNs})
 		require.NoError(t, err)
 		got, err := getAllNamespaces()
 		require.NoError(t, err)
 		require.Equal(t, 1, len(got))
 		assert.Equal(t, mockNs.Prefix, got[0].Prefix)
-		err = updateNamespaceStatusById(got[0].ID, Approved, "approver1")
+		err = updateNamespaceStatusById(got[0].ID, server_structs.RegApproved, "approver1")
 		assert.NoError(t, err)
 		got, err = getAllNamespaces()
 		assert.NoError(t, err)
 		require.Equal(t, 1, len(got))
 		assert.Equal(t, mockNs.Prefix, got[0].Prefix)
-		assert.Equal(t, Approved, got[0].AdminMetadata.Status)
+		assert.Equal(t, server_structs.RegApproved, got[0].AdminMetadata.Status)
 		assert.Equal(t, "approver1", got[0].AdminMetadata.ApproverID)
 		assert.NotEqual(t, time.Time{}, got[0].AdminMetadata.ApprovedAt)
 	})
@@ -395,20 +405,20 @@ func TestUpdateNamespaceStatusById(t *testing.T) {
 	t.Run("deny-does-not-modify-approval-fields", func(t *testing.T) {
 		defer resetNamespaceDB(t)
 
-		mockNs := mockNamespace("/test", "pubkey", "identity", AdminMetadata{UserID: "someone"})
-		err := insertMockDBData([]Namespace{mockNs})
+		mockNs := mockNamespace("/test", "pubkey", "identity", server_structs.AdminMetadata{UserID: "someone"})
+		err := insertMockDBData([]server_structs.Namespace{mockNs})
 		assert.NoError(t, err)
 		got, err := getAllNamespaces()
 		assert.NoError(t, err)
 		require.Equal(t, 1, len(got))
 		assert.Equal(t, mockNs.Prefix, got[0].Prefix)
-		err = updateNamespaceStatusById(got[0].ID, Denied, "approver1")
+		err = updateNamespaceStatusById(got[0].ID, server_structs.RegDenied, "approver1")
 		assert.NoError(t, err)
 		got, err = getAllNamespaces()
 		assert.NoError(t, err)
 		require.Equal(t, 1, len(got))
 		assert.Equal(t, mockNs.Prefix, got[0].Prefix)
-		assert.Equal(t, Denied, got[0].AdminMetadata.Status)
+		assert.Equal(t, server_structs.RegDenied, got[0].AdminMetadata.Status)
 		assert.Equal(t, "", got[0].AdminMetadata.ApproverID)
 		assert.Equal(t, time.Time{}, got[0].AdminMetadata.ApprovedAt)
 	})
@@ -423,27 +433,27 @@ func TestGetNamespacesByFilter(t *testing.T) {
 	defer teardownMockNamespaceDB(t)
 
 	t.Run("return-error-for-unsupported-operations", func(t *testing.T) {
-		filterNsID := Namespace{
+		filterNsID := server_structs.Namespace{
 			ID: 123,
 		}
 
 		_, err := getNamespacesByFilter(filterNsID, "")
 		require.Error(t, err, "Should return error for filtering against unsupported field ID")
 
-		filterNsCF := Namespace{
+		filterNsCF := server_structs.Namespace{
 			CustomFields: mockCustomFields,
 		}
 		_, err = getNamespacesByFilter(filterNsCF, "")
 		require.Error(t, err, "Should return error for filtering against unsupported custom fields")
 
-		filterNsIdentity := Namespace{
+		filterNsIdentity := server_structs.Namespace{
 			Identity: "someIdentity",
 		}
 
 		_, err = getNamespacesByFilter(filterNsIdentity, "")
 		require.Error(t, err, "Should return error for filtering against unsupported field Identity")
 
-		filterNsPubKey := Namespace{
+		filterNsPubKey := server_structs.Namespace{
 			Pubkey: "somePubkey",
 		}
 
@@ -452,21 +462,21 @@ func TestGetNamespacesByFilter(t *testing.T) {
 
 		// Now, for AdminMetadata filters to work, we need to have a valid object
 		resetNamespaceDB(t)
-		err = insertMockDBData([]Namespace{{
+		err = insertMockDBData([]server_structs.Namespace{{
 			Prefix: "/bar",
-			AdminMetadata: AdminMetadata{
+			AdminMetadata: server_structs.AdminMetadata{
 				Description:           "Mock description",
 				SiteName:              "UW-Madison",
 				Institution:           "123456",
 				SecurityContactUserID: "contactUserID",
 				ApproverID:            "mockApproverID",
-				Status:                Pending,
+				Status:                server_structs.RegPending,
 			},
 		}})
 		require.NoError(t, err)
 
-		filterNsCreateAt := Namespace{
-			AdminMetadata: AdminMetadata{
+		filterNsCreateAt := server_structs.Namespace{
+			AdminMetadata: server_structs.AdminMetadata{
 				CreatedAt: time.Now(),
 			},
 		}
@@ -474,8 +484,8 @@ func TestGetNamespacesByFilter(t *testing.T) {
 		_, err = getNamespacesByFilter(filterNsCreateAt, "")
 		require.Error(t, err, "Should return error for filtering against unsupported field CreatedAt")
 
-		filterNsUpdateAt := Namespace{
-			AdminMetadata: AdminMetadata{
+		filterNsUpdateAt := server_structs.Namespace{
+			AdminMetadata: server_structs.AdminMetadata{
 				UpdatedAt: time.Now(),
 			},
 		}
@@ -483,8 +493,8 @@ func TestGetNamespacesByFilter(t *testing.T) {
 		_, err = getNamespacesByFilter(filterNsUpdateAt, "")
 		require.Error(t, err, "Should return error for filtering against unsupported field UpdatedAt")
 
-		filterNsApproveAt := Namespace{
-			AdminMetadata: AdminMetadata{
+		filterNsApproveAt := server_structs.Namespace{
+			AdminMetadata: server_structs.AdminMetadata{
 				ApprovedAt: time.Now(),
 			},
 		}
@@ -499,7 +509,7 @@ func TestGetNamespacesByFilter(t *testing.T) {
 		err := insertMockDBData(append(mockNssWithOrigins, mockNssWithCaches...))
 		require.NoError(t, err)
 
-		filterNs := Namespace{}
+		filterNs := server_structs.Namespace{}
 		nssOrigins, err := getNamespacesByFilter(filterNs, OriginType)
 		require.NoError(t, err)
 		assert.NotEmpty(t, nssOrigins, "Should return non-empty result for OriginType")
@@ -513,22 +523,22 @@ func TestGetNamespacesByFilter(t *testing.T) {
 
 	t.Run("filter-by-admin-metadata", func(t *testing.T) {
 		resetNamespaceDB(t)
-		err := insertMockDBData([]Namespace{{
+		err := insertMockDBData([]server_structs.Namespace{{
 			Prefix: "/bar",
-			AdminMetadata: AdminMetadata{
+			AdminMetadata: server_structs.AdminMetadata{
 				Description:           "Mock description",
 				SiteName:              "UW-Madison",
 				UserID:                "mockUserID",
 				Institution:           "123456",
 				SecurityContactUserID: "contactUserID",
 				ApproverID:            "mockApproverID",
-				Status:                Pending,
+				Status:                server_structs.RegPending,
 			},
 		}})
 		require.NoError(t, err)
 
-		filterNs := Namespace{
-			AdminMetadata: AdminMetadata{
+		filterNs := server_structs.Namespace{
+			AdminMetadata: server_structs.AdminMetadata{
 				Description: "description",
 			},
 		}
@@ -537,8 +547,8 @@ func TestGetNamespacesByFilter(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEmpty(t, namespaces, "Should return non-empty result for Description")
 
-		filterNs = Namespace{
-			AdminMetadata: AdminMetadata{
+		filterNs = server_structs.Namespace{
+			AdminMetadata: server_structs.AdminMetadata{
 				SiteName: "Madison",
 			},
 		}
@@ -546,8 +556,8 @@ func TestGetNamespacesByFilter(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEmpty(t, namespaces, "Should return non-empty result for SiteName")
 
-		filterNs = Namespace{
-			AdminMetadata: AdminMetadata{
+		filterNs = server_structs.Namespace{
+			AdminMetadata: server_structs.AdminMetadata{
 				Institution: "123456",
 			},
 		}
@@ -555,8 +565,8 @@ func TestGetNamespacesByFilter(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEmpty(t, namespaces, "Should return non-empty result for Institution")
 
-		filterNs = Namespace{
-			AdminMetadata: AdminMetadata{
+		filterNs = server_structs.Namespace{
+			AdminMetadata: server_structs.AdminMetadata{
 				SecurityContactUserID: "contactUserID",
 			},
 		}
@@ -564,8 +574,8 @@ func TestGetNamespacesByFilter(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEmpty(t, namespaces, "Should return non-empty result for SecurityContactUserID")
 
-		filterNs = Namespace{
-			AdminMetadata: AdminMetadata{
+		filterNs = server_structs.Namespace{
+			AdminMetadata: server_structs.AdminMetadata{
 				ApproverID: "mockApproverID",
 			},
 		}
@@ -573,17 +583,17 @@ func TestGetNamespacesByFilter(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEmpty(t, namespaces, "Should return non-empty result for ApproverID")
 
-		filterNs = Namespace{
-			AdminMetadata: AdminMetadata{
-				Status: Pending,
+		filterNs = server_structs.Namespace{
+			AdminMetadata: server_structs.AdminMetadata{
+				Status: server_structs.RegPending,
 			},
 		}
 		namespaces, err = getNamespacesByFilter(filterNs, "")
 		require.NoError(t, err)
 		assert.NotEmpty(t, namespaces, "Should return non-empty result for Status")
 
-		filterNs = Namespace{
-			AdminMetadata: AdminMetadata{
+		filterNs = server_structs.Namespace{
+			AdminMetadata: server_structs.AdminMetadata{
 				UserID: "mockUserID",
 			},
 		}
@@ -594,25 +604,25 @@ func TestGetNamespacesByFilter(t *testing.T) {
 
 	t.Run("multiple-AND-match", func(t *testing.T) {
 		resetNamespaceDB(t)
-		err := insertMockDBData([]Namespace{{
+		err := insertMockDBData([]server_structs.Namespace{{
 			Prefix: "/bar",
-			AdminMetadata: AdminMetadata{
+			AdminMetadata: server_structs.AdminMetadata{
 				Description:           "Mock description",
 				SiteName:              "UW-Madison",
 				Institution:           "123456",
 				SecurityContactUserID: "contactUserID",
 				ApproverID:            "mockApproverID",
-				Status:                Pending,
+				Status:                server_structs.RegPending,
 			},
 		}})
 		require.NoError(t, err)
 
-		filterNs := Namespace{
+		filterNs := server_structs.Namespace{
 			Prefix: "/bar",
-			AdminMetadata: AdminMetadata{
+			AdminMetadata: server_structs.AdminMetadata{
 				SecurityContactUserID: "contactUserID",
 				ApproverID:            "mockApproverID",
-				Status:                Pending,
+				Status:                server_structs.RegPending,
 			},
 		}
 		namespaces, err := getNamespacesByFilter(filterNs, "")
@@ -622,19 +632,19 @@ func TestGetNamespacesByFilter(t *testing.T) {
 
 	t.Run("fully-match", func(t *testing.T) {
 		resetNamespaceDB(t)
-		mockNs := Namespace{
+		mockNs := server_structs.Namespace{
 			Prefix: "/bar",
-			AdminMetadata: AdminMetadata{
+			AdminMetadata: server_structs.AdminMetadata{
 				Description:           "Mock description",
 				SiteName:              "UW-Madison",
 				UserID:                "mockUserID",
 				Institution:           "123456",
 				SecurityContactUserID: "contactUserID",
 				ApproverID:            "mockApproverID",
-				Status:                Pending,
+				Status:                server_structs.RegPending,
 			},
 		}
-		err := insertMockDBData([]Namespace{mockNs})
+		err := insertMockDBData([]server_structs.Namespace{mockNs})
 		require.NoError(t, err)
 
 		filterNs := mockNs
@@ -645,23 +655,23 @@ func TestGetNamespacesByFilter(t *testing.T) {
 
 	t.Run("no-match", func(t *testing.T) {
 		resetNamespaceDB(t)
-		mockNs := Namespace{
+		mockNs := server_structs.Namespace{
 			Prefix: "/bar",
-			AdminMetadata: AdminMetadata{
+			AdminMetadata: server_structs.AdminMetadata{
 				Description:           "Mock description",
 				UserID:                "mockUserID",
 				SiteName:              "UW-Madison",
 				Institution:           "123456",
 				SecurityContactUserID: "contactUserID",
 				ApproverID:            "mockApproverID",
-				Status:                Pending,
+				Status:                server_structs.RegPending,
 			},
 		}
-		err := insertMockDBData([]Namespace{mockNs})
+		err := insertMockDBData([]server_structs.Namespace{mockNs})
 		require.NoError(t, err)
 
 		filterNs := mockNs
-		filterNs.AdminMetadata.Status = Denied
+		filterNs.AdminMetadata.Status = server_structs.RegDenied
 		namespaces, err := getNamespacesByFilter(filterNs, "")
 		require.NoError(t, err)
 		assert.Empty(t, namespaces, "Should return non-empty result for non-empty database without condition")
@@ -670,7 +680,7 @@ func TestGetNamespacesByFilter(t *testing.T) {
 	t.Run("empty-db-returns-empty-results", func(t *testing.T) {
 		resetNamespaceDB(t)
 
-		filterNs := Namespace{}
+		filterNs := server_structs.Namespace{}
 		namespaces, err := getNamespacesByFilter(filterNs, "")
 		require.NoError(t, err)
 		assert.Empty(t, namespaces, "Should return empty result for empty database")
@@ -693,11 +703,11 @@ func TestGetNamespaceJwksByPrefix(t *testing.T) {
 		jwksByte, err := json.Marshal(mockJwks)
 		require.NoError(t, err)
 
-		err = insertMockDBData([]Namespace{mockNamespace("/foo", string(jwksByte), "", AdminMetadata{})})
+		err = insertMockDBData([]server_structs.Namespace{mockNamespace("/foo", string(jwksByte), "", server_structs.AdminMetadata{})})
 		require.NoError(t, err)
 		_, admin_meta, err := getNamespaceJwksByPrefix("/foo")
 		require.NoError(t, err)
-		assert.Equal(t, AdminMetadata{}, *admin_meta)
+		assert.Equal(t, server_structs.AdminMetadata{}, *admin_meta)
 	})
 
 	t.Run("valid-prefix-non-empty-admin-metadata", func(t *testing.T) {
@@ -706,11 +716,11 @@ func TestGetNamespaceJwksByPrefix(t *testing.T) {
 		jwksByte, err := json.Marshal(mockJwks)
 		require.NoError(t, err)
 
-		err = insertMockDBData([]Namespace{mockNamespace("/foo", string(jwksByte), "", AdminMetadata{Status: Approved})})
+		err = insertMockDBData([]server_structs.Namespace{mockNamespace("/foo", string(jwksByte), "", server_structs.AdminMetadata{Status: server_structs.RegApproved})})
 		require.NoError(t, err)
 		_, admin_meta, err := getNamespaceJwksByPrefix("/foo")
 		require.NoError(t, err)
-		assert.Equal(t, Approved, admin_meta.Status)
+		assert.Equal(t, server_structs.RegApproved, admin_meta.Status)
 	})
 }
 
@@ -779,12 +789,12 @@ func TestRegistryTopology(t *testing.T) {
 	require.True(t, exists)
 
 	// Add a test namespace so we can test that checkExists still works
-	ns := Namespace{
+	ns := server_structs.Namespace{
 		ID:            0,
 		Prefix:        "/regular/foo",
 		Pubkey:        "",
 		Identity:      "",
-		AdminMetadata: AdminMetadata{},
+		AdminMetadata: server_structs.AdminMetadata{},
 	}
 	err = AddNamespace(&ns)
 	require.NoError(t, err)

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -28,10 +28,11 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/lestrrat-go/jwx/v2/jwk"
-	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/server_structs"
 )
 
 func TestHandleWildcard(t *testing.T) {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -61,7 +62,7 @@ func TestHandleWildcard(t *testing.T) {
 		mockJWKS := jwk.NewSet()
 		mockJWKSBytes, err := json.Marshal(mockJWKS)
 		require.NoError(t, err)
-		err = insertMockDBData([]Namespace{{Prefix: mockPrefix, Pubkey: string(mockJWKSBytes)}})
+		err = insertMockDBData([]server_structs.Namespace{{Prefix: mockPrefix, Pubkey: string(mockJWKSBytes)}})
 		require.NoError(t, err)
 		mockNs, err := getNamespaceByPrefix(mockPrefix)
 
@@ -138,11 +139,11 @@ func TestHandleWildcard(t *testing.T) {
 			mockJWKSBytes, err := json.Marshal(mockJWKS)
 			require.NoError(t, err)
 
-			mockStatus := Pending
+			mockStatus := server_structs.RegPending
 			if tc.IsApproved {
-				mockStatus = Approved
+				mockStatus = server_structs.RegApproved
 			}
-			err = insertMockDBData([]Namespace{{Prefix: mockPrefix, Pubkey: string(mockJWKSBytes), AdminMetadata: AdminMetadata{Status: mockStatus}}})
+			err = insertMockDBData([]server_structs.Namespace{{Prefix: mockPrefix, Pubkey: string(mockJWKSBytes), AdminMetadata: server_structs.AdminMetadata{Status: mockStatus}}})
 			require.NoError(t, err)
 			mockNs, err := getNamespaceByPrefix(mockPrefix)
 

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -75,7 +75,7 @@ const (
 
 func init() {
 	registrationFields = make([]registrationField, 0)
-	registrationFields = append(registrationFields, populateRegistrationFields("", Namespace{})...)
+	registrationFields = append(registrationFields, populateRegistrationFields("", server_structs.Namespace{})...)
 }
 
 // Populate registrationFields array to provide available namespace registration fields
@@ -131,21 +131,21 @@ func populateRegistrationFields(prefix string, data interface{}) []registrationF
 				break
 			}
 			// If it's AdminMetadata, add prefix and recursively call to parse fields
-			if field.Type == reflect.TypeOf(AdminMetadata{}) {
+			if field.Type == reflect.TypeOf(server_structs.AdminMetadata{}) {
 				existing_prefix := ""
 				if prefix != "" {
 					existing_prefix = prefix + "."
 				}
-				fields = append(fields, populateRegistrationFields(existing_prefix+"admin_metadata", AdminMetadata{})...)
+				fields = append(fields, populateRegistrationFields(existing_prefix+"admin_metadata", server_structs.AdminMetadata{})...)
 			}
 		}
 
-		if field.Type == reflect.TypeOf(RegistrationStatus("")) {
+		if field.Type == reflect.TypeOf(server_structs.RegistrationStatus("")) {
 			regField.Type = Enum
 			options := make([]registrationFieldOption, 3)
-			options[0] = registrationFieldOption{Name: Pending.String(), ID: Pending.LowerString()}
-			options[1] = registrationFieldOption{Name: Approved.String(), ID: Approved.LowerString()}
-			options[2] = registrationFieldOption{Name: Denied.String(), ID: Denied.LowerString()}
+			options[0] = registrationFieldOption{Name: server_structs.RegPending.String(), ID: server_structs.RegPending.LowerString()}
+			options[1] = registrationFieldOption{Name: server_structs.RegApproved.String(), ID: server_structs.RegApproved.LowerString()}
+			options[2] = registrationFieldOption{Name: server_structs.RegDenied.String(), ID: server_structs.RegDenied.LowerString()}
 			regField.Options = options
 			fields = append(fields, regField)
 		} else {
@@ -184,7 +184,7 @@ func listNamespaces(ctx *gin.Context) {
 	}
 
 	// For unauthed user with non-empty Status query != Approved, return 403
-	if !isAuthed && queryParams.Status != "" && queryParams.Status != Approved.String() {
+	if !isAuthed && queryParams.Status != "" && queryParams.Status != server_structs.RegApproved.String() {
 		ctx.JSON(http.StatusForbidden, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    "You don't have permission to filter non-approved namespace registrations"})
@@ -199,14 +199,14 @@ func listNamespaces(ctx *gin.Context) {
 		return
 	}
 
-	filterNs := Namespace{}
+	filterNs := server_structs.Namespace{}
 
 	// For authenticated users, it returns all namespaces.
 	// For unauthenticated users, it returns namespaces with AdminMetadata.Status = Approved
 	if isAuthed {
 		if queryParams.Status != "" {
-			if IsValidRegStatus(queryParams.Status) {
-				filterNs.AdminMetadata.Status = RegistrationStatus(queryParams.Status)
+			if server_structs.IsValidRegStatus(queryParams.Status) {
+				filterNs.AdminMetadata.Status = server_structs.RegistrationStatus(queryParams.Status)
 			} else {
 				ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
 					Status: server_structs.RespFailed,
@@ -214,7 +214,7 @@ func listNamespaces(ctx *gin.Context) {
 			}
 		}
 	} else {
-		filterNs.AdminMetadata.Status = Approved
+		filterNs.AdminMetadata.Status = server_structs.RegApproved
 	}
 
 	namespaces, err := getNamespacesByFilter(filterNs, ServerType(queryParams.ServerType))
@@ -250,11 +250,11 @@ func listNamespacesForUser(ctx *gin.Context) {
 		return
 	}
 
-	filterNs := Namespace{AdminMetadata: AdminMetadata{UserID: user}}
+	filterNs := server_structs.Namespace{AdminMetadata: server_structs.AdminMetadata{UserID: user}}
 
 	if queryParams.Status != "" {
-		if IsValidRegStatus(queryParams.Status) {
-			filterNs.AdminMetadata.Status = RegistrationStatus(queryParams.Status)
+		if server_structs.IsValidRegStatus(queryParams.Status) {
+			filterNs.AdminMetadata.Status = server_structs.RegistrationStatus(queryParams.Status)
 		} else {
 			ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
 				Status: server_structs.RespFailed,
@@ -323,7 +323,7 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 		}
 	}
 
-	ns := Namespace{}
+	ns := server_structs.Namespace{}
 	if ctx.ShouldBindJSON(&ns) != nil {
 		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
@@ -425,7 +425,7 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 	if !isUpdate { // Create
 		ns.AdminMetadata.UserID = user
 		// Overwrite status to Pending to filter malicious request
-		ns.AdminMetadata.Status = Pending
+		ns.AdminMetadata.Status = server_structs.RegPending
 		if inTopo {
 			ns.AdminMetadata.Description = fmt.Sprintf("[ Attention: A superspace or subspace of this prefix exists in OSDF topology: %s ] ", GetTopoPrefixString(topoNss))
 		}
@@ -493,7 +493,7 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 					Msg:    "Error checking namespace status"})
 				return
 			}
-			if existingStatus == Approved {
+			if existingStatus == server_structs.RegApproved {
 				log.Errorf("User '%s' is trying to modify approved namespace registration with id=%d", user, ns.ID)
 				ctx.JSON(http.StatusForbidden, server_structs.SimpleApiResp{
 					Status: server_structs.RespFailed,
@@ -573,7 +573,7 @@ func getNamespace(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, ns)
 }
 
-func updateNamespaceStatus(ctx *gin.Context, status RegistrationStatus) {
+func updateNamespaceStatus(ctx *gin.Context, status server_structs.RegistrationStatus) {
 	user := ctx.GetString("User")
 	idStr := ctx.Param("id")
 	id, err := strconv.Atoi(idStr)
@@ -783,10 +783,10 @@ func RegisterRegistryWebAPI(router *gin.RouterGroup) error {
 		registryWebAPI.DELETE("/namespaces/:id", web_ui.AuthHandler, web_ui.AdminAuthHandler, deleteNamespace)
 		registryWebAPI.GET("/namespaces/:id/pubkey", getNamespaceJWKS)
 		registryWebAPI.PATCH("/namespaces/:id/approve", web_ui.AuthHandler, web_ui.AdminAuthHandler, func(ctx *gin.Context) {
-			updateNamespaceStatus(ctx, Approved)
+			updateNamespaceStatus(ctx, server_structs.RegApproved)
 		})
 		registryWebAPI.PATCH("/namespaces/:id/deny", web_ui.AuthHandler, web_ui.AdminAuthHandler, func(ctx *gin.Context) {
-			updateNamespaceStatus(ctx, Denied)
+			updateNamespaceStatus(ctx, server_structs.RegDenied)
 		})
 	}
 	{

--- a/registry/registry_ui_test.go
+++ b/registry/registry_ui_test.go
@@ -38,16 +38,17 @@ import (
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/test_utils"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
-	"github.com/pkg/errors"
-	"github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // Mock wrong data fields for Institution
@@ -931,10 +932,10 @@ func TestCreateNamespace(t *testing.T) {
 			"string_field":   "random",
 			"datetime_field": 1696255200,
 		}
-		mockNs := Namespace{
+		mockNs := server_structs.Namespace{
 			Prefix:        "/foo",
 			Pubkey:        pubKeyStr,
-			AdminMetadata: AdminMetadata{Institution: "1000"},
+			AdminMetadata: server_structs.AdminMetadata{Institution: "1000"},
 			CustomFields:  customFieldsVals,
 		}
 		mockNsBytes, err := json.Marshal(mockNs)
@@ -955,7 +956,7 @@ func TestCreateNamespace(t *testing.T) {
 		require.Equal(t, 1, len(nss))
 		assert.Equal(t, "/foo", nss[0].Prefix)
 		assert.Equal(t, "admin", nss[0].AdminMetadata.UserID)
-		assert.Equal(t, Pending, nss[0].AdminMetadata.Status)
+		assert.Equal(t, server_structs.RegPending, nss[0].AdminMetadata.Status)
 		assert.NotEqual(t, time.Time{}, nss[0].AdminMetadata.CreatedAt)
 	})
 

--- a/registry/registry_ui_test.go
+++ b/registry/registry_ui_test.go
@@ -677,6 +677,10 @@ func TestUpdateNamespaceStatus(t *testing.T) {
 
 func TestCreateNamespace(t *testing.T) {
 	viper.Reset()
+
+	t.Cleanup(func() {
+		viper.Reset()
+	})
 	_, cancel, egrp := test_utils.TestContext(context.Background(), t)
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
@@ -922,6 +926,9 @@ func TestCreateNamespace(t *testing.T) {
 		viper.Set("Registry.CustomRegistrationFields", customFieldsConf)
 		err := InitCustomRegistrationFields()
 		require.NoError(t, err)
+		defer func() {
+			customRegFieldsConfigs = []customRegFieldsConfig{}
+		}()
 
 		pubKeyStr, err := GenerateMockJWKS()
 		require.NoError(t, err)
@@ -1047,6 +1054,9 @@ func TestCreateNamespace(t *testing.T) {
 
 func TestUpdateNamespaceHandler(t *testing.T) {
 	viper.Reset()
+	t.Cleanup(func() {
+		viper.Reset()
+	})
 	_, cancel, egrp := test_utils.TestContext(context.Background(), t)
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()

--- a/registry/registry_validation_test.go
+++ b/registry/registry_validation_test.go
@@ -22,11 +22,12 @@ import (
 	"testing"
 
 	"github.com/jellydator/ttlcache/v3"
-	"github.com/pelicanplatform/pelican/server_structs"
-	"github.com/pelicanplatform/pelican/test_utils"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/test_utils"
 )
 
 func TestValidateCustomFields(t *testing.T) {

--- a/registry/registry_validation_test.go
+++ b/registry/registry_validation_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/jellydator/ttlcache/v3"
+	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/test_utils"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -234,10 +235,10 @@ func TestValidateKeyChaining(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, jwkMockNew)
 
-	err = insertMockDBData([]Namespace{
-		mockNamespace("/foo", jwksStrFoo, "", AdminMetadata{}),
-		mockNamespace("/bar", jwksStrBar, "", AdminMetadata{}),
-		mockNamespace("/cache/randomCache", jwksStrCache, "", AdminMetadata{}),
+	err = insertMockDBData([]server_structs.Namespace{
+		mockNamespace("/foo", jwksStrFoo, "", server_structs.AdminMetadata{}),
+		mockNamespace("/bar", jwksStrBar, "", server_structs.AdminMetadata{}),
+		mockNamespace("/cache/randomCache", jwksStrCache, "", server_structs.AdminMetadata{}),
 	})
 
 	require.NoError(t, err)

--- a/server_structs/registry.go
+++ b/server_structs/registry.go
@@ -18,22 +18,104 @@
 
 package server_structs
 
-type CheckNamespaceExistsReq struct {
-	Prefix string `json:"prefix"`
-	PubKey string `json:"pubkey"`
+import (
+	"strings"
+	"time"
+)
+
+type RegistrationStatus string
+
+// The AdminMetadata is used in [Namespace] as a marshaled JSON string
+// to be stored in registry DB.
+//
+// The UserID and SecurityContactUserID are meant to correspond to the "sub" claim of the user token that
+// the OAuth client issues if the user is logged in using OAuth, or it should be
+// "admin" from local password-based authentication.
+//
+// To prevent users from writing to certain fields (readonly), you may use "post" tag
+// with value "exclude". This will exclude the field from user's create/update requests
+// and the field will also be excluded from field discovery endpoint (OPTION method).
+//
+// We use validator package to validate struct fields from user requests. If a field is
+// required, add `validate:"required"` to that field. This tag will also be used by fields discovery
+// endpoint to tell the UI if a field is required. For other validator tags,
+// visit: https://pkg.go.dev/github.com/go-playground/validator/v10
+type AdminMetadata struct {
+	UserID                string             `json:"user_id" post:"exclude"` // "sub" claim of user JWT who requested registration
+	Description           string             `json:"description"`
+	SiteName              string             `json:"site_name"`
+	Institution           string             `json:"institution" validate:"required"` // the unique identifier of the institution
+	SecurityContactUserID string             `json:"security_contact_user_id"`        // "sub" claim of user who is responsible for taking security concern
+	Status                RegistrationStatus `json:"status" post:"exclude"`
+	ApproverID            string             `json:"approver_id" post:"exclude"` // "sub" claim of user JWT who approved registration
+	ApprovedAt            time.Time          `json:"approved_at" post:"exclude"`
+	CreatedAt             time.Time          `json:"created_at" post:"exclude"`
+	UpdatedAt             time.Time          `json:"updated_at" post:"exclude"`
 }
 
-type CheckNamespaceExistsRes struct {
-	PrefixExists bool   `json:"prefix_exists"`
-	KeyMatch     bool   `json:"key_match"`
-	Message      string `json:"message"`
-	Error        string `json:"error"`
+type Namespace struct {
+	ID            int                    `json:"id" post:"exclude" gorm:"primaryKey"`
+	Prefix        string                 `json:"prefix" validate:"required"`
+	Pubkey        string                 `json:"pubkey" validate:"required"`
+	Identity      string                 `json:"identity" post:"exclude"`
+	AdminMetadata AdminMetadata          `json:"admin_metadata" gorm:"serializer:json"`
+	CustomFields  map[string]interface{} `json:"custom_fields" gorm:"serializer:json"`
 }
 
-type CheckNamespaceStatusReq struct {
-	Prefix string `json:"prefix"`
+type (
+	CheckNamespaceExistsReq struct {
+		Prefix string `json:"prefix"`
+		PubKey string `json:"pubkey"`
+	}
+
+	CheckNamespaceExistsRes struct {
+		PrefixExists bool   `json:"prefix_exists"`
+		KeyMatch     bool   `json:"key_match"`
+		Message      string `json:"message"`
+		Error        string `json:"error"`
+	}
+
+	CheckNamespaceStatusReq struct {
+		Prefix string `json:"prefix"`
+	}
+
+	CheckNamespaceStatusRes struct {
+		Approved bool `json:"approved"`
+	}
+)
+
+const (
+	RegPending  RegistrationStatus = "Pending"
+	RegApproved RegistrationStatus = "Approved"
+	RegDenied   RegistrationStatus = "Denied"
+	RegUnknown  RegistrationStatus = "Unknown"
+)
+
+func (rs RegistrationStatus) String() string {
+	return string(rs)
 }
 
-type CheckNamespaceStatusRes struct {
-	Approved bool `json:"approved"`
+func (rs RegistrationStatus) LowerString() string {
+	return strings.ToLower(string(rs))
+}
+
+func (a AdminMetadata) Equal(b AdminMetadata) bool {
+	return a.UserID == b.UserID &&
+		a.Description == b.Description &&
+		a.SiteName == b.SiteName &&
+		a.Institution == b.Institution &&
+		a.SecurityContactUserID == b.SecurityContactUserID &&
+		a.Status == b.Status &&
+		a.ApproverID == b.ApproverID &&
+		a.ApprovedAt.Equal(b.ApprovedAt) &&
+		a.CreatedAt.Equal(b.CreatedAt) &&
+		a.UpdatedAt.Equal(b.UpdatedAt)
+}
+
+func (Namespace) TableName() string {
+	return "namespace"
+}
+
+func IsValidRegStatus(s string) bool {
+	return s == "Pending" || s == "Approved" || s == "Denied" || s == "Unknown"
 }


### PR DESCRIPTION
Closes #1106 

Some points to note (copied from the ticket above):

* We need to have https://github.com/PelicanPlatform/pelican/issues/1107 ASAP; otherwise, with multi-export support at the origin, we can't wisely determine which namespace to fetch the site name from the registry. Currently, this PR only grab the first exported namespace as the prefix to query the site name at the registry, which is a bit sketchy.
* ~~We need to add an extra serverAd field Hostname to the director (and during advertisement), with this change.~~ When implementing this PR for caches, the director fails to verify the advertisement token from the cache because it relies on the `Name` field from the `serverAd` to find the namespace for the cache and grab the public jwks from the registry. If the Name is different from the hostname of the cache (which is used to register the namespace for the cache at the registry), the registry won't be able to find the namespace registration for the cache.  This PR took the approach that instead of adding a new field, the director now concatenates the namespace prefix for the cache with a new value, by extracting the hostname from `DataURL` or `WebURL` field in `OriginServerAd`