### PR TITLE
Add CacheHit field to plugin output

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -969,6 +969,11 @@ func addDataToClassAd(resultAd *classad.ClassAd, result *client.TransferResults,
 				if adErr != nil {
 					log.Errorf("Failed to set DataAge%d: %s", attempt.Number, adErr)
 				}
+				// CacheHit is true if CacheAge > 0 (data was already in cache), false if CacheAge == 0 (cache miss)
+				adErr = developerData.Set(fmt.Sprintf("CacheHit%d", attempt.Number), attempt.CacheAge > 0)
+				if adErr != nil {
+					log.Errorf("Failed to set CacheHit%d: %s", attempt.Number, adErr)
+				}
 			}
 			if attempt.Error != nil {
 				adErr := developerData.Set(fmt.Sprintf("TransferError%d", attempt.Number), attempt.Error.Error())


### PR DESCRIPTION
Fixes #2851. This PR adds a field to the plugin developer data to indicate if the attempt fetched data that was cached. This is complementary to the DataAge field but a bit easier to understand implicitly.
