### PR TITLE
The client now accurately reports when a token isn't sent

### DIFF
--- a/client/errorAccum.go
+++ b/client/errorAccum.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, University of Nebraska-Lincoln
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -36,6 +36,7 @@ import (
 type PermissionDeniedError struct {
 	message string
 	expired bool
+	noToken bool // true when no token was sent (e.g., public namespace via stale cache)
 }
 
 func (e *PermissionDeniedError) Error() string {
@@ -151,12 +152,12 @@ func (te *TransferErrors) UserError() string {
 
 // IsRetryable will return true if the error is retryable
 func IsRetryable(err error) bool {
-	// Special case: PermissionDeniedError has dynamic retryability based on token expiration
-	// Check this before the general PelicanError check since it's always wrapped but needs special handling
-	// If the token is expired, we can retry because we'll get a new token
+	// Special case: PermissionDeniedError has dynamic retryability based on token state.
+	// Check this before the general PelicanError check since it's always wrapped but needs special handling.
+	// Retryable if: token was expired (we'll get a new one) or no token was sent (we may try with one).
 	var pde *PermissionDeniedError
 	if errors.As(err, &pde) {
-		return pde.expired
+		return pde.expired || pde.noToken
 	}
 
 	// Check if it contains a TLS AlertError, which should always be retryable

--- a/client/errorAccum_test.go
+++ b/client/errorAccum_test.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, University of Nebraska-Lincoln
+ * Copyright (C) 2026, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -74,6 +74,12 @@ func TestErrorsRetryableFalse(t *testing.T) {
 	assert.False(t, te.AllErrorsRetryable(), "PermissionDeniedError with valid but rejected token should not be retryable")
 	te.resetErrors()
 
+	// Test PermissionDeniedError with no token sent (not retryable via this path - noToken=false, expired=false)
+	pdeNoTokenFalse := &PermissionDeniedError{noToken: false}
+	te.AddError(error_codes.NewAuthorizationError(pdeNoTokenFalse))
+	assert.False(t, te.AllErrorsRetryable(), "PermissionDeniedError with noToken=false should not be retryable")
+	te.resetErrors()
+
 }
 
 // TestErrorsRetryableTrue tests that errors are retryable
@@ -101,6 +107,12 @@ func TestErrorsRetryableTrue(t *testing.T) {
 	pdeExpired := &PermissionDeniedError{expired: true}
 	te.AddError(error_codes.NewAuthorizationError(pdeExpired))
 	assert.True(t, te.AllErrorsRetryable(), "PermissionDeniedError with expired token should be retryable")
+	te.resetErrors()
+
+	// Test PermissionDeniedError with no token sent (retryable)
+	pdeNoToken := &PermissionDeniedError{noToken: true}
+	te.AddError(error_codes.NewAuthorizationError(pdeNoToken))
+	assert.True(t, te.AllErrorsRetryable(), "PermissionDeniedError with no token sent should be retryable")
 	te.resetErrors()
 
 	// Test wrapped ConnectionSetupError (all ConnectionSetupErrors are wrapped in production)

--- a/client/error_helpers.go
+++ b/client/error_helpers.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -473,18 +473,26 @@ func wrapDownloadError(err error, transferEndpointURL string, tokenContents stri
 	// Handle permission denied errors
 	var pde *PermissionDeniedError
 	if errors.As(err, &pde) {
-		// If the token is expired we can retry because we will just get a new token
-		// otherwise something is wrong with the token
-		expired, expiration, tokenErr := tokenIsExpired(tokenContents)
-		if tokenErr != nil {
-			pde.message = "Permission denied: token could not be parsed"
+		if tokenContents == "" {
+			// No token was sent (e.g., public namespace accessed via a cache that doesn't know about it yet).
+			// Mark as retryable so the client can attempt at a different cache that isn't stale.
+			pde.message = "Permission denied: no token was sent"
 			pde.expired = false
-		} else if expired {
-			pde.message = "Permission denied: token expired at " + expiration.Format(time.RFC3339)
-			pde.expired = true
+			pde.noToken = true
 		} else {
-			pde.message = "Permission denied: token appears valid but was rejected by the server"
-			pde.expired = false
+			// If the token is expired we can retry because we will just get a new token
+			// otherwise something is wrong with the token
+			expired, expiration, tokenErr := tokenIsExpired(tokenContents)
+			if tokenErr != nil {
+				pde.message = "Permission denied: token could not be parsed"
+				pde.expired = false
+			} else if expired {
+				pde.message = "Permission denied: token expired at " + expiration.Format(time.RFC3339)
+				pde.expired = true
+			} else {
+				pde.message = "Permission denied: token appears valid but was rejected by the server"
+				pde.expired = false
+			}
 		}
 		return error_codes.NewAuthorizationError(pde), false, ""
 	}

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -3347,17 +3347,18 @@ func TestWrapDownloadError(t *testing.T) {
 		assert.Contains(t, wrappedPde.message, "token expired", "Message should indicate token expired")
 	})
 
-	t.Run("permission_denied_error_invalid_token", func(t *testing.T) {
-		emptyToken := ""
+	t.Run("permission_denied_error_no_token", func(t *testing.T) {
+		// When no token was sent (e.g., public namespace accessed via a cache that doesn't know about it),
+		// the error message should accurately reflect that no token was sent rather than claiming a parse error.
 		pde := &PermissionDeniedError{}
-		wrappedErr, _, _ := wrapDownloadError(pde, transferEndpointURL, emptyToken)
+		wrappedErr, _, _ := wrapDownloadError(pde, transferEndpointURL, "")
 
 		var wrappedPde *PermissionDeniedError
 		require.True(t, errors.As(wrappedErr, &wrappedPde), "Should contain PermissionDeniedError")
-		// With empty/invalid token, it should say "token could not be parsed"
-		assert.Contains(t, wrappedPde.message, "token could not be parsed", "Message should indicate parsing error")
-		assert.False(t, wrappedPde.expired, "Token should not be marked as expired when parsing fails")
-		// Note: The "valid but rejected" case is tested in TestPermissionDeniedError integration test
+		assert.Contains(t, wrappedPde.message, "no token was sent", "Message should indicate no token was sent")
+		assert.False(t, wrappedPde.expired, "Token should not be marked as expired when no token was sent")
+		assert.True(t, wrappedPde.noToken, "noToken should be set when no token was sent")
+		assert.True(t, IsRetryable(wrappedErr), "Should be retryable so client can attempt token acquisition")
 	})
 
 	t.Run("permission_denied_error_invalid_token", func(t *testing.T) {
@@ -3367,6 +3368,8 @@ func TestWrapDownloadError(t *testing.T) {
 		var wrappedPde *PermissionDeniedError
 		require.True(t, errors.As(wrappedErr, &wrappedPde), "Should contain PermissionDeniedError")
 		assert.Contains(t, wrappedPde.message, "token could not be parsed", "Message should indicate parsing error")
+		assert.False(t, wrappedPde.expired, "Token should not be marked as expired when parsing fails")
+		// Note: The "valid but rejected" case is tested in TestPermissionDeniedError integration test
 	})
 
 	t.Run("connection_reset_error", func(t *testing.T) {


### PR DESCRIPTION
-- When a permission denied error occurs and a token isn't sent, the client now accurately reports that
-- These errors are also marked as retryable because it occurs when the director tells the client a namespace is public, but it's contacting a cache that doesn't know about the namespace (possibly because its hasn't received new advertisements yet in order to update its auth file)


close: #2940 