### PR TITLE
Enable PROPFIND of Director health test API

### DIFF
--- a/director/director_test.go
+++ b/director/director_test.go
@@ -32,6 +32,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -2010,93 +2011,142 @@ func TestHeaderGenFuncs(t *testing.T) {
 }
 
 func TestGetHealthTestFile(t *testing.T) {
-	router := gin.Default()
-	router.Any("/api/v1.0/director/healthTest/*path", getHealthTestFile)
-	router.Handle("PROPFIND", "/api/v1.0/director/healthTest/*path", getHealthTestFile)
+	gEngine := gin.Default()
+	router := gEngine.Group("/")
+	ctx := context.Background()
+	ctx, cancel, _ := test_utils.TestContext(ctx, t)
+	defer cancel()
+	RegisterDirectorAPI(ctx, router)
 
-	t.Run("400-on-empty-path", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/api/v1.0/director/healthTest/", nil)
-		router.ServeHTTP(w, req)
+	tests := []struct {
+		name       string
+		method     string
+		url        string
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name:       "400-on-empty-path",
+			method:     "GET",
+			url:        "/api/v1.0/director/healthTest/",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "400-on-random-path",
+			method:     "GET",
+			url:        "/api/v1.0/director/healthTest/foo/bar",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "400-on-dir",
+			method:     "GET",
+			url:        "/api/v1.0/director/healthTest/pelican/monitoring",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "400-on-missing-file-ext-self-test",
+			method:     "GET",
+			url:        "/api/v1.0/director/healthTest/pelican/monitoring/selfTest/testfile",
+			wantStatus: http.StatusBadRequest,
+			wantBody:   "{\"status\":\"error\",\"msg\":\"Test file name is missing file extension: /pelican/monitoring/selfTest/testfile\"}",
+		},
+		{
+			name:       "400-on-missing-file-ext-director-test",
+			method:     "GET",
+			url:        "/api/v1.0/director/healthTest/pelican/monitoring/directorTest/testfile",
+			wantStatus: http.StatusBadRequest,
+			wantBody:   "{\"status\":\"error\",\"msg\":\"Test file name is missing file extension: /pelican/monitoring/directorTest/testfile\"}",
+		},
+		{
+			name:       "400-on-bad-timestamp-self-test",
+			method:     "GET",
+			url:        "/api/v1.0/director/healthTest/pelican/monitoring/selfTest/self-test-123123123123123.txt",
+			wantStatus: http.StatusBadRequest,
+			wantBody:   "{\"status\":\"error\",\"msg\":\"Invalid timestamp in file name: '123123123123123'. Should conform to 2006-01-02T15:04:05Z07:00 format (RFC 3339)\"}",
+		},
+		{
+			name:       "400-on-bad-timestamp-director-test",
+			method:     "GET",
+			url:        "/api/v1.0/director/healthTest/pelican/monitoring/directorTest/director-test-123123123123123.txt",
+			wantStatus: http.StatusBadRequest,
+			wantBody:   "{\"status\":\"error\",\"msg\":\"Invalid timestamp in file name: '123123123123123'. Should conform to 2006-01-02T15:04:05Z07:00 format (RFC 3339)\"}",
+		},
+		{
+			name:       "200-on-correct-request-file-self-test",
+			method:     "GET",
+			url:        "/api/v1.0/director/healthTest/pelican/monitoring/selfTest/self-test-2006-01-02T15:04:10Z.txt",
+			wantStatus: http.StatusOK,
+			wantBody:   server_utils.DirectorTestBody + "\n",
+		},
+		{
+			name:       "200-on-correct-request-file-director-test",
+			method:     "GET",
+			url:        "/api/v1.0/director/healthTest/pelican/monitoring/directorTest/director-test-2006-01-02T15:04:10Z.txt",
+			wantStatus: http.StatusOK,
+			wantBody:   server_utils.DirectorTestBody + "\n",
+		},
+		{
+			name:       "207-and-XML-on-PROPFIND-self-test",
+			method:     "PROPFIND",
+			url:        "/api/v1.0/director/healthTest/pelican/monitoring/selfTest/self-test-2006-01-02T15:04:10Z.txt",
+			wantStatus: http.StatusMultiStatus,
+			wantBody: `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:" xmlns:ns1="http://apache.org/dav/props/" xmlns:ns0="DAV:">
+	<D:response xmlns:lp1="DAV:" xmlns:lp2="http://apache.org/dav/props/" xmlns:lp3="LCGDM:">
+		<D:href>/pelican/monitoring/selfTest/self-test-2006-01-02T15:04:10Z.txt</D:href>
+		<D:propstat>
+			<D:prop>
+				<lp1:getcontentlength>67</lp1:getcontentlength>
+				<lp1:getlastmodified>Mon, 02 Jan 2006 15:04:10 GMT</lp1:getlastmodified>
+				<lp1:iscollection>0</lp1:iscollection>
+				<lp1:executable>F</lp1:executable>
+			</D:prop>
+			<D:status>HTTP/1.1 200 OK</D:status>
+		</D:propstat>
+	</D:response>
+</D:multistatus>`,
+		},
+		{
+			name:       "207-and-XML-on-PROPFIND-director-test",
+			method:     "PROPFIND",
+			url:        "/api/v1.0/director/healthTest/pelican/monitoring/directorTest/director-test-2006-01-02T15:04:10Z.txt",
+			wantStatus: http.StatusMultiStatus,
+			wantBody: `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:" xmlns:ns1="http://apache.org/dav/props/" xmlns:ns0="DAV:">
+	<D:response xmlns:lp1="DAV:" xmlns:lp2="http://apache.org/dav/props/" xmlns:lp3="LCGDM:">
+		<D:href>/pelican/monitoring/directorTest/director-test-2006-01-02T15:04:10Z.txt</D:href>
+		<D:propstat>
+			<D:prop>
+				<lp1:getcontentlength>67</lp1:getcontentlength>
+				<lp1:getlastmodified>Mon, 02 Jan 2006 15:04:10 GMT</lp1:getlastmodified>
+				<lp1:iscollection>0</lp1:iscollection>
+				<lp1:executable>F</lp1:executable>
+			</D:prop>
+			<D:status>HTTP/1.1 200 OK</D:status>
+		</D:propstat>
+	</D:response>
+</D:multistatus>`,
+		},
+	}
 
-		assert.Equal(t, http.StatusBadRequest, w.Code)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(tt.method, tt.url, nil)
+			gEngine.ServeHTTP(w, req)
 
-	t.Run("400-on-random-path", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/api/v1.0/director/healthTest/foo/bar", nil)
-		router.ServeHTTP(w, req)
-
-		assert.Equal(t, http.StatusBadRequest, w.Code)
-	})
-
-	t.Run("400-on-dir", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/api/v1.0/director/healthTest/pelican/monitoring", nil)
-		router.ServeHTTP(w, req)
-
-		assert.Equal(t, http.StatusBadRequest, w.Code)
-	})
-
-	t.Run("400-on-missing-file-ext", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/api/v1.0/director/healthTest/pelican/monitoring/selfTest/testfile", nil)
-		router.ServeHTTP(w, req)
-
-		assert.Equal(t, http.StatusBadRequest, w.Code)
-		bytes, err := io.ReadAll(w.Result().Body)
-		require.NoError(t, err)
-		assert.Contains(t, string(bytes), "Test file name is missing file extension")
-	})
-
-	t.Run("400-on-bad-timestamp", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/api/v1.0/director/healthTest/pelican/monitoring/directorTest/director-test-123123123123123.txt", nil)
-		router.ServeHTTP(w, req)
-
-		assert.Equal(t, http.StatusBadRequest, w.Code)
-		bytes, err := io.ReadAll(w.Result().Body)
-		require.NoError(t, err)
-		assert.Contains(t, string(bytes), "Invalid timestamp in file name")
-	})
-
-	t.Run("200-on-correct-request-file", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/api/v1.0/director/healthTest/pelican/monitoring/directorTest/director-test-2006-01-02T15:04:10Z.txt", nil)
-		router.ServeHTTP(w, req)
-
-		assert.Equal(t, http.StatusOK, w.Code)
-
-		bytes, err := io.ReadAll(w.Result().Body)
-		require.NoError(t, err)
-		assert.Equal(t, server_utils.DirectorTestBody+"\n", string(bytes))
-	})
-
-	t.Run("207-and-XML-on-PROPFIND", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		req, _ := http.NewRequest("PROPFIND", "/api/v1.0/director/healthTest/pelican/monitoring/directorTest/director-test-2006-01-02T15:04:10Z.txt", nil)
-		router.ServeHTTP(w, req)
-
-		require.Equal(t, http.StatusMultiStatus, w.Code)
-
-		bytes, err := io.ReadAll(w.Result().Body)
-		require.NoError(t, err)
-		assert.Equal(t, `<?xml version="1.0" encoding="utf-8"?>
-	<D:multistatus xmlns:D="DAV:" xmlns:ns1="http://apache.org/dav/props/" xmlns:ns0="DAV:">
-		<D:response xmlns:lp1="DAV:" xmlns:lp2="http://apache.org/dav/props/" xmlns:lp3="LCGDM:">
-			<D:href>/pelican/monitoring/directorTest/director-test-2006-01-02T15:04:10Z.txt</D:href>
-			<D:propstat>
-				<D:prop>
-					<lp1:getcontentlength>67</lp1:getcontentlength>
-					<lp1:getlastmodified>Mon, 02 Jan 2006 15:04:10 GMT</lp1:getlastmodified>
-					<lp1:iscollection>0</lp1:iscollection>
-					<lp1:executable>F</lp1:executable>
-				</D:prop>
-				<D:status>HTTP/1.1 200 OK</D:status>
-			</D:propstat>
-		</D:response>
-	</D:multistatus>`, string(bytes))
-	})
+			assert.Equal(t, tt.wantStatus, w.Code)
+			if tt.wantBody != "" {
+				bytes, err := io.ReadAll(w.Result().Body)
+				require.NoError(t, err)
+				// Normalize whitespace in the response body and expected body so
+				// we can compare them directly
+				actual := strings.Join(strings.Fields(string(bytes)), " ")
+				expected := strings.Join(strings.Fields(tt.wantBody), " ")
+				assert.Equal(t, expected, actual)
+			}
+		})
+	}
 }
 
 func TestHandleFilterServer(t *testing.T) {

--- a/e2e_fed_tests/README.md
+++ b/e2e_fed_tests/README.md
@@ -1,0 +1,13 @@
+# End to End Fed Tests Package
+
+This package is meant to be a repository of federation tests that test specific Pelican components
+when their interaction with other services is important. It has been created as its own package to
+avoid the potential for circular dependencies, and as such no functions here should ever be exported.
+
+For example, the Director's health test utility API needs to function with both caches and origins.
+Testing these components together is most easily done by using `fed_test_utils` to spin up a new
+federation test. However, that package cannot be imported by Director, Cache, or Origin tests directly
+because the fed test itself _must_ import those packages, leading to a cyclical dependency.
+
+The `github_scripts` directory contains a similar set of CI tests, but it's easier to write rigorous
+tests in go than it is to write them in bash.

--- a/e2e_fed_tests/director_test.go
+++ b/e2e_fed_tests/director_test.go
@@ -1,0 +1,123 @@
+/***************************************************************
+*
+* Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
+
+package fed_tests
+
+import (
+	"io"
+
+	"context"
+	"crypto/tls"
+	_ "embed"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/fed_test_utils"
+	"github.com/pelicanplatform/pelican/server_structs"
+
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/test_utils"
+)
+
+//go:embed resources/both-public.yml
+var bothPubNamespaces string
+
+type serverAdUnmarshal struct {
+	Type string `json:"type"`
+	URL  string `json:"url"`
+}
+
+// Queries the cache for a director test file -- this mimics the way the Pelican
+// process at the cache behaves, as its responsible for requesting files from its
+// own XRootD component
+func TestDirectorCacheHealthTest(t *testing.T) {
+	// Spin up a federation
+	_ = fed_test_utils.NewFedTest(t, bothPubNamespaces)
+
+	ctx := context.Background()
+	ctx, _, _ = test_utils.TestContext(ctx, t)
+	fedInfo, err := config.GetFederation(ctx)
+	require.NoError(t, err, "Failed to get federation service info")
+
+	directorUrlStr := fedInfo.DirectorEndpoint
+	directorUrl, err := url.Parse(directorUrlStr)
+	require.NoError(t, err, "Failed to parse director URL")
+
+	// There is no cache that will advertise the /pelican/monitoring namespace directly,
+	// so we first discover a cache, then ask for the file. To do that, hit the Director's
+	// server list endpoint and iterate through the servers until we find a cache.
+	listPath, err := url.JoinPath("api", "v1.0", "director_ui", "servers")
+	require.NoError(t, err, "Failed to join server list path")
+	directorUrl.Path = listPath
+	request, err := http.NewRequest("GET", directorUrl.String(), nil)
+	require.NoError(t, err, "Failed to create HTTP request against server list path")
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := http.Client{Transport: tr}
+	resp, err := client.Do(request)
+	assert.NoError(t, err, "Failed to get response")
+	defer resp.Body.Close()
+	require.Equal(t, resp.StatusCode, http.StatusOK, "Failed to get server list from director")
+	dirBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err, "Failed to read server list body")
+
+	// Unmarshal the body into a slice of dummy server ads. Can't use the actual server_structs.ServerAd
+	// struct without a custom unmarshaler (because of string --> url conversion)
+	var serverAds []serverAdUnmarshal
+	err = json.Unmarshal(dirBody, &serverAds)
+	require.NoError(t, err, "Failed to unmarshal server ads")
+	var cacheUrlStr string
+	found := false
+	for _, serverAd := range serverAds {
+		if serverAd.Type == server_structs.CacheType.String() {
+			cacheUrlStr = serverAd.URL
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "Failed to find a cache server in the server list")
+	cacheUrl, err := url.Parse(cacheUrlStr)
+	require.NoError(t, err, "Failed to parse cache URL")
+
+	// Now ask the cache for the director test file. When it gets the request,
+	// it'll turn around and ask the director for the file, exactly as it would
+	// if the cache's own self-test utility requested the file.
+	cachePath, err := url.JoinPath(server_utils.MonitoringBaseNs, "directorTest",
+		server_utils.DirectorTest.String()+"-2006-01-02T15:04:10Z.txt")
+	require.NoError(t, err, "Failed to join path")
+
+	cacheUrl.Path = cachePath
+	request, err = http.NewRequest("GET", cacheUrl.String(), nil)
+	require.NoError(t, err, "Failed to create HTTP request against cache")
+
+	resp, err = client.Do(request)
+	assert.NoError(t, err, "Failed to get response")
+	defer resp.Body.Close()
+	cacheBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err, "Failed to read cache body")
+	assert.Equal(t, resp.StatusCode, http.StatusOK, "Failed to get director test file from cache")
+	assert.Contains(t, string(cacheBody), "This object was created by the Pelican director-test functionality")
+}

--- a/e2e_fed_tests/director_test.go
+++ b/e2e_fed_tests/director_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 /***************************************************************
 *
 * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
@@ -19,12 +21,11 @@
 package fed_tests
 
 import (
-	"io"
-
 	"context"
 	"crypto/tls"
 	_ "embed"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"

--- a/e2e_fed_tests/resources/both-public.yml
+++ b/e2e_fed_tests/resources/both-public.yml
@@ -1,0 +1,15 @@
+# Origin export configuration to test full multi-export capabilities
+
+Origin:
+  # Things that configure the origin itself
+  StorageType: "posix"
+  EnableDirectReads: true
+  # The actual namespaces we export
+  Exports:
+    - StoragePrefix: /<SHOULD BE OVERRIDDEN>
+      FederationPrefix: /first/namespace
+      # Don't set Reads -- it should be toggled true by setting PublicReads
+      Capabilities: ["PublicReads", "Writes", "DirectReads", "Listings"]
+    - StoragePrefix: /<SHOULD BE OVERRIDDEN>
+      FederationPrefix: /second/namespace
+      Capabilities: ["PublicReads", "Writes", "DirectReads", "Listings"]


### PR DESCRIPTION
The cache's `xrdcl-pelican` plugin switched from doing a HEAD request against requested resources to a PROPFIND request, the answer to which is used by the cache to determine whether something is an object or a collection. That's hunky dory, except that it broke the pseudo Director origin responsible for generating health test files, because the Director's health test API wasn't handling the propfinds.

This commit adds PROPFIND handling and generates the XML needed by the cache to understand the response. Note that I constructed the XML by pinging a cache with a real PROPFIND and then templating the response with file name, size, and time stamp.

One item remaining here is an actual E2E test of the setup -- while the unit tests are passing just fine, they passed just fine when everything broke... a better setup is forthcoming.