### PR TITLE
Disable CGO again

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -61,9 +61,6 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - name: Install build tools
-      run: |
-        dnf -y install gcc gcc-c++ || (apt-get -y update && apt-get -y install gcc g++)
     - name: Test
       run: |
         make web-build

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -70,12 +70,7 @@ builds:
   # also use this to filter which modules are built into the binary.
   - id: pelican-server
     env:
-      # Enable CGO for the build that includes lotman. Lotman uses purego, which implements
-      # a fakecgo and persuades runtime that CGO is enabled. Then in the drop-privs feature,
-      # CGO_ENABLED=0 would make syscall.Setgid and syscall.Setuid call AllThreadsSyscall(),
-      # while this function is incompatible with binaries that use cgo (and fakecgo also counts).
-      # Set CGO_ENABLED=1 to avoid calling AllThreadsSyscall(), which causes this panic.
-      - CGO_ENABLED=1
+      - CGO_ENABLED=0
     goos:
       - linux
     goarch:


### PR DESCRIPTION
Turning on CGO would break our infra pipeline (see the [failure logs](https://github.com/PelicanPlatform/pelican/actions/runs/16327938614/job/46122841447#step:5:77) in new release GitHub Actions). For now, we'd turn it off again to avoid further (maybe significant) modifications to our infra.

CGO was enabled to resolve a drop privileges problem (see [here](https://github.com/PelicanPlatform/pelican/issues/2485#issuecomment-3070860613) for details). Now, because CGO is disabled, `pelican-server` binary will not support drop privileges, while `pelican` binary still supports. This means, at least for now, drop privileges cannot work together with lotman.