### PR TITLE
Move `ticker.Stop()` into goroutine

### DIFF
--- a/server_utils/monitor.go
+++ b/server_utils/monitor.go
@@ -59,9 +59,9 @@ func LaunchPeriodicDirectorTimeout(ctx context.Context, egrp *errgroup.Group, nC
 		return
 	}
 	directorTimeoutTicker := time.NewTicker(directorTimeoutDuration)
-	defer directorTimeoutTicker.Stop()
 
 	egrp.Go(func() error {
+		defer directorTimeoutTicker.Stop()
 		for {
 			select {
 			case <-directorTimeoutTicker.C:

--- a/server_utils/server_utils.go
+++ b/server_utils/server_utils.go
@@ -216,7 +216,6 @@ func LaunchWatcherMaintenance(ctx context.Context, dirPaths []string, descriptio
 	}
 	cases := make([]reflect.SelectCase, select_count)
 	ticker := time.NewTicker(sleepTime)
-	defer ticker.Stop()
 	cases[0].Dir = reflect.SelectRecv
 	cases[0].Chan = reflect.ValueOf(ticker.C)
 	cases[1].Dir = reflect.SelectRecv
@@ -233,6 +232,7 @@ func LaunchWatcherMaintenance(ctx context.Context, dirPaths []string, descriptio
 	}
 	egrp.Go(func() error {
 		defer watcher.Close()
+		defer ticker.Stop()
 		for {
 			chosen, recv, ok := reflect.Select(cases)
 			if chosen == 0 {


### PR DESCRIPTION
In the `Launch*` family of methods, if we stop the ticker outside the launched thread, it will never fire in the goroutine and hence never actually update.

From within the goroutine, it'll stop at shutdown and clean up the resources appropriately.

This needs to get backported to the v7.11 and v7.12 series.