### PR TITLE
Enable debug symbols in image builds of pelican client

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -71,7 +71,7 @@ RUN \
     cd xrdcl-pelican && \
     git checkout v0.9.4 && \
     mkdir build && cd build && \
-    cmake -DLIB_INSTALL_DIR=/usr/lib64 .. && \
+    cmake -DLIB_INSTALL_DIR=/usr/lib64 -DCMAKE_BUILD_TYPE=RelWithDebInfo .. && \
     make && make install
 
 ADD https://api.github.com/repos/PelicanPlatform/xrootd-s3-http/git/refs/heads/main /tmp/hash-xrootd-s3-http

--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -70,7 +70,7 @@ RUN \
     cd xrdcl-pelican && \
     git checkout v0.9.4 && \
     mkdir build && cd build && \
-    cmake -DLIB_INSTALL_DIR=/usr/lib64 .. && \
+    cmake -DLIB_INSTALL_DIR=/usr/lib64 -DCMAKE_BUILD_TYPE=RelWithDebInfo .. && \
     make && make install
 
 ADD https://api.github.com/repos/PelicanPlatform/xrootd-s3-http/git/refs/heads/main /tmp/hash-xrootd-s3-http


### PR DESCRIPTION
This changes cmake settings to use the RelWithDebInfo build type when building the pelican client for the docker images.

For the price of slightly less optimization (O3 to O2), and a slightly larger output binary (1.3M to 7.3M), we get line level debugging, which will make investigating segfaults much easier.