### PR TITLE
Persist a Pelican service's registered name

### DIFF
--- a/cmd/registry_client.go
+++ b/cmd/registry_client.go
@@ -38,6 +38,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/registry"
 )
 
@@ -113,15 +114,19 @@ func registerANamespace(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	siteName := param.Xrootd_Sitename.GetString()
+	if siteName == "" {
+		log.Errorf("Server name isn't set. Please set the name via %s", param.Xrootd_Sitename.GetName())
+		os.Exit(1)
+	}
 	if withIdentity {
-		// We haven't added support to pass sitename from CLI, so leave it empty
-		err := registry.NamespaceRegisterWithIdentity(privateKey, registrationEndpointURL, prefix, "")
+		err := registry.NamespaceRegisterWithIdentity(privateKey, registrationEndpointURL, prefix, siteName)
 		if err != nil {
 			log.Errorf("Failed to register prefix %s with identity: %v", prefix, err)
 			os.Exit(1)
 		}
 	} else {
-		err := registry.NamespaceRegister(privateKey, registrationEndpointURL, "", prefix, "")
+		err := registry.NamespaceRegister(privateKey, registrationEndpointURL, "", prefix, siteName)
 		if err != nil {
 			log.Errorf("Failed to register prefix %s: %v", prefix, err)
 			os.Exit(1)

--- a/database/server.go
+++ b/database/server.go
@@ -2,8 +2,11 @@ package database
 
 import (
 	"embed"
+	"strings"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 
@@ -148,4 +151,48 @@ func ShutdownDB() error {
 		log.Errorln("Failure when shutting down the database:", err)
 	}
 	return err
+}
+
+// Create or update a record for the given serverName
+// 1) If no such row exists, it inserts a new one.
+// 2) If a row with that name exists, it updates updated_at (and type).
+func UpsertServiceName(serverName string, typ server_structs.ServerType) error {
+	now := time.Now()
+
+	// look for existing
+	var entry server_structs.ServiceName
+	err := ServerDatabase.Where("name = ?", serverName).First(&entry).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		// no existing row → insert
+		entry = server_structs.ServiceName{
+			ID:        uuid.NewString(),
+			Name:      serverName,
+			Type:      strings.ToLower(typ.String()),
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		return ServerDatabase.Create(&entry).Error
+	}
+	if err != nil {
+		return err
+	}
+
+	// found → update timestamp
+	entry.UpdatedAt = now
+	entry.Type = strings.ToLower(typ.String())
+	return ServerDatabase.Save(&entry).Error
+}
+
+// Retrieve the server name in use - lookup the entry whose UpdatedAt is the most recent
+func GetServiceName() (string, error) {
+	var entry server_structs.ServiceName
+	// There is an index in the database to speed up this query
+	err := ServerDatabase.
+		Order("updated_at DESC").
+		First(&entry).Error
+	if err != nil {
+		// err will be gorm.ErrRecordNotFound if there's no matching row
+		return "", err
+	}
+	return entry.Name, nil
 }

--- a/database/server_test.go
+++ b/database/server_test.go
@@ -1,10 +1,13 @@
 package database
 
 import (
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/glebarez/sqlite"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
@@ -153,5 +156,131 @@ func TestDeleteDowntime(t *testing.T) {
 		err = ServerDatabase.First(&retrieved, "uuid = ?", mockDowntime.UUID).Error
 		assert.Error(t, err) // Expect record not found
 		assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
+	})
+}
+
+// Tests for server_name table
+
+func SetupMockServiceNameDB(t *testing.T) {
+	mockDB, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err, "opening in-memory sqlite DB")
+	ServerDatabase = mockDB
+	err = ServerDatabase.AutoMigrate(&server_structs.ServiceName{})
+	require.NoError(t, err, "migrating ServiceName schema")
+}
+
+func TeardownMockServiceNameDB(t *testing.T) {
+	err := ServerDatabase.Migrator().DropTable(&server_structs.ServiceName{})
+	require.NoError(t, err, "dropping ServiceName table")
+}
+
+func TestUpsertServiceName(t *testing.T) {
+	config.ResetConfig()
+	SetupMockServiceNameDB(t)
+	t.Cleanup(func() {
+		TeardownMockServiceNameDB(t)
+		config.ResetConfig()
+	})
+
+	const name1 = "server-one"
+	origType := server_structs.NewServerType()
+	origType.SetString("origin")
+	cacheType := server_structs.NewServerType()
+	cacheType.SetString("cache")
+
+	t.Run("insert-when-empty", func(t *testing.T) {
+		typ := server_structs.NewServerType()
+		typ.SetString("origin")
+		err := UpsertServiceName(name1, typ)
+		require.NoError(t, err)
+
+		var got server_structs.ServiceName
+		err = ServerDatabase.First(&got, "name = ?", name1).Error
+		require.NoError(t, err)
+
+		assert.Equal(t, name1, got.Name)
+		assert.Equal(t, strings.ToLower(typ.String()), got.Type)
+		assert.WithinDuration(t, time.Now().UTC(), got.CreatedAt, time.Second)
+		assert.WithinDuration(t, time.Now().UTC(), got.UpdatedAt, time.Second)
+	})
+
+	t.Run("update-existing-record", func(t *testing.T) {
+		// seed initial
+		err := UpsertServiceName(name1, origType)
+		require.NoError(t, err)
+
+		// capture original timestamps & ID
+		var original server_structs.ServiceName
+		require.NoError(t,
+			ServerDatabase.First(&original, "name = ?", name1).Error,
+		)
+
+		// Upsert with same name
+		err = UpsertServiceName(name1, origType)
+		require.NoError(t, err)
+
+		var updated server_structs.ServiceName
+		require.NoError(t,
+			ServerDatabase.First(&updated, "name = ?", name1).Error,
+		)
+
+		assert.Equal(t, original.ID, updated.ID, "ID should be unchanged")
+		assert.Equal(t, original.CreatedAt.UnixNano(), updated.CreatedAt.UnixNano(),
+			"CreatedAt should be unchanged")
+		assert.True(t, updated.UpdatedAt.After(original.UpdatedAt),
+			"UpdatedAt should be newer")
+		assert.Equal(t, strings.ToLower(origType.String()), updated.Type, "Type should not be updated")
+	})
+
+	t.Run("insert-second-record-when-name-differs", func(t *testing.T) {
+		err := UpsertServiceName(name1, origType)
+		require.NoError(t, err)
+		err = UpsertServiceName("server-two", cacheType)
+		require.NoError(t, err)
+
+		var count int64
+		require.NoError(t,
+			ServerDatabase.Model(&server_structs.ServiceName{}).Count(&count).Error,
+		)
+		assert.Equal(t, int64(2), count, "should have two distinct rows")
+	})
+}
+
+func TestGetServiceName(t *testing.T) {
+	config.ResetConfig()
+	SetupMockServiceNameDB(t)
+	t.Cleanup(func() {
+		TeardownMockServiceNameDB(t)
+		config.ResetConfig()
+	})
+
+	t.Run("empty-table", func(t *testing.T) {
+		_, err := GetServiceName()
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, gorm.ErrRecordNotFound))
+	})
+
+	t.Run("returns-latest-by-updated_at", func(t *testing.T) {
+		now := time.Now().UTC()
+		old := server_structs.ServiceName{
+			ID:        uuid.NewString(),
+			Name:      "old-server",
+			Type:      "cache",
+			CreatedAt: now.Add(-2 * time.Hour),
+			UpdatedAt: now.Add(-2 * time.Hour),
+		}
+		recent := server_structs.ServiceName{
+			ID:        uuid.NewString(),
+			Name:      "new-server",
+			Type:      "origin",
+			CreatedAt: now.Add(-1 * time.Hour),
+			UpdatedAt: now.Add(-1 * time.Hour),
+		}
+		require.NoError(t, ServerDatabase.Create(&old).Error)
+		require.NoError(t, ServerDatabase.Create(&recent).Error)
+
+		got, err := GetServiceName()
+		require.NoError(t, err)
+		assert.Equal(t, "new-server", got)
 	})
 }

--- a/database/universal_migrations/20250507041205_server_name.sql
+++ b/database/universal_migrations/20250507041205_server_name.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Persist service name and its history locally
+CREATE TABLE IF NOT EXISTS service_names (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    deleted_at DATETIME
+);
+-- Add index to speed up retrieval of the most recently updated (currently in use) service name
+CREATE INDEX IF NOT EXISTS idx_service_names_updated_at ON service_names(updated_at);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_service_names_updated_at;
+DROP TABLE IF EXISTS service_names;
+-- +goose StatementEnd

--- a/launcher_utils/advertise.go
+++ b/launcher_utils/advertise.go
@@ -39,6 +39,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/database"
 	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
@@ -114,6 +115,11 @@ func advertiseInternal(ctx context.Context, server server_structs.XRootDServer) 
 	name, err := server_utils.GetServiceName(ctx, server.GetServerType())
 	if err != nil {
 		return errors.Wrap(err, "failed to determine service name for advertising to director")
+	}
+
+	// Keep the service name in local database up to date
+	if err = database.UpsertServiceName(name, server.GetServerType()); err != nil {
+		return errors.Wrapf(err, "failed to upsert service name %s in local database", name)
 	}
 
 	if err = server.GetNamespaceAdsFromDirector(); err != nil {

--- a/launcher_utils/register_namespace.go
+++ b/launcher_utils/register_namespace.go
@@ -272,6 +272,9 @@ func RegisterNamespaceWithRetry(ctx context.Context, egrp *errgroup.Group, prefi
 		retryInterval = 10 * time.Second
 	}
 	siteName := param.Xrootd_Sitename.GetString()
+	if siteName == "" {
+		return errors.Errorf("Server name isn't set. Please set the name via %s", param.Xrootd_Sitename.GetName())
+	}
 
 	key, url, isRegistered, err := registerNamespacePrep(ctx, prefix)
 	if err != nil {

--- a/server_structs/db.go
+++ b/server_structs/db.go
@@ -1,6 +1,10 @@
 package server_structs
 
-import "time"
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
 
 type (
 	ApiKeyCached struct {
@@ -27,5 +31,14 @@ type (
 		ExpiresAt   time.Time `json:"expiration"`
 		CreatedAt   time.Time `json:"createdAt"`
 		CreatedBy   string    `gorm:"column:created_by;type:text" json:"createdBy"`
+	}
+
+	ServiceName struct {
+		ID        string         `gorm:"primaryKey;column:id;type:TEXT"`
+		Name      string         `gorm:"column:name;type:TEXT;not null"`
+		Type      string         `gorm:"column:type;type:TEXT;not null"`
+		CreatedAt time.Time      `gorm:"column:created_at;autoCreateTime"`
+		UpdatedAt time.Time      `gorm:"column:updated_at;autoUpdateTime"`
+		DeletedAt gorm.DeletedAt `gorm:"column:deleted_at;index"`
 	}
 )


### PR DESCRIPTION
### Big Picture

> In Pelican, semantically `site name` ~= `service name` == `server name`

In Registry database, there is a data field - 'admin_metadata'.'site_name' - that persists the  server's name in the federation. However, in OSDF production, 23 (out of 121) servers are missing this data field in the Registry. Consequently, these 23 servers even don't know what who they are - the name they have registered with! 

For any registered server, it can not determine which name is used for advertisement - 'admin_metadata'.'site_name' OR param.Xrootd_Sitename - especially if they changed the sitename in configs after the registration.

### This PR

1. Persist service name and history in the local database. Servers can easily know that what name they are advertising with now.
2. Enforce that the sitename must not be empty in the registration, so for all servers registered in the future, the Registry database will know their sitename