### PR TITLE
Mark additional errors as retry-able

### DIFF
--- a/client/errorAccum.go
+++ b/client/errorAccum.go
@@ -153,6 +153,9 @@ func IsRetryable(err error) bool {
 	if errors.Is(err, &allocateMemoryError{}) {
 		return true
 	}
+	if errors.Is(err, &InvalidByteInChunkLengthError{}) {
+		return true
+	}
 	if errors.Is(err, &dirListingNotSupportedError{}) {
 		// false because we cannot automatically retry, the user must change the url to use a different origin/namespace
 		// that enables dirlistings or the admin must enable dirlistings on the origin/namespace

--- a/client/errorAccum.go
+++ b/client/errorAccum.go
@@ -156,6 +156,9 @@ func IsRetryable(err error) bool {
 	if errors.Is(err, &InvalidByteInChunkLengthError{}) {
 		return true
 	}
+	if errors.Is(err, &UnexpectedEOFError{}) {
+		return true
+	}
 	if errors.Is(err, &dirListingNotSupportedError{}) {
 		// false because we cannot automatically retry, the user must change the url to use a different origin/namespace
 		// that enables dirlistings or the admin must enable dirlistings on the origin/namespace

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -3265,6 +3265,10 @@ func runPut(request *http.Request, responseChan chan<- *http.Response, errorChan
 	if err != nil {
 		if !errors.Is(err, context.Canceled) {
 			log.Errorln("Error with PUT:", err)
+			// Wrap TLS errors in a ConnectionSetupError
+			if strings.Contains(err.Error(), "certificate") || strings.Contains(err.Error(), "tls") {
+				err = &ConnectionSetupError{URL: request.URL.String(), Err: err}
+			}
 		}
 		errorChan <- err
 		close(errorChan)


### PR DESCRIPTION
The goal of this PR was to mark errors that weren't being retried as retry-able

Specifically, when an invalid byte is in the chunk length header or an unexpected EOF, as those are most likely because a connection dropped or something went wrong during data transfer.

The third error is when there is a TLS connection error on a put. The expectation is that, again, is retryable.