### PR TITLE
Fix read-only filesystem errors in K8s by skipping unnecessary chmod/chown

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1355,6 +1355,7 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 		}
 
 		pelicanLocationsNoRecursive := []string{
+			param.Server_TLSCertificateChain.GetString(),
 			param.Server_TLSKey.GetString(),
 		}
 		if (currentServers.IsEnabled(server_structs.OriginType) || currentServers.IsEnabled(server_structs.CacheType)) && param.Shoveler_Enable.GetBool() {

--- a/config/mkdirall_default.go
+++ b/config/mkdirall_default.go
@@ -20,6 +20,20 @@
 
 package config
 
+import (
+	"os"
+	"syscall"
+)
+
 func fixRootDirectory(p string) string {
 	return p
+}
+
+// Check if the given path has the correct ownership on Unix systems
+func checkOwnership(info os.FileInfo, expectedUid int, expectedGid int) bool {
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		return int(stat.Uid) == expectedUid && int(stat.Gid) == expectedGid
+	}
+	// If we can't get ownership info, assume we need to set it
+	return false
 }

--- a/config/mkdirall_windows.go
+++ b/config/mkdirall_windows.go
@@ -32,3 +32,8 @@ func fixRootDirectory(p string) string {
 	}
 	return p
 }
+
+// On Windows, we don't check uid/gid ownership since it works differently
+func checkOwnership(info os.FileInfo, expectedUid int, expectedGid int) bool {
+	return false
+}


### PR DESCRIPTION
This PR checks the current ownerships and permissions of a file or directory before changing it. If the current ownerships and permissions are correct, skip the chmod and chown operations. Hopefully, it could solve the permission error of a mounted file in k8s deployment.
```
sh-5.1# osdf-server cache serve
Error: Failure when configuring the server: failure when setting up the file permissions for pelican: Failed to set permissions on directory /etc/pelican/cert-orig: chmod /etc/pelican/cert-orig: read-only file system
```

In k8s, make sure `tls.key` and `tls.crt` files are owned by: [user: pelican, group: root]. file perms: 0640. In this way, Pelican should not perform chmod and chown operations to them, and you should see the following log: 
```
level=debug msg="Skipping chown/chmod for /etc/pelican/certificates/tls.crt because it already has the correct permissions and ownership"
level=debug msg="Skipping chown/chmod for /etc/pelican/certificates/tls.key because it already has the correct permissions and ownership"
```