### PR TITLE
Retry auth endpoint if the `stat` timeout

### DIFF
--- a/director/director_ui.go
+++ b/director/director_ui.go
@@ -41,7 +41,8 @@ type (
 	listServerResponse struct {
 		Name string `json:"name"`
 		// AuthURL is Deprecated, for Pelican severs, URL is used as the base URL for object access.
-		// This is to maintain compatibility with the topology servers
+		// This is to maintain compatibility with the topology servers, where it uses AuthURL for
+		// accessing protected objects and URL for public objects.
 		AuthURL           string                      `json:"authUrl"`
 		BrokerURL         string                      `json:"brokerUrl"`
 		URL               string                      `json:"url"`    // This is server's XRootD URL for file transfer

--- a/director/director_ui.go
+++ b/director/director_ui.go
@@ -21,7 +21,6 @@ package director
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"path"
 	"strings"
 
@@ -40,7 +39,9 @@ type (
 	}
 
 	listServerResponse struct {
-		Name              string                      `json:"name"`
+		Name string `json:"name"`
+		// AuthURL is Deprecated, for Pelican severs, URL is used as the base URL for object access.
+		// This is to maintain compatibility with the topology servers
 		AuthURL           string                      `json:"authUrl"`
 		BrokerURL         string                      `json:"brokerUrl"`
 		URL               string                      `json:"url"`    // This is server's XRootD URL for file transfer
@@ -112,16 +113,12 @@ func listServers(ctx *gin.Context) {
 			log.Debugf("listServers: healthTestUtils not found for server at %s", server.URL.String())
 		}
 		filtered, ft := checkFilter(server.Name)
-		var auth_url string
-		if server.AuthURL == (url.URL{}) {
-			auth_url = server.URL.String()
-		} else {
-			auth_url = server.AuthURL.String()
-		}
+
 		res := listServerResponse{
-			Name:         server.Name,
-			BrokerURL:    server.BrokerURL.String(),
-			AuthURL:      auth_url,
+			Name:      server.Name,
+			BrokerURL: server.BrokerURL.String(),
+			// For web UI, if authURL is not set, we don't want to confuse user by copying server URL as authURL
+			AuthURL:      server.AuthURL.String(),
 			URL:          server.URL.String(),
 			WebURL:       server.WebURL.String(),
 			Type:         server.Type,

--- a/director/director_ui_test.go
+++ b/director/director_ui_test.go
@@ -67,7 +67,7 @@ func TestListServers(t *testing.T) {
 	expectedlistOriginRes := listServerResponse{
 		Name:              mockOriginServerAd.Name,
 		BrokerURL:         mockOriginServerAd.BrokerURL.String(),
-		AuthURL:           mockOriginServerAd.URL.String(),
+		AuthURL:           "",
 		URL:               mockOriginServerAd.URL.String(),
 		WebURL:            mockOriginServerAd.WebURL.String(),
 		Type:              mockOriginServerAd.Type,
@@ -82,7 +82,7 @@ func TestListServers(t *testing.T) {
 	expectedlistCacheRes := listServerResponse{
 		Name:              mockCacheServerAd.Name,
 		BrokerURL:         mockCacheServerAd.BrokerURL.String(),
-		AuthURL:           mockCacheServerAd.URL.String(),
+		AuthURL:           "",
 		URL:               mockCacheServerAd.URL.String(),
 		WebURL:            mockCacheServerAd.WebURL.String(),
 		Type:              mockCacheServerAd.Type,

--- a/director/stat.go
+++ b/director/stat.go
@@ -339,7 +339,7 @@ func (stat *ObjectStat) queryServersForObject(cancelContext context.Context, obj
 				// For the topology server, if the server does not support public read,
 				// or the token is provided, then it's safe to assume this request goes to authenticated endpoint
 				// For Pelican server, we don't populate authURL and only use server URL as the base URL
-				if (!sAdInt.Caps.PublicReads || cfg.token != "") && sAD.AuthURL.String() != "" {
+				if sAdInt.FromTopology && (!sAdInt.Caps.PublicReads || cfg.token != "") && sAdInt.AuthURL.String() != "" {
 					baseUrl = sAD.AuthURL
 				}
 
@@ -359,15 +359,6 @@ func (stat *ObjectStat) queryServersForObject(cancelContext context.Context, obj
 					// does not have this turned on, or had trouble calculating the checksum
 					// For old origins/caches, it has different URLs for public VS protected data
 					// Retry without digest
-					metadata, err = stat.ReqHandler(maxCancelCtx, objectName, baseUrl, false, cfg.token, timeout)
-				}
-
-				// If baseUrl is already AuthURL, or AuthURL is not set, then we can skip the last attempt
-				if err != nil && baseUrl != sAD.AuthURL && sAD.AuthURL.String() != "" && !errors.As(err, &cancelErr) {
-					// If there's still error, then we try the authURL.
-					// For topology servers, they have different URLs for projected objects than public objects.
-					// If the origin server does not have public objects, then it's sAD.URL is not accessible
-					baseUrl = sAD.AuthURL
 					metadata, err = stat.ReqHandler(maxCancelCtx, objectName, baseUrl, false, cfg.token, timeout)
 				}
 

--- a/director/stat_test.go
+++ b/director/stat_test.go
@@ -61,27 +61,32 @@ func TestQueryServersForObject(t *testing.T) {
 		mockServerAd1 := server_structs.ServerAd{
 			Name:    "origin1",
 			URL:     url.URL{Host: "example1.com", Scheme: "https"},
-			AuthURL: url.URL{Host: "example1.com:8444", Scheme: "https"},
+			AuthURL: url.URL{Host: "example1-auth.com:8444", Scheme: "https"},
+			Caps:    server_structs.Capabilities{PublicReads: true},
 			Type:    server_structs.OriginType}
 		mockServerAd2 := server_structs.ServerAd{
 			Name:    "origin2",
 			URL:     url.URL{Host: "example2.com", Scheme: "https"},
-			AuthURL: url.URL{Host: "example2.com:8444", Scheme: "https"},
+			AuthURL: url.URL{Host: "example2-auth.com:8444", Scheme: "https"},
+			Caps:    server_structs.Capabilities{PublicReads: true},
 			Type:    server_structs.OriginType}
 		mockServerAd3 := server_structs.ServerAd{
 			Name:    "origin3",
 			URL:     url.URL{Host: "example3.com", Scheme: "https"},
-			AuthURL: url.URL{Host: "example3.com:8444", Scheme: "https"},
+			AuthURL: url.URL{Host: "example3-auth.com:8444", Scheme: "https"},
+			Caps:    server_structs.Capabilities{PublicReads: true},
 			Type:    server_structs.OriginType}
 		mockServerAd4 := server_structs.ServerAd{
 			Name:    "origin4",
 			URL:     url.URL{Host: "example4.com", Scheme: "https"},
-			AuthURL: url.URL{Host: "example4.com:8444", Scheme: "https"},
+			AuthURL: url.URL{Host: "example4-auth.com:8444", Scheme: "https"},
+			Caps:    server_structs.Capabilities{PublicReads: true},
 			Type:    server_structs.OriginType}
 		mockServerAd5 := server_structs.ServerAd{
 			Name:    "cache1",
 			URL:     url.URL{Host: "cache1.com", Scheme: "https"},
-			AuthURL: url.URL{Host: "cache1.com:8444", Scheme: "https"},
+			AuthURL: url.URL{Host: "cache1-auth.com:8444", Scheme: "https"},
+			Caps:    server_structs.Capabilities{PublicReads: true},
 			Type:    server_structs.CacheType}
 		mockNsAd0 := server_structs.NamespaceAdV2{Path: "/foo"}
 		mockNsAd1 := server_structs.NamespaceAdV2{Path: "/foo/bar"}
@@ -507,10 +512,10 @@ func TestQueryServersForObject(t *testing.T) {
 
 		stat.ReqHandler = func(maxCancelCtx context.Context, objectName string, dataUrl url.URL, digest bool, token string, timeout time.Duration) (*objectMetadata, error) {
 			if dataUrl.Host == "example2.com" {
-				return nil, headReqTimeoutErr{}
+				return nil, &headReqTimeoutErr{}
 			}
 			if dataUrl.Host == "example3.com" {
-				return nil, headReqNotFoundErr{}
+				return nil, &headReqNotFoundErr{}
 			}
 			return nil, errors.New("Default error")
 		}
@@ -592,7 +597,7 @@ func TestSendHeadReq(t *testing.T) {
 		defer cancel()
 		meta, err := stat.sendHeadReq(ctx, "/foo/bar/dne", mockOriginAd.URL, true, "", time.Second)
 		require.Error(t, err)
-		_, ok := err.(headReqNotFoundErr)
+		_, ok := err.(*headReqNotFoundErr)
 		assert.True(t, ok)
 		assert.Nil(t, meta)
 	})
@@ -604,7 +609,7 @@ func TestSendHeadReq(t *testing.T) {
 		defer cancel()
 		meta, err := stat.sendHeadReq(ctx, "/foo/bar/timeout.txt", mockOriginAd.URL, true, "", 200*time.Millisecond)
 		require.Error(t, err)
-		_, ok := err.(headReqTimeoutErr)
+		_, ok := err.(*headReqTimeoutErr)
 		assert.True(t, ok)
 		assert.Nil(t, meta)
 	})
@@ -621,7 +626,7 @@ func TestSendHeadReq(t *testing.T) {
 		meta, err := stat.sendHeadReq(ctx, "/foo/bar/timeout.txt", mockOriginAd.URL, true, "", 5*time.Second)
 
 		require.Error(t, err)
-		_, ok := err.(headReqCancelledErr)
+		_, ok := err.(*headReqCancelledErr)
 		assert.True(t, ok)
 		assert.Nil(t, meta)
 	})


### PR DESCRIPTION
Fixes #1464 

For topology legacy origins, they have `authUrl` for protected objects and `url` for public objects. However, our `stat` call only checks against `url` as the base url of the object. This PR added an additional attempt to try the `authUrl` endpoint if we get error from the first two attempts (first one is `url` endpoint with digest requested, second one is to get rid of digest)