### PR TITLE
Fix race condition in param 'IsSet' and 'Unmarshal'

### DIFF
--- a/generate/param_generator.go
+++ b/generate/param_generator.go
@@ -458,8 +458,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/viper"
-
 	"github.com/pelicanplatform/pelican/byte_rate"
 )
 
@@ -545,7 +543,7 @@ func (sP StringParam) GetName() string {
 }
 
 func (sP StringParam) IsSet() bool {
-	return viper.IsSet(sP.name)
+	return viperIsSet(sP.name)
 }
 
 func (sP StringParam) IsRuntimeConfigurable() bool {
@@ -572,7 +570,7 @@ func (slP StringSliceParam) GetName() string {
 }
 
 func (slP StringSliceParam) IsSet() bool {
-	return viper.IsSet(slP.name)
+	return viperIsSet(slP.name)
 }
 
 func (slP StringSliceParam) IsRuntimeConfigurable() bool {
@@ -599,7 +597,7 @@ func (iP IntParam) GetName() string {
 }
 
 func (iP IntParam) IsSet() bool {
-	return viper.IsSet(iP.name)
+	return viperIsSet(iP.name)
 }
 
 func (iP IntParam) IsRuntimeConfigurable() bool {
@@ -624,7 +622,7 @@ func (bRP ByteRateParam) GetName() string {
 }
 
 func (bRP ByteRateParam) IsSet() bool {
-	return viper.IsSet(bRP.name)
+	return viperIsSet(bRP.name)
 }
 
 func (bRP ByteRateParam) IsRuntimeConfigurable() bool {
@@ -651,7 +649,7 @@ func (bP BoolParam) GetName() string {
 }
 
 func (bP BoolParam) IsSet() bool {
-	return viper.IsSet(bP.name)
+	return viperIsSet(bP.name)
 }
 
 func (bP BoolParam) IsRuntimeConfigurable() bool {
@@ -678,7 +676,7 @@ func (dP DurationParam) GetName() string {
 }
 
 func (dP DurationParam) IsSet() bool {
-	return viper.IsSet(dP.name)
+	return viperIsSet(dP.name)
 }
 
 func (dP DurationParam) IsRuntimeConfigurable() bool {
@@ -690,7 +688,7 @@ func (dP DurationParam) GetEnvVarName() string {
 }
 
 func (oP ObjectParam) Unmarshal(rawVal any) error {
-	return viper.UnmarshalKey(oP.name, rawVal)
+	return viperUnmarshalKey(oP.name, rawVal)
 }
 
 func (oP ObjectParam) GetName() string {
@@ -698,7 +696,7 @@ func (oP ObjectParam) GetName() string {
 }
 
 func (oP ObjectParam) IsSet() bool {
-	return viper.IsSet(oP.name)
+	return viperIsSet(oP.name)
 }
 
 func (oP ObjectParam) IsRuntimeConfigurable() bool {

--- a/param/param.go
+++ b/param/param.go
@@ -47,6 +47,23 @@ func init() {
 	callbacks = make(map[string]ConfigCallback)
 }
 
+// viperIsSet wraps viper.IsSet with configMutex to prevent concurrent map
+// read/write panics inside viper's internal path-index cache. All generated
+// param IsSet() methods delegate here instead of calling viper directly.
+func viperIsSet(key string) bool {
+	configMutex.Lock()
+	defer configMutex.Unlock()
+	return viper.IsSet(key)
+}
+
+// viperUnmarshalKey wraps viper.UnmarshalKey with configMutex to prevent
+// concurrent map access panics for the same reason as viperIsSet.
+func viperUnmarshalKey(key string, rawVal any) error {
+	configMutex.Lock()
+	defer configMutex.Unlock()
+	return viper.UnmarshalKey(key, rawVal)
+}
+
 // Refresh reloads the atomic cached configuration from viper's *global* instance.
 //
 // The param accessors read from an atomic cached `Config` struct for performance.

--- a/param/param_test.go
+++ b/param/param_test.go
@@ -875,3 +875,112 @@ func TestByteRateDecoding(t *testing.T) {
 		assert.Equal(t, expected, config.Origin.TransferRateLimit)
 	})
 }
+
+// TestConcurrentIsSetAndUnmarshalConfig verifies that concurrent IsSet() calls
+// do not race with UnmarshalConfig() / Set(). Before the fix, this would panic
+// with "concurrent map read and map write" inside viper because IsSet() called
+// viper.IsSet() without holding configMutex while UnmarshalConfig() called
+// viper.AllSettings() which mutates viper's internal path-index cache.
+//
+// Run with: go test -race -run TestConcurrentIsSetAndUnmarshalConfig ./param/
+func TestConcurrentIsSetAndUnmarshalConfig(t *testing.T) {
+	require.NoError(t, Reset())
+	ClearCallbacks()
+	defer func() {
+		ClearCallbacks()
+		require.NoError(t, Reset())
+	}()
+
+	// Seed some config values so viper has internal state to race on
+	require.NoError(t, Set(Server_UIAdminUsers.GetName(), []string{"admin"}))
+	require.NoError(t, Set(Server_AdminGroups.GetName(), []string{"admins"}))
+	require.NoError(t, Set(Cache_Port.GetName(), 8443))
+	require.NoError(t, Set(Logging_Level.GetName(), "debug"))
+
+	var wg sync.WaitGroup
+
+	// Goroutines calling IsSet (the read path that was unprotected)
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 20 {
+				_ = Server_UIAdminUsers.IsSet()
+				_ = Server_AdminGroups.IsSet()
+				_ = Cache_Port.IsSet()
+				_ = Logging_Level.IsSet()
+			}
+		}()
+	}
+
+	// Goroutines calling UnmarshalConfig (the write path via AllSettings)
+	for range 3 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 5 {
+				_, _ = UnmarshalConfig()
+			}
+		}()
+	}
+
+	// Goroutines calling Set (another write path)
+	for i := range 3 {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for range 10 {
+				_ = Set(Logging_Level.GetName(), "info")
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// If we get here without a panic or race detector complaint, the fix works
+	config, err := GetUnmarshaledConfig()
+	require.NoError(t, err)
+	assert.NotNil(t, config)
+}
+
+// TestConcurrentObjectParamUnmarshal verifies that ObjectParam.Unmarshal()
+// doesn't race with concurrent viper writes.
+func TestConcurrentObjectParamUnmarshal(t *testing.T) {
+	require.NoError(t, Reset())
+	ClearCallbacks()
+	defer func() {
+		ClearCallbacks()
+		require.NoError(t, Reset())
+	}()
+
+	require.NoError(t, Set(Registry_Institutions.GetName(), []map[string]interface{}{
+		{"name": "TestInst", "id": "test-001"},
+	}))
+
+	var wg sync.WaitGroup
+
+	// Concurrent Unmarshal calls
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 10 {
+				var result any
+				_ = Registry_Institutions.Unmarshal(&result)
+			}
+		}()
+	}
+
+	// Concurrent Set calls to create contention
+	for range 3 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 10 {
+				_ = Set(Logging_Level.GetName(), "warn")
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/viper"
-
 	"github.com/pelicanplatform/pelican/byte_rate"
 )
 
@@ -865,7 +863,7 @@ func (sP StringParam) GetName() string {
 }
 
 func (sP StringParam) IsSet() bool {
-	return viper.IsSet(sP.name)
+	return viperIsSet(sP.name)
 }
 
 func (sP StringParam) IsRuntimeConfigurable() bool {
@@ -936,7 +934,7 @@ func (slP StringSliceParam) GetName() string {
 }
 
 func (slP StringSliceParam) IsSet() bool {
-	return viper.IsSet(slP.name)
+	return viperIsSet(slP.name)
 }
 
 func (slP StringSliceParam) IsRuntimeConfigurable() bool {
@@ -1053,7 +1051,7 @@ func (iP IntParam) GetName() string {
 }
 
 func (iP IntParam) IsSet() bool {
-	return viper.IsSet(iP.name)
+	return viperIsSet(iP.name)
 }
 
 func (iP IntParam) IsRuntimeConfigurable() bool {
@@ -1078,7 +1076,7 @@ func (bRP ByteRateParam) GetName() string {
 }
 
 func (bRP ByteRateParam) IsSet() bool {
-	return viper.IsSet(bRP.name)
+	return viperIsSet(bRP.name)
 }
 
 func (bRP ByteRateParam) IsRuntimeConfigurable() bool {
@@ -1255,7 +1253,7 @@ func (bP BoolParam) GetName() string {
 }
 
 func (bP BoolParam) IsSet() bool {
-	return viper.IsSet(bP.name)
+	return viperIsSet(bP.name)
 }
 
 func (bP BoolParam) IsRuntimeConfigurable() bool {
@@ -1392,7 +1390,7 @@ func (dP DurationParam) GetName() string {
 }
 
 func (dP DurationParam) IsSet() bool {
-	return viper.IsSet(dP.name)
+	return viperIsSet(dP.name)
 }
 
 func (dP DurationParam) IsRuntimeConfigurable() bool {
@@ -1404,7 +1402,7 @@ func (dP DurationParam) GetEnvVarName() string {
 }
 
 func (oP ObjectParam) Unmarshal(rawVal any) error {
-	return viper.UnmarshalKey(oP.name, rawVal)
+	return viperUnmarshalKey(oP.name, rawVal)
 }
 
 func (oP ObjectParam) GetName() string {
@@ -1412,7 +1410,7 @@ func (oP ObjectParam) GetName() string {
 }
 
 func (oP ObjectParam) IsSet() bool {
-	return viper.IsSet(oP.name)
+	return viperIsSet(oP.name)
 }
 
 func (oP ObjectParam) IsRuntimeConfigurable() bool {


### PR DESCRIPTION
These methods didn't grab the config mutex, leading to the potential for concurrent map reads/writes.

The new tests failed reliably with the old code when executed with Go's builtin race detector, but pass now.

The routine contention parameters (e.g. 3x5 goroutines or 10x10) were hand tuned a bit so that the tests don't timeout but that they do fail under the specific condition that caused the bug.

Note that they will almost always pass unless the tests are run with `-race`, which our CI inf doesn't do. I don't want to turn this on for all PR-triggered tests because of the 2-3x time overhead, but I plan to follow up with another issue to run these as part of our nightly tests.