### PR TITLE
Fix testing workflow for release candidates

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,19 @@
 name: Build and Test
 
+# This workflow is responsible for building Pelican's container images and
+# running the test suite. Much of its length and complexity is a consequence
+# of trying to keep build times short by taking advantage of caching.
+#
+# The intended behavior is that all container images are always built.
+# However:
+#
+#   - For pull requests: We never push images to a registry. In fact,
+#     we can't, because the credentials aren't available.
+#
+#   - Pushes to main: We push only pelican-test and pelican-dev.
+#
+#   - Pushes to semvar tags: We push pelican-test and all the "server" images.
+
 on:
   pull_request:
   push:
@@ -161,6 +175,8 @@ jobs:
           - osdf-cache
           - osdf-director
           - osdf-registry
+          # For release candidates, this is where we build and push the testing container.
+          - pelican-test
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test-linux-pr.yaml
+++ b/.github/workflows/test-linux-pr.yaml
@@ -2,6 +2,10 @@ name: Run Tests (Linux) [on pull request]
 
 on:
   pull_request:
+  repository_dispatch:
+    types:
+      - dispatch-build
+  workflow_dispatch:
 
 # On a pull request, we cannot build and push a newer image in which to run
 # the tests. Thus, we use the most recent container image that was built.


### PR DESCRIPTION
And while I'm here, make it so that the testing workflow for PRs can be triggered manually, just to be consistent with the other workflows.