### PR TITLE
Migrate OA4MP issuer to use origin's OIDC integration

### DIFF
--- a/client/acquire_token.go
+++ b/client/acquire_token.go
@@ -163,7 +163,7 @@ func AcquireToken(destination *url.URL, namespace namespaces.Namespace, opts con
 		return "", fmt.Errorf("Issuer for prefix %s is unknown", namespace.Path)
 	}
 
-	osdfConfig, err := config.GetConfigContents()
+	osdfConfig, err := config.GetCredentialConfigContents()
 	if err != nil {
 		return "", err
 	}

--- a/client/acquire_token.go
+++ b/client/acquire_token.go
@@ -121,7 +121,7 @@ func RegisterClient(namespace namespaces.Namespace) (*config.PrefixEntry, error)
 		return nil, fmt.Errorf("Issuer %s does not support dynamic client registration", *namespace.CredentialGen.Issuer)
 	}
 
-	drcp := oauth2.DCRPConfig{ClientRegistrationEndpointURL: issuer.RegistrationURL, Metadata: oauth2.Metadata{
+	drcp := oauth2.DCRPConfig{ClientRegistrationEndpointURL: issuer.RegistrationURL, Transport: config.GetTransport(), Metadata: oauth2.Metadata{
 		RedirectURIs:            []string{"https://localhost/osdf-client"},
 		TokenEndpointAuthMethod: "client_secret_basic",
 		GrantTypes:              []string{"refresh_token", "urn:ietf:params:oauth:grant-type:device_code"},

--- a/cmd/config_mgr.go
+++ b/cmd/config_mgr.go
@@ -37,11 +37,14 @@ var (
 	rootConfigCmd = &cobra.Command{
 		Use:   "credentials",
 		Short: "Interact with the credential configuration file",
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			return config.InitClient()
+		},
 	}
 )
 
 func printConfig() {
-	config, err := config.GetConfigContents()
+	config, err := config.GetCredentialConfigContents()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Failed to get credential configuration contents:", err)
 		os.Exit(1)
@@ -108,7 +111,7 @@ func addConfigSubcommands(configCmd *cobra.Command) {
 }
 
 func printOauthConfig() {
-	config, err := config.GetConfigContents()
+	config, err := config.GetCredentialConfigContents()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Failed to get configuration contents:", err)
 		os.Exit(1)
@@ -181,7 +184,7 @@ func addPrefixSubcommands(prefixCmd *cobra.Command) {
 		Long:  "Add a new oauth client",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			input_config, err := config.GetConfigContents()
+			input_config, err := config.GetCredentialConfigContents()
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Failed to get configuration contents:", err)
 				os.Exit(1)
@@ -216,7 +219,7 @@ func addPrefixSubcommands(prefixCmd *cobra.Command) {
 		Long:  "Set the oauth client attributes (client_id or client_secret)",
 		Args:  cobra.ExactArgs(3),
 		Run: func(cmd *cobra.Command, args []string) {
-			input_config, err := config.GetConfigContents()
+			input_config, err := config.GetCredentialConfigContents()
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Failed to get configuration contents:", err)
 				os.Exit(1)
@@ -258,7 +261,7 @@ func addPrefixSubcommands(prefixCmd *cobra.Command) {
 		Long:  "Delete the oauth client",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			input_config, err := config.GetConfigContents()
+			input_config, err := config.GetCredentialConfigContents()
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Failed to get configuration contents:", err)
 				os.Exit(1)

--- a/cmd/fed_serve_test.go
+++ b/cmd/fed_serve_test.go
@@ -81,6 +81,9 @@ func TestFedServePosixOrigin(t *testing.T) {
 	viper.Set("Origin.StoragePrefix", t.TempDir())
 	viper.Set("Origin.FederationPrefix", "/test")
 	viper.Set("Origin.StorageType", "posix")
+	viper.Set("Origin.Port", 0)
+	viper.Set("Server.WebPort", 0)
+
 	// Disable functionality we're not using (and is difficult to make work on Mac)
 	viper.Set("Origin.EnableCmsd", false)
 	viper.Set("Origin.EnableMacaroons", false)

--- a/config/encrypted.go
+++ b/config/encrypted.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"path/filepath"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/youmark/pkcs8"
 	"golang.org/x/crypto/curve25519"
@@ -73,11 +74,13 @@ func EncryptedConfigExists() (bool, error) {
 	return true, nil
 }
 
+// Return the PEM-formatted contents of the encrypted configuration file
 func GetEncryptedContents() (string, error) {
 	filename, err := GetEncryptedConfigName()
 	if err != nil {
 		return "", err
 	}
+	log.Debugln("Will read credential configuration from", filename)
 
 	buf, err := os.ReadFile(filename)
 	if err != nil {
@@ -180,7 +183,9 @@ func GetPassword(newFile bool) ([]byte, error) {
 	return term.ReadPassword(stdin)
 }
 
-func GetConfigContents() (OSDFConfig, error) {
+// Returns the current contents of the credential configuration
+// from disk.
+func GetCredentialConfigContents() (OSDFConfig, error) {
 	config := OSDFConfig{}
 
 	encContents, err := GetEncryptedContents()
@@ -266,7 +271,7 @@ func GetConfigContents() (OSDFConfig, error) {
 }
 
 func ResetPassword() error {
-	input_config, err := GetConfigContents()
+	input_config, err := GetCredentialConfigContents()
 	if err != nil {
 		return err
 	}

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -103,6 +103,7 @@ Transport:
   ExpectContinueTimeout: 1s
   ResponseHeaderTimeout: 10s
 OIDC:
+  Issuer: "https://cilogon.org"
   AuthorizationEndpoint: "https://cilogon.org/authorize"
   DeviceAuthEndpoint: "https://cilogon.org/oauth2/device_authorization"
   TokenEndpoint: "https://cilogon.org/oauth2/token"

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -113,4 +113,5 @@ Issuer:
   ScitokensServerLocation: /opt/scitokens-server
   QDLLocation: /opt/qdl
   OIDCAuthenticationUserClaim: sub
+  OIDCGroupClaim: groups
   AuthenticationSource: OIDC

--- a/director/discovery_test.go
+++ b/director/discovery_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -161,7 +162,7 @@ func TestFederationDiscoveryHandler(t *testing.T) {
 
 func TestOidcDiscoveryHandler(t *testing.T) {
 	router := gin.Default()
-	router.GET("/test", oidcDiscoveryHandler)
+	server_utils.RegisterOIDCAPI(router.Group("/test"), true)
 
 	tests := []struct {
 		name           string
@@ -216,7 +217,7 @@ func TestOidcDiscoveryHandler(t *testing.T) {
 			require.NoError(t, config.InitClient())
 
 			w := httptest.NewRecorder()
-			req, _ := http.NewRequest("GET", "/test", nil)
+			req, _ := http.NewRequest("GET", "/test"+oidcDiscoveryPath, nil)
 			router.ServeHTTP(w, req)
 
 			require.Equal(t, tc.statusCode, w.Result().StatusCode)

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1661,7 +1661,9 @@ description: |+
   - `file`: Read groups from an external, JSON-formatted file.  The file should contain a single JSON object
     with keys corresponding to the "user" name and the value a list of strings that are interpreted as the
     user's groups.
-  - `oidc`: Take group information from the token provided by the OIDC identity provider.  Uses the
+  - `oidc`: Take group information from the identity token provided by the OIDC identity provider.  Parses
+    the value of the claim specified by `Issuer.OIDCGroupClaim` (defaults to "groups") as a list of groups.
+    The value may either be a comma-separated string or an array of strings.
 type: string
 default: none
 components: ["origin"]
@@ -1670,6 +1672,7 @@ name: Issuer.OIDCGroupClaim
 description: |+
   The claim in the OIDC ID token to be used as the group for the issuer.  If the value is a string,
   it is assumed that a comma is used as a group delimiter; otherwise, an array of strings is assumed.
+  Check the documentation of your OIDC provider to determine the appropriate claim name.
 type: string
 default: "groups"
 components: ["origin"]

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1604,6 +1604,13 @@ type: string
 default: /opt/qdl
 components: ["origin"]
 ---
+name: Issuer.IssuerClaim
+description: |+
+  Contents of the issuer (`iss`) claim in the generated tokens
+type: string
+default: $(Server.ExternalWebUrl)
+components: ["origin"]
+---
 name: Issuer.AuthenticationSource
 description: |+
   How users should authenticate with the issuer.  Currently-supported values are:

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1604,7 +1604,7 @@ type: string
 default: /opt/qdl
 components: ["origin"]
 ---
-name: Issuer.IssuerClaim
+name: Issuer.IssuerClaimValue
 description: |+
   Contents of the issuer (`iss`) claim in the generated tokens
 type: string
@@ -1644,6 +1644,16 @@ type: string
 default: sub
 components: ["origin"]
 ---
+name: Issuer.UserStripDomain
+description: |+
+  Some OIDC issuers generate a username of the form user@domain (such as `john.doe@gmail.com`); when
+  `UserStripDomain` is enabled, Pelican will strip the domain when determining the username.
+
+  For example, the OIDC identity `john.doe@gmail.com` would map to `john.doe`.
+type: bool
+default: false
+components: ["origin"]
+---
 name: Issuer.GroupSource
 description: |+
   How the issuer should determine group information based on the authenticated identity.  Valid values are:
@@ -1651,8 +1661,17 @@ description: |+
   - `file`: Read groups from an external, JSON-formatted file.  The file should contain a single JSON object
     with keys corresponding to the "user" name and the value a list of strings that are interpreted as the
     user's groups.
+  - `oidc`: Take group information from the token provided by the OIDC identity provider.  Uses the
 type: string
 default: none
+components: ["origin"]
+---
+name: Issuer.OIDCGroupClaim
+description: |+
+  The claim in the OIDC ID token to be used as the group for the issuer.  If the value is a string,
+  it is assumed that a comma is used as a group delimiter; otherwise, an array of strings is assumed.
+type: string
+default: "groups"
 components: ["origin"]
 ---
 name: Issuer.GroupFile

--- a/launchers/cache_serve.go
+++ b/launchers/cache_serve.go
@@ -103,7 +103,7 @@ func CacheServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, m
 
 	// Director and origin also registers this metadata URL; avoid registering twice.
 	if !modules.IsEnabled(config.DirectorType) && !modules.IsEnabled(config.OriginType) {
-		server_utils.RegisterOIDCAPI(engine)
+		server_utils.RegisterOIDCAPI(engine.Group("/"), false)
 	}
 
 	log.Info("Launching cache")

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -213,6 +213,13 @@ func LaunchModules(ctx context.Context, modules config.ServerType) (servers []se
 		log.Errorln("Web engine check failed: ", err)
 		return
 	}
+	if param.Origin_EnableIssuer.GetBool() {
+		oa4mpHealthCheckUrl := param.Server_ExternalWebUrl.GetString() + "/api/v1.0/issuer/.well-known/openid-configuration"
+		if err = server_utils.WaitUntilWorking(ctx, "GET", oa4mpHealthCheckUrl, "Issuer", http.StatusOK, true); err != nil {
+			log.Errorln("Failed to startup issuer component: ", err)
+			return
+		}
+	}
 
 	if modules.IsEnabled(config.OriginType) {
 		log.Debug("Finishing origin server configuration")

--- a/launchers/origin_serve.go
+++ b/launchers/origin_serve.go
@@ -68,7 +68,7 @@ func OriginServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, 
 
 	// Director also registers this metadata URL; avoid registering twice.
 	if !modules.IsEnabled(config.DirectorType) {
-		server_utils.RegisterOIDCAPI(engine)
+		server_utils.RegisterOIDCAPI(engine.Group("/"), false)
 	}
 
 	if param.Origin_EnableIssuer.GetBool() {

--- a/oa4mp/proxy.go
+++ b/oa4mp/proxy.go
@@ -62,6 +62,12 @@ func getTransport() *http.Transport {
 	return transport
 }
 
+// Proxy a HTTP request from the Pelican server to the OA4MP server
+//
+// Maps a request to /api/v1.0/issuer/foo to /scitokens-server/foo.  Most
+// headers are forwarded as well.  The `X-Pelican-User` header is added
+// to the request, using data from the Pelican login session, allowing
+// the OA4MP server to base its logic on the Pelican authentication.
 func oa4mpProxy(ctx *gin.Context) {
 	var userEncoded string
 	var user string

--- a/oa4mp/resources/id_token_policies.qdl
+++ b/oa4mp/resources/id_token_policies.qdl
@@ -16,6 +16,18 @@
  *
  ***************************************************************/
 
+/* Unpack the user information from pelican.
+
+   This is a workaround for the fact that the HTTP header claim source
+   doesn't function with the device code flow.
+ */
+if [exec_phase == 'post_token'] [
+     userInfo. := from_json(decode(claims.sub));
+     claims.sub := userInfo.u;
+     claims.groups := userInfo.g;
+     say('Got user name from pelican: ' + claims.sub);
+];
+
 if [0 == size(proxy_claims.)] then
 [
      /* Fallback: OA4MP 5.4.1 doesn't set proxy_claims at all.

--- a/oa4mp/resources/policies.qdl
+++ b/oa4mp/resources/policies.qdl
@@ -18,11 +18,8 @@
 
 access_token.'sub' := claims.'sub';
 
-{{ if eq .GroupSource "file" -}}
-cfg. := new_template('file');
-cfg.'file_path' := '{{- .GroupFile -}}';
-group_list. := get_claims(create_source(cfg.), access_token.'sub');
-{{- end }}
+group_list. := claims.groups;
+remove(claims.groups);
 
 {{ if .GroupRequirements }}
 if [0 == size(|^group_list. \/ { {{- range $idx, $grp := .GroupRequirements -}}{{- if eq $idx 0 -}}'{{- $grp -}}'{{else}}, '{{- $grp -}}'{{- end -}}{{- end -}} })] then
@@ -37,14 +34,21 @@ scopes := {};
 {{ range .GroupAuthzTemplates }}
 while [has_value(key, group_list.)]
 [
-    group_scopes := { {{- range $idx, $action := .Actions }}{{- if eq $idx 0 -}}'{{- $action -}}'{{else}}, '{{- $action -}}'{{- end -}}{{ end -}} } + '{{- .Prefix -}}';
+    group_scopes := { {{- range $idx, $action := .Actions }}{{- if eq $idx 0 -}}'{{- $action -}}:'{{else}}, '{{- $action -}}:'{{- end -}}{{ end -}} } + '{{- .Prefix -}}';
     scopes := scopes \/ |^replace(~group_scopes, '$GROUP', key);
 ];
 {{- end }}
 {{ range .UserAuthzTemplates }}
-user_scopes := { {{- range $idx, $action := .Actions }}{{- if eq $idx 0 -}}'{{- $action -}}'{{else}}, '{{- $action -}}'{{- end -}}{{ end -}} } + '{{- .Prefix -}}';
+user_scopes := { {{- range $idx, $action := .Actions }}{{- if eq $idx 0 -}}'{{- $action -}}:'{{else}}, '{{- $action -}}:'{{- end -}}{{ end -}} } + '{{- .Prefix -}}';
 scopes := scopes \/ |^replace(~user_scopes, '$USER', claims.'sub');
 {{ end }}
 access_token.'scope' := detokenize(scopes, ' ', 2);
 
 access_token.iss := '{{- .OIDCIssuerURL -}}';
+
+/* Pelican generates WLCG-style token scopes; convert the
+   resulting access token to a WLCG token.
+ */
+remove(access_token.ver);
+access_token.'wlcg.ver' := '1.0';
+access_token.'aud' := 'https://wlcg.cern.ch/jwt/v1/any';

--- a/oa4mp/resources/server-config.xml
+++ b/oa4mp/resources/server-config.xml
@@ -52,12 +52,10 @@
         <JSONWebKey>
             <path>{{- .JwksLocation -}}</path>
         </JSONWebKey>
-        <!-- Remove the next authorizationServlet if using a proxy -->
-        <!--<authorizationServlet authorizationURI="https://{HOSTNAME}/scitokens-server/authorize"/>-->
-       <authorizationServlet
-                useProxy="true"
-                cfgFile="{{- .ScitokensServerLocation -}}/etc/proxy-config.xml"
-                cfgName="proxy-client"
+        <authorizationServlet
+            useHeader="true"
+            requireHeader="true"
+            headerFieldName="X-Pelican-User"
         />
         <deviceFlowServlet
                 verificationURI="{{- .IssuerURL -}}/device"

--- a/oa4mp/serve.go
+++ b/oa4mp/serve.go
@@ -156,7 +156,7 @@ func ConfigureOA4MP() (launcher daemon.Launcher, err error) {
 		}
 	}
 
-	oidcIssuerURL := param.Issuer_IssuerClaim.GetString()
+	oidcIssuerURL := param.Issuer_IssuerClaimValue.GetString()
 	if oidcIssuerURL == "" {
 		oidcIssuerURL = param.Server_ExternalWebUrl.GetString()
 	}

--- a/oa4mp/serve.go
+++ b/oa4mp/serve.go
@@ -27,6 +27,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"text/template"
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
@@ -295,6 +296,13 @@ func ConfigureOA4MP() (launcher daemon.Launcher, err error) {
 
 	user, err := config.GetOA4MPUser()
 	if err != nil {
+		return
+	}
+
+	// If the HTTP socket already exists then tomcat will refuse to configure.
+	socketName := filepath.Join(param.Issuer_ScitokensServerLocation.GetString(), "var", "http.sock")
+	if err = os.Remove(socketName); err != nil && !errors.Is(err, syscall.ENOENT) {
+		err = errors.Wrap(err, "failed to remove old tomcat communication socket")
 		return
 	}
 

--- a/oa4mp/serve.go
+++ b/oa4mp/serve.go
@@ -156,10 +156,9 @@ func ConfigureOA4MP() (launcher daemon.Launcher, err error) {
 		}
 	}
 
-	oidcIssuerURL := param.OIDC_Issuer.GetString()
+	oidcIssuerURL := param.Issuer_IssuerClaim.GetString()
 	if oidcIssuerURL == "" {
-		err = errors.New("OIDC.Issuer not set in the configuration")
-		return
+		oidcIssuerURL = param.Server_ExternalWebUrl.GetString()
 	}
 	oidcAuthzURL, err := config.GetOIDCAuthorizationEndpoint()
 	if err != nil {

--- a/oauth2/dcrp.go
+++ b/oauth2/dcrp.go
@@ -33,6 +33,9 @@ type DCRPConfig struct {
 	// This is a constant specific to each server.
 	ClientRegistrationEndpointURL string
 
+	// HTTP Transport to use; if nil, then the default one is used.
+	Transport http.RoundTripper
+
 	// Metadata specifies client metadata to be used for client registration
 	Metadata
 }
@@ -165,7 +168,7 @@ func (c *DCRPConfig) Register() (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	return doRoundTrip(req)
+	return c.doRoundTrip(req)
 }
 
 // RegistrationError describes errors returned by auth server during client registration process
@@ -193,8 +196,11 @@ func newHTTPRequest(registrationURL, initialAccessToken string, body []byte) (*h
 }
 
 // doRoundTrip performs communication with authorization server for client registration
-func doRoundTrip(req *http.Request) (*Response, error) {
+func (c *DCRPConfig) doRoundTrip(req *http.Request) (*Response, error) {
 	client := http.Client{}
+	if c.Transport != nil {
+		client.Transport = c.Transport
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/oauth2/device_auth.go
+++ b/oauth2/device_auth.go
@@ -67,6 +67,10 @@ const (
 	errInvalidScope         = "invalid_scope"
 )
 
+var (
+	ErrUnknownClient error = errors.New("unknown OAuth2 Client ID")
+)
+
 type DeviceAuth struct {
 	DeviceCode              string `json:"device_code"`
 	UserCode                string `json:"user_code"`
@@ -75,6 +79,11 @@ type DeviceAuth struct {
 	ExpiresIn               int    `json:"expires_in"`
 	Interval                int    `json:"interval,omitempty"`
 	raw                     map[string]interface{}
+}
+
+type oauth2Err struct {
+	Error       string `json:"error"`
+	Description string `json:"error_description"`
 }
 
 type Config struct {
@@ -119,6 +128,21 @@ func retrieveDeviceAuth(ctx context.Context, c *Config, v url.Values) (*DeviceAu
 		return nil, fmt.Errorf("oauth2: cannot auth device: %v", err)
 	}
 	if code := r.StatusCode; code < 200 || code > 299 {
+		if code == 400 {
+			contentType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+			if err != nil {
+				contentType = ""
+			}
+			if contentType == "application/json" {
+				var errMsg oauth2Err
+				if err := json.Unmarshal(body, &errMsg); err == nil {
+					if errMsg.Error == "unauthorized_client" && errMsg.Description == "unknown client" {
+						return nil, ErrUnknownClient
+					}
+				}
+			}
+		}
+
 		return nil, &oauth2_upstream.RetrieveError{
 			Response: r,
 			Body:     body,

--- a/oauth2/device_auth.go
+++ b/oauth2/device_auth.go
@@ -109,7 +109,7 @@ func retrieveDeviceAuth(ctx context.Context, c *Config, v url.Values) (*DeviceAu
 	req.SetBasicAuth(url.QueryEscape(c.ClientID), url.QueryEscape(c.ClientSecret))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	r, err := ctxhttp.Do(ctx, nil, req)
+	r, err := ctxhttp.Do(ctx, ContextClient(ctx), req)
 	if err != nil {
 		return nil, err
 	}

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -21,6 +21,7 @@ package oauth2
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path"
 	"strings"
@@ -76,7 +77,7 @@ func AcquireToken(issuerUrl string, entry *config.PrefixEntry, credentialGen *na
 	}
 
 	if !deviceCodeSupported(&issuerInfo.GrantTypes) {
-		return nil, fmt.Errorf("Issuer at %s for prefix %s does not support device flow", issuerUrl, entry.Prefix)
+		return nil, fmt.Errorf("issuer at %s for prefix %s does not support device flow", issuerUrl, entry.Prefix)
 	}
 
 	// Always trim the filename off the path
@@ -115,7 +116,8 @@ func AcquireToken(issuerUrl string, entry *config.PrefixEntry, credentialGen *na
 		Scopes: []string{"wlcg", "offline_access", storageScope},
 	}
 
-	ctx := context.Background()
+	client := &http.Client{Transport: config.GetTransport()}
+	ctx := context.WithValue(context.Background(), HTTPClient, client)
 	deviceAuth, err := oauth2Config.AuthDevice(ctx)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to perform device code flow with URL %s", issuerInfo.DeviceAuthURL)

--- a/origin/advertise.go
+++ b/origin/advertise.go
@@ -76,12 +76,6 @@ func (server *OriginServer) CreateAdvertisement(name string, originUrlStr string
 		return nil, err
 	}
 
-	originUrlURL, err := url.Parse(originUrlStr)
-	if err != nil {
-		err = errors.Wrap(err, "Invalid Origin Url")
-		return nil, err
-	}
-
 	var nsAds []server_structs.NamespaceAdV2
 	var prefixes []string
 	originExports, err := server_utils.GetOriginExports()
@@ -105,7 +99,7 @@ func (server *OriginServer) CreateAdvertisement(name string, originUrlStr string
 			Generation: []server_structs.TokenGen{{
 				Strategy:         server_structs.StrategyType("OAuth2"),
 				MaxScopeDepth:    3,
-				CredentialIssuer: *originUrlURL,
+				CredentialIssuer: *issuerUrl,
 			}},
 			Issuer: []server_structs.TokenIssuer{{
 				BasePaths: []string{export.FederationPrefix},

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -140,8 +140,9 @@ var (
 	Issuer_AuthenticationSource = StringParam{"Issuer.AuthenticationSource"}
 	Issuer_GroupFile = StringParam{"Issuer.GroupFile"}
 	Issuer_GroupSource = StringParam{"Issuer.GroupSource"}
-	Issuer_IssuerClaim = StringParam{"Issuer.IssuerClaim"}
+	Issuer_IssuerClaimValue = StringParam{"Issuer.IssuerClaimValue"}
 	Issuer_OIDCAuthenticationUserClaim = StringParam{"Issuer.OIDCAuthenticationUserClaim"}
+	Issuer_OIDCGroupClaim = StringParam{"Issuer.OIDCGroupClaim"}
 	Issuer_QDLLocation = StringParam{"Issuer.QDLLocation"}
 	Issuer_ScitokensServerLocation = StringParam{"Issuer.ScitokensServerLocation"}
 	Issuer_TomcatLocation = StringParam{"Issuer.TomcatLocation"}
@@ -298,6 +299,7 @@ var (
 	Director_EnableOIDC = BoolParam{"Director.EnableOIDC"}
 	DisableHttpProxy = BoolParam{"DisableHttpProxy"}
 	DisableProxyFallback = BoolParam{"DisableProxyFallback"}
+	Issuer_UserStripDomain = BoolParam{"Issuer.UserStripDomain"}
 	Logging_DisableProgressBars = BoolParam{"Logging.DisableProgressBars"}
 	Lotman_EnableAPI = BoolParam{"Lotman.EnableAPI"}
 	Monitoring_MetricAuthorization = BoolParam{"Monitoring.MetricAuthorization"}

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -140,6 +140,7 @@ var (
 	Issuer_AuthenticationSource = StringParam{"Issuer.AuthenticationSource"}
 	Issuer_GroupFile = StringParam{"Issuer.GroupFile"}
 	Issuer_GroupSource = StringParam{"Issuer.GroupSource"}
+	Issuer_IssuerClaim = StringParam{"Issuer.IssuerClaim"}
 	Issuer_OIDCAuthenticationUserClaim = StringParam{"Issuer.OIDCAuthenticationUserClaim"}
 	Issuer_QDLLocation = StringParam{"Issuer.QDLLocation"}
 	Issuer_ScitokensServerLocation = StringParam{"Issuer.ScitokensServerLocation"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -95,6 +95,7 @@ type Config struct {
 		GroupFile string
 		GroupRequirements []string
 		GroupSource string
+		IssuerClaim string
 		OIDCAuthenticationRequirements interface{}
 		OIDCAuthenticationUserClaim string
 		QDLLocation string
@@ -367,6 +368,7 @@ type configWithType struct {
 		GroupFile struct { Type string; Value string }
 		GroupRequirements struct { Type string; Value []string }
 		GroupSource struct { Type string; Value string }
+		IssuerClaim struct { Type string; Value string }
 		OIDCAuthenticationRequirements struct { Type string; Value interface{} }
 		OIDCAuthenticationUserClaim struct { Type string; Value string }
 		QDLLocation struct { Type string; Value string }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -95,12 +95,14 @@ type Config struct {
 		GroupFile string
 		GroupRequirements []string
 		GroupSource string
-		IssuerClaim string
+		IssuerClaimValue string
 		OIDCAuthenticationRequirements interface{}
 		OIDCAuthenticationUserClaim string
+		OIDCGroupClaim string
 		QDLLocation string
 		ScitokensServerLocation string
 		TomcatLocation string
+		UserStripDomain bool
 	}
 	IssuerKey string
 	LocalCache struct {
@@ -368,12 +370,14 @@ type configWithType struct {
 		GroupFile struct { Type string; Value string }
 		GroupRequirements struct { Type string; Value []string }
 		GroupSource struct { Type string; Value string }
-		IssuerClaim struct { Type string; Value string }
+		IssuerClaimValue struct { Type string; Value string }
 		OIDCAuthenticationRequirements struct { Type string; Value interface{} }
 		OIDCAuthenticationUserClaim struct { Type string; Value string }
+		OIDCGroupClaim struct { Type string; Value string }
 		QDLLocation struct { Type string; Value string }
 		ScitokensServerLocation struct { Type string; Value string }
 		TomcatLocation struct { Type string; Value string }
+		UserStripDomain struct { Type string; Value bool }
 	}
 	IssuerKey struct { Type string; Value string }
 	LocalCache struct {

--- a/registry/client_commands.go
+++ b/registry/client_commands.go
@@ -188,7 +188,9 @@ func NamespaceRegister(privateKey jwk.Key, namespaceRegistryEndpoint string, acc
 		if err != nil {
 			return errors.Wrapf(err, "Server responded with an error: %s. %s", respData.Message, respData.Error)
 		}
-		log.Errorf("Server responded with an error: %v. %s. %s", respData.Message, respData.Error, err)
+		if respData.Message != "" {
+			log.Debugf("Server responded to registration confirmation successfully with message: %s", respData.Message)
+		}
 	} else { // Error decoding JSON
 		if err != nil {
 			return errors.Wrapf(err, "Server responded with an error and failed to parse JSON response from the server. Raw response is %s", resp)

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -182,7 +182,7 @@ func populateRegistrationFields(prefix string, data interface{}) []registrationF
 // GET /namespaces
 func listNamespaces(ctx *gin.Context) {
 	// Directly call GetUser as we want this endpoint to also be able to serve unauthed users
-	user, err := web_ui.GetUser(ctx)
+	user, _, err := web_ui.GetUserGroups(ctx)
 	if err != nil {
 		log.Error("Failed to check user login status: ", err)
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -119,8 +119,16 @@ type (
 	}
 
 	OpenIdDiscoveryResponse struct {
-		Issuer  string `json:"issuer"`
-		JwksUri string `json:"jwks_uri"`
+		Issuer               string   `json:"issuer"`
+		JwksUri              string   `json:"jwks_uri"`
+		TokenEndpoint        string   `json:"token_endpoint,omitempty"`
+		UserInfoEndpoint     string   `json:"userinfo_endpoint,omitempty"`
+		RevocationEndpoint   string   `json:"revocation_endpoint,omitempty"`
+		GrantTypesSupported  []string `json:"grant_types_supported,omitempty"`
+		ScopesSupported      []string `json:"scopes_supported,omitempty"`
+		TokenAuthMethods     []string `json:"token_endpoint_auth_methods_supported,omitempty"`
+		RegistrationEndpoint string   `json:"registration_endpoint,omitempty"`
+		DeviceEndpoint       string   `json:"device_authorization_endpoint,omitempty"`
 	}
 )
 

--- a/server_utils/oidc.go
+++ b/server_utils/oidc.go
@@ -22,35 +22,136 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
 )
 
-func exportOpenIDConfig(c *gin.Context) {
-	issuerURL, _ := url.Parse(param.Server_ExternalWebUrl.GetString())
-	jwksUri, _ := url.JoinPath(issuerURL.String(), "/.well-known/issuer.jwks")
-	jsonData := gin.H{
-		"issuer":   issuerURL.String(),
-		"jwks_uri": jwksUri,
+const (
+	jwksPath string = "/.well-known/issuer.jwks"
+)
+
+// The director will prefer the federation's public endpoint instead of its own
+// public endpoint.  In almost all cases, these will be the same thing; this is
+// just providing some flexibility.
+func getDirectorBaseUrl(ctx *gin.Context) (directorUrl *url.URL) {
+	fedInfo, err := config.GetFederation(ctx)
+	if err != nil {
+		log.Error("Bad server configuration: Federation discovery could not resolve:", err)
+		ctx.AbortWithStatusJSON(http.StatusInternalServerError,
+			server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "Bad server configuration: Federation discovery could not resolve",
+			})
+		return
+	}
+	directorUrlStr := fedInfo.DirectorEndpoint
+	if directorUrlStr == "" {
+		log.Error("Bad server configuration: Federation.DirectorUrl is not set")
+		ctx.AbortWithStatusJSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Bad server configuration: director URL is not set",
+		})
+		return
+	}
+	directorUrl, err = url.Parse(directorUrlStr)
+	if err != nil {
+		log.Error("Bad server configuration: invalid URL from Federation.DirectorUrl: ", err)
+		ctx.AbortWithStatusJSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Bad server configuration: director URL is not valid",
+		})
+		return
+	}
+	if directorUrl.Scheme != "https" {
+		directorUrl.Scheme = "https"
+	}
+	if directorUrl.Port() == "443" {
+		directorUrl.Host = strings.TrimSuffix(directorUrl.Host, ":443")
 	}
 
-	c.JSON(http.StatusOK, jsonData)
+	return
 }
 
-func exportIssuerJWKS(c *gin.Context) {
-	keys, _ := config.GetIssuerPublicJWKS()
-	buf, _ := json.MarshalIndent(keys, "", " ")
+func createOidcConfigExporter(isDirector bool) func(ctx *gin.Context) {
+	return func(ctx *gin.Context) {
+		var issuerStr string
+		if isDirector {
+			if issuerUrl := getDirectorBaseUrl(ctx); issuerUrl == nil {
+				return
+			} else {
+				issuerStr = issuerUrl.String()
+			}
+		} else {
+			issuerStr = param.Server_ExternalWebUrl.GetString()
+		}
+		jwskUrl, err := url.JoinPath(issuerStr, jwksPath)
+		if err != nil {
+			log.Errorf("Bad server configuration: failed to construct jwks URL from issuer URL %s and JWKS path %s: %s", issuerStr, jwksPath, err)
+			ctx.AbortWithStatusJSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "Bad server configuration: cannot generate JWKs URL",
+			})
+			return
+		}
 
-	c.Data(http.StatusOK, "application/json; charset=utf-8", buf)
+		cfg := server_structs.OpenIdDiscoveryResponse{
+			Issuer:  issuerStr,
+			JwksUri: jwskUrl,
+		}
+		// If we have the built-in issuer enabled, fill in the URLs for OA4MP
+		if param.Origin_EnableIssuer.GetBool() {
+			serviceUri := issuerStr + "/api/v1.0/issuer"
+			cfg.TokenEndpoint = serviceUri + "/token"
+			cfg.UserInfoEndpoint = serviceUri + "/userinfo"
+			cfg.RevocationEndpoint = serviceUri + "/revoke"
+			cfg.GrantTypesSupported = []string{"refresh_token", "urn:ietf:params:oauth:grant-type:device_code", "authorization_code"}
+			cfg.ScopesSupported = []string{"openid", "offline_access", "wlcg", "storage.read:/",
+				"storage.modify:/", "storage.create:/"}
+			cfg.TokenAuthMethods = []string{"client_secret_basic", "client_secret_post"}
+			cfg.RegistrationEndpoint = serviceUri + "/oidc-cm"
+			cfg.DeviceEndpoint = serviceUri + "/device_authorization"
+		}
+
+		ctx.Header("Content-Disposition", "attachment; filename=pelican-oidc-configuration.json")
+
+		ctx.JSON(http.StatusOK, cfg)
+	}
 }
 
-func RegisterOIDCAPI(engine *gin.Engine) {
+func exportIssuerJWKS(ctx *gin.Context) {
+	key, err := config.GetIssuerPublicJWKS()
+	if err != nil {
+		log.Errorf("Failed to load director's public key: %v", err)
+		ctx.AbortWithStatusJSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to load director's public key",
+		})
+	} else {
+		jsonData, err := json.MarshalIndent(key, "", "  ")
+		if err != nil {
+			ctx.AbortWithStatusJSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "Failed to marshal director's public key",
+			})
+			return
+		}
+		// Append a new line to the JSON data
+		jsonData = append(jsonData, '\n')
+		ctx.Header("Content-Disposition", "attachment; filename=public-signing-key.jwks")
+		ctx.Data(200, "application/json", jsonData)
+	}
+}
+
+func RegisterOIDCAPI(engine *gin.RouterGroup, isDirector bool) {
 	group := engine.Group("/.well-known")
 	{
-		group.GET("/openid-configuration", exportOpenIDConfig)
+		group.GET("/openid-configuration", createOidcConfigExporter(isDirector))
 		group.GET("/issuer.jwks", exportIssuerJWKS)
 	}
 }

--- a/server_utils/oidc.go
+++ b/server_utils/oidc.go
@@ -127,17 +127,17 @@ func createOidcConfigExporter(isDirector bool) func(ctx *gin.Context) {
 func exportIssuerJWKS(ctx *gin.Context) {
 	key, err := config.GetIssuerPublicJWKS()
 	if err != nil {
-		log.Errorf("Failed to load director's public key: %v", err)
+		log.Errorf("Failed to load server's public key: %v", err)
 		ctx.AbortWithStatusJSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
-			Msg:    "Failed to load director's public key",
+			Msg:    "Failed to load server's public key",
 		})
 	} else {
 		jsonData, err := json.MarshalIndent(key, "", "  ")
 		if err != nil {
 			ctx.AbortWithStatusJSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 				Status: server_structs.RespFailed,
-				Msg:    "Failed to marshal director's public key",
+				Msg:    "Failed to marshal server's public key",
 			})
 			return
 		}

--- a/token/token_create.go
+++ b/token/token_create.go
@@ -51,6 +51,7 @@ type (
 		Subject      string            // Subject is 'sub' claim
 		Claims       map[string]string // Additional claims
 		scope        string            // scope is a string with space-delimited list of scopes. To enforce type check, use AddRawScope or AddScopes to add scopes to your token
+		group        []string          // List of groups to include in the token
 	}
 
 	openIdConfiguration struct {
@@ -178,6 +179,14 @@ func (config *TokenConfig) AddAudiences(audiences ...string) {
 
 func (config *TokenConfig) GetAudiences() []string {
 	return config.audience
+}
+
+func (config *TokenConfig) AddGroups(groups ...string) {
+	config.group = append(config.group, groups...)
+}
+
+func (config *TokenConfig) GetGroups() []string {
+	return config.group
 }
 
 // Verify if the token matches scitoken2 profile requirement
@@ -315,8 +324,14 @@ func (tokenConfig *TokenConfig) CreateTokenWithKey(key jwk.Key) (string, error) 
 
 	if tokenConfig.tokenProfile == TokenProfileScitokens2 {
 		builder.Claim("ver", tokenConfig.version)
-	} else if tokenConfig.tokenProfile == TokenProfileWLCG {
+	}
+	if tokenConfig.tokenProfile == TokenProfileWLCG {
 		builder.Claim("wlcg.ver", tokenConfig.version)
+		if len(tokenConfig.group) > 0 {
+			builder.Claim("wlcg.groups", tokenConfig.group)
+		}
+	} else if len(tokenConfig.group) > 0 {
+		builder.Claim("groups", tokenConfig.group)
 	}
 
 	if tokenConfig.Claims != nil {

--- a/web_ui/authentication.go
+++ b/web_ui/authentication.go
@@ -131,40 +131,55 @@ func configureAuthDB() error {
 
 // Get the "subject" claim from the JWT that "login" cookie stores,
 // where subject is set to be the username. Return empty string if no "login" cookie is present
-func GetUser(ctx *gin.Context) (string, error) {
+func GetUserGroups(ctx *gin.Context) (user string, groups []string, err error) {
 	token, err := ctx.Cookie("login")
 	if err != nil {
 		if err == http.ErrNoCookie {
-			return "", nil
+			err = nil
+			return
 		} else {
-			return "", err
+			return
 		}
 	}
 	if token == "" {
-		return "", errors.New("Login cookie is empty")
+		err = errors.New("Login cookie is empty")
+		return
 	}
 	jwks, err := config.GetIssuerPublicJWKS()
 	if err != nil {
-		return "", err
+		return
 	}
 	parsed, err := jwt.Parse([]byte(token), jwt.WithKeySet(jwks))
 	if err != nil {
-		return "", err
+		return
 	}
 	if err = jwt.Validate(parsed); err != nil {
-		return "", err
+		return
 	}
-	return parsed.Subject(), nil
+	user = parsed.Subject()
+	groupsIface, ok := parsed.Get("wlcg.groups")
+	if ok {
+		if groupsTmp, ok := groupsIface.([]interface{}); ok {
+			groups = make([]string, 0, len(groupsTmp))
+			for _, groupObj := range groupsTmp {
+				if groupStr, ok := groupObj.(string); ok {
+					groups = append(groups, groupStr)
+				}
+			}
+		}
+	}
+	return
 }
 
 // Create a JWT and set the "login" cookie to store that JWT
-func setLoginCookie(ctx *gin.Context, user string) {
+func setLoginCookie(ctx *gin.Context, user string, groups []string) {
 	loginCookieTokenCfg := token.NewWLCGToken()
 	loginCookieTokenCfg.Lifetime = 30 * time.Minute
 	loginCookieTokenCfg.Issuer = param.Server_ExternalWebUrl.GetString()
 	loginCookieTokenCfg.AddAudiences(param.Server_ExternalWebUrl.GetString())
 	loginCookieTokenCfg.Subject = user
 	loginCookieTokenCfg.AddScopes(token_scopes.WebUi_Access, token_scopes.Monitoring_Query, token_scopes.Monitoring_Scrape)
+	loginCookieTokenCfg.AddGroups(groups...)
 
 	// CreateToken also handles validation for us
 	tok, err := loginCookieTokenCfg.CreateToken()
@@ -185,7 +200,7 @@ func setLoginCookie(ctx *gin.Context, user string) {
 
 // Check if user is authenticated by checking if the "login" cookie is present and set the user identity to ctx
 func AuthHandler(ctx *gin.Context) {
-	user, err := GetUser(ctx)
+	user, groups, err := GetUserGroups(ctx)
 	if user == "" {
 		if err != nil {
 			log.Errorln("Invalid user cookie or unable to parse user cookie:", err)
@@ -197,6 +212,7 @@ func AuthHandler(ctx *gin.Context) {
 			})
 	} else {
 		ctx.Set("User", user)
+		ctx.Set("Groups", groups)
 		ctx.Next()
 	}
 }
@@ -206,7 +222,7 @@ func AuthHandler(ctx *gin.Context) {
 // The current implementation forces the OAuth2 endpoint; future work may instead use a generic
 // login page.
 func RequireAuthMiddleware(ctx *gin.Context) {
-	user, err := GetUser(ctx)
+	user, groups, err := GetUserGroups(ctx)
 	if user == "" || err != nil {
 		origPath := ctx.Request.URL.RequestURI()
 		redirUrl := url.URL{
@@ -217,6 +233,7 @@ func RequireAuthMiddleware(ctx *gin.Context) {
 		ctx.Abort()
 	} else {
 		ctx.Set("User", user)
+		ctx.Set("Groups", groups)
 		ctx.Next()
 	}
 }
@@ -313,7 +330,12 @@ func loginHandler(ctx *gin.Context) {
 		return
 	}
 
-	setLoginCookie(ctx, login.User)
+	groups, err := generateGroupInfo(login.User)
+	if err != nil {
+		log.Errorf("Failed to generate group info for user %s: %s", login.User, err)
+		groups = nil
+	}
+	setLoginCookie(ctx, login.User, groups)
 	ctx.JSON(http.StatusOK,
 		server_structs.SimpleApiResp{
 			Status: server_structs.RespOK,
@@ -362,7 +384,12 @@ func initLoginHandler(ctx *gin.Context) {
 		return
 	}
 
-	setLoginCookie(ctx, "admin")
+	groups, err := generateGroupInfo("admin")
+	if err != nil {
+		log.Errorln("Failed to generate group info for admin:", err)
+		groups = nil
+	}
+	setLoginCookie(ctx, "admin", groups)
 }
 
 // Handle reset password
@@ -413,7 +440,7 @@ func logoutHandler(ctx *gin.Context) {
 // Returns the authentication status of the current user, including user id and role
 func whoamiHandler(ctx *gin.Context) {
 	res := WhoAmIRes{}
-	if user, err := GetUser(ctx); err != nil || user == "" {
+	if user, _, err := GetUserGroups(ctx); err != nil || user == "" {
 		res.Authenticated = false
 		ctx.JSON(http.StatusOK, res)
 	} else {

--- a/web_ui/oauth2_client.go
+++ b/web_ui/oauth2_client.go
@@ -60,6 +60,7 @@ type (
 )
 
 const (
+	oauthLoginPath    = "/api/v1.0/auth/oauth/login"
 	oauthCallbackPath = "/api/v1.0/auth/oauth/callback"
 )
 

--- a/web_ui/oauth2_client.go
+++ b/web_ui/oauth2_client.go
@@ -28,6 +28,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/gin-contrib/sessions"
@@ -50,12 +51,6 @@ type (
 	oauthCallbackRequest struct {
 		State string `form:"state"`
 		Code  string `form:"code"`
-	}
-
-	cilogonUserInfo struct {
-		Email string `json:"email,omitempty"`
-		Sub   string `json:"sub"`
-		SubID string `json:"subject_id,omitempty"`
 	}
 )
 
@@ -119,6 +114,90 @@ func handleOAuthLogin(ctx *gin.Context) {
 
 	redirectUrl := oauthConfig.AuthCodeURL(csrfState)
 	ctx.Redirect(http.StatusTemporaryRedirect, redirectUrl)
+}
+
+// Given a user name, return the list of groups they belong to
+func generateGroupInfo(user string) (groups []string, err error) {
+	// Currently, only file-based lookup is supported
+	if param.Issuer_GroupSource.GetString() != "file" {
+		return
+	}
+	groupFile := param.Issuer_GroupFile.GetString()
+	if groupFile == "" {
+		return
+	}
+	groupBytes, err := os.ReadFile(groupFile)
+	if err != nil {
+		err = errors.Wrap(err, "failed to read Issuer.GroupFile for group information")
+		return
+	}
+	var groupTable map[string][]string
+	if err = json.Unmarshal(groupBytes, &groupTable); err != nil {
+		err = errors.Wrapf(err, "failed to parse Issuer.GroupFile (%s) as JSON", groupFile)
+		return
+	}
+	groups = groupTable[user]
+	return
+}
+
+// Given a map from a JSON object, generate user/group information according to
+// the current policy.
+func generateUserGroupInfo(userInfo map[string]interface{}) (user string, groups []string, err error) {
+	userClaim := param.Issuer_OIDCAuthenticationUserClaim.GetString()
+	if userClaim == "" {
+		userClaim = "sub"
+	}
+	userIdentifierIface, ok := userInfo[userClaim]
+	if !ok {
+		log.Errorln("User info endpoint did not return a value for the user claim", userClaim)
+		err = errors.New("identity provider did not return an identity for logged-in user")
+		return
+	}
+	userIdentifier, ok := userIdentifierIface.(string)
+	if !ok {
+		log.Errorln("User info endpoint did not return a string for the user claim", userClaim)
+		err = errors.New("identity provider did not return an identity for logged-in user")
+		return
+	}
+	if param.Issuer_UserStripDomain.GetBool() {
+		lastAt := strings.LastIndex(userIdentifier, "@")
+		if lastAt >= 0 {
+			userIdentifier = userIdentifier[:strings.LastIndex(userIdentifier, "@")]
+		}
+	}
+	if userIdentifier == "" {
+		log.Errorf("'%s' field of user info response from auth provider is empty. Can't determine user identity", userClaim)
+		err = errors.New("identity provider returned an empty username")
+		return
+	}
+	user = userIdentifier
+
+	if param.Issuer_GroupSource.GetString() == "oidc" {
+		groupClaim := param.Issuer_OIDCGroupClaim.GetString()
+		groupList, ok := userInfo[groupClaim]
+		if ok {
+			if groupsStr, ok := groupList.(string); ok {
+				groupsInfo := strings.Split(groupsStr, ",")
+				groups = make([]string, 0, len(groupsInfo))
+				for _, groupRaw := range groupsInfo {
+					group := strings.TrimSpace(groupRaw)
+					if group != "" {
+						groups = append(groups, group)
+					}
+				}
+			} else if groupsTmp, ok := groupList.([]interface{}); ok {
+				groups = make([]string, 0, len(groupsTmp))
+				for _, groupObj := range groupsTmp {
+					if groupStr, ok := groupObj.(string); ok {
+						groups = append(groups, groupStr)
+					}
+				}
+			}
+		}
+	} else {
+		groups, err = generateGroupInfo(user)
+	}
+	return
 }
 
 // Handle the callback request from CILogon when user is successfully authenticated
@@ -241,8 +320,7 @@ func handleOAuthCallback(ctx *gin.Context) {
 		return
 	}
 
-	userInfo := cilogonUserInfo{}
-
+	var userInfo map[string]interface{}
 	if err := json.Unmarshal(body, &userInfo); err != nil {
 		log.Errorf("Error parsing user info from auth provider at %s. %v", oauthUserInfoUrl, err)
 		ctx.JSON(http.StatusInternalServerError,
@@ -253,13 +331,12 @@ func handleOAuthCallback(ctx *gin.Context) {
 		return
 	}
 
-	userIdentifier := userInfo.Sub
-	if userIdentifier == "" {
-		log.Errorf("sub field of user info response from auth provider is empty. Can't determine user identity")
+	user, groups, err := generateUserGroupInfo(userInfo)
+	if err != nil {
 		ctx.JSON(http.StatusInternalServerError,
 			server_structs.SimpleApiResp{
 				Status: server_structs.RespFailed,
-				Msg:    "Error setting login cookie: can't find valid user id from CILogon",
+				Msg:    err.Error(),
 			})
 		return
 	}
@@ -270,7 +347,7 @@ func handleOAuthCallback(ctx *gin.Context) {
 	}
 
 	// Issue our own JWT for web UI access
-	setLoginCookie(ctx, userIdentifier)
+	setLoginCookie(ctx, user, groups)
 
 	// Redirect user to where they were or root path
 	ctx.Redirect(http.StatusTemporaryRedirect, redirectLocation)

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -221,7 +221,7 @@ func handleWebUIRedirect(ctx *gin.Context) {
 func handleWebUIAuth(ctx *gin.Context) {
 	requestPath := ctx.Param("requestPath")
 	db := authDB.Load()
-	user, err := GetUser(ctx)
+	user, _, err := GetUserGroups(ctx)
 
 	// Skip auth check for static files other than html pages
 	if path.Ext(requestPath) != "" && path.Ext(requestPath) != ".html" {

--- a/xrootd/authorization.go
+++ b/xrootd/authorization.go
@@ -75,19 +75,6 @@ type (
 		Global    GlobalCfg
 		IssuerMap map[string]Issuer
 	}
-
-	openIdConfig struct {
-		Issuer               string   `json:"issuer"`
-		JWKSURI              string   `json:"jwks_uri"`
-		TokenEndpoint        string   `json:"token_endpoint,omitempty"`
-		UserInfoEndpoint     string   `json:"userinfo_endpoint,omitempty"`
-		RevocationEndpoint   string   `json:"revocation_endpoint,omitempty"`
-		GrantTypesSupported  []string `json:"grant_types_supported,omitempty"`
-		ScopesSupported      []string `json:"scopes_supported,omitempty"`
-		TokenAuthMethods     []string `json:"token_endpoint_auth_methods_supported,omitempty"`
-		RegistrationEndpoint string   `json:"registration_endpoint,omitempty"`
-		DeviceEndpoint       string   `json:"device_authorization_endpoint,omitempty"`
-	}
 )
 
 var (
@@ -669,9 +656,9 @@ func EmitIssuerMetadata(exportPath string, xServeUrl string) error {
 	}
 	jwksUrl.Path = "/.well-known/issuer.jwks"
 
-	cfg := openIdConfig{
+	cfg := server_structs.OpenIdDiscoveryResponse{
 		Issuer:  xServeUrl,
-		JWKSURI: jwksUrl.String(),
+		JwksUri: jwksUrl.String(),
 	}
 
 	// If we have the built-in issuer enabled, fill in the URLs for OA4MP

--- a/xrootd/origin_test.go
+++ b/xrootd/origin_test.go
@@ -86,7 +86,7 @@ func originMockup(ctx context.Context, egrp *errgroup.Group, t *testing.T) conte
 	engine, err := web_ui.GetEngine()
 	require.NoError(t, err)
 
-	server_utils.RegisterOIDCAPI(engine)
+	server_utils.RegisterOIDCAPI(engine.Group("/"), false)
 
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	defer func() {

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -852,9 +852,9 @@ func mapXrootdLogLevels(xrdConfig *XrootdConfig) error {
 	// https://github.com/xrootd/xrootd/blob/8f8498d66aa583c54c0875bb1cfe432f4be040f4/src/XrdSciTokens/XrdSciTokensAccess.cc#L951-L963
 	xrdConfig.Logging.OriginScitokens, err = genLoggingConfig("scitokens", xrdConfig, param.Logging_Origin_Scitokens.GetString(), loggingMap{
 		Trace: "all",
-		Debug: "debug",
-		Info:  "info",
-		Warn:  "warning",
+		Debug: "debug info warning error",
+		Info:  "info warning error",
+		Warn:  "warning error",
 		Error: "error",
 		Fatal: "none",
 	})


### PR DESCRIPTION
With this PR, OA4MP uses the identity information (including newly-added group data) from the Pelican webapp.

Previously, OA4MP had a completely separate integration with CILogon, forwarding device code requests directly to CILogon.  This would prevent us from having our own identity management (such as integration with Globus or a local user/password).

Here's the way I started up Pelican in the dev container:

```
PELICAN_ORIGIN_URL=https://localhost:8443 \
  PELICAN_ORIGIN_ENABLEDIRECTREADS=true \
  PELICAN_ORIGIN_ENABLEISSUER=true \
  PELICAN_SERVER_EXTERNALWEBURL=https://localhost:8444 \
  PELICAN_ORIGIN_EXPORTVOLUME=/test \
  PELICAN_OIDC_CLIENTSECRETFILE=/tmp/bar 
  PELICAN_OIDC_CLIENTID=cilogon:/client_id/$ID \
  ./dist/pelican_linux_arm64/pelican serve --module registry,origin,director -d
```

(note -- this requires a CILogon OIDC client with a callback URL of localhost)

and the following configuration file:

```
OriginUrl: https://localhost:8444
TLSSkipVerify: true
Issuer:
  OIDCAuthenticationUserClaim: eppn
  UserStripDomain: true
  GroupSource: file
  GroupFile: "/etc/pelican/groups.json"
  AuthorizationTemplates:
  - actions: ["read", "modify"]
    prefix: /home/$USER
  - actions: ["read"]
    prefix: /group/$GROUP
Logging:
  Origin:
    Scitokens: debug
Server:
  ExternalWebUrl: "https://localhost:8444"
  Hostname: "localhost"
```