### PR TITLE
Fix health test deadlock

### DIFF
--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -186,6 +186,7 @@ func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]
 						})
 						log.Debugf("New director test suite issued for %s %s. Errgroup was evicted", string(ad.Type), ad.URL.String())
 					} else {
+						// Existing errorgroup still working
 						cancelCtx, cancel := context.WithCancel(existingUtil.ErrGrpContext)
 						started := existingUtil.ErrGrp.TryGo(func() error {
 							LaunchPeriodicDirectorTest(cancelCtx, sAd)

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -120,28 +120,32 @@ func LaunchTTLCache(ctx context.Context, egrp *errgroup.Group) {
 		}()
 
 		// Always lock statUtilsMutex first then healthTestUtilsMutex to avoid cyclic dependency
+		var util *healthTestUtil
+		var exists bool
 		func() {
 			healthTestUtilsMutex.RLock()
 			defer healthTestUtilsMutex.RUnlock()
-			util, exists := healthTestUtils[serverUrl]
-			if exists && util != nil {
-				log.Debugf("healthTestUtils: start clean up for %s server %s", string(serverAd.Type), serverAd.Name)
-				// Only call cancel instead of deleting the util to make sure there's no nil ptr reference
-				util.Cancel()
-				if util.ErrGrp != nil {
-					err := util.ErrGrp.Wait()
-					if err != nil {
-						log.Debugf("healthTestUtils: Errgroup returns error for %s %s %s", string(serverAd.Type), serverAd.Name, err.Error())
-					} else {
-						log.Debugf("healthTestUtils: Errgroup successfully emptied at TTL cache eviction for %s %s", string(serverAd.Type), serverAd.Name)
-					}
+			util, exists = healthTestUtils[serverUrl]
+		}()
+		if exists && util != nil {
+			log.Debugf("healthTestUtils: start clean up for %s server %s", string(serverAd.Type), serverAd.Name)
+			// Only call cancel instead of deleting the util to make sure there's no nil ptr reference
+			util.Cancel()
+			if util.ErrGrp != nil {
+				// Wait blocks until all Go function in errgroup return. Ideally, calling util.Cancel() cancels Go function
+				// but deadlock can happen if the serverAd evcited is recording the test result (by acquiring the lock)
+				err := util.ErrGrp.Wait()
+				if err != nil {
+					log.Debugf("healthTestUtils: Errgroup returns error for %s %s %s", string(serverAd.Type), serverAd.Name, err.Error())
 				} else {
-					log.Debugf("healthTestUtils: errgroup is nil when evict the registration from TTL cache for %s %s", string(serverAd.Type), serverAd.Name)
+					log.Debugf("healthTestUtils: Errgroup successfully emptied at TTL cache eviction for %s %s", string(serverAd.Type), serverAd.Name)
 				}
 			} else {
-				log.Debugf("healthTestUtil: not found for %s when evicting TTL cache item", serverAd.Name)
+				log.Debugf("healthTestUtils: errgroup is nil when evict the registration from TTL cache for %s %s", string(serverAd.Type), serverAd.Name)
 			}
-		}()
+		} else {
+			log.Debugf("healthTestUtil: not found for %s when evicting TTL cache item", serverAd.Name)
+		}
 	})
 
 	// Put stop logic in a separate goroutine so that parent function is not blocking


### PR DESCRIPTION
The fix in #1438 only partially fixed the issue. With the patched binary, the director runs OK at the server start, until some point in the future another deadlock happens.

The Prometheus log in the past several day shows this pattern:
![Screenshot 2024-06-24 at 3 17 02 PM](https://github.com/PelicanPlatform/pelican/assets/41393704/c51ce488-e660-4d9b-a084-fe30cd90069b)

where stable lines means no deadlock and sudden drops are server restarts.

Thanks for the `pprof` added in 7.9.1, after digging into `goroutines` stack trace, it seems that there's a deadlock in `healthTestUtil` itself, where we acquire the lock to clean up one instance of healthTestUtil at cache eviction, we call` ctx.Cancel` to cancel the goroutine in the errgroup that belongs to that serverAd, then we `Wait()` on the errgroup to return. However, the function in the goroutine may acquire the same lock to update the test result. If we call `Wait()` and coincidentally the goroutine is to report the test result, we basically acquire the same lock twice and never release any of them:

https://github.com/PelicanPlatform/pelican/blob/0af15729fe8b5897d9414f79ab553ce1c6b2084a/director/director_api.go#L120-L126

https://github.com/PelicanPlatform/pelican/blob/0af15729fe8b5897d9414f79ab553ce1c6b2084a/director/monitor.go#L269-L278

This PR fixes the issue by shrinking the critical section of the concurrent logic and avoid acquiring the lock and call `Wait` in the same function.
