### PR TITLE
Update docs/origin startup to prevent '/view' registration

### DIFF
--- a/docs/pages/federating-your-data/choosing-namespaces.mdx
+++ b/docs/pages/federating-your-data/choosing-namespaces.mdx
@@ -168,6 +168,7 @@ The following table lists the characters that Pelican does not allow when defini
 - `/cache`
 - `/origin`
 - `/pelican`
+- `/view`
 </div>
 
 </div>

--- a/server_utils/origin.go
+++ b/server_utils/origin.go
@@ -285,6 +285,13 @@ func validateFederationPrefix(prefix string) error {
 		return errors.Wrapf(ErrInvalidOriginConfig, "prefix %s is a reserved prefix for cache/origin server registration", prefix)
 	}
 
+	illegalPrefixes := []string{"/pelican", "/view"}
+	for _, illegalPrefix := range illegalPrefixes {
+		if prefix == illegalPrefix || strings.HasPrefix(prefix, illegalPrefix+"/") {
+			return errors.Wrapf(ErrInvalidOriginConfig, "prefix '%s' is a reserved prefix and cannot be registered to your Origin", prefix)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This documents and prevents registration of the `/view` namespace. This prefix is disallowed because we serve web UI content under `/view`.

I also noticed we weren't treating `/pelican` registration as an error at Origin startup. We do technically register this as a namespace for federation services, but we disallow user registration of the namespace. This new check won't prevent Pelican from registering `/pelican`, but it will prevent the user from trying to use the namespace in their Origin configuration.