### PR TITLE
Relax log directory permissions

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -451,7 +451,7 @@ nfpms:
         file_info:
           owner: root
           group: root
-          mode: 0700
+          mode: 0755
     overrides:
       rpm:
         provides:


### PR DESCRIPTION
Relax log directory permissions.

This can unblock unpriv users to use Pelican config tool.