### PR TITLE
Use namespace prefix token issuer as X-Pelican-Token-Generation issuer

### DIFF
--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -651,6 +651,10 @@ description: |+
   - IssuerUrls: A list of URLs that token requests to the federation prefix can use as issuers. These issuer URLs are used
       to craft the Origin's Scitokens configuration file. If unset, the Origin will fall back to its own external web URL and
       assume its server keys are also used for minting data access tokens.
+
+      When clients need to bootstrap access tokens using OAuth2 flows, they'll use the first URL in this list for bootstrapping.
+      If no URLs are provided but a defined namespace capability for the export requires tokens (`Reads`, `Writes`), the derived
+      value from `${Server.IssuerUrl}` will be used.
   - Capabilities: A list of the capabilities the origin is willing to support for the given export. Capabilities include:
       ["Reads", "PublicReads", "Writes", "Listings", "DirectReads"]
       where each of these has the same effect as the corresponding "Origin.Enable*" configuration, except scoped to the

--- a/origin/advertise.go
+++ b/origin/advertise.go
@@ -136,6 +136,16 @@ func (server *OriginServer) CreateAdvertisement(name, originUrlStr, originWebUrl
 			}
 		}
 
+		// Populate the struct for the namespace's "token generation" field
+		// TODO: It's not clear what the intended difference/abstraction between the
+		// "Generation" and the "Issuer" fields is... We should define these eventually
+		var tokGen server_structs.TokenGen
+		if len(issuerUrls) > 0 {
+			tokGen.Strategy = server_structs.OAuthStrategy
+			tokGen.MaxScopeDepth = 3
+			tokGen.CredentialIssuer = issuerUrls[0].IssuerUrl
+		}
+
 		nsAds = append(nsAds, server_structs.NamespaceAdV2{
 			Caps: server_structs.Capabilities{
 				PublicReads: export.Capabilities.PublicReads,
@@ -144,15 +154,9 @@ func (server *OriginServer) CreateAdvertisement(name, originUrlStr, originWebUrl
 				Listings:    export.Capabilities.Listings,
 				DirectReads: export.Capabilities.DirectReads,
 			},
-			Path: export.FederationPrefix,
-			Generation: []server_structs.TokenGen{{
-				Strategy:      server_structs.StrategyType("OAuth2"),
-				MaxScopeDepth: 3,
-				// TODO: Is this the correct issuer URL to assign here? It's not clear what the
-				// intended difference between the "Generation" and the "Issuer" fields is...
-				CredentialIssuer: *serverIssuerUrl,
-			}},
-			Issuer: issuerUrls,
+			Path:       export.FederationPrefix,
+			Generation: []server_structs.TokenGen{tokGen},
+			Issuer:     issuerUrls,
 		})
 		prefixes = append(prefixes, export.FederationPrefix)
 	}


### PR DESCRIPTION
Looking through various comments and past bugfixes, I'm really unsure what the guiding philosophy surrounding this header is supposed to be, and how that philosophy differs from the X-Pelican-Issuer header.

At a high level, there are issuers for a namespace and issuers for the Origin server itself, issuers for monitoring services and issuers for federation-related operations _at_ the Origin, but we've never formally explained how these interact, let alone the configuration mechanisms needed to cleanly split these as concepts. In any case, it seems like the token generation header should be using an issuer URL tied to the namespace itself.

This commit uses the first specified namespace issuer as the default issuer for clients to bootstrap tokens.