### PR TITLE
Disable ZTN authentication on Pelican origins

### DIFF
--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -89,7 +89,6 @@ pss.origin {{.Origin.XRootServiceUrl}}
 ofs.osslib libXrdPss.so
 {{end}}
 xrootd.seclib libXrdSec.so
-sec.protocol ztn
 ofs.authorize 1
 acc.audit deny grant
 acc.authdb {{.Origin.RunLocation}}/authfile-origin-generated


### PR DESCRIPTION
Caches cannot talk ZTN so this never worked anyhow.  Further, if a non-Pelican cache tries to talk to a Pelican origin over the xrootd protocol, by having ZTN enabled anonymous sessions are forbidden.

This change will allow anonymous sessions for the xrootd origin, meaning that requests must be authorized by tokens.

Fixes #1375 