### PR TITLE
Enable CGO for the binary build that includes purego

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -61,6 +61,9 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
+    - name: Install build tools
+      run: |
+        dnf -y install gcc gcc-c++ || (apt-get -y update && apt-get -y install gcc g++)
     - name: Test
       run: |
         make web-build

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -70,7 +70,12 @@ builds:
   # also use this to filter which modules are built into the binary.
   - id: pelican-server
     env:
-      - CGO_ENABLED=0
+      # Enable CGO for the build that includes lotman. Lotman uses purego, which implements
+      # a fakecgo and persuades runtime that CGO is enabled. Then in the drop-privs feature,
+      # CGO_ENABLED=0 would make syscall.Setgid and syscall.Setuid call AllThreadsSyscall(),
+      # while this function is incompatible with binaries that use cgo (and fakecgo also counts).
+      # Set CGO_ENABLED=1 to avoid calling AllThreadsSyscall(), which causes this panic.
+      - CGO_ENABLED=1
     goos:
       - linux
     goarch:

--- a/launchers/droppriv_unix.go
+++ b/launchers/droppriv_unix.go
@@ -30,25 +30,6 @@ import (
 	"github.com/pelicanplatform/pelican/param"
 )
 
-// rawSetuid and rawSetgid perform setuid and setgid using syscall.RawSyscall()
-// to avoid syscall.Setgid() and syscall.Setuid(). The latter internally use
-// AllThreadsSyscall(), which fails when CGO is disabled.
-func rawSetuid(uid int) error {
-	_, _, errno := syscall.RawSyscall(syscall.SYS_SETUID, uintptr(uid), 0, 0)
-	if errno != 0 {
-		return errno
-	}
-	return nil
-}
-
-func rawSetgid(gid int) error {
-	_, _, errno := syscall.RawSyscall(syscall.SYS_SETGID, uintptr(gid), 0, 0)
-	if errno != 0 {
-		return errno
-	}
-	return nil
-}
-
 func dropPrivileges() (err error) {
 	log.Info("Dropping privileges to user ", param.Server_UnprivilegedUser.GetString())
 	var puser config.User
@@ -64,13 +45,11 @@ func dropPrivileges() (err error) {
 		err = errors.Errorf("unable to drop privileges to user (user %s, group %s) with GID 0", puser.Username, puser.Groupname)
 		return
 	}
-
-	// Use raw syscalls to avoid failures when CGO is disabled
-	if err = rawSetgid(puser.Gid); err != nil {
+	if err = syscall.Setgid(puser.Gid); err != nil {
 		err = errors.Wrap(err, "failed to drop group privileges")
 		return
 	}
-	if err = rawSetuid(puser.Uid); err != nil {
+	if err = syscall.Setuid(puser.Uid); err != nil {
 		err = errors.Wrap(err, "failed to drop user privileges")
 		return
 	}


### PR DESCRIPTION
Enable CGO for the build that includes lotman. Lotman uses purego, which implements a fakecgo and persuades runtime that CGO is enabled. Then in the drop-privs feature, CGO_ENABLED=0 would make syscall.Setgid and syscall.Setuid call AllThreadsSyscall(), while this function is incompatible with binaries that use cgo (and fakecgo also counts). Set CGO_ENABLED=1 to avoid calling AllThreadsSyscall(), which causes this panic.

