### PR TITLE
Update Classads library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ toolchain go1.24.7
 
 require (
 	github.com/JGLTechnologies/gin-rate-limit v1.5.4
-	github.com/PelicanPlatform/classad v0.0.3
+	github.com/PelicanPlatform/classad v0.0.5
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
 	github.com/charmbracelet/glamour v0.8.0
 	github.com/cyphar/filepath-securejoin v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/PelicanPlatform/classad v0.0.3 h1:mt0+HSbARaeNICM9L4GKVp88+s6BvzTU6AnD58NbHCE=
-github.com/PelicanPlatform/classad v0.0.3/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
+github.com/PelicanPlatform/classad v0.0.5 h1:1mBmZOeKdPp9yasbgAl4iVQmgaerA65iHDERkRBB7f8=
+github.com/PelicanPlatform/classad v0.0.5/go.mod h1:z1d5dXdX+1pxBi8f8Ab/yCX8zKyiLam9CtQHSykMlWQ=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=


### PR DESCRIPTION
This PR updates the classads library to v0.0.5. This version fixes a bug that prevented parsing of concatenated classads. See the [release notes](https://github.com/PelicanPlatform/classad/releases/tag/v0.0.5) for more details.
