### PR TITLE
Force Login on Oauth Flow

### DIFF
--- a/oa4mp/proxy.go
+++ b/oa4mp/proxy.go
@@ -29,6 +29,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -50,21 +51,22 @@ import (
 var (
 	// We have a custom transport object based on the common code in `config`;
 	// this is because we need a custom dialer to talk to OA4MP over a socket.
-	transport *http.Transport
+	transport http.RoundTripper
 
 	onceTransport sync.Once
 )
 
-func getTransport() *http.Transport {
+func getTransport() http.RoundTripper {
 	onceTransport.Do(func() {
 		socketName := filepath.Join(param.Issuer_ScitokensServerLocation.GetString(),
 			"var", "http.sock")
-		transport = config.GetTransport().Clone()
+		transportConfig := config.GetTransport().Clone()
 		// When creating a new socket out to the remote server, ignore the actual
 		// requested address and return a Unix socket instead.
-		transport.DialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
+		transportConfig.DialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
 			return net.Dial("unix", socketName)
 		}
+		transport = transportConfig
 	})
 	return transport
 }
@@ -330,6 +332,20 @@ func GetUserCollectionScopes(db *gorm.DB, user string, groupsList []string) (sco
 	return scopes, matchedGroups, nil
 }
 
+// Determines whether OA4MP should force a re-login by interpreting the `fromLogin` query parameter as a boolean.
+// Only when `fromLogin` is present and parses as boolean true will this return false (i.e., not force a re-login);
+// missing, invalid, or false values will cause a re-login.
+func shouldForceOA4MPReLogin(requestURL *url.URL) bool {
+	loginAttempt, err := strconv.ParseBool(requestURL.Query().Get(web_ui.LoginAttemptQueryParam))
+	return err != nil || !loginAttempt
+}
+
+func stripLoginAttemptQueryParam(requestURL *url.URL) {
+	query := requestURL.Query()
+	query.Del(web_ui.LoginAttemptQueryParam)
+	requestURL.RawQuery = query.Encode()
+}
+
 // Proxy a HTTP request from the Pelican server to the OA4MP server
 //
 // Maps a request to /api/v1.0/issuer/foo to /scitokens-server/foo.  Most
@@ -343,10 +359,15 @@ func oa4mpProxy(ctx *gin.Context) {
 	var groupsList []string
 	var allMatchedGroups []string
 	if ctx.Request.URL.Path == "/api/v1.0/issuer/device" || ctx.Request.URL.Path == "/api/v1.0/issuer/authorize" {
+		if shouldForceOA4MPReLogin(ctx.Request.URL) {
+			web_ui.LogoutAndRedirectToLogin(ctx)
+			return
+		}
 		web_ui.RequireAuthMiddleware(ctx)
 		if ctx.IsAborted() {
 			return
 		}
+		stripLoginAttemptQueryParam(ctx.Request.URL)
 		user = ctx.GetString("User")
 		if user == "" {
 			// Should be impossible; proxy ought to be called via a middleware which always

--- a/oa4mp/proxy.go
+++ b/oa4mp/proxy.go
@@ -57,6 +57,10 @@ var (
 )
 
 func getTransport() http.RoundTripper {
+	// If a test has set a custom transport, use it
+	if transport != nil {
+		return transport
+	}
 	onceTransport.Do(func() {
 		socketName := filepath.Join(param.Issuer_ScitokensServerLocation.GetString(),
 			"var", "http.sock")

--- a/oa4mp/proxy.go
+++ b/oa4mp/proxy.go
@@ -57,16 +57,14 @@ var (
 )
 
 func getTransport() http.RoundTripper {
-	// If a test has set a custom transport, use it
-	if transport != nil {
-		return transport
-	}
 	onceTransport.Do(func() {
+		// If a test has set a custom transport, use it
+		if transport != nil {
+			return
+		}
 		socketName := filepath.Join(param.Issuer_ScitokensServerLocation.GetString(),
 			"var", "http.sock")
 		transportConfig := config.GetTransport().Clone()
-		// When creating a new socket out to the remote server, ignore the actual
-		// requested address and return a Unix socket instead.
 		transportConfig.DialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
 			return net.Dial("unix", socketName)
 		}
@@ -447,8 +445,8 @@ func oa4mpProxy(ctx *gin.Context) {
 	} else {
 		log.Debugln("Will proxy request to URL", ctx.Request.URL.String())
 	}
-	transport = getTransport()
-	resp, err := transport.RoundTrip(ctx.Request)
+	rt := getTransport()
+	resp, err := rt.RoundTrip(ctx.Request)
 	if err != nil {
 		log.Infoln("Failed to talk to OA4MP service:", err)
 		ctx.JSON(http.StatusServiceUnavailable, server_structs.SimpleApiResp{

--- a/oa4mp/proxy_test.go
+++ b/oa4mp/proxy_test.go
@@ -1,0 +1,130 @@
+package oa4mp
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/database"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/test_utils"
+	"github.com/pelicanplatform/pelican/token"
+	"github.com/pelicanplatform/pelican/token_scopes"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func setupOA4MPProxyTest(t *testing.T) *http.Cookie {
+	gin.SetMode(gin.TestMode)
+	server_utils.ResetTestState()
+	transport = nil
+	onceTransport = sync.Once{}
+	compiledAuthzRules = nil
+	t.Cleanup(func() {
+		server_utils.ResetTestState()
+		transport = nil
+		onceTransport = sync.Once{}
+		compiledAuthzRules = nil
+	})
+
+	require.NoError(t, param.ConfigDir.Set(t.TempDir()))
+	test_utils.MockFederationRoot(t, nil, nil)
+	require.NoError(t, config.InitServer(context.Background(), server_structs.OriginType))
+	_, err := config.GetIssuerPublicJWKS()
+	require.NoError(t, err)
+
+	mockDB, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	database.ServerDatabase = mockDB
+	require.NoError(t, database.ServerDatabase.AutoMigrate(&database.Collection{}, &database.CollectionACL{}))
+
+	loginCookieTokenCfg := token.NewWLCGToken()
+	loginCookieTokenCfg.Lifetime = 30 * time.Minute
+	loginCookieTokenCfg.Issuer = param.Server_ExternalWebUrl.GetString()
+	loginCookieTokenCfg.AddAudiences(param.Server_ExternalWebUrl.GetString())
+	loginCookieTokenCfg.Subject = "user"
+	loginCookieTokenCfg.AddScopes(token_scopes.WebUi_Access)
+	loginCookieTokenCfg.Claims = map[string]string{
+		"user_id": "user-id-1",
+	}
+
+	tok, err := loginCookieTokenCfg.CreateToken()
+	require.NoError(t, err)
+
+	return &http.Cookie{Name: "login", Value: tok}
+}
+
+func TestOA4MPProxyForcesFreshLoginWithoutLoginAttemptMarker(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	loginCookie := setupOA4MPProxyTest(t)
+
+	router := gin.New()
+	router.GET("/api/v1.0/issuer/authorize", oa4mpProxy)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/v1.0/issuer/authorize?client_id=test-client", nil)
+	require.NoError(t, err)
+	req.AddCookie(loginCookie)
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+	assert.Equal(t, "/api/v1.0/auth/oauth/login?nextUrl=%2Fapi%2Fv1.0%2Fissuer%2Fauthorize%3Fclient_id%3Dtest-client%26fromLogin%3Dtrue", recorder.Header().Get("Location"))
+
+	cookies := recorder.Result().Cookies()
+	require.NotEmpty(t, cookies)
+	assert.Equal(t, "login", cookies[0].Name)
+	assert.Greater(t, time.Now(), cookies[0].Expires)
+}
+
+func TestOA4MPProxyStripsLoginAttemptMarkerBeforeProxying(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	loginCookie := setupOA4MPProxyTest(t)
+
+	var proxiedPath string
+	var proxiedQuery string
+	var proxiedUserHeader string
+	transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		proxiedPath = req.URL.Path
+		proxiedQuery = req.URL.RawQuery
+		proxiedUserHeader = req.Header.Get("X-Pelican-User")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	})
+
+	router := gin.New()
+	router.GET("/api/v1.0/issuer/authorize", oa4mpProxy)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/v1.0/issuer/authorize?client_id=test-client&fromLogin=true", nil)
+	require.NoError(t, err)
+	req.AddCookie(loginCookie)
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, "/scitokens-server/authorize", proxiedPath)
+	assert.Equal(t, "client_id=test-client", proxiedQuery)
+	assert.NotEmpty(t, proxiedUserHeader)
+}

--- a/web_ui/authentication.go
+++ b/web_ui/authentication.go
@@ -82,7 +82,6 @@ const (
 	AdminRole              UserRole = "admin"
 	NonAdminRole           UserRole = "user"
 	LoginAttemptQueryParam          = "fromLogin"
-	loginAttemptQueryParam          = LoginAttemptQueryParam
 )
 
 // Periodically re-read the htpasswd file used for password-based authentication
@@ -726,10 +725,18 @@ func resetLoginHandler(ctx *gin.Context) {
 }
 
 func redirectToLogin(ctx *gin.Context, requestURI string) {
-	origPath := addLoginAttemptToNextURL(requestURI)
+	nextUrl, err := addLoginAttemptToNextURL(requestURI)
+	if err != nil {
+		log.Errorln("Failed to parse request URI for login redirect:", err)
+		ctx.AbortWithStatusJSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to construct login redirect URL",
+		})
+		return
+	}
 	redirUrl := url.URL{
 		Path:     oauthLoginPath,
-		RawQuery: "nextUrl=" + url.QueryEscape(origPath),
+		RawQuery: "nextUrl=" + url.QueryEscape(nextUrl),
 	}
 	ctx.Redirect(http.StatusTemporaryRedirect, redirUrl.String())
 	ctx.Abort()
@@ -842,15 +849,15 @@ func RegisterAuthEndpoints(ctx context.Context, routerGroup *gin.RouterGroup, eg
 	return nil
 }
 
-func addLoginAttemptToNextURL(requestURI string) string {
+func addLoginAttemptToNextURL(requestURI string) (string, error) {
 	parsedURL, err := url.ParseRequestURI(requestURI)
 	if err != nil {
-		return requestURI
+		return "", fmt.Errorf("failed to parse request URI %q: %w", requestURI, err)
 	}
 
 	query := parsedURL.Query()
-	query.Set(loginAttemptQueryParam, "true")
+	query.Set(LoginAttemptQueryParam, "true")
 	parsedURL.RawQuery = query.Encode()
 
-	return parsedURL.RequestURI()
+	return parsedURL.RequestURI(), nil
 }

--- a/web_ui/authentication.go
+++ b/web_ui/authentication.go
@@ -79,8 +79,10 @@ var (
 )
 
 const (
-	AdminRole    UserRole = "admin"
-	NonAdminRole UserRole = "user"
+	AdminRole              UserRole = "admin"
+	NonAdminRole           UserRole = "user"
+	LoginAttemptQueryParam          = "fromLogin"
+	loginAttemptQueryParam          = LoginAttemptQueryParam
 )
 
 // Periodically re-read the htpasswd file used for password-based authentication
@@ -381,13 +383,7 @@ func AuthHandler(ctx *gin.Context) {
 func RequireAuthMiddleware(ctx *gin.Context) {
 	user, userId, groups, err := GetUserGroups(ctx)
 	if user == "" || err != nil {
-		origPath := ctx.Request.URL.RequestURI()
-		redirUrl := url.URL{
-			Path:     oauthLoginPath,
-			RawQuery: "nextUrl=" + url.QueryEscape(origPath),
-		}
-		ctx.Redirect(http.StatusTemporaryRedirect, redirUrl.String())
-		ctx.Abort()
+		redirectToLogin(ctx, ctx.Request.URL.RequestURI())
 	} else {
 		ctx.Set("User", user)
 		ctx.Set("UserId", userId)
@@ -729,9 +725,31 @@ func resetLoginHandler(ctx *gin.Context) {
 	}
 }
 
-func logoutHandler(ctx *gin.Context) {
+func redirectToLogin(ctx *gin.Context, requestURI string) {
+	origPath := addLoginAttemptToNextURL(requestURI)
+	redirUrl := url.URL{
+		Path:     oauthLoginPath,
+		RawQuery: "nextUrl=" + url.QueryEscape(origPath),
+	}
+	ctx.Redirect(http.StatusTemporaryRedirect, redirUrl.String())
+	ctx.Abort()
+}
+
+func LogoutAndRedirectToLogin(ctx *gin.Context) {
+	clearLoginCookie(ctx)
+	ctx.Set("User", "")
+	ctx.Set("UserId", "")
+	ctx.Set("Groups", []string{})
+	redirectToLogin(ctx, ctx.Request.URL.RequestURI())
+}
+
+func clearLoginCookie(ctx *gin.Context) {
 	ctx.SetCookie("login", "", -1, "/", ctx.Request.URL.Host, true, true)
 	ctx.SetSameSite(http.SameSiteStrictMode)
+}
+
+func logoutHandler(ctx *gin.Context) {
+	clearLoginCookie(ctx)
 	ctx.Set("User", "")
 	ctx.JSON(http.StatusOK,
 		server_structs.SimpleApiResp{
@@ -822,4 +840,17 @@ func RegisterAuthEndpoints(ctx context.Context, routerGroup *gin.RouterGroup, eg
 	egrp.Go(func() error { return periodicAuthDBReload(ctx) })
 
 	return nil
+}
+
+func addLoginAttemptToNextURL(requestURI string) string {
+	parsedURL, err := url.ParseRequestURI(requestURI)
+	if err != nil {
+		return requestURI
+	}
+
+	query := parsedURL.Query()
+	query.Set(loginAttemptQueryParam, "true")
+	parsedURL.RawQuery = query.Encode()
+
+	return parsedURL.RequestURI()
 }

--- a/web_ui/authentication_test.go
+++ b/web_ui/authentication_test.go
@@ -1076,3 +1076,34 @@ func TestListOIDCEnabledServersHandler(t *testing.T) {
 		assert.Equal(t, expected, getResult)
 	})
 }
+
+func TestRequireAuthMiddlewareAddsLoginAttemptToNextURL(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.GET("/protected", RequireAuthMiddleware, func(ctx *gin.Context) { ctx.Status(http.StatusNoContent) })
+	router.GET("/protected-query", RequireAuthMiddleware, func(ctx *gin.Context) { ctx.Status(http.StatusNoContent) })
+
+	t.Run("plain-path", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/protected", nil)
+		require.NoError(t, err)
+
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+		assert.Equal(t, "/api/v1.0/auth/oauth/login?nextUrl=%2Fprotected%3FfromLogin%3Dtrue", recorder.Header().Get("Location"))
+	})
+
+	t.Run("existing-query", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/protected-query?foo=bar", nil)
+		require.NoError(t, err)
+
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+		assert.Equal(t, "/api/v1.0/auth/oauth/login?nextUrl=%2Fprotected-query%3Ffoo%3Dbar%26fromLogin%3Dtrue", recorder.Header().Get("Location"))
+	})
+}

--- a/web_ui/oauth2_client_test.go
+++ b/web_ui/oauth2_client_test.go
@@ -67,3 +67,12 @@ func TestParseOAuthState(t *testing.T) {
 		assert.Nil(t, get)
 	})
 }
+
+func TestOAuthStatePreservesNextURLWithLoginAttemptMarker(t *testing.T) {
+	nextURL := "/view/origin/globus/?foo=bar&" + loginAttemptQueryParam + "=true"
+
+	state := GenerateOAuthState(map[string]string{"nextUrl": nextURL})
+	parsed, err := ParseOAuthState(state)
+	require.NoError(t, err)
+	assert.Equal(t, nextURL, parsed["nextUrl"])
+}

--- a/web_ui/oauth2_client_test.go
+++ b/web_ui/oauth2_client_test.go
@@ -69,7 +69,7 @@ func TestParseOAuthState(t *testing.T) {
 }
 
 func TestOAuthStatePreservesNextURLWithLoginAttemptMarker(t *testing.T) {
-	nextURL := "/view/origin/globus/?foo=bar&" + loginAttemptQueryParam + "=true"
+	nextURL := "/view/origin/globus/?foo=bar&" + LoginAttemptQueryParam + "=true"
 
 	state := GenerateOAuthState(map[string]string{"nextUrl": nextURL})
 	parsed, err := ParseOAuthState(state)


### PR DESCRIPTION
Users are reused on issuer endpoints which means you can't try and relogin with new groups.

Make the endpoint smarter so that if you are not coming in from a recent login it forces a new login so that your data is as fresh as possible.