### PR TITLE
Fix plugin bug for incorrect start time

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -141,12 +141,13 @@ type (
 	// Represents the results of a single object transfer,
 	// potentially across multiple attempts / retries.
 	TransferResults struct {
-		jobId            uuid.UUID // The job ID this result corresponds to
-		job              *TransferJob
-		Error            error
-		TransferredBytes int64
-		Scheme           string
-		Attempts         []TransferResult
+		jobId             uuid.UUID // The job ID this result corresponds to
+		job               *TransferJob
+		Error             error
+		TransferredBytes  int64
+		TransferStartTime time.Time
+		Scheme            string
+		Attempts          []TransferResult
 	}
 
 	TransferResult struct {
@@ -1641,6 +1642,7 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 	transferResults = newTransferResults(transfer.job)
 	xferErrors := NewTransferErrors()
 	success := false
+	var transferStartTime time.Time
 	for idx, transferEndpoint := range attempts { // For each transfer attempt (usually 3), try to download via HTTP
 		var attempt TransferResult
 		attempt.Number = idx // Start with 0
@@ -1650,7 +1652,7 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 		transferEndpointUrl := *transferEndpoint.Url
 		transferEndpointUrl.Path = transfer.remoteURL.Path
 		transferEndpoint.Url = &transferEndpointUrl
-		transferStartTime := time.Now()
+		transferStartTime = time.Now()
 		attemptDownloaded, timeToFirstByte, serverVersion, err := downloadHTTP(
 			transfer.ctx, transfer.engine, transfer.callback, transferEndpoint, transfer.localPath, size, transfer.token, transfer.project,
 		)
@@ -1698,6 +1700,7 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 			break
 		}
 	}
+	transferResults.TransferStartTime = transferStartTime
 	transferResults.TransferredBytes = downloaded
 	if !success {
 		transferResults.Error = xferErrors

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -487,7 +487,6 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 				return
 			}
 			log.Debugln("Got result from transfer client")
-			startTime := time.Now().Unix()
 			resultAd := classads.NewClassAd()
 			// Set our DeveloperData:
 			developerData := make(map[string]interface{})
@@ -507,7 +506,7 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 
 			resultAd.Set("DeveloperData", developerData)
 
-			resultAd.Set("TransferStartTime", startTime)
+			resultAd.Set("TransferStartTime", result.TransferStartTime.Unix())
 			resultAd.Set("TransferEndTime", time.Now().Unix())
 			hostname, _ := os.Hostname()
 			resultAd.Set("TransferLocalMachineName", hostname)

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -24,11 +24,13 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"os/exec"
@@ -36,6 +38,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -52,6 +55,11 @@ import (
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
+)
+
+var (
+	//go:embed resources/test-https-origin.yml
+	httpsOriginConfig string
 )
 
 // TestReadMultiTransfer test if we can read multiple transfers from stdin
@@ -435,6 +443,93 @@ func TestPluginDirectRead(t *testing.T) {
 				require.True(t, ok)
 				assert.Equal(t, param.Origin_Url.GetString(), "https://"+endpoint)
 			}
+		}
+	}
+}
+
+// We ran into a bug where the start time for the transfer was not recorded correctly and was almost always the same as the end time
+// (since they were set at similar sections of code). This test ensures that they are different and that the start time is before the end time.
+func TestPluginCorrectStartAndEndTime(t *testing.T) {
+	viper.Reset()
+	viper.Set("ConfigDir", t.TempDir())
+	server_utils.ResetOriginExports()
+	defer viper.Reset()
+	defer server_utils.ResetOriginExports()
+	err := config.InitClient()
+	require.NoError(t, err)
+
+	// Set up our http backend so that we can sleep during transfer
+	body := "Hello, World!"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "HEAD" && r.URL.Path == "/test2/hello_world" {
+			w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+			w.WriteHeader(http.StatusOK)
+			return
+		} else if r.Method == "GET" && r.URL.Path == "/test2/hello_world" {
+			w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+			w.WriteHeader(http.StatusPartialContent)
+			time.Sleep(1 * time.Second)
+			_, err := w.Write([]byte(body))
+			require.NoError(t, err)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	viper.Set("Origin.HttpServiceUrl", srv.URL+"/test2")
+
+	config.InitConfig()
+	tmpPath := t.TempDir()
+
+	fed := fed_test_utils.NewFedTest(t, httpsOriginConfig)
+	host := param.Server_Hostname.GetString() + ":" + strconv.Itoa(param.Server_WebPort.GetInt())
+
+	downloadUrl := url.URL{
+		Scheme: "pelican",
+		Host:   host,
+		Path:   "/test/hello_world",
+	}
+
+	workChan := make(chan PluginTransfer, 2)
+	workChan <- PluginTransfer{url: &downloadUrl, localFile: tmpPath}
+	close(workChan)
+
+	results := make(chan *classads.ClassAd, 5)
+	fed.Egrp.Go(func() error {
+		return runPluginWorker(fed.Ctx, false, workChan, results)
+	})
+
+	done := false
+	for !done {
+		select {
+		case <-fed.Ctx.Done():
+			break
+		case resultAd, ok := <-results:
+			if !ok {
+				done = true
+				break
+			}
+			// Process results as soon as we get them
+			transferSuccess, err := resultAd.Get("TransferSuccess")
+			assert.NoError(t, err)
+			boolVal, ok := transferSuccess.(bool)
+			require.True(t, ok)
+			assert.True(t, boolVal)
+
+			// Assert that our start time is different from end time (and less than the end time)
+			startTime, err := resultAd.Get("TransferStartTime")
+			assert.NoError(t, err)
+			startTimeVal, ok := startTime.(int64)
+			require.True(t, ok)
+			assert.True(t, startTimeVal > 0)
+
+			endTime, err := resultAd.Get("TransferEndTime")
+			assert.NoError(t, err)
+			endTimeVal, ok := endTime.(int64)
+			require.True(t, ok)
+			assert.True(t, endTimeVal > 0)
+
+			require.True(t, startTimeVal < endTimeVal)
 		}
 	}
 }

--- a/cmd/resources/test-https-origin.yml
+++ b/cmd/resources/test-https-origin.yml
@@ -1,0 +1,7 @@
+Logging:
+  Cache:
+    Scitokens: debug
+Origin:
+  StorageType: https
+  FederationPrefix: /test
+  EnablePublicReads: true


### PR DESCRIPTION
The plugin was reporting the start time of the transfer in the wrong place. Originally, it was recorded right when we get the results for the transfer (which is wrong). Now, we record the start time in the TransferResults object so each transfer will have its own start time and it will be properly recording in the plugin output ad.