### PR TITLE
Add action to check if the current branch is rebased on main

### DIFF
--- a/.github/workflows/check-rebase-on-main.yml
+++ b/.github/workflows/check-rebase-on-main.yml
@@ -28,10 +28,6 @@ jobs:
           if ! git merge-base --is-ancestor origin/main HEAD; then
             echo "Error: This branch is not rebased on main."
             echo "Please rebase your branch on main before merging."
-            echo ""
-            echo "To rebase, run:"
-            echo "  git fetch origin main"
-            echo "  git rebase origin/main"
             exit 1
           fi
 


### PR DESCRIPTION
This PR adds a Github action to check if a PR is rebased off of main. This is to prevent regressions in tests or other functionality.