### PR TITLE
Update the version of golangci-lint used by pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     -   id: check-added-large-files
         args: ['--maxkb=1024']
 -   repo: https://github.com/golangci/golangci-lint
-    rev: v1.56.2
+    rev: v1.64.8
     hooks:
     -   id: golangci-lint
 -   repo: https://github.com/crate-ci/typos


### PR DESCRIPTION
This seems to resolve the failure in the GitHub Action.

In the name of expediency, I'm not attempting to upgrade everything that's fallen behind.