### PR TITLE
Make OIDC scopes configurable

### DIFF
--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -142,6 +142,7 @@ OIDC:
   DeviceAuthEndpoint: "https://cilogon.org/oauth2/device_authorization"
   TokenEndpoint: "https://cilogon.org/oauth2/token"
   UserInfoEndpoint: "https://cilogon.org/oauth2/userinfo"
+  Scopes: ["openid", "email", "profile"]
 Issuer:
   TomcatLocation: /opt/tomcat
   ScitokensServerLocation: /opt/scitokens-server

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2807,6 +2807,13 @@ type: url
 default: https://cilogon.org
 components: ["registry", "origin", "cache", "director"]
 ---
+name: OIDC.Scopes
+description: |+
+  A list of scopes to request from the authentication provider.
+type: stringSlice
+default: ["openid", "email", "profile"]
+components: ["registry", "origin", "cache", "director"]
+---
 name: OIDC.ClientRedirectHostname
 description: |+
   The hostname for the OIDC client redirect URL that the OIDC provider will redirect to after the user is authenticated.

--- a/oauth2/oidc_client.go
+++ b/oauth2/oidc_client.go
@@ -129,9 +129,9 @@ func ServerOIDCClient() (result Config, provider config.OIDCProvider, err error)
 	}
 	result.Endpoint.UserInfoURL = userInfoEndpointURL.String()
 
-	// Set the scope
-	result.Scopes = []string{"openid", "profile", "email"}
-	// Add extra scope only for CILogon user info endpoint
+	// Set the scopes.
+	result.Scopes = param.OIDC_Scopes.GetStringSlice()
+	// For backwards compatibility, implicitly add CILogon-specific scopes.
 	if provider == config.CILogon {
 		result.Scopes = append(result.Scopes, "org.cilogon.userinfo")
 	}

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -311,6 +311,7 @@ var (
 	Issuer_GroupRequirements = StringSliceParam{"Issuer.GroupRequirements"}
 	Issuer_RedirectUris = StringSliceParam{"Issuer.RedirectUris"}
 	Monitoring_AggregatePrefixes = StringSliceParam{"Monitoring.AggregatePrefixes"}
+	OIDC_Scopes = StringSliceParam{"OIDC.Scopes"}
 	Origin_ExportVolumes = StringSliceParam{"Origin.ExportVolumes"}
 	Origin_ScitokensRestrictedPaths = StringSliceParam{"Origin.ScitokensRestrictedPaths"}
 	Registry_AdminUsers = StringSliceParam{"Registry.AdminUsers"}

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -214,6 +214,7 @@ type Config struct {
 		ClientSecretFile string `mapstructure:"clientsecretfile" yaml:"ClientSecretFile"`
 		DeviceAuthEndpoint string `mapstructure:"deviceauthendpoint" yaml:"DeviceAuthEndpoint"`
 		Issuer string `mapstructure:"issuer" yaml:"Issuer"`
+		Scopes []string `mapstructure:"scopes" yaml:"Scopes"`
 		TokenEndpoint string `mapstructure:"tokenendpoint" yaml:"TokenEndpoint"`
 		UserInfoEndpoint string `mapstructure:"userinfoendpoint" yaml:"UserInfoEndpoint"`
 	} `mapstructure:"oidc" yaml:"OIDC"`
@@ -583,6 +584,7 @@ type configWithType struct {
 		ClientSecretFile struct { Type string; Value string }
 		DeviceAuthEndpoint struct { Type string; Value string }
 		Issuer struct { Type string; Value string }
+		Scopes struct { Type string; Value []string }
 		TokenEndpoint struct { Type string; Value string }
 		UserInfoEndpoint struct { Type string; Value string }
 	}

--- a/web_ui/oauth2_client.go
+++ b/web_ui/oauth2_client.go
@@ -349,9 +349,6 @@ func handleOAuthCallback(ctx *gin.Context) {
 
 	var idToken = make(map[string]interface{})
 	if idTokenRaw := token.Extra("id_token"); idTokenRaw != nil {
-		// The token's signature will show as "REDACTED" in the output.
-		log.Debugf("Found an OIDC ID token: %v", idTokenRaw)
-
 		// We were given this ID token by the authentication provider, not
 		// some third party. If we don't trust the provider, we have greater
 		// issues.


### PR DESCRIPTION
For testing, I believe it suffices to look at the value of the `scope` parameter when you're redirected to the authorization URL.