### PR TITLE
Add `stat` query to `redirectToCaches`

### DIFF
--- a/director/director.go
+++ b/director/director.go
@@ -380,8 +380,7 @@ func redirectToCache(ginCtx *gin.Context) {
 		if len(cacheAds) == 0 {
 			ginCtx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
 				Status: server_structs.RespFailed,
-				// TODO: make this message clearer by saying no fallback origin found
-				Msg: "No cache found for path",
+				Msg:    "No cache or fallback origin found for this object. The object may not exist in the federation",
 			})
 			return
 		}

--- a/director/sort.go
+++ b/director/sort.go
@@ -241,11 +241,15 @@ func sortServerAdsByTopo(ads []*server_structs.Advertisement) []*server_structs.
 	return ads
 }
 
+// Stable-sort the given serveAds in-place given the avaiMap, where the key of the map is serverAd.Url.String()
+// and the value is a bool suggesting if the server has the object requested.
+//
+// Smaller index in the sorted array means higher priority
 func sortServerAdsByAvailability(ads []server_structs.ServerAd, avaiMap map[string]bool) {
 	slices.SortStableFunc(ads, func(a, b server_structs.ServerAd) int {
-		if avaiMap[a.URL.String()] && !avaiMap[b.URL.String()] {
+		if !avaiMap[a.URL.String()] && avaiMap[b.URL.String()] {
 			return 1
-		} else if !avaiMap[a.URL.String()] && avaiMap[b.URL.String()] {
+		} else if avaiMap[a.URL.String()] && !avaiMap[b.URL.String()] {
 			return -1
 		} else {
 			// Preserve original ordering

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -286,7 +286,7 @@ func TestSortServerAdsByAvailability(t *testing.T) {
 	firstUrl := url.URL{Host: "first.org", Scheme: "https"}
 	secondUrl := url.URL{Host: "second.org", Scheme: "https"}
 	thirdUrl := url.URL{Host: "third.org", Scheme: "https"}
-	forthUrl := url.URL{Host: "forth.org", Scheme: "https"}
+	forthUrl := url.URL{Host: "fourth.org", Scheme: "https"}
 
 	firstServer := server_structs.ServerAd{URL: firstUrl}
 	secondServer := server_structs.ServerAd{URL: secondUrl}

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -24,6 +24,7 @@ import (
 	"math/rand"
 	"net"
 	"net/netip"
+	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -279,4 +280,27 @@ func TestSortServerAdsByIP(t *testing.T) {
 
 		assert.NotEqualValues(t, notExpected, sorted)
 	})
+}
+
+func TestSortServerAdsByAvailability(t *testing.T) {
+	firstUrl := url.URL{Host: "first.org", Scheme: "https"}
+	secondUrl := url.URL{Host: "second.org", Scheme: "https"}
+	thirdUrl := url.URL{Host: "third.org", Scheme: "https"}
+	forthUrl := url.URL{Host: "forth.org", Scheme: "https"}
+
+	firstServer := server_structs.ServerAd{URL: firstUrl}
+	secondServer := server_structs.ServerAd{URL: secondUrl}
+	thirdServer := server_structs.ServerAd{URL: thirdUrl}
+	forthServer := server_structs.ServerAd{URL: forthUrl}
+
+	randomOrder := []server_structs.ServerAd{thirdServer, firstServer, forthServer, secondServer}
+	expected := []server_structs.ServerAd{firstServer, secondServer, thirdServer, forthServer}
+	avaiMap := map[string]bool{}
+	avaiMap[firstUrl.String()] = true
+	avaiMap[secondUrl.String()] = true
+	avaiMap[thirdUrl.String()] = false
+	avaiMap[forthUrl.String()] = false
+
+	sortServerAdsByAvailability(randomOrder, avaiMap)
+	assert.EqualValues(t, expected, randomOrder)
 }

--- a/director/stat.go
+++ b/director/stat.go
@@ -134,7 +134,7 @@ func (e headReqCancelledErr) Error() string {
 }
 
 func (meta objectMetadata) String() string {
-	return fmt.Sprintf("Object Meatadata: File URL %q; Content-length:%d; Checksum: %s\n",
+	return fmt.Sprintf("Object URL: %q; Content-length:%d; Checksum: %s",
 		meta.URL.String(),
 		meta.ContentLength,
 		meta.Checksum,
@@ -154,9 +154,12 @@ func (m *objectMetadata) MarshalJSON() ([]byte, error) {
 
 func (q queryResult) String() string {
 	if q.Status == querySuccessful {
-		res := fmt.Sprintf("Query is successful: %s\nObjects: \n", q.Msg)
-		for _, obj := range q.Objects {
-			res += obj.String() + "\n"
+		res := fmt.Sprintf("Query is successful: %s Servers with the object: %d. Servers return denial: %d. Top-3 servers: ", q.Msg, len(q.Objects), len(q.DeniedServers))
+		for idx, obj := range q.Objects {
+			res += obj.String() + " "
+			if idx >= 2 {
+				break
+			}
 		}
 		return res
 	} else {


### PR DESCRIPTION
Closes #1308 

The idea is that for redirectToCaches, if `stat` is enabled (by default):
* Query **all** origins and caches that claim to serve the namespace
* If no caches claim to serve the namespace (not that they have the object), then iterate queried origins that claim to have the object and check if they enable "DirectRead". If none, then return 404. If there is, use the first one as the object server.
* If there's one or more caches claim to serve the namespace, we sort the caches based on existing GeoIP, but then sort again by availability. Caches that have the object have higher priority in the list
* Return the sorted caches