### PR TITLE
Enable crc32 and crc32c algorithms

### DIFF
--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -50,7 +50,7 @@ acc.authdb {{.Cache.RunLocation}}/authfile-cache-generated
 acc.authrefresh {{.Xrootd.AuthRefreshInterval}}
 ofs.authlib ++ libXrdAccSciTokens.so config={{.Cache.RunLocation}}/scitokens-cache-generated.cfg
 all.export {{.Cache.ExportLocation}}
-xrootd.chksum max 2 md5 adler32
+xrootd.chksum max 2 md5 adler32 crc32 crc32c
 xrootd.trace emsg login stall redirect
 xrootd.tls all
 xrd.network nodnr

--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -116,7 +116,7 @@ ofs.ckslib * libXrdMultiuser.so
 http.exthandler xrdpelican libXrdHttpPelican.so
 {{end}}
 xrootd.fslib ++ throttle  # throttle plugin is needed to calculate server IO load
-xrootd.chksum max 2 md5 adler32 crc32
+xrootd.chksum max 2 md5 adler32 crc32 crc32c
 xrootd.trace {{.Logging.OriginXrootd}}
 ofs.trace {{.Logging.OriginOfs}}
 oss.trace {{.Logging.OriginOss}}


### PR DESCRIPTION
This helps prepare Pelican for future end-to-end checksumming support by turning on a consistent set of algorithms, including `crc32c` (which I currently plan to use as the default).

Functionality at the origin tested by hand.