### PR TITLE
IsDir Check to Prevent Creation of Empty Files on Object Uploads

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2155,8 +2155,7 @@ func uploadObject(transfer *transferFile) (transferResult TransferResults, err e
 	} else {
 
 		if fileInfo.IsDir() {
-			log.Errorln("The given path", transfer.localPath, "is a directory. Use --recursive or -r flag if using the pelican object command for directories")
-			err := errors.New("the provided path '" + transfer.localPath + "' is a directory, but a file is expected; use --recursive or -r flag if using the pelican object command for directories")
+			err := errors.New("the provided path '" + transfer.localPath + "' is a directory, but a file is expected")
 			transferResult.Error = err
 			return transferResult, err
 		}

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2153,6 +2153,14 @@ func uploadObject(transfer *transferFile) (transferResult TransferResults, err e
 		ioreader = ap
 		sizer = ap
 	} else {
+
+		if fileInfo.IsDir() {
+			log.Errorln("The given path", transfer.localPath, "is a directory. Use --recursive or -r flag if using the pelican object command for directories")
+			err := errors.New("the provided path '" + transfer.localPath + "' is a directory, but a file is expected; use --recursive or -r flag if using the pelican object command for directories")
+			transferResult.Error = err
+			return transferResult, err
+		}
+
 		// Try opening the file to send
 		file, err := os.Open(transfer.localPath)
 		if err != nil {

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -313,12 +313,11 @@ func TestStashPluginMain(t *testing.T) {
 	assert.Contains(t, output, amountDownloaded)
 }
 
-// This test addresses the issue mentioned in issue #1645. It creates a directory containing two files.
-// The paths of both files and the directory itself (without any recursive option) are added to the infile,
-// which is then passed to the plugin for upload. The test verifies the following:
+// This test creates a directory containing two files, adds the paths of both files and the directory itself (without any recursive option) to the infile, and then passes it to the plugin for upload.
+// The test then verifies the following:
 // - Both files are successfully uploaded.
 // - The directory itself is not uploaded, and no empty file with the directory name is created at the destination.
-// - An appropriate message indicating the directory upload failure is returned in the corresponding classad.
+// - An appropriate message indicating the directory upload failure is returned in the corresponding resultad.
 func TestInfileUploadWithDirAndFiles(t *testing.T) {
 
 	server_utils.ResetTestState()


### PR DESCRIPTION
## `IsDir` Check to Prevent Creation of Empty Files on Object Uploads

Currently, when trying to upload an object without the recursive option and a directory path is provided, Pelican does not handle this gracefully. It outputs an error because it attempts to read a directory, and it also creates an empty file at the destination in the process.

This issue affects both `pelican object put` and `pelican plugin` commands since the same underlying function manages object uploads.

### Related Issue #1645

When Condor attempts to transfer a directory, it iterates through it and places both directory paths and file paths in the infile. Attempting to transfer a directory without the recursive option causes Pelican to create an empty file at the destination, which breaks the code.

This PR adds an `IsDir` check before initiating an object transfer. This update resolves both issues:
1. Passing a directory in the infile provided by Condor will no longer have any effect.
2. Using `pelican object put` with a directory without the recursive option will not create an empty file at the destination and will only output an error.

A similar problem occurs while downloading an object as well. This is more complex since the object to be transferred is on a remote machine, and the behavior differs when downloading from a cache or directly from the origin using the `?directread` query. A separate Issue #1706 has been created for tracking this.