### PR TITLE
Fixed an issue where Cache.DirectorTest is not enabled by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1350,7 +1350,6 @@ func SetServerDefaults(v *viper.Viper) error {
 	}
 	v.SetDefault(param.Origin_SelfTestMaxAge.GetName(), 1*time.Hour)
 	v.SetDefault(param.Cache_SelfTestMaxAge.GetName(), 1*time.Hour)
-	v.SetDefault(param.Origin_DirectorTest.GetName(), true)
 	// Set up the default S3 URL style to be path-style here as opposed to in the defaults.yaml because
 	// we want to be able to check if this is user-provided (which we can't do for defaults.yaml)
 	v.SetDefault(param.Origin_S3UrlStyle.GetName(), "path")

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -65,6 +65,7 @@ Director:
   FedTokenLifetime: 15m
 Cache:
   DefaultCacheTimeout: "9.5s"
+  DirectorTest: true
   EnableBroker: true
   EnablePrefetch: true
   SelfTest: true
@@ -88,6 +89,7 @@ LocalCache:
   HighWaterMarkPercentage: 95
   LowWaterMarkPercentage: 85
 Origin:
+  DirectorTest: true
   Multiuser: false
   EnableMacaroons: false
   EnableVoms: true

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1944,6 +1944,7 @@ description: |+
   A bool indicating whether the director should send file transfer tests to the cache.
 type: bool
 default: true
+hidden: true
 components: ["cache"]
 ---
 name: Cache.EnableOIDC

--- a/server_utils/monitor.go
+++ b/server_utils/monitor.go
@@ -54,15 +54,7 @@ func notifyNewDirectorResponse(ctx context.Context, nChan chan bool) {
 // Launch a go routine in errorgroup to report timeout if director-based health test
 // response was not sent within the defined time limit
 func LaunchPeriodicDirectorTimeout(ctx context.Context, egrp *errgroup.Group, nChan chan bool) {
-	// Check if director tests are enabled based on server type
-	directorTestEnabled := false
-	if param.Origin_DirectorTest.GetBool() {
-		directorTestEnabled = true
-	} else if param.Cache_DirectorTest.GetBool() {
-		directorTestEnabled = true
-	}
-
-	if !directorTestEnabled {
+	if !param.Cache_DirectorTest.GetBool() && !param.Origin_DirectorTest.GetBool() {
 		metrics.SetComponentHealthStatus(metrics.OriginCache_Director, metrics.StatusOK, "Origin.DirectorTest and Cache.DirectorTest are set to false. No director tests expected.")
 		return
 	}


### PR DESCRIPTION
-- Enables Cache.DirectorTest by default
-- Moves the defaults into defaults.yaml
-- Cleans up a little bit of monitoring code
-- Makes the parameter hidden, this isn't something we want to advertise

Will close #3096 