### PR TITLE
Autofill Security Contact If From Origin

### DIFF
--- a/web_ui/frontend/app/registry/components/Form.tsx
+++ b/web_ui/frontend/app/registry/components/Form.tsx
@@ -1,21 +1,10 @@
 import { Alert, Box, Button } from '@mui/material';
-import React, {
-  Dispatch,
-  SetStateAction,
-  useContext,
-  useState,
-  useEffect,
-} from 'react';
+import React, { Dispatch, SetStateAction, useContext, useEffect, useState, } from 'react';
 import useSWR from 'swr';
 
 import { RegistryNamespace } from '@/index';
 import CustomRegistrationField from '@/app/registry/components/CustomRegistrationField/index';
-import {
-  calculateKeys,
-  deleteKey,
-  getValue,
-  populateKey,
-} from '@/app/registry/components/util';
+import { calculateKeys, deleteKey, getValue, populateKey, } from '@/app/registry/components/util';
 import { CustomRegistrationFieldProps } from './CustomRegistrationField';
 import { alertOnError } from '@/helpers/util';
 import { optionsNamespaceRegistrationFields } from '@/helpers/api';
@@ -74,11 +63,9 @@ const Form = ({ namespace, onSubmit }: FormProps) => {
   // Auto-fill in the security contact if no security contact and request came from Origin
   const { data: user } = useSWR('getUser', getUser);
   useEffect(() => {
-
     // If there is a fromUrl param then it came from the Origin
     // We can assume this user is likely to be the security contact
-    const fromUrl = (new URL(window.location.href)).searchParams.get("fromUrl");
-
+    const fromUrl = new URL(window.location.href).searchParams.get('fromUrl');
 
     if (
       fromUrl &&

--- a/web_ui/frontend/app/registry/components/Form.tsx
+++ b/web_ui/frontend/app/registry/components/Form.tsx
@@ -71,10 +71,17 @@ const Form = ({ namespace, onSubmit }: FormProps) => {
     { fallbackData: [] }
   );
 
-  // Auto-fill in the security contact if no security contact
+  // Auto-fill in the security contact if no security contact and request came from Origin
   const { data: user } = useSWR('getUser', getUser);
   useEffect(() => {
+
+    // If there is a fromUrl param then it came from the Origin
+    // We can assume this user is likely to be the security contact
+    const fromUrl = (new URL(window.location.href)).searchParams.get("fromUrl");
+
+
     if (
+      fromUrl &&
       user !== undefined &&
       !namespace?.admin_metadata?.security_contact_user_id
     ) {

--- a/web_ui/frontend/app/registry/components/Form.tsx
+++ b/web_ui/frontend/app/registry/components/Form.tsx
@@ -1,10 +1,21 @@
 import { Alert, Box, Button } from '@mui/material';
-import React, { Dispatch, SetStateAction, useContext, useEffect, useState, } from 'react';
+import React, {
+  Dispatch,
+  SetStateAction,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 import useSWR from 'swr';
 
 import { RegistryNamespace } from '@/index';
 import CustomRegistrationField from '@/app/registry/components/CustomRegistrationField/index';
-import { calculateKeys, deleteKey, getValue, populateKey, } from '@/app/registry/components/util';
+import {
+  calculateKeys,
+  deleteKey,
+  getValue,
+  populateKey,
+} from '@/app/registry/components/util';
 import { CustomRegistrationFieldProps } from './CustomRegistrationField';
 import { alertOnError } from '@/helpers/util';
 import { optionsNamespaceRegistrationFields } from '@/helpers/api';


### PR DESCRIPTION
Only autofill the security contact if the user is coming from the Origin registration button.

This is a solid indicator that the person that is doing the registration is the one that is responsible for the service and therefore a good security contact.

Closes https://github.com/PelicanPlatform/pelican/issues/2629