### PR TITLE
Correctly record the start time for uploads

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2481,6 +2481,7 @@ Loop:
 		}
 	}
 
+	transferResult.TransferStartTime = transferStartTime
 	transferEndTime := time.Now()
 	uploaded = reader.BytesComplete()
 	transferResult.TransferredBytes = uploaded


### PR DESCRIPTION
As originally observed by @matyasselmeci, for uploads, the transfer's start time was never initialized in the `TransferResults` object.