### PR TITLE
Add configuration to enable cache eviction monitoring

### DIFF
--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -70,6 +70,7 @@ Cache:
   HighWaterMark: 95
   BlocksToPrefetch: 0
   EnableTLSClientAuth: false
+  EnableEvictionMonitoring: true
 Lotman:
   EnabledPolicy: "fairshare"
   DefaultLotExpirationLifetime: "2016h"

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1685,6 +1685,7 @@ components: ["cache"]
 name: Cache.EnableEvictionMonitoring
 description: |+
   Enable cache eviction monitoring.
+  The cache eviction monitoring data includes information like the total space available, the space used, and the space used by each namespace.
 type: bool
 default: true
 components: ["cache"]
@@ -1692,7 +1693,6 @@ components: ["cache"]
 name: Cache.EvictionMonitoringInterval
 description: |+
   The interval at which the eviction monitoring will be reported.
-  The cache eviction monitoring data includes information like the total space available, the space used, and the space used by each namespace.
   Valid values are 60, 300, 600, 900, 1800, 3600.
 type: duration
 default: 60s

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1682,6 +1682,13 @@ type: filename
 default: $ConfigBase/cache-fed-token
 components: ["cache"]
 ---
+name: Cache.EnableEvictionMonitoring
+description: |+
+  Enable cache eviction monitoring.
+type: bool
+default: true
+components: ["cache"]
+---
 name: Cache.EvictionMonitoringInterval
 description: |+
   The interval at which the eviction monitoring will be reported.

--- a/fed_test_utils/fed.go
+++ b/fed_test_utils/fed.go
@@ -168,6 +168,7 @@ func NewFedTest(t *testing.T, originConfig string) (ft *FedTest) {
 	viper.Set(param.Cache_DbLocation.GetName(), filepath.Join(t.TempDir(), "cache.sqlite"))
 	viper.Set(param.Server_EnableUI.GetName(), false)
 	viper.Set(param.Server_WebPort.GetName(), ports[2])
+	viper.Set(param.Cache_EnableEvictionMonitoring.GetName(), false)
 	// Unix domain sockets have a maximum length of 108 bytes, so we need to make sure our
 	// socket path is short enough to fit within that limit. Mac OS X has long temporary path
 	// names, so we need to make sure our socket path is short enough to fit within that limit.

--- a/launchers/cache_serve.go
+++ b/launchers/cache_serve.go
@@ -107,7 +107,9 @@ func CacheServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, m
 
 	cache.LaunchFedTokManager(ctx, egrp, cacheServer)
 
-	metrics.LaunchXrootdCacheEvictionMonitoring(ctx, egrp)
+	if param.Cache_EnableEvictionMonitoring.GetBool() {
+		metrics.LaunchXrootdCacheEvictionMonitoring(ctx, egrp)
+	}
 
 	concLimit := param.Cache_Concurrency.GetInt()
 	if concLimit > 0 {

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -357,6 +357,7 @@ var (
 
 var (
 	Cache_EnableBroker = BoolParam{"Cache.EnableBroker"}
+	Cache_EnableEvictionMonitoring = BoolParam{"Cache.EnableEvictionMonitoring"}
 	Cache_EnableLotman = BoolParam{"Cache.EnableLotman"}
 	Cache_EnableOIDC = BoolParam{"Cache.EnableOIDC"}
 	Cache_EnablePrefetch = BoolParam{"Cache.EnablePrefetch"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -32,6 +32,7 @@ type Config struct {
 		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
 		DefaultCacheTimeout time.Duration `mapstructure:"defaultcachetimeout" yaml:"DefaultCacheTimeout"`
 		EnableBroker bool `mapstructure:"enablebroker" yaml:"EnableBroker"`
+		EnableEvictionMonitoring bool `mapstructure:"enableevictionmonitoring" yaml:"EnableEvictionMonitoring"`
 		EnableLotman bool `mapstructure:"enablelotman" yaml:"EnableLotman"`
 		EnableOIDC bool `mapstructure:"enableoidc" yaml:"EnableOIDC"`
 		EnablePrefetch bool `mapstructure:"enableprefetch" yaml:"EnablePrefetch"`
@@ -395,6 +396,7 @@ type configWithType struct {
 		DbLocation struct { Type string; Value string }
 		DefaultCacheTimeout struct { Type string; Value time.Duration }
 		EnableBroker struct { Type string; Value bool }
+		EnableEvictionMonitoring struct { Type string; Value bool }
 		EnableLotman struct { Type string; Value bool }
 		EnableOIDC struct { Type string; Value bool }
 		EnablePrefetch struct { Type string; Value bool }


### PR DESCRIPTION
This PR adds a new configuration parameter `Cache.EnableEvictionMonitoring`. This will allow an operator to enable/disable cache eviction monitoring. We also disable the monitoring in the fed tests.