### PR TITLE
Install sssd-client in all origin containers

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -573,6 +573,9 @@ RUN --mount=type=bind,source=oa4mp/resources,target=/context \
   set -eux
   set -o pipefail
 
+  # Some XRootD multi-user setups require sssd-client.
+  dnf install -y sssd-client
+
   # OA4MP and Apache Tomcat both require a Java runtime.
   dnf install -y java-${JAVA_VER}-openjdk-headless
 
@@ -707,20 +710,7 @@ ENTRYPOINT ["/entrypoint.sh", "pelican-server", "origin"]
 CMD ["serve"]
 
 FROM origin AS osdf-origin
-ARG TARGETPLATFORM
-RUN --mount=type=cache,id=dnf-${TARGETPLATFORM},target=/var/cache/dnf,sharing=locked <<ENDRUN
-  set -eux
-  set -o pipefail
-
-  ln -s pelican-server /usr/local/sbin/osdf-server
-
-  # Some XRootD multi-user setups require sssd-client.
-  # The IDs here are chosen to match OSG's sssd sidecar containers.
-
-  groupadd -r -g 990 sssd
-  useradd -r -u 990 -g 990 -d / -s /sbin/nologin -c "System user for sssd" sssd
-  dnf install -y sssd-client
-ENDRUN
+RUN ln -s pelican-server /usr/local/sbin/osdf-server
 ENTRYPOINT ["/entrypoint.sh", "osdf-server", "origin"]
 CMD ["serve"]
 


### PR DESCRIPTION
It would also seem that there's no actual need for an `sssd` user account.