### PR TITLE
Use the web port for the token issuer

### DIFF
--- a/docs/pages/federating-your-data/generating-tokens.mdx
+++ b/docs/pages/federating-your-data/generating-tokens.mdx
@@ -11,7 +11,7 @@ The Pelican binary comes with a command `pelican origin token create` to generat
 ```bash copy
 pelican origin token create \
     --scope "storage.read:/" \
-    --issuer https://localhost:8443 \
+    --issuer https://localhost:8444 \
     --claim "wlcg.ver=1.0" \
     --subject origin \
     --audience https://wlcg.cern.ch/jwt/v1/any


### PR DESCRIPTION
There has been talk about removing the issuer from the xrootd
channel (e.g., port 8443)