### PR TITLE
Require Server.EnableUI = true for Globus backend

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1746,6 +1746,9 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 				return errors.Wrap(err, "unable to parse Origin.HTTPServiceUrl as a URL")
 			}
 		case "globus":
+			if !param.Server_EnableUI.GetBool() {
+				return errors.Errorf("%s must be true when %s is set to globus", param.Server_EnableUI.GetName(), param.Origin_StorageType.GetName())
+			}
 			pvd, err := GetOIDCProdiver()
 			if err != nil || pvd != Globus {
 				log.Info("Server OIDC provider is not Globus. Use Origin.GlobusClientIDFile instead")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -869,6 +869,25 @@ Logging:
 	require.NoError(t, err)
 }
 
+func TestInitServerGlobusBackendRequiresUI(t *testing.T) {
+	ResetConfig()
+	t.Cleanup(func() {
+		ResetConfig()
+	})
+
+	mockFederationRoot(t)
+	require.NoError(t, param.Set("ConfigDir", t.TempDir()))
+	require.NoError(t, param.Set(param.Origin_StorageType.GetName(), "globus"))
+	require.NoError(t, param.Set(param.Server_EnableUI.GetName(), false))
+	require.NoError(t, param.Set(param.OIDC_Issuer.GetName(), "globus"))
+
+	err := InitServer(context.Background(), server_structs.OriginType)
+	require.Error(t, err)
+	require.ErrorContains(t, err, param.Server_EnableUI.GetName())
+	require.ErrorContains(t, err, param.Origin_StorageType.GetName())
+	require.ErrorContains(t, err, "globus")
+}
+
 func TestDiscoverFederationImpl(t *testing.T) {
 	testCases := []struct {
 		name                  string


### PR DESCRIPTION
A Globus origin requires a functioning web UI to perform OAuth flow. However, this wasn't checked previously. This PR adds a validation check. This fixes #3139.
