### PR TITLE
Display legacy namespace registrations in the registry web UI

### DIFF
--- a/registry/custom_reg_fields.go
+++ b/registry/custom_reg_fields.go
@@ -163,7 +163,7 @@ func convertCustomRegFields(configFields []customRegFieldsConfig) []registration
 }
 
 // Helper function to exclude pubkey field from marshaling into json
-func excludePubKey(nss []*server_structs.Namespace) (nssNew []NamespaceWOPubkey) {
+func excludePubKey(nss []server_structs.Namespace) (nssNew []NamespaceWOPubkey) {
 	nssNew = make([]NamespaceWOPubkey, 0)
 	for _, ns := range nss {
 		nsNew := NamespaceWOPubkey{

--- a/registry/registry_db_test.go
+++ b/registry/registry_db_test.go
@@ -437,27 +437,27 @@ func TestGetNamespacesByFilter(t *testing.T) {
 			ID: 123,
 		}
 
-		_, err := getNamespacesByFilter(filterNsID, "")
+		_, err := getNamespacesByFilter(filterNsID, "", false)
 		require.Error(t, err, "Should return error for filtering against unsupported field ID")
 
 		filterNsCF := server_structs.Namespace{
 			CustomFields: mockCustomFields,
 		}
-		_, err = getNamespacesByFilter(filterNsCF, "")
+		_, err = getNamespacesByFilter(filterNsCF, "", false)
 		require.Error(t, err, "Should return error for filtering against unsupported custom fields")
 
 		filterNsIdentity := server_structs.Namespace{
 			Identity: "someIdentity",
 		}
 
-		_, err = getNamespacesByFilter(filterNsIdentity, "")
+		_, err = getNamespacesByFilter(filterNsIdentity, "", false)
 		require.Error(t, err, "Should return error for filtering against unsupported field Identity")
 
 		filterNsPubKey := server_structs.Namespace{
 			Pubkey: "somePubkey",
 		}
 
-		_, err = getNamespacesByFilter(filterNsPubKey, "")
+		_, err = getNamespacesByFilter(filterNsPubKey, "", false)
 		require.Error(t, err, "Should return error for filtering against unsupported field PubKey")
 
 		// Now, for AdminMetadata filters to work, we need to have a valid object
@@ -481,7 +481,7 @@ func TestGetNamespacesByFilter(t *testing.T) {
 			},
 		}
 
-		_, err = getNamespacesByFilter(filterNsCreateAt, "")
+		_, err = getNamespacesByFilter(filterNsCreateAt, "", false)
 		require.Error(t, err, "Should return error for filtering against unsupported field CreatedAt")
 
 		filterNsUpdateAt := server_structs.Namespace{
@@ -490,7 +490,7 @@ func TestGetNamespacesByFilter(t *testing.T) {
 			},
 		}
 
-		_, err = getNamespacesByFilter(filterNsUpdateAt, "")
+		_, err = getNamespacesByFilter(filterNsUpdateAt, "", false)
 		require.Error(t, err, "Should return error for filtering against unsupported field UpdatedAt")
 
 		filterNsApproveAt := server_structs.Namespace{
@@ -499,7 +499,7 @@ func TestGetNamespacesByFilter(t *testing.T) {
 			},
 		}
 
-		_, err = getNamespacesByFilter(filterNsApproveAt, "")
+		_, err = getNamespacesByFilter(filterNsApproveAt, "", false)
 		require.Error(t, err, "Should return error for filtering against unsupported field ApprovedAt")
 	})
 
@@ -510,12 +510,12 @@ func TestGetNamespacesByFilter(t *testing.T) {
 		require.NoError(t, err)
 
 		filterNs := server_structs.Namespace{}
-		nssOrigins, err := getNamespacesByFilter(filterNs, OriginType)
+		nssOrigins, err := getNamespacesByFilter(filterNs, OriginType, false)
 		require.NoError(t, err)
 		assert.NotEmpty(t, nssOrigins, "Should return non-empty result for OriginType")
 		assert.True(t, compareNamespaces(mockNssWithOrigins, nssOrigins, true), "Returned nssOrigins does not match")
 
-		nssCaches, err := getNamespacesByFilter(filterNs, CacheType)
+		nssCaches, err := getNamespacesByFilter(filterNs, CacheType, false)
 		require.NoError(t, err)
 		assert.NotEmpty(t, nssCaches, "Should return non-empty result for CacheType")
 		assert.True(t, compareNamespaces(mockNssWithCaches, nssCaches, true))
@@ -543,7 +543,7 @@ func TestGetNamespacesByFilter(t *testing.T) {
 			},
 		}
 
-		namespaces, err := getNamespacesByFilter(filterNs, "")
+		namespaces, err := getNamespacesByFilter(filterNs, "", false)
 		require.NoError(t, err)
 		assert.NotEmpty(t, namespaces, "Should return non-empty result for Description")
 
@@ -552,7 +552,7 @@ func TestGetNamespacesByFilter(t *testing.T) {
 				SiteName: "Madison",
 			},
 		}
-		namespaces, err = getNamespacesByFilter(filterNs, "")
+		namespaces, err = getNamespacesByFilter(filterNs, "", false)
 		require.NoError(t, err)
 		assert.NotEmpty(t, namespaces, "Should return non-empty result for SiteName")
 
@@ -561,7 +561,7 @@ func TestGetNamespacesByFilter(t *testing.T) {
 				Institution: "123456",
 			},
 		}
-		namespaces, err = getNamespacesByFilter(filterNs, "")
+		namespaces, err = getNamespacesByFilter(filterNs, "", false)
 		require.NoError(t, err)
 		assert.NotEmpty(t, namespaces, "Should return non-empty result for Institution")
 
@@ -570,7 +570,7 @@ func TestGetNamespacesByFilter(t *testing.T) {
 				SecurityContactUserID: "contactUserID",
 			},
 		}
-		namespaces, err = getNamespacesByFilter(filterNs, "")
+		namespaces, err = getNamespacesByFilter(filterNs, "", false)
 		require.NoError(t, err)
 		assert.NotEmpty(t, namespaces, "Should return non-empty result for SecurityContactUserID")
 
@@ -579,7 +579,7 @@ func TestGetNamespacesByFilter(t *testing.T) {
 				ApproverID: "mockApproverID",
 			},
 		}
-		namespaces, err = getNamespacesByFilter(filterNs, "")
+		namespaces, err = getNamespacesByFilter(filterNs, "", false)
 		require.NoError(t, err)
 		assert.NotEmpty(t, namespaces, "Should return non-empty result for ApproverID")
 
@@ -588,7 +588,7 @@ func TestGetNamespacesByFilter(t *testing.T) {
 				Status: server_structs.RegPending,
 			},
 		}
-		namespaces, err = getNamespacesByFilter(filterNs, "")
+		namespaces, err = getNamespacesByFilter(filterNs, "", false)
 		require.NoError(t, err)
 		assert.NotEmpty(t, namespaces, "Should return non-empty result for Status")
 
@@ -597,7 +597,7 @@ func TestGetNamespacesByFilter(t *testing.T) {
 				UserID: "mockUserID",
 			},
 		}
-		namespaces, err = getNamespacesByFilter(filterNs, "")
+		namespaces, err = getNamespacesByFilter(filterNs, "", false)
 		require.NoError(t, err)
 		assert.NotEmpty(t, namespaces, "Should return non-empty result for UserID")
 	})
@@ -625,7 +625,7 @@ func TestGetNamespacesByFilter(t *testing.T) {
 				Status:                server_structs.RegPending,
 			},
 		}
-		namespaces, err := getNamespacesByFilter(filterNs, "")
+		namespaces, err := getNamespacesByFilter(filterNs, "", false)
 		require.NoError(t, err)
 		assert.NotEmpty(t, namespaces, "Should return non-empty result for non-empty database without condition")
 	})
@@ -648,7 +648,7 @@ func TestGetNamespacesByFilter(t *testing.T) {
 		require.NoError(t, err)
 
 		filterNs := mockNs
-		namespaces, err := getNamespacesByFilter(filterNs, "")
+		namespaces, err := getNamespacesByFilter(filterNs, "", false)
 		require.NoError(t, err)
 		assert.NotEmpty(t, namespaces, "Should return non-empty result for non-empty database without condition")
 	})
@@ -672,18 +672,54 @@ func TestGetNamespacesByFilter(t *testing.T) {
 
 		filterNs := mockNs
 		filterNs.AdminMetadata.Status = server_structs.RegDenied
-		namespaces, err := getNamespacesByFilter(filterNs, "")
+		namespaces, err := getNamespacesByFilter(filterNs, "", false)
 		require.NoError(t, err)
-		assert.Empty(t, namespaces, "Should return non-empty result for non-empty database without condition")
+		assert.Empty(t, namespaces)
 	})
 
 	t.Run("empty-db-returns-empty-results", func(t *testing.T) {
 		resetNamespaceDB(t)
 
 		filterNs := server_structs.Namespace{}
-		namespaces, err := getNamespacesByFilter(filterNs, "")
+		namespaces, err := getNamespacesByFilter(filterNs, "", false)
 		require.NoError(t, err)
 		assert.Empty(t, namespaces, "Should return empty result for empty database")
+	})
+
+	t.Run("filter-legacy-result", func(t *testing.T) {
+		resetNamespaceDB(t)
+		mockLeg := server_structs.Namespace{
+			Prefix: "/legacy/1",
+		}
+		mockNs := server_structs.Namespace{
+			Prefix: "/bar",
+			AdminMetadata: server_structs.AdminMetadata{
+				Description:           "Mock description",
+				UserID:                "mockUserID",
+				SiteName:              "UW-Madison",
+				Institution:           "123456",
+				SecurityContactUserID: "contactUserID",
+				ApproverID:            "mockApproverID",
+				Status:                server_structs.RegPending,
+			},
+		}
+		err := insertMockDBData([]server_structs.Namespace{mockLeg, mockNs})
+		require.NoError(t, err)
+
+		filterNs := server_structs.Namespace{}
+		// Filter out legacy namespaces
+		namespaces, err := getNamespacesByFilter(filterNs, "", false)
+		require.NoError(t, err)
+		assert.Len(t, namespaces, 1)
+		assert.Equal(t, mockNs.Prefix, namespaces[0].Prefix)
+		assert.EqualValues(t, mockNs.AdminMetadata, namespaces[0].AdminMetadata)
+
+		// Want legacy namespaces
+		namespaces, err = getNamespacesByFilter(filterNs, "", true)
+		require.NoError(t, err)
+		assert.Len(t, namespaces, 1)
+		assert.Equal(t, mockLeg.Prefix, namespaces[0].Prefix)
+		assert.EqualValues(t, mockLeg.AdminMetadata, namespaces[0].AdminMetadata)
 	})
 }
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/test_utils"
 )
 
 func TestHandleWildcard(t *testing.T) {
@@ -257,7 +258,7 @@ func TestCheckNamespaceCompleteHandler(t *testing.T) {
 			NamespaceRegistrationEndpoint: "https://registry.org",
 		})
 
-		mockJWKS, err := GenerateMockJWKS()
+		mockJWKS, err := test_utils.GenerateJWKS()
 		require.NoError(t, err)
 
 		// Institution and UserId are empty
@@ -295,7 +296,7 @@ func TestCheckNamespaceCompleteHandler(t *testing.T) {
 			NamespaceRegistrationEndpoint: "https://registry.org",
 		})
 
-		mockJWKS, err := GenerateMockJWKS()
+		mockJWKS, err := test_utils.GenerateJWKS()
 		require.NoError(t, err)
 		// Institution and UserId are empty
 		err = insertMockDBData(
@@ -341,7 +342,7 @@ func TestCheckNamespaceCompleteHandler(t *testing.T) {
 			NamespaceRegistrationEndpoint: "https://registry.org",
 		})
 
-		mockJWKS, err := GenerateMockJWKS()
+		mockJWKS, err := test_utils.GenerateJWKS()
 		require.NoError(t, err)
 		// Institution and UserId are empty
 		err = insertMockDBData(

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -62,6 +62,7 @@ type (
 	listNamespaceRequest struct {
 		ServerType string `form:"server_type"`
 		Status     string `form:"status"`
+		Legacy     bool   `form:"legacy"`
 	}
 
 	listNamespacesForUserRequest struct {
@@ -200,6 +201,12 @@ func listNamespaces(ctx *gin.Context) {
 		return
 	}
 
+	if _, ok := ctx.GetQuery("legacy"); ok {
+		queryParams.Legacy = true
+	} else {
+		queryParams.Legacy = false
+	}
+
 	// For unauthed user with non-empty Status query != Approved, return 403
 	if !isAuthed && queryParams.Status != "" && queryParams.Status != server_structs.RegApproved.String() {
 		ctx.JSON(http.StatusForbidden, server_structs.SimpleApiResp{
@@ -234,7 +241,7 @@ func listNamespaces(ctx *gin.Context) {
 		filterNs.AdminMetadata.Status = server_structs.RegApproved
 	}
 
-	namespaces, err := getNamespacesByFilter(filterNs, ServerType(queryParams.ServerType))
+	namespaces, err := getNamespacesByFilter(filterNs, ServerType(queryParams.ServerType), queryParams.Legacy)
 	if err != nil {
 		log.Error("Failed to get namespaces by server type: ", err)
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
@@ -279,7 +286,7 @@ func listNamespacesForUser(ctx *gin.Context) {
 		}
 	}
 
-	namespaces, err := getNamespacesByFilter(filterNs, "")
+	namespaces, err := getNamespacesByFilter(filterNs, "", false)
 	if err != nil {
 		log.Error("Error getting namespaces for user ", user)
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{

--- a/swagger/pelican-swagger.yaml
+++ b/swagger/pelican-swagger.yaml
@@ -992,11 +992,12 @@ paths:
       parameters:
         - name: server_type
           in: query
+          type: string
           required: false
           description: The type of server to filter the results. The value can be either `origin` or `cache`
-          type: string
         - name: status
           in: query
+          type: string
           required: false
           description:
             The approval status of the namespaces, can be `pending`, `approved`, `denied`, or `unknown`.
@@ -1004,7 +1005,13 @@ paths:
             If `status == unknown`, internally it will match any registration with `status == ""` or `stauts == "unknown"`
 
             For unauthenticated users, filter with `status != approved` will result in a 403 error.
-          type: string
+        - name: legacy
+          in: query
+          type: boolean
+          required: false
+          description:
+            To show/filter out legacy namespace registrations, which only has two non-empty fields, `prefix` and `pubkey`.
+            Since this is a boolean parameter, it's OK to only pass `legacy` as the parameter without the `=true` value.
       produces:
         - application/json
       responses:


### PR DESCRIPTION
Fixes #1220 

This is built upon the existing `GET /registry_ui/namespaces` API with an additional query parameter `legacy`. By default the API ignores any legacy registrations, but with `?legacy`, it will only display the legacy registrations. Note that you may pass the parameter either in `legacy` or `legacy=true`.
 
@CannonLock  The idea for the UI is to render a list of legacy registrations as a separate table and allow registry admin to edit/delete those registrations.