### PR TITLE
Validate configured hostnames against TLS certificate chain

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1682,6 +1682,52 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 		return err
 	}
 
+	// The certificate was either generated or has been provided by now. Verify that any configured
+	// hostnames are valid w.r.t the given certificate.
+	//
+	// We'll always check both Server.Hostname, Server.ExternalWebUrl because we don't enforce that
+	// these point to the same hostname (maybe we should?), and we'll conditionally check
+	// Origin.Url/Cache.Url, depending on whether the origin/cache servers are enabled.
+	// See https://github.com/PelicanPlatform/pelican/issues/1802 for a description of why we check
+	// these particular hostnames.
+	serverHostname := param.Server_Hostname.GetString()
+	if err := ValidateHostCertificateHostname(serverHostname); err != nil {
+		return errors.Wrapf(err, "unable to validate server hostname '%s' configured via %s against the TLS certificate"+
+			" configured via %s",
+			serverHostname, param.Server_Hostname.GetName(), param.Server_TLSCertificateChain.GetName())
+	}
+
+	// Helper func to deal with params that may include ports, which must be parsed so
+	// we can grab the hostname
+	validateUrlHostname := func(urlParam param.StringParam) error {
+		urlStr := urlParam.GetString()
+		parsed, err := url.Parse(urlStr)
+		if err != nil {
+			return errors.Wrapf(err, "unable to parse %s as a URL", urlParam.GetName())
+		}
+
+		if err := ValidateHostCertificateHostname(parsed.Hostname()); err != nil {
+			return errors.Wrapf(err, "unable to validate hostname '%s' configured via %s against the TLS certificate"+
+				" configured via %s",
+				parsed.Hostname(), urlParam.GetName(), param.Server_TLSCertificateChain.GetName())
+		}
+		return nil
+	}
+
+	if err = validateUrlHostname(param.Server_ExternalWebUrl); err != nil {
+		return err
+	}
+	if currentServers.IsEnabled(server_structs.CacheType) {
+		if err = validateUrlHostname(param.Cache_Url); err != nil {
+			return err
+		}
+	}
+	if currentServers.IsEnabled(server_structs.OriginType) {
+		if err = validateUrlHostname(param.Origin_Url); err != nil {
+			return err
+		}
+	}
+
 	// Generate the session secret and save it as the default value
 	if err := GenerateSessionSecret(); err != nil {
 		return err


### PR DESCRIPTION
This is a quality-of-life improvement that tries to help admins starting a new Pelican server catch when their provided TLS cert files do not match the configured hostnames of the new server.

Overall the validation works by checking different places a Pelican admin may configure a hostname and then comparing that hostname against the SANs and CN of the provided certificate.