### PR TITLE
Docker images: Put binaries into standard locations

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -195,10 +195,10 @@ COPY --from=xrootd-plugin-builder /usr/lib64/libnlohmann_json_schema_validator.a
 COPY images/entrypoint.sh /entrypoint.sh
 
 # Copy here to reduce dependency on the pelican-build stage in the final-stage and x-base stage
-COPY --from=pelican-build /pelican/dist/pelican_linux_amd64_v1/pelican /pelican/pelican
-COPY --from=pelican-build /pelican/dist/pelican_linux_amd64_v1/pelican /pelican/osdf
-RUN chmod +x /pelican/pelican \
-    && chmod +x /pelican/osdf \
+COPY --from=pelican-build /pelican/dist/pelican_linux_amd64_v1/pelican /usr/local/bin/pelican
+COPY --from=pelican-build /pelican/dist/pelican_linux_amd64_v1/pelican /usr/local/bin/osdf
+RUN    chmod +x /usr/local/bin/pelican \
+    && chmod +x /usr/local/bin/osdf \
     && chmod +x /entrypoint.sh
 
 ######################
@@ -206,23 +206,23 @@ RUN chmod +x /pelican/pelican \
 ######################
 FROM final-stage AS pelican-base
 
-RUN rm -rf /pelican/osdf
+RUN rm -f /usr/local/bin/osdf
 
 ######################
 # OSDF base stage #
 ######################
 FROM final-stage AS osdf-base
 
-RUN rm -rf /pelican/pelican
+RUN rm -f /usr/local/bin/pelican
 
 ####################
 # pelican/cache    #
 ####################
 
 FROM pelican-base AS cache
-RUN rm -rf /pelican/pelican
-COPY --from=pelican-build /pelican/dist/pelican-server_linux_amd64_v1/pelican-server /pelican/pelican-server
-RUN chmod +x /pelican/pelican-server
+RUN rm -f /usr/local/bin/pelican
+COPY --from=pelican-build /pelican/dist/pelican-server_linux_amd64_v1/pelican-server /usr/local/sbin/pelican-server
+RUN chmod +x /usr/local/sbin/pelican-server
 # For now, we're only using pelican-server in the cache, but eventually we'll use it in all servers
 ENTRYPOINT [ "/entrypoint.sh", "pelican-server", "cache"]
 CMD [ "serve" ]
@@ -264,8 +264,8 @@ CMD [ "serve" ]
 
 FROM osdf-base AS osdf-cache
 RUN rm -rf /pelican/osdf
-COPY --from=pelican-build /pelican/dist/pelican-server_linux_amd64_v1/pelican-server /pelican/osdf-server
-RUN chmod +x /pelican/osdf-server
+COPY --from=pelican-build /pelican/dist/pelican-server_linux_amd64_v1/pelican-server /usr/local/sbin/osdf-server
+RUN chmod +x /usr/local/sbin/osdf-server
 ENTRYPOINT [ "/entrypoint.sh" ,"osdf-server", "cache"]
 CMD [ "serve" ]
 

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -114,7 +114,7 @@ if [ $# -ne 0 ]; then
         pelican)
             # Run pelican with the rest of the arguments
             echo "Running pelican with arguments: $@"
-            exec tini -- /pelican/pelican "$@"
+            exec tini -- /usr/local/bin/pelican "$@"
             # we shouldn't get here
             echo >&2 "Exec of tini failed!"
             exit 1
@@ -123,7 +123,7 @@ if [ $# -ne 0 ]; then
             # Our server-specific binary which may come with additional
             # features/system requirements (like Lotman)
             echo "Running pelican-server with arguments: $@"
-            exec tini -- /pelican/pelican-server "$@"
+            exec tini -- /usr/local/sbin/pelican-server "$@"
             # we shouldn't get here
             echo >&2 "Exec of tini failed!"
             exit 1
@@ -131,14 +131,14 @@ if [ $# -ne 0 ]; then
         osdf)
             # Run osdf with the rest of the arguments
             echo "Running osdf with arguments: $@"
-            exec tini -- /pelican/osdf "$@"
+            exec tini -- /usr/local/bin/osdf "$@"
             # we shouldn't get here
             echo >&2 "Exec of tini failed!"
             exit 1
             ;;
         osdf-server)
             echo "Running osdf-server with arguments: $@"
-            exec tini -- /pelican/osdf-server "$@"
+            exec tini -- /usr/local/sbin/osdf-server "$@"
             # we shouldn't get here
             echo >&2 "Exec of tini failed!"
             exit 1


### PR DESCRIPTION
- pelican and osdf go into /usr/local/bin
- pelican-server and osdf-server go into /usr/local/sbin

Fixes #1744