### PR TITLE
Use jwk.Equal() instead of JSON string comparison for super/sub spaces key matching

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -129,8 +129,8 @@ func (e *duplicateServerIdError) Error() string {
 	return e.Message
 }
 
+// Check whether any key in the input JWK matches any key already registered to an input namespace prefix
 func matchKeys(incomingKey jwk.Key, registeredNamespaces []string) (bool, error) {
-	log.Debugf("Matching the incoming key to the registered namespaces for namespace %v", registeredNamespaces)
 	// If this is the case, we want to make sure that at least one of the superspaces has the
 	// same registration key as the incoming. This guarantees the owner of the superspace is
 	// permitting the action (assuming their keys haven't been stolen!)
@@ -147,18 +147,8 @@ func matchKeys(incomingKey jwk.Key, registeredNamespaces []string) (bool, error)
 		for it := (keyset).Keys(context.Background()); it.Next(context.Background()); {
 			pair := it.Pair()
 			registeredKey := pair.Value.(jwk.Key)
-			registeredKeyBuf, err := json.Marshal(registeredKey)
-			if err != nil {
-				return false, errors.Wrapf(err, "failed to marshal a key registered to %s into JSON", ns)
-			}
-			incomingKeyBuf, err := json.Marshal(incomingKey)
-			if err != nil {
-				return false, errors.Wrap(err, "failed to marshal the incoming key into JSON")
-			}
-			log.Debugf("Matching key for namespace %s\n", ns)
-			log.Debugf("key in Registry DB: %s\n", string(registeredKeyBuf))
-			log.Debugf("key in incoming request: %s\n", string(incomingKeyBuf))
 
+			log.Debugf("Matching key for namespace %s: Registry DB key: %s, Incoming request key: %s", ns, registeredKey.KeyID(), incomingKey.KeyID())
 			// Use jwk.Equal for reliable key comparison
 			if jwk.Equal(registeredKey, incomingKey) {
 				foundMatch = true

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -130,6 +130,7 @@ func (e *duplicateServerIdError) Error() string {
 }
 
 func matchKeys(incomingKey jwk.Key, registeredNamespaces []string) (bool, error) {
+	log.Debugf("Matching the incoming key to the registered namespaces for namespace %v", registeredNamespaces)
 	// If this is the case, we want to make sure that at least one of the superspaces has the
 	// same registration key as the incoming. This guarantees the owner of the superspace is
 	// permitting the action (assuming their keys haven't been stolen!)
@@ -154,11 +155,18 @@ func matchKeys(incomingKey jwk.Key, registeredNamespaces []string) (bool, error)
 			if err != nil {
 				return false, errors.Wrap(err, "failed to marshal the incoming key into JSON")
 			}
+			log.Debugf("Matching key for namespace %s\n", ns)
+			log.Debugf("key in Registry DB: %s\n", string(registeredKeyBuf))
+			log.Debugf("key in incoming request: %s\n", string(incomingKeyBuf))
 
-			if string(registeredKeyBuf) == string(incomingKeyBuf) {
+			// Use jwk.Equal for reliable key comparison
+			if jwk.Equal(registeredKey, incomingKey) {
 				foundMatch = true
 				break
 			}
+		}
+		if foundMatch {
+			break
 		}
 	}
 


### PR DESCRIPTION
This method properly compares the cryptographic content rather than string representation, making the key comparison method in `matchKeys` function consistent with other parts of the codebase like:
* compareJwks() 
* checkNamespaceExistsHandler()

Also add extra debugging logs.

**Important Note** The current PR may not resolve the problem in the Github Issue, since I cannot reproduce this error in v7.16 with a similar setup (superspace "/foo" registered, try to register a new namespace "/foo/bar" with the same key) -> it works without the error. Nevertheless, this is my best shot at this time-sensitive moment. It at least implements the best practice for key comparison, and could provide more logs for debugging. Any wisdom would be appreciated!!