### PR TITLE
Improve deprecated parameter handling in `pelican config get`

### DIFF
--- a/cmd/config_printer/config_get.go
+++ b/cmd/config_printer/config_get.go
@@ -67,10 +67,6 @@ func configGet(cmd *cobra.Command, args []string) {
 				continue
 			}
 
-			if docParam.Deprecated && !includeDeprecated {
-				continue
-			}
-
 			if len(components) > 0 {
 				componentsCheckFailed := true
 				for _, c := range components {
@@ -105,6 +101,12 @@ func configGet(cmd *cobra.Command, args []string) {
 		}
 
 		if matchesFound {
+			// Check for deprecated parameter only when it matches the search criteria
+			if exists && docParam.Deprecated && !includeDeprecated {
+				fmt.Printf("%s: This parameter is DEPRECATED. If you still need to view it, run: pelican config get %s --include-deprecated\n", key, key)
+				continue
+			}
+
 			matches = append(matches, Match{
 				OriginalKey:      key,
 				HighlightedKey:   highlightedKey,

--- a/cmd/config_printer/config_get.go
+++ b/cmd/config_printer/config_get.go
@@ -121,6 +121,11 @@ func configGet(cmd *cobra.Command, args []string) {
 				continue
 			}
 
+			if exists && docParam.Hidden && !includeHidden {
+				fmt.Printf("%s: This parameter is HIDDEN. If you still need to view it, run: pelican config get %s --include-hidden\n", key, key)
+				continue
+			}
+
 			matches = append(matches, Match{
 				OriginalKey:      key,
 				HighlightedKey:   highlightedKey,

--- a/cmd/config_printer/config_get.go
+++ b/cmd/config_printer/config_get.go
@@ -88,14 +88,28 @@ func configGet(cmd *cobra.Command, args []string) {
 			for _, arg := range args {
 				argLower := strings.ToLower(arg)
 
-				if strings.Contains(strings.ToLower(key), argLower) {
-					highlightedKey = highlightSubstring(key, arg, color.FgYellow)
-					matchesFound = true
-				}
+				if exactMatch {
+					// Exact match comparison
+					if strings.EqualFold(key, arg) {
+						highlightedKey = highlightSubstring(key, arg, color.FgYellow)
+						matchesFound = true
+					}
 
-				if strings.Contains(strings.ToLower(valueStr), argLower) {
-					highlightedValue = highlightSubstring(valueStr, arg, color.FgYellow)
-					matchesFound = true
+					if strings.EqualFold(valueStr, arg) {
+						highlightedValue = highlightSubstring(valueStr, arg, color.FgYellow)
+						matchesFound = true
+					}
+				} else {
+					// Substring match (existing behavior)
+					if strings.Contains(strings.ToLower(key), argLower) {
+						highlightedKey = highlightSubstring(key, arg, color.FgYellow)
+						matchesFound = true
+					}
+
+					if strings.Contains(strings.ToLower(valueStr), argLower) {
+						highlightedValue = highlightSubstring(valueStr, arg, color.FgYellow)
+						matchesFound = true
+					}
 				}
 			}
 		}

--- a/cmd/config_printer/config_printer_root.go
+++ b/cmd/config_printer/config_printer_root.go
@@ -115,6 +115,7 @@ pelican config summary`,
 	components        []string
 	includeHidden     bool
 	includeDeprecated bool
+	exactMatch        bool
 )
 
 func init() {
@@ -129,6 +130,7 @@ func init() {
 		"Specify modules to filter the output of `config get`. The recognized modules are `client`, `registry`, `director`, `origin`, `cache`, and `localcache`. Multiple modules can be specified at the same time, for example: `config get -m cache -m origin`. If multiple modules are provided, parameters related to any of the modules will be retrieved. If no modules are specified, no module-based filter is applied to the search space.")
 	configGetCmd.Flags().BoolVar(&includeHidden, "include-hidden", false, "Include hidden configuration parameters")
 	configGetCmd.Flags().BoolVar(&includeDeprecated, "include-deprecated", false, "Include deprecated configuration parameters")
+	configGetCmd.Flags().BoolVar(&exactMatch, "exact-match", false, "Match configuration parameter names exactly instead of using substring matching")
 
 	configSummaryCmd.Flags().StringVarP(&format, "format", "o", "yaml", "Output format (yaml or json)")
 


### PR DESCRIPTION
When user tries to get a deprecated config via `pelican config get`, this PR:
1. Show deprecation messages for deprecated parameters instead of silently skipping them
2. Provide clear instructions on how to view deprecated parameters using `--include-deprecated` flag

It also gives users the flexibility to choose between broad discovery (substring) and precise targeting (exact match) when retrieving configuration parameters.

Expected behavior:
```
# pelican config get issuerkey
issuerkey: This parameter is DEPRECATED. If you still need to view it, run: pelican config get issuerkey --include-deprecated
issuerkeysdirectory: "issuer-keys"
# pelican config get issuerkey --exact-match
issuerkey: This parameter is DEPRECATED. If you still need to view it, run: pelican config get issuerkey --include-deprecated
No matching configuration parameters found.
# pelican config get issuerkey --exact-match --include-deprecated
issuerkey: "issuer.jwk"
```