### PR TITLE
Fix panic in thread creations metric

### DIFF
--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -473,9 +473,7 @@ var (
 		Help: "Number of scheduler threads",
 	}, []string{"state"})
 
-	// Unlink thread destructions this metric is not monotonic so we need to use a gauge
-	// See https://github.com/xrootd/xrootd/blob/f1de2038e0c5c10990769f5b7ff82200cc8c3d56/src/Xrd/XrdScheduler.cc#L700
-	ThreadCreations = promauto.NewGauge(prometheus.GaugeOpts{
+	ThreadCreations = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "xrootd_sched_thread_creations",
 		Help: "Number of scheduler thread creations",
 	})
@@ -1890,9 +1888,16 @@ func HandleSummaryPacket(packet []byte) error {
 			Queued.Set(float64(stat.Queued))
 			LongestQueue.Set(float64(stat.LongestQueue))
 			Jobs.Set(float64(stat.Jobs))
-			ThreadCreations.Set(float64(stat.ThreadCreations))
+			// We have to do this exclusively for thread creations because the metric is not monotonic
+			// See https://github.com/xrootd/xrootd/blob/f1de2038e0c5c10990769f5b7ff82200cc8c3d56/src/Xrd/XrdScheduler.cc#L700
+			incBy := float64(stat.ThreadCreations - lastStats.ThreadCreations)
+			if stat.ThreadCreations < lastStats.ThreadCreations {
+				incBy = 0
+			}
+			ThreadCreations.Add(incBy)
 			ThreadDestructions.Add(float64(stat.ThreadDestructions - lastStats.ThreadDestructions))
 			ThreadLimitReached.Add(float64(stat.ThreadLimitReached - lastStats.ThreadLimitReached))
+			lastStats.ThreadCreations = stat.ThreadCreations
 			lastStats.ThreadDestructions = stat.ThreadDestructions
 			lastStats.ThreadLimitReached = stat.ThreadLimitReached
 		case OssStat: // Oss stat should only appear on origin servers

--- a/metrics/xrootd_metrics_test.go
+++ b/metrics/xrootd_metrics_test.go
@@ -258,7 +258,7 @@ func TestHandlePacket(t *testing.T) {
 				threadCreations: 10,
 				expectedMetric: `
 # HELP xrootd_sched_thread_creations Number of scheduler thread creations
-# TYPE xrootd_sched_thread_creations gauge
+# TYPE xrootd_sched_thread_creations counter
 xrootd_sched_thread_creations 10
 `,
 			},
@@ -267,8 +267,8 @@ xrootd_sched_thread_creations 10
 				threadCreations: 5,
 				expectedMetric: `
 # HELP xrootd_sched_thread_creations Number of scheduler thread creations
-# TYPE xrootd_sched_thread_creations gauge
-xrootd_sched_thread_creations 5
+# TYPE xrootd_sched_thread_creations counter
+xrootd_sched_thread_creations 10
 `,
 			},
 		}


### PR DESCRIPTION
This PR addresses issue #2637. This PR changes the ThreadCreations metric from a counter to a gauge. This is because the underlying data from [XrootD is not monotonic](https://github.com/xrootd/xrootd/blob/f1de2038e0c5c10990769f5b7ff82200cc8c3d56/src/Xrd/XrdScheduler.cc#L700).

Note for reviewer:
Not sure if we should backport/patch this into 7.19, to include it into 7.20, or to wait and make it a 7.21 bug fix.