### PR TITLE
Report cache hits/misses

### DIFF
--- a/client/director.go
+++ b/client/director.go
@@ -146,7 +146,7 @@ func queryDirector(ctx context.Context, verb, sourcePath, directorUrl string) (r
 	}
 
 	defer resp.Body.Close()
-	log.Debugln("Director's response:", resp)
+	log.Traceln("Director's response:", resp)
 
 	// Check HTTP response -- should be 307 (redirect), else something went wrong
 	body, _ := io.ReadAll(resp.Body)
@@ -240,7 +240,7 @@ func newTransferDetailsUsingDirector(cache namespaces.DirectorCache, opts transf
 		cacheURL.Scheme = ""
 		cacheURL.Opaque = ""
 	}
-	log.Debugf("Parsed Cache: %s", cacheURL.String())
+	log.Tracef("Parsed Cache: %s", cacheURL.String())
 	if opts.NeedsToken {
 		// Unless we're using the local Unix domain socket cache, force HTTPS
 		if cacheURL.Scheme != "unix" {

--- a/client/errorAccum.go
+++ b/client/errorAccum.go
@@ -102,7 +102,12 @@ func (te *TransferErrors) UserError() string {
 	var errorsFormatted []string
 	for idx, err := range te.errors {
 		theError := err.(*TimestampedError)
-		errFmt := fmt.Sprintf("Attempt #%v: %s", idx+1, theError.err.Error())
+		var errFmt string
+		if len(te.errors) > 1 {
+			errFmt = fmt.Sprintf("Attempt #%v: %s", idx+1, theError.err.Error())
+		} else {
+			errFmt = theError.err.Error()
+		}
 		timeElapsed := theError.timestamp.Sub(lastError)
 		timeFormat := timeElapsed.Truncate(100 * time.Millisecond).String()
 		errFmt += " (" + timeFormat

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1880,7 +1880,7 @@ func downloadHTTP(ctx context.Context, te *TransferEngine, callback TransferCall
 	req = req.WithContext(ctx)
 
 	// Test the transfer speed every 5 seconds
-	t := time.NewTicker(5000 * time.Millisecond)
+	t := time.NewTicker(500 * time.Millisecond)
 	defer t.Stop()
 
 	// Progress ticker

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -384,7 +384,7 @@ func (e *SlowTransferError) Error() (errMsg string) {
 		"/s, total transferred=" +
 		ByteCountSI(e.BytesTransferred) +
 		", total transfer time=" +
-		e.Duration.String()
+		e.Duration.Round(time.Millisecond).String()
 	if e.CacheAge == 0 {
 		errMsg += ", cache miss"
 	} else if e.CacheAge > 0 {

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -449,6 +449,9 @@ func (e *ConnectionSetupError) Is(target error) bool {
 }
 
 func (e *StatusCodeError) Error() string {
+	if int(*e) == 504 {
+		return "cache timed out waiting on origin"
+	}
 	return (*grab.StatusCodeError)(e).Error()
 }
 

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2034,7 +2034,7 @@ Loop:
 				// The download is below the threshold for more than `SlowTransferWindow` seconds, cancel the download
 				cancel()
 
-				log.Errorln("Cancelled: Download speed of ", resp.BytesPerSecond(), "bytes/s", " is below the limit of", downloadLimit, "bytes/s")
+				log.Errorf("Cancelled: Download speed of %s/s is below the limit of %s/s", ByteCountSI(int64(resp.BytesPerSecond())), ByteCountSI(int64(downloadLimit)))
 
 				err = &SlowTransferError{
 					BytesTransferred: resp.BytesComplete(),

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2355,6 +2355,7 @@ func (te *TransferEngine) walkDirDownload(job *clientTransferJob, transfers []tr
 
 	auth := &bearerAuth{token: job.job.token}
 	client := gowebdav.NewAuthClient(rootUrl.String(), auth)
+	client.SetHeader("User-Agent", getUserAgent(job.job.project))
 
 	// XRootD does not like keep alives and kills things, so turn them off.
 	transport := config.GetTransport()

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -159,8 +159,11 @@ func TestSlowTransfers(t *testing.T) {
 	ctx, _, _ := test_utils.TestContext(context.Background(), t)
 
 	// Adjust down some timeouts to speed up the test
-	viper.Set("Client.SlowTransferWindow", 5)
-	viper.Set("Client.SlowTransferRampupTime", 10)
+	viper.Reset()
+	viper.Set("Client.SlowTransferWindow", 2)
+	viper.Set("Client.SlowTransferRampupTime", 1)
+	config.InitConfig()
+	require.NoError(t, config.InitClient())
 
 	channel := make(chan bool)
 	slowDownload := 1024 * 10 // 10 KiB/s < 100 KiB/s
@@ -240,8 +243,11 @@ func TestStoppedTransfer(t *testing.T) {
 	ctx, _, _ := test_utils.TestContext(context.Background(), t)
 
 	// Adjust down the timeouts
-	viper.Set("Client.StoppedTransferTimeout", 3)
+	viper.Reset()
+	viper.Set("Client.StoppedTransferTimeout", 2)
 	viper.Set("Client.SlowTransferRampupTime", 100)
+	config.InitConfig()
+	require.NoError(t, config.InitClient())
 
 	channel := make(chan bool)
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/client/main.go
+++ b/client/main.go
@@ -319,7 +319,27 @@ func getCachesFromNamespace(namespace namespaces.Namespace, useDirector bool, pr
 		} else {
 			caches = directorCaches
 		}
-		log.Debugln("Matched caches:", caches)
+		if log.IsLevelEnabled(log.DebugLevel) || log.IsLevelEnabled(log.TraceLevel) {
+			cacheHosts := make([]string, len(caches))
+			for idx, entry := range caches {
+				cacheStr := entry.(namespaces.DirectorCache).EndpointUrl
+				cacheUrl, err := url.Parse(cacheStr)
+				if err != nil {
+					cacheHosts[idx] = cacheStr
+				}
+				cacheSimpleUrl := url.URL{
+					Scheme: cacheUrl.Scheme,
+					Host:   cacheUrl.Host,
+				}
+				cacheHosts[idx] = cacheSimpleUrl.String()
+			}
+			if len(cacheHosts) <= 6 {
+				log.Debugln("Matched caches:", strings.Join(cacheHosts, ", "))
+			} else {
+				log.Debugf("Matched caches: %s ... (plus %d more)", strings.Join(cacheHosts[0:6], ", "), len(cacheHosts)-6)
+				log.Traceln("matched caches continued:", cacheHosts[6:])
+			}
+		}
 		return
 	}
 

--- a/client/util.go
+++ b/client/util.go
@@ -20,6 +20,9 @@ package client
 
 import "fmt"
 
+// Convert b bytes to a human-friendly string with SI units
+//
+// For example, ByteCountSI(2000) returns "2 KB"
 func ByteCountSI(b int64) string {
 	const unit = 1000
 	if b < unit {
@@ -31,5 +34,5 @@ func ByteCountSI(b int64) string {
 		exp++
 	}
 	return fmt.Sprintf("%.1f %cB",
-		float64(b)/float64(div), "kMGTPE"[exp])
+		float64(b)/float64(div), "KMGTPE"[exp])
 }

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -496,6 +496,9 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 				developerData[fmt.Sprintf("TransferEndTime%d", attempt.Number)] = attempt.TransferEndTime.Unix()
 				developerData[fmt.Sprintf("ServerVersion%d", attempt.Number)] = attempt.ServerVersion
 				developerData[fmt.Sprintf("TransferTime%d", attempt.Number)] = attempt.TransferTime.Round(time.Millisecond).Seconds()
+				if attempt.CacheAge >= 0 {
+					developerData[fmt.Sprintf("DataAge%d", attempt.Number)] = attempt.CacheAge.Round(time.Millisecond).Seconds()
+				}
 				if attempt.Error != nil {
 					developerData[fmt.Sprintf("TransferError%d", attempt.Number)] = attempt.Error.Error()
 				}

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -96,7 +96,7 @@ func stashPluginMain(args []string) {
 
 			// Set as failure and add errors
 			resultAd.Set("TransferSuccess", false)
-			errMsg := writeTransferErrorMessage(ret+";"+strings.ReplaceAll(string(debug.Stack()), "\n", ";"), "", false)
+			errMsg := writeTransferErrorMessage(ret+";"+strings.ReplaceAll(string(debug.Stack()), "\n", ";"), "")
 			resultAd.Set("TransferError", errMsg)
 			resultAds = append(resultAds, resultAd)
 
@@ -181,7 +181,7 @@ func stashPluginMain(args []string) {
 
 		// Set as failure and add errors
 		resultAd.Set("TransferSuccess", false)
-		errMsg := writeTransferErrorMessage(configErr.Error(), "", upload)
+		errMsg := writeTransferErrorMessage(configErr.Error(), "")
 		resultAd.Set("TransferError", errMsg)
 		if client.ShouldRetry(configErr) {
 			resultAd.Set("TransferRetryable", true)
@@ -531,7 +531,7 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 				if errors.As(result.Error, &te) {
 					errMsgInternal = te.UserError()
 				}
-				errMsg := writeTransferErrorMessage(errMsgInternal, transfer.url.String(), upload)
+				errMsg := writeTransferErrorMessage(errMsgInternal, transfer.url.String())
 				resultAd.Set("TransferError", errMsg)
 				resultAd.Set("TransferFileBytes", 0)
 				resultAd.Set("TransferTotalBytes", 0)
@@ -722,7 +722,7 @@ func readMultiTransfers(stdin bufio.Reader) (transfers []PluginTransfer, err err
 }
 
 // This function wraps the transfer error message into a more readable and user-friendly format.
-func writeTransferErrorMessage(currentError string, transferUrl string, upload bool) (errMsg string) {
+func writeTransferErrorMessage(currentError string, transferUrl string) (errMsg string) {
 
 	errMsg = "Pelican Client Error: "
 

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -231,7 +231,11 @@ func TestStashPluginMain(t *testing.T) {
 	viper.Reset()
 	server_utils.ResetOriginExports()
 
-	_, err := config.SetPreferredPrefix(config.StashPrefix)
+	oldPrefix, err := config.SetPreferredPrefix(config.StashPrefix)
+	defer func() {
+		_, err = config.SetPreferredPrefix(oldPrefix)
+		require.NoError(t, err)
+	}()
 	assert.NoError(t, err)
 
 	// Temp dir for downloads

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -567,7 +567,7 @@ func TestFailTransfer(t *testing.T) {
 		transferError, _ := result.Get("TransferError")
 		transferErrorStr, ok := transferError.(string)
 		require.True(t, ok)
-		assert.Equal(t, "cancelled transfer, too slow.  Detected speed: 0 B/s, total transferred: 0 B, total transfer time: 0s", transferErrorStr)
+		assert.Equal(t, "cancelled transfer, too slow; detected speed=0 B/s, total transferred=0 B, total transfer time=0s, cache miss", transferErrorStr)
 	})
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -1438,10 +1438,6 @@ func InitClient() error {
 
 	upper_prefix := GetPreferredPrefix()
 
-	viper.SetDefault("Client.StoppedTransferTimeout", 100)
-	viper.SetDefault("Client.SlowTransferRampupTime", 100)
-	viper.SetDefault("Client.SlowTransferWindow", 30)
-
 	if upper_prefix == OsdfPrefix || upper_prefix == StashPrefix {
 		viper.SetDefault("Federation.TopologyNamespaceURL", "https://topology.opensciencegrid.org/osdf/namespaces")
 	}

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -33,6 +33,9 @@ Logging:
     Xrd: error
     Xrootd: error
 Client:
+  SlowTransferRampupTime: 100
+  SlowTransferWindow: 30
+  StoppedTransferTimeout: 100
   WorkerCount: 5
 Server:
   WebPort: 8444

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -33,9 +33,9 @@ Logging:
     Xrd: error
     Xrootd: error
 Client:
-  SlowTransferRampupTime: 100
-  SlowTransferWindow: 30
-  StoppedTransferTimeout: 100
+  SlowTransferRampupTime: 100s
+  SlowTransferWindow: 30s
+  StoppedTransferTimeout: 100s
   WorkerCount: 5
 Server:
   WebPort: 8444

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -353,22 +353,22 @@ components: ["origin"]
 name: Client.StoppedTransferTimeout
 description: |+
   A timeout indicating when a "stopped transfer" event should be triggered.
-type: int
-default: 100
+type: duration
+default: 100s
 components: ["client"]
 ---
 name: Client.SlowTransferRampupTime
 description: |+
   A duration indicating the ramp up period for a slow transfer.
-type: int
-default: 30
+type: duration
+default: 30s
 components: ["client"]
 ---
 name: Client.SlowTransferWindow
 description: |+
   A duration indicating the sliding window over which to consider transfer speeds for slow transfers.
-type: int
-default: 30
+type: duration
+default: 30s
 components: ["client"]
 ---
 name: Client.DisableHttpProxy
@@ -409,7 +409,7 @@ components: ["client"]
 ---
 name: Client.MinimumDownloadSpeed
 description: |+
-  The minimum speed allowed for a client download before an error is thrown.
+  The minimum speed (in bytes per second) allowed for a client download before an error is thrown.
 type: int
 default: 102400
 components: ["client"]

--- a/local_cache/cache_linux_test.go
+++ b/local_cache/cache_linux_test.go
@@ -67,7 +67,7 @@ func TestPurge(t *testing.T) {
 		log.Debugln("Will write origin file", filepath.Join(ft.Exports[0].StoragePrefix, fmt.Sprintf("hello_world.txt.%d", idx)))
 		fp, err := os.OpenFile(filepath.Join(ft.Exports[0].StoragePrefix, fmt.Sprintf("hello_world.txt.%d", idx)), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 		require.NoError(t, err)
-		size = writeBigBuffer(t, fp, 1)
+		size = test_utils.WriteBigBuffer(t, fp, 1)
 	}
 	require.NotEqual(t, 0, size)
 
@@ -147,7 +147,7 @@ func TestForcePurge(t *testing.T) {
 		log.Debugln("Will write origin file", filepath.Join(ft.Exports[0].StoragePrefix, fmt.Sprintf("hello_world.txt.%d", idx)))
 		fp, err := os.OpenFile(filepath.Join(ft.Exports[0].StoragePrefix, fmt.Sprintf("hello_world.txt.%d", idx)), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 		require.NoError(t, err)
-		size = writeBigBuffer(t, fp, 1)
+		size = test_utils.WriteBigBuffer(t, fp, 1)
 	}
 	require.NotEqual(t, 0, size)
 

--- a/local_cache/cache_test.go
+++ b/local_cache/cache_test.go
@@ -294,34 +294,6 @@ func TestStat(t *testing.T) {
 	assert.Equal(t, uint64(13), size)
 }
 
-// Creates a buffer of at least 1MB
-func makeBigBuffer() []byte {
-	byteBuff := []byte("Hello, World!")
-	for {
-		byteBuff = append(byteBuff, []byte("Hello, World!")...)
-		if len(byteBuff) > 1024*1024 {
-			break
-		}
-	}
-	return byteBuff
-}
-
-// Writes a file at least the specified size in MB
-func writeBigBuffer(t *testing.T, fp io.WriteCloser, sizeMB int) (size int) {
-	defer fp.Close()
-	byteBuff := makeBigBuffer()
-	size = 0
-	for {
-		n, err := fp.Write(byteBuff)
-		require.NoError(t, err)
-		size += n
-		if size > sizeMB*1024*1024 {
-			break
-		}
-	}
-	return
-}
-
 // Create a 100MB file in the origin.  Download it (slowly) via the local cache.
 //
 // This triggers multiple internal requests to wait on the slow download
@@ -342,7 +314,7 @@ func TestLargeFile(t *testing.T) {
 
 	fp, err := os.OpenFile(filepath.Join(ft.Exports[0].StoragePrefix, "hello_world.txt"), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 	require.NoError(t, err)
-	size := writeBigBuffer(t, fp, 100)
+	size := test_utils.WriteBigBuffer(t, fp, 100)
 
 	require.NoError(t, err)
 	tr, err := client.DoGet(ctx, "pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt",
@@ -389,7 +361,7 @@ func TestOriginUnresponsive(t *testing.T) {
 
 	fp, err := os.OpenFile(filepath.Join(ft.Exports[0].StoragePrefix, "hello_world.txt"), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 	require.NoError(t, err)
-	writeBigBuffer(t, fp, 1)
+	test_utils.WriteBigBuffer(t, fp, 1)
 
 	downloadUrl := fmt.Sprintf("pelican://%s:%s%s/%s", param.Server_Hostname.GetString(), strconv.Itoa(param.Server_WebPort.GetInt()),
 		ft.Exports[0].FederationPrefix, "hello_world.txt")

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -266,9 +266,6 @@ var (
 	Cache_Port = IntParam{"Cache.Port"}
 	Client_MaximumDownloadSpeed = IntParam{"Client.MaximumDownloadSpeed"}
 	Client_MinimumDownloadSpeed = IntParam{"Client.MinimumDownloadSpeed"}
-	Client_SlowTransferRampupTime = IntParam{"Client.SlowTransferRampupTime"}
-	Client_SlowTransferWindow = IntParam{"Client.SlowTransferWindow"}
-	Client_StoppedTransferTimeout = IntParam{"Client.StoppedTransferTimeout"}
 	Client_WorkerCount = IntParam{"Client.WorkerCount"}
 	Director_MaxStatResponse = IntParam{"Director.MaxStatResponse"}
 	Director_MinStatResponse = IntParam{"Director.MinStatResponse"}
@@ -334,6 +331,9 @@ var (
 
 var (
 	Cache_SelfTestInterval = DurationParam{"Cache.SelfTestInterval"}
+	Client_SlowTransferRampupTime = DurationParam{"Client.SlowTransferRampupTime"}
+	Client_SlowTransferWindow = DurationParam{"Client.SlowTransferWindow"}
+	Client_StoppedTransferTimeout = DurationParam{"Client.StoppedTransferTimeout"}
 	Director_AdvertisementTTL = DurationParam{"Director.AdvertisementTTL"}
 	Director_OriginCacheHealthTestInterval = DurationParam{"Director.OriginCacheHealthTestInterval"}
 	Director_StatTimeout = DurationParam{"Director.StatTimeout"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -50,9 +50,9 @@ type Config struct {
 		DisableProxyFallback bool
 		MaximumDownloadSpeed int
 		MinimumDownloadSpeed int
-		SlowTransferRampupTime int
-		SlowTransferWindow int
-		StoppedTransferTimeout int
+		SlowTransferRampupTime time.Duration
+		SlowTransferWindow time.Duration
+		StoppedTransferTimeout time.Duration
 		WorkerCount int
 	}
 	ConfigDir string
@@ -326,9 +326,9 @@ type configWithType struct {
 		DisableProxyFallback struct { Type string; Value bool }
 		MaximumDownloadSpeed struct { Type string; Value int }
 		MinimumDownloadSpeed struct { Type string; Value int }
-		SlowTransferRampupTime struct { Type string; Value int }
-		SlowTransferWindow struct { Type string; Value int }
-		StoppedTransferTimeout struct { Type string; Value int }
+		SlowTransferRampupTime struct { Type string; Value time.Duration }
+		SlowTransferWindow struct { Type string; Value time.Duration }
+		StoppedTransferTimeout struct { Type string; Value time.Duration }
 		WorkerCount struct { Type string; Value int }
 	}
 	ConfigDir struct { Type string; Value string }

--- a/test_utils/utils.go
+++ b/test_utils/utils.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
@@ -131,4 +132,21 @@ func RegistryMockup(t *testing.T, prefix string) *httptest.Server {
 	}))
 	t.Cleanup(server.Close)
 	return server
+}
+
+// Initialize the client for a unit test
+//
+// Will set the configuration to a temporary directory (to
+// avoid pulling in global configuration) and set some arbitrary
+// viper configurations
+func InitClient(t *testing.T, initCfg map[string]any) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.Set("ConfigDir", t.TempDir())
+	for key, val := range initCfg {
+		viper.Set(key, val)
+	}
+
+	config.InitConfig()
+	require.NoError(t, config.InitClient())
 }


### PR DESCRIPTION
This PR tracks whether there was a cache hit or miss based on the `Age` header in the server response.  The goal is to provide some indication to users in the hold message as to why their transfer failed -- was it a slow origin or a slow cache?  (The assumption is if it was a cache hit and a slow transfer then the cache is at fault.)

Also in this PR:
- Minor cleanup of the debug log messages when doing transfers.  Less repetition; do not print caches that we won't ever use.
- Fix the pre-transfer queries to selected cache hosts; particularly, put caches that respond with an error to the back of the list.
- Send correct header for PROPFIND request.
- Fix a small "airplane mode" issue causing tests to fail when there's no internet connectivity.
