### PR TITLE
Fix default Cache.ClientStatisticsLocation in docs

### DIFF
--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1744,7 +1744,7 @@ description: |+
   The XRootD process will periodically write JSON-formatted statistics to the specified file, which can be read by external monitoring (e.g., `jq`).
   Leave unset to disable.
 type: filename
-default: /tmp/xrootd.stats
+default: ${Cache.RunLocation}/xrootd.stats
 components: ["cache"]
 ---
 ############################


### PR DESCRIPTION
Closes #2673. Does what the title says.