### PR TITLE
xrdcl-pelican metrics

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1046,7 +1046,7 @@ func SetServerDefaults(v *viper.Viper) error {
 	v.SetDefault(param.Xrootd_ShutdownTimeout.GetName(), 1*time.Minute)
 	v.SetDefault(param.Cache_EvictionMonitoringInterval.GetName(), 60)
 	v.SetDefault(param.Cache_EvictionMonitoringMaxDepth.GetName(), 1)
-	v.SetDefault(param.Cache_ClientStatisticsLocation.GetName(), "/tmp/xrootd.stats")
+	v.SetDefault(param.Cache_ClientStatisticsLocation.GetName(), filepath.Join(param.Cache_RunLocation.GetString(), "xrootd.stats"))
 	v.SetDefault(param.IssuerKey.GetName(), filepath.Join(configDir, "issuer.jwk"))
 	v.SetDefault(param.IssuerKeysDirectory.GetName(), filepath.Join(configDir, "issuer-keys"))
 	v.SetDefault(param.Server_UIPasswordFile.GetName(), filepath.Join(configDir, "server-web-passwd"))

--- a/config/config.go
+++ b/config/config.go
@@ -1046,6 +1046,7 @@ func SetServerDefaults(v *viper.Viper) error {
 	v.SetDefault(param.Xrootd_ShutdownTimeout.GetName(), 1*time.Minute)
 	v.SetDefault(param.Cache_EvictionMonitoringInterval.GetName(), 60)
 	v.SetDefault(param.Cache_EvictionMonitoringMaxDepth.GetName(), 1)
+	v.SetDefault(param.Cache_ClientStatisticsLocation.GetName(), "/tmp/xrootd.stats")
 	v.SetDefault(param.IssuerKey.GetName(), filepath.Join(configDir, "issuer.jwk"))
 	v.SetDefault(param.IssuerKeysDirectory.GetName(), filepath.Join(configDir, "issuer-keys"))
 	v.SetDefault(param.Server_UIPasswordFile.GetName(), filepath.Join(configDir, "server-web-passwd"))

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1718,7 +1718,7 @@ description: |+
 
   ```yaml
   Cache:
-    ClientStatisticsLocation: "$Cache.RunLocation/xrootd.stats"
+    ClientStatisticsLocation: "${Cache.RunLocation}/xrootd.stats"
   ```
 
   The XRootD process will periodically write JSON-formatted statistics to the specified file, which can be read by external monitoring (e.g., `jq`).

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1718,7 +1718,7 @@ description: |+
 
   ```yaml
   Cache:
-    ClientStatisticsLocation: "/tmp/xrootd.stats"
+    ClientStatisticsLocation: "$Cache.RunLocation/xrootd.stats"
   ```
 
   The XRootD process will periodically write JSON-formatted statistics to the specified file, which can be read by external monitoring (e.g., `jq`).

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1724,7 +1724,7 @@ description: |+
   The XRootD process will periodically write JSON-formatted statistics to the specified file, which can be read by external monitoring (e.g., `jq`).
   Leave unset to disable.
 type: filename
-default: none
+default: /tmp/xrootd.stats
 components: ["cache"]
 ---
 ############################

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1710,6 +1710,23 @@ type: int
 default: 1
 components: ["cache"]
 ---
+name: Cache.ClientStatisticsLocation
+description: |+
+  If set, Pelican will pass this path to the XRootD cache process via the `XRD_CURLSTATISTICSLOCATION` environment variable to enable client-side curl statistics in `xrdcl-pelican` (v1.5.0+).
+
+  Example:
+
+  ```yaml
+  Cache:
+    ClientStatisticsLocation: "/tmp/xrootd.stats"
+  ```
+
+  The XRootD process will periodically write JSON-formatted statistics to the specified file, which can be read by external monitoring (e.g., `jq`).
+  Leave unset to disable.
+type: filename
+default: none
+components: ["cache"]
+---
 ############################
 #  Director-level configs  #
 ############################

--- a/launchers/cache_serve.go
+++ b/launchers/cache_serve.go
@@ -111,6 +111,8 @@ func CacheServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, m
 		metrics.LaunchXrootdCacheEvictionMonitoring(ctx, egrp)
 	}
 
+	metrics.LaunchXrdCurlStatsMonitoring(ctx, egrp)
+
 	concLimit := param.Cache_Concurrency.GetInt()
 	if concLimit > 0 {
 		server_utils.LaunchConcurrencyMonitoring(ctx, egrp, cacheServer.GetServerType())

--- a/metrics/xrdcl_curl_stats.go
+++ b/metrics/xrdcl_curl_stats.go
@@ -17,7 +17,7 @@ import (
 // When XRootD v6 is released, this function should be removed along with Cache.ClientStatisticsLocation
 func LaunchXrdCurlStatsMonitoring(ctx context.Context, egrp *errgroup.Group) {
 	egrp.Go(func() error {
-		ticker := time.NewTicker(time.Second * 30)
+		ticker := time.NewTicker(time.Second * 5)
 		defer ticker.Stop()
 
 		for {

--- a/metrics/xrdcl_curl_stats.go
+++ b/metrics/xrdcl_curl_stats.go
@@ -1,0 +1,41 @@
+package metrics
+
+import (
+	"context"
+	"os"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/param"
+)
+
+// This function should be used up until XRootD v6 is released
+// When XRootD v6 is released, these stats will be available over the g-stream
+// Until then the stats are consumed from Cache.ClientStatisticsLocation
+// When XRootD v6 is released, this function should be removed along with Cache.ClientStatisticsLocation
+func LaunchXrdCurlStatsMonitoring(ctx context.Context, egrp *errgroup.Group) {
+	egrp.Go(func() error {
+		ticker := time.NewTicker(time.Second * 30)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-ticker.C:
+				stats, err := os.ReadFile(param.Cache_ClientStatisticsLocation.GetString())
+				if err != nil {
+					log.Errorf("XrdCurlStats monitoring: failed to read stats file: %v", err)
+					continue
+				}
+				err = handleXrdcurlstatsPacket(stats)
+				if err != nil {
+					log.Errorf("XrdCurlStats monitoring: failed to handle stats: %v", err)
+					continue
+				}
+			}
+		}
+	})
+}

--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -381,12 +381,12 @@ type (
 	}
 
 	XrdCurlStats struct {
-		Event   string             `json:"event"`
-		Start   float64            `json:"start"`
-		Now     float64            `json:"now"`
-		File    XrdCurlFileStats   `json:"file"`
-		Workers map[string]float64 `json:"workers"`
-		Queues  XrdCurlQueueStats  `json:"queues"`
+		Event   string            `json:"event"`
+		Start   float64           `json:"start"`
+		Now     float64           `json:"now"`
+		File    XrdCurlFileStats  `json:"file"`
+		Workers json.RawMessage   `json:"workers"`
+		Queues  XrdCurlQueueStats `json:"queues"`
 	}
 )
 
@@ -839,9 +839,80 @@ var (
 		Help: "Total time spent in S3 requests.",
 	}, []string{"type"})
 
+	// Xrdcl Caching/Prefetching client statistics
+	XrdclFilePrefetchCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "xrootd_xrdcl_prefetch_count_total",
+		Help: "Total number of prefetches started.",
+	})
+	XrdclFilePrefetchExpired = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "xrootd_xrdcl_prefetch_expired_total",
+		Help: "Total number of prefetches that expired.",
+	})
+	XrdclFilePrefetchFailed = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "xrootd_xrdcl_prefetch_failed_total",
+		Help: "Total number of prefetches that failed.",
+	})
+	XrdclFilePrefetchReadsHit = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "xrootd_xrdcl_prefetch_reads_hit_total",
+		Help: "Total number of successful reads from prefetch buffer.",
+	})
+	XrdclFilePrefetchReadsMiss = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "xrootd_xrdcl_prefetch_reads_miss_total",
+		Help: "Total number of reads that missed the prefetch buffer.",
+	})
+	XrdclFilePrefetchBytesUsed = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "xrootd_xrdcl_prefetch_bytes_used_total",
+		Help: "Total number of bytes served from prefetch.",
+	})
+	XrdclQueueProduced = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "xrootd_xrdcl_queue_produced_total",
+		Help: "Total number of HTTP requests placed into the queue.",
+	})
+	XrdclQueueConsumed = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "xrootd_xrdcl_queue_consumed_total",
+		Help: "Total number of HTTP requests read from the queue.",
+	})
+	XrdclQueuePending = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "xrootd_xrdcl_queue_pending",
+		Help: "Number of pending HTTP requests in the queue.",
+	})
+	XrdclQueueRejected = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "xrootd_xrdcl_queue_rejected_total",
+		Help: "Total number of HTTP requests rejected due to overload.",
+	})
+	XrdclWorkerOldestOp = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "xrootd_xrdcl_worker_oldest_op_timestamp_seconds",
+		Help: "Timestamp of the oldest operation in any of the worker threads.",
+	})
+	XrdclWorkerOldestCycle = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "xrootd_xrdcl_worker_oldest_cycle_timestamp_seconds",
+		Help: "Timestamp of the oldest event loop completion in any of the worker threads.",
+	})
+	XrdclHTTPRequests = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "xrootd_xrdcl_http_requests_total",
+		Help: "Statistics about HTTP requests.",
+	}, []string{"verb", "status", "type"})
+	XrdclHTTPRequestDuration = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "xrootd_xrdcl_http_request_duration_seconds_total",
+		Help: "Total duration of HTTP requests.",
+	}, []string{"verb", "status", "type"})
+	XrdclHTTPBytes = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "xrootd_xrdcl_http_bytes_total",
+		Help: "Bytes transferred for HTTP requests.",
+	}, []string{"verb", "status"})
+	XrdclConncall = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "xrootd_xrdcl_conncall_total",
+		Help: "Statistics about connection calls.",
+	}, []string{"type"})
+
 	lastStats        SummaryStat
 	lastOssStats     OSSStatsGs
 	lastS3CacheStats OssS3CacheGs
+	lastXrdCurlStats struct {
+		File    XrdCurlFileStats
+		Queues  XrdCurlQueueStats
+		Workers map[string]float64
+	}
 
 	procState = processUtilizationState{}
 
@@ -2184,5 +2255,95 @@ func handleXrdcurlstatsPacket(stats []byte) error {
 	}
 
 	log.Tracef("XrdCurlStats: %v", xrdCurlStats)
+
+	// File prefetch stats
+	lastXrdCurlStats.File.Prefetch.Count = updateCounter(xrdCurlStats.File.Prefetch.Count, lastXrdCurlStats.File.Prefetch.Count, XrdclFilePrefetchCount)
+	lastXrdCurlStats.File.Prefetch.Expired = updateCounter(xrdCurlStats.File.Prefetch.Expired, lastXrdCurlStats.File.Prefetch.Expired, XrdclFilePrefetchExpired)
+	lastXrdCurlStats.File.Prefetch.Failed = updateCounter(xrdCurlStats.File.Prefetch.Failed, lastXrdCurlStats.File.Prefetch.Failed, XrdclFilePrefetchFailed)
+	lastXrdCurlStats.File.Prefetch.ReadsHit = updateCounter(xrdCurlStats.File.Prefetch.ReadsHit, lastXrdCurlStats.File.Prefetch.ReadsHit, XrdclFilePrefetchReadsHit)
+	lastXrdCurlStats.File.Prefetch.ReadsMiss = updateCounter(xrdCurlStats.File.Prefetch.ReadsMiss, lastXrdCurlStats.File.Prefetch.ReadsMiss, XrdclFilePrefetchReadsMiss)
+	lastXrdCurlStats.File.Prefetch.BytesUsed = updateCounter(xrdCurlStats.File.Prefetch.BytesUsed, lastXrdCurlStats.File.Prefetch.BytesUsed, XrdclFilePrefetchBytesUsed)
+
+	// Queue stats
+	lastXrdCurlStats.Queues.Produced = updateCounter(xrdCurlStats.Queues.Produced, lastXrdCurlStats.Queues.Produced, XrdclQueueProduced)
+	lastXrdCurlStats.Queues.Consumed = updateCounter(xrdCurlStats.Queues.Consumed, lastXrdCurlStats.Queues.Consumed, XrdclQueueConsumed)
+	XrdclQueuePending.Set(xrdCurlStats.Queues.Pending)
+	lastXrdCurlStats.Queues.Rejected = updateCounter(xrdCurlStats.Queues.Rejected, lastXrdCurlStats.Queues.Rejected, XrdclQueueRejected)
+
+	// Worker stats
+	var workers map[string]float64
+	if err := json.Unmarshal(xrdCurlStats.Workers, &workers); err != nil {
+		return errors.Wrap(err, "failed to unmarshal xrdcurlstats workers")
+	}
+
+	if lastXrdCurlStats.Workers == nil {
+		lastXrdCurlStats.Workers = make(map[string]float64)
+	}
+
+	for key, value := range workers {
+		if key == "oldest_op" {
+			XrdclWorkerOldestOp.Set(value)
+			continue
+		}
+		if key == "oldest_cycle" {
+			XrdclWorkerOldestCycle.Set(value)
+			continue
+		}
+
+		// Update counters using deltas
+		oldValue := lastXrdCurlStats.Workers[key]
+		incBy := value - oldValue
+		if incBy < 0 {
+			incBy = value
+		}
+		lastXrdCurlStats.Workers[key] = value
+
+		if incBy <= 0 {
+			continue
+		}
+
+		if strings.HasPrefix(key, "http_") {
+			parts := strings.SplitN(key, "_", 4)
+			if len(parts) == 3 { // http_VERB_field
+				verb, field := parts[1], parts[2]
+				switch field {
+				case "started":
+					XrdclHTTPRequests.WithLabelValues(verb, "", "started").Add(incBy)
+				case "error":
+					XrdclHTTPRequests.WithLabelValues(verb, "", "error").Add(incBy)
+				case "timeout":
+					XrdclHTTPRequests.WithLabelValues(verb, "", "timeout").Add(incBy)
+				case "preheaderduration":
+					XrdclHTTPRequestDuration.WithLabelValues(verb, "", "preheader").Add(incBy)
+				}
+			} else if len(parts) == 4 { // http_VERB_STATUS_field
+				verb, status, field := parts[1], parts[2], parts[3]
+				switch field {
+				case "duration":
+					XrdclHTTPRequestDuration.WithLabelValues(verb, status, "duration").Add(incBy)
+				case "pauseduration":
+					XrdclHTTPRequestDuration.WithLabelValues(verb, status, "pause_duration").Add(incBy)
+				case "bytes":
+					XrdclHTTPBytes.WithLabelValues(verb, status).Add(incBy)
+				case "finished":
+					XrdclHTTPRequests.WithLabelValues(verb, status, "finished").Add(incBy)
+				case "servertimeout":
+					XrdclHTTPRequests.WithLabelValues(verb, status, "server_timeout").Add(incBy)
+				case "clienttimeout":
+					XrdclHTTPRequests.WithLabelValues(verb, status, "client_timeout").Add(incBy)
+				}
+			}
+		} else if strings.HasPrefix(key, "conncall_") {
+			parts := strings.Split(key, "_")
+			if len(parts) == 2 {
+				fieldType := parts[1]
+				switch fieldType {
+				case "error", "started", "success", "timeout":
+					XrdclConncall.WithLabelValues(fieldType).Add(incBy)
+				}
+			}
+		}
+	}
+
 	return nil
 }

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -146,6 +146,7 @@ func (oP ObjectParam) IsSet() bool {
 }
 
 var (
+	Cache_ClientStatisticsLocation = StringParam{"Cache.ClientStatisticsLocation"}
 	Cache_DataLocation = StringParam{"Cache.DataLocation"}
 	Cache_DbLocation = StringParam{"Cache.DbLocation"}
 	Cache_ExportLocation = StringParam{"Cache.ExportLocation"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -26,6 +26,7 @@ import (
 type Config struct {
 	Cache struct {
 		BlocksToPrefetch int `mapstructure:"blockstoprefetch" yaml:"BlocksToPrefetch"`
+		ClientStatisticsLocation string `mapstructure:"clientstatisticslocation" yaml:"ClientStatisticsLocation"`
 		Concurrency int `mapstructure:"concurrency" yaml:"Concurrency"`
 		DataLocation string `mapstructure:"datalocation" yaml:"DataLocation"`
 		DataLocations []string `mapstructure:"datalocations" yaml:"DataLocations"`
@@ -390,6 +391,7 @@ type Config struct {
 type configWithType struct {
 	Cache struct {
 		BlocksToPrefetch struct { Type string; Value int }
+		ClientStatisticsLocation struct { Type string; Value string }
 		Concurrency struct { Type string; Value int }
 		DataLocation struct { Type string; Value string }
 		DataLocations struct { Type string; Value []string }

--- a/xrootd/launch.go
+++ b/xrootd/launch.go
@@ -151,6 +151,11 @@ func makeUnprivilegedXrootdLauncher(daemonName string, xrootdRun string, configP
 		}
 		result.ExtraEnv = append(result.ExtraEnv, "XRD_PELICANFEDERATIONMETADATATIMEOUT="+param.Cache_DefaultCacheTimeout.GetDuration().String())
 		result.ExtraEnv = append(result.ExtraEnv, "XRD_PELICANDEFAULTHEADERTIMEOUT="+param.Cache_DefaultCacheTimeout.GetDuration().String())
+
+		// Enable client-side curl statistics if configured
+		if statsPath := param.Cache_ClientStatisticsLocation.GetString(); statsPath != "" {
+			result.ExtraEnv = append(result.ExtraEnv, "XRD_CURLSTATISTICSLOCATION="+statsPath)
+		}
 		// Pass through the advanced Pelican cache control features; meant for unit tests of xrdcl-pelican
 		// Purposely allowing these to override the ones from the Pelican config file
 		for _, envVar := range os.Environ() {


### PR DESCRIPTION
This PR addresses issue #2596. This PR consumes metrics from the xrdcl-pelican. It creates a new routine to periodically gather the new statistics and then funnels them along into Prometheus metrics.