### PR TITLE
Fix link depth header for listings

### DIFF
--- a/director/director.go
+++ b/director/director.go
@@ -204,10 +204,11 @@ func getLinkDepth(filepath, prefix string) (int, error) {
 	// To make the final calculation easier, we also remove the head slash from the file path.
 	// e.g. filepath = /foo/bar/barz.txt   prefix = /foo
 	// we want commonPath = bar/barz.txt
-	if !strings.HasSuffix(prefix, "/") && prefix != "/" {
-		prefix += "/"
-	}
 	commonPath := strings.TrimPrefix(filepath, prefix)
+	commonPath = strings.TrimPrefix(commonPath, "/")
+	if len(commonPath) == 0 {
+		return 0, nil
+	}
 	pathDepth := len(strings.Split(commonPath, "/"))
 	return pathDepth, nil
 }

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -121,6 +121,12 @@ func TestGetLinkDepth(t *testing.T) {
 			prefix:   "/foo",
 			depth:    1,
 		},
+		{
+			name:     "exact-match",
+			filepath: "/foo/bar",
+			prefix:   "/foo/bar",
+			depth:    0,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes an error where the link header depth when querying the directory for collections was incorrect at the top level of a namespace because the prefix would have an "/" appended to it which would cause the prefix matching to fail.

Simple solution, remove the potential extra "/" after doing the matching.

Also ensures that a full match has a link depth of 0.