### PR TITLE
Rewrite TCP connection reset / broken pipe messages

### DIFF
--- a/client/errorAccum.go
+++ b/client/errorAccum.go
@@ -146,6 +146,12 @@ func IsRetryable(err error) bool {
 	if errors.Is(err, config.MetadataTimeoutErr) {
 		return true
 	}
+	// There's little a user can do about a TCP connection reset besides retry; if it
+	// was due to the server crashing, then on a subsequent retry they should get a different
+	// error message (connection refused).
+	if errors.Is(err, &NetworkResetError{}) {
+		return true
+	}
 	if errors.Is(err, &StoppedTransferError{}) {
 		return true
 	}


### PR DESCRIPTION
Goal is to improve the user understanding of the error messages:

```
the existing TCP connection was broken (potentially caused by server restart or NAT/firewall issue)
```

Also marked these are retryable.

No unit tests here -- it's not clear how to inject TCP-level problems into the testing.