### PR TITLE
Warn users about unrecognized configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,6 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         make web-build
-        # Explicitly set XRootD to IPv4-only on Mac OS X to avoid a subtle config bug.
-        export PELICAN_XROOTD_IPV4ONLY=true
         go test -v -coverpkg=./... -coverprofile=coverage.out -covermode=count ./...
     - name: Test
       if: runner.os != 'macOS'

--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"reflect"
 	"slices"
 	"sort"
 	"strconv"
@@ -851,79 +850,6 @@ func setupTranslation() error {
 		t, _ := ut.T("required", fe.Field())
 		return t
 	})
-}
-
-// findFieldByTag searches for a field in a struct by the value of a tag. This is used to
-// check our Config struct against viper keys so we can warn the users if they feed the Pelican things
-// it doesn't know how to eat.
-func findFieldByTag(t reflect.Type, tagKey, tagValue string) (reflect.StructField, bool) {
-	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
-		tag := field.Tag.Get(tagKey)
-		if tag == tagValue {
-			return field, true
-		}
-	}
-	return reflect.StructField{}, false
-}
-
-// validateConfigKeys checks keys in the Viper config against fields in the Config struct
-func validateConfigKeys() []string {
-	possibleCfg := param.Config{}
-	unknownKeys := []string{}
-	// Get all currently-configured keys from Viper. This is a collection of default
-	// configurations (both set internally and in defaults.yaml) and user-provided config.
-	keys := viper.AllKeys()
-
-	// Unfortunately viper.AllKeys() won't grab things that would otherwise be discovered as
-	// env vars because of where we call the top-level function.
-	envs := os.Environ()
-	for _, env := range envs {
-		parts := strings.SplitN(env, "=", 2)
-		// Until we fully deprecate OSDF and STASH prefixes, we'll check for them here
-		if strings.HasPrefix(parts[0], "PELICAN_") || strings.HasPrefix(parts[0], "OSDF_") || strings.HasPrefix(parts[0], "STASH_") {
-			// Strip off the prefix, convert to lower and replace _ with .
-			key := strings.SplitN(parts[0], "_", 2)[1]
-			key = strings.ToLower(key)
-			key = strings.ReplaceAll(key, "_", ".")
-			keys = append(keys, key)
-		}
-	}
-
-	// Convert the config struct to a map
-	configValue := reflect.ValueOf(possibleCfg)
-	if configValue.Kind() == reflect.Ptr {
-		configValue = configValue.Elem()
-	}
-	configType := configValue.Type()
-
-	// Iterate over all keys
-	for _, key := range keys {
-		parts := strings.Split(key, ".")
-		// Start with the top-level struct
-		currentType := configType
-
-		for idx, part := range parts {
-			// Check if the part exists in the current struct
-			if idx == 0 && part == "config" { // A special case for the top-level config struct
-				continue
-			}
-			field, present := findFieldByTag(currentType, "mapstructure", part)
-			if !present {
-				unknownKeys = append(unknownKeys, key)
-				break
-			}
-
-			// If the field is a struct, descend into it
-			if field.Type.Kind() == reflect.Struct {
-				currentType = field.Type
-			} else {
-				break
-			}
-		}
-	}
-
-	return unknownKeys
 }
 
 func InitConfig() {

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"sort"
 	"strconv"
@@ -40,15 +41,15 @@ import (
 
 	"github.com/go-playground/locales/en"
 	ut "github.com/go-playground/universal-translator"
-	en_translations "github.com/go-playground/validator/v10/translations/en"
-
 	"github.com/go-playground/validator/v10"
-	"github.com/pelicanplatform/pelican/param"
+	en_translations "github.com/go-playground/validator/v10/translations/en"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/param"
 )
 
 // Structs holding the OAuth2 state (and any other OSDF config needed)
@@ -852,6 +853,79 @@ func setupTranslation() error {
 	})
 }
 
+// findFieldByTag searches for a field in a struct by the value of a tag. This is used to
+// check our Config struct against viper keys so we can warn the users if they feed the Pelican things
+// it doesn't know how to eat.
+func findFieldByTag(t reflect.Type, tagKey, tagValue string) (reflect.StructField, bool) {
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		tag := field.Tag.Get(tagKey)
+		if tag == tagValue {
+			return field, true
+		}
+	}
+	return reflect.StructField{}, false
+}
+
+// validateConfigKeys checks keys in the Viper config against fields in the Config struct
+func validateConfigKeys() []string {
+	possibleCfg := param.Config{}
+	unknownKeys := []string{}
+	// Get all currently-configured keys from Viper. This is a collection of default
+	// configurations (both set internally and in defaults.yaml) and user-provided config.
+	keys := viper.AllKeys()
+
+	// Unfortunately viper.AllKeys() won't grab things that would otherwise be discovered as
+	// env vars because of where we call the top-level function.
+	envs := os.Environ()
+	for _, env := range envs {
+		parts := strings.SplitN(env, "=", 2)
+		// Until we fully deprecate OSDF and STASH prefixes, we'll check for them here
+		if strings.HasPrefix(parts[0], "PELICAN_") || strings.HasPrefix(parts[0], "OSDF_") || strings.HasPrefix(parts[0], "STASH_") {
+			// Strip off the prefix, convert to lower and replace _ with .
+			key := strings.SplitN(parts[0], "_", 2)[1]
+			key = strings.ToLower(key)
+			key = strings.ReplaceAll(key, "_", ".")
+			keys = append(keys, key)
+		}
+	}
+
+	// Convert the config struct to a map
+	configValue := reflect.ValueOf(possibleCfg)
+	if configValue.Kind() == reflect.Ptr {
+		configValue = configValue.Elem()
+	}
+	configType := configValue.Type()
+
+	// Iterate over all keys
+	for _, key := range keys {
+		parts := strings.Split(key, ".")
+		// Start with the top-level struct
+		currentType := configType
+
+		for idx, part := range parts {
+			// Check if the part exists in the current struct
+			if idx == 0 && part == "config" { // A special case for the top-level config struct
+				continue
+			}
+			field, present := findFieldByTag(currentType, "mapstructure", part)
+			if !present {
+				unknownKeys = append(unknownKeys, key)
+				break
+			}
+
+			// If the field is a struct, descend into it
+			if field.Type.Kind() == reflect.Struct {
+				currentType = field.Type
+			} else {
+				break
+			}
+		}
+	}
+
+	return unknownKeys
+}
+
 func InitConfig() {
 	viper.SetConfigType("yaml")
 	// 1) Set up defaults.yaml
@@ -935,6 +1009,12 @@ func InitConfig() {
 
 	// Warn users about deprecated config keys they're using and try to map them to any new equivalent we've defined.
 	handleDeprecatedConfig()
+
+	// Spit out a warning if the user has passed config keys that are not recognized
+	// This should work against both config files and appropriately-prefixed env vars
+	if unknownKeys := validateConfigKeys(); len(unknownKeys) > 0 {
+		log.Warningln("Unknown configuration keys found: ", strings.Join(unknownKeys, ", "))
+	}
 
 	onceValidate.Do(func() {
 		err = setupTranslation()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -214,59 +214,6 @@ func TestDeprecateLogMessage(t *testing.T) {
 	})
 }
 
-func TestBadConfigKeys(t *testing.T) {
-	t.Cleanup(func() { viper.Reset() })
-
-	setupFunc := func() *test.Hook {
-		viper.Reset()
-		viper.Set("ConfigDir", t.TempDir())
-		viper.Set("Debug", true)
-		hook := test.NewLocal(logrus.StandardLogger())
-		return hook
-	}
-	t.Run("testRecognizedViperKey", func(t *testing.T) {
-		hook := setupFunc()
-		viper.Set("Origin.FederationPrefix", "/a/prefix")
-		InitConfig()
-
-		require.NotNil(t, hook.LastEntry())
-		assert.NotContains(t, hook.LastEntry().Message, "Unknown configuration keys found")
-	})
-
-	t.Run("testRecognizedEnvKey", func(t *testing.T) {
-		hook := setupFunc()
-		os.Setenv("PELICAN_ORIGIN_FEDERATIONPREFIX", "/a/prefix")
-		defer os.Unsetenv("PELICAN_ORIGIN_FEDERATIONPREFIX")
-		InitConfig()
-
-		require.NotNil(t, hook.LastEntry())
-		assert.NotContains(t, hook.LastEntry().Message, "Unknown configuration keys found")
-	})
-
-	t.Run("testBadViperKey", func(t *testing.T) {
-		hook := setupFunc()
-		viper.Set("Origin.Bad.Key", "/a/prefix")
-		InitConfig()
-
-		require.NotNil(t, hook.LastEntry())
-		assert.Equal(t, logrus.WarnLevel, hook.LastEntry().Level)
-		assert.Contains(t, hook.LastEntry().Message, "Unknown configuration keys found")
-		assert.Contains(t, hook.LastEntry().Message, "origin.bad.key")
-	})
-
-	t.Run("testBadEnvKey", func(t *testing.T) {
-		hook := setupFunc()
-		os.Setenv("PELICAN_ORIGIN_BAD_KEY", "/a/prefix")
-		defer os.Unsetenv("PELICAN_ORIGIN_BAD_KEY")
-		InitConfig()
-
-		require.NotNil(t, hook.LastEntry())
-		assert.Equal(t, logrus.WarnLevel, hook.LastEntry().Level)
-		assert.Contains(t, hook.LastEntry().Message, "Unknown configuration keys found")
-		assert.Contains(t, hook.LastEntry().Message, "origin.bad.key")
-	})
-}
-
 func TestEnabledServers(t *testing.T) {
 	allServerTypes := []ServerType{OriginType, CacheType, DirectorType, RegistryType}
 	allServerStrs := make([]string, 0)

--- a/config/config_validation.go
+++ b/config/config_validation.go
@@ -1,0 +1,102 @@
+/***************************************************************
+*
+* Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
+
+package config
+
+import (
+	"os"
+	"reflect"
+	"strings"
+
+	"github.com/spf13/viper"
+
+	"github.com/pelicanplatform/pelican/param"
+)
+
+// findFieldByTag searches for a field in a struct by the value of a tag. This is used to
+// check our Config struct against viper keys so we can warn the users if they feed the Pelican things
+// it doesn't know how to eat.
+func findFieldByTag(t reflect.Type, tagKey, tagValue string) (reflect.StructField, bool) {
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		tag := field.Tag.Get(tagKey)
+		if tag == tagValue {
+			return field, true
+		}
+	}
+	return reflect.StructField{}, false
+}
+
+// validateConfigKeys checks keys in the Viper config against fields in the Config struct
+func validateConfigKeys() []string {
+	possibleCfg := param.Config{}
+	unknownKeys := []string{}
+	// Get all currently-configured keys from Viper. This is a collection of default
+	// configurations (both set internally and in defaults.yaml) and user-provided config.
+	keys := viper.AllKeys()
+
+	// Unfortunately viper.AllKeys() won't grab things that would otherwise be discovered as
+	// env vars because of where we call the top-level function.
+	envs := os.Environ()
+	for _, env := range envs {
+		parts := strings.SplitN(env, "=", 2)
+		// Until we fully deprecate OSDF and STASH prefixes, we'll check for them here
+		if strings.HasPrefix(parts[0], "PELICAN_") || strings.HasPrefix(parts[0], "OSDF_") || strings.HasPrefix(parts[0], "STASH_") {
+			// Strip off the prefix, convert to lower and replace _ with .
+			key := strings.SplitN(parts[0], "_", 2)[1]
+			key = strings.ToLower(key)
+			key = strings.ReplaceAll(key, "_", ".")
+			keys = append(keys, key)
+		}
+	}
+
+	// Convert the config struct to a map
+	configValue := reflect.ValueOf(possibleCfg)
+	if configValue.Kind() == reflect.Ptr {
+		configValue = configValue.Elem()
+	}
+	configType := configValue.Type()
+
+	// Iterate over all keys
+	for _, key := range keys {
+		parts := strings.Split(key, ".")
+		// Start with the top-level struct
+		currentType := configType
+
+		for idx, part := range parts {
+			// Check if the part exists in the current struct
+			if idx == 0 && part == "config" { // A special case for the top-level config struct
+				continue
+			}
+			field, present := findFieldByTag(currentType, "mapstructure", part)
+			if !present {
+				unknownKeys = append(unknownKeys, key)
+				break
+			}
+
+			// If the field is a struct, descend into it
+			if field.Type.Kind() == reflect.Struct {
+				currentType = field.Type
+			} else {
+				break
+			}
+		}
+	}
+
+	return unknownKeys
+}

--- a/config/config_validation_test.go
+++ b/config/config_validation_test.go
@@ -1,0 +1,84 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test that Pelican notifies users about unrecognized configuration keys.
+func TestBadConfigKeys(t *testing.T) {
+	t.Cleanup(func() { viper.Reset() })
+
+	setupFunc := func() *test.Hook {
+		viper.Reset()
+		viper.Set("ConfigDir", t.TempDir())
+		viper.Set("Debug", true)
+		hook := test.NewLocal(logrus.StandardLogger())
+		return hook
+	}
+	t.Run("testRecognizedViperKey", func(t *testing.T) {
+		hook := setupFunc()
+		viper.Set("Origin.FederationPrefix", "/a/prefix")
+		InitConfig()
+
+		require.NotNil(t, hook.LastEntry())
+		assert.NotContains(t, hook.LastEntry().Message, "Unknown configuration keys found")
+	})
+
+	t.Run("testRecognizedEnvKey", func(t *testing.T) {
+		hook := setupFunc()
+		os.Setenv("PELICAN_ORIGIN_FEDERATIONPREFIX", "/a/prefix")
+		defer os.Unsetenv("PELICAN_ORIGIN_FEDERATIONPREFIX")
+		InitConfig()
+
+		require.NotNil(t, hook.LastEntry())
+		assert.NotContains(t, hook.LastEntry().Message, "Unknown configuration keys found")
+	})
+
+	t.Run("testBadViperKey", func(t *testing.T) {
+		hook := setupFunc()
+		viper.Set("Origin.Bad.Key", "/a/prefix")
+		InitConfig()
+
+		require.NotNil(t, hook.LastEntry())
+		assert.Equal(t, logrus.WarnLevel, hook.LastEntry().Level)
+		assert.Contains(t, hook.LastEntry().Message, "Unknown configuration keys found")
+		assert.Contains(t, hook.LastEntry().Message, "origin.bad.key")
+	})
+
+	t.Run("testBadEnvKey", func(t *testing.T) {
+		hook := setupFunc()
+		os.Setenv("PELICAN_ORIGIN_BAD_KEY", "/a/prefix")
+		defer os.Unsetenv("PELICAN_ORIGIN_BAD_KEY")
+		InitConfig()
+
+		require.NotNil(t, hook.LastEntry())
+		assert.Equal(t, logrus.WarnLevel, hook.LastEntry().Level)
+		assert.Contains(t, hook.LastEntry().Message, "Unknown configuration keys found")
+		assert.Contains(t, hook.LastEntry().Message, "origin.bad.key")
+	})
+}

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -650,6 +650,13 @@ type: bool
 default: true
 components: ["origin"]
 ---
+name: Origin.EnableMacaroons
+description: |+
+  A bool indicating whether the origin allows clients to authenticate using macaroons.
+type: bool
+default: false
+components: ["origin"]
+---
 name: Origin.SelfTest
 description: |+
   A bool indicating whether the origin should perform self health checks.
@@ -1952,6 +1959,13 @@ type: url
 default: none
 components: ["origin", "cache"]
 ---
+name: Xrootd.ManagerPort
+description: |+
+  The port at which the XRootD instance's Manager Host is available.
+type: int
+default: 1213
+components: ["origin", "cache"]
+---
 name: Xrootd.SummaryMonitoringHost
 description: |+
   A URL pointing toward the XRootD instance's Summary Monitoring Host.
@@ -1959,11 +1973,25 @@ type: url
 default: none
 components: ["origin", "cache"]
 ---
+name: Xrootd.SummaryMonitoringPort
+description: |+
+  The port at which the XRootD instance's Summary Monitoring Host is available.
+type: int
+default: 9931
+components: ["origin", "cache"]
+---
 name: Xrootd.DetailedMonitoringHost
 description: |+
   A URL pointing toward the XRootD instance's Detailed Monitoring Host.
 type: url
 default: none
+components: ["origin", "cache"]
+---
+name: Xrootd.DetailedMonitoringPort
+description: |+
+  The port at which the XRootD instance's Detailed Monitoring Host is available.
+type: int
+default: 9930
 components: ["origin", "cache"]
 ---
 name: Xrootd.LocalMonitoringHost

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -282,7 +282,10 @@ var (
 	Shoveler_PortHigher = IntParam{"Shoveler.PortHigher"}
 	Shoveler_PortLower = IntParam{"Shoveler.PortLower"}
 	Transport_MaxIdleConns = IntParam{"Transport.MaxIdleConns"}
+	Xrootd_DetailedMonitoringPort = IntParam{"Xrootd.DetailedMonitoringPort"}
+	Xrootd_ManagerPort = IntParam{"Xrootd.ManagerPort"}
 	Xrootd_Port = IntParam{"Xrootd.Port"}
+	Xrootd_SummaryMonitoringPort = IntParam{"Xrootd.SummaryMonitoringPort"}
 )
 
 var (
@@ -309,6 +312,7 @@ var (
 	Origin_EnableFallbackRead = BoolParam{"Origin.EnableFallbackRead"}
 	Origin_EnableIssuer = BoolParam{"Origin.EnableIssuer"}
 	Origin_EnableListings = BoolParam{"Origin.EnableListings"}
+	Origin_EnableMacaroons = BoolParam{"Origin.EnableMacaroons"}
 	Origin_EnableOIDC = BoolParam{"Origin.EnableOIDC"}
 	Origin_EnablePublicReads = BoolParam{"Origin.EnablePublicReads"}
 	Origin_EnableReads = BoolParam{"Origin.EnableReads"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -25,277 +25,281 @@ import (
 
 type Config struct {
 	Cache struct {
-		Concurrency int
-		DataLocation string
-		DataLocations []string
-		EnableLotman bool
-		EnableOIDC bool
-		EnableVoms bool
-		ExportLocation string
-		HighWaterMark string
-		LocalRoot string
-		LowWatermark string
-		MetaLocations []string
-		PermittedNamespaces []string
-		Port int
-		RunLocation string
-		SelfTest bool
-		SelfTestInterval time.Duration
-		SentinelLocation string
-		Url string
-		XRootDPrefix string
-	}
+		Concurrency int `mapstructure:"concurrency"`
+		DataLocation string `mapstructure:"datalocation"`
+		DataLocations []string `mapstructure:"datalocations"`
+		EnableLotman bool `mapstructure:"enablelotman"`
+		EnableOIDC bool `mapstructure:"enableoidc"`
+		EnableVoms bool `mapstructure:"enablevoms"`
+		ExportLocation string `mapstructure:"exportlocation"`
+		HighWaterMark string `mapstructure:"highwatermark"`
+		LocalRoot string `mapstructure:"localroot"`
+		LowWatermark string `mapstructure:"lowwatermark"`
+		MetaLocations []string `mapstructure:"metalocations"`
+		PermittedNamespaces []string `mapstructure:"permittednamespaces"`
+		Port int `mapstructure:"port"`
+		RunLocation string `mapstructure:"runlocation"`
+		SelfTest bool `mapstructure:"selftest"`
+		SelfTestInterval time.Duration `mapstructure:"selftestinterval"`
+		SentinelLocation string `mapstructure:"sentinellocation"`
+		Url string `mapstructure:"url"`
+		XRootDPrefix string `mapstructure:"xrootdprefix"`
+	} `mapstructure:"cache"`
 	Client struct {
-		DisableHttpProxy bool
-		DisableProxyFallback bool
-		MaximumDownloadSpeed int
-		MinimumDownloadSpeed int
-		SlowTransferRampupTime time.Duration
-		SlowTransferWindow time.Duration
-		StoppedTransferTimeout time.Duration
-		WorkerCount int
-	}
-	ConfigDir string
-	Debug bool
+		DisableHttpProxy bool `mapstructure:"disablehttpproxy"`
+		DisableProxyFallback bool `mapstructure:"disableproxyfallback"`
+		MaximumDownloadSpeed int `mapstructure:"maximumdownloadspeed"`
+		MinimumDownloadSpeed int `mapstructure:"minimumdownloadspeed"`
+		SlowTransferRampupTime time.Duration `mapstructure:"slowtransferrampuptime"`
+		SlowTransferWindow time.Duration `mapstructure:"slowtransferwindow"`
+		StoppedTransferTimeout time.Duration `mapstructure:"stoppedtransfertimeout"`
+		WorkerCount int `mapstructure:"workercount"`
+	} `mapstructure:"client"`
+	ConfigDir string `mapstructure:"configdir"`
+	Debug bool `mapstructure:"debug"`
 	Director struct {
-		AdvertisementTTL time.Duration
-		CacheResponseHostnames []string
-		CacheSortMethod string
-		DefaultResponse string
-		EnableBroker bool
-		EnableOIDC bool
-		FilteredServers []string
-		GeoIPLocation string
-		MaxMindKeyFile string
-		MaxStatResponse int
-		MinStatResponse int
-		OriginCacheHealthTestInterval time.Duration
-		OriginResponseHostnames []string
-		StatConcurrencyLimit int
-		StatTimeout time.Duration
-		SupportContactEmail string
-		SupportContactUrl string
-	}
-	DisableHttpProxy bool
-	DisableProxyFallback bool
+		AdvertisementTTL time.Duration `mapstructure:"advertisementttl"`
+		CacheResponseHostnames []string `mapstructure:"cacheresponsehostnames"`
+		CacheSortMethod string `mapstructure:"cachesortmethod"`
+		DefaultResponse string `mapstructure:"defaultresponse"`
+		EnableBroker bool `mapstructure:"enablebroker"`
+		EnableOIDC bool `mapstructure:"enableoidc"`
+		FilteredServers []string `mapstructure:"filteredservers"`
+		GeoIPLocation string `mapstructure:"geoiplocation"`
+		MaxMindKeyFile string `mapstructure:"maxmindkeyfile"`
+		MaxStatResponse int `mapstructure:"maxstatresponse"`
+		MinStatResponse int `mapstructure:"minstatresponse"`
+		OriginCacheHealthTestInterval time.Duration `mapstructure:"origincachehealthtestinterval"`
+		OriginResponseHostnames []string `mapstructure:"originresponsehostnames"`
+		StatConcurrencyLimit int `mapstructure:"statconcurrencylimit"`
+		StatTimeout time.Duration `mapstructure:"stattimeout"`
+		SupportContactEmail string `mapstructure:"supportcontactemail"`
+		SupportContactUrl string `mapstructure:"supportcontacturl"`
+	} `mapstructure:"director"`
+	DisableHttpProxy bool `mapstructure:"disablehttpproxy"`
+	DisableProxyFallback bool `mapstructure:"disableproxyfallback"`
 	Federation struct {
-		BrokerUrl string
-		DirectorUrl string
-		DiscoveryUrl string
-		JwkUrl string
-		RegistryUrl string
-		TopologyNamespaceUrl string
-		TopologyReloadInterval time.Duration
-		TopologyUrl string
-	}
-	GeoIPOverrides interface{}
+		BrokerUrl string `mapstructure:"brokerurl"`
+		DirectorUrl string `mapstructure:"directorurl"`
+		DiscoveryUrl string `mapstructure:"discoveryurl"`
+		JwkUrl string `mapstructure:"jwkurl"`
+		RegistryUrl string `mapstructure:"registryurl"`
+		TopologyNamespaceUrl string `mapstructure:"topologynamespaceurl"`
+		TopologyReloadInterval time.Duration `mapstructure:"topologyreloadinterval"`
+		TopologyUrl string `mapstructure:"topologyurl"`
+	} `mapstructure:"federation"`
+	GeoIPOverrides interface{} `mapstructure:"geoipoverrides"`
 	Issuer struct {
-		AuthenticationSource string
-		AuthorizationTemplates interface{}
-		GroupFile string
-		GroupRequirements []string
-		GroupSource string
-		IssuerClaimValue string
-		OIDCAuthenticationRequirements interface{}
-		OIDCAuthenticationUserClaim string
-		OIDCGroupClaim string
-		QDLLocation string
-		ScitokensServerLocation string
-		TomcatLocation string
-		UserStripDomain bool
-	}
-	IssuerKey string
+		AuthenticationSource string `mapstructure:"authenticationsource"`
+		AuthorizationTemplates interface{} `mapstructure:"authorizationtemplates"`
+		GroupFile string `mapstructure:"groupfile"`
+		GroupRequirements []string `mapstructure:"grouprequirements"`
+		GroupSource string `mapstructure:"groupsource"`
+		IssuerClaimValue string `mapstructure:"issuerclaimvalue"`
+		OIDCAuthenticationRequirements interface{} `mapstructure:"oidcauthenticationrequirements"`
+		OIDCAuthenticationUserClaim string `mapstructure:"oidcauthenticationuserclaim"`
+		OIDCGroupClaim string `mapstructure:"oidcgroupclaim"`
+		QDLLocation string `mapstructure:"qdllocation"`
+		ScitokensServerLocation string `mapstructure:"scitokensserverlocation"`
+		TomcatLocation string `mapstructure:"tomcatlocation"`
+		UserStripDomain bool `mapstructure:"userstripdomain"`
+	} `mapstructure:"issuer"`
+	IssuerKey string `mapstructure:"issuerkey"`
 	LocalCache struct {
-		DataLocation string
-		HighWaterMarkPercentage int
-		LowWaterMarkPercentage int
-		RunLocation string
-		Size string
-		Socket string
-	}
+		DataLocation string `mapstructure:"datalocation"`
+		HighWaterMarkPercentage int `mapstructure:"highwatermarkpercentage"`
+		LowWaterMarkPercentage int `mapstructure:"lowwatermarkpercentage"`
+		RunLocation string `mapstructure:"runlocation"`
+		Size string `mapstructure:"size"`
+		Socket string `mapstructure:"socket"`
+	} `mapstructure:"localcache"`
 	Logging struct {
 		Cache struct {
-			Http string
-			Ofs string
-			Pfc string
-			Pss string
-			Scitokens string
-			Xrd string
-			Xrootd string
-		}
-		DisableProgressBars bool
-		Level string
-		LogLocation string
+			Http string `mapstructure:"http"`
+			Ofs string `mapstructure:"ofs"`
+			Pfc string `mapstructure:"pfc"`
+			Pss string `mapstructure:"pss"`
+			Scitokens string `mapstructure:"scitokens"`
+			Xrd string `mapstructure:"xrd"`
+			Xrootd string `mapstructure:"xrootd"`
+		} `mapstructure:"cache"`
+		DisableProgressBars bool `mapstructure:"disableprogressbars"`
+		Level string `mapstructure:"level"`
+		LogLocation string `mapstructure:"loglocation"`
 		Origin struct {
-			Cms string
-			Http string
-			Ofs string
-			Oss string
-			Scitokens string
-			Xrd string
-			Xrootd string
-		}
-	}
+			Cms string `mapstructure:"cms"`
+			Http string `mapstructure:"http"`
+			Ofs string `mapstructure:"ofs"`
+			Oss string `mapstructure:"oss"`
+			Scitokens string `mapstructure:"scitokens"`
+			Xrd string `mapstructure:"xrd"`
+			Xrootd string `mapstructure:"xrootd"`
+		} `mapstructure:"origin"`
+	} `mapstructure:"logging"`
 	Lotman struct {
-		DbLocation string
-		EnableAPI bool
-		LibLocation string
-		Lots interface{}
-	}
-	MinimumDownloadSpeed int
+		DbLocation string `mapstructure:"dblocation"`
+		EnableAPI bool `mapstructure:"enableapi"`
+		LibLocation string `mapstructure:"liblocation"`
+		Lots interface{} `mapstructure:"lots"`
+	} `mapstructure:"lotman"`
+	MinimumDownloadSpeed int `mapstructure:"minimumdownloadspeed"`
 	Monitoring struct {
-		AggregatePrefixes []string
-		DataLocation string
-		MetricAuthorization bool
-		PortHigher int
-		PortLower int
-		PromQLAuthorization bool
-		TokenExpiresIn time.Duration
-		TokenRefreshInterval time.Duration
-	}
+		AggregatePrefixes []string `mapstructure:"aggregateprefixes"`
+		DataLocation string `mapstructure:"datalocation"`
+		MetricAuthorization bool `mapstructure:"metricauthorization"`
+		PortHigher int `mapstructure:"porthigher"`
+		PortLower int `mapstructure:"portlower"`
+		PromQLAuthorization bool `mapstructure:"promqlauthorization"`
+		TokenExpiresIn time.Duration `mapstructure:"tokenexpiresin"`
+		TokenRefreshInterval time.Duration `mapstructure:"tokenrefreshinterval"`
+	} `mapstructure:"monitoring"`
 	OIDC struct {
-		AuthorizationEndpoint string
-		ClientID string
-		ClientIDFile string
-		ClientRedirectHostname string
-		ClientSecretFile string
-		DeviceAuthEndpoint string
-		Issuer string
-		TokenEndpoint string
-		UserInfoEndpoint string
-	}
+		AuthorizationEndpoint string `mapstructure:"authorizationendpoint"`
+		ClientID string `mapstructure:"clientid"`
+		ClientIDFile string `mapstructure:"clientidfile"`
+		ClientRedirectHostname string `mapstructure:"clientredirecthostname"`
+		ClientSecretFile string `mapstructure:"clientsecretfile"`
+		DeviceAuthEndpoint string `mapstructure:"deviceauthendpoint"`
+		Issuer string `mapstructure:"issuer"`
+		TokenEndpoint string `mapstructure:"tokenendpoint"`
+		UserInfoEndpoint string `mapstructure:"userinfoendpoint"`
+	} `mapstructure:"oidc"`
 	Origin struct {
-		EnableBroker bool
-		EnableCmsd bool
-		EnableDirListing bool
-		EnableDirectReads bool
-		EnableFallbackRead bool
-		EnableIssuer bool
-		EnableListings bool
-		EnableOIDC bool
-		EnablePublicReads bool
-		EnableReads bool
-		EnableUI bool
-		EnableVoms bool
-		EnableWrite bool
-		EnableWrites bool
-		ExportVolume string
-		ExportVolumes []string
-		Exports interface{}
-		FederationPrefix string
-		HttpServiceUrl string
-		Mode string
-		Multiuser bool
-		NamespacePrefix string
-		Port int
-		RunLocation string
-		S3AccessKeyfile string
-		S3Bucket string
-		S3Region string
-		S3SecretKeyfile string
-		S3ServiceName string
-		S3ServiceUrl string
-		S3UrlStyle string
-		ScitokensDefaultUser string
-		ScitokensMapSubject bool
-		ScitokensNameMapFile string
-		ScitokensRestrictedPaths []string
-		ScitokensUsernameClaim string
-		SelfTest bool
-		SelfTestInterval time.Duration
-		StoragePrefix string
-		StorageType string
-		Url string
-		XRootDPrefix string
-		XRootServiceUrl string
-	}
+		EnableBroker bool `mapstructure:"enablebroker"`
+		EnableCmsd bool `mapstructure:"enablecmsd"`
+		EnableDirListing bool `mapstructure:"enabledirlisting"`
+		EnableDirectReads bool `mapstructure:"enabledirectreads"`
+		EnableFallbackRead bool `mapstructure:"enablefallbackread"`
+		EnableIssuer bool `mapstructure:"enableissuer"`
+		EnableListings bool `mapstructure:"enablelistings"`
+		EnableMacaroons bool `mapstructure:"enablemacaroons"`
+		EnableOIDC bool `mapstructure:"enableoidc"`
+		EnablePublicReads bool `mapstructure:"enablepublicreads"`
+		EnableReads bool `mapstructure:"enablereads"`
+		EnableUI bool `mapstructure:"enableui"`
+		EnableVoms bool `mapstructure:"enablevoms"`
+		EnableWrite bool `mapstructure:"enablewrite"`
+		EnableWrites bool `mapstructure:"enablewrites"`
+		ExportVolume string `mapstructure:"exportvolume"`
+		ExportVolumes []string `mapstructure:"exportvolumes"`
+		Exports interface{} `mapstructure:"exports"`
+		FederationPrefix string `mapstructure:"federationprefix"`
+		HttpServiceUrl string `mapstructure:"httpserviceurl"`
+		Mode string `mapstructure:"mode"`
+		Multiuser bool `mapstructure:"multiuser"`
+		NamespacePrefix string `mapstructure:"namespaceprefix"`
+		Port int `mapstructure:"port"`
+		RunLocation string `mapstructure:"runlocation"`
+		S3AccessKeyfile string `mapstructure:"s3accesskeyfile"`
+		S3Bucket string `mapstructure:"s3bucket"`
+		S3Region string `mapstructure:"s3region"`
+		S3SecretKeyfile string `mapstructure:"s3secretkeyfile"`
+		S3ServiceName string `mapstructure:"s3servicename"`
+		S3ServiceUrl string `mapstructure:"s3serviceurl"`
+		S3UrlStyle string `mapstructure:"s3urlstyle"`
+		ScitokensDefaultUser string `mapstructure:"scitokensdefaultuser"`
+		ScitokensMapSubject bool `mapstructure:"scitokensmapsubject"`
+		ScitokensNameMapFile string `mapstructure:"scitokensnamemapfile"`
+		ScitokensRestrictedPaths []string `mapstructure:"scitokensrestrictedpaths"`
+		ScitokensUsernameClaim string `mapstructure:"scitokensusernameclaim"`
+		SelfTest bool `mapstructure:"selftest"`
+		SelfTestInterval time.Duration `mapstructure:"selftestinterval"`
+		StoragePrefix string `mapstructure:"storageprefix"`
+		StorageType string `mapstructure:"storagetype"`
+		Url string `mapstructure:"url"`
+		XRootDPrefix string `mapstructure:"xrootdprefix"`
+		XRootServiceUrl string `mapstructure:"xrootserviceurl"`
+	} `mapstructure:"origin"`
 	Plugin struct {
-		Token string
-	}
+		Token string `mapstructure:"token"`
+	} `mapstructure:"plugin"`
 	Registry struct {
-		AdminUsers []string
-		CustomRegistrationFields interface{}
-		DbLocation string
-		Institutions interface{}
-		InstitutionsUrl string
-		InstitutionsUrlReloadMinutes time.Duration
-		RequireCacheApproval bool
-		RequireKeyChaining bool
-		RequireOriginApproval bool
-	}
+		AdminUsers []string `mapstructure:"adminusers"`
+		CustomRegistrationFields interface{} `mapstructure:"customregistrationfields"`
+		DbLocation string `mapstructure:"dblocation"`
+		Institutions interface{} `mapstructure:"institutions"`
+		InstitutionsUrl string `mapstructure:"institutionsurl"`
+		InstitutionsUrlReloadMinutes time.Duration `mapstructure:"institutionsurlreloadminutes"`
+		RequireCacheApproval bool `mapstructure:"requirecacheapproval"`
+		RequireKeyChaining bool `mapstructure:"requirekeychaining"`
+		RequireOriginApproval bool `mapstructure:"requireoriginapproval"`
+	} `mapstructure:"registry"`
 	Server struct {
-		EnableUI bool
-		ExternalWebUrl string
-		Hostname string
-		IssuerHostname string
-		IssuerJwks string
-		IssuerPort int
-		IssuerUrl string
-		Modules []string
-		RegistrationRetryInterval time.Duration
-		SessionSecretFile string
-		TLSCACertificateDirectory string
-		TLSCACertificateFile string
-		TLSCAKey string
-		TLSCertificate string
-		TLSKey string
-		UIActivationCodeFile string
-		UIAdminUsers []string
-		UILoginRateLimit int
-		UIPasswordFile string
-		WebConfigFile string
-		WebHost string
-		WebPort int
-	}
+		EnableUI bool `mapstructure:"enableui"`
+		ExternalWebUrl string `mapstructure:"externalweburl"`
+		Hostname string `mapstructure:"hostname"`
+		IssuerHostname string `mapstructure:"issuerhostname"`
+		IssuerJwks string `mapstructure:"issuerjwks"`
+		IssuerPort int `mapstructure:"issuerport"`
+		IssuerUrl string `mapstructure:"issuerurl"`
+		Modules []string `mapstructure:"modules"`
+		RegistrationRetryInterval time.Duration `mapstructure:"registrationretryinterval"`
+		SessionSecretFile string `mapstructure:"sessionsecretfile"`
+		TLSCACertificateDirectory string `mapstructure:"tlscacertificatedirectory"`
+		TLSCACertificateFile string `mapstructure:"tlscacertificatefile"`
+		TLSCAKey string `mapstructure:"tlscakey"`
+		TLSCertificate string `mapstructure:"tlscertificate"`
+		TLSKey string `mapstructure:"tlskey"`
+		UIActivationCodeFile string `mapstructure:"uiactivationcodefile"`
+		UIAdminUsers []string `mapstructure:"uiadminusers"`
+		UILoginRateLimit int `mapstructure:"uiloginratelimit"`
+		UIPasswordFile string `mapstructure:"uipasswordfile"`
+		WebConfigFile string `mapstructure:"webconfigfile"`
+		WebHost string `mapstructure:"webhost"`
+		WebPort int `mapstructure:"webport"`
+	} `mapstructure:"server"`
 	Shoveler struct {
-		AMQPExchange string
-		AMQPTokenLocation string
-		Enable bool
-		IPMapping interface{}
-		MessageQueueProtocol string
-		OutputDestinations []string
-		PortHigher int
-		PortLower int
-		QueueDirectory string
-		StompCert string
-		StompCertKey string
-		StompPassword string
-		StompUsername string
-		Topic string
-		URL string
-		VerifyHeader bool
-	}
+		AMQPExchange string `mapstructure:"amqpexchange"`
+		AMQPTokenLocation string `mapstructure:"amqptokenlocation"`
+		Enable bool `mapstructure:"enable"`
+		IPMapping interface{} `mapstructure:"ipmapping"`
+		MessageQueueProtocol string `mapstructure:"messagequeueprotocol"`
+		OutputDestinations []string `mapstructure:"outputdestinations"`
+		PortHigher int `mapstructure:"porthigher"`
+		PortLower int `mapstructure:"portlower"`
+		QueueDirectory string `mapstructure:"queuedirectory"`
+		StompCert string `mapstructure:"stompcert"`
+		StompCertKey string `mapstructure:"stompcertkey"`
+		StompPassword string `mapstructure:"stomppassword"`
+		StompUsername string `mapstructure:"stompusername"`
+		Topic string `mapstructure:"topic"`
+		URL string `mapstructure:"url"`
+		VerifyHeader bool `mapstructure:"verifyheader"`
+	} `mapstructure:"shoveler"`
 	StagePlugin struct {
-		Hook bool
-		MountPrefix string
-		OriginPrefix string
-		ShadowOriginPrefix string
-	}
-	TLSSkipVerify bool
+		Hook bool `mapstructure:"hook"`
+		MountPrefix string `mapstructure:"mountprefix"`
+		OriginPrefix string `mapstructure:"originprefix"`
+		ShadowOriginPrefix string `mapstructure:"shadoworiginprefix"`
+	} `mapstructure:"stageplugin"`
+	TLSSkipVerify bool `mapstructure:"tlsskipverify"`
 	Transport struct {
-		DialerKeepAlive time.Duration
-		DialerTimeout time.Duration
-		ExpectContinueTimeout time.Duration
-		IdleConnTimeout time.Duration
-		MaxIdleConns int
-		ResponseHeaderTimeout time.Duration
-		TLSHandshakeTimeout time.Duration
-	}
+		DialerKeepAlive time.Duration `mapstructure:"dialerkeepalive"`
+		DialerTimeout time.Duration `mapstructure:"dialertimeout"`
+		ExpectContinueTimeout time.Duration `mapstructure:"expectcontinuetimeout"`
+		IdleConnTimeout time.Duration `mapstructure:"idleconntimeout"`
+		MaxIdleConns int `mapstructure:"maxidleconns"`
+		ResponseHeaderTimeout time.Duration `mapstructure:"responseheadertimeout"`
+		TLSHandshakeTimeout time.Duration `mapstructure:"tlshandshaketimeout"`
+	} `mapstructure:"transport"`
 	Xrootd struct {
-		Authfile string
-		ConfigFile string
-		DetailedMonitoringHost string
-		LocalMonitoringHost string
-		MacaroonsKeyFile string
-		ManagerHost string
-		Mount string
-		Port int
-		RobotsTxtFile string
-		RunLocation string
-		ScitokensConfig string
-		Sitename string
-		SummaryMonitoringHost string
-	}
+		Authfile string `mapstructure:"authfile"`
+		ConfigFile string `mapstructure:"configfile"`
+		DetailedMonitoringHost string `mapstructure:"detailedmonitoringhost"`
+		DetailedMonitoringPort int `mapstructure:"detailedmonitoringport"`
+		LocalMonitoringHost string `mapstructure:"localmonitoringhost"`
+		MacaroonsKeyFile string `mapstructure:"macaroonskeyfile"`
+		ManagerHost string `mapstructure:"managerhost"`
+		ManagerPort int `mapstructure:"managerport"`
+		Mount string `mapstructure:"mount"`
+		Port int `mapstructure:"port"`
+		RobotsTxtFile string `mapstructure:"robotstxtfile"`
+		RunLocation string `mapstructure:"runlocation"`
+		ScitokensConfig string `mapstructure:"scitokensconfig"`
+		Sitename string `mapstructure:"sitename"`
+		SummaryMonitoringHost string `mapstructure:"summarymonitoringhost"`
+		SummaryMonitoringPort int `mapstructure:"summarymonitoringport"`
+	} `mapstructure:"xrootd"`
 }
 
 
@@ -448,6 +452,7 @@ type configWithType struct {
 		EnableFallbackRead struct { Type string; Value bool }
 		EnableIssuer struct { Type string; Value bool }
 		EnableListings struct { Type string; Value bool }
+		EnableMacaroons struct { Type string; Value bool }
 		EnableOIDC struct { Type string; Value bool }
 		EnablePublicReads struct { Type string; Value bool }
 		EnableReads struct { Type string; Value bool }
@@ -561,9 +566,11 @@ type configWithType struct {
 		Authfile struct { Type string; Value string }
 		ConfigFile struct { Type string; Value string }
 		DetailedMonitoringHost struct { Type string; Value string }
+		DetailedMonitoringPort struct { Type string; Value int }
 		LocalMonitoringHost struct { Type string; Value string }
 		MacaroonsKeyFile struct { Type string; Value string }
 		ManagerHost struct { Type string; Value string }
+		ManagerPort struct { Type string; Value int }
 		Mount struct { Type string; Value string }
 		Port struct { Type string; Value int }
 		RobotsTxtFile struct { Type string; Value string }
@@ -571,5 +578,6 @@ type configWithType struct {
 		ScitokensConfig struct { Type string; Value string }
 		Sitename struct { Type string; Value string }
 		SummaryMonitoringHost struct { Type string; Value string }
+		SummaryMonitoringPort struct { Type string; Value int }
 	}
 }


### PR DESCRIPTION
It turns out Pelicans are picky birds, and they only like eating config options they recognize. Instead of feeding our beloved bird things it doesn't like and can't eat, this PR warns users when config options that are passed via config files or env vars that are unrecognized. Ewww!

This is accomplished by adding a mapstructure value to entries in our generated param.Config struct consisting of each field's lowercased name, and then using that to match against viper keys read in from config. When a viper key exists and can't be mapped to a field name in param.Config, we add the key to a list that is passed to the user as a warning.

To test, try passing some garbage values in your config file, or passing something like `PELICAN_BAD_KEY` through the environment.

Closes #998 