### PR TITLE
Allow other commands in the dev entrypoint

### DIFF
--- a/images/dev-container-entrypoint.sh
+++ b/images/dev-container-entrypoint.sh
@@ -20,5 +20,9 @@
 # Run pre-commit install
 pre-commit install
 
-# Start an interactive bash shell
-exec "/bin/bash" -i
+# Default to bash but if a command is passed, run it
+if [ $# -eq 0 ]; then
+  exec /bin/bash
+else
+  exec "$@"
+fi

--- a/web_ui/frontend/README.md
+++ b/web_ui/frontend/README.md
@@ -17,7 +17,7 @@ as they would in production.
 ```shell
 # From repo root
 make pelican-build
-docker run --rm -it -p 8444:8444 -w /app -v $PWD/dist/pelican_linux_arm64/:/app -v $PWD/local/:/etc/pelican/ hub.opensciencegrid.org/pelican_platform/pelican-dev:latest-itb /bin/bash
+docker run --rm -it -p 8444:8444 -w /app -v $PWD/dist/pelican_linux_arm64/:/app -v $PWD/local/:/etc/pelican/ hub.opensciencegrid.org/pelican_platform/pelican-dev:latest-itb ./pelican serve --module director,registry,origin,cache
 ```
 
 ```shell


### PR DESCRIPTION
Default to bash but if they exist run the commands passed into the container. 