### PR TITLE
Fix checksum requirements on `put`

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2288,14 +2288,19 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 				if checksumInfo.Algorithm == checksum {
 					found = true
 					if !bytes.Equal(checksumInfo.Value, computedValue) {
-						transferResults.Error = &ChecksumMismatchError{
+						mismatchErr := &ChecksumMismatchError{
 							Info: ChecksumInfo{
 								Algorithm: checksumInfo.Algorithm,
 								Value:     computedValue,
 							},
 							ServerValue: checksumInfo.Value,
 						}
-						log.WithFields(fields).Errorln(transferResults.Error)
+						if transfer.requireChecksum {
+							transferResults.Error = mismatchErr
+							log.WithFields(fields).Errorln(transferResults.Error)
+						} else {
+							log.WithFields(fields).Warnln(mismatchErr.Error() + " (not required, continuing)")
+						}
 					} else {
 						successCtr++
 						log.WithFields(fields).Debugf("Checksum %s matches: %s",
@@ -3117,7 +3122,7 @@ func uploadObject(transfer *transferFile) (transferResult TransferResults, err e
 	// Create a checksum hash instance for each requested checksum.
 	// Will all be joined into a single writer
 	hashes := make([]io.Writer, 0, 1)
-	for _, checksum := range transfer.job.requestedChecksums {
+	for _, checksum := range transfer.requestedChecksums {
 		switch checksum {
 		case AlgCRC32:
 			hashes = append(hashes, crc32.NewIEEE())
@@ -3332,16 +3337,23 @@ Loop:
 		result, err := fetchChecksum(putContext, transfer.requestedChecksums, dest, tokenContents, transfer.job.project)
 		if err != nil {
 			log.Errorln("Error fetching checksum:", err)
-			attempt.Error = err
-
-			if transfer.job.requireChecksum {
+			if transfer.requireChecksum {
 				transferResult.Error = errors.New("checksum is required but endpoint was not able to provide it")
+				attempt.Error = &ChecksumMismatchError{
+					Info: ChecksumInfo{
+						Algorithm: transfer.requestedChecksums[0],
+						Value:     hashes[0].(hash.Hash).Sum(nil),
+					},
+					ServerValue: nil,
+				}
+			} else {
+				log.Warnln("Checksum is not required, but endpoint was not able to provide it. Continuing without verification.")
 			}
 		} else {
 			transferResult.ServerChecksums = result
 		}
 
-		checksumHashes := transfer.job.requestedChecksums
+		checksumHashes := transfer.requestedChecksums
 		if len(checksumHashes) == 0 {
 			checksumHashes = []ChecksumType{AlgDefault}
 		}
@@ -3362,14 +3374,21 @@ Loop:
 				if checksumInfo.Algorithm == checksum {
 					found = true
 					if !bytes.Equal(checksumInfo.Value, computedValue) {
-						transferResult.Error = &ChecksumMismatchError{
+						mismatchErr := &ChecksumMismatchError{
 							Info: ChecksumInfo{
 								Algorithm: checksum,
 								Value:     computedValue,
 							},
 							ServerValue: checksumInfo.Value,
 						}
-						log.WithFields(fields).Errorln(transferResult.Error)
+						if transfer.requireChecksum {
+							transferResult.Error = mismatchErr
+							log.WithFields(fields).Errorln(transferResult.Error)
+							attempt.Error = transferResult.Error
+							break
+						} else {
+							log.WithFields(fields).Warnln(mismatchErr.Error() + " (not required, continuing)")
+						}
 					} else {
 						successCtr++
 						log.WithFields(fields).Debugf("Checksum %s matches: %s",
@@ -3385,7 +3404,7 @@ Loop:
 					HttpDigestFromChecksum(checksum))
 			}
 		}
-		if successCtr == 0 && transfer.job.requireChecksum && transferResult.Error == nil {
+		if successCtr == 0 && transfer.requireChecksum && transferResult.Error == nil {
 			if len(transfer.requestedChecksums) == 0 {
 				log.WithFields(fields).Errorln(
 					"Client requires checksum to succeed and it was not provided by server; client computed crc32c value is",

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -943,7 +943,9 @@ func TestChecksumIncorrectWhenNotRequired(t *testing.T) {
 	}
 	transferResult, err := downloadObject(transfer)
 	assert.NoError(t, err)
-	assert.NoError(t, transferResult.Error, "Should not error when requireChecksum is false")
+	// We should expect an error because even when the checksum is not required, we still want to verify that the checksum is correct.
+	// We wouldn't want the object downloaded to different than the original.
+	assert.Error(t, transferResult.Error, "Should error when requireChecksum is false")
 
 	// Checksum validation
 	assert.Equal(t, 1, len(transferResult.ServerChecksums), "Checksum count is %d but should be 1", len(transferResult.ServerChecksums))

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -220,7 +220,7 @@ func TestSlowTransfers(t *testing.T) {
 	}
 
 	// Close the channel to allow the download to complete
-	channel <- true
+	close(channel)
 
 	// Make sure the errors are correct
 	assert.NotNil(t, err)
@@ -307,7 +307,7 @@ func TestStoppedTransfer(t *testing.T) {
 	}
 
 	// Close the channel to allow the download to complete
-	channel <- true
+	close(channel)
 
 	// Make sure the errors are correct
 	assert.NotNil(t, err)


### PR DESCRIPTION
This PR addresses #2543. This PR fixes the way we handle the case where the origin fails to produce a checksum requested by the client. In the previous implementation, we would produce an error and the transfer would fail. The transfer should only fail if we **required** the checksum in the transfer. 

This PR fixes the bug, adds tests, and fixes existing ones to reflect this behavior.