### PR TITLE
Suppress CodeQL false positives for filepath fields

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,14 @@
+name: "Pelican CodeQL Configuration"
+
+# Run the default queries plus our custom replacements.
+queries:
+  - uses: ./.github/codeql/go
+
+query-filters:
+  # Exclude the built-in go/clear-text-logging query. Our replacement in
+  # .github/codeql/go/CleartextLogging.ql keeps the same @id and logic but
+  # adds an allowlist for struct fields that hold file *paths* rather than
+  # secrets (S3SecretKeyfile, UIPasswordFile, PasswordLocation).
+  - exclude:
+      id: go/clear-text-logging
+      query path: /^Security\//

--- a/.github/codeql/go/CleartextLogging.ql
+++ b/.github/codeql/go/CleartextLogging.ql
@@ -1,0 +1,43 @@
+/**
+ * @name Clear-text logging of sensitive information (Pelican)
+ * @description Logging sensitive information without encryption or hashing can
+ *              expose it to an attacker. This is a Pelican-specific version of
+ *              go/clear-text-logging that excludes fields that store file paths
+ *              rather than secrets (S3SecretKeyfile, UIPasswordFile,
+ *              PasswordLocation).
+ * @kind path-problem
+ * @problem.severity error
+ * @security-severity 7.5
+ * @precision high
+ * @id go/clear-text-logging
+ * @tags security
+ *       external/cwe/cwe-312
+ *       external/cwe/cwe-315
+ *       external/cwe/cwe-359
+ */
+
+import go
+import semmle.go.security.CleartextLogging
+import CleartextLogging::Flow::PathGraph
+
+/**
+ * Holds if the source node refers to a field that stores a file path rather
+ * than the secret itself (e.g. S3SecretKeyfile, UIPasswordFile,
+ * PasswordLocation). These are false positives because logging a *path* does
+ * not expose the secret contained in the file at that path.
+ */
+predicate isSafeFilepathField(CleartextLogging::Source source) {
+  source
+      .describe()
+      .regexpMatch("(?i).*(" +
+          "S3SecretKeyfile|" +
+          "UIPasswordFile|" +
+          "PasswordLocation" + ").*")
+}
+
+from CleartextLogging::Flow::PathNode source, CleartextLogging::Flow::PathNode sink
+where
+  CleartextLogging::Flow::flowPath(source, sink) and
+  not isSafeFilepathField(source.getNode())
+select sink.getNode(), source, sink, "$@ flows to a logging call.", source.getNode(),
+  "Sensitive data returned by " + source.getNode().(CleartextLogging::Source).describe()

--- a/.github/codeql/go/codeql-pack.lock.yml
+++ b/.github/codeql/go/codeql-pack.lock.yml
@@ -1,0 +1,24 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/concepts:
+    version: 0.0.15
+  codeql/controlflow:
+    version: 2.0.25
+  codeql/dataflow:
+    version: 2.0.25
+  codeql/go-all:
+    version: 6.0.1
+  codeql/mad:
+    version: 1.0.41
+  codeql/ssa:
+    version: 2.0.17
+  codeql/threat-models:
+    version: 1.0.41
+  codeql/tutorial:
+    version: 1.0.41
+  codeql/typetracking:
+    version: 2.0.25
+  codeql/util:
+    version: 2.0.28
+compiled: false

--- a/.github/codeql/go/qlpack.yml
+++ b/.github/codeql/go/qlpack.yml
@@ -1,0 +1,4 @@
+name: pelican/go-custom
+version: 0.0.0
+dependencies:
+  codeql/go-all: "*"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,6 +44,7 @@ jobs:
       uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
+        config-file: ./.github/codeql/codeql-config.yml
 
     # Autobuild attempts to build any compiled languages.
     # If this step fails, then you should remove it and run the build manually (see below).


### PR DESCRIPTION
Add a custom replacement for the built-in go/clear-text-logging query that allowlists S3SecretKeyfile, UIPasswordFile, and PasswordLocation. These struct fields store file paths, not secrets, so logging them is safe.