### PR TITLE
Avoid duplicated server sitename in registration and update via CLI/webUI

### DIFF
--- a/registry/client_commands_test.go
+++ b/registry/client_commands_test.go
@@ -403,20 +403,20 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start by registering /foo/bar with the default key
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar", "test-site-foobar")
 	require.NoError(t, err)
 
 	// Perform one test with a subspace and the same key -- should succeed
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/test", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/test", "test-site-foobar-test")
 	require.NoError(t, err)
 
 	// If the namespace is a subspace from the topology and is registered without the identity
 	// we deny it
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo/foo/bar", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo/foo/bar", "test-site-topo-foobar")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "A superspace or subspace of this namespace /topo/foo/bar already exists in the OSDF topology: /topo/foo. To register a Pelican equivalence, you need to present your identity.")
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo/foo", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo/foo", "test-site-topo-foo")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "A superspace or subspace of this namespace /topo/foo already exists in the OSDF topology: /topo/foo. To register a Pelican equivalence, you need to present your identity.")
 
@@ -434,28 +434,28 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 	_, err = config.GetIssuerPublicJWKS()
 	require.NoError(t, err)
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/baz", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/baz", "test-site-foobarbaz")
 	require.ErrorContains(t, err, "Cannot register a namespace that is suffixed or prefixed")
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo", "test-site-foo")
 	require.ErrorContains(t, err, "Cannot register a namespace that is suffixed or prefixed")
 
 	// Make sure we can register things similar but distinct in prefix and suffix
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/fo", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/fo", "test-site-fo")
 	require.NoError(t, err)
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/barz", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/barz", "test-site-foobarz")
 	require.NoError(t, err)
 
 	// Now turn off token chaining and retry -- no errors should occur
 	viper.Set("Registry.RequireKeyChaining", false)
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/baz", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/baz", "test-site-foobarbaz2")
 	require.NoError(t, err)
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo", "test-site-foo2")
 	require.NoError(t, err)
 
 	// However, topology check should be independent of key chaining check
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo", "test-site-topo")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "A superspace or subspace of this namespace /topo already exists in the OSDF topology: /topo/foo. To register a Pelican equivalence, you need to present your identity.")
 
@@ -495,11 +495,11 @@ func TestRegistryKeyChaining(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start by registering /foo/bar with the default key
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar", "test-site-chaining-foobar")
 	require.NoError(t, err)
 
 	// Perform one test with a subspace and the same key -- should succeed
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/test", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/test", "test-site-chaining-foobar-test")
 	require.NoError(t, err)
 
 	// Now we create a new key and try to use it to register a super/sub space. These shouldn't succeed
@@ -514,17 +514,17 @@ func TestRegistryKeyChaining(t *testing.T) {
 	_, err = config.GetIssuerPublicJWKS()
 	require.NoError(t, err)
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/baz", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/baz", "test-site-chaining-foobarbaz")
 	require.ErrorContains(t, err, "Cannot register a namespace that is suffixed or prefixed")
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo", "test-site-chaining-foo")
 	require.ErrorContains(t, err, "Cannot register a namespace that is suffixed or prefixed")
 
 	// Now turn off token chaining and retry -- no errors should occur
 	viper.Set("Registry.RequireKeyChaining", false)
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/baz", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/baz", "test-site-chaining-foobarbaz2")
 	require.NoError(t, err)
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo", "test-site-chaining-foo2")
 	require.NoError(t, err)
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -315,7 +315,7 @@ func keySignChallengeCommit(ctx *gin.Context, data *registrationData) (bool, map
 
 	// Check if SiteName already exists for origin and cache namespaces
 	if server_structs.IsOriginNS(data.Prefix) || server_structs.IsCacheNS(data.Prefix) {
-		countOfSitename, err := serverSiteNameExists(data.SiteName, data.Prefix)
+		countOfSitename, err := serverSiteNameExists(data.SiteName)
 		if err != nil {
 			log.Errorf("Failed to check if SiteName already exists: %v", err)
 			return false, nil, errors.Wrap(err, "Server encountered an error checking if SiteName already exists")

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -453,8 +453,8 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 			return
 		}
 
-		// Ensure the requested SiteName is unique for this server type (origin or cache)
-		countOfSitename, err := serverSiteNameExists(ns.AdminMetadata.SiteName, ns.Prefix)
+		// Ensure the requested SiteName is unique across all servers
+		countOfSitename, err := serverSiteNameExists(ns.AdminMetadata.SiteName)
 		if err != nil {
 			log.Errorf("Failed to check if Sitename already exists: %v", err)
 			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{

--- a/registry/registry_ui_test.go
+++ b/registry/registry_ui_test.go
@@ -1025,7 +1025,7 @@ func TestCreateNamespace(t *testing.T) {
 		require.NoError(t, err)
 
 		mockNs := server_structs.Namespace{
-			Prefix: "/origins/new.example.com",
+			Prefix: "/caches/new.example.com",
 			Pubkey: newPubKeyStr,
 			AdminMetadata: server_structs.AdminMetadata{
 				Institution: "1000",
@@ -1587,7 +1587,7 @@ func TestUpdateNamespaceHandler(t *testing.T) {
 			},
 		}
 		existingNs2 := server_structs.Namespace{
-			Prefix: "/origins/test-update2.example.com",
+			Prefix: "/caches/test-update2.example.com",
 			Pubkey: pubKeyStr2,
 			AdminMetadata: server_structs.AdminMetadata{
 				Institution: "1000",


### PR DESCRIPTION
In this PR, we check if a server's sitename has already been taken by any same-type server in Registry every time when admin wants to register or update a server via CLI or webUI. If so, Pelican will terminate the registration/update process and prompt the admin to provide another sitename.


### Design Thinking
This feature looks simple at the first glance, but requires much more consideration. We cannot just add a new "unique" constraint to DB because a) sitename is not a DB column, but a field in a json string column `admin_metadata` b) sitename could be duplicate for a server namespace and the namespaces it host c) there are lots of duplicate namespaces in DB because of b)

So this PR focuses on the prevention of duplicate sitename for server (Origin/Cache) namespace _from now on_. If the a server's sitename was taken by another, admin will not able to register or update that server namespace _without_ changing the sitename. 

To clean up the existing duplicate registrations in OSDF Registry DB, there is a counterpart [Jira ticket](https://opensciencegrid.atlassian.net/browse/OPS-416). 

### Impact on dev env
With the introduction of no duplicate sitename for Pelican servers, running all Pelican services in a local dev environment becomes a little bit tricky - because by default Origin and Cache both use os.Hostname as `sitename`. If you spin up Cache after Origin in a fresh federation (meaning no DB entries in Registry DB), you will be hit by the following error message:

```
ERROR[2025-07-02T21:08:01Z] Server responded with an error: Bad request for key-sign challenge: The SiteName '88386cd92f0a' is already in use by another registered origin or cache namespace. . The POST attempt to https://88386cd92f0a:8446/api/v1.0/registry resulted in status code 400 
```

To avoid this error, you need to either:

1. After spinning up an Origin, change the sitename of the Origin in the Registry Web UI. For example, change the sitename from "88386cd92f0a" to "88386cd92f0a-Origin".
2. Use the new `docker compose` Pelican development environment. https://github.com/PelicanPlatform/pelican/pull/2268 It provides different config yaml file for Origin and Cache respectively, so that you could set different `Xrootd.Sitename` for them.

Note: this only impacts on a fresh federation. Once the registrations of both Origin and Cache are done, you don't need to do this trick when spinning up Origin and Cache in the future, as long as you don't nuke the registrations in Registry DB. 