### PR TITLE
Update detailed server on server update

### DIFF
--- a/web_ui/frontend/app/director/components/DirectorCard.tsx
+++ b/web_ui/frontend/app/director/components/DirectorCard.tsx
@@ -32,7 +32,7 @@ export const DirectorCard = ({ server, authenticated }: DirectorCardProps) => {
     if (detailedServer !== undefined && dropdownOpen) {
       updateDetailedServer(server.name, setDetailedServer, dispatch);
     }
-  }, [server, setDetailedServer, dispatch]);
+  }, [server, setDetailedServer, dispatch, dropdownOpen, detailedServer]);
 
   return (
     <>
@@ -56,11 +56,6 @@ export const DirectorCard = ({ server, authenticated }: DirectorCardProps) => {
           }}
           onClick={async () => {
             setDropdownOpen(!dropdownOpen);
-
-            // Update detailed server when the dropdown is opened
-            if (dropdownOpen) {
-              updateDetailedServer(server.name, setDetailedServer, dispatch);
-            }
           }}
         >
           <Box my={'auto'} ml={1} display={'flex'} flexDirection={'row'}>


### PR DESCRIPTION
- Only do so if the dropdown is open and the detailedServer has been previously fetched

@h2zh There is two levels of detail for a server, detailed and not. When you click the dropdown I fetch the detailed view and use that to display more granular details in the dropdown. 

The issue was that I preferred that detailed data over the other data in the dropdown, but unlike the normal data that updates itself the detailed never gets refetched. 

To fix this I added an effect that watches for server change and if it happens well the dropdown is populated and open, I refetch the detailed data. 