### PR TITLE
Null the token generator pointer for public reads

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1209,6 +1209,8 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 			tj.dirResp = dirResp
 			tj.token.DirResp = &dirResp
 		}
+	} else {
+		tj.token = nil
 	}
 
 	// If we are a recursive download and using the director, we want to attempt to get directory listings from

--- a/client/main.go
+++ b/client/main.go
@@ -116,6 +116,8 @@ func DoStat(ctx context.Context, destination string, options ...TransferOption) 
 		if err != nil || tokenContents == "" {
 			return nil, errors.Wrap(err, "failed to get token for transfer")
 		}
+	} else {
+		token = nil
 	}
 
 	if statInfo, err := statHttp(destUri, dirResp, token); err != nil {
@@ -298,6 +300,8 @@ func DoList(ctx context.Context, remoteObject string, options ...TransferOption)
 		if err != nil || tokenContents == "" {
 			return nil, errors.Wrap(err, "failed to get token for transfer")
 		}
+	} else {
+		token = nil
 	}
 
 	fileInfos, err = listHttp(remoteObjectUrl, dirResp, token)


### PR DESCRIPTION
Prior to the new token generator object, an empty / missing token was a no-op.  After it, the token generator could potentially try to acquire a token.  Even though it was non-fatal when no token was available, the error messages were awfully confusing.

Now, if no token is required, we explicitly nil out the token generator object, preventing the request.