### PR TITLE
Bump xrootd-s3-http version

### DIFF
--- a/github_scripts/osx_install.sh
+++ b/github_scripts/osx_install.sh
@@ -77,7 +77,7 @@ sudo mkdir -p /etc/xrootd/client.plugins.d/
 sudo cp release_dir/etc/xrootd/client.plugins.d/{curl,pelican}-plugin.conf /etc/xrootd/client.plugins.d/
 popd
 
-git clone --recurse-submodules --branch v0.5.1 https://github.com/PelicanPlatform/xrootd-s3-http.git
+git clone --recurse-submodules --branch v0.5.2 https://github.com/PelicanPlatform/xrootd-s3-http.git
 pushd xrootd-s3-http
 mkdir build
 cd build

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -62,8 +62,8 @@ ARG XRDHTTP_PELICAN_SRC_BUILD=false
 ARG XRDHTTP_PELICAN_VER=0.0.7
 ARG XROOTD_LOTMAN_SRC_BUILD=false
 ARG XROOTD_LOTMAN_VER=0.0.5
-ARG XROOTD_S3_HTTP_SRC_BUILD=false
-ARG XROOTD_S3_HTTP_VER=0.5.1
+ARG XROOTD_S3_HTTP_SRC_BUILD=true
+ARG XROOTD_S3_HTTP_VER=0.5.2
 
 # Set scitokens-oauth2-server image as a build stage so that we can copy its
 # OA4MP installation into the images being built here.


### PR DESCRIPTION
Simple version bump -- I successfully built the container locally from the repo root with:
```
docker build -t jhiemstra/pelican-test:latest -f images/Dockerfile --target origin .
```

When this is merged, I'll open a follow-up issue to switch this from a source build once it's been released through epel (which is not something we do in-house).