### PR TITLE
correct OA4MP storage directory permission

### DIFF
--- a/oa4mp/serve.go
+++ b/oa4mp/serve.go
@@ -308,24 +308,23 @@ func ConfigureOA4MP() (launcher daemon.Launcher, err error) {
 
 	// Ensure the OA4MP storage directory exists and has correct permissions and ownership
 	OA4MPStoragePath := "/opt/scitokens-server/var/storage"
-	if _, err := os.Stat(OA4MPStoragePath); os.IsNotExist(err) {
-		log.Debugln("OA4MP storage directory does not exist. Creating: ", OA4MPStoragePath)
-		if err = os.MkdirAll(OA4MPStoragePath, 0755); err != nil {
-			log.Errorln("Failed to create directory:", OA4MPStoragePath, ": ", err)
+
+	if err := os.Chmod(OA4MPStoragePath, 0700); err != nil {
+		if os.IsNotExist(err) {
+			log.Debugln("OA4MP storage directory does not exist. Creating", OA4MPStoragePath)
+			if err = os.MkdirAll(OA4MPStoragePath, 0755); err != nil {
+				log.Fatal("Failed to create directory", OA4MPStoragePath, ":", err)
+			}
+			if err = os.Chmod(OA4MPStoragePath, 0700); err != nil {
+				log.Errorln("Failed to change permissions of", OA4MPStoragePath, "after creating it:", err)
+			}
+		} else {
+			log.Errorln("Failed to change permissions of", OA4MPStoragePath, ":", err)
 		}
 	}
 
-	if err := os.Chmod(OA4MPStoragePath, 0700); err != nil {
-		log.Errorln("Failed to change permissions of: ", OA4MPStoragePath, ": ", err)
-	}
-
-	if user.Username != "tomcat" {
-		log.Errorln("Username should be 'tomcat', but is: ", user.Username)
-	}
-	uid, gid := user.Uid, user.Gid
-
-	if err := os.Chown(OA4MPStoragePath, uid, gid); err != nil {
-		log.Errorln("Failed to change ownership of ", OA4MPStoragePath, " to tomcat: ", err)
+	if err := os.Chown(OA4MPStoragePath, user.Uid, user.Gid); err != nil {
+		log.Errorln("Failed to change ownership of", OA4MPStoragePath, "to tomcat:", err)
 	}
 
 	qdlBoot := filepath.Join(param.Issuer_QDLLocation.GetString(), "var", "scripts", "boot.qdl")

--- a/oa4mp/serve.go
+++ b/oa4mp/serve.go
@@ -313,21 +313,21 @@ func ConfigureOA4MP() (launcher daemon.Launcher, err error) {
 		if os.IsNotExist(err) {
 			log.Debugln("OA4MP storage directory does not exist. Creating", OA4MPStoragePath)
 			if err = os.MkdirAll(OA4MPStoragePath, 0755); err != nil {
-				err = errors.Wrap(err, "Failed to create OA4MP storage directory")
+				err = errors.Wrap(err, "failed to create OA4MP storage directory")
 				return
 			}
 			if err = os.Chmod(OA4MPStoragePath, 0700); err != nil {
-				err = errors.Wrap(err, "Failed to change the permissions of OA4MP storage directory after creating it")
+				err = errors.Wrap(err, "failed to change the permissions of OA4MP storage directory after creating it")
 				return
 			}
 		} else {
-			err = errors.Wrap(err, "Failed to change the permissions of OA4MP storage directory")
+			err = errors.Wrap(err, "failed to change the permissions of OA4MP storage directory")
 			return
 		}
 	}
 
 	if err = os.Chown(OA4MPStoragePath, user.Uid, user.Gid); err != nil {
-		err = errors.Wrap(err, "Failed to change the ownership of OA4MP storage directory")
+		err = errors.Wrap(err, "failed to change the ownership of OA4MP storage directory")
 		return
 	}
 

--- a/oa4mp/serve.go
+++ b/oa4mp/serve.go
@@ -309,22 +309,26 @@ func ConfigureOA4MP() (launcher daemon.Launcher, err error) {
 	// Ensure the OA4MP storage directory exists and has correct permissions and ownership
 	OA4MPStoragePath := "/opt/scitokens-server/var/storage"
 
-	if err := os.Chmod(OA4MPStoragePath, 0700); err != nil {
+	if err = os.Chmod(OA4MPStoragePath, 0700); err != nil {
 		if os.IsNotExist(err) {
 			log.Debugln("OA4MP storage directory does not exist. Creating", OA4MPStoragePath)
 			if err = os.MkdirAll(OA4MPStoragePath, 0755); err != nil {
-				log.Fatal("Failed to create directory", OA4MPStoragePath, ":", err)
+				err = errors.Wrap(err, "Failed to create OA4MP storage directory")
+				return
 			}
 			if err = os.Chmod(OA4MPStoragePath, 0700); err != nil {
-				log.Errorln("Failed to change permissions of", OA4MPStoragePath, "after creating it:", err)
+				err = errors.Wrap(err, "Failed to change the permissions of OA4MP storage directory after creating it")
+				return
 			}
 		} else {
-			log.Errorln("Failed to change permissions of", OA4MPStoragePath, ":", err)
+			err = errors.Wrap(err, "Failed to change the permissions of OA4MP storage directory")
+			return
 		}
 	}
 
-	if err := os.Chown(OA4MPStoragePath, user.Uid, user.Gid); err != nil {
-		log.Errorln("Failed to change ownership of", OA4MPStoragePath, "to tomcat:", err)
+	if err = os.Chown(OA4MPStoragePath, user.Uid, user.Gid); err != nil {
+		err = errors.Wrap(err, "Failed to change the ownership of OA4MP storage directory")
+		return
 	}
 
 	qdlBoot := filepath.Join(param.Issuer_QDLLocation.GetString(), "var", "scripts", "boot.qdl")


### PR DESCRIPTION
see the linked issue for the goal of this PR

How I test it:
<img width="405" alt="Screenshot 2024-10-10 at 3 51 12 PM" src="https://github.com/user-attachments/assets/6842923d-53a0-45d1-afc4-6fdf92d1709e">
(1-4 corresponds the blue dots in the screenshot)
1. delete `/opt/scitokens-server/var/storage` directory if it exists
2. build and run the pelican project. verify if the above directory gets created
3. check the permissions of parent directory is 0755
4. check the permissions of leaf directory `/opt/scitokens-server/var/storage` is 0700