### PR TITLE
Set `http.maxwait` in XRootD configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1044,7 +1044,7 @@ func SetServerDefaults(v *viper.Viper) error {
 	v.SetDefault(param.Xrootd_Authfile.GetName(), filepath.Join(configDir, "xrootd", "authfile"))
 	v.SetDefault(param.Xrootd_MacaroonsKeyFile.GetName(), filepath.Join(configDir, "macaroons-secret"))
 	v.SetDefault(param.Xrootd_ShutdownTimeout.GetName(), 1*time.Minute)
-	v.SetDefault(param.Xrootd_HttpMaxDelay.GetName(), 9*time.Second)
+	v.SetDefault(param.Xrootd_HttpMaxDelay.GetName(), "9s")
 	v.SetDefault(param.Cache_EvictionMonitoringInterval.GetName(), 60)
 	v.SetDefault(param.Cache_EvictionMonitoringMaxDepth.GetName(), 1)
 	v.SetDefault(param.IssuerKey.GetName(), filepath.Join(configDir, "issuer.jwk"))

--- a/config/config.go
+++ b/config/config.go
@@ -1044,6 +1044,7 @@ func SetServerDefaults(v *viper.Viper) error {
 	v.SetDefault(param.Xrootd_Authfile.GetName(), filepath.Join(configDir, "xrootd", "authfile"))
 	v.SetDefault(param.Xrootd_MacaroonsKeyFile.GetName(), filepath.Join(configDir, "macaroons-secret"))
 	v.SetDefault(param.Xrootd_ShutdownTimeout.GetName(), 1*time.Minute)
+	v.SetDefault(param.Xrootd_HttpMaxDelay.GetName(), 9*time.Second)
 	v.SetDefault(param.Cache_EvictionMonitoringInterval.GetName(), 60)
 	v.SetDefault(param.Cache_EvictionMonitoringMaxDepth.GetName(), 1)
 	v.SetDefault(param.IssuerKey.GetName(), filepath.Join(configDir, "issuer.jwk"))

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2959,6 +2959,7 @@ description: |+
     - 12s: client times out first; the server stops retrying shortly after, reducing load.
 type: duration
 default: 9s
+hidden: true
 components: ["origin", "cache"]
 ---
 ############################

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2946,6 +2946,21 @@ type: duration
 default: 1m
 components: ["origin", "cache"]
 ---
+name: Xrootd.HttpMaxDelay
+description: |+
+  Configures the maximum amount of time the XRootD HTTP layer will continue internal retries
+  when a file open fails. XRootD retries every 3s until this limit is reached; once exceeded,
+  the request fails (typically with HTTP 500 / Internal Error).
+
+  The historical behavior is to retry for up to an hour, which can create server-side backlogs
+  when clients have much shorter timeouts. Set this to a small duration to avoid queue buildup.
+  With a 10s client timeout, common choices are:
+    - 9s: client likely still receives an HTTP 500 response before its own timeout.
+    - 12s: client times out first; the server stops retrying shortly after, reducing load.
+type: duration
+default: 9s
+components: ["origin", "cache"]
+---
 ############################
 # Monitoring-level configs #
 ############################

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -459,6 +459,7 @@ var (
 	Transport_ResponseHeaderTimeout = DurationParam{"Transport.ResponseHeaderTimeout"}
 	Transport_TLSHandshakeTimeout = DurationParam{"Transport.TLSHandshakeTimeout"}
 	Xrootd_AuthRefreshInterval = DurationParam{"Xrootd.AuthRefreshInterval"}
+	Xrootd_HttpMaxDelay = DurationParam{"Xrootd.HttpMaxDelay"}
 	Xrootd_MaxStartupWait = DurationParam{"Xrootd.MaxStartupWait"}
 	Xrootd_ShutdownTimeout = DurationParam{"Xrootd.ShutdownTimeout"}
 )

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -369,6 +369,7 @@ type Config struct {
 		DetailedMonitoringHost string `mapstructure:"detailedmonitoringhost" yaml:"DetailedMonitoringHost"`
 		DetailedMonitoringPort int `mapstructure:"detailedmonitoringport" yaml:"DetailedMonitoringPort"`
 		EnableLocalMonitoring bool `mapstructure:"enablelocalmonitoring" yaml:"EnableLocalMonitoring"`
+		HttpMaxDelay time.Duration `mapstructure:"httpmaxdelay" yaml:"HttpMaxDelay"`
 		LocalMonitoringHost string `mapstructure:"localmonitoringhost" yaml:"LocalMonitoringHost"`
 		MacaroonsKeyFile string `mapstructure:"macaroonskeyfile" yaml:"MacaroonsKeyFile"`
 		ManagerHost string `mapstructure:"managerhost" yaml:"ManagerHost"`
@@ -733,6 +734,7 @@ type configWithType struct {
 		DetailedMonitoringHost struct { Type string; Value string }
 		DetailedMonitoringPort struct { Type string; Value int }
 		EnableLocalMonitoring struct { Type string; Value bool }
+		HttpMaxDelay struct { Type string; Value time.Duration }
 		LocalMonitoringHost struct { Type string; Value string }
 		MacaroonsKeyFile struct { Type string; Value string }
 		ManagerHost struct { Type string; Value string }

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -99,6 +99,9 @@ http.trace {{.Logging.CacheHttp}}
 {{if .Xrootd.ConfigFile}}
 continue {{.Xrootd.ConfigFile}}
 {{end}}
+
+http.maxdelay {{.Xrootd.HttpMaxDelay}}
+
 # Add in http headers to make the web client capable of requesting resources
 http.staticheader -verb=OPTIONS Access-Control-Allow-Origin *
 http.staticheader -verb=OPTIONS Access-Control-Allow-Methods GET,PUT,PROPFIND

--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -135,6 +135,8 @@ xrootd.tls all
 xrd.network nodnr
 scitokens.trace {{.Logging.OriginScitokens}}
 
+http.maxdelay {{.Xrootd.HttpMaxDelay}}
+
 {{- if .Xrootd.ConfigFile}}
 # Continue onto the next set of configuration
 continue {{.Xrootd.ConfigFile}}


### PR DESCRIPTION
This PR addresses issue #2571. This PR introduces a new configuration parameter, `Xrootd.HttpMaxDelay`. The default value is configured to be 9 seconds. This new configuration is added to both the origin and the cache.