### PR TITLE
Enhance drop privs inter-processes test

### DIFF
--- a/xrootd/drop_privilege_test.go
+++ b/xrootd/drop_privilege_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pelicanplatform/pelican/cache"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/origin"
 	"github.com/pelicanplatform/pelican/server_utils"
@@ -41,8 +42,8 @@ const (
 	CmdUpdateCA = 1
 )
 
-// isValidFD checks if a file descriptor is valid.
-func isValidFD(fd int) (bool, error) {
+// validateFD checks if a file descriptor is valid.
+func validateFD(fd int) (bool, error) {
 	if fd < 0 {
 		return false, nil
 	}
@@ -88,7 +89,6 @@ func mockXRootDProcess(t *testing.T, fds [2]int, ready chan<- struct{}, wg *sync
 func startMockXrootdProcess(t *testing.T, isOrigin bool, wg *sync.WaitGroup) (ready <-chan struct{}) {
 	readyChan := make(chan struct{})
 	ready = readyChan
-
 	var targetFds *[2]int
 	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
 	require.NoError(t, err)
@@ -99,8 +99,14 @@ func startMockXrootdProcess(t *testing.T, isOrigin bool, wg *sync.WaitGroup) (re
 		g_cache_fds = [2]int{fds[0], fds[1]}
 		targetFds = &g_cache_fds
 	}
-
-	isValidFD, err := isValidFD(g_origin_fds[1])
+	t.Log("Global origin FDs after Socketpair setup: ", g_origin_fds)
+	t.Log("Global cache FDs after Socketpair setup: ", g_cache_fds)
+	var isValidFD bool
+	if isOrigin {
+		isValidFD, err = validateFD(g_origin_fds[1])
+	} else {
+		isValidFD, err = validateFD(g_cache_fds[1])
+	}
 	require.True(t, isValidFD, "Write file descriptor is not valid (os.Stat err)")
 	require.NoError(t, err)
 
@@ -142,82 +148,114 @@ func TestDropPrivilegeSignaling(t *testing.T) {
 		server_utils.ResetTestState()
 	})
 
-	runDir := t.TempDir()
-	viper.Set("Origin.RunLocation", runDir)
-	viper.Set("Cache.RunLocation", runDir)
-	viper.Set("ConfigDir", runDir)
-	config.InitConfig()
-
-	pelicanDir := filepath.Join(runDir, "pelican")
-	err := os.Mkdir(pelicanDir, 0755)
-	require.NoError(t, err, "Failed to create pelican directory")
-
-	// Set the configuration parameters before calling any xrootd functions
-	certFile, keyFile, err := generateTestCert(runDir)
-	require.NoError(t, err, "Failed to generate test certificate")
-
-	require.NotEmpty(t, certFile, "Empty certificate file path")
-	require.NotEmpty(t, keyFile, "Empty key file path")
-
-	// Dummy CA bundle data
-	caBundleData := []byte("Test CA Bundle Content")
-	caBundleFile := filepath.Join(runDir, "ca-bundle.crt")
-	require.NoError(t, os.WriteFile(caBundleFile, caBundleData, 0644))
-
-	// Open the CA bundle file
-	caBundle, err := os.Open(caBundleFile)
-	require.NoError(t, err, "Failed to open CA bundle file")
-	defer caBundle.Close()
-
-	var wg sync.WaitGroup
-
-	isOrigin := true
-	// Start mock XRootD (sets up the IPC)
-	ready := startMockXrootdProcess(t, isOrigin, &wg)
-	defer func() {
-		// Wait for the mock XRootD process to finish
-		wg.Wait() // Block until wg.Done() is called in the mock XRootD process
-		err := closeChildSocket(isOrigin)
-		require.NoError(t, err, "Failed to close child socket")
-	}()
-
-	// The ready channel signals to the test function that the mock XRootD process is ready to receive data (the command byte)
-	<-ready
-
-	viper.Set("Server.DropPrivileges", true)
-
-	// Send the command byte BEFORE calling dropPrivilegeCopy
-	command := []byte{byte(CmdUpdateCA)}
-
-	if isOrigin {
-		// Verify FD is valid before writing
-		isValidFD, err := isValidFD(g_origin_fds[1])
-		require.True(t, isValidFD, "Write file descriptor is not valid (os.Stat err)")
-		require.NoError(t, err)
-
-		t.Log("Global origin FDs: ", g_origin_fds)
-		t.Logf("Writing %x to fd %d", command, g_origin_fds[1])
-
-		n, err := syscall.Write(g_origin_fds[1], command)
-		require.NoError(t, err, "Failed to send command byte")
-		require.Equal(t, 1, n, "Expected to write 1 byte")
-	} else {
-		_, err = syscall.Write(g_cache_fds[1], command)
-		require.NoError(t, err, "Failed to send command byte")
+	testCases := []struct {
+		name     string
+		isOrigin bool
+	}{
+		{"Origin", true},
+		{"Cache", false},
 	}
 
-	err = dropPrivilegeCopy(&origin.OriginServer{})
-	require.NoError(t, err, "dropPrivilegeCopy failed")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				server_utils.ResetTestState()
+				// Clean up global FDs state
+				g_origin_fds = [2]int{-1, -1}
+				g_cache_fds = [2]int{-1, -1}
+			})
+			t.Log("Global origin FDs: ", g_origin_fds)
+			runDir := t.TempDir()
+			viper.Set("Origin.RunLocation", runDir)
+			viper.Set("Cache.RunLocation", runDir)
+			viper.Set("ConfigDir", runDir)
+			config.InitConfig()
 
-	// Verify the caBundleFile has been transferred in dropPrivilegeCopy func
-	expectedTransferredCAFileLocation := filepath.Join(runDir, "pelican", "copied-tls-creds.crt")
-	_, err = os.Stat(expectedTransferredCAFileLocation)
-	require.NoError(t, err, "Expected CA file does not exist")
+			pelicanDir := filepath.Join(runDir, "pelican")
+			err := os.Mkdir(pelicanDir, 0755)
+			require.NoError(t, err, "Failed to create pelican directory")
 
-	// Verify the contents of the transferred CA file
-	transferredData, err := os.ReadFile(expectedTransferredCAFileLocation)
-	require.NoError(t, err, "Failed to read transferred CA file")
-	transferredContents := string(transferredData)
-	require.Contains(t, transferredContents, "-----BEGIN CERTIFICATE-----", "Certificate header missing from transferred CA file")
-	require.Contains(t, transferredContents, "-----BEGIN PRIVATE KEY-----", "Private key header missing from transferred CA file")
+			// Set the configuration parameters before calling any xrootd functions
+			certFile, keyFile, err := generateTestCert(runDir)
+			require.NoError(t, err, "Failed to generate test certificate")
+
+			require.NotEmpty(t, certFile, "Empty certificate file path")
+			require.NotEmpty(t, keyFile, "Empty key file path")
+
+			// Dummy CA bundle data
+			caBundleData := []byte("Test CA Bundle Content")
+			caBundleFile := filepath.Join(runDir, "ca-bundle.crt")
+			require.NoError(t, os.WriteFile(caBundleFile, caBundleData, 0644))
+
+			// Open the CA bundle file
+			caBundle, err := os.Open(caBundleFile)
+			require.NoError(t, err, "Failed to open CA bundle file")
+			defer caBundle.Close()
+
+			var wg sync.WaitGroup
+
+			isOrigin := tc.isOrigin
+			// Start mock XRootD (sets up the IPC)
+			ready := startMockXrootdProcess(t, isOrigin, &wg)
+			defer func() {
+				// Wait for the mock XRootD process to finish
+				wg.Wait() // Block until wg.Done() is called in the mock XRootD process
+				err := closeChildSocket(isOrigin)
+				require.NoError(t, err, "Failed to close child socket")
+			}()
+
+			// The ready channel signals to the test function that the mock XRootD process is ready to receive data (the command byte)
+			<-ready
+
+			viper.Set("Server.DropPrivileges", true)
+
+			// Send the command byte BEFORE calling dropPrivilegeCopy
+			command := []byte{byte(CmdUpdateCA)}
+
+			if isOrigin {
+				// Verify FD is valid before writing
+				isValidFD, err := validateFD(g_origin_fds[1])
+				require.True(t, isValidFD, "Write file descriptor is not valid (os.Stat err)")
+				require.NoError(t, err)
+
+				t.Log("Global origin FDs: ", g_origin_fds)
+				t.Logf("Writing %x to fd %d", command, g_origin_fds[1])
+
+				n, err := syscall.Write(g_origin_fds[1], command)
+				require.NoError(t, err, "Failed to send command byte")
+				require.Equal(t, 1, n, "Expected to write 1 byte")
+			} else {
+				isValidFD, err := validateFD(g_cache_fds[1])
+				require.True(t, isValidFD, "Write file descriptor is not valid (os.Stat err)")
+				require.NoError(t, err)
+
+				t.Log("Global cache FDs: ", g_cache_fds)
+				t.Logf("Writing %x to fd %d", command, g_cache_fds[1])
+
+				_, err = syscall.Write(g_cache_fds[1], command)
+				require.NoError(t, err, "Failed to send command byte")
+			}
+
+			if isOrigin {
+				err = dropPrivilegeCopy(&origin.OriginServer{})
+			} else {
+				err = dropPrivilegeCopy(&cache.CacheServer{})
+			}
+			require.NoError(t, err, "dropPrivilegeCopy failed")
+
+			// Verify the caBundleFile has been transferred in dropPrivilegeCopy func
+			expectedTransferredCAFileLocation := filepath.Join(runDir, "pelican", "copied-tls-creds.crt")
+			_, err = os.Stat(expectedTransferredCAFileLocation)
+			require.NoError(t, err, "Expected CA file does not exist")
+
+			// Verify the contents of the transferred CA file
+			transferredData, err := os.ReadFile(expectedTransferredCAFileLocation)
+			require.NoError(t, err, "Failed to read transferred CA file")
+			transferredContents := string(transferredData)
+			require.Contains(t, transferredContents, "-----BEGIN CERTIFICATE-----", "Certificate header missing from transferred CA file")
+			require.Contains(t, transferredContents, "-----BEGIN PRIVATE KEY-----", "Private key header missing from transferred CA file")
+
+		})
+	}
+
 }


### PR DESCRIPTION
[Primary] Resolve occasional race condition in the drop privs test. 
Reason: Main test thread could clean up resources before the mock XRootD goroutine finished processing commands
Solution: Adding synchronization with `sync.WaitGroup` to ensure the mock XRootD process goroutine completes its work before the main test thread proceeds with cleanup

[Second] Verify the CA file has been transferred to the expected location and contain correct content

[Third] Add Cache test, in addition to the existing Origin test

Closes #2099