### PR TITLE
OSDF systemd services: use `pelican-server` everywhere

### DIFF
--- a/systemd/osdf-director.service
+++ b/systemd/osdf-director.service
@@ -4,7 +4,7 @@ After = network.target nss-lookup.target
 
 [Service]
 EnvironmentFile = -/etc/sysconfig/osdf-director
-ExecStart = /usr/bin/osdf --config /etc/pelican/osdf-director.yaml director serve
+ExecStart = /usr/bin/pelican-server --config /etc/pelican/osdf-director.yaml director serve
 Restart = on-failure
 RestartSec = 20s
 

--- a/systemd/osdf-registry.service
+++ b/systemd/osdf-registry.service
@@ -4,7 +4,7 @@ After = network.target nss-lookup.target
 
 [Service]
 EnvironmentFile = -/etc/sysconfig/osdf-registry
-ExecStart = /usr/bin/osdf --config /etc/pelican/osdf-registry.yaml registry serve
+ExecStart = /usr/bin/pelican-server --config /etc/pelican/osdf-registry.yaml registry serve
 Restart = on-failure
 RestartSec = 20s
 


### PR DESCRIPTION
This avoids reliance on the magic config from the `osdf` binary. Fixes #2464.