### PR TITLE
Don't construct Pelican URLs for copy commands

### DIFF
--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -167,11 +167,6 @@ func copyMain(cmd *cobra.Command, args []string) {
 	lastSrc := ""
 
 	for _, src := range source {
-		src, result = utils.UrlWithFederation(src)
-		if result != nil {
-			lastSrc = src
-			break
-		}
 		isRecursive, _ := cmd.Flags().GetBool("recursive")
 		_, result = client.DoCopy(ctx, src, dest, isRecursive, client.WithCallback(pb.callback), client.WithTokenLocation(tokenLocation), client.WithCaches(caches...))
 		if result != nil {


### PR DESCRIPTION
Stashcp needs to determine the copy direction dynamically, so we can't treat the source as a defacto Pelican/OSDF URL -- sometimes we're dealing with a GET, sometimes a PUT. The function `UrlWithFederation` was introduced with the intention of standardizing the way we handle gets/puts that don't conform to our `<pelican/osdf>://` url specification by building a pelican URL by default. This is safe to do when we know the direction of transfer, but copy commands _require_ a schemed url to determine direction. Because of this, all schemeless paths for copies _must_ be treated as local.