### PR TITLE
Print pelican version to stdout when --debug is provided

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1937,6 +1937,7 @@ func InitClient() error {
 	var printClientConfigErr error
 	printClientConfigOnce.Do(func() {
 		if log.GetLevel() == log.DebugLevel {
+			PrintPelicanVersion(os.Stdout)
 			printClientConfigErr = PrintClientConfig()
 		}
 	})


### PR DESCRIPTION
This PR addresses issue #2507. This PR does exactly what the title says.