### PR TITLE
Disable topology flags

### DIFF
--- a/config/resources/osdf.yaml
+++ b/config/resources/osdf.yaml
@@ -27,3 +27,5 @@ Federation:
 Registry:
   RequireCacheApproval: true
   RequireOriginApproval: true
+Topology:
+  DisableDowntime: false

--- a/config/resources/osdf.yaml
+++ b/config/resources/osdf.yaml
@@ -32,3 +32,4 @@ Topology:
   DisableCacheX509: false
   DisableOriginX509: false
   DisableCaches: false
+  DisableOrigins: false

--- a/config/resources/osdf.yaml
+++ b/config/resources/osdf.yaml
@@ -31,3 +31,4 @@ Topology:
   DisableDowntime: false
   DisableCacheX509: false
   DisableOriginX509: false
+  DisableCaches: false

--- a/config/resources/osdf.yaml
+++ b/config/resources/osdf.yaml
@@ -29,3 +29,5 @@ Registry:
   RequireOriginApproval: true
 Topology:
   DisableDowntime: false
+  DisableCacheX509: false
+  DisableOriginX509: false

--- a/director/advertise.go
+++ b/director/advertise.go
@@ -270,15 +270,17 @@ func AdvertiseOSDF(ctx context.Context) error {
 			}
 		}
 
-		for _, cache := range ns.Caches {
-			cacheAd := parseServerAdFromTopology(cache, server_structs.CacheType, server_structs.Capabilities{})
-			if existingAd, ok := cacheAdMap[cacheAd.URL.String()]; ok {
-				existingAd.NamespaceAds = append(existingAd.NamespaceAds, nsAd)
-				consolidatedAd := consolidateDupServerAd(cacheAd, existingAd.ServerAd)
-				existingAd.ServerAd = consolidatedAd
-			} else {
-				// New entry
-				cacheAdMap[cacheAd.URL.String()] = &server_structs.Advertisement{ServerAd: cacheAd, NamespaceAds: []server_structs.NamespaceAdV2{nsAd}}
+		if !param.Topology_DisableCaches.GetBool() {
+			for _, cache := range ns.Caches {
+				cacheAd := parseServerAdFromTopology(cache, server_structs.CacheType, server_structs.Capabilities{})
+				if existingAd, ok := cacheAdMap[cacheAd.URL.String()]; ok {
+					existingAd.NamespaceAds = append(existingAd.NamespaceAds, nsAd)
+					consolidatedAd := consolidateDupServerAd(cacheAd, existingAd.ServerAd)
+					existingAd.ServerAd = consolidatedAd
+				} else {
+					// New entry
+					cacheAdMap[cacheAd.URL.String()] = &server_structs.Advertisement{ServerAd: cacheAd, NamespaceAds: []server_structs.NamespaceAdV2{nsAd}}
+				}
 			}
 		}
 	}

--- a/director/advertise.go
+++ b/director/advertise.go
@@ -175,7 +175,9 @@ func AdvertiseOSDF(ctx context.Context) error {
 		return errors.Wrapf(err, "Failed to get topology JSON")
 	}
 
-	err = updateDowntimeFromTopology(ctx)
+	if !param.Topology_DisableDowntime.GetBool() {
+		err = updateDowntimeFromTopology(ctx)
+	}
 	if err != nil {
 		// Don't treat this as a fatal error, but log it in a loud way.
 		log.Errorf("Unable to generate downtime list for servers from topology: %v", err)

--- a/director/advertise.go
+++ b/director/advertise.go
@@ -258,15 +258,17 @@ func AdvertiseOSDF(ctx context.Context) error {
 		// We further assume that with this legacy code handling, each origin exporting a given namespace
 		// will have the same set of capabilities as the namespace itself. Pelican has teased apart origins
 		// and namespaces, so this isn't true outside this limited context.
-		for _, origin := range ns.Origins {
-			originAd := parseServerAdFromTopology(origin, server_structs.OriginType, caps)
-			if existingAd, ok := originAdMap[originAd.URL.String()]; ok {
-				existingAd.NamespaceAds = append(existingAd.NamespaceAds, nsAd)
-				consolidatedAd := consolidateDupServerAd(originAd, existingAd.ServerAd)
-				existingAd.ServerAd = consolidatedAd
-			} else {
-				// New entry
-				originAdMap[originAd.URL.String()] = &server_structs.Advertisement{ServerAd: originAd, NamespaceAds: []server_structs.NamespaceAdV2{nsAd}}
+		if !param.Topology_DisableOrigins.GetBool() {
+			for _, origin := range ns.Origins {
+				originAd := parseServerAdFromTopology(origin, server_structs.OriginType, caps)
+				if existingAd, ok := originAdMap[originAd.URL.String()]; ok {
+					existingAd.NamespaceAds = append(existingAd.NamespaceAds, nsAd)
+					consolidatedAd := consolidateDupServerAd(originAd, existingAd.ServerAd)
+					existingAd.ServerAd = consolidatedAd
+				} else {
+					// New entry
+					originAdMap[originAd.URL.String()] = &server_structs.Advertisement{ServerAd: originAd, NamespaceAds: []server_structs.NamespaceAdV2{nsAd}}
+				}
 			}
 		}
 

--- a/director/advertise_test.go
+++ b/director/advertise_test.go
@@ -352,6 +352,16 @@ func mockTopoDowntimeXMLHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestUpdateDowntimeFromTopology(t *testing.T) {
+	server_utils.ResetTestState()
+	serverAds.DeleteAll()
+	defer func() {
+		server_utils.ResetTestState()
+		serverAds.DeleteAll()
+		filteredServersMutex.Lock()
+		defer filteredServersMutex.Unlock()
+		filteredServers = map[string]filterType{}
+	}()
+
 	// Create a buffer to capture log output
 	var logBuffer bytes.Buffer
 	originalOutput := logrus.StandardLogger().Out
@@ -385,4 +395,64 @@ func TestUpdateDowntimeFromTopology(t *testing.T) {
 	assert.False(t, keyExists, "DENVER_INTERNET2_OSDF_CACHE should not be in filteredServers")
 	_, keyExists = filteredServers["HOW_MUCH_CASH_COULD_A_STASHCACHE_STASH"]
 	assert.False(t, keyExists, "HOW_MUCH_CASH_COULD_A_STASHCACHE_STASH should not be in filteredServers")
+}
+
+func TestDisableTopologyDowntime(t *testing.T) {
+	t.Run("disable-topology-downtime", func(t *testing.T) {
+		server_utils.ResetTestState()
+		serverAds.DeleteAll()
+		viper.Set("Topology.DisableDowntime", true)
+		defer func() {
+			server_utils.ResetTestState()
+			serverAds.DeleteAll()
+			filteredServersMutex.Lock()
+			defer filteredServersMutex.Unlock()
+			filteredServers = map[string]filterType{}
+		}()
+
+		assert.Len(t, filteredServers, 0)
+		topoServer := httptest.NewServer(http.HandlerFunc(mockTopoJSONHandler))
+		defer topoServer.Close()
+		viper.Set("Federation.TopologyNamespaceUrl", topoServer.URL)
+
+		downtimeServer := httptest.NewServer(http.HandlerFunc(mockTopoDowntimeXMLHandler))
+		t.Cleanup(func() {
+			downtimeServer.Close()
+		})
+		viper.Set("Federation.TopologyDowntimeUrl", downtimeServer.URL)
+
+		err := AdvertiseOSDF(context.Background())
+		require.NoError(t, err)
+
+		assert.Len(t, filteredServers, 0)
+	})
+
+	t.Run("enable-topology-downtime", func(t *testing.T) {
+		server_utils.ResetTestState()
+		serverAds.DeleteAll()
+		viper.Set("Topology.DisableDowntime", false)
+		defer func() {
+			server_utils.ResetTestState()
+			serverAds.DeleteAll()
+			filteredServersMutex.Lock()
+			defer filteredServersMutex.Unlock()
+			filteredServers = map[string]filterType{}
+		}()
+
+		assert.Len(t, filteredServers, 0)
+		topoServer := httptest.NewServer(http.HandlerFunc(mockTopoJSONHandler))
+		defer topoServer.Close()
+		viper.Set("Federation.TopologyNamespaceUrl", topoServer.URL)
+
+		downtimeServer := httptest.NewServer(http.HandlerFunc(mockTopoDowntimeXMLHandler))
+		t.Cleanup(func() {
+			downtimeServer.Close()
+		})
+		viper.Set("Federation.TopologyDowntimeUrl", downtimeServer.URL)
+
+		err := AdvertiseOSDF(context.Background())
+		require.NoError(t, err)
+
+		assert.Len(t, filteredServers, 1)
+	})
 }

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -3274,3 +3274,11 @@ type: bool
 hidden: true
 default: false
 components: ["origin"]
+---
+name: Topology.DisableCaches
+description: |+
+  When enabled, no longer retrieve caches from Topology
+type: bool
+hidden: true
+default: false
+components: ["director"]

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -3250,3 +3250,11 @@ description: |+
 type: duration
 default: 4032h
 components: ["cache"]
+---
+name: Topology.DisableDowntime
+description: |+
+  When enabled, no longer retrieve downtime information for origins and caches from Topology
+type: bool
+hidden: true
+default: false
+components: ["cache", "origin", "registry", "director"]

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -3282,3 +3282,11 @@ type: bool
 hidden: true
 default: false
 components: ["director"]
+---
+name: Topology.DisableOrigins
+description: |+
+  When enabled, no longer retrieve origins from Topology
+type: bool
+hidden: true
+default: false
+components: ["director", "registry"]

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -3257,4 +3257,20 @@ description: |+
 type: bool
 hidden: true
 default: false
-components: ["cache", "origin", "registry", "director"]
+components: ["director"]
+---
+name: Topology.DisableCacheX509
+description: |+
+  When enabled, no longer retrieve x509 certification authfiles for caches from Topology
+type: bool
+hidden: true
+default: false
+components: ["cache"]
+---
+name: Topology.DisableOriginX509
+description: |+
+  When enabled, no longer retrieve x509 certification authfiles for origins from Topology
+type: bool
+hidden: true
+default: false
+components: ["origin"]

--- a/launchers/registry_serve.go
+++ b/launchers/registry_serve.go
@@ -54,7 +54,7 @@ func RegistryServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group
 		}
 	}
 
-	if config.GetPreferredPrefix() == config.OsdfPrefix {
+	if config.GetPreferredPrefix() == config.OsdfPrefix && !param.Topology_DisableOrigins.GetBool() {
 		metrics.SetComponentHealthStatus(metrics.DirectorRegistry_Topology, metrics.StatusWarning, "Start requesting from topology, status unknown")
 		log.Info("Populating registry with namespaces from OSG topology service...")
 		if err := registry.PopulateTopology(ctx); err != nil {

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -408,6 +408,7 @@ var (
 	StagePlugin_Hook = BoolParam{"StagePlugin.Hook"}
 	TLSSkipVerify = BoolParam{"TLSSkipVerify"}
 	Topology_DisableCacheX509 = BoolParam{"Topology.DisableCacheX509"}
+	Topology_DisableCaches = BoolParam{"Topology.DisableCaches"}
 	Topology_DisableDowntime = BoolParam{"Topology.DisableDowntime"}
 	Topology_DisableOriginX509 = BoolParam{"Topology.DisableOriginX509"}
 	Xrootd_EnableLocalMonitoring = BoolParam{"Xrootd.EnableLocalMonitoring"}

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -407,6 +407,7 @@ var (
 	Shoveler_VerifyHeader = BoolParam{"Shoveler.VerifyHeader"}
 	StagePlugin_Hook = BoolParam{"StagePlugin.Hook"}
 	TLSSkipVerify = BoolParam{"TLSSkipVerify"}
+	Topology_DisableDowntime = BoolParam{"Topology.DisableDowntime"}
 	Xrootd_EnableLocalMonitoring = BoolParam{"Xrootd.EnableLocalMonitoring"}
 )
 

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -407,7 +407,9 @@ var (
 	Shoveler_VerifyHeader = BoolParam{"Shoveler.VerifyHeader"}
 	StagePlugin_Hook = BoolParam{"StagePlugin.Hook"}
 	TLSSkipVerify = BoolParam{"TLSSkipVerify"}
+	Topology_DisableCacheX509 = BoolParam{"Topology.DisableCacheX509"}
 	Topology_DisableDowntime = BoolParam{"Topology.DisableDowntime"}
+	Topology_DisableOriginX509 = BoolParam{"Topology.DisableOriginX509"}
 	Xrootd_EnableLocalMonitoring = BoolParam{"Xrootd.EnableLocalMonitoring"}
 )
 

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -411,6 +411,7 @@ var (
 	Topology_DisableCaches = BoolParam{"Topology.DisableCaches"}
 	Topology_DisableDowntime = BoolParam{"Topology.DisableDowntime"}
 	Topology_DisableOriginX509 = BoolParam{"Topology.DisableOriginX509"}
+	Topology_DisableOrigins = BoolParam{"Topology.DisableOrigins"}
 	Xrootd_EnableLocalMonitoring = BoolParam{"Xrootd.EnableLocalMonitoring"}
 )
 

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -336,6 +336,7 @@ type Config struct {
 		DisableCaches bool `mapstructure:"disablecaches" yaml:"DisableCaches"`
 		DisableDowntime bool `mapstructure:"disabledowntime" yaml:"DisableDowntime"`
 		DisableOriginX509 bool `mapstructure:"disableoriginx509" yaml:"DisableOriginX509"`
+		DisableOrigins bool `mapstructure:"disableorigins" yaml:"DisableOrigins"`
 	} `mapstructure:"topology" yaml:"Topology"`
 	Transport struct {
 		DialerKeepAlive time.Duration `mapstructure:"dialerkeepalive" yaml:"DialerKeepAlive"`
@@ -683,6 +684,7 @@ type configWithType struct {
 		DisableCaches struct { Type string; Value bool }
 		DisableDowntime struct { Type string; Value bool }
 		DisableOriginX509 struct { Type string; Value bool }
+		DisableOrigins struct { Type string; Value bool }
 	}
 	Transport struct {
 		DialerKeepAlive struct { Type string; Value time.Duration }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -332,7 +332,9 @@ type Config struct {
 	} `mapstructure:"stageplugin" yaml:"StagePlugin"`
 	TLSSkipVerify bool `mapstructure:"tlsskipverify" yaml:"TLSSkipVerify"`
 	Topology struct {
+		DisableCacheX509 bool `mapstructure:"disablecachex509" yaml:"DisableCacheX509"`
 		DisableDowntime bool `mapstructure:"disabledowntime" yaml:"DisableDowntime"`
+		DisableOriginX509 bool `mapstructure:"disableoriginx509" yaml:"DisableOriginX509"`
 	} `mapstructure:"topology" yaml:"Topology"`
 	Transport struct {
 		DialerKeepAlive time.Duration `mapstructure:"dialerkeepalive" yaml:"DialerKeepAlive"`
@@ -676,7 +678,9 @@ type configWithType struct {
 	}
 	TLSSkipVerify struct { Type string; Value bool }
 	Topology struct {
+		DisableCacheX509 struct { Type string; Value bool }
 		DisableDowntime struct { Type string; Value bool }
+		DisableOriginX509 struct { Type string; Value bool }
 	}
 	Transport struct {
 		DialerKeepAlive struct { Type string; Value time.Duration }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -333,6 +333,7 @@ type Config struct {
 	TLSSkipVerify bool `mapstructure:"tlsskipverify" yaml:"TLSSkipVerify"`
 	Topology struct {
 		DisableCacheX509 bool `mapstructure:"disablecachex509" yaml:"DisableCacheX509"`
+		DisableCaches bool `mapstructure:"disablecaches" yaml:"DisableCaches"`
 		DisableDowntime bool `mapstructure:"disabledowntime" yaml:"DisableDowntime"`
 		DisableOriginX509 bool `mapstructure:"disableoriginx509" yaml:"DisableOriginX509"`
 	} `mapstructure:"topology" yaml:"Topology"`
@@ -679,6 +680,7 @@ type configWithType struct {
 	TLSSkipVerify struct { Type string; Value bool }
 	Topology struct {
 		DisableCacheX509 struct { Type string; Value bool }
+		DisableCaches struct { Type string; Value bool }
 		DisableDowntime struct { Type string; Value bool }
 		DisableOriginX509 struct { Type string; Value bool }
 	}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -331,6 +331,9 @@ type Config struct {
 		ShadowOriginPrefix string `mapstructure:"shadoworiginprefix" yaml:"ShadowOriginPrefix"`
 	} `mapstructure:"stageplugin" yaml:"StagePlugin"`
 	TLSSkipVerify bool `mapstructure:"tlsskipverify" yaml:"TLSSkipVerify"`
+	Topology struct {
+		DisableDowntime bool `mapstructure:"disabledowntime" yaml:"DisableDowntime"`
+	} `mapstructure:"topology" yaml:"Topology"`
 	Transport struct {
 		DialerKeepAlive time.Duration `mapstructure:"dialerkeepalive" yaml:"DialerKeepAlive"`
 		DialerTimeout time.Duration `mapstructure:"dialertimeout" yaml:"DialerTimeout"`
@@ -672,6 +675,9 @@ type configWithType struct {
 		ShadowOriginPrefix struct { Type string; Value string }
 	}
 	TLSSkipVerify struct { Type string; Value bool }
+	Topology struct {
+		DisableDowntime struct { Type string; Value bool }
+	}
 	Transport struct {
 		DialerKeepAlive struct { Type string; Value time.Duration }
 		DialerTimeout struct { Type string; Value time.Duration }

--- a/xrootd/authorization.go
+++ b/xrootd/authorization.go
@@ -270,15 +270,18 @@ func EmitAuthfile(server server_structs.XRootDServer) error {
 	output := new(bytes.Buffer)
 	foundPublicLine := false
 	if config.GetPreferredPrefix() == config.OsdfPrefix {
-		log.Debugln("Retrieving OSDF Authfile for server")
-		bytes, err := getOSDFAuthFiles(server)
-		if err != nil {
-			return errors.Wrapf(err, "Failed to fetch osdf authfile from topology")
-		}
+		if (server.GetServerType().IsEnabled(server_structs.OriginType) && !param.Topology_DisableOriginX509.GetBool()) ||
+			(server.GetServerType().IsEnabled(server_structs.CacheType) && !param.Topology_DisableCacheX509.GetBool()) {
+			log.Debugln("Retrieving OSDF Authfile for server")
+			bytes, err := getOSDFAuthFiles(server)
+			if err != nil {
+				return errors.Wrapf(err, "Failed to fetch osdf authfile from topology")
+			}
 
-		log.Debugln("Parsing OSDF Authfile")
-		if bytes != nil {
-			output.Write(bytes)
+			log.Debugln("Parsing OSDF Authfile")
+			if bytes != nil {
+				output.Write(bytes)
+			}
 		}
 	}
 

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -185,53 +185,76 @@ func TestOSDFAuthRetrieval(t *testing.T) {
 
 func TestOSDFAuthCreation(t *testing.T) {
 	tests := []struct {
-		desc     string
-		authIn   string
-		authOut  string
-		server   server_structs.XRootDServer
-		hostname string
+		desc        string
+		authIn      string
+		authOut     string
+		server      server_structs.XRootDServer
+		hostname    string
+		disableX509 bool
 	}{
 		{
-			desc:     "osdf-origin-auth-no-merge",
-			authIn:   "",
-			authOut:  mergedAuthfileEntries,
-			server:   &origin.OriginServer{},
-			hostname: "origin-test",
+			desc:        "osdf-origin-auth-no-merge",
+			authIn:      "",
+			authOut:     mergedAuthfileEntries,
+			server:      &origin.OriginServer{},
+			hostname:    "origin-test",
+			disableX509: false,
 		},
 		{
-			desc:     "osdf-origin-auth-merge",
-			authIn:   cacheAuthfileMultilineInput,
-			authOut:  otherMergedAuthfileEntries,
-			server:   &origin.OriginServer{},
-			hostname: "origin-test",
+			desc:        "osdf-origin-auth-merge",
+			authIn:      cacheAuthfileMultilineInput,
+			authOut:     otherMergedAuthfileEntries,
+			server:      &origin.OriginServer{},
+			hostname:    "origin-test",
+			disableX509: false,
 		},
 		{
-			desc:     "osdf-cache-auth-no-merge",
-			authIn:   "",
-			authOut:  cacheAuthfileEntries,
-			server:   &cache.CacheServer{},
-			hostname: "cache-test",
+			desc:        "osdf-cache-auth-no-merge",
+			authIn:      "",
+			authOut:     cacheAuthfileEntries,
+			server:      &cache.CacheServer{},
+			hostname:    "cache-test",
+			disableX509: false,
 		},
 		{
-			desc:     "osdf-cache-auth-merge",
-			authIn:   cacheAuthfileMultilineInput,
-			authOut:  cacheMergedAuthfileEntries,
-			server:   &cache.CacheServer{},
-			hostname: "cache-test",
+			desc:        "osdf-cache-auth-merge",
+			authIn:      cacheAuthfileMultilineInput,
+			authOut:     cacheMergedAuthfileEntries,
+			server:      &cache.CacheServer{},
+			hostname:    "cache-test",
+			disableX509: false,
 		},
 		{
-			desc:     "osdf-origin-no-authfile",
-			authIn:   "",
-			authOut:  "u * /.well-known lr\n",
-			server:   &origin.OriginServer{},
-			hostname: "origin-test-empty",
+			desc:        "osdf-origin-no-authfile",
+			authIn:      "",
+			authOut:     "u * /.well-known lr\n",
+			server:      &origin.OriginServer{},
+			hostname:    "origin-test-empty",
+			disableX509: false,
 		},
 		{
-			desc:     "osdf-cache-no-authfile",
-			authIn:   "",
-			authOut:  "",
-			server:   &cache.CacheServer{},
-			hostname: "cache-test-empty",
+			desc:        "osdf-cache-no-authfile",
+			authIn:      "",
+			authOut:     "",
+			server:      &cache.CacheServer{},
+			hostname:    "cache-test-empty",
+			disableX509: false,
+		},
+		{
+			desc:        "osdf-cache-disable-auth",
+			authIn:      cacheAuthfileMultilineInput,
+			authOut:     "u * /user/ligo -rl /Gluex rl /NSG/PUBLIC rl /VDC/PUBLIC rl ",
+			server:      &cache.CacheServer{},
+			hostname:    "cache-test",
+			disableX509: true,
+		},
+		{
+			desc:        "osdf-origin-disable-auth",
+			authIn:      "",
+			authOut:     "u * /.well-known lr\n",
+			server:      &origin.OriginServer{},
+			hostname:    "origin-test",
+			disableX509: true,
 		},
 	}
 
@@ -276,6 +299,10 @@ func TestOSDFAuthCreation(t *testing.T) {
 			viper.Set("Xrootd.Authfile", filepath.Join(dirName, "authfile"))
 			viper.Set("Federation.TopologyUrl", ts.URL)
 			viper.Set("Server.Hostname", testInput.hostname)
+			if testInput.disableX509 {
+				viper.Set("Topology.DisableCacheX509", true)
+				viper.Set("Topology.DisableOriginX509", true)
+			}
 			var xrootdRun string
 			if strings.Contains(testInput.hostname, "cache") {
 				viper.Set("Cache.RunLocation", dirName)


### PR DESCRIPTION
Added flags to disable getting downtime from Topology, getting X509 authentication from Topology (caches and origins), getting caches themselves, and getting origins.

These are meant to be modular, so rather than gutting AdvertiseOSDF or playing with the "isTopology" settings in the ads, this just selectively disables what information it creates/retrieves from Topology as needed.

I recommend testing by using the osdf binary and selectively applying various versions of the TopologyFlags and seeing that the various features are turned off.