### PR TITLE
Require the xrdhttp-pelican >= 0.0.10 RPM for pelican-server (#3086)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -467,6 +467,7 @@ nfpms:
           - "xrootd-server >= 1:5.8.2"
           - "xrootd-scitokens"
           - "xrootd-voms"
+          - "xrdhttp-pelican >= 0.0.10"
       deb:
         provides:
           - "pelican-origin (= 7)"


### PR DESCRIPTION
The dependencies for Debian were not changed because xrdhttp-pelican Debs are not available. Closes #3086 .