### PR TITLE
Correctly clean up progress bars for completed transfers

### DIFF
--- a/cmd/progress_bars.go
+++ b/cmd/progress_bars.go
@@ -104,8 +104,8 @@ func (pb *progressBars) launchDisplay(ctx context.Context) {
 				return nil
 			case <-ticker.C:
 				func() {
-					pb.lock.RLock()
-					defer pb.lock.RUnlock()
+					pb.lock.Lock()
+					defer pb.lock.Unlock()
 					for path := range pbMap {
 						pbMap[path].xfer = -1
 					}


### PR DESCRIPTION
## Summary

A `pelican object sync` or `pelican object get --recursive` involving hundreds of thousands of objects will no longer degrade in performance, as in transfer fewer and fewer objects per unit time, when progress bars are enabled (which is the default).

As a consequence, users might notice that progress bars are no longer displayed _at all_ for transfers that complete under ~0.5 seconds.

> [!Note]
> There is the potential for a pathological scenario where no progress bars are displayed because _all_  transfers are starting and completing too quickly. The solution for that is to implement an overall status indicator — for example, number of objects transferred out of total number to be transferred — which is out of the scope for this PR.

## Details

The linked issue contains a test bench that can be used to verify the fix in this PR, as well as the raw data for the graph below.

The linked issue also contains evidence implicating that the client's handling of progress bars is at fault.

The primary loop is over `pb.status`:

https://github.com/PelicanPlatform/pelican/blob/088217e13dd2d3536b553beac140aed9e0d65266/cmd/progress_bars.go#L112-L114

This map is populated via a callback from the transfer jobs, and keyed by the paths of the objects being transferred.

The fundamental problem is we never remove keys from `pb.status`, so long after the transfer for a path has completed and the progress bar has been removed from the display, we're still updating it:

https://github.com/PelicanPlatform/pelican/blob/088217e13dd2d3536b553beac140aed9e0d65266/cmd/progress_bars.go#L135-L136

The whole business around setting `pbMap[path].xfer = -1` _should_ be clearing out progress bars for completed transfers. **We need only delete keys from `pb.status` as appropriate,** so that the logic there actually plays out as intended.

And indeed, once we do so, we get a more reasonable behavior:

---
<img width="511" height="450" alt="Screenshot 2026-01-11 at 13 32 51" src="https://github.com/user-attachments/assets/58c492aa-0e0c-4116-a78b-5f44cdafba64" />

---
I would post screenshots of the relevant visualizations from pprof, but I can't find anything significant related to the progress bars anymore, which would suggest that it's below the threshold for caring about.