### PR TITLE
Client/Plugin deadlock fix

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2945,6 +2945,10 @@ Loop:
 		case err = <-done:
 			downloaded = pw.BytesComplete()
 			break Loop
+
+		case <-ctx.Done():
+			err = ctx.Err()
+			break Loop
 		}
 	}
 	if err != nil {

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -420,6 +420,7 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 	}()
 	defer close(results)
 
+	resultsChan := tc.Results()
 	jobMap := make(map[string]PluginTransfer)
 	var recursive bool
 	var tj *client.TransferJob
@@ -466,7 +467,7 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 				failTransfer(transfer.url.String(), transfer.localFile, results, upload, err)
 				return err
 			}
-		case result, ok := <-tc.Results():
+		case result, ok := <-resultsChan:
 			if !ok {
 				log.Debugln("Client has no more results")
 				// Check to be sure we did not have a lookup error


### PR DESCRIPTION
This PR addresses issue #2652. This PR adds a missing case to the switch listener. This hopefully should resolve the deadlock NRAO was experiencing.

We should patch this into the 7.19.x series