### PR TITLE
Tuning Pelican for running xrootd under valgrind

### DIFF
--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -60,6 +60,7 @@ Director:
   CachePresenceTTL: 1m
   CachePresenceCapacity: 10000
 Cache:
+  DefaultCacheTimeout: "9.5s"
   Port: 8442
   SelfTest: true
   SelfTestInterval: 15s

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -100,6 +100,7 @@ Shoveler:
   PortHigher: 9999
   AMQPExchange: shoveled-xrd
 Xrootd:
+  MaxStartupWait: "10s"
   Mount: ""
   ManagerPort: 1213
   DetailedMonitoringPort: 9930

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1249,6 +1249,16 @@ type: int
 default: 0
 components: ["cache"]
 ---
+name: Cache.DefaultCacheTimeout
+description: |+
+  The default value of the cache operation timeout if one is not specified by the client.
+
+  Newer clients should always specify a timeout; changing this default is rarely necessary.
+type: duration
+default: 9.5s
+hidden: true
+components: ["cache"]
+---
 ############################
 #  Director-level configs  #
 ############################

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2278,6 +2278,15 @@ type: string
 default: none
 components: ["origin"]
 ---
+name: Xrootd.MaxStartupWait
+description: |+
+  The maximum amount of time pelican will wait for the xrootd daemons to
+  successfully start
+type: duration
+default: 10s
+hidden: true
+components: ["origin", "cache"]
+---
 ############################
 # Monitoring-level configs #
 ############################

--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -56,6 +56,7 @@ RUN yum install -y --enablerepo=osg-testing goreleaser npm xrootd-devel xrootd-s
     xrdcl-http jq procps docker make curl-devel java-17-openjdk-headless git cmake3 gcc-c++ openssl-devel sqlite-devel libcap-devel sssd-client \
     xrootd-multiuser \
     zlib-devel \
+    vim valgrind gdb gtest-devel \
     && yum clean all
 
 # The ADD command with a api.github.com URL in the next couple of sections

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -378,6 +378,7 @@ var (
 )
 
 var (
+	Cache_DefaultCacheTimeout = DurationParam{"Cache.DefaultCacheTimeout"}
 	Cache_SelfTestInterval = DurationParam{"Cache.SelfTestInterval"}
 	Client_SlowTransferRampupTime = DurationParam{"Client.SlowTransferRampupTime"}
 	Client_SlowTransferWindow = DurationParam{"Client.SlowTransferWindow"}

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -401,6 +401,7 @@ var (
 	Transport_ResponseHeaderTimeout = DurationParam{"Transport.ResponseHeaderTimeout"}
 	Transport_TLSHandshakeTimeout = DurationParam{"Transport.TLSHandshakeTimeout"}
 	Xrootd_AuthRefreshInterval = DurationParam{"Xrootd.AuthRefreshInterval"}
+	Xrootd_MaxStartupWait = DurationParam{"Xrootd.MaxStartupWait"}
 )
 
 var (

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -29,6 +29,7 @@ type Config struct {
 		Concurrency int `mapstructure:"concurrency" yaml:"Concurrency"`
 		DataLocation string `mapstructure:"datalocation" yaml:"DataLocation"`
 		DataLocations []string `mapstructure:"datalocations" yaml:"DataLocations"`
+		DefaultCacheTimeout time.Duration `mapstructure:"defaultcachetimeout" yaml:"DefaultCacheTimeout"`
 		EnableLotman bool `mapstructure:"enablelotman" yaml:"EnableLotman"`
 		EnableOIDC bool `mapstructure:"enableoidc" yaml:"EnableOIDC"`
 		EnableVoms bool `mapstructure:"enablevoms" yaml:"EnableVoms"`
@@ -334,6 +335,7 @@ type configWithType struct {
 		Concurrency struct { Type string; Value int }
 		DataLocation struct { Type string; Value string }
 		DataLocations struct { Type string; Value []string }
+		DefaultCacheTimeout struct { Type string; Value time.Duration }
 		EnableLotman struct { Type string; Value bool }
 		EnableOIDC struct { Type string; Value bool }
 		EnableVoms struct { Type string; Value bool }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -315,6 +315,7 @@ type Config struct {
 		MacaroonsKeyFile string `mapstructure:"macaroonskeyfile" yaml:"MacaroonsKeyFile"`
 		ManagerHost string `mapstructure:"managerhost" yaml:"ManagerHost"`
 		ManagerPort int `mapstructure:"managerport" yaml:"ManagerPort"`
+		MaxStartupWait time.Duration `mapstructure:"maxstartupwait" yaml:"MaxStartupWait"`
 		Mount string `mapstructure:"mount" yaml:"Mount"`
 		Port int `mapstructure:"port" yaml:"Port"`
 		RobotsTxtFile string `mapstructure:"robotstxtfile" yaml:"RobotsTxtFile"`
@@ -619,6 +620,7 @@ type configWithType struct {
 		MacaroonsKeyFile struct { Type string; Value string }
 		ManagerHost struct { Type string; Value string }
 		ManagerPort struct { Type string; Value int }
+		MaxStartupWait struct { Type string; Value time.Duration }
 		Mount struct { Type string; Value string }
 		Port struct { Type string; Value int }
 		RobotsTxtFile struct { Type string; Value string }

--- a/xrootd/launch.go
+++ b/xrootd/launch.go
@@ -165,7 +165,7 @@ func LaunchDaemons(ctx context.Context, launchers []daemon.Launcher, egrp *errgr
 		return
 	}
 
-	ticker := time.NewTicker(10 * time.Second)
+	ticker := time.NewTicker(param.Xrootd_MaxStartupWait.GetDuration())
 	defer ticker.Stop()
 	select {
 	case <-ctx.Done():
@@ -180,8 +180,8 @@ func LaunchDaemons(ctx context.Context, launchers []daemon.Launcher, egrp *errgr
 			portStartCallback(port)
 		}
 	case <-ticker.C:
-		log.Errorln("XRootD did not startup after 10s of waiting")
-		err = errors.New("XRootD did not startup after 10s of waiting")
+		log.Errorln("XRootD did not startup after", param.Xrootd_MaxStartupWait.GetDuration().String(), "of waiting")
+		err = errors.New("XRootD did not startup after " + param.Xrootd_MaxStartupWait.GetDuration().String() + " of waiting")
 		return
 	}
 

--- a/xrootd/launch.go
+++ b/xrootd/launch.go
@@ -91,6 +91,8 @@ func makeUnprivilegedXrootdLauncher(daemonName string, configPath string, isCach
 		if confDir := os.Getenv("XRD_PLUGINCONFDIR"); confDir != "" {
 			result.ExtraEnv = append(result.ExtraEnv, "XRD_PLUGINCONFDIR="+confDir)
 		}
+		result.ExtraEnv = append(result.ExtraEnv, "XRD_PELICANFEDERATIONMETADATATIMEOUT="+param.Cache_DefaultCacheTimeout.GetDuration().String())
+		result.ExtraEnv = append(result.ExtraEnv, "XRD_PELICANDEFAULTHEADERTIMEOUT="+param.Cache_DefaultCacheTimeout.GetDuration().String())
 	}
 	return
 }


### PR DESCRIPTION
Valgrind is incredibly useful C++ debugging tool to check for leaks and other memory usage errors.

However, it also makes the application incredibly slow: it's often a 20x (or more) performance penalty.  Xrootd caches hit the timeouts frequently.

This PR adds a few hidden tunables to allow us to increase timeouts enough for xrootd to run under valgrind.  It also adds some standard C++ debugging tools into the development container.