### PR TITLE
Fix flaky authfile test

### DIFF
--- a/xrootd/authorization.go
+++ b/xrootd/authorization.go
@@ -644,20 +644,21 @@ func populateAuthLinesMapForCache(authLinesMap map[string]*authLine, server serv
 // Given an authLine, serialize it into a string suitable for writing to an authfile.
 // Sort the authComponents by descending prefix length so that XRootD applies the most
 // specific policy first.
+// Prefixes with the same length are sorted lexicographically.
 func serializeAuthLine(al authLine) string {
 	// Collect and sort prefixes by descending length
 	prefixes := make([]string, 0, len(al.authComponents))
 	for prefix := range al.authComponents {
 		prefixes = append(prefixes, prefix)
 	}
-	slices.SortFunc(prefixes, func(a, b string) int {
+	slices.SortStableFunc(prefixes, func(a, b string) int {
 		if len(a) > len(b) {
 			return -1 // a before b
 		}
 		if len(a) < len(b) {
 			return 1 // b before a
 		}
-		return 0 // equal length
+		return strings.Compare(a, b) // equal length
 	})
 
 	// Build the line

--- a/xrootd/authorization_test.go
+++ b/xrootd/authorization_test.go
@@ -651,14 +651,16 @@ func TestSerializeAuthline(t *testing.T) {
 		},
 		{
 			"multiple paths with same lengths",
-			// Should preserve ordering if two paths have same length
+			// Until we switch to an ordered map, we'll always sort
+			// lexicographically when lengths are the same -- regular
+			// go maps have no order to preserve.
 			authLine{idType: "u", id: "*", authComponents: map[string]*authPathComponent{
 				"/path432": {prefix: "/path432", reads: true, listings: true, subtractive: false},
 				"/path123": {prefix: "/path123", reads: true, listings: false, subtractive: true},
 			},
 			},
 
-			"u * /path432 lr /path123 -r",
+			"u * /path123 -r /path432 lr",
 		},
 	}
 


### PR DESCRIPTION
There were previously a few issues with the test that I think stemmed from my waffling on how to handle serializing authfile lines when two prefixes were the same length.

Ultimately the ordering of prefixes with the same length isn't critical to security, but stable sorting these is really beneficial for making test assertions. While it would be nice to preserve as much of the authline ordering as possible when we're merging an admin-supplied authfile with the service's derived authfile, the data structure that holds these values (a map) makes that hard to do.

Instead, this implements a stable, lexicographical sort on these values. We may eventually return to this to switch from using go's default map to an ordered map, but I don't see this as critical for the time being.