### PR TITLE
Revert "Update JSON representations of Capabilities structs to match internal"

### DIFF
--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -47,11 +47,11 @@ type (
 
 	// Note that the json are kept in uppercase for backward compatibility
 	Capabilities struct {
-		PublicReads bool `json:"PublicReads"`
-		Reads       bool `json:"Reads"`
-		Writes      bool `json:"Writes"`
-		Listings    bool `json:"Listings"`
-		DirectReads bool `json:"DirectReads"`
+		PublicReads bool `json:"PublicRead"`
+		Reads       bool `json:"Read"`
+		Writes      bool `json:"Write"`
+		Listings    bool `json:"Listing"`
+		DirectReads bool `json:"FallBackRead"`
 	}
 
 	NamespaceAdV2 struct {


### PR DESCRIPTION
This reverts commit ba186d23895835285d79b118feabbdec22a902cc. I thought this change would be non-breaking but I was WRONG.

I'll follow up later today with another PR that handles potential breaking changes so we can stage this change over the next release or two.