### PR TITLE
Enable caches to update lots on startup

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1358,7 +1358,7 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 			pelicanDirs = append(pelicanDirs, param.LocalCache_RunLocation.GetString())
 		}
 		if currentServers.IsEnabled(server_structs.CacheType) && param.Cache_EnableLotman.GetBool() {
-			pelicanDirs = append(pelicanDirs, param.Lotman_LotHome.GetString(), param.Lotman_DbLocation.GetString())
+			pelicanDirs = append(pelicanDirs, param.Lotman_LotHome.GetString())
 		}
 		if (currentServers.IsEnabled(server_structs.OriginType) || currentServers.IsEnabled(server_structs.CacheType)) && param.Shoveler_Enable.GetBool() {
 			pelicanDirs = append(pelicanDirs, param.Shoveler_QueueDirectory.GetString())

--- a/lotman/lotman_test.go
+++ b/lotman/lotman_test.go
@@ -68,7 +68,7 @@ func setupLotmanFromConf(t *testing.T, readConfig bool, name string, discUrl str
 	// Load in our config
 	viper.Set("Cache.HighWaterMark", "100g")
 	viper.Set("Cache.LowWaterMark", "50g")
-	viper.Set("Debug", true)
+	viper.Set("Logging.Level", "debug")
 	if readConfig {
 		viper.SetConfigType("yaml")
 		err := viper.ReadConfig(strings.NewReader(yamlMockup))
@@ -374,6 +374,99 @@ func TestUpdateLot(t *testing.T) {
 	require.Equal(t, int64(84), lot.MPA.MaxNumObjects.Value)
 	require.Equal(t, "/test-1-updated", lot.Paths[0].Path)
 	require.False(t, lot.Paths[0].Recursive)
+}
+
+func TestAddToLot(t *testing.T) {
+	server_utils.ResetTestState()
+	server := getMockDiscoveryHost()
+	viper.Set("Federation.DiscoveryUrl", server.URL)
+	success, cleanup := setupLotmanFromConf(t, true, "LotmanInitConf", server.URL, nil)
+	defer cleanup()
+	require.True(t, success)
+
+	newLotPath := LotPath{
+		Path: "/a/new/path",
+		Recursive: true,
+	}
+	addition := LotAddition{
+		LotName: "test-1",
+		Paths: []LotPath{newLotPath},
+		Parents: []string{"default"},
+	}
+
+	err := AddToLot(&addition, server.URL)
+	require.NoError(t, err, "Failed to add to lot")
+	// Only after adding values to the lot do we set the lot name
+	// -- this lets us do the comparison later, as `GetLot()`` sets this value but
+	// `AddToLot()`` doesn't accept it
+	newLotPath.LotName = "test-1"
+
+	// Now check that the addition was successful
+	lot, err := GetLot("test-1", false)
+	require.NoError(t, err, "Failed to get lot")
+	require.Equal(t, "test-1", lot.LotName)
+	require.Equal(t, 2, len(lot.Paths), fmt.Sprintf("Expected 2 paths, got %+v", lot.Paths))
+	require.Contains(t, lot.Paths, newLotPath)
+}
+
+func TestRemoveLotParents(t *testing.T) {
+	server_utils.ResetTestState()
+	server := getMockDiscoveryHost()
+	viper.Set("Federation.DiscoveryUrl", server.URL)
+	success, cleanup := setupLotmanFromConf(t, true, "LotmanInitConf", server.URL, nil)
+	defer cleanup()
+	require.True(t, success)
+
+	// First add default lot as parent to test-1, then remove it. We do this
+	// because lotman won't let us remove _all_ parents.
+	addition := LotAddition{
+		LotName: "test-1",
+		Parents: []string{"default"},
+	}
+	err := AddToLot(&addition, server.URL)
+	require.NoError(t, err, "Failed to add to lot")
+	// Now check that the addition was successful
+	lot, err := GetLot("test-1", false)
+	require.NoError(t, err, "Failed to get lot")
+	require.Equal(t, "test-1", lot.LotName)
+	require.Equal(t, 2, len(lot.Parents), fmt.Sprintf("Expected 2 parents, got %+v", lot.Parents))
+	require.Contains(t, lot.Parents, "default")
+
+	// Now remove the default parent
+	removal := LotParentRemoval{
+		LotName: "test-1",
+		Parents: []string{"default"},
+	}
+	err = RemoveLotParents(&removal, server.URL)
+	require.NoError(t, err, "Failed to remove lot parents")
+	// Now check that the removal was successful
+	lot, err = GetLot("test-1", false)
+	require.NoError(t, err, "Failed to get lot")
+	require.Equal(t, "test-1", lot.LotName)
+	require.Equal(t, 1, len(lot.Parents), fmt.Sprintf("Expected 1 parent, got %+v", lot.Parents))
+	require.NotContains(t, lot.Parents, "default")
+}
+
+func TestRemoveLotPaths(t *testing.T) {
+	server_utils.ResetTestState()
+	server := getMockDiscoveryHost()
+	viper.Set("Federation.DiscoveryUrl", server.URL)
+	success, cleanup := setupLotmanFromConf(t, true, "LotmanInitConf", server.URL, nil)
+	defer cleanup()
+	require.True(t, success)
+
+	// Remove the pre-configured path
+	removal := LotPathRemoval{
+		Paths: []string{"/test-1"},
+	}
+
+	err := RemoveLotPaths(&removal, server.URL)
+	require.NoError(t, err, "Failed to remove lot paths")
+	// Now check that the removal was successful
+	lot, err := GetLot("test-1", false)
+	require.NoError(t, err, "Failed to get lot")
+	require.Equal(t, "test-1", lot.LotName)
+	require.Equal(t, 0, len(lot.Paths), fmt.Sprintf("Expected 0 paths, got %+v", lot.Paths))
 }
 
 func TestDeleteLotsRec(t *testing.T) {

--- a/lotman/lotman_utils.go
+++ b/lotman/lotman_utils.go
@@ -1,0 +1,312 @@
+//go:build lotman && linux && !ppc64le
+
+/***************************************************************
+*
+* Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
+
+// The LotMan library is used for managing storage in Pelican caches. For more information, see:
+// https://github.com/pelicanplatform/lotman
+package lotman
+
+import (
+	"reflect"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+type UpdateInfo[T comparable] struct {
+	Remove bool
+	Update T
+	Add    bool
+}
+
+// Helper function that converts a slice of type T to a set (map) of type T.
+func sliceToSet[T comparable](s []T) map[T]struct{} {
+	set := make(map[T]struct{}, len(s))
+	for _, item := range s {
+		set[item] = struct{}{}
+	}
+	return set
+}
+
+// Given two slices (lotman paths or parents), this function determines how to construct
+// an update map for the Lotman API. The nuance and special handling in this function comes
+// from a few Lotman peculiarities -- in particular, an update over a simple path list:
+//
+//	[path1, path2] -> [path1, path3, path4]
+//
+// could be constructed with lotman operations as:
+//  1. "update path2 to path3" and "add path4" OR
+//  2. "update path2 to path4" and "add path3" OR
+//  3. "remove path2" and "add path3" and "add path4"
+//
+// Because Lotman prevents you from deleting _all_ parents associated with a lot, we avoid
+// removals where we can and prefer options 1/2, which don't require a remove operation at all.
+// This function determines how to construct these update primitives based on the logic that
+// (remove + add) = update
+func getModMap[T comparable](existing, new []T) map[T]UpdateInfo[T] {
+	if len(existing) == 0 && len(new) == 0 {
+		return nil
+	}
+
+	updateMap := map[T]UpdateInfo[T]{}
+
+	eSet := sliceToSet(existing)
+	nSet := sliceToSet(new)
+
+	visited := make(map[T]bool)
+	removedItems := map[T]struct{}{}
+	addedItems := map[T]struct{}{}
+
+	// Check for removals
+	for eItem := range eSet {
+		if _, inNSet := nSet[eItem]; !inNSet {
+			updateMap[eItem] = UpdateInfo[T]{Remove: true}
+			visited[eItem] = true
+			removedItems[eItem] = struct{}{}
+		} else {
+			visited[eItem] = true
+		}
+	}
+
+	// Check for additions
+	for nItem := range nSet {
+		if _, exists := visited[nItem]; exists {
+			continue
+		}
+		if _, inESet := eSet[nItem]; !inESet {
+			updateMap[nItem] = UpdateInfo[T]{Add: true}
+			visited[nItem] = true
+			addedItems[nItem] = struct{}{}
+		}
+	}
+
+	// Convert removals + additions into updates where possible
+	numRemoved := len(removedItems)
+	numAdded := len(addedItems)
+	if numRemoved > 0 && numAdded > 0 {
+		if numRemoved <= numAdded {
+			for removedItem := range removedItems {
+				for addedItem := range addedItems {
+					updateMap[removedItem] = UpdateInfo[T]{Update: addedItem}
+					delete(updateMap, addedItem)
+					delete(addedItems, addedItem)
+					break
+				}
+			}
+		} else {
+			for addedItem := range addedItems {
+				for removedItem := range removedItems {
+					updateMap[removedItem] = UpdateInfo[T]{Update: addedItem}
+					delete(updateMap, addedItem)
+					delete(removedItems, removedItem)
+					break
+				}
+			}
+		}
+	}
+
+	return updateMap
+}
+
+// CompareMPAs checks whether two MPA structs have the same values, including dereferencing pointers.
+func compareMPAs(mpa1, mpa2 *MPA) bool {
+	if mpa1 == nil && mpa2 == nil {
+		return true
+	}
+	if mpa1 == nil || mpa2 == nil {
+		return false
+	}
+	if !reflect.DeepEqual(mpa1.DedicatedGB, mpa2.DedicatedGB) {
+		return false
+	}
+	if !reflect.DeepEqual(mpa1.OpportunisticGB, mpa2.OpportunisticGB) {
+		return false
+	}
+	if !reflect.DeepEqual(mpa1.MaxNumObjects, mpa2.MaxNumObjects) {
+		return false
+	}
+	if !reflect.DeepEqual(mpa1.CreationTime, mpa2.CreationTime) {
+		return false
+	}
+	if !reflect.DeepEqual(mpa1.ExpirationTime, mpa2.ExpirationTime) {
+		return false
+	}
+	if !reflect.DeepEqual(mpa1.DeletionTime, mpa2.DeletionTime) {
+		return false
+	}
+	return true
+}
+
+// Check various lot fields for the purpose of determining whether a lot needs an update.
+// Note that we can't use reflect.DeepEqual here because we need to ignore some fields from the
+// lot we grabbed via the `GetLot()` invocation (e.g. children, usage, etc.)
+func lotRequiresUpdate(existingLot, newLot *Lot) (bool, error) {
+	if existingLot == nil && newLot == nil {
+		return false, nil
+	}
+
+	if existingLot == nil || newLot == nil {
+		return false, errors.New("internal error -- lotRequiresUpdate was passed one nil lot")
+	}
+
+	// Compare fields explicitly, excluding the ones you want to ignore
+	if existingLot.LotName != newLot.LotName {
+		return false, errors.New("lot names do not match")
+	}
+
+	if existingLot.Owner != newLot.Owner {
+		return true, nil
+	}
+	if !reflect.DeepEqual(existingLot.Parents, newLot.Parents) {
+		return true, nil
+	}
+	if !reflect.DeepEqual(existingLot.Paths, newLot.Paths) {
+		return true, nil
+	}
+
+	if !compareMPAs(existingLot.MPA, newLot.MPA) {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// Given two lots, construct the relevant JSON objects for passing to Lotman's CRUD functions (if needed)
+func getLotUpdateJSONs(existingLot *Lot, newLot *Lot) (*LotUpdate, *LotAddition, *LotPathRemoval, *LotParentRemoval, error) {
+
+	lotRequiresUpdate, err := lotRequiresUpdate(existingLot, newLot)
+	if err != nil {
+		if existingLot == nil {
+			return nil, nil, nil, nil, errors.New("internal error -- unable to check whether lot requires update: existing lot is nil")
+		} else {
+			return nil, nil, nil, nil, errors.Errorf("unable to check whether lot %s requires update: %v", existingLot.LotName, err)
+		}
+	}
+
+	if !lotRequiresUpdate {
+		log.Debugf("Lot '%s' already exists and doesn't need to be updated", newLot.LotName)
+		return nil, nil, nil, nil, nil
+	}
+
+	// Otherwise, there's something to do. Start constructing relevant JSON objects
+	// for passing to Lotman's CRUD functions.
+	log.Debugf("Updating/adding to lot '%s'", newLot.LotName)
+
+	var lotUpdate *LotUpdate
+	var lotAddition *LotAddition
+	var lotPathRemoval *LotPathRemoval
+	var lotParentRemoval *LotParentRemoval
+
+	// Check for owner update
+	if existingLot.Owner != newLot.Owner {
+		if lotUpdate == nil {
+			lotUpdate = &LotUpdate{}
+		}
+		lotUpdate.Owner = &newLot.Owner
+	}
+
+	// Check for MPA update
+	// If the MPAs are different, we update the entire MPA
+	if !compareMPAs(existingLot.MPA, newLot.MPA) {
+		if lotUpdate == nil {
+			lotUpdate = &LotUpdate{}
+		}
+		lotUpdate.MPA = newLot.MPA
+
+		// Lotman doesn't let us update the creation time
+		lotUpdate.MPA.CreationTime = nil
+	}
+
+	// Check for parent updates
+	if !reflect.DeepEqual(existingLot.Parents, newLot.Parents) {
+		updateMap := getModMap(existingLot.Parents, newLot.Parents)
+		for parent, update := range updateMap {
+			switch {
+			case update.Remove:
+				if lotParentRemoval == nil {
+					lotParentRemoval = &LotParentRemoval{}
+				}
+				lotParentRemoval.Parents = append(lotParentRemoval.Parents, parent)
+			case update.Add:
+				if lotAddition == nil {
+					lotAddition = &LotAddition{}
+				}
+				lotAddition.Parents = append(lotAddition.Parents, parent)
+			default: // update
+				if lotUpdate == nil {
+					lotUpdate = &LotUpdate{}
+				}
+				lotParentUpdate := ParentUpdate{
+					Current: parent,
+					New:     update.Update,
+				}
+				if lotUpdate.Parents == nil {
+					lotUpdate.Parents = &[]ParentUpdate{}
+				}
+				*lotUpdate.Parents = append(*lotUpdate.Parents, lotParentUpdate)
+			}
+		}
+	}
+
+	// Check for path updates
+	if !reflect.DeepEqual(existingLot.Paths, newLot.Paths) {
+		updateMap := getModMap(existingLot.Paths, newLot.Paths)
+		for path, update := range updateMap {
+			switch {
+			case update.Remove:
+				if lotPathRemoval == nil {
+					lotPathRemoval = &LotPathRemoval{}
+				}
+				lotPathRemoval.Paths = append(lotPathRemoval.Paths, path.Path)
+			case update.Add:
+				if lotAddition == nil {
+					lotAddition = &LotAddition{}
+				}
+				lotAddition.Paths = append(lotAddition.Paths, path)
+			default: // update
+				if lotUpdate == nil {
+					lotUpdate = &LotUpdate{}
+				}
+				lotPathUpdate := PathUpdate{
+					Current:   path.Path,
+					New:       update.Update.Path,
+					Recursive: update.Update.Recursive,
+				}
+				if lotUpdate.Paths == nil {
+					lotUpdate.Paths = &[]PathUpdate{}
+				}
+				*lotUpdate.Paths = append(*lotUpdate.Paths, lotPathUpdate)
+			}
+		}
+	}
+
+	// Add LotName to the structs if they are not nil. Note that paths can
+	// belong to at most one lot, so the path removal struct doesn't have a lot name field
+	if lotUpdate != nil {
+		lotUpdate.LotName = newLot.LotName
+	}
+	if lotAddition != nil {
+		lotAddition.LotName = newLot.LotName
+	}
+	if lotParentRemoval != nil {
+		lotParentRemoval.LotName = newLot.LotName
+	}
+
+	return lotUpdate, lotAddition, lotPathRemoval, lotParentRemoval, nil
+}

--- a/lotman/lotman_utils_test.go
+++ b/lotman/lotman_utils_test.go
@@ -1,0 +1,496 @@
+//go:build lotman && linux && !ppc64le
+
+/***************************************************************
+*
+* Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
+
+package lotman
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSliceToSet(t *testing.T) {
+	sSlice := []string{"foo", "bar", "baz", "foo"}
+	sSet := sliceToSet(sSlice)
+
+	assert.Equal(t, 3, len(sSet))
+	assert.Contains(t, sSet, "foo")
+	assert.Contains(t, sSet, "bar")
+	assert.Contains(t, sSet, "baz")
+
+	lSlice := []LotPath{{Path: "/foo", Recursive: true}, {Path: "/bar", Recursive: false}, {Path: "/foo", Recursive: true}, {Path: "/foo", Recursive: false}}
+	lSet := sliceToSet(lSlice)
+	assert.Equal(t, len(lSet), 3)
+	assert.Contains(t, lSet, LotPath{Path: "/foo", Recursive: true})
+	assert.Contains(t, lSet, LotPath{Path: "/bar", Recursive: false})
+	assert.Contains(t, lSet, LotPath{Path: "/foo", Recursive: false})
+}
+
+// Helper function to create an MPA with given parameters
+func createMPA(dedicatedGB, opportunisticGB float64, maxNumObjects int64) *MPA {
+	return &MPA{
+		DedicatedGB:     &dedicatedGB,
+		OpportunisticGB: &opportunisticGB,
+		MaxNumObjects:   &Int64FromFloat{Value: maxNumObjects},
+	}
+}
+
+func TestCompareMPAs(t *testing.T) {
+	// This test only checks a subset of MAP fields, as the rest are\
+	// all handled similarly.
+	testCases := []struct {
+		name     string
+		mpa1     *MPA
+		mpa2     *MPA
+		expected bool
+	}{
+		{
+			name:     "Equal MPAs",
+			mpa1:     createMPA(10.0, 5.0, 100),
+			mpa2:     createMPA(10.0, 5.0, 100),
+			expected: true,
+		},
+		{
+			name:     "Different DedicatedGB",
+			mpa1:     createMPA(10.0, 5.0, 100),
+			mpa2:     createMPA(20.0, 5.0, 100),
+			expected: false,
+		},
+		{
+			name:     "Different OpportunisticGB",
+			mpa1:     createMPA(10.0, 5.0, 100),
+			mpa2:     createMPA(10.0, 10.0, 100),
+			expected: false,
+		},
+		{
+			name:     "Different MaxNumObjects",
+			mpa1:     createMPA(10.0, 5.0, 100),
+			mpa2:     createMPA(10.0, 5.0, 200),
+			expected: false,
+		},
+		{
+			name:     "One nil MPA",
+			mpa1:     createMPA(10.0, 5.0, 100),
+			mpa2:     nil,
+			expected: false,
+		},
+		{
+			name:     "Both nil MPAs",
+			mpa1:     nil,
+			mpa2:     nil,
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := compareMPAs(tc.mpa1, tc.mpa2)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// A test helper function for testing getModMap. This function takes the existing slice
+// and applies the mod map to it to generate the new slice, which is what we use for test
+// verification. This is much easier than verifying the mod map directly, because go maps
+// are unordered and there are multiple ways to represent the same mod map.
+func applyModMap[T comparable](existing []T, modMap map[T]UpdateInfo[T]) []T {
+	result := make([]T, 0, len(existing))
+	visited := make(map[T]bool)
+
+	for _, item := range existing {
+		if mod, exists := modMap[item]; exists {
+			if mod.Remove {
+				continue
+			}
+			var zeroValue T // Default zero value for type T
+			if mod.Update != zeroValue {
+				result = append(result, mod.Update)
+				visited[mod.Update] = true
+				continue
+			}
+		}
+		result = append(result, item)
+		visited[item] = true
+	}
+
+	for item, mod := range modMap {
+		if mod.Add && !visited[item] {
+			result = append(result, item)
+		}
+	}
+
+	return result
+}
+
+type ModMapTestCase[T comparable] struct {
+	name     string
+	existing []T
+	new      []T
+}
+
+func runGetModMapTests[T comparable](t *testing.T, testCases []ModMapTestCase[T]) {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			modMap := getModMap(tc.existing, tc.new)
+			result := applyModMap(tc.existing, modMap)
+			assert.ElementsMatch(t, tc.new, result)
+		})
+	}
+}
+func TestGetModMap(t *testing.T) {
+	stringTestCases := []ModMapTestCase[string]{
+		{"Single update", []string{"foo", "bar"}, []string{"foo", "baz"}},
+		{"Add item", []string{"foo", "bar"}, []string{"foo", "bar", "baz"}},
+		{"Remove item", []string{"foo", "bar"}, []string{"foo"}},
+		{"Update and add", []string{"foo", "bar"}, []string{"foo", "baz", "goo"}},
+		{"Update and remove", []string{"foo", "bar", "goo"}, []string{"foo", "baz"}},
+		{"Complex case", []string{"foo", "bar", "baz"}, []string{"foo", "goo", "boo"}},
+	}
+
+	lotPathTestCases := []ModMapTestCase[LotPath]{
+		{
+			name:     "Single update",
+			existing: []LotPath{{Path: "/foo", Recursive: true}, {Path: "/bar", Recursive: false}},
+			new:      []LotPath{{Path: "/foo", Recursive: true}, {Path: "/baz", Recursive: false}},
+		},
+		{
+			name:     "Add item",
+			existing: []LotPath{{Path: "/foo", Recursive: true}, {Path: "/bar", Recursive: false}},
+			new:      []LotPath{{Path: "/foo", Recursive: true}, {Path: "/bar", Recursive: false}, {Path: "/baz", Recursive: true}},
+		},
+		{
+			name:     "Remove item",
+			existing: []LotPath{{Path: "/foo", Recursive: true}, {Path: "/bar", Recursive: false}},
+			new:      []LotPath{{Path: "/foo", Recursive: true}},
+		},
+		{
+			name:     "Update two and add", // Note that the /foo is an update because of new recursive value
+			existing: []LotPath{{Path: "/foo", Recursive: true}, {Path: "/bar", Recursive: false}},
+			new:      []LotPath{{Path: "/foo", Recursive: false}, {Path: "/baz", Recursive: false}, {Path: "/goo", Recursive: true}},
+		},
+		{
+			name:     "Update and remove",
+			existing: []LotPath{{Path: "/foo", Recursive: true}, {Path: "/bar", Recursive: false}, {Path: "/goo", Recursive: true}},
+			new:      []LotPath{{Path: "/foo", Recursive: false}, {Path: "/baz", Recursive: false}},
+		},
+		{
+			name:     "Complex case",
+			existing: []LotPath{{Path: "/foo", Recursive: true}, {Path: "/bar", Recursive: false}, {Path: "/baz", Recursive: true}},
+			new:      []LotPath{{Path: "/foo", Recursive: true}, {Path: "/goo", Recursive: false}, {Path: "/boo", Recursive: true}},
+		},
+	}
+
+	runGetModMapTests(t, stringTestCases)
+	runGetModMapTests(t, lotPathTestCases)
+}
+
+// Some updates may have multiple correct solutions. In these cases, there is a dependency
+// between the LotUpdate and relevant removal/addition pieces for paths and parents. To handle
+// this, we define two types of solutions -- those where there's exactly one correct solution
+// (concreteSolution) and those where there are multiple correct solutions (dynamicSolution).
+// The dynamicSolution type contains maps that allow us to verify that the correct removals/additions
+// are present in the context of the other parts of the update.
+
+type concreteSolution struct {
+	Update   *LotUpdate
+	Add      *LotAddition
+	PathRm   *LotPathRemoval
+	ParentRm *LotParentRemoval
+}
+
+type dynamicSolution struct {
+	Owner                           *string
+	MPA                             *MPA
+	PathUpdateToRmMap               map[PathUpdate]*LotPathRemoval
+	PathUpdateToPathAdditionMap     map[PathUpdate][]LotPath
+	ParentUpdateToRmMap             map[ParentUpdate]*LotParentRemoval
+	ParentUpdateToParentAdditionMap map[ParentUpdate][]string
+}
+
+type updateSolution struct {
+	Concrete *concreteSolution
+	Dynamic  *dynamicSolution
+}
+
+func TestGetLotUpdateJSONs(t *testing.T) {
+	createLot := func(name, owner string, parents []string, paths []LotPath, mpa *MPA) *Lot {
+		return &Lot{
+			LotName: name,
+			Owner:   owner,
+			Parents: parents,
+			Paths:   paths,
+			MPA:     mpa,
+		}
+	}
+	stringPtr := func(s string) *string {
+		return &s
+	}
+
+	testCases := []struct {
+		name                string
+		existingLot         *Lot
+		newLot              *Lot
+		acceptableSolutions updateSolution
+		expectError         bool
+	}{
+		{
+			name: "No changes needed",
+			existingLot: createLot(
+				"lot1",
+				"owner1",
+				[]string{"parent1"},
+				[]LotPath{{Path: "/path1", Recursive: true}},
+				createMPA(10.0, 5.0, 100),
+			),
+			newLot: createLot(
+				"lot1",
+				"owner1",
+				[]string{"parent1"},
+				[]LotPath{{Path: "/path1", Recursive: true}},
+				createMPA(10.0, 5.0, 100),
+			),
+			acceptableSolutions: updateSolution{},
+			expectError:         false,
+		},
+		{
+			name: "Different lots produces error",
+			existingLot: createLot(
+				"lot1",
+				"owner1",
+				[]string{"parent1"},
+				[]LotPath{{Path: "/path1", Recursive: true}},
+				createMPA(10.0, 5.0, 100),
+			),
+			newLot: createLot(
+				"lot2",
+				"owner1",
+				[]string{"parent1"},
+				[]LotPath{{Path: "/path1", Recursive: true}},
+				createMPA(10.0, 5.0, 100),
+			),
+			acceptableSolutions: updateSolution{},
+			expectError:         true,
+		},
+		{
+			name: "Owner update needed",
+			existingLot: createLot(
+				"lot1",
+				"owner1",
+				[]string{"parent1"},
+				[]LotPath{{Path: "/path1", Recursive: true}},
+				createMPA(10.0, 5.0, 100),
+			),
+			newLot: createLot(
+				"lot1",
+				"owner2",
+				[]string{"parent1"},
+				[]LotPath{{Path: "/path1", Recursive: true}},
+				createMPA(10.0, 5.0, 100),
+			),
+			acceptableSolutions: updateSolution{
+				Concrete: &concreteSolution{
+					Update:   &LotUpdate{LotName: "lot1", Owner: stringPtr("owner2")},
+					Add:      nil,
+					PathRm:   nil,
+					ParentRm: nil,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "MPA update needed",
+			existingLot: createLot(
+				"lot1",
+				"owner1",
+				[]string{"parent1"},
+				[]LotPath{{Path: "/path1", Recursive: true}},
+				createMPA(10.0, 5.0, 100),
+			),
+			newLot: createLot(
+				"lot1",
+				"owner1",
+				[]string{"parent1"},
+				[]LotPath{{Path: "/path1", Recursive: true}},
+				createMPA(20.0, 10.0, 200),
+			),
+			acceptableSolutions: updateSolution{
+				Concrete: &concreteSolution{
+					Update:   &LotUpdate{LotName: "lot1", MPA: createMPA(20.0, 10.0, 200)},
+					Add:      nil,
+					PathRm:   nil,
+					ParentRm: nil,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "Parent addition needed",
+			existingLot: createLot(
+				"lot1",
+				"owner1",
+				[]string{"parent1"},
+				[]LotPath{{Path: "/path1", Recursive: true}},
+				createMPA(10.0, 5.0, 100),
+			),
+			newLot: createLot(
+				"lot1",
+				"owner1",
+				[]string{"parent1", "parent2"},
+				[]LotPath{{Path: "/path1", Recursive: true}},
+				createMPA(10.0, 5.0, 100),
+			),
+			acceptableSolutions: updateSolution{
+				Concrete: &concreteSolution{
+					Update:   nil,
+					Add:      &LotAddition{LotName: "lot1", Parents: []string{"parent2"}},
+					PathRm:   nil,
+					ParentRm: nil,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "Path removal needed",
+			existingLot: createLot(
+				"lot1",
+				"owner1",
+				[]string{"parent1"},
+				[]LotPath{{Path: "/path1", Recursive: true}, {Path: "/path2", Recursive: false}},
+				createMPA(10.0, 5.0, 100),
+			),
+			newLot: createLot(
+				"lot1",
+				"owner1",
+				[]string{"parent1"},
+				[]LotPath{{Path: "/path1", Recursive: true}},
+				createMPA(10.0, 5.0, 100),
+			),
+			acceptableSolutions: updateSolution{
+				Concrete: &concreteSolution{
+					Update:   nil,
+					Add:      nil,
+					PathRm:   &LotPathRemoval{Paths: []string{"/path2"}},
+					ParentRm: nil,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "Multiple updates needed (dynamic solution)",
+			existingLot: createLot(
+				"lot1",
+				"owner1",
+				[]string{"parent1", "parent2"},
+				[]LotPath{{Path: "/path1", Recursive: true}, {Path: "/path2", Recursive: false}},
+				createMPA(10.0, 5.0, 100),
+			),
+			newLot: createLot(
+				"lot1",
+				"owner2",
+				[]string{"parent1", "parent3", "parent4"},
+				[]LotPath{{Path: "/path1", Recursive: true}, {Path: "/path3", Recursive: true}, {Path: "/path4", Recursive: false}},
+				createMPA(20.0, 10.0, 200),
+			),
+			acceptableSolutions: updateSolution{
+				Dynamic: &dynamicSolution{
+					Owner: stringPtr("owner2"),
+					MPA:   createMPA(20.0, 10.0, 200),
+					PathUpdateToPathAdditionMap: map[PathUpdate][]LotPath{
+						{Current: "/path2", New: "/path3", Recursive: true}:  {{Path: "/path4", Recursive: false}},
+						{Current: "/path2", New: "/path4", Recursive: false}: {{Path: "/path3", Recursive: true}},
+					},
+					ParentUpdateToParentAdditionMap: map[ParentUpdate][]string{
+						{Current: "parent2", New: "parent3"}: {"parent4"},
+						{Current: "parent2", New: "parent4"}: {"parent3"},
+					},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			update, add, pathRm, parentRm, err := getLotUpdateJSONs(tc.existingLot, tc.newLot)
+			if tc.expectError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.acceptableSolutions.Concrete != nil {
+				assert.Equal(t, tc.acceptableSolutions.Concrete.Update, update)
+				assert.Equal(t, tc.acceptableSolutions.Concrete.Add, add)
+				assert.Equal(t, tc.acceptableSolutions.Concrete.PathRm, pathRm)
+				assert.Equal(t, tc.acceptableSolutions.Concrete.ParentRm, parentRm)
+
+				return
+			}
+
+			// If we have a dynamic solution because there's more than one correct answer,
+			// use our solutions maps to verify that each part of the update is correct in
+			// the context of the other parts of the update.
+			if tc.acceptableSolutions.Dynamic != nil {
+				assert.Equal(t, tc.acceptableSolutions.Dynamic.Owner, update.Owner)
+				assert.Equal(t, tc.acceptableSolutions.Dynamic.MPA, update.MPA)
+
+				// Validate dynamic path "updates", which may be a removal or an addition
+				pathUpdates := update.Paths
+				for _, pathUpdate := range *pathUpdates {
+					if tc.acceptableSolutions.Dynamic.PathUpdateToRmMap != nil {
+						if removal, ok := tc.acceptableSolutions.Dynamic.PathUpdateToRmMap[pathUpdate]; ok {
+							assert.Equal(t, removal.Paths, pathRm.Paths)
+							continue
+						}
+					}
+
+					if tc.acceptableSolutions.Dynamic.PathUpdateToPathAdditionMap != nil {
+						if additions, ok := tc.acceptableSolutions.Dynamic.PathUpdateToPathAdditionMap[pathUpdate]; ok {
+							assert.Equal(t, additions, add.Paths)
+							continue
+						}
+					}
+				}
+
+				// Same goes for parent updates
+				parentUpdates := update.Parents
+				for _, parentUpdate := range *parentUpdates {
+					if tc.acceptableSolutions.Dynamic.ParentUpdateToRmMap != nil {
+						if removal, ok := tc.acceptableSolutions.Dynamic.ParentUpdateToRmMap[parentUpdate]; ok {
+							assert.Contains(t, removal.Parents, parentRm.Parents)
+							continue
+						}
+					}
+
+					if tc.acceptableSolutions.Dynamic.ParentUpdateToParentAdditionMap != nil {
+						if additions, ok := tc.acceptableSolutions.Dynamic.ParentUpdateToParentAdditionMap[parentUpdate]; ok {
+							assert.Equal(t, additions, add.Parents)
+							continue
+						}
+					}
+				}
+
+				return
+			}
+		})
+	}
+}

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -787,7 +787,7 @@ func ConfigXrootd(ctx context.Context, isOrigin bool) (string, error) {
 		lotmanCfg := LotmanCfg{Enabled: false}
 		if param.Cache_EnableLotman.GetBool() {
 			lotmanCfg.Enabled = true
-			lotmanCfg.LotHome = param.Lotman_DbLocation.GetString()
+			lotmanCfg.LotHome = param.Lotman_LotHome.GetString()
 			policyMap, err := lotman.GetPolicyMap()
 			if err != nil {
 				return "", errors.Wrap(err, "unable to parse lotman configuration")


### PR DESCRIPTION
Previously the cache had no way of incorporating new knowledge of namespaces/lot configuration on startup. Now it can update lots if the initialization structs it builds don't match what's in the database.

Lots of the complexity here (ha) comes from the fact that poor design choices in Lotman give some of the update operations multiple correct solutions. For example, consider two lists of paths:
```
[path1, path2] --> [path1, path3, path4]
```
Using Lotman's APIs, we could construct this update as:
1. Remove path2, add path3, add path4
2. Update path2-->path3, add path4
3. update path2-->path4, add path3

For paths this is fine, but lotman has constraints on parents that prevent you from deleting some. To work around this, the code collapses any operation like "remove X then add Y" to a safer "update X-->Y".

My hand testing procedure:
1. Set up and start your registry/director
2. Start an origin advertising 1 namespace
3. Configure your cache to use Lotman. Some boilerplate config to help with math later on:
```
Lotman:
  LotHome: /some/path
Cache:
  EnableLotman: true
  HighWaterMark: 5g
  LowWaterMark: 4g
  FilesMaxSize: 3g
  FilesNominalSize: 2g
  FilesBaseSize: 1g
```
4. Start the cache and observe the lotman database (now located at `/some/path/.lot/lotman_cpp.sqlite` -- you should see that your singular origin prefix as a `dedicated_GB` value of `5` in the `management_policy_attributes` table, indicating it is allowed to use the entire high water mark value
5. Shut off the cache and origin -- restart the origin with two namespaces (one must be the same as before) , then restart the cache
6. Observe the lotman database -- you should now see the second namespace and observe that the `dedicated_GB` for the two namespaces is 2.5. Importantly, the first/former prefix must no longer be 5, which would indicate the update failed!