### PR TITLE
Sanity check received size and on-disk size for client GETs

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1906,6 +1906,11 @@ func parseTransferStatus(status string) (int, string) {
 // Verify that a file on disk matches the expected size. We ignore directories
 // and generic stat failures unless the file doesn't exist.
 func verifyFileSize(dest string, expectedSize int64, fields log.Fields) error {
+	if dest == "/dev/null" {
+		log.WithFields(fields).Debugf("Skipping size check because destination /dev/null")
+		return nil
+	}
+
 	fi, err := os.Stat(dest)
 	if err != nil { // Don't treat stat failure as fatal unless it indicates the file doesn't exist
 		if os.IsNotExist(err) {

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2233,27 +2233,13 @@ Loop:
 	}
 
 	// By now, we think the download succeeded. If we know how large the file was supposed to
-	// be based on the Content-Length header, we can check that a) the grab client witnessed
-	// the correct number of bytes and b) the file on disk is the correct size. If totalSize is
-	// <= 0, it indicates we don't know how large the transfer was supposed to be in the first
-	// place.
-	if totalSize > 0 {
-		// Check size of received bytes
-		if downloaded != totalSize {
-			log.WithFields(fields).Debugf("Download completed but received size '%db' does not match expected size '%db'", downloaded, totalSize)
-			err = errors.Errorf("download completed but received size '%db' does not match expected size '%db'", downloaded, totalSize)
-			return
-		}
-		// Check size of file on disk
-		fi, statErr := os.Stat(dest)
-		if statErr == nil { // Don't treat stat errors as a failure -- we've already passed one sanity check so we should move on.
-			sizeOnDisk := fi.Size()
-			if sizeOnDisk != totalSize {
-				log.WithFields(fields).Debugf("File size on disk '%db' does not match expected size '%db'", sizeOnDisk, totalSize)
-				err = errors.Errorf("file size on disk '%db' does not match expected size '%db'", sizeOnDisk, totalSize)
-				return
-			}
-		}
+	// be based on the Content-Length header, we can check that the grab client witnessed
+	// the correct number of bytes. If totalSize is <= 0, it indicates we don't know how large
+	// the transfer was supposed to be in the first place.
+	if totalSize > 0 && downloaded != totalSize {
+		log.WithFields(fields).Debugf("Download completed but received size '%db' does not match expected size '%db'", downloaded, totalSize)
+		err = errors.Errorf("download completed but received size '%db' does not match expected size '%db'", downloaded, totalSize)
+		return
 	}
 
 	if unpacker != nil {

--- a/github_scripts/citests.sh
+++ b/github_scripts/citests.sh
@@ -62,10 +62,12 @@ EOF
 SOCKET_DIR="`mktemp -d -t pelican-citest-XXXXXX`"
 export PELICAN_LOCALCACHE_SOCKET=$SOCKET_DIR/socket
 export PELICAN_LOCALCACHE_DATALOCATION=$SOCKET_DIR/data
+export PELICAN_CONFIG=${SOCKET_DIR}/pelican.yaml
 export PELICAN_SERVER_ENABLEUI=false
 export PELICAN_TLSSKIPVERIFY=true
+touch ${PELICAN_CONFIG}
 
-./pelican serve -d -f osg-htc.org --module localcache &
+./pelican serve --config ${PELICAN_CONFIG} -d -f osg-htc.org --module localcache &
 PELICAN_PID=$!
 
 cleanup() {


### PR DESCRIPTION
When the client requests an object, grab determines the expected download size by inspecting the `Content-Length` header. Previously we didn't perform any checks against this value to make sure the number of bytes we receive actually match the number of expected bytes -- we only used status codes to determine success.

With this diff, we sanity check the number of bytes witnessed by the grab client, and when the client is writing a regular file and not a directory/unpacked object, we also stat the file on disk as a second check.