### PR TITLE
Update S3 backend version to v0.1.4 to fix trailing / bug in URLs

### DIFF
--- a/github_scripts/osx_install.sh
+++ b/github_scripts/osx_install.sh
@@ -58,9 +58,9 @@ sudo mkdir -p /etc/xrootd/client.plugins.d/
 sudo cp release_dir/etc/xrootd/client.plugins.d/pelican-plugin.conf /etc/xrootd/client.plugins.d/
 popd
 
-git clone --recurse-submodules --branch v0.1.3 https://github.com/PelicanPlatform/xrootd-s3-http.git
+git clone --recurse-submodules --branch v0.1.4 https://github.com/PelicanPlatform/xrootd-s3-http.git
 pushd xrootd-s3-http
-git checkout v0.1.3
+git checkout v0.1.4
 mkdir build
 cd build
 cmake .. -GNinja -DCMAKE_INSTALL_PREFIX=$PWD/release_dir

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -84,7 +84,7 @@ ADD https://api.github.com/repos/PelicanPlatform/xrootd-s3-http/git/refs/heads/m
 RUN \
     git clone --recurse-submodules https://github.com/PelicanPlatform/xrootd-s3-http.git && \
     cd xrootd-s3-http && \
-    git checkout v0.1.3 && \
+    git checkout v0.1.4 && \
     mkdir build && cd build && \
     cmake -DLIB_INSTALL_DIR=/usr/lib64 .. && \
     make install

--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -114,7 +114,7 @@ ADD https://api.github.com/repos/PelicanPlatform/xrootd-s3-http/git/refs/heads/m
 RUN \
     git clone --recurse-submodules https://github.com/PelicanPlatform/xrootd-s3-http.git && \
     cd xrootd-s3-http && \
-    git checkout v0.1.3 && \
+    git checkout v0.1.4 && \
     mkdir build && cd build && \
     cmake -DLIB_INSTALL_DIR=/usr/lib64 .. && \
     make install


### PR DESCRIPTION
@turetske, I'll cut a `v7.9` release when this is passing tests and gets merged. It fixes a bug in the S3 plugin that mishandles S3 service URLs with a trailing slash. Contents of the bugfix can be found [here](https://github.com/PelicanPlatform/xrootd-s3-http/pull/37)