### PR TITLE
Revert "Remove `osg-development` from installation repos"

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -423,7 +423,7 @@ RUN --mount=type=bind,from=xrootd-build,source=/xrootd-build,target=/xrootd-buil
     if ${!SRC_BUILD}; then
       dnf install -y /xrootd-build/RPMS/*/${REPO}-*.rpm
     else
-      dnf install -y --enablerepo=epel-testing --enablerepo=osg-testing --enablerepo=osg-upcoming-testing ${REPO}-${!VER}
+      dnf install -y --enablerepo=epel-testing --enablerepo=osg-development --enablerepo=osg-testing --enablerepo=osg-upcoming-testing ${REPO}-${!VER}
     fi
   }
 


### PR DESCRIPTION
Reverts PelicanPlatform/pelican#2844 - this should only affect 7.21.x as we want to install and test the latest xrdhttp-pelican from `osg-development` in 7.22.x 