### PR TITLE
Add support for `pelican.timeout`

### DIFF
--- a/director/director.go
+++ b/director/director.go
@@ -147,7 +147,8 @@ func getLinkDepth(filepath, prefix string) (int, error) {
 	return pathDepth, nil
 }
 
-func getAuthzEscaped(req *http.Request) (authzEscaped string) {
+func getRequestParameters(req *http.Request) (requestParameterEscaped string) {
+	authzEscaped := ""
 	if authzQuery := req.URL.Query()["authz"]; len(authzQuery) > 0 {
 		authzEscaped = authzQuery[0]
 		// if the authz URL query is coming from XRootD, it probably has a "Bearer " tacked in front
@@ -157,15 +158,31 @@ func getAuthzEscaped(req *http.Request) (authzEscaped string) {
 		authzEscaped = strings.TrimPrefix(authzHeader[0], "Bearer ")
 		authzEscaped = url.QueryEscape(authzEscaped)
 	}
+	timeoutEscaped := ""
+	if timeoutQuery := req.URL.Query()["pelican.timeout"]; len(timeoutQuery) > 0 {
+		timeoutEscaped = timeoutQuery[0]
+	} else if timeoutHeader := req.Header["X-Pelican-Timeout"]; len(timeoutHeader) > 0 {
+		timeoutEscaped = url.QueryEscape(timeoutHeader[0])
+	}
+
+	if authzEscaped != "" {
+		requestParameterEscaped = "authz=" + authzEscaped
+	}
+	if timeoutEscaped != "" {
+		if requestParameterEscaped != "" {
+			requestParameterEscaped += "&"
+		}
+		requestParameterEscaped += "pelican.timeout=" + timeoutEscaped
+	}
 	return
 }
 
-func getFinalRedirectURL(rurl url.URL, authzEscaped string) string {
-	if len(authzEscaped) > 0 {
-		if len(rurl.RawQuery) > 0 {
+func getFinalRedirectURL(rurl url.URL, requestParameterEscaped string) string {
+	if requestParameterEscaped != "" {
+		if rurl.RawQuery != "" {
 			rurl.RawQuery += "&"
 		}
-		rurl.RawQuery += "authz=" + authzEscaped
+		rurl.RawQuery += requestParameterEscaped
 	}
 	return rurl.String()
 }
@@ -241,7 +258,7 @@ func redirectToCache(ginCtx *gin.Context) {
 		return
 	}
 
-	authzBearerEscaped := getAuthzEscaped(ginCtx.Request)
+	requestParameterEscaped := getRequestParameters(ginCtx.Request)
 
 	namespaceAd, originAds, cacheAds := getAdsForPath(reqPath)
 	// if GetAdsForPath doesn't find any ads because the prefix doesn't exist, we should
@@ -338,7 +355,7 @@ func redirectToCache(ginCtx *gin.Context) {
 	// duplicate link metadata above.  This is purposeful: the Link header might get too long if we repeat
 	// the token 20 times for 20 caches.  This means a "normal HTTP client" will correctly redirect but
 	// anything parsing the `Link` header for metalinks will need logic for redirecting appropriately.
-	ginCtx.Redirect(307, getFinalRedirectURL(redirectURL, authzBearerEscaped))
+	ginCtx.Redirect(307, getFinalRedirectURL(redirectURL, requestParameterEscaped))
 }
 
 func redirectToOrigin(ginCtx *gin.Context) {
@@ -369,7 +386,7 @@ func redirectToOrigin(ginCtx *gin.Context) {
 		return
 	}
 
-	authzBearerEscaped := getAuthzEscaped(ginCtx.Request)
+	requestParameterEscaped := getRequestParameters(ginCtx.Request)
 
 	namespaceAd, originAds, _ := getAdsForPath(reqPath)
 	// if GetAdsForPath doesn't find any ads because the prefix doesn't exist, we should
@@ -435,7 +452,7 @@ func redirectToOrigin(ginCtx *gin.Context) {
 				if brokerUrl := originAds[idx].BrokerURL; brokerUrl.String() != "" {
 					ginCtx.Header("X-Pelican-Broker", brokerUrl.String())
 				}
-				ginCtx.Redirect(http.StatusTemporaryRedirect, getFinalRedirectURL(redirectURL, authzBearerEscaped))
+				ginCtx.Redirect(http.StatusTemporaryRedirect, getFinalRedirectURL(redirectURL, requestParameterEscaped))
 				return
 			}
 		}
@@ -454,7 +471,7 @@ func redirectToOrigin(ginCtx *gin.Context) {
 				if brokerUrl := originAds[idx].BrokerURL; brokerUrl.String() != "" {
 					ginCtx.Header("X-Pelican-Broker", brokerUrl.String())
 				}
-				ginCtx.Redirect(http.StatusTemporaryRedirect, getFinalRedirectURL(redirectURL, authzBearerEscaped))
+				ginCtx.Redirect(http.StatusTemporaryRedirect, getFinalRedirectURL(redirectURL, requestParameterEscaped))
 				return
 			}
 		}
@@ -470,7 +487,7 @@ func redirectToOrigin(ginCtx *gin.Context) {
 				if brokerUrl := originAds[idx].BrokerURL; brokerUrl.String() != "" {
 					ginCtx.Header("X-Pelican-Broker", brokerUrl.String())
 				}
-				ginCtx.Redirect(http.StatusTemporaryRedirect, getFinalRedirectURL(redirectURL, authzBearerEscaped))
+				ginCtx.Redirect(http.StatusTemporaryRedirect, getFinalRedirectURL(redirectURL, requestParameterEscaped))
 				return
 			}
 		}
@@ -484,7 +501,7 @@ func redirectToOrigin(ginCtx *gin.Context) {
 
 		// See note in RedirectToCache as to why we only add the authz query parameter to this URL,
 		// not those in the `Link`.
-		ginCtx.Redirect(http.StatusTemporaryRedirect, getFinalRedirectURL(redirectURL, authzBearerEscaped))
+		ginCtx.Redirect(http.StatusTemporaryRedirect, getFinalRedirectURL(redirectURL, requestParameterEscaped))
 	}
 }
 

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -644,33 +644,61 @@ func TestGetAuthzEscaped(t *testing.T) {
 	req, err := http.NewRequest(http.MethodPost, "http://fake-server.com", bytes.NewBuffer([]byte("a body")))
 	assert.NoError(t, err)
 	req.Header.Set("Authorization", "tokenstring")
-	escapedToken := getAuthzEscaped(req)
-	assert.Equal(t, escapedToken, "tokenstring")
+	escapedToken := getRequestParameters(req)
+	assert.Equal(t, "authz=tokenstring", escapedToken)
 
 	// Test passing a token via query with no bearer prefix
 	req, err = http.NewRequest(http.MethodPost, "http://fake-server.com/foo?authz=tokenstring", bytes.NewBuffer([]byte("a body")))
 	assert.NoError(t, err)
-	escapedToken = getAuthzEscaped(req)
-	assert.Equal(t, escapedToken, "tokenstring")
+	escapedToken = getRequestParameters(req)
+	assert.Equal(t, "authz=tokenstring", escapedToken)
 
 	// Test passing the token via header with Bearer prefix
 	req, err = http.NewRequest(http.MethodPost, "http://fake-server.com", bytes.NewBuffer([]byte("a body")))
 	assert.NoError(t, err)
 	req.Header.Set("Authorization", "Bearer tokenstring")
-	escapedToken = getAuthzEscaped(req)
-	assert.Equal(t, escapedToken, "tokenstring")
+	escapedToken = getRequestParameters(req)
+	assert.Equal(t, "authz=tokenstring", escapedToken)
 
 	// Test passing the token via URL with Bearer prefix and + encoded space
 	req, err = http.NewRequest(http.MethodPost, "http://fake-server.com/foo?authz=Bearer+tokenstring", bytes.NewBuffer([]byte("a body")))
 	assert.NoError(t, err)
-	escapedToken = getAuthzEscaped(req)
-	assert.Equal(t, escapedToken, "tokenstring")
+	escapedToken = getRequestParameters(req)
+	assert.Equal(t, "authz=tokenstring", escapedToken)
 
 	// Finally, the same test as before, but test with %20 encoded space
 	req, err = http.NewRequest(http.MethodPost, "http://fake-server.com/foo?authz=Bearer%20tokenstring", bytes.NewBuffer([]byte("a body")))
 	assert.NoError(t, err)
-	escapedToken = getAuthzEscaped(req)
-	assert.Equal(t, escapedToken, "tokenstring")
+	escapedToken = getRequestParameters(req)
+	assert.Equal(t, "authz=tokenstring", escapedToken)
+}
+
+func TestGetRequestParameters(t *testing.T) {
+	// Test passing a token & timeout via header
+	req, err := http.NewRequest(http.MethodPost, "http://fake-server.com", bytes.NewBuffer([]byte("a body")))
+	assert.NoError(t, err)
+	req.Header.Set("Authorization", "tokenstring")
+	req.Header.Set("X-Pelican-Timeout", "3s")
+	escapedParam := getRequestParameters(req)
+	assert.Equal(t, "authz=tokenstring&pelican.timeout=3s", escapedParam)
+
+	// Test passing a timeout via query
+	req, err = http.NewRequest(http.MethodPost, "http://fake-server.com/foo?pelican.timeout=3s", bytes.NewBuffer([]byte("a body")))
+	assert.NoError(t, err)
+	escapedParam = getRequestParameters(req)
+	assert.Equal(t, "pelican.timeout=3s", escapedParam)
+
+	// Test passing nothing
+	req, err = http.NewRequest(http.MethodPost, "http://fake-server.com/foo", bytes.NewBuffer([]byte("a body")))
+	assert.NoError(t, err)
+	escapedParam = getRequestParameters(req)
+	assert.Equal(t, "", escapedParam)
+
+	// Test passing the token & timeout via URL query string
+	req, err = http.NewRequest(http.MethodPost, "http://fake-server.com/foo?pelican.timeout=3s&authz=tokenstring", bytes.NewBuffer([]byte("a body")))
+	assert.NoError(t, err)
+	escapedParam = getRequestParameters(req)
+	assert.Equal(t, "authz=tokenstring&pelican.timeout=3s", escapedParam)
 }
 
 func TestDiscoverOriginCache(t *testing.T) {

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -27,6 +27,7 @@ xrd.tlsca certdir {{.Server.TLSCACertificateDirectory}}
 xrd.tlsca certfile {{.Server.TLSCACertificateFile}}
 {{end}}
 http.header2cgi Authorization authz
+http.header2cgi X-Pelican-Timeout pelican.timeout
 {{if .Cache.EnableVoms}}
 http.secxtractor /usr/lib64/libXrdVoms.so
 {{end}}


### PR DESCRIPTION
The `pelican.timeout` / `X-Pelican-Timeout` headers should be passed by the director in its redirect and enabled in the cache config.

This (and a corresponding PR for `xrdcl-pelican`) will allow the client to differentiate between an unresponsive origin and an unresponsive cache.