### PR TITLE
Fix race condition in TestDirectorRegistration and goroutine leaks

### DIFF
--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -1377,7 +1377,7 @@ func TestStatusCodeErrorWrappingUpload(t *testing.T) {
 			var te *TransferErrors
 			if errors.As(err, &te) {
 				// Extract the first error from TransferErrors
-				if te.errors != nil && len(te.errors) > 0 {
+				if len(te.errors) > 0 {
 					if tsErr, ok := te.errors[0].(*TimestampedError); ok && tsErr != nil {
 						err = tsErr.err
 					} else {

--- a/cmd/object_put.go
+++ b/cmd/object_put.go
@@ -254,7 +254,8 @@ func putMain(cmd *cobra.Command, args []string) {
 
 	for _, src := range source {
 		isRecursive, _ := cmd.Flags().GetBool("recursive")
-		transferResults, result := client.DoPut(ctx, src, dest, isRecursive, options...)
+		transferResults, err := client.DoPut(ctx, src, dest, isRecursive, options...)
+		result = err
 		if result != nil {
 			lastSrc = src
 			break

--- a/cmd/plugin_stage.go
+++ b/cmd/plugin_stage.go
@@ -231,7 +231,7 @@ func processTransferInput(reader io.Reader, mountPrefixStr string, originPrefixP
 		return nil, nil, fmt.Errorf("Failed to parse ClassAd from stdin: %v", err), 1
 	}
 	inputList := classad.EvaluateAttr("TransferInput")
-	if err != nil || inputList.IsUndefined() {
+	if inputList.IsUndefined() {
 		// No TransferInput, no need to transform therefore we exit(0)
 		return nil, nil, fmt.Errorf("No transfer input found in classad, no need to transform."), 0
 	}

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -553,7 +553,7 @@ func TestPluginMulti(t *testing.T) {
 	for !done {
 		select {
 		case <-fed.Ctx.Done():
-			break
+			done = true
 		case resultAd, ok := <-results:
 			if !ok {
 				done = true
@@ -622,7 +622,7 @@ func TestPluginDirectRead(t *testing.T) {
 	for !done {
 		select {
 		case <-fed.Ctx.Done():
-			break
+			done = true
 		case resultAd, ok := <-results:
 			if !ok {
 				done = true
@@ -701,7 +701,7 @@ func TestPluginCorrectStartAndEndTime(t *testing.T) {
 	for !done {
 		select {
 		case <-fed.Ctx.Done():
-			break
+			done = true
 		case resultAd, ok := <-results:
 			if !ok {
 				done = true
@@ -1124,7 +1124,7 @@ func TestPluginRecursiveDownload(t *testing.T) {
 		for !done {
 			select {
 			case <-fed.Ctx.Done():
-				break
+				done = true
 			case resultAd, ok := <-results:
 				if !ok {
 					done = true

--- a/xrootd/origin_test.go
+++ b/xrootd/origin_test.go
@@ -74,7 +74,7 @@ func ensureXrdS3PluginAvailable(t *testing.T) {
 	appendEnvPaths("LD_LIBRARY_PATH")
 	appendEnvPaths("DYLD_LIBRARY_PATH")
 
-	pluginNames := []string{"libXrdS3.so", "libXrdS3-5.so", "libXrdS3.dylib", "libXrdS3-5.dylib"}
+	pluginNames := []string{"libXrdS3.so", "libXrdS3-5.so", "libXrdS3-6.so", "libXrdS3.dylib", "libXrdS3-5.dylib", "libXrdS3-6.dylib"}
 	for _, dir := range searchPaths {
 		for _, name := range pluginNames {
 			if _, err := os.Stat(filepath.Join(dir, name)); err == nil {


### PR DESCRIPTION
- Fix federation discovery race: Force GetFederation() to run immediately after setting config to prevent sync.Once from capturing empty viper state
- Fix nil pointer dereferences: Check for nil before calling Value() on cache lookups in 7 test cases
- Fix goroutine leaks: Properly capture and wait for cancel/egrp in TestDiscoverOriginCache, TestRedirects, and TestGetHealthTestFile

The sporadic test failure occurred when background goroutines called GetFederation() between ResetConfig() and param.Set(), causing the sync.Once to execute with empty config and cache that state permanently.

Fixes: #2918