### PR TITLE
Correct deprecated handling logic

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -615,21 +615,9 @@ func handleDeprecatedConfig() {
 			} else {
 				for _, rep := range replacement {
 					log.Warningf("The configuration key '%s' is deprecated. Please use '%s' instead.", deprecated, rep)
-					// value := viper.Get(deprecated)
-					// viper.SetDefault(rep, value)
+					value := viper.Get(deprecated)
+					viper.SetDefault(rep, value)
 
-					// Retrieve current values
-					currentValue := viper.Get(deprecated)
-					previousValue := viper.Get(rep)
-
-					// Set the new value
-					viper.SetDefault(rep, currentValue)
-
-					// Log the event
-					log.Warningf(
-						"Transferred value from deprecated key '%s' to new key '%s'. Deprecated value: '%v'. Previous value of new key: '%v'.",
-						deprecated, rep, currentValue, previousValue,
-					)
 				}
 			}
 		}


### PR DESCRIPTION
This PR corrects the handling of deprecated configuration parameters.

Before this PR, we handled the deprecation of parameters in the `InitConfig` function by overriding the default of the new parameter with the value of the old parameter if it was set. However, with that setup, the default value was being overridden in the `SetClientDefaults` and `SetServerDefaults` functions when the client and server were initialized.

With this PR, the deprecation handling logic is moved to the end of the `SetClientDefaults` and `SetServerDefaults` functions, after the defaults for the client and server are set, ensuring they are not overridden.

Also, even with these changes in place, there is an issue where any configuration parameter that replaces a deprecated parameter and whose value comes from `defaults.yaml` causes the deprecation handling logic to break. This is described in issue #1870.