### PR TITLE
Add RPM and Deb dependencies for the programs required to run the pre-install script

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -168,6 +168,12 @@ nfpms:
               mode: 0755
               owner: pelican
               group: pelican
+        dependencies:
+          - "/bin/sh"
+          # for useradd and groupadd:
+          - "shadow-utils"
+          # for getent:
+          - "glibc-common"
       deb:
         contents:
           - src: LICENSE
@@ -204,6 +210,13 @@ nfpms:
               mode: 0755
               owner: pelican
               group: pelican
+        dependencies:
+          # provides /bin/sh:
+          - "dash"
+          # for useradd and groupadd:
+          - "passwd"
+          # for getent:
+          - "libc-bin"
       apk:
         contents:
           - src: LICENSE


### PR DESCRIPTION
Add the dependencies required for the pre-script (which creates the pelican user and group) to run. Note that GoReleaser does not support the `Requires(pre)` header for RPMs, so even with the dependency, there is still no guarantee that e.g. /bin/sh will exist on disk by the time the pre script is invoked.