### PR TITLE
Enable checksumming on write for MultiUser plugin

### DIFF
--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -119,6 +119,7 @@ xrootd.export /.well-known
 {{- if .Origin.Multiuser}}
 ofs.osslib libXrdMultiuser.so default
 ofs.ckslib * libXrdMultiuser.so
+multiuser.checksumonwrite on
 {{- end}}
 {{- if .Server.DropPrivileges}}
 http.exthandler xrdpelican libXrdHttpPelican.so


### PR DESCRIPTION
Fixes #2943. This PR enables the checksum-on-write feature of the `xrootd-multiuser` plugin. Enabling this option should fix the issue of missing checksums for folks using the multiuser plugin.
