### PR TITLE
Increase maximum checksum jobs to 10

### DIFF
--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -124,7 +124,7 @@ ofs.ckslib * libXrdMultiuser.so
 http.exthandler xrdpelican libXrdHttpPelican.so
 {{- end}}
 xrootd.fslib ++ throttle  # throttle plugin is needed to calculate server IO load
-xrootd.chksum max 2 md5 adler32 crc32 crc32c
+xrootd.chksum max 10 md5 adler32 crc32 crc32c
 xrootd.trace {{.Logging.OriginXrootd}}
 ofs.trace {{.Logging.OriginOfs}}
 oss.trace {{.Logging.OriginOss}}


### PR DESCRIPTION
The previous value of `2` is lower than what is used for the concurrency of the memory stress test, resulting in occasional test failures.

Additionally, 10 concurrent jobs are probably more reasonable for an origin.

I don't currently see a need to make this exposed to the origin administrator (but I'm willing to revisit if needed).