### PR TITLE
Enable auto-generation of Lotman policies

### DIFF
--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -67,6 +67,16 @@ Cache:
   LowWatermark: 90
   HighWaterMark: 95
   BlocksToPrefetch: 0
+Lotman:
+  EnabledPolicy: "fairshare"
+  DefaultLotExpirationLifetime: "2016h"
+  DefaultLotDeletionLifetime: "4032h"
+  PolicyDefinitions:
+    - PolicyName: "fairshare"
+      DivideUnallocated: true
+      PurgeOrder: ["del", "exp", "opp", "ded"]
+      DiscoverPrefixes: true
+      MergeLocalWithDiscovered: false
 LocalCache:
   HighWaterMarkPercentage: 95
   LowWaterMarkPercentage: 85

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2722,34 +2722,126 @@ type: bool
 default: false
 components: ["cache"]
 ---
-name: Lotman.Lots
+name: Lotman.PolicyDefinitions
 description: |+
-  Declarative configuration for LotMan.  This is a list of objects, each of which describes a "lot". Every lot
-  can be defined with the following:
+  A list of named Lotman purge policy definitions that may be enabled by the cache administrator through setting the `Lotman.EnabledPolicy`
+  configuration. Each policy definition is an object with the following fields:
+  - `PolicyName`: The name of the policy. This is used to identify the policy in the `Lotman.EnabledPolicy` configuration.
+  - `PurgeOrder`: An ordered list of strings indicating the order in which lots should be purged. The strings should be one of the following:
+    - `del`: Purge lots that have passed their deletion time.
+    - `exp`: Purge lots that have passed their expiration time.
+    - `opp`: Purge lots that have passed their opportunistic storage quota.
+    - `ded`: Purge lots that have passed their dedicated storage quota.
+  - `DiscoverPrefixes`: A boolean indicating whether Lotman should automatically discover prefixes from the Director. If true, Lotman will
+    attempt to create lots for all discovered federation prefixes. Locally-defined lots will take precedence over discovered lots if the two have
+    the same name.
+  - `MergeLocalWithDiscovered`: A boolean indicating whether Lotman should merge locally-defined lot configurations with discovered namespaces.
+    Most Lot configuration fields will take precedence from local configuration, but the `Paths` and `Parents` fields are additive.
+  - `DivideUnallocated`: A boolean indicating whether Lotman should attempt to make intelligent decisions regarding management policy attributes
+    for lots that have not provided explicit values. These decisions are based on the cache's total storage capacity and the number of lots
+    that have been explicitly configured, and are intended to maximize potential cache utilization. This should be set to "true" in most cases.
+  - `Lots`: A list of lot objects, each of which describes a "lot". Every lot can be defined with the following:
+    - `LotName`: REQUIRED. The name of the lot.  This is used to identify the lot in the LotMan database.
+    - `Owner`: REQUIRED. A string identifying the owner of the lot's data (as opposed to someone who can modify the lot itself).
+      The Owner field should generally be set to the issue for the lot's namespace path. For example, if the lot
+      tracks namespace `/foo/bar`, the owner might be set to `https://registry.com/api/v1.0/registry/foo/bar`.
+    - `Paths`: OPTIONAL. A list of path objects, each of which describes a path that should be managed by the lot.
+        - `Path`: REQUIRED. The path to be managed by the lot.
+        - `Recursive`: REQUIRED. A boolean indicating whether the path should be managed recursively. If true, the lot will
+          manage all files and directories under the specified path.
+    - `ManagementPolicyAttrs`: REQUIRED. The lot's management policy attributes object. This contains information about resources the lot should
+      be allocated, and how it should be managed.
+        - `DedicatedGB`: REQUIRED. The amount of storage, in GB, that should be dedicated to the lot. This means the lot can assume it
+          always has access to this quantity.
+        - `OpportunisticGB`: REQUIRED. The amount of opportunistic storage, in GB, the lot should have access to, when storage is available.
+        - `MaxNumObjects`: REQUIRED. The maximum number of objects a lot is allowed to store.
+        - `CreationTime`: REQUIRED. A unix timestamp indicating when the lot should begin being considered valid. Times in the future indicate
+          the lot should not be considered valid until that time.
+        - `ExpirationTime`: REQUIRED. A unix timestamp indicating when the lot expires. Lots may continue to function after expiration, but lot
+          data owners should recognize the storage is at-will and may be pre-empted at any time.
+        - `DeletionTime`: REQUIRED. A unix timestamp indicating when the lot and its associated data should be deleted.
 
-  - `LotName`: REQUIRED. The name of the lot.  This is used to identify the lot in the LotMan database.
-  - `Owner`: REQUIRED. A string identifying the owner of the lot's data (as opposed to someone who can modify the lot itself).
-    The Owner field should generally be set to the issue for the lot's namespace path. For example, if the lot
-    tracks namespace `/foo/bar`, the owner might be set to `https://registry.com/api/v1.0/registry/foo/bar`.
-  - `Paths`: OPTIONAL. A list of path objects, each of which describes a path that should be managed by the lot.
-      - `Path`: REQUIRED. The path to be managed by the lot.
-      - `Recursive`: REQUIRED. A boolean indicating whether the path should be managed recursively. If true, the lot will
-        manage all files and directories under the specified path.
-  - `ManagementPolicyAttrs`: REQUIRED. The lot's management policy attributes object. This contains information about resources the lot should
-    be allocated, and how it should be managed.
-      - `DedicatedGB`: REQUIRED. The amount of storage, in GB, that should be dedicated to the lot. This means the lot can assume it
-        always has access to this quantity.
-      - `OpportunisticGB`: REQUIRED. The amount of opportunistic storage, in GB, the lot should have access to, when storage is available.
-      - `MaxNumObjects`: REQUIRED. The maximum number of objects a lot is allowed to store.
-      - `CreationTime`: REQUIRED. A unix timestamp indicating when the lot should begin being considered valid. Times in the future indicate
-        the lot should not be considered valid until that time.
-      - `ExpirationTime`: REQUIRED. A unix timestamp indicating when the lot expires. Lots may continue to function after expiration, but lot
-        data owners should recognize the storage is at-will and may be pre-empted at any time.
-      - `DeletionTime`: REQUIRED. A unix timestamp indicating when the lot and its associated data should be deleted.
+  For example, Lotman could be configured with the "my-policy" policy with the following:
+  ```yaml
+  Lotman:
+    EnabledPolicy: "my-policy"
+    PolicyDefinitions:
+    - PolicyName: "my-policy"
+      DivideUnallocated: true
+      PurgeOrder: ["del", "exp", "opp", "ded"]
+      DiscoverPrefixes: true
+      MergeLocalWithDiscovered: true
+      Lots:
+      - LotName: "/foo/bar"
+        Owner: "https://registry.com/api/v1.0/registry/foo/bar"
+        Paths:
+          Path: "/foo/bar"
+          Recursive: true
+        ManagementPolicyAttrs:
+          DedicatedGB: 100
+          OpportunisticGB: 100
+          MaxNumObjects: 1000
+          CreationTime: 1614556800
+          ExpirationTime: 1614556800
+          DeletionTime: 1614556800
+      - LotName ... <additional lots>
+  ```
 
-  Note that example configurations can be found in lotman/resources/lots-config.yaml
+  Additional example configurations can be found in lotman/resources/lots-config.yaml
   For more information about LotMan configuration, see:
   [https://github.com/pelicanplatform/lotman](https://github.com/pelicanplatform/lotman)
 type: object
 default: none
+components: ["cache"]
+---
+name: Lotman.EnabledPolicy
+description: |+
+  The name of the policy to use with Lotman's purge logic. Policy names are defined in the Lotman.PolicyDefinitions list object.
+  If unset, the "fairshare" policy is used, which evenly divides the cache's space amongst all top-level namespaces discoverable
+  through the Director and purges data according in order of lots past deletion, lots past expiration, lots past opportunistic
+  storage, and lots past dedicated storage. The "fairshare" policy is defined as follows:
+  ```yaml
+  Lotman:
+    EnabledPolicy: "fairshare"
+    DefaultLotExpirationLifetime: "2016h"
+    DefaultLotDeletionLifetime: "4032h"
+    PolicyDefinitions:
+    - PolicyName: "fairshare"
+      DivideUnallocated: true
+      PurgeOrder: ["del", "exp", "opp", "ded"]
+      DiscoverPrefixes: true
+      MergeLocalWithDiscovered: false
+  ```
+type: string
+default: "fairshare"
+components: ["cache"]
+---
+name: Lotman.DefaultLotExpirationLifetime
+description: |+
+  The default expiration lifetime for lots that have not provided an explicit expiration time. Valid time units are:
+    - ns for nanoseconds
+    - us (or µs) for microseconds
+    - ms for milliseconds
+    - s for seconds
+    - m for minutes
+    - h for hours
+
+  This value is fed to Lotman as a unix timestamp in microseconds, adjusted from the current time.
+type: duration
+default: 2016h
+components: ["cache"]
+---
+name: Lotman.DefaultLotDeletionLifetime
+description: |+
+  The default deletion lifetime for lots that have not provided an explicit deletion time. Valid time units are:
+    - ns for nanoseconds
+    - us (or µs) for microseconds
+    - ms for milliseconds
+    - s for seconds
+    - m for minutes
+    - h for hours
+
+  This value is fed to Lotman as a unix timestamp in microseconds, adjusted from the current time.
+type: duration
+default: 4032h
 components: ["cache"]

--- a/lotman/lotman.go
+++ b/lotman/lotman.go
@@ -29,13 +29,15 @@ import (
 
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/pelicanplatform/pelican/server_structs"
 )
 
 func RegisterLotman(ctx context.Context, router *gin.RouterGroup) {
 	log.Warningln("LotMan is not supported on this platform. Skipping...")
 }
 
-func InitLotman() bool {
+func InitLotman(adsFromFed []server_structs.NamespaceAdV2) bool {
 	log.Warningln("LotMan is not supported on this platform. Skipping...")
 	return false
 }

--- a/lotman/lotman_linux.go
+++ b/lotman/lotman_linux.go
@@ -29,15 +29,21 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
+	"strings"
 	"sync"
+	"syscall"
+	"time"
 	"unsafe"
 
 	"github.com/ebitengine/purego"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
 )
 
 var (
@@ -74,10 +80,10 @@ type (
 		Value int64
 	}
 
-	LotPaths struct {
+	LotPath struct {
 		Path      string `json:"path" mapstructure:"Path"`
 		Recursive bool   `json:"recursive" mapstructure:"Recursive"`
-		LotName   string `json:"lot_name,omitempty"`
+		LotName   string `json:"lot_name,omitempty"` // Not used when creating lots, but some queries will populate
 	}
 
 	LotValueMapInt struct {
@@ -137,7 +143,7 @@ type (
 		Parents []string `json:"parents" mapstructure:"Parents"`
 		// While we _could_ expose Children, that complicates things so for now we keep it hidden from the config
 		Children *[]string  `json:"children,omitempty"`
-		Paths    []LotPaths `json:"paths,omitempty" mapstructure:"Paths"`
+		Paths    []LotPath `json:"paths,omitempty" mapstructure:"Paths"`
 		MPA      *MPA       `json:"management_policy_attrs,omitempty" mapstructure:"ManagementPolicyAttrs"`
 		// Again, these are derived
 		RestrictiveMPA *RestrictiveMPA `json:"restrictive_management_policy_attrs,omitempty"`
@@ -162,6 +168,19 @@ type (
 		Paths   *[]PathUpdate   `json:"paths,omitempty"`
 		MPA     *MPA            `json:"management_policy_attrs,omitempty"`
 	}
+
+	PurgePolicy struct {
+		PurgeOrder               []string `json:"purge_order"`
+		PolicyName               string   `json:"policy_name"`
+		DiscoverPrefixes         bool     `json:"discover_prefixes"`
+		MergeLocalWithDiscovered bool     `json:"merge_local_with_discovered"`
+		DivideUnallocated        bool	  `json:"divide_unallocated"`
+		Lots                     []Lot    `json:"lots"`
+	}
+)
+
+const (
+	bytesInGigabyte = 1000 * 1000 * 1000
 )
 
 // Lotman has a tendency to return an int as 123.0 instead of 123. This struct is used to unmarshal
@@ -314,9 +333,580 @@ func getFederationIssuer() (string, error) {
 	return federationIssuer, nil
 }
 
+// Given MPA1 and MPA2, merge them into a single MPA. If a field is set in MPA1,
+// it will take precedence.
+func mergeMPAs(mpa1, mpa2 *MPA) *MPA {
+	// Handle nil cases
+    if mpa1 == nil && mpa2 == nil {
+        return nil
+    }
+    if mpa1 == nil {
+        return mpa2
+    }
+    if mpa2 == nil {
+        return mpa1
+    }
+
+	// Merge individual fields
+    mergedMPA := *mpa1
+    if mpa1.DedicatedGB == nil {
+        mergedMPA.DedicatedGB = mpa2.DedicatedGB
+    }
+    if mpa1.OpportunisticGB == nil {
+        mergedMPA.OpportunisticGB = mpa2.OpportunisticGB
+    }
+    if mpa1.MaxNumObjects == nil {
+        mergedMPA.MaxNumObjects = mpa2.MaxNumObjects
+    }
+    if mpa1.CreationTime == nil {
+        mergedMPA.CreationTime = mpa2.CreationTime
+    }
+    if mpa1.ExpirationTime == nil {
+        mergedMPA.ExpirationTime = mpa2.ExpirationTime
+    }
+    if mpa1.DeletionTime == nil {
+        mergedMPA.DeletionTime = mpa2.DeletionTime
+    }
+
+    return &mergedMPA
+}
+
+// Given lot1 and lot2, merge them into a single lot. If a field is set in lot1,
+// it will take precedence. Lots cannot be merged if they have separate names
+func mergeLots(lot1, lot2 Lot) (Lot, error) {
+	if lot1.LotName != lot2.LotName {
+		return Lot{}, errors.Errorf("cannot merge lots %s and %s because they have different names", lot1.LotName, lot2.LotName)
+	}
+	mergedLot := lot1
+
+	// Prefer lot1's owner
+    if lot1.Owner == "" {
+        mergedLot.Owner = lot2.Owner
+    }
+
+	// Calculate union between the parents -- if this gets us in trouble by introducing cycles,
+	// lotman will tell us on startup (hopefully...).
+	parentSet := make(map[string]bool)
+    for _, parent := range lot1.Parents {
+        parentSet[parent] = true
+    }
+    for _, parent := range lot2.Parents {
+        if !parentSet[parent] {
+            mergedLot.Parents = append(mergedLot.Parents, parent)
+            parentSet[parent] = true
+        }
+    }
+
+	// Merge the MPAs
+	mergedLot.MPA = mergeMPAs(lot1.MPA, lot2.MPA)
+
+    return mergedLot, nil
+}
+
+// Calculate the union of two lot maps. If a lot is present in both maps, merge them.
+func mergeLotMaps(map1, map2 map[string]Lot) (map[string]Lot, error) {
+    result := make(map[string]Lot)
+
+    // Add all entries from map1 to result
+    for key, value := range map1 {
+        result[key] = value
+    }
+
+    // Merge entries from map2 into result
+    for key, value := range map2 {
+        if existingValue, exists := result[key]; exists {
+			mergedLot, err := mergeLots(existingValue, value)
+			if err != nil {
+				return result, err
+			}
+            result[key] = mergedLot
+        } else {
+            result[key] = value
+        }
+    }
+
+    return result, nil
+}
+
+// Grab a map of policy definitions from the config file, where the policy
+// name is the key and its attributes comprise the value.
+func getPolicyMap() (map[string]PurgePolicy, error) {
+	policyMap := make(map[string]PurgePolicy)
+	var policies []PurgePolicy
+	err := viper.UnmarshalKey("Lotman.PolicyDefinitions", &policies)
+	if err != nil {
+		return policyMap, errors.Wrap(err, "error unmarshaling Lotman policy definitions")
+	}
+
+	for _, policy := range policies {
+		policyMap[policy.PolicyName] = policy
+	}
+
+	return policyMap, nil
+}
+
+// Given a filesystem path, try to get the amount of total and free disk space.
+func getDiskUsage(path string) (total uint64, free uint64, err error) {
+    var stat syscall.Statfs_t
+
+    err = syscall.Statfs(path, &stat)
+    if err != nil {
+        return 0, 0, err
+    }
+
+    // Total space is the block size multiplied by the total number of blocks
+    total = stat.Blocks * uint64(stat.Bsize)
+
+    // Free space is the block size multiplied by the number of free blocks
+    free = stat.Bfree * uint64(stat.Bsize)
+
+    return total, free, nil
+}
+
+func bytesToGigabytes(bytes uint64) float64 {
+    return float64(bytes) / bytesInGigabyte
+}
+
+func gigabytesToBytes(gb float64) uint64 {
+	return uint64(gb * bytesInGigabyte)
+}
+
+// Given the list of lots and the total disk space available to the cache, validate that
+// each lot has all necessary creation fields and that their values are within reasonable bounds.
+// In particular, we want to make sure that the sum of all lots' dedicatedGB values does not exceed
+// the high watermark of the cache, as this would allow the cache to purge data from namespaces
+// that are using less than their dedicated quota.
+func validateLotsConfig(lots []Lot, totalDiskSpaceB uint64) error {
+	hwmStr := param.Cache_HighWaterMark.GetString()
+	hwm, err := convertWatermarkToBytes(hwmStr, totalDiskSpaceB)
+	if err != nil {
+		return errors.Wrap(err, "error converting high watermark to byte value for Lotman")
+	}
+
+	totalDedicatedGB := 0.0
+	for _, lot := range lots {
+		// Skip the root lot, which is a container we use to make sure all lots have a federation-owned parent.
+		// We don't use the root lot for any other purpose.
+		if lot.LotName == "root" {
+			continue
+		}
+		// Instead of returning on the first missing field, try to get everything for the entire lot.
+		// We could also do this for _all_ lots before returning, but that may be an overwhelming error
+		// message. This way, the user can focus on one lot at a time.
+		missingValues := make([]string, 0)
+		if lot.LotName == "" {
+			return errors.New(fmt.Sprintf("detected a lot with no name: %+v", lot))
+		}
+		errMsg := fmt.Sprintf("the lot '%s' is missing required values:", lot.LotName)
+
+		if lot.Owner == "" {
+			missingValues = append(missingValues, "Owner")
+		}
+		if len(lot.Parents) == 0 {
+			missingValues = append(missingValues, "Parents")
+		} else {
+			for _, parent := range lot.Parents {
+				if parent == "" {
+					missingValues = append(missingValues, "Parents")
+				}
+			}
+		}
+		if len(lot.Paths) == 0 {
+			// Default lot doesn't need paths, but everybody else does
+			if lot.LotName != "default" {
+				missingValues = append(missingValues, "Paths")
+			}
+		} else {
+			for _, path := range lot.Paths {
+				if path.Path == "" {
+					missingValues = append(missingValues, "Paths.Path")
+				}
+			}
+		}
+
+		if lot.MPA == nil {
+			missingValues = append(missingValues, "ManagementPolicyAttrs")
+		} else {
+			if lot.MPA.DedicatedGB == nil {
+				missingValues = append(missingValues, "ManagementPolicyAttrs.DedicatedGB")
+			} else {
+				totalDedicatedGB += *lot.MPA.DedicatedGB
+			}
+			if lot.MPA.OpportunisticGB == nil {
+				missingValues = append(missingValues, "ManagementPolicyAttrs.OpportunisticGB")
+			}
+			// No checking for MaxNumObjects -- the purge plugin doesn't use it yet
+			if lot.MPA.CreationTime == nil || lot.MPA.CreationTime.Value == 0 {
+				missingValues = append(missingValues, "ManagementPolicyAttrs.CreationTime")
+			}
+			if lot.MPA.ExpirationTime == nil || lot.MPA.ExpirationTime.Value == 0 {
+				missingValues = append(missingValues, "ManagementPolicyAttrs.ExpirationTime")
+			}
+			if lot.MPA.DeletionTime == nil || lot.MPA.DeletionTime.Value == 0 {
+				missingValues = append(missingValues, "ManagementPolicyAttrs.DeletionTime")
+			}
+		}
+
+		if len(missingValues) > 0 {
+			return errors.New(fmt.Sprintf("%s %v", errMsg, missingValues))
+		}
+
+		// We don't apply validation to the opportunistic GB, as it's not a hard limit and the user
+		// may wish to do something unexpected. However, the sum of dedicated GB should not exceed the HWM
+		// or the cache may expose some data to purging when it should be protected.
+		if totalDedicatedGB > bytesToGigabytes(hwm) {
+			return errors.New(fmt.Sprintf("the sum of all lots' dedicatedGB values exceeds the high watermark of %s. This would allow the cache to purge namespaces using less than their dedicated quota", hwmStr))
+		}
+	}
+
+	return nil
+}
+
+// HWM and LWM values may be a percentage (e.g. 95) indicating the amount of available disk
+// to treat as the watermark, or they may be a suffixed byte value (e.g. 100G). We need this
+// information in bytes to calculate the amount of space to allocate to each lot.
+func convertWatermarkToBytes(value string, totalDiskSpace uint64) (uint64, error) {
+    suffixMultipliers := map[string]uint64{
+        "k": 1000,
+        "m": 1000 * 1000,
+        "g": 1000 * 1000 * 1000,
+        "t": 1000 * 1000 * 1000 * 1000,
+    }
+
+    // Check if the value has a suffix
+    if len(value) > 1 {
+        suffix := strings.ToLower(string(value[len(value)-1]))
+        if multiplier, exists := suffixMultipliers[suffix]; exists {
+            number, err := strconv.ParseUint(value[:len(value)-1], 10, 64)
+            if err != nil {
+                return 0, err
+            }
+            return number * multiplier, nil
+        }
+    }
+
+    // If no suffix, treat as percentage
+    percentage, err := strconv.ParseFloat(strings.TrimSuffix(value, "%"), 64)
+    if err != nil {
+        return 0, err
+    }
+    return uint64((percentage / 100) * float64(totalDiskSpace)), nil
+}
+
+
+// Divide the remaining space among lots' dedicatedGB values -- we don't ever want to
+// dedicate more space than we have available, as indicated by the HWM of the cache. This is because
+// our model is that as long as a lot stays under its dedicated GB, its data is safe in the cache --
+// If the sum of each lot's dedicated GB exceeds the HWM, the cache may purge data without a single lot
+// exceeding it's quota. BAD!
+//
+// Opportunistic space can (and should) be overallocated, so unless explicitly set, each lot will have
+// dedicatedGB + opportunisticGB = HWM. This isn't maxed out to the total disk space, because otherwise
+// no lot could ever exceed its opportunistic storage and we'd lose some of the capabilities to reason about
+// how greedy the lot is.
+func divideRemainingSpace(lotMap *map[string]Lot, totalDiskSpaceB uint64) error {
+	hwmStr := param.Cache_HighWaterMark.GetString()
+	if hwmStr == "" {
+		return errors.New("high watermark is not set in the cache configuration")
+	}
+	hwm, err := convertWatermarkToBytes(hwmStr, totalDiskSpaceB)
+	if err != nil {
+		return errors.Wrap(err, "error converting high watermark to byte value for Lotman")
+	}
+	remainingToHwmB := hwm
+
+    // first iterate through all lots and subtract from our total space any amount
+    // that's already been allocated. Note which lots have an unset value, as we'll
+    // need to return to them.
+    returnToKeys := make([]string, 0, len(*lotMap))
+	for key, lot := range *lotMap {
+		if lot.LotName == "root" {
+			continue
+		}
+		if lot.MPA != nil && lot.MPA.DedicatedGB != nil  {
+			remainingToHwmB -= gigabytesToBytes(*lot.MPA.DedicatedGB)
+			if lot.MPA.OpportunisticGB == nil {
+				oGb := bytesToGigabytes(hwm) - *lot.MPA.DedicatedGB
+				lot.MPA.OpportunisticGB = &oGb
+			}
+		} else {
+			returnToKeys = append(returnToKeys, lot.LotName)
+		}
+		(*lotMap)[key] = lot
+	}
+
+	if len(returnToKeys) > 0 {
+		// now iterate through the lots that need space allocated and assign them the
+		// remaining space
+		spacePerLotRemainingB := remainingToHwmB / uint64(len(returnToKeys))
+		for _, key := range returnToKeys {
+			lot := (*lotMap)[key]
+			if lot.MPA == nil {
+				lot.MPA = &MPA{}
+			}
+			dGb := bytesToGigabytes(spacePerLotRemainingB)
+			oGb := bytesToGigabytes(hwm - spacePerLotRemainingB)
+			lot.MPA.DedicatedGB = &dGb
+			if lot.MPA.OpportunisticGB == nil {
+				lot.MPA.OpportunisticGB = &oGb
+			}
+			lot.MPA.MaxNumObjects = &Int64FromFloat{Value: 0} // Purge plugin doesn't yet use this, set to 0.
+			(*lotMap)[key] = lot
+		}
+	}
+
+	return nil
+}
+
+// Lots have unix millisecond timestamps for creation, expiration, and deletion. If these are not set in the
+//config, we'll set them to the current time. Expiration and deletion times are set to the default lifetime
+func configLotTimestamps(lotMap *map[string]Lot) {
+	now := time.Now().UnixMilli()
+	defaultExpiration := now + param.Lotman_DefaultLotExpirationLifetime.GetDuration().Milliseconds()
+	defaultDeletion := now + param.Lotman_DefaultLotDeletionLifetime.GetDuration().Milliseconds()
+
+	for name, lot := range *lotMap {
+		if lot.MPA == nil {
+			lot.MPA = &MPA{}
+		}
+		if lot.MPA.CreationTime == nil || lot.MPA.CreationTime.Value == 0 {
+			lot.MPA.CreationTime = &Int64FromFloat{Value: now}
+		}
+		if lot.MPA.ExpirationTime == nil || lot.MPA.ExpirationTime.Value == 0 {
+			lot.MPA.ExpirationTime = &Int64FromFloat{Value: defaultExpiration}
+		}
+
+		if lot.MPA.DeletionTime == nil || lot.MPA.DeletionTime.Value == 0 {
+			lot.MPA.DeletionTime = &Int64FromFloat{Value: defaultDeletion}
+		}
+
+		(*lotMap)[name] = lot
+	}
+}
+
+// By default, Lotman should discover namespaces from the Director and try to create the relevant top-level
+// lots for those namespaces. This function creates those lots, but they may be merged with local config
+// at a later time.
+func configLotsFromFedPrefixes(nsAds []server_structs.NamespaceAdV2) (map[string]Lot, error) {
+	directorLotMap := make(map[string]Lot)
+	federationIssuer, err := getFederationIssuer()
+	if err != nil {
+		return directorLotMap, errors.Wrap(err, "Unable to determine federation issuer which is needed by Lotman to determine lot ownership")
+	}
+	if federationIssuer == "" {
+		return directorLotMap, errors.New("The detected federation issuer, which is needed by Lotman to determine lot/namespace ownership, is empty")
+	}
+	for _, nsAd := range nsAds {
+		// Skip monitoring namespaces
+		if strings.HasPrefix(nsAd.Path, "/pelican/monitoring") {
+			continue
+		}
+		var issuer string
+		if len(nsAd.Issuer) > 0 {
+			issuer = (nsAd.Issuer[0]).IssuerUrl.String()
+		} else {
+			issuer = federationIssuer
+		}
+
+		directorLotMap[nsAd.Path] = Lot{
+			LotName: nsAd.Path,
+			Owner:   issuer, // grab the first issuer -- lotman doesn't currently support multiple direct owners
+			// Assign parent as the root lot at the cache. This lets root edit the lot, but still allows the owner of the namespace to further subdivide
+			Parents: []string{"root"},
+			Paths: []LotPath{
+				{
+					Path: 	nsAd.Path,
+					Recursive: true,
+				},
+			},
+		}
+	}
+
+	return directorLotMap, nil
+}
+
+// One limitation in Lotman is that a lot cannot be created unless all of its parents exist. Unfortunately,
+// this means we have to sort our lots topologically to ensure that we create them in the correct order.
+// Failure to do so appears to result in a segfault in Lotman.
+func topoSort(lotMap map[string]Lot) ([]Lot, error) {
+    sorted := make([]Lot, 0, len(lotMap))
+    visited := make(map[string]bool)
+
+	// Recursively visit each lot and its parents, DFS-style
+	var visit func(string) error
+    visit = func(name string) error {
+        if visited[name] {
+            return nil
+        }
+        visited[name] = true
+
+        // Visit all parents first
+        for _, parent := range lotMap[name].Parents {
+            if err := visit(parent); err != nil {
+                return err
+            }
+        }
+		// Adding the leaves of the DFS parent tree to the sorted list
+		// guarantees that we'll add the parents before the children
+        sorted = append(sorted, lotMap[name])
+        return nil
+    }
+
+    for name := range lotMap {
+        if err := visit(name); err != nil {
+            return nil, err
+        }
+    }
+
+    return sorted, nil
+}
+
+
+// Initialize the lot configurations based on provided policy, discovered namespaces,
+// and available cache space, handling any necessary merges and validations along the way.
+func initLots(nsAds []server_structs.NamespaceAdV2) ([]Lot, error) {
+	var internalLots []Lot
+
+	policies, err := getPolicyMap()
+	if err != nil {
+		return internalLots, errors.Wrap(err, "unable to parse lotman configuration")
+	}
+
+	// Get the configured policy, which defines any lots we may need to handle
+	// along with merging logic and purge ordering
+	policyName := param.Lotman_EnabledPolicy.GetString()
+	if _, exists := policies[policyName]; !exists {
+		return internalLots, errors.Errorf("enabled policy %s is not defined in the configuration", policyName)
+	}
+	policy := policies[policyName]
+
+	discoverPrefixes := policy.DiscoverPrefixes
+	shouldMerge := policy.MergeLocalWithDiscovered
+	if shouldMerge && !discoverPrefixes {
+		return internalLots, errors.New("MergeLocalWithDiscovered is set to true, but DiscoverPrefixes is set to false. This is not a valid configuration")
+	}
+
+	// policyLotMap will hold the lots defined in the configuration file (if any) provided by the cache admin
+	policyLotMap := make(map[string]Lot)
+	for _, lot := range policy.Lots {
+		policyLotMap[lot.LotName] = lot
+	}
+
+	var lotMap map[string]Lot
+	if discoverPrefixes {
+		directorLotMap, err := configLotsFromFedPrefixes(nsAds)
+		if err != nil {
+			return internalLots, errors.Wrap(err, "error configuring lots from federation prefixes")
+		}
+
+		// Handle potential need to merge discovered namespaces with provided configuration
+		if shouldMerge {
+			log.Debug("Merging lot configuration from discovered namespaces with configured lots")
+			lotMap, err = mergeLotMaps(directorLotMap, policyLotMap)
+			if err != nil {
+				return internalLots, errors.Wrap(err, "error merging discovered namespaces with configured lots")
+			}
+			log.Tracef("Merged lot configuration: %+v", lotMap)
+		} else {
+			lotMap = make(map[string]Lot)
+			// first set things up with the director lots, then overwrite with the policy lots.
+			// This allows cache admins to override any discovered lots with their own configuration.
+			for key, value := range directorLotMap {
+				lotMap[key] = value
+			}
+			for key, value := range policyLotMap {
+				lotMap[key] = value
+			}
+		}
+	} else {
+		lotMap = policyLotMap
+	}
+
+	cacheDisks := param.Cache_DataLocations.GetStringSlice()
+	log.Tracef("Cache data locations being tracked by Lotman: %v", cacheDisks)
+	var totalDiskSpaceB uint64
+	for _, disk := range cacheDisks {
+		diskSpace, _, err := getDiskUsage(disk)
+		if err != nil {
+			return internalLots, errors.Wrapf(err, "error getting disk usage for filesystem path %s", disk)
+		}
+		totalDiskSpaceB += diskSpace
+	}
+
+	// Now guarantee our special "default" and "root" lots if the user hasn't provided them
+	// in the config. For now, these lots must always exist because they're used to make sure
+	// all data is tied to a lot (default) and that the requirement of a root lot is satisfied
+	// without allowing discovered lots to gain rootly status.
+	federationIssuer, err := getFederationIssuer()
+	if err != nil {
+		return internalLots, errors.Wrap(err, "Unable to determine federation issuer which is needed by Lotman to determine lot ownership")
+	}
+	if federationIssuer == "" {
+		return internalLots, errors.New("The detected federation issuer, which is needed by Lotman to determine lot/namespace ownership, is empty")
+	}
+	rootDedGB := bytesToGigabytes(totalDiskSpaceB)
+	zero := float64(0)
+	if _, exists := lotMap["default"]; !exists {
+		lotMap["default"] = Lot{
+			LotName: "default",
+			Owner:   federationIssuer,
+			Parents: []string{"default"},
+			MPA: &MPA{
+				// Set default values to 0 and let potential reallocation happen later.
+				DedicatedGB:     &zero,
+				OpportunisticGB: &zero,
+				MaxNumObjects:   &Int64FromFloat{Value: 0}, // Purge plugin doesn't yet use this, set to 0.
+			},
+
+		}
+	}
+	if _, exists := lotMap["root"]; !exists {
+		lotMap["root"] = Lot{
+			LotName: "root",
+			Owner:   federationIssuer,
+			Parents: []string{"root"},
+
+			Paths: []LotPath{
+				{
+					Path: 	"/",
+					Recursive: false, // setting this to true would prevent any other lot from claiming a path
+				},
+			},
+			MPA: &MPA{
+				// Max out dedicatedGB so the root lot never purges. All other lots should be tied to their own policies.
+				DedicatedGB: &rootDedGB,
+				OpportunisticGB: &zero,
+				MaxNumObjects:   &Int64FromFloat{Value: 0}, // Purge plugin doesn't yet use this, set to 0.
+			},
+		}
+	}
+
+	log.Tracef("Lotman will split lot disk space quotas amongst the discovered disk space: %vB", totalDiskSpaceB)
+	if policy.DivideUnallocated {
+		log.Traceln("Dividing unallocated space among lots")
+		divideRemainingSpace(&lotMap, totalDiskSpaceB)
+	}
+
+	// Set up lot timestamps (creation, expiration, deletion) if needed
+	configLotTimestamps(&lotMap)
+
+	internalLots, err = topoSort(lotMap)
+	if err != nil {
+		return internalLots, errors.Wrap(err, "error sorting lots prior to instantiation")
+	}
+
+	log.Tracef("Internal lot configuration: %+v", internalLots)
+	err = validateLotsConfig(internalLots, totalDiskSpaceB)
+	if err != nil {
+		return internalLots, errors.Wrap(err, "error validating deduced lot configuration")
+	}
+
+	return internalLots, nil
+}
+
 // Initialize the LotMan library and bind its functions to the global vars
 // We also perform a bit of extra setup such as setting the lotman db location
-func InitLotman() bool {
+func InitLotman(adsFromFed []server_structs.NamespaceAdV2) bool {
 	log.Infof("Initializing LotMan...")
 
 	// dlopen the LotMan library
@@ -358,12 +948,10 @@ func InitLotman() bool {
 		return false
 	}
 
-	defaultInitialized := false
-	rootInitialized := false
-
-	err = param.Lotman_Lots.Unmarshal(&initializedLots)
+	initializedLots, err = initLots(adsFromFed)
 	if err != nil {
-		log.Warningf("Error while unmarshaling Lots from config: %v", err)
+		log.Errorf("Error creating lot config: %v", err)
+		return false
 	}
 
 	federationIssuer, err := getFederationIssuer()
@@ -387,14 +975,13 @@ func InitLotman() bool {
 
 	// Create the basic lots if they don't already exist. We'll make one for default
 	// and one for the root namespace
+	defaultInitialized := false
 	ret = LotmanLotExists("default", &errMsg)
 	if ret < 0 {
 		trimBuf(&errMsg)
 		log.Errorf("Error checking if default lot exists: %s", string(errMsg))
 		return false
 	} else if ret == 0 {
-		// First we try to create the lots that might be configured via Pelican.yaml. If there are none, we'll use
-		// a few default values
 		for _, lot := range initializedLots {
 			if lot.LotName == "default" {
 				log.Debugf("Creating the default lot defined by %v", lot)
@@ -414,56 +1001,18 @@ func InitLotman() bool {
 			}
 		}
 
-		if !defaultInitialized {
-			// Create the default lot
-			if federationIssuer == "" {
-				log.Errorf("your federation's issuer could not be deduced from your config's federation discovery URL or director URL")
-				return false
-			}
-
-			initDedicatedGB := float64(0)
-			initOpportunisticGB := float64(0)
-			defaultLot := Lot{
-				LotName: "default",
-				// Set the owner to the Federation's discovery url -- under this model, we can treat it like an issuer
-				Owner: federationIssuer,
-				// A self-parent lot indicates superuser status
-				Parents: []string{"default"},
-				MPA: &MPA{
-					DedicatedGB:     &initDedicatedGB,
-					OpportunisticGB: &initOpportunisticGB,
-					MaxNumObjects:   &Int64FromFloat{Value: 0},
-					CreationTime:    &Int64FromFloat{Value: 0},
-					ExpirationTime:  &Int64FromFloat{Value: 0},
-					DeletionTime:    &Int64FromFloat{Value: 0},
-				},
-			}
-
-			log.Debugf("Creating the default lot defined by %v", defaultLot)
-			lotJSON, err := json.Marshal(defaultLot)
-			if err != nil {
-				log.Errorf("Error marshalling default lot JSON: %v", err)
-				return false
-			}
-
-			ret = LotmanAddLot(string(lotJSON), &errMsg)
-			if ret != 0 {
-				trimBuf(&errMsg)
-				log.Errorf("Error creating default lot: %s", string(errMsg))
-				return false
-			}
-		}
-
 		log.Infof("Created default lot")
+	} else if ret == 1 {
+		log.Infoln("Default lot already exists, skipping creation")
 	}
 
+	rootInitialized := false
 	ret = LotmanLotExists("root", &errMsg)
 	if ret < 0 {
 		trimBuf(&errMsg)
 		log.Errorf("Error checking if root lot exists: %s", string(errMsg))
 		return false
 	} else if ret == 0 {
-		// Try to create the root lot based on what we have in the config
 		for _, lot := range initializedLots {
 			if lot.LotName == "root" {
 				lotJSON, err := json.Marshal(lot)
@@ -482,67 +1031,45 @@ func InitLotman() bool {
 			}
 		}
 
-		if !rootInitialized {
-			// Create the root lot based on predefined setup
-			if federationIssuer == "" {
-				log.Errorf("your federation's issuer could not be deduced from your config's federation discovery URL or director URL")
-				return false
-			}
-
-			initDedicatedGB := float64(0)
-			initOpportunisticGB := float64(0)
-			rootLot := Lot{
-				LotName: "root",
-				Owner:   federationIssuer,
-				// A self-parent lot indicates superuser status
-				Parents: []string{"root"},
-				Paths: []LotPaths{
-					{
-						Path:      "/",
-						Recursive: false,
-					},
-				},
-				MPA: &MPA{
-					DedicatedGB:     &initDedicatedGB,
-					OpportunisticGB: &initOpportunisticGB,
-					MaxNumObjects:   &Int64FromFloat{Value: 0},
-					CreationTime:    &Int64FromFloat{Value: 0},
-					ExpirationTime:  &Int64FromFloat{Value: 0},
-					DeletionTime:    &Int64FromFloat{Value: 0},
-				},
-			}
-
-			log.Debugf("Creating the root lot defined by %v", rootLot)
-			lotJSON, err := json.Marshal(rootLot)
-			if err != nil {
-				log.Errorf("Error marshalling root lot JSON: %v", err)
-				return false
-			}
-
-			ret = LotmanAddLot(string(lotJSON), &errMsg)
-			if ret != 0 {
-				trimBuf(&errMsg)
-				log.Errorf("Error creating root lot: %s", string(errMsg))
-				return false
-			}
-		}
 		log.Infof("Created root lot")
+	} else if ret == 1 {
+		log.Infoln("Root lot already exists, skipping creation")
+	}
+
+	if !defaultInitialized || !rootInitialized {
+		log.Errorln("Failed to create default and/or root lots")
+		return false
 	}
 
 	// Now instantiate any other lots that are in the config
 	for _, lot := range initializedLots {
 		if lot.LotName != "default" && lot.LotName != "root" {
-			lotJSON, err := json.Marshal(lot)
-			if err != nil {
-				log.Errorf("Error marshalling lot JSON for %s: %v", lot.LotName, err)
-				return false
-			}
-
-			ret = LotmanAddLot(string(lotJSON), &errMsg)
-			if ret != 0 {
+			// Don't try to re-create lots that may already exist, as doing so could prevent
+			// the cache from restarting.
+			// TODO: Work out how to handle this case -- we may need to update the lot instead of creating it
+			ret = LotmanLotExists(lot.LotName, &errMsg)
+			if ret < 0 {
 				trimBuf(&errMsg)
-				log.Errorf("Error creating lot %s: %s", lot.LotName, string(errMsg))
-				log.Infoln("Full lot JSON passed to Lotman for lot creation:", string(lotJSON))
+				log.Errorf("Error checking if lot '%s'exists: %s", lot.LotName, string(errMsg))
+				return false
+			} else if ret == 0 {
+				lotJSON, err := json.Marshal(lot)
+				if err != nil {
+					log.Errorf("Error marshalling lot JSON for %s: %v", lot.LotName, err)
+					return false
+				}
+
+				ret = LotmanAddLot(string(lotJSON), &errMsg)
+				if ret != 0 {
+					trimBuf(&errMsg)
+					log.Errorf("Error creating lot %s: %s", lot.LotName, string(errMsg))
+					log.Infoln("Full lot JSON passed to Lotman for lot creation:", string(lotJSON))
+					return false
+				}
+			} else if ret == 1 {
+				log.Infof("Lot '%s' already exists, skipping creation", lot.LotName)
+			} else {
+				log.Errorf("Unexpected return value from Lotman for lot '%s' existence check: %d", lot.LotName, ret)
 				return false
 			}
 		}

--- a/lotman/lotman_linux.go
+++ b/lotman/lotman_linux.go
@@ -624,7 +624,13 @@ func divideRemainingSpace(lotMap *map[string]Lot, totalDiskSpaceB uint64) error 
 			continue
 		}
 		if lot.MPA != nil && lot.MPA.DedicatedGB != nil  {
-			remainingToHwmB -= gigabytesToBytes(*lot.MPA.DedicatedGB)
+			dedicatedGBBytes := gigabytesToBytes(*lot.MPA.DedicatedGB)
+			// While we check that lot config is valid later, we can't finish dividing space if
+			// remainintToHwmB dips negative. Can't check for < 0 after subraction because the uint64 will wrap
+			if remainingToHwmB < dedicatedGBBytes {
+				return errors.New(fmt.Sprintf("the sum of all lots' dedicatedGB values exceeds the high watermark of %s. This would allow the cache to purge namespaces using less than their dedicated quota", hwmStr))
+			}
+			remainingToHwmB -= dedicatedGBBytes
 			if lot.MPA.OpportunisticGB == nil {
 				oGb := bytesToGigabytes(hwm) - *lot.MPA.DedicatedGB
 				lot.MPA.OpportunisticGB = &oGb

--- a/lotman/lotman_linux.go
+++ b/lotman/lotman_linux.go
@@ -837,7 +837,7 @@ func initLots(nsAds []server_structs.NamespaceAdV2) ([]Lot, error) {
 		// Handle potential need to merge discovered namespaces with provided configuration
 		if shouldMerge {
 			log.Debug("Merging lot configuration from discovered namespaces with configured lots")
-			lotMap, err = mergeLotMaps(directorLotMap, policyLotMap)
+			lotMap, err = mergeLotMaps(policyLotMap, directorLotMap)
 			if err != nil {
 				return internalLots, errors.Wrap(err, "error merging discovered namespaces with configured lots")
 			}

--- a/lotman/lotman_linux.go
+++ b/lotman/lotman_linux.go
@@ -735,36 +735,36 @@ func configLotsFromFedPrefixes(nsAds []server_structs.NamespaceAdV2) (map[string
 // this means we have to sort our lots topologically to ensure that we create them in the correct order.
 // Failure to do so appears to result in a segfault in Lotman.
 func topoSort(lotMap map[string]Lot) ([]Lot, error) {
-    sorted := make([]Lot, 0, len(lotMap))
-    visited := make(map[string]bool)
+	sorted := make([]Lot, 0, len(lotMap))
+	visited := make(map[string]bool)
 
 	// Recursively visit each lot and its parents, DFS-style
 	var visit func(string) error
-    visit = func(name string) error {
-        if visited[name] {
-            return nil
-        }
-        visited[name] = true
+	visit = func(name string) error {
+		if visited[name] {
+			return nil
+		}
+		visited[name] = true
 
-        // Visit all parents first
-        for _, parent := range lotMap[name].Parents {
-            if err := visit(parent); err != nil {
-                return err
-            }
-        }
+		// Visit all parents first
+		for _, parent := range lotMap[name].Parents {
+			if err := visit(parent); err != nil {
+				return err
+			}
+		}
 		// Adding the leaves of the DFS parent tree to the sorted list
 		// guarantees that we'll add the parents before the children
-        sorted = append(sorted, lotMap[name])
-        return nil
-    }
+		sorted = append(sorted, lotMap[name])
+		return nil
+	}
 
-    for name := range lotMap {
-        if err := visit(name); err != nil {
-            return nil, err
-        }
-    }
+	for name := range lotMap {
+		if err := visit(name); err != nil {
+			return nil, err
+		}
+	}
 
-    return sorted, nil
+	return sorted, nil
 }
 
 

--- a/lotman/lotman_linux.go
+++ b/lotman/lotman_linux.go
@@ -83,7 +83,7 @@ type (
 	LotPath struct {
 		Path      string `json:"path" mapstructure:"Path"`
 		Recursive bool   `json:"recursive" mapstructure:"Recursive"`
-		LotName   string `json:"lot_name,omitempty"` // Not used when creating lots, but some queries will populate
+		LotName   string `json:"lot_name,omitempty"` // Not used when creating lots, but some queries will populate the field
 	}
 
 	LotValueMapInt struct {
@@ -845,7 +845,7 @@ func initLots(nsAds []server_structs.NamespaceAdV2) ([]Lot, error) {
 	// without allowing discovered lots to gain rootly status.
 	federationIssuer, err := getFederationIssuer()
 	if err != nil {
-		return internalLots, errors.Wrap(err, "Unable to determine federation issuer which is needed by Lotman to determine lot ownership")
+		return internalLots, errors.Wrap(err, "Unable to determine the federation's issuer, which is needed by Lotman to determine lot ownership")
 	}
 	if federationIssuer == "" {
 		return internalLots, errors.New("The detected federation issuer, which is needed by Lotman to determine lot/namespace ownership, is empty")

--- a/lotman/lotman_linux.go
+++ b/lotman/lotman_linux.go
@@ -896,15 +896,15 @@ func initLots(nsAds []server_structs.NamespaceAdV2) ([]Lot, error) {
 	// Set up lot timestamps (creation, expiration, deletion) if needed
 	configLotTimestamps(&lotMap)
 
-	internalLots, err = topoSort(lotMap)
-	if err != nil {
-		return internalLots, errors.Wrap(err, "error sorting lots prior to instantiation")
-	}
-
 	log.Tracef("Internal lot configuration: %+v", internalLots)
 	err = validateLotsConfig(internalLots, totalDiskSpaceB)
 	if err != nil {
 		return internalLots, errors.Wrap(err, "error validating deduced lot configuration")
+	}
+
+	internalLots, err = topoSort(lotMap)
+	if err != nil {
+		return internalLots, errors.Wrap(err, "error sorting lots prior to instantiation")
 	}
 
 	return internalLots, nil

--- a/lotman/lotman_test.go
+++ b/lotman/lotman_test.go
@@ -531,8 +531,9 @@ func TestGetPolicyMap(t *testing.T) {
 
 	policyMap, err := getPolicyMap()
 	require.NoError(t, err)
-	require.Equal(t, 1, len(policyMap))
+	require.Equal(t, 2, len(policyMap))
 	require.Contains(t, policyMap, "different-policy")
+	require.Contains(t, policyMap, "another policy")
 	require.Equal(t, "different-policy", viper.GetString("Lotman.EnabledPolicy"))
 }
 

--- a/lotman/resources/lots-config.yaml
+++ b/lotman/resources/lots-config.yaml
@@ -18,83 +18,50 @@
 
 # Configuration options used to test Lot declarations
 Lotman:
-  Lots:
-    - LotName: "default"
-      Owner: "SHOULD_OVERRIDE"
-      Parents:
-        - "default"
-      ManagementPolicyAttrs:
-        DedicatedGB: 100
-        OpportunisticGB: 200
-        # Wrapping these in a map is an unfortunate side effect of the
-        # way we need to handle the float-->int conversion.
-        MaxNumObjects:
-          Value: 1000
-        CreationTime:
-          Value: 1234
-        ExpirationTime:
-          Value: 12345
-        DeletionTime:
-          Value: 123456
-
-    - LotName: "root"
-      Owner: "SHOULD_OVERRIDE"
-      Parents:
-        - "root"
-      Paths:
-        - Path: "/"
-          Recursive: false
-      ManagementPolicyAttrs:
-        DedicatedGB: 1
-        OpportunisticGB: 2
-        # Wrapping these in a map is an unfortunate side effect of the
-        # way we need to handle the float-->int conversion.
-        MaxNumObjects:
-          Value: 10
-        CreationTime:
-          Value: 1234
-        ExpirationTime:
-          Value: 12345
-        DeletionTime:
-          Value: 123456
-
-    - LotName: "test-1"
-      Owner: "https://different-fake-federation.com"
-      Parents:
-        - "root"
-      Paths:
-        - Path: "/test-1"
-          Recursive: false
-      ManagementPolicyAttrs:
-        DedicatedGB: 1.11
-        OpportunisticGB: 2.22
-        # Wrapping these in a map is an unfortunate side effect of the
-        # way we need to handle the float-->int conversion.
-        MaxNumObjects:
-          Value: 42
-        CreationTime:
-          Value: 1234
-        ExpirationTime:
-          Value: 12345
-        DeletionTime:
-          Value: 123456
-    - LotName: "test-2"
-      Owner: "https://another-fake-federation.com"
-      Parents:
-        - "test-1"
-      Paths:
-        - Path: "/test-1/test-2"
-          Recursive: true
-      ManagementPolicyAttrs:
-        DedicatedGB: 1.11
-        OpportunisticGB: 2.22
-        # Wrapping these in a map is an unfortunate side effect of the
-        # way we need to handle the float-->int conversion.
-        MaxNumObjects:
-          Value: 42
-        CreationTime:
-          Value: 1234
-        ExpirationTime:
-          Value: 12345
-        DeletionTime:
-          Value: 123456
+  EnabledPolicy: "different-policy"
+  PolicyDefinitions:
+    - PolicyName: "different-policy"
+      DivideUnallocated: false
+      PurgeOrder: ["ded", "opp", "exp", "del"]
+      DiscoverPrefixes: false
+      Lots:
+        - LotName: "test-1"
+          Owner: "https://different-fake-federation.com"
+          Parents:
+            - "root"
+          Paths:
+            - Path: "/test-1"
+              Recursive: false
+          ManagementPolicyAttrs:
+            DedicatedGB: 1.11
+            OpportunisticGB: 2.22
+            # Wrapping these in a map is an unfortunate side effect of the
+            # way we need to handle the float-->int conversion.
+            MaxNumObjects:
+              Value: 42
+            CreationTime:
+              Value: 1234
+            ExpirationTime:
+              Value: 12345
+            DeletionTime:
+              Value: 123456
+        - LotName: "test-2"
+          Owner: "https://another-fake-federation.com"
+          Parents:
+            - "test-1"
+          Paths:
+            - Path: "/test-1/test-2"
+              Recursive: true
+          ManagementPolicyAttrs:
+            DedicatedGB: 1.11
+            OpportunisticGB: 2.22
+            # Wrapping these in a map is an unfortunate side effect of the
+            # way we need to handle the float-->int conversion.
+            MaxNumObjects:
+              Value: 42
+            CreationTime:
+              Value: 1234
+            ExpirationTime:
+              Value: 12345
+            DeletionTime:
+              Value: 123456

--- a/lotman/resources/lots-config.yaml
+++ b/lotman/resources/lots-config.yaml
@@ -65,3 +65,7 @@ Lotman:
               Value: 12345
             DeletionTime:
               Value: 123456
+    - PolicyName: "another policy"
+      DivideUnallocated: true
+      PurgeOrder: ["ded", "opp", "exp", "del"]
+      DiscoverPrefixes: true

--- a/lotman/resources/malformed-lots-config.yaml
+++ b/lotman/resources/malformed-lots-config.yaml
@@ -1,0 +1,25 @@
+# ***************************************************************
+#
+#  Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+#
+#  Licensed under the Apache License, Version 2.0 (the "License"); you
+#  may not use this file except in compliance with the License.  You may
+#  obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# ***************************************************************
+
+Lotman:
+  EnabledPolicy: "my-bad-policy"
+  PolicyDefinitions:
+    - PolicyName: "my-bad-policy"
+      IShouldCreateAnUnmarshalError: true
+      NoReallyImBad: ["ded", "opp", "exp", "del"]
+      PleaseDontLetMeWork: true

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -196,6 +196,7 @@ var (
 	Logging_Origin_Xrd = StringParam{"Logging.Origin.Xrd"}
 	Logging_Origin_Xrootd = StringParam{"Logging.Origin.Xrootd"}
 	Lotman_DbLocation = StringParam{"Lotman.DbLocation"}
+	Lotman_EnabledPolicy = StringParam{"Lotman.EnabledPolicy"}
 	Lotman_LibLocation = StringParam{"Lotman.LibLocation"}
 	Monitoring_DataLocation = StringParam{"Monitoring.DataLocation"}
 	OIDC_AuthorizationEndpoint = StringParam{"OIDC.AuthorizationEndpoint"}
@@ -391,6 +392,8 @@ var (
 	Director_OriginCacheHealthTestInterval = DurationParam{"Director.OriginCacheHealthTestInterval"}
 	Director_StatTimeout = DurationParam{"Director.StatTimeout"}
 	Federation_TopologyReloadInterval = DurationParam{"Federation.TopologyReloadInterval"}
+	Lotman_DefaultLotDeletionLifetime = DurationParam{"Lotman.DefaultLotDeletionLifetime"}
+	Lotman_DefaultLotExpirationLifetime = DurationParam{"Lotman.DefaultLotExpirationLifetime"}
 	Monitoring_DataRetention = DurationParam{"Monitoring.DataRetention"}
 	Monitoring_TokenExpiresIn = DurationParam{"Monitoring.TokenExpiresIn"}
 	Monitoring_TokenRefreshInterval = DurationParam{"Monitoring.TokenRefreshInterval"}
@@ -412,7 +415,7 @@ var (
 	GeoIPOverrides = ObjectParam{"GeoIPOverrides"}
 	Issuer_AuthorizationTemplates = ObjectParam{"Issuer.AuthorizationTemplates"}
 	Issuer_OIDCAuthenticationRequirements = ObjectParam{"Issuer.OIDCAuthenticationRequirements"}
-	Lotman_Lots = ObjectParam{"Lotman.Lots"}
+	Lotman_PolicyDefinitions = ObjectParam{"Lotman.PolicyDefinitions"}
 	Origin_Exports = ObjectParam{"Origin.Exports"}
 	Registry_CustomRegistrationFields = ObjectParam{"Registry.CustomRegistrationFields"}
 	Registry_Institutions = ObjectParam{"Registry.Institutions"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -153,9 +153,12 @@ type Config struct {
 	} `mapstructure:"logging" yaml:"Logging"`
 	Lotman struct {
 		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
+		DefaultLotDeletionLifetime time.Duration `mapstructure:"defaultlotdeletionlifetime" yaml:"DefaultLotDeletionLifetime"`
+		DefaultLotExpirationLifetime time.Duration `mapstructure:"defaultlotexpirationlifetime" yaml:"DefaultLotExpirationLifetime"`
 		EnableAPI bool `mapstructure:"enableapi" yaml:"EnableAPI"`
+		EnabledPolicy string `mapstructure:"enabledpolicy" yaml:"EnabledPolicy"`
 		LibLocation string `mapstructure:"liblocation" yaml:"LibLocation"`
-		Lots interface{} `mapstructure:"lots" yaml:"Lots"`
+		PolicyDefinitions interface{} `mapstructure:"policydefinitions" yaml:"PolicyDefinitions"`
 	} `mapstructure:"lotman" yaml:"Lotman"`
 	MinimumDownloadSpeed int `mapstructure:"minimumdownloadspeed" yaml:"MinimumDownloadSpeed"`
 	Monitoring struct {
@@ -461,9 +464,12 @@ type configWithType struct {
 	}
 	Lotman struct {
 		DbLocation struct { Type string; Value string }
+		DefaultLotDeletionLifetime struct { Type string; Value time.Duration }
+		DefaultLotExpirationLifetime struct { Type string; Value time.Duration }
 		EnableAPI struct { Type string; Value bool }
+		EnabledPolicy struct { Type string; Value string }
 		LibLocation struct { Type string; Value string }
-		Lots struct { Type string; Value interface{} }
+		PolicyDefinitions struct { Type string; Value interface{} }
 	}
 	MinimumDownloadSpeed struct { Type string; Value int }
 	Monitoring struct {

--- a/server_utils/server_utils.go
+++ b/server_utils/server_utils.go
@@ -31,7 +31,6 @@ import (
 	"io"
 	"net/http"
 	"reflect"
-	"time"
 	"strings"
 	"time"
 


### PR DESCRIPTION
This gives caches the ability to inform Lotman of known namespaces, which Lotman can use to automatically create a (currently toothless) purge policy.

A lot of the work here involved figuring out how to specify named lot policies through our yaml config. Examples of what I came up with can be found in docs/parameters.yaml. Outside of that, some changes involved figuring out how to merge local config with potentially-discovered config.

Until Pelican actually uses the new purge code with the Lotman purge plugin, none of this really does much other than set up a database. For now, this lets us set up most of the lot config in a cache through Pelican, and then the last bits for testing purge stuff need to be configured manually. Until then, the actual purge ordering portion of a policy isn't plumbed into anything -- eventually it will modify XRootD config directly.

Finally, I still haven't worked out completely how to manage expiration/deletion of lots. I'll save that for another PR, potentially in the next release cycle.