### PR TITLE
Memory jitter cleanup

### DIFF
--- a/broker/client.go
+++ b/broker/client.go
@@ -232,21 +232,21 @@ func ConnectToOrigin(ctx context.Context, brokerUrl, prefix, originName string) 
 
 	resp, err := client.Do(req)
 	if err != nil {
-		err = errors.Wrap(err, "Failure when invoking the broker URL")
+		err = errors.Wrap(err, "failure when invoking the broker URL")
 		return
 	}
 	defer resp.Body.Close()
 	responseBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		err = errors.Wrap(err, "Failure when reading response from broker response")
+		err = errors.Wrap(err, "failure when reading response from broker response")
 	}
 	if resp.StatusCode >= 400 {
 		errResp := server_structs.SimpleApiResp{}
 		log.Errorf("Failure (status code %d) when invoking the broker: %s", resp.StatusCode, string(responseBytes))
 		if err = json.Unmarshal(responseBytes, &errResp); err != nil {
-			err = errors.Errorf("Failure when invoking the broker (status code %d); unable to parse error message", resp.StatusCode)
+			err = errors.Errorf("failure when invoking the broker (status code %d); unable to parse error message", resp.StatusCode)
 		} else {
-			err = errors.Errorf("Failure when invoking the broker (status code %d): %s", resp.StatusCode, errResp.Msg)
+			err = errors.Errorf("failure when invoking the broker (status code %d): %s", resp.StatusCode, errResp.Msg)
 		}
 		return
 	}

--- a/broker/token_utils.go
+++ b/broker/token_utils.go
@@ -65,9 +65,9 @@ func LaunchNamespaceKeyMaintenance(ctx context.Context, egrp *errgroup.Group) {
 			return item
 		},
 	)
-	namespaceKeys = ttlcache.New[string, *jwk.Cache](
+	namespaceKeys = ttlcache.New(
 		ttlcache.WithTTL[string, *jwk.Cache](15*time.Minute),
-		ttlcache.WithLoader[string, *jwk.Cache](loader),
+		ttlcache.WithLoader(loader),
 	)
 
 	go namespaceKeys.Start()

--- a/director/director.go
+++ b/director/director.go
@@ -651,30 +651,40 @@ func getRequestID(ctx *gin.Context) uuid.UUID {
 func processSortedAdsErr(ginCtx *gin.Context, err error, requestId uuid.UUID) {
 	switch err.(type) {
 	case noOriginsForNsErr:
+		msg := fmt.Sprintf("No sources found for the requested path: %v: Request ID: %s", err, requestId.String())
+		log.Debugln(msg)
 		ginCtx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("No sources found for the requested path: %v: Request ID: %s", err, requestId.String()),
+			Msg:    msg,
 		})
 	case noOriginsForReqErr:
+		msg := fmt.Sprintf("Discovered sources for the namespace, but none support the request: %v: "+
+			"See '%s' to troubleshoot available origins/caches and their capabilities: Request ID: %s", err, param.Server_ExternalWebUrl.GetString(), requestId.String())
+		log.Debugln(msg)
 		ginCtx.JSON(http.StatusMethodNotAllowed, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
-			Msg: fmt.Sprintf("Discovered sources for the namespace, but none support the request: %v: "+
-				"See '%s' to troubleshoot available origins/caches and their capabilities: Request ID: %s", err, param.Server_ExternalWebUrl.GetString(), requestId.String()),
+			Msg:    msg,
 		})
 	case objectNotFoundErr:
+		msg := fmt.Sprintf("No sources reported possession of the object: %v: Are you sure it exists?: Request ID: %s", err, requestId.String())
+		log.Debugln(msg)
 		ginCtx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("No sources reported possession of the object: %v: Are you sure it exists?: Request ID: %s", err, requestId.String()),
+			Msg:    msg,
 		})
 	case directorStartupErr:
+		msg := fmt.Sprintf("%v: Request ID: %s", err, requestId.String())
+		log.Debugln(msg)
 		ginCtx.JSON(http.StatusTooManyRequests, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("%v: Request ID: %s", err, requestId.String()),
+			Msg:    msg,
 		})
 	default:
+		msg := fmt.Sprintf("Failed to get/sort server ads for the requested path: %v: Request ID: %s", err, requestId.String())
+		log.Debugln(msg)
 		ginCtx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("Failed to get/sort server ads for the requested path: %v: Request ID: %s", err, requestId.String()),
+			Msg:    msg,
 		})
 	}
 }
@@ -721,9 +731,11 @@ func redirectToCache(ginCtx *gin.Context) {
 			}
 		}
 		if len(cAds) == 0 {
+			msg := "No caches can fulfill this request and no fallback origins with the 'DirectReads' capability found for this object. Request ID: " + requestId.String()
+			log.Debugln(msg)
 			ginCtx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
 				Status: server_structs.RespFailed,
-				Msg:    "No caches can fulfill this request and no fallback origins with the 'DirectReads' capability found for this object. Request ID: " + requestId.String(),
+				Msg:    msg,
 			})
 			return
 		}

--- a/director/stat_stress_test.go
+++ b/director/stat_stress_test.go
@@ -35,6 +35,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/fed_test_utils"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_utils"
@@ -59,6 +60,7 @@ func TestStatMemory(t *testing.T) {
 	viper.Set(param.Origin_DirectorTest.GetName(), false)
 	viper.Set(param.Origin_SelfTest.GetName(), false)
 	fed := fed_test_utils.NewFedTest(t, directorPublicCfg)
+	config.DisableLoggingCensor()
 	discoveryUrl, err := url.Parse(param.Federation_DiscoveryUrl.GetString())
 	assert.NoError(t, err)
 

--- a/fed_test_utils/fed.go
+++ b/fed_test_utils/fed.go
@@ -52,11 +52,12 @@ import (
 
 type (
 	FedTest struct {
-		Exports []server_utils.OriginExport
-		Token   string
-		Ctx     context.Context
-		Egrp    *errgroup.Group
-		Pids    []int
+		AdvertiseCancel context.CancelFunc
+		Exports         []server_utils.OriginExport
+		Token           string
+		Ctx             context.Context
+		Egrp            *errgroup.Group
+		Pids            []int
 	}
 )
 
@@ -65,6 +66,7 @@ var (
 	fedTestDefaultConfig string
 )
 
+// Start up a new Pelican federation for unit testing
 func NewFedTest(t *testing.T, originConfig string) (ft *FedTest) {
 	ft = &FedTest{}
 	director.ResetState()
@@ -74,7 +76,11 @@ func NewFedTest(t *testing.T, originConfig string) (ft *FedTest) {
 	}
 
 	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	shutdownCtx, shutdownCancel := context.WithCancel(ctx)
+	ctx = context.WithValue(ctx, director.AdvertiseShutdownKey, shutdownCtx)
+	ctx = context.WithValue(ctx, server_utils.DirectorDiscoveryShutdownKey, shutdownCtx)
 	ft.Ctx = ctx
+	ft.AdvertiseCancel = shutdownCancel
 	ft.Egrp = egrp
 
 	tmpPathPattern := "Pelican-FedTest*"

--- a/launcher_utils/advertise.go
+++ b/launcher_utils/advertise.go
@@ -39,6 +39,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/director"
 	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
@@ -73,11 +74,20 @@ func LaunchPeriodicAdvertise(ctx context.Context, egrp *errgroup.Group, servers 
 		advertiseInterval = newInterval
 	}
 
+	shutdownAny := ctx.Value(director.AdvertiseShutdownKey)
+	var shutdownChannel <-chan struct{} = nil
+	if shutdownCtx, ok := shutdownAny.(context.Context); ok {
+		shutdownChannel = shutdownCtx.Done()
+	}
+
 	ticker := time.NewTicker(advertiseInterval)
 	egrp.Go(func() error {
 		defer ticker.Stop()
 		for {
 			select {
+			case <-shutdownChannel:
+				log.Infoln("Periodic advertise shut down on command")
+				return nil
 			case <-ticker.C:
 				doAdvertise(ctx, servers)
 			case <-ctx.Done():

--- a/server_utils/director_discovery.go
+++ b/server_utils/director_discovery.go
@@ -206,7 +206,7 @@ func LaunchPeriodicDirectorDiscovery(ctx context.Context, isDirector bool) error
 					log.Warningln("Failed to discover available director endpoints:", err)
 					select {
 					case <-ctx.Done():
-						log.Infoln("Periodic director advertise loop has been terminated")
+						log.Infoln("Periodic director discovery loop has been terminated")
 						return nil
 					default:
 						break
@@ -216,7 +216,7 @@ func LaunchPeriodicDirectorDiscovery(ctx context.Context, isDirector bool) error
 				}
 
 			case <-ctx.Done():
-				log.Infoln("Periodic advertisement loop has been terminated")
+				log.Infoln("Periodic director discovery loop has been terminated")
 				return nil
 			}
 		}

--- a/utils/client_test.go
+++ b/utils/client_test.go
@@ -100,27 +100,28 @@ func TestExtractAndMaskIP(t *testing.T) {
 }
 
 func TestExtractVersionAndServiceFromUserAgent(t *testing.T) {
-	t.Run("testNormalUserAgent", func(t *testing.T) {
-		userAgent := "pelican-origin/7.9.0"
-		expectedVersion := "7.9.0"
-		expectedService := "origin"
-		version, service := ExtractVersionAndServiceFromUserAgent(userAgent)
 
-		assert.Equal(t, expectedVersion, version)
-		assert.Equal(t, expectedService, service)
-	})
+	type TestExtractCase struct {
+		Name            string
+		UserAgent       string
+		ExpectedVersion string
+		ExpectedService string
+	}
+	var testCases = []TestExtractCase{
+		{Name: "testNormalUserAgent", UserAgent: "pelican-origin/7.9.0", ExpectedVersion: "7.9.0", ExpectedService: "origin"},
+		{Name: "testMissingSlash", UserAgent: "pelican-origin.7.9.0"},
+		{Name: "testNonAlpha", UserAgent: "pelican-origin1/7.9.9"},
+		{Name: "testBigVersion", UserAgent: "pelican-origin/7.9.9.9.9"},
+		{Name: "testNonNumeric", UserAgent: "pelican-origin/7s.9.0"},
+		{Name: "testInvalidUserAgent", UserAgent: "thisisnotvalid"},
+		{Name: "testEmptyUserAgent"},
+	}
 
-	t.Run("testInvalidUserAgent", func(t *testing.T) {
-		invalidUserAgent := "thisisnotvalid"
-		version, service := ExtractVersionAndServiceFromUserAgent(invalidUserAgent)
-		assert.Equal(t, 0, len(version))
-		assert.Equal(t, 0, len(service))
-	})
-
-	t.Run("testEmptyUserAgent", func(t *testing.T) {
-		emptyUserAgent := ""
-		version, service := ExtractVersionAndServiceFromUserAgent(emptyUserAgent)
-		assert.Equal(t, 0, len(version))
-		assert.Equal(t, 0, len(service))
-	})
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			version, service := ExtractVersionAndServiceFromUserAgent(tc.UserAgent)
+			assert.Equal(t, tc.ExpectedService, service)
+			assert.Equal(t, tc.ExpectedVersion, version)
+		})
+	}
 }


### PR DESCRIPTION
This PR has "various and sundry" cleanups around fixing up log messages, memory churn, and VS Code linter (which appears to be a bit more picky than the GHA?).

The unifying theme is various small changes that are prerequisites to a larger set of fixes for the "memory stress test" (which I'd like to make more reliable!).