### PR TITLE
Client cleanup

### DIFF
--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -488,7 +488,7 @@ func TestObjectStat(t *testing.T) {
 				require.NoError(t, err)
 			}
 			assert.Equal(t, int64(13), got.Size)
-			assert.Equal(t, "hello_world.txt", got.Name)
+			assert.Equal(t, fmt.Sprintf("%s/hello_world.txt", export.FederationPrefix), got.Name)
 		}
 	})
 
@@ -544,7 +544,7 @@ func TestObjectStat(t *testing.T) {
 		assert.NoError(t, err)
 		if err == nil {
 			assert.Equal(t, int64(17), int64(statInfo.Size))
-			assert.Equal(t, "test.txt", statInfo.Name)
+			assert.Equal(t, fmt.Sprintf("%s/%s", fed.Exports[0].FederationPrefix, fileName), statInfo.Name)
 		}
 	})
 

--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -786,10 +786,12 @@ func TestObjectList(t *testing.T) {
 				get, err := client.DoList(fed.Ctx, listURL, client.WithTokenLocation(""))
 				require.NoError(t, err)
 				require.Len(t, get, 2)
+				require.Equal(t, fmt.Sprintf("%s/hello_world.txt", export.FederationPrefix), get[0].Name)
 			} else {
 				get, err := client.DoList(fed.Ctx, listURL, client.WithTokenLocation(tempToken.Name()))
 				require.NoError(t, err)
 				require.Len(t, get, 2)
+				require.Equal(t, fmt.Sprintf("%s/hello_world.txt", export.FederationPrefix), get[0].Name)
 			}
 		}
 	})

--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -736,39 +737,18 @@ func TestObjectList(t *testing.T) {
 	// Other set-up items:
 	testFileContent := "test file content"
 	// Create the temporary file to upload
-	tempFile, err := os.CreateTemp(t.TempDir(), "test")
+	tempFileName := filepath.Join(t.TempDir(), "test")
+	tempFile, err := os.OpenFile(tempFileName, os.O_CREATE|os.O_RDWR, 0644)
 	assert.NoError(t, err, "Error creating temp file")
-	defer os.Remove(tempFile.Name())
 	_, err = tempFile.WriteString(testFileContent)
 	assert.NoError(t, err, "Error writing to temp file")
 	tempFile.Close()
 
-	issuer, err := config.GetServerIssuerURL()
-	require.NoError(t, err)
-
-	// Create a token file
-	tokenConfig := token.NewWLCGToken()
-	tokenConfig.Lifetime = time.Minute
-	tokenConfig.Issuer = issuer
-	tokenConfig.Subject = "origin"
-	tokenConfig.AddAudienceAny()
-
-	scopes := []token_scopes.TokenScope{}
-	readScope, err := token_scopes.Storage_Read.Path("/")
-	assert.NoError(t, err)
-	scopes = append(scopes, readScope)
-	modScope, err := token_scopes.Storage_Modify.Path("/")
-	assert.NoError(t, err)
-	scopes = append(scopes, modScope)
-	tokenConfig.AddScopes(scopes...)
-	token, err := tokenConfig.CreateToken()
-	assert.NoError(t, err)
-	tempToken, err := os.CreateTemp(t.TempDir(), "token")
-	assert.NoError(t, err, "Error creating temp token file")
+	// Get a temporary token file
+	tempToken, _ := getTempToken(t)
+	defer tempToken.Close()
 	defer os.Remove(tempToken.Name())
-	_, err = tempToken.WriteString(token)
-	assert.NoError(t, err, "Error writing to temp token file")
-	tempToken.Close()
+
 	// Disable progress bars to not reuse the same mpb instance
 	viper.Set("Logging.DisableProgressBars", true)
 
@@ -786,12 +766,24 @@ func TestObjectList(t *testing.T) {
 				get, err := client.DoList(fed.Ctx, listURL, client.WithTokenLocation(""))
 				require.NoError(t, err)
 				require.Len(t, get, 2)
-				require.Equal(t, fmt.Sprintf("%s/hello_world.txt", export.FederationPrefix), get[0].Name)
+				var name string
+				if strings.Contains(get[0].Name, "hello_world.txt") {
+					name = get[0].Name
+				} else {
+					name = get[1].Name
+				}
+				require.Equal(t, fmt.Sprintf("%s/hello_world.txt", export.FederationPrefix), name)
 			} else {
 				get, err := client.DoList(fed.Ctx, listURL, client.WithTokenLocation(tempToken.Name()))
 				require.NoError(t, err)
 				require.Len(t, get, 2)
-				require.Equal(t, fmt.Sprintf("%s/hello_world.txt", export.FederationPrefix), get[0].Name)
+				var name string
+				if strings.Contains(get[0].Name, "hello_world.txt") {
+					name = get[0].Name
+				} else {
+					name = get[1].Name
+				}
+				require.Equal(t, fmt.Sprintf("%s/hello_world.txt", export.FederationPrefix), name)
 			}
 		}
 	})

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -29,7 +29,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"path/filepath"
 	"reflect"
 	"regexp"
 	"slices"
@@ -2683,9 +2682,10 @@ func listHttp(ctx context.Context, remoteObjectUrl *url.URL, directorUrl string,
 	}
 
 	for _, info := range infos {
+		jPath, _ := url.JoinPath(remotePath, info.Name())
 		// Create a FileInfo for the file and append it to the slice
 		file := FileInfo{
-			Name:    filepath.Join(remotePath, info.Name()),
+			Name:    jPath,
 			Size:    info.Size(),
 			ModTime: info.ModTime(),
 			IsDir:   info.IsDir(),

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2665,7 +2665,7 @@ func listHttp(ctx context.Context, remoteObjectUrl *url.URL, directorUrl string,
 			if !info.IsDir() {
 				// NOTE: we implement our own FileInfo here because the one we get back from stat() does not have a .name field for some reason
 				file := FileInfo{
-					Name:    path.Base(remotePath),
+					Name:    remotePath,
 					Size:    info.Size(),
 					ModTime: info.ModTime(),
 					IsDir:   false,
@@ -2762,7 +2762,7 @@ func statHttp(ctx context.Context, dest *url.URL, namespace namespaces.Namespace
 				fsinfo, err := client.Stat(endpoint.Path)
 				if err == nil {
 					info = FileInfo{
-						Name:    path.Base(endpoint.Path),
+						Name:    endpoint.Path,
 						Size:    fsinfo.Size(),
 						IsDir:   fsinfo.IsDir(),
 						ModTime: fsinfo.ModTime(),
@@ -2801,7 +2801,7 @@ func statHttp(ctx context.Context, dest *url.URL, namespace namespaces.Namespace
 			}
 
 			resultsChan <- statResults{FileInfo{
-				Name:    path.Base(endpoint.Path),
+				Name:    endpoint.Path,
 				Size:    info.Size,
 				IsDir:   info.IsDir,
 				ModTime: info.ModTime,

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -29,6 +29,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"slices"
@@ -2684,7 +2685,7 @@ func listHttp(ctx context.Context, remoteObjectUrl *url.URL, directorUrl string,
 	for _, info := range infos {
 		// Create a FileInfo for the file and append it to the slice
 		file := FileInfo{
-			Name:    info.Name(),
+			Name:    filepath.Join(remotePath, info.Name()),
 			Size:    info.Size(),
 			ModTime: info.ModTime(),
 			IsDir:   info.IsDir(),

--- a/cmd/object_ls.go
+++ b/cmd/object_ls.go
@@ -44,7 +44,7 @@ var (
 func init() {
 	flagSet := lsCmd.Flags()
 	flagSet.StringP("token", "t", "", "Token file to use for transfer")
-	flagSet.BoolP("long", "L", false, "Include extended information")
+	flagSet.BoolP("long", "l", false, "Include extended information")
 	flagSet.BoolP("collectionOnly", "C", false, "List collections only")
 	flagSet.BoolP("objectonly", "O", false, "List objects only")
 	flagSet.BoolP("json", "j", false, "Print results in JSON format")

--- a/cmd/object_ls.go
+++ b/cmd/object_ls.go
@@ -45,7 +45,7 @@ var (
 func init() {
 	flagSet := lsCmd.Flags()
 	flagSet.StringP("token", "t", "", "Token file to use for transfer")
-	flagSet.BoolP("long", "l", false, "Include extended information")
+	flagSet.BoolP("long", "L", false, "Include extended information")
 	flagSet.BoolP("collectionOnly", "C", false, "List collections only")
 	flagSet.BoolP("objectonly", "O", false, "List objects only")
 	flagSet.BoolP("json", "j", false, "Print results in JSON format")

--- a/cmd/object_ls.go
+++ b/cmd/object_ls.go
@@ -122,7 +122,7 @@ func listMain(cmd *cobra.Command, args []string) error {
 	}
 
 	// Take our fileInfos and print them in a nice way
-	// if the -L flag was set, we print more information
+	// if the -l flag was set, we print more information
 	if long {
 		w := tabwriter.NewWriter(os.Stdout, 1, 2, 10, ' ', tabwriter.TabIndent|tabwriter.DiscardEmptyColumns)
 		// If we want JSON format, we append the file info to a slice of fileInfo structs so that we can marshal it
@@ -140,7 +140,7 @@ func listMain(cmd *cobra.Command, args []string) error {
 		}
 		w.Flush()
 	} else if asJSON {
-		// In this case, we are not using the long option (-L) and want a JSON format
+		// In this case, we are not using the long option (-l) and want a JSON format
 		jsonInfo := []string{}
 		for _, info := range filteredInfos {
 			jsonInfo = append(jsonInfo, info.Name)

--- a/cmd/object_ls.go
+++ b/cmd/object_ls.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"strconv"
 	"text/tabwriter"
 
@@ -159,7 +160,7 @@ func listMain(cmd *cobra.Command, args []string) error {
 		w := tabwriter.NewWriter(os.Stdout, 1, 2, 10, ' ', tabwriter.TabIndent|tabwriter.DiscardEmptyColumns)
 		var line string
 		for _, info := range filteredInfos {
-			line += info.Name
+			line += path.Base(info.Name)
 			//increase our counter
 			column++
 

--- a/cmd/object_ls.go
+++ b/cmd/object_ls.go
@@ -45,12 +45,18 @@ var (
 func init() {
 	flagSet := lsCmd.Flags()
 	flagSet.StringP("token", "t", "", "Token file to use for transfer")
-	flagSet.BoolP("long", "L", false, "Include extended information")
+	flagSet.BoolP("long", "L", false, "Include extended information - The '-L' for long output will be changed to '-l' in the 7.11.0 pelican release")
 	flagSet.BoolP("collectionOnly", "C", false, "List collections only")
 	flagSet.BoolP("objectonly", "O", false, "List objects only")
 	flagSet.BoolP("json", "j", false, "Print results in JSON format")
 
 	objectCmd.AddCommand(lsCmd)
+
+	lsCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		if cmd.Flags().Changed("long") {
+			log.Warningln("The '-L' for long output will be changed to '-l' in the 7.11.0 pelican release")
+		}
+	}
 }
 
 func listMain(cmd *cobra.Command, args []string) error {

--- a/cmd/object_ls.go
+++ b/cmd/object_ls.go
@@ -144,7 +144,7 @@ func listMain(cmd *cobra.Command, args []string) error {
 		// In this case, we are not using the long option (-l) and want a JSON format
 		jsonInfo := []string{}
 		for _, info := range filteredInfos {
-			jsonInfo = append(jsonInfo, info.Name)
+			jsonInfo = append(jsonInfo, path.Base(info.Name))
 		}
 		// Convert the FileInfo to JSON and print it
 		jsonData, err := json.Marshal(jsonInfo)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,6 +86,9 @@ func (i *uint16Value) String() string { return strconv.FormatUint(uint64(*i), 10
 func Execute() error {
 	egrp, egrpCtx := errgroup.WithContext(context.Background())
 	ctx := context.WithValue(egrpCtx, config.EgrpKey, egrp)
+	if rootCmd.Flags().Changed("log") {
+		fmt.Println("WARNING - '-l' as a flag for logging will be changed to '-L' in the 7.11.0 pelican release")
+	}
 	exeErr := rootCmd.ExecuteContext(ctx)
 	if exeErr != nil {
 		log.Errorln("Fatal error occurred at the start of the program. Cleanup started:", exeErr)
@@ -147,7 +150,7 @@ func init() {
 		panic(err)
 	}
 
-	rootCmd.PersistentFlags().StringP("log", "L", "", "Specified log output file")
+	rootCmd.PersistentFlags().StringP("log", "l", "", "Specified log output file - WARNING This is being deprecated and will become 'L' in 7.11.0")
 	if err := viper.BindPFlag("Logging.LogLocation", rootCmd.PersistentFlags().Lookup("log")); err != nil {
 		panic(err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,9 +86,6 @@ func (i *uint16Value) String() string { return strconv.FormatUint(uint64(*i), 10
 func Execute() error {
 	egrp, egrpCtx := errgroup.WithContext(context.Background())
 	ctx := context.WithValue(egrpCtx, config.EgrpKey, egrp)
-	if rootCmd.Flags().Changed("log") {
-		fmt.Println("WARNING - '-l' as a flag for logging will be changed to '-L' in the 7.11.0 pelican release")
-	}
 	exeErr := rootCmd.ExecuteContext(ctx)
 	if exeErr != nil {
 		log.Errorln("Fatal error occurred at the start of the program. Cleanup started:", exeErr)
@@ -150,7 +147,7 @@ func init() {
 		panic(err)
 	}
 
-	rootCmd.PersistentFlags().StringP("log", "l", "", "Specified log output file - WARNING This is being deprecated and will become 'L' in 7.11.0")
+	rootCmd.PersistentFlags().StringP("log", "l", "", "Specified log output file - The '-l' for logging will be changed to '-L' in the 7.11.0 pelican release")
 	if err := viper.BindPFlag("Logging.LogLocation", rootCmd.PersistentFlags().Lookup("log")); err != nil {
 		panic(err)
 	}
@@ -171,5 +168,11 @@ func init() {
 	}
 	if err := viper.BindPFlag("Server.WebPort", portFlag); err != nil {
 		panic(err)
+	}
+
+	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		if cmd.Flags().Changed("log") {
+			log.Warningln("The '-l' for logging will be changed to '-L' in the 7.11.0 pelican release")
+		}
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -147,7 +147,7 @@ func init() {
 		panic(err)
 	}
 
-	rootCmd.PersistentFlags().StringP("log", "l", "", "Specified log output file")
+	rootCmd.PersistentFlags().StringP("log", "L", "", "Specified log output file")
 	if err := viper.BindPFlag("Logging.LogLocation", rootCmd.PersistentFlags().Lookup("log")); err != nil {
 		panic(err)
 	}

--- a/github_scripts/get_put_test.sh
+++ b/github_scripts/get_put_test.sh
@@ -123,7 +123,7 @@ do
 done
 
 # Run pelican object put
-./pelican object put ./get_put_tmp/input.txt pelican://$HOSTNAME:8444/test/input.txt -d -t get_put_tmp/test-token.jwt -L get_put_tmp/putOutput.txt
+./pelican object put ./get_put_tmp/input.txt pelican://$HOSTNAME:8444/test/input.txt -d -t get_put_tmp/test-token.jwt -l get_put_tmp/putOutput.txt
 
 # Check output of command
 if grep -q "Dumping response: HTTP/1.1 200 OK" get_put_tmp/putOutput.txt; then
@@ -134,7 +134,7 @@ else
     exit 1
 fi
 
-./pelican object get pelican://$HOSTNAME:8444/test/input.txt get_put_tmp/output.txt -d -t get_put_tmp/test-token.jwt -L get_put_tmp/getOutput.txt
+./pelican object get pelican://$HOSTNAME:8444/test/input.txt get_put_tmp/output.txt -d -t get_put_tmp/test-token.jwt -l get_put_tmp/getOutput.txt
 
 # Check output of command
 if grep -q "HTTP Transfer was successful" get_put_tmp/getOutput.txt; then

--- a/github_scripts/get_put_test.sh
+++ b/github_scripts/get_put_test.sh
@@ -123,7 +123,7 @@ do
 done
 
 # Run pelican object put
-./pelican object put ./get_put_tmp/input.txt pelican://$HOSTNAME:8444/test/input.txt -d -t get_put_tmp/test-token.jwt -l get_put_tmp/putOutput.txt
+./pelican object put ./get_put_tmp/input.txt pelican://$HOSTNAME:8444/test/input.txt -d -t get_put_tmp/test-token.jwt -L get_put_tmp/putOutput.txt
 
 # Check output of command
 if grep -q "Dumping response: HTTP/1.1 200 OK" get_put_tmp/putOutput.txt; then
@@ -134,7 +134,7 @@ else
     exit 1
 fi
 
-./pelican object get pelican://$HOSTNAME:8444/test/input.txt get_put_tmp/output.txt -d -t get_put_tmp/test-token.jwt -l get_put_tmp/getOutput.txt
+./pelican object get pelican://$HOSTNAME:8444/test/input.txt get_put_tmp/output.txt -d -t get_put_tmp/test-token.jwt -L get_put_tmp/getOutput.txt
 
 # Check output of command
 if grep -q "HTTP Transfer was successful" get_put_tmp/getOutput.txt; then


### PR DESCRIPTION
This PR addresses two issues, both involving cleaning up client interaction and responses.

The first changes "ls -L" to "ls -l" This also changed the log flag to "-L" to avoid conflicts.

The second changes the output of "ls -l" and "stat" to return the full object name with the namespace rather than just the top level name.

closes #1498 
closes #1497 