### PR TITLE
Update MacOS GHA test env to fix deprecation error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.21.x]
-        os: [macos-12, windows-latest]
+        os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code

--- a/github_scripts/osx_install.sh
+++ b/github_scripts/osx_install.sh
@@ -23,6 +23,10 @@ scriptdir=$PWD/`dirname $0`
 
 brew install minio ninja coreutils
 
+# The new macos-latest runner has some issues with /usr/local/<lib/include>. Adjust perms ahead of time
+sudo mkdir -p /usr/local/lib && sudo mkdir -p /usr/local/include
+sudo chmod -R 777 /usr/local && sudo chown -R $(whoami):admin /usr/local
+
 mkdir dependencies
 pushd dependencies
 


### PR DESCRIPTION
Closes #1711 