### PR TITLE
Moved utils.GetTopologyJSON and related structs to server_utils package

### DIFF
--- a/director/advertise.go
+++ b/director/advertise.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
-	"github.com/pelicanplatform/pelican/utils"
+	"github.com/pelicanplatform/pelican/server_utils"
 )
 
 // Consolite two ServerAds that share the same ServerAd.URL. For all but the capability fields,
@@ -54,7 +54,7 @@ func consolidateDupServerAd(newAd, existingAd server_structs.ServerAd) server_st
 
 // Takes in server information from topology and handles converting the necessary bits into a new Pelican
 // ServerAd.
-func parseServerAdFromTopology(server utils.Server, serverType server_structs.ServerType, caps server_structs.Capabilities) server_structs.ServerAd {
+func parseServerAdFromTopology(server server_utils.Server, serverType server_structs.ServerType, caps server_structs.Capabilities) server_structs.ServerAd {
 	serverAd := server_structs.ServerAd{}
 	serverAd.Type = serverType
 	serverAd.Name = server.Resource
@@ -123,7 +123,7 @@ func parseServerAdFromTopology(server utils.Server, serverType server_structs.Se
 //
 // The excludeDowned is a list of running OSDF topology servers
 // The includeDowned is a list of running and downed OSDF topology servers
-func findDownedTopologyCache(excludeDowned, includeDowned []utils.Server) (caches []utils.Server) {
+func findDownedTopologyCache(excludeDowned, includeDowned []server_utils.Server) (caches []server_utils.Server) {
 	for _, included := range includeDowned {
 		found := false
 		for _, excluded := range excludeDowned {
@@ -140,7 +140,7 @@ func findDownedTopologyCache(excludeDowned, includeDowned []utils.Server) (cache
 }
 
 // Update filteredServers based on topology downtime
-func updateDowntimeFromTopology(excludedNss, includedNss *utils.TopologyNamespacesJSON) {
+func updateDowntimeFromTopology(excludedNss, includedNss *server_utils.TopologyNamespacesJSON) {
 	downedCaches := findDownedTopologyCache(excludedNss.Caches, includedNss.Caches)
 
 	filteredServersMutex.Lock()
@@ -165,13 +165,13 @@ func updateDowntimeFromTopology(excludedNss, includedNss *utils.TopologyNamespac
 
 // Populate internal cache with origin/cache ads
 func AdvertiseOSDF(ctx context.Context) error {
-	namespaces, err := utils.GetTopologyJSON(ctx, false)
+	namespaces, err := server_utils.GetTopologyJSON(ctx, false)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to get topology JSON")
 	}
 
 	// Second call to fetch all servers (including servers in downtime)
-	includedNss, err := utils.GetTopologyJSON(ctx, true)
+	includedNss, err := server_utils.GetTopologyJSON(ctx, true)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to get topology JSON with server in downtime included (include_downed)")
 	}

--- a/director/advertise_test.go
+++ b/director/advertise_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pelicanplatform/pelican/server_structs"
-	"github.com/pelicanplatform/pelican/utils"
+	"github.com/pelicanplatform/pelican/server_utils"
 )
 
 var (
@@ -98,7 +98,7 @@ func TestConsolidateDupServerAd(t *testing.T) {
 
 func TestParseServerAdFromTopology(t *testing.T) {
 
-	server := utils.Server{
+	server := server_utils.Server{
 		Endpoint:     "http://my-endpoint.com",
 		AuthEndpoint: "https://my-auth-endpoint.com",
 		Resource:     "MY_SERVER",
@@ -302,30 +302,30 @@ func TestAdvertiseOSDF(t *testing.T) {
 }
 
 func TestFindDownedTopologyCache(t *testing.T) {
-	mockTopoCacheA := utils.Server{AuthEndpoint: "cacheA.org:8443", Endpoint: "cacheA.org:8000", Resource: "CACHE_A"}
-	mockTopoCacheB := utils.Server{AuthEndpoint: "cacheB.org:8443", Endpoint: "cacheB.org:8000", Resource: "CACHE_B"}
-	mockTopoCacheC := utils.Server{AuthEndpoint: "cacheC.org:8443", Endpoint: "cacheC.org:8000", Resource: "CACHE_C"}
-	mockTopoCacheD := utils.Server{AuthEndpoint: "cacheD.org:8443", Endpoint: "cacheD.org:8000", Resource: "CACHE_D"}
+	mockTopoCacheA := server_utils.Server{AuthEndpoint: "cacheA.org:8443", Endpoint: "cacheA.org:8000", Resource: "CACHE_A"}
+	mockTopoCacheB := server_utils.Server{AuthEndpoint: "cacheB.org:8443", Endpoint: "cacheB.org:8000", Resource: "CACHE_B"}
+	mockTopoCacheC := server_utils.Server{AuthEndpoint: "cacheC.org:8443", Endpoint: "cacheC.org:8000", Resource: "CACHE_C"}
+	mockTopoCacheD := server_utils.Server{AuthEndpoint: "cacheD.org:8443", Endpoint: "cacheD.org:8000", Resource: "CACHE_D"}
 	t.Run("empty-response", func(t *testing.T) {
 		get := findDownedTopologyCache(
-			[]utils.Server{},
-			[]utils.Server{},
+			[]server_utils.Server{},
+			[]server_utils.Server{},
 		)
 		assert.Empty(t, get)
 	})
 
 	t.Run("no-downed-cache", func(t *testing.T) {
 		get := findDownedTopologyCache(
-			[]utils.Server{mockTopoCacheA, mockTopoCacheB, mockTopoCacheC, mockTopoCacheD},
-			[]utils.Server{mockTopoCacheA, mockTopoCacheB, mockTopoCacheC, mockTopoCacheD},
+			[]server_utils.Server{mockTopoCacheA, mockTopoCacheB, mockTopoCacheC, mockTopoCacheD},
+			[]server_utils.Server{mockTopoCacheA, mockTopoCacheB, mockTopoCacheC, mockTopoCacheD},
 		)
 		assert.Empty(t, get)
 	})
 
 	t.Run("one-downed-cache", func(t *testing.T) {
 		get := findDownedTopologyCache(
-			[]utils.Server{mockTopoCacheA, mockTopoCacheB, mockTopoCacheC},
-			[]utils.Server{mockTopoCacheA, mockTopoCacheB, mockTopoCacheC, mockTopoCacheD},
+			[]server_utils.Server{mockTopoCacheA, mockTopoCacheB, mockTopoCacheC},
+			[]server_utils.Server{mockTopoCacheA, mockTopoCacheB, mockTopoCacheC, mockTopoCacheD},
 		)
 		require.Len(t, get, 1)
 		assert.EqualValues(t, mockTopoCacheD, get[0])
@@ -333,8 +333,8 @@ func TestFindDownedTopologyCache(t *testing.T) {
 
 	t.Run("two-downed-cache", func(t *testing.T) {
 		get := findDownedTopologyCache(
-			[]utils.Server{mockTopoCacheB, mockTopoCacheC},
-			[]utils.Server{mockTopoCacheA, mockTopoCacheB, mockTopoCacheC, mockTopoCacheD},
+			[]server_utils.Server{mockTopoCacheB, mockTopoCacheC},
+			[]server_utils.Server{mockTopoCacheA, mockTopoCacheB, mockTopoCacheC, mockTopoCacheD},
 		)
 		require.Len(t, get, 2)
 		assert.EqualValues(t, mockTopoCacheA, get[0])
@@ -343,23 +343,23 @@ func TestFindDownedTopologyCache(t *testing.T) {
 
 	t.Run("all-downed-cache", func(t *testing.T) {
 		get := findDownedTopologyCache(
-			[]utils.Server{},
-			[]utils.Server{mockTopoCacheA, mockTopoCacheB, mockTopoCacheC, mockTopoCacheD},
+			[]server_utils.Server{},
+			[]server_utils.Server{mockTopoCacheA, mockTopoCacheB, mockTopoCacheC, mockTopoCacheD},
 		)
-		assert.EqualValues(t, []utils.Server{mockTopoCacheA, mockTopoCacheB, mockTopoCacheC, mockTopoCacheD}, get)
+		assert.EqualValues(t, []server_utils.Server{mockTopoCacheA, mockTopoCacheB, mockTopoCacheC, mockTopoCacheD}, get)
 	})
 }
 
 func TestUpdateDowntimeFromTopology(t *testing.T) {
-	mockTopoCacheA := utils.Server{AuthEndpoint: "cacheA.org:8443", Endpoint: "cacheA.org:8000", Resource: "CACHE_A"}
-	mockTopoCacheB := utils.Server{AuthEndpoint: "cacheB.org:8443", Endpoint: "cacheB.org:8000", Resource: "CACHE_B"}
-	mockTopoCacheC := utils.Server{AuthEndpoint: "cacheC.org:8443", Endpoint: "cacheC.org:8000", Resource: "CACHE_C"}
+	mockTopoCacheA := server_utils.Server{AuthEndpoint: "cacheA.org:8443", Endpoint: "cacheA.org:8000", Resource: "CACHE_A"}
+	mockTopoCacheB := server_utils.Server{AuthEndpoint: "cacheB.org:8443", Endpoint: "cacheB.org:8000", Resource: "CACHE_B"}
+	mockTopoCacheC := server_utils.Server{AuthEndpoint: "cacheC.org:8443", Endpoint: "cacheC.org:8000", Resource: "CACHE_C"}
 
 	t.Run("no-change-with-same-downtime", func(t *testing.T) {
 		filteredServers = map[string]filterType{}
 		updateDowntimeFromTopology(
-			&utils.TopologyNamespacesJSON{},
-			&utils.TopologyNamespacesJSON{Caches: []utils.Server{mockTopoCacheA, mockTopoCacheB}},
+			&server_utils.TopologyNamespacesJSON{},
+			&server_utils.TopologyNamespacesJSON{Caches: []server_utils.Server{mockTopoCacheA, mockTopoCacheB}},
 		)
 		checkResult := func() {
 			filteredServersMutex.RLock()
@@ -374,8 +374,8 @@ func TestUpdateDowntimeFromTopology(t *testing.T) {
 
 		// second round of updates
 		updateDowntimeFromTopology(
-			&utils.TopologyNamespacesJSON{},
-			&utils.TopologyNamespacesJSON{Caches: []utils.Server{mockTopoCacheA, mockTopoCacheB}},
+			&server_utils.TopologyNamespacesJSON{},
+			&server_utils.TopologyNamespacesJSON{Caches: []server_utils.Server{mockTopoCacheA, mockTopoCacheB}},
 		)
 		// Same result
 		checkResult()
@@ -384,8 +384,8 @@ func TestUpdateDowntimeFromTopology(t *testing.T) {
 	t.Run("one-server-back-online", func(t *testing.T) {
 		filteredServers = map[string]filterType{}
 		updateDowntimeFromTopology(
-			&utils.TopologyNamespacesJSON{},
-			&utils.TopologyNamespacesJSON{Caches: []utils.Server{mockTopoCacheA, mockTopoCacheB}},
+			&server_utils.TopologyNamespacesJSON{},
+			&server_utils.TopologyNamespacesJSON{Caches: []server_utils.Server{mockTopoCacheA, mockTopoCacheB}},
 		)
 		func() {
 			filteredServersMutex.RLock()
@@ -399,8 +399,8 @@ func TestUpdateDowntimeFromTopology(t *testing.T) {
 
 		// second round of updates
 		updateDowntimeFromTopology(
-			&utils.TopologyNamespacesJSON{Caches: []utils.Server{mockTopoCacheA}}, // A is back online
-			&utils.TopologyNamespacesJSON{Caches: []utils.Server{mockTopoCacheA, mockTopoCacheB}},
+			&server_utils.TopologyNamespacesJSON{Caches: []server_utils.Server{mockTopoCacheA}}, // A is back online
+			&server_utils.TopologyNamespacesJSON{Caches: []server_utils.Server{mockTopoCacheA, mockTopoCacheB}},
 		)
 
 		func() {
@@ -415,8 +415,8 @@ func TestUpdateDowntimeFromTopology(t *testing.T) {
 	t.Run("one-more-server-in-downtime", func(t *testing.T) {
 		filteredServers = map[string]filterType{}
 		updateDowntimeFromTopology(
-			&utils.TopologyNamespacesJSON{},
-			&utils.TopologyNamespacesJSON{Caches: []utils.Server{mockTopoCacheA, mockTopoCacheB}},
+			&server_utils.TopologyNamespacesJSON{},
+			&server_utils.TopologyNamespacesJSON{Caches: []server_utils.Server{mockTopoCacheA, mockTopoCacheB}},
 		)
 		func() {
 			filteredServersMutex.RLock()
@@ -430,8 +430,8 @@ func TestUpdateDowntimeFromTopology(t *testing.T) {
 
 		// second round of updates
 		updateDowntimeFromTopology(
-			&utils.TopologyNamespacesJSON{Caches: []utils.Server{}},
-			&utils.TopologyNamespacesJSON{Caches: []utils.Server{mockTopoCacheA, mockTopoCacheB, mockTopoCacheC}},
+			&server_utils.TopologyNamespacesJSON{Caches: []server_utils.Server{}},
+			&server_utils.TopologyNamespacesJSON{Caches: []server_utils.Server{mockTopoCacheA, mockTopoCacheB, mockTopoCacheC}},
 		)
 
 		func() {

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -35,7 +35,6 @@ import (
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/server_utils"
-	"github.com/pelicanplatform/pelican/utils"
 )
 
 type NamespaceWOPubkey struct {
@@ -521,7 +520,7 @@ func PopulateTopology(ctx context.Context) error {
 	}
 
 	// Next, get the values from topology
-	namespaces, err := utils.GetTopologyJSON(ctx, false)
+	namespaces, err := server_utils.GetTopologyJSON(ctx, false)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to get topology JSON")
 	}

--- a/server_utils/server_utils.go
+++ b/server_utils/server_utils.go
@@ -26,6 +26,8 @@ package server_utils
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"reflect"
@@ -37,7 +39,102 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/metrics"
+	"github.com/pelicanplatform/pelican/param"
 )
+
+type (
+	Server struct {
+		AuthEndpoint string `json:"auth_endpoint"`
+		Endpoint     string `json:"endpoint"`
+		Resource     string `json:"resource"`
+	}
+
+	Scitokens struct {
+		BasePath   []string `json:"base_path"`
+		Issuer     string   `json:"issuer"`
+		Restricted []string `json:"restricted_path"`
+	}
+
+	CredentialGeneration struct {
+		BasePath      string `json:"base_path"`
+		Issuer        string `json:"issuer"`
+		MaxScopeDepth int    `json:"max_scope_depth"`
+		Strategy      string `json:"strategy"`
+		VaultIssuer   string `json:"vault_issuer"`
+		VaultServer   string `json:"vault_server"`
+	}
+
+	Namespace struct {
+		Caches               []Server             `json:"caches"`
+		Origins              []Server             `json:"origins"`
+		CredentialGeneration CredentialGeneration `json:"credential_generation"`
+		DirlistHost          string               `json:"dirlisthost"`
+		Path                 string               `json:"path"`
+		ReadHTTPS            bool                 `json:"readhttps"`
+		Scitokens            []Scitokens          `json:"scitokens"`
+		UseTokenOnRead       bool                 `json:"usetokenonread"`
+		WritebackHost        string               `json:"writebackhost"`
+	}
+
+	TopologyNamespacesJSON struct {
+		Caches     []Server    `json:"caches"`
+		Namespaces []Namespace `json:"namespaces"`
+	}
+)
+
+// GetTopologyJSON returns the namespaces and caches from OSDF topology
+func GetTopologyJSON(ctx context.Context, includeDowned bool) (*TopologyNamespacesJSON, error) {
+	topoNamespaceUrl := param.Federation_TopologyNamespaceUrl.GetString()
+	if topoNamespaceUrl == "" {
+		metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusCritical, "Topology namespaces.json configuration option (`Federation.TopologyNamespaceURL`) not set")
+		return nil, errors.New("Topology namespaces.json configuration option (`Federation.TopologyNamespaceURL`) not set")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, topoNamespaceUrl, nil)
+	if err != nil {
+		metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusCritical, "Failure when getting OSDF namespace data from topology")
+		return nil, errors.Wrap(err, "Failure when getting OSDF namespace data from topology")
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	q := req.URL.Query()
+	if includeDowned {
+		q.Add("include_downed", "1")
+	}
+	req.URL.RawQuery = q.Encode()
+
+	// Use the transport to include timeouts
+	client := http.Client{Transport: config.GetTransport()}
+	resp, err := client.Do(req)
+	if err != nil {
+		metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusCritical, "Failure when getting response for OSDF namespace data")
+		return nil, errors.Wrap(err, "Failure when getting response for OSDF namespace data")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode > 299 {
+		metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusCritical, fmt.Sprintf("Error response %v from OSDF namespace endpoint: %v", resp.StatusCode, resp.Status))
+		return nil, fmt.Errorf("error response %v from OSDF namespace endpoint: %v", resp.StatusCode, resp.Status)
+	}
+
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusCritical, "Failure when reading OSDF namespace response")
+		return nil, errors.Wrap(err, "Failure when reading OSDF namespace response")
+	}
+
+	var namespaces TopologyNamespacesJSON
+	if err = json.Unmarshal(respBytes, &namespaces); err != nil {
+		metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusCritical, fmt.Sprintf("Failure when parsing JSON response from topology URL %v", topoNamespaceUrl))
+		return nil, errors.Wrapf(err, "Failure when parsing JSON response from topology URL %v", topoNamespaceUrl)
+	}
+
+	metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusOK, "")
+
+	return &namespaces, nil
+}
 
 // Wait until given `reqUrl` returns the expected status.
 // Logging messages emitted will refer to `server` (e.g., origin, cache, director)

--- a/utils/web_utils.go
+++ b/utils/web_utils.go
@@ -32,48 +32,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/pelicanplatform/pelican/config"
-	"github.com/pelicanplatform/pelican/metrics"
-	"github.com/pelicanplatform/pelican/param"
-)
-
-type (
-	Server struct {
-		AuthEndpoint string `json:"auth_endpoint"`
-		Endpoint     string `json:"endpoint"`
-		Resource     string `json:"resource"`
-	}
-
-	Scitokens struct {
-		BasePath   []string `json:"base_path"`
-		Issuer     string   `json:"issuer"`
-		Restricted []string `json:"restricted_path"`
-	}
-
-	CredentialGeneration struct {
-		BasePath      string `json:"base_path"`
-		Issuer        string `json:"issuer"`
-		MaxScopeDepth int    `json:"max_scope_depth"`
-		Strategy      string `json:"strategy"`
-		VaultIssuer   string `json:"vault_issuer"`
-		VaultServer   string `json:"vault_server"`
-	}
-
-	Namespace struct {
-		Caches               []Server             `json:"caches"`
-		Origins              []Server             `json:"origins"`
-		CredentialGeneration CredentialGeneration `json:"credential_generation"`
-		DirlistHost          string               `json:"dirlisthost"`
-		Path                 string               `json:"path"`
-		ReadHTTPS            bool                 `json:"readhttps"`
-		Scitokens            []Scitokens          `json:"scitokens"`
-		UseTokenOnRead       bool                 `json:"usetokenonread"`
-		WritebackHost        string               `json:"writebackhost"`
-	}
-
-	TopologyNamespacesJSON struct {
-		Caches     []Server    `json:"caches"`
-		Namespaces []Namespace `json:"namespaces"`
-	}
 )
 
 // MakeRequest makes an http request with our custom http client. It acts similarly to the http.NewRequest but
@@ -107,59 +65,6 @@ func MakeRequest(ctx context.Context, url string, method string, data map[string
 	}
 
 	return body, nil
-}
-
-// GetTopologyJSON returns the namespaces and caches from OSDF topology
-func GetTopologyJSON(ctx context.Context, includeDowned bool) (*TopologyNamespacesJSON, error) {
-	topoNamespaceUrl := param.Federation_TopologyNamespaceUrl.GetString()
-	if topoNamespaceUrl == "" {
-		metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusCritical, "Topology namespaces.json configuration option (`Federation.TopologyNamespaceURL`) not set")
-		return nil, errors.New("Topology namespaces.json configuration option (`Federation.TopologyNamespaceURL`) not set")
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, topoNamespaceUrl, nil)
-	if err != nil {
-		metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusCritical, "Failure when getting OSDF namespace data from topology")
-		return nil, errors.Wrap(err, "Failure when getting OSDF namespace data from topology")
-	}
-
-	req.Header.Set("Accept", "application/json")
-
-	q := req.URL.Query()
-	if includeDowned {
-		q.Add("include_downed", "1")
-	}
-	req.URL.RawQuery = q.Encode()
-
-	// Use the transport to include timeouts
-	client := http.Client{Transport: config.GetTransport()}
-	resp, err := client.Do(req)
-	if err != nil {
-		metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusCritical, "Failure when getting response for OSDF namespace data")
-		return nil, errors.Wrap(err, "Failure when getting response for OSDF namespace data")
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode > 299 {
-		metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusCritical, fmt.Sprintf("Error response %v from OSDF namespace endpoint: %v", resp.StatusCode, resp.Status))
-		return nil, fmt.Errorf("error response %v from OSDF namespace endpoint: %v", resp.StatusCode, resp.Status)
-	}
-
-	respBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusCritical, "Failure when reading OSDF namespace response")
-		return nil, errors.Wrap(err, "Failure when reading OSDF namespace response")
-	}
-
-	var namespaces TopologyNamespacesJSON
-	if err = json.Unmarshal(respBytes, &namespaces); err != nil {
-		metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusCritical, fmt.Sprintf("Failure when parsing JSON response from topology URL %v", topoNamespaceUrl))
-		return nil, errors.Wrapf(err, "Failure when parsing JSON response from topology URL %v", topoNamespaceUrl)
-	}
-
-	metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusOK, "")
-
-	return &namespaces, nil
 }
 
 // Copy headers from proxied src to dst, removing those defined


### PR DESCRIPTION
This PR is to address the issues raised by @bbockelm in #1445 with regards to moving around functions and structs