### PR TITLE
Do not assume the existence of XRootD (`xrootd`) when it is not necessary

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1341,9 +1341,12 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 		return errors.Wrapf(err, "failure when creating a directory for the monitoring data")
 	}
 
-	if err := MkdirAll(param.Shoveler_QueueDirectory.GetString(), 0750, user.Uid, user.Gid); err != nil {
-		return errors.Wrapf(err, "failure when creating a directory for the shoveler on-disk queue")
+	if currentServers.IsEnabled(server_structs.OriginType) || currentServers.IsEnabled(server_structs.CacheType) {
+		if err := MkdirAll(param.Shoveler_QueueDirectory.GetString(), 0750, user.Uid, user.Gid); err != nil {
+			return errors.Wrapf(err, "failure when creating a directory for the shoveler on-disk queue")
+		}
 	}
+
 	if currentServers.IsEnabled(server_structs.OriginType) {
 		ost := param.Origin_StorageType.GetString()
 		switch ost {

--- a/config/mkdirall.go
+++ b/config/mkdirall.go
@@ -23,7 +23,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"syscall"
 
 	"github.com/pkg/errors"
@@ -78,7 +77,11 @@ func MkdirAll(path string, perm os.FileMode, uid int, gid int) error {
 
 	// Set ownership on the directory that we just created.
 	if runtime.GOOS == "windows" {
-		cmd := exec.Command("icacls", path, "/grant", "*"+strconv.Itoa(uid)+":F")
+		username, err := GetDaemonUser() // FIXME (brianaydemir): This is not the correct user.
+		if err != nil {
+			return err
+		}
+		cmd := exec.Command("icacls", path, "/grant", username+":F")
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			return errors.Wrapf(err, "Failed to modify discretionary ACLs on directory %v: %s", path, string(output))


### PR DESCRIPTION
See #2055 and #2056 for this PR's background.

In `config/mkdirall.go`, I've decided that it's preferable to avoid doing a lookup on the provided `uid` and `gid` if at all possible. `MkdirAll` is a sufficiently low-level function that it seems reasonable that callers should bear the responsibility for providing correct UIDs and GIDs.