### PR TITLE
Increase `WaitUntilWorking` transfer timeout and adjust error message

### DIFF
--- a/server_utils/server_utils.go
+++ b/server_utils/server_utils.go
@@ -39,7 +39,7 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 )
 
-// Wait until given `reqUrl` returns a HTTP 200.
+// Wait until given `reqUrl` returns the expected status.
 // Logging messages emitted will refer to `server` (e.g., origin, cache, director)
 // Pass true to statusMismatch to allow a mismatch of expected status code and what's returned not fail immediately
 func WaitUntilWorking(ctx context.Context, method, reqUrl, server string, expectedStatus int, statusMismatch bool) error {
@@ -61,7 +61,7 @@ func WaitUntilWorking(ctx context.Context, method, reqUrl, server string, expect
 			}
 			httpClient := http.Client{
 				Transport: config.GetTransport(),
-				Timeout:   50 * time.Millisecond,
+				Timeout:   1 * time.Second,
 				CheckRedirect: func(req *http.Request, via []*http.Request) error {
 					return http.ErrUseLastResponse
 				},
@@ -126,7 +126,7 @@ func WaitUntilWorking(ctx context.Context, method, reqUrl, server string, expect
 	if statusError != nil {
 		return errors.Wrapf(statusError, "url %s didn't respond with the expected status code %d within 10s", reqUrl, expectedStatus)
 	} else {
-		return errors.Errorf("Server %s at %s did not startup after 10s of waiting", server, reqUrl)
+		return errors.Errorf("The %s server at %s either did not startup or did not respond quickly enough after 10s of waiting", server, reqUrl)
 	}
 }
 

--- a/server_utils/server_utils.go
+++ b/server_utils/server_utils.go
@@ -47,6 +47,7 @@ func WaitUntilWorking(ctx context.Context, method, reqUrl, server string, expect
 	ctx, cancel := context.WithDeadline(ctx, expiry)
 	defer cancel()
 	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
 	success := false
 	logged := false
 	var statusError error

--- a/server_utils/server_utils_test.go
+++ b/server_utils/server_utils_test.go
@@ -116,14 +116,15 @@ func TestWaitUntilWorking(t *testing.T) {
 	})
 
 	t.Run("server-timeout", func(t *testing.T) {
-		// cancel wait until working after 400ms so that we don't wait for 10s before it returns
+		// cancel wait until working after 1500ms so that we don't wait for 10s before it returns
 		earlyCancelCtx, earlyCancel := context.WithCancel(ctx)
 		go func() {
-			<-time.After(400 * time.Millisecond)
+			<-time.After(1500 * time.Millisecond)
 			earlyCancel()
 		}()
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			<-time.After(200 * time.Millisecond)
+			// WaitUntilWorking as a 1s timeout, so we make sure to wait longer than that
+			<-time.After(1100 * time.Millisecond)
 			w.WriteHeader(http.StatusOK) // 200
 		}))
 		defer server.Close()


### PR DESCRIPTION
When `WaitUtilWorking` was pointed at the OSDF Director (located in Madison) from a distant server, it couldn't get a response in the previously-configured 50ms. After peeking at this function, it doesn't seem like there's a good reason not to have a more permissive timeout.

I also adjusted the error message that was output from the previous circumstance. Setting up a distant cache resulted in saying "Server director <url> did not startup after 10s of waiting," which makes it seem like the cache is trying to start up a director.

Closes #1324 