### PR TITLE
Cleanup origin startup stdout

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -89,6 +89,9 @@ type (
 	}
 
 	ContextKey string
+
+	// Custom goose logger
+	CustomGooseLogger struct{}
 )
 
 const (
@@ -179,6 +182,14 @@ func init() {
 	translator = &trans
 
 	validate = validator.New(validator.WithRequiredStructEnabled())
+}
+
+// Implement logging for info and fatal levels using logrus.
+func (l CustomGooseLogger) Printf(format string, v ...interface{}) {
+	log.Infof(format, v...)
+}
+func (l CustomGooseLogger) Fatalf(format string, v ...interface{}) {
+	log.Fatalf(format, v...)
 }
 
 // setEnabledServer sets the global variable config.EnabledServers to include newServers.
@@ -750,16 +761,6 @@ func setWebConfigOverride(v *viper.Viper, configPath string) error {
 	return nil
 }
 
-// Custom goose logger
-type CustomGooseLogger struct{}
-
-func (l CustomGooseLogger) Printf(format string, v ...interface{}) {
-	log.Infof(format, v...)
-}
-func (l CustomGooseLogger) Fatalf(format string, v ...interface{}) {
-	log.Fatalf(format, v...)
-}
-
 func InitConfig() {
 	// Enable BindStruct to allow unmarshal env into a nested struct
 	viper.SetOptions(viper.ExperimentalBindStruct())
@@ -936,7 +937,6 @@ func LogPelicanVersion() {
 	log.Infoln("Version:", GetVersion())
 	log.Infoln("Build Date:", GetBuiltDate())
 	log.Infoln("Build Commit:", GetBuiltCommit())
-	log.Infoln("Built By:", GetBuiltBy())
 }
 
 // Print Pelican configuration to stderr

--- a/config/config.go
+++ b/config/config.go
@@ -48,6 +48,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
+	"github.com/pressly/goose/v3"
 
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/pelican_url"
@@ -749,6 +750,15 @@ func setWebConfigOverride(v *viper.Viper, configPath string) error {
 	return nil
 }
 
+// Custom goose logger
+type CustomGooseLogger struct{}
+func (l CustomGooseLogger) Printf(format string, v ...interface{}) {
+	log.Infof(format, v...)
+}
+func (l CustomGooseLogger) Fatalf(format string, v ...interface{}) {
+	log.Fatalf(format, v...)
+}
+
 func InitConfig() {
 	// Enable BindStruct to allow unmarshal env into a nested struct
 	viper.SetOptions(viper.ExperimentalBindStruct())
@@ -833,6 +843,8 @@ func InitConfig() {
 		cobra.CheckErr(err)
 		SetLogging(level)
 	}
+
+	goose.SetLogger(CustomGooseLogger{})
 
 	// Warn users about deprecated config keys they're using and try to map them to any new equivalent we've defined.
 	handleDeprecatedConfig()

--- a/config/config.go
+++ b/config/config.go
@@ -44,11 +44,11 @@ import (
 	"github.com/go-playground/validator/v10"
 	en_translations "github.com/go-playground/validator/v10/translations/en"
 	"github.com/pkg/errors"
+	"github.com/pressly/goose/v3"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
-	"github.com/pressly/goose/v3"
 
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/pelican_url"
@@ -752,6 +752,7 @@ func setWebConfigOverride(v *viper.Viper, configPath string) error {
 
 // Custom goose logger
 type CustomGooseLogger struct{}
+
 func (l CustomGooseLogger) Printf(format string, v ...interface{}) {
 	log.Infof(format, v...)
 }
@@ -929,6 +930,13 @@ func PrintPelicanVersion(out *os.File) {
 	fmt.Fprintln(out, "Build Date:", GetBuiltDate())
 	fmt.Fprintln(out, "Build Commit:", GetBuiltCommit())
 	fmt.Fprintln(out, "Built By:", GetBuiltBy())
+}
+
+func LogPelicanVersion() {
+	log.Infoln("Version:", GetVersion())
+	log.Infoln("Build Date:", GetBuiltDate())
+	log.Infoln("Build Commit:", GetBuiltCommit())
+	log.Infoln("Built By:", GetBuiltBy())
 }
 
 // Print Pelican configuration to stderr

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -21,7 +21,7 @@
 # OA4MP is only for origin. Don't configure it if the deamon is not origin
 # the script is expect the argument in "[osdf|pelican] [deamon name] [...args]"
 if [ "$2" == "origin" ]; then
-    echo "Initializing run environment for Pelican..."
+    #echo "Initializing run environment for Pelican..."
     ####
     # Setup the OA4MP configuration.  Items are taken from https://github.com/scitokens/scitokens-oauth2-server/blob/master/start.sh
     # which appears to have an Apache 2.0 license.
@@ -35,7 +35,7 @@ if [ "$2" == "origin" ]; then
     export PATH="${ST_HOME}/bin:${QDL_HOME}/bin:${PATH}"
 
     # Run the boot to inject the template
-    ${QDL_HOME}/var/scripts/boot.qdl
+    ${QDL_HOME}/var/scripts/boot.qdl > /dev/null
 
     # check for one or more files in a directory
     if [ -e /opt/scitokens-server/etc/qdl/ ]; then
@@ -52,7 +52,7 @@ if [ "$2" == "origin" ]; then
 
         shopt -s nullglob
         for fullfile in /opt/scitokens-server/etc/trusted-cas/*.pem; do
-            echo "Importing CA certificate $fullfile into the Java trusted CA store."
+            #echo "Importing CA certificate $fullfile into the Java trusted CA store."
             aliasname=$(basename "$file")
             aliasname="${filename%.*}"
             keytool -cacerts -importcert -noprompt -storepass changeit -file "$fullfile" -alias "$aliasname"
@@ -86,14 +86,14 @@ if [ "$2" == "origin" ]; then
     # Tomcat requires us to provide the intermediate chain (which, in Kubernetes, is often in the same
     # file as the host certificate itself.  If there wasn't one provided, try splitting it out.
     if [ ! -e /opt/tomcat/conf/chain.pem ]; then
-        echo "No chain present for host cert; trying to derive one"
+        #echo "No chain present for host cert; trying to derive one"
         pushd /tmp > /dev/null
         if csplit -f tls- -b "%02d.crt.pem" -s -z "/opt/tomcat/conf/hostcert.pem" '/-----BEGIN CERTIFICATE-----/' '{1}' 2>/dev/null ; then
-            echo "Chain present in hostcert.pem; using it."
+            #echo "Chain present in hostcert.pem; using it."
             cp /tmp/tls-01.crt.pem /opt/tomcat/conf/chain.pem
             rm /tmp/tls-*.crt.pem
         else
-            echo "No chain present; will use empty file"
+            #echo "No chain present; will use empty file"
             # No intermediate CAs found.  Create an empty file.
             touch /opt/tomcat/conf/chain.pem
         fi

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -58,7 +58,7 @@ func LaunchModules(ctx context.Context, modules server_structs.ServerType) (serv
 
 	ctx, shutdownCancel = context.WithCancel(ctx)
 
-	config.PrintPelicanVersion(os.Stderr) // Print Pelican version to stderr at server start
+	config.LogPelicanVersion()
 
 	// Print Pelican config at server start if it's in debug or info level
 	if log.GetLevel() >= log.InfoLevel {


### PR DESCRIPTION
This PR fixes #1502

- It incorporates Goose output into the logging system. Goose has two levels of output: `info` and `fatal`, which are now mapped to the corresponding levels in `logrus`.
- The build information at server startup is now logged as part of the `info` logs.
- Removed unwanted echoes when the origin starts in `entrypoint.sh` and suppressed the output from running the script `boot.qdl` inside `entrypoint.sh`. The `boot.qdl` script starts a new OA4MP issuer and always exits with a non-zero status, which appears to be the expected behavior for now.