### PR TITLE
Set monitoring scopes only for admins

### DIFF
--- a/web_ui/authentication.go
+++ b/web_ui/authentication.go
@@ -202,7 +202,7 @@ func setLoginCookie(ctx *gin.Context, userRecord *database.User, groups []string
 
 	// For backwards compatibility (see #398), add additional scopes
 	// for expert admins who extract the login cookie from their browser
-	// and use it query monitoring endpoints directly.
+	// and use it to query monitoring endpoints directly.
 	if isAdmin, _ := CheckAdmin(loginCookieTokenCfg.Subject); isAdmin {
 		loginCookieTokenCfg.AddScopes(token_scopes.Monitoring_Query, token_scopes.Monitoring_Scrape)
 	}


### PR DESCRIPTION
I proposed two solutions in #2767. Rather than rewrite Pelican's web UI's notion of "session" — which would be a significant undertaking — I've opted for the simpler solution: Don't set scopes that, by all evidence (look back to #398, for example) and current practice, should be available only to designated admins.