### PR TITLE
Start phasing out NamespaceAdV2.PublicRead in favor of NamespaceAdV2.Caps.PublicReads

### DIFF
--- a/director/advertise.go
+++ b/director/advertise.go
@@ -218,7 +218,7 @@ func AdvertiseOSDF(ctx context.Context) error {
 		}
 		nsAd := server_structs.NamespaceAdV2{
 			Path:         ns.Path,
-			PublicRead:   !ns.UseTokenOnRead,
+			PublicRead:   caps.PublicReads,
 			Caps:         caps,
 			Generation:   []server_structs.TokenGen{tGen},
 			Issuer:       tokenIssuers,

--- a/director/advertise_test.go
+++ b/director/advertise_test.go
@@ -170,7 +170,7 @@ func TestAdvertiseOSDF(t *testing.T) {
 
 	nsAd, oAds, cAds = getAdsForPath("/my/server/2/path/to/file")
 	assert.Equal(t, "/my/server/2", nsAd.Path)
-	assert.True(t, nsAd.PublicRead)
+	assert.True(t, nsAd.Caps.PublicReads)
 	assert.Equal(t, "https://origin2-auth-endpoint.com", oAds[0].AuthURL.String())
 	assert.Equal(t, "http://cache-endpoint.com", cAds[0].URL.String())
 }

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -52,8 +52,8 @@ func TestGetAdsForPath(t *testing.T) {
 	*/
 	nsAd1 := server_structs.NamespaceAdV2{
 		// PublicRead: false,
-		Caps:       server_structs.Capabilities{PublicReads: false},
-		Path:       "/chtc",
+		Caps: server_structs.Capabilities{PublicReads: false},
+		Path: "/chtc",
 		Issuer: []server_structs.TokenIssuer{{
 			IssuerUrl: url.URL{
 				Scheme: "https",
@@ -65,8 +65,8 @@ func TestGetAdsForPath(t *testing.T) {
 
 	nsAd2 := server_structs.NamespaceAdV2{
 		// PublicRead: true,
-		Caps:       server_structs.Capabilities{PublicReads: true},
-		Path:       "/chtc/PUBLIC",
+		Caps: server_structs.Capabilities{PublicReads: true},
+		Path: "/chtc/PUBLIC",
 		Issuer: []server_structs.TokenIssuer{{
 			IssuerUrl: url.URL{
 				Scheme: "https",
@@ -78,8 +78,8 @@ func TestGetAdsForPath(t *testing.T) {
 
 	nsAd3 := server_structs.NamespaceAdV2{
 		// PublicRead: true,
-		Caps:       server_structs.Capabilities{PublicReads: true},
-		Path:       "/chtc/PUBLIC2/",
+		Caps: server_structs.Capabilities{PublicReads: true},
+		Path: "/chtc/PUBLIC2/",
 		Issuer: []server_structs.TokenIssuer{{
 			IssuerUrl: url.URL{
 				Scheme: "https",
@@ -250,9 +250,9 @@ func TestLaunchTTLCache(t *testing.T) {
 		Longitude: 456.78,
 	}
 	mockNamespaceAd := server_structs.NamespaceAdV2{
-		Caps:       server_structs.Capabilities{PublicReads: false},
-		Path:       "/foo/bar/",
-		Issuer:     []server_structs.TokenIssuer{{IssuerUrl: url.URL{}}},
+		Caps:   server_structs.Capabilities{PublicReads: false},
+		Path:   "/foo/bar/",
+		Issuer: []server_structs.TokenIssuer{{IssuerUrl: url.URL{}}},
 		Generation: []server_structs.TokenGen{{
 			MaxScopeDepth: 1,
 			Strategy:      "",

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -51,7 +51,7 @@ func TestGetAdsForPath(t *testing.T) {
 			- Query for a few paths and make sure the correct ads are returned
 	*/
 	nsAd1 := server_structs.NamespaceAdV2{
-		PublicRead: false,
+		// PublicRead: false,
 		Caps:       server_structs.Capabilities{PublicReads: false},
 		Path:       "/chtc",
 		Issuer: []server_structs.TokenIssuer{{
@@ -64,7 +64,7 @@ func TestGetAdsForPath(t *testing.T) {
 	}
 
 	nsAd2 := server_structs.NamespaceAdV2{
-		PublicRead: true,
+		// PublicRead: true,
 		Caps:       server_structs.Capabilities{PublicReads: true},
 		Path:       "/chtc/PUBLIC",
 		Issuer: []server_structs.TokenIssuer{{
@@ -77,7 +77,7 @@ func TestGetAdsForPath(t *testing.T) {
 	}
 
 	nsAd3 := server_structs.NamespaceAdV2{
-		PublicRead: true,
+		// PublicRead: true,
 		Caps:       server_structs.Capabilities{PublicReads: true},
 		Path:       "/chtc/PUBLIC2/",
 		Issuer: []server_structs.TokenIssuer{{
@@ -90,7 +90,7 @@ func TestGetAdsForPath(t *testing.T) {
 	}
 
 	nsAdTopo1 := server_structs.NamespaceAdV2{
-		PublicRead:   true,
+		// PublicRead:   true,
 		Caps:         server_structs.Capabilities{PublicReads: true},
 		Path:         "/chtc",
 		FromTopology: true,
@@ -165,7 +165,7 @@ func TestGetAdsForPath(t *testing.T) {
 	assert.Equal(t, "/chtc", nsAd.Path)
 	// Make sure it's not from Topology
 	assert.False(t, nsAd.FromTopology)
-	assert.False(t, nsAd.PublicRead) // Topology one has public read turned on while Pelican one doesn't
+	assert.False(t, nsAd.Caps.PublicReads) // Topology one has public read turned on while Pelican one doesn't
 
 	assert.Equal(t, 1, len(oAds))
 	assert.Equal(t, 2, len(cAds))
@@ -250,7 +250,6 @@ func TestLaunchTTLCache(t *testing.T) {
 		Longitude: 456.78,
 	}
 	mockNamespaceAd := server_structs.NamespaceAdV2{
-		PublicRead: false,
 		Caps:       server_structs.Capabilities{PublicReads: false},
 		Path:       "/foo/bar/",
 		Issuer:     []server_structs.TokenIssuer{{IssuerUrl: url.URL{}}},

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -51,7 +51,6 @@ func TestGetAdsForPath(t *testing.T) {
 			- Query for a few paths and make sure the correct ads are returned
 	*/
 	nsAd1 := server_structs.NamespaceAdV2{
-		// PublicRead: false,
 		Caps: server_structs.Capabilities{PublicReads: false},
 		Path: "/chtc",
 		Issuer: []server_structs.TokenIssuer{{
@@ -64,7 +63,6 @@ func TestGetAdsForPath(t *testing.T) {
 	}
 
 	nsAd2 := server_structs.NamespaceAdV2{
-		// PublicRead: true,
 		Caps: server_structs.Capabilities{PublicReads: true},
 		Path: "/chtc/PUBLIC",
 		Issuer: []server_structs.TokenIssuer{{
@@ -77,7 +75,6 @@ func TestGetAdsForPath(t *testing.T) {
 	}
 
 	nsAd3 := server_structs.NamespaceAdV2{
-		// PublicRead: true,
 		Caps: server_structs.Capabilities{PublicReads: true},
 		Path: "/chtc/PUBLIC2/",
 		Issuer: []server_structs.TokenIssuer{{
@@ -90,7 +87,6 @@ func TestGetAdsForPath(t *testing.T) {
 	}
 
 	nsAdTopo1 := server_structs.NamespaceAdV2{
-		// PublicRead:   true,
 		Caps:         server_structs.Capabilities{PublicReads: true},
 		Path:         "/chtc",
 		FromTopology: true,

--- a/director/director.go
+++ b/director/director.go
@@ -490,7 +490,7 @@ func redirectToOrigin(ginCtx *gin.Context) {
 		} else {
 			linkHeader += ", "
 		}
-		redirectURL := getRedirectURL(reqPath, ad, !namespaceAd.PublicRead)
+		redirectURL := getRedirectURL(reqPath, ad, !namespaceAd.Caps.PublicReads)
 		linkHeader += fmt.Sprintf(`<%s>; rel="duplicate"; pri=%d; depth=%d`, redirectURL.String(), idx+1, depth)
 	}
 	ginCtx.Writer.Header()["Link"] = []string{linkHeader}
@@ -507,7 +507,7 @@ func redirectToOrigin(ginCtx *gin.Context) {
 		}
 	}
 	ginCtx.Writer.Header()["X-Pelican-Namespace"] = []string{fmt.Sprintf("namespace=%s, require-token=%v, collections-url=%s",
-		namespaceAd.Path, !namespaceAd.PublicRead, colUrl)}
+		namespaceAd.Path, !namespaceAd.Caps.PublicReads, colUrl)}
 
 	var redirectURL url.URL
 

--- a/director/director.go
+++ b/director/director.go
@@ -351,7 +351,7 @@ func redirectToCache(ginCtx *gin.Context) {
 	// If the namespace or the origin does not allow directory listings, then we should not advertise a collections-url.
 	// This is because the configuration of the origin/namespace should override the inclusion of "dirlisthost" for that origin.
 	// Listings is true by default so if it is ever set to false we should accept that config over the dirlisthost.
-	if namespaceAd.Caps.Listings && originAds[0].Caps.Listings {
+	if namespaceAd.Caps.Listings && len(originAds) > 0 && originAds[0].Caps.Listings {
 		if !namespaceAd.Caps.PublicReads && originAds[0].AuthURL != (url.URL{}) {
 			colUrl = originAds[0].AuthURL.String()
 		} else {
@@ -499,7 +499,7 @@ func redirectToOrigin(ginCtx *gin.Context) {
 	// If the namespace or the origin does not allow directory listings, then we should not advertise a collections-url.
 	// This is because the configuration of the origin/namespace should override the inclusion of "dirlisthost" for that origin.
 	// Listings is true by default so if it is ever set to false we should accept that config over the dirlisthost.
-	if namespaceAd.Caps.Listings && availableOriginAds[0].Listings {
+	if namespaceAd.Caps.Listings && len(availableOriginAds) > 0 && availableOriginAds[0].Listings {
 		if !namespaceAd.PublicRead && availableOriginAds[0].AuthURL != (url.URL{}) {
 			colUrl = availableOriginAds[0].AuthURL.String()
 		} else {

--- a/director/director_api_test.go
+++ b/director/director_api_test.go
@@ -51,7 +51,6 @@ func mockNamespaceAds(size int, serverPrefix string) []server_structs.NamespaceA
 	namespaceAds := make([]server_structs.NamespaceAdV2, size)
 	for i := 0; i < size; i++ {
 		namespaceAds[i] = server_structs.NamespaceAdV2{
-			PublicRead: false,
 			Caps: server_structs.Capabilities{
 				PublicReads: false,
 			},

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -792,7 +792,7 @@ func TestDiscoverOriginCache(t *testing.T) {
 		Caps: server_structs.Capabilities{
 			PublicReads: false,
 		},
-		Path:       "/foo/bar/",
+		Path: "/foo/bar/",
 		Issuer: []server_structs.TokenIssuer{{
 			BasePaths: []string{""},
 			IssuerUrl: url.URL{},

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -789,7 +789,9 @@ func TestDiscoverOriginCache(t *testing.T) {
 	}
 
 	mockNamespaceAd := server_structs.NamespaceAdV2{
-		PublicRead: false,
+		Caps: server_structs.Capabilities{
+			PublicReads: false,
+		},
 		Path:       "/foo/bar/",
 		Issuer: []server_structs.TokenIssuer{{
 			BasePaths: []string{""},

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -47,6 +47,8 @@ type (
 	}
 
 	NamespaceAdV2 struct {
+		// TODO: Deprecate this top-level PublicRead field in favor of the Caps.PublicReads field.
+		// Should be done ~v7.10 series
 		PublicRead   bool
 		Caps         Capabilities  // Namespace capabilities should be considered independently of the origin’s capabilities.
 		Path         string        `json:"path"`
@@ -293,7 +295,7 @@ func ConvertNamespaceAdsV1ToV2(nsAdsV1 []NamespaceAdV1, oAd *OriginAdvertiseV1) 
 			}
 
 			newNS := NamespaceAdV2{
-				PublicRead: !nsAd.RequireToken,
+				PublicRead: caps.PublicReads,
 				Caps:       caps,
 				Path:       nsAd.Path,
 			}

--- a/server_structs/director_test.go
+++ b/server_structs/director_test.go
@@ -37,9 +37,14 @@ func TestConversion(t *testing.T) {
 	require.NoError(t, err, "error parsing test issuer url")
 
 	v2Ads := []NamespaceAdV2{{
-		PublicRead: false,
-		Caps:       Capabilities{PublicReads: false, Reads: true, Writes: true, DirectReads: false, Listings: true},
-		Path:       "/foo/bar",
+		Caps: Capabilities{
+			PublicReads: false,
+			Reads:       true,
+			Writes:      true,
+			DirectReads: false,
+			Listings:    true,
+		},
+		Path: "/foo/bar",
 		Generation: []TokenGen{{
 			Strategy:         "OAuth2",
 			MaxScopeDepth:    3,
@@ -63,8 +68,9 @@ func TestConversion(t *testing.T) {
 				PublicReads: true,
 				Reads:       true,
 				Writes:      true,
+				DirectReads: false,
 				Listings:    true,
-				DirectReads: false},
+			},
 			Path: "/baz/bar",
 		},
 	}

--- a/xrootd/authorization.go
+++ b/xrootd/authorization.go
@@ -342,7 +342,7 @@ func EmitAuthfile(server server_structs.XRootDServer) error {
 			outStr = "u * "
 		}
 		for _, ad := range server.GetNamespaceAds() {
-			if ad.PublicRead && ad.Path != "" {
+			if ad.Caps.PublicReads && ad.Path != "" {
 				outStr += ad.Path + " lr "
 			}
 		}
@@ -546,7 +546,6 @@ func EmitScitokensConfig(server server_structs.XRootDServer) error {
 				return errors.Wrap(err, "can't parse Server_ExternalWebUrl when generating scitokens config")
 			}
 			cacheIssuer := server_structs.NamespaceAdV2{
-				PublicRead: false,
 				Caps:       server_structs.Capabilities{PublicReads: false, Reads: true, Writes: true},
 				Path:       "/pelican/monitoring",
 				Issuer: []server_structs.TokenIssuer{
@@ -618,7 +617,7 @@ func WriteCacheScitokensConfig(nsAds []server_structs.NamespaceAdV2) error {
 		return err
 	}
 	for _, ad := range nsAds {
-		if !ad.PublicRead {
+		if !ad.Caps.PublicReads {
 			for _, ti := range ad.Issuer {
 				if val, ok := cfg.IssuerMap[ti.IssuerUrl.String()]; ok {
 					val.BasePaths = append(val.BasePaths, ti.BasePaths...)

--- a/xrootd/authorization.go
+++ b/xrootd/authorization.go
@@ -546,8 +546,8 @@ func EmitScitokensConfig(server server_structs.XRootDServer) error {
 				return errors.Wrap(err, "can't parse Server_ExternalWebUrl when generating scitokens config")
 			}
 			cacheIssuer := server_structs.NamespaceAdV2{
-				Caps:       server_structs.Capabilities{PublicReads: false, Reads: true, Writes: true},
-				Path:       "/pelican/monitoring",
+				Caps: server_structs.Capabilities{PublicReads: false, Reads: true, Writes: true},
+				Path: "/pelican/monitoring",
 				Issuer: []server_structs.TokenIssuer{
 					{
 						BasePaths: []string{"/pelican/monitoring"},

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -678,7 +678,6 @@ func TestWriteCacheAuthFiles(t *testing.T) {
 
 	nsAds := []server_structs.NamespaceAdV2{
 		{
-			PublicRead: false,
 			Caps:       PrivateCaps,
 			Issuer: []server_structs.TokenIssuer{{
 				IssuerUrl:       issuer1URL,
@@ -686,7 +685,6 @@ func TestWriteCacheAuthFiles(t *testing.T) {
 				RestrictedPaths: []string{"/p1/nope", "p1/still_nope"}}},
 		},
 		{
-			PublicRead: false,
 			Caps:       PrivateCaps,
 			Issuer: []server_structs.TokenIssuer{{
 				IssuerUrl: issuer2URL,
@@ -695,11 +693,9 @@ func TestWriteCacheAuthFiles(t *testing.T) {
 		},
 		{
 			Path:       "/p3",
-			PublicRead: true,
 			Caps:       PublicCaps,
 		},
 		{
-			PublicRead: false,
 			Caps:       PrivateCaps,
 			Issuer: []server_structs.TokenIssuer{{
 				IssuerUrl: issuer1URL,
@@ -711,12 +707,10 @@ func TestWriteCacheAuthFiles(t *testing.T) {
 		},
 		{
 			Path:       "/p4/depth",
-			PublicRead: true,
 			Caps:       PublicCaps,
 		},
 		{
 			Path:       "/p2_noauth",
-			PublicRead: true,
 			Caps:       PublicCaps,
 		},
 	}

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -678,25 +678,25 @@ func TestWriteCacheAuthFiles(t *testing.T) {
 
 	nsAds := []server_structs.NamespaceAdV2{
 		{
-			Caps:       PrivateCaps,
+			Caps: PrivateCaps,
 			Issuer: []server_structs.TokenIssuer{{
 				IssuerUrl:       issuer1URL,
 				BasePaths:       []string{"/p1"},
 				RestrictedPaths: []string{"/p1/nope", "p1/still_nope"}}},
 		},
 		{
-			Caps:       PrivateCaps,
+			Caps: PrivateCaps,
 			Issuer: []server_structs.TokenIssuer{{
 				IssuerUrl: issuer2URL,
 				BasePaths: []string{"/p2/path", "/p2/foo", "/p2/baz"},
 			}},
 		},
 		{
-			Path:       "/p3",
-			Caps:       PublicCaps,
+			Path: "/p3",
+			Caps: PublicCaps,
 		},
 		{
-			Caps:       PrivateCaps,
+			Caps: PrivateCaps,
 			Issuer: []server_structs.TokenIssuer{{
 				IssuerUrl: issuer1URL,
 				BasePaths: []string{"/p1_again"},
@@ -706,12 +706,12 @@ func TestWriteCacheAuthFiles(t *testing.T) {
 			}},
 		},
 		{
-			Path:       "/p4/depth",
-			Caps:       PublicCaps,
+			Path: "/p4/depth",
+			Caps: PublicCaps,
 		},
 		{
-			Path:       "/p2_noauth",
-			Caps:       PublicCaps,
+			Path: "/p2_noauth",
+			Caps: PublicCaps,
 		},
 	}
 


### PR DESCRIPTION
NamespaceAdV2 has a weird duplication between `ad.PublicRead` and `ad.Caps.PublicReads`. Since we have the `Capabilities` struct, we should switch to populating that and to checking that. This will have to be done over several releases because this will break backwards compatibility if an old director (prior to whichever release this PR ends up in) tries to receive an ad from a new Origin.