### PR TITLE
Auto cleanup stale entries in `servers` and `services` tables

### DIFF
--- a/database/server.go
+++ b/database/server.go
@@ -107,9 +107,9 @@ func cleanupStaleServerEntries() error {
 		var staleServerIDs []string
 		rawQuery := `
 			SELECT DISTINCT servers.id
-			FROM services
+			FROM servers
+			LEFT JOIN services ON servers.id = services.server_id
 			LEFT JOIN registrations ON services.registration_id = registrations.id
-			LEFT JOIN servers ON servers.id = services.server_id
 			WHERE registrations.pubkey IS NULL`
 
 		if err := tx.Raw(rawQuery).Scan(&staleServerIDs).Error; err != nil {


### PR DESCRIPTION
This PR:

1. Remove database mover code
  Because Registry DB migration (to pelican.sqlite) was completed in v7.19
2.  Automatically cleanup the stale entries in the `servers` and `services` tables

- They are caused by the damaged foreign key constraint in `services` table and we didn't update webUI to use server deletion API in time.
- See https://opensciencegrid.atlassian.net/browse/OPS-438

### Relevant PRs
3 PRs will work together to fix this the root cause behind the `/ndp/public` [problem](https://opensciencegrid.atlassian.net/browse/OPS-438) (all under review, will get into Pelican v7.21): 
#2745 
#2739
#2748 