### PR TITLE
Fix broken collections-url in Director when origin/ns is from Topology

### DIFF
--- a/director/advertise.go
+++ b/director/advertise.go
@@ -32,12 +32,31 @@ import (
 	"github.com/pelicanplatform/pelican/utils"
 )
 
-func parseServerAd(server utils.Server, serverType server_structs.ServerType) server_structs.ServerAd {
+// Takes in server information from topology and handles converting the necessary bits into a new Pelican
+// ServerAd.
+func parseServerAdFromTopology(server utils.Server, serverType server_structs.ServerType, caps server_structs.Capabilities) server_structs.ServerAd {
 	serverAd := server_structs.ServerAd{}
 	serverAd.Type = serverType
 	serverAd.Name = server.Resource
 
-	serverAd.Writes = param.Origin_EnableWrites.GetBool()
+	// Explicitly set these to false for caches, because these caps don't really translate in that case
+	if serverAd.Type == server_structs.CacheType {
+		serverAd.Caps = server_structs.Capabilities{}
+		serverAd.Writes = false
+		serverAd.Listings = false
+		serverAd.DirectReads = false
+	} else {
+		// Until we consolidate ServerAd capabilities with NamespaceAdV2 capabilities, we'll keep setting the top-level
+		// ServerAd capabilities. Eventually we should replace with the actual caps struct.
+		serverAd.Writes = caps.Writes
+		serverAd.Listings = caps.Listings
+		serverAd.DirectReads = caps.DirectReads
+		serverAd.Caps = caps
+	}
+
+	// Set FromTopology to true, which we use for filtering Pelican vs Topology origins/namespaces that might be competing.
+	serverAd.FromTopology = true
+
 	// url.Parse requires that the scheme be present before the hostname,
 	// but endpoints do not have a scheme. As such, we need to add one for the.
 	// correct parsing. Luckily, we don't use this anywhere else (it's just to
@@ -51,7 +70,11 @@ func parseServerAd(server utils.Server, serverType server_structs.ServerType) se
 		log.Warningf("Namespace JSON returned server %s with invalid unauthenticated URL %s",
 			server.Resource, server.Endpoint)
 	}
-	serverAd.URL = *serverUrl
+	if serverUrl != nil {
+		serverAd.URL = *serverUrl
+	} else {
+		serverAd.URL = url.URL{}
+	}
 
 	if server.AuthEndpoint != "" {
 		if !strings.HasPrefix(server.AuthEndpoint, "http") { // just in case there's already an http(s) tacked in front
@@ -63,7 +86,11 @@ func parseServerAd(server utils.Server, serverType server_structs.ServerType) se
 				server.Resource, server.AuthEndpoint)
 		}
 
-		serverAd.AuthURL = *serverAuthUrl
+		if serverAuthUrl != nil {
+			serverAd.AuthURL = *serverAuthUrl
+		} else {
+			serverAd.AuthURL = url.URL{}
+		}
 	}
 
 	// We will leave serverAd.WebURL as empty when fetched from topology
@@ -122,7 +149,7 @@ func AdvertiseOSDF() error {
 		return errors.Wrapf(err, "Failed to get topology JSON")
 	}
 
-	// Second call the fetch all servers (including servers in downtime)
+	// Second call to fetch all servers (including servers in downtime)
 	includedNss, err := utils.GetTopologyJSON(true)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to get topology JSON with server in downtime included (include_downed)")
@@ -177,10 +204,17 @@ func AdvertiseOSDF() error {
 			write = false
 		}
 
+		listings := false
+		if ns.DirlistHost != "" {
+			listings = true
+		}
+
 		caps := server_structs.Capabilities{
 			PublicReads: !ns.UseTokenOnRead,
 			Reads:       ns.ReadHTTPS,
 			Writes:      write,
+			Listings:    listings,
+			DirectReads: true, // Topology namespaces should probably always have this turned on
 		}
 		nsAd := server_structs.NamespaceAdV2{
 			Path:         ns.Path,
@@ -195,15 +229,17 @@ func AdvertiseOSDF() error {
 		// Some namespaces show up in topology but don't have an origin (perhaps because
 		// they're listed as inactive by topology). These namespaces will all be mapped to the
 		// same useless origin ad, resulting in a 404 for queries to those namespaces
+
+		// We further assume that with this legacy code handling, each origin exporting a given namespace
+		// will have the same set of capabilities as the namespace itself. Pelican has teased apart origins
+		// and namespaces, so this isn't true outside this limited context.
 		for _, origin := range ns.Origins {
-			originAd := parseServerAd(origin, server_structs.OriginType)
-			originAd.FromTopology = true
+			originAd := parseServerAdFromTopology(origin, server_structs.OriginType, caps)
 			originAdMap[originAd] = append(originAdMap[originAd], nsAd)
 		}
 
 		for _, cache := range ns.Caches {
-			cacheAd := parseServerAd(cache, server_structs.CacheType)
-			cacheAd.FromTopology = true
+			cacheAd := parseServerAdFromTopology(cache, server_structs.CacheType, server_structs.Capabilities{})
 			cacheAdMap[cacheAd] = append(cacheAdMap[cacheAd], nsAd)
 		}
 	}

--- a/director/advertise_test.go
+++ b/director/advertise_test.go
@@ -22,9 +22,10 @@ import (
 	_ "embed"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,36 +39,85 @@ var (
 	mockTopology string
 )
 
-func TestParseServerAd(t *testing.T) {
+func TestParseServerAdFromTopology(t *testing.T) {
 
 	server := utils.Server{
-		Endpoint: "http://my-endpoint.com",
-		Resource: "MY_SERVER",
-	}
-
-	osdf_server := utils.Server{
 		Endpoint:     "http://my-endpoint.com",
-		Resource:     "MY_SERVER",
 		AuthEndpoint: "https://my-auth-endpoint.com",
+		Resource:     "MY_SERVER",
 	}
 
-	// Check that we populate all of the fields correctly -- note that lat/long don't get updated
-	// until right before the ad is recorded, so we don't check for that here.
-	ad := parseServerAd(server, server_structs.OriginType)
-	assert.Equal(t, "http://my-endpoint.com", ad.URL.String())
-	assert.Equal(t, "", ad.WebURL.String())
-	assert.Equal(t, "MY_SERVER", ad.Name)
-	assert.Equal(t, url.URL{}, ad.AuthURL)
-	assert.True(t, ad.Type == server_structs.OriginType)
+	t.Run("test-setting-name", func(t *testing.T) {
+		ad := parseServerAdFromTopology(server, server_structs.OriginType, server_structs.Capabilities{})
+		assert.Equal(t, "MY_SERVER", ad.Name)
+	})
 
-	// A quick check that type is set correctly
-	ad = parseServerAd(server, server_structs.CacheType)
-	assert.True(t, ad.Type == server_structs.CacheType)
+	t.Run("parse-server-ads-with-scheme", func(t *testing.T) {
+		ad := parseServerAdFromTopology(server, server_structs.OriginType, server_structs.Capabilities{})
+		assert.Equal(t, "http://my-endpoint.com", ad.URL.String())
+		assert.Equal(t, "https://my-auth-endpoint.com", ad.AuthURL.String())
+	})
 
-	// A check that the authurl is set correctly for parsing a server ad from topology
-	ad = parseServerAd(osdf_server, server_structs.OriginType)
-	assert.Equal(t, "http://my-endpoint.com", ad.URL.String())
-	assert.Equal(t, "https://my-auth-endpoint.com", ad.AuthURL.String())
+	t.Run("parse-server-ads-no-scheme", func(t *testing.T) {
+		server.Endpoint = "my-endpoint.com"
+		server.AuthEndpoint = "my-auth-endpoint.com"
+		ad := parseServerAdFromTopology(server, server_structs.OriginType, server_structs.Capabilities{})
+		assert.Equal(t, "http://my-endpoint.com", ad.URL.String())
+		assert.Equal(t, "https://my-auth-endpoint.com", ad.AuthURL.String())
+	})
+
+	t.Run("test-ad-type", func(t *testing.T) {
+		ad := parseServerAdFromTopology(server, server_structs.OriginType, server_structs.Capabilities{})
+		assert.True(t, ad.Type == server_structs.OriginType)
+		ad = parseServerAdFromTopology(server, server_structs.CacheType, server_structs.Capabilities{})
+		assert.True(t, ad.Type == server_structs.CacheType)
+	})
+	t.Run("test-from-topology", func(t *testing.T) {
+		ad := parseServerAdFromTopology(server, server_structs.OriginType, server_structs.Capabilities{})
+		assert.True(t, ad.FromTopology)
+		ad = parseServerAdFromTopology(server, server_structs.CacheType, server_structs.Capabilities{})
+		assert.True(t, ad.FromTopology)
+	})
+
+	t.Run("test-caps-parsing", func(t *testing.T) {
+		// Only testing the caps that also get set as top level fields
+		caps := server_structs.Capabilities{
+			Writes:      true,
+			Listings:    true,
+			DirectReads: true,
+		}
+		ad := parseServerAdFromTopology(server, server_structs.OriginType, caps)
+		assert.True(t, ad.Writes)
+		assert.True(t, ad.Caps.Writes)
+		assert.True(t, ad.Listings)
+		assert.True(t, ad.Caps.Listings)
+		assert.True(t, ad.DirectReads)
+		assert.True(t, ad.Caps.DirectReads)
+
+		ad = parseServerAdFromTopology(server, server_structs.CacheType, caps)
+		assert.False(t, ad.Writes)
+		assert.False(t, ad.Caps.Writes)
+		assert.False(t, ad.Listings)
+		assert.False(t, ad.Caps.Listings)
+		assert.False(t, ad.DirectReads)
+		assert.False(t, ad.Caps.DirectReads)
+	})
+
+	t.Run("test-invalid-url", func(t *testing.T) {
+		// Capture logs
+		hook := logrustest.NewLocal(logrus.StandardLogger())
+		defer hook.Reset()
+
+		server.Endpoint = "http://a server "
+		server.AuthEndpoint = "https://a different server "
+		ad := parseServerAdFromTopology(server, server_structs.OriginType, server_structs.Capabilities{})
+		assert.Empty(t, ad.URL.String())
+		assert.Empty(t, ad.AuthURL.String())
+		assert.Len(t, hook.AllEntries(), 2)
+		assert.Equal(t, logrus.WarnLevel, hook.LastEntry().Level)
+		assert.Contains(t, hook.Entries[0].Message, "invalid unauthenticated URL")
+		assert.Contains(t, hook.Entries[1].Message, "invalid authenticated URL")
+	})
 }
 
 func JSONHandler(w http.ResponseWriter, r *http.Request) {
@@ -105,10 +155,21 @@ func TestAdvertiseOSDF(t *testing.T) {
 	assert.Equal(t, uint(3), nsAd.Generation[0].MaxScopeDepth)
 	assert.Equal(t, "https://origin1-auth-endpoint.com", oAds[0].AuthURL.String())
 	assert.Equal(t, "https://cache2.com", cAds[0].URL.String())
+	// Check that various capabilities have survived until this point. Because these are from topology,
+	// origin and namespace caps should be the same
+	assert.True(t, oAds[0].Writes)
+	assert.True(t, oAds[0].Caps.Writes)
+	assert.True(t, oAds[0].Listings)
+	assert.True(t, oAds[0].Caps.Listings)
+	assert.False(t, oAds[0].Caps.PublicReads)
+	assert.True(t, nsAd.Caps.Writes)
+	assert.True(t, nsAd.Caps.Listings)
+	assert.False(t, nsAd.Caps.PublicReads)
+	assert.True(t, nsAd.Caps.Listings)
 
 	nsAd, oAds, cAds = getAdsForPath("/my/server/2/path/to/file")
 	assert.Equal(t, "/my/server/2", nsAd.Path)
-	assert.Equal(t, true, nsAd.PublicRead)
+	assert.True(t, nsAd.PublicRead)
 	assert.Equal(t, "https://origin2-auth-endpoint.com", oAds[0].AuthURL.String())
 	assert.Equal(t, "http://cache-endpoint.com", cAds[0].URL.String())
 }

--- a/director/director.go
+++ b/director/director.go
@@ -350,16 +350,19 @@ func redirectToCache(ginCtx *gin.Context) {
 	// If the namespace or the origin does not allow directory listings, then we should not advertise a collections-url.
 	// This is because the configuration of the origin/namespace should override the inclusion of "dirlisthost" for that origin.
 	// Listings is true by default so if it is ever set to false we should accept that config over the dirlisthost.
-	if namespaceAd.Caps.Listings && originAds[0].Listings {
-		if !namespaceAd.PublicRead && originAds[0].AuthURL != (url.URL{}) {
+	if namespaceAd.Caps.Listings && originAds[0].Caps.Listings {
+		if !namespaceAd.Caps.PublicReads && originAds[0].AuthURL != (url.URL{}) {
 			colUrl = originAds[0].AuthURL.String()
 		} else {
 			colUrl = originAds[0].URL.String()
 		}
 	}
-	ginCtx.Writer.Header()["X-Pelican-Namespace"] = []string{fmt.Sprintf("namespace=%s, require-token=%v, collections-url=%s",
-		namespaceAd.Path, !namespaceAd.PublicRead, colUrl)}
-
+	xPelicanNamespace := fmt.Sprintf("namespace=%s, require-token=%v", namespaceAd.Path, !namespaceAd.Caps.PublicReads)
+	if colUrl != "" {
+		xPelicanNamespace += fmt.Sprintf(", collections-url=%s", colUrl)
+	}
+	ginCtx.Writer.Header()["X-Pelican-Namespace"] = []string{xPelicanNamespace}
+	fmt.Printf("\n\n\nX-Pelican-Namespace: %s\n\n\n", xPelicanNamespace)
 	// Note we only append the `authz` query parameter in the case of the redirect response and not the
 	// duplicate link metadata above.  This is purposeful: the Link header might get too long if we repeat
 	// the token 20 times for 20 caches.  This means a "normal HTTP client" will correctly redirect but

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -1185,6 +1185,40 @@ func TestRedirects(t *testing.T) {
 		assert.NotContains(t, c.Writer.Header().Get("Link"), "pri=2")
 	})
 
+	// Make sure collections-url is correctly populated when the ns/origin comes from topology
+	t.Run("collections-url-from-topology", func(t *testing.T) {
+		viper.Reset()
+		serverAds.DeleteAll()
+		t.Cleanup(func() {
+			viper.Reset()
+			serverAds.DeleteAll()
+		})
+
+		topoServer := httptest.NewServer(http.HandlerFunc(JSONHandler))
+		defer topoServer.Close()
+		viper.Set("Federation.TopologyNamespaceUrl", topoServer.URL)
+		viper.Set("Director.CacheSortMethod", "random")
+		err := AdvertiseOSDF()
+		require.NoError(t, err)
+
+		// This one should have a collections url because it has a dirlisthost
+		req, _ := http.NewRequest("GET", "/my/server", nil)
+		req.Header.Add("User-Agent", "pelican-v7.999.999")
+		req.Header.Add("X-Real-Ip", "128.104.153.60")
+		recorder := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(recorder)
+		c.Request = req
+		redirectToCache(c)
+		assert.Contains(t, c.Writer.Header().Get("X-Pelican-Namespace"), "collections-url=https://origin1-auth-endpoint.com")
+
+		// This one has no dirlisthost
+		req, _ = http.NewRequest("GET", "/my/server/2", nil)
+		req.Header.Add("User-Agent", "pelican-v7.999.999")
+		req.Header.Add("X-Real-Ip", "128.104.153.60")
+		c.Request = req
+		redirectToCache(c)
+		assert.NotContains(t, c.Writer.Header().Get("X-Pelican-Namespace"), "collections-url")
+	})
 }
 
 func TestGetHealthTestFile(t *testing.T) {

--- a/director/resources/mock_topology.json
+++ b/director/resources/mock_topology.json
@@ -90,7 +90,7 @@
                         "restricted_path": []
                     }
                 ],
-                "dirlisthost": null,
+                "dirlisthost": "https://origin1-auth-endpoint.com",
                 "origins": [
                     {
                         "auth_endpoint": "https://origin1-auth-endpoint.com",

--- a/go.mod
+++ b/go.mod
@@ -177,7 +177,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.20.0 // indirect
 	go.uber.org/goleak v1.2.1 // indirect
 	golang.org/x/arch v0.3.0 // indirect
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/sync v0.6.0
 	golang.org/x/text v0.14.0
 	golang.org/x/time v0.5.0

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -67,18 +67,19 @@ type (
 	}
 
 	ServerAd struct {
-		Name         string     `json:"name"`
-		AuthURL      url.URL    `json:"auth_url"`
-		BrokerURL    url.URL    `json:"broker_url"` // The URL of the broker service to use for this host.
-		URL          url.URL    `json:"url"`        // This is server's XRootD URL for file transfer
-		WebURL       url.URL    `json:"web_url"`    // This is server's Web interface and API
-		Type         ServerType `json:"type"`
-		Latitude     float64    `json:"latitude"`
-		Longitude    float64    `json:"longitude"`
-		Writes       bool       `json:"enable_write"`
-		Listings     bool       `json:"enable_listing"`       // True if the origin allows directory listings
-		DirectReads  bool       `json:"enable_fallback_read"` // True if reads from the origin are permitted when no cache is available
-		FromTopology bool       `json:"from_topology"`
+		Name         string       `json:"name"`
+		AuthURL      url.URL      `json:"auth_url"`
+		BrokerURL    url.URL      `json:"broker_url"` // The URL of the broker service to use for this host.
+		URL          url.URL      `json:"url"`        // This is server's XRootD URL for file transfer
+		WebURL       url.URL      `json:"web_url"`    // This is server's Web interface and API
+		Type         ServerType   `json:"type"`
+		Latitude     float64      `json:"latitude"`
+		Longitude    float64      `json:"longitude"`
+		Caps         Capabilities `json:"capabilities"` // TODO: Get rid of Writes, Listings, DirectReads in favor of Caps.Writes, Caps.Listings, Caps.DirectReads
+		Writes       bool         `json:"enable_write"`
+		Listings     bool         `json:"enable_listing"`       // True if the origin allows directory listings
+		DirectReads  bool         `json:"enable_fallback_read"` // True if reads from the origin are permitted when no cache is available
+		FromTopology bool         `json:"from_topology"`
 	}
 
 	// The struct holding a server's advertisement (including ServerAd and NamespaceAd)


### PR DESCRIPTION
This starts moving the ServerAd struct toward its own set of capabilities as well. It also adds tests that would have hopefully caught this regression had they existed.

Closes #1357 