### PR TITLE
Toggle origin/cache downtimes in director correctly

### DIFF
--- a/director/director.go
+++ b/director/director.go
@@ -1169,33 +1169,36 @@ func registerServerAd(engineCtx context.Context, ctx *gin.Context, sType server_
 	// Process received server(origin/cache) downtimes and toggle the director's in-memory downtime tracker when necessary
 	if adV2.Downtimes != nil {
 		filteredServersMutex.Lock()
+		defer filteredServersMutex.Unlock()
+
+		// Update the cached server downtime list
 		serverDowntimes[adV2.Name] = adV2.Downtimes
-		currentTime := time.Now().UTC().UnixMilli()
-		bringItDown := false // Flag to indicate if this server is put in downtime during the traversal of the downtimes in this server ad
+
+		now := time.Now().UTC().UnixMilli()
 		sn := adV2.Name
-		// Check existing downtime filter
-		originalFilterType, hasOriginalFilter := filteredServers[sn]
-		// If this server is already put in downtime, we don't need to do anything
-		if !(hasOriginalFilter && originalFilterType != tempAllowed) {
-			// Check if the server is currently in downtime
-			for _, downtime := range adV2.Downtimes {
-				if downtime.StartTime < currentTime && (downtime.EndTime > currentTime || downtime.EndTime == server_structs.IndefiniteEndTime) {
-					// Server is currently in downtime
-					filteredServers[sn] = serverFiltered
-					bringItDown = true
-					break
-				}
+		active := false // Flag to indicate if this server has active downtime in this server ad
+		for _, dt := range adV2.Downtimes {
+			if dt.StartTime <= now &&
+				(dt.EndTime >= now || dt.EndTime == server_structs.IndefiniteEndTime) {
+				active = true
+				break
 			}
 		}
-		// If the server doesn't have an active downtime, it means Director's previously
-		// recorded downtime set by the server admin is stale and should be removed.
-		// It only removes the downtime set by the server admin, not the downtime set by others.
-		if !bringItDown {
-			if hasOriginalFilter && originalFilterType == serverFiltered {
+
+		// Inspect the existing downtime status for this server
+		existing, had := filteredServers[sn]
+
+		if active {
+			// Only override if there's no filter
+			if !had {
+				filteredServers[sn] = serverFiltered
+			}
+		} else {
+			// Clear only the downtimes with serverFiltered tag if it’s stale
+			if had && existing == serverFiltered {
 				delete(filteredServers, sn)
 			}
 		}
-		filteredServersMutex.Unlock()
 	}
 
 	// Forward to other directors, if applicable

--- a/director/director.go
+++ b/director/director.go
@@ -1186,16 +1186,16 @@ func registerServerAd(engineCtx context.Context, ctx *gin.Context, sType server_
 		}
 
 		// Inspect the existing downtime status for this server
-		existing, had := filteredServers[sn]
+		existingFilterType, isServerFiltered := filteredServers[sn]
 
 		if active {
 			// Only override if there's no filter
-			if !had {
+			if !isServerFiltered {
 				filteredServers[sn] = serverFiltered
 			}
 		} else {
 			// Clear only the downtimes with serverFiltered tag if it’s stale
-			if had && existing == serverFiltered {
+			if isServerFiltered && existingFilterType == serverFiltered {
 				delete(filteredServers, sn)
 			}
 		}


### PR DESCRIPTION
Fix the bug that when the Director toggles the downtimes set by origin/cache, it skips re-evaluating any server that already has a filter (downtime).

Also simplify the code logics.

For example, let's say there is a downtime entry set by the Origin and propagated to the Director with server ads every minute:

> Note: "existing" means "existingFilterType", "had" means "isServerFiltered" in the code
> First ever “active” → had==false, so it sets serverFiltered.
> 
> Subsequent still-active → had==true && existing==serverFiltered, it doesn’t enter the `!had` branch, but we also don’t delete, because active==true skips the delete block.
> 
> Subsequent no longer active → active == false && had == true && existing == serverFiltered, so it falls into the delete block
> 
> Change time: Active to future downtime → active==false, so it hits the delete block (because existing==serverFiltered) and remove it.
> 
> Change time: Future to active downtime → had==false again, so it’ll set it back in filteredServers.

Closes #2279