### PR TITLE
Update to xrdhttp-pelican v0.0.11

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -479,7 +479,7 @@ nfpms:
           - "xrootd-server >= 1:5.8.2"
           - "xrootd-scitokens"
           - "xrootd-voms"
-          - "xrdhttp-pelican >= 0.0.10"
+          - "xrdhttp-pelican >= 0.0.11"
       deb:
         provides:
           - "pelican-origin (= 7)"

--- a/github_scripts/osx_install.sh
+++ b/github_scripts/osx_install.sh
@@ -79,7 +79,7 @@ popd
 
 git clone https://github.com/PelicanPlatform/xrdhttp-pelican.git
 pushd xrdhttp-pelican
-git checkout v0.0.10
+git checkout v0.0.11
 mkdir build
 cd build
 cmake .. -GNinja -DCMAKE_INSTALL_PREFIX="$PWD/release_dir"

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -83,7 +83,7 @@ ARG XROOTD_S3_HTTP_SRC_BUILD=true
 ARG XROOTD_S3_HTTP_VER=0.6.4
 # Installed from Koji if not building it from source.
 ARG XRDHTTP_PELICAN_SRC_BUILD=false
-ARG XRDHTTP_PELICAN_VER=0.0.10
+ARG XRDHTTP_PELICAN_VER=0.0.11
 ARG XRDHTTP_PELICAN_RELEASE="1.osg${OSG_SERIES}.${BASE_OS}"
 
 # For controlling the version of OA4MP that is installed.


### PR DESCRIPTION
This new xrdhttp-pelican version (v0.0.11) fixes the federation token refresh failure in drop priviledges mode https://github.com/PelicanPlatform/xrdhttp-pelican/pull/23, and other small compability issues https://github.com/PelicanPlatform/xrdhttp-pelican/pull/22

This needs to be backported to 7.24 to actually test the drop-privileges feature in origin/cache.