### PR TITLE
Setup `pre-commit` to use Python 3.13 in the dev container

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -844,6 +844,8 @@ RUN --mount=type=bind,source=go.mod,target=/context/go.mod \
         gcc-c++ \
         graphviz \
         nano \
+        python3.13 \
+        python3.13-pip \
         systemd \
         valgrind \
         vim \
@@ -853,7 +855,7 @@ RUN --mount=type=bind,source=go.mod,target=/context/go.mod \
         libcap-devel \
         libuuid-devel \
         openssl-devel \
-        python3-devel \
+        python3.13-devel \
         sqlite-devel \
         tinyxml2-devel \
         zlib-devel \
@@ -868,7 +870,7 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 # Suppress Git's "dubious ownership" warning.
 ENV GOFLAGS="-buildvcs=false"
 
-RUN python3 -m pip --no-cache-dir install pre-commit
+RUN python3.13 -m pip --no-cache-dir install pre-commit
 COPY images/dev-config.yaml /etc/pelican/pelican.yaml
 WORKDIR /app
 COPY ./images/dev-container-entrypoint.sh /dev-container-entrypoint.sh


### PR DESCRIPTION
## Summary

Fixes #3203 by using a non-EOL version of Python in the dev container image.

## Details

As [mentioned in the linked issue](https://github.com/PelicanPlatform/pelican/issues/3203#issuecomment-4027363220), I'm loathe to modify the system-level Python install, so this PR does the next best thing: Install a version of Python (3.13) that won't go EOL until sometime in the year 2029 (~3 years from when I'm writing this comment), and use _that_ Python installation to install `pre-commit`.

Because `pre-commit` uses the Python installation it was installed with to create its virtual environments, this should resolve the original issue.

**The fly in the ointment:** The `pre-commit` package is still being installed as `root`, which means its script gets installed into a system-level location (`/usr/local/bin` last I looked). If someone later comes along and uses the system-level Python (3.9) to install `pre-commit`, hilarity and confusion will ensue. I'm assuming that this is a sufficiently remote possibility that need not be accounted for…