### PR TITLE
Downtime - Allow endTime to go before startTime with warning

### DIFF
--- a/web_ui/frontend/components/Downtime/Registry/ServerUnknownDowntimeForm.tsx
+++ b/web_ui/frontend/components/Downtime/Registry/ServerUnknownDowntimeForm.tsx
@@ -9,11 +9,19 @@ import {
   MenuItem,
   Select,
   TextField,
+  Typography,
 } from '@mui/material';
 import { DateTimePicker } from '@mui/x-date-pickers';
 import { mutate } from 'swr';
 import { DateTime } from 'luxon';
-import { Dispatch, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  Dispatch,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  useRef,
+} from 'react';
 import { DowntimeGet, DowntimeRegistryPost, DowntimeSeverity } from '@/types';
 import { DowntimeSeverities, ServerDowntimeKey } from '@/components/Downtime';
 import FormControl from '@mui/material/FormControl';
@@ -98,8 +106,13 @@ const ServerUnknownDowntimeForm = ({
   }, [downtime, setDowntime]);
 
   // If the starttime is updated, before the endtime, adjust the endtime to be 1 day after the starttime
+  const prevStartTimeRef = useRef(downtime.startTime);
   useEffect(() => {
+    const startTimeChanged = prevStartTimeRef.current !== downtime.startTime;
+    prevStartTimeRef.current = downtime.startTime;
+
     if (
+      startTimeChanged &&
       downtime.endTime !== -1 &&
       DateTime.fromMillis(downtime.endTime) <=
         DateTime.fromMillis(downtime.startTime)
@@ -112,6 +125,17 @@ const ServerUnknownDowntimeForm = ({
       });
     }
   }, [downtime, setDowntime]);
+
+  // Check that the downtime is valid for submission: start time must be before end time (if not endless), and severity must be set
+  const canSubmit = useMemo(() => {
+    if (!endless && downtime.endTime <= downtime.startTime) {
+      return false;
+    }
+    if (!downtime.severity) {
+      return false;
+    }
+    return true;
+  }, [downtime, endless]);
 
   return (
     <Box>
@@ -162,7 +186,7 @@ const ServerUnknownDowntimeForm = ({
           }
         />
       </Box>
-      <Box mt={2}>
+      <Box mt={2} display={'flex'} flexDirection={'column'}>
         <DateTimePicker
           label={`End Time (${getUtcOffsetString()})`}
           disabled={endless}
@@ -171,6 +195,13 @@ const ServerUnknownDowntimeForm = ({
             setDowntime({ ...downtime, endTime: v?.toMillis() || 0 })
           }
         />
+        {downtime.endTime !== -1 &&
+          DateTime.fromMillis(downtime.endTime) <=
+            DateTime.fromMillis(downtime.startTime) && (
+            <Typography variant={'caption'} color={'error'}>
+              End time must be after start time
+            </Typography>
+          )}
       </Box>
       <Box>
         <FormControlLabel
@@ -234,6 +265,7 @@ const ServerUnknownDowntimeForm = ({
       >
         <Button
           variant={'contained'}
+          disabled={!canSubmit}
           onClick={async () => {
             const r = await submitDowntime(downtime, dispatch, id);
 

--- a/web_ui/frontend/components/Downtime/Server/DowntimeForm.tsx
+++ b/web_ui/frontend/components/Downtime/Server/DowntimeForm.tsx
@@ -103,6 +103,17 @@ const DowntimeForm = ({
     }
   }, [downtime, setDowntime]);
 
+  // Check that the downtime is valid for submission: start time must be before end time (if not endless), and severity must be set
+  const canSubmit = useMemo(() => {
+    if (!endless && downtime.endTime <= downtime.startTime) {
+      return false;
+    }
+    if (!downtime.severity) {
+      return false;
+    }
+    return true;
+  }, [downtime, endless]);
+
   return (
     <Box>
       <Box mt={2}>
@@ -194,6 +205,7 @@ const DowntimeForm = ({
       >
         <Button
           variant={'contained'}
+          disabled={!canSubmit}
           onClick={async () => {
             const r = await submitDowntime(downtime, dispatch, id);
 


### PR DESCRIPTION
I am a user that is updating a downtimes end date, I want the end date to be able to have a time that is before the start time when entering, but not when submitting.

The issue arose from someone trying to update the end date to end today, but the time was before the current start time which meant the change would result in invalid state which isn't possible.

We should make invalid state possible but warn the user that is the case and prevent submission.