### PR TITLE
Fix test race conditions in `xrootd_config_test.go`

### DIFF
--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -78,11 +78,11 @@ func setupXrootd(t *testing.T, ctx context.Context, server server_structs.Server
 func TestXrootDOriginConfig(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	server_utils.ResetTestState()
-	defer server_utils.ResetTestState()
 	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
 	t.Cleanup(func() {
 		cancel()
 		require.NoError(t, egrp.Wait())
+		server_utils.ResetTestState()
 	})
 
 	tests := []struct {
@@ -370,11 +370,10 @@ func TestUpdateAuth(t *testing.T) {
 	t.Cleanup(func() {
 		cancel()
 		require.NoError(t, egrp.Wait())
+		server_utils.ResetTestState()
 	})
 
 	server_utils.ResetTestState()
-
-	defer server_utils.ResetTestState()
 
 	require.NoError(t, param.Set(param.Logging_Level.GetName(), "Debug"))
 	require.NoError(t, param.Set(param.Origin_RunLocation.GetName(), runDirname))
@@ -774,6 +773,7 @@ func TestAutoShutdownOnStaleAuthfile(t *testing.T) {
 	t.Cleanup(func() {
 		cancel()
 		require.NoError(t, egrp.Wait())
+		server_utils.ResetTestState()
 	})
 
 	require.NoError(t, param.Set(param.Logging_Level.GetName(), "Debug"))


### PR DESCRIPTION
There were two different race conditions, both related to the ordering of cleanup functions. I recommend the reviewer review each commit and the corresponding message, as I describe the issues more thoroughly there.

While it's a bit hard to reproduce test failures when they're not guaranteed, here are the two issues I faced running tests periodically on my laptop:
1. `TestCopyCertificates()` was failing ~1/3 of the time. Before this diff, running it a handful of times was usually enough to produce a failure. After the diff, I ran ~10 consecutive times and didn't find a failure. Assuming I'm in the right ballpark for how often the test failed initially, then the probability the test doesn't fail after 10 attempts while the underlying bug isn't fixed is `(1-1/3)^10 ~= 0.017`. To me, this strongly suggests the fix is correct.
2. Running the entire suite of `xrootd` package tests sometimes left a garbage test file at `xrootd/cache-authfile-generated`. I was really confused about why this was showing up there and not in a temp dir, especially because I didn't see any tests that weren't properly configured with a temp config dir. As it turns out, the issue was that resetting viper before the `LaunchXrootdMaintenance` routine finished could result in writing the auto-generated files to the current directory. I have less intuition about how often this was happening, but I re-ran the entire package tests ~5 times and didn't see the vestigial test file.