### PR TITLE
Populate director information for stash:// URLs

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -581,7 +581,7 @@ func (te *TransferEngine) newPelicanURL(remoteUrl *url.URL) (pelicanURL pelicanU
 	}
 
 	// With an osdf:// url scheme, we assume the user will be using the OSDF so load in our osdf metadata for our url
-	if scheme == "osdf" {
+	if scheme == "osdf" || scheme == "stash" {
 		// If we are using an osdf/stash binary, we discovered the federation already --> load into local url metadata
 		if config.GetPreferredPrefix() == config.OsdfPrefix {
 			log.Debugln("In OSDF mode with osdf:// url; populating metadata with OSDF defaults")

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -693,6 +693,31 @@ func TestNewPelicanURL(t *testing.T) {
 		// Note: can't really test this for an error since that would require osg-htc.org to be down
 	})
 
+	t.Run("TestStashSchemeWithPelicanPrefixNoError", func(t *testing.T) {
+		test_utils.InitClient(t, map[string]any{})
+		te, err := NewTransferEngine(ctx)
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, te.Shutdown())
+		}()
+
+		mock.MockOSDFDiscovery(t, config.GetTransport())
+		_, err = config.SetPreferredPrefix(config.PelicanPrefix)
+		config.InitConfig()
+		assert.NoError(t, err)
+		remoteObject := "stash:///something/somewhere/thatdoesnotexist.txt"
+		remoteObjectURL, err := url.Parse(remoteObject)
+		assert.NoError(t, err)
+
+		pelicanURL, err := te.newPelicanURL(remoteObjectURL)
+		assert.NoError(t, err)
+
+		// Check pelicanURL properly filled out
+		assert.Equal(t, "https://osdf-director.osg-htc.org", pelicanURL.directorUrl)
+		viper.Reset()
+		// Note: can't really test this for an error since that would require osg-htc.org to be down
+	})
+
 	t.Run("TestPelicanSchemeNoError", func(t *testing.T) {
 		test_utils.InitClient(t, map[string]any{
 			"TLSSkipVerify": true,


### PR DESCRIPTION
A missing conditional caused stash:// URLs to not trigger metadata discovery (subsequently causing topology to be used instead of the director).

This fixes the conditional and adds a regression test.