### PR TITLE
Enable S3 tracing option via Logging.Origin.Oss configuration

### DIFF
--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -80,6 +80,7 @@ s3.access_key_file {{.S3AccessKeyfile}}
 {{if .S3SecretKeyfile}}
 s3.secret_key_file {{.S3SecretKeyfile}}
 {{- end}}
+s3.trace {{$.Logging.OriginOss}}
 s3.end
 {{end}}
 {{else if eq .Origin.StorageType "https"}}

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -1182,8 +1182,12 @@ func mapXrootdLogLevels(xrdConfig *XrootdConfig) error {
 
 	// Origin Oss
 	if xrdConfig.Logging.OriginOss, err = genLoggingConfig(param.Logging_Origin_Oss.GetString(), loggingMap{
-		Trace: "all",
-		Info:  "-all",
+		Trace: "dump debug info warning error",
+		Debug: "debug info warning error",
+		Info:  "info warning error",
+		Warn:  "warning error",
+		Error: "error",
+		Fatal: "-all",
 	}); err != nil {
 		return errors.Wrapf(err, "failed to map logging level for Logging.Origin.Oss")
 	}


### PR DESCRIPTION
This PR addresses #2359. This PR enables the `s3.trace` configuration when the S3 backend is enabled. This doesn't introduce any new Pelican configuration parameters and the verbosity of the logging is handled through the `Logging.Origin.Oss`. 