### PR TITLE
Improve memory usage of the "stat cache"

### DIFF
--- a/client/fed_linux_test.go
+++ b/client/fed_linux_test.go
@@ -594,7 +594,7 @@ func TestSyncUpload(t *testing.T) {
 		require.NoError(t, err, "Error writing to new test file")
 
 		dirName := filepath.Base(tempDir)
-		uploadUrl := fmt.Sprintf("pelican://%s/first/namespace/sync_upload_none/%s/%s", discoveryUrl.Host, dirName, "test_single_upload")
+		uploadUrl := fmt.Sprintf("pelican://%s/first/namespace/sync_upload_file/%s/%s", discoveryUrl.Host, dirName, "test_single_upload")
 
 		// Upload the file
 		transferDetailsUpload, err := client.DoPut(fed.Ctx, newTestFile.Name(), uploadUrl, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))
@@ -635,7 +635,7 @@ func TestSyncUpload(t *testing.T) {
 		require.Equal(t, smallTestFileContent, string(contentBytes))
 
 		// Change the upload url to a collection
-		uploadUrl = fmt.Sprintf("pelican://%s/first/namespace/sync_upload_none/%s", discoveryUrl.Host, dirName)
+		uploadUrl = fmt.Sprintf("pelican://%s/first/namespace/sync_upload_file/%s", discoveryUrl.Host, dirName)
 
 		// Attempt to sync an upload of a single file to a collection, should fail
 		_, err = client.DoPut(fed.Ctx, smallTestFile.Name(), uploadUrl, true, client.WithTokenLocation(tempToken.Name()), client.WithSynchronize(client.SyncSize))

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1064,6 +1064,10 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 	tj.directorUrl = copyUrl.FedInfo.DirectorEndpoint
 	dirResp, err := GetDirectorInfoForPath(tj.ctx, &copyUrl, httpMethod, "")
 	if err != nil {
+		var sce *StatusCodeError
+		if errors.As(err, &sce) {
+			return
+		}
 		log.Errorln(err)
 		err = errors.Wrapf(err, "failed to get namespace information for remote URL %s", pUrl.String())
 		return
@@ -1081,6 +1085,10 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 		if contents != "" {
 			dirResp, err = GetDirectorInfoForPath(tj.ctx, &copyUrl, httpMethod, contents)
 			if err != nil {
+				var sce *StatusCodeError
+				if errors.As(err, &sce) {
+					return nil, err
+				}
 				log.Errorln(err)
 				err = errors.Wrapf(err, "failed to get namespace information for remote URL %s", copyUrl.String())
 				return nil, err

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -920,7 +920,7 @@ func TestPluginRecursiveDownload(t *testing.T) {
 		results := make(chan *classads.ClassAd, 5)
 		err = runPluginWorker(fed.Ctx, false, workChan, results)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "Failed to create new transfer job: no collections URL found in director response")
+		assert.Regexp(t, "Failed to create new transfer job: error while querying the director at https://[A-Za-z0-9:.-]+: server returned 404 Not Found", err.Error())
 	})
 }
 

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -50,7 +50,12 @@ Director:
   MinStatResponse: 1
   MaxStatResponse: 1
   StatTimeout: 2000ms
-  StatConcurrencyLimit: 1000
+  # This was decreased from the origin value of `1000` to `100` to
+  # reduce the potential memory use (each service could have up to
+  # `StatConcurrencyLimit` goroutines running in parallel).  It's
+  # unclear whether having more than 100 concurrent queries to the
+  # remote origin/cache is a good idea anyway...
+  StatConcurrencyLimit: 100
   AdvertisementTTL: 15m
   OriginCacheHealthTestInterval: 15s
   EnableBroker: true
@@ -58,7 +63,10 @@ Director:
   CheckCachePresence: true
   AssumePresenceAtSingleOrigin: true
   CachePresenceTTL: 1m
-  CachePresenceCapacity: 10000
+  # This was originally 10k entries; after some informal measurements,
+  # it seems golang uses 500 - 1000 bytes per entry; a reduction to
+  # 2k means there will be around 1-2MB of cached data per server.
+  CachePresenceCapacity: 2000
 Cache:
   DefaultCacheTimeout: "9.5s"
   Port: 8442

--- a/director/advertise_test.go
+++ b/director/advertise_test.go
@@ -162,8 +162,13 @@ func TestParseServerAdFromTopology(t *testing.T) {
 
 	t.Run("test-invalid-url", func(t *testing.T) {
 		// Capture logs
+		originalHooks := logrus.StandardLogger().Hooks
+		logrus.StandardLogger().Hooks = make(logrus.LevelHooks)
 		hook := logrustest.NewLocal(logrus.StandardLogger())
-		defer hook.Reset()
+		defer func() {
+			hook.Reset()
+			logrus.StandardLogger().Hooks = originalHooks
+		}()
 
 		server.Endpoint = "http://a server "
 		server.AuthEndpoint = "https://a different server "

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -169,7 +169,6 @@ func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]
 					ttlcache.WithDisableTouchOnHit[string, *objectMetadata](),
 					ttlcache.WithCapacity[string, *objectMetadata](uint64(cap)),
 				),
-				Generation: int(statUtilsGen.Add(1)),
 			}
 			log.Debugln("Creating a new stat cache with capacity", cap, "for endpoint ", ad.URL.String())
 			// The result cache TTL is stopped when the `serverAds` struct is evicted.  This  occurs

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -149,6 +149,7 @@ func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]
 			// we don't want to permit an unbounded number of queries due to potential
 			// memory usage.
 			if concLimit <= 0 {
+				log.Warningln("Concurrency limit 'Director.StatConcurrencyLimit' must be positive; ignoring value", concLimit, "and using 100 instead")
 				concLimit = 100
 			}
 			statErrGrp := utils.Group{}
@@ -158,6 +159,7 @@ func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]
 			// "unbounded" (bad) and a negative value gets cast to uint64,
 			// becoming an effectively unbounded number (also bad)
 			if cap <= 0 {
+				log.Warningln("Object presence cache limit 'Director.CachePresenceCapacity' must be positive; ignoring value", cap, "and using 100 instead")
 				cap = 100
 			}
 			newUtil := serverStatUtil{

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -438,7 +438,7 @@ func TestRecordAd(t *testing.T) {
 			defer statUtilsMutex.Unlock()
 			defer healthTestUtilsMutex.Unlock()
 			healthTestUtils = make(map[string]*healthTestUtil)
-			statUtils = make(map[string]serverStatUtil)
+			statUtils = make(map[string]*serverStatUtil)
 
 			serverAds.DeleteAll()
 			geoNetOverrides = nil
@@ -452,7 +452,7 @@ func TestRecordAd(t *testing.T) {
 			defer statUtilsMutex.Unlock()
 			defer healthTestUtilsMutex.Unlock()
 			healthTestUtils = make(map[string]*healthTestUtil)
-			statUtils = make(map[string]serverStatUtil)
+			statUtils = make(map[string]*serverStatUtil)
 
 			serverAds.DeleteAll()
 		}()

--- a/director/director.go
+++ b/director/director.go
@@ -102,7 +102,7 @@ var (
 	healthTestUtils      = make(map[string]*healthTestUtil) // The utilities for the director file tests. The key is string form of ServerAd.URL
 	healthTestUtilsMutex = sync.RWMutex{}
 
-	statUtils      = make(map[string]serverStatUtil) // The utilities for the stat call. The key is string form of ServerAd.URL
+	statUtils      = make(map[string]*serverStatUtil) // The utilities for the stat call. The key is string form of ServerAd.URL
 	statUtilsMutex = sync.RWMutex{}
 )
 

--- a/director/director.go
+++ b/director/director.go
@@ -424,7 +424,7 @@ func redirectToCache(ginCtx *gin.Context) {
 		maxRes := len(cacheAds) + len(originAds)
 		qr := q.Query(context.Background(), reqPath, st, 1, maxRes,
 			withOriginAds(originAds), withCacheAds(cacheAds), WithToken(reqParams.Get("authz")))
-		log.Debugf("Stat result for %s: %s", reqPath, qr.String())
+		log.Debugf("Cache stat result for %s: %s", reqPath, qr.String())
 
 		// For successful response, we got a list of URLs to access the object.
 		// We will use the host of the object url to match the URL field in originAds and cacheAds
@@ -443,7 +443,13 @@ func redirectToCache(ginCtx *gin.Context) {
 				}
 			}
 		} else if qr.Status == queryFailed {
-			if qr.ErrorType != queryInsufficientResErr {
+			if qr.ErrorType == queryNoSourcesErr {
+				ginCtx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
+					Status: server_structs.RespFailed,
+					Msg:    "Object not found at any cache",
+				})
+				return
+			} else if qr.ErrorType != queryInsufficientResErr {
 				ginCtx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 					Status: server_structs.RespFailed,
 					Msg:    fmt.Sprintf("Failed to query origins with error %s: %s", string(qr.ErrorType), qr.Msg),
@@ -626,7 +632,7 @@ func redirectToOrigin(ginCtx *gin.Context) {
 		q = NewObjectStat()
 		qr := q.Query(context.Background(), reqPath, server_structs.OriginType, 1, 3,
 			withOriginAds(originAds), WithToken(reqParams.Get("authz")), withAuth(!namespaceAd.Caps.PublicReads))
-		log.Debugf("Stat result for %s: %s", reqPath, qr.String())
+		log.Debugf("Origin stat result for %s: %s", reqPath, qr.String())
 
 		// For a successful response, we got a list of object URLs.
 		// We then use the host of the object url to match the URL field in originAds
@@ -642,7 +648,12 @@ func redirectToOrigin(ginCtx *gin.Context) {
 				}
 			}
 		} else if qr.Status == queryFailed {
-			if qr.ErrorType != queryInsufficientResErr {
+			if qr.ErrorType == queryNoSourcesErr {
+				ginCtx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
+					Status: server_structs.RespFailed,
+					Msg:    "All sources report object was not found",
+				})
+			} else if qr.ErrorType != queryInsufficientResErr {
 				ginCtx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 					Status: server_structs.RespFailed,
 					Msg:    fmt.Sprintf("Failed to query origins with error %s: %s", string(qr.ErrorType), qr.Msg),

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -96,6 +96,7 @@ func LaunchTTLCache(ctx context.Context, egrp *errgroup.Group) {
 	// Start automatic expired item deletion
 	go serverAds.Start()
 	go namespaceKeys.Start()
+	go clientIpCache.Start()
 
 	serverAds.OnEviction(func(ctx context.Context, er ttlcache.EvictionReason, i *ttlcache.Item[string, *server_structs.Advertisement]) {
 		serverAd := i.Value().ServerAd
@@ -158,6 +159,8 @@ func LaunchTTLCache(ctx context.Context, egrp *errgroup.Group) {
 		serverAds.Stop()
 		namespaceKeys.DeleteAll()
 		namespaceKeys.Stop()
+		clientIpCache.DeleteAll()
+		clientIpCache.Stop()
 		log.Info("Director TTL cache eviction has been stopped")
 		return nil
 	})

--- a/director/resources/director-public.yaml
+++ b/director/resources/director-public.yaml
@@ -1,0 +1,23 @@
+
+Server:
+  EnablePprof: true
+
+Logging:
+  Level: debug
+
+Director:
+  # For the director stress unit test, we want to force the pelican
+  # process to perform the stat and cache the result; this is more likely
+  # to trigger any memory hoarding issues.
+  #AssumePresenceAtSingleOrigin: false
+  CachePresenceCapacity: 100
+
+Origin:
+  # Things that configure the origin itself
+  StorageType: "posix"
+  EnableDirectReads: true
+  # The actual namespaces we export
+  Exports:
+    - StoragePrefix: /<SHOULD BE OVERRIDDEN>
+      FederationPrefix: /first/namespace
+      Capabilities: ["PublicReads", "DirectReads", "Listings"]

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -54,9 +54,13 @@ func TestCheckOverrides(t *testing.T) {
 
 	// We'll also check that our logging feature responsibly reports
 	// what Pelican is telling the user.
+	origOutput := log.StandardLogger().Out
 	logOutput := &(bytes.Buffer{})
 	log.SetOutput(logOutput)
 	log.SetLevel(log.DebugLevel)
+	t.Cleanup(func() {
+		log.SetOutput(origOutput)
+	})
 
 	viper.SetConfigType("yaml")
 	err := viper.ReadConfig(strings.NewReader(yamlMockup))
@@ -462,9 +466,13 @@ func TestGetClientLatLong(t *testing.T) {
 	clientIpCache.DeleteAll()
 	t.Run("invalid-ip", func(t *testing.T) {
 		// Capture the log and check that the correct error is logged
+		origOutput := log.StandardLogger().Out
 		logOutput := &(bytes.Buffer{})
 		log.SetOutput(logOutput)
 		log.SetLevel(log.DebugLevel)
+		defer func() {
+			log.SetOutput(origOutput)
+		}()
 
 		clientIp := netip.Addr{}
 		assert.False(t, clientIpCache.Has(clientIp))
@@ -485,8 +493,12 @@ func TestGetClientLatLong(t *testing.T) {
 
 	t.Run("valid-ip-no-geoip-match", func(t *testing.T) {
 		logOutput := &(bytes.Buffer{})
+		origOutput := log.StandardLogger().Out
 		log.SetOutput(logOutput)
 		log.SetLevel(log.DebugLevel)
+		defer func() {
+			log.SetOutput(origOutput)
+		}()
 
 		clientIp := netip.MustParseAddr("192.168.0.1")
 		assert.False(t, clientIpCache.Has(clientIp))

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -481,13 +481,13 @@ func TestGetClientLatLong(t *testing.T) {
 		assert.True(t, coord1.Lat <= usLatMax && coord1.Lat >= usLatMin)
 		assert.True(t, coord1.Long <= usLongMax && coord1.Long >= usLongMin)
 		assert.Contains(t, logOutput.String(), "Unable to sort servers based on client-server distance. Invalid client IP address")
-		assert.NotContains(t, logOutput.String(), "Retrieving pre-assigned lat/long")
+		assert.NotContains(t, logOutput.String(), "Using randomly-assigned lat/long")
 
 		// Get it again to make sure it's coming from the cache
 		coord2, _ := getClientLatLong(clientIp)
 		assert.Equal(t, coord1.Lat, coord2.Lat)
 		assert.Equal(t, coord1.Long, coord2.Long)
-		assert.Contains(t, logOutput.String(), "Retrieving pre-assigned lat/long for unresolved client IP")
+		assert.Contains(t, logOutput.String(), "Using randomly-assigned lat/long for unresolved client IP")
 		assert.True(t, clientIpCache.Has(clientIp))
 	})
 
@@ -507,13 +507,13 @@ func TestGetClientLatLong(t *testing.T) {
 		assert.True(t, coord1.Lat <= usLatMax && coord1.Lat >= usLatMin)
 		assert.True(t, coord1.Long <= usLongMax && coord1.Long >= usLongMin)
 		assert.Contains(t, logOutput.String(), "Client IP 192.168.0.1 has been re-assigned a random location in the contiguous US to lat/long")
-		assert.NotContains(t, logOutput.String(), "Retrieving pre-assigned lat/long")
+		assert.NotContains(t, logOutput.String(), "Using randomly-assigned lat/long")
 
 		// Get it again to make sure it's coming from the cache
 		coord2, _ := getClientLatLong(clientIp)
 		assert.Equal(t, coord1.Lat, coord2.Lat)
 		assert.Equal(t, coord1.Long, coord2.Long)
-		assert.Contains(t, logOutput.String(), "Retrieving pre-assigned lat/long for client IP")
+		assert.Contains(t, logOutput.String(), "Using randomly-assigned lat/long for client IP")
 		assert.True(t, clientIpCache.Has(clientIp))
 	})
 }

--- a/director/stat.go
+++ b/director/stat.go
@@ -273,7 +273,7 @@ func getStatUtils(ads []server_structs.ServerAd) map[string]*serverStatUtil {
 		url := ad.URL.String()
 		statUtil, ok := statUtils[url]
 		if ok {
-			result[url] = &statUtil
+			result[url] = statUtil
 		}
 	}
 	return result
@@ -457,7 +457,7 @@ func (stat *ObjectStat) queryServersForObject(ctx context.Context, objectName st
 				// then we assume this is a "hot" object and we'll benefit from the preemptively refreshing
 				// the ttlcache.  If we can, asynchronously query the service.
 				if time.Until(item.ExpiresAt()) < 10*time.Second {
-					statUtil.Errgroup.TryGo(func() (err error) { _, err = queryFunc(); return })
+					statUtil.Errgroup.TryGo(func() error { queryFunc(); return nil })
 				}
 				totalLabels["cached_result"] = "true"
 				if metadata := item.Value(); metadata != nil {

--- a/director/stat.go
+++ b/director/stat.go
@@ -116,6 +116,7 @@ const (
 	queryParameterErr       queryErrorType = "ParameterError"
 	queryNoPrefixMatchErr   queryErrorType = "NoPrefixMatchError"
 	queryInsufficientResErr queryErrorType = "InsufficientResError"
+	queryNoSourcesErr       queryErrorType = "NoSources"
 	queryCancelledErr       queryErrorType = "CancelledError"
 )
 
@@ -125,6 +126,11 @@ func (e *headReqTimeoutErr) Error() string {
 
 func (e *headReqNotFoundErr) Error() string {
 	return e.Message
+}
+
+func (*headReqNotFoundErr) Is(target error) bool {
+	_, ok := target.(*headReqNotFoundErr)
+	return ok
 }
 
 func (e *headReqForbiddenErr) Error() string {
@@ -334,6 +340,8 @@ func (stat *ObjectStat) queryServersForObject(ctx context.Context, objectName st
 	// Cancel the rest of the requests when requests received >= max required
 	maxCancelCtx, maxCancel := context.WithCancel(ctx)
 	numTotalReq := 0
+	// Track the number of responses we got received indicating "file not found"
+	numFileNotFound := 0
 	successResult := make([]*objectMetadata, 0)
 	deniedResult := make([]*headReqForbiddenErr, 0)
 
@@ -457,7 +465,7 @@ func (stat *ObjectStat) queryServersForObject(ctx context.Context, objectName st
 				// then we assume this is a "hot" object and we'll benefit from the preemptively refreshing
 				// the ttlcache.  If we can, asynchronously query the service.
 				if time.Until(item.ExpiresAt()) < 10*time.Second {
-					statUtil.Errgroup.TryGo(func() error { queryFunc(); return nil })
+					statUtil.Errgroup.TryGo(func() error { _, _ = queryFunc(); return nil })
 				}
 				totalLabels["cached_result"] = "true"
 				if metadata := item.Value(); metadata != nil {
@@ -482,7 +490,10 @@ func (stat *ObjectStat) queryServersForObject(ctx context.Context, objectName st
 		case deErr := <-deniedReqChan:
 			numTotalReq += 1
 			deniedResult = append(deniedResult, deErr)
-		case <-negativeReqChan:
+		case negErr := <-negativeReqChan:
+			if errors.Is(negErr, &headReqNotFoundErr{}) {
+				numFileNotFound += 1
+			}
 			numTotalReq += 1
 		case metaRes := <-positiveReqChan:
 			numTotalReq += 1
@@ -505,7 +516,14 @@ func (stat *ObjectStat) queryServersForObject(ctx context.Context, objectName st
 			// All requests finished
 			if numTotalReq == len(ads) {
 				maxCancel()
-				if len(successResult) < minReq {
+				if len(successResult) == 0 && numFileNotFound > 0 && numFileNotFound >= minReq && numTotalReq == numFileNotFound {
+					// In this case, we had a quorum of origins indicating this object didn't exist, no servers
+					// showing an unknown status (HTTP 500, HTTP 403, etc).  We're fairly sure the object doesn't exist.
+					qResult.Status = queryFailed
+					qResult.ErrorType = queryNoSourcesErr
+					qResult.Msg = "Object does not exist."
+					return
+				} else if len(successResult) < minReq {
 					qResult.Status = queryFailed
 					qResult.ErrorType = queryInsufficientResErr
 					qResult.Msg = fmt.Sprintf("Number of success response: %d is less than MinStatResponse (%d) required.", len(successResult), minReq)

--- a/director/stat_stress_test.go
+++ b/director/stat_stress_test.go
@@ -1,0 +1,107 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package director_test
+
+import (
+	_ "embed"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/fed_test_utils"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
+)
+
+var (
+	//go:embed resources/director-public.yaml
+	directorPublicCfg string
+)
+
+// A stress test for the director's memory cache
+//
+// Try to download as many non-existent objects as possible within a limited timeframe.
+// The goal is to generate significant load on the "statUtils" cache within the director
+// and related code to see if we can generate memory leaks / hoarding.
+func TestStatMemory(t *testing.T) {
+	server_utils.ResetTestState()
+
+	fed := fed_test_utils.NewFedTest(t, directorPublicCfg)
+	discoveryUrl, err := url.Parse(param.Federation_DiscoveryUrl.GetString())
+	assert.NoError(t, err)
+
+	grp, _ := errgroup.WithContext(fed.Ctx)
+	grp.SetLimit(10)
+	idx := 0
+	start := time.Now()
+	dest := filepath.Join(t.TempDir(), "dest.txt")
+
+	for time.Since(start) < (time.Second) {
+		downloadURL := fmt.Sprintf("pelican://%s%s/stress/%v.txt", discoveryUrl.Host, fed.Exports[0].FederationPrefix, idx)
+		grp.Go(func() error {
+			_, err := client.DoGet(fed.Ctx, downloadURL, dest, false)
+			assert.Error(t, err)
+			return nil
+		})
+		idx += 1
+	}
+	assert.NoError(t, grp.Wait())
+	origIdx := idx
+
+	runtime.GC()
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	goCnt := runtime.NumGoroutine()
+
+	for time.Since(start) < 10*time.Second {
+		downloadURL := fmt.Sprintf("pelican://%s%s/stress/%v.txt", discoveryUrl.Host, fed.Exports[0].FederationPrefix, idx)
+		grp.Go(func() error {
+			_, err := client.DoGet(fed.Ctx, downloadURL, dest, false)
+			assert.Error(t, err)
+			return nil
+		})
+		idx += 1
+	}
+	assert.NoError(t, grp.Wait())
+
+	runtime.GC()
+	var afterStats runtime.MemStats
+	runtime.ReadMemStats(&afterStats)
+	afterGoCnt := runtime.NumGoroutine()
+
+	log.Infoln("Total number of queries processed:", idx, " increase after warm-up:", idx-origIdx)
+	log.Infoln("Heap alloc after warm-up:", stats.HeapAlloc)
+	log.Infoln("Heap alloc after test:", afterStats.HeapAlloc)
+	log.Infoln("Increase in heap size:", int64(afterStats.HeapAlloc)-int64(stats.HeapAlloc))
+	log.Infoln("Go routine count after warm-up:", goCnt)
+	log.Infoln("Go routine count after test:", afterGoCnt)
+
+	assert.Less(t, afterStats.HeapAlloc, stats.HeapAlloc+7e5)
+	assert.Less(t, afterGoCnt, goCnt+10)
+}

--- a/director/stat_test.go
+++ b/director/stat_test.go
@@ -780,13 +780,13 @@ func TestCache(t *testing.T) {
 		qResult := stat.queryServersForObject(ctx, "/foo/notfound.txt", server_structs.CacheType, 1, 1)
 		assert.Equal(t, queryFailed, qResult.Status)
 		assert.Len(t, qResult.Objects, 0)
-		assert.Equal(t, queryInsufficientResErr, qResult.ErrorType)
+		assert.Equal(t, queryNoSourcesErr, qResult.ErrorType)
 		require.Equal(t, startCtr+1, reqCounter)
 
 		qResult = stat.queryServersForObject(ctx, "/foo/notfound.txt", server_structs.CacheType, 1, 1)
 		assert.Equal(t, queryFailed, qResult.Status)
 		assert.Len(t, qResult.Objects, 0)
-		assert.Equal(t, queryInsufficientResErr, qResult.ErrorType)
+		assert.Equal(t, queryNoSourcesErr, qResult.ErrorType)
 		require.Equal(t, startCtr+1, reqCounter)
 	})
 }

--- a/director/stat_test.go
+++ b/director/stat_test.go
@@ -57,7 +57,7 @@ func initMockStatUtils() {
 
 	for _, key := range serverAds.Keys() {
 		ctx, cancel := context.WithCancel(context.Background())
-		statUtils[key] = serverStatUtil{
+		statUtils[key] = &serverStatUtil{
 			Context:     ctx,
 			Cancel:      cancel,
 			Errgroup:    &utils.Group{},
@@ -390,7 +390,7 @@ func TestQueryServersForObject(t *testing.T) {
 		mockCacheServer := []server_structs.ServerAd{{Name: "cache-overwrite", URL: url.URL{Host: "cache-overwrites.com", Scheme: "https"}}}
 
 		statUtilsMutex.Lock()
-		statUtils[mockCacheServer[0].URL.String()] = serverStatUtil{
+		statUtils[mockCacheServer[0].URL.String()] = &serverStatUtil{
 			Context:     ctx,
 			Cancel:      cancel,
 			Errgroup:    &utils.Group{},
@@ -425,7 +425,7 @@ func TestQueryServersForObject(t *testing.T) {
 		mockOrigin := []server_structs.ServerAd{{Name: "origin-overwrite", URL: url.URL{Host: "origin-overwrites.com", Scheme: "https"}}}
 
 		statUtilsMutex.Lock()
-		statUtils[mockOrigin[0].URL.String()] = serverStatUtil{
+		statUtils[mockOrigin[0].URL.String()] = &serverStatUtil{
 			Context:     ctx,
 			Cancel:      cancel,
 			Errgroup:    &utils.Group{},

--- a/director/stat_test.go
+++ b/director/stat_test.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -58,10 +59,12 @@ func initMockStatUtils() {
 	for _, key := range serverAds.Keys() {
 		ctx, cancel := context.WithCancel(context.Background())
 		statUtils[key] = &serverStatUtil{
-			Context:     ctx,
-			Cancel:      cancel,
-			Errgroup:    &utils.Group{},
-			ResultCache: ttlcache.New[string, *objectMetadata](),
+			Context:  ctx,
+			Cancel:   cancel,
+			Errgroup: &utils.Group{},
+			ResultCache: ttlcache.New[string, *objectMetadata](
+				ttlcache.WithTTL[string, *objectMetadata](300 * time.Minute),
+			),
 		}
 	}
 }
@@ -708,10 +711,10 @@ func TestCache(t *testing.T) {
 	viper.Set("Logging.Level", "Debug")
 	viper.Set("ConfigDir", t.TempDir())
 	config.InitConfig()
-	reqCounter := 0
+	var reqCounter atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		reqCounter += 1
+		reqCounter.Add(1)
 		log.Debugln("Mock server handling request for ", req.URL.String())
 		if req.Method == "HEAD" && req.URL.String() == "/foo/test.txt" {
 			rw.Header().Set("Content-Length", "1")
@@ -756,18 +759,18 @@ func TestCache(t *testing.T) {
 
 		stat := NewObjectStat()
 
-		startCtr := reqCounter
+		startCtr := reqCounter.Load()
 		qResult := stat.queryServersForObject(ctx, "/foo/test.txt", server_structs.CacheType, 1, 1)
 		assert.Equal(t, querySuccessful, qResult.Status)
 		require.Len(t, qResult.Objects, 1)
 		assert.Equal(t, 1, qResult.Objects[0].ContentLength)
-		require.Equal(t, startCtr+1, reqCounter)
+		require.Equal(t, startCtr+1, reqCounter.Load())
 
 		qResult = stat.queryServersForObject(ctx, "/foo/test.txt", server_structs.CacheType, 1, 1)
 		assert.Equal(t, querySuccessful, qResult.Status)
 		require.Len(t, qResult.Objects, 1)
 		assert.Equal(t, 1, qResult.Objects[0].ContentLength)
-		require.Equal(t, startCtr+1, reqCounter)
+		require.Equal(t, startCtr+1, reqCounter.Load())
 	})
 
 	t.Run("repeated-cache-access-not-found", func(t *testing.T) {
@@ -776,18 +779,18 @@ func TestCache(t *testing.T) {
 
 		stat := NewObjectStat()
 
-		startCtr := reqCounter
+		startCtr := reqCounter.Load()
 		qResult := stat.queryServersForObject(ctx, "/foo/notfound.txt", server_structs.CacheType, 1, 1)
 		assert.Equal(t, queryFailed, qResult.Status)
 		assert.Len(t, qResult.Objects, 0)
 		assert.Equal(t, queryNoSourcesErr, qResult.ErrorType)
-		require.Equal(t, startCtr+1, reqCounter)
+		require.Equal(t, startCtr+1, reqCounter.Load())
 
 		qResult = stat.queryServersForObject(ctx, "/foo/notfound.txt", server_structs.CacheType, 1, 1)
 		assert.Equal(t, queryFailed, qResult.Status)
 		assert.Len(t, qResult.Objects, 0)
 		assert.Equal(t, queryNoSourcesErr, qResult.ErrorType)
-		require.Equal(t, startCtr+1, reqCounter)
+		require.Equal(t, startCtr+1, reqCounter.Load())
 	})
 }
 

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1553,7 +1553,7 @@ description: |+
   See [golang.org/x/sync/errgroup](https://pkg.go.dev/golang.org/x/sync@v0.6.0/errgroup#Group.SetLimit)
   for detail
 type: int
-default: 1000
+default: 100
 components: ["director"]
 ---
 name: Director.AdvertisementTTL
@@ -1648,7 +1648,7 @@ description: |+
 
   This parameter controls how many responses, per-service, will be cached.
 type: int
-default: 10000
+default: 2000
 hidden: true
 components: ["director"]
 ---

--- a/github_scripts/get_put_test.sh
+++ b/github_scripts/get_put_test.sh
@@ -126,8 +126,9 @@ done
 # Run pelican object put
 ./pelican object put ./get_put_tmp/input.txt pelican://$HOSTNAME:8444/test/input.txt -d -t get_put_tmp/test-token.jwt -L get_put_tmp/putOutput.txt
 
-# Check output of command
-if grep -q "Dumping response: HTTP/1.1 200 OK" get_put_tmp/putOutput.txt; then
+# Check output of command.  Note we can accept either
+# 200 (old, incorrect response from XRootD but we accept it) or 201 (Created; correct)
+if grep -q "Dumping response: HTTP/1.1 20" get_put_tmp/putOutput.txt; then
     echo "Uploaded bytes successfully!"
 else
     echo "Did not upload correctly"

--- a/local_cache/cache_test.go
+++ b/local_cache/cache_test.go
@@ -333,6 +333,7 @@ func TestClient(t *testing.T) {
 		require.Error(t, err)
 		// TODO (bbockelm, 10-Jan-2025): It's surprising that the `client.DoGet` above is querying the director then the local cache.
 		// It seems like, in the local cache case, we should skip any director queries.
+		// See description in https://github.com/PelicanPlatform/pelican/issues/1929
 		assert.Regexp(t, "error while querying the director at https://[a-zA-Z0-9:.-]+: server returned 404 Not Found", err.Error())
 	})
 	t.Cleanup(func() {

--- a/local_cache/cache_test.go
+++ b/local_cache/cache_test.go
@@ -331,7 +331,9 @@ func TestClient(t *testing.T) {
 		_, err = client.DoGet(ctx, "pelican://"+param.Server_Hostname.GetString()+":"+strconv.Itoa(param.Server_WebPort.GetInt())+"/test/hello_world.txt.1",
 			filepath.Join(tmpDir, "hello_world.txt.1"), false, client.WithToken(token), client.WithCaches(cacheUrl), client.WithAcquireToken(false))
 		require.Error(t, err)
-		assert.Equal(t, "failed download from local-cache: server returned 404 Not Found", err.Error())
+		// TODO (bbockelm, 10-Jan-2025): It's surprising that the `client.DoGet` above is querying the director then the local cache.
+		// It seems like, in the local cache case, we should skip any director queries.
+		assert.Regexp(t, "error while querying the director at https://[a-zA-Z0-9:.-]+: server returned 404 Not Found", err.Error())
 	})
 	t.Cleanup(func() {
 		cancel()

--- a/metrics/director.go
+++ b/metrics/director.go
@@ -65,7 +65,7 @@ var (
 	PelicanDirectorMapItemsTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "pelican_director_map_items_total",
 		Help: "The total number of map items in the director, by the name of the map",
-	}, []string{"name"}) // name: healthTestUtils, filteredServers, originStatUtils
+	}, []string{"name"}) // name: healthTestUtils, filteredServers, serverStatUtils, serverStatEntries
 
 	PelicanDirectorTTLCache = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "pelican_director_ttl_cache",


### PR DESCRIPTION
This PR tidies up the "stat cache" code, attempting to get it to the point where it can be enabled in production again.

Fixes/changes include:
- Addition of a "memory stress test" that performs as many transfers as possible within a fixed time interval.  The goal is to fill the contents of the stat cache and check for leaks.
- Several small memory hoarding / leak issues fixed:
   - The admin can no longer accidentally make the cache unbounded by setting the size to 0 and the TTLcache goroutine eviction is now run.
   - The client IP cache similarly grew unbounded as the TTL cache goroutine is run.  Various log lines have been tidied up.
   - The stat cache is cleared after a server disappears.
- A prometheus metric was added to record the number of entries in the caches, not just the number of caches.
- If all the potential origins respond saying they do not have the object, then the director responds with a 404.  Previously, in this case it would claim to have insufficient responses and redirect to the origin that sent the 404 in the first place.
- Unit tests are updated for where error messages have changed.