### PR TITLE
Implement regex based group authorization

### DIFF
--- a/oa4mp/proxy.go
+++ b/oa4mp/proxy.go
@@ -63,6 +63,50 @@ func getTransport() *http.Transport {
 	return transport
 }
 
+func calculateAllowedScopes(user string, groupsList []string) []string {
+	if len(compiledAuthzRules) == 0 {
+		return nil
+	}
+
+	scopeSet := make(map[string]struct{})
+	for _, rule := range compiledAuthzRules {
+		if len(rule.UserSet) > 0 {
+			if _, ok := rule.UserSet[user]; !ok {
+				continue
+			}
+		}
+
+		for _, group := range groupsList {
+			_, literalMatch := rule.GroupLiterals[group]
+			regexMatch := false
+			for _, rgx := range rule.GroupRegexes {
+				if rgx.MatchString(group) {
+					regexMatch = true
+					break
+				}
+			}
+
+			if !literalMatch && !regexMatch {
+				continue
+			}
+
+			for _, action := range rule.Actions {
+				s := strings.ReplaceAll(rule.Prefix+action, "$GROUP", group)
+				s = strings.ReplaceAll(s, "$USER", user)
+				scopeSet[s] = struct{}{}
+			}
+		}
+
+	}
+
+	allowedScopes := make([]string, 0, len(scopeSet))
+	for scope := range scopeSet {
+		allowedScopes = append(allowedScopes, scope)
+	}
+
+	return allowedScopes
+}
+
 // Proxy a HTTP request from the Pelican server to the OA4MP server
 //
 // Maps a request to /api/v1.0/issuer/foo to /scitokens-server/foo.  Most
@@ -100,6 +144,12 @@ func oa4mpProxy(ctx *gin.Context) {
 		userInfo := make(map[string]interface{})
 		userInfo["u"] = user
 		userInfo["g"] = groupsList
+
+		allowedScopes := calculateAllowedScopes(user, groupsList)
+		if len(allowedScopes) > 0 {
+			userInfo["s"] = allowedScopes
+		}
+
 		userBytes, err := json.Marshal(userInfo)
 		if err != nil {
 			ctx.AbortWithStatusJSON(http.StatusInternalServerError, server_structs.SimpleApiResp{

--- a/oa4mp/resources/id_token_policies.qdl
+++ b/oa4mp/resources/id_token_policies.qdl
@@ -25,6 +25,7 @@ if [exec_phase == 'post_token'] [
      userInfo. := from_json(decode(claims.sub));
      claims.sub := userInfo.u;
      claims.groups := userInfo.g;
+     claims.scopes := userInfo.s;
      say('Got user name from pelican: ' + claims.sub);
 ];
 

--- a/oa4mp/resources/policies.qdl
+++ b/oa4mp/resources/policies.qdl
@@ -32,6 +32,7 @@ if [0 == size(|^group_list. /\ { {{- range $idx, $grp := .GroupRequirements -}}{
 {{- end }}
 
 default_scopes := {};
+default_scopes := default_scopes \/ claims.scopes;
 {{ range .GroupAuthzTemplates }}
 {{ if eq 0 (len .Groups) -}}
 while [has_value(key, group_list.)]


### PR DESCRIPTION
Add regex-based group authorization, addressing #2443. This change introduces a `group_regexes` field to `Issuer.AuthorizationTemplates`, enabling deployments to map scopes with regular-expression patterns instead of only exact group names. `compileAuthzRules` now pre-compiles both literal and regex matchers at start-up to eliminate per-request overhead, and `calculateAllowedScopes` matches each incoming group against these matchers, deduplicates the resulting scopes, and injects them into the OA4MP proxy header. QDL policy files (id_token_policies.qdl, policies.qdl) are updated so the computed scopes flow into claims.scopes and merge with default_scopes. 