### PR TITLE
Restart Pelican when SIGHUP is received

### DIFF
--- a/daemon/launch_unix.go
+++ b/daemon/launch_unix.go
@@ -213,7 +213,7 @@ func LaunchDaemons(ctx context.Context, launchers []Launcher, egrp *errgroup.Gro
 	}
 
 	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 	cases := make([]reflect.SelectCase, len(daemons)+2)
 	for idx, daemon := range daemons {
 		cases[idx].Dir = reflect.SelectRecv

--- a/daemon/launch_unix.go
+++ b/daemon/launch_unix.go
@@ -239,6 +239,10 @@ func LaunchDaemons(ctx context.Context, launchers []Launcher, egrp *errgroup.Gro
 					log.Warnf("Received SIGTERM, pausing the signal forwarding to daemons for %s", param.Xrootd_ShutdownTimeout.GetDuration().String())
 					time.Sleep(param.Xrootd_ShutdownTimeout.GetDuration())
 				}
+				if sys_sig == syscall.SIGHUP {
+					log.Warnf("Received SIGHUP, reloading the daemons for %s", param.Xrootd_ShutdownTimeout.GetDuration().String())
+					time.Sleep(param.Xrootd_ShutdownTimeout.GetDuration())
+				}
 				log.Warnf("Forwarding signal %v to daemons\n", sys_sig)
 				var lastErr error
 				for idx := range daemons {


### PR DESCRIPTION
This PR addresses issue #2565. This PR makes it so, when Pelican receives a SIGHUP, the process will restart.