### PR TITLE
Implement new logging level configuration parameters.

### DIFF
--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -173,7 +173,7 @@ components: ["director"]
 ############################
 name: Logging.Level
 description: |+
-  A string defining the log level of the client. Options include (going from most info to least): Trace, Debug, Info, Warn, Error, Fatal, Panic.
+  A string defining the Pelican wide log level. Options include (going from most info to least): Trace, Debug, Info, Warn, Error, Fatal, Panic.
 
   Log levels are inherited by all components unless explicitly overridden. Levels are case-insensitive.
 type: string
@@ -200,6 +200,21 @@ description: |+
 type: duration
 default: 1m
 components: ["client"]
+---
+name: Logging.Client.Level
+description: |+
+  A string defining the log level of the client. Options include (going from most info to least): Trace, Debug, Info, Warn, Error, Fatal, Panic.
+  If unset, will fallback to `Logging.Level`.
+type: string
+default: error
+components: ["client"]
+---
+name: Logging.Server.Level
+description: |+
+  A string defining the log level of the server (Director, Registry, Origin, Cache). Options include (going from most info to least): Trace, Debug, Info, Warn, Error, Fatal, Panic.
+  If unset, will fallback to `Logging.Level`.
+type: string
+default: info
 ---
 name: Logging.Origin.Cms
 description: |+

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -197,6 +197,7 @@ var (
 	Logging_Cache_Scitokens = StringParam{"Logging.Cache.Scitokens"}
 	Logging_Cache_Xrd = StringParam{"Logging.Cache.Xrd"}
 	Logging_Cache_Xrootd = StringParam{"Logging.Cache.Xrootd"}
+	Logging_Client_Level = StringParam{"Logging.Client.Level"}
 	Logging_Level = StringParam{"Logging.Level"}
 	Logging_LogLocation = StringParam{"Logging.LogLocation"}
 	Logging_Origin_Cms = StringParam{"Logging.Origin.Cms"}
@@ -206,6 +207,7 @@ var (
 	Logging_Origin_Scitokens = StringParam{"Logging.Origin.Scitokens"}
 	Logging_Origin_Xrd = StringParam{"Logging.Origin.Xrd"}
 	Logging_Origin_Xrootd = StringParam{"Logging.Origin.Xrootd"}
+	Logging_Server_Level = StringParam{"Logging.Server.Level"}
 	Lotman_DbLocation = StringParam{"Lotman.DbLocation"}
 	Lotman_EnabledPolicy = StringParam{"Lotman.EnabledPolicy"}
 	Lotman_LibLocation = StringParam{"Lotman.LibLocation"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -155,6 +155,7 @@ type Config struct {
 			Xrootd string `mapstructure:"xrootd" yaml:"Xrootd"`
 		} `mapstructure:"cache" yaml:"Cache"`
 		Client struct {
+			Level string `mapstructure:"level" yaml:"Level"`
 			ProgressInterval time.Duration `mapstructure:"progressinterval" yaml:"ProgressInterval"`
 		} `mapstructure:"client" yaml:"Client"`
 		DisableProgressBars bool `mapstructure:"disableprogressbars" yaml:"DisableProgressBars"`
@@ -169,6 +170,9 @@ type Config struct {
 			Xrd string `mapstructure:"xrd" yaml:"Xrd"`
 			Xrootd string `mapstructure:"xrootd" yaml:"Xrootd"`
 		} `mapstructure:"origin" yaml:"Origin"`
+		Server struct {
+			Level string `mapstructure:"level" yaml:"Level"`
+		} `mapstructure:"server" yaml:"Server"`
 	} `mapstructure:"logging" yaml:"Logging"`
 	Lotman struct {
 		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
@@ -510,6 +514,7 @@ type configWithType struct {
 			Xrootd struct { Type string; Value string }
 		}
 		Client struct {
+			Level struct { Type string; Value string }
 			ProgressInterval struct { Type string; Value time.Duration }
 		}
 		DisableProgressBars struct { Type string; Value bool }
@@ -523,6 +528,9 @@ type configWithType struct {
 			Scitokens struct { Type string; Value string }
 			Xrd struct { Type string; Value string }
 			Xrootd struct { Type string; Value string }
+		}
+		Server struct {
+			Level struct { Type string; Value string }
 		}
 	}
 	Lotman struct {


### PR DESCRIPTION
This PR introduces two new logging configuration parameters, `Logging.Client.Level` and `Logging.Server.Level`. These new parameters are meant to separate the existing logging level into separate parameters. However if either of these are unset, it will fallback to `Logging.Level`. This PR also sets the default server logging level (Logging.Server.Level) to `info` and sets the default client logging level to `error`.