### PR TITLE
Downtime Upgrades

### DIFF
--- a/web_ui/frontend/components/Downtime/DateTile.tsx
+++ b/web_ui/frontend/components/Downtime/DateTile.tsx
@@ -1,74 +1,44 @@
 import { TileArgs } from 'react-calendar';
 import { DowntimeGet, DowntimeSeverity } from '@/types';
-import { Box, Tooltip } from '@mui/material';
+import { Box, Tooltip, alpha } from '@mui/material';
+import { red, blue, yellow } from '@mui/material/colors';
 
 interface DateTileProps extends TileArgs {
-  downtimes?: DowntimeGet[];
+  maxValue?: number;
+  binnedDowntimes?: Partial<Record<DowntimeSeverity, number>>;
 }
 
-const DateTile = ({
-  downtimes,
-  activeStartDate,
-  date,
-  view,
-}: DateTileProps) => {
-  // Pull out the downtimes that are applicable to the date
-  const applicableDowntimes = downtimes?.filter((downtime) => {
-    const start = new Date(downtime.startTime);
-    const end = new Date(downtime.endTime);
-    return date >= start && (date <= end || downtime.endTime === -1);
-  });
-
-  const severitiesBinned = binBySeverity(applicableDowntimes || []);
-
+const DateTile = ({ binnedDowntimes = {}, maxValue = 1 }: DateTileProps) => {
   return (
     <Box
       sx={{
         flexGrow: 1,
-        maxHeight: '50%',
         display: 'flex',
       }}
     >
-      {Object.entries(severitiesBinned).map(([severity, count], index) => {
+      {Object.entries(binnedDowntimes).map(([severity, count], index) => {
         return (
           <Tooltip title={severity} key={index}>
             <Box
+              className={'downtime-bar'}
               sx={{
                 backgroundColor: getSeverityColor(severity as DowntimeSeverity),
                 flexGrow: 1,
                 display: 'flex',
-                alignItems: 'center',
+                marginTop: 'auto',
+                height: `${(count / maxValue) * 100}%`,
+                alignItems: 'end',
                 justifyContent: 'center',
+                color: '#ffffff00',
               }}
             >
-              {count}
+              {count == 0 || count}
             </Box>
           </Tooltip>
         );
       })}
     </Box>
   );
-};
-
-const binBySeverity = (downtimes: DowntimeGet[]) => {
-  let binnedSeverities = {
-    'Outage (completely inaccessible)': 0,
-    'Severe (most services down)': 0,
-    'Intermittent Outage (may be up for some of the time)': 0,
-    "No Significant Outage Expected (you shouldn't notice)": 0,
-  } as Record<DowntimeSeverity, number>;
-
-  // Loop through the downtimes and bin them by severity
-  downtimes.forEach((d) => (binnedSeverities[d.severity] += 1));
-
-  // Filter out the severities that are 0
-  Object.keys(binnedSeverities).forEach((key) => {
-    if (binnedSeverities[key as DowntimeSeverity] === 0) {
-      delete binnedSeverities[key as DowntimeSeverity];
-    }
-  });
-
-  return binnedSeverities;
 };
 
 const getMaxSeverityDowntime = (downtimes: DowntimeGet[]) => {
@@ -91,13 +61,13 @@ const getMaxSeverityDowntime = (downtimes: DowntimeGet[]) => {
 const getSeverityColor = (severity: DowntimeSeverity) => {
   switch (severity) {
     case 'Outage (completely inaccessible)':
-      return 'error.light';
+      return alpha(red[300], 0.6);
     case 'Severe (most services down)':
-      return 'warning.light';
+      return alpha(yellow[300], 0.6);
     case 'Intermittent Outage (may be up for some of the time)':
-      return 'warning.light';
+      return alpha(yellow[100], 0.6);
     case "No Significant Outage Expected (you shouldn't notice)":
-      return 'info.light';
+      return alpha(blue[300], 0.6);
     default:
       return 'inherit';
   }

--- a/web_ui/frontend/components/Downtime/DowntimeCalendar.tsx
+++ b/web_ui/frontend/components/Downtime/DowntimeCalendar.tsx
@@ -5,17 +5,20 @@ import 'react-calendar/dist/Calendar.css';
 import './calendar.css';
 
 import DateTile from './DateTile';
-import { useContext } from 'react';
-import { DowntimeGet } from '@/types';
+import { useContext, useState } from 'react';
+import { DowntimeGet, DowntimeSeverity } from '@/types';
 import { CalendarDateTimeDispatchContext } from '@/components/Downtime/CalendarContext';
 
 const DowntimeCalendar = ({ data }: { data?: DowntimeGet[] }) => {
   const setRange = useContext(CalendarDateTimeDispatchContext);
 
+  const [maxValue, setMaxValue] = useState<number>(1);
+
   return (
     <Calendar
       selectRange
       returnValue={'range'}
+      calendarType={'gregory'}
       onActiveStartDateChange={(v) => {
         const startOfMonth = v.activeStartDate;
 
@@ -43,9 +46,44 @@ const DowntimeCalendar = ({ data }: { data?: DowntimeGet[] }) => {
           });
         }
       }}
-      tileContent={(args) => <DateTile downtimes={data} {...args} />}
+      tileContent={(args) => {
+        const tileDowntimes = data?.filter((downtime) => {
+          const start = new Date(downtime.startTime);
+          const end = new Date(downtime.endTime);
+          return (
+            args.date >= start && (args.date <= end || downtime.endTime === -1)
+          );
+        });
+
+        const binnedDowntimes = binBySeverity(tileDowntimes || []);
+
+        // Update maxValue
+        setMaxValue((p) => Math.max(p, ...Object.values(binnedDowntimes)));
+
+        return (
+          <DateTile
+            binnedDowntimes={binnedDowntimes}
+            maxValue={maxValue}
+            {...args}
+          />
+        );
+      }}
     />
   );
+};
+
+const binBySeverity = (downtimes: DowntimeGet[]) => {
+  let binnedSeverities = {
+    "No Significant Outage Expected (you shouldn't notice)": 0,
+    'Intermittent Outage (may be up for some of the time)': 0,
+    'Severe (most services down)': 0,
+    'Outage (completely inaccessible)': 0,
+  } as Record<DowntimeSeverity, number>;
+
+  // Loop through the downtimes and bin them by severity
+  downtimes.forEach((d) => (binnedSeverities[d.severity] += 1));
+
+  return binnedSeverities;
 };
 
 export default DowntimeCalendar;

--- a/web_ui/frontend/components/Downtime/DowntimeEditContext.tsx
+++ b/web_ui/frontend/components/Downtime/DowntimeEditContext.tsx
@@ -16,7 +16,7 @@ import { DowntimeGet, DowntimePost } from '@/types';
 
 type DowntimeFormProps =
   | DowntimeGet
-  | Omit<DowntimePost, 'severity' | 'class' | 'description'>;
+  | Partial<DowntimePost>;
 
 export const DowntimeEditContext = createContext<DowntimeFormProps | undefined>(
   undefined

--- a/web_ui/frontend/components/Downtime/DowntimeEditContext.tsx
+++ b/web_ui/frontend/components/Downtime/DowntimeEditContext.tsx
@@ -14,9 +14,7 @@ import {
 } from 'react';
 import { DowntimeGet, DowntimePost } from '@/types';
 
-type DowntimeFormProps =
-  | DowntimeGet
-  | Partial<DowntimePost>;
+type DowntimeFormProps = DowntimeGet | Partial<DowntimePost>;
 
 export const DowntimeEditContext = createContext<DowntimeFormProps | undefined>(
   undefined

--- a/web_ui/frontend/components/Downtime/EditDowntimePageHeader.tsx
+++ b/web_ui/frontend/components/Downtime/EditDowntimePageHeader.tsx
@@ -5,7 +5,6 @@ import { CalendarDateTimeContext } from '@/components/Downtime/CalendarContext';
 
 const EditDowntimePageHeader = () => {
   const setDowntime = useContext(DowntimeEditDispatchContext);
-  const range = useContext(CalendarDateTimeContext);
 
   return (
     <Box
@@ -18,10 +17,7 @@ const EditDowntimePageHeader = () => {
         variant={'contained'}
         color={'primary'}
         onClick={() => {
-          setDowntime({
-            startTime: range.startTime,
-            endTime: range.endTime,
-          });
+          setDowntime({});
         }}
       >
         Create Downtime

--- a/web_ui/frontend/components/Downtime/Registry/ServerUnknownDowntimeForm.tsx
+++ b/web_ui/frontend/components/Downtime/Registry/ServerUnknownDowntimeForm.tsx
@@ -73,7 +73,7 @@ const ServerUnknownDowntimeForm = ({
   // Get the cache and origin prefixes to key the downtimes for the director
   const { data: namespaces } = useApiSWR<RegistryNamespace[]>(
     'Could not fetch Origins and Caches to populate downtime form',
-    'getNamespaces',
+    'getNamespaces-TODO-update-this-key-to-share-cache',
     getNamespaces
   );
   const servers = useMemo(() => {

--- a/web_ui/frontend/components/Downtime/Registry/ServerUnknownDowntimeForm.tsx
+++ b/web_ui/frontend/components/Downtime/Registry/ServerUnknownDowntimeForm.tsx
@@ -42,10 +42,10 @@ import { Delete } from '@mui/icons-material';
 import FormHelperText from '@mui/material/FormHelperText';
 import { RegistryNamespace } from '@/index';
 import useApiSWR from '@/hooks/useApiSWR';
-import {getExtendedNamespaces} from "@/helpers/get";
-import extendNamespace from "@/helpers/Registry/namespaceToServer";
+import { getExtendedNamespaces } from '@/helpers/get';
+import extendNamespace from '@/helpers/Registry/namespaceToServer';
 import { NamespaceIcon } from '@/components';
-import getUtcOffsetString from "@/helpers/getUtcOffsetString";
+import getUtcOffsetString from '@/helpers/getUtcOffsetString';
 
 interface DowntimeFormProps {
   downtime: Partial<DowntimeGet>;
@@ -77,11 +77,16 @@ const ServerUnknownDowntimeForm = ({
     getNamespaces
   );
   const servers = useMemo(() => {
-    return (namespaces || []).map(extendNamespace)
-        .filter(x => (x.type === 'origin' || x.type === 'cache') &&
+    return (namespaces || [])
+      .map(extendNamespace)
+      .filter(
+        (x) =>
+          (x.type === 'origin' || x.type === 'cache') &&
           x.admin_metadata.status === 'Approved'
-        )
-        .sort((a,b) => (a?.adjustedPrefix || '') > (b?.adjustedPrefix || '') ? 1 : -1);
+      )
+      .sort((a, b) =>
+        (a?.adjustedPrefix || '') > (b?.adjustedPrefix || '') ? 1 : -1
+      );
   }, [namespaces]);
 
   // Set a default prefix on registry
@@ -96,32 +101,35 @@ const ServerUnknownDowntimeForm = ({
       <Box mt={2}>
         <Autocomplete
           options={servers}
-          getOptionLabel={(servers) => servers?.adjustedPrefix || "Error"}
+          getOptionLabel={(servers) => servers?.adjustedPrefix || 'Error'}
           isOptionEqualToValue={(servers, value) =>
-            servers?.adjustedPrefix === value?.adjustedPrefix}
-          value={servers.filter(x => x.prefix == downtime.serverName)[0] || servers[0]}
+            servers?.adjustedPrefix === value?.adjustedPrefix
+          }
+          value={
+            servers.filter((x) => x.prefix == downtime.serverName)[0] ||
+            servers[0]
+          }
           onChange={(e, v) => {
             if (!v) return;
             setDowntime({ ...downtime, serverName: v.prefix });
           }}
           renderInput={(params) => (
-            <TextField
-              {...params}
-              label='Server'
-              variant='outlined'
-              required
-            />
+            <TextField {...params} label='Server' variant='outlined' required />
           )}
           renderOption={(params, option) => (
             <Box component='li' {...params}>
-              <Box sx={{ display: 'flex', justifyContent: 'space-between', width: "100%" }}>
-                <Box display={"flex"}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  width: '100%',
+                }}
+              >
+                <Box display={'flex'}>
                   {option.adjustedPrefix || option.prefix}
                 </Box>
-                <Box display={"flex"}>
-                  <NamespaceIcon
-                      serverType={option.type}
-                  />
+                <Box display={'flex'}>
+                  <NamespaceIcon serverType={option.type} />
                 </Box>
               </Box>
             </Box>
@@ -301,8 +309,6 @@ const submitDowntime = async (
 const namespacesToRegistryServers = (
   namespaces: RegistryNamespace[]
 ): string[] => {
-
-
   const originsAndCaches = namespaces.filter(
     (n) => n.prefix.startsWith('/origin') || n.prefix.startsWith('/cache')
   );

--- a/web_ui/frontend/components/Downtime/Server/DowntimeForm.tsx
+++ b/web_ui/frontend/components/Downtime/Server/DowntimeForm.tsx
@@ -35,11 +35,12 @@ import {
 } from '@/components/AlertProvider';
 import { Delete } from '@mui/icons-material';
 import FormHelperText from '@mui/material/FormHelperText';
+import getUtcOffsetString from "@/helpers/getUtcOffsetString";
 
 interface DowntimeFormProps {
   downtime:
     | DowntimeGet
-    | Omit<DowntimePost, 'severity' | 'class' | 'description'>
+    | Partial<DowntimePost>
     | Omit<DowntimeRegistryPost, 'severity' | 'class' | 'description'>;
   onSuccess?: (downtime: DowntimePost) => void;
 }
@@ -53,16 +54,11 @@ const DowntimeForm = ({
   const id = 'id' in inputDowntime ? inputDowntime.id : undefined;
 
   const [downtime, setDowntime] = useState<DowntimePost>({
-    startTime: inputDowntime.startTime,
-    endTime: inputDowntime.endTime,
-    description:
-      'description' in inputDowntime ? inputDowntime.description : '',
-    severity:
-      'severity' in inputDowntime
-        ? inputDowntime.severity
-        : defaultDowntime.severity,
-    class:
-      'class' in inputDowntime ? inputDowntime.class : defaultDowntime.class,
+    startTime: inputDowntime?.startTime || Date.now(),
+    endTime: inputDowntime?.endTime || Date.now(),
+    description: '',
+    severity: defaultDowntime.severity,
+    class: defaultDowntime.class,
   });
 
   const endless = useMemo(() => downtime.endTime === -1, [downtime.endTime]);
@@ -71,7 +67,7 @@ const DowntimeForm = ({
     <Box>
       <Box mt={2}>
         <DateTimePicker
-          label={'Start Time'}
+          label={`Start Time (${getUtcOffsetString()})`}
           value={DateTime.fromMillis(downtime.startTime)}
           onChange={(v) =>
             setDowntime({ ...downtime, startTime: v?.toMillis() || 0 })
@@ -80,7 +76,7 @@ const DowntimeForm = ({
       </Box>
       <Box mt={2}>
         <DateTimePicker
-          label={'End Time'}
+          label={`End Time (${getUtcOffsetString()})`}
           disabled={endless}
           value={DateTime.fromMillis(downtime.endTime)}
           onChange={(v) =>
@@ -136,7 +132,7 @@ const DowntimeForm = ({
           <Select
             variant={'outlined'}
             labelId={'class'}
-            label={'class'}
+            label={'Scheduled'}
             value={downtime?.class}
             onChange={(e) =>
               setDowntime({

--- a/web_ui/frontend/components/Downtime/Server/DowntimeForm.tsx
+++ b/web_ui/frontend/components/Downtime/Server/DowntimeForm.tsx
@@ -35,7 +35,7 @@ import {
 } from '@/components/AlertProvider';
 import { Delete } from '@mui/icons-material';
 import FormHelperText from '@mui/material/FormHelperText';
-import getUtcOffsetString from "@/helpers/getUtcOffsetString";
+import getUtcOffsetString from '@/helpers/getUtcOffsetString';
 
 interface DowntimeFormProps {
   downtime:

--- a/web_ui/frontend/components/Downtime/calendar.css
+++ b/web_ui/frontend/components/Downtime/calendar.css
@@ -1,8 +1,8 @@
 .react-calendar__tile {
   padding: 0;
-  aspect-ratio: 4;
+  aspect-ratio: 2;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
 }
 
 /**
@@ -21,9 +21,9 @@
 }
 
 .react-calendar button {
-  border: 1px solid #ffffff;
+  border: 3px solid #ffffff;
   background-color: #cce2ff;
-  border-radius: 5px;
+  border-radius: 8px;
 }
 
 .react-calendar__tile--active {
@@ -34,10 +34,15 @@
 .react-calendar__tile > abbr {
   font-size: 1rem;
   line-height: 1.5rem;
-  height: 50%;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  align-items: top;
+  justify-content: start;
+  margin: 5px;
+  width: 50%;
+}
+
+.react-calendar__tile:hover .downtime-bar {
+  color: black;
 }
 
 .react-calendar {
@@ -49,4 +54,8 @@
 .react-calendar__decade-view__years__year--neighboringDecade,
 .react-calendar__century-view__decades__decade--neighboringCentury {
   background-color: #f3f3f3 !important;
+}
+
+.react-calendar__month-view__days__day--weekend {
+  color: black;
 }

--- a/web_ui/frontend/helpers/Registry/namespaceToServer.ts
+++ b/web_ui/frontend/helpers/Registry/namespaceToServer.ts
@@ -1,0 +1,28 @@
+import {RegistryNamespace} from "@/index";
+
+/**
+ * Extends a registry namespace
+ * @param namespace
+ */
+const extendNamespace = (namespace: Omit<RegistryNamespace, 'type' | 'adjustedPrefix'>) : RegistryNamespace => {
+
+	let type: RegistryNamespace['type'] = 'namespace';
+	let adjustedPrefix = undefined;
+
+	// Prefixes that start with /caches/ or /origins/ are considered cache or origin namespaces
+	if (namespace.prefix.startsWith('/caches/')) {
+		type = 'cache';
+		adjustedPrefix = namespace.prefix.replace('/caches/', '');
+	} else if (namespace.prefix.startsWith('/origins/')) {
+		type = 'origin';
+		adjustedPrefix = namespace.prefix.replace('/origins/', '');
+	}
+
+	return {
+		...namespace,
+		type,
+		adjustedPrefix
+	}
+}
+
+export default extendNamespace;

--- a/web_ui/frontend/helpers/Registry/namespaceToServer.ts
+++ b/web_ui/frontend/helpers/Registry/namespaceToServer.ts
@@ -1,28 +1,29 @@
-import {RegistryNamespace} from "@/index";
+import { RegistryNamespace } from '@/index';
 
 /**
  * Extends a registry namespace
  * @param namespace
  */
-const extendNamespace = (namespace: Omit<RegistryNamespace, 'type' | 'adjustedPrefix'>) : RegistryNamespace => {
+const extendNamespace = (
+  namespace: Omit<RegistryNamespace, 'type' | 'adjustedPrefix'>
+): RegistryNamespace => {
+  let type: RegistryNamespace['type'] = 'namespace';
+  let adjustedPrefix = undefined;
 
-	let type: RegistryNamespace['type'] = 'namespace';
-	let adjustedPrefix = undefined;
+  // Prefixes that start with /caches/ or /origins/ are considered cache or origin namespaces
+  if (namespace.prefix.startsWith('/caches/')) {
+    type = 'cache';
+    adjustedPrefix = namespace.prefix.replace('/caches/', '');
+  } else if (namespace.prefix.startsWith('/origins/')) {
+    type = 'origin';
+    adjustedPrefix = namespace.prefix.replace('/origins/', '');
+  }
 
-	// Prefixes that start with /caches/ or /origins/ are considered cache or origin namespaces
-	if (namespace.prefix.startsWith('/caches/')) {
-		type = 'cache';
-		adjustedPrefix = namespace.prefix.replace('/caches/', '');
-	} else if (namespace.prefix.startsWith('/origins/')) {
-		type = 'origin';
-		adjustedPrefix = namespace.prefix.replace('/origins/', '');
-	}
-
-	return {
-		...namespace,
-		type,
-		adjustedPrefix
-	}
-}
+  return {
+    ...namespace,
+    type,
+    adjustedPrefix,
+  };
+};
 
 export default extendNamespace;

--- a/web_ui/frontend/helpers/getDaysInMonth.ts
+++ b/web_ui/frontend/helpers/getDaysInMonth.ts
@@ -3,15 +3,15 @@
  * @param compDate - The date from which to derive the month
  */
 function getDaysInMonth(compDate: Date): Date[] {
-	const days: Date[] = [];
-	// month is 0-indexed (0 = January, 11 = December)
-	const month = compDate.getMonth();
-	const date = new Date(compDate.getFullYear(), compDate.getMonth(), 1);
-	while (date.getMonth() === month) {
-		days.push(new Date(date));
-		date.setDate(date.getDate() + 1);
-	}
-	return days;
+  const days: Date[] = [];
+  // month is 0-indexed (0 = January, 11 = December)
+  const month = compDate.getMonth();
+  const date = new Date(compDate.getFullYear(), compDate.getMonth(), 1);
+  while (date.getMonth() === month) {
+    days.push(new Date(date));
+    date.setDate(date.getDate() + 1);
+  }
+  return days;
 }
 
 export default getDaysInMonth;

--- a/web_ui/frontend/helpers/getDaysInMonth.ts
+++ b/web_ui/frontend/helpers/getDaysInMonth.ts
@@ -1,0 +1,17 @@
+/**
+ * Returns an array of Date objects representing all the days in the month of the given date.
+ * @param compDate - The date from which to derive the month
+ */
+function getDaysInMonth(compDate: Date): Date[] {
+	const days: Date[] = [];
+	// month is 0-indexed (0 = January, 11 = December)
+	const month = compDate.getMonth();
+	const date = new Date(compDate.getFullYear(), compDate.getMonth(), 1);
+	while (date.getMonth() === month) {
+		days.push(new Date(date));
+		date.setDate(date.getDate() + 1);
+	}
+	return days;
+}
+
+export default getDaysInMonth;

--- a/web_ui/frontend/helpers/getUtcOffsetString.ts
+++ b/web_ui/frontend/helpers/getUtcOffsetString.ts
@@ -1,0 +1,10 @@
+import {DateTime} from "luxon";
+
+/**
+ * Returns a string like `UTC-5` based on the current local time zone offset
+ */
+const getUtcOffsetString = (): string => {
+	return `UTC${DateTime.local().offset >= 0 ? '+' : ''}${DateTime.local().offset / 60}`
+}
+
+export default getUtcOffsetString;

--- a/web_ui/frontend/helpers/getUtcOffsetString.ts
+++ b/web_ui/frontend/helpers/getUtcOffsetString.ts
@@ -1,10 +1,10 @@
-import {DateTime} from "luxon";
+import { DateTime } from 'luxon';
 
 /**
  * Returns a string like `UTC-5` based on the current local time zone offset
  */
 const getUtcOffsetString = (): string => {
-	return `UTC${DateTime.local().offset >= 0 ? '+' : ''}${DateTime.local().offset / 60}`
-}
+  return `UTC${DateTime.local().offset >= 0 ? '+' : ''}${DateTime.local().offset / 60}`;
+};
 
 export default getUtcOffsetString;

--- a/web_ui/frontend/index.ts
+++ b/web_ui/frontend/index.ts
@@ -37,6 +37,7 @@ export interface Alert {
 export interface RegistryNamespace {
   id: number;
   prefix: string;
+  adjustedPrefix?: string; // This value is the same when type is 'namespace' otherwise it removes the type value
   pubkey: string;
   type: 'origin' | 'cache' | 'namespace';
   admin_metadata: NamespaceAdminMetadata;

--- a/web_ui/frontend/package-lock.json
+++ b/web_ui/frontend/package-lock.json
@@ -13,7 +13,7 @@
         "@emotion/styled": "^11.11.0",
         "@mui/base": "^5.0.0-beta.69",
         "@mui/icons-material": "^5.14.3",
-        "@mui/material": "^5.14.5",
+        "@mui/material": "^5.17.1",
         "@mui/x-date-pickers": "^7.0.0",
         "@mui/x-tree-view": "^7.6.1",
         "@next/bundle-analyzer": "^14.2.3",

--- a/web_ui/frontend/package.json
+++ b/web_ui/frontend/package.json
@@ -22,7 +22,7 @@
     "@emotion/styled": "^11.11.0",
     "@mui/base": "^5.0.0-beta.69",
     "@mui/icons-material": "^5.14.3",
-    "@mui/material": "^5.14.5",
+    "@mui/material": "^5.17.1",
     "@mui/x-date-pickers": "^7.0.0",
     "@mui/x-tree-view": "^7.6.1",
     "@next/bundle-analyzer": "^14.2.3",


### PR DESCRIPTION
- Sort, add icons, clean prefix in server options on registry
- Add note about current timezone on time entry
- Always have start and end time autopopulate to current time
- Filter out not approved servers
- Update styles to prevent number overload and add more meaning to Tiles

Closes #2373
Closes #2254
Closes https://github.com/PelicanPlatform/pelican/issues/2398