### PR TITLE
Graceful shutdown an Origin or Cache

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1066,6 +1066,7 @@ func SetServerDefaults(v *viper.Viper) error {
 	v.SetDefault(param.Xrootd_ScitokensConfig.GetName(), filepath.Join(configDir, "xrootd", "scitokens.cfg"))
 	v.SetDefault(param.Xrootd_Authfile.GetName(), filepath.Join(configDir, "xrootd", "authfile"))
 	v.SetDefault(param.Xrootd_MacaroonsKeyFile.GetName(), filepath.Join(configDir, "macaroons-secret"))
+	v.SetDefault(param.Xrootd_ShutdownTimeout.GetName(), 1*time.Minute)
 	v.SetDefault(param.IssuerKey.GetName(), filepath.Join(configDir, "issuer.jwk"))
 	v.SetDefault(param.IssuerKeysDirectory.GetName(), filepath.Join(configDir, "issuer-keys"))
 	v.SetDefault(param.Server_UIPasswordFile.GetName(), filepath.Join(configDir, "server-web-passwd"))

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -45,11 +45,12 @@ import (
 type filterType string
 
 const (
-	permFiltered   filterType = "permFiltered"     // Read from Director.FilteredServers
-	tempFiltered   filterType = "tempFiltered"     // Filtered by web UI, e.g. the server is put in downtime via the director website
-	serverFiltered filterType = "serverFiltered"   // Filtered by the server itself, e.g. the server is put in downtime by the server admin
-	topoFiltered   filterType = "topologyFiltered" // Filtered by Topology, e.g. the server is put in downtime via the OSDF Topology change
-	tempAllowed    filterType = "tempAllowed"      // Read from Director.FilteredServers but mutated by web UI
+	permFiltered     filterType = "permFiltered"     // Read from Director.FilteredServers
+	tempFiltered     filterType = "tempFiltered"     // Filtered by web UI, e.g. the server is put in downtime via the director website
+	serverFiltered   filterType = "serverFiltered"   // Filtered by the server itself, e.g. the server is put in downtime by the server admin
+	shutdownFiltered filterType = "shutdownFiltered" // Filtered by the server itself to block new work during the pre-shutdown drain period
+	topoFiltered     filterType = "topologyFiltered" // Filtered by Topology, e.g. the server is put in downtime via the OSDF Topology change
+	tempAllowed      filterType = "tempAllowed"      // Read from Director.FilteredServers but mutated by web UI
 )
 
 var (
@@ -79,6 +80,8 @@ func (f filterType) String() string {
 		return "Temporarily disabled via the admin website"
 	case serverFiltered:
 		return "Temporarily disabled by the server admin"
+	case shutdownFiltered:
+		return "Disabled due to the server shutdown in progress"
 	case topoFiltered:
 		return "Disabled via the Topology policy"
 	case tempAllowed:

--- a/director/director.go
+++ b/director/director.go
@@ -1221,7 +1221,7 @@ func registerServerAd(engineCtx context.Context, ctx *gin.Context, sType server_
 				log.Debugf("Server %s is shutting down, applying downtime to prevent new transfer requests", sn)
 			}
 			filteredServersMutex.Unlock()
-		} else if metrics.ParseHealthStatus(adV2.Status) != metrics.StatusShuttingDown {
+		} else {
 			// If the server is back online, we flush out existing shutdown filter if it exists
 			filteredServersMutex.Lock()
 			if existingFilterType, isServerFiltered := filteredServers[sn]; isServerFiltered {

--- a/director/director.go
+++ b/director/director.go
@@ -1171,16 +1171,15 @@ func registerServerAd(engineCtx context.Context, ctx *gin.Context, sType server_
 		adV2.Version = "unknown"
 	}
 
+	sn := adV2.Name
 	// Process received server(origin/cache) downtimes and toggle the director's in-memory downtime tracker when necessary
 	if adV2.Downtimes != nil {
 		filteredServersMutex.Lock()
-		defer filteredServersMutex.Unlock()
 
 		// Update the cached server downtime list
-		serverDowntimes[adV2.Name] = adV2.Downtimes
+		serverDowntimes[sn] = adV2.Downtimes
 
 		now := time.Now().UTC().UnixMilli()
-		sn := adV2.Name
 		active := false // Flag to indicate if this server has active downtime in this server ad
 		for _, dt := range adV2.Downtimes {
 			if dt.StartTime <= now &&
@@ -1203,6 +1202,35 @@ func registerServerAd(engineCtx context.Context, ctx *gin.Context, sType server_
 			if isServerFiltered && existingFilterType == serverFiltered {
 				delete(filteredServers, sn)
 			}
+		}
+		filteredServersMutex.Unlock()
+	}
+
+	// "Status" represents the server's overall health status. It is introduced in Pelican 7.17.0
+	if adV2.Status != "" { // For backward compatibility, we only process this if it is set
+		// If the server is about to shutdown, we silently put it into downtime.
+		// Then it will not receive new requests from the Director, but it will still be able to serve the existing ones.
+		if metrics.ParseHealthStatus(adV2.Status) == metrics.StatusShuttingDown {
+			filteredServersMutex.Lock()
+			// Inspect the existing downtime status for this server
+			existingFilterType, isServerFiltered := filteredServers[sn]
+
+			// Put the server in downtime only if no filter (downtime) exists or it was tempAllowed
+			if !isServerFiltered || existingFilterType == tempAllowed {
+				filteredServers[sn] = shutdownFiltered
+				log.Debugf("Server %s is shutting down, applying downtime to prevent new transfer requests", sn)
+			}
+			filteredServersMutex.Unlock()
+		} else if metrics.ParseHealthStatus(adV2.Status) != metrics.StatusShuttingDown {
+			// If the server is back online, we flush out existing shutdown filter if it exists
+			filteredServersMutex.Lock()
+			if existingFilterType, isServerFiltered := filteredServers[sn]; isServerFiltered {
+				if existingFilterType == shutdownFiltered {
+					delete(filteredServers, sn)
+					log.Debugf("Removed the active downtime for server %s as it has come back online", sn)
+				}
+			}
+			filteredServersMutex.Unlock()
 		}
 	}
 

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -82,6 +82,8 @@ func checkFilter(serverName string) (bool, filterType) {
 			return true, topoFiltered
 		case serverFiltered:
 			return true, serverFiltered
+		case shutdownFiltered:
+			return true, shutdownFiltered
 		case tempAllowed:
 			return false, tempAllowed
 		default:

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2848,6 +2848,15 @@ default: 10s
 hidden: true
 components: ["origin", "cache"]
 ---
+name: Xrootd.ShutdownTimeout
+description: |+
+  The maximum amount of time pelican will wait for the xrootd daemons to gracefully shutdown. 
+  During this period, the Director will stop redirect new transfer requests to this xrootd server, 
+  while in-flight transfers are allowed to proceed until timeout. 
+type: duration
+default: 1m
+components: ["origin", "cache"]
+---
 ############################
 # Monitoring-level configs #
 ############################

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2850,8 +2850,8 @@ components: ["origin", "cache"]
 ---
 name: Xrootd.ShutdownTimeout
 description: |+
-  The maximum amount of time pelican will wait for the xrootd daemons to gracefully shutdown.
-  During this period, the Director will stop redirect new transfer requests to this xrootd server,
+  The maximum amount of time pelican will wait for the xrootd daemons to gracefully shutdown before killing ongoing transfers.
+  During this period, the Director will stop redirecting clients to the Origin/Cache,
   while in-flight transfers are allowed to proceed until timeout.
 type: duration
 default: 1m

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2850,9 +2850,9 @@ components: ["origin", "cache"]
 ---
 name: Xrootd.ShutdownTimeout
 description: |+
-  The maximum amount of time pelican will wait for the xrootd daemons to gracefully shutdown. 
-  During this period, the Director will stop redirect new transfer requests to this xrootd server, 
-  while in-flight transfers are allowed to proceed until timeout. 
+  The maximum amount of time pelican will wait for the xrootd daemons to gracefully shutdown.
+  During this period, the Director will stop redirect new transfer requests to this xrootd server,
+  while in-flight transfers are allowed to proceed until timeout.
 type: duration
 default: 1m
 components: ["origin", "cache"]

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -28,6 +28,7 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
@@ -61,25 +62,6 @@ func LaunchModules(ctx context.Context, modules server_structs.ServerType) (serv
 	ctx, shutdownCancel = context.WithCancel(ctx)
 
 	config.LogPelicanVersion()
-
-	egrp.Go(func() error {
-		_ = config.RestartFlag
-		log.Debug("Will shutdown process on signal")
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
-		select {
-		case sig := <-sigs:
-			log.Warningf("Received signal %v; will shutdown process", sig)
-			shutdownCancel()
-			return ErrExitOnSignal
-		case <-config.RestartFlag:
-			log.Warningf("Received restart request; will restart the process")
-			shutdownCancel()
-			return ErrRestart
-		case <-ctx.Done():
-			return nil
-		}
-	})
 
 	var engine *gin.Engine
 	engine, err = web_ui.GetEngine()
@@ -381,6 +363,40 @@ func LaunchModules(ctx context.Context, modules server_structs.ServerType) (serv
 		log.Info("Starting web login...")
 		egrp.Go(func() error { return web_ui.InitServerWebLogin(ctx) })
 	}
+
+	egrp.Go(func() error {
+		_ = config.RestartFlag
+		log.Debug("Will shutdown process on signal")
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+		select {
+		case sig := <-sigs:
+			// Graceful shutdown if received SIGTERM
+			if sig == syscall.SIGTERM && (modules.IsEnabled(server_structs.OriginType) || modules.IsEnabled(server_structs.CacheType)) {
+				log.Warnf("Received SIGTERM, waiting %s for on-flight transfers before shutting down", param.Xrootd_ShutdownTimeout.GetDuration().String())
+
+				// Set component's health status, so the ad could pick up the shutdown flag (`Status`: `shutting down`)
+				metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusShuttingDown, "The server is shutting down")
+				// When the server is up again, the ShuttingDown status will be cleared
+
+				if advErr := launcher_utils.Advertise(ctx, servers); advErr != nil {
+					log.Errorf("Failed to advertise before shutdown: %v", advErr)
+				}
+				time.Sleep(param.Xrootd_ShutdownTimeout.GetDuration())
+				log.Warn("Shutdown grace period elapsed; proceeding with shutdown and discarding incomplete transfers")
+			}
+
+			log.Warningf("Received signal %v; will shutdown process", sig)
+			shutdownCancel()
+			return ErrExitOnSignal
+		case <-config.RestartFlag:
+			log.Warningf("Received restart request; will restart the process")
+			shutdownCancel()
+			return ErrRestart
+		case <-ctx.Done():
+			return nil
+		}
+	})
 
 	return
 }

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -393,7 +393,7 @@ func LaunchModules(ctx context.Context, modules server_structs.ServerType) (serv
 
 func handleGracefulShutdown(ctx context.Context, modules server_structs.ServerType, servers []server_structs.XRootDServer) {
 	if modules.IsEnabled(server_structs.OriginType) || modules.IsEnabled(server_structs.CacheType) {
-		log.Warnf("Waiting %s for on-flight transfers before shutting down", param.Xrootd_ShutdownTimeout.GetDuration().String())
+		log.Warnf("Waiting %s for in-flight transfers before shutting down", param.Xrootd_ShutdownTimeout.GetDuration().String())
 
 		// Set component's health status, so the ad could pick up the shutdown flag (`Status`: `shutting down`)
 		metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusShuttingDown, "The server is shutting down")

--- a/metrics/health.go
+++ b/metrics/health.go
@@ -53,8 +53,8 @@ type (
 
 // HealthStatusEnum are stored as Prometheus values and internal struct
 const (
-	StatusCritical HealthStatusEnum = iota + 1
-	StatusShuttingDown
+	StatusShuttingDown HealthStatusEnum = iota + 1
+	StatusCritical
 	StatusDegraded
 	StatusWarning
 	StatusOK
@@ -118,7 +118,7 @@ func ParseHealthStatus(status string) HealthStatusEnum {
 // matched string representation, so we will return "Error: status string index out of range"
 // as an indicator
 func (status HealthStatusEnum) String() string {
-	strings := [...]string{"critical", "shutting down", "degraded", "warning", "ok", "unknown"}
+	strings := [...]string{"shutting down", "critical", "degraded", "warning", "ok", "unknown"}
 
 	if int(status) < 1 || int(status) > len(strings) {
 		return statusIndexErrorMessage

--- a/metrics/health_test.go
+++ b/metrics/health_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestHealthStatusString(t *testing.T) {
-	expectedStrings := [...]string{"critical", "shutting down", "degraded", "warning", "ok", "unknown"}
+	expectedStrings := [...]string{"shutting down", "critical", "degraded", "warning", "ok", "unknown"}
 
 	t.Run("health-status-string-handles-out-of-range-index", func(t *testing.T) {
 		invalidIndex := len(expectedStrings) + 1

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -452,6 +452,7 @@ var (
 	Transport_TLSHandshakeTimeout = DurationParam{"Transport.TLSHandshakeTimeout"}
 	Xrootd_AuthRefreshInterval = DurationParam{"Xrootd.AuthRefreshInterval"}
 	Xrootd_MaxStartupWait = DurationParam{"Xrootd.MaxStartupWait"}
+	Xrootd_ShutdownTimeout = DurationParam{"Xrootd.ShutdownTimeout"}
 )
 
 var (

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -371,6 +371,7 @@ type Config struct {
 		RobotsTxtFile string `mapstructure:"robotstxtfile" yaml:"RobotsTxtFile"`
 		RunLocation string `mapstructure:"runlocation" yaml:"RunLocation"`
 		ScitokensConfig string `mapstructure:"scitokensconfig" yaml:"ScitokensConfig"`
+		ShutdownTimeout time.Duration `mapstructure:"shutdowntimeout" yaml:"ShutdownTimeout"`
 		Sitename string `mapstructure:"sitename" yaml:"Sitename"`
 		SummaryMonitoringHost string `mapstructure:"summarymonitoringhost" yaml:"SummaryMonitoringHost"`
 		SummaryMonitoringPort int `mapstructure:"summarymonitoringport" yaml:"SummaryMonitoringPort"`
@@ -726,6 +727,7 @@ type configWithType struct {
 		RobotsTxtFile struct { Type string; Value string }
 		RunLocation struct { Type string; Value string }
 		ScitokensConfig struct { Type string; Value string }
+		ShutdownTimeout struct { Type string; Value time.Duration }
 		Sitename struct { Type string; Value string }
 		SummaryMonitoringHost struct { Type string; Value string }
 		SummaryMonitoringPort struct { Type string; Value int }

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -159,6 +159,7 @@ type (
 	StrategyType string
 	SortType     string
 
+	// OriginAdvertiseV2 is the struct used to advertise BOTH Origin and Cache server to the director
 	OriginAdvertiseV2 struct {
 		ServerBaseAd
 		// The namespace prefix to register/look up the server in the registry.

--- a/web_ui/frontend/app/config/components/RestartBox.tsx
+++ b/web_ui/frontend/app/config/components/RestartBox.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@mui/material';
 import { Replay } from '@mui/icons-material';
+import { useState } from 'react';
 
 import { AlertDispatchContext } from '@/components/AlertProvider';
 import { useContext } from 'react';
@@ -8,12 +9,26 @@ import { restartServer } from '@/helpers/api';
 
 export const RestartBox = () => {
   const dispatch = useContext(AlertDispatchContext);
+  const [isDisabled, setIsDisabled] = useState(false);
+
+  const handleRestart = async () => {
+    setIsDisabled(true);
+    try {
+      await alertOnError(restartServer, 'Restart Server', dispatch);
+    } finally {
+      // TODO: Disable button for a given time set by param.Xrootd_ShutdownTimeout.GetDuration().Milliseconds()
+      setTimeout(() => {
+        setIsDisabled(false);
+      }, 60000);
+    }
+  };
 
   return (
     <Button
       variant='outlined'
       endIcon={<Replay />}
-      onClick={() => alertOnError(restartServer, 'Restart Server', dispatch)}
+      onClick={handleRestart}
+      disabled={isDisabled}
     >
       Restart Server
     </Button>


### PR DESCRIPTION
Trigger the graceful shutdown once a Pelican Origin or Cache receives a SIGTERM signal (`kill -TERM <pid>`)

Upon receiving `SIGTERM`, the Origin or Cache process waits one minute for in-flight transfers to complete. If any transfers remain after the one-minute grace period, the server shuts down immediately.

Before the wait, the Origin or Cache sends a shutdown advertisement with the new `Status` field (="shutting down") to the Director, instructing it to stop routing any new transfer requests to this server. The Director then applies an indefinite downtime window to this server, so that offline servers still listed in its cached `serverAds` will be excluded from new requests. Whenever the server is back online, it will send a regular server ad to flush out the "shutting down" downtime.

![graceful-shutdown (3) drawio](https://github.com/user-attachments/assets/f4dc7461-582d-470f-a1d9-79a5e2519dd3)

cc @bbockelm Here is a formal up-to-date system design diagram. (Content in this PR is marked in red)