### PR TITLE
Update S3 plugin in containers to fix segfault

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -82,7 +82,7 @@ ADD https://api.github.com/repos/PelicanPlatform/xrootd-s3-http/git/refs/heads/m
 RUN \
     git clone https://github.com/PelicanPlatform/xrootd-s3-http.git && \
     cd xrootd-s3-http && \
-    git checkout v0.1.1 && \
+    git checkout v0.1.2 && \
     mkdir build && cd build && \
     cmake -DLIB_INSTALL_DIR=/usr/lib64 .. && \
     make install

--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -104,7 +104,7 @@ ADD https://api.github.com/repos/PelicanPlatform/xrootd-s3-http/git/refs/heads/m
 RUN \
     git clone https://github.com/PelicanPlatform/xrootd-s3-http.git && \
     cd xrootd-s3-http && \
-    git checkout v0.1.1 && \
+    git checkout v0.1.2 && \
     mkdir build && cd build && \
     cmake -DLIB_INSTALL_DIR=/usr/lib64 .. && \
     make install


### PR DESCRIPTION
The `v0.1.1` plugin had a snippet of code that wasn't thread safe, but was only triggered in the case of PUTs. That has been fixed/tagged upstream in [this issue](https://github.com/PelicanPlatform/xrootd-s3-http/pull/33).

This PR updates the plugin version used in our containers.

@haoming29, when this is merged we should also patch it into 7.7