### PR TITLE
Install `sssd-client` into both origin container images

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -418,7 +418,10 @@ ARG TARGETPLATFORM
 
 RUN --mount=type=cache,id=dnf-${TARGETPLATFORM},target=/var/cache/dnf,sharing=locked <<ENDRUN
   set -eux
-  dnf install -y java-17-openjdk-headless
+
+  # We need OpenJDK for OA4MP.
+  # We need sssd-client for some xrootd-multiuser setups.
+  dnf install -y java-17-openjdk-headless sssd-client
 ENDRUN
 
 # Install OA4MP. Most of the installation is in /opt, but there are
@@ -519,7 +522,6 @@ RUN --mount=type=cache,id=dnf-${TARGETPLATFORM},target=/var/cache/dnf,sharing=lo
   # These IDs must match OSG's sssd sidecar containers.
   groupadd -r -g 990 sssd
   useradd -r -g sssd -u 990 -d / -s /usr/sbin/nologin -c "System user for sssd" sssd
-  dnf install -y sssd-client
 ENDRUN
 RUN ln -s pelican /usr/local/bin/osdf
 ENTRYPOINT ["/entrypoint.sh", "osdf", "origin"]


### PR DESCRIPTION
Curiously, at least to me, `sssd-client` doesn't create an `sssd` UID and GID.

If I recall correctly, the reason we create an `sssd` UID and GID is so that the sockets used to communicate with the actual `sssd` daemon are owned by the daemon, which is presumably running as that UID and GID. But in at least one instance I have access to, the sockets are public read/write and owned by `root` (which is what the daemon is running as).

So, it doesn't look like we actually need to create the `sssd` UID and GID, except perhaps as a nicety for those looking at the sockets on the file system in certain specific setups.