### PR TITLE
Allow connection broker to be used for director->cache communications

### DIFF
--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -110,6 +110,7 @@ func Setup(t *testing.T, ctx context.Context, egrp *errgroup.Group) {
 	})
 	require.NoError(t, err)
 
+	namespaceKeys = nil
 	LaunchNamespaceKeyMaintenance(ctx, egrp)
 }
 
@@ -193,7 +194,11 @@ func TestBroker(t *testing.T) {
 	viper.Set("Federation.RegistryUrl", param.Server_ExternalWebUrl.GetString())
 	listenerChan := make(chan any)
 	ctxQuick, deadlineCancel := context.WithTimeout(ctx, 5*time.Second) // Have shorter timeout for this handshake
-	err = LaunchRequestMonitor(ctxQuick, egrp, listenerChan)
+
+	externalWebUrl, err := url.Parse(param.Server_ExternalWebUrl.GetString())
+	require.NoError(t, err)
+
+	err = LaunchRequestMonitor(ctxQuick, egrp, server_structs.CacheType, externalWebUrl.Hostname(), listenerChan)
 	require.NoError(t, err)
 
 	// Initiate the callback using the cache-based routines.
@@ -203,9 +208,9 @@ func TestBroker(t *testing.T) {
 	brokerUrl.Path = "/api/v1.0/broker/reverse"
 	query := brokerUrl.Query()
 	query.Set("origin", param.Server_Hostname.GetString())
-	query.Set("prefix", "/foo")
+	query.Set("prefix", "/caches/"+externalWebUrl.Hostname())
 	brokerUrl.RawQuery = query.Encode()
-	clientConn, err := ConnectToOrigin(ctxQuick, brokerUrl.String(), "/foo", param.Server_Hostname.GetString())
+	clientConn, err := ConnectToOrigin(ctxQuick, brokerUrl.String(), "/caches/"+externalWebUrl.Hostname(), param.Server_Hostname.GetString())
 	require.NoError(t, err)
 	log.Debugf("Cache got reversed client connection with cache side %s and origin side %s", clientConn.LocalAddr(), clientConn.RemoteAddr())
 

--- a/broker/client.go
+++ b/broker/client.go
@@ -226,7 +226,7 @@ func ConnectToOrigin(ctx context.Context, brokerUrl, prefix, originName string) 
 	// Create a cloned transport which disables HTTP/2 (as that TCP string can't
 	// be hijacked which we will need to do below).  The clone ensures that we're
 	// not going to be reusing TCP connections.
-	tr := config.GetTransport().Clone()
+	tr := config.GetBasicTransport().Clone()
 	tr.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
 	client := &http.Client{Transport: tr}
 
@@ -385,7 +385,7 @@ func ConnectToOrigin(ctx context.Context, brokerUrl, prefix, originName string) 
 //
 // The TCP socket used for the callback will be converted to a one-shot listener
 // and reused with the origin as the "server".
-func doCallback(ctx context.Context, brokerResp reversalRequest) (listener net.Listener, err error) {
+func doCallback(ctx context.Context, sType server_structs.ServerType, brokerResp reversalRequest) (listener net.Listener, err error) {
 	log.Debugln("Origin starting callback to cache at", brokerResp.CallbackUrl)
 
 	privateKey, err := privateKeyFromBytes(brokerResp.PrivateKey)
@@ -415,7 +415,18 @@ func doCallback(ctx context.Context, brokerResp reversalRequest) (listener net.L
 	}
 	cacheAud.Path = ""
 
-	token, err := createToken(param.Origin_FederationPrefix.GetString(), param.Server_Hostname.GetString(), cacheAud.String(), token_scopes.Broker_Callback)
+	servicePrefix := ""
+	url, err := url.Parse(param.Server_ExternalWebUrl.GetString())
+	if err != nil {
+		err = errors.Wrap(err, "failure when parsing the external web URL")
+		return
+	}
+	if sType.IsEnabled(server_structs.CacheType) {
+		servicePrefix = server_structs.GetCacheNs(url.Hostname())
+	} else {
+		servicePrefix = server_structs.GetOriginNs(url.Host)
+	}
+	token, err := createToken(servicePrefix, url.Hostname(), cacheAud.String(), token_scopes.Broker_Callback)
 	if err != nil {
 		err = errors.Wrap(err, "failure when constructing the cache callback token")
 		return
@@ -550,10 +561,21 @@ func doCallback(ctx context.Context, brokerResp reversalRequest) (listener net.L
 // TLS listener where you can invoke "Accept" once before it automatically
 // closes itself.  It is the result of a successful connection reversal to
 // a cache.
-func LaunchRequestMonitor(ctx context.Context, egrp *errgroup.Group, resultChan chan any) (err error) {
+//
+// The request monitor is used by the "private service" (the service behind the
+// firewall) to know when to setup connections requested by the "public service"
+// (e.g., a cache).
+func LaunchRequestMonitor(ctx context.Context, egrp *errgroup.Group, sType server_structs.ServerType, privateName string, resultChan chan any) (err error) {
 	fedInfo, err := config.GetFederation(ctx)
 	if err != nil {
 		return err
+	}
+
+	prefix := ""
+	if sType.IsEnabled(server_structs.CacheType) {
+		prefix = server_structs.GetCacheNs(privateName)
+	} else {
+		prefix = server_structs.GetOriginNs(privateName)
 	}
 
 	brokerUrl := fedInfo.BrokerEndpoint
@@ -561,13 +583,9 @@ func LaunchRequestMonitor(ctx context.Context, egrp *errgroup.Group, resultChan 
 		return errors.New("Broker service is not set or discovered; cannot enable broker functionality.  Try setting Federation.BrokerUrl")
 	}
 	brokerEndpoint := brokerUrl + "/api/v1.0/broker/retrieve"
-	originUrl, err := url.Parse(param.Server_ExternalWebUrl.GetString())
-	if err != nil {
-		return
-	}
 	oReq := originRequest{
-		Origin: originUrl.Hostname(),
-		Prefix: param.Origin_FederationPrefix.GetString(),
+		Origin: privateName,
+		Prefix: prefix,
 	}
 	req, err := json.Marshal(&oReq)
 	if err != nil {
@@ -575,7 +593,27 @@ func LaunchRequestMonitor(ctx context.Context, egrp *errgroup.Group, resultChan 
 	}
 	reqReader := bytes.NewReader(req)
 
+	// Create a token that will be used to retrieve requests from the broker;
+	// this is done before the goroutine starts to guarantee that we are looking up
+	// the Viper config from a single-threaded context.  Otherwise, during startup,
+	// we may have concurrent read and write operations to the Viper config, which
+	// can lead to a panic.
+	brokerAud, err := url.Parse(fedInfo.BrokerEndpoint)
+	if err != nil {
+		log.Errorln("Failure when parsing broker URL:", err)
+		return
+	}
+	brokerAud.Path = ""
+	token, err := createToken(prefix, param.Server_Hostname.GetString(), brokerAud.String(), token_scopes.Broker_Retrieve)
+	if err != nil {
+		log.Errorln("Failure when constructing the broker retrieve token:", err)
+		return
+	}
+
+	client := &http.Client{Transport: config.GetBasicTransport()}
+
 	egrp.Go(func() (err error) {
+		firstLoop := true
 		for {
 			sleepDuration := time.Second + time.Duration(mrand.Intn(500))*time.Microsecond
 			select {
@@ -595,25 +633,21 @@ func LaunchRequestMonitor(ctx context.Context, egrp *errgroup.Group, resultChan 
 				req.Header.Set("Content-Type", "application/json")
 				req.Header.Set("User-Agent", "pelican-origin/"+config.GetVersion())
 
-				brokerAud, err := url.Parse(fedInfo.BrokerEndpoint)
-				if err != nil {
-					log.Errorln("Failure when parsing broker URL:", err)
-					break
+				if !firstLoop {
+					token, err = createToken(prefix, param.Server_Hostname.GetString(), brokerAud.String(), token_scopes.Broker_Retrieve)
+					if err != nil {
+						log.Errorln("Failure when constructing the broker retrieve token:", err)
+						break
+					}
 				}
-				brokerAud.Path = ""
-
-				token, err := createToken(param.Origin_FederationPrefix.GetString(), param.Server_Hostname.GetString(), brokerAud.String(), token_scopes.Broker_Retrieve)
-				if err != nil {
-					log.Errorln("Failure when constructing the broker retrieve token:", err)
-					break
-				}
+				firstLoop = false
 				req.Header.Set("Authorization", "Bearer "+token)
-
-				tr := config.GetTransport()
-				client := &http.Client{Transport: tr}
 
 				resp, err := client.Do(req)
 				if err != nil {
+					if errors.Is(err, context.Canceled) {
+						break
+					}
 					log.Errorln("Failure when invoking the broker URL for retrieving requests", err)
 					break
 				}
@@ -642,7 +676,7 @@ func LaunchRequestMonitor(ctx context.Context, egrp *errgroup.Group, resultChan 
 				}
 
 				if brokerResp.Status == server_structs.RespOK {
-					listener, err := doCallback(ctx, brokerResp.Request)
+					listener, err := doCallback(ctx, sType, brokerResp.Request)
 					if err != nil {
 						log.Errorln("Failed to callback to the cache:", err)
 						resultChan <- err

--- a/broker/dialer.go
+++ b/broker/dialer.go
@@ -1,0 +1,87 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// This file contains methods for a dialer that can use the broker
+// functionality to connect to a remote service.
+
+package broker
+
+import (
+	"context"
+	"net"
+
+	"github.com/jellydator/ttlcache/v3"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/param"
+)
+
+type (
+	// BrokerDialer is a dialer that can use the broker
+	// functionality to connect to a remote service.
+	BrokerDialer struct {
+		dialerContext func(ctx context.Context, network, addr string) (net.Conn, error)
+		// Map from service name to broker endpoint.
+		// If the service name is not found in the cache, then the dialer
+		// will use a normal TCP connection to the service.
+		brokerEndpoints *ttlcache.Cache[string, string]
+	}
+)
+
+// NewBrokerDialer creates a new BrokerDialer.
+func NewBrokerDialer(ctx context.Context, egrp *errgroup.Group) *BrokerDialer {
+
+	dialer := &net.Dialer{
+		Timeout:   param.Transport_DialerTimeout.GetDuration(),
+		KeepAlive: param.Transport_DialerKeepAlive.GetDuration(),
+	}
+	brokerEndpoints := ttlcache.New(
+		ttlcache.WithTTL[string, string](param.Transport_BrokerEndpointCacheTTL.GetDuration()),
+		ttlcache.WithDisableTouchOnHit[string, string](),
+	)
+
+	go brokerEndpoints.Start()
+	egrp.Go(func() error {
+		<-ctx.Done()
+		brokerEndpoints.DeleteAll()
+		brokerEndpoints.Stop()
+		return nil
+	})
+
+	return &BrokerDialer{
+		dialerContext:   dialer.DialContext,
+		brokerEndpoints: brokerEndpoints,
+	}
+}
+
+// Set the dialer to use `brokerUrl` as the broker endpoint for
+// the service `name`.
+func (d *BrokerDialer) UseBroker(name, brokerUrl string) {
+	d.brokerEndpoints.Set(name, brokerUrl, ttlcache.DefaultTTL)
+}
+
+// DialContext dials a connection to the given network and address using the broker.
+func (d *BrokerDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	info := d.brokerEndpoints.Get(addr)
+	if info == nil {
+		// If the endpoint is not found in the cache, use the default dialer.
+		return d.dialerContext(ctx, network, addr)
+	}
+
+	return ConnectToOrigin(ctx, info.Value(), "/", addr)
+}

--- a/broker/request_manager.go
+++ b/broker/request_manager.go
@@ -68,7 +68,7 @@ func getOriginQueue(prefix, origin string) chan reversalRequest {
 // Send a request to a given origin's queue.
 // Return a requestTimeout error if no origin retrieved the request before the context timed out.
 func handleRequest(ctx context.Context, origin string, req reversalRequest, timeout time.Duration) (err error) {
-	queue := getOriginQueue(req.Prefix, origin)
+	queue := getOriginQueue("/", origin)
 	maxTime := timeout - 500*time.Millisecond - time.Duration(rand.Intn(500))*time.Millisecond
 	if maxTime <= 0 {
 		maxTime = time.Millisecond
@@ -90,7 +90,7 @@ func handleRequest(ctx context.Context, origin string, req reversalRequest, time
 }
 
 // Handle the origin's request to retrieve any pending reversals.
-func handleRetrieve(appCtx context.Context, ginCtx context.Context, prefix, origin string, timeout time.Duration) (req reversalRequest, err error) {
+func handleRetrieve(appCtx context.Context, ginCtx context.Context, origin string, timeout time.Duration) (req reversalRequest, err error) {
 	// Return randomly short of the timeout.
 	maxTime := timeout - 500*time.Millisecond - time.Duration(rand.Intn(500))*time.Millisecond
 	if maxTime <= 0 {
@@ -99,7 +99,7 @@ func handleRetrieve(appCtx context.Context, ginCtx context.Context, prefix, orig
 	tick := time.NewTicker(maxTime)
 	defer tick.Stop()
 	select {
-	case req = <-getOriginQueue(prefix, origin):
+	case req = <-getOriginQueue("/", origin):
 		break
 	case <-tick.C:
 		err = errRetrieveTimeout

--- a/cache/broker_client_windows.go
+++ b/cache/broker_client_windows.go
@@ -23,10 +23,16 @@ package cache
 import (
 	"context"
 
+	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
 
 func LaunchRequestListener(ctx context.Context, egrp *errgroup.Group) error {
 	return errors.New("Broker functionality not supported on Windows")
+}
+
+func LaunchBrokerListener(ctx context.Context, egrp *errgroup.Group, engine *gin.Engine) (err error) {
+	err = errors.New("Broker functionality not supported on Windows")
+	return
 }

--- a/cmd/director_serve.go
+++ b/cmd/director_serve.go
@@ -28,7 +28,7 @@ import (
 
 func serveDirector(cmd *cobra.Command, args []string) error {
 	modules := server_structs.DirectorType
-	if param.Origin_EnableBroker.GetBool() {
+	if param.Director_EnableBroker.GetBool() {
 		modules.Set(server_structs.BrokerType)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -1849,6 +1849,7 @@ func ResetConfig() {
 	// Clear cached transport object
 	onceTransport = sync.Once{}
 	transport = nil
+	basicTransport = nil
 
 	// Clear the instance ID information for generated server ads
 	server_structs.Reset()

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -60,6 +60,7 @@ Director:
   FedTokenLifetime: 15m
 Cache:
   DefaultCacheTimeout: "9.5s"
+  EnableBroker: true
   EnablePrefetch: true
   Port: 8442
   SelfTest: true

--- a/config/transport.go
+++ b/config/transport.go
@@ -1,0 +1,113 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package config
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+
+	"github.com/pelicanplatform/pelican/param"
+)
+
+var (
+	// Our global transports that only will get reconfigured if needed
+	transport *http.Transport
+
+	// Once to ensure we only set up the transport once
+	onceTransport sync.Once
+
+	// Static dialer for the transport
+	dialerFunc atomic.Pointer[func(ctx context.Context, network, addr string) (net.Conn, error)]
+)
+
+// function to get/setup the transport (only once)
+func GetTransport() *http.Transport {
+	onceTransport.Do(func() {
+		setupTransport()
+	})
+	return transport
+}
+
+// Override the global transport's dialer function.
+//
+// Intended to allow the broker-aware dialer to be setup by other packages.
+// Will panic if the dialerFunc is nil.
+func SetTransportDialer(DialerConctext func(ctx context.Context, network, addr string) (net.Conn, error)) {
+	if DialerConctext == nil {
+		panic("dialerFunc cannot be nil")
+	}
+	dialerFunc.Store(&DialerConctext)
+}
+
+// Implement the DialContext interface for the global transport.
+//
+// Uses the global dialer function
+func brokerDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	return (*dialerFunc.Load())(ctx, network, addr)
+}
+
+func setupTransport() {
+	//Getting timeouts and other information from defaults.yaml
+	maxIdleConns := param.Transport_MaxIdleConns.GetInt()
+	idleConnTimeout := param.Transport_IdleConnTimeout.GetDuration()
+	transportTLSHandshakeTimeout := param.Transport_TLSHandshakeTimeout.GetDuration()
+	expectContinueTimeout := param.Transport_ExpectContinueTimeout.GetDuration()
+	responseHeaderTimeout := param.Transport_ResponseHeaderTimeout.GetDuration()
+
+	transportDialerTimeout := param.Transport_DialerTimeout.GetDuration()
+	transportKeepAlive := param.Transport_DialerKeepAlive.GetDuration()
+
+	defaultDialer := net.Dialer{
+		Timeout:   transportDialerTimeout,
+		KeepAlive: transportKeepAlive,
+	}
+	defaultDialerContext := defaultDialer.DialContext
+	dialerFunc.Store(&defaultDialerContext)
+
+	//Set up the transport
+	transport = &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           brokerDialContext,
+		MaxIdleConns:          maxIdleConns,
+		IdleConnTimeout:       idleConnTimeout,
+		TLSHandshakeTimeout:   transportTLSHandshakeTimeout,
+		ExpectContinueTimeout: expectContinueTimeout,
+		ResponseHeaderTimeout: responseHeaderTimeout,
+	}
+	if param.TLSSkipVerify.GetBool() {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	if caCert, err := LoadCertificate(param.Server_TLSCACertificateFile.GetString()); err == nil {
+		systemPool, err := x509.SystemCertPool()
+		if err == nil {
+			systemPool.AddCert(caCert)
+			// Ensure that we don't override the InsecureSkipVerify if it's present
+			if transport.TLSClientConfig == nil {
+				transport.TLSClientConfig = &tls.Config{RootCAs: systemPool}
+			} else {
+				transport.TLSClientConfig.RootCAs = systemPool
+			}
+		}
+	}
+}

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -179,7 +179,12 @@ func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]
 
 	// Inform the global broker dialer about the new server ad
 	if sAd.BrokerURL.Host != "" && brokerDialer != nil {
-		brokerDialer.UseBroker(sAd.AuthURL.Host, sAd.BrokerURL.String())
+		sType := server_structs.NewServerType()
+		sType.SetString(sAd.Type)
+		brokerDialer.UseBroker(sType, sAd.WebURL.Host, sAd.BrokerURL.String())
+		if sAd.Type == server_structs.OriginType.String() {
+			brokerDialer.UseBroker(sType, sAd.URL.Host, sAd.BrokerURL.String())
+		}
 	}
 
 	// Prepare `stat` call utilities for all servers regardless of its source (topology or Pelican)

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1421,6 +1421,16 @@ deprecated: true
 replacedby: Cache.StorageLocation
 components: ["cache"]
 ---
+name: Cache.EnableBroker
+description: |+
+  Control whether the cache will use the connection broker to talk to the director.
+
+  When enabled, the cache doesn't need an incoming network port open to communicate
+  with the director.
+type: bool
+default: true
+components: ["cache"]
+---
 name: Cache.EnablePrefetch
 description: |+
   Control whether data prefeteching is enabled in the cache.

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -142,6 +142,16 @@ type: duration
 default: 10s
 components: ["client", "registry", "origin"]
 ---
+name: Transport.BrokerEndpointCacheTTL
+description: |+
+  A Pelican service can indicate that a connection broker service is needed to create connections
+  (this allows the service to live behind a firewall without any incoming connectivity).  This controls
+  how long the server remembers the broker lookup information.
+type: duration
+default: 2m
+hidden: true
+components: ["director"]
+---
 name: GeoIPOverrides
 description: |+
   A list of IP addresses whose GeoIP resolution should be overridden with the supplied Lat/Long coordinates (in decimal form). This affects

--- a/fed_test_utils/fed.go
+++ b/fed_test_utils/fed.go
@@ -96,6 +96,7 @@ func NewFedTest(t *testing.T, originConfig string) (ft *FedTest) {
 	})
 
 	modules := server_structs.ServerType(0)
+	modules.Set(server_structs.BrokerType)
 	modules.Set(server_structs.CacheType)
 	modules.Set(server_structs.OriginType)
 	modules.Set(server_structs.DirectorType)

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -92,6 +92,14 @@ func LaunchModules(ctx context.Context, modules server_structs.ServerType) (serv
 		return
 	}
 
+	// If we are a director, we will potentially contact other
+	// services with the broker, so we need to set up the broker dialer
+	if modules.IsEnabled(server_structs.DirectorType) {
+		brokerDialer := broker.NewBrokerDialer(ctx, egrp)
+		config.SetTransportDialer(brokerDialer.DialContext)
+		director.SetBrokerDialer(brokerDialer)
+	}
+
 	// Print Pelican config at server start if it's in debug or info level
 	if log.GetLevel() >= log.InfoLevel {
 		if err = config.PrintConfig(); err != nil {

--- a/origin/broker_test.go
+++ b/origin/broker_test.go
@@ -1,0 +1,68 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package origin_test
+
+import (
+	_ "embed"
+	"net/http"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/fed_test_utils"
+	"github.com/pelicanplatform/pelican/origin"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
+)
+
+var (
+	//go:embed resources/broker-config.yaml
+	brokerConfig string
+)
+
+// A test that spins up a federation and verifies we can
+// perform API calls to the origin via the broker.
+func TestBrokerApi(t *testing.T) {
+	server_utils.ResetTestState()
+
+	fed := fed_test_utils.NewFedTest(t, brokerConfig)
+
+	collector, err := origin.PelicanBrokerConnections.GetMetricWithLabelValues("origin")
+	require.NoError(t, err, "Failed to get metric collector")
+
+	startVal := testutil.ToFloat64(collector)
+
+	desiredURL := param.Server_ExternalWebUrl.GetString() + "/api/v1.0/health"
+	err = server_utils.WaitUntilWorking(fed.Ctx, "GET", desiredURL, "director", 200, false)
+	require.NoError(t, err)
+
+	httpc := http.Client{
+		Transport: config.GetTransport().Clone(),
+	}
+	resp, err := httpc.Get(desiredURL)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "Expected HTTP status code 200")
+
+	// Verify the metric collector has been incremented
+	require.Greater(t, testutil.ToFloat64(collector), startVal, "Expected broker connections metric to be incremented")
+}

--- a/origin/resources/broker-config.yaml
+++ b/origin/resources/broker-config.yaml
@@ -1,0 +1,13 @@
+# Origin export configuration to test broker functionality
+
+Director:
+  EnableBroker: true
+
+Origin:
+  StorageType: "posix"
+  EnableBroker: true
+  EnableDirectReads: true
+  Exports:
+    - StoragePrefix: /<SHOULD BE OVERRIDDEN>
+      FederationPrefix: /test
+      Capabilities: ["PublicReads", "Writes", "DirectReads", "Listings"]

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -354,6 +354,7 @@ var (
 )
 
 var (
+	Cache_EnableBroker = BoolParam{"Cache.EnableBroker"}
 	Cache_EnableLotman = BoolParam{"Cache.EnableLotman"}
 	Cache_EnableOIDC = BoolParam{"Cache.EnableOIDC"}
 	Cache_EnablePrefetch = BoolParam{"Cache.EnablePrefetch"}

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -444,6 +444,7 @@ var (
 	Server_AdvertisementInterval = DurationParam{"Server.AdvertisementInterval"}
 	Server_RegistrationRetryInterval = DurationParam{"Server.RegistrationRetryInterval"}
 	Server_StartupTimeout = DurationParam{"Server.StartupTimeout"}
+	Transport_BrokerEndpointCacheTTL = DurationParam{"Transport.BrokerEndpointCacheTTL"}
 	Transport_DialerKeepAlive = DurationParam{"Transport.DialerKeepAlive"}
 	Transport_DialerTimeout = DurationParam{"Transport.DialerTimeout"}
 	Transport_ExpectContinueTimeout = DurationParam{"Transport.ExpectContinueTimeout"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -31,6 +31,7 @@ type Config struct {
 		DataLocations []string `mapstructure:"datalocations" yaml:"DataLocations"`
 		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
 		DefaultCacheTimeout time.Duration `mapstructure:"defaultcachetimeout" yaml:"DefaultCacheTimeout"`
+		EnableBroker bool `mapstructure:"enablebroker" yaml:"EnableBroker"`
 		EnableLotman bool `mapstructure:"enablelotman" yaml:"EnableLotman"`
 		EnableOIDC bool `mapstructure:"enableoidc" yaml:"EnableOIDC"`
 		EnablePrefetch bool `mapstructure:"enableprefetch" yaml:"EnablePrefetch"`
@@ -387,6 +388,7 @@ type configWithType struct {
 		DataLocations struct { Type string; Value []string }
 		DbLocation struct { Type string; Value string }
 		DefaultCacheTimeout struct { Type string; Value time.Duration }
+		EnableBroker struct { Type string; Value bool }
 		EnableLotman struct { Type string; Value bool }
 		EnableOIDC struct { Type string; Value bool }
 		EnablePrefetch struct { Type string; Value bool }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -346,6 +346,7 @@ type Config struct {
 		DisableOrigins bool `mapstructure:"disableorigins" yaml:"DisableOrigins"`
 	} `mapstructure:"topology" yaml:"Topology"`
 	Transport struct {
+		BrokerEndpointCacheTTL time.Duration `mapstructure:"brokerendpointcachettl" yaml:"BrokerEndpointCacheTTL"`
 		DialerKeepAlive time.Duration `mapstructure:"dialerkeepalive" yaml:"DialerKeepAlive"`
 		DialerTimeout time.Duration `mapstructure:"dialertimeout" yaml:"DialerTimeout"`
 		ExpectContinueTimeout time.Duration `mapstructure:"expectcontinuetimeout" yaml:"ExpectContinueTimeout"`
@@ -701,6 +702,7 @@ type configWithType struct {
 		DisableOrigins struct { Type string; Value bool }
 	}
 	Transport struct {
+		BrokerEndpointCacheTTL struct { Type string; Value time.Duration }
 		DialerKeepAlive struct { Type string; Value time.Duration }
 		DialerTimeout struct { Type string; Value time.Duration }
 		ExpectContinueTimeout struct { Type string; Value time.Duration }


### PR DESCRIPTION
This hooks the use of the broker into the director, allowing it to contact the cache.

With this, caches no longer need to allow incoming connections from the director to enable functionality like monitoring.