### PR TITLE
Assign unknown client IPs a random geo ip in the contiguous US & cache the result

### DIFF
--- a/director/director.go
+++ b/director/director.go
@@ -475,8 +475,8 @@ func redirectToCache(ginCtx *gin.Context) {
 		return
 	}
 
-	// "smart" sorting method takes care of availability factor
-	if param.Director_CacheSortMethod.GetString() != "smart" {
+	// "adaptive" sorting method takes care of availability factor
+	if param.Director_CacheSortMethod.GetString() == string(server_structs.AdaptiveType) {
 		// Re-sort by availability, where caches having the object have higher priority
 		sortServerAdsByAvailability(cacheAds, cachesAvailabilityMap)
 	}

--- a/director/sort.go
+++ b/director/sort.go
@@ -68,6 +68,13 @@ const (
 	objAvailabilityFactor    = 2    // Multiplier for knowing whether an object is present
 	loadHalvingThreshold     = 10.0 // Threshold where the load havling factor kicks in
 	loadHalvingFactor        = 4.0  // Halving interval for load
+
+	// A rough lat/long bounding box for the contiguous US. We might eventually make this box
+	// a configurable value, but for now it's hardcoded
+	usLatMin  = 30.0
+	usLatMax  = 50.0
+	usLongMin = -125.0
+	usLongMax = -65.0
 )
 
 func (me SwapMaps) Len() int {
@@ -173,12 +180,31 @@ func getLatLong(addr netip.Addr) (lat float64, long float64, err error) {
 	return
 }
 
-func getClientLatLong(addr netip.Addr) (coord Coordinate, ok bool) {
+// Given a bounding box, assign a random coordinate within that box.
+func assignRandBoundedCoord(minLat, maxLat, minLong, maxLong float64) (lat, long float64) {
+	lat = rand.Float64()*(maxLat-minLat) + minLat
+	long = rand.Float64()*(maxLong-minLong) + minLong
+	return
+}
+
+// Given a client address, attempt to get the lat/long of the client. If the address is invalid or
+// the lat/long is not resolvable, assign a random location in the contiguous US.
+func getClientLatLong(addr netip.Addr) (coord Coordinate) {
 	var err error
+	if !addr.IsValid() {
+		log.Warningf("Unable to sort servers based on client-server distance. Invalid client IP address: %s", addr.String())
+		coord.Lat, coord.Long = assignRandBoundedCoord(usLatMin, usLatMax, usLongMin, usLongMax)
+		log.Warningf("Assigning random location in the contiguous US to lat/long %f, %f ", coord.Lat, coord.Long)
+		return
+	}
+
 	coord.Lat, coord.Long, err = getLatLong(addr)
-	ok = (err == nil && !(coord.Lat == 0 && coord.Long == 0))
-	if err != nil {
-		log.Warningf("failed to resolve lat/long for address %s: %v", addr, err)
+	if err != nil || (coord.Lat == 0 && coord.Long == 0) {
+		if err != nil {
+			log.Warningf("Error while getting the client IP address: %v", err)
+		}
+		coord.Lat, coord.Long = assignRandBoundedCoord(usLatMin, usLatMax, usLongMin, usLongMax)
+		log.Warningf("Client IP %s has been re-assigned a random location in the contiguous US to lat/long %f, %f ", addr.String(), coord.Lat, coord.Long)
 	}
 	return
 }
@@ -192,7 +218,7 @@ func invertWeightIfNeeded(isRand bool, weight float64) float64 {
 	return weight
 }
 
-// The all-in-one method to sort serverAds based on Dirtector.CacheSortMethod configuration parameter
+// The all-in-one method to sort serverAds based on the Director.CacheSortMethod configuration parameter
 //   - distance: sort serverAds by the distance between the geolocation of the servers and the client
 //   - distanceAndLoad: sort serverAds by the distance with gated halving factor (see details in the adaptive method)
 //     and the server IO load
@@ -207,15 +233,8 @@ func sortServerAds(clientAddr netip.Addr, ads []server_structs.ServerAd, availab
 	// A larger weight is a higher priority.
 	weights := make(SwapMaps, len(ads))
 	sortMethod := param.Director_CacheSortMethod.GetString()
-
-	clientCoord := Coordinate{}
-	clientCoordOk := false
-
-	if clientAddr.IsValid() {
-		clientCoord, clientCoordOk = getClientLatLong(clientAddr)
-	} else {
-		log.Warningf("Unable to sort servers based on client-server distance. Invalid client IP address: %s", clientAddr.String())
-	}
+	// This will handle the case where the client address is invalid or the lat/long is not resolvable.
+	clientCoord := getClientLatLong(clientAddr)
 
 	// For each ad, we apply the configured sort method to determine a priority weight.
 	for idx, ad := range ads {
@@ -232,20 +251,16 @@ func sortServerAds(clientAddr netip.Addr, ads []server_structs.ServerAd, availab
 		case server_structs.DistanceAndLoadType:
 			weight := 1.0
 			// Distance weight
-			var distance float64
-			var isRand bool
-			if clientCoordOk {
-				distance, isRand = distanceWeight(clientCoord.Lat, clientCoord.Long, ad.Latitude, ad.Longitude, true)
-				if isRand {
-					// In distanceAndLoad/adaptive modes, pin random distance weights to the range [-0.475, -0.525)] in an attempt
-					// to make sure the weights from availability/load overpower the random distance weights while
-					// still having a stochastic element. We do this instead of ignoring the distance weight entirely, because
-					// it's possible load information and or availability information is not available for all servers.
-					weight = 0 - (0.475+rand.Float64())*(0.05)
-				} else {
-					dWeighted := gatedHalvingMultiplier(distance, distanceHalvingThreshold, distanceHalvingFactor)
-					weight *= dWeighted
-				}
+			distance, isRand := distanceWeight(clientCoord.Lat, clientCoord.Long, ad.Latitude, ad.Longitude, true)
+			if isRand {
+				// In distanceAndLoad/adaptive modes, pin random distance weights to the range [-0.475, -0.525)] in an attempt
+				// to make sure the weights from availability/load overpower the random distance weights while
+				// still having a stochastic element. We do this instead of ignoring the distance weight entirely, because
+				// it's possible load information and or availability information is not available for all servers.
+				weight = 0 - (0.475+rand.Float64())*(0.05)
+			} else {
+				dWeighted := gatedHalvingMultiplier(distance, distanceHalvingThreshold, distanceHalvingFactor)
+				weight *= dWeighted
 			}
 
 			// Load weight
@@ -255,17 +270,14 @@ func sortServerAds(clientAddr netip.Addr, ads []server_structs.ServerAd, availab
 		case server_structs.AdaptiveType:
 			weight := 1.0
 			// Distance weight
-			var distance float64
-			var isRand bool
-			if clientCoordOk {
-				distance, isRand = distanceWeight(clientCoord.Lat, clientCoord.Long, ad.Latitude, ad.Longitude, true)
-				if isRand {
-					weight = 0 - (0.475+rand.Float64())*(0.05)
-				} else {
-					dWeighted := gatedHalvingMultiplier(distance, distanceHalvingThreshold, distanceHalvingFactor)
-					weight *= dWeighted
-				}
+			distance, isRand := distanceWeight(clientCoord.Lat, clientCoord.Long, ad.Latitude, ad.Longitude, true)
+			if isRand {
+				weight = 0 - (0.475+rand.Float64())*(0.05)
+			} else {
+				dWeighted := gatedHalvingMultiplier(distance, distanceHalvingThreshold, distanceHalvingFactor)
+				weight *= dWeighted
 			}
+
 			// Availability weight
 			if availabilityMap == nil {
 				weight *= 1.0

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -45,6 +45,10 @@ var yamlMockup string
 
 func TestCheckOverrides(t *testing.T) {
 	viper.Reset()
+	t.Cleanup(func() {
+		viper.Reset()
+		geoIPOverrides = nil
+	})
 
 	// We'll also check that our logging feature responsibly reports
 	// what Pelican is telling the user.
@@ -138,8 +142,6 @@ func TestCheckOverrides(t *testing.T) {
 		require.Equal(t, expectedCoordinate.Lat, coordinate.Lat)
 		require.Equal(t, expectedCoordinate.Long, coordinate.Long)
 	})
-
-	viper.Reset()
 }
 
 func TestSortServerAdsByTopo(t *testing.T) {
@@ -192,6 +194,7 @@ func TestSortServerAds(t *testing.T) {
 	viper.Reset()
 	t.Cleanup(func() {
 		viper.Reset()
+		geoIPOverrides = nil
 	})
 
 	// A random IP that should geo-resolve to roughly the same location as the Madison server
@@ -443,6 +446,8 @@ func TestAssignRandBoundedCoord(t *testing.T) {
 }
 
 func TestGetClientLatLong(t *testing.T) {
+	// The cache may be populated from previous tests. Wipe it out and start fresh.
+	clientIpCache.DeleteAll()
 	t.Run("invalid-ip", func(t *testing.T) {
 		// Capture the log and check that the correct error is logged
 		logOutput := &(bytes.Buffer{})

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -450,11 +450,20 @@ func TestGetClientLatLong(t *testing.T) {
 		log.SetLevel(log.DebugLevel)
 
 		clientIp := netip.Addr{}
+		assert.False(t, clientIpCache.Has(clientIp))
 		coord := getClientLatLong(clientIp)
 
 		assert.True(t, coord.Lat <= usLatMax && coord.Lat >= usLatMin)
 		assert.True(t, coord.Long <= usLongMax && coord.Long >= usLongMin)
 		assert.Contains(t, logOutput.String(), "Unable to sort servers based on client-server distance. Invalid client IP address")
+		assert.NotContains(t, logOutput.String(), "Retrieving pre-assigned lat/long")
+
+		// Get it again to make sure it's coming from the cache
+		coord = getClientLatLong(clientIp)
+		assert.True(t, coord.Lat <= usLatMax && coord.Lat >= usLatMin)
+		assert.True(t, coord.Long <= usLongMax && coord.Long >= usLongMin)
+		assert.Contains(t, logOutput.String(), "Retrieving pre-assigned lat/long for unresolved client IP")
+		assert.True(t, clientIpCache.Has(clientIp))
 	})
 
 	t.Run("valid-ip-no-geoip-match", func(t *testing.T) {
@@ -463,10 +472,19 @@ func TestGetClientLatLong(t *testing.T) {
 		log.SetLevel(log.DebugLevel)
 
 		clientIp := netip.MustParseAddr("192.168.0.1")
+		assert.False(t, clientIpCache.Has(clientIp))
 		coord := getClientLatLong(clientIp)
 
 		assert.True(t, coord.Lat <= usLatMax && coord.Lat >= usLatMin)
 		assert.True(t, coord.Long <= usLongMax && coord.Long >= usLongMin)
 		assert.Contains(t, logOutput.String(), "Client IP 192.168.0.1 has been re-assigned a random location in the contiguous US to lat/long")
+		assert.NotContains(t, logOutput.String(), "Retrieving pre-assigned lat/long")
+
+		// Get it again to make sure it's coming from the cache
+		coord = getClientLatLong(clientIp)
+		assert.True(t, coord.Lat <= usLatMax && coord.Lat >= usLatMin)
+		assert.True(t, coord.Long <= usLongMax && coord.Long >= usLongMin)
+		assert.Contains(t, logOutput.String(), "Retrieving pre-assigned lat/long for client IP")
+		assert.True(t, clientIpCache.Has(clientIp))
 	})
 }

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -456,17 +456,17 @@ func TestGetClientLatLong(t *testing.T) {
 
 		clientIp := netip.Addr{}
 		assert.False(t, clientIpCache.Has(clientIp))
-		coord := getClientLatLong(clientIp)
+		coord1 := getClientLatLong(clientIp)
 
-		assert.True(t, coord.Lat <= usLatMax && coord.Lat >= usLatMin)
-		assert.True(t, coord.Long <= usLongMax && coord.Long >= usLongMin)
+		assert.True(t, coord1.Lat <= usLatMax && coord1.Lat >= usLatMin)
+		assert.True(t, coord1.Long <= usLongMax && coord1.Long >= usLongMin)
 		assert.Contains(t, logOutput.String(), "Unable to sort servers based on client-server distance. Invalid client IP address")
 		assert.NotContains(t, logOutput.String(), "Retrieving pre-assigned lat/long")
 
 		// Get it again to make sure it's coming from the cache
-		coord = getClientLatLong(clientIp)
-		assert.True(t, coord.Lat <= usLatMax && coord.Lat >= usLatMin)
-		assert.True(t, coord.Long <= usLongMax && coord.Long >= usLongMin)
+		coord2 := getClientLatLong(clientIp)
+		assert.Equal(t, coord1.Lat, coord2.Lat)
+		assert.Equal(t, coord1.Long, coord2.Long)
 		assert.Contains(t, logOutput.String(), "Retrieving pre-assigned lat/long for unresolved client IP")
 		assert.True(t, clientIpCache.Has(clientIp))
 	})
@@ -478,17 +478,17 @@ func TestGetClientLatLong(t *testing.T) {
 
 		clientIp := netip.MustParseAddr("192.168.0.1")
 		assert.False(t, clientIpCache.Has(clientIp))
-		coord := getClientLatLong(clientIp)
+		coord1 := getClientLatLong(clientIp)
 
-		assert.True(t, coord.Lat <= usLatMax && coord.Lat >= usLatMin)
-		assert.True(t, coord.Long <= usLongMax && coord.Long >= usLongMin)
+		assert.True(t, coord1.Lat <= usLatMax && coord1.Lat >= usLatMin)
+		assert.True(t, coord1.Long <= usLongMax && coord1.Long >= usLongMin)
 		assert.Contains(t, logOutput.String(), "Client IP 192.168.0.1 has been re-assigned a random location in the contiguous US to lat/long")
 		assert.NotContains(t, logOutput.String(), "Retrieving pre-assigned lat/long")
 
 		// Get it again to make sure it's coming from the cache
-		coord = getClientLatLong(clientIp)
-		assert.True(t, coord.Lat <= usLatMax && coord.Lat >= usLatMin)
-		assert.True(t, coord.Long <= usLongMax && coord.Long >= usLongMin)
+		coord2 := getClientLatLong(clientIp)
+		assert.Equal(t, coord1.Lat, coord2.Lat)
+		assert.Equal(t, coord1.Long, coord2.Long)
 		assert.Contains(t, logOutput.String(), "Retrieving pre-assigned lat/long for client IP")
 		assert.True(t, clientIpCache.Has(clientIp))
 	})


### PR DESCRIPTION
This PR aims to improve the Director's cache sorting algorithm, specifically in the case of clients whose GeoIP resolution can't be determined.

With these changes, client IPs that don't have an entry in MaxMind entry (or that can't be parsed as an IP in the first case) are assigned a random location in the contiguous United States. Doing this makes the Director behave as though it knows the client's true location by delivering caches sorted based on the new location. This differs from the previous algorithm, where those IP addresses resulted in completely random cache sorting.

When a client IP is assigned a random location, that location is cached for 20 minutes, unless refreshed by further client interactions. This is done so that repetitive client requests get a consistent cache ordering (barring any other load information or the sort algorithm's stochastic jiggle), which should further improve cache hits.

Closes #1587