### PR TITLE
Add mechanism to change authfile reload intervals

### DIFF
--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -96,6 +96,7 @@ Xrootd:
   ManagerPort: 1213
   DetailedMonitoringPort: 9930
   SummaryMonitoringPort: 9931
+  AuthRefreshInterval: 5m
 Transport:
   DialerTimeout: 10s
   DialerKeepAlive: 30s

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2041,6 +2041,15 @@ type: string
 default: none
 components: ["origin"]
 ---
+name: Xrootd.AuthRefreshInterval
+description: |+
+  The interval used by XRootD (cache/origin) for refreshing Authfiles. This affects how often the server polls for upstream changes
+  that might affect the authorization policy. For example, when applied to a cache, this affects how often origin permissions are
+  polled for changes.
+type: duration
+default: 5m
+components: ["origin", "cache"]
+---
 name: Xrootd.ManagerHost
 description: |+
   A URL pointing toward the XRootD instance's Manager Host.

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -360,6 +360,7 @@ var (
 	Transport_IdleConnTimeout = DurationParam{"Transport.IdleConnTimeout"}
 	Transport_ResponseHeaderTimeout = DurationParam{"Transport.ResponseHeaderTimeout"}
 	Transport_TLSHandshakeTimeout = DurationParam{"Transport.TLSHandshakeTimeout"}
+	Xrootd_AuthRefreshInterval = DurationParam{"Xrootd.AuthRefreshInterval"}
 )
 
 var (

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -290,6 +290,7 @@ type Config struct {
 		TLSHandshakeTimeout time.Duration `mapstructure:"tlshandshaketimeout"`
 	} `mapstructure:"transport"`
 	Xrootd struct {
+		AuthRefreshInterval time.Duration `mapstructure:"authrefreshinterval"`
 		Authfile string `mapstructure:"authfile"`
 		ConfigFile string `mapstructure:"configfile"`
 		DetailedMonitoringHost string `mapstructure:"detailedmonitoringhost"`
@@ -577,6 +578,7 @@ type configWithType struct {
 		TLSHandshakeTimeout struct { Type string; Value time.Duration }
 	}
 	Xrootd struct {
+		AuthRefreshInterval struct { Type string; Value time.Duration }
 		Authfile struct { Type string; Value string }
 		ConfigFile struct { Type string; Value string }
 		DetailedMonitoringHost struct { Type string; Value string }

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -44,6 +44,7 @@ sec.protocol ztn
 ofs.authorize 1
 acc.audit deny grant
 acc.authdb {{.Cache.RunLocation}}/authfile-cache-generated
+acc.authrefresh {{.Xrootd.AuthRefreshInterval}}
 ofs.authlib ++ libXrdAccSciTokens.so config={{.Cache.RunLocation}}/scitokens-cache-generated.cfg
 all.export {{.Cache.ExportLocation}}
 xrootd.chksum max 2 md5 adler32

--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -92,6 +92,7 @@ xrootd.seclib libXrdSec.so
 ofs.authorize 1
 acc.audit deny grant
 acc.authdb {{.Origin.RunLocation}}/authfile-origin-generated
+acc.authrefresh {{.Xrootd.AuthRefreshInterval}}
 ofs.authlib ++ libXrdAccSciTokens.so config={{.Origin.RunLocation}}/scitokens-origin-generated.cfg
 # Tell xrootd to make each namespace we export available as a path at the server
 {{range .Origin.Exports}}

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -647,8 +647,8 @@ func authRefreshStrToSecondsHookFunc() mapstructure.DecodeHookFuncType {
 			return nil, err
 		}
 
-		if duration < time.Second {
-			log.Warningf("'Xrootd.AuthRefreshInterval' appears as less than a second. Using fallback of 5m")
+		if duration < 60*time.Second {
+			log.Warningf("'Xrootd.AuthRefreshInterval' of %s appears as less than 60s. Using fallback of 5m", durStr)
 			duration = time.Minute * 5
 		}
 

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -629,7 +629,7 @@ func authRefreshStrToSecondsHookFunc() mapstructure.DecodeHookFuncType {
 		}
 
 		// Sanitize the input to guarantee we have a unit
-		suffixes := []string{"s", "m", "h", "d"}
+		suffixes := []string{"s", "m", "h"}
 		hasSuffix := false
 		for _, suffix := range suffixes {
 			if strings.HasSuffix(durStr, suffix) {
@@ -638,13 +638,13 @@ func authRefreshStrToSecondsHookFunc() mapstructure.DecodeHookFuncType {
 			}
 		}
 		if !hasSuffix {
-			log.Warningf("'Xrootd.AuthRefreshInterval' does not have a time unit (s, m, h, d). Interpreting as seconds")
+			log.Warningf("'Xrootd.AuthRefreshInterval' does not have a time unit (s, m, h). Interpreting as seconds")
 			durStr = durStr + "s"
 		}
 
 		duration, err := time.ParseDuration(durStr)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "Failed to parse 'Xrootd.AuthRefreshInterval' of %s as a duration", durStr)
 		}
 
 		if duration < 60*time.Second {

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -39,6 +39,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -131,6 +132,7 @@ type (
 		DetailedMonitoringHost string
 		DetailedMonitoringPort int
 		Authfile               string
+		AuthRefreshInterval    int // In the raw config we use a duration, but Xrootd needs this as a seconds integer. Conversion happens during the unmarshal
 		ScitokensConfig        string
 		Mount                  string
 		LocalMonitoringPort    int
@@ -605,8 +607,68 @@ func LaunchXrootdMaintenance(ctx context.Context, server server_structs.XRootDSe
 	)
 }
 
-func ConfigXrootd(ctx context.Context, isOrigin bool) (string, error) {
+// The default config has `Xrootd.AuthRefreshInterval: 5m`, which we need to convert
+// to an integer representation of seconds for our XRootD configuration. This hook
+// handles that conversion during unmarshalling, as well as some sanitization of user inputs.
+func authRefreshStrToSecondsHookFunc() mapstructure.DecodeHookFuncType {
+	return func(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+		// Filter out underlying data we don't want to risk manipulating
+		if t.Kind() != reflect.Struct || f.Kind() != reflect.Map || t.Name() != "XrootdOptions" {
+			return data, nil
+		}
 
+		// Get the value, load as a time.Duration, and then update the value with seconds as an int
+		dataMap, ok := data.(map[string]interface{})
+		if !ok {
+			return nil, errors.New("data is not a map[string]interface{}")
+		}
+
+		durStr, ok := dataMap["authrefreshinterval"].(string)
+		if !ok {
+			return nil, errors.New("authrefreshinterval is not a string")
+		}
+
+		// Sanitize the input to guarantee we have a unit
+		suffixes := []string{"s", "m", "h", "d"}
+		hasSuffix := false
+		for _, suffix := range suffixes {
+			if strings.HasSuffix(durStr, suffix) {
+				hasSuffix = true
+				break
+			}
+		}
+		if !hasSuffix {
+			log.Warningf("'Xrootd.AuthRefreshInterval' does not have a time unit (s, m, h, d). Interpreting as seconds")
+			durStr = durStr + "s"
+		}
+
+		duration, err := time.ParseDuration(durStr)
+		if err != nil {
+			return nil, err
+		}
+
+		if duration < time.Second {
+			log.Warningf("'Xrootd.AuthRefreshInterval' appears as less than a second. Using fallback of 5m")
+			duration = time.Minute * 5
+		}
+
+		dataMap["authrefreshinterval"] = int(duration.Seconds())
+		return data, nil
+	}
+}
+
+// A wrapper to combine multiple decoder hook functions for XRootD cfg unmarshalling
+func combinedDecodeHookFunc() mapstructure.DecodeHookFuncType {
+	return func(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+		data, err := authRefreshStrToSecondsHookFunc()(f, t, data)
+		if err != nil {
+			return data, err
+		}
+		return server_utils.StringListToCapsHookFunc()(f, t, data)
+	}
+}
+
+func ConfigXrootd(ctx context.Context, isOrigin bool) (string, error) {
 	gid, err := config.GetDaemonGID()
 	if err != nil {
 		return "", err
@@ -614,7 +676,7 @@ func ConfigXrootd(ctx context.Context, isOrigin bool) (string, error) {
 
 	var xrdConfig XrootdConfig
 	xrdConfig.Xrootd.LocalMonitoringPort = -1
-	if err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(server_utils.StringListToCapsHookFunc())); err != nil {
+	if err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc())); err != nil {
 		return "", errors.Wrap(err, "failed to unmarshal xrootd config")
 	}
 

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -779,6 +779,15 @@ func TestAuthIntervalUnmarshal(t *testing.T) {
 		assert.Equal(t, 300, xrdConfig.Xrootd.AuthRefreshInterval)
 	})
 
+	t.Run("test-hours-to-seconds", func(t *testing.T) {
+		viper.Reset()
+		var xrdConfig XrootdConfig
+		viper.Set("Xrootd.AuthRefreshInterval", "24h")
+		err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc()))
+		assert.NoError(t, err)
+		assert.Equal(t, 86400, xrdConfig.Xrootd.AuthRefreshInterval)
+	})
+
 	t.Run("test-seconds-to-seconds", func(t *testing.T) {
 		viper.Reset()
 		var xrdConfig XrootdConfig

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -801,10 +801,10 @@ func TestAuthIntervalUnmarshal(t *testing.T) {
 	t.Run("test-no-suffix-to-seconds", func(t *testing.T) {
 		viper.Reset()
 		var xrdConfig XrootdConfig
-		viper.Set("Xrootd.AuthRefreshInterval", "5")
+		viper.Set("Xrootd.AuthRefreshInterval", "99")
 		err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc()))
 		assert.NoError(t, err)
-		assert.Equal(t, 5, xrdConfig.Xrootd.AuthRefreshInterval)
+		assert.Equal(t, 99, xrdConfig.Xrootd.AuthRefreshInterval)
 	})
 
 	t.Run("test-less-than-second", func(t *testing.T) {

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -782,10 +782,20 @@ func TestAuthIntervalUnmarshal(t *testing.T) {
 	t.Run("test-seconds-to-seconds", func(t *testing.T) {
 		viper.Reset()
 		var xrdConfig XrootdConfig
-		viper.Set("Xrootd.AuthRefreshInterval", "5s")
+		viper.Set("Xrootd.AuthRefreshInterval", "100s")
 		err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc()))
 		assert.NoError(t, err)
-		assert.Equal(t, 5, xrdConfig.Xrootd.AuthRefreshInterval)
+		assert.Equal(t, 100, xrdConfig.Xrootd.AuthRefreshInterval)
+	})
+
+	t.Run("test-less-than-60s", func(t *testing.T) {
+		viper.Reset()
+		var xrdConfig XrootdConfig
+		viper.Set("Xrootd.AuthRefreshInterval", "10")
+		err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc()))
+		assert.NoError(t, err)
+		// Should fall back to 5m, or 300s
+		assert.Equal(t, 300, xrdConfig.Xrootd.AuthRefreshInterval)
 	})
 
 	t.Run("test-no-suffix-to-seconds", func(t *testing.T) {

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -766,5 +766,44 @@ func TestCopyCertificates(t *testing.T) {
 	require.NoError(t, err)
 	log.Debug("Will wait to see if the new certs are copied")
 	assert.True(t, waitForCopy())
+}
+
+func TestAuthIntervalUnmarshal(t *testing.T) {
+	defer viper.Reset()
+	t.Run("test-minutes-to-seconds", func(t *testing.T) {
+		viper.Reset()
+		var xrdConfig XrootdConfig
+		viper.Set("Xrootd.AuthRefreshInterval", "5m")
+		err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc()))
+		assert.NoError(t, err)
+		assert.Equal(t, 300, xrdConfig.Xrootd.AuthRefreshInterval)
+	})
+
+	t.Run("test-seconds-to-seconds", func(t *testing.T) {
+		viper.Reset()
+		var xrdConfig XrootdConfig
+		viper.Set("Xrootd.AuthRefreshInterval", "5s")
+		err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc()))
+		assert.NoError(t, err)
+		assert.Equal(t, 5, xrdConfig.Xrootd.AuthRefreshInterval)
+	})
+
+	t.Run("test-no-suffix-to-seconds", func(t *testing.T) {
+		viper.Reset()
+		var xrdConfig XrootdConfig
+		viper.Set("Xrootd.AuthRefreshInterval", "5")
+		err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc()))
+		assert.NoError(t, err)
+		assert.Equal(t, 5, xrdConfig.Xrootd.AuthRefreshInterval)
+	})
+
+	t.Run("test-less-than-second", func(t *testing.T) {
+		viper.Reset()
+		var xrdConfig XrootdConfig
+		viper.Set("Xrootd.AuthRefreshInterval", "0.5s")
+		err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc()))
+		assert.NoError(t, err)
+		assert.Equal(t, 300, xrdConfig.Xrootd.AuthRefreshInterval)
+	})
 
 }


### PR DESCRIPTION
Caches take too long to pull permissions changes from upstream origins (12hours, from Xrootd's default `acc.authrefresh 43200`). This sets the default refresh time to 5m and adds a mechanism for admin to adjust as needed.

Closes #1335 