### PR TITLE
Add bearer token config to HTTP backends for Globus compat

### DIFF
--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -907,6 +907,17 @@ type: string
 default: none
 components: ["origin"]
 ---
+name: Origin.HttpAuthTokenFile
+description: |+
+  When set, all requests from the origin to the http backend will include the contents of the file as a bearer token in the
+  Authorization header.
+
+  If the origin backend is configured with the `globus` storage type, any value set here will be overridden with the filepath to
+  the first file ending in `.tok` found in the $(Origin.GlobusConfigLocation)/tokens directory
+type: filename
+default: none
+components: ["origin"]
+---
 name: Origin.XRootServiceUrl
 description: |+
  When the origin is configured to export another XRootD storage backend by setting `Origin.StorageType = xroot`, the `XRootServiceUrl`

--- a/origin/globus.go
+++ b/origin/globus.go
@@ -58,11 +58,11 @@ type globusExportUI struct {
 }
 
 const (
-	globusInactive  = "Inactive"
-	globusActivated = "Activated"
+	GlobusInactive  = "Inactive"
+	GlobusActivated = "Activated"
 )
 
-const globusTokenFileExt = ".tok" // File extension for caching Globus access token
+const GlobusTokenFileExt = ".tok" // File extension for caching Globus access token
 
 var (
 	// An in-memory map-struct to keep Globus collections information with key being the collection UUID.
@@ -104,7 +104,7 @@ func InitGlobusBackend(exps []server_utils.OriginExport) error {
 		globusEsp := globusExport{
 			DisplayName:      esp.GlobusCollectionName,
 			FederationPrefix: esp.FederationPrefix,
-			Status:           globusInactive,
+			Status:           GlobusInactive,
 			Description:      "Server start",
 		}
 		// We check the origin db and see if we already have the refresh token in-place
@@ -150,7 +150,7 @@ func InitGlobusBackend(exps []server_utils.OriginExport) error {
 			globusEsp.DisplayName = col.Name
 		}
 
-		globusEsp.Status = globusActivated
+		globusEsp.Status = GlobusActivated
 		globusEsp.Token = collectionToken
 		globusEsp.HttpsServer = col.ServerURL
 		globusEsp.Description = "Activated with cached credentials"
@@ -167,7 +167,7 @@ func isExportActivated(fedPrefix string) (ok bool) {
 	defer globusExportsMutex.RUnlock()
 	for _, exp := range globusExports {
 		if exp.FederationPrefix == fedPrefix {
-			return exp.Status == globusActivated
+			return exp.Status == GlobusActivated
 		}
 	}
 	return false
@@ -185,7 +185,7 @@ func doGlobusTokenRefresh() error {
 			globusExportsMutex.Lock()
 			defer globusExportsMutex.Unlock()
 			// We can't refresh exports that are never activated
-			if exp.Status == globusInactive {
+			if exp.Status == GlobusInactive {
 				return nil
 			}
 			newTok, err := refreshGlobusToken(cid, exp.Token)
@@ -194,7 +194,7 @@ func doGlobusTokenRefresh() error {
 				newTok, err = refreshGlobusToken(cid, exp.Token)
 				if err != nil {
 					log.Errorf("Failed to retry refreshing Globus token for collection %s with name %s: %v", cid, exp.DisplayName, err)
-					exp.Status = globusInactive
+					exp.Status = GlobusInactive
 					exp.Description = fmt.Sprintf("Failed to refresh token: %v", err)
 					return err
 				}
@@ -242,7 +242,7 @@ func GetGlobusExportsValues(activeOnly bool) []globusExport {
 	exps := []globusExport{}
 	for _, val := range globusExports {
 		if activeOnly {
-			if val.Status == globusActivated {
+			if val.Status == GlobusActivated {
 				exps = append(exps, *val)
 			} else {
 				continue

--- a/origin/globus_client.go
+++ b/origin/globus_client.go
@@ -454,7 +454,7 @@ func handleGlobusCallback(ctx *gin.Context) {
 			log.Infof("Updating existing Globus export %s with new token", cid)
 			globusExports[cid].HttpsServer = transferJSON.HttpsServer
 			globusExports[cid].Token = collectionToken
-			globusExports[cid].Status = globusActivated
+			globusExports[cid].Status = GlobusActivated
 			globusExports[cid].Description = ""
 			if globusExports[cid].DisplayName == "" || globusExports[cid].DisplayName == cid {
 				globusExports[cid].DisplayName = transferJSON.DisplayName
@@ -567,8 +567,8 @@ func persistAccessToken(collectionID string, token *oauth2.Token) error {
 	if filepath.Clean(tokBase) == "" {
 		return fmt.Errorf("failed to update Globus token: Origin.GlobusTokenLocation is not a valid path: %s", tokBase)
 	}
-	tokFileName := filepath.Join(tokBase, collectionID+globusTokenFileExt)
-	tmpTokFile, err := os.CreateTemp(tokBase, collectionID+globusTokenFileExt)
+	tokFileName := filepath.Join(tokBase, collectionID+GlobusTokenFileExt)
+	tmpTokFile, err := os.CreateTemp(tokBase, collectionID+GlobusTokenFileExt)
 	if err != nil {
 		return errors.Wrap(err, "failed to update Globus token: unable to create a temporary Globus token file")
 	}

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -186,6 +186,7 @@ var (
 	Origin_GlobusCollectionID = StringParam{"Origin.GlobusCollectionID"}
 	Origin_GlobusCollectionName = StringParam{"Origin.GlobusCollectionName"}
 	Origin_GlobusConfigLocation = StringParam{"Origin.GlobusConfigLocation"}
+	Origin_HttpAuthTokenFile = StringParam{"Origin.HttpAuthTokenFile"}
 	Origin_HttpServiceUrl = StringParam{"Origin.HttpServiceUrl"}
 	Origin_Mode = StringParam{"Origin.Mode"}
 	Origin_NamespacePrefix = StringParam{"Origin.NamespacePrefix"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -191,6 +191,7 @@ type Config struct {
 		GlobusCollectionID string `mapstructure:"globuscollectionid"`
 		GlobusCollectionName string `mapstructure:"globuscollectionname"`
 		GlobusConfigLocation string `mapstructure:"globusconfiglocation"`
+		HttpAuthTokenFile string `mapstructure:"httpauthtokenfile"`
 		HttpServiceUrl string `mapstructure:"httpserviceurl"`
 		Mode string `mapstructure:"mode"`
 		Multiuser bool `mapstructure:"multiuser"`
@@ -478,6 +479,7 @@ type configWithType struct {
 		GlobusCollectionID struct { Type string; Value string }
 		GlobusCollectionName struct { Type string; Value string }
 		GlobusConfigLocation struct { Type string; Value string }
+		HttpAuthTokenFile struct { Type string; Value string }
 		HttpServiceUrl struct { Type string; Value string }
 		Mode struct { Type string; Value string }
 		Multiuser struct { Type string; Value bool }

--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -81,6 +81,9 @@ ofs.osslib libXrdHTTPServer.so
 httpserver.url_base {{.Origin.HttpServiceUrl}}
 httpserver.storage_prefix {{.Origin.FederationPrefix}}
 httpserver.trace debug info warning
+{{if .Origin.HttpAuthTokenFile -}}
+httpserver.token_file {{.Origin.HttpAuthTokenFile}}
+{{- end}}
 {{else if eq .Origin.StorageType "xroot"}}
 # This "origin" is actually acting like a cache that doesn't cache anything by pointing
 # to another xrootd server. It allows us to plug bespoke XRootD servers into the federation

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -91,6 +91,7 @@ type (
 		CalculatedPort    string
 		FederationPrefix  string
 		HttpServiceUrl    string
+		HttpAuthTokenFile string
 		XRootServiceUrl   string
 		RunLocation       string
 		StorageType       string
@@ -669,6 +670,31 @@ func ConfigXrootd(ctx context.Context, isOrigin bool) (string, error) {
 				xrdConfig.Origin.HttpServiceUrl = globusExports[0].HttpsServer
 			}
 			xrdConfig.Origin.FederationPrefix = globusExports[0].FederationPrefix
+
+			if globusExports[0].Status == origin.GlobusActivated {
+				// Check the contents of $(Origin.GlobusConfigLocation)/tokens and grab the first `.tok` file
+				// Feed this to the HTTP Plugin as the auth token file
+				tknFldr := filepath.Join(param.Origin_GlobusConfigLocation.GetString(), "tokens")
+				tokenFiles, err := os.ReadDir(tknFldr)
+				if err != nil {
+					return "", errors.Wrap(err, "failed to read Globus token directory for token files")
+				}
+
+				if len(tokenFiles) == 0 {
+					return "", errors.Errorf("failed to find a Globus auth token in %s", tknFldr)
+				}
+				var tFileName string
+				for _, tFile := range tokenFiles {
+					if ext := filepath.Ext(tFile.Name()); ext == origin.GlobusTokenFileExt {
+						tFileName = tFile.Name()
+						break
+					}
+				}
+				if tFileName == "" {
+					return "", errors.Errorf("no Globus auth tokens ending in %s could be found in %s", origin.GlobusTokenFileExt, tknFldr)
+				}
+				xrdConfig.Origin.HttpAuthTokenFile = filepath.Join(param.Origin_GlobusConfigLocation.GetString(), "tokens", tFileName)
+			}
 		}
 	}
 
@@ -695,7 +721,7 @@ func ConfigXrootd(ctx context.Context, isOrigin bool) (string, error) {
 		if xrdConfig.Origin.Multiuser {
 			ok, err := config.HasMultiuserCaps()
 			if err != nil {
-				return "", errors.Wrap(err, "Failed to determine if the origin can run in multiuser mode")
+				return "", errors.Wrap(err, "failed to determine if the origin can run in multiuser mode")
 			}
 			if !ok {
 				return "", errors.New("Origin.Multiuser is set to `true` but the command was run without sufficient privilege; was it launched as root?")


### PR DESCRIPTION
This adds a generic config for adding an bearer token to the `Authorization` header on requests from the origin to an http backend. In particular, this is needed for Globus collections.

Closes #1413 