### PR TITLE
Bugfix for downtime handling in Director

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1898,5 +1898,5 @@ func ResetConfig() {
 
 	ResetClientInitialized()
 
-	// other than what's above, resetting Origin exports will be done by ResetTestState() in server_utils pkg
+	// There are other test state resets in server_utils.ResetTestState()
 }

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -365,7 +365,7 @@ func getCachedDowntimes(serverName string) ([]server_structs.Downtime, error) {
 // Get the downtimes set by federation admin in the Registry
 func updateDowntimeFromRegistry(ctx context.Context) error {
 	fedInfo, err := config.GetFederation(ctx)
-	if err != nil || fedInfo.DirectorEndpoint == "" {
+	if err != nil || fedInfo.RegistryEndpoint == "" {
 		log.Error("Failed to get federation info: ", err)
 		return errors.Wrap(err, "failed to get federation info")
 	}
@@ -398,10 +398,9 @@ func updateDowntimeFromRegistry(ctx context.Context) error {
 		return errors.Wrap(err, "failed to marshal response in to JSON")
 	}
 
-	if len(latestFedDowntimes) == 0 {
-		log.Debug("No downtimes set by federation admin in the Registry")
-		return nil
-	}
+	// If `latestFedDowntimes` is empty, it means there's no downtime set by federation admin,
+	// or the downtime is expired (deleted). In either case, we still need to proceed to use
+	// it to update `filteredServers` and `federationDowntimes`, clearing out stale info.
 
 	filteredServersMutex.Lock()
 	defer filteredServersMutex.Unlock()


### PR DESCRIPTION
In Director, expired downtimes set by Registry should also be cleared when no active downtimes set by Registry.

### How to test this PR locally

Spin up Registry, Director, Origin (or Cache). In Registry, create a downtime (ends at X minutes from now) for the Origin. Go to Director to verify this Origin is **in** downtime. X minutes later, this downtime expires. Check this Origin in Director again to make sure it is **not in** downtime.

If you find these downtime logics are too complicated... here is a diagram for the Downtime management workflow in Pelican #2218  

