### PR TITLE
Fix xrootd log level mapping bug and inherit from Pelican log level

### DIFF
--- a/cmd/config_printer/config_printer_test.go
+++ b/cmd/config_printer/config_printer_test.go
@@ -47,7 +47,7 @@ func setupMockConfig(t *testing.T) error {
 	// Setting Non-default values
 	viper.Set("Logging.Cache.Http", "info")
 	viper.Set("Logging.Cache.Xrootd", "info")
-	viper.Set("Logging.Level", "info")
+	viper.Set("Logging.Level", "trace")
 	viper.Set("Logging.Origin.Http", "info")
 
 	return nil
@@ -76,13 +76,13 @@ func TestConfigGet(t *testing.T) {
 		{
 			name:        "no-arguments",
 			args:        []string{},
-			expected:    []string{`logging.cache.http: "info"`, `logging.cache.xrootd: "info"`, `logging.level: "info"`, `logging.origin.http: "info"`},
+			expected:    []string{`logging.cache.http: "info"`, `logging.cache.xrootd: "info"`, `logging.level: "trace"`, `logging.origin.http: "info"`},
 			notExpected: []string{},
 		},
 		{
 			name:        "match-http",
 			args:        []string{"Http", "level"},
-			expected:    []string{`logging.cache.http: "info"`, `logging.level: "info"`, `logging.origin.http: "info"`},
+			expected:    []string{`logging.cache.http: "info"`, `logging.level: "trace"`, `logging.origin.http: "info"`},
 			notExpected: []string{`logging.cache.xrootd: "info"`},
 		},
 
@@ -90,7 +90,7 @@ func TestConfigGet(t *testing.T) {
 			name:        "match-http-with-origin-flag",
 			args:        []string{"Http", "-m", "origin"},
 			expected:    []string{`logging.origin.http: "info"`},
-			notExpected: []string{`logging.cache.http: "info"`, `logging.cache.xrootd: "info"`, `logging.level: "info"`},
+			notExpected: []string{`logging.cache.http: "info"`, `logging.cache.xrootd: "info"`, `logging.level: "trace"`},
 		},
 	}
 
@@ -187,7 +187,7 @@ func TestConfigSummary(t *testing.T) {
 
 	got := strings.TrimSpace(strings.ToLower(buf.String()))
 
-	expectedLines := []string{`logging:`, `    cache:`, `    origin:`, `    level: info`, `        http: info`}
+	expectedLines := []string{`logging:`, `    cache:`, `    origin:`, `    level: trace`, `        http: info`}
 	notExpectedLines := []string{`debug: true`}
 
 	for _, expected := range expectedLines {

--- a/cmd/config_printer/config_printer_test.go
+++ b/cmd/config_printer/config_printer_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -33,22 +34,30 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 )
 
+// Config commands use ansi encoding for color output. This function strips
+// those characters for easier comparison of expected and actual output.
+func stripAnsiCodes(input string) string {
+	ansiEscape := regexp.MustCompile(`\x1b\[[0-9;]*m`)
+	return ansiEscape.ReplaceAllString(input, "")
+}
+
 // Mock configuration setup
 func setupMockConfig(t *testing.T) error {
+	// Setting Non-default values, mimics what we'd get from config file
+	viper.Set("Logging.Level", "trace")
+	viper.Set("Logging.Cache.Http", "info")
+	viper.Set("Logging.Cache.Xrootd", "info")
+	viper.Set("Logging.Origin.Http", "info")
+
 	// Set default config
-	config.SetBaseDefaultsInConfig(viper.GetViper())
 	viper.Set("ConfigDir", t.TempDir())
+	config.InitConfig()
 	if err := config.SetServerDefaults(viper.GetViper()); err != nil {
 		return err
 	}
 	if err := config.SetClientDefaults(viper.GetViper()); err != nil {
 		return err
 	}
-	// Setting Non-default values
-	viper.Set("Logging.Cache.Http", "info")
-	viper.Set("Logging.Cache.Xrootd", "info")
-	viper.Set("Logging.Level", "trace")
-	viper.Set("Logging.Origin.Http", "info")
 
 	return nil
 }
@@ -119,7 +128,7 @@ func TestConfigGet(t *testing.T) {
 		<-done
 		os.Stdout = oldStdout
 
-		got := strings.TrimSpace(strings.ToLower(buf.String()))
+		got := strings.TrimSpace(strings.ToLower(stripAnsiCodes(buf.String())))
 
 		for _, expected := range expectedLines {
 			expectedLower := strings.ToLower(expected)
@@ -185,7 +194,7 @@ func TestConfigSummary(t *testing.T) {
 	<-done
 	os.Stdout = oldStdout
 
-	got := strings.TrimSpace(strings.ToLower(buf.String()))
+	got := strings.TrimSpace(strings.ToLower(stripAnsiCodes(buf.String())))
 
 	expectedLines := []string{`logging:`, `    cache:`, `    origin:`, `    level: trace`, `        http: info`}
 	notExpectedLines := []string{`debug: true`}

--- a/config/config.go
+++ b/config/config.go
@@ -996,6 +996,18 @@ func SetServerDefaults(v *viper.Viper) error {
 	// we want to be able to check if this is user-provided (which we can't do for defaults.yaml)
 	v.SetDefault(param.Origin_S3UrlStyle.GetName(), "path")
 
+	// At the time of writing this comment, Pelican's default log level is set to "Error". However, that's still
+	// too verbose for some XRootD parameters. Because we generally want to use Pelican's configured log level as a
+	// default for the XRootD parameters, we only set the corrected default values for these special XRootD directives
+	// when Pelican is running in its own default Error level. Otherwise we use Pelican's configured log level as a
+	// default for other params (handled in xrootd/xrootd_config.go::mapXrootdLogLevels).
+	if log.GetLevel() == log.ErrorLevel {
+		v.SetDefault(param.Logging_Origin_Scitokens.GetName(), "fatal")
+		v.SetDefault(param.Logging_Origin_Xrootd.GetName(), "info")
+		v.SetDefault(param.Logging_Cache_Scitokens.GetName(), "fatal")
+		v.SetDefault(param.Logging_Cache_Pfc.GetName(), "info")
+	}
+
 	if IsRootExecution() {
 		v.SetDefault(param.Origin_RunLocation.GetName(), filepath.Join("/run", "pelican", "xrootd", "origin"))
 		v.SetDefault(param.Cache_RunLocation.GetName(), filepath.Join("/run", "pelican", "xrootd", "cache"))

--- a/config/config.go
+++ b/config/config.go
@@ -996,16 +996,43 @@ func SetServerDefaults(v *viper.Viper) error {
 	// we want to be able to check if this is user-provided (which we can't do for defaults.yaml)
 	v.SetDefault(param.Origin_S3UrlStyle.GetName(), "path")
 
-	// At the time of writing this comment, Pelican's default log level is set to "Error". However, that's still
+	// At the time of this comment, Pelican's default log level is set to "Error". However, that's still
 	// too verbose for some XRootD parameters. Because we generally want to use Pelican's configured log level as a
 	// default for the XRootD parameters, we only set the corrected default values for these special XRootD directives
 	// when Pelican is running in its own default Error level. Otherwise we use Pelican's configured log level as a
-	// default for other params (handled in xrootd/xrootd_config.go::mapXrootdLogLevels).
+	// default for other params.
+	defaultLevel := log.GetLevel().String()
+	for _, param := range []param.StringParam{
+		param.Logging_Origin_Cms,
+		param.Logging_Origin_Xrd,
+		param.Logging_Origin_Ofs,
+		param.Logging_Origin_Oss,
+		param.Logging_Origin_Http,
+		param.Logging_Cache_Ofs,
+		param.Logging_Cache_Pss,
+		param.Logging_Cache_PssSetOpt,
+		param.Logging_Cache_Http,
+		param.Logging_Cache_Xrd,
+		param.Logging_Cache_Xrootd,
+	} {
+		v.SetDefault(param.GetName(), defaultLevel)
+	}
+
+	// If Pelican is at its default error level, do our custom mapping
 	if log.GetLevel() == log.ErrorLevel {
 		v.SetDefault(param.Logging_Origin_Scitokens.GetName(), "fatal")
 		v.SetDefault(param.Logging_Origin_Xrootd.GetName(), "info")
 		v.SetDefault(param.Logging_Cache_Scitokens.GetName(), "fatal")
 		v.SetDefault(param.Logging_Cache_Pfc.GetName(), "info")
+	} else { // Otherwise treat them as any other log level
+		for _, param := range []param.StringParam{
+			param.Logging_Origin_Scitokens,
+			param.Logging_Origin_Xrootd,
+			param.Logging_Cache_Scitokens,
+			param.Logging_Cache_Pfc,
+		} {
+			v.SetDefault(param.GetName(), defaultLevel)
+		}
 	}
 
 	if IsRootExecution() {

--- a/config/config.go
+++ b/config/config.go
@@ -1019,7 +1019,7 @@ func SetServerDefaults(v *viper.Viper) error {
 	}
 
 	// If Pelican is at its default error level, do our custom mapping
-	if log.GetLevel() == log.ErrorLevel {
+	if defaultLevel == log.ErrorLevel.String() {
 		v.SetDefault(param.Logging_Origin_Scitokens.GetName(), "fatal")
 		v.SetDefault(param.Logging_Origin_Xrootd.GetName(), "info")
 		v.SetDefault(param.Logging_Cache_Scitokens.GetName(), "fatal")

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -15,7 +15,7 @@
 #
 
 Logging:
-  Level: "Error"
+  Level: error
 Client:
   SlowTransferRampupTime: 100s
   SlowTransferWindow: 30s

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -16,22 +16,6 @@
 
 Logging:
   Level: "Error"
-  Origin:
-    Cms: error
-    Http: error
-    Ofs: error
-    Oss: error
-    Scitokens: fatal
-    Xrd: error
-    Xrootd: info
-  Cache:
-    Http: error
-    Ofs: error
-    Pfc: info
-    Pss: error
-    Scitokens: fatal
-    Xrd: error
-    Xrootd: error
 Client:
   SlowTransferRampupTime: 100s
   SlowTransferWindow: 30s

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -287,6 +287,14 @@ type: string
 default: error
 components: ["cache"]
 ---
+name: Logging.Cache.PssSetOpt
+description: |+
+  Trace level of XRootD Proxy System Service Set Options. This component reports detailed information about the configuration
+  and operational settings of the Proxy System Service. Accepted values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`
+type: string
+default: error
+components: ["cache"]
+---
 name: Logging.Cache.Scitokens
 description: |+
   Trace level of scitokens debug output within XRootD configuration. This entails token management

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -174,8 +174,10 @@ components: ["director"]
 name: Logging.Level
 description: |+
   A string defining the log level of the client. Options include (going from most info to least): Trace, Debug, Info, Warn, Error, Fatal, Panic.
+
+  Log levels are inherited by all components unless explicitly overridden. Levels are case-insensitive.
 type: string
-default: Error
+default: error
 components: ["*"]
 ---
 name: Logging.LogLocation
@@ -199,6 +201,9 @@ description: |+
   connect to a master one informing it if a server is available. XRootD asks cms where a file
   could be found and cms works to report back the server for where the file is located.
   Accepted values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`
+
+  If a non-default value is configured for `Logging.Level`, that level will be inherited unless explicitly
+  overridden here. Levels are case-insensitive.
 type: string
 default: error
 components: ["origin"]
@@ -207,6 +212,9 @@ name: Logging.Origin.Scitokens
 description: |+
   Trace level of scitokens debug output within XRootD configuration. This entails token management
   and security credentials within XRootD. Accepted values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`
+
+  If a non-default value is configured for `Logging.Level`, that level will be inherited unless explicitly
+  overridden here. Levels are case-insensitive.
 type: string
 default: fatal
 components: ["origin"]
@@ -215,6 +223,9 @@ name: Logging.Origin.Xrd
 description: |+
   Trace level of the eXtended Request Daemon within XRootD, another main XRootD executable. This reports information
   the XRootD protocol and works with cms. Accepted values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`
+
+  If a non-default value is configured for `Logging.Level`, that level will be inherited unless explicitly
+  overridden here. Levels are case-insensitive.
 type: string
 default: error
 components: ["origin"]
@@ -223,7 +234,11 @@ name: Logging.Origin.Xrootd
 description: |+
   Trace options for XRootD debug output within XRootD configuration. This prefix is reserved for the xroot protocol,
   which is the component that sits on sockets and talks to clients as they query file-system info, open files, and read data.
-  This is the protocol for XRootD (like http) and handles connections and requests. Accepted values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`
+  This is the protocol for XRootD (like http) and handles connections and requests. Accepted values: `trace`, `debug`, `info`,
+  `warn`, `error`, `fatal`, `panic`
+
+  If a non-default value is configured for `Logging.Level`, that level will be inherited unless explicitly
+  overridden here. Levels are case-insensitive.
 type: string
 default: info
 components: ["origin"]
@@ -233,6 +248,9 @@ description: |+
   Logging level for the HTTP component of the origin. Increasing to debug
   will cause the Xrootd daemon to log all headers and requests.
   Accepted values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`
+
+  If a non-default value is configured for `Logging.Level`, that level will be inherited unless explicitly
+  overridden here. Levels are case-insensitive.
 type: string
 default: error
 components: ["origin"]
@@ -241,6 +259,9 @@ name: Logging.Origin.Ofs
 description: |+
   Logging level of Xrootd's "Open File System" (ofs) subsystem.  The OFS manages the file descriptor table and redirection/
   error handling. Accepted values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`
+
+  If a non-default value is configured for `Logging.Level`, that level will be inherited unless explicitly
+  overridden here. Levels are case-insensitive.
 type: string
 default: error
 components: ["origin"]
@@ -249,6 +270,9 @@ name: Logging.Origin.Oss
 description: |+
   Logging level of Xrootd's "Open Storage System" (oss) subsystem.  The OSS manages the interaction with the underlying
   POSIX storage (open, read, write, close, etc). Accepted values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`
+
+  If a non-default value is configured for `Logging.Level`, that level will be inherited unless explicitly
+  overridden here. Levels are case-insensitive.
 type: string
 default: error
 components: ["origin"]
@@ -257,6 +281,9 @@ name: Logging.Cache.Http
 description: |+
   Logging level for the HTTP component of the cache.  Increasing to debug will cause the Xrootd daemon to log
   all headers and requests. Accepted values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`
+
+  If a non-default value is configured for `Logging.Level`, that level will be inherited unless explicitly
+  overridden here. Levels are case-insensitive.
 type: string
 default: error
 components: ["cache"]
@@ -266,6 +293,9 @@ description: |+
   Trace level of XRootD's Open File System. This component cares about files and directories from the administrative perspective.
   This component is build on top of the Open Storage System component, which deals with things like file creation and reads and
   writes for files and directories. Accepted values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`
+
+  If a non-default value is configured for `Logging.Level`, that level will be inherited unless explicitly
+  overridden here. Levels are case-insensitive.
 type: string
 default: error
 components: ["cache"]
@@ -275,6 +305,9 @@ description: |+
   Trace level of XRootD Proxy File Cache (XCache), the caching mechanism used by XRootD. This component
   entails information for caches/caching within XRootD. This component instantiates its own Open Storage
   System (OSS) to write local files to. Accepted values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`
+
+  If a non-default value is configured for `Logging.Level`, that level will be inherited unless explicitly
+  overridden here. Levels are case-insensitive.
 type: string
 default: info
 components: ["cache"]
@@ -282,7 +315,11 @@ components: ["cache"]
 name: Logging.Cache.Pss
 description: |+
   Trace level of XRootD Proxy System Service. Variables this component reports include: number of remotes file opens,
-  number of opens that failed, number of remote file closes, and number of closes that failed. Accepted values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`
+  number of opens that failed, number of remote file closes, and number of closes that failed. Accepted values: `trace`, `debug`,
+  `info`, `warn`, `error`, `fatal`, `panic`
+
+  If a non-default value is configured for `Logging.Level`, that level will be inherited unless explicitly
+  overridden here. Levels are case-insensitive.
 type: string
 default: error
 components: ["cache"]
@@ -291,6 +328,9 @@ name: Logging.Cache.PssSetOpt
 description: |+
   Trace level of XRootD Proxy System Service Set Options. This component reports detailed information about the configuration
   and operational settings of the Proxy System Service. Accepted values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`
+
+  If a non-default value is configured for `Logging.Level`, that level will be inherited unless explicitly
+  overridden here. Levels are case-insensitive.
 type: string
 default: error
 components: ["cache"]
@@ -299,6 +339,9 @@ name: Logging.Cache.Scitokens
 description: |+
   Trace level of scitokens debug output within XRootD configuration. This entails token management
   and security credentials within XRootD. Accepted values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`
+
+  If a non-default value is configured for `Logging.Level`, that level will be inherited unless explicitly
+  overridden here. Levels are case-insensitive.
 type: string
 default: fatal
 components: ["cache"]
@@ -307,6 +350,9 @@ name: Logging.Cache.Xrd
 description: |+
   Trace level of the eXtended Request Daemon within XRootD, another main XRootD executable. This reports information
   the XRootD protocol and works with cms. Accepted values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`
+
+  If a non-default value is configured for `Logging.Level`, that level will be inherited unless explicitly
+  overridden here. Levels are case-insensitive.
 type: string
 default: error
 components: ["cache"]
@@ -316,6 +362,9 @@ description: |+
   Trace options for XRootD debug output within XRootD configuration. This prefix is reserved for the xroot protocol,
   which is the component that sits on sockets and talks to clients as they query file-system info, open files, and read data.
   This is the protocol for XRootD (like http) and handles connections and requests. Accepted values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`
+
+  If a non-default value is configured for `Logging.Level`, that level will be inherited unless explicitly
+  overridden here. Levels are case-insensitive.
 type: string
 default: error
 components: ["cache"]

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -189,6 +189,7 @@ var (
 	Logging_Cache_Ofs = StringParam{"Logging.Cache.Ofs"}
 	Logging_Cache_Pfc = StringParam{"Logging.Cache.Pfc"}
 	Logging_Cache_Pss = StringParam{"Logging.Cache.Pss"}
+	Logging_Cache_PssSetOpt = StringParam{"Logging.Cache.PssSetOpt"}
 	Logging_Cache_Scitokens = StringParam{"Logging.Cache.Scitokens"}
 	Logging_Cache_Xrd = StringParam{"Logging.Cache.Xrd"}
 	Logging_Cache_Xrootd = StringParam{"Logging.Cache.Xrootd"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -143,6 +143,7 @@ type Config struct {
 			Ofs string `mapstructure:"ofs" yaml:"Ofs"`
 			Pfc string `mapstructure:"pfc" yaml:"Pfc"`
 			Pss string `mapstructure:"pss" yaml:"Pss"`
+			PssSetOpt string `mapstructure:"psssetopt" yaml:"PssSetOpt"`
 			Scitokens string `mapstructure:"scitokens" yaml:"Scitokens"`
 			Xrd string `mapstructure:"xrd" yaml:"Xrd"`
 			Xrootd string `mapstructure:"xrootd" yaml:"Xrootd"`
@@ -469,6 +470,7 @@ type configWithType struct {
 			Ofs struct { Type string; Value string }
 			Pfc struct { Type string; Value string }
 			Pss struct { Type string; Value string }
+			PssSetOpt struct { Type string; Value string }
 			Scitokens struct { Type string; Value string }
 			Xrd struct { Type string; Value string }
 			Xrootd struct { Type string; Value string }

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -1030,7 +1030,7 @@ func genLoggingConfig(input string, logMap loggingMap) (string, error) {
 
 	level := levelMap[strings.ToLower(input)]
 	if level == "" {
-		return "", errors.Errorf("unrecognized input log level %s", input)
+		return "", errors.Errorf("unrecognized input log level '%s'", input)
 	}
 
 	return level, nil

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -955,166 +955,191 @@ func SetUpMonitoring(ctx context.Context, egrp *errgroup.Group) error {
 	return nil
 }
 
-func genLoggingConfig(config string, xrdConfig *XrootdConfig, configVal string, logMap loggingMap) (string, error) {
-	xrootdConfigLogLevel, err := log.ParseLevel(configVal)
-	if err != nil {
-		return "", errors.Wrapf(err, "Error parsing specified log level for %s, proper values include: panic, fatal, error, warn, info, debug, trace", config)
+// genLoggingConfig is a helper function that handles mapping input log levels to
+// log levels for XRootD components. In the event that the input log level doesn't have
+// a concretely-defined mapping for the XRootD component, it will get the next best level
+// of verbocity for which there is a defined mapping. If the input log level is empty, it
+// will inherit the log level from Pelican's log level.
+//
+// For example, an input loggingMap of:
+//
+//	loggingMap{
+//	  Info:  "bar",
+//	  Error: "foo",
+//	}
+//
+// Should result in the following mappings:
+//
+//	"trace" --> "bar"
+//	"debug" --> "bar"
+//	"info"  --> "bar"
+//	"warn"  --> "bar"
+//	"error" --> "foo"
+//	"fatal" --> "foo"
+//	"panic" --> "foo"
+func genLoggingConfig(input string, logMap loggingMap) (string, error) {
+	// If no input is configured, inherit from Pelican's log level
+	if input == "" {
+		// Grab the log level directly from param, not from the logrus object
+		// itself, which has a lot of fancy schmancy stuff that in effect makes it look
+		// like it's debug when Pelican uses its default "Error" level.
+		input = param.Logging_Level.GetString()
 	}
 
-	var previousValue string
+	orderedLevels := []string{
+		"Panic",
+		"Fatal",
+		"Error",
+		"Warn",
+		"Info",
+		"Debug",
+		"Trace",
+	}
 
-	// Iterate thru the map struct to see what values are set
-	logStruct := reflect.TypeOf(logMap)
-	logValue := reflect.ValueOf(logMap)
-	for i := 0; i < logStruct.NumField(); i++ {
-		field := logStruct.Field(i)
-		value := logValue.Field(i)
-		strValue := value.String()
+	levelMap := make(map[string]string, len(orderedLevels))
+	v := reflect.ValueOf(logMap)
 
-		// We get the logLevel of the field and check if it is the level we want
-		fieldLogLevel, err := log.ParseLevel(field.Name)
-		if err != nil {
-			return "", errors.Wrap(err, "Not a valid log level within logMap")
+	var lastValidValue string
+	comeBackTo := make([]string, 0, len(orderedLevels))
+	goneBack := false
+	for _, level := range orderedLevels {
+		field := v.FieldByName(level)
+		if field.IsValid() && field.Kind() == reflect.String && field.String() != "" {
+			lastValidValue = field.String()
 		}
-
-		// If we have a match we assign the value to xrootd config (the value should never be "")
-		if fieldLogLevel == xrootdConfigLogLevel && strValue != "" {
-			return strValue, nil
-		} else if fieldLogLevel == xrootdConfigLogLevel && strValue == "" {
-			// if we have no previous value, we return an error
-			if previousValue == "" {
-				if i > 1 {
-					// if we have room to get more previous levels, get them
-					return genLoggingConfig(config, xrdConfig, (xrootdConfigLogLevel + 1).String(), logMap)
-				}
-				return "", errors.New("Unset specified log level without a previous value, loggingMap passed to function needs fixing")
-			} else {
-				// If we have no value, get the previous
-				return previousValue, nil
+		// If we haven't yet encountered a valid log level for the component,
+		// we need to back-assign the first valid map we find.
+		if lastValidValue == "" && !goneBack {
+			comeBackTo = append(comeBackTo, level)
+			continue
+		}
+		if !goneBack {
+			goneBack = true
+			for _, unmappedLevel := range comeBackTo {
+				levelMap[strings.ToLower(unmappedLevel)] = lastValidValue
 			}
-		} else {
-			// else we continue and set the previous value
-			previousValue = strValue
 		}
 
+		levelMap[strings.ToLower(level)] = lastValidValue
 	}
-	return "", errors.New("No set log levels within loggingMap that match desired log level")
+
+	// Just in case the programmer provided an empty map
+	if len(levelMap) == 0 {
+		return "", errors.New("the logging map is empty -- this is a Pelican bug, not a user error!")
+	}
+
+	level := levelMap[strings.ToLower(input)]
+	if level == "" {
+		return "", errors.Errorf("unrecognized input log level %s", input)
+	}
+
+	return level, nil
 }
 
 // mapXrootdLogLevels is utilized to map Pelican config values to Xrootd ones
 // this is used to keep our log levels for Xrootd simple, so one does not need
 // to be an Xrootd expert to understand the inconsistent logs within Xrootd
 func mapXrootdLogLevels(xrdConfig *XrootdConfig) error {
-
 	/////////////////////////ORIGIN/////////////////////////////
 	// Origin Cms
 	// https://xrootd.slac.stanford.edu/doc/dev54/cms_config.htm
 	var err error
-	xrdConfig.Logging.OriginCms, err = genLoggingConfig("cms", xrdConfig, param.Logging_Origin_Cms.GetString(), loggingMap{
+	if xrdConfig.Logging.OriginCms, err = genLoggingConfig(param.Logging_Origin_Cms.GetString(), loggingMap{
 		Trace: "debug",
 		Debug: "debug",
 		Info:  "all",
 		Error: "-all",
-	})
-	if err != nil {
-		return errors.Wrap(err, "Error parsing specified log level for Origin_Cms")
+	}); err != nil {
+		return errors.Wrapf(err, "failed to map logging level for Logging.Origin.Cms")
 	}
 
 	// Origin Scitokens
 	// https://github.com/xrootd/xrootd/blob/8f8498d66aa583c54c0875bb1cfe432f4be040f4/src/XrdSciTokens/XrdSciTokensAccess.cc#L951-L963
-	xrdConfig.Logging.OriginScitokens, err = genLoggingConfig("scitokens", xrdConfig, param.Logging_Origin_Scitokens.GetString(), loggingMap{
+	if xrdConfig.Logging.OriginScitokens, err = genLoggingConfig(param.Logging_Origin_Scitokens.GetString(), loggingMap{
 		Trace: "all",
 		Debug: "debug info warning error",
 		Info:  "info warning error",
 		Warn:  "warning error",
 		Error: "error",
 		Fatal: "none",
-	})
-	if err != nil {
-		return errors.Wrap(err, "Error parsing specified log level for Origin_Scitokens")
+	}); err != nil {
+		return errors.Wrapf(err, "failed to map logging level for Logging.Origin.Scitokens")
 	}
 
 	// Origin Xrd
 	// https://xrootd.slac.stanford.edu/doc/dev56/xrd_config.htm
-	xrdConfig.Logging.OriginXrd, err = genLoggingConfig("xrd", xrdConfig, param.Logging_Origin_Xrd.GetString(), loggingMap{
+	if xrdConfig.Logging.OriginXrd, err = genLoggingConfig(param.Logging_Origin_Xrd.GetString(), loggingMap{
 		Trace: "all",
 		Debug: "debug",
 		Info:  "-all",
-	})
-	if err != nil {
-		return errors.Wrap(err, "Error parsing specified log level for Origin_Xrd")
+	}); err != nil {
+		return errors.Wrapf(err, "failed to map logging level for Logging.Origin.Xrd")
 	}
 
 	// Origin Xrootd
 	// https://xrootd.slac.stanford.edu/doc/dev56/xrd_config.htm
-	xrdConfig.Logging.OriginXrootd, err = genLoggingConfig("xrootd", xrdConfig, param.Logging_Origin_Xrootd.GetString(), loggingMap{
+	if xrdConfig.Logging.OriginXrootd, err = genLoggingConfig(param.Logging_Origin_Xrootd.GetString(), loggingMap{
 		Trace: "all",
 		Debug: "debug",
 		Info:  "emsg login stall redirect", // what we had set originally
 		Warn:  "emsg",                      // errors sent back to the client
 		Error: "-all",
-	})
-	if err != nil {
-		return errors.Wrap(err, "Error parsing specified log level for Origin_Xrootd")
+	}); err != nil {
+		return errors.Wrapf(err, "failed to map logging level for Logging.Origin.Xrootd")
 	}
 
 	// Origin Ofs
 	// https://xrootd.slac.stanford.edu/doc/dev56/ofs_config.htm
-	xrdConfig.Logging.OriginOfs, err = genLoggingConfig("ofs", xrdConfig, param.Logging_Origin_Ofs.GetString(), loggingMap{
+	if xrdConfig.Logging.OriginOfs, err = genLoggingConfig(param.Logging_Origin_Ofs.GetString(), loggingMap{
 		Trace: "all",
 		Debug: "debug",
 		Info:  "info",
 		Warn:  "most",
 		Error: "-all",
-	})
-	if err != nil {
-		return errors.Wrap(err, "Error parsing specified log level for Logging.Origin.Ofs")
+	}); err != nil {
+		return errors.Wrapf(err, "failed to map logging level for Logging.Origin.Ofs")
 	}
 
 	// Origin Oss
-	xrdConfig.Logging.OriginOss, err = genLoggingConfig("oss", xrdConfig, param.Logging_Origin_Oss.GetString(), loggingMap{
+	if xrdConfig.Logging.OriginOss, err = genLoggingConfig(param.Logging_Origin_Oss.GetString(), loggingMap{
 		Trace: "all",
 		Info:  "-all",
-	})
-	if err != nil {
-		return errors.Wrap(err, "Error parsing specified log level for Logging.Origin.Oss")
+	}); err != nil {
+		return errors.Wrapf(err, "failed to map logging level for Logging.Origin.Oss")
 	}
 
 	// Origin HTTP
-	xrdConfig.Logging.OriginHttp, err = genLoggingConfig("http", xrdConfig, param.Logging_Origin_Http.GetString(), loggingMap{
+	if xrdConfig.Logging.OriginHttp, err = genLoggingConfig(param.Logging_Origin_Http.GetString(), loggingMap{
 		Debug: "all",
 		Info:  "none",
-	})
-	if err != nil {
-		return errors.Wrap(err, "Error parsing specified log level for Logging.Origin.Http")
+	}); err != nil {
+		return errors.Wrapf(err, "failed to map logging level for Logging.Origin.Http")
 	}
 
 	//////////////////////////CACHE/////////////////////////////
 	// Cache Ofs
 	// https://xrootd.slac.stanford.edu/doc/dev56/ofs_config.htm
-	xrdConfig.Logging.CacheOfs, err = genLoggingConfig("Ofs", xrdConfig, param.Logging_Cache_Ofs.GetString(), loggingMap{
+	if xrdConfig.Logging.CacheOfs, err = genLoggingConfig(param.Logging_Cache_Ofs.GetString(), loggingMap{
 		Trace: "all",
 		Debug: "debug",
 		Info:  "info",
 		Warn:  "most",
 		Error: "-all",
-	})
-	if err != nil {
-		return errors.Wrap(err, "Error parsing specified log level for Cache_Ofs")
+	}); err != nil {
+		return errors.Wrapf(err, "failed to map logging level for Logging.Cache.Ofs")
 	}
 
 	// Cache Pfc
 	// https://xrootd.slac.stanford.edu/doc/dev56/pss_config.htm
-	xrdConfig.Logging.CachePfc, err = genLoggingConfig("pfc", xrdConfig, param.Logging_Cache_Pfc.GetString(), loggingMap{
+	if xrdConfig.Logging.CachePfc, err = genLoggingConfig(param.Logging_Cache_Pfc.GetString(), loggingMap{
 		Trace: "dump",
 		Debug: "debug",
 		Info:  "info",
 		Warn:  "warning",
 		Error: "error",
 		Fatal: "none",
-	})
-	if err != nil {
-		return errors.Wrap(err, "Error parsing specified log level for Cache_Pfc")
+	}); err != nil {
+		return errors.Wrapf(err, "failed to map logging level for Logging.Cache.Pfc")
 	}
 
 	// Cache PssSetOptCache and Cache Pss
@@ -1124,73 +1149,67 @@ func mapXrootdLogLevels(xrdConfig *XrootdConfig) error {
 	// on      warning events.
 	// debug   error events.
 	// Therefore the following pss.trace I came up with is what follows:
-	xrdConfig.Logging.CachePss, err = genLoggingConfig("pss", xrdConfig, param.Logging_Cache_Pss.GetString(), loggingMap{
+	if xrdConfig.Logging.CachePss, err = genLoggingConfig(param.Logging_Cache_Pss.GetString(), loggingMap{
 		Trace: "all",
 		Info:  "on",
 		Warn:  "debug",
 		Error: "off",
-	})
-	if err != nil {
-		return errors.Wrap(err, "Error parsing specified log level for Cache_Pss")
+	}); err != nil {
+		return errors.Wrapf(err, "failed to map logging level for Logging.Cache.Pss")
 	}
 
-	// Setopt:
-	xrdConfig.Logging.PssSetOptCache, err = genLoggingConfig("pss", xrdConfig, param.Logging_Cache_Pss.GetString(), loggingMap{
+	// Cache Setopt:
+	if xrdConfig.Logging.PssSetOptCache, err = genLoggingConfig(param.Logging_Cache_PssSetOpt.GetString(), loggingMap{
 		Trace: "DebugLevel 4",
 		Info:  "DebugLevel 3",
 		Warn:  "DebugLevel 2",
 		Error: "DebugLevel 1",
 		Fatal: "DebugLevel 0",
-	})
-	if err != nil {
-		return errors.Wrap(err, "Error parsing specified log level for Cache_Pss")
+	}); err != nil {
+		return errors.Wrapf(err, "failed to map logging level for Logging.Cache.PssSetOpt")
 	}
 
 	// Cache HTTP
-	xrdConfig.Logging.CacheHttp, err = genLoggingConfig("http", xrdConfig, param.Logging_Cache_Http.GetString(), loggingMap{
+	if xrdConfig.Logging.CacheHttp, err = genLoggingConfig(param.Logging_Cache_Http.GetString(), loggingMap{
 		Debug: "all",
 		Info:  "none",
-	})
-	if err != nil {
-		return errors.Wrap(err, "Error parsing specified log level for Logging.Cache.Http")
+	}); err != nil {
+		return errors.Wrapf(err, "failed to map logging level for Logging.Cache.Http")
 	}
 
 	// Cache Scitokens
 	// https://github.com/xrootd/xrootd/blob/8f8498d66aa583c54c0875bb1cfe432f4be040f4/src/XrdSciTokens/XrdSciTokensAccess.cc#L951-L963
-	xrdConfig.Logging.CacheScitokens, err = genLoggingConfig("scitokens", xrdConfig, param.Logging_Cache_Scitokens.GetString(), loggingMap{
+	if xrdConfig.Logging.CacheScitokens, err = genLoggingConfig(param.Logging_Cache_Scitokens.GetString(), loggingMap{
 		Trace: "all",
 		Debug: "debug info warning error",
 		Info:  "info warning error",
 		Warn:  "warning error",
 		Error: "error",
 		Fatal: "none",
-	})
-	if err != nil {
-		return errors.Wrap(err, "Error parsing specified log level for Cache_Scitokens")
+	}); err != nil {
+		return errors.Wrapf(err, "failed to map logging level for Logging.Cache.Scitokens")
 	}
 
 	// Cache Xrd
 	// https://xrootd.slac.stanford.edu/doc/dev56/xrd_config.htm
-	xrdConfig.Logging.CacheXrd, err = genLoggingConfig("xrd", xrdConfig, param.Logging_Cache_Xrd.GetString(), loggingMap{
+	if xrdConfig.Logging.CacheXrd, err = genLoggingConfig(param.Logging_Cache_Xrd.GetString(), loggingMap{
 		Trace: "all",
 		Debug: "debug",
 		Info:  "-all",
-	})
-	if err != nil {
-		return errors.Wrap(err, "Error parsing specified log level for Cache_Xrd")
+	}); err != nil {
+		return errors.Wrapf(err, "failed to map logging level for Logging.Cache.Xrd")
 	}
 
 	// Cache Xrootd
 	// https://xrootd.slac.stanford.edu/doc/dev56/xrd_config.htm
-	xrdConfig.Logging.CacheXrootd, err = genLoggingConfig("xrootd", xrdConfig, param.Logging_Cache_Xrootd.GetString(), loggingMap{
+	if xrdConfig.Logging.CacheXrootd, err = genLoggingConfig(param.Logging_Cache_Xrootd.GetString(), loggingMap{
 		Trace: "all",
 		Debug: "debug",
 		Info:  "emsg login stall redirect", // what we had set originally
 		Warn:  "emsg",                      // errors sent back to the client
 		Error: "-all",
-	})
-	if err != nil {
-		return errors.Wrap(err, "Error parsing specified log level for Cache_Xrootd")
+	}); err != nil {
+		return errors.Wrapf(err, "failed to map logging level for Logging.Cache.Xrootd")
 	}
 
 	return nil

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -98,153 +98,53 @@ func TestXrootDOriginConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, configPath)
 
-	t.Run("TestOriginCmsCorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
+	tests := []struct {
+		name            string
+		configKey       string
+		configValue     string
+		shouldError     bool
+		expectedContent string
+	}{
+		{"TestOriginCmsCorrectConfig", "Logging.Origin.Cms", "debug", false, "cms.trace debug"},
+		{"TestOriginCmsIncorrectConfig", "Logging.Origin.Cms", "degub", true, ""},
+		{"TestOriginScitokensCorrectConfig", "Logging.Origin.Scitokens", "debug", false, "scitokens.trace debug"},
+		{"TestOriginScitokensIncorrectConfig", "Logging.Origin.Scitokens", "degub", true, ""},
+		{"TestOriginXrdCorrectConfig", "Logging.Origin.Xrd", "debug", false, "xrd.trace debug"},
+		{"TestOriginXrdIncorrectConfig", "Logging.Origin.Xrd", "degub", true, ""},
+		{"TestOriginXrootdCorrectConfig", "Logging.Origin.Xrootd", "debug", false, "xrootd.trace debug"},
+		{"TestOriginXrootdIncorrectConfig", "Logging.Origin.Xrootd", "degub", true, ""},
+	}
 
-		// Set our config
-		viper.Set("Logging.Origin.Cms", "debug")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer server_utils.ResetTestState()
 
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, true)
-		require.NoError(t, err)
-		assert.NotNil(t, configPath)
+			xrootd := xrootdTest{T: t}
+			xrootd.setup()
 
-		// Verify the output
-		file, err := os.Open(configPath)
-		assert.NoError(t, err)
-		defer file.Close()
+			if tt.configKey != "" {
+				viper.Set(tt.configKey, tt.configValue)
+			}
 
-		content, err := io.ReadAll(file)
-		assert.NoError(t, err)
-		assert.Contains(t, string(content), "cms.trace debug")
-		server_utils.ResetTestState()
-	})
+			configPath, err := ConfigXrootd(ctx, true)
+			if tt.shouldError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, configPath)
 
-	t.Run("TestOriginCmsIncorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
+				file, err := os.Open(configPath)
+				assert.NoError(t, err)
+				defer file.Close()
 
-		// Set our config
-		viper.Set("Logging.Origin.Cms", "degub")
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, true)
-		require.Error(t, err)
-		assert.NotNil(t, configPath)
-		server_utils.ResetTestState()
-	})
-
-	t.Run("TestOriginScitokensCorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Origin.Scitokens", "debug")
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, true)
-		require.NoError(t, err)
-		assert.NotNil(t, configPath)
-
-		// Verify the output
-		file, err := os.Open(configPath)
-		assert.NoError(t, err)
-		defer file.Close()
-
-		content, err := io.ReadAll(file)
-		assert.NoError(t, err)
-		assert.Contains(t, string(content), "scitokens.trace debug")
-		server_utils.ResetTestState()
-	})
-
-	t.Run("TestOriginScitokensIncorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Origin.Scitokens", "degub")
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, true)
-		require.Error(t, err)
-		assert.NotNil(t, configPath)
-		server_utils.ResetTestState()
-	})
-
-	t.Run("TestOriginXrdCorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Origin.Xrd", "debug")
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, true)
-		require.NoError(t, err)
-		assert.NotNil(t, configPath)
-
-		// Verify the output
-		file, err := os.Open(configPath)
-		assert.NoError(t, err)
-		defer file.Close()
-
-		content, err := io.ReadAll(file)
-		assert.NoError(t, err)
-		assert.Contains(t, string(content), "xrd.trace debug")
-		server_utils.ResetTestState()
-	})
-
-	t.Run("TestOriginXrdIncorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Origin.Xrd", "degub")
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, true)
-		require.Error(t, err)
-		assert.NotNil(t, configPath)
-		server_utils.ResetTestState()
-	})
-
-	t.Run("TestOriginXrootdCorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Origin.Xrootd", "debug")
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, true)
-		require.NoError(t, err)
-		assert.NotNil(t, configPath)
-
-		// Verify the output
-		file, err := os.Open(configPath)
-		assert.NoError(t, err)
-		defer file.Close()
-
-		content, err := io.ReadAll(file)
-		assert.NoError(t, err)
-		assert.Contains(t, string(content), "xrootd.trace debug")
-		server_utils.ResetTestState()
-	})
-
-	t.Run("TestOriginXrootdIncorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Origin.Xrootd", "degub")
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, true)
-		require.Error(t, err)
-		assert.NotNil(t, configPath)
-		server_utils.ResetTestState()
-	})
+				content, err := io.ReadAll(file)
+				assert.NoError(t, err)
+				if tt.expectedContent != "" {
+					assert.Contains(t, string(content), tt.expectedContent)
+				}
+			}
+		})
+	}
 
 	t.Run("TestOsdfWithXRDHOSTAndPort", func(t *testing.T) {
 		xrootd := xrootdTest{T: t}
@@ -318,269 +218,60 @@ func TestXrootDCacheConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, configPath)
 
-	t.Run("TestCacheThrottlePluginEnabled", func(t *testing.T) {
-		defer server_utils.ResetTestState()
+	tests := []struct {
+		name            string
+		configKey       string
+		configValue     string
+		shouldError     bool
+		expectedContent string
+	}{
+		{"TestCacheThrottlePluginEnabled", "Cache.Concurrency", "10", false, "xrootd.fslib ++ throttle"},
+		{"TestCacheThrottlePluginDisabled", "", "", false, ""},
+		{"TestCacheOfsCorrectConfig", "Logging.Cache.Ofs", "debug", false, "ofs.trace debug"},
+		{"TestCacheOfsIncorrectConfig", "Logging.Cache.Ofs", "degub", true, ""},
+		{"TestCachePfcCorrectConfig", "Logging.Cache.Pfc", "debug", false, "pfc.trace debug"},
+		{"TestCachePfcIncorrectConfig", "Logging.Cache.Pfc", "degub", true, ""},
+		{"TestCachePssCorrectConfig", "Logging.Cache.Pss", "debug", false, "pss.trace on"},
+		{"TestCachePssIncorrectConfig", "Logging.Cache.Pss", "degub", true, ""},
+		{"TestCachePssSetOptCorrectConfig", "Logging.Cache.PssSetOpt", "debug", false, "pss.setopt DebugLevel 3"},
+		{"TestCacheScitokensCorrectConfig", "Logging.Cache.Scitokens", "debug", false, "scitokens.trace debug"},
+		{"TestCacheScitokensIncorrectConfig", "Logging.Cache.Scitokens", "degub", true, ""},
+		{"TestCacheXrdCorrectConfig", "Logging.Cache.Xrd", "debug", false, "xrd.trace debug"},
+		{"TestCacheXrdIncorrectConfig", "Logging.Cache.Xrd", "degub", true, ""},
+		{"TestCacheXrootdCorrectConfig", "Logging.Cache.Xrootd", "debug", false, "xrootd.trace debug"},
+		{"TestCacheXrootdIncorrectConfig", "Logging.Cache.Xrootd", "degub", true, ""},
+	}
 
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer server_utils.ResetTestState()
 
-		// Set our config
-		viper.Set("Cache.Concurrency", 10)
+			xrootd := xrootdTest{T: t}
+			xrootd.setup()
 
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, false)
-		require.NoError(t, err)
-		assert.NotNil(t, configPath)
+			if tt.configKey != "" {
+				viper.Set(tt.configKey, tt.configValue)
+			}
 
-		// Verify the output
-		file, err := os.Open(configPath)
-		assert.NoError(t, err)
-		defer file.Close()
+			configPath, err := ConfigXrootd(ctx, false)
+			if tt.shouldError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, configPath)
 
-		content, err := io.ReadAll(file)
-		assert.NoError(t, err)
-		assert.Contains(t, string(content), "xrootd.fslib ++ throttle")
-		assert.Contains(t, string(content), "throttle.throttle concurrency 10")
-	})
+				file, err := os.Open(configPath)
+				assert.NoError(t, err)
+				defer file.Close()
 
-	t.Run("TestCacheThrottlePluginDisabled", func(t *testing.T) {
-		defer server_utils.ResetTestState()
-
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, false)
-		require.NoError(t, err)
-		assert.NotNil(t, configPath)
-
-		// Verify the output
-		file, err := os.Open(configPath)
-		assert.NoError(t, err)
-		defer file.Close()
-
-		content, err := io.ReadAll(file)
-		assert.NoError(t, err)
-		assert.NotContains(t, string(content), "xrootd.fslib throttle default")
-		assert.NotContains(t, string(content), "throttle.throttle concurrency")
-	})
-
-	t.Run("TestCacheOfsCorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Cache.Ofs", "debug")
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, false)
-		require.NoError(t, err)
-		assert.NotNil(t, configPath)
-
-		// Verify the output
-		file, err := os.Open(configPath)
-		assert.NoError(t, err)
-		defer file.Close()
-
-		content, err := io.ReadAll(file)
-		assert.NoError(t, err)
-		assert.Contains(t, string(content), "ofs.trace debug")
-		server_utils.ResetTestState()
-	})
-
-	t.Run("TestCacheOfsIncorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Cache.Ofs", "degub")
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, false)
-		require.Error(t, err)
-		assert.NotNil(t, configPath)
-	})
-
-	t.Run("TestCachePfcCorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Cache.Pfc", "debug")
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, false)
-		require.NoError(t, err)
-		assert.NotNil(t, configPath)
-
-		// Verify the output
-		file, err := os.Open(configPath)
-		assert.NoError(t, err)
-		defer file.Close()
-
-		content, err := io.ReadAll(file)
-		assert.NoError(t, err)
-		assert.Contains(t, string(content), "pfc.trace debug")
-		server_utils.ResetTestState()
-	})
-
-	t.Run("TestCachePfcIncorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Cache.Pfc", "degub")
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, true)
-		require.Error(t, err)
-		assert.NotNil(t, configPath)
-		server_utils.ResetTestState()
-	})
-
-	t.Run("TestCachePssCorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Cache.Pss", "debug")
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, false)
-		require.NoError(t, err)
-		assert.NotNil(t, configPath)
-
-		// Verify the output
-		file, err := os.Open(configPath)
-		assert.NoError(t, err)
-		defer file.Close()
-
-		content, err := io.ReadAll(file)
-		assert.NoError(t, err)
-		assert.Contains(t, string(content), "pss.setopt DebugLevel 4")
-		server_utils.ResetTestState()
-	})
-
-	t.Run("TestCachePssIncorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Cache.Pss", "degub")
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, false)
-		require.Error(t, err)
-		assert.NotNil(t, configPath)
-	})
-
-	t.Run("TestCacheScitokensCorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Cache.Scitokens", "debug")
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, false)
-		require.NoError(t, err)
-		assert.NotNil(t, configPath)
-
-		// Verify the output
-		file, err := os.Open(configPath)
-		assert.NoError(t, err)
-		defer file.Close()
-
-		content, err := io.ReadAll(file)
-		assert.NoError(t, err)
-		assert.Contains(t, string(content), "scitokens.trace debug")
-		server_utils.ResetTestState()
-	})
-
-	t.Run("TestCacheScitokensIncorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Cache.Scitokens", "degub")
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, false)
-		require.Error(t, err)
-		assert.NotNil(t, configPath)
-	})
-
-	t.Run("TestCacheXrdCorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Cache.Xrd", "debug")
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, false)
-		require.NoError(t, err)
-		assert.NotNil(t, configPath)
-
-		// Verify the output
-		file, err := os.Open(configPath)
-		assert.NoError(t, err)
-		defer file.Close()
-
-		content, err := io.ReadAll(file)
-		assert.NoError(t, err)
-		assert.Contains(t, string(content), "xrd.trace debug")
-		server_utils.ResetTestState()
-	})
-
-	t.Run("TestCacheXrdIncorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Cache.Xrd", "degub")
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, false)
-		require.Error(t, err)
-		assert.NotNil(t, configPath)
-	})
-
-	t.Run("TestCacheXrootdCorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Cache.Xrootd", "debug")
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, false)
-		require.NoError(t, err)
-		assert.NotNil(t, configPath)
-
-		// Verify the output
-		file, err := os.Open(configPath)
-		assert.NoError(t, err)
-		defer file.Close()
-
-		content, err := io.ReadAll(file)
-		assert.NoError(t, err)
-		assert.Contains(t, string(content), "xrootd.trace debug")
-		server_utils.ResetTestState()
-	})
-
-	t.Run("TestCacheXrootdIncorrectConfig", func(t *testing.T) {
-		xrootd := xrootdTest{T: t}
-		xrootd.setup()
-
-		// Set our config
-		viper.Set("Logging.Cache.Xrootd", "degub")
-
-		// Generate the xrootd config
-		configPath, err := ConfigXrootd(ctx, false)
-		require.Error(t, err)
-		assert.NotNil(t, configPath)
-	})
+				content, err := io.ReadAll(file)
+				assert.NoError(t, err)
+				if tt.expectedContent != "" {
+					assert.Contains(t, string(content), tt.expectedContent)
+				}
+			}
+		})
+	}
 
 	t.Run("TestNestedDataMetaNamespace", func(t *testing.T) {
 		testDir := t.TempDir()


### PR DESCRIPTION
This carries two fixes -- the first is for providing an xrootd log level that previously didn't have a definition, e.g. Logging.Origin.Http: trace. The new code should handle mapping that down if able, and up a level if needed

The new code also uses Pelican's configured Logging.Level as the default for the other xrootd values. This lets us crank up logging all at once without having to toggle each directive individually, while still allowing for individual overrides if so desired.