### PR TITLE
Add Proxy for active services

### DIFF
--- a/web_ui/frontend/README.md
+++ b/web_ui/frontend/README.md
@@ -27,7 +27,7 @@ cp pelican osdf
 ./osdf origin serve -f https://osg-htc.org -v /tmp/stash/:/test
 ```
 
-##### To run all of the websites
+##### To run all the websites
 
 ```shell
 ./pelican serve --module director,registry,origin,cache
@@ -35,11 +35,31 @@ cp pelican osdf
 
 #### To run the website and the reverse proxy:
 
+First build the proxy so that you can point api requests to a instance of Pelican.
+
+```shell
+docker build -t pelican-api-proxy -f dev/image/Dockerfile dev/image
+```
+
+Then run the following command to start the website and the proxy.
+
+```shell
+docker restart pelican-dev-proxy
+docker run --name pelican-dev-proxy -it -p 8443:8443 -d pelican-api-proxy
+```
+
+If you would like to proxy the prometheus requests to another service you can do so by filling out .env.template
+and placing it as .env.local. Then run the docker statement like so to add those variables to the container.
+
+```shell
+docker run --name pelican-dev-proxy -it -p 8443:8443 --env-file dev/.env.local -d pelican-api-proxy
+```
+
 First make sure that the ports are correct in `dev/nginx.conf` so that they point to
 the website and the api as expected. Then run the following command.
 
 ```shell
-sh dev/run.sh
+
 npm run dev
 ```
 

--- a/web_ui/frontend/dev/.env.template
+++ b/web_ui/frontend/dev/.env.template
@@ -1,0 +1,2 @@
+API_URL=https://origin.test.org
+API_PASSWORD=password

--- a/web_ui/frontend/dev/image/Dockerfile
+++ b/web_ui/frontend/dev/image/Dockerfile
@@ -1,0 +1,28 @@
+FROM nginx:1.27
+
+ENV NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx
+
+# Set some default environment variables so we can check them later
+ENV API_URL=https://host.docker.internal:8444
+
+# Install cron
+RUN apt-get update && apt-get install -y cron
+
+# Update the entrypoint
+COPY ./entrypoint.sh /opt/bin/entrypoint.sh
+RUN chmod +x /opt/bin/entrypoint.sh
+ENTRYPOINT ["/opt/bin/entrypoint.sh"]
+
+# Copy the NGINX configuration file
+COPY ./nginx.conf /etc/nginx/templates/nginx.conf.template
+
+# Copy the login script
+COPY ./login.sh /opt/bin/login.sh
+RUN chmod +x /opt/bin/login.sh
+
+# Copy the crontab file and set up cron job
+COPY ./crontab /etc/cron.d/login_cron
+RUN chmod 0644 /etc/cron.d/login_cron
+RUN crontab /etc/cron.d/login_cron
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/web_ui/frontend/dev/image/crontab
+++ b/web_ui/frontend/dev/image/crontab
@@ -1,0 +1,1 @@
+*/28 * * * * /opt/bin/login.sh > /proc/1/fd/1

--- a/web_ui/frontend/dev/image/entrypoint.sh
+++ b/web_ui/frontend/dev/image/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Append environment variables to /etc/environment, excluding "no_proxy"
+echo "Appending environment variables to /etc/environment"
+printenv | grep -v "no_proxy" >> /etc/environment
+
+# Run the login script
+echo "Running login script"
+/opt/bin/login.sh
+
+# Start cron
+echo "Starting cron"
+cron
+
+# Run the original Docker entrypoint script with any passed arguments
+echo "Running original Docker entrypoint script with arguments: $@"
+/docker-entrypoint.sh "$@"

--- a/web_ui/frontend/dev/image/login.sh
+++ b/web_ui/frontend/dev/image/login.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Check if API_PASSWORD and API_URL are set in env
+if [ -z "$API_PASSWORD" ] || [ -z "$API_URL" ]; then
+  echo "API_PASSWORD or API_URL not set. Skipping login."
+  exit 0
+fi
+
+# Prepend /api/v1.0/auth/login to the API_URL
+LOGIN_URL="${API_URL%/}/api/v1.0/auth/login"
+
+# Login and store the cookie
+curl -s -c /etc/nginx/conf.d/login_cookie.txt -X POST -H "Content-Type: application/json" -d "{\"user\": \"admin\", \"password\": \"$API_PASSWORD\"}" "$LOGIN_URL"
+
+# Extract the JWT from the cookie file
+jwt=$(grep 'login' /etc/nginx/conf.d/login_cookie.txt | awk '{print $7}')
+
+# Create a file with the Authorization header
+echo "proxy_set_header Authorization \"Bearer $jwt\";" > /etc/nginx/conf.d/login_header.txt
+
+# Reload Nginx to apply the new configuration if process exists
+if [ -e /var/run/nginx.pid ]; then
+  nginx -s reload
+fi
+
+echo "\n Successfully Updated the Authorization Header"

--- a/web_ui/frontend/dev/image/nginx.conf
+++ b/web_ui/frontend/dev/image/nginx.conf
@@ -13,12 +13,35 @@ http {
     include    /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
+    log_format custom '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for" "$uri"';
+
     index    index.html index.htm index.php;
 
     server {
         listen              8443;
 
+        location ^~ /api/v1.0/prometheus/ {
+
+            # Clear the Cookie header
+            proxy_set_header Cookie "";
+
+            add_header location prometheus always;
+
+            proxy_read_timeout 300s;
+            proxy_connect_timeout 20s;
+
+            # Read the Authorization header from the file
+            include /etc/nginx/conf.d/*.txt;
+
+            proxy_pass ${API_URL};
+        }
+
         location ~ ^/(?:api|\.well-known)/ {
+
+            add_header location api always;
+
             proxy_read_timeout 300s;
             proxy_connect_timeout 10s;
             proxy_set_header X-Real-IP $remote_addr;
@@ -26,6 +49,9 @@ http {
         }
 
         location /view {
+
+            add_header location view always;
+
             proxy_read_timeout 300s;
             proxy_connect_timeout 10s;
             proxy_set_header X-Real-IP $remote_addr;

--- a/web_ui/frontend/dev/run.sh
+++ b/web_ui/frontend/dev/run.sh
@@ -1,2 +1,0 @@
-docker restart pelican-dev-proxy
-docker run --name pelican-dev-proxy -it -p 8443:8443 -v /Users/clock/GolandProjects/pelican/web_ui/frontend/dev/nginx.conf:/etc/nginx/nginx.conf:ro -d nginx


### PR DESCRIPTION
- Add the ability to proxy prometheus requests to an active service for real data
- Works by running a cron to get a new jwt and add it to the proxy auth headers every 30 minutes