### PR TITLE
Explicitly install make in pelican-build-base image

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -91,7 +91,7 @@ gpgcheck=0
 ENDCOPY
 RUN --mount=type=cache,id=dnf-${BUILDPLATFORM},target=/var/cache/dnf,sharing=locked <<ENDRUN
   set -eux
-  dnf install -y goreleaser
+  dnf install -y goreleaser make
 ENDRUN
 
 RUN curl -O https://dl.google.com/go/go${GO_VER}.${BUILDOS}-${BUILDARCH}.tar.gz \


### PR DESCRIPTION
This dependency was previously picked up implicitly by goreleaser, but stopped being installed automatically. However we still need it to run goreleaser's `make web-build` hook.