### PR TITLE
Use alma9 container for building prod pelican-server binaries

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -20,19 +20,47 @@ ARG BASE_YUM_REPO=release
 ARG BASE_OSG_SERIES=23
 ARG BASE_OS=el9
 
-FROM goreleaser/goreleaser:v1.21.0 AS pelican-build
+###########################
+# Pelican Build container #
+###########################
+# Building Pelican requires go, goreleaser, and packages for the web build
+FROM almalinux:9 AS pelican-build
 ARG IS_NONRELEASE_BUILD="true"
 
-RUN apk add --update nodejs-current npm
-
 WORKDIR /pelican
-
 COPY . .
 
+# Set the go environment variables, also picked up go goreleaser and used in the build
+# for constructing the directory binaries are built in (i.e. /pelican/dist/$GOOS_$GOARCH/pelican_$GOOS_$GOARCH_v1)
 ENV GOOS="linux"
 ENV GOARCH="amd64"
 
-RUN\
+# Install go
+RUN curl https://dl.google.com/go/go1.21.6.linux-$GOARCH.tar.gz -o go1.21.6.linux-$GOARCH.tar.gz && \
+    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.21.6.linux-$GOARCH.tar.gz
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# Make goreleaser installable with dnf by adding its repo
+# This is a bash-ism but on almalinux:9, /bin/sh _is_ bash so we don't need to change SHELL
+RUN echo $'[goreleaser] \n\
+name=GoReleaser \n\
+baseurl=https://repo.goreleaser.com/yum/ \n\
+enabled=1 \n\
+gpgcheck=0' > /etc/yum.repos.d/goreleaser.repo
+
+RUN dnf update -y && \
+    dnf install -y npm goreleaser
+
+# Use npm to install node
+RUN npm install -g n
+ENV PATH="${PATH}:/usr/lib/node_modules/npm/bin"
+
+# Ensure the correct version of Node.js is used
+RUN n 20 && \
+    npm install -g npm@latest && \
+    n prune
+
+RUN \
     if $IS_NONRELEASE_BUILD;\
         then goreleaser build --clean --snapshot --single-target;\
     else goreleaser build --clean --single-target;\
@@ -190,8 +218,8 @@ COPY --from=xrootd-plugin-builder /usr/lib64/libnlohmann_json_schema_validator.a
 COPY images/entrypoint.sh /entrypoint.sh
 
 # Copy here to reduce dependency on the pelican-build stage in the final-stage and x-base stage
-COPY --from=pelican-build /pelican/dist/pelican_linux_amd64_v1/pelican /usr/local/bin/pelican
-COPY --from=pelican-build /pelican/dist/pelican_linux_amd64_v1/pelican /usr/local/bin/osdf
+COPY --from=pelican-build /pelican/dist/linux_amd64/pelican_linux_amd64_v1/pelican /usr/local/bin/pelican
+COPY --from=pelican-build /pelican/dist/linux_amd64/pelican_linux_amd64_v1/pelican /usr/local/bin/osdf
 RUN    chmod +x /usr/local/bin/pelican \
     && chmod +x /usr/local/bin/osdf \
     && chmod +x /entrypoint.sh
@@ -215,8 +243,8 @@ RUN rm -f /usr/local/bin/pelican
 ####################
 
 FROM pelican-base AS cache
-RUN rm -f /usr/local/bin/pelican
-COPY --from=pelican-build /pelican/dist/pelican-server_linux_amd64_v1/pelican-server /usr/local/sbin/pelican-server
+RUN rm -f /usr/local/bin/pelican /usr/local/bin/osdf
+COPY --from=pelican-build /pelican/dist/linux_amd64/pelican-server_linux_amd64_v1/pelican-server /usr/local/sbin/pelican-server
 RUN chmod +x /usr/local/sbin/pelican-server
 # For now, we're only using pelican-server in the cache, but eventually we'll use it in all servers
 ENTRYPOINT [ "/entrypoint.sh", "pelican-server", "cache"]
@@ -258,8 +286,8 @@ CMD [ "serve" ]
 ####################
 
 FROM osdf-base AS osdf-cache
-RUN rm -rf /pelican/osdf
-COPY --from=pelican-build /pelican/dist/pelican-server_linux_amd64_v1/pelican-server /usr/local/sbin/osdf-server
+RUN rm -f /usr/local/bin/pelican /usr/local/bin/osdf
+COPY --from=pelican-build /pelican/dist/linux_amd64/pelican-server_linux_amd64_v1/pelican-server /usr/local/sbin/osdf-server
 RUN chmod +x /usr/local/sbin/osdf-server
 ENTRYPOINT [ "/entrypoint.sh" ,"osdf-server", "cache"]
 CMD [ "serve" ]


### PR DESCRIPTION
Prior to the introduction of the pelican-server binary, pelican was always statically-linked. However, pelican-sever needs to be dynamic so it can access the lotman shared library.

This caused an issue in our production cache containers because the pelican-server binary was built in an alpine container (inherited from the old goreleaser container) which uses libmusl for linking, but then copied into an Alma container in the final stage, where libmusl is unavailable.

In this fix, the base container used to build pelican binaries is switched from the goreleaser container to a raw alma9 container. A side effect of this is that we now have to install a few things we previously didn't. Another thing I can't readily explain is that making this change appears to have altered the path these binaries are built under from
`/pelican/dist/pelican_linux_amd64_v1/pelican`
to
`/pelican/dist/linux_amd64/pelican_linux_amd64_v1/pelican`

This doesn't appear to be an issue and was accounted for by changing a few paths in the Dockerfile. Famous last words?