### PR TITLE
Pelican object ls command implementation

### DIFF
--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -979,7 +979,7 @@ func TestObjectList(t *testing.T) {
 }
 
 // This tests object ls but for an origin that supports listings but with an object store that does not support PROPFIND.
-// We should get a 405 returned. This is a seperate test since we need a completely different origin
+// We should get a 405 returned. This is a separate test since we need a completely different origin
 func TestObjectList405Error(t *testing.T) {
 	viper.Reset()
 	viper.Set("ConfigDir", t.TempDir())

--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -765,9 +765,15 @@ func TestObjectList(t *testing.T) {
 			os.Stdout = w
 
 			go func() {
-				err := client.DoList(fed.Ctx, uploadURL, nil, client.WithTokenLocation(tempToken.Name()))
-				require.NoError(t, err)
-				w.Close()
+				if export.Capabilities.PublicReads {
+					err := client.DoList(fed.Ctx, uploadURL, client.WithTokenLocation(""))
+					require.NoError(t, err)
+					w.Close()
+				} else {
+					err := client.DoList(fed.Ctx, uploadURL, client.WithTokenLocation(tempToken.Name()))
+					require.NoError(t, err)
+					w.Close()
+				}
 			}()
 			var buf bytes.Buffer
 			_, err = io.Copy(&buf, r)
@@ -790,12 +796,16 @@ func TestObjectList(t *testing.T) {
 			originalStdout := os.Stdout
 			os.Stdout = w
 
-			flags := map[string]bool{"dironly": true}
-
 			go func() {
-				err := client.DoList(fed.Ctx, uploadURL, flags, client.WithTokenLocation(tempToken.Name()))
-				require.NoError(t, err)
-				w.Close()
+				if export.Capabilities.PublicReads {
+					err := client.DoList(fed.Ctx, uploadURL, client.WithDirOnlyOption(true))
+					require.NoError(t, err)
+					w.Close()
+				} else {
+					err := client.DoList(fed.Ctx, uploadURL, client.WithDirOnlyOption(true), client.WithTokenLocation(tempToken.Name()))
+					require.NoError(t, err)
+					w.Close()
+				}
 			}()
 			var buf bytes.Buffer
 			_, err = io.Copy(&buf, r)
@@ -818,12 +828,16 @@ func TestObjectList(t *testing.T) {
 			originalStdout := os.Stdout
 			os.Stdout = w
 
-			flags := map[string]bool{"fileonly": true}
-
 			go func() {
-				err := client.DoList(fed.Ctx, uploadURL, flags, client.WithTokenLocation(tempToken.Name()))
-				require.NoError(t, err)
-				w.Close()
+				if export.Capabilities.PublicReads {
+					err := client.DoList(fed.Ctx, uploadURL, client.WithFileOnlyOption(true))
+					require.NoError(t, err)
+					w.Close()
+				} else {
+					err := client.DoList(fed.Ctx, uploadURL, client.WithFileOnlyOption(true), client.WithTokenLocation(tempToken.Name()))
+					require.NoError(t, err)
+					w.Close()
+				}
 			}()
 			var buf bytes.Buffer
 			_, err = io.Copy(&buf, r)
@@ -846,12 +860,16 @@ func TestObjectList(t *testing.T) {
 			originalStdout := os.Stdout
 			os.Stdout = w
 
-			flags := map[string]bool{"long": true}
-
 			go func() {
-				err := client.DoList(fed.Ctx, uploadURL, flags, client.WithTokenLocation(tempToken.Name()))
-				require.NoError(t, err)
-				w.Close()
+				if export.Capabilities.PublicReads {
+					err := client.DoList(fed.Ctx, uploadURL, client.WithLongOption(true))
+					require.NoError(t, err)
+					w.Close()
+				} else {
+					err := client.DoList(fed.Ctx, uploadURL, client.WithLongOption(true), client.WithTokenLocation(tempToken.Name()))
+					require.NoError(t, err)
+					w.Close()
+				}
 			}()
 			var buf bytes.Buffer
 			_, err = io.Copy(&buf, r)
@@ -890,12 +908,16 @@ func TestObjectList(t *testing.T) {
 			originalStdout := os.Stdout
 			os.Stdout = w
 
-			flags := map[string]bool{"fileonly": true}
-
 			go func() {
-				err := client.DoList(fed.Ctx, uploadURL, flags, client.WithTokenLocation(tempToken.Name()))
-				require.NoError(t, err)
-				w.Close()
+				if export.Capabilities.PublicReads {
+					err := client.DoList(fed.Ctx, uploadURL, client.WithFileOnlyOption(true))
+					require.NoError(t, err)
+					w.Close()
+				} else {
+					err := client.DoList(fed.Ctx, uploadURL, client.WithFileOnlyOption(true), client.WithTokenLocation(tempToken.Name()))
+					require.NoError(t, err)
+					w.Close()
+				}
 			}()
 			var buf bytes.Buffer
 			_, err = io.Copy(&buf, r)

--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -770,7 +770,8 @@ func TestObjectList(t *testing.T) {
 				w.Close()
 			}()
 			var buf bytes.Buffer
-			io.Copy(&buf, r)
+			_, err = io.Copy(&buf, r)
+			require.NoError(t, err)
 			os.Stdout = originalStdout
 
 			assert.Contains(t, buf.String(), "hello_world.txt")
@@ -797,7 +798,8 @@ func TestObjectList(t *testing.T) {
 				w.Close()
 			}()
 			var buf bytes.Buffer
-			io.Copy(&buf, r)
+			_, err = io.Copy(&buf, r)
+			require.NoError(t, err)
 			os.Stdout = originalStdout
 
 			assert.Contains(t, buf.String(), "test")
@@ -824,7 +826,8 @@ func TestObjectList(t *testing.T) {
 				w.Close()
 			}()
 			var buf bytes.Buffer
-			io.Copy(&buf, r)
+			_, err = io.Copy(&buf, r)
+			require.NoError(t, err)
 			os.Stdout = originalStdout
 
 			assert.NotContains(t, buf.String(), "test")
@@ -851,7 +854,8 @@ func TestObjectList(t *testing.T) {
 				w.Close()
 			}()
 			var buf bytes.Buffer
-			io.Copy(&buf, r)
+			_, err = io.Copy(&buf, r)
+			require.NoError(t, err)
 			os.Stdout = originalStdout
 
 			assert.Contains(t, buf.String(), "test")
@@ -894,7 +898,8 @@ func TestObjectList(t *testing.T) {
 				w.Close()
 			}()
 			var buf bytes.Buffer
-			io.Copy(&buf, r)
+			_, err = io.Copy(&buf, r)
+			require.NoError(t, err)
 			os.Stdout = originalStdout
 
 			assert.Contains(t, buf.String(), "hello_world.txt")

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -37,6 +37,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
+	"text/tabwriter"
 	"time"
 
 	"github.com/VividCortex/ewma"
@@ -1098,48 +1099,11 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 	// If we are a recursive download and using the director, we want to attempt to get directory listings from
 	// PROPFINDing the director
 	if recursive && !upload && tj.useDirector {
-		// Query the director a PROPFIND to see if we can get our directory listing
-		resp, err := queryDirector(tj.ctx, "PROPFIND", remoteUrl.Path, tj.directorUrl)
+		dirListHost, err := getDirListHost(tj.ctx, remoteUrl, tj.namespace, tj.directorUrl)
 		if err != nil {
-			if resp.StatusCode == http.StatusNotFound {
-				// If we have an issue querying the director, we want to fallback to the deprecated dirlisthost from the namespace
-				// At this point, we have already queried the director (and it should have succeeded if we are here) so the error
-				// we get is most likely an issue with PROPFIND (and an outdated director). So we should try to continue.
-				if tj.namespace.DirListHost == "" {
-					err = &dirListingNotSupportedError{Err: errors.New("origin and/or namespace does not support directory listings")}
-					return nil, err
-				}
-			}
-		} else if resp.StatusCode == http.StatusMethodNotAllowed {
-			// If the director responds with 405 (method not allowed), we're working with an old Director.
-			// In that event, we try to fallback and use the deprecated dirlisthost
-			log.Debugln("Failed to find collections url from director, attempting to find directory listings host in namespace")
-			// Check for a dir list host in namespace
-			if tj.namespace.DirListHost == "" {
-				// Both methods to get directory listings failed
-				err = &dirListingNotSupportedError{Err: errors.New("origin and/or namespace does not support directory listings")}
-				return nil, err
-			}
-		} else if resp.StatusCode == http.StatusTemporaryRedirect {
-			// If the director responds with a 307 (temporary redirect), we're working with a new Director.
-			// In that event, we can get the collections URL from our redirect
-			collections := resp.Header.Get("Location")
-			if collections == "" {
-				return nil, errors.New("collections URL not found in director response")
-			}
-			// The resp redirect includes the full path to the object from the origin, we are only interested in the scheme and host
-			collectionsURL, err := url.Parse(collections)
-			if err != nil {
-				return nil, err
-			}
-			dirlisthost := url.URL{
-				Scheme: collectionsURL.Scheme,
-				Host:   collectionsURL.Host,
-			}
-			tj.namespace.DirListHost = dirlisthost.String()
-		} else {
-			return nil, fmt.Errorf("unexpected response from director when requesting collections url from origin: %v", resp.Status)
+			return nil, err
 		}
+		tj.namespace.DirListHost = dirListHost.String()
 	}
 
 	log.Debugf("Created new transfer job, ID %s client %s, for URL %s", tj.uuid.String(), tc.id.String(), remoteUrl.String())
@@ -2284,6 +2248,82 @@ func runPut(request *http.Request, responseChan chan<- *http.Response, errorChan
 
 }
 
+// This function queries the director with a PROPFIND to attempt to get the 'dirListHost'. If a propfind is not allowed on the director
+// We fall back to the deprecated dirlisthost in the namespace
+func getDirListHost(ctx context.Context, remoteObjectUrl *url.URL, namespace namespaces.Namespace, directorUrl string) (dirListHost *url.URL, err error) {
+	// If we are a recursive download and using the director, we want to attempt to get directory listings from
+	// PROPFINDing the director
+	if directorUrl != "" {
+		// Query the director a PROPFIND to see if we can get our directory listing
+		resp, err := queryDirector(ctx, "PROPFIND", remoteObjectUrl.Path, directorUrl)
+		if err != nil {
+			if resp.StatusCode == http.StatusNotFound {
+				// If we have an issue querying the director, we want to fallback to the deprecated dirlisthost from the namespace
+				// At this point, we have already queried the director (and it should have succeeded if we are here) so the error
+				// we get is most likely an issue with PROPFIND (and an outdated director). So we should try to continue.
+				if namespace.DirListHost == "" {
+					err = &dirListingNotSupportedError{Err: errors.New("origin and/or namespace does not support directory listings")}
+					return nil, err
+				} else {
+					dirListHost, err = url.Parse(namespace.DirListHost)
+					if err != nil {
+						return nil, err
+					}
+					return dirListHost, nil
+				}
+			} else {
+				return nil, err
+			}
+		} else if resp.StatusCode == http.StatusMethodNotAllowed {
+			// If the director responds with 405 (method not allowed), we're working with an old Director.
+			// In that event, we try to fallback and use the deprecated dirlisthost
+			log.Debugln("Failed to find collections url from director, attempting to find directory listings host in namespace")
+			// Check for a dir list host in namespace
+			if namespace.DirListHost == "" {
+				// Both methods to get directory listings failed
+				err = &dirListingNotSupportedError{Err: errors.New("origin and/or namespace does not support directory listings")}
+				return nil, err
+			} else {
+				dirListHost, err = url.Parse(namespace.DirListHost)
+				if err != nil {
+					return nil, err
+				}
+				return dirListHost, nil
+			}
+		} else if resp.StatusCode == http.StatusTemporaryRedirect {
+			// If the director responds with a 307 (temporary redirect), we're working with a new Director.
+			// In that event, we can get the collections URL from our redirect
+			collections := resp.Header.Get("Location")
+			if collections == "" {
+				return nil, errors.New("collections URL not found in director response")
+			}
+			// The resp redirect includes the full path to the object from the origin, we are only interested in the scheme and host
+			collectionsURL, err := url.Parse(collections)
+			if err != nil {
+				return nil, err
+			}
+			dirListHost = &url.URL{
+				Scheme: collectionsURL.Scheme,
+				Host:   collectionsURL.Host,
+			}
+			namespace.DirListHost = dirListHost.String()
+		} else {
+			return nil, errors.Errorf("unexpected response from director when requesting collections url from origin: %v", resp.Status)
+		}
+	} else if namespace.DirListHost != "" {
+		// If we're not using the director and are using topology, we should check for a dirlisthost from the namespace
+		dirListHost, err = url.Parse(namespace.DirListHost)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse directory listing host as a url")
+		}
+	} else {
+		// If we hit this point, we are not using the director and the namespace does not have a DirListHost therefore, the origin and/or namespace does not support it
+		err = &dirListingNotSupportedError{Err: errors.New("origin and/or namespace does not support directory listings")}
+		return nil, err
+	}
+	return
+}
+
 // Walk a remote directory in a WebDAV server, emitting the files discovered
 func (te *TransferEngine) walkDirDownload(job *clientTransferJob, transfers []transferAttemptDetails, files chan *clientTransferFile, url *url.URL) error {
 	// Create the client to walk the filesystem
@@ -2407,6 +2447,94 @@ func (te *TransferEngine) walkDirUpload(job *clientTransferJob, transfers []tran
 		}
 	}
 	return err
+}
+
+// This function performs the ls command by walking through the specified directory and printing the contents of the files
+func listHttp(ctx context.Context, remoteObjectUrl *url.URL, directorUrl string, namespace namespaces.Namespace, token string, flagOptions map[string]bool) (err error) {
+	// Get our directory listing host
+	dirListHost, err := getDirListHost(ctx, remoteObjectUrl, namespace, directorUrl)
+	if err != nil {
+		return
+	}
+	log.Debugln("Dir list host: ", dirListHost.String())
+
+	auth := &bearerAuth{token: token}
+	client := gowebdav.NewAuthClient(dirListHost.String(), auth)
+
+	// XRootD does not like keep alives and kills things, so turn them off.
+	transport := config.GetTransport()
+	client.SetTransport(transport)
+	remotePath := remoteObjectUrl.Path
+
+	infos, err := client.ReadDir(remotePath)
+	if err != nil {
+		// Check if we got a 404:
+		if gowebdav.IsErrNotFound(err) {
+			err = errors.Wrap(err, "file not found")
+		} else if gowebdav.IsErrCode(err, 500) {
+			// If we get an error code 500 (internal server error), we should check if the user is trying to ls on a file
+			info, err := client.Stat(remotePath)
+			if err != nil {
+				return errors.Wrap(err, "failed to stat remote path")
+			}
+			// If the path leads to a file and not a directory, just print the filename
+			if !info.IsDir() {
+				// Note: for some reason info.Name() returns nothing, so just printing base of the provided path since it should be the same
+				fmt.Println(path.Base(remotePath))
+				return nil
+			}
+		}
+		// Otherwise, a different error occurred and we should return it
+		return errors.Wrap(err, "failed to read remote directory")
+	}
+
+	// if the -L flag was set, we print more information
+	if flagOptions["long"] {
+		w := tabwriter.NewWriter(os.Stdout, 1, 2, 10, ' ', tabwriter.TabIndent|tabwriter.DiscardEmptyColumns)
+		for _, info := range infos {
+			if info.IsDir() && flagOptions["fileonly"] {
+				// If the object is a directory and we have fileonly (-F) set, ignore it
+				continue
+			} else if !info.IsDir() && flagOptions["dironly"] {
+				// If the object is a file and we have dironly (-D) set, ignore it
+				continue
+			}
+			fmt.Fprintln(w, info.Name()+"\t"+strconv.FormatInt(info.Size(), 10)+"\t"+info.ModTime().Format("2006-01-02 15:04:05")+"\t"+info.Mode().String())
+		}
+		w.Flush()
+	} else {
+		totalColumns := 4
+		// column is a counter letting us know what item/column we are on (can't use index in loop below since we have continues on conditions)
+		var column int
+		w := tabwriter.NewWriter(os.Stdout, 1, 2, 10, ' ', tabwriter.TabIndent|tabwriter.DiscardEmptyColumns)
+		var line string
+		for _, info := range infos {
+			if info.IsDir() && flagOptions["fileonly"] {
+				// If the object is a directory and we have fileonly (-F) set, ignore it
+				continue
+			} else if !info.IsDir() && flagOptions["dironly"] {
+				// If the object is a file and we have dironly (-D) set, ignore it
+				continue
+			}
+			line += info.Name()
+			//increase our counter
+			column++
+
+			// This section just checks if we go thru <numColumns> times, we print a newline. Otherwise, add the object to the current line with a tab after
+			if column%totalColumns == 0 {
+				fmt.Fprintln(w, line)
+				line = ""
+			} else {
+				line += "\t"
+			}
+		}
+		// If we have anything remaining in line, print it
+		if line != "" {
+			fmt.Fprintln(w, line)
+		}
+		w.Flush()
+	}
+	return nil
 }
 
 // Invoke HEAD against a remote URL, using the provided namespace information

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2499,6 +2499,9 @@ func listHttp(ctx context.Context, remoteObjectUrl *url.URL, directorUrl string,
 				fileInfos = append(fileInfos, file)
 				return fileInfos, nil
 			}
+		} else if gowebdav.IsErrCode(err, http.StatusMethodNotAllowed) {
+			// We replace the error from gowebdav with our own because gowebdav returns: "ReadDir /prefix/different-path/: 405" which is not very user friendly
+			return nil, errors.New("405: object listings are not supported by the specified origin")
 		}
 		// Otherwise, a different error occurred and we should return it
 		return nil, errors.Wrap(err, "failed to read remote directory")

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2477,7 +2477,7 @@ func (f *fileInfo) Size() int64        { return f.size }
 func (f *fileInfo) Mode() os.FileMode  { return f.mode }
 func (f *fileInfo) ModTime() time.Time { return f.modTime }
 func (f *fileInfo) IsDir() bool        { return f.isDir }
-func (f *fileInfo) Sys() interface{}   { return nil } // Return nil or a suitable value
+func (f *fileInfo) Sys() interface{}   { return nil }
 
 // This function performs the ls command by walking through the specified directory and printing the contents of the files
 func listHttp(ctx context.Context, remoteObjectUrl *url.URL, directorUrl string, namespace namespaces.Namespace, token string, options ...TransferOption) (fileInfos []fs.FileInfo, err error) {

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -936,9 +936,10 @@ func TestNewTransferEngine(t *testing.T) {
 	})
 }
 
-func TestGetDirListHost(t *testing.T) {
+func TestGetCollectionsUrl(t *testing.T) {
 	viper.Reset()
 	defer viper.Reset()
+	viper.Set("ConfigDir", t.TempDir())
 	config.InitConfig()
 	ctx := context.Background()
 	err := config.InitClient()
@@ -956,7 +957,7 @@ func TestGetDirListHost(t *testing.T) {
 		testObjectUrl, err := url.Parse("pelican://federation/some/object")
 		require.NoError(t, err)
 
-		dirListHost, err := getDirListHost(ctx, testObjectUrl, namespaces.Namespace{}, server.URL)
+		dirListHost, err := getCollectionsUrl(ctx, testObjectUrl, namespaces.Namespace{}, server.URL)
 		require.NoError(t, err)
 		assert.Equal(t, "http://some", dirListHost.String())
 	})
@@ -972,7 +973,7 @@ func TestGetDirListHost(t *testing.T) {
 		testObjectUrl, err := url.Parse("pelican://federation/some/object")
 		require.NoError(t, err)
 
-		dirListHost, err := getDirListHost(ctx, testObjectUrl, namespaces.Namespace{DirListHost: expectedLocation}, server.URL)
+		dirListHost, err := getCollectionsUrl(ctx, testObjectUrl, namespaces.Namespace{DirListHost: expectedLocation}, server.URL)
 		require.NoError(t, err)
 		assert.Equal(t, expectedLocation, dirListHost.String())
 	})
@@ -988,7 +989,7 @@ func TestGetDirListHost(t *testing.T) {
 		testObjectUrl, err := url.Parse("pelican://federation/some/object")
 		require.NoError(t, err)
 
-		dirListHost, err := getDirListHost(ctx, testObjectUrl, namespaces.Namespace{DirListHost: expectedLocation}, server.URL)
+		dirListHost, err := getCollectionsUrl(ctx, testObjectUrl, namespaces.Namespace{DirListHost: expectedLocation}, server.URL)
 		require.NoError(t, err)
 		assert.Equal(t, expectedLocation, dirListHost.String())
 	})
@@ -998,7 +999,7 @@ func TestGetDirListHost(t *testing.T) {
 		expectedLocation := "http://origin"
 		testObjectUrl, err := url.Parse("pelican://federation/some/object")
 		require.NoError(t, err)
-		dirListHost, err := getDirListHost(ctx, testObjectUrl, namespaces.Namespace{DirListHost: expectedLocation}, "")
+		dirListHost, err := getCollectionsUrl(ctx, testObjectUrl, namespaces.Namespace{DirListHost: expectedLocation}, "")
 		require.NoError(t, err)
 		assert.Equal(t, expectedLocation, dirListHost.String())
 	})
@@ -1013,7 +1014,7 @@ func TestGetDirListHost(t *testing.T) {
 		testObjectUrl, err := url.Parse("pelican://federation/some/object")
 		require.NoError(t, err)
 
-		_, err = getDirListHost(ctx, testObjectUrl, namespaces.Namespace{}, server.URL)
+		_, err = getCollectionsUrl(ctx, testObjectUrl, namespaces.Namespace{}, server.URL)
 		require.Error(t, err)
 		assert.IsType(t, &dirListingNotSupportedError{}, err)
 	})
@@ -1027,7 +1028,7 @@ func TestGetDirListHost(t *testing.T) {
 		defer server.Close()
 		testObjectUrl, err := url.Parse("pelican://federation/some/object")
 		require.NoError(t, err)
-		_, err = getDirListHost(ctx, testObjectUrl, namespaces.Namespace{}, server.URL)
+		_, err = getCollectionsUrl(ctx, testObjectUrl, namespaces.Namespace{}, server.URL)
 		require.Error(t, err)
 		assert.IsType(t, &dirListingNotSupportedError{}, err)
 	})
@@ -1036,7 +1037,7 @@ func TestGetDirListHost(t *testing.T) {
 	t.Run("testNoDirectorNoDirListInNamespace", func(t *testing.T) {
 		testObjectUrl, err := url.Parse("pelican://federation/some/object")
 		require.NoError(t, err)
-		_, err = getDirListHost(ctx, testObjectUrl, namespaces.Namespace{}, "")
+		_, err = getCollectionsUrl(ctx, testObjectUrl, namespaces.Namespace{}, "")
 		require.Error(t, err)
 		assert.IsType(t, &dirListingNotSupportedError{}, err)
 	})
@@ -1051,7 +1052,7 @@ func TestGetDirListHost(t *testing.T) {
 		testObjectUrl, err := url.Parse("pelican://federation/some/object")
 		require.NoError(t, err)
 
-		_, err = getDirListHost(ctx, testObjectUrl, namespaces.Namespace{}, server.URL)
+		_, err = getCollectionsUrl(ctx, testObjectUrl, namespaces.Namespace{}, server.URL)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "collections URL not found in director response")
 	})
@@ -1069,7 +1070,7 @@ func TestGetDirListHost(t *testing.T) {
 		testObjectUrl, err := url.Parse("pelican://federation/some/object")
 		require.NoError(t, err)
 
-		_, err = getDirListHost(ctx, testObjectUrl, namespaces.Namespace{}, server.URL)
+		_, err = getCollectionsUrl(ctx, testObjectUrl, namespaces.Namespace{}, server.URL)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "some server error")
 	})

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -936,6 +936,8 @@ func TestNewTransferEngine(t *testing.T) {
 	})
 }
 
+// Test the functionality of getting the collections URL from the director or from the namespace ad.
+// Tests different responses from the director with and without 'dirlisthost' specified in the namespace.
 func TestGetCollectionsUrl(t *testing.T) {
 	viper.Reset()
 	defer viper.Reset()

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -1057,7 +1057,8 @@ func TestGetDirListHost(t *testing.T) {
 		handler := func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusServiceUnavailable)
-			json.NewEncoder(w).Encode(map[string]string{"error": "some server error"})
+			err := json.NewEncoder(w).Encode(map[string]string{"error": "some server error"})
+			require.NoError(t, err)
 		}
 		server := httptest.NewServer(http.HandlerFunc(handler))
 		defer server.Close()

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/mock"
 	"github.com/pelicanplatform/pelican/namespaces"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
 )
 
@@ -949,6 +950,11 @@ func TestGetDirListHost(t *testing.T) {
 		ctx := context.Background()
 		testObjectUrl, err := url.Parse("pelican://federation/some/object")
 		require.NoError(t, err)
+
+		// Wait until our server is working
+		err = server_utils.WaitUntilWorking(ctx, "PROPFIND", server.URL, "testServer", http.StatusTemporaryRedirect, true)
+		require.NoError(t, err)
+
 		dirListHost, err := getDirListHost(ctx, testObjectUrl, namespaces.Namespace{}, server.URL)
 		require.NoError(t, err)
 		assert.Equal(t, "http://some", dirListHost.String())
@@ -965,6 +971,11 @@ func TestGetDirListHost(t *testing.T) {
 		ctx := context.Background()
 		testObjectUrl, err := url.Parse("pelican://federation/some/object")
 		require.NoError(t, err)
+
+		// Wait until our server is working
+		err = server_utils.WaitUntilWorking(ctx, "PROPFIND", server.URL, "testServer", http.StatusMethodNotAllowed, true)
+		require.NoError(t, err)
+
 		dirListHost, err := getDirListHost(ctx, testObjectUrl, namespaces.Namespace{DirListHost: expectedLocation}, server.URL)
 		require.NoError(t, err)
 		assert.Equal(t, expectedLocation, dirListHost.String())
@@ -981,6 +992,11 @@ func TestGetDirListHost(t *testing.T) {
 		ctx := context.Background()
 		testObjectUrl, err := url.Parse("pelican://federation/some/object")
 		require.NoError(t, err)
+
+		// Wait until our server is working
+		err = server_utils.WaitUntilWorking(ctx, "PROPFIND", server.URL, "testServer", http.StatusNotFound, true)
+		require.NoError(t, err)
+
 		dirListHost, err := getDirListHost(ctx, testObjectUrl, namespaces.Namespace{DirListHost: expectedLocation}, server.URL)
 		require.NoError(t, err)
 		assert.Equal(t, expectedLocation, dirListHost.String())
@@ -1007,6 +1023,11 @@ func TestGetDirListHost(t *testing.T) {
 		ctx := context.Background()
 		testObjectUrl, err := url.Parse("pelican://federation/some/object")
 		require.NoError(t, err)
+
+		// Wait until our server is working
+		err = server_utils.WaitUntilWorking(ctx, "PROPFIND", server.URL, "testServer", http.StatusMethodNotAllowed, true)
+		require.NoError(t, err)
+
 		_, err = getDirListHost(ctx, testObjectUrl, namespaces.Namespace{}, server.URL)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, &dirListingNotSupportedError{})
@@ -1047,6 +1068,11 @@ func TestGetDirListHost(t *testing.T) {
 		ctx := context.Background()
 		testObjectUrl, err := url.Parse("pelican://federation/some/object")
 		require.NoError(t, err)
+
+		// Wait until our server is working
+		err = server_utils.WaitUntilWorking(ctx, "PROPFIND", server.URL, "testServer", http.StatusTemporaryRedirect, true)
+		require.NoError(t, err)
+
 		_, err = getDirListHost(ctx, testObjectUrl, namespaces.Namespace{}, server.URL)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "collections URL not found in director response")
@@ -1065,6 +1091,11 @@ func TestGetDirListHost(t *testing.T) {
 		ctx := context.Background()
 		testObjectUrl, err := url.Parse("pelican://federation/some/object")
 		require.NoError(t, err)
+
+		// Wait until our server is working
+		err = server_utils.WaitUntilWorking(ctx, "PROPFIND", server.URL, "testServer", http.StatusServiceUnavailable, true)
+		require.NoError(t, err)
+
 		_, err = getDirListHost(ctx, testObjectUrl, namespaces.Namespace{}, server.URL)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "some server error")

--- a/client/main.go
+++ b/client/main.go
@@ -470,8 +470,8 @@ func schemeUnderstood(scheme string) error {
 	return nil
 }
 
-// TODO function header
-func DoList(ctx context.Context, remoteObject string, options ...TransferOption) (err error) { //TODO change from TransferOption to something with ls
+// Function for the object ls command, we get target information for our remote object and eventually print out the contents of the specified object
+func DoList(ctx context.Context, remoteObject string, options ...TransferOption) (err error) {
 	// First, create a handler for any panics that occur
 	defer func() {
 		if r := recover(); r != nil {
@@ -547,6 +547,7 @@ func DoList(ctx context.Context, remoteObject string, options ...TransferOption)
 		return err
 	}
 
+	// Take our fileInfos and print them in a nice way
 	// if the -L flag was set, we print more information
 	if long {
 		w := tabwriter.NewWriter(os.Stdout, 1, 2, 10, ' ', tabwriter.TabIndent|tabwriter.DiscardEmptyColumns)
@@ -562,6 +563,7 @@ func DoList(ctx context.Context, remoteObject string, options ...TransferOption)
 		}
 		w.Flush()
 	} else {
+		// We print using a tabwriter to enhance readability of the listed files and to make things look nicer
 		totalColumns := 4
 		// column is a counter letting us know what item/column we are on (can't use index in loop below since we have continues on conditions)
 		var column int

--- a/client/main.go
+++ b/client/main.go
@@ -552,7 +552,7 @@ func DoList(ctx context.Context, remoteObject string, options ...TransferOption)
 		}
 	}
 
-	// If a user specifies dirOnly and fileOnly, this means basic functionality (list both files and directories) so just remove the flags
+	// If a user specifies dirOnly and objectOnly, this means basic functionality (list both objects and directories) so just remove the flags
 	if dironly && objectonly {
 		dironly = false
 		objectonly = false

--- a/client/resources/test-https-origin.yml
+++ b/client/resources/test-https-origin.yml
@@ -1,0 +1,8 @@
+# This is used to test an origin with an https backend
+Logging:
+  Cache:
+    Scitokens: debug
+Origin:
+  StorageType: https
+  FederationPrefix: /test
+  EnablePublicReads: true

--- a/cmd/object_ls.go
+++ b/cmd/object_ls.go
@@ -42,6 +42,7 @@ func init() {
 	flagSet.BoolP("long", "L", false, "Include extended information")
 	flagSet.BoolP("dironly", "D", false, "List directories only")
 	flagSet.BoolP("fileonly", "F", false, "List files only")
+	flagSet.BoolP("json", "j", false, "Print results in JSON format")
 
 	objectCmd.AddCommand(lsCmd)
 }
@@ -77,9 +78,10 @@ func listMain(cmd *cobra.Command, args []string) {
 	long, _ := cmd.Flags().GetBool("long")
 	dirOnly, _ := cmd.Flags().GetBool("dironly")
 	fileOnly, _ := cmd.Flags().GetBool("fileonly")
+	json, _ := cmd.Flags().GetBool("json")
 
 	result := client.DoList(ctx, object, client.WithTokenLocation(tokenLocation), client.WithLongOption(long),
-		client.WithDirOnlyOption(dirOnly), client.WithFileOnlyOption(fileOnly))
+		client.WithDirOnlyOption(dirOnly), client.WithFileOnlyOption(fileOnly), client.WithJsonOption(json))
 
 	// Exit with failure
 	if result != nil {

--- a/cmd/object_ls.go
+++ b/cmd/object_ls.go
@@ -21,11 +21,12 @@ package main
 import (
 	"os"
 
-	"github.com/pelicanplatform/pelican/client"
-	"github.com/pelicanplatform/pelican/config"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/config"
 )
 
 var (
@@ -41,7 +42,7 @@ func init() {
 	flagSet.StringP("token", "t", "", "Token file to use for transfer")
 	flagSet.BoolP("long", "L", false, "Include extended information")
 	flagSet.BoolP("dironly", "D", false, "List directories only")
-	flagSet.BoolP("fileonly", "F", false, "List files only")
+	flagSet.BoolP("objectonly", "O", false, "List objects only")
 	flagSet.BoolP("json", "j", false, "Print results in JSON format")
 
 	objectCmd.AddCommand(lsCmd)
@@ -77,22 +78,22 @@ func listMain(cmd *cobra.Command, args []string) {
 
 	long, _ := cmd.Flags().GetBool("long")
 	dirOnly, _ := cmd.Flags().GetBool("dironly")
-	fileOnly, _ := cmd.Flags().GetBool("fileonly")
+	objectOnly, _ := cmd.Flags().GetBool("objectonly")
 	json, _ := cmd.Flags().GetBool("json")
 
-	result := client.DoList(ctx, object, client.WithTokenLocation(tokenLocation), client.WithLongOption(long),
-		client.WithDirOnlyOption(dirOnly), client.WithFileOnlyOption(fileOnly), client.WithJsonOption(json))
+	err = client.DoList(ctx, object, client.WithTokenLocation(tokenLocation), client.WithLongOption(long),
+		client.WithDirOnlyOption(dirOnly), client.WithObjectOnlyOption(objectOnly), client.WithJsonOption(json))
 
 	// Exit with failure
-	if result != nil {
+	if err != nil {
 		// Print the list of errors
-		errMsg := result.Error()
+		errMsg := err.Error()
 		var te *client.TransferErrors
-		if errors.As(result, &te) {
+		if errors.As(err, &te) {
 			errMsg = te.UserError()
 		}
 		log.Errorln("Failure getting " + object + ": " + errMsg)
-		if client.ShouldRetry(result) {
+		if client.ShouldRetry(err) {
 			log.Errorln("Errors are retryable")
 			os.Exit(11)
 		}

--- a/cmd/object_ls.go
+++ b/cmd/object_ls.go
@@ -43,7 +43,6 @@ func init() {
 	flagSet.BoolP("dironly", "D", false, "List directories only")
 	flagSet.BoolP("fileonly", "F", false, "List files only")
 
-	//flagSet.BoolP("recursive", "r", false, "Recursively list a directory. Will list all nested directories within specified directory")
 	objectCmd.AddCommand(lsCmd)
 }
 
@@ -79,14 +78,8 @@ func listMain(cmd *cobra.Command, args []string) {
 	dirOnly, _ := cmd.Flags().GetBool("dironly")
 	fileOnly, _ := cmd.Flags().GetBool("fileonly")
 
-	options := map[string]bool{
-		"long":     long,
-		"dironly":  dirOnly,
-		"fileonly": fileOnly,
-	}
-
-	//isRecursive, _ := cmd.Flags().GetBool("recursive")
-	result := client.DoList(ctx, object, options, client.WithTokenLocation(tokenLocation))
+	result := client.DoList(ctx, object, client.WithTokenLocation(tokenLocation), client.WithLongOption(long),
+		client.WithDirOnlyOption(dirOnly), client.WithFileOnlyOption(fileOnly))
 
 	// Exit with failure
 	if result != nil {

--- a/cmd/object_ls.go
+++ b/cmd/object_ls.go
@@ -1,0 +1,106 @@
+/***************************************************************
+*
+* Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
+
+package main
+
+import (
+	"os"
+
+	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	lsCmd = &cobra.Command{
+		Use:   "ls {object}",
+		Short: "List objects in a namespace from a federation",
+		Run:   listMain,
+	}
+)
+
+func init() {
+	flagSet := lsCmd.Flags()
+	flagSet.StringP("token", "t", "", "Token file to use for transfer")
+	flagSet.BoolP("long", "L", false, "Include extended information")
+	flagSet.BoolP("dironly", "D", false, "List directories only")
+	flagSet.BoolP("fileonly", "F", false, "List files only")
+
+	//flagSet.BoolP("recursive", "r", false, "Recursively list a directory. Will list all nested directories within specified directory")
+	objectCmd.AddCommand(lsCmd)
+}
+
+func listMain(cmd *cobra.Command, args []string) {
+	ctx := cmd.Context()
+	err := config.InitClient()
+	if err != nil {
+		log.Errorln(err)
+
+		if client.IsRetryable(err) {
+			log.Errorln("Errors are retryable")
+			os.Exit(11)
+		} else {
+			os.Exit(1)
+		}
+	}
+
+	tokenLocation, _ := cmd.Flags().GetString("token")
+
+	if len(args) < 1 {
+		log.Errorln("no object provided")
+		err = cmd.Help()
+		if err != nil {
+			log.Errorln("failed to print out help:", err)
+		}
+		os.Exit(1)
+	}
+	object := args[len(args)-1]
+
+	log.Debugln("Object:", object)
+
+	long, _ := cmd.Flags().GetBool("long")
+	dirOnly, _ := cmd.Flags().GetBool("dironly")
+	fileOnly, _ := cmd.Flags().GetBool("fileonly")
+
+	options := map[string]bool{
+		"long":     long,
+		"dironly":  dirOnly,
+		"fileonly": fileOnly,
+	}
+
+	//isRecursive, _ := cmd.Flags().GetBool("recursive")
+	result := client.DoList(ctx, object, options, client.WithTokenLocation(tokenLocation))
+
+	// Exit with failure
+	if result != nil {
+		// Print the list of errors
+		errMsg := result.Error()
+		var te *client.TransferErrors
+		if errors.As(result, &te) {
+			errMsg = te.UserError()
+		}
+		log.Errorln("Failure getting " + object + ": " + errMsg)
+		if client.ShouldRetry(result) {
+			log.Errorln("Errors are retryable")
+			os.Exit(11)
+		}
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
New command added `pelican object ls` that lists the objects of the specified dir in a namespace (or on the namespace itself). This PR also comes with tests for this new command as well as tests for a helper function to obtain 'dirlisthost'. The new command with a few sets of flags that I felt were the most important from the standard 'ls' command.

This still needs a little more polishing, but I thought to go ahead and make the PR if anyone wants to take a look and to push my current progress on this new command