### PR TITLE
Update href for version links in _meta.js

### DIFF
--- a/docs/app/_meta.js
+++ b/docs/app/_meta.js
@@ -25,7 +25,7 @@ export default {
 		"items": versions.reverse().reduce((acc, v) => {
 			acc[`${v}`] = {
 				title: v === 'latest' ? 'Latest' : v,
-				href: v === 'latest' ? '/' : `/${v}/`
+				href: v === 'latest' ? '/' : `https://docs.pelicanplatform.org/${v}/`
 			}
 			return acc
 		}, {})


### PR DESCRIPTION
@h2zh Unfortunately this will have to be patched into 7.21