### PR TITLE
Properly handle the trailing`/` in namespace registration and advertisement

### DIFF
--- a/director/director.go
+++ b/director/director.go
@@ -993,6 +993,11 @@ func registerServerAd(engineCtx context.Context, ctx *gin.Context, sType server_
 		adV2 = server_structs.ConvertOriginAdV1ToV2(ad)
 	}
 
+	// Check every namespace path to strip the trailing slash
+	for i := range adV2.Namespaces {
+		adV2.Namespaces[i].Path = server_utils.RemoveTrailingSlash(adV2.Namespaces[i].Path)
+	}
+
 	// Filter the advertised prefixes in the cache server ad
 	// based on the allowed prefixes for caches data.
 	if sType == server_structs.CacheType {
@@ -1061,7 +1066,7 @@ func registerServerAd(engineCtx context.Context, ctx *gin.Context, sType server_
 	// Verify server registration
 	token := strings.TrimPrefix(tokens[0], "Bearer ")
 
-	registryPrefix := adV2.RegistryPrefix
+	registryPrefix := server_utils.RemoveTrailingSlash(adV2.RegistryPrefix)
 	verifyServer := true
 	if registryPrefix == "" {
 		if sType == server_structs.OriginType {

--- a/registry/registry_validation.go
+++ b/registry/registry_validation.go
@@ -55,7 +55,7 @@ func validatePrefix(nspath string) (string, error) {
 	result := ""
 	for _, component := range components {
 		if len(component) == 0 {
-			continue
+			continue // This can remove the trailing '/' in nspath
 		} else if component == "." {
 			return "", errors.New("Path component cannot be '.'")
 		} else if component == ".." {

--- a/server_utils/origin_test.go
+++ b/server_utils/origin_test.go
@@ -42,6 +42,9 @@ var (
 	//go:embed resources/posix-origins/multi-export-valid.yml
 	multiExportValidConfig string
 
+	//go:embed resources/posix-origins/multi-export-trailing-slash.yml
+	multiExportTrailingSlashConfig string
+
 	//go:embed resources/posix-origins/single-export-block.yml
 	singleExportBlockConfig string
 
@@ -205,6 +208,16 @@ func TestGetExports(t *testing.T) {
 		assert.Len(t, exports, 2, "expected 2 exports")
 		assert.Equal(t, expectedExport1, exports[0])
 		assert.Equal(t, expectedExport2, exports[1])
+	})
+
+	t.Run("testTrailingSlashRemovalPosix", func(t *testing.T) {
+		defer ResetTestState()
+		exports := setup(t, multiExportTrailingSlashConfig, false)
+
+		// Both trailing-slash prefixes should have been trimmed
+		assert.Len(t, exports, 2)
+		assert.Equal(t, "/first/namespace", exports[0].FederationPrefix)
+		assert.Equal(t, "/", exports[1].FederationPrefix)
 	})
 
 	t.Run("testExportVolumesValid", func(t *testing.T) {

--- a/server_utils/resources/posix-origins/multi-export-trailing-slash.yml
+++ b/server_utils/resources/posix-origins/multi-export-trailing-slash.yml
@@ -1,0 +1,13 @@
+# Origin export configuration to test if the Director can strip trailing slashes 
+# in the advertising prefixes
+
+Origin:
+  StorageType: "posix"
+  EnableDirectReads: true
+  Exports:
+    - StoragePrefix: /foo
+      FederationPrefix: /first/namespace/
+      Capabilities: ["PublicReads", "Writes"]
+    - StoragePrefix: /bar
+      FederationPrefix: /
+      Capabilities: ["Reads"]

--- a/server_utils/resources/posix-origins/multi-export-trailing-slash.yml
+++ b/server_utils/resources/posix-origins/multi-export-trailing-slash.yml
@@ -1,4 +1,4 @@
-# Origin export configuration to test if the Director can strip trailing slashes 
+# Origin export configuration to test if the Director can strip trailing slashes
 # in the advertising prefixes
 
 Origin:


### PR DESCRIPTION
We should allow user to set either `/foo/bar` or `/foo/bar/` as the federationprefix, but fundamentally treat them as the same (without trailing slash).

This patch switches the order of prefix validation and prefix existence checking. It removes the trailing slash for the user input prefix, which prevents the error [like this](https://github.com/PelicanPlatform/pelican/issues/1806#issuecomment-2840109314) in the future.

Closes #1806 