### PR TITLE
Fix various issues in `stat`

### DIFF
--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -48,7 +48,7 @@ Director:
   CacheSortMethod: "distance"
   MinStatResponse: 1
   MaxStatResponse: 1
-  StatTimeout: 300ms
+  StatTimeout: 1000ms
   StatConcurrencyLimit: 1000
   AdvertisementTTL: 15m
   OriginCacheHealthTestInterval: 15s

--- a/director/director.go
+++ b/director/director.go
@@ -537,7 +537,7 @@ func redirectToOrigin(ginCtx *gin.Context) {
 		// Query Origins and check if the object exists on the server
 		q := NewObjectStat()
 		qr := q.Query(context.Background(), reqPath, config.OriginType, 1, 3,
-			withOriginAds(originAds), WithToken(reqParams.Get("authz")))
+			withOriginAds(originAds), WithToken(reqParams.Get("authz")), withAuth(!namespaceAd.PublicRead))
 		log.Debugf("Stat result for %s: %s", reqPath, qr.String())
 
 		// For successful response, we got a list of URL to access the object.

--- a/director/director.go
+++ b/director/director.go
@@ -546,7 +546,7 @@ func redirectToOrigin(ginCtx *gin.Context) {
 			for _, obj := range qr.Objects {
 				serverHost := obj.URL.Host
 				for _, oAd := range originAds {
-					if oAd.URL.Host == serverHost {
+					if oAd.URL.Host == serverHost || oAd.AuthURL.Host == serverHost {
 						availableOriginAds = append(availableOriginAds, oAd)
 					}
 				}

--- a/director/stat.go
+++ b/director/stat.go
@@ -213,7 +213,7 @@ func (stat *ObjectStat) sendHeadReq(ctx context.Context, objectName string, data
 	if res.StatusCode == 404 {
 		return nil, &headReqNotFoundErr{"file not found on the server " + dataUrl.String()}
 	} else if res.StatusCode == 403 {
-		return nil, &headReqForbiddenErr{fmt.Sprintf("authorization failed for origin %s. Token is required", dataUrl.String()), ""}
+		return nil, &headReqForbiddenErr{fmt.Sprintf("authorization failed for the server at %s. Token is required", dataUrl.String()), ""}
 	} else if res.StatusCode != 200 {
 		resBody, err := io.ReadAll(res.Body)
 		if err != nil {
@@ -322,34 +322,34 @@ func (stat *ObjectStat) queryServersForObject(cancelContext context.Context, obj
 	statUtilsMutex.RLock()
 	defer statUtilsMutex.RUnlock()
 
-	for _, sAD := range ads {
-		statUtil, ok := statUtils[sAD.URL.String()]
+	for _, adExt := range ads {
+		statUtil, ok := statUtils[adExt.URL.String()]
 		if !ok {
 			numTotalReq += 1
-			log.Debugf("Origin %q is missing data for stat call, skip querying...", sAD.Name)
+			log.Debugf("Server %q is missing data for stat call, skip querying...", adExt.Name)
 			continue
 		}
 		if statUtil.Context.Err() != nil {
 			numTotalReq += 1
-			log.Debugf("Origin %q is evicted from the cache, context has been cancelled, skip querying...", sAD.Name)
+			log.Debugf("Server %q is evicted from the cache, context has been cancelled, skip querying...", adExt.Name)
 			continue
 		}
 		// Use an anonymous func to pass variable safely to the goroutine
-		func(sAdInt server_structs.ServerAd) {
+		func(serverAd server_structs.ServerAd) {
 			statUtil.Errgroup.Go(func() error {
-				baseUrl := sAdInt.URL
+				baseUrl := serverAd.URL
 
 				// For the topology server, if the server does not support public read,
 				// or the token is provided, then it's safe to assume this request goes to authenticated endpoint
 				// For Pelican server, we don't populate authURL and only use server URL as the base URL
-				if sAdInt.FromTopology && (!sAdInt.Caps.PublicReads || cfg.token != "") && sAdInt.AuthURL.String() != "" {
-					baseUrl = sAD.AuthURL
+				if serverAd.FromTopology && (!serverAd.Caps.PublicReads || cfg.token != "") && serverAd.AuthURL.String() != "" {
+					baseUrl = serverAd.AuthURL
 				}
 
 				activeLabels := prometheus.Labels{
-					"server_name": sAdInt.Name,
-					"server_url":  sAdInt.URL.String(),
-					"server_type": string(sAdInt.Type),
+					"server_name": serverAd.Name,
+					"server_url":  baseUrl.String(),
+					"server_type": string(serverAd.Type),
 				}
 				metrics.PelicanDirectorStatActive.With(activeLabels).Inc()
 				defer metrics.PelicanDirectorStatActive.With(activeLabels).Dec()
@@ -360,35 +360,34 @@ func (stat *ObjectStat) queryServersForObject(cancelContext context.Context, obj
 				if err != nil && !errors.As(err, &cancelErr) { // Skip additional requests if the previous one is cancelled
 					// If the request returns 403 or 500, it could be because we request a digest and xrootd
 					// does not have this turned on, or had trouble calculating the checksum
-					// For old origins/caches, it has different URLs for public VS protected data
 					// Retry without digest
 					metadata, err = stat.ReqHandler(maxCancelCtx, objectName, baseUrl, false, cfg.token, timeout)
 				}
 
 				totalLabels := prometheus.Labels{
-					"server_name": sAdInt.Name,
+					"server_name": serverAd.Name,
 					"server_url":  baseUrl.String(),
-					"server_type": string(sAdInt.Type),
+					"server_type": string(serverAd.Type),
 					"result":      "",
 				}
 				if err != nil {
 					switch e := err.(type) {
 					case *headReqTimeoutErr:
-						log.Debugf("Timeout querying %s server %s for object %s after %s: %s", sAdInt.Type, sAdInt.URL.String(), objectName, timeout.String(), e.Message)
+						log.Debugf("Timeout querying %s server %s for object %s after %s: %s", serverAd.Type, baseUrl.String(), objectName, timeout.String(), e.Message)
 						negativeReqChan <- err
 						totalLabels["result"] = string(metrics.StatTimeout)
 						metrics.PelicanDirectorStatTotal.With(totalLabels).Inc()
 						return nil
 					case *headReqNotFoundErr:
-						log.Debugf("Object %s not found at %s server %s: %s", objectName, sAdInt.Type, sAdInt.URL.String(), e.Message)
+						log.Debugf("Object %s not found at %s server %s: %s", objectName, serverAd.Type, baseUrl.String(), e.Message)
 						negativeReqChan <- err
 						totalLabels["result"] = string(metrics.StatNotFound)
 						metrics.PelicanDirectorStatTotal.With(totalLabels).Inc()
 						return nil
 					case *headReqForbiddenErr:
 						fErr := err.(*headReqForbiddenErr)
-						fErr.IssuerUrl = sAD.AuthURL.String()
-						log.Debugf("Access denied for object %s at %s server %s: %s", objectName, sAdInt.Type, sAdInt.URL.String(), e.Message)
+						fErr.IssuerUrl = serverAd.AuthURL.String()
+						log.Debugf("Access denied for object %s at %s server %s: %s", objectName, serverAd.Type, baseUrl.String(), e.Message)
 						deniedReqChan <- fErr
 						totalLabels["result"] = string(metrics.StatForbidden)
 						metrics.PelicanDirectorStatTotal.With(totalLabels).Inc()
@@ -411,7 +410,7 @@ func (stat *ObjectStat) queryServersForObject(cancelContext context.Context, obj
 				}
 				return nil
 			})
-		}(sAD)
+		}(adExt)
 	}
 
 	for {

--- a/director/stat.go
+++ b/director/stat.go
@@ -43,6 +43,7 @@ type (
 		originAds         []server_structs.ServerAd
 		cacheAds          []server_structs.ServerAd
 		token             string
+		protected         bool
 		originAdsProvided bool // Explicitly mark the originAds are provided, not based on the length of the array
 		cacheAdsProvided  bool // Explicitly mark the cacheAds are provided, not based on the length of the array
 	}
@@ -247,6 +248,14 @@ func withCacheAds(ads []server_structs.ServerAd) queryOption {
 	}
 }
 
+// For internal use only. Use to specify if the object is protected based on
+// namespace capability
+func withAuth(auth bool) queryOption {
+	return func(c *queryConfig) {
+		c.protected = auth
+	}
+}
+
 // Issue the stat call with a token
 func WithToken(tk string) queryOption {
 	return func(c *queryConfig) {
@@ -340,9 +349,9 @@ func (stat *ObjectStat) queryServersForObject(cancelContext context.Context, obj
 				baseUrl := serverAd.URL
 
 				// For the topology server, if the server does not support public read,
-				// or the token is provided, then it's safe to assume this request goes to authenticated endpoint
+				// or the token is provided, or the object is protected, then it's safe to assume this request goes to authenticated endpoint
 				// For Pelican server, we don't populate authURL and only use server URL as the base URL
-				if serverAd.FromTopology && (!serverAd.Caps.PublicReads || cfg.token != "") && serverAd.AuthURL.String() != "" {
+				if serverAd.FromTopology && (!serverAd.Caps.PublicReads || cfg.protected || cfg.token != "") && serverAd.AuthURL.String() != "" {
 					baseUrl = serverAd.AuthURL
 				}
 

--- a/director/stat.go
+++ b/director/stat.go
@@ -369,6 +369,7 @@ func (stat *ObjectStat) queryServersForObject(cancelContext context.Context, obj
 					"server_url":  baseUrl.String(),
 					"server_type": string(serverAd.Type),
 					"result":      "",
+					"message":     "",
 				}
 				if err != nil {
 					switch e := err.(type) {
@@ -400,6 +401,7 @@ func (stat *ObjectStat) queryServersForObject(cancelContext context.Context, obj
 					default:
 						negativeReqChan <- err
 						totalLabels["result"] = string(metrics.StatUnkownErr)
+						totalLabels["message"] = err.Error()
 						metrics.PelicanDirectorStatTotal.With(totalLabels).Inc()
 						return nil
 					}

--- a/director/stat_test.go
+++ b/director/stat_test.go
@@ -52,7 +52,7 @@ func TestQueryServersForObject(t *testing.T) {
 	stat.ReqHandler = func(maxCancelCtx context.Context, objectName string, dataUrl url.URL, digest bool, token string, timeout time.Duration) (*objectMetadata, error) {
 		// For a protected origin with an authURL, if it's from topology, then the serverAd.URL is likely timeout
 		if dataUrl.String() == "https://mock-private-topo-origin.com" ||
-			(dataUrl.String() == "https://mock-mix-ns-topo-origin.com" && strings.HasPrefix(objectName, "/mix/private")) {
+			(dataUrl.String() == "http://mock-mix-ns-topo-origin.com" && strings.HasPrefix(objectName, "/mix/private")) {
 			return nil, &headReqTimeoutErr{"Request timeout"}
 		} else {
 			return &objectMetadata{URL: *dataUrl.JoinPath(objectName)}, nil
@@ -91,27 +91,27 @@ func TestQueryServersForObject(t *testing.T) {
 			Type:    server_structs.OriginType}
 		mockServerAdPrivateTopology := server_structs.ServerAd{
 			Name:         "originPrivateTopology",
-			URL:          url.URL{Host: "mock-private-topo-origin.com", Scheme: "https"},
+			URL:          url.URL{Host: "mock-private-topo-origin.com", Scheme: "http"},
 			AuthURL:      url.URL{Host: "mock-private-topo-origin-auth.com:8444", Scheme: "https"},
 			Caps:         server_structs.Capabilities{PublicReads: false},
 			Type:         server_structs.OriginType,
 			FromTopology: true}
 		mockServerAdPublicTopology := server_structs.ServerAd{
 			Name:         "originPublicTopology",
-			URL:          url.URL{Host: "mock-public-topo-origin.com", Scheme: "https"},
+			URL:          url.URL{Host: "mock-public-topo-origin.com", Scheme: "http"},
 			AuthURL:      url.URL{Host: "mock-public-topo-origin-auth.com:8444", Scheme: "https"},
 			Caps:         server_structs.Capabilities{PublicReads: true},
 			Type:         server_structs.OriginType,
 			FromTopology: true}
 		mockServerAdPrivateTopologyWOAuthUrl := server_structs.ServerAd{
 			Name:         "originPrivateTopologyNoAuthUrl",
-			URL:          url.URL{Host: "mock-private-topo-origin-no-authurl.com", Scheme: "https"},
+			URL:          url.URL{Host: "mock-private-topo-origin-no-authurl.com", Scheme: "http"},
 			Caps:         server_structs.Capabilities{PublicReads: false},
 			Type:         server_structs.OriginType,
 			FromTopology: true}
 		mockTopoPubServerMixNs := server_structs.ServerAd{
 			Name:         "originMixNsTopology",
-			URL:          url.URL{Host: "mock-mix-ns-topo-origin.com", Scheme: "https"},
+			URL:          url.URL{Host: "mock-mix-ns-topo-origin.com", Scheme: "http"},
 			AuthURL:      url.URL{Host: "mock-mix-ns-topo-origin-auth.com:8444", Scheme: "https"},
 			Caps:         server_structs.Capabilities{PublicReads: true},
 			Type:         server_structs.OriginType,
@@ -635,7 +635,7 @@ func TestQueryServersForObject(t *testing.T) {
 
 		assert.Contains(t, result.Msg, "Maximum responses reached for stat. Return result and cancel ongoing requests.")
 		require.Equal(t, 1, len(result.Objects))
-		assert.Equal(t, "https://mock-public-topo-origin.com/public/topology/test.txt", result.Objects[0].URL.String(),
+		assert.Equal(t, "http://mock-public-topo-origin.com/public/topology/test.txt", result.Objects[0].URL.String(),
 			"Return value is not expected:", result.Objects[0].URL.String())
 	})
 
@@ -654,7 +654,7 @@ func TestQueryServersForObject(t *testing.T) {
 
 		assert.Contains(t, result.Msg, "Maximum responses reached for stat. Return result and cancel ongoing requests.")
 		require.Equal(t, 1, len(result.Objects))
-		assert.Equal(t, "https://mock-private-topo-origin-no-authurl.com/protected/topology/noauth/test.txt", result.Objects[0].URL.String(),
+		assert.Equal(t, "http://mock-private-topo-origin-no-authurl.com/protected/topology/noauth/test.txt", result.Objects[0].URL.String(),
 			"Return value is not expected:", result.Objects[0].URL.String())
 	})
 
@@ -692,7 +692,7 @@ func TestQueryServersForObject(t *testing.T) {
 
 		assert.Contains(t, result.Msg, "Maximum responses reached for stat. Return result and cancel ongoing requests.")
 		require.Equal(t, 1, len(result.Objects))
-		assert.Equal(t, "https://mock-mix-ns-topo-origin.com/mix/public/test.txt", result.Objects[0].URL.String(),
+		assert.Equal(t, "http://mock-mix-ns-topo-origin.com/mix/public/test.txt", result.Objects[0].URL.String(),
 			"Return value is not expected:", result.Objects[0].URL.String())
 	})
 }

--- a/local_cache/cache_test.go
+++ b/local_cache/cache_test.go
@@ -416,7 +416,7 @@ func TestOriginUnresponsive(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	viper.Reset()
-	viper.Set("Transport.ResponseHeaderTimeout", "2s")
+	viper.Set("Transport.ResponseHeaderTimeout", "3s")
 	viper.Set("Logging.Level", "debug")
 	ft := fed_test_utils.NewFedTest(t, pubOriginCfg)
 
@@ -442,7 +442,7 @@ func TestOriginUnresponsive(t *testing.T) {
 		client.WithCaches(cacheUrl))
 	assert.Error(t, err)
 	var sce *client.StatusCodeError
-	assert.True(t, errors.As(err, &sce))
+	assert.True(t, errors.As(err, &sce), "error type does not match expected. Got ", err.Error())
 	if sce != nil {
 		assert.Equal(t, int(*sce), 504)
 	}

--- a/metrics/director.go
+++ b/metrics/director.go
@@ -80,5 +80,5 @@ var (
 	PelicanDirectorStatTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "pelican_director_stat_total",
 		Help: "The total stat queries the director issues. The status can be Succeeded, Cancelled, Timeout, Forbidden, or UnknownErr",
-	}, []string{"server_name", "server_url", "server_type", "result"}) // status: see enums for DirectorStatResult
+	}, []string{"server_name", "server_url", "server_type", "result", "message"}) // result: see enums for DirectorStatResult. message: error message if result  == StatUnkownErr
 )


### PR DESCRIPTION
Fixes #1474 

This PR fixes two issues related to `stat`:
- If `stat` uses AuthURL instead of URL due to Topology server authentication, there is a mismatch when we compare the `stat` result and available serverAds and generate the final server response, thus a successful stat returns 0 matched servers and a 404
- Shadowed variable name in the `stat` goroutine that gave back wrong URL in both log and as the `issuer` url
- The default `300ms` timeout is too short for the Origins distant from the director, and this PR raised default value to 1000ms 

With this patch in, we should be able to fix most of the 404s the director returned in the production 