### PR TITLE
Avoid ASCII color codes printed to non-terminals

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-kit/log/term"
 	"github.com/go-playground/locales/en"
 	ut "github.com/go-playground/universal-translator"
 	"github.com/go-playground/validator/v10"
@@ -856,7 +857,7 @@ func printConfigHelper(bytes []byte) {
 		log.SetFormatter(originalFormatter)
 	}()
 
-	isStdout := param.Logging_LogLocation.GetString() == ""
+	isStdout := param.Logging_LogLocation.GetString() == "" && term.IsTerminal(log.StandardLogger().Out)
 
 	log.SetFormatter(&log.TextFormatter{
 		DisableQuote:           true,

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -85,7 +85,6 @@ func FlushLogs(pushToFile bool) {
 	flushOnce.Do(func() {
 		hook := bufferedHook.Load()
 		if hook == nil {
-			fmt.Fprintln(os.Stderr, "FlushLogs called but no bufferedHook exists")
 			return
 		}
 

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/go-kit/log/term"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -123,7 +124,7 @@ func FlushLogs(pushToFile bool) {
 			// Restore colorized output when logging to stderr
 			log.SetFormatter(&log.TextFormatter{
 				FullTimestamp:          true,
-				ForceColors:            true,
+				ForceColors:            term.IsTerminal(log.StandardLogger().Out),
 				DisableColors:          false,
 				DisableLevelTruncation: true,
 			})

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"embed"
 	"fmt"
+	builtin_log "log"
 	"math/rand"
 	"mime"
 	"net"
@@ -880,10 +881,16 @@ func runEngineWithListener(ctx context.Context, ln net.Listener, engine *gin.Eng
 	config := &tls.Config{
 		GetCertificate: getCert,
 	}
+	logWriter := builtin_log.New(
+		log.StandardLogger().WriterLevel(log.WarnLevel),
+		"",
+		0,
+	)
 	server := &http.Server{
 		Addr:      addr,
 		Handler:   engine.Handler(),
 		TLSConfig: config,
+		ErrorLog:  logWriter,
 	}
 	log.Debugln("Starting web engine at address", addr)
 


### PR DESCRIPTION
Additionally, removes a `println` statement that triggers during unit tests.