### PR TITLE
Don't build dev images on git tags, tag im with latest-itb and sha256

### DIFF
--- a/.github/workflows/build-dev-container.yml
+++ b/.github/workflows/build-dev-container.yml
@@ -3,10 +3,6 @@ name: Build and Push Dev Image
 on:
   pull_request:
   push:
-    tags:
-      # only build and publish container on v7.0.0 and up
-      - v[7-9]\.[0-9]+\.[0-9]+-**
-      - v[1-9][0-9]+\.[0-9]+\.[0-9]+-**
     branches:
       - main
 
@@ -24,9 +20,7 @@ jobs:
         with:
           images: hub.opensciencegrid.org/pelican_platform/pelican-dev
           tags: |
-            type=semver,pattern={{version}}
             type=raw,value=latest-itb
-            type=ref,enable=true,prefix=itb-,suffix=-{{date 'YYYYMMDDHHmmss'}},event=tag
             type=raw,value=sha-{{sha}}
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
The previous action had a side effect such that whenever someone created a new tag for some release/release candidate, a new container with latest-itb would get pushed to Harbor, but from the `dev.Dockerfile` as it exists for that tag.

This essentially means _some_ but not all latest-itb tags weren't actually tracking main, but other branches instead.

After a chat with Sarthak & Emma, we don't see much use in building dev containers that aren't produced from the main branch, since we don't do dev work like that on our release series branches.

This commit removes tags as a trigger from the workflow, and only uses the image's sha256 and latest-itb as tags