### PR TITLE
Implemented client version metric

### DIFF
--- a/director/director.go
+++ b/director/director.go
@@ -1166,6 +1166,7 @@ func collectClientVersionMetric(c *gin.Context) {
 
 	reqVer, err := version.NewVersion(reqVerStr)
 	if err != nil {
+		log.Error("Failed to parse client version")
 		return
 	}
 	versionSegments := reqVer.Segments()

--- a/director/director.go
+++ b/director/director.go
@@ -1180,7 +1180,7 @@ func collectClientVersionMetric(reqVer *version.Version, service string) {
 
 	shortendVersion := strings.Join(strSegments, ".")
 
-	metrics.PelicanDirectorClientVersionTotal.With(prometheus.Labels{"version": shortendVersion}).Inc()
+	metrics.PelicanDirectorClientVersionTotal.With(prometheus.Labels{"version": shortendVersion, "service": service}).Inc()
 }
 
 func RegisterDirectorAPI(ctx context.Context, router *gin.RouterGroup) {

--- a/director/director.go
+++ b/director/director.go
@@ -1168,6 +1168,13 @@ func collectClientVersionMetric(c *gin.Context) {
 	}
 	reqVerStr, _ := utils.ExtractVersionAndServiceFromUserAgent(userAgentSlc[0])
 
+	// non-pelican client
+	if len(reqVerStr) == 0 {
+		// non-pelican clients will be marked as "other"
+		metrics.PelicanDirectorClientVersionTotal.With(prometheus.Labels{"version": "other"}).Inc()
+		return
+	}
+
 	reqVer, err := version.NewVersion(reqVerStr)
 	if err != nil {
 		log.Error("Failed to parse client version")

--- a/director/director.go
+++ b/director/director.go
@@ -216,7 +216,7 @@ func versionCompatCheck(ginCtx *gin.Context) error {
 	// requirements between origins, clients, and other services.
 	reqVerStr, service := utils.ExtractVersionAndServiceFromUserAgent(userAgent)
 	if reqVerStr == "" || service == "" {
-		return errors.New("Could not extract service or client version")
+		return nil
 	}
 	reqVer, err := version.NewVersion(reqVerStr)
 	if err != nil {

--- a/director/director.go
+++ b/director/director.go
@@ -1160,13 +1160,14 @@ func collectClientVersionMiddleware(c *gin.Context) {
 	userAgentSlc := c.Request.Header["User-Agent"]
 	if len(userAgentSlc) < 1 {
 		log.Error("Failed to parse User-Agent")
+		return
 	}
 
 	userAgent := userAgentSlc[0]
-
 	uaRegExp := regexp.MustCompile(`^pelican-[^\/]+\/\d+\.\d+\.\d+`)
 	if matches := uaRegExp.MatchString(userAgent); !matches {
 		log.Error("Failed to match User-Agent for Pelican client version")
+		return
 	}
 
 	userAgentSplit := strings.Split(userAgent, "/")

--- a/director/director.go
+++ b/director/director.go
@@ -1156,6 +1156,10 @@ func getHealthTestFile(ctx *gin.Context) {
 	}
 }
 
+// collectClientVersionMetric will get the user agent of an incoming request
+// parse out the version from it and update the pelican_director_client_version_total metric
+//
+// In the case that parser fails, then metric is not updated
 func collectClientVersionMetric(c *gin.Context) {
 	userAgentSlc := c.Request.Header["User-Agent"]
 	if len(userAgentSlc) < 1 {

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -1183,7 +1183,7 @@ func TestRedirects(t *testing.T) {
 		// Create a request to the endpoint
 		w := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", "/api/v1.0/director/origin/pelican/monitoring/test.txt", nil)
-		req.Header.Add("User-Agent", "pelican-v7.6.1")
+		req.Header.Add("User-Agent", "pelican-client/7.6.1")
 		router.ServeHTTP(w, req)
 
 		require.Equal(t, http.StatusTemporaryRedirect, w.Code)
@@ -1214,7 +1214,7 @@ func TestRedirects(t *testing.T) {
 
 		req, _ := http.NewRequest("GET", "/my/server", nil)
 		// Provide a few things so that redirectToCache doesn't choke
-		req.Header.Add("User-Agent", "pelican-v7.999.999")
+		req.Header.Add("User-Agent", "pelican-client/7.6.1")
 		req.Header.Add("X-Real-Ip", "128.104.153.60")
 
 		recorder := httptest.NewRecorder()
@@ -1229,7 +1229,7 @@ func TestRedirects(t *testing.T) {
 
 		// Make sure we can still get a cache list with a smaller number of caches
 		req, _ = http.NewRequest("GET", "/my/server/2", nil)
-		req.Header.Add("User-Agent", "pelican-v7.999.999")
+		req.Header.Add("User-Agent", "pelican-client/7.6.1")
 		req.Header.Add("X-Real-Ip", "128.104.153.60")
 		c.Request = req
 
@@ -1256,7 +1256,7 @@ func TestRedirects(t *testing.T) {
 
 		// This one should have a collections url because it has a dirlisthost
 		req, _ := http.NewRequest("GET", "/my/server", nil)
-		req.Header.Add("User-Agent", "pelican-v7.999.999")
+		req.Header.Add("User-Agent", "pelican-client/7.6.1")
 		req.Header.Add("X-Real-Ip", "128.104.153.60")
 		recorder := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(recorder)
@@ -1266,7 +1266,7 @@ func TestRedirects(t *testing.T) {
 
 		// This one has no dirlisthost
 		req, _ = http.NewRequest("GET", "/my/server/2", nil)
-		req.Header.Add("User-Agent", "pelican-v7.999.999")
+		req.Header.Add("User-Agent", "pelican-client/7.6.1")
 		req.Header.Add("X-Real-Ip", "128.104.153.60")
 		c.Request = req
 		redirectToCache(c)

--- a/metrics/director.go
+++ b/metrics/director.go
@@ -81,4 +81,9 @@ var (
 		Name: "pelican_director_stat_total",
 		Help: "The total stat queries the director issues. The status can be Succeeded, Cancelled, Timeout, Forbidden, or UnknownErr",
 	}, []string{"server_name", "server_url", "server_type", "result"}) // status: see enums for DirectorStatResult
+
+	PelicanDirectorClientVersionTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "pelican_director_client_version_total",
+		Help: "The total amount of requests from client versions.",
+	}, []string{"version"})
 )

--- a/metrics/director.go
+++ b/metrics/director.go
@@ -85,5 +85,5 @@ var (
 	PelicanDirectorClientVersionTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "pelican_director_client_version_total",
 		Help: "The total number of requests from client versions.",
-	}, []string{"version"})
+	}, []string{"version", "service"})
 )

--- a/metrics/director.go
+++ b/metrics/director.go
@@ -84,6 +84,6 @@ var (
 
 	PelicanDirectorClientVersionTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "pelican_director_client_version_total",
-		Help: "The total amount of requests from client versions.",
+		Help: "The total number of requests from client versions.",
 	}, []string{"version"})
 )

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -21,6 +21,7 @@ package utils
 import (
 	"net"
 	"net/url"
+	"regexp"
 	"strings"
 	"unicode"
 
@@ -142,4 +143,16 @@ func ExtractAndMaskIP(ipStr string) (maskedIP string, ok bool) {
 	} else {
 		return ApplyIPMask(ipStr)
 	}
+}
+
+func ExtractVersionAndServiceFromUserAgent(userAgent string) (reqVer, service string) {
+	uaRegExp := regexp.MustCompile(`^pelican-[^\/]+\/\d+\.\d+\.\d+`)
+	if matches := uaRegExp.MatchString(userAgent); !matches {
+		return "", ""
+	}
+
+	userAgentSplit := strings.Split(userAgent, "/")
+	reqVer = userAgentSplit[1]
+	service = (strings.Split(userAgentSplit[0], "-"))[1]
+	return reqVer, service
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -145,6 +145,9 @@ func ExtractAndMaskIP(ipStr string) (maskedIP string, ok bool) {
 	}
 }
 
+// ExtractVersionAndServiceFromUserAgent will extract the Pelican version and service from
+// the user agent.
+// It will return empty strings if the provided userAgent failes to match against the parser
 func ExtractVersionAndServiceFromUserAgent(userAgent string) (reqVer, service string) {
 	uaRegExp := regexp.MustCompile(`^pelican-[^\/]+\/\d+\.\d+\.\d+`)
 	if matches := uaRegExp.MatchString(userAgent); !matches {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -184,3 +184,29 @@ func TestExtractAndMaskIP(t *testing.T) {
 		assert.Equal(t, expected, maskedIP)
 	})
 }
+
+func TestExtractVersionAndServiceFromUserAgent(t *testing.T) {
+	t.Run("testNormalUserAgent", func(t *testing.T) {
+		userAgent := "pelican-origin/7.9.0"
+		expectedVersion := "7.9.0"
+		expectedService := "origin"
+		version, service := ExtractVersionAndServiceFromUserAgent(userAgent)
+
+		assert.Equal(t, expectedVersion, version)
+		assert.Equal(t, expectedService, service)
+	})
+
+	t.Run("testInvalidUserAgent", func(t *testing.T) {
+		invalidUserAgent := "thisisnotvalid"
+		version, service := ExtractVersionAndServiceFromUserAgent(invalidUserAgent)
+		assert.Equal(t, 0, len(version))
+		assert.Equal(t, 0, len(service))
+	})
+
+	t.Run("testEmptyUserAgent", func(t *testing.T) {
+		emptyUserAgent := ""
+		version, service := ExtractVersionAndServiceFromUserAgent(emptyUserAgent)
+		assert.Equal(t, 0, len(version))
+		assert.Equal(t, 0, len(service))
+	})
+}


### PR DESCRIPTION
This PR addresses issue #1483. This PR adds a new middleware to collect and parse the user-agent from client requests and increment a counter metric with the label being the client version.