### PR TITLE
Base64 encode the OAuth state to avoid a double URL-encoded string

### DIFF
--- a/web_ui/oauth2_client.go
+++ b/web_ui/oauth2_client.go
@@ -360,6 +360,7 @@ func handleOAuthCallback(ctx *gin.Context) {
 			})
 		return
 	}
+	log.Debugf("User info from auth provider: %v", string(body))
 
 	var userInfo map[string]interface{}
 	if err := json.Unmarshal(body, &userInfo); err != nil {

--- a/web_ui/oauth2_client.go
+++ b/web_ui/oauth2_client.go
@@ -61,6 +61,12 @@ func ParseOAuthState(state string) (metadata map[string]string, err error) {
 		return metadata, nil
 	}
 
+	stateBytes, err := base64.RawURLEncoding.DecodeString(state)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to base64 decode the OAuth state: %v", state)
+	}
+	state = string(stateBytes)
+
 	keyvals := strings.Split(state, "&")
 	metadata = map[string]string{}
 	for _, kvStr := range keyvals {
@@ -86,14 +92,16 @@ func ParseOAuthState(state string) (metadata map[string]string, err error) {
 //
 // key1=val1&key2=val2
 //
-// where values are url-encoded
+// where values are url-encoded. We then base64 encode the resulting string
+// in order to ensure that over-zealous providers do not treat the final URL
+// as a double-encoding attack or somesuch.
 func GenerateOAuthState(metadata map[string]string) string {
 	metaStr := ""
 	for key, val := range metadata {
 		metaStr += key + "=" + url.QueryEscape(val) + "&"
 	}
 	metaStr = strings.TrimSuffix(metaStr, "&")
-	return metaStr
+	return base64.RawURLEncoding.EncodeToString([]byte(metaStr))
 }
 
 // Generate a 16B random string and set as the value of ctx session key "oauthstate"


### PR DESCRIPTION
Given that [double encoding attacks](https://en.wikipedia.org/wiki/Double_encoding) are a thing, in order to prevent OAuth providers from mangling the `state` parameter that Pelican constructs, the simplest fix might be to set the parameter's value to a value that does not contain any URL encoding. I've chosen to base-64 encode it.

And while not strictly related to the above issue, I'm taking this opportunity to add a line to the debug logging, specifically to record the user info received from an OAuth provider. This is related to making #1054 a reality (same as this PR), and it's otherwise "challenging" to get any insight into this part of the OAuth flow.