### PR TITLE
Don't change the perms and ownership of TLS key file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1373,9 +1373,7 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 			return errors.Wrap(err, "failure when setting up the file permissions for pelican")
 		}
 
-		pelicanLocationsNoRecursive := []string{
-			param.Server_TLSKey.GetString(),
-		}
+		pelicanLocationsNoRecursive := []string{}
 		if (currentServers.IsEnabled(server_structs.OriginType) || currentServers.IsEnabled(server_structs.CacheType)) && param.Shoveler_Enable.GetBool() {
 			pelicanLocationsNoRecursive = append(pelicanLocationsNoRecursive, param.Shoveler_AMQPTokenLocation.GetString())
 		}


### PR DESCRIPTION
This PR replaces another PR to fix the linked issue (see the [reason](https://github.com/PelicanPlatform/pelican/pull/2540#issuecomment-3156084793))

With this PR, Pelican won't programmatically chmod/chown the `tls.key`, `tls.crt`, so the program won't hit the "read-only external file system" error. Admin needs to change the perms and ownership of them beforehand to the following values, to allow the TLS certs auto update in the drop-privs mode.

owned by: [user: pelican, group: root]. file perms: 0640