### PR TITLE
Make Origin throttling configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1196,6 +1196,15 @@ func SetServerDefaults(v *viper.Viper) error {
 		v.Set(param.Server_ExternalWebUrl.GetName(), parsedExtAdd.String())
 	}
 
+	if originConcurrency := v.GetInt(param.Origin_Concurrency.GetName()); originConcurrency < 0 {
+		return errors.Errorf("invalid value of '%d' for config param %s; must be greater than or equal to 0, where 0 disables the feature",
+			originConcurrency, param.Origin_Concurrency.GetName())
+	}
+	if cacheConcurrency := v.GetInt(param.Cache_Concurrency.GetName()); cacheConcurrency < 0 {
+		return errors.Errorf("invalid value of '%d' for config param %s; must be greater than or equal to 0, where 0 disables the feature",
+			cacheConcurrency, param.Cache_Concurrency.GetName())
+	}
+
 	// Setup the audience to use.  We may customize the Origin.URL in the future if it has
 	// a `0` for the port number; to make the audience predictable (it goes into the xrootd
 	// configuration but we don't know the origin's port until after xrootd has started), we

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -814,6 +814,15 @@ type: bool
 default: false
 components: ["origin"]
 ---
+name: Origin.Concurrency
+description: |+
+  This value represents the maximum number of connections to an Origin for XRootD throttling.
+  When this value is set, it enables the XRootD throttling plugin and will set the maximum
+  number of connections to this value.
+type: int
+default: none
+components: ["origin"]
+---
 name: Origin.DirectorTest
 description: |+
   A bool indicating whether the director should send file transfer tests to the origin.

--- a/go.mod
+++ b/go.mod
@@ -195,7 +195,7 @@ require (
 	golang.org/x/sync v0.8.0
 	golang.org/x/text v0.16.0
 	golang.org/x/time v0.5.0
-	google.golang.org/appengine v1.6.8 // indirect
+	google.golang.org/appengine v1.6.8
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	kernel.org/pub/linux/libs/security/libcap/psx v1.2.69 // indirect

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -337,6 +337,7 @@ var (
 	Monitoring_PortHigher = IntParam{"Monitoring.PortHigher"}
 	Monitoring_PortLower = IntParam{"Monitoring.PortLower"}
 	Monitoring_SampleLimit = IntParam{"Monitoring.SampleLimit"}
+	Origin_Concurrency = IntParam{"Origin.Concurrency"}
 	Origin_Port = IntParam{"Origin.Port"}
 	Server_IssuerPort = IntParam{"Server.IssuerPort"}
 	Server_UILoginRateLimit = IntParam{"Server.UILoginRateLimit"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -204,6 +204,7 @@ type Config struct {
 		UserInfoEndpoint string `mapstructure:"userinfoendpoint" yaml:"UserInfoEndpoint"`
 	} `mapstructure:"oidc" yaml:"OIDC"`
 	Origin struct {
+		Concurrency int `mapstructure:"concurrency" yaml:"Concurrency"`
 		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
 		DirectorTest bool `mapstructure:"directortest" yaml:"DirectorTest"`
 		EnableBroker bool `mapstructure:"enablebroker" yaml:"EnableBroker"`
@@ -545,6 +546,7 @@ type configWithType struct {
 		UserInfoEndpoint struct { Type string; Value string }
 	}
 	Origin struct {
+		Concurrency struct { Type string; Value int }
 		DbLocation struct { Type string; Value string }
 		DirectorTest struct { Type string; Value bool }
 		EnableBroker struct { Type string; Value bool }

--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -23,25 +23,25 @@ if exec xrootd
   xrd.protocol http:{{.Origin.CalculatedPort}} libXrdHttp.so
 fi
 xrd.tls {{.Origin.RunLocation}}/copied-tls-creds.crt {{.Origin.RunLocation}}/copied-tls-creds.crt
-{{if .Server.TLSCACertificateDirectory}}
+{{- if .Server.TLSCACertificateDirectory}}
 xrd.tlsca certdir {{.Server.TLSCACertificateDirectory}}
-{{else}}
+{{- else}}
 xrd.tlsca certfile {{.Server.TLSCACertificateFile}}
-{{end}}
-{{if eq .Origin.EnableListings false}}
+{{- end}}
+{{- if eq .Origin.EnableListings false}}
 http.listingdeny true
-{{end}}
-{{if eq .Origin.EnablePublicReads true}}
+{{- end}}
+{{- if eq .Origin.EnablePublicReads true}}
 sec.protbind * none
-{{end}}
+{{- end}}
 {{if .Origin.EnableMacaroons}}
 http.exthandler xrdmacaroons libXrdMacaroons.so
 macaroons.secretkey {{.Xrootd.MacaroonsKeyFile}}
 ofs.authlib ++ libXrdMacaroons.so
 {{end}}
-{{if .Origin.Concurrency}}
+{{- if .Origin.Concurrency}}
 throttle.throttle concurrency {{.Origin.Concurrency}}
-{{end}}
+{{- end}}
 http.header2cgi Authorization authz
 {{if .Origin.EnableVoms}}
 http.secxtractor /usr/lib64/libXrdVoms.so
@@ -104,22 +104,23 @@ acc.audit deny grant
 acc.authdb {{.Origin.RunLocation}}/authfile-origin-generated
 acc.authrefresh {{.Xrootd.AuthRefreshInterval}}
 ofs.authlib ++ libXrdAccSciTokens.so config={{.Origin.RunLocation}}/scitokens-origin-generated.cfg
+
 # Tell xrootd to make each namespace we export available as a path at the server
-{{range .Origin.Exports}}
+{{- range .Origin.Exports}}
 all.export {{.FederationPrefix}}
-{{end}}
-{{if or .Origin.SelfTest .Origin.DirectorTest }}
+{{- end}}
+{{- if or .Origin.SelfTest .Origin.DirectorTest }}
 # Note we don't want to export this via cmsd; only for self-test
 xrootd.export /pelican/monitoring
 xrootd.export /.well-known
-{{end}}
-{{if .Origin.Multiuser}}
+{{- end}}
+{{- if .Origin.Multiuser}}
 ofs.osslib libXrdMultiuser.so default
 ofs.ckslib * libXrdMultiuser.so
-{{end}}
-{{if .Server.DropPrivileges}}
+{{- end}}
+{{- if .Server.DropPrivileges}}
 http.exthandler xrdpelican libXrdHttpPelican.so
-{{end}}
+{{- end}}
 xrootd.fslib ++ throttle  # throttle plugin is needed to calculate server IO load
 xrootd.chksum max 2 md5 adler32 crc32 crc32c
 xrootd.trace {{.Logging.OriginXrootd}}
@@ -131,6 +132,8 @@ http.trace {{.Logging.OriginHttp}}
 xrootd.tls all
 xrd.network nodnr
 scitokens.trace {{.Logging.OriginScitokens}}
-{{if .Xrootd.ConfigFile}}
+
+{{- if .Xrootd.ConfigFile}}
+# Continue onto the next set of configuration
 continue {{.Xrootd.ConfigFile}}
-{{end}}
+{{- end}}

--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -39,6 +39,9 @@ http.exthandler xrdmacaroons libXrdMacaroons.so
 macaroons.secretkey {{.Xrootd.MacaroonsKeyFile}}
 ofs.authlib ++ libXrdMacaroons.so
 {{end}}
+{{if .Origin.Concurrency}}
+throttle.throttle concurrency {{.Origin.Concurrency}}
+{{end}}
 http.header2cgi Authorization authz
 {{if .Origin.EnableVoms}}
 http.secxtractor /usr/lib64/libXrdVoms.so

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -91,6 +91,7 @@ type (
 		EnablePublicReads bool
 		EnableListings    bool
 		SelfTest          bool
+		Concurrency       int
 		CalculatedPort    string
 		FederationPrefix  string
 		HttpServiceUrl    string


### PR DESCRIPTION
This lets an Origin admin set:
```
Origin:
  Concurrency: <int>
```
to limit the number of accepted concurrent requests to the Origin. You can test the diff by adding the config and observing the line `throttle.throttle concurrency <int>` in the generated xrootd config.

I also got annoyed enough by all the errant whitespace in the generated xrootd config that I tidied some of it up.