### PR TITLE
Trigger release actions if tag matches new `-rc.X` prerelease tags

### DIFF
--- a/.github/workflows/build-prod-container.yml
+++ b/.github/workflows/build-prod-container.yml
@@ -94,7 +94,7 @@ jobs:
         id: latest_version
         run: |
           git fetch --tags
-          tags=$(git tag -l 'v*.*.*' | sort -V)
+          tags=$(git tag -l 'v*.*.*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V)
           highest_tag=$(echo "${tags}" | tail -n1)
           echo "Highest version tag is ${highest_tag}"
           if [[ "${GITHUB_REF##*/}" == "${highest_tag}" ]]; then

--- a/.github/workflows/build-prod-container.yml
+++ b/.github/workflows/build-prod-container.yml
@@ -8,7 +8,9 @@ on:
     tags:
       # only run release on v7.0.0 and up
       - v[7-9]\.[0-9]+\.[0-9]+
+      - v[7-9]\.[0-9]+\.[0-9]+-rc\.[0-9]+
       - v[1-9][0-9]+\.[0-9]+\.[0-9]+
+      - v[1-9][0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+
   repository_dispatch:
     types:
       - dispatch-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,11 @@ on:
   push:
     tags:
       # only run release on v7.0.0 and up
+      # Match against v7.0.0, v7.0.0-rc.1, v7.0.0-rc.2, etc.
       - v[7-9]\.[0-9]+\.[0-9]+
+      - v[7-9]\.[0-9]+\.[0-9]+-rc\.[0-9]+
       - v[1-9][0-9]+\.[0-9]+\.[0-9]+
+      - v[1-9][0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+
 
 permissions:
   contents: write

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -109,6 +109,10 @@ nfpms:
   - package_name: pelican
     builds:
       - pelican
+    # Note that git tags like v7.0.0-rc.1 will be modified by goreleaser when building
+    # rpms to be v7.0.0~rc.1-1. The tilde is a special character in RPM versioning that
+    # signifies some version substring should be sorted as less than the rest of the version,
+    # so that v7.0.0~rc.1-1 < v7.0.0-1.
     file_name_template: "{{ .ConventionalFileName }}"
     id: pelican
     vendor: OSG Consortium


### PR DESCRIPTION
Since we now plan to give release candidates tags suffixed with `-rc.X`, where X indicates the release candidate number, we also need to run the release actions for these tags.

The release.yaml action generates artifacts for our github repo and marks things as a pre-release, so we definitely want it to trigger on release candidate tags. The build-prod-container.yaml action creates our containers, and since these are used by integrations to test release candidates, we also need those too. It looks like the triggers for dev container builds will already match against release candidate tags (if I can mentally parse the regex) so we should be fine there.