### PR TITLE
Groups-Collections Authorization Integration

### DIFF
--- a/database/collection.go
+++ b/database/collection.go
@@ -658,3 +658,15 @@ func RemoveGroupMember(db *gorm.DB, groupId, member, removedBy string, groups []
 	}
 	return nil
 }
+
+func GetMemberGroups(db *gorm.DB, user string) ([]Group, error) {
+	groups := []Group{}
+	if result := db.Model(&Group{}).
+		Joins("JOIN group_members ON groups.id = group_members.group_id").
+		Where("group_members.member = ?", user).
+		Select("groups.id, groups.name").
+		Find(&groups); result.Error != nil {
+		return nil, result.Error
+	}
+	return groups, nil
+}

--- a/database/collection.go
+++ b/database/collection.go
@@ -661,11 +661,12 @@ func RemoveGroupMember(db *gorm.DB, groupId, member, removedBy string, groups []
 
 func GetMemberGroups(db *gorm.DB, user string) ([]Group, error) {
 	groups := []Group{}
-	if result := db.Model(&Group{}).
+	result := db.Model(&Group{}).
 		Joins("JOIN group_members ON groups.id = group_members.group_id").
 		Where("group_members.member = ?", user).
 		Select("groups.id, groups.name").
-		Find(&groups); result.Error != nil {
+		Find(&groups)
+	if result.Error != nil {
 		return nil, result.Error
 	}
 	return groups, nil

--- a/oa4mp/proxy.go
+++ b/oa4mp/proxy.go
@@ -223,7 +223,6 @@ func oa4mpProxy(ctx *gin.Context) {
 		if groupsList == nil {
 			groupsList = make([]string, 0)
 		}
-		log.Debugln("groupsList", groupsList)
 		// WORKAROUND: OA4MP 5.4.x does not provide a mechanism to pass data through headers (the
 		// existing mechanism only works with the authorization code grant, not the device authorization
 		// grant).  Therefore, all the data we want passed we stuff into the username (which *is* copied
@@ -234,8 +233,6 @@ func oa4mpProxy(ctx *gin.Context) {
 		allowedScopes, matchedGroups := calculateAllowedScopes(user, groupsList)
 		userInfo["g"] = matchedGroups
 		userInfo["s"] = allowedScopes
-		log.Debugln("allowedScopes", allowedScopes)
-		log.Debugln("matchedGroups", matchedGroups)
 		userBytes, err := json.Marshal(userInfo)
 		if err != nil {
 			ctx.AbortWithStatusJSON(http.StatusInternalServerError, server_structs.SimpleApiResp{

--- a/oa4mp/proxy.go
+++ b/oa4mp/proxy.go
@@ -129,6 +129,16 @@ func calculateAllowedScopes(user string, groupsList []string) ([]string, []strin
 						scope = "storage.create"
 					case "modify":
 						scope = "storage.modify"
+					case "collection_read":
+						scope = "collection.read"
+					case "collection_write":
+						scope = "collection.modify"
+					case "collection_create":
+						scope = "collection.create"
+					case "collection_modify":
+						scope = "collection.modify"
+					case "collection_delete":
+						scope = "collection.delete"
 					default:
 						scope = action
 					}
@@ -150,6 +160,16 @@ func calculateAllowedScopes(user string, groupsList []string) ([]string, []strin
 					scope = "storage.create"
 				case "modify":
 					scope = "storage.modify"
+				case "collection_read":
+					scope = "collection.read"
+				case "collection_write":
+					scope = "collection.modify"
+				case "collection_create":
+					scope = "collection.create"
+				case "collection_modify":
+					scope = "collection.modify"
+				case "collection_delete":
+					scope = "collection.delete"
 				default:
 					scope = action
 				}

--- a/oa4mp/proxy.go
+++ b/oa4mp/proxy.go
@@ -203,6 +203,7 @@ func oa4mpProxy(ctx *gin.Context) {
 		if groupsList == nil {
 			groupsList = make([]string, 0)
 		}
+		log.Debugln("groupsList", groupsList)
 		// WORKAROUND: OA4MP 5.4.x does not provide a mechanism to pass data through headers (the
 		// existing mechanism only works with the authorization code grant, not the device authorization
 		// grant).  Therefore, all the data we want passed we stuff into the username (which *is* copied
@@ -213,7 +214,8 @@ func oa4mpProxy(ctx *gin.Context) {
 		allowedScopes, matchedGroups := calculateAllowedScopes(user, groupsList)
 		userInfo["g"] = matchedGroups
 		userInfo["s"] = allowedScopes
-
+		log.Debugln("allowedScopes", allowedScopes)
+		log.Debugln("matchedGroups", matchedGroups)
 		userBytes, err := json.Marshal(userInfo)
 		if err != nil {
 			ctx.AbortWithStatusJSON(http.StatusInternalServerError, server_structs.SimpleApiResp{

--- a/oa4mp/resources/policies.qdl
+++ b/oa4mp/resources/policies.qdl
@@ -90,3 +90,4 @@ access_token.'scope' := detokenize(unique(sort(user_scopes. ~ user_scopes_loose.
 remove(access_token.ver);
 access_token.'wlcg.ver' := '1.0';
 access_token.'aud' := 'https://wlcg.cern.ch/jwt/v1/any';
+access_token.'wlcg.groups' := group_list.;

--- a/oa4mp/serve.go
+++ b/oa4mp/serve.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pelicanplatform/pelican/daemon"
 	"github.com/pelicanplatform/pelican/oauth2"
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/web_ui"
 )
 
 type (
@@ -232,8 +233,12 @@ func ConfigureOA4MP() (launcher daemon.Launcher, err error) {
 
 	oidcAuthnUserClaim := param.Issuer_OIDCAuthenticationUserClaim.GetString()
 	groupSource := param.Issuer_GroupSource.GetString()
+	if groupSource != web_ui.GroupSourceTypeOIDC && groupSource != web_ui.GroupSourceTypeFile && groupSource != web_ui.GroupSourceTypeInternal {
+		err = errors.New("invalid group source: " + groupSource)
+		return
+	}
 	groupFile := param.Issuer_GroupFile.GetString()
-	if groupFile == "" && groupSource == "file" {
+	if groupFile == "" && groupSource == web_ui.GroupSourceTypeFile {
 		err = errors.New("Issuer.GroupFile must be set to use the 'file' group source")
 		return
 	}

--- a/oa4mp/serve.go
+++ b/oa4mp/serve.go
@@ -269,6 +269,16 @@ func ConfigureOA4MP() (launcher daemon.Launcher, err error) {
 				scope_actions = append(scope_actions, "storage.create")
 			case "modify":
 				scope_actions = append(scope_actions, "storage.modify")
+			case "collection_read":
+				scope_actions = append(scope_actions, "collection.read")
+			case "collection_write":
+				scope_actions = append(scope_actions, "collection.modify")
+			case "collection_create":
+				scope_actions = append(scope_actions, "collection.create")
+			case "collection_modify":
+				scope_actions = append(scope_actions, "collection.modify")
+			case "collection_delete":
+				scope_actions = append(scope_actions, "collection.delete")
 			default:
 				scope_actions = append(scope_actions, scope)
 			}

--- a/web_ui/oauth2_client.go
+++ b/web_ui/oauth2_client.go
@@ -257,7 +257,6 @@ func generateUserGroupInfo(userInfo map[string]interface{}, idToken map[string]i
 		if err != nil {
 			return "", nil, err
 		}
-		return user, groups, nil
 	case GroupSourceTypeInternal:
 		log.Debugf("Getting groups for user %s", user)
 		groupList, err := database.GetMemberGroups(database.ServerDatabase, user)
@@ -268,12 +267,12 @@ func generateUserGroupInfo(userInfo map[string]interface{}, idToken map[string]i
 		for _, group := range groupList {
 			groups = append(groups, group.Name)
 		}
-		log.Debugf("Groups for user %s: %v", user, groups)
-		return user, groups, nil
+
 	default:
 		err = errors.New("invalid group source: " + groupSource)
 		return "", nil, err
 	}
+	log.Debugf("Groups for user %s (source=%s): %v", user, groupSource, groups)
 	return user, groups, nil
 }
 


### PR DESCRIPTION
This PR addresses issue #2617. This PR allows for an authorization template to use a database defined group as a requirement for access. This PR also allows the Origin's built-in issuer to issue tokens with the collections scopes. 