### PR TITLE
Untie prefix from Broker communication paths

### DIFF
--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -119,10 +119,10 @@ func doRetrieveRequest(t *testing.T, ctx context.Context, dur time.Duration) (*h
 	brokerEndpoint := param.Server_ExternalWebUrl.GetString() + "/api/v1.0/broker/retrieve"
 	originUrl, err := url.Parse(param.Server_ExternalWebUrl.GetString())
 	require.NoError(t, err)
-
+	serverNs := "/origins/" + originUrl.Host
 	oReq := originRequest{
-		Origin: originUrl.Hostname(),
-		Prefix: param.Origin_FederationPrefix.GetString(),
+		OriginNs: serverNs,
+		ServerNs: serverNs,
 	}
 	reqBytes, err := json.Marshal(&oReq)
 	require.NoError(t, err)
@@ -202,10 +202,12 @@ func TestBroker(t *testing.T) {
 
 	brokerUrl.Path = "/api/v1.0/broker/reverse"
 	query := brokerUrl.Query()
-	query.Set("origin", param.Server_Hostname.GetString())
+	originUrl, err := url.Parse(param.Server_ExternalWebUrl.GetString())
+	require.NoError(t, err)
+	query.Set("origin", originUrl.Host)
 	query.Set("prefix", "/foo")
 	brokerUrl.RawQuery = query.Encode()
-	clientConn, err := ConnectToOrigin(ctxQuick, brokerUrl.String(), "/foo", param.Server_Hostname.GetString())
+	clientConn, err := ConnectToOrigin(ctxQuick, brokerUrl.String(), originUrl.Host)
 	require.NoError(t, err)
 	log.Debugf("Cache got reversed client connection with cache side %s and origin side %s", clientConn.LocalAddr(), clientConn.RemoteAddr())
 

--- a/cache/broker_client.go
+++ b/cache/broker_client.go
@@ -42,8 +42,7 @@ import (
 type (
 	xrootdBrokerRequest struct {
 		BrokerURL  string `json:"broker_url"`
-		OriginName string `json:"origin"`
-		Prefix     string `json:"prefix"`
+		OriginHost string `json:"origin"`
 		err        error
 	}
 
@@ -121,7 +120,7 @@ func handleRequest(ctx context.Context, xrdConn net.Conn) {
 			sendXrootdError(xrdConn, errStr)
 			return
 		}
-		newConn, err := broker.ConnectToOrigin(ctx, xrdReq.BrokerURL, xrdReq.Prefix, xrdReq.OriginName)
+		newConn, err := broker.ConnectToOrigin(ctx, xrdReq.BrokerURL, xrdReq.OriginHost)
 		if err != nil {
 			errStr := "Failure when getting connection reversal from origin: " + err.Error()
 			log.Warning(errStr)

--- a/launchers/cache_serve.go
+++ b/launchers/cache_serve.go
@@ -96,6 +96,9 @@ func CacheServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, m
 
 	broker.RegisterBrokerCallback(ctx, engine.Group("/", web_ui.ServerHeaderMiddleware))
 	broker.LaunchNamespaceKeyMaintenance(ctx, egrp)
+	if err = cache.LaunchRequestListener(ctx, egrp); err != nil {
+		return nil, err
+	}
 	configPath, err := xrootd.ConfigXrootd(ctx, false)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR refactors the code so that all communication paths rely solely on the origin identifier (hostname + port) and no longer depend on the prefixes exported by the origin.