### PR TITLE
Move PELICAN_MAXMINDKEY config handling into config package and deprecate

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1562,6 +1562,9 @@ func SetServerDefaults(v *viper.Viper) error {
 func InitServer(ctx context.Context, currentServers server_structs.ServerType) error {
 	InitConfigInternal(log.InfoLevel)
 
+	// Bind any legacy env vars to their new config params -- will generate warnings about deprecated env vars
+	bindLegacyServerEnv()
+
 	setEnabledServer(currentServers)
 
 	// Output warnings before the defaults are set. The SetServerDefaults function sets the default values

--- a/config/env.go
+++ b/config/env.go
@@ -266,3 +266,24 @@ func bindClassAdConfig() {
 		}
 	}
 }
+
+// Bind any legacy/deprecated server environment variables to their new config parameters.
+// The function should log any warnings about deprecation; this class of env vars is so old
+// these config parameters are not included in the params table, meaning
+// `config/config.go::handleDeprecatedConfig` will not catch them/log warnings.
+func bindLegacyServerEnv() {
+	prefixes := GetAllPrefixes()
+
+	// MAXMINDKEY
+	for _, prefix := range prefixes {
+		if val, isSet := os.LookupEnv(prefix.String() + "_MAXMINDKEY"); isSet {
+			log.Warningf("You are using a legacy/deprecated parameter '%s_MAXMINDKEY' to indicate the MaxMind license key. "+
+				"Support for this environment variable will be removed in a future release. Please use %s instead", prefix.String(),
+				param.Director_MaxMindKeyFile.GetName())
+
+			// Use SetDefault so that if both the env var and the config param are set, the config param takes precedence
+			viper.SetDefault(param.Director_MaxMindKeyFile.GetName(), val)
+			break
+		}
+	}
+}


### PR DESCRIPTION
Setting the MaxMind key file via this env var pre-dates Pelican being Pelican, and it looks like handling for this configuration never fully made it into the config package.

This PR moves the environment variable handling into the config package and logs a deprecation warning when users configure it.