### PR TITLE
Upgrade to xrdcl-pelican v1.3.1

### DIFF
--- a/github_scripts/osx_install.sh
+++ b/github_scripts/osx_install.sh
@@ -54,14 +54,14 @@ ninja
 ninja install
 popd
 
-git clone --branch v1.2.3 https://github.com/PelicanPlatform/xrdcl-pelican.git
+git clone --branch v1.4.0 https://github.com/PelicanPlatform/xrdcl-pelican.git
 pushd xrdcl-pelican
 mkdir build
 cd build
 cmake .. -GNinja -DCMAKE_INSTALL_PREFIX="$PWD/release_dir"
 ninja install
 sudo mkdir -p /etc/xrootd/client.plugins.d/
-sudo cp release_dir/etc/xrootd/client.plugins.d/pelican-plugin.conf /etc/xrootd/client.plugins.d/
+sudo cp release_dir/etc/xrootd/client.plugins.d/{curl,pelican}-plugin.conf /etc/xrootd/client.plugins.d/
 popd
 
 git clone --recurse-submodules --branch v0.2.1 https://github.com/PelicanPlatform/xrootd-s3-http.git

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -53,8 +53,11 @@ ARG NODEJS_VER=20
 #
 ARG LOTMAN_SRC_BUILD=false
 ARG LOTMAN_VER=0.0.4
-ARG XRDCL_PELICAN_SRC_BUILD=false
-ARG XRDCL_PELICAN_VER=1.2.3
+# Note: github_scripts/osx_install.sh also (separately) specifies the version to use
+# Until the two places are programmatically synchronized, please double-check by hand
+# when doing version changes.
+ARG XRDCL_PELICAN_SRC_BUILD=true
+ARG XRDCL_PELICAN_VER=1.4.0
 ARG XRDHTTP_PELICAN_SRC_BUILD=false
 ARG XRDHTTP_PELICAN_VER=0.0.7
 ARG XROOTD_LOTMAN_SRC_BUILD=false

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -74,9 +74,21 @@ lib = libXrdClPelican.so
 enable = true
 `
 
+	clientHttpPluginDefault = `
+url = http://*;https://*
+lib = libXrdClCurl.so
+enable = true
+`
+
 	clientPluginMac = `
 url = pelican://*
 lib = libXrdClPelican.dylib
+enable = true
+`
+
+	clientHttpPluginMac = `
+url = http://*;https://*
+lib = libXrdClCurl.dylib
 enable = true
 `
 )
@@ -459,8 +471,14 @@ func CheckXrootdEnv(server server_structs.XRootDServer) error {
 		}
 		if runtime.GOOS == "darwin" {
 			err = os.WriteFile(filepath.Join(clientPluginsDir, "pelican-plugin.conf"), []byte(clientPluginMac), os.FileMode(0644))
+			if err == nil {
+				err = os.WriteFile(filepath.Join(clientPluginsDir, "http-plugin.conf"), []byte(clientHttpPluginMac), os.FileMode(0644))
+			}
 		} else {
 			err = os.WriteFile(filepath.Join(clientPluginsDir, "pelican-plugin.conf"), []byte(clientPluginDefault), os.FileMode(0644))
+			if err == nil {
+				err = os.WriteFile(filepath.Join(clientPluginsDir, "http-plugin.conf"), []byte(clientHttpPluginDefault), os.FileMode(0644))
+			}
 		}
 		if err != nil {
 			return errors.Wrap(err, "Unable to configure cache client plugin")


### PR DESCRIPTION
xrdcl-pelican splits pelican:// and https:// into two different plugins (the former relies on the latter); this includes corresponding changes to the plugin configuration generation.