### PR TITLE
Fix tests for GeoIP overrides

### DIFF
--- a/director/resources/geoip_overrides.yaml
+++ b/director/resources/geoip_overrides.yaml
@@ -50,7 +50,7 @@ GeoIPOverrides:
       Lat: 123.4
       Long: 987.6
   # Valid IPv6
-  - IP: "FD00::FAB2/112"
+  - IP: "FD00::/112"
     Coordinate:
       Lat: 43.073904
       Long: -89.384859

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -87,7 +87,9 @@ func TestCheckOverrides(t *testing.T) {
 		}
 
 		addr := net.ParseIP("192.168.0.1")
+		require.NotNil(t, addr)
 		coordinate := checkOverrides(addr)
+		require.NotNil(t, coordinate)
 		require.Equal(t, expectedCoordinate.Lat, coordinate.Lat)
 		require.Equal(t, expectedCoordinate.Long, coordinate.Long)
 	})
@@ -100,7 +102,9 @@ func TestCheckOverrides(t *testing.T) {
 		}
 
 		addr := net.ParseIP("10.0.0.136")
+		require.NotNil(t, addr)
 		coordinate := checkOverrides(addr)
+		require.NotNil(t, coordinate)
 		require.Equal(t, expectedCoordinate.Lat, coordinate.Lat)
 		require.Equal(t, expectedCoordinate.Long, coordinate.Long)
 	})
@@ -112,7 +116,9 @@ func TestCheckOverrides(t *testing.T) {
 		}
 
 		addr := net.ParseIP("FC00::0001")
+		require.NotNil(t, addr)
 		coordinate := checkOverrides(addr)
+		require.NotNil(t, coordinate)
 		require.Equal(t, expectedCoordinate.Lat, coordinate.Lat)
 		require.Equal(t, expectedCoordinate.Long, coordinate.Long)
 	})
@@ -124,7 +130,9 @@ func TestCheckOverrides(t *testing.T) {
 		}
 
 		addr := net.ParseIP("FD00::FA1B")
+		assert.NotNil(t, addr)
 		coordinate := checkOverrides(addr)
+		require.NotNil(t, coordinate)
 		require.Equal(t, expectedCoordinate.Lat, coordinate.Lat)
 		require.Equal(t, expectedCoordinate.Long, coordinate.Long)
 	})


### PR DESCRIPTION
The tests didn't catch a bad IPV6 CIDR block that I passed as "this should be good". The updates fix the tests and fix the IPV6 address.