### PR TITLE
Accept SciTokens-profile JWT

### DIFF
--- a/client/acquire_token.go
+++ b/client/acquire_token.go
@@ -411,8 +411,18 @@ func tokenIsAcceptable(jwtSerialized string, objectName string, dirResp server_s
 		return false
 	}
 
-	// For now, we'll accept any WLCG token
-	if wlcg_ver, present := tok.Get("wlcg.ver"); !present || wlcg_ver == nil {
+	// Accept either a WLCG token (wlcg.ver) or a SciToken (ver starting “scitokens:”)
+	var isWLCG, isSci bool
+
+	if wlcgVer, ok := tok.Get("wlcg.ver"); ok && wlcgVer != nil {
+		isWLCG = true
+	}
+	if ver, ok := tok.Get("ver"); ok {
+		if s, ok2 := ver.(string); ok2 && strings.HasPrefix(s, "scitokens:") {
+			isSci = true
+		}
+	}
+	if !isWLCG && !isSci {
 		return false
 	}
 

--- a/client/main_test.go
+++ b/client/main_test.go
@@ -506,22 +506,18 @@ func TestParseRemoteAsPUrl(t *testing.T) {
 	}
 }
 
-// mustURL parses a string into *url.URL or fails the test.
-func mustURL(t *testing.T, s string) *url.URL {
-	u, err := url.Parse(s)
-	require.NoError(t, err)
-	return u
-}
-
 // Verify if a scitoken‐profile JWT is acceptable for a given namespace
 func TestTokenIsAcceptableForSciTokens(t *testing.T) {
+	issuerURL, err := url.Parse("https://issuer.example")
+	require.NoError(t, err)
+
 	// 1) Build a minimal DirectorResponse whose namespace is "/foo"
 	dirResp := server_structs.DirectorResponse{
 		XPelNsHdr: server_structs.XPelNs{
 			Namespace: "/foo",
 		},
 		XPelTokGenHdr: server_structs.XPelTokGen{
-			Issuers:   []*url.URL{mustURL(t, "https://issuer.example")},
+			Issuers:   []*url.URL{issuerURL},
 			BasePaths: []string{"/foo"},
 		},
 	}


### PR DESCRIPTION
Pelican’s client today only recognizes WLCG tokens (i.e. JWTs with a wlcg.ver claim). When a user supplies a SciTokens‑profile JWT (with ver: "scitokens:2.0"), Pelican will reject it as “unacceptable”. This PR extends the token profiles Pelican support from WLCG to SciTokens. Check out the linked issue for more details.

Close #2130 
