### PR TITLE
Overwrite topology server if there is a Pelican server with the same url

### DIFF
--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -59,17 +59,37 @@ func recordAd(ad server_structs.ServerAd, namespaceAds *[]server_structs.Namespa
 		log.Errorf("The URL of the serverAd %#v is empty. Cannot set the TTL cache.", ad)
 		return
 	}
+	// Since servers from topology always use http, while servers from Pelican always use https
+	// we want to ignore the scheme difference when checking duplicates (only consider hostname:port)
+	rawURL := ad.URL.String() // could be http (topology) or https (Pelican or some topology ones)
+	httpURL := ad.URL.String()
+	httpsURL := ad.URL.String()
+	if strings.HasPrefix(rawURL, "https") {
+		httpURL = "http" + strings.TrimPrefix(rawURL, "https")
+	}
+	if strings.HasPrefix(rawURL, "http://") {
+		httpsURL = "https://" + strings.TrimPrefix(rawURL, "http://")
+	}
+
+	existing := serverAds.Get(httpURL)
+	if existing == nil {
+		existing = serverAds.Get(httpsURL)
+	}
+	if existing == nil {
+		existing = serverAds.Get(rawURL)
+	}
 
 	// There's an existing ad in the cache
-	if existing := serverAds.Get(ad.URL.String()); existing != nil {
+	if existing != nil {
 		if ad.FromTopology && !existing.Value().FromTopology {
 			// if the incoming is from topology but the existing is from Pelican
-			log.Debugf("ServerAd from the topology server %s (url: %s) was ignored. There's an existing Pelican serverAd in the director", ad.Name, ad.URL.String())
+			log.Debugf("The ServerAd generated from topology with name %s and URL %s was ignored because there's already a Pelican ad for this server", ad.Name, ad.URL.String())
 			return
 		}
 		if !ad.FromTopology && existing.Value().FromTopology {
 			// Pelican server will overwrite topology one. We leave a message to let admin know
-			log.Debugf("Existing topology server %s (url: %s) is replaced by the Pelican server %s", existing.Value().Name, existing.Value().URL.String(), ad.Name)
+			log.Debugf("The existing ServerAd generated from topology with name %s and URL %s is replaced by the Pelican server with name %s", existing.Value().Name, existing.Value().URL.String(), ad.Name)
+			serverAds.Delete(existing.Value().URL.String())
 		}
 	}
 

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -380,8 +380,9 @@ func TestRecordAd(t *testing.T) {
 		serverAds.DeleteAll()
 	})
 
-	topologyServerUrl := url.URL{Scheme: "https", Host: "origin.chtc.wisc.edu"}
-	pelicanServerUrl := url.URL{Scheme: "https", Host: "pelican.chtc.wisc.edu"}
+	topologyServerUrl := url.URL{Scheme: "http", Host: "origin.chtc.wisc.edu"} // Topology server URL is always in http
+	pelicanServerUrl := url.URL{Scheme: "https", Host: "origin.chtc.wisc.edu"} // Pelican server URL is always in https
+
 	mockTopology := &server_structs.Advertisement{
 		ServerAd: server_structs.ServerAd{
 			URL:          topologyServerUrl,
@@ -399,13 +400,13 @@ func TestRecordAd(t *testing.T) {
 
 	t.Run("topology-server-added-if-no-duplicate", func(t *testing.T) {
 		recordAd(mockTopology.ServerAd, &mockTopology.NamespaceAds)
-
+		assert.Len(t, serverAds.Items(), 1)
 		assert.True(t, serverAds.Has(topologyServerUrl.String()))
 	})
 
-	t.Run("topology-server-added-if-no-duplicate", func(t *testing.T) {
+	t.Run("pelican-server-added-if-no-duplicate", func(t *testing.T) {
 		recordAd(mockPelican.ServerAd, &mockPelican.NamespaceAds)
-
+		assert.Len(t, serverAds.Items(), 1)
 		assert.True(t, serverAds.Has(pelicanServerUrl.String()))
 	})
 
@@ -413,6 +414,7 @@ func TestRecordAd(t *testing.T) {
 		recordAd(mockTopology.ServerAd, &mockTopology.NamespaceAds)
 		recordAd(mockPelican.ServerAd, &mockPelican.NamespaceAds)
 
+		assert.Len(t, serverAds.Items(), 1)
 		assert.True(t, serverAds.Has(pelicanServerUrl.String()))
 		getAd := serverAds.Get(pelicanServerUrl.String())
 		assert.NotNil(t, getAd)
@@ -423,6 +425,7 @@ func TestRecordAd(t *testing.T) {
 		recordAd(mockPelican.ServerAd, &mockPelican.NamespaceAds)
 		recordAd(mockTopology.ServerAd, &mockTopology.NamespaceAds)
 
+		assert.Len(t, serverAds.Items(), 1)
 		assert.True(t, serverAds.Has(pelicanServerUrl.String()))
 		getAd := serverAds.Get(pelicanServerUrl.String())
 		assert.NotNil(t, getAd)


### PR DESCRIPTION
With the new TTL cache key in place #1186, there can be a case where a server from the topology shares the exact same url as a Pelican server, so there's a "key collision" and the two servers will fight against each other in the cache. This PR sets the rule that, in case of a key collision:
* If the existing server in the cache is a _Pelican_ server, and the incoming server is from the topology, then we ignore the incoming server/
* If the existing server in the cache is a topology server, and the incoming server is from Pelican, then we **overwrite** the existing server by the incoming server