### PR TITLE
Use /pelicanplatform/test/hello-world.txt object throughout docs

### DIFF
--- a/docs/app/about-pelican/core-concepts/page.mdx
+++ b/docs/app/about-pelican/core-concepts/page.mdx
@@ -25,13 +25,13 @@ to the object within that federation (there is the potential that some objects r
 the OSDF’s federation hostname is `osg-htc.org`, an example path to an object in the federation is:
 
 ```bash copy
-/ospool/uc-shared/public/OSG-Staff/validation/test.txt
+/pelicanplatform/test/hello-world.txt
 ```
 
 Combining these two pieces of information, we say the the **object's URL** is:
 
 ```bash copy
-pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt
+pelican://osg-htc.org/pelicanplatform/test/hello-world.txt
 ```
 
 ### Namespace or Federation Prefixes
@@ -41,6 +41,7 @@ Each origin supports one or more *namespace prefixes*, which are analogous to th
 Below is an example of a full Pelican object name:
 
 ```bash
+# Note -- this is an example and the object is not expected to exist
 pelican://osg-htc.org/demo/testfile.txt
 ```
 
@@ -56,11 +57,11 @@ over what happens in the directory, including the ability to delegate the creati
 Starting with a full Pelican URL object  name can make it tricky to determine where the actual namespace prefix ends and the underlying object name (as understood by the
 Origin's configured data repository) begins. For example, this test object has a deeply-nested path:
 ```bash copy
-pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt
+pelican://osg-htc.org/pelicanplatform/test/hello-world.txt
 ```
 
-In this example, the namespace prefix happens to be `/ospool/uc-shared/public/`, and this is hosted by a posix origin that exports a directory tree containing
-`/OSG-Staff/validation/test.txt`.
+In this example, the namespace prefix happens to be /pelicanplatform/`, and this is hosted by a POSIX Origin that exports a directory tree containing
+`test/hello-world.txt`.
 
 In most cases, users don't need to know the namespace/object name split for the objects they'd like to interact with -- knowing the full pelican URL is generally sufficient.
 However, understanding this becomes more important for those who want to federate their own data by hosting an Origin, or for some types of troubleshooting. Pelican provides
@@ -72,10 +73,10 @@ which should list all prefixes registered in the federation. Using the search ba
 be filtered for you.
 
 Another way to get this information is by interacting with the federation Directly using an HTTP client like curl. The following command is an example of a valid request to and
-response from the OSDF Director for the `pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt` object:
+response from the OSDF Director for the `pelican://osg-htc.org/pelicanplatform/test/hello-world.txt` object:
 ```bash
-$ curl -v https://osdf-director.osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt
-> GET /ospool/uc-shared/public/OSG-Staff/validation/test.txt HTTP/2
+$ curl -v https://osdf-director.osg-htc.org/pelicanplatform/test/hello-world.txt
+> GET /pelicanplatform/test/hello-world.txt HTTP/2
 > Host: osdf-director.osg-htc.org
 > user-agent: curl/7.76.1
 > accept: */*
@@ -83,14 +84,15 @@ $ curl -v https://osdf-director.osg-htc.org/ospool/uc-shared/public/OSG-Staff/va
 < HTTP/2 307
 < content-type: text/html; charset=utf-8
 < date: Thu, 19 Dec 2024 21:12:35 GMT
-< link: <https://osdf-uw-cache.svc.osg-htc.org:8443/ospool/uc-shared/public/OSG-Staff/validation/test.txt>; rel="duplicate"; pri=1; depth=3
-< location: https://osdf-uw-cache.svc.osg-htc.org:8443/ospool/uc-shared/public/OSG-Staff/validation/test.txt
+< link: <https://osdf-uw-cache.svc.osg-htc.org:8443/pelicanplatform/test/hello-world.txt>; rel="duplicate"; pri=1; depth=3
+< location: https://osdf-uw-cache.svc.osg-htc.org:8443/pelicanplatform/test/hello-world.txt
 < x-pelican-authorization: issuer=https://osg-htc.org/ospool
-< x-pelican-namespace: namespace=/ospool/uc-shared/public, require-token=false, collections-url=https://pelican-osdf-public.tempest.uchicago.edu:8443
-< x-pelican-token-generation: issuer=https://osg-htc.org/ospool, max-scope-depth=3, strategy=OAuth2, base-path=/ospool/uc-shared/public
-< content-length: 132
+< x-pelican-namespace: namespace=/pelicanplatform, require-token=false, collections-url=https://pelicanplatform-origin.osdf-prod.chtc.io:8443
+< x-pelican-token-generation: issuer=https://osg-htc.org/ospool, max-scope-depth=3, strategy=OAuth2
+< x-pelican-jobid: d07c5925-8a39-4a2d-890c-404fca7a21dc
+< content-length: 115
 <
-<a href="https://osdf-uw-cache.svc.osg-htc.org:8443/ospool/uc-shared/public/OSG-Staff/validation/test.txt">Temporary Redirect</a>.
+<a href="https://osdf-uw-cache.svc.osg-htc.org:8443/pelicanplatform/test/hello-world.txt">Temporary Redirect</a>.
 ```
 
 Note that the `X-Pelican-Namespace` header has a "namespace" attribute explaining which portion of the path is the registered namespace.

--- a/docs/app/getting-data-with-pelican/client/page.mdx
+++ b/docs/app/getting-data-with-pelican/client/page.mdx
@@ -25,13 +25,13 @@ Before using the Pelican client to interact with objects from your federation, t
 All object paths in a federation begin with a preceding `/`, and no relative paths are allowed. Here is the example URL we used in the [Quick Start Guide](../getting-started/accessing-data.mdx#federations):
 
 ```bash copy
-/ospool/uc-shared/public/OSG-Staff/validation/test.txt
+/pelicanplatform/test/hello-world.txt
 ```
 
 This is the full object path that we will be using in examples below.
 
 ### Tokens and JWT
-Some namespace prefixes are public, like `/ospool/uc-shared/public`, while others are protected (i.e. they require authorization). Objects in public namespaces can be downloaded by anybody, but downloading objects from protected namespaces requires you prove to the origin supporting that namespace that you are allowed to access the object. In Pelican, this is done using signed JSON Web Tokens, or *JWT*s for short. In many cases, these tokens can be generated automatically.
+Some namespace prefixes are public, like `/pelicanplatform/`, while others are protected (i.e. they require authorization). Objects in public namespaces can be downloaded by anybody, but downloading objects from protected namespaces requires you prove to the origin supporting that namespace that you are allowed to access the object. In Pelican, this is done using signed JSON Web Tokens, or *JWT*s for short. In many cases, these tokens can be generated automatically.
 
 ### The Different Pelican URL Schemes
 When running client commands with a request URL, there are two different URL schemes a user can use: `pelican` and `osdf`. This page uses examples with the `pelican://` URL scheme. Below is a description of the two URL schemes and what to expect when they are used:
@@ -72,15 +72,15 @@ pelican object get pelican://<federation-url></namespace-prefix></path/to/file> 
 You can try this yourself by getting the public file that was mentioned earlier from the OSDF. Using the `object get` sub command, and providing the federation URL for the OSDF:
 
 ```bash copy
-pelican object get pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt downloaded-testfile.txt
+pelican object get pelican://osg-htc.org/pelicanplatform/test/hello-world.txt downloaded-testfile.txt
 ```
 
-This command will download the object `/OSG-Staff/validation/test.txt` from the OSDF's `/ospool/uc-shared/public/` namespace and save it in your local directory with the name `downloaded-testfile.txt`.
+This command will download the object `test/hello-world.txt` from the OSDF's `/pelicanplatform/` namespace and save it in your current working directory with the name `downloaded-testfile.txt`.
 
 More specifically, it breaks into these components:
-- Federation URL: `osg-htc.org`
-- Namespace: `/ospool/uc-shared/public/`
-- Object name: `OSG-Staff/validation/test.txt`
+- Federation hostname: `osg-htc.org`
+- Namespace: `/pelicanplatform/`
+- Object name: `test/hello-world.txt`
 - Destination: `downloaded-testfile.txt`
 
 
@@ -250,7 +250,7 @@ The Pelican binary can change its behavior depending on what it is named. This f
 When the name of the Pelican binary begins with `osdf`, Pelican will assume that all objects are coming from the OSDF which allows it to make several assumptions. The most immediate effect for users is that you no longer need to specify a federation URL, ONLY with no URL scheme or an `osdf:///` URL scheme. The command to download a public file from above can then be simplified to:
 
 ```bash copy
-osdf object copy /ospool/uc-shared/public/OSG-Staff/validation/test.txt downloaded-testfile.txt
+osdf object copy /pelicanplatform/test/hello-world.txt downloaded-testfile.txt
 ```
 
 >**Note:** When using client commands with the OSDF binary, be careful when using it with `pelican://` URL schemes. When using the `pelican://` URL scheme, you are still required to provide a federation URL no matter what binary name you are using.

--- a/docs/app/getting-started/accessing-data/page.mdx
+++ b/docs/app/getting-started/accessing-data/page.mdx
@@ -37,20 +37,20 @@ We can break down the components of this command before you try it yourself:
 Now it is time for you to get your first object from a federation. Before getting your first object, be sure you are in a directory/location where you want to download this test file. To get the object, run the command below:
 
 ```bash copy
-pelican object get pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt downloaded-test.txt
+pelican object get pelican://osg-htc.org/pelicanplatform/test/hello-world.txt downloaded-test.txt
 ```
 
->**Note:** with pelican:// URLs like the one above, it is important to include the correct number of slashes (`/`). This is because pelican URLs rely on the hostname being the federation URL therefore, they must only contain two slashes after `pelican`. For more information, visit the [Pelican Client Usage](../getting-data-with-pelican/client.mdx#the-different-pelican-url-schemes) page
+>**Note:** with pelican:// URLs like the one above, it is important to include the correct number of slashes (`/`). This is because pelican URLs rely on the hostname being the federation URL therefore, they must only contain two slashes after `pelican`. For more information, visit the [Pelican Client Usage](../getting-data-with-pelican/client.mdx#the-different-pelican-url-schemes) page.
 
 You should see a progress bar output and eventually a file named `downloaded-test.txt` within your local directory:
 
 ```bash
-$ pelican object get pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt downloaded-test.txt
-downloaded-test.txt 14.00 b / 14.00 b [==============================================================================] Done!
+$ pelican object get pelican://osg-htc.org/pelicanplatform/test/hello-world.txt downloaded-test.txt
+downloaded-test.txt 27.00 b / 27.00 b [==============================================================================] Done!
 $ ls
 downloaded-test.txt
 $ cat downloaded-test.txt
-Hello, World!
+If you are seeing this message, getting an object from OSDF was successful.
 ```
 
 ## Where to Go from Here

--- a/docs/app/install/page.mdx
+++ b/docs/app/install/page.mdx
@@ -100,8 +100,8 @@ To fix the issue, install the Pelican package first by following [the preceding 
 1. Test the Client's functionality by running an **object get** command that downloads a test file from [Open Science Data Federation (OSDF)](https://osg-htc.org/services/osdf) to your current directory
 
     ```bash
-    $ pelican object get pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt .
-    test.txt 14.00b / 14.00b [=============================================================================================] Done!
+    $ pelican object get pelican://osg-htc.org/pelicanplatform/test/hello-world.txt .
+    hello-world.txt 27.00b / 27.00b [=============================================================================================] Done!
     ```
 
 ## Next Steps


### PR DESCRIPTION
Trying to knock out a few easily-closed stale issues.