### PR TITLE
Fix non-existent `authfile-cache-generated` file errors during Pelican initial startup

### DIFF
--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -322,7 +322,7 @@ func TestOSDFAuthCreation(t *testing.T) {
 			err = os.WriteFile(filepath.Join(dirName, "authfile"), []byte(testInput.authIn), fs.FileMode(0600))
 			require.NoError(t, err, "Failure writing test input authfile")
 
-			err = EmitAuthfile(testInput.server)
+			err = EmitAuthfile(testInput.server, false)
 			require.NoError(t, err, "Failure generating authfile")
 
 			finalAuthPath := filepath.Join(xrootdRun, "authfile-origin-generated")
@@ -383,7 +383,7 @@ func TestEmitAuthfile(t *testing.T) {
 			err := os.WriteFile(filepath.Join(dirName, "authfile"), []byte(testInput.authIn), fs.FileMode(0600))
 			require.NoError(t, err)
 
-			err = EmitAuthfile(server)
+			err = EmitAuthfile(server, false)
 			require.NoError(t, err)
 
 			contents, err := os.ReadFile(filepath.Join(dirName, "authfile-origin-generated"))
@@ -412,7 +412,7 @@ func TestEmitOriginAuthfileWithCacheAuth(t *testing.T) {
 	err := os.WriteFile(filepath.Join(dirName, "authfile"), []byte(""), fs.FileMode(0600))
 	require.NoError(t, err)
 
-	err = EmitAuthfile(originServer)
+	err = EmitAuthfile(originServer, false)
 	require.NoError(t, err)
 
 	contents, err := os.ReadFile(filepath.Join(dirName, "authfile-origin-generated"))
@@ -461,7 +461,7 @@ func TestEmitOriginAuthfileWithCapabilities(t *testing.T) {
 			err := os.WriteFile(filepath.Join(dirName, "authfile"), []byte(""), fs.FileMode(0600))
 			require.NoError(t, err)
 
-			err = EmitAuthfile(originServer)
+			err = EmitAuthfile(originServer, false)
 			require.NoError(t, err)
 
 			contents, err := os.ReadFile(filepath.Join(dirName, "authfile-origin-generated"))
@@ -1059,7 +1059,7 @@ func TestWriteOriginAuthFiles(t *testing.T) {
 			err := os.WriteFile(authfileProvided, []byte(authStart), 0600)
 			assert.NoError(t, err)
 
-			err = EmitAuthfile(server)
+			err = EmitAuthfile(server, false)
 			assert.NoError(t, err)
 
 			authGen, err := os.ReadFile(xAuthFile)
@@ -1112,7 +1112,7 @@ func TestWriteCacheAuthFiles(t *testing.T) {
 
 			assert.Equal(t, sciTokenResult, string(genSciToken))
 
-			err = EmitAuthfile(server)
+			err = EmitAuthfile(server, false)
 			assert.NoError(t, err)
 
 			authGen, err := os.ReadFile(authFile)

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -551,7 +551,7 @@ func CheckXrootdEnv(server server_structs.XRootDServer) error {
 	} else if !errors.Is(err, os.ErrExist) {
 		return err
 	}
-	if err := EmitAuthfile(server); err != nil {
+	if err := EmitAuthfile(server, true); err != nil {
 		return err
 	}
 
@@ -712,7 +712,7 @@ func LaunchXrootdMaintenance(ctx context.Context, server server_structs.XRootDSe
 				log.Debugln("Successfully updated the Xrootd TLS certificates")
 			}
 			lastErr := err
-			if err := EmitAuthfile(server); err != nil {
+			if err := EmitAuthfile(server, false); err != nil {
 				if lastErr != nil {
 					log.Errorln("Failure when generating authfile:", err)
 				}

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -322,7 +322,7 @@ default_user = user2
 	err = EmitScitokensConfig(server)
 	require.NoError(t, err)
 
-	err = EmitAuthfile(server)
+	err = EmitAuthfile(server, false)
 	require.NoError(t, err)
 
 	destScitokensName := filepath.Join(param.Origin_RunLocation.GetString(), "scitokens-origin-generated.cfg")


### PR DESCRIPTION
- create a first-run mode for authfile emission (EmitAuthfile) during startup
- If the drop privileges feature is enabled, the first run should write the authfile as root user, and the subsequent runs will write the authfile as the unprivileged pelican user via the xrdhttp-pelican plugin.