### PR TITLE
Only log error message when failing to get checksum when checksum is required

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -3378,8 +3378,8 @@ Loop:
 		// Fetch the checksums from the server
 		result, err := fetchChecksum(putContext, transfer.requestedChecksums, dest, tokenContents, transfer.job.project)
 		if err != nil {
-			log.Errorln("Error fetching checksum:", err)
 			if transfer.requireChecksum {
+				log.Errorln("Error fetching checksum:", err)
 				transferResult.Error = errors.New("checksum is required but endpoint was not able to provide it")
 				attempt.Error = err
 			} else {


### PR DESCRIPTION
This PR addresses issue #2692. This issue moves the logging of the error beneath the checksum requirement check. 