### PR TITLE
Fix Cache eviction monitoring interval to be reasonable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1067,7 +1067,7 @@ func SetServerDefaults(v *viper.Viper) error {
 	v.SetDefault(param.Xrootd_ShutdownTimeout.GetName(), 1*time.Minute)
 	v.SetDefault(param.Xrootd_HttpMaxDelay.GetName(), "9s")
 	v.SetDefault(param.Xrootd_MaxThreads.GetName(), 20000)
-	v.SetDefault(param.Cache_EvictionMonitoringInterval.GetName(), 60)
+	v.SetDefault(param.Cache_EvictionMonitoringInterval.GetName(), "60s")
 	v.SetDefault(param.Cache_EvictionMonitoringMaxDepth.GetName(), 1)
 	v.SetDefault(param.Cache_ClientStatisticsLocation.GetName(), filepath.Join(param.Cache_RunLocation.GetString(), "xrootd.stats"))
 	v.SetDefault(param.IssuerKey.GetName(), filepath.Join(configDir, "issuer.jwk"))


### PR DESCRIPTION
This PR changes the default monitoring interval from being interpreted as `60ns` to `60s`. 

Test to reproduce:
1. Enable the `Cache.EnableEvictionMonitoring`, do not set `Cache.EvictionMonitoringInterval`. 
2. Run `pelican config get Cache.EvictionMonitoringInterval`, this should report `1m0s` with this fix enabled. Without the fix it should report `60ns`

@turetske this needs to be patched into the 7.19.x series