### PR TITLE
Hint upload size

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -3253,6 +3253,16 @@ func uploadObject(transfer *transferFile) (transferResult TransferResults, err e
 		transferResult.Error = err
 		return transferResult, err
 	}
+
+	// Hint upload size
+	// Only do this for non-zero size files and not for pack uploads
+	// Because with compressed files, we don't know the decompressed size
+	if nonZeroSize && pack == "" {
+		query := request.URL.Query()
+		query.Add("oss.asize", strconv.FormatInt(fileInfo.Size(), 10))
+		request.URL.RawQuery = query.Encode()
+	}
+
 	// Set the authorization header as well as other headers
 	var tokenContents string
 	if transfer.token != nil {


### PR DESCRIPTION
This PR addresses issue #2580. After an extensive investigation, I had found that the client buffers the entire object into memory, when setting the `Request.ContentLength` field. I had also looked into setting the `Content-Length` header directly, and Go will ignore this. This PR adds the `oss.asize` query parameter to the upload to provide the hint. It only applies this query parameter if the object is greater than zero bytes and is not compressed.