### PR TITLE
Images: Pin xrdhttp-pelican to a specific version

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -60,12 +60,14 @@ ARG LOTMAN_VER=0.0.4
 # when doing version changes.
 ARG XRDCL_PELICAN_SRC_BUILD=false
 ARG XRDCL_PELICAN_VER=1.5.6
-ARG XRDHTTP_PELICAN_SRC_BUILD=false
-ARG XRDHTTP_PELICAN_VER=0.0.7
 ARG XROOTD_LOTMAN_SRC_BUILD=false
 ARG XROOTD_LOTMAN_VER=0.0.5
 ARG XROOTD_S3_HTTP_SRC_BUILD=true
 ARG XROOTD_S3_HTTP_VER=0.5.2
+# Installed from Koji if not building it from source
+ARG XRDHTTP_PELICAN_SRC_BUILD=false
+ARG XRDHTTP_PELICAN_VER=0.0.7
+ARG XRDHTTP_PELICAN_RELEASE="1.osg${OSG_SERIES}.${BASE_OS}"
 
 # Set scitokens-oauth2-server image as a build stage so that we can copy its
 # OA4MP installation into the images being built here.
@@ -380,16 +382,22 @@ ENDRUN
 # for running an origin and plugins for running a cache.
 #################################################################
 FROM xrootd-software-init AS xrootd-software-base
+ARG TARGETARCH
 ARG LOTMAN_SRC_BUILD
 ARG LOTMAN_VER
 ARG XRDCL_PELICAN_SRC_BUILD
 ARG XRDCL_PELICAN_VER
 ARG XRDHTTP_PELICAN_SRC_BUILD
 ARG XRDHTTP_PELICAN_VER
+ARG XRDHTTP_PELICAN_RELEASE
 ARG XROOTD_LOTMAN_SRC_BUILD
 ARG XROOTD_LOTMAN_VER
 ARG XROOTD_S3_HTTP_SRC_BUILD
 ARG XROOTD_S3_HTTP_VER
+
+# If we didn't build it from source, install it from Koji instead.
+# Note the %ARCH% placeholders that need to be substituted.
+ARG XRDHTTP_PELICAN_KOJI_URL="https://kojihub2000.chtc.wisc.edu/kojifiles/packages/xrdhttp-pelican/${XRDHTTP_PELICAN_VER}/${XRDHTTP_PELICAN_RELEASE}/%ARCH%/xrdhttp-pelican-${XRDHTTP_PELICAN_VER}-${XRDHTTP_PELICAN_RELEASE}.%ARCH%.rpm"
 
 RUN --mount=type=bind,from=xrootd-build,source=/xrootd-build,target=/xrootd-build \
     --mount=type=cache,id=dnf-${TARGETPLATFORM},target=/var/cache/dnf,sharing=locked \
@@ -398,6 +406,13 @@ RUN --mount=type=bind,from=xrootd-build,source=/xrootd-build,target=/xrootd-buil
   set -eux
 
   dnf install -y xrootd-multiuser
+
+  if [ "$TARGETARCH" = "amd64" ]; then
+      PKG_ARCH=x86_64
+  elif [ "$TARGETARCH" = "arm64" ]; then
+      PKG_ARCH=aarch64
+  fi
+
 
   # NOTE: We include the `PROJECT` parameter here, even thought it is not
   # used, in order to maintain symmetry with the xrootd-build stage above.
@@ -409,9 +424,13 @@ RUN --mount=type=bind,from=xrootd-build,source=/xrootd-build,target=/xrootd-buil
 
     local SRC_BUILD=${ARG}_SRC_BUILD
     local VER=${ARG}_VER
+    local KOJI_URL=${ARG}_KOJI_URL
 
     if ${!SRC_BUILD}; then
       dnf install -y /xrootd-build/RPMS/*/${REPO}-*.rpm
+    elif [ -n "${!KOJI_URL-}" ]; then
+      echo ${!KOJI_URL} | sed "s/%ARCH%/${PKG_ARCH}/g" | xargs \
+          dnf install -y --enablerepo=epel-testing --enablerepo=osg-testing
     else
       dnf install -y --enablerepo=epel-testing --enablerepo=osg-testing --enablerepo=osg-upcoming-testing ${REPO}-${!VER}
     fi


### PR DESCRIPTION
This is necessary because xrdhttp-pelican is locked to a specific minor version of xrootd and we're pinning the xrootd version, so we can't just take whatever is the newest in the repos.

Take it from Koji if we're not building it ourselves.

This PR against 7.21 pins it to the version that is already in use in the v7.21.2-rc.1 images.