### PR TITLE
Dev QOL Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs/parameters.json
 web_ui/frontend/public/data/parameters.json
 local
 web_ui/frontend/app/api/docs/pelican-swagger.yaml
+.goreleaser.dev.yml

--- a/Makefile
+++ b/Makefile
@@ -45,20 +45,12 @@ endif
 WEBSITE_SRC_PATH := web_ui/frontend
 WEBSITE_OUT_PATH := web_ui/frontend/out
 WEBSITE_CACHE_PATH := web_ui/frontend/.next
-WEBSITE_SRC_FILES := $(shell find $(WEBSITE_SRC_PATH)/app -type f) \
-						$(shell find $(WEBSITE_SRC_PATH)/components -type f) \
-						$(shell find $(WEBSITE_SRC_PATH)/helpers -type f) \
-						$(shell find $(WEBSITE_SRC_PATH)/public -type f) \
-						web_ui/frontend/tsconfig.json \
-						web_ui/frontend/next.config.js \
-						web_ui/frontend/package.json \
-						web_ui/frontend/package-lock.json \
-						web_ui/frontend/Dockerfile
 
-WEBSITE_OUT_FILE := $(WEBSITE_OUT_FILES)/index.html
-
+WEBSITE_SRC_FILES := $(shell find $(WEBSITE_SRC_PATH) -type f -not -path "*.next*" -not -path "*out*" -not -path "*node_modules*" -not -path "*pelican-swagger.yaml")
 WEBSITE_CLEAN_LIST := $(WEBSITE_OUT_PATH) \
 						$(WEBSITE_CACHE_PATH)
+
+$(info These files have changed causing the website to have to rebuild: [$(shell find $(WEBSITE_SRC_PATH) -type f -not -path "*.next*" -not -path "*out*" -not -path "*node_modules*" -not -path "*pelican-swagger.yaml" -newer web_ui/frontend/out/index.html)])
 
 
 .PHONY: all
@@ -96,7 +88,7 @@ else
 web-build: generate web_ui/frontend/out/index.html
 endif
 
-web_ui/frontend/out/index.html : $(WEBSITE_SRC_FILES)
+web_ui/frontend/out/index.html : $(WEBSITE_SRC_FILES) swagger/pelican-swagger.yaml
 ifeq ($(USE_DOCKER),0)
 	@cd $(WEBSITE_SRC_PATH) && npm install && npm run build
 else
@@ -126,6 +118,15 @@ ifeq ($(USE_DOCKER),0)
 	@goreleaser --clean --snapshot
 else
 	@$(CONTAINER_TOOL) run -w /app -v $(PWD):/app goreleaser/goreleaser --clean --snapshot
+endif
+
+.PHONY: pelican-build
+pelican-dev-build:
+	@echo PELICAN BUILD
+ifeq ($(USE_DOCKER),0)
+	@goreleaser --clean --snapshot --config .goreleaser.dev.yml
+else
+	@$(CONTAINER_TOOL) run -w /app -v $(PWD):/app goreleaser/goreleaser --clean --snapshot --config .goreleaser.dev.yml
 endif
 
 .PHONY: pelican-serve-test-origin


### PR DESCRIPTION
- Add ability for dev goreleaser file to constrain the binaries that are built
- Fixed Makefile so the website-build step doesn't rely on a file that is symlinked in the step before but rather relies on the source of that file

Allows the inclusion of a goreleaser file usable with `make pelican-dev-build`.

```
# ***************************************************************
#
#  Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
#
#  Licensed under the Apache License, Version 2.0 (the "License"); you
#  may not use this file except in compliance with the License.  You may
#  obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
#  Unless required by applicable law or agreed to in writing, software
#  distributed under the License is distributed on an "AS IS" BASIS,
#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
#  See the License for the specific language governing permissions and
#  limitations under the License.
#
# ***************************************************************

project_name: pelican
version: 2

release:
  prerelease: true
before:
  hooks:
    - go mod tidy
    - go generate ./...
    - make web-build
builds:
  - env:
      - CGO_ENABLED=0
    goos:
      - linux
    goarch:
      - arm64
    id: "pelican"
    dir: ./cmd
    binary: pelican
    tags:
      - forceposix
    ldflags:
      - -s -w -X github.com/pelicanplatform/pelican/version.commit={{.Commit}} -X github.com/pelicanplatform/pelican/version.date={{.Date}} -X github.com/pelicanplatform/pelican/version.builtBy=goreleaser -X github.com/pelicanplatform/pelican/version.version={{.Version}}
checksum:
  name_template: "checksums.txt"
snapshot:
  version_template: "{{ .Version }}"
changelog:
  sort: asc
  filters:
    exclude:
      - "^docs:"
      - "^test:"
      - Merge pull request
      - Merge branch
```