### PR TITLE
Update pre-commit to run in smarter locations

### DIFF
--- a/.github/workflows/format-fix.yml
+++ b/.github/workflows/format-fix.yml
@@ -1,4 +1,4 @@
-name: Format and Push Web UI
+name: Format and Push
 
 on:
   pull_request:
@@ -54,5 +54,63 @@ jobs:
           if [[ $(git status --porcelain) ]]; then
             git add .
             git commit -m 'Run Prettier via GitHub Actions'
+            git push origin HEAD:${{ github.head_ref }}
+          fi
+
+  format_go_code:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          persist-credentials: false # Needed so as not to use the default GITHUB_TOKEN
+
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.LINT_APP_ID }}
+          private-key: ${{ secrets.LINT_APP_PRIVATE_KEY }}
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api \"/users/${{ steps.app-token.outputs.app-slug }}[bot]\" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up git user
+        run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+
+      - name: Set remote URL
+        run: git remote set-url origin "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git"
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: false
+
+      - name: Generate placeholder files
+        id: generate-placeholder
+        run: |
+          go generate ./...
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files --hook-stage manual
+        continue-on-error: true
+
+      - name: Commit and push changes
+        run: |
+          if [[ $(git status --porcelain) ]]; then
+            git add .
+            git commit -m 'Run Go Pre Commit and Push via GitHub Actions'
             git push origin HEAD:${{ github.head_ref }}
           fi

--- a/.github/workflows/pre-commit-linter.yml
+++ b/.github/workflows/pre-commit-linter.yml
@@ -42,20 +42,3 @@ jobs:
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
-
-  prettier-linter:
-    name: prettier-linter
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Move to the web repository
-        run: |
-          cd web_ui/frontend
-          npm install
-          npm run format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,17 +24,22 @@ repos:
     hooks:
     -   id: trailing-whitespace
         exclude: github_scripts/pelican_protocol.patch
+        stages: [manual]
     -   id: end-of-file-fixer
+        stages: [manual]
     -   id: check-yaml
         # Multi-documents are yaml files with multiple --- separating blocks, like
         # in our docs/parameters.yaml. We need this argument so those parse.
         args: [--allow-multiple-documents]
+        stages: [manual]
     -   id: check-added-large-files
         args: ['--maxkb=1024']
+        stages: [commit]
 -   repo: https://github.com/golangci/golangci-lint
     rev: v1.64.8
     hooks:
     -   id: golangci-lint
+        stages: [push]
 -   repo: https://github.com/crate-ci/typos
     rev: v1.28.2
     hooks:
@@ -42,8 +47,10 @@ repos:
         # Override the default arguments, which include writing back all
         # suggested changes. We don't want false positives to mangle files.
         args: [--force-exclude, --sort]
+        stages: [push]
 -   repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.10.0.1
     hooks:
     -   id: shellcheck
         args: [--severity=warning]
+        stages: [push]


### PR DESCRIPTION
Tweak when the pre-commits are run. Offloads some of them for the final push, and the ones that it can fix automatically are handled automatically rather then bothering the dev.

The following items are run/fixed automatically by CI:

1. trailing-whitespace
1. end-of-file-fixer

These are run on each commit:

1. check-yaml
1. check-added-large-files

These are checked on push:

1. typos
2. shellcheck
3. golangci-lint

I am iffy on where yall want the ones that aren't automatic.