### PR TITLE
Handle directories permission denied error in drop privs mode

### DIFF
--- a/cmd/generate_password.go
+++ b/cmd/generate_password.go
@@ -33,6 +33,7 @@ import (
 	"github.com/tg123/go-htpasswd"
 	"golang.org/x/term"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/web_ui"
 )
@@ -121,6 +122,15 @@ func passwordMain(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	file.Close()
+
+	// chown the file to the pelican user
+	user, err := config.GetPelicanUser()
+	if err != nil {
+		return errors.Wrap(err, "no OS user found for pelican")
+	}
+	if err := os.Chown(outPasswordPath, user.Uid, user.Gid); err != nil {
+		return errors.Wrapf(err, "failed to set ownership on %s", outPasswordPath)
+	}
 
 	_, err = htpasswd.New(outPasswordPath, []htpasswd.PasswdParser{htpasswd.AcceptBcrypt}, nil)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -1368,7 +1368,9 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 		// Set up the directories for the server to run as a non-root user;
 		// for the most part, we need to recursively chown and chmod the directory
 		// so either root or pelican can access it.
-		pelicanLocations := []string{}
+		pelicanLocations := []string{
+			param.Server_DbLocation.GetString(),
+		}
 		if currentServers.IsEnabled(server_structs.RegistryType) {
 			pelicanLocations = append(pelicanLocations, param.Registry_DbLocation.GetString())
 		}
@@ -1390,8 +1392,17 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 			return errors.Wrap(err, "failure when setting up the file permissions for pelican")
 		}
 
+		pelicanLocationsSingleFiles := []string{
+			param.Server_UIPasswordFile.GetString(),
+			param.IssuerKey.GetString(), // Backward compatibility for legacy key file
+		}
+		if err = setFilePerms(pelicanLocationsSingleFiles, 0640, puser.Uid, 0); err != nil {
+			return errors.Wrap(err, "failure when setting up the file permissions for pelican")
+		}
+
 		pelicanDirs := []string{
 			param.Monitoring_DataLocation.GetString(),
+			param.IssuerKeysDirectory.GetString(),
 		}
 		if currentServers.IsEnabled(server_structs.LocalCacheType) {
 			pelicanDirs = append(pelicanDirs, param.LocalCache_RunLocation.GetString())

--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -708,19 +708,8 @@ func GeneratePEM(dir string) (key jwk.Key, err error) {
 		return nil, errors.Wrap(err, "failed to get pelican user for setting ownership")
 	}
 
-	// Windows does not have "chown", has to work differently
-	currentOS := runtime.GOOS
-	if currentOS == "windows" {
-		cmd := exec.Command("icacls", fname, "/grant", user.Username+":F")
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to chown generated key %v to daemon group %v: %s",
-				fname, user.Groupname, string(output))
-		}
-	} else { // Else we are running on linux/mac
-		if err = os.Chown(fname, user.Uid, user.Gid); err != nil {
-			return nil, errors.Wrapf(err, "failed to chown key file %s", fname)
-		}
+	if err = SetOwnershipAndPermissions(fname, 0640, user); err != nil {
+		return nil, errors.Wrapf(err, "failed to set ownership and permissions for %s", fname)
 	}
 
 	if err = generatePrivateKeyToFile(keyFile, elliptic.P256()); err != nil {

--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -671,6 +671,7 @@ func loadPEMFiles(dir string) (jwk.Key, error) {
 func GeneratePEM(dir string) (key jwk.Key, err error) {
 	var fname string
 	var keyFile *os.File
+
 	if dir == "" {
 		issuerKeyLocation := param.IssuerKey.GetString()
 		if issuerKeyLocation == "" {
@@ -685,8 +686,7 @@ func GeneratePEM(dir string) (key jwk.Key, err error) {
 			return
 		}
 	} else {
-		// Generate a unique filename using a POSIX mkstemp-like logic
-		// Create a temp file, store its filename, then immediately delete this temp file
+		// Generate a unique filename
 		filenamePattern := fmt.Sprintf("pelican_generated_%d_*.pem",
 			time.Now().UnixNano())
 		if err = createDirForKeys(dir); err != nil {
@@ -695,13 +695,25 @@ func GeneratePEM(dir string) (key jwk.Key, err error) {
 		}
 		keyFile, err = os.CreateTemp(dir, filenamePattern)
 		if err != nil {
-			err = errors.Wrap(err, "failed to remove temp file")
+			err = errors.Wrap(err, "failed to create private key file")
 			return
 		}
 		fname = keyFile.Name()
 		log.Debugln("Generating new private key in the IssuerKeys directory at", fname)
 	}
 	defer keyFile.Close()
+
+	user, err := GetPelicanUser()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get pelican user for ownership: %v", err)
+	}
+
+	if err = os.Chmod(fname, 0640); err != nil {
+		return nil, errors.Wrapf(err, "failed to set permission for key file %s", fname)
+	}
+	if err = os.Chown(fname, user.Uid, user.Gid); err != nil {
+		return nil, errors.Wrapf(err, "failed to chown key file %s", fname)
+	}
 
 	if err = generatePrivateKeyToFile(keyFile, elliptic.P256()); err != nil {
 		return nil, errors.Wrapf(err, "failed to generate private key in file %s", fname)

--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -705,7 +705,7 @@ func GeneratePEM(dir string) (key jwk.Key, err error) {
 
 	user, err := GetPelicanUser()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get pelican user for ownership: %v", err)
+		return nil, errors.Wrap(err, "failed to get pelican user for setting ownership")
 	}
 
 	// Windows does not have "chown", has to work differently
@@ -714,7 +714,7 @@ func GeneratePEM(dir string) (key jwk.Key, err error) {
 		cmd := exec.Command("icacls", fname, "/grant", user.Username+":F")
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return nil, errors.Wrapf(err, "Failed to chown generated key %v to daemon group %v: %s",
+			return nil, errors.Wrapf(err, "failed to chown generated key %v to daemon group %v: %s",
 				fname, user.Groupname, string(output))
 		}
 	} else { // Else we are running on linux/mac

--- a/config/mkdirall.go
+++ b/config/mkdirall.go
@@ -101,6 +101,24 @@ func MkdirAll(path string, perm os.FileMode, uid int, gid int) error {
 	return nil
 }
 
+// Set the permissions on the targeted file only if it exists. Doesn't care about its parent or siblings
+func setFilePerms(paths []string, perm os.FileMode, uid int, gid int) error {
+	for _, path := range paths {
+		// Skip the file if it doesn't exist
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			continue
+		}
+		// Set the permissions on the file
+		if err := os.Chmod(path, perm); err != nil {
+			return errors.Wrapf(err, "Failed to set permissions on file %v", path)
+		}
+		if err := os.Chown(path, uid, gid); err != nil {
+			return errors.Wrapf(err, "Failed to chown file %v", path)
+		}
+	}
+	return nil
+}
+
 func setFileAndDirPerms(paths []string, dirPerm os.FileMode, perm os.FileMode, uid int, gid int, recursive bool) error {
 	dirs := map[string]bool{}
 	for _, path := range paths {

--- a/config/mkdirall.go
+++ b/config/mkdirall.go
@@ -110,10 +110,10 @@ func setFilePerms(paths []string, perm os.FileMode, uid int, gid int) error {
 		}
 		// Set the permissions on the file
 		if err := os.Chmod(path, perm); err != nil {
-			return errors.Wrapf(err, "Failed to set permissions on file %v", path)
+			return errors.Wrapf(err, "failed to set permissions on file %v", path)
 		}
 		if err := os.Chown(path, uid, gid); err != nil {
-			return errors.Wrapf(err, "Failed to chown file %v", path)
+			return errors.Wrapf(err, "failed to chown file %v", path)
 		}
 	}
 	return nil

--- a/config/mkdirall.go
+++ b/config/mkdirall.go
@@ -28,6 +28,28 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Apply the given permission bits and ownership to path in a cross-platform way.
+//   - On Windows it runs “icacls path /grant username:F”
+//   - On Linux/macOS it does os.Chmod(path, perm) then os.Chown(path, uid, gid)
+func SetOwnershipAndPermissions(path string, perm os.FileMode, user User) error {
+	if runtime.GOOS == "windows" {
+		cmd := exec.Command("icacls", path, "/grant", user.Username+":F")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return errors.Wrapf(err, "unable to modify ACLs on %q: %s", path, string(out))
+		}
+		return nil
+	}
+
+	// Assume macOS or Linux
+	if err := os.Chmod(path, perm); err != nil {
+		return errors.Wrapf(err, "unable to chmod %q to %v", path, perm)
+	}
+	if err := os.Chown(path, user.Uid, user.Gid); err != nil {
+		return errors.Wrapf(err, "unable to chown %q to %d:%d", path, user.Uid, user.Gid)
+	}
+	return nil
+}
+
 // This is the pelican version of `MkdirAll`; ensures that any created directory
 // is owned by a given uid/gid.  This allows the created directory to be owned by
 // the xrootd user.
@@ -76,27 +98,12 @@ func MkdirAll(path string, perm os.FileMode, uid int, gid int) error {
 	}
 
 	// Set ownership on the directory that we just created.
-	if runtime.GOOS == "windows" {
-		username, err := GetDaemonUser() // FIXME (brianaydemir): This is not the correct user.
-		if err != nil {
-			return err
-		}
-		cmd := exec.Command("icacls", path, "/grant", username+":F")
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			return errors.Wrapf(err, "unable to modify discretionary ACLs on directory %v: %s", path, string(output))
-		}
-	} else { // Assume macOS or Linux.
-		// Any default system umask may prevent previous application of the permissions
-		// from taking effect. To override this, set the permissions explicitly
-		// after creation.
-		if err = os.Chmod(path, perm); err != nil {
-			return errors.Wrapf(err, "unable to chmod on directory %v to %v", path, perm)
-		}
-
-		if err = os.Chown(path, uid, gid); err != nil {
-			return errors.Wrapf(err, "unable to chown on directory %v to %v:%v", path, uid, gid)
-		}
+	user, err := GetPelicanUser()
+	if err != nil {
+		return errors.Wrap(err, "failed to get pelican user")
+	}
+	if err = SetOwnershipAndPermissions(path, perm, User{Uid: uid, Gid: gid, Username: user.Username}); err != nil {
+		return errors.Wrapf(err, "failed to set ownership and permissions for %s", path)
 	}
 	return nil
 }

--- a/xrootd/authorization.go
+++ b/xrootd/authorization.go
@@ -191,7 +191,8 @@ func writeScitokensConfiguration(modules server_structs.ServerType, cfg *Scitoke
 			return errors.Wrap(err, "failed to seek to beginning of the file")
 		}
 
-		// Use plugin to transplant the final file to a directory owned by xrootd. This is because
+		// Use command "7" in xrdhttp-pelican plugin to transplant the scitoken config file to a
+		// directory owned by xrootd. The directory is specified in `xrootd/launch.go`. This is because
 		// the xrootd daemon will periodically reload the scitokens.cfg and, in some cases, we may
 		// want to update it without restarting the server.
 		if err = FileCopyToXrootdDir(modules.IsEnabled(server_structs.OriginType), 7, file); err != nil {
@@ -418,6 +419,9 @@ func EmitAuthfile(server server_structs.XRootDServer) error {
 			return errors.Wrap(err, "failed to seek to beginning of the file")
 		}
 
+		// Transplant the auth file using the xrdhttp-pelican plugin so xrootd can access it.
+		// Command "6" instructs the plugin to put the auth file into the designated location owned by "xrootd" user,
+		// which is specified in `xrootd/launch.go`.
 		if err = FileCopyToXrootdDir(server.GetServerType().IsEnabled(server_structs.OriginType), 6, file); err != nil {
 			return errors.Wrap(err, "failed to copy the auth file to the xrootd directory")
 		}

--- a/xrootd/launch.go
+++ b/xrootd/launch.go
@@ -165,6 +165,19 @@ func makeUnprivilegedXrootdLauncher(daemonName string, configPath string, isCach
 		testFileCinfoLocation := filepath.Join(basePath, "self-test-cache-server.txt.cinfo")
 		result.ExtraEnv = append(result.ExtraEnv, "XRDHTTP_PELICAN_CACHE_SELF_TEST_FILE="+testFileLocation)
 		result.ExtraEnv = append(result.ExtraEnv, "XRDHTTP_PELICAN_CACHE_SELF_TEST_FILE_CINFO="+testFileCinfoLocation)
+
+		xrootdRun := param.Origin_RunLocation.GetString()
+		authFileName := "authfile-origin-generated"
+		scitokensCfgFileName := "scitokens-origin-generated.cfg"
+		if isCache {
+			xrootdRun = param.Cache_RunLocation.GetString()
+			authFileName = "authfile-cache-generated"
+			scitokensCfgFileName = "scitokens-cache-generated.cfg"
+		}
+		authPath := filepath.Join(xrootdRun, authFileName)
+		configPath := filepath.Join(xrootdRun, scitokensCfgFileName)
+		result.ExtraEnv = append(result.ExtraEnv, "XRDHTTP_PELICAN_AUTHFILE_GENERATED="+authPath)
+		result.ExtraEnv = append(result.ExtraEnv, "XRDHTTP_PELICAN_SCITOKENS_GENERATED="+configPath)
 	}
 	return
 }

--- a/xrootd/self_monitor.go
+++ b/xrootd/self_monitor.go
@@ -246,8 +246,7 @@ func generateTestFileViaPlugin() (string, error) {
 	}
 
 	// Construct and return the URL of the copied test file in the selfTestDir
-	cachePort := param.Cache_Port.GetInt()
-	baseUrlStr := fmt.Sprintf("https://%s:%d", param.Server_Hostname.GetString(), cachePort)
+	baseUrlStr := fmt.Sprintf("https://%s:%d", param.Server_Hostname.GetString(), param.Cache_Port.GetInt())
 	baseUrl, err := url.Parse(baseUrlStr)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to validate the base url for self-test download")

--- a/xrootd/self_monitor.go
+++ b/xrootd/self_monitor.go
@@ -236,12 +236,12 @@ func generateTestFileViaPlugin() (string, error) {
 	// Transplant the test file to selfTestDir using the xrdhttp-pelican plugin.
 	// Command "4" instructs the plugin to put the test file into the designated location, which is specified in `xrootd/launch.go`.
 	// Check `src/XrdHttpPelican.cc` in https://github.com/PelicanPlatform/xrdhttp-pelican for the counterpart in the plugin.
-	if err = SelfTestFileCopy(4, file); err != nil {
+	if err = FileCopyToXrootdDir(false, 4, file); err != nil {
 		return "", errors.Wrap(err, "failed to copy the test file to the self-test directory")
 	}
 	// Transplant the cinfo file to selfTestDir using the xrdhttp-pelican plugin.
 	// Command "5" instructs the plugin to put the cinfo file into the designated location, which is specified in `xrootd/launch.go`.
-	if err = SelfTestFileCopy(5, cinfoFile); err != nil {
+	if err = FileCopyToXrootdDir(false, 5, cinfoFile); err != nil {
 		return "", errors.Wrap(err, "failed to copy the test cinfo file to the self-test directory")
 	}
 

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -611,10 +611,10 @@ func copyXrootdCertificates(server server_structs.XRootDServer) error {
 	return nil
 }
 
-func SelfTestFileCopy(cmd int, file *os.File) error {
-	log.Debug("Transplanting a self-test file")
-	if err := sendChildFD(false, cmd, file); err != nil {
-		return errors.Wrap(err, "Failed to copy the self-test file via FD")
+func FileCopyToXrootdDir(isOrigin bool, cmd int, file *os.File) error {
+	log.Debugf("Transplanting file %s to a directory owned by the xrootd process", file.Name())
+	if err := sendChildFD(isOrigin, cmd, file); err != nil {
+		return errors.Wrapf(err, "Failed to copy the file %s via FD", file.Name())
 	}
 	return nil
 }


### PR DESCRIPTION
This PR is built on top of #2120, which should be reviewed first.

During the development of the above PR, I notice there are several other permissions denied errors happened on several directories/locations, as below:

```
WARNING[2025-03-17T17:06:33Z] Failed to open auth database for reload:open /etc/pelican/server-web-passwd: permission denied

WARNING[2025-03-17T17:07:03Z] Failed to load key /etc/pelican/issuer-keys/pelican_generated_1740770124479586092_2096306543.pem: failed to read key file: open /etc/pelican/issuer-keys/pelican_generated_1740770124479586092_2096306543.pem: permission denied

ERROR[2025-03-17T17:08:03Z] Failure when generating authfile: Failed to create a generated authfile /run/pelican/xrootd/cache/authfile-cache-generated: open /run/pelican/xrootd/cache/authfile-cache-generated: permission denied

ERROR[2025-03-17T17:08:03Z] Failure when emitting the scitokens.cfg: Failed to create a temporary scitokens file /run/pelican/xrootd/cache/scitokens-generated.cfg.tmp: open /run/pelican/xrootd/cache/scitokens-generated.cfg.tmp: permission denied

WARNING[2025-04-30T13:45:36Z] Failure during xrootd maintenance routine: Failure when opening certificate key pair file to pass to xrootd: open /run/pelican/xrootd/cache/pelican/copied-tls-creds.crt: permission denied

WARNING[2025-03-17T17:07:03Z] Failure during cache director-based health test clean up routine: stat /run/pelican/cache/namespace/pelican/monitoring: permission denied
```

All of them except the last one are resolved in this PR - I didn't fix the last one because it is not urgent and xrootd already has a purge mechanism to deal with test files cleanup - I created a separate issue for this problem #2265 

### How to test

If you are on a fresh container, spin up all four Pelican services as usual to set up the initial configs. Then shut them down and restart Pelican services in drop privs mode by setting the following configs in `pelican.yaml`
```
Server:
  DropPrivileges: true
  UnprivilegedUser: pelican
```
Check the logging, search for "permissions denied". There should not be any result except the  "cache director-based health test clean up .... permission denied". Also consider doing other basic tests.