### PR TITLE
Plugin now also accepts PELICAN_NEAREST_CACHE

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -399,6 +399,11 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 		if err != nil {
 			return
 		}
+	} else if nearestCache, ok := os.LookupEnv("PELICAN_NEAREST_CACHE"); ok && nearestCache != "" {
+		caches, err = utils.GetPreferredCaches(nearestCache)
+		if err != nil {
+			return
+		}
 	}
 
 	tc, err := te.NewClient(client.WithAcquireToken(false))

--- a/github_scripts/citests.sh
+++ b/github_scripts/citests.sh
@@ -98,6 +98,20 @@ if [ ! -e "$SOCKET_DIR/data/ospool/uc-shared/public/OSG-Staff/validation/test.tx
   exit 1
 fi
 
+# Test we work with PELICAN_NEAREST_CACHE as well
+PELICAN_NEAREST_CACHE="unix://$SOCKET_DIR/socket" ./stash_plugin -d osdf:///ospool/uc-shared/public/OSG-Staff/validation/test.txt /dev/null
+exit_status=$?
+
+if ! [[ "$exit_status" = 0 ]]; then
+  echo "Cache plugin download failed"
+  exit 1
+fi
+
+if [ ! -e "$SOCKET_DIR/data/ospool/uc-shared/public/OSG-Staff/validation/test.txt.DONE" ]; then
+  echo "Test file not in local cache"
+  exit 1
+fi
+
 ########################################
 # Test we return 0 when HOME is not set
 ########################################


### PR DESCRIPTION
As requsted from the condor devs, Pelican now accepts PELICAN_NEAREST_CACHE. This is so this set environment varible looks more important and not confusing for what it is for when set in condor configuration