### PR TITLE
Fallback to in-process memory if the kernel session keyring is unavailable

### DIFF
--- a/config/keyring_default.go
+++ b/config/keyring_default.go
@@ -2,7 +2,7 @@
 
 /***************************************************************
  *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -20,18 +20,24 @@
 
 package config
 
-var saved_password bool = false
-var saved_password_val []byte = make([]byte, 0)
+var savedPassword bool = false
+var savedPasswordVal []byte = make([]byte, 0)
 
+// Returns the password stored in the session keyring, or an empty byte
+// array if it cannot be found. The keyring is provided by in-process memory
+// because we assume that the kernel key retention service is unavailable.
 func TryGetPassword() ([]byte, error) {
-	if saved_password {
-		return saved_password_val, nil
+	if savedPassword {
+		return savedPasswordVal, nil
 	}
 	return make([]byte, 0), nil
 }
 
-func SavePassword(new_pass []byte) error {
-	saved_password_val = new_pass
-	saved_password = true
+// Saves a password to the session keyring. The keyring is provided by
+// in-process memory because we assume that the kernel key retention service
+// is unavailable.
+func SavePassword(password []byte) error {
+	savedPasswordVal = password
+	savedPassword = true
 	return nil
 }


### PR DESCRIPTION
### Previously

On Linux/amd64, we used only the kernel session keyring to save the password for Pelican's local credentials file.

### Now

On Linux/amd64, we will fallback to using in-process memory when the kernel session keyring is unavailable, to match the behavior on non-Linux platforms.

The upshot for users is that they shouldn't ever have to type in the password for Pelican's local credentials file more than once per invocation of the CLI.