### PR TITLE
Constraint width on alert so it doesn't go off screen

### DIFF
--- a/web_ui/frontend/components/AlertPortal.tsx
+++ b/web_ui/frontend/components/AlertPortal.tsx
@@ -39,7 +39,7 @@ export const AlertPortal = ({
         <Alert
           onClose={autoHideDuration ? undefined : onClose}
           severity={alertProps?.severity}
-          sx={{ width: '100%', maxWidth: { xs: "100vw", sm: "70vw" } }}
+          sx={{ width: '100%', maxWidth: { xs: '100vw', sm: '70vw' } }}
         >
           {title && <AlertTitle>{title}</AlertTitle>}
           {message}


### PR DESCRIPTION
100vw on phone and 70 on larger devices so that it doesn't go off the left of the screen.

Closes https://github.com/PelicanPlatform/pelican/issues/2201