### PR TITLE
Fix OSDF Director startup warnings and separate GeoIP metric collection

### DIFF
--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -82,7 +82,7 @@ func (f filterType) String() string {
 //  4. Set up utilities for collecting origin/health server file transfer test status
 //  5. Return the updated ServerAd. The ServerAd passed in will not be modified
 func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]server_structs.NamespaceAdV2) (updatedAd server_structs.ServerAd) {
-	if err := updateLatLong(ctx, &sAd); err != nil {
+	if err := updateLatLong(&sAd); err != nil {
 		switch err := err.(type) {
 		case GeoIPError:
 			labels := err.labels
@@ -246,7 +246,7 @@ func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]
 	return sAd
 }
 
-func updateLatLong(ctx context.Context, ad *server_structs.ServerAd) error {
+func updateLatLong(ad *server_structs.ServerAd) error {
 	if ad == nil {
 		return errors.New("Cannot provide a nil ad to UpdateLatLong")
 	}

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -83,13 +83,11 @@ func (f filterType) String() string {
 //  5. Return the updated ServerAd. The ServerAd passed in will not be modified
 func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]server_structs.NamespaceAdV2) (updatedAd server_structs.ServerAd) {
 	if err := updateLatLong(&sAd); err != nil {
-		switch err := err.(type) {
-		case GeoIPError:
-			labels := err.labels
+		if geoIPError, ok := err.(geoIPError); ok {
+			labels := geoIPError.labels
 			metrics.PelicanDirectorGeoIPErrors.With(labels).Inc()
-		default:
-			log.Debugln("Failed to lookup GeoIP coordinates for host", sAd.URL.Host)
 		}
+		log.Debugln("Failed to lookup GeoIP coordinates for host", sAd.URL.Host)
 	}
 
 	if sAd.URL.String() == "" {

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -33,6 +33,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/utils"
@@ -82,7 +83,13 @@ func (f filterType) String() string {
 //  5. Return the updated ServerAd. The ServerAd passed in will not be modified
 func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]server_structs.NamespaceAdV2) (updatedAd server_structs.ServerAd) {
 	if err := updateLatLong(ctx, &sAd); err != nil {
-		log.Debugln("Failed to lookup GeoIP coordinates for host", sAd.URL.Host)
+		switch err := err.(type) {
+		case GeoIPError:
+			labels := err.labels
+			metrics.PelicanDirectorGeoIPErrors.With(labels).Inc()
+		default:
+			log.Debugln("Failed to lookup GeoIP coordinates for host", sAd.URL.Host)
+		}
 	}
 
 	if sAd.URL.String() == "" {

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -264,7 +264,7 @@ func updateLatLong(ctx context.Context, ad *server_structs.ServerAd) error {
 	}
 	// NOTE: If GeoIP resolution of this address fails, lat/long are set to 0.0 (the null lat/long)
 	// This causes the server to be sorted to the end of the list whenever the Director requires distance-aware sorting.
-	lat, long, err := getLatLong(ctx, addr)
+	lat, long, err := getLatLong(addr)
 	if err != nil {
 		return err
 	}

--- a/director/sort.go
+++ b/director/sort.go
@@ -209,7 +209,7 @@ func getLatLong(addr netip.Addr) (lat float64, long float64, err error) {
 	// comes from a private range.
 	if lat == 0 && long == 0 {
 		errMsg := fmt.Sprintf("GeoIP Resolution of the address %s resulted in the null lat/long. This will result in random server sorting.", ip.String())
-		log.Warningf(errMsg)
+		log.Warning(errMsg)
 		labels["source"] = "client"
 		err = GeoIPError{labels: labels, errorMsg: errMsg}
 	}
@@ -221,6 +221,7 @@ func getLatLong(addr netip.Addr) (lat float64, long float64, err error) {
 	if record.Location.AccuracyRadius >= 900 {
 		errMsg := fmt.Sprintf("GeoIP resolution of the address %s resulted in a suspiciously large accuracy radius of %d km. "+
 			"This will be treated as GeoIP resolution failure and result in random server sorting. Setting lat/long to null.", ip.String(), record.Location.AccuracyRadius)
+		log.Warning(errMsg)
 		lat = 0
 		long = 0
 		labels["source"] = "client"

--- a/director/sort.go
+++ b/director/sort.go
@@ -61,47 +61,14 @@ type (
 		Coordinate Coordinate `mapstructure:"Coordinate"`
 	}
 
-	GeoIPMaskError struct {
-		IpStr string
-	}
-	GeoIPProjectError struct{}
-	GeoIPMaxMindError struct{}
-	GeoIPNullError    struct {
-		IpStr string
-	}
-	GeoIPReaderError struct {
-		errStr string
-	}
-	GeoIPAccuracyError struct {
-		IpStr     string
-		AcuRadius uint16
+	GeoIPError struct {
+		labels   prometheus.Labels
+		errorMsg string
 	}
 )
 
-func (e GeoIPMaskError) Error() string {
-	return fmt.Sprintf("Failed to apply IP mask to address %s", e.IpStr)
-}
-
-func (e GeoIPProjectError) Error() string {
-	return "Failed to get project from context"
-}
-
-func (e GeoIPMaxMindError) Error() string {
-	return "No GeoIP database is available"
-}
-
-func (e GeoIPNullError) Error() string {
-	return fmt.Sprintf("GeoIP Resolution of the address %s resulted in the null lat/long. This will result in random server sorting.", e.IpStr)
-}
-
-func (e GeoIPReaderError) Error() string {
-	return e.errStr
-}
-
-func (e GeoIPAccuracyError) Error() string {
-	errStr := fmt.Sprintf("GeoIP resolution of the address %s resulted in a suspiciously large accuracy radius of %d km. ", e.IpStr, e.AcuRadius)
-	errStr += "This will be treated as GeoIP resolution failure and result in random server sorting. Setting lat/long to null."
-	return errStr
+func (e GeoIPError) Error() string {
+	return e.errorMsg
 }
 
 var (
@@ -219,7 +186,6 @@ func getLatLong(ctx context.Context, addr netip.Addr) (lat float64, long float64
 	network, ok := utils.ApplyIPMask(addr.String())
 	if !ok {
 		log.Warningf("Failed to apply IP mask to address %s", ip.String())
-		err = GeoIPMaskError{IpStr: ip.String()}
 		labels["network"] = "unknown"
 	} else {
 		labels["network"] = network
@@ -227,23 +193,19 @@ func getLatLong(ctx context.Context, addr netip.Addr) (lat float64, long float64
 
 	ok = setProjectLabel(ctx, labels)
 	if !ok {
-		log.Warningf("Failed to get project from context")
-		err = GeoIPProjectError{}
 		labels["source"] = "server"
 	}
 
 	reader := maxMindReader.Load()
 	if reader == nil {
-		err = GeoIPMaxMindError{}
 		labels["source"] = "server"
-		metrics.PelicanDirectorGeoIPErrors.With(labels).Inc()
+		err = GeoIPError{labels: labels, errorMsg: "No GeoIP database is available"}
 		return
 	}
 	record, err := reader.City(ip)
 	if err != nil {
-		err = GeoIPReaderError{errStr: err.Error()}
 		labels["source"] = "server"
-		metrics.PelicanDirectorGeoIPErrors.With(labels).Inc()
+		err = GeoIPError{labels: labels, errorMsg: err.Error()}
 		return
 	}
 	lat = record.Location.Latitude
@@ -253,10 +215,10 @@ func getLatLong(ctx context.Context, addr netip.Addr) (lat float64, long float64
 	// There's likely a problem with the GeoIP database or the IP address. Usually this just means the IP address
 	// comes from a private range.
 	if lat == 0 && long == 0 {
-		log.Warningf("GeoIP Resolution of the address %s resulted in the null lat/long. This will result in random server sorting.", ip.String())
-		err = GeoIPNullError{IpStr: ip.String()}
+		errMsg := fmt.Sprintf("GeoIP Resolution of the address %s resulted in the null lat/long. This will result in random server sorting.", ip.String())
+		log.Warningf(errMsg)
 		labels["source"] = "client"
-		metrics.PelicanDirectorGeoIPErrors.With(labels).Inc()
+		err = GeoIPError{labels: labels, errorMsg: errMsg}
 	}
 
 	// MaxMind provides an accuracy radius in kilometers. When it actually has no clue how to resolve a valid, public
@@ -264,13 +226,12 @@ func getLatLong(ctx context.Context, addr netip.Addr) (lat float64, long float64
 	// should be very suspicious of the data, and mark it as appearing at the null lat/long (and provide a warning in
 	// the Director), which also triggers random weighting in our sort algorithms.
 	if record.Location.AccuracyRadius >= 900 {
-		log.Warningf("GeoIP resolution of the address %s resulted in a suspiciously large accuracy radius of %d km. "+
+		errMsg := fmt.Sprintf("GeoIP resolution of the address %s resulted in a suspiciously large accuracy radius of %d km. "+
 			"This will be treated as GeoIP resolution failure and result in random server sorting. Setting lat/long to null.", ip.String(), record.Location.AccuracyRadius)
-		err = GeoIPAccuracyError{IpStr: ip.String(), AcuRadius: record.Location.AccuracyRadius}
 		lat = 0
 		long = 0
 		labels["source"] = "client"
-		metrics.PelicanDirectorGeoIPErrors.With(labels).Inc()
+		err = GeoIPError{labels: labels, errorMsg: errMsg}
 	}
 
 	return

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -470,9 +470,7 @@ func TestGetClientLatLong(t *testing.T) {
 
 		clientIp := netip.Addr{}
 		assert.False(t, clientIpCache.Has(clientIp))
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
-		coord1, _ := getClientLatLong(ctx, clientIp)
+		coord1, _ := getClientLatLong(clientIp)
 
 		assert.True(t, coord1.Lat <= usLatMax && coord1.Lat >= usLatMin)
 		assert.True(t, coord1.Long <= usLongMax && coord1.Long >= usLongMin)
@@ -480,9 +478,7 @@ func TestGetClientLatLong(t *testing.T) {
 		assert.NotContains(t, logOutput.String(), "Retrieving pre-assigned lat/long")
 
 		// Get it again to make sure it's coming from the cache
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
-		coord2, _ := getClientLatLong(ctx, clientIp)
+		coord2, _ := getClientLatLong(clientIp)
 		assert.Equal(t, coord1.Lat, coord2.Lat)
 		assert.Equal(t, coord1.Long, coord2.Long)
 		assert.Contains(t, logOutput.String(), "Retrieving pre-assigned lat/long for unresolved client IP")
@@ -496,9 +492,7 @@ func TestGetClientLatLong(t *testing.T) {
 
 		clientIp := netip.MustParseAddr("192.168.0.1")
 		assert.False(t, clientIpCache.Has(clientIp))
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
-		coord1, _ := getClientLatLong(ctx, clientIp)
+		coord1, _ := getClientLatLong(clientIp)
 
 		assert.True(t, coord1.Lat <= usLatMax && coord1.Lat >= usLatMin)
 		assert.True(t, coord1.Long <= usLongMax && coord1.Long >= usLongMin)
@@ -506,9 +500,7 @@ func TestGetClientLatLong(t *testing.T) {
 		assert.NotContains(t, logOutput.String(), "Retrieving pre-assigned lat/long")
 
 		// Get it again to make sure it's coming from the cache
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
-		coord2, _ := getClientLatLong(ctx, clientIp)
+		coord2, _ := getClientLatLong(clientIp)
 		assert.Equal(t, coord1.Lat, coord2.Lat)
 		assert.Equal(t, coord1.Long, coord2.Long)
 		assert.Contains(t, logOutput.String(), "Retrieving pre-assigned lat/long for client IP")

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -472,7 +472,7 @@ func TestGetClientLatLong(t *testing.T) {
 		assert.False(t, clientIpCache.Has(clientIp))
 		ctx := context.Background()
 		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
-		coord1 := getClientLatLong(ctx, clientIp)
+		coord1, _ := getClientLatLong(ctx, clientIp)
 
 		assert.True(t, coord1.Lat <= usLatMax && coord1.Lat >= usLatMin)
 		assert.True(t, coord1.Long <= usLongMax && coord1.Long >= usLongMin)
@@ -482,7 +482,7 @@ func TestGetClientLatLong(t *testing.T) {
 		// Get it again to make sure it's coming from the cache
 		ctx = context.Background()
 		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
-		coord2 := getClientLatLong(ctx, clientIp)
+		coord2, _ := getClientLatLong(ctx, clientIp)
 		assert.Equal(t, coord1.Lat, coord2.Lat)
 		assert.Equal(t, coord1.Long, coord2.Long)
 		assert.Contains(t, logOutput.String(), "Retrieving pre-assigned lat/long for unresolved client IP")
@@ -498,7 +498,7 @@ func TestGetClientLatLong(t *testing.T) {
 		assert.False(t, clientIpCache.Has(clientIp))
 		ctx := context.Background()
 		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
-		coord1 := getClientLatLong(ctx, clientIp)
+		coord1, _ := getClientLatLong(ctx, clientIp)
 
 		assert.True(t, coord1.Lat <= usLatMax && coord1.Lat >= usLatMin)
 		assert.True(t, coord1.Long <= usLongMax && coord1.Long >= usLongMin)
@@ -508,7 +508,7 @@ func TestGetClientLatLong(t *testing.T) {
 		// Get it again to make sure it's coming from the cache
 		ctx = context.Background()
 		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
-		coord2 := getClientLatLong(ctx, clientIp)
+		coord2, _ := getClientLatLong(ctx, clientIp)
 		assert.Equal(t, coord1.Lat, coord2.Lat)
 		assert.Equal(t, coord1.Long, coord2.Long)
 		assert.Contains(t, logOutput.String(), "Retrieving pre-assigned lat/long for client IP")


### PR DESCRIPTION
This PR addresses issue #1717. This PR fixes the unnecessary logging and separates out the GeoIP error metric collection. This is achieved via using a custom error type. This new error type carries along the prometheus labels. When we observe this new error type, we then update the metric with the passed along labels.