### PR TITLE
Fixed an issue where the Cache.Url port was being overwritten if set

### DIFF
--- a/launchers/cache_serve.go
+++ b/launchers/cache_serve.go
@@ -138,8 +138,11 @@ func CacheServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, m
 
 	portStartCallback := func(port int) {
 		viper.Set("Cache.Port", port)
-		if cacheUrl, err := url.Parse(param.Origin_Url.GetString()); err == nil {
-			cacheUrl.Host = cacheUrl.Hostname() + ":" + strconv.Itoa(port)
+		if cacheUrl, err := url.Parse(param.Cache_Url.GetString()); err == nil {
+			if cacheUrl.Port() == "" {
+				cacheUrl.Host = cacheUrl.Hostname() + ":" + strconv.Itoa(port)
+			}
+
 			viper.Set("Cache.Url", cacheUrl.String())
 			log.Debugln("Resetting Cache.Url to", cacheUrl.String())
 		}


### PR DESCRIPTION
-- If Cache.Url is set and Cache.Port is also set, Cache.Port only overwrites Cache.Url's port if Cache.Url doesn't have a port set 
-- Also, now uses Cache.Url instead of Origin.Url