### PR TITLE
Add Adaptive Sort knob and touch up other constants

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1288,6 +1288,15 @@ func SetServerDefaults(v *viper.Viper) error {
 		v.Set(p.GetName(), 5*time.Minute)
 	}
 
+	// By default, set adaptive sort truncate to the same number of servers the Director expects to send.
+	// Cannot be set below 3 because Pelican clients expect to try that many servers.
+	v.SetDefault(param.Director_AdaptiveSortTruncateConstant.GetName(), 6)
+	if adaptiveSortTruncateConst := v.GetInt(param.Director_AdaptiveSortTruncateConstant.GetName()); adaptiveSortTruncateConst < 3 {
+		log.Warningf("Invalid value of '%d' for config param %s; must be greater than or equal to 3. Resetting to default of %d",
+			adaptiveSortTruncateConst, param.Director_AdaptiveSortTruncateConstant.GetName(), 6)
+		v.Set(param.Director_AdaptiveSortTruncateConstant.GetName(), 6)
+	}
+
 	// Setup the audience to use.  We may customize the Origin.URL in the future if it has
 	// a `0` for the port number; to make the audience predictable (it goes into the xrootd
 	// configuration but we don't know the origin's port until after xrootd has started), we

--- a/director/sort.go
+++ b/director/sort.go
@@ -59,7 +59,6 @@ type (
 
 // Constants for director sorting algorithms
 const (
-	sourceWorkingSetSize = 15 // Number of servers we consider after first GeoIP sort in adaptive method
 	sourceServerAdsLimit = 6  // Number of servers sent to the client after all sorting operations complete
 )
 

--- a/director/sort_algorithms_test.go
+++ b/director/sort_algorithms_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
 )
 
@@ -531,19 +532,19 @@ func TestIOLoadWeightFn(t *testing.T) {
 		},
 		{
 			name:          "below threshold",
-			load:          9.0,
+			load:          loadHalvingThreshold / 2,
 			weightValid:   true,
 			expectedValue: 1.0,
 		},
 		{
 			name:          "at threshold",
-			load:          10.0,
+			load:          loadHalvingThreshold,
 			weightValid:   true,
 			expectedValue: 1.0,
 		},
 		{
 			name:          "one halving factor above threshold",
-			load:          14.0,
+			load:          loadHalvingThreshold + loadHalvingFactor,
 			weightValid:   true,
 			expectedValue: 0.5,
 		},
@@ -1076,7 +1077,7 @@ func TestAdaptiveSortAlg(t *testing.T) {
 		for range 5000 {
 			sortedAds, err := sortAlg.Sort(snapshotAds, sCtx)
 			assert.NoError(t, err, "unexpected error from AdaptiveSort alg")
-			assert.Equal(t, sourceWorkingSetSize, len(sortedAds), "number of sorted ads does not match expected")
+			assert.Equal(t, param.Director_AdaptiveSortTruncateConstant.GetInt(), len(sortedAds), "number of sorted ads does not match expected")
 			for _, ad := range sortedAds {
 				urlsSet[ad.Name] = struct{}{}
 			}

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1850,6 +1850,21 @@ default: 5m
 hidden: true
 components: ["director"]
 ---
+name: Director.AdaptiveSortTruncateConstant
+description: |+
+  The first step in the Director's adaptive sorting algorithm is to sort all servers for the given request
+  by their distance from the client and then truncate to the nearest N server before generating the other
+  adaptive sort weights (load, status, locality).
+
+  This constant sets the value of N. Higher values increase the pool of servers considered for adaptive sorting,
+  while lower values restrict the pool to only the closest servers.
+
+  The constant cannot be set to a value lower than 3, as Pelican clients expect to receive 3 servers at minimum,
+  and the Director will reply with at most 6 servers regardless of this value.
+type: int
+default: 6
+components: ["director"]
+---
 name: Director.OriginResponseHostnames
 description: |+
   A list of virtual hostnames for the director. If a request is sent by the client to one of these hostnames,

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -329,6 +329,7 @@ var (
 	Client_MaximumDownloadSpeed = IntParam{"Client.MaximumDownloadSpeed"}
 	Client_MinimumDownloadSpeed = IntParam{"Client.MinimumDownloadSpeed"}
 	Client_WorkerCount = IntParam{"Client.WorkerCount"}
+	Director_AdaptiveSortTruncateConstant = IntParam{"Director.AdaptiveSortTruncateConstant"}
 	Director_CachePresenceCapacity = IntParam{"Director.CachePresenceCapacity"}
 	Director_MaxStatResponse = IntParam{"Director.MaxStatResponse"}
 	Director_MinStatResponse = IntParam{"Director.MinStatResponse"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -80,6 +80,7 @@ type Config struct {
 	Debug bool `mapstructure:"debug" yaml:"Debug"`
 	Director struct {
 		AdaptiveSortEWMATimeConstant time.Duration `mapstructure:"adaptivesortewmatimeconstant" yaml:"AdaptiveSortEWMATimeConstant"`
+		AdaptiveSortTruncateConstant int `mapstructure:"adaptivesorttruncateconstant" yaml:"AdaptiveSortTruncateConstant"`
 		AdvertiseUrl string `mapstructure:"advertiseurl" yaml:"AdvertiseUrl"`
 		AdvertisementTTL time.Duration `mapstructure:"advertisementttl" yaml:"AdvertisementTTL"`
 		AssumePresenceAtSingleOrigin bool `mapstructure:"assumepresenceatsingleorigin" yaml:"AssumePresenceAtSingleOrigin"`
@@ -448,6 +449,7 @@ type configWithType struct {
 	Debug struct { Type string; Value bool }
 	Director struct {
 		AdaptiveSortEWMATimeConstant struct { Type string; Value time.Duration }
+		AdaptiveSortTruncateConstant struct { Type string; Value int }
 		AdvertiseUrl struct { Type string; Value string }
 		AdvertisementTTL struct { Type string; Value time.Duration }
 		AssumePresenceAtSingleOrigin struct { Type string; Value bool }


### PR DESCRIPTION
After running our Adaptive Sort experiment for ~1 day, we've been able to look at concrete statistics to see where there's room for improvement without another overhaul.

The two things that stood out were large over-prioritization of load weights (the halving threshold/factor applied to the distribution of actual raw IO load numbers from OSDF resulted in derived io weights in 1e-10 to 1e-60) and that we should be more restrictive about geolocation (we're still sending clients to caches that are a little too geographically distributed).

This commit adds a tunable knob for setting the algorithm's initial geo-truncate value, and changes the load constants used when deriving load weights. It's a conscious choice at this time not to make magic numbers other than the truncate value tunable.