### PR TITLE
Start plumbing redirect choice info into Director's response body

### DIFF
--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -277,7 +277,7 @@ func updateLatLong(ad *server_structs.ServerAd) error {
 	}
 	// NOTE: If GeoIP resolution of this address fails, lat/long are set to 0.0 (the null lat/long)
 	// This causes the server to be sorted to the end of the list whenever the Director requires distance-aware sorting.
-	lat, long, err := getLatLong(addr)
+	lat, long, _, err := getLatLong(addr)
 	if err != nil {
 		return err
 	}

--- a/director/director.go
+++ b/director/director.go
@@ -603,7 +603,9 @@ func redirectToCache(ginCtx *gin.Context) {
 	// duplicate link metadata above.  This is purposeful: the Link header might get too long if we repeat
 	// the token 20 times for 20 caches.  This means a "normal HTTP client" will correctly redirect but
 	// anything parsing the `Link` header for metalinks will need logic for redirecting appropriately.
-	ginCtx.JSON(http.StatusTemporaryRedirect, redirectInfo)
+	if ginCtx.GetHeader("X-Pelican-Debug") == "true" {
+		ginCtx.JSON(http.StatusTemporaryRedirect, redirectInfo)
+	}
 	ginCtx.Redirect(http.StatusTemporaryRedirect, getFinalRedirectURL(redirectURL, reqParams))
 }
 
@@ -911,7 +913,9 @@ func redirectToOrigin(ginCtx *gin.Context) {
 
 		// See note in RedirectToCache as to why we only add the authz query parameter to this URL,
 		// not those in the `Link`.
-		ginCtx.JSON(http.StatusTemporaryRedirect, redirectInfo)
+		if ginCtx.GetHeader("X-Pelican-Debug") == "true" {
+			ginCtx.JSON(http.StatusTemporaryRedirect, redirectInfo)
+		}
 		ginCtx.Redirect(http.StatusTemporaryRedirect, getFinalRedirectURL(redirectURL, reqParams))
 	}
 }

--- a/director/director.go
+++ b/director/director.go
@@ -546,7 +546,8 @@ func redirectToCache(ginCtx *gin.Context) {
 	ctx := context.Background()
 	project := utils.ExtractProjectFromUserAgent(ginCtx.Request.Header.Values("User-Agent"))
 	ctx = context.WithValue(ctx, ProjectContextKey{}, project)
-	cacheAds, err = sortServerAds(ctx, ipAddr, cacheAds, cachesAvailabilityMap)
+	redirectInfo := server_structs.NewRedirectInfoFromIP(ipAddr.String())
+	cacheAds, err = sortServerAds(ctx, ipAddr, cacheAds, cachesAvailabilityMap, redirectInfo)
 	if err != nil {
 		log.Error("Error determining server ordering for cacheAds: ", err)
 		ginCtx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
@@ -602,7 +603,8 @@ func redirectToCache(ginCtx *gin.Context) {
 	// duplicate link metadata above.  This is purposeful: the Link header might get too long if we repeat
 	// the token 20 times for 20 caches.  This means a "normal HTTP client" will correctly redirect but
 	// anything parsing the `Link` header for metalinks will need logic for redirecting appropriately.
-	ginCtx.Redirect(307, getFinalRedirectURL(redirectURL, reqParams))
+	ginCtx.JSON(http.StatusTemporaryRedirect, redirectInfo)
+	ginCtx.Redirect(http.StatusTemporaryRedirect, getFinalRedirectURL(redirectURL, reqParams))
 }
 
 func redirectToOrigin(ginCtx *gin.Context) {
@@ -796,8 +798,8 @@ func redirectToOrigin(ginCtx *gin.Context) {
 	ctx := context.Background()
 	project := utils.ExtractProjectFromUserAgent(ginCtx.Request.Header.Values("User-Agent"))
 	ctx = context.WithValue(ctx, ProjectContextKey{}, project)
-
-	availableAds, err = sortServerAds(ctx, ipAddr, availableAds, nil)
+	redirectInfo := server_structs.NewRedirectInfoFromIP(ipAddr.String())
+	availableAds, err = sortServerAds(ctx, ipAddr, availableAds, nil, redirectInfo)
 	if err != nil {
 		log.Error("Error determining server ordering for originAds: ", err)
 		ginCtx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
@@ -909,6 +911,7 @@ func redirectToOrigin(ginCtx *gin.Context) {
 
 		// See note in RedirectToCache as to why we only add the authz query parameter to this URL,
 		// not those in the `Link`.
+		ginCtx.JSON(http.StatusTemporaryRedirect, redirectInfo)
 		ginCtx.Redirect(http.StatusTemporaryRedirect, getFinalRedirectURL(redirectURL, reqParams))
 	}
 }

--- a/director/sort.go
+++ b/director/sort.go
@@ -340,10 +340,10 @@ func sortServerAds(ctx context.Context, clientAddr netip.Addr, ads []server_stru
 	// For each ad, we apply the configured sort method to determine a priority weight.
 	for idx, ad := range ads {
 		redirectInfo.ServersInfo[ad.URL.String()] = &server_structs.ServerRedirectInfo{
-			Lat: ad.Latitude,
-			Lon: ad.Longitude,
+			Lat:        ad.Latitude,
+			Lon:        ad.Longitude,
 			LoadWeight: ad.IOLoad,
-			HasObject: "unknown",
+			HasObject:  "unknown",
 		}
 
 		switch server_structs.SortType(sortMethod) {

--- a/director/sort.go
+++ b/director/sort.go
@@ -408,14 +408,15 @@ func sortServerAds(ctx context.Context, clientAddr netip.Addr, ads []server_stru
 			weights[idx] = SwapMap{rand.Float64(), idx}
 		default:
 			// Never say never, but this should never get hit because we validate the value on startup.
+			// The only real way to get here is through writing unit tests.
 			return nil, errors.Errorf("Invalid sort method '%s' set in Director.CacheSortMethod.", param.Director_CacheSortMethod.GetString())
 		}
 	}
 
 	if sortMethod == string(server_structs.AdaptiveType) {
-		candidates, _ := stochasticSort(weights, serverResLimit)
+		candidates := stochasticSort(weights, serverResLimit)
 		resultAds := []server_structs.ServerAd{}
-		for _, cidx := range candidates[:serverResLimit] {
+		for _, cidx := range candidates[:min(len(candidates), serverResLimit)] {
 			resultAds = append(resultAds, ads[cidx])
 		}
 		return resultAds, nil

--- a/director/sort_algorithms.go
+++ b/director/sort_algorithms.go
@@ -96,6 +96,57 @@ func gatedHalvingMultiplier(val float64, threshold float64, halvingFactor float6
 	}
 }
 
+// Given a map of ranges and an index, remove the range at the index and shift the rest of the ranges
+// to the left.
+func removeAndRerange(wSum *float64, ranges map[int][]float64, index int) {
+    shiftVal := ranges[index][1] - ranges[index][0]
+	*wSum -= shiftVal
+    delete(ranges, index)
+    for i := range ranges {
+        if i > index {
+            ranges[i][0] -= shiftVal
+            ranges[i][1] -= shiftVal
+        }
+    }
+}
+
+// Given a SwapMaps struct, generate the ranges for each weight and the total weight sum.
+func generateRanges(sm SwapMaps) (wSum float64, ranges map[int][]float64) {
+	wSum = 0.0
+	ranges = make(map[int][]float64, len(sm))
+	// Some incoming weights may be negative, indicating they should be sorted at the end of the list.
+	// However, this adaptive sort algorithm assumes positive weights because of the way it stochastically
+	// grabs values from ranges. To handle this, we'll normalize the negative weights by making positive and
+	// dividing by the smallest non-negative weight from the swap maps. This guarantees negative weights always
+	// have a smaller range than positive weights, and more negative weights have smaller ranges.
+	var minWeight float64
+	for idx, val := range sm {
+		if idx == 0 {
+			minWeight = val.Weight
+		} else if val.Weight < minWeight && val.Weight >= 0 {
+			minWeight = val.Weight
+		}
+	}
+
+	// Calculate the ranges for each weight, and the total weight sum
+	for idx, val := range sm {
+		// Guarantee that any negative weights are turned into a positive range,
+		// where the more negative weights correspond to smaller ranges.
+		if val.Weight < 0 {
+			val.Weight = -1 * minWeight / (val.Weight - 1) // subtract by one to guarantee abs(denominator) > 1
+		}
+		if idx == 0 {
+			ranges[idx] = []float64{0.0, val.Weight}
+		} else {
+			prev := ranges[idx-1][1]
+			ranges[idx] = []float64{prev, prev + val.Weight}
+		}
+		wSum += val.Weight
+	}
+
+	return
+}
+
 // Given a SwapMaps struct, stochasticlly sort the weights based on the following procedure:
 //
 //  1. Create ranges [0, weight_1), [weight_1, weight_1 + weight_2), ... for each weight.
@@ -104,39 +155,28 @@ func gatedHalvingMultiplier(val float64, threshold float64, halvingFactor float6
 //
 //  3. If the number falls within the range corresponding to the weight, it is sorted to the top.
 //
-//  4. Repeat step 2-3 to select a the rest weights
+//  4. Remove the range corresponding to the selected weight and re-calculate the ranges.
 //
-// Returnss the sorted list of SwapMap.Index and the generated random weights for reference.
+//  5. Repeat step 2-4 to select a the rest weights
+//
+// Returns the sorted list of SwapMap.Index
 // You may specify the maxOut argument to limit the output.
-func stochasticSort(sm SwapMaps, maxOut int) (candidates []int, randWeights []float64) {
-	if maxOut <= 0 {
+func stochasticSort(sm SwapMaps, maxOut int) (candidates []int) {
+	if maxOut <= 0 || maxOut > len(sm) {
 		maxOut = len(sm)
 	}
-	maxOut = min(maxOut, len(sm))
 
-	wSum := 0.0
-	ranges := [][]float64{} // items in ranges should corresponds to items in sm
-	visited := make([]bool, len(sm))
-	for idx, val := range sm {
-		if idx == 0 {
-			ranges = append(ranges, []float64{0.0, val.Weight})
-		} else {
-			prev := ranges[idx-1][1]
-			ranges = append(ranges, []float64{prev, prev + val.Weight})
-		}
-		wSum += val.Weight
-		visited[idx] = false
-	}
+	wSum, ranges := generateRanges(sm)
 
 	for len(candidates) < maxOut {
 		ranNum := rand.Float64() * wSum
 		for idx, r := range ranges {
-			if ranNum >= r[0] && ranNum < r[1] && !visited[idx] {
+			if ranNum >= r[0] && ranNum < r[1] {
+				removeAndRerange(&wSum, ranges, idx)
+
 				// Here, we append Index of the SwapMaps[idx] as that's the
 				// true index to sort
 				candidates = append(candidates, sm[idx].Index)
-				randWeights = append(randWeights, ranNum)
-				visited[idx] = true
 				break
 			}
 		}

--- a/director/sort_algorithms.go
+++ b/director/sort_algorithms.go
@@ -99,15 +99,15 @@ func gatedHalvingMultiplier(val float64, threshold float64, halvingFactor float6
 // Given a map of ranges and an index, remove the range at the index and shift the rest of the ranges
 // to the left.
 func removeAndRerange(wSum *float64, ranges map[int][]float64, index int) {
-    shiftVal := ranges[index][1] - ranges[index][0]
+	shiftVal := ranges[index][1] - ranges[index][0]
 	*wSum -= shiftVal
-    delete(ranges, index)
-    for i := range ranges {
-        if i > index {
-            ranges[i][0] -= shiftVal
-            ranges[i][1] -= shiftVal
-        }
-    }
+	delete(ranges, index)
+	for i := range ranges {
+		if i > index {
+			ranges[i][0] -= shiftVal
+			ranges[i][1] -= shiftVal
+		}
+	}
 }
 
 // Given a SwapMaps struct, generate the ranges for each weight and the total weight sum.

--- a/director/sort_algorithms_test.go
+++ b/director/sort_algorithms_test.go
@@ -98,7 +98,7 @@ func TestStochasticSort(t *testing.T) {
 	})
 
 	t.Run("maxOut-greater-than-length-returns-len-of-sm", func(t *testing.T) {
-		c:= stochasticSort(mockSwapMaps, len(mockSwapMaps)+1)
+		c := stochasticSort(mockSwapMaps, len(mockSwapMaps)+1)
 		assert.Len(t, c, len(mockSwapMaps))
 	})
 

--- a/director/sort_algorithms_test.go
+++ b/director/sort_algorithms_test.go
@@ -84,58 +84,26 @@ func TestStochasticSort(t *testing.T) {
 		{Weight: 10.5, Index: 4},
 		{Weight: 8, Index: 5},
 		{Weight: 2.1, Index: 0},
+		{Weight: -0.9, Index: 7},
 	}
 	t.Run("non-positive-maxOut-returns-all", func(t *testing.T) {
-		c, r := stochasticSort(mockSwapMaps, 0)
+		c := stochasticSort(mockSwapMaps, 0)
 		assert.Len(t, c, len(mockSwapMaps))
-		assert.Len(t, r, len(mockSwapMaps))
 
-		c, r = stochasticSort(mockSwapMaps, -1)
+		c = stochasticSort(mockSwapMaps, -1)
 		assert.Len(t, c, len(mockSwapMaps))
-		assert.Len(t, r, len(mockSwapMaps))
 
-		c, r = stochasticSort(mockSwapMaps, -10)
+		c = stochasticSort(mockSwapMaps, -10)
 		assert.Len(t, c, len(mockSwapMaps))
-		assert.Len(t, r, len(mockSwapMaps))
 	})
 
 	t.Run("maxOut-greater-than-length-returns-len-of-sm", func(t *testing.T) {
-		c, r := stochasticSort(mockSwapMaps, len(mockSwapMaps)+1)
+		c:= stochasticSort(mockSwapMaps, len(mockSwapMaps)+1)
 		assert.Len(t, c, len(mockSwapMaps))
-		assert.Len(t, r, len(mockSwapMaps))
 	})
 
 	t.Run("maxOut-returns-correctly", func(t *testing.T) {
-		c, r := stochasticSort(mockSwapMaps, 3)
+		c := stochasticSort(mockSwapMaps, 3)
 		assert.Len(t, c, 3)
-		assert.Len(t, r, 3)
-	})
-
-	t.Run("random-num-matches-range", func(t *testing.T) {
-		c, r := stochasticSort(mockSwapMaps, 0)
-		ranges := [][]float64{} // items in ranges should corresponds to items in sm
-		for idx, val := range mockSwapMaps {
-			if idx == 0 {
-				ranges = append(ranges, []float64{0.0, val.Weight})
-			} else {
-				prev := ranges[idx-1][1]
-				ranges = append(ranges, []float64{prev, prev + val.Weight})
-			}
-		}
-
-		for ridx, ran := range r {
-			foundWeight := -1.0
-			foundMMIdx := -1
-			for midx, mm := range mockSwapMaps {
-				if c[ridx] == mm.Index {
-					foundWeight = mm.Weight
-					foundMMIdx = midx
-				}
-			}
-			assert.NotEqual(t, foundWeight, -1.0)
-			assert.NotEqual(t, foundMMIdx, -1)
-
-			assert.True(t, ran >= ranges[foundMMIdx][0] && ran < ranges[foundMMIdx][1])
-		}
 	})
 }

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -172,6 +172,28 @@ type (
 		VaultServer   *url.URL
 	}
 
+	ClientRedirectInfo struct {
+		Lat           float64 `json:"lat"`
+		Lon           float64 `json:"lon"`
+		GeoIpRadiusKm uint16  `json:"geo-ip-radius-km"` // 0 will indicate no radius (i.e. no resolution)
+		Resolved      bool    `json:"resolved"`         // whether or not the client IP was resolved by MaxMind
+		FromTTLCache  bool    `json:"from-ttlcache"`    // whether we're using a cached value
+		IpAddr        string  `json:"ip-addr"`
+	}
+
+	ServerRedirectInfo struct {
+		Lat        float64 `json:"lat"`
+		Lon        float64 `json:"lon"`
+		HasObject  string  `json:"has-object"`
+		LoadWeight float64 `json:"load-weight"`
+	}
+
+	RedirectInfo struct {
+		ClientInfo         ClientRedirectInfo
+		ServersInfo        map[string]*ServerRedirectInfo
+		DirectorSortMethod string
+	}
+
 	DirectorResponse struct {
 		ObjectServers []*url.URL // List of servers provided in Link header
 		Location      *url.URL   // URL content of the location header
@@ -271,6 +293,15 @@ func (x *XPelTokGen) ParseRawResponse(resp *http.Response) error {
 		}
 	}
 	return nil
+}
+
+func NewRedirectInfoFromIP(ipAddr string) *RedirectInfo {
+	return &RedirectInfo{
+		ClientInfo: ClientRedirectInfo{
+			IpAddr: ipAddr,
+		},
+		ServersInfo: map[string]*ServerRedirectInfo{},
+	}
 }
 
 const (

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -175,23 +175,23 @@ type (
 	ClientRedirectInfo struct {
 		Lat           float64 `json:"lat"`
 		Lon           float64 `json:"lon"`
-		GeoIpRadiusKm uint16  `json:"geo-ip-radius-km"` // 0 will indicate no radius (i.e. no resolution)
-		Resolved      bool    `json:"resolved"`         // whether or not the client IP was resolved by MaxMind
-		FromTTLCache  bool    `json:"from-ttlcache"`    // whether we're using a cached value
-		IpAddr        string  `json:"ip-addr"`
+		GeoIpRadiusKm uint16  `json:"geoIpRadiusKm"` // 0 will indicate no radius (i.e. no resolution)
+		Resolved      bool    `json:"resolved"`      // whether or not the client IP was resolved by MaxMind
+		FromTTLCache  bool    `json:"fromTtlcache"`  // whether we're using a cached value
+		IpAddr        string  `json:"ipAddr"`
 	}
 
 	ServerRedirectInfo struct {
 		Lat        float64 `json:"lat"`
 		Lon        float64 `json:"lon"`
-		HasObject  string  `json:"has-object"`
-		LoadWeight float64 `json:"load-weight"`
+		HasObject  string  `json:"hasObject"`
+		LoadWeight float64 `json:"loadWeight"`
 	}
 
 	RedirectInfo struct {
-		ClientInfo         ClientRedirectInfo
-		ServersInfo        map[string]*ServerRedirectInfo
-		DirectorSortMethod string
+		ClientInfo         ClientRedirectInfo             `json:"clientInfo"`
+		ServersInfo        map[string]*ServerRedirectInfo `json:"serversInfo"`
+		DirectorSortMethod string                         `json:"directorSortMethod"`
 	}
 
 	DirectorResponse struct {


### PR DESCRIPTION
One of the most frequent user/integrator issues I've encountered is "why is the Director choosing _this_ list of caches/origins to redirect me to." As this redirection logic grows more complex, it may be useful to empower curious users to inspect some of the underlying logic themselves (with the appropriate debug logging flags). Not only does provide information about the Director's choices, but it might also let users identify issues that we can solve, such as client IPs that aren't resolvable with MaxMind.

This PR should accomplish two things:
- Add information about the Director's redirect choices to its response body for both cache & origin redirects
- Display that information in the client when debug information is turned on