### PR TITLE
Correctly compare the total local size with the total downloaded size

### DIFF
--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -945,7 +945,7 @@ func TestResume(t *testing.T) {
 		} else if r.Method == "GET" {
 			require.Equal(t, "bytes=9-", r.Header.Get("Range"))
 			w.Header().Set("Content-Range", "bytes 9-16/17")
-			w.WriteHeader(http.StatusOK)
+			w.WriteHeader(http.StatusPartialContent)
 			_, err := w.Write([]byte(" content"))
 			assert.NoError(t, err)
 		} else {


### PR DESCRIPTION
Previously, only the bytes from the latest attempt (which doesn't necessarily start at the beginning of the file if done during a retry) were used, meaning the comparison with total size always failed.

Additionally, avoid doing a transfer retry when there are zero bytes left to transfer.  That will always fail.