### PR TITLE
Add a refresh interval to the origin exports

### DIFF
--- a/web_ui/frontend/app/origin/page.tsx
+++ b/web_ui/frontend/app/origin/page.tsx
@@ -19,7 +19,14 @@
 'use client';
 
 import { useState, Suspense } from 'react';
-import { Box, IconButton, Grid, Tooltip, Typography, Skeleton } from '@mui/material';
+import {
+  Box,
+  IconButton,
+  Grid,
+  Tooltip,
+  Typography,
+  Skeleton,
+} from '@mui/material';
 import { Key, CheckCircle } from '@mui/icons-material';
 
 import RateGraph from '@/components/graphs/RateGraph';
@@ -85,7 +92,7 @@ export default function Home() {
                 )}
               </Tooltip>
             </Box>
-            <Suspense fallback={<Skeleton/>}>
+            <Suspense fallback={<Skeleton />}>
               <DataExportTable />
             </Suspense>
           </Grid>

--- a/web_ui/frontend/app/origin/page.tsx
+++ b/web_ui/frontend/app/origin/page.tsx
@@ -18,8 +18,8 @@
 
 'use client';
 
-import { useState } from 'react';
-import { Box, IconButton, Grid, Tooltip, Typography } from '@mui/material';
+import { useState, Suspense } from 'react';
+import { Box, IconButton, Grid, Tooltip, Typography, Skeleton } from '@mui/material';
 import { Key, CheckCircle } from '@mui/icons-material';
 
 import RateGraph from '@/components/graphs/RateGraph';
@@ -85,7 +85,9 @@ export default function Home() {
                 )}
               </Tooltip>
             </Box>
-            <DataExportTable />
+            <Suspense fallback={<Skeleton/>}>
+              <DataExportTable />
+            </Suspense>
           </Grid>
           <Grid item xs={12} lg={6}>
             <Box

--- a/web_ui/frontend/components/DataExportTable.tsx
+++ b/web_ui/frontend/components/DataExportTable.tsx
@@ -22,7 +22,6 @@ import useSWR from 'swr';
 import { getErrorMessage } from '@/helpers/util';
 import { Capabilities } from '@/types';
 import { CapabilitiesDisplay } from '@/components';
-import CircularProgress from '@mui/material/CircularProgress';
 import { useSearchParams } from 'next/navigation';
 
 type RegistrationStatus =
@@ -368,10 +367,14 @@ const generateEditUrl = (editUrl: string, fromUrl: string) => {
 }
 
 export const DataExportTable = ({ boxProps }: { boxProps?: BoxProps }) => {
+
+  const searchParams = useSearchParams()
+  const from_registry = searchParams.get('from_registry') == 'true'
+
   const [pending, setPending] = useState<boolean>(false);
   const [ fromUrl, setFromUrl ] = useState<string | undefined>(undefined);
   const { data, mutate } = useSWR('getDataExport', getExportData, {
-    refreshInterval: 10000
+    refreshInterval: from_registry ? 10000 : 0,
   });
 
   useEffect(() => {
@@ -380,11 +383,8 @@ export const DataExportTable = ({ boxProps }: { boxProps?: BoxProps }) => {
     setTimeout(() => {
       mutate()
       setPending(false);
-    }, 5000);
+    }, 10000);
   }, []);
-
-  const searchParams = useSearchParams()
-  const from_registry = searchParams.get('from_registry') == 'true'
 
   const dataEnhanced = useMemo(() => {
 

--- a/web_ui/frontend/components/DataExportTable.tsx
+++ b/web_ui/frontend/components/DataExportTable.tsx
@@ -12,7 +12,7 @@ import {
   Pagination,
   Paper,
   Alert,
-  IconButton,
+  IconButton, LinearProgress,
 } from '@mui/material';
 import React, { ReactElement, useEffect, useMemo, useState } from 'react';
 import { Skeleton } from '@mui/material';
@@ -22,6 +22,7 @@ import useSWR from 'swr';
 import { getErrorMessage } from '@/helpers/util';
 import { Capabilities } from '@/types';
 import { CapabilitiesDisplay } from '@/components';
+import CircularProgress from '@mui/material/CircularProgress';
 
 type RegistrationStatus =
   | 'Not Supported'
@@ -351,11 +352,19 @@ export const getExportData = async (): Promise<ExportRes> => {
 };
 
 export const DataExportTable = ({ boxProps }: { boxProps?: BoxProps }) => {
-  const [fromUrl, setFromUrl] = useState<string | undefined>(undefined);
-  const { data, error } = useSWR('getDataExport', getExportData);
+  const [pending, setPending] = useState<boolean>(false);
+  const [ fromUrl, setFromUrl ] = useState<string | undefined>(undefined);
+  const { data, error, mutate } = useSWR('getDataExport', getExportData, {
+    refreshInterval: 10000
+  });
 
   useEffect(() => {
     setFromUrl(window.location.href);
+    setPending(true);
+    setTimeout(() => {
+      mutate()
+      setPending(false);
+    }, 5000);
   }, []);
 
   if (error) {
@@ -396,6 +405,12 @@ export const DataExportTable = ({ boxProps }: { boxProps?: BoxProps }) => {
 
   return (
     <Box {...boxProps}>
+      {pending &&
+        <Box display={"flex"} flexDirection={"column"}>
+          <LinearProgress sx={{mb:1, w: "100%"}} />
+          <Typography variant={'subtitle2'} color={grey[400]} mx={"auto"}>Checking Registry for Updates</Typography>
+        </Box>
+      }
       <Typography pb={1} variant={'h5'} component={'h3'}>
         Origin
       </Typography>

--- a/web_ui/frontend/components/DataExportTable.tsx
+++ b/web_ui/frontend/components/DataExportTable.tsx
@@ -355,7 +355,7 @@ export const getExportData = async (): Promise<ExportRes> => {
 const generateEditUrl = (editUrl: string, fromUrl: string) => {
   try {
     let updatedFromUrl = new URL(fromUrl)
-    if(!('from_registry' in updatedFromUrl.searchParams)) {
+    if(updatedFromUrl.searchParams.get('from_registry') === null) {
       updatedFromUrl.searchParams.append('from_registry', 'true')
     }
     const url = new URL(editUrl);
@@ -413,7 +413,7 @@ export const DataExportTable = ({ boxProps }: { boxProps?: BoxProps }) => {
       {from_registry && pending &&
         <Box display={"flex"} flexDirection={"column"}>
           <LinearProgress sx={{mb:1, w: "100%"}} />
-          <Typography variant={'subtitle2'} color={grey[400]} mx={"auto"}>Checking Registry for Updates</Typography>
+          <Typography variant={'subtitle2'} color={grey[400]} mx={"auto"}>Starting Update Watcher; Will Poll Every 10 Seconds;</Typography>
         </Box>
       }
       <Typography pb={1} variant={'h5'} component={'h3'}>

--- a/web_ui/frontend/components/DataExportTable.tsx
+++ b/web_ui/frontend/components/DataExportTable.tsx
@@ -12,7 +12,8 @@ import {
   Pagination,
   Paper,
   Alert,
-  IconButton, LinearProgress,
+  IconButton,
+  LinearProgress,
 } from '@mui/material';
 import React, { ReactElement, useEffect, useMemo, useState } from 'react';
 import { Skeleton } from '@mui/material';
@@ -353,9 +354,9 @@ export const getExportData = async (): Promise<ExportRes> => {
 
 const generateEditUrl = (editUrl: string, fromUrl: string) => {
   try {
-    let updatedFromUrl = new URL(fromUrl)
-    if(updatedFromUrl.searchParams.get('from_registry') === null) {
-      updatedFromUrl.searchParams.append('from_registry', 'true')
+    let updatedFromUrl = new URL(fromUrl);
+    if (updatedFromUrl.searchParams.get('from_registry') === null) {
+      updatedFromUrl.searchParams.append('from_registry', 'true');
     }
     const url = new URL(editUrl);
     url.searchParams.append('fromUrl', updatedFromUrl.toString());
@@ -364,15 +365,14 @@ const generateEditUrl = (editUrl: string, fromUrl: string) => {
     console.error('Failed to generate editUrl', e);
     return editUrl;
   }
-}
+};
 
 export const DataExportTable = ({ boxProps }: { boxProps?: BoxProps }) => {
-
-  const searchParams = useSearchParams()
-  const from_registry = searchParams.get('from_registry') == 'true'
+  const searchParams = useSearchParams();
+  const from_registry = searchParams.get('from_registry') == 'true';
 
   const [pending, setPending] = useState<boolean>(false);
-  const [ fromUrl, setFromUrl ] = useState<string | undefined>(undefined);
+  const [fromUrl, setFromUrl] = useState<string | undefined>(undefined);
   const { data, mutate } = useSWR('getDataExport', getExportData, {
     refreshInterval: from_registry ? 10000 : 0,
   });
@@ -381,13 +381,12 @@ export const DataExportTable = ({ boxProps }: { boxProps?: BoxProps }) => {
     setFromUrl(window.location.href);
     setPending(true);
     setTimeout(() => {
-      mutate()
+      mutate();
       setPending(false);
     }, 10000);
   }, []);
 
   const dataEnhanced = useMemo(() => {
-
     // If no from URL return current data
     if (!fromUrl) {
       return data;
@@ -398,24 +397,25 @@ export const DataExportTable = ({ boxProps }: { boxProps?: BoxProps }) => {
       return undefined;
     }
 
-    let dataEnhanced = structuredClone(data)
+    let dataEnhanced = structuredClone(data);
     dataEnhanced.editUrl = generateEditUrl(dataEnhanced.editUrl, fromUrl);
     dataEnhanced.exports.map((val) => {
       val.editUrl = generateEditUrl(val.editUrl, fromUrl);
     });
 
     return dataEnhanced;
-
-  }, [data, fromUrl])
+  }, [data, fromUrl]);
 
   return (
     <Box {...boxProps}>
-      {from_registry && pending &&
-        <Box display={"flex"} flexDirection={"column"}>
-          <LinearProgress sx={{mb:1, w: "100%"}} />
-          <Typography variant={'subtitle2'} color={grey[400]} mx={"auto"}>Starting Update Watcher; Will Poll Every 10 Seconds;</Typography>
+      {from_registry && pending && (
+        <Box display={'flex'} flexDirection={'column'}>
+          <LinearProgress sx={{ mb: 1, w: '100%' }} />
+          <Typography variant={'subtitle2'} color={grey[400]} mx={'auto'}>
+            Starting Update Watcher; Will Poll Every 10 Seconds;
+          </Typography>
         </Box>
-      }
+      )}
       <Typography pb={1} variant={'h5'} component={'h3'}>
         Origin
       </Typography>

--- a/web_ui/frontend/components/DataExportTable.tsx
+++ b/web_ui/frontend/components/DataExportTable.tsx
@@ -412,7 +412,7 @@ export const DataExportTable = ({ boxProps }: { boxProps?: BoxProps }) => {
         <Box display={'flex'} flexDirection={'column'}>
           <LinearProgress sx={{ mb: 1, w: '100%' }} />
           <Typography variant={'subtitle2'} color={grey[400]} mx={'auto'}>
-            Starting Update Watcher; Will Poll Every 10 Seconds;
+            Polling from Registry for Updates Every 10 Seconds
           </Typography>
         </Box>
       )}


### PR DESCRIPTION
- UI and UI backing updates to make sure its up to date

The current issue is that when you redirect from a corrected registration in the registry back to the origin you were registering the initial query from the origin is so fast that it misses the changes. 

This adds a UI loading bar that waits 5 seconds for a requery. If for some reason it takes longer then 5 seconds I also auto refresh these metrics every 5 seconds in the background so things will just switch over automatically in the UI.