### PR TITLE
Use proper name from registry when requesting federation tokens

### DIFF
--- a/broker/client.go
+++ b/broker/client.go
@@ -215,7 +215,7 @@ func ConnectToOrigin(ctx context.Context, brokerUrl, prefix, originName string) 
 	brokerAud.RawQuery = ""
 	brokerAud.Path = ""
 
-	cachePrefix := server_structs.GetCacheNS(param.Server_Hostname.GetString())
+	cachePrefix := server_structs.GetCacheNs(param.Server_Hostname.GetString())
 	token, err := createToken(cachePrefix, param.Server_Hostname.GetString(), brokerAud.String(), token_scopes.Broker_Reverse)
 	if err != nil {
 		err = errors.Wrap(err, "failure when constructing the broker request token")

--- a/broker/server_apis.go
+++ b/broker/server_apis.go
@@ -145,7 +145,7 @@ func reverseRequest(ctx context.Context, ginCtx *gin.Context) {
 		return
 	}
 
-	ok, err := verifyToken(ctx, token, server_structs.GetCacheNS(hostname), param.Server_ExternalWebUrl.GetString(), token_scopes.Broker_Reverse)
+	ok, err := verifyToken(ctx, token, server_structs.GetCacheNs(hostname), param.Server_ExternalWebUrl.GetString(), token_scopes.Broker_Reverse)
 	if err != nil {
 		log.Errorln("Failed to verify token for cache reversal request:", err)
 		ginCtx.AbortWithStatusJSON(http.StatusBadRequest, newBrokerRespFail("Failed to verify provided token"))

--- a/cache/advertise.go
+++ b/cache/advertise.go
@@ -51,7 +51,7 @@ type (
 var MinFedTokenTickerRate = 1 * time.Minute
 
 func (server *CacheServer) CreateAdvertisement(name, originUrl, originWebUrl string) (*server_structs.OriginAdvertiseV2, error) {
-	registryPrefix := server_structs.GetCacheNS(param.Xrootd_Sitename.GetString())
+	registryPrefix := server_structs.GetCacheNs(param.Xrootd_Sitename.GetString())
 
 	// Fetch cache's active and future downtimes
 	downtimes, err := database.GetIncompleteDowntimes(strings.ToLower(server_structs.CacheType.String()))

--- a/director/director.go
+++ b/director/director.go
@@ -1075,7 +1075,7 @@ func registerServerAd(engineCtx context.Context, ctx *gin.Context, sType server_
 		} else {
 			// For caches <= 7.8.1, they don't have RegistryPrefix
 			// so we fall back to Name
-			registryPrefix = server_structs.GetCacheNS(adV2.Name)
+			registryPrefix = server_structs.GetCacheNs(adV2.Name)
 		}
 	}
 

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2829,10 +2829,12 @@ components: ["origin", "cache"]
 ---
 name: Xrootd.Sitename
 description: |+
-  The sitename, as configured for XRootD. In caches, this value will also be used by the cache/origin service when registering
-  with the federation's Registry (overriding the service's hostname, which is the default).
+  The sitename, as configured for XRootD. It is generally used as a human readable way to convey
+  something about the institution running the service. This value will also be used by caches when
+  registering with the federation's Registry (overriding the service's hostname, which is the default).
+  Origins currently always use the hostname at the Registry.
 
-  For both cahces/origins it will be displayed as the service's name in the federation's Director.
+  For both cahces/origins the sitename will be displayed as the service's name in the federation's Director.
 type: string
 default: none
 components: ["origin", "cache"]

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2829,10 +2829,13 @@ components: ["origin", "cache"]
 ---
 name: Xrootd.Sitename
 description: |+
-  The sitename, as configured for XRootD.
+  The sitename, as configured for XRootD. In caches, this value will also be used by the cache/origin service when registering
+  with the federation's Registry (overriding the service's hostname, which is the default).
+
+  For both cahces/origins it will be displayed as the service's name in the federation's Director.
 type: string
 default: none
-components: ["origin"]
+components: ["origin", "cache"]
 ---
 name: Xrootd.MaxStartupWait
 description: |+

--- a/e2e_fed_tests/downtime_test.go
+++ b/e2e_fed_tests/downtime_test.go
@@ -162,7 +162,7 @@ func TestServerDowntimeDirectorForwarding(t *testing.T) {
 	registryUrl.Path = downtimeCreationPath
 
 	downtimeByFedAdmin := web_ui.DowntimeInput{
-		ServerName:  server_structs.GetCacheNS(cacheServerName), // In Registry downtime table, the server name uses server's registered prefix
+		ServerName:  server_structs.GetCacheNs(cacheServerName), // In Registry downtime table, the server name uses server's registered prefix
 		Source:      strings.ToLower(server_structs.RegistryType.String()),
 		Class:       "SCHEDULED",
 		Description: "This is a test downtime set by federation admin",

--- a/launchers/cache_serve.go
+++ b/launchers/cache_serve.go
@@ -149,7 +149,7 @@ func CacheServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, m
 func CacheServeFinish(ctx context.Context, egrp *errgroup.Group, cacheServer server_structs.XRootDServer) error {
 	log.Debug("Register Cache")
 	metrics.SetComponentHealthStatus(metrics.OriginCache_Registry, metrics.StatusWarning, "Start to register namespaces for the cache server")
-	if err := launcher_utils.RegisterNamespaceWithRetry(ctx, egrp, server_structs.GetCacheNS(param.Xrootd_Sitename.GetString())); err != nil {
+	if err := launcher_utils.RegisterNamespaceWithRetry(ctx, egrp, server_structs.GetCacheNs(param.Xrootd_Sitename.GetString())); err != nil {
 		return err
 	}
 	log.Debug("Cache is registered")

--- a/server_structs/xrootd_server.go
+++ b/server_structs/xrootd_server.go
@@ -64,7 +64,7 @@ func (s ServerPrefix) String() string {
 
 // Get the namespace for a cache server, i.e. /caches/<hostname>
 // It returns an empty string is the host is empty
-func GetCacheNS(host string) string {
+func GetCacheNs(host string) string {
 	if host == "" {
 		return ""
 	}

--- a/server_structs/xrootd_server_test.go
+++ b/server_structs/xrootd_server_test.go
@@ -24,16 +24,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetCacheNS(t *testing.T) {
+func TestGetCacheNs(t *testing.T) {
 	t.Run("returns-empty-string-w-empty-input", func(t *testing.T) {
-		assert.Empty(t, GetCacheNS(""))
+		assert.Empty(t, GetCacheNs(""))
 	})
 
 	t.Run("returns-prefix", func(t *testing.T) {
-		assert.Equal(t, "/caches/hostname", GetCacheNS("hostname"))
-		assert.Equal(t, "/caches/127.0.0.1", GetCacheNS("127.0.0.1"))
-		assert.Equal(t, "/caches/https://example.org", GetCacheNS("https://example.org"))
-		assert.Equal(t, "/caches/localhost:2000", GetCacheNS("localhost:2000"))
+		assert.Equal(t, "/caches/hostname", GetCacheNs("hostname"))
+		assert.Equal(t, "/caches/127.0.0.1", GetCacheNs("127.0.0.1"))
+		assert.Equal(t, "/caches/https://example.org", GetCacheNs("https://example.org"))
+		assert.Equal(t, "/caches/localhost:2000", GetCacheNs("localhost:2000"))
 	})
 }
 

--- a/server_utils/sitename.go
+++ b/server_utils/sitename.go
@@ -110,7 +110,7 @@ func GetServiceName(ctx context.Context, server server_structs.ServerType) (name
 			log.Errorf("Failed to get sitename from the registry for the origin. Will fallback to using %s: %v", param.Xrootd_Sitename.GetName(), err)
 		}
 	} else if server.IsEnabled(server_structs.CacheType) {
-		cachePrefix := server_structs.GetCacheNS(param.Xrootd_Sitename.GetString())
+		cachePrefix := server_structs.GetCacheNs(param.Xrootd_Sitename.GetString())
 		name, err = getSitenameFromReg(ctx, cachePrefix)
 		if err != nil {
 			log.Errorf("Failed to get sitename from the registry for the cache. Will fallback to use %s: %v", param.Xrootd_Sitename.GetName(), err)


### PR DESCRIPTION
The bug was that I'd designed this to always use the server's hostname when requesting federation tokens. However, when `Xrootd.Sitename` is set in caches, that's the name that gets registered. This misalignment prevented the Director from validating caches' advertise tokens, which blocked it from handing out the federation tokens.

Assigning @h2zh as the reviewer since I know he's currently working on some things related to server names in the Registry -- does this approach look okay to you? Ultimately the value I send to the director's fed token API in the `host` query parameter needs to match the cache/origin's registered name.