### PR TITLE
Fix metrics scraping by accepting fed tokens for Director service discovery

### DIFF
--- a/director/director.go
+++ b/director/director.go
@@ -1435,7 +1435,7 @@ func serverAdMetricMiddleware(ctx *gin.Context) {
 func discoverOriginCache(ctx *gin.Context) {
 	authOption := token.AuthOption{
 		Sources: []token.TokenSource{token.Header},
-		Issuers: []token.TokenIssuer{token.LocalIssuer, token.APITokenIssuer},
+		Issuers: []token.TokenIssuer{token.LocalIssuer, token.APITokenIssuer, token.FederationIssuer},
 		Scopes:  []token_scopes.TokenScope{token_scopes.Pelican_DirectorServiceDiscovery},
 	}
 

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -1363,18 +1363,9 @@ func TestDiscoverOriginCache(t *testing.T) {
 	viper.Set("Server.ExternalWebUrl", fedInfo.DirectorEndpoint)
 
 	// Batch set up different tokens
-	setupToken := func(wrongIssuer string) []byte {
-		issuerURL, err := url.Parse(fedInfo.DiscoveryEndpoint)
-		assert.NoError(t, err, "Error parsing director's URL")
-		tokenIssuerString := ""
-		if wrongIssuer != "" {
-			tokenIssuerString = wrongIssuer
-		} else {
-			tokenIssuerString = issuerURL.String()
-		}
-
+	setupToken := func(issuer string) []byte {
 		tok, err := jwt.NewBuilder().
-			Issuer(tokenIssuerString).
+			Issuer(issuer).
 			Claim("scope", token_scopes.Pelican_DirectorServiceDiscovery).
 			Audience([]string{"director.test"}).
 			Subject("director").
@@ -1521,7 +1512,7 @@ func TestDiscoverOriginCache(t *testing.T) {
 			},
 		}}
 
-		req.Header.Set("Authorization", "Bearer "+string(setupToken("")))
+		req.Header.Set("Authorization", "Bearer "+string(setupToken(fedInfo.DiscoveryEndpoint)))
 
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)
@@ -1577,7 +1568,7 @@ func TestDiscoverOriginCache(t *testing.T) {
 		resStr, err := json.Marshal(expectedRes)
 		assert.NoError(t, err, "Could not marshal json response")
 
-		req.Header.Set("Authorization", "Bearer "+string(setupToken("")))
+		req.Header.Set("Authorization", "Bearer "+string(setupToken(fedInfo.DiscoveryEndpoint)))
 
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -1284,6 +1284,13 @@ func TestCheckRedirectQuery(t *testing.T) {
 }
 
 func TestDiscoverOriginCache(t *testing.T) {
+	server_utils.ResetTestState()
+	defer server_utils.ResetTestState()
+
+	// Isolate the test so it doesn't use system config
+	viper.Set("ConfigDir", t.TempDir())
+	config.InitConfig()
+
 	mockPelicanOriginServerAd := server_structs.ServerAd{
 		URL: url.URL{
 			Scheme: "https",
@@ -1336,37 +1343,28 @@ func TestDiscoverOriginCache(t *testing.T) {
 		}},
 	}
 
-	mockDirectorUrl := "https://fake-director.org:8888"
-
-	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
-	defer func() { require.NoError(t, egrp.Wait()) }()
-	defer cancel()
-
-	server_utils.ResetTestState()
-	// Direcor SD will only be used for director's Prometheus scraper to get available origins,
-	// so the token issuer is issentially the director server itself
-	// There's no need to rely on Federation.DirectorUrl as token issuer in this case
-	viper.Set("Server.ExternalWebUrl", mockDirectorUrl)
-
-	tDir := t.TempDir()
-	kDir := filepath.Join(tDir, "testKeyDir")
-	viper.Set(param.IssuerKeysDirectory.GetName(), kDir)
-
-	viper.Set("ConfigDir", t.TempDir())
-	config.InitConfig()
-	err := config.InitServer(ctx, server_structs.DirectorType)
-	require.NoError(t, err)
-
-	// Generate a private key to use for the test
-	_, err = config.GetIssuerPublicJWKS()
-	assert.NoError(t, err, "Error generating private key")
-	// Get private key
+	// Generate the keys we need for the test
+	ctx, _, _ := test_utils.TestContext(context.Background(), t)
+	viper.Set(param.IssuerKeysDirectory.GetName(), filepath.Join(t.TempDir(), "testKeyDir"))
+	pKeySet, err := config.GetIssuerPublicJWKS()
+	assert.NoError(t, err, "Error fetching public key for test")
 	privateKey, err := config.GetIssuerPrivateJWK()
-	assert.NoError(t, err, "Error loading private key")
+	assert.NoError(t, err, "Error fetching private key for test")
+
+	// Set up the mock federation, which must exist for the auth handler to fetch federation keys
+	test_utils.MockFederationRoot(t, nil, &pKeySet)
+	fedInfo, err := config.GetFederation(ctx)
+	assert.NoError(t, err, "Error fetching federation info for test")
+
+	// The Director's service discovery endpoint should accept tokens from the local issuer,
+	// the API token issuer or the federation issuer. Configure the URL to be used for local
+	// issuer scenarios. To be as realistic as possible, make the local issuer URL look like
+	// this mock federation's Director.
+	viper.Set("Server.ExternalWebUrl", fedInfo.DirectorEndpoint)
 
 	// Batch set up different tokens
 	setupToken := func(wrongIssuer string) []byte {
-		issuerURL, err := url.Parse(mockDirectorUrl)
+		issuerURL, err := url.Parse(fedInfo.DiscoveryEndpoint)
 		assert.NoError(t, err, "Error parsing director's URL")
 		tokenIssuerString := ""
 		if wrongIssuer != "" {
@@ -1433,32 +1431,49 @@ func TestDiscoverOriginCache(t *testing.T) {
 		assert.Equal(t, 403, w.Code)
 		assert.Equal(t, `{"status":"error","msg":"Authentication is required but no token is present."}`, w.Body.String())
 	})
-	t.Run("token-present-with-wrong-issuer-should-give-403", func(t *testing.T) {
+	t.Run("token-present-with-unknown-issuer-should-give-403", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "/test", nil)
 		if err != nil {
 			t.Fatalf("Could not make a GET request: %v", err)
 		}
 
-		req.Header.Set("Authorization", "Bearer "+string(setupToken("https://wrong-issuer.org")))
+		unknownIssuer := "https://unknown-issuer.org"
+		req.Header.Set("Authorization", "Bearer "+string(setupToken(unknownIssuer)))
 
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)
 
-		assert.Equal(t, 403, w.Code)
-		assert.Equal(t, `{"status":"error","msg":"Cannot verify token: Cannot verify token with server issuer:  Token issuer https://wrong-issuer.org does not match the local issuer on the current server. Expecting https://fake-director.org:8888\nCannot verify token with API token issuer:  Invalid API token format\n"}`, w.Body.String())
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.Contains(t, w.Body.String(), fmt.Sprintf("Token issuer %s does not match the local issuer on the current server. Expecting %s", unknownIssuer, fedInfo.DirectorEndpoint))
+		assert.Contains(t, w.Body.String(), fmt.Sprintf("Token issuer %s does not match the issuer from the federation. Expecting the issuer to be %s", unknownIssuer, fedInfo.DiscoveryEndpoint))
 	})
-	t.Run("token-present-valid-should-give-200-and-empty-array", func(t *testing.T) {
+	t.Run("token-present-fed-issuer-should-give-200-and-empty-array", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "/test", nil)
 		if err != nil {
 			t.Fatalf("Could not make a GET request: %v", err)
 		}
 
-		req.Header.Set("Authorization", "Bearer "+string(setupToken("")))
+		req.Header.Set("Authorization", "Bearer "+string(setupToken(fedInfo.DiscoveryEndpoint)))
 
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)
 
-		assert.Equal(t, 200, w.Code)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, `[]`, w.Body.String())
+	})
+	t.Run("token-present-local-issuer-should-give-200-and-empty-array", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/test", nil)
+		if err != nil {
+			t.Fatalf("Could not make a GET request: %v", err)
+		}
+
+		// Here, the local issuer should be the same as the federation director
+		req.Header.Set("Authorization", "Bearer "+string(setupToken(fedInfo.DirectorEndpoint)))
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, `[]`, w.Body.String())
 	})
 	t.Run("response-should-match-serverAds", func(t *testing.T) {
@@ -1511,7 +1526,7 @@ func TestDiscoverOriginCache(t *testing.T) {
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)
 
-		require.Equal(t, 200, w.Code)
+		require.Equal(t, http.StatusOK, w.Code)
 
 		var resMarshalled []PromDiscoveryItem
 		err = json.Unmarshal(w.Body.Bytes(), &resMarshalled)
@@ -1567,7 +1582,7 @@ func TestDiscoverOriginCache(t *testing.T) {
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)
 
-		assert.Equal(t, 200, w.Code)
+		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, string(resStr), w.Body.String(), "Response doesn't match expected")
 	})
 }

--- a/test_utils/utils.go
+++ b/test_utils/utils.go
@@ -285,15 +285,17 @@ func MockFederationRoot(t *testing.T, fInfo *pelican_url.FederationDiscovery, kS
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 
-			_, err := w.Write([]byte(fmt.Sprintf(`{
-				"director_endpoint": "%s",
-				"director_advertise_endpoints": %s,
-				"namespace_registration_endpoint": "%s",
-				"broker_endpoint": "%s",
-				"jwks_uri": "%s"
-			}`, getInternalFInfo().DirectorEndpoint, getInternalFInfo().DirectorAdvertiseEndpoints, getInternalFInfo().RegistryEndpoint,
-				getInternalFInfo().BrokerEndpoint, getInternalFInfo().JwksUri)))
+			discoveryMetadata := pelican_url.FederationDiscovery{
+				DirectorEndpoint:           getInternalFInfo().DirectorEndpoint,
+				RegistryEndpoint:           getInternalFInfo().RegistryEndpoint,
+				BrokerEndpoint:             getInternalFInfo().BrokerEndpoint,
+				JwksUri:                    getInternalFInfo().JwksUri,
+				DirectorAdvertiseEndpoints: getInternalFInfo().DirectorAdvertiseEndpoints,
+			}
 
+			discoveryJSONBytes, err := json.Marshal(discoveryMetadata)
+			require.NoError(t, err, "Failed to marshal discovery metadata")
+			_, err = w.Write(discoveryJSONBytes)
 			require.NoError(t, err)
 		// If someone follows the jwks_uri value, return the keys
 		case "/.well-known/issuer.jwks":

--- a/test_utils/utils.go
+++ b/test_utils/utils.go
@@ -25,11 +25,13 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v2/jwa"
@@ -40,6 +42,8 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/pelican_url"
 )
 
 func TestContext(ictx context.Context, t *testing.T) (ctx context.Context, cancel context.CancelFunc, egrp *errgroup.Group) {
@@ -245,4 +249,101 @@ func GetUniqueAvailablePorts(count int) ([]int, error) {
 	}
 
 	return portList, nil
+}
+
+// Create a mock federation root that can respond to requests for metadata and federation keys
+func MockFederationRoot(t *testing.T, fInfo *pelican_url.FederationDiscovery, kSet *jwk.Set) { // *httptest.Server {
+	// Set up the keys to use in our response jwks
+	var pKeySetInternal jwk.Set
+	var err error
+	if kSet == nil {
+		keysDir := filepath.Join(t.TempDir(), "testKeyDir")
+		viper.Set(param.IssuerKeysDirectory.GetName(), keysDir)
+		pKeySetInternal, err = config.GetIssuerPublicJWKS()
+		require.NoError(t, err, "Failed to load public JWKS while creating mock federation root")
+	} else {
+		pKeySetInternal = *kSet
+	}
+	kSetBytes, err := json.Marshal(pKeySetInternal)
+	require.NoError(t, err, "Failed to marshal public JWKS while creating mock federation root")
+
+	// Mock the JSON responses. Values get populated at query time using the getInternalFInfo function
+	var getInternalFInfo func() pelican_url.FederationDiscovery
+	responseHandler := func(w http.ResponseWriter, r *http.Request) {
+		// We only understand GET requests
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			_, err := w.Write([]byte("I only understand GET requests, but you sent me " + r.Method))
+			require.NoError(t, err)
+			return
+		}
+
+		path := r.URL.Path
+		switch path {
+		// Provide base fed root metadata
+		case "/.well-known/pelican-configuration":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			_, err := w.Write([]byte(fmt.Sprintf(`{
+				"director_endpoint": "%s",
+				"director_advertise_endpoints": %s,
+				"namespace_registration_endpoint": "%s",
+				"broker_endpoint": "%s",
+				"jwks_uri": "%s"
+			}`, getInternalFInfo().DirectorEndpoint, getInternalFInfo().DirectorAdvertiseEndpoints, getInternalFInfo().RegistryEndpoint,
+				getInternalFInfo().BrokerEndpoint, getInternalFInfo().JwksUri)))
+
+			require.NoError(t, err)
+		// If someone follows the jwks_uri value, return the keys
+		case "/.well-known/issuer.jwks":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(kSetBytes))
+			require.NoError(t, err)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, err := w.Write([]byte("I don't understand this path: " + path))
+			require.NoError(t, err)
+		}
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(responseHandler))
+	serverUrl := server.URL
+	getInternalFInfo = func() pelican_url.FederationDiscovery {
+		// Pre-populate some fed metadata values
+		internalFInfo := pelican_url.FederationDiscovery{
+			DirectorEndpoint: "https://fake-director.com",
+			RegistryEndpoint: "https://fake-registry.com",
+			BrokerEndpoint:   "https://fake-broker.com",
+			JwksUri:          fmt.Sprintf("%s/.well-known/issuer.jwks", serverUrl),
+		}
+
+		// Override as needed based on the passed in fInfo
+		if fInfo != nil {
+			if fInfo.DirectorEndpoint != "" {
+				internalFInfo.DirectorEndpoint = fInfo.DirectorEndpoint
+			}
+			if fInfo.RegistryEndpoint != "" {
+				internalFInfo.RegistryEndpoint = fInfo.RegistryEndpoint
+			}
+			if fInfo.BrokerEndpoint != "" {
+				internalFInfo.BrokerEndpoint = fInfo.BrokerEndpoint
+			}
+			if fInfo.JwksUri != "" {
+				internalFInfo.JwksUri = fInfo.JwksUri
+			}
+			if fInfo.DirectorAdvertiseEndpoints != nil {
+				internalFInfo.DirectorAdvertiseEndpoints = fInfo.DirectorAdvertiseEndpoints
+			}
+		}
+		return internalFInfo
+	}
+
+	// Cleanup, cleanup, everybody do your share!
+	t.Cleanup(server.Close)
+
+	// Finally, set this as the federation discovery URL so tests
+	// can "discover" the info
+	viper.Set(param.Federation_DiscoveryUrl.GetName(), serverUrl)
 }


### PR DESCRIPTION
The bug was that we switched the Director to issue service discovery tokens using the Federation root as an issuer, but neglected to update the auth handler in the service discovery endpoint to accept federation tokens.

This adds the extra auth handler and gives the test a face lift that I think would have caught the bug the first go around had they existed.

I also added a mock federation root server, which I've wound up re-implementing too many times. Some other time I'll go back through some old code and switch it to use this standard test utility.