### PR TITLE
Web client - Origin and Cache changes

### DIFF
--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -98,3 +98,17 @@ http.trace {{.Logging.CacheHttp}}
 {{if .Xrootd.ConfigFile}}
 continue {{.Xrootd.ConfigFile}}
 {{end}}
+# Add in http headers to make the web client capable of requesting resources
+http.staticheader -verb=OPTIONS Access-Control-Allow-Origin *
+http.staticheader -verb=OPTIONS Access-Control-Allow-Methods GET,PUT,PROPFIND
+http.staticheader -verb=OPTIONS Access-Control-Allow-Headers Authorization,Want-Digest,Content-Type,User-Agent,Depth,Content-Length,Translate
+
+http.staticheader -verb=GET Access-Control-Allow-Origin *
+http.staticheader -verb=GET Access-Control-Allow-Headers Authorization,Want-Digest,Content-Type,User-Agent
+http.staticheader -verb=GET Content-Disposition attachment
+
+http.staticheader -verb=PUT Access-Control-Allow-Origin *
+http.staticheader -verb=PUT Access-Control-Allow-Headers Authorization
+
+http.staticheader -verb=PROPFIND Access-Control-Allow-Origin *
+http.staticheader -verb=PROPFIND Access-Control-Allow-Headers Depth,Content-Type,Authorization,Content-Length,Translate

--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -139,3 +139,19 @@ scitokens.trace {{.Logging.OriginScitokens}}
 # Continue onto the next set of configuration
 continue {{.Xrootd.ConfigFile}}
 {{- end}}
+
+# Add in http headers to make the web client capable of requesting resources
+# Add in http headers to make the web client capable of requesting resources
+http.staticheader -verb=OPTIONS Access-Control-Allow-Origin *
+http.staticheader -verb=OPTIONS Access-Control-Allow-Methods GET,PUT,PROPFIND
+http.staticheader -verb=OPTIONS Access-Control-Allow-Headers Authorization,Want-Digest,Content-Type,User-Agent,Depth,Content-Length,Translate
+
+http.staticheader -verb=GET Access-Control-Allow-Origin *
+http.staticheader -verb=GET Access-Control-Allow-Headers Authorization,Want-Digest,Content-Type,User-Agent
+http.staticheader -verb=GET Content-Disposition attachment
+
+http.staticheader -verb=PUT Access-Control-Allow-Origin *
+http.staticheader -verb=PUT Access-Control-Allow-Headers Authorization
+
+http.staticheader -verb=PROPFIND Access-Control-Allow-Origin *
+http.staticheader -verb=PROPFIND Access-Control-Allow-Headers Depth,Content-Type,Authorization,Content-Length,Translate


### PR DESCRIPTION
Adds the appropriate CORS headers to that we can make queries to Xrootd services from the browser.

To test spin up a Origin/Cache and curl it to verify that it is returning the appropriate headers. 