### PR TITLE
Cleanup downtime when a server is deleted

### DIFF
--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -828,6 +828,10 @@ func deleteRegistrationByID(id int) error {
 				if err := tx.Where("id = ? AND NOT EXISTS (?)", svc.ServerID, subq).Delete(&server_structs.Server{}).Error; err != nil {
 					return err
 				}
+				// Delete all downtimes associated with this server (no FK constraint, so must be done explicitly)
+				if err := tx.Where("server_id = ?", svc.ServerID).Delete(&server_structs.Downtime{}).Error; err != nil {
+					return errors.Wrapf(err, "failed to delete downtimes for server %s", svc.ServerID)
+				}
 			} else {
 				// Update server flags to reflect remaining service types
 				var hasOrigin, hasCache bool
@@ -888,9 +892,12 @@ func deleteServerByID(id string) error {
 				return errors.Wrapf(err, "failed to delete the registration corresponding to the server: %s", registration.Prefix)
 			}
 		}
+		// Delete all downtimes associated with this server
+		if err := tx.Where("server_id = ?", id).Delete(&server_structs.Downtime{}).Error; err != nil {
+			return errors.Wrapf(err, "failed to delete downtimes for server %s", id)
+		}
 		return nil
 	})
-
 }
 
 func getAllRegistrations() ([]*server_structs.Registration, error) {

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -864,17 +864,21 @@ func deleteRegistrationByPrefix(prefix string) error {
 }
 
 func deleteServerByID(id string) error {
+	// Fetch registrations before opening the transaction. getServerByID uses the
+	// global database.ServerDatabase rather than a tx-scoped connection; calling it
+	// inside the Transaction callback would require a second connection from the pool,
+	// which deadlocks on a single-connection SQLite pool (common in tests).
+	serverRegistration, err := getServerByID(id)
+	if err != nil {
+		return errors.Wrap(err, "failed to get server by ID")
+	}
+
 	// Wrap all database operations in a transaction
 	// If any operation fails, all changes are reverted. No partial records left.
 	return database.ServerDatabase.Transaction(func(tx *gorm.DB) error {
-		serverRegistration, err := getServerByID(id)
-		if err != nil {
-			return errors.Wrap(err, "failed to get server by ID")
-		}
 		// Because of the foreign key constraints applied on the DB,
-		// All entries with matching server_id in "services", "endpoints", "contacts" tables will be deleted automatically
-		err = tx.Delete(&server_structs.Server{}, id).Error
-		if err != nil {
+		// All entries with matching server_id in "services", "endpoints", "contacts" tables will be deleted automatically.
+		if err := tx.Where("id = ?", id).Delete(&server_structs.Server{}).Error; err != nil {
 			return errors.Wrap(err, "failed to delete server")
 		}
 		// Delete all registrations corresponding to the server separately

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -868,28 +868,25 @@ func deleteRegistrationByPrefix(prefix string) error {
 }
 
 func deleteServerByID(id string) error {
-	// Fetch registrations before opening the transaction. getServerByID uses the
-	// global database.ServerDatabase rather than a tx-scoped connection; calling it
-	// inside the Transaction callback would require a second connection from the pool,
-	// which deadlocks on a single-connection SQLite pool (common in tests).
-	serverRegistration, err := getServerByID(id)
-	if err != nil {
-		return errors.Wrap(err, "failed to get server by ID")
-	}
-
 	// Wrap all database operations in a transaction
 	// If any operation fails, all changes are reverted. No partial records left.
 	return database.ServerDatabase.Transaction(func(tx *gorm.DB) error {
+		// Look up registration IDs for this server inside the transaction to avoid
+		// a race where a registration is added after we read but before we delete.
+		var registrationIDs []int
+		if err := tx.Model(&server_structs.Service{}).Where("server_id = ?", id).Pluck("registration_id", &registrationIDs).Error; err != nil {
+			return errors.Wrapf(err, "failed to get registration IDs for server %s", id)
+		}
+
 		// Because of the foreign key constraints applied on the DB,
 		// All entries with matching server_id in "services", "endpoints", "contacts" tables will be deleted automatically.
 		if err := tx.Where("id = ?", id).Delete(&server_structs.Server{}).Error; err != nil {
 			return errors.Wrap(err, "failed to delete server")
 		}
 		// Delete all registrations corresponding to the server separately
-		for _, registration := range serverRegistration.Registration {
-			err = tx.Delete(&server_structs.Registration{}, registration.ID).Error
-			if err != nil {
-				return errors.Wrapf(err, "failed to delete the registration corresponding to the server: %s", registration.Prefix)
+		if len(registrationIDs) > 0 {
+			if err := tx.Delete(&server_structs.Registration{}, registrationIDs).Error; err != nil {
+				return errors.Wrapf(err, "failed to delete registrations for server %s", id)
 			}
 		}
 		// Delete all downtimes associated with this server

--- a/registry/registry_db_server_test.go
+++ b/registry/registry_db_server_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -686,5 +687,117 @@ func TestServerWithMultipleServices(t *testing.T) {
 
 		assert.False(t, server2.IsOrigin, "Server2 should not be marked as origin")
 		assert.True(t, server2.IsCache, "Server2 should be marked as cache")
+	})
+}
+
+func testDowntimeForServer(serverID, serverName string) server_structs.Downtime {
+	now := time.Now().UnixMilli()
+	return server_structs.Downtime{
+		UUID:        uuid.NewString(),
+		ServerID:    serverID,
+		ServerName:  serverName,
+		CreatedBy:   "test-user",
+		UpdatedBy:   "test-user",
+		Source:      "registry",
+		Class:       server_structs.SCHEDULED,
+		Description: "unit test downtime",
+		Severity:    server_structs.NoSignificantOutageExpected,
+		StartTime:   now,
+		EndTime:     now + 3600000,
+	}
+}
+
+// TestDeleteRegistrationByID_RemovesDowntimes covers explicit downtime cleanup when the last
+// service for a server is removed (no FK from downtimes to servers).
+func TestDeleteRegistrationByID_RemovesDowntimes(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	setupMockRegistryDB(t)
+	defer teardownMockRegistryDB(t)
+
+	t.Run("deletes-downtimes-when-last-service-removed", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		ns := server_structs.Registration{
+			Prefix: "/origins/downtime-reg-delete.edu",
+			Pubkey: "test-pubkey",
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName:    "downtime-reg-delete.edu",
+				Institution: "Test University",
+				Status:      server_structs.RegApproved,
+			},
+		}
+		err := AddRegistration(&ns)
+		require.NoError(t, err)
+
+		server, err := getServerByRegistrationID(ns.ID)
+		require.NoError(t, err)
+		require.NotEmpty(t, server.ID)
+
+		dt := testDowntimeForServer(server.ID, server.Name)
+		err = database.ServerDatabase.Create(&dt).Error
+		require.NoError(t, err)
+
+		err = deleteRegistrationByID(ns.ID)
+		require.NoError(t, err)
+
+		var downtimeCount int64
+		err = database.ServerDatabase.Model(&server_structs.Downtime{}).Where("server_id = ?", server.ID).Count(&downtimeCount).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), downtimeCount)
+
+		var serverCount int64
+		err = database.ServerDatabase.Model(&server_structs.Server{}).Where("id = ?", server.ID).Count(&serverCount).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), serverCount)
+	})
+
+	t.Run("keeps-downtimes-when-other-service-remains", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		jwks, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+
+		originReg := server_structs.Registration{
+			Prefix: "/origins/downtime-dual.edu",
+			Pubkey: jwks,
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName:    "downtime-dual.edu",
+				Institution: "Test University",
+				Status:      server_structs.RegApproved,
+			},
+		}
+		err = AddRegistration(&originReg)
+		require.NoError(t, err)
+
+		cacheReg := server_structs.Registration{
+			Prefix: "/caches/downtime-dual.edu",
+			Pubkey: jwks,
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName:    "downtime-dual.edu",
+				Institution: "Test University",
+				Status:      server_structs.RegApproved,
+			},
+		}
+		err = AddRegistration(&cacheReg)
+		require.NoError(t, err)
+
+		server, err := getServerByRegistrationID(originReg.ID)
+		require.NoError(t, err)
+		dt := testDowntimeForServer(server.ID, server.Name)
+		err = database.ServerDatabase.Create(&dt).Error
+		require.NoError(t, err)
+
+		err = deleteRegistrationByID(originReg.ID)
+		require.NoError(t, err)
+
+		var downtimeCount int64
+		err = database.ServerDatabase.Model(&server_structs.Downtime{}).Where("server_id = ?", server.ID).Count(&downtimeCount).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), downtimeCount)
+
+		var serverCount int64
+		err = database.ServerDatabase.Model(&server_structs.Server{}).Where("id = ?", server.ID).Count(&serverCount).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), serverCount)
 	})
 }

--- a/registry/registry_db_test.go
+++ b/registry/registry_db_test.go
@@ -68,6 +68,7 @@ func setupMockRegistryDB(t *testing.T) {
 		&server_structs.Service{},
 		&server_structs.Contact{},
 		&server_structs.Endpoint{},
+		&server_structs.Downtime{},
 		&database.User{},
 		&database.Group{},
 		&database.GroupMember{},
@@ -83,6 +84,7 @@ func resetMockRegistryDB(t *testing.T) {
 		"service":   &server_structs.Service{},
 		"contact":   &server_structs.Contact{},
 		"endpoint":  &server_structs.Endpoint{},
+		"downtimes": &server_structs.Downtime{},
 	}
 
 	for name, model := range tablesToClear {

--- a/registry/registry_ui_server_test.go
+++ b/registry/registry_ui_server_test.go
@@ -23,14 +23,17 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pelicanplatform/pelican/database"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/test_utils"
 )
 
 func createTestServerData(t *testing.T) []server_structs.Registration {
@@ -439,4 +442,63 @@ func TestServerIntegrationWithNamespaceOperations(t *testing.T) {
 		require.Len(t, updatedServer.Registration, 1, "Expected exactly one registration")
 		assert.Equal(t, "Updated description", updatedServer.Registration[0].AdminMetadata.Description)
 	})
+}
+
+// TestDeleteServerHandler_RemovesDowntimes verifies that deleting a server via the
+// HTTP handler also removes its orphaned downtime entries (no FK constraint exists
+// between the downtimes and servers tables).
+func TestDeleteServerHandler_RemovesDowntimes(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	setupMockRegistryDB(t)
+	defer teardownMockRegistryDB(t)
+
+	ns := server_structs.Registration{
+		Prefix: "/origins/downtime-server-delete.edu",
+		Pubkey: "test-pubkey",
+		AdminMetadata: server_structs.AdminMetadata{
+			SiteName:    "downtime-server-delete.edu",
+			Institution: "Test University",
+			Status:      server_structs.RegApproved,
+		},
+	}
+	require.NoError(t, AddRegistration(&ns))
+
+	server, err := getServerByRegistrationID(ns.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, server.ID)
+
+	now := time.Now().UnixMilli()
+	dt := server_structs.Downtime{
+		UUID:        uuid.NewString(),
+		ServerID:    server.ID,
+		ServerName:  server.Name,
+		CreatedBy:   "test-user",
+		UpdatedBy:   "test-user",
+		Source:      "registry",
+		Class:       server_structs.SCHEDULED,
+		Description: "unit test downtime",
+		Severity:    server_structs.NoSignificantOutageExpected,
+		StartTime:   now,
+		EndTime:     now + 3600000,
+	}
+	require.NoError(t, database.ServerDatabase.Create(&dt).Error)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.DELETE("/servers/:id", deleteServerHandler)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/servers/"+server.ID, nil)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var downtimeCount int64
+	require.NoError(t, database.ServerDatabase.Model(&server_structs.Downtime{}).
+		Where("server_id = ?", server.ID).Count(&downtimeCount).Error)
+	assert.Equal(t, int64(0), downtimeCount, "downtimes should be removed with the server")
+
+	var regCount int64
+	require.NoError(t, database.ServerDatabase.Model(&server_structs.Registration{}).
+		Where("id = ?", ns.ID).Count(&regCount).Error)
+	assert.Equal(t, int64(0), regCount, "registration should be removed with the server")
 }


### PR DESCRIPTION
Besides downtime cleanup during server removal, this PR also fixes bugs in the SQL query for `DELETE /api/v1.0/registry_ui/servers/:id` (though this endpoint is never used in WebUI)