### PR TITLE
Cleanup a few deprecation warnings from the old Federation.NamespaceUrl config key

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -770,6 +770,9 @@ func GetEnTranslator() ut.Translator {
 	return *translator
 }
 
+// If the user provides a deprecated key in their config that can be mapped to some new key, we do that here
+// along with printing out a warning to let them know they should update. Whether or not keys are mapped is
+// configured in docs/parameters.yaml using the `deprecated: true` and replacedby: `<list of new keys>` fields.
 func handleDeprecatedConfig() {
 	deprecatedMap := param.GetDeprecated()
 	for deprecated, replacement := range deprecatedMap {
@@ -930,10 +933,7 @@ func InitConfig() {
 		SetLogging(level)
 	}
 
-	if oldNsUrl := viper.GetString("Federation.NamespaceUrl"); oldNsUrl != "" {
-		log.Errorln("Federation.NamespaceUrl is deprecated and removed from parameters. Please use Federation.RegistryUrl instead")
-		os.Exit(1)
-	}
+	// Warn users about deprecated config keys they're using and try to map them to any new equivalent we've defined.
 	handleDeprecatedConfig()
 
 	onceValidate.Do(func() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -207,23 +207,9 @@ func TestDeprecateLogMessage(t *testing.T) {
 		assert.Equal(t, logrus.WarnLevel, hook.LastEntry().Level)
 		assert.Equal(t, "Deprecated configuration key Origin.NamespacePrefix is set. Please migrate to use Origin.FederationPrefix instead", hook.Entries[len(hook.Entries)-2].Message)
 		assert.Equal(t, "Will attempt to use the value of Origin.NamespacePrefix as default for Origin.FederationPrefix", hook.LastEntry().Message)
-		// We expect the default value of Federation.RegistryUrl is set to Federation.NamespaceUrl
-		// if Federation.NamespaceUrl is not empty for backward compatibility
+		// If the deprecated key is set to something that we can map to the new key, that mapping should be handled in InitConfig.
+		// Since Origin.NamespacePrefix maps to Origin.FederationPrefix, check that it succeeded.
 		assert.Equal(t, "/a/prefix", viper.GetString("Origin.FederationPrefix"))
-		hook.Reset()
-	})
-
-	t.Run("no-deprecated-message-if-namespace-url-unset", func(t *testing.T) {
-		hook := test.NewGlobal()
-		viper.Reset()
-		viper.Set("Logging.Level", "Warning")
-		viper.Set("Federation.RegistryUrl", "https://dont-use.com")
-		viper.Set("ConfigDir", tmpPath)
-		InitConfig()
-
-		assert.Equal(t, 0, len(hook.Entries))
-		assert.Equal(t, "https://dont-use.com", viper.GetString("Federation.RegistryUrl"))
-		assert.Equal(t, "", viper.GetString("Federation.NamespaceUrl"))
 		hook.Reset()
 	})
 }


### PR DESCRIPTION
@haoming29, I came across these old deprecation warnings, and thought they were old enough that we could safely clean them up. If you disagree, you can close the PR as `wontfix` and we can open a separate issue to remove them in a later release.