### PR TITLE
Fix `generate keygen` so that public keys included required fields

### DIFF
--- a/cmd/generate_keygen_test.go
+++ b/cmd/generate_keygen_test.go
@@ -60,6 +60,14 @@ func checkKeys(t *testing.T, privateKey, publicKey string) {
 	assert.True(t, ok)
 	err = key.Validate()
 	assert.NoError(t, err)
+
+	// The "alg" and "kid" keys must explicitly be added to the JWK.
+	// Thus, we test that this actually happened.
+	// See also: https://github.com/PelicanPlatform/pelican/issues/2084
+	_, ok = key.Get("alg")
+	assert.True(t, ok)
+	_, ok = key.Get("kid")
+	assert.True(t, ok)
 }
 
 func TestKeygenMain(t *testing.T) {

--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -554,7 +554,7 @@ func initKeysMap() {
 }
 
 // Helper function to load one .pem file from specified filename
-func loadSinglePEM(path string) (jwk.Key, error) {
+func LoadSinglePEM(path string) (jwk.Key, error) {
 	contents, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read key file")
@@ -562,7 +562,7 @@ func loadSinglePEM(path string) (jwk.Key, error) {
 
 	key, err := jwk.ParseKey(contents, jwk.WithPEM(true))
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse issuer key file %v", path)
+		return nil, errors.Wrapf(err, "failed to parse key file %v", path)
 	}
 
 	// Add the algorithm to the key, needed for verifying tokens elsewhere
@@ -589,7 +589,7 @@ func loadPEMFiles(dir string) (jwk.Key, error) {
 	issuerKeyPath := param.IssuerKey.GetString()
 	if issuerKeyPath != "" {
 		if _, err := os.Stat(issuerKeyPath); err == nil {
-			issuerKey, err := loadSinglePEM(issuerKeyPath)
+			issuerKey, err := LoadSinglePEM(issuerKeyPath)
 			if err != nil {
 				log.Warnf("Failed to load key %s: %v", issuerKeyPath, err)
 			} else {
@@ -624,7 +624,7 @@ func loadPEMFiles(dir string) (jwk.Key, error) {
 			}
 			if dirEnt.Type().IsRegular() && filepath.Ext(dirEnt.Name()) == ".pem" {
 				// Parse the private key in this file and add to the in-memory keys map
-				key, err := loadSinglePEM(path)
+				key, err := LoadSinglePEM(path)
 				if err != nil {
 					log.Warnf("Failed to load key %s: %v", path, err)
 					return nil // Skip this file and continue
@@ -706,7 +706,7 @@ func GeneratePEM(dir string) (key jwk.Key, err error) {
 		return nil, errors.Wrapf(err, "failed to generate private key in file %s", fname)
 	}
 
-	if key, err = loadSinglePEM(fname); err != nil {
+	if key, err = LoadSinglePEM(fname); err != nil {
 		log.Errorf("Failed to load key %s: %v", fname, err)
 		err = errors.Wrapf(err, "failed to load key from %s", fname)
 		return


### PR DESCRIPTION
`config.GeneratePrivateKey` is documented as generating a PEM-encoded key, so I've updated the code underlying `generate keygen` to use what seems to be the function for reading such PEM-encoded keys.

(There seem to be multiple functions for "reading" private keys, so I went with calling the function whose implementation most directly seems to address the problems of #2084.)