### PR TITLE
Fix error msg, timeout for metadata

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -532,6 +532,11 @@ func (te *TransferEngine) newPelicanURL(remoteUrl *url.URL) (pelicanURL pelicanU
 		if config.GetPreferredPrefix() == config.OsdfPrefix {
 			log.Debugln("In OSDF mode with osdf:// url; populating metadata with OSDF defaults")
 			fedInfo, err := config.GetFederation(te.ctx)
+			var metadataTimeoutErr *config.MetadataErr
+			// If we timed out, we should just return the timeout error (and the user can typically just try again)
+			if errors.As(err, &metadataTimeoutErr) {
+				return pelicanUrl{}, err
+			}
 			if fedInfo.DirectorEndpoint == "" {
 				if err != nil {
 					return pelicanUrl{}, errors.Wrap(err, "no OSDF metadata available")

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -565,7 +565,8 @@ func failTransfer(remoteUrl string, localFile string, results chan<- *classads.C
 		resultAd.Set("TransferRetryable", false)
 	}
 	resultAd.Set("TransferSuccess", false)
-	resultAd.Set("TransferError", err.Error())
+	errMsg := writeTransferErrorMessage(err.Error(), remoteUrl)
+	resultAd.Set("TransferError", errMsg)
 
 	results <- resultAd
 }

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -96,7 +96,7 @@ func stashPluginMain(args []string) {
 
 			// Set as failure and add errors
 			resultAd.Set("TransferSuccess", false)
-			errMsg := writeTransferErrorMessage(ret+";"+strings.ReplaceAll(string(debug.Stack()), "\n", ";"), "", false)
+			errMsg := writeTransferErrorMessage(ret+";"+strings.ReplaceAll(string(debug.Stack()), "\n", ";"), "")
 			resultAd.Set("TransferError", errMsg)
 			resultAds = append(resultAds, resultAd)
 
@@ -181,7 +181,7 @@ func stashPluginMain(args []string) {
 
 		// Set as failure and add errors
 		resultAd.Set("TransferSuccess", false)
-		errMsg := writeTransferErrorMessage(configErr.Error(), "", upload)
+		errMsg := writeTransferErrorMessage(configErr.Error(), "")
 		resultAd.Set("TransferError", errMsg)
 		if client.ShouldRetry(configErr) {
 			resultAd.Set("TransferRetryable", true)
@@ -532,7 +532,7 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 				if errors.As(result.Error, &te) {
 					errMsgInternal = te.UserError()
 				}
-				errMsg := writeTransferErrorMessage(errMsgInternal, transfer.url.String(), upload)
+				errMsg := writeTransferErrorMessage(errMsgInternal, transfer.url.String())
 				resultAd.Set("TransferError", errMsg)
 				resultAd.Set("TransferFileBytes", 0)
 				resultAd.Set("TransferTotalBytes", 0)
@@ -723,7 +723,7 @@ func readMultiTransfers(stdin bufio.Reader) (transfers []PluginTransfer, err err
 }
 
 // This function wraps the transfer error message into a more readable and user-friendly format.
-func writeTransferErrorMessage(currentError string, transferUrl string, upload bool) (errMsg string) {
+func writeTransferErrorMessage(currentError string, transferUrl string) (errMsg string) {
 
 	errMsg = "Pelican Client Error: "
 

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -481,7 +481,7 @@ func TestFailTransfer(t *testing.T) {
 		transferError, _ := result.Get("TransferError")
 		transferErrorStr, ok := transferError.(string)
 		require.True(t, ok)
-		assert.Equal(t, "test error", transferErrorStr)
+		assert.Contains(t, transferErrorStr, "Pelican Client Error: test error")
 	})
 
 	// Test when we call failTransfer with a download
@@ -524,7 +524,7 @@ func TestFailTransfer(t *testing.T) {
 		transferError, _ := result.Get("TransferError")
 		transferErrorStr, ok := transferError.(string)
 		require.True(t, ok)
-		assert.Equal(t, "test error", transferErrorStr)
+		assert.Contains(t, transferErrorStr, "Pelican Client Error: test error")
 	})
 
 	// Test when we call failTransfer with a retryable error
@@ -567,7 +567,7 @@ func TestFailTransfer(t *testing.T) {
 		transferError, _ := result.Get("TransferError")
 		transferErrorStr, ok := transferError.(string)
 		require.True(t, ok)
-		assert.Equal(t, "cancelled transfer, too slow.  Detected speed: 0 B/s, total transferred: 0 B, total transfer time: 0s", transferErrorStr)
+		assert.Contains(t, transferErrorStr, "Pelican Client Error: cancelled transfer, too slow.  Detected speed: 0 B/s, total transferred: 0 B, total transfer time: 0s")
 	})
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -488,10 +488,7 @@ func DiscoverUrlFederation(ctx context.Context, federationDiscoveryUrl string) (
 	if err != nil {
 		var netErr net.Error
 		if errors.As(err, &netErr) && netErr.Timeout() {
-			// Note: we replace the error with a MetadataTimeoutErr because the error we get from http is pretty redundant and contains
-			// no more useful information however, we will put it in trace logging so no info is completely lost from the message
-			log.Traceln(err)
-			err = NewMetadataError(nil, "timeout when discovering federation metadata from url "+federationUrl.String()+", exceeded "+httpClient.Timeout.String())
+			err = MetadataTimeoutErr.Wrap(err)
 			return
 		} else {
 			err = NewMetadataError(err, "Error occurred when querying for metadata")


### PR DESCRIPTION
Made changes to the error message printed for metadata timeouts. For the plugin the message was very verbose and contained some information that is not very useful (especially towards users). This reformats the message to contain just information that there was a timeout and how long it took to timeout (10s). Also tweaked a function in plugin.go to get rid of a non-used variable.

I did not think this needs testing since it is just changes to an error message that is changing relatively often

Old error message:
`14719161.10317 lsaleh          5/21 11:42 Transfer input files failure at execution point slot1_116@GP-ARGO-semo-backfill.12f972dda5e8 using protocol osdf. Details: Error from slot1_116@GP-ARGO-semo-backfill.12f972dda5e8: Failed to transfer files: FILETRANSFER:1:non-zero exit (11) from /pilot/osgvo-pilot-zdibnM/stash_plugin. |Error: error generating metadata for specified url: no OSDF metadata available: invalid federation value (osg-htc.org): Timeout when querying metadata: Get "https://osg-htc.org/.well-known/pelican-configuration": context deadline exceeded (Client.Timeout exceeded while awaiting headers) ( URL file = osdf:///ospool/ap21/data/lsaleh/lsaleh_gate_9.2.1.sif )|`

New error message:
`Transfer input files failure at execution point slot1_1@32d76da37136 using protocol pelican. Details: Error from slot1_1@32d76da37136: Failed to transfer files: FILETRANSFER:1:non-zero exit (11) from stash_plugin. |Error: Pelican Client Error: timeout when discovering federation metadata from url: Get "https://osg-htc.org/.well-known/pelican-configuration": context deadline exceeded (Client.Timeout exceeded while awaiting headers) (Version: 7.8.1-next; Site: test) ( URL file = pelican://osg-htc.org/test/foo.txt )`