### PR TITLE
Run release action against triggering tag instead of checking out branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 # .github/workflows/release.yaml
-name: goreleaser
+name: Generate Release Artifacts
 
 on:
   push:
@@ -18,15 +18,11 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - name: Set Branch
-        id: set_branch
-        run: |
-          echo "branch=${GITHUB_REF_NAME%.*}.x" >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ steps.set_branch.outputs.branch }}
+          ref: ${{ github.ref_name }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
Previously, the action would trigger on a tag like `v7.12.3` and would then use regex to checkout `v7.12.x`, which it would use for generating goreleaser artifacts.

If I'm parsing things correctly, this means that creating a tag and then adding extra commits on top of 7.12.x _could_ cause us to build the wrong thing if the tag is pushed after the extra commits.

Instead, this just checks out whatever github ref triggered the action and builds that.