### PR TITLE
Fix log level/location issues coming from web UI config

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -26,9 +26,8 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"time"
-
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -144,6 +144,11 @@ func TestHandleCLIVersionFlag(t *testing.T) {
 func TestHandleCLIExecutableAlias(t *testing.T) {
 	aliasTestMutex := sync.Mutex{} // Lock to ensure each t.Run goroutine have consistent access to binary
 
+	// Isolate the test from system config
+	configDir := t.TempDir()
+	os.Setenv("PELICAN_CONFIGDIR", configDir)
+	defer os.Unsetenv("PELICAN_CONFIGDIR")
+
 	// If we're in the process started by exec.Command, run the handleCLI function.
 	if os.Getenv("BE_CRASHER") == "1" {
 		err := handleCLI(os.Args[1:])

--- a/config/config.go
+++ b/config/config.go
@@ -787,7 +787,7 @@ func setLoggingInternal() error {
 		logLevel := param.Logging_Level.GetString()
 		level, err := log.ParseLevel(logLevel)
 		if err != nil {
-			return errors.Wrapf(err, "failed to parse logging level '%s'", logLevel)
+			return errors.Wrapf(err, "failed to parse value of config param %s", param.Logging_Level.GetString())
 		}
 		SetLogging(level)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -1816,6 +1816,7 @@ func ResetConfig() {
 
 	// Clear cached preferred prefix
 	testingPreferredPrefix = ""
+	logging.ResetLogFlush()
 
 	// Clear cached transport object
 	onceTransport = sync.Once{}

--- a/config/config.go
+++ b/config/config.go
@@ -1279,16 +1279,19 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 	}
 
 	if err := SetServerDefaults(viper.GetViper()); err != nil {
+		logging.FlushLogs(true)
 		return err
 	}
 
 	webConfigPath := param.Server_WebConfigFile.GetString()
 	if webConfigPath != "" {
 		if err := os.MkdirAll(filepath.Dir(webConfigPath), 0700); err != nil {
+			logging.FlushLogs(true)
 			cobra.CheckErr(errors.Wrapf(err, "failed to create directory for web config file at %s", webConfigPath))
 		}
 	}
 	if err := setWebConfigOverride(viper.GetViper(), webConfigPath); err != nil {
+		logging.FlushLogs(true)
 		cobra.CheckErr(errors.Wrapf(err, "failed to override configuration based on changes from web UI"))
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -813,6 +813,11 @@ func InitConfigDir(v *viper.Viper) {
 // InitConfig sets up the global Viper instance by loading defaults and
 // user-defined config files, validates config params, and initializes logging.
 func InitConfig() {
+	// Set a prefix so Viper knows how to parse PELICAN_* env vars
+	// This must happen before config dir initialization so that Pelican
+	// can pick up setting the config dir with PELICAN_CONFIGDIR
+	viper.SetEnvPrefix("pelican")
+	viper.AutomaticEnv()
 
 	// Enable BindStruct to allow unmarshal env into a nested struct
 	viper.SetOptions(viper.ExperimentalBindStruct())
@@ -830,9 +835,6 @@ func InitConfig() {
 
 	// Load environment variables into the config
 	bindNonPelicanEnv() // Deprecate OSDF env prefix but be compatible for now
-
-	viper.SetEnvPrefix("pelican")
-	viper.AutomaticEnv()
 
 	// This line allows viper to use an env var like ORIGIN_VALUE to override the viper string "Origin.Value"
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -79,6 +79,7 @@ func TestMain(m *testing.M) {
 	viper.Set("Transport.Dialer.Timeout", time.Second*1)
 	viper.Set("Transport.Dialer.KeepAlive", time.Second*30)
 	viper.Set("TLSSkipVerify", true)
+	viper.Set(param.Logging_Level.GetName(), "debug")
 	server.StartTLS()
 	defer server.Close()
 	exitCode := m.Run()
@@ -578,20 +579,18 @@ func TestInitServerUrl(t *testing.T) {
 	}
 
 	t.Run("web-url-defaults-to-hostname-port", func(t *testing.T) {
-		ResetConfig()
+		initDirectoryConfig()
 		viper.Set("Server.Hostname", mockHostname)
 		viper.Set("Server.WebPort", mockNon443Port)
-		InitConfigDir(viper.GetViper())
 		err := InitServer(context.Background(), 0)
 		require.NoError(t, err)
 		assert.Equal(t, mockWebUrlWNon443Port, param.Server_ExternalWebUrl.GetString())
 	})
 
 	t.Run("default-web-url-removes-443-port", func(t *testing.T) {
-		ResetConfig()
+		initDirectoryConfig()
 		viper.Set("Server.Hostname", mockHostname)
 		viper.Set("Server.WebPort", mock443Port)
-		InitConfigDir(viper.GetViper())
 		err := InitServer(context.Background(), 0)
 		require.NoError(t, err)
 		assert.Equal(t, mockWebUrlWoPort, param.Server_ExternalWebUrl.GetString())
@@ -599,9 +598,8 @@ func TestInitServerUrl(t *testing.T) {
 
 	t.Run("remove-443-port-for-set-web-url", func(t *testing.T) {
 		// We respect the URL value set directly by others. Won't remove 443 port
-		ResetConfig()
+		initDirectoryConfig()
 		viper.Set("Server.ExternalWebUrl", mockWebUrlW443Port)
-		InitConfigDir(viper.GetViper())
 		err := InitServer(context.Background(), 0)
 		require.NoError(t, err)
 		assert.Equal(t, mockWebUrlWoPort, param.Server_ExternalWebUrl.GetString())

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -727,6 +727,11 @@ Logging:
 	err := InitServer(context.Background(), server_structs.OriginType)
 	require.NoError(t, err)
 
+	// Manually close the logger's file handle -- this happens automatically
+	// when running Pelican proper, but the file lingers in test code and Windows
+	// won't be able to close the file because it's in use.
+	logging.CloseLogger()
+
 	// Stat the file -- that it was created is sufficient evidence of success
 	_, err = os.Stat(logFile)
 	require.NoError(t, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -568,6 +568,7 @@ func TestInitServerUrl(t *testing.T) {
 		ResetConfig()
 		tempDir := t.TempDir()
 		viper.Set("ConfigDir", tempDir)
+		viper.Set(param.Logging_Level.GetName(), "debug")
 	}
 
 	initDirectoryConfig := func() {

--- a/config/config_validation_test.go
+++ b/config/config_validation_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/param"
 )
 
 // Test that Pelican notifies users about unrecognized configuration keys.
@@ -36,7 +38,7 @@ func TestBadConfigKeys(t *testing.T) {
 	setupFunc := func() *test.Hook {
 		ResetConfig()
 		viper.Set("ConfigDir", t.TempDir())
-		viper.Set("Debug", true)
+		viper.Set(param.Debug.GetName(), true)
 		hook := test.NewLocal(logrus.StandardLogger())
 		return hook
 	}

--- a/local_cache/cache_linux_test.go
+++ b/local_cache/cache_linux_test.go
@@ -117,6 +117,7 @@ func TestForcePurge(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	server_utils.ResetTestState()
+	defer server_utils.ResetTestState()
 	viper.Set("LocalCache.Size", "5MB")
 	// Decrease the low water mark so invoking purge will result in 3 files in the cache.
 	viper.Set("LocalCache.LowWaterMarkPercentage", "80")
@@ -217,6 +218,7 @@ func TestPurgeFirst(t *testing.T) {
 	viper.Set("ConfigDir", configDir)
 
 	dataDir := t.TempDir()
+	viper.Set(param.Logging_Level.GetName(), "debug")
 	viper.Set(param.LocalCache_DataLocation.GetName(), dataDir)
 	viper.Set(param.LocalCache_Size.GetName(), "10MB")
 	viper.Set(param.LocalCache_LowWaterMarkPercentage.GetName(), "50")

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -44,6 +44,10 @@ var (
 	flushOnce    sync.Once
 )
 
+func ResetLogFlush() {
+	flushOnce = sync.Once{}
+}
+
 func NewBufferedLogHook() *BufferedLogHook {
 	return &BufferedLogHook{
 		entries: make([]*log.Entry, 0),

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -44,6 +44,8 @@ var (
 	flushOnce    sync.Once
 )
 
+// Reset function intended for unit tests to be able to
+// reset log flush state.
 func ResetLogFlush() {
 	flushOnce = sync.Once{}
 }

--- a/registry/registry_ui_test.go
+++ b/registry/registry_ui_test.go
@@ -71,6 +71,7 @@ func TestListNamespaces(t *testing.T) {
 
 	dirName := t.TempDir()
 	viper.Set("ConfigDir", dirName)
+	viper.Set(param.Logging_Level.GetName(), "debug")
 	viper.Set("Origin.Port", 0)
 	err := config.InitServer(ctx, server_structs.OriginType)
 	require.NoError(t, err)

--- a/server_utils/server_utils.go
+++ b/server_utils/server_utils.go
@@ -44,6 +44,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/logging"
 	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
@@ -285,6 +286,7 @@ func LaunchWatcherMaintenance(ctx context.Context, dirPaths []string, descriptio
 func ResetTestState() {
 	config.ResetConfig()
 	ResetOriginExports()
+	logging.ResetLogFlush()
 	baseAdOnce = sync.Once{}
 	baseAd = server_structs.ServerBaseAd{}
 	baseAdErr = nil

--- a/web_ui/authentication_test.go
+++ b/web_ui/authentication_test.go
@@ -161,6 +161,7 @@ func TestPasswordResetAPI(t *testing.T) {
 	dirName := t.TempDir()
 	server_utils.ResetTestState()
 	viper.Set("ConfigDir", dirName)
+	viper.Set(param.Logging_Level.GetName(), "debug")
 	viper.Set("Origin.Port", 8443)
 	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
 	err := config.InitServer(ctx, server_structs.OriginType)

--- a/web_ui/server_api_test.go
+++ b/web_ui/server_api_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/database"
+	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/test_utils"
 )
@@ -76,6 +77,7 @@ func TestDowntime(t *testing.T) {
 
 	dirName := t.TempDir()
 	viper.Set("ConfigDir", dirName)
+	viper.Set(param.Logging_Level.GetName(), "debug")
 	viper.Set("Origin.Port", 0)
 	err := config.InitServer(ctx, server_structs.OriginType)
 	require.NoError(t, err)

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -270,7 +270,6 @@ func TestOSDFAuthCreation(t *testing.T) {
 		t.Run(testInput.desc, func(t *testing.T) {
 			dirName := t.TempDir()
 			server_utils.ResetTestState()
-
 			defer server_utils.ResetTestState()
 
 			viper.Set("Xrootd.Authfile", filepath.Join(dirName, "authfile"))
@@ -308,7 +307,6 @@ func TestOSDFAuthCreation(t *testing.T) {
 			require.NoError(t, err, "Error reading generated authfile")
 
 			require.Equal(t, testInput.authOut, string(genAuth))
-			server_utils.ResetTestState()
 		})
 	}
 }
@@ -487,9 +485,9 @@ func TestLoadScitokensConfig(t *testing.T) {
 func TestMergeConfig(t *testing.T) {
 	dirname := t.TempDir()
 	server_utils.ResetTestState()
-
 	defer server_utils.ResetTestState()
 
+	viper.Set(param.Logging_Level.GetName(), "debug")
 	viper.Set("Origin.RunLocation", dirname)
 	viper.Set("Origin.Port", 8443)
 	viper.Set("Origin.StoragePrefix", "/")
@@ -705,6 +703,7 @@ func TestGenerateOriginIssuer(t *testing.T) {
 			defer server_utils.ResetTestState()
 			ctx, _, _ := test_utils.TestContext(context.Background(), t)
 			viper.Set("ConfigDir", t.TempDir())
+			viper.Set(param.Logging_Level.GetName(), "debug")
 
 			// Load in test config
 			viper.SetConfigType("yaml")
@@ -1100,6 +1099,7 @@ func TestWriteOriginScitokensConfig(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	viper.Set("ConfigDir", tmpDir)
+	viper.Set(param.Logging_Level.GetName(), "debug")
 	viper.Set(param.Origin_RunLocation.GetName(), tmpDir)
 	viper.Set(param.Origin_SelfTest.GetName(), true)
 	viper.Set(param.Origin_FederationPrefix.GetName(), "/foo/bar")


### PR DESCRIPTION
There were two bugs here:
1) The web config override function assigned all the new viper overrides but it didn't use them to set the log level. Because the logging library doesn't look at viper, it was potentially unaware it needed to update its levels.
2) Logs were flushed (and consequently their location assigned) before the web config yaml was loaded/merged.

The reviewer can test this diff by starting any Pelican server and modifying log levels and log locations via the web UI. Previously, doing this had no effect but now the values should be used correctly.