### PR TITLE
Bump s3 plugin version for OSX CI test

### DIFF
--- a/github_scripts/osx_install.sh
+++ b/github_scripts/osx_install.sh
@@ -37,9 +37,9 @@ sudo mkdir -p /etc/xrootd/client.plugins.d/
 sudo cp release_dir/etc/xrootd/client.plugins.d/pelican-plugin.conf /etc/xrootd/client.plugins.d/
 popd
 
-git clone --branch v0.1.1 https://github.com/PelicanPlatform/xrootd-s3-http.git
+git clone --branch v0.1.2 https://github.com/PelicanPlatform/xrootd-s3-http.git
 pushd xrootd-s3-http
-git checkout v0.1.1
+git checkout v0.1.2
 mkdir build
 cd build
 cmake .. -GNinja -DCMAKE_INSTALL_PREFIX=$PWD/release_dir


### PR DESCRIPTION
My previous PR missed one place where the S3 version was declared. In a future release cycle, I hope we can centralize this so I don't have to remember the growing list of places that need these updates.