### PR TITLE
Exclude namespace itself from its super/sub spaces & allow Registry admin to overwrite the public key of a namespace

### DIFF
--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -133,7 +133,7 @@ func namespaceSupSubChecks(prefix string) (superspaces []string, subspaces []str
 	// Check if any registered namespaces already superspace the incoming namespace,
 	// eg if /foo is already registered, this will be true for an incoming /foo/bar because
 	// /foo is logically above /foo/bar (according to my logic, anyway)
-	superspaceQuery := `SELECT prefix FROM namespace WHERE (? || '/') LIKE (prefix || '/%')`
+	superspaceQuery := `SELECT prefix FROM namespace WHERE (?) LIKE (prefix || '/%')`
 	err = db.Raw(superspaceQuery, prefix).Scan(&superspaces).Error
 	if err != nil {
 		return
@@ -142,7 +142,7 @@ func namespaceSupSubChecks(prefix string) (superspaces []string, subspaces []str
 	// Check if any registered namespaces already subspace the incoming namespace,
 	// eg if /foo/bar is already registered, this will be true for an incoming /foo because
 	// /foo/bar is logically below /foo
-	subspaceQuery := `SELECT prefix FROM namespace WHERE (prefix || '/') LIKE (? || '/%')`
+	subspaceQuery := `SELECT prefix FROM namespace WHERE (prefix) LIKE (? || '/%')`
 	err = db.Raw(subspaceQuery, prefix).Scan(&subspaces).Error
 	if err != nil {
 		return

--- a/registry/registry_ui_test.go
+++ b/registry/registry_ui_test.go
@@ -1365,6 +1365,10 @@ func TestUpdateNamespaceHandler(t *testing.T) {
 		updatedNs := mockNs
 		updatedNs.AdminMetadata.Description = "newDescription"
 
+		updatedPubKeyStr, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+		updatedNs.Pubkey = updatedPubKeyStr
+
 		mockNsBytes, err := json.Marshal(updatedNs)
 		require.NoError(t, err)
 
@@ -1385,6 +1389,7 @@ func TestUpdateNamespaceHandler(t *testing.T) {
 		require.Equal(t, 1, len(nss))
 		assert.Equal(t, "/foo", nss[0].Prefix)
 		assert.Equal(t, "newDescription", nss[0].AdminMetadata.Description)
+		assert.Equal(t, updatedPubKeyStr, nss[0].Pubkey)
 	})
 }
 

--- a/registry/registry_validation_test.go
+++ b/registry/registry_validation_test.go
@@ -247,6 +247,11 @@ func TestValidateKeyChaining(t *testing.T) {
 
 	t.Run("off-param-no-check", func(t *testing.T) {
 		viper.Set("Registry.RequireKeyChaining", false)
+		superspaces, subspaces, _, _, err := namespaceSupSubChecks("/foo/barz")
+		assert.NoError(t, err)
+		assert.Len(t, superspaces, 1)
+		assert.Empty(t, subspaces)
+
 		_, _, validErr, serverErr := validateKeyChaining("/foo/barz", jwkFoo)
 		assert.NoError(t, serverErr)
 		assert.NoError(t, validErr)
@@ -268,6 +273,11 @@ func TestValidateKeyChaining(t *testing.T) {
 
 	t.Run("on-param-ignore-cache", func(t *testing.T) {
 		viper.Set("Registry.RequireKeyChaining", true)
+		superspaces, subspaces, _, _, err := namespaceSupSubChecks("/cache/newCache")
+		assert.NoError(t, err)
+		assert.Empty(t, superspaces)
+		assert.Empty(t, subspaces)
+
 		_, _, validErr, serverErr := validateKeyChaining("/cache/newCache", jwkCache)
 		// Same public key as /cache/randomCache shouldn't give error
 		assert.NoError(t, serverErr)
@@ -277,6 +287,21 @@ func TestValidateKeyChaining(t *testing.T) {
 		// Different public key as /cache/randomCache shouldn't give error
 		assert.NoError(t, serverErr)
 		assert.NoError(t, validErr)
+	})
+
+	t.Run("super-sub-space-edge-case-check", func(t *testing.T) {
+		// A namespace's super/sub spaces should not contain itself
+		superspaces, subspaces, _, _, err := namespaceSupSubChecks("/foo")
+		assert.NoError(t, err)
+		assert.Empty(t, superspaces)
+		assert.Empty(t, subspaces)
+
+		// A complicated namespace
+		superspaces, subspaces, _, _, err = namespaceSupSubChecks("/foo/bar/baz")
+		assert.NoError(t, err)
+		assert.Len(t, superspaces, 1)
+		assert.Contains(t, superspaces, "/foo")
+		assert.Empty(t, subspaces)
 	})
 }
 


### PR DESCRIPTION
It excludes the namespace itself from its super/sub spaces.
With this update, Registry admin can overwrite any namespace's public key.

Q: After this change, when a namespace registers, how do we check if there is a same namespace already registered?
A: We have a dedicated `namespaceExistsByPrefix` func to do that when a namespace registers. Note that this func won't be executed when Registry admin updates the namespace. So, it's safe to exclude the namespace itself from its super/sub spaces.

Next, @CannonLock will add a warning on the UI when Registry admin wants to edit the public key of a namespace that has super/sub spaces.