### PR TITLE
Switch xrootd source in prod container from osg-testing repo to osg

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -47,10 +47,8 @@ RUN groupadd -o -g 10940 xrootd
 RUN useradd -o -u 10940 -g 10940 -s /bin/sh xrootd
 
 # Install dependencies
-# FIXME: We install xrootd from the osg-test repo to incorporate patch for the throttle plugin
-# We should come back and remove it once xrootd 5.7.0 is released
 RUN yum -y update \
-    && yum -y --allowerasing --enablerepo osg-testing install tini xrootd xrootd-client xrdcl-http xrootd-server xrootd-scitokens xrootd-voms xrootd-multiuser curl java-17-openjdk-headless \
+    && yum -y --allowerasing install tini xrootd xrootd-client xrdcl-http xrootd-server xrootd-scitokens xrootd-voms xrootd-multiuser curl java-17-openjdk-headless \
     && yum clean all \
     && rm -rf /var/cache/yum/
 
@@ -59,7 +57,7 @@ RUN yum -y update \
 ####
 FROM dependency-build AS xrootd-plugin-builder
 # Install necessary build dependencies
-RUN  yum install -y --enablerepo=osg-testing xrootd-devel xrootd-server-devel xrootd-client-devel curl-devel openssl-devel git cmake3 gcc-c++ sqlite-devel
+RUN  yum install -y xrootd-devel xrootd-server-devel xrootd-client-devel curl-devel openssl-devel git cmake3 gcc-c++ sqlite-devel
 
 # The ADD command with a api.github.com URL in the next couple of sections
 # are for cache-hashing of the external repository that we rely on to build

--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -57,7 +57,7 @@ RUN yum install -y yum-utils createrepo https://repo.opensciencegrid.org/osg/23-
     yum install -y rpm-build && \
     mkdir -p /usr/local/src/rpmbuild/SRPMS && \
     cd /usr/local/src/rpmbuild/SRPMS && \
-    yumdownloader --source xrootd --disablerepo=\* --enablerepo=osg-development-source && \
+    yumdownloader --source xrootd --disablerepo=\* --enablerepo=osg-source && \
     yum-builddep -y xrootd-*.osg*.src.rpm && \
     rpmbuild --define 'osg 1' \
              --define 'dist .osg.el9' \


### PR DESCRIPTION
Things in osg-testing started breaking, and I crave stability in this wild, uncertain world. Let's go back to installing xrootd from the `osg` repos and remember a time when life was simpler.

Doing so seems to fix the prod container's inability to build xrdcl-pelican due to CMake errors complaining about bad function overrides.