### PR TITLE
Client uses token issuer as selection criteria during token selection process

### DIFF
--- a/client/acquire_token.go
+++ b/client/acquire_token.go
@@ -416,6 +416,28 @@ func tokenIsAcceptable(jwtSerialized string, objectName string, dirResp server_s
 		return false
 	}
 
+	// Ensure the token issuer matches one of the issuers in the director response, if provided
+	if len(dirResp.XPelTokGenHdr.Issuers) > 0 {
+		issVal, ok := tok.Get("iss")
+		if !ok {
+			return false
+		}
+		issStr, ok := issVal.(string)
+		if !ok {
+			return false
+		}
+		foundIssuer := false
+		for _, u := range dirResp.XPelTokGenHdr.Issuers {
+			if u != nil && issStr == u.String() {
+				foundIssuer = true
+				break
+			}
+		}
+		if !foundIssuer {
+			return false
+		}
+	}
+
 	osdfPathCleaned := path.Clean(objectName)
 	if !strings.HasPrefix(osdfPathCleaned, dirResp.XPelNsHdr.Namespace) {
 		return false


### PR DESCRIPTION
This PR addresses issue #2131 by adding an additional selection criterion to the token selection process. Specifically, it introduces a check to compare the issuer provided in the Director’s response with the issuer in each token. Tokens are only considered further if the issuers match.