### PR TITLE
Reduce memory hoarding in the unit test

### DIFF
--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -114,6 +114,7 @@ Xrootd:
   DetailedMonitoringPort: 9930
   SummaryMonitoringPort: 9931
   AuthRefreshInterval: 5m
+  EnableLocalMonitoring: true
 Transport:
   DialerTimeout: 10s
   DialerKeepAlive: 30s

--- a/director/resources/director-public.yaml
+++ b/director/resources/director-public.yaml
@@ -11,6 +11,9 @@ Director:
   # to trigger any memory hoarding issues.
   #AssumePresenceAtSingleOrigin: false
   CachePresenceCapacity: 100
+  CheckCachePresence: true
+  CheckOriginPresence: true
+  EnableStat: true
 
 Origin:
   # Things that configure the origin itself

--- a/director/stat_stress_test.go
+++ b/director/stat_stress_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sync/errgroup"
 
@@ -52,6 +53,7 @@ var (
 func TestStatMemory(t *testing.T) {
 	server_utils.ResetTestState()
 
+	viper.Set(param.Xrootd_EnableLocalMonitoring.GetName(), false)
 	fed := fed_test_utils.NewFedTest(t, directorPublicCfg)
 	discoveryUrl, err := url.Parse(param.Federation_DiscoveryUrl.GetString())
 	assert.NoError(t, err)
@@ -102,6 +104,6 @@ func TestStatMemory(t *testing.T) {
 	log.Infoln("Go routine count after warm-up:", goCnt)
 	log.Infoln("Go routine count after test:", afterGoCnt)
 
-	assert.Less(t, afterStats.HeapAlloc, stats.HeapAlloc+7e5)
-	assert.Less(t, afterGoCnt, goCnt+10)
+	assert.Less(t, afterStats.HeapAlloc, stats.HeapAlloc+5e5)
+	assert.Less(t, afterGoCnt, goCnt+20)
 }

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2590,6 +2590,18 @@ type: int
 default: 9930
 components: ["origin", "cache"]
 ---
+name: Xrootd.EnableLocalMonitoring
+description: |+
+  Controls whether pelican will consume and monitor the detailed monitoring from
+  XRootD.  The detailed monitoring requires a modest amount of memory (typically, a
+  few megabytes) and is recommended to always leave enabled.
+
+  This option exists to minimize memory churn during unit tests.
+type: bool
+default: true
+hidden: true
+components: ["origin", "cache"]
+---
 name: Xrootd.LocalMonitoringHost
 description: |+
   A URL pointing toward the XRootD instance's Local Monitoring Host.

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -398,6 +398,7 @@ var (
 	Shoveler_VerifyHeader = BoolParam{"Shoveler.VerifyHeader"}
 	StagePlugin_Hook = BoolParam{"StagePlugin.Hook"}
 	TLSSkipVerify = BoolParam{"TLSSkipVerify"}
+	Xrootd_EnableLocalMonitoring = BoolParam{"Xrootd.EnableLocalMonitoring"}
 )
 
 var (

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -334,6 +334,7 @@ type Config struct {
 		ConfigFile string `mapstructure:"configfile" yaml:"ConfigFile"`
 		DetailedMonitoringHost string `mapstructure:"detailedmonitoringhost" yaml:"DetailedMonitoringHost"`
 		DetailedMonitoringPort int `mapstructure:"detailedmonitoringport" yaml:"DetailedMonitoringPort"`
+		EnableLocalMonitoring bool `mapstructure:"enablelocalmonitoring" yaml:"EnableLocalMonitoring"`
 		LocalMonitoringHost string `mapstructure:"localmonitoringhost" yaml:"LocalMonitoringHost"`
 		MacaroonsKeyFile string `mapstructure:"macaroonskeyfile" yaml:"MacaroonsKeyFile"`
 		ManagerHost string `mapstructure:"managerhost" yaml:"ManagerHost"`
@@ -662,6 +663,7 @@ type configWithType struct {
 		ConfigFile struct { Type string; Value string }
 		DetailedMonitoringHost struct { Type string; Value string }
 		DetailedMonitoringPort struct { Type string; Value int }
+		EnableLocalMonitoring struct { Type string; Value bool }
 		LocalMonitoringHost struct { Type string; Value string }
 		MacaroonsKeyFile struct { Type string; Value string }
 		ManagerHost struct { Type string; Value string }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -36,6 +36,7 @@ import (
 
 var (
 	watermarkUnits = []byte{'k', 'm', 'g', 't'}
+	uaRegExp       = regexp.MustCompile(`^pelican-[^\/]+\/\d+\.\d+\.\d+`)
 )
 
 // snakeCaseToCamelCase converts a snake case string to camel case.
@@ -124,7 +125,6 @@ func ExtractAndMaskIP(ipStr string) (maskedIP string, ok bool) {
 // the user agent.
 // It will return empty strings if the provided userAgent fails to match against the parser
 func ExtractVersionAndServiceFromUserAgent(userAgent string) (reqVer, service string) {
-	uaRegExp := regexp.MustCompile(`^pelican-[^\/]+\/\d+\.\d+\.\d+`)
 	if matches := uaRegExp.MatchString(userAgent); !matches {
 		return "", ""
 	}


### PR DESCRIPTION
This PR reduces memory hoarding and memory churn by:

1. Hoisting a regexp compilation from a local (called from the HTTP request handler) to a global.
2. Deleting an entry out of a cache once we will no longer use it.
3. Providing the unit tests with a configuration knob to completely disable local xrootd monitoring, making their memory usage more predictable.