### PR TITLE
Pelican MCP for object access

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -1,0 +1,88 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package main
+
+import (
+	"context"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/pelicanplatform/pelican/mcp"
+)
+
+var (
+	mcpCmd = &cobra.Command{
+		Use:   "mcp",
+		Short: "Model Context Protocol (MCP) server for Pelican client",
+		Long: `Start a Model Context Protocol (MCP) server that exposes Pelican client
+functionality to AI assistants and other MCP clients.
+
+The MCP server allows AI assistants to download files, get file information,
+and list directories using the Pelican client. It communicates via JSON-RPC
+over stdin/stdout.
+
+Example usage with an MCP client:
+  pelican mcp serve
+
+Tools provided:
+  - pelican_download: Download files from Pelican URLs
+  - pelican_stat: Get metadata about Pelican objects
+  - pelican_list: List contents of Pelican directories`,
+	}
+
+	mcpServeCmd = &cobra.Command{
+		Use:   "serve",
+		Short: "Start the MCP server",
+		Long: `Start the Model Context Protocol server that exposes Pelican client
+functionality to AI assistants.
+
+The server reads JSON-RPC requests from stdin and writes responses to stdout.
+It should be launched by an MCP client (such as an AI assistant with MCP support).`,
+		RunE: runMCPServe,
+	}
+)
+
+func init() {
+	mcpCmd.AddCommand(mcpServeCmd)
+	rootCmd.AddCommand(mcpCmd)
+}
+
+func runMCPServe(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	// Set up logging to stderr so it doesn't interfere with JSON-RPC on stdout
+	log.SetOutput(os.Stderr)
+	log.SetLevel(log.InfoLevel)
+
+	// Check for debug flag
+	if debugFlag, _ := cmd.Flags().GetBool("debug"); debugFlag {
+		log.SetLevel(log.DebugLevel)
+	}
+
+	// Create and run the MCP server
+	server := mcp.NewServer(ctx, os.Stdin, os.Stdout)
+	if err := server.Run(); err != nil {
+		log.Errorf("MCP server error: %v", err)
+		return err
+	}
+
+	return nil
+}

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -36,7 +36,7 @@ var (
 functionality to AI assistants and other MCP clients.
 
 The MCP server allows AI assistants to download files, get file information,
-and list directories using the Pelican client. It communicates via JSON-RPC
+and list collections using the Pelican client. It communicates via JSON-RPC
 over stdin/stdout.
 
 Example usage with an MCP client:
@@ -45,7 +45,7 @@ Example usage with an MCP client:
 Tools provided:
   - pelican_download: Download files from Pelican URLs
   - pelican_stat: Get metadata about Pelican objects
-  - pelican_list: List contents of Pelican directories`,
+  - pelican_list: List contents of Pelican collections`,
 	}
 
 	mcpServeCmd = &cobra.Command{

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -70,12 +70,6 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 
 	// Set up logging to stderr so it doesn't interfere with JSON-RPC on stdout
 	log.SetOutput(os.Stderr)
-	log.SetLevel(log.InfoLevel)
-
-	// Check for debug flag
-	if debugFlag, _ := cmd.Flags().GetBool("debug"); debugFlag {
-		log.SetLevel(log.DebugLevel)
-	}
 
 	// Create and run the MCP server
 	server := mcp.NewServer(ctx, os.Stdin, os.Stdout)

--- a/docs/app/getting-data-with-pelican/_meta.js
+++ b/docs/app/getting-data-with-pelican/_meta.js
@@ -1,4 +1,5 @@
 export default {
   "client": "Command Line Client",
-  "fsspec": "Python FSSpec"
+  "fsspec": "Python FSSpec",
+  "mcp": "AI Assistants (MCP)"
 }

--- a/docs/app/getting-data-with-pelican/mcp/page.mdx
+++ b/docs/app/getting-data-with-pelican/mcp/page.mdx
@@ -6,11 +6,12 @@ This allows you to use natural language to interact with Pelican data directly f
 ## What is MCP?
 
 The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standard that allows AI assistants to connect to external tools and data sources.
-By running a Pelican MCP server, your AI assistant can work with **public** namespaces, but not protected namespaces:
+By running a Pelican MCP server, your AI assistant can work with both public and protected namespaces:
 
 - Download objects from Pelican federations using natural language requests
 - Get metadata about objects (size, modification time, checksums)
 - List collection contents
+- Authenticate to protected namespaces using OAuth device flow
 
 ## Before Starting
 
@@ -104,7 +105,7 @@ Copilot will use the Pelican MCP server to download the file.
 
 ## Available Tools
 
-Once configured, your AI assistant has access to three Pelican tools:
+Once configured, your AI assistant has access to five Pelican tools:
 
 ### pelican_download
 
@@ -144,7 +145,66 @@ Lists the contents of a Pelican collection.
 **Parameters**:
 - `url`: The Pelican URL of the collection to list
 
+### pelican_auth
+
+Starts authentication to a protected Pelican namespace using OAuth device flow.
+This tool returns a verification URL immediately that you can click to authorize access.
+After authorization, call `pelican_auth_complete` to finish the authentication process.
+
+**Example prompts**:
+- "Authenticate to pelican://osg-htc.org/protected/data/"
+- "I need to access a protected namespace at pelican://federation.example.com/private/, please authenticate"
+- "Get access token for pelican://osg-htc.org/restricted/path"
+
+**Parameters**:
+- `url`: The Pelican URL of the protected resource to authenticate for
+
+### pelican_auth_complete
+
+Completes the OAuth device flow authentication after the user has visited the verification URL.
+Call this after the user confirms they have completed authorization in their browser.
+
+**Parameters**:
+- `url`: The same Pelican URL that was used with `pelican_auth`
+
+**How authentication works (two-step process)**:
+1. Call `pelican_auth` - returns a verification URL immediately
+2. User clicks the URL and completes authorization in their browser
+3. User tells the AI they have completed authorization
+4. AI calls `pelican_auth_complete` to verify and cache the token
+5. The token is now cached for future operations
+
 ## Example Workflows
+
+### Accessing Protected Namespaces
+
+```
+User: I need to download data from pelican://osg-htc.org/protected/data/file.txt
+but it requires authentication.
+
+AI: I'll help you authenticate.
+[Uses pelican_auth tool]
+
+🔐 Authentication Required
+
+To access the protected namespace, please:
+1. Click or visit this URL to authenticate:
+   https://cilogon.org/device?user_code=ABCD-EFGH
+2. Complete the authorization in your browser
+
+You have 3 minutes to complete authentication.
+Let me know when you're done!
+
+User: Done, I authorized it.
+
+AI: Great! Let me verify the authorization.
+[Uses pelican_auth_complete tool]
+
+✅ Authorization successful! Token has been cached.
+Now let me download the file.
+[Uses pelican_download tool]
+Successfully downloaded to ./file.txt
+```
 
 ### Downloading Test Data
 
@@ -228,7 +288,11 @@ chmod +x $(which pelican)
 
 If downloads fail with authentication errors:
 
-1. Ensure it is a public namespace, and verify the URL is correct using the CLI:
+1. For protected namespaces, use the `pelican_auth` tool first to authenticate:
+   - Ask your AI assistant to "authenticate to pelican://..."
+   - Click the verification URL provided
+   - Complete authorization in your browser
+2. Verify the URL is correct using the CLI:
 ```bash
 pelican object get pelican://... /tmp/test
 ```

--- a/docs/app/getting-data-with-pelican/mcp/page.mdx
+++ b/docs/app/getting-data-with-pelican/mcp/page.mdx
@@ -1,0 +1,333 @@
+# Using Pelican with AI Assistants via MCP
+
+The Pelican Model Context Protocol (MCP) server enables AI assistants like Claude Code, VS Code Copilot, and other MCP-compatible tools to download files, inspect metadata, and list directories from Pelican federations. This allows you to use natural language to interact with Pelican data directly from your AI-powered development environment.
+
+## What is MCP?
+
+The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standard that allows AI assistants to connect to external tools and data sources. By running a Pelican MCP server, your AI assistant can work with **public** namespaces (not support protected namespaces):
+
+- Download objects from Pelican federations using natural language requests
+- Get metadata about objects (size, modification time, checksums)
+- List directory contents
+
+## Before Starting
+
+### Assumptions
+
+This guide assumes:
+
+- You have Pelican installed on your system with the `pelican` command accessible in your PATH
+- You're familiar with [Pelican's command line client](../client/page.mdx) and basic concepts
+- You have an MCP-compatible AI assistant installed (Claude Code or VS Code with GitHub Copilot)
+
+### Verify Pelican Installation
+
+Ensure the Pelican MCP server is available:
+
+```bash copy
+pelican mcp --help
+```
+
+You should see output describing the `pelican mcp serve` command. If not, refer to the [Pelican installation docs](../../install.mdx) to install or update Pelican.
+
+## Setting Up with Claude Code
+
+Claude Code CLI natively supports MCP servers, making it easy to integrate Pelican.
+
+### 1. Add Pelican MCP Server
+
+Ensure you have Claude Code installed. Run the following command to add Pelican binary to Claude Code as a local stdio server:
+
+```bash copy
+claude mcp add pelican --transport stdio pelican mcp serve
+```
+
+After you see a confirmation, Claude Code will automatically load the Pelican MCP server when you start a new session. No restart is required - the MCP server is loaded on-demand.
+
+### 2. Use Claude Code with Pelican
+
+Start a Claude Code session in your terminal. You can now ask Claude to download Pelican objects using natural language:
+
+```
+Download the file pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt to my Downloads folder
+```
+
+Claude will fetch the file and confirm when it's complete.
+
+## Setting Up with VS Code
+
+VS Code with GitHub Copilot can also use MCP servers to enhance its capabilities.
+
+### 1. Install Required Extensions
+
+Ensure you have:
+- [GitHub Copilot extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot)
+- MCP support (available in recent Copilot versions)
+
+### 2. Configure MCP Settings
+
+Open your VS Code settings.json (`Cmd/Ctrl + Shift + P` → "Preferences: Open User Settings (JSON)") and add:
+
+```json copy
+{
+  "github.copilot.mcp.servers": {
+    "pelican": {
+      "command": "pelican",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+### 3. Reload VS Code
+
+After saving the configuration, reload VS Code:
+- Press `Cmd/Ctrl + Shift + P`
+- Type "Developer: Reload Window"
+- Press Enter
+
+### 4. Use Copilot Chat with Pelican
+
+In the Copilot Chat panel, you can now request Pelican operations:
+
+```
+@workspace Download pelican://osg-htc.org/pelicanplatform/test/hello-world.txt to the current workspace
+```
+
+Copilot will use the Pelican MCP server to download the file.
+
+## Available Tools
+
+Once configured, your AI assistant has access to three Pelican tools:
+
+### pelican_download
+
+Downloads objects from Pelican URLs to your local filesystem.
+
+**Example prompts**:
+- "Download pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt to /tmp/test.txt"
+- "Get the hello-world.txt file from pelican://osg-htc.org/pelicanplatform/test/ and save it locally"
+- "Download the entire validation directory recursively from pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/"
+
+**Parameters**:
+- `source`: The Pelican URL to download from
+- `destination`: Local path where the object should be saved
+- `recursive`: (optional) Set to true to download directories recursively
+### pelican_stat
+
+Gets metadata about a Pelican object including size, modification time, and checksums.
+
+**Example prompts**:
+- "What's the size of pelican://osg-htc.org/pelicanplatform/test/hello-world.txt?"
+- "Get information about the validation test file"
+- "Show me the metadata for pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt"
+
+**Parameters**:
+- `url`: The Pelican URL to inspect
+
+### pelican_list
+
+Lists the contents of a Pelican directory.
+
+**Example prompts**:
+- "List the contents of pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/"
+- "What files are in the pelicanplatform test directory?"
+- "Show me all objects under pelican://osg-htc.org/pelicanplatform/test/"
+
+**Parameters**:
+- `url`: The Pelican URL of the directory to list
+
+## Example Workflows
+
+### Downloading Research Data
+
+```
+User: I need to download the LIGO gravitational wave data from
+pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt
+to my research directory
+
+AI: I'll download that file for you. [Uses pelican_download tool]
+Successfully downloaded to ~/research/strain.hdf5 (2.3 GB)
+```
+
+### Exploring Available Data
+
+```
+User: What data is available in the pelican://osg-htc.org/pelicanplatform/test/ directory?
+
+AI: Let me check that for you. [Uses pelican_list tool]
+
+The directory contains:
+- hello-world.txt (27 bytes)
+- sample-data.csv (1.2 MB)
+- README.md (543 bytes)
+```
+
+### Checking File Metadata Before Download
+
+```
+User: Before I download pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt,
+can you tell me how large it is?
+
+AI: [Uses pelican_stat tool]
+
+The file is 27 bytes, last modified on 2024-03-15. It has MD5 checksum: a1b2c3d4...
+Since it's very small, would you like me to download it?
+
+User: Yes please, to /tmp/
+
+AI: [Uses pelican_download tool]
+Downloaded to /tmp/test.txt
+```
+
+## Troubleshooting
+
+### MCP Server Not Connecting
+
+If your AI assistant shows the Pelican MCP server as disconnected:
+
+1. **Verify Pelican is in PATH**:
+   ```bash
+   which pelican
+   ```
+   If this returns nothing, add Pelican to your PATH or use the full path in your MCP configuration.
+
+2. **Test MCP server manually**:
+   ```bash
+   pelican mcp serve
+   ```
+   You should see "Pelican MCP server started" in the output. Press Ctrl+C to exit.
+
+3. **Check configuration syntax**:
+   Ensure your JSON configuration is valid. Use a JSON validator if needed.
+
+4. **Restart your AI assistant completely**:
+   Make sure you fully quit (not just close) and relaunch.
+
+### Permission Errors
+
+If you get permission errors:
+
+```bash
+chmod +x $(which pelican)
+```
+
+### Downloads Fail
+
+If downloads fail with authentication errors:
+
+1. Ensure it is a public namespace, and verify the URL is correct using the CLI:
+```bash
+pelican object get pelican://... /tmp/test
+```
+
+### AI Assistant Doesn't Use Pelican Tools
+
+If your AI assistant isn't using the Pelican tools:
+
+1. **Be explicit**: Say "Use the pelican to..."
+2. **Check MCP connection**: Verify the server shows as connected
+3. **Provide complete Pelican URLs**: Include the full `pelican://` URL
+
+## Advanced Configuration
+
+### Custom Pelican Installation Path
+
+If Pelican is not in your system PATH, specify the full path:
+
+```json
+{
+  "mcpServers": {
+    "pelican": {
+      "command": "path/to/your/pelican/binary",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+### Debug Mode
+
+To enable debug logging for troubleshooting:
+
+```json
+{
+  "mcpServers": {
+    "pelican": {
+      "command": "pelican",
+      "args": ["mcp", "serve", "--debug"]
+    }
+  }
+}
+```
+
+Logs will appear in your AI assistant's MCP server logs.
+
+### Environment Variables
+
+You can pass environment variables to configure the MCP server:
+
+```json
+{
+  "mcpServers": {
+    "pelican": {
+      "command": "pelican",
+      "args": ["mcp", "serve"],
+      "env": {
+        "PELICAN_FEDERATION_URL": "https://my-federation.org"
+      }
+    }
+  }
+}
+```
+
+## Best Practices
+
+### Use Descriptive Prompts
+
+Instead of:
+```
+Download the file
+```
+
+Use:
+```
+Download pelican://osg-htc.org/pelicanplatform/test/hello-world.txt to ~/Downloads/hello.txt
+```
+
+### Verify Before Large Downloads
+
+For large files or directories, ask for metadata first:
+
+```
+How large is pelican://osg-htc.org/ospool/data/large-dataset/ recursively?
+```
+
+Then download if appropriate.
+
+### Organize Downloaded Files
+
+Specify organized destination paths:
+
+```
+Download pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt
+to ~/pelican-data/validation/test.txt
+```
+
+The MCP server will create directories as needed.
+
+## Learn More
+
+- [Pelican Command Line Client](../client/page.mdx) - Learn the CLI commands that power the MCP server
+- [Model Context Protocol Specification](https://modelcontextprotocol.io/) - Learn about the MCP standard
+- [Claude Code MCP Documentation](https://docs.claude.com/en/docs/claude-code/mcp) - More on using MCP with Claude Code
+- [VS Code MCP Documentation](https://code.visualstudio.com/docs/copilot/customization/mcp-servers) - Integrating MCP with VS Code
+
+## Support
+
+The Pelican MCP server feature just rolled out, if you encounter issues:
+
+1. Check the [Pelican documentation](../../) for general Pelican help
+2. Verify your configuration follows the examples above
+3. Test with the Pelican CLI first to ensure basic functionality works
+4. Report issues on the [Pelican GitHub repository](https://github.com/PelicanPlatform/pelican/issues)

--- a/docs/app/getting-data-with-pelican/mcp/page.mdx
+++ b/docs/app/getting-data-with-pelican/mcp/page.mdx
@@ -1,14 +1,16 @@
 # Using Pelican with AI Assistants via MCP
 
-The Pelican Model Context Protocol (MCP) server enables AI assistants like Claude Code, VS Code Copilot, and other MCP-compatible tools to download files, inspect metadata, and list directories from Pelican federations. This allows you to use natural language to interact with Pelican data directly from your AI-powered development environment.
+The Pelican Model Context Protocol (MCP) server enables AI assistants like Claude Code, VS Code Copilot, and other MCP-compatible tools to download files, inspect metadata, and list collections from Pelican federations.
+This allows you to use natural language to interact with Pelican data directly from your AI-powered development environment.
 
 ## What is MCP?
 
-The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standard that allows AI assistants to connect to external tools and data sources. By running a Pelican MCP server, your AI assistant can work with **public** namespaces (not support protected namespaces):
+The [Model Context Protocol](https://modelcontextprotocol.io/) is an open standard that allows AI assistants to connect to external tools and data sources.
+By running a Pelican MCP server, your AI assistant can work with **public** namespaces, but not protected namespaces:
 
 - Download objects from Pelican federations using natural language requests
 - Get metadata about objects (size, modification time, checksums)
-- List directory contents
+- List collection contents
 
 ## Before Starting
 
@@ -28,7 +30,8 @@ Ensure the Pelican MCP server is available:
 pelican mcp --help
 ```
 
-You should see output describing the `pelican mcp serve` command. If not, refer to the [Pelican installation docs](../../install.mdx) to install or update Pelican.
+You should see output describing the `pelican mcp serve` command.
+If not, refer to the [Pelican installation docs](../../install.mdx) to install or update Pelican.
 
 ## Setting Up with Claude Code
 
@@ -36,20 +39,23 @@ Claude Code CLI natively supports MCP servers, making it easy to integrate Pelic
 
 ### 1. Add Pelican MCP Server
 
-Ensure you have Claude Code installed. Run the following command to add Pelican binary to Claude Code as a local stdio server:
+Ensure you have Claude Code installed.
+Run the following command to add the Pelican binary to Claude Code as a local stdio server:
 
 ```bash copy
 claude mcp add pelican --transport stdio pelican mcp serve
 ```
 
-After you see a confirmation, Claude Code will automatically load the Pelican MCP server when you start a new session. No restart is required - the MCP server is loaded on-demand.
+After you see a confirmation, Claude Code will automatically load the Pelican MCP server when you start a new session.
+No restart is required; the MCP server is loaded on-demand.
 
 ### 2. Use Claude Code with Pelican
 
-Start a Claude Code session in your terminal. You can now ask Claude to download Pelican objects using natural language:
+Start a Claude Code session in your terminal.
+You can now ask Claude to download Pelican objects using natural language:
 
 ```
-Download the file pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt to my Downloads folder
+Download the file pelican://osg-htc.org/pelicanplatform/test/hello-world.txt to my Downloads folder
 ```
 
 Claude will fetch the file and confirm when it's complete.
@@ -105,59 +111,62 @@ Once configured, your AI assistant has access to three Pelican tools:
 Downloads objects from Pelican URLs to your local filesystem.
 
 **Example prompts**:
-- "Download pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt to /tmp/test.txt"
+- "Download pelican://osg-htc.org/pelicanplatform/test/hello-world.txt to /tmp/test.txt"
 - "Get the hello-world.txt file from pelican://osg-htc.org/pelicanplatform/test/ and save it locally"
-- "Download the entire validation directory recursively from pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/"
+- "Download the entire pelican://osg-htc.org/pelicanplatform/test/ collection recursively"
 
 **Parameters**:
 - `source`: The Pelican URL to download from
 - `destination`: Local path where the object should be saved
-- `recursive`: (optional) Set to true to download directories recursively
+- `recursive`: (optional) Set to true to download collections recursively
+
 ### pelican_stat
 
 Gets metadata about a Pelican object including size, modification time, and checksums.
 
 **Example prompts**:
 - "What's the size of pelican://osg-htc.org/pelicanplatform/test/hello-world.txt?"
-- "Get information about the validation test file"
-- "Show me the metadata for pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt"
+- "Get information about the hello-world test file"
+- "Show me the metadata for pelican://osg-htc.org/pelicanplatform/test/hello-world.txt"
 
 **Parameters**:
 - `url`: The Pelican URL to inspect
 
 ### pelican_list
 
-Lists the contents of a Pelican directory.
+Lists the contents of a Pelican collection.
 
 **Example prompts**:
-- "List the contents of pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/"
-- "What files are in the pelicanplatform test directory?"
+- "List the contents of pelican://osg-htc.org/pelicanplatform/test/"
+- "What files are in the pelicanplatform test collection?"
 - "Show me all objects under pelican://osg-htc.org/pelicanplatform/test/"
 
 **Parameters**:
-- `url`: The Pelican URL of the directory to list
+- `url`: The Pelican URL of the collection to list
 
 ## Example Workflows
 
-### Downloading Research Data
+### Downloading Test Data
 
 ```
-User: I need to download the LIGO gravitational wave data from
-pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt
+User: I need to download the hello-world test file from
+pelican://osg-htc.org/pelicanplatform/test/hello-world.txt
 to my research directory
 
-AI: I'll download that file for you. [Uses pelican_download tool]
-Successfully downloaded to ~/research/strain.hdf5 (2.3 GB)
+AI: I'll download that file for you.
+[Uses pelican_download tool]
+Successfully downloaded to ~/research/hello-world.txt (27 bytes)
 ```
 
 ### Exploring Available Data
 
 ```
-User: What data is available in the pelican://osg-htc.org/pelicanplatform/test/ directory?
+User: What data is available in the pelican://osg-htc.org/pelicanplatform/test/ collection?
 
-AI: Let me check that for you. [Uses pelican_list tool]
+AI: Let me check that for you.
+[Uses pelican_list tool]
 
-The directory contains:
+The collection contains:
 - hello-world.txt (27 bytes)
 - sample-data.csv (1.2 MB)
 - README.md (543 bytes)
@@ -166,18 +175,19 @@ The directory contains:
 ### Checking File Metadata Before Download
 
 ```
-User: Before I download pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt,
+User: Before I download pelican://osg-htc.org/pelicanplatform/test/hello-world.txt,
 can you tell me how large it is?
 
 AI: [Uses pelican_stat tool]
 
-The file is 27 bytes, last modified on 2024-03-15. It has MD5 checksum: a1b2c3d4...
+The file is 27 bytes, last modified on 2024-03-15.
+It has MD5 checksum: a1b2c3d4...
 Since it's very small, would you like me to download it?
 
 User: Yes please, to /tmp/
 
 AI: [Uses pelican_download tool]
-Downloaded to /tmp/test.txt
+Downloaded to /tmp/hello-world.txt
 ```
 
 ## Troubleshooting
@@ -196,10 +206,12 @@ If your AI assistant shows the Pelican MCP server as disconnected:
    ```bash
    pelican mcp serve
    ```
-   You should see "Pelican MCP server started" in the output. Press Ctrl+C to exit.
+   You should see "Pelican MCP server started" in the output.
+   Press Ctrl+C to exit.
 
 3. **Check configuration syntax**:
-   Ensure your JSON configuration is valid. Use a JSON validator if needed.
+   Ensure your JSON configuration is valid.
+   Use a JSON validator if needed.
 
 4. **Restart your AI assistant completely**:
    Make sure you fully quit (not just close) and relaunch.
@@ -225,7 +237,7 @@ pelican object get pelican://... /tmp/test
 
 If your AI assistant isn't using the Pelican tools:
 
-1. **Be explicit**: Say "Use the pelican to..."
+1. **Be explicit**: Say "Use Pelican to..."
 2. **Check MCP connection**: Verify the server shows as connected
 3. **Provide complete Pelican URLs**: Include the full `pelican://` URL
 
@@ -297,7 +309,7 @@ Download pelican://osg-htc.org/pelicanplatform/test/hello-world.txt to ~/Downloa
 
 ### Verify Before Large Downloads
 
-For large files or directories, ask for metadata first:
+For large files or collections, ask for metadata first:
 
 ```
 How large is pelican://osg-htc.org/ospool/data/large-dataset/ recursively?
@@ -310,8 +322,8 @@ Then download if appropriate.
 Specify organized destination paths:
 
 ```
-Download pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt
-to ~/pelican-data/validation/test.txt
+Download pelican://osg-htc.org/pelicanplatform/test/hello-world.txt
+to ~/pelican-data/hello-world.txt
 ```
 
 The MCP server will create directories as needed.
@@ -325,7 +337,8 @@ The MCP server will create directories as needed.
 
 ## Support
 
-The Pelican MCP server feature just rolled out, if you encounter issues:
+The Pelican MCP server feature just rolled out.
+If you encounter issues, try the following:
 
 1. Check the [Pelican documentation](../../) for general Pelican help
 2. Verify your configuration follows the examples above

--- a/docs/app/getting-data-with-pelican/page.mdx
+++ b/docs/app/getting-data-with-pelican/page.mdx
@@ -29,6 +29,11 @@ If your goal is to integrate Pelican with Python, you're looking for our [Pelica
 This client lets you interact with Pelican objects at any level of your code, including by plugging Pelican directly into popular Python libraries like [xarray](https://github.com/PelicanPlatform/pelicanfs/tree/main/examples/xarray)
 and [PyTorch data loaders](https://github.com/PelicanPlatform/pelicanfs/tree/main/examples/pytorch).
 
+### Pelican's Model Context Protocol (MCP) Server
+If you work with AI assistants like Claude Code or VS Code Copilot, the Pelican MCP server allows you to download data from Pelican federations
+using natural language. Simply ask your AI assistant to "download pelican://..." and it will handle the transfer for you. The MCP server also
+provides tools to list directories and inspect object metadata, making it easy to explore and work with federated data directly from your AI-powered
+development environment. For details, see [Using Pelican with AI Assistants](./getting-data-with-pelican/mcp.mdx).
 
 ### Pelican's HTCondor Plugin
 Pelican maintains a plugin that acts as the preferred transfer tool for [HTCondor](https://htcondor.org/), a software suite used in many distributed/clustered

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -1,0 +1,197 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/pelicanplatform/pelican/config"
+)
+
+// Server implements the MCP server
+type Server struct {
+	reader *bufio.Reader
+	writer io.Writer
+	ctx    context.Context
+}
+
+// NewServer creates a new MCP server
+func NewServer(ctx context.Context, reader io.Reader, writer io.Writer) *Server {
+	return &Server{
+		reader: bufio.NewReader(reader),
+		writer: writer,
+		ctx:    ctx,
+	}
+}
+
+// Run starts the MCP server and handles requests
+func (s *Server) Run() error {
+	// Initialize the Pelican client
+	if err := config.InitClient(); err != nil {
+		return fmt.Errorf("failed to initialize Pelican client: %w", err)
+	}
+
+	log.Info("Pelican MCP server started")
+
+	for {
+		line, err := s.reader.ReadBytes('\n')
+		if err != nil {
+			if err == io.EOF {
+				log.Info("Client disconnected")
+				return nil
+			}
+			return fmt.Errorf("error reading request: %w", err)
+		}
+
+		var req JSONRPCRequest
+		if err := json.Unmarshal(line, &req); err != nil {
+			log.Errorf("Error parsing JSON-RPC request: %v", err)
+			s.sendError(nil, -32700, "Parse error", nil)
+			continue
+		}
+
+		log.Debugf("Received request: %s (ID: %v)", req.Method, req.ID)
+
+		if err := s.handleRequest(&req); err != nil {
+			log.Errorf("Error handling request: %v", err)
+		}
+	}
+}
+
+// handleRequest processes a JSON-RPC request
+func (s *Server) handleRequest(req *JSONRPCRequest) error {
+	switch req.Method {
+	case "initialize":
+		return s.handleInitialize(req)
+	case "tools/list":
+		return s.handleListTools(req)
+	case "tools/call":
+		return s.handleCallTool(req)
+	case "ping":
+		return s.sendResponse(req.ID, map[string]interface{}{})
+	default:
+		return s.sendError(req.ID, -32601, "Method not found", nil)
+	}
+}
+
+// handleInitialize handles the initialize request
+func (s *Server) handleInitialize(req *JSONRPCRequest) error {
+	var params InitializeParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return s.sendError(req.ID, -32602, "Invalid params", err.Error())
+	}
+
+	result := InitializeResult{
+		ProtocolVersion: "2024-11-05",
+		Capabilities: map[string]interface{}{
+			"tools": map[string]interface{}{},
+		},
+		ServerInfo: ServerInfo{
+			Name:    "pelican-mcp-server",
+			Version: "1.0.0",
+		},
+	}
+
+	return s.sendResponse(req.ID, result)
+}
+
+// handleListTools handles the tools/list request
+func (s *Server) handleListTools(req *JSONRPCRequest) error {
+	result := ListToolsResult{Tools: getToolsList()}
+	return s.sendResponse(req.ID, result)
+}
+
+// handleCallTool handles the tools/call request
+func (s *Server) handleCallTool(req *JSONRPCRequest) error {
+	var params CallToolParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return s.sendError(req.ID, -32602, "Invalid params", err.Error())
+	}
+
+	log.Infof("Calling tool: %s with arguments: %v", params.Name, params.Arguments)
+
+	var result CallToolResult
+
+	switch params.Name {
+	case "pelican_download":
+		result = s.handleDownload(params.Arguments)
+	case "pelican_stat":
+		result = s.handleStat(params.Arguments)
+	case "pelican_list":
+		result = s.handleList(params.Arguments)
+	default:
+		return s.sendError(req.ID, -32602, "Unknown tool", params.Name)
+	}
+
+	return s.sendResponse(req.ID, result)
+}
+
+// sendResponse sends a JSON-RPC response
+func (s *Server) sendResponse(id interface{}, result interface{}) error {
+	resp := JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  result,
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return fmt.Errorf("error marshaling response: %w", err)
+	}
+
+	data = append(data, '\n')
+	if _, err := s.writer.Write(data); err != nil {
+		return fmt.Errorf("error writing response: %w", err)
+	}
+
+	log.Debugf("Sent response for ID: %v", id)
+	return nil
+}
+
+// sendError sends a JSON-RPC error response
+func (s *Server) sendError(id interface{}, code int, message string, data interface{}) error {
+	resp := JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: &RPCError{
+			Code:    code,
+			Message: message,
+			Data:    data,
+		},
+	}
+
+	respData, err := json.Marshal(resp)
+	if err != nil {
+		return fmt.Errorf("error marshaling error response: %w", err)
+	}
+
+	respData = append(respData, '\n')
+	if _, err := s.writer.Write(respData); err != nil {
+		return fmt.Errorf("error writing error response: %w", err)
+	}
+
+	log.Debugf("Sent error response for ID: %v", id)
+	return nil
+}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -77,7 +77,9 @@ func (s *Server) Run() error {
 		var req JSONRPCRequest
 		if err := json.Unmarshal(line, &req); err != nil {
 			log.Errorf("Error parsing JSON-RPC request: %v", err)
-			s.sendError(nil, -32700, "Parse error", nil)
+			if sendErr := s.sendError(nil, -32700, "Parse error", nil); sendErr != nil {
+				log.Errorf("Failed to send error response: %v", sendErr)
+			}
 			continue
 		}
 
@@ -132,7 +134,7 @@ func (s *Server) handleInitialize(req *JSONRPCRequest) error {
 	}
 
 	result := InitializeResult{
-		ProtocolVersion: "2024-11-05",
+		ProtocolVersion: "2025-11-17",
 		Capabilities: map[string]interface{}{
 			"tools": map[string]interface{}{},
 		},

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -32,9 +32,10 @@ import (
 
 // Server implements the MCP server
 type Server struct {
-	reader *bufio.Reader
-	writer io.Writer
-	ctx    context.Context
+	reader      *bufio.Reader
+	writer      io.Writer
+	ctx         context.Context
+	initialized bool
 }
 
 // NewServer creates a new MCP server
@@ -46,13 +47,21 @@ func NewServer(ctx context.Context, reader io.Reader, writer io.Writer) *Server 
 	}
 }
 
+// ensureInitialized initializes the Pelican client if not already done
+func (s *Server) ensureInitialized() error {
+	if !s.initialized {
+		if err := config.InitClient(); err != nil {
+			log.Errorf("Failed to initialize Pelican client: %v", err)
+			return fmt.Errorf("failed to initialize Pelican client: %w", err)
+		}
+		s.initialized = true
+		log.Info("Pelican client initialized")
+	}
+	return nil
+}
+
 // Run starts the MCP server and handles requests
 func (s *Server) Run() error {
-	// Initialize the Pelican client
-	if err := config.InitClient(); err != nil {
-		return fmt.Errorf("failed to initialize Pelican client: %w", err)
-	}
-
 	log.Info("Pelican MCP server started")
 
 	for {

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -24,32 +24,71 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
 )
 
+// Flusher is an interface for writers that support flushing buffered data
+type Flusher interface {
+	Flush() error
+}
+
+// pendingAuth stores the state for an in-progress device authentication
+type pendingAuth struct {
+	authInfo  *client.DeviceAuthInfo
+	url       string
+	createdAt time.Time
+}
+
+// cachedToken stores an acquired token for a namespace
+type cachedToken struct {
+	token     string
+	namespace string // The namespace prefix this token is valid for
+	createdAt time.Time
+}
+
 // Server implements the MCP server
 type Server struct {
-	reader      *bufio.Reader
-	writer      io.Writer
-	ctx         context.Context
-	initialized bool
+	reader       *bufio.Reader
+	writer       io.Writer
+	ctx          context.Context
+	initialized  bool
+	pendingAuths map[string]*pendingAuth // Map from URL to pending auth info
+	cachedTokens map[string]*cachedToken // Map from namespace prefix to cached token
+	authMutex    sync.Mutex
 }
 
 // NewServer creates a new MCP server
 func NewServer(ctx context.Context, reader io.Reader, writer io.Writer) *Server {
 	return &Server{
-		reader: bufio.NewReader(reader),
-		writer: writer,
-		ctx:    ctx,
+		reader:       bufio.NewReader(reader),
+		writer:       writer,
+		ctx:          ctx,
+		pendingAuths: make(map[string]*pendingAuth),
+		cachedTokens: make(map[string]*cachedToken),
 	}
 }
 
 // ensureInitialized initializes the Pelican client if not already done
 func (s *Server) ensureInitialized() error {
 	if !s.initialized {
+		// Set environment variable to skip terminal check for device auth flow.
+		// The MCP server runs as a subprocess spawned by AI assistants (like Claude Code or
+		// VS Code Copilot) which don't have a TTY attached. The terminal check in oauth2.AcquireToken
+		// would normally prevent device auth from working in non-terminal environments.
+		// By setting this env var, we enable the device auth flow to work, allowing the MCP server
+		// to return verification URLs that users can click to authenticate.
+		// This is safe because the MCP protocol allows returning the verification URL to the user
+		// through the AI assistant's interface.
+		os.Setenv(config.GetPreferredPrefix().String()+"_SKIP_TERMINAL_CHECK", "true")
+
 		if err := config.InitClient(); err != nil {
 			log.Errorf("Failed to initialize Pelican client: %v", err)
 			return fmt.Errorf("failed to initialize Pelican client: %w", err)
@@ -58,6 +97,51 @@ func (s *Server) ensureInitialized() error {
 		log.Info("Pelican client initialized")
 	}
 	return nil
+}
+
+// cacheToken stores a token for a given namespace
+func (s *Server) cacheToken(namespace, token string) {
+	s.authMutex.Lock()
+	defer s.authMutex.Unlock()
+	s.cachedTokens[namespace] = &cachedToken{
+		token:     token,
+		namespace: namespace,
+		createdAt: time.Now(),
+	}
+	log.Infof("Cached token for namespace: %s", namespace)
+}
+
+// getTokenForURL attempts to find a cached token that matches the given URL
+func (s *Server) getTokenForURL(urlStr string) string {
+	s.authMutex.Lock()
+	defer s.authMutex.Unlock()
+
+	// Extract the path from the URL
+	var path string
+	if strings.HasPrefix(urlStr, "pelican://") || strings.HasPrefix(urlStr, "osdf://") {
+		// URL format: pelican://host/path or osdf://path
+		parts := strings.SplitN(urlStr, "://", 2)
+		if len(parts) == 2 {
+			hostAndPath := parts[1]
+			slashIdx := strings.Index(hostAndPath, "/")
+			if slashIdx != -1 {
+				path = hostAndPath[slashIdx:]
+			}
+		}
+	}
+
+	if path == "" {
+		return ""
+	}
+
+	// Check each cached token to see if its namespace matches the URL path
+	for namespace, cached := range s.cachedTokens {
+		if strings.HasPrefix(path, namespace) {
+			log.Debugf("Found cached token for URL %s (namespace: %s)", urlStr, namespace)
+			return cached.token
+		}
+	}
+	return ""
 }
 
 // Run starts the MCP server and handles requests
@@ -71,22 +155,23 @@ func (s *Server) Run() error {
 				log.Info("Client disconnected")
 				return nil
 			}
+			log.Errorf("Error reading request: %v", err)
 			return fmt.Errorf("error reading request: %w", err)
 		}
 
 		var req JSONRPCRequest
 		if err := json.Unmarshal(line, &req); err != nil {
-			log.Errorf("Error parsing JSON-RPC request: %v", err)
+			log.Errorf("Error parsing JSON-RPC request: %v (raw: %s)", err, string(line))
 			if sendErr := s.sendError(nil, -32700, "Parse error", nil); sendErr != nil {
 				log.Errorf("Failed to send error response: %v", sendErr)
 			}
 			continue
 		}
 
-		log.Debugf("Received request: %s (ID: %v)", req.Method, req.ID)
+		log.Infof("Received request: method=%s, id=%v", req.Method, req.ID)
 
 		if err := s.handleRequest(&req); err != nil {
-			log.Errorf("Error handling request: %v", err)
+			log.Errorf("Error handling request %s: %v", req.Method, err)
 		}
 	}
 }
@@ -133,8 +218,13 @@ func (s *Server) handleInitialize(req *JSONRPCRequest) error {
 		return s.sendError(req.ID, -32602, "Invalid params", err.Error())
 	}
 
+	log.Infof("Received initialize request from client: %s (protocol version: %s)",
+		params.ClientInfo.Name, params.ProtocolVersion)
+
 	result := InitializeResult{
-		ProtocolVersion: "2025-11-17",
+		// Use a stable protocol version that's compatible with MCP clients
+		// The MCP protocol uses dates as version strings; 2024-11-05 is widely supported
+		ProtocolVersion: "2024-11-05",
 		Capabilities: map[string]interface{}{
 			"tools": map[string]interface{}{},
 		},
@@ -144,6 +234,7 @@ func (s *Server) handleInitialize(req *JSONRPCRequest) error {
 		},
 	}
 
+	log.Infof("Sending initialize response with protocol version: %s", result.ProtocolVersion)
 	return s.sendResponse(req.ID, result)
 }
 
@@ -171,6 +262,10 @@ func (s *Server) handleCallTool(req *JSONRPCRequest) error {
 		result = s.handleStat(params.Arguments)
 	case "pelican_list":
 		result = s.handleList(params.Arguments)
+	case "pelican_auth":
+		result = s.handleAuth(params.Arguments)
+	case "pelican_auth_complete":
+		result = s.handleAuthComplete(params.Arguments)
 	default:
 		return s.sendError(req.ID, -32602, "Unknown tool", params.Name)
 	}
@@ -188,15 +283,31 @@ func (s *Server) sendResponse(id interface{}, result interface{}) error {
 
 	data, err := json.Marshal(resp)
 	if err != nil {
+		log.Errorf("Error marshaling response: %v", err)
 		return fmt.Errorf("error marshaling response: %w", err)
 	}
 
 	data = append(data, '\n')
-	if _, err := s.writer.Write(data); err != nil {
+	n, err := s.writer.Write(data)
+	if err != nil {
+		log.Errorf("Error writing response: %v", err)
 		return fmt.Errorf("error writing response: %w", err)
 	}
 
-	log.Debugf("Sent response for ID: %v", id)
+	if n != len(data) {
+		log.Errorf("Incomplete write: wrote %d of %d bytes", n, len(data))
+		return fmt.Errorf("incomplete write: wrote %d of %d bytes", n, len(data))
+	}
+
+	// Flush if the writer supports it (e.g., bufio.Writer)
+	if flusher, ok := s.writer.(Flusher); ok {
+		if err := flusher.Flush(); err != nil {
+			log.Errorf("Error flushing response: %v", err)
+			return fmt.Errorf("error flushing response: %w", err)
+		}
+	}
+
+	log.Infof("Sent response for ID: %v (%d bytes)", id, len(data))
 	return nil
 }
 
@@ -214,14 +325,30 @@ func (s *Server) sendError(id interface{}, code int, message string, data interf
 
 	respData, err := json.Marshal(resp)
 	if err != nil {
+		log.Errorf("Error marshaling error response: %v", err)
 		return fmt.Errorf("error marshaling error response: %w", err)
 	}
 
 	respData = append(respData, '\n')
-	if _, err := s.writer.Write(respData); err != nil {
+	n, err := s.writer.Write(respData)
+	if err != nil {
+		log.Errorf("Error writing error response: %v", err)
 		return fmt.Errorf("error writing error response: %w", err)
 	}
 
-	log.Debugf("Sent error response for ID: %v", id)
+	if n != len(respData) {
+		log.Errorf("Incomplete write: wrote %d of %d bytes", n, len(respData))
+		return fmt.Errorf("incomplete write: wrote %d of %d bytes", n, len(respData))
+	}
+
+	// Flush if the writer supports it
+	if flusher, ok := s.writer.(Flusher); ok {
+		if err := flusher.Flush(); err != nil {
+			log.Errorf("Error flushing error response: %v", err)
+			return fmt.Errorf("error flushing error response: %w", err)
+		}
+	}
+
+	log.Infof("Sent error response for ID: %v (code: %d, message: %s)", id, code, message)
 	return nil
 }

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -92,6 +92,34 @@ func getToolsList() []Tool {
 				"required": []string{"url"},
 			},
 		},
+		{
+			Name:        "pelican_auth",
+			Description: "Start authentication to a protected Pelican namespace using OAuth device flow. This returns a verification URL that the user must visit to authorize access. IMPORTANT: After the user completes authorization in their browser, call pelican_auth_complete to finish authentication and cache the token.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"url": map[string]interface{}{
+						"type":        "string",
+						"description": "The Pelican URL of the protected resource to authenticate for (e.g., pelican://osg-htc.org/protected/path)",
+					},
+				},
+				"required": []string{"url"},
+			},
+		},
+		{
+			Name:        "pelican_auth_complete",
+			Description: "Complete the OAuth device flow authentication after the user has visited the verification URL. Call this AFTER the user confirms they have completed authorization in their browser. This will poll for the token and cache it for future operations.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"url": map[string]interface{}{
+						"type":        "string",
+						"description": "The same Pelican URL that was used to start authentication with pelican_auth",
+					},
+				},
+				"required": []string{"url"},
+			},
+		},
 	}
 }
 

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -97,6 +97,14 @@ func getToolsList() []Tool {
 
 // handleDownload implements the pelican_download tool
 func (s *Server) handleDownload(args map[string]interface{}) CallToolResult {
+	// Ensure Pelican client is initialized
+	if err := s.ensureInitialized(); err != nil {
+		return CallToolResult{
+			Content: []ContentItem{{Type: "text", Text: fmt.Sprintf("Error: Failed to initialize Pelican client: %v", err)}},
+			IsError: true,
+		}
+	}
+
 	source, ok := args["source"].(string)
 	if !ok {
 		return CallToolResult{
@@ -160,6 +168,14 @@ func (s *Server) handleDownload(args map[string]interface{}) CallToolResult {
 
 // handleStat implements the pelican_stat tool
 func (s *Server) handleStat(args map[string]interface{}) CallToolResult {
+	// Ensure Pelican client is initialized
+	if err := s.ensureInitialized(); err != nil {
+		return CallToolResult{
+			Content: []ContentItem{{Type: "text", Text: fmt.Sprintf("Error: Failed to initialize Pelican client: %v", err)}},
+			IsError: true,
+		}
+	}
+
 	url, ok := args["url"].(string)
 	if !ok {
 		return CallToolResult{
@@ -205,6 +221,14 @@ func (s *Server) handleStat(args map[string]interface{}) CallToolResult {
 
 // handleList implements the pelican_list tool
 func (s *Server) handleList(args map[string]interface{}) CallToolResult {
+	// Ensure Pelican client is initialized
+	if err := s.ensureInitialized(); err != nil {
+		return CallToolResult{
+			Content: []ContentItem{{Type: "text", Text: fmt.Sprintf("Error: Failed to initialize Pelican client: %v", err)}},
+			IsError: true,
+		}
+	}
+
 	url, ok := args["url"].(string)
 	if !ok {
 		return CallToolResult{

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -1,0 +1,250 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package mcp
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/pelicanplatform/pelican/client"
+)
+
+// getToolsList returns the list of available MCP tools
+func getToolsList() []Tool {
+	return []Tool{
+		{
+			Name:        "pelican_download",
+			Description: "Download an object from a Pelican URL to a local destination. Supports both single files and recursive directory downloads.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"source": map[string]interface{}{
+						"type":        "string",
+						"description": "The Pelican URL to download from (e.g., pelican://osg-htc.org/ospool/uc-shared/public/OSG-Staff/validation/test.txt)",
+					},
+					"destination": map[string]interface{}{
+						"type":        "string",
+						"description": "The local file path where the object should be saved",
+					},
+					"recursive": map[string]interface{}{
+						"type":        "boolean",
+						"description": "If true, recursively download directories",
+						"default":     false,
+					},
+					"token": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional authentication token for accessing protected resources",
+					},
+				},
+				"required": []string{"source", "destination"},
+			},
+		},
+		{
+			Name:        "pelican_stat",
+			Description: "Get metadata information about a Pelican object, including size, modification time, and checksums.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"url": map[string]interface{}{
+						"type":        "string",
+						"description": "The Pelican URL to get information about",
+					},
+					"token": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional authentication token for accessing protected resources",
+					},
+				},
+				"required": []string{"url"},
+			},
+		},
+		{
+			Name:        "pelican_list",
+			Description: "List the contents of a directory in Pelican.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"url": map[string]interface{}{
+						"type":        "string",
+						"description": "The Pelican URL of the directory to list",
+					},
+					"token": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional authentication token for accessing protected resources",
+					},
+				},
+				"required": []string{"url"},
+			},
+		},
+	}
+}
+
+// handleDownload implements the pelican_download tool
+func (s *Server) handleDownload(args map[string]interface{}) CallToolResult {
+	source, ok := args["source"].(string)
+	if !ok {
+		return CallToolResult{
+			Content: []ContentItem{{Type: "text", Text: "Error: 'source' parameter is required and must be a string"}},
+			IsError: true,
+		}
+	}
+
+	destination, ok := args["destination"].(string)
+	if !ok {
+		return CallToolResult{
+			Content: []ContentItem{{Type: "text", Text: "Error: 'destination' parameter is required and must be a string"}},
+			IsError: true,
+		}
+	}
+
+	recursive := false
+	if r, ok := args["recursive"].(bool); ok {
+		recursive = r
+	}
+
+	// Build transfer options
+	var options []client.TransferOption
+	if token, ok := args["token"].(string); ok && token != "" {
+		options = append(options, client.WithToken(token))
+	}
+
+	// Create destination directory if it doesn't exist
+	destDir := filepath.Dir(destination)
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return CallToolResult{
+			Content: []ContentItem{{Type: "text", Text: fmt.Sprintf("Error creating destination directory: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	// Perform the download
+	transferResults, err := client.DoGet(s.ctx, source, destination, recursive, options...)
+	if err != nil {
+		return CallToolResult{
+			Content: []ContentItem{{Type: "text", Text: fmt.Sprintf("Download failed: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	// Build success message
+	var totalBytes int64
+	for _, result := range transferResults {
+		totalBytes += result.TransferredBytes
+	}
+
+	message := fmt.Sprintf("Successfully downloaded from %s to %s\n", source, destination)
+	message += fmt.Sprintf("Files transferred: %d\n", len(transferResults))
+	message += fmt.Sprintf("Total bytes: %d (%.2f MB)\n", totalBytes, float64(totalBytes)/(1024*1024))
+
+	return CallToolResult{
+		Content: []ContentItem{{Type: "text", Text: message}},
+		IsError: false,
+	}
+}
+
+// handleStat implements the pelican_stat tool
+func (s *Server) handleStat(args map[string]interface{}) CallToolResult {
+	url, ok := args["url"].(string)
+	if !ok {
+		return CallToolResult{
+			Content: []ContentItem{{Type: "text", Text: "Error: 'url' parameter is required and must be a string"}},
+			IsError: true,
+		}
+	}
+
+	// Build transfer options
+	var options []client.TransferOption
+	if token, ok := args["token"].(string); ok && token != "" {
+		options = append(options, client.WithToken(token))
+	}
+
+	// Get file info
+	fileInfo, err := client.DoStat(s.ctx, url, options...)
+	if err != nil {
+		return CallToolResult{
+			Content: []ContentItem{{Type: "text", Text: fmt.Sprintf("Stat failed: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	// Build response message
+	message := fmt.Sprintf("Object information for %s:\n", url)
+	message += fmt.Sprintf("Name: %s\n", fileInfo.Name)
+	message += fmt.Sprintf("Size: %d bytes (%.2f MB)\n", fileInfo.Size, float64(fileInfo.Size)/(1024*1024))
+	message += fmt.Sprintf("Modified: %s\n", fileInfo.ModTime.Format("2006-01-02 15:04:05 MST"))
+	message += fmt.Sprintf("Is Collection: %v\n", fileInfo.IsCollection)
+
+	if len(fileInfo.Checksums) > 0 {
+		message += "Checksums:\n"
+		for algo, checksum := range fileInfo.Checksums {
+			message += fmt.Sprintf("  %s: %s\n", algo, checksum)
+		}
+	}
+
+	return CallToolResult{
+		Content: []ContentItem{{Type: "text", Text: message}},
+		IsError: false,
+	}
+}
+
+// handleList implements the pelican_list tool
+func (s *Server) handleList(args map[string]interface{}) CallToolResult {
+	url, ok := args["url"].(string)
+	if !ok {
+		return CallToolResult{
+			Content: []ContentItem{{Type: "text", Text: "Error: 'url' parameter is required and must be a string"}},
+			IsError: true,
+		}
+	}
+
+	// Build transfer options
+	var options []client.TransferOption
+	if token, ok := args["token"].(string); ok && token != "" {
+		options = append(options, client.WithToken(token))
+	}
+
+	// List directory contents
+	fileInfos, err := client.DoList(s.ctx, url, options...)
+	if err != nil {
+		return CallToolResult{
+			Content: []ContentItem{{Type: "text", Text: fmt.Sprintf("List failed: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	// Build response message
+	message := fmt.Sprintf("Contents of %s:\n\n", url)
+	for _, info := range fileInfos {
+		typeStr := "file"
+		if info.IsCollection {
+			typeStr = "dir"
+		}
+		message += fmt.Sprintf("[%s] %s (%d bytes, modified: %s)\n",
+			typeStr, info.Name, info.Size, info.ModTime.Format("2006-01-02 15:04:05"))
+	}
+
+	if len(fileInfos) == 0 {
+		message += "(empty directory)\n"
+	}
+
+	return CallToolResult{
+		Content: []ContentItem{{Type: "text", Text: message}},
+		IsError: false,
+	}
+}

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -1,0 +1,90 @@
+/***************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package mcp
+
+import "encoding/json"
+
+// MCP protocol message structures
+type JSONRPCRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      interface{}     `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type JSONRPCResponse struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id,omitempty"`
+	Result  interface{} `json:"result,omitempty"`
+	Error   *RPCError   `json:"error,omitempty"`
+}
+
+type RPCError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+// MCP-specific structures
+type InitializeParams struct {
+	ProtocolVersion string                 `json:"protocolVersion"`
+	Capabilities    map[string]interface{} `json:"capabilities"`
+	ClientInfo      ClientInfo             `json:"clientInfo"`
+}
+
+type ClientInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type InitializeResult struct {
+	ProtocolVersion string                 `json:"protocolVersion"`
+	Capabilities    map[string]interface{} `json:"capabilities"`
+	ServerInfo      ServerInfo             `json:"serverInfo"`
+}
+
+type ServerInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type Tool struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	InputSchema map[string]interface{} `json:"inputSchema"`
+}
+
+type ListToolsResult struct {
+	Tools []Tool `json:"tools"`
+}
+
+type CallToolParams struct {
+	Name      string                 `json:"name"`
+	Arguments map[string]interface{} `json:"arguments,omitempty"`
+}
+
+type CallToolResult struct {
+	Content []ContentItem `json:"content"`
+	IsError bool          `json:"isError,omitempty"`
+}
+
+type ContentItem struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -30,7 +30,7 @@ type JSONRPCRequest struct {
 
 type JSONRPCResponse struct {
 	JSONRPC string      `json:"jsonrpc"`
-	ID      interface{} `json:"id,omitempty"`
+	ID      interface{} `json:"id"`
 	Result  interface{} `json:"result,omitempty"`
 	Error   *RPCError   `json:"error,omitempty"`
 }


### PR DESCRIPTION
This PR comes with **Pelican Docs updates**. Check out how to use this feature there. Here is a [sample conversation](https://claude.ai/share/7b1c80e0-1571-4a1e-a073-331337c119e8) using Claude to get an object from a protected Pelican namespace.

### Benefits
This Model Context Protocol (MCP) integration enables researchers to access scientific datasets using natural language through AI assistants like Claude Code and VSCode Copilot. This positions Pelican at the forefront of the AI-powered scientific computing revolution and reach a wider user base.

MCP is the emerging standard for connecting AI to the real world. Think of it as "USB for AI assistants" - a standardized protocol that allows any MCP-compatible AI assistant (Claude, VS Code Copilot, Cline, etc.) to interact with external tools and data sources. As a data federation CLI tool, Pelican Client is a perfect fit as a MCP to plug in the Agentic AI world.

For users, no more sophisticated commands memorization required - AI can understand the most download demands. What's more, it can suggest the next step, even accomplish the entire workflow from data downloads to data analysis, eventually provides a report on its own. 

### System design in a nutshell
AI Assistant (e.g. VS Code Copilot) spawns a MCP server process, which is just a thin JSON-RPC wrapper around existing client API. The MCP server does NOT execute `pelican object get` as a subprocess. Instead, it imports and calls the client library functions (e.g. client.DoGet) directly.

### Limitation
~~This MCP only supports public namespaces, because MCP cannot open an external browser to complete the OAuth flow. But since a large portion of Pelican usage is public data, this documented feature is ready for the production.~~

The above limitation is resolved by the new commits in Feb 2026. See the below comment.

