### PR TITLE
Add prefix restrictions on caches

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1369,6 +1369,15 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 	}
 
 	if currentServers.IsEnabled(server_structs.DirectorType) {
+		refreshInterval := param.Director_RegistryQueryInterval.GetDuration()
+		if refreshInterval < 1*time.Second {
+			log.Warnf("Director.RegistryQueryInterval is set to: %v, which is too low. Falling back to default: 1m", refreshInterval)
+
+			viper.Set(param.Director_RegistryQueryInterval.GetName(), "1m")
+		}
+	}
+
+	if currentServers.IsEnabled(server_structs.DirectorType) {
 		viper.SetDefault("Federation.DirectorUrl", param.Server_ExternalWebUrl.GetString())
 		minStatRes := param.Director_MinStatResponse.GetInt()
 		maxStatRes := param.Director_MaxStatResponse.GetInt()

--- a/director/director.go
+++ b/director/director.go
@@ -1033,15 +1033,8 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 					continue
 				}
 
-				allowed := false
-				for _, prefix := range prefixes {
-					if namespace.Path == prefix {
-						allowed = true
-						break
-					}
-				}
-
-				if allowed {
+				// Check if the namespace path exists in the allowed set
+				if _, allowed := prefixes[namespace.Path]; allowed {
 					filteredNamespaces = append(filteredNamespaces, namespace)
 				} else {
 					log.Warnf("Rejected namespace: cache hostname=%s, namespace path=%s", cacheHostname, namespace.Path)

--- a/director/director.go
+++ b/director/director.go
@@ -981,10 +981,10 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 	}
 
 	// Check if the allowed prefixes for caches data from the registry
-	// have been initialized in the director
+	// has been initialized in the director
 	if sType == server_structs.CacheType {
 		// If the allowed prefix for caches data is not initialized,
-		// wait for it to be initialized within 3 seconds.
+		// wait for it to be initialized for 3 seconds.
 		if allowedPrefixesForCachesLastSetTimestamp.Load() == 0 {
 			log.Warning("Allowed prefixes for caches data is not initialized. Waiting for initialization before continuing with processing cache server advertisement.")
 			start := time.Now()
@@ -1004,7 +1004,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 			log.Error("Allowed prefixes for caches data is outdated, rejecting cache server ad.")
 			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 				Status: server_structs.RespFailed,
-				Msg:    "Allowed prefixes for caches data is outdated",
+				Msg:    "Something is wrong with the director or registry. Allowed prefixes for caches data is outdated.",
 			})
 			return
 		}
@@ -1029,8 +1029,8 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 		adV2 = server_structs.ConvertOriginAdV1ToV2(ad)
 	}
 
-	// Filter the advertised prefixes in the cache server advertisement
-	// based on the allowed prefix for caches data.
+	// Filter the advertised prefixes in the cache server ad
+	// based on the allowed prefixes for caches data.
 	if sType == server_structs.CacheType {
 		// Parse URL to extract hostname
 		parsedURL, err := url.Parse(adV2.DataURL)
@@ -1057,7 +1057,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 		// filter the advertised prefixes. If the cache hostname is not present,
 		// do nothing. This is the default behavior where all prefixes are allowed.
 		//
-		// `prefixes` is a set of prefixes that the given cache is allowed to serve.
+		// Variable `prefixes` is a set of prefixes that the given cache is allowed to serve.
 		if prefixes, exists := (*allowedPrefixesMap)[cacheHostname]; exists {
 			filteredNamespaces := []server_structs.NamespaceAdV2{}
 

--- a/director/director.go
+++ b/director/director.go
@@ -1042,13 +1042,6 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 			}
 
 			adV2.Namespaces = filteredNamespaces
-		} else {
-			log.Warnf("Cache hostname not found in AllowedPrefixesForCaches: %s", cacheHostname)
-			ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
-				Status: server_structs.RespFailed,
-				Msg:    fmt.Sprintf("Cache hostname not found in AllowedPrefixesForCaches: %s", cacheHostname),
-			})
-			return
 		}
 	}
 

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -642,8 +642,8 @@ func TestDirectorRegistration(t *testing.T) {
 		allowedPrefixesForCachesLastSetTimestamp.Store(time.Now().Unix())
 
 		ad := server_structs.OriginAdvertiseV2{
-			Name:           "Human-readable name", // For web UI display
-			RegistryPrefix: "/caches/test",        // For registry lookup
+			Name:           "Human-readable name",
+			RegistryPrefix: "/caches/test",
 			DataURL:        "https://data-url.org",
 			WebURL:         "https://localhost:8844",
 			Namespaces: []server_structs.NamespaceAdV2{

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -607,6 +607,8 @@ func TestDirectorRegistration(t *testing.T) {
 		jsonad, err := json.Marshal(ad)
 		assert.NoError(t, err, "Error marshalling OriginAdvertise")
 
+		allowedPrefixesForCachesLastSetTimestamp.Store(time.Now().Unix())
+
 		setupRequest(c, r, jsonad, token, server_structs.CacheType)
 
 		r.ServeHTTP(w, c.Request)
@@ -631,10 +633,11 @@ func TestDirectorRegistration(t *testing.T) {
 		// Define allowed prefixes
 		allowedPrefixes := map[string]map[string]struct{}{
 			"data-url.org": {
-				"/foo/bazz": {},
+				"/foo/baz": {},
 			},
 		}
 		allowedPrefixesForCaches.Store(&allowedPrefixes)
+		allowedPrefixesForCachesLastSetTimestamp.Store(time.Now().Unix())
 
 		// Create advertisement with namespaces
 		ad := server_structs.OriginAdvertiseV2{
@@ -648,7 +651,7 @@ func TestDirectorRegistration(t *testing.T) {
 					Issuer: []server_structs.TokenIssuer{{IssuerUrl: isurl}},
 				},
 				{
-					Path:   "/foo/bazz",
+					Path:   "/foo/baz",
 					Issuer: []server_structs.TokenIssuer{{IssuerUrl: isurl}},
 				},
 			},
@@ -675,19 +678,19 @@ func TestDirectorRegistration(t *testing.T) {
 		assert.NotNil(t, namespaceAds, "NamespaceAds should not be nil")
 
 		foundFooBar := false
-		foundFooBazz := false
+		foundFooBaz := false
 
 		for _, ns := range namespaceAds {
 			if ns.Path == "/foo/bar" {
 				foundFooBar = true
 			}
-			if ns.Path == "/foo/bazz" {
-				foundFooBazz = true
+			if ns.Path == "/foo/baz" {
+				foundFooBaz = true
 			}
 		}
 
 		assert.False(t, foundFooBar, "Namespace with path /foo/bar should not be registered")
-		assert.True(t, foundFooBazz, "Namespace with path /foo/bazz should be registered")
+		assert.True(t, foundFooBaz, "Namespace with path /foo/baz should be registered")
 
 		teardown()
 	})

--- a/director/registry_periodic_query.go
+++ b/director/registry_periodic_query.go
@@ -36,9 +36,9 @@ import (
 )
 
 var (
-	// allowedPrefixesForCaches maps cache hostnames to a set of prefixes the caches are allowed to serve.
+	// allowedPrefixesForCaches maps cache hostnames to a set of prefixes the caches are allowed to serve
 	allowedPrefixesForCaches atomic.Pointer[map[string]map[string]struct{}]
-	// allowedPrefixesForCachesLastSetTimestamp tracks when allowedPrefixesForCaches was last explicitly set.
+	// allowedPrefixesForCachesLastSetTimestamp tracks when allowedPrefixesForCaches was last set
 	allowedPrefixesForCachesLastSetTimestamp atomic.Int64
 )
 
@@ -150,7 +150,7 @@ func LaunchRegistryPeriodicQuery(ctx context.Context, egrp *errgroup.Group) {
 				allowedPrefixesForCachesLastSetTimestamp.Store(time.Now().Unix())
 				log.Debug("Allowed prefixes for caches data updated successfully")
 			case <-ctx.Done():
-				log.Debug("Periodic fetch terminated")
+				log.Debug("Periodic fetch fopr allowed prefixes for caches data terminated")
 				return nil
 			}
 		}

--- a/director/registry_periodic_query.go
+++ b/director/registry_periodic_query.go
@@ -105,7 +105,11 @@ func fetchAllowedPrefixesForCaches(ctx context.Context) (map[string]map[string]s
 }
 
 // LaunchRegistryPeriodicQuery starts a new goroutine that periodically refreshes
-// the allowed prefixes for cache data maintained by the director in memory.
+// the allowed prefixes for caches data maintained by the director in memory.
+// It queries the registry at the interval specified by the config parameter
+// Director.RegistryQueryInterval. If the data is stale (older than 15 minutes)
+// or uninitialized, it queries the registry at a shorter interval of 1 second
+// and switches back to the regular interval upon successful retrieval of the information.
 func LaunchRegistryPeriodicQuery(ctx context.Context, egrp *errgroup.Group) {
 	refreshInterval := param.Director_RegistryQueryInterval.GetDuration()
 

--- a/director/registry_periodic_query.go
+++ b/director/registry_periodic_query.go
@@ -1,0 +1,146 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package director
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync/atomic"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
+)
+
+var (
+	// allowedPrefixesForCaches maps cahce hostnames to a list of prefixes the caches are allowed to serve.
+	allowedPrefixesForCaches atomic.Pointer[map[string][]string]
+	// allowedPrefixesForCachesLastSetTimestamp tracks when allowedPrefixesForCaches was last explicitly set.
+	allowedPrefixesForCachesLastSetTimestamp atomic.Int64
+)
+
+func init() {
+	emptyMap := make(map[string][]string)
+	allowedPrefixesForCaches.Store(&emptyMap)
+
+	// Initialize allowedPrefixesForCachesLastSetTimestamp to 0 (indicating never set)
+	allowedPrefixesForCachesLastSetTimestamp.Store(0)
+}
+
+// fetchAllowedPrefixesForCaches makes a request to the registry endpoint to retrieve
+// information about allowed prefixes for caches and returns the result.
+func fetchAllowedPrefixesForCaches(ctx context.Context) (map[string][]string, error) {
+	fedInfo, err := config.GetFederation(ctx)
+	if err != nil {
+		return nil, err
+	}
+	registryUrlStr := fedInfo.RegistryEndpoint
+	registryUrl, err := url.Parse(registryUrlStr)
+	if err != nil {
+		return nil, err
+	}
+	reqUrl := registryUrl.JoinPath("/api/v1.0/registry/caches/allowedPrefixes")
+
+	client := http.Client{Transport: config.GetTransport()}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch allowed prefixes for caches from the registry: unexpected status code %d", resp.StatusCode)
+	}
+
+	var result map[string][]string
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// LaunchRegistryPeriodicQuery starts a new goroutine that periodically refreshes
+// the allowed prefixes for cache data maintained by the director in memory.
+// This can later be extended to include any registry data the director wants to maintain in memory.
+func LaunchRegistryPeriodicQuery(ctx context.Context, egrp *errgroup.Group) {
+	refreshInterval := param.Director_RegistryQueryInterval.GetDuration()
+
+	if refreshInterval < 1*time.Millisecond {
+		log.Warnf("Director.RegistryQueryInterval is set to: %v, which is too low. Falling back to default: 1m", refreshInterval)
+
+		viper.Set("Director.RegistryQueryInterval", "1m")
+		refreshInterval = 1 * time.Minute
+	}
+
+	ticker := time.NewTicker(refreshInterval)
+
+	data, err := fetchAllowedPrefixesForCaches(ctx)
+	if err != nil {
+		ticker.Reset(1 * time.Second) // Higher frequency (10s)
+		log.Warningf("Error fetching allowed prefixes for caches data on first attempt: %v", err)
+		log.Debug("Switching to higher frequency (1s) for allowed prefixes for caches data fetch")
+	} else {
+		allowedPrefixesForCaches.Store(&data)
+		allowedPrefixesForCachesLastSetTimestamp.Store(time.Now().Unix())
+		log.Debug("Allowed prefixes for caches data updated successfully on first attempt")
+	}
+
+	egrp.Go(func() error {
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				data, err := fetchAllowedPrefixesForCaches(ctx)
+				if err != nil {
+					log.Warningf("Error fetching allowed prefixes for caches data: %v", err)
+					lastSet := allowedPrefixesForCachesLastSetTimestamp.Load()
+					if time.Since(time.Unix(lastSet, 0)) >= 15*time.Minute {
+						log.Debug("Allowed prefixes for caches data last updated over 15 minutes ago, switching to higher frequency")
+						ticker.Reset(1 * time.Second) // Higher frequency (1s)
+					}
+					continue
+				}
+				ticker.Reset(refreshInterval) // Normal frequency
+				allowedPrefixesForCaches.Store(&data)
+				allowedPrefixesForCachesLastSetTimestamp.Store(time.Now().Unix())
+				log.Debug("Allowed prefixes for caches data updated successfully")
+			case <-ctx.Done():
+				log.Debug("Periodic fetch terminated")
+				return nil
+			}
+		}
+	})
+}

--- a/director/registry_periodic_query.go
+++ b/director/registry_periodic_query.go
@@ -51,7 +51,7 @@ func init() {
 }
 
 // convertListToSet converts a map of string to list of strings into a map of string to set of strings.
-func convertListToSet(input map[string][]string) map[string]map[string]struct{} {
+func convertMapOfListToMapOfSet(input map[string][]string) map[string]map[string]struct{} {
 	result := make(map[string]map[string]struct{})
 	for key, list := range input {
 		set := make(map[string]struct{})
@@ -101,7 +101,7 @@ func fetchAllowedPrefixesForCaches(ctx context.Context) (map[string]map[string]s
 		return nil, err
 	}
 
-	return convertListToSet(result), nil
+	return convertMapOfListToMapOfSet(result), nil
 }
 
 // LaunchRegistryPeriodicQuery starts a new goroutine that periodically refreshes

--- a/director/registry_periodic_query_test.go
+++ b/director/registry_periodic_query_test.go
@@ -1,0 +1,97 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package director
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/config"
+)
+
+func TestLaunchRegistryPeriodicQuery(t *testing.T) {
+	config.ResetConfig()
+	defer config.ResetConfig()
+
+	mockDataChan := make(chan map[string][]string, 2)
+	mockData := map[string][]string{
+		"cacheHostname1": {"/ns1/ns2", "/ns3/ns4"},
+	}
+	mockDataChan <- mockData
+
+	var lastData map[string][]string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		select {
+		case currentData := <-mockDataChan:
+			lastData = currentData
+		default:
+		}
+		if lastData == nil {
+			lastData = make(map[string][]string)
+		}
+		if err := json.NewEncoder(w).Encode(lastData); err != nil {
+			log.Errorf("Failed to encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	// Set the registry URL to the mock server.
+	viper.Set("Federation.Registryurl", server.URL)
+	viper.Set("Director.RegistryQueryInterval", "200ms")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	egrp := &errgroup.Group{}
+
+	LaunchRegistryPeriodicQuery(ctx, egrp)
+
+	time.Sleep(500 * time.Millisecond)
+
+	currentMapPtr := allowedPrefixesForCaches.Load()
+	assert.NotNil(t, currentMapPtr, "allowedPrefixesForCaches should not be nil")
+
+	assert.Equal(t, convertMapOfListToMapOfSet(mockData), *currentMapPtr, "allowedPrefixesForCaches does not match the expected value")
+
+	mockData = map[string][]string{
+		"cacheHostname2": {"/ns5/ns6", "/ns7/ns8"},
+	}
+	mockDataChan <- mockData
+
+	time.Sleep(500 * time.Millisecond)
+
+	currentMapPtr = allowedPrefixesForCaches.Load()
+	assert.NotNil(t, currentMapPtr, "allowedPrefixesForCaches should not be nil")
+
+	assert.Equal(t, convertMapOfListToMapOfSet(mockData), *currentMapPtr, "allowedPrefixesForCaches does not match the expected value")
+
+	cancel()
+
+	require.NoError(t, egrp.Wait(), "Periodic fetch goroutine did not terminate properly")
+}

--- a/director/registry_periodic_query_test.go
+++ b/director/registry_periodic_query_test.go
@@ -35,6 +35,8 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 )
 
+// TestLaunchRegistryPeriodicQuery verifies if the director correctly maintains
+// in its memory the allowed prefixes for caches data from the registry.
 func TestLaunchRegistryPeriodicQuery(t *testing.T) {
 	config.ResetConfig()
 	defer config.ResetConfig()

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1635,7 +1635,9 @@ components: ["director"]
 ---
 name: Director.RegistryQueryInterval
 description: |+
-  Defines the interval at which the director queries the registry to refresh its in-memory cache.
+  Defines the interval at which the director queries the registry to refresh its in-memory cache of registry data.
+  Although this parameter is intended for any registry data the director might need to keep in memory, it currently
+  only stores the allowed prefixes for caches data.
 type: duration
 hidden: true
 default: 1m

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1633,6 +1633,14 @@ default: 10000
 hidden: true
 components: ["director"]
 ---
+name: Director.RegistryQueryInterval
+description: |+
+  Defines the interval at which the director queries the registry to refresh its in-memory cache.
+type: duration
+hidden: true
+default: 1m
+components: ["director"]
+---
 ############################
 #  Registry-level configs  #
 ############################

--- a/launchers/director_serve.go
+++ b/launchers/director_serve.go
@@ -52,6 +52,8 @@ func DirectorServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group
 
 	director.LaunchServerIOQuery(ctx, egrp)
 
+	director.LaunchRegistryPeriodicQuery(ctx, egrp)
+
 	if config.GetPreferredPrefix() == config.OsdfPrefix {
 		metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusWarning, "Start requesting from topology, status unknown")
 		log.Info("Generating/advertising server ads from OSG topology service...")

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -392,6 +392,7 @@ var (
 	Director_AdvertisementTTL = DurationParam{"Director.AdvertisementTTL"}
 	Director_CachePresenceTTL = DurationParam{"Director.CachePresenceTTL"}
 	Director_OriginCacheHealthTestInterval = DurationParam{"Director.OriginCacheHealthTestInterval"}
+	Director_RegistryQueryInterval = DurationParam{"Director.RegistryQueryInterval"}
 	Director_StatTimeout = DurationParam{"Director.StatTimeout"}
 	Federation_TopologyReloadInterval = DurationParam{"Federation.TopologyReloadInterval"}
 	Lotman_DefaultLotDeletionLifetime = DurationParam{"Lotman.DefaultLotDeletionLifetime"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -84,6 +84,7 @@ type Config struct {
 		MinStatResponse int `mapstructure:"minstatresponse" yaml:"MinStatResponse"`
 		OriginCacheHealthTestInterval time.Duration `mapstructure:"origincachehealthtestinterval" yaml:"OriginCacheHealthTestInterval"`
 		OriginResponseHostnames []string `mapstructure:"originresponsehostnames" yaml:"OriginResponseHostnames"`
+		RegistryQueryInterval time.Duration `mapstructure:"registryqueryinterval" yaml:"RegistryQueryInterval"`
 		StatConcurrencyLimit int `mapstructure:"statconcurrencylimit" yaml:"StatConcurrencyLimit"`
 		StatTimeout time.Duration `mapstructure:"stattimeout" yaml:"StatTimeout"`
 		SupportContactEmail string `mapstructure:"supportcontactemail" yaml:"SupportContactEmail"`
@@ -396,6 +397,7 @@ type configWithType struct {
 		MinStatResponse struct { Type string; Value int }
 		OriginCacheHealthTestInterval struct { Type string; Value time.Duration }
 		OriginResponseHostnames struct { Type string; Value []string }
+		RegistryQueryInterval struct { Type string; Value time.Duration }
 		StatConcurrencyLimit struct { Type string; Value int }
 		StatTimeout struct { Type string; Value time.Duration }
 		SupportContactEmail struct { Type string; Value string }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -895,7 +895,7 @@ func wildcardHandler(ctx *gin.Context) {
 
 		ctx.JSON(http.StatusOK, nsCfg)
 		return
-	} else if strings.HasSuffix(path, "/caches/allowed-prefixes") {
+	} else if strings.HasSuffix(path, "/caches/allowedPrefixes") {
 		getAllowedPrefixesForCachesHandler(ctx)
 		return
 	} else {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1157,18 +1157,20 @@ func checkStatusHandler(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, server_structs.CheckNamespaceCompleteRes{Results: results})
 }
 
+// getAllowedPrefixesForCachesHandler is the handler function for the
+// /caches/allowedPrefixes endpoint.
 func getAllowedPrefixesForCachesHandler(ctx *gin.Context) {
-	caches, err := getAllowedPrefixesForCaches()
+	allowedPrefixesForCachesData, err := getAllowedPrefixesForCaches()
 
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("Error fetching prohibited caches: %s", err.Error()),
+			Msg:    fmt.Sprintf("Error fetching allowed prefixes for caches data: %s", err.Error()),
 		})
 		return
 	}
 
-	ctx.JSON(http.StatusOK, caches)
+	ctx.JSON(http.StatusOK, allowedPrefixesForCachesData)
 }
 
 func RegisterRegistryAPI(router *gin.RouterGroup) {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -895,6 +895,9 @@ func wildcardHandler(ctx *gin.Context) {
 
 		ctx.JSON(http.StatusOK, nsCfg)
 		return
+	} else if strings.HasSuffix(path, "/caches/allowed-prefixes") {
+		getAllowedPrefixesForCachesHandler(ctx)
+		return
 	} else {
 		// Default to get the namespace by its prefix
 		getNamespaceHandler(ctx)
@@ -1152,6 +1155,20 @@ func checkStatusHandler(ctx *gin.Context) {
 		}
 	}
 	ctx.JSON(http.StatusOK, server_structs.CheckNamespaceCompleteRes{Results: results})
+}
+
+func getAllowedPrefixesForCachesHandler(ctx *gin.Context) {
+	caches, err := getAllowedPrefixesForCaches()
+
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Error fetching prohibited caches: %s", err.Error()),
+		})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, caches)
 }
 
 func RegisterRegistryAPI(router *gin.RouterGroup) {

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -280,6 +280,10 @@ func getNamespaceByPrefix(prefix string) (*server_structs.Namespace, error) {
 	return &ns, nil
 }
 
+// getAllowedPrefixesForCaches queries the database to create a map of cache
+// hostnames to a list of prefixes that each cache is allowed to serve.
+// If a cache hostname key is not present in the resultant map, it implies the
+// default behavior where the cache is allowed to serve all prefixes.
 func getAllowedPrefixesForCaches() (map[string][]string, error) {
 	var namespaces []server_structs.Namespace
 
@@ -291,7 +295,7 @@ func getAllowedPrefixesForCaches() (map[string][]string, error) {
 	allowedPrefixesForCachesMap := make(map[string][]string)
 
 	for _, namespace := range namespaces {
-		// Remove "/caches" from the beginning of the Prefix
+		// Remove "/caches/" from the beginning of the Prefix
 		cacheHostname := strings.TrimPrefix(namespace.Prefix, "/caches/")
 
 		allowedPrefixesRaw, exists := namespace.CustomFields["AllowedPrefixes"]

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -288,7 +288,7 @@ func getAllowedPrefixesForCaches() (map[string][]string, error) {
 		return nil, err
 	}
 
-	AllowedPrefixesForCachesMap := make(map[string][]string)
+	allowedPrefixesForCachesMap := make(map[string][]string)
 
 	for _, namespace := range namespaces {
 		// Remove "/caches" from the beginning of the Prefix
@@ -316,10 +316,10 @@ func getAllowedPrefixesForCaches() (map[string][]string, error) {
 			continue // Skip if the only value is "*"
 		}
 
-		AllowedPrefixesForCachesMap[cacheHostname] = allowedPrefixes
+		allowedPrefixesForCachesMap[cacheHostname] = allowedPrefixes
 	}
 
-	return AllowedPrefixesForCachesMap, nil
+	return allowedPrefixesForCachesMap, nil
 }
 
 // Get a collection of namespaces by filtering against various non-default namespace fields

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -292,7 +292,7 @@ func getAllowedPrefixesForCaches() (map[string][]string, error) {
 
 	for _, namespace := range namespaces {
 		// Remove "/caches" from the beginning of the Prefix
-		cacheHostname := strings.TrimPrefix(namespace.Prefix, "/caches")
+		cacheHostname := strings.TrimPrefix(namespace.Prefix, "/caches/")
 
 		allowedPrefixesRaw, exists := namespace.CustomFields["AllowedPrefixes"]
 		if !exists {

--- a/registry/registry_db_test.go
+++ b/registry/registry_db_test.go
@@ -748,6 +748,9 @@ func TestGetNamespacesByFilter(t *testing.T) {
 	})
 }
 
+// TestGetAllowedPrefixesForCaches verifies if the function
+// getAllowedPrefixesForCaches correctly constructs the mapping
+// from cache hostnames to allowed prefixes.
 func TestGetAllowedPrefixesForCaches(t *testing.T) {
 	setupMockRegistryDB(t)
 	defer teardownMockNamespaceDB(t)


### PR DESCRIPTION
### Description

This PR introduces a mechanism to define restrictions on the prefixes a cache is allowed to serve. The list of allowed prefixes can now be configured in the `custom_fields` column of the registry database as a JSON list, for example:

```json
{"AllowedPrefixes": ["/ns1", "/ns1/ns2"]}
```

- The cache will only serve requests for the specified prefixes in the `AllowedPrefixes` list.
- If the `AllowedPrefixes` key is absent in `custom_fields`, the default behavior remains unchanged (i.e., the cache will serve all prefixes).
- **Note**: If `/ns1` is in `AllowedPrefixes`, it does not imply that the cache is allowed to serve `/ns1/ns2`.

---

### Implementation Details

1. **New Registry Endpoint**:  
   - A new endpoint, `/caches/allowedPrefixes`, is added to the registry.
   - This endpoint returns a mapping of cache hostnames to their respective allowed prefixes.

2. **In-Memory Data Management**:  
   - A new goroutine is implemented in Director to maintain the allowed prefixes data for caches in memory by periodically querying the new registry endpoint.
   - The in-memory data has a 15-minute timeout. The goroutine:
     - Queries the registry API at a configurable interval (`Director.RegistryQueryInterval`).
     - Falls back to a 1-second interval if the data is uninitialized or expired, switching back to the regular interval upon successful retrieval.

3. **Prefix Filtering in Server Ads**:  
   - While processing a server ad in the director, the allowed prefixes are filtered using the in-memory data.
   - **Fail-safe behaviors**:
     - **Fail-Close Mechanism**: Reject the server advertisement if the in-memory data is outdated (older than 15 minutes).
     - **Sync Grace Period**: If the in-memory data is uninitialized, wait up to 3 seconds for the registry and director to sync before rejecting the advertisement.

---

### Additional Information

- This implementation introduces a backward compatibility issue between central services. The new director with this mechanism will not work with an older registry that does not include the `/caches/allowedPrefixes` endpoint.

- A new endpoint, `/caches/allowedPrefixes`, has been created in the registry. The top-level endpoint in the registry is defined as `/*wildcard`, which is used to retrieve information about namespaces. Due to this change, if a cache in the federation is named `allowedPrefixes`, it would not work. While this is not seen as a significant issue, middleware can be implemented to address it if necessary.

- After merging this PR, I will create a new issue to enable users to update the caches data in the registry through its UI, allowing them to add the list of allowed prefixes for a cache to the database.
