### PR TITLE
Build deb pelican-server package and make sure it pulls in its required dependencies

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -221,19 +221,12 @@ nfpms:
     license: ASL 2.0
     meta: true
     formats:
-      # XXX Deb has some different conventions; planned for a later release
-      # - deb
+      - deb
       - rpm
     release: 1
     section: default
     priority: extra
     # dependencies are per-package format
-    provides:
-      ## {{ .Version }} substitutions do not work in this list
-      - "pelican-origin = 7"
-      - "pelican-cache = 7"
-      - "pelican-registry = 7"
-      - "pelican-director = 7"
     contents:
       - src: "systemd/pelican-cache.service"
         dst: "/usr/lib/systemd/system/pelican-cache.service"
@@ -267,9 +260,26 @@ nfpms:
 
     overrides:
       rpm:
+        provides:
+          ## {{ .Version }} substitutions do not work in this list
+          - "pelican-origin = 7"
+          - "pelican-cache = 7"
+          - "pelican-registry = 7"
+          - "pelican-director = 7"
         dependencies:
           - "pelican >= 7.4.0"
           - "xrootd-server >= 1:5.6.3"
           - "xrootd-scitokens"
           - "xrootd-voms"
+      deb:
+        provides:
+          - "pelican-origin (= 7)"
+          - "pelican-cache (= 7)"
+          - "pelican-registry (= 7)"
+          - "pelican-director (= 7)"
+        dependencies:
+          - "pelican (>= 7.4.0)"
+          - "xrootd-server (>= 5.6.3)"
+          - "xrootd-scitokens-plugins"
+          - "xrootd-voms-plugins"
   # end package pelican-server


### PR DESCRIPTION
Note that it is not installable on debian:latest or ubuntu:22.04 because they do not have the required version of xrootd.  It does install on ubuntu:24.04 (ubuntu:latest).

Closes #1272 