### PR TITLE
`HandleDirectorTestResponse` API returns if the authentication check fails

### DIFF
--- a/registry/registry_validation.go
+++ b/registry/registry_validation.go
@@ -162,7 +162,7 @@ func validateJwks(jwksStr string) (jwk.Key, error) {
 }
 
 // Validates if the instID, the id of the institution, matches institution options
-// provided through Registry.InstitutionsUrl or Registy.Institutions. If both are set,
+// provided through Registry.InstitutionsUrl or Registry.Institutions. If both are set,
 // content of Registry.InstitutionsUrl will be ignored
 func validateInstitution(instID string) (bool, error) {
 	if instID == "" {

--- a/server_utils/monitor.go
+++ b/server_utils/monitor.go
@@ -87,11 +87,12 @@ func HandleDirectorTestResponse(ctx *gin.Context, nChan chan bool) {
 		Issuers: []token.TokenIssuer{token.FederationIssuer},
 		Scopes:  []token_scopes.TokenScope{token_scopes.Pelican_DirectorTestReport},
 	})
-	if !ok {
+	if !ok || err != nil {
 		ctx.JSON(status, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
-			Msg:    err.Error(),
+			Msg:    fmt.Sprint("Failed to verify the token: ", err),
 		})
+		return
 	}
 
 	dt := server_structs.DirectorTestResult{}


### PR DESCRIPTION
Fixes #1219 