### PR TITLE
Make sure the server dblocation is in a tmpdir in NewFedTest

### DIFF
--- a/fed_test_utils/fed.go
+++ b/fed_test_utils/fed.go
@@ -147,6 +147,7 @@ func NewFedTest(t *testing.T, originConfig string) (ft *FedTest) {
 	viper.Set(param.Server_EnableUI.GetName(), false)
 	viper.Set(param.Server_WebPort.GetName(), ports[2])
 	viper.Set(param.LocalCache_RunLocation.GetName(), filepath.Join(tmpPath, "local-cache"))
+	viper.Set(param.Server_DbLocation.GetName(), filepath.Join(t.TempDir(), "server.sqlite"))
 
 	// Set the Director's start time to 6 minutes ago. This prevents it from sending an HTTP 429 for
 	// unknown prefixes.


### PR DESCRIPTION
Fix a bug in the downtime tests.