### PR TITLE
Add "Continue" method for config file patching

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -853,13 +853,13 @@ func setupTranslation() error {
 	})
 }
 
-// If the user defines `Continue: /path/to/dir` in their configuration, this function will
+// If the user defines `ContinuedConfigLocation: /path/to/dir` in their configuration, this function will
 // crawl through that directory and parse all the yaml files in lexicographical order, overriding
 // viper keys that are redefined as it goes. This will NEVER override a key that's hard-coded in source
 func handleContinuedCfg() error {
 	merged := map[string]bool{}
-	for viper.IsSet("Continue") {
-		nextCfgDir := viper.GetString("Continue")
+	for viper.IsSet("ContinuedConfigLocation") {
+		nextCfgDir := viper.GetString("ContinuedConfigLocation")
 		if _, ok := merged[nextCfgDir]; ok {
 			break
 		}
@@ -868,7 +868,7 @@ func handleContinuedCfg() error {
 		// Check that the directory exists
 		if _, err := os.Stat(nextCfgDir); err != nil {
 			if os.IsNotExist(err) {
-				return errors.Errorf("directory %s specified in config 'Continue' does not exist", nextCfgDir)
+				return errors.Errorf("directory %s specified in config 'ContinuedConfigLocation' does not exist", nextCfgDir)
 			} else {
 				return errors.Wrapf(err, "failed to load extra configuration")
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -860,7 +860,7 @@ func handleContinuedCfg() error {
 	if cfgDirs := viper.GetStringSlice("ConfigLocations"); len(cfgDirs) != 0 {
 		for _, cfgDir := range cfgDirs {
 
-		// Check that the directory exists
+			// Check that the directory exists
 			if _, err := os.Stat(cfgDir); err != nil {
 				if os.IsNotExist(err) {
 					return errors.Errorf("directory %s specified by the 'ConfigLocations' key does not exist", cfgDir)

--- a/config/config.go
+++ b/config/config.go
@@ -853,68 +853,55 @@ func setupTranslation() error {
 	})
 }
 
-// If the user defines `ContinuedConfigLocation: /path/to/dir` in their configuration, this function will
-// crawl through that directory and parse all the yaml files in lexicographical order, overriding
-// viper keys that are redefined as it goes. This will NEVER override a key that's hard-coded in source
+// If the config file defines a "ConfigLocations" key and a list of corresponding directories, we parse all the yaml
+// files in those directories according to directory-scoped lexicographical order. This allows users/admins to split
+// their configuration across multiple directories/files.
 func handleContinuedCfg() error {
-	merged := map[string]bool{}
-	for viper.IsSet("ContinuedConfigLocation") {
-		nextCfgDir := viper.GetString("ContinuedConfigLocation")
-		if _, ok := merged[nextCfgDir]; ok {
-			break
-		}
-		merged[nextCfgDir] = true
+	if cfgDirs := viper.GetStringSlice("ConfigLocations"); len(cfgDirs) != 0 {
+		for _, cfgDir := range cfgDirs {
 
 		// Check that the directory exists
-		if _, err := os.Stat(nextCfgDir); err != nil {
-			if os.IsNotExist(err) {
-				return errors.Errorf("directory %s specified in config 'ContinuedConfigLocation' does not exist", nextCfgDir)
-			} else {
+			if _, err := os.Stat(cfgDir); err != nil {
+				if os.IsNotExist(err) {
+					return errors.Errorf("directory %s specified by the 'ConfigLocations' key does not exist", cfgDir)
+				} else {
+					return errors.Wrapf(err, "failed to load extra configuration from %s", cfgDir)
+				}
+			}
+
+			// Get all files from the directory, sorted in lexicographical order (sorting handled by WalkDir)
+			configFiles := []string{}
+			fileSystem := os.DirFS(cfgDir)
+			err := fs.WalkDir(fileSystem, ".", func(path string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if !d.IsDir() && path != "." {
+					configFiles = append(configFiles, path)
+				}
+				return nil
+			})
+			if err != nil {
 				return errors.Wrapf(err, "failed to load extra configuration")
 			}
-		}
 
-		// Get all files from our continue directory, sorted in lexicographical order (handled by WalkDir)
-		configFiles := []string{}
-		fileSystem := os.DirFS(nextCfgDir)
-		err := fs.WalkDir(fileSystem, ".", func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			if !d.IsDir() && path != "." {
-				configFiles = append(configFiles, path)
-			}
-			return nil
-		})
-		if err != nil {
-			return errors.Wrapf(err, "failed to load extra configuration")
-		}
+			for _, file := range configFiles {
+				fHandle, err := os.Open(filepath.Join(cfgDir, file))
+				if err != nil {
+					return errors.Wrapf(err, "failed to open extra configuration file %s", filepath.Join(cfgDir, file))
+				}
+				defer fHandle.Close()
 
-		for _, file := range configFiles {
-			fHandle, err := os.Open(filepath.Join(nextCfgDir, file))
-			if err != nil {
-				return errors.Wrapf(err, "failed to open extra configuration file %s", filepath.Join(nextCfgDir, file))
-			}
-			defer fHandle.Close()
-
-			reader := io.Reader(fHandle)
-			err = viper.MergeConfig(reader)
-			if err != nil {
-				return errors.Wrapf(err, "failed to merge extra configuration file %s", filepath.Join(nextCfgDir, file))
+				reader := io.Reader(fHandle)
+				err = viper.MergeConfig(reader)
+				if err != nil {
+					return errors.Wrapf(err, "failed to merge extra configuration file %s", filepath.Join(cfgDir, file))
+				}
 			}
 		}
-	}
 
-	if len(merged) > 0 {
-		// Log all the extra config files we used, converting the map to a slice of keys for prettier printing
-		keys := make([]string, len(merged))
-		i := 0
-		for k := range merged {
-			keys[i] = k
-			i++
-		}
-		log.Infof("Configuration constructed according to lexicographical file order from the following directories: %s",
-			strings.Join(keys, ", "))
+		log.Infof("Configuration constructed according to directory-scoped lexicographical file order from the following directories: %s",
+			strings.Join(cfgDirs, ", "))
 	}
 
 	return nil
@@ -971,7 +958,7 @@ func InitConfig() {
 		}
 	}
 
-	// If the config file defines a "Continue" key, we parse all the yaml files in that directory
+	// Handle any extra yaml configurations specified in the ConfigLocations key
 	err = handleContinuedCfg()
 	if err != nil {
 		cobra.CheckErr(err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -190,7 +190,7 @@ func setupContConfig(t *testing.T, continueDir string) {
 	viper.SetConfigType("yaml")
 	viper.SetConfigName("pelican")
 
-	err := os.WriteFile(filepath.Join(rootCfgDir, "pelican.yaml"), []byte(fmt.Sprintf("Continue: %s\nOtherVal: bar", continueDir)), 0644)
+	err := os.WriteFile(filepath.Join(rootCfgDir, "pelican.yaml"), []byte(fmt.Sprintf("ContinuedConfigLocation: %s\nOtherVal: bar", continueDir)), 0644)
 	require.NoError(t, err)
 	err = viper.MergeInConfig()
 	require.NoError(t, err)
@@ -251,7 +251,7 @@ func TestContinuedCfg(t *testing.T) {
 		continueDir2 := t.TempDir()
 		continueFile1 := filepath.Join(continueDir1, "continue1.yaml")
 		// The first continued config will point to the second directory
-		err := os.WriteFile(continueFile1, []byte(fmt.Sprintf("Continue: %s\nTestVal: foo", continueDir2)), 0644)
+		err := os.WriteFile(continueFile1, []byte(fmt.Sprintf("ContinuedConfigLocation: %s\nTestVal: foo", continueDir2)), 0644)
 		require.NoError(t, err)
 
 		continueFile2 := filepath.Join(continueDir2, "continue2.yaml")
@@ -274,11 +274,11 @@ func TestContinuedCfg(t *testing.T) {
 		continueDir2 := t.TempDir()
 		continueFile1 := filepath.Join(continueDir1, "continue1.yaml")
 		// The first continued config will point to the second directory
-		err := os.WriteFile(continueFile1, []byte(fmt.Sprintf("Continue: %s\nTestVal: foo", continueDir2)), 0644)
+		err := os.WriteFile(continueFile1, []byte(fmt.Sprintf("ContinuedConfigLocation: %s\nTestVal: foo", continueDir2)), 0644)
 		require.NoError(t, err)
 
 		continueFile2 := filepath.Join(continueDir2, "continue2.yaml")
-		err = os.WriteFile(continueFile2, []byte(fmt.Sprintf("Continue: %s\nTestVal: boo", continueDir1)), 0644)
+		err = os.WriteFile(continueFile2, []byte(fmt.Sprintf("ContinuedConfigLocation: %s\nTestVal: boo", continueDir1)), 0644)
 		require.NoError(t, err)
 
 		// We'll start with 1, go to 2, then re-check 1 to find we've already done it. The result is that

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -182,21 +182,28 @@ func TestInitConfig(t *testing.T) {
 	assert.Equal(t, "", param.Federation_DiscoveryUrl.GetString())
 }
 
-// Create a root config file with a Continue key pointing to a test directory
-func setupContConfig(t *testing.T, continueDir string) {
+// Helper func for TestExtraCfg
+//
+// Sets up the root config file and adds the ConfigLocations key to point to a test's tempdir
+func setupConfigLocations(t *testing.T, continueDirs []string) {
 	rootCfgDir := t.TempDir()
 
 	viper.AddConfigPath(rootCfgDir)
 	viper.SetConfigType("yaml")
 	viper.SetConfigName("pelican")
 
-	err := os.WriteFile(filepath.Join(rootCfgDir, "pelican.yaml"), []byte(fmt.Sprintf("ContinuedConfigLocation: %s\nOtherVal: bar", continueDir)), 0644)
+	// Convert the slice of directories into a YAML list
+	yamlDirs := strings.Join(continueDirs, "\", \"")
+	yamlDirs = fmt.Sprintf("[\"%s\"]", yamlDirs)
+
+	err := os.WriteFile(filepath.Join(rootCfgDir, "pelican.yaml"), []byte(fmt.Sprintf("ConfigLocations: %s\nOtherVal: bar", yamlDirs)), 0644)
 	require.NoError(t, err)
 	err = viper.MergeInConfig()
 	require.NoError(t, err)
 }
 
-func TestContinuedCfg(t *testing.T) {
+// Test that the `ConfigLocations` key works as expected
+func TestExtraCfg(t *testing.T) {
 	viper.Reset()
 	t.Cleanup(func() {
 		viper.Reset()
@@ -207,13 +214,26 @@ func TestContinuedCfg(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("test-one-continue-one-file", func(t *testing.T) {
+	t.Run("test-one-dir-no-files", func(t *testing.T) {
 		viper.Reset()
-		continueDir := t.TempDir()
-		setupContConfig(t, continueDir)
+		dir1 := t.TempDir()
+		setupConfigLocations(t, []string{dir1})
+
+		// If there are no files in a directory pointed to by ConfigLocations, we should not error
+		// We should also do no config merging
+		err := handleContinuedCfg()
+		assert.NoError(t, err)
+		// Check the other value in our original config to make sure we didn't simply overwrite
+		assert.Equal(t, "bar", viper.GetString("OtherVal"))
+	})
+
+	t.Run("test-one-dir-one-file", func(t *testing.T) {
+		viper.Reset()
+		dir1 := t.TempDir()
+		setupConfigLocations(t, []string{dir1})
 
 		// Write a key: value to a file in the continue directory
-		continueFile := filepath.Join(continueDir, "continue.yaml")
+		continueFile := filepath.Join(dir1, "config.yaml")
 		err := os.WriteFile(continueFile, []byte("TestVal: foo"), 0644)
 		require.NoError(t, err)
 
@@ -224,75 +244,59 @@ func TestContinuedCfg(t *testing.T) {
 		assert.Equal(t, "bar", viper.GetString("otherVal"))
 	})
 
-	t.Run("test-one-continue-two-files", func(t *testing.T) {
+	t.Run("test-two-dirs-one-file-each", func(t *testing.T) {
 		viper.Reset()
-		continueDir := t.TempDir()
-		setupContConfig(t, continueDir)
+		dir1 := t.TempDir()
+		dir2 := t.TempDir()
+		setupConfigLocations(t, []string{dir1, dir2})
 
-		continueFile1 := filepath.Join(continueDir, "continue1.yaml")
-		err := os.WriteFile(continueFile1, []byte("TestVal: foo"), 0644)
-		require.NoError(t, err)
-		continueFile2 := filepath.Join(continueDir, "continue2.yaml")
-		err = os.WriteFile(continueFile2, []byte("TestVal: boo"), 0644)
-		require.NoError(t, err)
+		for idx, dir := range []string{dir1, dir2} {
+			continueFile := filepath.Join(dir, "config.yaml")
+			err := os.WriteFile(continueFile, []byte(fmt.Sprintf("TestVal: foo-%d\nDirVal%d: %d", idx, idx, idx)), 0644)
+			require.NoError(t, err)
+		}
 
-		// Now we should pick up "boo" as the value, because continue2 is parsed last according to lexicographical order
-		err = handleContinuedCfg()
+		// Because we've configured ConfigLocations: [dir1, dir2], we should expect the value from dir1 to be overwritten by the value from dir2
+		err := handleContinuedCfg()
 		assert.NoError(t, err)
-		assert.Equal(t, "boo", viper.GetString("TestVal"))
+		assert.Equal(t, "foo-1", viper.GetString("TestVal"))
+		// Any previously-undefined keys should still be picked up (ie they're new and not a "patch")
+		assert.Equal(t, "0", viper.GetString("DirVal0"))
+		assert.Equal(t, "1", viper.GetString("DirVal1"))
+
+		// Check the other value in our original config to make sure we didn't simply overwrite the entire config with our new values
 		assert.Equal(t, "bar", viper.GetString("otherVal"))
 	})
 
-	t.Run("test-two-continues-two-files", func(t *testing.T) {
+	t.Run("test-two-dirs-two-files-each", func(t *testing.T) {
 		viper.Reset()
-		continueDir1 := t.TempDir()
-		setupContConfig(t, continueDir1)
+		dir1 := t.TempDir()
+		dir2 := t.TempDir()
+		setupConfigLocations(t, []string{dir1, dir2})
 
-		continueDir2 := t.TempDir()
-		continueFile1 := filepath.Join(continueDir1, "continue1.yaml")
-		// The first continued config will point to the second directory
-		err := os.WriteFile(continueFile1, []byte(fmt.Sprintf("ContinuedConfigLocation: %s\nTestVal: foo", continueDir2)), 0644)
-		require.NoError(t, err)
+		counter := 1
+		for dirIdx, dir := range []string{dir1, dir2} {
+			for fileIdx := 0; fileIdx < 2; fileIdx++ {
+				// These should be parsed in lexicographical order. That's not extensively tested here, because
+				// it's a feature of the underlying library filesystem library.
+				continueFile := filepath.Join(dir, fmt.Sprintf("config-%d.yaml", dirIdx))
+				err := os.WriteFile(continueFile, []byte(fmt.Sprintf("TestVal: foo-%d-%d", dirIdx, fileIdx)), 0644)
+				require.NoError(t, err)
+			}
+			counter += 1
+		}
 
-		continueFile2 := filepath.Join(continueDir2, "continue2.yaml")
-		err = os.WriteFile(continueFile2, []byte("TestVal: boo"), 0644)
-		require.NoError(t, err)
-
-		// Start with dir 1, ensure we get to dir 2 and pick up the correct overwritten "boo" value
-		// We should pick up "boo" as the value, because continue2 is parsed last
-		err = handleContinuedCfg()
+		err := handleContinuedCfg()
 		assert.NoError(t, err)
-		assert.Equal(t, "boo", viper.GetString("TestVal"))
-		assert.Equal(t, "bar", viper.GetString("otherVal"))
-	})
-
-	t.Run("test-circular-continue", func(t *testing.T) {
-		viper.Reset()
-		continueDir1 := t.TempDir()
-		setupContConfig(t, continueDir1)
-
-		continueDir2 := t.TempDir()
-		continueFile1 := filepath.Join(continueDir1, "continue1.yaml")
-		// The first continued config will point to the second directory
-		err := os.WriteFile(continueFile1, []byte(fmt.Sprintf("ContinuedConfigLocation: %s\nTestVal: foo", continueDir2)), 0644)
-		require.NoError(t, err)
-
-		continueFile2 := filepath.Join(continueDir2, "continue2.yaml")
-		err = os.WriteFile(continueFile2, []byte(fmt.Sprintf("ContinuedConfigLocation: %s\nTestVal: boo", continueDir1)), 0644)
-		require.NoError(t, err)
-
-		// We'll start with 1, go to 2, then re-check 1 to find we've already done it. The result is that
-		// we should pick up "boo" as the value, because continue2 is parsed last
-		err = handleContinuedCfg()
-		assert.NoError(t, err)
-		assert.Equal(t, "boo", viper.GetString("TestVal"))
+		assert.Equal(t, "foo-1-1", viper.GetString("TestVal"))
+		// Check the other value in our original config to make sure we didn't simply overwrite the entire config with our new values
 		assert.Equal(t, "bar", viper.GetString("otherVal"))
 	})
 
 	t.Run("test-bad-directory", func(t *testing.T) {
 		viper.Reset()
 		continueDir := t.TempDir()
-		setupContConfig(t, continueDir+"-dne")
+		setupConfigLocations(t, []string{continueDir + "-dne"})
 
 		continueFile := filepath.Join(continueDir, "continue.yaml")
 		err := os.WriteFile(continueFile, []byte("TestVal: foo"), 0644)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -192,6 +192,11 @@ func setupConfigLocations(t *testing.T, continueDirs []string) {
 	viper.SetConfigType("yaml")
 	viper.SetConfigName("pelican")
 
+	// Escape backslashes in the directory paths -- needed for Windows tests
+	for idx, dir := range continueDirs {
+		continueDirs[idx] = strings.ReplaceAll(dir, "\\", "\\\\")
+	}
+
 	// Convert the slice of directories into a YAML list
 	yamlDirs := strings.Join(continueDirs, "\", \"")
 	yamlDirs = fmt.Sprintf("[\"%s\"]", yamlDirs)

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -30,6 +30,21 @@ default: "~/.config/pelican"
 components: ["*"]
 type: filename
 ---
+name: ContinuedConfigLocation
+description: |+
+  When `ContinuedConfigLocation` is specified in a configuration file, Pelican will continue to read and parse
+  configuration files from that location, overriding previous keys if they're re-defined. Configuration files
+  in a directory are parsed in lexicographical order.
+
+  A configuration file that's already continued to may defined further `ContinuedConfigLocation` keys, allowing
+  for a chain of configuration files to be read and parsed. If no additional `ContinuedConfigLocation` keys are
+  specified, additional directories in a continued directory will be ignored.
+
+  NOTE: This feature assumes that any file in a directory that's continued to is also a yaml configuration file.
+default: none
+components: ["*"]
+type: filename
+---
 name: Debug
 description: |+
   A bool indicating whether Pelican should emit debug messages in its log.

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -42,7 +42,7 @@ description: |+
   and `/configs2`, the value from `/configs2` will be used. If `/configs1` contains files `a.yaml` and `b.yaml` where both define the same key, the value
   from `b.yaml` will be used.
 
-  Subdirectories of the provided directories are not read.
+  Subdirectories of the provided directories are not read. Only the root config file's `ConfigLocations` key is used, and any redefinitions are ignored.
 type: stringSlice
 default: none
 components: ["*"]

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -30,20 +30,22 @@ default: "~/.config/pelican"
 components: ["*"]
 type: filename
 ---
-name: ContinuedConfigLocation
+name: ConfigLocations
 description: |+
-  When `ContinuedConfigLocation` is specified in a configuration file, Pelican will continue to read and parse
-  configuration files from that location, overriding previous keys if they're re-defined. Configuration files
-  in a directory are parsed in lexicographical order.
+  `ConfigLocations` provides administrators a way to define a list of directories containing Pelican configuration files. Within a given directory,
+  files are read in lexicographical order, and any keys that are defined in multiple files will take the value from the last file read. Directories are
+  read in the order provided by the list. For example, specifying:
 
-  A configuration file that's already continued to may defined further `ContinuedConfigLocation` keys, allowing
-  for a chain of configuration files to be read and parsed. If no additional `ContinuedConfigLocation` keys are
-  specified, additional directories in a continued directory will be ignored.
+  `ConfigLocations: ["/configs1", "/configs2"]`
 
-  NOTE: This feature assumes that any file in a directory that's continued to is also a yaml configuration file.
+  will read files first from `/configs1` and then from `/configs2`. If a key is defined in both `/configs1`
+  and `/configs2`, the value from `/configs2` will be used. If `/configs1` contains files `a.yaml` and `b.yaml` where both define the same key, the value
+  from `b.yaml` will be used.
+
+  Subdirectories of the provided directories are not read.
+type: stringSlice
 default: none
 components: ["*"]
-type: filename
 ---
 name: Debug
 description: |+

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -127,7 +127,6 @@ var (
 	Cache_SentinelLocation = StringParam{"Cache.SentinelLocation"}
 	Cache_Url = StringParam{"Cache.Url"}
 	Cache_XRootDPrefix = StringParam{"Cache.XRootDPrefix"}
-	ContinuedConfigLocation = StringParam{"ContinuedConfigLocation"}
 	Director_CacheSortMethod = StringParam{"Director.CacheSortMethod"}
 	Director_DefaultResponse = StringParam{"Director.DefaultResponse"}
 	Director_GeoIPLocation = StringParam{"Director.GeoIPLocation"}
@@ -249,6 +248,7 @@ var (
 	Cache_DataLocations = StringSliceParam{"Cache.DataLocations"}
 	Cache_MetaLocations = StringSliceParam{"Cache.MetaLocations"}
 	Cache_PermittedNamespaces = StringSliceParam{"Cache.PermittedNamespaces"}
+	ConfigLocations = StringSliceParam{"ConfigLocations"}
 	Director_CacheResponseHostnames = StringSliceParam{"Director.CacheResponseHostnames"}
 	Director_FilteredServers = StringSliceParam{"Director.FilteredServers"}
 	Director_OriginResponseHostnames = StringSliceParam{"Director.OriginResponseHostnames"}

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -127,6 +127,7 @@ var (
 	Cache_SentinelLocation = StringParam{"Cache.SentinelLocation"}
 	Cache_Url = StringParam{"Cache.Url"}
 	Cache_XRootDPrefix = StringParam{"Cache.XRootDPrefix"}
+	ContinuedConfigLocation = StringParam{"ContinuedConfigLocation"}
 	Director_CacheSortMethod = StringParam{"Director.CacheSortMethod"}
 	Director_DefaultResponse = StringParam{"Director.DefaultResponse"}
 	Director_GeoIPLocation = StringParam{"Director.GeoIPLocation"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -56,6 +56,7 @@ type Config struct {
 		WorkerCount int `mapstructure:"workercount"`
 	} `mapstructure:"client"`
 	ConfigDir string `mapstructure:"configdir"`
+	ContinuedConfigLocation string `mapstructure:"continuedconfiglocation"`
 	Debug bool `mapstructure:"debug"`
 	Director struct {
 		AdvertisementTTL time.Duration `mapstructure:"advertisementttl"`
@@ -336,6 +337,7 @@ type configWithType struct {
 		WorkerCount struct { Type string; Value int }
 	}
 	ConfigDir struct { Type string; Value string }
+	ContinuedConfigLocation struct { Type string; Value string }
 	Debug struct { Type string; Value bool }
 	Director struct {
 		AdvertisementTTL struct { Type string; Value time.Duration }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -56,7 +56,7 @@ type Config struct {
 		WorkerCount int `mapstructure:"workercount"`
 	} `mapstructure:"client"`
 	ConfigDir string `mapstructure:"configdir"`
-	ContinuedConfigLocation string `mapstructure:"continuedconfiglocation"`
+	ConfigLocations []string `mapstructure:"configlocations"`
 	Debug bool `mapstructure:"debug"`
 	Director struct {
 		AdvertisementTTL time.Duration `mapstructure:"advertisementttl"`
@@ -337,7 +337,7 @@ type configWithType struct {
 		WorkerCount struct { Type string; Value int }
 	}
 	ConfigDir struct { Type string; Value string }
-	ContinuedConfigLocation struct { Type string; Value string }
+	ConfigLocations struct { Type string; Value []string }
 	Debug struct { Type string; Value bool }
 	Director struct {
 		AdvertisementTTL struct { Type string; Value time.Duration }


### PR DESCRIPTION
This adds the ability to define "Continue" directories in your config, where doing so causes Pelican to merge in any additional files in that directory. For example, if my `/etc/pelican/pelican.yaml` has the line `Continue: /foo`, this addition causes Pelican to merge any extra yamls located in `/foo`. If `/foo/config.yaml` further defines `Continue: /bar`, Pelican will then look to `/bar` for extra config.

Config files in a "Continue" directory are parsed according to lexicographical order. This does not currently support adding entries to viper slices, so, for example, if `/etc/pelican/pelican.yaml` defines:
```
Origin:
  Exports:
    - < values for export 1 >
Continue: /foo
```

and `/foo/config.yaml` defines:
```
Origin:
  Exports:
    - < values for export 2 >
```

the exports slice will be overwritten with export 2, instead of appended to.

Closes #1122 