### PR TITLE
Fix race condition in director advertise shutdown

### DIFF
--- a/director/director_api.go
+++ b/director/director_api.go
@@ -176,8 +176,10 @@ func LaunchTTLCache(ctx context.Context, egrp *errgroup.Group) {
 		clientIpRandAssignmentCache.Stop()
 		clientIpGeoOverrideCache.DeleteAll()
 		clientIpGeoOverrideCache.Stop()
+		directorAdMutex.Lock()
 		directorAds.DeleteAll()
 		directorAds.Stop()
+		directorAdMutex.Unlock()
 		log.Info("Director TTL cache eviction has been stopped")
 		return nil
 	})


### PR DESCRIPTION
The TestDirectorShutdown test was failing with a panic due to a race condition between the ttlcache library's internal eviction goroutine and code calling directorAds.Range().

Root Cause:
- directorAds.Range() iterates over the cache's internal linked list
- The cache's automatic eviction goroutine modifies the same list
- This causes concurrent read/write on the list, leading to nil pointer dereference when the list structure is accessed during modification

It's documented in the upstream docs that basically there's no way to do this correctly.  This was picked up as a panic in the tests during shutdown.

Changes:
1. Replaced all directorAds.Range() calls with directorAds.Items() in 4 locations (sendMyAd, listDirectors, forwardServiceAd, updateInternalDirectorCache). Items() returns a snapshot copy that is safe from concurrent modifications.

2. Added mutex locking around directorAds cleanup operations in LaunchTTLCache to prevent races during shutdown.

The fix prevents the entire class of bugs related to unsafe iteration over ttlcache while the eviction goroutine is running.

Fixes panic: invalid memory address or nil pointer dereference in container/list.(*Element).Next during TestDirectorShutdown