### PR TITLE
Comment out the Federation.DiscoveryUrl from `/etc/pelican/config.d/10-federation.yaml` from the `pelican-server` RPM

### DIFF
--- a/systemd/examples/10-federation.yaml
+++ b/systemd/examples/10-federation.yaml
@@ -5,9 +5,10 @@
 # Required configuration to integrate with your federation
 #####################################################
 
-Federation:
-  ## The main URL for your federation. You must specify this.
-  DiscoveryUrl:
+# Federation:
+#   ## The main URL for your federation. You must specify this unless
+#   ## you are using one of the `osdf-*` service RPMs.
+#   DiscoveryUrl:
 
 ## If the external DNS name of your host is different from the output
 ## of `hostname -f`, set Hostname to the external DNS name


### PR DESCRIPTION
We don't want it to override a valid Federation.DiscoveryUrl that was specified earlier in the config sequence, such as in `/usr/share/pelican/config.d`.