### PR TITLE
Bump containerized xrootd-s3-http plugin version to 0.4.1

### DIFF
--- a/github_scripts/osx_install.sh
+++ b/github_scripts/osx_install.sh
@@ -66,7 +66,7 @@ popd
 
 git clone --recurse-submodules --branch v0.2.1 https://github.com/PelicanPlatform/xrootd-s3-http.git
 pushd xrootd-s3-http
-git checkout v0.2.1
+git checkout v0.4.1
 mkdir build
 cd build
 cmake .. -GNinja -DCMAKE_INSTALL_PREFIX="$PWD/release_dir"

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -59,8 +59,8 @@ ARG XRDHTTP_PELICAN_SRC_BUILD=false
 ARG XRDHTTP_PELICAN_VER=0.0.6
 ARG XROOTD_LOTMAN_SRC_BUILD=false
 ARG XROOTD_LOTMAN_VER=0.0.3
-ARG XROOTD_S3_HTTP_SRC_BUILD=false
-ARG XROOTD_S3_HTTP_VER=0.2.1
+ARG XROOTD_S3_HTTP_SRC_BUILD=true
+ARG XROOTD_S3_HTTP_VER=0.4.1
 
 # Set scitokens-oauth2-server image as a build stage so that we can copy its
 # OA4MP installation into the images being built here.


### PR DESCRIPTION
This new plugin version comes with a few bugfixes that we hope help with various deadlocks we've seen recently.