### PR TITLE
Rejected Advertisement Metric

### DIFF
--- a/director/director.go
+++ b/director/director.go
@@ -1074,6 +1074,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 			if err == adminApprovalErr {
 				log.Warningf("Failed to verify token. %s %q was not approved", sType.String(), adV2.Name)
 				ctx.JSON(http.StatusForbidden, gin.H{"approval_error": true, "error": fmt.Sprintf("%s %q was not approved by an administrator. %s", sType.String(), ad.Name, approvalErrMsg)})
+				metrics.PelicanDirectorRejectedAdvertisements.Inc()
 				return
 			} else {
 				log.Warningln("Failed to verify token:", err)
@@ -1081,6 +1082,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 					Status: server_structs.RespFailed,
 					Msg:    fmt.Sprintf("Authorization token verification failed %v", err),
 				})
+				metrics.PelicanDirectorRejectedAdvertisements.Inc()
 				return
 			}
 		}
@@ -1090,6 +1092,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 				Status: server_structs.RespFailed,
 				Msg:    "Authorization token verification failed. Token missing required scope",
 			})
+			metrics.PelicanDirectorRejectedAdvertisements.Inc()
 			return
 		}
 	}
@@ -1104,6 +1107,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 				if err == adminApprovalErr {
 					log.Warningf("Failed to verify advertise token. Namespace %q requires administrator approval", namespace.Path)
 					ctx.JSON(http.StatusForbidden, gin.H{"approval_error": true, "error": fmt.Sprintf("The namespace %q was not approved by an administrator. %s", namespace.Path, approvalErrMsg)})
+					metrics.PelicanDirectorRejectedAdvertisements.Inc()
 					return
 				} else {
 					log.Warningln("Failed to verify token:", err)
@@ -1111,6 +1115,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 						Status: server_structs.RespFailed,
 						Msg:    fmt.Sprintf("Authorization token verification failed: %v", err),
 					})
+					metrics.PelicanDirectorRejectedAdvertisements.Inc()
 					return
 				}
 			}
@@ -1121,6 +1126,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 					Status: server_structs.RespFailed,
 					Msg:    "Authorization token verification failed. Token missing required scope",
 				})
+				metrics.PelicanDirectorRejectedAdvertisements.Inc()
 				return
 			}
 		}

--- a/director/director.go
+++ b/director/director.go
@@ -1074,7 +1074,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 			if err == adminApprovalErr {
 				log.Warningf("Failed to verify token. %s %q was not approved", sType.String(), adV2.Name)
 				ctx.JSON(http.StatusForbidden, gin.H{"approval_error": true, "error": fmt.Sprintf("%s %q was not approved by an administrator. %s", sType.String(), ad.Name, approvalErrMsg)})
-				metrics.PelicanDirectorRejectedAdvertisements.Inc()
+				metrics.PelicanDirectorRejectedAdvertisements.With(prometheus.Labels{"hostname": adV2.Name}).Inc()
 				return
 			} else {
 				log.Warningln("Failed to verify token:", err)
@@ -1082,7 +1082,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 					Status: server_structs.RespFailed,
 					Msg:    fmt.Sprintf("Authorization token verification failed %v", err),
 				})
-				metrics.PelicanDirectorRejectedAdvertisements.Inc()
+				metrics.PelicanDirectorRejectedAdvertisements.With(prometheus.Labels{"hostname": adV2.Name}).Inc()
 				return
 			}
 		}
@@ -1092,7 +1092,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 				Status: server_structs.RespFailed,
 				Msg:    "Authorization token verification failed. Token missing required scope",
 			})
-			metrics.PelicanDirectorRejectedAdvertisements.Inc()
+			metrics.PelicanDirectorRejectedAdvertisements.With(prometheus.Labels{"hostname": adV2.Name}).Inc()
 			return
 		}
 	}
@@ -1107,7 +1107,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 				if err == adminApprovalErr {
 					log.Warningf("Failed to verify advertise token. Namespace %q requires administrator approval", namespace.Path)
 					ctx.JSON(http.StatusForbidden, gin.H{"approval_error": true, "error": fmt.Sprintf("The namespace %q was not approved by an administrator. %s", namespace.Path, approvalErrMsg)})
-					metrics.PelicanDirectorRejectedAdvertisements.Inc()
+					metrics.PelicanDirectorRejectedAdvertisements.With(prometheus.Labels{"hostname": adV2.Name}).Inc()
 					return
 				} else {
 					log.Warningln("Failed to verify token:", err)
@@ -1115,7 +1115,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 						Status: server_structs.RespFailed,
 						Msg:    fmt.Sprintf("Authorization token verification failed: %v", err),
 					})
-					metrics.PelicanDirectorRejectedAdvertisements.Inc()
+					metrics.PelicanDirectorRejectedAdvertisements.With(prometheus.Labels{"hostname": adV2.Name}).Inc()
 					return
 				}
 			}
@@ -1126,7 +1126,7 @@ func registerServeAd(engineCtx context.Context, ctx *gin.Context, sType server_s
 					Status: server_structs.RespFailed,
 					Msg:    "Authorization token verification failed. Token missing required scope",
 				})
-				metrics.PelicanDirectorRejectedAdvertisements.Inc()
+				metrics.PelicanDirectorRejectedAdvertisements.With(prometheus.Labels{"hostname": adV2.Name}).Inc()
 				return
 			}
 		}

--- a/metrics/director.go
+++ b/metrics/director.go
@@ -102,8 +102,8 @@ var (
 		Help: "The total number of errors encountered trying to resolve coordinates using the GeoIP MaxMind database",
 	}, []string{"network", "source", "proj"})
 
-	PelicanDirectorRejectedAdvertisements = promauto.NewCounterVec(prometheus.CounterOpts{
+	PelicanDirectorRejectedAdvertisements = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "pelican_director_rejected_advertisements",
 		Help: "The total number of advertisements rejected by the director",
-	}, []string{"server_type", "reason"})
+	})
 )

--- a/metrics/director.go
+++ b/metrics/director.go
@@ -101,4 +101,9 @@ var (
 		Name: "pelican_director_geoip_errors",
 		Help: "The total number of errors encountered trying to resolve coordinates using the GeoIP MaxMind database",
 	}, []string{"network", "source", "proj"})
+
+	PelicanDirectorRejectedAdvertisements = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "pelican_director_rejected_advertisements",
+		Help: "The total number of advertisements rejected by the director",
+	}, []string{"server_type", "reason"})
 )

--- a/metrics/director.go
+++ b/metrics/director.go
@@ -102,8 +102,8 @@ var (
 		Help: "The total number of errors encountered trying to resolve coordinates using the GeoIP MaxMind database",
 	}, []string{"network", "source", "proj"})
 
-	PelicanDirectorRejectedAdvertisements = promauto.NewCounter(prometheus.CounterOpts{
+	PelicanDirectorRejectedAdvertisements = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "pelican_director_rejected_advertisements",
 		Help: "The total number of advertisements rejected by the director",
-	})
+	}, []string{"hostname"})
 )


### PR DESCRIPTION
This PR addresses issue #1774. This metric is a simple counter that tracks the number of times the director has rejected an advertisement from an origin or cache. 