### PR TITLE
Implementation of pelican object stat

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -173,7 +173,7 @@ func DoStat(ctx context.Context, destination string, options ...TransferOption) 
 
 	defer func() {
 		if r := recover(); r != nil {
-			log.Debugln("Panic captured while attempting to perform size check:", r)
+			log.Debugln("Panic captured while attempting to stat:", r)
 			log.Debugln("Panic caused by the following", string(debug.Stack()))
 			ret := fmt.Sprintf("Unrecoverable error (panic) while check file size: %v", r)
 			err = errors.New(ret)

--- a/cmd/object_stat.go
+++ b/cmd/object_stat.go
@@ -72,18 +72,18 @@ func statMain(cmd *cobra.Command, args []string) {
 
 	log.Debugln("Object:", object)
 
-	_, result := client.DoStat(ctx, object, client.WithTokenLocation(tokenLocation), client.WithJson(jsn))
+	_, err = client.DoStat(ctx, object, client.WithTokenLocation(tokenLocation), client.WithJson(jsn))
 
 	// Exit with failure
-	if result != nil {
+	if err != nil {
 		// Print the list of errors
-		errMsg := result.Error()
+		errMsg := err.Error()
 		var te *client.TransferErrors
-		if errors.As(result, &te) {
+		if errors.As(err, &te) {
 			errMsg = te.UserError()
 		}
 		log.Errorln("Failure getting " + object + ": " + errMsg)
-		if client.ShouldRetry(result) {
+		if client.ShouldRetry(err) {
 			log.Errorln("Errors are retryable")
 			os.Exit(11)
 		}

--- a/cmd/object_stat.go
+++ b/cmd/object_stat.go
@@ -1,0 +1,92 @@
+/***************************************************************
+*
+* Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
+
+package main
+
+import (
+	"os"
+
+	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	statCmd = &cobra.Command{
+		Use:   "stat {object}",
+		Short: "Stat objects in a namespace from a federation",
+		Run:   statMain,
+	}
+)
+
+func init() {
+	flagSet := statCmd.Flags()
+	flagSet.StringP("token", "t", "", "Token file to use for transfer")
+	flagSet.BoolP("json", "j", false, "Print results in JSON format")
+	objectCmd.AddCommand(statCmd)
+}
+
+func statMain(cmd *cobra.Command, args []string) {
+	ctx := cmd.Context()
+	err := config.InitClient()
+	if err != nil {
+		log.Errorln(err)
+
+		if client.IsRetryable(err) {
+			log.Errorln("Errors are retryable")
+			os.Exit(11)
+		} else {
+			os.Exit(1)
+		}
+	}
+
+	tokenLocation, _ := cmd.Flags().GetString("token")
+	jsn, _ := cmd.Flags().GetBool("json")
+
+	if len(args) < 1 {
+		log.Errorln("no object provided")
+		err = cmd.Help()
+		if err != nil {
+			log.Errorln("failed to print out help:", err)
+		}
+		os.Exit(1)
+	}
+	object := args[len(args)-1]
+
+	log.Debugln("Object:", object)
+
+	_, result := client.DoStat(ctx, object, client.WithTokenLocation(tokenLocation), client.WithJson(jsn))
+
+	// Exit with failure
+	if result != nil {
+		// Print the list of errors
+		errMsg := result.Error()
+		var te *client.TransferErrors
+		if errors.As(result, &te) {
+			errMsg = te.UserError()
+		}
+		log.Errorln("Failure getting " + object + ": " + errMsg)
+		if client.ShouldRetry(result) {
+			log.Errorln("Errors are retryable")
+			os.Exit(11)
+		}
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
The initial implentation of object stat command. This allows users to run the command `pelican object stat` on an object in a namespace and get the following information: Name, Size, ModTime, and IsDir. The only current issue is that if we stat a directory we are currently unable to give a size as the webdav client does not support it.