### PR TITLE
Bump base os to el9, use osg 23 main repo, and fix maven vulnerability

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -17,7 +17,8 @@
 # ***************************************************************
 
 ARG BASE_YUM_REPO=release
-ARG BASE_OSG_SERIES=3.6
+ARG BASE_OSG_SERIES=23
+ARG BASE_OS=el9
 
 FROM goreleaser/goreleaser:v1.21.0 AS pelican-build
 ARG IS_NONRELEASE_BUILD="true"
@@ -39,7 +40,7 @@ RUN\
 
 FROM --platform=linux/amd64 hub.opensciencegrid.org/sciauth/scitokens-oauth2-server:release-20231118-1823 AS scitokens-oauth2-server
 
-FROM --platform=linux/amd64 opensciencegrid/software-base:$BASE_OSG_SERIES-el8-$BASE_YUM_REPO AS dependency-build
+FROM --platform=linux/amd64 opensciencegrid/software-base:$BASE_OSG_SERIES-$BASE_OS-$BASE_YUM_REPO AS dependency-build
 
 # Create the xrootd user with a fixed GID/UID
 RUN groupadd -o -g 10940 xrootd
@@ -47,8 +48,7 @@ RUN useradd -o -u 10940 -g 10940 -s /bin/sh xrootd
 
 # Install dependencies
 RUN yum -y update \
-    && yum -y install https://repo.opensciencegrid.org/osg/23-main/osg-23-main-el8-release-latest.rpm\
-    && yum -y install tini xrootd xrootd-client xrdcl-http xrootd-server xrootd-scitokens xrootd-voms curl java-17-openjdk-headless \
+    && yum -y --allowerasing install tini xrootd xrootd-client xrdcl-http xrootd-server xrootd-scitokens xrootd-voms curl java-17-openjdk-headless \
     && yum clean all \
     && rm -rf /var/cache/yum/
 
@@ -124,7 +124,7 @@ WORKDIR /pelican
 # Download and install tomcat
 RUN useradd -r -s /sbin/nologin tomcat ;\
     mkdir -p /opt/tomcat ;\
-    curl -s -L https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.80/bin/apache-tomcat-9.0.80.tar.gz | tar -zxf - -C /opt/tomcat --strip-components=1 ;\
+    curl -s -L https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.83/bin/apache-tomcat-9.0.83.tar.gz | tar -zxf - -C /opt/tomcat --strip-components=1 ;\
     chgrp -R tomcat /opt/tomcat/conf ;\
     chmod g+rwx /opt/tomcat/conf ;\
     chmod g+r /opt/tomcat/conf/* ;\

--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -20,7 +20,7 @@
 # fail on building this container on arm machine
 FROM --platform=linux/amd64 hub.opensciencegrid.org/sciauth/scitokens-oauth2-server:release-20231118-1823 AS scitokens-oauth2-server
 
-FROM almalinux:8
+FROM almalinux:9
 
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 ARG TARGETARCH
@@ -32,7 +32,7 @@ ENV GOFLAGS="-buildvcs=false"
 RUN groupadd -o -g 10940 xrootd
 RUN useradd -o -u 10940 -g 10940 -s /bin/sh xrootd
 
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
     /usr/bin/crb enable && \
     # ^^ crb enables the Code Ready Builder repository (EL9) or PowerTools (EL8), needed for some of our dependencies \
     yum clean all
@@ -49,7 +49,7 @@ gpgcheck=0' > /etc/yum.repos.d/goreleaser.repo
 RUN echo '%_topdir /usr/local/src/rpmbuild' > $HOME/.rpmmacros
 
 # Download OSG's XRootD SRPM and rebuild it. Create a yum repository to put the results in.
-RUN yum install -y yum-utils createrepo https://repo.opensciencegrid.org/osg/23-main/osg-23-main-el8-release-latest.rpm && \
+RUN yum install -y yum-utils createrepo https://repo.opensciencegrid.org/osg/23-main/osg-23-main-el9-release-latest.rpm && \
     yum-config-manager --setopt=install_weak_deps=False --save && \
     # ^^ save some space by not installing weak dependencies \
     yum-config-manager --disable osg --save && \
@@ -60,7 +60,7 @@ RUN yum install -y yum-utils createrepo https://repo.opensciencegrid.org/osg/23-
     yumdownloader --source xrootd --disablerepo=\* --enablerepo=osg-development-source && \
     yum-builddep -y xrootd-*.osg*.src.rpm && \
     rpmbuild --define 'osg 1' \
-             --define 'dist .osg.el8' \
+             --define 'dist .osg.el9' \
              --without compat \
              --without doc \
              --nocheck \
@@ -164,7 +164,7 @@ RUN n lts && \
 ##
 RUN useradd -r -s /sbin/nologin tomcat ;\
     mkdir -p /opt/tomcat ;\
-    curl -s -L https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.80/bin/apache-tomcat-9.0.80.tar.gz | tar -zxf - -C /opt/tomcat --strip-components=1 ;\
+    curl -s -L https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.83/bin/apache-tomcat-9.0.83.tar.gz | tar -zxf - -C /opt/tomcat --strip-components=1 ;\
     chgrp -R tomcat /opt/tomcat/conf ;\
     chmod g+rwx /opt/tomcat/conf ;\
     chmod g+r /opt/tomcat/conf/* ;\

--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -229,8 +229,8 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     fi
 
 # Install pre-commit
-RUN yum install -y python39 python39-pip &&\
-    /bin/pip-3.9 install pre-commit
+RUN python3.9 -m ensurepip &&\
+    pip3.9 install pre-commit
 
 COPY ./images/dev-container-entrypoint.sh /usr/local/bin/
 


### PR DESCRIPTION
Closes #1199 

For the rest of vulnerabilities, they are coming from the `scitoken-oauth-server` image we inherit, essentially the OA4MP software we depend on. I've opened an issue in the OA4MP repo for fixing those vulnerabilities: https://github.com/ncsa/oa4mp/issues/183