### PR TITLE
Fixed `object get` directory checking for multiple sources

### DIFF
--- a/cmd/object_get.go
+++ b/cmd/object_get.go
@@ -106,7 +106,10 @@ func getMain(cmd *cobra.Command, args []string) {
 	}
 
 	if len(source) > 1 {
-		if destStat, err := os.Stat(dest); err != nil && destStat.IsDir() {
+		if destStat, err := os.Stat(dest); err != nil {
+			log.Errorln("Destination does not exist")
+			os.Exit(1)
+		} else if !destStat.IsDir() {
 			log.Errorln("Destination is not a directory")
 			os.Exit(1)
 		}


### PR DESCRIPTION
Object get had incomplete error checking for whether the destination was a directory when copying multiple sources. Found from #1337 