### PR TITLE
Revise Prometheus Metric Names

### DIFF
--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -86,6 +86,7 @@ func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]
 		if geoIPError, ok := err.(geoIPError); ok {
 			labels := geoIPError.labels
 			metrics.PelicanDirectorGeoIPErrors.With(labels).Inc()
+			metrics.PelicanDirectorGeoIPErrorsTotal.With(labels).Inc()
 		}
 		log.Debugln("Failed to lookup GeoIP coordinates for host", sAd.URL.Host)
 	}

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -85,6 +85,8 @@ func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]
 	if err := updateLatLong(&sAd); err != nil {
 		if geoIPError, ok := err.(geoIPError); ok {
 			labels := geoIPError.labels
+			// TODO: Remove this metric (the line directly below)
+			// The renamed metric was added in v7.16
 			metrics.PelicanDirectorGeoIPErrors.With(labels).Inc()
 			metrics.PelicanDirectorGeoIPErrorsTotal.With(labels).Inc()
 		}

--- a/director/director.go
+++ b/director/director.go
@@ -1566,6 +1566,7 @@ func getHealthTestFile(ctx *gin.Context) {
 func collectClientVersionMetric(reqVer *version.Version, service string) {
 	if reqVer == nil || service == "" {
 		metrics.PelicanDirectorClientVersionTotal.With(prometheus.Labels{"version": "other", "service": "other"}).Inc()
+		metrics.PelicanDirectorClientRequestsTotal.With(prometheus.Labels{"version": "other", "service": "other"}).Inc()
 		return
 	}
 
@@ -1576,6 +1577,7 @@ func collectClientVersionMetric(reqVer *version.Version, service string) {
 
 	if reqVer.GreaterThan(directorVersion) {
 		metrics.PelicanDirectorClientVersionTotal.With(prometheus.Labels{"version": "pelican-future", "service": service}).Inc()
+		metrics.PelicanDirectorClientRequestsTotal.With(prometheus.Labels{"version": "pelican-future", "service": service}).Inc()
 	}
 
 	versionSegments := reqVer.Segments()
@@ -1591,6 +1593,7 @@ func collectClientVersionMetric(reqVer *version.Version, service string) {
 	shortenedVersion := strings.Join(strSegments, ".")
 
 	metrics.PelicanDirectorClientVersionTotal.With(prometheus.Labels{"version": shortenedVersion, "service": service}).Inc()
+	metrics.PelicanDirectorClientRequestsTotal.With(prometheus.Labels{"version": shortenedVersion, "service": service}).Inc()
 }
 
 func collectDirectorRedirectionMetric(ctx *gin.Context, destination string) {
@@ -1619,6 +1622,7 @@ func collectDirectorRedirectionMetric(ctx *gin.Context, destination string) {
 		labels["network"] = "unknown"
 	}
 	metrics.PelicanDirectorRedirectionsTotal.With(labels).Inc()
+	metrics.PelicanDirectorRedirectsTotal.With(labels).Inc()
 }
 
 func RegisterDirectorAPI(ctx context.Context, router *gin.RouterGroup) {

--- a/director/director.go
+++ b/director/director.go
@@ -1565,6 +1565,8 @@ func getHealthTestFile(ctx *gin.Context) {
 // In the case that parser fails, then metric is not updated
 func collectClientVersionMetric(reqVer *version.Version, service string) {
 	if reqVer == nil || service == "" {
+		// TODO: Remove this metric (the line directly below)
+		// The renamed metric was added in v7.16
 		metrics.PelicanDirectorClientVersionTotal.With(prometheus.Labels{"version": "other", "service": "other"}).Inc()
 		metrics.PelicanDirectorClientRequestsTotal.With(prometheus.Labels{"version": "other", "service": "other"}).Inc()
 		return
@@ -1576,6 +1578,8 @@ func collectClientVersionMetric(reqVer *version.Version, service string) {
 	}
 
 	if reqVer.GreaterThan(directorVersion) {
+		// TODO: Remove this metric (the line directly below)
+		// The renamed metric was added in v7.16
 		metrics.PelicanDirectorClientVersionTotal.With(prometheus.Labels{"version": "pelican-future", "service": service}).Inc()
 		metrics.PelicanDirectorClientRequestsTotal.With(prometheus.Labels{"version": "pelican-future", "service": service}).Inc()
 	}
@@ -1592,6 +1596,8 @@ func collectClientVersionMetric(reqVer *version.Version, service string) {
 
 	shortenedVersion := strings.Join(strSegments, ".")
 
+	// TODO: Remove this metric (the line directly below)
+	// The renamed metric was added in v7.16
 	metrics.PelicanDirectorClientVersionTotal.With(prometheus.Labels{"version": shortenedVersion, "service": service}).Inc()
 	metrics.PelicanDirectorClientRequestsTotal.With(prometheus.Labels{"version": shortenedVersion, "service": service}).Inc()
 }
@@ -1621,6 +1627,8 @@ func collectDirectorRedirectionMetric(ctx *gin.Context, destination string) {
 	} else {
 		labels["network"] = "unknown"
 	}
+	// TODO: Remove this metric (the line directly below)
+	// The renamed metric was added in v7.16
 	metrics.PelicanDirectorRedirectionsTotal.With(labels).Inc()
 	metrics.PelicanDirectorRedirectsTotal.With(labels).Inc()
 }

--- a/director/sort.go
+++ b/director/sort.go
@@ -333,6 +333,7 @@ func sortServerAds(ctx context.Context, clientAddr netip.Addr, ads []server_stru
 			labels := geoIPError.labels
 			setProjectLabel(ctx, &labels)
 			metrics.PelicanDirectorGeoIPErrors.With(labels).Inc()
+			metrics.PelicanDirectorGeoIPErrorsTotal.With(labels).Inc()
 		}
 		log.Warningf("Error while getting the client IP address: %v", err)
 	}

--- a/director/sort.go
+++ b/director/sort.go
@@ -332,6 +332,8 @@ func sortServerAds(ctx context.Context, clientAddr netip.Addr, ads []server_stru
 		if geoIPError, ok := err.(geoIPError); ok {
 			labels := geoIPError.labels
 			setProjectLabel(ctx, &labels)
+			// TODO: Remove this metric (the line directly below)
+			// The renamed metric was added in v7.16
 			metrics.PelicanDirectorGeoIPErrors.With(labels).Inc()
 			metrics.PelicanDirectorGeoIPErrorsTotal.With(labels).Inc()
 		}

--- a/metrics/director.go
+++ b/metrics/director.go
@@ -92,13 +92,28 @@ var (
 		Help: "The total number of requests from client versions.",
 	}, []string{"version", "service"})
 
+	PelicanDirectorClientRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "pelican_director_client_requests_total",
+		Help: "The total number of requests from clients.",
+	}, []string{"version", "service"})
+
 	PelicanDirectorRedirectionsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "pelican_director_redirections_total",
 		Help: "The total number of redirections the director issued.",
 	}, []string{"destination", "status_code", "version", "network"})
 
+	PelicanDirectorRedirectsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "pelican_director_redirects_total",
+		Help: "The total number of redirects the director issued.",
+	}, []string{"destination", "status_code", "version", "network"})
+
 	PelicanDirectorGeoIPErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "pelican_director_geoip_errors",
+		Help: "The total number of errors encountered trying to resolve coordinates using the GeoIP MaxMind database",
+	}, []string{"network", "source", "proj"})
+
+	PelicanDirectorGeoIPErrorsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "pelican_director_geoip_errors_total",
 		Help: "The total number of errors encountered trying to resolve coordinates using the GeoIP MaxMind database",
 	}, []string{"network", "source", "proj"})
 

--- a/metrics/director.go
+++ b/metrics/director.go
@@ -87,6 +87,8 @@ var (
 		Help: "The number of servers currently recognized by the Director, delineated by pelican/non-pelican and origin/cache",
 	}, []string{"server_name", "server_type", "from_topology"})
 
+	// TODO: Remove this metric (the line directly below)
+	// The renamed metric was added in v7.16
 	PelicanDirectorClientVersionTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "pelican_director_client_version_total",
 		Help: "The total number of requests from client versions.",
@@ -97,6 +99,8 @@ var (
 		Help: "The total number of requests from clients.",
 	}, []string{"version", "service"})
 
+	// TODO: Remove this metric (the line directly below)
+	// The renamed metric was added in v7.16
 	PelicanDirectorRedirectionsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "pelican_director_redirections_total",
 		Help: "The total number of redirections the director issued.",
@@ -107,6 +111,8 @@ var (
 		Help: "The total number of redirects the director issued.",
 	}, []string{"destination", "status_code", "version", "network"})
 
+	// TODO: Remove this metric (the line directly below)
+	// The renamed metric was added in v7.16
 	PelicanDirectorGeoIPErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "pelican_director_geoip_errors",
 		Help: "The total number of errors encountered trying to resolve coordinates using the GeoIP MaxMind database",

--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -345,6 +345,8 @@ const (
 )
 
 var (
+	// TODO: Remove this metric (the line directly below)
+	// The renamed metric was added in v7.16
 	PacketsReceived = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "xrootd_monitoring_packets_received",
 		Help: "The total number of monitoring UDP packets received",
@@ -355,6 +357,8 @@ var (
 		Help: "The total number of monitoring UDP packets received",
 	})
 
+	// TODO: Remove this metric (the line directly below)
+	// The renamed metric was added in v7.16
 	TransferReadvSegs = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "xrootd_transfer_readv_segments_count",
 		Help: "Number of segments in readv operations",
@@ -365,6 +369,8 @@ var (
 		Help: "Number of segments in readv operations",
 	}, []string{"path", "ap", "dn", "role", "org", "proj", "network"})
 
+	// TODO: Remove this metric (the line directly below)
+	// The renamed metric was added in v7.16
 	TransferOps = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "xrootd_transfer_operations_count",
 		Help: "Number of transfer operations performed",
@@ -385,6 +391,8 @@ var (
 		Help: "Number of scheduler threads",
 	}, []string{"state"})
 
+	// TODO: Remove this metric (the line directly below)
+	// The renamed metric was added in v7.16
 	Connections = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "xrootd_server_connection_count",
 		Help: "Aggregate number of server connections",
@@ -400,6 +408,8 @@ var (
 		Help: "Number of bytes read into the server",
 	}, []string{"direction"})
 
+	// TODO: Remove this metric (the line directly below)
+	// The renamed metric was added in v7.16
 	BytesXferTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "xrootd_server_bytes_total",
 		Help: "Number of bytes read into the server",
@@ -425,6 +435,8 @@ var (
 		Help: "Number of ongoing storage operations in origin/cache server",
 	})
 
+	// TODO: Remove this metric (the line directly below)
+	// The renamed metric was added in v7.16
 	ServerIOWaitTime = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "xrootd_server_io_wait_time",
 		Help: "The aggregate time spent in storage operations in origin/cache server",
@@ -804,6 +816,8 @@ func ConfigureMonitoring(ctx context.Context, egrp *errgroup.Group) (int, error)
 					log.Errorln("Failed to read from UDP connection while aggregating monitoring packet from XRootD:", err)
 					continue
 				}
+				// TODO: Remove this metric (the line directly below)
+				// The renamed metric was added in v7.16
 				PacketsReceived.Inc()
 				PacketsReceivedTotal.Inc()
 				if !enableHandlePacket {
@@ -1103,6 +1117,8 @@ func handlePacket(packet []byte) error {
 				if fileHdr.RecFlag&0x02 == 0x02 { // XrdXrootdMonFileHdr::hasOPS
 					// sizeof(XrdXrootdMonFileHdr) + sizeof(XrdXrootdMonStatXFR)
 					opsOffset := uint32(8 + 24)
+					// TODO: Remove this metric (the 2 lines directly below)
+					// The renamed metric was added in v7.16
 					counter := TransferReadvSegs.With(labels)
 					counter.Add(float64(int64(binary.BigEndian.Uint64(
 						packet[offset+opsOffset+16:offset+opsOffset+24]) -
@@ -1113,6 +1129,8 @@ func handlePacket(packet []byte) error {
 						oldReadvSegs)))
 
 					labels["type"] = "read"
+					// TODO: Remove this metric (the 2 lines directly below)
+					// The renamed metric was added in v7.16
 					counter = TransferOps.With(labels)
 					counter.Add(float64(int32(binary.BigEndian.Uint32(
 						packet[offset+opsOffset:offset+opsOffset+4]) -
@@ -1123,6 +1141,8 @@ func handlePacket(packet []byte) error {
 						oldReadOps)))
 
 					labels["type"] = "readv"
+					// TODO: Remove this metric (the 2 lines directly below)
+					// The renamed metric was added in v7.16
 					counter = TransferOps.With(labels)
 					counter.Add(float64(int32(binary.BigEndian.Uint32(
 						packet[offset+opsOffset+4:offset+opsOffset+8]) -
@@ -1133,6 +1153,8 @@ func handlePacket(packet []byte) error {
 						oldReadvOps)))
 
 					labels["type"] = "write"
+					// TODO: Remove this metric (the 2 lines directly below)
+					// The renamed metric was added in v7.16
 					counter = TransferOps.With(labels)
 					counter.Add(float64(int32(binary.BigEndian.Uint32(
 						packet[offset+opsOffset+8:offset+opsOffset+12]) -


### PR DESCRIPTION
This PR addresses #1434. To maintain backwards compatibility, this adds metrics with new names instead of changing the existing names. Eventually we will want to use just the newly named metrics.