### PR TITLE
Add a `Monitoring.EnablePrometheus` configuration parameter to disable the embedded Prometheus server and related checks

### DIFF
--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2880,6 +2880,13 @@ components: ["origin", "cache"]
 ############################
 # Monitoring-level configs #
 ############################
+name: Monitoring.EnablePrometheus
+description: |+
+  Enable the internal Prometheus server.
+type: bool
+default: true
+components: ["origin", "cache", "director", "registry"]
+---
 name: Monitoring.DataLocation
 description: |+
   A filepath where Prometheus should host its monitoring data.

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -89,6 +89,10 @@ func LaunchModules(ctx context.Context, modules server_structs.ServerType) (serv
 
 	// Register OIDC endpoint
 	if param.Server_EnableUI.GetBool() {
+		// Warn if Prometheus is disabled, but Web UI is enabled. Metrics via Web UI will not be available.
+		if !param.Monitoring_EnablePrometheus.GetBool() {
+			log.Warn("Prometheus is disabled, but Web UI is enabled. Metrics via Web UI will not be available.")
+		}
 		if modules.IsEnabled(server_structs.RegistryType) ||
 			(modules.IsEnabled(server_structs.OriginType) && param.Origin_EnableOIDC.GetBool()) ||
 			(modules.IsEnabled(server_structs.CacheType) && param.Cache_EnableOIDC.GetBool()) ||
@@ -370,7 +374,7 @@ func LaunchModules(ctx context.Context, modules server_structs.ServerType) (serv
 
 	}
 
-	if param.Server_EnableUI.GetBool() {
+	if param.Monitoring_EnablePrometheus.GetBool() {
 		metrics.SetComponentHealthStatus(metrics.Prometheus, metrics.StatusWarning, "Prometheus not started")
 		if err = web_ui.ConfigureEmbeddedPrometheus(ctx, engine); err != nil {
 			err = errors.Wrap(err, "Failed to configure embedded prometheus instance")

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -379,6 +379,7 @@ var (
 	Issuer_UserStripDomain = BoolParam{"Issuer.UserStripDomain"}
 	Logging_DisableProgressBars = BoolParam{"Logging.DisableProgressBars"}
 	Lotman_EnableAPI = BoolParam{"Lotman.EnableAPI"}
+	Monitoring_EnablePrometheus = BoolParam{"Monitoring.EnablePrometheus"}
 	Monitoring_MetricAuthorization = BoolParam{"Monitoring.MetricAuthorization"}
 	Monitoring_PromQLAuthorization = BoolParam{"Monitoring.PromQLAuthorization"}
 	Origin_DirectorTest = BoolParam{"Origin.DirectorTest"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -186,6 +186,7 @@ type Config struct {
 		AggregatePrefixes []string `mapstructure:"aggregateprefixes" yaml:"AggregatePrefixes"`
 		DataLocation string `mapstructure:"datalocation" yaml:"DataLocation"`
 		DataRetention time.Duration `mapstructure:"dataretention" yaml:"DataRetention"`
+		EnablePrometheus bool `mapstructure:"enableprometheus" yaml:"EnablePrometheus"`
 		LabelLimit int `mapstructure:"labellimit" yaml:"LabelLimit"`
 		LabelNameLengthLimit int `mapstructure:"labelnamelengthlimit" yaml:"LabelNameLengthLimit"`
 		LabelValueLengthLimit int `mapstructure:"labelvaluelengthlimit" yaml:"LabelValueLengthLimit"`
@@ -544,6 +545,7 @@ type configWithType struct {
 		AggregatePrefixes struct { Type string; Value []string }
 		DataLocation struct { Type string; Value string }
 		DataRetention struct { Type string; Value time.Duration }
+		EnablePrometheus struct { Type string; Value bool }
 		LabelLimit struct { Type string; Value int }
 		LabelNameLengthLimit struct { Type string; Value int }
 		LabelValueLengthLimit struct { Type string; Value int }

--- a/server_utils/server_utils.go
+++ b/server_utils/server_utils.go
@@ -534,6 +534,10 @@ func SetFedTok(ctx context.Context, server server_structs.XRootDServer, tok stri
 // that gets reported to the Director, which can help inform the Director whether it needs to
 // cool down redirects to the server.
 func LaunchConcurrencyMonitoring(ctx context.Context, egrp *errgroup.Group, sType server_structs.ServerType) {
+	if !param.Monitoring_EnablePrometheus.GetBool() {
+		log.Infoln("Prometheus is not enabled, skipping IO concurrency monitoring")
+		return
+	}
 
 	doLoadMonitoring := func(ctx context.Context) error {
 		var concLimit int


### PR DESCRIPTION
This PR address issue #2458. This PR introduces a new configuration parameter, `Monitoring.EnablePrometheus`, which defaults to true.  When set to false, the embedded Prometheus server will not be started and will skip the IO-concurrency monitoring introduced in PR #2338. Also when Prometheus is disabled and the Web UI is enabled, it will put a warning message in the logs to warn that metrics will not be available in the Web UI.