### PR TITLE
Run tests in more appropriate container images

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,4 +1,4 @@
-name: Build and Push Container Images
+name: Build and Test
 
 on:
   pull_request:
@@ -15,9 +15,6 @@ on:
     types:
       - dispatch-build
   workflow_dispatch:
-
-permissions:
-  contents: write
 
 jobs:
   set-build-parameters:
@@ -145,7 +142,9 @@ jobs:
           file: ./images/Dockerfile
           platforms: ${{ needs.set-build-parameters.outputs.platforms }}
           target: origin
-          cache-from: type=local,src=/tmp/.base-buildx-cache
+          cache-from: |
+            type=registry,ref=hub.opensciencegrid.org/pelican_platform/pelican-dev:buildcache
+            type=local,src=/tmp/.base-buildx-cache
           cache-to: type=local,dest=/tmp/.base-buildx-cache,mode=max
 
   build-server-images:
@@ -162,6 +161,7 @@ jobs:
           - osdf-cache
           - osdf-director
           - osdf-registry
+          - pelican-test
     runs-on: ubuntu-latest
 
     steps:
@@ -235,13 +235,26 @@ jobs:
           tags: "${{ steps.generate-tag-list.outputs.taglist }}"
           cache-from: type=local,src=/tmp/.base-buildx-cache
 
-  build-dev-container-image:
+  build-devtest-images:
     needs: [set-build-parameters, cache-image-layers]
     runs-on: ubuntu-latest
     steps:
 
-      - name: Determine image tags
-        id: meta
+      # NOTE (brianaydemir): If it wasn't for the potential expense of
+      # loading the Docker Buildx cache, we could implement this job using
+      # a matrix and eliminate near-identical steps.
+
+      - name: Determine image tags (pelican-test)
+        id: pelican-test-tags
+        uses: docker/metadata-action@v5
+        with:
+          images: hub.opensciencegrid.org/pelican_platform/pelican-test
+          tags: |
+            type=raw,value=latest-itb
+            type=raw,value=sha-{{sha}}
+
+      - name: Determine image tags (pelican-dev)
+        id: pelican-dev-tags
         uses: docker/metadata-action@v5
         with:
           images: hub.opensciencegrid.org/pelican_platform/pelican-dev
@@ -285,13 +298,62 @@ jobs:
           #
           fail-on-cache-miss: true
 
-      - name: Build and push Docker images
+      - name: Build and push Docker images (pelican-test)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./images/Dockerfile
           platforms: ${{ needs.set-build-parameters.outputs.platforms }}
-          target: dev-container
+          target: pelican-test
           push: ${{ needs.set-build-parameters.outputs.push-dev == 'true' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.pelican-test-tags.outputs.tags }}
           cache-from: type=local,src=/tmp/.base-buildx-cache
+
+      - name: Build and push Docker images (pelican-dev)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./images/Dockerfile
+          platforms: ${{ needs.set-build-parameters.outputs.platforms }}
+          target: pelican-dev
+          push: ${{ needs.set-build-parameters.outputs.push-dev == 'true' }}
+          tags: ${{ steps.pelican-dev-tags.outputs.tags }}
+          cache-from: type=local,src=/tmp/.base-buildx-cache
+          cache-to: type=registry,ref=hub.opensciencegrid.org/pelican_platform/pelican-dev:buildcache,mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true
+
+  # The macOS and Windows tests do not depend on any of the images being
+  # built above. We go ahead and trigger those tests here so that all of our
+  # tests are triggered from a single workflow.
+
+  test-macos-windows:
+    uses: ./.github/workflows/test-macos-windows.yml
+
+  # The Linux tests are less straightforward because we need to decide
+  # which container image to run the tests in, which might require waiting
+  # for the image to be built.
+  #
+  # For the pull-request job, we cannot build and push a newer image. Thus,
+  # in the name of simplicity, the job uses the most recent container image
+  # that was built. (And technically, it might also get triggered in other
+  # scenarios, but pull requests requests will be the common one.)
+
+  test-linux-pull-request:
+    needs: [set-build-parameters]
+    if: ${{ needs.set-build-parameters.outputs.push-dev != 'true' && needs.set-build-parameters.outputs.push-server != 'true' }}
+    uses: ./.github/workflows/test-linux.yml
+    with:
+      image: hub.opensciencegrid.org/pelican_platform/pelican-test:latest-itb
+
+  test-linux-push-to-main:
+    needs: [set-build-parameters, build-devtest-images]
+    if: ${{ needs.set-build-parameters.outputs.push-dev == 'true' }}
+    uses: ./.github/workflows/test-linux.yml
+    with:
+      image: hub.opensciencegrid.org/pelican_platform/pelican-test:latest-itb
+
+  test-linux-push-to-tag:
+    needs: [set-build-parameters, set-tags, build-server-images]
+    if: ${{ needs.set-build-parameters.outputs.push-server == 'true' }}
+    uses: ./.github/workflows/test-linux.yml
+    with:
+      image: hub.opensciencegrid.org/pelican_platform/pelican-test:${{ needs.set-tags.outputs.GITHUB_TAG }}

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -1,15 +1,11 @@
-name: Test Template
+name: Run Tests (Linux)
+
+# This workflow is intended to be called from build-and-test.yml.
 
 on:
   workflow_call:
     inputs:
-      tags:
-        required: true
-        type: string
-      coverprofile:
-        required: true
-        type: string
-      binary_name:
+      image:
         required: true
         type: string
 
@@ -17,7 +13,16 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: hub.opensciencegrid.org/pelican_platform/pelican-dev:latest-itb
+      image: ${{ inputs.image }}
+    strategy:
+      matrix:
+        include:
+          - binary_name: pelican
+            coverprofile: coverage.out
+            tags: ""
+          - binary_name: pelican-server
+            coverprofile: coverage-server.out
+            tags: lotman
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -42,13 +47,13 @@ jobs:
     - name: Test
       run: |
         make web-build
-        go test -tags=${{ inputs.tags }} -timeout 15m -coverpkg=./... -coverprofile=${{ inputs.coverprofile }} -covermode=count ./...
+        go test -tags=${{ matrix.tags }} -timeout 15m -coverpkg=./... -coverprofile=${{ matrix.coverprofile }} -covermode=count ./...
     - name: Get total code coverage
       if: github.event_name == 'pull_request'
       id: cc
       run: |
         set -x
-        cc_total=`go tool cover -func=${{ inputs.coverprofile }} | grep total | grep -Eo '[0-9]+\.[0-9]+'`
+        cc_total=`go tool cover -func=${{ matrix.coverprofile }} | grep total | grep -Eo '[0-9]+\.[0-9]+'`
         echo "cc_total=$cc_total" >> $GITHUB_OUTPUT
     - name: Restore base test coverage
       id: base-coverage
@@ -67,7 +72,7 @@ jobs:
         git reset --hard ${{ github.event.pull_request.base.sha }}
         make web-build
         go generate ./...
-        go test -tags=${{ inputs.tags }} -timeout 15m -coverpkg=./... -coverprofile=base_coverage.out -covermode=count ./...
+        go test -tags=${{ matrix.tags }} -timeout 15m -coverpkg=./... -coverprofile=base_coverage.out -covermode=count ./...
         go tool cover -func=base_coverage.out > unit-base.txt
         git reset --hard $HEAD
     - name: Get base code coverage value
@@ -88,7 +93,7 @@ jobs:
         args: build --single-target --clean --snapshot
     - name: Copy files (Ubuntu)
       run: |
-        cp dist/${{ inputs.binary_name }}_linux_amd64_v1/${{ inputs.binary_name }} ./pelican
+        cp dist/${{ matrix.binary_name }}_linux_amd64_v1/${{ matrix.binary_name }} ./pelican
     - name: Run Integration Tests
       run: ./github_scripts/citests.sh
     - name: Run End-to-End Test for Object get/put

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -15,6 +15,7 @@ jobs:
     container:
       image: ${{ inputs.image }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - binary_name: pelican

--- a/.github/workflows/test-macos-windows.yml
+++ b/.github/workflows/test-macos-windows.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         go-version: [1.21.x]
         os: [macos-latest, windows-latest]

--- a/.github/workflows/test-macos-windows.yml
+++ b/.github/workflows/test-macos-windows.yml
@@ -1,7 +1,10 @@
-on: [push, pull_request]
-name: Test
-permissions:
-  pull-requests: write
+name: Run Tests (macOS, Windows)
+
+# This workflow is intended to be called from build-and-test.yml.
+
+on:
+  workflow_call:
+
 jobs:
   test:
     strategy:
@@ -54,15 +57,3 @@ jobs:
         distribution: goreleaser
         version: latest
         args: build --single-target --clean --snapshot
-  test-ubuntu:
-    uses: ./.github/workflows/test-template.yml
-    with:
-      tags: ""
-      coverprofile: "coverage.out"
-      binary_name: "pelican"
-  test-ubuntu-server:
-    uses: ./.github/workflows/test-template.yml
-    with:
-      tags: "lotman"
-      coverprofile: "coverage-server.out"
-      binary_name: "pelican-server"

--- a/github_scripts/citests.sh
+++ b/github_scripts/citests.sh
@@ -63,6 +63,7 @@ SOCKET_DIR="`mktemp -d -t pelican-citest-XXXXXX`"
 export PELICAN_LOCALCACHE_SOCKET=$SOCKET_DIR/socket
 export PELICAN_LOCALCACHE_DATALOCATION=$SOCKET_DIR/data
 export PELICAN_SERVER_ENABLEUI=false
+export PELICAN_TLSSKIPVERIFY=true
 
 ./pelican serve -d -f osg-htc.org --module localcache &
 PELICAN_PID=$!

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -521,46 +521,27 @@ ENTRYPOINT ["/entrypoint.sh", "osdf-server", "cache"]
 CMD ["serve"]
 
 #################################################################
-# DevTest Container Base
+# Testing Environment
+#
+# This container should contain a minimum of extra packages and
+# other software for testing a Pelican release.
 #################################################################
-FROM origin-base AS devtest-container-base
+FROM origin-base AS pelican-test
 ARG TARGETPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 ARG GO_VER
-ARG NODEJS_VER
 
-# Install the Go and Node.js toolchains using the same commands as the
-# pelican-build-init stage, taking care that the installation matches this
-# build's target platform.
+# Install select development packages.
+RUN --mount=type=cache,id=dnf-${TARGETPLATFORM},target=/var/cache/dnf,sharing=locked \
+  dnf install -y git make
 
-COPY <<ENDCOPY /etc/yum.repos.d/goreleaser.repo
-[goreleaser]
-name=GoReleaser
-baseurl=https://repo.goreleaser.com/yum/
-enabled=1
-gpgcheck=0
-ENDCOPY
-RUN --mount=type=cache,id=dnf-${TARGETPLATFORM},target=/var/cache/dnf,sharing=locked <<ENDRUN
-  set -eux
-  dnf install -y goreleaser
-ENDRUN
-
+# Install Go using the same commands as the pelican-build-init stage.
 RUN curl -O https://dl.google.com/go/go${GO_VER}.${TARGETOS}-${TARGETARCH}.tar.gz \
     && rm -rf /usr/local/go \
     && tar -C /usr/local -xzf go${GO_VER}.${TARGETOS}-${TARGETARCH}.tar.gz \
     && rm -rf go${GO_VER}.${TARGETOS}-${TARGETARCH}.tar.gz
 ENV PATH="/usr/local/go/bin:${PATH}"
-
-RUN --mount=type=cache,id=dnf-${TARGETPLATFORM},target=/var/cache/dnf,sharing=locked <<ENDRUN
-  set -eux
-  dnf install -y npm
-  npm install -g n
-  n ${NODEJS_VER}
-  dnf remove -y npm
-  npm install -g npm@latest
-  n prune
-ENDRUN
 
 # Install the MinIO server and client for S3 tests.
 RUN --mount=type=cache,id=dnf-${TARGETPLATFORM},target=/var/cache/dnf,sharing=locked <<ENDRUN
@@ -577,15 +558,44 @@ RUN --mount=type=cache,id=dnf-${TARGETPLATFORM},target=/var/cache/dnf,sharing=lo
   rm -f ./minio.rpm
 ENDRUN
 
+ENTRYPOINT []
+CMD ["/bin/bash"]
+WORKDIR /app
+
 #################################################################
-# Development Container
+# Development Environment
 #
 # This container should contain all of Pelican's dependencies,
 # both run-time and development-time. Because it is intended for
 # development, it does not need Pelican itself.
 #################################################################
-FROM devtest-container-base AS dev-container
+FROM pelican-test AS pelican-dev
 ARG TARGETPLATFORM
+ARG NODEJS_VER
+
+# Install GoReleaser using the same commands as the pelican-build-init stage.
+COPY <<ENDCOPY /etc/yum.repos.d/goreleaser.repo
+[goreleaser]
+name=GoReleaser
+baseurl=https://repo.goreleaser.com/yum/
+enabled=1
+gpgcheck=0
+ENDCOPY
+RUN --mount=type=cache,id=dnf-${TARGETPLATFORM},target=/var/cache/dnf,sharing=locked <<ENDRUN
+  set -eux
+  dnf install -y goreleaser
+ENDRUN
+
+# Install Node.js using the same commands as the pelican-build-init stage.
+RUN --mount=type=cache,id=dnf-${TARGETPLATFORM},target=/var/cache/dnf,sharing=locked <<ENDRUN
+  set -eux
+  dnf install -y npm
+  npm install -g n
+  n ${NODEJS_VER}
+  dnf remove -y npm
+  npm install -g npm@latest
+  n prune
+ENDRUN
 
 # Enable the CodeReady Linux Builder repository.
 RUN /usr/bin/crb enable

--- a/images/build-stages.dot
+++ b/images/build-stages.dot
@@ -37,6 +37,6 @@ digraph {
 
   subgraph cluster_4 {
     style=invis;
-    origin_base -> devtest_container_base -> dev_container;
+    origin_base -> pelican_test -> pelican_dev;
   }
 }

--- a/images/build-stages.svg
+++ b/images/build-stages.svg
@@ -79,26 +79,26 @@
 <!-- origin -->
 <g id="node13" class="node">
 <title>origin</title>
-<polygon fill="none" stroke="black" points="439,-124 385,-124 385,-88 439,-88 439,-124"/>
-<text text-anchor="middle" x="412" y="-101.8" font-family="Times,serif" font-size="14.00">origin</text>
+<polygon fill="none" stroke="black" points="424,-124 370,-124 370,-88 424,-88 424,-124"/>
+<text text-anchor="middle" x="397" y="-101.8" font-family="Times,serif" font-size="14.00">origin</text>
 </g>
 <!-- pelican_build&#45;&gt;origin -->
 <g id="edge18" class="edge">
 <title>pelican_build-&gt;origin</title>
-<path fill="none" stroke="gray" stroke-dasharray="1,5" d="M550.32,-447.92C554.46,-439.69 559.04,-429.55 562,-420 574.91,-378.26 578,-366.69 578,-323 578,-323 578,-323 578,-249 578,-215.29 497.97,-159.93 449.04,-129.24"/>
-<polygon fill="gray" stroke="gray" points="451.04,-126.36 440.7,-124.06 447.35,-132.31 451.04,-126.36"/>
+<path fill="none" stroke="gray" stroke-dasharray="1,5" d="M550.32,-447.92C554.46,-439.69 559.04,-429.55 562,-420 574.91,-378.26 578,-366.69 578,-323 578,-323 578,-323 578,-249 578,-212.87 487.58,-156.87 434.56,-127.15"/>
+<polygon fill="gray" stroke="gray" points="436.26,-124.09 425.81,-122.3 432.86,-130.21 436.26,-124.09"/>
 </g>
 <!-- cache -->
 <g id="node15" class="node">
 <title>cache</title>
-<polygon fill="none" stroke="black" points="537,-124 483,-124 483,-88 537,-88 537,-124"/>
-<text text-anchor="middle" x="510" y="-101.8" font-family="Times,serif" font-size="14.00">cache</text>
+<polygon fill="none" stroke="black" points="522,-124 468,-124 468,-88 522,-88 522,-124"/>
+<text text-anchor="middle" x="495" y="-101.8" font-family="Times,serif" font-size="14.00">cache</text>
 </g>
 <!-- pelican_build&#45;&gt;cache -->
 <g id="edge19" class="edge">
 <title>pelican_build-&gt;cache</title>
-<path fill="none" stroke="gray" stroke-dasharray="1,5" d="M566.59,-447.57C575.84,-440.08 585.57,-430.6 592,-420 615.03,-382.03 616,-367.41 616,-323 616,-323 616,-323 616,-249 616,-204.59 619.08,-187.2 592,-152 580.9,-137.57 563.79,-127.15 548.07,-119.99"/>
-<polygon fill="gray" stroke="gray" points="549.47,-116.78 538.89,-116.13 546.75,-123.23 549.47,-116.78"/>
+<path fill="none" stroke="gray" stroke-dasharray="1,5" d="M566.59,-447.57C575.84,-440.08 585.57,-430.6 592,-420 615.03,-382.03 616,-367.41 616,-323 616,-323 616,-323 616,-249 616,-204.59 620.25,-186.27 592,-152 577.15,-133.99 553.5,-122.82 533.26,-116.11"/>
+<polygon fill="gray" stroke="gray" points="534.48,-112.82 523.9,-113.27 532.45,-119.52 534.48,-112.82"/>
 </g>
 <!-- pelican_software_base -->
 <g id="node4" class="node">
@@ -163,24 +163,24 @@
 <!-- xrootd_software_base&#45;&gt;cache -->
 <g id="edge16" class="edge">
 <title>xrootd_software_base-&gt;cache</title>
-<path fill="none" stroke="black" d="M288.9,-231.59C335.38,-205.4 423.13,-155.95 472.97,-127.87"/>
-<polygon fill="black" stroke="black" points="474.39,-131.08 481.38,-123.13 470.95,-124.99 474.39,-131.08"/>
+<path fill="none" stroke="black" d="M287.06,-231.59C330.01,-205.85 410.45,-157.66 457.7,-129.35"/>
+<polygon fill="black" stroke="black" points="459.46,-132.37 466.24,-124.23 455.86,-126.37 459.46,-132.37"/>
 </g>
 <!-- origin_base&#45;&gt;origin -->
 <g id="edge14" class="edge">
 <title>origin_base-&gt;origin</title>
-<path fill="none" stroke="black" d="M296.46,-159.52C320.26,-148.7 350.67,-134.88 374.32,-124.13"/>
-<polygon fill="black" stroke="black" points="375.63,-127.38 383.28,-120.05 372.73,-121.01 375.63,-127.38"/>
+<path fill="none" stroke="black" d="M292.72,-159.52C313.08,-149.26 338.81,-136.31 359.61,-125.83"/>
+<polygon fill="black" stroke="black" points="360.98,-129.06 368.34,-121.43 357.83,-122.81 360.98,-129.06"/>
 </g>
-<!-- devtest_container_base -->
+<!-- pelican_test -->
 <g id="node17" class="node">
-<title>devtest_container_base</title>
-<polygon fill="none" stroke="black" points="331.31,-124 184.69,-124 184.69,-88 331.31,-88 331.31,-124"/>
-<text text-anchor="middle" x="258" y="-101.8" font-family="Times,serif" font-size="14.00">devtest_container_base</text>
+<title>pelican_test</title>
+<polygon fill="none" stroke="black" points="299.43,-124 216.57,-124 216.57,-88 299.43,-88 299.43,-124"/>
+<text text-anchor="middle" x="258" y="-101.8" font-family="Times,serif" font-size="14.00">pelican_test</text>
 </g>
-<!-- origin_base&#45;&gt;devtest_container_base -->
+<!-- origin_base&#45;&gt;pelican_test -->
 <g id="edge20" class="edge">
-<title>origin_base-&gt;devtest_container_base</title>
+<title>origin_base-&gt;pelican_test</title>
 <path fill="none" stroke="black" d="M258,-159.7C258,-152.41 258,-143.73 258,-135.54"/>
 <polygon fill="black" stroke="black" points="261.5,-135.62 258,-125.62 254.5,-135.62 261.5,-135.62"/>
 </g>
@@ -217,36 +217,36 @@
 <!-- osdf_origin -->
 <g id="node14" class="node">
 <title>osdf_origin</title>
-<polygon fill="none" stroke="black" points="452.28,-52 371.72,-52 371.72,-16 452.28,-16 452.28,-52"/>
-<text text-anchor="middle" x="412" y="-29.8" font-family="Times,serif" font-size="14.00">osdf_origin</text>
+<polygon fill="none" stroke="black" points="437.28,-52 356.72,-52 356.72,-16 437.28,-16 437.28,-52"/>
+<text text-anchor="middle" x="397" y="-29.8" font-family="Times,serif" font-size="14.00">osdf_origin</text>
 </g>
 <!-- origin&#45;&gt;osdf_origin -->
 <g id="edge15" class="edge">
 <title>origin-&gt;osdf_origin</title>
-<path fill="none" stroke="black" d="M412,-87.7C412,-80.41 412,-71.73 412,-63.54"/>
-<polygon fill="black" stroke="black" points="415.5,-63.62 412,-53.62 408.5,-63.62 415.5,-63.62"/>
+<path fill="none" stroke="black" d="M397,-87.7C397,-80.41 397,-71.73 397,-63.54"/>
+<polygon fill="black" stroke="black" points="400.5,-63.62 397,-53.62 393.5,-63.62 400.5,-63.62"/>
 </g>
 <!-- osdf_cache -->
 <g id="node16" class="node">
 <title>osdf_cache</title>
-<polygon fill="none" stroke="black" points="549.48,-52 470.52,-52 470.52,-16 549.48,-16 549.48,-52"/>
-<text text-anchor="middle" x="510" y="-29.8" font-family="Times,serif" font-size="14.00">osdf_cache</text>
+<polygon fill="none" stroke="black" points="534.48,-52 455.52,-52 455.52,-16 534.48,-16 534.48,-52"/>
+<text text-anchor="middle" x="495" y="-29.8" font-family="Times,serif" font-size="14.00">osdf_cache</text>
 </g>
 <!-- cache&#45;&gt;osdf_cache -->
 <g id="edge17" class="edge">
 <title>cache-&gt;osdf_cache</title>
-<path fill="none" stroke="black" d="M510,-87.7C510,-80.41 510,-71.73 510,-63.54"/>
-<polygon fill="black" stroke="black" points="513.5,-63.62 510,-53.62 506.5,-63.62 513.5,-63.62"/>
+<path fill="none" stroke="black" d="M495,-87.7C495,-80.41 495,-71.73 495,-63.54"/>
+<polygon fill="black" stroke="black" points="498.5,-63.62 495,-53.62 491.5,-63.62 498.5,-63.62"/>
 </g>
-<!-- dev_container -->
+<!-- pelican_dev -->
 <g id="node18" class="node">
-<title>dev_container</title>
-<polygon fill="none" stroke="black" points="305.65,-52 210.35,-52 210.35,-16 305.65,-16 305.65,-52"/>
-<text text-anchor="middle" x="258" y="-29.8" font-family="Times,serif" font-size="14.00">dev_container</text>
+<title>pelican_dev</title>
+<polygon fill="none" stroke="black" points="299.82,-52 216.18,-52 216.18,-16 299.82,-16 299.82,-52"/>
+<text text-anchor="middle" x="258" y="-29.8" font-family="Times,serif" font-size="14.00">pelican_dev</text>
 </g>
-<!-- devtest_container_base&#45;&gt;dev_container -->
+<!-- pelican_test&#45;&gt;pelican_dev -->
 <g id="edge21" class="edge">
-<title>devtest_container_base-&gt;dev_container</title>
+<title>pelican_test-&gt;pelican_dev</title>
 <path fill="none" stroke="black" d="M258,-87.7C258,-80.41 258,-71.73 258,-63.54"/>
 <polygon fill="black" stroke="black" points="261.5,-63.62 258,-53.62 254.5,-63.62 261.5,-63.62"/>
 </g>

--- a/images/dev-config.yaml
+++ b/images/dev-config.yaml
@@ -16,5 +16,4 @@
 #
 # ***************************************************************
 
-OriginUrl: https://localhost:8444
 TLSSkipVerify: true


### PR DESCRIPTION
The triggers for the unit tests have been moved into `build-and-test.yaml` (which was previously named `build-images.yaml`), because in order to run unit tests in a more appropriate container image, we might need to wait for that container to be built first.

The basic philosophy is this:

- Tags (`v{semvar}`) are always tested in a container based on the containers being pushed for that release or release candidate. This is the critical part.

- Pull requests are tested in whatever version of `pelican-test:latest-itb` happens to be available at the time. We can't push images during a pull request, and in the name of simplicity, I decided to forgo trying to find a "better" image. In practice, this should be fine so long as:

    1. Updates to Pelican's dependences are pushed to `main` prior to work that depends on those updates.
    2. All branches currently under development function correctly under `main`'s versions of those dependencies.

- Pushes to `main` trigger a new build of the `pelican-test` container image, which is then used to run the unit tests.

Other notable changes:

- I've attempted to restore the registry-based caching that was part of the dev container build process prior to #1972.

- I've removed the unrecognized `OriginUrl` parameter from `images/dev-config.yaml`. Along the way, I determined that `github_scripts/citests.sh` actually depended on that config file being in `/etc/pelican`, so I've added the relevant env var exports to the script. (Tests shouldn't be looking at or relying on `/etc/pelican`.)

Other remarks:

- The GitHub Actions web UI does a not-great job of visually laying out the jobs. You have to hover over each node to see its dependencies highlighted clearly.