### PR TITLE
Add config parameter to allow preferring OIDC ID token claims

### DIFF
--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -137,6 +137,7 @@ Issuer:
   TomcatLocation: /opt/tomcat
   ScitokensServerLocation: /opt/scitokens-server
   QDLLocation: /opt/qdl
+  OIDCPreferClaimsFromIDToken: false
   OIDCAuthenticationUserClaim: sub
   OIDCGroupClaim: groups
   AuthenticationSource: OIDC

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2298,9 +2298,21 @@ type: object
 default: []
 components: ["origin"]
 ---
+name: Issuer.OIDCPreferClaimsFromIDToken
+description: |+
+  If set to `true`, then the claims specified by
+  `Issuer.OIDCAuthenticationUserClaim` and `Issuer.GroupSource` will first
+  be searched for in the OIDC ID token before falling back on claims from
+  the UserInfo endpoint.
+
+  If set to `false`, then only the OIDC UserInfo endpoint will be considered.
+type: bool
+default: false  # this was the behavior prior to this parameter's introduction
+components: ["origin"]
+---
 name: Issuer.OIDCAuthenticationUserClaim
 description: |+
-  The claim in the OIDC ID token to be used as the "username" for the issuer.
+  The claim to be used as the "username" for the issuer.
 type: string
 default: sub
 components: ["origin"]
@@ -2331,7 +2343,7 @@ components: ["origin"]
 ---
 name: Issuer.OIDCGroupClaim
 description: |+
-  The claim in the OIDC ID token to be used as the group for the issuer.  If the value is a string,
+  The claim to be used as the group for the issuer.  If the value is a string,
   it is assumed that a comma is used as a group delimiter; otherwise, an array of strings is assumed.
   Check the documentation of your OIDC provider to determine the appropriate claim name.
 type: string

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2300,12 +2300,12 @@ components: ["origin"]
 ---
 name: Issuer.OIDCPreferClaimsFromIDToken
 description: |+
-  If set to `true`, then the claims specified by
-  `Issuer.OIDCAuthenticationUserClaim` and `Issuer.GroupSource` will first
-  be searched for in the OIDC ID token before falling back on claims from
-  the UserInfo endpoint.
+  This applies to the claims specified by `Issuer.OIDCAuthenticationUserClaim`
+  and `Issuer.GroupSource`.
 
-  If set to `false`, then only the OIDC UserInfo endpoint will be considered.
+  If set to `true`, then claims will be searched for in the OIDC ID token
+  before falling back on claims from the UserInfo endpoint. If set to `false`,
+  then only the UserInfo endpoint will be considered.
 type: bool
 default: false  # this was the behavior prior to this parameter's introduction
 components: ["origin"]

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -368,6 +368,7 @@ var (
 	Director_EnableStat = BoolParam{"Director.EnableStat"}
 	DisableHttpProxy = BoolParam{"DisableHttpProxy"}
 	DisableProxyFallback = BoolParam{"DisableProxyFallback"}
+	Issuer_OIDCPreferClaimsFromIDToken = BoolParam{"Issuer.OIDCPreferClaimsFromIDToken"}
 	Issuer_UserStripDomain = BoolParam{"Issuer.UserStripDomain"}
 	Logging_DisableProgressBars = BoolParam{"Logging.DisableProgressBars"}
 	Lotman_EnableAPI = BoolParam{"Lotman.EnableAPI"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -125,6 +125,7 @@ type Config struct {
 		OIDCAuthenticationRequirements interface{} `mapstructure:"oidcauthenticationrequirements" yaml:"OIDCAuthenticationRequirements"`
 		OIDCAuthenticationUserClaim string `mapstructure:"oidcauthenticationuserclaim" yaml:"OIDCAuthenticationUserClaim"`
 		OIDCGroupClaim string `mapstructure:"oidcgroupclaim" yaml:"OIDCGroupClaim"`
+		OIDCPreferClaimsFromIDToken bool `mapstructure:"oidcpreferclaimsfromidtoken" yaml:"OIDCPreferClaimsFromIDToken"`
 		QDLLocation string `mapstructure:"qdllocation" yaml:"QDLLocation"`
 		ScitokensServerLocation string `mapstructure:"scitokensserverlocation" yaml:"ScitokensServerLocation"`
 		TomcatLocation string `mapstructure:"tomcatlocation" yaml:"TomcatLocation"`
@@ -460,6 +461,7 @@ type configWithType struct {
 		OIDCAuthenticationRequirements struct { Type string; Value interface{} }
 		OIDCAuthenticationUserClaim struct { Type string; Value string }
 		OIDCGroupClaim struct { Type string; Value string }
+		OIDCPreferClaimsFromIDToken struct { Type string; Value bool }
 		QDLLocation struct { Type string; Value string }
 		ScitokensServerLocation struct { Type string; Value string }
 		TomcatLocation struct { Type string; Value string }

--- a/web_ui/oauth2_client.go
+++ b/web_ui/oauth2_client.go
@@ -180,8 +180,8 @@ func generateGroupInfo(user string) (groups []string, err error) {
 	return
 }
 
-// Given a map from a JSON object, generate user/group information according to
-// the current policy.
+// Given the maps for the UserInfo and ID token JSON objects, generate
+// user/group information according to the current policy.
 func generateUserGroupInfo(userInfo map[string]interface{}, idToken map[string]interface{}) (user string, groups []string, err error) {
 	claimsSource := maps.Clone(userInfo)
 	if param.Issuer_OIDCPreferClaimsFromIDToken.GetBool() {
@@ -312,7 +312,7 @@ func handleOAuthCallback(ctx *gin.Context) {
 		return
 	}
 
-	var idToken map[string]interface{}
+	var idToken = make(map[string]interface{})
 	if idTokenRaw := token.Extra("id_token"); idTokenRaw != nil {
 		// The token's signature will show as "REDACTED" in the output.
 		log.Debugf("Found an OIDC ID token: %v", idTokenRaw)


### PR DESCRIPTION
This PR introduces a new configuration parameter, `Issuer.OIDCPreferClaimsFromIDToken`, that when when set to `true`, causes Pelican's user authentication flow to first look for claims in the OIDC ID token before falling back on the OIDC UserInfo endpoint.

Pelican's current behavior is to consider only the UserInfo endpoint, hence why this new parameter's default value is `false`.