### PR TITLE
Install sssd-client in dev/prod containers

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -57,7 +57,7 @@ RUN yum -y update \
 ####
 FROM dependency-build AS xrootd-plugin-builder
 # Install necessary build dependencies
-RUN  yum install -y --enablerepo=osg-testing xrootd-devel xrootd-server-devel xrootd-client-devel curl-devel openssl-devel git cmake3 gcc-c++ sqlite-devel
+RUN  yum install -y --enablerepo=osg-testing xrootd-devel xrootd-server-devel xrootd-client-devel curl-devel openssl-devel git cmake3 gcc-c++ sqlite-devel sssd-client
 
 # The ADD command with a api.github.com URL in the next couple of sections
 # are for cache-hashing of the external repository that we rely on to build

--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -53,7 +53,7 @@ gpgcheck=0' > /etc/yum.repos.d/goreleaser.repo
 
 # Install goreleaser and various other packages we need
 RUN yum install -y --enablerepo=osg-testing goreleaser npm xrootd-devel xrootd-server-devel xrootd-client-devel nano xrootd-scitokens xrootd-voms \
-    xrdcl-http jq procps docker make curl-devel java-17-openjdk-headless git cmake3 gcc-c++ openssl-devel sqlite-devel libcap-devel \
+    xrdcl-http jq procps docker make curl-devel java-17-openjdk-headless git cmake3 gcc-c++ openssl-devel sqlite-devel libcap-devel sssd-client \
     xrootd-multiuser \
     zlib-devel \
     && yum clean all


### PR DESCRIPTION
@williamnswanson, as you requested

When this is patched into 7.10, it should also cause the container builds to pick up xrootd 5.7.1 (unless there's some weird caching going on that I'm unaware of).