### PR TITLE
Add "sync" functionality to the client

### DIFF
--- a/client/director_test.go
+++ b/client/director_test.go
@@ -103,7 +103,7 @@ func TestQueryDirector(t *testing.T) {
 	defer server.Close()
 
 	// Call QueryDirector with the test server URL and a source path
-	actualResp, err := queryDirector(context.Background(), "GET", "/foo/bar", server.URL)
+	actualResp, err := queryDirector(context.Background(), "GET", "/foo/bar", server.URL, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,7 +194,7 @@ func TestGetDirectorInfoForPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			_, err := GetDirectorInfoForPath(ctx, tt.resourcePath, tt.directorUrl, tt.isPut, tt.query)
+			_, err := GetDirectorInfoForPath(ctx, tt.resourcePath, tt.directorUrl, tt.isPut, tt.query, "")
 			if tt.expectedError != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)

--- a/client/fed_linux_test.go
+++ b/client/fed_linux_test.go
@@ -457,3 +457,278 @@ func TestFailureOnOriginDisablingListings(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no collections URL found in director response")
 }
+
+func TestSyncUpload(t *testing.T) {
+	// Create instance of test federation
+	viper.Reset()
+	server_utils.ResetOriginExports()
+
+	fed := fed_test_utils.NewFedTest(t, bothAuthOriginCfg)
+
+	// Create a token file
+	issuer, err := config.GetServerIssuerURL()
+	require.NoError(t, err)
+
+	tokenConfig := token.NewWLCGToken()
+	tokenConfig.Lifetime = time.Minute
+	tokenConfig.Issuer = issuer
+	tokenConfig.Subject = "origin"
+	tokenConfig.AddAudienceAny()
+	tokenConfig.AddResourceScopes(token_scopes.NewResourceScope(token_scopes.Storage_Read, "/"),
+		token_scopes.NewResourceScope(token_scopes.Storage_Modify, "/"))
+	token, err := tokenConfig.CreateToken()
+	assert.NoError(t, err)
+	tempToken, err := os.CreateTemp(t.TempDir(), "token")
+	assert.NoError(t, err, "Error creating temp token file")
+	defer os.Remove(tempToken.Name())
+	_, err = tempToken.WriteString(token)
+	assert.NoError(t, err, "Error writing to temp token file")
+	tempToken.Close()
+
+	// Disable progress bars to not reuse the same mpb instance
+	viper.Set("Logging.DisableProgressBars", true)
+
+	// Make our test directories and files
+	tempDir := t.TempDir()
+	innerTempDir, err := os.MkdirTemp(tempDir, "InnerUploadDir")
+	assert.NoError(t, err)
+	permissions := os.FileMode(0755)
+	err = os.Chmod(tempDir, permissions)
+	require.NoError(t, err)
+	err = os.Chmod(innerTempDir, permissions)
+	require.NoError(t, err)
+
+	testFileContent1 := "test file content"
+	testFileContent2 := "more test file content!"
+	innerTestFileContent := "this content is within another dir!"
+	tempFile1, err := os.CreateTemp(tempDir, "test1")
+	require.NoError(t, err, "Error creating temp1 file")
+	tempFile2, err := os.CreateTemp(tempDir, "test1")
+	require.NoError(t, err, "Error creating temp2 file")
+	innerTempFile, err := os.CreateTemp(innerTempDir, "testInner")
+	require.NoError(t, err, "Error creating inner test file")
+
+	_, err = tempFile1.WriteString(testFileContent1)
+	require.NoError(t, err, "Error writing to temp1 file")
+	tempFile1.Close()
+	_, err = tempFile2.WriteString(testFileContent2)
+	require.NoError(t, err, "Error writing to temp2 file")
+	tempFile2.Close()
+	_, err = innerTempFile.WriteString(innerTestFileContent)
+	require.NoError(t, err, "Error writing to inner test file")
+	innerTempFile.Close()
+
+	t.Run("testSyncUploadFull", func(t *testing.T) {
+		// Set path for object to upload/download
+		tempPath := tempDir
+		dirName := filepath.Base(tempPath)
+		uploadURL := fmt.Sprintf("pelican://%s:%s/first/namespace/sync_upload/%s", param.Server_Hostname.GetString(), strconv.Itoa(param.Server_WebPort.GetInt()), dirName)
+
+		// Upload the file with PUT
+		transferDetailsUpload, err := client.DoPut(fed.Ctx, tempDir, uploadURL, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		require.NoError(t, err)
+		verifySuccessfulTransfer(t, transferDetailsUpload)
+
+		// Download the files we just uploaded
+		transferDetailsDownload, err := client.DoGet(fed.Ctx, uploadURL, t.TempDir(), true, client.WithTokenLocation(tempToken.Name()))
+		require.NoError(t, err)
+		verifySuccessfulTransfer(t, transferDetailsDownload)
+	})
+
+	t.Run("testSyncUploadNone", func(t *testing.T) {
+		// Set path for object to upload/download
+		dirName := filepath.Base(tempDir)
+		uploadURL := fmt.Sprintf("pelican://%s:%s/first/namespace/sync_upload_none/%s", param.Server_Hostname.GetString(), strconv.Itoa(param.Server_WebPort.GetInt()), dirName)
+
+		// Upload the file with PUT
+		transferDetailsUpload, err := client.DoPut(fed.Ctx, tempDir, uploadURL, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		require.NoError(t, err)
+		verifySuccessfulTransfer(t, transferDetailsUpload)
+
+		// Synchronize the uploaded files again.
+		transferDetailsUpload, err = client.DoPut(fed.Ctx, tempDir, uploadURL, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		require.NoError(t, err)
+
+		// Should have already been uploaded once
+		assert.Len(t, transferDetailsUpload, 0)
+	})
+
+	t.Run("testSyncUploadPartial", func(t *testing.T) {
+		// Set path for object to upload/download
+		dirName := filepath.Base(tempDir)
+		uploadURL := fmt.Sprintf("pelican://%s:%s/first/namespace/sync_upload_partial/%s", param.Server_Hostname.GetString(), strconv.Itoa(param.Server_WebPort.GetInt()), dirName)
+		uploadInnerURL := fmt.Sprintf("pelican://%s:%s/first/namespace/sync_upload_partial/%s/%s", param.Server_Hostname.GetString(), strconv.Itoa(param.Server_WebPort.GetInt()), dirName, filepath.Base(innerTempDir))
+
+		// Upload some files with PUT
+		transferDetailsUpload, err := client.DoPut(fed.Ctx, innerTempDir, uploadInnerURL, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		require.NoError(t, err)
+		require.Len(t, transferDetailsUpload, 1)
+
+		// Change the contents of the already-uploaded file; changes shouldn't be detected as the size stays the same
+		newTestFileContent := "XXXX content is within another XXXX"
+		err = os.WriteFile(innerTempFile.Name(), []byte(newTestFileContent), os.FileMode(0755))
+		require.NoError(t, err)
+
+		// Upload again; this time there should be fewer uploads as the subdir was already moved.
+		transferDetailsUpload, err = client.DoPut(fed.Ctx, tempDir, uploadURL, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		require.NoError(t, err)
+		require.Len(t, transferDetailsUpload, 2)
+
+		// Download all the objects
+		downloadDir := t.TempDir()
+		transferDetailsDownload, err := client.DoGet(fed.Ctx, uploadURL, downloadDir, true, client.WithTokenLocation(tempToken.Name()))
+		require.NoError(t, err)
+		verifySuccessfulTransfer(t, transferDetailsDownload)
+
+		// Verify we received the original contents, not any modified contents
+		contentBytes, err := os.ReadFile(filepath.Join(downloadDir, dirName, filepath.Base(innerTempDir), filepath.Base(innerTempFile.Name())))
+		require.NoError(t, err)
+		assert.Equal(t, innerTestFileContent, string(contentBytes))
+	})
+}
+
+func TestSyncDownload(t *testing.T) {
+	// Create instance of test federation
+	viper.Reset()
+	server_utils.ResetOriginExports()
+
+	fed := fed_test_utils.NewFedTest(t, bothAuthOriginCfg)
+
+	// Create a token file
+	issuer, err := config.GetServerIssuerURL()
+	require.NoError(t, err)
+
+	tokenConfig := token.NewWLCGToken()
+	tokenConfig.Lifetime = time.Minute
+	tokenConfig.Issuer = issuer
+	tokenConfig.Subject = "origin"
+	tokenConfig.AddAudienceAny()
+	tokenConfig.AddResourceScopes(token_scopes.NewResourceScope(token_scopes.Storage_Read, "/"),
+		token_scopes.NewResourceScope(token_scopes.Storage_Modify, "/"))
+	token, err := tokenConfig.CreateToken()
+	assert.NoError(t, err)
+	tempToken, err := os.CreateTemp(t.TempDir(), "token")
+	assert.NoError(t, err, "Error creating temp token file")
+	defer os.Remove(tempToken.Name())
+	_, err = tempToken.WriteString(token)
+	assert.NoError(t, err, "Error writing to temp token file")
+	tempToken.Close()
+
+	// Disable progress bars to not reuse the same mpb instance
+	viper.Set("Logging.DisableProgressBars", true)
+
+	// Make our test directories and files
+	tempDir := t.TempDir()
+	innerTempDir, err := os.MkdirTemp(tempDir, "InnerUploadDir")
+	assert.NoError(t, err)
+	permissions := os.FileMode(0755)
+	err = os.Chmod(tempDir, permissions)
+	require.NoError(t, err)
+	err = os.Chmod(innerTempDir, permissions)
+	require.NoError(t, err)
+
+	testFileContent1 := "test file content"
+	testFileContent2 := "more test file content!"
+	innerTestFileContent := "this content is within another dir!"
+	tempFile1, err := os.CreateTemp(tempDir, "test1")
+	require.NoError(t, err, "Error creating temp1 file")
+	tempFile2, err := os.CreateTemp(tempDir, "test1")
+	require.NoError(t, err, "Error creating temp2 file")
+	innerTempFile, err := os.CreateTemp(innerTempDir, "testInner")
+	require.NoError(t, err, "Error creating inner test file")
+
+	_, err = tempFile1.WriteString(testFileContent1)
+	require.NoError(t, err, "Error writing to temp1 file")
+	tempFile1.Close()
+	_, err = tempFile2.WriteString(testFileContent2)
+	require.NoError(t, err, "Error writing to temp2 file")
+	tempFile2.Close()
+	_, err = innerTempFile.WriteString(innerTestFileContent)
+	require.NoError(t, err, "Error writing to inner test file")
+	innerTempFile.Close()
+
+	// Set path for object to upload/download
+	tempPath := tempDir
+	dirName := filepath.Base(tempPath)
+	uploadURL := fmt.Sprintf("pelican://%s:%s/first/namespace/sync_download/%s", param.Server_Hostname.GetString(), strconv.Itoa(param.Server_WebPort.GetInt()), dirName)
+
+	// Upload the file with PUT
+	transferDetailsUpload, err := client.DoPut(fed.Ctx, tempDir, uploadURL, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+	require.NoError(t, err)
+	verifySuccessfulTransfer(t, transferDetailsUpload)
+
+	t.Run("testSyncDownloadFull", func(t *testing.T) {
+		// Download the files we just uploaded
+		transferDetailsDownload, err := client.DoGet(fed.Ctx, uploadURL, t.TempDir(), true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		require.NoError(t, err)
+		verifySuccessfulTransfer(t, transferDetailsDownload)
+	})
+
+	t.Run("testSyncDownloadNone", func(t *testing.T) {
+		// Set path for object to upload/download
+		dirName := t.TempDir()
+
+		// Synchronize the uploaded files to a local directory
+		transferDetailsDownload, err := client.DoGet(fed.Ctx, uploadURL, dirName, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		require.NoError(t, err)
+		verifySuccessfulTransfer(t, transferDetailsDownload)
+
+		// Synchronize the files again; should result in no transfers
+		transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadURL, dirName, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		assert.NoError(t, err)
+		assert.Len(t, transferDetailsDownload, 0)
+	})
+
+	t.Run("testSyncDownloadPartial", func(t *testing.T) {
+		// Set path for object to upload/download
+		downloadDir := t.TempDir()
+		dirName := filepath.Base(tempDir)
+		uploadURL := fmt.Sprintf("pelican://%s:%s/first/namespace/sync_download_partial/%s", param.Server_Hostname.GetString(), strconv.Itoa(param.Server_WebPort.GetInt()), dirName)
+		uploadInnerURL := fmt.Sprintf("pelican://%s:%s/first/namespace/sync_download_partial/%s/%s", param.Server_Hostname.GetString(), strconv.Itoa(param.Server_WebPort.GetInt()), dirName, filepath.Base(innerTempDir))
+
+		// Upload the initial files
+		transferDetailsUpload, err := client.DoPut(fed.Ctx, tempDir, uploadURL, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		require.NoError(t, err)
+		verifySuccessfulTransfer(t, transferDetailsUpload)
+
+		// Download the inner directory
+		innerDownloadDir := filepath.Join(downloadDir, dirName, filepath.Base(innerTempDir))
+		transferDetailsDownload, err := client.DoGet(fed.Ctx, uploadInnerURL, innerDownloadDir, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		require.NoError(t, err)
+		require.Len(t, transferDetailsDownload, 1)
+
+		// Change the contents of one already-uploaded file and re-upload it.
+		// Filesize is the same so a re-download should be skipped.
+		newTestFileContent := "XXXX content is within another XXXX"
+		err = os.WriteFile(innerTempFile.Name(), []byte(newTestFileContent), os.FileMode(0755))
+		require.NoError(t, err)
+		transferDetailsUpload, err = client.DoPut(fed.Ctx, innerTempDir, uploadInnerURL, true, client.WithTokenLocation(tempToken.Name()))
+		require.NoError(t, err)
+		require.Len(t, transferDetailsUpload, 1)
+
+		// Download all the objects
+		transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadURL, downloadDir, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		require.NoError(t, err)
+		assert.Len(t, transferDetailsDownload, 2)
+
+		// Verify we received the original contents, not any modified contents
+		contentBytes, err := os.ReadFile(filepath.Join(innerDownloadDir, filepath.Base(innerTempFile.Name())))
+		require.NoError(t, err)
+		assert.Equal(t, innerTestFileContent, string(contentBytes))
+
+		// Change the local size, then re-sync
+		innerDownloadFile := filepath.Join(innerDownloadDir, filepath.Base(innerTempFile.Name()))
+		log.Debugln("Overwriting old version of file", innerDownloadFile)
+		err = os.Remove(innerDownloadFile)
+		require.NoError(t, err)
+		err = os.WriteFile(innerDownloadFile, []byte("XXXX"), os.FileMode(0755))
+		require.NoError(t, err)
+		log.Debugln("Re-downloading file direct from origin")
+		transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadURL+"?directread", downloadDir, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		require.NoError(t, err)
+		assert.Len(t, transferDetailsDownload, 1)
+		contentBytes, err = os.ReadFile(filepath.Join(innerDownloadDir, filepath.Base(innerTempFile.Name())))
+		require.NoError(t, err)
+		assert.Equal(t, newTestFileContent, string(contentBytes))
+	})
+}

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1008,9 +1008,9 @@ func (te *TransferEngine) runMux() error {
 			// Notification that a job has been processed into files (or failed)
 			job := recv.Interface().(*clientTransferJob)
 			job.job.lookupDone.Store(true)
-			// If no transfers were created and we have an error, the job is no
+			// If no transfers were created or we have an error, the job is no
 			// longer active
-			if job.job.lookupErr != nil && job.job.totalXfer == 0 {
+			if job.job.lookupErr != nil || job.job.totalXfer == 0 {
 				// Remove this job from the list of active jobs for the client.
 				activeJobs[job.uuid] = slices.DeleteFunc(activeJobs[job.uuid], func(oldJob *TransferJob) bool {
 					return oldJob.uuid == job.job.uuid
@@ -2470,6 +2470,7 @@ func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfer
 					attempts:   transfers,
 				},
 			}:
+				job.job.totalXfer += 1
 			}
 		}
 	}
@@ -2519,6 +2520,7 @@ func (te *TransferEngine) walkDirUpload(job *clientTransferJob, transfers []tran
 					attempts:   transfers,
 				},
 			}:
+				job.job.totalXfer += 1
 			}
 		}
 	}

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1201,6 +1201,13 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 		// The director response may change if it's given a token; let's repeat the query.
 		if contents != "" {
 			dirResp, err = GetDirectorInfoForPath(tj.ctx, remoteUrl.Path, pelicanURL.directorUrl, upload, remoteUrl.RawQuery, contents)
+			if err != nil {
+				log.Errorln(err)
+				err = errors.Wrapf(err, "failed to get namespace information for remote URL %s", remoteUrl.String())
+				return nil, err
+			}
+			tj.dirResp = dirResp
+			tj.token.DirResp = &dirResp
 		}
 	}
 

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2764,15 +2764,6 @@ func statHttp(dest *url.URL, dirResp server_structs.DirectorResponse, token *tok
 				return
 			}
 
-			if info.Size == 0 {
-				if info.IsCollection {
-					resultsChan <- statResults{info, nil}
-				}
-				err = errors.New("Stat response did not include a size")
-				resultsChan <- statResults{FileInfo{}, err}
-				return
-			}
-
 			resultsChan <- statResults{FileInfo{
 				Name:         endpoint.Path,
 				Size:         info.Size,

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1140,7 +1140,6 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 		callback:       tc.callback,
 		skipAcquire:    tc.skipAcquire,
 		syncLevel:      tc.syncLevel,
-		tokenLocation:  tc.tokenLocation,
 		upload:         upload,
 		uuid:           id,
 		project:        project,
@@ -1200,8 +1199,8 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 		}
 
 		// The director response may change if it's given a token; let's repeat the query.
-		if tj.token != "" {
-			dirResp, err = GetDirectorInfoForPath(tj.ctx, remoteUrl.Path, pelicanURL.directorUrl, upload, remoteUrl.RawQuery, tj.token)
+		if contents != "" {
+			dirResp, err = GetDirectorInfoForPath(tj.ctx, remoteUrl.Path, pelicanURL.directorUrl, upload, remoteUrl.RawQuery, contents)
 		}
 	}
 

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1144,7 +1144,7 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 	}
 
 	tj.directorUrl = pelicanURL.directorUrl
-	dirResp, err := GetDirectorInfoForPath(tj.ctx, remoteUrl.Path, pelicanURL.directorUrl, upload, remoteUrl.RawQuery)
+	dirResp, err := GetDirectorInfoForPath(tj.ctx, remoteUrl.Path, pelicanURL.directorUrl, upload, remoteUrl.RawQuery, "")
 	if err != nil {
 		log.Errorln(err)
 		err = errors.Wrapf(err, "failed to get namespace information for remote URL %s", remoteUrl.String())
@@ -1157,6 +1157,11 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 		contents, err := tj.token.get()
 		if err != nil || contents == "" {
 			return nil, errors.Wrap(err, "failed to get token for transfer")
+		}
+
+		// The director response may change if it's given a token; let's repeat the query.
+		if tj.token != "" {
+			dirResp, err = GetDirectorInfoForPath(tj.ctx, remoteUrl.Path, pelicanURL.directorUrl, upload, remoteUrl.RawQuery, tj.token)
 		}
 	}
 

--- a/client/main.go
+++ b/client/main.go
@@ -94,7 +94,7 @@ func DoStat(ctx context.Context, destination string, options ...TransferOption) 
 		return nil, errors.Wrap(err, "Failed to generate pelicanURL object")
 	}
 
-	dirResp, err := GetDirectorInfoForPath(ctx, destUri.Path, pelicanURL.directorUrl, false, "")
+	dirResp, err := GetDirectorInfoForPath(ctx, destUri.Path, pelicanURL.directorUrl, false, "", "")
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func GetObjectServerHostnames(ctx context.Context, testFile string) (urls []stri
 		return
 	}
 
-	parsedDirResp, err := GetDirectorInfoForPath(ctx, testFile, fedInfo.DirectorEndpoint, false, "")
+	parsedDirResp, err := GetDirectorInfoForPath(ctx, testFile, fedInfo.DirectorEndpoint, false, "", "")
 	if err != nil {
 		return
 	}
@@ -275,7 +275,7 @@ func DoList(ctx context.Context, remoteObject string, options ...TransferOption)
 		return nil, errors.Wrap(err, "failed to generate pelicanURL object")
 	}
 
-	dirResp, err := GetDirectorInfoForPath(ctx, remoteObjectUrl.Path, pelicanURL.directorUrl, false, "")
+	dirResp, err := GetDirectorInfoForPath(ctx, remoteObjectUrl.Path, pelicanURL.directorUrl, false, "", "")
 	if err != nil {
 		return nil, err
 	}

--- a/client/sharing_url.go
+++ b/client/sharing_url.go
@@ -89,7 +89,7 @@ func CreateSharingUrl(ctx context.Context, objectUrl *url.URL, isWrite bool) (st
 	objectUrl.Path = "/" + strings.TrimPrefix(objectUrl.Path, "/")
 
 	log.Debugln("Will query director for path", objectUrl.Path)
-	dirResp, err := queryDirector(ctx, "GET", objectUrl.Path, directorUrl)
+	dirResp, err := queryDirector(ctx, "GET", objectUrl.Path, directorUrl, "")
 	if err != nil {
 		log.Errorln("Error while querying the Director:", err)
 		return "", errors.Wrapf(err, "Error while querying the director at %s", directorUrl)

--- a/cmd/config_mgr.go
+++ b/cmd/config_mgr.go
@@ -154,7 +154,7 @@ func addTokenSubcommands(tokenCmd *cobra.Command) {
 				os.Exit(1)
 			}
 
-			dirResp, err := client.GetDirectorInfoForPath(cmd.Context(), dest.Path, fedInfo.DirectorEndpoint, isWrite, "")
+			dirResp, err := client.GetDirectorInfoForPath(cmd.Context(), dest.Path, fedInfo.DirectorEndpoint, isWrite, "", "")
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Failed to get director info for path:", err)
 				os.Exit(1)

--- a/cmd/object_sync.go
+++ b/cmd/object_sync.go
@@ -1,0 +1,215 @@
+/***************************************************************
+*
+* Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
+
+package main
+
+import (
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/error_codes"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/utils"
+)
+
+var (
+	syncCmd = &cobra.Command{
+		Use:   "sync {source ...} {destination}",
+		Short: "Sync a directory to or from a Pelican federation",
+		Run:   syncMain,
+	}
+)
+
+func init() {
+	flagSet := syncCmd.Flags()
+	flagSet.StringP("cache", "c", "", "Cache to use")
+	flagSet.StringP("token", "t", "", "Token file to use for transfer")
+	objectCmd.AddCommand(syncCmd)
+}
+
+func getLastScheme(scheme string) string {
+	idx := strings.LastIndex(scheme, "+")
+	if idx == -1 {
+		return scheme
+	}
+	return scheme[idx+1:]
+}
+
+// Returns true if the input is a url-like object that
+// pelican can consume.
+//
+// Schemes we understand are "osdf", "pelican",
+// "foo+osdf", or "foo+pelican" where "foo" is some arbitrary
+// prefix not containing a "/"
+func isPelicanUrl(input string) bool {
+	prefix, _, found := strings.Cut(input, "://")
+	if !found {
+		return false
+	}
+	if strings.Contains(prefix, "/") {
+		return false
+	}
+	scheme := getLastScheme(prefix)
+	if scheme != "pelican" && scheme != "osdf" {
+		return false
+	}
+	if _, err := url.Parse(input); err != nil {
+		return false
+	}
+	return true
+}
+
+func syncMain(cmd *cobra.Command, args []string) {
+	ctx := cmd.Context()
+
+	err := config.InitClient()
+	if err != nil {
+		log.Errorln(err)
+
+		if client.IsRetryable(err) {
+			log.Errorln("Errors are retryable")
+			os.Exit(11)
+		} else {
+			os.Exit(1)
+		}
+	}
+
+	tokenLocation, _ := cmd.Flags().GetString("token")
+
+	pb := newProgressBar()
+	defer pb.shutdown()
+
+	// Check if the program was executed from a terminal
+	// https://rosettacode.org/wiki/Check_output_device_is_a_terminal#Go
+	if fileInfo, _ := os.Stdout.Stat(); (fileInfo.Mode()&os.ModeCharDevice) != 0 && param.Logging_LogLocation.GetString() == "" && !param.Logging_DisableProgressBars.GetBool() {
+		pb.launchDisplay(ctx)
+	}
+
+	if len(args) < 2 {
+		log.Errorln("No source or destination to sync")
+		err = cmd.Help()
+		if err != nil {
+			log.Errorln("Failed to print out help:", err)
+		}
+		os.Exit(1)
+	}
+	sources := args[:len(args)-1]
+	dest := args[len(args)-1]
+	doDownload := false
+	if isPelicanUrl(dest) {
+		for _, src := range sources {
+			if isPelicanUrl(src) {
+				log.Errorf("URL (%s) cannot be a source when synchronizing to a federation URL", src)
+				os.Exit(1)
+			}
+		}
+		log.Debugln("Synchronizing to a Pelican data federation")
+	} else {
+		if !isPelicanUrl(sources[0]) {
+			log.Errorln("Either the first or last argument must be a pelican:// or osdf://-style URL specifying a remote destination")
+			os.Exit(1)
+		}
+		for _, src := range sources {
+			if !isPelicanUrl(src) {
+				log.Errorln("When synchronizing to a local directory, all sources must be pelican URLs:", src)
+				os.Exit(1)
+			}
+		}
+		log.Debugln("Synchronizing from a Pelican data federation")
+		doDownload = true
+	}
+
+	log.Debugln("Sources:", sources)
+	log.Debugln("Destination:", dest)
+
+	// Check for manually entered cache to use
+	var preferredCache string
+	if nearestCache, ok := os.LookupEnv("NEAREST_CACHE"); ok {
+		preferredCache = nearestCache
+	} else if cache, _ := cmd.Flags().GetString("cache"); cache != "" {
+		preferredCache = cache
+	}
+	var caches []*url.URL
+	caches, err = utils.GetPreferredCaches(preferredCache)
+	if err != nil {
+		log.Errorln(err)
+		os.Exit(1)
+	}
+
+	if doDownload && len(sources) > 1 {
+		if destStat, err := os.Stat(dest); err != nil {
+			log.Errorln("Destination does not exist")
+			os.Exit(1)
+		} else if !destStat.IsDir() {
+			log.Errorln("Destination is not a directory")
+			os.Exit(1)
+		}
+	}
+
+	lastSrc := ""
+
+	if doDownload {
+		for _, src := range sources {
+			if _, err = client.DoGet(ctx, src, dest, true,
+				client.WithCallback(pb.callback), client.WithTokenLocation(tokenLocation),
+				client.WithCaches(caches...), client.WithSynchronize(client.SyncExist)); err != nil {
+				lastSrc = src
+				break
+			}
+		}
+	} else {
+		for _, src := range sources {
+			if _, err = client.DoPut(ctx, src, dest, true,
+				client.WithCallback(pb.callback), client.WithTokenLocation(tokenLocation),
+				client.WithCaches(caches...), client.WithSynchronize(client.SyncExist)); err != nil {
+				lastSrc = src
+				break
+			}
+		}
+	}
+
+	// Exit with failure
+	if err != nil {
+		// Print the list of errors
+		errMsg := err.Error()
+		var pe error_codes.PelicanError
+		var te *client.TransferErrors
+		if errors.As(err, &te) {
+			errMsg = te.UserError()
+		}
+		if errors.Is(err, &pe) {
+			errMsg = pe.Error()
+			log.Errorln("Failure getting " + lastSrc + ": " + errMsg)
+			os.Exit(pe.ExitCode())
+		} else { // For now, keeping this else here to catch any errors that are not classified PelicanErrors
+			log.Errorln("Failure getting " + lastSrc + ": " + errMsg)
+			if client.ShouldRetry(err) {
+				log.Errorln("Errors are retryable")
+				os.Exit(11)
+			}
+			os.Exit(1)
+		}
+	}
+}

--- a/director/director.go
+++ b/director/director.go
@@ -373,6 +373,11 @@ func redirectToCache(ginCtx *gin.Context) {
 		log.Errorf("Failed to get depth attribute for the redirecting request to %q, with best match namespace prefix %q", reqPath, namespaceAd.Path)
 	}
 
+	// If the namespace requires a token yet there's no token available, skip the stat.
+	if !namespaceAd.Caps.PublicReads && reqParams.Get("authz") == "" {
+		skipStat = true
+	}
+
 	// Stat origins and caches for object availability
 	// For origins, we only want ones with the object
 	// For caches, we still list all in the response but turn down priorities for ones that don't have the object
@@ -572,6 +577,11 @@ func redirectToOrigin(ginCtx *gin.Context) {
 			Msg:    "No namespace found for path. Either it doesn't exist, or the Director is experiencing problems",
 		})
 		return
+	}
+
+	// If the namespace requires a token yet there's no token available, skip the stat.
+	if !namespaceAd.Caps.PublicReads && reqParams.Get("authz") == "" {
+		skipStat = true
 	}
 
 	var q *ObjectStat


### PR DESCRIPTION
This adds a "rsync-like" interface, `object sync`, to the command line client.  Example:

```
pelican object sync pelican://localhost:8444/tmp/test /tmp/download
```

This can be called multiple times; partially-downloaded files will be completed and completed files will be skipped (similar behavior on uploads).

The intent for this functionality is to allow someone to do a transfer of a large number of files into the OSDF from a host that might be rebooted or otherwise interrupted.

This includes multiple small bugfixes discovered in the client while testing, including:
- Fixed client hang for transfers of empty directories.
- Fixed client hang if the transfers finish before the directory walk finishes
- Do not consider a zero-sized file an error.
- If the director notices a namespace requires authorization -- but the client didn't provide a token -- then don't bother performing a stat (as it's just going to fail immediately).  In this case, the client will retry the director lookup once it's acquired a token.