### PR TITLE
Allow net timeouts to be retryable errors

### DIFF
--- a/client/errorAccum.go
+++ b/client/errorAccum.go
@@ -21,6 +21,7 @@ package client
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -172,6 +173,13 @@ func IsRetryable(err error) bool {
 			return false
 		}
 	}
+
+	// If we have a timeout error, we are retryable
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
 	return false
 }
 

--- a/client/errorAccum_test.go
+++ b/client/errorAccum_test.go
@@ -26,6 +26,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Make a mock net timeout error
+type timeoutError struct {
+	msg string
+}
+
+func (e *timeoutError) Error() string   { return e.msg }
+func (e *timeoutError) Timeout() bool   { return true }
+func (e *timeoutError) Temporary() bool { return false }
+
 // TestErrorAccum tests simple adding and removing from the accumulator
 func TestErrorAccum(t *testing.T) {
 	te := NewTransferErrors()
@@ -76,6 +85,10 @@ func TestErrorsRetryableTrue(t *testing.T) {
 	te.resetErrors()
 
 	te.AddError(&allocateMemoryError{})
+	assert.True(t, te.AllErrorsRetryable(), "ErrorsRetryable should be true")
+	te.resetErrors()
+
+	te.AddError(&timeoutError{msg: "test timeout error"})
 	assert.True(t, te.AllErrorsRetryable(), "ErrorsRetryable should be true")
 	te.resetErrors()
 

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -577,6 +577,11 @@ func writeOutfile(err error, resultAds []*classads.ClassAd, outputFile *os.File)
 			resultAd := classads.NewClassAd()
 			resultAd.Set("TransferSuccess", false)
 			resultAd.Set("TransferError", err.Error())
+			if client.ShouldRetry(err) {
+				resultAd.Set("TransferRetryable", true)
+			} else {
+				resultAd.Set("TransferRetryable", false)
+			}
 			resultAds = append(resultAds, resultAd)
 		}
 	}


### PR DESCRIPTION
Adds net timeouts to the list of retryable errors. Also, in the plugin, where we check if we already failed we used to only return TransferError and TransferSuccess, now we return TransferRetryable as well.