### PR TITLE
Free space in the GitHub Action runner before building images

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -120,6 +120,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: Free disk space
+        shell: bash
+        run: |
+          # Use `df` to quickly check how much space is available.
+
+          echo "::group::Before"
+          df -h
+          echo "::endgroup::"
+
+          sudo rm -rf /usr/local/lib/android
+
+          echo "::group::After"
+          df -h
+          echo "::endgroup::"
+
       - name: Checkout code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
I've restored the workflow step that deletes the Android SDK, which frees up ~10G of disk space. It's easy to confirm this by looking at the output of that step, because I've included before and after snapshots from `df`.

I originally deleted this step in 3676a0ecf59a5f5f0259285a76f25db50ce24b0e in order to shave some time off of the build process, but it looks like we'll simply have to pay that cost now.