### PR TITLE
Origins now have directreads on by default

### DIFF
--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -73,7 +73,7 @@ Origin:
   EnableReads: true
   EnableWrites: true
   EnableListings: true
-  EnableDirectReads: false
+  EnableDirectReads: true
   Port: 8443
   SelfTestInterval: 15s
 Registry:


### PR DESCRIPTION
Direct reads are now enabled by default in pelican origins