### PR TITLE
Support multiple keys in string encrypt/decrypt functions

### DIFF
--- a/config/encrypted_test.go
+++ b/config/encrypted_test.go
@@ -20,18 +20,17 @@ package config
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"os"
-
 	"github.com/pelicanplatform/pelican/param"
-	log "github.com/sirupsen/logrus"
 )
 
 func TestGetSecret(t *testing.T) {
@@ -81,15 +80,15 @@ func TestEncryptString(t *testing.T) {
 func TestDecryptString(t *testing.T) {
 	ResetConfig()
 
+	tmp := t.TempDir()
+	keyDir := filepath.Join(tmp, "issuer-keys")
+	viper.Set(param.IssuerKeysDirectory.GetName(), keyDir)
+
 	t.Cleanup(func() {
 		ResetConfig()
 	})
 
 	t.Run("decrypt-without-err", func(t *testing.T) {
-		tmp := t.TempDir()
-		keyDir := filepath.Join(tmp, "issuer-keys")
-		viper.Set(param.IssuerKeysDirectory.GetName(), keyDir)
-
 		secret := "Some secret to encrypt"
 		encrypted, err := EncryptString(secret)
 		require.NoError(t, err)
@@ -101,10 +100,6 @@ func TestDecryptString(t *testing.T) {
 	})
 
 	t.Run("decrypt-with-another-valid-key", func(t *testing.T) {
-		tmp := t.TempDir()
-		keyDir := filepath.Join(tmp, "issuer-keys")
-		viper.Set(param.IssuerKeysDirectory.GetName(), keyDir)
-
 		secret := "Some secret to encrypt"
 		encrypted, err := EncryptString(secret)
 		require.NoError(t, err)
@@ -132,10 +127,6 @@ func TestDecryptString(t *testing.T) {
 	})
 
 	t.Run("decrypt-with-invalid-nonce", func(t *testing.T) {
-		tmp := t.TempDir()
-		keyDir := filepath.Join(tmp, "issuer-keys")
-		viper.Set(param.IssuerKeysDirectory.GetName(), keyDir)
-
 		secret := "Some secret to encrypt"
 		encrypted, err := EncryptString(secret)
 		require.NoError(t, err)
@@ -151,10 +142,6 @@ func TestDecryptString(t *testing.T) {
 	})
 
 	t.Run("decrypt-with-multiple-keys", func(t *testing.T) {
-		tmp := t.TempDir()
-		keyDir := filepath.Join(tmp, "issuer-keys")
-		viper.Set(param.IssuerKeysDirectory.GetName(), keyDir)
-
 		// Encrypt with the first key
 		secret := "Some secret to encrypt"
 		encrypted, err := EncryptString(secret)

--- a/config/encrypted_test.go
+++ b/config/encrypted_test.go
@@ -19,13 +19,11 @@
 package config
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -99,7 +97,7 @@ func TestDecryptString(t *testing.T) {
 		assert.Equal(t, secret, decrypted)
 	})
 
-	t.Run("decrypt-with-another-valid-key", func(t *testing.T) {
+	t.Run("decrypt-with-another-invalid-key", func(t *testing.T) {
 		secret := "Some secret to encrypt"
 		encrypted, err := EncryptString(secret)
 		require.NoError(t, err)
@@ -109,15 +107,9 @@ func TestDecryptString(t *testing.T) {
 		parts[0] = "another-valid-key-id"
 		encrypted = strings.Join(parts, ".")
 
-		// Capture log output
-		var logOutput bytes.Buffer
-		log.SetOutput(&logOutput)
-		defer log.SetOutput(os.Stderr)
-
-		decrypted, _, err := DecryptString(encrypted)
-		require.NoError(t, err)
-		assert.Equal(t, secret, decrypted)
-		assert.Contains(t, logOutput.String(), "The key used in encryption (id: another-valid-key-id) is not the current issuer key")
+		_, _, err = DecryptString(encrypted)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "the key used for encryption (with ID another-valid-key-id) is not found")
 	})
 
 	t.Run("decrypt-with-invalid-format", func(t *testing.T) {

--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -980,7 +980,11 @@ func GenerateSessionSecret() error {
 		}
 	}
 
-	secret, err := GetSecret()
+	currentIssuerKey, err := GetIssuerPrivateJWK()
+	if err != nil {
+		return errors.Wrap(err, "failed to get the current issuer key")
+	}
+	secret, err := GetSecret(currentIssuerKey)
 	if err != nil {
 		return errors.Wrap(err, "failed to get the secret")
 	}


### PR DESCRIPTION
- Update string encrypt/decrypt functions with NaCl's box pkg
- Record the id of the key used for encryption in the output string
- Iterate all valid issuer key to decrypt

  - Enable support for key rotation and decryption of data encrypted with previous keys.
  - To achieve this goal, GetSecret and key pair derivation functions now accept a specific issuer key as input

- No backward compatibility issue because the `EncryptString` and `DecryptString` are used for globus collection only, which is never in the prod. cc @whwjiang: This PR may have impact on your globus development.
- Replace the standard errors package with github.com/pkg/errors