### PR TITLE
Add geoquery tool to Director containers

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -473,8 +473,8 @@ ARG TARGETOS TARGETARCH
 COPY --from=pelican-build /pelican-build/dist/${TARGETOS}_${TARGETARCH}/pelican_${TARGETOS}_${TARGETARCH}/pelican /usr/local/bin/pelican
 COPY images/entrypoint.sh /entrypoint.sh
 COPY scripts/geoquery.py /usr/local/sbin/geoquery
-RUN dnf install -y python3-pip
-RUN python3 -m pip install geoip2
+RUN dnf install -y python3-pip \
+    && python3 -m pip install geoip2
 ENTRYPOINT ["/entrypoint.sh", "pelican", "director"]
 CMD ["serve"]
 

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -472,6 +472,9 @@ FROM pelican-software-base AS director
 ARG TARGETOS TARGETARCH
 COPY --from=pelican-build /pelican-build/dist/${TARGETOS}_${TARGETARCH}/pelican_${TARGETOS}_${TARGETARCH}/pelican /usr/local/bin/pelican
 COPY images/entrypoint.sh /entrypoint.sh
+COPY scripts/geoquery.py /usr/local/sbin/geoquery
+RUN dnf install -y python3-pip
+RUN python3 -m pip install geoip2
 ENTRYPOINT ["/entrypoint.sh", "pelican", "director"]
 CMD ["serve"]
 

--- a/scripts/geoquery.py
+++ b/scripts/geoquery.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import sys
+import geoip2.database
+import geoip2.errors
+import argparse
+
+def resolve_ip(database_path, ip_address):
+    try:
+        with geoip2.database.Reader(database_path) as reader:
+            response = reader.city(ip_address)
+            print(f"IP address {ip_address} is resolvable.")
+            print(f"City: {response.city.name}")
+            print(f"Country: {response.country.name}")
+            print(f"Latitude: {response.location.latitude}")
+            print(f"Longitude: {response.location.longitude}")
+            print(f"Accuracy Radius: {response.location.accuracy_radius}")
+    except geoip2.errors.AddressNotFoundError:
+        print(f"IP address {ip_address} is not resolvable.")
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Resolve IP address using GeoIP2 database.")
+    parser.add_argument("-d", "--db-path", help="Path to the GeoIP2 database file", default="/var/cache/pelican/maxmind/GeoLite2-City.mmdb")
+    parser.add_argument("-i", "--ip", help="IP address to resolve", required=True)
+
+    args = parser.parse_args()
+
+    resolve_ip(args.db_path, args.ip)

--- a/scripts/geoquery.py
+++ b/scripts/geoquery.py
@@ -22,8 +22,18 @@ def resolve_ip(database_path, ip_address):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Resolve IP address using GeoIP2 database.")
-    parser.add_argument("-d", "--db-path", help="Path to the GeoIP2 database file", default="/var/cache/pelican/maxmind/GeoLite2-City.mmdb")
-    parser.add_argument("-i", "--ip", help="IP address to resolve", required=True)
+    parser.add_argument(
+        "-d",
+        "--db-path",
+        help="Path to the GeoIP2 database file",
+        default="/var/cache/pelican/maxmind/GeoLite2-City.mmdb"
+    )
+    parser.add_argument(
+        "-i",
+        "--ip",
+        help="IP address to resolve",
+        required=True
+    )
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This new tool lets you run `geoquery -i {ip addr}` inside Director containers. The output is a printout of what the Director is able to tell about the IP address, based on the MaxMind database, e.g.:
```
$ geoquery -i "128.104.153.58"
IP address 128.104.153.58 is resolvable.
City: Madison
Country: United States
Latitude: 43.0782
Longitude: -89.4075
Accuracy Radius: 10
```