### PR TITLE
Add versions to docs

### DIFF
--- a/docs/app/_meta.js
+++ b/docs/app/_meta.js
@@ -1,4 +1,10 @@
 
+if(!process.env.VERSIONS && process.env.NODE_ENV !== 'development') {
+	throw new Exception("Missing required env variable VERSIONS");
+} else {
+	process.env.VERSIONS = process.env.VERSIONS || "['latest']"
+}
+
 const versions = eval(process.env.VERSIONS);
 
 export default {


### PR DESCRIPTION
Work is done in the docs repo and build process.

This assumes there is a Versions array as a env variable in the build env which I inject in the CI.

https://github.com/PelicanPlatform/docs/actions/runs/18564247219/job/52921277005
export VERSIONS='["v7.18", "v7.19", "v7.20", "latest"]'

The docs are already in place, just need the navigation element:

docs.pelicanplatform.org/v7.20/

<img width="1920" height="1080" alt="Screenshot 2025-10-15 at 3 36 35 PM (2)" src="https://github.com/user-attachments/assets/60ba9b26-4f85-478d-a2a6-cb71a6965f07" />

Closes #1909 
