### PR TITLE
Attempt longer ctx deadline in flaky localcache test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
         # either 'goreleaser' (default) or 'goreleaser-pro'
         distribution: goreleaser
         version: latest
-        args: --clean --snapshot
+        args: --clean --snapshot --single-target
     - name: Copy files (Ubuntu)
       run: |
         cp dist/pelican_linux_amd64_v1/pelican ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
         # either 'goreleaser' (default) or 'goreleaser-pro'
         distribution: goreleaser
         version: latest
-        args: --clean --snapshot --single-target
+        args: build --single-target --clean --snapshot
     - name: Copy files (Ubuntu)
       run: |
         cp dist/pelican_linux_amd64_v1/pelican ./

--- a/local_cache/cache_test.go
+++ b/local_cache/cache_test.go
@@ -376,7 +376,7 @@ func TestLargeFile(t *testing.T) {
 
 	clientConfig := map[string]interface{}{
 		"Client.MaximumDownloadSpeed":     40 * 1024 * 1024,
-		"Transport.ResponseHeaderTimeout": "1000s",
+		"Transport.ResponseHeaderTimeout": "60s",
 	}
 	test_utils.InitClient(t, clientConfig)
 	ft := fed_test_utils.NewFedTest(t, pubOriginCfg)

--- a/local_cache/cache_test.go
+++ b/local_cache/cache_test.go
@@ -375,7 +375,7 @@ func TestLargeFile(t *testing.T) {
 	server_utils.ResetTestState()
 
 	clientConfig := map[string]interface{}{
-		"Client.MaximumDownloadSpeed": 40 * 1024 * 1024,
+		"Client.MaximumDownloadSpeed":     40 * 1024 * 1024,
 		"Transport.ResponseHeaderTimeout": "1000s",
 	}
 	test_utils.InitClient(t, clientConfig)


### PR DESCRIPTION
This has been a flaky test for too long, and I've even seen it start failing locally when I'm running heavy Docker processes in the background. Clearly something just needs a bit more time to do its thing.