### PR TITLE
Revert "Handle legacy Capability name gracefully"

### DIFF
--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -51,28 +51,13 @@ type (
 		CredentialIssuer url.URL      `json:"issuer"`
 	}
 
+	// Note that the json are kept in uppercase for backward compatibility
 	Capabilities struct {
-		PublicReads bool `json:"PublicReads"`
-		Reads       bool `json:"Reads"`
-		Writes      bool `json:"Writes"`
-		Listings    bool `json:"Listings"`
-		DirectReads bool `json:"DirectReads"`
-	}
-
-	// Supports both old and new JSON field names
-	capabilitiesCompat struct {
-		// New field names
-		PublicReads bool `json:"PublicReads"`
-		Reads       bool `json:"Reads"`
-		Writes      bool `json:"Writes"`
-		Listings    bool `json:"Listings"`
-		DirectReads bool `json:"DirectReads"`
-		// Old field names (for backward compatibility)
-		PublicRead   bool `json:"PublicRead"`
-		Read         bool `json:"Read"`
-		Write        bool `json:"Write"`
-		Listing      bool `json:"Listing"`
-		FallBackRead bool `json:"FallBackRead"`
+		PublicReads bool `json:"PublicRead"`
+		Reads       bool `json:"Read"`
+		Writes      bool `json:"Write"`
+		Listings    bool `json:"Listing"`
+		DirectReads bool `json:"FallBackRead"`
 	}
 
 	NamespaceAdV2 struct {
@@ -336,24 +321,6 @@ const (
 // Indicate the downtime is ongoing indefinitely.
 // We chose -1 to avoid the default value (0) of the int64 type
 const IndefiniteEndTime int64 = -1
-
-// Custom JSON unmarshalling for Capabilities to support backward compatibility.
-// Old field names from origins/caches running Pelican earlier than v7.22.0 will be converted to the new field names.
-func (c *Capabilities) UnmarshalJSON(data []byte) error {
-	var compat capabilitiesCompat
-	if err := json.Unmarshal(data, &compat); err != nil {
-		return err
-	}
-
-	// Use new field names if set, otherwise fall back to old field names
-	c.PublicReads = compat.PublicReads || compat.PublicRead
-	c.Reads = compat.Reads || compat.Read
-	c.Writes = compat.Writes || compat.Write
-	c.Listings = compat.Listings || compat.Listing
-	c.DirectReads = compat.DirectReads || compat.FallBackRead
-
-	return nil
-}
 
 func (x XPelNs) GetName() string {
 	return "X-Pelican-Namespace"

--- a/web_ui/frontend/components/CapabilitiesDisplay.tsx
+++ b/web_ui/frontend/components/CapabilitiesDisplay.tsx
@@ -54,7 +54,9 @@ export const CapabilitiesChip = ({
         overflow: 'hidden',
       }}
     >
-      <Typography variant={'body2'}>{name}</Typography>
+      <Typography variant={'body2'}>
+        {CAPABILITY_LABEL_MAP[name] || name}
+      </Typography>
       <Box display={'flex'}>
         {value ? <Check fontSize='small' /> : <Clear fontSize='small' />}
       </Box>
@@ -71,4 +73,12 @@ export const CapabilityChipStyle = {
   mb: 0.2,
   border: '1px 1px solid black',
   backgroundColor: green[300],
+};
+
+const CAPABILITY_LABEL_MAP: Record<string, string> = {
+  PublicRead: 'PublicReads',
+  Read: 'Reads',
+  Write: 'Writes',
+  Listing: 'Listings',
+  FallBackRead: 'DirectReads',
 };

--- a/web_ui/frontend/types.ts
+++ b/web_ui/frontend/types.ts
@@ -1,9 +1,9 @@
 export interface Capabilities {
-  PublicReads: boolean;
-  Reads: boolean;
-  Writes: boolean;
-  Listings: boolean;
-  DirectReads: boolean;
+  PublicRead: boolean;
+  Read: boolean;
+  Write: boolean;
+  Listing: boolean;
+  FallBackRead: boolean;
 }
 
 export interface TokenGeneration {


### PR DESCRIPTION
Reverts PelicanPlatform/pelican#2841

This caused backwards compatibility issues between a new v7.24 Director and old Caches. The issue is that old Caches call the `/api/v2.0/director/listNamespaces` API to grab all namespace policies when constructing scitokens/authfile configurations. Old caches hitting the new Director get a JSON they don't recognize, preventing them from constructing the correct access policies.

I'm reverting this to unblock the `v7.24` release process while Howard is out, but here are a few potential options I propose for the next attempt at this fix:
- We create a `v3` API endpoint that returns the new JSON structure while preserving the `v2` behavior (we should probably never be changing the response given by an API without bumping its version)
- We give Caches the ability to detect/handle both JSON objects and then retire the old JSON once there are no longer any Caches in OSDF that expect it
- We wait until pelican `v26` and we break backwards compatibility to our hearts' content
