### PR TITLE
Map deprecated values to the correct ones

### DIFF
--- a/web_ui/frontend/components/CapabilitiesDisplay.tsx
+++ b/web_ui/frontend/components/CapabilitiesDisplay.tsx
@@ -54,7 +54,9 @@ export const CapabilitiesChip = ({
         overflow: 'hidden',
       }}
     >
-      <Typography variant={'body2'}>{CAPABILITY_LABEL_MAP[name] || name}</Typography>
+      <Typography variant={'body2'}>
+        {CAPABILITY_LABEL_MAP[name] || name}
+      </Typography>
       <Box display={'flex'}>
         {value ? <Check fontSize='small' /> : <Clear fontSize='small' />}
       </Box>
@@ -74,9 +76,9 @@ export const CapabilityChipStyle = {
 };
 
 const CAPABILITY_LABEL_MAP: Record<string, string> = {
-  "PublicRead": "PublicReads",
-  "Read": "Reads",
-  "Write": "Writes",
-  "Listing": "Listings",
-  "FallBackRead": "DirectReads",
-}
+  PublicRead: 'PublicReads',
+  Read: 'Reads',
+  Write: 'Writes',
+  Listing: 'Listings',
+  FallBackRead: 'DirectReads',
+};


### PR DESCRIPTION
const CAPABILITY_LABEL_MAP: Record<string, string> = {
  "PublicRead": "PublicReads",
  "Read": "Reads",
  "Write": "Writes",
  "Listing": "Listings",
  "FallBackRead": "DirectReads",
}

Closes https://github.com/PelicanPlatform/pelican/issues/2263