### PR TITLE
Updated runPut to mimic downloadHttp's proxy logic

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -3102,7 +3102,9 @@ func uploadObject(transfer *transferFile) (transferResult TransferResults, err e
 	var lastKnownWritten int64
 	uploadStart := time.Now()
 
-	go runPut(request, responseChan, errorChan, transfer.attempts[0].Proxy)
+	useProxy := transfer.attempts[0].Proxy
+
+	go runPut(request, responseChan, errorChan, useProxy)
 	var lastError error = nil
 
 	tickerDuration := 100 * time.Millisecond

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -3102,7 +3102,7 @@ func uploadObject(transfer *transferFile) (transferResult TransferResults, err e
 	var lastKnownWritten int64
 	uploadStart := time.Now()
 
-	go runPut(request, responseChan, errorChan)
+	go runPut(request, responseChan, errorChan, transfer.attempts[0].Proxy)
 	var lastError error = nil
 
 	tickerDuration := 100 * time.Millisecond
@@ -3204,9 +3204,13 @@ Loop:
 //
 // This is executed in a separate goroutine to allow periodic progress callbacks
 // to be created within the main goroutine.
-func runPut(request *http.Request, responseChan chan<- *http.Response, errorChan chan<- error) {
-	var UploadClient = &http.Client{Transport: config.GetTransport()}
-	client := UploadClient
+func runPut(request *http.Request, responseChan chan<- *http.Response, errorChan chan<- error, proxy bool) {
+	client := http.Client{}
+	transport := config.GetTransport()
+	if !proxy {
+		transport.Proxy = nil
+	}
+	client.Transport = transport
 	dump, _ := httputil.DumpRequestOut(request, false)
 	log.Debugf("Dumping request: %s", dump)
 	response, err := client.Do(request)

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -386,7 +386,7 @@ func TestUploadZeroLengthFile(t *testing.T) {
 	request.Header.Set("Authorization", "Bearer test")
 	errorChan := make(chan error, 1)
 	responseChan := make(chan *http.Response)
-	go runPut(request, responseChan, errorChan)
+	go runPut(request, responseChan, errorChan, false)
 	select {
 	case err := <-errorChan:
 		assert.NoError(t, err)
@@ -416,7 +416,7 @@ func TestFailedUpload(t *testing.T) {
 	request.Header.Set("Authorization", "Bearer test")
 	errorChan := make(chan error, 1)
 	responseChan := make(chan *http.Response)
-	go runPut(request, responseChan, errorChan)
+	go runPut(request, responseChan, errorChan, false)
 	select {
 	case err := <-errorChan:
 		assert.Error(t, err)


### PR DESCRIPTION
This is fixing the issue described here: #2248 

It mimics how downloadHTTP deals with the proxy.
 
This is just meant to be a fix to make sure both functions are behaving the same way, but I think there is a larger issue involving the correctness of the code that I created a different issue for in #2371 

Test this by running a put using the built binary on the ospool with 

Requirements = GLIDEIN_Site == "UA Little Rock ITS"