### PR TITLE
Stop specifying Federation.DirectorUrl in osdf-cache config

### DIFF
--- a/systemd/osdf-cache.yaml
+++ b/systemd/osdf-cache.yaml
@@ -4,9 +4,6 @@ Logging:
   LogLocation: /var/log/pelican/osdf-cache.log
   ## Valid Levels are Trace, Debug, Info, Warning, Error, Fatal and Panic.
   # Level: "Error"
-Federation:
-  # We need the "origins" director to find origins instead of the default ("caches" director)
-  DirectorUrl: https://osdf-director-origins.osg-htc.org
 Server:
   TLSCertificate: /etc/pki/tls/certs/pelican.crt
   TLSKey: /etc/pki/tls/private/pelican.key


### PR DESCRIPTION
The issue causing caches to have to be told the location of the "origins" director has long since been solved.