### PR TITLE
Restore lotman through splitting off a second server binary

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -88,7 +88,7 @@ jobs:
         args: build --single-target --clean --snapshot
     - name: Copy files (Ubuntu)
       run: |
-        cp dist/pelican_linux_amd64_v1/${{ inputs.binary_name }} ./
+        cp dist/${{ inputs.binary_name }}_linux_amd64_v1/${{ inputs.binary_name }} ./
     - name: Run Integration Tests
       run: ./github_scripts/citests.sh
     - name: Run End-to-End Test for Object get/put

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -1,0 +1,101 @@
+name: Test Template
+
+on:
+  workflow_call:
+    inputs:
+      tags:
+        required: true
+        type: string
+      coverprofile:
+        required: true
+        type: string
+      binary_name:
+        required: true
+        type: string
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: hub.opensciencegrid.org/pelican_platform/pelican-dev:latest-itb
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+    - name: Fetch tags
+      run: |
+        git config --global --add safe.directory /__w/pelican/pelican
+        git fetch --force --tags
+    - name: Cache Next.js
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.npm
+          ${{ github.workspace }}/.next/cache
+        key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+        restore-keys: |
+          ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+    - name: Test
+      run: |
+        make web-build
+        go test -tags=${{ inputs.tags }} -timeout 15m -coverpkg=./... -coverprofile=${{ inputs.coverprofile }} -covermode=count ./...
+    - name: Get total code coverage
+      if: github.event_name == 'pull_request'
+      id: cc
+      run: |
+        set -x
+        cc_total=`go tool cover -func=${{ inputs.coverprofile }} | grep total | grep -Eo '[0-9]+\.[0-9]+'`
+        echo "cc_total=$cc_total" >> $GITHUB_OUTPUT
+    - name: Restore base test coverage
+      id: base-coverage
+      if: github.event.pull_request.base.sha != ''
+      uses: actions/cache@v4
+      with:
+        path: |
+          unit-base.txt
+        key: ${{ runner.os }}-unit-test-coverage-${{ (github.event.pull_request.base.sha != github.event.after) && github.event.pull_request.base.sha || github.event.after }}
+    - name: Run test for base code
+      if: steps.base-coverage.outputs.cache-hit != 'true' && github.event.pull_request.base.sha != ''
+      run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        git fetch origin main ${{ github.event.pull_request.base.sha }}
+        HEAD=$(git rev-parse HEAD)
+        git reset --hard ${{ github.event.pull_request.base.sha }}
+        make web-build
+        go generate ./...
+        go test -tags=${{ inputs.tags }} -timeout 15m -coverpkg=./... -coverprofile=base_coverage.out -covermode=count ./...
+        go tool cover -func=base_coverage.out > unit-base.txt
+        git reset --hard $HEAD
+    - name: Get base code coverage value
+      if: github.event_name == 'pull_request'
+      id: cc_b
+      run: |
+        set -x
+        cc_base_total=`grep total ./unit-base.txt | grep -Eo '[0-9]+\.[0-9]+'`
+        echo "cc_base_total=$cc_base_total" >> $GITHUB_OUTPUT
+    - name: Add coverage information to action summary
+      if: github.event_name == 'pull_request'
+      run: echo 'Code coverage ' ${{steps.cc.outputs.cc_total}}'% Prev ' ${{steps.cc_b.outputs.cc_base_total}}'%' >> $GITHUB_STEP_SUMMARY
+    - name: Run GoReleaser for Ubuntu
+      uses: goreleaser/goreleaser-action@v5
+      with:
+        distribution: goreleaser
+        version: latest
+        args: build --single-target --clean --snapshot
+    - name: Copy files (Ubuntu)
+      run: |
+        cp dist/pelican_linux_amd64_v1/${{ inputs.binary_name }} ./
+    - name: Run Integration Tests
+      run: ./github_scripts/citests.sh
+    - name: Run End-to-End Test for Object get/put
+      run: ./github_scripts/get_put_test.sh
+    - name: Run End-to-End Test for Director stat
+      run: ./github_scripts/stat_test.sh
+    - name: Run End-to-End Test of x509 access
+      run: ./github_scripts/x509_test.sh
+    - name: Run End-to-End Test for --version flag
+      run: ./github_scripts/version_test.sh

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -88,7 +88,7 @@ jobs:
         args: build --single-target --clean --snapshot
     - name: Copy files (Ubuntu)
       run: |
-        cp dist/${{ inputs.binary_name }}_linux_amd64_v1/${{ inputs.binary_name }} ./
+        cp dist/${{ inputs.binary_name }}_linux_amd64_v1/${{ inputs.binary_name }} ./pelican
     - name: Run Integration Tests
       run: ./github_scripts/citests.sh
     - name: Run End-to-End Test for Object get/put

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
+        # Do fetch depth 0 here because otherwise goreleaser might not work properly:
+        # https://goreleaser.com/ci/actions/?h=tag#workflow
         fetch-depth: 0
     - uses: actions/setup-node@v4
       with:
@@ -23,7 +25,9 @@ jobs:
         path: |
           ~/.npm
           ${{ github.workspace }}/.next/cache
+        # Generate a new cache whenever packages or source files change.
         key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx', '!**/node_modules/**') }}
+        # If source files changed but packages didn't, rebuild from a prior cache.
         restore-keys: |
           ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
     - name: Install Go
@@ -46,6 +50,7 @@ jobs:
     - name: Run GoReleaser for Non-Ubuntu
       uses: goreleaser/goreleaser-action@v5
       with:
+        # either 'goreleaser' (default) or 'goreleaser-pro'
         distribution: goreleaser
         version: latest
         args: build --single-target --clean --snapshot

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-      # Do fetch depth 0 here because otherwise goreleaser might not work properly:
-      # https://goreleaser.com/ci/actions/?h=tag#workflow
         fetch-depth: 0
     - uses: actions/setup-node@v4
       with:
@@ -25,9 +23,7 @@ jobs:
         path: |
           ~/.npm
           ${{ github.workspace }}/.next/cache
-        # Generate a new cache whenever packages or source files change.
         key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx', '!**/node_modules/**') }}
-        # If source files changed but packages didn't, rebuild from a prior cache.
         restore-keys: |
           ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
     - name: Install Go
@@ -50,99 +46,18 @@ jobs:
     - name: Run GoReleaser for Non-Ubuntu
       uses: goreleaser/goreleaser-action@v5
       with:
-        # either 'goreleaser' (default) or 'goreleaser-pro'
         distribution: goreleaser
         version: latest
         args: build --single-target --clean --snapshot
   test-ubuntu:
-    runs-on: ubuntu-latest
-    container:
-      image: hub.opensciencegrid.org/pelican_platform/pelican-dev:latest-itb
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        # See above for why fetch depth is 0 here
-        fetch-depth: 0
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 20
-      # Fetch the tags is essential so that goreleaser can build the correct version. Workaround found here:
-      # https://github.com/actions/checkout/issues/290
-    - name: Fetch tags
-      run: |
-        git config --global --add safe.directory /__w/pelican/pelican
-        git fetch --force --tags
-    - name: Cache Next.js
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.npm
-          ${{ github.workspace }}/.next/cache
-        # Generate a new cache whenever packages or source files change.
-        key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
-        # If source files changed but packages didn't, rebuild from a prior cache.
-        restore-keys: |
-          ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
-    - name: Test
-      run: |
-        make web-build
-        go test -timeout 15m -coverpkg=./... -coverprofile=coverage.out -covermode=count ./...
-    - name: Get total code coverage
-      if: github.event_name == 'pull_request'
-      id: cc
-      run: |
-        set -x
-        cc_total=`go tool cover -func=coverage.out | grep total | grep -Eo '[0-9]+\.[0-9]+'`
-        echo "cc_total=$cc_total" >> $GITHUB_OUTPUT
-    - name: Restore base test coverage
-      id: base-coverage
-      if: github.event.pull_request.base.sha != ''
-      uses: actions/cache@v4
-      with:
-        path: |
-          unit-base.txt
-        # Use base sha for PR or new commit hash for master/main push in test result key.
-        key: ${{ runner.os }}-unit-test-coverage-${{ (github.event.pull_request.base.sha != github.event.after) && github.event.pull_request.base.sha || github.event.after }}
-    - name: Run test for base code
-      if: steps.base-coverage.outputs.cache-hit != 'true' && github.event.pull_request.base.sha != ''
-      run: |
-        git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        git fetch origin main ${{ github.event.pull_request.base.sha }}
-        HEAD=$(git rev-parse HEAD)
-        git reset --hard ${{ github.event.pull_request.base.sha }}
-        make web-build
-        go generate ./...
-        go test -timeout 15m -coverpkg=./... -coverprofile=base_coverage.out -covermode=count ./...
-        go tool cover -func=base_coverage.out > unit-base.txt
-        git reset --hard $HEAD
-    - name: Get base code coverage value
-      if: github.event_name == 'pull_request'
-      id: cc_b
-      run: |
-        set -x
-        cc_base_total=`grep total ./unit-base.txt | grep -Eo '[0-9]+\.[0-9]+'`
-        echo "cc_base_total=$cc_base_total" >> $GITHUB_OUTPUT
-    - name: Add coverage information to action summary
-      if: github.event_name == 'pull_request'
-      run: echo 'Code coverage ' ${{steps.cc.outputs.cc_total}}'% Prev ' ${{steps.cc_b.outputs.cc_base_total}}'%' >> $GITHUB_STEP_SUMMARY
-    - name: Run GoReleaser for Ubuntu
-      uses: goreleaser/goreleaser-action@v5
-      with:
-        # either 'goreleaser' (default) or 'goreleaser-pro'
-        distribution: goreleaser
-        version: latest
-        args: build --single-target --clean --snapshot
-    - name: Copy files (Ubuntu)
-      run: |
-        cp dist/pelican_linux_amd64_v1/pelican ./
-    - name: Run Integration Tests
-      run: ./github_scripts/citests.sh
-    - name: Run End-to-End Test for Object get/put
-      run: ./github_scripts/get_put_test.sh
-    - name: Run End-to-End Test for Director stat
-      run: ./github_scripts/stat_test.sh
-    - name: Run End-to-End Test of x509 access
-      run: ./github_scripts/x509_test.sh
-    - name: Run End-to-End Test for --version flag
-      run: ./github_scripts/version_test.sh
+    uses: ./.github/workflows/test-template.yml
+    with:
+      tags: ""
+      coverprofile: "coverage.out"
+      binary_name: "pelican"
+  test-ubuntu-server:
+    uses: ./.github/workflows/test-template.yml
+    with:
+      tags: "lotman"
+      coverprofile: "coverage-server.out"
+      binary_name: "pelican-server"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,8 +67,13 @@ builds:
       - lotman
     ldflags:
       - -s -w -X github.com/pelicanplatform/pelican/config.commit={{.Commit}} -X github.com/pelicanplatform/pelican/config.date={{.Date}} -X github.com/pelicanplatform/pelican/config.builtBy=goreleaser -X github.com/pelicanplatform/pelican/config.version={{.Version}}
+# Goreleaser complains if there's a different number of binaries built for different architectures
+# in the same archive. Instead of plopping pelican-server in the same archive as pelican, split the
+# builds into separate archives.
 archives:
   - id: pelican
+    builds:
+      - pelican
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
@@ -78,6 +83,15 @@ archives:
       - goos: windows
         format: zip
     wrap_in_directory: '{{ .ProjectName }}-{{ trimsuffix .Version "-next" }}'
+  - id: pelican-server
+    builds:
+      - pelican-server
+    name_template: >-
+      {{ .ProjectName }}-server_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+    wrap_in_directory: '{{ .ProjectName }}-server-{{ trimsuffix .Version "-next" }}'
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,7 +50,23 @@ builds:
         goarch: ppc64le
       - goos: darwin
         goarch: ppc64le
-
+  # Set things up to build a second server binary that enables Lotman. Eventually
+  # we'll also use this to filter which moduels are built into the binary.
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - "amd64"
+      - "arm64"
+    id: "pelican-server"
+    dir: ./cmd
+    binary: pelican-server
+    tags:
+      - forceposix
+      - lotman
+    ldflags:
+      - -s -w -X github.com/pelicanplatform/pelican/config.commit={{.Commit}} -X github.com/pelicanplatform/pelican/config.date={{.Date}} -X github.com/pelicanplatform/pelican/config.builtBy=goreleaser -X github.com/pelicanplatform/pelican/config.version={{.Version}}
 archives:
   - id: pelican
     name_template: >-

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -220,8 +220,11 @@ RUN rm -rf /pelican/pelican
 ####################
 
 FROM pelican-base AS cache
-
-ENTRYPOINT [ "/entrypoint.sh", "pelican", "cache"]
+RUN rm -rf /pelican/pelican
+COPY --from=pelican-build /pelican/dist/pelican-server_linux_amd64_v1/pelican-server /pelican/pelican-server
+RUN chmod +x /pelican/pelican-server
+# For now, we're only using pelican-server in the cache, but eventually we'll use it in all servers
+ENTRYPOINT [ "/entrypoint.sh", "pelican-server", "cache"]
 CMD [ "serve" ]
 
 ####################
@@ -260,8 +263,10 @@ CMD [ "serve" ]
 ####################
 
 FROM osdf-base AS osdf-cache
-
-ENTRYPOINT [ "/entrypoint.sh" ,"osdf", "cache"]
+RUN rm -rf /pelican/osdf
+COPY --from=pelican-build /pelican/dist/pelican-server_linux_amd64_v1/pelican-server /pelican/osdf-server
+RUN chmod +x /pelican/osdf-server
+ENTRYPOINT [ "/entrypoint.sh" ,"osdf-server", "cache"]
 CMD [ "serve" ]
 
 ####################

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -119,10 +119,26 @@ if [ $# -ne 0 ]; then
             echo >&2 "Exec of tini failed!"
             exit 1
             ;;
+        pelican-server)
+            # Our server-specific binary which may come with additional
+            # features/system requirements (like Lotman)
+            echo "Running pelican-server with arguments: $@"
+            exec tini -- /pelican/pelican-server "$@"
+            # we shouldn't get here
+            echo >&2 "Exec of tini failed!"
+            exit 1
+            ;;
         osdf)
             # Run osdf with the rest of the arguments
             echo "Running osdf with arguments: $@"
             exec tini -- /pelican/osdf "$@"
+            # we shouldn't get here
+            echo >&2 "Exec of tini failed!"
+            exit 1
+            ;;
+        osdf-server)
+            echo "Running osdf-server with arguments: $@"
+            exec tini -- /pelican/osdf-server "$@"
             # we shouldn't get here
             echo >&2 "Exec of tini failed!"
             exit 1

--- a/lotman/lotman.go
+++ b/lotman/lotman.go
@@ -1,4 +1,4 @@
-//go:build windows || darwin || linux
+//go:build !lotman || (lotman && linux && ppc64le) || !linux
 
 // For now we're shutting off LotMan due to weirdness with purego. When we return to this, remember
 // that purego doesn't support (linux && ppc64le), so we'll need to add that back here.

--- a/lotman/lotman_linux.go
+++ b/lotman/lotman_linux.go
@@ -1,5 +1,4 @@
-//go:build false
-// For now we're shutting off LotMan due to weirdness with purego
+//go:build lotman && linux && !ppc64le
 
 /***************************************************************
 *

--- a/lotman/lotman_linux.go
+++ b/lotman/lotman_linux.go
@@ -59,6 +59,7 @@ var (
 	// Auxilliary functions
 	LotmanLotExists     func(lotName string, errMsg *[]byte) int32
 	LotmanSetContextStr func(contextKey string, contextValue string, errMsg *[]byte) int32
+	LotmanGetContextStr func(key string, output *[]byte, errMsg *[]byte) int32
 	// Functions that would normally take a char *** as an argument take an *unsafe.Pointer instead because
 	// these functions are responsible for allocating and deallocating the memory for the char ***. The Go
 	// runtime will handle the memory management for the *unsafe.Pointer.
@@ -339,6 +340,7 @@ func InitLotman() bool {
 	// Auxilliary functions
 	purego.RegisterLibFunc(&LotmanLotExists, lotmanLib, "lotman_lot_exists")
 	purego.RegisterLibFunc(&LotmanSetContextStr, lotmanLib, "lotman_set_context_str")
+	purego.RegisterLibFunc(&LotmanGetContextStr, lotmanLib, "lotman_get_context_str")
 	purego.RegisterLibFunc(&LotmanGetLotOwners, lotmanLib, "lotman_get_owners")
 	purego.RegisterLibFunc(&LotmanGetLotParents, lotmanLib, "lotman_get_parent_names")
 	purego.RegisterLibFunc(&LotmanGetLotsFromDir, lotmanLib, "lotman_get_lots_from_dir")
@@ -540,6 +542,7 @@ func InitLotman() bool {
 			if ret != 0 {
 				trimBuf(&errMsg)
 				log.Errorf("Error creating lot %s: %s", lot.LotName, string(errMsg))
+				log.Infoln("Full lot JSON passed to Lotman for lot creation:", string(lotJSON))
 				return false
 			}
 		}

--- a/lotman/lotman_test.go
+++ b/lotman/lotman_test.go
@@ -1,6 +1,5 @@
-//go:build false
+//go:build lotman && linux && !ppc64le
 
-//linux && !ppc64le
 /***************************************************************
 *
 * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research

--- a/lotman/lotman_ui.go
+++ b/lotman/lotman_ui.go
@@ -1,5 +1,4 @@
-//go:build false
-//linux && !ppc64le
+//go:build lotman && linux && !ppc64le
 
 /***************************************************************
 *

--- a/lotman/resources/lots-config.yaml
+++ b/lotman/resources/lots-config.yaml
@@ -20,7 +20,7 @@
 Lotman:
   Lots:
     - LotName: "default"
-      Owner: "https://fake-federation.com"
+      Owner: "SHOULD_OVERRIDE"
       Parents:
         - "default"
       ManagementPolicyAttrs:
@@ -38,7 +38,7 @@ Lotman:
           Value: 123456
 
     - LotName: "root"
-      Owner: "https://fake-federation.com"
+      Owner: "SHOULD_OVERRIDE"
       Parents:
         - "root"
       Paths:


### PR DESCRIPTION
This PR creates a second server binary, which for now only enables Lotman by passing the `lotman` build tag through goreleaser. This is necessary for the long-term development goals we have to use Pelican as the distribution layer for lotman configuration across caches.

Eventually we can also use this second binary to fine-tune which modules are built into clients or servers, which should make the HTCondor developers happy as well. For now, the new server binary replaces the regular binary only in cache containers, since that's where lotman is needed.

As for testing, I've tried to split our GHA test runner across the two binaries. This resulted in creating a workflow template that I can pass build tags/binary names to. 