### PR TITLE
Made the xrootd cache prefetch variable configurable via a pelican va…

### DIFF
--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -65,6 +65,7 @@ Cache:
   SelfTestInterval: 15s
   LowWatermark: 90
   HighWaterMark: 95
+  BlocksToPrefetch: 0
 LocalCache:
   HighWaterMarkPercentage: 95
   LowWaterMarkPercentage: 85

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1240,9 +1240,11 @@ type: bool
 default: false
 components: ["cache"]
 ---
-name: Cache.Prefetch
+name: Cache.BlocksToPrefetch
 description: |+
-  The number of blocks the cache will prefetch per file
+  The number of 1 megabyte blocks the cache will read ahead when recieving requests. This will put the data in the cache
+  potentially before it is needed and reduce the latency to the client when a request is made. However, it can also cause
+  many extra requests to an origin and potentially overload it when unnessesary. As such, this is turned off by default.
 type: int
 default: 0
 components: ["cache"]

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1242,7 +1242,7 @@ components: ["cache"]
 ---
 name: Cache.BlocksToPrefetch
 description: |+
-  The number of 1 megabyte blocks the cache will read ahead when recieving requests. This will put the data in the cache
+  The number of 128 kilobyte blocks the cache will read ahead when recieving requests. This will put the data in the cache
   potentially before it is needed and reduce the latency to the client when a request is made. However, it can also cause
   many extra requests to an origin and potentially overload it when unnessesary. As such, this is turned off by default.
 type: int

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1240,6 +1240,13 @@ type: bool
 default: false
 components: ["cache"]
 ---
+name: Cache.Prefetch
+description: |+
+  The number of blocks the cache will prefetch per file
+type: int
+default: 0
+components: ["cache"]
+---
 ############################
 #  Director-level configs  #
 ############################

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -296,9 +296,9 @@ var (
 )
 
 var (
+	Cache_BlocksToPrefetch = IntParam{"Cache.BlocksToPrefetch"}
 	Cache_Concurrency = IntParam{"Cache.Concurrency"}
 	Cache_Port = IntParam{"Cache.Port"}
-	Cache_Prefetch = IntParam{"Cache.Prefetch"}
 	Client_MaximumDownloadSpeed = IntParam{"Client.MaximumDownloadSpeed"}
 	Client_MinimumDownloadSpeed = IntParam{"Client.MinimumDownloadSpeed"}
 	Client_WorkerCount = IntParam{"Client.WorkerCount"}

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -298,6 +298,7 @@ var (
 var (
 	Cache_Concurrency = IntParam{"Cache.Concurrency"}
 	Cache_Port = IntParam{"Cache.Port"}
+	Cache_Prefetch = IntParam{"Cache.Prefetch"}
 	Client_MaximumDownloadSpeed = IntParam{"Client.MaximumDownloadSpeed"}
 	Client_MinimumDownloadSpeed = IntParam{"Client.MinimumDownloadSpeed"}
 	Client_WorkerCount = IntParam{"Client.WorkerCount"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -25,6 +25,7 @@ import (
 
 type Config struct {
 	Cache struct {
+		BlocksToPrefetch int `mapstructure:"blockstoprefetch"`
 		Concurrency int `mapstructure:"concurrency"`
 		DataLocation string `mapstructure:"datalocation"`
 		DataLocations []string `mapstructure:"datalocations"`
@@ -38,7 +39,6 @@ type Config struct {
 		MetaLocations []string `mapstructure:"metalocations"`
 		PermittedNamespaces []string `mapstructure:"permittednamespaces"`
 		Port int `mapstructure:"port"`
-		Prefetch int `mapstructure:"prefetch"`
 		RunLocation string `mapstructure:"runlocation"`
 		SelfTest bool `mapstructure:"selftest"`
 		SelfTestInterval time.Duration `mapstructure:"selftestinterval"`
@@ -328,6 +328,7 @@ type Config struct {
 
 type configWithType struct {
 	Cache struct {
+		BlocksToPrefetch struct { Type string; Value int }
 		Concurrency struct { Type string; Value int }
 		DataLocation struct { Type string; Value string }
 		DataLocations struct { Type string; Value []string }
@@ -341,7 +342,6 @@ type configWithType struct {
 		MetaLocations struct { Type string; Value []string }
 		PermittedNamespaces struct { Type string; Value []string }
 		Port struct { Type string; Value int }
-		Prefetch struct { Type string; Value int }
 		RunLocation struct { Type string; Value string }
 		SelfTest struct { Type string; Value bool }
 		SelfTestInterval struct { Type string; Value time.Duration }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -38,6 +38,7 @@ type Config struct {
 		MetaLocations []string `mapstructure:"metalocations"`
 		PermittedNamespaces []string `mapstructure:"permittednamespaces"`
 		Port int `mapstructure:"port"`
+		Prefetch int `mapstructure:"prefetch"`
 		RunLocation string `mapstructure:"runlocation"`
 		SelfTest bool `mapstructure:"selftest"`
 		SelfTestInterval time.Duration `mapstructure:"selftestinterval"`
@@ -340,6 +341,7 @@ type configWithType struct {
 		MetaLocations struct { Type string; Value []string }
 		PermittedNamespaces struct { Type string; Value []string }
 		Port struct { Type string; Value int }
+		Prefetch struct { Type string; Value int }
 		RunLocation struct { Type string; Value string }
 		SelfTest struct { Type string; Value bool }
 		SelfTestInterval struct { Type string; Value time.Duration }

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -53,7 +53,7 @@ pfc.trace info
 xrootd.tls all
 xrd.network nodnr
 pfc.blocksize 128k
-pfc.prefetch {{.Cache.Prefetch}}
+pfc.prefetch {{.Cache.BlocksToPrefetch}}
 pfc.writequeue 16 4
 pfc.ram 4g
 pfc.diskusage {{if .Cache.LowWatermark}}{{.Cache.LowWatermark}}{{else}}0.90{{end}} {{if .Cache.HighWaterMark}}{{.Cache.HighWaterMark}}{{else}}0.95{{end}} purgeinterval 300s

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -53,7 +53,7 @@ pfc.trace info
 xrootd.tls all
 xrd.network nodnr
 pfc.blocksize 128k
-pfc.prefetch 20
+pfc.prefetch {{.Cache.Prefetch}}
 pfc.writequeue 16 4
 pfc.ram 4g
 pfc.diskusage {{if .Cache.LowWatermark}}{{.Cache.LowWatermark}}{{else}}0.90{{end}} {{if .Cache.HighWaterMark}}{{.Cache.HighWaterMark}}{{else}}0.95{{end}} purgeinterval 300s

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -117,6 +117,7 @@ type (
 		MetaLocations                    []string
 		LocalRoot                        string
 		PSSOrigin                        string
+		Prefetch                         int
 		Concurrency                      int
 		X509ClientAuthenticationPrefixes []string
 	}

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -117,7 +117,7 @@ type (
 		MetaLocations                    []string
 		LocalRoot                        string
 		PSSOrigin                        string
-		Prefetch                         int
+		BlocksToPrefetch                 int
 		Concurrency                      int
 		X509ClientAuthenticationPrefixes []string
 	}


### PR DESCRIPTION
…riable.

Added the Pelican variable Cache.Prefetch and used it to set the cache prefix value in the cache Changed its default from 20 to 0
Updated the xrootd config and cache templates accordingly