### PR TITLE
When creating custom TLS certs, add IPs to SANs as IPs and not DNS names

### DIFF
--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -564,6 +564,11 @@ func GenerateCert() error {
 // RFC 6125 section 6.4.4 specifies that we may match against the CN ONLY if there are no DNS names.
 // This logic is implemented by x509.Certificate.VerifyHostname.
 func ValidateHostCertificateHostname(hostname string) error {
+	if param.TLSSkipVerify.GetBool() {
+		log.Warnf("Skipping TLS certificate hostname verification for %s because %s is set to true", hostname, param.TLSSkipVerify.GetName())
+		return nil
+	}
+
 	tlsCert := param.Server_TLSCertificateChain.GetString()
 	if tlsCert == "" {
 		return errors.Errorf("TLS certificate file is not set. See documentation for %s", param.Server_TLSCertificateChain.GetName())


### PR DESCRIPTION
The issue being fixed here is that some of our internal tests were producing bad certificates by adding IP addresses as DNS names, which was exposed recently when we started checking the configured certs against the configured server hostnames

This diff does two things -- it only toggles the cert<-->hostname validation when TLS is enabled in Pelican, and it adds the IP addresses to the cert correctly regardless.