### PR TITLE
Bump xrdcl-pelican version to 1.5.1

### DIFF
--- a/github_scripts/osx_install.sh
+++ b/github_scripts/osx_install.sh
@@ -54,7 +54,7 @@ ninja
 ninja install
 popd
 
-git clone --branch v1.4.2 https://github.com/PelicanPlatform/xrdcl-pelican.git
+git clone --branch v1.5.1 https://github.com/PelicanPlatform/xrdcl-pelican.git
 pushd xrdcl-pelican
 mkdir build
 cd build

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -57,7 +57,7 @@ ARG LOTMAN_VER=0.0.4
 # Until the two places are programmatically synchronized, please double-check by hand
 # when doing version changes.
 ARG XRDCL_PELICAN_SRC_BUILD=false
-ARG XRDCL_PELICAN_VER=1.4.2
+ARG XRDCL_PELICAN_VER=1.5.1
 ARG XRDHTTP_PELICAN_SRC_BUILD=false
 ARG XRDHTTP_PELICAN_VER=0.0.7
 ARG XROOTD_LOTMAN_SRC_BUILD=false


### PR DESCRIPTION
Bumps xrdcl-pelican to 1.5.1 (for the 7.19 release)