### PR TITLE
Do not advertise HTTP caches

### DIFF
--- a/director/advertise.go
+++ b/director/advertise.go
@@ -270,13 +270,15 @@ func AdvertiseOSDF(ctx context.Context) error {
 
 		for _, cache := range ns.Caches {
 			cacheAd := parseServerAdFromTopology(cache, server_structs.CacheType, server_structs.Capabilities{})
-			if existingAd, ok := cacheAdMap[cacheAd.URL.String()]; ok {
-				existingAd.NamespaceAds = append(existingAd.NamespaceAds, nsAd)
-				consolidatedAd := consolidateDupServerAd(cacheAd, existingAd.ServerAd)
-				existingAd.ServerAd = consolidatedAd
-			} else {
-				// New entry
-				cacheAdMap[cacheAd.URL.String()] = &server_structs.Advertisement{ServerAd: cacheAd, NamespaceAds: []server_structs.NamespaceAdV2{nsAd}}
+			if cacheAd.URL.Scheme != "http" {
+				if existingAd, ok := cacheAdMap[cacheAd.URL.String()]; ok {
+					existingAd.NamespaceAds = append(existingAd.NamespaceAds, nsAd)
+					consolidatedAd := consolidateDupServerAd(cacheAd, existingAd.ServerAd)
+					existingAd.ServerAd = consolidatedAd
+				} else {
+					// New entry
+					cacheAdMap[cacheAd.URL.String()] = &server_structs.Advertisement{ServerAd: cacheAd, NamespaceAds: []server_structs.NamespaceAdV2{nsAd}}
+				}
 			}
 		}
 	}

--- a/director/advertise_test.go
+++ b/director/advertise_test.go
@@ -243,7 +243,7 @@ func TestAdvertiseOSDF(t *testing.T) {
 		assert.Equal(t, "/my/server/2", nsAd.Path)
 		assert.True(t, nsAd.Caps.PublicReads)
 		assert.Equal(t, "https://origin2-auth-endpoint.com", oAds[0].AuthURL.String())
-		assert.Equal(t, "http://cache-endpoint.com", cAds[0].URL.String())
+		assert.Equal(t, "https://cache-endpoint.com", cAds[0].URL.String())
 	})
 
 	t.Run("multiple-ns-single-origin", func(t *testing.T) {
@@ -290,9 +290,9 @@ func TestAdvertiseOSDF(t *testing.T) {
 		require.NoError(t, err)
 
 		// This cache should serve 2 namespaces
-		found := serverAds.Has("http://dtn-pas.bois.nrp.internet2.edu:8000")
+		found := serverAds.Has("https://dtn-pas.bois.nrp.internet2.edu:8000")
 		require.True(t, found)
-		foundAd := serverAds.Get("http://dtn-pas.bois.nrp.internet2.edu:8000").Value()
+		foundAd := serverAds.Get("https://dtn-pas.bois.nrp.internet2.edu:8000").Value()
 		require.NotNil(t, foundAd)
 		assert.Equal(t, server_structs.CacheType.String(), foundAd.Type)
 		assert.Len(t, foundAd.NamespaceAds, 2)

--- a/director/resources/mock_topology.json
+++ b/director/resources/mock_topology.json
@@ -34,6 +34,11 @@
                 "auth_endpoint": "https://cache7.com",
                 "endpoint": "https://cache7.com",
                 "resource": "CACHE7"
+            },
+            {
+                "auth_endpoint": "http://cache8.com",
+                "endpoint": "http://cache8.com",
+                "resource": "HTTP_CACHE"
             }
         ],
         "namespaces": [
@@ -107,7 +112,7 @@
                 "caches": [
                     {
                         "auth_endpoint": "https://cache-auth-endpoint.com",
-                        "endpoint": "http://cache-endpoint.com",
+                        "endpoint": "https://cache-endpoint.com",
                         "resource": "MY_CACHE"
                     }
                 ],
@@ -122,6 +127,39 @@
                     }
                 ],
                 "path": "/my/server/2",
+                "readhttps": true,
+                "usetokenonread": false,
+                "writebackhost": null
+            },
+            {
+                "caches": [
+                    {
+                            "auth_endpoint": "http://cache8.com",
+                            "endpoint": "http://cache8.com",
+                            "resource": "HTTP_CACHE"
+                    },
+                    {
+                        "auth_endpoint": "https://cache3.com",
+                        "endpoint": "https://cache3.com",
+                        "resource": "CACHE3"
+                    },
+                    {
+                        "auth_endpoint": "https://cache4.com",
+                        "endpoint": "https://cache4.com",
+                        "resource": "CACHE4"
+                    }
+                ],
+                "credential_generation": null,
+                "scitokens": [],
+                "dirlisthost": null,
+                "origins": [
+                    {
+                        "auth_endpoint": "https://origin3-auth-endpoint.com",
+                        "endpoint": "http://origin3-endpoint.com",
+                        "resource": "MY_ORIGIN3"
+                    }
+                ],
+                "path": "/my/server/3",
                 "readhttps": true,
                 "usetokenonread": false,
                 "writebackhost": null

--- a/director/resources/multi_export_topology.json
+++ b/director/resources/multi_export_topology.json
@@ -4,8 +4,8 @@
      {
         "caches":[
          {
-            "auth_endpoint": "osdf-uw-cache.svc.osg-htc.org:8443",
-            "endpoint": "osdf-uw-cache.svc.osg-htc.org:8443",
+            "auth_endpoint": "https://osdf-uw-cache.svc.osg-htc.org:8443",
+            "endpoint": "https://osdf-uw-cache.svc.osg-htc.org:8443",
             "production": true,
             "resource": "CHTC_PELICAN_CACHE"
             }
@@ -34,13 +34,13 @@
            }
         ],
         "usetokenonread":true,
-        "writebackhost":"http://sdsc-origin.nationalresearchplatform.org:1095"
+        "writebackhost":"https://sdsc-origin.nationalresearchplatform.org:1095"
      },
      {
         "caches":[
            {
-              "auth_endpoint":"dtn-pas.bois.nrp.internet2.edu:8443",
-              "endpoint":"dtn-pas.bois.nrp.internet2.edu:8000",
+              "auth_endpoint":"https://dtn-pas.bois.nrp.internet2.edu:8443",
+              "endpoint":"https://dtn-pas.bois.nrp.internet2.edu:8000",
               "production":true,
               "resource":"BOISE_INTERNET2_OSDF_CACHE"
            }
@@ -66,8 +66,8 @@
      {
         "caches":[
            {
-              "auth_endpoint":"dtn-pas.bois.nrp.internet2.edu:8443",
-              "endpoint":"dtn-pas.bois.nrp.internet2.edu:8000",
+              "auth_endpoint":"https://dtn-pas.bois.nrp.internet2.edu:8443",
+              "endpoint":"https://dtn-pas.bois.nrp.internet2.edu:8000",
               "production":true,
               "resource":"BOISE_INTERNET2_OSDF_CACHE"
            }

--- a/director/stat_test.go
+++ b/director/stat_test.go
@@ -709,7 +709,7 @@ func TestCache(t *testing.T) {
 	config.InitConfig()
 	reqCounter := 0
 
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		reqCounter += 1
 		log.Debugln("Mock server handling request for ", req.URL.String())
 		if req.Method == "HEAD" && req.URL.String() == "/foo/test.txt" {
@@ -724,6 +724,7 @@ func TestCache(t *testing.T) {
 	}))
 	defer server.Close()
 
+	viper.Set("TLSSkipVerify", true)
 	viper.Set("Server.ExternalWebUrl", server.URL)
 	viper.Set("IssuerUrl", server.URL)
 	realServerUrl, err := url.Parse(server.URL)


### PR DESCRIPTION
For security reasons, we want to stop advertisement of HTTP caches.

This only occurs with non-pelican caches, which should be phased out by April. As such this shouldn't cause a large disruption (there are only a few caches where this occurs)

I decided to stop those caches from advertising to the director because I don't want them to be listed in the federation if they aren't available to the user.