### PR TITLE
Split out group membership into new table

### DIFF
--- a/database/universal_migrations/20250729143942_collections.sql
+++ b/database/universal_migrations/20250729143942_collections.sql
@@ -24,11 +24,13 @@ CREATE TABLE collection_members (
 CREATE TABLE users (
     id TEXT PRIMARY KEY,
     username TEXT NOT NULL,
+    sub TEXT NOT NULL,
     issuer TEXT NOT NULL,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE UNIQUE INDEX idx_user_issuer ON users (username, issuer);
+CREATE UNIQUE INDEX idx_user_sub_issuer ON users (sub, issuer);
 
 CREATE TABLE groups (
     id TEXT PRIMARY KEY,
@@ -75,4 +77,5 @@ DROP TABLE collection_members;
 DROP TABLE collections;
 DROP INDEX idx_owner_name;
 DROP INDEX idx_user_issuer;
+DROP INDEX idx_user_sub_issuer;
 -- +goose StatementEnd

--- a/database/universal_migrations/20250729143942_collections.sql
+++ b/database/universal_migrations/20250729143942_collections.sql
@@ -21,6 +21,12 @@ CREATE TABLE collection_members (
     PRIMARY KEY (collection_id, object_url)
 );
 
+CREATE TABLE users (
+    id TEXT PRIMARY KEY,
+    username TEXT NOT NULL UNIQUE,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE groups (
     id TEXT PRIMARY KEY,
     name TEXT NOT NULL UNIQUE,
@@ -31,10 +37,10 @@ CREATE TABLE groups (
 
 CREATE TABLE group_members (
     group_id TEXT NOT NULL,
-    member TEXT NOT NULL,
+    user_id TEXT NOT NULL,
     added_by TEXT NOT NULL,
     added_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (group_id, member)
+    PRIMARY KEY (group_id, user_id)
 );
 
 CREATE TABLE collection_acls (
@@ -61,6 +67,7 @@ DROP TABLE collection_metadata;
 DROP TABLE collection_acls;
 DROP TABLE group_members;
 DROP TABLE groups;
+DROP TABLE users;
 DROP TABLE collection_members;
 DROP TABLE collections;
 DROP INDEX idx_owner_name;

--- a/database/universal_migrations/20250729143942_collections.sql
+++ b/database/universal_migrations/20250729143942_collections.sql
@@ -23,9 +23,12 @@ CREATE TABLE collection_members (
 
 CREATE TABLE users (
     id TEXT PRIMARY KEY,
-    username TEXT NOT NULL UNIQUE,
+    username TEXT NOT NULL,
+    issuer TEXT NOT NULL,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE UNIQUE INDEX idx_user_issuer ON users (username, issuer);
 
 CREATE TABLE groups (
     id TEXT PRIMARY KEY,
@@ -71,4 +74,5 @@ DROP TABLE users;
 DROP TABLE collection_members;
 DROP TABLE collections;
 DROP INDEX idx_owner_name;
+DROP INDEX idx_user_issuer;
 -- +goose StatementEnd

--- a/swagger/pelican-swagger.yaml
+++ b/swagger/pelican-swagger.yaml
@@ -945,6 +945,25 @@ definitions:
         items:
           $ref: "#/definitions/GroupMember"
         description: List of group members
+  User:
+    type: object
+    properties:
+      id:
+        type: string
+        description: Unique identifier for the user
+      username:
+        type: string
+        description: Username of the user
+      sub:
+        type: string
+        description: The 'sub' claim from the user's OIDC token
+      issuer:
+        type: string
+        description: The 'iss' claim from the user's OIDC token
+      created_at:
+        type: string
+        format: date-time
+        description: When the user was created
   GroupMember:
     type: object
     properties:
@@ -952,10 +971,11 @@ definitions:
         type: string
         description: ID of the group
         example: "abc12345"
-      member:
+      user_id:
         type: string
-        description: Member identifier
-        example: "user@example.com"
+        description: ID of the user
+      user:
+        $ref: "#/definitions/User"
       added_by:
         type: string
         description: User who added this member
@@ -1096,12 +1116,22 @@ definitions:
   AddGroupMemberRequest:
     type: object
     required:
-      - member
+      - username
+      - sub
+      - issuer
     properties:
-      member:
+      username:
         type: string
-        description: Member identifier to add
-        example: "user@example.com"
+        description: Username of the member to add
+        example: "new-member"
+      sub:
+        type: string
+        description: The 'sub' claim for the member to add
+        example: "new-member-sub"
+      issuer:
+        type: string
+        description: The 'iss' claim for the member to add
+        example: "https://test-issuer.org"
   ListCollectionResponse:
     type: object
     properties:
@@ -3704,6 +3734,28 @@ paths:
 
   # Group Management APIs
   /groups:
+    get:
+      tags:
+        - groups
+      summary: List all groups
+      description: "`Authentication Required`"
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/Group"
+        "401":
+          description: Authentication required
+          schema:
+            $ref: "#/definitions/ErrorModelV2"
+        "500":
+          description: Internal server error
+          schema:
+            $ref: "#/definitions/ErrorModelV2"
     post:
       tags:
         - groups
@@ -3738,6 +3790,38 @@ paths:
           schema:
             $ref: "#/definitions/ErrorModelV2"
   /groups/{id}/members:
+    get:
+      tags:
+        - groups
+      summary: List members of a group
+      description: "`Authentication Required`"
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: ID of the group
+          required: true
+          type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/GroupMember"
+        "401":
+          description: Authentication required
+          schema:
+            $ref: "#/definitions/ErrorModelV2"
+        "404":
+          description: Group not found
+          schema:
+            $ref: "#/definitions/ErrorModelV2"
+        "500":
+          description: Internal server error
+          schema:
+            $ref: "#/definitions/ErrorModelV2"
     post:
       tags:
         - groups
@@ -3753,15 +3837,19 @@ paths:
           description: ID of the group
           required: true
           type: string
-        - in: body
-          name: member
-          description: The member to add
+        - name: sub
+          in: query
+          description: The 'sub' claim of the member to remove
           required: true
-          schema:
-            $ref: "#/definitions/AddGroupMemberRequest"
+          type: string
+        - name: issuer
+          in: query
+          description: The 'iss' claim of the member to remove
+          required: true
+          type: string
       responses:
         "204":
-          description: Member added successfully
+          description: Member removed successfully
         "400":
           description: Bad request
           schema:
@@ -3775,7 +3863,7 @@ paths:
           schema:
             $ref: "#/definitions/ErrorModelV2"
         "404":
-          description: Group not found
+          description: Group or member not found
           schema:
             $ref: "#/definitions/ErrorModelV2"
         "500":
@@ -3817,6 +3905,29 @@ paths:
             $ref: "#/definitions/ErrorModelV2"
         "404":
           description: Group or member not found
+          schema:
+            $ref: "#/definitions/ErrorModelV2"
+        "500":
+          description: Internal server error
+          schema:
+            $ref: "#/definitions/ErrorModelV2"
+  /users:
+    get:
+      tags:
+        - groups
+      summary: List all users
+      description: "`Authentication Required`"
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/User"
+        "401":
+          description: Authentication required
           schema:
             $ref: "#/definitions/ErrorModelV2"
         "500":

--- a/web_ui/groups.go
+++ b/web_ui/groups.go
@@ -20,7 +20,9 @@ type CreateGroupReq struct {
 }
 
 type AddGroupMemberReq struct {
-	Member string `json:"member"`
+	Username string `json:"username"`
+	Sub      string `json:"sub"`
+	Issuer   string `json:"issuer"`
 }
 
 func handleListGroups(ctx *gin.Context) {
@@ -168,10 +170,10 @@ func handleAddGroupMember(ctx *gin.Context) {
 		return
 	}
 
-	if req.Member == "" {
+	if req.Username == "" || req.Sub == "" || req.Issuer == "" {
 		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
-			Msg:    "Group member is required",
+			Msg:    "Username, sub, and issuer are required",
 		})
 		return
 	}
@@ -185,7 +187,7 @@ func handleAddGroupMember(ctx *gin.Context) {
 		return
 	}
 
-	err = database.AddGroupMember(database.ServerDatabase, ctx.Param("id"), req.Member, user, groups)
+	err = database.AddGroupMember(database.ServerDatabase, ctx.Param("id"), req.Username, req.Sub, req.Issuer, user, groups)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
@@ -224,11 +226,12 @@ func handleRemoveGroupMember(ctx *gin.Context) {
 		return
 	}
 
-	member := ctx.Query("member")
-	if member == "" {
+	sub := ctx.Query("sub")
+	issuer := ctx.Query("issuer")
+	if sub == "" || issuer == "" {
 		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
-			Msg:    "Group member is required",
+			Msg:    "sub and issuer query parameters are required",
 		})
 		return
 	}
@@ -242,7 +245,7 @@ func handleRemoveGroupMember(ctx *gin.Context) {
 		return
 	}
 
-	err = database.RemoveGroupMember(database.ServerDatabase, ctx.Param("id"), member, user, groups)
+	err = database.RemoveGroupMember(database.ServerDatabase, ctx.Param("id"), sub, issuer, user, groups)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{

--- a/web_ui/oauth2_client.go
+++ b/web_ui/oauth2_client.go
@@ -228,6 +228,19 @@ func generateUserGroupInfo(userInfo map[string]interface{}, idToken map[string]i
 	}
 	user = userIdentifier
 
+	subIface, ok := claimsSource["sub"]
+	if !ok {
+		log.Errorln("User info endpoint did not return a value for the sub claim")
+		err = errors.New("identity provider did not return a subject for logged-in user")
+		return
+	}
+	sub, ok := subIface.(string)
+	if !ok {
+		log.Errorln("User info endpoint did not return a string for the sub claim")
+		err = errors.New("identity provider did not return a subject for logged-in user")
+		return
+	}
+
 	issuerClaim := param.Issuer_IssuerClaimValue.GetString()
 	if issuerClaim == "" {
 		issuerClaim = "iss"
@@ -296,7 +309,7 @@ func generateUserGroupInfo(userInfo map[string]interface{}, idToken map[string]i
 	}
 
 	// now that we have verified that the user belongs to a group we should create the user if it doesn't exist
-	_, err = database.GetOrCreateUser(database.ServerDatabase, user, issuerClaimValue)
+	_, err = database.GetOrCreateUser(database.ServerDatabase, user, sub, issuerClaimValue)
 	if err != nil {
 		return "", nil, err
 	}

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -604,9 +604,13 @@ func configureCommonEndpoints(engine *gin.Engine) error {
 		downtimeAPI.DELETE("/:uuid", AuthHandler, AdminAuthHandler, HandleDeleteDowntime)
 	}
 
+	engine.GET("/api/v1.0/groups", AuthHandler, handleListGroups)
 	engine.POST("/api/v1.0/groups", AuthHandler, handleCreateGroup)
+	engine.GET("/api/v1.0/groups/:id/members", AuthHandler, handleListGroupMembers)
 	engine.POST("/api/v1.0/groups/:id/members", AuthHandler, handleAddGroupMember)
 	engine.DELETE("/api/v1.0/groups/:id/members", AuthHandler, handleRemoveGroupMember)
+
+	engine.GET("/api/v1.0/users", AuthHandler, handleListUsers)
 
 	return nil
 }


### PR DESCRIPTION
This PR addresses issue #2690. This PR splits out group membership into a users table and adds QOL improvements to the group management APIs. This PR makes the `sub` and `issuer` the primary identifiers of a user and the `username` is a more user friendly identifier. 