### PR TITLE
NEAREST_CACHE preprend cache list when specified

### DIFF
--- a/client/main_test.go
+++ b/client/main_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/mock"
@@ -81,7 +82,7 @@ func TestGetCachesFromNamespace(t *testing.T) {
 	t.Run("testNoPreferredCache", func(t *testing.T) {
 		caches, err := getCachesFromNamespace(namespace, true, nil)
 		assert.NoError(t, err)
-		assert.Len(t, caches, 3)
+		require.Len(t, caches, 3)
 		assert.Equal(t, "https://some/cache/0", caches[0].(namespaces.DirectorCache).EndpointUrl)
 		assert.Equal(t, "https://some/cache/1", caches[1].(namespaces.DirectorCache).EndpointUrl)
 		assert.Equal(t, "https://some/cache/2", caches[2].(namespaces.DirectorCache).EndpointUrl)
@@ -96,13 +97,53 @@ func TestGetCachesFromNamespace(t *testing.T) {
 		assert.Contains(t, err.Error(), "Preferred cache was specified as an empty string")
 	})
 
-	// Test that the list of caches we get back has more than just the preferred cache when it is specified with a "+" at the end
-	t.Run("testPreferredCachePrepend", func(t *testing.T) {
-		preferredCacheURL, _ := url.Parse("https://I/Like/This/Cache/The/Most+")
-		preferredCacheList := []*url.URL{preferredCacheURL}
+	// Test we work with multiple preferred caches
+	t.Run("testMultiplePreferredCaches", func(t *testing.T) {
+		preferredCache1, _ := url.Parse("https://I/like/this/cache")
+		preferredCache2, _ := url.Parse("https://I/like/this/cache/too")
+		preferredCacheList := []*url.URL{preferredCache1, preferredCache2}
 		caches, err := getCachesFromNamespace(namespace, true, preferredCacheList)
 		assert.NoError(t, err)
-		assert.Len(t, caches, 4)
+		require.Len(t, caches, 2)
+		assert.Equal(t, "https://I/like/this/cache", caches[0].(namespaces.DirectorCache).EndpointUrl)
+		assert.Equal(t, "https://I/like/this/cache/too", caches[1].(namespaces.DirectorCache).EndpointUrl)
+	})
+
+	// Test our prepend works with multiple preferred caches
+	t.Run("testMutliPreferredCachesPrepend", func(t *testing.T) {
+		preferredCache1, _ := url.Parse("https://I/like/this/cache")
+		preferredCache2, _ := url.Parse("https://I/like/this/cache/too")
+		preferredCache3, _ := url.Parse("+")
+		preferredCacheList := []*url.URL{preferredCache1, preferredCache2, preferredCache3}
+		caches, err := getCachesFromNamespace(namespace, true, preferredCacheList)
+		assert.NoError(t, err)
+		require.Len(t, caches, 5)
+		assert.Equal(t, "https://I/like/this/cache", caches[0].(namespaces.DirectorCache).EndpointUrl)
+		assert.Equal(t, "https://I/like/this/cache/too", caches[1].(namespaces.DirectorCache).EndpointUrl)
+		assert.Equal(t, "https://some/cache/0", caches[2].(namespaces.DirectorCache).EndpointUrl)
+		assert.Equal(t, "https://some/cache/1", caches[3].(namespaces.DirectorCache).EndpointUrl)
+		assert.Equal(t, "https://some/cache/2", caches[4].(namespaces.DirectorCache).EndpointUrl)
+	})
+
+	// Test the function fails if the + character is not at the end of the list
+	t.Run("testPlusNotAtEnd", func(t *testing.T) {
+		preferredCache1, _ := url.Parse("https://I/like/this/cache")
+		preferredCache2, _ := url.Parse("+")
+		preferredCache3, _ := url.Parse("https://I/like/this/cache/too")
+		preferredCacheList := []*url.URL{preferredCache1, preferredCache2, preferredCache3}
+		_, err := getCachesFromNamespace(namespace, true, preferredCacheList)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "The special character '+' must be the last item in the list of preferred caches")
+	})
+
+	// Test that the list of caches we get back has more than just the preferred cache when a + is at the end of the list
+	t.Run("testPreferredCachePrepend", func(t *testing.T) {
+		preferredCacheURL, _ := url.Parse("https://I/Like/This/Cache/The/Most")
+		preferredPlusURL, _ := url.Parse("+")
+		preferredCacheList := []*url.URL{preferredCacheURL, preferredPlusURL}
+		caches, err := getCachesFromNamespace(namespace, true, preferredCacheList)
+		assert.NoError(t, err)
+		require.Len(t, caches, 4)
 		assert.Equal(t, "https://I/Like/This/Cache/The/Most", caches[0].(namespaces.DirectorCache).EndpointUrl)
 		assert.Equal(t, "https://some/cache/0", caches[1].(namespaces.DirectorCache).EndpointUrl)
 		assert.Equal(t, "https://some/cache/1", caches[2].(namespaces.DirectorCache).EndpointUrl)
@@ -115,7 +156,7 @@ func TestGetCachesFromNamespace(t *testing.T) {
 		preferredCacheList := []*url.URL{preferredCacheURL}
 		caches, err := getCachesFromNamespace(namespace, true, preferredCacheList)
 		assert.NoError(t, err)
-		assert.Len(t, caches, 1)
+		require.Len(t, caches, 1)
 		assert.Equal(t, "https://I/Like/This/Cache/The/Most", caches[0].(namespaces.DirectorCache).EndpointUrl)
 	})
 }

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -181,12 +181,15 @@ func copyMain(cmd *cobra.Command, args []string) {
 	}
 	caches := make([]*url.URL, 0, 1)
 	if preferredCache != "" {
-		if preferredCacheURL, err := url.Parse(preferredCache); err != nil {
-			log.Errorf("Unable to parse preferred cache (%s) as URL: %s", preferredCache, err.Error())
-			os.Exit(1)
-		} else {
-			caches = append(caches, preferredCacheURL)
-			log.Debugln("Preferred cache for transfer:", preferredCacheURL)
+		cacheList := strings.Split(preferredCache, ",")
+		for _, cache := range cacheList {
+			if preferredCacheURL, err := url.Parse(cache); err != nil {
+				log.Errorf("Unable to parse preferred cache (%s) as URL: %s", cache, err.Error())
+				os.Exit(1)
+			} else {
+				caches = append(caches, preferredCacheURL)
+				log.Debugln("Preferred cache for transfer:", preferredCacheURL)
+			}
 		}
 	}
 

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/namespaces"
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/utils"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -179,18 +180,11 @@ func copyMain(cmd *cobra.Command, args []string) {
 	} else if cache, _ := cmd.Flags().GetString("cache"); cache != "" {
 		preferredCache = cache
 	}
-	caches := make([]*url.URL, 0, 1)
-	if preferredCache != "" {
-		cacheList := strings.Split(preferredCache, ",")
-		for _, cache := range cacheList {
-			if preferredCacheURL, err := url.Parse(cache); err != nil {
-				log.Errorf("Unable to parse preferred cache (%s) as URL: %s", cache, err.Error())
-				os.Exit(1)
-			} else {
-				caches = append(caches, preferredCacheURL)
-				log.Debugln("Preferred cache for transfer:", preferredCacheURL)
-			}
-		}
+	var caches []*url.URL
+	caches, err = utils.GetPreferredCaches(preferredCache)
+	if err != nil {
+		log.Errorln(err)
+		os.Exit(1)
 	}
 
 	if len(source) > 1 {

--- a/cmd/object_get.go
+++ b/cmd/object_get.go
@@ -21,6 +21,7 @@ package main
 import (
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
@@ -99,12 +100,15 @@ func getMain(cmd *cobra.Command, args []string) {
 	}
 	caches := make([]*url.URL, 0, 1)
 	if preferredCache != "" {
-		if preferredCacheURL, err := url.Parse(preferredCache); err != nil {
-			log.Errorf("Unable to parse preferred cache (%s) as URL: %s", preferredCache, err.Error())
-			os.Exit(1)
-		} else {
-			caches = append(caches, preferredCacheURL)
-			log.Debugln("Preferred cache for transfer:", preferredCacheURL)
+		cacheList := strings.Split(preferredCache, ",")
+		for _, cache := range cacheList {
+			if preferredCacheURL, err := url.Parse(cache); err != nil {
+				log.Errorf("Unable to parse preferred cache (%s) as URL: %s", cache, err.Error())
+				os.Exit(1)
+			} else {
+				caches = append(caches, preferredCacheURL)
+				log.Debugln("Preferred cache for transfer:", preferredCacheURL)
+			}
 		}
 	}
 

--- a/cmd/object_get.go
+++ b/cmd/object_get.go
@@ -21,11 +21,11 @@ package main
 import (
 	"net/url"
 	"os"
-	"strings"
 
 	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/utils"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -98,18 +98,11 @@ func getMain(cmd *cobra.Command, args []string) {
 	} else if cache, _ := cmd.Flags().GetString("cache"); cache != "" {
 		preferredCache = cache
 	}
-	caches := make([]*url.URL, 0, 1)
-	if preferredCache != "" {
-		cacheList := strings.Split(preferredCache, ",")
-		for _, cache := range cacheList {
-			if preferredCacheURL, err := url.Parse(cache); err != nil {
-				log.Errorf("Unable to parse preferred cache (%s) as URL: %s", cache, err.Error())
-				os.Exit(1)
-			} else {
-				caches = append(caches, preferredCacheURL)
-				log.Debugln("Preferred cache for transfer:", preferredCacheURL)
-			}
-		}
+	var caches []*url.URL
+	caches, err = utils.GetPreferredCaches(preferredCache)
+	if err != nil {
+		log.Errorln(err)
+		os.Exit(1)
 	}
 
 	if len(source) > 1 {

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pelicanplatform/pelican/classads"
 	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/utils"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -383,18 +384,12 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 		}
 	}()
 
-	caches := make([]*url.URL, 0, 1)
-	var nearestCacheURL *url.URL
+	// Check for local cache
+	var caches []*url.URL
 	if nearestCache, ok := os.LookupEnv("NEAREST_CACHE"); ok && nearestCache != "" {
-		cacheList := strings.Split(nearestCache, ",")
-		for _, cache := range cacheList {
-			if nearestCacheURL, err = url.Parse(cache); err != nil {
-				err = errors.Wrapf(err, "unable to parse preferred cache (%s) as URL", nearestCacheURL)
-				return
-			} else {
-				caches = append(caches, nearestCacheURL)
-				log.Debugln("Setting nearest cache to", nearestCacheURL.String())
-			}
+		caches, err = utils.GetPreferredCaches(nearestCache)
+		if err != nil {
+			return
 		}
 	}
 

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -384,14 +384,17 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 	}()
 
 	caches := make([]*url.URL, 0, 1)
+	var nearestCacheURL *url.URL
 	if nearestCache, ok := os.LookupEnv("NEAREST_CACHE"); ok && nearestCache != "" {
-		var nearestCacheURL *url.URL
-		if nearestCacheURL, err = url.Parse(nearestCache); err != nil {
-			err = errors.Wrapf(err, "unable to parse preferred cache (%s) as URL", nearestCacheURL)
-			return
-		} else {
-			caches = append(caches, nearestCacheURL)
-			log.Debugln("Setting nearest cache to", nearestCacheURL.String())
+		cacheList := strings.Split(nearestCache, ",")
+		for _, cache := range cacheList {
+			if nearestCacheURL, err = url.Parse(cache); err != nil {
+				err = errors.Wrapf(err, "unable to parse preferred cache (%s) as URL", nearestCacheURL)
+				return
+			} else {
+				caches = append(caches, nearestCacheURL)
+				log.Debugln("Setting nearest cache to", nearestCacheURL.String())
+			}
 		}
 	}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -19,9 +19,12 @@
 package utils
 
 import (
+	"net/url"
 	"strings"
 	"unicode"
 
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -50,4 +53,20 @@ func SnakeCaseToHumanReadable(input string) string {
 		words[i] = cases.Title(language.English).String(word)
 	}
 	return strings.Join(words, " ")
+}
+
+// GetPreferredCaches parses the caches it is given and returns it as a list of url's
+func GetPreferredCaches(preferredCaches string) (caches []*url.URL, err error) {
+	if preferredCaches != "" {
+		cacheList := strings.Split(preferredCaches, ",")
+		for _, cache := range cacheList {
+			if preferredCacheURL, err := url.Parse(cache); err != nil {
+				return nil, errors.Errorf("Unable to parse preferred cache (%s) as URL: %s", cache, err.Error())
+			} else {
+				caches = append(caches, preferredCacheURL)
+				log.Debugln("Preferred cache for transfer:", preferredCacheURL)
+			}
+		}
+	}
+	return
 }


### PR DESCRIPTION
To specify the local cache, users need to set the NEAREST_CACHE env variable. In the old functionality, setting this means we do not look for any other caches and just try to use this "preferred cache". Now, if the specified NEAREST_CACHE has a '+' character at the end of it, it will now append the "normal" list of caches behind the preferred cache in the list of caches to try.