### PR TITLE
Plugin advertises PluginVersion

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -131,6 +131,7 @@ func stashPluginMain(args []string) {
 			// Print classad and exit
 			fmt.Println("MultipleFileSupport = true")
 			fmt.Println("PelicanPluginVersion = \"" + config.GetVersion() + "\"")
+			fmt.Println("PluginVersion = \"" + config.GetVersion() + "\"")
 			fmt.Println("PluginType = \"FileTransfer\"")
 			fmt.Println("ProtocolVersion = 2")
 			fmt.Println("SupportedMethods = \"stash, osdf\"")


### PR DESCRIPTION
Ran into an issue on ospool since the pelican plugin stopped advertising PluginVersion with -classad, this change reimplements that advertisement in addition with PelicanPluginVersion.