### PR TITLE
Fix nil pointer bug caused by trying to list namespaces with no coll URL

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2591,6 +2591,10 @@ func (te *TransferEngine) walkDirUpload(job *clientTransferJob, transfers []tran
 // This function performs the ls command by walking through the specified collections and printing the contents of the files
 func listHttp(remoteUrl *pelican_url.PelicanURL, dirResp server_structs.DirectorResponse, token *tokenGenerator) (fileInfos []FileInfo, err error) {
 	// Get our collection listing host
+	if dirResp.XPelNsHdr.CollectionsUrl == nil {
+		return nil, errors.Errorf("Collections URL not found in director response. Are you sure there's an origin for prefix %s that supports listings?", dirResp.XPelNsHdr.Namespace)
+	}
+
 	collectionsUrl := dirResp.XPelNsHdr.CollectionsUrl
 	log.Debugln("Collections URL: ", collectionsUrl.String())
 

--- a/client/main.go
+++ b/client/main.go
@@ -309,7 +309,7 @@ func DoList(ctx context.Context, remoteObject string, options ...TransferOption)
 
 	fileInfos, err = listHttp(pUrl, dirResp, token)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to do the list")
+		return nil, errors.Wrap(err, "failed to perform list request")
 	}
 
 	return fileInfos, nil


### PR DESCRIPTION
Previously, the code in `listHttp` didn't check whether or not the director response it had actually contained a valid collections URL. Now it checks whether the URL is populated, and if not returns an error with a hint.

I've also added very basic unit test coverage for this, but noticed both `listHttp` and `statHttp` could use a lot more. Rather than do that in this bug fix PR, I'll open a followup ticket that targets only these two functions for unit test development.

Closes #1705