### PR TITLE
Images: Pin xrdhttp-pelican to a specific version

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -72,8 +72,8 @@ ARG XROOTD_S3_HTTP_SRC_BUILD=true
 ARG XROOTD_S3_HTTP_VER=0.5.2
 # Installed from Koji if not building it from source
 ARG XRDHTTP_PELICAN_SRC_BUILD=false
-ARG XRDHTTP_PELICAN_VER=0.0.7
-ARG XRDHTTP_PELICAN_RELEASE="2.osg${OSG_SERIES}.${BASE_OS}"
+ARG XRDHTTP_PELICAN_VER=0.0.8
+ARG XRDHTTP_PELICAN_RELEASE="1.osg${OSG_SERIES}.${BASE_OS}"
 
 # Set scitokens-oauth2-server image as a build stage so that we can copy its
 # OA4MP installation into the images being built here.


### PR DESCRIPTION
This is necessary because xrdhttp-pelican is locked to a specific minor version of xrootd and we're pinning the xrootd version, so we can't just take whatever is the newest in the repos.

Take it from Koji if we're not building it ourselves.