### PR TITLE
Fix director bug in looking up prefix for cache

### DIFF
--- a/cache/advertise.go
+++ b/cache/advertise.go
@@ -39,12 +39,14 @@ type (
 	}
 )
 
-func (server *CacheServer) CreateAdvertisement(name string, originUrl string, originWebUrl string) (*server_structs.OriginAdvertiseV2, error) {
+func (server *CacheServer) CreateAdvertisement(name, originUrl, originWebUrl string) (*server_structs.OriginAdvertiseV2, error) {
+	registryPrefix := "/caches/" + param.Xrootd_Sitename.GetString()
 	ad := server_structs.OriginAdvertiseV2{
-		Name:       name,
-		DataURL:    originUrl,
-		WebURL:     originWebUrl,
-		Namespaces: server.GetNamespaceAds(),
+		Name:           name,
+		RegistryPrefix: registryPrefix,
+		DataURL:        originUrl,
+		WebURL:         originWebUrl,
+		Namespaces:     server.GetNamespaceAds(),
 	}
 
 	return &ad, nil

--- a/director/director.go
+++ b/director/director.go
@@ -694,11 +694,13 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 		}
 	} else {
 		token := strings.TrimPrefix(tokens[0], "Bearer ")
-		// Use hostname from adv2.DataUrl instead of adv2.Name as Name is the site name
-		hostname := adUrl.Hostname()
 
-		prefix := path.Join("/caches", hostname)
-		ok, err := verifyAdvertiseToken(engineCtx, token, prefix)
+		registryPrefix := adV2.RegistryPrefix
+		if registryPrefix == "" { // For caches <= 7.8.1
+			registryPrefix = path.Join("/caches", adV2.Name)
+		}
+
+		ok, err := verifyAdvertiseToken(engineCtx, token, registryPrefix)
 		if err != nil {
 			if err == adminApprovalErr {
 				log.Warningf("Failed to verify token. Cache %q was not approved", adV2.Name)

--- a/origin/advertise.go
+++ b/origin/advertise.go
@@ -57,7 +57,7 @@ func (server *OriginServer) GetPids() (pids []int) {
 	return
 }
 
-func (server *OriginServer) CreateAdvertisement(name string, originUrlStr string, originWebUrl string) (*server_structs.OriginAdvertiseV2, error) {
+func (server *OriginServer) CreateAdvertisement(name, originUrlStr, originWebUrl string) (*server_structs.OriginAdvertiseV2, error) {
 	// Here we instantiate the namespaceAd slice, but we still need to define the namespace
 	issuerUrlStr, err := config.GetServerIssuerURL()
 	if err != nil {
@@ -112,10 +112,11 @@ func (server *OriginServer) CreateAdvertisement(name string, originUrlStr string
 	// PublicReads implies reads
 	reads := param.Origin_EnableReads.GetBool() || param.Origin_EnablePublicReads.GetBool()
 	ad := server_structs.OriginAdvertiseV2{
-		Name:       name,
-		DataURL:    originUrlStr,
-		WebURL:     originWebUrl,
-		Namespaces: nsAds,
+		Name:           name,
+		RegistryPrefix: "", // TODO: set origin's RegistryPrefix to /origins/{xrootd.sitename} once we support registering origins
+		DataURL:        originUrlStr,
+		WebURL:         originWebUrl,
+		Namespaces:     nsAds,
 		Caps: server_structs.Capabilities{
 			PublicReads: param.Origin_EnablePublicReads.GetBool(),
 			Reads:       reads,

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -369,10 +369,6 @@ func keySignChallengeCommit(ctx *gin.Context, data *registrationData) (bool, map
 			}
 		}
 
-		// Since CLI/auto-registered namespace did not have site name as part of their registration
-		// Use their IP for an educated guess
-		ns.AdminMetadata.SiteName = ctx.ClientIP()
-
 		// Overwrite status to Pending to filter malicious request
 		ns.AdminMetadata.Status = server_structs.RegPending
 

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -91,13 +91,18 @@ type (
 	StrategyType string
 
 	OriginAdvertiseV2 struct {
-		Name       string          `json:"name"`
-		BrokerURL  string          `json:"broker-url,omitempty"`
-		DataURL    string          `json:"data-url" binding:"required"`
-		WebURL     string          `json:"web-url,omitempty"`
-		Caps       Capabilities    `json:"capabilities"`
-		Namespaces []NamespaceAdV2 `json:"namespaces"`
-		Issuer     []TokenIssuer   `json:"token-issuer"`
+		// The displayed name of the server.
+		// The value is from the Sitename of the server registration in the registry if set, or Xrootd.Sitename if not
+		Name string `json:"name"`
+		// The namespace prefix to register/look up the server in the registry.
+		// The value is /caches/{Xrootd.Sitename} for cache servers and /origins/{Xrootd.Sitename} for the origin servers
+		RegistryPrefix string          `json:"registry-prefix"`
+		BrokerURL      string          `json:"broker-url,omitempty"`
+		DataURL        string          `json:"data-url" binding:"required"`
+		WebURL         string          `json:"web-url,omitempty"`
+		Caps           Capabilities    `json:"capabilities"`
+		Namespaces     []NamespaceAdV2 `json:"namespaces"`
+		Issuer         []TokenIssuer   `json:"token-issuer"`
 	}
 
 	OriginAdvertiseV1 struct {

--- a/web_ui/frontend/app/registry/components/util.tsx
+++ b/web_ui/frontend/app/registry/components/util.tsx
@@ -74,8 +74,11 @@ const namespaceFormNodeToJSON = (formData: FormData) => {
 
 export const namespaceToCache = (data: Namespace) => {
     // Build the cache prefix
-    data['prefix'] = `/caches/${data.prefix}`
+    if (data.prefix.startsWith("/caches")) {
+        return data
+    }
 
+    data['prefix'] = `/caches/${data.prefix}`
     return data
 }
 


### PR DESCRIPTION
Fixes #1241 

The bug was introduced in 7.8.0 where the director uses `hostname` of `DataURL` of the cache to concatenate with `/caches/{hostname}` for looking up the namespace prefix for the cache in the registry. This is based on the premise that the default value of `Xrootd.Sitename` is `Server.Hostname`, which is what the cache used to register itself at the registry.

However, in most of our ITB/production servers, we changed `Xrootd.Sitename` to something more human-readable, which causes the discrepancy between director look-up and what register records. 

This PR fixes the issue by adding a new field in origin/cache advertisement, `RegistryPrefix`, which is the full namespace prefix the cache used to register itself at the registry, i.e. `/caches/{Xrootd.Sitename}`, so that the director can use this value for registry look up.

This extra field will also help use build #1107 in the future.

This PR also fixed a bug in the UI where editing cache registration will prepend `/caches/` to the existing namespace prefix, causing duplicated prefix `/caches/caches/blah/blah`

Come with tests.