### PR TITLE
New Reset function 

### DIFF
--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -76,7 +76,7 @@ func getHelloWorldHandler(t *testing.T) func(resp http.ResponseWriter, req *http
 func Setup(t *testing.T, ctx context.Context, egrp *errgroup.Group) {
 	dirpath := t.TempDir()
 
-	config.Reset()
+	server_utils.Reset()
 	viper.Set("Logging.Level", "Debug")
 	viper.Set("ConfigDir", filepath.Join(dirpath, "config"))
 	config.InitConfig()

--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -76,7 +76,7 @@ func getHelloWorldHandler(t *testing.T) func(resp http.ResponseWriter, req *http
 func Setup(t *testing.T, ctx context.Context, egrp *errgroup.Group) {
 	dirpath := t.TempDir()
 
-	viper.Reset()
+	config.Reset()
 	viper.Set("Logging.Level", "Debug")
 	viper.Set("ConfigDir", filepath.Join(dirpath, "config"))
 	config.InitConfig()

--- a/broker/token_utils_test.go
+++ b/broker/token_utils_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestGetCacheHostnameFromToken(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	viper.Set("ConfigDir", t.TempDir())
 	config.InitConfig()
 	require.NoError(t, config.InitClient())

--- a/broker/token_utils_test.go
+++ b/broker/token_utils_test.go
@@ -28,10 +28,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/server_utils"
 )
 
 func TestGetCacheHostnameFromToken(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	viper.Set("ConfigDir", t.TempDir())
 	config.InitConfig()
 	require.NoError(t, config.InitClient())

--- a/cache/advertise_test.go
+++ b/cache/advertise_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 )
 
 func TestFilterNsAdsForCache(t *testing.T) {
@@ -82,8 +83,8 @@ func TestFilterNsAdsForCache(t *testing.T) {
 			expectedNumNS: 2,
 		},
 	}
-	config.Reset()
-	defer config.Reset()
+	server_utils.Reset()
+	defer server_utils.Reset()
 
 	nsAds := []server_structs.NamespaceAdV2{
 		{
@@ -130,7 +131,7 @@ func TestFilterNsAdsForCache(t *testing.T) {
 			if testInput.permittedNS != nil {
 				viper.Set("Cache.PermittedNamespaces", testInput.permittedNS)
 			}
-			defer config.Reset()
+			defer server_utils.Reset()
 
 			cacheServer.SetFilters()
 			err = cacheServer.GetNamespaceAdsFromDirector()

--- a/cache/advertise_test.go
+++ b/cache/advertise_test.go
@@ -82,8 +82,8 @@ func TestFilterNsAdsForCache(t *testing.T) {
 			expectedNumNS: 2,
 		},
 	}
-	viper.Reset()
-	defer viper.Reset()
+	config.Reset()
+	defer config.Reset()
 
 	nsAds := []server_structs.NamespaceAdV2{
 		{
@@ -130,7 +130,7 @@ func TestFilterNsAdsForCache(t *testing.T) {
 			if testInput.permittedNS != nil {
 				viper.Set("Cache.PermittedNamespaces", testInput.permittedNS)
 			}
-			defer viper.Reset()
+			defer config.Reset()
 
 			cacheServer.SetFilters()
 			err = cacheServer.GetNamespaceAdsFromDirector()

--- a/cache/cache_api_test.go
+++ b/cache/cache_api_test.go
@@ -27,19 +27,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
 )
 
 func TestCheckCacheSentinelLocation(t *testing.T) {
 	t.Run("sentinel-not-set", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		err := CheckCacheSentinelLocation()
 		assert.NoError(t, err)
 	})
 
 	t.Run("sentinel-contains-dir", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		viper.Set(param.Cache_SentinelLocation.GetName(), "/test.txt")
 		err := CheckCacheSentinelLocation()
 		require.Error(t, err)
@@ -48,7 +48,7 @@ func TestCheckCacheSentinelLocation(t *testing.T) {
 
 	t.Run("sentinel-dne", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		config.Reset()
+		server_utils.Reset()
 		viper.Set(param.Cache_SentinelLocation.GetName(), "test.txt")
 		viper.Set(param.Cache_LocalRoot.GetName(), tmpDir)
 		err := CheckCacheSentinelLocation()
@@ -58,7 +58,7 @@ func TestCheckCacheSentinelLocation(t *testing.T) {
 
 	t.Run("sentinel-exists", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		config.Reset()
+		server_utils.Reset()
 
 		viper.Set(param.Cache_SentinelLocation.GetName(), "test.txt")
 		viper.Set(param.Cache_LocalRoot.GetName(), tmpDir)

--- a/cache/cache_api_test.go
+++ b/cache/cache_api_test.go
@@ -27,18 +27,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 )
 
 func TestCheckCacheSentinelLocation(t *testing.T) {
 	t.Run("sentinel-not-set", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		err := CheckCacheSentinelLocation()
 		assert.NoError(t, err)
 	})
 
 	t.Run("sentinel-contains-dir", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		viper.Set(param.Cache_SentinelLocation.GetName(), "/test.txt")
 		err := CheckCacheSentinelLocation()
 		require.Error(t, err)
@@ -47,7 +48,7 @@ func TestCheckCacheSentinelLocation(t *testing.T) {
 
 	t.Run("sentinel-dne", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		viper.Reset()
+		config.Reset()
 		viper.Set(param.Cache_SentinelLocation.GetName(), "test.txt")
 		viper.Set(param.Cache_LocalRoot.GetName(), tmpDir)
 		err := CheckCacheSentinelLocation()
@@ -57,7 +58,7 @@ func TestCheckCacheSentinelLocation(t *testing.T) {
 
 	t.Run("sentinel-exists", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		viper.Reset()
+		config.Reset()
 
 		viper.Set(param.Cache_SentinelLocation.GetName(), "test.txt")
 		viper.Set(param.Cache_LocalRoot.GetName(), tmpDir)

--- a/client/fed_linux_test.go
+++ b/client/fed_linux_test.go
@@ -47,8 +47,7 @@ import (
 
 func TestRecursiveUploadsAndDownloads(t *testing.T) {
 	// Create instance of test federation
-	config.Reset()
-	server_utils.ResetOriginExports()
+	server_utils.Reset()
 
 	fed := fed_test_utils.NewFedTest(t, mixedAuthOriginCfg)
 	discoveryUrl, err := url.Parse(param.Federation_DiscoveryUrl.GetString())
@@ -222,8 +221,8 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 			log.Errorln("Failure when shutting down transfer engine:", err)
 		}
 		// Throw in a config.Reset for good measure. Keeps our env squeaky clean!
-		config.Reset()
-		server_utils.ResetOriginExports()
+		server_utils.Reset()
+
 	})
 }
 
@@ -243,8 +242,7 @@ func verifySuccessfulTransfer(t *testing.T, transferResults []client.TransferRes
 // Test that recursive uploads and downloads work with the ?recursive query
 func TestRecursiveUploadsAndDownloadsWithQuery(t *testing.T) {
 	// Create instance of test federation
-	config.Reset()
-	server_utils.ResetOriginExports()
+	server_utils.Reset()
 
 	fed := fed_test_utils.NewFedTest(t, mixedAuthOriginCfg)
 	discoveryUrl, err := url.Parse(param.Federation_DiscoveryUrl.GetString())
@@ -258,8 +256,8 @@ func TestRecursiveUploadsAndDownloadsWithQuery(t *testing.T) {
 			log.Errorln("Failure when shutting down transfer engine:", err)
 		}
 		// Throw in a config.Reset for good measure. Keeps our env squeaky clean!
-		config.Reset()
-		server_utils.ResetOriginExports()
+		server_utils.Reset()
+
 	})
 
 	// Create a token file
@@ -436,8 +434,7 @@ func TestRecursiveUploadsAndDownloadsWithQuery(t *testing.T) {
 // This tests that is origins disable listings, we should fail the download
 // Note: origins disabling listings override the existence of dirlisthost, causing a failure
 func TestFailureOnOriginDisablingListings(t *testing.T) {
-	config.Reset()
-	server_utils.ResetOriginExports()
+	server_utils.Reset()
 
 	viper.Set("Logging.Level", "debug")
 	viper.Set("Origin.StorageType", "posix")
@@ -461,8 +458,7 @@ func TestFailureOnOriginDisablingListings(t *testing.T) {
 
 func TestSyncUpload(t *testing.T) {
 	// Create instance of test federation
-	config.Reset()
-	server_utils.ResetOriginExports()
+	server_utils.Reset()
 
 	fed := fed_test_utils.NewFedTest(t, bothAuthOriginCfg)
 	discoveryUrl, err := url.Parse(param.Federation_DiscoveryUrl.GetString())
@@ -592,8 +588,7 @@ func TestSyncUpload(t *testing.T) {
 
 func TestSyncDownload(t *testing.T) {
 	// Create instance of test federation
-	config.Reset()
-	server_utils.ResetOriginExports()
+	server_utils.Reset()
 
 	fed := fed_test_utils.NewFedTest(t, bothAuthOriginCfg)
 	discoveryUrl, err := url.Parse(param.Federation_DiscoveryUrl.GetString())

--- a/client/fed_linux_test.go
+++ b/client/fed_linux_test.go
@@ -47,7 +47,7 @@ import (
 
 func TestRecursiveUploadsAndDownloads(t *testing.T) {
 	// Create instance of test federation
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
 
 	fed := fed_test_utils.NewFedTest(t, mixedAuthOriginCfg)
@@ -221,8 +221,8 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 		if err := te.Shutdown(); err != nil {
 			log.Errorln("Failure when shutting down transfer engine:", err)
 		}
-		// Throw in a viper.Reset for good measure. Keeps our env squeaky clean!
-		viper.Reset()
+		// Throw in a config.Reset for good measure. Keeps our env squeaky clean!
+		config.Reset()
 		server_utils.ResetOriginExports()
 	})
 }
@@ -243,7 +243,7 @@ func verifySuccessfulTransfer(t *testing.T, transferResults []client.TransferRes
 // Test that recursive uploads and downloads work with the ?recursive query
 func TestRecursiveUploadsAndDownloadsWithQuery(t *testing.T) {
 	// Create instance of test federation
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
 
 	fed := fed_test_utils.NewFedTest(t, mixedAuthOriginCfg)
@@ -257,8 +257,8 @@ func TestRecursiveUploadsAndDownloadsWithQuery(t *testing.T) {
 		if err := te.Shutdown(); err != nil {
 			log.Errorln("Failure when shutting down transfer engine:", err)
 		}
-		// Throw in a viper.Reset for good measure. Keeps our env squeaky clean!
-		viper.Reset()
+		// Throw in a config.Reset for good measure. Keeps our env squeaky clean!
+		config.Reset()
 		server_utils.ResetOriginExports()
 	})
 
@@ -436,7 +436,7 @@ func TestRecursiveUploadsAndDownloadsWithQuery(t *testing.T) {
 // This tests that is origins disable listings, we should fail the download
 // Note: origins disabling listings override the existence of dirlisthost, causing a failure
 func TestFailureOnOriginDisablingListings(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
 
 	viper.Set("Logging.Level", "debug")
@@ -461,7 +461,7 @@ func TestFailureOnOriginDisablingListings(t *testing.T) {
 
 func TestSyncUpload(t *testing.T) {
 	// Create instance of test federation
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
 
 	fed := fed_test_utils.NewFedTest(t, bothAuthOriginCfg)
@@ -592,7 +592,7 @@ func TestSyncUpload(t *testing.T) {
 
 func TestSyncDownload(t *testing.T) {
 	// Create instance of test federation
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
 
 	fed := fed_test_utils.NewFedTest(t, bothAuthOriginCfg)

--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -105,7 +105,7 @@ func getTempToken(t *testing.T) (tempToken *os.File, tkn string) {
 
 // A test that spins up a federation, and tests object get and put
 func TestGetAndPutAuth(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
 	fed := fed_test_utils.NewFedTest(t, bothAuthOriginCfg)
 	discoveryUrl, err := url.Parse(param.Federation_DiscoveryUrl.GetString())
@@ -282,14 +282,14 @@ func TestGetAndPutAuth(t *testing.T) {
 		}
 	})
 	t.Cleanup(func() {
-		// Throw in a viper.Reset for good measure. Keeps our env squeaky clean!
-		viper.Reset()
+		// Throw in a config.Reset for good measure. Keeps our env squeaky clean!
+		config.Reset()
 	})
 }
 
 // A test that spins up a federation, and tests object get and put
 func TestCopyAuth(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
 	fed := fed_test_utils.NewFedTest(t, bothAuthOriginCfg)
 	discoveryUrl, err := url.Parse(param.Federation_DiscoveryUrl.GetString())
@@ -443,14 +443,14 @@ func TestCopyAuth(t *testing.T) {
 		if err := te.Shutdown(); err != nil {
 			log.Errorln("Failure when shutting down transfer engine:", err)
 		}
-		// Throw in a viper.Reset for good measure. Keeps our env squeaky clean!
-		viper.Reset()
+		// Throw in a config.Reset for good measure. Keeps our env squeaky clean!
+		config.Reset()
 	})
 }
 
 // A test that spins up the federation, where the origin is in EnablePublicReads mode. Then GET a file from the origin without a token
 func TestGetPublicRead(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
 	fed := fed_test_utils.NewFedTest(t, bothPublicOriginCfg)
 
@@ -480,17 +480,17 @@ func TestGetPublicRead(t *testing.T) {
 		}
 	})
 	t.Cleanup(func() {
-		// Throw in a viper.Reset for good measure. Keeps our env squeaky clean!
-		viper.Reset()
+		// Throw in a config.Reset for good measure. Keeps our env squeaky clean!
+		config.Reset()
 	})
 }
 
 // A test that spins up a federation, and tests object stat
 func TestObjectStat(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
 	defer server_utils.ResetOriginExports()
-	defer viper.Reset()
+	defer config.Reset()
 	fed := fed_test_utils.NewFedTest(t, mixedAuthOriginCfg)
 	discoveryUrl, err := url.Parse(param.Federation_DiscoveryUrl.GetString())
 	require.NoError(t, err)
@@ -593,9 +593,9 @@ func TestObjectStat(t *testing.T) {
 
 // Test the functionality of the direct reads feature (?directread)
 func TestDirectReads(t *testing.T) {
-	defer viper.Reset()
+	defer config.Reset()
 	t.Run("testDirectReadsSuccess", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		server_utils.ResetOriginExports()
 		viper.Set("Origin.EnableDirectReads", true)
 		fed := fed_test_utils.NewFedTest(t, bothPublicOriginCfg)
@@ -637,7 +637,7 @@ func TestDirectReads(t *testing.T) {
 
 	// Test that direct reads fail if DirectReads=false is set for origin config but true for namespace/export
 	t.Run("testDirectReadsDirectReadFalseByOrigin", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		server_utils.ResetOriginExports()
 		fed := fed_test_utils.NewFedTest(t, pubOriginNoDirectRead)
 		discoveryUrl, err := url.Parse(param.Federation_DiscoveryUrl.GetString())
@@ -667,7 +667,7 @@ func TestDirectReads(t *testing.T) {
 
 	// Test that direct reads fail if DirectReads=false is set for namespace/export config but true for origin
 	t.Run("testDirectReadsDirectReadFalseByNamespace", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		server_utils.ResetOriginExports()
 		fed := fed_test_utils.NewFedTest(t, pubExportNoDirectRead)
 		discoveryUrl, err := url.Parse(param.Federation_DiscoveryUrl.GetString())
@@ -699,8 +699,8 @@ func TestDirectReads(t *testing.T) {
 
 // Test the functionality of NewTransferJob, checking we return at the correct locations for certain errors
 func TestNewTransferJob(t *testing.T) {
-	viper.Reset()
-	defer viper.Reset()
+	config.Reset()
+	defer config.Reset()
 	server_utils.ResetOriginExports()
 	defer server_utils.ResetOriginExports()
 	fed := fed_test_utils.NewFedTest(t, mixedAuthOriginCfg)
@@ -748,10 +748,10 @@ func TestNewTransferJob(t *testing.T) {
 
 // A test that spins up a federation, and tests object list
 func TestObjectList(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
 	defer server_utils.ResetOriginExports()
-	defer viper.Reset()
+	defer config.Reset()
 	fed := fed_test_utils.NewFedTest(t, mixedAuthOriginCfg)
 
 	// Other set-up items:
@@ -882,7 +882,7 @@ func TestObjectList405Error(t *testing.T) {
 // Startup a mini-federation and ensure the "pack=auto" functionality works
 // end-to-end
 func TestClientUnpack(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
 	defer server_utils.ResetOriginExports()
 	err := config.InitClient()
@@ -942,7 +942,7 @@ func TestClientUnpack(t *testing.T) {
 
 // A test that generates a token locally from the private key
 func TestTokenGenerate(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
 	fed := fed_test_utils.NewFedTest(t, bothAuthOriginCfg)
 

--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -105,8 +105,8 @@ func getTempToken(t *testing.T) (tempToken *os.File, tkn string) {
 
 // A test that spins up a federation, and tests object get and put
 func TestGetAndPutAuth(t *testing.T) {
-	config.Reset()
-	server_utils.ResetOriginExports()
+	server_utils.Reset()
+
 	fed := fed_test_utils.NewFedTest(t, bothAuthOriginCfg)
 	discoveryUrl, err := url.Parse(param.Federation_DiscoveryUrl.GetString())
 	assert.NoError(t, err)
@@ -283,14 +283,14 @@ func TestGetAndPutAuth(t *testing.T) {
 	})
 	t.Cleanup(func() {
 		// Throw in a config.Reset for good measure. Keeps our env squeaky clean!
-		config.Reset()
+		server_utils.Reset()
 	})
 }
 
 // A test that spins up a federation, and tests object get and put
 func TestCopyAuth(t *testing.T) {
-	config.Reset()
-	server_utils.ResetOriginExports()
+	server_utils.Reset()
+
 	fed := fed_test_utils.NewFedTest(t, bothAuthOriginCfg)
 	discoveryUrl, err := url.Parse(param.Federation_DiscoveryUrl.GetString())
 	assert.NoError(t, err)
@@ -444,14 +444,14 @@ func TestCopyAuth(t *testing.T) {
 			log.Errorln("Failure when shutting down transfer engine:", err)
 		}
 		// Throw in a config.Reset for good measure. Keeps our env squeaky clean!
-		config.Reset()
+		server_utils.Reset()
 	})
 }
 
 // A test that spins up the federation, where the origin is in EnablePublicReads mode. Then GET a file from the origin without a token
 func TestGetPublicRead(t *testing.T) {
-	config.Reset()
-	server_utils.ResetOriginExports()
+	server_utils.Reset()
+
 	fed := fed_test_utils.NewFedTest(t, bothPublicOriginCfg)
 
 	t.Run("testPubObjGet", func(t *testing.T) {
@@ -481,16 +481,15 @@ func TestGetPublicRead(t *testing.T) {
 	})
 	t.Cleanup(func() {
 		// Throw in a config.Reset for good measure. Keeps our env squeaky clean!
-		config.Reset()
+		server_utils.Reset()
 	})
 }
 
 // A test that spins up a federation, and tests object stat
 func TestObjectStat(t *testing.T) {
-	config.Reset()
-	server_utils.ResetOriginExports()
-	defer server_utils.ResetOriginExports()
-	defer config.Reset()
+	server_utils.Reset()
+
+	defer server_utils.Reset()
 	fed := fed_test_utils.NewFedTest(t, mixedAuthOriginCfg)
 	discoveryUrl, err := url.Parse(param.Federation_DiscoveryUrl.GetString())
 	require.NoError(t, err)
@@ -593,10 +592,10 @@ func TestObjectStat(t *testing.T) {
 
 // Test the functionality of the direct reads feature (?directread)
 func TestDirectReads(t *testing.T) {
-	defer config.Reset()
+	defer server_utils.Reset()
 	t.Run("testDirectReadsSuccess", func(t *testing.T) {
-		config.Reset()
-		server_utils.ResetOriginExports()
+		server_utils.Reset()
+
 		viper.Set("Origin.EnableDirectReads", true)
 		fed := fed_test_utils.NewFedTest(t, bothPublicOriginCfg)
 		discoveryUrl, err := url.Parse(param.Federation_DiscoveryUrl.GetString())
@@ -637,8 +636,8 @@ func TestDirectReads(t *testing.T) {
 
 	// Test that direct reads fail if DirectReads=false is set for origin config but true for namespace/export
 	t.Run("testDirectReadsDirectReadFalseByOrigin", func(t *testing.T) {
-		config.Reset()
-		server_utils.ResetOriginExports()
+		server_utils.Reset()
+
 		fed := fed_test_utils.NewFedTest(t, pubOriginNoDirectRead)
 		discoveryUrl, err := url.Parse(param.Federation_DiscoveryUrl.GetString())
 		require.NoError(t, err)
@@ -667,8 +666,8 @@ func TestDirectReads(t *testing.T) {
 
 	// Test that direct reads fail if DirectReads=false is set for namespace/export config but true for origin
 	t.Run("testDirectReadsDirectReadFalseByNamespace", func(t *testing.T) {
-		config.Reset()
-		server_utils.ResetOriginExports()
+		server_utils.Reset()
+
 		fed := fed_test_utils.NewFedTest(t, pubExportNoDirectRead)
 		discoveryUrl, err := url.Parse(param.Federation_DiscoveryUrl.GetString())
 		require.NoError(t, err)
@@ -699,10 +698,9 @@ func TestDirectReads(t *testing.T) {
 
 // Test the functionality of NewTransferJob, checking we return at the correct locations for certain errors
 func TestNewTransferJob(t *testing.T) {
-	config.Reset()
-	defer config.Reset()
-	server_utils.ResetOriginExports()
-	defer server_utils.ResetOriginExports()
+	server_utils.Reset()
+	defer server_utils.Reset()
+
 	fed := fed_test_utils.NewFedTest(t, mixedAuthOriginCfg)
 	discoveryUrl, err := url.Parse(param.Federation_DiscoveryUrl.GetString())
 	require.NoError(t, err)
@@ -748,10 +746,9 @@ func TestNewTransferJob(t *testing.T) {
 
 // A test that spins up a federation, and tests object list
 func TestObjectList(t *testing.T) {
-	config.Reset()
-	server_utils.ResetOriginExports()
-	defer server_utils.ResetOriginExports()
-	defer config.Reset()
+	server_utils.Reset()
+
+	defer server_utils.Reset()
 	fed := fed_test_utils.NewFedTest(t, mixedAuthOriginCfg)
 
 	// Other set-up items:
@@ -845,8 +842,7 @@ func TestObjectList(t *testing.T) {
 // We should get a 405 returned. This is a separate test since we need a completely different origin
 func TestObjectList405Error(t *testing.T) {
 	test_utils.InitClient(t, nil)
-	server_utils.ResetOriginExports()
-	defer server_utils.ResetOriginExports()
+
 	err := config.InitClient()
 	require.NoError(t, err)
 
@@ -882,9 +878,8 @@ func TestObjectList405Error(t *testing.T) {
 // Startup a mini-federation and ensure the "pack=auto" functionality works
 // end-to-end
 func TestClientUnpack(t *testing.T) {
-	config.Reset()
-	server_utils.ResetOriginExports()
-	defer server_utils.ResetOriginExports()
+	server_utils.Reset()
+
 	err := config.InitClient()
 	require.NoError(t, err)
 
@@ -942,8 +937,8 @@ func TestClientUnpack(t *testing.T) {
 
 // A test that generates a token locally from the private key
 func TestTokenGenerate(t *testing.T) {
-	config.Reset()
-	server_utils.ResetOriginExports()
+	server_utils.Reset()
+
 	fed := fed_test_utils.NewFedTest(t, bothAuthOriginCfg)
 
 	// Other set-up items:

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -43,11 +43,12 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/error_codes"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
 )
 
 func TestMain(m *testing.M) {
-	config.Reset()
+	server_utils.Reset()
 	if err := config.InitClient(); err != nil {
 		os.Exit(1)
 	}
@@ -145,7 +146,7 @@ func TestNewTransferDetailsEnv(t *testing.T) {
 	assert.Equal(t, "https", transfers[0].Url.Scheme)
 	assert.Equal(t, false, transfers[0].Proxy)
 	os.Unsetenv("OSG_DISABLE_PROXY_FALLBACK")
-	config.Reset()
+	server_utils.Reset()
 	err := config.InitClient()
 	assert.Nil(t, err)
 }
@@ -508,7 +509,7 @@ func TestTimeoutHeaderSetForDownload(t *testing.T) {
 	assert.NoError(t, err)
 	_, _, _, _, err = downloadHTTP(ctx, nil, nil, transferAttemptDetails{Url: serverURL, Proxy: false}, filepath.Join(t.TempDir(), "test.txt"), -1, "", "")
 	assert.NoError(t, err)
-	config.Reset()
+	server_utils.Reset()
 }
 
 func TestJobIdHeaderSetForDownload(t *testing.T) {
@@ -547,7 +548,7 @@ func TestJobIdHeaderSetForDownload(t *testing.T) {
 	assert.NoError(t, err)
 	_, _, _, _, err = downloadHTTP(ctx, nil, nil, transferAttemptDetails{Url: serverURL, Proxy: false}, filepath.Join(t.TempDir(), "test.txt"), -1, "", "")
 	assert.NoError(t, err)
-	config.Reset()
+	server_utils.Reset()
 	os.Unsetenv("_CONDOR_JOB_AD")
 }
 
@@ -910,8 +911,8 @@ func TestFailedLargeUploadError(t *testing.T) {
 }
 
 func TestNewTransferEngine(t *testing.T) {
-	config.Reset()
-	defer config.Reset()
+	server_utils.Reset()
+	defer server_utils.Reset()
 	// Test we fail if we do not call initclient() before
 	t.Run("TestInitClientNotCalled", func(t *testing.T) {
 		config.ResetClientInitialized()

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -37,7 +37,6 @@ import (
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -48,7 +47,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	viper.Reset()
+	config.Reset()
 	if err := config.InitClient(); err != nil {
 		os.Exit(1)
 	}
@@ -146,7 +145,7 @@ func TestNewTransferDetailsEnv(t *testing.T) {
 	assert.Equal(t, "https", transfers[0].Url.Scheme)
 	assert.Equal(t, false, transfers[0].Proxy)
 	os.Unsetenv("OSG_DISABLE_PROXY_FALLBACK")
-	viper.Reset()
+	config.Reset()
 	err := config.InitClient()
 	assert.Nil(t, err)
 }
@@ -509,7 +508,7 @@ func TestTimeoutHeaderSetForDownload(t *testing.T) {
 	assert.NoError(t, err)
 	_, _, _, _, err = downloadHTTP(ctx, nil, nil, transferAttemptDetails{Url: serverURL, Proxy: false}, filepath.Join(t.TempDir(), "test.txt"), -1, "", "")
 	assert.NoError(t, err)
-	viper.Reset()
+	config.Reset()
 }
 
 func TestJobIdHeaderSetForDownload(t *testing.T) {
@@ -548,7 +547,7 @@ func TestJobIdHeaderSetForDownload(t *testing.T) {
 	assert.NoError(t, err)
 	_, _, _, _, err = downloadHTTP(ctx, nil, nil, transferAttemptDetails{Url: serverURL, Proxy: false}, filepath.Join(t.TempDir(), "test.txt"), -1, "", "")
 	assert.NoError(t, err)
-	viper.Reset()
+	config.Reset()
 	os.Unsetenv("_CONDOR_JOB_AD")
 }
 
@@ -911,8 +910,8 @@ func TestFailedLargeUploadError(t *testing.T) {
 }
 
 func TestNewTransferEngine(t *testing.T) {
-	viper.Reset()
-	defer viper.Reset()
+	config.Reset()
+	defer config.Reset()
 	// Test we fail if we do not call initclient() before
 	t.Run("TestInitClientNotCalled", func(t *testing.T) {
 		config.ResetClientInitialized()

--- a/client/main_test.go
+++ b/client/main_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pelicanplatform/pelican/mock"
 	"github.com/pelicanplatform/pelican/pelican_url"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
 )
 
@@ -138,7 +139,7 @@ func TestGetToken(t *testing.T) {
 	// Need a namespace for token acquisition
 	defer os.Unsetenv("PELICAN_FEDERATION_TOPOLOGYNAMESPACEURL")
 	os.Setenv("PELICAN_TOPOLOGY_NAMESPACE_URL", "https://topology.opensciencegrid.org/osdf/namespaces")
-	config.Reset()
+	server_utils.Reset()
 	err := config.InitClient()
 	assert.Nil(t, err)
 

--- a/client/main_test.go
+++ b/client/main_test.go
@@ -31,7 +31,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -139,7 +138,7 @@ func TestGetToken(t *testing.T) {
 	// Need a namespace for token acquisition
 	defer os.Unsetenv("PELICAN_FEDERATION_TOPOLOGYNAMESPACEURL")
 	os.Setenv("PELICAN_TOPOLOGY_NAMESPACE_URL", "https://topology.opensciencegrid.org/osdf/namespaces")
-	viper.Reset()
+	config.Reset()
 	err := config.InitClient()
 	assert.Nil(t, err)
 

--- a/cmd/fed_serve_cache_test.go
+++ b/cmd/fed_serve_cache_test.go
@@ -44,10 +44,9 @@ func TestFedServeCache(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	config.Reset()
-	server_utils.ResetOriginExports()
-	defer config.Reset()
-	defer server_utils.ResetOriginExports()
+	server_utils.Reset()
+
+	defer server_utils.Reset()
 
 	modules := server_structs.ServerType(0)
 	modules.Set(server_structs.CacheType)

--- a/cmd/fed_serve_cache_test.go
+++ b/cmd/fed_serve_cache_test.go
@@ -44,9 +44,9 @@ func TestFedServeCache(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
-	defer viper.Reset()
+	defer config.Reset()
 	defer server_utils.ResetOriginExports()
 
 	modules := server_structs.ServerType(0)

--- a/cmd/fed_serve_test.go
+++ b/cmd/fed_serve_test.go
@@ -47,9 +47,9 @@ func TestFedServePosixOrigin(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
-	defer viper.Reset()
+	defer config.Reset()
 	defer server_utils.ResetOriginExports()
 
 	modules := server_structs.ServerType(0)

--- a/cmd/fed_serve_test.go
+++ b/cmd/fed_serve_test.go
@@ -47,10 +47,9 @@ func TestFedServePosixOrigin(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	config.Reset()
-	server_utils.ResetOriginExports()
-	defer config.Reset()
-	defer server_utils.ResetOriginExports()
+	server_utils.Reset()
+
+	defer server_utils.Reset()
 
 	modules := server_structs.ServerType(0)
 	modules.Set(server_structs.OriginType)

--- a/cmd/generate_keygen_test.go
+++ b/cmd/generate_keygen_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/server_utils"
 )
 
 // Create tmpdir, change cwd, and setup clean up functions
@@ -43,7 +44,7 @@ func setupTestRun(t *testing.T) string {
 	t.Cleanup(func() {
 		err := os.Chdir(wd)
 		require.NoError(t, err)
-		config.Reset()
+		server_utils.Reset()
 		config.ResetIssuerJWKPtr()
 	})
 	return tmpDir
@@ -66,7 +67,7 @@ func TestKeygenMain(t *testing.T) {
 	config.ResetIssuerJWKPtr()
 
 	t.Cleanup(func() {
-		config.Reset()
+		server_utils.Reset()
 		config.ResetIssuerJWKPtr()
 	})
 

--- a/cmd/generate_keygen_test.go
+++ b/cmd/generate_keygen_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -44,7 +43,7 @@ func setupTestRun(t *testing.T) string {
 	t.Cleanup(func() {
 		err := os.Chdir(wd)
 		require.NoError(t, err)
-		viper.Reset()
+		config.Reset()
 		config.ResetIssuerJWKPtr()
 	})
 	return tmpDir
@@ -67,7 +66,7 @@ func TestKeygenMain(t *testing.T) {
 	config.ResetIssuerJWKPtr()
 
 	t.Cleanup(func() {
-		viper.Reset()
+		config.Reset()
 		config.ResetIssuerJWKPtr()
 	})
 

--- a/cmd/origin_reset_password_test.go
+++ b/cmd/origin_reset_password_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
 )
 
@@ -42,7 +43,7 @@ func TestResetPassword(t *testing.T) {
 	defer cancel()
 
 	dirName := t.TempDir()
-	config.Reset()
+	server_utils.Reset()
 	viper.Set("ConfigDir", dirName)
 	config.InitConfig()
 	viper.Set("Server.WebPort", 8444)

--- a/cmd/origin_reset_password_test.go
+++ b/cmd/origin_reset_password_test.go
@@ -42,7 +42,7 @@ func TestResetPassword(t *testing.T) {
 	defer cancel()
 
 	dirName := t.TempDir()
-	viper.Reset()
+	config.Reset()
 	viper.Set("ConfigDir", dirName)
 	config.InitConfig()
 	viper.Set("Server.WebPort", 8444)

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -232,13 +232,12 @@ func (f *FedTest) Teardown() {
 	f.Cancel()
 	f.FedCancel()
 	assert.NoError(f.T, f.ErrGroup.Wait())
-	config.Reset()
+	server_utils.Reset()
 }
 
 // Test the main function for the pelican plugin
 func TestStashPluginMain(t *testing.T) {
-	config.Reset()
-	server_utils.ResetOriginExports()
+	server_utils.Reset()
 
 	oldPrefix, err := config.SetPreferredPrefix(config.StashPrefix)
 	defer func() {
@@ -314,8 +313,7 @@ func TestStashPluginMain(t *testing.T) {
 
 // Test multiple downloads from the plugin
 func TestPluginMulti(t *testing.T) {
-	config.Reset()
-	server_utils.ResetOriginExports()
+	server_utils.Reset()
 
 	dirName := t.TempDir()
 
@@ -379,10 +377,8 @@ func TestPluginMulti(t *testing.T) {
 
 // Test multiple downloads from the plugin
 func TestPluginDirectRead(t *testing.T) {
-	config.Reset()
-	defer config.Reset()
-	defer server_utils.ResetOriginExports()
-	server_utils.ResetOriginExports()
+	server_utils.Reset()
+	defer server_utils.Reset()
 
 	dirName := t.TempDir()
 
@@ -457,8 +453,7 @@ func TestPluginDirectRead(t *testing.T) {
 func TestPluginCorrectStartAndEndTime(t *testing.T) {
 	test_utils.InitClient(t, nil)
 	server_utils.ResetOriginExports()
-	defer config.Reset()
-	defer server_utils.ResetOriginExports()
+	defer server_utils.Reset()
 
 	// Set up our http backend so that we can sleep during transfer
 	body := "Hello, World!"
@@ -670,10 +665,8 @@ func TestFailTransfer(t *testing.T) {
 
 // Test recursive downloads from the plugin
 func TestPluginRecursiveDownload(t *testing.T) {
-	config.Reset()
-	defer config.Reset()
-	defer server_utils.ResetOriginExports()
-	server_utils.ResetOriginExports()
+	server_utils.Reset()
+	defer server_utils.Reset()
 
 	dirName := t.TempDir()
 

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -232,12 +232,12 @@ func (f *FedTest) Teardown() {
 	f.Cancel()
 	f.FedCancel()
 	assert.NoError(f.T, f.ErrGroup.Wait())
-	viper.Reset()
+	config.Reset()
 }
 
 // Test the main function for the pelican plugin
 func TestStashPluginMain(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
 
 	oldPrefix, err := config.SetPreferredPrefix(config.StashPrefix)
@@ -314,7 +314,7 @@ func TestStashPluginMain(t *testing.T) {
 
 // Test multiple downloads from the plugin
 func TestPluginMulti(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
 
 	dirName := t.TempDir()
@@ -379,8 +379,8 @@ func TestPluginMulti(t *testing.T) {
 
 // Test multiple downloads from the plugin
 func TestPluginDirectRead(t *testing.T) {
-	viper.Reset()
-	defer viper.Reset()
+	config.Reset()
+	defer config.Reset()
 	defer server_utils.ResetOriginExports()
 	server_utils.ResetOriginExports()
 
@@ -457,7 +457,7 @@ func TestPluginDirectRead(t *testing.T) {
 func TestPluginCorrectStartAndEndTime(t *testing.T) {
 	test_utils.InitClient(t, nil)
 	server_utils.ResetOriginExports()
-	defer viper.Reset()
+	defer config.Reset()
 	defer server_utils.ResetOriginExports()
 
 	// Set up our http backend so that we can sleep during transfer
@@ -670,8 +670,8 @@ func TestFailTransfer(t *testing.T) {
 
 // Test recursive downloads from the plugin
 func TestPluginRecursiveDownload(t *testing.T) {
-	viper.Reset()
-	defer viper.Reset()
+	config.Reset()
+	defer config.Reset()
 	defer server_utils.ResetOriginExports()
 	server_utils.ResetOriginExports()
 

--- a/config/config.go
+++ b/config/config.go
@@ -1504,7 +1504,7 @@ func InitClient() error {
 	return nil
 }
 
-func Reset() {
+func ResetConfig() {
 	viper.Reset()
 
 	// Clear cached preferred prefix
@@ -1519,20 +1519,5 @@ func Reset() {
 	globalFedInfo = pelican_url.FederationDiscovery{}
 	globalFedErr = nil
 
-	// // Reset other global variables
-	// setServerOnce = sync.Once{}
-	// enabledServers = 0
-
-	// tempRunDir = ""
-	// cleanupOnce = sync.Once{}
-	// clientInitialized = false
-
-	// // Reset validator and translator-related variables
-	// onceValidate = sync.Once{}
-	// validate = nil
-	// uni = nil // Clear the universal translator
-	// translator = nil
-
-	// // delete Origin exports
-	// // server_utils.ResetOriginExports()
+	// deleting Origin exports is done by Reset() in server_utils pkg
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1516,7 +1516,7 @@ func Reset() {
 
 	// Reset federation metadata
 	fedDiscoveryOnce = &sync.Once{}
-	globalFedInfo = FederationDiscovery{}
+	globalFedInfo = pelican_url.FederationDiscovery{}
 	globalFedErr = nil
 
 	// // Reset other global variables

--- a/config/config.go
+++ b/config/config.go
@@ -1503,3 +1503,36 @@ func InitClient() error {
 
 	return nil
 }
+
+func Reset() {
+	viper.Reset()
+
+	// Clear cached preferred prefix
+	testingPreferredPrefix = ""
+
+	// Clear cached transport object
+	onceTransport = sync.Once{}
+	transport = nil
+
+	// Reset federation metadata
+	fedDiscoveryOnce = &sync.Once{}
+	globalFedInfo = FederationDiscovery{}
+	globalFedErr = nil
+
+	// // Reset other global variables
+	// setServerOnce = sync.Once{}
+	// enabledServers = 0
+
+	// tempRunDir = ""
+	// cleanupOnce = sync.Once{}
+	// clientInitialized = false
+
+	// // Reset validator and translator-related variables
+	// onceValidate = sync.Once{}
+	// validate = nil
+	// uni = nil // Clear the universal translator
+	// translator = nil
+
+	// // delete Origin exports
+	// // server_utils.ResetOriginExports()
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -136,9 +136,9 @@ func TestDialerTimeout(t *testing.T) {
 }
 
 func TestInitConfig(t *testing.T) {
-	viper.Reset()
+	Reset()
 	t.Cleanup(func() {
-		viper.Reset()
+		Reset()
 	})
 	// Set prefix to OSDF to ensure that config is being set
 	testingPreferredPrefix = "OSDF"
@@ -161,13 +161,13 @@ func TestInitConfig(t *testing.T) {
 	if err := viper.WriteConfigAs(tempCfgFile.Name()); err != nil {
 		t.Fatalf("Failed to write to config file: %v", err)
 	}
-	viper.Reset()
+	Reset()
 	viper.Set("config", tempCfgFile.Name()) // Set the temp file as the new 'pelican.yaml'
 	InitConfig()
 
 	// Check if server address overrides the default
 	assert.Equal(t, "1.1.1.1", param.Server_WebHost.GetString())
-	viper.Reset()
+	Reset()
 
 	//Test if prefix is not set, should not be able to find osdfYaml configuration
 	testingPreferredPrefix = ""
@@ -207,9 +207,9 @@ func setupConfigLocations(t *testing.T, continueDirs []string) {
 
 // Test that the `ConfigLocations` key works as expected
 func TestExtraCfg(t *testing.T) {
-	viper.Reset()
+	Reset()
 	t.Cleanup(func() {
-		viper.Reset()
+		Reset()
 	})
 
 	t.Run("test-no-continue", func(t *testing.T) {
@@ -218,7 +218,7 @@ func TestExtraCfg(t *testing.T) {
 	})
 
 	t.Run("test-one-dir-no-files", func(t *testing.T) {
-		viper.Reset()
+		Reset()
 		dir1 := t.TempDir()
 		setupConfigLocations(t, []string{dir1})
 
@@ -231,7 +231,7 @@ func TestExtraCfg(t *testing.T) {
 	})
 
 	t.Run("test-one-dir-one-file", func(t *testing.T) {
-		viper.Reset()
+		Reset()
 		dir1 := t.TempDir()
 		setupConfigLocations(t, []string{dir1})
 
@@ -248,7 +248,7 @@ func TestExtraCfg(t *testing.T) {
 	})
 
 	t.Run("test-two-dirs-one-file-each", func(t *testing.T) {
-		viper.Reset()
+		Reset()
 		dir1 := t.TempDir()
 		dir2 := t.TempDir()
 		setupConfigLocations(t, []string{dir1, dir2})
@@ -272,7 +272,7 @@ func TestExtraCfg(t *testing.T) {
 	})
 
 	t.Run("test-two-dirs-two-files-each", func(t *testing.T) {
-		viper.Reset()
+		Reset()
 		dir1 := t.TempDir()
 		dir2 := t.TempDir()
 		setupConfigLocations(t, []string{dir1, dir2})
@@ -297,7 +297,7 @@ func TestExtraCfg(t *testing.T) {
 	})
 
 	t.Run("test-bad-directory", func(t *testing.T) {
-		viper.Reset()
+		Reset()
 		continueDir := t.TempDir()
 		setupConfigLocations(t, []string{continueDir + "-dne"})
 
@@ -322,11 +322,11 @@ func TestDeprecateLogMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	viper.Set("ConfigDir", tmpPath)
-	viper.Reset()
+	Reset()
 	t.Run("expect-deprecated-message-if-namespace-is-set", func(t *testing.T) {
 		hook := test.NewGlobal()
-		viper.Reset()
-		defer viper.Reset()
+		Reset()
+		defer Reset()
 		// The default value is set to Error, but this is a warning message
 		viper.Set("Logging.Level", "Warning")
 		viper.Set("Origin.NamespacePrefix", "/a/prefix")
@@ -584,11 +584,11 @@ func TestInitServerUrl(t *testing.T) {
 	mockWebUrlWNon443Port := "https://example.com:8444"
 
 	t.Cleanup(func() {
-		viper.Reset()
+		Reset()
 	})
 
 	initConfig := func() {
-		viper.Reset()
+		Reset()
 		tempDir := t.TempDir()
 		viper.Set("ConfigDir", tempDir)
 	}
@@ -600,7 +600,7 @@ func TestInitServerUrl(t *testing.T) {
 	}
 
 	t.Run("web-url-defaults-to-hostname-port", func(t *testing.T) {
-		viper.Reset()
+		Reset()
 		viper.Set("Server.Hostname", mockHostname)
 		viper.Set("Server.WebPort", mockNon443Port)
 		err := InitConfigDir()
@@ -611,7 +611,7 @@ func TestInitServerUrl(t *testing.T) {
 	})
 
 	t.Run("default-web-url-removes-443-port", func(t *testing.T) {
-		viper.Reset()
+		Reset()
 		viper.Set("Server.Hostname", mockHostname)
 		viper.Set("Server.WebPort", mock443Port)
 		err := InitConfigDir()
@@ -623,7 +623,7 @@ func TestInitServerUrl(t *testing.T) {
 
 	t.Run("remove-443-port-for-set-web-url", func(t *testing.T) {
 		// We respect the URL value set directly by others. Won't remove 443 port
-		viper.Reset()
+		Reset()
 		viper.Set("Server.ExternalWebUrl", mockWebUrlW443Port)
 		err := InitConfigDir()
 		require.NoError(t, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -136,9 +136,9 @@ func TestDialerTimeout(t *testing.T) {
 }
 
 func TestInitConfig(t *testing.T) {
-	Reset()
+	ResetConfig()
 	t.Cleanup(func() {
-		Reset()
+		ResetConfig()
 	})
 	// Set prefix to OSDF to ensure that config is being set
 	testingPreferredPrefix = "OSDF"
@@ -161,13 +161,13 @@ func TestInitConfig(t *testing.T) {
 	if err := viper.WriteConfigAs(tempCfgFile.Name()); err != nil {
 		t.Fatalf("Failed to write to config file: %v", err)
 	}
-	Reset()
+	ResetConfig()
 	viper.Set("config", tempCfgFile.Name()) // Set the temp file as the new 'pelican.yaml'
 	InitConfig()
 
 	// Check if server address overrides the default
 	assert.Equal(t, "1.1.1.1", param.Server_WebHost.GetString())
-	Reset()
+	ResetConfig()
 
 	//Test if prefix is not set, should not be able to find osdfYaml configuration
 	testingPreferredPrefix = ""
@@ -207,9 +207,9 @@ func setupConfigLocations(t *testing.T, continueDirs []string) {
 
 // Test that the `ConfigLocations` key works as expected
 func TestExtraCfg(t *testing.T) {
-	Reset()
+	ResetConfig()
 	t.Cleanup(func() {
-		Reset()
+		ResetConfig()
 	})
 
 	t.Run("test-no-continue", func(t *testing.T) {
@@ -218,7 +218,7 @@ func TestExtraCfg(t *testing.T) {
 	})
 
 	t.Run("test-one-dir-no-files", func(t *testing.T) {
-		Reset()
+		ResetConfig()
 		dir1 := t.TempDir()
 		setupConfigLocations(t, []string{dir1})
 
@@ -231,7 +231,7 @@ func TestExtraCfg(t *testing.T) {
 	})
 
 	t.Run("test-one-dir-one-file", func(t *testing.T) {
-		Reset()
+		ResetConfig()
 		dir1 := t.TempDir()
 		setupConfigLocations(t, []string{dir1})
 
@@ -248,7 +248,7 @@ func TestExtraCfg(t *testing.T) {
 	})
 
 	t.Run("test-two-dirs-one-file-each", func(t *testing.T) {
-		Reset()
+		ResetConfig()
 		dir1 := t.TempDir()
 		dir2 := t.TempDir()
 		setupConfigLocations(t, []string{dir1, dir2})
@@ -272,7 +272,7 @@ func TestExtraCfg(t *testing.T) {
 	})
 
 	t.Run("test-two-dirs-two-files-each", func(t *testing.T) {
-		Reset()
+		ResetConfig()
 		dir1 := t.TempDir()
 		dir2 := t.TempDir()
 		setupConfigLocations(t, []string{dir1, dir2})
@@ -297,7 +297,7 @@ func TestExtraCfg(t *testing.T) {
 	})
 
 	t.Run("test-bad-directory", func(t *testing.T) {
-		Reset()
+		ResetConfig()
 		continueDir := t.TempDir()
 		setupConfigLocations(t, []string{continueDir + "-dne"})
 
@@ -322,11 +322,11 @@ func TestDeprecateLogMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	viper.Set("ConfigDir", tmpPath)
-	Reset()
+	ResetConfig()
 	t.Run("expect-deprecated-message-if-namespace-is-set", func(t *testing.T) {
 		hook := test.NewGlobal()
-		Reset()
-		defer Reset()
+		ResetConfig()
+		defer ResetConfig()
 		// The default value is set to Error, but this is a warning message
 		viper.Set("Logging.Level", "Warning")
 		viper.Set("Origin.NamespacePrefix", "/a/prefix")
@@ -584,11 +584,11 @@ func TestInitServerUrl(t *testing.T) {
 	mockWebUrlWNon443Port := "https://example.com:8444"
 
 	t.Cleanup(func() {
-		Reset()
+		ResetConfig()
 	})
 
 	initConfig := func() {
-		Reset()
+		ResetConfig()
 		tempDir := t.TempDir()
 		viper.Set("ConfigDir", tempDir)
 	}
@@ -600,7 +600,7 @@ func TestInitServerUrl(t *testing.T) {
 	}
 
 	t.Run("web-url-defaults-to-hostname-port", func(t *testing.T) {
-		Reset()
+		ResetConfig()
 		viper.Set("Server.Hostname", mockHostname)
 		viper.Set("Server.WebPort", mockNon443Port)
 		err := InitConfigDir()
@@ -611,7 +611,7 @@ func TestInitServerUrl(t *testing.T) {
 	})
 
 	t.Run("default-web-url-removes-443-port", func(t *testing.T) {
-		Reset()
+		ResetConfig()
 		viper.Set("Server.Hostname", mockHostname)
 		viper.Set("Server.WebPort", mock443Port)
 		err := InitConfigDir()
@@ -623,7 +623,7 @@ func TestInitServerUrl(t *testing.T) {
 
 	t.Run("remove-443-port-for-set-web-url", func(t *testing.T) {
 		// We respect the URL value set directly by others. Won't remove 443 port
-		Reset()
+		ResetConfig()
 		viper.Set("Server.ExternalWebUrl", mockWebUrlW443Port)
 		err := InitConfigDir()
 		require.NoError(t, err)

--- a/config/config_validation_test.go
+++ b/config/config_validation_test.go
@@ -31,10 +31,10 @@ import (
 
 // Test that Pelican notifies users about unrecognized configuration keys.
 func TestBadConfigKeys(t *testing.T) {
-	t.Cleanup(func() { Reset() })
+	t.Cleanup(func() { ResetConfig() })
 
 	setupFunc := func() *test.Hook {
-		Reset()
+		ResetConfig()
 		viper.Set("ConfigDir", t.TempDir())
 		viper.Set("Debug", true)
 		hook := test.NewLocal(logrus.StandardLogger())

--- a/config/config_validation_test.go
+++ b/config/config_validation_test.go
@@ -31,10 +31,10 @@ import (
 
 // Test that Pelican notifies users about unrecognized configuration keys.
 func TestBadConfigKeys(t *testing.T) {
-	t.Cleanup(func() { viper.Reset() })
+	t.Cleanup(func() { Reset() })
 
 	setupFunc := func() *test.Hook {
-		viper.Reset()
+		Reset()
 		viper.Set("ConfigDir", t.TempDir())
 		viper.Set("Debug", true)
 		hook := test.NewLocal(logrus.StandardLogger())

--- a/config/encrypted_test.go
+++ b/config/encrypted_test.go
@@ -30,10 +30,10 @@ import (
 )
 
 func TestGetSecret(t *testing.T) {
-	viper.Reset()
+	Reset()
 
 	t.Cleanup(func() {
-		viper.Reset()
+		Reset()
 	})
 	t.Run("generate-32B-hash", func(t *testing.T) {
 		tmp := t.TempDir()
@@ -47,10 +47,10 @@ func TestGetSecret(t *testing.T) {
 }
 
 func TestEncryptString(t *testing.T) {
-	viper.Reset()
+	Reset()
 
 	t.Cleanup(func() {
-		viper.Reset()
+		Reset()
 	})
 
 	t.Run("encrypt-without-err", func(t *testing.T) {
@@ -65,10 +65,10 @@ func TestEncryptString(t *testing.T) {
 }
 
 func TestDecryptString(t *testing.T) {
-	viper.Reset()
+	Reset()
 
 	t.Cleanup(func() {
-		viper.Reset()
+		Reset()
 	})
 	t.Run("decrypt-without-err", func(t *testing.T) {
 		tmp := t.TempDir()

--- a/config/encrypted_test.go
+++ b/config/encrypted_test.go
@@ -30,10 +30,10 @@ import (
 )
 
 func TestGetSecret(t *testing.T) {
-	Reset()
+	ResetConfig()
 
 	t.Cleanup(func() {
-		Reset()
+		ResetConfig()
 	})
 	t.Run("generate-32B-hash", func(t *testing.T) {
 		tmp := t.TempDir()
@@ -47,10 +47,10 @@ func TestGetSecret(t *testing.T) {
 }
 
 func TestEncryptString(t *testing.T) {
-	Reset()
+	ResetConfig()
 
 	t.Cleanup(func() {
-		Reset()
+		ResetConfig()
 	})
 
 	t.Run("encrypt-without-err", func(t *testing.T) {
@@ -65,10 +65,10 @@ func TestEncryptString(t *testing.T) {
 }
 
 func TestDecryptString(t *testing.T) {
-	Reset()
+	ResetConfig()
 
 	t.Cleanup(func() {
-		Reset()
+		ResetConfig()
 	})
 	t.Run("decrypt-without-err", func(t *testing.T) {
 		tmp := t.TempDir()

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -35,7 +35,7 @@ func TestOsdfEnvToPelican(t *testing.T) {
 	hook := test.NewGlobal()
 
 	t.Run("non-osdf-prefix-does-nothing", func(t *testing.T) {
-		viper.Reset()
+		Reset()
 		testingPreferredPrefix = PelicanPrefix
 
 		os.Setenv("OSDF_MOCK", "randomStr")
@@ -49,7 +49,7 @@ func TestOsdfEnvToPelican(t *testing.T) {
 	})
 
 	t.Run("one-osdf-env", func(t *testing.T) {
-		viper.Reset()
+		Reset()
 		hook.Reset()
 		testingPreferredPrefix = OsdfPrefix
 
@@ -67,7 +67,7 @@ func TestOsdfEnvToPelican(t *testing.T) {
 	})
 
 	t.Run("one-stash-env", func(t *testing.T) {
-		viper.Reset()
+		Reset()
 		hook.Reset()
 		testingPreferredPrefix = StashPrefix
 
@@ -85,7 +85,7 @@ func TestOsdfEnvToPelican(t *testing.T) {
 	})
 
 	t.Run("complex-osdf-env", func(t *testing.T) {
-		viper.Reset()
+		Reset()
 		hook.Reset()
 		testingPreferredPrefix = OsdfPrefix
 
@@ -102,7 +102,7 @@ func TestOsdfEnvToPelican(t *testing.T) {
 	})
 
 	t.Run("pelican-env-still-works", func(t *testing.T) {
-		viper.Reset()
+		Reset()
 		hook.Reset()
 		testingPreferredPrefix = OsdfPrefix
 
@@ -129,7 +129,7 @@ func TestOsdfEnvToPelican(t *testing.T) {
 	})
 
 	t.Run("pelican-env-overwrites-osdf", func(t *testing.T) {
-		viper.Reset()
+		Reset()
 		hook.Reset()
 		testingPreferredPrefix = OsdfPrefix
 

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -35,7 +35,7 @@ func TestOsdfEnvToPelican(t *testing.T) {
 	hook := test.NewGlobal()
 
 	t.Run("non-osdf-prefix-does-nothing", func(t *testing.T) {
-		Reset()
+		ResetConfig()
 		testingPreferredPrefix = PelicanPrefix
 
 		os.Setenv("OSDF_MOCK", "randomStr")
@@ -49,7 +49,7 @@ func TestOsdfEnvToPelican(t *testing.T) {
 	})
 
 	t.Run("one-osdf-env", func(t *testing.T) {
-		Reset()
+		ResetConfig()
 		hook.Reset()
 		testingPreferredPrefix = OsdfPrefix
 
@@ -67,7 +67,7 @@ func TestOsdfEnvToPelican(t *testing.T) {
 	})
 
 	t.Run("one-stash-env", func(t *testing.T) {
-		Reset()
+		ResetConfig()
 		hook.Reset()
 		testingPreferredPrefix = StashPrefix
 
@@ -85,7 +85,7 @@ func TestOsdfEnvToPelican(t *testing.T) {
 	})
 
 	t.Run("complex-osdf-env", func(t *testing.T) {
-		Reset()
+		ResetConfig()
 		hook.Reset()
 		testingPreferredPrefix = OsdfPrefix
 
@@ -102,7 +102,7 @@ func TestOsdfEnvToPelican(t *testing.T) {
 	})
 
 	t.Run("pelican-env-still-works", func(t *testing.T) {
-		Reset()
+		ResetConfig()
 		hook.Reset()
 		testingPreferredPrefix = OsdfPrefix
 
@@ -129,7 +129,7 @@ func TestOsdfEnvToPelican(t *testing.T) {
 	})
 
 	t.Run("pelican-env-overwrites-osdf", func(t *testing.T) {
-		Reset()
+		ResetConfig()
 		hook.Reset()
 		testingPreferredPrefix = OsdfPrefix
 

--- a/config/oidc_metadata_test.go
+++ b/config/oidc_metadata_test.go
@@ -30,10 +30,10 @@ import (
 
 func TestGetOIDCProvider(t *testing.T) {
 	t.Cleanup(func() {
-		Reset()
+		ResetConfig()
 	})
 	t.Run("empty-endpoints-gives-error", func(t *testing.T) {
-		Reset()
+		ResetConfig()
 		get, err := GetOIDCProdiver()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "nothing set for config parameter OIDC.IssuerUrl or OIDC.AuthorizationEndpoint")
@@ -41,7 +41,7 @@ func TestGetOIDCProvider(t *testing.T) {
 	})
 
 	t.Run("auth-endpoint-gives-correct-result", func(t *testing.T) {
-		Reset()
+		ResetConfig()
 		viper.Set(param.OIDC_AuthorizationEndpoint.GetName(), "https://example.com/authorization")
 		get, err := GetOIDCProdiver()
 		require.NoError(t, err)
@@ -61,7 +61,7 @@ func TestGetOIDCProvider(t *testing.T) {
 	})
 
 	t.Run("issuer-endpoint-gives-correct-result", func(t *testing.T) {
-		Reset()
+		ResetConfig()
 		viper.Set(param.OIDC_Issuer.GetName(), "https://example.com")
 		get, err := GetOIDCProdiver()
 		require.NoError(t, err)

--- a/config/oidc_metadata_test.go
+++ b/config/oidc_metadata_test.go
@@ -30,10 +30,10 @@ import (
 
 func TestGetOIDCProvider(t *testing.T) {
 	t.Cleanup(func() {
-		viper.Reset()
+		Reset()
 	})
 	t.Run("empty-endpoints-gives-error", func(t *testing.T) {
-		viper.Reset()
+		Reset()
 		get, err := GetOIDCProdiver()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "nothing set for config parameter OIDC.IssuerUrl or OIDC.AuthorizationEndpoint")
@@ -41,7 +41,7 @@ func TestGetOIDCProvider(t *testing.T) {
 	})
 
 	t.Run("auth-endpoint-gives-correct-result", func(t *testing.T) {
-		viper.Reset()
+		Reset()
 		viper.Set(param.OIDC_AuthorizationEndpoint.GetName(), "https://example.com/authorization")
 		get, err := GetOIDCProdiver()
 		require.NoError(t, err)
@@ -61,7 +61,7 @@ func TestGetOIDCProvider(t *testing.T) {
 	})
 
 	t.Run("issuer-endpoint-gives-correct-result", func(t *testing.T) {
-		viper.Reset()
+		Reset()
 		viper.Set(param.OIDC_Issuer.GetName(), "https://example.com")
 		get, err := GetOIDCProdiver()
 		require.NoError(t, err)

--- a/director/advertise_test.go
+++ b/director/advertise_test.go
@@ -34,7 +34,8 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
+	
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
 )
 
@@ -199,10 +200,10 @@ func multiExportsTopoJSONHandler(w http.ResponseWriter, r *http.Request) {
 
 func TestAdvertiseOSDF(t *testing.T) {
 	t.Run("mock-topology-parse-correctly", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		serverAds.DeleteAll()
 		defer func() {
-			viper.Reset()
+			config.Reset()
 			serverAds.DeleteAll()
 		}()
 
@@ -251,10 +252,10 @@ func TestAdvertiseOSDF(t *testing.T) {
 	})
 
 	t.Run("multiple-ns-single-origin", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		serverAds.DeleteAll()
 		defer func() {
-			viper.Reset()
+			config.Reset()
 			serverAds.DeleteAll()
 		}()
 
@@ -279,10 +280,10 @@ func TestAdvertiseOSDF(t *testing.T) {
 	})
 
 	t.Run("caches-serving-multiple-nss", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		serverAds.DeleteAll()
 		defer func() {
-			viper.Reset()
+			config.Reset()
 			serverAds.DeleteAll()
 		}()
 

--- a/director/advertise_test.go
+++ b/director/advertise_test.go
@@ -34,9 +34,9 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	
-	"github.com/pelicanplatform/pelican/config"
+
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 )
 
 var (
@@ -200,10 +200,10 @@ func multiExportsTopoJSONHandler(w http.ResponseWriter, r *http.Request) {
 
 func TestAdvertiseOSDF(t *testing.T) {
 	t.Run("mock-topology-parse-correctly", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		serverAds.DeleteAll()
 		defer func() {
-			config.Reset()
+			server_utils.Reset()
 			serverAds.DeleteAll()
 		}()
 
@@ -252,10 +252,10 @@ func TestAdvertiseOSDF(t *testing.T) {
 	})
 
 	t.Run("multiple-ns-single-origin", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		serverAds.DeleteAll()
 		defer func() {
-			config.Reset()
+			server_utils.Reset()
 			serverAds.DeleteAll()
 		}()
 
@@ -280,10 +280,10 @@ func TestAdvertiseOSDF(t *testing.T) {
 	})
 
 	t.Run("caches-serving-multiple-nss", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		serverAds.DeleteAll()
 		defer func() {
-			config.Reset()
+			server_utils.Reset()
 			serverAds.DeleteAll()
 		}()
 

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -30,8 +30,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 )
 
 func hasServerAdWithName(serverAds []server_structs.ServerAd, name string) bool {
@@ -432,7 +432,7 @@ func TestRecordAd(t *testing.T) {
 
 	t.Run("recorded-sad-should-match-health-test-utils-one", func(t *testing.T) {
 		t.Cleanup(func() {
-			config.Reset()
+			server_utils.Reset()
 			healthTestUtilsMutex.Lock()
 			statUtilsMutex.Lock()
 			defer statUtilsMutex.Unlock()
@@ -443,7 +443,7 @@ func TestRecordAd(t *testing.T) {
 			serverAds.DeleteAll()
 			geoIPOverrides = nil
 		})
-		config.Reset()
+		server_utils.Reset()
 		func() {
 			geoIPOverrides = nil
 

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
 )
 
@@ -431,7 +432,7 @@ func TestRecordAd(t *testing.T) {
 
 	t.Run("recorded-sad-should-match-health-test-utils-one", func(t *testing.T) {
 		t.Cleanup(func() {
-			viper.Reset()
+			config.Reset()
 			healthTestUtilsMutex.Lock()
 			statUtilsMutex.Lock()
 			defer statUtilsMutex.Unlock()
@@ -442,7 +443,7 @@ func TestRecordAd(t *testing.T) {
 			serverAds.DeleteAll()
 			geoIPOverrides = nil
 		})
-		viper.Reset()
+		config.Reset()
 		func() {
 			geoIPOverrides = nil
 

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -141,7 +141,7 @@ func TestDirectorRegistration(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	viper.Reset()
+	config.Reset()
 
 	// Mock registry server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -1077,7 +1077,7 @@ func TestDiscoverOriginCache(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	viper.Reset()
+	config.Reset()
 	// Direcor SD will only be used for director's Prometheus scraper to get available origins,
 	// so the token issuer is issentially the director server itself
 	// There's no need to rely on Federation.DirectorUrl as token issuer in this case
@@ -1369,7 +1369,7 @@ func TestRedirects(t *testing.T) {
 		expectedPath = "/api/v1.0/director/object/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("redirect-middleware", func(t *testing.T) {
@@ -1459,7 +1459,7 @@ func TestRedirects(t *testing.T) {
 		expectedPath = "/api/v1.0/director/origin/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("cache-test-file-redirect", func(t *testing.T) {
@@ -1476,9 +1476,9 @@ func TestRedirects(t *testing.T) {
 	})
 
 	t.Run("redirect-link-header-length", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		t.Cleanup(func() {
-			viper.Reset()
+			config.Reset()
 		})
 
 		viper.Set("Director.CacheSortMethod", "random")
@@ -1511,9 +1511,9 @@ func TestRedirects(t *testing.T) {
 
 	// Make sure collections-url is correctly populated when the ns/origin comes from topology
 	t.Run("collections-url-from-topology", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		t.Cleanup(func() {
-			viper.Reset()
+			config.Reset()
 		})
 
 		viper.Set("Director.CacheSortMethod", "random")
@@ -1538,9 +1538,9 @@ func TestRedirects(t *testing.T) {
 	})
 
 	t.Run("object-endpoint-returns-all-headers", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		t.Cleanup(func() {
-			viper.Reset()
+			config.Reset()
 		})
 
 		viper.Set("Director.CacheSortMethod", "random")
@@ -1561,9 +1561,9 @@ func TestRedirects(t *testing.T) {
 	})
 
 	t.Run("origin-endpoint-returns-all-headers", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		t.Cleanup(func() {
-			viper.Reset()
+			config.Reset()
 		})
 
 		viper.Set("Director.CacheSortMethod", "random")

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -141,7 +141,7 @@ func TestDirectorRegistration(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	config.Reset()
+	server_utils.Reset()
 
 	// Mock registry server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -1077,7 +1077,7 @@ func TestDiscoverOriginCache(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	config.Reset()
+	server_utils.Reset()
 	// Direcor SD will only be used for director's Prometheus scraper to get available origins,
 	// so the token issuer is issentially the director server itself
 	// There's no need to rely on Federation.DirectorUrl as token issuer in this case
@@ -1369,7 +1369,7 @@ func TestRedirects(t *testing.T) {
 		expectedPath = "/api/v1.0/director/object/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("redirect-middleware", func(t *testing.T) {
@@ -1459,7 +1459,7 @@ func TestRedirects(t *testing.T) {
 		expectedPath = "/api/v1.0/director/origin/foo/bar"
 		assert.Equal(t, expectedPath, c.Request.URL.Path)
 
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("cache-test-file-redirect", func(t *testing.T) {
@@ -1476,9 +1476,9 @@ func TestRedirects(t *testing.T) {
 	})
 
 	t.Run("redirect-link-header-length", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		t.Cleanup(func() {
-			config.Reset()
+			server_utils.Reset()
 		})
 
 		viper.Set("Director.CacheSortMethod", "random")
@@ -1511,9 +1511,9 @@ func TestRedirects(t *testing.T) {
 
 	// Make sure collections-url is correctly populated when the ns/origin comes from topology
 	t.Run("collections-url-from-topology", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		t.Cleanup(func() {
-			config.Reset()
+			server_utils.Reset()
 		})
 
 		viper.Set("Director.CacheSortMethod", "random")
@@ -1538,9 +1538,9 @@ func TestRedirects(t *testing.T) {
 	})
 
 	t.Run("object-endpoint-returns-all-headers", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		t.Cleanup(func() {
-			config.Reset()
+			server_utils.Reset()
 		})
 
 		viper.Set("Director.CacheSortMethod", "random")
@@ -1561,9 +1561,9 @@ func TestRedirects(t *testing.T) {
 	})
 
 	t.Run("origin-endpoint-returns-all-headers", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		t.Cleanup(func() {
-			config.Reset()
+			server_utils.Reset()
 		})
 
 		viper.Set("Director.CacheSortMethod", "random")

--- a/director/discovery_test.go
+++ b/director/discovery_test.go
@@ -139,7 +139,7 @@ func TestFederationDiscoveryHandler(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			viper.Reset()
+			config.Reset()
 			viper.Set("ConfigDir", t.TempDir())
 			viper.Set("Federation.DirectorUrl", tc.dirUrl)
 			viper.Set("Federation.RegistryUrl", tc.regUrl)
@@ -212,7 +212,7 @@ func TestOidcDiscoveryHandler(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			viper.Reset()
+			config.Reset()
 			viper.Set("ConfigDir", t.TempDir())
 			viper.Set("Federation.DirectorUrl", tc.dirUrl)
 			config.InitConfig()

--- a/director/discovery_test.go
+++ b/director/discovery_test.go
@@ -139,7 +139,7 @@ func TestFederationDiscoveryHandler(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			config.Reset()
+			server_utils.Reset()
 			viper.Set("ConfigDir", t.TempDir())
 			viper.Set("Federation.DirectorUrl", tc.dirUrl)
 			viper.Set("Federation.RegistryUrl", tc.regUrl)
@@ -212,7 +212,7 @@ func TestOidcDiscoveryHandler(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			config.Reset()
+			server_utils.Reset()
 			viper.Set("ConfigDir", t.TempDir())
 			viper.Set("Federation.DirectorUrl", tc.dirUrl)
 			config.InitConfig()

--- a/director/origin_api_test.go
+++ b/director/origin_api_test.go
@@ -47,7 +47,7 @@ func TestVerifyAdvertiseToken(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	config.Reset()
+	server_utils.Reset()
 
 	tDir := t.TempDir()
 	kfile := filepath.Join(tDir, "t-key")

--- a/director/origin_api_test.go
+++ b/director/origin_api_test.go
@@ -47,7 +47,7 @@ func TestVerifyAdvertiseToken(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	viper.Reset()
+	config.Reset()
 
 	tDir := t.TempDir()
 	kfile := filepath.Join(tDir, "t-key")

--- a/director/prom_query_test.go
+++ b/director/prom_query_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pelicanplatform/pelican/param"
-	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/server_utils"
 )
 
 var (
@@ -203,8 +203,8 @@ func TestParsePromRes(t *testing.T) {
 }
 
 func TestQueryPrometheus(t *testing.T) {
-	config.Reset()
-	t.Cleanup(config.Reset)
+	server_utils.Reset()
+	t.Cleanup(server_utils.Reset)
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		query := r.URL.Query().Get("query")

--- a/director/prom_query_test.go
+++ b/director/prom_query_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/config"
 )
 
 var (
@@ -202,8 +203,8 @@ func TestParsePromRes(t *testing.T) {
 }
 
 func TestQueryPrometheus(t *testing.T) {
-	viper.Reset()
-	t.Cleanup(viper.Reset)
+	config.Reset()
+	t.Cleanup(config.Reset)
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		query := r.URL.Query().Get("query")

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -35,8 +35,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 )
 
 // Geo Override Yaml mockup
@@ -45,9 +45,9 @@ import (
 var yamlMockup string
 
 func TestCheckOverrides(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	t.Cleanup(func() {
-		config.Reset()
+		server_utils.Reset()
 		geoIPOverrides = nil
 	})
 
@@ -192,9 +192,9 @@ func TestSortServerAdsByTopo(t *testing.T) {
 }
 
 func TestSortServerAds(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	t.Cleanup(func() {
-		config.Reset()
+		server_utils.Reset()
 		geoIPOverrides = nil
 	})
 

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
 )
 
@@ -44,9 +45,9 @@ import (
 var yamlMockup string
 
 func TestCheckOverrides(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	t.Cleanup(func() {
-		viper.Reset()
+		config.Reset()
 		geoIPOverrides = nil
 	})
 
@@ -191,9 +192,9 @@ func TestSortServerAdsByTopo(t *testing.T) {
 }
 
 func TestSortServerAds(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	t.Cleanup(func() {
-		viper.Reset()
+		config.Reset()
 		geoIPOverrides = nil
 	})
 

--- a/director/stat_test.go
+++ b/director/stat_test.go
@@ -40,7 +40,7 @@ import (
 )
 
 func TestQueryServersForObject(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	viper.Set("Director.MinStatResponse", 1)
 	viper.Set("Director.MaxStatResponse", 1)
 	viper.Set("Director.StatTimeout", time.Microsecond*200)
@@ -216,7 +216,7 @@ func TestQueryServersForObject(t *testing.T) {
 		cleanupMock()
 		// Restore the old serverAds at the end of this test func
 		serverAds = oldAds
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("empty-server-ads-returns", func(t *testing.T) {
@@ -698,7 +698,7 @@ func TestQueryServersForObject(t *testing.T) {
 }
 
 func TestSendHeadReq(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 
 	// Start a local HTTP server
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {

--- a/director/stat_test.go
+++ b/director/stat_test.go
@@ -37,10 +37,11 @@ import (
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 )
 
 func TestQueryServersForObject(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	viper.Set("Director.MinStatResponse", 1)
 	viper.Set("Director.MaxStatResponse", 1)
 	viper.Set("Director.StatTimeout", time.Microsecond*200)
@@ -216,7 +217,7 @@ func TestQueryServersForObject(t *testing.T) {
 		cleanupMock()
 		// Restore the old serverAds at the end of this test func
 		serverAds = oldAds
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("empty-server-ads-returns", func(t *testing.T) {
@@ -698,7 +699,7 @@ func TestQueryServersForObject(t *testing.T) {
 }
 
 func TestSendHeadReq(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 
 	// Start a local HTTP server
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {

--- a/fed_test_utils/fed.go
+++ b/fed_test_utils/fed.go
@@ -225,8 +225,8 @@ func NewFedTest(t *testing.T, originConfig string) (ft *FedTest) {
 		}
 		err := os.RemoveAll(tmpPath)
 		require.NoError(t, err)
-		// Throw in a viper.Reset for good measure. Keeps our env squeaky clean!
-		viper.Reset()
+		// Throw in a config.Reset for good measure. Keeps our env squeaky clean!
+		config.Reset()
 	})
 
 	return

--- a/fed_test_utils/fed.go
+++ b/fed_test_utils/fed.go
@@ -226,7 +226,7 @@ func NewFedTest(t *testing.T, originConfig string) (ft *FedTest) {
 		err := os.RemoveAll(tmpPath)
 		require.NoError(t, err)
 		// Throw in a config.Reset for good measure. Keeps our env squeaky clean!
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	return

--- a/launcher_utils/advertise_test.go
+++ b/launcher_utils/advertise_test.go
@@ -32,11 +32,12 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/pelican_url"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 )
 
 func TestGetSitenameFromReg(t *testing.T) {
 	t.Cleanup(func() {
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("no-registry-url", func(t *testing.T) {
@@ -49,7 +50,7 @@ func TestGetSitenameFromReg(t *testing.T) {
 	})
 
 	t.Run("registry-returns-404", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 		}))
@@ -63,7 +64,7 @@ func TestGetSitenameFromReg(t *testing.T) {
 	})
 
 	t.Run("registry-returns-correct-object", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			if strings.HasPrefix(req.URL.Path, "/api/v1.0/registry") {
 				prefix := strings.TrimPrefix(req.URL.Path, "/api/v1.0/registry")

--- a/launcher_utils/advertise_test.go
+++ b/launcher_utils/advertise_test.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -37,7 +36,7 @@ import (
 
 func TestGetSitenameFromReg(t *testing.T) {
 	t.Cleanup(func() {
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("no-registry-url", func(t *testing.T) {
@@ -50,7 +49,7 @@ func TestGetSitenameFromReg(t *testing.T) {
 	})
 
 	t.Run("registry-returns-404", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 		}))
@@ -64,7 +63,7 @@ func TestGetSitenameFromReg(t *testing.T) {
 	})
 
 	t.Run("registry-returns-correct-object", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			if strings.HasPrefix(req.URL.Path, "/api/v1.0/registry") {
 				prefix := strings.TrimPrefix(req.URL.Path, "/api/v1.0/registry")

--- a/launcher_utils/register_namespace_test.go
+++ b/launcher_utils/register_namespace_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/registry"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
 )
 
@@ -56,7 +57,7 @@ func TestRegistration(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	config.Reset()
+	server_utils.Reset()
 	viper.Set("ConfigDir", tempConfigDir)
 
 	config.InitConfig()

--- a/launcher_utils/register_namespace_test.go
+++ b/launcher_utils/register_namespace_test.go
@@ -56,7 +56,7 @@ func TestRegistration(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	viper.Reset()
+	config.Reset()
 	viper.Set("ConfigDir", tempConfigDir)
 
 	config.InitConfig()

--- a/local_cache/cache_linux_test.go
+++ b/local_cache/cache_linux_test.go
@@ -51,7 +51,7 @@ import (
 func TestPurge(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	viper.Reset()
+	config.Reset()
 	viper.Set("LocalCache.Size", "5MB")
 	ft := fed_test_utils.NewFedTest(t, pubOriginCfg)
 
@@ -103,8 +103,8 @@ func TestPurge(t *testing.T) {
 		if err := te.Shutdown(); err != nil {
 			log.Errorln("Failure when shutting down transfer engine:", err)
 		}
-		// Throw in a viper.Reset for good measure. Keeps our env squeaky clean!
-		viper.Reset()
+		// Throw in a config.Reset for good measure. Keeps our env squeaky clean!
+		config.Reset()
 	})
 }
 
@@ -113,7 +113,7 @@ func TestPurge(t *testing.T) {
 func TestForcePurge(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	viper.Reset()
+	config.Reset()
 	viper.Set("LocalCache.Size", "5MB")
 	// Decrease the low water mark so invoking purge will result in 3 files in the cache.
 	viper.Set("LocalCache.LowWaterMarkPercentage", "80")
@@ -195,7 +195,7 @@ func TestForcePurge(t *testing.T) {
 		if err := te.Shutdown(); err != nil {
 			log.Errorln("Failure when shutting down transfer engine:", err)
 		}
-		// Throw in a viper.Reset for good measure. Keeps our env squeaky clean!
-		viper.Reset()
+		// Throw in a config.Reset for good measure. Keeps our env squeaky clean!
+		config.Reset()
 	})
 }

--- a/local_cache/cache_linux_test.go
+++ b/local_cache/cache_linux_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/fed_test_utils"
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
@@ -51,7 +52,7 @@ import (
 func TestPurge(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	config.Reset()
+	server_utils.Reset()
 	viper.Set("LocalCache.Size", "5MB")
 	ft := fed_test_utils.NewFedTest(t, pubOriginCfg)
 
@@ -104,7 +105,7 @@ func TestPurge(t *testing.T) {
 			log.Errorln("Failure when shutting down transfer engine:", err)
 		}
 		// Throw in a config.Reset for good measure. Keeps our env squeaky clean!
-		config.Reset()
+		server_utils.Reset()
 	})
 }
 
@@ -113,7 +114,7 @@ func TestPurge(t *testing.T) {
 func TestForcePurge(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	config.Reset()
+	server_utils.Reset()
 	viper.Set("LocalCache.Size", "5MB")
 	// Decrease the low water mark so invoking purge will result in 3 files in the cache.
 	viper.Set("LocalCache.LowWaterMarkPercentage", "80")
@@ -196,6 +197,6 @@ func TestForcePurge(t *testing.T) {
 			log.Errorln("Failure when shutting down transfer engine:", err)
 		}
 		// Throw in a config.Reset for good measure. Keeps our env squeaky clean!
-		config.Reset()
+		server_utils.Reset()
 	})
 }

--- a/local_cache/cache_test.go
+++ b/local_cache/cache_test.go
@@ -64,7 +64,7 @@ var (
 // The download is done twice -- once to verify functionality and once
 // as a cache hit.
 func TestFedPublicGet(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	ft := fed_test_utils.NewFedTest(t, pubOriginCfg)
 
 	lc, err := local_cache.NewLocalCache(ft.Ctx, ft.Egrp)
@@ -89,7 +89,7 @@ func TestFedPublicGet(t *testing.T) {
 
 // Test the local cache library on an authenticated GET.
 func TestFedAuthGet(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	ft := fed_test_utils.NewFedTest(t, authOriginCfg)
 
 	lc, err := local_cache.NewLocalCache(ft.Ctx, ft.Egrp)
@@ -121,7 +121,7 @@ func TestFedAuthGet(t *testing.T) {
 
 // Test a raw HTTP request (no Pelican client) works with the local cache
 func TestHttpReq(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	ft := fed_test_utils.NewFedTest(t, authOriginCfg)
 
 	transport := config.GetTransport().Clone()
@@ -144,7 +144,7 @@ func TestHttpReq(t *testing.T) {
 
 // Test a raw HTTP request (no Pelican client) returns a 404 for an unknown object
 func TestHttpFailures(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	fed_test_utils.NewFedTest(t, authOriginCfg)
 
 	transport := config.GetTransport().Clone()
@@ -188,7 +188,7 @@ func TestHttpFailures(t *testing.T) {
 
 // Test that the client library (with authentication) works with the local cache
 func TestClient(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	ft := fed_test_utils.NewFedTest(t, authOriginCfg)
 
 	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
@@ -337,14 +337,14 @@ func TestClient(t *testing.T) {
 		if err := egrp.Wait(); err != nil && err != context.Canceled && err != http.ErrServerClosed {
 			require.NoError(t, err)
 		}
-		// Throw in a viper.Reset for good measure. Keeps our env squeaky clean!
-		viper.Reset()
+		// Throw in a config.Reset for good measure. Keeps our env squeaky clean!
+		config.Reset()
 	})
 }
 
 // Test that HEAD requests to the local cache return the correct result
 func TestStat(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	ft := fed_test_utils.NewFedTest(t, pubOriginCfg)
 
 	lc, err := local_cache.NewLocalCache(ft.Ctx, ft.Egrp)
@@ -371,7 +371,7 @@ func TestStat(t *testing.T) {
 func TestLargeFile(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	viper.Reset()
+	config.Reset()
 	viper.Set("Client.MaximumDownloadSpeed", 40*1024*1024)
 	ft := fed_test_utils.NewFedTest(t, pubOriginCfg)
 
@@ -404,8 +404,8 @@ func TestLargeFile(t *testing.T) {
 		if err := te.Shutdown(); err != nil {
 			log.Errorln("Failure when shutting down transfer engine:", err)
 		}
-		// Throw in a viper.Reset for good measure. Keeps our env squeaky clean!
-		viper.Reset()
+		// Throw in a config.Reset for good measure. Keeps our env squeaky clean!
+		config.Reset()
 	})
 
 }
@@ -415,7 +415,7 @@ func TestLargeFile(t *testing.T) {
 func TestOriginUnresponsive(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	viper.Reset()
+	config.Reset()
 	viper.Set("Transport.ResponseHeaderTimeout", "3s")
 	viper.Set("Logging.Level", "debug")
 	ft := fed_test_utils.NewFedTest(t, pubOriginCfg)

--- a/local_cache/cache_test.go
+++ b/local_cache/cache_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/pelicanplatform/pelican/fed_test_utils"
 	local_cache "github.com/pelicanplatform/pelican/local_cache"
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
@@ -64,7 +65,7 @@ var (
 // The download is done twice -- once to verify functionality and once
 // as a cache hit.
 func TestFedPublicGet(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	ft := fed_test_utils.NewFedTest(t, pubOriginCfg)
 
 	lc, err := local_cache.NewLocalCache(ft.Ctx, ft.Egrp)
@@ -89,7 +90,7 @@ func TestFedPublicGet(t *testing.T) {
 
 // Test the local cache library on an authenticated GET.
 func TestFedAuthGet(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	ft := fed_test_utils.NewFedTest(t, authOriginCfg)
 
 	lc, err := local_cache.NewLocalCache(ft.Ctx, ft.Egrp)
@@ -121,7 +122,7 @@ func TestFedAuthGet(t *testing.T) {
 
 // Test a raw HTTP request (no Pelican client) works with the local cache
 func TestHttpReq(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	ft := fed_test_utils.NewFedTest(t, authOriginCfg)
 
 	transport := config.GetTransport().Clone()
@@ -144,7 +145,7 @@ func TestHttpReq(t *testing.T) {
 
 // Test a raw HTTP request (no Pelican client) returns a 404 for an unknown object
 func TestHttpFailures(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	fed_test_utils.NewFedTest(t, authOriginCfg)
 
 	transport := config.GetTransport().Clone()
@@ -188,7 +189,7 @@ func TestHttpFailures(t *testing.T) {
 
 // Test that the client library (with authentication) works with the local cache
 func TestClient(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	ft := fed_test_utils.NewFedTest(t, authOriginCfg)
 
 	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
@@ -338,13 +339,13 @@ func TestClient(t *testing.T) {
 			require.NoError(t, err)
 		}
 		// Throw in a config.Reset for good measure. Keeps our env squeaky clean!
-		config.Reset()
+		server_utils.Reset()
 	})
 }
 
 // Test that HEAD requests to the local cache return the correct result
 func TestStat(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	ft := fed_test_utils.NewFedTest(t, pubOriginCfg)
 
 	lc, err := local_cache.NewLocalCache(ft.Ctx, ft.Egrp)
@@ -371,7 +372,7 @@ func TestStat(t *testing.T) {
 func TestLargeFile(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	config.Reset()
+	server_utils.Reset()
 	viper.Set("Client.MaximumDownloadSpeed", 40*1024*1024)
 	ft := fed_test_utils.NewFedTest(t, pubOriginCfg)
 
@@ -405,7 +406,7 @@ func TestLargeFile(t *testing.T) {
 			log.Errorln("Failure when shutting down transfer engine:", err)
 		}
 		// Throw in a config.Reset for good measure. Keeps our env squeaky clean!
-		config.Reset()
+		server_utils.Reset()
 	})
 
 }
@@ -415,7 +416,7 @@ func TestLargeFile(t *testing.T) {
 func TestOriginUnresponsive(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	config.Reset()
+	server_utils.Reset()
 	viper.Set("Transport.ResponseHeaderTimeout", "3s")
 	viper.Set("Logging.Level", "debug")
 	ft := fed_test_utils.NewFedTest(t, pubOriginCfg)

--- a/lotman/lotman_test.go
+++ b/lotman/lotman_test.go
@@ -30,11 +30,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pelicanplatform/pelican/server_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
-
-	"github.com/pelicanplatform/pelican/config"
 )
 
 //go:embed resources/lots-config.yaml
@@ -60,13 +59,13 @@ func setupLotmanFromConf(t *testing.T, readConfig bool, name string) (bool, func
 	success := InitLotman()
 	//reset func
 	return success, func() {
-		config.Reset()
+		server_utils.Reset()
 	}
 }
 
 // Test the library initializer. NOTE: this also tests CreateLot, which is a part of initialization.
 func TestLotmanInit(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 
 	t.Run("TestBadInit", func(t *testing.T) {
 		// We haven't set various bits needed to create the lots, like discovery URL
@@ -120,7 +119,7 @@ func TestLotmanInit(t *testing.T) {
 }
 
 func TestLotmanInitFromConfig(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 
 	success, cleanup := setupLotmanFromConf(t, true, "LotmanInitConf")
 	defer cleanup()
@@ -220,7 +219,7 @@ func TestGetLotmanLib(t *testing.T) {
 }
 
 func TestGetAuthzCallers(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	success, cleanup := setupLotmanFromConf(t, true, "LotmanGetAuthzCalleres")
 	defer cleanup()
 	require.True(t, success)
@@ -239,7 +238,7 @@ func TestGetAuthzCallers(t *testing.T) {
 }
 
 func TestGetLot(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	success, cleanup := setupLotmanFromConf(t, true, "LotmanGetLot")
 	defer cleanup()
 	require.True(t, success)
@@ -262,7 +261,7 @@ func TestGetLot(t *testing.T) {
 }
 
 func TestUpdateLot(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	success, cleanup := setupLotmanFromConf(t, true, "LotmanInitConf")
 	defer cleanup()
 	require.True(t, success)
@@ -300,7 +299,7 @@ func TestUpdateLot(t *testing.T) {
 }
 
 func TestDeleteLotsRec(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	success, cleanup := setupLotmanFromConf(t, true, "LotmanInitConf")
 	defer cleanup()
 	require.True(t, success)

--- a/lotman/lotman_test.go
+++ b/lotman/lotman_test.go
@@ -33,6 +33,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/config"
 )
 
 //go:embed resources/lots-config.yaml
@@ -58,13 +60,13 @@ func setupLotmanFromConf(t *testing.T, readConfig bool, name string) (bool, func
 	success := InitLotman()
 	//reset func
 	return success, func() {
-		viper.Reset()
+		config.Reset()
 	}
 }
 
 // Test the library initializer. NOTE: this also tests CreateLot, which is a part of initialization.
 func TestLotmanInit(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 
 	t.Run("TestBadInit", func(t *testing.T) {
 		// We haven't set various bits needed to create the lots, like discovery URL
@@ -118,7 +120,7 @@ func TestLotmanInit(t *testing.T) {
 }
 
 func TestLotmanInitFromConfig(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 
 	success, cleanup := setupLotmanFromConf(t, true, "LotmanInitConf")
 	defer cleanup()
@@ -218,7 +220,7 @@ func TestGetLotmanLib(t *testing.T) {
 }
 
 func TestGetAuthzCallers(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	success, cleanup := setupLotmanFromConf(t, true, "LotmanGetAuthzCalleres")
 	defer cleanup()
 	require.True(t, success)
@@ -237,7 +239,7 @@ func TestGetAuthzCallers(t *testing.T) {
 }
 
 func TestGetLot(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	success, cleanup := setupLotmanFromConf(t, true, "LotmanGetLot")
 	defer cleanup()
 	require.True(t, success)
@@ -260,7 +262,7 @@ func TestGetLot(t *testing.T) {
 }
 
 func TestUpdateLot(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	success, cleanup := setupLotmanFromConf(t, true, "LotmanInitConf")
 	defer cleanup()
 	require.True(t, success)
@@ -298,7 +300,7 @@ func TestUpdateLot(t *testing.T) {
 }
 
 func TestDeleteLotsRec(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	success, cleanup := setupLotmanFromConf(t, true, "LotmanInitConf")
 	defer cleanup()
 	require.True(t, success)

--- a/oauth2/oidc_client_test.go
+++ b/oauth2/oidc_client_test.go
@@ -26,16 +26,16 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pelicanplatform/pelican/param"
-	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/server_utils"
 )
 
 func TestGetRedirectURL(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	t.Cleanup(func() {
-		config.Reset()
+		server_utils.Reset()
 	})
 	t.Run("no-redirect-host-no-cb-path-set", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		viper.Set(param.Server_ExternalWebUrl.GetName(), "https://localhost:8888")
 		get, err := GetRedirectURL("")
 		require.NoError(t, err)
@@ -43,7 +43,7 @@ func TestGetRedirectURL(t *testing.T) {
 	})
 
 	t.Run("no-redirect-host-cp-path-set", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		viper.Set(param.Server_ExternalWebUrl.GetName(), "https://localhost:8888")
 		get, err := GetRedirectURL("/new/url")
 		require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestGetRedirectURL(t *testing.T) {
 	})
 
 	t.Run("redirect-host-cp-path-set", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		viper.Set(param.Server_ExternalWebUrl.GetName(), "https://ea123fsac:8888")
 		viper.Set("Server.WebPort", 8888)
 		viper.Set(param.OIDC_ClientRedirectHostname.GetName(), "localhost")

--- a/oauth2/oidc_client_test.go
+++ b/oauth2/oidc_client_test.go
@@ -26,15 +26,16 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/config"
 )
 
 func TestGetRedirectURL(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	t.Cleanup(func() {
-		viper.Reset()
+		config.Reset()
 	})
 	t.Run("no-redirect-host-no-cb-path-set", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		viper.Set(param.Server_ExternalWebUrl.GetName(), "https://localhost:8888")
 		get, err := GetRedirectURL("")
 		require.NoError(t, err)
@@ -42,7 +43,7 @@ func TestGetRedirectURL(t *testing.T) {
 	})
 
 	t.Run("no-redirect-host-cp-path-set", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		viper.Set(param.Server_ExternalWebUrl.GetName(), "https://localhost:8888")
 		get, err := GetRedirectURL("/new/url")
 		require.NoError(t, err)
@@ -50,7 +51,7 @@ func TestGetRedirectURL(t *testing.T) {
 	})
 
 	t.Run("redirect-host-cp-path-set", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		viper.Set(param.Server_ExternalWebUrl.GetName(), "https://ea123fsac:8888")
 		viper.Set("Server.WebPort", 8888)
 		viper.Set(param.OIDC_ClientRedirectHostname.GetName(), "localhost")

--- a/origin/origin_db_test.go
+++ b/origin/origin_db_test.go
@@ -131,10 +131,10 @@ func TestCollectionExistsByUUID(t *testing.T) {
 }
 
 func TestGetCollectionByUUID(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	setupMockOriginDB(t)
 	t.Cleanup(func() {
-		viper.Reset()
+		config.Reset()
 		teardownMockOriginDB(t)
 	})
 	err := insertMockDBData(mockGC)
@@ -164,10 +164,10 @@ func TestGetCollectionByUUID(t *testing.T) {
 }
 
 func TestCreateCollection(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	setupMockOriginDB(t)
 	t.Cleanup(func() {
-		viper.Reset()
+		config.Reset()
 		teardownMockOriginDB(t)
 	})
 
@@ -204,10 +204,10 @@ func TestCreateCollection(t *testing.T) {
 }
 
 func TestUpdateCollection(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	setupMockOriginDB(t)
 	t.Cleanup(func() {
-		viper.Reset()
+		config.Reset()
 		teardownMockOriginDB(t)
 	})
 
@@ -234,10 +234,10 @@ func TestUpdateCollection(t *testing.T) {
 }
 
 func TestDeleteCollectionByUUID(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	setupMockOriginDB(t)
 	t.Cleanup(func() {
-		viper.Reset()
+		config.Reset()
 		teardownMockOriginDB(t)
 	})
 

--- a/origin/origin_db_test.go
+++ b/origin/origin_db_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
 )
 
 const (
@@ -131,10 +132,10 @@ func TestCollectionExistsByUUID(t *testing.T) {
 }
 
 func TestGetCollectionByUUID(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	setupMockOriginDB(t)
 	t.Cleanup(func() {
-		config.Reset()
+		server_utils.Reset()
 		teardownMockOriginDB(t)
 	})
 	err := insertMockDBData(mockGC)
@@ -164,10 +165,10 @@ func TestGetCollectionByUUID(t *testing.T) {
 }
 
 func TestCreateCollection(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	setupMockOriginDB(t)
 	t.Cleanup(func() {
-		config.Reset()
+		server_utils.Reset()
 		teardownMockOriginDB(t)
 	})
 
@@ -204,10 +205,10 @@ func TestCreateCollection(t *testing.T) {
 }
 
 func TestUpdateCollection(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	setupMockOriginDB(t)
 	t.Cleanup(func() {
-		config.Reset()
+		server_utils.Reset()
 		teardownMockOriginDB(t)
 	})
 
@@ -234,10 +235,10 @@ func TestUpdateCollection(t *testing.T) {
 }
 
 func TestDeleteCollectionByUUID(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	setupMockOriginDB(t)
 	t.Cleanup(func() {
-		config.Reset()
+		server_utils.Reset()
 		teardownMockOriginDB(t)
 	})
 

--- a/origin/reg_status_test.go
+++ b/origin/reg_status_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 
 	"github.com/jellydator/ttlcache/v3"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -74,14 +73,14 @@ func mockRegistryCheck(t *testing.T) *httptest.Server {
 
 func TestFetchRegStatus(t *testing.T) {
 	t.Cleanup(func() {
-		viper.Reset()
+		config.Reset()
 		config.ResetFederationForTest()
 	})
 
 	t.Run("successful-fetch", func(t *testing.T) {
 		ts := mockRegistryCheck(t)
 		defer ts.Close()
-		viper.Reset()
+		config.Reset()
 		config.ResetFederationForTest()
 		config.SetFederation(pelican_url.FederationDiscovery{
 			RegistryEndpoint: ts.URL,
@@ -105,7 +104,7 @@ func TestFetchRegStatus(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 		}))
 		defer ts.Close()
-		viper.Reset()
+		config.Reset()
 		config.ResetFederationForTest()
 		config.SetFederation(pelican_url.FederationDiscovery{
 			RegistryEndpoint: ts.URL,
@@ -125,7 +124,7 @@ func TestFetchRegStatus(t *testing.T) {
 			w.WriteHeader(http.StatusInternalServerError)
 		}))
 		defer ts.Close()
-		viper.Reset()
+		config.Reset()
 		config.ResetFederationForTest()
 		config.SetFederation(pelican_url.FederationDiscovery{
 			RegistryEndpoint: ts.URL,
@@ -139,11 +138,11 @@ func TestFetchRegStatus(t *testing.T) {
 
 func TestWrapExportsByStatus(t *testing.T) {
 	t.Cleanup(func() {
-		viper.Reset()
+		config.Reset()
 		config.ResetFederationForTest()
 	})
 
-	viper.Reset()
+	config.Reset()
 	config.SetFederation(pelican_url.FederationDiscovery{
 		RegistryEndpoint: "https://mock-registry.org",
 	})
@@ -191,7 +190,7 @@ func TestWrapExportsByStatus(t *testing.T) {
 	})
 
 	t.Run("partial-cached", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		ts := mockRegistryCheck(t)
 		defer ts.Close()
 		config.ResetFederationForTest()
@@ -237,6 +236,6 @@ func TestWrapExportsByStatus(t *testing.T) {
 		assert.EqualValues(t, expected, got)
 
 		registrationsStatus.DeleteAll()
-		viper.Reset()
+		config.Reset()
 	})
 }

--- a/origin/reg_status_test.go
+++ b/origin/reg_status_test.go
@@ -73,14 +73,14 @@ func mockRegistryCheck(t *testing.T) *httptest.Server {
 
 func TestFetchRegStatus(t *testing.T) {
 	t.Cleanup(func() {
-		config.Reset()
+		server_utils.Reset()
 		config.ResetFederationForTest()
 	})
 
 	t.Run("successful-fetch", func(t *testing.T) {
 		ts := mockRegistryCheck(t)
 		defer ts.Close()
-		config.Reset()
+		server_utils.Reset()
 		config.ResetFederationForTest()
 		config.SetFederation(pelican_url.FederationDiscovery{
 			RegistryEndpoint: ts.URL,
@@ -104,7 +104,7 @@ func TestFetchRegStatus(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 		}))
 		defer ts.Close()
-		config.Reset()
+		server_utils.Reset()
 		config.ResetFederationForTest()
 		config.SetFederation(pelican_url.FederationDiscovery{
 			RegistryEndpoint: ts.URL,
@@ -124,7 +124,7 @@ func TestFetchRegStatus(t *testing.T) {
 			w.WriteHeader(http.StatusInternalServerError)
 		}))
 		defer ts.Close()
-		config.Reset()
+		server_utils.Reset()
 		config.ResetFederationForTest()
 		config.SetFederation(pelican_url.FederationDiscovery{
 			RegistryEndpoint: ts.URL,
@@ -138,11 +138,11 @@ func TestFetchRegStatus(t *testing.T) {
 
 func TestWrapExportsByStatus(t *testing.T) {
 	t.Cleanup(func() {
-		config.Reset()
+		server_utils.Reset()
 		config.ResetFederationForTest()
 	})
 
-	config.Reset()
+	server_utils.Reset()
 	config.SetFederation(pelican_url.FederationDiscovery{
 		RegistryEndpoint: "https://mock-registry.org",
 	})
@@ -190,7 +190,7 @@ func TestWrapExportsByStatus(t *testing.T) {
 	})
 
 	t.Run("partial-cached", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		ts := mockRegistryCheck(t)
 		defer ts.Close()
 		config.ResetFederationForTest()
@@ -236,6 +236,6 @@ func TestWrapExportsByStatus(t *testing.T) {
 		assert.EqualValues(t, expected, got)
 
 		registrationsStatus.DeleteAll()
-		config.Reset()
+		server_utils.Reset()
 	})
 }

--- a/registry/client_commands_test.go
+++ b/registry/client_commands_test.go
@@ -71,7 +71,7 @@ func TestServeNamespaceRegistry(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	viper.Reset()
+	config.Reset()
 
 	svr := registryMockup(ctx, t, "serveregistry")
 	defer func() {
@@ -140,7 +140,7 @@ func TestServeNamespaceRegistry(t *testing.T) {
 		stdoutCapture = string(capturedOutput[:n])
 		assert.Equal(t, "[]\n", stdoutCapture)
 	})
-	viper.Reset()
+	config.Reset()
 }
 
 func TestRegistryKeyChainingOSDF(t *testing.T) {
@@ -148,7 +148,7 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	viper.Reset()
+	config.Reset()
 	_, err := config.SetPreferredPrefix(config.OsdfPrefix)
 	assert.NoError(t, err)
 	viper.Set("Federation.DirectorUrl", "https://osdf-director.osg-htc.org")
@@ -238,7 +238,7 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 
 	_, err = config.SetPreferredPrefix(config.PelicanPrefix)
 	assert.NoError(t, err)
-	viper.Reset()
+	config.Reset()
 }
 
 func TestRegistryKeyChaining(t *testing.T) {
@@ -246,7 +246,7 @@ func TestRegistryKeyChaining(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	viper.Reset()
+	config.Reset()
 	// On by default, but just to make things explicit
 	viper.Set("Registry.RequireKeyChaining", true)
 
@@ -297,5 +297,5 @@ func TestRegistryKeyChaining(t *testing.T) {
 	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo", "")
 	require.NoError(t, err)
 
-	viper.Reset()
+	config.Reset()
 }

--- a/registry/client_commands_test.go
+++ b/registry/client_commands_test.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
 )
 
@@ -71,7 +72,7 @@ func TestServeNamespaceRegistry(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	config.Reset()
+	server_utils.Reset()
 
 	svr := registryMockup(ctx, t, "serveregistry")
 	defer func() {
@@ -140,7 +141,7 @@ func TestServeNamespaceRegistry(t *testing.T) {
 		stdoutCapture = string(capturedOutput[:n])
 		assert.Equal(t, "[]\n", stdoutCapture)
 	})
-	config.Reset()
+	server_utils.Reset()
 }
 
 func TestRegistryKeyChainingOSDF(t *testing.T) {
@@ -148,7 +149,7 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	config.Reset()
+	server_utils.Reset()
 	_, err := config.SetPreferredPrefix(config.OsdfPrefix)
 	assert.NoError(t, err)
 	viper.Set("Federation.DirectorUrl", "https://osdf-director.osg-htc.org")
@@ -238,7 +239,7 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 
 	_, err = config.SetPreferredPrefix(config.PelicanPrefix)
 	assert.NoError(t, err)
-	config.Reset()
+	server_utils.Reset()
 }
 
 func TestRegistryKeyChaining(t *testing.T) {
@@ -246,7 +247,7 @@ func TestRegistryKeyChaining(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	config.Reset()
+	server_utils.Reset()
 	// On by default, but just to make things explicit
 	viper.Set("Registry.RequireKeyChaining", true)
 
@@ -297,5 +298,5 @@ func TestRegistryKeyChaining(t *testing.T) {
 	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo", "")
 	require.NoError(t, err)
 
-	config.Reset()
+	server_utils.Reset()
 }

--- a/registry/registry_db_test.go
+++ b/registry/registry_db_test.go
@@ -805,7 +805,7 @@ func topologyMockup(t *testing.T, namespaces []string) *httptest.Server {
 }
 
 func TestRegistryTopology(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 
 	topoNamespaces := []string{"/topo/foo", "/topo/bar"}
 	svr := topologyMockup(t, topoNamespaces)
@@ -894,7 +894,7 @@ func TestRegistryTopology(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, exists)
 
-	viper.Reset()
+	config.Reset()
 }
 
 func TestGetTopoPrefixString(t *testing.T) {

--- a/registry/registry_db_test.go
+++ b/registry/registry_db_test.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
 )
 
@@ -805,7 +806,7 @@ func topologyMockup(t *testing.T, namespaces []string) *httptest.Server {
 }
 
 func TestRegistryTopology(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 
 	topoNamespaces := []string{"/topo/foo", "/topo/bar"}
 	svr := topologyMockup(t, topoNamespaces)
@@ -894,7 +895,7 @@ func TestRegistryTopology(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, exists)
 
-	config.Reset()
+	server_utils.Reset()
 }
 
 func TestGetTopoPrefixString(t *testing.T) {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -81,7 +81,7 @@ func TestHandleWildcard(t *testing.T) {
 	})
 
 	t.Run("match-wildcard-metadataHandler", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		mockPrefix := "/testnamespace/foo"
 
 		setupMockRegistryDB(t)
@@ -151,7 +151,7 @@ func TestHandleWildcard(t *testing.T) {
 
 	for _, tc := range mockApprovalTcs {
 		t.Run(tc.Name, func(t *testing.T) {
-			viper.Reset()
+			config.Reset()
 			viper.Set("Registry.RequireCacheApproval", tc.CacheApprovedOnly)
 			viper.Set("Registry.RequireOriginApproval", tc.OriginApprovedOnly)
 
@@ -197,7 +197,7 @@ func TestCheckNamespaceCompleteHandler(t *testing.T) {
 	router.POST("/namespaces/check/status", checkStatusHandler)
 
 	t.Cleanup(func() {
-		viper.Reset()
+		config.Reset()
 		config.ResetFederationForTest()
 	})
 
@@ -253,7 +253,7 @@ func TestCheckNamespaceCompleteHandler(t *testing.T) {
 
 	t.Run("incomplete-registration", func(t *testing.T) {
 		resetNamespaceDB(t)
-		viper.Reset()
+		config.Reset()
 		config.ResetFederationForTest()
 		config.SetFederation(pelican_url.FederationDiscovery{
 			RegistryEndpoint: "https://registry.org",
@@ -291,7 +291,7 @@ func TestCheckNamespaceCompleteHandler(t *testing.T) {
 
 	t.Run("complete-registration", func(t *testing.T) {
 		resetNamespaceDB(t)
-		viper.Reset()
+		config.Reset()
 		config.ResetFederationForTest()
 		config.SetFederation(pelican_url.FederationDiscovery{
 			RegistryEndpoint: "https://registry.org",
@@ -337,7 +337,7 @@ func TestCheckNamespaceCompleteHandler(t *testing.T) {
 
 	t.Run("multiple-complete-registrations", func(t *testing.T) {
 		resetNamespaceDB(t)
-		viper.Reset()
+		config.Reset()
 		config.ResetFederationForTest()
 		config.SetFederation(pelican_url.FederationDiscovery{
 			RegistryEndpoint: "https://registry.org",

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/pelican_url"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
 )
 
@@ -81,7 +82,7 @@ func TestHandleWildcard(t *testing.T) {
 	})
 
 	t.Run("match-wildcard-metadataHandler", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		mockPrefix := "/testnamespace/foo"
 
 		setupMockRegistryDB(t)
@@ -151,7 +152,7 @@ func TestHandleWildcard(t *testing.T) {
 
 	for _, tc := range mockApprovalTcs {
 		t.Run(tc.Name, func(t *testing.T) {
-			config.Reset()
+			server_utils.Reset()
 			viper.Set("Registry.RequireCacheApproval", tc.CacheApprovedOnly)
 			viper.Set("Registry.RequireOriginApproval", tc.OriginApprovedOnly)
 
@@ -197,7 +198,7 @@ func TestCheckNamespaceCompleteHandler(t *testing.T) {
 	router.POST("/namespaces/check/status", checkStatusHandler)
 
 	t.Cleanup(func() {
-		config.Reset()
+		server_utils.Reset()
 		config.ResetFederationForTest()
 	})
 
@@ -253,7 +254,7 @@ func TestCheckNamespaceCompleteHandler(t *testing.T) {
 
 	t.Run("incomplete-registration", func(t *testing.T) {
 		resetNamespaceDB(t)
-		config.Reset()
+		server_utils.Reset()
 		config.ResetFederationForTest()
 		config.SetFederation(pelican_url.FederationDiscovery{
 			RegistryEndpoint: "https://registry.org",
@@ -291,7 +292,7 @@ func TestCheckNamespaceCompleteHandler(t *testing.T) {
 
 	t.Run("complete-registration", func(t *testing.T) {
 		resetNamespaceDB(t)
-		config.Reset()
+		server_utils.Reset()
 		config.ResetFederationForTest()
 		config.SetFederation(pelican_url.FederationDiscovery{
 			RegistryEndpoint: "https://registry.org",
@@ -337,7 +338,7 @@ func TestCheckNamespaceCompleteHandler(t *testing.T) {
 
 	t.Run("multiple-complete-registrations", func(t *testing.T) {
 		resetNamespaceDB(t)
-		config.Reset()
+		server_utils.Reset()
 		config.ResetFederationForTest()
 		config.SetFederation(pelican_url.FederationDiscovery{
 			RegistryEndpoint: "https://registry.org",

--- a/registry/registry_ui_test.go
+++ b/registry/registry_ui_test.go
@@ -56,7 +56,7 @@ func mockAdminToken() (string, error) {
 }
 
 func TestListNamespaces(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
@@ -310,7 +310,7 @@ func TestListNamespaces(t *testing.T) {
 }
 
 func TestListNamespacesForUser(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	_, cancel, egrp := test_utils.TestContext(context.Background(), t)
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
@@ -720,10 +720,10 @@ func TestUpdateNamespaceStatus(t *testing.T) {
 }
 
 func TestCreateNamespace(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 
 	t.Cleanup(func() {
-		viper.Reset()
+		config.Reset()
 		customRegFieldsConfigs = []customRegFieldsConfig{}
 	})
 
@@ -805,7 +805,7 @@ func TestCreateNamespace(t *testing.T) {
 	})
 
 	t.Run("missing-institution-returns-400", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		viper.Set("Registry.Institutions", []map[string]string{{"name": "Mock School", "id": "123"}})
 		resetNamespaceDB(t)
 		jwks, err := test_utils.GenerateJWKS()
@@ -825,7 +825,7 @@ func TestCreateNamespace(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
 		assert.Contains(t, string(body), "Validation for Institution failed:")
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("invalid-prefix-returns-400", func(t *testing.T) {
@@ -914,7 +914,7 @@ func TestCreateNamespace(t *testing.T) {
 	})
 
 	t.Run("key-chaining-failure-returns-400", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		viper.Set("Registry.RequireKeyChaining", true)
 		resetNamespaceDB(t)
 
@@ -941,7 +941,7 @@ func TestCreateNamespace(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
 		assert.Contains(t, string(body), "Cannot register a namespace that is suffixed or prefixed by an already-registered namespace unless the incoming public key matches a registered key")
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("inst-failure-returns-400", func(t *testing.T) {
@@ -1094,7 +1094,7 @@ func TestCreateNamespace(t *testing.T) {
 		assert.Equal(t, "admin", nss[0].AdminMetadata.UserID)
 		assert.Equal(t, server_structs.RegPending, nss[0].AdminMetadata.Status)
 		assert.NotEqual(t, time.Time{}, nss[0].AdminMetadata.CreatedAt)
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("osdf-topology-same-prefix-request-gives-200", func(t *testing.T) {
@@ -1136,14 +1136,14 @@ func TestCreateNamespace(t *testing.T) {
 		assert.Equal(t, "admin", nss[0].AdminMetadata.UserID)
 		assert.Equal(t, server_structs.RegPending, nss[0].AdminMetadata.Status)
 		assert.NotEqual(t, time.Time{}, nss[0].AdminMetadata.CreatedAt)
-		viper.Reset()
+		config.Reset()
 	})
 }
 
 func TestUpdateNamespaceHandler(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	t.Cleanup(func() {
-		viper.Reset()
+		config.Reset()
 	})
 	_, cancel, egrp := test_utils.TestContext(context.Background(), t)
 	defer func() { require.NoError(t, egrp.Wait()) }()
@@ -1388,7 +1388,7 @@ func TestUpdateNamespaceHandler(t *testing.T) {
 }
 
 func TestListInsitutions(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	router := gin.Default()
 	router.GET("/institutions", listInstitutions)
 
@@ -1408,7 +1408,7 @@ func TestListInsitutions(t *testing.T) {
 	})
 
 	t.Run("cache-hit-returns", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		mockUrl := url.URL{Scheme: "https", Host: "example.com"}
 		viper.Set("Registry.InstitutionsUrl", mockUrl.String())
 		mockInsts := []registrationFieldOption{{Name: "Foo", ID: "001"}}
@@ -1432,7 +1432,7 @@ func TestListInsitutions(t *testing.T) {
 	})
 
 	t.Run("nil-cache-with-nonnil-config-returns", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		optionsCache.DeleteAll()
 
 		mockInstsConfig := []registrationFieldOption{{Name: "foo", ID: "bar"}}
@@ -1456,7 +1456,7 @@ func TestListInsitutions(t *testing.T) {
 	})
 
 	t.Run("non-nil-cache-with-nonnil-config-return-config", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		mockUrl := url.URL{Scheme: "https", Host: "example.com"}
 		viper.Set("Registry.InstitutionsUrl", mockUrl.String())
 		mockInsts := []registrationFieldOption{{Name: "Foo", ID: "001"}}

--- a/registry/registry_ui_test.go
+++ b/registry/registry_ui_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
@@ -56,7 +57,7 @@ func mockAdminToken() (string, error) {
 }
 
 func TestListNamespaces(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
@@ -310,7 +311,7 @@ func TestListNamespaces(t *testing.T) {
 }
 
 func TestListNamespacesForUser(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	_, cancel, egrp := test_utils.TestContext(context.Background(), t)
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
@@ -720,10 +721,10 @@ func TestUpdateNamespaceStatus(t *testing.T) {
 }
 
 func TestCreateNamespace(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 
 	t.Cleanup(func() {
-		config.Reset()
+		server_utils.Reset()
 		customRegFieldsConfigs = []customRegFieldsConfig{}
 	})
 
@@ -805,7 +806,7 @@ func TestCreateNamespace(t *testing.T) {
 	})
 
 	t.Run("missing-institution-returns-400", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		viper.Set("Registry.Institutions", []map[string]string{{"name": "Mock School", "id": "123"}})
 		resetNamespaceDB(t)
 		jwks, err := test_utils.GenerateJWKS()
@@ -825,7 +826,7 @@ func TestCreateNamespace(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
 		assert.Contains(t, string(body), "Validation for Institution failed:")
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("invalid-prefix-returns-400", func(t *testing.T) {
@@ -914,7 +915,7 @@ func TestCreateNamespace(t *testing.T) {
 	})
 
 	t.Run("key-chaining-failure-returns-400", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		viper.Set("Registry.RequireKeyChaining", true)
 		resetNamespaceDB(t)
 
@@ -941,7 +942,7 @@ func TestCreateNamespace(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
 		assert.Contains(t, string(body), "Cannot register a namespace that is suffixed or prefixed by an already-registered namespace unless the incoming public key matches a registered key")
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("inst-failure-returns-400", func(t *testing.T) {
@@ -1094,7 +1095,7 @@ func TestCreateNamespace(t *testing.T) {
 		assert.Equal(t, "admin", nss[0].AdminMetadata.UserID)
 		assert.Equal(t, server_structs.RegPending, nss[0].AdminMetadata.Status)
 		assert.NotEqual(t, time.Time{}, nss[0].AdminMetadata.CreatedAt)
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("osdf-topology-same-prefix-request-gives-200", func(t *testing.T) {
@@ -1136,14 +1137,14 @@ func TestCreateNamespace(t *testing.T) {
 		assert.Equal(t, "admin", nss[0].AdminMetadata.UserID)
 		assert.Equal(t, server_structs.RegPending, nss[0].AdminMetadata.Status)
 		assert.NotEqual(t, time.Time{}, nss[0].AdminMetadata.CreatedAt)
-		config.Reset()
+		server_utils.Reset()
 	})
 }
 
 func TestUpdateNamespaceHandler(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	t.Cleanup(func() {
-		config.Reset()
+		server_utils.Reset()
 	})
 	_, cancel, egrp := test_utils.TestContext(context.Background(), t)
 	defer func() { require.NoError(t, egrp.Wait()) }()
@@ -1388,7 +1389,7 @@ func TestUpdateNamespaceHandler(t *testing.T) {
 }
 
 func TestListInsitutions(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	router := gin.Default()
 	router.GET("/institutions", listInstitutions)
 
@@ -1408,7 +1409,7 @@ func TestListInsitutions(t *testing.T) {
 	})
 
 	t.Run("cache-hit-returns", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		mockUrl := url.URL{Scheme: "https", Host: "example.com"}
 		viper.Set("Registry.InstitutionsUrl", mockUrl.String())
 		mockInsts := []registrationFieldOption{{Name: "Foo", ID: "001"}}
@@ -1432,7 +1433,7 @@ func TestListInsitutions(t *testing.T) {
 	})
 
 	t.Run("nil-cache-with-nonnil-config-returns", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		optionsCache.DeleteAll()
 
 		mockInstsConfig := []registrationFieldOption{{Name: "foo", ID: "bar"}}
@@ -1456,7 +1457,7 @@ func TestListInsitutions(t *testing.T) {
 	})
 
 	t.Run("non-nil-cache-with-nonnil-config-return-config", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		mockUrl := url.URL{Scheme: "https", Host: "example.com"}
 		viper.Set("Registry.InstitutionsUrl", mockUrl.String())
 		mockInsts := []registrationFieldOption{{Name: "Foo", ID: "001"}}

--- a/registry/registry_validation_test.go
+++ b/registry/registry_validation_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/test_utils"
 )
@@ -200,12 +201,12 @@ func TestValidateCustomFields(t *testing.T) {
 }
 
 func TestValidateKeyChaining(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	setupMockRegistryDB(t)
 	defer func() {
 		resetNamespaceDB(t)
 		teardownMockNamespaceDB(t)
-		viper.Reset()
+		config.Reset()
 	}()
 
 	_, jwksFoo, jwksStrFoo, err := test_utils.GenerateJWK()

--- a/registry/registry_validation_test.go
+++ b/registry/registry_validation_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
 )
 
@@ -201,12 +201,12 @@ func TestValidateCustomFields(t *testing.T) {
 }
 
 func TestValidateKeyChaining(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	setupMockRegistryDB(t)
 	defer func() {
 		resetNamespaceDB(t)
 		teardownMockNamespaceDB(t)
-		config.Reset()
+		server_utils.Reset()
 	}()
 
 	_, jwksFoo, jwksStrFoo, err := test_utils.GenerateJWK()

--- a/server_utils/origin_test.go
+++ b/server_utils/origin_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
 )
 
@@ -83,12 +82,12 @@ func setup(t *testing.T, config string) []OriginExport {
 // tests an origin configuration that mimics what you could do with env vars due to the
 // fact that we don't use a yaml list
 func TestGetExports(t *testing.T) {
-	config.Reset()
+	Reset()
 	ResetOriginExports()
 
 	// Posix tests
 	t.Run("testSingleExportValid", func(t *testing.T) {
-		defer config.Reset()
+		defer Reset()
 		defer ResetOriginExports()
 		exports := setup(t, envVarMimicConfig)
 
@@ -102,7 +101,7 @@ func TestGetExports(t *testing.T) {
 	})
 
 	t.Run("testMultiExportValid", func(t *testing.T) {
-		defer config.Reset()
+		defer Reset()
 		defer ResetOriginExports()
 		exports := setup(t, multiExportValidConfig)
 		assert.Len(t, exports, 2, "expected 2 exports")
@@ -135,7 +134,7 @@ func TestGetExports(t *testing.T) {
 	})
 
 	t.Run("testExportVolumesValid", func(t *testing.T) {
-		defer config.Reset()
+		defer Reset()
 		defer ResetOriginExports()
 		exports := setup(t, exportVolumesValidConfig)
 		assert.Len(t, exports, 2, "expected 2 exports")
@@ -170,7 +169,7 @@ func TestGetExports(t *testing.T) {
 	// When we have a single export volume, we also set a few viper variables that can be
 	// used by sections of code that assume a single export. Test that those are set properly
 	t.Run("testExportVolumesSingle", func(t *testing.T) {
-		defer config.Reset()
+		defer Reset()
 		defer ResetOriginExports()
 		exports := setup(t, exportSingleVolumeConfig)
 		assert.Len(t, exports, 1, "expected 1 export")
@@ -199,7 +198,7 @@ func TestGetExports(t *testing.T) {
 	})
 
 	t.Run("testSingleExportBlock", func(t *testing.T) {
-		defer config.Reset()
+		defer Reset()
 		defer ResetOriginExports()
 		exports := setup(t, singleExportBlockConfig)
 		assert.Len(t, exports, 1, "expected 1 export")
@@ -228,7 +227,7 @@ func TestGetExports(t *testing.T) {
 	})
 
 	t.Run("testInvalidExport", func(t *testing.T) {
-		defer config.Reset()
+		defer Reset()
 		defer ResetOriginExports()
 
 		viper.Set("Origin.StorageType", "posix")
@@ -237,14 +236,14 @@ func TestGetExports(t *testing.T) {
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, ErrInvalidOriginConfig)
 
-		config.Reset()
+		Reset()
 		viper.Set("Origin.StorageType", "posix")
 		viper.Set("Origin.ExportVolumes", "foo")
 		_, err = GetOriginExports()
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrInvalidOriginConfig)
 
-		config.Reset()
+		Reset()
 		viper.Set("Origin.StorageType", "blah")
 		_, err = GetOriginExports()
 		assert.Error(t, err)
@@ -253,7 +252,7 @@ func TestGetExports(t *testing.T) {
 
 	// S3 tests
 	t.Run("testSingleExportValidS3", func(t *testing.T) {
-		defer config.Reset()
+		defer Reset()
 		defer ResetOriginExports()
 
 		exports := setup(t, s3envVarMimicConfig)
@@ -271,7 +270,7 @@ func TestGetExports(t *testing.T) {
 	})
 
 	t.Run("testMultiExportValidS3", func(t *testing.T) {
-		defer config.Reset()
+		defer Reset()
 		defer ResetOriginExports()
 		exports := setup(t, s3multiExportValidConfig)
 		assert.Len(t, exports, 2, "expected 2 exports")
@@ -306,7 +305,7 @@ func TestGetExports(t *testing.T) {
 	})
 
 	t.Run("testExportVolumesValidS3", func(t *testing.T) {
-		defer config.Reset()
+		defer Reset()
 		defer ResetOriginExports()
 		exports := setup(t, s3exportVolumesValidConfig)
 		assert.Len(t, exports, 2, "expected 2 exports")
@@ -341,7 +340,7 @@ func TestGetExports(t *testing.T) {
 	})
 
 	t.Run("testExportVolumesSingleS3", func(t *testing.T) {
-		defer config.Reset()
+		defer Reset()
 		defer ResetOriginExports()
 		exports := setup(t, s3exportSingleVolumeConfig)
 		assert.Len(t, exports, 1, "expected 1 export")
@@ -375,7 +374,7 @@ func TestGetExports(t *testing.T) {
 	})
 
 	t.Run("testSingleExportBlockS3", func(t *testing.T) {
-		defer config.Reset()
+		defer Reset()
 		defer ResetOriginExports()
 		exports := setup(t, s3singleExportBlockConfig)
 		assert.Len(t, exports, 1, "expected 1 export")

--- a/server_utils/origin_test.go
+++ b/server_utils/origin_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
 )
 
@@ -82,12 +83,12 @@ func setup(t *testing.T, config string) []OriginExport {
 // tests an origin configuration that mimics what you could do with env vars due to the
 // fact that we don't use a yaml list
 func TestGetExports(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	ResetOriginExports()
 
 	// Posix tests
 	t.Run("testSingleExportValid", func(t *testing.T) {
-		defer viper.Reset()
+		defer config.Reset()
 		defer ResetOriginExports()
 		exports := setup(t, envVarMimicConfig)
 
@@ -101,7 +102,7 @@ func TestGetExports(t *testing.T) {
 	})
 
 	t.Run("testMultiExportValid", func(t *testing.T) {
-		defer viper.Reset()
+		defer config.Reset()
 		defer ResetOriginExports()
 		exports := setup(t, multiExportValidConfig)
 		assert.Len(t, exports, 2, "expected 2 exports")
@@ -134,7 +135,7 @@ func TestGetExports(t *testing.T) {
 	})
 
 	t.Run("testExportVolumesValid", func(t *testing.T) {
-		defer viper.Reset()
+		defer config.Reset()
 		defer ResetOriginExports()
 		exports := setup(t, exportVolumesValidConfig)
 		assert.Len(t, exports, 2, "expected 2 exports")
@@ -169,7 +170,7 @@ func TestGetExports(t *testing.T) {
 	// When we have a single export volume, we also set a few viper variables that can be
 	// used by sections of code that assume a single export. Test that those are set properly
 	t.Run("testExportVolumesSingle", func(t *testing.T) {
-		defer viper.Reset()
+		defer config.Reset()
 		defer ResetOriginExports()
 		exports := setup(t, exportSingleVolumeConfig)
 		assert.Len(t, exports, 1, "expected 1 export")
@@ -198,7 +199,7 @@ func TestGetExports(t *testing.T) {
 	})
 
 	t.Run("testSingleExportBlock", func(t *testing.T) {
-		defer viper.Reset()
+		defer config.Reset()
 		defer ResetOriginExports()
 		exports := setup(t, singleExportBlockConfig)
 		assert.Len(t, exports, 1, "expected 1 export")
@@ -227,7 +228,7 @@ func TestGetExports(t *testing.T) {
 	})
 
 	t.Run("testInvalidExport", func(t *testing.T) {
-		defer viper.Reset()
+		defer config.Reset()
 		defer ResetOriginExports()
 
 		viper.Set("Origin.StorageType", "posix")
@@ -236,14 +237,14 @@ func TestGetExports(t *testing.T) {
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, ErrInvalidOriginConfig)
 
-		viper.Reset()
+		config.Reset()
 		viper.Set("Origin.StorageType", "posix")
 		viper.Set("Origin.ExportVolumes", "foo")
 		_, err = GetOriginExports()
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrInvalidOriginConfig)
 
-		viper.Reset()
+		config.Reset()
 		viper.Set("Origin.StorageType", "blah")
 		_, err = GetOriginExports()
 		assert.Error(t, err)
@@ -252,7 +253,7 @@ func TestGetExports(t *testing.T) {
 
 	// S3 tests
 	t.Run("testSingleExportValidS3", func(t *testing.T) {
-		defer viper.Reset()
+		defer config.Reset()
 		defer ResetOriginExports()
 
 		exports := setup(t, s3envVarMimicConfig)
@@ -270,7 +271,7 @@ func TestGetExports(t *testing.T) {
 	})
 
 	t.Run("testMultiExportValidS3", func(t *testing.T) {
-		defer viper.Reset()
+		defer config.Reset()
 		defer ResetOriginExports()
 		exports := setup(t, s3multiExportValidConfig)
 		assert.Len(t, exports, 2, "expected 2 exports")
@@ -305,7 +306,7 @@ func TestGetExports(t *testing.T) {
 	})
 
 	t.Run("testExportVolumesValidS3", func(t *testing.T) {
-		defer viper.Reset()
+		defer config.Reset()
 		defer ResetOriginExports()
 		exports := setup(t, s3exportVolumesValidConfig)
 		assert.Len(t, exports, 2, "expected 2 exports")
@@ -340,7 +341,7 @@ func TestGetExports(t *testing.T) {
 	})
 
 	t.Run("testExportVolumesSingleS3", func(t *testing.T) {
-		defer viper.Reset()
+		defer config.Reset()
 		defer ResetOriginExports()
 		exports := setup(t, s3exportSingleVolumeConfig)
 		assert.Len(t, exports, 1, "expected 1 export")
@@ -374,7 +375,7 @@ func TestGetExports(t *testing.T) {
 	})
 
 	t.Run("testSingleExportBlockS3", func(t *testing.T) {
-		defer viper.Reset()
+		defer config.Reset()
 		defer ResetOriginExports()
 		exports := setup(t, s3singleExportBlockConfig)
 		assert.Len(t, exports, 1, "expected 1 export")

--- a/server_utils/registry_test.go
+++ b/server_utils/registry_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestGetNSIssuerURL(t *testing.T) {
-	config.Reset()
+	Reset()
 	viper.Set("ConfigDir", t.TempDir())
 	config.InitConfig()
 	require.NoError(t, config.InitClient())
@@ -39,11 +39,11 @@ func TestGetNSIssuerURL(t *testing.T) {
 	url, err := GetNSIssuerURL("/test-prefix")
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "https://registry.com:8446/api/v1.0/registry/test-prefix", url)
-	config.Reset()
+	Reset()
 }
 
 func TestGetJWKSURLFromIssuerURL(t *testing.T) {
-	config.Reset()
+	Reset()
 	viper.Set("ConfigDir", t.TempDir())
 	config.InitConfig()
 	require.NoError(t, config.InitClient())

--- a/server_utils/registry_test.go
+++ b/server_utils/registry_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestGetNSIssuerURL(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	viper.Set("ConfigDir", t.TempDir())
 	config.InitConfig()
 	require.NoError(t, config.InitClient())
@@ -39,11 +39,11 @@ func TestGetNSIssuerURL(t *testing.T) {
 	url, err := GetNSIssuerURL("/test-prefix")
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "https://registry.com:8446/api/v1.0/registry/test-prefix", url)
-	viper.Reset()
+	config.Reset()
 }
 
 func TestGetJWKSURLFromIssuerURL(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	viper.Set("ConfigDir", t.TempDir())
 	config.InitConfig()
 	require.NoError(t, config.InitClient())

--- a/server_utils/server_utils.go
+++ b/server_utils/server_utils.go
@@ -271,3 +271,8 @@ func LaunchWatcherMaintenance(ctx context.Context, dirPaths []string, descriptio
 		}
 	})
 }
+
+func Reset() {
+	config.ResetConfig()
+	ResetOriginExports()
+}

--- a/test_utils/utils.go
+++ b/test_utils/utils.go
@@ -191,8 +191,8 @@ func RegistryMockup(t *testing.T, prefix string) *httptest.Server {
 // avoid pulling in global configuration) and set some arbitrary
 // viper configurations
 func InitClient(t *testing.T, initCfg map[string]any) {
-	viper.Reset()
-	t.Cleanup(viper.Reset)
+	config.Reset()
+	t.Cleanup(config.Reset)
 	viper.Set("ConfigDir", t.TempDir())
 	for key, val := range initCfg {
 		viper.Set(key, val)

--- a/test_utils/utils.go
+++ b/test_utils/utils.go
@@ -191,8 +191,8 @@ func RegistryMockup(t *testing.T, prefix string) *httptest.Server {
 // avoid pulling in global configuration) and set some arbitrary
 // viper configurations
 func InitClient(t *testing.T, initCfg map[string]any) {
-	config.Reset()
-	t.Cleanup(config.Reset)
+	config.ResetConfig()
+	t.Cleanup(config.ResetConfig)
 	viper.Set("ConfigDir", t.TempDir())
 	for key, val := range initCfg {
 		viper.Set(key, val)

--- a/token/token_create_test.go
+++ b/token/token_create_test.go
@@ -205,7 +205,7 @@ func TestCreateToken(t *testing.T) {
 	defer cancel()
 
 	// Some viper pre-requisites
-	config.Reset()
+	config.ResetConfig()
 	viper.Set("IssuerUrl", "https://my-issuer.com")
 	tDir := t.TempDir()
 	kfile := filepath.Join(tDir, "testKey")

--- a/token/token_create_test.go
+++ b/token/token_create_test.go
@@ -205,7 +205,7 @@ func TestCreateToken(t *testing.T) {
 	defer cancel()
 
 	// Some viper pre-requisites
-	viper.Reset()
+	config.Reset()
 	viper.Set("IssuerUrl", "https://my-issuer.com")
 	tDir := t.TempDir()
 	kfile := filepath.Join(tDir, "testKey")

--- a/web_ui/authentication_test.go
+++ b/web_ui/authentication_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
@@ -53,7 +54,7 @@ func TestWaitUntilLogin(t *testing.T) {
 	defer cancel()
 
 	dirName := t.TempDir()
-	config.Reset()
+	server_utils.Reset()
 	viper.Set("ConfigDir", dirName)
 	config.InitConfig()
 	err := config.InitServer(ctx, server_structs.OriginType)
@@ -102,7 +103,7 @@ func TestCodeBasedLogin(t *testing.T) {
 	defer cancel()
 
 	dirName := t.TempDir()
-	config.Reset()
+	server_utils.Reset()
 	viper.Set("ConfigDir", dirName)
 	config.InitConfig()
 	err := config.InitServer(ctx, server_structs.OriginType)
@@ -158,7 +159,7 @@ func TestPasswordResetAPI(t *testing.T) {
 	defer cancel()
 
 	dirName := t.TempDir()
-	config.Reset()
+	server_utils.Reset()
 	viper.Set("ConfigDir", dirName)
 	viper.Set("Origin.Port", 8443)
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
@@ -300,7 +301,7 @@ func TestPasswordBasedLoginAPI(t *testing.T) {
 	defer cancel()
 
 	dirName := t.TempDir()
-	config.Reset()
+	server_utils.Reset()
 	viper.Set("ConfigDir", dirName)
 	config.InitConfig()
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
@@ -418,7 +419,7 @@ func TestWhoamiAPI(t *testing.T) {
 	defer cancel()
 
 	dirName := t.TempDir()
-	config.Reset()
+	server_utils.Reset()
 	config.InitConfig()
 	viper.Set("ConfigDir", dirName)
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
@@ -585,7 +586,7 @@ func TestAdminAuthHandler(t *testing.T) {
 			if tc.expectedError != "" {
 				assert.Contains(t, w.Body.String(), tc.expectedError)
 			}
-			config.Reset()
+			server_utils.Reset()
 		})
 	}
 }
@@ -596,7 +597,7 @@ func TestLogoutAPI(t *testing.T) {
 	defer cancel()
 
 	dirName := t.TempDir()
-	config.Reset()
+	server_utils.Reset()
 	config.InitConfig()
 	viper.Set("ConfigDir", dirName)
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
@@ -677,10 +678,10 @@ func TestListOIDCEnabledServersHandler(t *testing.T) {
 	router := gin.New()
 	router.GET("/oauth", listOIDCEnabledServersHandler)
 	t.Cleanup(func() {
-		config.Reset()
+		server_utils.Reset()
 	})
 	t.Run("registry-included-by-default", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		expected := OIDCEnabledServerRes{ODICEnabledServers: []string{"registry"}}
 		req, err := http.NewRequest("GET", "/oauth", nil)
 		assert.NoError(t, err)
@@ -701,7 +702,7 @@ func TestListOIDCEnabledServersHandler(t *testing.T) {
 	})
 
 	t.Run("origin-included-if-flag-is-on", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		viper.Set("Origin.EnableOIDC", true)
 		expected := OIDCEnabledServerRes{ODICEnabledServers: []string{"registry", "origin"}}
 		req, err := http.NewRequest("GET", "/oauth", nil)
@@ -723,7 +724,7 @@ func TestListOIDCEnabledServersHandler(t *testing.T) {
 	})
 
 	t.Run("cache-included-if-flag-is-on", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		viper.Set("Cache.EnableOIDC", true)
 		expected := OIDCEnabledServerRes{ODICEnabledServers: []string{"registry", "cache"}}
 		req, err := http.NewRequest("GET", "/oauth", nil)
@@ -745,7 +746,7 @@ func TestListOIDCEnabledServersHandler(t *testing.T) {
 	})
 
 	t.Run("director-included-if-flag-is-on", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		viper.Set("Director.EnableOIDC", true)
 		expected := OIDCEnabledServerRes{ODICEnabledServers: []string{"registry", "director"}}
 		req, err := http.NewRequest("GET", "/oauth", nil)
@@ -767,7 +768,7 @@ func TestListOIDCEnabledServersHandler(t *testing.T) {
 	})
 
 	t.Run("origin-cache-both-included-if-flags-are-on", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		viper.Set("Origin.EnableOIDC", true)
 		viper.Set("Cache.EnableOIDC", true)
 		viper.Set("Director.EnableOIDC", true)

--- a/web_ui/authentication_test.go
+++ b/web_ui/authentication_test.go
@@ -53,7 +53,7 @@ func TestWaitUntilLogin(t *testing.T) {
 	defer cancel()
 
 	dirName := t.TempDir()
-	viper.Reset()
+	config.Reset()
 	viper.Set("ConfigDir", dirName)
 	config.InitConfig()
 	err := config.InitServer(ctx, server_structs.OriginType)
@@ -102,7 +102,7 @@ func TestCodeBasedLogin(t *testing.T) {
 	defer cancel()
 
 	dirName := t.TempDir()
-	viper.Reset()
+	config.Reset()
 	viper.Set("ConfigDir", dirName)
 	config.InitConfig()
 	err := config.InitServer(ctx, server_structs.OriginType)
@@ -158,7 +158,7 @@ func TestPasswordResetAPI(t *testing.T) {
 	defer cancel()
 
 	dirName := t.TempDir()
-	viper.Reset()
+	config.Reset()
 	viper.Set("ConfigDir", dirName)
 	viper.Set("Origin.Port", 8443)
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
@@ -300,7 +300,7 @@ func TestPasswordBasedLoginAPI(t *testing.T) {
 	defer cancel()
 
 	dirName := t.TempDir()
-	viper.Reset()
+	config.Reset()
 	viper.Set("ConfigDir", dirName)
 	config.InitConfig()
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
@@ -418,7 +418,7 @@ func TestWhoamiAPI(t *testing.T) {
 	defer cancel()
 
 	dirName := t.TempDir()
-	viper.Reset()
+	config.Reset()
 	config.InitConfig()
 	viper.Set("ConfigDir", dirName)
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
@@ -585,7 +585,7 @@ func TestAdminAuthHandler(t *testing.T) {
 			if tc.expectedError != "" {
 				assert.Contains(t, w.Body.String(), tc.expectedError)
 			}
-			viper.Reset()
+			config.Reset()
 		})
 	}
 }
@@ -596,7 +596,7 @@ func TestLogoutAPI(t *testing.T) {
 	defer cancel()
 
 	dirName := t.TempDir()
-	viper.Reset()
+	config.Reset()
 	config.InitConfig()
 	viper.Set("ConfigDir", dirName)
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
@@ -677,10 +677,10 @@ func TestListOIDCEnabledServersHandler(t *testing.T) {
 	router := gin.New()
 	router.GET("/oauth", listOIDCEnabledServersHandler)
 	t.Cleanup(func() {
-		viper.Reset()
+		config.Reset()
 	})
 	t.Run("registry-included-by-default", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		expected := OIDCEnabledServerRes{ODICEnabledServers: []string{"registry"}}
 		req, err := http.NewRequest("GET", "/oauth", nil)
 		assert.NoError(t, err)
@@ -701,7 +701,7 @@ func TestListOIDCEnabledServersHandler(t *testing.T) {
 	})
 
 	t.Run("origin-included-if-flag-is-on", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		viper.Set("Origin.EnableOIDC", true)
 		expected := OIDCEnabledServerRes{ODICEnabledServers: []string{"registry", "origin"}}
 		req, err := http.NewRequest("GET", "/oauth", nil)
@@ -723,7 +723,7 @@ func TestListOIDCEnabledServersHandler(t *testing.T) {
 	})
 
 	t.Run("cache-included-if-flag-is-on", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		viper.Set("Cache.EnableOIDC", true)
 		expected := OIDCEnabledServerRes{ODICEnabledServers: []string{"registry", "cache"}}
 		req, err := http.NewRequest("GET", "/oauth", nil)
@@ -745,7 +745,7 @@ func TestListOIDCEnabledServersHandler(t *testing.T) {
 	})
 
 	t.Run("director-included-if-flag-is-on", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		viper.Set("Director.EnableOIDC", true)
 		expected := OIDCEnabledServerRes{ODICEnabledServers: []string{"registry", "director"}}
 		req, err := http.NewRequest("GET", "/oauth", nil)
@@ -767,7 +767,7 @@ func TestListOIDCEnabledServersHandler(t *testing.T) {
 	})
 
 	t.Run("origin-cache-both-included-if-flags-are-on", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		viper.Set("Origin.EnableOIDC", true)
 		viper.Set("Cache.EnableOIDC", true)
 		viper.Set("Director.EnableOIDC", true)

--- a/web_ui/engine_test.go
+++ b/web_ui/engine_test.go
@@ -48,7 +48,7 @@ import (
 // Setup a gin engine that will serve up a /ping endpoint on a Unix domain socket.
 func setupPingEngine(t *testing.T, ctx context.Context, egrp *errgroup.Group) (chan bool, context.CancelFunc, string) {
 	dirname := t.TempDir()
-	viper.Reset()
+	config.Reset()
 	viper.Set("Logging.Level", "Debug")
 	viper.Set("ConfigDir", dirname)
 	viper.Set("Server.WebPort", 8444)

--- a/web_ui/engine_test.go
+++ b/web_ui/engine_test.go
@@ -42,13 +42,14 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
 )
 
 // Setup a gin engine that will serve up a /ping endpoint on a Unix domain socket.
 func setupPingEngine(t *testing.T, ctx context.Context, egrp *errgroup.Group) (chan bool, context.CancelFunc, string) {
 	dirname := t.TempDir()
-	config.Reset()
+	server_utils.Reset()
 	viper.Set("Logging.Level", "Debug")
 	viper.Set("ConfigDir", dirname)
 	viper.Set("Server.WebPort", 8444)

--- a/web_ui/prometheus_test.go
+++ b/web_ui/prometheus_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
@@ -49,7 +50,7 @@ func TestPrometheusUnprotected(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	config.Reset()
+	server_utils.Reset()
 
 	av1 := route.New().WithPrefix("/api/v1.0/prometheus")
 	av1.Get("/query", func(w http.ResponseWriter, r *http.Request) {
@@ -102,7 +103,7 @@ func TestPrometheusProtectionCookieAuth(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	config.Reset()
+	server_utils.Reset()
 
 	av1 := route.New().WithPrefix("/api/v1.0/prometheus")
 
@@ -161,7 +162,7 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	config.Reset()
+	server_utils.Reset()
 	viper.Set("Server.ExternalWebUrl", "https://test-origin.org:8444")
 	viper.Set("Monitoring.PromQLAuthorization", true)
 

--- a/web_ui/prometheus_test.go
+++ b/web_ui/prometheus_test.go
@@ -49,7 +49,7 @@ func TestPrometheusUnprotected(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	viper.Reset()
+	config.Reset()
 
 	av1 := route.New().WithPrefix("/api/v1.0/prometheus")
 	av1.Get("/query", func(w http.ResponseWriter, r *http.Request) {
@@ -102,7 +102,7 @@ func TestPrometheusProtectionCookieAuth(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	viper.Reset()
+	config.Reset()
 
 	av1 := route.New().WithPrefix("/api/v1.0/prometheus")
 
@@ -161,7 +161,7 @@ func TestPrometheusProtectionOriginHeaderScope(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	viper.Reset()
+	config.Reset()
 	viper.Set("Server.ExternalWebUrl", "https://test-origin.org:8444")
 	viper.Set("Monitoring.PromQLAuthorization", true)
 

--- a/web_ui/ui_test.go
+++ b/web_ui/ui_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
 )
@@ -208,12 +209,12 @@ func TestHandleWebUIAuth(t *testing.T) {
 	})
 
 	t.Run("403-for-logged-in-non-admin-user", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		// We let the frontend to handle unauthorized user (if the password is initialzied)
 		setupTestAuthDB(t)
 		t.Cleanup(func() {
 			cleanupAuthDB()
-			config.Reset()
+			server_utils.Reset()
 		})
 
 		tmpDir := t.TempDir()

--- a/web_ui/ui_test.go
+++ b/web_ui/ui_test.go
@@ -208,12 +208,12 @@ func TestHandleWebUIAuth(t *testing.T) {
 	})
 
 	t.Run("403-for-logged-in-non-admin-user", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		// We let the frontend to handle unauthorized user (if the password is initialzied)
 		setupTestAuthDB(t)
 		t.Cleanup(func() {
 			cleanupAuthDB()
-			viper.Reset()
+			config.Reset()
 		})
 
 		tmpDir := t.TempDir()

--- a/web_ui/ui_unix_test.go
+++ b/web_ui/ui_unix_test.go
@@ -25,18 +25,17 @@ import (
 	"path"
 	"testing"
 
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tg123/go-htpasswd"
-	
-	"github.com/pelicanplatform/pelican/config"
 )
 
 func TestDoReload(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	savedAuthDB := authDB.Load()
 	authDB.Store(nil)
 	defer authDB.Store(savedAuthDB)

--- a/web_ui/ui_unix_test.go
+++ b/web_ui/ui_unix_test.go
@@ -31,10 +31,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tg123/go-htpasswd"
+	
+	"github.com/pelicanplatform/pelican/config"
 )
 
 func TestDoReload(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	savedAuthDB := authDB.Load()
 	authDB.Store(nil)
 	defer authDB.Store(savedAuthDB)

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -164,7 +164,7 @@ func TestOSDFAuthRetrieval(t *testing.T) {
 		transport.TLSClientConfig = oldConfig
 	})
 
-	config.Reset()
+	server_utils.Reset()
 	viper.Set("Federation.TopologyUrl", "https://topology.opensciencegrid.org/")
 	viper.Set("Server.Hostname", "sc-origin.chtc.wisc.edu")
 
@@ -172,7 +172,7 @@ func TestOSDFAuthRetrieval(t *testing.T) {
 	_, err := getOSDFAuthFiles(originServer)
 
 	require.NoError(t, err, "error")
-	config.Reset()
+	server_utils.Reset()
 }
 
 func TestOSDFAuthCreation(t *testing.T) {
@@ -261,10 +261,9 @@ func TestOSDFAuthCreation(t *testing.T) {
 	for _, testInput := range tests {
 		t.Run(testInput.desc, func(t *testing.T) {
 			dirName := t.TempDir()
-			config.Reset()
-			server_utils.ResetOriginExports()
-			defer config.Reset()
-			defer server_utils.ResetOriginExports()
+			server_utils.Reset()
+
+			defer server_utils.Reset()
 
 			viper.Set("Xrootd.Authfile", filepath.Join(dirName, "authfile"))
 			viper.Set("Federation.TopologyUrl", ts.URL)
@@ -301,7 +300,7 @@ func TestOSDFAuthCreation(t *testing.T) {
 			require.NoError(t, err, "Error reading generated authfile")
 
 			require.Equal(t, testInput.authOut, string(genAuth))
-			config.Reset()
+			server_utils.Reset()
 		})
 	}
 }
@@ -338,10 +337,10 @@ func TestEmitAuthfile(t *testing.T) {
 	for _, testInput := range tests {
 		t.Run(testInput.desc, func(t *testing.T) {
 			dirName := t.TempDir()
-			config.Reset()
-			server_utils.ResetOriginExports()
-			defer config.Reset()
-			defer server_utils.ResetOriginExports()
+			server_utils.Reset()
+
+			defer server_utils.Reset()
+
 			viper.Set("Xrootd.Authfile", filepath.Join(dirName, "authfile"))
 			viper.Set("Origin.RunLocation", dirName)
 			viper.Set("Origin.FederationPrefix", "/")
@@ -364,10 +363,10 @@ func TestEmitAuthfile(t *testing.T) {
 
 func TestEmitCfg(t *testing.T) {
 	dirname := t.TempDir()
-	config.Reset()
-	server_utils.ResetOriginExports()
-	defer config.Reset()
-	defer server_utils.ResetOriginExports()
+	server_utils.Reset()
+
+	defer server_utils.Reset()
+
 	viper.Set("Origin.RunLocation", dirname)
 	err := config.InitClient()
 	assert.Nil(t, err)
@@ -444,10 +443,10 @@ func TestDeduplicateBasePaths(t *testing.T) {
 
 func TestLoadScitokensConfig(t *testing.T) {
 	dirname := t.TempDir()
-	config.Reset()
-	server_utils.ResetOriginExports()
-	defer config.Reset()
-	defer server_utils.ResetOriginExports()
+	server_utils.Reset()
+
+	defer server_utils.Reset()
+
 	viper.Set("Origin.RunLocation", dirname)
 	err := config.InitClient()
 	assert.Nil(t, err)
@@ -479,10 +478,10 @@ func TestLoadScitokensConfig(t *testing.T) {
 // Test that merging the configuration works without throwing any errors
 func TestMergeConfig(t *testing.T) {
 	dirname := t.TempDir()
-	config.Reset()
-	server_utils.ResetOriginExports()
-	defer config.Reset()
-	defer server_utils.ResetOriginExports()
+	server_utils.Reset()
+
+	defer server_utils.Reset()
+
 	viper.Set("Origin.RunLocation", dirname)
 	viper.Set("Origin.Port", 8443)
 	viper.Set("Origin.StoragePrefix", "/")
@@ -528,10 +527,10 @@ func TestGenerateConfig(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	config.Reset()
-	server_utils.ResetOriginExports()
-	defer config.Reset()
-	defer server_utils.ResetOriginExports()
+	server_utils.Reset()
+
+	defer server_utils.Reset()
+
 	viper.Set("Origin.SelfTest", false)
 	issuer, err := GenerateMonitoringIssuer()
 	require.NoError(t, err)
@@ -553,7 +552,7 @@ func TestGenerateConfig(t *testing.T) {
 	assert.Equal(t, "/pelican/monitoring", issuer.BasePaths[0])
 	assert.Equal(t, "xrootd", issuer.DefaultUser)
 
-	config.Reset()
+	server_utils.Reset()
 	viper.Set("Origin.SelfTest", false)
 	viper.Set("Origin.ScitokensDefaultUser", "user1")
 	viper.Set("Origin.ScitokensMapSubject", true)
@@ -575,12 +574,12 @@ func TestGenerateConfig(t *testing.T) {
 }
 
 func TestWriteOriginAuthFiles(t *testing.T) {
-	config.Reset()
-	server_utils.ResetOriginExports()
+	server_utils.Reset()
+
 	originAuthTester := func(server server_structs.XRootDServer, authStart string, authResult string) func(t *testing.T) {
 		return func(t *testing.T) {
-			defer config.Reset()
-			defer server_utils.ResetOriginExports()
+			defer server_utils.Reset()
+
 			viper.Set("Origin.StorageType", "posix")
 			dirname := t.TempDir()
 			viper.Set("Origin.RunLocation", dirname)
@@ -626,7 +625,7 @@ func TestWriteCacheAuthFiles(t *testing.T) {
 		return func(t *testing.T) {
 
 			dirname := t.TempDir()
-			config.Reset()
+			server_utils.Reset()
 			viper.Set("Cache.RunLocation", dirname)
 			if server.GetServerType().IsEnabled(server_structs.OriginType) {
 				viper.Set("Xrootd.ScitokensConfig", filepath.Join(dirname, "scitokens-origin-generated.cfg"))
@@ -735,7 +734,7 @@ func TestWriteOriginScitokensConfig(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	config.Reset()
+	server_utils.Reset()
 	dirname := t.TempDir()
 	os.Setenv("PELICAN_ORIGIN_RUNLOCATION", dirname)
 	defer os.Unsetenv("PELICAN_ORIGIN_RUNLOCATION")

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -164,7 +164,7 @@ func TestOSDFAuthRetrieval(t *testing.T) {
 		transport.TLSClientConfig = oldConfig
 	})
 
-	viper.Reset()
+	config.Reset()
 	viper.Set("Federation.TopologyUrl", "https://topology.opensciencegrid.org/")
 	viper.Set("Server.Hostname", "sc-origin.chtc.wisc.edu")
 
@@ -172,7 +172,7 @@ func TestOSDFAuthRetrieval(t *testing.T) {
 	_, err := getOSDFAuthFiles(originServer)
 
 	require.NoError(t, err, "error")
-	viper.Reset()
+	config.Reset()
 }
 
 func TestOSDFAuthCreation(t *testing.T) {
@@ -261,9 +261,9 @@ func TestOSDFAuthCreation(t *testing.T) {
 	for _, testInput := range tests {
 		t.Run(testInput.desc, func(t *testing.T) {
 			dirName := t.TempDir()
-			viper.Reset()
+			config.Reset()
 			server_utils.ResetOriginExports()
-			defer viper.Reset()
+			defer config.Reset()
 			defer server_utils.ResetOriginExports()
 
 			viper.Set("Xrootd.Authfile", filepath.Join(dirName, "authfile"))
@@ -301,7 +301,7 @@ func TestOSDFAuthCreation(t *testing.T) {
 			require.NoError(t, err, "Error reading generated authfile")
 
 			require.Equal(t, testInput.authOut, string(genAuth))
-			viper.Reset()
+			config.Reset()
 		})
 	}
 }
@@ -338,9 +338,9 @@ func TestEmitAuthfile(t *testing.T) {
 	for _, testInput := range tests {
 		t.Run(testInput.desc, func(t *testing.T) {
 			dirName := t.TempDir()
-			viper.Reset()
+			config.Reset()
 			server_utils.ResetOriginExports()
-			defer viper.Reset()
+			defer config.Reset()
 			defer server_utils.ResetOriginExports()
 			viper.Set("Xrootd.Authfile", filepath.Join(dirName, "authfile"))
 			viper.Set("Origin.RunLocation", dirName)
@@ -364,9 +364,9 @@ func TestEmitAuthfile(t *testing.T) {
 
 func TestEmitCfg(t *testing.T) {
 	dirname := t.TempDir()
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
-	defer viper.Reset()
+	defer config.Reset()
 	defer server_utils.ResetOriginExports()
 	viper.Set("Origin.RunLocation", dirname)
 	err := config.InitClient()
@@ -444,9 +444,9 @@ func TestDeduplicateBasePaths(t *testing.T) {
 
 func TestLoadScitokensConfig(t *testing.T) {
 	dirname := t.TempDir()
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
-	defer viper.Reset()
+	defer config.Reset()
 	defer server_utils.ResetOriginExports()
 	viper.Set("Origin.RunLocation", dirname)
 	err := config.InitClient()
@@ -479,9 +479,9 @@ func TestLoadScitokensConfig(t *testing.T) {
 // Test that merging the configuration works without throwing any errors
 func TestMergeConfig(t *testing.T) {
 	dirname := t.TempDir()
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
-	defer viper.Reset()
+	defer config.Reset()
 	defer server_utils.ResetOriginExports()
 	viper.Set("Origin.RunLocation", dirname)
 	viper.Set("Origin.Port", 8443)
@@ -528,9 +528,9 @@ func TestGenerateConfig(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
-	defer viper.Reset()
+	defer config.Reset()
 	defer server_utils.ResetOriginExports()
 	viper.Set("Origin.SelfTest", false)
 	issuer, err := GenerateMonitoringIssuer()
@@ -553,7 +553,7 @@ func TestGenerateConfig(t *testing.T) {
 	assert.Equal(t, "/pelican/monitoring", issuer.BasePaths[0])
 	assert.Equal(t, "xrootd", issuer.DefaultUser)
 
-	viper.Reset()
+	config.Reset()
 	viper.Set("Origin.SelfTest", false)
 	viper.Set("Origin.ScitokensDefaultUser", "user1")
 	viper.Set("Origin.ScitokensMapSubject", true)
@@ -575,11 +575,11 @@ func TestGenerateConfig(t *testing.T) {
 }
 
 func TestWriteOriginAuthFiles(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
 	originAuthTester := func(server server_structs.XRootDServer, authStart string, authResult string) func(t *testing.T) {
 		return func(t *testing.T) {
-			defer viper.Reset()
+			defer config.Reset()
 			defer server_utils.ResetOriginExports()
 			viper.Set("Origin.StorageType", "posix")
 			dirname := t.TempDir()
@@ -626,7 +626,7 @@ func TestWriteCacheAuthFiles(t *testing.T) {
 		return func(t *testing.T) {
 
 			dirname := t.TempDir()
-			viper.Reset()
+			config.Reset()
 			viper.Set("Cache.RunLocation", dirname)
 			if server.GetServerType().IsEnabled(server_structs.OriginType) {
 				viper.Set("Xrootd.ScitokensConfig", filepath.Join(dirname, "scitokens-origin-generated.cfg"))
@@ -735,7 +735,7 @@ func TestWriteOriginScitokensConfig(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	viper.Reset()
+	config.Reset()
 	dirname := t.TempDir()
 	os.Setenv("PELICAN_ORIGIN_RUNLOCATION", dirname)
 	defer os.Unsetenv("PELICAN_ORIGIN_RUNLOCATION")

--- a/xrootd/fed_test.go
+++ b/xrootd/fed_test.go
@@ -50,10 +50,10 @@ var (
 )
 
 func TestHttpOriginConfig(t *testing.T) {
-	viper.Reset()
+	config.Reset()
 	viper.Set("ConfigDir", t.TempDir())
 	server_utils.ResetOriginExports()
-	defer viper.Reset()
+	defer config.Reset()
 	defer server_utils.ResetOriginExports()
 
 	body := "Hello, World!"

--- a/xrootd/fed_test.go
+++ b/xrootd/fed_test.go
@@ -50,11 +50,10 @@ var (
 )
 
 func TestHttpOriginConfig(t *testing.T) {
-	config.Reset()
+	server_utils.Reset()
 	viper.Set("ConfigDir", t.TempDir())
 	server_utils.ResetOriginExports()
-	defer config.Reset()
-	defer server_utils.ResetOriginExports()
+	defer server_utils.Reset()
 
 	body := "Hello, World!"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/xrootd/origin_test.go
+++ b/xrootd/origin_test.go
@@ -152,10 +152,9 @@ func TestOrigin(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	config.Reset()
-	server_utils.ResetOriginExports()
-	defer config.Reset()
-	defer server_utils.ResetOriginExports()
+	server_utils.Reset()
+
+	defer server_utils.Reset()
 
 	viper.Set("Origin.StoragePrefix", t.TempDir())
 	viper.Set("Origin.FederationPrefix", "/test")
@@ -191,10 +190,8 @@ func TestMultiExportOrigin(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	config.Reset()
-	defer config.Reset()
-	server_utils.ResetOriginExports()
-	defer server_utils.ResetOriginExports()
+	server_utils.Reset()
+	defer server_utils.Reset()
 
 	viper.SetConfigType("yaml")
 	// Use viper to read in the embedded config
@@ -239,10 +236,10 @@ func runS3Test(t *testing.T, bucketName, urlStyle, objectName string) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	config.Reset()
-	server_utils.ResetOriginExports()
-	defer config.Reset()
-	defer server_utils.ResetOriginExports()
+	server_utils.Reset()
+
+	defer server_utils.Reset()
+
 	federationPrefix := "/test"
 	regionName := "us-east-1"
 	serviceUrl := "https://s3.amazonaws.com"

--- a/xrootd/origin_test.go
+++ b/xrootd/origin_test.go
@@ -152,9 +152,9 @@ func TestOrigin(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
-	defer viper.Reset()
+	defer config.Reset()
 	defer server_utils.ResetOriginExports()
 
 	viper.Set("Origin.StoragePrefix", t.TempDir())
@@ -191,8 +191,8 @@ func TestMultiExportOrigin(t *testing.T) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	viper.Reset()
-	defer viper.Reset()
+	config.Reset()
+	defer config.Reset()
 	server_utils.ResetOriginExports()
 	defer server_utils.ResetOriginExports()
 
@@ -239,9 +239,9 @@ func runS3Test(t *testing.T, bucketName, urlStyle, objectName string) {
 	defer func() { require.NoError(t, egrp.Wait()) }()
 	defer cancel()
 
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
-	defer viper.Reset()
+	defer config.Reset()
 	defer server_utils.ResetOriginExports()
 	federationPrefix := "/test"
 	regionName := "us-east-1"

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -52,7 +52,7 @@ type xrootdTest struct {
 }
 
 func (x *xrootdTest) setup() {
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
 	dirname, err := os.MkdirTemp("", "tmpDir")
 	require.NoError(x.T, err)
@@ -83,9 +83,9 @@ func TestXrootDOriginConfig(t *testing.T) {
 	t.Cleanup(func() {
 		os.RemoveAll(dirname)
 	})
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
-	defer viper.Reset()
+	defer config.Reset()
 	defer server_utils.ResetOriginExports()
 	viper.Set("Configdir", dirname)
 	viper.Set("Origin.RunLocation", dirname)
@@ -117,7 +117,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "cms.trace debug")
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("TestOriginCmsIncorrectConfig", func(t *testing.T) {
@@ -131,7 +131,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		configPath, err := ConfigXrootd(ctx, true)
 		require.Error(t, err)
 		assert.NotNil(t, configPath)
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("TestOriginScitokensCorrectConfig", func(t *testing.T) {
@@ -154,7 +154,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "scitokens.trace debug")
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("TestOriginScitokensIncorrectConfig", func(t *testing.T) {
@@ -168,7 +168,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		configPath, err := ConfigXrootd(ctx, true)
 		require.Error(t, err)
 		assert.NotNil(t, configPath)
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("TestOriginXrdCorrectConfig", func(t *testing.T) {
@@ -191,7 +191,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "xrd.trace debug")
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("TestOriginXrdIncorrectConfig", func(t *testing.T) {
@@ -205,7 +205,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		configPath, err := ConfigXrootd(ctx, true)
 		require.Error(t, err)
 		assert.NotNil(t, configPath)
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("TestOriginXrootdCorrectConfig", func(t *testing.T) {
@@ -228,7 +228,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "xrootd.trace debug")
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("TestOriginXrootdIncorrectConfig", func(t *testing.T) {
@@ -242,7 +242,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		configPath, err := ConfigXrootd(ctx, true)
 		require.Error(t, err)
 		assert.NotNil(t, configPath)
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("TestOsdfWithXRDHOSTAndPort", func(t *testing.T) {
@@ -259,7 +259,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		assert.NotNil(t, configPath)
 		assert.Equal(t, "my-xrootd.com", os.Getenv("XRDHOST"))
 
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("TestOsdfWithXRDHOSTAndNoPort", func(t *testing.T) {
@@ -276,7 +276,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		assert.NotNil(t, configPath)
 		assert.Equal(t, "my-xrootd.com", os.Getenv("XRDHOST"))
 
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("TestPelicanWithXRDHOST", func(t *testing.T) {
@@ -294,7 +294,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		_, xrdhostIsSet := os.LookupEnv("XRDHOST")
 		assert.False(t, xrdhostIsSet, "XRDHOST should only be set in OSDF mode")
 
-		viper.Reset()
+		config.Reset()
 	})
 }
 
@@ -308,7 +308,7 @@ func TestXrootDCacheConfig(t *testing.T) {
 	t.Cleanup(func() {
 		os.RemoveAll(dirname)
 	})
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
 	viper.Set("Cache.RunLocation", dirname)
 	viper.Set("ConfigDir", dirname)
@@ -318,7 +318,7 @@ func TestXrootDCacheConfig(t *testing.T) {
 	assert.NotNil(t, configPath)
 
 	t.Run("TestCacheThrottlePluginEnabled", func(t *testing.T) {
-		defer viper.Reset()
+		defer config.Reset()
 		defer server_utils.ResetOriginExports()
 		xrootd := xrootdTest{T: t}
 		xrootd.setup()
@@ -343,7 +343,7 @@ func TestXrootDCacheConfig(t *testing.T) {
 	})
 
 	t.Run("TestCacheThrottlePluginDisabled", func(t *testing.T) {
-		defer viper.Reset()
+		defer config.Reset()
 		defer server_utils.ResetOriginExports()
 		xrootd := xrootdTest{T: t}
 		xrootd.setup()
@@ -384,7 +384,7 @@ func TestXrootDCacheConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "ofs.trace debug")
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("TestCacheOfsIncorrectConfig", func(t *testing.T) {
@@ -420,7 +420,7 @@ func TestXrootDCacheConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "pfc.trace debug")
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("TestCachePfcIncorrectConfig", func(t *testing.T) {
@@ -434,7 +434,7 @@ func TestXrootDCacheConfig(t *testing.T) {
 		configPath, err := ConfigXrootd(ctx, true)
 		require.Error(t, err)
 		assert.NotNil(t, configPath)
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("TestCachePssCorrectConfig", func(t *testing.T) {
@@ -457,7 +457,7 @@ func TestXrootDCacheConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "pss.setopt DebugLevel 4")
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("TestCachePssIncorrectConfig", func(t *testing.T) {
@@ -493,7 +493,7 @@ func TestXrootDCacheConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "scitokens.trace debug")
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("TestCacheScitokensIncorrectConfig", func(t *testing.T) {
@@ -529,7 +529,7 @@ func TestXrootDCacheConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "xrd.trace debug")
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("TestCacheXrdIncorrectConfig", func(t *testing.T) {
@@ -565,7 +565,7 @@ func TestXrootDCacheConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "xrootd.trace debug")
-		viper.Reset()
+		config.Reset()
 	})
 
 	t.Run("TestCacheXrootdIncorrectConfig", func(t *testing.T) {
@@ -589,9 +589,9 @@ func TestUpdateAuth(t *testing.T) {
 
 	runDirname := t.TempDir()
 	configDirname := t.TempDir()
-	viper.Reset()
+	config.Reset()
 	server_utils.ResetOriginExports()
-	defer viper.Reset()
+	defer config.Reset()
 	defer server_utils.ResetOriginExports()
 	viper.Set("Logging.Level", "Debug")
 	viper.Set("Origin.RunLocation", runDirname)
@@ -686,7 +686,7 @@ func TestCopyCertificates(t *testing.T) {
 
 	runDirname := t.TempDir()
 	configDirname := t.TempDir()
-	viper.Reset()
+	config.Reset()
 	viper.Set("Logging.Level", "Debug")
 	viper.Set("Origin.RunLocation", runDirname)
 	viper.Set("ConfigDir", configDirname)
@@ -770,9 +770,9 @@ func TestCopyCertificates(t *testing.T) {
 }
 
 func TestAuthIntervalUnmarshal(t *testing.T) {
-	defer viper.Reset()
+	defer config.Reset()
 	t.Run("test-minutes-to-seconds", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		var xrdConfig XrootdConfig
 		viper.Set("Xrootd.AuthRefreshInterval", "5m")
 		err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc()))
@@ -781,7 +781,7 @@ func TestAuthIntervalUnmarshal(t *testing.T) {
 	})
 
 	t.Run("test-hours-to-seconds", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		var xrdConfig XrootdConfig
 		viper.Set("Xrootd.AuthRefreshInterval", "24h")
 		err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc()))
@@ -790,7 +790,7 @@ func TestAuthIntervalUnmarshal(t *testing.T) {
 	})
 
 	t.Run("test-seconds-to-seconds", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		var xrdConfig XrootdConfig
 		viper.Set("Xrootd.AuthRefreshInterval", "100s")
 		err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc()))
@@ -799,7 +799,7 @@ func TestAuthIntervalUnmarshal(t *testing.T) {
 	})
 
 	t.Run("test-less-than-60s", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		var xrdConfig XrootdConfig
 		viper.Set("Xrootd.AuthRefreshInterval", "10")
 		err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc()))
@@ -809,7 +809,7 @@ func TestAuthIntervalUnmarshal(t *testing.T) {
 	})
 
 	t.Run("test-no-suffix-to-seconds", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		var xrdConfig XrootdConfig
 		viper.Set("Xrootd.AuthRefreshInterval", "99")
 		err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc()))
@@ -818,7 +818,7 @@ func TestAuthIntervalUnmarshal(t *testing.T) {
 	})
 
 	t.Run("test-less-than-second", func(t *testing.T) {
-		viper.Reset()
+		config.Reset()
 		var xrdConfig XrootdConfig
 		viper.Set("Xrootd.AuthRefreshInterval", "0.5s")
 		err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc()))

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -52,8 +52,8 @@ type xrootdTest struct {
 }
 
 func (x *xrootdTest) setup() {
-	config.Reset()
-	server_utils.ResetOriginExports()
+	server_utils.Reset()
+
 	dirname, err := os.MkdirTemp("", "tmpDir")
 	require.NoError(x.T, err)
 	x.T.Cleanup(func() {
@@ -83,10 +83,10 @@ func TestXrootDOriginConfig(t *testing.T) {
 	t.Cleanup(func() {
 		os.RemoveAll(dirname)
 	})
-	config.Reset()
-	server_utils.ResetOriginExports()
-	defer config.Reset()
-	defer server_utils.ResetOriginExports()
+	server_utils.Reset()
+
+	defer server_utils.Reset()
+
 	viper.Set("Configdir", dirname)
 	viper.Set("Origin.RunLocation", dirname)
 	viper.Set("Xrootd.RunLocation", dirname)
@@ -117,7 +117,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "cms.trace debug")
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("TestOriginCmsIncorrectConfig", func(t *testing.T) {
@@ -131,7 +131,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		configPath, err := ConfigXrootd(ctx, true)
 		require.Error(t, err)
 		assert.NotNil(t, configPath)
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("TestOriginScitokensCorrectConfig", func(t *testing.T) {
@@ -154,7 +154,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "scitokens.trace debug")
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("TestOriginScitokensIncorrectConfig", func(t *testing.T) {
@@ -168,7 +168,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		configPath, err := ConfigXrootd(ctx, true)
 		require.Error(t, err)
 		assert.NotNil(t, configPath)
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("TestOriginXrdCorrectConfig", func(t *testing.T) {
@@ -191,7 +191,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "xrd.trace debug")
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("TestOriginXrdIncorrectConfig", func(t *testing.T) {
@@ -205,7 +205,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		configPath, err := ConfigXrootd(ctx, true)
 		require.Error(t, err)
 		assert.NotNil(t, configPath)
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("TestOriginXrootdCorrectConfig", func(t *testing.T) {
@@ -228,7 +228,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "xrootd.trace debug")
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("TestOriginXrootdIncorrectConfig", func(t *testing.T) {
@@ -242,7 +242,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		configPath, err := ConfigXrootd(ctx, true)
 		require.Error(t, err)
 		assert.NotNil(t, configPath)
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("TestOsdfWithXRDHOSTAndPort", func(t *testing.T) {
@@ -259,7 +259,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		assert.NotNil(t, configPath)
 		assert.Equal(t, "my-xrootd.com", os.Getenv("XRDHOST"))
 
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("TestOsdfWithXRDHOSTAndNoPort", func(t *testing.T) {
@@ -276,7 +276,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		assert.NotNil(t, configPath)
 		assert.Equal(t, "my-xrootd.com", os.Getenv("XRDHOST"))
 
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("TestPelicanWithXRDHOST", func(t *testing.T) {
@@ -294,7 +294,7 @@ func TestXrootDOriginConfig(t *testing.T) {
 		_, xrdhostIsSet := os.LookupEnv("XRDHOST")
 		assert.False(t, xrdhostIsSet, "XRDHOST should only be set in OSDF mode")
 
-		config.Reset()
+		server_utils.Reset()
 	})
 }
 
@@ -308,8 +308,8 @@ func TestXrootDCacheConfig(t *testing.T) {
 	t.Cleanup(func() {
 		os.RemoveAll(dirname)
 	})
-	config.Reset()
-	server_utils.ResetOriginExports()
+	server_utils.Reset()
+
 	viper.Set("Cache.RunLocation", dirname)
 	viper.Set("ConfigDir", dirname)
 	config.InitConfig()
@@ -318,8 +318,8 @@ func TestXrootDCacheConfig(t *testing.T) {
 	assert.NotNil(t, configPath)
 
 	t.Run("TestCacheThrottlePluginEnabled", func(t *testing.T) {
-		defer config.Reset()
-		defer server_utils.ResetOriginExports()
+		defer server_utils.Reset()
+
 		xrootd := xrootdTest{T: t}
 		xrootd.setup()
 
@@ -343,8 +343,8 @@ func TestXrootDCacheConfig(t *testing.T) {
 	})
 
 	t.Run("TestCacheThrottlePluginDisabled", func(t *testing.T) {
-		defer config.Reset()
-		defer server_utils.ResetOriginExports()
+		defer server_utils.Reset()
+
 		xrootd := xrootdTest{T: t}
 		xrootd.setup()
 
@@ -384,7 +384,7 @@ func TestXrootDCacheConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "ofs.trace debug")
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("TestCacheOfsIncorrectConfig", func(t *testing.T) {
@@ -420,7 +420,7 @@ func TestXrootDCacheConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "pfc.trace debug")
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("TestCachePfcIncorrectConfig", func(t *testing.T) {
@@ -434,7 +434,7 @@ func TestXrootDCacheConfig(t *testing.T) {
 		configPath, err := ConfigXrootd(ctx, true)
 		require.Error(t, err)
 		assert.NotNil(t, configPath)
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("TestCachePssCorrectConfig", func(t *testing.T) {
@@ -457,7 +457,7 @@ func TestXrootDCacheConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "pss.setopt DebugLevel 4")
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("TestCachePssIncorrectConfig", func(t *testing.T) {
@@ -493,7 +493,7 @@ func TestXrootDCacheConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "scitokens.trace debug")
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("TestCacheScitokensIncorrectConfig", func(t *testing.T) {
@@ -529,7 +529,7 @@ func TestXrootDCacheConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "xrd.trace debug")
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("TestCacheXrdIncorrectConfig", func(t *testing.T) {
@@ -565,7 +565,7 @@ func TestXrootDCacheConfig(t *testing.T) {
 		content, err := io.ReadAll(file)
 		assert.NoError(t, err)
 		assert.Contains(t, string(content), "xrootd.trace debug")
-		config.Reset()
+		server_utils.Reset()
 	})
 
 	t.Run("TestCacheXrootdIncorrectConfig", func(t *testing.T) {
@@ -589,10 +589,10 @@ func TestUpdateAuth(t *testing.T) {
 
 	runDirname := t.TempDir()
 	configDirname := t.TempDir()
-	config.Reset()
-	server_utils.ResetOriginExports()
-	defer config.Reset()
-	defer server_utils.ResetOriginExports()
+	server_utils.Reset()
+
+	defer server_utils.Reset()
+
 	viper.Set("Logging.Level", "Debug")
 	viper.Set("Origin.RunLocation", runDirname)
 	viper.Set("ConfigDir", configDirname)
@@ -686,7 +686,7 @@ func TestCopyCertificates(t *testing.T) {
 
 	runDirname := t.TempDir()
 	configDirname := t.TempDir()
-	config.Reset()
+	server_utils.Reset()
 	viper.Set("Logging.Level", "Debug")
 	viper.Set("Origin.RunLocation", runDirname)
 	viper.Set("ConfigDir", configDirname)
@@ -770,9 +770,9 @@ func TestCopyCertificates(t *testing.T) {
 }
 
 func TestAuthIntervalUnmarshal(t *testing.T) {
-	defer config.Reset()
+	defer server_utils.Reset()
 	t.Run("test-minutes-to-seconds", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		var xrdConfig XrootdConfig
 		viper.Set("Xrootd.AuthRefreshInterval", "5m")
 		err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc()))
@@ -781,7 +781,7 @@ func TestAuthIntervalUnmarshal(t *testing.T) {
 	})
 
 	t.Run("test-hours-to-seconds", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		var xrdConfig XrootdConfig
 		viper.Set("Xrootd.AuthRefreshInterval", "24h")
 		err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc()))
@@ -790,7 +790,7 @@ func TestAuthIntervalUnmarshal(t *testing.T) {
 	})
 
 	t.Run("test-seconds-to-seconds", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		var xrdConfig XrootdConfig
 		viper.Set("Xrootd.AuthRefreshInterval", "100s")
 		err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc()))
@@ -799,7 +799,7 @@ func TestAuthIntervalUnmarshal(t *testing.T) {
 	})
 
 	t.Run("test-less-than-60s", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		var xrdConfig XrootdConfig
 		viper.Set("Xrootd.AuthRefreshInterval", "10")
 		err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc()))
@@ -809,7 +809,7 @@ func TestAuthIntervalUnmarshal(t *testing.T) {
 	})
 
 	t.Run("test-no-suffix-to-seconds", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		var xrdConfig XrootdConfig
 		viper.Set("Xrootd.AuthRefreshInterval", "99")
 		err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc()))
@@ -818,7 +818,7 @@ func TestAuthIntervalUnmarshal(t *testing.T) {
 	})
 
 	t.Run("test-less-than-second", func(t *testing.T) {
-		config.Reset()
+		server_utils.Reset()
 		var xrdConfig XrootdConfig
 		viper.Set("Xrootd.AuthRefreshInterval", "0.5s")
 		err := viper.Unmarshal(&xrdConfig, viper.DecodeHook(combinedDecodeHookFunc()))


### PR DESCRIPTION
This new Reset function addresses the issue #1302, integrating:

1. viper.Reset()
2. reset cached preferred prefix
3. reset cached transport object 
4. reset Federation metadata
5. reset Origin exports

If the use case needs to reset all of them, use `server_utils.Reset()`
If it needs to reset 1-4, use `config.ResetConfig()`
If only origin exports need to be reset, use `server_utils.ResetOriginExports()` 