### PR TITLE
Modify the `sync` sub-command to sync based on size differences (#1611)

### DIFF
--- a/cmd/object_sync.go
+++ b/cmd/object_sync.go
@@ -174,7 +174,7 @@ func syncMain(cmd *cobra.Command, args []string) {
 		for _, src := range sources {
 			if _, err = client.DoGet(ctx, src, dest, true,
 				client.WithCallback(pb.callback), client.WithTokenLocation(tokenLocation),
-				client.WithCaches(caches...), client.WithSynchronize(client.SyncExist)); err != nil {
+				client.WithCaches(caches...), client.WithSynchronize(client.SyncSize)); err != nil {
 				lastSrc = src
 				break
 			}
@@ -183,7 +183,7 @@ func syncMain(cmd *cobra.Command, args []string) {
 		for _, src := range sources {
 			if _, err = client.DoPut(ctx, src, dest, true,
 				client.WithCallback(pb.callback), client.WithTokenLocation(tokenLocation),
-				client.WithCaches(caches...), client.WithSynchronize(client.SyncExist)); err != nil {
+				client.WithCaches(caches...), client.WithSynchronize(client.SyncSize)); err != nil {
 				lastSrc = src
 				break
 			}


### PR DESCRIPTION
Exactly what the title says, which is what the original PR (#1586) for the `sync` sub-command was aiming for:

> This can be called multiple times; partially-downloaded files will be completed and completed files will be skipped (similar behavior on uploads).

This PR addresses issue #1611.