### PR TITLE
Fix duplicate name handling in the registration process

### DIFF
--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -100,6 +100,9 @@ func Setup(t *testing.T, ctx context.Context, egrp *errgroup.Group) {
 		Prefix:   "/caches/" + param.Server_Hostname.GetString(),
 		Pubkey:   string(keysetBytes),
 		Identity: "test_data",
+		AdminMetadata: server_structs.AdminMetadata{
+			SiteName: "Test-Site-Name",
+		},
 	})
 	require.NoError(t, err)
 	err = registry.AddRegistration(&server_structs.Registration{
@@ -107,6 +110,9 @@ func Setup(t *testing.T, ctx context.Context, egrp *errgroup.Group) {
 		Prefix:   "/foo",
 		Pubkey:   string(keysetBytes),
 		Identity: "test_data",
+		AdminMetadata: server_structs.AdminMetadata{
+			SiteName: "Test-Site-Name",
+		},
 	})
 	require.NoError(t, err)
 

--- a/registry/client_commands_test.go
+++ b/registry/client_commands_test.go
@@ -403,20 +403,20 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start by registering /foo/bar with the default key
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar", "test-site-name")
 	require.NoError(t, err)
 
 	// Perform one test with a subspace and the same key -- should succeed
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/test", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/test", "test-site-name")
 	require.NoError(t, err)
 
 	// If the namespace is a subspace from the topology and is registered without the identity
 	// we deny it
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo/foo/bar", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo/foo/bar", "test-site-name")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "A superspace or subspace of this namespace /topo/foo/bar already exists in the OSDF topology: /topo/foo. To register a Pelican equivalence, you need to present your identity.")
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo/foo", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo/foo", "test-site-name")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "A superspace or subspace of this namespace /topo/foo already exists in the OSDF topology: /topo/foo. To register a Pelican equivalence, you need to present your identity.")
 
@@ -433,28 +433,28 @@ func TestRegistryKeyChainingOSDF(t *testing.T) {
 	_, err = config.GetIssuerPublicJWKS()
 	require.NoError(t, err)
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/baz", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/baz", "test-site-name")
 	require.ErrorContains(t, err, "Cannot register a namespace that is suffixed or prefixed")
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo", "test-site-name")
 	require.ErrorContains(t, err, "Cannot register a namespace that is suffixed or prefixed")
 
 	// Make sure we can register things similar but distinct in prefix and suffix
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/fo", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/fo", "test-site-name")
 	require.NoError(t, err)
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/barz", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/barz", "test-site-name")
 	require.NoError(t, err)
 
 	// Now turn off token chaining and retry -- no errors should occur
 	viper.Set("Registry.RequireKeyChaining", false)
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/baz", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/baz", "test-site-name")
 	require.NoError(t, err)
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo", "test-site-name")
 	require.NoError(t, err)
 
 	// However, topology check should be independent of key chaining check
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/topo", "test-site-name")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "A superspace or subspace of this namespace /topo already exists in the OSDF topology: /topo/foo. To register a Pelican equivalence, you need to present your identity.")
 
@@ -494,11 +494,11 @@ func TestRegistryKeyChaining(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start by registering /foo/bar with the default key
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar", "test-site-name")
 	require.NoError(t, err)
 
 	// Perform one test with a subspace and the same key -- should succeed
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/test", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/test", "test-site-name")
 	require.NoError(t, err)
 
 	// Now we create a new key and try to use it to register a super/sub space. These shouldn't succeed
@@ -512,17 +512,17 @@ func TestRegistryKeyChaining(t *testing.T) {
 	_, err = config.GetIssuerPublicJWKS()
 	require.NoError(t, err)
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/baz", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/baz", "test-site-name")
 	require.ErrorContains(t, err, "Cannot register a namespace that is suffixed or prefixed")
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo", "test-site-name")
 	require.ErrorContains(t, err, "Cannot register a namespace that is suffixed or prefixed")
 
 	// Now turn off token chaining and retry -- no errors should occur
 	viper.Set("Registry.RequireKeyChaining", false)
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/baz", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo/bar/baz", "test-site-name")
 	require.NoError(t, err)
 
-	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo", "")
+	err = NamespaceRegister(privKey, registrySvr.URL+"/api/v1.0/registry", "", "/foo", "test-site-name")
 	require.NoError(t, err)
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -230,7 +230,7 @@ func verifyServerOwnership(existingServer *server_structs.ServerRegistration, da
 		return false, err
 	}
 
-	// Use direct key access instead of iterator since iterator isn't finding any keys
+	// Iterate through all keys in the server's keyset recorded in Registry to find one that can verify the client signature
 	for i := 0; i < existingKeySet.Len(); i++ {
 		key, exists := existingKeySet.Key(i)
 		if !exists {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -48,6 +48,7 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/oauth2"
@@ -207,6 +208,48 @@ func verifySignature(payload []byte, signature []byte, publicKey *ecdsa.PublicKe
 	return ecdsa.VerifyASN1(publicKey, hash[:], signature)
 }
 
+// When a request wants to register a new service (Origin/Cache) on an existing server,
+// we need to verify they are allowed to do so by checking if the signature they present can be verified by the existing server's keyset
+func verifyServerOwnership(existingServer *server_structs.ServerRegistration, data *registrationData) (bool, error) {
+	if existingServer == nil || len(existingServer.Registration) == 0 {
+		return false, errors.New("no existing registrations to verify against")
+	}
+
+	// Parse existing server's public key
+	// When one server has multiple services, they all share the same public key(s), so we just need to check the first registration
+	existingKeySet, err := jwk.ParseString(existingServer.Registration[0].Pubkey)
+	if err != nil {
+		return false, err
+	}
+
+	// If the signature in the request could be verified by any of the keys in the existing server's keyset,
+	// then we consider whoever send this request is the owner of the existing server
+	clientPayload := []byte(data.ClientNonce + data.ServerNonce)
+	clientSignature, err := hex.DecodeString(data.ClientSignature)
+	if err != nil {
+		return false, err
+	}
+	ctx := context.Background()
+	it := existingKeySet.Iterate(ctx)
+	for it.Next(ctx) {
+		pair := it.Pair()
+		key, ok := pair.Value.(jwk.Key)
+		if !ok {
+			continue
+		}
+		var rawkey interface{}
+		if err := key.Raw(&rawkey); err != nil {
+			return false, err
+		}
+
+		verified := verifySignature(clientPayload, clientSignature, (rawkey).(*ecdsa.PublicKey))
+		if verified {
+			return true, nil // Stop iteration
+		}
+	}
+	return false, nil
+}
+
 // Generate server nonce for key-sign challenge
 func keySignChallengeInit(data *registrationData) (map[string]interface{}, error) {
 	serverNonce, err := generateNonce()
@@ -306,6 +349,28 @@ func keySignChallengeCommit(ctx *gin.Context, data *registrationData) (bool, map
 		}
 		log.Infof("Skipping registration of prefix %s because it's already registered.", data.Prefix)
 		return false, returnMsg, nil
+	}
+
+	// For a server registration attempt, check if the site name is duplicated
+	isOrigin := strings.HasPrefix(data.Prefix, server_structs.OriginPrefix.String())
+	isCache := strings.HasPrefix(data.Prefix, server_structs.CachePrefix.String())
+	if isOrigin || isCache {
+		existingServer, err := getServerByName(strings.TrimSpace(data.SiteName))
+		if err != nil {
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				return false, nil, errors.Wrapf(err, "failed to check for existing server %q", data.SiteName)
+			}
+			// Record not found, continue with registration
+		} else if existingServer != nil && existingServer.ID != "" {
+			// Server exists, verify ownership
+			verified, err := verifyServerOwnership(existingServer, data)
+			if err != nil {
+				return false, nil, errors.Wrapf(err, "Failed to verify server ownership for %s", data.SiteName)
+			}
+			if !verified {
+				return false, nil, permissionDeniedError{Message: fmt.Sprintf("unable to verify you own the registered server %q", data.SiteName)}
+			}
+		}
 	}
 
 	inTopo, topoNss, valErr, sysErr := validateKeyChaining(data.Prefix, key)

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -513,6 +513,9 @@ func getRegistrationsByFilter(filterNs server_structs.Registration, pType prefix
 }
 
 func AddRegistration(ns *server_structs.Registration) error {
+	if ns.AdminMetadata.SiteName == "" {
+		return errors.New("Site Name is required")
+	}
 	// Adding default values to the field. Note that you need to pass other fields
 	// including user_id before this function
 	ns.AdminMetadata.CreatedAt = time.Now()

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -287,6 +287,38 @@ func getServerByRegistrationID(registrationID int) (*server_structs.ServerRegist
 	return result, nil
 }
 
+// Retrieve the details of a server by server name
+func getServerByName(serverName string) (*server_structs.ServerRegistration, error) {
+	var server server_structs.Server
+	if err := database.ServerDatabase.Where("name = ?", serverName).First(&server).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, gorm.ErrRecordNotFound
+		}
+		return nil, errors.Wrapf(err, "failed to get server by name: %s", serverName)
+	}
+
+	var services []server_structs.Service
+	if err := database.ServerDatabase.Where("server_id = ?", server.ID).Preload("Registration").Find(&services).Error; err != nil {
+		return nil, errors.Wrapf(err, "failed to get services for server name: %s", serverName)
+	}
+
+	result := &server_structs.ServerRegistration{
+		ID:        server.ID,
+		Name:      server.Name,
+		IsOrigin:  server.IsOrigin,
+		IsCache:   server.IsCache,
+		Note:      server.Note,
+		CreatedAt: server.CreatedAt,
+		UpdatedAt: server.UpdatedAt,
+	}
+
+	for _, service := range services {
+		result.Registration = append(result.Registration, service.Registration)
+	}
+
+	return result, nil
+}
+
 // Get the complete info of all servers
 func listServers() ([]server_structs.ServerRegistration, error) {
 	var servers []server_structs.Server
@@ -563,7 +595,29 @@ func AddRegistration(ns *server_structs.Registration) error {
 			} else if err != nil {
 				return errors.Wrapf(err, "failed to check for existing server: %s", ns.AdminMetadata.SiteName)
 			} else {
-				// Server exists, update its services (a server can be both an origin and a cache)
+				// If there's an existing server with the same name owned by the same entity,
+				// update its services (a server can be both an origin and a cache).
+				// We consider they belong to the same entity if they have the same public key(s)
+
+				// Get the first registration for this server to compare public keys
+				// Because if multiple services registered to the same server, they all have the same public keys
+				var existingService server_structs.Service
+				if err := tx.Where("server_id = ?", existingServer.ID).Preload("Registration").First(&existingService).Error; err != nil {
+					return errors.Wrapf(err, "failed to get existing service for server: %s", ns.AdminMetadata.SiteName)
+				}
+
+				existingPubkeySet, err := jwk.ParseString(existingService.Registration.Pubkey)
+				if err != nil {
+					return errors.Wrapf(err, "failed to parse existing server's pubkey as a jwks: %s", ns.AdminMetadata.SiteName)
+				}
+				inputPubkeySet, err := jwk.ParseString(ns.Pubkey)
+				if err != nil {
+					return errors.Wrapf(err, "failed to parse input registration's pubkey as a jwks: %s", ns.AdminMetadata.SiteName)
+				}
+
+				if !compareJwks(existingPubkeySet, inputPubkeySet) {
+					return errors.Errorf("A server with the name %q already exists. Please choose a different server name or prove you have ownership of this server.", ns.AdminMetadata.SiteName)
+				}
 				if isOrigin {
 					existingServer.IsOrigin = true
 				}

--- a/registry/registry_db_test.go
+++ b/registry/registry_db_test.go
@@ -290,7 +290,7 @@ func TestAddNamespace(t *testing.T) {
 
 	t.Run("set-default-fields", func(t *testing.T) {
 		defer resetMockRegistryDB(t)
-		mockNs := mockNamespace("/test", "pubkey", "identity", server_structs.AdminMetadata{UserID: "someone"})
+		mockNs := mockNamespace("/test", "pubkey", "identity", server_structs.AdminMetadata{UserID: "someone", SiteName: "test-site-name"})
 		err := AddRegistration(&mockNs)
 		require.NoError(t, err)
 		got, err := getAllRegistrations()
@@ -308,7 +308,7 @@ func TestAddNamespace(t *testing.T) {
 		defer resetMockRegistryDB(t)
 		mockCreateAt := time.Now().Add(time.Hour * 10)
 		mockUpdatedAt := time.Now().Add(time.Minute * 20)
-		mockNs := mockNamespace("/test", "pubkey", "identity", server_structs.AdminMetadata{UserID: "someone", CreatedAt: mockCreateAt, UpdatedAt: mockUpdatedAt})
+		mockNs := mockNamespace("/test", "pubkey", "identity", server_structs.AdminMetadata{UserID: "someone", CreatedAt: mockCreateAt, UpdatedAt: mockUpdatedAt, SiteName: "test-site-name"})
 		err := AddRegistration(&mockNs)
 		require.NoError(t, err)
 		got, err := getAllRegistrations()
@@ -908,11 +908,13 @@ func TestRegistryTopology(t *testing.T) {
 
 	// Add a test namespace so we can test that checkExists still works
 	ns := server_structs.Registration{
-		ID:            0,
-		Prefix:        "/regular/foo",
-		Pubkey:        "",
-		Identity:      "",
-		AdminMetadata: server_structs.AdminMetadata{},
+		ID:       0,
+		Prefix:   "/regular/foo",
+		Pubkey:   "",
+		Identity: "",
+		AdminMetadata: server_structs.AdminMetadata{
+			SiteName: "test-sitename",
+		},
 	}
 	err = AddRegistration(&ns)
 	require.NoError(t, err)

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -484,7 +484,7 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 			log.Errorf("Failed to insert namespace with id %d. %v", ns.ID, err)
 			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 				Status: server_structs.RespFailed,
-				Msg:    "Fail to insert namespace"})
+				Msg:    fmt.Sprintf("New registration failed. %s", err.Error())})
 			return
 		}
 		if inTopo {

--- a/registry/registry_ui_test.go
+++ b/registry/registry_ui_test.go
@@ -975,7 +975,7 @@ func TestCreateNamespace(t *testing.T) {
 		pubKeyStr, err := test_utils.GenerateJWKS()
 		require.NoError(t, err)
 
-		mockNs := server_structs.Registration{Prefix: "/foo", Pubkey: pubKeyStr, AdminMetadata: server_structs.AdminMetadata{Institution: "1000"}}
+		mockNs := server_structs.Registration{Prefix: "/foo", Pubkey: pubKeyStr, AdminMetadata: server_structs.AdminMetadata{Institution: "1000", SiteName: "test-site-name"}}
 		mockNsBytes, err := json.Marshal(mockNs)
 		require.NoError(t, err)
 		// Create a request to the endpoint
@@ -1030,7 +1030,7 @@ func TestCreateNamespace(t *testing.T) {
 		mockNs := server_structs.Registration{
 			Prefix:        "/foo",
 			Pubkey:        pubKeyStr,
-			AdminMetadata: server_structs.AdminMetadata{Institution: "1000"},
+			AdminMetadata: server_structs.AdminMetadata{Institution: "1000", SiteName: "test-site-name"},
 			CustomFields:  customFieldsVals,
 		}
 		mockNsBytes, err := json.Marshal(mockNs)
@@ -1073,7 +1073,7 @@ func TestCreateNamespace(t *testing.T) {
 		pubKeyStr, err := test_utils.GenerateJWKS()
 		require.NoError(t, err)
 
-		mockNs := server_structs.Registration{Prefix: "/topo/foo/bar", Pubkey: pubKeyStr, AdminMetadata: server_structs.AdminMetadata{Institution: "1000"}}
+		mockNs := server_structs.Registration{Prefix: "/topo/foo/bar", Pubkey: pubKeyStr, AdminMetadata: server_structs.AdminMetadata{Institution: "1000", SiteName: "test-site-name"}}
 		mockNsBytes, err := json.Marshal(mockNs)
 		require.NoError(t, err)
 		// Create a request to the endpoint
@@ -1115,7 +1115,7 @@ func TestCreateNamespace(t *testing.T) {
 		pubKeyStr, err := test_utils.GenerateJWKS()
 		require.NoError(t, err)
 
-		mockNs := server_structs.Registration{Prefix: "/topo/foo", Pubkey: pubKeyStr, AdminMetadata: server_structs.AdminMetadata{Institution: "1000"}}
+		mockNs := server_structs.Registration{Prefix: "/topo/foo", Pubkey: pubKeyStr, AdminMetadata: server_structs.AdminMetadata{Institution: "1000", SiteName: "test-site-name"}}
 		mockNsBytes, err := json.Marshal(mockNs)
 		require.NoError(t, err)
 		// Create a request to the endpoint
@@ -1208,7 +1208,7 @@ func TestUpdateNamespaceHandler(t *testing.T) {
 		pubKeyStr, err := test_utils.GenerateJWKS()
 		require.NoError(t, err)
 
-		mockNs := server_structs.Registration{Prefix: "/foo", Pubkey: pubKeyStr, AdminMetadata: server_structs.AdminMetadata{Institution: "1000"}}
+		mockNs := server_structs.Registration{Prefix: "/foo", Pubkey: pubKeyStr, AdminMetadata: server_structs.AdminMetadata{Institution: "1000", SiteName: "test-site-name"}}
 		mockNsBytes, err := json.Marshal(mockNs)
 		require.NoError(t, err)
 		// Create a request to the endpoint
@@ -1231,7 +1231,7 @@ func TestUpdateNamespaceHandler(t *testing.T) {
 		pubKeyStr, err := test_utils.GenerateJWKS()
 		require.NoError(t, err)
 
-		mockNs := server_structs.Registration{Prefix: "/foo", Pubkey: pubKeyStr, AdminMetadata: server_structs.AdminMetadata{Institution: "1000", UserID: "notYourNs"}}
+		mockNs := server_structs.Registration{Prefix: "/foo", Pubkey: pubKeyStr, AdminMetadata: server_structs.AdminMetadata{Institution: "1000", UserID: "notYourNs", SiteName: "test-site-name"}}
 
 		err = insertMockDBData([]server_structs.Registration{mockNs})
 		require.NoError(t, err)
@@ -1268,6 +1268,7 @@ func TestUpdateNamespaceHandler(t *testing.T) {
 				Institution: "1000",
 				UserID:      "mockUser",                 // same as currently sign-in user
 				Status:      server_structs.RegApproved, // but it's approved
+				SiteName:    "test-site-name",
 			},
 		}
 
@@ -1307,6 +1308,7 @@ func TestUpdateNamespaceHandler(t *testing.T) {
 				Institution: "1000",
 				UserID:      "mockUser",                // same as currently sign-in user
 				Status:      server_structs.RegPending, // but it's approved
+				SiteName:    "test-site-name",
 			},
 		}
 
@@ -1352,6 +1354,7 @@ func TestUpdateNamespaceHandler(t *testing.T) {
 				Institution: "1000",
 				UserID:      "mockUser",                 // same as currently sign-in user
 				Status:      server_structs.RegApproved, // but it's approved
+				SiteName:    "test-site-name",
 			},
 		}
 


### PR DESCRIPTION
This PR fixes the problems found by William in Pelican 7.19.0-rc.0 testing and other minor issues.

After the Registry ID Overhaul (#2483), a server could have more than one service (Origin/Cache). There are two ways to register a service on a server in the Registry: CLI auto-registration adn Registry WebUI.

When a request wants to register a new service (Origin/Cache) on an existing server, we need to verify they are allowed to do so by checking if they have the same public keys.

- For CLI auto-registration, we add an extra step: check if the signature they present can be verified by the existing server's keyset