### PR TITLE
Replace esoteric error message with one more meaningful for users

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2852,8 +2852,9 @@ Loop:
 		if errorStatus := trailer.Get("X-Transfer-Status"); errorStatus != "" {
 			statusCode, statusText := parseTransferStatus(errorStatus)
 			if statusCode != http.StatusOK {
-				log.WithFields(fields).Debugln("Got error from file transfer")
-				err = errors.New("transfer error: " + statusText)
+				log.WithFields(fields).Debugln("Got error from file transfer:", statusText)
+				statusText = strings.Replace(statusText, "sTREAM ioctl timeout", "cache timed out waiting on origin", 1)
+				err = errors.New("download error after server response started: " + statusText)
 				return
 			}
 		}

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -366,7 +366,7 @@ func TestTrailerError(t *testing.T) {
 	_, _, _, _, err = downloadHTTP(ctx, nil, nil, transfers[0], fname, writer, 0, -1, "", "")
 
 	assert.NotNil(t, err)
-	assert.EqualError(t, err, "transfer error: Unable to read test.txt; input/output error")
+	assert.EqualError(t, err, "download error after server response started: Unable to read test.txt; input/output error")
 }
 
 func TestUploadZeroLengthFile(t *testing.T) {


### PR DESCRIPTION
The sTREAM timeout error message means the upstream origin was unresponsive.