### PR TITLE
Fix golangci linter on imports

### DIFF
--- a/.github/workflows/pre-commit-linter.yml
+++ b/.github/workflows/pre-commit-linter.yml
@@ -36,11 +36,9 @@ jobs:
 
       # We still run this so that we can get the nice hint of gofmt issues inline
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
-          skip-pkg-cache: true
-          skip-build-cache: true
 
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1

--- a/director/prom_query_test.go
+++ b/director/prom_query_test.go
@@ -26,10 +26,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pelicanplatform/pelican/param"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/param"
 )
 
 var (


### PR DESCRIPTION
Our linter GHA on the main branch is failing, and this PR addressed the issue by fixing the uncaught import error.