### PR TITLE
Update gorelease config to retain symbols in release builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,8 +47,6 @@ builds:
     ldflags:
       - &ldflags-metadata
         -X github.com/pelicanplatform/pelican/version.commit={{.Commit}} -X github.com/pelicanplatform/pelican/version.date={{.Date}} -X github.com/pelicanplatform/pelican/version.builtBy=goreleaser -X github.com/pelicanplatform/pelican/version.version={{.Version}}
-      - &ldflags-strip-symbols
-        -s -w
     ignore:
       - goos: windows
         goarch: arm64
@@ -83,7 +81,6 @@ builds:
       - lotman
     ldflags:
       - *ldflags-metadata
-      - *ldflags-strip-symbols
 
 # Goreleaser complains if there's a different number of binaries built for different architectures
 # in the same archive. Instead of plopping pelican-server in the same archive as pelican, split the


### PR DESCRIPTION
Having symbols would be handy for debugging issues that appear in production deployments.

A build of the main branch with debug symbols gives a pelican-server binary of 76MB, vs 57MB in the v7.19.2 image. Note that this should leave optimization enabled.