### PR TITLE
Move /pelican/monitoring into the "namespace" directory

### DIFF
--- a/cache/cache_api.go
+++ b/cache/cache_api.go
@@ -37,7 +37,7 @@ import (
 func CheckCacheSentinelLocation() error {
 	if param.Cache_SentinelLocation.IsSet() {
 		sentinelPath := param.Cache_SentinelLocation.GetString()
-		dataLoc := param.Cache_StorageLocation.GetString()
+		dataLoc := param.Cache_NamespaceLocation.GetString()
 		sentinelPath = path.Clean(sentinelPath)
 		if path.Base(sentinelPath) != sentinelPath {
 			return errors.Errorf("invalid Cache.SentinelLocation path. File must not contain a directory. Got %s", sentinelPath)
@@ -51,17 +51,17 @@ func CheckCacheSentinelLocation() error {
 	return nil
 }
 
-// Periodically scan the ${Cache.StorageLocation}/pelican/monitoring directory to clean up test files
+// Periodically scan the ${Cache.NamespaceLocation}/pelican/monitoring directory to clean up test files
 // TODO: Director test files should be under /pelican/monitoring/directorTest and the file names
 // should have director-test- as the prefix
 func LaunchDirectorTestFileCleanup(ctx context.Context) {
 	server_utils.LaunchWatcherMaintenance(ctx,
-		[]string{filepath.Join(param.Cache_StorageLocation.GetString(), "pelican", "monitoring")},
+		[]string{filepath.Join(param.Cache_NamespaceLocation.GetString(), "pelican", "monitoring")},
 		"cache director-based health test clean up",
 		time.Minute,
 		func(notifyEvent bool) error {
 			// We run this function regardless of notifyEvent to do the cleanup
-			dirPath := filepath.Join(param.Cache_StorageLocation.GetString(), "pelican", "monitoring")
+			dirPath := filepath.Join(param.Cache_NamespaceLocation.GetString(), "pelican", "monitoring")
 			dirInfo, err := os.Stat(dirPath)
 			if err != nil {
 				return err

--- a/cache/cache_api_test.go
+++ b/cache/cache_api_test.go
@@ -50,7 +50,7 @@ func TestCheckCacheSentinelLocation(t *testing.T) {
 		tmpDir := t.TempDir()
 		server_utils.ResetTestState()
 		viper.Set(param.Cache_SentinelLocation.GetName(), "test.txt")
-		viper.Set(param.Cache_StorageLocation.GetName(), tmpDir)
+		viper.Set(param.Cache_NamespaceLocation.GetName(), tmpDir)
 		err := CheckCacheSentinelLocation()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to open Cache.SentinelLocation")
@@ -61,7 +61,7 @@ func TestCheckCacheSentinelLocation(t *testing.T) {
 		server_utils.ResetTestState()
 
 		viper.Set(param.Cache_SentinelLocation.GetName(), "test.txt")
-		viper.Set(param.Cache_StorageLocation.GetName(), tmpDir)
+		viper.Set(param.Cache_NamespaceLocation.GetName(), tmpDir)
 
 		file, err := os.Create(filepath.Join(tmpDir, "test.txt"))
 		require.NoError(t, err)

--- a/cache/self_monitor.go
+++ b/cache/self_monitor.go
@@ -59,7 +59,7 @@ func InitSelfTestDir() error {
 		return err
 	}
 
-	basePath := param.Cache_StorageLocation.GetString()
+	basePath := param.Cache_NamespaceLocation.GetString()
 	pelicanMonPath := filepath.Join(basePath, "/pelican")
 	monitoringPath := filepath.Join(pelicanMonPath, "/monitoring")
 	selfTestPath := filepath.Join(monitoringPath, "/selfTest")
@@ -80,9 +80,9 @@ func InitSelfTestDir() error {
 }
 
 func generateTestFile() (string, error) {
-	basePath := param.Cache_StorageLocation.GetString()
+	basePath := param.Cache_NamespaceLocation.GetString()
 	if basePath == "" {
-		return "", errors.New("failed to generate self-test file for cache: Cache.StorageLocation is not set.")
+		return "", errors.New("failed to generate self-test file for cache: Cache.NamespaceLocation is not set.")
 	}
 	selfTestPath := filepath.Join(basePath, selfTestDir)
 	_, err := os.Stat(selfTestPath)
@@ -225,7 +225,7 @@ func downloadTestFile(ctx context.Context, fileUrl string) error {
 }
 
 func deleteTestFile(fileUrlStr string) error {
-	basePath := param.Cache_StorageLocation.GetString()
+	basePath := param.Cache_NamespaceLocation.GetString()
 	fileUrl, err := url.Parse(fileUrlStr)
 	if err != nil {
 		return errors.Wrap(err, "invalid file url to remove the test file")


### PR DESCRIPTION
The /pelican/monitoring namespace is where we write various test files that are used to determine whether an XRootD service is currently healthy. After updating our default locations for various cache directories, this was missed, and the monitoring namespace was written to an inaccessible location. This commit corrects the locations.