### PR TITLE
Bug fix for '+' in NEAREST_CACHE

### DIFF
--- a/local_cache/cache_test.go
+++ b/local_cache/cache_test.go
@@ -204,6 +204,11 @@ func TestClient(t *testing.T) {
 		Path:   param.LocalCache_Socket.GetString(),
 	}
 
+	invalidCacheUrl := &url.URL{
+		Scheme: "unix",
+		Path:   "/this/path/does/not/exist/abc1234/foo/bar/baz",
+	}
+
 	t.Run("correct-auth", func(t *testing.T) {
 		tr, err := client.DoGet(ctx, "pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt",
 			filepath.Join(tmpDir, "hello_world.txt"), false, client.WithToken(ft.Token), client.WithCaches(cacheUrl), client.WithAcquireToken(false))
@@ -215,7 +220,11 @@ func TestClient(t *testing.T) {
 		byteBuff, err := os.ReadFile(filepath.Join(tmpDir, "hello_world.txt"))
 		assert.NoError(t, err)
 		assert.Equal(t, "Hello, World!", string(byteBuff))
+
+		// Assert our endpoint is the local cache (we should only have 1 transferResult and 1 attempt since only 1 cache listed)
+		assert.Equal(t, tr[0].Attempts[0].Endpoint, cacheUrl.Host)
 	})
+
 	t.Run("incorrect-auth", func(t *testing.T) {
 		_, err := client.DoGet(ctx, "pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt",
 			filepath.Join(tmpDir, "hello_world.txt"), false, client.WithToken("badtoken"), client.WithCaches(cacheUrl), client.WithAcquireToken(false))
@@ -228,7 +237,7 @@ func TestClient(t *testing.T) {
 	})
 
 	// Test the local cache works with the client when multiple are specified
-	t.Run("mutli-caches", func(t *testing.T) {
+	t.Run("multi-caches", func(t *testing.T) {
 		cacheList := []*url.URL{cacheUrl, cacheUrl2}
 		tr, err := client.DoGet(ctx, "pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt",
 			filepath.Join(tmpDir, "hello_world.txt"), false, client.WithToken(ft.Token), client.WithCaches(cacheList...), client.WithAcquireToken(false))
@@ -240,6 +249,63 @@ func TestClient(t *testing.T) {
 		byteBuff, err := os.ReadFile(filepath.Join(tmpDir, "hello_world.txt"))
 		assert.NoError(t, err)
 		assert.Equal(t, "Hello, World!", string(byteBuff))
+
+		// Assert our endpoint is the local cache (we should only have 1 transferResult and 1 attempt since only 1 cache listed)
+		assert.Equal(t, tr[0].Attempts[0].Endpoint, cacheUrl.Host)
+	})
+
+	// Test the local cache works with '+' specified (append normal list of caches as well) and that we match with the local cache
+	t.Run("append-caches-hit-local-cache", func(t *testing.T) {
+		plusCache := &url.URL{Path: "+"}
+		cacheList := []*url.URL{cacheUrl, plusCache}
+		tr, err := client.DoGet(ctx, "pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt",
+			filepath.Join(tmpDir, "hello_world.txt"), false, client.WithToken(ft.Token), client.WithCaches(cacheList...), client.WithAcquireToken(false))
+		assert.NoError(t, err)
+		require.Equal(t, 1, len(tr))
+		assert.Equal(t, int64(13), tr[0].TransferredBytes)
+		assert.NoError(t, tr[0].Error)
+
+		byteBuff, err := os.ReadFile(filepath.Join(tmpDir, "hello_world.txt"))
+		assert.NoError(t, err)
+		assert.Equal(t, "Hello, World!", string(byteBuff))
+
+		// Assert our endpoint is the local cache
+		assert.Equal(t, tr[0].Attempts[0].Endpoint, cacheUrl.Host)
+	})
+
+	// Test the local cache works with '+' specified (append normal list of caches as well) and that we match with our fed cache when local cache fails
+	t.Run("append-caches-hit-appended-cache", func(t *testing.T) {
+		plusCache := &url.URL{Path: "+"}
+		cacheList := []*url.URL{invalidCacheUrl, plusCache}
+		tr, err := client.DoGet(ctx, "pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt",
+			filepath.Join(tmpDir, "hello_world.txt"), false, client.WithToken(ft.Token), client.WithCaches(cacheList...), client.WithAcquireToken(false))
+		assert.NoError(t, err)
+		require.Equal(t, 1, len(tr))
+		assert.Equal(t, int64(13), tr[0].TransferredBytes)
+		assert.NoError(t, tr[0].Error)
+
+		// Check that we still successfully downloaded the file
+		byteBuff, err := os.ReadFile(filepath.Join(tmpDir, "hello_world.txt"))
+		assert.NoError(t, err)
+		assert.Equal(t, "Hello, World!", string(byteBuff))
+
+		// Check that the file was written to the fed cache by checking our endpoint
+		hitAppendedCache := false
+		cacheEndpointUrl, err := url.Parse(param.Cache_Url.GetString())
+		require.NoError(t, err)
+		cacheEndpoint := cacheEndpointUrl.Host
+
+		// We will have multiple attempts since the first attempt towards local cache will fail
+		for _, attempt := range tr[0].Attempts {
+			// If the endpoint is our faulty cache, ensure we have an error
+			if attempt.Endpoint == invalidCacheUrl.Host {
+				assert.NotNil(t, attempt.Error)
+			} else if attempt.Endpoint == cacheEndpoint {
+				hitAppendedCache = true
+				assert.Nil(t, attempt.Error)
+			}
+		}
+		assert.True(t, hitAppendedCache)
 	})
 
 	t.Run("file-not-found", func(t *testing.T) {


### PR DESCRIPTION
There was a bug when having a '+' character in the NEAREST_CACHE list. The cache list would be populated correctly with the local cache as the first item and the 'normal' cache list appended after it. However, when calling sortAttempts() we would try to do a HEAD request against the local cache (to sort our fastest caches first) but that would fail due to an unrecognized scheme, causing the local cache to go to the end of the list of attempts to try. This fix now looks at the scheme and if it is a `unix://` scheme we skip the HEAD request. This also adds more tests to ensure this does not happen.