### PR TITLE
Fix formatting for deprecated metrics section

### DIFF
--- a/docs/app/monitoring-pelican-services/prometheus/page.mdx
+++ b/docs/app/monitoring-pelican-services/prometheus/page.mdx
@@ -765,7 +765,7 @@ The URL of the server.
 
 The following metrics are deprecated and will be removed in a future release.
 
-- `pelican_director_geoip_errors`: [Deprecated -- split into separate client/server metrics (pelican_director_maxmind_{server,client}_errors_total)] The total number of errors encountered trying to resolve coordinates using the GeoIP MaxMind database.
+- `pelican_director_geoip_errors`: [Deprecated -- split into separate client/server metrics (pelican_director_maxmind_\{server,client\}_errors_total)] The total number of errors encountered trying to resolve coordinates using the GeoIP MaxMind database.
 - `xrootd_monitoring_packets_received`: Renamed to `xrootd_monitoring_packets_received_total`.
 - `xrootd_transfer_readv_segments_count`: Renamed to `xrootd_transfer_readv_segments_total`.
 - `xrootd_transfer_operations_count`: Renamed to `xrootd_transfer_operations_total`.


### PR DESCRIPTION
Fixed a issue with unescaped {} in mdx. These are reserved characters intended to contain `js` blocks.

This will have to be patched into the 7.23 tag so that we have a fixed build there.

Image rendered after I fixed. I also built the website with this fix in place and it built just fine.

<img width="1512" height="982" alt="Screenshot 2026-03-05 at 12 19 58 PM" src="https://github.com/user-attachments/assets/8c7d72af-d19e-4041-b612-936f1153ed60" />