### PR TITLE
Fixes for the director tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1068,10 +1068,15 @@ func SetServerDefaults(v *viper.Viper) error {
 		v.SetDefault(param.Shoveler_QueueDirectory.GetName(), filepath.Join(configDir, "shoveler/queue"))
 		v.SetDefault(param.Shoveler_AMQPTokenLocation.GetName(), filepath.Join(configDir, "shoveler-token"))
 
-		runtimeDir := filepath.Join(os.TempDir(), "pelican-xrootd-*") // Construct the expected path
-
+		var runtimeDir string
 		if v == viper.GetViper() && os.Getenv("XDG_RUNTIME_DIR") != "" {
 			runtimeDir = filepath.Join(os.Getenv("XDG_RUNTIME_DIR"), "pelican")
+		} else {
+			var err error
+			runtimeDir, err = os.MkdirTemp("", "pelican-xrootd-*")
+			if err != nil {
+				return errors.Wrap(err, "Failed to create temporary runtime directory for Pelican")
+			}
 		}
 
 		v.SetDefault(param.Cache_RunLocation.GetName(), filepath.Join(runtimeDir, "cache"))

--- a/director/monitor.go
+++ b/director/monitor.go
@@ -45,14 +45,14 @@ var originReportNotFoundError = errors.New("Origin does not support new reportin
 
 // Report the health status of test file transfer to storage server
 func reportStatusToServer(ctx context.Context, serverWebUrl string, status string, message string, serverType string, fallback bool) error {
-	directorUrl, err := url.Parse(param.Server_ExternalWebUrl.GetString())
+	fedInfo, err := config.GetFederation(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "failed to parse external URL %v", param.Server_ExternalWebUrl.GetString())
+		return err
 	}
 
 	testTokenCfg := token.NewWLCGToken()
 	testTokenCfg.Lifetime = time.Minute
-	testTokenCfg.Issuer = directorUrl.String()
+	testTokenCfg.Issuer = fedInfo.DiscoveryEndpoint
 	testTokenCfg.AddAudiences(serverWebUrl)
 	testTokenCfg.Subject = "director"
 	testTokenCfg.AddScopes(token_scopes.Pelican_DirectorTestReport)

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1919,6 +1919,14 @@ type: string
 default: none
 components: ["cache", "director", "origin", "registry"]
 ---
+name: Server.HealthMonitoringPublic
+description: |+
+  Whether the server's health monitoring results should be made public without any
+  authentication required
+type: bool
+default: false
+components: ["cache", "director", "origin", "registry"]
+---
 name: Server.IssuerUrl
 description: |+
   The URL and port at which the server's issuer can be accessed.

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -383,6 +383,7 @@ var (
 	Registry_RequireOriginApproval = BoolParam{"Registry.RequireOriginApproval"}
 	Server_EnablePprof = BoolParam{"Server.EnablePprof"}
 	Server_EnableUI = BoolParam{"Server.EnableUI"}
+	Server_HealthMonitoringPublic = BoolParam{"Server.HealthMonitoringPublic"}
 	Shoveler_Enable = BoolParam{"Shoveler.Enable"}
 	Shoveler_VerifyHeader = BoolParam{"Shoveler.VerifyHeader"}
 	StagePlugin_Hook = BoolParam{"StagePlugin.Hook"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -261,6 +261,7 @@ type Config struct {
 		EnablePprof bool `mapstructure:"enablepprof" yaml:"EnablePprof"`
 		EnableUI bool `mapstructure:"enableui" yaml:"EnableUI"`
 		ExternalWebUrl string `mapstructure:"externalweburl" yaml:"ExternalWebUrl"`
+		HealthMonitoringPublic bool `mapstructure:"healthmonitoringpublic" yaml:"HealthMonitoringPublic"`
 		Hostname string `mapstructure:"hostname" yaml:"Hostname"`
 		IssuerHostname string `mapstructure:"issuerhostname" yaml:"IssuerHostname"`
 		IssuerJwks string `mapstructure:"issuerjwks" yaml:"IssuerJwks"`
@@ -579,6 +580,7 @@ type configWithType struct {
 		EnablePprof struct { Type string; Value bool }
 		EnableUI struct { Type string; Value bool }
 		ExternalWebUrl struct { Type string; Value string }
+		HealthMonitoringPublic struct { Type string; Value bool }
 		Hostname struct { Type string; Value string }
 		IssuerHostname struct { Type string; Value string }
 		IssuerJwks struct { Type string; Value string }

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -458,10 +458,16 @@ func configureMetrics(engine *gin.Engine) error {
 	prometheusMonitor.ReqCntURLLabelMappingFn = mapPrometheusPath
 	prometheusMonitor.Use(engine)
 
-	engine.GET("/api/v1.0/metrics/health", AuthHandler, AdminAuthHandler, func(ctx *gin.Context) {
+	// Health check endpoint for metrics
+	healthFunc := func(ctx *gin.Context) {
 		healthStatus := metrics.GetHealthStatus()
 		ctx.JSON(http.StatusOK, healthStatus)
-	})
+	}
+	if param.Server_HealthMonitoringPublic.GetBool() {
+		engine.GET("/api/v1.0/metrics/health", healthFunc)
+	} else {
+		engine.GET("/api/v1.0/metrics/health", AuthHandler, AdminAuthHandler, healthFunc)
+	}
 	return nil
 }
 

--- a/xrootd/authorization.go
+++ b/xrootd/authorization.go
@@ -569,6 +569,10 @@ func WriteOriginScitokensConfig(authedPaths []string) error {
 	if err != nil {
 		return err
 	}
+	if aud := config.GetServerAudience(); !slices.Contains(cfg.Global.Audience, aud) {
+		cfg.Global.Audience = append(cfg.Global.Audience, aud)
+	}
+	log.Debugln("Audience setting:", cfg.Global.Audience)
 	if issuer, err := GenerateOriginIssuer(authedPaths); err == nil && len(issuer.Name) > 0 {
 		if val, ok := cfg.IssuerMap[issuer.Issuer]; ok {
 			val.BasePaths = append(val.BasePaths, issuer.BasePaths...)
@@ -576,7 +580,6 @@ func WriteOriginScitokensConfig(authedPaths []string) error {
 			cfg.IssuerMap[issuer.Issuer] = val
 		} else {
 			cfg.IssuerMap[issuer.Issuer] = issuer
-			cfg.Global.Audience = append(cfg.Global.Audience, config.GetServerAudience())
 		}
 	} else if err != nil {
 		return errors.Wrap(err, "failed to generate xrootd issuer for the origin")
@@ -589,7 +592,6 @@ func WriteOriginScitokensConfig(authedPaths []string) error {
 			cfg.IssuerMap[issuer.Issuer] = val
 		} else {
 			cfg.IssuerMap[issuer.Issuer] = issuer
-			cfg.Global.Audience = append(cfg.Global.Audience, config.GetServerAudience())
 		}
 	} else if err != nil {
 		return errors.Wrap(err, "failed to generate xrootd issuer for self-monitoring")

--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+# Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you
 # may not use this file except in compliance with the License.  You may
@@ -103,7 +103,7 @@ ofs.authlib ++ libXrdAccSciTokens.so config={{.Origin.RunLocation}}/scitokens-or
 {{range .Origin.Exports}}
 all.export {{.FederationPrefix}}
 {{end}}
-{{if .Origin.SelfTest}}
+{{if or .Origin.SelfTest .Origin.DirectorTest }}
 # Note we don't want to export this via cmsd; only for self-test
 xrootd.export /pelican/monitoring
 xrootd.export /.well-known

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -83,6 +83,7 @@ enable = true
 type (
 	OriginConfig struct {
 		Multiuser         bool
+		DirectorTest      bool
 		EnableCmsd        bool
 		EnableMacaroons   bool
 		EnableVoms        bool


### PR DESCRIPTION
This PR contains one fix for the director test (solving confusion between the discovery URL and the director URL -- the director tests should have been using the discovery URL).

An integration test is *not* included but bugfixes are included that will eventually be necessary for the integration test.  In discussion with @jhiemstrawisc, we realized that the "federation-in-the-box" tests are failing because the scitokens.cfg is written prior to XRootD startup but the correct audience URL is not known until _after_ startup.  Our best idea for a fix is to implement an "automatic" mode for XRootD to have it determine the correct audience (which will require an XRootD release and hence take some time).

In the meantime, the bugfixes for a future test include:
1. Correct temporary directory creation in the configuration code (this was causing state to leak between tests).
2. Make the "health" metrics publicly available (simplifies the test as the test then doesn't require a token to verify it worked).
3. Allow the director test to run when the self test is disabled (previously, if the self test is disabled and the director test is enabled, then the director test would be broken due to a missing export).

Fixes #1902
Fixes #1930