### PR TITLE
Fix bug preventing Origins with `Logging.Level: Warn` from starting

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1093,6 +1093,12 @@ func SetServerDefaults(v *viper.Viper) error {
 	// when Pelican is running in its own default Error level. Otherwise we use Pelican's configured log level as a
 	// default for other params.
 	defaultLevel := log.GetLevel().String()
+	// Logrus parses "warn" and converts it to "warning". Pelican uses "warn" in its config and docs,
+	// so we map it back here. This makes sure that something like `param.Logging_Origin_Cms.GetString()`
+	// returns a pelican-compatible log level.
+	if defaultLevel == log.WarnLevel.String() {
+		defaultLevel = "warn"
+	}
 	for _, param := range []param.StringParam{
 		param.Logging_Origin_Cms,
 		param.Logging_Origin_Xrd,

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -1149,10 +1149,16 @@ func genLoggingConfig(input string, logMap loggingMap) (string, error) {
 		input = param.Logging_Level.GetString()
 	}
 
+	// Note that while Pelican itself doesn't take a "warning" level, when
+	// logrus parses a level of "warn" it converts it to "warning". By
+	// adding "Warning" here, we'll automatically fall down to the "Warn" level
+	// if we happen to grab a log level that passed through logrus without being
+	// mapped back "warn".
 	orderedLevels := []string{
 		"Panic",
 		"Fatal",
 		"Error",
+		"Warning",
 		"Warn",
 		"Info",
 		"Debug",


### PR DESCRIPTION
The crux of the issue was a conversion of Pelican log levels through logrus:
```
Warn --> (parse with Logrus) --> Warning --> apply default level on sub-systems
```

This meant that when you set `Logging.Level: Warn`, we'd parse the level and use the parsed level to set defaults for things like `Logging.Origin.Cms`.

However, when we mapped the derived default for `param.Logging_Origin_Cms` into xrootd config, the mapping failed because we didn't check for `warning`.

This fix is two-fold:
- first, I map "warning" back to "warn" when we're setting defaults for the subsystems.
- second, I modified the xrootd logging code to treat "warning" the same as "Warn"

Either of these fixes would solve the original bug, but I'm hoping that the application of both makes a future regression that much less likely.