### PR TITLE
New GeoIP Error Metric

### DIFF
--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -80,7 +80,7 @@ func (f filterType) String() string {
 //  4. Set up utilities for collecting origin/health server file transfer test status
 //  5. Return the updated ServerAd. The ServerAd passed in will not be modified
 func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]server_structs.NamespaceAdV2) (updatedAd server_structs.ServerAd) {
-	if err := updateLatLong(&sAd); err != nil {
+	if err := updateLatLong(ctx, &sAd); err != nil {
 		log.Debugln("Failed to lookup GeoIP coordinates for host", sAd.URL.Host)
 	}
 
@@ -233,7 +233,7 @@ func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]
 	return sAd
 }
 
-func updateLatLong(ad *server_structs.ServerAd) error {
+func updateLatLong(ctx context.Context, ad *server_structs.ServerAd) error {
 	if ad == nil {
 		return errors.New("Cannot provide a nil ad to UpdateLatLong")
 	}
@@ -243,7 +243,7 @@ func updateLatLong(ad *server_structs.ServerAd) error {
 		return err
 	}
 	if len(ip) == 0 {
-		return fmt.Errorf("Unable to find an IP address for hostname %s", hostname)
+		return fmt.Errorf("unable to find an IP address for hostname %s", hostname)
 	}
 	addr, ok := netip.AddrFromSlice(ip[0])
 	if !ok {
@@ -251,7 +251,7 @@ func updateLatLong(ad *server_structs.ServerAd) error {
 	}
 	// NOTE: If GeoIP resolution of this address fails, lat/long are set to 0.0 (the null lat/long)
 	// This causes the server to be sorted to the end of the list whenever the Director requires distance-aware sorting.
-	lat, long, err := getLatLong(addr)
+	lat, long, err := getLatLong(ctx, addr)
 	if err != nil {
 		return err
 	}

--- a/director/director.go
+++ b/director/director.go
@@ -290,12 +290,18 @@ func extractVersionAndService(ginCtx *gin.Context) (reqVer *version.Version, ser
 
 // Helper function to extract project from User-Agent
 // Will return an empty string if no project is found
-func extractProjectFromUserAgent(userAgent string) string {
+func extractProjectFromUserAgent(userAgents []string) string {
 	prefix := "project/"
 
-	if idx := strings.Index(userAgent, prefix); idx != -1 {
-		return userAgent[idx+len(prefix):]
+	for _, userAgent := range userAgents {
+		parts := strings.Split(userAgent, " ")
+		for _, part := range parts {
+			if strings.HasPrefix(part, prefix) {
+				return strings.TrimPrefix(part, prefix)
+			}
+		}
 	}
+
 	return ""
 }
 
@@ -498,7 +504,7 @@ func redirectToCache(ginCtx *gin.Context) {
 	}
 
 	ctx := context.Background()
-	project := extractProjectFromUserAgent(ginCtx.Request.Header.Get("User-Agent"))
+	project := extractProjectFromUserAgent(ginCtx.Request.Header.Values("User-Agent"))
 	ctx = context.WithValue(ctx, ProjectContextKey{}, project)
 	cacheAds, err = sortServerAds(ctx, ipAddr, cacheAds, cachesAvailabilityMap)
 	if err != nil {
@@ -735,7 +741,7 @@ func redirectToOrigin(ginCtx *gin.Context) {
 	}
 
 	ctx := context.Background()
-	project := extractProjectFromUserAgent(ginCtx.Request.Header.Get("User-Agent"))
+	project := extractProjectFromUserAgent(ginCtx.Request.Header.Values("User-Agent"))
 	ctx = context.WithValue(ctx, ProjectContextKey{}, project)
 
 	availableAds, err = sortServerAds(ctx, ipAddr, availableAds, nil)

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -2021,4 +2021,34 @@ func TestExtractProjectFromUserAgent(t *testing.T) {
 		result := extractProjectFromUserAgent(userAgents)
 		assert.Equal(t, "test", result)
 	})
+
+	t.Run("Single User-Agent with additional segments", func(t *testing.T) {
+		userAgents := []string{"pelican-client/blah project/myproject foo/bar"}
+		result := extractProjectFromUserAgent(userAgents)
+		assert.Equal(t, "myproject", result)
+	})
+
+	t.Run("Multiple User-Agents with project prefix", func(t *testing.T) {
+		userAgents := []string{"pelican-client/1.0.0 project/test", "pelican-client/1.0.0 project/test2"}
+		result := extractProjectFromUserAgent(userAgents)
+		assert.Equal(t, "test", result)
+	})
+
+	t.Run("Multiple User-Agents with swapped order", func(t *testing.T) {
+		userAgents := []string{"project/test pelican-client/1.0.0", "project/test2 pelican-client/1.0.0"}
+		result := extractProjectFromUserAgent(userAgents)
+		assert.Equal(t, "test", result)
+	})
+
+	t.Run("No Project Prefix", func(t *testing.T) {
+		userAgents := []string{"pelican-client/1.0.0"}
+		result := extractProjectFromUserAgent(userAgents)
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("No User-Agent", func(t *testing.T) {
+		userAgents := []string{}
+		result := extractProjectFromUserAgent(userAgents)
+		assert.Equal(t, "", result)
+	})
 }

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -2009,3 +2009,16 @@ func TestGetFinalRedirectURL(t *testing.T) {
 		assert.Equal(t, "https://example.org:8444?key1=val1&key2=val2&raw="+encodedVal, get)
 	})
 }
+
+func TestExtractProjectFromUserAgent(t *testing.T) {
+	t.Run("Single User-Agent with project prefix", func(t *testing.T) {
+		userAgents := []string{"pelican-client/1.0.0 project/test"}
+		result := extractProjectFromUserAgent(userAgents)
+		assert.Equal(t, "test", result)
+	})
+	t.Run("Singlue User-Agent with swapped order", func(t *testing.T) {
+		userAgents := []string{"project/test pelican-client/1.0.0"}
+		result := extractProjectFromUserAgent(userAgents)
+		assert.Equal(t, "test", result)
+	})
+}

--- a/director/sort.go
+++ b/director/sort.go
@@ -159,7 +159,7 @@ func getLatLong(ctx context.Context, addr netip.Addr) (lat float64, long float64
 	labels := prometheus.Labels{
 		"network": "",
 		"source":  "",
-		"project": "",
+		"proj":    "",
 	}
 
 	network, ok := utils.ApplyIPMask(addr.String())
@@ -172,11 +172,11 @@ func getLatLong(ctx context.Context, addr netip.Addr) (lat float64, long float64
 	project, ok := ctx.Value(ProjectContextKey{}).(string)
 	if !ok || project == "" {
 		log.Warningf("Failed to get project from context")
-		labels["project"] = "unknown"
+		labels["proj"] = "unknown"
 		labels["network"] = "unknown"
 		labels["source"] = "server"
 	} else {
-		labels["project"] = project
+		labels["proj"] = project
 	}
 
 	reader := maxMindReader.Load()

--- a/director/sort.go
+++ b/director/sort.go
@@ -165,6 +165,7 @@ func getLatLong(ctx context.Context, addr netip.Addr) (lat float64, long float64
 	network, ok := utils.ApplyIPMask(addr.String())
 	if !ok {
 		log.Warningf("Failed to apply IP mask to address %s", ip.String())
+		labels["network"] = "unknown"
 	} else {
 		labels["network"] = network
 	}
@@ -173,7 +174,6 @@ func getLatLong(ctx context.Context, addr netip.Addr) (lat float64, long float64
 	if !ok || project == "" {
 		log.Warningf("Failed to get project from context")
 		labels["proj"] = "unknown"
-		labels["network"] = "unknown"
 		labels["source"] = "server"
 	} else {
 		labels["proj"] = project

--- a/director/sort.go
+++ b/director/sort.go
@@ -162,7 +162,7 @@ func getLatLong(ctx context.Context, addr netip.Addr) (lat float64, long float64
 	}
 
 	project, ok := ctx.Value(ProjectContextKey{}).(string)
-	if !ok {
+	if !ok || project == "" {
 		log.Warningf("Failed to get project from context")
 		project = "unknown"
 	}

--- a/director/sort.go
+++ b/director/sort.go
@@ -245,7 +245,6 @@ func getClientLatLong(ctx context.Context, addr netip.Addr) (coord Coordinate) {
 	}
 
 	coord.Lat, coord.Long, err = getLatLong(ctx, addr)
-	coord.Lat, coord.Long, err = getLatLong(ctx, addr)
 	if err != nil || (coord.Lat == 0 && coord.Long == 0) {
 		if err != nil {
 			log.Warningf("Error while getting the client IP address: %v", err)

--- a/director/sort.go
+++ b/director/sort.go
@@ -244,6 +244,7 @@ func getClientLatLong(ctx context.Context, addr netip.Addr) (coord Coordinate) {
 	}
 
 	coord.Lat, coord.Long, err = getLatLong(ctx, addr)
+	coord.Lat, coord.Long, err = getLatLong(ctx, addr)
 	if err != nil || (coord.Lat == 0 && coord.Long == 0) {
 		if err != nil {
 			log.Warningf("Error while getting the client IP address: %v", err)
@@ -286,12 +287,6 @@ func sortServerAds(ctx context.Context, clientAddr netip.Addr, ads []server_stru
 	sortMethod := param.Director_CacheSortMethod.GetString()
 	// This will handle the case where the client address is invalid or the lat/long is not resolvable.
 	clientCoord := getClientLatLong(ctx, clientAddr)
-
-	if clientAddr.IsValid() {
-		clientCoord = getClientLatLong(ctx, clientAddr)
-	} else {
-		log.Warningf("Unable to sort servers based on client-server distance. Invalid client IP address: %s", clientAddr.String())
-	}
 
 	// For each ad, we apply the configured sort method to determine a priority weight.
 	for idx, ad := range ads {

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -471,7 +471,7 @@ func TestGetClientLatLong(t *testing.T) {
 		clientIp := netip.Addr{}
 		assert.False(t, clientIpCache.Has(clientIp))
 		ctx := context.Background()
-		ctx = context.WithValue(ctx, ProjectContextKey{}, "test")
+		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
 		coord1 := getClientLatLong(ctx, clientIp)
 
 		assert.True(t, coord1.Lat <= usLatMax && coord1.Lat >= usLatMin)
@@ -480,6 +480,8 @@ func TestGetClientLatLong(t *testing.T) {
 		assert.NotContains(t, logOutput.String(), "Retrieving pre-assigned lat/long")
 
 		// Get it again to make sure it's coming from the cache
+		ctx = context.Background()
+		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
 		coord2 := getClientLatLong(ctx, clientIp)
 		assert.Equal(t, coord1.Lat, coord2.Lat)
 		assert.Equal(t, coord1.Long, coord2.Long)
@@ -495,7 +497,7 @@ func TestGetClientLatLong(t *testing.T) {
 		clientIp := netip.MustParseAddr("192.168.0.1")
 		assert.False(t, clientIpCache.Has(clientIp))
 		ctx := context.Background()
-		ctx = context.WithValue(ctx, ProjectContextKey{}, "test")
+		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
 		coord1 := getClientLatLong(ctx, clientIp)
 
 		assert.True(t, coord1.Lat <= usLatMax && coord1.Lat >= usLatMin)
@@ -504,6 +506,8 @@ func TestGetClientLatLong(t *testing.T) {
 		assert.NotContains(t, logOutput.String(), "Retrieving pre-assigned lat/long")
 
 		// Get it again to make sure it's coming from the cache
+		ctx = context.Background()
+		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
 		coord2 := getClientLatLong(ctx, clientIp)
 		assert.Equal(t, coord1.Lat, coord2.Lat)
 		assert.Equal(t, coord1.Long, coord2.Long)

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -20,6 +20,7 @@ package director
 
 import (
 	"bytes"
+	"context"
 	_ "embed"
 	"math"
 	"math/rand"
@@ -343,7 +344,9 @@ func TestSortServerAds(t *testing.T) {
 		viper.Set("Director.CacheSortMethod", "distance")
 		expected := []server_structs.ServerAd{madisonServer, sdscServer, bigBenServer, kremlinServer,
 			daejeonServer, mcMurdoServer, nullIslandServer}
-		sorted, err := sortServerAds(clientIP, randAds, nil)
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
+		sorted, err := sortServerAds(ctx, clientIP, randAds, nil)
 		require.NoError(t, err)
 		assert.EqualValues(t, expected, sorted)
 	})
@@ -353,7 +356,10 @@ func TestSortServerAds(t *testing.T) {
 		viper.Set("Director.CacheSortMethod", "distanceAndLoad")
 		expected := []server_structs.ServerAd{madisonServer, sdscServer, bigBenServer, kremlinServer,
 			daejeonServer, mcMurdoServer, nullIslandServer}
-		sorted, err := sortServerAds(clientIP, randAds, nil)
+
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
+		sorted, err := sortServerAds(ctx, clientIP, randAds, nil)
 		require.NoError(t, err)
 		assert.EqualValues(t, expected, sorted)
 	})
@@ -361,7 +367,9 @@ func TestSortServerAds(t *testing.T) {
 	t.Run("test-distanceAndLoad-sort-load-only", func(t *testing.T) {
 		viper.Set("Director.CacheSortMethod", "distanceAndLoad")
 		expected := []server_structs.ServerAd{serverLoad1, serverLoad2, serverLoad3, serverLoad4, serverLoad6NullLoc}
-		sorted, err := sortServerAds(clientIP, randLoadAds, nil)
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
+		sorted, err := sortServerAds(ctx, clientIP, randLoadAds, nil)
 		require.NoError(t, err)
 		assert.EqualValues(t, expected, sorted)
 	})
@@ -370,7 +378,10 @@ func TestSortServerAds(t *testing.T) {
 		viper.Set("Director.CacheSortMethod", "distanceAndLoad")
 		expected := []server_structs.ServerAd{chicagoLowload, sdscServer, madisonServerHighLoad, kremlinServer,
 			daejeonServer, mcMurdoServer, bigBenServerHighLoad, serverLoad5NullLoc, serverLoad6NullLoc}
-		sorted, err := sortServerAds(clientIP, randDistanceLoadAds, nil)
+
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
+		sorted, err := sortServerAds(ctx, clientIP, randDistanceLoadAds, nil)
 		require.NoError(t, err)
 		assert.EqualValues(t, expected, sorted)
 	})
@@ -385,12 +396,14 @@ func TestSortServerAds(t *testing.T) {
 		notExpected := []server_structs.ServerAd{madisonServer, sdscServer, bigBenServer, kremlinServer, daejeonServer,
 			mcMurdoServer}
 
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
 		// The probability this test fails the first time due to randomly sorting into ascending distances is (1/6!) = 1/720
 		// To mitigate risk of this failing because of that, we'll run the sort 3 times to get a 1/720^3 = 1/373,248,000 chance
 		// of failure. If you run thrice and you still get the distance-sorted slice, you might consider buying a powerball ticket
 		// (1/292,201,338 chance of winning).
 		for i := 0; i < 3; i++ {
-			sorted, err = sortServerAds(clientIP, randAds, nil)
+			sorted, err = sortServerAds(ctx, clientIP, randAds, nil)
 			require.NoError(t, err)
 
 			// If the values are not equal, break the loop
@@ -457,7 +470,9 @@ func TestGetClientLatLong(t *testing.T) {
 
 		clientIp := netip.Addr{}
 		assert.False(t, clientIpCache.Has(clientIp))
-		coord1 := getClientLatLong(clientIp)
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ProjectContextKey{}, "test")
+		coord1 := getClientLatLong(ctx, clientIp)
 
 		assert.True(t, coord1.Lat <= usLatMax && coord1.Lat >= usLatMin)
 		assert.True(t, coord1.Long <= usLongMax && coord1.Long >= usLongMin)
@@ -465,7 +480,7 @@ func TestGetClientLatLong(t *testing.T) {
 		assert.NotContains(t, logOutput.String(), "Retrieving pre-assigned lat/long")
 
 		// Get it again to make sure it's coming from the cache
-		coord2 := getClientLatLong(clientIp)
+		coord2 := getClientLatLong(ctx, clientIp)
 		assert.Equal(t, coord1.Lat, coord2.Lat)
 		assert.Equal(t, coord1.Long, coord2.Long)
 		assert.Contains(t, logOutput.String(), "Retrieving pre-assigned lat/long for unresolved client IP")
@@ -479,7 +494,9 @@ func TestGetClientLatLong(t *testing.T) {
 
 		clientIp := netip.MustParseAddr("192.168.0.1")
 		assert.False(t, clientIpCache.Has(clientIp))
-		coord1 := getClientLatLong(clientIp)
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ProjectContextKey{}, "test")
+		coord1 := getClientLatLong(ctx, clientIp)
 
 		assert.True(t, coord1.Lat <= usLatMax && coord1.Lat >= usLatMin)
 		assert.True(t, coord1.Long <= usLongMax && coord1.Long >= usLongMin)
@@ -487,7 +504,7 @@ func TestGetClientLatLong(t *testing.T) {
 		assert.NotContains(t, logOutput.String(), "Retrieving pre-assigned lat/long")
 
 		// Get it again to make sure it's coming from the cache
-		coord2 := getClientLatLong(clientIp)
+		coord2 := getClientLatLong(ctx, clientIp)
 		assert.Equal(t, coord1.Lat, coord2.Lat)
 		assert.Equal(t, coord1.Long, coord2.Long)
 		assert.Contains(t, logOutput.String(), "Retrieving pre-assigned lat/long for client IP")

--- a/metrics/director.go
+++ b/metrics/director.go
@@ -96,4 +96,9 @@ var (
 		Name: "pelican_director_redirections_total",
 		Help: "The total number of redirections the director issued.",
 	}, []string{"destination", "status_code", "version", "network"})
+
+	PelicanDirectorGeoIPErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "pelican_director_geoip_errors",
+		Help: "The total number of errors encountered while downloading the GeoIP database",
+	}, []string{"network", "source", "project"})
 )

--- a/metrics/director.go
+++ b/metrics/director.go
@@ -100,5 +100,5 @@ var (
 	PelicanDirectorGeoIPErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "pelican_director_geoip_errors",
 		Help: "The total number of errors encountered trying to resolve coordinates using the GeoIP MaxMind database",
-	}, []string{"network", "source", "project"})
+	}, []string{"network", "source", "proj"})
 )

--- a/metrics/director.go
+++ b/metrics/director.go
@@ -99,6 +99,6 @@ var (
 
 	PelicanDirectorGeoIPErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "pelican_director_geoip_errors",
-		Help: "The total number of errors encountered while downloading the GeoIP database",
+		Help: "The total number of errors encountered trying to resolve coordinates using the GeoIP MaxMind database",
 	}, []string{"network", "source", "project"})
 )


### PR DESCRIPTION
This PR aims to fix issue #1605. This PR implements a new metric called `pelican_director_geoip_errors`. This metric has the following labels:

- `network` - this is the client's network
- `source` - this is the source of the error, it can take the value of `client` or `server`
- `project` - this is the project that the client sends along in the User-Agent

The goal is to integrate this metric into the WebUI, as addressed in #1548.