### PR TITLE
Cache Eviction Metrics

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1012,6 +1012,8 @@ func SetServerDefaults(v *viper.Viper) error {
 	v.SetDefault(param.Xrootd_Authfile.GetName(), filepath.Join(configDir, "xrootd", "authfile"))
 	v.SetDefault(param.Xrootd_MacaroonsKeyFile.GetName(), filepath.Join(configDir, "macaroons-secret"))
 	v.SetDefault(param.Xrootd_ShutdownTimeout.GetName(), 1*time.Minute)
+	v.SetDefault(param.Xrootd_EvictionMonitoringInterval.GetName(), 60)
+	v.SetDefault(param.Xrootd_EvictionMonitoringMaxDepth.GetName(), 3)
 	v.SetDefault(param.IssuerKey.GetName(), filepath.Join(configDir, "issuer.jwk"))
 	v.SetDefault(param.IssuerKeysDirectory.GetName(), filepath.Join(configDir, "issuer-keys"))
 	v.SetDefault(param.Server_UIPasswordFile.GetName(), filepath.Join(configDir, "server-web-passwd"))

--- a/config/config.go
+++ b/config/config.go
@@ -1013,7 +1013,7 @@ func SetServerDefaults(v *viper.Viper) error {
 	v.SetDefault(param.Xrootd_MacaroonsKeyFile.GetName(), filepath.Join(configDir, "macaroons-secret"))
 	v.SetDefault(param.Xrootd_ShutdownTimeout.GetName(), 1*time.Minute)
 	v.SetDefault(param.Xrootd_EvictionMonitoringInterval.GetName(), 60)
-	v.SetDefault(param.Xrootd_EvictionMonitoringMaxDepth.GetName(), 3)
+	v.SetDefault(param.Xrootd_EvictionMonitoringMaxDepth.GetName(), 1)
 	v.SetDefault(param.IssuerKey.GetName(), filepath.Join(configDir, "issuer.jwk"))
 	v.SetDefault(param.IssuerKeysDirectory.GetName(), filepath.Join(configDir, "issuer-keys"))
 	v.SetDefault(param.Server_UIPasswordFile.GetName(), filepath.Join(configDir, "server-web-passwd"))

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2877,6 +2877,20 @@ type: duration
 default: 1m
 components: ["origin", "cache"]
 ---
+name: Xrootd.EvictionMonitoringInterval
+description: |+
+  The interval of which the eviction monitoring will be reported. Valid values are 60, 300, 600, 900, 1800, 3600.
+type: int
+default: 60
+components: ["cache"]
+---
+name: Xrootd.EvictionMonitoringMaxDepth
+description: |+
+  The maximum depth of the eviction monitoring. Where depth 0 is root only.
+type: int
+default: 3
+components: ["cache"]
+---
 ############################
 # Monitoring-level configs #
 ############################

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2888,7 +2888,7 @@ name: Xrootd.EvictionMonitoringMaxDepth
 description: |+
   The maximum depth of the eviction monitoring. Where depth 0 is root only.
 type: int
-default: 3
+default: 1
 components: ["cache"]
 ---
 ############################

--- a/launchers/cache_serve.go
+++ b/launchers/cache_serve.go
@@ -107,6 +107,8 @@ func CacheServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, m
 
 	cache.LaunchFedTokManager(ctx, egrp, cacheServer)
 
+	metrics.LaunchXrootdCacheEvictionMonitoring(ctx, egrp)
+
 	concLimit := param.Cache_Concurrency.GetInt()
 	if concLimit > 0 {
 		server_utils.LaunchConcurrencyMonitoring(ctx, egrp, cacheServer.GetServerType())

--- a/metrics/xrootd_cache_eviction.go
+++ b/metrics/xrootd_cache_eviction.go
@@ -1,0 +1,262 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package metrics
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path"
+	"path/filepath"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/param"
+)
+
+type (
+	DirStatistics struct {
+		SnapshotStatsResetTime int        `json:"m_sshot_stats_reset_time"`
+		UsageUpdateTime        int        `json:"m_usage_update_time"`
+		DiskTotal              int64      `json:"m_disk_total"`
+		DiskUsed               int64      `json:"m_disk_used"`
+		FileUsage              int        `json:"m_file_usage"`
+		MetaTotal              int64      `json:"m_meta_total"`
+		MetaUsed               int64      `json:"m_meta_used"`
+		DirStates              []DirState `json:"m_dir_states"`
+	}
+
+	DirState struct {
+		DirName        string   `json:"m_dir_name"`
+		Stats          DirStats `json:"m_stats"`
+		Usage          Usage    `json:"m_usage"`
+		Parent         int      `json:"m_parent"`
+		DaughtersBegin int      `json:"m_daughters_begin"`
+		DaughtersEnd   int      `json:"m_daughters_end"`
+	}
+
+	DirStats struct {
+		NumIos              int `json:"m_NumIos"`
+		Duration            int `json:"m_Duration"`
+		BytesHit            int `json:"m_BytesHit"`
+		BytesMissed         int `json:"m_BytesMissed"`
+		BytesBypassed       int `json:"m_BytesBypassed"`
+		BytesWritten        int `json:"m_BytesWritten"`
+		StBlocksAdded       int `json:"m_StBlocksAdded"`
+		NCksumErrors        int `json:"m_NCksumErrors"`
+		StBlocksRemoved     int `json:"m_StBlocksRemoved"`
+		NFilesOpened        int `json:"m_NFilesOpened"`
+		NFilesClosed        int `json:"m_NFilesClosed"`
+		NFilesCreated       int `json:"m_NFilesCreated"`
+		NFilesRemoved       int `json:"m_NFilesRemoved"`
+		NDirectoriesCreated int `json:"m_NDirectoriesCreated"`
+		NDirectoriesRemoved int `json:"m_NDirectoriesRemoved"`
+	}
+
+	Usage struct {
+		LastOpenTime  int `json:"m_LastOpenTime"`
+		LastCloseTime int `json:"m_LastCloseTime"`
+		StBlocks      int `json:"m_StBlocks"`
+		NFilesOpen    int `json:"m_NFilesOpen"`
+		NFiles        int `json:"m_NFiles"`
+		NDirectories  int `json:"m_NDirectories"`
+	}
+)
+
+var (
+	XrootdCacheEvictionLastUpdateTime = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "xrootd_cache_eviction_last_update_time",
+		Help: "The last time the xrootd cache eviction was updated",
+	})
+	XrootdCacheEvictionDiskUsage = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "xrootd_cache_eviction_disk_usage",
+		Help: "The disk usage of the xrootd cache eviction",
+	})
+	XrootdCacheEvictionSnapshotStatsResetTime = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "xrootd_cache_eviction_snapshot_stats_reset_time",
+		Help: "The time when the snapshot statistics were last reset",
+	})
+	XrootdCacheEvictionDiskTotal = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "xrootd_cache_eviction_disk_total",
+		Help: "The total disk space available for the cache",
+	})
+	XrootdCacheEvictionFileUsage = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "xrootd_cache_eviction_file_usage",
+		Help: "The file usage of the xrootd cache",
+	})
+	XrootdCacheEvictionMetaTotal = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "xrootd_cache_eviction_meta_total",
+		Help: "The total metadata storage available for the cache",
+	})
+	XrootdCacheEvictionMetaUsed = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "xrootd_cache_eviction_meta_used",
+		Help: "The used metadata storage for the cache",
+	})
+
+	XrootdCacheEvictionDirNumIos = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "xrootd_cache_eviction_dir_num_ios",
+		Help: "Number of I/Os per directory",
+	}, []string{"dir_name"})
+	XrootdCacheEvictionDirDuration = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "xrootd_cache_eviction_dir_duration",
+		Help: "Duration of I/Os per directory",
+	}, []string{"dir_name"})
+	XrootdCacheEvictionDirBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "xrootd_cache_eviction_dir_bytes",
+		Help: "Bytes transferred per directory",
+	}, []string{"dir_name", "type"})
+	XrootdCacheEvictionDirStBlockBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "xrootd_cache_eviction_dir_st_block_bytes",
+		Help: "Bytes from storage blocks per directory",
+	}, []string{"dir_name", "type"})
+	XrootdCacheEvictionDirNCksumErrors = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "xrootd_cache_eviction_dir_n_cksum_errors",
+		Help: "Number of checksum errors per directory",
+	}, []string{"dir_name"})
+	XrootdCacheEvictionDirFiles = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "xrootd_cache_eviction_dir_files",
+		Help: "File operations per directory",
+	}, []string{"dir_name", "type"})
+	XrootdCacheEvictionDirDirectories = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "xrootd_cache_eviction_dir_directories",
+		Help: "Directory operations per directory",
+	}, []string{"dir_name", "type"})
+
+	XrootdCacheEvictionDirLastAccessTime = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "xrootd_cache_eviction_dir_last_access_time",
+		Help: "Last access time per directory",
+	}, []string{"dir_name", "type"})
+	XrootdCacheEvictionDirStBlocksUsage = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "xrootd_cache_eviction_dir_st_blocks_usage",
+		Help: "Storage blocks usage per directory",
+	}, []string{"dir_name"})
+	XrootdCacheEvictionDirNFilesOpen = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "xrootd_cache_eviction_dir_n_files_open",
+		Help: "Number of open files per directory",
+	}, []string{"dir_name"})
+	XrootdCacheEvictionDirNFiles = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "xrootd_cache_eviction_dir_n_files",
+		Help: "Number of files per directory",
+	}, []string{"dir_name"})
+	XrootdCacheEvictionDirNDirectories = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "xrootd_cache_eviction_dir_n_directories",
+		Help: "Number of directories per directory",
+	}, []string{"dir_name"})
+)
+
+func LaunchXrootdCacheEvictionMonitoring(ctx context.Context, egrp *errgroup.Group) {
+	egrp.Go(func() error {
+
+		statsFile := filepath.Join(param.Cache_StorageLocation.GetString(), "namespace", "pfc-stats", "DirStat.json")
+
+		interval := param.Xrootd_EvictionMonitoringInterval.GetInt()
+		ticker := time.NewTicker(time.Duration(interval) * time.Second)
+
+		// We use this to detect if the stats file is stale
+		var lastUpdateTime int
+
+		for {
+			select {
+			case <-ctx.Done():
+				log.Info("Xrootd cache eviction monitoring: context done")
+				return nil
+			case <-ticker.C:
+				log.Info("Xrootd cache eviction monitoring: tick")
+				stats, err := os.ReadFile(statsFile)
+				if err != nil {
+					log.Errorf("Xrootd cache eviction monitoring: failed to read stats file: %v", err)
+				}
+				var dirStatistics DirStatistics
+				err = json.Unmarshal(stats, &dirStatistics)
+				if err != nil {
+					log.Errorf("Xrootd cache eviction monitoring: failed to unmarshal stats file: %v", err)
+				}
+
+				log.Infof("Xrootd cache eviction monitoring: dirStatistics: %+v", dirStatistics)
+
+				if dirStatistics.UsageUpdateTime <= lastUpdateTime {
+					log.Infof("Xrootd cache eviction monitoring: directory stats is stale")
+					continue
+				}
+
+				lastUpdateTime = dirStatistics.UsageUpdateTime
+				XrootdCacheEvictionLastUpdateTime.Set(float64(lastUpdateTime))
+
+				XrootdCacheEvictionDiskUsage.Set(float64(dirStatistics.DiskUsed))
+
+				XrootdCacheEvictionSnapshotStatsResetTime.Set(float64(dirStatistics.SnapshotStatsResetTime))
+				XrootdCacheEvictionDiskTotal.Set(float64(dirStatistics.DiskTotal))
+				XrootdCacheEvictionFileUsage.Set(float64(dirStatistics.FileUsage))
+				XrootdCacheEvictionMetaTotal.Set(float64(dirStatistics.MetaTotal))
+				XrootdCacheEvictionMetaUsed.Set(float64(dirStatistics.MetaUsed))
+
+				for i, dirState := range dirStatistics.DirStates {
+					// Build the full path by traversing up the parent hierarchy
+					var pathParts []string
+					curr := i
+					for curr != -1 {
+						pathParts = append(pathParts, dirStatistics.DirStates[curr].DirName)
+						curr = dirStatistics.DirStates[curr].Parent
+					}
+
+					// Reverse the parts to get the correct order from root to leaf
+					for i, j := 0, len(pathParts)-1; i < j; i, j = i+1, j-1 {
+						pathParts[i], pathParts[j] = pathParts[j], pathParts[i]
+					}
+
+					// Join the path parts. The root directory is an empty string, so we prepend "/"
+					dirName := path.Join(pathParts...)
+					if dirName == "" {
+						dirName = "/"
+					} else if dirName[0] != '/' {
+						dirName = "/" + dirName
+					}
+					// DirStats
+					XrootdCacheEvictionDirNumIos.WithLabelValues(dirName).Set(float64(dirState.Stats.NumIos))
+					XrootdCacheEvictionDirDuration.WithLabelValues(dirName).Set(float64(dirState.Stats.Duration))
+					XrootdCacheEvictionDirBytes.WithLabelValues(dirName, "hit").Set(float64(dirState.Stats.BytesHit))
+					XrootdCacheEvictionDirBytes.WithLabelValues(dirName, "missed").Set(float64(dirState.Stats.BytesMissed))
+					XrootdCacheEvictionDirBytes.WithLabelValues(dirName, "bypassed").Set(float64(dirState.Stats.BytesBypassed))
+					XrootdCacheEvictionDirBytes.WithLabelValues(dirName, "written").Set(float64(dirState.Stats.BytesWritten))
+					XrootdCacheEvictionDirStBlockBytes.WithLabelValues(dirName, "added").Set(float64(dirState.Stats.StBlocksAdded) * 512)
+					XrootdCacheEvictionDirStBlockBytes.WithLabelValues(dirName, "removed").Set(float64(dirState.Stats.StBlocksRemoved) * 512)
+					XrootdCacheEvictionDirNCksumErrors.WithLabelValues(dirName).Set(float64(dirState.Stats.NCksumErrors))
+					XrootdCacheEvictionDirFiles.WithLabelValues(dirName, "opened").Set(float64(dirState.Stats.NFilesOpened))
+					XrootdCacheEvictionDirFiles.WithLabelValues(dirName, "closed").Set(float64(dirState.Stats.NFilesClosed))
+					XrootdCacheEvictionDirFiles.WithLabelValues(dirName, "created").Set(float64(dirState.Stats.NFilesCreated))
+					XrootdCacheEvictionDirFiles.WithLabelValues(dirName, "removed").Set(float64(dirState.Stats.NFilesRemoved))
+					XrootdCacheEvictionDirDirectories.WithLabelValues(dirName, "created").Set(float64(dirState.Stats.NDirectoriesCreated))
+					XrootdCacheEvictionDirDirectories.WithLabelValues(dirName, "removed").Set(float64(dirState.Stats.NDirectoriesRemoved))
+
+					// Usage
+					XrootdCacheEvictionDirLastAccessTime.WithLabelValues(dirName, "open").Set(float64(dirState.Usage.LastOpenTime))
+					XrootdCacheEvictionDirLastAccessTime.WithLabelValues(dirName, "close").Set(float64(dirState.Usage.LastCloseTime))
+					XrootdCacheEvictionDirStBlocksUsage.WithLabelValues(dirName).Set(float64(dirState.Usage.StBlocks))
+					XrootdCacheEvictionDirNFilesOpen.WithLabelValues(dirName).Set(float64(dirState.Usage.NFilesOpen))
+					XrootdCacheEvictionDirNFiles.WithLabelValues(dirName).Set(float64(dirState.Usage.NFiles))
+					XrootdCacheEvictionDirNDirectories.WithLabelValues(dirName).Set(float64(dirState.Usage.NDirectories))
+				}
+			}
+		}
+	})
+}

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -348,6 +348,8 @@ var (
 	Shoveler_PortLower = IntParam{"Shoveler.PortLower"}
 	Transport_MaxIdleConns = IntParam{"Transport.MaxIdleConns"}
 	Xrootd_DetailedMonitoringPort = IntParam{"Xrootd.DetailedMonitoringPort"}
+	Xrootd_EvictionMonitoringInterval = IntParam{"Xrootd.EvictionMonitoringInterval"}
+	Xrootd_EvictionMonitoringMaxDepth = IntParam{"Xrootd.EvictionMonitoringMaxDepth"}
 	Xrootd_ManagerPort = IntParam{"Xrootd.ManagerPort"}
 	Xrootd_Port = IntParam{"Xrootd.Port"}
 	Xrootd_SummaryMonitoringPort = IntParam{"Xrootd.SummaryMonitoringPort"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -363,6 +363,8 @@ type Config struct {
 		DetailedMonitoringHost string `mapstructure:"detailedmonitoringhost" yaml:"DetailedMonitoringHost"`
 		DetailedMonitoringPort int `mapstructure:"detailedmonitoringport" yaml:"DetailedMonitoringPort"`
 		EnableLocalMonitoring bool `mapstructure:"enablelocalmonitoring" yaml:"EnableLocalMonitoring"`
+		EvictionMonitoringInterval int `mapstructure:"evictionmonitoringinterval" yaml:"EvictionMonitoringInterval"`
+		EvictionMonitoringMaxDepth int `mapstructure:"evictionmonitoringmaxdepth" yaml:"EvictionMonitoringMaxDepth"`
 		LocalMonitoringHost string `mapstructure:"localmonitoringhost" yaml:"LocalMonitoringHost"`
 		MacaroonsKeyFile string `mapstructure:"macaroonskeyfile" yaml:"MacaroonsKeyFile"`
 		ManagerHost string `mapstructure:"managerhost" yaml:"ManagerHost"`
@@ -721,6 +723,8 @@ type configWithType struct {
 		DetailedMonitoringHost struct { Type string; Value string }
 		DetailedMonitoringPort struct { Type string; Value int }
 		EnableLocalMonitoring struct { Type string; Value bool }
+		EvictionMonitoringInterval struct { Type string; Value int }
+		EvictionMonitoringMaxDepth struct { Type string; Value int }
 		LocalMonitoringHost struct { Type string; Value string }
 		MacaroonsKeyFile struct { Type string; Value string }
 		ManagerHost struct { Type string; Value string }

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -44,6 +44,7 @@ ofs.osslib ++ libXrdOssStats.so
 xrd.report {{if .Xrootd.SummaryMonitoringHost -}}{{.Xrootd.SummaryMonitoringHost}}:{{.Xrootd.SummaryMonitoringPort}},{{- end}}127.0.0.1:{{.Xrootd.LocalMonitoringPort}} every 30s
 xrootd.monitor all auth flush 30s window 5s fstat 60 lfn ops xfr 5 {{if .Xrootd.DetailedMonitoringHost -}} dest redir fstat info files user pfc tcpmon ccm throttle {{.Xrootd.DetailedMonitoringHost}}:{{.Xrootd.DetailedMonitoringPort}} {{- end}} dest redir fstat info files user pfc tcpmon ccm throttle 127.0.0.1:{{.Xrootd.LocalMonitoringPort}}
 xrootd.mongstream oss throttle use send json dflthdr 127.0.0.1:{{.Xrootd.LocalMonitoringPort}}
+pfc.dirstats interval {{.Xrootd.EvictionMonitoringInterval}} maxdepth {{.Xrootd.EvictionMonitoringMaxDepth}}
 all.adminpath {{.Cache.RunLocation}}
 all.pidpath {{.Cache.RunLocation}}
 xrootd.seclib libXrdSec.so

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -137,22 +137,24 @@ type (
 	}
 
 	XrootdOptions struct {
-		Port                   int
-		ManagerHost            string
-		ManagerPort            string
-		ConfigFile             string
-		MacaroonsKeyFile       string
-		RobotsTxtFile          string
-		Sitename               string
-		SummaryMonitoringHost  string
-		SummaryMonitoringPort  int
-		DetailedMonitoringHost string
-		DetailedMonitoringPort int
-		Authfile               string
-		AuthRefreshInterval    int // In the raw config we use a duration, but Xrootd needs this as a seconds integer. Conversion happens during the unmarshal
-		ScitokensConfig        string
-		Mount                  string
-		LocalMonitoringPort    int
+		Port                       int
+		ManagerHost                string
+		ManagerPort                string
+		ConfigFile                 string
+		MacaroonsKeyFile           string
+		RobotsTxtFile              string
+		Sitename                   string
+		SummaryMonitoringHost      string
+		SummaryMonitoringPort      int
+		DetailedMonitoringHost     string
+		DetailedMonitoringPort     int
+		Authfile                   string
+		AuthRefreshInterval        int // In the raw config we use a duration, but Xrootd needs this as a seconds integer. Conversion happens during the unmarshal
+		ScitokensConfig            string
+		Mount                      string
+		LocalMonitoringPort        int
+		EvictionMonitoringInterval int
+		EvictionMonitoringMaxDepth int
 	}
 
 	ServerConfig struct {


### PR DESCRIPTION
This PR address issue #2466. This PR introduces support for monitoring XRootD cache‐eviction via `pfc.dirstats` and exposes per‐directory eviction metrics to Prometheus. It also adds the necessary configuration knobs (`Xrootd.EvictionMonitoringInterval` and `Xrootd.EvictionMonitoringMaxDepth`) so operators can tune the reporting interval and traversal depth.