### PR TITLE
Removed logging shoveler message at debug level and fix empty version

### DIFF
--- a/metrics/shoveler.go
+++ b/metrics/shoveler.go
@@ -35,6 +35,7 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 )
 
@@ -51,6 +52,12 @@ var (
 )
 
 func configShoveler(c *shoveler.Config) error {
+	// Use Pelican build info for Shoveler
+	shoveler.ShovelerVersion = "Pelican-" + config.GetVersion()
+	shoveler.ShovelerBuiltBy = config.GetBuiltBy()
+	shoveler.ShovelerDate = config.GetBuiltDate()
+	shoveler.ShovelerCommit = config.GetBuiltCommit()
+
 	c.MQ = param.Shoveler_MessageQueueProtocol.GetString()
 	if c.MQ != "amqp" && c.MQ != "stomp" {
 		return fmt.Errorf("Bad config for Shoveler.MessageQueueProtocol. Expected \"amqp\" or \"stomp\", got %s", c.MQ)

--- a/metrics/shoveler.go
+++ b/metrics/shoveler.go
@@ -258,7 +258,7 @@ func LaunchShoveler(ctx context.Context, egrp *errgroup.Group, metricsPort int) 
 		if err != nil {
 			shovelerLogger.Errorln("Error closing UDP connection:", err)
 		} else {
-			log.Infoln("Xrootd monitoring shoveler has been stopped")
+			shovelerLogger.Infoln("Xrootd monitoring shoveler has been stopped")
 		}
 		return nil
 	})
@@ -290,7 +290,6 @@ func LaunchShoveler(ctx context.Context, egrp *errgroup.Group, metricsPort int) 
 			}
 
 			// Send the message to the queue
-			shovelerLogger.Debugln("Sending msg:", string(msg))
 			cq.Enqueue(msg)
 
 			// Send to the UDP destinations


### PR DESCRIPTION
As @bbockelm reported, the current logging setup in the shoveler logs every message it sent to the MQ, which causes lots of noises at the debug level. This PR removed logging such messages.

Also, currently the `version` field in the message sent to MQ is empty, due to the fact that we shoveler is now part of Pelican code. This PR set the related shoveler build info with that from Pelican