### PR TITLE
Force labelling of PRs + connecting to an issue and reopen unlabeled issues

### DIFF
--- a/.github/workflows/enforce-PR-labelling.yml
+++ b/.github/workflows/enforce-PR-labelling.yml
@@ -1,4 +1,4 @@
-name: PR and Issue Validation
+name: PR Validation
 
 on:
   pull_request:

--- a/.github/workflows/enforce-PR-labelling.yml
+++ b/.github/workflows/enforce-PR-labelling.yml
@@ -1,0 +1,55 @@
+name: PR and Issue Validation
+
+on:
+  pull_request:
+    # one limitation here is that there's no trigger to re-run any time we "connect" or "disconnect" an issue
+    types: [opened, edited, labeled, unlabeled, synchronize]
+
+jobs:
+  validate-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Validate PR has labels
+        id: check_labels
+        run: |
+          PR_LABELS=$(jq -r '.pull_request.labels | length' $GITHUB_EVENT_PATH)
+          if [ "$PR_LABELS" -eq "0" ]; then
+            echo "No labels found on the pull request."
+            exit 1
+          fi
+
+      - name: Validate PR is linked to an issue
+        id: check_linked_issues
+        run: |
+          PR_NUMBER=$(jq -r '.pull_request.number' $GITHUB_EVENT_PATH)
+          REPO_OWNER=$(jq -r '.repository.owner.login' $GITHUB_EVENT_PATH)
+          REPO_NAME=$(jq -r '.repository.name' $GITHUB_EVENT_PATH)
+          TIMELINE_JSON=$(curl -s "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/issues/$PR_NUMBER/timeline")
+
+          # Count the number of times the timeline sees a "connected" event and subract the number of "disconnected" events
+          # We might also consider using the "cross-referenced" event in the future if actual connecting/disconnecting is too heavy-handed
+          LINKED_ISSUES=$(echo "$TIMELINE_JSON" | jq '
+            reduce .[] as $event (
+              0;
+              if $event.event == "connected" then
+                . + 1
+              elif $event.event == "disconnected" then
+                . - 1
+              else
+                .
+              end
+            )')
+
+          # If the sum is 0, then no linked issues were found
+          if [ "$LINKED_ISSUES" -eq "0" ]; then
+            echo "❌ No linked issues found in the pull request."
+            exit 1
+          elif [ "$LINKED_ISSUES" -lt "0" ]; then
+            echo "Error: More disconnected events than connected events. This shouldn't be possible and likely indicates a big ol' 🪲"
+            exit 1
+          else
+            echo "Linked issues found: $LINKED_ISSUES"
+          fi

--- a/.github/workflows/enforce-issue-labelling.yml
+++ b/.github/workflows/enforce-issue-labelling.yml
@@ -1,0 +1,32 @@
+name: Issue Validation
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  validate-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Validate issue has labels
+        id: check_labels
+        run: |
+          ISSUE_LABELS=$(jq -r '.issue.labels | length' $GITHUB_EVENT_PATH)
+          if [ "$ISSUE_LABELS" -eq "0" ]; then
+            echo "No labels found on the issue."
+            # Re-open the issue
+            ISSUE_NUMBER=$(jq -r '.issue.number' $GITHUB_EVENT_PATH)
+            REPO_OWNER=$(jq -r '.repository.owner.login' $GITHUB_EVENT_PATH)
+            REPO_NAME=$(jq -r '.repository.name' $GITHUB_EVENT_PATH)
+            curl -L \
+              -X PATCH \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/issues/$ISSUE_NUMBER \
+              -d '{"state":"open"}'
+            exit 1
+          fi


### PR DESCRIPTION
This PR comes with two new actions -- one that forces every PR to be connected to at least one issue, as well as forcing at least one label on every PR, and one that re-opens issues if they're closed without a label.

After some consideration, I decided not to work on an action that prevents closing issues without a linked PR because some issues may be closed as `won't-fix`, which inherently means they won't link to anything.

One caveat is that the action for re-opening issues currently requires that the `GITHUB_TOKEN` has write permissions, because it sends a PATCH request through the github api. Not sure how the reviewer will test this ahead of time, since I think it needs to be merged into main. For my own testing, I merged these into my fork's main (which I later reset to track upstream/main again) and then opened+closed an unlabeled issue. I was able to successfully observe that it gets re-opened until a label is assigned.