### PR TITLE
Put the dynamically-linked pelican-server binary in the pelican-server RPM

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -430,7 +430,7 @@ nfpms:
           - "pelican-registry = 7"
           - "pelican-director = 7"
         dependencies:
-          - "pelican >= 7.4.0"
+          - "pelican >= 7.11.0"
           - "xrootd-server >= 1:5.7.0"
           - "xrootd-scitokens"
           - "xrootd-voms"
@@ -441,7 +441,7 @@ nfpms:
           - "pelican-registry (= 7)"
           - "pelican-director (= 7)"
         dependencies:
-          - "pelican (>= 7.4.0)"
+          - "pelican (>= 7.11.0)"
           - "xrootd-server (>= 5.7.0)"
           - "xrootd-scitokens-plugins"
           - "xrootd-voms-plugins"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -348,18 +348,20 @@ nfpms:
   # end package pelican-osdf-compet
 
   - package_name: pelican-server
-    builds: []
+    builds:
+      - pelican-server
     file_name_template: "{{ .ConventionalFileName }}"
     id: pelican-server
     vendor: OSG Consortium
     homepage: https://pelicanplatform.org
     maintainer: Pelican Team <help@pelicanplatform.org>
-    description: SystemD files and configs for Pelican services
+    description: Server binary, SystemD files and configs for Pelican services
     license: ASL 2.0
-    meta: true
+    meta: false
     formats:
       - deb
       - rpm
+    bindir: /usr/bin
     release: 1
     section: default
     priority: extra

--- a/systemd/osdf-cache.service
+++ b/systemd/osdf-cache.service
@@ -4,7 +4,7 @@ After = network.target nss-lookup.target
 
 [Service]
 EnvironmentFile = -/etc/sysconfig/osdf-cache
-ExecStart = /usr/bin/osdf --config /etc/pelican/osdf-cache.yaml cache serve
+ExecStart = /usr/bin/pelican-server --config /etc/pelican/osdf-cache.yaml cache serve
 Restart = on-failure
 RestartSec = 20s
 WorkingDirectory = /var/spool/osdf

--- a/systemd/osdf-origin.service
+++ b/systemd/osdf-origin.service
@@ -4,7 +4,7 @@ After = network.target nss-lookup.target
 
 [Service]
 EnvironmentFile = -/etc/sysconfig/osdf-origin
-ExecStart = /usr/bin/osdf --config /etc/pelican/osdf-origin.yaml origin serve
+ExecStart = /usr/bin/pelican-server --config /etc/pelican/osdf-origin.yaml origin serve
 Restart = on-failure
 RestartSec = 20s
 WorkingDirectory = /var/spool/osdf

--- a/systemd/pelican-cache.service
+++ b/systemd/pelican-cache.service
@@ -4,7 +4,7 @@ After = network.target nss-lookup.target
 
 [Service]
 EnvironmentFile = -/etc/sysconfig/pelican-cache
-ExecStart = /usr/bin/pelican --config /etc/pelican/pelican-cache.yaml cache serve
+ExecStart = /usr/bin/pelican-server --config /etc/pelican/pelican-cache.yaml cache serve
 Restart = on-failure
 RestartSec = 20s
 WorkingDirectory = /var/spool/pelican

--- a/systemd/pelican-origin.service
+++ b/systemd/pelican-origin.service
@@ -4,7 +4,7 @@ After = network.target nss-lookup.target
 
 [Service]
 EnvironmentFile = -/etc/sysconfig/pelican-origin
-ExecStart = /usr/bin/pelican --config /etc/pelican/pelican-origin.yaml origin serve
+ExecStart = /usr/bin/pelican-server --config /etc/pelican/pelican-origin.yaml origin serve
 Restart = on-failure
 RestartSec = 20s
 WorkingDirectory = /var/spool/pelican


### PR DESCRIPTION
Also updates the SystemD files for the cache and origin to use `pelican-server` instead of `pelican` or `osdf`.  For consistency with the current images, the director and registry .service files continue to use `pelican` or `osdf`.  Note that osdf-cache and osdf-origin no longer run a program with the magic `osdf` prefix, so they will be getting generic config unless overridden.