### PR TITLE
Update downtimes

### DIFF
--- a/web_ui/frontend/app/registry/components/Form.tsx
+++ b/web_ui/frontend/app/registry/components/Form.tsx
@@ -71,10 +71,17 @@ const Form = ({ namespace, onSubmit }: FormProps) => {
     { fallbackData: [] }
   );
 
-  // Auto-fill in the security contact if no security contact
+  // Auto-fill in the security contact if no security contact and request came from Origin
   const { data: user } = useSWR('getUser', getUser);
   useEffect(() => {
+
+    // If there is a fromUrl param then it came from the Origin
+    // We can assume this user is likely to be the security contact
+    const fromUrl = (new URL(window.location.href)).searchParams.get("fromUrl");
+
+
     if (
+      fromUrl &&
       user !== undefined &&
       !namespace?.admin_metadata?.security_contact_user_id
     ) {

--- a/web_ui/frontend/components/Downtime/CalendarContext.tsx
+++ b/web_ui/frontend/components/Downtime/CalendarContext.tsx
@@ -40,7 +40,7 @@ export const CalendarDateTimeProvider = ({
   useEffect(() => {
     const now = new Date();
     const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
-    const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+    const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 1);
 
     setRange({
       startTime: startOfMonth.getTime(),

--- a/web_ui/frontend/components/Downtime/Card.tsx
+++ b/web_ui/frontend/components/Downtime/Card.tsx
@@ -7,6 +7,7 @@ import {
   Paper,
   Tooltip,
   Typography,
+  Badge
 } from '@mui/material';
 import React, { useContext, useState } from 'react';
 import { DateTime } from 'luxon'
@@ -50,128 +51,137 @@ const DowntimeCard = ({
       onMouseLeave={() => setHovered(false)}
       onClick={() => setExpanded(!expanded)}
     >
-      <Paper
-        elevation={hovered ? 3 : 1}
-        sx={{
-          width: '100%',
-          cursor: 'pointer',
-          display: 'flex',
-          flexDirection: 'row',
-          justifyContent: 'space-between',
-          border: 'solid #ececec 1px',
-          borderRadius: 2
-        }}
+      <Badge
+        color={'success'}
+        invisible={!updatedRecently}
+        badgeContent={' '}
       >
-        <Box width={'100%'} sx={{bgcolor: updatedRecently ? '#fff4e5' : 'inherit'}} p={1}>
-          <Grid container>
-            <Grid item xs={12}>
-              <Box display={'flex'} flexDirection={'row'} alignItems={'center'}>
-                <Box pr={1}>
-                  <Tooltip title={downtime.severity}>
-                    <DowntimeIcon
-                      sx={{ height: '100%' }}
-                      fontSize={'large'}
-                      severity={downtime.severity}
-                    />
-                  </Tooltip>
-                </Box>
-                <Box flexGrow={1}>
-                  {federationLevel && (
-                    <Typography variant={'subtitle2'}>
-                      {adjustedPrefix || downtime.serverName}
-                    </Typography>
-                  )}
-                  <Typography variant={'subtitle2'}>
-                    {downtime.description}
-                  </Typography>
-                </Box>
-                {editable && (
-                  <Box>
-                    <IconButton
-                      onClick={() => {
-                        setDowntime(downtime);
-                      }}
-                    >
-                      <Edit />
-                    </IconButton>
+        <Paper
+          elevation={hovered ? 3 : 1}
+          sx={{
+            width: '100%',
+            cursor: 'pointer',
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            border: 'solid #ececec 1px',
+            borderRadius: 2,
+            position: 'relative',
+            overflow: 'hidden',
+            p: 1
+          }}
+        >
+          <Box width={'100%'}>
+            <Grid container>
+              <Grid item xs={12}>
+                <Box display={'flex'} flexDirection={'row'} alignItems={'center'}>
+                  <Box pr={1}>
+                    <Tooltip title={downtime.severity}>
+                      <DowntimeIcon
+                        sx={{ height: '100%' }}
+                        fontSize={'large'}
+                        severity={downtime.severity}
+                      />
+                    </Tooltip>
                   </Box>
-                )}
-              </Box>
-            </Grid>
-            <Grid item xs={12}>
-              <Divider></Divider>
-            </Grid>
-            <Grid item xs={12}>
-              <Box width={'100%'} borderRadius={2} mt={1}>
-                <Grid container>
-                  <Grid item xs={6}>
+                  <Box flexGrow={1}>
+                    {federationLevel && (
+                      <Typography variant={'subtitle2'}>
+                        {adjustedPrefix || downtime.serverName}
+                      </Typography>
+                    )}
                     <Typography variant={'subtitle2'}>
-                      <b>Severity:</b> {downtime.severity}
+                      {downtime.description}
                     </Typography>
-                  </Grid>
-                  <Grid item xs={6}>
-                    <Typography variant={'subtitle2'}>
-                      <b>Local Start Time:</b>{' '}
-                      {new Date(downtime.startTime).toLocaleString()}
-                    </Typography>
-                  </Grid>
-                  <Grid item xs={6}>
-                    <Typography variant={'subtitle2'}>
-                      <b>Class:</b> {downtime.class}
-                    </Typography>
-                  </Grid>
-                  <Grid item xs={6}>
-                    <Typography variant={'subtitle2'}>
-                      <b>Local End Time:</b>{' '}
-                      {downtime.endTime === -1
-                        ? 'None'
-                        : new Date(downtime.endTime).toLocaleString()}
-                    </Typography>
-                  </Grid>
-                </Grid>
-                <Collapse in={expanded} timeout={100} sx={{ width: '100%' }}>
+                  </Box>
+                  {editable && (
+                    <Box>
+                      <IconButton
+                        onClick={() => {
+                          setDowntime(downtime);
+                        }}
+                      >
+                        <Edit />
+                      </IconButton>
+                    </Box>
+                  )}
+                </Box>
+              </Grid>
+              <Grid item xs={12}>
+                <Divider></Divider>
+              </Grid>
+              <Grid item xs={12}>
+                <Box width={'100%'} borderRadius={2} mt={1}>
                   <Grid container>
                     <Grid item xs={6}>
                       <Typography variant={'subtitle2'}>
-                        <b>Created By:</b> {downtime.createdBy}
+                        <b>Severity:</b> {downtime.severity}
                       </Typography>
                     </Grid>
                     <Grid item xs={6}>
                       <Typography variant={'subtitle2'}>
-                        <b>Local Creation Time:</b>{' '}
-                        {new Date(downtime.createdAt).toLocaleString()}
+                        <b>Local Start Time:</b>{' '}
+                        {new Date(downtime.startTime).toLocaleString()}
                       </Typography>
                     </Grid>
                     <Grid item xs={6}>
                       <Typography variant={'subtitle2'}>
-                        <b>Updated By:</b> {downtime.updatedBy}
+                        <b>Class:</b> {downtime.class}
                       </Typography>
                     </Grid>
                     <Grid item xs={6}>
                       <Typography variant={'subtitle2'}>
-                        <b>Local Update Time:</b>{' '}
-                        {new Date(downtime.updatedAt).toLocaleString()}
+                        <b>Local End Time:</b>{' '}
+                        {downtime.endTime === -1
+                          ? 'None'
+                          : new Date(downtime.endTime).toLocaleString()}
                       </Typography>
                     </Grid>
-                    <Grid item xs={6}>
-                      <Typography variant={'subtitle2'}>
-                        <b>ID:</b> {downtime.id}
-                      </Typography>
-                    </Grid>
-                    {federationLevel && (
+                  </Grid>
+                  <Collapse in={expanded} timeout={100} sx={{ width: '100%' }}>
+                    <Grid container>
                       <Grid item xs={6}>
                         <Typography variant={'subtitle2'}>
-                          <b>Server:</b> {downtime.source}
+                          <b>Created By:</b> {downtime.createdBy}
                         </Typography>
                       </Grid>
-                    )}
-                  </Grid>
-                </Collapse>
-              </Box>
+                      <Grid item xs={6}>
+                        <Typography variant={'subtitle2'}>
+                          <b>Local Creation Time:</b>{' '}
+                          {new Date(downtime.createdAt).toLocaleString()}
+                        </Typography>
+                      </Grid>
+                      <Grid item xs={6}>
+                        <Typography variant={'subtitle2'}>
+                          <b>Updated By:</b> {downtime.updatedBy}
+                        </Typography>
+                      </Grid>
+                      <Grid item xs={6}>
+                        <Typography variant={'subtitle2'}>
+                          <b>Local Update Time:</b>{' '}
+                          {new Date(downtime.updatedAt).toLocaleString()}
+                        </Typography>
+                      </Grid>
+                      <Grid item xs={6}>
+                        <Typography variant={'subtitle2'}>
+                          <b>ID:</b> {downtime.id}
+                        </Typography>
+                      </Grid>
+                      {federationLevel && (
+                        <Grid item xs={6}>
+                          <Typography variant={'subtitle2'}>
+                            <b>Server:</b> {downtime.source}
+                          </Typography>
+                        </Grid>
+                      )}
+                    </Grid>
+                  </Collapse>
+                </Box>
+              </Grid>
             </Grid>
-          </Grid>
-        </Box>
-      </Paper>
+          </Box>
+        </Paper>
+      </Badge>
     </Box>
   );
 };

--- a/web_ui/frontend/components/Downtime/Card.tsx
+++ b/web_ui/frontend/components/Downtime/Card.tsx
@@ -9,10 +9,13 @@ import {
   Typography,
 } from '@mui/material';
 import React, { useContext, useState } from 'react';
+import { DateTime } from 'luxon'
 import DowntimeIcon from './DowntimeIcon';
 import { Edit } from '@mui/icons-material';
 import { DowntimeEditDispatchContext } from '@/components/Downtime/DowntimeEditContext';
 import { DowntimeGet } from '@/types';
+import extendPrefix from '@/helpers/extendPrefix';
+import isRecent from '@/components/Downtime/isRecent';
 
 interface GeneralDowntimeCardProps {
   downtime: DowntimeGet;
@@ -37,6 +40,10 @@ const DowntimeCard = ({
   const [hovered, setHovered] = useState(false);
   const [expanded, setExpanded] = useState(false);
 
+  const {type, adjustedPrefix} = extendPrefix(downtime.serverName)
+
+  const updatedRecently = isRecent(DateTime.fromMillis(downtime.updatedAt));
+
   return (
     <Box
       onMouseEnter={() => setHovered(true)}
@@ -52,11 +59,10 @@ const DowntimeCard = ({
           flexDirection: 'row',
           justifyContent: 'space-between',
           border: 'solid #ececec 1px',
-          borderRadius: 2,
-          p: 1,
+          borderRadius: 2
         }}
       >
-        <Box width={'100%'}>
+        <Box width={'100%'} sx={{bgcolor: updatedRecently ? '#fff4e5' : 'inherit'}} p={1}>
           <Grid container>
             <Grid item xs={12}>
               <Box display={'flex'} flexDirection={'row'} alignItems={'center'}>
@@ -72,7 +78,7 @@ const DowntimeCard = ({
                 <Box flexGrow={1}>
                   {federationLevel && (
                     <Typography variant={'subtitle2'}>
-                      {downtime.serverName}
+                      {adjustedPrefix || downtime.serverName}
                     </Typography>
                   )}
                   <Typography variant={'subtitle2'}>

--- a/web_ui/frontend/components/Downtime/DowntimeModal.tsx
+++ b/web_ui/frontend/components/Downtime/DowntimeModal.tsx
@@ -48,4 +48,6 @@ const style = {
   p: 2,
   width: '600px',
   maxWidth: '100%',
+  maxHeight: '100%',
+  overflowY: 'auto',
 };

--- a/web_ui/frontend/components/Downtime/EditDowntimePageHeader.tsx
+++ b/web_ui/frontend/components/Downtime/EditDowntimePageHeader.tsx
@@ -1,8 +1,7 @@
 import React, { useContext } from 'react';
 import { DowntimeEditDispatchContext } from '@/components/Downtime/DowntimeEditContext';
 import { Box, Button, Typography } from '@mui/material';
-import { CalendarDateTimeContext } from '@/components/Downtime/CalendarContext';
-
+import AuthenticatedContent from '@/components/layout/AuthenticatedContent';
 const EditDowntimePageHeader = () => {
   const setDowntime = useContext(DowntimeEditDispatchContext);
 
@@ -13,15 +12,17 @@ const EditDowntimePageHeader = () => {
       justifyContent={'space-between'}
     >
       <Typography variant={'h4'}>Service Downtime</Typography>
-      <Button
-        variant={'contained'}
-        color={'primary'}
-        onClick={() => {
-          setDowntime({});
-        }}
-      >
-        Create Downtime
-      </Button>
+      <AuthenticatedContent allowedRoles={['admin']} >
+        <Button
+          variant={'contained'}
+          color={'primary'}
+          onClick={() => {
+            setDowntime({});
+          }}
+        >
+          Create Downtime
+        </Button>
+      </AuthenticatedContent>
     </Box>
   );
 };

--- a/web_ui/frontend/components/Downtime/Registry/RegistryDowntimePage.tsx
+++ b/web_ui/frontend/components/Downtime/Registry/RegistryDowntimePage.tsx
@@ -33,13 +33,12 @@ const ServerDowntimePage = () => {
     }
   }, [setDowntime]);
 
-  const { data } = useApiSWR<DowntimeGet[]>(
+  const { data: downtimes } = useApiSWR<DowntimeGet[]>(
     'Failed to fetch downtimes',
     ServerDowntimeKey,
     getDowntime
   );
-
-  const downtimes = sortDowntimes(data || [])
+  const sortedDowntimes = sortDowntimes(downtimes || [])
 
   return (
     <>
@@ -48,9 +47,9 @@ const ServerDowntimePage = () => {
           <Grid item xs={12} lg={12}>
             <EditDowntimePageHeader />
             <Box my={2}>
-              <DowntimeCalendar data={data} />
+              <DowntimeCalendar data={downtimes} />
             </Box>
-            <RegistryDowntimeList data={downtimes} />
+            <RegistryDowntimeList data={sortedDowntimes} />
           </Grid>
         </Grid>
       </Box>

--- a/web_ui/frontend/components/Downtime/Registry/RegistryDowntimePage.tsx
+++ b/web_ui/frontend/components/Downtime/Registry/RegistryDowntimePage.tsx
@@ -15,6 +15,7 @@ import useApiSWR from '@/hooks/useApiSWR';
 import { DowntimeGet } from '@/types';
 import { ServerDowntimeKey } from '@/components/Downtime';
 import { getDowntime } from '@/helpers/api';
+import sortDowntimes from '@/components/Downtime/sortDowntimes';
 
 const ServerDowntimePage = () => {
   const setDowntime = useContext(DowntimeEditDispatchContext);
@@ -38,6 +39,8 @@ const ServerDowntimePage = () => {
     getDowntime
   );
 
+  const downtimes = sortDowntimes(data || [])
+
   return (
     <>
       <Box>
@@ -47,7 +50,7 @@ const ServerDowntimePage = () => {
             <Box my={2}>
               <DowntimeCalendar data={data} />
             </Box>
-            <RegistryDowntimeList data={data} />
+            <RegistryDowntimeList data={downtimes} />
           </Grid>
         </Grid>
       </Box>

--- a/web_ui/frontend/components/Downtime/Registry/ServerUnknownDowntimeForm.tsx
+++ b/web_ui/frontend/components/Downtime/Registry/ServerUnknownDowntimeForm.tsx
@@ -44,6 +44,7 @@ import useApiSWR from '@/hooks/useApiSWR';
 import extendNamespace from '@/helpers/Registry/namespaceToServer';
 import { NamespaceIcon } from '@/components';
 import getUtcOffsetString from '@/helpers/getUtcOffsetString';
+import { defaultDowntime } from '@/components/Downtime/constant';
 
 interface DowntimeFormProps {
   downtime: Partial<DowntimeGet>;
@@ -291,26 +292,6 @@ const submitDowntime = async (
       dispatch
     );
   }
-};
-
-const namespacesToRegistryServers = (
-  namespaces: RegistryNamespace[]
-): string[] => {
-  const originsAndCaches = namespaces.filter(
-    (n) => n.prefix.startsWith('/origin') || n.prefix.startsWith('/cache')
-  );
-
-  // Pull the prefixes out of the namespaces
-  return originsAndCaches.map((n) => n.prefix);
-};
-
-const defaultDowntime = {
-  serverName:  '',
-  startTime: DateTime.now().toMillis(),
-  endTime: DateTime.now().plus({days: 1}).toMillis(),
-  description: '',
-  severity: 'Outage (completely inaccessible)' as DowntimeSeverity,
-  class: 'SCHEDULED' as DowntimeClass,
 };
 
 export default ServerUnknownDowntimeForm;

--- a/web_ui/frontend/components/Downtime/Registry/ServerUnknownDowntimeForm.tsx
+++ b/web_ui/frontend/components/Downtime/Registry/ServerUnknownDowntimeForm.tsx
@@ -123,7 +123,7 @@ const ServerUnknownDowntimeForm = ({
           }
           value={
             servers.filter((x) => x.prefix == downtime.serverName)[0] ||
-            servers[0]
+            null
           }
           onChange={(e, v) => {
             if (!v) return;

--- a/web_ui/frontend/components/Downtime/Server/ServerDowntimePage.tsx
+++ b/web_ui/frontend/components/Downtime/Server/ServerDowntimePage.tsx
@@ -15,16 +15,18 @@ import useApiSWR from '@/hooks/useApiSWR';
 import { DowntimeGet } from '@/types';
 import { ServerDowntimeKey } from '@/components/Downtime';
 import { getDowntime } from '@/helpers/api';
+import sortDowntimes from '@/components/Downtime/sortDowntimes';
 
 const ServerDowntimePage = () => {
   const setDowntime = useContext(DowntimeEditDispatchContext);
   const downtime = useContext(DowntimeEditContext);
 
-  const { data } = useApiSWR<DowntimeGet[]>(
+  const { data: downtimes } = useApiSWR<DowntimeGet[]>(
     'Failed to fetch downtimes',
     ServerDowntimeKey,
     getDowntime
   );
+  const sortedDowntimes = sortDowntimes(downtimes || [])
 
   return (
     <>
@@ -33,9 +35,9 @@ const ServerDowntimePage = () => {
           <Grid item xs={12} lg={12}>
             <EditDowntimePageHeader />
             <Box my={2}>
-              <DowntimeCalendar data={data} />
+              <DowntimeCalendar data={downtimes} />
             </Box>
-            <DowntimeList data={data} />
+            <DowntimeList data={sortedDowntimes} />
           </Grid>
         </Grid>
       </Box>

--- a/web_ui/frontend/components/Downtime/constant.ts
+++ b/web_ui/frontend/components/Downtime/constant.ts
@@ -1,0 +1,12 @@
+import {DateTime} from "luxon";
+import { DowntimeClass, DowntimeSeverity } from '@/types';
+
+export const defaultDowntime = {
+	serverName:  '',
+	startTime: DateTime.now().toMillis(),
+	endTime: DateTime.now().plus({days: 1}).toMillis(),
+	description: '',
+	severity: 'Outage (completely inaccessible)' as DowntimeSeverity,
+	class: 'SCHEDULED' as DowntimeClass,
+};
+

--- a/web_ui/frontend/components/Downtime/isRecent.ts
+++ b/web_ui/frontend/components/Downtime/isRecent.ts
@@ -1,0 +1,7 @@
+import { DateTime } from 'luxon';
+
+const isRecent = (date: DateTime) => {
+  return date > DateTime.now().minus({ minutes: 10 });
+}
+
+export default isRecent;

--- a/web_ui/frontend/components/Downtime/sortDowntimes.ts
+++ b/web_ui/frontend/components/Downtime/sortDowntimes.ts
@@ -1,0 +1,23 @@
+import { DowntimeGet } from '@/types';
+
+import { DateTime } from 'luxon';
+import isRecent from '@/components/Downtime/isRecent';
+
+const sortDowntimes = (downtimes: DowntimeGet[]) => {
+  return downtimes.sort((a, b) => {
+    return scoreDowntime(b) - scoreDowntime(a);
+  });
+}
+
+/**
+ * Score function to determine order
+ * Goal is to group by recently updated, then start time
+ * @param downtime
+ */
+const scoreDowntime = (downtime: DowntimeGet): number => {
+  const recentlyUpdated = isRecent(DateTime.fromMillis(downtime.updatedAt))
+  const score = recentlyUpdated ? 100000000000000 : 0;
+  return score + downtime.startTime;
+}
+
+export default sortDowntimes;

--- a/web_ui/frontend/helpers/Registry/namespaceToServer.ts
+++ b/web_ui/frontend/helpers/Registry/namespaceToServer.ts
@@ -1,4 +1,5 @@
 import { RegistryNamespace } from '@/index';
+import extendPrefix from '@/helpers/extendPrefix';
 
 /**
  * Extends a registry namespace
@@ -7,18 +8,8 @@ import { RegistryNamespace } from '@/index';
 const extendNamespace = (
   namespace: Omit<RegistryNamespace, 'type' | 'adjustedPrefix'>
 ): RegistryNamespace => {
-  let type: RegistryNamespace['type'] = 'namespace';
-  let adjustedPrefix = undefined;
 
-  // Prefixes that start with /caches/ or /origins/ are considered cache or origin namespaces
-  if (namespace.prefix.startsWith('/caches/')) {
-    type = 'cache';
-    adjustedPrefix = namespace.prefix.replace('/caches/', '');
-  } else if (namespace.prefix.startsWith('/origins/')) {
-    type = 'origin';
-    adjustedPrefix = namespace.prefix.replace('/origins/', '');
-  }
-
+  const {type, adjustedPrefix} = extendPrefix(namespace.prefix);
   return {
     ...namespace,
     type,

--- a/web_ui/frontend/helpers/extendPrefix.ts
+++ b/web_ui/frontend/helpers/extendPrefix.ts
@@ -1,0 +1,30 @@
+import { RegistryNamespace } from '@/index';
+
+/**
+ * Extends a registry namespace
+ * @param prefix - Registration prefix, prefixed with /caches/ or /origins/ for cache or origin types, otherwise a namespace
+ */
+const extendPrefix = (
+  prefix: string
+): {type: RegistryNamespace['type'], adjustedPrefix: string } => {
+
+  if (prefix.startsWith('/caches/')) {
+    return {
+      type: "cache",
+      adjustedPrefix: prefix.replace('/caches/', ''),
+    }
+
+  } else if (prefix.startsWith('/origins/')) {
+    return {
+      type: 'origin',
+      adjustedPrefix: prefix.replace('/origins/', ''),
+    }
+  }
+
+  return {
+    type: 'namespace',
+    adjustedPrefix: prefix,
+  }
+};
+
+export default extendPrefix;

--- a/web_ui/frontend/styles/shimmer.module.css
+++ b/web_ui/frontend/styles/shimmer.module.css
@@ -1,0 +1,16 @@
+.shimmer::after {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, rgba(255,244,229,0) 0%, rgba(255,244,229,0.7) 50%, rgba(255,244,229,0) 100%);
+    animation: shimmer 1.5s 1;
+    pointer-events: none;
+    z-index: 1;
+}
+
+@keyframes shimmer {
+    0% { transform: translateX(-100%); }
+    100% { transform: translateX(100%); }
+}


### PR DESCRIPTION
Closes:
- https://github.com/PelicanPlatform/pelican/issues/2512
- https://github.com/PelicanPlatform/pelican/issues/2582

Solves:
- By default, creating a downtime creates a 0-second-long downtime starting now. That's a pretty useless default. Let's have the default be 24 hours starting now.
- There's a drop-down for scheduled/unscheduled. That's historical baggage from the LHC. Let's remove the UI element and set it automatically (if >24 hours in advance, it's scheduled; otherwise, it's unscheduled).
- Don't show the internal prefix (/caches/blah); have a dropdown for service type and a dropdown of the service to select.
- After clicking "Submit", it shows the list of downtimes in the default mode and it's impossible to pick out which one I just created. Highlight (or only show?) the newly-created downtime.
- Similar to (4), in the downtime view, never show /caches/CHTC_PELICAN_CACHE but just show CHTC_PELICAN_CACHE and a UI element whether it's a cache or origin.
- Sort the services in the drop-down alphabetically
- Do not allow me to click the "create downtime" button if I'm not logged in (instead of letting me fill out the information and only rejecting it when I click submit
- Allow scrolling the Create Downtime box as a whole in case I don't have enough vertical space to display the whole thing
- Indicate new additions better with a badge
- Fix the auto selection in the form