### PR TITLE
Fix bug when director returns 404 for PROPFIND

### DIFF
--- a/client/director.go
+++ b/client/director.go
@@ -152,7 +152,11 @@ func queryDirector(ctx context.Context, verb, sourcePath, directorUrl string) (r
 	body, _ := io.ReadAll(resp.Body)
 
 	// If we get a 404, the director will hopefully tell us why. It might be that the namespace doesn't exist
-	if resp.StatusCode == 404 {
+	if resp.StatusCode == 404 && verb == "PROPFIND" {
+		// If we get a 404 response from a PROPFIND, we are likely working with an old director so we should return a response
+		return resp, errors.New("404: " + string(body))
+	} else if resp.StatusCode == 404 {
+		// If we get a 404 response when we are not doing a PROPFIND, just return the 404 error without a response
 		return nil, errors.New("404: " + string(body))
 	} else if resp.StatusCode == http.StatusMethodNotAllowed && verb == "PROPFIND" {
 		// If we get a 405 with a PROPFIND, the client will handle it

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1097,11 +1097,14 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 		// Query the director a PROPFIND to see if we can get our directory listing
 		resp, err := queryDirector(tj.ctx, "PROPFIND", remoteUrl.Path, tj.directorUrl)
 		if err != nil {
-			// If we have an issue querying the director, we want to fallback to the deprecated dirlisthost from the namespace
-			// At this point, we have already queried the director (and it should have succeeded if we are here) so the error
-			// we get is most likely an issue with PROPFIND (and an outdated director). So we should try to continue.
-			if tj.namespace.DirListHost == "" {
-				return nil, err
+			if resp.StatusCode == http.StatusNotFound {
+				// If we have an issue querying the director, we want to fallback to the deprecated dirlisthost from the namespace
+				// At this point, we have already queried the director (and it should have succeeded if we are here) so the error
+				// we get is most likely an issue with PROPFIND (and an outdated director). So we should try to continue.
+				if tj.namespace.DirListHost == "" {
+					err = &dirListingNotSupportedError{Err: errors.New("origin and/or namespace does not support directory listings")}
+					return nil, err
+				}
 			}
 		} else if resp.StatusCode == http.StatusMethodNotAllowed {
 			// If the director responds with 405 (method not allowed), we're working with an old Director.


### PR DESCRIPTION
Found a bug when we try to PROPFIND against an outdated director, the director returns a 404 not found (because it redirects to a cache and that cache cannot find the object to PROPFIND so it returns a 404). When this happens the client returns just the error and not the response. Therefore, the fix is to check if we fail querying the director with a PROPFIND, we check if the namespace has a dirlisthost. If dirlisthost is present, we continue and otherwise, we fail. We'll need to eventually create a way to test against outdated directors but for now, we'll stick to this band-aid.