### PR TITLE
Various GoReleaser artifact tweaks

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -107,6 +107,12 @@ nfpms:
             file_info:
               mode: 0644
             type: doc
+          - dst: "/etc/pelican"
+            type: dir
+            file_info:
+              mode: 0755
+              owner: root
+              group: root
       deb:
         contents:
           - src: LICENSE
@@ -119,6 +125,30 @@ nfpms:
             file_info:
               mode: 0644
             type: doc
+          - dst: "/etc/pelican"
+            type: dir
+            file_info:
+              mode: 0755
+              owner: root
+              group: root
+      apk:
+        contents:
+          - src: LICENSE
+            dst: "/usr/share/doc/{{ .PackageName }}/LICENSE.txt"
+            file_info:
+              mode: 0644
+            type: doc
+          - src: README.md
+            dst: "/usr/share/doc/{{ .PackageName }}/README.md"
+            file_info:
+              mode: 0644
+            type: doc
+          - dst: "/etc/pelican"
+            type: dir
+            file_info:
+              mode: 0755
+              owner: root
+              group: root
   # end package pelican
 
   - package_name: pelican-osdf-compat

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,6 +61,7 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+    wrap_in_directory: "{{ .ProjectName }}-{{ .RawVersion }}"
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,7 +61,7 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
-    wrap_in_directory: "{{ .ProjectName }}-{{ .RawVersion }}"
+    wrap_in_directory: '{{ .ProjectName }}-{{ trimsuffix .Version "-next" }}'
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
See #1271. This puts the contents of the pelican tarball into a pelican-<version>/ directory and also has the pelican apk/rpm/deb create and take ownership of the /etc/pelican directory.