### PR TITLE
XRootD CPU Utilization Metric

### DIFF
--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -302,16 +302,23 @@ type (
 		Wq   int `xml:"wq"`
 	}
 
+	ProcTimes struct {
+		Seconds      int `xml:"s"`
+		MicroSeconds int `xml:"u"`
+	}
+
 	SummaryStat struct {
-		Id      SummaryStatType    `xml:"id,attr"`
-		Total   int                `xml:"tot"`
-		In      int                `xml:"in"`
-		Out     int                `xml:"out"`
-		Threads int                `xml:"threads"`
-		Idle    int                `xml:"idle"`
-		Paths   SummaryPath        `xml:"paths"` // For Oss Summary Data
-		Store   SummaryCacheStore  `xml:"store"`
-		Memory  SummaryCacheMemory `xml:"mem"`
+		Id         SummaryStatType    `xml:"id,attr"`
+		Total      int                `xml:"tot"`
+		In         int                `xml:"in"`
+		Out        int                `xml:"out"`
+		Threads    int                `xml:"threads"`
+		Idle       int                `xml:"idle"`
+		Paths      SummaryPath        `xml:"paths"` // For Oss Summary Data
+		Store      SummaryCacheStore  `xml:"store"`
+		Memory     SummaryCacheMemory `xml:"mem"`
+		ProcSystem ProcTimes          `xml:"sys"`
+		ProcUser   ProcTimes          `xml:"usr"`
 	}
 
 	SummaryStatistics struct {
@@ -342,6 +349,7 @@ const (
 	SchedStat SummaryStatType = "sched" // https://xrootd.slac.stanford.edu/doc/dev55/xrd_monitoring.htm#_Toc99653745
 	OssStat   SummaryStatType = "oss"   // https://xrootd.slac.stanford.edu/doc/dev55/xrd_monitoring.htm#_Toc99653741
 	CacheStat SummaryStatType = "cache" // https://xrootd.slac.stanford.edu/doc/dev55/xrd_monitoring.htm#_Toc99653733
+	ProcStat  SummaryStatType = "proc"  // https://xrootd.web.cern.ch/doc/dev57/xrd_monitoring.htm#_Toc138968507
 )
 
 var (
@@ -1612,6 +1620,12 @@ func HandleSummaryPacket(packet []byte) error {
 				Set(float64(cacheStore.Size))
 			StorageVolume.With(prometheus.Labels{"ns": "/cache", "type": "free", "server_type": "cache"}).
 				Set(float64(cacheStore.Size - cacheStore.Used))
+		case ProcStat:
+			fmt.Println("Got proc stat: ", string(packet))
+			fmt.Println("Proc System Seconds: ", stat.ProcSystem.Seconds)
+			fmt.Print("Proc System MicroSeconds: ", stat.ProcSystem.MicroSeconds)
+			fmt.Println("Proc User Seconds: ", stat.ProcUser.Seconds)
+			fmt.Println("Proc User MicroSeconds: ", stat.ProcUser.MicroSeconds)
 		}
 	}
 	return nil

--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -1637,6 +1637,7 @@ func HandleSummaryPacket(packet []byte) error {
 				Set(float64(cacheStore.Size - cacheStore.Used))
 		case ProcStat:
 			procState.Lock()
+			defer procState.Unlock()
 			currentTime := time.Now()
 			currentUserSeconds := float64(stat.ProcUser.Seconds) + float64(stat.ProcUser.MicroSeconds)/1e6
 			currentSystemSeconds := float64(stat.ProcSystem.Seconds) + float64(stat.ProcSystem.MicroSeconds)/1e6
@@ -1659,7 +1660,6 @@ func HandleSummaryPacket(packet []byte) error {
 			procState.lastUserSeconds = currentUserSeconds
 			procState.lastSysSeconds = currentSystemSeconds
 			procState.lastUpdateTime = currentTime
-			procState.Unlock()
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR addresses #1463. This PR adds a new metric `xrootd_cpu_utilization`. This metric is calculated from the summary statistics provided by XRootD. The CPU utilization is calculated via the following: (CPU time used) / (Wall time elapsed). The CPU time used is calculate by calculating the delta between the last amount of CPU time used and the current cpu time used. The wall time elapsed is calculated as the difference between the current time and the last time we received a summary statistic. 