### PR TITLE
Add /version endpoint to expose version and build info

### DIFF
--- a/swagger/pelican-swagger.yaml
+++ b/swagger/pelican-swagger.yaml
@@ -651,7 +651,7 @@ definitions:
       exports:
         type: array
         items:
-           $ref: "#/definitions/OriginExport"
+          $ref: "#/definitions/OriginExport"
         minItems: 0
   GlobusExport:
     type: object
@@ -800,8 +800,7 @@ paths:
       tags:
         - "common"
       summary: Update the server configuration with user-provided changes
-      description:
-        "`Authentication Required` `Admin privilege Required`
+      description: "`Authentication Required` `Admin privilege Required`
 
 
         The server will restart promptly after a  successful request. You may query against
@@ -816,8 +815,7 @@ paths:
         - in: body
           name: config
           required: true
-          description:
-            The config value to update.
+          description: The config value to update.
             It must be a JSON object with keys/values that match config parameters' name and data type.
             Parameter names are case-insensitive.
           schema:
@@ -932,6 +930,39 @@ paths:
           schema:
             type: object
             $ref: "#/definitions/ErrorModelV2"
+  /version:
+    get:
+      tags:
+        - "common"
+      summary: Retrieve server version and build details
+      description: |
+        This endpoint returns detailed version information about the server,
+        including the build commit, build date, the entity responsible for the build, and the current version.
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: Successful retrieval of server version and build metadata
+          schema:
+            type: object
+            properties:
+              Build Commit:
+                type: string
+                example: "2a6af914c9b9ed4831ef78cbd2611da43f454324"
+                description: The unique commit hash used for the build
+              Build Date:
+                type: string
+                format: date-time
+                example: "2025-02-24T16:24:23Z"
+                description: The timestamp when the build was created
+              Built By:
+                type: string
+                example: "goreleaser"
+                description: The tool responsible for the build
+              Version:
+                type: string
+                example: "7.8.0"
+                description: The current version of the server
   /metrics/health:
     get:
       tags:
@@ -2113,7 +2144,7 @@ paths:
             type: string
           description: The authorization token, may also be passed via "Authorization" header.
       responses:
-        '200':
+        "200":
           description: Successfully generated federation token.
           content:
             application/json:
@@ -2123,7 +2154,7 @@ paths:
                   AccessToken:
                     type: string
                     description: The generated federation token.
-        '403':
+        "403":
           description: Forbidden - validation error or unauthorized request.
           content:
             application/json:
@@ -2136,7 +2167,7 @@ paths:
                   Msg:
                     type: string
                     description: Error message.
-        '500':
+        "500":
           description: Internal Server Error - unexpected error occurred.
           content:
             application/json:

--- a/swagger/pelican-swagger.yaml
+++ b/swagger/pelican-swagger.yaml
@@ -946,20 +946,20 @@ paths:
           schema:
             type: object
             properties:
-              Build Commit:
+              buildCommit:
                 type: string
                 example: "2a6af914c9b9ed4831ef78cbd2611da43f454324"
                 description: The unique commit hash used for the build
-              Build Date:
+              buildDate:
                 type: string
                 format: date-time
                 example: "2025-02-24T16:24:23Z"
                 description: The timestamp when the build was created
-              Built By:
+              builtBy:
                 type: string
                 example: "goreleaser"
                 description: The tool responsible for the build
-              Version:
+              version:
                 type: string
                 example: "7.8.0"
                 description: The current version of the server

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -189,6 +189,17 @@ func getEnabledServers(ctx *gin.Context) {
 	ctx.JSON(200, gin.H{"servers": enabledServers})
 }
 
+func getVersionHandler(ctx *gin.Context) {
+	response := gin.H{
+		"Version":      config.GetVersion(),
+		"Build Date":   config.GetBuiltDate(),
+		"Build Commit": config.GetBuiltCommit(),
+		"Built By":     config.GetBuiltBy(),
+	}
+
+	ctx.JSON(http.StatusOK, response)
+}
+
 func handleGlobusPages(ctx *gin.Context) {
 	// /foo/bar
 	requestPath := ctx.Param("requestPath")
@@ -534,6 +545,7 @@ func configureCommonEndpoints(engine *gin.Engine) error {
 	})
 	engine.POST("/api/v1.0/createApiToken", createApiToken)
 	engine.DELETE("/api/v1.0/deleteApiToken/:id", deleteApiToken)
+	engine.GET("/api/v1.0/version", getVersionHandler)
 	return nil
 }
 

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -191,10 +191,10 @@ func getEnabledServers(ctx *gin.Context) {
 
 func getVersionHandler(ctx *gin.Context) {
 	response := gin.H{
-		"Version":      config.GetVersion(),
-		"Build Date":   config.GetBuiltDate(),
-		"Build Commit": config.GetBuiltCommit(),
-		"Built By":     config.GetBuiltBy(),
+		"version":     config.GetVersion(),
+		"buildDate":   config.GetBuiltDate(),
+		"buildCommit": config.GetBuiltCommit(),
+		"builtBy":     config.GetBuiltBy(),
 	}
 
 	ctx.JSON(http.StatusOK, response)


### PR DESCRIPTION
Added a new /version endpoint to expose version and build details, including build commit, build date, built by, and version number. Integrated this into the common set of APIs and updated the Swagger documentation accordingly.