### PR TITLE
Fail-stop multiple origin config for globus (for now)

### DIFF
--- a/server_utils/origin.go
+++ b/server_utils/origin.go
@@ -421,6 +421,13 @@ func (b *BaseOrigin) validateExports(o Origin) (err error) {
 		return errors.New("no exports configured")
 	}
 
+	// The XRootD Globus backend currently generates a single backend stanza.
+	// Rejecting multiple exports here avoids silently configuring only the
+	// first export in the list.
+	if o.Type(o) == server_structs.OriginStorageGlobus && len(b.Exports) > 1 {
+		return errors.Errorf("globus backend does not yet support multiple exports, but %d were provided", len(b.Exports))
+	}
+
 	if err = handleIssuersIfNeeded(b.Exports); err != nil {
 		return errors.Wrap(err, "failed to validate export issuer URLs")
 	}

--- a/server_utils/origin_test.go
+++ b/server_utils/origin_test.go
@@ -590,47 +590,9 @@ func TestGetExports(t *testing.T) {
 		assert.Equal(t, "Pelican >> Globus!", viper.GetString("Origin.GlobusCollectionName"))
 	})
 
-	t.Run("testMultiExportValidGlobus", func(t *testing.T) {
+	t.Run("testMultiExportInvalidGlobus", func(t *testing.T) {
 		defer ResetTestState()
-		exports := setup(t, globusMultiExport, false)
-
-		expectedExport1 := OriginExport{
-			FederationPrefix:     "/first/namespace",
-			StoragePrefix:        "/foo",
-			GlobusCollectionID:   "abc123",
-			GlobusCollectionName: "Pelican >> Globus!",
-			Capabilities: server_structs.Capabilities{
-				Writes:      false,
-				PublicReads: true,
-				Listings:    false,
-				Reads:       true,
-				DirectReads: true,
-			},
-			IssuerUrls: []string{defaultIssuerUrl},
-		}
-
-		expectedExport2 := OriginExport{
-			FederationPrefix:     "/second/namespace",
-			StoragePrefix:        "/bar",
-			GlobusCollectionID:   "123abc",
-			GlobusCollectionName: "Globus << Pelican!",
-			Capabilities: server_structs.Capabilities{
-				Writes:      false,
-				PublicReads: true,
-				Listings:    false,
-				Reads:       true,
-				DirectReads: true,
-			},
-			// No issuer is populated because there are no namespaces requiring it
-		}
-
-		assert.Len(t, exports, 2, "expected 2 exports")
-		assert.Equal(t, expectedExport1, exports[0])
-		assert.Equal(t, expectedExport2, exports[1])
-		assert.NotEqual(t, "SHOULD-OVERRIDE-TEMPFILE", viper.GetString("Origin.GlobusClientIDFile"), "GlobusClientIDFile was not overridden from config")
-		assert.NotEmpty(t, viper.GetString("Origin.GlobusClientIDFile"))
-		assert.NotEqual(t, "SHOULD-OVERRIDE-TEMPFILE", viper.GetString("Origin.GlobusClientSecretFile"), "GlobusClientSecretFile was not overridden from config")
-		assert.NotEmpty(t, viper.GetString("Origin.GlobusClientSecretFile"))
+		_ = setup(t, globusMultiExport, true)
 	})
 
 	// XRoot Origin tests


### PR DESCRIPTION
Fixes #3163 

We validate that the export doesn't configure multiple origins. I also inverted the "multiple origin export for Globus" unit test