### PR TITLE
Add simple mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+Emma Turetsky <turetske@gmail.com> <turetske@gmail.com>
+Brian Bockelman <bbockelman@morgridge.org> <bbockelman@morgridge.org>
+Brian Bockelman <bbockelman@morgridge.org> <bbockelm@cse.unl.edu>


### PR DESCRIPTION
`git shortlog -se` provides interesting statistics about the repo.

Unfortunately, it seems my and Emma's git configuration differs from host to host and it doesn't aggregate the contributions correctly. The `.mailmap` file instructs `git` to correctly merge these entries when calculating authorship.