### PR TITLE
Deprecate Lotman.DbLocation in favor of Lotman.LotHome

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1012,7 +1012,7 @@ func SetServerDefaults(v *viper.Viper) error {
 		v.SetDefault(param.Registry_DbLocation.GetName(), "/var/lib/pelican/registry.sqlite")
 		v.SetDefault(param.Director_DbLocation.GetName(), "/var/lib/pelican/director.sqlite")
 		// The lotman db will actually take this path and create the lot at /path/.lot/lotman_cpp.sqlite
-		v.SetDefault(param.Lotman_DbLocation.GetName(), "/var/lib/pelican")
+		v.SetDefault(param.Lotman_LotHome.GetName(), "/var/lib/pelican")
 		v.SetDefault(param.Monitoring_DataLocation.GetName(), "/var/lib/pelican/monitoring/data")
 		v.SetDefault(param.Shoveler_QueueDirectory.GetName(), "/var/spool/pelican/shoveler/queue")
 		v.SetDefault(param.Shoveler_AMQPTokenLocation.GetName(), "/etc/pelican/shoveler-token")
@@ -1023,7 +1023,7 @@ func SetServerDefaults(v *viper.Viper) error {
 		v.SetDefault(param.Registry_DbLocation.GetName(), filepath.Join(configDir, "ns-registry.sqlite"))
 		v.SetDefault(param.Director_DbLocation.GetName(), filepath.Join(configDir, "director.sqlite"))
 		// Lotdb will live at <configDir>/.lot/lotman_cpp.sqlite
-		v.SetDefault(param.Lotman_DbLocation.GetName(), configDir)
+		v.SetDefault(param.Lotman_LotHome.GetName(), configDir)
 		v.SetDefault(param.Monitoring_DataLocation.GetName(), filepath.Join(configDir, "monitoring/data"))
 		v.SetDefault(param.Shoveler_QueueDirectory.GetName(), filepath.Join(configDir, "shoveler/queue"))
 		v.SetDefault(param.Shoveler_AMQPTokenLocation.GetName(), filepath.Join(configDir, "shoveler-token"))

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2886,13 +2886,27 @@ components: ["plugin"]
 ############################
 #   LotMan-level configs   #
 ############################
+name: Lotman.LotHome
+description: |+
+  The prefix indicating where LotMan should store its lot database. Configured with path `<path>`, the database
+  will be stored at `<path>/.lot/lotman_cpp.sqlite`.
+type: filename
+root_default: /var/run/pelican
+default: $ConfigBase
+components: ["cache"]
+---
 name: Lotman.DbLocation
 description: |+
+  [Deprecated] `Lotman.DbLocation` is deprecated and will be removed in a future release. Please migrate to
+  use `Lotman.LotHome` instead.
+
   The prefix indicating where LotMan should store its lot database. For the provided path, the database
   will be stored at <path>/.lot/lotman_cpp.sqlite.
 type: filename
 root_default: /var/run/pelican
 default: $ConfigBase
+deprecated: true
+replacedby: ["Lotman.LotHome"]
 components: ["cache"]
 ---
 name: Lotman.LibLocation

--- a/lotman/lotman_linux.go
+++ b/lotman/lotman_linux.go
@@ -970,7 +970,7 @@ func InitLotman(adsFromFed []server_structs.NamespaceAdV2) bool {
 	purego.RegisterLibFunc(&LotmanGetLotsFromDir, lotmanLib, "lotman_get_lots_from_dir")
 
 	// Set the lot_home context -- where the db lives
-	lotHome := param.Lotman_DbLocation.GetString()
+	lotHome := param.Lotman_LotHome.GetString()
 
 	errMsg := make([]byte, 2048)
 

--- a/lotman/lotman_test.go
+++ b/lotman/lotman_test.go
@@ -108,7 +108,7 @@ func setupLotmanFromConf(t *testing.T, readConfig bool, name string, discUrl str
 	tmpPath, err := os.MkdirTemp("", tmpPathPattern)
 	require.NoError(t, err)
 
-	viper.Set("Lotman.DbLocation", tmpPath)
+	viper.Set("Lotman.LotHome", tmpPath)
 	success := InitLotman(nsAds)
 	//reset func
 	return success, func() {

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -57,6 +57,7 @@ func GetDeprecated() map[string][]string {
         "DisableHttpProxy": {"Client.DisableHttpProxy"},
         "DisableProxyFallback": {"Client.DisableProxyFallback"},
         "IssuerKey": {"none"},
+        "Lotman.DbLocation": {"Lotman.LotHome"},
         "MinimumDownloadSpeed": {"Client.MinimumDownloadSpeed"},
         "Origin.EnableDirListing": {"Origin.EnableListings"},
         "Origin.EnableFallbackRead": {"Origin.EnableDirectReads"},
@@ -204,6 +205,7 @@ var (
 	Lotman_DbLocation = StringParam{"Lotman.DbLocation"}
 	Lotman_EnabledPolicy = StringParam{"Lotman.EnabledPolicy"}
 	Lotman_LibLocation = StringParam{"Lotman.LibLocation"}
+	Lotman_LotHome = StringParam{"Lotman.LotHome"}
 	Monitoring_DataLocation = StringParam{"Monitoring.DataLocation"}
 	OIDC_AuthorizationEndpoint = StringParam{"OIDC.AuthorizationEndpoint"}
 	OIDC_ClientID = StringParam{"OIDC.ClientID"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -167,6 +167,7 @@ type Config struct {
 		EnableAPI bool `mapstructure:"enableapi" yaml:"EnableAPI"`
 		EnabledPolicy string `mapstructure:"enabledpolicy" yaml:"EnabledPolicy"`
 		LibLocation string `mapstructure:"liblocation" yaml:"LibLocation"`
+		LotHome string `mapstructure:"lothome" yaml:"LotHome"`
 		PolicyDefinitions interface{} `mapstructure:"policydefinitions" yaml:"PolicyDefinitions"`
 	} `mapstructure:"lotman" yaml:"Lotman"`
 	MinimumDownloadSpeed int `mapstructure:"minimumdownloadspeed" yaml:"MinimumDownloadSpeed"`
@@ -493,6 +494,7 @@ type configWithType struct {
 		EnableAPI struct { Type string; Value bool }
 		EnabledPolicy struct { Type string; Value string }
 		LibLocation struct { Type string; Value string }
+		LotHome struct { Type string; Value string }
 		PolicyDefinitions struct { Type string; Value interface{} }
 	}
 	MinimumDownloadSpeed struct { Type string; Value int }


### PR DESCRIPTION
Elsewhere in Pelican, `DbLocation` params point to the the name of an actual file, not the base directory for a file. So as not to break that convention, I'm renaming this Lotman key to match the name Lotman actually uses to refer to the path.