### PR TITLE
Align OSDF RunLocation hierarchy with Pelican components

### DIFF
--- a/systemd/osdf-cache.yaml
+++ b/systemd/osdf-cache.yaml
@@ -20,4 +20,4 @@ XRootD:
   Sitename: TOPOLOGY_RESOURCE_NAME
 Cache:
   DataLocation: "/mnt/osdf"
-  RunLocation: /run/pelican/osdf-cache/xrootd
+  RunLocation: /run/pelican/xrootd/osdf-cache

--- a/systemd/osdf-origin.yaml
+++ b/systemd/osdf-origin.yaml
@@ -23,4 +23,4 @@ XRootD:
 Origin:
   NamespacePrefix: "/MY_NAMESPACE"
   Multiuser: false
-  RunLocation: /run/pelican/osdf-origin/xrootd/
+  RunLocation: /run/pelican/xrootd/osdf-origin


### PR DESCRIPTION
The asymmetry was bothering me. Though it's unclear to me /why/ we need separate run dirs? Because we can't serve different federations with single origin/cache services now?