### PR TITLE
Improved `pelican_director_server_count` metric

### DIFF
--- a/director/director.go
+++ b/director/director.go
@@ -106,7 +106,7 @@ var (
 )
 
 func init() {
-	HookServerAdsCache()
+	hookServerAdsCache()
 }
 
 func getRedirectURL(reqPath string, ad server_structs.ServerAd, requiresAuth bool) (redirectURL url.URL) {

--- a/director/director.go
+++ b/director/director.go
@@ -105,6 +105,10 @@ var (
 	statUtilsMutex = sync.RWMutex{}
 )
 
+func init() {
+	HookServerAdsCache()
+}
+
 func getRedirectURL(reqPath string, ad server_structs.ServerAd, requiresAuth bool) (redirectURL url.URL) {
 	var serverURL url.URL
 	if requiresAuth && ad.AuthURL.String() != "" {

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -198,7 +198,7 @@ func LaunchMapMetrics(ctx context.Context, egrp *errgroup.Group) {
 	})
 }
 
-func HookServerAdsCache() {
+func hookServerAdsCache() {
 	// Hook into server ads cache
 	// By hooking into the insertion and eviction events, we can keep track of the number of servers in the director
 	// The metric is updated based on the server type, server name, and whether the server is from the topology

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -198,7 +198,7 @@ func LaunchMapMetrics(ctx context.Context, egrp *errgroup.Group) {
 	})
 }
 
-func LaunchServerCountMetric() {
+func HookServerAdsCache() {
 	// Hook into server ads cache
 	// By hooking into the insertion and eviction events, we can keep track of the number of servers in the director
 	// The metric is updated based on the server type, server name, and whether the server is from the topology

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -198,7 +198,7 @@ func LaunchMapMetrics(ctx context.Context, egrp *errgroup.Group) {
 	})
 }
 
-func LaunchServerCountMetric(ctx context.Context, egrp *errgroup.Group) {
+func LaunchServerCountMetric() {
 	// Hook into server ads cache
 	// By hooking into the insertion and eviction events, we can keep track of the number of servers in the director
 	// The metric is updated based on the server type, server name, and whether the server is from the topology

--- a/launchers/director_serve.go
+++ b/launchers/director_serve.go
@@ -45,7 +45,7 @@ func DirectorServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group
 
 	director.LaunchMapMetrics(ctx, egrp)
 
-	director.LaunchServerCountMetric(ctx, egrp)
+	director.LaunchServerCountMetric()
 
 	director.ConfigFilterdServers()
 

--- a/launchers/director_serve.go
+++ b/launchers/director_serve.go
@@ -45,8 +45,6 @@ func DirectorServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group
 
 	director.LaunchMapMetrics(ctx, egrp)
 
-	director.LaunchServerCountMetric()
-
 	director.ConfigFilterdServers()
 
 	director.LaunchServerIOQuery(ctx, egrp)

--- a/metrics/director.go
+++ b/metrics/director.go
@@ -82,10 +82,10 @@ var (
 		Help: "The total stat queries the director issues. The status can be Succeeded, Cancelled, Timeout, Forbidden, or UnknownErr",
 	}, []string{"server_name", "server_url", "server_type", "result"}) // result: see enums for DirectorStatResult
 
-	PelicanDirectorServerCount = promauto.NewCounterVec(prometheus.CounterOpts{
+	PelicanDirectorServerCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "pelican_director_server_count",
-		Help: "Total number of servers, delineated by pelican/non-pelican and origin/cache",
-	}, []string{"server_name", "server_type", "server_url", "server_web_url", "server_lat", "server_long", "from_topology"})
+		Help: "The number of servers, delineated by pelican/non-pelican and origin/cache",
+	}, []string{"server_name", "server_type", "from_topology"})
 
 	PelicanDirectorClientVersionTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "pelican_director_client_version_total",

--- a/metrics/director.go
+++ b/metrics/director.go
@@ -84,7 +84,7 @@ var (
 
 	PelicanDirectorServerCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "pelican_director_server_count",
-		Help: "The number of servers, delineated by pelican/non-pelican and origin/cache",
+		Help: "The number of servers currently recognized by the Director, delineated by pelican/non-pelican and origin/cache",
 	}, []string{"server_name", "server_type", "from_topology"})
 
 	PelicanDirectorClientVersionTotal = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
This PR addresses issue #1636. This PR removes unnecessary labels from the metric and changes the metric to a gauge. This metric should now reflect at any given moment, how many servers are connected to the director.