### PR TITLE
Update macos.mdx to make architectures match

### DIFF
--- a/docs/pages/install/macos.mdx
+++ b/docs/pages/install/macos.mdx
@@ -20,7 +20,7 @@ Pelican provides a binary executable file instead of a `DMG` installer for MacOS
     Example to install Pelican executable for an Apple Silicon Mac:
 
     ```bash
-    curl -LO https://github.com/PelicanPlatform/pelican/releases/download/v7.10.5/pelican_Darwin_x86_64.tar.gz
+    curl -LO https://github.com/PelicanPlatform/pelican/releases/download/v7.10.5/pelican_Darwin_arm64.tar.gz
     tar -zxvf pelican_Darwin_arm64.tar.gz
     ```
 


### PR DESCRIPTION
In the current readme, `curl` and `tar` refer to different osx architectures. This PR makes them match.