### PR TITLE
Use capabilities structs in various types of server ads

### DIFF
--- a/director/advertise.go
+++ b/director/advertise.go
@@ -49,10 +49,6 @@ func consolidateDupServerAd(newAd, existingAd server_structs.ServerAd) server_st
 	consolidatedAd.Caps.Writes = existingAd.Caps.Writes || newAd.Caps.Writes
 	consolidatedAd.Caps.Listings = existingAd.Caps.Listings || newAd.Caps.Listings
 
-	consolidatedAd.DirectReads = existingAd.DirectReads || newAd.DirectReads
-	consolidatedAd.Writes = existingAd.Writes || newAd.Writes
-	consolidatedAd.Listings = existingAd.Listings || newAd.Listings
-
 	return consolidatedAd
 }
 
@@ -67,15 +63,11 @@ func parseServerAdFromTopology(server server_structs.TopoServer, serverType serv
 	// Explicitly set these to false for caches, because these caps don't really translate in that case
 	if serverAd.Type == server_structs.CacheType.String() {
 		serverAd.Caps = server_structs.Capabilities{}
-		serverAd.Writes = false
-		serverAd.Listings = false
-		serverAd.DirectReads = false
+		serverAd.Caps.Writes = false
+		serverAd.Caps.Listings = false
+		serverAd.Caps.DirectReads = false
+		serverAd.Caps.PublicReads = true
 	} else {
-		// Until we consolidate ServerAd capabilities with NamespaceAdV2 capabilities, we'll keep setting the top-level
-		// ServerAd capabilities. Eventually we should replace with the actual caps struct.
-		serverAd.Writes = caps.Writes
-		serverAd.Listings = caps.Listings
-		serverAd.DirectReads = caps.DirectReads
 		serverAd.Caps = caps
 	}
 
@@ -250,7 +242,6 @@ func AdvertiseOSDF(ctx context.Context) error {
 		}
 		nsAd := server_structs.NamespaceAdV2{
 			Path:         ns.Path,
-			PublicRead:   caps.PublicReads,
 			Caps:         caps,
 			Generation:   []server_structs.TokenGen{tGen},
 			Issuer:       tokenIssuers,

--- a/director/advertise_test.go
+++ b/director/advertise_test.go
@@ -47,20 +47,20 @@ var (
 
 func TestConsolidateDupServerAd(t *testing.T) {
 	t.Run("union-capabilities", func(t *testing.T) {
-		existingAd := server_structs.ServerAd{Writes: false}
-		newAd := server_structs.ServerAd{Writes: true}
+		existingAd := server_structs.ServerAd{Caps: server_structs.Capabilities{Writes: false}}
+		newAd := server_structs.ServerAd{Caps: server_structs.Capabilities{Writes: true}}
 		get := consolidateDupServerAd(newAd, existingAd)
-		assert.True(t, get.Writes)
+		assert.True(t, get.Caps.Writes)
 
-		existingAd = server_structs.ServerAd{DirectReads: false}
-		newAd = server_structs.ServerAd{DirectReads: true}
+		existingAd = server_structs.ServerAd{Caps: server_structs.Capabilities{DirectReads: false}}
+		newAd = server_structs.ServerAd{Caps: server_structs.Capabilities{DirectReads: true}}
 		get = consolidateDupServerAd(newAd, existingAd)
-		assert.True(t, get.DirectReads)
+		assert.True(t, get.Caps.DirectReads)
 
-		existingAd = server_structs.ServerAd{Listings: false}
-		newAd = server_structs.ServerAd{Listings: true}
+		existingAd = server_structs.ServerAd{Caps: server_structs.Capabilities{Listings: false}}
+		newAd = server_structs.ServerAd{Caps: server_structs.Capabilities{Listings: true}}
 		get = consolidateDupServerAd(newAd, existingAd)
-		assert.True(t, get.Listings)
+		assert.True(t, get.Caps.Listings)
 
 		// All false
 		existingAd = server_structs.ServerAd{Caps: server_structs.Capabilities{}}
@@ -144,22 +144,19 @@ func TestParseServerAdFromTopology(t *testing.T) {
 			Writes:      true,
 			Listings:    true,
 			DirectReads: true,
+			PublicReads: true,
 		}
 		ad := parseServerAdFromTopology(server, server_structs.OriginType, caps)
-		assert.True(t, ad.Writes)
 		assert.True(t, ad.Caps.Writes)
-		assert.True(t, ad.Listings)
 		assert.True(t, ad.Caps.Listings)
-		assert.True(t, ad.DirectReads)
 		assert.True(t, ad.Caps.DirectReads)
+		assert.True(t, ad.Caps.PublicReads)
 
 		ad = parseServerAdFromTopology(server, server_structs.CacheType, caps)
-		assert.False(t, ad.Writes)
 		assert.False(t, ad.Caps.Writes)
-		assert.False(t, ad.Listings)
 		assert.False(t, ad.Caps.Listings)
-		assert.False(t, ad.DirectReads)
 		assert.False(t, ad.Caps.DirectReads)
+		assert.True(t, ad.Caps.PublicReads)
 	})
 
 	t.Run("test-invalid-url", func(t *testing.T) {
@@ -233,9 +230,7 @@ func TestAdvertiseOSDF(t *testing.T) {
 		assert.Equal(t, "https://cache2.com", cAds[0].URL.String())
 		// Check that various capabilities have survived until this point. Because these are from topology,
 		// origin and namespace caps should be the same
-		assert.True(t, oAds[0].Writes)
 		assert.True(t, oAds[0].Caps.Writes)
-		assert.True(t, oAds[0].Listings)
 		assert.True(t, oAds[0].Caps.Listings)
 		assert.False(t, oAds[0].Caps.PublicReads)
 		assert.True(t, nsAd.Caps.Writes)
@@ -273,8 +268,8 @@ func TestAdvertiseOSDF(t *testing.T) {
 		assert.Equal(t, server_structs.OriginType.String(), foundAd.Type)
 		assert.Len(t, foundAd.NamespaceAds, 3)
 		// This origin has at least one namespace enables the following capacity
-		assert.True(t, foundAd.DirectReads)
-		assert.True(t, foundAd.Writes)
+		assert.True(t, foundAd.Caps.DirectReads)
+		assert.True(t, foundAd.Caps.Writes)
 		assert.True(t, foundAd.Caps.PublicReads)
 	})
 

--- a/origin/advertise.go
+++ b/origin/advertise.go
@@ -100,7 +100,6 @@ func (server *OriginServer) CreateAdvertisement(name, originUrlStr, originWebUrl
 		// PublicReads implies reads
 		reads := export.Capabilities.PublicReads || export.Capabilities.Reads
 		nsAds = append(nsAds, server_structs.NamespaceAdV2{
-			PublicRead: export.Capabilities.PublicReads,
 			Caps: server_structs.Capabilities{
 				PublicReads: export.Capabilities.PublicReads,
 				Reads:       reads,

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -47,11 +47,11 @@ type (
 
 	// Note that the json are kept in uppercase for backward compatibility
 	Capabilities struct {
-		PublicReads bool `json:"PublicRead"`
-		Reads       bool `json:"Read"`
-		Writes      bool `json:"Write"`
-		Listings    bool `json:"Listing"`
-		DirectReads bool `json:"FallBackRead"`
+		PublicReads bool `json:"PublicReads"`
+		Reads       bool `json:"Reads"`
+		Writes      bool `json:"Writes"`
+		Listings    bool `json:"Listings"`
+		DirectReads bool `json:"DirectReads"`
 	}
 
 	NamespaceAdV2 struct {

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -450,8 +450,8 @@ func ConvertNamespaceAdsV1ToV2(nsAdsV1 []NamespaceAdV1, oAd *OriginAdvertiseV1) 
 			}
 
 			newNS := NamespaceAdV2{
-				Caps:       caps,
-				Path:       nsAd.Path,
+				Caps: caps,
+				Path: nsAd.Path,
 			}
 
 			if nsAd.RequireToken {

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -55,10 +55,7 @@ type (
 	}
 
 	NamespaceAdV2 struct {
-		// TODO: Deprecate this top-level PublicRead field in favor of the Caps.PublicReads field.
-		// Should be done ~v7.10 series
-		PublicRead   bool
-		Caps         Capabilities  // Namespace capabilities should be considered independently of the origin’s capabilities.
+		Caps         Capabilities  `json:"capabilities"` // Namespace capabilities should be considered independently of the origin’s capabilities.
 		Path         string        `json:"path"`
 		Generation   []TokenGen    `json:"token-generation"`
 		Issuer       []TokenIssuer `json:"token-issuer"`
@@ -87,10 +84,7 @@ type (
 		Type                string            `json:"type"`
 		Latitude            float64           `json:"latitude"`
 		Longitude           float64           `json:"longitude"`
-		Caps                Capabilities      `json:"capabilities"` // TODO: Get rid of Writes, Listings, DirectReads in favor of Caps.Writes, Caps.Listings, Caps.DirectReads
-		Writes              bool              `json:"enable_write"`
-		Listings            bool              `json:"enable_listing"`       // True if the origin allows directory listings
-		DirectReads         bool              `json:"enable_fallback_read"` // True if reads from the origin are permitted when no cache is available
+		Caps                Capabilities      `json:"capabilities"`
 		FromTopology        bool              `json:"from_topology"`
 		IOLoad              float64           `json:"io_load"`
 	}
@@ -456,7 +450,6 @@ func ConvertNamespaceAdsV1ToV2(nsAdsV1 []NamespaceAdV1, oAd *OriginAdvertiseV1) 
 			}
 
 			newNS := NamespaceAdV2{
-				PublicRead: caps.PublicReads,
 				Caps:       caps,
 				Path:       nsAd.Path,
 			}

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -55,7 +55,7 @@ type (
 	}
 
 	NamespaceAdV2 struct {
-		Caps         Capabilities  `json:"capabilities"` // Namespace capabilities should be considered independently of the origin’s capabilities.
+		Caps         Capabilities  // Namespace capabilities should be considered independently of the origin’s capabilities.
 		Path         string        `json:"path"`
 		Generation   []TokenGen    `json:"token-generation"`
 		Issuer       []TokenIssuer `json:"token-issuer"`

--- a/server_structs/director_test.go
+++ b/server_structs/director_test.go
@@ -66,7 +66,6 @@ func TestConversion(t *testing.T) {
 			}},
 	},
 		{
-			PublicRead: true,
 			Caps: Capabilities{
 				PublicReads: true,
 				Reads:       true,


### PR DESCRIPTION
This moves us away from using something like `ad.Writes` in favor of `ads.Caps.Writes` by using our capabilities struct across the board where appropriate.

The work in this PR has been spread out over 3 releases to minimize potential impact to backwards compatibility issues, with the 7.11 release targeted for final breaking changes.

Closes issue #1367 
Closes issue #1368 