### PR TITLE
Convert the token from a string to an object

### DIFF
--- a/client/bearer_auth.go
+++ b/client/bearer_auth.go
@@ -28,12 +28,12 @@ import (
 
 // BasicAuth structure holds our credentials, this is the authorizer
 type bearerAuth struct {
-	token string
+	token *tokenGenerator
 }
 
 // BearerAuthenticator is an Authenticator for BearerAuth
 type bearerAuthenticator struct {
-	token string
+	token *tokenGenerator
 }
 
 // NewAuthenticator creates a new BearerAuthenticator
@@ -48,7 +48,11 @@ func (b *bearerAuth) AddAuthenticator(key string, fn gowebdav.AuthFactory) {
 
 // Authorize the current request
 func (b *bearerAuthenticator) Authorize(c *http.Client, rq *http.Request, path string) error {
-	rq.Header.Add("Authorization", "Bearer "+b.token) //set the header with the token
+	if b.token != nil {
+		if tokenContents, err := b.token.get(); err == nil && tokenContents != "" {
+			rq.Header.Add("Authorization", "Bearer "+tokenContents) //set the header with the token
+		}
+	}
 	return nil
 }
 

--- a/client/bearer_auth_test.go
+++ b/client/bearer_auth_test.go
@@ -37,7 +37,9 @@ func TestBearerAuthenticator_Authorize(t *testing.T) {
 	}))
 	defer server.Close()
 
-	authenticator := &bearerAuthenticator{token: "some_token_1234_abc"}
+	token := newTokenGenerator(nil, nil, false, false)
+	token.SetToken("some_token_1234_abc")
+	authenticator := &bearerAuthenticator{token: token}
 	client := &http.Client{}
 
 	// Create a HTTP request to be authorized
@@ -53,7 +55,9 @@ func TestBearerAuthenticator_Authorize(t *testing.T) {
 }
 
 func TestBearerAuthenticator_Verify(t *testing.T) {
-	authenticator := &bearerAuthenticator{token: "some_token_1234_abc"}
+	token := newTokenGenerator(nil, nil, false, false)
+	token.SetToken("some_token_1234_abc")
+	authenticator := &bearerAuthenticator{token: token}
 	client := &http.Client{}
 
 	// Create a dummy HTTP response with a 401 status

--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -144,12 +144,12 @@ func TestGetAndPutAuth(t *testing.T) {
 
 			// Upload the file with PUT
 			transferResultsUpload, err := client.DoPut(fed.Ctx, tempFile.Name(), uploadURL, false, client.WithTokenLocation(tempToken.Name()))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, transferResultsUpload[0].TransferredBytes, int64(17))
 
 			// Download that same file with GET
 			transferResultsDownload, err := client.DoGet(fed.Ctx, uploadURL, t.TempDir(), false, client.WithTokenLocation(tempToken.Name()))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, transferResultsDownload[0].TransferredBytes, transferResultsUpload[0].TransferredBytes)
 		}
 	})

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -459,24 +459,26 @@ func TestSortAttempts(t *testing.T) {
 
 	defer cancel()
 
-	size, results := sortAttempts(ctx, "/path", []transferAttemptDetails{attempt1, attempt2, attempt3}, "")
+	token := newTokenGenerator(nil, nil, false, false)
+	token.SetToken("aaa")
+	size, results := sortAttempts(ctx, "/path", []transferAttemptDetails{attempt1, attempt2, attempt3}, token)
 	assert.Equal(t, int64(42), size)
 	assert.Equal(t, svr2.URL, results[0].Url.String())
 	assert.Equal(t, svr3.URL, results[1].Url.String())
 	assert.Equal(t, svr1.URL, results[2].Url.String())
 
-	size, results = sortAttempts(ctx, "/path", []transferAttemptDetails{attempt2, attempt3, attempt1}, "")
+	size, results = sortAttempts(ctx, "/path", []transferAttemptDetails{attempt2, attempt3, attempt1}, token)
 	assert.Equal(t, int64(42), size)
 	assert.Equal(t, svr2.URL, results[0].Url.String())
 	assert.Equal(t, svr3.URL, results[1].Url.String())
 	assert.Equal(t, svr1.URL, results[2].Url.String())
 
-	size, results = sortAttempts(ctx, "/path", []transferAttemptDetails{attempt1, attempt1}, "")
+	size, results = sortAttempts(ctx, "/path", []transferAttemptDetails{attempt1, attempt1}, token)
 	assert.Equal(t, int64(-1), size)
 	assert.Equal(t, svr1.URL, results[0].Url.String())
 	assert.Equal(t, svr1.URL, results[1].Url.String())
 
-	size, results = sortAttempts(ctx, "/path", []transferAttemptDetails{attempt2, attempt3}, "")
+	size, results = sortAttempts(ctx, "/path", []transferAttemptDetails{attempt2, attempt3}, token)
 	assert.Equal(t, int64(42), size)
 	assert.Equal(t, svr2.URL, results[0].Url.String())
 	assert.Equal(t, svr3.URL, results[1].Url.String())
@@ -1023,6 +1025,8 @@ func TestHeadRequestWithDownloadToken(t *testing.T) {
 	svrURL, err := url.Parse(svr.URL)
 	require.NoError(t, err)
 
+	token := newTokenGenerator(nil, nil, false, false)
+	token.SetToken("test-token")
 	transfer := &transferFile{
 		ctx:       context.Background(),
 		job:       &TransferJob{},
@@ -1033,7 +1037,7 @@ func TestHeadRequestWithDownloadToken(t *testing.T) {
 				Url: svrURL,
 			},
 		},
-		token: "test-token",
+		token: token,
 	}
 	_, _ = downloadObject(transfer)
 }

--- a/client/handle_ingest.go
+++ b/client/handle_ingest.go
@@ -50,7 +50,7 @@ func generateDestination(filePath string, originPrefix string, shadowOriginPrefi
 	if strings.HasPrefix(hashString, cleanedOriginPrefix) {
 		return shadowOriginPrefix + hashString[len(cleanedOriginPrefix):], localSize, nil
 	}
-	return "", 0, errors.New("File path must have the origin prefix")
+	return "", 0, errors.New("file path must have the origin prefix")
 }
 
 func DoShadowIngest(ctx context.Context, sourceFile string, originPrefix string, shadowOriginPrefix string, options ...TransferOption) (int64, string, error) {
@@ -118,5 +118,5 @@ func DoShadowIngest(ctx context.Context, sourceFile string, originPrefix string,
 			return transferResults[0].TransferredBytes, shadowFile, err
 		}
 	}
-	return 0, "", errors.New("After 10 upload attempts, file was still being modified during ingest.")
+	return 0, "", errors.New("after 10 upload attempts, file was still being modified during ingest")
 }

--- a/client/main_test.go
+++ b/client/main_test.go
@@ -150,9 +150,10 @@ func TestGetToken(t *testing.T) {
 
 	// ENVs to test: BEARER_TOKEN, BEARER_TOKEN_FILE, XDG_RUNTIME_DIR/bt_u<uid>, TOKEN, _CONDOR_CREDS/scitoken.use, .condor_creds/scitokens.use
 	os.Setenv("BEARER_TOKEN", "bearer_token_contents")
-	token, err := getToken(url, dirResp, true, "", "", false)
+	token := newTokenGenerator(url, &dirResp, true, false)
+	tokenContents, err := token.get()
 	assert.NoError(t, err)
-	assert.Equal(t, "bearer_token_contents", token)
+	assert.Equal(t, "bearer_token_contents", tokenContents)
 	os.Unsetenv("BEARER_TOKEN")
 
 	// BEARER_TOKEN_FILE
@@ -163,9 +164,10 @@ func TestGetToken(t *testing.T) {
 	err = os.WriteFile(bearer_token_file, tmpFile, 0644)
 	assert.NoError(t, err)
 	os.Setenv("BEARER_TOKEN_FILE", bearer_token_file)
-	token, err = getToken(url, dirResp, true, "", "", false)
+	token = newTokenGenerator(url, &dirResp, true, false)
+	tokenContents, err = token.get()
 	assert.NoError(t, err)
-	assert.Equal(t, token_contents, token)
+	assert.Equal(t, token_contents, tokenContents)
 	os.Unsetenv("BEARER_TOKEN_FILE")
 
 	// XDG_RUNTIME_DIR/bt_u<uid>
@@ -175,9 +177,10 @@ func TestGetToken(t *testing.T) {
 	err = os.WriteFile(bearer_token_file, tmpFile, 0644)
 	assert.NoError(t, err)
 	os.Setenv("XDG_RUNTIME_DIR", tmpDir)
-	token, err = getToken(url, dirResp, true, "", "", false)
+	token = newTokenGenerator(url, &dirResp, true, false)
+	tokenContents, err = token.get()
 	assert.NoError(t, err)
-	assert.Equal(t, token_contents, token)
+	assert.Equal(t, token_contents, tokenContents)
 	os.Unsetenv("XDG_RUNTIME_DIR")
 
 	// TOKEN
@@ -187,9 +190,10 @@ func TestGetToken(t *testing.T) {
 	err = os.WriteFile(bearer_token_file, tmpFile, 0644)
 	assert.NoError(t, err)
 	os.Setenv("TOKEN", bearer_token_file)
-	token, err = getToken(url, dirResp, true, "", "", false)
+	token = newTokenGenerator(url, &dirResp, true, false)
+	tokenContents, err = token.get()
 	assert.NoError(t, err)
-	assert.Equal(t, token_contents, token)
+	assert.Equal(t, token_contents, tokenContents)
 	os.Unsetenv("TOKEN")
 
 	// _CONDOR_CREDS/scitokens.use
@@ -199,9 +203,10 @@ func TestGetToken(t *testing.T) {
 	err = os.WriteFile(bearer_token_file, tmpFile, 0644)
 	assert.NoError(t, err)
 	os.Setenv("_CONDOR_CREDS", tmpDir)
-	token, err = getToken(url, dirResp, true, "", "", false)
+	token = newTokenGenerator(url, &dirResp, true, false)
+	tokenContents, err = token.get()
 	assert.NoError(t, err)
-	assert.Equal(t, token_contents, token)
+	assert.Equal(t, token_contents, tokenContents)
 	os.Unsetenv("_CONDOR_CREDS")
 
 	// _CONDOR_CREDS/renamed.use
@@ -219,9 +224,10 @@ func TestGetToken(t *testing.T) {
 			Namespace: "/user/ligo/frames",
 		},
 	}
-	token, err = getToken(renamedUrl, ligoDirResp, false, "", "", false)
+	token = newTokenGenerator(renamedUrl, &ligoDirResp, false, false)
+	tokenContents, err = token.get()
 	assert.NoError(t, err)
-	assert.Equal(t, token_contents, token)
+	assert.Equal(t, token_contents, tokenContents)
 	os.Unsetenv("_CONDOR_CREDS")
 
 	// _CONDOR_CREDS/renamed_handle1.use via renamed_handle1+osdf:///user/ligo/frames
@@ -236,9 +242,10 @@ func TestGetToken(t *testing.T) {
 	renamedUrl, err = url.Parse("renamed.handle1+osdf:///user/ligo/frames")
 	renamedUrl.Scheme = "renamed_handle1+osdf"
 	assert.NoError(t, err)
-	token, err = getToken(renamedUrl, ligoDirResp, false, "", "", false)
+	token = newTokenGenerator(renamedUrl, &ligoDirResp, false, false)
+	tokenContents, err = token.get()
 	assert.NoError(t, err)
-	assert.Equal(t, token_contents, token)
+	assert.Equal(t, token_contents, tokenContents)
 	os.Unsetenv("_CONDOR_CREDS")
 
 	// _CONDOR_CREDS/renamed_handle2.use via renamed.handle2+osdf:///user/ligo/frames
@@ -251,9 +258,10 @@ func TestGetToken(t *testing.T) {
 	os.Setenv("_CONDOR_CREDS", tmpDir)
 	renamedUrl, err = url.Parse("renamed.handle2+osdf:///user/ligo/frames")
 	assert.NoError(t, err)
-	token, err = getToken(renamedUrl, ligoDirResp, false, "", "", false)
+	token = newTokenGenerator(renamedUrl, &ligoDirResp, false, false)
+	tokenContents, err = token.get()
 	assert.NoError(t, err)
-	assert.Equal(t, token_contents, token)
+	assert.Equal(t, token_contents, tokenContents)
 	os.Unsetenv("_CONDOR_CREDS")
 
 	// _CONDOR_CREDS/renamed.handle3.use via renamed.handle3+osdf:///user/ligo/frames
@@ -266,9 +274,10 @@ func TestGetToken(t *testing.T) {
 	os.Setenv("_CONDOR_CREDS", tmpDir)
 	renamedUrl, err = url.Parse("renamed.handle3+osdf:///user/ligo/frames")
 	assert.NoError(t, err)
-	token, err = getToken(renamedUrl, ligoDirResp, false, "", "", false)
+	token = newTokenGenerator(renamedUrl, &ligoDirResp, false, false)
+	tokenContents, err = token.get()
 	assert.NoError(t, err)
-	assert.Equal(t, token_contents, token)
+	assert.Equal(t, token_contents, tokenContents)
 	os.Unsetenv("_CONDOR_CREDS")
 
 	// _CONDOR_CREDS/renamed.use
@@ -281,9 +290,11 @@ func TestGetToken(t *testing.T) {
 	os.Setenv("_CONDOR_CREDS", tmpDir)
 	renamedUrl, err = url.Parse("/user/ligo/frames")
 	assert.NoError(t, err)
-	token, err = getToken(renamedUrl, ligoDirResp, false, "renamed", "", false)
+	token = newTokenGenerator(renamedUrl, &ligoDirResp, false, false)
+	token.SetTokenName("renamed")
+	tokenContents, err = token.get()
 	assert.NoError(t, err)
-	assert.Equal(t, token_contents, token)
+	assert.Equal(t, token_contents, tokenContents)
 	os.Unsetenv("_CONDOR_CREDS")
 
 	// Current directory .condor_creds/scitokens.use
@@ -298,14 +309,17 @@ func TestGetToken(t *testing.T) {
 	assert.NoError(t, err)
 	err = os.Chdir(tmpDir)
 	assert.NoError(t, err)
-	token, err = getToken(url, dirResp, true, "", "", false)
+	token = newTokenGenerator(url, &dirResp, true, false)
+	tokenContents, err = token.get()
 	assert.NoError(t, err)
-	assert.Equal(t, token_contents, token)
+	assert.Equal(t, token_contents, tokenContents)
 	err = os.Chdir(currentDir)
 	assert.NoError(t, err)
 
-	_, err = getToken(url, dirResp, true, "", "", false)
-	assert.EqualError(t, err, "Credential is required for osdf:///user/foo but is currently missing")
+	// Check that we haven't regressed on our error messages
+	token = newTokenGenerator(url, &dirResp, true, false)
+	_, err = token.get()
+	assert.EqualError(t, err, "credential is required for osdf:///user/foo but was not discovered")
 }
 
 // TestGetTokenName tests getTokenName

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/glebarez/sqlite v1.10.0
 	github.com/go-ini/ini v1.67.0
 	github.com/go-kit/log v0.2.1
-	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/gorilla/csrf v1.7.2
 	github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd
 	github.com/gwatts/gin-adapter v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -292,8 +292,7 @@ github.com/gofrs/flock v0.7.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14j
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=


### PR DESCRIPTION
The token tracked internally through a transfer is now a standalone struct instead of a string.  The `get` method that produces the string needed for transfers will check the validity of the current token and, if it's expired, iterate through the environment to find a new one.

The goal is long-lived transfers will be able to acquire a fresh token, as needed, from their environment (or from the token issuer) instead of using the expired one.