### PR TITLE
RPM: Specify pre-install script requirements by binary instead of by containing package

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -170,10 +170,9 @@ nfpms:
               group: pelican
         dependencies:
           - "/bin/sh"
+          - "/usr/bin/getent"
           # for useradd and groupadd:
           - "shadow-utils"
-          # for getent:
-          - "glibc-common"
       deb:
         contents:
           - src: LICENSE

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -171,8 +171,8 @@ nfpms:
         dependencies:
           - "/bin/sh"
           - "/usr/bin/getent"
-          # for useradd and groupadd:
-          - "shadow-utils"
+          - "/usr/sbin/useradd"
+          - "/usr/sbin/groupadd"
       deb:
         contents:
           - src: LICENSE


### PR DESCRIPTION
Closes #2284 . The packages providing `/usr/bin/getent`, `/usr/sbin/useradd`, and `/usr/sbin/groupadd` (used in the pre-install script to create the `pelican` user and group) are not named the same on openSUSE Leap vs RHEL-based distributions. We can get around the issue by requiring the specific files instead.
