### PR TITLE
Allow for Shoveler messages to be understood by monitoring packet handler. 

### DIFF
--- a/metrics/shoveler.go
+++ b/metrics/shoveler.go
@@ -184,7 +184,7 @@ func packageUdp(packet []byte, remote *net.UDPAddr) ([]byte, error) {
 	return b, nil
 }
 
-func LaunchShoveler(ctx context.Context, egrp *errgroup.Group, metricsPort int) (int, error) {
+func LaunchShoveler(ctx context.Context, egrp *errgroup.Group) (int, error) {
 	shovelerLogger = log.WithField("component", "shoveler")
 	shoveler.SetLogger(shovelerLogger)
 

--- a/metrics/shoveler.go
+++ b/metrics/shoveler.go
@@ -270,7 +270,7 @@ func LaunchShoveler(ctx context.Context, egrp *errgroup.Group) (int, error) {
 				return
 			} else if err != nil {
 				// output errors
-				shovelerLogger.Errorln("Failed to read from UDP connection:", err)
+				shovelerLogger.Errorln("Failed to read from UDP connection while aggregating monitoring packet from XRootD:", err)
 				// If we failed to read from the UDP connection, I'm not
 				// sure what to do, maybe just continue as if nothing happened?
 				continue
@@ -279,7 +279,7 @@ func LaunchShoveler(ctx context.Context, egrp *errgroup.Group) (int, error) {
 
 			err = handlePacket(buf[:rlen])
 			if err != nil {
-				shovelerLogger.Errorln("Failed to handle packet:", err)
+				shovelerLogger.Errorln("Pelican failed to handle monitoring packet received from the Shoveler:", err)
 				continue
 			}
 

--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -413,7 +413,7 @@ func ConfigureMonitoring(ctx context.Context, egrp *errgroup.Group) (int, error)
 				if errors.Is(err, net.ErrClosed) {
 					return
 				} else if err != nil {
-					log.Errorln("Failed to read from UDP connection", err)
+					log.Errorln("Failed to read from UDP connection while aggregating monitoring packet from XRootD:", err)
 					continue
 				}
 				PacketsReceived.Inc()
@@ -421,7 +421,7 @@ func ConfigureMonitoring(ctx context.Context, egrp *errgroup.Group) (int, error)
 					continue
 				}
 				if err = handlePacket(buf[:plen]); err != nil {
-					log.Errorln("Failed to handle packet:", err)
+					log.Errorln("Pelican failed to handle monitoring packet received from XRootD:", err)
 				}
 			}
 		}

--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -592,6 +592,9 @@ func NullTermToString(nullTermBytes []byte) (str string) {
 }
 
 func HandlePacket(packet []byte) error {
+	if len(packet) < 8 {
+		return errors.New("Packet is too small to be valid XRootD monitoring packet")
+	}
 	// If a message starts with `{` its a shoveler message in the form of JSON
 	/*
 		{
@@ -613,7 +616,6 @@ func HandlePacket(packet []byte) error {
 		if err != nil {
 			return errors.Wrap(err, "Failed to decode base64 encoded data")
 		}
-
 	}
 
 	// XML '<' character indicates a summary packet
@@ -621,9 +623,6 @@ func HandlePacket(packet []byte) error {
 		return HandleSummaryPacket(packet)
 	}
 
-	if len(packet) < 8 {
-		return errors.New("Packet is too small to be valid XRootD monitoring packet")
-	}
 	var header XrdXrootdMonHeader
 	header.Code = packet[0]
 	header.Pseq = packet[1]

--- a/metrics/xrootd_metrics_test.go
+++ b/metrics/xrootd_metrics_test.go
@@ -240,7 +240,7 @@ func TestHandlePacket(t *testing.T) {
 	mockWrite := int64(120)
 
 	t.Run("an-empty-detail-packet-should-return-error", func(t *testing.T) {
-		err := HandlePacket([]byte{})
+		err := handlePacket([]byte{})
 		assert.Error(t, err, "No error reported with an empty detail packet")
 	})
 
@@ -270,7 +270,7 @@ func TestHandlePacket(t *testing.T) {
 		`
 		expectedReader := strings.NewReader(mockPromThreads)
 
-		err = HandlePacket(mockShedSummaryBytes)
+		err = handlePacket(mockShedSummaryBytes)
 		require.NoError(t, err, "Error handling the packet")
 		if err := testutil.CollectAndCompare(Threads, expectedReader, "xrootd_sched_thread_count"); err != nil {
 			require.NoError(t, err, "Collected metric is different from expected")
@@ -359,7 +359,7 @@ func TestHandlePacket(t *testing.T) {
 		expectedLinkByteXferIncDup := strings.NewReader(mockPromLinkByteXferInc)
 
 		// First time received a summary packet
-		err = HandlePacket(mockLinkSummaryBaseBytes)
+		err = handlePacket(mockLinkSummaryBaseBytes)
 		require.NoError(t, err, "Error handling the packet")
 		if err := testutil.CollectAndCompare(Connections, expectedLinkConnectBase, "xrootd_server_connection_count"); err != nil {
 			require.NoError(t, err, "Collected metric is different from expected")
@@ -372,13 +372,13 @@ func TestHandlePacket(t *testing.T) {
 		// And metrics should be updated to the max number
 
 		// Have one CMSD summary packets which should be ignored
-		err = HandlePacket(mockLinkSummaryCMSDBaseBytes)
+		err = handlePacket(mockLinkSummaryCMSDBaseBytes)
 		require.NoError(t, err, "Error handling the packet")
 		// Have one CMSD summary packets which should be ignored
-		err = HandlePacket(mockLinkSummaryCMSDBaseBytes)
+		err = handlePacket(mockLinkSummaryCMSDBaseBytes)
 		require.NoError(t, err, "Error handling the packet")
 
-		err = HandlePacket(mockLinkSummaryIncBaseBytes)
+		err = handlePacket(mockLinkSummaryIncBaseBytes)
 		require.NoError(t, err, "Error handling the packet")
 
 		if err := testutil.CollectAndCompare(Connections, expectedLinkConnectInc, "xrootd_server_connection_count"); err != nil {
@@ -389,7 +389,7 @@ func TestHandlePacket(t *testing.T) {
 		}
 
 		// Summary data sent to CMSD shouldn't be recorded into the metrics
-		err = HandlePacket(mockLinkSummaryCMSDBaseBytes)
+		err = handlePacket(mockLinkSummaryCMSDBaseBytes)
 		require.NoError(t, err, "Error handling the packet")
 
 		if err := testutil.CollectAndCompare(Connections, expectedLinkConnectIncDup, "xrootd_server_connection_count"); err != nil {
@@ -432,7 +432,7 @@ func TestHandlePacket(t *testing.T) {
 
 		buf, err := mockMonMap.Serialize()
 		require.NoError(t, err, "Error serializing monitor packet")
-		err = HandlePacket(buf)
+		err = handlePacket(buf)
 		require.NoError(t, err, "Error handling packet")
 
 		require.Equal(t, 1, len(sessions.Keys()), "Session cache didn't update")
@@ -480,7 +480,7 @@ func TestHandlePacket(t *testing.T) {
 
 		buf, err := mockMonMapIPv4.Serialize()
 		require.NoError(t, err, "Error serializing monitor packet")
-		err = HandlePacket(buf)
+		err = handlePacket(buf)
 		require.NoError(t, err, "Error handling packet")
 
 		require.Equal(t, 1, len(sessions.Keys()), "Session cache didn't update")
@@ -523,7 +523,7 @@ func TestHandlePacket(t *testing.T) {
 
 		buf, err := mockMonMapIPv6.Serialize()
 		require.NoError(t, err, "Error serializing monitor packet")
-		err = HandlePacket(buf)
+		err = handlePacket(buf)
 		require.NoError(t, err, "Error handling packet")
 
 		require.Equal(t, 1, len(sessions.Keys()), "Session cache didn't update")
@@ -560,7 +560,7 @@ func TestHandlePacket(t *testing.T) {
 
 		transfers.DeleteAll()
 
-		err = HandlePacket(buf)
+		err = handlePacket(buf)
 		require.NoError(t, err, "Error handling packet")
 		require.Equal(t, 1, len(transfers.Keys()), "Transfer cache didn't update")
 		assert.Equal(t, uint32(10), transfers.Keys()[0].Id, "Id in session cache entry doesn't match expected")
@@ -580,7 +580,7 @@ func TestHandlePacket(t *testing.T) {
 
 		transfers.DeleteAll()
 
-		err = HandlePacket(bytePacket)
+		err = handlePacket(bytePacket)
 		require.NoError(t, err, "Error handling the packet")
 		require.Equal(t, 1, len(transfers.Keys()), "Transfer cache didn't update")
 		assert.Equal(t, mockFileID, transfers.Keys()[0].Id, "Id in session cache entry doesn't match expected")
@@ -601,7 +601,7 @@ func TestHandlePacket(t *testing.T) {
 
 		transfers.DeleteAll()
 
-		err = HandlePacket(bytePacket)
+		err = handlePacket(bytePacket)
 		require.NoError(t, err, "Error handling the packet")
 		require.Equal(t, 1, len(transfers.Keys()), "Transfer cache didn't update")
 		assert.Equal(t, mockFileID, transfers.Keys()[0].Id, "Id in session cache entry doesn't match expected")
@@ -621,10 +621,10 @@ func TestHandlePacket(t *testing.T) {
 
 		transfers.DeleteAll()
 
-		err = HandlePacket(openPacket)
+		err = handlePacket(openPacket)
 		require.NoError(t, err, "Error handling the file open packet")
 
-		err = HandlePacket(xftPacket)
+		err = handlePacket(xftPacket)
 		require.NoError(t, err, "Error handling the file transfer packet")
 
 		require.Equal(t, 1, len(transfers.Keys()), "Transfer cache didn't update")
@@ -665,7 +665,7 @@ func TestHandlePacket(t *testing.T) {
 		transfers.DeleteAll()
 		sessions.DeleteAll()
 
-		err = HandlePacket(openPacket)
+		err = handlePacket(openPacket)
 		require.NoError(t, err, "Error handling the file open packet")
 
 		require.Equal(t, 1, len(transfers.Keys()), "Transfer cache didn't update")
@@ -674,10 +674,10 @@ func TestHandlePacket(t *testing.T) {
 		assert.Equal(t, "/", transferEntry.Path, "Path in transfer cache entry doesn't match expected")
 		assert.Equal(t, mockUserID, transferEntry.UserId.Id, "UserID in transfer cache entry doesn't match expected")
 
-		err = HandlePacket(xftPacket)
+		err = handlePacket(xftPacket)
 		require.NoError(t, err, "Error handling the file transfer packet")
 
-		err = HandlePacket(clsPacket)
+		err = handlePacket(clsPacket)
 		require.NoError(t, err, "Error handling the file close packet")
 
 		// Transfer item should be deleted on file close
@@ -774,7 +774,7 @@ func TestHandlePacket(t *testing.T) {
 
 		buf, err := mockMonMap1.Serialize()
 		require.NoError(t, err, "Error serializing monitor packet")
-		err = HandlePacket(buf)
+		err = handlePacket(buf)
 		require.NoError(t, err, "Error handling packet")
 
 		require.Equal(t, 1, len(sessions.Keys()), "Session cache didn't update")
@@ -788,7 +788,7 @@ func TestHandlePacket(t *testing.T) {
 
 		buf, err = mockMonMap2.Serialize()
 		require.NoError(t, err)
-		err = HandlePacket(buf)
+		err = handlePacket(buf)
 		require.NoError(t, err)
 
 		require.Equal(t, 1, len(sessions.Keys()))

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -1015,7 +1015,7 @@ func SetUpMonitoring(ctx context.Context, egrp *errgroup.Group) error {
 	// If shoveler is enabled, shoveler will send a forwarding UDP stream to metrics handler above
 	// and shoveler will start a new UDP server to listen to XRootD stream
 	if param.Shoveler_Enable.GetBool() {
-		monitorPort, err = metrics.LaunchShoveler(ctx, egrp, monitorPort)
+		monitorPort, err = metrics.LaunchShoveler(ctx, egrp)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR fixes [issue #1916](https://github.com/PelicanPlatform/pelican/issues/1916). During investigation with the local federation, we discovered that the XRootD monitoring packet handler wasn’t processing shoveler messages correctly. The shoveler was sending JSON-encoded packets, which the existing code couldn’t interpret. This update ensures that shoveler packets are now correctly parsed and understood.