### PR TITLE
Throw clear error when InitClient() not called

### DIFF
--- a/client/fed_linux_test.go
+++ b/client/fed_linux_test.go
@@ -49,7 +49,8 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 
 	fed := fed_test_utils.NewFedTest(t, mixedAuthOriginCfg)
 
-	te := client.NewTransferEngine(fed.Ctx)
+	te, err := client.NewTransferEngine(fed.Ctx)
+	require.NoError(t, err)
 
 	// Create a token file
 	issuer, err := config.GetServerIssuerURL()
@@ -243,7 +244,8 @@ func TestRecursiveUploadsAndDownloadsWithQuery(t *testing.T) {
 
 	fed := fed_test_utils.NewFedTest(t, mixedAuthOriginCfg)
 
-	te := client.NewTransferEngine(fed.Ctx)
+	te, err := client.NewTransferEngine(fed.Ctx)
+	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		if err := te.Shutdown(); err != nil {

--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -223,7 +223,8 @@ func TestCopyAuth(t *testing.T) {
 	server_utils.ResetOriginExports()
 	fed := fed_test_utils.NewFedTest(t, bothAuthOriginCfg)
 
-	te := client.NewTransferEngine(fed.Ctx)
+	te, err := client.NewTransferEngine(fed.Ctx)
+	require.NoError(t, err)
 
 	// Other set-up items:
 	testFileContent := "test file content"
@@ -624,7 +625,8 @@ func TestNewTransferJob(t *testing.T) {
 	defer server_utils.ResetOriginExports()
 	fed := fed_test_utils.NewFedTest(t, mixedAuthOriginCfg)
 
-	te := client.NewTransferEngine(fed.Ctx)
+	te, err := client.NewTransferEngine(fed.Ctx)
+	require.NoError(t, err)
 
 	// Test when we have a failure during namespace lookup (here we will get a 404)
 	t.Run("testFailureToGetNamespaceInfo", func(t *testing.T) {

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -47,6 +47,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	viper.Reset()
 	if err := config.InitClient(); err != nil {
 		os.Exit(1)
 	}
@@ -596,7 +597,9 @@ func TestNewPelicanURL(t *testing.T) {
 
 	t.Run("TestOsdfOrStashSchemeWithOSDFPrefixNoError", func(t *testing.T) {
 		viper.Reset()
-		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
+		err := config.InitClient()
+		require.NoError(t, err)
+		_, err = config.SetPreferredPrefix(config.OsdfPrefix)
 		viper.Set("ConfigDir", t.TempDir())
 		assert.NoError(t, err)
 		// Init config to get proper timeouts
@@ -627,7 +630,9 @@ func TestNewPelicanURL(t *testing.T) {
 
 	t.Run("TestOsdfOrStashSchemeWithOSDFPrefixWithError", func(t *testing.T) {
 		viper.Reset()
-		_, err := config.SetPreferredPrefix(config.OsdfPrefix)
+		err := config.InitClient()
+		require.NoError(t, err)
+		_, err = config.SetPreferredPrefix(config.OsdfPrefix)
 		viper.Set("ConfigDir", t.TempDir())
 		require.NoError(t, err)
 		config.InitConfig()
@@ -654,6 +659,8 @@ func TestNewPelicanURL(t *testing.T) {
 
 	t.Run("TestOsdfOrStashSchemeWithPelicanPrefixNoError", func(t *testing.T) {
 		viper.Reset()
+		err := config.InitClient()
+		require.NoError(t, err)
 		viper.Set("ConfigDir", t.TempDir())
 		config.InitConfig()
 		require.NoError(t, config.InitClient())
@@ -738,6 +745,8 @@ func TestNewPelicanURL(t *testing.T) {
 		viper.Reset()
 		viper.Set("ConfigDir", t.TempDir())
 		config.InitConfig()
+		err := config.InitClient()
+		require.NoError(t, err)
 
 		te, err := NewTransferEngine(ctx)
 		require.NoError(t, err)

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -868,9 +868,10 @@ func TestNewTransferEngine(t *testing.T) {
 	})
 
 	t.Run("TestInitClientCalled", func(t *testing.T) {
-		config.InitClient()
+		err := config.InitClient()
+		require.NoError(t, err)
 		ctx := context.Background()
-		_, err := NewTransferEngine(ctx)
+		_, err = NewTransferEngine(ctx)
 		assert.NoError(t, err)
 	})
 }

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -602,7 +602,9 @@ func TestNewPelicanURL(t *testing.T) {
 		// Init config to get proper timeouts
 		config.InitConfig()
 
-		te := NewTransferEngine(ctx)
+		te, err := NewTransferEngine(ctx)
+		require.NoError(t, err)
+
 		defer func() {
 			require.NoError(t, te.Shutdown())
 		}()
@@ -631,8 +633,8 @@ func TestNewPelicanURL(t *testing.T) {
 		config.InitConfig()
 		require.NoError(t, config.InitClient())
 
-		te := NewTransferEngine(ctx)
-		require.NotNil(t, te)
+		te, err := NewTransferEngine(ctx)
+		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, te.Shutdown())
 		}()
@@ -655,14 +657,14 @@ func TestNewPelicanURL(t *testing.T) {
 		viper.Set("ConfigDir", t.TempDir())
 		config.InitConfig()
 		require.NoError(t, config.InitClient())
-		te := NewTransferEngine(ctx)
-		require.NotNil(t, te)
+		te, err := NewTransferEngine(ctx)
+		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, te.Shutdown())
 		}()
 
 		mock.MockOSDFDiscovery(t, config.GetTransport())
-		_, err := config.SetPreferredPrefix(config.PelicanPrefix)
+		_, err = config.SetPreferredPrefix(config.PelicanPrefix)
 		config.InitConfig()
 		assert.NoError(t, err)
 		remoteObject := "osdf:///something/somewhere/thatdoesnotexist.txt"
@@ -686,8 +688,8 @@ func TestNewPelicanURL(t *testing.T) {
 		err := config.InitClient()
 		require.NoError(t, err)
 
-		te := NewTransferEngine(ctx)
-		require.NotNil(t, te)
+		te, err := NewTransferEngine(ctx)
+		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, te.Shutdown())
 		}()
@@ -737,8 +739,8 @@ func TestNewPelicanURL(t *testing.T) {
 		viper.Set("ConfigDir", t.TempDir())
 		config.InitConfig()
 
-		te := NewTransferEngine(ctx)
-		require.NotNil(t, te)
+		te, err := NewTransferEngine(ctx)
+		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, te.Shutdown())
 		}()
@@ -762,7 +764,8 @@ func TestNewPelicanURL(t *testing.T) {
 		err := config.InitClient()
 		require.NoError(t, err)
 
-		te := NewTransferEngine(ctx)
+		te, err := NewTransferEngine(ctx)
+		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, te.Shutdown())
 		}()
@@ -849,5 +852,25 @@ func TestSearchJobAd(t *testing.T) {
 		// Call GetProjectName and check the result
 		jobId := searchJobAd(jobId)
 		assert.Equal(t, "12345", jobId)
+	})
+}
+
+func TestNewTransferEngine(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+	// Test we fail if we do not call initclient() before
+	t.Run("TestInitClientNotCalled", func(t *testing.T) {
+		config.ResetClientInitialized()
+		ctx := context.Background()
+		_, err := NewTransferEngine(ctx)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "client has not been initialized, unable to create transfer engine")
+	})
+
+	t.Run("TestInitClientCalled", func(t *testing.T) {
+		config.InitClient()
+		ctx := context.Background()
+		_, err := NewTransferEngine(ctx)
+		assert.NoError(t, err)
 	})
 }

--- a/client/main.go
+++ b/client/main.go
@@ -182,7 +182,11 @@ func DoStat(ctx context.Context, destination string, options ...TransferOption) 
 		return 0, err
 	}
 
-	te := NewTransferEngine(ctx)
+	te, err := NewTransferEngine(ctx)
+	if err != nil {
+		return 0, err
+	}
+
 	defer func() {
 		if err := te.Shutdown(); err != nil {
 			log.Errorln("Failure when shutting down transfer engine:", err)
@@ -509,7 +513,11 @@ func DoPut(ctx context.Context, localObject string, remoteDestination string, re
 		return nil, err
 	}
 
-	te := NewTransferEngine(ctx)
+	te, err := NewTransferEngine(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	defer func() {
 		if err := te.Shutdown(); err != nil {
 			log.Errorln("Failure when shutting down transfer engine:", err)
@@ -607,7 +615,11 @@ func DoGet(ctx context.Context, remoteObject string, localDestination string, re
 
 	success := false
 
-	te := NewTransferEngine(ctx)
+	te, err := NewTransferEngine(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	defer func() {
 		if err := te.Shutdown(); err != nil {
 			log.Errorln("Failure when shutting down transfer engine:", err)
@@ -776,7 +788,11 @@ func DoCopy(ctx context.Context, sourceFile string, destination string, recursiv
 	success := false
 	var downloaded int64 = 0
 
-	te := NewTransferEngine(ctx)
+	te, err := NewTransferEngine(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	defer func() {
 		if err := te.Shutdown(); err != nil {
 			log.Errorln("Failure when shutting down transfer engine:", err)

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -386,7 +386,11 @@ func writeClassadOutputAndBail(exitCode int, resultAds []*classads.ClassAd) {
 // writes the resultAds for each transfer
 // Returns: resultAds and if an error given is retryable
 func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTransfer, results chan<- *classads.ClassAd) (err error) {
-	te := client.NewTransferEngine(ctx)
+	te, err := client.NewTransferEngine(ctx)
+	if err != nil {
+		return
+	}
+
 	defer func() {
 		if shutdownErr := te.Shutdown(); shutdownErr != nil && err == nil {
 			err = shutdownErr

--- a/config/config.go
+++ b/config/config.go
@@ -186,6 +186,8 @@ var (
 		StashPrefix:   true,
 		"":            true,
 	}
+
+	clientInitialized = false
 )
 
 // This function creates a new MetadataError by wrapping the previous error
@@ -1427,6 +1429,16 @@ func InitServer(ctx context.Context, currentServers ServerType) error {
 	return nil
 }
 
+// This function checks if initClient has been called
+func IsClientInitialized() bool {
+	return clientInitialized
+}
+
+// This function resets the clientInitialized variable (mainly used for testing)
+func ResetClientInitialized() {
+	clientInitialized = false
+}
+
 func InitClient() error {
 	if err := initConfigDir(); err != nil {
 		log.Warningln("No home directory found for user -- will check for configuration yaml in /etc/pelican/")
@@ -1529,6 +1541,13 @@ func InitClient() error {
 		viper.Set("Client.MinimumDownloadSpeed", downloadLimit)
 	}
 
+	// Ensure our worker count is set
+	if viper.IsSet("Client.WorkerCount") {
+		viper.SetDefault("Client.WorkerCount", param.Client_WorkerCount.GetInt())
+	} else {
+		viper.Set("Client.WorkerCount", 5)
+	}
+
 	// The transport will automatically trust this CA cert file.
 	// Even though it's a "server" setting, it's useful to have this in the client when testing
 	// against a local self-signed server.
@@ -1552,6 +1571,8 @@ func InitClient() error {
 
 	// Sets (or resets) the deferred federation lookup
 	fedDiscoveryOnce = &sync.Once{}
+
+	clientInitialized = true
 
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1541,12 +1541,8 @@ func InitClient() error {
 		viper.Set("Client.MinimumDownloadSpeed", downloadLimit)
 	}
 
-	// Ensure our worker count is set
-	if viper.IsSet("Client.WorkerCount") {
-		viper.SetDefault("Client.WorkerCount", param.Client_WorkerCount.GetInt())
-	} else {
-		viper.Set("Client.WorkerCount", 5)
-	}
+	// Set our default worker count
+	viper.SetDefault("Client.WorkerCount", 5)
 
 	// The transport will automatically trust this CA cert file.
 	// Even though it's a "server" setting, it's useful to have this in the client when testing

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -32,8 +32,6 @@ Logging:
     Scitokens: fatal
     Xrd: error
     Xrootd: error
-Client:
-  WorkerCount: 5
 Server:
   WebPort: 8444
   WebHost: "0.0.0.0"

--- a/local_cache/cache_linux_test.go
+++ b/local_cache/cache_linux_test.go
@@ -55,7 +55,8 @@ func TestPurge(t *testing.T) {
 	ft := fed_test_utils.NewFedTest(t, pubOriginCfg)
 
 	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
-	te := client.NewTransferEngine(ctx)
+	te, err := client.NewTransferEngine(ctx)
+	require.NoError(t, err)
 
 	cacheUrl := &url.URL{
 		Scheme: "unix",
@@ -118,7 +119,8 @@ func TestForcePurge(t *testing.T) {
 	ft := fed_test_utils.NewFedTest(t, pubOriginCfg)
 
 	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
-	te := client.NewTransferEngine(ctx)
+	te, err := client.NewTransferEngine(ctx)
+	require.NoError(t, err)
 
 	issuer, err := config.GetServerIssuerURL()
 	require.NoError(t, err)

--- a/local_cache/cache_test.go
+++ b/local_cache/cache_test.go
@@ -333,7 +333,8 @@ func TestLargeFile(t *testing.T) {
 	ft := fed_test_utils.NewFedTest(t, pubOriginCfg)
 
 	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
-	te := client.NewTransferEngine(ctx)
+	te, err := client.NewTransferEngine(ctx)
+	require.NoError(t, err)
 
 	cacheUrl := &url.URL{
 		Scheme: "unix",

--- a/local_cache/local_cache.go
+++ b/local_cache/local_cache.go
@@ -269,10 +269,21 @@ func NewLocalCache(ctx context.Context, egrp *errgroup.Group, options ...LocalCa
 		return
 	}
 
+	// Ensure to initialize the client before getting a transfer engine
+	err = config.InitClient()
+	if err != nil {
+		return
+	}
+
+	te, err := client.NewTransferEngine(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	lc = &LocalCache{
 		ctx:         ctx,
 		egrp:        egrp,
-		te:          client.NewTransferEngine(ctx),
+		te:          te,
 		downloads:   make(map[string]*activeDownload),
 		hitChan:     make(chan lruEntry, 64),
 		highWater:   (cacheSize / 100) * uint64(highWaterPercentage),


### PR DESCRIPTION
The transfer engine in the client now throws a clear error if config.InitClient() has not been called. Before this fix, if InitClient() was not called we would get an error from the TransferEngine about not having worker count set or other unexpected/undesired behavior. Now, InitClient() checks if the workercount has been set (sets a default value if not) and NewTransferEngine() now throws an error if the client has not been initialized.