### PR TITLE
Do not compile xrootd when building the dev image

### DIFF
--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -54,6 +54,7 @@ gpgcheck=0' > /etc/yum.repos.d/goreleaser.repo
 # Install goreleaser and various other packages we need
 RUN yum install -y --enablerepo=osg-testing goreleaser npm xrootd-devel xrootd-server-devel xrootd-client-devel nano xrootd-scitokens xrootd-voms \
     xrdcl-http jq procps docker make curl-devel java-17-openjdk-headless git cmake3 gcc-c++ openssl-devel sqlite-devel libcap-devel \
+    xrootd-multiuser \
     zlib-devel \
     && yum clean all
 
@@ -68,16 +69,6 @@ RUN \
     git clone https://github.com/PelicanPlatform/xrdcl-pelican.git && \
     cd xrdcl-pelican && \
     git reset cbd6850 --hard && \
-    mkdir build && cd build && \
-    cmake -DLIB_INSTALL_DIR=/usr/lib64 .. && \
-    make && make install
-
-# Install xrootd-multiuser from source (otherwise it's only available from osg repos)
-ADD https://api.github.com/repos/opensciencegrid/xrootd-multiuser/git/refs/heads/master /tmp/hash-xrootd-multiuser
-RUN \
-    git clone https://github.com/opensciencegrid/xrootd-multiuser.git && \
-    cd xrootd-multiuser && \
-    git checkout v2.2.0-1 && \
     mkdir build && cd build && \
     cmake -DLIB_INSTALL_DIR=/usr/lib64 .. && \
     make && make install

--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -54,6 +54,7 @@ gpgcheck=0' > /etc/yum.repos.d/goreleaser.repo
 # Install goreleaser and various other packages we need
 RUN yum install -y --enablerepo=osg-testing goreleaser npm xrootd-devel xrootd-server-devel xrootd-client-devel nano xrootd-scitokens xrootd-voms \
     xrdcl-http jq procps docker make curl-devel java-17-openjdk-headless git cmake3 gcc-c++ openssl-devel sqlite-devel libcap-devel \
+    zlib-devel \
     && yum clean all
 
 # The ADD command with a api.github.com URL in the next couple of sections

--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -44,6 +44,13 @@ RUN yum install -y \
     yum clean all
 
 # Get goreleaser
+# This is a bash-ism but on almalinux:9, /bin/sh _is_ bash so we don't need to change SHELL
+RUN echo $'[goreleaser] \n\
+name=GoReleaser \n\
+baseurl=https://repo.goreleaser.com/yum/ \n\
+enabled=1 \n\
+gpgcheck=0' > /etc/yum.repos.d/goreleaser.repo
+
 # Install goreleaser and various other packages we need
 RUN yum install -y --enablerepo=osg-testing goreleaser npm xrootd-devel xrootd-server-devel xrootd-client-devel nano xrootd-scitokens xrootd-voms \
     xrdcl-http jq procps docker make curl-devel java-17-openjdk-headless git cmake3 gcc-c++ openssl-devel sqlite-devel libcap-devel \


### PR DESCRIPTION
Compiling xrootd greatly slows down the build and is no longer necessary since OSG has builds for both X86 and ARM in the osg-testing repos.