### PR TITLE
Collections api

### DIFF
--- a/database/api_token.go
+++ b/database/api_token.go
@@ -168,3 +168,12 @@ func ListApiKeys(db *gorm.DB) ([]server_structs.ApiKey, error) {
 
 	return apiKeys, nil
 }
+
+func GetApiKeyCreator(db *gorm.DB, id string) (string, error) {
+	var apiKey server_structs.ApiKey
+	result := db.First(&apiKey, "id = ?", id)
+	if result.Error != nil {
+		return "", errors.Wrap(result.Error, "failed to get the API key creator")
+	}
+	return apiKey.CreatedBy, nil
+}

--- a/database/collection.go
+++ b/database/collection.go
@@ -1,6 +1,12 @@
 package database
 
-import "time"
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"time"
+
+	"gorm.io/gorm"
+)
 
 type Visibility string
 
@@ -19,10 +25,9 @@ const (
 
 type Collection struct {
 	ID          string `gorm:"primaryKey"`
-	Name        string `gorm:"not null;uniqueIndex:idx_owner_issuer_name"`
+	Name        string `gorm:"not null;uniqueIndex:idx_owner_name"`
 	Description string
-	OwnerSub    string               `gorm:"not null;uniqueIndex:idx_owner_issuer_name"`
-	OwnerIssuer string               `gorm:"not null;uniqueIndex:idx_owner_issuer_name"`
+	Owner       string               `gorm:"not null;uniqueIndex:idx_owner_name"`
 	Visibility  Visibility           `gorm:"not null;default:private"`
 	CreatedAt   time.Time            `gorm:"not null;default:CURRENT_TIMESTAMP"`
 	UpdatedAt   time.Time            `gorm:"not null;default:CURRENT_TIMESTAMP"`
@@ -34,22 +39,110 @@ type Collection struct {
 type CollectionMember struct {
 	CollectionID string    `gorm:"primaryKey"`
 	ObjectURL    string    `gorm:"primaryKey"` // full pelican:// URL
-	AddedBySub   string    `gorm:"not null"`
+	AddedBy      string    `gorm:"not null"`
 	AddedAt      time.Time `gorm:"not null;default:CURRENT_TIMESTAMP"`
 }
 
 type CollectionACL struct {
-	CollectionID    string    `gorm:"primaryKey"`
-	PrincipalSub    string    `gorm:"primaryKey"`
-	PrincipalIssuer string    `gorm:"primaryKey;not null"`
-	Role            AclRole   `gorm:"primaryKey;not null"`
-	GrantedBySub    string    `gorm:"not null"`
-	GrantedAt       time.Time `gorm:"not null;default:CURRENT_TIMESTAMP"`
-	ExpiresAt       *time.Time
+	CollectionID string    `gorm:"primaryKey"`
+	Principal    string    `gorm:"primaryKey"`
+	Role         AclRole   `gorm:"primaryKey;not null"`
+	GrantedBy    string    `gorm:"not null"`
+	GrantedAt    time.Time `gorm:"not null;default:CURRENT_TIMESTAMP"`
+	ExpiresAt    *time.Time
 }
 
 type CollectionMetadata struct {
 	CollectionID string `gorm:"primaryKey"`
 	Key          string `gorm:"primaryKey;not null"`
 	Value        string `gorm:"not null"`
+}
+
+func generateSlug() (string, error) {
+	slug := make([]byte, 16)
+	_, err := rand.Read(slug)
+	if err != nil {
+		return "", err
+	}
+	slugStr := hex.EncodeToString(slug)
+	slugStr = slugStr[:8]
+	return slugStr, nil
+}
+
+func CreateCollection(db *gorm.DB, name, description, owner string, visibility Visibility) (*Collection, error) {
+	// generate a human readable slug
+	// using random bytes
+	slug, err := generateSlug()
+	if err != nil {
+		return nil, err
+	}
+
+	collection := &Collection{
+		ID:          slug,
+		Name:        name,
+		Description: description,
+		Owner:       owner,
+		Visibility:  visibility,
+	}
+
+	result := db.Create(collection)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return collection, nil
+}
+
+func CreateCollectionWithMetadata(db *gorm.DB, name, description, owner string, visibility Visibility, metadata map[string]string) (*Collection, error) {
+	slug, err := generateSlug()
+	if err != nil {
+		return nil, err
+	}
+
+	collection := &Collection{
+		ID:          slug,
+		Name:        name,
+		Description: description,
+		Owner:       owner,
+		Visibility:  visibility,
+	}
+
+	err = db.Transaction(func(tx *gorm.DB) error {
+		if result := tx.Create(collection); result.Error != nil {
+			return result.Error
+		}
+
+		if len(metadata) > 0 {
+			metadataEntries := make([]CollectionMetadata, 0, len(metadata))
+			for k, v := range metadata {
+				metadataEntries = append(metadataEntries, CollectionMetadata{
+					CollectionID: collection.ID,
+					Key:          k,
+					Value:        v,
+				})
+			}
+			if result := tx.Create(&metadataEntries); result.Error != nil {
+				return result.Error
+			}
+		}
+
+		// Also create the owner ACL
+		ownerAcl := &CollectionACL{
+			CollectionID: collection.ID,
+			Principal:    owner,
+			Role:         AclRoleOwner,
+			GrantedBy:    owner,
+		}
+		if result := tx.Create(ownerAcl); result.Error != nil {
+			return result.Error
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return collection, nil
 }

--- a/database/collection.go
+++ b/database/collection.go
@@ -1,0 +1,55 @@
+package database
+
+import "time"
+
+type Visibility string
+
+const (
+	VisibilityPrivate Visibility = "private"
+	VisibilityPublic  Visibility = "public"
+)
+
+type AclRole string
+
+const (
+	AclRoleRead  AclRole = "read"
+	AclRoleWrite AclRole = "write"
+	AclRoleOwner AclRole = "owner"
+)
+
+type Collection struct {
+	ID          string `gorm:"primaryKey"`
+	Name        string `gorm:"not null;uniqueIndex:idx_owner_issuer_name"`
+	Description string
+	OwnerSub    string               `gorm:"not null;uniqueIndex:idx_owner_issuer_name"`
+	OwnerIssuer string               `gorm:"not null;uniqueIndex:idx_owner_issuer_name"`
+	Visibility  Visibility           `gorm:"not null;default:private"`
+	CreatedAt   time.Time            `gorm:"not null;default:CURRENT_TIMESTAMP"`
+	UpdatedAt   time.Time            `gorm:"not null;default:CURRENT_TIMESTAMP"`
+	Members     []CollectionMember   `gorm:"foreignKey:CollectionID"`
+	ACLs        []CollectionACL      `gorm:"foreignKey:CollectionID"`
+	Metadata    []CollectionMetadata `gorm:"foreignKey:CollectionID"`
+}
+
+type CollectionMember struct {
+	CollectionID string    `gorm:"primaryKey"`
+	ObjectURL    string    `gorm:"primaryKey"` // full pelican:// URL
+	AddedBySub   string    `gorm:"not null"`
+	AddedAt      time.Time `gorm:"not null;default:CURRENT_TIMESTAMP"`
+}
+
+type CollectionACL struct {
+	CollectionID    string    `gorm:"primaryKey"`
+	PrincipalSub    string    `gorm:"primaryKey"`
+	PrincipalIssuer string    `gorm:"primaryKey;not null"`
+	Role            AclRole   `gorm:"primaryKey;not null"`
+	GrantedBySub    string    `gorm:"not null"`
+	GrantedAt       time.Time `gorm:"not null;default:CURRENT_TIMESTAMP"`
+	ExpiresAt       *time.Time
+}
+
+type CollectionMetadata struct {
+	CollectionID string `gorm:"primaryKey"`
+	Key          string `gorm:"primaryKey;not null"`
+	Value        string `gorm:"not null"`
+}

--- a/database/universal_migrations/20250729143942_collections.sql
+++ b/database/universal_migrations/20250729143942_collections.sql
@@ -4,32 +4,30 @@ CREATE TABLE collections (
     id TEXT PRIMARY KEY,
     name TEXT NOT NULL,
     description TEXT,
-    owner_sub TEXT NOT NULL,
-    owner_issuer TEXT NOT NULL,
+    owner TEXT NOT NULL,
     visibility TEXT NOT NULL DEFAULT 'private',
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE UNIQUE INDEX idx_owner_issuer_name ON collections (owner_sub, owner_issuer, name);
+CREATE UNIQUE INDEX idx_owner_name ON collections (owner, name);
 
 CREATE TABLE collection_members (
     collection_id TEXT NOT NULL,
     object_url TEXT NOT NULL,
-    added_by_sub TEXT NOT NULL,
+    added_by TEXT NOT NULL,
     added_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (collection_id, object_url)
 );
 
 CREATE TABLE collection_acls (
     collection_id TEXT NOT NULL,
-    principal_sub TEXT NOT NULL,
-    principal_issuer TEXT NOT NULL,
+    principal TEXT NOT NULL,
     role TEXT NOT NULL,
-    granted_by_sub TEXT NOT NULL,
+    granted_by TEXT NOT NULL,
     granted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     expires_at DATETIME,
-    PRIMARY KEY (collection_id, principal_sub, principal_issuer, role)
+    PRIMARY KEY (collection_id, principal, role)
 );
 
 CREATE TABLE collection_metadata (
@@ -46,5 +44,5 @@ DROP TABLE collection_metadata;
 DROP TABLE collection_acls;
 DROP TABLE collection_members;
 DROP TABLE collections;
-DROP INDEX idx_owner_issuer_name;
+DROP INDEX idx_owner_name;
 -- +goose StatementEnd

--- a/database/universal_migrations/20250729143942_collections.sql
+++ b/database/universal_migrations/20250729143942_collections.sql
@@ -1,0 +1,50 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE collections (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    owner_sub TEXT NOT NULL,
+    owner_issuer TEXT NOT NULL,
+    visibility TEXT NOT NULL DEFAULT 'private',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX idx_owner_issuer_name ON collections (owner_sub, owner_issuer, name);
+
+CREATE TABLE collection_members (
+    collection_id TEXT NOT NULL,
+    object_url TEXT NOT NULL,
+    added_by_sub TEXT NOT NULL,
+    added_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (collection_id, object_url)
+);
+
+CREATE TABLE collection_acls (
+    collection_id TEXT NOT NULL,
+    principal_sub TEXT NOT NULL,
+    principal_issuer TEXT NOT NULL,
+    role TEXT NOT NULL,
+    granted_by_sub TEXT NOT NULL,
+    granted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at DATETIME,
+    PRIMARY KEY (collection_id, principal_sub, principal_issuer, role)
+);
+
+CREATE TABLE collection_metadata (
+    collection_id TEXT NOT NULL,
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    PRIMARY KEY (collection_id, key)
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE collection_metadata;
+DROP TABLE collection_acls;
+DROP TABLE collection_members;
+DROP TABLE collections;
+DROP INDEX idx_owner_issuer_name;
+-- +goose StatementEnd

--- a/database/universal_migrations/20250729143942_collections.sql
+++ b/database/universal_migrations/20250729143942_collections.sql
@@ -5,6 +5,7 @@ CREATE TABLE collections (
     name TEXT NOT NULL,
     description TEXT,
     owner TEXT NOT NULL,
+    namespace TEXT NOT NULL,
     visibility TEXT NOT NULL DEFAULT 'private',
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
@@ -20,14 +21,30 @@ CREATE TABLE collection_members (
     PRIMARY KEY (collection_id, object_url)
 );
 
+CREATE TABLE groups (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    description TEXT,
+    created_by TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE group_members (
+    group_id TEXT NOT NULL,
+    member TEXT NOT NULL,
+    added_by TEXT NOT NULL,
+    added_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (group_id, member)
+);
+
 CREATE TABLE collection_acls (
     collection_id TEXT NOT NULL,
-    principal TEXT NOT NULL,
+    group_id TEXT NOT NULL,
     role TEXT NOT NULL,
     granted_by TEXT NOT NULL,
     granted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     expires_at DATETIME,
-    PRIMARY KEY (collection_id, principal, role)
+    PRIMARY KEY (collection_id, group_id, role)
 );
 
 CREATE TABLE collection_metadata (
@@ -42,6 +59,8 @@ CREATE TABLE collection_metadata (
 -- +goose StatementBegin
 DROP TABLE collection_metadata;
 DROP TABLE collection_acls;
+DROP TABLE group_members;
+DROP TABLE groups;
 DROP TABLE collection_members;
 DROP TABLE collections;
 DROP INDEX idx_owner_name;

--- a/docs/scopes.yaml
+++ b/docs/scopes.yaml
@@ -187,3 +187,30 @@ description: >-
   For deleting a lot from a cache
 issuedBy: ["origin"]
 acceptedBy: ["cache"]
+---
+############################
+#    Collection Scopes     #
+############################
+name: "collection.create"
+description: >-
+  For creating a new collection
+issuedBy: ["origin"]
+acceptedBy: ["origin", "director"]
+---
+name: "collection.read"
+description: >-
+  For getting/reading the contents of a collection
+issuedBy: ["origin"]
+acceptedBy: ["origin", "director"]
+---
+name: "collection.modify"
+description: >-
+  For modifying the contents of a collection
+issuedBy: ["origin"]
+acceptedBy: ["origin", "director"]
+---
+name: "collection.delete"
+description: >-
+  For deleting a collection
+issuedBy: ["origin"]
+acceptedBy: ["origin", "director"]

--- a/go.mod
+++ b/go.mod
@@ -190,7 +190,7 @@ require (
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
-	go.uber.org/goleak v1.3.0 // indirect
+	go.uber.org/goleak v1.3.0
 	golang.org/x/arch v0.3.0 // indirect
 	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8
 	golang.org/x/sync v0.12.0

--- a/origin/collections.go
+++ b/origin/collections.go
@@ -1,0 +1,87 @@
+package origin
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/pelicanplatform/pelican/database"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/token"
+	"github.com/pelicanplatform/pelican/token_scopes"
+	"github.com/pelicanplatform/pelican/web_ui"
+)
+
+type CreateCollectionReq struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	Visibility  string            `json:"visibility"`
+	Metadata    map[string]string `json:"metadata"`
+}
+
+func handleCreateCollection(ctx *gin.Context) {
+	authOption := token.AuthOption{
+		Sources: []token.TokenSource{token.Cookie, token.Header},
+		Issuers: []token.TokenIssuer{token.LocalIssuer, token.APITokenIssuer},
+		Scopes:  []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Create},
+	}
+	status, ok, err := token.Verify(ctx, authOption)
+	if !ok {
+		ctx.JSON(status, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    err.Error(),
+		})
+		return
+	}
+
+	var req CreateCollectionReq
+	err = ctx.ShouldBindJSON(&req)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Invalid request body: %v", err),
+		})
+		return
+	}
+
+	if req.Name == "" {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "A name for the collection is required",
+		})
+		return
+	}
+
+	owner, _, err := web_ui.GetUserGroups(ctx)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to get user from context: %v", err),
+		})
+	}
+
+	visibility := database.Visibility(strings.ToLower(req.Visibility))
+	if visibility != database.VisibilityPublic && visibility != database.VisibilityPrivate {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "A collection's visibility must be either 'private' or 'public'",
+		})
+		return
+	}
+
+	coll, err := database.CreateCollectionWithMetadata(database.ServerDatabase, req.Name, req.Description, owner, visibility, req.Metadata)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to create collection: %v", err),
+		})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, server_structs.SimpleApiResp{
+		Status: server_structs.RespOK,
+		Msg:    fmt.Sprintf("Collection created with ID %s", coll.ID),
+	})
+}

--- a/origin/collections.go
+++ b/origin/collections.go
@@ -2,8 +2,12 @@ package origin
 
 import (
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -22,7 +26,32 @@ type CreateCollectionReq struct {
 	Metadata    map[string]string `json:"metadata"`
 }
 
+type UpdateCollectionReq struct {
+	Name        *string `json:"name"`
+	Description *string `json:"description"`
+	Visibility  *string `json:"visibility"`
+}
+
+type MetadataValue struct {
+	Value string `json:"value"`
+}
+
+type GrantAclReq struct {
+	Principal string     `json:"principal"`
+	Role      string     `json:"role"`
+	ExpiresAt *time.Time `json:"expires_at"`
+}
+
+type RevokeAclReq struct {
+	Principal string `json:"principal"`
+	Role      string `json:"role"`
+}
+
 type AddCollectionMembersReq struct {
+	Members []string `json:"members"`
+}
+
+type RemoveCollectionMembersReq struct {
 	Members []string `json:"members"`
 }
 
@@ -92,10 +121,181 @@ func handleCreateCollection(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, server_structs.SimpleApiResp{
-		Status: server_structs.RespOK,
-		Msg:    fmt.Sprintf("Collection created with ID %s", coll.ID),
-	})
+	ctx.JSON(http.StatusCreated, coll)
+}
+
+func handleUpdateCollection(ctx *gin.Context) {
+	authOption := token.AuthOption{
+		Sources: []token.TokenSource{token.Cookie, token.Header},
+		Issuers: []token.TokenIssuer{token.LocalIssuer, token.APITokenIssuer},
+		Scopes:  []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Modify},
+	}
+	status, ok, err := token.Verify(ctx, authOption)
+	if !ok {
+		ctx.JSON(status, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    err.Error(),
+		})
+		return
+	}
+
+	var req UpdateCollectionReq
+	err = ctx.ShouldBindJSON(&req)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Invalid request body: %v", err),
+		})
+		return
+	}
+
+	user, _, err := web_ui.GetUserGroups(ctx)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to get user from context: %v", err),
+		})
+	}
+	if user == "" {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to get user from context",
+		})
+		return
+	}
+
+	var visibility database.Visibility
+	if req.Visibility != nil {
+		v := database.Visibility(strings.ToLower(*req.Visibility))
+		if v != database.VisibilityPublic && v != database.VisibilityPrivate {
+			ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "A collection's visibility must be either 'private' or 'public'",
+			})
+			return
+		}
+		visibility = v
+	}
+
+	var visPtr *database.Visibility
+	if req.Visibility != nil {
+		visPtr = &visibility
+	}
+
+	err = database.UpdateCollection(database.ServerDatabase, ctx.Param("id"), user, req.Name, req.Description, visPtr)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to update collection: %v", err),
+		})
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}
+
+func handleRemoveCollectionMembers(ctx *gin.Context) {
+	authOption := token.AuthOption{
+		Sources: []token.TokenSource{token.Cookie, token.Header},
+		Issuers: []token.TokenIssuer{token.LocalIssuer, token.APITokenIssuer},
+		Scopes:  []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Modify},
+	}
+	status, ok, err := token.Verify(ctx, authOption)
+	if !ok {
+		ctx.JSON(status, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    err.Error(),
+		})
+		return
+	}
+
+	var req RemoveCollectionMembersReq
+	err = ctx.ShouldBindJSON(&req)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Invalid request body: %v", err),
+		})
+		return
+	}
+
+	user, _, err := web_ui.GetUserGroups(ctx)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to get user from context: %v", err),
+		})
+	}
+	if user == "" {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to get user from context",
+		})
+		return
+	}
+
+	err = database.RemoveCollectionMembers(database.ServerDatabase, ctx.Param("id"), req.Members, user)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to remove collection members: %v", err),
+		})
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}
+
+func handleRemoveCollectionMember(ctx *gin.Context) {
+	authOption := token.AuthOption{
+		Sources: []token.TokenSource{token.Cookie, token.Header},
+		Issuers: []token.TokenIssuer{token.LocalIssuer, token.APITokenIssuer},
+		Scopes:  []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Modify},
+	}
+	status, ok, err := token.Verify(ctx, authOption)
+	if !ok {
+		ctx.JSON(status, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    err.Error(),
+		})
+		return
+	}
+
+	encodedObjectURL := ctx.Param("encoded_object_url")
+	objectURL, err := url.PathUnescape(encodedObjectURL)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Invalid encoded object URL: %v", err),
+		})
+		return
+	}
+
+	user, _, err := web_ui.GetUserGroups(ctx)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to get user from context: %v", err),
+		})
+	}
+	if user == "" {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to get user from context",
+		})
+		return
+	}
+
+	err = database.RemoveCollectionMembers(database.ServerDatabase, ctx.Param("id"), []string{objectURL}, user)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to remove collection member: %v", err),
+		})
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
 }
 
 func handleAddCollectionMembers(ctx *gin.Context) {
@@ -159,10 +359,249 @@ func handleAddCollectionMembers(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, server_structs.SimpleApiResp{
-		Status: server_structs.RespOK,
-		Msg:    "Collection members added",
-	})
+	ctx.Status(http.StatusNoContent)
+}
+
+func handleListCollectionMembers(ctx *gin.Context) {
+	authOption := token.AuthOption{
+		Sources: []token.TokenSource{token.Cookie, token.Header},
+		Issuers: []token.TokenIssuer{token.LocalIssuer, token.APITokenIssuer},
+		Scopes:  []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Read},
+	}
+	status, ok, err := token.Verify(ctx, authOption)
+	if !ok {
+		ctx.JSON(status, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    err.Error(),
+		})
+		return
+	}
+
+	user, _, err := web_ui.GetUserGroups(ctx)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to get user from context: %v", err),
+		})
+	}
+	if user == "" {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to get user from context",
+		})
+		return
+	}
+
+	sinceStr := ctx.Query("since")
+	var since *time.Time
+	if sinceStr != "" {
+		t, err := time.Parse(time.RFC3339, sinceStr)
+		if err != nil {
+			ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "Invalid 'since' timestamp format. Use ISO8601",
+			})
+			return
+		}
+		since = &t
+	}
+
+	limitStr := ctx.Query("limit")
+	limit := 100 // default
+	if limitStr != "" {
+		l, err := strconv.Atoi(limitStr)
+		if err != nil || l <= 0 {
+			ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "Invalid 'limit' parameter. Must be a positive integer",
+			})
+			return
+		}
+		if l > 1000 {
+			limit = 1000 // max
+		} else {
+			limit = l
+		}
+	}
+
+	members, err := database.GetCollectionMembers(database.ServerDatabase, ctx.Param("id"), user, since, limit)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to list collection members: %v", err),
+		})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, members)
+}
+
+func handleGetCollectionMetadata(ctx *gin.Context) {
+	authOption := token.AuthOption{
+		Sources: []token.TokenSource{token.Cookie, token.Header},
+		Issuers: []token.TokenIssuer{token.LocalIssuer, token.APITokenIssuer},
+		Scopes:  []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Read},
+	}
+	status, ok, err := token.Verify(ctx, authOption)
+	if !ok {
+		ctx.JSON(status, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    err.Error(),
+		})
+		return
+	}
+
+	user, _, err := web_ui.GetUserGroups(ctx)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to get user from context: %v", err),
+		})
+	}
+	if user == "" {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to get user from context",
+		})
+		return
+	}
+
+	metadata, err := database.GetCollectionMetadata(database.ServerDatabase, ctx.Param("id"), user)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to get collection metadata: %v", err),
+		})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, metadata)
+}
+
+func handlePutCollectionMetadata(ctx *gin.Context) {
+	authOption := token.AuthOption{
+		Sources: []token.TokenSource{token.Cookie, token.Header},
+		Issuers: []token.TokenIssuer{token.LocalIssuer, token.APITokenIssuer},
+		Scopes:  []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Modify},
+	}
+	status, ok, err := token.Verify(ctx, authOption)
+	if !ok {
+		ctx.JSON(status, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    err.Error(),
+		})
+		return
+	}
+
+	key := ctx.Param("key")
+	if key == "" {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Metadata key is required",
+		})
+		return
+	}
+
+	var value string
+	contentType := ctx.ContentType()
+	if contentType == "application/json" {
+		var mv MetadataValue
+		if err := ctx.ShouldBindJSON(&mv); err != nil {
+			ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    fmt.Sprintf("Invalid JSON body: %v", err),
+			})
+			return
+		}
+		value = mv.Value
+	} else {
+		bodyBytes, err := io.ReadAll(ctx.Request.Body)
+		if err != nil {
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "Failed to read request body",
+			})
+			return
+		}
+		value = string(bodyBytes)
+	}
+
+	user, _, err := web_ui.GetUserGroups(ctx)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to get user from context: %v", err),
+		})
+	}
+	if user == "" {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to get user from context",
+		})
+		return
+	}
+
+	err = database.UpsertCollectionMetadata(database.ServerDatabase, ctx.Param("id"), user, key, value)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to put collection metadata: %v", err),
+		})
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}
+
+func handleDeleteCollectionMetadata(ctx *gin.Context) {
+	authOption := token.AuthOption{
+		Sources: []token.TokenSource{token.Cookie, token.Header},
+		Issuers: []token.TokenIssuer{token.LocalIssuer, token.APITokenIssuer},
+		Scopes:  []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Modify},
+	}
+	status, ok, err := token.Verify(ctx, authOption)
+	if !ok {
+		ctx.JSON(status, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    err.Error(),
+		})
+		return
+	}
+
+	key := ctx.Param("key")
+	if key == "" {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Metadata key is required",
+		})
+		return
+	}
+
+	user, _, err := web_ui.GetUserGroups(ctx)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to get user from context: %v", err),
+		})
+	}
+	if user == "" {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to get user from context",
+		})
+		return
+	}
+
+	err = database.DeleteCollectionMetadata(database.ServerDatabase, ctx.Param("id"), user, key)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to delete collection metadata: %v", err),
+		})
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
 }
 
 func handleGetCollection(ctx *gin.Context) {
@@ -247,8 +686,193 @@ func handleDeleteCollection(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, server_structs.SimpleApiResp{
-		Status: server_structs.RespOK,
-		Msg:    "Collection deleted",
-	})
+	ctx.Status(http.StatusNoContent)
+}
+
+func handleGetCollectionAcls(ctx *gin.Context) {
+	authOption := token.AuthOption{
+		Sources: []token.TokenSource{token.Cookie, token.Header},
+		Issuers: []token.TokenIssuer{token.LocalIssuer, token.APITokenIssuer},
+		Scopes:  []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Read},
+	}
+	status, ok, err := token.Verify(ctx, authOption)
+	if !ok {
+		ctx.JSON(status, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    err.Error(),
+		})
+		return
+	}
+
+	user, _, err := web_ui.GetUserGroups(ctx)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to get user from context: %v", err),
+		})
+	}
+	if user == "" {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to get user from context",
+		})
+		return
+	}
+
+	acls, err := database.GetCollectionAcls(database.ServerDatabase, ctx.Param("id"), user)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to get collection acls: %v", err),
+		})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, acls)
+}
+
+func handleGrantCollectionAcl(ctx *gin.Context) {
+	authOption := token.AuthOption{
+		Sources: []token.TokenSource{token.Cookie, token.Header},
+		Issuers: []token.TokenIssuer{token.LocalIssuer, token.APITokenIssuer},
+		Scopes:  []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Modify},
+	}
+	status, ok, err := token.Verify(ctx, authOption)
+	if !ok {
+		ctx.JSON(status, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    err.Error(),
+		})
+		return
+	}
+
+	var req GrantAclReq
+	err = ctx.ShouldBindJSON(&req)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Invalid request body: %v", err),
+		})
+		return
+	}
+
+	if req.Principal == "" || req.Role == "" {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Principal and role are required",
+		})
+		return
+	}
+
+	role := database.AclRole(req.Role)
+	if role != database.AclRoleRead && role != database.AclRoleWrite && role != database.AclRoleOwner {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Invalid role. Must be one of 'read', 'write', or 'owner'",
+		})
+		return
+	}
+
+	user, _, err := web_ui.GetUserGroups(ctx)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to get user from context: %v", err),
+		})
+	}
+	if user == "" {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to get user from context",
+		})
+		return
+	}
+
+	err = database.GrantCollectionAcl(database.ServerDatabase, ctx.Param("id"), user, req.Principal, role, req.ExpiresAt)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to grant collection acl: %v", err),
+		})
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}
+
+func handleRevokeCollectionAcl(ctx *gin.Context) {
+	authOption := token.AuthOption{
+		Sources: []token.TokenSource{token.Cookie, token.Header},
+		Issuers: []token.TokenIssuer{token.LocalIssuer, token.APITokenIssuer},
+		Scopes:  []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Modify},
+	}
+	status, ok, err := token.Verify(ctx, authOption)
+	if !ok {
+		ctx.JSON(status, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    err.Error(),
+		})
+		return
+	}
+
+	var principal, roleStr string
+
+	if ctx.Request.Method == "DELETE" && ctx.Request.Header.Get("Content-Type") == "application/json" {
+		var req RevokeAclReq
+		if err := ctx.ShouldBindJSON(&req); err != nil {
+			ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    fmt.Sprintf("Invalid request body: %v", err),
+			})
+			return
+		}
+		principal = req.Principal
+		roleStr = req.Role
+	} else {
+		principal = ctx.Query("principal")
+		roleStr = ctx.Query("role")
+	}
+
+	if principal == "" || roleStr == "" {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Principal and role are required",
+		})
+		return
+	}
+
+	role := database.AclRole(roleStr)
+	if role != database.AclRoleRead && role != database.AclRoleWrite && role != database.AclRoleOwner {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Invalid role. Must be one of 'read', 'write', or 'owner'",
+		})
+		return
+	}
+
+	user, _, err := web_ui.GetUserGroups(ctx)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to get user from context: %v", err),
+		})
+	}
+	if user == "" {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to get user from context",
+		})
+		return
+	}
+
+	err = database.RevokeCollectionAcl(database.ServerDatabase, ctx.Param("id"), user, principal, role)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to revoke collection acl: %v", err),
+		})
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
 }

--- a/origin/collections.go
+++ b/origin/collections.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/pelicanplatform/pelican/database"
+	"github.com/pelicanplatform/pelican/pelican_url"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
@@ -19,6 +20,10 @@ type CreateCollectionReq struct {
 	Description string            `json:"description"`
 	Visibility  string            `json:"visibility"`
 	Metadata    map[string]string `json:"metadata"`
+}
+
+type AddCollectionMembersReq struct {
+	Members []string `json:"members"`
 }
 
 func handleCreateCollection(ctx *gin.Context) {
@@ -61,6 +66,13 @@ func handleCreateCollection(ctx *gin.Context) {
 			Msg:    fmt.Sprintf("Failed to get user from context: %v", err),
 		})
 	}
+	if owner == "" {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to get user from context",
+		})
+		return
+	}
 
 	visibility := database.Visibility(strings.ToLower(req.Visibility))
 	if visibility != database.VisibilityPublic && visibility != database.VisibilityPrivate {
@@ -84,4 +96,113 @@ func handleCreateCollection(ctx *gin.Context) {
 		Status: server_structs.RespOK,
 		Msg:    fmt.Sprintf("Collection created with ID %s", coll.ID),
 	})
+}
+
+func handleAddCollectionMembers(ctx *gin.Context) {
+	authOption := token.AuthOption{
+		Sources: []token.TokenSource{token.Cookie, token.Header},
+		Issuers: []token.TokenIssuer{token.LocalIssuer, token.APITokenIssuer},
+		Scopes:  []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Modify},
+	}
+
+	status, ok, err := token.Verify(ctx, authOption)
+	if !ok {
+		ctx.JSON(status, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    err.Error(),
+		})
+		return
+	}
+
+	var req AddCollectionMembersReq
+	err = ctx.ShouldBindJSON(&req)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Invalid request body: %v", err),
+		})
+		return
+	}
+
+	// validate the members are valid pelican URLs
+	for _, member := range req.Members {
+		if _, err := pelican_url.Parse(member, []pelican_url.ParseOption{}, []pelican_url.DiscoveryOption{}); err != nil {
+			ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    fmt.Sprintf("Invalid member URL: %v", err),
+			})
+			return
+		}
+	}
+
+	user, _, err := web_ui.GetUserGroups(ctx)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to get user from context: %v", err),
+		})
+	}
+	if user == "" {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to get user from context",
+		})
+		return
+	}
+
+	err = database.AddCollectionMembers(database.ServerDatabase, ctx.Param("id"), req.Members, user)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to add collection members: %v", err),
+		})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, server_structs.SimpleApiResp{
+		Status: server_structs.RespOK,
+		Msg:    "Collection members added",
+	})
+}
+
+func handleGetCollection(ctx *gin.Context) {
+	authOption := token.AuthOption{
+		Sources: []token.TokenSource{token.Cookie, token.Header},
+		Issuers: []token.TokenIssuer{token.LocalIssuer, token.APITokenIssuer},
+		Scopes:  []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Read},
+	}
+	status, ok, err := token.Verify(ctx, authOption)
+	if !ok {
+		ctx.JSON(status, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    err.Error(),
+		})
+		return
+	}
+
+	user, _, err := web_ui.GetUserGroups(ctx)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to get user from context: %v", err),
+		})
+	}
+	if user == "" {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to get user from context",
+		})
+		return
+	}
+
+	coll, err := database.GetCollection(database.ServerDatabase, ctx.Param("id"), user)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    fmt.Sprintf("Failed to get collection: %v", err),
+		})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, coll)
 }

--- a/origin/collections.go
+++ b/origin/collections.go
@@ -1,6 +1,7 @@
 package origin
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -291,10 +292,17 @@ func handleUpdateCollection(ctx *gin.Context) {
 
 	err = database.UpdateCollection(database.ServerDatabase, ctx.Param("id"), user, groups, req.Name, req.Description, visPtr)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
-			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("Failed to update collection: %v", err),
-		})
+		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
+			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "collection not found",
+			})
+		} else {
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    fmt.Sprintf("Failed to update collection: %v", err),
+			})
+		}
 		return
 	}
 
@@ -343,10 +351,17 @@ func handleRemoveCollectionMembers(ctx *gin.Context) {
 
 	err = database.RemoveCollectionMembers(database.ServerDatabase, ctx.Param("id"), req.Members, user, groups)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
-			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("Failed to remove collection members: %v", err),
-		})
+		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
+			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "collection not found",
+			})
+		} else {
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    fmt.Sprintf("Failed to remove collection members: %v", err),
+			})
+		}
 		return
 	}
 
@@ -395,10 +410,17 @@ func handleRemoveCollectionMember(ctx *gin.Context) {
 
 	err = database.RemoveCollectionMembers(database.ServerDatabase, ctx.Param("id"), []string{objectURL}, user, groups)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
-			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("Failed to remove collection member: %v", err),
-		})
+		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
+			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "collection not found",
+			})
+		} else {
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    fmt.Sprintf("Failed to remove collection member: %v", err),
+			})
+		}
 		return
 	}
 
@@ -459,10 +481,17 @@ func handleAddCollectionMembers(ctx *gin.Context) {
 
 	err = database.AddCollectionMembers(database.ServerDatabase, ctx.Param("id"), req.Members, user, groups)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
-			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("Failed to add collection members: %v", err),
-		})
+		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
+			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "collection not found",
+			})
+		} else {
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    fmt.Sprintf("Failed to add collection members: %v", err),
+			})
+		}
 		return
 	}
 
@@ -533,10 +562,17 @@ func handleListCollectionMembers(ctx *gin.Context) {
 
 	members, err := database.GetCollectionMembers(database.ServerDatabase, ctx.Param("id"), user, groups, since, limit)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
-			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("Failed to list collection members: %v", err),
-		})
+		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
+			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "collection not found",
+			})
+		} else {
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    fmt.Sprintf("Failed to list collection members: %v", err),
+			})
+		}
 		return
 	}
 
@@ -575,10 +611,17 @@ func handleGetCollectionMetadata(ctx *gin.Context) {
 
 	metadata, err := database.GetCollectionMetadata(database.ServerDatabase, ctx.Param("id"), user, groups)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
-			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("Failed to get collection metadata: %v", err),
-		})
+		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
+			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "collection not found",
+			})
+		} else {
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    fmt.Sprintf("Failed to get collection metadata: %v", err),
+			})
+		}
 		return
 	}
 
@@ -650,10 +693,17 @@ func handlePutCollectionMetadata(ctx *gin.Context) {
 
 	err = database.UpsertCollectionMetadata(database.ServerDatabase, ctx.Param("id"), user, groups, key, value)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
-			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("Failed to put collection metadata: %v", err),
-		})
+		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
+			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "collection not found",
+			})
+		} else {
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    fmt.Sprintf("Failed to put collection metadata: %v", err),
+			})
+		}
 		return
 	}
 
@@ -701,10 +751,17 @@ func handleDeleteCollectionMetadata(ctx *gin.Context) {
 
 	err = database.DeleteCollectionMetadata(database.ServerDatabase, ctx.Param("id"), user, groups, key)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
-			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("Failed to delete collection metadata: %v", err),
-		})
+		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
+			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "collection not found",
+			})
+		} else {
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    fmt.Sprintf("Failed to delete collection metadata: %v", err),
+			})
+		}
 		return
 	}
 
@@ -743,7 +800,7 @@ func handleGetCollection(ctx *gin.Context) {
 
 	coll, err := database.GetCollection(database.ServerDatabase, ctx.Param("id"), user, groups)
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
 			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{Status: server_structs.RespFailed, Msg: "collection not found"})
 			return
 		}
@@ -813,10 +870,17 @@ func handleDeleteCollection(ctx *gin.Context) {
 
 	err = database.DeleteCollection(database.ServerDatabase, ctx.Param("id"), user, groups)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
-			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("Failed to delete collection: %v", err),
-		})
+		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
+			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "collection not found",
+			})
+		} else {
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    fmt.Sprintf("Failed to delete collection: %v", err),
+			})
+		}
 		return
 	}
 
@@ -855,10 +919,17 @@ func handleGetCollectionAcls(ctx *gin.Context) {
 
 	acls, err := database.GetCollectionAcls(database.ServerDatabase, ctx.Param("id"), user, groups)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
-			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("Failed to get collection acls: %v", err),
-		})
+		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
+			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "collection not found",
+			})
+		} else {
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    fmt.Sprintf("Failed to get collection acls: %v", err),
+			})
+		}
 		return
 	}
 
@@ -924,10 +995,17 @@ func handleGrantCollectionAcl(ctx *gin.Context) {
 
 	err = database.GrantCollectionAcl(database.ServerDatabase, ctx.Param("id"), user, groups, req.GroupID, role, req.ExpiresAt)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
-			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("Failed to grant collection acl: %v", err),
-		})
+		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
+			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "collection not found",
+			})
+		} else {
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    fmt.Sprintf("Failed to grant collection acl: %v", err),
+			})
+		}
 		return
 	}
 
@@ -1001,10 +1079,17 @@ func handleRevokeCollectionAcl(ctx *gin.Context) {
 
 	err = database.RevokeCollectionAcl(database.ServerDatabase, ctx.Param("id"), user, groups, principal, role)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
-			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("Failed to revoke collection acl: %v", err),
-		})
+		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
+			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "collection not found",
+			})
+		} else {
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    fmt.Sprintf("Failed to revoke collection acl: %v", err),
+			})
+		}
 		return
 	}
 
@@ -1116,10 +1201,22 @@ func handleAddGroupMember(ctx *gin.Context) {
 
 	err = database.AddGroupMember(database.ServerDatabase, ctx.Param("id"), req.Member, user, groups)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
-			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("Failed to add group member: %v", err),
-		})
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "group not found",
+			})
+		} else if errors.Is(err, database.ErrForbidden) {
+			ctx.JSON(http.StatusForbidden, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "you do not have permission to add members to this group",
+			})
+		} else {
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    fmt.Sprintf("Failed to add group member: %v", err),
+			})
+		}
 		return
 	}
 
@@ -1161,10 +1258,22 @@ func handleRemoveGroupMember(ctx *gin.Context) {
 
 	err = database.RemoveGroupMember(database.ServerDatabase, ctx.Param("id"), member, user, groups)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
-			Status: server_structs.RespFailed,
-			Msg:    fmt.Sprintf("Failed to remove group member: %v", err),
-		})
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "group or member not found",
+			})
+		} else if errors.Is(err, database.ErrForbidden) {
+			ctx.JSON(http.StatusForbidden, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "you do not have permission to remove members from this group",
+			})
+		} else {
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    fmt.Sprintf("Failed to remove group member: %v", err),
+			})
+		}
 		return
 	}
 

--- a/origin/group_test.go
+++ b/origin/group_test.go
@@ -1,0 +1,188 @@
+package origin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/database"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/test_utils"
+	"github.com/pelicanplatform/pelican/token_scopes"
+	"github.com/pelicanplatform/pelican/web_ui"
+)
+
+func TestGroupManagementAPI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	defer func() {
+		if err := egrp.Wait(); err != nil {
+			fmt.Println("Failure when shutting down service:", err)
+			os.Exit(1)
+		}
+	}()
+	defer cancel()
+
+	//set a temporary password file:
+	tempFile, err := os.CreateTemp("", "web-ui-passwd")
+	if err != nil {
+		fmt.Println("Failed to setup web-ui-passwd file")
+		os.Exit(1)
+	}
+	tempPasswdFile = tempFile
+
+	//Override viper default for testing
+	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
+
+	//Make a testing issuer.jwk file to get a cookie
+	tempJWKDir, err := os.MkdirTemp("", "tempDir")
+	if err != nil {
+		fmt.Println("Error making temp jwk dir")
+		os.Exit(1)
+	}
+	//Override viper default for testing
+	viper.Set(param.IssuerKeysDirectory.GetName(), filepath.Join(tempJWKDir, "issuer-keys"))
+
+	// Ensure we load up the default configs.
+	dirname, err := os.MkdirTemp("", "tmpDir")
+	if err != nil {
+		fmt.Println("Error making temp config dir")
+		os.Exit(1)
+	}
+	viper.Set("ConfigDir", dirname)
+	viper.Set("Server.UILoginRateLimit", 100)
+
+	// Set up origin exports
+	exportDir, err := os.MkdirTemp("", "test-export")
+	require.NoError(t, err)
+	//The defer call to remove the directory and its contents is commented out because it was causing a race condition with the file watcher.
+	//defer os.RemoveAll(exportDir)
+	err = os.WriteFile(filepath.Join(exportDir, "test-origin"), []byte("test"), 0644)
+	require.NoError(t, err)
+
+	if err := config.InitServer(ctx, server_structs.OriginType); err != nil {
+		fmt.Println("Failed to configure the test module")
+		os.Exit(1)
+	}
+
+	//Get keys
+	_, err = config.GetIssuerPublicJWKS()
+	if err != nil {
+		fmt.Println("Error issuing jwks")
+		os.Exit(1)
+	}
+
+	//Configure Web API
+	err = web_ui.ConfigureServerWebAPI(ctx, router, egrp)
+	if err != nil {
+		fmt.Println("Error configuring web UI")
+		os.Exit(1)
+	}
+	err = RegisterOriginWebAPI(router)
+	require.NoError(t, err)
+
+	// set up database
+	mockDB, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	database.ServerDatabase = mockDB
+	require.NoError(t, err, "Error setting up mock origin DB")
+
+	err = database.ServerDatabase.AutoMigrate(&database.Collection{})
+	require.NoError(t, err, "Failed to migrate DB for collections table")
+	err = database.ServerDatabase.AutoMigrate(&database.CollectionMember{})
+	require.NoError(t, err, "Failed to migrate DB for collection members table")
+	err = database.ServerDatabase.AutoMigrate(&database.CollectionMetadata{})
+	require.NoError(t, err, "Failed to migrate DB for collection metadata table")
+	err = database.ServerDatabase.AutoMigrate(&database.CollectionACL{})
+	require.NoError(t, err, "Failed to migrate DB for collection ACLs table")
+	err = database.ServerDatabase.AutoMigrate(&database.Group{})
+	require.NoError(t, err, "Failed to migrate DB for groups table")
+	err = database.ServerDatabase.AutoMigrate(&database.GroupMember{})
+	require.NoError(t, err, "Failed to migrate DB for group members table")
+	t.Run("test-group-lifecycle", func(t *testing.T) {
+		// 1. Create a group as 'owner-user'
+		groupName := "test-group-lifecycle"
+		createGroupReq := map[string]string{"name": groupName, "description": "test group"}
+		body, err := json.Marshal(createGroupReq)
+		require.NoError(t, err)
+
+		req, err := http.NewRequest("POST", "/api/v1.0/origin_ui/groups", bytes.NewReader(body))
+		require.NoError(t, err)
+
+		ownerToken, err := generateToken(ctx, []token_scopes.TokenScope{token_scopes.WebUi_Access}, "owner-user")
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: ownerToken})
+		req.Header.Set("Content-Type", "application/json")
+
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusCreated, recorder.Code)
+
+		var createGroupResp map[string]string
+		err = json.NewDecoder(recorder.Body).Decode(&createGroupResp)
+		require.NoError(t, err)
+		groupID := createGroupResp["id"]
+		require.NotEmpty(t, groupID)
+
+		// 2. Add a member to the group as 'owner-user'
+		addMemberReq := map[string]string{"member": "new-member"}
+		body, err = json.Marshal(addMemberReq)
+		require.NoError(t, err)
+
+		req, err = http.NewRequest("POST", "/api/v1.0/origin_ui/groups/"+groupID+"/members", bytes.NewReader(body))
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: ownerToken})
+		req.Header.Set("Content-Type", "application/json")
+
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+
+		// 3. Try to add a member as a different user ('other-user') - should fail
+		otherToken, err := generateToken(ctx, []token_scopes.TokenScope{token_scopes.WebUi_Access}, "other-user")
+		require.NoError(t, err)
+
+		req, err = http.NewRequest("POST", "/api/v1.0/origin_ui/groups/"+groupID+"/members", bytes.NewReader(body))
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: otherToken})
+		req.Header.Set("Content-Type", "application/json")
+
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusForbidden, recorder.Code)
+
+		// 4. Try to remove a member as 'other-user' - should fail
+		req, err = http.NewRequest("DELETE", "/api/v1.0/origin_ui/groups/"+groupID+"/members?member=new-member", nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: otherToken})
+
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusForbidden, recorder.Code)
+
+		// 5. Remove the member from the group as 'owner-user'
+		req, err = http.NewRequest("DELETE", "/api/v1.0/origin_ui/groups/"+groupID+"/members?member=new-member", nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: ownerToken})
+
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+	})
+}

--- a/origin/origin.go
+++ b/origin/origin.go
@@ -66,6 +66,10 @@ func RegisterOriginAPI(router *gin.Engine, ctx context.Context, egrp *errgroup.G
 		group.GET("/collections/:id/acl", web_ui.AuthHandler, handleGetCollectionAcls)
 		group.POST("/collections/:id/acl", web_ui.AuthHandler, handleGrantCollectionAcl)
 		group.DELETE("/collections/:id/acl", web_ui.AuthHandler, handleRevokeCollectionAcl)
+
+		group.POST("/groups", web_ui.AuthHandler, handleCreateGroup)
+		group.POST("/groups/:id/members", web_ui.AuthHandler, handleAddGroupMember)
+		group.DELETE("/groups/:id/members", web_ui.AuthHandler, handleRemoveGroupMember)
 	}
 	return nil
 }

--- a/origin/origin.go
+++ b/origin/origin.go
@@ -53,6 +53,7 @@ func RegisterOriginAPI(router *gin.Engine, ctx context.Context, egrp *errgroup.G
 	{
 		group.POST("/directorTest", func(ctx *gin.Context) { server_utils.HandleDirectorTestResponse(ctx, notificationChan) })
 		group.POST("/collections", web_ui.AuthHandler, handleCreateCollection)
+		group.DELETE("/collections/:id", web_ui.AuthHandler, handleDeleteCollection)
 		group.GET("/collections/:id", web_ui.AuthHandler, handleGetCollection)
 		group.PATCH("/collections/:id/members", web_ui.AuthHandler, handleAddCollectionMembers)
 	}

--- a/origin/origin.go
+++ b/origin/origin.go
@@ -53,9 +53,19 @@ func RegisterOriginAPI(router *gin.Engine, ctx context.Context, egrp *errgroup.G
 	{
 		group.POST("/directorTest", func(ctx *gin.Context) { server_utils.HandleDirectorTestResponse(ctx, notificationChan) })
 		group.POST("/collections", web_ui.AuthHandler, handleCreateCollection)
+		group.PATCH("/collections/:id", web_ui.AuthHandler, handleUpdateCollection)
 		group.DELETE("/collections/:id", web_ui.AuthHandler, handleDeleteCollection)
 		group.GET("/collections/:id", web_ui.AuthHandler, handleGetCollection)
-		group.PATCH("/collections/:id/members", web_ui.AuthHandler, handleAddCollectionMembers)
+		group.POST("/collections/:id/members", web_ui.AuthHandler, handleAddCollectionMembers)
+		group.DELETE("/collections/:id/members", web_ui.AuthHandler, handleRemoveCollectionMembers)
+		group.DELETE("/collections/:id/members/:encoded_object_url", web_ui.AuthHandler, handleRemoveCollectionMember)
+		group.GET("/collections/:id/members", web_ui.AuthHandler, handleListCollectionMembers)
+		group.GET("/collections/:id/metadata", web_ui.AuthHandler, handleGetCollectionMetadata)
+		group.PUT("/collections/:id/metadata/:key", web_ui.AuthHandler, handlePutCollectionMetadata)
+		group.DELETE("/collections/:id/metadata/:key", web_ui.AuthHandler, handleDeleteCollectionMetadata)
+		group.GET("/collections/:id/acl", web_ui.AuthHandler, handleGetCollectionAcls)
+		group.POST("/collections/:id/acl", web_ui.AuthHandler, handleGrantCollectionAcl)
+		group.DELETE("/collections/:id/acl", web_ui.AuthHandler, handleRevokeCollectionAcl)
 	}
 	return nil
 }

--- a/origin/origin.go
+++ b/origin/origin.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/web_ui"
 )
 
 var (
@@ -51,7 +52,9 @@ func RegisterOriginAPI(router *gin.Engine, ctx context.Context, egrp *errgroup.G
 	group := router.Group("/api/v1.0/origin")
 	{
 		group.POST("/directorTest", func(ctx *gin.Context) { server_utils.HandleDirectorTestResponse(ctx, notificationChan) })
-		group.POST("/collections", handleCreateCollection)
+		group.POST("/collections", web_ui.AuthHandler, handleCreateCollection)
+		group.GET("/collections/:id", web_ui.AuthHandler, handleGetCollection)
+		group.PATCH("/collections/:id/members", web_ui.AuthHandler, handleAddCollectionMembers)
 	}
 	return nil
 }

--- a/origin/origin.go
+++ b/origin/origin.go
@@ -51,6 +51,7 @@ func RegisterOriginAPI(router *gin.Engine, ctx context.Context, egrp *errgroup.G
 	group := router.Group("/api/v1.0/origin")
 	{
 		group.POST("/directorTest", func(ctx *gin.Context) { server_utils.HandleDirectorTestResponse(ctx, notificationChan) })
+		group.POST("/collections", handleCreateCollection)
 	}
 	return nil
 }

--- a/origin/origin.go
+++ b/origin/origin.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/server_utils"
-	"github.com/pelicanplatform/pelican/web_ui"
 )
 
 var (
@@ -52,24 +51,6 @@ func RegisterOriginAPI(router *gin.Engine, ctx context.Context, egrp *errgroup.G
 	group := router.Group("/api/v1.0/origin")
 	{
 		group.POST("/directorTest", func(ctx *gin.Context) { server_utils.HandleDirectorTestResponse(ctx, notificationChan) })
-		group.POST("/collections", web_ui.AuthHandler, handleCreateCollection)
-		group.PATCH("/collections/:id", web_ui.AuthHandler, handleUpdateCollection)
-		group.DELETE("/collections/:id", web_ui.AuthHandler, handleDeleteCollection)
-		group.GET("/collections/:id", web_ui.AuthHandler, handleGetCollection)
-		group.POST("/collections/:id/members", web_ui.AuthHandler, handleAddCollectionMembers)
-		group.DELETE("/collections/:id/members", web_ui.AuthHandler, handleRemoveCollectionMembers)
-		group.DELETE("/collections/:id/members/:encoded_object_url", web_ui.AuthHandler, handleRemoveCollectionMember)
-		group.GET("/collections/:id/members", web_ui.AuthHandler, handleListCollectionMembers)
-		group.GET("/collections/:id/metadata", web_ui.AuthHandler, handleGetCollectionMetadata)
-		group.PUT("/collections/:id/metadata/:key", web_ui.AuthHandler, handlePutCollectionMetadata)
-		group.DELETE("/collections/:id/metadata/:key", web_ui.AuthHandler, handleDeleteCollectionMetadata)
-		group.GET("/collections/:id/acl", web_ui.AuthHandler, handleGetCollectionAcls)
-		group.POST("/collections/:id/acl", web_ui.AuthHandler, handleGrantCollectionAcl)
-		group.DELETE("/collections/:id/acl", web_ui.AuthHandler, handleRevokeCollectionAcl)
-
-		group.POST("/groups", web_ui.AuthHandler, handleCreateGroup)
-		group.POST("/groups/:id/members", web_ui.AuthHandler, handleAddGroupMember)
-		group.DELETE("/groups/:id/members", web_ui.AuthHandler, handleRemoveGroupMember)
 	}
 	return nil
 }

--- a/origin/origin_ui.go
+++ b/origin/origin_ui.go
@@ -165,6 +165,27 @@ func RegisterOriginWebAPI(engine *gin.Engine) error {
 	originWebAPI := engine.Group("/api/v1.0/origin_ui", web_ui.ServerHeaderMiddleware)
 	{
 		originWebAPI.GET("/exports", web_ui.AuthHandler, web_ui.AdminAuthHandler, handleExports)
+
+		// Collections API
+		originWebAPI.POST("/collections", web_ui.AuthHandler, handleCreateCollection)
+		originWebAPI.PATCH("/collections/:id", web_ui.AuthHandler, handleUpdateCollection)
+		originWebAPI.DELETE("/collections/:id", web_ui.AuthHandler, handleDeleteCollection)
+		originWebAPI.GET("/collections/:id", web_ui.AuthHandler, handleGetCollection)
+		originWebAPI.POST("/collections/:id/members", web_ui.AuthHandler, handleAddCollectionMembers)
+		originWebAPI.DELETE("/collections/:id/members", web_ui.AuthHandler, handleRemoveCollectionMembers)
+		originWebAPI.DELETE("/collections/:id/members/:encoded_object_url", web_ui.AuthHandler, handleRemoveCollectionMember)
+		originWebAPI.GET("/collections/:id/members", web_ui.AuthHandler, handleListCollectionMembers)
+		originWebAPI.GET("/collections/:id/metadata", web_ui.AuthHandler, handleGetCollectionMetadata)
+		originWebAPI.PUT("/collections/:id/metadata/:key", web_ui.AuthHandler, handlePutCollectionMetadata)
+		originWebAPI.DELETE("/collections/:id/metadata/:key", web_ui.AuthHandler, handleDeleteCollectionMetadata)
+		originWebAPI.GET("/collections/:id/acl", web_ui.AuthHandler, handleGetCollectionAcls)
+		originWebAPI.POST("/collections/:id/acl", web_ui.AuthHandler, handleGrantCollectionAcl)
+		originWebAPI.DELETE("/collections/:id/acl", web_ui.AuthHandler, handleRevokeCollectionAcl)
+
+		// Group Management (Related to Collections)
+		originWebAPI.POST("/groups", web_ui.AuthHandler, handleCreateGroup)
+		originWebAPI.POST("/groups/:id/members", web_ui.AuthHandler, handleAddGroupMember)
+		originWebAPI.DELETE("/groups/:id/members", web_ui.AuthHandler, handleRemoveGroupMember)
 	}
 
 	// Globus backend specific. Config other origin routes above this line

--- a/origin/origin_ui.go
+++ b/origin/origin_ui.go
@@ -167,6 +167,7 @@ func RegisterOriginWebAPI(engine *gin.Engine) error {
 		originWebAPI.GET("/exports", web_ui.AuthHandler, web_ui.AdminAuthHandler, handleExports)
 
 		// Collections API
+		originWebAPI.GET("/collections", web_ui.AuthHandler, handleListCollections)
 		originWebAPI.POST("/collections", web_ui.AuthHandler, handleCreateCollection)
 		originWebAPI.PATCH("/collections/:id", web_ui.AuthHandler, handleUpdateCollection)
 		originWebAPI.DELETE("/collections/:id", web_ui.AuthHandler, handleDeleteCollection)

--- a/origin/origin_ui_test.go
+++ b/origin/origin_ui_test.go
@@ -1,0 +1,534 @@
+package origin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/database"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/test_utils"
+	"github.com/pelicanplatform/pelican/token"
+	"github.com/pelicanplatform/pelican/token_scopes"
+	"github.com/pelicanplatform/pelican/web_ui"
+)
+
+var (
+	tempPasswdFile *os.File
+	router         *gin.Engine
+)
+
+func generateToken(ctx context.Context, scopes []token_scopes.TokenScope, subject string) (string, error) {
+	fedInfo, err := config.GetFederation(ctx)
+	if err != nil {
+		return "", err
+	}
+	tk := token.NewWLCGToken()
+	tk.Issuer = fedInfo.DiscoveryEndpoint
+	tk.Subject = subject
+	tk.Lifetime = 5 * time.Minute
+	tk.AddAudiences(fedInfo.DiscoveryEndpoint)
+	tk.AddScopes(scopes...)
+	tok, err := tk.CreateToken()
+	if err != nil {
+		return "", err
+	}
+	return tok, nil
+}
+
+func generateTokenWithGroups(ctx context.Context, scopes []token_scopes.TokenScope, subject string, groups []string) (string, error) {
+	fedInfo, err := config.GetFederation(ctx)
+	if err != nil {
+		return "", err
+	}
+	tk := token.NewWLCGToken()
+	tk.Issuer = fedInfo.DiscoveryEndpoint
+	tk.Subject = subject
+	tk.Lifetime = 5 * time.Minute
+	tk.AddAudiences(fedInfo.DiscoveryEndpoint)
+	tk.AddScopes(scopes...)
+	tk.AddGroups(groups...)
+	tok, err := tk.CreateToken()
+	if err != nil {
+		return "", err
+	}
+	return tok, nil
+}
+
+func TestCollectionsAPI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	defer func() {
+		if err := egrp.Wait(); err != nil {
+			fmt.Println("Failure when shutting down service:", err)
+			os.Exit(1)
+		}
+	}()
+	defer cancel()
+
+	//set a temporary password file:
+	tempFile, err := os.CreateTemp("", "web-ui-passwd")
+	if err != nil {
+		fmt.Println("Failed to setup web-ui-passwd file")
+		os.Exit(1)
+	}
+	tempPasswdFile = tempFile
+
+	//Override viper default for testing
+	viper.Set("Server.UIPasswordFile", tempPasswdFile.Name())
+
+	//Make a testing issuer.jwk file to get a cookie
+	tempJWKDir, err := os.MkdirTemp("", "tempDir")
+	if err != nil {
+		fmt.Println("Error making temp jwk dir")
+		os.Exit(1)
+	}
+	//Override viper default for testing
+	viper.Set(param.IssuerKeysDirectory.GetName(), filepath.Join(tempJWKDir, "issuer-keys"))
+
+	// Ensure we load up the default configs.
+	dirname, err := os.MkdirTemp("", "tmpDir")
+	if err != nil {
+		fmt.Println("Error making temp config dir")
+		os.Exit(1)
+	}
+	viper.Set("ConfigDir", dirname)
+	viper.Set("Server.UILoginRateLimit", 100)
+
+	// Set up origin exports
+	exportDir, err := os.MkdirTemp("", "test-export")
+	require.NoError(t, err)
+	//The defer call to remove the directory and its contents is commented out because it was causing a race condition with the file watcher.
+	//defer os.RemoveAll(exportDir)
+	err = os.WriteFile(filepath.Join(exportDir, "test-origin"), []byte("test"), 0644)
+	require.NoError(t, err)
+
+	viper.Set("Origin.StorageType", "posix")
+	viper.Set("Origin.Exports", []map[string]interface{}{
+		{
+			"StoragePrefix":    exportDir,
+			"FederationPrefix": "/test1",
+			"SentinelLocation": "test-origin",
+		},
+		{
+			"StoragePrefix":    "/test2",
+			"FederationPrefix": "/test2",
+		},
+	})
+
+	if err := config.InitServer(ctx, server_structs.OriginType); err != nil {
+		fmt.Println("Failed to configure the test module")
+		os.Exit(1)
+	}
+
+	//Get keys
+	_, err = config.GetIssuerPublicJWKS()
+	if err != nil {
+		fmt.Println("Error issuing jwks")
+		os.Exit(1)
+	}
+	router = gin.Default()
+
+	//Configure Web API
+	err = web_ui.ConfigureServerWebAPI(ctx, router, egrp)
+	if err != nil {
+		fmt.Println("Error configuring web UI")
+		os.Exit(1)
+	}
+	err = RegisterOriginWebAPI(router)
+	require.NoError(t, err)
+
+	// set up database
+	mockDB, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	database.ServerDatabase = mockDB
+	require.NoError(t, err, "Error setting up mock origin DB")
+
+	err = database.ServerDatabase.AutoMigrate(&database.Collection{})
+	require.NoError(t, err, "Failed to migrate DB for collections table")
+	err = database.ServerDatabase.AutoMigrate(&database.CollectionMember{})
+	require.NoError(t, err, "Failed to migrate DB for collection members table")
+	err = database.ServerDatabase.AutoMigrate(&database.CollectionMetadata{})
+	require.NoError(t, err, "Failed to migrate DB for collection metadata table")
+	err = database.ServerDatabase.AutoMigrate(&database.CollectionACL{})
+	require.NoError(t, err, "Failed to migrate DB for collection ACLs table")
+	err = database.ServerDatabase.AutoMigrate(&database.Group{})
+	require.NoError(t, err, "Failed to migrate DB for groups table")
+	err = database.ServerDatabase.AutoMigrate(&database.GroupMember{})
+	require.NoError(t, err, "Failed to migrate DB for group members table")
+
+	t.Run("create-delete-collection", func(t *testing.T) {
+		createReq := CreateCollectionReq{
+			Name:        "test",
+			Description: "test",
+			Namespace:   "/test1",
+			Visibility:  "public",
+			Metadata:    map[string]string{"key": "value"},
+		}
+		body, err := json.Marshal(createReq)
+		require.NoError(t, err)
+		req, err := http.NewRequest("POST", "/api/v1.0/origin_ui/collections", bytes.NewReader(body))
+		require.NoError(t, err)
+
+		token, err := generateToken(ctx, []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Create, token_scopes.Collection_Delete}, "test-user")
+		require.NoError(t, err)
+
+		req.AddCookie(&http.Cookie{Name: "login", Value: token})
+		req.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusCreated, recorder.Code)
+
+		var createCollectionResp map[string]string
+		err = json.NewDecoder(recorder.Body).Decode(&createCollectionResp)
+		assert.NoError(t, err)
+		collectionID := createCollectionResp["id"]
+		assert.NotEmpty(t, collectionID)
+
+		// Delete the collection
+		req, err = http.NewRequest("DELETE", "/api/v1.0/origin_ui/collections/"+collectionID, nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: token})
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+	})
+
+	t.Run("create-collection-with-invalid-visibility", func(t *testing.T) {
+		createReq := CreateCollectionReq{
+			Name:        "test-invalid-visibility",
+			Description: "test",
+			Namespace:   "/test1",
+			Visibility:  "invalid",
+			Metadata:    map[string]string{"key": "value"},
+		}
+		body, err := json.Marshal(createReq)
+		require.NoError(t, err)
+		req, err := http.NewRequest("POST", "/api/v1.0/origin_ui/collections", bytes.NewReader(body))
+		require.NoError(t, err)
+
+		token, err := generateToken(ctx, []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Create}, "test-user")
+		require.NoError(t, err)
+
+		req.AddCookie(&http.Cookie{Name: "login", Value: token})
+		req.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	})
+
+	t.Run("create-collection-with-unconfigured-namespace", func(t *testing.T) {
+		createReq := CreateCollectionReq{
+			Name:        "test-unconfigured-namespace",
+			Description: "test",
+			Namespace:   "/unconfigured",
+			Visibility:  "public",
+		}
+		body, err := json.Marshal(createReq)
+		require.NoError(t, err)
+		req, err := http.NewRequest("POST", "/api/v1.0/origin_ui/collections", bytes.NewReader(body))
+		require.NoError(t, err)
+		token, err := generateToken(ctx, []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Create}, "test-user")
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: token})
+		req.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	})
+
+	t.Run("create-collection-without-permission", func(t *testing.T) {
+		createReq := CreateCollectionReq{
+			Name:        "test-no-perms",
+			Description: "test",
+			Namespace:   "/test1",
+			Visibility:  "public",
+		}
+		body, err := json.Marshal(createReq)
+		require.NoError(t, err)
+		req, err := http.NewRequest("POST", "/api/v1.0/origin_ui/collections", bytes.NewReader(body))
+		require.NoError(t, err)
+		token, err := generateToken(ctx, []token_scopes.TokenScope{token_scopes.Monitoring_Query}, "test-user")
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: token})
+		req.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusForbidden, recorder.Code)
+	})
+
+	t.Run("test-collection-lifecycle", func(t *testing.T) {
+		// 1. Create a collection
+		createReq := CreateCollectionReq{
+			Name:        "test-lifecycle",
+			Description: "test lifecycle",
+			Namespace:   "/test1",
+			Visibility:  "public",
+		}
+		body, err := json.Marshal(createReq)
+		require.NoError(t, err)
+		req, err := http.NewRequest("POST", "/api/v1.0/origin_ui/collections", bytes.NewReader(body))
+		require.NoError(t, err)
+
+		token, err := generateToken(ctx, []token_scopes.TokenScope{
+			token_scopes.WebUi_Access,
+			token_scopes.Collection_Create,
+			token_scopes.Collection_Read,
+			token_scopes.Collection_Modify,
+			token_scopes.Collection_Delete},
+			"test-user",
+		)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: token})
+		req.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusCreated, recorder.Code)
+		var createResp map[string]string
+		err = json.NewDecoder(recorder.Body).Decode(&createResp)
+		require.NoError(t, err)
+		collectionID := createResp["id"]
+		require.NotEmpty(t, collectionID)
+
+		// 2. List collections and verify the new one is there
+		req, err = http.NewRequest("GET", "/api/v1.0/origin_ui/collections", nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: token})
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusOK, recorder.Code)
+
+		var listResp []ListCollectionRes
+		err = json.NewDecoder(recorder.Body).Decode(&listResp)
+		require.NoError(t, err)
+		found := false
+		for _, col := range listResp {
+			if col.ID == collectionID {
+				found = true
+				assert.Equal(t, "test-lifecycle", col.Name)
+				break
+			}
+		}
+		assert.True(t, found, "collection was not found in list")
+
+		// 3. Get the specific collection
+		req, err = http.NewRequest("GET", "/api/v1.0/origin_ui/collections/"+collectionID, nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: token})
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		var getResp GetCollectionRes
+		err = json.NewDecoder(recorder.Body).Decode(&getResp)
+		require.NoError(t, err)
+		assert.Equal(t, "test-lifecycle", getResp.Name)
+		assert.Equal(t, "test lifecycle", getResp.Description)
+
+		// 4. Update the collection
+		updatedDesc := "updated description"
+		updateReq := UpdateCollectionReq{
+			Description: &updatedDesc,
+		}
+		body, err = json.Marshal(updateReq)
+		require.NoError(t, err)
+		req, err = http.NewRequest("PATCH", "/api/v1.0/origin_ui/collections/"+collectionID, bytes.NewReader(body))
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: token})
+		req.Header.Set("Content-Type", "application/json")
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+
+		// Verify the update
+		req, err = http.NewRequest("GET", "/api/v1.0/origin_ui/collections/"+collectionID, nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: token})
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		var updatedResp GetCollectionRes
+		err = json.NewDecoder(recorder.Body).Decode(&updatedResp)
+		require.NoError(t, err)
+		assert.Equal(t, "updated description", updatedResp.Description)
+
+		// 5. Delete the collection
+		req, err = http.NewRequest("DELETE", "/api/v1.0/origin_ui/collections/"+collectionID, nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: token})
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+
+		// 6. Verify the collection is gone
+		req, err = http.NewRequest("GET", "/api/v1.0/origin_ui/collections/"+collectionID, nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: token})
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusNotFound, recorder.Code)
+	})
+
+	t.Run("test-collection-acls", func(t *testing.T) {
+		// 1. Create a group
+		groupName := "test-group"
+		createGroupReq := map[string]string{"name": groupName, "description": "test group"}
+		body, err := json.Marshal(createGroupReq)
+		require.NoError(t, err)
+		req, err := http.NewRequest("POST", "/api/v1.0/origin_ui/groups", bytes.NewReader(body))
+		require.NoError(t, err)
+
+		adminToken, err := generateToken(ctx, []token_scopes.TokenScope{token_scopes.WebUi_Access}, "admin")
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: adminToken})
+		req.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusCreated, recorder.Code)
+		var createGroupResp map[string]string
+		err = json.NewDecoder(recorder.Body).Decode(&createGroupResp)
+		require.NoError(t, err)
+		groupID := createGroupResp["id"]
+		require.NotEmpty(t, groupID)
+
+		// 2. Create a private collection
+		createColReq := CreateCollectionReq{
+			Name:       "test-private-collection",
+			Namespace:  "/test1",
+			Visibility: "private",
+		}
+		body, err = json.Marshal(createColReq)
+		require.NoError(t, err)
+		req, err = http.NewRequest("POST", "/api/v1.0/origin_ui/collections", bytes.NewReader(body))
+		require.NoError(t, err)
+		createToken, err := generateTokenWithGroups(ctx, []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Create}, "test-user-owner", []string{groupName})
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: createToken})
+		req.Header.Set("Content-Type", "application/json")
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusCreated, recorder.Code)
+		var createColResp map[string]string
+		err = json.NewDecoder(recorder.Body).Decode(&createColResp)
+		require.NoError(t, err)
+		collectionID := createColResp["id"]
+		require.NotEmpty(t, collectionID)
+
+		// 3. Grant the group read access to the collection
+		grantAclReq := map[string]string{"group_id": groupID, "role": "read"}
+		body, err = json.Marshal(grantAclReq)
+		require.NoError(t, err)
+		req, err = http.NewRequest("POST", "/api/v1.0/origin_ui/collections/"+collectionID+"/acl", bytes.NewReader(body))
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: createToken}) // The owner grants the ACL
+		req.Header.Set("Content-Type", "application/json")
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusNoContent, recorder.Code)
+
+		// 4. A user not in the group cannot read the collection
+		rogueToken, err := generateTokenWithGroups(ctx, []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Read}, "rogue-user", []string{"some-other-group"})
+		require.NoError(t, err)
+		req, err = http.NewRequest("GET", "/api/v1.0/origin_ui/collections/"+collectionID, nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: rogueToken})
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusNotFound, recorder.Code)
+
+		// 5. A user in the group can read the collection
+		groupToken, err := generateTokenWithGroups(ctx, []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Read}, "group-user", []string{groupName})
+		require.NoError(t, err)
+		req, err = http.NewRequest("GET", "/api/v1.0/origin_ui/collections/"+collectionID, nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: groupToken})
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusOK, recorder.Code)
+
+		// 6. Grant the group write access to the collection
+		grantAclReq = map[string]string{"group_id": groupID, "role": "write"}
+		body, err = json.Marshal(grantAclReq)
+		require.NoError(t, err)
+		req, err = http.NewRequest("POST", "/api/v1.0/origin_ui/collections/"+collectionID+"/acl", bytes.NewReader(body))
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: createToken}) // The owner grants the ACL
+		req.Header.Set("Content-Type", "application/json")
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusNoContent, recorder.Code)
+
+		// 7. A user not in the group cannot update the collection
+		updatedDesc := "rogue update"
+		updateReq := UpdateCollectionReq{Description: &updatedDesc}
+		body, err = json.Marshal(updateReq)
+		require.NoError(t, err)
+		req, err = http.NewRequest("PATCH", "/api/v1.0/origin_ui/collections/"+collectionID, bytes.NewReader(body))
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: rogueToken})
+		req.Header.Set("Content-Type", "application/json")
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusNotFound, recorder.Code)
+
+		// 8. A user in the group can update the collection
+		updatedDesc = "group update"
+		updateReq = UpdateCollectionReq{Description: &updatedDesc}
+		body, err = json.Marshal(updateReq)
+		require.NoError(t, err)
+		req, err = http.NewRequest("PATCH", "/api/v1.0/origin_ui/collections/"+collectionID, bytes.NewReader(body))
+		require.NoError(t, err)
+		groupWriteToken, err := generateTokenWithGroups(ctx, []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Modify}, "group-user-write", []string{groupName})
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: groupWriteToken})
+		req.Header.Set("Content-Type", "application/json")
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+
+		// 9. Grant the group owner access to the collection
+		grantAclReq = map[string]string{"group_id": groupID, "role": "owner"}
+		body, err = json.Marshal(grantAclReq)
+		require.NoError(t, err)
+		req, err = http.NewRequest("POST", "/api/v1.0/origin_ui/collections/"+collectionID+"/acl", bytes.NewReader(body))
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: createToken}) // The owner grants the ACL
+		req.Header.Set("Content-Type", "application/json")
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		require.Equal(t, http.StatusNoContent, recorder.Code)
+
+		// 10. A user not in the group cannot delete the collection
+		req, err = http.NewRequest("DELETE", "/api/v1.0/origin_ui/collections/"+collectionID, nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: rogueToken})
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusNotFound, recorder.Code)
+
+		// 11. A user in the group can delete the collection
+		groupOwnerToken, err := generateTokenWithGroups(ctx, []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Delete}, "group-user-owner", []string{groupName})
+		require.NoError(t, err)
+		req, err = http.NewRequest("DELETE", "/api/v1.0/origin_ui/collections/"+collectionID, nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "login", Value: groupOwnerToken})
+		recorder = httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+	})
+}

--- a/origin/origin_ui_test.go
+++ b/origin/origin_ui_test.go
@@ -416,7 +416,7 @@ func TestCollectionsAPI(t *testing.T) {
 		require.NoError(t, err)
 		req, err = http.NewRequest("POST", "/api/v1.0/origin_ui/collections", bytes.NewReader(body))
 		require.NoError(t, err)
-		createToken, err := generateTokenWithGroups(ctx, []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Create}, "test-user-owner", []string{groupName})
+		createToken, err := generateTokenWithGroups(ctx, []token_scopes.TokenScope{token_scopes.WebUi_Access, token_scopes.Collection_Create, token_scopes.Collection_Delete}, "test-user-owner", []string{groupName})
 		require.NoError(t, err)
 		req.AddCookie(&http.Cookie{Name: "login", Value: createToken})
 		req.Header.Set("Content-Type", "application/json")

--- a/token_scopes/token_scopes.go
+++ b/token_scopes/token_scopes.go
@@ -40,6 +40,10 @@ const (
 	Broker_Retrieve TokenScope = "broker.retrieve"
 	Broker_Callback TokenScope = "broker.callback"
 	Localcache_Purge TokenScope = "localcache.purge"
+	Collection_Create TokenScope = "collection.create"
+	Collection_Read TokenScope = "collection.read"
+	Collection_Modify TokenScope = "collection.modify"
+	Collection_Delete TokenScope = "collection.delete"
 
 	// WLCG Scopes
 	Wlcg_Storage_Read TokenScope = "storage.read"


### PR DESCRIPTION
This PR introduces a collection management API. A collection is a named, mutable grouping of logically related objects. While collections can be created, modified, or deleted, the objects within them remain immutable, modifying a collection does not alter the underlying data, only the grouping and associated metadata. Collections provide a way for users (especially researchers) to group related data without enforcing physical co-location or tight namespace coupling. A collection is analogous to an S3 bucket, but is decoupled from the object namespace: the same object may belong to multiple collections. Collection access is managed by groups. Groups are the principals that appear in a Collection's ACLs. A collection may grant different roles to many groups and a single group may appear in many collections. A group is composed of a set of accounts. Every user also has an implicit personal group called user-<username>.