### PR TITLE
Tune up file transfer tests

### DIFF
--- a/cache/self_monitor.go
+++ b/cache/self_monitor.go
@@ -30,13 +30,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/token"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
+	"github.com/pelicanplatform/pelican/token_scopes"
 )
 
 const (
@@ -174,7 +176,7 @@ func generateFileTestScitoken() (string, error) {
 	fTestTokenCfg.Lifetime = time.Minute
 	fTestTokenCfg.Issuer = issuerUrl
 	fTestTokenCfg.Subject = "cache"
-	fTestTokenCfg.Claims = map[string]string{"scope": "storage.read:/pelican/monitoring/selfTest"}
+	fTestTokenCfg.AddResourceScopes(token_scopes.NewResourceScope(token_scopes.Storage_Read, "/pelican/monitoring/selfTest"))
 	// For self-tests, the audience is the server itself
 	fTestTokenCfg.AddAudienceAny()
 

--- a/director/director.go
+++ b/director/director.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
 )
@@ -945,16 +946,16 @@ func getPrefixByPath(ctx *gin.Context) {
 // Generate a mock file for caches to fetch. This is for director-based health tests for caches
 // So that we don't require an origin to feed the test file to the cache
 func getHealthTestFile(ctx *gin.Context) {
-	// Expected path: /pelican/monitoring/2006-01-02T15:04:05Z07:00.txt
+	// Expected path: /pelican/monitoring/directorTest/2006-01-02T15:04:05Z07:00.txt
 	pathParam := ctx.Param("path")
 	cleanedPath := path.Clean(pathParam)
-	if cleanedPath == "" || !strings.HasPrefix(cleanedPath, cacheMonitroingBasePath+"/") {
+	if cleanedPath == "" || !strings.HasPrefix(cleanedPath, server_utils.MonitoringBaseNs+"/") {
 		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    "Path parameter is not a valid health test path: " + cleanedPath})
 		return
 	}
-	fileName := strings.TrimPrefix(cleanedPath, cacheMonitroingBasePath+"/")
+	fileName := strings.TrimPrefix(cleanedPath, server_utils.MonitoringBaseNs+"/")
 	if fileName == "" {
 		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
@@ -969,9 +970,7 @@ func getHealthTestFile(ctx *gin.Context) {
 		return
 	}
 
-	filenameWoExt := fileNameSplit[0]
-
-	fileContent := fmt.Sprintf("%s%s\n", testFileContent, filenameWoExt)
+	fileContent := server_utils.DirectorTestBody + "\n"
 
 	if ctx.Request.Method == "HEAD" {
 		ctx.Header("Content-Length", strconv.Itoa(len(fileContent)))

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -46,6 +46,7 @@ import (
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
@@ -1159,7 +1160,7 @@ func TestGetHealthTestFile(t *testing.T) {
 
 		bytes, err := io.ReadAll(w.Result().Body)
 		require.NoError(t, err)
-		assert.Equal(t, testFileContent+"testfile\n", string(bytes))
+		assert.Equal(t, server_utils.DirectorTestBody+"\n", string(bytes))
 	})
 }
 

--- a/director/monitor.go
+++ b/director/monitor.go
@@ -180,7 +180,7 @@ func LaunchPeriodicDirectorTest(ctx context.Context, serverAd server_structs.Ser
 			var err error
 			if serverAd.Type == server_structs.OriginType {
 				fileTests := server_utils.TestFileTransferImpl{}
-				ok, err = fileTests.RunTests(ctx, serverUrl, serverUrl, "", server_utils.DirectorFileTest)
+				ok, err = fileTests.RunTests(ctx, serverUrl, serverUrl, "", server_utils.DirectorTest)
 			} else if serverAd.Type == server_structs.CacheType {
 				err = runCacheTest(ctx, serverAd.URL)
 			}

--- a/origin/self_monitor.go
+++ b/origin/self_monitor.go
@@ -34,7 +34,7 @@ func doSelfMonitor(ctx context.Context) {
 	log.Debug("Starting a new self-test monitoring cycle")
 	fileTests := server_utils.TestFileTransferImpl{}
 	issuerUrl := param.Server_ExternalWebUrl.GetString()
-	ok, err := fileTests.RunTests(ctx, param.Origin_Url.GetString(), config.GetServerAudience(), issuerUrl, server_utils.OriginSelfFileTest)
+	ok, err := fileTests.RunTests(ctx, param.Origin_Url.GetString(), config.GetServerAudience(), issuerUrl, server_utils.ServerSelfTest)
 	if ok && err == nil {
 		log.Debugln("Self-test monitoring cycle succeeded at", time.Now().Format(time.UnixDate))
 		metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusOK, "Self-test monitoring cycle succeeded at "+time.Now().Format(time.RFC3339))

--- a/xrootd/origin_test.go
+++ b/xrootd/origin_test.go
@@ -180,7 +180,7 @@ func TestOrigin(t *testing.T) {
 	issuerUrl, err := config.GetServerIssuerURL()
 	require.NoError(t, err)
 
-	ok, err := fileTests.RunTests(ctx, param.Origin_Url.GetString(), config.GetServerAudience(), issuerUrl, server_utils.OriginSelfFileTest)
+	ok, err := fileTests.RunTests(ctx, param.Origin_Url.GetString(), config.GetServerAudience(), issuerUrl, server_utils.ServerSelfTest)
 	require.NoError(t, err)
 	require.True(t, ok)
 }
@@ -228,7 +228,7 @@ func TestMultiExportOrigin(t *testing.T) {
 	issuerUrl, err := config.GetServerIssuerURL()
 	require.NoError(t, err)
 
-	ok, err := fileTests.RunTests(ctx, param.Origin_Url.GetString(), config.GetServerAudience(), issuerUrl, server_utils.OriginSelfFileTest)
+	ok, err := fileTests.RunTests(ctx, param.Origin_Url.GetString(), config.GetServerAudience(), issuerUrl, server_utils.ServerSelfTest)
 	require.NoError(t, err)
 	require.True(t, ok)
 }


### PR DESCRIPTION
Closes #1281 

The director won't reject redirect requests such as `/pelican/monitoring/xxx.txt`, `/pelican/monitoring/selfTest/xxx.txt`, and `/pelican/monitoring/directorTest/<wrong-prefix>.txt` for backward compat reason, but the rest of the requirements are implemented in this PR.