### PR TITLE
Add docker-compose method for developing website

### DIFF
--- a/web_ui/frontend/README.md
+++ b/web_ui/frontend/README.md
@@ -6,14 +6,23 @@ This ui is generated with Next.js.
 
 ### Setup
 
-To develop the Pelican frontend you must run the backend in a separately, as well as set up a proxy to serve your backend and frontend requests from the same host.
+To quickly develop the Pelican frontend you can run the Pelican backend and NextJS frontend separately, as well as set up a proxy to serve them both from the same host.
+
+**Remember to replace the volume with the binary location in the `docker-compose.yml` file to your local pelican binary.**
 
 ```shell
 docker compose run pelican-builder
 docker compose up pelican-server pelican-api-proxy
 ```
 
-If you would like to proxy the prometheus requests to another service you can do so by filling out .env.template and placing it as .env.local.
+If you would like to proxy the prometheus requests to another service you can do so by filling out `./dev/env.template` and placing it as `./dev/env.local`.
+
+`./dev/env.local`
+
+```shell
+API_URL=https://origin.test.org
+API_PASSWORD=password
+```
 
 ### Running the Frontend
 

--- a/web_ui/frontend/docker-compose.yml
+++ b/web_ui/frontend/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     working_dir: /app
     volumes:
       - ../../:/app
-    command: --clean --snapshot --config .goreleaser.dev.yml
+    command: --clean --snapshot --config .goreleaser.yml
 
   # Run pelican server with all modules
   pelican-server:
@@ -14,7 +14,7 @@ services:
       - '8444:8444'
     working_dir: /app
     volumes:
-      - ../../dist/pelican_linux_arm64_v8.0/:/app
+      - ../../dist/pelican_linux_arm64_v8.0/:/app # Replace with the correct path to the built binary
       - ../../local/:/etc/pelican/
     command: ./pelican serve --module director,registry,origin,cache
 
@@ -28,6 +28,6 @@ services:
     ports:
       - '8443:8443'
     env_file:
-      - ./dev/.env.local
+      - ./dev/.env.local # You can comment this out if you don't have a .env.local file
     stdin_open: true
     tty: true


### PR DESCRIPTION
Adds a docker compose file to simplify the setup and running of the the api and reverse proxy when you are developing the frontend.