### PR TITLE
Change director TTL cache key from `ServerAd` to server URL

### DIFF
--- a/director/advertise_test.go
+++ b/director/advertise_test.go
@@ -155,17 +155,16 @@ func TestAdvertiseOSDF(t *testing.T) {
 	err := AdvertiseOSDF()
 	require.NoError(t, err)
 
-	var foundServer server_structs.ServerAd
+	var foundServer server_structs.Advertisement
 	for _, item := range serverAds.Items() {
-		if item.Key().URL.Host == "origin1-endpoint.com" {
-			foundServer = item.Key()
+		if item.Value().URL.Host == "origin1-endpoint.com" {
+			foundServer = *item.Value()
 		}
 	}
 	require.NotNil(t, foundServer)
 	assert.True(t, foundServer.FromTopology)
-	nss := serverAds.Get(foundServer)
-	require.NotNil(t, nss)
-	assert.True(t, nss.Value()[0].FromTopology)
+	require.NotNil(t, foundServer.NamespaceAds)
+	assert.True(t, foundServer.NamespaceAds[0].FromTopology)
 
 	// Test a few values. If they're correct, it indicates the whole process likely succeeded
 	nsAd, oAds, cAds := getAdsForPath("/my/server/path/to/file")

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -45,7 +45,6 @@ const (
 
 var (
 	serverAds            = ttlcache.New(ttlcache.WithTTL[server_structs.ServerAd, []server_structs.NamespaceAdV2](15 * time.Minute))
-	serverAdMutex        = sync.RWMutex{}
 	filteredServers      = map[string]filterType{}
 	filteredServersMutex = sync.RWMutex{}
 )
@@ -54,8 +53,6 @@ func recordAd(ad server_structs.ServerAd, namespaceAds *[]server_structs.Namespa
 	if err := updateLatLong(&ad); err != nil {
 		log.Debugln("Failed to lookup GeoIP coordinates for host", ad.URL.Host)
 	}
-	serverAdMutex.Lock()
-	defer serverAdMutex.Unlock()
 
 	customTTL := param.Director_AdvertisementTTL.GetDuration()
 	if customTTL == 0 {

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -44,8 +44,9 @@ const (
 )
 
 var (
-	serverAds            = ttlcache.New(ttlcache.WithTTL[server_structs.ServerAd, []server_structs.NamespaceAdV2](15 * time.Minute))
-	filteredServers      = map[string]filterType{}
+	// The in-memory cache of xrootd server advertisement, with the key being ServerAd.URL.String()
+	serverAds            = ttlcache.New(ttlcache.WithTTL[string, *server_structs.Advertisement](15 * time.Minute))
+	filteredServers      = map[string]filterType{} // The map holds servers that are disabled, with the key being the ServerAd.Name
 	filteredServersMutex = sync.RWMutex{}
 )
 
@@ -54,11 +55,15 @@ func recordAd(ad server_structs.ServerAd, namespaceAds *[]server_structs.Namespa
 		log.Debugln("Failed to lookup GeoIP coordinates for host", ad.URL.Host)
 	}
 
+	if ad.URL.String() == "" {
+		log.Errorf("The URL of the serverAd %#v is empty. Cannot set the TTL cache.", ad)
+		return
+	}
 	customTTL := param.Director_AdvertisementTTL.GetDuration()
 	if customTTL == 0 {
-		serverAds.Set(ad, *namespaceAds, ttlcache.DefaultTTL)
+		serverAds.Set(ad.URL.String(), &server_structs.Advertisement{ServerAd: ad, NamespaceAds: *namespaceAds}, ttlcache.DefaultTTL)
 	} else {
-		serverAds.Set(ad, *namespaceAds, customTTL)
+		serverAds.Set(ad.URL.String(), &server_structs.Advertisement{ServerAd: ad, NamespaceAds: *namespaceAds}, customTTL)
 	}
 }
 
@@ -137,31 +142,28 @@ func getAdsForPath(reqPath string) (originNamespace server_structs.NamespaceAdV2
 	// is the server ad itself (either cache or origin), and the value
 	// is a slice of namespace prefixes are supported by that server
 	var best *server_structs.NamespaceAdV2
-	ads := serverAds.Keys()
+	ads := []*server_structs.Advertisement{}
+	for _, item := range serverAds.Items() {
+		ads = append(ads, item.Value())
+	}
 	sortedAds := sortServerAdsByTopo(ads)
-	for _, serverAd := range sortedAds {
-		var namespaces []server_structs.NamespaceAdV2
-		if serverAds.Has(serverAd) {
-			namespaces = serverAds.Get(serverAd).Value()
-		} else {
+	for _, ad := range sortedAds {
+		if filtered, ft := checkFilter(ad.Name); filtered {
+			log.Debugf("Skipping %s server %s as it's in the filtered server list with type %s", ad.Type, ad.Name, ft)
 			continue
 		}
-		if filtered, ft := checkFilter(serverAd.Name); filtered {
-			log.Debugf("Skipping %s server %s as it's in the filtered server list with type %s", serverAd.Type, serverAd.Name, ft)
-			continue
-		}
-		if ns := matchesPrefix(reqPath, namespaces); ns != nil {
+		if ns := matchesPrefix(reqPath, ad.NamespaceAds); ns != nil {
 			if best == nil || len(ns.Path) > len(best.Path) {
 				best = ns
 				// If anything was previously set by a namespace that constituted a shorter
 				// prefix, we overwrite that here because we found a better ns. We also clear
 				// the other slice of server ads, because we know those aren't good anymore
-				if serverAd.Type == server_structs.OriginType {
-					originAds = []server_structs.ServerAd{serverAd}
+				if ad.Type == server_structs.OriginType {
+					originAds = []server_structs.ServerAd{ad.ServerAd}
 					cacheAds = []server_structs.ServerAd{}
-				} else if serverAd.Type == server_structs.CacheType {
+				} else if ad.Type == server_structs.CacheType {
 					originAds = []server_structs.ServerAd{}
-					cacheAds = []server_structs.ServerAd{serverAd}
+					cacheAds = []server_structs.ServerAd{ad.ServerAd}
 				}
 			} else if ns.Path == best.Path {
 				// If the current is from Pelican but the best is from topology
@@ -170,28 +172,28 @@ func getAdsForPath(reqPath string) (originNamespace server_structs.NamespaceAdV2
 					best = ns
 				}
 				// We treat serverAds differently from namespace
-				if serverAd.Type == server_structs.OriginType {
+				if ad.Type == server_structs.OriginType {
 					// For origin, if there's no origin in the list yet, and there's a matched one from topology, then add it
 					// However, if the first one is from Topology but the second matched one is from Pelican, replace it (repeat this process)
 					if len(originAds) == 0 {
-						originAds = append(originAds, serverAd)
+						originAds = append(originAds, ad.ServerAd)
 					} else {
-						if originAds[len(originAds)-1].FromTopology == serverAd.FromTopology {
-							originAds = append(originAds, serverAd)
-						} else if !serverAd.FromTopology {
+						if originAds[len(originAds)-1].FromTopology == ad.FromTopology {
+							originAds = append(originAds, ad.ServerAd)
+						} else if !ad.FromTopology {
 							// Incoming ad is from Pelican and current last item in originAd is from Topology:
 							// clear originAds and put Pelican server in
 							skippedServers = append(skippedServers, originAds...)
-							originAds = []server_structs.ServerAd{serverAd}
+							originAds = []server_structs.ServerAd{ad.ServerAd}
 						} else {
 							// Incoming ad is from Topology but current last item in originAd is from Pelican: skip
-							skippedServers = append(skippedServers, serverAd)
+							skippedServers = append(skippedServers, ad.ServerAd)
 							continue
 						}
 					}
-				} else if serverAd.Type == server_structs.CacheType {
+				} else if ad.Type == server_structs.CacheType {
 					// For caches, we allow both server from Topology and Pelican to serve the same namespace
-					cacheAds = append(cacheAds, serverAd)
+					cacheAds = append(cacheAds, ad.ServerAd)
 				}
 			}
 		}

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -277,8 +277,6 @@ func TestConfigCacheEviction(t *testing.T) {
 		ctx, cancelFunc := context.WithDeadline(errgrpCtx, time.Now().Add(time.Second*5))
 
 		func() {
-			serverAdMutex.Lock()
-			defer serverAdMutex.Unlock()
 			serverAds.DeleteAll()
 			serverAds.Set(mockPelicanOriginServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
 			healthTestUtilsMutex.Lock()
@@ -303,8 +301,6 @@ func TestConfigCacheEviction(t *testing.T) {
 		}()
 
 		func() {
-			serverAdMutex.Lock()
-			defer serverAdMutex.Unlock()
 			serverAds.Delete(mockPelicanOriginServerAd) // This should call onEviction handler and close the context
 
 			require.False(t, serverAds.Has(mockPelicanOriginServerAd), "serverAds didn't delete originAd")
@@ -340,8 +336,6 @@ func TestServerAdsCacheEviction(t *testing.T) {
 		cancelChan := make(chan int)
 
 		func() {
-			serverAdMutex.Lock()
-			defer serverAdMutex.Unlock()
 			serverAds.DeleteAll()
 
 			serverAds.Set(mockServerAd, []server_structs.NamespaceAdV2{}, time.Second*2)

--- a/director/director.go
+++ b/director/director.go
@@ -792,8 +792,6 @@ func discoverOriginCache(ctx *gin.Context) {
 		return
 	}
 
-	serverAdMutex.RLock()
-	defer serverAdMutex.RUnlock()
 	serverAds := serverAds.Keys()
 	promDiscoveryRes := make([]PromDiscoveryItem, 0)
 	for _, ad := range serverAds {

--- a/director/director.go
+++ b/director/director.go
@@ -85,7 +85,7 @@ var (
 	healthTestUtils      = make(map[server_structs.ServerAd]*healthTestUtil)
 	healthTestUtilsMutex = sync.RWMutex{}
 
-	originStatUtils      = make(map[url.URL]originStatUtil)
+	originStatUtils      = make(map[string]originStatUtil)
 	originStatUtilsMutex = sync.RWMutex{}
 )
 
@@ -732,7 +732,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 	if sType == server_structs.OriginType {
 		originStatUtilsMutex.Lock()
 		defer originStatUtilsMutex.Unlock()
-		statUtil, ok := originStatUtils[sAd.URL]
+		statUtil, ok := originStatUtils[sAd.URL.String()]
 		if !ok || statUtil.Errgroup == nil {
 			baseCtx, cancel := context.WithCancel(engineCtx)
 			concLimit := param.Director_StatConcurrencyLimit.GetInt()
@@ -743,7 +743,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 				Cancel:   cancel,
 				Context:  baseCtx,
 			}
-			originStatUtils[sAd.URL] = newUtil
+			originStatUtils[sAd.URL.String()] = newUtil
 		}
 	}
 
@@ -792,30 +792,30 @@ func discoverOriginCache(ctx *gin.Context) {
 		return
 	}
 
-	serverAds := serverAds.Keys()
 	promDiscoveryRes := make([]PromDiscoveryItem, 0)
-	for _, ad := range serverAds {
-		if ad.WebURL.String() == "" {
+	for _, ad := range serverAds.Items() {
+		serverAd := ad.Value()
+		if serverAd.WebURL.String() == "" {
 			// Origins and caches fetched from topology can't be scraped as they
 			// don't have a WebURL
 			continue
 		}
 		var auth_url string
-		if ad.AuthURL == (url.URL{}) {
-			auth_url = ad.URL.String()
+		if serverAd.AuthURL == (url.URL{}) {
+			auth_url = serverAd.URL.String()
 		} else {
-			auth_url = ad.AuthURL.String()
+			auth_url = serverAd.AuthURL.String()
 		}
 		promDiscoveryRes = append(promDiscoveryRes, PromDiscoveryItem{
-			Targets: []string{ad.WebURL.Hostname() + ":" + ad.WebURL.Port()},
+			Targets: []string{serverAd.WebURL.Hostname() + ":" + serverAd.WebURL.Port()},
 			Labels: map[string]string{
-				"server_type":     string(ad.Type),
-				"server_name":     ad.Name,
+				"server_type":     string(serverAd.Type),
+				"server_name":     serverAd.Name,
 				"server_auth_url": auth_url,
-				"server_url":      ad.URL.String(),
-				"server_web_url":  ad.WebURL.String(),
-				"server_lat":      fmt.Sprintf("%.4f", ad.Latitude),
-				"server_long":     fmt.Sprintf("%.4f", ad.Longitude),
+				"server_url":      serverAd.URL.String(),
+				"server_web_url":  serverAd.WebURL.String(),
+				"server_lat":      fmt.Sprintf("%.4f", serverAd.Latitude),
+				"server_long":     fmt.Sprintf("%.4f", serverAd.Longitude),
 			},
 		})
 	}

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -32,10 +32,6 @@ import (
 
 // List all namespaces from origins registered at the director
 func listNamespacesFromOrigins() []server_structs.NamespaceAdV2 {
-
-	serverAdMutex.RLock()
-	defer serverAdMutex.RUnlock()
-
 	serverAdItems := serverAds.Items()
 	namespaces := make([]server_structs.NamespaceAdV2, 0, len(serverAdItems))
 	for _, item := range serverAdItems {
@@ -48,8 +44,6 @@ func listNamespacesFromOrigins() []server_structs.NamespaceAdV2 {
 
 // List all serverAds in the cache that matches the serverType array
 func listServerAds(serverTypes []server_structs.ServerType) []server_structs.ServerAd {
-	serverAdMutex.RLock()
-	defer serverAdMutex.RUnlock()
 	ads := make([]server_structs.ServerAd, 0)
 	for _, ad := range serverAds.Keys() {
 		for _, serverType := range serverTypes {
@@ -133,8 +127,6 @@ func ConfigTTLCache(ctx context.Context, egrp *errgroup.Group) {
 	egrp.Go(func() error {
 		<-ctx.Done()
 		log.Info("Gracefully stopping director TTL cache eviction...")
-		serverAdMutex.Lock()
-		defer serverAdMutex.Unlock()
 		serverAds.DeleteAll()
 		serverAds.Stop()
 		namespaceKeys.DeleteAll()

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -35,8 +35,9 @@ func listNamespacesFromOrigins() []server_structs.NamespaceAdV2 {
 	serverAdItems := serverAds.Items()
 	namespaces := make([]server_structs.NamespaceAdV2, 0, len(serverAdItems))
 	for _, item := range serverAdItems {
-		if item.Key().Type == server_structs.OriginType {
-			namespaces = append(namespaces, item.Value()...)
+		ad := item.Value()
+		if ad.Type == server_structs.OriginType {
+			namespaces = append(namespaces, ad.NamespaceAds...)
 		}
 	}
 	return namespaces
@@ -45,10 +46,11 @@ func listNamespacesFromOrigins() []server_structs.NamespaceAdV2 {
 // List all serverAds in the cache that matches the serverType array
 func listServerAds(serverTypes []server_structs.ServerType) []server_structs.ServerAd {
 	ads := make([]server_structs.ServerAd, 0)
-	for _, ad := range serverAds.Keys() {
+	for _, item := range serverAds.Items() {
+		ad := item.Value()
 		for _, serverType := range serverTypes {
 			if ad.Type == serverType {
-				ads = append(ads, ad)
+				ads = append(ads, ad.ServerAd)
 			}
 		}
 	}
@@ -90,35 +92,38 @@ func ConfigTTLCache(ctx context.Context, egrp *errgroup.Group) {
 	go serverAds.Start()
 	go namespaceKeys.Start()
 
-	serverAds.OnEviction(func(ctx context.Context, er ttlcache.EvictionReason, i *ttlcache.Item[server_structs.ServerAd, []server_structs.NamespaceAdV2]) {
+	serverAds.OnEviction(func(ctx context.Context, er ttlcache.EvictionReason, i *ttlcache.Item[string, *server_structs.Advertisement]) {
 		healthTestUtilsMutex.RLock()
 		defer healthTestUtilsMutex.RUnlock()
-		if util, exists := healthTestUtils[i.Key()]; exists {
+		serverAd := i.Value().ServerAd
+		serverUrl := i.Key()
+
+		if util, exists := healthTestUtils[serverAd]; exists {
 			util.Cancel()
 			if util.ErrGrp != nil {
 				err := util.ErrGrp.Wait()
 				if err != nil {
-					log.Debugf("Error from errgroup when evict the registration from TTL cache for %s %s %s", string(i.Key().Type), i.Key().Name, err.Error())
+					log.Debugf("Error from errgroup when evict the registration from TTL cache for %s %s %s", string(serverAd.Type), serverAd.Name, err.Error())
 				} else {
-					log.Debugf("Errgroup successfully emptied at TTL cache eviction for %s %s", string(i.Key().Type), i.Key().Name)
+					log.Debugf("Errgroup successfully emptied at TTL cache eviction for %s %s", string(serverAd.Type), serverAd.Name)
 				}
 			} else {
-				log.Debugf("errgroup is nil when evict the registration from TTL cache for %s %s", string(i.Key().Type), i.Key().Name)
+				log.Debugf("errgroup is nil when evict the registration from TTL cache for %s %s", string(serverAd.Type), serverAd.Name)
 			}
 		} else {
-			log.Debugf("healthTestUtil not found for %s when evicting TTL cache item", i.Key().Name)
+			log.Debugf("healthTestUtil not found for %s when evicting TTL cache item", serverAd.Name)
 		}
 
-		if i.Key().Type == server_structs.OriginType {
+		if serverAd.Type == server_structs.OriginType {
 			originStatUtilsMutex.Lock()
 			defer originStatUtilsMutex.Unlock()
-			statUtil, ok := originStatUtils[i.Key().URL]
+			statUtil, ok := originStatUtils[serverUrl]
 			if ok {
 				statUtil.Cancel()
 				if err := statUtil.Errgroup.Wait(); err != nil {
-					log.Info(fmt.Sprintf("Error happened when stopping origin %q stat goroutine group: %v", i.Key().Name, err))
+					log.Info(fmt.Sprintf("Error happened when stopping origin %q stat goroutine group: %v", serverAd.Name, err))
 				}
-				delete(originStatUtils, i.Key().URL)
+				delete(originStatUtils, serverUrl)
 			}
 		}
 	})

--- a/director/director_api_test.go
+++ b/director/director_api_test.go
@@ -80,8 +80,6 @@ func namespaceAdContainsPath(ns []server_structs.NamespaceAdV2, path string) boo
 
 func TestListNamespaces(t *testing.T) {
 	setup := func() {
-		serverAdMutex.Lock()
-		defer serverAdMutex.Unlock()
 		serverAds.DeleteAll()
 	}
 
@@ -140,8 +138,6 @@ func TestListServerAds(t *testing.T) {
 
 	t.Run("empty-cache", func(t *testing.T) {
 		func() {
-			serverAdMutex.Lock()
-			defer serverAdMutex.Unlock()
 			serverAds.DeleteAll()
 		}()
 		ads := listServerAds([]server_structs.ServerType{server_structs.OriginType, server_structs.CacheType})
@@ -150,8 +146,6 @@ func TestListServerAds(t *testing.T) {
 
 	t.Run("get-by-server-type", func(t *testing.T) {
 		func() {
-			serverAdMutex.Lock()
-			defer serverAdMutex.Unlock()
 			serverAds.DeleteAll()
 		}()
 		serverAds.Set(mockOriginServerAd, []server_structs.NamespaceAdV2{}, ttlcache.DefaultTTL)

--- a/director/director_api_test.go
+++ b/director/director_api_test.go
@@ -31,7 +31,7 @@ import (
 
 var mockOriginServerAd server_structs.ServerAd = server_structs.ServerAd{
 	Name:      "test-origin-server",
-	URL:       url.URL{},
+	URL:       url.URL{Host: "origin.com", Scheme: "https"},
 	Type:      server_structs.OriginType,
 	Latitude:  123.05,
 	Longitude: 456.78,
@@ -39,7 +39,7 @@ var mockOriginServerAd server_structs.ServerAd = server_structs.ServerAd{
 
 var mockCacheServerAd server_structs.ServerAd = server_structs.ServerAd{
 	Name:      "test-cache-server",
-	URL:       url.URL{},
+	URL:       url.URL{Host: "cache.com", Scheme: "https"},
 	Type:      server_structs.CacheType,
 	Latitude:  45.67,
 	Longitude: 123.05,
@@ -92,7 +92,10 @@ func TestListNamespaces(t *testing.T) {
 	})
 	t.Run("one-origin-namespace-entry", func(t *testing.T) {
 		setup()
-		serverAds.Set(mockOriginServerAd, mockNamespaceAds(1, "origin1"), ttlcache.DefaultTTL)
+		serverAds.Set(mockOriginServerAd.URL.String(), &server_structs.Advertisement{
+			ServerAd:     mockOriginServerAd,
+			NamespaceAds: mockNamespaceAds(1, "origin1"),
+		}, ttlcache.DefaultTTL)
 		ns := listNamespacesFromOrigins()
 
 		// Only one entry added
@@ -101,7 +104,10 @@ func TestListNamespaces(t *testing.T) {
 	})
 	t.Run("multiple-origin-namespace-entries-from-same-origin", func(t *testing.T) {
 		setup()
-		serverAds.Set(mockOriginServerAd, mockNamespaceAds(10, "origin1"), ttlcache.DefaultTTL)
+		serverAds.Set(mockOriginServerAd.URL.String(), &server_structs.Advertisement{
+			ServerAd:     mockOriginServerAd,
+			NamespaceAds: mockNamespaceAds(10, "origin1"),
+		}, ttlcache.DefaultTTL)
 		ns := listNamespacesFromOrigins()
 
 		assert.Equal(t, 10, len(ns), "List has length not equal to 10 for namespace cache with 10 entries.")
@@ -110,23 +116,31 @@ func TestListNamespaces(t *testing.T) {
 	t.Run("multiple-origin-namespace-entries-from-different-origins", func(t *testing.T) {
 		setup()
 
-		serverAds.Set(mockOriginServerAd, mockNamespaceAds(10, "origin1"), ttlcache.DefaultTTL)
-
+		serverAds.Set(mockOriginServerAd.URL.String(), &server_structs.Advertisement{
+			ServerAd:     mockOriginServerAd,
+			NamespaceAds: mockNamespaceAds(10, "origin1"),
+		}, ttlcache.DefaultTTL)
 		// change the name field of serverAD as same name will cause cache to merge
-		oldServerName := mockOriginServerAd.Name
-		mockOriginServerAd.Name = "test-origin-server-2"
+		oldServerUrl := mockOriginServerAd.URL
+		mockOriginServerAd.URL.Host = "origin2.com"
 
-		serverAds.Set(mockOriginServerAd, mockNamespaceAds(10, "origin2"), ttlcache.DefaultTTL)
+		serverAds.Set(mockOriginServerAd.URL.String(), &server_structs.Advertisement{
+			ServerAd:     mockOriginServerAd,
+			NamespaceAds: mockNamespaceAds(10, "origin2"),
+		}, ttlcache.DefaultTTL)
 		ns := listNamespacesFromOrigins()
 
 		assert.Equal(t, 20, len(ns), "List has length not equal to 10 for namespace cache with 10 entries.")
 		assert.True(t, namespaceAdContainsPath(ns, mockPathPreix+"origin1/"+fmt.Sprint(5)), "Returned namespace path does not match what's added")
 		assert.True(t, namespaceAdContainsPath(ns, mockPathPreix+"origin2/"+fmt.Sprint(9)), "Returned namespace path does not match what's added")
-		mockOriginServerAd.Name = oldServerName
+		mockOriginServerAd.URL = oldServerUrl
 	})
 	t.Run("one-cache-namespace-entry", func(t *testing.T) {
 		setup()
-		serverAds.Set(mockCacheServerAd, mockNamespaceAds(1, "cache1"), ttlcache.DefaultTTL)
+		serverAds.Set(mockCacheServerAd.URL.String(), &server_structs.Advertisement{
+			ServerAd:     mockCacheServerAd,
+			NamespaceAds: mockNamespaceAds(1, "cache1"),
+		}, ttlcache.DefaultTTL)
 		ns := listNamespacesFromOrigins()
 
 		// Should not show namespace from cache server
@@ -148,8 +162,16 @@ func TestListServerAds(t *testing.T) {
 		func() {
 			serverAds.DeleteAll()
 		}()
-		serverAds.Set(mockOriginServerAd, []server_structs.NamespaceAdV2{}, ttlcache.DefaultTTL)
-		serverAds.Set(mockCacheServerAd, []server_structs.NamespaceAdV2{}, ttlcache.DefaultTTL)
+		serverAds.Set(mockOriginServerAd.URL.String(),
+			&server_structs.Advertisement{
+				ServerAd:     mockOriginServerAd,
+				NamespaceAds: []server_structs.NamespaceAdV2{},
+			}, ttlcache.DefaultTTL)
+		serverAds.Set(mockCacheServerAd.URL.String(),
+			&server_structs.Advertisement{
+				ServerAd:     mockCacheServerAd,
+				NamespaceAds: []server_structs.NamespaceAdV2{}},
+			ttlcache.DefaultTTL)
 		adsAll := listServerAds([]server_structs.ServerType{server_structs.OriginType, server_structs.CacheType})
 		assert.Equal(t, 2, len(adsAll))
 

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -248,8 +248,6 @@ func TestDirectorRegistration(t *testing.T) {
 	}
 
 	teardown := func() {
-		serverAdMutex.Lock()
-		defer serverAdMutex.Unlock()
 		serverAds.DeleteAll()
 		namespaceKeys.DeleteAll()
 	}
@@ -781,15 +779,11 @@ func TestDiscoverOriginCache(t *testing.T) {
 			t.Fatalf("Could not make a GET request: %v", err)
 		}
 
-		func() {
-			serverAdMutex.Lock()
-			defer serverAdMutex.Unlock()
-			serverAds.DeleteAll()
-			serverAds.Set(mockPelicanOriginServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
-			// Server fetched from topology should not be present in SD response
-			serverAds.Set(mockTopoOriginServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
-			serverAds.Set(mockCacheServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
-		}()
+		serverAds.DeleteAll()
+		serverAds.Set(mockPelicanOriginServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
+		// Server fetched from topology should not be present in SD response
+		serverAds.Set(mockTopoOriginServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
+		serverAds.Set(mockCacheServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
 
 		expectedRes := []PromDiscoveryItem{{
 			Targets: []string{mockCacheServerAd.WebURL.Hostname() + ":" + mockCacheServerAd.WebURL.Port()},
@@ -835,17 +829,13 @@ func TestDiscoverOriginCache(t *testing.T) {
 			t.Fatalf("Could not make a GET request: %v", err)
 		}
 
-		func() {
-			serverAdMutex.Lock()
-			defer serverAdMutex.Unlock()
-			serverAds.DeleteAll()
-			// Add multiple same serverAds
-			serverAds.Set(mockPelicanOriginServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
-			serverAds.Set(mockPelicanOriginServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
-			serverAds.Set(mockPelicanOriginServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
-			// Server fetched from topology should not be present in SD response
-			serverAds.Set(mockTopoOriginServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
-		}()
+		serverAds.DeleteAll()
+		// Add multiple same serverAds
+		serverAds.Set(mockPelicanOriginServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
+		serverAds.Set(mockPelicanOriginServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
+		serverAds.Set(mockPelicanOriginServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
+		// Server fetched from topology should not be present in SD response
+		serverAds.Set(mockTopoOriginServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
 
 		expectedRes := []PromDiscoveryItem{{
 			Targets: []string{mockPelicanOriginServerAd.WebURL.Hostname() + ":" + mockPelicanOriginServerAd.WebURL.Port()},

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -427,8 +427,8 @@ func TestDirectorRegistration(t *testing.T) {
 		r.ServeHTTP(w, c.Request)
 
 		assert.Equal(t, 200, w.Result().StatusCode, "Expected status code of 200")
-		assert.Equal(t, 1, len(serverAds.Keys()), "Origin fail to register at serverAds")
-		assert.Equal(t, "https://localhost:8844", serverAds.Keys()[0].WebURL.String(), "WebURL in serverAds does not match data in origin registration request")
+		assert.NotNil(t, serverAds.Get("https://or-url.org"), "Origin fail to register at serverAds")
+		assert.Equal(t, "https://localhost:8844", serverAds.Get("https://or-url.org").Value().WebURL.String(), "WebURL in serverAds does not match data in origin registration request")
 		teardown()
 	})
 
@@ -442,7 +442,7 @@ func TestDirectorRegistration(t *testing.T) {
 		isurl := url.URL{}
 		isurl.Path = ts.URL
 
-		ad := server_structs.OriginAdvertiseV2{DataURL: "https://or-url.org", WebURL: "https://localhost:8844", Namespaces: []server_structs.NamespaceAdV2{{
+		ad := server_structs.OriginAdvertiseV2{DataURL: "https://data-url.org", WebURL: "https://localhost:8844", Namespaces: []server_structs.NamespaceAdV2{{
 			Path:   "/foo/bar",
 			Issuer: []server_structs.TokenIssuer{{IssuerUrl: isurl}},
 		}}}
@@ -455,8 +455,8 @@ func TestDirectorRegistration(t *testing.T) {
 		r.ServeHTTP(w, c.Request)
 
 		assert.Equal(t, 200, w.Result().StatusCode, "Expected status code of 200")
-		assert.Equal(t, 1, len(serverAds.Keys()), "Origin fail to register at serverAds")
-		assert.Equal(t, "https://localhost:8844", serverAds.Keys()[0].WebURL.String(), "WebURL in serverAds does not match data in origin registration request")
+		assert.NotNil(t, serverAds.Get("https://data-url.org"), "Origin fail to register at serverAds")
+		assert.Equal(t, "https://localhost:8844", serverAds.Get("https://data-url.org").Value().WebURL.String(), "WebURL in serverAds does not match data in origin registration request")
 		teardown()
 	})
 
@@ -481,8 +481,8 @@ func TestDirectorRegistration(t *testing.T) {
 		r.ServeHTTP(w, c.Request)
 
 		assert.Equal(t, 200, w.Result().StatusCode, "Expected status code of 200")
-		assert.Equal(t, 1, len(serverAds.Keys()), "Origin fail to register at serverAds")
-		assert.Equal(t, "", serverAds.Keys()[0].WebURL.String(), "WebURL in serverAds isn't empty with no WebURL provided in registration")
+		assert.NotNil(t, 1, serverAds.Get("https://or-url.org"), "Origin fail to register at serverAds")
+		assert.Equal(t, "", serverAds.Get("https://or-url.org").Value().WebURL.String(), "WebURL in serverAds isn't empty with no WebURL provided in registration")
 		teardown()
 	})
 
@@ -507,8 +507,8 @@ func TestDirectorRegistration(t *testing.T) {
 		r.ServeHTTP(w, c.Request)
 
 		assert.Equal(t, 200, w.Result().StatusCode, "Expected status code of 200")
-		assert.Equal(t, 1, len(serverAds.Keys()), "Origin fail to register at serverAds")
-		assert.Equal(t, "", serverAds.Keys()[0].WebURL.String(), "WebURL in serverAds isn't empty with no WebURL provided in registration")
+		assert.NotNil(t, serverAds.Get("https://or-url.org"), "Origin fail to register at serverAds")
+		assert.Equal(t, "", serverAds.Get("https://or-url.org").Value().WebURL.String(), "WebURL in serverAds isn't empty with no WebURL provided in registration")
 		teardown()
 	})
 
@@ -780,10 +780,19 @@ func TestDiscoverOriginCache(t *testing.T) {
 		}
 
 		serverAds.DeleteAll()
-		serverAds.Set(mockPelicanOriginServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
+		serverAds.Set(mockPelicanOriginServerAd.URL.String(), &server_structs.Advertisement{
+			ServerAd:     mockPelicanOriginServerAd,
+			NamespaceAds: []server_structs.NamespaceAdV2{mockNamespaceAd},
+		}, ttlcache.DefaultTTL)
 		// Server fetched from topology should not be present in SD response
-		serverAds.Set(mockTopoOriginServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
-		serverAds.Set(mockCacheServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
+		serverAds.Set(mockTopoOriginServerAd.URL.String(), &server_structs.Advertisement{
+			ServerAd:     mockTopoOriginServerAd,
+			NamespaceAds: []server_structs.NamespaceAdV2{mockNamespaceAd},
+		}, ttlcache.DefaultTTL)
+		serverAds.Set(mockCacheServerAd.URL.String(), &server_structs.Advertisement{
+			ServerAd:     mockCacheServerAd,
+			NamespaceAds: []server_structs.NamespaceAdV2{mockNamespaceAd},
+		}, ttlcache.DefaultTTL)
 
 		expectedRes := []PromDiscoveryItem{{
 			Targets: []string{mockCacheServerAd.WebURL.Hostname() + ":" + mockCacheServerAd.WebURL.Port()},
@@ -831,11 +840,23 @@ func TestDiscoverOriginCache(t *testing.T) {
 
 		serverAds.DeleteAll()
 		// Add multiple same serverAds
-		serverAds.Set(mockPelicanOriginServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
-		serverAds.Set(mockPelicanOriginServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
-		serverAds.Set(mockPelicanOriginServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
+		serverAds.Set(mockPelicanOriginServerAd.URL.String(), &server_structs.Advertisement{
+			ServerAd:     mockPelicanOriginServerAd,
+			NamespaceAds: []server_structs.NamespaceAdV2{mockNamespaceAd},
+		}, ttlcache.DefaultTTL)
+		serverAds.Set(mockPelicanOriginServerAd.URL.String(), &server_structs.Advertisement{
+			ServerAd:     mockPelicanOriginServerAd,
+			NamespaceAds: []server_structs.NamespaceAdV2{mockNamespaceAd},
+		}, ttlcache.DefaultTTL)
+		serverAds.Set(mockPelicanOriginServerAd.URL.String(), &server_structs.Advertisement{
+			ServerAd:     mockPelicanOriginServerAd,
+			NamespaceAds: []server_structs.NamespaceAdV2{mockNamespaceAd},
+		}, ttlcache.DefaultTTL)
 		// Server fetched from topology should not be present in SD response
-		serverAds.Set(mockTopoOriginServerAd, []server_structs.NamespaceAdV2{mockNamespaceAd}, ttlcache.DefaultTTL)
+		serverAds.Set(mockTopoOriginServerAd.URL.String(), &server_structs.Advertisement{
+			ServerAd:     mockTopoOriginServerAd,
+			NamespaceAds: []server_structs.NamespaceAdV2{mockNamespaceAd},
+		}, ttlcache.DefaultTTL)
 
 		expectedRes := []PromDiscoveryItem{{
 			Targets: []string{mockPelicanOriginServerAd.WebURL.Hostname() + ":" + mockPelicanOriginServerAd.WebURL.Port()},

--- a/director/director_ui_test.go
+++ b/director/director_ui_test.go
@@ -35,15 +35,11 @@ func TestListServers(t *testing.T) {
 
 	router.GET("/servers", listServers)
 
-	func() {
-		serverAdMutex.Lock()
-		defer serverAdMutex.Unlock()
-		serverAds.DeleteAll()
-		serverAds.Set(mockOriginServerAd, mockNamespaceAds(5, "origin1"), ttlcache.DefaultTTL)
-		serverAds.Set(mockCacheServerAd, mockNamespaceAds(4, "cache1"), ttlcache.DefaultTTL)
-		require.True(t, serverAds.Has(mockOriginServerAd))
-		require.True(t, serverAds.Has(mockCacheServerAd))
-	}()
+	serverAds.DeleteAll()
+	serverAds.Set(mockOriginServerAd, mockNamespaceAds(5, "origin1"), ttlcache.DefaultTTL)
+	serverAds.Set(mockCacheServerAd, mockNamespaceAds(4, "cache1"), ttlcache.DefaultTTL)
+	require.True(t, serverAds.Has(mockOriginServerAd))
+	require.True(t, serverAds.Has(mockCacheServerAd))
 
 	mocklistOriginRes := listServerResponse{
 		Name:        mockOriginServerAd.Name,

--- a/director/director_ui_test.go
+++ b/director/director_ui_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jellydator/ttlcache/v3"
+	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,10 +37,17 @@ func TestListServers(t *testing.T) {
 	router.GET("/servers", listServers)
 
 	serverAds.DeleteAll()
-	serverAds.Set(mockOriginServerAd, mockNamespaceAds(5, "origin1"), ttlcache.DefaultTTL)
-	serverAds.Set(mockCacheServerAd, mockNamespaceAds(4, "cache1"), ttlcache.DefaultTTL)
-	require.True(t, serverAds.Has(mockOriginServerAd))
-	require.True(t, serverAds.Has(mockCacheServerAd))
+	serverAds.Set(mockOriginServerAd.URL.String(),
+		&server_structs.Advertisement{
+			ServerAd:     mockOriginServerAd,
+			NamespaceAds: mockNamespaceAds(5, "origin1"),
+		}, ttlcache.DefaultTTL)
+	serverAds.Set(mockCacheServerAd.URL.String(), &server_structs.Advertisement{
+		ServerAd:     mockCacheServerAd,
+		NamespaceAds: mockNamespaceAds(4, "cache1"),
+	}, ttlcache.DefaultTTL)
+	require.True(t, serverAds.Has(mockOriginServerAd.URL.String()))
+	require.True(t, serverAds.Has(mockCacheServerAd.URL.String()))
 
 	mocklistOriginRes := listServerResponse{
 		Name:        mockOriginServerAd.Name,

--- a/director/sort.go
+++ b/director/sort.go
@@ -195,8 +195,8 @@ func sortServerAdsByIP(addr netip.Addr, ads []server_structs.ServerAd) ([]server
 // Sort a list of ServerAds with the following rule:
 // * if a ServerAds has FromTopology = true, then it will be moved to the end of the list
 // * if two ServerAds has the SAME FromTopology value (both true or false), then
-func sortServerAdsByTopo(ads []server_structs.ServerAd) []server_structs.ServerAd {
-	slices.SortStableFunc(ads, func(a, b server_structs.ServerAd) int {
+func sortServerAdsByTopo(ads []*server_structs.Advertisement) []*server_structs.Advertisement {
+	slices.SortStableFunc(ads, func(a, b *server_structs.Advertisement) int {
 		if a.FromTopology && !b.FromTopology {
 			return 1
 		} else if !a.FromTopology && b.FromTopology {

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -129,33 +129,45 @@ func TestCheckOverrides(t *testing.T) {
 }
 
 func TestSortServerAdsByTopo(t *testing.T) {
-	mock1 := server_structs.ServerAd{
-		FromTopology: true,
-		Name:         "alpha",
+	mock1 := server_structs.Advertisement{
+		ServerAd: server_structs.ServerAd{
+			FromTopology: true,
+			Name:         "alpha",
+		},
 	}
-	mock2 := server_structs.ServerAd{
-		FromTopology: true,
-		Name:         "bravo",
+	mock2 := server_structs.Advertisement{
+		ServerAd: server_structs.ServerAd{
+			FromTopology: true,
+			Name:         "bravo",
+		},
 	}
-	mock3 := server_structs.ServerAd{
-		FromTopology: true,
-		Name:         "charlie",
+	mock3 := server_structs.Advertisement{
+		ServerAd: server_structs.ServerAd{
+			FromTopology: true,
+			Name:         "charlie",
+		},
 	}
-	mock4 := server_structs.ServerAd{
-		FromTopology: false,
-		Name:         "alpha",
+	mock4 := server_structs.Advertisement{
+		ServerAd: server_structs.ServerAd{
+			FromTopology: false,
+			Name:         "alpha",
+		},
 	}
-	mock5 := server_structs.ServerAd{
-		FromTopology: false,
-		Name:         "bravo",
+	mock5 := server_structs.Advertisement{
+		ServerAd: server_structs.ServerAd{
+			FromTopology: false,
+			Name:         "bravo",
+		},
 	}
-	mock6 := server_structs.ServerAd{
-		FromTopology: false,
-		Name:         "charlie",
+	mock6 := server_structs.Advertisement{
+		ServerAd: server_structs.ServerAd{
+			FromTopology: false,
+			Name:         "charlie",
+		},
 	}
 
-	randomList := []server_structs.ServerAd{mock6, mock1, mock2, mock4, mock5, mock3}
-	expectedList := []server_structs.ServerAd{mock4, mock5, mock6, mock1, mock2, mock3}
+	randomList := []*server_structs.Advertisement{&mock6, &mock1, &mock2, &mock4, &mock5, &mock3}
+	expectedList := []*server_structs.Advertisement{&mock4, &mock5, &mock6, &mock1, &mock2, &mock3}
 
 	sortedList := sortServerAdsByTopo(randomList)
 

--- a/director/stat.go
+++ b/director/stat.go
@@ -188,7 +188,7 @@ func (stat *ObjectStat) queryOriginsForObject(objectName string, cancelContext c
 	defer originStatUtilsMutex.RUnlock()
 
 	for _, originAd := range originAds {
-		originUtil, ok := originStatUtils[originAd.URL]
+		originUtil, ok := originStatUtils[originAd.URL.String()]
 		if !ok {
 			numTotalReq += 1
 			log.Warningf("Origin %q is missing data for stat call, skip querying...", originAd.Name)

--- a/director/stat_test.go
+++ b/director/stat_test.go
@@ -54,15 +54,9 @@ func TestQueryOriginsForObject(t *testing.T) {
 	// The OnEviction function is added to serverAds, which will clear deleted cache item
 	// but will have dead-lock for our test cases. Bypass the onEviction function
 	// by re-init serverAds
-	func() {
-		serverAdMutex.Lock()
-		defer serverAdMutex.Unlock()
-		serverAds = ttlcache.New[server_structs.ServerAd, []server_structs.NamespaceAdV2](ttlcache.WithTTL[server_structs.ServerAd, []server_structs.NamespaceAdV2](15 * time.Minute))
-	}()
+	serverAds = ttlcache.New[server_structs.ServerAd, []server_structs.NamespaceAdV2](ttlcache.WithTTL[server_structs.ServerAd, []server_structs.NamespaceAdV2](15 * time.Minute))
 
 	mockTTLCache := func() {
-		serverAdMutex.Lock()
-		defer serverAdMutex.Unlock()
 		mockServerAd1 := server_structs.ServerAd{Name: "origin1", URL: url.URL{Host: "example1.com", Scheme: "https"}, Type: server_structs.OriginType}
 		mockServerAd2 := server_structs.ServerAd{Name: "origin2", URL: url.URL{Host: "example2.com", Scheme: "https"}, Type: server_structs.OriginType}
 		mockServerAd3 := server_structs.ServerAd{Name: "origin3", URL: url.URL{Host: "example3.com", Scheme: "https"}, Type: server_structs.OriginType}
@@ -82,8 +76,6 @@ func TestQueryOriginsForObject(t *testing.T) {
 	}
 
 	cleanupMock := func() {
-		serverAdMutex.Lock()
-		defer serverAdMutex.Unlock()
 		originStatUtilsMutex.Lock()
 		defer originStatUtilsMutex.Unlock()
 		serverAds.DeleteAll()
@@ -93,8 +85,6 @@ func TestQueryOriginsForObject(t *testing.T) {
 	}
 
 	initMockStatUtils := func() {
-		serverAdMutex.RLock()
-		defer serverAdMutex.RUnlock()
 		originStatUtilsMutex.Lock()
 		defer originStatUtilsMutex.Unlock()
 

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -80,6 +80,12 @@ type (
 		FromTopology bool       `json:"from_topology"`
 	}
 
+	// The struct holding a server's advertisement (including ServerAd and NamespaceAd)
+	Advertisement struct {
+		ServerAd
+		NamespaceAds []NamespaceAdV2
+	}
+
 	ServerType   string
 	StrategyType string
 


### PR DESCRIPTION
Closes #870 

This PR also removed the mutex locks we used for TTL cache as TTL cache is thread-safe.