### PR TITLE
Add work flow to close stale issues

### DIFF
--- a/.github/workflows/enforce-issue-labelling.yml
+++ b/.github/workflows/enforce-issue-labelling.yml
@@ -6,27 +6,37 @@ on:
 
 jobs:
   validate-issue:
+    # 1. Don’t even start the job when the stale-bot did the closing **or**
+    #    when the issue already bears the `stale` label.
+    if: |
+      github.actor != 'github-actions[bot]' &&
+      !contains(join(github.event.issue.labels.*.name, ','), 'stale')
+
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Validate issue has labels
+      - name: Validate that the closed issue still has at least one label
         id: check_labels
         run: |
-          ISSUE_LABELS=$(jq -r '.issue.labels | length' $GITHUB_EVENT_PATH)
-          if [ "$ISSUE_LABELS" -eq "0" ]; then
-            echo "No labels found on the issue."
-            # Re-open the issue
-            ISSUE_NUMBER=$(jq -r '.issue.number' $GITHUB_EVENT_PATH)
-            REPO_OWNER=$(jq -r '.repository.owner.login' $GITHUB_EVENT_PATH)
-            REPO_NAME=$(jq -r '.repository.name' $GITHUB_EVENT_PATH)
-            curl -L \
-              -X PATCH \
-              -H "Accept: application/vnd.github.v3+json" \
+          # 2. Extra safety-net: bail out quietly if the stale label is present
+          if jq -e '.issue.labels[] | select(.name=="stale")' "$GITHUB_EVENT_PATH" > /dev/null; then
+            echo "Closed by stale-bot – skipping label check."
+            exit 0
+          fi
+
+          LABEL_COUNT=$(jq -r '.issue.labels | length' "$GITHUB_EVENT_PATH")
+          if [ "$LABEL_COUNT" -eq 0 ]; then
+            echo "No labels found – reopening."
+            ISSUE_NUMBER=$(jq -r '.issue.number' "$GITHUB_EVENT_PATH")
+            OWNER=$(jq -r '.repository.owner.login' "$GITHUB_EVENT_PATH")
+            REPO=$(jq -r '.repository.name' "$GITHUB_EVENT_PATH")
+
+            curl -sSL -X PATCH \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/issues/$ISSUE_NUMBER \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$OWNER/$REPO/issues/$ISSUE_NUMBER" \
               -d '{"state":"open"}'
             exit 1
           fi

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,23 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "00 00 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 30
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 60 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 30 days since being marked as stale."
+          operations-per-run: 100
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR address issue #2551. This PR adds a Github action workflow to close stale issues. Issues are automatically marked with a `stale` label after 60 days of no activity. They can also be closed if it has been inactive for 30 days since being marked as stale.