### PR TITLE
Add checksum support to `pelican object put`

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -3221,7 +3221,7 @@ Loop:
 		// If they match, we're good. If they don't, we need to return an error.
 
 		// Fetch the checksums from the server
-		result, err := fetchChecksum(putContext, transfer.job.requestedChecksums, dest, tokenContents, transfer.job.project)
+		result, err := fetchChecksum(putContext, transfer.requestedChecksums, dest, tokenContents, transfer.job.project)
 		if err != nil {
 			log.Errorln("Error fetching checksum:", err)
 			transferResult.Error = err

--- a/client/main.go
+++ b/client/main.go
@@ -524,7 +524,7 @@ func DoPut(ctx context.Context, localObject string, remoteDestination string, re
 	if err != nil {
 		return
 	}
-	tj, err := client.NewTransferJob(context.Background(), pUrl.GetRawUrl(), localObject, true, recursive)
+	tj, err := client.NewTransferJob(context.Background(), pUrl.GetRawUrl(), localObject, true, recursive, options...)
 	if err != nil {
 		return
 	}

--- a/cmd/object_put.go
+++ b/cmd/object_put.go
@@ -43,7 +43,7 @@ func init() {
 	flagSet := putCmd.Flags()
 	flagSet.StringP("token", "t", "", "Token file to use for transfer")
 	flagSet.BoolP("recursive", "r", false, "Recursively upload a collection.  Forces methods to only be http to get the freshest collection contents")
-	flagSet.String("checksum", "crc32c", "Checksum algorithm to use for upload and validation")
+	flagSet.String("checksum", "", "Checksum algorithm to use for upload and validation")
 	objectCmd.AddCommand(putCmd)
 }
 

--- a/cmd/object_put.go
+++ b/cmd/object_put.go
@@ -43,7 +43,7 @@ func init() {
 	flagSet := putCmd.Flags()
 	flagSet.StringP("token", "t", "", "Token file to use for transfer")
 	flagSet.BoolP("recursive", "r", false, "Recursively upload a collection.  Forces methods to only be http to get the freshest collection contents")
-	flagSet.String("checksum", "", "Checksum algorithm to use for upload and validation")
+	flagSet.String("checksum", "crc32c", "Checksum algorithm to use for upload and validation")
 	objectCmd.AddCommand(putCmd)
 }
 


### PR DESCRIPTION
This PR addresses issue #2231. This PR introduces the `--checksum` flag to the `pelican object put` command. This PR efficiently calculates the checksum on the fly as the object is being uploaded. Once the object is uploaded we will fetch the checksum from the Origin and then compare the locally calculated checksum and the server provided checksum. By default we use the crc32c algorithm to calculate the checksum.