### PR TITLE
Add a few eye relief whitespaces for config print commands

### DIFF
--- a/cmd/config_printer/config_get.go
+++ b/cmd/config_printer/config_get.go
@@ -147,6 +147,9 @@ func configGet(cmd *cobra.Command, args []string) {
 	for _, match := range matches {
 		fmt.Printf("%s: %s\n", match.HighlightedKey, match.HighlightedValue)
 	}
+
+	// Add an eye break before any other logs are printed.
+	fmt.Println()
 }
 
 // flattenConfig recursively flattens the config structure into a map[string]string.

--- a/cmd/config_printer/utils.go
+++ b/cmd/config_printer/utils.go
@@ -91,6 +91,9 @@ func printConfig(configData interface{}, format string) {
 	default:
 		log.Errorf("Unsupported format: %s. Use 'yaml' or 'json'.", format)
 	}
+
+	// Add an eye break before any other logs are printed.
+	fmt.Println()
 }
 
 // formatValue formats values appropriately for printing.


### PR DESCRIPTION
This adds a whitespace between the output of `config get` and `config dump` and any warning/error logs that get flushed, e.g.:
```
$pelican config get issuerkeysdi
issuerkeysdirectory: "/workspaces/pelican/issuer-keys"

WARNING[2025-10-30T16:08:27Z] The configuration key "DisableHttpProxy" is deprecated. Please use "Client.DisableHttpProxy" instead. Will use the value of deprecated config key "DisableHttpProxy" for the new config key "Client.DisableHttpProxy". 
```