### PR TITLE
Add push to release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,3 +41,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+
+  # After the release is created, the post-release workflow will toggle the webhook to update pelicanplatform.org
+  upload-release:
+    needs: goreleaser
+    uses: ./.github/workflows/post-release.yaml


### PR DESCRIPTION
Current webhook toggle doesn't run because an action can't trigger another action. Update the release so that after the release is done we explicitly run the webhook.

Closes https://github.com/PelicanPlatform/pelican/issues/2631