### PR TITLE
Switch container builds to use osg-testing instead of osg repos

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -48,7 +48,7 @@ RUN useradd -o -u 10940 -g 10940 -s /bin/sh xrootd
 
 # Install dependencies
 RUN yum -y update \
-    && yum -y --allowerasing install tini xrootd xrootd-client xrdcl-http xrootd-server xrootd-scitokens xrootd-voms xrootd-multiuser curl java-17-openjdk-headless \
+    && yum -y --allowerasing --enablerepo osg-testing install tini xrootd xrootd-client xrdcl-http xrootd-server xrootd-scitokens xrootd-voms xrootd-multiuser curl java-17-openjdk-headless \
     && yum clean all \
     && rm -rf /var/cache/yum/
 
@@ -57,7 +57,7 @@ RUN yum -y update \
 ####
 FROM dependency-build AS xrootd-plugin-builder
 # Install necessary build dependencies
-RUN  yum install -y xrootd-devel xrootd-server-devel xrootd-client-devel curl-devel openssl-devel git cmake3 gcc-c++ sqlite-devel
+RUN  yum install -y --enablerepo=osg-testing xrootd-devel xrootd-server-devel xrootd-client-devel curl-devel openssl-devel git cmake3 gcc-c++ sqlite-devel
 
 # The ADD command with a api.github.com URL in the next couple of sections
 # are for cache-hashing of the external repository that we rely on to build

--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -57,7 +57,7 @@ RUN yum install -y yum-utils createrepo https://repo.opensciencegrid.org/osg/23-
     yum install -y rpm-build && \
     mkdir -p /usr/local/src/rpmbuild/SRPMS && \
     cd /usr/local/src/rpmbuild/SRPMS && \
-    yumdownloader --source xrootd --disablerepo=\* --enablerepo=osg-source && \
+    yumdownloader --source xrootd --disablerepo=\* --enablerepo=osg-testing-source && \
     yum-builddep -y xrootd-*.osg*.src.rpm && \
     rpmbuild --define 'osg 1' \
              --define 'dist .osg.el9' \


### PR DESCRIPTION
This gets us a fixed patch to improve S3 origin performance by switching to the `osg-testing` repos for xrootd installation.

Closes #1552 