### PR TITLE
Fix `TestStatMemory` (maybe)

### DIFF
--- a/director/stat_stress_test.go
+++ b/director/stat_stress_test.go
@@ -85,9 +85,9 @@ func TestStatMemory(t *testing.T) {
 	runtime.ReadMemStats(&stats)
 	goCnt := runtime.NumGoroutine()
 
-	// Ensure that this test runs for longer than the "warm up" stage,
-	// but still bound the run time in case we're on an unusually slow
-	// test host.
+	// Now, do enough work to fully evict and replace the cache's
+	// contents from the "warm up" stage. If we're on an unusually
+	// fast host, keep going until "enough" time has elapsed.
 	for idx < 2*cacheSize || time.Since(start) < 10*time.Second {
 		downloadURL := fmt.Sprintf("pelican://%s%s/stress/%v.txt", discoveryUrl.Host, fed.Exports[0].FederationPrefix, idx)
 		grp.Go(func() error {

--- a/director/stat_stress_test.go
+++ b/director/stat_stress_test.go
@@ -63,8 +63,12 @@ func TestStatMemory(t *testing.T) {
 	idx := 0
 	start := time.Now()
 	dest := filepath.Join(t.TempDir(), "dest.txt")
+	cacheSize := param.Director_CachePresenceCapacity.GetInt()
 
-	for time.Since(start) < (time.Second) {
+	// Fill the cache before taking the baseline measurement. Otherwise,
+	// it might end up that increased memory usage is due to filling up the
+	// cache and not an actual memory leak.
+	for idx < cacheSize {
 		downloadURL := fmt.Sprintf("pelican://%s%s/stress/%v.txt", discoveryUrl.Host, fed.Exports[0].FederationPrefix, idx)
 		grp.Go(func() error {
 			_, err := client.DoGet(fed.Ctx, downloadURL, dest, false)

--- a/director/stat_stress_test.go
+++ b/director/stat_stress_test.go
@@ -85,7 +85,10 @@ func TestStatMemory(t *testing.T) {
 	runtime.ReadMemStats(&stats)
 	goCnt := runtime.NumGoroutine()
 
-	for time.Since(start) < 10*time.Second {
+	// Ensure that this test runs for longer than the "warm up" stage,
+	// but still bound the run time in case we're on an unusually slow
+	// test host.
+	for idx < 2*cacheSize || time.Since(start) < 10*time.Second {
 		downloadURL := fmt.Sprintf("pelican://%s%s/stress/%v.txt", discoveryUrl.Host, fed.Exports[0].FederationPrefix, idx)
 		grp.Go(func() error {
 			_, err := client.DoGet(fed.Ctx, downloadURL, dest, false)


### PR DESCRIPTION
Fill the cache before testing for potential memory leaks.

That said, it's worth noting that Go's runtime [does not use a "stop the world" collector](https://tip.golang.org/doc/gc-guide), and thus while [`runtime.GC()` promises to stop its caller in order to perform one complete generation of garbage collection](https://cs.opensource.google/go/go/+/refs/tags/go1.24.1:src/runtime/mgc.go;l=467), it's not clear to me what this actually means when we ask the runtime for the heap's current metrics. 