### PR TITLE
Actually make use of Origin.ScitokensNameMapFile

### DIFF
--- a/xrootd/authorization.go
+++ b/xrootd/authorization.go
@@ -637,6 +637,7 @@ func GenerateOriginIssuers() (issuers []Issuer, err error) {
 			MapSubject:      param.Origin_ScitokensMapSubject.GetBool(),
 			DefaultUser:     param.Origin_ScitokensDefaultUser.GetString(),
 			UsernameClaim:   param.Origin_ScitokensUsernameClaim.GetString(),
+			NameMapfile:     param.Origin_ScitokensNameMapFile.GetString(),
 		})
 	}
 


### PR DESCRIPTION
We just forgot to plumb the parameter's value through the process of configuring XRootD.