### PR TITLE
Persist server downtime

### DIFF
--- a/director/director_api.go
+++ b/director/director_api.go
@@ -225,7 +225,7 @@ func LaunchServerCountMetric(ctx context.Context, egrp *errgroup.Group) {
 	})
 }
 
-// Populate internal filteredServers map by Director.FilteredServers
+// Populate internal filteredServers map by Director.FilteredServers and director db
 func ConfigFilterdServers() {
 	filteredServersMutex.Lock()
 	defer filteredServersMutex.Unlock()
@@ -236,6 +236,15 @@ func ConfigFilterdServers() {
 
 	for _, sn := range param.Director_FilteredServers.GetStringSlice() {
 		filteredServers[sn] = permFiltered
+	}
+
+	persistedServerStatuses, err := GetAllServerStatuses()
+	if err != nil {
+		log.Error("Failed to read persisted ServerStatuses from director db", err)
+		return
+	}
+	for _, serverStatus := range persistedServerStatuses {
+		filteredServers[serverStatus.Name] = serverStatus.FilterType
 	}
 }
 

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -66,7 +66,7 @@ func listAdvertisement(serverTypes []server_structs.ServerType) []*server_struct
 func checkFilter(serverName string) (bool, filterType) {
 	filteredServersMutex.RLock()
 	defer filteredServersMutex.RUnlock()
-
+	log.Debugln("Checking the filter applied on server", serverName, "Current filteredServers map:", filteredServers)
 	status, exists := filteredServers[serverName]
 	// No filter entry
 	if !exists {
@@ -225,26 +225,29 @@ func LaunchServerCountMetric(ctx context.Context, egrp *errgroup.Group) {
 	})
 }
 
-// Populate internal filteredServers map by Director.FilteredServers and director db
+// Populate internal filteredServers map using Director.FilteredServers param and director db
 func ConfigFilterdServers() {
 	filteredServersMutex.Lock()
 	defer filteredServersMutex.Unlock()
 
-	if !param.Director_FilteredServers.IsSet() {
-		return
+	if param.Director_FilteredServers.IsSet() {
+		for _, sn := range param.Director_FilteredServers.GetStringSlice() {
+			filteredServers[sn] = permFiltered
+		}
+		log.Debugln("Loaded filtered servers config from Director.FilteredServers param", filteredServers)
 	}
 
-	for _, sn := range param.Director_FilteredServers.GetStringSlice() {
-		filteredServers[sn] = permFiltered
-	}
-
-	persistedServerStatuses, err := GetAllServerStatuses()
-	if err != nil {
-		log.Error("Failed to read persisted ServerStatuses from director db", err)
-		return
-	}
-	for _, serverStatus := range persistedServerStatuses {
-		filteredServers[serverStatus.Name] = serverStatus.FilterType
+	if param.Director_DbLocation.IsSet() {
+		persistedServerDowntimes, err := GetAllServerDowntimes()
+		if err != nil {
+			log.Error("Failed to read persisted ServerDowntimes from director db", err)
+			return
+		}
+		for _, serverDowntime := range persistedServerDowntimes {
+			filteredServers[serverDowntime.Name] = serverDowntime.FilterType
+		}
+		log.Debugln("Loaded filtered servers config from director db's server_downtimes table, the final filteredServers var has the following value", filteredServers)
+		// if a filtered server config rule is set in both Director.FilteredServers param and director db, the latter one will eventually be used
 	}
 }
 

--- a/director/director_db.go
+++ b/director/director_db.go
@@ -1,0 +1,109 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+package director
+
+import (
+	"embed"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pkg/errors"
+	"gorm.io/gorm"
+)
+
+type ServerStatus struct {
+	UUID     string `gorm:"primaryKey"`
+	URL      string `gorm:"not null;default:''"`
+	Downtime bool   `gorm:"not null;default:false"`
+	// We don't use gorm default gorm.Model to change ID type to string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt gorm.DeletedAt
+}
+
+var db *gorm.DB
+
+//go:embed migrations/*.sql
+var embedMigrations embed.FS
+
+func InitializeDB() error {
+	dbPath := param.Director_DbLocation.GetString()
+	tdb, err := server_utils.InitSQLiteDB(dbPath)
+	if err != nil {
+		return err
+	}
+	db = tdb
+	sqldb, err := db.DB()
+	if err != nil {
+		return errors.Wrapf(err, "Failed to get sql.DB from gorm DB: %s", dbPath)
+	}
+	// Run database migrations
+	if err := server_utils.MigrateDB(sqldb, embedMigrations); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ShutdownDirectorDB() error {
+	return server_utils.ShutdownDB(db)
+}
+
+func CreateServerStatus(url string) error {
+	id, err := uuid.NewV7()
+	if err != nil {
+		return errors.Wrap(err, "Unable to create new UUID for new entry in server status table")
+	}
+	serverStatus := ServerStatus{
+		UUID:      id.String(),
+		URL:       url,
+		Downtime:  false,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	if err := db.Create(serverStatus).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
+func GetServerDowntime(url string) (bool, error) {
+	var serverStatus ServerStatus
+	err := db.First(&serverStatus, "url = ?", url).Error
+	if err != nil {
+		return false, err
+	}
+	return serverStatus.Downtime, nil
+}
+
+func SetServerDowntime(downtime bool, url string) error {
+	var serverStatus ServerStatus
+	err := db.First(&serverStatus, "url = ?", url).Error
+	if err != nil {
+		return err
+	}
+	serverStatus.Downtime = downtime
+	serverStatus.UpdatedAt = time.Now()
+
+	if err := db.Save(&serverStatus).Error; err != nil {
+		return err
+	}
+	return nil
+}

--- a/director/director_db_test.go
+++ b/director/director_db_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	mockSS []ServerStatus = []ServerStatus{
+	mockSS []ServerDowntime = []ServerDowntime{
 		{UUID: uuid.NewString(), Name: "/4a334d532d69:8443", FilterType: tempAllowed},
 		{UUID: uuid.NewString(), Name: "/my-origin.com/foo/Bar", FilterType: permFiltered},
 		{UUID: uuid.NewString(), Name: "/my-cache.com/chtc", FilterType: permFiltered},
@@ -23,7 +23,7 @@ func setupMockDirectorDB(t *testing.T) {
 	mockDB, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	db = mockDB
 	require.NoError(t, err, "Error setting up mock origin DB")
-	err = db.AutoMigrate(&ServerStatus{})
+	err = db.AutoMigrate(&ServerDowntime{})
 	require.NoError(t, err, "Failed to migrate DB for Globus table")
 }
 
@@ -32,7 +32,7 @@ func teardownMockDirectorDB(t *testing.T) {
 	require.NoError(t, err, "Error tearing down mock director DB")
 }
 
-func insertMockDBData(ss []ServerStatus) error {
+func insertMockDBData(ss []ServerDowntime) error {
 	return db.Create(&ss).Error
 }
 
@@ -46,36 +46,36 @@ func TestDirectorDBBasics(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("get-downtime", func(t *testing.T) {
-		filterType, err := GetServerStatus(mockSS[1].Name)
+		filterType, err := GetServerDowntime(mockSS[1].Name)
 		assert.Equal(t, filterType, permFiltered)
 		require.NoError(t, err)
 	})
 
 	t.Run("get-all-downtime", func(t *testing.T) {
-		statuses, err := GetAllServerStatuses()
+		statuses, err := GetAllServerDowntimes()
 		require.NoError(t, err)
 		assert.Len(t, statuses, len(mockSS))
 	})
 
 	t.Run("set-downtime", func(t *testing.T) {
-		err = SetServerStatus(mockSS[1].Name, tempAllowed)
+		err = SetServerDowntime(mockSS[1].Name, tempAllowed)
 		require.NoError(t, err)
-		filterType, err := GetServerStatus(mockSS[1].Name)
+		filterType, err := GetServerDowntime(mockSS[1].Name)
 		assert.Equal(t, filterType, tempAllowed)
 		require.NoError(t, err)
 	})
 
 	t.Run("duplicate-name-insert", func(t *testing.T) {
-		err := CreateServerStatus(mockSS[1].Name, tempAllowed)
+		err := CreateServerDowntime(mockSS[1].Name, tempAllowed)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "UNIQUE constraint failed")
 	})
 
 	t.Run("delete-downtime-entry-from-directory-db", func(t *testing.T) {
-		err = DeleteServerStatus(mockSS[0].Name)
+		err = DeleteServerDowntime(mockSS[0].Name)
 		require.NoError(t, err, "Error deleting server status")
 
-		_, err = GetServerStatus(mockSS[0].Name)
+		_, err = GetServerDowntime(mockSS[0].Name)
 		assert.Error(t, err, "Expected error retrieving deleted server status")
 	})
 }

--- a/director/director_db_test.go
+++ b/director/director_db_test.go
@@ -1,0 +1,57 @@
+package director
+
+import (
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"github.com/google/uuid"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+var (
+	mockSS []ServerStatus = []ServerStatus{
+		{UUID: uuid.NewString(), URL: "https://4a334d532d69:8443", Downtime: false},
+		{UUID: uuid.NewString(), URL: "https://my-origin.com:8443", Downtime: true},
+		{UUID: uuid.NewString(), URL: "https://my-cache.com:8447"},
+	}
+)
+
+func setupMockDirectorDB(t *testing.T) {
+	mockDB, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	db = mockDB
+	require.NoError(t, err, "Error setting up mock origin DB")
+	err = db.AutoMigrate(&ServerStatus{})
+	require.NoError(t, err, "Failed to migrate DB for Globus table")
+}
+
+func teardownMockDirectorDB(t *testing.T) {
+	err := ShutdownDirectorDB()
+	require.NoError(t, err, "Error tearing down mock director DB")
+}
+
+func insertMockDBData(ss []ServerStatus) error {
+	return db.Create(&ss).Error
+}
+
+func TestDirectorDBBasics(t *testing.T) {
+	server_utils.ResetTestState()
+	setupMockDirectorDB(t)
+	t.Cleanup(func() {
+		teardownMockDirectorDB(t)
+	})
+	err := insertMockDBData(mockSS)
+	require.NoError(t, err)
+
+	downtime, err := GetServerDowntime(mockSS[1].URL)
+	assert.True(t, downtime)
+	require.NoError(t, err)
+
+	err = SetServerDowntime(false, mockSS[1].URL)
+	require.NoError(t, err)
+	downtime, err = GetServerDowntime(mockSS[1].URL)
+	assert.False(t, downtime)
+	require.NoError(t, err)
+}

--- a/director/director_ui.go
+++ b/director/director_ui.go
@@ -251,8 +251,10 @@ func handleFilterServer(ctx *gin.Context) {
 	// If we previously temporarily allowed a server, we switch to permFiltered (reset)
 	if filterType == tempAllowed {
 		filteredServers[sn] = permFiltered
+		SetServerStatus(sn, permFiltered)
 	} else {
 		filteredServers[sn] = tempFiltered
+		SetServerStatus(sn, tempFiltered)
 	}
 	ctx.JSON(http.StatusOK, server_structs.SimpleApiResp{Status: server_structs.RespOK, Msg: "success"})
 }
@@ -284,9 +286,11 @@ func handleAllowServer(ctx *gin.Context) {
 	if ft == tempFiltered {
 		// For temporarily filtered server, allowing them by removing the server from the map
 		delete(filteredServers, sn)
+		DeleteServerStatus(sn)
 	} else if ft == permFiltered {
 		// For servers to filter from the config, temporarily allow the server
 		filteredServers[sn] = tempAllowed
+		SetServerStatus(sn, tempAllowed)
 	} else if ft == topoFiltered {
 		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,

--- a/director/director_ui.go
+++ b/director/director_ui.go
@@ -251,10 +251,10 @@ func handleFilterServer(ctx *gin.Context) {
 	// If we previously temporarily allowed a server, we switch to permFiltered (reset)
 	if filterType == tempAllowed {
 		filteredServers[sn] = permFiltered
-		SetServerStatus(sn, permFiltered)
+		SetServerDowntime(sn, permFiltered)
 	} else {
 		filteredServers[sn] = tempFiltered
-		SetServerStatus(sn, tempFiltered)
+		SetServerDowntime(sn, tempFiltered)
 	}
 	ctx.JSON(http.StatusOK, server_structs.SimpleApiResp{Status: server_structs.RespOK, Msg: "success"})
 }
@@ -286,11 +286,11 @@ func handleAllowServer(ctx *gin.Context) {
 	if ft == tempFiltered {
 		// For temporarily filtered server, allowing them by removing the server from the map
 		delete(filteredServers, sn)
-		DeleteServerStatus(sn)
+		DeleteServerDowntime(sn)
 	} else if ft == permFiltered {
 		// For servers to filter from the config, temporarily allow the server
 		filteredServers[sn] = tempAllowed
-		SetServerStatus(sn, tempAllowed)
+		SetServerDowntime(sn, tempAllowed)
 	} else if ft == topoFiltered {
 		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,

--- a/director/maxmind.go
+++ b/director/maxmind.go
@@ -144,7 +144,7 @@ func periodicMaxMindReload(ctx context.Context) {
 	}
 }
 
-func InitializeDB(ctx context.Context) {
+func InitializeGeoIPDB(ctx context.Context) {
 	go periodicMaxMindReload(ctx)
 	localFile := param.Director_GeoIPLocation.GetString()
 	localReader, err := geoip2.Open(localFile)

--- a/director/migrations/20241017135850_create_db_tables.sql
+++ b/director/migrations/20241017135850_create_db_tables.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE server_status (
+    uuid TEXT PRIMARY KEY,
+    url TEXT NOT NULL DEFAULT '',
+    downtime BOOLEAN NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- +goose StatementEnd

--- a/director/migrations/20241017135850_create_db_tables.sql
+++ b/director/migrations/20241017135850_create_db_tables.sql
@@ -2,8 +2,8 @@
 -- +goose StatementBegin
 CREATE TABLE server_status (
     uuid TEXT PRIMARY KEY,
-    url TEXT NOT NULL DEFAULT '',
-    downtime BOOLEAN NOT NULL DEFAULT 0,
+    name TEXT NOT NULL UNIQUE,
+    filter_type TEXT NOT NULL,
     created_at DATETIME NOT NULL,
     updated_at DATETIME NOT NULL
 );

--- a/director/migrations/20241017135850_create_db_tables.sql
+++ b/director/migrations/20241017135850_create_db_tables.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 -- +goose StatementBegin
-CREATE TABLE server_status (
+CREATE TABLE server_downtimes (
     uuid TEXT PRIMARY KEY,
     name TEXT NOT NULL UNIQUE,
     filter_type TEXT NOT NULL,

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1243,6 +1243,14 @@ components: ["cache"]
 ############################
 #  Director-level configs  #
 ############################
+name: Director.DbLocation
+description: |+
+  A filepath to the intended location of the director's database.
+type: filename
+root_default: /var/lib/pelican/director.sqlite
+default: $ConfigBase/director.sqlite
+components: ["director"]
+---
 name: Director.DefaultResponse
 description: |+
   The default response type of a redirect for a director instance. Can be either "cache" or "origin". If a director

--- a/launchers/director_serve.go
+++ b/launchers/director_serve.go
@@ -39,6 +39,9 @@ func DirectorServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group
 	log.Info("Initializing Director GeoIP database...")
 	director.InitializeGeoIPDB(ctx)
 
+	if err := director.InitializeDB(); err != nil {
+		return errors.Wrap(err, "failed to initialize director sqlite database")
+	}
 	director.ConfigFilterdServers()
 
 	director.LaunchTTLCache(ctx, egrp)
@@ -46,8 +49,6 @@ func DirectorServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group
 	director.LaunchMapMetrics(ctx, egrp)
 
 	director.LaunchServerCountMetric(ctx, egrp)
-
-	director.ConfigFilterdServers()
 
 	director.LaunchServerIOQuery(ctx, egrp)
 
@@ -76,9 +77,6 @@ func DirectorServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group
 		if err != nil {
 			return errors.Wrap(err, "invalid URL for Director.SupportContactUrl")
 		}
-	}
-	if err := director.InitializeDB(); err != nil {
-		return errors.Wrap(err, "failed to initialize director sqlite database")
 	}
 	rootGroup := engine.Group("/")
 	director.RegisterDirectorOIDCAPI(rootGroup)

--- a/launchers/director_serve.go
+++ b/launchers/director_serve.go
@@ -37,7 +37,7 @@ import (
 func DirectorServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group) error {
 
 	log.Info("Initializing Director GeoIP database...")
-	director.InitializeDB(ctx)
+	director.InitializeGeoIPDB(ctx)
 
 	director.ConfigFilterdServers()
 
@@ -76,6 +76,9 @@ func DirectorServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group
 		if err != nil {
 			return errors.Wrap(err, "invalid URL for Director.SupportContactUrl")
 		}
+	}
+	if err := director.InitializeDB(); err != nil {
+		return errors.Wrap(err, "failed to initialize director sqlite database")
 	}
 	rootGroup := engine.Group("/")
 	director.RegisterDirectorOIDCAPI(rootGroup)

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -151,6 +151,7 @@ var (
 	Cache_Url = StringParam{"Cache.Url"}
 	Cache_XRootDPrefix = StringParam{"Cache.XRootDPrefix"}
 	Director_CacheSortMethod = StringParam{"Director.CacheSortMethod"}
+	Director_DbLocation = StringParam{"Director.DbLocation"}
 	Director_DefaultResponse = StringParam{"Director.DefaultResponse"}
 	Director_GeoIPLocation = StringParam{"Director.GeoIPLocation"}
 	Director_MaxMindKeyFile = StringParam{"Director.MaxMindKeyFile"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -63,6 +63,7 @@ type Config struct {
 		CacheResponseHostnames []string `mapstructure:"cacheresponsehostnames"`
 		CacheSortMethod string `mapstructure:"cachesortmethod"`
 		CachesPullFromCaches bool `mapstructure:"cachespullfromcaches"`
+		DbLocation string `mapstructure:"dblocation"`
 		DefaultResponse string `mapstructure:"defaultresponse"`
 		EnableBroker bool `mapstructure:"enablebroker"`
 		EnableOIDC bool `mapstructure:"enableoidc"`
@@ -359,6 +360,7 @@ type configWithType struct {
 		CacheResponseHostnames struct { Type string; Value []string }
 		CacheSortMethod struct { Type string; Value string }
 		CachesPullFromCaches struct { Type string; Value bool }
+		DbLocation struct { Type string; Value string }
 		DefaultResponse struct { Type string; Value string }
 		EnableBroker struct { Type string; Value bool }
 		EnableOIDC struct { Type string; Value bool }


### PR DESCRIPTION
This PR enables director to persist the origin/cache server downtime set by the admin in a sqlite db. Fundamentally, it syncs the existing variable `filteredServers` in cache with the `server_downtimes` table in db.

In order to test it, you need to add Director.DbLocation: <directory_of_your_choice> (e.g. /workspaces/pelican/director.sqlite) in `pelican.yaml`

A little bit interpretation of the existing code:
`filteredServers` has a data field `filterType`, which have the following types:
> permFiltered: "Permanently Disabled via the director configuration"
> tempFiltered: "Temporarily disabled via the admin website"
> topoFiltered: "Disabled via the Topology policy"
> tempAllowed: "Temporarily enabled via the admin website"
> "": the empty value at the UI side
> default: "Unknown Type"
Different filter types decide the server downtime is temporary or permanent. The new db in this PR coheres this logic.