### PR TITLE
Update authenticated block to not render content you aren't auth'd for

### DIFF
--- a/web_ui/frontend/components/layout/AuthenticatedContent.tsx
+++ b/web_ui/frontend/components/layout/AuthenticatedContent.tsx
@@ -41,6 +41,7 @@ interface AuthenticatedContentProps {
   promptLogin?: boolean;
   redirect?: boolean;
   trustThenValidate?: boolean;
+  preloadChildren?: boolean;
   boxProps?: BoxProps;
   allowedRoles?: User['role'][];
   replace?: boolean;
@@ -52,6 +53,7 @@ interface AuthenticatedContentProps {
  * @param promptLogin If true then the user will be prompted to login if they are not authenticated
  * @param redirect If true then the user will be redirected to the login page if they are not authenticated
  * @param trustThenValidate If true then the user will be shown the content if they are not authenticated but will be validated after
+ * @param preloadChildren If true then the children will be preloaded even if the user is not authenticated. This is useful for pages that require authentication but want to show a skeleton while loading.
  * @param boxProps The props to pass to the Box component
  * @param allowedRoles The roles that are allowed to see the content
  * @param replace If true then the
@@ -62,6 +64,7 @@ const AuthenticatedContent = ({
   promptLogin = false,
   redirect = false,
   trustThenValidate = false,
+  preloadChildren = false,
   children,
   boxProps,
   allowedRoles,
@@ -124,7 +127,7 @@ const AuthenticatedContent = ({
         }}
       >
         <Skeleton variant='rounded' height={'100%'} width={'100%'}>
-          {authenticated && children}
+          {preloadChildren && children}
         </Skeleton>
       </Box>
     );


### PR DESCRIPTION
Adds an off by default param that allows children of the auth block to be preloaded to properly size the loading box. 

Useful to turn on if your content will not throw errors when un authenticated.

The linked bug was being caused by the child block that was calling out to a authenticated endpoint being rendered for the sake of getting its dimensions for a loading box. On render that component was making auth'd calls and reporting failures. 

This prevents that by default but allows for the possibility of a component that is smart enough to do its own error catching before it is shown to render.