### PR TITLE
Ensure test is properly shut down on failure

### DIFF
--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -205,6 +205,7 @@ func (f *FedTest) Spinup() {
 
 	_, f.FedCancel, err = launchers.LaunchModules(ctx, modules)
 	if err != nil {
+		f.FedCancel()
 		f.T.Fatalf("Failure in fedServeInternal: %v", err)
 	}
 


### PR DESCRIPTION
Without this, if the test fails, various goroutines stick around and can prevent the unit test framework from a clean shutdown.