### PR TITLE
Downtime CLI for server admin

### DIFF
--- a/cmd/director.go
+++ b/cmd/director.go
@@ -19,8 +19,29 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/token"
+	"github.com/pelicanplatform/pelican/token_scopes"
+	"github.com/pelicanplatform/pelican/utils"
+)
+
+const (
+	// The API path for downtime management
+	serverDowntimeAPIPath = "/api/v1.0/downtime"
 )
 
 var (
@@ -58,4 +79,101 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+}
+
+// Helper function to validate the server URL and construct the full API endpoint URL
+func constructDowntimeApiURL(serverURLStr string) (*url.URL, error) {
+	if serverURLStr == "" {
+		return nil, errors.New("The --server flag providing the server's web URL is required")
+	}
+	serverURLStr = strings.TrimSuffix(serverURLStr, "/") // Normalize URL
+	baseURL, err := url.Parse(serverURLStr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Invalid server URL format: %s", serverURLStr)
+	}
+	// A Pelican server must use HTTPS scheme
+	if baseURL.Scheme != "https" {
+		return nil, errors.Errorf("Server URL must have an https scheme: %s", serverURLStr)
+	}
+	if baseURL.Host == "" {
+		return nil, errors.Errorf("Server URL must include a hostname: %s", serverURLStr)
+	}
+	// Construct the full API endpoint URL
+	targetURL, err := baseURL.Parse(serverDowntimeAPIPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to construct downtime API URL")
+	}
+	return targetURL, nil
+}
+
+// Helper function to load or generate token that could access server's web API with admin privileges
+func fetchOrGenerateWebAPIAdminToken(serverURLStr, tokenLocation string) (string, error) {
+	var tok string
+	var err error
+	// Prioritize using a token from a file if one is provided.
+	if tokenLocation != "" {
+		if _, err := os.Stat(tokenLocation); errors.Is(err, os.ErrNotExist) {
+			return "", errors.Errorf("Token file not found at: %s", tokenLocation)
+		} else if err != nil {
+			return "", errors.Wrapf(err, "Error checking token file: %s", tokenLocation)
+		}
+		tok, err = utils.GetTokenFromFile(tokenLocation)
+		if err != nil {
+			return "", errors.Wrapf(err, "Failed to read token file: %s", tokenLocation)
+		}
+	}
+	// If no token is provided, generate a new one with current issuer key
+	if tok == "" {
+		tc := token.NewWLCGToken()
+		tc.Lifetime = 5 * time.Minute
+		tc.Subject = "admin"
+		tc.Issuer = serverURLStr
+		tc.AddAudienceAny()
+		tc.AddScopes(token_scopes.WebUi_Access)
+		tok, err := tc.CreateToken()
+		if err != nil {
+			log.Debugln("Token Configuration (partial):")
+			log.Debugln("  Issuer:", tc.Issuer)
+			log.Debugln("  Subject:", tc.Subject)
+			return "", errors.Wrap(err, "Failed to create the downtime operation token")
+		}
+		return tok, nil
+	}
+	return tok, nil
+}
+
+// handleAdminApiResponse checks the HTTP status code for API calls
+// that requires server admin authorization.
+// Returns the body bytes on success (2xx) or an error for non-2xx status codes.
+// Attempts to parse standard Pelican error responses (SimpleApiResp).
+func handleAdminApiResponse(resp *http.Response) ([]byte, error) {
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read response body (status: %s)", resp.Status)
+	}
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return bodyBytes, nil // Success
+	}
+
+	// Attempt to parse a standard error response
+	var errorResp server_structs.SimpleApiResp
+	errMsg := fmt.Sprintf("server responded with %s", resp.Status)
+	if parseErr := json.Unmarshal(bodyBytes, &errorResp); parseErr == nil && errorResp.Msg != "" {
+		errMsg = fmt.Sprintf("%s: %s", errMsg, errorResp.Msg)
+	} else {
+		// Fallback if parsing fails or message is empty
+		if len(bodyBytes) > 0 && len(bodyBytes) < 512 { // Avoid logging huge bodies
+			errMsg += fmt.Sprintf(" (body: %s)", string(bodyBytes))
+		}
+	}
+
+	// Add specific messages for common auth errors
+	if resp.StatusCode == http.StatusUnauthorized { // 401
+		errMsg += " (check if token is valid or expired)"
+	} else if resp.StatusCode == http.StatusForbidden { // 403
+		errMsg += " (check if token has required admin privileges)"
+	}
+
+	return bodyBytes, errors.New(errMsg)
 }

--- a/cmd/downtime.go
+++ b/cmd/downtime.go
@@ -30,4 +30,15 @@ var (
 for Pelican servers (Origins/Caches). These commands interact with the server's
 administrative API endpoint.`,
 	}
+
+	serverURLStr  string
+	tokenLocation string
 )
+
+func init() {
+	// Add the server URL as a REQUIRED persistent flag to all subcommands of downtimeCmd
+	downtimeCmd.PersistentFlags().StringVarP(&serverURLStr, "server", "s", "", "Web URL of the Pelican server (e.g. https://my-origin.com:8447)")
+
+	// Optional persistent flag
+	downtimeCmd.PersistentFlags().StringVarP(&tokenLocation, "token", "t", "", "Path to the admin token file")
+}

--- a/cmd/downtime.go
+++ b/cmd/downtime.go
@@ -1,0 +1,33 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	downtimeCmd = &cobra.Command{
+		Use:   "downtime",
+		Short: "Manage server's own downtime periods",
+		Long: `Provide commands to list, create, update, and delete scheduled downtime periods
+for Pelican servers (Origins/Caches). These commands interact with the server's
+administrative API endpoint.`,
+	}
+)

--- a/cmd/downtime_create.go
+++ b/cmd/downtime_create.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/server_structs"
+)
+
+// downtimeCreateCmd creates a new downtime period interactively.
+var downtimeCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new downtime period for the server",
+	Long:  "Interactively prompt for downtime fields and send a POST request to create a new downtime period.",
+	RunE:  createDowntimeFunc,
+}
+
+func init() {
+	flags := downtimeCreateCmd.Flags()
+	flags.StringP("server", "s", "", "Web URL of the target Pelican server (e.g. https://my-origin.com:8447)")
+	downtimeCreateCmd.MarkFlagRequired("server")
+	flags.StringP("token", "t", "", "Path to the admin token file")
+	downtimeCmd.AddCommand(downtimeCreateCmd)
+}
+
+func createDowntimeFunc(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if err := config.InitClient(); err != nil {
+		log.Errorln("Failed to initialize client:", err)
+	}
+
+	serverURLStr, _ := cmd.Flags().GetString("server")
+	tokenLocation, _ := cmd.Flags().GetString("token")
+
+	targetURL, err := constructDowntimeApiURL(serverURLStr)
+	if err != nil {
+		return err
+	}
+
+	// Create a reader to prompt the user.
+	reader := bufio.NewReader(os.Stdin)
+
+	// Prompt for Downtime Class
+	var downtimeClass string
+	for {
+		fmt.Println("Select downtime Class:")
+		classes := []string{
+			string(server_structs.SCHEDULED),
+			string(server_structs.UNSCHEDULED),
+		}
+		for i, cls := range classes {
+			fmt.Printf("%d. %s\n", i+1, cls)
+		}
+		fmt.Print("Enter choice number: ")
+		classInput, err := reader.ReadString('\n')
+		if err != nil {
+			return errors.Wrap(err, "failed to read downtime class")
+		}
+		classInput = strings.TrimSpace(classInput)
+		classChoice, err := strconv.Atoi(classInput)
+		if err != nil || classChoice < 1 || classChoice > len(classes) {
+			fmt.Println("Invalid downtime class selection. Please try again.")
+			continue
+		}
+		downtimeClass = classes[classChoice-1]
+		break
+	}
+
+	// Prompt for Description
+	fmt.Print("Enter downtime Description: ")
+	description, err := reader.ReadString('\n')
+	if err != nil {
+		return errors.Wrap(err, "failed to read description")
+	}
+	description = strings.TrimSpace(description)
+
+	// Prompt for Severity
+	var downtimeSeverity string
+	for {
+		fmt.Println("Select downtime Severity:")
+		severities := []string{
+			string(server_structs.Outage),
+			string(server_structs.Severe),
+			string(server_structs.IntermittentOutage),
+			string(server_structs.NoSignificantOutageExpected),
+		}
+		for i, sev := range severities {
+			fmt.Printf("%d. %s\n", i+1, sev)
+		}
+		fmt.Print("Enter number to choose: ")
+		sevInput, err := reader.ReadString('\n')
+		if err != nil {
+			return errors.Wrap(err, "failed to read severity")
+		}
+		sevInput = strings.TrimSpace(sevInput)
+		sevChoice, err := strconv.Atoi(sevInput)
+		if err != nil || sevChoice < 1 || sevChoice > len(severities) {
+			fmt.Println("Invalid severity selection. Please try again.")
+			continue
+		}
+		downtimeSeverity = severities[sevChoice-1]
+		break
+	}
+
+	// Prompt for Start Time
+	fmt.Print("Enter start time in UTC (YYYY-MM-DD HH:MM:SS): ")
+	startInput, err := reader.ReadString('\n')
+	if err != nil {
+		return errors.Wrap(err, "failed to read start time")
+	}
+	startInput = strings.TrimSpace(startInput)
+	startTime, err := time.Parse("2006-01-02 15:04:05", startInput)
+	if err != nil {
+		return errors.Wrap(err, "Invalid start time format")
+	}
+
+	// Prompt for End Time
+	fmt.Print("Enter end time in UTC (YYYY-MM-DD HH:MM:SS) or '-1' for indefinite: ")
+	endInput, err := reader.ReadString('\n')
+	if err != nil {
+		return errors.Wrap(err, "failed to read end time")
+	}
+	endInput = strings.TrimSpace(endInput)
+	var endTimeMilli int64
+	if endInput == "-1" {
+		endTimeMilli = -1
+	} else {
+		endTime, err := time.Parse("2006-01-02 15:04:05", endInput)
+		if err != nil {
+			return errors.Wrap(err, "Invalid end time format")
+		}
+		endTimeMilli = endTime.UnixMilli()
+	}
+
+	// Build downtime payload
+	downtimePayload := server_structs.Downtime{
+		Class:       server_structs.Class(downtimeClass),
+		Description: description,
+		Severity:    server_structs.Severity(downtimeSeverity),
+		StartTime:   startTime.UnixMilli(),
+		EndTime:     endTimeMilli,
+		// The server will set CreatedBy to "admin", based on the token
+	}
+
+	payloadBytes, err := json.Marshal(downtimePayload)
+	if err != nil {
+		return errors.Wrap(err, "Failed to marshal downtime payload")
+	}
+
+	// Get token using the provided helper.
+	tok, err := getToken(serverURLStr, tokenLocation)
+	if err != nil {
+		return err
+	}
+
+	// Prepare and send the HTTP request.
+	req, err := http.NewRequestWithContext(ctx, "POST", targetURL.String(), bytes.NewBuffer(payloadBytes))
+	if err != nil {
+		return errors.Wrap(err, "Failed to create HTTP request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.AddCookie(&http.Cookie{Name: "login", Value: tok})
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "pelican-client/"+config.GetVersion())
+
+	httpClient := &http.Client{Transport: config.GetTransport()}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "HTTP request failed")
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := handleAdminApiResponse(resp)
+	if err != nil {
+		return errors.Wrap(err, "Server request failed")
+	}
+
+	fmt.Println("Downtime created successfully:")
+	fmt.Println(string(bodyBytes))
+	return nil
+}

--- a/cmd/downtime_create.go
+++ b/cmd/downtime_create.go
@@ -43,14 +43,14 @@ var downtimeCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new downtime period for the server",
 	Long:  "Interactively prompt for downtime fields and send a POST request to create a new downtime period.",
-	RunE:  createDowntimeFunc,
+	RunE:  createDowntime,
 }
 
 func init() {
 	downtimeCmd.AddCommand(downtimeCreateCmd)
 }
 
-func createDowntimeFunc(cmd *cobra.Command, args []string) error {
+func createDowntime(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	if ctx == nil {
 		ctx = context.Background()
@@ -176,7 +176,7 @@ func createDowntimeFunc(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get token using the provided helper.
-	tok, err := getToken(serverURLStr, tokenLocation)
+	tok, err := fetchOrGenerateWebAPIAdminToken(serverURLStr, tokenLocation)
 	if err != nil {
 		return err
 	}

--- a/cmd/downtime_create.go
+++ b/cmd/downtime_create.go
@@ -1,3 +1,21 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
 package main
 
 import (
@@ -29,10 +47,6 @@ var downtimeCreateCmd = &cobra.Command{
 }
 
 func init() {
-	flags := downtimeCreateCmd.Flags()
-	flags.StringP("server", "s", "", "Web URL of the target Pelican server (e.g. https://my-origin.com:8447)")
-	downtimeCreateCmd.MarkFlagRequired("server")
-	flags.StringP("token", "t", "", "Path to the admin token file")
 	downtimeCmd.AddCommand(downtimeCreateCmd)
 }
 
@@ -45,9 +59,6 @@ func createDowntimeFunc(cmd *cobra.Command, args []string) error {
 	if err := config.InitClient(); err != nil {
 		log.Errorln("Failed to initialize client:", err)
 	}
-
-	serverURLStr, _ := cmd.Flags().GetString("server")
-	tokenLocation, _ := cmd.Flags().GetString("token")
 
 	targetURL, err := constructDowntimeApiURL(serverURLStr)
 	if err != nil {

--- a/cmd/downtime_delete.go
+++ b/cmd/downtime_delete.go
@@ -1,3 +1,21 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
 package main
 
 import (
@@ -22,10 +40,6 @@ var downtimeDeleteCmd = &cobra.Command{
 }
 
 func init() {
-	flags := downtimeDeleteCmd.Flags()
-	flags.StringP("server", "s", "", "Web URL of the target Pelican server (e.g. https://my-origin.com:8447)")
-	downtimeDeleteCmd.MarkFlagRequired("server")
-	flags.StringP("token", "t", "", "Path to the admin token file")
 	downtimeCmd.AddCommand(downtimeDeleteCmd)
 }
 
@@ -39,10 +53,6 @@ func deleteDowntimeFunc(cmd *cobra.Command, args []string) error {
 	if err := config.InitClient(); err != nil {
 		log.Errorln("Failed to initialize client:", err)
 	}
-
-	// Get Flag Values
-	serverURLStr, _ := cmd.Flags().GetString("server")
-	tokenLocation, _ := cmd.Flags().GetString("token")
 
 	// Basic validation of the input
 	apiURL, err := constructDowntimeApiURL(serverURLStr)

--- a/cmd/downtime_delete.go
+++ b/cmd/downtime_delete.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -46,13 +45,9 @@ func deleteDowntimeFunc(cmd *cobra.Command, args []string) error {
 	tokenLocation, _ := cmd.Flags().GetString("token")
 
 	// Basic validation of the input
-	if serverURLStr == "" {
-		return errors.New("The --server flag is required")
-	}
-	serverURLStr = strings.TrimSuffix(serverURLStr, "/")
-	baseURL, err := url.Parse(serverURLStr)
+	apiURL, err := constructDowntimeApiURL(serverURLStr)
 	if err != nil {
-		return errors.Wrapf(err, "Invalid server URL: %s", serverURLStr)
+		return err
 	}
 
 	tok, err := getToken(serverURLStr, tokenLocation)
@@ -60,8 +55,8 @@ func deleteDowntimeFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Build the API URL for deletion.
-	targetURL, err := baseURL.Parse(serverDowntimeAPIPath + "/" + downtimeUUID)
+	// Build the API URL for deletion
+	targetURL, err := url.Parse(apiURL.String() + "/" + downtimeUUID)
 	if err != nil {
 		return errors.Wrap(err, "Failed to build delete API URL")
 	}

--- a/cmd/downtime_delete.go
+++ b/cmd/downtime_delete.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/pelicanplatform/pelican/config"
+)
+
+var downtimeDeleteCmd = &cobra.Command{
+	Use:   "delete [uuid]",
+	Short: "Delete a downtime period",
+	Long:  "Delete the specified downtime period by UUID. Sends a DELETE request to the downtime API.",
+	Args:  cobra.ExactArgs(1),
+	RunE:  deleteDowntimeFunc,
+}
+
+func init() {
+	flags := downtimeDeleteCmd.Flags()
+	flags.StringP("server", "s", "", "Web URL of the target Pelican server (e.g. https://my-origin.com:8447)")
+	downtimeDeleteCmd.MarkFlagRequired("server")
+	flags.StringP("token", "t", "", "Path to the admin token file")
+	downtimeCmd.AddCommand(downtimeDeleteCmd)
+}
+
+func deleteDowntimeFunc(cmd *cobra.Command, args []string) error {
+	downtimeUUID := args[0]
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if err := config.InitClient(); err != nil {
+		log.Errorln("Failed to initialize client:", err)
+	}
+
+	// Get Flag Values
+	serverURLStr, _ := cmd.Flags().GetString("server")
+	tokenLocation, _ := cmd.Flags().GetString("token")
+
+	// Basic validation of the input
+	if serverURLStr == "" {
+		return errors.New("The --server flag is required")
+	}
+	serverURLStr = strings.TrimSuffix(serverURLStr, "/")
+	baseURL, err := url.Parse(serverURLStr)
+	if err != nil {
+		return errors.Wrapf(err, "Invalid server URL: %s", serverURLStr)
+	}
+
+	tok, err := getToken(serverURLStr, tokenLocation)
+	if err != nil {
+		return err
+	}
+
+	// Build the API URL for deletion.
+	targetURL, err := baseURL.Parse(serverDowntimeAPIPath + "/" + downtimeUUID)
+	if err != nil {
+		return errors.Wrap(err, "Failed to build delete API URL")
+	}
+
+	log.Debugln("Deleting downtime from:", targetURL.String())
+
+	req, err := http.NewRequestWithContext(ctx, "DELETE", targetURL.String(), nil)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create HTTP request")
+	}
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.AddCookie(&http.Cookie{Name: "login", Value: tok})
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "pelican-client/"+config.GetVersion())
+
+	httpClient := &http.Client{Transport: config.GetTransport()}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "HTTP request failed")
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := handleAdminApiResponse(resp)
+	if err != nil {
+		return errors.Wrap(err, "Server delete request failed")
+	}
+
+	fmt.Println("Downtime deleted successfully:")
+	fmt.Println(string(bodyBytes))
+	return nil
+}

--- a/cmd/downtime_delete.go
+++ b/cmd/downtime_delete.go
@@ -36,14 +36,14 @@ var downtimeDeleteCmd = &cobra.Command{
 	Short: "Delete a downtime period",
 	Long:  "Delete the specified downtime period by UUID. Sends a DELETE request to the downtime API.",
 	Args:  cobra.ExactArgs(1),
-	RunE:  deleteDowntimeFunc,
+	RunE:  deleteDowntime,
 }
 
 func init() {
 	downtimeCmd.AddCommand(downtimeDeleteCmd)
 }
 
-func deleteDowntimeFunc(cmd *cobra.Command, args []string) error {
+func deleteDowntime(cmd *cobra.Command, args []string) error {
 	downtimeUUID := args[0]
 	ctx := cmd.Context()
 	if ctx == nil {
@@ -60,7 +60,7 @@ func deleteDowntimeFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	tok, err := getToken(serverURLStr, tokenLocation)
+	tok, err := fetchOrGenerateWebAPIAdminToken(serverURLStr, tokenLocation)
 	if err != nil {
 		return err
 	}

--- a/cmd/downtime_list.go
+++ b/cmd/downtime_list.go
@@ -69,12 +69,8 @@ var (
 func init() {
 	// Add flags specific to the list command
 	flags := downtimeListCmd.Flags()
-	// Required Flags
-	flags.StringP("server", "s", "", "Base URL of the target Pelican server's web interface (e.g., https://my-origin.com:8447)")
-	downtimeListCmd.MarkFlagRequired("server")
 
 	// Optional Flags
-	flags.StringP("token", "t", "", "Path to the admin token file for authenticating with the server")
 	flags.String("status", "incomplete", "Filter downtimes by status ('incomplete' shows active/future, 'all' shows all history)")
 	flags.StringP("output", "o", "table", "Output format (table, json, yaml)")
 
@@ -93,9 +89,7 @@ func listDowntimeFunc(cmd *cobra.Command, args []string) error {
 		log.Errorln("Failed to initialize client:", err)
 	}
 
-	// Get Flag Values
-	serverURLStr, _ := cmd.Flags().GetString("server")
-	tokenLocation, _ := cmd.Flags().GetString("token")
+	// Get additional flag Values
 	statusFilter, _ := cmd.Flags().GetString("status")
 	outputFormat, _ := cmd.Flags().GetString("output")
 
@@ -175,7 +169,7 @@ func listDowntimeFunc(cmd *cobra.Command, args []string) error {
 // Helper function to validate the server URL and construct the full API endpoint URL
 func constructDowntimeApiURL(serverURLStr string) (*url.URL, error) {
 	if serverURLStr == "" {
-		return nil, errors.New("The --server flag providing the target server's base URL is required")
+		return nil, errors.New("The --server flag providing the server's web URL is required")
 	}
 	serverURLStr = strings.TrimSuffix(serverURLStr, "/") // Normalize URL
 	baseURL, err := url.Parse(serverURLStr)

--- a/cmd/downtime_list.go
+++ b/cmd/downtime_list.go
@@ -1,0 +1,303 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/token"
+	"github.com/pelicanplatform/pelican/token_scopes"
+)
+
+const (
+	// Define the specific API path for downtime management
+	serverDowntimeAPIPath = "/api/v1.0/downtime"
+)
+
+// downtimeDisplay struct helps in formatting time for output
+type downtimeDisplay struct {
+	server_structs.Downtime
+	StartTimeStr string `json:"start_time_str" yaml:"start_time_str"`
+	EndTimeStr   string `json:"end_time_str" yaml:"end_time_str"`
+}
+
+var (
+	downtimeListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List server's scheduled downtime periods",
+		Long: `List scheduled downtime periods for a Pelican server (Origin/Cache).
+  Requires an administrative token for the server.
+  Shows active and future downtimes ('incomplete') by default.`,
+		Args:    cobra.NoArgs,
+		RunE:    listDowntimeFunc,
+		Aliases: []string{"ls"},
+	}
+)
+
+func init() {
+	// Add flags specific to the list command
+	flags := downtimeListCmd.Flags()
+	// Required Flags
+	flags.StringP("server", "s", "", "Base URL of the target Pelican server's web interface (e.g., https://my-origin.com:8447)")
+	downtimeListCmd.MarkFlagRequired("server")
+
+	// Optional Flags
+	flags.StringP("token", "t", "", "Path to the admin token file for authenticating with the server")
+	flags.String("status", "incomplete", "Filter downtimes by status ('incomplete' shows active/future, 'all' shows all history)")
+	flags.StringP("output", "o", "table", "Output format (table, json, yaml)")
+
+	// Add list command to the downtime group
+	downtimeCmd.AddCommand(downtimeListCmd)
+}
+
+// Core logic for the 'pelican downtime list' command
+func listDowntimeFunc(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if err := config.InitClient(); err != nil {
+		log.Errorln("Failed to initialize client configuration:", err)
+	}
+
+	// Get Flag Values
+	serverURLStr, _ := cmd.Flags().GetString("server")
+	tokenLocation, _ := cmd.Flags().GetString("token")
+	statusFilter, _ := cmd.Flags().GetString("status")
+	outputFormat, _ := cmd.Flags().GetString("output")
+
+	// Basic validation of the input
+	if serverURLStr == "" {
+		return errors.New("The --server flag providing the target server's base URL is required")
+	}
+	serverURLStr = strings.TrimSuffix(serverURLStr, "/") // Normalize URL
+	baseURL, err := url.Parse(serverURLStr)
+	if err != nil {
+		return errors.Wrapf(err, "Invalid server URL format: %s", serverURLStr)
+	}
+	if baseURL.Scheme != "http" && baseURL.Scheme != "https" {
+		return errors.Errorf("Server URL must have an http or https scheme: %s", serverURLStr)
+	}
+	if baseURL.Host == "" {
+		return errors.Errorf("Server URL must include a hostname: %s", serverURLStr)
+	}
+
+	statusFilter = strings.ToLower(statusFilter)
+	if statusFilter != "incomplete" && statusFilter != "all" {
+		return errors.New("Invalid status filter: must be 'incomplete' or 'all'")
+	}
+
+	outputFormat = strings.ToLower(outputFormat)
+	if outputFormat != "table" && outputFormat != "json" && outputFormat != "yaml" {
+		return errors.New("Invalid output format: must be 'table', 'json', or 'yaml'")
+	}
+
+	// Load Token
+	var tok string
+	// Prioritize using a token from a file if one is provided.
+	if tokenLocation != "" {
+		if _, err := os.Stat(tokenLocation); errors.Is(err, os.ErrNotExist) {
+			return errors.Errorf("Token file not found at: %s", tokenLocation)
+		} else if err != nil {
+			return errors.Wrapf(err, "Error checking token file: %s", tokenLocation)
+		}
+		tokenBytes, err := os.ReadFile(tokenLocation)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to read token file: %s", tokenLocation)
+		}
+		tok = strings.TrimSpace(string(tokenBytes))
+	}
+	// If no token is provided, generate a new one with current issuer key
+	if tok == "" {
+		tc := token.NewWLCGToken()
+		tc.Lifetime = 5 * time.Minute
+		tc.Subject = "admin"
+		tc.Issuer = serverURLStr
+		tc.AddAudienceAny()
+		tc.AddScopes(token_scopes.WebUi_Access)
+		tok, err = tc.CreateToken()
+		if err != nil {
+			log.Debugln("Token Configuration (partial):")
+			log.Debugln("  Issuer:", tc.Issuer)
+			log.Debugln("  Subject:", tc.Subject)
+			log.Debugln("  Claims:")
+			for key, value := range tc.Claims {
+				log.Debugf("    %s: %s\n", key, value)
+			}
+			return errors.Wrap(err, "Failed to create downtime listing token")
+		}
+	}
+
+	// Prepare HTTP Request
+	// Construct the full API endpoint URL
+	targetURL, err := baseURL.Parse(serverDowntimeAPIPath)
+	if err != nil {
+		return errors.Wrap(err, "Failed to construct downtime API URL")
+	}
+
+	// Add query parameter
+	query := targetURL.Query()
+	query.Set("status", statusFilter)
+	targetURL.RawQuery = query.Encode()
+
+	log.Debugln("Requesting downtimes from:", targetURL.String())
+
+	req, err := http.NewRequestWithContext(ctx, "GET", targetURL.String(), nil)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create HTTP request")
+	}
+
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.AddCookie(&http.Cookie{Name: "login", Value: tok})
+	req.Header.Set("User-Agent", "pelican-client/"+config.GetVersion()) // Assumes client.GetUserAgent is accessible
+	req.Header.Set("Accept", "application/json")
+
+	// Execute Request
+	httpClient := &http.Client{Transport: config.GetTransport()}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return errors.New("Request cancelled")
+		}
+		return errors.Wrapf(err, "Failed to execute request to server %s", baseURL.Host)
+	}
+	defer resp.Body.Close()
+
+	// Handle Response
+	bodyBytes, err := handleAdminApiResponse(resp)
+	if err != nil {
+		log.Debugf("Raw response body on error: %s", string(bodyBytes))
+		return errors.Wrap(err, "Server request failed")
+	}
+
+	// Parse Response
+	var downtimes []server_structs.Downtime
+	if err := json.Unmarshal(bodyBytes, &downtimes); err != nil {
+		log.Debugf("Raw response body on parse error: %s", string(bodyBytes))
+		return errors.Wrap(err, "Failed to parse JSON response from server")
+	}
+
+	// Format and Print Output
+	if err := printDowntimes(downtimes, outputFormat); err != nil {
+		return errors.Wrap(err, "Failed to format or print output")
+	}
+
+	return nil
+}
+
+// handleAdminApiResponse checks the HTTP status code for API calls
+// that requires server admin authorization.
+// Returns the body bytes on success (2xx) or an error for non-2xx status codes.
+// Attempts to parse standard Pelican error responses (SimpleApiResp).
+func handleAdminApiResponse(resp *http.Response) ([]byte, error) {
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read response body (status: %s)", resp.Status)
+	}
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return bodyBytes, nil // Success
+	}
+
+	// Attempt to parse a standard error response
+	var errorResp server_structs.SimpleApiResp
+	errMsg := fmt.Sprintf("server responded with %s", resp.Status)
+	if parseErr := json.Unmarshal(bodyBytes, &errorResp); parseErr == nil && errorResp.Msg != "" {
+		errMsg = fmt.Sprintf("%s: %s", errMsg, errorResp.Msg)
+	} else {
+		// Fallback if parsing fails or message is empty
+		if len(bodyBytes) > 0 && len(bodyBytes) < 512 { // Avoid logging huge bodies
+			errMsg += fmt.Sprintf(" (body: %s)", string(bodyBytes))
+		}
+	}
+
+	// Add specific messages for common auth errors
+	if resp.StatusCode == http.StatusUnauthorized { // 401
+		errMsg += " (check if token is valid or expired)"
+	} else if resp.StatusCode == http.StatusForbidden { // 403
+		errMsg += " (check if token has required admin privileges)"
+	}
+
+	return bodyBytes, errors.New(errMsg)
+}
+
+// Helper function to print downtimes in the specified format
+func printDowntimes(downtimes []server_structs.Downtime, format string) error {
+	if len(downtimes) == 0 {
+		fmt.Println("No downtime periods found matching the criteria.")
+		return nil
+	}
+
+	// Sort by start time for consistent table output
+	sort.Slice(downtimes, func(i, j int) bool {
+		return downtimes[i].StartTime < downtimes[j].StartTime
+	})
+
+	// Prepare display data (format times)
+	displayData := make([]downtimeDisplay, len(downtimes))
+	for i, dt := range downtimes {
+		// Convert Unix Milliseconds to human-readable time in UTC
+		startTime := time.UnixMilli(dt.StartTime).UTC()
+		displayData[i].StartTimeStr = startTime.Format(time.RFC3339) // ISO 8601 format
+
+		if dt.EndTime > 0 {
+			endTime := time.UnixMilli(dt.EndTime).UTC()
+			displayData[i].EndTimeStr = endTime.Format(time.RFC3339)
+		} else {
+			displayData[i].EndTimeStr = "Indefinite"
+		}
+		displayData[i].Downtime = dt
+	}
+
+	switch format {
+	case "yaml":
+		yamlData, err := yaml.Marshal(displayData)
+		if err != nil {
+			return errors.Wrap(err, "Failed to marshal data to YAML")
+		}
+		fmt.Println(string(yamlData))
+	case "json":
+		fallthrough // Default to json
+	default:
+		jsonData, err := json.MarshalIndent(displayData, "", "  ")
+		if err != nil {
+			return errors.Wrap(err, "Failed to marshal data to JSON")
+		}
+		fmt.Println(string(jsonData))
+	}
+
+	return nil
+}

--- a/cmd/downtime_list.go
+++ b/cmd/downtime_list.go
@@ -22,10 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
-	"net/url"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -37,13 +34,6 @@ import (
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
-	"github.com/pelicanplatform/pelican/token"
-	"github.com/pelicanplatform/pelican/token_scopes"
-)
-
-const (
-	// The API path for downtime management
-	serverDowntimeAPIPath = "/api/v1.0/downtime"
 )
 
 // downtimeDisplay struct helps in formatting time for output
@@ -61,7 +51,7 @@ var (
   Requires an administrative token for the server.
   Shows active and future downtimes ('incomplete') by default.`,
 		Args:    cobra.NoArgs,
-		RunE:    listDowntimeFunc,
+		RunE:    listDowntime,
 		Aliases: []string{"ls"},
 	}
 )
@@ -79,7 +69,7 @@ func init() {
 }
 
 // Core logic for the 'pelican downtime list' command
-func listDowntimeFunc(cmd *cobra.Command, args []string) error {
+func listDowntime(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	if ctx == nil {
 		ctx = context.Background()
@@ -109,7 +99,7 @@ func listDowntimeFunc(cmd *cobra.Command, args []string) error {
 		return errors.New("Invalid output format: must be 'table', 'json', or 'yaml'")
 	}
 
-	tok, err := getToken(serverURLStr, tokenLocation)
+	tok, err := fetchOrGenerateWebAPIAdminToken(serverURLStr, tokenLocation)
 	if err != nil {
 		return err
 	}
@@ -164,102 +154,6 @@ func listDowntimeFunc(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
-}
-
-// Helper function to validate the server URL and construct the full API endpoint URL
-func constructDowntimeApiURL(serverURLStr string) (*url.URL, error) {
-	if serverURLStr == "" {
-		return nil, errors.New("The --server flag providing the server's web URL is required")
-	}
-	serverURLStr = strings.TrimSuffix(serverURLStr, "/") // Normalize URL
-	baseURL, err := url.Parse(serverURLStr)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Invalid server URL format: %s", serverURLStr)
-	}
-	if baseURL.Scheme != "http" && baseURL.Scheme != "https" {
-		return nil, errors.Errorf("Server URL must have an http or https scheme: %s", serverURLStr)
-	}
-	if baseURL.Host == "" {
-		return nil, errors.Errorf("Server URL must include a hostname: %s", serverURLStr)
-	}
-	// Construct the full API endpoint URL
-	targetURL, err := baseURL.Parse(serverDowntimeAPIPath)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to construct downtime API URL")
-	}
-	return targetURL, nil
-}
-
-// Helper function to load or generate token
-func getToken(serverURLStr, tokenLocation string) (string, error) {
-	var tok string
-	// Prioritize using a token from a file if one is provided.
-	if tokenLocation != "" {
-		if _, err := os.Stat(tokenLocation); errors.Is(err, os.ErrNotExist) {
-			return "", errors.Errorf("Token file not found at: %s", tokenLocation)
-		} else if err != nil {
-			return "", errors.Wrapf(err, "Error checking token file: %s", tokenLocation)
-		}
-		tokenBytes, err := os.ReadFile(tokenLocation)
-		if err != nil {
-			return "", errors.Wrapf(err, "Failed to read token file: %s", tokenLocation)
-		}
-		tok = strings.TrimSpace(string(tokenBytes))
-	}
-	// If no token is provided, generate a new one with current issuer key
-	if tok == "" {
-		tc := token.NewWLCGToken()
-		tc.Lifetime = 5 * time.Minute
-		tc.Subject = "admin"
-		tc.Issuer = serverURLStr
-		tc.AddAudienceAny()
-		tc.AddScopes(token_scopes.WebUi_Access)
-		tok, err := tc.CreateToken()
-		if err != nil {
-			log.Debugln("Token Configuration (partial):")
-			log.Debugln("  Issuer:", tc.Issuer)
-			log.Debugln("  Subject:", tc.Subject)
-			return "", errors.Wrap(err, "Failed to create the downtime operation token")
-		}
-		return tok, nil
-	}
-	return tok, nil
-}
-
-// handleAdminApiResponse checks the HTTP status code for API calls
-// that requires server admin authorization.
-// Returns the body bytes on success (2xx) or an error for non-2xx status codes.
-// Attempts to parse standard Pelican error responses (SimpleApiResp).
-func handleAdminApiResponse(resp *http.Response) ([]byte, error) {
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to read response body (status: %s)", resp.Status)
-	}
-
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		return bodyBytes, nil // Success
-	}
-
-	// Attempt to parse a standard error response
-	var errorResp server_structs.SimpleApiResp
-	errMsg := fmt.Sprintf("server responded with %s", resp.Status)
-	if parseErr := json.Unmarshal(bodyBytes, &errorResp); parseErr == nil && errorResp.Msg != "" {
-		errMsg = fmt.Sprintf("%s: %s", errMsg, errorResp.Msg)
-	} else {
-		// Fallback if parsing fails or message is empty
-		if len(bodyBytes) > 0 && len(bodyBytes) < 512 { // Avoid logging huge bodies
-			errMsg += fmt.Sprintf(" (body: %s)", string(bodyBytes))
-		}
-	}
-
-	// Add specific messages for common auth errors
-	if resp.StatusCode == http.StatusUnauthorized { // 401
-		errMsg += " (check if token is valid or expired)"
-	} else if resp.StatusCode == http.StatusForbidden { // 403
-		errMsg += " (check if token has required admin privileges)"
-	}
-
-	return bodyBytes, errors.New(errMsg)
 }
 
 // Helper function to print downtimes in the specified format

--- a/cmd/downtime_update.go
+++ b/cmd/downtime_update.go
@@ -1,3 +1,21 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
 package main
 
 import (
@@ -31,10 +49,6 @@ var downtimeUpdateCmd = &cobra.Command{
 }
 
 func init() {
-	flags := downtimeUpdateCmd.Flags()
-	flags.StringP("server", "s", "", "Web URL of the target Pelican server (e.g. https://my-origin.com:8447)")
-	downtimeUpdateCmd.MarkFlagRequired("server")
-	flags.StringP("token", "t", "", "Path to the admin token file")
 	downtimeCmd.AddCommand(downtimeUpdateCmd)
 }
 
@@ -49,9 +63,6 @@ func updateDowntimeFunc(cmd *cobra.Command, args []string) error {
 	if err := config.InitClient(); err != nil {
 		log.Errorln("Failed to initialize client:", err)
 	}
-
-	serverURLStr, _ := cmd.Flags().GetString("server")
-	tokenLocation, _ := cmd.Flags().GetString("token")
 
 	apiURL, err := constructDowntimeApiURL(serverURLStr)
 	if err != nil {

--- a/cmd/downtime_update.go
+++ b/cmd/downtime_update.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/web_ui"
+)
+
+var downtimeUpdateCmd = &cobra.Command{
+	Use:   "update [uuid]",
+	Short: "Update an existing downtime period",
+	Long:  "Interactively prompt for downtime fields and send a PUT request to update the specified downtime period. Press Enter without typing anything to leave a field unchanged.",
+	Args:  cobra.ExactArgs(1),
+	RunE:  updateDowntimeFunc,
+}
+
+func init() {
+	flags := downtimeUpdateCmd.Flags()
+	flags.StringP("server", "s", "", "Web URL of the target Pelican server (e.g. https://my-origin.com:8447)")
+	downtimeUpdateCmd.MarkFlagRequired("server")
+	flags.StringP("token", "t", "", "Path to the admin token file")
+	downtimeCmd.AddCommand(downtimeUpdateCmd)
+}
+
+func updateDowntimeFunc(cmd *cobra.Command, args []string) error {
+	downtimeUUID := args[0]
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	// Initialize client
+	if err := config.InitClient(); err != nil {
+		log.Errorln("Failed to initialize client:", err)
+	}
+
+	serverURLStr, _ := cmd.Flags().GetString("server")
+	tokenLocation, _ := cmd.Flags().GetString("token")
+
+	apiURL, err := constructDowntimeApiURL(serverURLStr)
+	if err != nil {
+		return err
+	}
+
+	// Create a reader to prompt the user.
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Printf("Updating downtime record %s\n", downtimeUUID)
+	fmt.Println("Press Enter without typing anything to leave a field unchanged.")
+
+	// Build update payload (only non-empty values will be included)
+	updatePayload := web_ui.DowntimeInput{}
+
+	// Prompt for new Downtime Class
+	fmt.Println("Select new downtime Class (or leave blank to keep unchanged):")
+	classes := []string{
+		string(server_structs.SCHEDULED),
+		string(server_structs.UNSCHEDULED),
+	}
+	for {
+		for i, cls := range classes {
+			fmt.Printf("%d. %s\n", i+1, cls)
+		}
+		fmt.Print("Enter choice number: ")
+		classInput, err := reader.ReadString('\n')
+		if err != nil {
+			return errors.Wrap(err, "failed to read downtime class")
+		}
+		classInput = strings.TrimSpace(classInput)
+		if classInput == "" {
+			break // leave unchanged
+		}
+		choice, err := strconv.Atoi(classInput)
+		if err != nil || choice < 1 || choice > len(classes) {
+			fmt.Println("Invalid downtime class selection. Please try again.")
+			continue
+		}
+		updatePayload.Class = server_structs.Class(classes[choice-1])
+		break
+	}
+
+	// Prompt for new Description
+	fmt.Print("Enter new downtime Description (or leave blank to keep unchanged): ")
+	description, err := reader.ReadString('\n')
+	if err != nil {
+		return errors.Wrap(err, "failed to read description")
+	}
+	description = strings.TrimSpace(description)
+	if description != "" {
+		updatePayload.Description = description
+	}
+
+	// Prompt for new Severity
+	fmt.Println("Select new downtime Severity (or leave blank to keep unchanged):")
+	severities := []string{
+		string(server_structs.Outage),
+		string(server_structs.Severe),
+		string(server_structs.IntermittentOutage),
+		string(server_structs.NoSignificantOutageExpected),
+	}
+	for {
+		for i, sev := range severities {
+			fmt.Printf("%d. %s\n", i+1, sev)
+		}
+		fmt.Print("Enter choice number: ")
+		sevInput, err := reader.ReadString('\n')
+		if err != nil {
+			return errors.Wrap(err, "failed to read severity")
+		}
+		sevInput = strings.TrimSpace(sevInput)
+		if sevInput == "" {
+			break // leave unchanged
+		}
+		choice, err := strconv.Atoi(sevInput)
+		if err != nil || choice < 1 || choice > len(severities) {
+			fmt.Println("Invalid severity selection. Please try again.")
+			continue
+		}
+		updatePayload.Severity = server_structs.Severity(severities[choice-1])
+		break
+	}
+
+	// Prompt for new Start Time
+	fmt.Print("Enter new start time in UTC (YYYY-MM-DD HH:MM:SS) (or leave blank to keep unchanged): ")
+	startInput, err := reader.ReadString('\n')
+	if err != nil {
+		return errors.Wrap(err, "failed to read start time")
+	}
+	startInput = strings.TrimSpace(startInput)
+	if startInput != "" {
+		startTime, err := time.Parse("2006-01-02 15:04:05", startInput)
+		if err != nil {
+			return errors.Wrap(err, "Invalid start time format")
+		}
+		updatePayload.StartTime = startTime.UnixMilli()
+	}
+
+	// Prompt for new End Time
+	fmt.Print("Enter new end time in UTC (YYYY-MM-DD HH:MM:SS), or '-1' for indefinite (or leave blank to keep unchanged): ")
+	endInput, err := reader.ReadString('\n')
+	if err != nil {
+		return errors.Wrap(err, "failed to read end time")
+	}
+	endInput = strings.TrimSpace(endInput)
+	if endInput != "" {
+		var endTimeMilli int64
+		if endInput == "-1" {
+			endTimeMilli = -1
+		} else {
+			endTime, err := time.Parse("2006-01-02 15:04:05", endInput)
+			if err != nil {
+				return errors.Wrap(err, "Invalid end time format")
+			}
+			endTimeMilli = endTime.UnixMilli()
+		}
+		updatePayload.EndTime = endTimeMilli
+	}
+
+	// Marshal update payload.
+	payloadBytes, err := json.Marshal(updatePayload)
+	if err != nil {
+		return errors.Wrap(err, "Failed to marshal update payload")
+	}
+
+	// Get token using your provided helper.
+	tok, err := getToken(serverURLStr, tokenLocation)
+	if err != nil {
+		return err
+	}
+
+	// Build the API URL for update
+	targetURL, err := url.Parse(apiURL.String() + "/" + downtimeUUID)
+	if err != nil {
+		return errors.Wrap(err, "Failed to build delete API URL")
+	}
+
+	// Prepare and send the HTTP request.
+	req, err := http.NewRequestWithContext(ctx, "PUT", targetURL.String(), bytes.NewBuffer(payloadBytes))
+	if err != nil {
+		return errors.Wrap(err, "Failed to create HTTP request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.AddCookie(&http.Cookie{Name: "login", Value: tok})
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "pelican-client/"+config.GetVersion())
+
+	httpClient := &http.Client{Transport: config.GetTransport()}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "HTTP request failed")
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := handleAdminApiResponse(resp)
+	if err != nil {
+		return errors.Wrap(err, "Server update request failed")
+	}
+
+	fmt.Println("Downtime updated successfully:")
+	fmt.Println(string(bodyBytes))
+	return nil
+}

--- a/cmd/downtime_update.go
+++ b/cmd/downtime_update.go
@@ -45,14 +45,14 @@ var downtimeUpdateCmd = &cobra.Command{
 	Short: "Update an existing downtime period",
 	Long:  "Interactively prompt for downtime fields and send a PUT request to update the specified downtime period. Press Enter without typing anything to leave a field unchanged.",
 	Args:  cobra.ExactArgs(1),
-	RunE:  updateDowntimeFunc,
+	RunE:  updateDowntime,
 }
 
 func init() {
 	downtimeCmd.AddCommand(downtimeUpdateCmd)
 }
 
-func updateDowntimeFunc(cmd *cobra.Command, args []string) error {
+func updateDowntime(cmd *cobra.Command, args []string) error {
 	downtimeUUID := args[0]
 	ctx := cmd.Context()
 	if ctx == nil {
@@ -188,8 +188,7 @@ func updateDowntimeFunc(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "Failed to marshal update payload")
 	}
 
-	// Get token using your provided helper.
-	tok, err := getToken(serverURLStr, tokenLocation)
+	tok, err := fetchOrGenerateWebAPIAdminToken(serverURLStr, tokenLocation)
 	if err != nil {
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -144,6 +144,7 @@ func init() {
 	rootCmd.AddCommand(rootPluginCmd)
 	rootCmd.AddCommand(serveCmd)
 	rootCmd.AddCommand(generateCmd)
+	rootCmd.AddCommand(downtimeCmd)
 	rootCmd.AddCommand(config_printer.ConfigCmd)
 	preferredPrefix := config.GetPreferredPrefix()
 	rootCmd.Use = strings.ToLower(preferredPrefix.String())

--- a/database/server.go
+++ b/database/server.go
@@ -95,7 +95,7 @@ func GetIncompleteDowntimes() ([]server_structs.Downtime, error) {
 	var downtimes []server_structs.Downtime
 	currentTime := time.Now().UTC().UnixMilli()
 
-	err := ServerDatabase.Where("end_time > ? OR end_time = 0", currentTime).Find(&downtimes).Error
+	err := ServerDatabase.Where("end_time > ? OR end_time = ?", currentTime, server_structs.IndefiniteEndTime).Find(&downtimes).Error
 	if err != nil {
 		return nil, err
 	}

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -277,6 +277,10 @@ const (
 	NoSignificantOutageExpected Severity = "No Significant Outage Expected (you shouldn't notice)"
 )
 
+// Indicate the downtime is ongoing indefinitely.
+// We chose -1 to avoid the default value (0) of the int64 type
+const IndefiniteEndTime int64 = -1
+
 func (x XPelNs) GetName() string {
 	return "X-Pelican-Namespace"
 }

--- a/web_ui/server_api.go
+++ b/web_ui/server_api.go
@@ -40,10 +40,6 @@ type (
 	}
 )
 
-// Indicate the downtime is ongoing indefinitely.
-// We chose -1 to avoid the default value (0) of the int64 type
-const indefiniteEndTime int64 = -1
-
 func isValidClass(class server_structs.Class) bool {
 	validClasses := map[server_structs.Class]bool{
 		server_structs.SCHEDULED:   true,
@@ -66,7 +62,7 @@ func isValidTimeRange(startTime, endTime int64) bool {
 	// When endTime is indefinite, the downtime is considered ongoing forever
 	// Note: when you do a partial update and not provide startTime/endTime,
 	// they are 0 by default and should be considered as valid input
-	if endTime == indefiniteEndTime {
+	if endTime == server_structs.IndefiniteEndTime {
 		return startTime >= 0
 	}
 	return startTime <= endTime


### PR DESCRIPTION
This PR gives server admin the power of setting their own server's downtime via command line interface. The commands includes list, create, update, delete downtimes.

Examples:

`pelican downtime list --server=<WEB_URL>  [--status=incomplete(default)/all] [--output=json(default)/yaml]`

`pelican downtime create --server=<WEB_URL>`

`pelican downtime update <DOWNTIME_ID> --server=<WEB_URL>`

`pelican downtime delete <DOWNTIME_ID> --server=<WEB_URL>` 

Optional flag for above commands: `--token=<PATH_TO_TOKEN_FILE>` Use the token in specific file, instead of the token automatically generated by Pelican's current issuer key.