### PR TITLE
Fix integration test failure

### DIFF
--- a/github_scripts/citests.sh
+++ b/github_scripts/citests.sh
@@ -30,7 +30,7 @@ if ! [[ $classad_output =~ "PluginType = \"FileTransfer\"" ]]; then
   to_exit=1
 fi
 
-if ! [[ $classad_output =~ "SupportedMethods = \"stash, osdf\"" ]]; then
+if ! [[ $classad_output =~ "SupportedMethods = \"stash, osdf, pelican\"" ]]; then
   echo "SupportedMethods not in classad output"
   to_exit=1
 fi


### PR DESCRIPTION
The PR to add 'pelican' to SupportedMethods list was merged before the integration tests could run. Once they were run it was revealed that I forgot to update the check for the -classad output. This fixes that.`