### PR TITLE
Bump OS X Dependencies to avoid potential segfault

### DIFF
--- a/github_scripts/osx_install.sh
+++ b/github_scripts/osx_install.sh
@@ -45,7 +45,7 @@ popd
 # Add patches to xrootd source code if needed
 git clone https://github.com/PelicanPlatform/xrootd.git
 pushd xrootd
-git checkout v5.7.2-pelican
+git checkout v5.7.3-pelican
 mkdir xrootd_build
 cd xrootd_build
 cmake .. -GNinja
@@ -53,7 +53,7 @@ ninja
 ninja install
 popd
 
-git clone --branch v1.0.2 https://github.com/PelicanPlatform/xrdcl-pelican.git
+git clone --branch v1.0.5 https://github.com/PelicanPlatform/xrdcl-pelican.git
 pushd xrdcl-pelican
 mkdir build
 cd build


### PR DESCRIPTION
Try to update the OS X dependencies to match Linux; we've been observing infrequent (but annoying) segfaults during unit tests.

Particularly, xrdcl-pelican v1.0.3 fixes a segfault in the director response caching code.

I'm not entirely sure this will fix the problem -- but it's useful to hit the "low hanging fruit"!