### PR TITLE
Add OSDF Institution Count Metric Collection

### DIFF
--- a/launchers/registry_serve.go
+++ b/launchers/registry_serve.go
@@ -62,6 +62,9 @@ func RegistryServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group
 
 		// Checks topology for updates every 10 minutes
 		go registry.PeriodicTopologyReload(ctx)
+
+		// Launch Federation Institutions Metrics
+		registry.LaunchFederationInstitutionMetrics(ctx, egrp)
 	}
 
 	rootRouterGroup := engine.Group("/")

--- a/launchers/registry_serve.go
+++ b/launchers/registry_serve.go
@@ -62,9 +62,6 @@ func RegistryServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group
 
 		// Checks topology for updates every 10 minutes
 		go registry.PeriodicTopologyReload(ctx)
-
-		// Launch Federation Institutions Metrics
-		registry.LaunchFederationInstitutionMetrics(ctx, egrp)
 	}
 
 	rootRouterGroup := engine.Group("/")
@@ -75,8 +72,8 @@ func RegistryServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group
 		return err
 	}
 
-	// launch namespace prometheus metric
-	registry.LaunchNamespaceMetrics(ctx, egrp)
+	// Launch registry prometheus metrics
+	registry.LaunchRegistryMetrics(ctx, egrp)
 
 	egrp.Go(func() error {
 		<-ctx.Done()

--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -12,5 +12,5 @@ var PelicanRegistryFederationNamespaces = promauto.NewGaugeVec(prometheus.GaugeO
 
 var PelicanOSDFInstitutions = promauto.NewGauge(prometheus.GaugeOpts{
 	Name: "pelican_osdf_institution_count",
-	Help: "Total number of participating institutions in OSDF mode.",
+	Help: "Total number of participating institutions.",
 })

--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -12,5 +12,5 @@ var PelicanRegistryFederationNamespaces = promauto.NewGaugeVec(prometheus.GaugeO
 
 var PelicanOSDFInstitutions = promauto.NewGauge(prometheus.GaugeOpts{
 	Name: "pelican_osdf_institution_count",
-	Help: "Total number of participating institutions.",
+	Help: "Total number of contributing institutions",
 })

--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -9,3 +9,8 @@ var PelicanRegistryFederationNamespaces = promauto.NewGaugeVec(prometheus.GaugeO
 	Name: "pelican_registry_federation_namespaces",
 	Help: "The number of federation namespace associated with a public key, excluding server namespaces, in the registry.",
 }, []string{"status"})
+
+var PelicanOSDFInstitutions = promauto.NewGauge(prometheus.GaugeOpts{
+	Name: "pelican_osdf_institution_count",
+	Help: "Total number of participating institutions in OSDF mode.",
+})

--- a/registry/registry_api.go
+++ b/registry/registry_api.go
@@ -97,7 +97,7 @@ func LaunchFederationInstitutionMetrics(ctx context.Context, egrp *errgroup.Grou
 						continue
 					}
 					institutionCount = len(institutionsList)
-				case param.StringParam: // pram.Registry_InstitutionsUrl
+				case param.StringParam: // param.Registry_InstitutionsUrl
 					url := institutions.GetString()
 					if len(url) != 0 {
 						log.Warningln("Failed to update institution count metric.")

--- a/registry/registry_api.go
+++ b/registry/registry_api.go
@@ -8,6 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
@@ -30,7 +31,32 @@ func getCountofFederationNamespacesByStatus(status server_structs.RegistrationSt
 	return len(namespaces), nil
 }
 
-func LaunchNamespaceMetrics(ctx context.Context, egrp *errgroup.Group) {
+func updateOSDFInstitutionCountMetric() error {
+	institutions := []registrationFieldOption{}
+	var institutionCount int
+	if err := param.Registry_Institutions.Unmarshal(&institutions); err != nil {
+		log.Warning("Failed to unmarshal institutions.", err.Error())
+		return err
+	}
+
+	if param.Registry_InstitutionsUrl.GetString() != "" {
+		if len(institutions) > 0 {
+			institutionCount = len(institutions)
+		} else {
+			institutions, err := getCachedOptions(param.Registry_InstitutionsUrl.GetString(), ttlcache.DefaultTTL)
+			if err != nil {
+				log.Warningln("Failed to update institution count metric.", err.Error())
+				return err
+			}
+			institutionCount = len(institutions)
+		}
+	}
+
+	metrics.PelicanOSDFInstitutions.Set(float64(institutionCount))
+	return nil
+}
+
+func LaunchRegistryMetrics(ctx context.Context, egrp *errgroup.Group) {
 	egrp.Go(func() error {
 		ticker := time.NewTicker(time.Second * 15)
 		defer ticker.Stop()
@@ -40,8 +66,14 @@ func LaunchNamespaceMetrics(ctx context.Context, egrp *errgroup.Group) {
 			case <-ctx.Done():
 				return nil
 			case <-ticker.C:
-				// get the amount of approved, denied, and pending namespaces
+				if config.GetPreferredPrefix() == config.OsdfPrefix {
+					if err := updateOSDFInstitutionCountMetric(); err != nil {
+						log.Warningln("Failed to update OSDF institution count metric.", err.Error())
+						continue
+					}
+				}
 
+				// get the amount of approved, denied, and pending namespaces
 				numApproved, err := getCountofFederationNamespacesByStatus(server_structs.RegApproved)
 				if err != nil {
 					log.Warningln("Failed to update namespace metric for approved namespaces.", err.Error())
@@ -62,42 +94,6 @@ func LaunchNamespaceMetrics(ctx context.Context, egrp *errgroup.Group) {
 					continue
 				}
 				metrics.PelicanRegistryFederationNamespaces.WithLabelValues(server_structs.RegPending.LowerString()).Set(float64(numPending))
-			}
-		}
-	})
-}
-
-func LaunchFederationInstitutionMetrics(ctx context.Context, egrp *errgroup.Group) {
-	egrp.Go(func() error {
-		ticker := time.NewTicker(time.Second * 15)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return nil
-			case <-ticker.C:
-				institutions := []registrationFieldOption{}
-				var institutionCount int
-				if err := param.Registry_Institutions.Unmarshal(&institutions); err != nil {
-					log.Warning("Failed to unmarshal institutions.", err.Error())
-					return nil
-				}
-
-				if param.Registry_InstitutionsUrl.GetString() != "" {
-					if len(institutions) > 0 {
-						log.Warning("Registry.Institutions and Registry.InstitutionsUrl are both set. Registry.InstitutionsUrl is ignored")
-						institutionCount = len(institutions)
-					} else {
-						institutions, err := getCachedOptions(param.Registry_InstitutionsUrl.GetString(), ttlcache.DefaultTTL)
-						if err != nil {
-							log.Warningln("Failed to update institution count metric.", err.Error())
-							continue
-						}
-						institutionCount = len(institutions)
-					}
-				}
-
-				metrics.PelicanOSDFInstitutions.Set(float64(institutionCount))
 			}
 		}
 	})

--- a/registry/registry_api.go
+++ b/registry/registry_api.go
@@ -35,7 +35,7 @@ func updateOSDFInstitutionCountMetric() error {
 	institutions := []registrationFieldOption{}
 	var institutionCount int
 	if err := param.Registry_Institutions.Unmarshal(&institutions); err != nil {
-		log.Warning("Failed to unmarshal institutions.", err.Error())
+		log.Warning("Failed to update institution count metric: failed to unmarshal institutions.", err.Error())
 		return err
 	}
 


### PR DESCRIPTION
This PR implements a metric for tracking the number of participating institutions in OSDF mode. It includes:
- A goroutine that periodically collects and updates the institution count metric.
- Support for fetching institutions from both configuration values and a URL.
- Integration with Prometheus to expose the metric as `pelican_osdf_institution_count`.

This PR addresses the issue #1424