### PR TITLE
Packaging: create pelican user and group and some directories for it

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -128,6 +128,8 @@ nfpms:
     release: 1
     section: default
     priority: extra
+    scripts:
+      preinstall: "scripts/preinstall.sh"
     overrides:
       rpm:
         contents:
@@ -147,6 +149,24 @@ nfpms:
               mode: 0755
               owner: root
               group: root
+          - dst: "/var/lib/pelican"
+            type: dir
+            file_info:
+              mode: 0755
+              owner: pelican
+              group: pelican
+          - dst: "/var/lib/pelican/monitoring"
+            type: dir
+            file_info:
+              mode: 0755
+              owner: pelican
+              group: pelican
+          - dst: "/var/spool/pelican"
+            type: dir
+            file_info:
+              mode: 0755
+              owner: pelican
+              group: pelican
       deb:
         contents:
           - src: LICENSE
@@ -165,6 +185,24 @@ nfpms:
               mode: 0755
               owner: root
               group: root
+          - dst: "/var/lib/pelican"
+            type: dir
+            file_info:
+              mode: 0755
+              owner: pelican
+              group: pelican
+          - dst: "/var/lib/pelican/monitoring"
+            type: dir
+            file_info:
+              mode: 0755
+              owner: pelican
+              group: pelican
+          - dst: "/var/spool/pelican"
+            type: dir
+            file_info:
+              mode: 0755
+              owner: pelican
+              group: pelican
       apk:
         contents:
           - src: LICENSE
@@ -183,6 +221,24 @@ nfpms:
               mode: 0755
               owner: root
               group: root
+          - dst: "/var/lib/pelican"
+            type: dir
+            file_info:
+              mode: 0755
+              owner: pelican
+              group: pelican
+          - dst: "/var/lib/pelican/monitoring"
+            type: dir
+            file_info:
+              mode: 0755
+              owner: pelican
+              group: pelican
+          - dst: "/var/spool/pelican"
+            type: dir
+            file_info:
+              mode: 0755
+              owner: pelican
+              group: pelican
   # end package pelican
 
   - package_name: pelican-osdf-compat

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -239,6 +239,8 @@ nfpms:
               mode: 0755
               owner: pelican
               group: pelican
+        scripts:
+          preinstall: "scripts/preinstall-alpine.sh"
   # end package pelican
 
   - package_name: pelican-osdf-compat

--- a/scripts/preinstall-alpine.sh
+++ b/scripts/preinstall-alpine.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+getent group pelican >/dev/null || addgroup -S pelican
+getent passwd pelican >/dev/null || \
+    adduser -S -G pelican -g "Pelican service user" \
+        -s /sbin/nologin -D -H -h /var/lib/pelican pelican

--- a/scripts/preinstall.sh
+++ b/scripts/preinstall.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+getent group pelican >/dev/null || groupadd -r pelican
+getent passwd pelican >/dev/null || \
+    useradd -r -g pelican -c "Pelican service user" \
+        -s /sbin/nologin -d /var/lib/pelican pelican


### PR DESCRIPTION
#1860 ; this creates a system user and group named `pelican`; it also pre-creates some directories that Pelican won't be able to create after dropping privs to the `pelican` user.
