### PR TITLE
Multiple Director Bug Fixes

### DIFF
--- a/director/director.go
+++ b/director/director.go
@@ -1207,7 +1207,7 @@ func registerServerAd(engineCtx context.Context, ctx *gin.Context, sType server_
 	}
 
 	// Forward to other directors, if applicable
-	forwardServiceAd(engineCtx, &adV2, sType, nil)
+	forwardServiceAd(engineCtx, &adV2, sType, "")
 
 	// Correct any clock skews detected in the client
 	now := time.Now()

--- a/director/director.go
+++ b/director/director.go
@@ -1207,7 +1207,7 @@ func registerServerAd(engineCtx context.Context, ctx *gin.Context, sType server_
 	}
 
 	// Forward to other directors, if applicable
-	forwardServiceAd(engineCtx, &adV2, sType)
+	forwardServiceAd(engineCtx, &adV2, sType, nil)
 
 	// Correct any clock skews detected in the client
 	now := time.Now()

--- a/director/director_advertise.go
+++ b/director/director_advertise.go
@@ -76,7 +76,7 @@ type (
 	// We provided both the director that produced the ad and the
 	// ad itself.  Having the director ad helps detect forwarding
 	// loops -- we can break early if we detect we're talking to ourself!
-	forwardAd struct {
+	ForwardAd struct {
 		DirectorAd *server_structs.DirectorAd        `json:"director-ad"`
 		AdType     string                            `json:"ad-type"`
 		Now        time.Time                         `json:"now"`
@@ -134,7 +134,7 @@ func registerDirectorAd(appCtx context.Context, egrp *errgroup.Group, ctx *gin.C
 		return
 	}
 
-	fAd := forwardAd{}
+	fAd := ForwardAd{}
 	if err = ctx.MustBindWith(&fAd, binding.JSON); err != nil {
 		log.Errorln("Failed to bind JSON:", err)
 		return
@@ -237,7 +237,7 @@ func forwardServiceAd(engineCtx context.Context, serviceAd *server_structs.Origi
 // functions to avoid refactoring the DirectorAd and OriginAdvertiseV2 to have
 // a common interface.
 func (dir *directorInfo) forwardDirector(ad *server_structs.DirectorAd) {
-	forwardAd := &forwardAd{
+	forwardAd := &ForwardAd{
 		DirectorAd: ad,
 		AdType:     server_structs.DirectorType.String(),
 		Now:        time.Now(),
@@ -281,7 +281,7 @@ func (dir *directorInfo) forwardService(ctx context.Context, ad *server_structs.
 		AdvertiseUrl: adUrl,
 	}
 	directorAd.Initialize(name)
-	forwardAd := &forwardAd{
+	forwardAd := &ForwardAd{
 		DirectorAd: directorAd,
 		ServiceAd:  ad,
 		AdType:     sType.String(),

--- a/director/forward_service_test.go
+++ b/director/forward_service_test.go
@@ -77,7 +77,7 @@ func TestForwardService(t *testing.T) {
 	data, err := io.ReadAll(info.contents)
 	require.NoError(t, err)
 
-	var fwd ForwardAd
+	var fwd forwardAd
 	require.NoError(t, json.Unmarshal(data, &fwd))
 	assert.Equal(t, viper.GetString(param.Director_AdvertiseUrl.GetName()), fwd.DirectorAd.AdvertiseUrl)
 	assert.Equal(t, server_structs.OriginType.String(), fwd.AdType)
@@ -141,7 +141,7 @@ func TestForwardServiceAd(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	forwardServiceAd(ctx, svcAd, server_structs.OriginType, dir1.ad)
+	forwardServiceAd(ctx, svcAd, server_structs.OriginType, dir1.ad.Name)
 
 	// We should have received an ad on channel 2 but not channel 1
 	select {

--- a/director/forward_service_test.go
+++ b/director/forward_service_test.go
@@ -1,0 +1,86 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package director
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
+)
+
+func TestForwardService(t *testing.T) {
+	directorNameOnce = sync.Once{}
+	directorName = ""
+	directorNameError = nil
+
+	viper.Set(param.Director_AdvertiseUrl.GetName(), "http://director-ad-url")
+	defer viper.Set(param.Director_AdvertiseUrl.GetName(), "")
+	viper.Set(param.Server_ExternalWebUrl.GetName(), "http://external-url")
+	defer viper.Set(param.Server_ExternalWebUrl.GetName(), "")
+
+	ctx := context.Background()
+	ad := &server_structs.OriginAdvertiseV2{
+		ServerBaseAd: server_structs.ServerBaseAd{
+			Name:         "svc-name",
+			InstanceID:   "inst-id",
+			StartTime:    12345,
+			GenerationID: 1,
+			Version:      "v1",
+			Expiration:   time.Unix(67890, 0).UTC(),
+		},
+		DataURL: "http://data-url",
+	}
+
+	ch := make(chan *forwardAdInfo, 1)
+	dir := &directorInfo{forwardAdChan: ch}
+
+	dir.forwardService(ctx, ad, server_structs.OriginType)
+
+	info := <-ch
+	assert.Equal(t, ad.Name, info.key)
+	assert.Equal(t, server_structs.OriginType, info.adType)
+	assert.Equal(t, ad.Name, info.serverBase.Name)
+	assert.Equal(t, ad.InstanceID, info.serverBase.InstanceID)
+	assert.Equal(t, ad.StartTime, info.serverBase.StartTime)
+	assert.Equal(t, ad.GenerationID, info.serverBase.GenerationID)
+	assert.Equal(t, ad.Version, info.serverBase.Version)
+	assert.Equal(t, ad.Expiration, info.serverBase.Expiration)
+
+	data, err := io.ReadAll(info.contents)
+	require.NoError(t, err)
+
+	var fwd ForwardAd
+	require.NoError(t, json.Unmarshal(data, &fwd))
+	assert.Equal(t, viper.GetString(param.Director_AdvertiseUrl.GetName()), fwd.DirectorAd.AdvertiseUrl)
+	assert.Equal(t, server_structs.OriginType.String(), fwd.AdType)
+	assert.False(t, fwd.Now.IsZero())
+	assert.Equal(t, ad, fwd.ServiceAd)
+}

--- a/director/forward_service_test.go
+++ b/director/forward_service_test.go
@@ -84,3 +84,76 @@ func TestForwardService(t *testing.T) {
 	assert.False(t, fwd.Now.IsZero())
 	assert.Equal(t, ad, fwd.ServiceAd)
 }
+
+// TestForwardServiceAd tests that we forward the service ad to the correct director
+// We have two directors, each with different advertise urls
+// We have a service ad that should be only forwarded to the director that is not itself
+func TestForwardServiceAd(t *testing.T) {
+	viper.Set(param.Server_ExternalWebUrl.GetName(), "http://director1.com")
+	defer viper.Set(param.Server_ExternalWebUrl.GetName(), "")
+
+	// Reset the cache
+	directorAds.DeleteAll()
+
+	ch1 := make(chan *forwardAdInfo, 1)
+	dir1 := &directorInfo{
+		ad: &server_structs.DirectorAd{
+			AdvertiseUrl: "http://director-ad-url-1",
+			ServerBaseAd: server_structs.ServerBaseAd{
+				Name:         "dir1",
+				InstanceID:   "inst-id-1",
+				StartTime:    12345,
+				GenerationID: 1,
+				Version:      "v1",
+			},
+		},
+		forwardAdChan: ch1,
+	}
+
+	ch2 := make(chan *forwardAdInfo, 1)
+	dir2 := &directorInfo{
+		ad: &server_structs.DirectorAd{
+			AdvertiseUrl: "http://director-ad-url-2",
+			ServerBaseAd: server_structs.ServerBaseAd{
+				Name:         "dir2",
+				InstanceID:   "inst-id-2",
+				StartTime:    12345,
+				GenerationID: 1,
+				Version:      "v1",
+			},
+		},
+		forwardAdChan: ch2,
+	}
+
+	directorAds.Set("dir1", dir1, 15*time.Minute)
+	directorAds.Set("dir2", dir2, 15*time.Minute)
+
+	// Build a fake service ad
+	svcAd := &server_structs.OriginAdvertiseV2{
+		ServerBaseAd: server_structs.ServerBaseAd{
+			Name:         "svc-name",
+			InstanceID:   "inst-id",
+			StartTime:    12345,
+			GenerationID: 1,
+			Version:      "v1",
+			Expiration:   time.Unix(67890, 0).UTC(),
+		},
+	}
+
+	ctx := context.Background()
+	forwardServiceAd(ctx, svcAd, server_structs.OriginType, dir1.ad)
+
+	// We should have received an ad on channel 2 but not channel 1
+	select {
+	case adInfo := <-ch1:
+		assert.Fail(t, "Received an ad on channel 1 but it should have been skipped", adInfo.serverBase)
+	default:
+	}
+
+	select {
+	case adInfo := <-ch2: // We should have received an ad on channel 2
+		assert.Equal(t, svcAd.ServerBaseAd, adInfo.serverBase)
+	default:
+		assert.Fail(t, "Failed to receive an ad on channel 2")
+	}
+}

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -467,6 +468,14 @@ func (ad ServerBaseAd) GetExpiration() time.Time {
 
 // Returns true if `ad` was generated after `other`,
 func (ad *ServerBaseAd) After(other ServerBaseAdInterface) AdAfter {
+	// An interface value is nil only if both the type and value are nil.
+	// A typed-nil value (e.g. (*DirectorAd)(nil)) is not nil, and it will
+	// cause a panic if we try to access its methods.
+	// So we use reflection to check if the underlying value is nil.
+	if other == nil || (reflect.ValueOf(other).Kind() == reflect.Ptr && reflect.ValueOf(other).IsNil()) {
+		return AdAfterUnknown
+	}
+
 	// Handle the error condition -- the ad names must match.
 	if ad.Name != other.GetName() {
 		return AdAfterUnknown

--- a/server_utils/sitename.go
+++ b/server_utils/sitename.go
@@ -131,6 +131,10 @@ func GetServiceName(ctx context.Context, server server_structs.ServerType) (name
 //
 // We define "self" to be any ad with our name and instance ID.
 func IsDirectorAdFromSelf(ctx context.Context, ad server_structs.ServerBaseAdInterface) (bool, error) {
+	if ad == nil {
+		return false, fmt.Errorf("received nil advertisement")
+	}
+
 	baseAdOnce.Do(func() {
 		var name string
 		name, baseAdErr = GetServiceName(ctx, server_structs.DirectorType)

--- a/server_utils/test_file_transfer.go
+++ b/server_utils/test_file_transfer.go
@@ -72,8 +72,9 @@ func (t TestType) String() string {
 }
 
 func (t TestFileTransferImpl) generateFileTestScitoken() (string, error) {
-	// Issuer is whichever server that initiates the test, so it's the server itself
-	issuerUrl := param.Server_ExternalWebUrl.GetString()
+	// The origin/cache server is using the federation issuer to verify the token
+	// See server_utils/monitor.go:HandleDirectorTestResponse
+	issuerUrl := param.Federation_DiscoveryUrl.GetString()
 	if t.issuerUrl != "" { // Get from param if it's not empty
 		issuerUrl = t.issuerUrl
 	}


### PR DESCRIPTION
This PR addresses issue #2369. 

The following key changes were made:
1. Implemented `nil` checks in advertisement handling, specifically within `updateInternalDirectorCache` and `IsDirectorAdFromSelf`. This resolves the `SIGSEGV` and `nil pointer dereference` panics that occurred when processing `nil` director ads, a core problem noted in the issue.

2. All service and director advertisements are now wrapped in a consistent `forwardAd` struct before being propagated to other directors. This ensures uniform processing across the federation.

3. Directors now track the originator of incoming service ads and will not forward them back to the sender. This crucial change prevents advertisement loops, which were causing instability and timeouts.

4. Fixed a bug in `updateInternalDirectorCache` where updating a director's information would inadvertently discard existing data. The cache update now correctly modifies the entry in-place, preserving data integrity and ensuring each director maintains an accurate view of its peers.