### PR TITLE
Ensure goroutine always shuts down cleanly when the context is done

### DIFF
--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -271,6 +271,7 @@ func TestBroker(t *testing.T) {
 	require.NoError(t, param.Set("Federation.RegistryUrl", param.Server_ExternalWebUrl.GetString()))
 	listenerChan := make(chan any)
 	ctxQuick, deadlineCancel := context.WithTimeout(ctx, 5*time.Second) // Have shorter timeout for this handshake
+	defer deadlineCancel()
 
 	externalWebUrl, err := url.Parse(param.Server_ExternalWebUrl.GetString())
 	require.NoError(t, err)

--- a/broker/client.go
+++ b/broker/client.go
@@ -627,7 +627,7 @@ func LaunchRequestMonitor(ctx context.Context, egrp *errgroup.Group, sType serve
 			sleepDuration := time.Second + time.Duration(mrand.Intn(500))*time.Microsecond
 			select {
 			case <-ctx.Done():
-				return
+				return nil
 			default:
 				// Send a request to the broker for a connection reversal
 				reqReader.Reset(req)


### PR DESCRIPTION
It should not return an error when the context is complete; instead, return `nil` to indicate a clean shutdown.

Also ensure the broker test (which exposed the bug) cancels its context.

Fixes: #2913