### PR TITLE
Overhaul the Director's sorting algorithms

### DIFF
--- a/.github/workflows/pre-commit-linter.yml
+++ b/.github/workflows/pre-commit-linter.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          version: v2.4.0
           args: --config=.golangci.yaml
 
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
 # ***************************************************************
 #
-#  Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+#  Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you
 #  may not use this file except in compliance with the License.  You may

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
 # ***************************************************************
 #
-#  Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+#  Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you
 #  may not use this file except in compliance with the License.  You may

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     -   id: check-added-large-files
         args: ['--maxkb=1024']
 -   repo: https://github.com/golangci/golangci-lint
-    rev: v2.4.0
+    rev: v1.64.8
     hooks:
     -   id: golangci-lint
 -   repo: https://github.com/crate-ci/typos

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     -   id: check-added-large-files
         args: ['--maxkb=1024']
 -   repo: https://github.com/golangci/golangci-lint
-    rev: v1.64.8
+    rev: v2.4.0
     hooks:
     -   id: golangci-lint
 -   repo: https://github.com/crate-ci/typos

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -36,6 +36,7 @@ Server:
 Director:
   DefaultResponse: cache
   CacheSortMethod: "distance"
+  FilterCachesInErrorState: true
   AdaptiveSortEWMATimeConstant: 5m
   MinStatResponse: 1
   MaxStatResponse: 1

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -100,7 +100,8 @@ func LaunchTTLCache(ctx context.Context, egrp *errgroup.Group) {
 	// Start automatic expired item deletion
 	go serverAds.Start()
 	go namespaceKeys.Start()
-	go clientIpCache.Start()
+	go clientIpRandAssignmentCache.Start()
+	go clientIpGeoOverrideCache.Start()
 	go directorAds.Start()
 
 	serverAds.OnEviction(func(ctx context.Context, er ttlcache.EvictionReason, i *ttlcache.Item[string, *server_structs.Advertisement]) {
@@ -171,8 +172,10 @@ func LaunchTTLCache(ctx context.Context, egrp *errgroup.Group) {
 		serverAds.Stop()
 		namespaceKeys.DeleteAll()
 		namespaceKeys.Stop()
-		clientIpCache.DeleteAll()
-		clientIpCache.Stop()
+		clientIpRandAssignmentCache.DeleteAll()
+		clientIpRandAssignmentCache.Stop()
+		clientIpGeoOverrideCache.DeleteAll()
+		clientIpGeoOverrideCache.Stop()
 		directorAds.DeleteAll()
 		directorAds.Stop()
 		log.Info("Director TTL cache eviction has been stopped")

--- a/director/director_ui.go
+++ b/director/director_ui.go
@@ -50,6 +50,7 @@ type (
 		URL          string                      `json:"url"`    // This is server's XRootD URL for file transfer
 		WebURL       string                      `json:"webUrl"` // This is server's Web interface and API
 		Type         string                      `json:"type"`
+		Coordinate   server_structs.Coordinate   `json:"coordinate"`
 		Latitude     float64                     `json:"latitude"`
 		Longitude    float64                     `json:"longitude"`
 		Caps         server_structs.Capabilities `json:"capabilities"`
@@ -90,6 +91,7 @@ type (
 		URL                    string                      `json:"url"`    // This is server's XRootD URL for file transfer
 		WebURL                 string                      `json:"webUrl"` // This is server's Web interface and API
 		Type                   string                      `json:"type"`
+		Coordinate             server_structs.Coordinate   `json:"coordinate"`
 		Latitude               float64                     `json:"latitude"`
 		Longitude              float64                     `json:"longitude"`
 		Caps                   server_structs.Capabilities `json:"capabilities"`

--- a/director/sort.go
+++ b/director/sort.go
@@ -467,7 +467,10 @@ func getSortedAds(ctx *gin.Context, requestId uuid.UUID) (sortedOrigins, sortedC
 	// 2. Supported predicates: if the cache passes the common predicate, we can mark whether we know it supports a feature.
 	// 3. Unknown predicates: if the cache passes the common predicate but we don't know if it supports a feature, we can
 	//    mark it as unknown.
-	commonPredicates := []AdPredicate{cacheNotInErrorState(), cacheNotFromTopoIfPubReads()}
+	commonPredicates := []AdPredicate{cacheNotFromTopoIfPubReads()}
+	if param.Director_FilterCachesInErrorState.GetBool() {
+		commonPredicates = append(commonPredicates, cacheNotInErrorState())
+	}
 	supportedPredicates := []AdPredicate{cacheSupportsFeature(requiredFeatures)}
 	unknownPredicates := []AdPredicate{cacheMightSupportFeature(requiredFeatures)}
 	sortedCaches, unknownCaches := filterCaches(ctx, cacheAds, commonPredicates, supportedPredicates, unknownPredicates)

--- a/director/sort.go
+++ b/director/sort.go
@@ -69,8 +69,8 @@ const (
 //     and the server IO load
 //   - random: sort serverAds randomly
 //   - adaptive:  sort serverAds based on rules discussed in these places:
-//       - https://github.com/PelicanPlatform/pelican/discussions/1198
-//       - https://docs.google.com/document/d/1w-1oUhFTN6QN_PfQ5qbS7uf8Su3K8q6MZD3TGLKTHB8/edit?tab=t.0
+//   - https://github.com/PelicanPlatform/pelican/discussions/1198
+//   - https://docs.google.com/document/d/1w-1oUhFTN6QN_PfQ5qbS7uf8Su3K8q6MZD3TGLKTHB8/edit?tab=t.0
 //
 // Note that if the client IP isn't overridden and MaxMind cannot resolve accurate coordinates for it, the client's
 // coordinate is randomly assigned within the contiguous US and cached for re-use. This means that distance-based sorts

--- a/director/sort.go
+++ b/director/sort.go
@@ -70,7 +70,7 @@ const (
 //   - random: sort serverAds randomly
 //   - adaptive:  sort serverAds based on rules discussed in these places:
 //   - https://github.com/PelicanPlatform/pelican/discussions/1198
-//   - https://docs.google.com/document/d/1w-1oUhFTN6QN_PfQ5qbS7uf8Su3K8q6MZD3TGLKTHB8/edit?tab=t.0
+//   - https://docs.google.com/document/d/e/2PACX-1vQg9biPzp3RbC5qVuJFvgMZHgIM-nw92JzjHkGl-h7djeNNXa68ckv2rAqtXEDYe8QvXL3oX0Fr0-bp/pub
 //
 // Note that if the client IP isn't overridden and MaxMind cannot resolve accurate coordinates for it, the client's
 // coordinate is randomly assigned within the contiguous US and cached for re-use. This means that distance-based sorts

--- a/director/sort_algorithms.go
+++ b/director/sort_algorithms.go
@@ -385,7 +385,7 @@ func (ds *DistanceSort) Sort(sAds []server_structs.ServerAd, sCtx SortContext) (
 // An adaptive sort that combines multiple factors: distance, IO load, status weight, and availability.
 // See:
 //   - https://github.com/PelicanPlatform/pelican/discussions/1198
-//   - https://docs.google.com/document/d/1w-1oUhFTN6QN_PfQ5qbS7uf8Su3K8q6MZD3TGLKTHB8/edit?tab=t.0
+//   - https://docs.google.com/document/d/e/2PACX-1vQg9biPzp3RbC5qVuJFvgMZHgIM-nw92JzjHkGl-h7djeNNXa68ckv2rAqtXEDYe8QvXL3oX0Fr0-bp/pub
 type AdaptiveSort struct{}
 
 func (rs *AdaptiveSort) Type() server_structs.SortType {

--- a/director/sort_algorithms_test.go
+++ b/director/sort_algorithms_test.go
@@ -761,7 +761,18 @@ func TestDistanceSortAlg(t *testing.T) {
 					}
 					serverInfo := *tc.sCtx.RedirectInfo.ServersInfo[ad.URL.String()]
 
-					assert.EqualValues(t, expectedRInfo, serverInfo, "redirect info for ad '%s' does not match expected", ad.Name)
+					// Compare coordinates
+					assert.Equal(t, expectedRInfo.Coordinate.Lat, serverInfo.Coordinate.Lat, "lat mismatch for ad '%s'", ad.Name)
+					assert.Equal(t, expectedRInfo.Coordinate.Long, serverInfo.Coordinate.Long, "long mismatch for ad '%s'", ad.Name)
+					assert.Equal(t, expectedRInfo.Coordinate.AccuracyRadius, serverInfo.Coordinate.AccuracyRadius, "accuracy radius mismatch for ad '%s'", ad.Name)
+					assert.Equal(t, expectedRInfo.Coordinate.Source, serverInfo.Coordinate.Source, "coordinate source mismatch for ad '%s'", ad.Name)
+					assert.Equal(t, expectedRInfo.Coordinate.FromTTLCache, serverInfo.Coordinate.FromTTLCache, "fromTTLCache mismatch for ad '%s'", ad.Name)
+
+					// Compare redirect weights (in delta because of floating point math)
+					assert.InDelta(t, expectedRInfo.RedirectWeights.DistanceWeight, serverInfo.RedirectWeights.DistanceWeight, 1e-8, "distance weight mismatch for ad '%s'", ad.Name)
+					assert.InDelta(t, expectedRInfo.RedirectWeights.IOLoadWeight, serverInfo.RedirectWeights.IOLoadWeight, 1e-8, "io load weight mismatch for ad '%s'", ad.Name)
+					assert.InDelta(t, expectedRInfo.RedirectWeights.StatusWeight, serverInfo.RedirectWeights.StatusWeight, 1e-8, "status weight mismatch for ad '%s'", ad.Name)
+					assert.InDelta(t, expectedRInfo.RedirectWeights.AvailabilityWeight, serverInfo.RedirectWeights.AvailabilityWeight, 1e-8, "availability weight mismatch for ad '%s'", ad.Name)
 				}
 			}
 		})
@@ -976,8 +987,18 @@ func TestAdaptiveSortAlg(t *testing.T) {
 						}
 						serverInfo := *tc.sCtx.RedirectInfo.ServersInfo[ad.URL.String()]
 
-						// Use require here because if this fails, sorts may be invalid
-						require.EqualValues(t, expectedRInfo, serverInfo, "redirect info for ad '%s' does not match expected", ad.Name)
+						// Use require here because if RInfo values are incorrect, sorts later in the test will likely be invalid
+						require.Equal(t, expectedRInfo.Coordinate.Lat, serverInfo.Coordinate.Lat, "lat mismatch for ad '%s'", ad.Name)
+						require.Equal(t, expectedRInfo.Coordinate.Long, serverInfo.Coordinate.Long, "long mismatch for ad '%s'", ad.Name)
+						require.Equal(t, expectedRInfo.Coordinate.AccuracyRadius, serverInfo.Coordinate.AccuracyRadius, "accuracy radius mismatch for ad '%s'", ad.Name)
+						require.Equal(t, expectedRInfo.Coordinate.Source, serverInfo.Coordinate.Source, "coordinate source mismatch for ad '%s'", ad.Name)
+						require.Equal(t, expectedRInfo.Coordinate.FromTTLCache, serverInfo.Coordinate.FromTTLCache, "fromTTLCache mismatch for ad '%s'", ad.Name)
+
+						// Compare redirect weights (in delta because of floating point math)
+						require.InDelta(t, expectedRInfo.RedirectWeights.DistanceWeight, serverInfo.RedirectWeights.DistanceWeight, 1e-8, "distance weight mismatch for ad '%s'", ad.Name)
+						require.InDelta(t, expectedRInfo.RedirectWeights.IOLoadWeight, serverInfo.RedirectWeights.IOLoadWeight, 1e-8, "io load weight mismatch for ad '%s'", ad.Name)
+						require.InDelta(t, expectedRInfo.RedirectWeights.StatusWeight, serverInfo.RedirectWeights.StatusWeight, 1e-8, "status weight mismatch for ad '%s'", ad.Name)
+						require.InDelta(t, expectedRInfo.RedirectWeights.AvailabilityWeight, serverInfo.RedirectWeights.AvailabilityWeight, 1e-8, "availability weight mismatch for ad '%s'", ad.Name)
 					}
 				}
 			}

--- a/director/sort_algorithms_test.go
+++ b/director/sort_algorithms_test.go
@@ -666,6 +666,424 @@ func TestAvailabilityWeightFn(t *testing.T) {
 	}
 }
 
+// Helper for setting up server ads in distance/adaptive sort tests
+func getAdBase(name string, lat, long float64) server_structs.ServerAd {
+	ad := server_structs.ServerAd{Latitude: lat, Longitude: long, Coordinate: server_structs.Coordinate{Lat: lat, Long: long}, URL: url.URL{Host: name}}
+	ad.Initialize(name)
+	return ad
+}
+
+func TestDistanceSortAlg(t *testing.T) {
+	// Note that this test is relatively paired back and doesn't
+	// exhaustively test cases like invalid client IPs. This is because
+	// the internal functions that handle these edge cases are tested
+	// rigorously and separately. For example, getClientCoordinate()
+	// is guaranteed to return _some_ client coordinate so a test here
+	// for an invalid IP still only tests basic distance sorting logic.
+
+	setupOverrideCache(t) // will map 192.168.1.4 --> Discovery building's lat/long
+
+	testCases := []struct {
+		name          string
+		sCtx          SortContext
+		sAds          []server_structs.ServerAd
+		expectedOrder []string
+		expectedRInfo map[string]server_structs.ServerRedirectInfo
+	}{
+		{
+			name: "basic distance sort",
+			sCtx: SortContext{
+				ClientAddr:   netip.MustParseAddr("192.168.1.4"),
+				RedirectInfo: &server_structs.RedirectInfo{},
+			},
+			sAds: []server_structs.ServerAd{
+				// These coordinates are approximate and chosen to yield a clear order
+				// based on distance from the Discovery building in Madison, WI
+				getAdBase("LA", 34.0522, -118.2437),
+				getAdBase("Chicago", 41.8781, -87.6298),
+				getAdBase("NYC", 40.7128, -74.0060),
+				getAdBase("unknown1", 0.0, 0.0), // invalid coordinates
+				getAdBase("unknown2", 0.0, 0.0),
+			},
+			expectedOrder: []string{"Chicago", "NYC", "unknown1", "unknown2", "LA"},
+			expectedRInfo: map[string]server_structs.ServerRedirectInfo{
+				"LA": {
+					Coordinate:      server_structs.Coordinate{Lat: 34.0522, Long: -118.2437},
+					RedirectWeights: server_structs.RedirectWeights{DistanceWeight: 0.0030855674215090165},
+				},
+				"NYC": {
+					Coordinate:      server_structs.Coordinate{Lat: 40.7128, Long: -74.0060},
+					RedirectWeights: server_structs.RedirectWeights{DistanceWeight: 0.06083031669691837},
+				},
+				"unknown1": {
+					Coordinate:      server_structs.Coordinate{Lat: 0, Long: 0},                          // Will still have invalid coord
+					RedirectWeights: server_structs.RedirectWeights{DistanceWeight: 0.06083031669691837}, // Will get imputed distance weight from NYC
+				},
+			},
+		},
+		{
+			name: "all unknown coordinates preserves original order",
+			sCtx: SortContext{
+				ClientAddr:   netip.MustParseAddr("192.168.1.4"),
+				RedirectInfo: &server_structs.RedirectInfo{},
+			},
+			sAds: []server_structs.ServerAd{
+				getAdBase("unknown1", 0.0, 0.0),
+				getAdBase("unknown2", 0.0, 0.0),
+				getAdBase("unknown3", 0.0, 0.0),
+			},
+			expectedOrder: []string{"unknown1", "unknown2", "unknown3"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sortAlg := &DistanceSort{}
+			sortedAds, err := sortAlg.Sort(tc.sAds, tc.sCtx)
+
+			// Distance sort should not return an error
+			assert.NoError(t, err, "unexpected error from DistanceSort alg")
+			assert.Equal(t, len(sortedAds), len(tc.expectedOrder), "number of sorted ads does not match expected")
+
+			// Check order of sorted ads
+			for i, expectedName := range tc.expectedOrder {
+				assert.Equal(t, expectedName, sortedAds[i].Name, "ad at position %d does not match expected", i)
+			}
+
+			// Validate redirect info if expected
+			if tc.expectedRInfo != nil {
+				for _, ad := range sortedAds {
+					expectedRInfo, ok := tc.expectedRInfo[ad.Name]
+					if !ok {
+						// Skip ads if the test doesn't provide an expected value for this
+						// This lets of us only check a subset of redirect info as needed
+						continue
+					}
+					serverInfo := *tc.sCtx.RedirectInfo.ServersInfo[ad.URL.String()]
+
+					assert.EqualValues(t, expectedRInfo, serverInfo, "redirect info for ad '%s' does not match expected", ad.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestAdaptiveSortAlg(t *testing.T) {
+	// There are two primary test types here:
+	// - A set of tests that test adaptive sorting along individual weight axes.
+	//   These work by setting all but one weight to a constant value, and
+	//   varying the remaining weight to produce a clear expected order.
+	// - A "snapshot" test that comes from a real-world snapshot of server state
+	//   from a Madison client in July 2025. Before refactoring the Director's sorting
+	//   logic/algorithms (which happened shortly after this snapshot was taken),
+	//   the adaptive sort algorithm produced an ordering we decided was wrong because
+	//   it mishandled unknown load values and sorted European caches to the top of the
+	//   list for a US client. The snapshot test makes sure these issues remain fixed.
+	//
+	// Both the tests use multiple runs of the stochastic sort in an attempt to catch
+	// improbable-but-possible misorderings. The assumption for the per-axis tests is
+	// that ordering each server along the varied axis should produce a clear mode position
+	// after the stochastic sort. That is, if s1 has the highest weight and s2 has second
+	// highest, s1 should appear most often at position 0 and s2 should appear most often
+	// at position 1.
+	setupOverrideCache(t) // will map 192.168.1.4 --> Discovery building's lat/long
+
+	var getAd = func(name string, lat, long float64, ioLoad float64, sWeight float64) server_structs.ServerAd {
+		ad := getAdBase(name, lat, long)
+		ad.IOLoad = ioLoad
+		ad.StatusWeight = sWeight
+		return ad
+	}
+
+	testCases := []struct {
+		name             string
+		sCtx             SortContext
+		sAds             []server_structs.ServerAd
+		expectedModeIdxs map[string][]int // If ad name maps to multiple valid mode positions, list them all here
+		expectedRInfo    map[string]server_structs.ServerRedirectInfo
+	}{
+		{
+			name: "sort along distance weight axis",
+			sCtx: SortContext{
+				Ctx:          context.Background(),
+				ClientAddr:   netip.MustParseAddr("192.168.1.4"),
+				RedirectInfo: &server_structs.RedirectInfo{},
+			},
+			sAds: []server_structs.ServerAd{
+				// These coordinates are approximate and chosen to yield a clear order
+				// based on distance from the Discovery building in Madison, WI
+				getAd("LA", 34.0522, -118.2437, 0.0, 0.5),
+				getAd("Chicago", 41.8781, -87.6298, 0.0, 0.5),
+				getAd("NYC", 40.7128, -74.0060, 0.0, 0.5),
+				getAd("unknown1", 0.0, 0.0, 0.0, 0.5), // unknowns should be in middle
+				getAd("unknown2", 0.0, 0.0, 0.0, 0.5),
+			},
+			expectedModeIdxs: map[string][]int{
+				"Chicago":  {0},
+				"NYC":      {1, 2, 3}, // NYC's distance will become the imputed median, so it will flipflop with unknowns
+				"unknown1": {1, 2, 3},
+				"unknown2": {1, 2, 3},
+				"LA":       {4},
+			},
+			expectedRInfo: map[string]server_structs.ServerRedirectInfo{
+				"LA": {
+					Coordinate:      server_structs.Coordinate{Lat: 34.0522, Long: -118.2437},
+					RedirectWeights: server_structs.RedirectWeights{DistanceWeight: 0.0030855674215090165, IOLoadWeight: 1.0, StatusWeight: 0.5, AvailabilityWeight: 1.0},
+				},
+				"NYC": {
+					Coordinate:      server_structs.Coordinate{Lat: 40.7128, Long: -74.0060},
+					RedirectWeights: server_structs.RedirectWeights{DistanceWeight: 0.06083031669691837, IOLoadWeight: 1.0, StatusWeight: 0.5, AvailabilityWeight: 1.0},
+				},
+				"unknown1": {
+					Coordinate:      server_structs.Coordinate{Lat: 0, Long: 0}, // Will still have invalid coord, but distance weight will be imputed from NYC weight
+					RedirectWeights: server_structs.RedirectWeights{DistanceWeight: 0.06083031669691837, IOLoadWeight: 1.0, StatusWeight: 0.5, AvailabilityWeight: 1.0},
+				},
+			},
+		},
+		{
+			name: "sort along io load weight axis",
+			sCtx: SortContext{
+				Ctx:          context.Background(),
+				ClientAddr:   netip.MustParseAddr("192.168.1.4"),
+				RedirectInfo: &server_structs.RedirectInfo{},
+			},
+			sAds: []server_structs.ServerAd{
+				getAd("zero load", 43.07296, -89.40831, 0.0, 0.5),                                                              // should produce ioLoad weight of 1.0
+				getAd("load below threshold", 43.07296, -89.40831, loadHalvingThreshold*0.5, 0.5),                              // also 1.0
+				getAd("load slightly above threshold", 43.07296, -89.40831, loadHalvingThreshold+(3.0*loadHalvingFactor), 0.5), // Load weight of 1/8
+				getAd("load greatly above threshold", 43.07296, -89.40831, loadHalvingThreshold+(5.0*loadHalvingFactor), 0.5),  // Load weight of 1/32
+				getAd("load causes underflow", 43.07296, -89.40831, 1e12, 0.5),                                                 // should produce ioLoad weight of 0.0, causing filtering
+				getAd("unknown1", 43.07296, -89.40831, -1.0, 0.5),                                                              // unknowns should produce median load weight of 1/8
+				getAd("unknown2", 43.07296, -89.40831, -1.0, 0.5),
+			},
+			expectedModeIdxs: map[string][]int{
+				"zero load":                     {0, 1}, // will filpflop with load below threshold
+				"load below threshold":          {0, 1},
+				"unknown1":                      {2, 3, 4}, // although the underflow load gets filtered, it's still used in median calc
+				"unknown2":                      {2, 3, 4},
+				"load slightly above threshold": {2, 3, 4},
+				"load greatly above threshold":  {5},
+				"load causes underflow":         {}, // should be filtered out
+			},
+			expectedRInfo: map[string]server_structs.ServerRedirectInfo{
+				"zero load": {
+					Coordinate:      server_structs.Coordinate{Lat: 43.07296, Long: -89.40831},
+					RedirectWeights: server_structs.RedirectWeights{DistanceWeight: 1.0, IOLoadWeight: 1.0, StatusWeight: 0.5, AvailabilityWeight: 1.0},
+				},
+				"load causes underflow": {
+					Coordinate:      server_structs.Coordinate{Lat: 43.07296, Long: -89.40831},
+					RedirectWeights: server_structs.RedirectWeights{DistanceWeight: 1.0, IOLoadWeight: 0.0, StatusWeight: 0.5, AvailabilityWeight: 1.0},
+				},
+				"load below threshold": {
+					Coordinate:      server_structs.Coordinate{Lat: 43.07296, Long: -89.40831},
+					RedirectWeights: server_structs.RedirectWeights{DistanceWeight: 1.0, IOLoadWeight: 1.0, StatusWeight: 0.5, AvailabilityWeight: 1.0},
+				},
+			},
+		},
+		{
+			name: "sort along status weight axis",
+			sCtx: SortContext{
+				Ctx:          context.Background(),
+				ClientAddr:   netip.MustParseAddr("192.168.1.4"),
+				RedirectInfo: &server_structs.RedirectInfo{},
+			},
+			sAds: []server_structs.ServerAd{
+				getAd("one status weight", 43.07296, -89.40831, 0.0, 1.0),
+				getAd("very small status weight", 43.07296, -89.40831, 0.0, math.SmallestNonzeroFloat64), // smallest value EWMA calc will set
+				getAd("medium weight", 43.07296, -89.40831, 0.0, 0.5),
+				getAd("unknown status weight", 43.07296, -89.40831, 0.0, 0.0), // constitutes error, impute median
+				getAd("negative status weight", 43.07296, -89.40831, 0.0, -1), // shouldn't happen, but would be treated as unknown
+			},
+			expectedModeIdxs: map[string][]int{
+				"one status weight":        {0},
+				"medium weight":            {1, 2, 3},
+				"unknown status weight":    {1, 2, 3},
+				"negative status weight":   {1, 2, 3},
+				"very small status weight": {4},
+			},
+			expectedRInfo: map[string]server_structs.ServerRedirectInfo{
+				// Already checked RInfo in other cases, only one per test from here on out.
+				"medium weight": {
+					Coordinate:      server_structs.Coordinate{Lat: 43.07296, Long: -89.40831},
+					RedirectWeights: server_structs.RedirectWeights{DistanceWeight: 1.0, IOLoadWeight: 1.0, StatusWeight: 0.5, AvailabilityWeight: 1.0},
+				},
+			},
+		},
+		{
+			name: "sort along avail weight axis with availability map",
+			sCtx: SortContext{
+				Ctx:          context.Background(),
+				ClientAddr:   netip.MustParseAddr("192.168.1.4"),
+				RedirectInfo: &server_structs.RedirectInfo{},
+				AvailabilityMap: map[string]bool{
+					"s1": true,  // avail weight 2.0
+					"s2": false, // avail weight 0.5
+					"s3": true,
+					"s4": false,
+				},
+			},
+			sAds: []server_structs.ServerAd{
+				getAd("s1", 43.07296, -89.40831, 0.0, 1.0),
+				getAd("s2", 43.07296, -89.40831, 0.0, 1.0),
+				getAd("s3", 43.07296, -89.40831, 0.0, 1.0),
+				getAd("s4", 43.07296, -89.40831, 0.0, 1.0),
+				getAd("unknown", 43.07296, -89.40831, 0.0, 1.0), // should get median avail weight of 1.25
+			},
+			expectedModeIdxs: map[string][]int{
+				"s1":      {0, 1},
+				"s3":      {0, 1},
+				"unknown": {2},
+				"s2":      {3, 4},
+				"s4":      {3, 4},
+			},
+			expectedRInfo: map[string]server_structs.ServerRedirectInfo{
+				// Already checked RInfo in other cases, only one per test from here on out.
+				"unknown": {
+					Coordinate:      server_structs.Coordinate{Lat: 43.07296, Long: -89.40831},
+					RedirectWeights: server_structs.RedirectWeights{DistanceWeight: 1.0, IOLoadWeight: 1.0, StatusWeight: 1.0, AvailabilityWeight: 1.25},
+				},
+			},
+		},
+		// No explicit test for nil availability map because it results
+		// in uniform random sorting along that axis, and this case was
+		// implicitly tested by previous adaptive sort tests!
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			counts := make(map[string]map[int]int)
+			for range 5000 {
+				sortAlg := &AdaptiveSort{}
+				sortedAds, err := sortAlg.Sort(tc.sAds, tc.sCtx)
+				assert.NoError(t, err, "unexpected error from AdaptiveSort alg")
+
+				// Record positions of each ad in this sorted result
+				for pos, ad := range sortedAds {
+					if counts[ad.Name] == nil {
+						counts[ad.Name] = make(map[int]int)
+					}
+					counts[ad.Name][pos]++
+				}
+
+				// Validate redirect info if expected
+				if tc.expectedRInfo != nil {
+					for _, ad := range sortedAds {
+						expectedRInfo, ok := tc.expectedRInfo[ad.Name]
+						if !ok {
+							// Skip ads if the test doesn't provide an expected value for this
+							// This lets of us only check a subset of redirect info as needed
+							continue
+						}
+						serverInfo := *tc.sCtx.RedirectInfo.ServersInfo[ad.URL.String()]
+
+						// Use require here because if this fails, sorts may be invalid
+						require.EqualValues(t, expectedRInfo, serverInfo, "redirect info for ad '%s' does not match expected", ad.Name)
+					}
+				}
+			}
+
+			// Check that computed modes match expected modes
+			for adName, freqMap := range counts {
+				modePos, maxCount := -1, -1
+				for pos, cnt := range freqMap {
+					if cnt > maxCount {
+						modePos, maxCount = pos, cnt
+					}
+				}
+				expectedPositions, ok := tc.expectedModeIdxs[adName]
+				if !ok {
+					t.Errorf("unexpected ad %s found after sort (should have been filtered out)", adName)
+					continue
+				}
+				if !slices.Contains(expectedPositions, modePos) {
+					t.Errorf("ad %s: expected mode position in %v, got %d (distribution=%v)", adName, expectedPositions, modePos, freqMap)
+				}
+			}
+		})
+	}
+
+	t.Run("full snapshot test with real ads", func(t *testing.T) {
+		// This test uses a real snapshot of information from the OSDF in ~July 2025
+		// that came from the Director's "redirectInfo" for a client request in Madison, WI.
+		// Status and availability weights were not present, so those are set to constant values
+		// for this test (we can always get a new snapshot in the future and update if desired).
+		// The assertions for this test are meant to:
+		// 1) Ensure no non-USA-based servers appear in the output results (they should all be
+		//    filtered by the first pass of distance weights)
+		// 2) Ensure we get the expected number of server ads (sourceWorkingSetSize)
+		//
+		// Beyond that, we don't assert a specific order because doing so in this multi-dimensional
+		// stochastic sort makes it seem like we mere mortals actually know the "correct" order.
+		sCtx := SortContext{
+			Ctx:          context.Background(),
+			ClientAddr:   netip.MustParseAddr("192.168.1.4"),
+			RedirectInfo: &server_structs.RedirectInfo{},
+		}
+		snapshotAds := []server_structs.ServerAd{
+			getAd("https://amst-fiona.nationalresearchplatform.org:8443", 52.3759, 4.8975, 90.79649122807017, 1.0),
+			getAd("https://amst-osdf-xcache01.es.net:8443", 52.3759, 4.8975, 0, 1.0),
+			getAd("https://buzzard-pelican-ext.pace.gatech.edu:8443", 33.7697, -84.3754, 83.17163799425266, 1.0),
+			getAd("https://ccpelicanli01.in2p3.fr:8443", 48.8582, 2.3387, 73.0979891298627, 1.0),
+			getAd("https://cf-ac-uk-cache.nationalresearchplatform.org:8443", 51.4801, -3.1855, 71.8774451840182, 1.0),
+			getAd("https://dtn-pas.bois.nrp.internet2.edu:8443", 43.6349, -116.2023, 108.14186865780573, 1.0),
+			getAd("https://dtn-pas.denv.nrp.internet2.edu:8443", 39.7391, -104.9866, 142.77894736842103, 1.0),
+			getAd("https://dtn-pas.hous.nrp.internet2.edu:8443", 29.7539, -95.359, 64.05263157894736, 1.0),
+			getAd("https://dtn-pas.jack.nrp.internet2.edu:8443", 30.3337, -81.6542, 200.95859985473635, 1.0),
+			getAd("https://dtn-pas.kans.nrp.internet2.edu:8443", 39.1024, -94.5986, 218.10953722644638, 1.0),
+			getAd("https://fdp-d3d-cache.nationalresearchplatform.org:8443", 32.8919, -117.2035, 70.01428075186227, 1.0),
+			getAd("https://kagra-dsr-b1.icrr.u-tokyo.ac.jp:8443", 35.8566, 139.9185, 41.01481481481482, 1.0),
+			getAd("https://mghpcc-cache.nationalresearchplatform.org:8443", 42.2043, -72.6162, 235.43591381022392, 1.0),
+			getAd("https://ncar-cache.nationalresearchplatform.org:8443", 39.9834, -105.143, 59.42105263157894, 1.0),
+			getAd("https://osdf-cache.sprace.org.br:8443", -23.5475, -46.6361, 0, 1.0),
+			getAd("https://osdf1.amst.nrp.internet2.edu:8443", 53.2048, 5.8055, 55.6446378133717, 1.0),
+			getAd("https://osdf1.chic.nrp.internet2.edu:8443", 41.8882, -87.6164, 130.5337913466363, 1.0),
+			getAd("https://osdf1.newy32aoa.nrp.internet2.edu:8443", 40.78, -73.97, 100.3017543859649, 1.0),
+			getAd("https://osdfcache.ligo.caltech.edu:8443", 34.1424, -118.1257, 51.09824561403508, 1.0),
+			getAd("https://osg-cache.ms4.surfsara.nl:8443", 52.3824, 4.8995, 63.831354977701835, 1.0),
+			getAd("https://osg-houston-stashcache.nrp.internet2.edu:8443", 29.8137, -95.3111, 43.9578947368421, 1.0),
+			getAd("https://osg-sunnyvale-stashcache.nrp.internet2.edu:8443", 37.4043, -122.0748, 101.86315789473683, 1.0),
+			getAd("https://sdsc-cache.nationalresearchplatform.org:8443", 32.7173, -117.157, 64.6699485264964, 1.0),
+			getAd("https://singapore.nationalresearchplatform.org:8443", 1.3024, 103.7857, 36.266666666666666, 1.0),
+			getAd("https://ucsd-t2-cache.nationalresearchplatform.org:8443", 32.7173, -117.157, 181.9830946775252, 1.0),
+			getAd("https://unl-cache.nationalresearchplatform.org:8443", 40.8035, -96.651, 523.5684210526315, 1.0),
+		}
+
+		urlsSet := map[string]struct{}{}
+		sortAlg := &AdaptiveSort{}
+		// Run the test multiple times to catch low-probability servers
+		// that shouldn't end up in the results
+		for range 5000 {
+			sortedAds, err := sortAlg.Sort(snapshotAds, sCtx)
+			assert.NoError(t, err, "unexpected error from AdaptiveSort alg")
+			assert.Equal(t, sourceWorkingSetSize, len(sortedAds), "number of sorted ads does not match expected")
+			for _, ad := range sortedAds {
+				urlsSet[ad.Name] = struct{}{}
+			}
+		}
+
+		// A set of caches we'd NEVER want the Madison client to be sent to
+		// because they're outside the US and thus too far away to even consider.
+		// These should be filtered by the adaptive sort's first pass over
+		// distance weights as long as len(snapshotAds) - len(these ads) > sourceWorkingSetSize.
+		shouldNeverBeReturned := []string{
+			"https://amst-fiona.nationalresearchplatform.org:8443",
+			"https://amst-osdf-xcache01.es.net:8443",
+			"https://ccpelicanli01.in2p3.fr:8443",
+			"https://cf-ac-uk-cache.nationalresearchplatform.org:8443",
+			"https://kagra-dsr-b1.icrr.u-tokyo.ac.jp:8443",
+			"https://osdf1.amst.nrp.internet2.edu:8443",
+			"https://osdf-cache.sprace.org.br:8443",
+			"https://osg-cache.ms4.surfsara.nl:8443",
+			"https://singapore.nationalresearchplatform.org:8443",
+		}
+
+		for _, badUrl := range shouldNeverBeReturned {
+			if _, found := urlsSet[badUrl]; found {
+				t.Errorf("server %s should not have been returned by adaptive sort", badUrl)
+			}
+		}
+	})
+}
 
 func TestSortServerAdsByTopo(t *testing.T) {
 	mock1 := server_structs.Advertisement{

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -19,693 +19,21 @@
 package director
 
 import (
-	"bytes"
 	"context"
 	_ "embed"
-	"math"
-	"math/rand"
-	"net"
 	"net/http"
-	"net/netip"
 	"net/url"
-	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pelicanplatform/pelican/features"
+	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/pelican_url"
 	"github.com/pelicanplatform/pelican/server_structs"
-	"github.com/pelicanplatform/pelican/server_utils"
 )
-
-// Geo Override Yaml mockup
-//
-//go:embed resources/geoip_overrides.yaml
-var yamlMockup string
-
-func TestCheckOverrides(t *testing.T) {
-	server_utils.ResetTestState()
-	t.Cleanup(func() {
-		server_utils.ResetTestState()
-		geoNetOverrides = nil
-	})
-
-	// We'll also check that our logging feature responsibly reports
-	// what Pelican is telling the user.
-	origOutput := log.StandardLogger().Out
-	logOutput := &(bytes.Buffer{})
-	log.SetOutput(logOutput)
-	log.SetLevel(log.DebugLevel)
-	t.Cleanup(func() {
-		log.SetOutput(origOutput)
-	})
-
-	viper.SetConfigType("yaml")
-	err := viper.ReadConfig(strings.NewReader(yamlMockup))
-	if err != nil {
-		t.Fatalf("Error reading config: %v", err)
-	}
-
-	t.Run("test-no-ipv4-match", func(t *testing.T) {
-		// In the event that no override is detected, `checkOverrides` should return a nil override
-		addr := net.ParseIP("192.168.0.2")
-		coordinate := checkOverrides(addr)
-		require.Nil(t, coordinate)
-	})
-
-	t.Run("test-no-ipv6-match", func(t *testing.T) {
-		addr := net.ParseIP("ABCD::0123")
-		coordinate := checkOverrides(addr)
-		require.Nil(t, coordinate)
-	})
-
-	t.Run("test-log-output", func(t *testing.T) {
-		// Check that the log caught our malformed IP and CIDR. We only need to test this once, because it is only logged the very first time.
-		require.Contains(t, logOutput.String(), "Failed to parse configured GeoIPOverride address (192.168.0). Unable to use for GeoIP resolution!")
-		require.Contains(t, logOutput.String(), "Failed to parse configured GeoIPOverride address (10.0.0./24). Unable to use for GeoIP resolution!")
-		require.Contains(t, logOutput.String(), "Failed to parse configured GeoIPOverride address (FD00::000G). Unable to use for GeoIP resolution!")
-		require.Contains(t, logOutput.String(), "Failed to parse configured GeoIPOverride address (FD00::000F/11S). Unable to use for GeoIP resolution!")
-	})
-
-	t.Run("test-ipv4-match", func(t *testing.T) {
-		// When we match against a regular IPv4, we expect a non-nil coordinate
-		expectedCoordinate := Coordinate{
-			Lat:  123.4,
-			Long: 987.6,
-		}
-
-		addr := net.ParseIP("192.168.0.1")
-		require.NotNil(t, addr)
-		coordinate := checkOverrides(addr)
-		require.NotNil(t, coordinate)
-		require.Equal(t, expectedCoordinate.Lat, coordinate.Lat)
-		require.Equal(t, expectedCoordinate.Long, coordinate.Long)
-	})
-
-	t.Run("test-ipv4-CIDR-match", func(t *testing.T) {
-		// Same goes for CIDR matches
-		expectedCoordinate := Coordinate{
-			Lat:  43.073904,
-			Long: -89.384859,
-		}
-
-		addr := net.ParseIP("10.0.0.136")
-		require.NotNil(t, addr)
-		coordinate := checkOverrides(addr)
-		require.NotNil(t, coordinate)
-		require.Equal(t, expectedCoordinate.Lat, coordinate.Lat)
-		require.Equal(t, expectedCoordinate.Long, coordinate.Long)
-	})
-
-	t.Run("test-ipv6-match", func(t *testing.T) {
-		expectedCoordinate := Coordinate{
-			Lat:  123.4,
-			Long: 987.6,
-		}
-
-		addr := net.ParseIP("FC00::0001")
-		require.NotNil(t, addr)
-		coordinate := checkOverrides(addr)
-		require.NotNil(t, coordinate)
-		require.Equal(t, expectedCoordinate.Lat, coordinate.Lat)
-		require.Equal(t, expectedCoordinate.Long, coordinate.Long)
-	})
-
-	t.Run("test-ipv6-CIDR-match", func(t *testing.T) {
-		expectedCoordinate := Coordinate{
-			Lat:  43.073904,
-			Long: -89.384859,
-		}
-
-		addr := net.ParseIP("FD00::FA1B")
-		assert.NotNil(t, addr)
-		coordinate := checkOverrides(addr)
-		require.NotNil(t, coordinate)
-		require.Equal(t, expectedCoordinate.Lat, coordinate.Lat)
-		require.Equal(t, expectedCoordinate.Long, coordinate.Long)
-	})
-}
-
-func TestSortServerAdsByTopo(t *testing.T) {
-	mock1 := server_structs.Advertisement{
-		ServerAd: server_structs.ServerAd{
-			FromTopology: true,
-		},
-	}
-	mock1.ServerAd.Initialize("alpha")
-	mock2 := server_structs.Advertisement{
-		ServerAd: server_structs.ServerAd{
-			FromTopology: true,
-		},
-	}
-	mock2.ServerAd.Initialize("bravo")
-	mock3 := server_structs.Advertisement{
-		ServerAd: server_structs.ServerAd{
-			FromTopology: true,
-		},
-	}
-	mock3.ServerAd.Initialize("charlie")
-	mock4 := server_structs.Advertisement{
-		ServerAd: server_structs.ServerAd{
-			FromTopology: false,
-		},
-	}
-	mock4.ServerAd.Initialize("alpha")
-	mock5 := server_structs.Advertisement{
-		ServerAd: server_structs.ServerAd{
-			FromTopology: false,
-		},
-	}
-	mock5.ServerAd.Initialize("bravo")
-	mock6 := server_structs.Advertisement{
-		ServerAd: server_structs.ServerAd{
-			FromTopology: false,
-		},
-	}
-	mock6.ServerAd.Initialize("charlie")
-
-	randomList := []*server_structs.Advertisement{&mock6, &mock1, &mock2, &mock4, &mock5, &mock3}
-	expectedList := []*server_structs.Advertisement{&mock4, &mock5, &mock6, &mock1, &mock2, &mock3}
-
-	sortedList := sortServerAdsByTopo(randomList)
-
-	assert.EqualValues(t, expectedList, sortedList)
-}
-
-// Helper function for adaptive sort that finds the average index of a server in a sorted list
-func calcAvgIndex(counts []int) float64 {
-	totalAppearances := 0
-	weightedSum := 0
-
-	for index, count := range counts {
-		weightedSum += index * count
-		totalAppearances += count
-	}
-
-	if totalAppearances > 0 {
-		return float64(weightedSum) / float64(totalAppearances)
-	} else {
-		return 0.0
-	}
-}
-
-// Helper func for adaptive sort to check that the calculated avg index is in the expected range
-func inRange(min float64, max float64, val float64) bool {
-	return val >= min && val <= max
-}
-
-func TestSortServerAds(t *testing.T) {
-	server_utils.ResetTestState()
-	clientIpCache.DeleteAll()
-	t.Cleanup(func() {
-		server_utils.ResetTestState()
-		clientIpCache.DeleteAll()
-		geoNetOverrides = nil
-	})
-
-	// A random IP that should geo-resolve to roughly the same location as the Madison server
-	clientIP := netip.MustParseAddr("128.104.153.60")
-	// We need to provide a geo-ip override so that our sorting functions know where this is located
-	viper.SetConfigType("yaml")
-	err := viper.ReadConfig(strings.NewReader(yamlMockup))
-	if err != nil {
-		t.Fatalf("Error reading config: %v", err)
-	}
-
-	// These are listed in order of increasing distance from the clientIP
-	madisonServer := server_structs.ServerAd{
-		URL:       url.URL{Scheme: "https", Host: "madison-cache.org"},
-		Latitude:  43.0753,
-		Longitude: -89.4114,
-	}
-	madisonServer.Initialize("madison server")
-	sdscServer := server_structs.ServerAd{
-		URL:       url.URL{Scheme: "https", Host: "sdsc-cache.org"},
-		Latitude:  32.8761,
-		Longitude: -117.2318,
-	}
-	sdscServer.Initialize("sdsc server")
-	bigBenServer := server_structs.ServerAd{
-		URL:       url.URL{Scheme: "https", Host: "bigBen-cache.org"},
-		Latitude:  51.5103,
-		Longitude: -0.1167,
-	}
-	bigBenServer.Initialize("bigBen server")
-	kremlinServer := server_structs.ServerAd{
-		URL:       url.URL{Scheme: "https", Host: "kremlin-cache.org"},
-		Latitude:  55.752121,
-		Longitude: 37.617664,
-	}
-	kremlinServer.Initialize("kremlin server")
-	daejeonServer := server_structs.ServerAd{
-		URL:       url.URL{Scheme: "https", Host: "daejeon-cache.org"},
-		Latitude:  36.3213,
-		Longitude: 127.4200,
-	}
-	daejeonServer.Initialize("daejeon server")
-	mcMurdoServer := server_structs.ServerAd{
-		URL:       url.URL{Scheme: "https", Host: "mcMurdo-cache.org"},
-		Latitude:  -77.8500,
-		Longitude: 166.6666,
-	}
-	mcMurdoServer.Initialize("mcMurdo server")
-	nullIslandServer := server_structs.ServerAd{
-		URL:       url.URL{Scheme: "https", Host: "null-cache.org"},
-		Latitude:  0.0,
-		Longitude: 0.0,
-	}
-	nullIslandServer.Initialize("Null Island Server")
-
-	// Mock servers with same geolocation but different loads
-	serverLoad1 := server_structs.ServerAd{
-		URL:       url.URL{Scheme: "https", Host: "server1.org"},
-		Latitude:  43.0753,
-		Longitude: -89.4114,
-		IOLoad:    0.0,
-	}
-	serverLoad1.Initialize("load1")
-
-	serverLoad2 := server_structs.ServerAd{
-		URL:       url.URL{Scheme: "https", Host: "server2.org"},
-		Latitude:  43.0753,
-		Longitude: -89.4114,
-		IOLoad:    10.2,
-	}
-	serverLoad2.Initialize("load2")
-
-	serverLoad3 := server_structs.ServerAd{
-		URL:       url.URL{Scheme: "https", Host: "server3.org"},
-		Latitude:  43.0753,
-		Longitude: -89.4114,
-		IOLoad:    14,
-	}
-	serverLoad3.Initialize("load3")
-
-	serverLoad4 := server_structs.ServerAd{
-		URL:       url.URL{Scheme: "https", Host: "server4.org"},
-		Latitude:  43.0753,
-		Longitude: -89.4114,
-		IOLoad:    60.3,
-	}
-	serverLoad4.Initialize("load4")
-
-	serverLoad5NullLoc := server_structs.ServerAd{
-		URL:       url.URL{Scheme: "https", Host: "server5.org"},
-		Latitude:  0.0,
-		Longitude: 0.0,
-		IOLoad:    10.0,
-	}
-	serverLoad5NullLoc.Initialize("load5NullLoc")
-
-	serverLoad6NullLoc := server_structs.ServerAd{
-		URL:       url.URL{Scheme: "https", Host: "server6.org"},
-		Latitude:  0.0,
-		Longitude: 0.0,
-		IOLoad:    99.0,
-	}
-	serverLoad6NullLoc.Initialize("load6NullLoc")
-
-	// These are listed in order of increasing distance from the clientIP
-	// However, madison server is overloaded and bigBenServer has very high load
-	madisonServerHighLoad := server_structs.ServerAd{
-		URL:       url.URL{Scheme: "https", Host: "madison-cache.org"},
-		Latitude:  43.0753,
-		Longitude: -89.4114,
-		IOLoad:    100.4,
-	}
-	madisonServerHighLoad.Initialize("madison high load")
-	chicagoLowload := server_structs.ServerAd{
-		URL:       url.URL{Scheme: "https", Host: "chicago-cache.org"},
-		Latitude:  41.789722,
-		Longitude: -87.599724,
-		IOLoad:    10,
-	}
-	chicagoLowload.Initialize("chicago low load")
-	bigBenServerHighLoad := server_structs.ServerAd{
-		URL:       url.URL{Scheme: "https", Host: "bigben-highload.org"},
-		Latitude:  51.5103,
-		Longitude: -0.1167,
-		IOLoad:    65.7,
-	}
-	bigBenServerHighLoad.Initialize("big ben high load")
-
-	randAds := []server_structs.ServerAd{madisonServer, sdscServer, bigBenServer, kremlinServer,
-		daejeonServer, mcMurdoServer, nullIslandServer}
-
-	randLoadAds := []server_structs.ServerAd{serverLoad6NullLoc, serverLoad4, serverLoad1, serverLoad3, serverLoad2}
-
-	randDistanceLoadAds := []server_structs.ServerAd{
-		madisonServerHighLoad,
-		chicagoLowload,
-		sdscServer,
-		bigBenServerHighLoad,
-		kremlinServer,
-		daejeonServer,
-		mcMurdoServer,
-		serverLoad5NullLoc,
-		serverLoad6NullLoc,
-	}
-
-	// Shuffle so that we don't give the sort function an already-sorted slice!
-	rand.Shuffle(len(randAds), func(i, j int) {
-		randAds[i], randAds[j] = randAds[j], randAds[i]
-	})
-
-	t.Run("test-distance-sort", func(t *testing.T) {
-		viper.Set("Director.CacheSortMethod", "distance")
-		rInfo := server_structs.NewRedirectInfoFromIP(clientIP.String())
-		expected := []server_structs.ServerAd{madisonServer, sdscServer, bigBenServer, kremlinServer,
-			daejeonServer, mcMurdoServer, nullIslandServer}
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
-		sorted, err := sortServerAds(ctx, clientIP, randAds, nil, rInfo)
-		require.NoError(t, err)
-		assert.EqualValues(t, expected, sorted)
-		assert.True(t, rInfo.ClientInfo.Resolved)
-		assert.Equal(t, rInfo.ClientInfo.Lat, 43.073904)
-		assert.Equal(t, rInfo.ClientInfo.Lon, -89.384859)
-		assert.Equal(t, rInfo.ClientInfo.IpAddr, "128.104.153.60")
-		assert.Equal(t, len(randAds), len(rInfo.ServersInfo))
-	})
-
-	t.Run("test-distanceAndLoad-sort-distance-only", func(t *testing.T) {
-		// Should return the same ordering as the distance test
-		viper.Set("Director.CacheSortMethod", "distanceAndLoad")
-		rInfo := server_structs.NewRedirectInfoFromIP(clientIP.String())
-		expected := []server_structs.ServerAd{madisonServer, sdscServer, bigBenServer, kremlinServer,
-			daejeonServer, mcMurdoServer, nullIslandServer}
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
-		sorted, err := sortServerAds(ctx, clientIP, randAds, nil, rInfo)
-		require.NoError(t, err)
-		assert.EqualValues(t, expected, sorted)
-		assert.True(t, rInfo.ClientInfo.Resolved)
-		assert.Equal(t, rInfo.ClientInfo.Lat, 43.073904)
-		assert.Equal(t, rInfo.ClientInfo.Lon, -89.384859)
-		assert.Equal(t, rInfo.ClientInfo.IpAddr, "128.104.153.60")
-		assert.Equal(t, len(randAds), len(rInfo.ServersInfo))
-	})
-
-	t.Run("test-distanceAndLoad-sort-load-only", func(t *testing.T) {
-		viper.Set("Director.CacheSortMethod", "distanceAndLoad")
-		rInfo := server_structs.NewRedirectInfoFromIP(clientIP.String())
-		expected := []server_structs.ServerAd{serverLoad1, serverLoad2, serverLoad3, serverLoad4, serverLoad6NullLoc}
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
-		sorted, err := sortServerAds(ctx, clientIP, randLoadAds, nil, rInfo)
-		require.NoError(t, err)
-		assert.EqualValues(t, expected, sorted)
-		assert.True(t, rInfo.ClientInfo.Resolved)
-		assert.Equal(t, rInfo.ClientInfo.Lat, 43.073904)
-		assert.Equal(t, rInfo.ClientInfo.Lon, -89.384859)
-		assert.Equal(t, rInfo.ClientInfo.IpAddr, "128.104.153.60")
-		assert.Equal(t, len(randLoadAds), len(rInfo.ServersInfo))
-		// Now that we have load information in the input servers, check
-		// that rInfo is receiving the correct values for a few of them
-		assert.Equal(t, serverLoad1.IOLoad, rInfo.ServersInfo[serverLoad1.URL.String()].LoadWeight)
-		assert.Equal(t, serverLoad2.IOLoad, rInfo.ServersInfo[serverLoad2.URL.String()].LoadWeight)
-		assert.Equal(t, serverLoad3.IOLoad, rInfo.ServersInfo[serverLoad3.URL.String()].LoadWeight)
-	})
-
-	t.Run("test-distanceAndLoad-sort-distance-and-load", func(t *testing.T) {
-		viper.Set("Director.CacheSortMethod", "distanceAndLoad")
-		rInfo := server_structs.NewRedirectInfoFromIP(clientIP.String())
-		expected := []server_structs.ServerAd{chicagoLowload, sdscServer, madisonServerHighLoad, kremlinServer,
-			daejeonServer, mcMurdoServer, bigBenServerHighLoad, serverLoad5NullLoc, serverLoad6NullLoc}
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
-		sorted, err := sortServerAds(ctx, clientIP, randDistanceLoadAds, nil, rInfo)
-		require.NoError(t, err)
-		assert.EqualValues(t, expected, sorted)
-		assert.True(t, rInfo.ClientInfo.Resolved)
-		assert.Equal(t, rInfo.ClientInfo.Lat, 43.073904)
-		assert.Equal(t, rInfo.ClientInfo.Lon, -89.384859)
-		assert.Equal(t, rInfo.ClientInfo.IpAddr, "128.104.153.60")
-		assert.Equal(t, len(randDistanceLoadAds), len(rInfo.ServersInfo))
-		assert.Equal(t, chicagoLowload.IOLoad, rInfo.ServersInfo[chicagoLowload.URL.String()].LoadWeight)
-		assert.Equal(t, sdscServer.IOLoad, rInfo.ServersInfo[sdscServer.URL.String()].LoadWeight)
-		assert.Equal(t, bigBenServerHighLoad.IOLoad, rInfo.ServersInfo[bigBenServerHighLoad.URL.String()].LoadWeight)
-	})
-
-	t.Run("test-adaptive-sort", func(t *testing.T) {
-		viper.Set("Director.CacheSortMethod", "adaptive")
-		rInfo := server_structs.NewRedirectInfoFromIP(clientIP.String())
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
-
-		// Set up which servers are known to have the object, and which are known to not have it
-		// Servers not in the map are assumed to have an unknown status
-		availMap := map[string]bool{}
-		availMap[chicagoLowload.URL.String()] = true
-		availMap[sdscServer.URL.String()] = true
-		availMap[madisonServerHighLoad.URL.String()] = false
-		availMap[kremlinServer.URL.String()] = false
-
-		// A map for keeping track of how many times each server appears in a sorted position.
-		// This strategy lets us deal with some of the stochastic jiggle in the adaptive sort
-		// algorithm by observing trends over many iterations.
-		serverSortCounter := make(map[string][]int)
-		for _, ad := range randDistanceLoadAds {
-			serverSortCounter[ad.Name] = make([]int, serverResLimit)
-		}
-
-		// Run the sort 1000 times to get a good idea of how the servers are being sorted
-		for range 1000 {
-			sorted, err := sortServerAds(ctx, clientIP, randDistanceLoadAds, availMap, rInfo)
-			require.NoError(t, err)
-
-			for pos, s := range sorted {
-				serverSortCounter[s.Name][pos]++
-			}
-		}
-
-		// Due to the very stochastic nature of this test, it's difficult to predict which servers will be in the
-		// output list, let alone their order. Instead, we notice that chicago and sdsc should have a strong preference
-		// for spots 1/2 because they have the object and are (relatively) close to Madison. The rest are much less predictable.
-		// Until we've convinced ourselves that we actually like the magic values in adaptive sort, I (Justin H.) don't think
-		// we should spend too much time trying to make this test more rigorous.
-		// TODO: When we understand adaptive sort better and can make assertions about how these servers should be sorted,
-		//       come back and make this test more rigorous
-		assert.True(t, inRange(0, 1, calcAvgIndex(serverSortCounter[chicagoLowload.Name])))
-		assert.True(t, inRange(0.5, 1.5, calcAvgIndex(serverSortCounter[sdscServer.Name])))
-		assert.True(t, rInfo.ClientInfo.Resolved)
-		assert.Equal(t, rInfo.ClientInfo.Lat, 43.073904)
-		assert.Equal(t, rInfo.ClientInfo.Lon, -89.384859)
-		assert.Equal(t, rInfo.ClientInfo.IpAddr, "128.104.153.60")
-		assert.Equal(t, len(randDistanceLoadAds), len(rInfo.ServersInfo))
-		assert.Equal(t, chicagoLowload.IOLoad, rInfo.ServersInfo[chicagoLowload.URL.String()].LoadWeight)
-		assert.Equal(t, sdscServer.IOLoad, rInfo.ServersInfo[sdscServer.URL.String()].LoadWeight)
-		assert.Equal(t, bigBenServerHighLoad.IOLoad, rInfo.ServersInfo[bigBenServerHighLoad.URL.String()].LoadWeight)
-		assert.Equal(t, "true", rInfo.ServersInfo[chicagoLowload.URL.String()].HasObject)
-		assert.Equal(t, "true", rInfo.ServersInfo[sdscServer.URL.String()].HasObject)
-		assert.Equal(t, "false", rInfo.ServersInfo[madisonServerHighLoad.URL.String()].HasObject)
-		assert.Equal(t, "false", rInfo.ServersInfo[kremlinServer.URL.String()].HasObject)
-		assert.Equal(t, "unknown", rInfo.ServersInfo[daejeonServer.URL.String()].HasObject)
-		assert.Equal(t, "unknown", rInfo.ServersInfo[mcMurdoServer.URL.String()].HasObject)
-	})
-
-	t.Run("test-random-sort", func(t *testing.T) {
-		viper.Set("Director.CacheSortMethod", "random")
-
-		var sorted []server_structs.ServerAd
-		var err error
-
-		// We don't expect to get back the sorted slice, but it's possible
-		notExpected := []server_structs.ServerAd{madisonServer, sdscServer, bigBenServer, kremlinServer, daejeonServer,
-			mcMurdoServer}
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
-		// The probability this test fails the first time due to randomly sorting into ascending distances is (1/6!) = 1/720
-		// To mitigate risk of this failing because of that, we'll run the sort 3 times to get a 1/720^3 = 1/373,248,000 chance
-		// of failure. If you run thrice and you still get the distance-sorted slice, you might consider buying a powerball ticket
-		// (1/292,201,338 chance of winning).
-		for range 3 {
-			redirectInfo := server_structs.NewRedirectInfoFromIP(clientIP.String())
-			sorted, err = sortServerAds(ctx, clientIP, randAds, nil, redirectInfo)
-			require.NoError(t, err)
-
-			// If the values are not equal, break the loop
-			if !reflect.DeepEqual(notExpected, sorted) {
-				break
-			}
-		}
-
-		assert.NotEqualValues(t, notExpected, sorted)
-	})
-
-	t.Run("test-status-weight-sort", func(t *testing.T) {
-		viper.Set("Director.CacheSortMethod", "adaptive")
-
-		// Pin all other factors used in adaptive sorting to isolate the status weight factor.
-		sAds := []server_structs.ServerAd{
-			{StatusWeight: 0.5, IOLoad: 1.0, Latitude: 32.8761, Longitude: -117.2318},
-			{StatusWeight: 0.2, IOLoad: 1.0, Latitude: 32.8761, Longitude: -117.2318},
-			{StatusWeight: 0.8, IOLoad: 1.0, Latitude: 32.8761, Longitude: -117.2318},
-		}
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, ProjectContextKey{}, "pelican-client/1.0.0 project/test")
-		redirectInfo := server_structs.NewRedirectInfoFromIP(clientIP.String())
-		require.NoError(t, err)
-
-		// To get around stochastic jiggle, run the test multiple times and grab average indices
-		iters := 1000
-		positionCounts := make([][]int, len(sAds))
-		for i := range positionCounts {
-			positionCounts[i] = make([]int, len(sAds))
-		}
-
-		for range iters {
-			sorted, err := sortServerAds(ctx, clientIP, sAds, nil, redirectInfo)
-			require.NoError(t, err)
-			for pos, ad := range sorted {
-				if ad.StatusWeight == 0.8 {
-					// These indices correspond to the initial ad values
-					// and how they should be sorted
-					positionCounts[2][pos]++
-				} else if ad.StatusWeight == 0.5 {
-					positionCounts[0][pos]++
-				} else {
-					positionCounts[1][pos]++
-				}
-			}
-		}
-
-		// Calculate the average index for each ad
-		avgsPos := make([]float64, len(sAds))
-		for i, counts := range positionCounts {
-			for j, count := range counts {
-				avgsPos[i] += float64(j) * float64(count)
-			}
-
-			avgsPos[i] /= float64(iters)
-		}
-
-		// Now assert the ordering: lower average index means higher position
-		assert.Less(t, avgsPos[2], avgsPos[0], "Status weight 0.8 should be sorted higher than 0.5")
-		assert.Less(t, avgsPos[0], avgsPos[1], "Status weight 0.5 should be sorted higher than 0.2")
-	})
-}
-
-func TestSortServerAdsByAvailability(t *testing.T) {
-	firstUrl := url.URL{Host: "first.org", Scheme: "https"}
-	secondUrl := url.URL{Host: "second.org", Scheme: "https"}
-	thirdUrl := url.URL{Host: "third.org", Scheme: "https"}
-	fourthUrl := url.URL{Host: "fourth.org", Scheme: "https"}
-
-	firstServer := server_structs.ServerAd{URL: firstUrl}
-	secondServer := server_structs.ServerAd{URL: secondUrl}
-	thirdServer := server_structs.ServerAd{URL: thirdUrl}
-	fourthServer := server_structs.ServerAd{URL: fourthUrl}
-
-	randomOrder := []server_structs.ServerAd{thirdServer, firstServer, fourthServer, secondServer}
-	expected := []server_structs.ServerAd{firstServer, secondServer, thirdServer, fourthServer}
-	avaiMap := map[string]bool{}
-	avaiMap[firstUrl.String()] = true
-	avaiMap[secondUrl.String()] = true
-	avaiMap[thirdUrl.String()] = false
-	avaiMap[fourthUrl.String()] = false
-
-	sortServerAdsByAvailability(randomOrder, avaiMap)
-	assert.EqualValues(t, expected, randomOrder)
-}
-
-func TestAssignRandBoundedCoord(t *testing.T) {
-	// Because of the test's randomness, do it a few times to increase the likelihood of catching errors
-	for i := 0; i < 10; i++ {
-		// Generate a random bounding box between -200, 200
-		lat1 := rand.Float64()*400 - 200
-		long1 := rand.Float64()*400 - 200
-		lat2 := rand.Float64()*400 - 200
-		long2 := rand.Float64()*400 - 200
-
-		// Assign mins and maxes
-		minLat, maxLat := math.Min(lat1, lat2), math.Max(lat1, lat2)
-		minLong, maxLong := math.Min(long1, long2), math.Max(long1, long2)
-
-		// Assign a random coordinate within the bounding box
-		lat, long := assignRandBoundedCoord(minLat, maxLat, minLong, maxLong)
-		assert.True(t, lat >= minLat && lat <= maxLat)
-		assert.True(t, long >= minLong && long <= maxLong)
-	}
-}
-
-func TestGetClientLatLong(t *testing.T) {
-	// The cache may be populated from previous tests. Wipe it out and start fresh.
-	clientIpCache.DeleteAll()
-	defer clientIpCache.DeleteAll()
-	t.Run("invalid-ip", func(t *testing.T) {
-		// Capture the log and check that the correct error is logged
-		origOutput := log.StandardLogger().Out
-		logOutput := &(bytes.Buffer{})
-		log.SetOutput(logOutput)
-		log.SetLevel(log.DebugLevel)
-		defer func() {
-			log.SetOutput(origOutput)
-		}()
-
-		clientIp := netip.Addr{}
-		assert.False(t, clientIpCache.Has(clientIp))
-		rInfo := server_structs.NewRedirectInfoFromIP(clientIp.String())
-		coord1, _ := getClientLatLong(clientIp, rInfo)
-
-		assert.True(t, coord1.Lat <= usLatMax && coord1.Lat >= usLatMin)
-		assert.True(t, coord1.Long <= usLongMax && coord1.Long >= usLongMin)
-		assert.False(t, rInfo.ClientInfo.Resolved)
-		assert.False(t, rInfo.ClientInfo.FromTTLCache)
-		assert.Contains(t, logOutput.String(), "Unable to sort servers based on client-server distance. Invalid client IP address")
-		assert.NotContains(t, logOutput.String(), "Using randomly-assigned lat/long")
-
-		// Get it again to make sure it's coming from the cache
-		coord2, _ := getClientLatLong(clientIp, rInfo)
-		assert.Equal(t, coord1.Lat, coord2.Lat)
-		assert.Equal(t, coord1.Long, coord2.Long)
-		assert.False(t, rInfo.ClientInfo.Resolved)
-		assert.True(t, rInfo.ClientInfo.FromTTLCache)
-		assert.Contains(t, logOutput.String(), "Using randomly-assigned lat/long for unresolved client IP")
-		assert.True(t, clientIpCache.Has(clientIp))
-	})
-
-	t.Run("valid-ip-no-geoip-match", func(t *testing.T) {
-		logOutput := &(bytes.Buffer{})
-		origOutput := log.StandardLogger().Out
-		log.SetOutput(logOutput)
-		log.SetLevel(log.DebugLevel)
-		defer func() {
-			log.SetOutput(origOutput)
-		}()
-
-		clientIp := netip.MustParseAddr("192.168.0.1")
-		assert.False(t, clientIpCache.Has(clientIp))
-		rInfo := server_structs.NewRedirectInfoFromIP(clientIp.String())
-		coord1, _ := getClientLatLong(clientIp, rInfo)
-
-		assert.True(t, coord1.Lat <= usLatMax && coord1.Lat >= usLatMin)
-		assert.True(t, coord1.Long <= usLongMax && coord1.Long >= usLongMin)
-		assert.False(t, rInfo.ClientInfo.Resolved)
-		assert.False(t, rInfo.ClientInfo.FromTTLCache)
-		assert.Contains(t, logOutput.String(), "Client IP 192.168.0.1 has been re-assigned a random location in the contiguous US to lat/long")
-		assert.NotContains(t, logOutput.String(), "Using randomly-assigned lat/long")
-
-		// Get it again to make sure it's coming from the cache
-		coord2, _ := getClientLatLong(clientIp, rInfo)
-		assert.Equal(t, coord1.Lat, coord2.Lat)
-		assert.Equal(t, coord1.Long, coord2.Long)
-		assert.False(t, rInfo.ClientInfo.Resolved)
-		assert.True(t, rInfo.ClientInfo.FromTTLCache)
-		assert.Contains(t, logOutput.String(), "Using randomly-assigned lat/long for client IP")
-		assert.True(t, clientIpCache.Has(clientIp))
-	})
-}
 
 func hasServerAdWithName(ads []copyAd, name string) bool {
 	for _, ad := range ads {
@@ -1473,11 +801,63 @@ func TestCacheNotFromTopoIfPubReads(t *testing.T) {
 	}
 }
 
+func TestCacheNotInErrorState(t *testing.T) {
+	testCases := []struct {
+		name     string
+		status   metrics.HealthStatusEnum
+		expected bool
+	}{
+		{
+			name:     "Cache in healthy state",
+			status:   metrics.StatusOK,
+			expected: true,
+		},
+		{
+			name:     "Cache in unknown state",
+			status:   metrics.StatusUnknown,
+			expected: true,
+		},
+		{
+			name:     "Cache in warning state",
+			status:   metrics.StatusWarning,
+			expected: true,
+		},
+		{
+			name:     "Cache in degraded state",
+			status:   metrics.StatusDegraded,
+			expected: true,
+		},
+		{
+			name:     "Cache in critical state",
+			status:   metrics.StatusCritical,
+			expected: false,
+		},
+		{
+			name:     "Cache in shutting down state",
+			status:   metrics.StatusShuttingDown,
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ad := copyAd{
+				ServerAd: server_structs.ServerAd{
+					Status: tc.status.String(),
+				},
+			}
+
+			ctx := &gin.Context{}
+			assert.Equal(t, tc.expected, cacheNotInErrorState()(ctx, ad))
+		})
+	}
+}
+
 func TestFilterCaches(t *testing.T) {
 	testCases := []struct {
 		name            string
 		ads             []copyAd
-		commonPred      AdPredicate
+		commonPreds     []AdPredicate
 		supportedPreds  []AdPredicate
 		unknownPreds    []AdPredicate
 		expectedSupport []string
@@ -1489,7 +869,9 @@ func TestFilterCaches(t *testing.T) {
 				produceAd("ad1", server_structs.CacheType.String(), ""),
 				produceAd("ad2", server_structs.CacheType.String(), ""),
 			},
-			commonPred: func(ctx *gin.Context, ad copyAd) bool { return true },
+			commonPreds: []AdPredicate{
+				func(ctx *gin.Context, ad copyAd) bool { return true },
+			},
 			supportedPreds: []AdPredicate{
 				func(ctx *gin.Context, ad copyAd) bool { return true },
 			},
@@ -1503,7 +885,9 @@ func TestFilterCaches(t *testing.T) {
 				produceAd("ad1", server_structs.CacheType.String(), ""),
 				produceAd("ad2", server_structs.CacheType.String(), ""),
 			},
-			commonPred: func(ctx *gin.Context, ad copyAd) bool { return true },
+			commonPreds: []AdPredicate{
+				func(ctx *gin.Context, ad copyAd) bool { return true },
+			},
 			supportedPreds: []AdPredicate{
 				func(ctx *gin.Context, ad copyAd) bool { return ad.ServerAd.Name == "ad1" },
 			},
@@ -1519,7 +903,9 @@ func TestFilterCaches(t *testing.T) {
 				produceAd("ad1", server_structs.CacheType.String(), ""),
 				produceAd("ad2", server_structs.CacheType.String(), ""),
 			},
-			commonPred: func(ctx *gin.Context, ad copyAd) bool { return true },
+			commonPreds: []AdPredicate{
+				func(ctx *gin.Context, ad copyAd) bool { return true },
+			},
 			supportedPreds: []AdPredicate{
 				func(ctx *gin.Context, ad copyAd) bool { return false },
 			},
@@ -1535,7 +921,9 @@ func TestFilterCaches(t *testing.T) {
 				produceAd("ad1", server_structs.CacheType.String(), ""),
 				produceAd("ad2", server_structs.CacheType.String(), ""),
 			},
-			commonPred: func(ctx *gin.Context, ad copyAd) bool { return false },
+			commonPreds: []AdPredicate{
+				func(ctx *gin.Context, ad copyAd) bool { return false },
+			},
 			supportedPreds: []AdPredicate{
 				func(ctx *gin.Context, ad copyAd) bool { return true },
 			},
@@ -1552,7 +940,9 @@ func TestFilterCaches(t *testing.T) {
 				produceAd("ad2", server_structs.CacheType.String(), ""),
 				produceAd("ad3", server_structs.CacheType.String(), ""),
 			},
-			commonPred: func(ctx *gin.Context, ad copyAd) bool { return true },
+			commonPreds: []AdPredicate{
+				func(ctx *gin.Context, ad copyAd) bool { return true },
+			},
 			supportedPreds: []AdPredicate{
 				func(ctx *gin.Context, ad copyAd) bool { return ad.ServerAd.Name == "ad1" },
 			},
@@ -1567,7 +957,7 @@ func TestFilterCaches(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := &gin.Context{}
-			supported, unknown := filterCaches(ctx, tc.ads, tc.commonPred, tc.supportedPreds, tc.unknownPreds)
+			supported, unknown := filterCaches(ctx, tc.ads, tc.commonPreds, tc.supportedPreds, tc.unknownPreds)
 
 			// Verify supported ads
 			assert.Len(t, supported, len(tc.expectedSupport), "Number of supported ads should match")

--- a/director/sort_utilities.go
+++ b/director/sort_utilities.go
@@ -201,6 +201,39 @@ func angularDistanceOnSphere(lat1 float64, long1 float64, lat2 float64, long2 fl
 	return arc
 }
 
+// Apply a thresholded exponential halving multiplier to a value:
+// 1; 0 <= val <= threshold
+// 2 ^ (-(val-threshold)/halvingFactor); val > threshold
+// If any invalid parameters are provided (negative threshold/halving factor, etc), 1.0 is returned.
+func thresholdedExponentialHalvingMultiplier(val float64, threshold float64, halvingFactor float64) float64 {
+	if halvingFactor <= 0 {
+		return 1.0
+	}
+
+	if threshold < 0 {
+		return 1.0
+	}
+
+	// this also handles nevative values, since they will always be <= threshold
+	if val <= threshold {
+		return 1.0
+	}
+
+	return math.Pow(2.0, -1.0*((val-threshold)/halvingFactor))
+}
+
+// Given a slice of ads, truncate it to the specified limit. A limit of 0 or less means no truncation.
+func truncateAds(ads []server_structs.ServerAd, limit int) []server_structs.ServerAd {
+	if limit <= 0 {
+		return ads
+	}
+
+	if len(ads) > limit {
+		return ads[:limit]
+	}
+	return ads
+}
+
 // Given a bounding box, assign a random coordinate within that box.
 func assignRandBoundedCoord(minLat, maxLat, minLong, maxLong float64) (lat, long float64) {
 	lat = rand.Float64()*(maxLat-minLat) + minLat

--- a/director/sort_utilities.go
+++ b/director/sort_utilities.go
@@ -349,19 +349,17 @@ func getServerCoordinate(sAd server_structs.ServerAd) (coord server_structs.Coor
 	// Now try MaxMind
 	coord, err = getMaxMindCoordinate(addr)
 	if err != nil {
-		if param.Monitoring_EnablePrometheus.GetBool() {
-			network, ok := utils.ApplyIPMask(addr.String())
-			if !ok {
-				log.Warningf("Failed to apply IP mask to address %s", addr.String())
-				network = "unknown"
-			}
-
-			labels := prometheus.Labels{
-				"network":     network,
-				"server_name": sAd.Name,
-			}
-			metrics.PelicanDirectorMaxMindServerErrorsTotal.With(labels).Inc()
+		network, ok := utils.ApplyIPMask(addr.String())
+		if !ok {
+			log.Warningf("Failed to apply IP mask to address %s", addr.String())
+			network = "unknown"
 		}
+
+		labels := prometheus.Labels{
+			"network":     network,
+			"server_name": sAd.Name,
+		}
+		metrics.PelicanDirectorMaxMindServerErrorsTotal.With(labels).Inc()
 	}
 
 	return
@@ -387,19 +385,17 @@ func getClientCoordinate(ctx context.Context, addr netip.Addr) (coord server_str
 	}
 
 	handleClientGeoIPFailure := func(addr netip.Addr) {
-		if param.Monitoring_EnablePrometheus.GetBool() {
-			network, ok := utils.ApplyIPMask(addr.String())
-			if !ok {
-				log.Warningf("Failed to apply IP mask to address %s", addr.String())
-				network = "unknown"
-			}
-			proj := getProjectLabel(ctx)
-			labels := prometheus.Labels{
-				"network": network,
-				"project": proj,
-			}
-			metrics.PelicanDirectorMaxMindClientErrorsTotal.With(labels).Inc()
+		network, ok := utils.ApplyIPMask(addr.String())
+		if !ok {
+			log.Warningf("Failed to apply IP mask to address %s", addr.String())
+			network = "unknown"
 		}
+		proj := getProjectLabel(ctx)
+		labels := prometheus.Labels{
+			"network": network,
+			"project": proj,
+		}
+		metrics.PelicanDirectorMaxMindClientErrorsTotal.With(labels).Inc()
 	}
 
 	// Check the random assignment cache

--- a/director/sort_utilities.go
+++ b/director/sort_utilities.go
@@ -1,0 +1,358 @@
+/***************************************************************
+*
+* Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you
+* may not use this file except in compliance with the License.  You may
+* obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************/
+
+package director
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"net"
+	"net/netip"
+	"slices"
+	"time"
+
+	"github.com/jellydator/ttlcache/v3"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/pelicanplatform/pelican/metrics"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/utils"
+)
+
+type (
+	// A GeoIPOverride maps a specific IP to a configured lat/long coordinate.
+	GeoIPOverride struct {
+		IP         string                    `mapstructure:"IP"`
+		Coordinate server_structs.Coordinate `mapstructure:"Coordinate"`
+	}
+
+	// A GeoNetOverride maps a CIDR block to a configured lat/long coordinate.
+	GeoNetOverride struct {
+		IPNet      netip.Prefix
+		Coordinate server_structs.Coordinate
+	}
+)
+
+var (
+	// Stores the unmarshalled GeoIP override config in a form that's efficient to test
+	geoNetOverrides []GeoNetOverride
+
+	// Stores a mapping of client IPs that have been randomly assigned a coordinate
+	clientIpRandAssignmentCache = ttlcache.New(ttlcache.WithTTL[netip.Addr, server_structs.Coordinate](20*time.Minute),
+		ttlcache.WithDisableTouchOnHit[netip.Addr, server_structs.Coordinate](),
+		ttlcache.WithCapacity[netip.Addr, server_structs.Coordinate](10_000),
+	)
+
+	// Stores a mapping of client IPs that have previously matched some GeoIP override
+	// Note that this cache does not have an actual TTL/Expiration because GeoIP overrides
+	// come from static yaml config and exist for the duration of the instance -- if an
+	// IP matches an override, we expect it to match the override every time until the config
+	// is updated and the service is rebooted.
+	// This cache should only be accessed by `checkOverrides` to guarantee overrides have already been unmarshalled
+	clientIpGeoOverrideCache = ttlcache.New(
+		ttlcache.WithCapacity[netip.Addr, server_structs.Coordinate](50_000), // limit was chosen somewhat arbitrarily, but seems reasonable
+	)
+)
+
+const (
+	earthRadiusToMilesFactor = 3960
+
+	// A rough lat/long bounding box for the contiguous US. We might eventually make this box
+	// a configurable value, but for now it's hardcoded
+	usLatMin  = 30.0
+	usLatMax  = 50.0
+	usLongMin = -125.0
+	usLongMax = -65.0
+)
+
+// Unmarshal any configured GeoIP overrides.
+// Malformed IPs and CIDRs are logged but not returned as errors.
+func unmarshalOverrides() error {
+	var geoIPOverrides []GeoIPOverride
+
+	// Ensure that we're starting with an empty slice.
+	geoNetOverrides = nil
+
+	if err := param.GeoIPOverrides.Unmarshal(&geoIPOverrides); err != nil {
+		return err
+	}
+
+	for _, override := range geoIPOverrides {
+		var addr netip.Addr
+		var prefix netip.Prefix
+		var err error
+
+		// Try CIDR first.
+		if pfx, perr := netip.ParsePrefix(override.IP); perr == nil {
+			prefix = pfx
+		} else if a, aerr := netip.ParseAddr(override.IP); aerr == nil {
+			addr = a
+			// Turn it into a /32 (IPv4) or /128 (IPv6) prefix (i.e. a one-host CIDR block)
+			prefix = netip.PrefixFrom(addr, addr.BitLen())
+		} else {
+			err = fmt.Errorf("failed to parse as CIDR (%v) or IP (%v)", perr, aerr)
+		}
+
+		if err != nil {
+			log.Warningf("Failed to parse configured GeoIPOverride address (%s): %v. Unable to use for GeoIP resolution!", override.IP, err)
+			continue
+		}
+
+		coordinate := server_structs.Coordinate{
+			Lat:            override.Coordinate.Lat,
+			Long:           override.Coordinate.Long,
+			AccuracyRadius: 0, // Maybe this should be the maximum possible accuracy radius instead of using 0 to mean "unknown"?
+			Source:         server_structs.CoordinateSourceOverride,
+			FromTTLCache:   false,
+		}
+		geoNetOverrides = append(geoNetOverrides, GeoNetOverride{
+			IPNet:      prefix,
+			Coordinate: coordinate,
+		})
+	}
+	return nil
+}
+
+// Check for any pre-configured IP-to-lat/long overrides. If the passed address
+// matches an override IP (either directly or via CIDR masking), then we use the
+// configured lat/long from the override instead of relying on MaxMind.
+// NOTE: We don't return an error because if checkOverrides encounters an issue,
+// we still have GeoIP to fall back on.
+func checkOverrides(addr netip.Addr) (coord server_structs.Coordinate, exists bool) {
+	if cached := clientIpGeoOverrideCache.Get(addr); cached != nil {
+		coord = cached.Value()
+		return coord, true
+	}
+
+	// Unmarshal the GeoIP override config if we haven't already done so.
+	if geoNetOverrides == nil {
+		if err := unmarshalOverrides(); err != nil {
+			log.Warningf("Unable to unmarshal GeoIP overrides: %v", err)
+			return
+		}
+	}
+	for _, override := range geoNetOverrides {
+		if override.IPNet.Contains(addr) {
+			// Insert entry into cache with -1 to indicate no expiration
+			// If the cache is already full, it should use LRU GC
+			clientIpGeoOverrideCache.Set(addr, override.Coordinate, -1)
+			// Moreover, while we're technically sticking this in a cache, we don't
+			// set set FromTTLCache to true because this is a configured override that
+			// has no expiration. We're only using the ttl cache for efficient lookup.
+			return override.Coordinate, true
+		}
+	}
+
+	return
+}
+
+// Mathematical function, not implementation, came from
+// http://www.johndcook.com/python_longitude_latitude.html
+// Returned values are not actual distances, but is relative to earth's radius
+func angularDistanceOnSphere(lat1 float64, long1 float64, lat2 float64, long2 float64) float64 {
+
+	if (lat1 == lat2) && (long1 == long2) {
+		return 0.0
+	}
+
+	// Convert latitude and longitude to
+	// spherical coordinates in radians.
+	degrees_to_radians := math.Pi / 180.0
+
+	// phi = 90 - latitude
+	phi1 := (90.0 - lat1) * degrees_to_radians
+	phi2 := (90.0 - lat2) * degrees_to_radians
+
+	// theta = longitude
+	theta1 := long1 * degrees_to_radians
+	theta2 := long2 * degrees_to_radians
+
+	// Compute spherical distance from spherical coordinates.
+
+	// For two locations in spherical coordinates
+	// (1, theta, phi) and (1, theta, phi)
+	// cosine( arc length ) =
+	//    sin phi sin phi' cos(theta-theta') + cos phi cos phi'
+	// distance = rho * arc length
+
+	cos := (math.Sin(phi1)*math.Sin(phi2)*math.Cos(theta1-theta2) +
+		math.Cos(phi1)*math.Cos(phi2))
+	arc := math.Acos(cos)
+
+	return arc
+}
+
+// Given a bounding box, assign a random coordinate within that box.
+func assignRandBoundedCoord(minLat, maxLat, minLong, maxLong float64) (lat, long float64) {
+	lat = rand.Float64()*(maxLat-minLat) + minLat
+	long = rand.Float64()*(maxLong-minLong) + minLong
+	return
+}
+
+// Given a hostname, perform a DNS lookup to find the associated IP address.
+// While this is only used by getServerCoordinate at time of writing, it's split
+// into a separate function to facilitate unit testing (where it's useful to override this)
+var getIPFromHostname = func(hostname string) (netip.Addr, error) {
+	ip, err := net.LookupIP(hostname)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+	if len(ip) == 0 {
+		return netip.Addr{}, fmt.Errorf("unable to find an IP address for hostname '%s'", hostname)
+	}
+	addr, ok := netip.AddrFromSlice(ip[0])
+	if !ok {
+		return netip.Addr{}, fmt.Errorf("unable to convert IP address '%s' associated with hostname '%s' to netip.Addr", ip[0].String(), hostname)
+	}
+	return addr, nil
+}
+
+// Client redirects use the gin request's user agent to specify a project.
+// The project gets tied to the request context so it can be passed around as needed.
+func getProjectLabel(ctx context.Context) (project string) {
+	project, ok := ctx.Value(ProjectContextKey{}).(string)
+	if !ok || project == "" {
+		project = "unknown"
+	}
+
+	return
+}
+
+// Given a server ad, retrieve the associated geolocation coordinate,
+// including provenance metadata (coordinate source, accuracy radius, etc.)
+//
+// The URL from the server ad is first used for a DNS lookup to get the IP address,
+// which is then used for GeoIP resolution.
+// Coordinates are determined in order of precedence:
+// 1. Configured GeoIP Overrides
+// 2. MaxMind Lookups
+func getServerCoordinate(sAd server_structs.ServerAd) (coord server_structs.Coordinate, err error) {
+	// Get the IP from the server ad's hostname
+	hostname := sAd.URL.Hostname()
+	addr, err := getIPFromHostname(hostname)
+	if err != nil {
+		return coord, fmt.Errorf("failed to get IP address for server ad '%s' with hostname '%s': %v", sAd.Name, hostname, err)
+	}
+
+	// Check for overrides
+	if overrideCoord, exists := checkOverrides(addr); exists {
+		// All coordinate provenance fields should have been handled on GeoOverride unmarshal or cache insertion
+		coord = overrideCoord
+		log.Tracef("Overriding Geolocation of detected client IP (%s) (lat:long %f:%f) based on configured overrides",
+			addr.String(), coord.Lat, coord.Long)
+		return
+	}
+
+	// Now try MaxMind
+	coord, err = getMaxMindCoordinate(addr)
+	if err != nil {
+		if param.Monitoring_EnablePrometheus.GetBool() {
+			network, ok := utils.ApplyIPMask(addr.String())
+			if !ok {
+				log.Warningf("Failed to apply IP mask to address %s", addr.String())
+				network = "unknown"
+			}
+
+			labels := prometheus.Labels{
+				"network":     network,
+				"server_name": sAd.Name,
+			}
+			metrics.PelicanDirectorMaxMindServerErrorsTotal.With(labels).Inc()
+		}
+	}
+
+	return
+}
+
+// Given a client IP address, retrieve the associated geolocation coordinate
+// including provenance metadata (coordinate source, accuracy radius, etc.)
+// This method does not return an error because it will always return a coordinate,
+// so any GeoIP/MaxMind errors generated during the lookup process are handled internally.
+//
+// Coordinates are determined in order of precedence:
+// 1. Configured GeoIP Overrides
+// 2. MaxMind Lookups
+// 3. Random, Geo-Bounded Assignments (when (1), (2) are not available)
+func getClientCoordinate(ctx context.Context, addr netip.Addr) (coord server_structs.Coordinate) {
+	// Check for overrides
+	if overrideCoord, exists := checkOverrides(addr); exists {
+		// All coordinate provenance fields should have been handled on GeoOverride unmarshal or cache insertion
+		coord = overrideCoord
+		log.Tracef("Overriding Geolocation of detected client IP (%s) (lat:long %f:%f) based on configured overrides",
+			addr.String(), coord.Lat, coord.Long)
+		return
+	}
+
+	handleClientGeoIPFailure := func(addr netip.Addr) {
+		if param.Monitoring_EnablePrometheus.GetBool() {
+			network, ok := utils.ApplyIPMask(addr.String())
+			if !ok {
+				log.Warningf("Failed to apply IP mask to address %s", addr.String())
+				network = "unknown"
+			}
+			proj := getProjectLabel(ctx)
+			labels := prometheus.Labels{
+				"network": network,
+				"project": proj,
+			}
+			metrics.PelicanDirectorMaxMindClientErrorsTotal.With(labels).Inc()
+		}
+	}
+
+	// Check the random assignment cache
+	if cached := clientIpRandAssignmentCache.Get(addr); cached != nil {
+		// Even though this is a cached random assignment, we still want to increment the
+		// Prometheus metric for GeoIP failures because this would presumably cause another
+		// failure were it not cached.
+		handleClientGeoIPFailure(addr)
+
+		// Similarly, provenance fields should have been handled on cache insertion
+		coord = cached.Value()
+		log.Tracef("Grabbing coordinate of detected client IP (%s) from random assignment cache (lat:long %f:%f). This assignment will be cached for %v",
+			addr.String(), coord.Lat, coord.Long, time.Until(cached.ExpiresAt()))
+		return
+	}
+
+	// Now try MaxMind
+	mmCoord, err := getMaxMindCoordinate(addr)
+	if err == nil {
+		coord = mmCoord
+		return
+	}
+
+	// Getting here means we tried and failed to find a coordinate via all other
+	// sources of truth and we're using a fallback random assignment.
+	// Increment the Prometheus metric that tracks GeoIP errors for client IPs
+	handleClientGeoIPFailure(addr)
+
+	log.Tracef("Assigning random location in the contiguous US to lat/long %f, %f to unresolvable client IP %s. This assignment will be cached for 20 minutes.", coord.Lat, coord.Long, addr.String())
+	coord.Lat, coord.Long = assignRandBoundedCoord(usLatMin, usLatMax, usLongMin, usLongMax)
+	coord.AccuracyRadius = 0
+	coord.Source = server_structs.CoordinateSourceRandom
+	// Set the coord's TTL cache field to true so cached value is accurate, but reset it on return
+	// because this value wasn't cached when we generated it.
+	coord.FromTTLCache = true
+	clientIpRandAssignmentCache.Set(addr, coord, 20*time.Minute)
+
+	coord.FromTTLCache = false
+	return
+}

--- a/director/sort_utilities_test.go
+++ b/director/sort_utilities_test.go
@@ -219,6 +219,134 @@ func TestAngularDistanceOnSphere(t *testing.T) {
 	}
 }
 
+func TestThresholdedExponentialHalvingMultiplier(t *testing.T) {
+	testCases := []struct {
+		name          string
+		val           float64
+		threshold     float64
+		halvingFactor float64
+		expected      float64
+	}{
+		{
+			name:          "value below threshold",
+			val:           5.0,
+			threshold:     10.0,
+			halvingFactor: 20.0,
+			expected:      1.0,
+		},
+		{
+			name:          "value at threshold",
+			val:           10.0,
+			threshold:     10.0,
+			halvingFactor: 20.0,
+			expected:      1.0,
+		},
+		{
+			name:          "value one halving factor above threshold",
+			val:           30.0,
+			threshold:     10.0,
+			halvingFactor: 20.0,
+			expected:      0.5,
+		},
+		{
+			name:          "value two halving factors above threshold",
+			val:           50.0,
+			threshold:     10.0,
+			halvingFactor: 20.0,
+			expected:      0.25,
+		},
+		{
+			name:          "negative threshold",
+			val:           5.0,
+			threshold:     -10.0,
+			halvingFactor: 20.0,
+			expected:      1.0,
+		},
+		{
+			name:          "zero halving factor",
+			val:           30.0,
+			threshold:     10.0,
+			halvingFactor: 0.0,
+			expected:      1.0,
+		},
+		{
+			name:          "negative halving factor",
+			val:           30.0,
+			threshold:     10.0,
+			halvingFactor: -20.0,
+			expected:      1.0,
+		},
+		{
+			name:          "negative value",
+			val:           -5.0,
+			threshold:     10.0,
+			halvingFactor: 20.0,
+			expected:      1.0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := thresholdedExponentialHalvingMultiplier(tc.val, tc.threshold, tc.halvingFactor)
+			assert.InDelta(t, tc.expected, result, 0.0001)
+		})
+	}
+}
+
+func TestTruncateAds(t *testing.T) {
+	ad1 := server_structs.ServerAd{}
+	ad1.Initialize("ad1")
+	ad2 := server_structs.ServerAd{}
+	ad2.Initialize("ad2")
+	ad3 := server_structs.ServerAd{}
+	ad3.Initialize("ad3")
+
+	testCases := []struct {
+		name     string
+		ads      []server_structs.ServerAd
+		maxAds   int
+		expected []server_structs.ServerAd
+	}{
+		{
+			name:     "fewer ads than max",
+			ads:      []server_structs.ServerAd{ad1, ad2},
+			maxAds:   5,
+			expected: []server_structs.ServerAd{ad1, ad2},
+		},
+		{
+			name:     "equal number of ads and max",
+			ads:      []server_structs.ServerAd{ad1, ad2, ad3},
+			maxAds:   3,
+			expected: []server_structs.ServerAd{ad1, ad2, ad3},
+		},
+		{
+			name:     "more ads than max",
+			ads:      []server_structs.ServerAd{ad1, ad2, ad3},
+			maxAds:   2,
+			expected: []server_structs.ServerAd{ad1, ad2},
+		},
+		{
+			name:     "max ads is zero",
+			ads:      []server_structs.ServerAd{ad1, ad2, ad3},
+			maxAds:   0,
+			expected: []server_structs.ServerAd{ad1, ad2, ad3},
+		},
+		{
+			name:     "max ads is negative",
+			ads:      []server_structs.ServerAd{ad1, ad2, ad3},
+			maxAds:   -1,
+			expected: []server_structs.ServerAd{ad1, ad2, ad3},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := truncateAds(tc.ads, tc.maxAds)
+			assert.EqualValues(t, tc.expected, result)
+		})
+	}
+}
+
 func TestAssignRandBoundedCoord(t *testing.T) {
 	// Because of the test's randomness, do it a few times to increase the likelihood of catching errors
 	for range 10 {

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1820,6 +1820,17 @@ type: string
 default: distance
 components: ["director"]
 ---
+name: Director.FilterCachesInErrorState
+description: |+
+  If true, the Director will filter out any caches that report a health status worse than "warning" when deciding which
+  caches might fulfill a client request. This filter is independent of the cache sorting method, and is applied before sorting.
+
+  This knob is meant mostly to aid in unit testing, where it has been tricky to start all tests with healthy services.
+type: bool
+default: true
+hidden: true
+components: ["director"]
+---
 name: Director.AdaptiveSortEWMATimeConstant
 description: |+
   The time constant used for calculating alpha in the Director's EWMA smoothing of server status weights.

--- a/fed_test_utils/fed.go
+++ b/fed_test_utils/fed.go
@@ -156,6 +156,7 @@ func NewFedTest(t *testing.T, originConfig string) (ft *FedTest) {
 	viper.Set(param.Registry_RequireCacheApproval.GetName(), false)
 	viper.Set(param.Director_CacheSortMethod.GetName(), "distance")
 	viper.Set(param.Director_DbLocation.GetName(), filepath.Join(t.TempDir(), "director.sqlite"))
+	viper.Set(param.Director_FilterCachesInErrorState.GetName(), false)
 	viper.Set(param.Origin_EnableCmsd.GetName(), false)
 	viper.Set(param.Origin_EnableVoms.GetName(), false)
 	viper.Set(param.Origin_Port.GetName(), ports[0])
@@ -164,16 +165,16 @@ func NewFedTest(t *testing.T, originConfig string) (ft *FedTest) {
 	viper.Set(param.Origin_TokenAudience.GetName(), "")
 	viper.Set(param.Cache_Port.GetName(), ports[1])
 	viper.Set(param.Cache_RunLocation.GetName(), filepath.Join(tmpPath, "cache"))
+	viper.Set(param.Cache_EnableEvictionMonitoring.GetName(), false)
 	viper.Set(param.Cache_StorageLocation.GetName(), filepath.Join(tmpPath, "xcache-data"))
 	viper.Set(param.Cache_DbLocation.GetName(), filepath.Join(t.TempDir(), "cache.sqlite"))
 	viper.Set(param.Server_EnableUI.GetName(), false)
 	viper.Set(param.Server_WebPort.GetName(), ports[2])
-	viper.Set(param.Cache_EnableEvictionMonitoring.GetName(), false)
+	viper.Set(param.Server_DbLocation.GetName(), filepath.Join(t.TempDir(), "server.sqlite"))
 	// Unix domain sockets have a maximum length of 108 bytes, so we need to make sure our
 	// socket path is short enough to fit within that limit. Mac OS X has long temporary path
 	// names, so we need to make sure our socket path is short enough to fit within that limit.
 	viper.Set(param.LocalCache_RunLocation.GetName(), filepath.Join(tmpPath, "lc"))
-	viper.Set(param.Server_DbLocation.GetName(), filepath.Join(t.TempDir(), "server.sqlite"))
 
 	// Set the Director's start time to 6 minutes ago. This prevents it from sending an HTTP 429 for
 	// unknown prefixes.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/pelicanplatform/pelican
 // Unpublish Go package as we are not intended to allow users us import our packages for now
 retract [v1.0.0, v1.0.5]
 
-go 1.24.0
+go 1.24
 
 toolchain go1.24.7
 
@@ -28,7 +28,7 @@ require (
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 	github.com/oklog/run v1.1.0
 	github.com/opensciencegrid/xrootd-monitoring-shoveler v1.3.0
-	github.com/oschwald/geoip2-golang v1.9.0
+	github.com/oschwald/geoip2-golang/v2 v2.0.0-beta.4
 	github.com/pkg/errors v0.9.1
 	github.com/pressly/goose/v3 v3.18.0
 	github.com/prometheus/client_golang v1.17.0
@@ -82,6 +82,7 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.15.3-0.20240618155329-98d742f6907a // indirect
+	github.com/oschwald/maxminddb-golang/v2 v2.0.0-beta.9 // indirect
 	github.com/redis/go-redis/v9 v9.0.2 // indirect
 	github.com/sagikazarmark/locafero v0.6.0 // indirect
 	github.com/sethvargo/go-retry v0.2.4 // indirect
@@ -92,7 +93,7 @@ require (
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0016 // indirect
 	go.opentelemetry.io/collector/semconv v0.87.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/sys v0.31.0 // indirect
+	golang.org/x/sys v0.35.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241223144023-3abc09e42ca8 // indirect
 	google.golang.org/grpc v1.67.3 // indirect
 	modernc.org/sqlite v1.28.0 // indirect
@@ -166,7 +167,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
-	github.com/oschwald/maxminddb-golang v1.11.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -607,10 +607,10 @@ github.com/opensciencegrid/xrootd-monitoring-shoveler v1.3.0 h1:LH4tawmXopCaGSCq
 github.com/opensciencegrid/xrootd-monitoring-shoveler v1.3.0/go.mod h1:Vwfgh7SVDvaHDpbLsJVoTtIHAg8Uv8b2aRoTBGozASM=
 github.com/ory/dockertest/v3 v3.10.0 h1:4K3z2VMe8Woe++invjaTB7VRyQXQy5UY+loujO4aNE4=
 github.com/ory/dockertest/v3 v3.10.0/go.mod h1:nr57ZbRWMqfsdGdFNLHz5jjNdDb7VVFnzAeW1n5N1Lg=
-github.com/oschwald/geoip2-golang v1.9.0 h1:uvD3O6fXAXs+usU+UGExshpdP13GAqp4GBrzN7IgKZc=
-github.com/oschwald/geoip2-golang v1.9.0/go.mod h1:BHK6TvDyATVQhKNbQBdrj9eAvuwOMi2zSFXizL3K81Y=
-github.com/oschwald/maxminddb-golang v1.11.0 h1:aSXMqYR/EPNjGE8epgqwDay+P30hCBZIveY0WZbAWh0=
-github.com/oschwald/maxminddb-golang v1.11.0/go.mod h1:YmVI+H0zh3ySFR3w+oz8PCfglAFj3PuCmui13+P9zDg=
+github.com/oschwald/geoip2-golang/v2 v2.0.0-beta.4 h1:O5fVXaiCQ1t1284iEGPHaMSqOfjBqWig7NOD6WIQkxA=
+github.com/oschwald/geoip2-golang/v2 v2.0.0-beta.4/go.mod h1:fHGWi8nhf3ZNFPE09LPwp7p2ABZoc5XXx6VY5mIBNNw=
+github.com/oschwald/maxminddb-golang/v2 v2.0.0-beta.9 h1:Fc8OfrOEHSDsxEe2MOsNz/7Wq4MNBJczl1/B/+/5k2I=
+github.com/oschwald/maxminddb-golang/v2 v2.0.0-beta.9/go.mod h1:EkyB0XWibbE1/+tXyR+ZehlGg66bRtMzxQSPotYH2EA=
 github.com/ovh/go-ovh v1.4.3 h1:Gs3V823zwTFpzgGLZNI6ILS4rmxZgJwJCz54Er9LwD0=
 github.com/ovh/go-ovh v1.4.3/go.mod h1:AkPXVtgwB6xlKblMjRKJJmjRp+ogrE7fz2lVgcQY8SY=
 github.com/paulmach/orb v0.10.0 h1:guVYVqzxHE/CQ1KpfGO077TR0ATHSNjp4s6XGLn3W9s=
@@ -972,8 +972,8 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
-golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
+golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/metrics/director.go
+++ b/metrics/director.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -111,17 +111,30 @@ var (
 		Help: "The total number of redirects the director issued.",
 	}, []string{"destination", "status_code", "version", "network"})
 
-	// TODO: Remove this metric (the line directly below)
-	// The renamed metric was added in v7.16
+	// TODO: Remove these two metrics (the lines directly below)
+	// They're no longer being tracked because they were split into separate client/server metrics
+	// (see PelicanDirectorMaxMind{Server,Client}ErrorsTotal) because the error conditions are
+	// now different and generated under different internal processes.
 	PelicanDirectorGeoIPErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "pelican_director_geoip_errors",
-		Help: "The total number of errors encountered trying to resolve coordinates using the GeoIP MaxMind database",
+		Help: "[Deprecated] The total number of errors encountered trying to resolve coordinates using the GeoIP MaxMind database",
 	}, []string{"network", "source", "proj"})
 
 	PelicanDirectorGeoIPErrorsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "pelican_director_geoip_errors_total",
-		Help: "The total number of errors encountered trying to resolve coordinates using the GeoIP MaxMind database",
+		Help: "[Deprecated -- split into separate client/server metrics (pelican_director_maxmind_{server,client}_errors_total)] The total number of errors encountered trying to resolve coordinates using the GeoIP MaxMind database",
 	}, []string{"network", "source", "proj"})
+
+	// The next two metrics replace the previous two deprecated GeoIP error metrics
+	PelicanDirectorMaxMindServerErrorsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "pelican_director_maxmind_server_errors_total",
+		Help: "The total number of errors encountered trying to resolve server coordinates using the GeoIP MaxMind database",
+	}, []string{"network", "server_name"})
+
+	PelicanDirectorMaxMindClientErrorsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "pelican_director_maxmind_client_errors_total",
+		Help: "The total number of errors encountered trying to resolve client coordinates using the GeoIP MaxMind database",
+	}, []string{"network", "project"})
 
 	PelicanDirectorRejectedAdvertisements = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "pelican_director_rejected_advertisements",

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -378,6 +378,7 @@ var (
 	Director_EnableBroker = BoolParam{"Director.EnableBroker"}
 	Director_EnableOIDC = BoolParam{"Director.EnableOIDC"}
 	Director_EnableStat = BoolParam{"Director.EnableStat"}
+	Director_FilterCachesInErrorState = BoolParam{"Director.FilterCachesInErrorState"}
 	DisableHttpProxy = BoolParam{"DisableHttpProxy"}
 	DisableProxyFallback = BoolParam{"DisableProxyFallback"}
 	Issuer_OIDCPreferClaimsFromIDToken = BoolParam{"Issuer.OIDCPreferClaimsFromIDToken"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -96,6 +96,7 @@ type Config struct {
 		EnableOIDC bool `mapstructure:"enableoidc" yaml:"EnableOIDC"`
 		EnableStat bool `mapstructure:"enablestat" yaml:"EnableStat"`
 		FedTokenLifetime time.Duration `mapstructure:"fedtokenlifetime" yaml:"FedTokenLifetime"`
+		FilterCachesInErrorState bool `mapstructure:"filtercachesinerrorstate" yaml:"FilterCachesInErrorState"`
 		FilteredServers []string `mapstructure:"filteredservers" yaml:"FilteredServers"`
 		GeoIPLocation string `mapstructure:"geoiplocation" yaml:"GeoIPLocation"`
 		MaxMindKeyFile string `mapstructure:"maxmindkeyfile" yaml:"MaxMindKeyFile"`
@@ -463,6 +464,7 @@ type configWithType struct {
 		EnableOIDC struct { Type string; Value bool }
 		EnableStat struct { Type string; Value bool }
 		FedTokenLifetime struct { Type string; Value time.Duration }
+		FilterCachesInErrorState struct { Type string; Value bool }
 		FilteredServers struct { Type string; Value []string }
 		GeoIPLocation struct { Type string; Value string }
 		MaxMindKeyFile struct { Type string; Value string }

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -421,7 +421,7 @@ const (
 )
 
 const (
-	// SortType for sorting the server ads
+	// SortType for server ad sorting algorithms
 	DistanceType        SortType = "distance"
 	DistanceAndLoadType SortType = "distanceAndLoad"
 	RandomType          SortType = "random"
@@ -431,6 +431,10 @@ const (
 	AdAfterTrue    AdAfter = 1 // The ad was generated after the compared one
 	AdAfterUnknown AdAfter = 2 // One of the ads in the comparison is missing necessary attributes to determine when it was generated
 )
+
+func (st SortType) String() string {
+	return string(st)
+}
 
 func IsValidStrategy(strategy string) bool {
 	switch StrategyType(strategy) {

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -256,11 +256,16 @@ type (
 		IpAddr     string `json:"ipAddr"`
 	}
 
+	RedirectWeights struct {
+		DistanceWeight     float64 `json:"distanceWeight"`
+		IOLoadWeight       float64 `json:"ioLoadWeight"`
+		StatusWeight       float64 `json:"statusWeight"`
+		AvailabilityWeight float64 `json:"availabilityWeight"`
+	}
+
 	ServerRedirectInfo struct {
-		HasObject    string  `json:"hasObject"`
-		LoadWeight   float64 `json:"loadWeight"`
-		StatusWeight float64 `json:"statusWeight"` // The current EWMA-derived weight for this server's status, populated by the Director
 		Coordinate      Coordinate
+		RedirectWeights RedirectWeights
 	}
 
 	RedirectInfo struct {


### PR DESCRIPTION
Notes for reviewers:
- I did my best to arrange the git history coherently to explain the various steps I took to undertake this overhaul. That being said, if you step through commit-by-commit there may be a few wonky artifacts that came from difficulties I had in splitting all the hunks the way I wanted (I got to know `git add -e` pretty well!). Each commit message tries to explain the broad intentions of that commit, so if you see unrelated stuff assume it's addressed in another commit.
- I'd advise reviewing the code starting from `sortServerAds` which acts as the entrypoint for all the sorting algorithms. For a given algorithm, step through the code to understand the steps that go into re-arranging the input server ads.
- This diff spans work from roughly two weeks, and I waffled a bit on some pieces of design. When I changed directions (e.g. changing where/how sorting weights are validated, whether or not some functions should be capable of returning errors, etc.)  I did my best to go back and refactor all the relevant code but it's possible I missed things. Watch out for inconsistencies in approach.
- There's still some follow-up work to do here. In particular, I'll need @CannonLock's help updating the Director's "Unlocated Networks" box because it previously pulled from a Prometheus metric I'm redefining. The relevant new prometheus metrics split server and client errors because they're different levels of severity and the old metric didn't tell you which server was generating the error. The new metrics for ingestion are `pelican_director_maxmind_server_errors_total` with labels `network` and `server_name`, and `pelican_director_maxmind_client_errors_total` with labels `network` and `project`.
- This diff also filters caches that report they're in an error state to the Director. Due to some organic growth, this is not the same error state used to color server boxes red/green in the Director, which means it'll be hard to detect error states from the Director until #2625 is merged. We shouldn't cut a release with this diff until that PR is also merged.
- ~~I had issues with the `golangci-lint` tool when I tried to commit things. Following advice on their repo, I updated the version we use in our pre-commit hook and then ran `golangci-lint migrate` to change the golangci-lint configuration from a "v1" configuration to a "v2" configuration. From what I can tell, their auto-migration tool worked?~~ -- It did not work as anticipated.