### PR TITLE
Added filtering on osdf topology namespaces for production and its

### DIFF
--- a/config/resources/osdf.yaml
+++ b/config/resources/osdf.yaml
@@ -23,6 +23,8 @@ Federation:
   TopologyURL: https://topology.opensciencegrid.org
   TopologyNamespaceURL: https://topology.opensciencegrid.org/osdf/namespaces
   TopologyReloadInterval: 4.5m
+  TopologyITB: false
+  TopologyProduction: true
 Registry:
   RequireCacheApproval: true
   RequireOriginApproval: true

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -337,6 +337,22 @@ osdf_default: 4.5m
 default: none
 components: ["director", "registry"]
 ---
+name: Federation.TopologyProduction
+description: |+
+  Whether to include production caches and origins configured via the OSG Topology application (a legacy integration).
+osdf_default: true
+default: none
+type: bool
+components: ["director"]
+---
+name: Federation.TopologyITB
+description: |+
+  Whether to include itb caches and origins configured via the OSG Topology application (a legacy integration).
+osdf_default: false
+default: none
+type: bool
+componenets: ["director"]
+---
 name: Federation.BrokerUrl
 description: |+
   The URL of the broker endpoint used by the origin.

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -300,6 +300,8 @@ var (
 	Director_EnableOIDC = BoolParam{"Director.EnableOIDC"}
 	DisableHttpProxy = BoolParam{"DisableHttpProxy"}
 	DisableProxyFallback = BoolParam{"DisableProxyFallback"}
+	Federation_TopologyITB = BoolParam{"Federation.TopologyITB"}
+	Federation_TopologyProduction = BoolParam{"Federation.TopologyProduction"}
 	Issuer_UserStripDomain = BoolParam{"Issuer.UserStripDomain"}
 	Logging_DisableProgressBars = BoolParam{"Logging.DisableProgressBars"}
 	Lotman_EnableAPI = BoolParam{"Lotman.EnableAPI"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -84,7 +84,9 @@ type Config struct {
 		DiscoveryUrl string
 		JwkUrl string
 		RegistryUrl string
+		TopologyITB bool
 		TopologyNamespaceUrl string
+		TopologyProduction bool
 		TopologyReloadInterval time.Duration
 		TopologyUrl string
 	}
@@ -360,7 +362,9 @@ type configWithType struct {
 		DiscoveryUrl struct { Type string; Value string }
 		JwkUrl struct { Type string; Value string }
 		RegistryUrl struct { Type string; Value string }
+		TopologyITB struct { Type string; Value bool }
 		TopologyNamespaceUrl struct { Type string; Value string }
+		TopologyProduction struct { Type string; Value bool }
 		TopologyReloadInterval struct { Type string; Value time.Duration }
 		TopologyUrl struct { Type string; Value string }
 	}

--- a/utils/web_utils.go
+++ b/utils/web_utils.go
@@ -127,6 +127,23 @@ func GetTopologyJSON(includeDowned bool) (*TopologyNamespacesJSON, error) {
 
 	req.Header.Set("Accept", "application/json")
 
+	var prodval, itbval string
+	if param.Federation_TopologyITB.GetBool() {
+		itbval = "1"
+	} else {
+		itbval = "0"
+	}
+
+	if param.Federation_TopologyProduction.GetBool() {
+		prodval = "1"
+	} else {
+		prodval = "0"
+	}
+	q := req.URL.Query()
+	q.Add("production", prodval)
+	q.Add("itb", itbval)
+	//req.URL.RawQuery = q.Encode()
+
 	// Use the transport to include timeouts
 	client := http.Client{Transport: config.GetTransport()}
 	resp, err := client.Do(req)


### PR DESCRIPTION

closes #1250 

Note that this passes a query to the topology namespace URL. Since we all the topology testing is faked/offline, there isn't an easy way to test it in unit tests as really the only true way to test it is to actually call out to the OSDF topology url and test that the query is filtering properly.