### PR TITLE
Fix wrong type for integer values in requests with customized registration fields at the registry

### DIFF
--- a/registry/custom_reg_fields.go
+++ b/registry/custom_reg_fields.go
@@ -208,6 +208,18 @@ func checkUniqueInstitutions(insts []Institution) bool {
 	return true
 }
 
+// Format custom registration fields in-place, by converting any float64/32 number to int
+func formatCustomFields(customFields map[string]interface{}) {
+	for key, val := range customFields {
+		switch v := val.(type) {
+		case float64:
+			customFields[key] = int(v)
+		case float32:
+			customFields[key] = int(v)
+		}
+	}
+}
+
 // Returns the institution options that are fetched from Registry.InstitutionsUrl
 // and stored in a TTL cache
 func getCachedInstitutions() (inst []Institution, intError error, extError error) {

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -406,6 +406,8 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 		return
 	}
 
+	formatCustomFields(ns.CustomFields)
+
 	if validCF, err := validateCustomFields(ns.CustomFields); !validCF {
 		if !validCF && err != nil {
 			ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{


### PR DESCRIPTION
As @CannonLock found out, the current validation for customized registration fields fails on `integer` type values, since Go will by default marshal JSON numbers to `float64` type. This PR converts any customized fields with `float64` or `float32` type to `int` type, which should be a relatively safe assumption as we currently don't support float-time customized fields. 

This PR also improves test coverage for the registration to cover this case.