### PR TITLE
Clean up and document OA4MP QDL scripts

### DIFF
--- a/oa4mp/resources/id_token_policies.qdl
+++ b/oa4mp/resources/id_token_policies.qdl
@@ -55,6 +55,10 @@ if [0 == size(proxy_claims.)] then
     ];
 ];
 
+/*
+ * Check that the claims in Pelican's Issuer.OIDCAuthenticationRequirements
+ * parameter are present.
+ */
 {{ range $req := .OIDCAuthnReqs }}
 if [!is_defined(proxy_claims.'{{- $req.Claim -}}')] then
 [
@@ -64,6 +68,10 @@ if [!is_defined(proxy_claims.'{{- $req.Claim -}}')] then
 ];
 {{ end }}
 
+/*
+ * Check that the claims in Pelican's Issuer.OIDCAuthenticationRequirements
+ * parameter have the required value.
+ */
 {{ range $req := .OIDCAuthnReqs }}
 if [proxy_claims.'{{- $req.Claim -}}' != '{{- $req.Value -}}'] then
 [
@@ -73,6 +81,9 @@ if [proxy_claims.'{{- $req.Claim -}}' != '{{- $req.Value -}}'] then
 ];
 {{ end }}
 
+/*
+ * Check that the claim Pelican is using as the "username" is present.
+ */
 if [!is_defined(proxy_claims.'{{- .OIDCAuthnUserClaim -}}')] then
 [
     sys_err.ok := false;
@@ -80,5 +91,8 @@ if [!is_defined(proxy_claims.'{{- .OIDCAuthnUserClaim -}}')] then
     return();
 ];
 
+/*
+ * Set the essential/required/core claims.
+ */
 claims.sub := proxy_claims.'{{- .OIDCAuthnUserClaim -}}';
 claims.iss := '{{- .OIDCIssuerURL -}}';

--- a/oa4mp/resources/policies.qdl
+++ b/oa4mp/resources/policies.qdl
@@ -18,13 +18,17 @@
 
 say('Scopes in the initial request: ' + to_string(scopes.));
 
+/*
+ * Set the essential/required/core claims.
+ */
 access_token.sub := claims.sub;
 access_token.iss := '{{- .OIDCIssuerURL -}}';
 
-group_list. := claims.groups;
-
+/*
+ * Check that the authenticated user is a member of the required groups.
+ */
 {{ if .GroupRequirements -}}
-if [0 == size(|^group_list. /\ { {{- range $idx, $grp := .GroupRequirements -}}{{- if eq $idx 0 -}}'{{- $grp -}}'{{else}}, '{{- $grp -}}'{{- end -}}{{- end -}} })] then
+if [0 == size(|^claims.groups. /\ { {{- range $idx, $grp := .GroupRequirements -}}{{- if eq $idx 0 -}}'{{- $grp -}}'{{else}}, '{{- $grp -}}'{{- end -}}{{- end -}} })] then
 [
     sys_err.ok := false;
     sys_err.message := 'Authenticated user is not in any of the following groups: {{ range $idx, $grp := .GroupRequirements -}}{{- if eq $idx 0 -}}"{{- $grp -}}"{{else}}, "{{- $grp -}}"{{- end -}}{{- end -}}';
@@ -58,5 +62,5 @@ user_scopes_loose. := mask(~default_scopes, -1 < starts_with(~default_scopes, sc
 access_token.'scope' := detokenize(unique(sort(user_scopes. ~ user_scopes_loose.)), ' ', 2);
 access_token.'wlcg.ver' := '1.0';
 access_token.'aud' := 'https://wlcg.cern.ch/jwt/v1/any';
-access_token.'wlcg.groups' := group_list.;
+access_token.'wlcg.groups' := claims.groups.;
 remove(access_token.ver);


### PR DESCRIPTION
The functional changes here are:

1. Additional debugging output (`say`) in both `id_token_policies.qdl` and `policies.qdl`. This should make it easier to know what the scripts are working with, especially when it's Pelican provided inputs to OA4MP.

2. The removal of `remove(claims.groups);` in `policies.qdl`. There is no reason to have this, and it occasionally causes problems if we manage to run these QDL scripts in some unanticipated manner.

3. The removal of scripting that duplicates what Pelican itself does now as of #2462.

Everything else should be whitespace tweaks, which I thought GitHub would do a better job of glossing over in the diffs.