### PR TITLE
Include defaults in debug config print

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1515,6 +1515,13 @@ func InitClient() error {
 
 	clientInitialized = true
 
+	// Print Pelican configuration after client config initialization if log level is set to debug
+	if log.GetLevel() == log.DebugLevel {
+		if err = PrintConfig(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -1001,7 +1001,6 @@ func filterConfigRecursive(v reflect.Value, currentPath string, component string
 
 // PrintClientConfig prints the client config in JSON format to stderr.
 func PrintClientConfig() error {
-
 	clientConfig, err := GetComponentConfig("client")
 	if err != nil {
 		return err

--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"sort"
 	"strconv"
@@ -50,6 +51,7 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/pelicanplatform/pelican/docs"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/pelican_url"
 	"github.com/pelicanplatform/pelican/server_structs"
@@ -171,7 +173,8 @@ var (
 		"":            true,
 	}
 
-	clientInitialized = false
+	clientInitialized     = false
+	printClientConfigOnce sync.Once
 )
 
 func init() {
@@ -922,6 +925,100 @@ func PrintConfig() error {
 	return nil
 }
 
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+// GetComponentConfig filters the full config and returns only the config parameters related to the given component.
+// The filtering is based on whether the given component is part of the components in docs.parameters.yaml.
+func GetComponentConfig(component string) (map[string]interface{}, error) {
+	rawConfig, err := param.UnmarshalConfig(viper.GetViper())
+	if err != nil {
+		return nil, err
+	}
+	value, hasValue := filterConfigRecursive(reflect.ValueOf(rawConfig), "", component)
+	if hasValue {
+		return (*value).(map[string]interface{}), nil
+	}
+	return nil, nil
+}
+
+// filterConfigRecursive is a helper function for GetComponentConfig.
+// It recursively creates a nested config map of the parameters that relate to the given component.
+func filterConfigRecursive(v reflect.Value, currentPath string, component string) (*interface{}, bool) {
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	switch v.Kind() {
+	case reflect.Struct:
+		t := v.Type()
+		result := make(map[string]interface{})
+		hasField := false
+		for i := 0; i < v.NumField(); i++ {
+			field := v.Field(i)
+			fieldType := t.Field(i)
+			if !fieldType.IsExported() {
+				continue
+			}
+
+			fieldName := strings.ToLower(fieldType.Name)
+
+			var newPath string
+			if currentPath == "" {
+				newPath = fieldName
+			} else {
+				newPath = currentPath + "." + fieldName
+			}
+
+			fieldValue, fieldHasValue := filterConfigRecursive(field, newPath, component)
+			if fieldHasValue && fieldValue != nil {
+				result[fieldName] = *fieldValue
+				hasField = true
+			}
+		}
+		if hasField {
+			resultInterface := interface{}(result)
+			return &resultInterface, true
+		}
+		return nil, false
+	default:
+		lowerPath := strings.ToLower(currentPath)
+		paramDoc, exists := docs.ParsedParameters[lowerPath]
+		if exists && contains(paramDoc.Components, component) {
+			resultValue := v.Interface()
+			resultInterface := interface{}(resultValue)
+			return &resultInterface, true
+		}
+		return nil, false
+	}
+}
+
+// PrintClientConfig prints the client config in JSON format to stderr.
+func PrintClientConfig() error {
+
+	clientConfig, err := GetComponentConfig("client")
+	if err != nil {
+		return err
+	}
+
+	bytes, err := json.MarshalIndent(clientConfig, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stderr,
+		"================ Pelican Client Configuration ================\n",
+		string(bytes),
+		"\n",
+		"============= End of Pelican Client Configuration ============")
+	return nil
+}
+
 func SetServerDefaults(v *viper.Viper) error {
 	configDir := v.GetString("ConfigDir")
 	v.SetConfigType("yaml")
@@ -1515,11 +1612,16 @@ func InitClient() error {
 
 	clientInitialized = true
 
-	// Print Pelican configuration after client config initialization if log level is set to debug
-	if log.GetLevel() == log.DebugLevel {
-		if err = PrintConfig(); err != nil {
-			return err
+	var printClientConfigErr error
+	printClientConfigOnce.Do(func() {
+		if log.GetLevel() == log.DebugLevel {
+			printClientConfigErr = PrintClientConfig()
 		}
+	})
+
+	// Return any error encountered during PrintClientConfig
+	if printClientConfigErr != nil {
+		return printClientConfigErr
 	}
 
 	return nil

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -60,13 +60,6 @@ func LaunchModules(ctx context.Context, modules server_structs.ServerType) (serv
 
 	config.LogPelicanVersion()
 
-	// Print Pelican config at server start if it's in debug or info level
-	if log.GetLevel() >= log.InfoLevel {
-		if err = config.PrintConfig(); err != nil {
-			return
-		}
-	}
-
 	egrp.Go(func() error {
 		_ = config.RestartFlag
 		log.Debug("Will shutdown process on signal")
@@ -95,6 +88,13 @@ func LaunchModules(ctx context.Context, modules server_structs.ServerType) (serv
 	if err = config.InitServer(ctx, modules); err != nil {
 		err = errors.Wrap(err, "Failure when configuring the server")
 		return
+	}
+
+	// Print Pelican config at server start if it's in debug or info level
+	if log.GetLevel() >= log.InfoLevel {
+		if err = config.PrintConfig(); err != nil {
+			return
+		}
 	}
 
 	// Set up necessary APIs to support Web UI, including auth and metrics


### PR DESCRIPTION
Fixes #1720: On server startup, prints the full configuration after applying defaults if log level is INFO or higher. On client initialization, prints client-specific configuration when log level is DEBUG.