### PR TITLE
Pelicanize "NEAREST_CACHE" env var with 'Client.PreferredCaches'

### DIFF
--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -1,0 +1,67 @@
+/***************************************************************
+*
+* Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
+
+package main
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/pelicanplatform/pelican/param"
+)
+
+// Given an input map of flag-->viper config, convert any comma-delineated
+// input lists and store them as a string slice with Viper
+func commaFlagsListToViperSlice(cmd *cobra.Command, flags map[string]string) {
+	for flagName, viperName := range flags {
+		if flagValue, _ := cmd.Flags().GetString(flagName); flagValue != "" {
+			viper.Set(viperName, strings.Split(flagValue, ","))
+		}
+	}
+}
+
+// To be invoked by cmds that need to pass a slice of "preferred" caches
+// as an option when invoking a new transfer job/client.
+func getPreferredCaches() ([]*url.URL, error) {
+	var caches []*url.URL
+	for _, cacheStr := range param.Client_PreferredCaches.GetStringSlice() {
+		// If the current entry contains a comma because it comes directly from an env var
+		// and hasn't yet been converted to a string slice, split it into multiple entries
+		if strings.Contains(cacheStr, ",") {
+			for _, cache := range strings.Split(cacheStr, ",") {
+				cache, err := url.Parse(strings.TrimSpace(cache))
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to parse cache URL from preferred caches config: %s", cacheStr)
+				}
+				caches = append(caches, cache)
+			}
+		} else {
+			cache, err := url.Parse(cacheStr)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to parse cache URL from preferred caches config: %s", cacheStr)
+			}
+			caches = append(caches, cache)
+		}
+	}
+
+	return caches, nil
+}

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -53,7 +53,8 @@ func init() {
 	// Being case-insensitive
 	execName = strings.ToLower(execName)
 	flagSet := copyCmd.Flags()
-	flagSet.StringP("cache", "c", "", "Cache to use")
+	flagSet.StringP("cache", "c", "", `A comma-separated list of preferred caches to try for the transfer, where a "+" in the list indicates
+the client should fallback to discovered caches if all preferred caches fail.`)
 	flagSet.StringP("token", "t", "", "Token file to use for transfer")
 	flagSet.BoolP("recursive", "r", false, "Recursively copy a collection.  Forces methods to only be http to get the freshest collection contents")
 	flagSet.StringP("cache-list-name", "n", "xroot", "(Deprecated) Cache list to use, currently either xroot or xroots; may be ignored")

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -1,25 +1,24 @@
 /***************************************************************
- *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you
- * may not use this file except in compliance with the License.  You may
- * obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- ***************************************************************/
+*
+* Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
 
 package main
 
 import (
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,11 +26,11 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
-	"github.com/pelicanplatform/pelican/utils"
 )
 
 var (
@@ -41,6 +40,9 @@ var (
 		Use:   "copy {source ...} {destination}",
 		Short: "Copy a file to/from a Pelican federation",
 		Run:   copyMain,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			commaFlagsListToViperSlice(cmd, map[string]string{"cache": param.Client_PreferredCaches.GetName()})
+		},
 	}
 )
 
@@ -56,6 +58,10 @@ func init() {
 	flagSet.BoolP("recursive", "r", false, "Recursively copy a collection.  Forces methods to only be http to get the freshest collection contents")
 	flagSet.StringP("cache-list-name", "n", "xroot", "(Deprecated) Cache list to use, currently either xroot or xroots; may be ignored")
 	flagSet.Lookup("cache-list-name").Hidden = true
+
+	if err := viper.BindPFlag(param.Client_PreferredCaches.GetName(), copyCmd.Flags().Lookup("cache")); err != nil {
+		panic(err)
+	}
 	// All the deprecated or hidden flags that are only relevant if we are in historical "stashcp mode"
 	if strings.HasPrefix(execName, "stashcp") {
 		copyCmd.Use = "stashcp {source ...} {destination}"
@@ -139,17 +145,11 @@ func copyMain(cmd *cobra.Command, args []string) {
 	log.Debugln("Sources:", source)
 	log.Debugln("Destination:", dest)
 
-	// Check for manually entered cache to use
-	var preferredCache string
-	if nearestCache, ok := os.LookupEnv("NEAREST_CACHE"); ok {
-		preferredCache = nearestCache
-	} else if cache, _ := cmd.Flags().GetString("cache"); cache != "" {
-		preferredCache = cache
-	}
-	var caches []*url.URL
-	caches, err = utils.GetPreferredCaches(preferredCache)
+	// Get any configured preferred caches, to be passed along to the client
+	// as options.
+	caches, err := getPreferredCaches()
 	if err != nil {
-		log.Errorln(err)
+		log.Errorln("Failed to get preferred caches:", err)
 		os.Exit(1)
 	}
 

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
@@ -60,9 +59,6 @@ the client should fallback to discovered caches if all preferred caches fail.`)
 	flagSet.StringP("cache-list-name", "n", "xroot", "(Deprecated) Cache list to use, currently either xroot or xroots; may be ignored")
 	flagSet.Lookup("cache-list-name").Hidden = true
 
-	if err := viper.BindPFlag(param.Client_PreferredCaches.GetName(), copyCmd.Flags().Lookup("cache")); err != nil {
-		panic(err)
-	}
 	// All the deprecated or hidden flags that are only relevant if we are in historical "stashcp mode"
 	if strings.HasPrefix(execName, "stashcp") {
 		copyCmd.Use = "stashcp {source ...} {destination}"

--- a/cmd/object_get.go
+++ b/cmd/object_get.go
@@ -45,7 +45,8 @@ var (
 
 func init() {
 	flagSet := getCmd.Flags()
-	flagSet.StringP("cache", "c", "", "Cache to use")
+	flagSet.StringP("cache", "c", "", `A comma-separated list of preferred caches to try for the transfer, where a "+" in the list indicates
+the client should fallback to discovered caches if all preferred caches fail.`)
 	flagSet.StringP("token", "t", "", "Token file to use for transfer")
 	flagSet.BoolP("recursive", "r", false, "Recursively download a collection.  Forces methods to only be http to get the freshest collection contents")
 	flagSet.StringP("cache-list-name", "n", "xroot", "(Deprecated) Cache list to use, currently either xroot or xroots; may be ignored")

--- a/cmd/object_get.go
+++ b/cmd/object_get.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
@@ -53,10 +52,6 @@ the client should fallback to discovered caches if all preferred caches fail.`)
 	flagSet.Lookup("cache-list-name").Hidden = true
 	flagSet.String("caches", "", "A JSON file containing the list of caches")
 	objectCmd.AddCommand(getCmd)
-
-	if err := viper.BindPFlag(param.Client_PreferredCaches.GetName(), getCmd.Flags().Lookup("cache")); err != nil {
-		panic(err)
-	}
 }
 
 func getMain(cmd *cobra.Command, args []string) {

--- a/cmd/object_prestage.go
+++ b/cmd/object_prestage.go
@@ -46,7 +46,8 @@ var (
 
 func init() {
 	flagSet := prestageCmd.Flags()
-	flagSet.StringP("cache", "c", "", "Cache to use")
+	flagSet.StringP("cache", "c", "", `A comma-separated list of preferred caches to try for the transfer, where a "+" in the list indicates
+the client should fallback to discovered caches if all preferred caches fail.`)
 	flagSet.StringP("token", "t", "", "Token file to use for transfer")
 	objectCmd.AddCommand(prestageCmd)
 

--- a/cmd/object_prestage.go
+++ b/cmd/object_prestage.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
@@ -50,10 +49,6 @@ func init() {
 the client should fallback to discovered caches if all preferred caches fail.`)
 	flagSet.StringP("token", "t", "", "Token file to use for transfer")
 	objectCmd.AddCommand(prestageCmd)
-
-	if err := viper.BindPFlag(param.Client_PreferredCaches.GetName(), prestageCmd.Flags().Lookup("cache")); err != nil {
-		panic(err)
-	}
 }
 
 func prestageMain(cmd *cobra.Command, args []string) {

--- a/cmd/object_sync.go
+++ b/cmd/object_sync.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
@@ -51,10 +50,6 @@ func init() {
 the client should fallback to discovered caches if all preferred caches fail.`)
 	flagSet.StringP("token", "t", "", "Token file to use for transfer")
 	objectCmd.AddCommand(syncCmd)
-
-	if err := viper.BindPFlag(param.Client_PreferredCaches.GetName(), syncCmd.Flags().Lookup("cache")); err != nil {
-		panic(err)
-	}
 }
 
 func getLastScheme(scheme string) string {

--- a/cmd/object_sync.go
+++ b/cmd/object_sync.go
@@ -47,7 +47,8 @@ var (
 
 func init() {
 	flagSet := syncCmd.Flags()
-	flagSet.StringP("cache", "c", "", "Cache to use")
+	flagSet.StringP("cache", "c", "", `A comma-separated list of preferred caches to try for the transfer, where a "+" in the list indicates
+the client should fallback to discovered caches if all preferred caches fail.`)
 	flagSet.StringP("token", "t", "", "Token file to use for transfer")
 	objectCmd.AddCommand(syncCmd)
 

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -44,7 +44,6 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/pelican_url"
-	"github.com/pelicanplatform/pelican/utils"
 )
 
 var (
@@ -403,18 +402,12 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 		}
 	}()
 
-	// Check for local cache
-	var caches []*url.URL
-	if nearestCache, ok := os.LookupEnv("NEAREST_CACHE"); ok && nearestCache != "" {
-		caches, err = utils.GetPreferredCaches(nearestCache)
-		if err != nil {
-			return
-		}
-	} else if nearestCache, ok := os.LookupEnv("PELICAN_NEAREST_CACHE"); ok && nearestCache != "" {
-		caches, err = utils.GetPreferredCaches(nearestCache)
-		if err != nil {
-			return
-		}
+	// Get any configured preferred caches, to be passed along to the client
+	// as options.
+	caches, err := getPreferredCaches()
+	if err != nil {
+		log.Errorln("Failed to get preferred caches:", err)
+		os.Exit(1)
 	}
 
 	tc, err := te.NewClient(client.WithAcquireToken(false))

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -1,20 +1,20 @@
 /***************************************************************
- *
- * Copyright (C) 2024, University of Nebraska-Lincoln
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you
- * may not use this file except in compliance with the License.  You may
- * obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- ***************************************************************/
+*
+* Copyright (C) 2025, University of Nebraska-Lincoln
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
 
 package main
 

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -406,8 +406,7 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 	// as options.
 	caches, err := getPreferredCaches()
 	if err != nil {
-		log.Errorln("Failed to get preferred caches:", err)
-		os.Exit(1)
+		return errors.Wrap(err, "unable to determine whether to use any preferred caches")
 	}
 
 	tc, err := te.NewClient(client.WithAcquireToken(false))

--- a/config/config.go
+++ b/config/config.go
@@ -1,20 +1,20 @@
 /***************************************************************
- *
- * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you
- * may not use this file except in compliance with the License.  You may
- * obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- ***************************************************************/
+*
+* Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
 
 package config
 
@@ -1753,6 +1753,19 @@ func SetClientDefaults(v *viper.Viper) error {
 			viper.SetDefault(param.Client_DisableHttpProxy.GetName(), param.DisableHttpProxy.GetBool())
 		}
 
+		// Handle legacy config for (PELICAN_)NEAREST_CACHE
+		if configuredCaches, isSet := os.LookupEnv("NEAREST_CACHE"); isSet {
+			log.Warningf("You are using a legacy/deprecated parameter 'NEAREST_CACHE' to indicate preferred caches. Please use %s instead", param.Client_PreferredCaches.GetName())
+			viper.Set(param.Client_PreferredCaches.GetName(), strings.Split(configuredCaches, ","))
+		} else {
+			for _, prefix := range prefixes {
+				if val, isSet := os.LookupEnv(prefix.String() + "_NEAREST_CACHE"); isSet {
+					log.Warningf("You are using a legacy/deprecated parameter '%s_NEAREST_CACHE' to indicate preferred caches. Please use %s instead", prefix.String(), param.Client_PreferredCaches.GetName())
+					viper.Set(param.Client_PreferredCaches.GetName(), strings.Split(val, ","))
+					break
+				}
+			}
+		}
 	}
 
 	// Some client actions may take different defaults depending on whether we detect the plugin

--- a/docs/pages/advanced-usage/plugin.mdx
+++ b/docs/pages/advanced-usage/plugin.mdx
@@ -56,8 +56,12 @@ For example, to configure the Plugin to transfer objects only via a specific cac
 you would use the following line:
 
 ```
-environment = "PELICAN_NEAREST_CACHE=https://address.to.desired.cache:port"
+environment = "PELICAN_CLIENT_PREFERREDCACHES=https://address.to.desired.cache:port"
 ```
+
+> **Note:** Plugins older than v7.16.0 should use the `PELICAN_NEAREST_CACHE` environment variable,
+as `PELICAN_CLIENT_PREFERREDCACHES` was introduced in v7.16.0 with the intention of deprecating
+`PELICAN_NEAREST_CACHE`.
 
 > This particular example would be useful for testing that a specific cache is operational
 > and accessible from the EP the job is running at.

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -573,7 +573,7 @@ hidden: true
 ---
 name: Client.PreferredCaches
 description: |+
-  A list of preferred caches the Pelican client/plugin should use when interacting with a remote object. There are two configuration options:
+  A list of preferred cache hostname/ports the Pelican client/plugin should use when interacting with a remote object. There are two configuration options:
     - A list containing `+` as a discrete element
     - A list with no `+`
 
@@ -588,12 +588,12 @@ description: |+
   Caches are generally tried in the order they're presented. For example, the configuration:
   ```yaml
   Client:
-    PreferredCaches: ["cache1", "cache2", "+"]
+    PreferredCaches: ["https://cache1.com:8443", "https://cache2.com:8443", "+"]
   ```
   should result in trying `cache1`, then `cache2`, and finally any caches discovered by the Director (if needed).
 
   When set via the `PELICAN_CLIENT_PREFERREDCACHES` environment variable, caches should be space-separated, e.g.:
-  `PELICAN_CLIENT_PREFERREDCACHES="cache cache2 +"`
+  `PELICAN_CLIENT_PREFERREDCACHES="https://cache1.com:8443 https://cache2.com:8443 +"`
 type: stringSlice
 default: none
 components: ["client"]

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -580,6 +580,11 @@ description: |+
   When `+` is included in the list, the client should _first_ try the provided caches, then fall back to any discovered via the Director. If no
   `+` is included, the client should try _only_ the preferred caches and fail if none is able to provide the object.
 
+  > Use of this configuration, especially when omitting the `+`, 
+  > *bypasses the Director and any of its potential logic for cache selection*. 
+  > As such, this configuration should only be used for testing
+  > or for preferring an on- or near-premises cache. 
+
   Caches are generally tried in the order they're presented. For example, the configuration:
   ```yaml
   Client:

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -571,6 +571,28 @@ default: false
 components: ["client"]
 hidden: true
 ---
+name: Client.PreferredCaches
+description: |+
+  A list of preferred caches the Pelican client/plugin should use when interacting with a remote object. There are two configuration options:
+    - A list containing `+` as a discrete element
+    - A list with no `+`
+
+  When `+` is included in the list, the client should _first_ try the provided caches, then fall back to any discovered via the Director. If no
+  `+` is included, the client should try _only_ the preferred caches and fail if none is able to provide the object.
+
+  Caches are generally tried in the order they're presented. For example, the configuration:
+  ```yaml
+  Client:
+    PreferredCaches: ["cache1", "cache2", "+"]
+  ```
+  should result in trying `cache1`, then `cache2`, and finally any caches discovered by the Director (if needed).
+
+  When set via the `PELICAN_CLIENT_PREFERREDCACHES` environment variable, caches should be comma-separated, e.g.:
+  `PELICAN_CLIENT_PREFERREDCACHES=cache1,cache2,+`
+type: stringSlice
+default: none
+components: ["client"]
+---
 ############################
 #   Origin-level Configs   #
 ############################

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -574,11 +574,12 @@ hidden: true
 name: Client.PreferredCaches
 description: |+
   A list of preferred cache hostname/ports the Pelican client/plugin should use when interacting with a remote object. There are two configuration options:
-    - A list containing `+` as a discrete element
+    - A list containing `+` as its last element
     - A list with no `+`
 
-  When `+` is included in the list, the client should _first_ try the provided caches, then fall back to any discovered via the Director. If no
-  `+` is included, the client should try _only_ the preferred caches and fail if none is able to provide the object.
+  When `+` is last in the list, the client should _first_ try the provided caches, then fall back to any discovered via the Director. If no
+  `+` is included, the client should try _only_ the preferred caches and fail if none is able to provide the object. A `+` anywhere else in the list
+  will generate an error.
 
   > Use of this configuration, especially when omitting the `+`,
   > *bypasses the Director and any of its potential logic for cache selection*.

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -592,8 +592,8 @@ description: |+
   ```
   should result in trying `cache1`, then `cache2`, and finally any caches discovered by the Director (if needed).
 
-  When set via the `PELICAN_CLIENT_PREFERREDCACHES` environment variable, caches should be comma-separated, e.g.:
-  `PELICAN_CLIENT_PREFERREDCACHES=cache1,cache2,+`
+  When set via the `PELICAN_CLIENT_PREFERREDCACHES` environment variable, caches should be space-separated, e.g.:
+  `PELICAN_CLIENT_PREFERREDCACHES="cache cache2 +"`
 type: stringSlice
 default: none
 components: ["client"]

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -580,10 +580,10 @@ description: |+
   When `+` is included in the list, the client should _first_ try the provided caches, then fall back to any discovered via the Director. If no
   `+` is included, the client should try _only_ the preferred caches and fail if none is able to provide the object.
 
-  > Use of this configuration, especially when omitting the `+`, 
-  > *bypasses the Director and any of its potential logic for cache selection*. 
+  > Use of this configuration, especially when omitting the `+`,
+  > *bypasses the Director and any of its potential logic for cache selection*.
   > As such, this configuration should only be used for testing
-  > or for preferring an on- or near-premises cache. 
+  > or for preferring an on- or near-premises cache.
 
   Caches are generally tried in the order they're presented. For example, the configuration:
   ```yaml

--- a/github_scripts/citests.sh
+++ b/github_scripts/citests.sh
@@ -103,7 +103,7 @@ if [ ! -e "$SOCKET_DIR/data/ospool/uc-shared/public/OSG-Staff/validation/test.tx
 fi
 
 # Test we work with PELICAN_NEAREST_CACHE as well
-PELICAN_NEAREST_CACHE="unix://$SOCKET_DIR/socket" ./stash_plugin -d osdf:///ospool/uc-shared/public/OSG-Staff/validation/test.txt /dev/null
+PELICAN_PREFFERREDCACHES="unix://$SOCKET_DIR/socket" ./stash_plugin -d osdf:///ospool/uc-shared/public/OSG-Staff/validation/test.txt /dev/null
 exit_status=$?
 
 if ! [[ "$exit_status" = 0 ]]; then

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -302,6 +302,7 @@ var (
 	Cache_DataLocations = StringSliceParam{"Cache.DataLocations"}
 	Cache_MetaLocations = StringSliceParam{"Cache.MetaLocations"}
 	Cache_PermittedNamespaces = StringSliceParam{"Cache.PermittedNamespaces"}
+	Client_PreferredCaches = StringSliceParam{"Client.PreferredCaches"}
 	ConfigLocations = StringSliceParam{"ConfigLocations"}
 	Director_CacheResponseHostnames = StringSliceParam{"Director.CacheResponseHostnames"}
 	Director_FilteredServers = StringSliceParam{"Director.FilteredServers"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -64,6 +64,7 @@ type Config struct {
 		IsPlugin bool `mapstructure:"isplugin" yaml:"IsPlugin"`
 		MaximumDownloadSpeed int `mapstructure:"maximumdownloadspeed" yaml:"MaximumDownloadSpeed"`
 		MinimumDownloadSpeed int `mapstructure:"minimumdownloadspeed" yaml:"MinimumDownloadSpeed"`
+		PreferredCaches []string `mapstructure:"preferredcaches" yaml:"PreferredCaches"`
 		SlowTransferRampupTime time.Duration `mapstructure:"slowtransferrampuptime" yaml:"SlowTransferRampupTime"`
 		SlowTransferWindow time.Duration `mapstructure:"slowtransferwindow" yaml:"SlowTransferWindow"`
 		StoppedTransferTimeout time.Duration `mapstructure:"stoppedtransfertimeout" yaml:"StoppedTransferTimeout"`
@@ -415,6 +416,7 @@ type configWithType struct {
 		IsPlugin struct { Type string; Value bool }
 		MaximumDownloadSpeed struct { Type string; Value int }
 		MinimumDownloadSpeed struct { Type string; Value int }
+		PreferredCaches struct { Type string; Value []string }
 		SlowTransferRampupTime struct { Type string; Value time.Duration }
 		SlowTransferWindow struct { Type string; Value time.Duration }
 		StoppedTransferTimeout struct { Type string; Value time.Duration }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -21,7 +21,6 @@ package utils
 import (
 	"encoding/json"
 	"net"
-	"net/url"
 	"os"
 	"regexp"
 	"slices"
@@ -65,22 +64,6 @@ func SnakeCaseToHumanReadable(input string) string {
 		words[i] = cases.Title(language.English).String(word)
 	}
 	return strings.Join(words, " ")
-}
-
-// GetPreferredCaches parses the caches it is given and returns it as a list of url's
-func GetPreferredCaches(preferredCaches string) (caches []*url.URL, err error) {
-	if preferredCaches != "" {
-		cacheList := strings.Split(preferredCaches, ",")
-		for _, cache := range cacheList {
-			if preferredCacheURL, err := url.Parse(cache); err != nil {
-				return nil, errors.Errorf("Unable to parse preferred cache (%s) as URL: %s", cache, err.Error())
-			} else {
-				caches = append(caches, preferredCacheURL)
-				log.Debugln("Preferred cache for transfer:", preferredCacheURL)
-			}
-		}
-	}
-	return
 }
 
 func maskIPv4With24(ip net.IP) (masked string, ok bool) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,20 +1,20 @@
 /***************************************************************
- *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you
- * may not use this file except in compliance with the License.  You may
- * obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- ***************************************************************/
+*
+* Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
 
 package utils
 


### PR DESCRIPTION
This standardizes our use of `Client.PreferredCaches` internally as a
string slice, bearing the "+ means continue" semantics. Previously
we used an entirely undocumented environment variable `NEAREST_CACHE`,
and in only a subset of places we also checked for `PELICAN_NEAREST_CACHE`.
With the new approach, we still handle these configurations, but immediately
stuff them into viper to be used later in a standardized way.