### PR TITLE
A radical fix for “future-to-active-toggle” downtime test

### DIFF
--- a/director/director_test.go
+++ b/director/director_test.go
@@ -1251,10 +1251,10 @@ func TestDirectorRegistration(t *testing.T) {
 			require.NoError(t, err)
 			setupJwksCache(t, "/caches/test", pub)
 
-			// 1) future-only
+			// 1) Create a downtime in the future
 			ad1 := baseAd
 			ad1.Downtimes = []server_structs.Downtime{
-				makeDT(now+5_000, now+6_000),
+				makeDT(now+86400_000, now+172800_000), // now + 1 day, now + 2 days
 			}
 			ad1.Initialize("test-cache")
 			body1, _ := json.Marshal(ad1)
@@ -1266,13 +1266,13 @@ func TestDirectorRegistration(t *testing.T) {
 			filteredServersMutex.RUnlock()
 			assert.False(t, ok1, "no filter on future downtime")
 
-			// 2) now active
+			// 2) Flush out the future downtime with an active one
 			ad2 := baseAd
 			ad2.Downtimes = []server_structs.Downtime{
-				// A new active downtime with 20s (+/-10s) window to prevent it expiring
+				// A new active downtime with 2 days (+/- 1 day) window to prevent it expiring
 				// before the server ad gets to the Director, which results in a flaky test.
 				// This should clear the previous future downtime.
-				makeDT(now-10_000, now+10_000),
+				makeDT(now-86400_000, now+86400_000),
 			}
 			ad2.Initialize("test-cache")
 			body2, _ := json.Marshal(ad2)
@@ -1282,12 +1282,13 @@ func TestDirectorRegistration(t *testing.T) {
 			c.Request.Header.Set("Authorization", "Bearer "+token)
 			c.Request.Header.Set("Content-Type", "application/json")
 			r.ServeHTTP(w, c.Request)
-			r.ServeHTTP(w, c.Request)
 			assert.Equal(t, http.StatusOK, w.Result().StatusCode)
 
+			// 3) Verify the downtime filter is set
 			filteredServersMutex.RLock()
 			f2, ok2 := filteredServers["test-cache"]
 			filteredServersMutex.RUnlock()
+			t.Log("Now: ", now, "; Downtime start: ", ad2.Downtimes[0].StartTime, "; Downtime end: ", ad2.Downtimes[0].EndTime)
 			assert.True(t, ok2, "filter added on active downtime")
 			assert.Equal(t, serverFiltered, f2)
 		})


### PR DESCRIPTION
The previous fix #2308 for the flaky test “future-to-active-toggle” was not enough. This test still goes south sometimes ([example](https://github.com/PelicanPlatform/pelican/actions/runs/15218213055/job/42808498892#step:9:14717)).

This PR aims to eliminate the flakiness by the following two approaches:

1. Radically increase the test downtime window to avoid `now` not being in the downtime window
2. Wrap the filter check in an `eventually` block with deterministic timeout and polling, so that we don't need to worry that downtime setting on the mock server is slower than the test execution.

Closes #2309 