### PR TITLE
Refresh Namespace list on update

### DIFF
--- a/web_ui/frontend/app/registry/denied/page.tsx
+++ b/web_ui/frontend/app/registry/denied/page.tsx
@@ -31,11 +31,12 @@ import DeniedCard from '@/components/Namespace/DeniedCard';
 import { getExtendedNamespaces } from '@/helpers/get';
 import { AlertDispatchContext } from '@/components/AlertProvider';
 import { alertOnError } from '@/helpers/util';
+import { NAMESPACE_KEY } from '@/helpers/api';
 
 export default function Home() {
   const dispatch = useContext(AlertDispatchContext);
 
-  const { data } = useSWR('getExtendedNamespaces', async () =>
+  const { data } = useSWR(NAMESPACE_KEY, async () =>
     alertOnError(getExtendedNamespaces, "Couldn't fetch namespaces", dispatch)
   );
   const { data: user, error } = useSWR('getUser', async () =>

--- a/web_ui/frontend/app/registry/page.tsx
+++ b/web_ui/frontend/app/registry/page.tsx
@@ -47,6 +47,7 @@ import { PendingCardProps } from '@/components/Namespace/PendingCard';
 import { AlertDispatchContext } from '@/components/AlertProvider';
 import { alertOnError } from '@/helpers/util';
 import { getExtendedNamespaces } from '@/helpers/get';
+import { NAMESPACE_KEY } from '@/helpers/api';
 
 export default function Home() {
   const dispatch = useContext(AlertDispatchContext);
@@ -54,7 +55,7 @@ export default function Home() {
   const { data, mutate: mutateNamespaces } = useSWR<
     { namespace: RegistryNamespace }[] | undefined
   >(
-    'getExtendedNamespaces',
+    NAMESPACE_KEY,
     () =>
       alertOnError(
         getExtendedNamespaces,

--- a/web_ui/frontend/components/Namespace/Card.tsx
+++ b/web_ui/frontend/components/Namespace/Card.tsx
@@ -23,7 +23,7 @@ import Link from 'next/link';
 import InformationDropdown from './InformationDropdown';
 import { NamespaceIcon } from '@/components/Namespace/index';
 import { User } from '@/index';
-import { deleteNamespace } from '@/helpers/api';
+import { deleteNamespace, NAMESPACE_KEY } from '@/helpers/api';
 import { useSWRConfig } from 'swr';
 import { AlertDispatchContext } from '@/components/AlertProvider';
 import { alertOnError } from '@/helpers/util';
@@ -156,7 +156,7 @@ export const Card = ({ namespace, authenticated, onUpdate }: CardProps) => {
                           'Could Not Delete Registration',
                           dispatch
                         );
-                        setTimeout(() => mutate('getExtendedNamespaces'), 600);
+                        await mutate(NAMESPACE_KEY);
                         if (onUpdate) {
                           onUpdate();
                         }

--- a/web_ui/frontend/components/Namespace/DeniedCard.tsx
+++ b/web_ui/frontend/components/Namespace/DeniedCard.tsx
@@ -10,7 +10,11 @@ import { AlertContext, AlertDispatchContext } from '@/components/AlertProvider';
 import { User } from '@/index';
 import { useSWRConfig } from 'swr';
 import CodeBlock from '@/components/CodeBlock';
-import { approveNamespace, deleteNamespace } from '@/helpers/api';
+import {
+  approveNamespace,
+  deleteNamespace,
+  NAMESPACE_KEY,
+} from '@/helpers/api';
 import { alertOnError } from '@/helpers/util';
 
 export interface DeniedCardProps {
@@ -89,6 +93,7 @@ export const DeniedCard = ({ namespace, authenticated }: DeniedCardProps) => {
                           'Could Not Delete Registration',
                           dispatch
                         );
+                        mutate(NAMESPACE_KEY);
                       }}
                     >
                       <Delete />
@@ -105,7 +110,7 @@ export const DeniedCard = ({ namespace, authenticated }: DeniedCardProps) => {
                           'Could Not Approve Registration',
                           dispatch
                         );
-                        setTimeout(() => mutate('getExtendedNamespaces'), 600);
+                        mutate(NAMESPACE_KEY);
                       }}
                     >
                       <Check />

--- a/web_ui/frontend/helpers/api.ts
+++ b/web_ui/frontend/helpers/api.ts
@@ -158,6 +158,8 @@ export const getDirectorNamespaces = async () => {
   return await fetchApi(async () => await fetch(url));
 };
 
+export const NAMESPACE_KEY = 'getNamespaces';
+
 /**
  * Get namespaces
  */


### PR DESCRIPTION
- Create single mutate key for all getExtendedNamespace functions that is called when the data is updated

Closes #2124