### PR TITLE
Implement Object Delete Command

### DIFF
--- a/client/director_test.go
+++ b/client/director_test.go
@@ -187,7 +187,7 @@ func TestGetDirectorInfoForPath(t *testing.T) {
 			directorUrl:   ts.URL,
 			httpMethod:    http.MethodPut,
 			query:         "",
-			expectedError: "error 405: No writeable origins were found",
+			expectedError: "the director returned status code 405",
 		},
 		{
 			name:          "Queries are propagated", // also generates 405, although this is a feauture of the director

--- a/client/director_test.go
+++ b/client/director_test.go
@@ -161,7 +161,7 @@ func TestGetDirectorInfoForPath(t *testing.T) {
 		name          string
 		resourcePath  string
 		directorUrl   string
-		isPut         bool
+		httpMethod    string
 		query         string
 		expectedError string
 	}{
@@ -169,7 +169,7 @@ func TestGetDirectorInfoForPath(t *testing.T) {
 			name:          "No director URL",
 			resourcePath:  "/test",
 			directorUrl:   "",
-			isPut:         false,
+			httpMethod:    http.MethodGet,
 			query:         "",
 			expectedError: "unable to retrieve information from a Director for object /test because none was found in pelican URL metadata.",
 		},
@@ -177,7 +177,7 @@ func TestGetDirectorInfoForPath(t *testing.T) {
 			name:          "Successful GET request",
 			resourcePath:  "/test",
 			directorUrl:   ts.URL,
-			isPut:         false,
+			httpMethod:    http.MethodGet,
 			query:         "",
 			expectedError: "",
 		},
@@ -185,7 +185,7 @@ func TestGetDirectorInfoForPath(t *testing.T) {
 			name:          "PUT request changes verb", // also generates 405, although this is a feauture of the director
 			resourcePath:  "/test",
 			directorUrl:   ts.URL,
-			isPut:         true,
+			httpMethod:    http.MethodPut,
 			query:         "",
 			expectedError: "error 405: No writeable origins were found",
 		},
@@ -193,7 +193,7 @@ func TestGetDirectorInfoForPath(t *testing.T) {
 			name:          "Queries are propagated", // also generates 405, although this is a feauture of the director
 			resourcePath:  "/test",
 			directorUrl:   ts.URL,
-			isPut:         false,
+			httpMethod:    http.MethodGet,
 			query:         "directread",
 			expectedError: "200: {\"status\": \"direct read\"}",
 		},
@@ -212,7 +212,7 @@ func TestGetDirectorInfoForPath(t *testing.T) {
 
 			pUrl.FedInfo.DirectorEndpoint = tt.directorUrl
 
-			_, err = GetDirectorInfoForPath(ctx, pUrl, tt.isPut, "")
+			_, err = GetDirectorInfoForPath(ctx, pUrl, tt.httpMethod, "")
 			if tt.expectedError != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)

--- a/client/fed_linux_test.go
+++ b/client/fed_linux_test.go
@@ -1095,6 +1095,6 @@ func TestObjectDelete(t *testing.T) {
 		err := client.DoDelete(fed.Ctx, collectionToDeletePelicanUrl, false, client.WithTokenLocation(tempToken.Name()))
 
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "403")
+		require.Contains(t, err.Error(), "405")
 	})
 }

--- a/client/fed_linux_test.go
+++ b/client/fed_linux_test.go
@@ -978,7 +978,7 @@ func TestObjectDelete(t *testing.T) {
 
 	// Note: Even though os.Mkdir is called with permissions, it may create directories
 	// with 0755 permissions due to internal behavior. To ensure the directory has the desired
-	// permissions permissions, we explicitly call os.Chmod after creating the directory.
+	// permissions, we explicitly call os.Chmod after creating the directory.
 	//
 	// We need to set 0777 permissions on the directory to enable deletion of its contents by non-owners.
 	err = os.Chmod(complexCollection, 0777)

--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -69,6 +69,9 @@ var (
 
 	//go:embed resources/test-https-origin.yml
 	httpsOriginConfig string
+
+	//go:embed resources/origin-with-and-without-write.yaml
+	originConfigWithAndWithoutWrite string
 )
 
 // Helper function to get a temporary token file

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2655,8 +2655,9 @@ func listHttp(remoteUrl *pelican_url.PelicanURL, dirResp server_structs.Director
 }
 
 func deleteHttp(remoteUrl *pelican_url.PelicanURL, recursive bool, dirResp server_structs.DirectorResponse, token *tokenGenerator) (err error) {
+	log.Debugln("Attempting to delete:", remoteUrl.Path)
 	if dirResp.XPelNsHdr.CollectionsUrl == nil {
-		return errors.Errorf("Collections URL not found in director response. Are you sure there's an origin for prefix %s that supports deletions?", dirResp.XPelNsHdr.Namespace)
+		return errors.Errorf("collections URL not found in director response.")
 	}
 
 	collectionsUrl := dirResp.XPelNsHdr.CollectionsUrl
@@ -2699,7 +2700,7 @@ func deleteHttp(remoteUrl *pelican_url.PelicanURL, recursive bool, dirResp serve
 		}
 		return errors.Wrap(err, "failed to delete remote object")
 	}
-
+	log.Debugln("Successfully deleted:", remoteUrl.Path)
 	return nil
 }
 

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1056,11 +1056,9 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 		}
 	}
 
-	httpMethod := http.MethodPut
+	httpMethod := http.MethodGet
 	if upload {
 		httpMethod = http.MethodPut
-	} else {
-		httpMethod = http.MethodGet
 	}
 
 	tj.directorUrl = copyUrl.FedInfo.DirectorEndpoint

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1056,8 +1056,15 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 		}
 	}
 
+	httpMethod := http.MethodPut
+	if upload {
+		httpMethod = http.MethodPut
+	} else {
+		httpMethod = http.MethodGet
+	}
+
 	tj.directorUrl = copyUrl.FedInfo.DirectorEndpoint
-	dirResp, err := GetDirectorInfoForPath(tj.ctx, &copyUrl, upload, "")
+	dirResp, err := GetDirectorInfoForPath(tj.ctx, &copyUrl, httpMethod, "")
 	if err != nil {
 		log.Errorln(err)
 		err = errors.Wrapf(err, "failed to get namespace information for remote URL %s", pUrl.String())
@@ -1074,7 +1081,7 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 
 		// The director response may change if it's given a token; let's repeat the query.
 		if contents != "" {
-			dirResp, err = GetDirectorInfoForPath(tj.ctx, &copyUrl, upload, contents)
+			dirResp, err = GetDirectorInfoForPath(tj.ctx, &copyUrl, httpMethod, contents)
 			if err != nil {
 				log.Errorln(err)
 				err = errors.Wrapf(err, "failed to get namespace information for remote URL %s", copyUrl.String())

--- a/client/main.go
+++ b/client/main.go
@@ -135,7 +135,7 @@ func DoStat(ctx context.Context, destination string, options ...TransferOption) 
 		}
 	}()
 
-	dirResp, err := GetDirectorInfoForPath(ctx, pUrl, false, "")
+	dirResp, err := GetDirectorInfoForPath(ctx, pUrl, http.MethodGet, "")
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func GetObjectServerHostnames(ctx context.Context, testFile string) (urls []stri
 	if err != nil {
 		return
 	}
-	parsedDirResp, err := GetDirectorInfoForPath(ctx, pUrl, false, "")
+	parsedDirResp, err := GetDirectorInfoForPath(ctx, pUrl, http.MethodGet, "")
 	if err != nil {
 		return
 	}
@@ -280,7 +280,7 @@ func DoList(ctx context.Context, remoteObject string, options ...TransferOption)
 		}
 	}()
 
-	dirResp, err := GetDirectorInfoForPath(ctx, pUrl, false, "")
+	dirResp, err := GetDirectorInfoForPath(ctx, pUrl, http.MethodGet, "")
 	if err != nil {
 		return nil, err
 	}
@@ -332,7 +332,7 @@ func DoDelete(ctx context.Context, remoteDestination string, recursive bool, opt
 	if _, exists := pUrl.Query()[pelican_url.QueryRecursive]; exists {
 		recursive = true
 	}
-	dirResp, err := GetDirectorInfoForPath(ctx, pUrl, true, "")
+	dirResp, err := GetDirectorInfoForPath(ctx, pUrl, http.MethodDelete, "")
 	if err != nil {
 		return err
 	}

--- a/client/main.go
+++ b/client/main.go
@@ -316,7 +316,6 @@ func DoList(ctx context.Context, remoteObject string, options ...TransferOption)
 }
 
 func DoDelete(ctx context.Context, remoteDestination string, recursive bool, options ...TransferOption) (err error) {
-	log.Debug("Starting DoDelete")
 	defer func() {
 		if r := recover(); r != nil {
 			log.Debugln("Panic captured while attempting to perform transfer (DoList):", r)

--- a/client/main.go
+++ b/client/main.go
@@ -329,11 +329,11 @@ func DoDelete(ctx context.Context, remoteObject string, options ...TransferOptio
 	if err != nil {
 		return errors.Wrapf(err, "failed to parse remote path: %s", remoteObject)
 	}
-	dirResp, err := GetDirectorInfoForPath(ctx, pUrl, false, "")
+	dirResp, err := GetDirectorInfoForPath(ctx, pUrl, true, "")
 	if err != nil {
 		return err
 	}
-	token := newTokenGenerator(pUrl, &dirResp, false, true)
+	token := newTokenGenerator(pUrl, &dirResp, true, true)
 	for _, option := range options {
 		switch option.Ident() {
 		case identTransferOptionTokenLocation{}:

--- a/client/main.go
+++ b/client/main.go
@@ -315,6 +315,7 @@ func DoList(ctx context.Context, remoteObject string, options ...TransferOption)
 	return fileInfos, nil
 }
 
+// DoDelete queries the director using the DELETE HTTP method, retrieves the token, and initializes the delete operation.
 func DoDelete(ctx context.Context, remoteDestination string, recursive bool, options ...TransferOption) (err error) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/client/resources/origin-with-and-without-write.yaml
+++ b/client/resources/origin-with-and-without-write.yaml
@@ -1,0 +1,10 @@
+Origin:
+  StorageType: "posix"
+  EnableDirectReads: true
+  Exports:
+    - StoragePrefix: /<SHOULD BE OVERRIDDEN>
+      FederationPrefix: /with-write
+      Capabilities: ["PublicReads", "Writes", "Listings"]
+    - StoragePrefix: /<SHOULD BE OVERRIDDEN>
+      FederationPrefix: /without-write
+      Capabilities: ["PublicReads", "Listings"]

--- a/client/resources/origin-with-and-without-write.yaml
+++ b/client/resources/origin-with-and-without-write.yaml
@@ -1,3 +1,5 @@
+# Origin configuration with two prefixes: one with write capability and one without.
+
 Origin:
   StorageType: "posix"
   EnableDirectReads: true

--- a/cmd/config_mgr.go
+++ b/cmd/config_mgr.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -133,11 +134,12 @@ func addTokenSubcommands(tokenCmd *cobra.Command) {
 		Args:  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 
-			isWrite := false
+			httpMethod := http.MethodGet
 			switch args[0] {
 			case "read":
 			case "write":
-				isWrite = true
+				httpMethod = http.MethodPut
+
 			default:
 				fmt.Fprintln(os.Stderr, "Unknown value for operation type (must be 'read' or 'write')", args[0])
 				os.Exit(1)
@@ -152,14 +154,14 @@ func addTokenSubcommands(tokenCmd *cobra.Command) {
 				fmt.Fprintln(os.Stderr, "Failed to parse URL:", err)
 				os.Exit(1)
 			}
-			dirResp, err := client.GetDirectorInfoForPath(cmd.Context(), pUrl, isWrite, "")
+			dirResp, err := client.GetDirectorInfoForPath(cmd.Context(), pUrl, httpMethod, "")
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "Failed to get director info for path:", err)
 				os.Exit(1)
 			}
 
 			opts := config.TokenGenerationOpts{Operation: config.TokenRead}
-			if isWrite {
+			if httpMethod == http.MethodPut {
 				opts.Operation = config.TokenWrite
 			}
 			token, err := client.AcquireToken(pUrl.GetRawUrl(), dirResp, opts)

--- a/cmd/object_delete.go
+++ b/cmd/object_delete.go
@@ -32,7 +32,7 @@ import (
 var (
 	objectDeleteCmd = &cobra.Command{
 		Use:   "delete {object}",
-		Short: "Delete an object from a namespace in a federation",
+		Short: "Delete an object or a collection",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return fmt.Errorf("no location provided for deletion")
@@ -42,7 +42,8 @@ var (
 			}
 			return nil
 		},
-		RunE: deleteMain,
+		RunE:   deleteMain,
+		Hidden: true,
 	}
 )
 
@@ -54,6 +55,7 @@ func init() {
 	objectCmd.AddCommand(objectDeleteCmd)
 }
 
+// deleteMain is the top-level function for executing the object delete command.
 func deleteMain(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 

--- a/cmd/object_delete.go
+++ b/cmd/object_delete.go
@@ -42,7 +42,11 @@ var (
 			}
 			return nil
 		},
-		RunE:   deleteMain,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			log.Warning("Object delete command is not openly supported and will only remove data from the origin, not from caches the data might have propagated to.")
+
+			return deleteMain(cmd, args)
+		},
 		Hidden: true,
 	}
 )

--- a/cmd/object_delete.go
+++ b/cmd/object_delete.go
@@ -1,0 +1,96 @@
+/***************************************************************
+*
+* Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/config"
+)
+
+var (
+	objectDeleteCmd = &cobra.Command{
+		Use:   "delete {object}",
+		Short: "Delete an object from a namespace in a federation",
+		RunE:  deleteMain,
+	}
+)
+
+func init() {
+	flagSet := objectDeleteCmd.Flags()
+	flagSet.StringP("token", "t", "", "Token file to use for transfer")
+
+	objectCmd.AddCommand(objectDeleteCmd)
+}
+
+func deleteMain(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	err := config.InitClient()
+	if err != nil {
+		log.Errorln("Failed to initialize client:", err)
+
+		if client.IsRetryable(err) {
+			return fmt.Errorf("retryable error occurred: %v", err)
+		}
+		return fmt.Errorf("non-retryable error occurred: %v", err)
+	}
+
+	tokenLocation, _ := cmd.Flags().GetString("token")
+
+	if len(args) < 1 {
+		_ = cmd.Help()
+		return fmt.Errorf("no location provided for deletion")
+	}
+	object := args[len(args)-1]
+	log.Debugln("Object to be deleted:", object)
+
+	err = client.DoDelete(ctx, object, client.WithTokenLocation(tokenLocation))
+	// if err != nil {
+	// 	if client.IsRetryable(err) {
+	// 		return fmt.Errorf("temporary error deleting object: %s. Please try again later", object)
+	// 	}
+	// 	return fmt.Errorf("unexpected error while deleting object: %v", err)
+	// }
+
+	// Exit with failure
+	if err != nil {
+		// Print the list of errors
+		errMsg := err.Error()
+		var te *client.TransferErrors
+		if errors.As(err, &te) {
+			errMsg = te.UserError()
+		}
+		log.Errorln("Failure getting " + object + ": " + errMsg)
+		if client.ShouldRetry(err) {
+			log.Errorln("Errors are retryable")
+			os.Exit(11)
+		}
+		os.Exit(1)
+	}
+
+	log.Infoln("Successfully deleted object:", object)
+	return nil
+}

--- a/director/director.go
+++ b/director/director.go
@@ -894,8 +894,8 @@ func ShortcutMiddleware(defaultResponse string) gin.HandlerFunc {
 			c.Next()
 			return
 		}
-		// Regardless of the remainder of the settings, we currently handle a PUT as a query to the origin endpoint
-		if c.Request.Method == "PUT" {
+		// Regardless of the remainder of the settings, we currently handle a PUT and DELETE as a query to the origin endpoint
+		if c.Request.Method == "PUT" || c.Request.Method == "DELETE" {
 			c.Request.URL.Path = "/api/v1.0/director/origin" + c.Request.URL.Path
 			redirectToOrigin(c)
 			c.Abort()
@@ -1393,6 +1393,7 @@ func RegisterDirectorAPI(ctx context.Context, router *gin.RouterGroup) {
 		directorAPIV1.GET("/origin/*any", redirectToOrigin)
 		directorAPIV1.HEAD("/origin/*any", redirectToOrigin)
 		directorAPIV1.PUT("/origin/*any", redirectToOrigin)
+		directorAPIV1.DELETE("/origin/*any", redirectToOrigin)
 		directorAPIV1.POST("/registerOrigin", serverAdMetricMiddleware, func(gctx *gin.Context) { registerServeAd(ctx, gctx, server_structs.OriginType) })
 		directorAPIV1.POST("/registerCache", serverAdMetricMiddleware, func(gctx *gin.Context) { registerServeAd(ctx, gctx, server_structs.CacheType) })
 		directorAPIV1.GET("/listNamespaces", listNamespacesV1)

--- a/director/director.go
+++ b/director/director.go
@@ -819,10 +819,10 @@ func redirectToOrigin(ginCtx *gin.Context) {
 	generateXAuthHeader(ginCtx, namespaceAd)
 	generateXTokenGenHeader(ginCtx, namespaceAd)
 
-	// If we are doing a PUT, check to see if any origins are writeable
-	if ginCtx.Request.Method == "PUT" {
+	// If we are doing a PUT or DELETE, check to see if any origins are writeable
+	if ginCtx.Request.Method == http.MethodPut || ginCtx.Request.Method == http.MethodDelete {
 		for idx, ad := range availableAds {
-			if ad.Caps.Writes {
+			if ad.Caps.Writes && namespaceAd.Caps.Writes {
 				redirectURL = getRedirectURL(reqPath, availableAds[idx], !namespaceAd.Caps.PublicReads)
 				if brokerUrl := availableAds[idx].BrokerURL; brokerUrl.String() != "" {
 					ginCtx.Header("X-Pelican-Broker", brokerUrl.String())

--- a/director/director.go
+++ b/director/director.go
@@ -894,7 +894,7 @@ func ShortcutMiddleware(defaultResponse string) gin.HandlerFunc {
 			c.Next()
 			return
 		}
-		// Regardless of the remainder of the settings, we currently handle a PUT and DELETE as a query to the origin endpoint
+		// Regardless of the remainder of the settings, we currently handle PUT or DELETE as a query to the origin endpoint
 		if c.Request.Method == "PUT" || c.Request.Method == "DELETE" {
 			c.Request.URL.Path = "/api/v1.0/director/origin" + c.Request.URL.Path
 			redirectToOrigin(c)

--- a/director/director.go
+++ b/director/director.go
@@ -895,7 +895,7 @@ func ShortcutMiddleware(defaultResponse string) gin.HandlerFunc {
 			return
 		}
 		// Regardless of the remainder of the settings, we currently handle PUT or DELETE as a query to the origin endpoint
-		if c.Request.Method == "PUT" || c.Request.Method == "DELETE" {
+		if c.Request.Method == http.MethodPut || c.Request.Method == http.MethodDelete {
 			c.Request.URL.Path = "/api/v1.0/director/origin" + c.Request.URL.Path
 			redirectToOrigin(c)
 			c.Abort()
@@ -916,7 +916,7 @@ func ShortcutMiddleware(defaultResponse string) gin.HandlerFunc {
 
 		// If we are doing a PROPFIND, we should always redirect to the origin
 		if c.Request.Method == "PROPFIND" {
-			if !strings.HasPrefix(c.Request.URL.Path, "/api/v1.0/director/") && (c.Request.Method == "PROPFIND" || c.Request.Method == "HEAD") {
+			if !strings.HasPrefix(c.Request.URL.Path, "/api/v1.0/director/") && (c.Request.Method == "PROPFIND" || c.Request.Method == http.MethodHead) {
 				c.Request.URL.Path = "/api/v1.0/director/origin" + c.Request.URL.Path
 				redirectToOrigin(c)
 				c.Abort()
@@ -936,7 +936,7 @@ func ShortcutMiddleware(defaultResponse string) gin.HandlerFunc {
 		// If we're configured for cache mode or we haven't set the flag,
 		// we should use cache middleware
 		if defaultResponse == "cache" {
-			if !strings.HasPrefix(c.Request.URL.Path, "/api/v1.0/director/") && (c.Request.Method == "GET" || c.Request.Method == "HEAD") {
+			if !strings.HasPrefix(c.Request.URL.Path, "/api/v1.0/director/") && (c.Request.Method == http.MethodGet || c.Request.Method == http.MethodHead) {
 				c.Request.URL.Path = "/api/v1.0/director/object" + c.Request.URL.Path
 				redirectToCache(c)
 				c.Abort()
@@ -946,7 +946,7 @@ func ShortcutMiddleware(defaultResponse string) gin.HandlerFunc {
 			// If the path starts with the correct prefix, continue with the next handler
 			c.Next()
 		} else if defaultResponse == "origin" {
-			if !strings.HasPrefix(c.Request.URL.Path, "/api/v1.0/director/") && (c.Request.Method == "GET" || c.Request.Method == "HEAD") {
+			if !strings.HasPrefix(c.Request.URL.Path, "/api/v1.0/director/") && (c.Request.Method == http.MethodGet || c.Request.Method == http.MethodHead) {
 				c.Request.URL.Path = "/api/v1.0/director/origin" + c.Request.URL.Path
 				redirectToOrigin(c)
 				c.Abort()


### PR DESCRIPTION
This PR closes #1685 by implementing an object delete command.

The object delete command is not openly supported and is marked hidden. It deletes data from the origin and does not clean data from caches the data might have propagated to.

The object delete command supports the recursive option to delete collections.