### PR TITLE
Fixes an issue where a misplaced `defer ticker.Stop()` stopped the re…

### DIFF
--- a/launcher_utils/advertise.go
+++ b/launcher_utils/advertise.go
@@ -68,9 +68,8 @@ func LaunchPeriodicAdvertise(ctx context.Context, egrp *errgroup.Group, servers 
 	doAdvertise(ctx, servers)
 
 	ticker := time.NewTicker(1 * time.Minute)
-	defer ticker.Stop()
 	egrp.Go(func() error {
-
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:


### PR DESCRIPTION
…-advertisement of caches/origins