### PR TITLE
Prevent test suite from killing Docker init process

### DIFF
--- a/xrootd/restart.go
+++ b/xrootd/restart.go
@@ -141,6 +141,10 @@ func RestartXrootd(ctx context.Context, oldPids []int) (newPids []int, err error
 	// Step 1: Gracefully shutdown existing XRootD processes
 	log.Debug("Sending SIGTERM to existing XRootD processes")
 	for _, pid := range oldPids {
+		if pid <= 1 {
+			log.Warnf("Skipping restart signal for critical PID %d", pid)
+			continue
+		}
 		if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
 			log.WithError(err).Warnf("Failed to send SIGTERM to PID %d", pid)
 		}
@@ -168,6 +172,9 @@ func RestartXrootd(ctx context.Context, oldPids []int) (newPids []int, err error
 
 	// Force kill any remaining processes
 	for _, pid := range oldPids {
+		if pid <= 1 {
+			continue
+		}
 		process, err := os.FindProcess(pid)
 		if err == nil && process != nil {
 			if err := process.Signal(syscall.Signal(0)); err == nil {

--- a/xrootd/restart_test.go
+++ b/xrootd/restart_test.go
@@ -96,7 +96,7 @@ func TestRestartXrootd_NoProcesses(t *testing.T) {
 	var launchers []daemon.Launcher
 	egrp := &errgroup.Group{}
 	callback := func(int) {}
-	StoreRestartInfo(launchers, []int{1, 2}, egrp, callback, false, false, false)
+	StoreRestartInfo(launchers, []int{999999, 999998}, egrp, callback, false, false, false)
 
 	// Try to restart with empty PID list - should fail since there's no xrootd config
 	_, err := RestartXrootd(ctx, []int{})


### PR DESCRIPTION
Fixes #2944. This PR prevents the XRootD restart feature from killing PID 1 and updates the test to use dummy PIDs.
