### PR TITLE
Add Warning Comment for Misaligned ServerAd and serverResponse structs

### DIFF
--- a/director/director_ui.go
+++ b/director/director_ui.go
@@ -65,6 +65,9 @@ type (
 	}
 
 	// A response struct for a server Ad that provides a detailed view into the servers data
+	// ** BE WARNED **
+	// This struct and associated functions need to be kept in sync with BOTH the listServerResponse
+	// and the server_structs.ServerAd.
 	serverResponse struct {
 		Name                string                           `json:"name"`
 		StorageType         server_structs.OriginStorageType `json:"storageType"`

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -122,6 +122,8 @@ type (
 		AdvertiseUrl string `json:"advertise_url"` // The URL / endpoint where the director expects ads to be POST'd
 	}
 
+	// ** BE WARNED **
+	// This struct needs to be kept in sync with BOTH the director/director_ui.go:listServerResponse and the director/director_ui.go:serverResponse
 	ServerAd struct {
 		ServerBaseAd
 		StorageType         OriginStorageType `json:"storageType"` // Always POSIX for caches


### PR DESCRIPTION
This PR addresses issue #2073. After a series of trials and conversations with @jhiemstrawisc. We concluded that it would be difficult to align these structures together without breaking compatibility. This PR adds a warning message comment so that hopefully to prevent misalignments in the future. 