### PR TITLE
Create API token listing endpoint

### DIFF
--- a/database/director.go
+++ b/database/director.go
@@ -160,3 +160,13 @@ func DeleteApiKey(id string, verifiedKeysCache *ttlcache.Cache[string, server_st
 	verifiedKeysCache.Delete(id)
 	return nil
 }
+
+func ListApiKeys() ([]server_structs.ApiKey, error) {
+	var apiKeys []server_structs.ApiKey
+	result := DirectorDB.Select([]string{"id", "name", "created_at", "created_by", "expires_at", "scopes"}).Find(&apiKeys)
+	if result.Error != nil {
+		return nil, errors.Wrap(result.Error, "failed to list API keys")
+	}
+
+	return apiKeys, nil
+}

--- a/server_structs/db.go
+++ b/server_structs/db.go
@@ -12,7 +12,7 @@ type (
 	ApiKey struct {
 		ID          string `gorm:"primaryKey;column:id;type:text;not null;unique"`
 		Name        string `gorm:"column:name;type:text"`
-		HashedValue string `gorm:"column:hashed_value;type:text;not null"`
+		HashedValue string `gorm:"column:hashed_value;type:text;not null" json:"-"`
 		Scopes      string `gorm:"column:scopes;type:text"`
 		ExpiresAt   time.Time
 		CreatedAt   time.Time

--- a/swagger/pelican-swagger.yaml
+++ b/swagger/pelican-swagger.yaml
@@ -167,6 +167,29 @@ definitions:
       expiration:
         type: string
         description: The expiration time of the token. If it is empty or "never", the token will never expire. The token should be in the RFC3339 format.
+  ListApiTokenSuccess:
+    type: object
+    properties:
+      keys:
+        type: array
+        items:
+          type: object
+          properties:
+            Name:
+              type: string
+              description: The name of the token
+            ID:
+              type: string
+              description: The ID of the token
+            CreatedBy:
+              type: string
+              description: The user who created the token
+            ExpiresAt:
+              type: string
+              description: The expiration time of the token. The token should be in the RFC3339 format.
+            Scopes:
+              type: string
+              description: The scopes of the token. Comma-separated string
   CreateApiTokenSuccess:
     type: object
     properties:
@@ -927,6 +950,25 @@ paths:
             $ref: "#/definitions/SuccessModelV2"
         "500":
           description: Failed to delete token
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModelV2"
+  /listApiTokens:
+    get:
+      tags:
+        - common
+      summary: List all API tokens for the user
+      description: "`Authentication Required`"
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: Token list retrieved successfully
+          schema:
+            type: object
+            $ref: "#/definitions/ListApiTokenSuccess"
+        "500":
+          description: Failed to list tokens
           schema:
             type: object
             $ref: "#/definitions/ErrorModelV2"

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -507,6 +507,35 @@ func deleteApiToken(ctx *gin.Context) {
 	})
 }
 
+func listApiTokens(ctx *gin.Context) {
+	authOption := token.AuthOption{
+		Sources: []token.TokenSource{token.Cookie},
+		Issuers: []token.TokenIssuer{token.LocalIssuer},
+		Scopes:  []token_scopes.TokenScope{token_scopes.WebUi_Access},
+	}
+	status, ok, err := token.Verify(ctx, authOption)
+	if !ok {
+		log.Warningf("Cannot verify token: %v", err)
+		ctx.JSON(status, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    err.Error(),
+		})
+		return
+	}
+
+	apiKeys, err := database.ListApiKeys()
+	if err != nil {
+		log.Warning("Failed to list API keys: ", err)
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    err.Error(),
+		})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"keys": apiKeys})
+}
+
 func configureWebResource(engine *gin.Engine) {
 
 	// Register the MIME type for .txt files
@@ -545,6 +574,7 @@ func configureCommonEndpoints(engine *gin.Engine) error {
 	})
 	engine.POST("/api/v1.0/createApiToken", createApiToken)
 	engine.DELETE("/api/v1.0/deleteApiToken/:id", deleteApiToken)
+	engine.GET("/api/v1.0/listApiTokens", listApiTokens)
 	engine.GET("/api/v1.0/version", getVersionHandler)
 	return nil
 }

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -515,7 +515,7 @@ func listApiTokens(ctx *gin.Context) {
 	}
 	status, ok, err := token.Verify(ctx, authOption)
 	if !ok {
-		log.Warningf("Cannot verify token: %v", err)
+		log.Warningf("Failed to verify WebUi Access Cookie: %v", err)
 		ctx.JSON(status, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    err.Error(),


### PR DESCRIPTION
Closes #2069. This PR adds an endpoint to list all of the api tokens. This new endpoint is available with the other director web UI endpoints.