### PR TITLE
Server count metric

### DIFF
--- a/director/director_api.go
+++ b/director/director_api.go
@@ -21,7 +21,6 @@ package director
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"strconv"
 	"time"
 
@@ -211,21 +210,14 @@ func LaunchServerCountMetric(ctx context.Context, egrp *errgroup.Group) {
 			case <-ticker.C:
 				for _, ad := range serverAds.Items() {
 					serverAd := ad.Value()
-					var auth_url string
-					if serverAd.AuthURL == (url.URL{}) {
-						auth_url = serverAd.URL.String()
-					} else {
-						auth_url = serverAd.AuthURL.String()
-					}
 					metrics.PelicanDirectorServerCount.With(prometheus.Labels{
-						"server_type":     string(serverAd.Type),
-						"server_name":     serverAd.Name,
-						"server_auth_url": auth_url,
-						"server_url":      serverAd.URL.String(),
-						"server_web_url":  serverAd.WebURL.String(),
-						"server_lat":      fmt.Sprintf("%.4f", serverAd.Latitude),
-						"server_long":     fmt.Sprintf("%.4f", serverAd.Longitude),
-						"from_topology":   strconv.FormatBool(serverAd.FromTopology),
+						"server_name":    serverAd.Name,
+						"server_type":    string(serverAd.Type),
+						"server_url":     serverAd.URL.String(),
+						"server_web_url": serverAd.WebURL.String(),
+						"server_lat":     fmt.Sprintf("%.4f", serverAd.Latitude),
+						"server_long":    fmt.Sprintf("%.4f", serverAd.Longitude),
+						"from_topology":  strconv.FormatBool(serverAd.FromTopology),
 					}).Inc()
 				}
 			}

--- a/launchers/director_serve.go
+++ b/launchers/director_serve.go
@@ -45,6 +45,8 @@ func DirectorServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group
 
 	director.LaunchMapMetrics(ctx, egrp)
 
+	director.LaunchServerCountMetric(ctx, egrp)
+
 	director.ConfigFilterdServers()
 
 	director.LaunchServerIOQuery(ctx, egrp)

--- a/metrics/director.go
+++ b/metrics/director.go
@@ -81,4 +81,9 @@ var (
 		Name: "pelican_director_stat_total",
 		Help: "The total stat queries the director issues. The status can be Succeeded, Cancelled, Timeout, Forbidden, or UnknownErr",
 	}, []string{"server_name", "server_url", "server_type", "result"}) // status: see enums for DirectorStatResult
+
+	PelicanDirectorServerCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "pelican_director_server_count",
+		Help: "Total number of servers, delineated by pelican/non-pelican and origin/cache",
+	}, []string{"server_name", "server_type", "server_url", "server_web_url", "server_lat", "server_long", "from_topology"})
 )


### PR DESCRIPTION
This PR address issue #1492. This PR implements a new metric in the director to count the number of pelican an non-pelican servers. 