### PR TITLE
Run nightly tests with race detector and add nightly test badge

### DIFF
--- a/.github/workflows/test-linux-scheduled.yml
+++ b/.github/workflows/test-linux-scheduled.yml
@@ -16,6 +16,7 @@ jobs:
     uses: ./.github/workflows/test-linux.yml
     with:
       image: hub.opensciencegrid.org/pelican_platform/pelican-test:latest-itb
+      race_detection: true
 
   analyze-runs:
     name: Analyze Runs

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -16,6 +16,10 @@ on:
       image:
         required: true
         type: string
+      race_detection:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   run-tests:
@@ -88,7 +92,19 @@ jobs:
           echo "::group::Building web UI"
           make web-build
           echo "::endgroup::"
-          gotestsum --format pkgname-and-test-fails --hide-summary=output --junitfile "$JUNIT_FILE" -- -p=4 -timeout=15m -coverpkg=./... -covermode=count -coverprofile=${{ matrix.coverprofile }} -tags=${{ matrix.tags }} ./...
+          gotestsum \
+            --format pkgname-and-test-fails \
+            --hide-summary=output \
+            --junitfile "$JUNIT_FILE" \
+            -- \
+            -p=4 \
+            -timeout=${{ inputs.race_detection && '30m' || '15m' }} \
+            ${{ inputs.race_detection && '-race' || '' }} \
+            ${{ !inputs.race_detection && '-coverpkg=./...' || '' }} \
+            ${{ !inputs.race_detection && '-covermode=count' || '' }} \
+            ${{ !inputs.race_detection && format('-coverprofile={0}', matrix.coverprofile) || '' }} \
+            -tags=${{ matrix.tags }} \
+            ./...
 
       - name: Upload JUnit report
         if: always()

--- a/.github/workflows/test-macos-scheduled.yml
+++ b/.github/workflows/test-macos-scheduled.yml
@@ -10,6 +10,8 @@ jobs:
   run-tests:
     name: Test
     uses: ./.github/workflows/test-macos.yml
+    with:
+      race_detection: true
 
   analyze-runs:
     name: Analyze Runs

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -16,6 +16,11 @@ on:
     types:
       - dispatch-build
   workflow_call:
+    inputs:
+      race_detection:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
 
 jobs:
@@ -87,7 +92,19 @@ jobs:
           echo "::group::Building web UI"
           make web-build
           echo "::endgroup::"
-          gotestsum --format pkgname-and-test-fails --hide-summary=output --junitfile "$JUNIT_FILE" -- -p=4 -timeout=15m -coverpkg=./... -covermode=count -coverprofile=${{ matrix.coverprofile }} -tags=${{ matrix.tags }} ./...
+          gotestsum \
+            --format pkgname-and-test-fails \
+            --hide-summary=output \
+            --junitfile "$JUNIT_FILE" \
+            -- \
+            -p=4 \
+            -timeout=${{ inputs.race_detection && '30m' || '15m' }} \
+            ${{ inputs.race_detection && '-race' || '' }} \
+            ${{ !inputs.race_detection && '-coverpkg=./...' || '' }} \
+            ${{ !inputs.race_detection && '-covermode=count' || '' }} \
+            ${{ !inputs.race_detection && format('-coverprofile={0}', matrix.coverprofile) || '' }} \
+            -tags=${{ matrix.tags }} \
+            ./...
 
       - name: Upload JUnit report
         if: always()

--- a/.github/workflows/test-windows-scheduled.yml
+++ b/.github/workflows/test-windows-scheduled.yml
@@ -10,6 +10,8 @@ jobs:
   run-tests:
     name: Test
     uses: ./.github/workflows/test-windows.yml
+    with:
+      race_detection: true
 
   analyze-runs:
     name: Analyze Runs

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -16,6 +16,11 @@ on:
     types:
       - dispatch-build
   workflow_call:
+    inputs:
+      race_detection:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
 
 jobs:
@@ -64,6 +69,7 @@ jobs:
       - name: Run "go test"
         env:
           JUNIT_FILE: junit-${{ matrix.binary_name }}.xml
+        shell: bash
         run: |
           # Building the web UI on Windows merely creates an empty file at
           # web_ui/frontend/out/index.html. Nevertheless, we'll go through
@@ -71,7 +77,19 @@ jobs:
           echo "::group::Building web UI"
           make web-build
           echo "::endgroup::"
-          gotestsum --format pkgname-and-test-fails --hide-summary=output --junitfile "$env:JUNIT_FILE" -- -p=4 -timeout=15m -coverpkg=./... -covermode=count -coverprofile=${{ matrix.coverprofile }} -tags=${{ matrix.tags }} ./...
+          gotestsum \
+            --format pkgname-and-test-fails \
+            --hide-summary=output \
+            --junitfile "$JUNIT_FILE" \
+            -- \
+            -p=4 \
+            -timeout=${{ inputs.race_detection && '30m' || '15m' }} \
+            ${{ inputs.race_detection && '-race' || '' }} \
+            ${{ !inputs.race_detection && '-coverpkg=./...' || '' }} \
+            ${{ !inputs.race_detection && '-covermode=count' || '' }} \
+            ${{ !inputs.race_detection && format('-coverprofile={0}', matrix.coverprofile) || '' }} \
+            -tags=${{ matrix.tags }} \
+            ./...
 
       - name: Upload JUnit report
         if: always()

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
   <img alt="Go Report" src="https://img.shields.io/badge/go%20report-A+-brightgreen.svg?style=for-the-badge">
 </p>
 
+<p align="center">
+  <a href="https://github.com/PelicanPlatform/pelican/actions/workflows/test-linux-scheduled.yml"><img alt="Nightly Tests (Linux)" src="https://img.shields.io/github/actions/workflow/status/PelicanPlatform/pelican/test-linux-scheduled.yml?style=for-the-badge&label=Nightly%20(Linux)"></a>
+  <a href="https://github.com/PelicanPlatform/pelican/actions/workflows/test-macos-scheduled.yml"><img alt="Nightly Tests (macOS)" src="https://img.shields.io/github/actions/workflow/status/PelicanPlatform/pelican/test-macos-scheduled.yml?style=for-the-badge&label=Nightly%20(macOS)"></a>
+  <a href="https://github.com/PelicanPlatform/pelican/actions/workflows/test-windows-scheduled.yml"><img alt="Nightly Tests (Windows)" src="https://img.shields.io/github/actions/workflow/status/PelicanPlatform/pelican/test-windows-scheduled.yml?style=for-the-badge&label=Nightly%20(Windows)"></a>
+</p>
+
 The Pelican command line tool allows one to use a Pelican federation as a client and serve datasets through running a Pelican origin service.
 
 For more information on Pelican, see the [Pelican Platform page](https://pelicanplatform.org/).

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -768,7 +768,8 @@ RUN --mount=type=cache,id=dnf-${TARGETPLATFORM},target=/var/cache/dnf,sharing=lo
   set -o pipefail
 
   # Install packages for building Pelican.
-  dnf install -y git make
+  # gcc is also needed to enable the Go race detector (-race flag).
+  dnf install -y gcc git make
 
   # Install HTCondor for integration tests, but forcibly remove the
   # Pelican packages that it pulls in so that there is zero chance tests


### PR DESCRIPTION
Since the race detector is good at... finding race bugs, I decided it was worth running nightly. I don't want to run as part of every PR's suite of actions because of the extra time overhead (2-3x from what I can tell).

In addition, I'm adding a repo badge that will turn red when nightly tests fail. I more or less expect this to be red for the foreseeable future, and it'll be a badge of shame until we finally clean up all of our lousy tests.

Closes #3263 