### PR TITLE
Add configuration for Prometheus to limit cardinality

### DIFF
--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -105,7 +105,7 @@ Monitoring:
   PromQLAuthorization: true
   AggregatePrefixes: ["/*"]
   DataRetention: 360h
-  LabelLimt: 64
+  LabelLimit: 64
   LabelNameLengthLimit: 128
   LabelValueLengthLimit: 2048
   SampleLimit: 200

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -105,6 +105,10 @@ Monitoring:
   PromQLAuthorization: true
   AggregatePrefixes: ["/*"]
   DataRetention: 360h
+  LabelLimt: 64
+  LabelNameLengthLimit: 128
+  LabelValueLengthLimit: 2048
+  SampleLimit: 200
 Shoveler:
   MessageQueueProtocol: amqp
   PortLower: 9930

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2496,6 +2496,36 @@ type: duration
 default: 360h
 components: ["origin", "cache", "director", "registry"]
 ---
+name: Monitoring.LabelLimit
+description: |+
+  The maximum number of labels that can be attached to a single metric. 0 means no limit.
+type: int
+default: 64
+components: ["origin", "cache", "director", "registry"]
+---
+name: Monitoring.LabelNameLengthLimit
+description: |+
+  The maximum length of a label name. 0 means no limit. The default value is 128 bytes, which allows for up to 32 characters.
+type: int
+default: 128
+components: ["origin", "cache", "director", "registry"]
+---
+name: Monitoring.LabelValueLengthLimit
+description: |+
+  The maximum length of a label value. 0 means no limit. The default value is 2048 bytes, which allows for up to 512 characters.
+type: int
+default: 2048
+components: ["origin", "cache", "director", "registry"]
+---
+name: Monitoring.SampleLimit
+description: |+
+  Per-scrape limit on the number of scraped samples that will be accepted.
+  If more than this number of samples are present after metric relabeling
+  the entire scrape will be treated as failed. 0 means no limit.
+type: int
+default: 200
+components: ["origin", "cache", "director", "registry"]
+---
 ############################
 #   Shoveler-level configs   #
 ############################

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2506,6 +2506,16 @@ components: ["origin", "cache", "director", "registry"]
 name: Monitoring.LabelNameLengthLimit
 description: |+
   The maximum length of a label name. 0 means no limit. The default value is 128 bytes, which allows for up to 32 characters.
+  For an example where the LabelNameLengthLimit is set to 24, meaning the label name can only be 6 characters long (This is very unrealistic).
+  ```
+  metric{name="Alice"} -> OK
+
+  other_metric{very_long_label_name="Alice"} -> Error
+  ```
+
+  It is worth noting that the picking sensible values is really important. The Prometheus server will reject any metrics that exceed the limit,
+  meaning that the metrics will not be scraped and will not be available for querying. If it is too large we could exceed the memory limits of Prometheus.
+  Be wary of modify this value. Similar considerations should be made for modifying Monitoring.LabelValueLengthLimit, Monitoring.LabelLimit, and Monitoring.SampleLimit.
 type: int
 default: 128
 components: ["origin", "cache", "director", "registry"]

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -316,8 +316,12 @@ var (
 	LocalCache_HighWaterMarkPercentage = IntParam{"LocalCache.HighWaterMarkPercentage"}
 	LocalCache_LowWaterMarkPercentage = IntParam{"LocalCache.LowWaterMarkPercentage"}
 	MinimumDownloadSpeed = IntParam{"MinimumDownloadSpeed"}
+	Monitoring_LabelLimit = IntParam{"Monitoring.LabelLimit"}
+	Monitoring_LabelNameLengthLimit = IntParam{"Monitoring.LabelNameLengthLimit"}
+	Monitoring_LabelValueLengthLimit = IntParam{"Monitoring.LabelValueLengthLimit"}
 	Monitoring_PortHigher = IntParam{"Monitoring.PortHigher"}
 	Monitoring_PortLower = IntParam{"Monitoring.PortLower"}
+	Monitoring_SampleLimit = IntParam{"Monitoring.SampleLimit"}
 	Origin_Port = IntParam{"Origin.Port"}
 	Server_IssuerPort = IntParam{"Server.IssuerPort"}
 	Server_UILoginRateLimit = IntParam{"Server.UILoginRateLimit"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -165,10 +165,14 @@ type Config struct {
 		AggregatePrefixes []string `mapstructure:"aggregateprefixes" yaml:"AggregatePrefixes"`
 		DataLocation string `mapstructure:"datalocation" yaml:"DataLocation"`
 		DataRetention time.Duration `mapstructure:"dataretention" yaml:"DataRetention"`
+		LabelLimit int `mapstructure:"labellimit" yaml:"LabelLimit"`
+		LabelNameLengthLimit int `mapstructure:"labelnamelengthlimit" yaml:"LabelNameLengthLimit"`
+		LabelValueLengthLimit int `mapstructure:"labelvaluelengthlimit" yaml:"LabelValueLengthLimit"`
 		MetricAuthorization bool `mapstructure:"metricauthorization" yaml:"MetricAuthorization"`
 		PortHigher int `mapstructure:"porthigher" yaml:"PortHigher"`
 		PortLower int `mapstructure:"portlower" yaml:"PortLower"`
 		PromQLAuthorization bool `mapstructure:"promqlauthorization" yaml:"PromQLAuthorization"`
+		SampleLimit int `mapstructure:"samplelimit" yaml:"SampleLimit"`
 		TokenExpiresIn time.Duration `mapstructure:"tokenexpiresin" yaml:"TokenExpiresIn"`
 		TokenRefreshInterval time.Duration `mapstructure:"tokenrefreshinterval" yaml:"TokenRefreshInterval"`
 	} `mapstructure:"monitoring" yaml:"Monitoring"`
@@ -477,10 +481,14 @@ type configWithType struct {
 		AggregatePrefixes struct { Type string; Value []string }
 		DataLocation struct { Type string; Value string }
 		DataRetention struct { Type string; Value time.Duration }
+		LabelLimit struct { Type string; Value int }
+		LabelNameLengthLimit struct { Type string; Value int }
+		LabelValueLengthLimit struct { Type string; Value int }
 		MetricAuthorization struct { Type string; Value bool }
 		PortHigher struct { Type string; Value int }
 		PortLower struct { Type string; Value int }
 		PromQLAuthorization struct { Type string; Value bool }
+		SampleLimit struct { Type string; Value int }
 		TokenExpiresIn struct { Type string; Value time.Duration }
 		TokenRefreshInterval struct { Type string; Value time.Duration }
 	}

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -228,6 +228,13 @@ func configDirectorPromScraper(ctx context.Context) (*config.ScrapeConfig, error
 		RefreshInterval:  model.Duration(15 * time.Second),
 		HTTPClientConfig: sdHttpClientConfig,
 	}
+
+	// Cardinality limits for Prometheus, configured via Pelican configuration file
+	scrapeConfig.LabelLimit = uint(param.Monitoring_LabelLimit.GetInt())
+	scrapeConfig.LabelNameLengthLimit = uint(param.Monitoring_LabelNameLengthLimit.GetInt())
+	scrapeConfig.LabelValueLengthLimit = uint(param.Monitoring_LabelValueLengthLimit.GetInt())
+	scrapeConfig.SampleLimit = uint(param.Monitoring_SampleLimit.GetInt())
+
 	return &scrapeConfig, nil
 }
 
@@ -396,6 +403,13 @@ func ConfigureEmbeddedPrometheus(ctx context.Context, engine *gin.Engine) error 
 			}},
 		},
 	}
+
+	// Cardinality limits for Prometheus, configured via Pelican configuration file
+	scrapeConfig.LabelLimit = uint(param.Monitoring_LabelLimit.GetInt())
+	scrapeConfig.LabelNameLengthLimit = uint(param.Monitoring_LabelNameLengthLimit.GetInt())
+	scrapeConfig.LabelValueLengthLimit = uint(param.Monitoring_LabelValueLengthLimit.GetInt())
+	scrapeConfig.SampleLimit = uint(param.Monitoring_SampleLimit.GetInt())
+
 	promCfg.ScrapeConfigs[0] = &scrapeConfig
 
 	// Add origins/caches monitoring to director's prometheus instance
@@ -737,6 +751,11 @@ func ConfigureEmbeddedPrometheus(ctx context.Context, engine *gin.Engine) error 
 								if err != nil {
 									return fmt.Errorf("Failed to generate token for director scraper when refresh it: %v", err)
 								}
+								// Cardinality limits for Prometheus, configured via Pelican configuration file
+								storageServerScrapeCfg.LabelLimit = uint(param.Monitoring_LabelLimit.GetInt())
+								storageServerScrapeCfg.LabelNameLengthLimit = uint(param.Monitoring_LabelNameLengthLimit.GetInt())
+								storageServerScrapeCfg.LabelValueLengthLimit = uint(param.Monitoring_LabelValueLengthLimit.GetInt())
+								storageServerScrapeCfg.SampleLimit = uint(param.Monitoring_SampleLimit.GetInt())
 
 								// Idx 0 is the config for server's onboard scraper
 								// Idx 1 is the config for director scraper at origins/caches

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -84,6 +84,28 @@ func init() {
 	prometheus.MustRegister(version.NewCollector(strings.ReplaceAll(appName, "-", "_")))
 }
 
+const (
+	MaxLabelLimit            = 10
+	MaxLabelNameLengthLimit  = 256
+	MaxLabelValueLengthLimit = 4096
+	MaxSampleLimit           = 800
+)
+
+func setCardinalityLimits(cfg *config.ScrapeConfig) {
+	if param.Monitoring_LabelLimit.GetInt() > 0 && param.Monitoring_LabelLimit.GetInt() < MaxLabelLimit {
+		cfg.LabelLimit = uint(param.Monitoring_LabelLimit.GetInt())
+	}
+	if param.Monitoring_LabelNameLengthLimit.GetInt() > 0 && param.Monitoring_LabelNameLengthLimit.GetInt() < MaxLabelNameLengthLimit {
+		cfg.LabelNameLengthLimit = uint(param.Monitoring_LabelNameLengthLimit.GetInt())
+	}
+	if param.Monitoring_LabelValueLengthLimit.GetInt() > 0 && param.Monitoring_LabelValueLengthLimit.GetInt() < MaxLabelValueLengthLimit {
+		cfg.LabelValueLengthLimit = uint(param.Monitoring_LabelValueLengthLimit.GetInt())
+	}
+	if param.Monitoring_SampleLimit.GetInt() > 0 && param.Monitoring_SampleLimit.GetInt() < MaxSampleLimit {
+		cfg.SampleLimit = uint(param.Monitoring_SampleLimit.GetInt())
+	}
+}
+
 type flagConfig struct {
 	serverStoragePath   string
 	forGracePeriod      model.Duration
@@ -230,10 +252,7 @@ func configDirectorPromScraper(ctx context.Context) (*config.ScrapeConfig, error
 	}
 
 	// Cardinality limits for Prometheus, configured via Pelican configuration file
-	scrapeConfig.LabelLimit = uint(param.Monitoring_LabelLimit.GetInt())
-	scrapeConfig.LabelNameLengthLimit = uint(param.Monitoring_LabelNameLengthLimit.GetInt())
-	scrapeConfig.LabelValueLengthLimit = uint(param.Monitoring_LabelValueLengthLimit.GetInt())
-	scrapeConfig.SampleLimit = uint(param.Monitoring_SampleLimit.GetInt())
+	setCardinalityLimits(&scrapeConfig)
 
 	return &scrapeConfig, nil
 }
@@ -405,10 +424,7 @@ func ConfigureEmbeddedPrometheus(ctx context.Context, engine *gin.Engine) error 
 	}
 
 	// Cardinality limits for Prometheus, configured via Pelican configuration file
-	scrapeConfig.LabelLimit = uint(param.Monitoring_LabelLimit.GetInt())
-	scrapeConfig.LabelNameLengthLimit = uint(param.Monitoring_LabelNameLengthLimit.GetInt())
-	scrapeConfig.LabelValueLengthLimit = uint(param.Monitoring_LabelValueLengthLimit.GetInt())
-	scrapeConfig.SampleLimit = uint(param.Monitoring_SampleLimit.GetInt())
+	setCardinalityLimits(&scrapeConfig)
 
 	promCfg.ScrapeConfigs[0] = &scrapeConfig
 
@@ -752,10 +768,7 @@ func ConfigureEmbeddedPrometheus(ctx context.Context, engine *gin.Engine) error 
 									return fmt.Errorf("Failed to generate token for director scraper when refresh it: %v", err)
 								}
 								// Cardinality limits for Prometheus, configured via Pelican configuration file
-								storageServerScrapeCfg.LabelLimit = uint(param.Monitoring_LabelLimit.GetInt())
-								storageServerScrapeCfg.LabelNameLengthLimit = uint(param.Monitoring_LabelNameLengthLimit.GetInt())
-								storageServerScrapeCfg.LabelValueLengthLimit = uint(param.Monitoring_LabelValueLengthLimit.GetInt())
-								storageServerScrapeCfg.SampleLimit = uint(param.Monitoring_SampleLimit.GetInt())
+								setCardinalityLimits(storageServerScrapeCfg)
 
 								// Idx 0 is the config for server's onboard scraper
 								// Idx 1 is the config for director scraper at origins/caches

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -19,7 +19,6 @@ package web_ui
 import (
 	"context"
 	"fmt"
-	pelican_log "log"
 	"math"
 	"net/http"
 	"net/url"
@@ -94,21 +93,22 @@ const (
 
 func setCardinalityLimits(cfg *config.ScrapeConfig) {
 	if !(param.Monitoring_LabelLimit.GetInt() > 0 && param.Monitoring_LabelLimit.GetInt() < MaxLabelLimit) {
-		pelican_log.Printf("Provided Monitoring.LabelLimit value: %d is either negative or greater than the maximum of %d. Defaulting to %d\n",
+		logrus.Warnf("Provided Monitoring.LabelLimit value: %d is either negative or greater than the maximum of %d. Defaulting to %d\n",
 			param.Monitoring_LabelLimit.GetInt(), MaxLabelLimit, 64)
 		cfg.LabelLimit = 64
 	}
 	if !(param.Monitoring_LabelNameLengthLimit.GetInt() > 0 && param.Monitoring_LabelNameLengthLimit.GetInt() < MaxLabelNameLengthLimit) {
-		pelican_log.Printf("Provided Monitoring.LabelNameLengthLimit value: %d is either negative or greater than the maximum of %d. Defaulting to %d\n",
+		logrus.Warnf("Provided Monitoring.LabelNameLengthLimit value: %d is either negative or greater than the maximum of %d. Defaulting to %d\n",
 			param.Monitoring_LabelNameLengthLimit.GetInt(), MaxLabelNameLengthLimit, 128)
 		cfg.LabelNameLengthLimit = 128
 	}
 	if !(param.Monitoring_LabelValueLengthLimit.GetInt() > 0 && param.Monitoring_LabelValueLengthLimit.GetInt() < MaxLabelValueLengthLimit) {
-		pelican_log.Printf("Provided Monitoring.LabelValueLengthLimit value: %d is either negative or greater than the maximum of %d. Defaulting to %d\n", param.Monitoring_LabelValueLengthLimit.GetInt(), 4096, 2048)
+		logrus.Warnf("Provided Monitoring.LabelValueLengthLimit value: %d is either negative or greater than the maximum of %d. Defaulting to %d\n",
+			param.Monitoring_LabelValueLengthLimit.GetInt(), 4096, 2048)
 		cfg.LabelValueLengthLimit = 2048
 	}
 	if !(param.Monitoring_SampleLimit.GetInt() > 0 && param.Monitoring_SampleLimit.GetInt() < MaxSampleLimit) {
-		pelican_log.Printf("Provided Monitoring.SampleLimit value: %d is either negative or greater than the maximum of %d. Defaulting to %d\n",
+		logrus.Warnf("Provided Monitoring.SampleLimit value: %d is either negative or greater than the maximum of %d. Defaulting to %d\n",
 			param.Monitoring_SampleLimit.GetInt(), MaxSampleLimit, 200)
 		cfg.SampleLimit = 200
 	}

--- a/web_ui/prometheus.go
+++ b/web_ui/prometheus.go
@@ -19,6 +19,7 @@ package web_ui
 import (
 	"context"
 	"fmt"
+	pelican_log "log"
 	"math"
 	"net/http"
 	"net/url"
@@ -85,24 +86,31 @@ func init() {
 }
 
 const (
-	MaxLabelLimit            = 10
+	MaxLabelLimit            = 128
 	MaxLabelNameLengthLimit  = 256
 	MaxLabelValueLengthLimit = 4096
 	MaxSampleLimit           = 800
 )
 
 func setCardinalityLimits(cfg *config.ScrapeConfig) {
-	if param.Monitoring_LabelLimit.GetInt() > 0 && param.Monitoring_LabelLimit.GetInt() < MaxLabelLimit {
-		cfg.LabelLimit = uint(param.Monitoring_LabelLimit.GetInt())
+	if !(param.Monitoring_LabelLimit.GetInt() > 0 && param.Monitoring_LabelLimit.GetInt() < MaxLabelLimit) {
+		pelican_log.Printf("Provided Monitoring.LabelLimit value: %d is either negative or greater than the maximum of %d. Defaulting to %d\n",
+			param.Monitoring_LabelLimit.GetInt(), MaxLabelLimit, 64)
+		cfg.LabelLimit = 64
 	}
-	if param.Monitoring_LabelNameLengthLimit.GetInt() > 0 && param.Monitoring_LabelNameLengthLimit.GetInt() < MaxLabelNameLengthLimit {
-		cfg.LabelNameLengthLimit = uint(param.Monitoring_LabelNameLengthLimit.GetInt())
+	if !(param.Monitoring_LabelNameLengthLimit.GetInt() > 0 && param.Monitoring_LabelNameLengthLimit.GetInt() < MaxLabelNameLengthLimit) {
+		pelican_log.Printf("Provided Monitoring.LabelNameLengthLimit value: %d is either negative or greater than the maximum of %d. Defaulting to %d\n",
+			param.Monitoring_LabelNameLengthLimit.GetInt(), MaxLabelNameLengthLimit, 128)
+		cfg.LabelNameLengthLimit = 128
 	}
-	if param.Monitoring_LabelValueLengthLimit.GetInt() > 0 && param.Monitoring_LabelValueLengthLimit.GetInt() < MaxLabelValueLengthLimit {
-		cfg.LabelValueLengthLimit = uint(param.Monitoring_LabelValueLengthLimit.GetInt())
+	if !(param.Monitoring_LabelValueLengthLimit.GetInt() > 0 && param.Monitoring_LabelValueLengthLimit.GetInt() < MaxLabelValueLengthLimit) {
+		pelican_log.Printf("Provided Monitoring.LabelValueLengthLimit value: %d is either negative or greater than the maximum of %d. Defaulting to %d\n", param.Monitoring_LabelValueLengthLimit.GetInt(), 4096, 2048)
+		cfg.LabelValueLengthLimit = 2048
 	}
-	if param.Monitoring_SampleLimit.GetInt() > 0 && param.Monitoring_SampleLimit.GetInt() < MaxSampleLimit {
-		cfg.SampleLimit = uint(param.Monitoring_SampleLimit.GetInt())
+	if !(param.Monitoring_SampleLimit.GetInt() > 0 && param.Monitoring_SampleLimit.GetInt() < MaxSampleLimit) {
+		pelican_log.Printf("Provided Monitoring.SampleLimit value: %d is either negative or greater than the maximum of %d. Defaulting to %d\n",
+			param.Monitoring_SampleLimit.GetInt(), MaxSampleLimit, 200)
+		cfg.SampleLimit = 200
 	}
 }
 


### PR DESCRIPTION
This PR addresses issue #1311. This PR uses the default values as described in [this design doc](https://docs.google.com/document/d/1sVJiZWKj8g3k7t_cy07aA_P7Es3Cg39mklrDKe_xo3c/edit?usp=sharing). This PR adds the ability to configure the label name and value length limits, the number of labels per time series, and the scrape limit. More information about these parameters can be found [here](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config)