### PR TITLE
Align token endpoints with REST API best practices

### DIFF
--- a/server_structs/db.go
+++ b/server_structs/db.go
@@ -18,4 +18,14 @@ type (
 		CreatedAt   time.Time `json:"createdAt"`
 		CreatedBy   string    `gorm:"column:created_by;type:text" json:"createdBy"`
 	}
+
+	ApiKeyResponse struct {
+		ID          string    `gorm:"primaryKey;column:id;type:text;not null;unique" json:"id"`
+		Name        string    `gorm:"column:name;type:text" json:"name"`
+		HashedValue string    `gorm:"column:hashed_value;type:text;not null" json:"-"`
+		Scopes      []string  `gorm:"column:scopes;type:text" json:"scopes"`
+		ExpiresAt   time.Time `json:"expiration"`
+		CreatedAt   time.Time `json:"createdAt"`
+		CreatedBy   string    `gorm:"column:created_by;type:text" json:"createdBy"`
+	}
 )

--- a/server_structs/db.go
+++ b/server_structs/db.go
@@ -10,12 +10,12 @@ type (
 	}
 
 	ApiKey struct {
-		ID          string `gorm:"primaryKey;column:id;type:text;not null;unique"`
-		Name        string `gorm:"column:name;type:text"`
-		HashedValue string `gorm:"column:hashed_value;type:text;not null" json:"-"`
-		Scopes      string `gorm:"column:scopes;type:text"`
-		ExpiresAt   time.Time
-		CreatedAt   time.Time
-		CreatedBy   string `gorm:"column:created_by;type:text"`
+		ID          string    `gorm:"primaryKey;column:id;type:text;not null;unique" json:"id"`
+		Name        string    `gorm:"column:name;type:text" json:"name"`
+		HashedValue string    `gorm:"column:hashed_value;type:text;not null" json:"-"`
+		Scopes      string    `gorm:"column:scopes;type:text" json:"scopes"`
+		ExpiresAt   time.Time `json:"expiresAt"`
+		CreatedAt   time.Time `json:"createdAt"`
+		CreatedBy   string    `gorm:"column:created_by;type:text" json:"createdBy"`
 	}
 )

--- a/server_structs/db.go
+++ b/server_structs/db.go
@@ -14,7 +14,7 @@ type (
 		Name        string    `gorm:"column:name;type:text" json:"name"`
 		HashedValue string    `gorm:"column:hashed_value;type:text;not null" json:"-"`
 		Scopes      string    `gorm:"column:scopes;type:text" json:"scopes"`
-		ExpiresAt   time.Time `json:"expiresAt"`
+		ExpiresAt   time.Time `json:"expiration"`
 		CreatedAt   time.Time `json:"createdAt"`
 		CreatedBy   string    `gorm:"column:created_by;type:text" json:"createdBy"`
 	}

--- a/swagger/pelican-swagger.yaml
+++ b/swagger/pelican-swagger.yaml
@@ -180,16 +180,16 @@ definitions:
         items:
           type: object
           properties:
-            name:
-              type: string
-              description: The name of the token
             id:
               type: string
               description: The ID of the token
+            name:
+              type: string
+              description: The name of the token
             createdBy:
               type: string
               description: The user who created the token
-            expiresAt:
+            expiration:
               type: string
               description: The expiration time of the token. If it is empty or "never", the token will never expire. The token should be in the RFC3339 format.
             scopes:

--- a/swagger/pelican-swagger.yaml
+++ b/swagger/pelican-swagger.yaml
@@ -161,12 +161,17 @@ definitions:
       name:
         type: string
         description: The name of the token
-      created_by:
+      createdBy:
         type: string
         description: The user who created the token
       expiration:
         type: string
         description: The expiration time of the token. If it is empty or "never", the token will never expire. The token should be in the RFC3339 format.
+      scopes:
+        type: array
+        items:
+          type: string
+        description: Token scopes, complete list can be found at https://github.com/PelicanPlatform/pelican/blob/main/token_scopes/token_scopes.go
   ListApiTokenSuccess:
     type: object
     properties:
@@ -175,21 +180,21 @@ definitions:
         items:
           type: object
           properties:
-            Name:
+            name:
               type: string
               description: The name of the token
-            ID:
+            id:
               type: string
               description: The ID of the token
-            CreatedBy:
+            createdBy:
               type: string
               description: The user who created the token
-            ExpiresAt:
+            expiresAt:
               type: string
-              description: The expiration time of the token. The token should be in the RFC3339 format.
-            Scopes:
+              description: The expiration time of the token. If it is empty or "never", the token will never expire. The token should be in the RFC3339 format.
+            scopes:
               type: string
-              description: The scopes of the token. Comma-separated string
+              description: Token scopes, complete list can be found at https://github.com/PelicanPlatform/pelican/blob/main/token_scopes/token_scopes.go
   CreateApiTokenSuccess:
     type: object
     properties:
@@ -946,7 +951,7 @@ paths:
           schema:
             type: object
             $ref: "#/definitions/ErrorModelV2"
-  /tokens/:id:
+  /tokens/{id}:
     delete:
       tags:
         - common

--- a/swagger/pelican-swagger.yaml
+++ b/swagger/pelican-swagger.yaml
@@ -902,7 +902,7 @@ paths:
           schema:
             type: object
             $ref: "#/definitions/ErrorModelV2"
-  /createApiToken:
+  /tokens:
     post:
       tags:
         - common
@@ -928,7 +928,25 @@ paths:
           schema:
             type: object
             $ref: "#/definitions/ErrorModelV2"
-  /deleteApiToken/:id:
+    get:
+      tags:
+        - common
+      summary: List all API tokens for the user
+      description: "`Authentication Required`"
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: Token list retrieved successfully
+          schema:
+            type: object
+            $ref: "#/definitions/ListApiTokenSuccess"
+        "500":
+          description: Failed to list tokens
+          schema:
+            type: object
+            $ref: "#/definitions/ErrorModelV2"
+  /tokens/:id:
     delete:
       tags:
         - common
@@ -950,25 +968,6 @@ paths:
             $ref: "#/definitions/SuccessModelV2"
         "500":
           description: Failed to delete token
-          schema:
-            type: object
-            $ref: "#/definitions/ErrorModelV2"
-  /listApiTokens:
-    get:
-      tags:
-        - common
-      summary: List all API tokens for the user
-      description: "`Authentication Required`"
-      produces:
-        - application/json
-      responses:
-        "200":
-          description: Token list retrieved successfully
-          schema:
-            type: object
-            $ref: "#/definitions/ListApiTokenSuccess"
-        "500":
-          description: Failed to list tokens
           schema:
             type: object
             $ref: "#/definitions/ErrorModelV2"

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -572,9 +572,9 @@ func configureCommonEndpoints(engine *gin.Engine) error {
 	engine.GET("/api/v1.0/health", func(ctx *gin.Context) {
 		ctx.JSON(http.StatusOK, gin.H{"message": fmt.Sprintf("Web Engine Running. Time: %s", time.Now().String())})
 	})
-	engine.POST("/api/v1.0/createApiToken", createApiToken)
-	engine.DELETE("/api/v1.0/deleteApiToken/:id", deleteApiToken)
-	engine.GET("/api/v1.0/listApiTokens", listApiTokens)
+	engine.POST("/api/v1.0/tokens", createApiToken)
+	engine.DELETE("/api/v1.0/tokens/:id", deleteApiToken)
+	engine.GET("/api/v1.0/tokens", listApiTokens)
 	engine.GET("/api/v1.0/version", getVersionHandler)
 	return nil
 }

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -73,7 +73,7 @@ func ServerHeaderMiddleware(ctx *gin.Context) {
 
 type CreateApiTokenReq struct {
 	Name       string   `json:"name"`
-	CreatedBy  string   `json:"created_by"`
+	CreatedBy  string   `json:"createdBy"`
 	Expiration string   `json:"expiration"` // RFC3339 format, if not provided or "never" or "", token will not expire
 	Scopes     []string `json:"scopes"`
 }

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -533,7 +533,20 @@ func listApiTokens(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, gin.H{"keys": apiKeys})
+	// Convert the API keys to the response format
+	apiKeysResponse := make([]server_structs.ApiKeyResponse, len(apiKeys))
+	for i, apiKey := range apiKeys {
+		apiKeysResponse[i] = server_structs.ApiKeyResponse{
+			ID:        apiKey.ID,
+			Name:      apiKey.Name,
+			Scopes:    strings.Split(apiKey.Scopes, ","),
+			ExpiresAt: apiKey.ExpiresAt,
+			CreatedAt: apiKey.CreatedAt,
+			CreatedBy: apiKey.CreatedBy,
+		}
+	}
+
+	ctx.JSON(http.StatusOK, apiKeysResponse)
 }
 
 func configureWebResource(engine *gin.Engine) {

--- a/web_ui/ui_test.go
+++ b/web_ui/ui_test.go
@@ -598,7 +598,7 @@ func TestApiToken(t *testing.T) {
 			name: "create-and-delete-token",
 			run: func(t *testing.T) {
 				// Create a token
-				req, err := http.NewRequest("POST", "/api/v1.0/createApiToken", nil)
+				req, err := http.NewRequest("POST", "/api/v1.0/tokens", nil)
 				assert.NoError(t, err)
 				req.AddCookie(&http.Cookie{Name: "login", Value: cookieValue})
 
@@ -625,7 +625,7 @@ func TestApiToken(t *testing.T) {
 
 				// Delete the token using its ID (the part before the dot)
 				tokenID := strings.Split(tokenStr, ".")[0]
-				endpoint := fmt.Sprintf("/api/v1.0/deleteApiToken/%s", tokenID)
+				endpoint := fmt.Sprintf("/api/v1.0/tokens/%s", tokenID)
 				req, err = http.NewRequest("DELETE", endpoint, nil)
 				assert.NoError(t, err)
 				req.AddCookie(&http.Cookie{Name: "login", Value: cookieValue})
@@ -638,7 +638,7 @@ func TestApiToken(t *testing.T) {
 		{
 			name: "unauthorized-create",
 			run: func(t *testing.T) {
-				req, err := http.NewRequest("POST", "/api/v1.0/createApiToken", nil)
+				req, err := http.NewRequest("POST", "/api/v1.0/tokens", nil)
 				assert.NoError(t, err)
 				recorder := httptest.NewRecorder()
 				route.ServeHTTP(recorder, req)
@@ -648,7 +648,7 @@ func TestApiToken(t *testing.T) {
 		{
 			name: "unauthorized-delete",
 			run: func(t *testing.T) {
-				req, err := http.NewRequest("DELETE", "/api/v1.0/deleteApiToken/123", nil)
+				req, err := http.NewRequest("DELETE", "/api/v1.0/tokens/123", nil)
 				assert.NoError(t, err)
 				recorder := httptest.NewRecorder()
 				route.ServeHTTP(recorder, req)
@@ -669,7 +669,7 @@ func TestApiToken(t *testing.T) {
 			name: "authorized-privileged-route",
 			run: func(t *testing.T) {
 				// First, create a token to use for authorization
-				req, err := http.NewRequest("POST", "/api/v1.0/createApiToken", nil)
+				req, err := http.NewRequest("POST", "/api/v1.0/tokens", nil)
 				assert.NoError(t, err)
 				req.AddCookie(&http.Cookie{Name: "login", Value: cookieValue})
 
@@ -706,7 +706,7 @@ func TestApiToken(t *testing.T) {
 			name: "correct-id-wrong-secret",
 			run: func(t *testing.T) {
 				// Create a token
-				req, err := http.NewRequest("POST", "/api/v1.0/createApiToken", nil)
+				req, err := http.NewRequest("POST", "/api/v1.0/tokens", nil)
 				assert.NoError(t, err)
 				req.AddCookie(&http.Cookie{Name: "login", Value: cookieValue})
 
@@ -748,7 +748,7 @@ func TestApiToken(t *testing.T) {
 			name: "list-tokens",
 			run: func(t *testing.T) {
 				// we need to create a token first
-				req, err := http.NewRequest("POST", "/api/v1.0/createApiToken", nil)
+				req, err := http.NewRequest("POST", "/api/v1.0/tokens", nil)
 				assert.NoError(t, err)
 				req.AddCookie(&http.Cookie{Name: "login", Value: cookieValue})
 
@@ -774,7 +774,7 @@ func TestApiToken(t *testing.T) {
 				assert.NotEmpty(t, token)
 
 				// list tokens
-				req, err = http.NewRequest("GET", "/api/v1.0/listApiTokens", nil)
+				req, err = http.NewRequest("GET", "/api/v1.0/tokens", nil)
 				assert.NoError(t, err)
 				req.AddCookie(&http.Cookie{Name: "login", Value: cookieValue})
 
@@ -802,7 +802,7 @@ func TestApiToken(t *testing.T) {
 		{
 			name: "list-tokens-unauthorized",
 			run: func(t *testing.T) {
-				req, err := http.NewRequest("GET", "/api/v1.0/listApiTokens", nil)
+				req, err := http.NewRequest("GET", "/api/v1.0/tokens", nil)
 				assert.NoError(t, err)
 
 				recorder := httptest.NewRecorder()

--- a/web_ui/ui_test.go
+++ b/web_ui/ui_test.go
@@ -767,18 +767,17 @@ func TestApiToken(t *testing.T) {
 				route.ServeHTTP(recorder, req)
 				assert.Equal(t, http.StatusOK, recorder.Code)
 
-				var listTokensResp map[string][]server_structs.ApiKey
+				var listTokensResp []server_structs.ApiKeyResponse
 				err = json.NewDecoder(recorder.Body).Decode(&listTokensResp)
 				assert.NoError(t, err)
-				keys := listTokensResp["keys"]
-				assert.NotEmpty(t, keys)
+				assert.NotEmpty(t, listTokensResp)
 
-				for _, apiKey := range keys {
+				for _, apiKey := range listTokensResp {
 					if apiKey.ID == tokenID {
 						assert.Equal(t, "test-token", apiKey.Name)
 						assert.Equal(t, "admin", apiKey.CreatedBy)
 						assert.Equal(t, time.Time{}, apiKey.ExpiresAt)
-						assert.Equal(t, token_scopes.Monitoring_Scrape.String(), apiKey.Scopes)
+						assert.Equal(t, []string([]string{"monitoring.scrape"}), apiKey.Scopes)
 						return
 					}
 				}


### PR DESCRIPTION
Token API Patches:
- Align the endpoints to best practices using the HTTP verbs to indicate the action
- Unify the json that is returned to use the same keys across all models ( expiration vs expiresAt )
- Unify the json so the object posted aligns with the one I get back (scopes is a array on POST and csv on GET)
- Update the json keys to use camelCase
- Patch the Swagger docs to work with params in the path

PR is not to be a pedant, these small things result in a messy UI and I would rather just fix them.