### PR TITLE
Use Server.Hostname as the prefix for origin/cache namespace registration

### DIFF
--- a/cache/advertise.go
+++ b/cache/advertise.go
@@ -42,7 +42,7 @@ type (
 )
 
 func (server *CacheServer) CreateAdvertisement(name, originUrl, originWebUrl string) (*server_structs.OriginAdvertiseV2, error) {
-	registryPrefix := server_structs.GetCacheNS(param.Xrootd_Sitename.GetString())
+	registryPrefix := server_structs.GetCacheNS(param.Server_Hostname.GetString())
 	ad := server_structs.OriginAdvertiseV2{
 		Name:           name,
 		RegistryPrefix: registryPrefix,

--- a/launcher_utils/advertise.go
+++ b/launcher_utils/advertise.go
@@ -145,7 +145,8 @@ func advertiseInternal(ctx context.Context, server server_structs.XRootDServer) 
 			log.Errorf("Failed to get sitename from the registry for the origin. Will fallback to use Xrootd.Sitename: %v", err)
 		}
 	} else if server.GetServerType().IsEnabled(server_structs.CacheType) {
-		cachePrefix := server_structs.GetCacheNS(param.Xrootd_Sitename.GetString())
+		hostname := param.Server_Hostname.GetString()
+		cachePrefix := server_structs.GetCacheNS(hostname)
 		name, err = getSitenameFromReg(ctx, cachePrefix)
 		if err != nil {
 			log.Errorf("Failed to get sitename from the registry for the cache. Will fallback to use Xrootd.Sitename: %v", err)

--- a/launcher_utils/advertise.go
+++ b/launcher_utils/advertise.go
@@ -137,13 +137,9 @@ func advertiseInternal(ctx context.Context, server server_structs.XRootDServer) 
 	var err error
 	// Fetch site name from the registry, if not, fall back to Xrootd.Sitename.
 	if server.GetServerType().IsEnabled(server_structs.OriginType) {
-		// Note we use Server_ExternalWebUrl as the origin prefix
-		// But caches still use Xrootd_Sitename, which will be changed to Server_ExternalWebUrl in
-		// https://github.com/PelicanPlatform/pelican/issues/1351
-		extUrlStr := param.Server_ExternalWebUrl.GetString()
-		extUrl, _ := url.Parse(extUrlStr)
-		// Only use hostname:port
-		originPrefix := server_structs.GetOriginNs(extUrl.Host)
+		// We use Server_Hostname (without port) as the origin/cache prefix
+		hostname := param.Server_Hostname.GetString()
+		originPrefix := server_structs.GetOriginNs(hostname)
 		name, err = getSitenameFromReg(ctx, originPrefix)
 		if err != nil {
 			log.Errorf("Failed to get sitename from the registry for the origin. Will fallback to use Xrootd.Sitename: %v", err)

--- a/launcher_utils/key_refresh_and_update_namespace_pubkey.go
+++ b/launcher_utils/key_refresh_and_update_namespace_pubkey.go
@@ -89,9 +89,9 @@ func updateNamespacesPubKey(ctx context.Context, prefixes []string) error {
 }
 
 func triggerNamespacesPubKeyUpdate(ctx context.Context) error {
-	extUrlStr := param.Server_ExternalWebUrl.GetString()
-	extUrl, _ := url.Parse(extUrlStr)
-	namespace := server_structs.GetOriginNs(extUrl.Host)
+	hostname := param.Server_Hostname.GetString()
+	// Only use server's hostname as prefix/namespace (without port)
+	namespace := server_structs.GetOriginNs(hostname)
 	if err := updateNamespacesPubKey(ctx, []string{namespace}); err != nil {
 		log.Errorf("Error updating the public key of the registered origin namespace %s: %v", namespace, err)
 	}

--- a/launchers/cache_serve.go
+++ b/launchers/cache_serve.go
@@ -142,7 +142,7 @@ func CacheServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, m
 func CacheServeFinish(ctx context.Context, egrp *errgroup.Group, cacheServer server_structs.XRootDServer) error {
 	log.Debug("Register Cache")
 	metrics.SetComponentHealthStatus(metrics.OriginCache_Registry, metrics.StatusWarning, "Start to register namespaces for the cache server")
-	if err := launcher_utils.RegisterNamespaceWithRetry(ctx, egrp, server_structs.GetCacheNS(param.Xrootd_Sitename.GetString())); err != nil {
+	if err := launcher_utils.RegisterNamespaceWithRetry(ctx, egrp, server_structs.GetCacheNS(param.Server_Hostname.GetString())); err != nil {
 		return err
 	}
 	log.Debug("Cache is registered")

--- a/launchers/origin_serve.go
+++ b/launchers/origin_serve.go
@@ -155,10 +155,9 @@ func OriginServeFinish(ctx context.Context, egrp *errgroup.Group) error {
 
 	metrics.SetComponentHealthStatus(metrics.OriginCache_Registry, metrics.StatusWarning, "Start to register namespaces for the origin server")
 	log.Debug("Register Origin")
-	extUrlStr := param.Server_ExternalWebUrl.GetString()
-	extUrl, _ := url.Parse(extUrlStr)
-	// Only use hostname:port
-	if err := launcher_utils.RegisterNamespaceWithRetry(ctx, egrp, server_structs.GetOriginNs(extUrl.Host)); err != nil {
+	hostname := param.Server_Hostname.GetString()
+	// Only use server's hostname as prefix (without port)
+	if err := launcher_utils.RegisterNamespaceWithRetry(ctx, egrp, server_structs.GetOriginNs(hostname)); err != nil {
 		return err
 	}
 	log.Debug("Origin is registered")

--- a/origin/advertise.go
+++ b/origin/advertise.go
@@ -123,10 +123,9 @@ func (server *OriginServer) CreateAdvertisement(name, originUrlStr, originWebUrl
 
 	// PublicReads implies reads
 	reads := param.Origin_EnableReads.GetBool() || param.Origin_EnablePublicReads.GetBool()
-	extUrlStr := param.Server_ExternalWebUrl.GetString()
-	extUrl, _ := url.Parse(extUrlStr)
-	// Only use hostname:port
-	registryPrefix := server_structs.GetOriginNs(extUrl.Host)
+	hostname := param.Server_Hostname.GetString()
+	// Only use server's hostname as prefix (without port)
+	registryPrefix := server_structs.GetOriginNs(hostname)
 	ad := server_structs.OriginAdvertiseV2{
 		Name:           name,
 		RegistryPrefix: registryPrefix,

--- a/origin/origin_ui.go
+++ b/origin/origin_ui.go
@@ -65,10 +65,9 @@ func handleExports(ctx *gin.Context) {
 
 	res := exportsRes{Type: string(storageType)}
 
-	extUrlStr := param.Server_ExternalWebUrl.GetString()
-	extUrl, _ := url.Parse(extUrlStr)
-	// Only use hostname:port
-	originPrefix := server_structs.GetOriginNs(extUrl.Host)
+	hostname := param.Server_Hostname.GetString()
+	// Only use server's hostname as prefix (without port)
+	originPrefix := server_structs.GetOriginNs(hostname)
 	if !registrationsStatus.Has(originPrefix) {
 		if err := FetchAndSetRegStatus(originPrefix); err != nil {
 			log.Errorf("Failed to fetch registration status from the registry: %v", err)

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -105,7 +105,7 @@ type (
 		// The value is from the Sitename of the server registration in the registry if set, or Xrootd.Sitename if not
 		Name string `json:"name"`
 		// The namespace prefix to register/look up the server in the registry.
-		// The value is /caches/{Xrootd.Sitename} for cache servers and /origins/{Xrootd.Sitename} for the origin servers
+		// The value is /caches/{Server.Hostname} for cache servers and /origins/{Server.Hostname} for the origin servers
 		RegistryPrefix      string            `json:"registry-prefix"`
 		BrokerURL           string            `json:"broker-url,omitempty"`
 		DataURL             string            `json:"data-url" binding:"required"`


### PR DESCRIPTION
This PR unifies the namespace registration for both origin and cache by using their server hostname (without port) as prefix. Before this PR, origin itself registers with "hostname:port" in its own `Server_ExternalWebUrl` as prefix; cache registers with its `Xrootd_Sitename` as prefix (no port). This inconsistency causes plenty of friction. The change in this PR will be a cornerstone for multiple subsequent tickets for Pelican developers.

When this comes into prod, the origin/cache server installed this Pelican version will send serverAd with the updated prefix. OSDF system admin needs to approve server's new advertisement and remove the old registration db entries if necessary. 