### PR TITLE
Add more events to response for long history issues

### DIFF
--- a/.github/workflows/enforce-PR-labelling.yml
+++ b/.github/workflows/enforce-PR-labelling.yml
@@ -28,7 +28,7 @@ jobs:
           PR_NUMBER=$(jq -r '.pull_request.number' $GITHUB_EVENT_PATH)
           REPO_OWNER=$(jq -r '.repository.owner.login' $GITHUB_EVENT_PATH)
           REPO_NAME=$(jq -r '.repository.name' $GITHUB_EVENT_PATH)
-          TIMELINE_JSON=$(curl -s "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/issues/$PR_NUMBER/timeline")
+          TIMELINE_JSON=$(curl -s "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/issues/$PR_NUMBER/timeline?per_page=100")
 
           # Count the number of times the timeline sees a "connected" event and subtract the number of "disconnected" events
           # We might also consider using the "cross-referenced" event in the future if actual connecting/disconnecting is too heavy-handed


### PR DESCRIPTION
Increase event page size to 100 for issues with more then 30 events. This isn't a perfect update but should be good enough.