### PR TITLE
Add user and group requirements to the built-in issuer's authorization templates

### DIFF
--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2434,32 +2434,53 @@ components: ["origin"]
 ---
 name: Issuer.AuthorizationTemplates
 description: |+
-  The authorizations that should be generated for an authenticated request.  Value should be a list of
-  authorized actions.
+  The authorizations that may be generated for an authenticated request,
+  specified via a list of templates.
 
-  Each action is a key-value pair with the following keys defined:
-  - `actions`: A list of authorized actions.  Valid string values are `read`, `modify`, and `create`.
-  - `prefix`: A prefix where the actions are authorized.  If the prefix contains the substring `$USER`, the
-    string is replaced with the authenticated username.  If the prefix contains the substring `$GROUP`, then
-    an authorization is emitted for _each group_ authenticated.
+  Each template defines a set of authorizations that can depend on the
+  authenticated username and groups. An authorization is an action and
+  a prefix to which it applies.
 
-  For example, if the request is authenticated as user `bbockelm` with groups `dept_a` and `dept_b`, then
-  the following configuration:
+  Concretely, a template is a collection of key-value pairs:
+
+  - `actions`: A list of actions. Valid values are `read`, `create`, and
+    `modify`.
+
+  - `prefix`: The prefix to which those actions apply. If the prefix
+    contains the substring `$USER`, the string is replaced with the
+    authenticated username. If the prefix contains the substring `$GROUP`,
+    then an authorization is generated for each authenticated group.
+
+  - `users` (optional): A list of usernames. If non-empty, the authenticated
+    username must be in this list in order for this template to generate any
+    authorizations.
+
+  - `groups` (optional): A list of groups. If non-empty, at least one
+    authenticated group must be in this list in order for this template to
+    generate any authorizations. If `prefix` contains the substring
+    `$GROUP`, then authorizations will be generated only for the groups
+    listed here.
+
+  For example, if the request is authenticated as username `bbockelm` and
+  groups `dept_a` and `dept_b`, then the list of templates
 
   ```yaml
-  - actions: ["read", "create"]
-    prefix: /projects/$GROUP
   - actions: ["read", "modify"]
     prefix: /home/$USER
+  - actions: ["read"]
+    prefix: /staging/$USER
+    users: ["alice", "bob"]
+  - actions: ["read", "create"]
+    prefix: /projects/$GROUP
+    groups: ["dept_a", "dept_c"]
   ```
 
   will result in the following authorizations:
-  - read /projects/dept_a
-  - create /projects/dept_a
-  - read /projects/dept_b
-  - create /projects/dept_b
+
   - read /home/bbockelm
   - modify /home/bbockelm
+  - read /projects/dept_a
+  - create /projects_dept_a
 type: object
 default: []
 components: ["origin"]

--- a/oa4mp/resources/policies.qdl
+++ b/oa4mp/resources/policies.qdl
@@ -21,7 +21,7 @@ access_token.'sub' := claims.'sub';
 group_list. := claims.groups;
 remove(claims.groups);
 
-{{ if .GroupRequirements }}
+{{ if .GroupRequirements -}}
 if [0 == size(|^group_list. /\ { {{- range $idx, $grp := .GroupRequirements -}}{{- if eq $idx 0 -}}'{{- $grp -}}'{{else}}, '{{- $grp -}}'{{- end -}}{{- end -}} })] then
 [
     sys_err.ok := false;
@@ -32,22 +32,48 @@ if [0 == size(|^group_list. /\ { {{- range $idx, $grp := .GroupRequirements -}}{
 
 scopes := {};
 {{ range .GroupAuthzTemplates }}
+{{ if eq 0 (len .Groups) -}}
 while [has_value(key, group_list.)]
+{{- else -}}
+while [has_value(key, |^group_list. /\ { {{- range $idx, $grp := .Groups -}}{{- if eq $idx 0 -}}'{{- $grp -}}'{{else}}, '{{- $grp -}}'{{- end -}}{{- end -}} })]
+{{- end }}
 [
-    group_scopes := { {{- range $idx, $action := .Actions }}{{- if eq $idx 0 -}}'{{- $action -}}:'{{else}}, '{{- $action -}}:'{{- end -}}{{ end -}} } + '{{- .Prefix -}}';
-    scopes := scopes \/ |^replace(~group_scopes, '$GROUP', encode(key, 1)); /* 1 = URL-encode (RFC 3986) */
+    {{ if eq 0 (len .Users) -}}
+    if [true] then
+    {{- else -}}
+    if [0 != size({claims.'sub'} /\ { {{- range $idx, $user := .Users -}}{{- if eq $idx 0 -}}'{{- $user -}}'{{else}}, '{{- $user -}}'{{- end -}}{{- end -}} })] then
+    {{- end }}
+    [
+        group_scopes := { {{- range $idx, $action := .Actions }}{{- if eq $idx 0 -}}'{{- $action -}}:'{{else}}, '{{- $action -}}:'{{- end -}}{{- end -}} } + '{{- .Prefix -}}';
+        scopes := scopes \/ |^replace(~group_scopes, '$GROUP', encode(key, 1)); /* 1 = URL-encode (RFC 3986) */
+    ];
+];
+{{- end -}}
+{{ range .UserAuthzTemplates }}
+{{ if eq 0 (len .Users) -}}
+if [true] then
+{{- else -}}
+if [0 != size({claims.'sub'} /\ { {{- range $idx, $user := .Users -}}{{- if eq $idx 0 -}}'{{- $user -}}'{{else}}, '{{- $user -}}'{{- end -}}{{- end -}} })] then
+{{- end }}
+[
+    {{ if eq 0 (len .Groups) -}}
+    if [true] then
+    {{- else -}}
+    if [0 != size(|^group_list. /\ { {{- range $idx, $grp := .Groups -}}{{- if eq $idx 0 -}}'{{- $grp -}}'{{else}}, '{{- $grp -}}'{{- end -}}{{- end -}} })] then
+    {{- end }}
+    [
+        user_scopes := { {{- range $idx, $action := .Actions }}{{- if eq $idx 0 -}}'{{- $action -}}:'{{else}}, '{{- $action -}}:'{{- end -}}{{- end -}} } + '{{- .Prefix -}}';
+        scopes := scopes \/ |^replace(~user_scopes, '$USER', encode(claims.'sub', 1)); /* 1 = URL-encode (RFC 3986) */
+    ];
 ];
 {{- end }}
-{{ range .UserAuthzTemplates }}
-user_scopes := { {{- range $idx, $action := .Actions }}{{- if eq $idx 0 -}}'{{- $action -}}:'{{else}}, '{{- $action -}}:'{{- end -}}{{ end -}} } + '{{- .Prefix -}}';
-scopes := scopes \/ |^replace(~user_scopes, '$USER', encode(claims.'sub', 1)); /* 1 = URL-encode (RFC 3986) */
-{{ end }}
-access_token.'scope' := detokenize(scopes, ' ', 2);
 
+access_token.'scope' := detokenize(sort(scopes), ' ', 2);
 access_token.iss := '{{- .OIDCIssuerURL -}}';
 
-/* Pelican generates WLCG-style token scopes; convert the
-   resulting access token to a WLCG token.
+/*
+ * Pelican generates WLCG-style token scopes,
+ * so convert the resulting access token to a WLCG token.
  */
 remove(access_token.ver);
 access_token.'wlcg.ver' := '1.0';

--- a/oa4mp/resources/policies.qdl
+++ b/oa4mp/resources/policies.qdl
@@ -17,6 +17,7 @@
  ***************************************************************/
 
 access_token.'sub' := claims.'sub';
+access_token.'iss' := '{{- .OIDCIssuerURL -}}';
 
 group_list. := claims.groups;
 remove(claims.groups);
@@ -30,7 +31,7 @@ if [0 == size(|^group_list. /\ { {{- range $idx, $grp := .GroupRequirements -}}{
 ];
 {{- end }}
 
-scopes := {};
+default_scopes := {};
 {{ range .GroupAuthzTemplates }}
 {{ if eq 0 (len .Groups) -}}
 while [has_value(key, group_list.)]
@@ -45,7 +46,7 @@ while [has_value(key, |^group_list. /\ { {{- range $idx, $grp := .Groups -}}{{- 
     {{- end }}
     [
         group_scopes := { {{- range $idx, $action := .Actions }}{{- if eq $idx 0 -}}'{{- $action -}}:'{{else}}, '{{- $action -}}:'{{- end -}}{{- end -}} } + '{{- .Prefix -}}';
-        scopes := scopes \/ |^replace(~group_scopes, '$GROUP', encode(key, 1)); /* 1 = URL-encode (RFC 3986) */
+        default_scopes := default_scopes \/ |^replace(~group_scopes, '$GROUP', encode(key, 1)); /* 1 = URL-encode (RFC 3986) */
     ];
 ];
 {{- end -}}
@@ -63,13 +64,24 @@ if [0 != size({claims.'sub'} /\ { {{- range $idx, $user := .Users -}}{{- if eq $
     {{- end }}
     [
         user_scopes := { {{- range $idx, $action := .Actions }}{{- if eq $idx 0 -}}'{{- $action -}}:'{{else}}, '{{- $action -}}:'{{- end -}}{{- end -}} } + '{{- .Prefix -}}';
-        scopes := scopes \/ |^replace(~user_scopes, '$USER', encode(claims.'sub', 1)); /* 1 = URL-encode (RFC 3986) */
+        default_scopes := default_scopes \/ |^replace(~user_scopes, '$USER', encode(claims.'sub', 1)); /* 1 = URL-encode (RFC 3986) */
     ];
 ];
 {{- end }}
 
-access_token.'scope' := detokenize(sort(scopes), ' ', 2);
-access_token.iss := '{{- .OIDCIssuerURL -}}';
+/*
+ * If the requested scope is a tighter requirement than what is permitted,
+ * then grant the tighter requirement.
+ */
+user_scopes. := mask(scopes., -1 < starts_with(scopes., ~default_scopes));
+
+/*
+ * If the requested scope is a looser requirement than what is permitted,
+ * then grant based on the default scopes.
+ */
+user_scopes_loose. := mask(~default_scopes, -1 < starts_with(~default_scopes, scopes.));
+
+access_token.'scope' := detokenize(sort(|^user_scopes. \/ |^user_scopes_loose.), ' ', 2);
 
 /*
  * Pelican generates WLCG-style token scopes,

--- a/oa4mp/serve.go
+++ b/oa4mp/serve.go
@@ -70,6 +70,8 @@ type (
 	authzTemplate struct {
 		Actions []string `mapstructure:"actions"`
 		Prefix  string   `mapstructure:"prefix"`
+		Users   []string `mapstructure:"users"`
+		Groups  []string `mapstructure:"groups"`
 	}
 )
 


### PR DESCRIPTION
Please refer to the updated documentation in `parameters.yaml` for how this new functionality is intended to work.

Some notes about the implementation:

- `if [true] then` in the generated QDL is superfluous, but that is an intentional stylistic choice on my part. It ensures that each authorization template renders to a similar set of QDL control-flow constructs, which I think makes it easer to scan the generated QDL.

- I added a `sort` to the process of generating the final `scope` claim, because it makes it easier, as a human, to check for the presence or absence of a particular authorization, especially when the list gets quite long.