### PR TITLE
Stop restarting Pelican if it crashes too frequently

### DIFF
--- a/systemd/osdf-cache.service
+++ b/systemd/osdf-cache.service
@@ -1,6 +1,8 @@
 [Unit]
 Description = Pelican service osdf-cache
 After = network.target nss-lookup.target
+StartLimitIntervalSec = 60
+StartLimitBurst = 3
 
 [Service]
 EnvironmentFile = -/etc/sysconfig/osdf-cache

--- a/systemd/osdf-director.service
+++ b/systemd/osdf-director.service
@@ -1,6 +1,8 @@
 [Unit]
 Description = Pelican service osdf-director
 After = network.target nss-lookup.target
+StartLimitIntervalSec = 60
+StartLimitBurst = 3
 
 [Service]
 EnvironmentFile = -/etc/sysconfig/osdf-director

--- a/systemd/osdf-origin.service
+++ b/systemd/osdf-origin.service
@@ -1,6 +1,8 @@
 [Unit]
 Description = Pelican service osdf-origin
 After = network.target nss-lookup.target
+StartLimitIntervalSec = 60
+StartLimitBurst = 3
 
 [Service]
 EnvironmentFile = -/etc/sysconfig/osdf-origin

--- a/systemd/osdf-registry.service
+++ b/systemd/osdf-registry.service
@@ -1,6 +1,8 @@
 [Unit]
 Description = Pelican service osdf-registry
 After = network.target nss-lookup.target
+StartLimitIntervalSec = 60
+StartLimitBurst = 3
 
 [Service]
 EnvironmentFile = -/etc/sysconfig/osdf-registry

--- a/systemd/pelican-cache.service
+++ b/systemd/pelican-cache.service
@@ -1,6 +1,8 @@
 [Unit]
 Description = Pelican service pelican-cache
 After = network.target nss-lookup.target
+StartLimitIntervalSec = 60
+StartLimitBurst = 3
 
 [Service]
 EnvironmentFile = -/etc/sysconfig/pelican-cache

--- a/systemd/pelican-director.service
+++ b/systemd/pelican-director.service
@@ -1,6 +1,8 @@
 [Unit]
 Description = Pelican service pelican-director
 After = network.target nss-lookup.target
+StartLimitIntervalSec = 60
+StartLimitBurst = 3
 
 [Service]
 EnvironmentFile = -/etc/sysconfig/pelican-director

--- a/systemd/pelican-origin.service
+++ b/systemd/pelican-origin.service
@@ -1,6 +1,8 @@
 [Unit]
 Description = Pelican service pelican-origin
 After = network.target nss-lookup.target
+StartLimitIntervalSec = 60
+StartLimitBurst = 3
 
 [Service]
 EnvironmentFile = -/etc/sysconfig/pelican-origin

--- a/systemd/pelican-registry.service
+++ b/systemd/pelican-registry.service
@@ -1,6 +1,8 @@
 [Unit]
 Description = Pelican service pelican-registry
 After = network.target nss-lookup.target
+StartLimitIntervalSec = 60
+StartLimitBurst = 3
 
 [Service]
 EnvironmentFile = -/etc/sysconfig/pelican-registry


### PR DESCRIPTION
Disable the SystemD auto-restart of Pelican services if they've exited after less than 60 seconds, 3 times in a row.  After that, the admin will need to `systemctl start SERVICE` by hand.
