### PR TITLE
Origin requires multiple scitokens

### DIFF
--- a/origin/advertise.go
+++ b/origin/advertise.go
@@ -192,7 +192,23 @@ func (server *OriginServer) GetAuthorizedPrefixes() ([]string, error) {
 	}
 
 	for _, export := range originExports {
-		if ((export.Capabilities.Reads || export.Capabilities.PublicReads) && !export.Capabilities.DirectReads) || export.Capabilities.Writes {
+		if (export.Capabilities.Reads && !export.Capabilities.PublicReads) || export.Capabilities.Writes {
+			prefixes = append(prefixes, export.FederationPrefix)
+		}
+	}
+
+	return prefixes, nil
+}
+
+func (server *OriginServer) GetPublicReadOnlyPrefixes() ([]string, error) {
+	var prefixes []string
+	originExports, err := server_utils.GetOriginExports()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, export := range originExports {
+		if export.Capabilities.PublicReads && !export.Capabilities.DirectReads && !export.Capabilities.Writes {
 			prefixes = append(prefixes, export.FederationPrefix)
 		}
 	}

--- a/origin/advertise.go
+++ b/origin/advertise.go
@@ -192,7 +192,7 @@ func (server *OriginServer) GetAuthorizedPrefixes() ([]string, error) {
 	}
 
 	for _, export := range originExports {
-		if (export.Capabilities.Reads && !export.Capabilities.PublicReads) || export.Capabilities.Writes {
+		if ((export.Capabilities.Reads || export.Capabilities.PublicReads) && !export.Capabilities.DirectReads) || export.Capabilities.Writes {
 			prefixes = append(prefixes, export.FederationPrefix)
 		}
 	}

--- a/xrootd/authorization.go
+++ b/xrootd/authorization.go
@@ -30,7 +30,6 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -552,6 +551,9 @@ func EmitScitokensConfig(server server_structs.XRootDServer) error {
 			return err
 		}
 		publicReadsPrefixes, err := originServer.GetPublicReadOnlyPrefixes()
+		if err != nil {
+			return err
+		}
 		return WriteOriginScitokensConfig(authedPrefixes, publicReadsPrefixes)
 	} else if cacheServer, ok := server.(*cache.CacheServer); ok {
 		directorAds := cacheServer.GetNamespaceAds()

--- a/xrootd/authorization.go
+++ b/xrootd/authorization.go
@@ -299,7 +299,7 @@ func EmitAuthfile(server server_structs.XRootDServer) error {
 				}
 
 				for _, export := range originExports {
-					if export.Capabilities.PublicReads {
+					if export.Capabilities.DirectReads {
 						outStr += export.FederationPrefix + " lr "
 					}
 				}
@@ -314,7 +314,7 @@ func EmitAuthfile(server server_structs.XRootDServer) error {
 			output.Write([]byte(lineContents + "\n"))
 		}
 	}
-	// If Origin has no authfile already exists, add the ./well-known to the authfile
+	// If Origin has no authfile already, add the ./well-known to the authfile
 	if !foundPublicLine && server.GetServerType().IsEnabled(server_structs.OriginType) {
 		outStr := "u * /.well-known lr"
 
@@ -325,7 +325,7 @@ func EmitAuthfile(server server_structs.XRootDServer) error {
 		}
 
 		for _, export := range originExports {
-			if export.Capabilities.PublicReads {
+			if export.Capabilities.DirectReads {
 				outStr += " " + export.FederationPrefix + " lr"
 			}
 		}
@@ -532,7 +532,7 @@ func makeSciTokensCfg() (cfg ScitokensCfg, err error) {
 // Writes out the server's scitokens.cfg configuration
 func EmitScitokensConfig(server server_structs.XRootDServer) error {
 	if originServer, ok := server.(*origin.OriginServer); ok {
-		authedPrefixes, err := originServer.GetAuthorizedPrefixes()
+		authedPrefixes, err := originServer.GetAuthorizedPrefixes() //ETTODO Change to not just get authorized prefixes
 		if err != nil {
 			return err
 		}

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -611,7 +611,7 @@ func TestWriteOriginAuthFiles(t *testing.T) {
 
 	t.Run("EmptyAuth", originAuthTester(originServer, "", "u * /.well-known lr\n"))
 
-	viper.Set("Origin.EnablePublicReads", true)
+	viper.Set("Origin.EnableDirectReads", true)
 	viper.Set("Origin.FederationPrefix", "/foo/bar")
 	t.Run("PublicAuth", originAuthTester(originServer, "", "u * /.well-known lr /foo/bar lr\n"))
 }

--- a/xrootd/resources/scitokens.cfg
+++ b/xrootd/resources/scitokens.cfg
@@ -41,6 +41,10 @@ name_mapfile = {{.NameMapfile}}
 {{- if .UsernameClaim}}
 username_claim = {{.UsernameClaim}}
 {{- end}}
+{{- if .FedIssuer}}
+required_authorization = all
+acceptable_authorization = none
+{{- end}}
 
 {{end -}}
 # End of config

--- a/xrootd/resources/test-scitokens-monitoring.cfg
+++ b/xrootd/resources/test-scitokens-monitoring.cfg
@@ -22,6 +22,12 @@
 [Global]
 audience_json = ["test_audience","https://origin.example.com:8443"]
 
+[Issuer Registry]
+issuer = fed.discovery.com
+base_path = /foo/bar, /public
+required_authorization = all
+acceptable_authorization = none
+
 [Issuer Demo]
 issuer = https://demo.scitokens.org
 base_path = /bar, /foo

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -275,7 +275,11 @@ func CheckOriginXrootdEnv(exportPath string, server server_structs.XRootDServer,
 		if err != nil {
 			return err
 		}
-		err = WriteOriginScitokensConfig(authedPrefixes)
+		publicReadPrefixes, err := originServer.GetPublicReadOnlyPrefixes()
+		if err != nil {
+			return err
+		}
+		err = WriteOriginScitokensConfig(authedPrefixes, publicReadPrefixes)
 		if err != nil {
 			return err
 		}

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -630,6 +630,7 @@ func TestUpdateAuth(t *testing.T) {
 	viper.Set("Xrootd.ScitokensConfig", scitokensName)
 	viper.Set("Origin.FederationPrefix", "/test")
 	viper.Set("Origin.StoragePrefix", "/")
+	viper.Set("Origin.EnableDirectReads", false)
 	config.InitConfig()
 
 	err := config.InitServer(ctx, server_structs.OriginType)


### PR DESCRIPTION
This PR updates the origin scitokens and authfiles to reflect the cache auth changes.

If an origin's namespace has direct-read capabilities, the authfile still remains the same. However, if it doesn't, but has PublicRead capabilities, then that path is moved into the origin's scitoken file behind a federation Issuer. Private capabilities now also require that federation issuer.

This is still a draft PR because full testing can't be done until all the other cache auth pieces are complete.