### PR TITLE
Don't refresh expiration on serverAds.Get()

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1559,9 +1559,13 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 
 			viper.Set(param.Director_RegistryQueryInterval.GetName(), "1m")
 		}
-	}
 
-	if currentServers.IsEnabled(server_structs.DirectorType) {
+		if adTTL := param.Director_AdvertisementTTL.GetDuration(); adTTL <= 0 {
+			log.Warningf("Invalid value of '%s' for config param %s; must be greater than 0, falling back to default of 15 minutes",
+				adTTL, param.Director_AdvertisementTTL.GetName())
+			viper.Set(param.Director_AdvertisementTTL.GetName(), "15m")
+		}
+
 		viper.SetDefault("Federation.DirectorUrl", param.Server_ExternalWebUrl.GetString())
 		minStatRes := param.Director_MinStatResponse.GetInt()
 		maxStatRes := param.Director_MaxStatResponse.GetInt()

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -54,7 +54,8 @@ const (
 
 var (
 	// The in-memory cache of xrootd server advertisement, with the key being ServerAd.URL.String()
-	serverAds = ttlcache.New(ttlcache.WithTTL[string, *server_structs.Advertisement](param.Director_AdvertisementTTL.GetDuration()))
+	serverAds = ttlcache.New(ttlcache.WithTTL[string, *server_structs.Advertisement](param.Director_AdvertisementTTL.GetDuration()),
+		ttlcache.WithDisableTouchOnHit[string, *server_structs.Advertisement]())
 	// The map holds servers that are disabled, with the key being the ServerAd.Name
 	// The map should be idenpendent of serverAds as we want to persist this change in-memory, regardless of the presence of the serverAd
 	filteredServers = map[string]filterType{}

--- a/go.mod
+++ b/go.mod
@@ -196,7 +196,7 @@ require (
 	golang.org/x/sync v0.12.0
 	golang.org/x/text v0.23.0
 	golang.org/x/time v0.5.0
-	google.golang.org/appengine v1.6.8
+	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	kernel.org/pub/linux/libs/security/libcap/psx v1.2.69 // indirect


### PR DESCRIPTION
The bug here was nuanced -- if a server had previously succeeded at advertising but was restarted quickly in a way that caused advertisement failure, the IO Stats routine would refresh the ad every 15 seconds, completely preventing expiration. This adds the disable on touch option so that these ads can expire.

I've also added it as the default behavior on ttlcache instantiation as well. Why do it in both places, you may ask? I want to future proof the bug against anyone purposefully/accidentally removing the default from the ttlcache instantiation, while also adding some protection against this type of bug for anyone in the future who might write a routine that calls `serverAds.Get()` without remembering to include the option there as well. Including the option in both places covers both of these bases.