### PR TITLE
Add IP address (network) label to XRootD access metrics

### DIFF
--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -66,6 +66,7 @@ type (
 		Org                    string
 		Groups                 []string
 		Project                string
+		Host                   string
 	}
 
 	FileId struct {
@@ -280,17 +281,17 @@ var (
 	TransferReadvSegs = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "xrootd_transfer_readv_segments_count",
 		Help: "Number of segments in readv operations",
-	}, []string{"path", "ap", "dn", "role", "org", "proj"})
+	}, []string{"path", "ap", "dn", "role", "org", "proj", "network"})
 
 	TransferOps = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "xrootd_transfer_operations_count",
 		Help: "Number of transfer operations performed",
-	}, []string{"path", "ap", "dn", "role", "org", "proj", "type"})
+	}, []string{"path", "ap", "dn", "role", "org", "proj", "type", "network"})
 
 	TransferBytes = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "xrootd_transfer_bytes",
 		Help: "Bytes of transfers",
-	}, []string{"path", "ap", "dn", "role", "org", "proj", "type"})
+	}, []string{"path", "ap", "dn", "role", "org", "proj", "type", "network"})
 
 	Threads = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "xrootd_sched_thread_count",
@@ -642,12 +643,13 @@ func HandlePacket(packet []byte) error {
 				xferRecord := transfers.Get(fileId)
 				transfers.Delete(fileId)
 				labels := prometheus.Labels{
-					"path": "/",
-					"ap":   "",
-					"dn":   "",
-					"role": "",
-					"org":  "",
-					"proj": "",
+					"path":    "/",
+					"ap":      "",
+					"dn":      "",
+					"role":    "",
+					"org":     "",
+					"proj":    "",
+					"network": "",
 				}
 				var oldReadvSegs uint64 = 0
 				var oldReadOps uint32 = 0
@@ -746,12 +748,13 @@ func HandlePacket(packet []byte) error {
 				writeBytes := binary.BigEndian.Uint64(packet[offset+24 : offset+32])
 
 				labels := prometheus.Labels{
-					"path": "/",
-					"ap":   "",
-					"dn":   "",
-					"role": "",
-					"org":  "",
-					"proj": "",
+					"path":    "/",
+					"ap":      "",
+					"dn":      "",
+					"role":    "",
+					"org":     "",
+					"proj":    "",
+					"network": "",
 				}
 
 				if item != nil {

--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -515,7 +515,7 @@ func ParseXrdUserId(userid string) (xrdUserId XrdUserId, err error) {
 	xrdUserId.User = protUserIdInfo[1][:lastIdx]
 	xrdUserId.Pid = pid
 	xrdUserId.Sid = sid
-	xrdUserId.Host = string(sidAtHostname[1])
+	xrdUserId.Host = string(sidAtHostnameInfo[1])
 	return
 }
 

--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -664,7 +664,7 @@ func HandlePacket(packet []byte) error {
 					sessions.Delete(xferRecord.Value().UserId)
 					labels["path"] = xferRecord.Value().Path
 					if userRecord != nil {
-						maskedIP, ok := utils.ApplyIPMask(userRecord.Value().Host)
+						maskedIP, ok := utils.ExtractAndMaskIP(userRecord.Value().Host)
 						if !ok {
 							log.Warning(fmt.Sprintf("Failed to mask IP address: %s", maskedIP))
 						} else {
@@ -769,7 +769,7 @@ func HandlePacket(packet []byte) error {
 					userRecord := sessions.Get(record.UserId)
 					labels["path"] = record.Path
 					if userRecord != nil {
-						maskedIP, ok := utils.ApplyIPMask(userRecord.Value().Host)
+						maskedIP, ok := utils.ExtractAndMaskIP(userRecord.Value().Host)
 						if !ok {
 							log.Warning(fmt.Sprintf("Failed to mask IP address: %s", maskedIP))
 						} else {

--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -664,7 +664,7 @@ func HandlePacket(packet []byte) error {
 					sessions.Delete(xferRecord.Value().UserId)
 					labels["path"] = xferRecord.Value().Path
 					if userRecord != nil {
-						maskedIP, ok := utils.MaskIP(userRecord.Value().Host)
+						maskedIP, ok := utils.ApplyIPMask(userRecord.Value().Host)
 						if !ok {
 							log.Warning(fmt.Sprintf("Failed to mask IP address: %s", maskedIP))
 						} else {
@@ -769,7 +769,7 @@ func HandlePacket(packet []byte) error {
 					userRecord := sessions.Get(record.UserId)
 					labels["path"] = record.Path
 					if userRecord != nil {
-						maskedIP, ok := utils.MaskIP(userRecord.Value().Host)
+						maskedIP, ok := utils.ApplyIPMask(userRecord.Value().Host)
 						if !ok {
 							log.Warning(fmt.Sprintf("Failed to mask IP address: %s", maskedIP))
 						} else {

--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -666,7 +666,7 @@ func HandlePacket(packet []byte) error {
 					if userRecord != nil {
 						maskedIP, ok := utils.MaskIP(userRecord.Value().Host)
 						if !ok {
-							log.Warning("Failed to mask IP address")
+							log.Warning(fmt.Sprintf("Failed to mask IP address: %s", maskedIP))
 						} else {
 							labels["network"] = maskedIP
 						}
@@ -771,7 +771,7 @@ func HandlePacket(packet []byte) error {
 					if userRecord != nil {
 						maskedIP, ok := utils.MaskIP(userRecord.Value().Host)
 						if !ok {
-							log.Warning("Failed to mask IP address")
+							log.Warning(fmt.Sprintf("Failed to mask IP address: %s", maskedIP))
 						} else {
 							labels["network"] = maskedIP
 						}

--- a/metrics/xrootd_metrics_test.go
+++ b/metrics/xrootd_metrics_test.go
@@ -442,8 +442,92 @@ func TestHandlePacket(t *testing.T) {
 		assert.Equal(t, mockUserRecord.DN, sessionEntry.DN)
 		assert.Equal(t, mockUserRecord.Role, sessionEntry.Role)
 		assert.Equal(t, mockUserRecord.Org, sessionEntry.Org)
+		assert.Equal(t, mockXrdUserId.Host, sessionEntry.Host)
 
 		sessions.DeleteAll()
+	})
+
+	t.Run("auth-packet-u-ipv4-host", func(t *testing.T) {
+		mockUserRecord := UserRecord{
+			AuthenticationProtocol: "https",
+			DN:                     "clientName",
+			Role:                   "clientRole",
+			Org:                    "clientOrg",
+		}
+		expectedIPv4 := "192.168.1.1"
+		mockXrdUserIdIPv4 := XrdUserId{
+			Prot: "https",
+			User: "unknown",
+			Pid:  0,
+			Sid:  143152967831384,
+			Host: expectedIPv4,
+		}
+		mockInfoIPv4 := []byte(getUserIdString(mockXrdUserIdIPv4) + "\n" + getAuthInfoString(mockUserRecord))
+		mockMonMapIPv4 := XrdXrootdMonMap{
+			Hdr: XrdXrootdMonHeader{ // 8B
+				// u-stream provides client login information; enabled by the auth and use
+				Code: 'u',
+				Pseq: 1,
+				Plen: uint16(12 + len(mockInfoIPv4)),
+				Stod: int32(time.Now().Unix()),
+			},
+			Dictid: uint32(0x12345678), // 4B
+			Info:   mockInfoIPv4,
+		}
+
+		sessions.DeleteAll()
+
+		buf, err := mockMonMapIPv4.Serialize()
+		require.NoError(t, err, "Error serializing monitor packet")
+		err = HandlePacket(buf)
+		require.NoError(t, err, "Error handling packet")
+
+		require.Equal(t, 1, len(sessions.Keys()), "Session cache didn't update")
+
+		sessionEntry := sessions.Get(sessions.Keys()[0]).Value()
+		assert.Equal(t, expectedIPv4, sessionEntry.Host)
+
+	})
+
+	t.Run("auth-packet-u-ipv6-host", func(t *testing.T) {
+		mockUserRecord := UserRecord{
+			AuthenticationProtocol: "https",
+			DN:                     "clientName",
+			Role:                   "clientRole",
+			Org:                    "clientOrg",
+		}
+		expectedIPv6 := "2001:0db8:3333:4444:5555:6666:7777:8888"
+		mockXrdUserIdIPv6 := XrdUserId{
+			Prot: "https",
+			User: "unknown",
+			Pid:  0,
+			Sid:  143152967831384,
+			Host: expectedIPv6,
+		}
+		mockInfoIPv6 := []byte(getUserIdString(mockXrdUserIdIPv6) + "\n" + getAuthInfoString(mockUserRecord))
+		mockMonMapIPv6 := XrdXrootdMonMap{
+			Hdr: XrdXrootdMonHeader{ // 8B
+				// u-stream provides client login information; enabled by the auth and use
+				Code: 'u',
+				Pseq: 1,
+				Plen: uint16(12 + len(mockInfoIPv6)),
+				Stod: int32(time.Now().Unix()),
+			},
+			Dictid: uint32(0x12345678), // 4B
+			Info:   mockInfoIPv6,
+		}
+
+		sessions.DeleteAll()
+
+		buf, err := mockMonMapIPv6.Serialize()
+		require.NoError(t, err, "Error serializing monitor packet")
+		err = HandlePacket(buf)
+		require.NoError(t, err, "Error handling packet")
+
+		require.Equal(t, 1, len(sessions.Keys()), "Session cache didn't update")
+
+		sessionEntry := sessions.Get(sessions.Keys()[0]).Value()
+		assert.Equal(t, expectedIPv6, sessionEntry.Host)
 	})
 
 	t.Run("file-path-packet-d-should-register-correct-info", func(t *testing.T) {

--- a/metrics/xrootd_metrics_test.go
+++ b/metrics/xrootd_metrics_test.go
@@ -600,23 +600,23 @@ func TestHandlePacket(t *testing.T) {
 		expectedTransferReadvSegs := `
 		# HELP xrootd_transfer_readv_segments_count Number of segments in readv operations
 		# TYPE xrootd_transfer_readv_segments_count counter
-		xrootd_transfer_readv_segments_count{ap="",dn="",org="",path="/",proj="",role=""} 1000
+		xrootd_transfer_readv_segments_count{ap="",dn="",network="",org="",path="/",proj="",role=""} 1000
 		`
 
 		expectedTransferOps := `
 		# HELP xrootd_transfer_operations_count Number of transfer operations performed
 		# TYPE xrootd_transfer_operations_count counter
-		xrootd_transfer_operations_count{ap="",dn="",org="",path="/",proj="",role="",type="read"} 120
-		xrootd_transfer_operations_count{ap="",dn="",org="",path="/",proj="",role="",type="readv"} 10
-		xrootd_transfer_operations_count{ap="",dn="",org="",path="/",proj="",role="",type="write"} 30
+		xrootd_transfer_operations_count{ap="",dn="",network="",org="",path="/",proj="",role="",type="read"} 120
+		xrootd_transfer_operations_count{ap="",dn="",network="",org="",path="/",proj="",role="",type="readv"} 10
+		xrootd_transfer_operations_count{ap="",dn="",network="",org="",path="/",proj="",role="",type="write"} 30
 		`
 
 		expectedTransferBytes := `
 		# HELP xrootd_transfer_bytes Bytes of transfers
 		# TYPE xrootd_transfer_bytes counter
-		xrootd_transfer_bytes{ap="",dn="",org="",path="/",proj="",role="",type="read"} 10000
-		xrootd_transfer_bytes{ap="",dn="",org="",path="/",proj="",role="",type="readv"} 20000
-		xrootd_transfer_bytes{ap="",dn="",org="",path="/",proj="",role="",type="write"} 120
+		xrootd_transfer_bytes{ap="",dn="",network="",org="",path="/",proj="",role="",type="read"} 10000
+		xrootd_transfer_bytes{ap="",dn="",network="",org="",path="/",proj="",role="",type="readv"} 20000
+		xrootd_transfer_bytes{ap="",dn="",network="",org="",path="/",proj="",role="",type="write"} 120
 		`
 
 		expectedTransferReadvSegsReader := strings.NewReader(expectedTransferReadvSegs)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -104,21 +104,13 @@ func CheckValidQuery(transferUrl *url.URL) (err error) {
 	return errors.New("invalid query parameter(s) " + transferUrl.RawQuery + " provided in url " + transferUrl.String())
 }
 
-func maskIPv4(ipStr string) (masked string, ok bool) {
-	ip := net.ParseIP(ipStr).To4()
-	if ip == nil {
-		return "", false
-	}
+func maskIPv4(ip net.IP) (masked string, ok bool) {
 	mask := net.CIDRMask(24, 32)
 	maskedIP := ip.Mask(mask)
 	return maskedIP.String(), true
 }
 
-func maskIPv6(ipStr string) (masked string, ok bool) {
-	ip := net.ParseIP(ipStr).To16()
-	if ip == nil || ip.To4() != nil {
-		return "", false
-	}
+func maskIPv6(ip net.IP) (masked string, ok bool) {
 	mask := net.CIDRMask(64, 128)
 	maskedIP := ip.Mask(mask)
 	return maskedIP.String(), true
@@ -132,11 +124,11 @@ func MaskIP(ipStr string) (maskedIP string, ok bool) {
 		return "", false
 	}
 	if ip.To4() != nil {
-		return maskIPv4(ipStr)
+		return maskIPv4(ip)
 	}
 
 	if ip.To16() != nil {
-		return maskIPv6(ipStr)
+		return maskIPv6(ip)
 	}
 	return "", false
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -132,3 +132,14 @@ func ApplyIPMask(ipStr string) (maskedIP string, ok bool) {
 	}
 	return ipStr, false
 }
+
+// ExtractAndMaskIP will extract an IP address from a leading "[" and trailing "]".
+// Then the function will apply the ApplyIPMask function
+func ExtractAndMaskIP(ipStr string) (maskedIP string, ok bool) {
+	if strings.HasPrefix(ipStr, "[") && strings.HasSuffix(ipStr, "]") {
+		extractedIP := ipStr[1 : len(ipStr)-1]
+		return ApplyIPMask(extractedIP)
+	} else {
+		return ApplyIPMask(ipStr)
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -19,6 +19,7 @@
 package utils
 
 import (
+	"net"
 	"net/url"
 	"strings"
 	"unicode"
@@ -101,4 +102,41 @@ func CheckValidQuery(transferUrl *url.URL) (err error) {
 	}
 
 	return errors.New("invalid query parameter(s) " + transferUrl.RawQuery + " provided in url " + transferUrl.String())
+}
+
+func maskIPv4(ipStr string) (masked string, ok bool) {
+	ip := net.ParseIP(ipStr).To4()
+	if ip == nil {
+		return "", false
+	}
+	mask := net.CIDRMask(24, 32)
+	maskedIP := ip.Mask(mask)
+	return maskedIP.String(), true
+}
+
+func maskIPv6(ipStr string) (masked string, ok bool) {
+	ip := net.ParseIP(ipStr).To16()
+	if ip == nil || ip.To4() != nil {
+		return "", false
+	}
+	mask := net.CIDRMask(64, 128)
+	maskedIP := ip.Mask(mask)
+	return maskedIP.String(), true
+}
+
+// MaskIP will apply a /24 bit mask to IPv4 addresses and a /64 bit mask to IPv6
+// Will return an empty string along with ok == false if there is any error while masking
+func MaskIP(ipStr string) (maskedIP string, ok bool) {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return "", false
+	}
+	if ip.To4() != nil {
+		return maskIPv4(ipStr)
+	}
+
+	if ip.To16() != nil {
+		return maskIPv6(ipStr)
+	}
+	return "", false
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -104,31 +104,31 @@ func CheckValidQuery(transferUrl *url.URL) (err error) {
 	return errors.New("invalid query parameter(s) " + transferUrl.RawQuery + " provided in url " + transferUrl.String())
 }
 
-func maskIPv4(ip net.IP) (masked string, ok bool) {
+func maskIPv4With24(ip net.IP) (masked string, ok bool) {
 	mask := net.CIDRMask(24, 32)
 	maskedIP := ip.Mask(mask)
 	return maskedIP.String(), true
 }
 
-func maskIPv6(ip net.IP) (masked string, ok bool) {
+func maskIPv6With64(ip net.IP) (masked string, ok bool) {
 	mask := net.CIDRMask(64, 128)
 	maskedIP := ip.Mask(mask)
 	return maskedIP.String(), true
 }
 
-// MaskIP will apply a /24 bit mask to IPv4 addresses and a /64 bit mask to IPv6
+// ApplyIPMask will apply a /24 bit mask to IPv4 addresses and a /64 bit mask to IPv6
 // Will return the input string along with ok == false if there is any error while masking
-func MaskIP(ipStr string) (maskedIP string, ok bool) {
+func ApplyIPMask(ipStr string) (maskedIP string, ok bool) {
 	ip := net.ParseIP(ipStr)
 	if ip == nil {
 		return ipStr, false
 	}
 	if ip.To4() != nil {
-		return maskIPv4(ip)
+		return maskIPv4With24(ip)
 	}
 
 	if ip.To16() != nil {
-		return maskIPv6(ip)
+		return maskIPv6With64(ip)
 	}
 	return ipStr, false
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -117,11 +117,11 @@ func maskIPv6(ip net.IP) (masked string, ok bool) {
 }
 
 // MaskIP will apply a /24 bit mask to IPv4 addresses and a /64 bit mask to IPv6
-// Will return an empty string along with ok == false if there is any error while masking
+// Will return the input string along with ok == false if there is any error while masking
 func MaskIP(ipStr string) (maskedIP string, ok bool) {
 	ip := net.ParseIP(ipStr)
 	if ip == nil {
-		return "", false
+		return ipStr, false
 	}
 	if ip.To4() != nil {
 		return maskIPv4(ip)
@@ -130,5 +130,5 @@ func MaskIP(ipStr string) (maskedIP string, ok bool) {
 	if ip.To16() != nil {
 		return maskIPv6(ip)
 	}
-	return "", false
+	return ipStr, false
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -134,3 +134,53 @@ func TestApplyIPMask(t *testing.T) {
 		assert.Equal(t, maskedIP, invalid)
 	})
 }
+
+func TestExtractAndMaskIP(t *testing.T) {
+	t.Run("testWrappedIPv4", func(t *testing.T) {
+		expectedMaskedIP := "192.168.1.0"
+		wrappedValidIPv4 := "[192.168.1.1]"
+		maskedIP, ok := ExtractAndMaskIP(wrappedValidIPv4)
+		assert.True(t, ok)
+		assert.Equal(t, expectedMaskedIP, maskedIP)
+	})
+
+	t.Run("testWrappedIPv6", func(t *testing.T) {
+		expectedMaskedIP := "2001:db8:3333:4444::"
+		wrappedValidIPv6 := "[2001:0db8:3333:4444:5555:6666:7777:8888]"
+		maskedIP, ok := ExtractAndMaskIP(wrappedValidIPv6)
+		assert.True(t, ok)
+		assert.Equal(t, expectedMaskedIP, maskedIP)
+	})
+
+	t.Run("testWrappedInvalid", func(t *testing.T) {
+		invalid := "[abc.123]"
+		expected := "abc.123"
+		maskedIP, ok := ExtractAndMaskIP(invalid)
+		assert.False(t, ok)
+		assert.Equal(t, maskedIP, expected)
+	})
+
+	t.Run("testUnwrappedIPv4", func(t *testing.T) {
+		expectedMaskedIP := "192.168.1.0"
+		validIPv4 := "192.168.1.1"
+		maskedIP, ok := ExtractAndMaskIP(validIPv4)
+		assert.True(t, ok)
+		assert.Equal(t, expectedMaskedIP, maskedIP)
+	})
+
+	t.Run("testUnwrappedIPv6", func(t *testing.T) {
+		expectedMaskedIP := "2001:db8:3333:4444::"
+		validIPv6 := "2001:0db8:3333:4444:5555:6666:7777:8888"
+		maskedIP, ok := ExtractAndMaskIP(validIPv6)
+		assert.True(t, ok)
+		assert.Equal(t, expectedMaskedIP, maskedIP)
+	})
+
+	t.Run("testWrappedReal", func(t *testing.T) {
+		real := "[::ffff:79.110.62.117]"
+		expected := "79.110.62.0"
+		maskedIP, ok := ExtractAndMaskIP(real)
+		assert.True(t, ok)
+		assert.Equal(t, expected, maskedIP)
+	})
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -109,3 +109,28 @@ func TestValidQuery(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+func TestMaskIP(t *testing.T) {
+	t.Run("testValidIPv4", func(t *testing.T) {
+		expectedMaskedIP := "192.168.1.0"
+		validIPv4 := "192.168.1.1"
+		maskedIP, ok := MaskIP(validIPv4)
+		assert.True(t, ok)
+		assert.Equal(t, expectedMaskedIP, maskedIP)
+	})
+
+	t.Run("testValidIPv6", func(t *testing.T) {
+		expectedMaskedIP := "2001:db8:3333:4444::"
+		validIPv6 := "2001:0db8:3333:4444:5555:6666:7777:8888"
+		maskedIP, ok := MaskIP(validIPv6)
+		assert.True(t, ok)
+		assert.Equal(t, expectedMaskedIP, maskedIP)
+	})
+
+	t.Run("testInvalidInput", func(t *testing.T) {
+		invalid := "abc.123"
+		maskedIP, ok := MaskIP(invalid)
+		assert.False(t, ok)
+		assert.Equal(t, maskedIP, invalid)
+	})
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -110,11 +110,11 @@ func TestValidQuery(t *testing.T) {
 	})
 }
 
-func TestMaskIP(t *testing.T) {
+func TestApplyIPMask(t *testing.T) {
 	t.Run("testValidIPv4", func(t *testing.T) {
 		expectedMaskedIP := "192.168.1.0"
 		validIPv4 := "192.168.1.1"
-		maskedIP, ok := MaskIP(validIPv4)
+		maskedIP, ok := ApplyIPMask(validIPv4)
 		assert.True(t, ok)
 		assert.Equal(t, expectedMaskedIP, maskedIP)
 	})
@@ -122,14 +122,14 @@ func TestMaskIP(t *testing.T) {
 	t.Run("testValidIPv6", func(t *testing.T) {
 		expectedMaskedIP := "2001:db8:3333:4444::"
 		validIPv6 := "2001:0db8:3333:4444:5555:6666:7777:8888"
-		maskedIP, ok := MaskIP(validIPv6)
+		maskedIP, ok := ApplyIPMask(validIPv6)
 		assert.True(t, ok)
 		assert.Equal(t, expectedMaskedIP, maskedIP)
 	})
 
 	t.Run("testInvalidInput", func(t *testing.T) {
 		invalid := "abc.123"
-		maskedIP, ok := MaskIP(invalid)
+		maskedIP, ok := ApplyIPMask(invalid)
 		assert.False(t, ok)
 		assert.Equal(t, maskedIP, invalid)
 	})

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -51,6 +51,7 @@ xrootd.chksum max 2 md5 adler32
 xrootd.trace emsg login stall redirect
 pfc.trace info
 xrootd.tls all
+xrd.network nodnr
 pfc.blocksize 128k
 pfc.prefetch 20
 pfc.writequeue 16 4

--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -119,6 +119,7 @@ xrd.trace {{.Logging.OriginXrd}}
 cms.trace {{.Logging.OriginCms}}
 http.trace {{.Logging.OriginHttp}}
 xrootd.tls all
+xrd.network nodnr
 scitokens.trace {{.Logging.OriginScitokens}}
 {{if .Xrootd.ConfigFile}}
 continue {{.Xrootd.ConfigFile}}


### PR DESCRIPTION
This PR addresses #1425. This PR adds a IP address (netwrok) label to XRD access metrics (xrootd_transfer_readv_segments_count, xrootd_transfer_operations_count, and xrootd_transfer_bytes). This PR also updated some tests to handle the new label. This PR also addresses comments from @bbockelm in PR #1445.