### PR TITLE
Install xrootd-lotman and lotman from osg repos

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -51,13 +51,13 @@ ARG NODEJS_VER=20
 #     claims to be will *always* come from the .spec file. The upstream Git
 #     repository must have a correct .spec file, or confusion will ensue.
 #
-ARG LOTMAN_SRC_BUILD=true
+ARG LOTMAN_SRC_BUILD=false
 ARG LOTMAN_VER=0.0.4
 ARG XRDCL_PELICAN_SRC_BUILD=false
 ARG XRDCL_PELICAN_VER=1.2.3
 ARG XRDHTTP_PELICAN_SRC_BUILD=false
 ARG XRDHTTP_PELICAN_VER=0.0.7
-ARG XROOTD_LOTMAN_SRC_BUILD=true
+ARG XROOTD_LOTMAN_SRC_BUILD=false
 ARG XROOTD_LOTMAN_VER=0.0.5
 ARG XROOTD_S3_HTTP_SRC_BUILD=true
 ARG XROOTD_S3_HTTP_VER=0.4.1


### PR DESCRIPTION
Now that `xrootd-lotman-0.0.5` is in the OSG repos, we should install from there instead of building from source.

This should also fix the currently-failing tests that point to an un-located symbol when dlopening Lotman.

Since this passed the GHA tests last time, I'd recommend the following testing procedure:
1. Checkout this diff
2. Build the image, launch tests in the container, e.g.:
```
# from repo root
docker build -t pelican-test:latest -f images/Dockerfile
docker run --rm --volume $(pwd):/pelican --entrypoint go -w /pelican/lotman pelican-test:latest test -tags=lotman
```

This avoids any container/repo mangling that happens in the GHA tests.