### PR TITLE
POSIX Sync Handling

### DIFF
--- a/client/fed_linux_test.go
+++ b/client/fed_linux_test.go
@@ -32,7 +32,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pelicanplatform/pelican/client"
@@ -68,12 +67,12 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 	tokenConfig.AddResourceScopes(token_scopes.NewResourceScope(token_scopes.Storage_Read, "/"),
 		token_scopes.NewResourceScope(token_scopes.Storage_Modify, "/"))
 	token, err := tokenConfig.CreateToken()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tempToken, err := os.CreateTemp(t.TempDir(), "token")
-	assert.NoError(t, err, "Error creating temp token file")
+	require.NoError(t, err, "Error creating temp token file")
 	defer os.Remove(tempToken.Name())
 	_, err = tempToken.WriteString(token)
-	assert.NoError(t, err, "Error writing to temp token file")
+	require.NoError(t, err, "Error writing to temp token file")
 	tempToken.Close()
 
 	// Disable progress bars to not reuse the same mpb instance
@@ -81,9 +80,9 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 
 	// Make our test directories and files
 	tempDir, err := os.MkdirTemp("", "UploadDir")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	innerTempDir, err := os.MkdirTemp(tempDir, "InnerUploadDir")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.RemoveAll(tempDir)
 	defer os.RemoveAll(tempDir)
 	permissions := os.FileMode(0755)
@@ -96,28 +95,28 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 	testFileContent2 := "more test file content!"
 	innerTestFileContent := "this content is within another dir!"
 	tempFile1, err := os.CreateTemp(tempDir, "test1")
-	assert.NoError(t, err, "Error creating temp1 file")
+	require.NoError(t, err, "Error creating temp1 file")
 	tempFile2, err := os.CreateTemp(tempDir, "test1")
-	assert.NoError(t, err, "Error creating temp2 file")
+	require.NoError(t, err, "Error creating temp2 file")
 	innerTempFile, err := os.CreateTemp(innerTempDir, "testInner")
-	assert.NoError(t, err, "Error creating inner test file")
+	require.NoError(t, err, "Error creating inner test file")
 	defer os.Remove(tempFile1.Name())
 	defer os.Remove(tempFile2.Name())
 	defer os.Remove(innerTempFile.Name())
 
 	_, err = tempFile1.WriteString(testFileContent1)
-	assert.NoError(t, err, "Error writing to temp1 file")
+	require.NoError(t, err, "Error writing to temp1 file")
 	tempFile1.Close()
 	_, err = tempFile2.WriteString(testFileContent2)
-	assert.NoError(t, err, "Error writing to temp2 file")
+	require.NoError(t, err, "Error writing to temp2 file")
 	tempFile2.Close()
 	_, err = innerTempFile.WriteString(innerTestFileContent)
-	assert.NoError(t, err, "Error writing to inner test file")
+	require.NoError(t, err, "Error writing to inner test file")
 	innerTempFile.Close()
 
 	t.Run("testPelicanRecursiveGetAndPutPelicanURL", func(t *testing.T) {
 		oldPref, err := config.SetPreferredPrefix(config.PelicanPrefix)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		defer func() {
 			_, err := config.SetPreferredPrefix(oldPref)
 			require.NoError(t, err)
@@ -153,7 +152,7 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 			_, err := config.SetPreferredPrefix(oldPref)
 			require.NoError(t, err)
 		}()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		oldHost, err := pelican_url.SetOsdfDiscoveryHost(discoveryUrl.String())
 		require.NoError(t, err)
@@ -187,7 +186,7 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 
 	t.Run("testOsdfRecursiveGetAndPutPelicanURL", func(t *testing.T) {
 		oldPref, err := config.SetPreferredPrefix(config.OsdfPrefix)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		defer func() {
 			_, err := config.SetPreferredPrefix(oldPref)
 			require.NoError(t, err)
@@ -272,12 +271,12 @@ func TestRecursiveUploadsAndDownloadsWithQuery(t *testing.T) {
 	tokenConfig.AddResourceScopes(token_scopes.NewResourceScope(token_scopes.Storage_Read, "/"),
 		token_scopes.NewResourceScope(token_scopes.Storage_Modify, "/"))
 	token, err := tokenConfig.CreateToken()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tempToken, err := os.CreateTemp(t.TempDir(), "token")
-	assert.NoError(t, err, "Error creating temp token file")
+	require.NoError(t, err, "Error creating temp token file")
 	defer os.Remove(tempToken.Name())
 	_, err = tempToken.WriteString(token)
-	assert.NoError(t, err, "Error writing to temp token file")
+	require.NoError(t, err, "Error writing to temp token file")
 	tempToken.Close()
 
 	// Disable progress bars to not reuse the same mpb instance
@@ -285,9 +284,9 @@ func TestRecursiveUploadsAndDownloadsWithQuery(t *testing.T) {
 
 	// Make our test directories and files
 	tempDir, err := os.MkdirTemp("", "UploadDir")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	innerTempDir, err := os.MkdirTemp(tempDir, "InnerUploadDir")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.RemoveAll(tempDir)
 	permissions := os.FileMode(0755)
 	err = os.Chmod(tempDir, permissions)
@@ -299,29 +298,29 @@ func TestRecursiveUploadsAndDownloadsWithQuery(t *testing.T) {
 	testFileContent2 := "more test file content!"
 	innerTestFileContent := "this content is within another dir!"
 	tempFile1, err := os.CreateTemp(tempDir, "test1")
-	assert.NoError(t, err, "Error creating temp1 file")
+	require.NoError(t, err, "Error creating temp1 file")
 	tempFile2, err := os.CreateTemp(tempDir, "test1")
-	assert.NoError(t, err, "Error creating temp2 file")
+	require.NoError(t, err, "Error creating temp2 file")
 	innerTempFile, err := os.CreateTemp(innerTempDir, "testInner")
-	assert.NoError(t, err, "Error creating inner test file")
+	require.NoError(t, err, "Error creating inner test file")
 	defer os.Remove(tempFile1.Name())
 	defer os.Remove(tempFile2.Name())
 	defer os.Remove(innerTempFile.Name())
 
 	_, err = tempFile1.WriteString(testFileContent1)
-	assert.NoError(t, err, "Error writing to temp1 file")
+	require.NoError(t, err, "Error writing to temp1 file")
 	tempFile1.Close()
 	_, err = tempFile2.WriteString(testFileContent2)
-	assert.NoError(t, err, "Error writing to temp2 file")
+	require.NoError(t, err, "Error writing to temp2 file")
 	tempFile2.Close()
 	_, err = innerTempFile.WriteString(innerTestFileContent)
-	assert.NoError(t, err, "Error writing to inner test file")
+	require.NoError(t, err, "Error writing to inner test file")
 	innerTempFile.Close()
 
 	// Test we work with just the query
 	t.Run("testRecursiveGetAndPutWithQuery", func(t *testing.T) {
 		_, err := config.SetPreferredPrefix(config.PelicanPrefix)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		for _, export := range fed.Exports {
 			// Set path for object to upload/download
@@ -349,7 +348,7 @@ func TestRecursiveUploadsAndDownloadsWithQuery(t *testing.T) {
 	// Test we work with a value assigned to it (we print deprecation warning)
 	t.Run("testRecursiveGetAndPutWithQueryWithValueTrue", func(t *testing.T) {
 		_, err := config.SetPreferredPrefix(config.PelicanPrefix)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		for _, export := range fed.Exports {
 			// Set path for object to upload/download
@@ -377,7 +376,7 @@ func TestRecursiveUploadsAndDownloadsWithQuery(t *testing.T) {
 	// Test we work with a value assigned to it but says recursive=false (we print deprecation warning and ignore arguments in query so we still work)
 	t.Run("testRecursiveGetAndPutWithQueryWithValueFalse", func(t *testing.T) {
 		_, err := config.SetPreferredPrefix(config.PelicanPrefix)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		for _, export := range fed.Exports {
 			// Set path for object to upload/download
@@ -405,7 +404,7 @@ func TestRecursiveUploadsAndDownloadsWithQuery(t *testing.T) {
 	// Test we work with both recursive and directread query params
 	t.Run("testRecursiveGetAndPutWithQueryAndDirectread", func(t *testing.T) {
 		_, err := config.SetPreferredPrefix(config.PelicanPrefix)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		for _, export := range fed.Exports {
 			// Set path for object to upload/download
@@ -452,8 +451,8 @@ func TestFailureOnOriginDisablingListings(t *testing.T) {
 		fed.Exports[0].FederationPrefix, "test")
 
 	_, err = client.DoGet(fed.Ctx, downloadURL, t.TempDir(), true)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no collections URL found in director response")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no collections URL found in director response")
 }
 
 func TestSyncUpload(t *testing.T) {
@@ -476,12 +475,12 @@ func TestSyncUpload(t *testing.T) {
 	tokenConfig.AddResourceScopes(token_scopes.NewResourceScope(token_scopes.Storage_Read, "/"),
 		token_scopes.NewResourceScope(token_scopes.Storage_Modify, "/"))
 	token, err := tokenConfig.CreateToken()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tempToken, err := os.CreateTemp(t.TempDir(), "token")
-	assert.NoError(t, err, "Error creating temp token file")
+	require.NoError(t, err, "Error creating temp token file")
 	defer os.Remove(tempToken.Name())
 	_, err = tempToken.WriteString(token)
-	assert.NoError(t, err, "Error writing to temp token file")
+	require.NoError(t, err, "Error writing to temp token file")
 	tempToken.Close()
 
 	// Disable progress bars to not reuse the same mpb instance
@@ -490,7 +489,7 @@ func TestSyncUpload(t *testing.T) {
 	// Make our test directories and files
 	tempDir := t.TempDir()
 	innerTempDir, err := os.MkdirTemp(tempDir, "InnerUploadDir")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	permissions := os.FileMode(0755)
 	err = os.Chmod(tempDir, permissions)
 	require.NoError(t, err)
@@ -502,7 +501,7 @@ func TestSyncUpload(t *testing.T) {
 	innerTestFileContent := "this content is within another dir!"
 	tempFile1, err := os.CreateTemp(tempDir, "test1")
 	require.NoError(t, err, "Error creating temp1 file")
-	tempFile2, err := os.CreateTemp(tempDir, "test1")
+	tempFile2, err := os.CreateTemp(tempDir, "test2")
 	require.NoError(t, err, "Error creating temp2 file")
 	innerTempFile, err := os.CreateTemp(innerTempDir, "testInner")
 	require.NoError(t, err, "Error creating inner test file")
@@ -523,7 +522,7 @@ func TestSyncUpload(t *testing.T) {
 		dirName := filepath.Base(tempPath)
 		uploadUrl := fmt.Sprintf("pelican://%s/first/namespace/sync_upload/%s", discoveryUrl.Host, dirName)
 
-		// Upload the file with PUT
+		// Upload the files with PUT
 		transferDetailsUpload, err := client.DoPut(fed.Ctx, tempDir, uploadUrl, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
 		require.NoError(t, err)
 		verifySuccessfulTransfer(t, transferDetailsUpload)
@@ -539,7 +538,7 @@ func TestSyncUpload(t *testing.T) {
 		dirName := filepath.Base(tempDir)
 		uploadUrl := fmt.Sprintf("pelican://%s/first/namespace/sync_upload_none/%s", discoveryUrl.Host, dirName)
 
-		// Upload the file with PUT
+		// Upload the files with PUT
 		transferDetailsUpload, err := client.DoPut(fed.Ctx, tempDir, uploadUrl, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
 		require.NoError(t, err)
 		verifySuccessfulTransfer(t, transferDetailsUpload)
@@ -549,7 +548,7 @@ func TestSyncUpload(t *testing.T) {
 		require.NoError(t, err)
 
 		// Should have already been uploaded once
-		assert.Len(t, transferDetailsUpload, 0)
+		require.Len(t, transferDetailsUpload, 0)
 	})
 
 	t.Run("testSyncUploadPartial", func(t *testing.T) {
@@ -580,9 +579,67 @@ func TestSyncUpload(t *testing.T) {
 		verifySuccessfulTransfer(t, transferDetailsDownload)
 
 		// Verify we received the original contents, not any modified contents
-		contentBytes, err := os.ReadFile(filepath.Join(downloadDir, dirName, filepath.Base(innerTempDir), filepath.Base(innerTempFile.Name())))
+		contentBytes, err := os.ReadFile(filepath.Join(downloadDir, filepath.Base(innerTempDir), filepath.Base(innerTempFile.Name())))
 		require.NoError(t, err)
-		assert.Equal(t, innerTestFileContent, string(contentBytes))
+		require.Equal(t, innerTestFileContent, string(contentBytes))
+	})
+
+	t.Run("testSyncUploadFile", func(t *testing.T) {
+		// Create a new test file to upload
+		newDir := t.TempDir()
+		newTestFile, err := os.CreateTemp(newDir, "newTest")
+		newTestFileContent := "This is a brand new file"
+		require.NoError(t, err, "Error creating new test file")
+		_, err = newTestFile.WriteString(newTestFileContent)
+		require.NoError(t, err, "Error writing to new test file")
+
+		dirName := filepath.Base(tempDir)
+		uploadUrl := fmt.Sprintf("pelican://%s/first/namespace/sync_upload_none/%s/%s", discoveryUrl.Host, dirName, "test_single_upload")
+
+		// Upload the file
+		transferDetailsUpload, err := client.DoPut(fed.Ctx, newTestFile.Name(), uploadUrl, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		require.NoError(t, err)
+		require.Len(t, transferDetailsUpload, 1)
+
+		// Download the new object
+		downloadDir := t.TempDir()
+		transferDetailsDownload, err := client.DoGet(fed.Ctx, uploadUrl, downloadDir, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		require.NoError(t, err)
+		require.Len(t, transferDetailsDownload, 1)
+
+		// Verify we received the new contents with the expected object name
+		contentBytes, err := os.ReadFile(filepath.Join(downloadDir, "test_single_upload"))
+		require.NoError(t, err)
+		require.Equal(t, newTestFileContent, string(contentBytes))
+
+		smallTestFile, err := os.CreateTemp(newDir, "smallTest")
+		smallTestFileContent := "smaller test file"
+		require.NoError(t, err, "Error creating small test file")
+		_, err = smallTestFile.WriteString(smallTestFileContent)
+		require.NoError(t, err, "Error writing to small test file")
+
+		//Upload the file into the same location as the previous test file - should overwrite
+		transferDetailsUpload, err = client.DoPut(fed.Ctx, smallTestFile.Name(), uploadUrl, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		require.NoError(t, err)
+		require.Len(t, transferDetailsUpload, 1)
+
+		// Download the overwritten object directly from the origin
+		downloadDir = t.TempDir()
+		transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadUrl+"?directread", downloadDir, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		require.NoError(t, err)
+		require.Len(t, transferDetailsDownload, 1)
+
+		// Verify we received the overwritten contents with the expected object name
+		contentBytes, err = os.ReadFile(filepath.Join(downloadDir, "test_single_upload"))
+		require.NoError(t, err)
+		require.Equal(t, smallTestFileContent, string(contentBytes))
+
+		// Change the upload url to a collection
+		uploadUrl = fmt.Sprintf("pelican://%s/first/namespace/sync_upload_none/%s", discoveryUrl.Host, dirName)
+
+		// Attempt to sync an upload of a single file to a collection, should fail
+		_, err = client.DoPut(fed.Ctx, smallTestFile.Name(), uploadUrl, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		require.ErrorContains(t, err, "Request failed (HTTP status 409)")
 	})
 }
 
@@ -606,12 +663,12 @@ func TestSyncDownload(t *testing.T) {
 	tokenConfig.AddResourceScopes(token_scopes.NewResourceScope(token_scopes.Storage_Read, "/"),
 		token_scopes.NewResourceScope(token_scopes.Storage_Modify, "/"))
 	token, err := tokenConfig.CreateToken()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tempToken, err := os.CreateTemp(t.TempDir(), "token")
-	assert.NoError(t, err, "Error creating temp token file")
+	require.NoError(t, err, "Error creating temp token file")
 	defer os.Remove(tempToken.Name())
 	_, err = tempToken.WriteString(token)
-	assert.NoError(t, err, "Error writing to temp token file")
+	require.NoError(t, err, "Error writing to temp token file")
 	tempToken.Close()
 
 	// Disable progress bars to not reuse the same mpb instance
@@ -620,7 +677,7 @@ func TestSyncDownload(t *testing.T) {
 	// Make our test directories and files
 	tempDir := t.TempDir()
 	innerTempDir, err := os.MkdirTemp(tempDir, "InnerUploadDir")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	permissions := os.FileMode(0755)
 	err = os.Chmod(tempDir, permissions)
 	require.NoError(t, err)
@@ -632,7 +689,7 @@ func TestSyncDownload(t *testing.T) {
 	innerTestFileContent := "this content is within another dir!"
 	tempFile1, err := os.CreateTemp(tempDir, "test1")
 	require.NoError(t, err, "Error creating temp1 file")
-	tempFile2, err := os.CreateTemp(tempDir, "test1")
+	tempFile2, err := os.CreateTemp(tempDir, "test2")
 	require.NoError(t, err, "Error creating temp2 file")
 	innerTempFile, err := os.CreateTemp(innerTempDir, "testInner")
 	require.NoError(t, err, "Error creating inner test file")
@@ -675,8 +732,54 @@ func TestSyncDownload(t *testing.T) {
 
 		// Synchronize the files again; should result in no transfers
 		transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadUrl, dirName, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
-		assert.NoError(t, err)
-		assert.Len(t, transferDetailsDownload, 0)
+		require.NoError(t, err)
+		require.Len(t, transferDetailsDownload, 0)
+	})
+
+	t.Run("testSyncDownloadObject", func(t *testing.T) {
+		// Set path for object to upload/download
+		dirName := t.TempDir()
+		filename1 := filepath.Base(tempFile1.Name())
+		uploadUrlObj := fmt.Sprintf("%s/%s", uploadUrl, filename1)
+		downloadObjName := filepath.Join(dirName, filename1)
+
+		// Synchronize a download of a single file into an existing directory (should create the file)
+		transferDetailsDownload, err := client.DoGet(fed.Ctx, uploadUrlObj, dirName, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		require.NoError(t, err)
+		require.Len(t, transferDetailsDownload, 1)
+		contentBytes, err := os.ReadFile(downloadObjName)
+		require.NoError(t, err)
+		require.Equal(t, "test file content", string(contentBytes))
+
+		// Change the upload url to a new file
+		filenameInner := filepath.Base(innerTempFile.Name())
+		uploadUrlObj = fmt.Sprintf("%s/%s/%s", uploadUrl, filepath.Base(innerTempDir), filenameInner)
+
+		// Synchronize a download of a single file into a an existing filename (should overwrite the contents)
+		transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadUrlObj, downloadObjName, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		require.NoError(t, err)
+		require.Len(t, transferDetailsDownload, 1)
+		contentBytes, err = os.ReadFile(downloadObjName)
+		require.NoError(t, err)
+		require.Equal(t, "this content is within another dir!", string(contentBytes))
+
+		// Synchronize a download of a single file into a non-existent filename (should create the file)
+		nonExistFilename := filepath.Join(dirName, "non-existent")
+		transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadUrlObj, nonExistFilename, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		require.NoError(t, err)
+		require.Len(t, transferDetailsDownload, 1)
+		contentBytes, err = os.ReadFile(nonExistFilename)
+		require.NoError(t, err)
+		require.Equal(t, "this content is within another dir!", string(contentBytes))
+
+		// Synchronize a download of a single file into a non-existent directory w/ trailing filepath separator (should create the directory and file)
+		nonExistDir := filepath.Join(dirName, "new-dir") + string(filepath.Separator)
+		transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadUrlObj, nonExistDir, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		require.NoError(t, err)
+		require.Len(t, transferDetailsDownload, 1)
+		contentBytes, err = os.ReadFile(filepath.Join(dirName, "new-dir", filenameInner))
+		require.NoError(t, err)
+		require.Equal(t, "this content is within another dir!", string(contentBytes))
 	})
 
 	t.Run("testSyncDownloadPartial", func(t *testing.T) {
@@ -692,7 +795,7 @@ func TestSyncDownload(t *testing.T) {
 		verifySuccessfulTransfer(t, transferDetailsUpload)
 
 		// Download the inner directory
-		innerDownloadDir := filepath.Join(downloadDir, dirName, filepath.Base(innerTempDir))
+		innerDownloadDir := filepath.Join(downloadDir, filepath.Base(innerTempDir))
 		transferDetailsDownload, err := client.DoGet(fed.Ctx, uploadInnerUrl, innerDownloadDir, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
 		require.NoError(t, err)
 		require.Len(t, transferDetailsDownload, 1)
@@ -709,12 +812,12 @@ func TestSyncDownload(t *testing.T) {
 		// Download all the objects
 		transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadUrl, downloadDir, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
 		require.NoError(t, err)
-		assert.Len(t, transferDetailsDownload, 2)
+		require.Len(t, transferDetailsDownload, 2)
 
 		// Verify we received the original contents, not any modified contents
 		contentBytes, err := os.ReadFile(filepath.Join(innerDownloadDir, filepath.Base(innerTempFile.Name())))
 		require.NoError(t, err)
-		assert.Equal(t, innerTestFileContent, string(contentBytes))
+		require.Equal(t, innerTestFileContent, string(contentBytes))
 
 		// Change the local size, then re-sync
 		innerDownloadFile := filepath.Join(innerDownloadDir, filepath.Base(innerTempFile.Name()))
@@ -726,9 +829,9 @@ func TestSyncDownload(t *testing.T) {
 		log.Debugln("Re-downloading file direct from origin")
 		transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadUrl+"?directread", downloadDir, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
 		require.NoError(t, err)
-		assert.Len(t, transferDetailsDownload, 1)
+		require.Len(t, transferDetailsDownload, 1)
 		contentBytes, err = os.ReadFile(filepath.Join(innerDownloadDir, filepath.Base(innerTempFile.Name())))
 		require.NoError(t, err)
-		assert.Equal(t, newTestFileContent, string(contentBytes))
+		require.Equal(t, newTestFileContent, string(contentBytes))
 	})
 }

--- a/client/fed_linux_test.go
+++ b/client/fed_linux_test.go
@@ -740,11 +740,11 @@ func TestSyncDownload(t *testing.T) {
 		// Set path for object to upload/download
 		dirName := t.TempDir()
 		filename1 := filepath.Base(tempFile1.Name())
-		uploadUrlObj := fmt.Sprintf("%s/%s", uploadUrl, filename1)
+		downloadUrlObj := fmt.Sprintf("%s/%s", uploadUrl, filename1)
 		downloadObjName := filepath.Join(dirName, filename1)
 
 		// Synchronize a download of a single file into an existing directory (should create the file)
-		transferDetailsDownload, err := client.DoGet(fed.Ctx, uploadUrlObj, dirName, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		transferDetailsDownload, err := client.DoGet(fed.Ctx, downloadUrlObj, dirName, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
 		require.NoError(t, err)
 		require.Len(t, transferDetailsDownload, 1)
 		contentBytes, err := os.ReadFile(downloadObjName)
@@ -753,10 +753,10 @@ func TestSyncDownload(t *testing.T) {
 
 		// Change the upload url to a new file
 		filenameInner := filepath.Base(innerTempFile.Name())
-		uploadUrlObj = fmt.Sprintf("%s/%s/%s", uploadUrl, filepath.Base(innerTempDir), filenameInner)
+		downloadUrlObj = fmt.Sprintf("%s/%s/%s", uploadUrl, filepath.Base(innerTempDir), filenameInner)
 
 		// Synchronize a download of a single file into a an existing filename (should overwrite the contents)
-		transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadUrlObj, downloadObjName, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		transferDetailsDownload, err = client.DoGet(fed.Ctx, downloadUrlObj, downloadObjName, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
 		require.NoError(t, err)
 		require.Len(t, transferDetailsDownload, 1)
 		contentBytes, err = os.ReadFile(downloadObjName)
@@ -765,7 +765,7 @@ func TestSyncDownload(t *testing.T) {
 
 		// Synchronize a download of a single file into a non-existent filename (should create the file)
 		nonExistFilename := filepath.Join(dirName, "non-existent")
-		transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadUrlObj, nonExistFilename, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		transferDetailsDownload, err = client.DoGet(fed.Ctx, downloadUrlObj, nonExistFilename, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
 		require.NoError(t, err)
 		require.Len(t, transferDetailsDownload, 1)
 		contentBytes, err = os.ReadFile(nonExistFilename)
@@ -774,7 +774,7 @@ func TestSyncDownload(t *testing.T) {
 
 		// Synchronize a download of a single file into a non-existent directory w/ trailing filepath separator (should create the directory and file)
 		nonExistDir := filepath.Join(dirName, "new-dir") + string(filepath.Separator)
-		transferDetailsDownload, err = client.DoGet(fed.Ctx, uploadUrlObj, nonExistDir, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
+		transferDetailsDownload, err = client.DoGet(fed.Ctx, downloadUrlObj, nonExistDir, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
 		require.NoError(t, err)
 		require.Len(t, transferDetailsDownload, 1)
 		contentBytes, err = os.ReadFile(filepath.Join(dirName, "new-dir", filenameInner))

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2510,7 +2510,7 @@ func (te *TransferEngine) walkDirUpload(job *clientTransferJob, transfers []tran
 		if err != nil {
 			return errors.Wrap(err, "failed to stat local path")
 		}
-		// If the path leads to a file and not a directory, create a job to uploade the file and return
+		// If the path leads to a file and not a directory, create a job to upload the file and return
 		if !info.IsDir() {
 			if remotePath := path.Join(job.job.remoteURL.Path, strings.TrimPrefix(localPath, job.job.localPath)); skipUpload(job.job, localPath, job.job.remoteURL) {
 				log.Infoln("Skipping upload of object", remotePath, "as it already exists at the destination")

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1829,6 +1829,8 @@ func downloadHTTP(ctx context.Context, te *TransferEngine, callback TransferCall
 	}
 	req.HTTPRequest.Header.Set("TE", "trailers")
 	req.HTTPRequest.Header.Set("User-Agent", getUserAgent(project))
+
+	req.NoResume = true
 	req = req.WithContext(ctx)
 
 	// Test the transfer speed every 0.5 seconds

--- a/client/main.go
+++ b/client/main.go
@@ -407,13 +407,19 @@ func DoGet(ctx context.Context, remoteObject string, localDestination string, re
 
 	//Check if path exists or if its in a folder
 	if destStat, err := os.Stat(localDestPath); os.IsNotExist(err) {
-		localDestination = localDestPath
+		trailingChar := ""
+		if string(localDestination[len(localDestination)-1]) == string(filepath.Separator) {
+			trailingChar = string(filepath.Separator)
+		}
+		localDestination = localDestPath + trailingChar
 	} else if destStat.IsDir() && pUrl.Query().Get(pelican_url.QueryPack) == "" {
 		// If we have an auto-pack request, it's OK for the destination to be a directory
 		// Otherwise, get the base name of the source and append it to the destination dir.
 		// Note that we use the pUrl.Path, as this will have stripped any query params for us
 		remoteObjectFilename := path.Base(pUrl.Path)
-		localDestination = path.Join(localDestPath, remoteObjectFilename)
+		if !recursive {
+			localDestination = path.Join(localDestPath, remoteObjectFilename)
+		}
 	}
 
 	success := false

--- a/cmd/object_sync.go
+++ b/cmd/object_sync.go
@@ -181,6 +181,13 @@ func syncMain(cmd *cobra.Command, args []string) {
 		}
 	} else {
 		for _, src := range sources {
+			if srcStat, err := os.Stat(src); err != nil {
+				log.Errorln("Source does not exist")
+				os.Exit(1)
+			} else if !srcStat.IsDir() && string(dest[len(dest)-1]) == `/` {
+				log.Warningln("Destination ends with '/', but the source is a file. If the destination does not exist, it will be treated as an object, not a collection.")
+			}
+
 			if _, err = client.DoPut(ctx, src, dest, true,
 				client.WithCallback(pb.callback), client.WithTokenLocation(tokenLocation),
 				client.WithCaches(caches...), client.WithSynchronize(client.SyncSize)); err != nil {

--- a/cmd/object_sync.go
+++ b/cmd/object_sync.go
@@ -182,10 +182,10 @@ func syncMain(cmd *cobra.Command, args []string) {
 	} else {
 		for _, src := range sources {
 			if srcStat, err := os.Stat(src); err != nil {
-				log.Errorln("Source does not exist")
+				log.Errorln("Source: " + src + " does not exist")
 				os.Exit(1)
 			} else if !srcStat.IsDir() && string(dest[len(dest)-1]) == `/` {
-				log.Warningln("Destination ends with '/', but the source is a file. If the destination does not exist, it will be treated as an object, not a collection.")
+				log.Warningln("Destination: " + dest + " ends with '/', but the source is a file. If the destination does not exist, it will be treated as an object, not a collection.")
 			}
 
 			if _, err = client.DoPut(ctx, src, dest, true,

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -729,27 +729,6 @@ func TestPluginRecursiveDownload(t *testing.T) {
 		assert.Equal(t, 2, len(resultAds))
 	})
 
-	// Check to make sure the plugin properly fails when setting recursive=true on a file
-	// instead of a directory
-	t.Run("TestRecursiveFailureOnRecursiveSetForFile", func(t *testing.T) {
-		// Change the downloadUrl to be a path to a file instead of a directory
-		downloadUrl1 := url.URL{
-			Scheme:   "pelican",
-			Host:     host,
-			Path:     "/test/test/test.txt",
-			RawQuery: "recursive=true",
-		}
-
-		workChan := make(chan PluginTransfer, 1)
-		workChan <- PluginTransfer{url: &downloadUrl1, localFile: localPath1}
-		close(workChan)
-
-		results := make(chan *classads.ClassAd, 5)
-		err = runPluginWorker(fed.Ctx, false, workChan, results)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to read remote collection: PROPFIND /test/test/test.txt/: 500")
-	})
-
 	t.Run("TestRecursiveFailureDirNotFound", func(t *testing.T) {
 		// Change the downloadUrl to be a path to a file instead of a directory
 		downloadUrl1 := url.URL{


### PR DESCRIPTION
This code adjust the sync behavior for transfers to and from origins. Only fully tested on POSIX right now due to S3 PROPFIND/LS issues.

The cases and behavior that should occur are discussed here: #1638 - For the benefit of the reviewer, here is the list of test commands I ran with the various caveats about the files/dirs/collections/objects. Be sure you match the various different existence cases of each test.


| Left Argument Type | Right Argument Type | Command | Expected Result | Description |
| ----------  | -------------------- | --------------------- | ------ | ------------ |
| Collection | File (which exists) | `/pelican object sync pelican://3695d3c19055:8445/my-origin/test origin.go` | FAILURE | Trying to sync a remote collection with a file is expected to fail|
| Collection | Directory (does exist) | `./pelican object sync pelican://3695d3c19055:8445/my-origin/test $PWD/test` | SUCCESS |  Everything in `my-origin/test` is recursively moved into `$PWD/test` |
| Collection | Directory (does not exist | `./pelican object sync pelican://3695d3c19055:8445/my-origin/test $PWD/test` | SUCCESS | Creates `$PWD/test` and everything in `my-origin/test` is recursively moved into `$PWD/test` | 
| Object | Directory (exists) | `./pelican object sync pelican://3695d3c19055:8445/my-origin/locked-file2.txt tmp/ ` | SUCESS | Moves `locked-file2.txt` into `tmp/` |
| Object | FilePath (does not exist) w '/'| `./pelican object sync pelican://3695d3c19055:8445/my-origin/locked-file2.txt tmp/` | SUCCESS | Creates `tmp/` and moves `locked-file2.txt` into `tmp`|
| Object | DirPath (does not exist) w/o '/'| `./pelican object sync pelican://3695d3c19055:8445/my-origin/locked-file2.txt tmp` | SUCCESS | Copies `locked-file2.txt` into `tmp` |
| Object | FilePath (exists) | `./pelican object sync pelican://3695d3c19055:8445/my-origin/locked-file2.txt tmp.txt ` | SUCCESS | Overwites `tmp.txt` with `locked-file2.txt` |
| Directory | Namespace Prefix | `./pelican object sync $PWD/tmp/inner/ pelican://3695d3c19055:8445/my-origin/outer -t test-token.jwt` | SUCCESS | Copies contents of `$PWD/tmp/inner/` into `/my-origin/outer` Creating prefixes as needed |
| File | Collection (POSIX Origin) | `./pelican object sync $PWD/testfile.txt pelican://3695d3c19055:8445/my-origin/outer -t test-token.jwt` | FAILURE | Trying to sync a file with a POSIX Collection should fail |
| File | Collection (S3 Origin) | `./pelican object sync /workspaces/pelican/test-cache/xrootd_server.go pelican://3695d3c19055:8445/my-s3/testing/uwdf-test -d -t test-token.jwt` | SUCCESS | Trying to sync a file with an S3 collection name should create an object of that name (because S3 allows for both)|
| File | Object (POSIX Origin) | `./pelican object sync $PWD/testfile.txt pelican://3695d3c19055:8445/my-origin/test-file.txt -t test-token.jwt` | SUCCESS | Overwrites `/my-origin/test-file.txt` with `$PWD/testfile.txt`|
| File | non-existent namespace prefix | `./pelican object sync $PWD/testfile.txt pelican://3695d3c19055:8445/my-origin/fileput/oops/test.txt -t test-token.jwt` | SUCCESS | Writes the file to the location and creates prefixes as necessary|