### PR TITLE
Escape user and group names in issued tokens (#1494)

### DIFF
--- a/oa4mp/resources/policies.qdl
+++ b/oa4mp/resources/policies.qdl
@@ -35,12 +35,12 @@ scopes := {};
 while [has_value(key, group_list.)]
 [
     group_scopes := { {{- range $idx, $action := .Actions }}{{- if eq $idx 0 -}}'{{- $action -}}:'{{else}}, '{{- $action -}}:'{{- end -}}{{ end -}} } + '{{- .Prefix -}}';
-    scopes := scopes \/ |^replace(~group_scopes, '$GROUP', key);
+    scopes := scopes \/ |^replace(~group_scopes, '$GROUP', encode(key, 1)); /* 1 = URL-encode (RFC 3986) */
 ];
 {{- end }}
 {{ range .UserAuthzTemplates }}
 user_scopes := { {{- range $idx, $action := .Actions }}{{- if eq $idx 0 -}}'{{- $action -}}:'{{else}}, '{{- $action -}}:'{{- end -}}{{ end -}} } + '{{- .Prefix -}}';
-scopes := scopes \/ |^replace(~user_scopes, '$USER', claims.'sub');
+scopes := scopes \/ |^replace(~user_scopes, '$USER', encode(claims.'sub', 1)); /* 1 = URL-encode (RFC 3986) */
 {{ end }}
 access_token.'scope' := detokenize(scopes, ' ', 2);
 


### PR DESCRIPTION
Both the SciTokens and WLCG profiles require that a scope's path components be URL encoded. When substituting for `$USER` and `$GROUP` in any authorization templates, we should ensure that the value being substituted in is URL encoded.

References:

* [QDL function reference](https://qdl-lang.org/pdf/function-reference.pdf)
* [SciTokens profile](https://scitokens.org/technical_docs/Claims)
* [WLCG profile](https://github.com/WLCG-AuthZ-WG/common-jwt-profile/blob/master/profile.md)