### PR TITLE
Install multiuser plugin from osg-testing repo to get segfault patch

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -488,7 +488,7 @@ RUN --mount=type=bind,from=xrootd-build,source=/xrootd-build,target=/xrootd-buil
   set -eux
   set -o pipefail
 
-  dnf install -y xrootd-multiuser
+  dnf install -y --enablerepo=osg-testing xrootd-multiuser
 
   if [ "$TARGETARCH" = "amd64" ]; then
       PKG_ARCH=x86_64


### PR DESCRIPTION
@h2zh I didn't see a PR for tracking v7.25.0-rc.1 patches, but feel free to create an issue for all the linkage if you want to do that kind of tracking. Otherwise, this is one patch that should go into your next release candidate. It's not being merged into main first because Matyas plans to solve this a different way for the v7.26 release.