### PR TITLE
Fix logic for handling deprecated configuration parameters

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -610,22 +610,17 @@ func handleDeprecatedConfig() {
 	deprecatedMap := param.GetDeprecated()
 	for deprecated, replacement := range deprecatedMap {
 		if viper.IsSet(deprecated) {
-			if len(replacement) == 1 {
-				if replacement[0] == "none" {
-					log.Warningf("Deprecated configuration key %s is set. This is being removed in future release", deprecated)
-				} else {
-					log.Warningf("Deprecated configuration key %s is set. Please migrate to use %s instead", deprecated, replacement[0])
-					log.Warningf("Will attempt to use the value of %s as default for %s", deprecated, replacement[0])
-					value := viper.Get(deprecated)
-					viper.SetDefault(replacement[0], value)
-				}
+			if replacement[0] == "none" {
+				log.Warningf("Deprecated configuration key %s is set. This is being removed in future release", deprecated)
 			} else {
-				log.Warningf("Deprecated configuration key %s is set. This is being replaced by %s instead", deprecated, replacement)
-				log.Warningf("Setting default values of '%s' to the value of %s.", replacement, deprecated)
-
-				value := viper.Get(deprecated)
 				for _, rep := range replacement {
-					viper.SetDefault(rep, value)
+					if viper.IsSet(rep) {
+						log.Warningf("The configuration key '%s' is deprecated. The value from its replacement '%s' will be used instead, and the value of the deprecated configuration key '%s' will be ignored.", deprecated, rep, deprecated)
+					} else {
+						log.Warningf("The configuration key '%s' is deprecated. Please use '%s' instead. Will use the value of deprecated config key '%s' for the new config key '%s'.", deprecated, rep, deprecated, rep)
+						value := viper.Get(deprecated)
+						viper.Set(rep, value)
+					}
 				}
 			}
 		}
@@ -1044,12 +1039,7 @@ func SetServerDefaults(v *viper.Viper) error {
 		v.SetDefault(param.Origin_RunLocation.GetName(), filepath.Join("/run", "pelican", "xrootd", "origin"))
 		v.SetDefault(param.Cache_RunLocation.GetName(), filepath.Join("/run", "pelican", "xrootd", "cache"))
 
-		// Several deprecated keys point to Cache.StorageLocation, and by the time we reach this section of code, we should
-		// have already mapped those keys in handleDeprecatedConfig(). To prevent overriding potentially-mapped deprecated keys,
-		// we only re-set he default here if this key is not set.
-		if !v.IsSet(param.Cache_StorageLocation.GetName()) {
-			v.SetDefault(param.Cache_StorageLocation.GetName(), filepath.Join("/run", "pelican", "cache"))
-		}
+		v.SetDefault(param.Cache_StorageLocation.GetName(), filepath.Join("/run", "pelican", "cache"))
 		v.SetDefault(param.Cache_NamespaceLocation.GetName(), filepath.Join(param.Cache_StorageLocation.GetString(), "namespace"))
 		v.SetDefault(param.Cache_DataLocations.GetName(), []string{filepath.Join(param.Cache_StorageLocation.GetString(), "data")})
 		v.SetDefault(param.Cache_MetaLocations.GetName(), []string{filepath.Join(param.Cache_StorageLocation.GetString(), "meta")})
@@ -1083,33 +1073,15 @@ func SetServerDefaults(v *viper.Viper) error {
 			runtimeDir = filepath.Join(os.Getenv("XDG_RUNTIME_DIR"), "pelican")
 		}
 
-		if !v.IsSet(param.Cache_RunLocation.GetName()) {
-			if v.IsSet(param.Xrootd_RunLocation.GetName()) {
-				v.SetDefault(param.Cache_RunLocation.GetName(), v.GetString(param.Xrootd_RunLocation.GetName()))
-			} else {
-				v.SetDefault(param.Cache_RunLocation.GetName(), filepath.Join(runtimeDir, "cache"))
-			}
-		}
-
-		if !v.IsSet(param.Origin_RunLocation.GetName()) {
-			if v.IsSet(param.Xrootd_RunLocation.GetName()) {
-				v.SetDefault(param.Origin_RunLocation.GetName(), v.GetString(param.Xrootd_RunLocation.GetName()))
-			} else {
-				v.SetDefault(param.Origin_RunLocation.GetName(), filepath.Join(runtimeDir, "origin"))
-			}
-		}
+		v.SetDefault(param.Cache_RunLocation.GetName(), filepath.Join(runtimeDir, "cache"))
+		v.SetDefault(param.Origin_RunLocation.GetName(), filepath.Join(runtimeDir, "origin"))
 
 		v.SetDefault(param.Origin_GlobusConfigLocation.GetName(), filepath.Join(runtimeDir, "xrootd", "origin", "globus"))
 
-		// Several deprecated keys point to Cache.StorageLocation, and by the time we reach this section of code, we should
-		// have already mapped those keys in handleDeprecatedConfig(). To prevent overriding potentially-mapped deprecated keys,
-		// we only re-set he default here if this key is not set.
-		if !viper.IsSet(param.Cache_StorageLocation.GetName()) {
-			viper.SetDefault(param.Cache_StorageLocation.GetName(), filepath.Join(runtimeDir, "cache"))
-		}
-		viper.SetDefault(param.Cache_NamespaceLocation.GetName(), filepath.Join(param.Cache_StorageLocation.GetString(), "namespace"))
-		viper.SetDefault(param.Cache_DataLocations.GetName(), []string{filepath.Join(param.Cache_StorageLocation.GetString(), "data")})
-		viper.SetDefault(param.Cache_MetaLocations.GetName(), []string{filepath.Join(param.Cache_StorageLocation.GetString(), "meta")})
+		v.SetDefault(param.Cache_StorageLocation.GetName(), filepath.Join(runtimeDir, "cache"))
+		v.SetDefault(param.Cache_NamespaceLocation.GetName(), filepath.Join(param.Cache_StorageLocation.GetString(), "namespace"))
+		v.SetDefault(param.Cache_DataLocations.GetName(), []string{filepath.Join(param.Cache_StorageLocation.GetString(), "data")})
+		v.SetDefault(param.Cache_MetaLocations.GetName(), []string{filepath.Join(param.Cache_StorageLocation.GetString(), "meta")})
 
 		v.SetDefault(param.LocalCache_RunLocation.GetName(), filepath.Join(runtimeDir, "cache"))
 		v.SetDefault(param.Origin_Multiuser.GetName(), false)

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -60,7 +60,7 @@ description: |+
   When set to true, Pelican will skip TLS verification. This allows a "man in the middle" attack on the connection but can simplify testing.  Intended for developers.
 type: bool
 default: false
-components: ["origin", "registry", "director"]
+components: ["cache", "director", "origin", "registry"]
 ---
 name: IssuerKey
 description: |+
@@ -1788,7 +1788,7 @@ components: ["registry"]
 ############################
 name: Server.TLSCertificate
 description: |+
-  A filepath to a file containing an X.509 host certificate to use for TLS
+  [Deprecated] A filepath to a file containing an X.509 host certificate to use for TLS
   authentication when running server components of Pelican.
 
   If you override this filepath, you need to provide the matched-pair private key
@@ -1798,7 +1798,7 @@ root_default: /etc/pelican/certificates/tls.crt
 default: "$ConfigBase/certificates/tls.crt"
 deprecated: true
 replacedby: "Server.TLSCertificateChain"
-components: ["origin", "registry", "director"]
+components: ["cache", "director", "origin", "registry"]
 ---
 name: Server.TLSCertificateChain
 description: |+
@@ -1810,7 +1810,7 @@ description: |+
 type: filename
 root_default: /etc/pelican/certificates/tls.crt
 default: "$ConfigBase/certificates/tls.crt"
-components: ["origin", "registry", "director"]
+components: ["cache", "director", "origin", "registry"]
 ---
 name: Server.TLSCACertificateFile
 description: |+
@@ -1821,7 +1821,7 @@ description: |+
 type: filename
 root_default: /etc/pelican/certificates/tlsca.pem
 default: "$ConfigBase/certificates/tlsca.pem"
-components: ["origin", "registry", "director"]
+components: ["cache", "director", "origin", "registry"]
 ---
 name: Server.TLSCACertificateDirectory
 description: |+
@@ -1832,7 +1832,7 @@ description: |+
   over Server.TLSCACertificateFile.
 type: string
 default: none
-components: ["origin", "registry", "director"]
+components: ["cache", "director", "origin", "registry"]
 ---
 name: Server.TLSCAKey
 description: |+
@@ -1841,7 +1841,7 @@ description: |+
 type: filename
 root_default: /etc/pelican/certificates/tlsca.key
 default: "$ConfigBase/certificates/tlsca.key"
-components: ["origin", "registry", "director"]
+components: ["cache", "director", "origin", "registry"]
 ---
 name: Server.TLSKey
 description: |+
@@ -1851,7 +1851,7 @@ description: |+
 type: filename
 root_default: /etc/pelican/certificates/tls.key
 default: "$ConfigBase/certificates/tls.key"
-components: ["origin", "registry", "director"]
+components: ["cache", "director", "origin", "registry"]
 ---
 name: Server.EnableUI
 description: |+
@@ -1865,14 +1865,14 @@ description: |+
   The port number the Pelican web interface and internal web APIs will be bound to.
 type: int
 default: 8444
-components: ["origin", "director", "registry"]
+components: ["cache", "director", "origin", "registry"]
 ---
 name: Server.WebHost
 description: |+
   A string-encoded IP address that the Pelican web engine is configured to listen on.
 type: string
 default: "0.0.0.0"
-components: ["origin", "director", "registry"]
+components: ["cache", "director", "origin", "registry"]
 ---
 name: Server.ExternalWebUrl
 description: |+
@@ -1881,14 +1881,14 @@ description: |+
   Port number will be stripped if it's 443, from `Server.WebPort` or directly set through `Server.ExternalWebUrl`.
 type: url
 default: https://${Server.Hostname}:${Server.WebPort} (for ${Server.WebPort} != 443)
-components: ["origin", "director", "registry"]
+components: ["cache", "director", "origin", "registry"]
 ---
 name: Server.Hostname
 description: |+
   The server's hostname, by default it's os.Hostname().
 type: string
 default: none
-components: ["origin", "director", "registry"]
+components: ["cache", "director", "origin", "registry"]
 ---
 name: Server.IssuerUrl
 description: |+
@@ -1896,7 +1896,7 @@ description: |+
 type: string
 # Setting default to none for now because it changes based on server type and server mode.
 default: none
-components: ["origin", "director", "registry"]
+components: ["cache", "director", "origin", "registry"]
 ---
 name: Server.IssuerHostname
 description: |+
@@ -1904,7 +1904,7 @@ description: |+
 type: string
 # Setting default to none for now because it changes based on server type and server mode.
 default: none
-components: ["origin", "director", "registry"]
+components: ["cache", "director", "origin", "registry"]
 ---
 name: Server.IssuerPort
 description: |+
@@ -1912,14 +1912,14 @@ description: |+
 type: int
 # Setting default to none for now because it changes based on server type and server mode.
 default: none
-components: ["origin", "director", "registry"]
+components: ["cache", "director", "origin", "registry"]
 ---
 name: Server.IssuerJwks
 description: |+
   A filepath indicating where the server's public JSON web keyset can be found.
 type: filename
 default: none
-components: ["origin", "director", "registry"]
+components: ["cache", "director", "origin", "registry"]
 ---
 name: Server.Modules
 description: |+


### PR DESCRIPTION
This PR fixes the logic of handling for deprecated parameters. Before this PR, we were setting the values from the deprecated config parameters as the default for the values of the new config parameters. However, these defaults from deprecated config params were overwritten when the server or client were initialized.

This PR adds changes so that rather than setting the value from the deprecated param as `viper.SetDefault` on the new config parameter, it uses `viper.Set` if the new config param is not set.

There still remains the issue that if the default of the new config param comes from `defaults.yaml`, the deprecation handling logic would fail. Another issue #1870 is created to address this.