### PR TITLE
Sync JWKS URI

### DIFF
--- a/director/discovery.go
+++ b/director/discovery.go
@@ -184,10 +184,10 @@ func federationDiscoveryHandler(ctx *gin.Context) {
 
 	jwksUri := fedInfo.JwksUri
 	if jwksUri == "" {
-		log.Error("Bad server configuration: fail to get JwksUri: ", err)
+		log.Error("Bad server configuration: Director is missing federation keys (jwks_uri is empty)")
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
-			Msg:    "Bad server configuration: unable to get JwksUri",
+			Msg:    "Bad server configuration: Director is missing federation keys (jwks_uri is empty)",
 		})
 		return
 	}


### PR DESCRIPTION
This PR syncs the JWKS URI in federation discovery endpoint `/.well-known/pelican-configuration` with the JWKS URI in Pelican process' global federation metadata `pelican_url.FederationDiscovery`

- Before this PR, the JWKS URI in federation discovery endpoint is just appending `/.well-known/pelican-configuration` to Director URL, even though the Discovery URL is set. This means the JWKS URI provided by Discovery URL may contain a different set of keys.
~~But this may be intentional! Director should advertise its own key endpoint rather than potentially pointing to a different server's JWKS URI.~~

> A quick recap: In `discoverFederationImpl` func, `fedInfo.JwksUri` will first fill with the value of the `Federation.JwkUrl` config param. If it is not set, that function will probe Discovery Endpoint to get the `jwks_uri` there. At last, if `fedInfo.JwksUri` is still empty, it will fallbacks to Director's externalUrl + "/.well-known/issuer.jwks"

- This PR will work with #3008. [How does they work?](https://github.com/PelicanPlatform/pelican/pull/3009#issuecomment-3786059290)
- ~~This PR was intended to replace #3008. But I realize maybe the good practice for a server is using its own JWKS URI, instead of pointing to another's, even though there might be discrepancy for the keys between them! We should still use a dedicated goroutine to monitor the discrepancy, as in #3008. So I just close this PR.~~