### PR TITLE
Report origin/cache version info in Director display

### DIFF
--- a/director/director_ui.go
+++ b/director/director_ui.go
@@ -60,6 +60,7 @@ type (
 		HealthStatus      HealthTestStatus            `json:"healthStatus"`
 		IOLoad            float64                     `json:"ioLoad"`
 		NamespacePrefixes []string                    `json:"namespacePrefixes"`
+		Version           string                      `json:"version"`
 	}
 
 	// A response struct for a server Ad that provides a detailed view into the servers data
@@ -84,6 +85,7 @@ type (
 		HealthStatus HealthTestStatus            `json:"healthStatus"`
 		IOLoad       float64                     `json:"ioLoad"`
 		Namespaces   []NamespaceAdV2Response     `json:"namespaces"`
+		Version      string                      `json:"version"`
 	}
 
 	// TokenIssuerResponse creates a response struct for TokenIssuer
@@ -246,6 +248,7 @@ func advertisementToServerResponse(ad *server_structs.Advertisement) serverRespo
 		FromTopology:        ad.FromTopology,
 		HealthStatus:        healthStatus,
 		IOLoad:              ad.GetIOLoad(),
+		Version:             ad.Version,
 	}
 	for _, ns := range ad.NamespaceAds {
 		nsRes := namespaceAdV2ToResponse(&ns)
@@ -273,6 +276,7 @@ func serverResponseToListServerResponse(res serverResponse) listServerResponse {
 		FromTopology:        res.FromTopology,
 		HealthStatus:        res.HealthStatus,
 		IOLoad:              res.IOLoad,
+		Version:             res.Version,
 	}
 	for _, ns := range res.Namespaces {
 		listRes.NamespacePrefixes = append(listRes.NamespacePrefixes, ns.Path)


### PR DESCRIPTION
Now Origin/Cache version can be obtained in the following Director API endpoints:
{DIRECTOR_HOSTNAME}/api/v1.0/director_ui/servers
{DIRECTOR_HOSTNAME}/api/v1.0/director_ui/servers/{SERVER_NAME}

Then the frontend can consume them for displaying version for each origin/cache in the Director web UI.