### PR TITLE
Enable "third-party copies" in origins out-of-the box

### DIFF
--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+# Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you
 # may not use this file except in compliance with the License.  You may
@@ -176,6 +176,9 @@ xrd.network nodnr
 scitokens.trace {{.Logging.OriginScitokens}}
 
 http.maxdelay {{.Xrootd.HttpMaxDelay}}
+
+# Enable third-party copies
+http.exthandler xrdtpc libXrdHttpTPC.so
 
 # Add in http headers to make the web client capable of requesting resources
 http.staticheader -verb=OPTIONS Access-Control-Allow-Origin *


### PR DESCRIPTION
## Summary

The XRootD software stack that underpins a Pelican origin supports a "third-party copy" mode that enables one origin to copy data directly from another origin.

This is useful when the ultimate goal is to transfer data between two object stores, each of which has a Pelican origin sitting in front of it, because it eliminates the need to stage the data at some intermediate store.

This PR enables the feature by default.

## Other details

To test this PR, you'll need to build a client off of #3141.

With this change, we're one-away from hitting the limit for [the number of `http.exthandler`s that can be configured](https://xrootd.web.cern.ch/doc/dev57/xrd_config.htm#_Toc171720007).

Closes #3147.