### PR TITLE
Fix `object ls` output: sorted, terminal-aware columns, and directory distinction

### DIFF
--- a/cmd/object_ls.go
+++ b/cmd/object_ls.go
@@ -177,8 +177,7 @@ func listMain(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 		for _, info := range filteredInfos {
-			// If not json formats, just print out the information in a clean way
-			fmt.Fprintln(w, info.Name+"\t"+strconv.FormatInt(info.Size, 10)+"\t"+info.ModTime.Format("2006-01-02 15:04:05"))
+			fmt.Fprintln(w, formatLongEntry(info))
 		}
 		w.Flush()
 	} else if asJSON {
@@ -214,6 +213,21 @@ func listMain(cmd *cobra.Command, args []string) error {
 		printColumns(os.Stdout, names, termWidth)
 	}
 	return nil
+}
+
+// formatLongEntry formats a single FileInfo as a tab-separated row for the
+// long listing (-l) output.  The row has four tab-delimited fields:
+//
+// <name>  <size>  <mod-time>
+//
+// <size> is the decimal byte count for objects; "DIR" for directory/prefix,
+// whose sizes are backend-dependent and not meaningful to the user.
+func formatLongEntry(info client.FileInfo) string {
+	sizeField := strconv.FormatInt(info.Size, 10)
+	if info.IsCollection {
+		sizeField = "DIR"
+	}
+	return info.Name + "\t" + sizeField + "\t" + info.ModTime.Format("2006-01-02 15:04:05")
 }
 
 // printColumns writes names to w in a multi-column layout that fits within

--- a/cmd/object_ls_test.go
+++ b/cmd/object_ls_test.go
@@ -22,9 +22,12 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/client"
 )
 
 func TestPrintColumns_Empty(t *testing.T) {
@@ -93,6 +96,64 @@ func TestPrintColumns_ColumnWidthDrivenByLongestName(t *testing.T) {
 	for _, name := range names {
 		assert.Contains(t, output, name)
 	}
+}
+
+func TestFormatLongEntry_RegularFile(t *testing.T) {
+	modTime := time.Date(2025, 5, 5, 19, 4, 2, 0, time.UTC)
+	info := client.FileInfo{
+		Name:         "/ns/empty.txt",
+		Size:         0,
+		ModTime:      modTime,
+		IsCollection: false,
+	}
+	row := formatLongEntry(info)
+	fields := strings.Split(row, "\t")
+	require.Len(t, fields, 3)
+	assert.Equal(t, "/ns/empty.txt", fields[0])
+	assert.Equal(t, "0", fields[1], "size must be '0' for a zero-byte file, not 'DIR'")
+	assert.Equal(t, "2025-05-05 19:04:02", fields[2])
+}
+
+func TestFormatLongEntry_NonEmptyFile(t *testing.T) {
+	modTime := time.Date(2025, 3, 14, 13, 39, 34, 0, time.UTC)
+	info := client.FileInfo{
+		Name:         "/ns/README.txt",
+		Size:         43,
+		ModTime:      modTime,
+		IsCollection: false,
+	}
+	row := formatLongEntry(info)
+	fields := strings.Split(row, "\t")
+	require.Len(t, fields, 3)
+	assert.Equal(t, "/ns/README.txt", fields[0])
+	assert.Equal(t, "43", fields[1])
+}
+
+func TestFormatLongEntry_Collection(t *testing.T) {
+	modTime := time.Date(2025, 5, 5, 19, 6, 26, 0, time.UTC)
+	info := client.FileInfo{
+		Name:         "/ns/sub-directory",
+		Size:         0,
+		ModTime:      modTime,
+		IsCollection: true,
+	}
+	row := formatLongEntry(info)
+	fields := strings.Split(row, "\t")
+	require.Len(t, fields, 3)
+	assert.Equal(t, "/ns/sub-directory", fields[0])
+	assert.Equal(t, "DIR", fields[1], "size must be 'DIR' for a collection, not '0'")
+	assert.Equal(t, "2025-05-05 19:06:26", fields[2])
+}
+
+func TestFormatLongEntry_CollectionVsZeroByteFile_AreDistinguishable(t *testing.T) {
+	ts := time.Date(2025, 5, 5, 0, 0, 0, 0, time.UTC)
+	dir := formatLongEntry(client.FileInfo{Name: "/ns/prefix", Size: 0, ModTime: ts, IsCollection: true})
+	file := formatLongEntry(client.FileInfo{Name: "/ns/empty.txt", Size: 0, ModTime: ts, IsCollection: false})
+	assert.NotEqual(t, dir, file, "a zero-byte file and a collection must produce different output")
+	dirFields := strings.Split(dir, "\t")
+	fileFields := strings.Split(file, "\t")
+	assert.Equal(t, "DIR", dirFields[1], "collection size field must be 'DIR'")
+	assert.Equal(t, "0", fileFields[1], "zero-byte file size field must be '0'")
 }
 
 // nonBlankLines returns non-empty, non-whitespace-only lines from s.


### PR DESCRIPTION
Closes #2281, closes #2296.

This PR ships 3 nice improvements for `pelican object ls (-l)` command:

- Sort — all listing modes (short, long, single-column, JSON) now sort entries lexicographically by base name before output.
- Dynamic columns — the short listing no longer hard-codes 4 columns. It queries the terminal width, computes a uniform column width from the longest entry name plus 2 spaces of padding, and fills as many columns as fit. Falls back to 80 characters when the width is unavailable.
- Directory distinction in `-l` — the long listing now shows DIR in the size column for directories instead of 0, making zero-byte files and directories unambiguous at a glance.