### PR TITLE
Add a default /etc/pelican/pelican.yaml file to the image

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -192,7 +192,12 @@ RUN --mount=type=cache,id=dnf-${TARGETPLATFORM},target=/var/cache/dnf,sharing=lo
   printf '%s\n' "metadata_expire=1800" >> /etc/dnf/dnf.conf
 
   dnf install -y tini 'dnf-command(versionlock)'
+
+  mkdir -p /etc/pelican/config.d
+  mkdir -p /usr/share/pelican/config.d
 ENDRUN
+
+COPY images/pelican.yaml /etc/pelican/pelican.yaml
 
 #################################################################
 # XRootD Software Init

--- a/images/pelican.yaml
+++ b/images/pelican.yaml
@@ -1,0 +1,21 @@
+# ***************************************************************
+#
+#  Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+#
+#  Licensed under the Apache License, Version 2.0 (the "License"); you
+#  may not use this file except in compliance with the License.  You may
+#  obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# ***************************************************************
+
+ConfigLocations:
+  - "/usr/share/pelican/config.d"
+  - "/etc/pelican/config.d"


### PR DESCRIPTION
which just loads all the config from `/usr/share/pelican/config.d` and `/etc/pelican/config.d`. Create those directories when building the image.