### PR TITLE
Make XRootD max threads configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1045,6 +1045,7 @@ func SetServerDefaults(v *viper.Viper) error {
 	v.SetDefault(param.Xrootd_MacaroonsKeyFile.GetName(), filepath.Join(configDir, "macaroons-secret"))
 	v.SetDefault(param.Xrootd_ShutdownTimeout.GetName(), 1*time.Minute)
 	v.SetDefault(param.Xrootd_HttpMaxDelay.GetName(), "9s")
+	v.SetDefault(param.Xrootd_MaxThreads.GetName(), 20000)
 	v.SetDefault(param.Cache_EvictionMonitoringInterval.GetName(), 60)
 	v.SetDefault(param.Cache_EvictionMonitoringMaxDepth.GetName(), 1)
 	v.SetDefault(param.IssuerKey.GetName(), filepath.Join(configDir, "issuer.jwk"))

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2962,6 +2962,14 @@ default: 9s
 hidden: true
 components: ["origin", "cache"]
 ---
+name: Xrootd.MaxThreads
+description: |+
+  The maximum number of threads that XRootD will use. See the XRootD [documentation](https://xrootd.web.cern.ch/doc/dev6/xrd_config.htm#_sched) for more information.
+type: int
+default: 20000
+components: ["origin", "cache"]
+hidden: true
+---
 ############################
 # Monitoring-level configs #
 ############################

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -351,6 +351,7 @@ var (
 	Transport_MaxIdleConns = IntParam{"Transport.MaxIdleConns"}
 	Xrootd_DetailedMonitoringPort = IntParam{"Xrootd.DetailedMonitoringPort"}
 	Xrootd_ManagerPort = IntParam{"Xrootd.ManagerPort"}
+	Xrootd_MaxThreads = IntParam{"Xrootd.MaxThreads"}
 	Xrootd_Port = IntParam{"Xrootd.Port"}
 	Xrootd_SummaryMonitoringPort = IntParam{"Xrootd.SummaryMonitoringPort"}
 )

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -375,6 +375,7 @@ type Config struct {
 		ManagerHost string `mapstructure:"managerhost" yaml:"ManagerHost"`
 		ManagerPort int `mapstructure:"managerport" yaml:"ManagerPort"`
 		MaxStartupWait time.Duration `mapstructure:"maxstartupwait" yaml:"MaxStartupWait"`
+		MaxThreads int `mapstructure:"maxthreads" yaml:"MaxThreads"`
 		Mount string `mapstructure:"mount" yaml:"Mount"`
 		Port int `mapstructure:"port" yaml:"Port"`
 		RobotsTxtFile string `mapstructure:"robotstxtfile" yaml:"RobotsTxtFile"`
@@ -740,6 +741,7 @@ type configWithType struct {
 		ManagerHost struct { Type string; Value string }
 		ManagerPort struct { Type string; Value int }
 		MaxStartupWait struct { Type string; Value time.Duration }
+		MaxThreads struct { Type string; Value int }
 		Mount struct { Type string; Value string }
 		Port struct { Type string; Value int }
 		RobotsTxtFile struct { Type string; Value string }

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -56,6 +56,7 @@ acc.authrefresh {{.Xrootd.AuthRefreshInterval}}
 ofs.authlib ++ libXrdAccSciTokens.so config={{.Cache.RunLocation}}/scitokens-cache-generated.cfg
 all.export {{.Cache.ExportLocation}}
 xrootd.chksum max 2 md5 adler32 crc32 crc32c
+xrd.sched maxt {{.Xrootd.MaxThreads}}
 xrootd.trace emsg login stall redirect
 xrootd.tls all
 xrd.network nodnr

--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -125,6 +125,7 @@ http.exthandler xrdpelican libXrdHttpPelican.so
 {{- end}}
 xrootd.fslib ++ throttle  # throttle plugin is needed to calculate server IO load
 xrootd.chksum max 10 md5 adler32 crc32 crc32c
+xrd.sched maxt {{.Xrootd.MaxThreads}}
 xrootd.trace {{.Logging.OriginXrootd}}
 ofs.trace {{.Logging.OriginOfs}}
 oss.trace {{.Logging.OriginOss}}

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -168,6 +168,7 @@ type (
 		Mount                  string
 		LocalMonitoringPort    int
 		HttpMaxDelay           int
+		MaxThreads             int
 	}
 
 	ServerConfig struct {


### PR DESCRIPTION
This PR addresses issue #2583. This PR adds a new configuration parameter `Xrootd.MaxThreads`. This value is defaulted to 20,000. 