### PR TITLE
Fix the bug that Pelican `config` CLI tool does not take env vars into account

### DIFF
--- a/cmd/config_printer/utils.go
+++ b/cmd/config_printer/utils.go
@@ -38,6 +38,15 @@ import (
 // It takes a Viper instance, populates the client and server parameters, unmarshals it into
 // a config struct, and returns it.
 func initClientAndServerConfig(v *viper.Viper) *param.Config {
+	// To provide a cleaner output, we temporarily suppress excessive logging in `InitConfigInternal`
+	currentLevel := log.GetLevel()
+	log.SetLevel(log.ErrorLevel) // Suppress debug, warnings and info messages
+
+	config.InitConfigInternal()
+
+	// Restore original log level
+	log.SetLevel(currentLevel)
+
 	if err := config.SetClientDefaults(v); err != nil {
 		log.Errorf("Error setting client defaults: %v", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -1983,6 +1983,9 @@ func ResetConfig() {
 	globalFedInfo = pelican_url.FederationDiscovery{}
 	globalFedErr = nil
 
+	warnIssuerKeyOnce = sync.Once{}
+	warnDeprecatedOnce = sync.Once{}
+
 	setServerOnce = sync.Once{}
 
 	ResetIssuerPrivateKeys()

--- a/go.mod
+++ b/go.mod
@@ -190,7 +190,7 @@ require (
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
-	go.uber.org/goleak v1.3.0 // indirect
+	go.uber.org/goleak v1.3.0
 	golang.org/x/arch v0.3.0 // indirect
 	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8
 	golang.org/x/sync v0.12.0


### PR DESCRIPTION
This PR fixes the bug that Pelican `config` CLI tool does not take env vars into account.

Design thinking: I decide to temporarily suppress excessive logging in `InitConfigInternal`, because the power user of this CLI tool wants to get a cleaner output