### PR TITLE
Add X-Pelican-[Authorization/Token-Generation] headers to origin redirects

### DIFF
--- a/director/director.go
+++ b/director/director.go
@@ -184,6 +184,44 @@ func getRequestParameters(req *http.Request) (requestParams url.Values) {
 	return
 }
 
+// Generates the X-Pelican-Authorization header (when applicable) for responses that have
+// issued a request where token generation may be needed. This header informs the client
+// of the issuer that can be used to generate a token for the requested resource.
+func generateXAuthHeader(ginCtx *gin.Context, namespaceAd server_structs.NamespaceAdV2) {
+	if len(namespaceAd.Issuer) != 0 {
+		issStrings := []string{}
+		for _, tokIss := range namespaceAd.Issuer {
+			issStrings = append(issStrings, "issuer="+tokIss.IssuerUrl.String())
+		}
+		ginCtx.Writer.Header()["X-Pelican-Authorization"] = issStrings
+	}
+}
+
+// Generates the X-Pelican-Token-Generation header (when applicable) for responses that have
+// issued a request where token generation may be needed.
+func generateXTokenGenHeader(ginCtx *gin.Context, namespaceAd server_structs.NamespaceAdV2) {
+	if len(namespaceAd.Generation) != 0 {
+		tokenGen := ""
+		first := true
+		hdrVals := []string{namespaceAd.Generation[0].CredentialIssuer.String(), fmt.Sprint(namespaceAd.Generation[0].MaxScopeDepth),
+			string(namespaceAd.Generation[0].Strategy)}
+		for idx, hdrKey := range []string{"issuer", "max-scope-depth", "strategy"} {
+			hdrVal := hdrVals[idx]
+			if hdrVal == "" {
+				continue
+			}
+			if !first {
+				tokenGen += ", "
+			}
+			first = false
+			tokenGen += hdrKey + "=" + hdrVal
+		}
+		if tokenGen != "" {
+			ginCtx.Writer.Header()["X-Pelican-Token-Generation"] = []string{tokenGen}
+		}
+	}
+}
+
 func getFinalRedirectURL(rurl url.URL, requstParams url.Values) string {
 	rQuery := rurl.Query()
 	for key, vals := range requstParams {
@@ -417,34 +455,10 @@ func redirectToCache(ginCtx *gin.Context) {
 		linkHeader += fmt.Sprintf(`<%s>; rel="duplicate"; pri=%d; depth=%d`, redirectURL.String(), idx+1, depth)
 	}
 	ginCtx.Writer.Header()["Link"] = []string{linkHeader}
-	if len(namespaceAd.Issuer) != 0 {
 
-		issStrings := []string{}
-		for _, tokIss := range namespaceAd.Issuer {
-			issStrings = append(issStrings, "issuer="+tokIss.IssuerUrl.String())
-		}
-		ginCtx.Writer.Header()["X-Pelican-Authorization"] = issStrings
-	}
-
-	if len(namespaceAd.Generation) != 0 {
-		tokenGen := ""
-		first := true
-		hdrVals := []string{namespaceAd.Generation[0].CredentialIssuer.String(), fmt.Sprint(namespaceAd.Generation[0].MaxScopeDepth), string(namespaceAd.Generation[0].Strategy)}
-		for idx, hdrKey := range []string{"issuer", "max-scope-depth", "strategy"} {
-			hdrVal := hdrVals[idx]
-			if hdrVal == "" {
-				continue
-			}
-			if !first {
-				tokenGen += ", "
-			}
-			first = false
-			tokenGen += hdrKey + "=" + hdrVal
-		}
-		if tokenGen != "" {
-			ginCtx.Writer.Header()["X-Pelican-Token-Generation"] = []string{tokenGen}
-		}
-	}
+	// Generate headers needed for token generation/verification
+	generateXAuthHeader(ginCtx, namespaceAd)
+	generateXTokenGenHeader(ginCtx, namespaceAd)
 
 	var colUrl string
 	// If the namespace or the origin does not allow directory listings, then we should not advertise a collections-url.
@@ -675,6 +689,10 @@ func redirectToOrigin(ginCtx *gin.Context) {
 		})
 		return
 	}
+
+	// Generate headers needed for token generation/verification
+	generateXAuthHeader(ginCtx, namespaceAd)
+	generateXTokenGenHeader(ginCtx, namespaceAd)
 
 	// If we are doing a PUT, check to see if any origins are writeable
 	if ginCtx.Request.Method == "PUT" {

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -1040,6 +1040,18 @@ func TestRedirects(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
+	// Use ads generated via mock topology for generating list of caches
+	topoServer := httptest.NewServer(http.HandlerFunc(mockTopoJSONHandler))
+	defer topoServer.Close()
+	viper.Set("Federation.TopologyNamespaceUrl", topoServer.URL)
+	// viper.Set("Director.CacheSortMethod", "random")
+	// Populate ads for redirectToCache to use
+	err := AdvertiseOSDF(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		serverAds.DeleteAll()
+	})
+
 	router := gin.Default()
 	router.GET("/api/v1.0/director/origin/*any", redirectToOrigin)
 
@@ -1192,25 +1204,12 @@ func TestRedirects(t *testing.T) {
 	})
 
 	t.Run("redirect-link-header-length", func(t *testing.T) {
-		ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
-		defer func() { require.NoError(t, egrp.Wait()) }()
-		defer cancel()
-
 		viper.Reset()
-		serverAds.DeleteAll()
 		t.Cleanup(func() {
 			viper.Reset()
-			serverAds.DeleteAll()
 		})
 
-		// Use ads generated via mock topology for generating list of caches
-		topoServer := httptest.NewServer(http.HandlerFunc(mockTopoJSONHandler))
-		defer topoServer.Close()
-		viper.Set("Federation.TopologyNamespaceUrl", topoServer.URL)
 		viper.Set("Director.CacheSortMethod", "random")
-		// Populate ads for redirectToCache to use
-		err := AdvertiseOSDF(ctx)
-		require.NoError(t, err)
 
 		req, _ := http.NewRequest("GET", "/my/server", nil)
 		// Provide a few things so that redirectToCache doesn't choke
@@ -1241,18 +1240,11 @@ func TestRedirects(t *testing.T) {
 	// Make sure collections-url is correctly populated when the ns/origin comes from topology
 	t.Run("collections-url-from-topology", func(t *testing.T) {
 		viper.Reset()
-		serverAds.DeleteAll()
 		t.Cleanup(func() {
 			viper.Reset()
-			serverAds.DeleteAll()
 		})
 
-		topoServer := httptest.NewServer(http.HandlerFunc(mockTopoJSONHandler))
-		defer topoServer.Close()
-		viper.Set("Federation.TopologyNamespaceUrl", topoServer.URL)
 		viper.Set("Director.CacheSortMethod", "random")
-		err := AdvertiseOSDF(ctx)
-		require.NoError(t, err)
 
 		// This one should have a collections url because it has a dirlisthost
 		req, _ := http.NewRequest("GET", "/my/server", nil)
@@ -1271,6 +1263,52 @@ func TestRedirects(t *testing.T) {
 		c.Request = req
 		redirectToCache(c)
 		assert.NotContains(t, c.Writer.Header().Get("X-Pelican-Namespace"), "collections-url")
+	})
+
+	t.Run("object-endpoint-returns-all-headers", func(t *testing.T) {
+		viper.Reset()
+		t.Cleanup(func() {
+			viper.Reset()
+		})
+
+		viper.Set("Director.CacheSortMethod", "random")
+
+		req, _ := http.NewRequest("GET", "/my/server", nil)
+		req.Header.Add("User-Agent", "pelican-v7.999.999")
+		req.Header.Add("X-Real-Ip", "128.104.153.60")
+		recorder := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(recorder)
+		c.Request = req
+		redirectToCache(c)
+
+		assert.NotEmpty(t, c.Writer.Header().Get("Location"))
+		assert.NotEmpty(t, c.Writer.Header().Get("Link"))
+		assert.NotEmpty(t, c.Writer.Header().Get("X-Pelican-Authorization"))
+		assert.NotEmpty(t, c.Writer.Header().Get("X-Pelican-Token-Generation"))
+		assert.NotEmpty(t, c.Writer.Header().Get("X-Pelican-Namespace"))
+	})
+
+	t.Run("origin-endpoint-returns-all-headers", func(t *testing.T) {
+		viper.Reset()
+		t.Cleanup(func() {
+			viper.Reset()
+		})
+
+		viper.Set("Director.CacheSortMethod", "random")
+
+		req, _ := http.NewRequest("GET", "/my/server", nil)
+		req.Header.Add("User-Agent", "pelican-v7.999.999")
+		req.Header.Add("X-Real-Ip", "128.104.153.60")
+		recorder := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(recorder)
+		c.Request = req
+		redirectToOrigin(c)
+
+		assert.NotEmpty(t, c.Writer.Header().Get("Location"))
+		assert.NotEmpty(t, c.Writer.Header().Get("Link"))
+		assert.NotEmpty(t, c.Writer.Header().Get("X-Pelican-Authorization"))
+		assert.NotEmpty(t, c.Writer.Header().Get("X-Pelican-Token-Generation"))
+		assert.NotEmpty(t, c.Writer.Header().Get("X-Pelican-Namespace"))
 	})
 }
 


### PR DESCRIPTION
Brian noticed that PUTS using the Pelican client couldn't get the required information for token generation when an origin was configured with its own OA4MP issuer.

This PR adds the needed headers to origin redirects, and tests that both object/origin redirects contain the expected headers.

Closes #1488 