### PR TITLE
Add `pelican key create` command

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -66,6 +66,6 @@ func init() {
 	passwordCmd.Flags().StringVarP(&outPasswordPath, "output", "o", "", "The path to the generate htpasswd password file. Default: ./server-web-passwd")
 	passwordCmd.Flags().StringVarP(&inPasswordPath, "password", "p", "", "The path to the file containing the password. Will take from terminal input if not provided")
 
-	keygenCmd.Flags().StringVar(&privateKeyPath, "private-key", "", "The path to the generate private key file. Default: ./issuer.jwk")
+	keygenCmd.Flags().StringVar(&privateKeyPath, "private-key", "", "The path to the generate private key file. Default: ./issuer.pem")
 	keygenCmd.Flags().StringVar(&publicKeyPath, "public-key", "", "The path to the generate public key file. Default: ./issuer-pub.jwks")
 }

--- a/cmd/generate_keygen.go
+++ b/cmd/generate_keygen.go
@@ -54,7 +54,7 @@ func keygenMain(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "failed to get the current working directory")
 	}
 	if privateKeyPath == "" {
-		privateKeyPath = filepath.Join(wd, "issuer.jwk")
+		privateKeyPath = filepath.Join(wd, "issuer.pem")
 	} else {
 		privateKeyPath = filepath.Clean(strings.TrimSpace(privateKeyPath))
 	}

--- a/cmd/generate_keygen_test.go
+++ b/cmd/generate_keygen_test.go
@@ -87,7 +87,7 @@ func TestKeygenMain(t *testing.T) {
 
 		checkKeys(
 			t,
-			filepath.Join(tempDir, "issuer.jwk"),
+			filepath.Join(tempDir, "issuer.pem"),
 			filepath.Join(tempDir, "issuer-pub.jwks"),
 		)
 	})
@@ -119,7 +119,7 @@ func TestKeygenMain(t *testing.T) {
 
 		checkKeys(
 			t,
-			filepath.Join(tempWd, "issuer.jwk"),
+			filepath.Join(tempWd, "issuer.pem"),
 			publicKeyPath,
 		)
 	})
@@ -153,7 +153,7 @@ func TestKeygenMain(t *testing.T) {
 
 		checkKeys(
 			t,
-			filepath.Join(tempWd, "issuer.jwk"),
+			filepath.Join(tempWd, "issuer.pem"),
 			publicKeyPath,
 		)
 	})

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	keyCmd = &cobra.Command{
+		Use:   "key",
+		Short: "Manage Pelican issuer keys",
+	}
+
+	// `pelican key create` command aims to replace `pelican generate keygen` command in the future.
+	// For now, they are both available and do the same thing to maintain backward compatibility.
+	keyCreateCmd = &cobra.Command{
+		Use:   "create",
+		Short: "Generate a public-private key-pair for Pelican OIDC issuer",
+		Long: `Generate a public-private key-pair for a Pelican server.
+The private key is a ECDSA key with P256 curve. The corresponding public key
+is a JWKS in JSON. The public key follows OIDC protocol and can be used
+for JWT signature verification.`,
+		RunE: keygenMain,
+		// Note: no new tests are needed for this new command, because it reuses the `keygenMain` function,
+		// which is already tested in `pelican/cmd/generate_keygen_test.go`.
+		SilenceUsage: true,
+	}
+)
+
+func init() {
+	keyCmd.AddCommand(keyCreateCmd)
+
+	// Attach flags to the `create` sub-command
+	keyCreateCmd.Flags().StringVar(&privateKeyPath, "private-key", "", "The path to the generate private key file. Default: ./issuer.jwk")
+	keyCreateCmd.Flags().StringVar(&publicKeyPath, "public-key", "", "The path to the generate public key file. Default: ./issuer-pub.jwks")
+}

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -30,6 +30,6 @@ func init() {
 	keyCmd.AddCommand(keyCreateCmd)
 
 	// Attach flags to the `create` sub-command
-	keyCreateCmd.Flags().StringVar(&privateKeyPath, "private-key", "", "The path to the generate private key file. Default: ./issuer.jwk")
+	keyCreateCmd.Flags().StringVar(&privateKeyPath, "private-key", "", "The path to the generate private key file. Default: ./issuer.pem")
 	keyCreateCmd.Flags().StringVar(&publicKeyPath, "public-key", "", "The path to the generate public key file. Default: ./issuer-pub.jwks")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -145,6 +145,7 @@ func init() {
 	rootCmd.AddCommand(rootPluginCmd)
 	rootCmd.AddCommand(serveCmd)
 	rootCmd.AddCommand(generateCmd)
+	rootCmd.AddCommand(keyCmd)
 	rootCmd.AddCommand(downtimeCmd)
 	rootCmd.AddCommand(config_printer.ConfigCmd)
 	preferredPrefix := config.GetPreferredPrefix()


### PR DESCRIPTION
What this new command does is identical to `pelican generate keygen` command - create a pair of private/public keys. The only difference is the new private key file will be named as "issuer.pem" instead of "issuer.jwk". The new extension reflects the real format (PEM, Privacy-Enhanced Mail) of this private key file and is required by Pelican to automatically detect it in the `IssuerKeysDirectory`. 

There is no backward compatibility issue for this change because it won't affect the existing "issuer.jwk" file (which still work via the `IssuerKey` config param). I also updated the Pelican docs to let facilitators and users know this change.

`pelican generate keygen` is planned to retire it in the future. For now, it remains available for backward compatibility.

Closes #2192 