### PR TITLE
Bugfixes, tests, and tools around checksums

### DIFF
--- a/classads/classads_test.go
+++ b/classads/classads_test.go
@@ -74,6 +74,28 @@ func TestStringClassAd(t *testing.T) {
 	assert.Equal(t, localFileName1, localFileName2)
 }
 
+func TestSubClassAd(t *testing.T) {
+	ad := NewClassAd()
+	subMap := make(map[string]string)
+	subMap["LocalFileName"] = "/path/to/local/copy/of/foo"
+	subMap["Url"] = "url://server/some/directory//foo"
+	ad.Set("SubClassAd", subMap)
+	adStr := ad.String()
+	// We don't know the order of the attributes in the subclassad; test for both
+	option1 := "[SubClassAd = [LocalFileName = \"/path/to/local/copy/of/foo\"; Url = \"url://server/some/directory//foo\"; ]; ]"
+	option2 := "[SubClassAd = [Url = \"url://server/some/directory//foo\"; LocalFileName = \"/path/to/local/copy/of/foo\"; ]; ]"
+	assert.True(t, adStr == option1 || adStr == option2, "ClassAd.String() returned %s, expected %s or %s", adStr, option1, option2)
+
+	ad = NewClassAd()
+	subAd := make(map[string]any)
+	subAd2 := make(map[string]any)
+	subAd["foo"] = subAd2
+	subAd2["bar"] = "baz"
+	ad.Set("SubClassAd", subAd)
+	adStr = ad.String()
+	assert.Equal(t, "[SubClassAd = [foo = [bar = \"baz\"; ]; ]; ]", adStr)
+}
+
 func TestStringQuoteClassAd(t *testing.T) {
 	ad := NewClassAd()
 	ad.Set("StringValue", "Get quotes \"right\"")

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -350,14 +350,21 @@ const (
 	attrProjectName classAdAttr = "ProjectName"
 	attrJobId       classAdAttr = "GlobalJobId"
 
+	// The checksum algorithms supported by the client
+	//
+	// Note we have a helper function, KnownChecksumTypes, that returns a list
+	// of all the elements enumerated below; do not skip integers in this list
+	// or that functionality will break.
+	//
 	AlgMD5     ChecksumType = iota // Checksum is using the MD5 algorithm
 	AlgCRC32C                      // Checksum is using the CRC32C algorithm
 	AlgCRC32                       // Checksum is using the CRC32 algorithm
 	AlgSHA1                        // Checksum is using the SHA-1 algorithm
-	AlgUnknown                     // Unknown checksum algorithm
+	AlgUnknown                     // Unknown checksum algorithm.  Always a "trailer" indicating the last known algorithm.
 
 	AlgDefault = AlgCRC32C // Default checksum algorithm is CRC32C if the client doesn't specify one.
 	algFirst   = AlgMD5
+	algLast    = AlgUnknown
 
 	SyncNone  = iota // When synchronizing, always re-transfer, regardless of existence at destination.
 	SyncExist        // Skip synchronization transfer if the destination exists
@@ -398,8 +405,8 @@ func ChecksumFromHttpDigest(httpDigest string) ChecksumType {
 
 // List all the checksum types known to the client
 func KnownChecksumTypes() (result []ChecksumType) {
-	result = make([]ChecksumType, AlgUnknown-algFirst)
-	for idx := algFirst; idx < AlgUnknown; idx++ {
+	result = make([]ChecksumType, algLast-algFirst)
+	for idx := algFirst; idx < algLast; idx++ {
 		result[idx-algFirst] = idx
 	}
 	return

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2064,7 +2064,11 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 	}
 	fileWriter = io.MultiWriter(fileWriter, hashesWriter)
 
-	size, attempts := sortAttempts(transfer.job.ctx, transfer.remoteURL.Path, transfer.attempts, transfer.token)
+	var size int64 = -1
+	attempts := transfer.attempts
+	if transfer.job != nil && transfer.job.ctx != nil {
+		size, attempts = sortAttempts(transfer.job.ctx, transfer.remoteURL.Path, transfer.attempts, transfer.token)
+	}
 
 	transferResults = newTransferResults(transfer.job)
 	xferErrors := NewTransferErrors()

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -115,6 +115,12 @@ type (
 		Err error
 	}
 
+	// Represents a mismatched checksum
+	ChecksumMismatchError struct {
+		Info        ChecksumInfo // The checksum that was calculated by the client
+		ServerValue []byte       // The checksum value that was calculated by the server
+	}
+
 	HeaderTimeoutError struct{}
 
 	NetworkResetError struct{}
@@ -156,7 +162,8 @@ type (
 		job               *TransferJob
 		Error             error
 		TransferredBytes  int64
-		Checksums         []ChecksumInfo
+		ServerChecksums   []ChecksumInfo // Checksums returned by the server
+		ClientChecksums   []ChecksumInfo // Checksums calculated by the client
 		TransferStartTime time.Time
 		Scheme            string
 		Attempts          []TransferResult
@@ -343,13 +350,14 @@ const (
 	attrProjectName classAdAttr = "ProjectName"
 	attrJobId       classAdAttr = "GlobalJobId"
 
-	AlgMD5     = iota // Checksum is using the MD5 algorithm
-	AlgCRC32C         // Checksum is using the CRC32C algorithm
-	AlgCRC32          // Checksum is using the CRC32 algorithm
-	AlgSHA1           // Checksum is using the SHA-1 algorithm
-	AlgUnknown        // Unknown checksum algorithm
+	AlgMD5     ChecksumType = iota // Checksum is using the MD5 algorithm
+	AlgCRC32C                      // Checksum is using the CRC32C algorithm
+	AlgCRC32                       // Checksum is using the CRC32 algorithm
+	AlgSHA1                        // Checksum is using the SHA-1 algorithm
+	AlgUnknown                     // Unknown checksum algorithm
 
 	AlgDefault = AlgCRC32C // Default checksum algorithm is CRC32C if the client doesn't specify one.
+	algFirst   = AlgMD5
 
 	SyncNone  = iota // When synchronizing, always re-transfer, regardless of existence at destination.
 	SyncExist        // Skip synchronization transfer if the destination exists
@@ -370,9 +378,11 @@ var (
 	// Error condition indicating that the progress writer was externally closed
 	// before the transfer was completed
 	progressWriterClosed error = errors.New("progress writer closed")
+
+	ErrServerChecksumMissing = errors.New("no checksum information was returned by server but checksums were required by the client")
 )
 
-func checksumFromHttpDigest(httpDigest string) ChecksumType {
+func ChecksumFromHttpDigest(httpDigest string) ChecksumType {
 	switch httpDigest {
 	case "md5":
 		return AlgMD5
@@ -386,7 +396,26 @@ func checksumFromHttpDigest(httpDigest string) ChecksumType {
 	return AlgUnknown
 }
 
-func httpDigestFromChecksum(checksumType ChecksumType) string {
+// List all the checksum types known to the client
+func KnownChecksumTypes() (result []ChecksumType) {
+	result = make([]ChecksumType, AlgUnknown-algFirst)
+	for idx := algFirst; idx < AlgUnknown; idx++ {
+		result[idx-algFirst] = idx
+	}
+	return
+}
+
+// List all the checksum types known as HTTP digest strings
+func KnownChecksumTypesAsHttpDigest() (result []string) {
+	known := KnownChecksumTypes()
+	result = make([]string, len(known))
+	for idx, checksumType := range known {
+		result[idx] = HttpDigestFromChecksum(checksumType)
+	}
+	return
+}
+
+func HttpDigestFromChecksum(checksumType ChecksumType) string {
 	switch checksumType {
 	case AlgCRC32:
 		return "crc32"
@@ -414,6 +443,15 @@ func checksumValueToHttpDigest(checksumType ChecksumType, checksumValue []byte) 
 		return base64.StdEncoding.EncodeToString(checksumValue)
 	}
 	return "(unknown checksum type)"
+}
+
+func (e *ChecksumMismatchError) Error() string {
+	return fmt.Sprintf(
+		"checksum mismatch for %s; client computed %s, server reported %s",
+		HttpDigestFromChecksum(e.Info.Algorithm),
+		checksumValueToHttpDigest(e.Info.Algorithm, e.Info.Value),
+		checksumValueToHttpDigest(e.Info.Algorithm, e.ServerValue),
+	)
 }
 
 // Reset the memory-cached copy of the HTCondor job ad
@@ -2138,7 +2176,7 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 				tokenContents, _ = transfer.token.get()
 			}
 			if checksums, err := fetchChecksum(ctx, transfer.requestedChecksums, url, tokenContents, transfer.project); err == nil {
-				transferResults.Checksums = checksums
+				transferResults.ServerChecksums = checksums
 				gotChecksum = true
 			}
 		}
@@ -2158,24 +2196,30 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 			"job": transfer.job.ID(),
 		}
 		successCtr := 0
+		transferResults.ClientChecksums = make([]ChecksumInfo, 0, len(checksumHashes))
 		for idx, checksum := range checksumHashes {
 			computedValue := hashes[idx].(hash.Hash).Sum(nil)
+			transferResults.ClientChecksums = append(transferResults.ClientChecksums, ChecksumInfo{
+				Algorithm: checksum,
+				Value:     computedValue,
+			})
 			found := false
-			for _, checksumInfo := range transferResults.Checksums {
+			for _, checksumInfo := range transferResults.ServerChecksums {
 				if checksumInfo.Algorithm == checksum {
 					found = true
 					if !bytes.Equal(checksumInfo.Value, computedValue) {
-						transferResults.Error = errors.Errorf(
-							"checksum mismatch for %s: server sent '%s', client computed '%s'",
-							httpDigestFromChecksum(checksumInfo.Algorithm),
-							checksumValueToHttpDigest(checksumInfo.Algorithm, checksumInfo.Value),
-							checksumValueToHttpDigest(checksumInfo.Algorithm, computedValue),
-						)
+						transferResults.Error = &ChecksumMismatchError{
+							Info: ChecksumInfo{
+								Algorithm: checksumInfo.Algorithm,
+								Value:     computedValue,
+							},
+							ServerValue: checksumInfo.Value,
+						}
 						log.WithFields(fields).Errorln(transferResults.Error)
 					} else {
 						successCtr++
 						log.WithFields(fields).Debugf("Checksum %s matches: %s",
-							httpDigestFromChecksum(checksumInfo.Algorithm),
+							HttpDigestFromChecksum(checksumInfo.Algorithm),
 							checksumValueToHttpDigest(checksumInfo.Algorithm, checksumInfo.Value),
 						)
 					}
@@ -2184,13 +2228,13 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 			}
 			if !found {
 				log.WithFields(fields).Debugf("Client requested checksum %s but server did not provide it",
-					httpDigestFromChecksum(checksum),
+					HttpDigestFromChecksum(checksum),
 				)
 			}
 		}
 		// Can happen if all the checksum values we received are not known checksum algorithms
 		// we computed (the server can ignore our requested checksums and send its preferred ones)
-		if successCtr == 0 && transfer.requireChecksum {
+		if successCtr == 0 && transfer.requireChecksum && transferResults.Error == nil {
 			if len(transfer.requestedChecksums) == 0 {
 				log.WithFields(fields).Errorln(
 					"Client requires checksum to succeed and it was not provided by server; client computed crc32c value is",
@@ -2199,22 +2243,22 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 			} else {
 				log.WithFields(fields).Errorln(
 					"Client requires checksum to succeed and it was not provided by server; client computed",
-					httpDigestFromChecksum(transfer.requestedChecksums[0]), "value as",
+					HttpDigestFromChecksum(transfer.requestedChecksums[0]), "value as",
 					checksumValueToHttpDigest(transfer.requestedChecksums[0], hashes[0].(hash.Hash).Sum(nil)),
 				)
 			}
-			transferResults.Error = errors.New("no checksum information was returned but checksums are required")
+			transferResults.Error = ErrServerChecksumMissing
 			// Otherwise, it's not an error so we should log what we did
-		} else if successCtr == 0 && len(transferResults.Checksums) == 0 {
+		} else if successCtr == 0 && len(transferResults.ServerChecksums) == 0 && transferResults.Error == nil {
 			log.WithFields(fields).Debugln(
 				"Client computed crc32c value is", hex.EncodeToString(hashes[0].(hash.Hash).Sum(nil)),
 				"(server did not provide any checksum values to compare)",
 			)
-		} else if successCtr == 0 {
-			for _, checksumInfo := range transferResults.Checksums {
+		} else if successCtr == 0 && transferResults.Error == nil {
+			for _, checksumInfo := range transferResults.ServerChecksums {
 				log.WithFields(fields).Debugf(
 					"Server provided checksum not requested by client (cannot compare to local) %s=%x",
-					httpDigestFromChecksum(checksumInfo.Algorithm),
+					HttpDigestFromChecksum(checksumInfo.Algorithm),
 					checksumValueToHttpDigest(checksumInfo.Algorithm, checksumInfo.Value),
 				)
 			}
@@ -2226,7 +2270,7 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 			} else {
 				log.WithFields(fields).Debugln(
 					"Checksum algorithms provided by server were not the requested ones; client computed",
-					httpDigestFromChecksum(transfer.requestedChecksums[0]), "value as",
+					HttpDigestFromChecksum(transfer.requestedChecksums[0]), "value as",
 					checksumValueToHttpDigest(transfer.requestedChecksums[0], hashes[0].(hash.Hash).Sum(nil)),
 				)
 			}
@@ -2270,7 +2314,7 @@ func fetchChecksum(ctx context.Context, types []ChecksumType, url *url.URL, toke
 			if checksumTypes != "" {
 				checksumTypes += ", "
 			}
-			checksumTypes += httpDigestFromChecksum(cksum)
+			checksumTypes += HttpDigestFromChecksum(cksum)
 		}
 		if checksumTypes == "" {
 			log.WithFields(fields).Debugln(
@@ -2294,7 +2338,7 @@ func fetchChecksum(ctx context.Context, types []ChecksumType, url *url.URL, toke
 		request.Header.Set("X-Pelican-JobId", val)
 	}
 	if len(types) == 0 {
-		request.Header.Set("Want-Digest", httpDigestFromChecksum(AlgDefault))
+		request.Header.Set("Want-Digest", HttpDigestFromChecksum(AlgDefault))
 	} else {
 		multiple := false
 		val := ""
@@ -2302,7 +2346,7 @@ func fetchChecksum(ctx context.Context, types []ChecksumType, url *url.URL, toke
 			if multiple {
 				val += ","
 			}
-			val += httpDigestFromChecksum(cksum)
+			val += HttpDigestFromChecksum(cksum)
 			multiple = true
 		}
 		request.Header.Set("Want-Digest", val)
@@ -2334,7 +2378,8 @@ func fetchChecksum(ctx context.Context, types []ChecksumType, url *url.URL, toke
 			}
 			log.WithFields(fields).Debugf("Server reported object has checksum %s=%s", info[0], info[1])
 			checksumInfo := ChecksumInfo{}
-			if checksumInfo.Algorithm = checksumFromHttpDigest(info[0]); checksumInfo.Algorithm == AlgUnknown {
+			if checksumInfo.Algorithm = ChecksumFromHttpDigest(info[0]); checksumInfo.Algorithm == AlgUnknown {
+				log.WithFields(fields).Warningln("Unknown checksum algorithm:", info[0])
 				continue
 			}
 			val := make([]byte, 32)
@@ -2373,9 +2418,11 @@ func fetchChecksum(ctx context.Context, types []ChecksumType, url *url.URL, toke
 				fallthrough
 			case "sha":
 				decoder := base64.NewDecoder(base64.StdEncoding, bytes.NewReader([]byte(info[1])))
-				if _, err := decoder.Read(val); err != nil {
+				if count, err := decoder.Read(val); err != nil {
 					log.WithFields(fields).Errorf("Failed to parse %s checksum value (%s): %s", info[0], info[1], err)
 					continue
+				} else {
+					val = val[:count]
 				}
 				checksumInfo.Value = val
 			default:

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -44,6 +44,7 @@ import (
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/error_codes"
+	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/pelican_url"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/server_utils"
@@ -767,7 +768,7 @@ func TestGatewayTimeout(t *testing.T) {
 // Test checksum calculation and validation
 func TestChecksum(t *testing.T) {
 	test_utils.InitClient(t, map[string]any{
-		"Logging.Level": "debug",
+		param.Logging_Level.GetName(): "debug",
 	})
 
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -817,7 +818,7 @@ func TestChecksum(t *testing.T) {
 // Test behavior when checksum is incorrect
 func TestChecksumIncorrect(t *testing.T) {
 	test_utils.InitClient(t, map[string]any{
-		"Logging.Level": "debug",
+		param.Logging_Level.GetName(): "debug",
 	})
 
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -871,7 +872,7 @@ func TestChecksumIncorrect(t *testing.T) {
 // Test behavior when checksum is missing
 func TestChecksumMissing(t *testing.T) {
 	test_utils.InitClient(t, map[string]any{
-		"Logging.Level": "debug",
+		param.Logging_Level.GetName(): "debug",
 	})
 
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -23,6 +23,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"io/fs"
 	"net"
 	"net/http"
@@ -761,6 +762,237 @@ func TestGatewayTimeout(t *testing.T) {
 	} else {
 		require.Fail(t, "downloadObject did not return a status code error", "%s", err)
 	}
+}
+
+// Test checksum calculation and validation
+func TestChecksum(t *testing.T) {
+	test_utils.InitClient(t, map[string]any{
+		"Logging.Level": "debug",
+	})
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "HEAD" {
+			w.Header().Set("Content-Length", "17")
+			w.Header().Set("Digest", "crc32c=977b8112")
+			w.WriteHeader(http.StatusOK)
+		} else if r.Method == "GET" {
+			w.Header().Set("Content-Length", "17")
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("test file content"))
+			assert.NoError(t, err)
+		} else {
+			t.Fatal("Unexpected method:", r.Method)
+		}
+	}))
+	defer svr.Close()
+	svrURL, err := url.Parse(svr.URL)
+	require.NoError(t, err)
+
+	transfer := &transferFile{
+		ctx:       context.Background(),
+		job:       &TransferJob{},
+		localPath: "/dev/null",
+		remoteURL: svrURL,
+		attempts: []transferAttemptDetails{
+			{
+				Url: svrURL,
+			},
+		},
+	}
+	transferResult, err := downloadObject(transfer)
+	assert.NoError(t, err)
+	assert.NoError(t, transferResult.Error)
+	// Checksum validation
+	assert.Equal(t, 1, len(transferResult.ServerChecksums), "Checksum count is %d but should be 1", len(transferResult.ServerChecksums))
+	info := transferResult.ServerChecksums[0]
+	assert.Equal(t, "977b8112", hex.EncodeToString(info.Value))
+	assert.Equal(t, ChecksumType(AlgCRC32C), info.Algorithm)
+
+	assert.Equal(t, 1, len(transferResult.ClientChecksums), "Checksum count is %d but should be 1", len(transferResult.ClientChecksums))
+	info = transferResult.ClientChecksums[0]
+	assert.Equal(t, "977b8112", hex.EncodeToString(info.Value))
+	assert.Equal(t, ChecksumType(AlgCRC32C), info.Algorithm)
+}
+
+// Test behavior when checksum is incorrect
+func TestChecksumIncorrect(t *testing.T) {
+	test_utils.InitClient(t, map[string]any{
+		"Logging.Level": "debug",
+	})
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "HEAD" {
+			w.Header().Set("Content-Length", "17")
+			w.Header().Set("Digest", "crc32c=977b8111") // Incorrect checksum; should be 977b8112
+			w.WriteHeader(http.StatusOK)
+		} else if r.Method == "GET" {
+			w.Header().Set("Content-Length", "17")
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("test file content"))
+			assert.NoError(t, err)
+		} else {
+			t.Fatal("Unexpected method:", r.Method)
+		}
+	}))
+	defer svr.Close()
+	svrURL, err := url.Parse(svr.URL)
+	require.NoError(t, err)
+
+	transfer := &transferFile{
+		ctx:       context.Background(),
+		job:       &TransferJob{},
+		localPath: "/dev/null",
+		remoteURL: svrURL,
+		attempts: []transferAttemptDetails{
+			{
+				Url: svrURL,
+			},
+		},
+	}
+	transferResult, err := downloadObject(transfer)
+	assert.NoError(t, err)
+	assert.Error(t, transferResult.Error)
+	incorrectChecksumError := &ChecksumMismatchError{}
+	assert.True(t, errors.As(transferResult.Error, &incorrectChecksumError), "Expected a checksum mismatch error")
+	assert.Equal(t, "checksum mismatch for crc32c; client computed 977b8112, server reported 977b8111", incorrectChecksumError.Error())
+
+	// Checksum validation
+	assert.Equal(t, 1, len(transferResult.ServerChecksums), "Checksum count is %d but should be 1", len(transferResult.ServerChecksums))
+	info := transferResult.ServerChecksums[0]
+	assert.Equal(t, "977b8111", hex.EncodeToString(info.Value))
+	assert.Equal(t, ChecksumType(AlgCRC32C), info.Algorithm)
+
+	assert.Equal(t, 1, len(transferResult.ClientChecksums), "Checksum count is %d but should be 1", len(transferResult.ClientChecksums))
+	info = transferResult.ClientChecksums[0]
+	assert.Equal(t, "977b8112", hex.EncodeToString(info.Value))
+	assert.Equal(t, ChecksumType(AlgCRC32C), info.Algorithm)
+}
+
+// Test behavior when checksum is missing
+func TestChecksumMissing(t *testing.T) {
+	test_utils.InitClient(t, map[string]any{
+		"Logging.Level": "debug",
+	})
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "HEAD" {
+			w.Header().Set("Content-Length", "17")
+			w.WriteHeader(http.StatusOK)
+		} else if r.Method == "GET" {
+			w.Header().Set("Content-Length", "17")
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("test file content"))
+			assert.NoError(t, err)
+		} else {
+			t.Fatal("Unexpected method:", r.Method)
+		}
+	}))
+	defer svr.Close()
+	svrURL, err := url.Parse(svr.URL)
+	require.NoError(t, err)
+
+	transfer := &transferFile{
+		ctx:       context.Background(),
+		job:       &TransferJob{},
+		localPath: "/dev/null",
+		remoteURL: svrURL,
+		attempts: []transferAttemptDetails{
+			{
+				Url: svrURL,
+			},
+		},
+		requireChecksum: true,
+	}
+	transferResult, err := downloadObject(transfer)
+	assert.NoError(t, err)
+	assert.Error(t, transferResult.Error)
+	assert.True(t, errors.Is(transferResult.Error, ErrServerChecksumMissing), "Expected checksum missing error")
+}
+
+// Test behavior when resuming a transfer after an EOF
+//
+// Sets up two servers, one that returns the first 9 bytes and then an EOF (simulating a network
+// error), and another that returns the rest of the file. The test checks that the transfer resumes
+// after the first attempt and that the checksums are calculated and validated properly.
+func TestResume(t *testing.T) {
+	test_utils.InitClient(t, map[string]any{
+		"Logging.Level": "debug",
+	})
+
+	svr1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "HEAD" {
+			w.Header().Set("Content-Length", "17")
+			w.Header().Set("Digest", "crc32c=977b8112")
+			w.WriteHeader(http.StatusOK)
+		} else if r.Method == "GET" {
+			w.Header().Set("Content-Length", "17")
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("test file"))
+			assert.NoError(t, err)
+		} else {
+			t.Fatal("Unexpected method:", r.Method)
+		}
+	}))
+	defer svr1.Close()
+	svr1URL, err := url.Parse(svr1.URL)
+	require.NoError(t, err)
+
+	svr2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "HEAD" {
+			w.Header().Set("Content-Length", "17")
+			w.WriteHeader(http.StatusOK)
+		} else if r.Method == "GET" {
+			require.Equal(t, "bytes=9-", r.Header.Get("Range"))
+			w.Header().Set("Content-Range", "bytes 9-16/17")
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(" content"))
+			assert.NoError(t, err)
+		} else {
+			t.Fatal("Unexpected method:", r.Method)
+		}
+	}))
+	defer svr2.Close()
+	svr2URL, err := url.Parse(svr2.URL)
+	require.NoError(t, err)
+
+	transfer := &transferFile{
+		ctx:       context.Background(),
+		job:       &TransferJob{},
+		localPath: "/dev/null",
+		remoteURL: svr1URL,
+		attempts: []transferAttemptDetails{
+			{
+				Url: svr1URL,
+			},
+			{
+				Url: svr2URL,
+			},
+		},
+		requireChecksum: true,
+	}
+	transferResult, err := downloadObject(transfer)
+	assert.NoError(t, err)
+	assert.NoError(t, transferResult.Error)
+
+	assert.Equal(t, 1, len(transferResult.ServerChecksums), "Checksum count is %d but should be 1", len(transferResult.ServerChecksums))
+	info := transferResult.ServerChecksums[0]
+	assert.Equal(t, "977b8112", hex.EncodeToString(info.Value))
+	assert.Equal(t, ChecksumType(AlgCRC32C), info.Algorithm)
+
+	assert.Equal(t, 1, len(transferResult.ClientChecksums), "Checksum count is %d but should be 1", len(transferResult.ClientChecksums))
+	info = transferResult.ClientChecksums[0]
+	assert.Equal(t, "977b8112", hex.EncodeToString(info.Value))
+	assert.Equal(t, ChecksumType(AlgCRC32C), info.Algorithm)
+
+	// Check that two attempts were made
+	assert.Equal(t, 2, len(transferResult.Attempts), "Expected 2 attempts, got %d", len(transferResult.Attempts))
+	tae := &TransferAttemptError{}
+	require.True(t, errors.As(transferResult.Attempts[0].Error, &tae), "Got error of type %T; expected transfer attempt error", transferResult.Attempts[0].Error)
+	assert.Equal(t, "unexpected EOF", tae.Unwrap().Error())
+	assert.Equal(t, int64(9), transferResult.Attempts[0].TransferFileBytes)
+	assert.NoError(t, transferResult.Attempts[1].Error)
+	assert.Equal(t, int64(8), transferResult.Attempts[1].TransferFileBytes)
+	assert.Equal(t, int64(17), transferResult.TransferredBytes)
 }
 
 // Test failed connection setup error message for downloads

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -553,6 +553,34 @@ func TestPluginMulti(t *testing.T) {
 			boolVal, ok := transferSuccess.(bool)
 			require.True(t, ok)
 			assert.True(t, boolVal)
+
+			log.Debugln("Got result ad:", resultAd)
+			// Verify the checksums
+			fileName, err := resultAd.Get("TransferFileName")
+			require.NoError(t, err)
+			fileNameString, ok := fileName.(string)
+			require.True(t, ok)
+
+			devData, err := resultAd.Get("DeveloperData")
+			require.NoError(t, err)
+			devDataMap, ok := devData.(map[string]interface{})
+			require.True(t, ok)
+			checksum, ok := devDataMap["ClientChecksums"]
+			require.True(t, ok)
+			checksumMap, ok := checksum.(map[string]interface{})
+			require.True(t, ok, "Expected transfer checksum to be a map type; was %T", checksum)
+			checksumValue, ok := checksumMap["crc32c"]
+			require.True(t, ok)
+			checksumString, ok := checksumValue.(string)
+			require.True(t, ok)
+
+			if fileNameString == filepath.Base(localPath1) {
+				assert.Equal(t, "977b8112", checksumString)
+			} else if fileNameString == filepath.Base(localPath2) {
+				assert.Equal(t, "b99ecaad", checksumString)
+			} else {
+				t.Fatalf("Unexpected file name: %s", fileNameString)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR improves the checksum functionality:
- Adds a bugfix that prevents checksum failures from not being reported as checksum mismatch errors (@jhiemstrawisc - I think this is probably important enough to put into a 7.16 RC).
- Records the client and server-side checksums into the plugin outputs.  This will allow ElasticSearch to detect the frequency of errors.
- Adds a flag to `pelican object stat` that allows CLI users to get a checksum back.

Example:
```
pelican object stat --json --checksums md5 pelican://`hostname`:8444/tmp/test/hello_world.txt
{"Name":"/tmp/test/hello_world.txt","Size":12,"ModTime":"2025-04-26T15:16:26Z","IsCollection":false,"checksums":{"md5":"6f5902ac237024bdd0c176cb93063dc4"}}
```