### PR TITLE
Follow symlink to load private key

### DIFF
--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -679,7 +679,14 @@ func loadPEMFiles(dir string) (jwk.Key, error) {
 			if (path != dir) && dirEnt.IsDir() {
 				return filepath.SkipDir
 			}
-			if dirEnt.Type().IsRegular() && (filepath.Ext(dirEnt.Name()) == ".pem" || filepath.Ext(dirEnt.Name()) == ".jwk") {
+			// Check if this is a regular file or a symlink that points to a regular file
+			// Use os.Stat() to follow symlinks, unlike dirEnt.Type() which doesn't follow symlinks
+			fileInfo, statErr := os.Stat(path)
+			if statErr != nil {
+				log.Warnf("Failed to stat file %s: %v", path, statErr)
+				return nil
+			}
+			if fileInfo.Mode().IsRegular() && (filepath.Ext(dirEnt.Name()) == ".pem" || filepath.Ext(dirEnt.Name()) == ".jwk") {
 				// Parse the private key in this file and add to the in-memory keys map
 				key, err := LoadSinglePEM(path)
 				if err != nil {


### PR DESCRIPTION
Let Pelican to follow issuer key symlinks.

### Testing Idea

1. Use `pelican key create` command to create a new pair of private and public keys in any directory.
2. In `IssuerKeyDirectory`, create a symlink pointing to the private key you just created. 
3. Obtain the public key of this server (e.g. via the .well-known endpoint). If it contains a key whose id is the same as the public key id generated in the first step, the test passes.