### PR TITLE
Fix infinite redirect of UI init page

### DIFF
--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -219,19 +219,22 @@ func handleWebUIAuth(ctx *gin.Context) {
 	user, err := GetUser(ctx)
 
 	// Skip auth check for static files other than html pages
-	if path.Ext(requestPath) != ".html" {
+	if path.Ext(requestPath) != "" && path.Ext(requestPath) != ".html" {
 		ctx.Next()
 		return
 	}
 
 	// Handle initialization. If db is nill, then redirect user to the initialization page
 	if strings.HasPrefix(requestPath, "/initialization") {
-		if db != nil {
+		if db != nil { // Password initialized, redirect away from the init page
 			ctx.Redirect(http.StatusFound, "/view/")
 			ctx.Abort()
 			return
+		} else { // If not init, pass the auth handler and render the page
+			ctx.Next()
+			return
 		}
-	} else if db == nil {
+	} else if db == nil { // For all other paths, if the password is not initialized
 		ctx.Redirect(http.StatusFound, "/view/initialization/code/")
 		ctx.Abort()
 		return

--- a/web_ui/ui_test.go
+++ b/web_ui/ui_test.go
@@ -133,7 +133,7 @@ func TestHandleWebUIAuth(t *testing.T) {
 	route := gin.New()
 	route.GET("/view/*requestPath", handleWebUIAuth, func(ctx *gin.Context) { ctx.Status(200) })
 
-	t.Run("html-redirect-to-init-without-db", func(t *testing.T) {
+	t.Run("redirect-to-init-without-db", func(t *testing.T) {
 		cleanupAuthDB()
 		r := httptest.NewRecorder()
 		req, err := http.NewRequest("GET", "/view/test.html", nil)
@@ -143,7 +143,34 @@ func TestHandleWebUIAuth(t *testing.T) {
 		assert.Equal(t, "/view/initialization/code/", r.Result().Header.Get("Location"))
 	})
 
-	t.Run("html-redirect-to-login-with-db", func(t *testing.T) {
+	t.Run("init-page-no-redirct-without-db", func(t *testing.T) {
+		cleanupAuthDB()
+		r := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/view/initialization/code/", nil)
+		require.NoError(t, err)
+		route.ServeHTTP(r, req)
+
+		assert.Equal(t, http.StatusOK, r.Result().StatusCode)
+
+		r = httptest.NewRecorder()
+		req, err = http.NewRequest("GET", "/view/initialization/password/", nil)
+		require.NoError(t, err)
+		route.ServeHTTP(r, req)
+
+		assert.Equal(t, http.StatusOK, r.Result().StatusCode)
+	})
+
+	t.Run("no-redirect-without-db-on-init-page", func(t *testing.T) {
+		cleanupAuthDB()
+		r := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/view/initialization/code/", nil)
+		require.NoError(t, err)
+		route.ServeHTTP(r, req)
+
+		assert.Equal(t, http.StatusOK, r.Result().StatusCode)
+	})
+
+	t.Run("redirect-to-login-with-db-initialzied", func(t *testing.T) {
 		setupTestAuthDB(t)
 		t.Cleanup(cleanupAuthDB)
 
@@ -153,6 +180,34 @@ func TestHandleWebUIAuth(t *testing.T) {
 		route.ServeHTTP(r, req)
 
 		assert.Equal(t, "/view/login/", r.Result().Header.Get("Location"))
+
+		r = httptest.NewRecorder()
+		req, err = http.NewRequest("GET", "/view/origin/", nil)
+		require.NoError(t, err)
+		route.ServeHTTP(r, req)
+
+		assert.Equal(t, "/view/login/", r.Result().Header.Get("Location"))
+
+		authDB.Store(nil)
+	})
+
+	t.Run("init-page-redirect-to-root-with-db-initialized", func(t *testing.T) {
+		setupTestAuthDB(t)
+		t.Cleanup(cleanupAuthDB)
+
+		r := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/view/initialization/code/", nil)
+		require.NoError(t, err)
+		route.ServeHTTP(r, req)
+
+		assert.Equal(t, "/view/", r.Result().Header.Get("Location"))
+
+		r = httptest.NewRecorder()
+		req, err = http.NewRequest("GET", "/view/initialization/password/", nil)
+		require.NoError(t, err)
+		route.ServeHTTP(r, req)
+
+		assert.Equal(t, "/view/", r.Result().Header.Get("Location"))
 
 		authDB.Store(nil)
 	})


### PR DESCRIPTION
As recently found out in the Denver cache deployment and NSDF S3 origin deployment, the web UI is trapped in an infinite redirect at the server start (not yet initialized with admin password). This PR is to fix this issue.

To test the fix, follow the instructions below:
* Remove your admin password file (backup first): `rm /etc/pelican/server-web-passwd`
* Build and run an origin `./pelican origin serve`
* Go to the admin website at https://localhost:8444/
* You should be redirect to the initialization code page at `/view/initialization/code/`