### PR TITLE
Shim in ability for the director to use load-aware cache redirects

### DIFF
--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -42,6 +42,7 @@ Server:
   UILoginRateLimit: 1
 Director:
   DefaultResponse: cache
+  CacheSortMethod: "distance"
   MinStatResponse: 1
   MaxStatResponse: 1
   StatTimeout: 200ms

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -164,6 +164,7 @@ func TestDirectorRegistration(t *testing.T) {
 	defer ts.Close()
 
 	viper.Set("Federation.RegistryUrl", ts.URL)
+	viper.Set("Director.CacheSortMethod", "distance")
 
 	setupContext := func() (*gin.Context, *gin.Engine, *httptest.ResponseRecorder) {
 		// Setup httptest recorder and context for the the unit test

--- a/director/resources/geoip_overrides.yaml
+++ b/director/resources/geoip_overrides.yaml
@@ -18,6 +18,12 @@
 
 # Configuration options used to test Geo Overrides in sort_test.go
 GeoIPOverrides:
+  # Override for clientIP for sorting tests. This is a UW Madison IP and here we
+  # pin it to UW Madison's coordinates to avoid needing the GeoIP database
+  - IP: "128.104.153.60"
+    Coordinate:
+      Lat: 43.073904
+      Long: -89.384859
   # Valid IPv4
   - IP: "192.168.0.1"
     Coordinate:

--- a/director/sort.go
+++ b/director/sort.go
@@ -209,7 +209,8 @@ func sortServerAdsByIP(addr netip.Addr, ads []server_structs.ServerAd) ([]server
 		case "random":
 			weights[idx] = SwapMap{rand.Float64(), idx}
 		default:
-			return nil, errors.Errorf("Invalid sort method '%s' set in Director.CacheSortMethod", param.Director_CacheSortMethod.GetString())
+			return nil, errors.Errorf("Invalid sort method '%s' set in Director.CacheSortMethod. Valid methods are 'distance',"+
+				"'distanceAndLoad', and 'random.'", param.Director_CacheSortMethod.GetString())
 		}
 	}
 

--- a/director/sort.go
+++ b/director/sort.go
@@ -179,6 +179,7 @@ func getClientLatLong(addr netip.Addr) (coord Coordinate, ok bool) {
 // server IP and client having higher priority
 func sortServerAdsByIP(addr netip.Addr, ads []server_structs.ServerAd) ([]server_structs.ServerAd, error) {
 	// Each entry in weights will map a priority to an index in the original ads slice.
+	// A larger weight is a higher priority.
 	weights := make(SwapMaps, len(ads))
 	sortMethod := param.Director_CacheSortMethod.GetString()
 
@@ -201,7 +202,7 @@ func sortServerAdsByIP(addr netip.Addr, ads []server_structs.ServerAd) ([]server
 			if !ok {
 				weights[idx] = SwapMap{0 - rand.Float64(), idx}
 			} else {
-				// Each server ad has a load value that we can use for sorting
+				// Each server ad will have a load value that we can use for sorting
 				weights[idx] = SwapMap{distanceAndLoadWeight(clientCoord, ad),
 					idx}
 			}
@@ -212,7 +213,7 @@ func sortServerAdsByIP(addr netip.Addr, ads []server_structs.ServerAd) ([]server
 		}
 	}
 
-	// Higher weight = higher priority, so we reverse the sort (which would otherwise default to ascending)
+	// Larger weight = higher priority, so we reverse the sort (which would otherwise default to ascending)
 	sort.Sort(sort.Reverse(weights))
 	resultAds := make([]server_structs.ServerAd, len(ads))
 	for idx, weight := range weights {

--- a/director/sort.go
+++ b/director/sort.go
@@ -57,7 +57,7 @@ var (
 
 type (
 	SwapMap struct {
-		Distance float64
+		Weight float64
 		Index    int
 	}
 
@@ -82,7 +82,7 @@ func (me SwapMaps) Len() int {
 }
 
 func (me SwapMaps) Less(left, right int) bool {
-	return me[left].Distance < me[right].Distance
+	return me[left].Weight < me[right].Weight
 }
 
 func (me SwapMaps) Swap(left, right int) {
@@ -165,29 +165,58 @@ func getLatLong(addr netip.Addr) (lat float64, long float64, err error) {
 	return
 }
 
+func getClientLatLong(addr netip.Addr) (coord Coordinate, ok bool) {
+	var err error
+	coord.Lat, coord.Long, err = getLatLong(addr)
+	ok = (err == nil && !(coord.Lat == 0 && coord.Long == 0))
+	if err != nil {
+		log.Warningf("failed to resolve lat/long for address %s: %v", addr, err)
+	}
+	return
+}
+
 // Sort serverAds based on the IP address of the client with shorter distance between
 // server IP and client having higher priority
 func sortServerAdsByIP(addr netip.Addr, ads []server_structs.ServerAd) ([]server_structs.ServerAd, error) {
-	distances := make(SwapMaps, len(ads))
-	lat, long, err := getLatLong(addr)
-	// If we don't get a valid coordinate set for the incoming address, either because
-	// of an error or the null address, we randomize the output
-	isInvalid := (err != nil || (lat == 0 && long == 0))
+	// Each entry in weights will map a priority to an index in the original ads slice.
+	weights := make(SwapMaps, len(ads))
+	sortMethod := param.Director_CacheSortMethod.GetString()
+
+	// For each ad, we apply the configured sort method to determine a priority weight.
 	for idx, ad := range ads {
-		if isInvalid || (ad.Latitude == 0 && ad.Longitude == 0) {
-			// Unable to compute distances for this server; just do random distances.
-			// Note that valid distances are between 0 and 1, hence (1 + random) is always
-			// going to be sorted after valid distances.
-			distances[idx] = SwapMap{1 + rand.Float64(), idx}
-		} else {
-			distances[idx] = SwapMap{distanceOnSphere(lat, long, ad.Latitude, ad.Longitude),
-				idx}
+		switch sortMethod {
+		case "distance":
+			clientCoord, ok := getClientLatLong(addr)
+			if !ok {
+				// Unable to compute distances for this server; just do random distances.
+				// Below we sort weights in descending order, so we assign negative value here,
+				// causing them to always be at the end of the sorted list.
+				weights[idx] = SwapMap{0 - rand.Float64(), idx}
+			} else {
+				weights[idx] = SwapMap{distanceWeight(clientCoord, ad),
+					idx}
+			}
+		case "distanceAndLoad":
+			clientCoord, ok := getClientLatLong(addr)
+			if !ok {
+				weights[idx] = SwapMap{0 - rand.Float64(), idx}
+			} else {
+				// Each server ad has a load value that we can use for sorting
+				weights[idx] = SwapMap{distanceAndLoadWeight(clientCoord, ad),
+					idx}
+			}
+		case "random":
+			weights[idx] = SwapMap{rand.Float64(), idx}
+		default:
+			return nil, errors.Errorf("Invalid sort method '%s' set in Director.CacheSortMethod", param.Director_CacheSortMethod.GetString())
 		}
 	}
-	sort.Sort(distances)
+
+	// Higher weight = higher priority, so we reverse the sort (which would otherwise default to ascending)
+	sort.Sort(sort.Reverse(weights))
 	resultAds := make([]server_structs.ServerAd, len(ads))
-	for idx, distance := range distances {
-		resultAds[idx] = ads[distance.Index]
+	for idx, weight := range weights {
+		resultAds[idx] = ads[weight.Index]
 	}
 	return resultAds, nil
 }

--- a/director/sort.go
+++ b/director/sort.go
@@ -58,7 +58,7 @@ var (
 type (
 	SwapMap struct {
 		Weight float64
-		Index    int
+		Index  int
 	}
 
 	SwapMaps []SwapMap

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -21,15 +21,19 @@ package director
 import (
 	"bytes"
 	_ "embed"
+	"math/rand"
 	"net"
+	"net/netip"
+	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/pelicanplatform/pelican/server_structs"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/server_structs"
 )
 
 // Geo Override Yaml mockup
@@ -172,4 +176,99 @@ func TestSortServerAdsByTopo(t *testing.T) {
 	sortedList := sortServerAdsByTopo(randomList)
 
 	assert.EqualValues(t, expectedList, sortedList)
+}
+
+func TestSortServerAdsByIP(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(func() {
+		viper.Reset()
+	})
+
+	// A random IP that should geo-resolve to roughly the same location as the Madison server
+	clientIP := netip.MustParseAddr("128.104.153.60")
+	// We need to provide a geo-ip override so that our sorting functions know where this is located
+	viper.SetConfigType("yaml")
+	err := viper.ReadConfig(strings.NewReader(yamlMockup))
+	if err != nil {
+		t.Fatalf("Error reading config: %v", err)
+	}
+
+	// These are listed in order of increasing distance from the clientIP
+	madisonServer := server_structs.ServerAd{
+		Latitude:  43.0753,
+		Longitude: -89.4114,
+	}
+	sdscServer := server_structs.ServerAd{
+		Latitude:  32.8761,
+		Longitude: -117.2318,
+	}
+	bigBenServer := server_structs.ServerAd{
+		Latitude:  51.5103,
+		Longitude: -0.1167,
+	}
+	kremlinServer := server_structs.ServerAd{
+		Latitude:  55.752121,
+		Longitude: 37.617664,
+	}
+	daejeonServer := server_structs.ServerAd{
+		Latitude:  36.3213,
+		Longitude: 127.4200,
+	}
+	mcMurdoServer := server_structs.ServerAd{
+		Latitude:  -77.8500,
+		Longitude: 166.6666,
+	}
+
+	randAds := []server_structs.ServerAd{madisonServer, sdscServer, bigBenServer, kremlinServer,
+		daejeonServer, mcMurdoServer}
+	// Shuffle so that we don't give the sort function an already-sorted slice!
+	rand.Shuffle(len(randAds), func(i, j int) {
+		randAds[i], randAds[j] = randAds[j], randAds[i]
+	})
+
+	t.Run("test-distance-sort", func(t *testing.T) {
+		viper.Set("Director.CacheSortMethod", "distance")
+		expected := []server_structs.ServerAd{madisonServer, sdscServer, bigBenServer, kremlinServer,
+			daejeonServer, mcMurdoServer}
+		sorted, err := sortServerAdsByIP(clientIP, randAds)
+		require.NoError(t, err)
+		assert.EqualValues(t, expected, sorted)
+	})
+
+	t.Run("test-distanceAndLoad-sort", func(t *testing.T) {
+		// For now, this test should return the same ordering as the distance test
+		viper.Set("Director.CacheSortMethod", "distanceAndLoad")
+		expected := []server_structs.ServerAd{madisonServer, sdscServer, bigBenServer, kremlinServer,
+			daejeonServer, mcMurdoServer}
+		sorted, err := sortServerAdsByIP(clientIP, randAds)
+		require.NoError(t, err)
+		assert.EqualValues(t, expected, sorted)
+	})
+
+	t.Run("test-random-sort", func(t *testing.T) {
+		viper.Set("Director.CacheSortMethod", "random")
+
+		var sorted []server_structs.ServerAd
+		var err error
+
+		// We don't expect to get back the sorted slice, but it's possible
+		notExpected := []server_structs.ServerAd{madisonServer, sdscServer, bigBenServer, kremlinServer, daejeonServer,
+			mcMurdoServer}
+
+		// The probability this test fails the first time due to randomly sorting into ascending distances is (1/6!) = 1/720
+		// To mitigate risk of this failing because of that, we'll run the sort 3 times to get a 1/720^3 = 1/373,248,000 chance
+		// of failure. If you run thrice and you still get the distance-sorted slice, you might consider buying a powerball ticket
+		// (1/292,201,338 chance of winning).
+		for i := 0; i < 3; i++ {
+			sorted, err = sortServerAdsByIP(clientIP, randAds)
+			require.NoError(t, err)
+
+			// If the values are not equal, break the loop
+			if !reflect.DeepEqual(notExpected, sorted) {
+				break
+			}
+		}
+
+		assert.NotEqualValues(t, notExpected, sorted)
+	})
 }

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1082,6 +1082,21 @@ type: stringSlice
 default: none
 components: ["director"]
 ---
+name: Director.CacheSortMethod
+description: |+
+  When the director recieves a client request that needs to be redirected to a cache, it will use this method to
+  determine the ordering of the caches. The default method is "distance", which sorts caches by their spherical distance
+  from the client.
+
+  Available methods include:
+  - "distance": Sorts caches by their spherical distance from the client.
+  - "distanceAndLoad": Sorts caches according to both their distance and a calculated load. This is currently a placeholder,
+    and returns the same ordering as "distance".
+  - "random": Sorts caches randomly.
+type: string
+default: distance
+components: ["director"]
+---
 name: Director.OriginResponseHostnames
 description: |+
   A list of virtual hostnames for the director. If a request is sent by the client to one of these hostnames,

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -125,6 +125,7 @@ var (
 	Cache_SentinelLocation = StringParam{"Cache.SentinelLocation"}
 	Cache_Url = StringParam{"Cache.Url"}
 	Cache_XRootDPrefix = StringParam{"Cache.XRootDPrefix"}
+	Director_CacheSortMethod = StringParam{"Director.CacheSortMethod"}
 	Director_DefaultResponse = StringParam{"Director.DefaultResponse"}
 	Director_GeoIPLocation = StringParam{"Director.GeoIPLocation"}
 	Director_MaxMindKeyFile = StringParam{"Director.MaxMindKeyFile"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -57,6 +57,7 @@ type Config struct {
 	Director struct {
 		AdvertisementTTL time.Duration
 		CacheResponseHostnames []string
+		CacheSortMethod string
 		DefaultResponse string
 		EnableBroker bool
 		EnableOIDC bool
@@ -325,6 +326,7 @@ type configWithType struct {
 	Director struct {
 		AdvertisementTTL struct { Type string; Value time.Duration }
 		CacheResponseHostnames struct { Type string; Value []string }
+		CacheSortMethod struct { Type string; Value string }
 		DefaultResponse struct { Type string; Value string }
 		EnableBroker struct { Type string; Value bool }
 		EnableOIDC struct { Type string; Value bool }


### PR DESCRIPTION
Currently, the director blindly redirects clients to the cache nearest to them without any consideration of whether that cache may be overloaded. While we work to make cache load information available in the Director, this adds a "load-aware" load balancing function -- that currently assumes the same load for every cache.

When we have load information for each cache, this new feature should be able to grab that information from the cache's serverAd and do something intelligent with it. For now, I'm assuming load will be from [0,1] where 0 is no load and 1 is the highest.

This commit also makes it a bit easier to develop more load-balancing algorithms by hooking up algorithm selection to a configurable parameter. For testing, we can also randomly sort things.

Closes #1173