### PR TITLE
Update xrdcl-pelican to v0.9.4

### DIFF
--- a/github_scripts/osx_install.sh
+++ b/github_scripts/osx_install.sh
@@ -48,7 +48,7 @@ ninja
 ninja install
 popd
 
-git clone --depth=1 https://github.com/PelicanPlatform/xrdcl-pelican.git
+git clone --branch v0.9.4 https://github.com/PelicanPlatform/xrdcl-pelican.git
 pushd xrdcl-pelican
 mkdir build
 cd build

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -69,7 +69,7 @@ ADD https://api.github.com/repos/PelicanPlatform/xrdcl-pelican/git/refs/heads/ma
 RUN \
     git clone https://github.com/PelicanPlatform/xrdcl-pelican.git && \
     cd xrdcl-pelican && \
-    git reset 9562795 --hard && \
+    git checkout v0.9.4 && \
     mkdir build && cd build && \
     cmake -DLIB_INSTALL_DIR=/usr/lib64 .. && \
     make && make install

--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -68,7 +68,7 @@ ADD https://api.github.com/repos/PelicanPlatform/xrdcl-pelican/git/refs/heads/ma
 RUN \
     git clone https://github.com/PelicanPlatform/xrdcl-pelican.git && \
     cd xrdcl-pelican && \
-    git reset cbd6850 --hard && \
+    git checkout v0.9.4 && \
     mkdir build && cd build && \
     cmake -DLIB_INSTALL_DIR=/usr/lib64 .. && \
     make && make install


### PR DESCRIPTION
This update, among other things, includes the ability to handle X509 auth when caches speak to origins.