### PR TITLE
Plumb HTTPS backend through CLI and adjust it to use full storage prefixes

### DIFF
--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -844,7 +844,7 @@ func TestObjectList405Error(t *testing.T) {
 	server_utils.ResetTestState()
 	defer server_utils.ResetTestState()
 	test_utils.InitClient(t, nil)
-	
+
 	var storageName string
 
 	// Set up our http backend so that we can return a 405 on a PROPFIND

--- a/client/resources/test-https-origin.yml
+++ b/client/resources/test-https-origin.yml
@@ -4,5 +4,6 @@ Logging:
     Scitokens: debug
 Origin:
   StorageType: https
-  FederationPrefix: /test
+  FederationPrefix: /my-prefix
+  StoragePrefix: /test
   EnablePublicReads: true

--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -97,7 +97,7 @@ func init() {
 	originCmd.AddCommand(originServeCmd)
 
 	// The -m flag is used to specify what kind of backend we plan to use for the origin.
-	originServeCmd.Flags().StringP("mode", "m", "posix", "Set the mode for the origin service (default is 'posix'). Supported modes are 'posix' and 's3'.")
+	originServeCmd.Flags().StringP("mode", "m", "posix", "Set the mode for the origin service (default is 'posix'). Supported modes are 'posix', 's3, 'https', 'globus' and 'xroot'.")
 	if err := viper.BindPFlag("Origin.StorageType", originServeCmd.Flags().Lookup("mode")); err != nil {
 		panic(err)
 	}
@@ -155,6 +155,16 @@ instead.
 	originServeCmd.Flags().String("xroot-service-url", "", "When configured in xroot mode, specifies the hostname and port of the upstream xroot server "+
 		"(not to be mistaken with the current server's hostname).")
 	if err := viper.BindPFlag("Origin.XRootServiceUrl", originServeCmd.Flags().Lookup("xroot-service-url")); err != nil {
+		panic(err)
+	}
+
+	// https backend flags
+	originServeCmd.Flags().String("http-service-url", "", "Specify the http(s) service-url. Only used when an origin is launched in https/globus modes.")
+	if err := viper.BindPFlag("Origin.HttpServiceUrl", originServeCmd.Flags().Lookup("http-service-url")); err != nil {
+		panic(err)
+	}
+	originServeCmd.Flags().String("http-tokenfile", "", "Specify a filepath to use for configuring the http(s) token. See documentation for details.")
+	if err := viper.BindPFlag("Origin.HttpAuthTokenFile", originServeCmd.Flags().Lookup("http-tokenfile")); err != nil {
 		panic(err)
 	}
 

--- a/cmd/resources/test-https-origin.yml
+++ b/cmd/resources/test-https-origin.yml
@@ -3,5 +3,6 @@ Logging:
     Scitokens: debug
 Origin:
   StorageType: https
-  FederationPrefix: /test
+  FederationPrefix: /my-prefix
+  StoragePrefix: /test
   EnablePublicReads: true

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -919,9 +919,9 @@ components: ["origin"]
 name: Origin.HttpServiceUrl
 description: |+
   If Origin.StorageType is set to `https`, the service URL is used as the base for requests to the backend.  To generate the
-  request, the Origin.FederationPrefix is removed from the object name, then the result is joined with the service URL.
-  For example, if one sets `Origin.HTTPServiceUrl=https://example.com/testfiles` and `Origin.FederationPrefix=/foo`, then a request
-  for an object named `/foo/bar` will generate a request to https://example.com/testfiles/bar.
+  request, the Origin.FederationPrefix is removed from the object name, then the result is joined with the service URL and storage prefix.
+  For example, if one sets `Origin.HTTPServiceUrl=https://example.com`, `Origin.StoragePrefix=/testfiles` and `Origin.FederationPrefix=/foo`,
+  then a request for an object named `/foo/bar` will generate a request to https://example.com/testfiles/bar.
 type: string
 default: none
 components: ["origin"]

--- a/server_utils/origin.go
+++ b/server_utils/origin.go
@@ -392,6 +392,7 @@ func GetOriginExports() ([]OriginExport, error) {
 			// clean up trailing / in the storage prefix
 			if strings.HasSuffix(storagePrefix, "/") {
 				log.Warningln("Removing trailing '/' from storage prefix", storagePrefix)
+				storagePrefix = strings.TrimSuffix(storagePrefix, "/")
 			}
 			originExport := OriginExport{
 				FederationPrefix: federationPrefix,
@@ -452,6 +453,7 @@ func GetOriginExports() ([]OriginExport, error) {
 			storagePrefix := param.Origin_StoragePrefix.GetString()
 			if strings.HasSuffix(storagePrefix, "/") {
 				log.Warningln("Removing trailing '/' from storage prefix", storagePrefix)
+				storagePrefix = strings.TrimSuffix(storagePrefix, "/")
 			}
 			originExport = OriginExport{
 				FederationPrefix: federationPrefix,

--- a/xrootd/fed_test.go
+++ b/xrootd/fed_test.go
@@ -24,24 +24,18 @@ import (
 	_ "embed"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
-	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pelicanplatform/pelican/client"
-	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/fed_test_utils"
-	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_utils"
-	"github.com/pelicanplatform/pelican/token"
-	"github.com/pelicanplatform/pelican/token_scopes"
 )
 
 var (
@@ -51,17 +45,18 @@ var (
 
 func TestHttpOriginConfig(t *testing.T) {
 	server_utils.ResetTestState()
-	viper.Set("ConfigDir", t.TempDir())
-	server_utils.ResetOriginExports()
 	defer server_utils.ResetTestState()
+	// temp place holder so we can start the test server before this value has been parsed
+	// from the http origin config
+	var storageName string
 
 	body := "Hello, World!"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "HEAD" && r.URL.Path == "/test2/hello_world" {
+		if r.Method == "HEAD" && r.URL.Path == storageName {
 			w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 			w.WriteHeader(http.StatusOK)
 			return
-		} else if r.Method == "GET" && r.URL.Path == "/test2/hello_world" {
+		} else if r.Method == "GET" && r.URL.Path == storageName {
 			w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 			w.WriteHeader(http.StatusPartialContent)
 			_, err := w.Write([]byte(body))
@@ -71,59 +66,19 @@ func TestHttpOriginConfig(t *testing.T) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer srv.Close()
-
-	modules := server_structs.ServerType(0)
-	modules.Set(server_structs.OriginType)
-	modules.Set(server_structs.DirectorType)
-	modules.Set(server_structs.RegistryType)
-
-	viper.Set("Origin.HttpServiceUrl", srv.URL+"/test2")
-	viper.Set("Origin.FederationPrefix", "/test")
-
-	config.InitConfig()
-
-	tmpPath := t.TempDir()
+	viper.Set("Origin.HttpServiceUrl", srv.URL)
 
 	fed := fed_test_utils.NewFedTest(t, httpsOriginConfig)
-
-	issuer, err := config.GetServerIssuerURL()
-	require.NoError(t, err)
-
-	// Create a token file
-	tokenConfig := token.NewWLCGToken()
-	tokenConfig.Lifetime = time.Minute
-	tokenConfig.Issuer = issuer
-	tokenConfig.Subject = "origin"
-	tokenConfig.AddAudienceAny()
-
-	scopes := []token_scopes.TokenScope{}
-	readScope, err := token_scopes.Storage_Read.Path("/")
-	assert.NoError(t, err)
-	scopes = append(scopes, readScope)
-	modScope, err := token_scopes.Storage_Modify.Path("/")
-	assert.NoError(t, err)
-	scopes = append(scopes, modScope)
-	tokenConfig.AddScopes(scopes...)
-	token, err := tokenConfig.CreateToken()
-	assert.NoError(t, err)
-	tempToken, err := os.CreateTemp(t.TempDir(), "token")
-	assert.NoError(t, err, "Error creating temp token file")
-	defer tempToken.Close()
-	_, err = tempToken.WriteString(token)
-	assert.NoError(t, err, "Error writing to temp token file")
-
-	fedInfo, err := config.GetFederation(fed.Ctx)
-	require.NoError(t, err)
-	fedUrl, err := url.Parse(fedInfo.DirectorEndpoint)
-	require.NoError(t, err)
+	storageName = fed.Exports[0].StoragePrefix + "/hello_world"
+	discoveryHost := param.Server_Hostname.GetString() + ":" + strconv.Itoa(param.Server_WebPort.GetInt())
 
 	// Download the test file
+	tmpPath := t.TempDir()
 	transferResults, err := client.DoGet(
 		fed.Ctx,
-		"pelican://"+fedUrl.Host+"/test/hello_world",
+		"pelican://"+discoveryHost+"/my-prefix/hello_world",
 		filepath.Join(tmpPath, "hw"),
 		false,
-		client.WithTokenLocation(tempToken.Name()),
 	)
 	assert.NoError(t, err)
 	if err == nil {

--- a/xrootd/resources/test-https-origin.yml
+++ b/xrootd/resources/test-https-origin.yml
@@ -3,4 +3,6 @@ Logging:
     Scitokens: debug
 Origin:
   StorageType: https
-  FederationPrefix: /test
+  FederationPrefix: /my-prefix
+  StoragePrefix: /test
+  EnablePublicReads: true

--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -78,7 +78,9 @@ s3.end
 {{end}}
 {{else if eq .Origin.StorageType "https"}}
 ofs.osslib libXrdHTTPServer.so
-httpserver.url_base {{.Origin.HttpServiceUrl}}
+# We currently only allow one export for https (handled way before config templating),
+# so we should be safe indexing like this until we expand support to multiple prefixes
+httpserver.url_base {{.Origin.HttpServiceUrl}}{{(index .Origin.Exports 0).StoragePrefix}}
 httpserver.storage_prefix {{.Origin.FederationPrefix}}
 httpserver.trace debug info warning
 {{if .Origin.HttpAuthTokenFile -}}


### PR DESCRIPTION
This PR accomplishes two things -- first, it plumbs a few of the https backend components through the CLI, allowing users to serve minimal https origins without writing a configuration yaml.

Second, it adjust the https backend to use storage prefixes. Consider the following configuration:
```
Origin:
  StorageType: "https"
  HttpServiceUrl: "https://data.lhncbc.nlm.nih.gov/public"
  Exports:
    - StoragePrefix: "/Tuberculosis-Chest-X-ray-Datasets/Montgomery-County-CXR-Set/MontgomerySet/CXR_png"
      FederationPrefix: "/my-prefix"
```

The adjustments cause a request for object `/my-prefix/MCUCXR_0005_0.png` to be converted to a libCurl request in the Origin for `https://data.lhncbc.nlm.nih.gov/public/Tuberculosis-Chest-X-ray-Datasets/Montgomery-County-CXR-Set/MontgomerySet/CXR_png/MCUCXR_0005_0.png`

While we don't yet support multiple exports for the https backend, I think this configuration affords us maximum flexibility for the future where we do by allowing us to set the service URL (every request to the origin uses this as the base URL), a storage prefix (each namespace can then carve out some section of data hosted by the service url), and the typical federation prefix mapping (i.e. strip the fed prefix from the object and tack that value to the end of the service url + storage prefix).

While this is a slight change in how an http origin would be configured, I'm not worried about backwards compat because a) we never documented the limitations of this, even within our own codebase and b) this makes the https backend conformant with the way we use storage prefixes in every other backend.

Closes #1279 