### PR TITLE
XRootD config changes for v7.16

### DIFF
--- a/xrootd/launch_linux.go
+++ b/xrootd/launch_linux.go
@@ -100,7 +100,7 @@ func (plauncher PrivilegedXrootdLauncher) Launch(ctx context.Context) (context.C
 		env = append(env, "XDG_CACHE_HOME="+xdgCacheHome)
 	}
 
-	launcher := cap.NewLauncher(executable, []string{plauncher.Name(), "-f", "-s", pidFile, "-c", plauncher.configPath}, env)
+	launcher := cap.NewLauncher(executable, []string{plauncher.Name(), "-f", "-s", pidFile, "-c", plauncher.configPath, "-n", "origin"}, env)
 	launcher.Callback(func(attrs *syscall.ProcAttr, _ interface{}) error {
 		attrs.Files[1] = writeStdout.Fd()
 		attrs.Files[2] = writeStderr.Fd()

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -19,6 +19,7 @@ if exec xrootd
   xrd.protocol http:{{.Cache.CalculatedPort}} libXrdHttp.so
 fi
 ofs.osslib libXrdPss.so
+ofs.ckslib * libXrdPss.so
 ofs.osslib ++ libXrdOssStats.so
 pss.cachelib libXrdPfc.so
 xrd.tls {{.Cache.RunLocation}}/copied-tls-creds.crt {{.Cache.RunLocation}}/copied-tls-creds.crt


### PR DESCRIPTION
This adds configuration and runtime environment tweaks for XRootD ahead of upcoming v71.6 features (particularly, allows for checksums to be passed through and is needed for some xrdcl-pelican unit tests).