### PR TITLE
Add missing Origin disk usage calculation defaults

### DIFF
--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -91,6 +91,9 @@ LocalCache:
   LowWaterMarkPercentage: 85
 Origin:
   DirectorTest: true
+  DiskUsageCalculationDelay: 5m
+  DiskUsageCalculationInterval: 24h
+  DiskUsageCalculationRateLimit: 1000
   Multiuser: false
   EnableMacaroons: false
   EnableVoms: true


### PR DESCRIPTION
Closes #3225 

Confirmed that these show up correctly via `pelican config dump`:
```
    DiskUsageCalculationDelay: 5m0s
    DiskUsageCalculationInterval: 24h0m0s
    DiskUsageCalculationRateLimit: 1000
```