### PR TITLE
Modify `WaitUntilWorking` init probe to provide more useful error messages

### DIFF
--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -198,7 +198,8 @@ func LaunchModules(ctx context.Context, modules server_structs.ServerType) (serv
 
 	healthCheckUrl := param.Server_ExternalWebUrl.GetString() + "/api/v1.0/health"
 	if err = server_utils.WaitUntilWorking(ctx, "GET", healthCheckUrl, "Web UI", http.StatusOK, true); err != nil {
-		log.Errorln("Web engine check failed: ", err)
+		log.Errorf("The server was unable to unable to ping its health test endpoint at the configured %s during startup: %v",
+			param.Server_ExternalWebUrl.GetName(), err)
 		return
 	}
 

--- a/server_utils/server_utils.go
+++ b/server_utils/server_utils.go
@@ -143,9 +143,9 @@ func WaitUntilWorking(ctx context.Context, method, reqUrl, server string, expect
 		}
 		resp, err := client.Do(req)
 		if err != nil {
-			// Only record lastConnErr if it's not a context error. Otherwise we  risk overwriting
-			// something useful like "no route to host" with a generic "context canceled".
-			if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+			// Only record lastConnErr if it's not a context error or we haven't yet recorded any errors.
+			// Otherwise we risk overwriting something useful like "no route to host" with a generic "context canceled".
+			if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) || lastConnErr == nil {
 				lastConnErr = err
 			}
 			if !loggedConn {
@@ -206,7 +206,7 @@ func WaitUntilWorking(ctx context.Context, method, reqUrl, server string, expect
 			if lastConnErr != nil {
 				return errors.Wrapf(lastConnErr, msg)
 			}
-			return ctx.Err() // context was canceled or deadline exceeded
+			return errors.Wrap(ctx.Err(), msg) // context was canceled or deadline exceeded
 		}
 	}
 }


### PR DESCRIPTION
This vein of work was to improve the error messages around this `WaitUntilWorking` startup probe. The problem was that the probe fires every ~50ms until some timeout is reached, but we didn't do anything to keep track of any intermittent errors that occurred up until the very last failure. Instead, these intermediary errors were tucked into log messages that were hard to identify as coming from the function.

With these changes, we keep track of the most recent error that may be generated by each firing of the probe so we can present that error if the overall function fails.