### PR TITLE
Add two Prometheus metrics for director `stat` queries

### DIFF
--- a/director/monitor.go
+++ b/director/monitor.go
@@ -223,8 +223,8 @@ func LaunchPeriodicDirectorTest(ctx context.Context, serverAd server_structs.Ser
 									"server_name":    serverName,
 									"server_web_url": serverWebUrl,
 									"server_type":    string(serverAd.Type),
-									"status":         string(metrics.FTXTestSucceeded),
-									"report_status":  string(metrics.FTXTestFailed),
+									"status":         string(metrics.MetricSucceeded),
+									"report_status":  string(metrics.MetricFailed),
 								},
 							).Inc()
 							// Successfully report to the origin/cache via the legacy endpoint
@@ -234,8 +234,8 @@ func LaunchPeriodicDirectorTest(ctx context.Context, serverAd server_structs.Ser
 									"server_name":    serverName,
 									"server_web_url": serverWebUrl,
 									"server_type":    string(serverAd.Type),
-									"status":         string(metrics.FTXTestSucceeded),
-									"report_status":  string(metrics.FTXTestSucceeded),
+									"status":         string(metrics.MetricSucceeded),
+									"report_status":  string(metrics.MetricSucceeded),
 								},
 							).Inc()
 						}
@@ -247,8 +247,8 @@ func LaunchPeriodicDirectorTest(ctx context.Context, serverAd server_structs.Ser
 								"server_name":    serverName,
 								"server_web_url": serverWebUrl,
 								"server_type":    string(serverAd.Type),
-								"status":         string(metrics.FTXTestSucceeded),
-								"report_status":  string(metrics.FTXTestFailed),
+								"status":         string(metrics.MetricSucceeded),
+								"report_status":  string(metrics.MetricFailed),
 							},
 						).Inc()
 					}
@@ -259,8 +259,8 @@ func LaunchPeriodicDirectorTest(ctx context.Context, serverAd server_structs.Ser
 							"server_name":    serverName,
 							"server_web_url": serverWebUrl,
 							"server_type":    string(serverAd.Type),
-							"status":         string(metrics.FTXTestSucceeded),
-							"report_status":  string(metrics.FTXTestSucceeded),
+							"status":         string(metrics.MetricSucceeded),
+							"report_status":  string(metrics.MetricSucceeded),
 						},
 					).Inc()
 				}
@@ -301,8 +301,8 @@ func LaunchPeriodicDirectorTest(ctx context.Context, serverAd server_structs.Ser
 									"server_name":    serverName,
 									"server_web_url": serverWebUrl,
 									"server_type":    string(serverAd.Type),
-									"status":         string(metrics.FTXTestFailed),
-									"report_status":  string(metrics.FTXTestFailed),
+									"status":         string(metrics.MetricFailed),
+									"report_status":  string(metrics.MetricFailed),
 								},
 							).Inc()
 							// Successfully report to the origin/cache via the legacy endpoint
@@ -312,8 +312,8 @@ func LaunchPeriodicDirectorTest(ctx context.Context, serverAd server_structs.Ser
 									"server_name":    serverName,
 									"server_web_url": serverWebUrl,
 									"server_type":    string(serverAd.Type),
-									"status":         string(metrics.FTXTestFailed),
-									"report_status":  string(metrics.FTXTestSucceeded),
+									"status":         string(metrics.MetricFailed),
+									"report_status":  string(metrics.MetricSucceeded),
 								},
 							).Inc()
 						}
@@ -325,8 +325,8 @@ func LaunchPeriodicDirectorTest(ctx context.Context, serverAd server_structs.Ser
 								"server_name":    serverName,
 								"server_web_url": serverWebUrl,
 								"server_type":    string(serverAd.Type),
-								"status":         string(metrics.FTXTestFailed),
-								"report_status":  string(metrics.FTXTestFailed),
+								"status":         string(metrics.MetricFailed),
+								"report_status":  string(metrics.MetricFailed),
 							},
 						).Inc()
 					}
@@ -338,8 +338,8 @@ func LaunchPeriodicDirectorTest(ctx context.Context, serverAd server_structs.Ser
 							"server_name":    serverName,
 							"server_web_url": serverWebUrl,
 							"server_type":    string(serverAd.Type),
-							"status":         string(metrics.FTXTestFailed),
-							"report_status":  string(metrics.FTXTestSucceeded),
+							"status":         string(metrics.MetricFailed),
+							"report_status":  string(metrics.MetricSucceeded),
 						},
 					).Inc()
 				}

--- a/metrics/director.go
+++ b/metrics/director.go
@@ -24,12 +24,21 @@ import (
 )
 
 type (
-	DirectorFTXTestStatus string
+	MetricSimpleStatus    string
+	DirectorFTXTestStatus MetricSimpleStatus
+	DirectorStatResult    string
 )
 
 const (
-	FTXTestSucceeded DirectorFTXTestStatus = "Succeeded"
-	FTXTestFailed    DirectorFTXTestStatus = "Failed"
+	MetricSucceeded MetricSimpleStatus = "Succeeded"
+	MetricFailed    MetricSimpleStatus = "Failed"
+
+	StatSucceeded DirectorStatResult = "Succeeded"
+	StatNotFound  DirectorStatResult = "NotFound"
+	StatTimeout   DirectorStatResult = "Timeout"
+	StatCancelled DirectorStatResult = "Cancelled"
+	StatForbidden DirectorStatResult = "Forbidden"
+	StatUnkownErr DirectorStatResult = "UnknownErr"
 )
 
 var (
@@ -62,4 +71,14 @@ var (
 		Name: "pelican_director_ttl_cache",
 		Help: "The statistics of various TTL caches",
 	}, []string{"name", "type"}) // name: serverAds, jwks; type: evictions, insersions, hits, misses, total
+
+	PelicanDirectorStatActive = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pelican_director_stat_active",
+		Help: "The active stat queries in the director",
+	}, []string{"server_name", "server_url", "server_type"})
+
+	PelicanDirectorStatTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pelican_director_stat_total",
+		Help: "The total stat queries the director issues. The status can be Succeeded, Cancelled, Timeout, Forbidden, or UnknownErr",
+	}, []string{"server_name", "server_url", "server_type", "result"}) // status: see enums for DirectorStatResult
 )


### PR DESCRIPTION
Closes #1431 

To test, first spin up your director. If you'd like to also test a local file, then you'll need to spin up your local federation (director, registry, origin)
* Get the test file through the origin: `curl -k -o /dev/null https://localhost:8444/api/v1.0/director/ospool/uc-shared/public/OSG-Staff/validation/test.txt`. Assuming that your local director runs at `8444`
* Check the Prometheus `/metric` endpoint to confirm the value. Login to your director web UI and go to `https://localhost:8444/metrics`. You should see two metrics named `pelican_director_stat_active` and `pelican_director_stat_total` where the value of `pelican_director_stat_total` should be 1 (for the test file you just queried)