### PR TITLE
Bump containerized S3/HTTP backend version from v0.1.7 to v0.1.8

### DIFF
--- a/github_scripts/osx_install.sh
+++ b/github_scripts/osx_install.sh
@@ -66,7 +66,7 @@ popd
 
 git clone --recurse-submodules --branch v0.1.7 https://github.com/PelicanPlatform/xrootd-s3-http.git
 pushd xrootd-s3-http
-git checkout v0.1.7
+git checkout v0.1.8
 mkdir build
 cd build
 cmake .. -GNinja -DCMAKE_INSTALL_PREFIX=$PWD/release_dir

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -82,7 +82,7 @@ ADD https://api.github.com/repos/PelicanPlatform/xrootd-s3-http/git/refs/heads/m
 RUN \
     git clone --recurse-submodules https://github.com/PelicanPlatform/xrootd-s3-http.git && \
     cd xrootd-s3-http && \
-    git checkout v0.1.7 && \
+    git checkout v0.1.8 && \
     mkdir build && cd build && \
     cmake -DLIB_INSTALL_DIR=/usr/lib64 .. && \
     make install

--- a/images/dev.Dockerfile
+++ b/images/dev.Dockerfile
@@ -82,7 +82,7 @@ ADD https://api.github.com/repos/PelicanPlatform/xrootd-s3-http/git/refs/heads/m
 RUN \
     git clone --recurse-submodules https://github.com/PelicanPlatform/xrootd-s3-http.git && \
     cd xrootd-s3-http && \
-    git checkout v0.1.7 && \
+    git checkout v0.1.8 && \
     mkdir build && cd build && \
     cmake -DLIB_INSTALL_DIR=/usr/lib64 .. && \
     make install


### PR DESCRIPTION
Changes primarily affect the S3 backend, with big speedups for reads/writes and bug fixes that correct the way we parse some headers.