### PR TITLE
Use HTTPS when the director is sending clients to Pelican servers

### DIFF
--- a/director/director.go
+++ b/director/director.go
@@ -103,7 +103,10 @@ func getRedirectURL(reqPath string, ad server_structs.ServerAd, requiresAuth boo
 	if requiresAuth {
 		redirectURL.Scheme = "https"
 	} else {
-		redirectURL.Scheme = "http"
+		redirectURL.Scheme = "https"
+		if ad.FromTopology {
+			redirectURL.Scheme = "http"
+		}
 	}
 	redirectURL.Host = serverURL.Host
 	redirectURL.Path = reqPath


### PR DESCRIPTION
Previously, we determined the scheme based on whether the requested object required an authorization token, but all Pelican servers should be HTTPS all of the time. The only time we need to redirect to HTTP is when when the client is fetching a public object from a legacy cache/origin.

Closes #1204 