### PR TITLE
Auto fill in GitHub-OAuth-specific config param values

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1781,13 +1781,13 @@ func ApplyLogLevelInheritance(v *viper.Viper) {
 // values show up as IsSet()=true even when the user never wrote them. We use these
 // constants to distinguish "came from defaults.yaml" from "user explicitly set".
 var cilogonOIDCDefaults = struct {
-	issuer              string
-	authorizationEndpt  string
-	tokenEndpt          string
-	userInfoEndpt       string
-	deviceAuthEndpt     string
-	scopes              []string
-	authUserClaim       string
+	issuer             string
+	authorizationEndpt string
+	tokenEndpt         string
+	userInfoEndpt      string
+	deviceAuthEndpt    string
+	scopes             []string
+	authUserClaim      string
 }{
 	issuer:             "https://cilogon.org",
 	authorizationEndpt: "https://cilogon.org/authorize",

--- a/config/config.go
+++ b/config/config.go
@@ -1243,6 +1243,11 @@ func initConfigInternalImpl(logLevel log.Level) {
 		cobra.CheckErr(err)
 	}
 
+	// Auto-fill GitHub OAuth2 endpoints and claim names when GroupSource is "github".
+	// This runs after all config sources are merged so GroupSource is readable,
+	// and early enough that pelican config get also reflects the filled values.
+	cobra.CheckErr(applyGitHubOAuthDefaults())
+
 	// Use configuration to set the logging level, which must be fed to
 	// the logging library and isn't accessed directly through viper
 	err = setLoggingInternal()
@@ -1769,6 +1774,94 @@ func ApplyLogLevelInheritance(v *viper.Viper) {
 			v.Set(name, effectiveLevel)
 		}
 	}
+}
+
+// cilogonOIDCDefaults holds the OIDC values that defaults.yaml seeds for CILogon.
+// Because defaults.yaml is loaded via MergeConfig (not viper.SetDefault), these
+// values show up as IsSet()=true even when the user never wrote them. We use these
+// constants to distinguish "came from defaults.yaml" from "user explicitly set".
+var cilogonOIDCDefaults = struct {
+	issuer              string
+	authorizationEndpt  string
+	tokenEndpt          string
+	userInfoEndpt       string
+	deviceAuthEndpt     string
+	scopes              []string
+	authUserClaim       string
+}{
+	issuer:             "https://cilogon.org",
+	authorizationEndpt: "https://cilogon.org/authorize",
+	tokenEndpt:         "https://cilogon.org/oauth2/token",
+	userInfoEndpt:      "https://cilogon.org/oauth2/userinfo",
+	deviceAuthEndpt:    "https://cilogon.org/oauth2/device_authorization",
+	scopes:             []string{"openid", "email", "profile"},
+	authUserClaim:      "sub",
+}
+
+// isOIDCParamUserSet returns true only if the string parameter was explicitly set
+// by the user (not just populated from defaults.yaml).
+// defaults.yaml is loaded via MergeConfig, making IsSet() return true for all its
+// keys. We work around this by treating a value that still matches the known
+// defaults.yaml default as "not user-set".
+func isOIDCParamUserSet(p param.StringParam, defaultVal string) bool {
+	return p.IsSet() && p.GetString() != defaultVal
+}
+
+// applyGitHubOAuthDefaults sets GitHub-specific OAuth2 endpoint and claim defaults
+// when Issuer.GroupSource is set to "github". This spares operators from having to
+// manually specify every fixed GitHub endpoint and claim name.
+// Values that the user has explicitly set (i.e. differ from the CILogon defaults
+// that defaults.yaml seeds) are never overwritten.
+func applyGitHubOAuthDefaults() error {
+	if strings.ToLower(param.Issuer_GroupSource.GetString()) != "github" {
+		return nil
+	}
+	log.Info("GitHub group source detected; auto-filling GitHub OAuth2 endpoint and claim defaults")
+	defaults := map[string]interface{}{}
+
+	if !isOIDCParamUserSet(param.OIDC_Issuer, cilogonOIDCDefaults.issuer) {
+		defaults[param.OIDC_Issuer.GetName()] = "https://github.com"
+	}
+	if !isOIDCParamUserSet(param.OIDC_AuthorizationEndpoint, cilogonOIDCDefaults.authorizationEndpt) {
+		defaults[param.OIDC_AuthorizationEndpoint.GetName()] = "https://github.com/login/oauth/authorize"
+	}
+	if !isOIDCParamUserSet(param.OIDC_TokenEndpoint, cilogonOIDCDefaults.tokenEndpt) {
+		defaults[param.OIDC_TokenEndpoint.GetName()] = "https://github.com/login/oauth/access_token"
+	}
+	if !isOIDCParamUserSet(param.OIDC_UserInfoEndpoint, cilogonOIDCDefaults.userInfoEndpt) {
+		defaults[param.OIDC_UserInfoEndpoint.GetName()] = "https://api.github.com/user"
+	}
+	if !isOIDCParamUserSet(param.OIDC_DeviceAuthEndpoint, cilogonOIDCDefaults.deviceAuthEndpt) {
+		defaults[param.OIDC_DeviceAuthEndpoint.GetName()] = "https://github.com/login/device/code"
+	}
+	// For scopes, compare the sorted slice against the known CILogon default.
+	currentScopes := param.OIDC_Scopes.GetStringSlice()
+	scopesAreDefault := len(currentScopes) == len(cilogonOIDCDefaults.scopes)
+	if scopesAreDefault {
+		for i, s := range cilogonOIDCDefaults.scopes {
+			if currentScopes[i] != s {
+				scopesAreDefault = false
+				break
+			}
+		}
+	}
+	if !param.OIDC_Scopes.IsSet() || scopesAreDefault {
+		defaults[param.OIDC_Scopes.GetName()] = []string{"user", "read:org"}
+	}
+	if !isOIDCParamUserSet(param.Issuer_OIDCAuthenticationUserClaim, cilogonOIDCDefaults.authUserClaim) {
+		defaults[param.Issuer_OIDCAuthenticationUserClaim.GetName()] = "login"
+	}
+	// OIDCSubjectClaim has no defaults.yaml entry, so IsSet() is reliable here.
+	if !param.Issuer_OIDCSubjectClaim.IsSet() {
+		defaults[param.Issuer_OIDCSubjectClaim.GetName()] = "id"
+	}
+
+	if len(defaults) > 0 {
+		if err := param.MultiSet(defaults); err != nil {
+			return errors.Wrap(err, "failed to apply GitHub OAuth2 defaults")
+		}
+	}
+	return nil
 }
 
 // Initialize Pelican server instance. Pass a bit mask of `currentServers` if you want to enable multiple services.

--- a/config/config.go
+++ b/config/config.go
@@ -1243,11 +1243,6 @@ func initConfigInternalImpl(logLevel log.Level) {
 		cobra.CheckErr(err)
 	}
 
-	// Auto-fill GitHub OAuth2 endpoints and claim names when GroupSource is "github".
-	// This runs after all config sources are merged so GroupSource is readable,
-	// and early enough that pelican config get also reflects the filled values.
-	cobra.CheckErr(applyGitHubOAuthDefaults())
-
 	// Use configuration to set the logging level, which must be fed to
 	// the logging library and isn't accessed directly through viper
 	err = setLoggingInternal()
@@ -1556,6 +1551,10 @@ func SetServerDefaults(v *viper.Viper) error {
 	// the base default ("none") and the client default ("warn").
 	ApplyServerDefaults(v)
 
+	// Register OIDC/OAuth2 endpoint and claim defaults based on the configured OAuth
+	// flavor (CILogon by default, GitHub when Issuer.GroupSource == "github").
+	setOAuthFlavorDefaults(v)
+
 	// Deprecated param defaults: excluded from generated SetParameterDefaults
 	// because deprecated params are skipped during generation. Keep these until
 	// the params are fully removed.
@@ -1776,92 +1775,67 @@ func ApplyLogLevelInheritance(v *viper.Viper) {
 	}
 }
 
-// cilogonOIDCDefaults holds the OIDC values that defaults.yaml seeds for CILogon.
-// Because defaults.yaml is loaded via MergeConfig (not viper.SetDefault), these
-// values show up as IsSet()=true even when the user never wrote them. We use these
-// constants to distinguish "came from defaults.yaml" from "user explicitly set".
-var cilogonOIDCDefaults = struct {
-	issuer             string
-	authorizationEndpt string
-	tokenEndpt         string
-	userInfoEndpt      string
-	deviceAuthEndpt    string
-	scopes             []string
-	authUserClaim      string
-}{
-	issuer:             "https://cilogon.org",
-	authorizationEndpt: "https://cilogon.org/authorize",
-	tokenEndpt:         "https://cilogon.org/oauth2/token",
-	userInfoEndpt:      "https://cilogon.org/oauth2/userinfo",
-	deviceAuthEndpt:    "https://cilogon.org/oauth2/device_authorization",
-	scopes:             []string{"openid", "email", "profile"},
-	authUserClaim:      "sub",
+// OAuthFlavor decides the default values for OIDC/OAuth2 config params.
+// Pelican ships two flavors: CILogon (the federation default) and GitHub.
+// The flavor is selected at runtime from Issuer.GroupSource.
+type OAuthFlavor string
+
+const (
+	OAuthFlavorCILogon OAuthFlavor = "cilogon"
+	OAuthFlavorGitHub  OAuthFlavor = "github"
+)
+
+// oauthFlavorFromGroupSource maps an Issuer.GroupSource value to an OAuthFlavor.
+// Only "github" selects the GitHub flavor; every other value (none, file, oidc,
+// internal, unset) falls back to CILogon so existing deployments are unaffected.
+func oauthFlavorFromGroupSource(groupSource string) OAuthFlavor {
+	if strings.EqualFold(groupSource, string(OAuthFlavorGitHub)) {
+		return OAuthFlavorGitHub
+	}
+	return OAuthFlavorCILogon
 }
 
-// isOIDCParamUserSet returns true only if the string parameter was explicitly set
-// by the user (not just populated from defaults.yaml).
-// defaults.yaml is loaded via MergeConfig, making IsSet() return true for all its
-// keys. We work around this by treating a value that still matches the known
-// defaults.yaml default as "not user-set".
-func isOIDCParamUserSet(p param.StringParam, defaultVal string) bool {
-	return p.IsSet() && p.GetString() != defaultVal
+// oauthFlavorDefaults holds the OIDC/OAuth2 endpoint and claim defaults for each OAuth
+// flavor. These params carry "default: none" in parameters.yaml so this map is the
+// single source of their defaults; the per-flavor values are documented per-param in
+// parameters.yaml.
+var oauthFlavorDefaults = map[OAuthFlavor]map[string]any{
+	OAuthFlavorCILogon: {
+		param.OIDC_Issuer.GetName():                        "https://cilogon.org",
+		param.OIDC_AuthorizationEndpoint.GetName():         "https://cilogon.org/authorize",
+		param.OIDC_TokenEndpoint.GetName():                 "https://cilogon.org/oauth2/token",
+		param.OIDC_UserInfoEndpoint.GetName():              "https://cilogon.org/oauth2/userinfo",
+		param.OIDC_DeviceAuthEndpoint.GetName():            "https://cilogon.org/oauth2/device_authorization",
+		param.OIDC_Scopes.GetName():                        []string{"openid", "email", "profile"},
+		param.Issuer_OIDCAuthenticationUserClaim.GetName(): "sub",
+		param.Issuer_OIDCSubjectClaim.GetName():            "sub",
+	},
+	OAuthFlavorGitHub: {
+		param.OIDC_Issuer.GetName():                        "https://github.com",
+		param.OIDC_AuthorizationEndpoint.GetName():         "https://github.com/login/oauth/authorize",
+		param.OIDC_TokenEndpoint.GetName():                 "https://github.com/login/oauth/access_token",
+		param.OIDC_UserInfoEndpoint.GetName():              "https://api.github.com/user",
+		param.OIDC_DeviceAuthEndpoint.GetName():            "https://github.com/login/device/code",
+		param.OIDC_Scopes.GetName():                        []string{"user", "read:org"},
+		param.Issuer_OIDCAuthenticationUserClaim.GetName(): "login",
+		param.Issuer_OIDCSubjectClaim.GetName():            "id",
+	},
 }
 
-// applyGitHubOAuthDefaults sets GitHub-specific OAuth2 endpoint and claim defaults
-// when Issuer.GroupSource is set to "github". This spares operators from having to
-// manually specify every fixed GitHub endpoint and claim name.
-// Values that the user has explicitly set (i.e. differ from the CILogon defaults
-// that defaults.yaml seeds) are never overwritten.
-func applyGitHubOAuthDefaults() error {
-	if strings.ToLower(param.Issuer_GroupSource.GetString()) != "github" {
-		return nil
+func setOAuthFlavorDefaults(v *viper.Viper) {
+	flavor := oauthFlavorFromGroupSource(v.GetString(param.Issuer_GroupSource.GetName()))
+	if flavor == OAuthFlavorGitHub {
+		log.Debug("GitHub group source detected; applying GitHub OAuth2 endpoint and claim defaults")
 	}
-	log.Info("GitHub group source detected; auto-filling GitHub OAuth2 endpoint and claim defaults")
-	defaults := map[string]interface{}{}
-
-	if !isOIDCParamUserSet(param.OIDC_Issuer, cilogonOIDCDefaults.issuer) {
-		defaults[param.OIDC_Issuer.GetName()] = "https://github.com"
-	}
-	if !isOIDCParamUserSet(param.OIDC_AuthorizationEndpoint, cilogonOIDCDefaults.authorizationEndpt) {
-		defaults[param.OIDC_AuthorizationEndpoint.GetName()] = "https://github.com/login/oauth/authorize"
-	}
-	if !isOIDCParamUserSet(param.OIDC_TokenEndpoint, cilogonOIDCDefaults.tokenEndpt) {
-		defaults[param.OIDC_TokenEndpoint.GetName()] = "https://github.com/login/oauth/access_token"
-	}
-	if !isOIDCParamUserSet(param.OIDC_UserInfoEndpoint, cilogonOIDCDefaults.userInfoEndpt) {
-		defaults[param.OIDC_UserInfoEndpoint.GetName()] = "https://api.github.com/user"
-	}
-	if !isOIDCParamUserSet(param.OIDC_DeviceAuthEndpoint, cilogonOIDCDefaults.deviceAuthEndpt) {
-		defaults[param.OIDC_DeviceAuthEndpoint.GetName()] = "https://github.com/login/device/code"
-	}
-	// For scopes, compare the sorted slice against the known CILogon default.
-	currentScopes := param.OIDC_Scopes.GetStringSlice()
-	scopesAreDefault := len(currentScopes) == len(cilogonOIDCDefaults.scopes)
-	if scopesAreDefault {
-		for i, s := range cilogonOIDCDefaults.scopes {
-			if currentScopes[i] != s {
-				scopesAreDefault = false
-				break
-			}
+	st := GetSourceTracker()
+	for key, val := range oauthFlavorDefaults[flavor] {
+		// Use v.SetDefault so any value the user set via config
+		// file or env still wins through viper's normal precedence
+		v.SetDefault(key, val)
+		if src, ok := st.Get(strings.ToLower(key)); !ok || src.Type == SourceDefault {
+			st.Record(strings.ToLower(key), ConfigSource{Type: SourceDefault})
 		}
 	}
-	if !param.OIDC_Scopes.IsSet() || scopesAreDefault {
-		defaults[param.OIDC_Scopes.GetName()] = []string{"user", "read:org"}
-	}
-	if !isOIDCParamUserSet(param.Issuer_OIDCAuthenticationUserClaim, cilogonOIDCDefaults.authUserClaim) {
-		defaults[param.Issuer_OIDCAuthenticationUserClaim.GetName()] = "login"
-	}
-	// OIDCSubjectClaim has no defaults.yaml entry, so IsSet() is reliable here.
-	if !param.Issuer_OIDCSubjectClaim.IsSet() {
-		defaults[param.Issuer_OIDCSubjectClaim.GetName()] = "id"
-	}
-
-	if len(defaults) > 0 {
-		if err := param.MultiSet(defaults); err != nil {
-			return errors.Wrap(err, "failed to apply GitHub OAuth2 defaults")
-		}
-	}
-	return nil
 }
 
 // Initialize Pelican server instance. Pass a bit mask of `currentServers` if you want to enable multiple services.

--- a/config/config.go
+++ b/config/config.go
@@ -2122,13 +2122,13 @@ func ApplyLogLevelInheritance(v *viper.Viper) {
 // values show up as IsSet()=true even when the user never wrote them. We use these
 // constants to distinguish "came from defaults.yaml" from "user explicitly set".
 var cilogonOIDCDefaults = struct {
-	issuer              string
-	authorizationEndpt  string
-	tokenEndpt          string
-	userInfoEndpt       string
-	deviceAuthEndpt     string
-	scopes              []string
-	authUserClaim       string
+	issuer             string
+	authorizationEndpt string
+	tokenEndpt         string
+	userInfoEndpt      string
+	deviceAuthEndpt    string
+	scopes             []string
+	authUserClaim      string
 }{
 	issuer:             "https://cilogon.org",
 	authorizationEndpt: "https://cilogon.org/authorize",

--- a/config/config.go
+++ b/config/config.go
@@ -1539,6 +1539,11 @@ func initConfigInternalImpl(logLevel log.Level) {
 		cobra.CheckErr(err)
 	}
 
+	// Auto-fill GitHub OAuth2 endpoints and claim names when GroupSource is "github".
+	// This runs after all config sources are merged so GroupSource is readable,
+	// and early enough that pelican config get also reflects the filled values.
+	cobra.CheckErr(applyGitHubOAuthDefaults())
+
 	// Use configuration to set the logging level, which must be fed to
 	// the logging library and isn't accessed directly through viper
 	err = setLoggingInternal()
@@ -2110,6 +2115,94 @@ func ApplyLogLevelInheritance(v *viper.Viper) {
 			v.Set(name, effectiveLevel)
 		}
 	}
+}
+
+// cilogonOIDCDefaults holds the OIDC values that defaults.yaml seeds for CILogon.
+// Because defaults.yaml is loaded via MergeConfig (not viper.SetDefault), these
+// values show up as IsSet()=true even when the user never wrote them. We use these
+// constants to distinguish "came from defaults.yaml" from "user explicitly set".
+var cilogonOIDCDefaults = struct {
+	issuer              string
+	authorizationEndpt  string
+	tokenEndpt          string
+	userInfoEndpt       string
+	deviceAuthEndpt     string
+	scopes              []string
+	authUserClaim       string
+}{
+	issuer:             "https://cilogon.org",
+	authorizationEndpt: "https://cilogon.org/authorize",
+	tokenEndpt:         "https://cilogon.org/oauth2/token",
+	userInfoEndpt:      "https://cilogon.org/oauth2/userinfo",
+	deviceAuthEndpt:    "https://cilogon.org/oauth2/device_authorization",
+	scopes:             []string{"openid", "email", "profile"},
+	authUserClaim:      "sub",
+}
+
+// isOIDCParamUserSet returns true only if the string parameter was explicitly set
+// by the user (not just populated from defaults.yaml).
+// defaults.yaml is loaded via MergeConfig, making IsSet() return true for all its
+// keys. We work around this by treating a value that still matches the known
+// defaults.yaml default as "not user-set".
+func isOIDCParamUserSet(p param.StringParam, defaultVal string) bool {
+	return p.IsSet() && p.GetString() != defaultVal
+}
+
+// applyGitHubOAuthDefaults sets GitHub-specific OAuth2 endpoint and claim defaults
+// when Issuer.GroupSource is set to "github". This spares operators from having to
+// manually specify every fixed GitHub endpoint and claim name.
+// Values that the user has explicitly set (i.e. differ from the CILogon defaults
+// that defaults.yaml seeds) are never overwritten.
+func applyGitHubOAuthDefaults() error {
+	if strings.ToLower(param.Issuer_GroupSource.GetString()) != "github" {
+		return nil
+	}
+	log.Info("GitHub group source detected; auto-filling GitHub OAuth2 endpoint and claim defaults")
+	defaults := map[string]interface{}{}
+
+	if !isOIDCParamUserSet(param.OIDC_Issuer, cilogonOIDCDefaults.issuer) {
+		defaults[param.OIDC_Issuer.GetName()] = "https://github.com"
+	}
+	if !isOIDCParamUserSet(param.OIDC_AuthorizationEndpoint, cilogonOIDCDefaults.authorizationEndpt) {
+		defaults[param.OIDC_AuthorizationEndpoint.GetName()] = "https://github.com/login/oauth/authorize"
+	}
+	if !isOIDCParamUserSet(param.OIDC_TokenEndpoint, cilogonOIDCDefaults.tokenEndpt) {
+		defaults[param.OIDC_TokenEndpoint.GetName()] = "https://github.com/login/oauth/access_token"
+	}
+	if !isOIDCParamUserSet(param.OIDC_UserInfoEndpoint, cilogonOIDCDefaults.userInfoEndpt) {
+		defaults[param.OIDC_UserInfoEndpoint.GetName()] = "https://api.github.com/user"
+	}
+	if !isOIDCParamUserSet(param.OIDC_DeviceAuthEndpoint, cilogonOIDCDefaults.deviceAuthEndpt) {
+		defaults[param.OIDC_DeviceAuthEndpoint.GetName()] = "https://github.com/login/device/code"
+	}
+	// For scopes, compare the sorted slice against the known CILogon default.
+	currentScopes := param.OIDC_Scopes.GetStringSlice()
+	scopesAreDefault := len(currentScopes) == len(cilogonOIDCDefaults.scopes)
+	if scopesAreDefault {
+		for i, s := range cilogonOIDCDefaults.scopes {
+			if currentScopes[i] != s {
+				scopesAreDefault = false
+				break
+			}
+		}
+	}
+	if !param.OIDC_Scopes.IsSet() || scopesAreDefault {
+		defaults[param.OIDC_Scopes.GetName()] = []string{"user", "read:org"}
+	}
+	if !isOIDCParamUserSet(param.Issuer_OIDCAuthenticationUserClaim, cilogonOIDCDefaults.authUserClaim) {
+		defaults[param.Issuer_OIDCAuthenticationUserClaim.GetName()] = "login"
+	}
+	// OIDCSubjectClaim has no defaults.yaml entry, so IsSet() is reliable here.
+	if !param.Issuer_OIDCSubjectClaim.IsSet() {
+		defaults[param.Issuer_OIDCSubjectClaim.GetName()] = "id"
+	}
+
+	if len(defaults) > 0 {
+		if err := param.MultiSet(defaults); err != nil {
+			return errors.Wrap(err, "failed to apply GitHub OAuth2 defaults")
+		}
+	}
+	return nil
 }
 
 // Initialize Pelican server instance. Pass a bit mask of `currentServers` if you want to enable multiple services.

--- a/config/config.go
+++ b/config/config.go
@@ -1539,11 +1539,6 @@ func initConfigInternalImpl(logLevel log.Level) {
 		cobra.CheckErr(err)
 	}
 
-	// Auto-fill GitHub OAuth2 endpoints and claim names when GroupSource is "github".
-	// This runs after all config sources are merged so GroupSource is readable,
-	// and early enough that pelican config get also reflects the filled values.
-	cobra.CheckErr(applyGitHubOAuthDefaults())
-
 	// Use configuration to set the logging level, which must be fed to
 	// the logging library and isn't accessed directly through viper
 	err = setLoggingInternal()
@@ -1882,6 +1877,10 @@ func SetServerDefaults(v *viper.Viper) error {
 	// the base default ("none") and the client default ("warn").
 	ApplyServerDefaults(v)
 
+	// Register OIDC/OAuth2 endpoint and claim defaults based on the configured OAuth
+	// flavor (CILogon by default, GitHub when Issuer.GroupSource == "github").
+	setOAuthFlavorDefaults(v)
+
 	// Deprecated param defaults: excluded from generated SetParameterDefaults
 	// because deprecated params are skipped during generation. Keep these until
 	// the params are fully removed.
@@ -2117,92 +2116,67 @@ func ApplyLogLevelInheritance(v *viper.Viper) {
 	}
 }
 
-// cilogonOIDCDefaults holds the OIDC values that defaults.yaml seeds for CILogon.
-// Because defaults.yaml is loaded via MergeConfig (not viper.SetDefault), these
-// values show up as IsSet()=true even when the user never wrote them. We use these
-// constants to distinguish "came from defaults.yaml" from "user explicitly set".
-var cilogonOIDCDefaults = struct {
-	issuer             string
-	authorizationEndpt string
-	tokenEndpt         string
-	userInfoEndpt      string
-	deviceAuthEndpt    string
-	scopes             []string
-	authUserClaim      string
-}{
-	issuer:             "https://cilogon.org",
-	authorizationEndpt: "https://cilogon.org/authorize",
-	tokenEndpt:         "https://cilogon.org/oauth2/token",
-	userInfoEndpt:      "https://cilogon.org/oauth2/userinfo",
-	deviceAuthEndpt:    "https://cilogon.org/oauth2/device_authorization",
-	scopes:             []string{"openid", "email", "profile"},
-	authUserClaim:      "sub",
+// OAuthFlavor decides the default values for OIDC/OAuth2 config params.
+// Pelican ships two flavors: CILogon (the federation default) and GitHub.
+// The flavor is selected at runtime from Issuer.GroupSource.
+type OAuthFlavor string
+
+const (
+	OAuthFlavorCILogon OAuthFlavor = "cilogon"
+	OAuthFlavorGitHub  OAuthFlavor = "github"
+)
+
+// oauthFlavorFromGroupSource maps an Issuer.GroupSource value to an OAuthFlavor.
+// Only "github" selects the GitHub flavor; every other value (none, file, oidc,
+// internal, unset) falls back to CILogon so existing deployments are unaffected.
+func oauthFlavorFromGroupSource(groupSource string) OAuthFlavor {
+	if strings.EqualFold(groupSource, string(OAuthFlavorGitHub)) {
+		return OAuthFlavorGitHub
+	}
+	return OAuthFlavorCILogon
 }
 
-// isOIDCParamUserSet returns true only if the string parameter was explicitly set
-// by the user (not just populated from defaults.yaml).
-// defaults.yaml is loaded via MergeConfig, making IsSet() return true for all its
-// keys. We work around this by treating a value that still matches the known
-// defaults.yaml default as "not user-set".
-func isOIDCParamUserSet(p param.StringParam, defaultVal string) bool {
-	return p.IsSet() && p.GetString() != defaultVal
+// oauthFlavorDefaults holds the OIDC/OAuth2 endpoint and claim defaults for each OAuth
+// flavor. These params carry "default: none" in parameters.yaml so this map is the
+// single source of their defaults; the per-flavor values are documented per-param in
+// parameters.yaml.
+var oauthFlavorDefaults = map[OAuthFlavor]map[string]any{
+	OAuthFlavorCILogon: {
+		param.OIDC_Issuer.GetName():                        "https://cilogon.org",
+		param.OIDC_AuthorizationEndpoint.GetName():         "https://cilogon.org/authorize",
+		param.OIDC_TokenEndpoint.GetName():                 "https://cilogon.org/oauth2/token",
+		param.OIDC_UserInfoEndpoint.GetName():              "https://cilogon.org/oauth2/userinfo",
+		param.OIDC_DeviceAuthEndpoint.GetName():            "https://cilogon.org/oauth2/device_authorization",
+		param.OIDC_Scopes.GetName():                        []string{"openid", "email", "profile"},
+		param.Issuer_OIDCAuthenticationUserClaim.GetName(): "sub",
+		param.Issuer_OIDCSubjectClaim.GetName():            "sub",
+	},
+	OAuthFlavorGitHub: {
+		param.OIDC_Issuer.GetName():                        "https://github.com",
+		param.OIDC_AuthorizationEndpoint.GetName():         "https://github.com/login/oauth/authorize",
+		param.OIDC_TokenEndpoint.GetName():                 "https://github.com/login/oauth/access_token",
+		param.OIDC_UserInfoEndpoint.GetName():              "https://api.github.com/user",
+		param.OIDC_DeviceAuthEndpoint.GetName():            "https://github.com/login/device/code",
+		param.OIDC_Scopes.GetName():                        []string{"user", "read:org"},
+		param.Issuer_OIDCAuthenticationUserClaim.GetName(): "login",
+		param.Issuer_OIDCSubjectClaim.GetName():            "id",
+	},
 }
 
-// applyGitHubOAuthDefaults sets GitHub-specific OAuth2 endpoint and claim defaults
-// when Issuer.GroupSource is set to "github". This spares operators from having to
-// manually specify every fixed GitHub endpoint and claim name.
-// Values that the user has explicitly set (i.e. differ from the CILogon defaults
-// that defaults.yaml seeds) are never overwritten.
-func applyGitHubOAuthDefaults() error {
-	if strings.ToLower(param.Issuer_GroupSource.GetString()) != "github" {
-		return nil
+func setOAuthFlavorDefaults(v *viper.Viper) {
+	flavor := oauthFlavorFromGroupSource(v.GetString(param.Issuer_GroupSource.GetName()))
+	if flavor == OAuthFlavorGitHub {
+		log.Debug("GitHub group source detected; applying GitHub OAuth2 endpoint and claim defaults")
 	}
-	log.Info("GitHub group source detected; auto-filling GitHub OAuth2 endpoint and claim defaults")
-	defaults := map[string]interface{}{}
-
-	if !isOIDCParamUserSet(param.OIDC_Issuer, cilogonOIDCDefaults.issuer) {
-		defaults[param.OIDC_Issuer.GetName()] = "https://github.com"
-	}
-	if !isOIDCParamUserSet(param.OIDC_AuthorizationEndpoint, cilogonOIDCDefaults.authorizationEndpt) {
-		defaults[param.OIDC_AuthorizationEndpoint.GetName()] = "https://github.com/login/oauth/authorize"
-	}
-	if !isOIDCParamUserSet(param.OIDC_TokenEndpoint, cilogonOIDCDefaults.tokenEndpt) {
-		defaults[param.OIDC_TokenEndpoint.GetName()] = "https://github.com/login/oauth/access_token"
-	}
-	if !isOIDCParamUserSet(param.OIDC_UserInfoEndpoint, cilogonOIDCDefaults.userInfoEndpt) {
-		defaults[param.OIDC_UserInfoEndpoint.GetName()] = "https://api.github.com/user"
-	}
-	if !isOIDCParamUserSet(param.OIDC_DeviceAuthEndpoint, cilogonOIDCDefaults.deviceAuthEndpt) {
-		defaults[param.OIDC_DeviceAuthEndpoint.GetName()] = "https://github.com/login/device/code"
-	}
-	// For scopes, compare the sorted slice against the known CILogon default.
-	currentScopes := param.OIDC_Scopes.GetStringSlice()
-	scopesAreDefault := len(currentScopes) == len(cilogonOIDCDefaults.scopes)
-	if scopesAreDefault {
-		for i, s := range cilogonOIDCDefaults.scopes {
-			if currentScopes[i] != s {
-				scopesAreDefault = false
-				break
-			}
+	st := GetSourceTracker()
+	for key, val := range oauthFlavorDefaults[flavor] {
+		// Use v.SetDefault so any value the user set via config
+		// file or env still wins through viper's normal precedence
+		v.SetDefault(key, val)
+		if src, ok := st.Get(strings.ToLower(key)); !ok || src.Type == SourceDefault {
+			st.Record(strings.ToLower(key), ConfigSource{Type: SourceDefault})
 		}
 	}
-	if !param.OIDC_Scopes.IsSet() || scopesAreDefault {
-		defaults[param.OIDC_Scopes.GetName()] = []string{"user", "read:org"}
-	}
-	if !isOIDCParamUserSet(param.Issuer_OIDCAuthenticationUserClaim, cilogonOIDCDefaults.authUserClaim) {
-		defaults[param.Issuer_OIDCAuthenticationUserClaim.GetName()] = "login"
-	}
-	// OIDCSubjectClaim has no defaults.yaml entry, so IsSet() is reliable here.
-	if !param.Issuer_OIDCSubjectClaim.IsSet() {
-		defaults[param.Issuer_OIDCSubjectClaim.GetName()] = "id"
-	}
-
-	if len(defaults) > 0 {
-		if err := param.MultiSet(defaults); err != nil {
-			return errors.Wrap(err, "failed to apply GitHub OAuth2 defaults")
-		}
-	}
-	return nil
 }
 
 // Initialize Pelican server instance. Pass a bit mask of `currentServers` if you want to enable multiple services.

--- a/config/oidc_metadata_test.go
+++ b/config/oidc_metadata_test.go
@@ -22,11 +22,76 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pelicanplatform/pelican/param"
 )
+
+func TestApplyGitHubOAuthDefaults(t *testing.T) {
+	t.Cleanup(ResetConfig)
+
+	t.Run("no-op-when-group-source-not-github", func(t *testing.T) {
+		ResetConfig()
+		SetBaseDefaultsInConfig(viper.GetViper())
+		require.NoError(t, applyGitHubOAuthDefaults())
+		assert.Equal(t, cilogonOIDCDefaults.issuer, param.OIDC_Issuer.GetString())
+	})
+
+	t.Run("fills-all-github-values-from-cilogon-defaults", func(t *testing.T) {
+		ResetConfig()
+		// Load defaults.yaml so all OIDC params are "IsSet" with CILogon values
+		SetBaseDefaultsInConfig(viper.GetViper())
+		require.NoError(t, param.Issuer_GroupSource.Set("github"))
+		require.NoError(t, applyGitHubOAuthDefaults())
+
+		assert.Equal(t, "https://github.com", param.OIDC_Issuer.GetString())
+		assert.Equal(t, "https://github.com/login/oauth/authorize", param.OIDC_AuthorizationEndpoint.GetString())
+		assert.Equal(t, "https://github.com/login/oauth/access_token", param.OIDC_TokenEndpoint.GetString())
+		assert.Equal(t, "https://api.github.com/user", param.OIDC_UserInfoEndpoint.GetString())
+		assert.Equal(t, "https://github.com/login/device/code", param.OIDC_DeviceAuthEndpoint.GetString())
+		assert.Equal(t, []string{"user", "read:org"}, param.OIDC_Scopes.GetStringSlice())
+		assert.Equal(t, "login", param.Issuer_OIDCAuthenticationUserClaim.GetString())
+		assert.Equal(t, "id", param.Issuer_OIDCSubjectClaim.GetString())
+	})
+
+	t.Run("case-insensitive-group-source", func(t *testing.T) {
+		ResetConfig()
+		SetBaseDefaultsInConfig(viper.GetViper())
+		require.NoError(t, param.Issuer_GroupSource.Set("GitHub"))
+		require.NoError(t, applyGitHubOAuthDefaults())
+		assert.Equal(t, "https://github.com", param.OIDC_Issuer.GetString())
+	})
+
+	t.Run("user-set-issuer-not-overwritten", func(t *testing.T) {
+		ResetConfig()
+		SetBaseDefaultsInConfig(viper.GetViper())
+		require.NoError(t, param.Issuer_GroupSource.Set("github"))
+		require.NoError(t, param.OIDC_Issuer.Set("https://my-custom-oauth.example.com"))
+		require.NoError(t, applyGitHubOAuthDefaults())
+		assert.Equal(t, "https://my-custom-oauth.example.com", param.OIDC_Issuer.GetString())
+	})
+
+	t.Run("user-set-scopes-not-overwritten", func(t *testing.T) {
+		ResetConfig()
+		SetBaseDefaultsInConfig(viper.GetViper())
+		require.NoError(t, param.Issuer_GroupSource.Set("github"))
+		require.NoError(t, param.OIDC_Scopes.Set([]string{"user", "read:org", "repo"}))
+		require.NoError(t, applyGitHubOAuthDefaults())
+		assert.Equal(t, []string{"user", "read:org", "repo"}, param.OIDC_Scopes.GetStringSlice())
+	})
+
+	t.Run("user-set-auth-claim-not-overwritten", func(t *testing.T) {
+		ResetConfig()
+		SetBaseDefaultsInConfig(viper.GetViper())
+		require.NoError(t, param.Issuer_GroupSource.Set("github"))
+		require.NoError(t, param.Issuer_OIDCAuthenticationUserClaim.Set("email"))
+		require.NoError(t, applyGitHubOAuthDefaults())
+		assert.Equal(t, "email", param.Issuer_OIDCAuthenticationUserClaim.GetString())
+	})
+}
+
 
 func TestGetOIDCProvider(t *testing.T) {
 	t.Cleanup(func() {

--- a/config/oidc_metadata_test.go
+++ b/config/oidc_metadata_test.go
@@ -92,7 +92,6 @@ func TestApplyGitHubOAuthDefaults(t *testing.T) {
 	})
 }
 
-
 func TestGetOIDCProvider(t *testing.T) {
 	t.Cleanup(func() {
 		ResetConfig()

--- a/config/oidc_metadata_test.go
+++ b/config/oidc_metadata_test.go
@@ -19,6 +19,7 @@
 package config
 
 import (
+	"strings"
 	"sync"
 	"testing"
 
@@ -29,22 +30,39 @@ import (
 	"github.com/pelicanplatform/pelican/param"
 )
 
-func TestApplyGitHubOAuthDefaults(t *testing.T) {
+func TestSetOAuthFlavorDefaults(t *testing.T) {
 	t.Cleanup(ResetConfig)
 
-	t.Run("no-op-when-group-source-not-github", func(t *testing.T) {
+	// setOAuthFlavorDefaults registers defaults directly on viper; refresh the cached
+	// param.Config so the typed accessors reflect them (InitServer and the config tool
+	// do the same after SetServerDefaults).
+	refresh := func(t *testing.T) {
+		_, err := param.Refresh()
+		require.NoError(t, err)
+	}
+
+	t.Run("cilogon-defaults-when-group-source-not-github", func(t *testing.T) {
 		ResetConfig()
 		SetBaseDefaultsInConfig(viper.GetViper())
-		require.NoError(t, applyGitHubOAuthDefaults())
-		assert.Equal(t, cilogonOIDCDefaults.issuer, param.OIDC_Issuer.GetString())
+		setOAuthFlavorDefaults(viper.GetViper())
+		refresh(t)
+
+		assert.Equal(t, "https://cilogon.org", param.OIDC_Issuer.GetString())
+		assert.Equal(t, "https://cilogon.org/authorize", param.OIDC_AuthorizationEndpoint.GetString())
+		assert.Equal(t, "https://cilogon.org/oauth2/token", param.OIDC_TokenEndpoint.GetString())
+		assert.Equal(t, "https://cilogon.org/oauth2/userinfo", param.OIDC_UserInfoEndpoint.GetString())
+		assert.Equal(t, "https://cilogon.org/oauth2/device_authorization", param.OIDC_DeviceAuthEndpoint.GetString())
+		assert.Equal(t, []string{"openid", "email", "profile"}, param.OIDC_Scopes.GetStringSlice())
+		assert.Equal(t, "sub", param.Issuer_OIDCAuthenticationUserClaim.GetString())
+		assert.Equal(t, "sub", param.Issuer_OIDCSubjectClaim.GetString())
 	})
 
-	t.Run("fills-all-github-values-from-cilogon-defaults", func(t *testing.T) {
+	t.Run("github-defaults-when-group-source-github", func(t *testing.T) {
 		ResetConfig()
-		// Load defaults.yaml so all OIDC params are "IsSet" with CILogon values
 		SetBaseDefaultsInConfig(viper.GetViper())
 		require.NoError(t, param.Issuer_GroupSource.Set("github"))
-		require.NoError(t, applyGitHubOAuthDefaults())
+		setOAuthFlavorDefaults(viper.GetViper())
+		refresh(t)
 
 		assert.Equal(t, "https://github.com", param.OIDC_Issuer.GetString())
 		assert.Equal(t, "https://github.com/login/oauth/authorize", param.OIDC_AuthorizationEndpoint.GetString())
@@ -56,38 +74,74 @@ func TestApplyGitHubOAuthDefaults(t *testing.T) {
 		assert.Equal(t, "id", param.Issuer_OIDCSubjectClaim.GetString())
 	})
 
+	t.Run("records-flavor-default-provenance", func(t *testing.T) {
+		ResetConfig()
+		SetBaseDefaultsInConfig(viper.GetViper())
+		require.NoError(t, param.Issuer_GroupSource.Set("github"))
+		setOAuthFlavorDefaults(viper.GetViper())
+
+		// The flavor defaults are set after RecordDefaultKeys, so the dispatcher must
+		// record them itself — otherwise `config get --verbose` reports "unknown".
+		src, ok := GetSourceTracker().Get(strings.ToLower(param.OIDC_Issuer.GetName()))
+		require.True(t, ok)
+		assert.Equal(t, SourceDefault, src.Type)
+	})
+
 	t.Run("case-insensitive-group-source", func(t *testing.T) {
 		ResetConfig()
 		SetBaseDefaultsInConfig(viper.GetViper())
 		require.NoError(t, param.Issuer_GroupSource.Set("GitHub"))
-		require.NoError(t, applyGitHubOAuthDefaults())
+		setOAuthFlavorDefaults(viper.GetViper())
+		refresh(t)
 		assert.Equal(t, "https://github.com", param.OIDC_Issuer.GetString())
 	})
 
-	t.Run("user-set-issuer-not-overwritten", func(t *testing.T) {
+	t.Run("non-github-group-sources-fall-back-to-cilogon", func(t *testing.T) {
+		for _, gs := range []string{"none", "file", "oidc", "internal"} {
+			ResetConfig()
+			SetBaseDefaultsInConfig(viper.GetViper())
+			require.NoError(t, param.Issuer_GroupSource.Set(gs))
+			setOAuthFlavorDefaults(viper.GetViper())
+			refresh(t)
+			assert.Equal(t, "https://cilogon.org", param.OIDC_Issuer.GetString(), "group source %q should use CILogon", gs)
+		}
+	})
+
+	t.Run("user-set-issuer-wins-and-keeps-its-provenance", func(t *testing.T) {
 		ResetConfig()
 		SetBaseDefaultsInConfig(viper.GetViper())
 		require.NoError(t, param.Issuer_GroupSource.Set("github"))
-		require.NoError(t, param.OIDC_Issuer.Set("https://my-custom-oauth.example.com"))
-		require.NoError(t, applyGitHubOAuthDefaults())
-		assert.Equal(t, "https://my-custom-oauth.example.com", param.OIDC_Issuer.GetString())
+		// A value set via Set() (override) outranks SetDefault, so the flavor default
+		// must not clobber it (e.g. a GitHub Enterprise issuer)...
+		require.NoError(t, param.OIDC_Issuer.Set("https://github-enterprise.example.com"))
+		setOAuthFlavorDefaults(viper.GetViper())
+		refresh(t)
+		assert.Equal(t, "https://github-enterprise.example.com", param.OIDC_Issuer.GetString())
+		// ...and its non-default provenance is preserved, not downgraded to default.
+		src, ok := GetSourceTracker().Get(strings.ToLower(param.OIDC_Issuer.GetName()))
+		require.True(t, ok)
+		assert.NotEqual(t, SourceDefault, src.Type)
+		// Params the user did not set still receive GitHub values.
+		assert.Equal(t, "https://api.github.com/user", param.OIDC_UserInfoEndpoint.GetString())
 	})
 
-	t.Run("user-set-scopes-not-overwritten", func(t *testing.T) {
+	t.Run("user-set-scopes-win-over-flavor-default", func(t *testing.T) {
 		ResetConfig()
 		SetBaseDefaultsInConfig(viper.GetViper())
 		require.NoError(t, param.Issuer_GroupSource.Set("github"))
 		require.NoError(t, param.OIDC_Scopes.Set([]string{"user", "read:org", "repo"}))
-		require.NoError(t, applyGitHubOAuthDefaults())
+		setOAuthFlavorDefaults(viper.GetViper())
+		refresh(t)
 		assert.Equal(t, []string{"user", "read:org", "repo"}, param.OIDC_Scopes.GetStringSlice())
 	})
 
-	t.Run("user-set-auth-claim-not-overwritten", func(t *testing.T) {
+	t.Run("user-set-auth-claim-wins-over-flavor-default", func(t *testing.T) {
 		ResetConfig()
 		SetBaseDefaultsInConfig(viper.GetViper())
 		require.NoError(t, param.Issuer_GroupSource.Set("github"))
 		require.NoError(t, param.Issuer_OIDCAuthenticationUserClaim.Set("email"))
-		require.NoError(t, applyGitHubOAuthDefaults())
+		setOAuthFlavorDefaults(viper.GetViper())
+		refresh(t)
 		assert.Equal(t, "email", param.Issuer_OIDCAuthenticationUserClaim.GetString())
 	})
 }

--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -274,16 +274,12 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 	v.SetDefault(param.Issuer_DynamicClientUnusedTimeout.GetName(), "1h")
 	// Issuer.IDTokenLifetime
 	v.SetDefault(param.Issuer_IDTokenLifetime.GetName(), "1h")
-	// Issuer.OIDCAuthenticationUserClaim
-	v.SetDefault(param.Issuer_OIDCAuthenticationUserClaim.GetName(), "sub")
 	// Issuer.OIDCGroupClaim
 	v.SetDefault(param.Issuer_OIDCGroupClaim.GetName(), "groups")
 	// Issuer.OIDCIssuerClaim
 	v.SetDefault(param.Issuer_OIDCIssuerClaim.GetName(), "iss")
 	// Issuer.OIDCPreferClaimsFromIDToken
 	v.SetDefault(param.Issuer_OIDCPreferClaimsFromIDToken.GetName(), false)
-	// Issuer.OIDCSubjectClaim
-	v.SetDefault(param.Issuer_OIDCSubjectClaim.GetName(), "sub")
 	// Issuer.PublicClientID
 	v.SetDefault(param.Issuer_PublicClientID.GetName(), "pelican-public-client")
 	// Issuer.QDLLocation
@@ -458,8 +454,6 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 	v.SetDefault(param.Monitoring_TokenExpiresIn.GetName(), "1h")
 	// Monitoring.TokenRefreshInterval
 	v.SetDefault(param.Monitoring_TokenRefreshInterval.GetName(), "5m")
-	// OIDC.AuthorizationEndpoint
-	v.SetDefault(param.OIDC_AuthorizationEndpoint.GetName(), "https://cilogon.org/authorize")
 	// OIDC.ClientIDFile
 	{
 		val := "${ConfigBase}/oidc-client-id"
@@ -472,16 +466,6 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 		val = strings.ReplaceAll(val, "${ConfigBase}", v.GetString(param.ConfigBase.GetName()))
 		v.SetDefault(param.OIDC_ClientSecretFile.GetName(), val)
 	}
-	// OIDC.DeviceAuthEndpoint
-	v.SetDefault(param.OIDC_DeviceAuthEndpoint.GetName(), "https://cilogon.org/oauth2/device_authorization")
-	// OIDC.Issuer
-	v.SetDefault(param.OIDC_Issuer.GetName(), "https://cilogon.org")
-	// OIDC.Scopes
-	v.SetDefault(param.OIDC_Scopes.GetName(), []string{"openid", "email", "profile"})
-	// OIDC.TokenEndpoint
-	v.SetDefault(param.OIDC_TokenEndpoint.GetName(), "https://cilogon.org/oauth2/token")
-	// OIDC.UserInfoEndpoint
-	v.SetDefault(param.OIDC_UserInfoEndpoint.GetName(), "https://cilogon.org/oauth2/userinfo")
 	// Origin.ConcurrencyDegradedThreshold
 	v.SetDefault(param.Origin_ConcurrencyDegradedThreshold.GetName(), 90)
 	// Origin.DbLocation

--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -294,16 +294,12 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 	v.SetDefault(param.Issuer_DynamicClientUnusedTimeout.GetName(), "1h")
 	// Issuer.IDTokenLifetime
 	v.SetDefault(param.Issuer_IDTokenLifetime.GetName(), "1h")
-	// Issuer.OIDCAuthenticationUserClaim
-	v.SetDefault(param.Issuer_OIDCAuthenticationUserClaim.GetName(), "sub")
 	// Issuer.OIDCGroupClaim
 	v.SetDefault(param.Issuer_OIDCGroupClaim.GetName(), "groups")
 	// Issuer.OIDCIssuerClaim
 	v.SetDefault(param.Issuer_OIDCIssuerClaim.GetName(), "iss")
 	// Issuer.OIDCPreferClaimsFromIDToken
 	v.SetDefault(param.Issuer_OIDCPreferClaimsFromIDToken.GetName(), false)
-	// Issuer.OIDCSubjectClaim
-	v.SetDefault(param.Issuer_OIDCSubjectClaim.GetName(), "sub")
 	// Issuer.PublicClientID
 	v.SetDefault(param.Issuer_PublicClientID.GetName(), "pelican-public-client")
 	// Issuer.QDLLocation
@@ -496,8 +492,6 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 	v.SetDefault(param.Monitoring_TokenExpiresIn.GetName(), "1h")
 	// Monitoring.TokenRefreshInterval
 	v.SetDefault(param.Monitoring_TokenRefreshInterval.GetName(), "5m")
-	// OIDC.AuthorizationEndpoint
-	v.SetDefault(param.OIDC_AuthorizationEndpoint.GetName(), "https://cilogon.org/authorize")
 	// OIDC.ClientIDFile
 	{
 		val := "${ConfigBase}/oidc-client-id"
@@ -510,16 +504,6 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 		val = strings.ReplaceAll(val, "${ConfigBase}", v.GetString(param.ConfigBase.GetName()))
 		v.SetDefault(param.OIDC_ClientSecretFile.GetName(), val)
 	}
-	// OIDC.DeviceAuthEndpoint
-	v.SetDefault(param.OIDC_DeviceAuthEndpoint.GetName(), "https://cilogon.org/oauth2/device_authorization")
-	// OIDC.Issuer
-	v.SetDefault(param.OIDC_Issuer.GetName(), "https://cilogon.org")
-	// OIDC.Scopes
-	v.SetDefault(param.OIDC_Scopes.GetName(), []string{"openid", "email", "profile"})
-	// OIDC.TokenEndpoint
-	v.SetDefault(param.OIDC_TokenEndpoint.GetName(), "https://cilogon.org/oauth2/token")
-	// OIDC.UserInfoEndpoint
-	v.SetDefault(param.OIDC_UserInfoEndpoint.GetName(), "https://cilogon.org/oauth2/userinfo")
 	// Origin.ConcurrencyDegradedThreshold
 	v.SetDefault(param.Origin_ConcurrencyDegradedThreshold.GetName(), 90)
 	// Origin.DbLocation

--- a/docs/app/federating-your-data/origin/page.mdx
+++ b/docs/app/federating-your-data/origin/page.mdx
@@ -165,7 +165,8 @@ For Origins that require token-based authentication (i.e., namespaces with `Read
 This allows you to restrict data access to members of specific GitHub organizations.
 
 <Callout type="info">
-GitHub uses OAuth2, not full OIDC (OpenID Connect). This means you need to explicitly configure the OAuth endpoints and specify which claims to use from GitHub's user info response (see the configuration example below).
+GitHub uses OAuth2, not full OIDC (OpenID Connect), which means its OAuth endpoints and user info claim names differ from standard OIDC defaults.
+When `Issuer.GroupSource: github` is set, Pelican automatically fills in all of these GitHub-specific values — endpoints, scopes, and claim names — so you only need to supply your OAuth App credentials and site-specific settings.
 </Callout>
 
 #### Prerequisites
@@ -180,22 +181,10 @@ GitHub uses OAuth2, not full OIDC (OpenID Connect). This means you need to expli
 Add the following to your Origin's configuration file to enable GitHub OAuth2:
 
 ```yaml filename="pelican.yaml" copy
-# GitHub OAuth2 endpoints (required since GitHub doesn't support OIDC discovery)
 OIDC:
-  Issuer: https://github.com
-  AuthorizationEndpoint: https://github.com/login/oauth/authorize
-  TokenEndpoint: https://github.com/login/oauth/access_token
-  UserInfoEndpoint: https://api.github.com/user
-  DeviceAuthEndpoint: https://github.com/login/device/code
-
   # Your GitHub OAuth App credentials
   ClientID: <your-github-client-id>
   ClientSecretFile: /path/to/client-secret-file
-
-  # GitHub-specific scopes
-  Scopes:
-    - user
-    - read:org  # Required for organization-based access control
 
 Origin:
   EnableIssuer: true
@@ -211,11 +200,8 @@ Origin:
       Capabilities: ["Writes", "DirectReads", "Reads", "Listings"]
 
 Issuer:
-  # GitHub returns "login" for username instead of OIDC standard "sub"
-  OIDCAuthenticationUserClaim: login
-  # GitHub returns "id" (numeric) instead of OIDC standard "sub"
-  OIDCSubjectClaim: id
-  # Use GitHub organization membership as groups
+  # Setting GroupSource to "github" automatically configures all GitHub OAuth2
+  # endpoints and claim names. No other OIDC settings are required.
   GroupSource: github
 
   # Require users to be members of at least one of these GitHub orgs
@@ -232,9 +218,25 @@ Issuer:
 
 Server:
   ExternalWebUrl: https://your-origin.example.com
-  # Grant admin access to specific GitHub users
+  # Grant WebUI admin access to specific GitHub users
   UIAdminUsers: ["<your-github-username>"]
 ```
+
+<Callout type="info">
+The following values are set automatically and do not need to appear in your config file when `GroupSource: github` is set.
+You may still override any of them explicitly if needed.
+
+| Parameter | Auto-filled value |
+|---|---|
+| `OIDC.Issuer` | `https://github.com` |
+| `OIDC.AuthorizationEndpoint` | `https://github.com/login/oauth/authorize` |
+| `OIDC.TokenEndpoint` | `https://github.com/login/oauth/access_token` |
+| `OIDC.UserInfoEndpoint` | `https://api.github.com/user` |
+| `OIDC.DeviceAuthEndpoint` | `https://github.com/login/device/code` |
+| `OIDC.Scopes` | `[user, read:org]` |
+| `Issuer.OIDCAuthenticationUserClaim` | `login` |
+| `Issuer.OIDCSubjectClaim` | `id` |
+</Callout>
 
 #### User Authentication Flow
 

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -3785,8 +3785,11 @@ components: ["origin"]
 name: Issuer.OIDCAuthenticationUserClaim
 description: |+
   The claim to be used as the "username" for the issuer.
+
+  The default is selected from the OAuth flavor (`Issuer.GroupSource`): `sub` for CILogon,
+  or `login` when `Issuer.GroupSource` is `github`.
 type: string
-default: sub
+default: none
 components: ["origin"]
 ---
 name: Issuer.OIDCSubjectClaim
@@ -3797,8 +3800,11 @@ description: |+
 
   If the claim is not found in the user info response, the system will fall back to using the username.
   If the claim value is numeric, it will be converted to a string.
+
+  The default is selected from the OAuth flavor (`Issuer.GroupSource`): `sub` for CILogon,
+  or `id` when `Issuer.GroupSource` is `github`.
 type: string
-default: sub
+default: none
 components: ["origin", "registry", "cache", "director"]
 ---
 name: Issuer.OIDCIssuerClaim
@@ -4045,32 +4051,48 @@ components: ["registry", "origin", "cache", "director"]
 name: OIDC.DeviceAuthEndpoint
 description: |+
   A URL describing an OIDC Device Auth Endpoint. This is used by the namespace registry to establish OIDC information
-  for authenticated registration. The default value is set to the URL from CILogon.
+  for authenticated registration.
+
+  The default is selected from the OAuth flavor (`Issuer.GroupSource`):
+  `https://cilogon.org/oauth2/device_authorization` for CILogon, or
+  `https://github.com/login/device/code` when `Issuer.GroupSource` is `github`.
 type: url
-default: "https://cilogon.org/oauth2/device_authorization"
+default: none
 components: ["registry", "origin", "cache", "director"]
 ---
 name: OIDC.TokenEndpoint
 description: |+
   A URL describing an OIDC Token Endpoint. This is used by the namespace registry to establish OIDC information
-  for authenticated registration. The default value is set to the URL from CILogon.
+  for authenticated registration.
+
+  The default is selected from the OAuth flavor (`Issuer.GroupSource`):
+  `https://cilogon.org/oauth2/token` for CILogon, or
+  `https://github.com/login/oauth/access_token` when `Issuer.GroupSource` is `github`.
 type: url
-default: "https://cilogon.org/oauth2/token"
+default: none
 components: ["registry", "origin", "cache", "director"]
 ---
 name: OIDC.UserInfoEndpoint
 description: |+
   A URL describing an OIDC User Info Endpoint. This is used by the namespace registry to establish OIDC information
-  for authenticated registration. The default value is set to the URL from CILogon.
+  for authenticated registration.
+
+  The default is selected from the OAuth flavor (`Issuer.GroupSource`):
+  `https://cilogon.org/oauth2/userinfo` for CILogon, or
+  `https://api.github.com/user` when `Issuer.GroupSource` is `github`.
 type: url
-default: "https://cilogon.org/oauth2/userinfo"
+default: none
 components: ["registry", "origin", "cache", "director"]
 ---
 name: OIDC.AuthorizationEndpoint
 description: |+
-  A URL containing the OIDC authorization endpoint. The default value is set to the URL from CILogon.
+  A URL containing the OIDC authorization endpoint.
+
+  The default is selected from the OAuth flavor (`Issuer.GroupSource`):
+  `https://cilogon.org/authorize` for CILogon, or
+  `https://github.com/login/oauth/authorize` when `Issuer.GroupSource` is `github`.
 type: url
-default: "https://cilogon.org/authorize"
+default: none
 components: ["registry", "origin", "cache", "director"]
 ---
 name: OIDC.Issuer
@@ -4079,23 +4101,29 @@ description: |+
   device auth). The URL should not contain a path unless your authentication server enables multi-tenant support.
 
   If the OIDC auto-discovery failed, Pelican will fall back to use individual endpoints set in the configuration. For
-  any unset endpoints, Pelican will use default values, which are from CILogon.
+  any unset endpoints, Pelican will use default values selected from the OAuth flavor (`Issuer.GroupSource`).
 
   **Note**: If you explicitly set the OIDC endpoints (AuthorizationEndpoint, TokenEndpoint, etc.), those values will
   take precedence over auto-discovery. This is useful for OAuth2 providers like GitHub that don't support OIDC discovery.
 
+  The default is selected from the OAuth flavor (`Issuer.GroupSource`): `https://cilogon.org` for CILogon,
+  or `https://github.com` when `Issuer.GroupSource` is `github`.
+
   For CILogon, it's https://cilogon.org
   For Globus, it's https://auth.globus.org
-  For GitHub OAuth2, set this to https://github.com and explicitly configure the individual endpoints
+  For GitHub OAuth2, it's https://github.com
 type: url
-default: https://cilogon.org
+default: none
 components: ["registry", "origin", "cache", "director"]
 ---
 name: OIDC.Scopes
 description: |+
   A list of scopes to request from the authentication provider.
+
+  The default is selected from the OAuth flavor (`Issuer.GroupSource`): `["openid", "email", "profile"]`
+  for CILogon, or `["user", "read:org"]` when `Issuer.GroupSource` is `github`.
 type: stringSlice
-default: ["openid", "email", "profile"]
+default: none
 components: ["registry", "origin", "cache", "director"]
 ---
 name: OIDC.ClientRedirectHostname

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -4780,8 +4780,11 @@ components: ["origin"]
 name: Issuer.OIDCAuthenticationUserClaim
 description: |+
   The claim to be used as the "username" for the issuer.
+
+  The default is selected from the OAuth flavor (`Issuer.GroupSource`): `sub` for CILogon,
+  or `login` when `Issuer.GroupSource` is `github`.
 type: string
-default: sub
+default: none
 components: ["origin"]
 ---
 name: Issuer.OIDCSubjectClaim
@@ -4792,8 +4795,11 @@ description: |+
 
   If the claim is not found in the user info response, the system will fall back to using the username.
   If the claim value is numeric, it will be converted to a string.
+
+  The default is selected from the OAuth flavor (`Issuer.GroupSource`): `sub` for CILogon,
+  or `id` when `Issuer.GroupSource` is `github`.
 type: string
-default: sub
+default: none
 components: ["origin", "registry", "cache", "director"]
 ---
 name: Issuer.OIDCIssuerClaim
@@ -5048,32 +5054,48 @@ components: ["registry", "origin", "cache", "director"]
 name: OIDC.DeviceAuthEndpoint
 description: |+
   A URL describing an OIDC Device Auth Endpoint. This is used by the namespace registry to establish OIDC information
-  for authenticated registration. The default value is set to the URL from CILogon.
+  for authenticated registration.
+
+  The default is selected from the OAuth flavor (`Issuer.GroupSource`):
+  `https://cilogon.org/oauth2/device_authorization` for CILogon, or
+  `https://github.com/login/device/code` when `Issuer.GroupSource` is `github`.
 type: url
-default: "https://cilogon.org/oauth2/device_authorization"
+default: none
 components: ["registry", "origin", "cache", "director"]
 ---
 name: OIDC.TokenEndpoint
 description: |+
   A URL describing an OIDC Token Endpoint. This is used by the namespace registry to establish OIDC information
-  for authenticated registration. The default value is set to the URL from CILogon.
+  for authenticated registration.
+
+  The default is selected from the OAuth flavor (`Issuer.GroupSource`):
+  `https://cilogon.org/oauth2/token` for CILogon, or
+  `https://github.com/login/oauth/access_token` when `Issuer.GroupSource` is `github`.
 type: url
-default: "https://cilogon.org/oauth2/token"
+default: none
 components: ["registry", "origin", "cache", "director"]
 ---
 name: OIDC.UserInfoEndpoint
 description: |+
   A URL describing an OIDC User Info Endpoint. This is used by the namespace registry to establish OIDC information
-  for authenticated registration. The default value is set to the URL from CILogon.
+  for authenticated registration.
+
+  The default is selected from the OAuth flavor (`Issuer.GroupSource`):
+  `https://cilogon.org/oauth2/userinfo` for CILogon, or
+  `https://api.github.com/user` when `Issuer.GroupSource` is `github`.
 type: url
-default: "https://cilogon.org/oauth2/userinfo"
+default: none
 components: ["registry", "origin", "cache", "director"]
 ---
 name: OIDC.AuthorizationEndpoint
 description: |+
-  A URL containing the OIDC authorization endpoint. The default value is set to the URL from CILogon.
+  A URL containing the OIDC authorization endpoint.
+
+  The default is selected from the OAuth flavor (`Issuer.GroupSource`):
+  `https://cilogon.org/authorize` for CILogon, or
+  `https://github.com/login/oauth/authorize` when `Issuer.GroupSource` is `github`.
 type: url
-default: "https://cilogon.org/authorize"
+default: none
 components: ["registry", "origin", "cache", "director"]
 ---
 name: OIDC.Issuer
@@ -5082,23 +5104,29 @@ description: |+
   device auth). The URL should not contain a path unless your authentication server enables multi-tenant support.
 
   If the OIDC auto-discovery failed, Pelican will fall back to use individual endpoints set in the configuration. For
-  any unset endpoints, Pelican will use default values, which are from CILogon.
+  any unset endpoints, Pelican will use default values selected from the OAuth flavor (`Issuer.GroupSource`).
 
   **Note**: If you explicitly set the OIDC endpoints (AuthorizationEndpoint, TokenEndpoint, etc.), those values will
   take precedence over auto-discovery. This is useful for OAuth2 providers like GitHub that don't support OIDC discovery.
 
+  The default is selected from the OAuth flavor (`Issuer.GroupSource`): `https://cilogon.org` for CILogon,
+  or `https://github.com` when `Issuer.GroupSource` is `github`.
+
   For CILogon, it's https://cilogon.org
   For Globus, it's https://auth.globus.org
-  For GitHub OAuth2, set this to https://github.com and explicitly configure the individual endpoints
+  For GitHub OAuth2, it's https://github.com
 type: url
-default: https://cilogon.org
+default: none
 components: ["registry", "origin", "cache", "director"]
 ---
 name: OIDC.Scopes
 description: |+
   A list of scopes to request from the authentication provider.
+
+  The default is selected from the OAuth flavor (`Issuer.GroupSource`): `["openid", "email", "profile"]`
+  for CILogon, or `["user", "read:org"]` when `Issuer.GroupSource` is `github`.
 type: stringSlice
-default: ["openid", "email", "profile"]
+default: none
 components: ["registry", "origin", "cache", "director"]
 ---
 name: OIDC.ClientRedirectHostname


### PR DESCRIPTION
- When `Issuer.GroupSource: github` is set, GitHub OAuth endpoints, scopes, and claim names should be set automatically
- So admin only needs to supply the OAuth App credentials and site-specific settings
- Values that the user has explicitly set (i.e. differ from the CILogon defaults that defaults.yaml seeds) are never overwritten

> Note: if a param is set in defaults.yaml, `IsSet()` returns true. I introduce a comparison here to tell what OIDC params are actually set by the user

- Also update the docs
- I span up a Github OAuth origin in the local federation to make sure it functions the same, and webUI, `pelican config get` can see the correct value.