### PR TITLE
Bump xrdcl-pelican to 1.5.6

### DIFF
--- a/github_scripts/osx_install.sh
+++ b/github_scripts/osx_install.sh
@@ -67,7 +67,7 @@ ninja
 ninja install
 popd
 
-git clone --branch v1.5.4 https://github.com/PelicanPlatform/xrdcl-pelican.git
+git clone --branch v1.5.6 https://github.com/PelicanPlatform/xrdcl-pelican.git
 pushd xrdcl-pelican
 mkdir build
 cd build

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -57,7 +57,7 @@ ARG LOTMAN_VER=0.0.4
 # Until the two places are programmatically synchronized, please double-check by hand
 # when doing version changes.
 ARG XRDCL_PELICAN_SRC_BUILD=false
-ARG XRDCL_PELICAN_VER=1.5.4
+ARG XRDCL_PELICAN_VER=1.5.6
 ARG XRDHTTP_PELICAN_SRC_BUILD=false
 ARG XRDHTTP_PELICAN_VER=0.0.7
 ARG XROOTD_LOTMAN_SRC_BUILD=false


### PR DESCRIPTION
This PR bumps the xrdcl-pelican to 1.5.6. This version will first be backported into the 7.18.x series and if all goes well will be backported into the 7.19.x and 7.20.x series. 