### PR TITLE
Convert unneeded warning to debug statement

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -4603,7 +4603,7 @@ func objectCached(ctx context.Context, objectUrl *url.URL, token *tokenGenerator
 	// Allow response body to fail to read; we are only interested in the headers
 	// of the response, not the contents.
 	if _, err := io.Copy(io.Discard, headResponse.Body); err != nil {
-		log.Warningln("Failure when reading the one-byte-response body:", err)
+		log.Debugln("Failure when reading the one-byte-response body - expected because the body is discarded:", err)
 	}
 	headResponse.Body.Close()
 	gotContentRange := false


### PR DESCRIPTION
Closes #2939

Converts an expected warning (so not something a general user should see/care about) into a debug statement.

