### PR TITLE
Web client - All Changes

### DIFF
--- a/client/acquire_token.go
+++ b/client/acquire_token.go
@@ -534,7 +534,6 @@ func registerClient(dirResp server_structs.DirectorResponse) (*config.PrefixEntr
 	}
 
 	drcp := oauth2.DCRPConfig{ClientRegistrationEndpointURL: issuer.RegistrationURL, Transport: config.GetTransport(), Metadata: oauth2.Metadata{
-		RedirectURIs:            []string{"https://localhost/osdf-client"},
 		TokenEndpointAuthMethod: "client_secret_basic",
 		GrantTypes:              []string{"refresh_token", "urn:ietf:params:oauth:grant-type:device_code"},
 		ResponseTypes:           []string{"code"},

--- a/director/director.go
+++ b/director/director.go
@@ -1666,10 +1666,6 @@ func collectDirectorRedirectionMetric(ctx *gin.Context, destination string) {
 func RegisterDirectorAPI(ctx context.Context, router *gin.RouterGroup) {
 	egrp := ctx.Value(config.EgrpKey).(*errgroup.Group)
 
-	// Print out a log statement so we know what version is running
-	log.Debugf("Starting Pelican Director API v%s", "s")
-	gin.SetMode(gin.DebugMode)
-
 	directorAPIV1 := router.Group("/api/v1.0/director", web_ui.ServerHeaderMiddleware)
 	{
 		// Answer CORS preflight requests, trivial response inlined

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2580,6 +2580,17 @@ type: object
 default: []
 components: ["origin"]
 ---
+name: Issuer.RedirectUris
+description: |+
+  The list of redirect URIs for Issuer Clients to use in the Authorization Code Flow. Used to enable the use of a
+  Pelican Web Client at the redirect target. The URIs must use the `https` scheme.
+
+  More information on using the [Pelican Web Client](https://github.com/PelicanPlatform/web-client).
+type: stringSlice
+root_default: []
+default: []
+components: ["origin"]
+---
 ###################################
 #   Server's OIDC Configuration   #
 ###################################

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -458,6 +458,7 @@ COPY --chown=root:tomcat oa4mp/resources/server.xml /opt/tomcat/conf/server.xml
 # authenticates the user and proxies requests.
 COPY --chown=tomcat:tomcat oa4mp/resources/client-template.xml /opt/scitokens-server/etc/templates/client-template.xml
 RUN sed -i -e 's/action="\${actionToTake}" //' /opt/tomcat/webapps/scitokens-server/device-consent.jsp
+RUN sed -i -e 's|action="\${actionToTake}"|action="/api/v1.0/issuer/authorize"|' /opt/tomcat/webapps/scitokens-server/authorize-remote-user.jsp
 
 # This script is a documented part of OA4MP's bootstrap process, but we
 # otherwise do not need it.

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -457,8 +457,10 @@ COPY --chown=root:tomcat oa4mp/resources/server.xml /opt/tomcat/conf/server.xml
 # Replace other bits and bobs to take into account the fact that Pelican
 # authenticates the user and proxies requests.
 COPY --chown=tomcat:tomcat oa4mp/resources/client-template.xml /opt/scitokens-server/etc/templates/client-template.xml
-RUN sed -i -e 's/action="\${actionToTake}" //' /opt/tomcat/webapps/scitokens-server/device-consent.jsp
-RUN sed -i -e 's|action="\${actionToTake}"|action="/api/v1.0/issuer/authorize"|' /opt/tomcat/webapps/scitokens-server/authorize-remote-user.jsp
+COPY --chown=tomcat:tomcat oa4mp/resources/device-consent.jsp /opt/tomcat/webapps/scitokens-server/device-consent.jsp
+COPY --chown=tomcat:tomcat oa4mp/resources/authorize-remote-user.jsp /opt/tomcat/webapps/scitokens-server/authorize-remote-user.jsp
+COPY --chown=tomcat:tomcat oa4mp/resources/device-fail.jsp /opt/tomcat/webapps/scitokens-server/device-fail.jsp
+COPY --chown=tomcat:tomcat oa4mp/resources/device-ok.jsp /opt/tomcat/webapps/scitokens-server/device-ok.jsp
 
 # This script is a documented part of OA4MP's bootstrap process, but we
 # otherwise do not need it.

--- a/oa4mp/resources/authorize-remote-user.jsp
+++ b/oa4mp/resources/authorize-remote-user.jsp
@@ -1,0 +1,135 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ page session="false" %>
+<html>
+<head>
+    <title>Pelican Consent Page</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital@0;1&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Poppins', 'Helvetica Neue', Arial, sans-serif;
+            background-color: #ffffff;
+            margin: 0;
+            padding: 0;
+            position: relative;
+            overflow: hidden;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+        }
+        .background-effect {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: conic-gradient(from 180deg at 80% 80%, #16abff 0deg, #0885ff 55deg, #54d6ff 120deg, #0071ff 160deg, #0071ff 1turn);
+            opacity: 20%;
+            z-index: -1;
+            filter: blur(20px);
+        }
+        .pelican-header {
+            background-color: #0885ff;
+            color: white;
+            padding: 20px;
+            text-align: center;
+        }
+        .pelican-logo {
+            vertical-align: middle;
+        }
+        h1 {
+            margin: 0;
+            font-size: 24px;
+        }
+        h2 {
+            color: #0885ff;
+            text-align: center;
+        }
+        p {
+            text-align: center;
+            font-size: 16px;
+        }
+        .pelican-button {
+            background-color: #0885ff;
+            color: white;
+            border: none;
+            padding: 10px 20px;
+            cursor: pointer;
+            font-size: 14px;
+            border-radius: 5px;
+        }
+        .pelican-button:hover {
+            background-color: #005bb5;
+        }
+        a {
+            text-decoration: none;
+        }
+        .content-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            margin: 20px;
+        }
+        .client-info {
+            background-color: white;
+            padding: 20px;
+            border-radius: 5px;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+            margin-bottom: 20px;
+        }
+        .button-container {
+            display: flex;
+            justify-content: center;
+            gap: 10px;
+            margin-bottom: 20px;
+        }
+        .footer-logo {
+            text-align: center;
+            margin-top: 40px;
+        }
+        .retry-message {
+            color: #ff0000;
+            font-weight: bold;
+            text-align: center;
+            margin-top: 10px;
+        }
+    </style>
+</head>
+<body>
+<div class="background-effect"></div>
+<main>
+    <div class="content-container">
+        <h2>Welcome to the Pelican Client Consent Page</h2>
+        <p>The Client below is requesting access to your account.</p>
+        <form action="/api/v1.0/issuer/authorize" method="POST">
+            <div class="client-info">
+                <p>The client listed below is requesting access to your account. Approve or reject access below.</p>
+                <p><i>Name:</i> ${clientName}</p>
+                <p><i>URL:</i> ${clientHome}</p>
+                <p><i>Requested Scopes:</i> ${clientScopes}</p>
+                <p class="retry-message">${retryMessage}</p>
+            </div>
+            <div class="button-container">
+                <input type="submit" value="Approve" class="pelican-button"/>
+                <a href="${clientHome}">
+                    <input type="button" name="cancel" value="Reject" class="pelican-button"/>
+                </a>
+            </div>
+            <div class="button-container">
+
+            </div>
+            <input type="hidden" id="status" name="${action}" value="${actionOk}"/>
+            <input type="hidden" id="token" name="${tokenKey}" value="${authorizationGrant}"/>
+            <input type="hidden" id="state" name="${stateKey}" value="${authorizationState}"/>
+            <input type="hidden" id="page_type" name="page_type" value="consent"/>
+        </form>
+    </div>
+</main>
+<div class="footer-logo">
+    <img height="80" src="https://pelicanplatform.org/static/images/PelicanPlatformLogo_Icon.png" alt="Pelican Logo">
+</div>
+</body>
+</html>

--- a/oa4mp/resources/device-consent.jsp
+++ b/oa4mp/resources/device-consent.jsp
@@ -1,0 +1,125 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ page session="false" %>
+<html>
+<head>
+    <title>Pelican Consent Page</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital@0;1&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Poppins', 'Helvetica Neue', Arial, sans-serif;
+            background-color: #ffffff;
+            margin: 0;
+            padding: 0;
+            position: relative;
+            overflow: hidden;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+        }
+        .background-effect {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: conic-gradient(from 180deg at 80% 80%, #16abff 0deg, #0885ff 55deg, #54d6ff 120deg, #0071ff 160deg, #0071ff 1turn);
+            opacity: 20%;
+            z-index: -1;
+            filter: blur(20px);
+        }
+        .pelican-header {
+            background-color: #0885ff;
+            color: white;
+            padding: 20px;
+            text-align: center;
+        }
+        .pelican-logo {
+            vertical-align: middle;
+        }
+        h1 {
+            margin: 0;
+            font-size: 24px;
+        }
+        h2 {
+            color: #0885ff;
+            text-align: center;
+        }
+        p {
+            text-align: center;
+            font-size: 16px;
+        }
+        .pelican-button {
+            background-color: #0885ff;
+            color: white;
+            border: none;
+            padding: 10px 20px;
+            cursor: pointer;
+            font-size: 14px;
+            border-radius: 5px;
+        }
+        .pelican-button:hover {
+            background-color: #005bb5;
+        }
+        a {
+            text-decoration: none;
+        }
+        .content-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            margin: 20px;
+        }
+        .client-info {
+            background-color: white;
+            padding: 20px;
+            border-radius: 5px;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+            margin-bottom: 20px;
+        }
+        .button-container {
+            display: flex;
+            justify-content: center;
+            gap: 10px;
+            margin-bottom: 20px;
+        }
+        .footer-logo {
+            text-align: center;
+            margin-top: 40px;
+        }
+    </style>
+</head>
+<body>
+<div class="background-effect"></div>
+<main>
+    <div class="content-container">
+        <h2>Welcome to the Pelican Consent Page</h2>
+        <p>The Client below is requesting access to your account.</p>
+        <form method="POST">
+            <div class="client-info">
+                <p>The client listed below is requesting access to your account. Approve or reject access below.</p>
+                <p><i>Name:</i> ${clientName}</p>
+                <p><i>URL:</i> ${clientHome}</p>
+                <p><i>Requested Scopes:</i> ${clientScopes}</p>
+            </div>
+            <div class="button-container">
+                <input type="submit" value="Approve" class="pelican-button"/>
+                <a href="${clientHome}">
+                    <input type="button" name="cancel" value="Reject" class="pelican-button"/>
+                </a>
+            </div>
+            <input type="hidden" id="status" name="${action}" value="${actionOk}"/>
+            <input type="hidden" id="token" name="${tokenKey}" value="${authorizationGrant}"/>
+            <input type="hidden" id="state" name="${stateKey}" value="${authorizationState}"/>
+            <input type="hidden" id="page_type" name="page_type" value="consent"/>
+        </form>
+    </div>
+</main>
+<div class="footer-logo">
+    <img height="80" src="https://pelicanplatform.org/static/images/PelicanPlatformLogo_Icon.png" alt="Pelican Logo">
+</div>
+</body>
+</html>

--- a/oa4mp/resources/device-fail.jsp
+++ b/oa4mp/resources/device-fail.jsp
@@ -1,0 +1,107 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ page session="false" %>
+<html>
+<head>
+  <title>Pelican Consent Page</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:ital@0;1&display=swap" rel="stylesheet">
+  <style>
+    body {
+      font-family: 'Poppins', 'Helvetica Neue', Arial, sans-serif;
+      background-color: #ffffff;
+      margin: 0;
+      padding: 0;
+      position: relative;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+    }
+    .background-effect {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: conic-gradient(from 180deg at 80% 80%, #16abff 0deg, #0885ff 55deg, #54d6ff 120deg, #0071ff 160deg, #0071ff 1turn);
+      opacity: 20%;
+      z-index: -1;
+      filter: blur(20px);
+    }
+    .pelican-header {
+      background-color: #0885ff;
+      color: white;
+      padding: 20px;
+      text-align: center;
+    }
+    .pelican-logo {
+      vertical-align: middle;
+    }
+    h1 {
+      margin: 0;
+      font-size: 24px;
+    }
+    h2 {
+      color: #0885ff;
+      text-align: center;
+    }
+    p {
+      text-align: center;
+      font-size: 16px;
+    }
+    .pelican-button {
+      background-color: #0885ff;
+      color: white;
+      border: none;
+      padding: 10px 20px;
+      cursor: pointer;
+      font-size: 14px;
+      border-radius: 5px;
+    }
+    .pelican-button:hover {
+      background-color: #005bb5;
+    }
+    a {
+      text-decoration: none;
+    }
+    .content-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      margin: 20px;
+    }
+    .client-info {
+      background-color: white;
+      padding: 20px;
+      border-radius: 5px;
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+      margin-bottom: 20px;
+    }
+    .button-container {
+      display: flex;
+      justify-content: center;
+      gap: 10px;
+      margin-bottom: 20px;
+    }
+    .footer-logo {
+      text-align: center;
+      margin-top: 40px;
+    }
+  </style>
+</head>
+<body>
+<div class="background-effect"></div>
+<main>
+  <div class="content-container">
+    <h2>User Code Denied!</h2>
+    <p>You have exceeded the number of retry attempts for entering a code.</p>
+  </div>
+</main>
+<div class="footer-logo">
+  <img height="80" src="https://pelicanplatform.org/static/images/PelicanPlatformLogo_Icon.png" alt="Pelican Logo">
+</div>
+</body>
+</html>

--- a/oa4mp/resources/device-ok.jsp
+++ b/oa4mp/resources/device-ok.jsp
@@ -1,0 +1,107 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ page session="false" %>
+<html>
+<head>
+  <title>Pelican Consent Page</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:ital@0;1&display=swap" rel="stylesheet">
+  <style>
+    body {
+      font-family: 'Poppins', 'Helvetica Neue', Arial, sans-serif;
+      background-color: #ffffff;
+      margin: 0;
+      padding: 0;
+      position: relative;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+    }
+    .background-effect {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: conic-gradient(from 180deg at 80% 80%, #16abff 0deg, #0885ff 55deg, #54d6ff 120deg, #0071ff 160deg, #0071ff 1turn);
+      opacity: 20%;
+      z-index: -1;
+      filter: blur(20px);
+    }
+    .pelican-header {
+      background-color: #0885ff;
+      color: white;
+      padding: 20px;
+      text-align: center;
+    }
+    .pelican-logo {
+      vertical-align: middle;
+    }
+    h1 {
+      margin: 0;
+      font-size: 24px;
+    }
+    h2 {
+      color: #0885ff;
+      text-align: center;
+    }
+    p {
+      text-align: center;
+      font-size: 16px;
+    }
+    .pelican-button {
+      background-color: #0885ff;
+      color: white;
+      border: none;
+      padding: 10px 20px;
+      cursor: pointer;
+      font-size: 14px;
+      border-radius: 5px;
+    }
+    .pelican-button:hover {
+      background-color: #005bb5;
+    }
+    a {
+      text-decoration: none;
+    }
+    .content-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      margin: 20px;
+    }
+    .client-info {
+      background-color: white;
+      padding: 20px;
+      border-radius: 5px;
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+      margin-bottom: 20px;
+    }
+    .button-container {
+      display: flex;
+      justify-content: center;
+      gap: 10px;
+      margin-bottom: 20px;
+    }
+    .footer-logo {
+      text-align: center;
+      margin-top: 40px;
+    }
+  </style>
+</head>
+<body>
+<div class="background-effect"></div>
+<main>
+  <div class="content-container">
+    <h2>User Code Accepted!</h2>
+    <p>Continue on the CLI.</p>
+  </div>
+</main>
+<div class="footer-logo">
+  <img height="80" src="https://pelicanplatform.org/static/images/PelicanPlatformLogo_Icon.png" alt="Pelican Logo">
+</div>
+</body>
+</html>

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -50,27 +50,27 @@ type ObjectParam struct {
 }
 
 func GetDeprecated() map[string][]string {
-	return map[string][]string{
-		"Cache.DataLocation":        {"Cache.StorageLocation"},
-		"Cache.LocalRoot":           {"Cache.StorageLocation"},
-		"Director.EnableStat":       {"Director.CheckOriginPresence"},
-		"DisableHttpProxy":          {"Client.DisableHttpProxy"},
-		"DisableProxyFallback":      {"Client.DisableProxyFallback"},
-		"IssuerKey":                 {"none"},
-		"Lotman.DbLocation":         {"Lotman.LotHome"},
-		"MinimumDownloadSpeed":      {"Client.MinimumDownloadSpeed"},
-		"Origin.EnableDirListing":   {"Origin.EnableListings"},
-		"Origin.EnableFallbackRead": {"Origin.EnableDirectReads"},
-		"Origin.EnableWrite":        {"Origin.EnableWrites"},
-		"Origin.ExportVolume":       {"Origin.ExportVolumes"},
-		"Origin.Mode":               {"Origin.StorageType"},
-		"Origin.NamespacePrefix":    {"Origin.FederationPrefix"},
-		"Origin.S3ServiceName":      {"none"},
-		"Registry.AdminUsers":       {"Server.UIAdminUsers"},
-		"Server.TLSCertificate":     {"Server.TLSCertificateChain"},
-		"Xrootd.Port":               {"Origin.Port", "Cache.Port"},
-		"Xrootd.RunLocation":        {"Cache.RunLocation", "Origin.RunLocation"},
-	}
+    return map[string][]string{
+        "Cache.DataLocation": {"Cache.StorageLocation"},
+        "Cache.LocalRoot": {"Cache.StorageLocation"},
+        "Director.EnableStat": {"Director.CheckOriginPresence"},
+        "DisableHttpProxy": {"Client.DisableHttpProxy"},
+        "DisableProxyFallback": {"Client.DisableProxyFallback"},
+        "IssuerKey": {"none"},
+        "Lotman.DbLocation": {"Lotman.LotHome"},
+        "MinimumDownloadSpeed": {"Client.MinimumDownloadSpeed"},
+        "Origin.EnableDirListing": {"Origin.EnableListings"},
+        "Origin.EnableFallbackRead": {"Origin.EnableDirectReads"},
+        "Origin.EnableWrite": {"Origin.EnableWrites"},
+        "Origin.ExportVolume": {"Origin.ExportVolumes"},
+        "Origin.Mode": {"Origin.StorageType"},
+        "Origin.NamespacePrefix": {"Origin.FederationPrefix"},
+        "Origin.S3ServiceName": {"none"},
+        "Registry.AdminUsers": {"Server.UIAdminUsers"},
+        "Server.TLSCertificate": {"Server.TLSCertificateChain"},
+        "Xrootd.Port": {"Origin.Port", "Cache.Port"},
+        "Xrootd.RunLocation": {"Cache.RunLocation", "Origin.RunLocation"},
+    }
 }
 
 func (sP StringParam) GetString() string {
@@ -146,325 +146,325 @@ func (oP ObjectParam) IsSet() bool {
 }
 
 var (
-	Cache_DataLocation                 = StringParam{"Cache.DataLocation"}
-	Cache_DbLocation                   = StringParam{"Cache.DbLocation"}
-	Cache_ExportLocation               = StringParam{"Cache.ExportLocation"}
-	Cache_FedTokenLocation             = StringParam{"Cache.FedTokenLocation"}
-	Cache_FilesBaseSize                = StringParam{"Cache.FilesBaseSize"}
-	Cache_FilesMaxSize                 = StringParam{"Cache.FilesMaxSize"}
-	Cache_FilesNominalSize             = StringParam{"Cache.FilesNominalSize"}
-	Cache_HighWaterMark                = StringParam{"Cache.HighWaterMark"}
-	Cache_LocalRoot                    = StringParam{"Cache.LocalRoot"}
-	Cache_LowWatermark                 = StringParam{"Cache.LowWatermark"}
-	Cache_NamespaceLocation            = StringParam{"Cache.NamespaceLocation"}
-	Cache_RunLocation                  = StringParam{"Cache.RunLocation"}
-	Cache_SentinelLocation             = StringParam{"Cache.SentinelLocation"}
-	Cache_StorageLocation              = StringParam{"Cache.StorageLocation"}
-	Cache_Url                          = StringParam{"Cache.Url"}
-	Cache_XRootDPrefix                 = StringParam{"Cache.XRootDPrefix"}
-	Director_AdvertiseUrl              = StringParam{"Director.AdvertiseUrl"}
-	Director_CacheSortMethod           = StringParam{"Director.CacheSortMethod"}
-	Director_DbLocation                = StringParam{"Director.DbLocation"}
-	Director_DefaultResponse           = StringParam{"Director.DefaultResponse"}
-	Director_GeoIPLocation             = StringParam{"Director.GeoIPLocation"}
-	Director_MaxMindKeyFile            = StringParam{"Director.MaxMindKeyFile"}
-	Director_SupportContactEmail       = StringParam{"Director.SupportContactEmail"}
-	Director_SupportContactUrl         = StringParam{"Director.SupportContactUrl"}
-	Federation_DiscoveryUrl            = StringParam{"Federation.DiscoveryUrl"}
-	Federation_TopologyDowntimeUrl     = StringParam{"Federation.TopologyDowntimeUrl"}
-	Federation_TopologyNamespaceUrl    = StringParam{"Federation.TopologyNamespaceUrl"}
-	Federation_TopologyUrl             = StringParam{"Federation.TopologyUrl"}
-	IssuerKey                          = StringParam{"IssuerKey"}
-	IssuerKeysDirectory                = StringParam{"IssuerKeysDirectory"}
-	Issuer_AuthenticationSource        = StringParam{"Issuer.AuthenticationSource"}
-	Issuer_GroupFile                   = StringParam{"Issuer.GroupFile"}
-	Issuer_GroupSource                 = StringParam{"Issuer.GroupSource"}
-	Issuer_IssuerClaimValue            = StringParam{"Issuer.IssuerClaimValue"}
+	Cache_DataLocation = StringParam{"Cache.DataLocation"}
+	Cache_DbLocation = StringParam{"Cache.DbLocation"}
+	Cache_ExportLocation = StringParam{"Cache.ExportLocation"}
+	Cache_FedTokenLocation = StringParam{"Cache.FedTokenLocation"}
+	Cache_FilesBaseSize = StringParam{"Cache.FilesBaseSize"}
+	Cache_FilesMaxSize = StringParam{"Cache.FilesMaxSize"}
+	Cache_FilesNominalSize = StringParam{"Cache.FilesNominalSize"}
+	Cache_HighWaterMark = StringParam{"Cache.HighWaterMark"}
+	Cache_LocalRoot = StringParam{"Cache.LocalRoot"}
+	Cache_LowWatermark = StringParam{"Cache.LowWatermark"}
+	Cache_NamespaceLocation = StringParam{"Cache.NamespaceLocation"}
+	Cache_RunLocation = StringParam{"Cache.RunLocation"}
+	Cache_SentinelLocation = StringParam{"Cache.SentinelLocation"}
+	Cache_StorageLocation = StringParam{"Cache.StorageLocation"}
+	Cache_Url = StringParam{"Cache.Url"}
+	Cache_XRootDPrefix = StringParam{"Cache.XRootDPrefix"}
+	Director_AdvertiseUrl = StringParam{"Director.AdvertiseUrl"}
+	Director_CacheSortMethod = StringParam{"Director.CacheSortMethod"}
+	Director_DbLocation = StringParam{"Director.DbLocation"}
+	Director_DefaultResponse = StringParam{"Director.DefaultResponse"}
+	Director_GeoIPLocation = StringParam{"Director.GeoIPLocation"}
+	Director_MaxMindKeyFile = StringParam{"Director.MaxMindKeyFile"}
+	Director_SupportContactEmail = StringParam{"Director.SupportContactEmail"}
+	Director_SupportContactUrl = StringParam{"Director.SupportContactUrl"}
+	Federation_DiscoveryUrl = StringParam{"Federation.DiscoveryUrl"}
+	Federation_TopologyDowntimeUrl = StringParam{"Federation.TopologyDowntimeUrl"}
+	Federation_TopologyNamespaceUrl = StringParam{"Federation.TopologyNamespaceUrl"}
+	Federation_TopologyUrl = StringParam{"Federation.TopologyUrl"}
+	IssuerKey = StringParam{"IssuerKey"}
+	IssuerKeysDirectory = StringParam{"IssuerKeysDirectory"}
+	Issuer_AuthenticationSource = StringParam{"Issuer.AuthenticationSource"}
+	Issuer_GroupFile = StringParam{"Issuer.GroupFile"}
+	Issuer_GroupSource = StringParam{"Issuer.GroupSource"}
+	Issuer_IssuerClaimValue = StringParam{"Issuer.IssuerClaimValue"}
 	Issuer_OIDCAuthenticationUserClaim = StringParam{"Issuer.OIDCAuthenticationUserClaim"}
-	Issuer_OIDCGroupClaim              = StringParam{"Issuer.OIDCGroupClaim"}
-	Issuer_QDLLocation                 = StringParam{"Issuer.QDLLocation"}
-	Issuer_ScitokensServerLocation     = StringParam{"Issuer.ScitokensServerLocation"}
-	Issuer_TomcatLocation              = StringParam{"Issuer.TomcatLocation"}
-	LocalCache_DataLocation            = StringParam{"LocalCache.DataLocation"}
-	LocalCache_RunLocation             = StringParam{"LocalCache.RunLocation"}
-	LocalCache_Size                    = StringParam{"LocalCache.Size"}
-	LocalCache_Socket                  = StringParam{"LocalCache.Socket"}
-	Logging_Cache_Http                 = StringParam{"Logging.Cache.Http"}
-	Logging_Cache_Ofs                  = StringParam{"Logging.Cache.Ofs"}
-	Logging_Cache_Pfc                  = StringParam{"Logging.Cache.Pfc"}
-	Logging_Cache_Pss                  = StringParam{"Logging.Cache.Pss"}
-	Logging_Cache_PssSetOpt            = StringParam{"Logging.Cache.PssSetOpt"}
-	Logging_Cache_Scitokens            = StringParam{"Logging.Cache.Scitokens"}
-	Logging_Cache_Xrd                  = StringParam{"Logging.Cache.Xrd"}
-	Logging_Cache_Xrootd               = StringParam{"Logging.Cache.Xrootd"}
-	Logging_Level                      = StringParam{"Logging.Level"}
-	Logging_LogLocation                = StringParam{"Logging.LogLocation"}
-	Logging_Origin_Cms                 = StringParam{"Logging.Origin.Cms"}
-	Logging_Origin_Http                = StringParam{"Logging.Origin.Http"}
-	Logging_Origin_Ofs                 = StringParam{"Logging.Origin.Ofs"}
-	Logging_Origin_Oss                 = StringParam{"Logging.Origin.Oss"}
-	Logging_Origin_Scitokens           = StringParam{"Logging.Origin.Scitokens"}
-	Logging_Origin_Xrd                 = StringParam{"Logging.Origin.Xrd"}
-	Logging_Origin_Xrootd              = StringParam{"Logging.Origin.Xrootd"}
-	Lotman_DbLocation                  = StringParam{"Lotman.DbLocation"}
-	Lotman_EnabledPolicy               = StringParam{"Lotman.EnabledPolicy"}
-	Lotman_LibLocation                 = StringParam{"Lotman.LibLocation"}
-	Lotman_LotHome                     = StringParam{"Lotman.LotHome"}
-	Monitoring_DataLocation            = StringParam{"Monitoring.DataLocation"}
-	OIDC_AuthorizationEndpoint         = StringParam{"OIDC.AuthorizationEndpoint"}
-	OIDC_ClientID                      = StringParam{"OIDC.ClientID"}
-	OIDC_ClientIDFile                  = StringParam{"OIDC.ClientIDFile"}
-	OIDC_ClientRedirectHostname        = StringParam{"OIDC.ClientRedirectHostname"}
-	OIDC_ClientSecretFile              = StringParam{"OIDC.ClientSecretFile"}
-	OIDC_DeviceAuthEndpoint            = StringParam{"OIDC.DeviceAuthEndpoint"}
-	OIDC_Issuer                        = StringParam{"OIDC.Issuer"}
-	OIDC_TokenEndpoint                 = StringParam{"OIDC.TokenEndpoint"}
-	OIDC_UserInfoEndpoint              = StringParam{"OIDC.UserInfoEndpoint"}
-	Origin_DbLocation                  = StringParam{"Origin.DbLocation"}
-	Origin_ExportVolume                = StringParam{"Origin.ExportVolume"}
-	Origin_FedTokenLocation            = StringParam{"Origin.FedTokenLocation"}
-	Origin_FederationPrefix            = StringParam{"Origin.FederationPrefix"}
-	Origin_GlobusClientIDFile          = StringParam{"Origin.GlobusClientIDFile"}
-	Origin_GlobusClientSecretFile      = StringParam{"Origin.GlobusClientSecretFile"}
-	Origin_GlobusCollectionID          = StringParam{"Origin.GlobusCollectionID"}
-	Origin_GlobusCollectionName        = StringParam{"Origin.GlobusCollectionName"}
-	Origin_GlobusConfigLocation        = StringParam{"Origin.GlobusConfigLocation"}
-	Origin_HttpAuthTokenFile           = StringParam{"Origin.HttpAuthTokenFile"}
-	Origin_HttpServiceUrl              = StringParam{"Origin.HttpServiceUrl"}
-	Origin_Mode                        = StringParam{"Origin.Mode"}
-	Origin_NamespacePrefix             = StringParam{"Origin.NamespacePrefix"}
-	Origin_RunLocation                 = StringParam{"Origin.RunLocation"}
-	Origin_S3AccessKeyfile             = StringParam{"Origin.S3AccessKeyfile"}
-	Origin_S3Bucket                    = StringParam{"Origin.S3Bucket"}
-	Origin_S3Region                    = StringParam{"Origin.S3Region"}
-	Origin_S3SecretKeyfile             = StringParam{"Origin.S3SecretKeyfile"}
-	Origin_S3ServiceName               = StringParam{"Origin.S3ServiceName"}
-	Origin_S3ServiceUrl                = StringParam{"Origin.S3ServiceUrl"}
-	Origin_S3UrlStyle                  = StringParam{"Origin.S3UrlStyle"}
-	Origin_ScitokensDefaultUser        = StringParam{"Origin.ScitokensDefaultUser"}
-	Origin_ScitokensNameMapFile        = StringParam{"Origin.ScitokensNameMapFile"}
-	Origin_ScitokensUsernameClaim      = StringParam{"Origin.ScitokensUsernameClaim"}
-	Origin_StoragePrefix               = StringParam{"Origin.StoragePrefix"}
-	Origin_StorageType                 = StringParam{"Origin.StorageType"}
-	Origin_TokenAudience               = StringParam{"Origin.TokenAudience"}
-	Origin_Url                         = StringParam{"Origin.Url"}
-	Origin_XRootDPrefix                = StringParam{"Origin.XRootDPrefix"}
-	Origin_XRootServiceUrl             = StringParam{"Origin.XRootServiceUrl"}
-	Plugin_Token                       = StringParam{"Plugin.Token"}
-	Registry_DbLocation                = StringParam{"Registry.DbLocation"}
-	Registry_InstitutionsUrl           = StringParam{"Registry.InstitutionsUrl"}
-	Server_DbLocation                  = StringParam{"Server.DbLocation"}
-	Server_ExternalWebUrl              = StringParam{"Server.ExternalWebUrl"}
-	Server_Hostname                    = StringParam{"Server.Hostname"}
-	Server_IssuerHostname              = StringParam{"Server.IssuerHostname"}
-	Server_IssuerJwks                  = StringParam{"Server.IssuerJwks"}
-	Server_IssuerUrl                   = StringParam{"Server.IssuerUrl"}
-	Server_SessionSecretFile           = StringParam{"Server.SessionSecretFile"}
-	Server_TLSCACertificateDirectory   = StringParam{"Server.TLSCACertificateDirectory"}
-	Server_TLSCACertificateFile        = StringParam{"Server.TLSCACertificateFile"}
-	Server_TLSCAKey                    = StringParam{"Server.TLSCAKey"}
-	Server_TLSCertificate              = StringParam{"Server.TLSCertificate"}
-	Server_TLSCertificateChain         = StringParam{"Server.TLSCertificateChain"}
-	Server_TLSKey                      = StringParam{"Server.TLSKey"}
-	Server_UIActivationCodeFile        = StringParam{"Server.UIActivationCodeFile"}
-	Server_UIPasswordFile              = StringParam{"Server.UIPasswordFile"}
-	Server_UnprivilegedUser            = StringParam{"Server.UnprivilegedUser"}
-	Server_WebConfigFile               = StringParam{"Server.WebConfigFile"}
-	Server_WebHost                     = StringParam{"Server.WebHost"}
-	Shoveler_AMQPExchange              = StringParam{"Shoveler.AMQPExchange"}
-	Shoveler_AMQPTokenLocation         = StringParam{"Shoveler.AMQPTokenLocation"}
-	Shoveler_MessageQueueProtocol      = StringParam{"Shoveler.MessageQueueProtocol"}
-	Shoveler_QueueDirectory            = StringParam{"Shoveler.QueueDirectory"}
-	Shoveler_StompCert                 = StringParam{"Shoveler.StompCert"}
-	Shoveler_StompCertKey              = StringParam{"Shoveler.StompCertKey"}
-	Shoveler_StompPassword             = StringParam{"Shoveler.StompPassword"}
-	Shoveler_StompUsername             = StringParam{"Shoveler.StompUsername"}
-	Shoveler_Topic                     = StringParam{"Shoveler.Topic"}
-	Shoveler_URL                       = StringParam{"Shoveler.URL"}
-	StagePlugin_MountPrefix            = StringParam{"StagePlugin.MountPrefix"}
-	StagePlugin_OriginPrefix           = StringParam{"StagePlugin.OriginPrefix"}
-	StagePlugin_ShadowOriginPrefix     = StringParam{"StagePlugin.ShadowOriginPrefix"}
-	Xrootd_Authfile                    = StringParam{"Xrootd.Authfile"}
-	Xrootd_ConfigFile                  = StringParam{"Xrootd.ConfigFile"}
-	Xrootd_DetailedMonitoringHost      = StringParam{"Xrootd.DetailedMonitoringHost"}
-	Xrootd_LocalMonitoringHost         = StringParam{"Xrootd.LocalMonitoringHost"}
-	Xrootd_MacaroonsKeyFile            = StringParam{"Xrootd.MacaroonsKeyFile"}
-	Xrootd_ManagerHost                 = StringParam{"Xrootd.ManagerHost"}
-	Xrootd_Mount                       = StringParam{"Xrootd.Mount"}
-	Xrootd_RobotsTxtFile               = StringParam{"Xrootd.RobotsTxtFile"}
-	Xrootd_RunLocation                 = StringParam{"Xrootd.RunLocation"}
-	Xrootd_ScitokensConfig             = StringParam{"Xrootd.ScitokensConfig"}
-	Xrootd_Sitename                    = StringParam{"Xrootd.Sitename"}
-	Xrootd_SummaryMonitoringHost       = StringParam{"Xrootd.SummaryMonitoringHost"}
+	Issuer_OIDCGroupClaim = StringParam{"Issuer.OIDCGroupClaim"}
+	Issuer_QDLLocation = StringParam{"Issuer.QDLLocation"}
+	Issuer_ScitokensServerLocation = StringParam{"Issuer.ScitokensServerLocation"}
+	Issuer_TomcatLocation = StringParam{"Issuer.TomcatLocation"}
+	LocalCache_DataLocation = StringParam{"LocalCache.DataLocation"}
+	LocalCache_RunLocation = StringParam{"LocalCache.RunLocation"}
+	LocalCache_Size = StringParam{"LocalCache.Size"}
+	LocalCache_Socket = StringParam{"LocalCache.Socket"}
+	Logging_Cache_Http = StringParam{"Logging.Cache.Http"}
+	Logging_Cache_Ofs = StringParam{"Logging.Cache.Ofs"}
+	Logging_Cache_Pfc = StringParam{"Logging.Cache.Pfc"}
+	Logging_Cache_Pss = StringParam{"Logging.Cache.Pss"}
+	Logging_Cache_PssSetOpt = StringParam{"Logging.Cache.PssSetOpt"}
+	Logging_Cache_Scitokens = StringParam{"Logging.Cache.Scitokens"}
+	Logging_Cache_Xrd = StringParam{"Logging.Cache.Xrd"}
+	Logging_Cache_Xrootd = StringParam{"Logging.Cache.Xrootd"}
+	Logging_Level = StringParam{"Logging.Level"}
+	Logging_LogLocation = StringParam{"Logging.LogLocation"}
+	Logging_Origin_Cms = StringParam{"Logging.Origin.Cms"}
+	Logging_Origin_Http = StringParam{"Logging.Origin.Http"}
+	Logging_Origin_Ofs = StringParam{"Logging.Origin.Ofs"}
+	Logging_Origin_Oss = StringParam{"Logging.Origin.Oss"}
+	Logging_Origin_Scitokens = StringParam{"Logging.Origin.Scitokens"}
+	Logging_Origin_Xrd = StringParam{"Logging.Origin.Xrd"}
+	Logging_Origin_Xrootd = StringParam{"Logging.Origin.Xrootd"}
+	Lotman_DbLocation = StringParam{"Lotman.DbLocation"}
+	Lotman_EnabledPolicy = StringParam{"Lotman.EnabledPolicy"}
+	Lotman_LibLocation = StringParam{"Lotman.LibLocation"}
+	Lotman_LotHome = StringParam{"Lotman.LotHome"}
+	Monitoring_DataLocation = StringParam{"Monitoring.DataLocation"}
+	OIDC_AuthorizationEndpoint = StringParam{"OIDC.AuthorizationEndpoint"}
+	OIDC_ClientID = StringParam{"OIDC.ClientID"}
+	OIDC_ClientIDFile = StringParam{"OIDC.ClientIDFile"}
+	OIDC_ClientRedirectHostname = StringParam{"OIDC.ClientRedirectHostname"}
+	OIDC_ClientSecretFile = StringParam{"OIDC.ClientSecretFile"}
+	OIDC_DeviceAuthEndpoint = StringParam{"OIDC.DeviceAuthEndpoint"}
+	OIDC_Issuer = StringParam{"OIDC.Issuer"}
+	OIDC_TokenEndpoint = StringParam{"OIDC.TokenEndpoint"}
+	OIDC_UserInfoEndpoint = StringParam{"OIDC.UserInfoEndpoint"}
+	Origin_DbLocation = StringParam{"Origin.DbLocation"}
+	Origin_ExportVolume = StringParam{"Origin.ExportVolume"}
+	Origin_FedTokenLocation = StringParam{"Origin.FedTokenLocation"}
+	Origin_FederationPrefix = StringParam{"Origin.FederationPrefix"}
+	Origin_GlobusClientIDFile = StringParam{"Origin.GlobusClientIDFile"}
+	Origin_GlobusClientSecretFile = StringParam{"Origin.GlobusClientSecretFile"}
+	Origin_GlobusCollectionID = StringParam{"Origin.GlobusCollectionID"}
+	Origin_GlobusCollectionName = StringParam{"Origin.GlobusCollectionName"}
+	Origin_GlobusConfigLocation = StringParam{"Origin.GlobusConfigLocation"}
+	Origin_HttpAuthTokenFile = StringParam{"Origin.HttpAuthTokenFile"}
+	Origin_HttpServiceUrl = StringParam{"Origin.HttpServiceUrl"}
+	Origin_Mode = StringParam{"Origin.Mode"}
+	Origin_NamespacePrefix = StringParam{"Origin.NamespacePrefix"}
+	Origin_RunLocation = StringParam{"Origin.RunLocation"}
+	Origin_S3AccessKeyfile = StringParam{"Origin.S3AccessKeyfile"}
+	Origin_S3Bucket = StringParam{"Origin.S3Bucket"}
+	Origin_S3Region = StringParam{"Origin.S3Region"}
+	Origin_S3SecretKeyfile = StringParam{"Origin.S3SecretKeyfile"}
+	Origin_S3ServiceName = StringParam{"Origin.S3ServiceName"}
+	Origin_S3ServiceUrl = StringParam{"Origin.S3ServiceUrl"}
+	Origin_S3UrlStyle = StringParam{"Origin.S3UrlStyle"}
+	Origin_ScitokensDefaultUser = StringParam{"Origin.ScitokensDefaultUser"}
+	Origin_ScitokensNameMapFile = StringParam{"Origin.ScitokensNameMapFile"}
+	Origin_ScitokensUsernameClaim = StringParam{"Origin.ScitokensUsernameClaim"}
+	Origin_StoragePrefix = StringParam{"Origin.StoragePrefix"}
+	Origin_StorageType = StringParam{"Origin.StorageType"}
+	Origin_TokenAudience = StringParam{"Origin.TokenAudience"}
+	Origin_Url = StringParam{"Origin.Url"}
+	Origin_XRootDPrefix = StringParam{"Origin.XRootDPrefix"}
+	Origin_XRootServiceUrl = StringParam{"Origin.XRootServiceUrl"}
+	Plugin_Token = StringParam{"Plugin.Token"}
+	Registry_DbLocation = StringParam{"Registry.DbLocation"}
+	Registry_InstitutionsUrl = StringParam{"Registry.InstitutionsUrl"}
+	Server_DbLocation = StringParam{"Server.DbLocation"}
+	Server_ExternalWebUrl = StringParam{"Server.ExternalWebUrl"}
+	Server_Hostname = StringParam{"Server.Hostname"}
+	Server_IssuerHostname = StringParam{"Server.IssuerHostname"}
+	Server_IssuerJwks = StringParam{"Server.IssuerJwks"}
+	Server_IssuerUrl = StringParam{"Server.IssuerUrl"}
+	Server_SessionSecretFile = StringParam{"Server.SessionSecretFile"}
+	Server_TLSCACertificateDirectory = StringParam{"Server.TLSCACertificateDirectory"}
+	Server_TLSCACertificateFile = StringParam{"Server.TLSCACertificateFile"}
+	Server_TLSCAKey = StringParam{"Server.TLSCAKey"}
+	Server_TLSCertificate = StringParam{"Server.TLSCertificate"}
+	Server_TLSCertificateChain = StringParam{"Server.TLSCertificateChain"}
+	Server_TLSKey = StringParam{"Server.TLSKey"}
+	Server_UIActivationCodeFile = StringParam{"Server.UIActivationCodeFile"}
+	Server_UIPasswordFile = StringParam{"Server.UIPasswordFile"}
+	Server_UnprivilegedUser = StringParam{"Server.UnprivilegedUser"}
+	Server_WebConfigFile = StringParam{"Server.WebConfigFile"}
+	Server_WebHost = StringParam{"Server.WebHost"}
+	Shoveler_AMQPExchange = StringParam{"Shoveler.AMQPExchange"}
+	Shoveler_AMQPTokenLocation = StringParam{"Shoveler.AMQPTokenLocation"}
+	Shoveler_MessageQueueProtocol = StringParam{"Shoveler.MessageQueueProtocol"}
+	Shoveler_QueueDirectory = StringParam{"Shoveler.QueueDirectory"}
+	Shoveler_StompCert = StringParam{"Shoveler.StompCert"}
+	Shoveler_StompCertKey = StringParam{"Shoveler.StompCertKey"}
+	Shoveler_StompPassword = StringParam{"Shoveler.StompPassword"}
+	Shoveler_StompUsername = StringParam{"Shoveler.StompUsername"}
+	Shoveler_Topic = StringParam{"Shoveler.Topic"}
+	Shoveler_URL = StringParam{"Shoveler.URL"}
+	StagePlugin_MountPrefix = StringParam{"StagePlugin.MountPrefix"}
+	StagePlugin_OriginPrefix = StringParam{"StagePlugin.OriginPrefix"}
+	StagePlugin_ShadowOriginPrefix = StringParam{"StagePlugin.ShadowOriginPrefix"}
+	Xrootd_Authfile = StringParam{"Xrootd.Authfile"}
+	Xrootd_ConfigFile = StringParam{"Xrootd.ConfigFile"}
+	Xrootd_DetailedMonitoringHost = StringParam{"Xrootd.DetailedMonitoringHost"}
+	Xrootd_LocalMonitoringHost = StringParam{"Xrootd.LocalMonitoringHost"}
+	Xrootd_MacaroonsKeyFile = StringParam{"Xrootd.MacaroonsKeyFile"}
+	Xrootd_ManagerHost = StringParam{"Xrootd.ManagerHost"}
+	Xrootd_Mount = StringParam{"Xrootd.Mount"}
+	Xrootd_RobotsTxtFile = StringParam{"Xrootd.RobotsTxtFile"}
+	Xrootd_RunLocation = StringParam{"Xrootd.RunLocation"}
+	Xrootd_ScitokensConfig = StringParam{"Xrootd.ScitokensConfig"}
+	Xrootd_Sitename = StringParam{"Xrootd.Sitename"}
+	Xrootd_SummaryMonitoringHost = StringParam{"Xrootd.SummaryMonitoringHost"}
 )
 
 var (
-	Cache_DataLocations              = StringSliceParam{"Cache.DataLocations"}
-	Cache_MetaLocations              = StringSliceParam{"Cache.MetaLocations"}
-	Cache_PermittedNamespaces        = StringSliceParam{"Cache.PermittedNamespaces"}
-	Client_PreferredCaches           = StringSliceParam{"Client.PreferredCaches"}
-	ConfigLocations                  = StringSliceParam{"ConfigLocations"}
-	Director_CacheResponseHostnames  = StringSliceParam{"Director.CacheResponseHostnames"}
-	Director_FilteredServers         = StringSliceParam{"Director.FilteredServers"}
+	Cache_DataLocations = StringSliceParam{"Cache.DataLocations"}
+	Cache_MetaLocations = StringSliceParam{"Cache.MetaLocations"}
+	Cache_PermittedNamespaces = StringSliceParam{"Cache.PermittedNamespaces"}
+	Client_PreferredCaches = StringSliceParam{"Client.PreferredCaches"}
+	ConfigLocations = StringSliceParam{"ConfigLocations"}
+	Director_CacheResponseHostnames = StringSliceParam{"Director.CacheResponseHostnames"}
+	Director_FilteredServers = StringSliceParam{"Director.FilteredServers"}
 	Director_OriginResponseHostnames = StringSliceParam{"Director.OriginResponseHostnames"}
-	Issuer_GroupRequirements         = StringSliceParam{"Issuer.GroupRequirements"}
-	Issuer_RedirectUris              = StringSliceParam{"Issuer.RedirectUris"}
-	Monitoring_AggregatePrefixes     = StringSliceParam{"Monitoring.AggregatePrefixes"}
-	Origin_ExportVolumes             = StringSliceParam{"Origin.ExportVolumes"}
-	Origin_ScitokensRestrictedPaths  = StringSliceParam{"Origin.ScitokensRestrictedPaths"}
-	Registry_AdminUsers              = StringSliceParam{"Registry.AdminUsers"}
-	Server_DirectorUrls              = StringSliceParam{"Server.DirectorUrls"}
-	Server_Modules                   = StringSliceParam{"Server.Modules"}
-	Server_UIAdminUsers              = StringSliceParam{"Server.UIAdminUsers"}
-	Shoveler_OutputDestinations      = StringSliceParam{"Shoveler.OutputDestinations"}
+	Issuer_GroupRequirements = StringSliceParam{"Issuer.GroupRequirements"}
+	Issuer_RedirectUris = StringSliceParam{"Issuer.RedirectUris"}
+	Monitoring_AggregatePrefixes = StringSliceParam{"Monitoring.AggregatePrefixes"}
+	Origin_ExportVolumes = StringSliceParam{"Origin.ExportVolumes"}
+	Origin_ScitokensRestrictedPaths = StringSliceParam{"Origin.ScitokensRestrictedPaths"}
+	Registry_AdminUsers = StringSliceParam{"Registry.AdminUsers"}
+	Server_DirectorUrls = StringSliceParam{"Server.DirectorUrls"}
+	Server_Modules = StringSliceParam{"Server.Modules"}
+	Server_UIAdminUsers = StringSliceParam{"Server.UIAdminUsers"}
+	Shoveler_OutputDestinations = StringSliceParam{"Shoveler.OutputDestinations"}
 )
 
 var (
-	Cache_BlocksToPrefetch             = IntParam{"Cache.BlocksToPrefetch"}
-	Cache_Concurrency                  = IntParam{"Cache.Concurrency"}
-	Cache_Port                         = IntParam{"Cache.Port"}
-	Client_DirectorRetries             = IntParam{"Client.DirectorRetries"}
-	Client_MaximumDownloadSpeed        = IntParam{"Client.MaximumDownloadSpeed"}
-	Client_MinimumDownloadSpeed        = IntParam{"Client.MinimumDownloadSpeed"}
-	Client_WorkerCount                 = IntParam{"Client.WorkerCount"}
-	Director_CachePresenceCapacity     = IntParam{"Director.CachePresenceCapacity"}
-	Director_MaxStatResponse           = IntParam{"Director.MaxStatResponse"}
-	Director_MinStatResponse           = IntParam{"Director.MinStatResponse"}
-	Director_StatConcurrencyLimit      = IntParam{"Director.StatConcurrencyLimit"}
+	Cache_BlocksToPrefetch = IntParam{"Cache.BlocksToPrefetch"}
+	Cache_Concurrency = IntParam{"Cache.Concurrency"}
+	Cache_Port = IntParam{"Cache.Port"}
+	Client_DirectorRetries = IntParam{"Client.DirectorRetries"}
+	Client_MaximumDownloadSpeed = IntParam{"Client.MaximumDownloadSpeed"}
+	Client_MinimumDownloadSpeed = IntParam{"Client.MinimumDownloadSpeed"}
+	Client_WorkerCount = IntParam{"Client.WorkerCount"}
+	Director_CachePresenceCapacity = IntParam{"Director.CachePresenceCapacity"}
+	Director_MaxStatResponse = IntParam{"Director.MaxStatResponse"}
+	Director_MinStatResponse = IntParam{"Director.MinStatResponse"}
+	Director_StatConcurrencyLimit = IntParam{"Director.StatConcurrencyLimit"}
 	LocalCache_HighWaterMarkPercentage = IntParam{"LocalCache.HighWaterMarkPercentage"}
-	LocalCache_LowWaterMarkPercentage  = IntParam{"LocalCache.LowWaterMarkPercentage"}
-	MinimumDownloadSpeed               = IntParam{"MinimumDownloadSpeed"}
-	Monitoring_LabelLimit              = IntParam{"Monitoring.LabelLimit"}
-	Monitoring_LabelNameLengthLimit    = IntParam{"Monitoring.LabelNameLengthLimit"}
-	Monitoring_LabelValueLengthLimit   = IntParam{"Monitoring.LabelValueLengthLimit"}
-	Monitoring_PortHigher              = IntParam{"Monitoring.PortHigher"}
-	Monitoring_PortLower               = IntParam{"Monitoring.PortLower"}
-	Monitoring_SampleLimit             = IntParam{"Monitoring.SampleLimit"}
-	Origin_Concurrency                 = IntParam{"Origin.Concurrency"}
-	Origin_Port                        = IntParam{"Origin.Port"}
-	Server_IssuerPort                  = IntParam{"Server.IssuerPort"}
-	Server_UILoginRateLimit            = IntParam{"Server.UILoginRateLimit"}
-	Server_WebPort                     = IntParam{"Server.WebPort"}
-	Shoveler_PortHigher                = IntParam{"Shoveler.PortHigher"}
-	Shoveler_PortLower                 = IntParam{"Shoveler.PortLower"}
-	Transport_MaxIdleConns             = IntParam{"Transport.MaxIdleConns"}
-	Xrootd_DetailedMonitoringPort      = IntParam{"Xrootd.DetailedMonitoringPort"}
-	Xrootd_ManagerPort                 = IntParam{"Xrootd.ManagerPort"}
-	Xrootd_Port                        = IntParam{"Xrootd.Port"}
-	Xrootd_SummaryMonitoringPort       = IntParam{"Xrootd.SummaryMonitoringPort"}
+	LocalCache_LowWaterMarkPercentage = IntParam{"LocalCache.LowWaterMarkPercentage"}
+	MinimumDownloadSpeed = IntParam{"MinimumDownloadSpeed"}
+	Monitoring_LabelLimit = IntParam{"Monitoring.LabelLimit"}
+	Monitoring_LabelNameLengthLimit = IntParam{"Monitoring.LabelNameLengthLimit"}
+	Monitoring_LabelValueLengthLimit = IntParam{"Monitoring.LabelValueLengthLimit"}
+	Monitoring_PortHigher = IntParam{"Monitoring.PortHigher"}
+	Monitoring_PortLower = IntParam{"Monitoring.PortLower"}
+	Monitoring_SampleLimit = IntParam{"Monitoring.SampleLimit"}
+	Origin_Concurrency = IntParam{"Origin.Concurrency"}
+	Origin_Port = IntParam{"Origin.Port"}
+	Server_IssuerPort = IntParam{"Server.IssuerPort"}
+	Server_UILoginRateLimit = IntParam{"Server.UILoginRateLimit"}
+	Server_WebPort = IntParam{"Server.WebPort"}
+	Shoveler_PortHigher = IntParam{"Shoveler.PortHigher"}
+	Shoveler_PortLower = IntParam{"Shoveler.PortLower"}
+	Transport_MaxIdleConns = IntParam{"Transport.MaxIdleConns"}
+	Xrootd_DetailedMonitoringPort = IntParam{"Xrootd.DetailedMonitoringPort"}
+	Xrootd_ManagerPort = IntParam{"Xrootd.ManagerPort"}
+	Xrootd_Port = IntParam{"Xrootd.Port"}
+	Xrootd_SummaryMonitoringPort = IntParam{"Xrootd.SummaryMonitoringPort"}
 )
 
 var (
-	Cache_EnableBroker                    = BoolParam{"Cache.EnableBroker"}
-	Cache_EnableLotman                    = BoolParam{"Cache.EnableLotman"}
-	Cache_EnableOIDC                      = BoolParam{"Cache.EnableOIDC"}
-	Cache_EnablePrefetch                  = BoolParam{"Cache.EnablePrefetch"}
-	Cache_EnableTLSClientAuth             = BoolParam{"Cache.EnableTLSClientAuth"}
-	Cache_EnableVoms                      = BoolParam{"Cache.EnableVoms"}
-	Cache_SelfTest                        = BoolParam{"Cache.SelfTest"}
-	Client_AssumeDirectorServerHeader     = BoolParam{"Client.AssumeDirectorServerHeader"}
-	Client_DisableHttpProxy               = BoolParam{"Client.DisableHttpProxy"}
-	Client_DisableProxyFallback           = BoolParam{"Client.DisableProxyFallback"}
-	Client_IsPlugin                       = BoolParam{"Client.IsPlugin"}
-	Debug                                 = BoolParam{"Debug"}
+	Cache_EnableBroker = BoolParam{"Cache.EnableBroker"}
+	Cache_EnableLotman = BoolParam{"Cache.EnableLotman"}
+	Cache_EnableOIDC = BoolParam{"Cache.EnableOIDC"}
+	Cache_EnablePrefetch = BoolParam{"Cache.EnablePrefetch"}
+	Cache_EnableTLSClientAuth = BoolParam{"Cache.EnableTLSClientAuth"}
+	Cache_EnableVoms = BoolParam{"Cache.EnableVoms"}
+	Cache_SelfTest = BoolParam{"Cache.SelfTest"}
+	Client_AssumeDirectorServerHeader = BoolParam{"Client.AssumeDirectorServerHeader"}
+	Client_DisableHttpProxy = BoolParam{"Client.DisableHttpProxy"}
+	Client_DisableProxyFallback = BoolParam{"Client.DisableProxyFallback"}
+	Client_IsPlugin = BoolParam{"Client.IsPlugin"}
+	Debug = BoolParam{"Debug"}
 	Director_AssumePresenceAtSingleOrigin = BoolParam{"Director.AssumePresenceAtSingleOrigin"}
-	Director_CachesPullFromCaches         = BoolParam{"Director.CachesPullFromCaches"}
-	Director_CheckCachePresence           = BoolParam{"Director.CheckCachePresence"}
-	Director_CheckOriginPresence          = BoolParam{"Director.CheckOriginPresence"}
-	Director_EnableBroker                 = BoolParam{"Director.EnableBroker"}
-	Director_EnableOIDC                   = BoolParam{"Director.EnableOIDC"}
-	Director_EnableStat                   = BoolParam{"Director.EnableStat"}
-	DisableHttpProxy                      = BoolParam{"DisableHttpProxy"}
-	DisableProxyFallback                  = BoolParam{"DisableProxyFallback"}
-	Issuer_OIDCPreferClaimsFromIDToken    = BoolParam{"Issuer.OIDCPreferClaimsFromIDToken"}
-	Issuer_UserStripDomain                = BoolParam{"Issuer.UserStripDomain"}
-	Logging_DisableProgressBars           = BoolParam{"Logging.DisableProgressBars"}
-	Lotman_EnableAPI                      = BoolParam{"Lotman.EnableAPI"}
-	Monitoring_MetricAuthorization        = BoolParam{"Monitoring.MetricAuthorization"}
-	Monitoring_PromQLAuthorization        = BoolParam{"Monitoring.PromQLAuthorization"}
-	Origin_DirectorTest                   = BoolParam{"Origin.DirectorTest"}
-	Origin_DisableDirectClients           = BoolParam{"Origin.DisableDirectClients"}
-	Origin_EnableBroker                   = BoolParam{"Origin.EnableBroker"}
-	Origin_EnableCmsd                     = BoolParam{"Origin.EnableCmsd"}
-	Origin_EnableDirListing               = BoolParam{"Origin.EnableDirListing"}
-	Origin_EnableDirectReads              = BoolParam{"Origin.EnableDirectReads"}
-	Origin_EnableFallbackRead             = BoolParam{"Origin.EnableFallbackRead"}
-	Origin_EnableIssuer                   = BoolParam{"Origin.EnableIssuer"}
-	Origin_EnableListings                 = BoolParam{"Origin.EnableListings"}
-	Origin_EnableMacaroons                = BoolParam{"Origin.EnableMacaroons"}
-	Origin_EnableOIDC                     = BoolParam{"Origin.EnableOIDC"}
-	Origin_EnablePublicReads              = BoolParam{"Origin.EnablePublicReads"}
-	Origin_EnableReads                    = BoolParam{"Origin.EnableReads"}
-	Origin_EnableUI                       = BoolParam{"Origin.EnableUI"}
-	Origin_EnableVoms                     = BoolParam{"Origin.EnableVoms"}
-	Origin_EnableWrite                    = BoolParam{"Origin.EnableWrite"}
-	Origin_EnableWrites                   = BoolParam{"Origin.EnableWrites"}
-	Origin_Multiuser                      = BoolParam{"Origin.Multiuser"}
-	Origin_ScitokensMapSubject            = BoolParam{"Origin.ScitokensMapSubject"}
-	Origin_SelfTest                       = BoolParam{"Origin.SelfTest"}
-	Registry_RequireCacheApproval         = BoolParam{"Registry.RequireCacheApproval"}
-	Registry_RequireKeyChaining           = BoolParam{"Registry.RequireKeyChaining"}
-	Registry_RequireOriginApproval        = BoolParam{"Registry.RequireOriginApproval"}
-	Server_DropPrivileges                 = BoolParam{"Server.DropPrivileges"}
-	Server_EnablePprof                    = BoolParam{"Server.EnablePprof"}
-	Server_EnableUI                       = BoolParam{"Server.EnableUI"}
-	Server_HealthMonitoringPublic         = BoolParam{"Server.HealthMonitoringPublic"}
-	Shoveler_Enable                       = BoolParam{"Shoveler.Enable"}
-	Shoveler_VerifyHeader                 = BoolParam{"Shoveler.VerifyHeader"}
-	StagePlugin_Hook                      = BoolParam{"StagePlugin.Hook"}
-	TLSSkipVerify                         = BoolParam{"TLSSkipVerify"}
-	Topology_DisableCacheX509             = BoolParam{"Topology.DisableCacheX509"}
-	Topology_DisableCaches                = BoolParam{"Topology.DisableCaches"}
-	Topology_DisableDowntime              = BoolParam{"Topology.DisableDowntime"}
-	Topology_DisableOriginX509            = BoolParam{"Topology.DisableOriginX509"}
-	Topology_DisableOrigins               = BoolParam{"Topology.DisableOrigins"}
-	Xrootd_EnableLocalMonitoring          = BoolParam{"Xrootd.EnableLocalMonitoring"}
+	Director_CachesPullFromCaches = BoolParam{"Director.CachesPullFromCaches"}
+	Director_CheckCachePresence = BoolParam{"Director.CheckCachePresence"}
+	Director_CheckOriginPresence = BoolParam{"Director.CheckOriginPresence"}
+	Director_EnableBroker = BoolParam{"Director.EnableBroker"}
+	Director_EnableOIDC = BoolParam{"Director.EnableOIDC"}
+	Director_EnableStat = BoolParam{"Director.EnableStat"}
+	DisableHttpProxy = BoolParam{"DisableHttpProxy"}
+	DisableProxyFallback = BoolParam{"DisableProxyFallback"}
+	Issuer_OIDCPreferClaimsFromIDToken = BoolParam{"Issuer.OIDCPreferClaimsFromIDToken"}
+	Issuer_UserStripDomain = BoolParam{"Issuer.UserStripDomain"}
+	Logging_DisableProgressBars = BoolParam{"Logging.DisableProgressBars"}
+	Lotman_EnableAPI = BoolParam{"Lotman.EnableAPI"}
+	Monitoring_MetricAuthorization = BoolParam{"Monitoring.MetricAuthorization"}
+	Monitoring_PromQLAuthorization = BoolParam{"Monitoring.PromQLAuthorization"}
+	Origin_DirectorTest = BoolParam{"Origin.DirectorTest"}
+	Origin_DisableDirectClients = BoolParam{"Origin.DisableDirectClients"}
+	Origin_EnableBroker = BoolParam{"Origin.EnableBroker"}
+	Origin_EnableCmsd = BoolParam{"Origin.EnableCmsd"}
+	Origin_EnableDirListing = BoolParam{"Origin.EnableDirListing"}
+	Origin_EnableDirectReads = BoolParam{"Origin.EnableDirectReads"}
+	Origin_EnableFallbackRead = BoolParam{"Origin.EnableFallbackRead"}
+	Origin_EnableIssuer = BoolParam{"Origin.EnableIssuer"}
+	Origin_EnableListings = BoolParam{"Origin.EnableListings"}
+	Origin_EnableMacaroons = BoolParam{"Origin.EnableMacaroons"}
+	Origin_EnableOIDC = BoolParam{"Origin.EnableOIDC"}
+	Origin_EnablePublicReads = BoolParam{"Origin.EnablePublicReads"}
+	Origin_EnableReads = BoolParam{"Origin.EnableReads"}
+	Origin_EnableUI = BoolParam{"Origin.EnableUI"}
+	Origin_EnableVoms = BoolParam{"Origin.EnableVoms"}
+	Origin_EnableWrite = BoolParam{"Origin.EnableWrite"}
+	Origin_EnableWrites = BoolParam{"Origin.EnableWrites"}
+	Origin_Multiuser = BoolParam{"Origin.Multiuser"}
+	Origin_ScitokensMapSubject = BoolParam{"Origin.ScitokensMapSubject"}
+	Origin_SelfTest = BoolParam{"Origin.SelfTest"}
+	Registry_RequireCacheApproval = BoolParam{"Registry.RequireCacheApproval"}
+	Registry_RequireKeyChaining = BoolParam{"Registry.RequireKeyChaining"}
+	Registry_RequireOriginApproval = BoolParam{"Registry.RequireOriginApproval"}
+	Server_DropPrivileges = BoolParam{"Server.DropPrivileges"}
+	Server_EnablePprof = BoolParam{"Server.EnablePprof"}
+	Server_EnableUI = BoolParam{"Server.EnableUI"}
+	Server_HealthMonitoringPublic = BoolParam{"Server.HealthMonitoringPublic"}
+	Shoveler_Enable = BoolParam{"Shoveler.Enable"}
+	Shoveler_VerifyHeader = BoolParam{"Shoveler.VerifyHeader"}
+	StagePlugin_Hook = BoolParam{"StagePlugin.Hook"}
+	TLSSkipVerify = BoolParam{"TLSSkipVerify"}
+	Topology_DisableCacheX509 = BoolParam{"Topology.DisableCacheX509"}
+	Topology_DisableCaches = BoolParam{"Topology.DisableCaches"}
+	Topology_DisableDowntime = BoolParam{"Topology.DisableDowntime"}
+	Topology_DisableOriginX509 = BoolParam{"Topology.DisableOriginX509"}
+	Topology_DisableOrigins = BoolParam{"Topology.DisableOrigins"}
+	Xrootd_EnableLocalMonitoring = BoolParam{"Xrootd.EnableLocalMonitoring"}
 )
 
 var (
-	Cache_DefaultCacheTimeout              = DurationParam{"Cache.DefaultCacheTimeout"}
-	Cache_SelfTestInterval                 = DurationParam{"Cache.SelfTestInterval"}
-	Client_SlowTransferRampupTime          = DurationParam{"Client.SlowTransferRampupTime"}
-	Client_SlowTransferWindow              = DurationParam{"Client.SlowTransferWindow"}
-	Client_StoppedTransferTimeout          = DurationParam{"Client.StoppedTransferTimeout"}
-	Director_AdvertisementTTL              = DurationParam{"Director.AdvertisementTTL"}
-	Director_CachePresenceTTL              = DurationParam{"Director.CachePresenceTTL"}
-	Director_FedTokenLifetime              = DurationParam{"Director.FedTokenLifetime"}
+	Cache_DefaultCacheTimeout = DurationParam{"Cache.DefaultCacheTimeout"}
+	Cache_SelfTestInterval = DurationParam{"Cache.SelfTestInterval"}
+	Client_SlowTransferRampupTime = DurationParam{"Client.SlowTransferRampupTime"}
+	Client_SlowTransferWindow = DurationParam{"Client.SlowTransferWindow"}
+	Client_StoppedTransferTimeout = DurationParam{"Client.StoppedTransferTimeout"}
+	Director_AdvertisementTTL = DurationParam{"Director.AdvertisementTTL"}
+	Director_CachePresenceTTL = DurationParam{"Director.CachePresenceTTL"}
+	Director_FedTokenLifetime = DurationParam{"Director.FedTokenLifetime"}
 	Director_OriginCacheHealthTestInterval = DurationParam{"Director.OriginCacheHealthTestInterval"}
-	Director_RegistryQueryInterval         = DurationParam{"Director.RegistryQueryInterval"}
-	Director_StatTimeout                   = DurationParam{"Director.StatTimeout"}
-	Federation_TopologyReloadInterval      = DurationParam{"Federation.TopologyReloadInterval"}
-	Logging_Client_ProgressInterval        = DurationParam{"Logging.Client.ProgressInterval"}
-	Lotman_DefaultLotDeletionLifetime      = DurationParam{"Lotman.DefaultLotDeletionLifetime"}
-	Lotman_DefaultLotExpirationLifetime    = DurationParam{"Lotman.DefaultLotExpirationLifetime"}
-	Monitoring_DataRetention               = DurationParam{"Monitoring.DataRetention"}
-	Monitoring_TokenExpiresIn              = DurationParam{"Monitoring.TokenExpiresIn"}
-	Monitoring_TokenRefreshInterval        = DurationParam{"Monitoring.TokenRefreshInterval"}
-	Origin_SelfTestInterval                = DurationParam{"Origin.SelfTestInterval"}
-	Registry_InstitutionsUrlReloadMinutes  = DurationParam{"Registry.InstitutionsUrlReloadMinutes"}
-	Server_AdLifetime                      = DurationParam{"Server.AdLifetime"}
-	Server_AdvertisementInterval           = DurationParam{"Server.AdvertisementInterval"}
-	Server_RegistrationRetryInterval       = DurationParam{"Server.RegistrationRetryInterval"}
-	Server_StartupTimeout                  = DurationParam{"Server.StartupTimeout"}
-	Transport_BrokerEndpointCacheTTL       = DurationParam{"Transport.BrokerEndpointCacheTTL"}
-	Transport_DialerKeepAlive              = DurationParam{"Transport.DialerKeepAlive"}
-	Transport_DialerTimeout                = DurationParam{"Transport.DialerTimeout"}
-	Transport_ExpectContinueTimeout        = DurationParam{"Transport.ExpectContinueTimeout"}
-	Transport_IdleConnTimeout              = DurationParam{"Transport.IdleConnTimeout"}
-	Transport_ResponseHeaderTimeout        = DurationParam{"Transport.ResponseHeaderTimeout"}
-	Transport_TLSHandshakeTimeout          = DurationParam{"Transport.TLSHandshakeTimeout"}
-	Xrootd_AuthRefreshInterval             = DurationParam{"Xrootd.AuthRefreshInterval"}
-	Xrootd_MaxStartupWait                  = DurationParam{"Xrootd.MaxStartupWait"}
-	Xrootd_ShutdownTimeout                 = DurationParam{"Xrootd.ShutdownTimeout"}
+	Director_RegistryQueryInterval = DurationParam{"Director.RegistryQueryInterval"}
+	Director_StatTimeout = DurationParam{"Director.StatTimeout"}
+	Federation_TopologyReloadInterval = DurationParam{"Federation.TopologyReloadInterval"}
+	Logging_Client_ProgressInterval = DurationParam{"Logging.Client.ProgressInterval"}
+	Lotman_DefaultLotDeletionLifetime = DurationParam{"Lotman.DefaultLotDeletionLifetime"}
+	Lotman_DefaultLotExpirationLifetime = DurationParam{"Lotman.DefaultLotExpirationLifetime"}
+	Monitoring_DataRetention = DurationParam{"Monitoring.DataRetention"}
+	Monitoring_TokenExpiresIn = DurationParam{"Monitoring.TokenExpiresIn"}
+	Monitoring_TokenRefreshInterval = DurationParam{"Monitoring.TokenRefreshInterval"}
+	Origin_SelfTestInterval = DurationParam{"Origin.SelfTestInterval"}
+	Registry_InstitutionsUrlReloadMinutes = DurationParam{"Registry.InstitutionsUrlReloadMinutes"}
+	Server_AdLifetime = DurationParam{"Server.AdLifetime"}
+	Server_AdvertisementInterval = DurationParam{"Server.AdvertisementInterval"}
+	Server_RegistrationRetryInterval = DurationParam{"Server.RegistrationRetryInterval"}
+	Server_StartupTimeout = DurationParam{"Server.StartupTimeout"}
+	Transport_BrokerEndpointCacheTTL = DurationParam{"Transport.BrokerEndpointCacheTTL"}
+	Transport_DialerKeepAlive = DurationParam{"Transport.DialerKeepAlive"}
+	Transport_DialerTimeout = DurationParam{"Transport.DialerTimeout"}
+	Transport_ExpectContinueTimeout = DurationParam{"Transport.ExpectContinueTimeout"}
+	Transport_IdleConnTimeout = DurationParam{"Transport.IdleConnTimeout"}
+	Transport_ResponseHeaderTimeout = DurationParam{"Transport.ResponseHeaderTimeout"}
+	Transport_TLSHandshakeTimeout = DurationParam{"Transport.TLSHandshakeTimeout"}
+	Xrootd_AuthRefreshInterval = DurationParam{"Xrootd.AuthRefreshInterval"}
+	Xrootd_MaxStartupWait = DurationParam{"Xrootd.MaxStartupWait"}
+	Xrootd_ShutdownTimeout = DurationParam{"Xrootd.ShutdownTimeout"}
 )
 
 var (
-	GeoIPOverrides                        = ObjectParam{"GeoIPOverrides"}
-	Issuer_AuthorizationTemplates         = ObjectParam{"Issuer.AuthorizationTemplates"}
+	GeoIPOverrides = ObjectParam{"GeoIPOverrides"}
+	Issuer_AuthorizationTemplates = ObjectParam{"Issuer.AuthorizationTemplates"}
 	Issuer_OIDCAuthenticationRequirements = ObjectParam{"Issuer.OIDCAuthenticationRequirements"}
-	Lotman_PolicyDefinitions              = ObjectParam{"Lotman.PolicyDefinitions"}
-	Origin_Exports                        = ObjectParam{"Origin.Exports"}
-	Registry_CustomRegistrationFields     = ObjectParam{"Registry.CustomRegistrationFields"}
-	Registry_Institutions                 = ObjectParam{"Registry.Institutions"}
-	Shoveler_IPMapping                    = ObjectParam{"Shoveler.IPMapping"}
+	Lotman_PolicyDefinitions = ObjectParam{"Lotman.PolicyDefinitions"}
+	Origin_Exports = ObjectParam{"Origin.Exports"}
+	Registry_CustomRegistrationFields = ObjectParam{"Registry.CustomRegistrationFields"}
+	Registry_Institutions = ObjectParam{"Registry.Institutions"}
+	Shoveler_IPMapping = ObjectParam{"Shoveler.IPMapping"}
 )

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -50,27 +50,27 @@ type ObjectParam struct {
 }
 
 func GetDeprecated() map[string][]string {
-    return map[string][]string{
-        "Cache.DataLocation": {"Cache.StorageLocation"},
-        "Cache.LocalRoot": {"Cache.StorageLocation"},
-        "Director.EnableStat": {"Director.CheckOriginPresence"},
-        "DisableHttpProxy": {"Client.DisableHttpProxy"},
-        "DisableProxyFallback": {"Client.DisableProxyFallback"},
-        "IssuerKey": {"none"},
-        "Lotman.DbLocation": {"Lotman.LotHome"},
-        "MinimumDownloadSpeed": {"Client.MinimumDownloadSpeed"},
-        "Origin.EnableDirListing": {"Origin.EnableListings"},
-        "Origin.EnableFallbackRead": {"Origin.EnableDirectReads"},
-        "Origin.EnableWrite": {"Origin.EnableWrites"},
-        "Origin.ExportVolume": {"Origin.ExportVolumes"},
-        "Origin.Mode": {"Origin.StorageType"},
-        "Origin.NamespacePrefix": {"Origin.FederationPrefix"},
-        "Origin.S3ServiceName": {"none"},
-        "Registry.AdminUsers": {"Server.UIAdminUsers"},
-        "Server.TLSCertificate": {"Server.TLSCertificateChain"},
-        "Xrootd.Port": {"Origin.Port", "Cache.Port"},
-        "Xrootd.RunLocation": {"Cache.RunLocation", "Origin.RunLocation"},
-    }
+	return map[string][]string{
+		"Cache.DataLocation":        {"Cache.StorageLocation"},
+		"Cache.LocalRoot":           {"Cache.StorageLocation"},
+		"Director.EnableStat":       {"Director.CheckOriginPresence"},
+		"DisableHttpProxy":          {"Client.DisableHttpProxy"},
+		"DisableProxyFallback":      {"Client.DisableProxyFallback"},
+		"IssuerKey":                 {"none"},
+		"Lotman.DbLocation":         {"Lotman.LotHome"},
+		"MinimumDownloadSpeed":      {"Client.MinimumDownloadSpeed"},
+		"Origin.EnableDirListing":   {"Origin.EnableListings"},
+		"Origin.EnableFallbackRead": {"Origin.EnableDirectReads"},
+		"Origin.EnableWrite":        {"Origin.EnableWrites"},
+		"Origin.ExportVolume":       {"Origin.ExportVolumes"},
+		"Origin.Mode":               {"Origin.StorageType"},
+		"Origin.NamespacePrefix":    {"Origin.FederationPrefix"},
+		"Origin.S3ServiceName":      {"none"},
+		"Registry.AdminUsers":       {"Server.UIAdminUsers"},
+		"Server.TLSCertificate":     {"Server.TLSCertificateChain"},
+		"Xrootd.Port":               {"Origin.Port", "Cache.Port"},
+		"Xrootd.RunLocation":        {"Cache.RunLocation", "Origin.RunLocation"},
+	}
 }
 
 func (sP StringParam) GetString() string {
@@ -146,324 +146,325 @@ func (oP ObjectParam) IsSet() bool {
 }
 
 var (
-	Cache_DataLocation = StringParam{"Cache.DataLocation"}
-	Cache_DbLocation = StringParam{"Cache.DbLocation"}
-	Cache_ExportLocation = StringParam{"Cache.ExportLocation"}
-	Cache_FedTokenLocation = StringParam{"Cache.FedTokenLocation"}
-	Cache_FilesBaseSize = StringParam{"Cache.FilesBaseSize"}
-	Cache_FilesMaxSize = StringParam{"Cache.FilesMaxSize"}
-	Cache_FilesNominalSize = StringParam{"Cache.FilesNominalSize"}
-	Cache_HighWaterMark = StringParam{"Cache.HighWaterMark"}
-	Cache_LocalRoot = StringParam{"Cache.LocalRoot"}
-	Cache_LowWatermark = StringParam{"Cache.LowWatermark"}
-	Cache_NamespaceLocation = StringParam{"Cache.NamespaceLocation"}
-	Cache_RunLocation = StringParam{"Cache.RunLocation"}
-	Cache_SentinelLocation = StringParam{"Cache.SentinelLocation"}
-	Cache_StorageLocation = StringParam{"Cache.StorageLocation"}
-	Cache_Url = StringParam{"Cache.Url"}
-	Cache_XRootDPrefix = StringParam{"Cache.XRootDPrefix"}
-	Director_AdvertiseUrl = StringParam{"Director.AdvertiseUrl"}
-	Director_CacheSortMethod = StringParam{"Director.CacheSortMethod"}
-	Director_DbLocation = StringParam{"Director.DbLocation"}
-	Director_DefaultResponse = StringParam{"Director.DefaultResponse"}
-	Director_GeoIPLocation = StringParam{"Director.GeoIPLocation"}
-	Director_MaxMindKeyFile = StringParam{"Director.MaxMindKeyFile"}
-	Director_SupportContactEmail = StringParam{"Director.SupportContactEmail"}
-	Director_SupportContactUrl = StringParam{"Director.SupportContactUrl"}
-	Federation_DiscoveryUrl = StringParam{"Federation.DiscoveryUrl"}
-	Federation_TopologyDowntimeUrl = StringParam{"Federation.TopologyDowntimeUrl"}
-	Federation_TopologyNamespaceUrl = StringParam{"Federation.TopologyNamespaceUrl"}
-	Federation_TopologyUrl = StringParam{"Federation.TopologyUrl"}
-	IssuerKey = StringParam{"IssuerKey"}
-	IssuerKeysDirectory = StringParam{"IssuerKeysDirectory"}
-	Issuer_AuthenticationSource = StringParam{"Issuer.AuthenticationSource"}
-	Issuer_GroupFile = StringParam{"Issuer.GroupFile"}
-	Issuer_GroupSource = StringParam{"Issuer.GroupSource"}
-	Issuer_IssuerClaimValue = StringParam{"Issuer.IssuerClaimValue"}
+	Cache_DataLocation                 = StringParam{"Cache.DataLocation"}
+	Cache_DbLocation                   = StringParam{"Cache.DbLocation"}
+	Cache_ExportLocation               = StringParam{"Cache.ExportLocation"}
+	Cache_FedTokenLocation             = StringParam{"Cache.FedTokenLocation"}
+	Cache_FilesBaseSize                = StringParam{"Cache.FilesBaseSize"}
+	Cache_FilesMaxSize                 = StringParam{"Cache.FilesMaxSize"}
+	Cache_FilesNominalSize             = StringParam{"Cache.FilesNominalSize"}
+	Cache_HighWaterMark                = StringParam{"Cache.HighWaterMark"}
+	Cache_LocalRoot                    = StringParam{"Cache.LocalRoot"}
+	Cache_LowWatermark                 = StringParam{"Cache.LowWatermark"}
+	Cache_NamespaceLocation            = StringParam{"Cache.NamespaceLocation"}
+	Cache_RunLocation                  = StringParam{"Cache.RunLocation"}
+	Cache_SentinelLocation             = StringParam{"Cache.SentinelLocation"}
+	Cache_StorageLocation              = StringParam{"Cache.StorageLocation"}
+	Cache_Url                          = StringParam{"Cache.Url"}
+	Cache_XRootDPrefix                 = StringParam{"Cache.XRootDPrefix"}
+	Director_AdvertiseUrl              = StringParam{"Director.AdvertiseUrl"}
+	Director_CacheSortMethod           = StringParam{"Director.CacheSortMethod"}
+	Director_DbLocation                = StringParam{"Director.DbLocation"}
+	Director_DefaultResponse           = StringParam{"Director.DefaultResponse"}
+	Director_GeoIPLocation             = StringParam{"Director.GeoIPLocation"}
+	Director_MaxMindKeyFile            = StringParam{"Director.MaxMindKeyFile"}
+	Director_SupportContactEmail       = StringParam{"Director.SupportContactEmail"}
+	Director_SupportContactUrl         = StringParam{"Director.SupportContactUrl"}
+	Federation_DiscoveryUrl            = StringParam{"Federation.DiscoveryUrl"}
+	Federation_TopologyDowntimeUrl     = StringParam{"Federation.TopologyDowntimeUrl"}
+	Federation_TopologyNamespaceUrl    = StringParam{"Federation.TopologyNamespaceUrl"}
+	Federation_TopologyUrl             = StringParam{"Federation.TopologyUrl"}
+	IssuerKey                          = StringParam{"IssuerKey"}
+	IssuerKeysDirectory                = StringParam{"IssuerKeysDirectory"}
+	Issuer_AuthenticationSource        = StringParam{"Issuer.AuthenticationSource"}
+	Issuer_GroupFile                   = StringParam{"Issuer.GroupFile"}
+	Issuer_GroupSource                 = StringParam{"Issuer.GroupSource"}
+	Issuer_IssuerClaimValue            = StringParam{"Issuer.IssuerClaimValue"}
 	Issuer_OIDCAuthenticationUserClaim = StringParam{"Issuer.OIDCAuthenticationUserClaim"}
-	Issuer_OIDCGroupClaim = StringParam{"Issuer.OIDCGroupClaim"}
-	Issuer_QDLLocation = StringParam{"Issuer.QDLLocation"}
-	Issuer_ScitokensServerLocation = StringParam{"Issuer.ScitokensServerLocation"}
-	Issuer_TomcatLocation = StringParam{"Issuer.TomcatLocation"}
-	LocalCache_DataLocation = StringParam{"LocalCache.DataLocation"}
-	LocalCache_RunLocation = StringParam{"LocalCache.RunLocation"}
-	LocalCache_Size = StringParam{"LocalCache.Size"}
-	LocalCache_Socket = StringParam{"LocalCache.Socket"}
-	Logging_Cache_Http = StringParam{"Logging.Cache.Http"}
-	Logging_Cache_Ofs = StringParam{"Logging.Cache.Ofs"}
-	Logging_Cache_Pfc = StringParam{"Logging.Cache.Pfc"}
-	Logging_Cache_Pss = StringParam{"Logging.Cache.Pss"}
-	Logging_Cache_PssSetOpt = StringParam{"Logging.Cache.PssSetOpt"}
-	Logging_Cache_Scitokens = StringParam{"Logging.Cache.Scitokens"}
-	Logging_Cache_Xrd = StringParam{"Logging.Cache.Xrd"}
-	Logging_Cache_Xrootd = StringParam{"Logging.Cache.Xrootd"}
-	Logging_Level = StringParam{"Logging.Level"}
-	Logging_LogLocation = StringParam{"Logging.LogLocation"}
-	Logging_Origin_Cms = StringParam{"Logging.Origin.Cms"}
-	Logging_Origin_Http = StringParam{"Logging.Origin.Http"}
-	Logging_Origin_Ofs = StringParam{"Logging.Origin.Ofs"}
-	Logging_Origin_Oss = StringParam{"Logging.Origin.Oss"}
-	Logging_Origin_Scitokens = StringParam{"Logging.Origin.Scitokens"}
-	Logging_Origin_Xrd = StringParam{"Logging.Origin.Xrd"}
-	Logging_Origin_Xrootd = StringParam{"Logging.Origin.Xrootd"}
-	Lotman_DbLocation = StringParam{"Lotman.DbLocation"}
-	Lotman_EnabledPolicy = StringParam{"Lotman.EnabledPolicy"}
-	Lotman_LibLocation = StringParam{"Lotman.LibLocation"}
-	Lotman_LotHome = StringParam{"Lotman.LotHome"}
-	Monitoring_DataLocation = StringParam{"Monitoring.DataLocation"}
-	OIDC_AuthorizationEndpoint = StringParam{"OIDC.AuthorizationEndpoint"}
-	OIDC_ClientID = StringParam{"OIDC.ClientID"}
-	OIDC_ClientIDFile = StringParam{"OIDC.ClientIDFile"}
-	OIDC_ClientRedirectHostname = StringParam{"OIDC.ClientRedirectHostname"}
-	OIDC_ClientSecretFile = StringParam{"OIDC.ClientSecretFile"}
-	OIDC_DeviceAuthEndpoint = StringParam{"OIDC.DeviceAuthEndpoint"}
-	OIDC_Issuer = StringParam{"OIDC.Issuer"}
-	OIDC_TokenEndpoint = StringParam{"OIDC.TokenEndpoint"}
-	OIDC_UserInfoEndpoint = StringParam{"OIDC.UserInfoEndpoint"}
-	Origin_DbLocation = StringParam{"Origin.DbLocation"}
-	Origin_ExportVolume = StringParam{"Origin.ExportVolume"}
-	Origin_FedTokenLocation = StringParam{"Origin.FedTokenLocation"}
-	Origin_FederationPrefix = StringParam{"Origin.FederationPrefix"}
-	Origin_GlobusClientIDFile = StringParam{"Origin.GlobusClientIDFile"}
-	Origin_GlobusClientSecretFile = StringParam{"Origin.GlobusClientSecretFile"}
-	Origin_GlobusCollectionID = StringParam{"Origin.GlobusCollectionID"}
-	Origin_GlobusCollectionName = StringParam{"Origin.GlobusCollectionName"}
-	Origin_GlobusConfigLocation = StringParam{"Origin.GlobusConfigLocation"}
-	Origin_HttpAuthTokenFile = StringParam{"Origin.HttpAuthTokenFile"}
-	Origin_HttpServiceUrl = StringParam{"Origin.HttpServiceUrl"}
-	Origin_Mode = StringParam{"Origin.Mode"}
-	Origin_NamespacePrefix = StringParam{"Origin.NamespacePrefix"}
-	Origin_RunLocation = StringParam{"Origin.RunLocation"}
-	Origin_S3AccessKeyfile = StringParam{"Origin.S3AccessKeyfile"}
-	Origin_S3Bucket = StringParam{"Origin.S3Bucket"}
-	Origin_S3Region = StringParam{"Origin.S3Region"}
-	Origin_S3SecretKeyfile = StringParam{"Origin.S3SecretKeyfile"}
-	Origin_S3ServiceName = StringParam{"Origin.S3ServiceName"}
-	Origin_S3ServiceUrl = StringParam{"Origin.S3ServiceUrl"}
-	Origin_S3UrlStyle = StringParam{"Origin.S3UrlStyle"}
-	Origin_ScitokensDefaultUser = StringParam{"Origin.ScitokensDefaultUser"}
-	Origin_ScitokensNameMapFile = StringParam{"Origin.ScitokensNameMapFile"}
-	Origin_ScitokensUsernameClaim = StringParam{"Origin.ScitokensUsernameClaim"}
-	Origin_StoragePrefix = StringParam{"Origin.StoragePrefix"}
-	Origin_StorageType = StringParam{"Origin.StorageType"}
-	Origin_TokenAudience = StringParam{"Origin.TokenAudience"}
-	Origin_Url = StringParam{"Origin.Url"}
-	Origin_XRootDPrefix = StringParam{"Origin.XRootDPrefix"}
-	Origin_XRootServiceUrl = StringParam{"Origin.XRootServiceUrl"}
-	Plugin_Token = StringParam{"Plugin.Token"}
-	Registry_DbLocation = StringParam{"Registry.DbLocation"}
-	Registry_InstitutionsUrl = StringParam{"Registry.InstitutionsUrl"}
-	Server_DbLocation = StringParam{"Server.DbLocation"}
-	Server_ExternalWebUrl = StringParam{"Server.ExternalWebUrl"}
-	Server_Hostname = StringParam{"Server.Hostname"}
-	Server_IssuerHostname = StringParam{"Server.IssuerHostname"}
-	Server_IssuerJwks = StringParam{"Server.IssuerJwks"}
-	Server_IssuerUrl = StringParam{"Server.IssuerUrl"}
-	Server_SessionSecretFile = StringParam{"Server.SessionSecretFile"}
-	Server_TLSCACertificateDirectory = StringParam{"Server.TLSCACertificateDirectory"}
-	Server_TLSCACertificateFile = StringParam{"Server.TLSCACertificateFile"}
-	Server_TLSCAKey = StringParam{"Server.TLSCAKey"}
-	Server_TLSCertificate = StringParam{"Server.TLSCertificate"}
-	Server_TLSCertificateChain = StringParam{"Server.TLSCertificateChain"}
-	Server_TLSKey = StringParam{"Server.TLSKey"}
-	Server_UIActivationCodeFile = StringParam{"Server.UIActivationCodeFile"}
-	Server_UIPasswordFile = StringParam{"Server.UIPasswordFile"}
-	Server_UnprivilegedUser = StringParam{"Server.UnprivilegedUser"}
-	Server_WebConfigFile = StringParam{"Server.WebConfigFile"}
-	Server_WebHost = StringParam{"Server.WebHost"}
-	Shoveler_AMQPExchange = StringParam{"Shoveler.AMQPExchange"}
-	Shoveler_AMQPTokenLocation = StringParam{"Shoveler.AMQPTokenLocation"}
-	Shoveler_MessageQueueProtocol = StringParam{"Shoveler.MessageQueueProtocol"}
-	Shoveler_QueueDirectory = StringParam{"Shoveler.QueueDirectory"}
-	Shoveler_StompCert = StringParam{"Shoveler.StompCert"}
-	Shoveler_StompCertKey = StringParam{"Shoveler.StompCertKey"}
-	Shoveler_StompPassword = StringParam{"Shoveler.StompPassword"}
-	Shoveler_StompUsername = StringParam{"Shoveler.StompUsername"}
-	Shoveler_Topic = StringParam{"Shoveler.Topic"}
-	Shoveler_URL = StringParam{"Shoveler.URL"}
-	StagePlugin_MountPrefix = StringParam{"StagePlugin.MountPrefix"}
-	StagePlugin_OriginPrefix = StringParam{"StagePlugin.OriginPrefix"}
-	StagePlugin_ShadowOriginPrefix = StringParam{"StagePlugin.ShadowOriginPrefix"}
-	Xrootd_Authfile = StringParam{"Xrootd.Authfile"}
-	Xrootd_ConfigFile = StringParam{"Xrootd.ConfigFile"}
-	Xrootd_DetailedMonitoringHost = StringParam{"Xrootd.DetailedMonitoringHost"}
-	Xrootd_LocalMonitoringHost = StringParam{"Xrootd.LocalMonitoringHost"}
-	Xrootd_MacaroonsKeyFile = StringParam{"Xrootd.MacaroonsKeyFile"}
-	Xrootd_ManagerHost = StringParam{"Xrootd.ManagerHost"}
-	Xrootd_Mount = StringParam{"Xrootd.Mount"}
-	Xrootd_RobotsTxtFile = StringParam{"Xrootd.RobotsTxtFile"}
-	Xrootd_RunLocation = StringParam{"Xrootd.RunLocation"}
-	Xrootd_ScitokensConfig = StringParam{"Xrootd.ScitokensConfig"}
-	Xrootd_Sitename = StringParam{"Xrootd.Sitename"}
-	Xrootd_SummaryMonitoringHost = StringParam{"Xrootd.SummaryMonitoringHost"}
+	Issuer_OIDCGroupClaim              = StringParam{"Issuer.OIDCGroupClaim"}
+	Issuer_QDLLocation                 = StringParam{"Issuer.QDLLocation"}
+	Issuer_ScitokensServerLocation     = StringParam{"Issuer.ScitokensServerLocation"}
+	Issuer_TomcatLocation              = StringParam{"Issuer.TomcatLocation"}
+	LocalCache_DataLocation            = StringParam{"LocalCache.DataLocation"}
+	LocalCache_RunLocation             = StringParam{"LocalCache.RunLocation"}
+	LocalCache_Size                    = StringParam{"LocalCache.Size"}
+	LocalCache_Socket                  = StringParam{"LocalCache.Socket"}
+	Logging_Cache_Http                 = StringParam{"Logging.Cache.Http"}
+	Logging_Cache_Ofs                  = StringParam{"Logging.Cache.Ofs"}
+	Logging_Cache_Pfc                  = StringParam{"Logging.Cache.Pfc"}
+	Logging_Cache_Pss                  = StringParam{"Logging.Cache.Pss"}
+	Logging_Cache_PssSetOpt            = StringParam{"Logging.Cache.PssSetOpt"}
+	Logging_Cache_Scitokens            = StringParam{"Logging.Cache.Scitokens"}
+	Logging_Cache_Xrd                  = StringParam{"Logging.Cache.Xrd"}
+	Logging_Cache_Xrootd               = StringParam{"Logging.Cache.Xrootd"}
+	Logging_Level                      = StringParam{"Logging.Level"}
+	Logging_LogLocation                = StringParam{"Logging.LogLocation"}
+	Logging_Origin_Cms                 = StringParam{"Logging.Origin.Cms"}
+	Logging_Origin_Http                = StringParam{"Logging.Origin.Http"}
+	Logging_Origin_Ofs                 = StringParam{"Logging.Origin.Ofs"}
+	Logging_Origin_Oss                 = StringParam{"Logging.Origin.Oss"}
+	Logging_Origin_Scitokens           = StringParam{"Logging.Origin.Scitokens"}
+	Logging_Origin_Xrd                 = StringParam{"Logging.Origin.Xrd"}
+	Logging_Origin_Xrootd              = StringParam{"Logging.Origin.Xrootd"}
+	Lotman_DbLocation                  = StringParam{"Lotman.DbLocation"}
+	Lotman_EnabledPolicy               = StringParam{"Lotman.EnabledPolicy"}
+	Lotman_LibLocation                 = StringParam{"Lotman.LibLocation"}
+	Lotman_LotHome                     = StringParam{"Lotman.LotHome"}
+	Monitoring_DataLocation            = StringParam{"Monitoring.DataLocation"}
+	OIDC_AuthorizationEndpoint         = StringParam{"OIDC.AuthorizationEndpoint"}
+	OIDC_ClientID                      = StringParam{"OIDC.ClientID"}
+	OIDC_ClientIDFile                  = StringParam{"OIDC.ClientIDFile"}
+	OIDC_ClientRedirectHostname        = StringParam{"OIDC.ClientRedirectHostname"}
+	OIDC_ClientSecretFile              = StringParam{"OIDC.ClientSecretFile"}
+	OIDC_DeviceAuthEndpoint            = StringParam{"OIDC.DeviceAuthEndpoint"}
+	OIDC_Issuer                        = StringParam{"OIDC.Issuer"}
+	OIDC_TokenEndpoint                 = StringParam{"OIDC.TokenEndpoint"}
+	OIDC_UserInfoEndpoint              = StringParam{"OIDC.UserInfoEndpoint"}
+	Origin_DbLocation                  = StringParam{"Origin.DbLocation"}
+	Origin_ExportVolume                = StringParam{"Origin.ExportVolume"}
+	Origin_FedTokenLocation            = StringParam{"Origin.FedTokenLocation"}
+	Origin_FederationPrefix            = StringParam{"Origin.FederationPrefix"}
+	Origin_GlobusClientIDFile          = StringParam{"Origin.GlobusClientIDFile"}
+	Origin_GlobusClientSecretFile      = StringParam{"Origin.GlobusClientSecretFile"}
+	Origin_GlobusCollectionID          = StringParam{"Origin.GlobusCollectionID"}
+	Origin_GlobusCollectionName        = StringParam{"Origin.GlobusCollectionName"}
+	Origin_GlobusConfigLocation        = StringParam{"Origin.GlobusConfigLocation"}
+	Origin_HttpAuthTokenFile           = StringParam{"Origin.HttpAuthTokenFile"}
+	Origin_HttpServiceUrl              = StringParam{"Origin.HttpServiceUrl"}
+	Origin_Mode                        = StringParam{"Origin.Mode"}
+	Origin_NamespacePrefix             = StringParam{"Origin.NamespacePrefix"}
+	Origin_RunLocation                 = StringParam{"Origin.RunLocation"}
+	Origin_S3AccessKeyfile             = StringParam{"Origin.S3AccessKeyfile"}
+	Origin_S3Bucket                    = StringParam{"Origin.S3Bucket"}
+	Origin_S3Region                    = StringParam{"Origin.S3Region"}
+	Origin_S3SecretKeyfile             = StringParam{"Origin.S3SecretKeyfile"}
+	Origin_S3ServiceName               = StringParam{"Origin.S3ServiceName"}
+	Origin_S3ServiceUrl                = StringParam{"Origin.S3ServiceUrl"}
+	Origin_S3UrlStyle                  = StringParam{"Origin.S3UrlStyle"}
+	Origin_ScitokensDefaultUser        = StringParam{"Origin.ScitokensDefaultUser"}
+	Origin_ScitokensNameMapFile        = StringParam{"Origin.ScitokensNameMapFile"}
+	Origin_ScitokensUsernameClaim      = StringParam{"Origin.ScitokensUsernameClaim"}
+	Origin_StoragePrefix               = StringParam{"Origin.StoragePrefix"}
+	Origin_StorageType                 = StringParam{"Origin.StorageType"}
+	Origin_TokenAudience               = StringParam{"Origin.TokenAudience"}
+	Origin_Url                         = StringParam{"Origin.Url"}
+	Origin_XRootDPrefix                = StringParam{"Origin.XRootDPrefix"}
+	Origin_XRootServiceUrl             = StringParam{"Origin.XRootServiceUrl"}
+	Plugin_Token                       = StringParam{"Plugin.Token"}
+	Registry_DbLocation                = StringParam{"Registry.DbLocation"}
+	Registry_InstitutionsUrl           = StringParam{"Registry.InstitutionsUrl"}
+	Server_DbLocation                  = StringParam{"Server.DbLocation"}
+	Server_ExternalWebUrl              = StringParam{"Server.ExternalWebUrl"}
+	Server_Hostname                    = StringParam{"Server.Hostname"}
+	Server_IssuerHostname              = StringParam{"Server.IssuerHostname"}
+	Server_IssuerJwks                  = StringParam{"Server.IssuerJwks"}
+	Server_IssuerUrl                   = StringParam{"Server.IssuerUrl"}
+	Server_SessionSecretFile           = StringParam{"Server.SessionSecretFile"}
+	Server_TLSCACertificateDirectory   = StringParam{"Server.TLSCACertificateDirectory"}
+	Server_TLSCACertificateFile        = StringParam{"Server.TLSCACertificateFile"}
+	Server_TLSCAKey                    = StringParam{"Server.TLSCAKey"}
+	Server_TLSCertificate              = StringParam{"Server.TLSCertificate"}
+	Server_TLSCertificateChain         = StringParam{"Server.TLSCertificateChain"}
+	Server_TLSKey                      = StringParam{"Server.TLSKey"}
+	Server_UIActivationCodeFile        = StringParam{"Server.UIActivationCodeFile"}
+	Server_UIPasswordFile              = StringParam{"Server.UIPasswordFile"}
+	Server_UnprivilegedUser            = StringParam{"Server.UnprivilegedUser"}
+	Server_WebConfigFile               = StringParam{"Server.WebConfigFile"}
+	Server_WebHost                     = StringParam{"Server.WebHost"}
+	Shoveler_AMQPExchange              = StringParam{"Shoveler.AMQPExchange"}
+	Shoveler_AMQPTokenLocation         = StringParam{"Shoveler.AMQPTokenLocation"}
+	Shoveler_MessageQueueProtocol      = StringParam{"Shoveler.MessageQueueProtocol"}
+	Shoveler_QueueDirectory            = StringParam{"Shoveler.QueueDirectory"}
+	Shoveler_StompCert                 = StringParam{"Shoveler.StompCert"}
+	Shoveler_StompCertKey              = StringParam{"Shoveler.StompCertKey"}
+	Shoveler_StompPassword             = StringParam{"Shoveler.StompPassword"}
+	Shoveler_StompUsername             = StringParam{"Shoveler.StompUsername"}
+	Shoveler_Topic                     = StringParam{"Shoveler.Topic"}
+	Shoveler_URL                       = StringParam{"Shoveler.URL"}
+	StagePlugin_MountPrefix            = StringParam{"StagePlugin.MountPrefix"}
+	StagePlugin_OriginPrefix           = StringParam{"StagePlugin.OriginPrefix"}
+	StagePlugin_ShadowOriginPrefix     = StringParam{"StagePlugin.ShadowOriginPrefix"}
+	Xrootd_Authfile                    = StringParam{"Xrootd.Authfile"}
+	Xrootd_ConfigFile                  = StringParam{"Xrootd.ConfigFile"}
+	Xrootd_DetailedMonitoringHost      = StringParam{"Xrootd.DetailedMonitoringHost"}
+	Xrootd_LocalMonitoringHost         = StringParam{"Xrootd.LocalMonitoringHost"}
+	Xrootd_MacaroonsKeyFile            = StringParam{"Xrootd.MacaroonsKeyFile"}
+	Xrootd_ManagerHost                 = StringParam{"Xrootd.ManagerHost"}
+	Xrootd_Mount                       = StringParam{"Xrootd.Mount"}
+	Xrootd_RobotsTxtFile               = StringParam{"Xrootd.RobotsTxtFile"}
+	Xrootd_RunLocation                 = StringParam{"Xrootd.RunLocation"}
+	Xrootd_ScitokensConfig             = StringParam{"Xrootd.ScitokensConfig"}
+	Xrootd_Sitename                    = StringParam{"Xrootd.Sitename"}
+	Xrootd_SummaryMonitoringHost       = StringParam{"Xrootd.SummaryMonitoringHost"}
 )
 
 var (
-	Cache_DataLocations = StringSliceParam{"Cache.DataLocations"}
-	Cache_MetaLocations = StringSliceParam{"Cache.MetaLocations"}
-	Cache_PermittedNamespaces = StringSliceParam{"Cache.PermittedNamespaces"}
-	Client_PreferredCaches = StringSliceParam{"Client.PreferredCaches"}
-	ConfigLocations = StringSliceParam{"ConfigLocations"}
-	Director_CacheResponseHostnames = StringSliceParam{"Director.CacheResponseHostnames"}
-	Director_FilteredServers = StringSliceParam{"Director.FilteredServers"}
+	Cache_DataLocations              = StringSliceParam{"Cache.DataLocations"}
+	Cache_MetaLocations              = StringSliceParam{"Cache.MetaLocations"}
+	Cache_PermittedNamespaces        = StringSliceParam{"Cache.PermittedNamespaces"}
+	Client_PreferredCaches           = StringSliceParam{"Client.PreferredCaches"}
+	ConfigLocations                  = StringSliceParam{"ConfigLocations"}
+	Director_CacheResponseHostnames  = StringSliceParam{"Director.CacheResponseHostnames"}
+	Director_FilteredServers         = StringSliceParam{"Director.FilteredServers"}
 	Director_OriginResponseHostnames = StringSliceParam{"Director.OriginResponseHostnames"}
-	Issuer_GroupRequirements = StringSliceParam{"Issuer.GroupRequirements"}
-	Monitoring_AggregatePrefixes = StringSliceParam{"Monitoring.AggregatePrefixes"}
-	Origin_ExportVolumes = StringSliceParam{"Origin.ExportVolumes"}
-	Origin_ScitokensRestrictedPaths = StringSliceParam{"Origin.ScitokensRestrictedPaths"}
-	Registry_AdminUsers = StringSliceParam{"Registry.AdminUsers"}
-	Server_DirectorUrls = StringSliceParam{"Server.DirectorUrls"}
-	Server_Modules = StringSliceParam{"Server.Modules"}
-	Server_UIAdminUsers = StringSliceParam{"Server.UIAdminUsers"}
-	Shoveler_OutputDestinations = StringSliceParam{"Shoveler.OutputDestinations"}
+	Issuer_GroupRequirements         = StringSliceParam{"Issuer.GroupRequirements"}
+	Issuer_RedirectUris              = StringSliceParam{"Issuer.RedirectUris"}
+	Monitoring_AggregatePrefixes     = StringSliceParam{"Monitoring.AggregatePrefixes"}
+	Origin_ExportVolumes             = StringSliceParam{"Origin.ExportVolumes"}
+	Origin_ScitokensRestrictedPaths  = StringSliceParam{"Origin.ScitokensRestrictedPaths"}
+	Registry_AdminUsers              = StringSliceParam{"Registry.AdminUsers"}
+	Server_DirectorUrls              = StringSliceParam{"Server.DirectorUrls"}
+	Server_Modules                   = StringSliceParam{"Server.Modules"}
+	Server_UIAdminUsers              = StringSliceParam{"Server.UIAdminUsers"}
+	Shoveler_OutputDestinations      = StringSliceParam{"Shoveler.OutputDestinations"}
 )
 
 var (
-	Cache_BlocksToPrefetch = IntParam{"Cache.BlocksToPrefetch"}
-	Cache_Concurrency = IntParam{"Cache.Concurrency"}
-	Cache_Port = IntParam{"Cache.Port"}
-	Client_DirectorRetries = IntParam{"Client.DirectorRetries"}
-	Client_MaximumDownloadSpeed = IntParam{"Client.MaximumDownloadSpeed"}
-	Client_MinimumDownloadSpeed = IntParam{"Client.MinimumDownloadSpeed"}
-	Client_WorkerCount = IntParam{"Client.WorkerCount"}
-	Director_CachePresenceCapacity = IntParam{"Director.CachePresenceCapacity"}
-	Director_MaxStatResponse = IntParam{"Director.MaxStatResponse"}
-	Director_MinStatResponse = IntParam{"Director.MinStatResponse"}
-	Director_StatConcurrencyLimit = IntParam{"Director.StatConcurrencyLimit"}
+	Cache_BlocksToPrefetch             = IntParam{"Cache.BlocksToPrefetch"}
+	Cache_Concurrency                  = IntParam{"Cache.Concurrency"}
+	Cache_Port                         = IntParam{"Cache.Port"}
+	Client_DirectorRetries             = IntParam{"Client.DirectorRetries"}
+	Client_MaximumDownloadSpeed        = IntParam{"Client.MaximumDownloadSpeed"}
+	Client_MinimumDownloadSpeed        = IntParam{"Client.MinimumDownloadSpeed"}
+	Client_WorkerCount                 = IntParam{"Client.WorkerCount"}
+	Director_CachePresenceCapacity     = IntParam{"Director.CachePresenceCapacity"}
+	Director_MaxStatResponse           = IntParam{"Director.MaxStatResponse"}
+	Director_MinStatResponse           = IntParam{"Director.MinStatResponse"}
+	Director_StatConcurrencyLimit      = IntParam{"Director.StatConcurrencyLimit"}
 	LocalCache_HighWaterMarkPercentage = IntParam{"LocalCache.HighWaterMarkPercentage"}
-	LocalCache_LowWaterMarkPercentage = IntParam{"LocalCache.LowWaterMarkPercentage"}
-	MinimumDownloadSpeed = IntParam{"MinimumDownloadSpeed"}
-	Monitoring_LabelLimit = IntParam{"Monitoring.LabelLimit"}
-	Monitoring_LabelNameLengthLimit = IntParam{"Monitoring.LabelNameLengthLimit"}
-	Monitoring_LabelValueLengthLimit = IntParam{"Monitoring.LabelValueLengthLimit"}
-	Monitoring_PortHigher = IntParam{"Monitoring.PortHigher"}
-	Monitoring_PortLower = IntParam{"Monitoring.PortLower"}
-	Monitoring_SampleLimit = IntParam{"Monitoring.SampleLimit"}
-	Origin_Concurrency = IntParam{"Origin.Concurrency"}
-	Origin_Port = IntParam{"Origin.Port"}
-	Server_IssuerPort = IntParam{"Server.IssuerPort"}
-	Server_UILoginRateLimit = IntParam{"Server.UILoginRateLimit"}
-	Server_WebPort = IntParam{"Server.WebPort"}
-	Shoveler_PortHigher = IntParam{"Shoveler.PortHigher"}
-	Shoveler_PortLower = IntParam{"Shoveler.PortLower"}
-	Transport_MaxIdleConns = IntParam{"Transport.MaxIdleConns"}
-	Xrootd_DetailedMonitoringPort = IntParam{"Xrootd.DetailedMonitoringPort"}
-	Xrootd_ManagerPort = IntParam{"Xrootd.ManagerPort"}
-	Xrootd_Port = IntParam{"Xrootd.Port"}
-	Xrootd_SummaryMonitoringPort = IntParam{"Xrootd.SummaryMonitoringPort"}
+	LocalCache_LowWaterMarkPercentage  = IntParam{"LocalCache.LowWaterMarkPercentage"}
+	MinimumDownloadSpeed               = IntParam{"MinimumDownloadSpeed"}
+	Monitoring_LabelLimit              = IntParam{"Monitoring.LabelLimit"}
+	Monitoring_LabelNameLengthLimit    = IntParam{"Monitoring.LabelNameLengthLimit"}
+	Monitoring_LabelValueLengthLimit   = IntParam{"Monitoring.LabelValueLengthLimit"}
+	Monitoring_PortHigher              = IntParam{"Monitoring.PortHigher"}
+	Monitoring_PortLower               = IntParam{"Monitoring.PortLower"}
+	Monitoring_SampleLimit             = IntParam{"Monitoring.SampleLimit"}
+	Origin_Concurrency                 = IntParam{"Origin.Concurrency"}
+	Origin_Port                        = IntParam{"Origin.Port"}
+	Server_IssuerPort                  = IntParam{"Server.IssuerPort"}
+	Server_UILoginRateLimit            = IntParam{"Server.UILoginRateLimit"}
+	Server_WebPort                     = IntParam{"Server.WebPort"}
+	Shoveler_PortHigher                = IntParam{"Shoveler.PortHigher"}
+	Shoveler_PortLower                 = IntParam{"Shoveler.PortLower"}
+	Transport_MaxIdleConns             = IntParam{"Transport.MaxIdleConns"}
+	Xrootd_DetailedMonitoringPort      = IntParam{"Xrootd.DetailedMonitoringPort"}
+	Xrootd_ManagerPort                 = IntParam{"Xrootd.ManagerPort"}
+	Xrootd_Port                        = IntParam{"Xrootd.Port"}
+	Xrootd_SummaryMonitoringPort       = IntParam{"Xrootd.SummaryMonitoringPort"}
 )
 
 var (
-	Cache_EnableBroker = BoolParam{"Cache.EnableBroker"}
-	Cache_EnableLotman = BoolParam{"Cache.EnableLotman"}
-	Cache_EnableOIDC = BoolParam{"Cache.EnableOIDC"}
-	Cache_EnablePrefetch = BoolParam{"Cache.EnablePrefetch"}
-	Cache_EnableTLSClientAuth = BoolParam{"Cache.EnableTLSClientAuth"}
-	Cache_EnableVoms = BoolParam{"Cache.EnableVoms"}
-	Cache_SelfTest = BoolParam{"Cache.SelfTest"}
-	Client_AssumeDirectorServerHeader = BoolParam{"Client.AssumeDirectorServerHeader"}
-	Client_DisableHttpProxy = BoolParam{"Client.DisableHttpProxy"}
-	Client_DisableProxyFallback = BoolParam{"Client.DisableProxyFallback"}
-	Client_IsPlugin = BoolParam{"Client.IsPlugin"}
-	Debug = BoolParam{"Debug"}
+	Cache_EnableBroker                    = BoolParam{"Cache.EnableBroker"}
+	Cache_EnableLotman                    = BoolParam{"Cache.EnableLotman"}
+	Cache_EnableOIDC                      = BoolParam{"Cache.EnableOIDC"}
+	Cache_EnablePrefetch                  = BoolParam{"Cache.EnablePrefetch"}
+	Cache_EnableTLSClientAuth             = BoolParam{"Cache.EnableTLSClientAuth"}
+	Cache_EnableVoms                      = BoolParam{"Cache.EnableVoms"}
+	Cache_SelfTest                        = BoolParam{"Cache.SelfTest"}
+	Client_AssumeDirectorServerHeader     = BoolParam{"Client.AssumeDirectorServerHeader"}
+	Client_DisableHttpProxy               = BoolParam{"Client.DisableHttpProxy"}
+	Client_DisableProxyFallback           = BoolParam{"Client.DisableProxyFallback"}
+	Client_IsPlugin                       = BoolParam{"Client.IsPlugin"}
+	Debug                                 = BoolParam{"Debug"}
 	Director_AssumePresenceAtSingleOrigin = BoolParam{"Director.AssumePresenceAtSingleOrigin"}
-	Director_CachesPullFromCaches = BoolParam{"Director.CachesPullFromCaches"}
-	Director_CheckCachePresence = BoolParam{"Director.CheckCachePresence"}
-	Director_CheckOriginPresence = BoolParam{"Director.CheckOriginPresence"}
-	Director_EnableBroker = BoolParam{"Director.EnableBroker"}
-	Director_EnableOIDC = BoolParam{"Director.EnableOIDC"}
-	Director_EnableStat = BoolParam{"Director.EnableStat"}
-	DisableHttpProxy = BoolParam{"DisableHttpProxy"}
-	DisableProxyFallback = BoolParam{"DisableProxyFallback"}
-	Issuer_OIDCPreferClaimsFromIDToken = BoolParam{"Issuer.OIDCPreferClaimsFromIDToken"}
-	Issuer_UserStripDomain = BoolParam{"Issuer.UserStripDomain"}
-	Logging_DisableProgressBars = BoolParam{"Logging.DisableProgressBars"}
-	Lotman_EnableAPI = BoolParam{"Lotman.EnableAPI"}
-	Monitoring_MetricAuthorization = BoolParam{"Monitoring.MetricAuthorization"}
-	Monitoring_PromQLAuthorization = BoolParam{"Monitoring.PromQLAuthorization"}
-	Origin_DirectorTest = BoolParam{"Origin.DirectorTest"}
-	Origin_DisableDirectClients = BoolParam{"Origin.DisableDirectClients"}
-	Origin_EnableBroker = BoolParam{"Origin.EnableBroker"}
-	Origin_EnableCmsd = BoolParam{"Origin.EnableCmsd"}
-	Origin_EnableDirListing = BoolParam{"Origin.EnableDirListing"}
-	Origin_EnableDirectReads = BoolParam{"Origin.EnableDirectReads"}
-	Origin_EnableFallbackRead = BoolParam{"Origin.EnableFallbackRead"}
-	Origin_EnableIssuer = BoolParam{"Origin.EnableIssuer"}
-	Origin_EnableListings = BoolParam{"Origin.EnableListings"}
-	Origin_EnableMacaroons = BoolParam{"Origin.EnableMacaroons"}
-	Origin_EnableOIDC = BoolParam{"Origin.EnableOIDC"}
-	Origin_EnablePublicReads = BoolParam{"Origin.EnablePublicReads"}
-	Origin_EnableReads = BoolParam{"Origin.EnableReads"}
-	Origin_EnableUI = BoolParam{"Origin.EnableUI"}
-	Origin_EnableVoms = BoolParam{"Origin.EnableVoms"}
-	Origin_EnableWrite = BoolParam{"Origin.EnableWrite"}
-	Origin_EnableWrites = BoolParam{"Origin.EnableWrites"}
-	Origin_Multiuser = BoolParam{"Origin.Multiuser"}
-	Origin_ScitokensMapSubject = BoolParam{"Origin.ScitokensMapSubject"}
-	Origin_SelfTest = BoolParam{"Origin.SelfTest"}
-	Registry_RequireCacheApproval = BoolParam{"Registry.RequireCacheApproval"}
-	Registry_RequireKeyChaining = BoolParam{"Registry.RequireKeyChaining"}
-	Registry_RequireOriginApproval = BoolParam{"Registry.RequireOriginApproval"}
-	Server_DropPrivileges = BoolParam{"Server.DropPrivileges"}
-	Server_EnablePprof = BoolParam{"Server.EnablePprof"}
-	Server_EnableUI = BoolParam{"Server.EnableUI"}
-	Server_HealthMonitoringPublic = BoolParam{"Server.HealthMonitoringPublic"}
-	Shoveler_Enable = BoolParam{"Shoveler.Enable"}
-	Shoveler_VerifyHeader = BoolParam{"Shoveler.VerifyHeader"}
-	StagePlugin_Hook = BoolParam{"StagePlugin.Hook"}
-	TLSSkipVerify = BoolParam{"TLSSkipVerify"}
-	Topology_DisableCacheX509 = BoolParam{"Topology.DisableCacheX509"}
-	Topology_DisableCaches = BoolParam{"Topology.DisableCaches"}
-	Topology_DisableDowntime = BoolParam{"Topology.DisableDowntime"}
-	Topology_DisableOriginX509 = BoolParam{"Topology.DisableOriginX509"}
-	Topology_DisableOrigins = BoolParam{"Topology.DisableOrigins"}
-	Xrootd_EnableLocalMonitoring = BoolParam{"Xrootd.EnableLocalMonitoring"}
+	Director_CachesPullFromCaches         = BoolParam{"Director.CachesPullFromCaches"}
+	Director_CheckCachePresence           = BoolParam{"Director.CheckCachePresence"}
+	Director_CheckOriginPresence          = BoolParam{"Director.CheckOriginPresence"}
+	Director_EnableBroker                 = BoolParam{"Director.EnableBroker"}
+	Director_EnableOIDC                   = BoolParam{"Director.EnableOIDC"}
+	Director_EnableStat                   = BoolParam{"Director.EnableStat"}
+	DisableHttpProxy                      = BoolParam{"DisableHttpProxy"}
+	DisableProxyFallback                  = BoolParam{"DisableProxyFallback"}
+	Issuer_OIDCPreferClaimsFromIDToken    = BoolParam{"Issuer.OIDCPreferClaimsFromIDToken"}
+	Issuer_UserStripDomain                = BoolParam{"Issuer.UserStripDomain"}
+	Logging_DisableProgressBars           = BoolParam{"Logging.DisableProgressBars"}
+	Lotman_EnableAPI                      = BoolParam{"Lotman.EnableAPI"}
+	Monitoring_MetricAuthorization        = BoolParam{"Monitoring.MetricAuthorization"}
+	Monitoring_PromQLAuthorization        = BoolParam{"Monitoring.PromQLAuthorization"}
+	Origin_DirectorTest                   = BoolParam{"Origin.DirectorTest"}
+	Origin_DisableDirectClients           = BoolParam{"Origin.DisableDirectClients"}
+	Origin_EnableBroker                   = BoolParam{"Origin.EnableBroker"}
+	Origin_EnableCmsd                     = BoolParam{"Origin.EnableCmsd"}
+	Origin_EnableDirListing               = BoolParam{"Origin.EnableDirListing"}
+	Origin_EnableDirectReads              = BoolParam{"Origin.EnableDirectReads"}
+	Origin_EnableFallbackRead             = BoolParam{"Origin.EnableFallbackRead"}
+	Origin_EnableIssuer                   = BoolParam{"Origin.EnableIssuer"}
+	Origin_EnableListings                 = BoolParam{"Origin.EnableListings"}
+	Origin_EnableMacaroons                = BoolParam{"Origin.EnableMacaroons"}
+	Origin_EnableOIDC                     = BoolParam{"Origin.EnableOIDC"}
+	Origin_EnablePublicReads              = BoolParam{"Origin.EnablePublicReads"}
+	Origin_EnableReads                    = BoolParam{"Origin.EnableReads"}
+	Origin_EnableUI                       = BoolParam{"Origin.EnableUI"}
+	Origin_EnableVoms                     = BoolParam{"Origin.EnableVoms"}
+	Origin_EnableWrite                    = BoolParam{"Origin.EnableWrite"}
+	Origin_EnableWrites                   = BoolParam{"Origin.EnableWrites"}
+	Origin_Multiuser                      = BoolParam{"Origin.Multiuser"}
+	Origin_ScitokensMapSubject            = BoolParam{"Origin.ScitokensMapSubject"}
+	Origin_SelfTest                       = BoolParam{"Origin.SelfTest"}
+	Registry_RequireCacheApproval         = BoolParam{"Registry.RequireCacheApproval"}
+	Registry_RequireKeyChaining           = BoolParam{"Registry.RequireKeyChaining"}
+	Registry_RequireOriginApproval        = BoolParam{"Registry.RequireOriginApproval"}
+	Server_DropPrivileges                 = BoolParam{"Server.DropPrivileges"}
+	Server_EnablePprof                    = BoolParam{"Server.EnablePprof"}
+	Server_EnableUI                       = BoolParam{"Server.EnableUI"}
+	Server_HealthMonitoringPublic         = BoolParam{"Server.HealthMonitoringPublic"}
+	Shoveler_Enable                       = BoolParam{"Shoveler.Enable"}
+	Shoveler_VerifyHeader                 = BoolParam{"Shoveler.VerifyHeader"}
+	StagePlugin_Hook                      = BoolParam{"StagePlugin.Hook"}
+	TLSSkipVerify                         = BoolParam{"TLSSkipVerify"}
+	Topology_DisableCacheX509             = BoolParam{"Topology.DisableCacheX509"}
+	Topology_DisableCaches                = BoolParam{"Topology.DisableCaches"}
+	Topology_DisableDowntime              = BoolParam{"Topology.DisableDowntime"}
+	Topology_DisableOriginX509            = BoolParam{"Topology.DisableOriginX509"}
+	Topology_DisableOrigins               = BoolParam{"Topology.DisableOrigins"}
+	Xrootd_EnableLocalMonitoring          = BoolParam{"Xrootd.EnableLocalMonitoring"}
 )
 
 var (
-	Cache_DefaultCacheTimeout = DurationParam{"Cache.DefaultCacheTimeout"}
-	Cache_SelfTestInterval = DurationParam{"Cache.SelfTestInterval"}
-	Client_SlowTransferRampupTime = DurationParam{"Client.SlowTransferRampupTime"}
-	Client_SlowTransferWindow = DurationParam{"Client.SlowTransferWindow"}
-	Client_StoppedTransferTimeout = DurationParam{"Client.StoppedTransferTimeout"}
-	Director_AdvertisementTTL = DurationParam{"Director.AdvertisementTTL"}
-	Director_CachePresenceTTL = DurationParam{"Director.CachePresenceTTL"}
-	Director_FedTokenLifetime = DurationParam{"Director.FedTokenLifetime"}
+	Cache_DefaultCacheTimeout              = DurationParam{"Cache.DefaultCacheTimeout"}
+	Cache_SelfTestInterval                 = DurationParam{"Cache.SelfTestInterval"}
+	Client_SlowTransferRampupTime          = DurationParam{"Client.SlowTransferRampupTime"}
+	Client_SlowTransferWindow              = DurationParam{"Client.SlowTransferWindow"}
+	Client_StoppedTransferTimeout          = DurationParam{"Client.StoppedTransferTimeout"}
+	Director_AdvertisementTTL              = DurationParam{"Director.AdvertisementTTL"}
+	Director_CachePresenceTTL              = DurationParam{"Director.CachePresenceTTL"}
+	Director_FedTokenLifetime              = DurationParam{"Director.FedTokenLifetime"}
 	Director_OriginCacheHealthTestInterval = DurationParam{"Director.OriginCacheHealthTestInterval"}
-	Director_RegistryQueryInterval = DurationParam{"Director.RegistryQueryInterval"}
-	Director_StatTimeout = DurationParam{"Director.StatTimeout"}
-	Federation_TopologyReloadInterval = DurationParam{"Federation.TopologyReloadInterval"}
-	Logging_Client_ProgressInterval = DurationParam{"Logging.Client.ProgressInterval"}
-	Lotman_DefaultLotDeletionLifetime = DurationParam{"Lotman.DefaultLotDeletionLifetime"}
-	Lotman_DefaultLotExpirationLifetime = DurationParam{"Lotman.DefaultLotExpirationLifetime"}
-	Monitoring_DataRetention = DurationParam{"Monitoring.DataRetention"}
-	Monitoring_TokenExpiresIn = DurationParam{"Monitoring.TokenExpiresIn"}
-	Monitoring_TokenRefreshInterval = DurationParam{"Monitoring.TokenRefreshInterval"}
-	Origin_SelfTestInterval = DurationParam{"Origin.SelfTestInterval"}
-	Registry_InstitutionsUrlReloadMinutes = DurationParam{"Registry.InstitutionsUrlReloadMinutes"}
-	Server_AdLifetime = DurationParam{"Server.AdLifetime"}
-	Server_AdvertisementInterval = DurationParam{"Server.AdvertisementInterval"}
-	Server_RegistrationRetryInterval = DurationParam{"Server.RegistrationRetryInterval"}
-	Server_StartupTimeout = DurationParam{"Server.StartupTimeout"}
-	Transport_BrokerEndpointCacheTTL = DurationParam{"Transport.BrokerEndpointCacheTTL"}
-	Transport_DialerKeepAlive = DurationParam{"Transport.DialerKeepAlive"}
-	Transport_DialerTimeout = DurationParam{"Transport.DialerTimeout"}
-	Transport_ExpectContinueTimeout = DurationParam{"Transport.ExpectContinueTimeout"}
-	Transport_IdleConnTimeout = DurationParam{"Transport.IdleConnTimeout"}
-	Transport_ResponseHeaderTimeout = DurationParam{"Transport.ResponseHeaderTimeout"}
-	Transport_TLSHandshakeTimeout = DurationParam{"Transport.TLSHandshakeTimeout"}
-	Xrootd_AuthRefreshInterval = DurationParam{"Xrootd.AuthRefreshInterval"}
-	Xrootd_MaxStartupWait = DurationParam{"Xrootd.MaxStartupWait"}
-	Xrootd_ShutdownTimeout = DurationParam{"Xrootd.ShutdownTimeout"}
+	Director_RegistryQueryInterval         = DurationParam{"Director.RegistryQueryInterval"}
+	Director_StatTimeout                   = DurationParam{"Director.StatTimeout"}
+	Federation_TopologyReloadInterval      = DurationParam{"Federation.TopologyReloadInterval"}
+	Logging_Client_ProgressInterval        = DurationParam{"Logging.Client.ProgressInterval"}
+	Lotman_DefaultLotDeletionLifetime      = DurationParam{"Lotman.DefaultLotDeletionLifetime"}
+	Lotman_DefaultLotExpirationLifetime    = DurationParam{"Lotman.DefaultLotExpirationLifetime"}
+	Monitoring_DataRetention               = DurationParam{"Monitoring.DataRetention"}
+	Monitoring_TokenExpiresIn              = DurationParam{"Monitoring.TokenExpiresIn"}
+	Monitoring_TokenRefreshInterval        = DurationParam{"Monitoring.TokenRefreshInterval"}
+	Origin_SelfTestInterval                = DurationParam{"Origin.SelfTestInterval"}
+	Registry_InstitutionsUrlReloadMinutes  = DurationParam{"Registry.InstitutionsUrlReloadMinutes"}
+	Server_AdLifetime                      = DurationParam{"Server.AdLifetime"}
+	Server_AdvertisementInterval           = DurationParam{"Server.AdvertisementInterval"}
+	Server_RegistrationRetryInterval       = DurationParam{"Server.RegistrationRetryInterval"}
+	Server_StartupTimeout                  = DurationParam{"Server.StartupTimeout"}
+	Transport_BrokerEndpointCacheTTL       = DurationParam{"Transport.BrokerEndpointCacheTTL"}
+	Transport_DialerKeepAlive              = DurationParam{"Transport.DialerKeepAlive"}
+	Transport_DialerTimeout                = DurationParam{"Transport.DialerTimeout"}
+	Transport_ExpectContinueTimeout        = DurationParam{"Transport.ExpectContinueTimeout"}
+	Transport_IdleConnTimeout              = DurationParam{"Transport.IdleConnTimeout"}
+	Transport_ResponseHeaderTimeout        = DurationParam{"Transport.ResponseHeaderTimeout"}
+	Transport_TLSHandshakeTimeout          = DurationParam{"Transport.TLSHandshakeTimeout"}
+	Xrootd_AuthRefreshInterval             = DurationParam{"Xrootd.AuthRefreshInterval"}
+	Xrootd_MaxStartupWait                  = DurationParam{"Xrootd.MaxStartupWait"}
+	Xrootd_ShutdownTimeout                 = DurationParam{"Xrootd.ShutdownTimeout"}
 )
 
 var (
-	GeoIPOverrides = ObjectParam{"GeoIPOverrides"}
-	Issuer_AuthorizationTemplates = ObjectParam{"Issuer.AuthorizationTemplates"}
+	GeoIPOverrides                        = ObjectParam{"GeoIPOverrides"}
+	Issuer_AuthorizationTemplates         = ObjectParam{"Issuer.AuthorizationTemplates"}
 	Issuer_OIDCAuthenticationRequirements = ObjectParam{"Issuer.OIDCAuthenticationRequirements"}
-	Lotman_PolicyDefinitions = ObjectParam{"Lotman.PolicyDefinitions"}
-	Origin_Exports = ObjectParam{"Origin.Exports"}
-	Registry_CustomRegistrationFields = ObjectParam{"Registry.CustomRegistrationFields"}
-	Registry_Institutions = ObjectParam{"Registry.Institutions"}
-	Shoveler_IPMapping = ObjectParam{"Shoveler.IPMapping"}
+	Lotman_PolicyDefinitions              = ObjectParam{"Lotman.PolicyDefinitions"}
+	Origin_Exports                        = ObjectParam{"Origin.Exports"}
+	Registry_CustomRegistrationFields     = ObjectParam{"Registry.CustomRegistrationFields"}
+	Registry_Institutions                 = ObjectParam{"Registry.Institutions"}
+	Shoveler_IPMapping                    = ObjectParam{"Shoveler.IPMapping"}
 )

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -25,1649 +25,717 @@ import (
 
 type Config struct {
 	Cache struct {
-		BlocksToPrefetch    int           `mapstructure:"blockstoprefetch" yaml:"BlocksToPrefetch"`
-		Concurrency         int           `mapstructure:"concurrency" yaml:"Concurrency"`
-		DataLocation        string        `mapstructure:"datalocation" yaml:"DataLocation"`
-		DataLocations       []string      `mapstructure:"datalocations" yaml:"DataLocations"`
-		DbLocation          string        `mapstructure:"dblocation" yaml:"DbLocation"`
+		BlocksToPrefetch int `mapstructure:"blockstoprefetch" yaml:"BlocksToPrefetch"`
+		Concurrency int `mapstructure:"concurrency" yaml:"Concurrency"`
+		DataLocation string `mapstructure:"datalocation" yaml:"DataLocation"`
+		DataLocations []string `mapstructure:"datalocations" yaml:"DataLocations"`
+		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
 		DefaultCacheTimeout time.Duration `mapstructure:"defaultcachetimeout" yaml:"DefaultCacheTimeout"`
-		EnableBroker        bool          `mapstructure:"enablebroker" yaml:"EnableBroker"`
-		EnableLotman        bool          `mapstructure:"enablelotman" yaml:"EnableLotman"`
-		EnableOIDC          bool          `mapstructure:"enableoidc" yaml:"EnableOIDC"`
-		EnablePrefetch      bool          `mapstructure:"enableprefetch" yaml:"EnablePrefetch"`
-		EnableTLSClientAuth bool          `mapstructure:"enabletlsclientauth" yaml:"EnableTLSClientAuth"`
-		EnableVoms          bool          `mapstructure:"enablevoms" yaml:"EnableVoms"`
-		ExportLocation      string        `mapstructure:"exportlocation" yaml:"ExportLocation"`
-		FedTokenLocation    string        `mapstructure:"fedtokenlocation" yaml:"FedTokenLocation"`
-		FilesBaseSize       string        `mapstructure:"filesbasesize" yaml:"FilesBaseSize"`
-		FilesMaxSize        string        `mapstructure:"filesmaxsize" yaml:"FilesMaxSize"`
-		FilesNominalSize    string        `mapstructure:"filesnominalsize" yaml:"FilesNominalSize"`
-		HighWaterMark       string        `mapstructure:"highwatermark" yaml:"HighWaterMark"`
-		LocalRoot           string        `mapstructure:"localroot" yaml:"LocalRoot"`
-		LowWatermark        string        `mapstructure:"lowwatermark" yaml:"LowWatermark"`
-		MetaLocations       []string      `mapstructure:"metalocations" yaml:"MetaLocations"`
-		NamespaceLocation   string        `mapstructure:"namespacelocation" yaml:"NamespaceLocation"`
-		PermittedNamespaces []string      `mapstructure:"permittednamespaces" yaml:"PermittedNamespaces"`
-		Port                int           `mapstructure:"port" yaml:"Port"`
-		RunLocation         string        `mapstructure:"runlocation" yaml:"RunLocation"`
-		SelfTest            bool          `mapstructure:"selftest" yaml:"SelfTest"`
-		SelfTestInterval    time.Duration `mapstructure:"selftestinterval" yaml:"SelfTestInterval"`
-		SentinelLocation    string        `mapstructure:"sentinellocation" yaml:"SentinelLocation"`
-		StorageLocation     string        `mapstructure:"storagelocation" yaml:"StorageLocation"`
-		Url                 string        `mapstructure:"url" yaml:"Url"`
-		XRootDPrefix        string        `mapstructure:"xrootdprefix" yaml:"XRootDPrefix"`
+		EnableBroker bool `mapstructure:"enablebroker" yaml:"EnableBroker"`
+		EnableLotman bool `mapstructure:"enablelotman" yaml:"EnableLotman"`
+		EnableOIDC bool `mapstructure:"enableoidc" yaml:"EnableOIDC"`
+		EnablePrefetch bool `mapstructure:"enableprefetch" yaml:"EnablePrefetch"`
+		EnableTLSClientAuth bool `mapstructure:"enabletlsclientauth" yaml:"EnableTLSClientAuth"`
+		EnableVoms bool `mapstructure:"enablevoms" yaml:"EnableVoms"`
+		ExportLocation string `mapstructure:"exportlocation" yaml:"ExportLocation"`
+		FedTokenLocation string `mapstructure:"fedtokenlocation" yaml:"FedTokenLocation"`
+		FilesBaseSize string `mapstructure:"filesbasesize" yaml:"FilesBaseSize"`
+		FilesMaxSize string `mapstructure:"filesmaxsize" yaml:"FilesMaxSize"`
+		FilesNominalSize string `mapstructure:"filesnominalsize" yaml:"FilesNominalSize"`
+		HighWaterMark string `mapstructure:"highwatermark" yaml:"HighWaterMark"`
+		LocalRoot string `mapstructure:"localroot" yaml:"LocalRoot"`
+		LowWatermark string `mapstructure:"lowwatermark" yaml:"LowWatermark"`
+		MetaLocations []string `mapstructure:"metalocations" yaml:"MetaLocations"`
+		NamespaceLocation string `mapstructure:"namespacelocation" yaml:"NamespaceLocation"`
+		PermittedNamespaces []string `mapstructure:"permittednamespaces" yaml:"PermittedNamespaces"`
+		Port int `mapstructure:"port" yaml:"Port"`
+		RunLocation string `mapstructure:"runlocation" yaml:"RunLocation"`
+		SelfTest bool `mapstructure:"selftest" yaml:"SelfTest"`
+		SelfTestInterval time.Duration `mapstructure:"selftestinterval" yaml:"SelfTestInterval"`
+		SentinelLocation string `mapstructure:"sentinellocation" yaml:"SentinelLocation"`
+		StorageLocation string `mapstructure:"storagelocation" yaml:"StorageLocation"`
+		Url string `mapstructure:"url" yaml:"Url"`
+		XRootDPrefix string `mapstructure:"xrootdprefix" yaml:"XRootDPrefix"`
 	} `mapstructure:"cache" yaml:"Cache"`
 	Client struct {
-		AssumeDirectorServerHeader bool          `mapstructure:"assumedirectorserverheader" yaml:"AssumeDirectorServerHeader"`
-		DirectorRetries            int           `mapstructure:"directorretries" yaml:"DirectorRetries"`
-		DisableHttpProxy           bool          `mapstructure:"disablehttpproxy" yaml:"DisableHttpProxy"`
-		DisableProxyFallback       bool          `mapstructure:"disableproxyfallback" yaml:"DisableProxyFallback"`
-		IsPlugin                   bool          `mapstructure:"isplugin" yaml:"IsPlugin"`
-		MaximumDownloadSpeed       int           `mapstructure:"maximumdownloadspeed" yaml:"MaximumDownloadSpeed"`
-		MinimumDownloadSpeed       int           `mapstructure:"minimumdownloadspeed" yaml:"MinimumDownloadSpeed"`
-		PreferredCaches            []string      `mapstructure:"preferredcaches" yaml:"PreferredCaches"`
-		SlowTransferRampupTime     time.Duration `mapstructure:"slowtransferrampuptime" yaml:"SlowTransferRampupTime"`
-		SlowTransferWindow         time.Duration `mapstructure:"slowtransferwindow" yaml:"SlowTransferWindow"`
-		StoppedTransferTimeout     time.Duration `mapstructure:"stoppedtransfertimeout" yaml:"StoppedTransferTimeout"`
-		WorkerCount                int           `mapstructure:"workercount" yaml:"WorkerCount"`
+		AssumeDirectorServerHeader bool `mapstructure:"assumedirectorserverheader" yaml:"AssumeDirectorServerHeader"`
+		DirectorRetries int `mapstructure:"directorretries" yaml:"DirectorRetries"`
+		DisableHttpProxy bool `mapstructure:"disablehttpproxy" yaml:"DisableHttpProxy"`
+		DisableProxyFallback bool `mapstructure:"disableproxyfallback" yaml:"DisableProxyFallback"`
+		IsPlugin bool `mapstructure:"isplugin" yaml:"IsPlugin"`
+		MaximumDownloadSpeed int `mapstructure:"maximumdownloadspeed" yaml:"MaximumDownloadSpeed"`
+		MinimumDownloadSpeed int `mapstructure:"minimumdownloadspeed" yaml:"MinimumDownloadSpeed"`
+		PreferredCaches []string `mapstructure:"preferredcaches" yaml:"PreferredCaches"`
+		SlowTransferRampupTime time.Duration `mapstructure:"slowtransferrampuptime" yaml:"SlowTransferRampupTime"`
+		SlowTransferWindow time.Duration `mapstructure:"slowtransferwindow" yaml:"SlowTransferWindow"`
+		StoppedTransferTimeout time.Duration `mapstructure:"stoppedtransfertimeout" yaml:"StoppedTransferTimeout"`
+		WorkerCount int `mapstructure:"workercount" yaml:"WorkerCount"`
 	} `mapstructure:"client" yaml:"Client"`
-	ConfigDir       string   `mapstructure:"configdir" yaml:"ConfigDir"`
+	ConfigDir string `mapstructure:"configdir" yaml:"ConfigDir"`
 	ConfigLocations []string `mapstructure:"configlocations" yaml:"ConfigLocations"`
-	Debug           bool     `mapstructure:"debug" yaml:"Debug"`
-	Director        struct {
-		AdvertiseUrl                  string        `mapstructure:"advertiseurl" yaml:"AdvertiseUrl"`
-		AdvertisementTTL              time.Duration `mapstructure:"advertisementttl" yaml:"AdvertisementTTL"`
-		AssumePresenceAtSingleOrigin  bool          `mapstructure:"assumepresenceatsingleorigin" yaml:"AssumePresenceAtSingleOrigin"`
-		CachePresenceCapacity         int           `mapstructure:"cachepresencecapacity" yaml:"CachePresenceCapacity"`
-		CachePresenceTTL              time.Duration `mapstructure:"cachepresencettl" yaml:"CachePresenceTTL"`
-		CacheResponseHostnames        []string      `mapstructure:"cacheresponsehostnames" yaml:"CacheResponseHostnames"`
-		CacheSortMethod               string        `mapstructure:"cachesortmethod" yaml:"CacheSortMethod"`
-		CachesPullFromCaches          bool          `mapstructure:"cachespullfromcaches" yaml:"CachesPullFromCaches"`
-		CheckCachePresence            bool          `mapstructure:"checkcachepresence" yaml:"CheckCachePresence"`
-		CheckOriginPresence           bool          `mapstructure:"checkoriginpresence" yaml:"CheckOriginPresence"`
-		DbLocation                    string        `mapstructure:"dblocation" yaml:"DbLocation"`
-		DefaultResponse               string        `mapstructure:"defaultresponse" yaml:"DefaultResponse"`
-		EnableBroker                  bool          `mapstructure:"enablebroker" yaml:"EnableBroker"`
-		EnableOIDC                    bool          `mapstructure:"enableoidc" yaml:"EnableOIDC"`
-		EnableStat                    bool          `mapstructure:"enablestat" yaml:"EnableStat"`
-		FedTokenLifetime              time.Duration `mapstructure:"fedtokenlifetime" yaml:"FedTokenLifetime"`
-		FilteredServers               []string      `mapstructure:"filteredservers" yaml:"FilteredServers"`
-		GeoIPLocation                 string        `mapstructure:"geoiplocation" yaml:"GeoIPLocation"`
-		MaxMindKeyFile                string        `mapstructure:"maxmindkeyfile" yaml:"MaxMindKeyFile"`
-		MaxStatResponse               int           `mapstructure:"maxstatresponse" yaml:"MaxStatResponse"`
-		MinStatResponse               int           `mapstructure:"minstatresponse" yaml:"MinStatResponse"`
+	Debug bool `mapstructure:"debug" yaml:"Debug"`
+	Director struct {
+		AdvertiseUrl string `mapstructure:"advertiseurl" yaml:"AdvertiseUrl"`
+		AdvertisementTTL time.Duration `mapstructure:"advertisementttl" yaml:"AdvertisementTTL"`
+		AssumePresenceAtSingleOrigin bool `mapstructure:"assumepresenceatsingleorigin" yaml:"AssumePresenceAtSingleOrigin"`
+		CachePresenceCapacity int `mapstructure:"cachepresencecapacity" yaml:"CachePresenceCapacity"`
+		CachePresenceTTL time.Duration `mapstructure:"cachepresencettl" yaml:"CachePresenceTTL"`
+		CacheResponseHostnames []string `mapstructure:"cacheresponsehostnames" yaml:"CacheResponseHostnames"`
+		CacheSortMethod string `mapstructure:"cachesortmethod" yaml:"CacheSortMethod"`
+		CachesPullFromCaches bool `mapstructure:"cachespullfromcaches" yaml:"CachesPullFromCaches"`
+		CheckCachePresence bool `mapstructure:"checkcachepresence" yaml:"CheckCachePresence"`
+		CheckOriginPresence bool `mapstructure:"checkoriginpresence" yaml:"CheckOriginPresence"`
+		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
+		DefaultResponse string `mapstructure:"defaultresponse" yaml:"DefaultResponse"`
+		EnableBroker bool `mapstructure:"enablebroker" yaml:"EnableBroker"`
+		EnableOIDC bool `mapstructure:"enableoidc" yaml:"EnableOIDC"`
+		EnableStat bool `mapstructure:"enablestat" yaml:"EnableStat"`
+		FedTokenLifetime time.Duration `mapstructure:"fedtokenlifetime" yaml:"FedTokenLifetime"`
+		FilteredServers []string `mapstructure:"filteredservers" yaml:"FilteredServers"`
+		GeoIPLocation string `mapstructure:"geoiplocation" yaml:"GeoIPLocation"`
+		MaxMindKeyFile string `mapstructure:"maxmindkeyfile" yaml:"MaxMindKeyFile"`
+		MaxStatResponse int `mapstructure:"maxstatresponse" yaml:"MaxStatResponse"`
+		MinStatResponse int `mapstructure:"minstatresponse" yaml:"MinStatResponse"`
 		OriginCacheHealthTestInterval time.Duration `mapstructure:"origincachehealthtestinterval" yaml:"OriginCacheHealthTestInterval"`
-		OriginResponseHostnames       []string      `mapstructure:"originresponsehostnames" yaml:"OriginResponseHostnames"`
-		RegistryQueryInterval         time.Duration `mapstructure:"registryqueryinterval" yaml:"RegistryQueryInterval"`
-		StatConcurrencyLimit          int           `mapstructure:"statconcurrencylimit" yaml:"StatConcurrencyLimit"`
-		StatTimeout                   time.Duration `mapstructure:"stattimeout" yaml:"StatTimeout"`
-		SupportContactEmail           string        `mapstructure:"supportcontactemail" yaml:"SupportContactEmail"`
-		SupportContactUrl             string        `mapstructure:"supportcontacturl" yaml:"SupportContactUrl"`
+		OriginResponseHostnames []string `mapstructure:"originresponsehostnames" yaml:"OriginResponseHostnames"`
+		RegistryQueryInterval time.Duration `mapstructure:"registryqueryinterval" yaml:"RegistryQueryInterval"`
+		StatConcurrencyLimit int `mapstructure:"statconcurrencylimit" yaml:"StatConcurrencyLimit"`
+		StatTimeout time.Duration `mapstructure:"stattimeout" yaml:"StatTimeout"`
+		SupportContactEmail string `mapstructure:"supportcontactemail" yaml:"SupportContactEmail"`
+		SupportContactUrl string `mapstructure:"supportcontacturl" yaml:"SupportContactUrl"`
 	} `mapstructure:"director" yaml:"Director"`
-	DisableHttpProxy     bool `mapstructure:"disablehttpproxy" yaml:"DisableHttpProxy"`
+	DisableHttpProxy bool `mapstructure:"disablehttpproxy" yaml:"DisableHttpProxy"`
 	DisableProxyFallback bool `mapstructure:"disableproxyfallback" yaml:"DisableProxyFallback"`
-	Federation           struct {
-		BrokerUrl              string        `mapstructure:"brokerurl" yaml:"BrokerUrl"`
-		DirectorUrl            string        `mapstructure:"directorurl" yaml:"DirectorUrl"`
-		DiscoveryUrl           string        `mapstructure:"discoveryurl" yaml:"DiscoveryUrl"`
-		JwkUrl                 string        `mapstructure:"jwkurl" yaml:"JwkUrl"`
-		RegistryUrl            string        `mapstructure:"registryurl" yaml:"RegistryUrl"`
-		TopologyDowntimeUrl    string        `mapstructure:"topologydowntimeurl" yaml:"TopologyDowntimeUrl"`
-		TopologyNamespaceUrl   string        `mapstructure:"topologynamespaceurl" yaml:"TopologyNamespaceUrl"`
+	Federation struct {
+		BrokerUrl string `mapstructure:"brokerurl" yaml:"BrokerUrl"`
+		DirectorUrl string `mapstructure:"directorurl" yaml:"DirectorUrl"`
+		DiscoveryUrl string `mapstructure:"discoveryurl" yaml:"DiscoveryUrl"`
+		JwkUrl string `mapstructure:"jwkurl" yaml:"JwkUrl"`
+		RegistryUrl string `mapstructure:"registryurl" yaml:"RegistryUrl"`
+		TopologyDowntimeUrl string `mapstructure:"topologydowntimeurl" yaml:"TopologyDowntimeUrl"`
+		TopologyNamespaceUrl string `mapstructure:"topologynamespaceurl" yaml:"TopologyNamespaceUrl"`
 		TopologyReloadInterval time.Duration `mapstructure:"topologyreloadinterval" yaml:"TopologyReloadInterval"`
-		TopologyUrl            string        `mapstructure:"topologyurl" yaml:"TopologyUrl"`
+		TopologyUrl string `mapstructure:"topologyurl" yaml:"TopologyUrl"`
 	} `mapstructure:"federation" yaml:"Federation"`
 	GeoIPOverrides interface{} `mapstructure:"geoipoverrides" yaml:"GeoIPOverrides"`
-	Issuer         struct {
-		AuthenticationSource           string      `mapstructure:"authenticationsource" yaml:"AuthenticationSource"`
-		AuthorizationTemplates         interface{} `mapstructure:"authorizationtemplates" yaml:"AuthorizationTemplates"`
-		GroupFile                      string      `mapstructure:"groupfile" yaml:"GroupFile"`
-		GroupRequirements              []string    `mapstructure:"grouprequirements" yaml:"GroupRequirements"`
-		GroupSource                    string      `mapstructure:"groupsource" yaml:"GroupSource"`
-		IssuerClaimValue               string      `mapstructure:"issuerclaimvalue" yaml:"IssuerClaimValue"`
+	Issuer struct {
+		AuthenticationSource string `mapstructure:"authenticationsource" yaml:"AuthenticationSource"`
+		AuthorizationTemplates interface{} `mapstructure:"authorizationtemplates" yaml:"AuthorizationTemplates"`
+		GroupFile string `mapstructure:"groupfile" yaml:"GroupFile"`
+		GroupRequirements []string `mapstructure:"grouprequirements" yaml:"GroupRequirements"`
+		GroupSource string `mapstructure:"groupsource" yaml:"GroupSource"`
+		IssuerClaimValue string `mapstructure:"issuerclaimvalue" yaml:"IssuerClaimValue"`
 		OIDCAuthenticationRequirements interface{} `mapstructure:"oidcauthenticationrequirements" yaml:"OIDCAuthenticationRequirements"`
-		OIDCAuthenticationUserClaim    string      `mapstructure:"oidcauthenticationuserclaim" yaml:"OIDCAuthenticationUserClaim"`
-		OIDCGroupClaim                 string      `mapstructure:"oidcgroupclaim" yaml:"OIDCGroupClaim"`
-		OIDCPreferClaimsFromIDToken    bool        `mapstructure:"oidcpreferclaimsfromidtoken" yaml:"OIDCPreferClaimsFromIDToken"`
-		QDLLocation                    string      `mapstructure:"qdllocation" yaml:"QDLLocation"`
-		RedirectUris                   []string    `mapstructure:"redirecturis" yaml:"RedirectUris"`
-		ScitokensServerLocation        string      `mapstructure:"scitokensserverlocation" yaml:"ScitokensServerLocation"`
-		TomcatLocation                 string      `mapstructure:"tomcatlocation" yaml:"TomcatLocation"`
-		UserStripDomain                bool        `mapstructure:"userstripdomain" yaml:"UserStripDomain"`
+		OIDCAuthenticationUserClaim string `mapstructure:"oidcauthenticationuserclaim" yaml:"OIDCAuthenticationUserClaim"`
+		OIDCGroupClaim string `mapstructure:"oidcgroupclaim" yaml:"OIDCGroupClaim"`
+		OIDCPreferClaimsFromIDToken bool `mapstructure:"oidcpreferclaimsfromidtoken" yaml:"OIDCPreferClaimsFromIDToken"`
+		QDLLocation string `mapstructure:"qdllocation" yaml:"QDLLocation"`
+		RedirectUris []string `mapstructure:"redirecturis" yaml:"RedirectUris"`
+		ScitokensServerLocation string `mapstructure:"scitokensserverlocation" yaml:"ScitokensServerLocation"`
+		TomcatLocation string `mapstructure:"tomcatlocation" yaml:"TomcatLocation"`
+		UserStripDomain bool `mapstructure:"userstripdomain" yaml:"UserStripDomain"`
 	} `mapstructure:"issuer" yaml:"Issuer"`
-	IssuerKey           string `mapstructure:"issuerkey" yaml:"IssuerKey"`
+	IssuerKey string `mapstructure:"issuerkey" yaml:"IssuerKey"`
 	IssuerKeysDirectory string `mapstructure:"issuerkeysdirectory" yaml:"IssuerKeysDirectory"`
-	LocalCache          struct {
-		DataLocation            string `mapstructure:"datalocation" yaml:"DataLocation"`
-		HighWaterMarkPercentage int    `mapstructure:"highwatermarkpercentage" yaml:"HighWaterMarkPercentage"`
-		LowWaterMarkPercentage  int    `mapstructure:"lowwatermarkpercentage" yaml:"LowWaterMarkPercentage"`
-		RunLocation             string `mapstructure:"runlocation" yaml:"RunLocation"`
-		Size                    string `mapstructure:"size" yaml:"Size"`
-		Socket                  string `mapstructure:"socket" yaml:"Socket"`
+	LocalCache struct {
+		DataLocation string `mapstructure:"datalocation" yaml:"DataLocation"`
+		HighWaterMarkPercentage int `mapstructure:"highwatermarkpercentage" yaml:"HighWaterMarkPercentage"`
+		LowWaterMarkPercentage int `mapstructure:"lowwatermarkpercentage" yaml:"LowWaterMarkPercentage"`
+		RunLocation string `mapstructure:"runlocation" yaml:"RunLocation"`
+		Size string `mapstructure:"size" yaml:"Size"`
+		Socket string `mapstructure:"socket" yaml:"Socket"`
 	} `mapstructure:"localcache" yaml:"LocalCache"`
 	Logging struct {
 		Cache struct {
-			Http      string `mapstructure:"http" yaml:"Http"`
-			Ofs       string `mapstructure:"ofs" yaml:"Ofs"`
-			Pfc       string `mapstructure:"pfc" yaml:"Pfc"`
-			Pss       string `mapstructure:"pss" yaml:"Pss"`
+			Http string `mapstructure:"http" yaml:"Http"`
+			Ofs string `mapstructure:"ofs" yaml:"Ofs"`
+			Pfc string `mapstructure:"pfc" yaml:"Pfc"`
+			Pss string `mapstructure:"pss" yaml:"Pss"`
 			PssSetOpt string `mapstructure:"psssetopt" yaml:"PssSetOpt"`
 			Scitokens string `mapstructure:"scitokens" yaml:"Scitokens"`
-			Xrd       string `mapstructure:"xrd" yaml:"Xrd"`
-			Xrootd    string `mapstructure:"xrootd" yaml:"Xrootd"`
+			Xrd string `mapstructure:"xrd" yaml:"Xrd"`
+			Xrootd string `mapstructure:"xrootd" yaml:"Xrootd"`
 		} `mapstructure:"cache" yaml:"Cache"`
 		Client struct {
 			ProgressInterval time.Duration `mapstructure:"progressinterval" yaml:"ProgressInterval"`
 		} `mapstructure:"client" yaml:"Client"`
-		DisableProgressBars bool   `mapstructure:"disableprogressbars" yaml:"DisableProgressBars"`
-		Level               string `mapstructure:"level" yaml:"Level"`
-		LogLocation         string `mapstructure:"loglocation" yaml:"LogLocation"`
-		Origin              struct {
-			Cms       string `mapstructure:"cms" yaml:"Cms"`
-			Http      string `mapstructure:"http" yaml:"Http"`
-			Ofs       string `mapstructure:"ofs" yaml:"Ofs"`
-			Oss       string `mapstructure:"oss" yaml:"Oss"`
+		DisableProgressBars bool `mapstructure:"disableprogressbars" yaml:"DisableProgressBars"`
+		Level string `mapstructure:"level" yaml:"Level"`
+		LogLocation string `mapstructure:"loglocation" yaml:"LogLocation"`
+		Origin struct {
+			Cms string `mapstructure:"cms" yaml:"Cms"`
+			Http string `mapstructure:"http" yaml:"Http"`
+			Ofs string `mapstructure:"ofs" yaml:"Ofs"`
+			Oss string `mapstructure:"oss" yaml:"Oss"`
 			Scitokens string `mapstructure:"scitokens" yaml:"Scitokens"`
-			Xrd       string `mapstructure:"xrd" yaml:"Xrd"`
-			Xrootd    string `mapstructure:"xrootd" yaml:"Xrootd"`
+			Xrd string `mapstructure:"xrd" yaml:"Xrd"`
+			Xrootd string `mapstructure:"xrootd" yaml:"Xrootd"`
 		} `mapstructure:"origin" yaml:"Origin"`
 	} `mapstructure:"logging" yaml:"Logging"`
 	Lotman struct {
-		DbLocation                   string        `mapstructure:"dblocation" yaml:"DbLocation"`
-		DefaultLotDeletionLifetime   time.Duration `mapstructure:"defaultlotdeletionlifetime" yaml:"DefaultLotDeletionLifetime"`
+		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
+		DefaultLotDeletionLifetime time.Duration `mapstructure:"defaultlotdeletionlifetime" yaml:"DefaultLotDeletionLifetime"`
 		DefaultLotExpirationLifetime time.Duration `mapstructure:"defaultlotexpirationlifetime" yaml:"DefaultLotExpirationLifetime"`
-		EnableAPI                    bool          `mapstructure:"enableapi" yaml:"EnableAPI"`
-		EnabledPolicy                string        `mapstructure:"enabledpolicy" yaml:"EnabledPolicy"`
-		LibLocation                  string        `mapstructure:"liblocation" yaml:"LibLocation"`
-		LotHome                      string        `mapstructure:"lothome" yaml:"LotHome"`
-		PolicyDefinitions            interface{}   `mapstructure:"policydefinitions" yaml:"PolicyDefinitions"`
+		EnableAPI bool `mapstructure:"enableapi" yaml:"EnableAPI"`
+		EnabledPolicy string `mapstructure:"enabledpolicy" yaml:"EnabledPolicy"`
+		LibLocation string `mapstructure:"liblocation" yaml:"LibLocation"`
+		LotHome string `mapstructure:"lothome" yaml:"LotHome"`
+		PolicyDefinitions interface{} `mapstructure:"policydefinitions" yaml:"PolicyDefinitions"`
 	} `mapstructure:"lotman" yaml:"Lotman"`
 	MinimumDownloadSpeed int `mapstructure:"minimumdownloadspeed" yaml:"MinimumDownloadSpeed"`
-	Monitoring           struct {
-		AggregatePrefixes     []string      `mapstructure:"aggregateprefixes" yaml:"AggregatePrefixes"`
-		DataLocation          string        `mapstructure:"datalocation" yaml:"DataLocation"`
-		DataRetention         time.Duration `mapstructure:"dataretention" yaml:"DataRetention"`
-		LabelLimit            int           `mapstructure:"labellimit" yaml:"LabelLimit"`
-		LabelNameLengthLimit  int           `mapstructure:"labelnamelengthlimit" yaml:"LabelNameLengthLimit"`
-		LabelValueLengthLimit int           `mapstructure:"labelvaluelengthlimit" yaml:"LabelValueLengthLimit"`
-		MetricAuthorization   bool          `mapstructure:"metricauthorization" yaml:"MetricAuthorization"`
-		PortHigher            int           `mapstructure:"porthigher" yaml:"PortHigher"`
-		PortLower             int           `mapstructure:"portlower" yaml:"PortLower"`
-		PromQLAuthorization   bool          `mapstructure:"promqlauthorization" yaml:"PromQLAuthorization"`
-		SampleLimit           int           `mapstructure:"samplelimit" yaml:"SampleLimit"`
-		TokenExpiresIn        time.Duration `mapstructure:"tokenexpiresin" yaml:"TokenExpiresIn"`
-		TokenRefreshInterval  time.Duration `mapstructure:"tokenrefreshinterval" yaml:"TokenRefreshInterval"`
+	Monitoring struct {
+		AggregatePrefixes []string `mapstructure:"aggregateprefixes" yaml:"AggregatePrefixes"`
+		DataLocation string `mapstructure:"datalocation" yaml:"DataLocation"`
+		DataRetention time.Duration `mapstructure:"dataretention" yaml:"DataRetention"`
+		LabelLimit int `mapstructure:"labellimit" yaml:"LabelLimit"`
+		LabelNameLengthLimit int `mapstructure:"labelnamelengthlimit" yaml:"LabelNameLengthLimit"`
+		LabelValueLengthLimit int `mapstructure:"labelvaluelengthlimit" yaml:"LabelValueLengthLimit"`
+		MetricAuthorization bool `mapstructure:"metricauthorization" yaml:"MetricAuthorization"`
+		PortHigher int `mapstructure:"porthigher" yaml:"PortHigher"`
+		PortLower int `mapstructure:"portlower" yaml:"PortLower"`
+		PromQLAuthorization bool `mapstructure:"promqlauthorization" yaml:"PromQLAuthorization"`
+		SampleLimit int `mapstructure:"samplelimit" yaml:"SampleLimit"`
+		TokenExpiresIn time.Duration `mapstructure:"tokenexpiresin" yaml:"TokenExpiresIn"`
+		TokenRefreshInterval time.Duration `mapstructure:"tokenrefreshinterval" yaml:"TokenRefreshInterval"`
 	} `mapstructure:"monitoring" yaml:"Monitoring"`
 	OIDC struct {
-		AuthorizationEndpoint  string `mapstructure:"authorizationendpoint" yaml:"AuthorizationEndpoint"`
-		ClientID               string `mapstructure:"clientid" yaml:"ClientID"`
-		ClientIDFile           string `mapstructure:"clientidfile" yaml:"ClientIDFile"`
+		AuthorizationEndpoint string `mapstructure:"authorizationendpoint" yaml:"AuthorizationEndpoint"`
+		ClientID string `mapstructure:"clientid" yaml:"ClientID"`
+		ClientIDFile string `mapstructure:"clientidfile" yaml:"ClientIDFile"`
 		ClientRedirectHostname string `mapstructure:"clientredirecthostname" yaml:"ClientRedirectHostname"`
-		ClientSecretFile       string `mapstructure:"clientsecretfile" yaml:"ClientSecretFile"`
-		DeviceAuthEndpoint     string `mapstructure:"deviceauthendpoint" yaml:"DeviceAuthEndpoint"`
-		Issuer                 string `mapstructure:"issuer" yaml:"Issuer"`
-		TokenEndpoint          string `mapstructure:"tokenendpoint" yaml:"TokenEndpoint"`
-		UserInfoEndpoint       string `mapstructure:"userinfoendpoint" yaml:"UserInfoEndpoint"`
+		ClientSecretFile string `mapstructure:"clientsecretfile" yaml:"ClientSecretFile"`
+		DeviceAuthEndpoint string `mapstructure:"deviceauthendpoint" yaml:"DeviceAuthEndpoint"`
+		Issuer string `mapstructure:"issuer" yaml:"Issuer"`
+		TokenEndpoint string `mapstructure:"tokenendpoint" yaml:"TokenEndpoint"`
+		UserInfoEndpoint string `mapstructure:"userinfoendpoint" yaml:"UserInfoEndpoint"`
 	} `mapstructure:"oidc" yaml:"OIDC"`
 	Origin struct {
-		Concurrency              int           `mapstructure:"concurrency" yaml:"Concurrency"`
-		DbLocation               string        `mapstructure:"dblocation" yaml:"DbLocation"`
-		DirectorTest             bool          `mapstructure:"directortest" yaml:"DirectorTest"`
-		DisableDirectClients     bool          `mapstructure:"disabledirectclients" yaml:"DisableDirectClients"`
-		EnableBroker             bool          `mapstructure:"enablebroker" yaml:"EnableBroker"`
-		EnableCmsd               bool          `mapstructure:"enablecmsd" yaml:"EnableCmsd"`
-		EnableDirListing         bool          `mapstructure:"enabledirlisting" yaml:"EnableDirListing"`
-		EnableDirectReads        bool          `mapstructure:"enabledirectreads" yaml:"EnableDirectReads"`
-		EnableFallbackRead       bool          `mapstructure:"enablefallbackread" yaml:"EnableFallbackRead"`
-		EnableIssuer             bool          `mapstructure:"enableissuer" yaml:"EnableIssuer"`
-		EnableListings           bool          `mapstructure:"enablelistings" yaml:"EnableListings"`
-		EnableMacaroons          bool          `mapstructure:"enablemacaroons" yaml:"EnableMacaroons"`
-		EnableOIDC               bool          `mapstructure:"enableoidc" yaml:"EnableOIDC"`
-		EnablePublicReads        bool          `mapstructure:"enablepublicreads" yaml:"EnablePublicReads"`
-		EnableReads              bool          `mapstructure:"enablereads" yaml:"EnableReads"`
-		EnableUI                 bool          `mapstructure:"enableui" yaml:"EnableUI"`
-		EnableVoms               bool          `mapstructure:"enablevoms" yaml:"EnableVoms"`
-		EnableWrite              bool          `mapstructure:"enablewrite" yaml:"EnableWrite"`
-		EnableWrites             bool          `mapstructure:"enablewrites" yaml:"EnableWrites"`
-		ExportVolume             string        `mapstructure:"exportvolume" yaml:"ExportVolume"`
-		ExportVolumes            []string      `mapstructure:"exportvolumes" yaml:"ExportVolumes"`
-		Exports                  interface{}   `mapstructure:"exports" yaml:"Exports"`
-		FedTokenLocation         string        `mapstructure:"fedtokenlocation" yaml:"FedTokenLocation"`
-		FederationPrefix         string        `mapstructure:"federationprefix" yaml:"FederationPrefix"`
-		GlobusClientIDFile       string        `mapstructure:"globusclientidfile" yaml:"GlobusClientIDFile"`
-		GlobusClientSecretFile   string        `mapstructure:"globusclientsecretfile" yaml:"GlobusClientSecretFile"`
-		GlobusCollectionID       string        `mapstructure:"globuscollectionid" yaml:"GlobusCollectionID"`
-		GlobusCollectionName     string        `mapstructure:"globuscollectionname" yaml:"GlobusCollectionName"`
-		GlobusConfigLocation     string        `mapstructure:"globusconfiglocation" yaml:"GlobusConfigLocation"`
-		HttpAuthTokenFile        string        `mapstructure:"httpauthtokenfile" yaml:"HttpAuthTokenFile"`
-		HttpServiceUrl           string        `mapstructure:"httpserviceurl" yaml:"HttpServiceUrl"`
-		Mode                     string        `mapstructure:"mode" yaml:"Mode"`
-		Multiuser                bool          `mapstructure:"multiuser" yaml:"Multiuser"`
-		NamespacePrefix          string        `mapstructure:"namespaceprefix" yaml:"NamespacePrefix"`
-		Port                     int           `mapstructure:"port" yaml:"Port"`
-		RunLocation              string        `mapstructure:"runlocation" yaml:"RunLocation"`
-		S3AccessKeyfile          string        `mapstructure:"s3accesskeyfile" yaml:"S3AccessKeyfile"`
-		S3Bucket                 string        `mapstructure:"s3bucket" yaml:"S3Bucket"`
-		S3Region                 string        `mapstructure:"s3region" yaml:"S3Region"`
-		S3SecretKeyfile          string        `mapstructure:"s3secretkeyfile" yaml:"S3SecretKeyfile"`
-		S3ServiceName            string        `mapstructure:"s3servicename" yaml:"S3ServiceName"`
-		S3ServiceUrl             string        `mapstructure:"s3serviceurl" yaml:"S3ServiceUrl"`
-		S3UrlStyle               string        `mapstructure:"s3urlstyle" yaml:"S3UrlStyle"`
-		ScitokensDefaultUser     string        `mapstructure:"scitokensdefaultuser" yaml:"ScitokensDefaultUser"`
-		ScitokensMapSubject      bool          `mapstructure:"scitokensmapsubject" yaml:"ScitokensMapSubject"`
-		ScitokensNameMapFile     string        `mapstructure:"scitokensnamemapfile" yaml:"ScitokensNameMapFile"`
-		ScitokensRestrictedPaths []string      `mapstructure:"scitokensrestrictedpaths" yaml:"ScitokensRestrictedPaths"`
-		ScitokensUsernameClaim   string        `mapstructure:"scitokensusernameclaim" yaml:"ScitokensUsernameClaim"`
-		SelfTest                 bool          `mapstructure:"selftest" yaml:"SelfTest"`
-		SelfTestInterval         time.Duration `mapstructure:"selftestinterval" yaml:"SelfTestInterval"`
-		StoragePrefix            string        `mapstructure:"storageprefix" yaml:"StoragePrefix"`
-		StorageType              string        `mapstructure:"storagetype" yaml:"StorageType"`
-		TokenAudience            string        `mapstructure:"tokenaudience" yaml:"TokenAudience"`
-		Url                      string        `mapstructure:"url" yaml:"Url"`
-		XRootDPrefix             string        `mapstructure:"xrootdprefix" yaml:"XRootDPrefix"`
-		XRootServiceUrl          string        `mapstructure:"xrootserviceurl" yaml:"XRootServiceUrl"`
+		Concurrency int `mapstructure:"concurrency" yaml:"Concurrency"`
+		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
+		DirectorTest bool `mapstructure:"directortest" yaml:"DirectorTest"`
+		DisableDirectClients bool `mapstructure:"disabledirectclients" yaml:"DisableDirectClients"`
+		EnableBroker bool `mapstructure:"enablebroker" yaml:"EnableBroker"`
+		EnableCmsd bool `mapstructure:"enablecmsd" yaml:"EnableCmsd"`
+		EnableDirListing bool `mapstructure:"enabledirlisting" yaml:"EnableDirListing"`
+		EnableDirectReads bool `mapstructure:"enabledirectreads" yaml:"EnableDirectReads"`
+		EnableFallbackRead bool `mapstructure:"enablefallbackread" yaml:"EnableFallbackRead"`
+		EnableIssuer bool `mapstructure:"enableissuer" yaml:"EnableIssuer"`
+		EnableListings bool `mapstructure:"enablelistings" yaml:"EnableListings"`
+		EnableMacaroons bool `mapstructure:"enablemacaroons" yaml:"EnableMacaroons"`
+		EnableOIDC bool `mapstructure:"enableoidc" yaml:"EnableOIDC"`
+		EnablePublicReads bool `mapstructure:"enablepublicreads" yaml:"EnablePublicReads"`
+		EnableReads bool `mapstructure:"enablereads" yaml:"EnableReads"`
+		EnableUI bool `mapstructure:"enableui" yaml:"EnableUI"`
+		EnableVoms bool `mapstructure:"enablevoms" yaml:"EnableVoms"`
+		EnableWrite bool `mapstructure:"enablewrite" yaml:"EnableWrite"`
+		EnableWrites bool `mapstructure:"enablewrites" yaml:"EnableWrites"`
+		ExportVolume string `mapstructure:"exportvolume" yaml:"ExportVolume"`
+		ExportVolumes []string `mapstructure:"exportvolumes" yaml:"ExportVolumes"`
+		Exports interface{} `mapstructure:"exports" yaml:"Exports"`
+		FedTokenLocation string `mapstructure:"fedtokenlocation" yaml:"FedTokenLocation"`
+		FederationPrefix string `mapstructure:"federationprefix" yaml:"FederationPrefix"`
+		GlobusClientIDFile string `mapstructure:"globusclientidfile" yaml:"GlobusClientIDFile"`
+		GlobusClientSecretFile string `mapstructure:"globusclientsecretfile" yaml:"GlobusClientSecretFile"`
+		GlobusCollectionID string `mapstructure:"globuscollectionid" yaml:"GlobusCollectionID"`
+		GlobusCollectionName string `mapstructure:"globuscollectionname" yaml:"GlobusCollectionName"`
+		GlobusConfigLocation string `mapstructure:"globusconfiglocation" yaml:"GlobusConfigLocation"`
+		HttpAuthTokenFile string `mapstructure:"httpauthtokenfile" yaml:"HttpAuthTokenFile"`
+		HttpServiceUrl string `mapstructure:"httpserviceurl" yaml:"HttpServiceUrl"`
+		Mode string `mapstructure:"mode" yaml:"Mode"`
+		Multiuser bool `mapstructure:"multiuser" yaml:"Multiuser"`
+		NamespacePrefix string `mapstructure:"namespaceprefix" yaml:"NamespacePrefix"`
+		Port int `mapstructure:"port" yaml:"Port"`
+		RunLocation string `mapstructure:"runlocation" yaml:"RunLocation"`
+		S3AccessKeyfile string `mapstructure:"s3accesskeyfile" yaml:"S3AccessKeyfile"`
+		S3Bucket string `mapstructure:"s3bucket" yaml:"S3Bucket"`
+		S3Region string `mapstructure:"s3region" yaml:"S3Region"`
+		S3SecretKeyfile string `mapstructure:"s3secretkeyfile" yaml:"S3SecretKeyfile"`
+		S3ServiceName string `mapstructure:"s3servicename" yaml:"S3ServiceName"`
+		S3ServiceUrl string `mapstructure:"s3serviceurl" yaml:"S3ServiceUrl"`
+		S3UrlStyle string `mapstructure:"s3urlstyle" yaml:"S3UrlStyle"`
+		ScitokensDefaultUser string `mapstructure:"scitokensdefaultuser" yaml:"ScitokensDefaultUser"`
+		ScitokensMapSubject bool `mapstructure:"scitokensmapsubject" yaml:"ScitokensMapSubject"`
+		ScitokensNameMapFile string `mapstructure:"scitokensnamemapfile" yaml:"ScitokensNameMapFile"`
+		ScitokensRestrictedPaths []string `mapstructure:"scitokensrestrictedpaths" yaml:"ScitokensRestrictedPaths"`
+		ScitokensUsernameClaim string `mapstructure:"scitokensusernameclaim" yaml:"ScitokensUsernameClaim"`
+		SelfTest bool `mapstructure:"selftest" yaml:"SelfTest"`
+		SelfTestInterval time.Duration `mapstructure:"selftestinterval" yaml:"SelfTestInterval"`
+		StoragePrefix string `mapstructure:"storageprefix" yaml:"StoragePrefix"`
+		StorageType string `mapstructure:"storagetype" yaml:"StorageType"`
+		TokenAudience string `mapstructure:"tokenaudience" yaml:"TokenAudience"`
+		Url string `mapstructure:"url" yaml:"Url"`
+		XRootDPrefix string `mapstructure:"xrootdprefix" yaml:"XRootDPrefix"`
+		XRootServiceUrl string `mapstructure:"xrootserviceurl" yaml:"XRootServiceUrl"`
 	} `mapstructure:"origin" yaml:"Origin"`
 	Plugin struct {
 		Token string `mapstructure:"token" yaml:"Token"`
 	} `mapstructure:"plugin" yaml:"Plugin"`
 	Registry struct {
-		AdminUsers                   []string      `mapstructure:"adminusers" yaml:"AdminUsers"`
-		CustomRegistrationFields     interface{}   `mapstructure:"customregistrationfields" yaml:"CustomRegistrationFields"`
-		DbLocation                   string        `mapstructure:"dblocation" yaml:"DbLocation"`
-		Institutions                 interface{}   `mapstructure:"institutions" yaml:"Institutions"`
-		InstitutionsUrl              string        `mapstructure:"institutionsurl" yaml:"InstitutionsUrl"`
+		AdminUsers []string `mapstructure:"adminusers" yaml:"AdminUsers"`
+		CustomRegistrationFields interface{} `mapstructure:"customregistrationfields" yaml:"CustomRegistrationFields"`
+		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
+		Institutions interface{} `mapstructure:"institutions" yaml:"Institutions"`
+		InstitutionsUrl string `mapstructure:"institutionsurl" yaml:"InstitutionsUrl"`
 		InstitutionsUrlReloadMinutes time.Duration `mapstructure:"institutionsurlreloadminutes" yaml:"InstitutionsUrlReloadMinutes"`
-		RequireCacheApproval         bool          `mapstructure:"requirecacheapproval" yaml:"RequireCacheApproval"`
-		RequireKeyChaining           bool          `mapstructure:"requirekeychaining" yaml:"RequireKeyChaining"`
-		RequireOriginApproval        bool          `mapstructure:"requireoriginapproval" yaml:"RequireOriginApproval"`
+		RequireCacheApproval bool `mapstructure:"requirecacheapproval" yaml:"RequireCacheApproval"`
+		RequireKeyChaining bool `mapstructure:"requirekeychaining" yaml:"RequireKeyChaining"`
+		RequireOriginApproval bool `mapstructure:"requireoriginapproval" yaml:"RequireOriginApproval"`
 	} `mapstructure:"registry" yaml:"Registry"`
 	Server struct {
-		AdLifetime                time.Duration `mapstructure:"adlifetime" yaml:"AdLifetime"`
-		AdvertisementInterval     time.Duration `mapstructure:"advertisementinterval" yaml:"AdvertisementInterval"`
-		DbLocation                string        `mapstructure:"dblocation" yaml:"DbLocation"`
-		DirectorUrls              []string      `mapstructure:"directorurls" yaml:"DirectorUrls"`
-		DropPrivileges            bool          `mapstructure:"dropprivileges" yaml:"DropPrivileges"`
-		EnablePprof               bool          `mapstructure:"enablepprof" yaml:"EnablePprof"`
-		EnableUI                  bool          `mapstructure:"enableui" yaml:"EnableUI"`
-		ExternalWebUrl            string        `mapstructure:"externalweburl" yaml:"ExternalWebUrl"`
-		HealthMonitoringPublic    bool          `mapstructure:"healthmonitoringpublic" yaml:"HealthMonitoringPublic"`
-		Hostname                  string        `mapstructure:"hostname" yaml:"Hostname"`
-		IssuerHostname            string        `mapstructure:"issuerhostname" yaml:"IssuerHostname"`
-		IssuerJwks                string        `mapstructure:"issuerjwks" yaml:"IssuerJwks"`
-		IssuerPort                int           `mapstructure:"issuerport" yaml:"IssuerPort"`
-		IssuerUrl                 string        `mapstructure:"issuerurl" yaml:"IssuerUrl"`
-		Modules                   []string      `mapstructure:"modules" yaml:"Modules"`
+		AdLifetime time.Duration `mapstructure:"adlifetime" yaml:"AdLifetime"`
+		AdvertisementInterval time.Duration `mapstructure:"advertisementinterval" yaml:"AdvertisementInterval"`
+		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
+		DirectorUrls []string `mapstructure:"directorurls" yaml:"DirectorUrls"`
+		DropPrivileges bool `mapstructure:"dropprivileges" yaml:"DropPrivileges"`
+		EnablePprof bool `mapstructure:"enablepprof" yaml:"EnablePprof"`
+		EnableUI bool `mapstructure:"enableui" yaml:"EnableUI"`
+		ExternalWebUrl string `mapstructure:"externalweburl" yaml:"ExternalWebUrl"`
+		HealthMonitoringPublic bool `mapstructure:"healthmonitoringpublic" yaml:"HealthMonitoringPublic"`
+		Hostname string `mapstructure:"hostname" yaml:"Hostname"`
+		IssuerHostname string `mapstructure:"issuerhostname" yaml:"IssuerHostname"`
+		IssuerJwks string `mapstructure:"issuerjwks" yaml:"IssuerJwks"`
+		IssuerPort int `mapstructure:"issuerport" yaml:"IssuerPort"`
+		IssuerUrl string `mapstructure:"issuerurl" yaml:"IssuerUrl"`
+		Modules []string `mapstructure:"modules" yaml:"Modules"`
 		RegistrationRetryInterval time.Duration `mapstructure:"registrationretryinterval" yaml:"RegistrationRetryInterval"`
-		SessionSecretFile         string        `mapstructure:"sessionsecretfile" yaml:"SessionSecretFile"`
-		StartupTimeout            time.Duration `mapstructure:"startuptimeout" yaml:"StartupTimeout"`
-		TLSCACertificateDirectory string        `mapstructure:"tlscacertificatedirectory" yaml:"TLSCACertificateDirectory"`
-		TLSCACertificateFile      string        `mapstructure:"tlscacertificatefile" yaml:"TLSCACertificateFile"`
-		TLSCAKey                  string        `mapstructure:"tlscakey" yaml:"TLSCAKey"`
-		TLSCertificate            string        `mapstructure:"tlscertificate" yaml:"TLSCertificate"`
-		TLSCertificateChain       string        `mapstructure:"tlscertificatechain" yaml:"TLSCertificateChain"`
-		TLSKey                    string        `mapstructure:"tlskey" yaml:"TLSKey"`
-		UIActivationCodeFile      string        `mapstructure:"uiactivationcodefile" yaml:"UIActivationCodeFile"`
-		UIAdminUsers              []string      `mapstructure:"uiadminusers" yaml:"UIAdminUsers"`
-		UILoginRateLimit          int           `mapstructure:"uiloginratelimit" yaml:"UILoginRateLimit"`
-		UIPasswordFile            string        `mapstructure:"uipasswordfile" yaml:"UIPasswordFile"`
-		UnprivilegedUser          string        `mapstructure:"unprivilegeduser" yaml:"UnprivilegedUser"`
-		WebConfigFile             string        `mapstructure:"webconfigfile" yaml:"WebConfigFile"`
-		WebHost                   string        `mapstructure:"webhost" yaml:"WebHost"`
-		WebPort                   int           `mapstructure:"webport" yaml:"WebPort"`
+		SessionSecretFile string `mapstructure:"sessionsecretfile" yaml:"SessionSecretFile"`
+		StartupTimeout time.Duration `mapstructure:"startuptimeout" yaml:"StartupTimeout"`
+		TLSCACertificateDirectory string `mapstructure:"tlscacertificatedirectory" yaml:"TLSCACertificateDirectory"`
+		TLSCACertificateFile string `mapstructure:"tlscacertificatefile" yaml:"TLSCACertificateFile"`
+		TLSCAKey string `mapstructure:"tlscakey" yaml:"TLSCAKey"`
+		TLSCertificate string `mapstructure:"tlscertificate" yaml:"TLSCertificate"`
+		TLSCertificateChain string `mapstructure:"tlscertificatechain" yaml:"TLSCertificateChain"`
+		TLSKey string `mapstructure:"tlskey" yaml:"TLSKey"`
+		UIActivationCodeFile string `mapstructure:"uiactivationcodefile" yaml:"UIActivationCodeFile"`
+		UIAdminUsers []string `mapstructure:"uiadminusers" yaml:"UIAdminUsers"`
+		UILoginRateLimit int `mapstructure:"uiloginratelimit" yaml:"UILoginRateLimit"`
+		UIPasswordFile string `mapstructure:"uipasswordfile" yaml:"UIPasswordFile"`
+		UnprivilegedUser string `mapstructure:"unprivilegeduser" yaml:"UnprivilegedUser"`
+		WebConfigFile string `mapstructure:"webconfigfile" yaml:"WebConfigFile"`
+		WebHost string `mapstructure:"webhost" yaml:"WebHost"`
+		WebPort int `mapstructure:"webport" yaml:"WebPort"`
 	} `mapstructure:"server" yaml:"Server"`
 	Shoveler struct {
-		AMQPExchange         string      `mapstructure:"amqpexchange" yaml:"AMQPExchange"`
-		AMQPTokenLocation    string      `mapstructure:"amqptokenlocation" yaml:"AMQPTokenLocation"`
-		Enable               bool        `mapstructure:"enable" yaml:"Enable"`
-		IPMapping            interface{} `mapstructure:"ipmapping" yaml:"IPMapping"`
-		MessageQueueProtocol string      `mapstructure:"messagequeueprotocol" yaml:"MessageQueueProtocol"`
-		OutputDestinations   []string    `mapstructure:"outputdestinations" yaml:"OutputDestinations"`
-		PortHigher           int         `mapstructure:"porthigher" yaml:"PortHigher"`
-		PortLower            int         `mapstructure:"portlower" yaml:"PortLower"`
-		QueueDirectory       string      `mapstructure:"queuedirectory" yaml:"QueueDirectory"`
-		StompCert            string      `mapstructure:"stompcert" yaml:"StompCert"`
-		StompCertKey         string      `mapstructure:"stompcertkey" yaml:"StompCertKey"`
-		StompPassword        string      `mapstructure:"stomppassword" yaml:"StompPassword"`
-		StompUsername        string      `mapstructure:"stompusername" yaml:"StompUsername"`
-		Topic                string      `mapstructure:"topic" yaml:"Topic"`
-		URL                  string      `mapstructure:"url" yaml:"URL"`
-		VerifyHeader         bool        `mapstructure:"verifyheader" yaml:"VerifyHeader"`
+		AMQPExchange string `mapstructure:"amqpexchange" yaml:"AMQPExchange"`
+		AMQPTokenLocation string `mapstructure:"amqptokenlocation" yaml:"AMQPTokenLocation"`
+		Enable bool `mapstructure:"enable" yaml:"Enable"`
+		IPMapping interface{} `mapstructure:"ipmapping" yaml:"IPMapping"`
+		MessageQueueProtocol string `mapstructure:"messagequeueprotocol" yaml:"MessageQueueProtocol"`
+		OutputDestinations []string `mapstructure:"outputdestinations" yaml:"OutputDestinations"`
+		PortHigher int `mapstructure:"porthigher" yaml:"PortHigher"`
+		PortLower int `mapstructure:"portlower" yaml:"PortLower"`
+		QueueDirectory string `mapstructure:"queuedirectory" yaml:"QueueDirectory"`
+		StompCert string `mapstructure:"stompcert" yaml:"StompCert"`
+		StompCertKey string `mapstructure:"stompcertkey" yaml:"StompCertKey"`
+		StompPassword string `mapstructure:"stomppassword" yaml:"StompPassword"`
+		StompUsername string `mapstructure:"stompusername" yaml:"StompUsername"`
+		Topic string `mapstructure:"topic" yaml:"Topic"`
+		URL string `mapstructure:"url" yaml:"URL"`
+		VerifyHeader bool `mapstructure:"verifyheader" yaml:"VerifyHeader"`
 	} `mapstructure:"shoveler" yaml:"Shoveler"`
 	StagePlugin struct {
-		Hook               bool   `mapstructure:"hook" yaml:"Hook"`
-		MountPrefix        string `mapstructure:"mountprefix" yaml:"MountPrefix"`
-		OriginPrefix       string `mapstructure:"originprefix" yaml:"OriginPrefix"`
+		Hook bool `mapstructure:"hook" yaml:"Hook"`
+		MountPrefix string `mapstructure:"mountprefix" yaml:"MountPrefix"`
+		OriginPrefix string `mapstructure:"originprefix" yaml:"OriginPrefix"`
 		ShadowOriginPrefix string `mapstructure:"shadoworiginprefix" yaml:"ShadowOriginPrefix"`
 	} `mapstructure:"stageplugin" yaml:"StagePlugin"`
 	TLSSkipVerify bool `mapstructure:"tlsskipverify" yaml:"TLSSkipVerify"`
-	Topology      struct {
-		DisableCacheX509  bool `mapstructure:"disablecachex509" yaml:"DisableCacheX509"`
-		DisableCaches     bool `mapstructure:"disablecaches" yaml:"DisableCaches"`
-		DisableDowntime   bool `mapstructure:"disabledowntime" yaml:"DisableDowntime"`
+	Topology struct {
+		DisableCacheX509 bool `mapstructure:"disablecachex509" yaml:"DisableCacheX509"`
+		DisableCaches bool `mapstructure:"disablecaches" yaml:"DisableCaches"`
+		DisableDowntime bool `mapstructure:"disabledowntime" yaml:"DisableDowntime"`
 		DisableOriginX509 bool `mapstructure:"disableoriginx509" yaml:"DisableOriginX509"`
-		DisableOrigins    bool `mapstructure:"disableorigins" yaml:"DisableOrigins"`
+		DisableOrigins bool `mapstructure:"disableorigins" yaml:"DisableOrigins"`
 	} `mapstructure:"topology" yaml:"Topology"`
 	Transport struct {
 		BrokerEndpointCacheTTL time.Duration `mapstructure:"brokerendpointcachettl" yaml:"BrokerEndpointCacheTTL"`
-		DialerKeepAlive        time.Duration `mapstructure:"dialerkeepalive" yaml:"DialerKeepAlive"`
-		DialerTimeout          time.Duration `mapstructure:"dialertimeout" yaml:"DialerTimeout"`
-		ExpectContinueTimeout  time.Duration `mapstructure:"expectcontinuetimeout" yaml:"ExpectContinueTimeout"`
-		IdleConnTimeout        time.Duration `mapstructure:"idleconntimeout" yaml:"IdleConnTimeout"`
-		MaxIdleConns           int           `mapstructure:"maxidleconns" yaml:"MaxIdleConns"`
-		ResponseHeaderTimeout  time.Duration `mapstructure:"responseheadertimeout" yaml:"ResponseHeaderTimeout"`
-		TLSHandshakeTimeout    time.Duration `mapstructure:"tlshandshaketimeout" yaml:"TLSHandshakeTimeout"`
+		DialerKeepAlive time.Duration `mapstructure:"dialerkeepalive" yaml:"DialerKeepAlive"`
+		DialerTimeout time.Duration `mapstructure:"dialertimeout" yaml:"DialerTimeout"`
+		ExpectContinueTimeout time.Duration `mapstructure:"expectcontinuetimeout" yaml:"ExpectContinueTimeout"`
+		IdleConnTimeout time.Duration `mapstructure:"idleconntimeout" yaml:"IdleConnTimeout"`
+		MaxIdleConns int `mapstructure:"maxidleconns" yaml:"MaxIdleConns"`
+		ResponseHeaderTimeout time.Duration `mapstructure:"responseheadertimeout" yaml:"ResponseHeaderTimeout"`
+		TLSHandshakeTimeout time.Duration `mapstructure:"tlshandshaketimeout" yaml:"TLSHandshakeTimeout"`
 	} `mapstructure:"transport" yaml:"Transport"`
 	Xrootd struct {
-		AuthRefreshInterval    time.Duration `mapstructure:"authrefreshinterval" yaml:"AuthRefreshInterval"`
-		Authfile               string        `mapstructure:"authfile" yaml:"Authfile"`
-		ConfigFile             string        `mapstructure:"configfile" yaml:"ConfigFile"`
-		DetailedMonitoringHost string        `mapstructure:"detailedmonitoringhost" yaml:"DetailedMonitoringHost"`
-		DetailedMonitoringPort int           `mapstructure:"detailedmonitoringport" yaml:"DetailedMonitoringPort"`
-		EnableLocalMonitoring  bool          `mapstructure:"enablelocalmonitoring" yaml:"EnableLocalMonitoring"`
-		LocalMonitoringHost    string        `mapstructure:"localmonitoringhost" yaml:"LocalMonitoringHost"`
-		MacaroonsKeyFile       string        `mapstructure:"macaroonskeyfile" yaml:"MacaroonsKeyFile"`
-		ManagerHost            string        `mapstructure:"managerhost" yaml:"ManagerHost"`
-		ManagerPort            int           `mapstructure:"managerport" yaml:"ManagerPort"`
-		MaxStartupWait         time.Duration `mapstructure:"maxstartupwait" yaml:"MaxStartupWait"`
-		Mount                  string        `mapstructure:"mount" yaml:"Mount"`
-		Port                   int           `mapstructure:"port" yaml:"Port"`
-		RobotsTxtFile          string        `mapstructure:"robotstxtfile" yaml:"RobotsTxtFile"`
-		RunLocation            string        `mapstructure:"runlocation" yaml:"RunLocation"`
-		ScitokensConfig        string        `mapstructure:"scitokensconfig" yaml:"ScitokensConfig"`
-		ShutdownTimeout        time.Duration `mapstructure:"shutdowntimeout" yaml:"ShutdownTimeout"`
-		Sitename               string        `mapstructure:"sitename" yaml:"Sitename"`
-		SummaryMonitoringHost  string        `mapstructure:"summarymonitoringhost" yaml:"SummaryMonitoringHost"`
-		SummaryMonitoringPort  int           `mapstructure:"summarymonitoringport" yaml:"SummaryMonitoringPort"`
+		AuthRefreshInterval time.Duration `mapstructure:"authrefreshinterval" yaml:"AuthRefreshInterval"`
+		Authfile string `mapstructure:"authfile" yaml:"Authfile"`
+		ConfigFile string `mapstructure:"configfile" yaml:"ConfigFile"`
+		DetailedMonitoringHost string `mapstructure:"detailedmonitoringhost" yaml:"DetailedMonitoringHost"`
+		DetailedMonitoringPort int `mapstructure:"detailedmonitoringport" yaml:"DetailedMonitoringPort"`
+		EnableLocalMonitoring bool `mapstructure:"enablelocalmonitoring" yaml:"EnableLocalMonitoring"`
+		LocalMonitoringHost string `mapstructure:"localmonitoringhost" yaml:"LocalMonitoringHost"`
+		MacaroonsKeyFile string `mapstructure:"macaroonskeyfile" yaml:"MacaroonsKeyFile"`
+		ManagerHost string `mapstructure:"managerhost" yaml:"ManagerHost"`
+		ManagerPort int `mapstructure:"managerport" yaml:"ManagerPort"`
+		MaxStartupWait time.Duration `mapstructure:"maxstartupwait" yaml:"MaxStartupWait"`
+		Mount string `mapstructure:"mount" yaml:"Mount"`
+		Port int `mapstructure:"port" yaml:"Port"`
+		RobotsTxtFile string `mapstructure:"robotstxtfile" yaml:"RobotsTxtFile"`
+		RunLocation string `mapstructure:"runlocation" yaml:"RunLocation"`
+		ScitokensConfig string `mapstructure:"scitokensconfig" yaml:"ScitokensConfig"`
+		ShutdownTimeout time.Duration `mapstructure:"shutdowntimeout" yaml:"ShutdownTimeout"`
+		Sitename string `mapstructure:"sitename" yaml:"Sitename"`
+		SummaryMonitoringHost string `mapstructure:"summarymonitoringhost" yaml:"SummaryMonitoringHost"`
+		SummaryMonitoringPort int `mapstructure:"summarymonitoringport" yaml:"SummaryMonitoringPort"`
 	} `mapstructure:"xrootd" yaml:"Xrootd"`
 }
 
+
 type configWithType struct {
 	Cache struct {
-		BlocksToPrefetch struct {
-			Type  string
-			Value int
-		}
-		Concurrency struct {
-			Type  string
-			Value int
-		}
-		DataLocation struct {
-			Type  string
-			Value string
-		}
-		DataLocations struct {
-			Type  string
-			Value []string
-		}
-		DbLocation struct {
-			Type  string
-			Value string
-		}
-		DefaultCacheTimeout struct {
-			Type  string
-			Value time.Duration
-		}
-		EnableBroker struct {
-			Type  string
-			Value bool
-		}
-		EnableLotman struct {
-			Type  string
-			Value bool
-		}
-		EnableOIDC struct {
-			Type  string
-			Value bool
-		}
-		EnablePrefetch struct {
-			Type  string
-			Value bool
-		}
-		EnableTLSClientAuth struct {
-			Type  string
-			Value bool
-		}
-		EnableVoms struct {
-			Type  string
-			Value bool
-		}
-		ExportLocation struct {
-			Type  string
-			Value string
-		}
-		FedTokenLocation struct {
-			Type  string
-			Value string
-		}
-		FilesBaseSize struct {
-			Type  string
-			Value string
-		}
-		FilesMaxSize struct {
-			Type  string
-			Value string
-		}
-		FilesNominalSize struct {
-			Type  string
-			Value string
-		}
-		HighWaterMark struct {
-			Type  string
-			Value string
-		}
-		LocalRoot struct {
-			Type  string
-			Value string
-		}
-		LowWatermark struct {
-			Type  string
-			Value string
-		}
-		MetaLocations struct {
-			Type  string
-			Value []string
-		}
-		NamespaceLocation struct {
-			Type  string
-			Value string
-		}
-		PermittedNamespaces struct {
-			Type  string
-			Value []string
-		}
-		Port struct {
-			Type  string
-			Value int
-		}
-		RunLocation struct {
-			Type  string
-			Value string
-		}
-		SelfTest struct {
-			Type  string
-			Value bool
-		}
-		SelfTestInterval struct {
-			Type  string
-			Value time.Duration
-		}
-		SentinelLocation struct {
-			Type  string
-			Value string
-		}
-		StorageLocation struct {
-			Type  string
-			Value string
-		}
-		Url struct {
-			Type  string
-			Value string
-		}
-		XRootDPrefix struct {
-			Type  string
-			Value string
-		}
+		BlocksToPrefetch struct { Type string; Value int }
+		Concurrency struct { Type string; Value int }
+		DataLocation struct { Type string; Value string }
+		DataLocations struct { Type string; Value []string }
+		DbLocation struct { Type string; Value string }
+		DefaultCacheTimeout struct { Type string; Value time.Duration }
+		EnableBroker struct { Type string; Value bool }
+		EnableLotman struct { Type string; Value bool }
+		EnableOIDC struct { Type string; Value bool }
+		EnablePrefetch struct { Type string; Value bool }
+		EnableTLSClientAuth struct { Type string; Value bool }
+		EnableVoms struct { Type string; Value bool }
+		ExportLocation struct { Type string; Value string }
+		FedTokenLocation struct { Type string; Value string }
+		FilesBaseSize struct { Type string; Value string }
+		FilesMaxSize struct { Type string; Value string }
+		FilesNominalSize struct { Type string; Value string }
+		HighWaterMark struct { Type string; Value string }
+		LocalRoot struct { Type string; Value string }
+		LowWatermark struct { Type string; Value string }
+		MetaLocations struct { Type string; Value []string }
+		NamespaceLocation struct { Type string; Value string }
+		PermittedNamespaces struct { Type string; Value []string }
+		Port struct { Type string; Value int }
+		RunLocation struct { Type string; Value string }
+		SelfTest struct { Type string; Value bool }
+		SelfTestInterval struct { Type string; Value time.Duration }
+		SentinelLocation struct { Type string; Value string }
+		StorageLocation struct { Type string; Value string }
+		Url struct { Type string; Value string }
+		XRootDPrefix struct { Type string; Value string }
 	}
 	Client struct {
-		AssumeDirectorServerHeader struct {
-			Type  string
-			Value bool
-		}
-		DirectorRetries struct {
-			Type  string
-			Value int
-		}
-		DisableHttpProxy struct {
-			Type  string
-			Value bool
-		}
-		DisableProxyFallback struct {
-			Type  string
-			Value bool
-		}
-		IsPlugin struct {
-			Type  string
-			Value bool
-		}
-		MaximumDownloadSpeed struct {
-			Type  string
-			Value int
-		}
-		MinimumDownloadSpeed struct {
-			Type  string
-			Value int
-		}
-		PreferredCaches struct {
-			Type  string
-			Value []string
-		}
-		SlowTransferRampupTime struct {
-			Type  string
-			Value time.Duration
-		}
-		SlowTransferWindow struct {
-			Type  string
-			Value time.Duration
-		}
-		StoppedTransferTimeout struct {
-			Type  string
-			Value time.Duration
-		}
-		WorkerCount struct {
-			Type  string
-			Value int
-		}
+		AssumeDirectorServerHeader struct { Type string; Value bool }
+		DirectorRetries struct { Type string; Value int }
+		DisableHttpProxy struct { Type string; Value bool }
+		DisableProxyFallback struct { Type string; Value bool }
+		IsPlugin struct { Type string; Value bool }
+		MaximumDownloadSpeed struct { Type string; Value int }
+		MinimumDownloadSpeed struct { Type string; Value int }
+		PreferredCaches struct { Type string; Value []string }
+		SlowTransferRampupTime struct { Type string; Value time.Duration }
+		SlowTransferWindow struct { Type string; Value time.Duration }
+		StoppedTransferTimeout struct { Type string; Value time.Duration }
+		WorkerCount struct { Type string; Value int }
 	}
-	ConfigDir struct {
-		Type  string
-		Value string
-	}
-	ConfigLocations struct {
-		Type  string
-		Value []string
-	}
-	Debug struct {
-		Type  string
-		Value bool
-	}
+	ConfigDir struct { Type string; Value string }
+	ConfigLocations struct { Type string; Value []string }
+	Debug struct { Type string; Value bool }
 	Director struct {
-		AdvertiseUrl struct {
-			Type  string
-			Value string
-		}
-		AdvertisementTTL struct {
-			Type  string
-			Value time.Duration
-		}
-		AssumePresenceAtSingleOrigin struct {
-			Type  string
-			Value bool
-		}
-		CachePresenceCapacity struct {
-			Type  string
-			Value int
-		}
-		CachePresenceTTL struct {
-			Type  string
-			Value time.Duration
-		}
-		CacheResponseHostnames struct {
-			Type  string
-			Value []string
-		}
-		CacheSortMethod struct {
-			Type  string
-			Value string
-		}
-		CachesPullFromCaches struct {
-			Type  string
-			Value bool
-		}
-		CheckCachePresence struct {
-			Type  string
-			Value bool
-		}
-		CheckOriginPresence struct {
-			Type  string
-			Value bool
-		}
-		DbLocation struct {
-			Type  string
-			Value string
-		}
-		DefaultResponse struct {
-			Type  string
-			Value string
-		}
-		EnableBroker struct {
-			Type  string
-			Value bool
-		}
-		EnableOIDC struct {
-			Type  string
-			Value bool
-		}
-		EnableStat struct {
-			Type  string
-			Value bool
-		}
-		FedTokenLifetime struct {
-			Type  string
-			Value time.Duration
-		}
-		FilteredServers struct {
-			Type  string
-			Value []string
-		}
-		GeoIPLocation struct {
-			Type  string
-			Value string
-		}
-		MaxMindKeyFile struct {
-			Type  string
-			Value string
-		}
-		MaxStatResponse struct {
-			Type  string
-			Value int
-		}
-		MinStatResponse struct {
-			Type  string
-			Value int
-		}
-		OriginCacheHealthTestInterval struct {
-			Type  string
-			Value time.Duration
-		}
-		OriginResponseHostnames struct {
-			Type  string
-			Value []string
-		}
-		RegistryQueryInterval struct {
-			Type  string
-			Value time.Duration
-		}
-		StatConcurrencyLimit struct {
-			Type  string
-			Value int
-		}
-		StatTimeout struct {
-			Type  string
-			Value time.Duration
-		}
-		SupportContactEmail struct {
-			Type  string
-			Value string
-		}
-		SupportContactUrl struct {
-			Type  string
-			Value string
-		}
+		AdvertiseUrl struct { Type string; Value string }
+		AdvertisementTTL struct { Type string; Value time.Duration }
+		AssumePresenceAtSingleOrigin struct { Type string; Value bool }
+		CachePresenceCapacity struct { Type string; Value int }
+		CachePresenceTTL struct { Type string; Value time.Duration }
+		CacheResponseHostnames struct { Type string; Value []string }
+		CacheSortMethod struct { Type string; Value string }
+		CachesPullFromCaches struct { Type string; Value bool }
+		CheckCachePresence struct { Type string; Value bool }
+		CheckOriginPresence struct { Type string; Value bool }
+		DbLocation struct { Type string; Value string }
+		DefaultResponse struct { Type string; Value string }
+		EnableBroker struct { Type string; Value bool }
+		EnableOIDC struct { Type string; Value bool }
+		EnableStat struct { Type string; Value bool }
+		FedTokenLifetime struct { Type string; Value time.Duration }
+		FilteredServers struct { Type string; Value []string }
+		GeoIPLocation struct { Type string; Value string }
+		MaxMindKeyFile struct { Type string; Value string }
+		MaxStatResponse struct { Type string; Value int }
+		MinStatResponse struct { Type string; Value int }
+		OriginCacheHealthTestInterval struct { Type string; Value time.Duration }
+		OriginResponseHostnames struct { Type string; Value []string }
+		RegistryQueryInterval struct { Type string; Value time.Duration }
+		StatConcurrencyLimit struct { Type string; Value int }
+		StatTimeout struct { Type string; Value time.Duration }
+		SupportContactEmail struct { Type string; Value string }
+		SupportContactUrl struct { Type string; Value string }
 	}
-	DisableHttpProxy struct {
-		Type  string
-		Value bool
-	}
-	DisableProxyFallback struct {
-		Type  string
-		Value bool
-	}
+	DisableHttpProxy struct { Type string; Value bool }
+	DisableProxyFallback struct { Type string; Value bool }
 	Federation struct {
-		BrokerUrl struct {
-			Type  string
-			Value string
-		}
-		DirectorUrl struct {
-			Type  string
-			Value string
-		}
-		DiscoveryUrl struct {
-			Type  string
-			Value string
-		}
-		JwkUrl struct {
-			Type  string
-			Value string
-		}
-		RegistryUrl struct {
-			Type  string
-			Value string
-		}
-		TopologyDowntimeUrl struct {
-			Type  string
-			Value string
-		}
-		TopologyNamespaceUrl struct {
-			Type  string
-			Value string
-		}
-		TopologyReloadInterval struct {
-			Type  string
-			Value time.Duration
-		}
-		TopologyUrl struct {
-			Type  string
-			Value string
-		}
+		BrokerUrl struct { Type string; Value string }
+		DirectorUrl struct { Type string; Value string }
+		DiscoveryUrl struct { Type string; Value string }
+		JwkUrl struct { Type string; Value string }
+		RegistryUrl struct { Type string; Value string }
+		TopologyDowntimeUrl struct { Type string; Value string }
+		TopologyNamespaceUrl struct { Type string; Value string }
+		TopologyReloadInterval struct { Type string; Value time.Duration }
+		TopologyUrl struct { Type string; Value string }
 	}
-	GeoIPOverrides struct {
-		Type  string
-		Value interface{}
-	}
+	GeoIPOverrides struct { Type string; Value interface{} }
 	Issuer struct {
-		AuthenticationSource struct {
-			Type  string
-			Value string
-		}
-		AuthorizationTemplates struct {
-			Type  string
-			Value interface{}
-		}
-		GroupFile struct {
-			Type  string
-			Value string
-		}
-		GroupRequirements struct {
-			Type  string
-			Value []string
-		}
-		GroupSource struct {
-			Type  string
-			Value string
-		}
-		IssuerClaimValue struct {
-			Type  string
-			Value string
-		}
-		OIDCAuthenticationRequirements struct {
-			Type  string
-			Value interface{}
-		}
-		OIDCAuthenticationUserClaim struct {
-			Type  string
-			Value string
-		}
-		OIDCGroupClaim struct {
-			Type  string
-			Value string
-		}
-		OIDCPreferClaimsFromIDToken struct {
-			Type  string
-			Value bool
-		}
-		QDLLocation struct {
-			Type  string
-			Value string
-		}
-		RedirectUris struct {
-			Type  string
-			Value []string
-		}
-		ScitokensServerLocation struct {
-			Type  string
-			Value string
-		}
-		TomcatLocation struct {
-			Type  string
-			Value string
-		}
-		UserStripDomain struct {
-			Type  string
-			Value bool
-		}
+		AuthenticationSource struct { Type string; Value string }
+		AuthorizationTemplates struct { Type string; Value interface{} }
+		GroupFile struct { Type string; Value string }
+		GroupRequirements struct { Type string; Value []string }
+		GroupSource struct { Type string; Value string }
+		IssuerClaimValue struct { Type string; Value string }
+		OIDCAuthenticationRequirements struct { Type string; Value interface{} }
+		OIDCAuthenticationUserClaim struct { Type string; Value string }
+		OIDCGroupClaim struct { Type string; Value string }
+		OIDCPreferClaimsFromIDToken struct { Type string; Value bool }
+		QDLLocation struct { Type string; Value string }
+		RedirectUris struct { Type string; Value []string }
+		ScitokensServerLocation struct { Type string; Value string }
+		TomcatLocation struct { Type string; Value string }
+		UserStripDomain struct { Type string; Value bool }
 	}
-	IssuerKey struct {
-		Type  string
-		Value string
-	}
-	IssuerKeysDirectory struct {
-		Type  string
-		Value string
-	}
+	IssuerKey struct { Type string; Value string }
+	IssuerKeysDirectory struct { Type string; Value string }
 	LocalCache struct {
-		DataLocation struct {
-			Type  string
-			Value string
-		}
-		HighWaterMarkPercentage struct {
-			Type  string
-			Value int
-		}
-		LowWaterMarkPercentage struct {
-			Type  string
-			Value int
-		}
-		RunLocation struct {
-			Type  string
-			Value string
-		}
-		Size struct {
-			Type  string
-			Value string
-		}
-		Socket struct {
-			Type  string
-			Value string
-		}
+		DataLocation struct { Type string; Value string }
+		HighWaterMarkPercentage struct { Type string; Value int }
+		LowWaterMarkPercentage struct { Type string; Value int }
+		RunLocation struct { Type string; Value string }
+		Size struct { Type string; Value string }
+		Socket struct { Type string; Value string }
 	}
 	Logging struct {
 		Cache struct {
-			Http struct {
-				Type  string
-				Value string
-			}
-			Ofs struct {
-				Type  string
-				Value string
-			}
-			Pfc struct {
-				Type  string
-				Value string
-			}
-			Pss struct {
-				Type  string
-				Value string
-			}
-			PssSetOpt struct {
-				Type  string
-				Value string
-			}
-			Scitokens struct {
-				Type  string
-				Value string
-			}
-			Xrd struct {
-				Type  string
-				Value string
-			}
-			Xrootd struct {
-				Type  string
-				Value string
-			}
+			Http struct { Type string; Value string }
+			Ofs struct { Type string; Value string }
+			Pfc struct { Type string; Value string }
+			Pss struct { Type string; Value string }
+			PssSetOpt struct { Type string; Value string }
+			Scitokens struct { Type string; Value string }
+			Xrd struct { Type string; Value string }
+			Xrootd struct { Type string; Value string }
 		}
 		Client struct {
-			ProgressInterval struct {
-				Type  string
-				Value time.Duration
-			}
+			ProgressInterval struct { Type string; Value time.Duration }
 		}
-		DisableProgressBars struct {
-			Type  string
-			Value bool
-		}
-		Level struct {
-			Type  string
-			Value string
-		}
-		LogLocation struct {
-			Type  string
-			Value string
-		}
+		DisableProgressBars struct { Type string; Value bool }
+		Level struct { Type string; Value string }
+		LogLocation struct { Type string; Value string }
 		Origin struct {
-			Cms struct {
-				Type  string
-				Value string
-			}
-			Http struct {
-				Type  string
-				Value string
-			}
-			Ofs struct {
-				Type  string
-				Value string
-			}
-			Oss struct {
-				Type  string
-				Value string
-			}
-			Scitokens struct {
-				Type  string
-				Value string
-			}
-			Xrd struct {
-				Type  string
-				Value string
-			}
-			Xrootd struct {
-				Type  string
-				Value string
-			}
+			Cms struct { Type string; Value string }
+			Http struct { Type string; Value string }
+			Ofs struct { Type string; Value string }
+			Oss struct { Type string; Value string }
+			Scitokens struct { Type string; Value string }
+			Xrd struct { Type string; Value string }
+			Xrootd struct { Type string; Value string }
 		}
 	}
 	Lotman struct {
-		DbLocation struct {
-			Type  string
-			Value string
-		}
-		DefaultLotDeletionLifetime struct {
-			Type  string
-			Value time.Duration
-		}
-		DefaultLotExpirationLifetime struct {
-			Type  string
-			Value time.Duration
-		}
-		EnableAPI struct {
-			Type  string
-			Value bool
-		}
-		EnabledPolicy struct {
-			Type  string
-			Value string
-		}
-		LibLocation struct {
-			Type  string
-			Value string
-		}
-		LotHome struct {
-			Type  string
-			Value string
-		}
-		PolicyDefinitions struct {
-			Type  string
-			Value interface{}
-		}
+		DbLocation struct { Type string; Value string }
+		DefaultLotDeletionLifetime struct { Type string; Value time.Duration }
+		DefaultLotExpirationLifetime struct { Type string; Value time.Duration }
+		EnableAPI struct { Type string; Value bool }
+		EnabledPolicy struct { Type string; Value string }
+		LibLocation struct { Type string; Value string }
+		LotHome struct { Type string; Value string }
+		PolicyDefinitions struct { Type string; Value interface{} }
 	}
-	MinimumDownloadSpeed struct {
-		Type  string
-		Value int
-	}
+	MinimumDownloadSpeed struct { Type string; Value int }
 	Monitoring struct {
-		AggregatePrefixes struct {
-			Type  string
-			Value []string
-		}
-		DataLocation struct {
-			Type  string
-			Value string
-		}
-		DataRetention struct {
-			Type  string
-			Value time.Duration
-		}
-		LabelLimit struct {
-			Type  string
-			Value int
-		}
-		LabelNameLengthLimit struct {
-			Type  string
-			Value int
-		}
-		LabelValueLengthLimit struct {
-			Type  string
-			Value int
-		}
-		MetricAuthorization struct {
-			Type  string
-			Value bool
-		}
-		PortHigher struct {
-			Type  string
-			Value int
-		}
-		PortLower struct {
-			Type  string
-			Value int
-		}
-		PromQLAuthorization struct {
-			Type  string
-			Value bool
-		}
-		SampleLimit struct {
-			Type  string
-			Value int
-		}
-		TokenExpiresIn struct {
-			Type  string
-			Value time.Duration
-		}
-		TokenRefreshInterval struct {
-			Type  string
-			Value time.Duration
-		}
+		AggregatePrefixes struct { Type string; Value []string }
+		DataLocation struct { Type string; Value string }
+		DataRetention struct { Type string; Value time.Duration }
+		LabelLimit struct { Type string; Value int }
+		LabelNameLengthLimit struct { Type string; Value int }
+		LabelValueLengthLimit struct { Type string; Value int }
+		MetricAuthorization struct { Type string; Value bool }
+		PortHigher struct { Type string; Value int }
+		PortLower struct { Type string; Value int }
+		PromQLAuthorization struct { Type string; Value bool }
+		SampleLimit struct { Type string; Value int }
+		TokenExpiresIn struct { Type string; Value time.Duration }
+		TokenRefreshInterval struct { Type string; Value time.Duration }
 	}
 	OIDC struct {
-		AuthorizationEndpoint struct {
-			Type  string
-			Value string
-		}
-		ClientID struct {
-			Type  string
-			Value string
-		}
-		ClientIDFile struct {
-			Type  string
-			Value string
-		}
-		ClientRedirectHostname struct {
-			Type  string
-			Value string
-		}
-		ClientSecretFile struct {
-			Type  string
-			Value string
-		}
-		DeviceAuthEndpoint struct {
-			Type  string
-			Value string
-		}
-		Issuer struct {
-			Type  string
-			Value string
-		}
-		TokenEndpoint struct {
-			Type  string
-			Value string
-		}
-		UserInfoEndpoint struct {
-			Type  string
-			Value string
-		}
+		AuthorizationEndpoint struct { Type string; Value string }
+		ClientID struct { Type string; Value string }
+		ClientIDFile struct { Type string; Value string }
+		ClientRedirectHostname struct { Type string; Value string }
+		ClientSecretFile struct { Type string; Value string }
+		DeviceAuthEndpoint struct { Type string; Value string }
+		Issuer struct { Type string; Value string }
+		TokenEndpoint struct { Type string; Value string }
+		UserInfoEndpoint struct { Type string; Value string }
 	}
 	Origin struct {
-		Concurrency struct {
-			Type  string
-			Value int
-		}
-		DbLocation struct {
-			Type  string
-			Value string
-		}
-		DirectorTest struct {
-			Type  string
-			Value bool
-		}
-		DisableDirectClients struct {
-			Type  string
-			Value bool
-		}
-		EnableBroker struct {
-			Type  string
-			Value bool
-		}
-		EnableCmsd struct {
-			Type  string
-			Value bool
-		}
-		EnableDirListing struct {
-			Type  string
-			Value bool
-		}
-		EnableDirectReads struct {
-			Type  string
-			Value bool
-		}
-		EnableFallbackRead struct {
-			Type  string
-			Value bool
-		}
-		EnableIssuer struct {
-			Type  string
-			Value bool
-		}
-		EnableListings struct {
-			Type  string
-			Value bool
-		}
-		EnableMacaroons struct {
-			Type  string
-			Value bool
-		}
-		EnableOIDC struct {
-			Type  string
-			Value bool
-		}
-		EnablePublicReads struct {
-			Type  string
-			Value bool
-		}
-		EnableReads struct {
-			Type  string
-			Value bool
-		}
-		EnableUI struct {
-			Type  string
-			Value bool
-		}
-		EnableVoms struct {
-			Type  string
-			Value bool
-		}
-		EnableWrite struct {
-			Type  string
-			Value bool
-		}
-		EnableWrites struct {
-			Type  string
-			Value bool
-		}
-		ExportVolume struct {
-			Type  string
-			Value string
-		}
-		ExportVolumes struct {
-			Type  string
-			Value []string
-		}
-		Exports struct {
-			Type  string
-			Value interface{}
-		}
-		FedTokenLocation struct {
-			Type  string
-			Value string
-		}
-		FederationPrefix struct {
-			Type  string
-			Value string
-		}
-		GlobusClientIDFile struct {
-			Type  string
-			Value string
-		}
-		GlobusClientSecretFile struct {
-			Type  string
-			Value string
-		}
-		GlobusCollectionID struct {
-			Type  string
-			Value string
-		}
-		GlobusCollectionName struct {
-			Type  string
-			Value string
-		}
-		GlobusConfigLocation struct {
-			Type  string
-			Value string
-		}
-		HttpAuthTokenFile struct {
-			Type  string
-			Value string
-		}
-		HttpServiceUrl struct {
-			Type  string
-			Value string
-		}
-		Mode struct {
-			Type  string
-			Value string
-		}
-		Multiuser struct {
-			Type  string
-			Value bool
-		}
-		NamespacePrefix struct {
-			Type  string
-			Value string
-		}
-		Port struct {
-			Type  string
-			Value int
-		}
-		RunLocation struct {
-			Type  string
-			Value string
-		}
-		S3AccessKeyfile struct {
-			Type  string
-			Value string
-		}
-		S3Bucket struct {
-			Type  string
-			Value string
-		}
-		S3Region struct {
-			Type  string
-			Value string
-		}
-		S3SecretKeyfile struct {
-			Type  string
-			Value string
-		}
-		S3ServiceName struct {
-			Type  string
-			Value string
-		}
-		S3ServiceUrl struct {
-			Type  string
-			Value string
-		}
-		S3UrlStyle struct {
-			Type  string
-			Value string
-		}
-		ScitokensDefaultUser struct {
-			Type  string
-			Value string
-		}
-		ScitokensMapSubject struct {
-			Type  string
-			Value bool
-		}
-		ScitokensNameMapFile struct {
-			Type  string
-			Value string
-		}
-		ScitokensRestrictedPaths struct {
-			Type  string
-			Value []string
-		}
-		ScitokensUsernameClaim struct {
-			Type  string
-			Value string
-		}
-		SelfTest struct {
-			Type  string
-			Value bool
-		}
-		SelfTestInterval struct {
-			Type  string
-			Value time.Duration
-		}
-		StoragePrefix struct {
-			Type  string
-			Value string
-		}
-		StorageType struct {
-			Type  string
-			Value string
-		}
-		TokenAudience struct {
-			Type  string
-			Value string
-		}
-		Url struct {
-			Type  string
-			Value string
-		}
-		XRootDPrefix struct {
-			Type  string
-			Value string
-		}
-		XRootServiceUrl struct {
-			Type  string
-			Value string
-		}
+		Concurrency struct { Type string; Value int }
+		DbLocation struct { Type string; Value string }
+		DirectorTest struct { Type string; Value bool }
+		DisableDirectClients struct { Type string; Value bool }
+		EnableBroker struct { Type string; Value bool }
+		EnableCmsd struct { Type string; Value bool }
+		EnableDirListing struct { Type string; Value bool }
+		EnableDirectReads struct { Type string; Value bool }
+		EnableFallbackRead struct { Type string; Value bool }
+		EnableIssuer struct { Type string; Value bool }
+		EnableListings struct { Type string; Value bool }
+		EnableMacaroons struct { Type string; Value bool }
+		EnableOIDC struct { Type string; Value bool }
+		EnablePublicReads struct { Type string; Value bool }
+		EnableReads struct { Type string; Value bool }
+		EnableUI struct { Type string; Value bool }
+		EnableVoms struct { Type string; Value bool }
+		EnableWrite struct { Type string; Value bool }
+		EnableWrites struct { Type string; Value bool }
+		ExportVolume struct { Type string; Value string }
+		ExportVolumes struct { Type string; Value []string }
+		Exports struct { Type string; Value interface{} }
+		FedTokenLocation struct { Type string; Value string }
+		FederationPrefix struct { Type string; Value string }
+		GlobusClientIDFile struct { Type string; Value string }
+		GlobusClientSecretFile struct { Type string; Value string }
+		GlobusCollectionID struct { Type string; Value string }
+		GlobusCollectionName struct { Type string; Value string }
+		GlobusConfigLocation struct { Type string; Value string }
+		HttpAuthTokenFile struct { Type string; Value string }
+		HttpServiceUrl struct { Type string; Value string }
+		Mode struct { Type string; Value string }
+		Multiuser struct { Type string; Value bool }
+		NamespacePrefix struct { Type string; Value string }
+		Port struct { Type string; Value int }
+		RunLocation struct { Type string; Value string }
+		S3AccessKeyfile struct { Type string; Value string }
+		S3Bucket struct { Type string; Value string }
+		S3Region struct { Type string; Value string }
+		S3SecretKeyfile struct { Type string; Value string }
+		S3ServiceName struct { Type string; Value string }
+		S3ServiceUrl struct { Type string; Value string }
+		S3UrlStyle struct { Type string; Value string }
+		ScitokensDefaultUser struct { Type string; Value string }
+		ScitokensMapSubject struct { Type string; Value bool }
+		ScitokensNameMapFile struct { Type string; Value string }
+		ScitokensRestrictedPaths struct { Type string; Value []string }
+		ScitokensUsernameClaim struct { Type string; Value string }
+		SelfTest struct { Type string; Value bool }
+		SelfTestInterval struct { Type string; Value time.Duration }
+		StoragePrefix struct { Type string; Value string }
+		StorageType struct { Type string; Value string }
+		TokenAudience struct { Type string; Value string }
+		Url struct { Type string; Value string }
+		XRootDPrefix struct { Type string; Value string }
+		XRootServiceUrl struct { Type string; Value string }
 	}
 	Plugin struct {
-		Token struct {
-			Type  string
-			Value string
-		}
+		Token struct { Type string; Value string }
 	}
 	Registry struct {
-		AdminUsers struct {
-			Type  string
-			Value []string
-		}
-		CustomRegistrationFields struct {
-			Type  string
-			Value interface{}
-		}
-		DbLocation struct {
-			Type  string
-			Value string
-		}
-		Institutions struct {
-			Type  string
-			Value interface{}
-		}
-		InstitutionsUrl struct {
-			Type  string
-			Value string
-		}
-		InstitutionsUrlReloadMinutes struct {
-			Type  string
-			Value time.Duration
-		}
-		RequireCacheApproval struct {
-			Type  string
-			Value bool
-		}
-		RequireKeyChaining struct {
-			Type  string
-			Value bool
-		}
-		RequireOriginApproval struct {
-			Type  string
-			Value bool
-		}
+		AdminUsers struct { Type string; Value []string }
+		CustomRegistrationFields struct { Type string; Value interface{} }
+		DbLocation struct { Type string; Value string }
+		Institutions struct { Type string; Value interface{} }
+		InstitutionsUrl struct { Type string; Value string }
+		InstitutionsUrlReloadMinutes struct { Type string; Value time.Duration }
+		RequireCacheApproval struct { Type string; Value bool }
+		RequireKeyChaining struct { Type string; Value bool }
+		RequireOriginApproval struct { Type string; Value bool }
 	}
 	Server struct {
-		AdLifetime struct {
-			Type  string
-			Value time.Duration
-		}
-		AdvertisementInterval struct {
-			Type  string
-			Value time.Duration
-		}
-		DbLocation struct {
-			Type  string
-			Value string
-		}
-		DirectorUrls struct {
-			Type  string
-			Value []string
-		}
-		DropPrivileges struct {
-			Type  string
-			Value bool
-		}
-		EnablePprof struct {
-			Type  string
-			Value bool
-		}
-		EnableUI struct {
-			Type  string
-			Value bool
-		}
-		ExternalWebUrl struct {
-			Type  string
-			Value string
-		}
-		HealthMonitoringPublic struct {
-			Type  string
-			Value bool
-		}
-		Hostname struct {
-			Type  string
-			Value string
-		}
-		IssuerHostname struct {
-			Type  string
-			Value string
-		}
-		IssuerJwks struct {
-			Type  string
-			Value string
-		}
-		IssuerPort struct {
-			Type  string
-			Value int
-		}
-		IssuerUrl struct {
-			Type  string
-			Value string
-		}
-		Modules struct {
-			Type  string
-			Value []string
-		}
-		RegistrationRetryInterval struct {
-			Type  string
-			Value time.Duration
-		}
-		SessionSecretFile struct {
-			Type  string
-			Value string
-		}
-		StartupTimeout struct {
-			Type  string
-			Value time.Duration
-		}
-		TLSCACertificateDirectory struct {
-			Type  string
-			Value string
-		}
-		TLSCACertificateFile struct {
-			Type  string
-			Value string
-		}
-		TLSCAKey struct {
-			Type  string
-			Value string
-		}
-		TLSCertificate struct {
-			Type  string
-			Value string
-		}
-		TLSCertificateChain struct {
-			Type  string
-			Value string
-		}
-		TLSKey struct {
-			Type  string
-			Value string
-		}
-		UIActivationCodeFile struct {
-			Type  string
-			Value string
-		}
-		UIAdminUsers struct {
-			Type  string
-			Value []string
-		}
-		UILoginRateLimit struct {
-			Type  string
-			Value int
-		}
-		UIPasswordFile struct {
-			Type  string
-			Value string
-		}
-		UnprivilegedUser struct {
-			Type  string
-			Value string
-		}
-		WebConfigFile struct {
-			Type  string
-			Value string
-		}
-		WebHost struct {
-			Type  string
-			Value string
-		}
-		WebPort struct {
-			Type  string
-			Value int
-		}
+		AdLifetime struct { Type string; Value time.Duration }
+		AdvertisementInterval struct { Type string; Value time.Duration }
+		DbLocation struct { Type string; Value string }
+		DirectorUrls struct { Type string; Value []string }
+		DropPrivileges struct { Type string; Value bool }
+		EnablePprof struct { Type string; Value bool }
+		EnableUI struct { Type string; Value bool }
+		ExternalWebUrl struct { Type string; Value string }
+		HealthMonitoringPublic struct { Type string; Value bool }
+		Hostname struct { Type string; Value string }
+		IssuerHostname struct { Type string; Value string }
+		IssuerJwks struct { Type string; Value string }
+		IssuerPort struct { Type string; Value int }
+		IssuerUrl struct { Type string; Value string }
+		Modules struct { Type string; Value []string }
+		RegistrationRetryInterval struct { Type string; Value time.Duration }
+		SessionSecretFile struct { Type string; Value string }
+		StartupTimeout struct { Type string; Value time.Duration }
+		TLSCACertificateDirectory struct { Type string; Value string }
+		TLSCACertificateFile struct { Type string; Value string }
+		TLSCAKey struct { Type string; Value string }
+		TLSCertificate struct { Type string; Value string }
+		TLSCertificateChain struct { Type string; Value string }
+		TLSKey struct { Type string; Value string }
+		UIActivationCodeFile struct { Type string; Value string }
+		UIAdminUsers struct { Type string; Value []string }
+		UILoginRateLimit struct { Type string; Value int }
+		UIPasswordFile struct { Type string; Value string }
+		UnprivilegedUser struct { Type string; Value string }
+		WebConfigFile struct { Type string; Value string }
+		WebHost struct { Type string; Value string }
+		WebPort struct { Type string; Value int }
 	}
 	Shoveler struct {
-		AMQPExchange struct {
-			Type  string
-			Value string
-		}
-		AMQPTokenLocation struct {
-			Type  string
-			Value string
-		}
-		Enable struct {
-			Type  string
-			Value bool
-		}
-		IPMapping struct {
-			Type  string
-			Value interface{}
-		}
-		MessageQueueProtocol struct {
-			Type  string
-			Value string
-		}
-		OutputDestinations struct {
-			Type  string
-			Value []string
-		}
-		PortHigher struct {
-			Type  string
-			Value int
-		}
-		PortLower struct {
-			Type  string
-			Value int
-		}
-		QueueDirectory struct {
-			Type  string
-			Value string
-		}
-		StompCert struct {
-			Type  string
-			Value string
-		}
-		StompCertKey struct {
-			Type  string
-			Value string
-		}
-		StompPassword struct {
-			Type  string
-			Value string
-		}
-		StompUsername struct {
-			Type  string
-			Value string
-		}
-		Topic struct {
-			Type  string
-			Value string
-		}
-		URL struct {
-			Type  string
-			Value string
-		}
-		VerifyHeader struct {
-			Type  string
-			Value bool
-		}
+		AMQPExchange struct { Type string; Value string }
+		AMQPTokenLocation struct { Type string; Value string }
+		Enable struct { Type string; Value bool }
+		IPMapping struct { Type string; Value interface{} }
+		MessageQueueProtocol struct { Type string; Value string }
+		OutputDestinations struct { Type string; Value []string }
+		PortHigher struct { Type string; Value int }
+		PortLower struct { Type string; Value int }
+		QueueDirectory struct { Type string; Value string }
+		StompCert struct { Type string; Value string }
+		StompCertKey struct { Type string; Value string }
+		StompPassword struct { Type string; Value string }
+		StompUsername struct { Type string; Value string }
+		Topic struct { Type string; Value string }
+		URL struct { Type string; Value string }
+		VerifyHeader struct { Type string; Value bool }
 	}
 	StagePlugin struct {
-		Hook struct {
-			Type  string
-			Value bool
-		}
-		MountPrefix struct {
-			Type  string
-			Value string
-		}
-		OriginPrefix struct {
-			Type  string
-			Value string
-		}
-		ShadowOriginPrefix struct {
-			Type  string
-			Value string
-		}
+		Hook struct { Type string; Value bool }
+		MountPrefix struct { Type string; Value string }
+		OriginPrefix struct { Type string; Value string }
+		ShadowOriginPrefix struct { Type string; Value string }
 	}
-	TLSSkipVerify struct {
-		Type  string
-		Value bool
-	}
+	TLSSkipVerify struct { Type string; Value bool }
 	Topology struct {
-		DisableCacheX509 struct {
-			Type  string
-			Value bool
-		}
-		DisableCaches struct {
-			Type  string
-			Value bool
-		}
-		DisableDowntime struct {
-			Type  string
-			Value bool
-		}
-		DisableOriginX509 struct {
-			Type  string
-			Value bool
-		}
-		DisableOrigins struct {
-			Type  string
-			Value bool
-		}
+		DisableCacheX509 struct { Type string; Value bool }
+		DisableCaches struct { Type string; Value bool }
+		DisableDowntime struct { Type string; Value bool }
+		DisableOriginX509 struct { Type string; Value bool }
+		DisableOrigins struct { Type string; Value bool }
 	}
 	Transport struct {
-		BrokerEndpointCacheTTL struct {
-			Type  string
-			Value time.Duration
-		}
-		DialerKeepAlive struct {
-			Type  string
-			Value time.Duration
-		}
-		DialerTimeout struct {
-			Type  string
-			Value time.Duration
-		}
-		ExpectContinueTimeout struct {
-			Type  string
-			Value time.Duration
-		}
-		IdleConnTimeout struct {
-			Type  string
-			Value time.Duration
-		}
-		MaxIdleConns struct {
-			Type  string
-			Value int
-		}
-		ResponseHeaderTimeout struct {
-			Type  string
-			Value time.Duration
-		}
-		TLSHandshakeTimeout struct {
-			Type  string
-			Value time.Duration
-		}
+		BrokerEndpointCacheTTL struct { Type string; Value time.Duration }
+		DialerKeepAlive struct { Type string; Value time.Duration }
+		DialerTimeout struct { Type string; Value time.Duration }
+		ExpectContinueTimeout struct { Type string; Value time.Duration }
+		IdleConnTimeout struct { Type string; Value time.Duration }
+		MaxIdleConns struct { Type string; Value int }
+		ResponseHeaderTimeout struct { Type string; Value time.Duration }
+		TLSHandshakeTimeout struct { Type string; Value time.Duration }
 	}
 	Xrootd struct {
-		AuthRefreshInterval struct {
-			Type  string
-			Value time.Duration
-		}
-		Authfile struct {
-			Type  string
-			Value string
-		}
-		ConfigFile struct {
-			Type  string
-			Value string
-		}
-		DetailedMonitoringHost struct {
-			Type  string
-			Value string
-		}
-		DetailedMonitoringPort struct {
-			Type  string
-			Value int
-		}
-		EnableLocalMonitoring struct {
-			Type  string
-			Value bool
-		}
-		LocalMonitoringHost struct {
-			Type  string
-			Value string
-		}
-		MacaroonsKeyFile struct {
-			Type  string
-			Value string
-		}
-		ManagerHost struct {
-			Type  string
-			Value string
-		}
-		ManagerPort struct {
-			Type  string
-			Value int
-		}
-		MaxStartupWait struct {
-			Type  string
-			Value time.Duration
-		}
-		Mount struct {
-			Type  string
-			Value string
-		}
-		Port struct {
-			Type  string
-			Value int
-		}
-		RobotsTxtFile struct {
-			Type  string
-			Value string
-		}
-		RunLocation struct {
-			Type  string
-			Value string
-		}
-		ScitokensConfig struct {
-			Type  string
-			Value string
-		}
-		ShutdownTimeout struct {
-			Type  string
-			Value time.Duration
-		}
-		Sitename struct {
-			Type  string
-			Value string
-		}
-		SummaryMonitoringHost struct {
-			Type  string
-			Value string
-		}
-		SummaryMonitoringPort struct {
-			Type  string
-			Value int
-		}
+		AuthRefreshInterval struct { Type string; Value time.Duration }
+		Authfile struct { Type string; Value string }
+		ConfigFile struct { Type string; Value string }
+		DetailedMonitoringHost struct { Type string; Value string }
+		DetailedMonitoringPort struct { Type string; Value int }
+		EnableLocalMonitoring struct { Type string; Value bool }
+		LocalMonitoringHost struct { Type string; Value string }
+		MacaroonsKeyFile struct { Type string; Value string }
+		ManagerHost struct { Type string; Value string }
+		ManagerPort struct { Type string; Value int }
+		MaxStartupWait struct { Type string; Value time.Duration }
+		Mount struct { Type string; Value string }
+		Port struct { Type string; Value int }
+		RobotsTxtFile struct { Type string; Value string }
+		RunLocation struct { Type string; Value string }
+		ScitokensConfig struct { Type string; Value string }
+		ShutdownTimeout struct { Type string; Value time.Duration }
+		Sitename struct { Type string; Value string }
+		SummaryMonitoringHost struct { Type string; Value string }
+		SummaryMonitoringPort struct { Type string; Value int }
 	}
 }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -25,715 +25,1649 @@ import (
 
 type Config struct {
 	Cache struct {
-		BlocksToPrefetch int `mapstructure:"blockstoprefetch" yaml:"BlocksToPrefetch"`
-		Concurrency int `mapstructure:"concurrency" yaml:"Concurrency"`
-		DataLocation string `mapstructure:"datalocation" yaml:"DataLocation"`
-		DataLocations []string `mapstructure:"datalocations" yaml:"DataLocations"`
-		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
+		BlocksToPrefetch    int           `mapstructure:"blockstoprefetch" yaml:"BlocksToPrefetch"`
+		Concurrency         int           `mapstructure:"concurrency" yaml:"Concurrency"`
+		DataLocation        string        `mapstructure:"datalocation" yaml:"DataLocation"`
+		DataLocations       []string      `mapstructure:"datalocations" yaml:"DataLocations"`
+		DbLocation          string        `mapstructure:"dblocation" yaml:"DbLocation"`
 		DefaultCacheTimeout time.Duration `mapstructure:"defaultcachetimeout" yaml:"DefaultCacheTimeout"`
-		EnableBroker bool `mapstructure:"enablebroker" yaml:"EnableBroker"`
-		EnableLotman bool `mapstructure:"enablelotman" yaml:"EnableLotman"`
-		EnableOIDC bool `mapstructure:"enableoidc" yaml:"EnableOIDC"`
-		EnablePrefetch bool `mapstructure:"enableprefetch" yaml:"EnablePrefetch"`
-		EnableTLSClientAuth bool `mapstructure:"enabletlsclientauth" yaml:"EnableTLSClientAuth"`
-		EnableVoms bool `mapstructure:"enablevoms" yaml:"EnableVoms"`
-		ExportLocation string `mapstructure:"exportlocation" yaml:"ExportLocation"`
-		FedTokenLocation string `mapstructure:"fedtokenlocation" yaml:"FedTokenLocation"`
-		FilesBaseSize string `mapstructure:"filesbasesize" yaml:"FilesBaseSize"`
-		FilesMaxSize string `mapstructure:"filesmaxsize" yaml:"FilesMaxSize"`
-		FilesNominalSize string `mapstructure:"filesnominalsize" yaml:"FilesNominalSize"`
-		HighWaterMark string `mapstructure:"highwatermark" yaml:"HighWaterMark"`
-		LocalRoot string `mapstructure:"localroot" yaml:"LocalRoot"`
-		LowWatermark string `mapstructure:"lowwatermark" yaml:"LowWatermark"`
-		MetaLocations []string `mapstructure:"metalocations" yaml:"MetaLocations"`
-		NamespaceLocation string `mapstructure:"namespacelocation" yaml:"NamespaceLocation"`
-		PermittedNamespaces []string `mapstructure:"permittednamespaces" yaml:"PermittedNamespaces"`
-		Port int `mapstructure:"port" yaml:"Port"`
-		RunLocation string `mapstructure:"runlocation" yaml:"RunLocation"`
-		SelfTest bool `mapstructure:"selftest" yaml:"SelfTest"`
-		SelfTestInterval time.Duration `mapstructure:"selftestinterval" yaml:"SelfTestInterval"`
-		SentinelLocation string `mapstructure:"sentinellocation" yaml:"SentinelLocation"`
-		StorageLocation string `mapstructure:"storagelocation" yaml:"StorageLocation"`
-		Url string `mapstructure:"url" yaml:"Url"`
-		XRootDPrefix string `mapstructure:"xrootdprefix" yaml:"XRootDPrefix"`
+		EnableBroker        bool          `mapstructure:"enablebroker" yaml:"EnableBroker"`
+		EnableLotman        bool          `mapstructure:"enablelotman" yaml:"EnableLotman"`
+		EnableOIDC          bool          `mapstructure:"enableoidc" yaml:"EnableOIDC"`
+		EnablePrefetch      bool          `mapstructure:"enableprefetch" yaml:"EnablePrefetch"`
+		EnableTLSClientAuth bool          `mapstructure:"enabletlsclientauth" yaml:"EnableTLSClientAuth"`
+		EnableVoms          bool          `mapstructure:"enablevoms" yaml:"EnableVoms"`
+		ExportLocation      string        `mapstructure:"exportlocation" yaml:"ExportLocation"`
+		FedTokenLocation    string        `mapstructure:"fedtokenlocation" yaml:"FedTokenLocation"`
+		FilesBaseSize       string        `mapstructure:"filesbasesize" yaml:"FilesBaseSize"`
+		FilesMaxSize        string        `mapstructure:"filesmaxsize" yaml:"FilesMaxSize"`
+		FilesNominalSize    string        `mapstructure:"filesnominalsize" yaml:"FilesNominalSize"`
+		HighWaterMark       string        `mapstructure:"highwatermark" yaml:"HighWaterMark"`
+		LocalRoot           string        `mapstructure:"localroot" yaml:"LocalRoot"`
+		LowWatermark        string        `mapstructure:"lowwatermark" yaml:"LowWatermark"`
+		MetaLocations       []string      `mapstructure:"metalocations" yaml:"MetaLocations"`
+		NamespaceLocation   string        `mapstructure:"namespacelocation" yaml:"NamespaceLocation"`
+		PermittedNamespaces []string      `mapstructure:"permittednamespaces" yaml:"PermittedNamespaces"`
+		Port                int           `mapstructure:"port" yaml:"Port"`
+		RunLocation         string        `mapstructure:"runlocation" yaml:"RunLocation"`
+		SelfTest            bool          `mapstructure:"selftest" yaml:"SelfTest"`
+		SelfTestInterval    time.Duration `mapstructure:"selftestinterval" yaml:"SelfTestInterval"`
+		SentinelLocation    string        `mapstructure:"sentinellocation" yaml:"SentinelLocation"`
+		StorageLocation     string        `mapstructure:"storagelocation" yaml:"StorageLocation"`
+		Url                 string        `mapstructure:"url" yaml:"Url"`
+		XRootDPrefix        string        `mapstructure:"xrootdprefix" yaml:"XRootDPrefix"`
 	} `mapstructure:"cache" yaml:"Cache"`
 	Client struct {
-		AssumeDirectorServerHeader bool `mapstructure:"assumedirectorserverheader" yaml:"AssumeDirectorServerHeader"`
-		DirectorRetries int `mapstructure:"directorretries" yaml:"DirectorRetries"`
-		DisableHttpProxy bool `mapstructure:"disablehttpproxy" yaml:"DisableHttpProxy"`
-		DisableProxyFallback bool `mapstructure:"disableproxyfallback" yaml:"DisableProxyFallback"`
-		IsPlugin bool `mapstructure:"isplugin" yaml:"IsPlugin"`
-		MaximumDownloadSpeed int `mapstructure:"maximumdownloadspeed" yaml:"MaximumDownloadSpeed"`
-		MinimumDownloadSpeed int `mapstructure:"minimumdownloadspeed" yaml:"MinimumDownloadSpeed"`
-		PreferredCaches []string `mapstructure:"preferredcaches" yaml:"PreferredCaches"`
-		SlowTransferRampupTime time.Duration `mapstructure:"slowtransferrampuptime" yaml:"SlowTransferRampupTime"`
-		SlowTransferWindow time.Duration `mapstructure:"slowtransferwindow" yaml:"SlowTransferWindow"`
-		StoppedTransferTimeout time.Duration `mapstructure:"stoppedtransfertimeout" yaml:"StoppedTransferTimeout"`
-		WorkerCount int `mapstructure:"workercount" yaml:"WorkerCount"`
+		AssumeDirectorServerHeader bool          `mapstructure:"assumedirectorserverheader" yaml:"AssumeDirectorServerHeader"`
+		DirectorRetries            int           `mapstructure:"directorretries" yaml:"DirectorRetries"`
+		DisableHttpProxy           bool          `mapstructure:"disablehttpproxy" yaml:"DisableHttpProxy"`
+		DisableProxyFallback       bool          `mapstructure:"disableproxyfallback" yaml:"DisableProxyFallback"`
+		IsPlugin                   bool          `mapstructure:"isplugin" yaml:"IsPlugin"`
+		MaximumDownloadSpeed       int           `mapstructure:"maximumdownloadspeed" yaml:"MaximumDownloadSpeed"`
+		MinimumDownloadSpeed       int           `mapstructure:"minimumdownloadspeed" yaml:"MinimumDownloadSpeed"`
+		PreferredCaches            []string      `mapstructure:"preferredcaches" yaml:"PreferredCaches"`
+		SlowTransferRampupTime     time.Duration `mapstructure:"slowtransferrampuptime" yaml:"SlowTransferRampupTime"`
+		SlowTransferWindow         time.Duration `mapstructure:"slowtransferwindow" yaml:"SlowTransferWindow"`
+		StoppedTransferTimeout     time.Duration `mapstructure:"stoppedtransfertimeout" yaml:"StoppedTransferTimeout"`
+		WorkerCount                int           `mapstructure:"workercount" yaml:"WorkerCount"`
 	} `mapstructure:"client" yaml:"Client"`
-	ConfigDir string `mapstructure:"configdir" yaml:"ConfigDir"`
+	ConfigDir       string   `mapstructure:"configdir" yaml:"ConfigDir"`
 	ConfigLocations []string `mapstructure:"configlocations" yaml:"ConfigLocations"`
-	Debug bool `mapstructure:"debug" yaml:"Debug"`
-	Director struct {
-		AdvertiseUrl string `mapstructure:"advertiseurl" yaml:"AdvertiseUrl"`
-		AdvertisementTTL time.Duration `mapstructure:"advertisementttl" yaml:"AdvertisementTTL"`
-		AssumePresenceAtSingleOrigin bool `mapstructure:"assumepresenceatsingleorigin" yaml:"AssumePresenceAtSingleOrigin"`
-		CachePresenceCapacity int `mapstructure:"cachepresencecapacity" yaml:"CachePresenceCapacity"`
-		CachePresenceTTL time.Duration `mapstructure:"cachepresencettl" yaml:"CachePresenceTTL"`
-		CacheResponseHostnames []string `mapstructure:"cacheresponsehostnames" yaml:"CacheResponseHostnames"`
-		CacheSortMethod string `mapstructure:"cachesortmethod" yaml:"CacheSortMethod"`
-		CachesPullFromCaches bool `mapstructure:"cachespullfromcaches" yaml:"CachesPullFromCaches"`
-		CheckCachePresence bool `mapstructure:"checkcachepresence" yaml:"CheckCachePresence"`
-		CheckOriginPresence bool `mapstructure:"checkoriginpresence" yaml:"CheckOriginPresence"`
-		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
-		DefaultResponse string `mapstructure:"defaultresponse" yaml:"DefaultResponse"`
-		EnableBroker bool `mapstructure:"enablebroker" yaml:"EnableBroker"`
-		EnableOIDC bool `mapstructure:"enableoidc" yaml:"EnableOIDC"`
-		EnableStat bool `mapstructure:"enablestat" yaml:"EnableStat"`
-		FedTokenLifetime time.Duration `mapstructure:"fedtokenlifetime" yaml:"FedTokenLifetime"`
-		FilteredServers []string `mapstructure:"filteredservers" yaml:"FilteredServers"`
-		GeoIPLocation string `mapstructure:"geoiplocation" yaml:"GeoIPLocation"`
-		MaxMindKeyFile string `mapstructure:"maxmindkeyfile" yaml:"MaxMindKeyFile"`
-		MaxStatResponse int `mapstructure:"maxstatresponse" yaml:"MaxStatResponse"`
-		MinStatResponse int `mapstructure:"minstatresponse" yaml:"MinStatResponse"`
+	Debug           bool     `mapstructure:"debug" yaml:"Debug"`
+	Director        struct {
+		AdvertiseUrl                  string        `mapstructure:"advertiseurl" yaml:"AdvertiseUrl"`
+		AdvertisementTTL              time.Duration `mapstructure:"advertisementttl" yaml:"AdvertisementTTL"`
+		AssumePresenceAtSingleOrigin  bool          `mapstructure:"assumepresenceatsingleorigin" yaml:"AssumePresenceAtSingleOrigin"`
+		CachePresenceCapacity         int           `mapstructure:"cachepresencecapacity" yaml:"CachePresenceCapacity"`
+		CachePresenceTTL              time.Duration `mapstructure:"cachepresencettl" yaml:"CachePresenceTTL"`
+		CacheResponseHostnames        []string      `mapstructure:"cacheresponsehostnames" yaml:"CacheResponseHostnames"`
+		CacheSortMethod               string        `mapstructure:"cachesortmethod" yaml:"CacheSortMethod"`
+		CachesPullFromCaches          bool          `mapstructure:"cachespullfromcaches" yaml:"CachesPullFromCaches"`
+		CheckCachePresence            bool          `mapstructure:"checkcachepresence" yaml:"CheckCachePresence"`
+		CheckOriginPresence           bool          `mapstructure:"checkoriginpresence" yaml:"CheckOriginPresence"`
+		DbLocation                    string        `mapstructure:"dblocation" yaml:"DbLocation"`
+		DefaultResponse               string        `mapstructure:"defaultresponse" yaml:"DefaultResponse"`
+		EnableBroker                  bool          `mapstructure:"enablebroker" yaml:"EnableBroker"`
+		EnableOIDC                    bool          `mapstructure:"enableoidc" yaml:"EnableOIDC"`
+		EnableStat                    bool          `mapstructure:"enablestat" yaml:"EnableStat"`
+		FedTokenLifetime              time.Duration `mapstructure:"fedtokenlifetime" yaml:"FedTokenLifetime"`
+		FilteredServers               []string      `mapstructure:"filteredservers" yaml:"FilteredServers"`
+		GeoIPLocation                 string        `mapstructure:"geoiplocation" yaml:"GeoIPLocation"`
+		MaxMindKeyFile                string        `mapstructure:"maxmindkeyfile" yaml:"MaxMindKeyFile"`
+		MaxStatResponse               int           `mapstructure:"maxstatresponse" yaml:"MaxStatResponse"`
+		MinStatResponse               int           `mapstructure:"minstatresponse" yaml:"MinStatResponse"`
 		OriginCacheHealthTestInterval time.Duration `mapstructure:"origincachehealthtestinterval" yaml:"OriginCacheHealthTestInterval"`
-		OriginResponseHostnames []string `mapstructure:"originresponsehostnames" yaml:"OriginResponseHostnames"`
-		RegistryQueryInterval time.Duration `mapstructure:"registryqueryinterval" yaml:"RegistryQueryInterval"`
-		StatConcurrencyLimit int `mapstructure:"statconcurrencylimit" yaml:"StatConcurrencyLimit"`
-		StatTimeout time.Duration `mapstructure:"stattimeout" yaml:"StatTimeout"`
-		SupportContactEmail string `mapstructure:"supportcontactemail" yaml:"SupportContactEmail"`
-		SupportContactUrl string `mapstructure:"supportcontacturl" yaml:"SupportContactUrl"`
+		OriginResponseHostnames       []string      `mapstructure:"originresponsehostnames" yaml:"OriginResponseHostnames"`
+		RegistryQueryInterval         time.Duration `mapstructure:"registryqueryinterval" yaml:"RegistryQueryInterval"`
+		StatConcurrencyLimit          int           `mapstructure:"statconcurrencylimit" yaml:"StatConcurrencyLimit"`
+		StatTimeout                   time.Duration `mapstructure:"stattimeout" yaml:"StatTimeout"`
+		SupportContactEmail           string        `mapstructure:"supportcontactemail" yaml:"SupportContactEmail"`
+		SupportContactUrl             string        `mapstructure:"supportcontacturl" yaml:"SupportContactUrl"`
 	} `mapstructure:"director" yaml:"Director"`
-	DisableHttpProxy bool `mapstructure:"disablehttpproxy" yaml:"DisableHttpProxy"`
+	DisableHttpProxy     bool `mapstructure:"disablehttpproxy" yaml:"DisableHttpProxy"`
 	DisableProxyFallback bool `mapstructure:"disableproxyfallback" yaml:"DisableProxyFallback"`
-	Federation struct {
-		BrokerUrl string `mapstructure:"brokerurl" yaml:"BrokerUrl"`
-		DirectorUrl string `mapstructure:"directorurl" yaml:"DirectorUrl"`
-		DiscoveryUrl string `mapstructure:"discoveryurl" yaml:"DiscoveryUrl"`
-		JwkUrl string `mapstructure:"jwkurl" yaml:"JwkUrl"`
-		RegistryUrl string `mapstructure:"registryurl" yaml:"RegistryUrl"`
-		TopologyDowntimeUrl string `mapstructure:"topologydowntimeurl" yaml:"TopologyDowntimeUrl"`
-		TopologyNamespaceUrl string `mapstructure:"topologynamespaceurl" yaml:"TopologyNamespaceUrl"`
+	Federation           struct {
+		BrokerUrl              string        `mapstructure:"brokerurl" yaml:"BrokerUrl"`
+		DirectorUrl            string        `mapstructure:"directorurl" yaml:"DirectorUrl"`
+		DiscoveryUrl           string        `mapstructure:"discoveryurl" yaml:"DiscoveryUrl"`
+		JwkUrl                 string        `mapstructure:"jwkurl" yaml:"JwkUrl"`
+		RegistryUrl            string        `mapstructure:"registryurl" yaml:"RegistryUrl"`
+		TopologyDowntimeUrl    string        `mapstructure:"topologydowntimeurl" yaml:"TopologyDowntimeUrl"`
+		TopologyNamespaceUrl   string        `mapstructure:"topologynamespaceurl" yaml:"TopologyNamespaceUrl"`
 		TopologyReloadInterval time.Duration `mapstructure:"topologyreloadinterval" yaml:"TopologyReloadInterval"`
-		TopologyUrl string `mapstructure:"topologyurl" yaml:"TopologyUrl"`
+		TopologyUrl            string        `mapstructure:"topologyurl" yaml:"TopologyUrl"`
 	} `mapstructure:"federation" yaml:"Federation"`
 	GeoIPOverrides interface{} `mapstructure:"geoipoverrides" yaml:"GeoIPOverrides"`
-	Issuer struct {
-		AuthenticationSource string `mapstructure:"authenticationsource" yaml:"AuthenticationSource"`
-		AuthorizationTemplates interface{} `mapstructure:"authorizationtemplates" yaml:"AuthorizationTemplates"`
-		GroupFile string `mapstructure:"groupfile" yaml:"GroupFile"`
-		GroupRequirements []string `mapstructure:"grouprequirements" yaml:"GroupRequirements"`
-		GroupSource string `mapstructure:"groupsource" yaml:"GroupSource"`
-		IssuerClaimValue string `mapstructure:"issuerclaimvalue" yaml:"IssuerClaimValue"`
+	Issuer         struct {
+		AuthenticationSource           string      `mapstructure:"authenticationsource" yaml:"AuthenticationSource"`
+		AuthorizationTemplates         interface{} `mapstructure:"authorizationtemplates" yaml:"AuthorizationTemplates"`
+		GroupFile                      string      `mapstructure:"groupfile" yaml:"GroupFile"`
+		GroupRequirements              []string    `mapstructure:"grouprequirements" yaml:"GroupRequirements"`
+		GroupSource                    string      `mapstructure:"groupsource" yaml:"GroupSource"`
+		IssuerClaimValue               string      `mapstructure:"issuerclaimvalue" yaml:"IssuerClaimValue"`
 		OIDCAuthenticationRequirements interface{} `mapstructure:"oidcauthenticationrequirements" yaml:"OIDCAuthenticationRequirements"`
-		OIDCAuthenticationUserClaim string `mapstructure:"oidcauthenticationuserclaim" yaml:"OIDCAuthenticationUserClaim"`
-		OIDCGroupClaim string `mapstructure:"oidcgroupclaim" yaml:"OIDCGroupClaim"`
-		OIDCPreferClaimsFromIDToken bool `mapstructure:"oidcpreferclaimsfromidtoken" yaml:"OIDCPreferClaimsFromIDToken"`
-		QDLLocation string `mapstructure:"qdllocation" yaml:"QDLLocation"`
-		ScitokensServerLocation string `mapstructure:"scitokensserverlocation" yaml:"ScitokensServerLocation"`
-		TomcatLocation string `mapstructure:"tomcatlocation" yaml:"TomcatLocation"`
-		UserStripDomain bool `mapstructure:"userstripdomain" yaml:"UserStripDomain"`
+		OIDCAuthenticationUserClaim    string      `mapstructure:"oidcauthenticationuserclaim" yaml:"OIDCAuthenticationUserClaim"`
+		OIDCGroupClaim                 string      `mapstructure:"oidcgroupclaim" yaml:"OIDCGroupClaim"`
+		OIDCPreferClaimsFromIDToken    bool        `mapstructure:"oidcpreferclaimsfromidtoken" yaml:"OIDCPreferClaimsFromIDToken"`
+		QDLLocation                    string      `mapstructure:"qdllocation" yaml:"QDLLocation"`
+		RedirectUris                   []string    `mapstructure:"redirecturis" yaml:"RedirectUris"`
+		ScitokensServerLocation        string      `mapstructure:"scitokensserverlocation" yaml:"ScitokensServerLocation"`
+		TomcatLocation                 string      `mapstructure:"tomcatlocation" yaml:"TomcatLocation"`
+		UserStripDomain                bool        `mapstructure:"userstripdomain" yaml:"UserStripDomain"`
 	} `mapstructure:"issuer" yaml:"Issuer"`
-	IssuerKey string `mapstructure:"issuerkey" yaml:"IssuerKey"`
+	IssuerKey           string `mapstructure:"issuerkey" yaml:"IssuerKey"`
 	IssuerKeysDirectory string `mapstructure:"issuerkeysdirectory" yaml:"IssuerKeysDirectory"`
-	LocalCache struct {
-		DataLocation string `mapstructure:"datalocation" yaml:"DataLocation"`
-		HighWaterMarkPercentage int `mapstructure:"highwatermarkpercentage" yaml:"HighWaterMarkPercentage"`
-		LowWaterMarkPercentage int `mapstructure:"lowwatermarkpercentage" yaml:"LowWaterMarkPercentage"`
-		RunLocation string `mapstructure:"runlocation" yaml:"RunLocation"`
-		Size string `mapstructure:"size" yaml:"Size"`
-		Socket string `mapstructure:"socket" yaml:"Socket"`
+	LocalCache          struct {
+		DataLocation            string `mapstructure:"datalocation" yaml:"DataLocation"`
+		HighWaterMarkPercentage int    `mapstructure:"highwatermarkpercentage" yaml:"HighWaterMarkPercentage"`
+		LowWaterMarkPercentage  int    `mapstructure:"lowwatermarkpercentage" yaml:"LowWaterMarkPercentage"`
+		RunLocation             string `mapstructure:"runlocation" yaml:"RunLocation"`
+		Size                    string `mapstructure:"size" yaml:"Size"`
+		Socket                  string `mapstructure:"socket" yaml:"Socket"`
 	} `mapstructure:"localcache" yaml:"LocalCache"`
 	Logging struct {
 		Cache struct {
-			Http string `mapstructure:"http" yaml:"Http"`
-			Ofs string `mapstructure:"ofs" yaml:"Ofs"`
-			Pfc string `mapstructure:"pfc" yaml:"Pfc"`
-			Pss string `mapstructure:"pss" yaml:"Pss"`
+			Http      string `mapstructure:"http" yaml:"Http"`
+			Ofs       string `mapstructure:"ofs" yaml:"Ofs"`
+			Pfc       string `mapstructure:"pfc" yaml:"Pfc"`
+			Pss       string `mapstructure:"pss" yaml:"Pss"`
 			PssSetOpt string `mapstructure:"psssetopt" yaml:"PssSetOpt"`
 			Scitokens string `mapstructure:"scitokens" yaml:"Scitokens"`
-			Xrd string `mapstructure:"xrd" yaml:"Xrd"`
-			Xrootd string `mapstructure:"xrootd" yaml:"Xrootd"`
+			Xrd       string `mapstructure:"xrd" yaml:"Xrd"`
+			Xrootd    string `mapstructure:"xrootd" yaml:"Xrootd"`
 		} `mapstructure:"cache" yaml:"Cache"`
 		Client struct {
 			ProgressInterval time.Duration `mapstructure:"progressinterval" yaml:"ProgressInterval"`
 		} `mapstructure:"client" yaml:"Client"`
-		DisableProgressBars bool `mapstructure:"disableprogressbars" yaml:"DisableProgressBars"`
-		Level string `mapstructure:"level" yaml:"Level"`
-		LogLocation string `mapstructure:"loglocation" yaml:"LogLocation"`
-		Origin struct {
-			Cms string `mapstructure:"cms" yaml:"Cms"`
-			Http string `mapstructure:"http" yaml:"Http"`
-			Ofs string `mapstructure:"ofs" yaml:"Ofs"`
-			Oss string `mapstructure:"oss" yaml:"Oss"`
+		DisableProgressBars bool   `mapstructure:"disableprogressbars" yaml:"DisableProgressBars"`
+		Level               string `mapstructure:"level" yaml:"Level"`
+		LogLocation         string `mapstructure:"loglocation" yaml:"LogLocation"`
+		Origin              struct {
+			Cms       string `mapstructure:"cms" yaml:"Cms"`
+			Http      string `mapstructure:"http" yaml:"Http"`
+			Ofs       string `mapstructure:"ofs" yaml:"Ofs"`
+			Oss       string `mapstructure:"oss" yaml:"Oss"`
 			Scitokens string `mapstructure:"scitokens" yaml:"Scitokens"`
-			Xrd string `mapstructure:"xrd" yaml:"Xrd"`
-			Xrootd string `mapstructure:"xrootd" yaml:"Xrootd"`
+			Xrd       string `mapstructure:"xrd" yaml:"Xrd"`
+			Xrootd    string `mapstructure:"xrootd" yaml:"Xrootd"`
 		} `mapstructure:"origin" yaml:"Origin"`
 	} `mapstructure:"logging" yaml:"Logging"`
 	Lotman struct {
-		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
-		DefaultLotDeletionLifetime time.Duration `mapstructure:"defaultlotdeletionlifetime" yaml:"DefaultLotDeletionLifetime"`
+		DbLocation                   string        `mapstructure:"dblocation" yaml:"DbLocation"`
+		DefaultLotDeletionLifetime   time.Duration `mapstructure:"defaultlotdeletionlifetime" yaml:"DefaultLotDeletionLifetime"`
 		DefaultLotExpirationLifetime time.Duration `mapstructure:"defaultlotexpirationlifetime" yaml:"DefaultLotExpirationLifetime"`
-		EnableAPI bool `mapstructure:"enableapi" yaml:"EnableAPI"`
-		EnabledPolicy string `mapstructure:"enabledpolicy" yaml:"EnabledPolicy"`
-		LibLocation string `mapstructure:"liblocation" yaml:"LibLocation"`
-		LotHome string `mapstructure:"lothome" yaml:"LotHome"`
-		PolicyDefinitions interface{} `mapstructure:"policydefinitions" yaml:"PolicyDefinitions"`
+		EnableAPI                    bool          `mapstructure:"enableapi" yaml:"EnableAPI"`
+		EnabledPolicy                string        `mapstructure:"enabledpolicy" yaml:"EnabledPolicy"`
+		LibLocation                  string        `mapstructure:"liblocation" yaml:"LibLocation"`
+		LotHome                      string        `mapstructure:"lothome" yaml:"LotHome"`
+		PolicyDefinitions            interface{}   `mapstructure:"policydefinitions" yaml:"PolicyDefinitions"`
 	} `mapstructure:"lotman" yaml:"Lotman"`
 	MinimumDownloadSpeed int `mapstructure:"minimumdownloadspeed" yaml:"MinimumDownloadSpeed"`
-	Monitoring struct {
-		AggregatePrefixes []string `mapstructure:"aggregateprefixes" yaml:"AggregatePrefixes"`
-		DataLocation string `mapstructure:"datalocation" yaml:"DataLocation"`
-		DataRetention time.Duration `mapstructure:"dataretention" yaml:"DataRetention"`
-		LabelLimit int `mapstructure:"labellimit" yaml:"LabelLimit"`
-		LabelNameLengthLimit int `mapstructure:"labelnamelengthlimit" yaml:"LabelNameLengthLimit"`
-		LabelValueLengthLimit int `mapstructure:"labelvaluelengthlimit" yaml:"LabelValueLengthLimit"`
-		MetricAuthorization bool `mapstructure:"metricauthorization" yaml:"MetricAuthorization"`
-		PortHigher int `mapstructure:"porthigher" yaml:"PortHigher"`
-		PortLower int `mapstructure:"portlower" yaml:"PortLower"`
-		PromQLAuthorization bool `mapstructure:"promqlauthorization" yaml:"PromQLAuthorization"`
-		SampleLimit int `mapstructure:"samplelimit" yaml:"SampleLimit"`
-		TokenExpiresIn time.Duration `mapstructure:"tokenexpiresin" yaml:"TokenExpiresIn"`
-		TokenRefreshInterval time.Duration `mapstructure:"tokenrefreshinterval" yaml:"TokenRefreshInterval"`
+	Monitoring           struct {
+		AggregatePrefixes     []string      `mapstructure:"aggregateprefixes" yaml:"AggregatePrefixes"`
+		DataLocation          string        `mapstructure:"datalocation" yaml:"DataLocation"`
+		DataRetention         time.Duration `mapstructure:"dataretention" yaml:"DataRetention"`
+		LabelLimit            int           `mapstructure:"labellimit" yaml:"LabelLimit"`
+		LabelNameLengthLimit  int           `mapstructure:"labelnamelengthlimit" yaml:"LabelNameLengthLimit"`
+		LabelValueLengthLimit int           `mapstructure:"labelvaluelengthlimit" yaml:"LabelValueLengthLimit"`
+		MetricAuthorization   bool          `mapstructure:"metricauthorization" yaml:"MetricAuthorization"`
+		PortHigher            int           `mapstructure:"porthigher" yaml:"PortHigher"`
+		PortLower             int           `mapstructure:"portlower" yaml:"PortLower"`
+		PromQLAuthorization   bool          `mapstructure:"promqlauthorization" yaml:"PromQLAuthorization"`
+		SampleLimit           int           `mapstructure:"samplelimit" yaml:"SampleLimit"`
+		TokenExpiresIn        time.Duration `mapstructure:"tokenexpiresin" yaml:"TokenExpiresIn"`
+		TokenRefreshInterval  time.Duration `mapstructure:"tokenrefreshinterval" yaml:"TokenRefreshInterval"`
 	} `mapstructure:"monitoring" yaml:"Monitoring"`
 	OIDC struct {
-		AuthorizationEndpoint string `mapstructure:"authorizationendpoint" yaml:"AuthorizationEndpoint"`
-		ClientID string `mapstructure:"clientid" yaml:"ClientID"`
-		ClientIDFile string `mapstructure:"clientidfile" yaml:"ClientIDFile"`
+		AuthorizationEndpoint  string `mapstructure:"authorizationendpoint" yaml:"AuthorizationEndpoint"`
+		ClientID               string `mapstructure:"clientid" yaml:"ClientID"`
+		ClientIDFile           string `mapstructure:"clientidfile" yaml:"ClientIDFile"`
 		ClientRedirectHostname string `mapstructure:"clientredirecthostname" yaml:"ClientRedirectHostname"`
-		ClientSecretFile string `mapstructure:"clientsecretfile" yaml:"ClientSecretFile"`
-		DeviceAuthEndpoint string `mapstructure:"deviceauthendpoint" yaml:"DeviceAuthEndpoint"`
-		Issuer string `mapstructure:"issuer" yaml:"Issuer"`
-		TokenEndpoint string `mapstructure:"tokenendpoint" yaml:"TokenEndpoint"`
-		UserInfoEndpoint string `mapstructure:"userinfoendpoint" yaml:"UserInfoEndpoint"`
+		ClientSecretFile       string `mapstructure:"clientsecretfile" yaml:"ClientSecretFile"`
+		DeviceAuthEndpoint     string `mapstructure:"deviceauthendpoint" yaml:"DeviceAuthEndpoint"`
+		Issuer                 string `mapstructure:"issuer" yaml:"Issuer"`
+		TokenEndpoint          string `mapstructure:"tokenendpoint" yaml:"TokenEndpoint"`
+		UserInfoEndpoint       string `mapstructure:"userinfoendpoint" yaml:"UserInfoEndpoint"`
 	} `mapstructure:"oidc" yaml:"OIDC"`
 	Origin struct {
-		Concurrency int `mapstructure:"concurrency" yaml:"Concurrency"`
-		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
-		DirectorTest bool `mapstructure:"directortest" yaml:"DirectorTest"`
-		DisableDirectClients bool `mapstructure:"disabledirectclients" yaml:"DisableDirectClients"`
-		EnableBroker bool `mapstructure:"enablebroker" yaml:"EnableBroker"`
-		EnableCmsd bool `mapstructure:"enablecmsd" yaml:"EnableCmsd"`
-		EnableDirListing bool `mapstructure:"enabledirlisting" yaml:"EnableDirListing"`
-		EnableDirectReads bool `mapstructure:"enabledirectreads" yaml:"EnableDirectReads"`
-		EnableFallbackRead bool `mapstructure:"enablefallbackread" yaml:"EnableFallbackRead"`
-		EnableIssuer bool `mapstructure:"enableissuer" yaml:"EnableIssuer"`
-		EnableListings bool `mapstructure:"enablelistings" yaml:"EnableListings"`
-		EnableMacaroons bool `mapstructure:"enablemacaroons" yaml:"EnableMacaroons"`
-		EnableOIDC bool `mapstructure:"enableoidc" yaml:"EnableOIDC"`
-		EnablePublicReads bool `mapstructure:"enablepublicreads" yaml:"EnablePublicReads"`
-		EnableReads bool `mapstructure:"enablereads" yaml:"EnableReads"`
-		EnableUI bool `mapstructure:"enableui" yaml:"EnableUI"`
-		EnableVoms bool `mapstructure:"enablevoms" yaml:"EnableVoms"`
-		EnableWrite bool `mapstructure:"enablewrite" yaml:"EnableWrite"`
-		EnableWrites bool `mapstructure:"enablewrites" yaml:"EnableWrites"`
-		ExportVolume string `mapstructure:"exportvolume" yaml:"ExportVolume"`
-		ExportVolumes []string `mapstructure:"exportvolumes" yaml:"ExportVolumes"`
-		Exports interface{} `mapstructure:"exports" yaml:"Exports"`
-		FedTokenLocation string `mapstructure:"fedtokenlocation" yaml:"FedTokenLocation"`
-		FederationPrefix string `mapstructure:"federationprefix" yaml:"FederationPrefix"`
-		GlobusClientIDFile string `mapstructure:"globusclientidfile" yaml:"GlobusClientIDFile"`
-		GlobusClientSecretFile string `mapstructure:"globusclientsecretfile" yaml:"GlobusClientSecretFile"`
-		GlobusCollectionID string `mapstructure:"globuscollectionid" yaml:"GlobusCollectionID"`
-		GlobusCollectionName string `mapstructure:"globuscollectionname" yaml:"GlobusCollectionName"`
-		GlobusConfigLocation string `mapstructure:"globusconfiglocation" yaml:"GlobusConfigLocation"`
-		HttpAuthTokenFile string `mapstructure:"httpauthtokenfile" yaml:"HttpAuthTokenFile"`
-		HttpServiceUrl string `mapstructure:"httpserviceurl" yaml:"HttpServiceUrl"`
-		Mode string `mapstructure:"mode" yaml:"Mode"`
-		Multiuser bool `mapstructure:"multiuser" yaml:"Multiuser"`
-		NamespacePrefix string `mapstructure:"namespaceprefix" yaml:"NamespacePrefix"`
-		Port int `mapstructure:"port" yaml:"Port"`
-		RunLocation string `mapstructure:"runlocation" yaml:"RunLocation"`
-		S3AccessKeyfile string `mapstructure:"s3accesskeyfile" yaml:"S3AccessKeyfile"`
-		S3Bucket string `mapstructure:"s3bucket" yaml:"S3Bucket"`
-		S3Region string `mapstructure:"s3region" yaml:"S3Region"`
-		S3SecretKeyfile string `mapstructure:"s3secretkeyfile" yaml:"S3SecretKeyfile"`
-		S3ServiceName string `mapstructure:"s3servicename" yaml:"S3ServiceName"`
-		S3ServiceUrl string `mapstructure:"s3serviceurl" yaml:"S3ServiceUrl"`
-		S3UrlStyle string `mapstructure:"s3urlstyle" yaml:"S3UrlStyle"`
-		ScitokensDefaultUser string `mapstructure:"scitokensdefaultuser" yaml:"ScitokensDefaultUser"`
-		ScitokensMapSubject bool `mapstructure:"scitokensmapsubject" yaml:"ScitokensMapSubject"`
-		ScitokensNameMapFile string `mapstructure:"scitokensnamemapfile" yaml:"ScitokensNameMapFile"`
-		ScitokensRestrictedPaths []string `mapstructure:"scitokensrestrictedpaths" yaml:"ScitokensRestrictedPaths"`
-		ScitokensUsernameClaim string `mapstructure:"scitokensusernameclaim" yaml:"ScitokensUsernameClaim"`
-		SelfTest bool `mapstructure:"selftest" yaml:"SelfTest"`
-		SelfTestInterval time.Duration `mapstructure:"selftestinterval" yaml:"SelfTestInterval"`
-		StoragePrefix string `mapstructure:"storageprefix" yaml:"StoragePrefix"`
-		StorageType string `mapstructure:"storagetype" yaml:"StorageType"`
-		TokenAudience string `mapstructure:"tokenaudience" yaml:"TokenAudience"`
-		Url string `mapstructure:"url" yaml:"Url"`
-		XRootDPrefix string `mapstructure:"xrootdprefix" yaml:"XRootDPrefix"`
-		XRootServiceUrl string `mapstructure:"xrootserviceurl" yaml:"XRootServiceUrl"`
+		Concurrency              int           `mapstructure:"concurrency" yaml:"Concurrency"`
+		DbLocation               string        `mapstructure:"dblocation" yaml:"DbLocation"`
+		DirectorTest             bool          `mapstructure:"directortest" yaml:"DirectorTest"`
+		DisableDirectClients     bool          `mapstructure:"disabledirectclients" yaml:"DisableDirectClients"`
+		EnableBroker             bool          `mapstructure:"enablebroker" yaml:"EnableBroker"`
+		EnableCmsd               bool          `mapstructure:"enablecmsd" yaml:"EnableCmsd"`
+		EnableDirListing         bool          `mapstructure:"enabledirlisting" yaml:"EnableDirListing"`
+		EnableDirectReads        bool          `mapstructure:"enabledirectreads" yaml:"EnableDirectReads"`
+		EnableFallbackRead       bool          `mapstructure:"enablefallbackread" yaml:"EnableFallbackRead"`
+		EnableIssuer             bool          `mapstructure:"enableissuer" yaml:"EnableIssuer"`
+		EnableListings           bool          `mapstructure:"enablelistings" yaml:"EnableListings"`
+		EnableMacaroons          bool          `mapstructure:"enablemacaroons" yaml:"EnableMacaroons"`
+		EnableOIDC               bool          `mapstructure:"enableoidc" yaml:"EnableOIDC"`
+		EnablePublicReads        bool          `mapstructure:"enablepublicreads" yaml:"EnablePublicReads"`
+		EnableReads              bool          `mapstructure:"enablereads" yaml:"EnableReads"`
+		EnableUI                 bool          `mapstructure:"enableui" yaml:"EnableUI"`
+		EnableVoms               bool          `mapstructure:"enablevoms" yaml:"EnableVoms"`
+		EnableWrite              bool          `mapstructure:"enablewrite" yaml:"EnableWrite"`
+		EnableWrites             bool          `mapstructure:"enablewrites" yaml:"EnableWrites"`
+		ExportVolume             string        `mapstructure:"exportvolume" yaml:"ExportVolume"`
+		ExportVolumes            []string      `mapstructure:"exportvolumes" yaml:"ExportVolumes"`
+		Exports                  interface{}   `mapstructure:"exports" yaml:"Exports"`
+		FedTokenLocation         string        `mapstructure:"fedtokenlocation" yaml:"FedTokenLocation"`
+		FederationPrefix         string        `mapstructure:"federationprefix" yaml:"FederationPrefix"`
+		GlobusClientIDFile       string        `mapstructure:"globusclientidfile" yaml:"GlobusClientIDFile"`
+		GlobusClientSecretFile   string        `mapstructure:"globusclientsecretfile" yaml:"GlobusClientSecretFile"`
+		GlobusCollectionID       string        `mapstructure:"globuscollectionid" yaml:"GlobusCollectionID"`
+		GlobusCollectionName     string        `mapstructure:"globuscollectionname" yaml:"GlobusCollectionName"`
+		GlobusConfigLocation     string        `mapstructure:"globusconfiglocation" yaml:"GlobusConfigLocation"`
+		HttpAuthTokenFile        string        `mapstructure:"httpauthtokenfile" yaml:"HttpAuthTokenFile"`
+		HttpServiceUrl           string        `mapstructure:"httpserviceurl" yaml:"HttpServiceUrl"`
+		Mode                     string        `mapstructure:"mode" yaml:"Mode"`
+		Multiuser                bool          `mapstructure:"multiuser" yaml:"Multiuser"`
+		NamespacePrefix          string        `mapstructure:"namespaceprefix" yaml:"NamespacePrefix"`
+		Port                     int           `mapstructure:"port" yaml:"Port"`
+		RunLocation              string        `mapstructure:"runlocation" yaml:"RunLocation"`
+		S3AccessKeyfile          string        `mapstructure:"s3accesskeyfile" yaml:"S3AccessKeyfile"`
+		S3Bucket                 string        `mapstructure:"s3bucket" yaml:"S3Bucket"`
+		S3Region                 string        `mapstructure:"s3region" yaml:"S3Region"`
+		S3SecretKeyfile          string        `mapstructure:"s3secretkeyfile" yaml:"S3SecretKeyfile"`
+		S3ServiceName            string        `mapstructure:"s3servicename" yaml:"S3ServiceName"`
+		S3ServiceUrl             string        `mapstructure:"s3serviceurl" yaml:"S3ServiceUrl"`
+		S3UrlStyle               string        `mapstructure:"s3urlstyle" yaml:"S3UrlStyle"`
+		ScitokensDefaultUser     string        `mapstructure:"scitokensdefaultuser" yaml:"ScitokensDefaultUser"`
+		ScitokensMapSubject      bool          `mapstructure:"scitokensmapsubject" yaml:"ScitokensMapSubject"`
+		ScitokensNameMapFile     string        `mapstructure:"scitokensnamemapfile" yaml:"ScitokensNameMapFile"`
+		ScitokensRestrictedPaths []string      `mapstructure:"scitokensrestrictedpaths" yaml:"ScitokensRestrictedPaths"`
+		ScitokensUsernameClaim   string        `mapstructure:"scitokensusernameclaim" yaml:"ScitokensUsernameClaim"`
+		SelfTest                 bool          `mapstructure:"selftest" yaml:"SelfTest"`
+		SelfTestInterval         time.Duration `mapstructure:"selftestinterval" yaml:"SelfTestInterval"`
+		StoragePrefix            string        `mapstructure:"storageprefix" yaml:"StoragePrefix"`
+		StorageType              string        `mapstructure:"storagetype" yaml:"StorageType"`
+		TokenAudience            string        `mapstructure:"tokenaudience" yaml:"TokenAudience"`
+		Url                      string        `mapstructure:"url" yaml:"Url"`
+		XRootDPrefix             string        `mapstructure:"xrootdprefix" yaml:"XRootDPrefix"`
+		XRootServiceUrl          string        `mapstructure:"xrootserviceurl" yaml:"XRootServiceUrl"`
 	} `mapstructure:"origin" yaml:"Origin"`
 	Plugin struct {
 		Token string `mapstructure:"token" yaml:"Token"`
 	} `mapstructure:"plugin" yaml:"Plugin"`
 	Registry struct {
-		AdminUsers []string `mapstructure:"adminusers" yaml:"AdminUsers"`
-		CustomRegistrationFields interface{} `mapstructure:"customregistrationfields" yaml:"CustomRegistrationFields"`
-		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
-		Institutions interface{} `mapstructure:"institutions" yaml:"Institutions"`
-		InstitutionsUrl string `mapstructure:"institutionsurl" yaml:"InstitutionsUrl"`
+		AdminUsers                   []string      `mapstructure:"adminusers" yaml:"AdminUsers"`
+		CustomRegistrationFields     interface{}   `mapstructure:"customregistrationfields" yaml:"CustomRegistrationFields"`
+		DbLocation                   string        `mapstructure:"dblocation" yaml:"DbLocation"`
+		Institutions                 interface{}   `mapstructure:"institutions" yaml:"Institutions"`
+		InstitutionsUrl              string        `mapstructure:"institutionsurl" yaml:"InstitutionsUrl"`
 		InstitutionsUrlReloadMinutes time.Duration `mapstructure:"institutionsurlreloadminutes" yaml:"InstitutionsUrlReloadMinutes"`
-		RequireCacheApproval bool `mapstructure:"requirecacheapproval" yaml:"RequireCacheApproval"`
-		RequireKeyChaining bool `mapstructure:"requirekeychaining" yaml:"RequireKeyChaining"`
-		RequireOriginApproval bool `mapstructure:"requireoriginapproval" yaml:"RequireOriginApproval"`
+		RequireCacheApproval         bool          `mapstructure:"requirecacheapproval" yaml:"RequireCacheApproval"`
+		RequireKeyChaining           bool          `mapstructure:"requirekeychaining" yaml:"RequireKeyChaining"`
+		RequireOriginApproval        bool          `mapstructure:"requireoriginapproval" yaml:"RequireOriginApproval"`
 	} `mapstructure:"registry" yaml:"Registry"`
 	Server struct {
-		AdLifetime time.Duration `mapstructure:"adlifetime" yaml:"AdLifetime"`
-		AdvertisementInterval time.Duration `mapstructure:"advertisementinterval" yaml:"AdvertisementInterval"`
-		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
-		DirectorUrls []string `mapstructure:"directorurls" yaml:"DirectorUrls"`
-		DropPrivileges bool `mapstructure:"dropprivileges" yaml:"DropPrivileges"`
-		EnablePprof bool `mapstructure:"enablepprof" yaml:"EnablePprof"`
-		EnableUI bool `mapstructure:"enableui" yaml:"EnableUI"`
-		ExternalWebUrl string `mapstructure:"externalweburl" yaml:"ExternalWebUrl"`
-		HealthMonitoringPublic bool `mapstructure:"healthmonitoringpublic" yaml:"HealthMonitoringPublic"`
-		Hostname string `mapstructure:"hostname" yaml:"Hostname"`
-		IssuerHostname string `mapstructure:"issuerhostname" yaml:"IssuerHostname"`
-		IssuerJwks string `mapstructure:"issuerjwks" yaml:"IssuerJwks"`
-		IssuerPort int `mapstructure:"issuerport" yaml:"IssuerPort"`
-		IssuerUrl string `mapstructure:"issuerurl" yaml:"IssuerUrl"`
-		Modules []string `mapstructure:"modules" yaml:"Modules"`
+		AdLifetime                time.Duration `mapstructure:"adlifetime" yaml:"AdLifetime"`
+		AdvertisementInterval     time.Duration `mapstructure:"advertisementinterval" yaml:"AdvertisementInterval"`
+		DbLocation                string        `mapstructure:"dblocation" yaml:"DbLocation"`
+		DirectorUrls              []string      `mapstructure:"directorurls" yaml:"DirectorUrls"`
+		DropPrivileges            bool          `mapstructure:"dropprivileges" yaml:"DropPrivileges"`
+		EnablePprof               bool          `mapstructure:"enablepprof" yaml:"EnablePprof"`
+		EnableUI                  bool          `mapstructure:"enableui" yaml:"EnableUI"`
+		ExternalWebUrl            string        `mapstructure:"externalweburl" yaml:"ExternalWebUrl"`
+		HealthMonitoringPublic    bool          `mapstructure:"healthmonitoringpublic" yaml:"HealthMonitoringPublic"`
+		Hostname                  string        `mapstructure:"hostname" yaml:"Hostname"`
+		IssuerHostname            string        `mapstructure:"issuerhostname" yaml:"IssuerHostname"`
+		IssuerJwks                string        `mapstructure:"issuerjwks" yaml:"IssuerJwks"`
+		IssuerPort                int           `mapstructure:"issuerport" yaml:"IssuerPort"`
+		IssuerUrl                 string        `mapstructure:"issuerurl" yaml:"IssuerUrl"`
+		Modules                   []string      `mapstructure:"modules" yaml:"Modules"`
 		RegistrationRetryInterval time.Duration `mapstructure:"registrationretryinterval" yaml:"RegistrationRetryInterval"`
-		SessionSecretFile string `mapstructure:"sessionsecretfile" yaml:"SessionSecretFile"`
-		StartupTimeout time.Duration `mapstructure:"startuptimeout" yaml:"StartupTimeout"`
-		TLSCACertificateDirectory string `mapstructure:"tlscacertificatedirectory" yaml:"TLSCACertificateDirectory"`
-		TLSCACertificateFile string `mapstructure:"tlscacertificatefile" yaml:"TLSCACertificateFile"`
-		TLSCAKey string `mapstructure:"tlscakey" yaml:"TLSCAKey"`
-		TLSCertificate string `mapstructure:"tlscertificate" yaml:"TLSCertificate"`
-		TLSCertificateChain string `mapstructure:"tlscertificatechain" yaml:"TLSCertificateChain"`
-		TLSKey string `mapstructure:"tlskey" yaml:"TLSKey"`
-		UIActivationCodeFile string `mapstructure:"uiactivationcodefile" yaml:"UIActivationCodeFile"`
-		UIAdminUsers []string `mapstructure:"uiadminusers" yaml:"UIAdminUsers"`
-		UILoginRateLimit int `mapstructure:"uiloginratelimit" yaml:"UILoginRateLimit"`
-		UIPasswordFile string `mapstructure:"uipasswordfile" yaml:"UIPasswordFile"`
-		UnprivilegedUser string `mapstructure:"unprivilegeduser" yaml:"UnprivilegedUser"`
-		WebConfigFile string `mapstructure:"webconfigfile" yaml:"WebConfigFile"`
-		WebHost string `mapstructure:"webhost" yaml:"WebHost"`
-		WebPort int `mapstructure:"webport" yaml:"WebPort"`
+		SessionSecretFile         string        `mapstructure:"sessionsecretfile" yaml:"SessionSecretFile"`
+		StartupTimeout            time.Duration `mapstructure:"startuptimeout" yaml:"StartupTimeout"`
+		TLSCACertificateDirectory string        `mapstructure:"tlscacertificatedirectory" yaml:"TLSCACertificateDirectory"`
+		TLSCACertificateFile      string        `mapstructure:"tlscacertificatefile" yaml:"TLSCACertificateFile"`
+		TLSCAKey                  string        `mapstructure:"tlscakey" yaml:"TLSCAKey"`
+		TLSCertificate            string        `mapstructure:"tlscertificate" yaml:"TLSCertificate"`
+		TLSCertificateChain       string        `mapstructure:"tlscertificatechain" yaml:"TLSCertificateChain"`
+		TLSKey                    string        `mapstructure:"tlskey" yaml:"TLSKey"`
+		UIActivationCodeFile      string        `mapstructure:"uiactivationcodefile" yaml:"UIActivationCodeFile"`
+		UIAdminUsers              []string      `mapstructure:"uiadminusers" yaml:"UIAdminUsers"`
+		UILoginRateLimit          int           `mapstructure:"uiloginratelimit" yaml:"UILoginRateLimit"`
+		UIPasswordFile            string        `mapstructure:"uipasswordfile" yaml:"UIPasswordFile"`
+		UnprivilegedUser          string        `mapstructure:"unprivilegeduser" yaml:"UnprivilegedUser"`
+		WebConfigFile             string        `mapstructure:"webconfigfile" yaml:"WebConfigFile"`
+		WebHost                   string        `mapstructure:"webhost" yaml:"WebHost"`
+		WebPort                   int           `mapstructure:"webport" yaml:"WebPort"`
 	} `mapstructure:"server" yaml:"Server"`
 	Shoveler struct {
-		AMQPExchange string `mapstructure:"amqpexchange" yaml:"AMQPExchange"`
-		AMQPTokenLocation string `mapstructure:"amqptokenlocation" yaml:"AMQPTokenLocation"`
-		Enable bool `mapstructure:"enable" yaml:"Enable"`
-		IPMapping interface{} `mapstructure:"ipmapping" yaml:"IPMapping"`
-		MessageQueueProtocol string `mapstructure:"messagequeueprotocol" yaml:"MessageQueueProtocol"`
-		OutputDestinations []string `mapstructure:"outputdestinations" yaml:"OutputDestinations"`
-		PortHigher int `mapstructure:"porthigher" yaml:"PortHigher"`
-		PortLower int `mapstructure:"portlower" yaml:"PortLower"`
-		QueueDirectory string `mapstructure:"queuedirectory" yaml:"QueueDirectory"`
-		StompCert string `mapstructure:"stompcert" yaml:"StompCert"`
-		StompCertKey string `mapstructure:"stompcertkey" yaml:"StompCertKey"`
-		StompPassword string `mapstructure:"stomppassword" yaml:"StompPassword"`
-		StompUsername string `mapstructure:"stompusername" yaml:"StompUsername"`
-		Topic string `mapstructure:"topic" yaml:"Topic"`
-		URL string `mapstructure:"url" yaml:"URL"`
-		VerifyHeader bool `mapstructure:"verifyheader" yaml:"VerifyHeader"`
+		AMQPExchange         string      `mapstructure:"amqpexchange" yaml:"AMQPExchange"`
+		AMQPTokenLocation    string      `mapstructure:"amqptokenlocation" yaml:"AMQPTokenLocation"`
+		Enable               bool        `mapstructure:"enable" yaml:"Enable"`
+		IPMapping            interface{} `mapstructure:"ipmapping" yaml:"IPMapping"`
+		MessageQueueProtocol string      `mapstructure:"messagequeueprotocol" yaml:"MessageQueueProtocol"`
+		OutputDestinations   []string    `mapstructure:"outputdestinations" yaml:"OutputDestinations"`
+		PortHigher           int         `mapstructure:"porthigher" yaml:"PortHigher"`
+		PortLower            int         `mapstructure:"portlower" yaml:"PortLower"`
+		QueueDirectory       string      `mapstructure:"queuedirectory" yaml:"QueueDirectory"`
+		StompCert            string      `mapstructure:"stompcert" yaml:"StompCert"`
+		StompCertKey         string      `mapstructure:"stompcertkey" yaml:"StompCertKey"`
+		StompPassword        string      `mapstructure:"stomppassword" yaml:"StompPassword"`
+		StompUsername        string      `mapstructure:"stompusername" yaml:"StompUsername"`
+		Topic                string      `mapstructure:"topic" yaml:"Topic"`
+		URL                  string      `mapstructure:"url" yaml:"URL"`
+		VerifyHeader         bool        `mapstructure:"verifyheader" yaml:"VerifyHeader"`
 	} `mapstructure:"shoveler" yaml:"Shoveler"`
 	StagePlugin struct {
-		Hook bool `mapstructure:"hook" yaml:"Hook"`
-		MountPrefix string `mapstructure:"mountprefix" yaml:"MountPrefix"`
-		OriginPrefix string `mapstructure:"originprefix" yaml:"OriginPrefix"`
+		Hook               bool   `mapstructure:"hook" yaml:"Hook"`
+		MountPrefix        string `mapstructure:"mountprefix" yaml:"MountPrefix"`
+		OriginPrefix       string `mapstructure:"originprefix" yaml:"OriginPrefix"`
 		ShadowOriginPrefix string `mapstructure:"shadoworiginprefix" yaml:"ShadowOriginPrefix"`
 	} `mapstructure:"stageplugin" yaml:"StagePlugin"`
 	TLSSkipVerify bool `mapstructure:"tlsskipverify" yaml:"TLSSkipVerify"`
-	Topology struct {
-		DisableCacheX509 bool `mapstructure:"disablecachex509" yaml:"DisableCacheX509"`
-		DisableCaches bool `mapstructure:"disablecaches" yaml:"DisableCaches"`
-		DisableDowntime bool `mapstructure:"disabledowntime" yaml:"DisableDowntime"`
+	Topology      struct {
+		DisableCacheX509  bool `mapstructure:"disablecachex509" yaml:"DisableCacheX509"`
+		DisableCaches     bool `mapstructure:"disablecaches" yaml:"DisableCaches"`
+		DisableDowntime   bool `mapstructure:"disabledowntime" yaml:"DisableDowntime"`
 		DisableOriginX509 bool `mapstructure:"disableoriginx509" yaml:"DisableOriginX509"`
-		DisableOrigins bool `mapstructure:"disableorigins" yaml:"DisableOrigins"`
+		DisableOrigins    bool `mapstructure:"disableorigins" yaml:"DisableOrigins"`
 	} `mapstructure:"topology" yaml:"Topology"`
 	Transport struct {
 		BrokerEndpointCacheTTL time.Duration `mapstructure:"brokerendpointcachettl" yaml:"BrokerEndpointCacheTTL"`
-		DialerKeepAlive time.Duration `mapstructure:"dialerkeepalive" yaml:"DialerKeepAlive"`
-		DialerTimeout time.Duration `mapstructure:"dialertimeout" yaml:"DialerTimeout"`
-		ExpectContinueTimeout time.Duration `mapstructure:"expectcontinuetimeout" yaml:"ExpectContinueTimeout"`
-		IdleConnTimeout time.Duration `mapstructure:"idleconntimeout" yaml:"IdleConnTimeout"`
-		MaxIdleConns int `mapstructure:"maxidleconns" yaml:"MaxIdleConns"`
-		ResponseHeaderTimeout time.Duration `mapstructure:"responseheadertimeout" yaml:"ResponseHeaderTimeout"`
-		TLSHandshakeTimeout time.Duration `mapstructure:"tlshandshaketimeout" yaml:"TLSHandshakeTimeout"`
+		DialerKeepAlive        time.Duration `mapstructure:"dialerkeepalive" yaml:"DialerKeepAlive"`
+		DialerTimeout          time.Duration `mapstructure:"dialertimeout" yaml:"DialerTimeout"`
+		ExpectContinueTimeout  time.Duration `mapstructure:"expectcontinuetimeout" yaml:"ExpectContinueTimeout"`
+		IdleConnTimeout        time.Duration `mapstructure:"idleconntimeout" yaml:"IdleConnTimeout"`
+		MaxIdleConns           int           `mapstructure:"maxidleconns" yaml:"MaxIdleConns"`
+		ResponseHeaderTimeout  time.Duration `mapstructure:"responseheadertimeout" yaml:"ResponseHeaderTimeout"`
+		TLSHandshakeTimeout    time.Duration `mapstructure:"tlshandshaketimeout" yaml:"TLSHandshakeTimeout"`
 	} `mapstructure:"transport" yaml:"Transport"`
 	Xrootd struct {
-		AuthRefreshInterval time.Duration `mapstructure:"authrefreshinterval" yaml:"AuthRefreshInterval"`
-		Authfile string `mapstructure:"authfile" yaml:"Authfile"`
-		ConfigFile string `mapstructure:"configfile" yaml:"ConfigFile"`
-		DetailedMonitoringHost string `mapstructure:"detailedmonitoringhost" yaml:"DetailedMonitoringHost"`
-		DetailedMonitoringPort int `mapstructure:"detailedmonitoringport" yaml:"DetailedMonitoringPort"`
-		EnableLocalMonitoring bool `mapstructure:"enablelocalmonitoring" yaml:"EnableLocalMonitoring"`
-		LocalMonitoringHost string `mapstructure:"localmonitoringhost" yaml:"LocalMonitoringHost"`
-		MacaroonsKeyFile string `mapstructure:"macaroonskeyfile" yaml:"MacaroonsKeyFile"`
-		ManagerHost string `mapstructure:"managerhost" yaml:"ManagerHost"`
-		ManagerPort int `mapstructure:"managerport" yaml:"ManagerPort"`
-		MaxStartupWait time.Duration `mapstructure:"maxstartupwait" yaml:"MaxStartupWait"`
-		Mount string `mapstructure:"mount" yaml:"Mount"`
-		Port int `mapstructure:"port" yaml:"Port"`
-		RobotsTxtFile string `mapstructure:"robotstxtfile" yaml:"RobotsTxtFile"`
-		RunLocation string `mapstructure:"runlocation" yaml:"RunLocation"`
-		ScitokensConfig string `mapstructure:"scitokensconfig" yaml:"ScitokensConfig"`
-		ShutdownTimeout time.Duration `mapstructure:"shutdowntimeout" yaml:"ShutdownTimeout"`
-		Sitename string `mapstructure:"sitename" yaml:"Sitename"`
-		SummaryMonitoringHost string `mapstructure:"summarymonitoringhost" yaml:"SummaryMonitoringHost"`
-		SummaryMonitoringPort int `mapstructure:"summarymonitoringport" yaml:"SummaryMonitoringPort"`
+		AuthRefreshInterval    time.Duration `mapstructure:"authrefreshinterval" yaml:"AuthRefreshInterval"`
+		Authfile               string        `mapstructure:"authfile" yaml:"Authfile"`
+		ConfigFile             string        `mapstructure:"configfile" yaml:"ConfigFile"`
+		DetailedMonitoringHost string        `mapstructure:"detailedmonitoringhost" yaml:"DetailedMonitoringHost"`
+		DetailedMonitoringPort int           `mapstructure:"detailedmonitoringport" yaml:"DetailedMonitoringPort"`
+		EnableLocalMonitoring  bool          `mapstructure:"enablelocalmonitoring" yaml:"EnableLocalMonitoring"`
+		LocalMonitoringHost    string        `mapstructure:"localmonitoringhost" yaml:"LocalMonitoringHost"`
+		MacaroonsKeyFile       string        `mapstructure:"macaroonskeyfile" yaml:"MacaroonsKeyFile"`
+		ManagerHost            string        `mapstructure:"managerhost" yaml:"ManagerHost"`
+		ManagerPort            int           `mapstructure:"managerport" yaml:"ManagerPort"`
+		MaxStartupWait         time.Duration `mapstructure:"maxstartupwait" yaml:"MaxStartupWait"`
+		Mount                  string        `mapstructure:"mount" yaml:"Mount"`
+		Port                   int           `mapstructure:"port" yaml:"Port"`
+		RobotsTxtFile          string        `mapstructure:"robotstxtfile" yaml:"RobotsTxtFile"`
+		RunLocation            string        `mapstructure:"runlocation" yaml:"RunLocation"`
+		ScitokensConfig        string        `mapstructure:"scitokensconfig" yaml:"ScitokensConfig"`
+		ShutdownTimeout        time.Duration `mapstructure:"shutdowntimeout" yaml:"ShutdownTimeout"`
+		Sitename               string        `mapstructure:"sitename" yaml:"Sitename"`
+		SummaryMonitoringHost  string        `mapstructure:"summarymonitoringhost" yaml:"SummaryMonitoringHost"`
+		SummaryMonitoringPort  int           `mapstructure:"summarymonitoringport" yaml:"SummaryMonitoringPort"`
 	} `mapstructure:"xrootd" yaml:"Xrootd"`
 }
 
-
 type configWithType struct {
 	Cache struct {
-		BlocksToPrefetch struct { Type string; Value int }
-		Concurrency struct { Type string; Value int }
-		DataLocation struct { Type string; Value string }
-		DataLocations struct { Type string; Value []string }
-		DbLocation struct { Type string; Value string }
-		DefaultCacheTimeout struct { Type string; Value time.Duration }
-		EnableBroker struct { Type string; Value bool }
-		EnableLotman struct { Type string; Value bool }
-		EnableOIDC struct { Type string; Value bool }
-		EnablePrefetch struct { Type string; Value bool }
-		EnableTLSClientAuth struct { Type string; Value bool }
-		EnableVoms struct { Type string; Value bool }
-		ExportLocation struct { Type string; Value string }
-		FedTokenLocation struct { Type string; Value string }
-		FilesBaseSize struct { Type string; Value string }
-		FilesMaxSize struct { Type string; Value string }
-		FilesNominalSize struct { Type string; Value string }
-		HighWaterMark struct { Type string; Value string }
-		LocalRoot struct { Type string; Value string }
-		LowWatermark struct { Type string; Value string }
-		MetaLocations struct { Type string; Value []string }
-		NamespaceLocation struct { Type string; Value string }
-		PermittedNamespaces struct { Type string; Value []string }
-		Port struct { Type string; Value int }
-		RunLocation struct { Type string; Value string }
-		SelfTest struct { Type string; Value bool }
-		SelfTestInterval struct { Type string; Value time.Duration }
-		SentinelLocation struct { Type string; Value string }
-		StorageLocation struct { Type string; Value string }
-		Url struct { Type string; Value string }
-		XRootDPrefix struct { Type string; Value string }
+		BlocksToPrefetch struct {
+			Type  string
+			Value int
+		}
+		Concurrency struct {
+			Type  string
+			Value int
+		}
+		DataLocation struct {
+			Type  string
+			Value string
+		}
+		DataLocations struct {
+			Type  string
+			Value []string
+		}
+		DbLocation struct {
+			Type  string
+			Value string
+		}
+		DefaultCacheTimeout struct {
+			Type  string
+			Value time.Duration
+		}
+		EnableBroker struct {
+			Type  string
+			Value bool
+		}
+		EnableLotman struct {
+			Type  string
+			Value bool
+		}
+		EnableOIDC struct {
+			Type  string
+			Value bool
+		}
+		EnablePrefetch struct {
+			Type  string
+			Value bool
+		}
+		EnableTLSClientAuth struct {
+			Type  string
+			Value bool
+		}
+		EnableVoms struct {
+			Type  string
+			Value bool
+		}
+		ExportLocation struct {
+			Type  string
+			Value string
+		}
+		FedTokenLocation struct {
+			Type  string
+			Value string
+		}
+		FilesBaseSize struct {
+			Type  string
+			Value string
+		}
+		FilesMaxSize struct {
+			Type  string
+			Value string
+		}
+		FilesNominalSize struct {
+			Type  string
+			Value string
+		}
+		HighWaterMark struct {
+			Type  string
+			Value string
+		}
+		LocalRoot struct {
+			Type  string
+			Value string
+		}
+		LowWatermark struct {
+			Type  string
+			Value string
+		}
+		MetaLocations struct {
+			Type  string
+			Value []string
+		}
+		NamespaceLocation struct {
+			Type  string
+			Value string
+		}
+		PermittedNamespaces struct {
+			Type  string
+			Value []string
+		}
+		Port struct {
+			Type  string
+			Value int
+		}
+		RunLocation struct {
+			Type  string
+			Value string
+		}
+		SelfTest struct {
+			Type  string
+			Value bool
+		}
+		SelfTestInterval struct {
+			Type  string
+			Value time.Duration
+		}
+		SentinelLocation struct {
+			Type  string
+			Value string
+		}
+		StorageLocation struct {
+			Type  string
+			Value string
+		}
+		Url struct {
+			Type  string
+			Value string
+		}
+		XRootDPrefix struct {
+			Type  string
+			Value string
+		}
 	}
 	Client struct {
-		AssumeDirectorServerHeader struct { Type string; Value bool }
-		DirectorRetries struct { Type string; Value int }
-		DisableHttpProxy struct { Type string; Value bool }
-		DisableProxyFallback struct { Type string; Value bool }
-		IsPlugin struct { Type string; Value bool }
-		MaximumDownloadSpeed struct { Type string; Value int }
-		MinimumDownloadSpeed struct { Type string; Value int }
-		PreferredCaches struct { Type string; Value []string }
-		SlowTransferRampupTime struct { Type string; Value time.Duration }
-		SlowTransferWindow struct { Type string; Value time.Duration }
-		StoppedTransferTimeout struct { Type string; Value time.Duration }
-		WorkerCount struct { Type string; Value int }
+		AssumeDirectorServerHeader struct {
+			Type  string
+			Value bool
+		}
+		DirectorRetries struct {
+			Type  string
+			Value int
+		}
+		DisableHttpProxy struct {
+			Type  string
+			Value bool
+		}
+		DisableProxyFallback struct {
+			Type  string
+			Value bool
+		}
+		IsPlugin struct {
+			Type  string
+			Value bool
+		}
+		MaximumDownloadSpeed struct {
+			Type  string
+			Value int
+		}
+		MinimumDownloadSpeed struct {
+			Type  string
+			Value int
+		}
+		PreferredCaches struct {
+			Type  string
+			Value []string
+		}
+		SlowTransferRampupTime struct {
+			Type  string
+			Value time.Duration
+		}
+		SlowTransferWindow struct {
+			Type  string
+			Value time.Duration
+		}
+		StoppedTransferTimeout struct {
+			Type  string
+			Value time.Duration
+		}
+		WorkerCount struct {
+			Type  string
+			Value int
+		}
 	}
-	ConfigDir struct { Type string; Value string }
-	ConfigLocations struct { Type string; Value []string }
-	Debug struct { Type string; Value bool }
+	ConfigDir struct {
+		Type  string
+		Value string
+	}
+	ConfigLocations struct {
+		Type  string
+		Value []string
+	}
+	Debug struct {
+		Type  string
+		Value bool
+	}
 	Director struct {
-		AdvertiseUrl struct { Type string; Value string }
-		AdvertisementTTL struct { Type string; Value time.Duration }
-		AssumePresenceAtSingleOrigin struct { Type string; Value bool }
-		CachePresenceCapacity struct { Type string; Value int }
-		CachePresenceTTL struct { Type string; Value time.Duration }
-		CacheResponseHostnames struct { Type string; Value []string }
-		CacheSortMethod struct { Type string; Value string }
-		CachesPullFromCaches struct { Type string; Value bool }
-		CheckCachePresence struct { Type string; Value bool }
-		CheckOriginPresence struct { Type string; Value bool }
-		DbLocation struct { Type string; Value string }
-		DefaultResponse struct { Type string; Value string }
-		EnableBroker struct { Type string; Value bool }
-		EnableOIDC struct { Type string; Value bool }
-		EnableStat struct { Type string; Value bool }
-		FedTokenLifetime struct { Type string; Value time.Duration }
-		FilteredServers struct { Type string; Value []string }
-		GeoIPLocation struct { Type string; Value string }
-		MaxMindKeyFile struct { Type string; Value string }
-		MaxStatResponse struct { Type string; Value int }
-		MinStatResponse struct { Type string; Value int }
-		OriginCacheHealthTestInterval struct { Type string; Value time.Duration }
-		OriginResponseHostnames struct { Type string; Value []string }
-		RegistryQueryInterval struct { Type string; Value time.Duration }
-		StatConcurrencyLimit struct { Type string; Value int }
-		StatTimeout struct { Type string; Value time.Duration }
-		SupportContactEmail struct { Type string; Value string }
-		SupportContactUrl struct { Type string; Value string }
+		AdvertiseUrl struct {
+			Type  string
+			Value string
+		}
+		AdvertisementTTL struct {
+			Type  string
+			Value time.Duration
+		}
+		AssumePresenceAtSingleOrigin struct {
+			Type  string
+			Value bool
+		}
+		CachePresenceCapacity struct {
+			Type  string
+			Value int
+		}
+		CachePresenceTTL struct {
+			Type  string
+			Value time.Duration
+		}
+		CacheResponseHostnames struct {
+			Type  string
+			Value []string
+		}
+		CacheSortMethod struct {
+			Type  string
+			Value string
+		}
+		CachesPullFromCaches struct {
+			Type  string
+			Value bool
+		}
+		CheckCachePresence struct {
+			Type  string
+			Value bool
+		}
+		CheckOriginPresence struct {
+			Type  string
+			Value bool
+		}
+		DbLocation struct {
+			Type  string
+			Value string
+		}
+		DefaultResponse struct {
+			Type  string
+			Value string
+		}
+		EnableBroker struct {
+			Type  string
+			Value bool
+		}
+		EnableOIDC struct {
+			Type  string
+			Value bool
+		}
+		EnableStat struct {
+			Type  string
+			Value bool
+		}
+		FedTokenLifetime struct {
+			Type  string
+			Value time.Duration
+		}
+		FilteredServers struct {
+			Type  string
+			Value []string
+		}
+		GeoIPLocation struct {
+			Type  string
+			Value string
+		}
+		MaxMindKeyFile struct {
+			Type  string
+			Value string
+		}
+		MaxStatResponse struct {
+			Type  string
+			Value int
+		}
+		MinStatResponse struct {
+			Type  string
+			Value int
+		}
+		OriginCacheHealthTestInterval struct {
+			Type  string
+			Value time.Duration
+		}
+		OriginResponseHostnames struct {
+			Type  string
+			Value []string
+		}
+		RegistryQueryInterval struct {
+			Type  string
+			Value time.Duration
+		}
+		StatConcurrencyLimit struct {
+			Type  string
+			Value int
+		}
+		StatTimeout struct {
+			Type  string
+			Value time.Duration
+		}
+		SupportContactEmail struct {
+			Type  string
+			Value string
+		}
+		SupportContactUrl struct {
+			Type  string
+			Value string
+		}
 	}
-	DisableHttpProxy struct { Type string; Value bool }
-	DisableProxyFallback struct { Type string; Value bool }
+	DisableHttpProxy struct {
+		Type  string
+		Value bool
+	}
+	DisableProxyFallback struct {
+		Type  string
+		Value bool
+	}
 	Federation struct {
-		BrokerUrl struct { Type string; Value string }
-		DirectorUrl struct { Type string; Value string }
-		DiscoveryUrl struct { Type string; Value string }
-		JwkUrl struct { Type string; Value string }
-		RegistryUrl struct { Type string; Value string }
-		TopologyDowntimeUrl struct { Type string; Value string }
-		TopologyNamespaceUrl struct { Type string; Value string }
-		TopologyReloadInterval struct { Type string; Value time.Duration }
-		TopologyUrl struct { Type string; Value string }
+		BrokerUrl struct {
+			Type  string
+			Value string
+		}
+		DirectorUrl struct {
+			Type  string
+			Value string
+		}
+		DiscoveryUrl struct {
+			Type  string
+			Value string
+		}
+		JwkUrl struct {
+			Type  string
+			Value string
+		}
+		RegistryUrl struct {
+			Type  string
+			Value string
+		}
+		TopologyDowntimeUrl struct {
+			Type  string
+			Value string
+		}
+		TopologyNamespaceUrl struct {
+			Type  string
+			Value string
+		}
+		TopologyReloadInterval struct {
+			Type  string
+			Value time.Duration
+		}
+		TopologyUrl struct {
+			Type  string
+			Value string
+		}
 	}
-	GeoIPOverrides struct { Type string; Value interface{} }
+	GeoIPOverrides struct {
+		Type  string
+		Value interface{}
+	}
 	Issuer struct {
-		AuthenticationSource struct { Type string; Value string }
-		AuthorizationTemplates struct { Type string; Value interface{} }
-		GroupFile struct { Type string; Value string }
-		GroupRequirements struct { Type string; Value []string }
-		GroupSource struct { Type string; Value string }
-		IssuerClaimValue struct { Type string; Value string }
-		OIDCAuthenticationRequirements struct { Type string; Value interface{} }
-		OIDCAuthenticationUserClaim struct { Type string; Value string }
-		OIDCGroupClaim struct { Type string; Value string }
-		OIDCPreferClaimsFromIDToken struct { Type string; Value bool }
-		QDLLocation struct { Type string; Value string }
-		ScitokensServerLocation struct { Type string; Value string }
-		TomcatLocation struct { Type string; Value string }
-		UserStripDomain struct { Type string; Value bool }
+		AuthenticationSource struct {
+			Type  string
+			Value string
+		}
+		AuthorizationTemplates struct {
+			Type  string
+			Value interface{}
+		}
+		GroupFile struct {
+			Type  string
+			Value string
+		}
+		GroupRequirements struct {
+			Type  string
+			Value []string
+		}
+		GroupSource struct {
+			Type  string
+			Value string
+		}
+		IssuerClaimValue struct {
+			Type  string
+			Value string
+		}
+		OIDCAuthenticationRequirements struct {
+			Type  string
+			Value interface{}
+		}
+		OIDCAuthenticationUserClaim struct {
+			Type  string
+			Value string
+		}
+		OIDCGroupClaim struct {
+			Type  string
+			Value string
+		}
+		OIDCPreferClaimsFromIDToken struct {
+			Type  string
+			Value bool
+		}
+		QDLLocation struct {
+			Type  string
+			Value string
+		}
+		RedirectUris struct {
+			Type  string
+			Value []string
+		}
+		ScitokensServerLocation struct {
+			Type  string
+			Value string
+		}
+		TomcatLocation struct {
+			Type  string
+			Value string
+		}
+		UserStripDomain struct {
+			Type  string
+			Value bool
+		}
 	}
-	IssuerKey struct { Type string; Value string }
-	IssuerKeysDirectory struct { Type string; Value string }
+	IssuerKey struct {
+		Type  string
+		Value string
+	}
+	IssuerKeysDirectory struct {
+		Type  string
+		Value string
+	}
 	LocalCache struct {
-		DataLocation struct { Type string; Value string }
-		HighWaterMarkPercentage struct { Type string; Value int }
-		LowWaterMarkPercentage struct { Type string; Value int }
-		RunLocation struct { Type string; Value string }
-		Size struct { Type string; Value string }
-		Socket struct { Type string; Value string }
+		DataLocation struct {
+			Type  string
+			Value string
+		}
+		HighWaterMarkPercentage struct {
+			Type  string
+			Value int
+		}
+		LowWaterMarkPercentage struct {
+			Type  string
+			Value int
+		}
+		RunLocation struct {
+			Type  string
+			Value string
+		}
+		Size struct {
+			Type  string
+			Value string
+		}
+		Socket struct {
+			Type  string
+			Value string
+		}
 	}
 	Logging struct {
 		Cache struct {
-			Http struct { Type string; Value string }
-			Ofs struct { Type string; Value string }
-			Pfc struct { Type string; Value string }
-			Pss struct { Type string; Value string }
-			PssSetOpt struct { Type string; Value string }
-			Scitokens struct { Type string; Value string }
-			Xrd struct { Type string; Value string }
-			Xrootd struct { Type string; Value string }
+			Http struct {
+				Type  string
+				Value string
+			}
+			Ofs struct {
+				Type  string
+				Value string
+			}
+			Pfc struct {
+				Type  string
+				Value string
+			}
+			Pss struct {
+				Type  string
+				Value string
+			}
+			PssSetOpt struct {
+				Type  string
+				Value string
+			}
+			Scitokens struct {
+				Type  string
+				Value string
+			}
+			Xrd struct {
+				Type  string
+				Value string
+			}
+			Xrootd struct {
+				Type  string
+				Value string
+			}
 		}
 		Client struct {
-			ProgressInterval struct { Type string; Value time.Duration }
+			ProgressInterval struct {
+				Type  string
+				Value time.Duration
+			}
 		}
-		DisableProgressBars struct { Type string; Value bool }
-		Level struct { Type string; Value string }
-		LogLocation struct { Type string; Value string }
+		DisableProgressBars struct {
+			Type  string
+			Value bool
+		}
+		Level struct {
+			Type  string
+			Value string
+		}
+		LogLocation struct {
+			Type  string
+			Value string
+		}
 		Origin struct {
-			Cms struct { Type string; Value string }
-			Http struct { Type string; Value string }
-			Ofs struct { Type string; Value string }
-			Oss struct { Type string; Value string }
-			Scitokens struct { Type string; Value string }
-			Xrd struct { Type string; Value string }
-			Xrootd struct { Type string; Value string }
+			Cms struct {
+				Type  string
+				Value string
+			}
+			Http struct {
+				Type  string
+				Value string
+			}
+			Ofs struct {
+				Type  string
+				Value string
+			}
+			Oss struct {
+				Type  string
+				Value string
+			}
+			Scitokens struct {
+				Type  string
+				Value string
+			}
+			Xrd struct {
+				Type  string
+				Value string
+			}
+			Xrootd struct {
+				Type  string
+				Value string
+			}
 		}
 	}
 	Lotman struct {
-		DbLocation struct { Type string; Value string }
-		DefaultLotDeletionLifetime struct { Type string; Value time.Duration }
-		DefaultLotExpirationLifetime struct { Type string; Value time.Duration }
-		EnableAPI struct { Type string; Value bool }
-		EnabledPolicy struct { Type string; Value string }
-		LibLocation struct { Type string; Value string }
-		LotHome struct { Type string; Value string }
-		PolicyDefinitions struct { Type string; Value interface{} }
+		DbLocation struct {
+			Type  string
+			Value string
+		}
+		DefaultLotDeletionLifetime struct {
+			Type  string
+			Value time.Duration
+		}
+		DefaultLotExpirationLifetime struct {
+			Type  string
+			Value time.Duration
+		}
+		EnableAPI struct {
+			Type  string
+			Value bool
+		}
+		EnabledPolicy struct {
+			Type  string
+			Value string
+		}
+		LibLocation struct {
+			Type  string
+			Value string
+		}
+		LotHome struct {
+			Type  string
+			Value string
+		}
+		PolicyDefinitions struct {
+			Type  string
+			Value interface{}
+		}
 	}
-	MinimumDownloadSpeed struct { Type string; Value int }
+	MinimumDownloadSpeed struct {
+		Type  string
+		Value int
+	}
 	Monitoring struct {
-		AggregatePrefixes struct { Type string; Value []string }
-		DataLocation struct { Type string; Value string }
-		DataRetention struct { Type string; Value time.Duration }
-		LabelLimit struct { Type string; Value int }
-		LabelNameLengthLimit struct { Type string; Value int }
-		LabelValueLengthLimit struct { Type string; Value int }
-		MetricAuthorization struct { Type string; Value bool }
-		PortHigher struct { Type string; Value int }
-		PortLower struct { Type string; Value int }
-		PromQLAuthorization struct { Type string; Value bool }
-		SampleLimit struct { Type string; Value int }
-		TokenExpiresIn struct { Type string; Value time.Duration }
-		TokenRefreshInterval struct { Type string; Value time.Duration }
+		AggregatePrefixes struct {
+			Type  string
+			Value []string
+		}
+		DataLocation struct {
+			Type  string
+			Value string
+		}
+		DataRetention struct {
+			Type  string
+			Value time.Duration
+		}
+		LabelLimit struct {
+			Type  string
+			Value int
+		}
+		LabelNameLengthLimit struct {
+			Type  string
+			Value int
+		}
+		LabelValueLengthLimit struct {
+			Type  string
+			Value int
+		}
+		MetricAuthorization struct {
+			Type  string
+			Value bool
+		}
+		PortHigher struct {
+			Type  string
+			Value int
+		}
+		PortLower struct {
+			Type  string
+			Value int
+		}
+		PromQLAuthorization struct {
+			Type  string
+			Value bool
+		}
+		SampleLimit struct {
+			Type  string
+			Value int
+		}
+		TokenExpiresIn struct {
+			Type  string
+			Value time.Duration
+		}
+		TokenRefreshInterval struct {
+			Type  string
+			Value time.Duration
+		}
 	}
 	OIDC struct {
-		AuthorizationEndpoint struct { Type string; Value string }
-		ClientID struct { Type string; Value string }
-		ClientIDFile struct { Type string; Value string }
-		ClientRedirectHostname struct { Type string; Value string }
-		ClientSecretFile struct { Type string; Value string }
-		DeviceAuthEndpoint struct { Type string; Value string }
-		Issuer struct { Type string; Value string }
-		TokenEndpoint struct { Type string; Value string }
-		UserInfoEndpoint struct { Type string; Value string }
+		AuthorizationEndpoint struct {
+			Type  string
+			Value string
+		}
+		ClientID struct {
+			Type  string
+			Value string
+		}
+		ClientIDFile struct {
+			Type  string
+			Value string
+		}
+		ClientRedirectHostname struct {
+			Type  string
+			Value string
+		}
+		ClientSecretFile struct {
+			Type  string
+			Value string
+		}
+		DeviceAuthEndpoint struct {
+			Type  string
+			Value string
+		}
+		Issuer struct {
+			Type  string
+			Value string
+		}
+		TokenEndpoint struct {
+			Type  string
+			Value string
+		}
+		UserInfoEndpoint struct {
+			Type  string
+			Value string
+		}
 	}
 	Origin struct {
-		Concurrency struct { Type string; Value int }
-		DbLocation struct { Type string; Value string }
-		DirectorTest struct { Type string; Value bool }
-		DisableDirectClients struct { Type string; Value bool }
-		EnableBroker struct { Type string; Value bool }
-		EnableCmsd struct { Type string; Value bool }
-		EnableDirListing struct { Type string; Value bool }
-		EnableDirectReads struct { Type string; Value bool }
-		EnableFallbackRead struct { Type string; Value bool }
-		EnableIssuer struct { Type string; Value bool }
-		EnableListings struct { Type string; Value bool }
-		EnableMacaroons struct { Type string; Value bool }
-		EnableOIDC struct { Type string; Value bool }
-		EnablePublicReads struct { Type string; Value bool }
-		EnableReads struct { Type string; Value bool }
-		EnableUI struct { Type string; Value bool }
-		EnableVoms struct { Type string; Value bool }
-		EnableWrite struct { Type string; Value bool }
-		EnableWrites struct { Type string; Value bool }
-		ExportVolume struct { Type string; Value string }
-		ExportVolumes struct { Type string; Value []string }
-		Exports struct { Type string; Value interface{} }
-		FedTokenLocation struct { Type string; Value string }
-		FederationPrefix struct { Type string; Value string }
-		GlobusClientIDFile struct { Type string; Value string }
-		GlobusClientSecretFile struct { Type string; Value string }
-		GlobusCollectionID struct { Type string; Value string }
-		GlobusCollectionName struct { Type string; Value string }
-		GlobusConfigLocation struct { Type string; Value string }
-		HttpAuthTokenFile struct { Type string; Value string }
-		HttpServiceUrl struct { Type string; Value string }
-		Mode struct { Type string; Value string }
-		Multiuser struct { Type string; Value bool }
-		NamespacePrefix struct { Type string; Value string }
-		Port struct { Type string; Value int }
-		RunLocation struct { Type string; Value string }
-		S3AccessKeyfile struct { Type string; Value string }
-		S3Bucket struct { Type string; Value string }
-		S3Region struct { Type string; Value string }
-		S3SecretKeyfile struct { Type string; Value string }
-		S3ServiceName struct { Type string; Value string }
-		S3ServiceUrl struct { Type string; Value string }
-		S3UrlStyle struct { Type string; Value string }
-		ScitokensDefaultUser struct { Type string; Value string }
-		ScitokensMapSubject struct { Type string; Value bool }
-		ScitokensNameMapFile struct { Type string; Value string }
-		ScitokensRestrictedPaths struct { Type string; Value []string }
-		ScitokensUsernameClaim struct { Type string; Value string }
-		SelfTest struct { Type string; Value bool }
-		SelfTestInterval struct { Type string; Value time.Duration }
-		StoragePrefix struct { Type string; Value string }
-		StorageType struct { Type string; Value string }
-		TokenAudience struct { Type string; Value string }
-		Url struct { Type string; Value string }
-		XRootDPrefix struct { Type string; Value string }
-		XRootServiceUrl struct { Type string; Value string }
+		Concurrency struct {
+			Type  string
+			Value int
+		}
+		DbLocation struct {
+			Type  string
+			Value string
+		}
+		DirectorTest struct {
+			Type  string
+			Value bool
+		}
+		DisableDirectClients struct {
+			Type  string
+			Value bool
+		}
+		EnableBroker struct {
+			Type  string
+			Value bool
+		}
+		EnableCmsd struct {
+			Type  string
+			Value bool
+		}
+		EnableDirListing struct {
+			Type  string
+			Value bool
+		}
+		EnableDirectReads struct {
+			Type  string
+			Value bool
+		}
+		EnableFallbackRead struct {
+			Type  string
+			Value bool
+		}
+		EnableIssuer struct {
+			Type  string
+			Value bool
+		}
+		EnableListings struct {
+			Type  string
+			Value bool
+		}
+		EnableMacaroons struct {
+			Type  string
+			Value bool
+		}
+		EnableOIDC struct {
+			Type  string
+			Value bool
+		}
+		EnablePublicReads struct {
+			Type  string
+			Value bool
+		}
+		EnableReads struct {
+			Type  string
+			Value bool
+		}
+		EnableUI struct {
+			Type  string
+			Value bool
+		}
+		EnableVoms struct {
+			Type  string
+			Value bool
+		}
+		EnableWrite struct {
+			Type  string
+			Value bool
+		}
+		EnableWrites struct {
+			Type  string
+			Value bool
+		}
+		ExportVolume struct {
+			Type  string
+			Value string
+		}
+		ExportVolumes struct {
+			Type  string
+			Value []string
+		}
+		Exports struct {
+			Type  string
+			Value interface{}
+		}
+		FedTokenLocation struct {
+			Type  string
+			Value string
+		}
+		FederationPrefix struct {
+			Type  string
+			Value string
+		}
+		GlobusClientIDFile struct {
+			Type  string
+			Value string
+		}
+		GlobusClientSecretFile struct {
+			Type  string
+			Value string
+		}
+		GlobusCollectionID struct {
+			Type  string
+			Value string
+		}
+		GlobusCollectionName struct {
+			Type  string
+			Value string
+		}
+		GlobusConfigLocation struct {
+			Type  string
+			Value string
+		}
+		HttpAuthTokenFile struct {
+			Type  string
+			Value string
+		}
+		HttpServiceUrl struct {
+			Type  string
+			Value string
+		}
+		Mode struct {
+			Type  string
+			Value string
+		}
+		Multiuser struct {
+			Type  string
+			Value bool
+		}
+		NamespacePrefix struct {
+			Type  string
+			Value string
+		}
+		Port struct {
+			Type  string
+			Value int
+		}
+		RunLocation struct {
+			Type  string
+			Value string
+		}
+		S3AccessKeyfile struct {
+			Type  string
+			Value string
+		}
+		S3Bucket struct {
+			Type  string
+			Value string
+		}
+		S3Region struct {
+			Type  string
+			Value string
+		}
+		S3SecretKeyfile struct {
+			Type  string
+			Value string
+		}
+		S3ServiceName struct {
+			Type  string
+			Value string
+		}
+		S3ServiceUrl struct {
+			Type  string
+			Value string
+		}
+		S3UrlStyle struct {
+			Type  string
+			Value string
+		}
+		ScitokensDefaultUser struct {
+			Type  string
+			Value string
+		}
+		ScitokensMapSubject struct {
+			Type  string
+			Value bool
+		}
+		ScitokensNameMapFile struct {
+			Type  string
+			Value string
+		}
+		ScitokensRestrictedPaths struct {
+			Type  string
+			Value []string
+		}
+		ScitokensUsernameClaim struct {
+			Type  string
+			Value string
+		}
+		SelfTest struct {
+			Type  string
+			Value bool
+		}
+		SelfTestInterval struct {
+			Type  string
+			Value time.Duration
+		}
+		StoragePrefix struct {
+			Type  string
+			Value string
+		}
+		StorageType struct {
+			Type  string
+			Value string
+		}
+		TokenAudience struct {
+			Type  string
+			Value string
+		}
+		Url struct {
+			Type  string
+			Value string
+		}
+		XRootDPrefix struct {
+			Type  string
+			Value string
+		}
+		XRootServiceUrl struct {
+			Type  string
+			Value string
+		}
 	}
 	Plugin struct {
-		Token struct { Type string; Value string }
+		Token struct {
+			Type  string
+			Value string
+		}
 	}
 	Registry struct {
-		AdminUsers struct { Type string; Value []string }
-		CustomRegistrationFields struct { Type string; Value interface{} }
-		DbLocation struct { Type string; Value string }
-		Institutions struct { Type string; Value interface{} }
-		InstitutionsUrl struct { Type string; Value string }
-		InstitutionsUrlReloadMinutes struct { Type string; Value time.Duration }
-		RequireCacheApproval struct { Type string; Value bool }
-		RequireKeyChaining struct { Type string; Value bool }
-		RequireOriginApproval struct { Type string; Value bool }
+		AdminUsers struct {
+			Type  string
+			Value []string
+		}
+		CustomRegistrationFields struct {
+			Type  string
+			Value interface{}
+		}
+		DbLocation struct {
+			Type  string
+			Value string
+		}
+		Institutions struct {
+			Type  string
+			Value interface{}
+		}
+		InstitutionsUrl struct {
+			Type  string
+			Value string
+		}
+		InstitutionsUrlReloadMinutes struct {
+			Type  string
+			Value time.Duration
+		}
+		RequireCacheApproval struct {
+			Type  string
+			Value bool
+		}
+		RequireKeyChaining struct {
+			Type  string
+			Value bool
+		}
+		RequireOriginApproval struct {
+			Type  string
+			Value bool
+		}
 	}
 	Server struct {
-		AdLifetime struct { Type string; Value time.Duration }
-		AdvertisementInterval struct { Type string; Value time.Duration }
-		DbLocation struct { Type string; Value string }
-		DirectorUrls struct { Type string; Value []string }
-		DropPrivileges struct { Type string; Value bool }
-		EnablePprof struct { Type string; Value bool }
-		EnableUI struct { Type string; Value bool }
-		ExternalWebUrl struct { Type string; Value string }
-		HealthMonitoringPublic struct { Type string; Value bool }
-		Hostname struct { Type string; Value string }
-		IssuerHostname struct { Type string; Value string }
-		IssuerJwks struct { Type string; Value string }
-		IssuerPort struct { Type string; Value int }
-		IssuerUrl struct { Type string; Value string }
-		Modules struct { Type string; Value []string }
-		RegistrationRetryInterval struct { Type string; Value time.Duration }
-		SessionSecretFile struct { Type string; Value string }
-		StartupTimeout struct { Type string; Value time.Duration }
-		TLSCACertificateDirectory struct { Type string; Value string }
-		TLSCACertificateFile struct { Type string; Value string }
-		TLSCAKey struct { Type string; Value string }
-		TLSCertificate struct { Type string; Value string }
-		TLSCertificateChain struct { Type string; Value string }
-		TLSKey struct { Type string; Value string }
-		UIActivationCodeFile struct { Type string; Value string }
-		UIAdminUsers struct { Type string; Value []string }
-		UILoginRateLimit struct { Type string; Value int }
-		UIPasswordFile struct { Type string; Value string }
-		UnprivilegedUser struct { Type string; Value string }
-		WebConfigFile struct { Type string; Value string }
-		WebHost struct { Type string; Value string }
-		WebPort struct { Type string; Value int }
+		AdLifetime struct {
+			Type  string
+			Value time.Duration
+		}
+		AdvertisementInterval struct {
+			Type  string
+			Value time.Duration
+		}
+		DbLocation struct {
+			Type  string
+			Value string
+		}
+		DirectorUrls struct {
+			Type  string
+			Value []string
+		}
+		DropPrivileges struct {
+			Type  string
+			Value bool
+		}
+		EnablePprof struct {
+			Type  string
+			Value bool
+		}
+		EnableUI struct {
+			Type  string
+			Value bool
+		}
+		ExternalWebUrl struct {
+			Type  string
+			Value string
+		}
+		HealthMonitoringPublic struct {
+			Type  string
+			Value bool
+		}
+		Hostname struct {
+			Type  string
+			Value string
+		}
+		IssuerHostname struct {
+			Type  string
+			Value string
+		}
+		IssuerJwks struct {
+			Type  string
+			Value string
+		}
+		IssuerPort struct {
+			Type  string
+			Value int
+		}
+		IssuerUrl struct {
+			Type  string
+			Value string
+		}
+		Modules struct {
+			Type  string
+			Value []string
+		}
+		RegistrationRetryInterval struct {
+			Type  string
+			Value time.Duration
+		}
+		SessionSecretFile struct {
+			Type  string
+			Value string
+		}
+		StartupTimeout struct {
+			Type  string
+			Value time.Duration
+		}
+		TLSCACertificateDirectory struct {
+			Type  string
+			Value string
+		}
+		TLSCACertificateFile struct {
+			Type  string
+			Value string
+		}
+		TLSCAKey struct {
+			Type  string
+			Value string
+		}
+		TLSCertificate struct {
+			Type  string
+			Value string
+		}
+		TLSCertificateChain struct {
+			Type  string
+			Value string
+		}
+		TLSKey struct {
+			Type  string
+			Value string
+		}
+		UIActivationCodeFile struct {
+			Type  string
+			Value string
+		}
+		UIAdminUsers struct {
+			Type  string
+			Value []string
+		}
+		UILoginRateLimit struct {
+			Type  string
+			Value int
+		}
+		UIPasswordFile struct {
+			Type  string
+			Value string
+		}
+		UnprivilegedUser struct {
+			Type  string
+			Value string
+		}
+		WebConfigFile struct {
+			Type  string
+			Value string
+		}
+		WebHost struct {
+			Type  string
+			Value string
+		}
+		WebPort struct {
+			Type  string
+			Value int
+		}
 	}
 	Shoveler struct {
-		AMQPExchange struct { Type string; Value string }
-		AMQPTokenLocation struct { Type string; Value string }
-		Enable struct { Type string; Value bool }
-		IPMapping struct { Type string; Value interface{} }
-		MessageQueueProtocol struct { Type string; Value string }
-		OutputDestinations struct { Type string; Value []string }
-		PortHigher struct { Type string; Value int }
-		PortLower struct { Type string; Value int }
-		QueueDirectory struct { Type string; Value string }
-		StompCert struct { Type string; Value string }
-		StompCertKey struct { Type string; Value string }
-		StompPassword struct { Type string; Value string }
-		StompUsername struct { Type string; Value string }
-		Topic struct { Type string; Value string }
-		URL struct { Type string; Value string }
-		VerifyHeader struct { Type string; Value bool }
+		AMQPExchange struct {
+			Type  string
+			Value string
+		}
+		AMQPTokenLocation struct {
+			Type  string
+			Value string
+		}
+		Enable struct {
+			Type  string
+			Value bool
+		}
+		IPMapping struct {
+			Type  string
+			Value interface{}
+		}
+		MessageQueueProtocol struct {
+			Type  string
+			Value string
+		}
+		OutputDestinations struct {
+			Type  string
+			Value []string
+		}
+		PortHigher struct {
+			Type  string
+			Value int
+		}
+		PortLower struct {
+			Type  string
+			Value int
+		}
+		QueueDirectory struct {
+			Type  string
+			Value string
+		}
+		StompCert struct {
+			Type  string
+			Value string
+		}
+		StompCertKey struct {
+			Type  string
+			Value string
+		}
+		StompPassword struct {
+			Type  string
+			Value string
+		}
+		StompUsername struct {
+			Type  string
+			Value string
+		}
+		Topic struct {
+			Type  string
+			Value string
+		}
+		URL struct {
+			Type  string
+			Value string
+		}
+		VerifyHeader struct {
+			Type  string
+			Value bool
+		}
 	}
 	StagePlugin struct {
-		Hook struct { Type string; Value bool }
-		MountPrefix struct { Type string; Value string }
-		OriginPrefix struct { Type string; Value string }
-		ShadowOriginPrefix struct { Type string; Value string }
+		Hook struct {
+			Type  string
+			Value bool
+		}
+		MountPrefix struct {
+			Type  string
+			Value string
+		}
+		OriginPrefix struct {
+			Type  string
+			Value string
+		}
+		ShadowOriginPrefix struct {
+			Type  string
+			Value string
+		}
 	}
-	TLSSkipVerify struct { Type string; Value bool }
+	TLSSkipVerify struct {
+		Type  string
+		Value bool
+	}
 	Topology struct {
-		DisableCacheX509 struct { Type string; Value bool }
-		DisableCaches struct { Type string; Value bool }
-		DisableDowntime struct { Type string; Value bool }
-		DisableOriginX509 struct { Type string; Value bool }
-		DisableOrigins struct { Type string; Value bool }
+		DisableCacheX509 struct {
+			Type  string
+			Value bool
+		}
+		DisableCaches struct {
+			Type  string
+			Value bool
+		}
+		DisableDowntime struct {
+			Type  string
+			Value bool
+		}
+		DisableOriginX509 struct {
+			Type  string
+			Value bool
+		}
+		DisableOrigins struct {
+			Type  string
+			Value bool
+		}
 	}
 	Transport struct {
-		BrokerEndpointCacheTTL struct { Type string; Value time.Duration }
-		DialerKeepAlive struct { Type string; Value time.Duration }
-		DialerTimeout struct { Type string; Value time.Duration }
-		ExpectContinueTimeout struct { Type string; Value time.Duration }
-		IdleConnTimeout struct { Type string; Value time.Duration }
-		MaxIdleConns struct { Type string; Value int }
-		ResponseHeaderTimeout struct { Type string; Value time.Duration }
-		TLSHandshakeTimeout struct { Type string; Value time.Duration }
+		BrokerEndpointCacheTTL struct {
+			Type  string
+			Value time.Duration
+		}
+		DialerKeepAlive struct {
+			Type  string
+			Value time.Duration
+		}
+		DialerTimeout struct {
+			Type  string
+			Value time.Duration
+		}
+		ExpectContinueTimeout struct {
+			Type  string
+			Value time.Duration
+		}
+		IdleConnTimeout struct {
+			Type  string
+			Value time.Duration
+		}
+		MaxIdleConns struct {
+			Type  string
+			Value int
+		}
+		ResponseHeaderTimeout struct {
+			Type  string
+			Value time.Duration
+		}
+		TLSHandshakeTimeout struct {
+			Type  string
+			Value time.Duration
+		}
 	}
 	Xrootd struct {
-		AuthRefreshInterval struct { Type string; Value time.Duration }
-		Authfile struct { Type string; Value string }
-		ConfigFile struct { Type string; Value string }
-		DetailedMonitoringHost struct { Type string; Value string }
-		DetailedMonitoringPort struct { Type string; Value int }
-		EnableLocalMonitoring struct { Type string; Value bool }
-		LocalMonitoringHost struct { Type string; Value string }
-		MacaroonsKeyFile struct { Type string; Value string }
-		ManagerHost struct { Type string; Value string }
-		ManagerPort struct { Type string; Value int }
-		MaxStartupWait struct { Type string; Value time.Duration }
-		Mount struct { Type string; Value string }
-		Port struct { Type string; Value int }
-		RobotsTxtFile struct { Type string; Value string }
-		RunLocation struct { Type string; Value string }
-		ScitokensConfig struct { Type string; Value string }
-		ShutdownTimeout struct { Type string; Value time.Duration }
-		Sitename struct { Type string; Value string }
-		SummaryMonitoringHost struct { Type string; Value string }
-		SummaryMonitoringPort struct { Type string; Value int }
+		AuthRefreshInterval struct {
+			Type  string
+			Value time.Duration
+		}
+		Authfile struct {
+			Type  string
+			Value string
+		}
+		ConfigFile struct {
+			Type  string
+			Value string
+		}
+		DetailedMonitoringHost struct {
+			Type  string
+			Value string
+		}
+		DetailedMonitoringPort struct {
+			Type  string
+			Value int
+		}
+		EnableLocalMonitoring struct {
+			Type  string
+			Value bool
+		}
+		LocalMonitoringHost struct {
+			Type  string
+			Value string
+		}
+		MacaroonsKeyFile struct {
+			Type  string
+			Value string
+		}
+		ManagerHost struct {
+			Type  string
+			Value string
+		}
+		ManagerPort struct {
+			Type  string
+			Value int
+		}
+		MaxStartupWait struct {
+			Type  string
+			Value time.Duration
+		}
+		Mount struct {
+			Type  string
+			Value string
+		}
+		Port struct {
+			Type  string
+			Value int
+		}
+		RobotsTxtFile struct {
+			Type  string
+			Value string
+		}
+		RunLocation struct {
+			Type  string
+			Value string
+		}
+		ScitokensConfig struct {
+			Type  string
+			Value string
+		}
+		ShutdownTimeout struct {
+			Type  string
+			Value time.Duration
+		}
+		Sitename struct {
+			Type  string
+			Value string
+		}
+		SummaryMonitoringHost struct {
+			Type  string
+			Value string
+		}
+		SummaryMonitoringPort struct {
+			Type  string
+			Value int
+		}
 	}
 }

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -201,16 +201,17 @@ type (
 	}
 
 	OpenIdDiscoveryResponse struct {
-		Issuer               string   `json:"issuer"`
-		JwksUri              string   `json:"jwks_uri"`
-		TokenEndpoint        string   `json:"token_endpoint,omitempty"`
-		UserInfoEndpoint     string   `json:"userinfo_endpoint,omitempty"`
-		RevocationEndpoint   string   `json:"revocation_endpoint,omitempty"`
-		GrantTypesSupported  []string `json:"grant_types_supported,omitempty"`
-		ScopesSupported      []string `json:"scopes_supported,omitempty"`
-		TokenAuthMethods     []string `json:"token_endpoint_auth_methods_supported,omitempty"`
-		RegistrationEndpoint string   `json:"registration_endpoint,omitempty"`
-		DeviceEndpoint       string   `json:"device_authorization_endpoint,omitempty"`
+		Issuer                string   `json:"issuer"`
+		JwksUri               string   `json:"jwks_uri"`
+		TokenEndpoint         string   `json:"token_endpoint,omitempty"`
+		UserInfoEndpoint      string   `json:"userinfo_endpoint,omitempty"`
+		RevocationEndpoint    string   `json:"revocation_endpoint,omitempty"`
+		GrantTypesSupported   []string `json:"grant_types_supported,omitempty"`
+		ScopesSupported       []string `json:"scopes_supported,omitempty"`
+		TokenAuthMethods      []string `json:"token_endpoint_auth_methods_supported,omitempty"`
+		RegistrationEndpoint  string   `json:"registration_endpoint,omitempty"`
+		DeviceEndpoint        string   `json:"device_authorization_endpoint,omitempty"`
+		AuthorizationEndpoint string   `json:"authorization_endpoint,omitempty"`
 	}
 
 	XPelHeader interface {

--- a/server_utils/oidc.go
+++ b/server_utils/oidc.go
@@ -116,9 +116,11 @@ func createOidcConfigExporter(isDirector bool) func(ctx *gin.Context) {
 			cfg.TokenAuthMethods = []string{"client_secret_basic", "client_secret_post"}
 			cfg.RegistrationEndpoint = serviceUri + "/oidc-cm"
 			cfg.DeviceEndpoint = serviceUri + "/device_authorization"
+			cfg.AuthorizationEndpoint = serviceUri + "/authorize"
 		}
 
 		ctx.Header("Content-Disposition", "attachment; filename=pelican-oidc-configuration.json")
+		ctx.Header("Access-Control-Allow-Origin", "*")
 
 		ctx.JSON(http.StatusOK, cfg)
 	}


### PR DESCRIPTION
Intended to be merged after #2467

**Add redirect=false to the director so that the web client can read the directors headers before being redirected**

Used by the web client which cannot read headers from a url that has redirected itself. Allows the web client to consume the `X-Pelican-Authorization` header, which in turn points it at the issuer to begin the token exchange.

**Add CORs configuration on the Director and the Origin Issuer**

Enables browser requests to the Director and the Origin. These are used on PUT, POST, OPTION, GET methods depending on the service. 

The director needs to be able to handle the PUT, POST, GET and OPTION which are typically forwarded to the cache/origin.

The Origin needs to be able to respond to the Issuer requests such as the code exchange and the Client registration.

**Configure Issuer to only respond to configured Web Clients**

Added a new configuration knob called `Issuer.RedirectUris`. This knob makes it so that only RedirectUris that the Origin admin has approved can be used for dynamic clients. The hosts from these clients are also the only hosts that can make browser requests to the Origin issuer.

This is to prevent anyone from setting up a web client for a Origin. If that was possible it would not be challenging for someone to accidentally use a fake client and expose their object tokens. 

**Add new configuration to `register` web client uris**

Used for the purpose above. Is a slice of strings.