### PR TITLE
Use `bsdtar` to work around a bug with ARM64 emulation and `tar`

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -650,8 +650,16 @@ ARG TARGETARCH
 ARG GO_VER
 
 # Install select development packages.
+# We need to work around a bug with ARM64 emulation and `tar`:
+#
+#   - Issue: https://github.com/tonistiigi/binfmt/issues/285
+#   - Workaround: https://github.com/apollographql/apollo-runtime/pull/71
+#
+# The locale settings below should match the defaults in /etc/locale.conf
+# and are necessary for `bsdtar` to be able to extract the Go distribution.
+ENV LANG=C.utf8 LC_ALL=C.utf8
 RUN --mount=type=cache,id=dnf-${TARGETPLATFORM},target=/var/cache/dnf,sharing=locked \
-  dnf install -y git make
+  dnf install -y git make bsdtar && ln -sf /usr/bin/bsdtar /usr/bin/tar
 
 # Install Go using the same commands as the pelican-build-init stage.
 RUN curl -O https://dl.google.com/go/go${GO_VER}.${TARGETOS}-${TARGETARCH}.tar.gz \


### PR DESCRIPTION
## Summary

Having identified the the source of our build woes in #3063, we will take inspiration from https://github.com/apollographql/apollo-runtime/pull/71 and replace `tar` in our test and dev containers with `bsdtar`.

## Other remarks

The long-term fix is #3051 and moving away from emulated builds. In the meantime, I'm willing to tolerate this divergence between the test container and the actual runtime containers. (If explicitly setting `LANG` and `LC_ALL` reveals or masks an issue, that's probably interesting in an of itself.)