### PR TITLE
Prevent overwriting objects at upload

### DIFF
--- a/client/fed_long_test.go
+++ b/client/fed_long_test.go
@@ -149,6 +149,7 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 			}
 			require.NoError(t, err)
 			verifySuccessfulTransfer(t, transferDetailsDownload)
+			require.NoError(t, client.DoDelete(fed.Ctx, uploadUrl, true, client.WithTokenLocation(tempToken.Name())))
 		}
 	})
 
@@ -187,6 +188,7 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 			}
 			require.NoError(t, err)
 			verifySuccessfulTransfer(t, transferDetailsDownload)
+			require.NoError(t, client.DoDelete(fed.Ctx, uploadUrl, true, client.WithTokenLocation(tempToken.Name())))
 		}
 	})
 
@@ -218,6 +220,7 @@ func TestRecursiveUploadsAndDownloads(t *testing.T) {
 			}
 			require.NoError(t, err)
 			verifySuccessfulTransfer(t, transferDetailsDownload)
+			require.NoError(t, client.DoDelete(fed.Ctx, uploadUrl, true, client.WithTokenLocation(tempToken.Name())))
 		}
 	})
 
@@ -348,6 +351,7 @@ func TestRecursiveUploadsAndDownloadsWithQuery(t *testing.T) {
 			}
 			require.NoError(t, err)
 			verifySuccessfulTransfer(t, transferDetailsDownload)
+			require.NoError(t, client.DoDelete(fed.Ctx, uploadUrl, true, client.WithTokenLocation(tempToken.Name())))
 		}
 	})
 
@@ -376,6 +380,7 @@ func TestRecursiveUploadsAndDownloadsWithQuery(t *testing.T) {
 			}
 			require.NoError(t, err)
 			verifySuccessfulTransfer(t, transferDetailsDownload)
+			require.NoError(t, client.DoDelete(fed.Ctx, uploadUrl, true, client.WithTokenLocation(tempToken.Name())))
 		}
 	})
 
@@ -404,6 +409,7 @@ func TestRecursiveUploadsAndDownloadsWithQuery(t *testing.T) {
 			}
 			require.NoError(t, err)
 			verifySuccessfulTransfer(t, transferDetailsDownload)
+			require.NoError(t, client.DoDelete(fed.Ctx, uploadUrl, true, client.WithTokenLocation(tempToken.Name())))
 		}
 	})
 
@@ -432,6 +438,7 @@ func TestRecursiveUploadsAndDownloadsWithQuery(t *testing.T) {
 			}
 			require.NoError(t, err)
 			verifySuccessfulTransfer(t, transferDetailsDownload)
+			require.NoError(t, client.DoDelete(fed.Ctx, uploadUrl, true, client.WithTokenLocation(tempToken.Name())))
 		}
 	})
 }
@@ -538,6 +545,7 @@ func TestSyncUpload(t *testing.T) {
 		transferDetailsDownload, err := client.DoGet(fed.Ctx, uploadUrl, t.TempDir(), true, client.WithTokenLocation(tempToken.Name()))
 		require.NoError(t, err)
 		verifySuccessfulTransfer(t, transferDetailsDownload)
+		require.NoError(t, client.DoDelete(fed.Ctx, uploadUrl, true, client.WithTokenLocation(tempToken.Name())))
 	})
 
 	t.Run("testSyncUploadNone", func(t *testing.T) {
@@ -556,6 +564,7 @@ func TestSyncUpload(t *testing.T) {
 
 		// Should have already been uploaded once
 		require.Len(t, transferDetailsUpload, 0)
+		require.NoError(t, client.DoDelete(fed.Ctx, uploadUrl, true, client.WithTokenLocation(tempToken.Name())))
 	})
 
 	t.Run("testSyncUploadPartial", func(t *testing.T) {
@@ -589,6 +598,7 @@ func TestSyncUpload(t *testing.T) {
 		contentBytes, err := os.ReadFile(filepath.Join(downloadDir, filepath.Base(innerTempDir), filepath.Base(innerTempFile.Name())))
 		require.NoError(t, err)
 		require.Equal(t, innerTestFileContent, string(contentBytes))
+		require.NoError(t, client.DoDelete(fed.Ctx, uploadUrl, true, client.WithTokenLocation(tempToken.Name())))
 	})
 
 	t.Run("testSyncUploadFile", func(t *testing.T) {
@@ -862,6 +872,7 @@ func TestSyncDownload(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, newTestFileContent, string(contentBytes))
 	})
+	require.NoError(t, client.DoDelete(fed.Ctx, uploadUrl, true, client.WithTokenLocation(tempToken.Name())))
 }
 
 // This test verifies the behavior when a directory path is passed to the object put command without the recursive option.

--- a/client/fed_long_test.go
+++ b/client/fed_long_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
@@ -1074,7 +1075,7 @@ func TestObjectDelete(t *testing.T) {
 		doesNotExistPath := fmt.Sprintf("pelican://%s%s/doesNotExist", discoveryUrl.Host, "/with-write")
 		err := client.DoDelete(fed.Ctx, doesNotExistPath, false, client.WithTokenLocation(tempToken.Name()))
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "404")
+		require.True(t, errors.Is(err, client.ErrObjectNotFound))
 	})
 
 	// Test deleting an existing object.

--- a/client/fed_test.go
+++ b/client/fed_test.go
@@ -152,6 +152,7 @@ func TestGetAndPutAuth(t *testing.T) {
 			transferResultsDownload, err := client.DoGet(fed.Ctx, uploadURL, t.TempDir(), false, client.WithTokenLocation(tempToken.Name()))
 			require.NoError(t, err)
 			assert.Equal(t, transferResultsDownload[0].TransferredBytes, transferResultsUpload[0].TransferredBytes)
+			require.NoError(t, client.DoDelete(fed.Ctx, uploadURL, false, client.WithTokenLocation(tempToken.Name())))
 		}
 	})
 
@@ -189,6 +190,7 @@ func TestGetAndPutAuth(t *testing.T) {
 			stats, err := os.Stat(filepath.Join(tempDir, fileName))
 			assert.NoError(t, err)
 			assert.NotNil(t, stats)
+			require.NoError(t, client.DoDelete(fed.Ctx, uploadUrl.String(), false, client.WithTokenLocation(tempToken.Name())))
 		}
 	})
 
@@ -219,6 +221,7 @@ func TestGetAndPutAuth(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, len(transferResultsDownload), 1)
 			assert.Equal(t, transferResultsDownload[0].TransferredBytes, transferResultsUpload[0].TransferredBytes)
+			require.NoError(t, client.DoDelete(fed.Ctx, uploadURL, false, client.WithToken(tmpTkn)))
 		}
 	})
 
@@ -248,6 +251,7 @@ func TestGetAndPutAuth(t *testing.T) {
 			transferResultsDownload, err := client.DoGet(fed.Ctx, uploadURL, t.TempDir(), false, client.WithTokenLocation(tempToken.Name()))
 			require.NoError(t, err)
 			assert.Equal(t, transferResultsDownload[0].TransferredBytes, transferResultsUpload[0].TransferredBytes)
+			require.NoError(t, client.DoDelete(fed.Ctx, uploadURL, false, client.WithTokenLocation(tempToken.Name())))
 		}
 	})
 
@@ -282,6 +286,7 @@ func TestGetAndPutAuth(t *testing.T) {
 			transferResultsDownload, err := client.DoGet(fed.Ctx, uploadUrl, t.TempDir(), false, client.WithTokenLocation(tempToken.Name()))
 			assert.NoError(t, err)
 			assert.Equal(t, transferResultsDownload[0].TransferredBytes, transferResultsUpload[0].TransferredBytes)
+			require.NoError(t, client.DoDelete(fed.Ctx, uploadUrl, false, client.WithTokenLocation(tempToken.Name())))
 		}
 	})
 	t.Cleanup(func() {
@@ -342,6 +347,7 @@ func TestCopyAuth(t *testing.T) {
 			transferResultsDownload, err := client.DoCopy(fed.Ctx, uploadURL, t.TempDir(), false, client.WithTokenLocation(tempToken.Name()))
 			assert.NoError(t, err)
 			assert.Equal(t, int64(17), transferResultsDownload[0].TransferredBytes)
+			require.NoError(t, client.DoDelete(fed.Ctx, uploadURL, false, client.WithTokenLocation(tempToken.Name())))
 		}
 	})
 
@@ -378,6 +384,7 @@ func TestCopyAuth(t *testing.T) {
 			stats, err := os.Stat(filepath.Join(tempDir, fileName))
 			assert.NoError(t, err)
 			assert.NotNil(t, stats)
+			require.NoError(t, client.DoDelete(fed.Ctx, uploadUrl.String(), false, client.WithTokenLocation(tempToken.Name())))
 		}
 	})
 
@@ -406,6 +413,7 @@ func TestCopyAuth(t *testing.T) {
 			transferResultsDownload, err := client.DoCopy(fed.Ctx, uploadURL, t.TempDir(), false, client.WithTokenLocation(tempToken.Name()))
 			assert.NoError(t, err)
 			assert.Equal(t, transferResultsDownload[0].TransferredBytes, transferResultsUpload[0].TransferredBytes)
+			require.NoError(t, client.DoDelete(fed.Ctx, uploadURL, false, client.WithTokenLocation(tempToken.Name())))
 		}
 	})
 
@@ -440,6 +448,7 @@ func TestCopyAuth(t *testing.T) {
 			transferResultsDownload, err := client.DoCopy(fed.Ctx, uploadUrl, t.TempDir(), false, client.WithTokenLocation(tempToken.Name()))
 			assert.NoError(t, err)
 			assert.Equal(t, transferResultsDownload[0].TransferredBytes, transferResultsUpload[0].TransferredBytes)
+			require.NoError(t, client.DoDelete(fed.Ctx, uploadUrl, false, client.WithTokenLocation(tempToken.Name())))
 		}
 	})
 	t.Cleanup(func() {

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -3108,7 +3108,9 @@ func uploadObject(transfer *transferFile) (transferResult TransferResults, err e
 	transferResult.job = transfer.job
 
 	// Check if the remote object already exists using statHttp
-	if transfer.remoteURL != nil && transfer.job != nil {
+	// If the job is recursive, we skip this check as the check is already performed in walkDirUpload
+	// If the job is not recursive, we check if the object exists at the origin
+	if transfer.remoteURL != nil && transfer.job != nil && (transfer.job.syncLevel == SyncNone || !transfer.job.recursive) {
 		remoteUrl, dirResp, token := transfer.job.remoteURL, transfer.job.dirResp, transfer.job.token
 		_, statErr := statHttp(remoteUrl, dirResp, token)
 		if statErr == nil {

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -78,6 +78,9 @@ var (
 
 	// Indicates the origin responded too slowly after the cache tried to download from it
 	CacheTimedOutReadingFromOrigin = errors.New("cache timed out waiting on origin")
+
+	// ErrObjectNotFound is returned when the requested remote object does not exist.
+	ErrObjectNotFound = errors.New("remote object not found")
 )
 
 type (
@@ -3117,10 +3120,12 @@ func uploadObject(transfer *transferFile) (transferResult TransferResults, err e
 			// Object exists, abort upload
 			transferResult.Error = errors.New("remote object already exists, upload aborted")
 			return transferResult, transferResult.Error
-		} else if !strings.Contains(statErr.Error(), "not found") && !strings.Contains(statErr.Error(), "no such object") && !strings.Contains(statErr.Error(), "cannot remove remote path") {
-			log.Warningln("Failed to check if object exists at the origin, proceeding with upload")
+		} else if !errors.Is(statErr, ErrObjectNotFound) {
+			// We encountered an unexpected error while checking for object existence.
+			// Log a warning but proceed with the upload; the upload itself may still succeed.
+			log.Warningln("Failed to check if object exists at the origin, proceeding with upload:", statErr)
 		}
-		// If not found, proceed with upload
+		// If statErr indicates the object was not found, proceed with upload
 	}
 
 	var sizer Sizer = &ConstantSizer{size: 0}
@@ -3899,7 +3904,7 @@ func deleteHttp(ctx context.Context, remoteUrl *pelican_url.PelicanURL, recursiv
 	info, err := client.Stat(remotePath)
 	if err != nil {
 		if gowebdav.IsErrNotFound(err) {
-			return errors.Wrapf(err, "cannot remove remote path %s: no such object or collection", remotePath)
+			return errors.Wrapf(ErrObjectNotFound, "cannot remove remote path %s: no such object or collection", remotePath)
 		}
 		return errors.Wrap(err, "failed to check object existence")
 	}
@@ -4002,7 +4007,7 @@ func statHttp(dest *pelican_url.PelicanURL, dirResp server_structs.DirectorRespo
 					resultsChan <- statResults{FileInfo{}, err}
 					return
 				} else if gowebdav.IsErrNotFound(err) {
-					err = errors.Wrapf(err, "object %s not found at the endpoint %s", dest.String(), endpoint.String())
+					err = errors.Wrapf(ErrObjectNotFound, "object %s not found at the endpoint %s", dest.String(), endpoint.String())
 					resultsChan <- statResults{FileInfo{}, err}
 					return
 				}

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -3116,9 +3116,7 @@ func uploadObject(transfer *transferFile) (transferResult TransferResults, err e
 			transferResult.Error = errors.New("remote object already exists, upload aborted")
 			return transferResult, transferResult.Error
 		} else if !strings.Contains(statErr.Error(), "not found") && !strings.Contains(statErr.Error(), "no such object") && !strings.Contains(statErr.Error(), "cannot remove remote path") {
-			// If the error is not a 'not found' error, treat as fatal
-			transferResult.Error = errors.Wrap(statErr, "failed to stat remote object before upload")
-			return transferResult, transferResult.Error
+			log.Warningln("Failed to check if object exists at the origin, proceeding with upload")
 		}
 		// If not found, proceed with upload
 	}

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -3110,7 +3110,7 @@ func uploadObject(transfer *transferFile) (transferResult TransferResults, err e
 	// Check if the remote object already exists using statHttp
 	// If the job is recursive, we skip this check as the check is already performed in walkDirUpload
 	// If the job is not recursive, we check if the object exists at the origin
-	if transfer.remoteURL != nil && transfer.job != nil && (transfer.job.syncLevel == SyncNone || !transfer.job.recursive) {
+	if transfer.remoteURL != nil && transfer.job != nil && transfer.job.syncLevel != SyncNone && !transfer.job.recursive {
 		remoteUrl, dirResp, token := transfer.job.remoteURL, transfer.job.dirResp, transfer.job.token
 		_, statErr := statHttp(remoteUrl, dirResp, token)
 		if statErr == nil {

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -1523,6 +1523,13 @@ func TestFailedUploadError(t *testing.T) {
 				Host:   svrURL.Host,
 				Path:   svrURL.Path + "/test.txt",
 			},
+			dirResp: server_structs.DirectorResponse{
+				XPelNsHdr: server_structs.XPelNs{
+					Namespace:      "/test",
+					RequireToken:   false,
+					CollectionsUrl: svrURL,
+				},
+			},
 		},
 		localPath: testfileLocation,
 		remoteURL: svrURL,
@@ -1584,6 +1591,13 @@ func TestFailedLargeUploadError(t *testing.T) {
 				Scheme: "pelican://",
 				Host:   svrURL.Host,
 				Path:   svrURL.Path + "/test.txt",
+			},
+			dirResp: server_structs.DirectorResponse{
+				XPelNsHdr: server_structs.XPelNs{
+					Namespace:      "/test",
+					RequireToken:   false,
+					CollectionsUrl: svrURL,
+				},
 			},
 		},
 		localPath: testfileLocation,

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -2133,8 +2133,22 @@ func TestPutOverwrite(t *testing.T) {
 			},
 		}
 
+		// Capture log warnings
+		var logBuf bytes.Buffer
+		origOut := log.StandardLogger().Out
+		log.SetOutput(&logBuf)
+		origLevel := log.GetLevel()
+		log.SetLevel(log.WarnLevel)
+		defer func() {
+			log.SetOutput(origOut)
+			log.SetLevel(origLevel)
+		}()
+
 		result, err := uploadObject(transfer)
 		require.NoError(t, err) // We should not get an error from the uploadObject call
 		require.NoError(t, result.Error)
+
+		// Ensure the expected warning was logged
+		assert.Contains(t, logBuf.String(), "Failed to check if object exists at the origin, proceeding with upload")
 	})
 }

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -1971,7 +1971,8 @@ func TestPutOverwrite(t *testing.T) {
     </D:propstat>
   </D:response>
 </D:multistatus>`
-				w.Write([]byte(response))
+				_, err := w.Write([]byte(response))
+				require.NoError(t, err)
 				return
 			}
 			if r.Method == "PUT" {

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -1506,6 +1506,10 @@ func TestFailedUploadError(t *testing.T) {
 
 	shutdownChan := make(chan bool)
 	svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PROPFIND" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
 		<-shutdownChan
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -1575,6 +1579,10 @@ func TestFailedLargeUploadError(t *testing.T) {
 
 	shutdownChan := make(chan bool)
 	svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PROPFIND" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
 		<-shutdownChan
 		w.WriteHeader(http.StatusOK)
 	}))


### PR DESCRIPTION
This PR addresses issue #2470. This PR adds a simple check to see if the object exists at the origin before proceeding with the upload. This check doesn't take into account any tokens and will simply block the upload if the object exists. 

I added test cases to ensure this behavior works as expected. 