### PR TITLE
Remove stale pending server registration requests automatically

### DIFF
--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -635,6 +635,10 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 	v.SetDefault(param.Origin_XRootDPrefix.GetName(), "origin")
 	// Plugin.DirectorDecisionPercentage
 	v.SetDefault(param.Plugin_DirectorDecisionPercentage.GetName(), 20)
+	// Registry.InactiveRegistrationCleanupInterval
+	v.SetDefault(param.Registry_InactiveRegistrationCleanupInterval.GetName(), "5m")
+	// Registry.InactiveRegistrationTimeout
+	v.SetDefault(param.Registry_InactiveRegistrationTimeout.GetName(), "20m")
 	// Registry.InstitutionsUrlReloadMinutes
 	v.SetDefault(param.Registry_InstitutionsUrlReloadMinutes.GetName(), "15m")
 	// Registry.RequireCacheApproval

--- a/database/registry_migrations/20260330140244_add_last_seen_to_servers.sql
+++ b/database/registry_migrations/20260330140244_add_last_seen_to_servers.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- +goose StatementBegin
+
+ALTER TABLE servers ADD COLUMN last_seen DATETIME DEFAULT NULL;
+
+-- Backfill existing servers from their own timestamps 
+-- so they have a meaningful last_seen rather than NULL.
+UPDATE servers
+SET last_seen = COALESCE(updated_at, created_at)
+WHERE last_seen IS NULL;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE servers DROP COLUMN last_seen;
+-- +goose StatementEnd

--- a/database/registry_migrations/20260330140244_add_last_seen_to_servers.sql
+++ b/database/registry_migrations/20260330140244_add_last_seen_to_servers.sql
@@ -3,7 +3,7 @@
 
 ALTER TABLE servers ADD COLUMN last_seen DATETIME DEFAULT NULL;
 
--- Backfill existing servers from their own timestamps 
+-- Backfill existing servers from their own timestamps
 -- so they have a meaningful last_seen rather than NULL.
 UPDATE servers
 SET last_seen = COALESCE(updated_at, created_at)

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -3257,9 +3257,12 @@ components: ["registry"]
 ---
 name: Registry.InactiveRegistrationTimeout
 description: |+
-  The duration after which a server row is considered stale if its metadata has not been polled.
-  The registry updates servers.last_seen every time a server polls its metadata. The cleanup goroutine
-  deletes every registration linked to stale servers (including the server itself).
+  How long a pending server registration can linger in the registry if it stops running after
+  registering itself. While an Origin or Cache is awaiting admin approval, the registry
+  records the last time the server polled its own registration metadata. If no contact is
+  received within this timeout, the registration and all its associated namespace entries are
+  deleted. Only registrations still in the Pending state are affected; registrations that have
+  already been approved or denied are never removed by this cleanup.
 type: duration
 default: 20m
 components: ["registry"]

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -3259,7 +3259,7 @@ name: Registry.InactiveRegistrationTimeout
 description: |+
   The duration after which a server row is considered stale if its metadata has not been polled.
   The registry updates servers.last_seen every time a server polls its metadata. The cleanup goroutine
-  deletes every registration linked to stale servers (including the server itself). 
+  deletes every registration linked to stale servers (including the server itself).
 type: duration
 default: 20m
 components: ["registry"]

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -3255,6 +3255,22 @@ default: false
 osdf_default: true
 components: ["registry"]
 ---
+name: Registry.InactiveRegistrationTimeout
+description: |+
+  The duration after which a server row is considered stale if its metadata has not been polled.
+  The registry updates servers.last_seen every time a server polls its metadata. The cleanup goroutine
+  deletes every registration linked to stale servers (including the server itself). 
+type: duration
+default: 20m
+components: ["registry"]
+---
+name: Registry.InactiveRegistrationCleanupInterval
+description: |+
+  How often the registry runs the inactive server registration cleanup job.
+type: duration
+default: 5m
+components: ["registry"]
+---
 ############################
 #   Server-level configs   #
 ############################

--- a/launchers/registry_serve.go
+++ b/launchers/registry_serve.go
@@ -75,6 +75,9 @@ func RegistryServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group
 	// Launch registry prometheus metrics
 	registry.LaunchRegistryMetrics(ctx, egrp)
 
+	// Launch cleanup goroutine for inactive pending registrations
+	registry.LaunchInactiveRegistrationCleanup(ctx, egrp)
+
 	egrp.Go(func() error {
 		<-ctx.Done()
 		return database.ShutdownDB()

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -418,6 +418,8 @@ var runtimeConfigurableMap = map[string]bool{
 	"Registry.AdminUsers": false,
 	"Registry.CustomRegistrationFields": false,
 	"Registry.DbLocation": false,
+	"Registry.InactiveRegistrationCleanupInterval": false,
+	"Registry.InactiveRegistrationTimeout": false,
 	"Registry.Institutions": false,
 	"Registry.InstitutionsUrl": false,
 	"Registry.InstitutionsUrlReloadMinutes": false,
@@ -1120,6 +1122,8 @@ var durationAccessors = map[string]func(*Config) time.Duration{
 	"Origin.SelfTestInterval": func(c *Config) time.Duration { return c.Origin.SelfTestInterval },
 	"Origin.SelfTestMaxAge": func(c *Config) time.Duration { return c.Origin.SelfTestMaxAge },
 	"Origin.UserMapfileRefreshInterval": func(c *Config) time.Duration { return c.Origin.UserMapfileRefreshInterval },
+	"Registry.InactiveRegistrationCleanupInterval": func(c *Config) time.Duration { return c.Registry.InactiveRegistrationCleanupInterval },
+	"Registry.InactiveRegistrationTimeout": func(c *Config) time.Duration { return c.Registry.InactiveRegistrationTimeout },
 	"Registry.InstitutionsUrlReloadMinutes": func(c *Config) time.Duration { return c.Registry.InstitutionsUrlReloadMinutes },
 	"Server.AdLifetime": func(c *Config) time.Duration { return c.Server.AdLifetime },
 	"Server.AdvertisementInterval": func(c *Config) time.Duration { return c.Server.AdvertisementInterval },
@@ -1549,6 +1553,8 @@ var allParameterNames = []string{
 	"Registry.AdminUsers",
 	"Registry.CustomRegistrationFields",
 	"Registry.DbLocation",
+	"Registry.InactiveRegistrationCleanupInterval",
+	"Registry.InactiveRegistrationTimeout",
 	"Registry.Institutions",
 	"Registry.InstitutionsUrl",
 	"Registry.InstitutionsUrlReloadMinutes",
@@ -2075,6 +2081,8 @@ var (
 	Origin_SelfTestInterval = DurationParam{"Origin.SelfTestInterval"}
 	Origin_SelfTestMaxAge = DurationParam{"Origin.SelfTestMaxAge"}
 	Origin_UserMapfileRefreshInterval = DurationParam{"Origin.UserMapfileRefreshInterval"}
+	Registry_InactiveRegistrationCleanupInterval = DurationParam{"Registry.InactiveRegistrationCleanupInterval"}
+	Registry_InactiveRegistrationTimeout = DurationParam{"Registry.InactiveRegistrationTimeout"}
 	Registry_InstitutionsUrlReloadMinutes = DurationParam{"Registry.InstitutionsUrlReloadMinutes"}
 	Server_AdLifetime = DurationParam{"Server.AdLifetime"}
 	Server_AdvertisementInterval = DurationParam{"Server.AdvertisementInterval"}
@@ -2524,6 +2532,8 @@ func init() {
 		"Origin.SelfTestInterval": Origin_SelfTestInterval,
 		"Origin.SelfTestMaxAge": Origin_SelfTestMaxAge,
 		"Origin.UserMapfileRefreshInterval": Origin_UserMapfileRefreshInterval,
+		"Registry.InactiveRegistrationCleanupInterval": Registry_InactiveRegistrationCleanupInterval,
+		"Registry.InactiveRegistrationTimeout": Registry_InactiveRegistrationTimeout,
 		"Registry.InstitutionsUrlReloadMinutes": Registry_InstitutionsUrlReloadMinutes,
 		"Server.AdLifetime": Server_AdLifetime,
 		"Server.AdvertisementInterval": Server_AdvertisementInterval,

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -382,6 +382,8 @@ type Config struct {
 		AdminUsers []string `mapstructure:"adminusers" yaml:"AdminUsers"`
 		CustomRegistrationFields any `mapstructure:"customregistrationfields" yaml:"CustomRegistrationFields"`
 		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
+		InactiveRegistrationCleanupInterval time.Duration `mapstructure:"inactiveregistrationcleanupinterval" yaml:"InactiveRegistrationCleanupInterval"`
+		InactiveRegistrationTimeout time.Duration `mapstructure:"inactiveregistrationtimeout" yaml:"InactiveRegistrationTimeout"`
 		Institutions any `mapstructure:"institutions" yaml:"Institutions"`
 		InstitutionsUrl string `mapstructure:"institutionsurl" yaml:"InstitutionsUrl"`
 		InstitutionsUrlReloadMinutes time.Duration `mapstructure:"institutionsurlreloadminutes" yaml:"InstitutionsUrlReloadMinutes"`
@@ -868,6 +870,8 @@ type configWithType struct {
 		AdminUsers struct { Type string; Value []string }
 		CustomRegistrationFields struct { Type string; Value any }
 		DbLocation struct { Type string; Value string }
+		InactiveRegistrationCleanupInterval struct { Type string; Value time.Duration }
+		InactiveRegistrationTimeout struct { Type string; Value time.Duration }
 		Institutions struct { Type string; Value any }
 		InstitutionsUrl struct { Type string; Value string }
 		InstitutionsUrlReloadMinutes struct { Type string; Value time.Duration }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1282,7 +1282,7 @@ func getServerByPrefixHandler(ctx *gin.Context) {
 
 	// Refresh servers.last_seen so the cleanup goroutine knows this server is still active.
 	if err := updateServerLastSeen(server.ID); err != nil {
-		log.Warningf("Failed to update last_seen for server %s (prefix %s): %v", server.ID, prefix, err)
+		log.Warningf("Failed to update last_seen for server %q (prefix %q): %v", server.ID, prefix, err)
 	}
 
 	ctx.JSON(http.StatusOK, server)

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1280,6 +1280,11 @@ func getServerByPrefixHandler(ctx *gin.Context) {
 		return
 	}
 
+	// Refresh servers.last_seen so the cleanup goroutine knows this server is still active.
+	if err := updateServerLastSeen(server.ID); err != nil {
+		log.Warningf("Failed to update last_seen for server %s (prefix %s): %v", server.ID, prefix, err)
+	}
+
 	ctx.JSON(http.StatusOK, server)
 }
 

--- a/registry/registry_api.go
+++ b/registry/registry_api.go
@@ -76,7 +76,7 @@ func LaunchInactiveRegistrationCleanup(ctx context.Context, egrp *errgroup.Group
 					continue
 				}
 				if nRegs > 0 || nServers > 0 {
-					log.Infof("Cleaned up %d registration(s) and %d server(s) with last_seen older than %s", nRegs, nServers, timeout)
+					log.Infof("Inactive registration cleanup: removed %d pending registration(s) across %d server(s) that had no activity for more than %s", nRegs, nServers, timeout)
 				}
 			}
 		}

--- a/registry/registry_api.go
+++ b/registry/registry_api.go
@@ -56,6 +56,33 @@ func updateOSDFInstitutionCountMetric() error {
 	return nil
 }
 
+// LaunchInactiveRegistrationCleanup starts a goroutine that periodically finds servers whose
+// last_seen (updated on metadata polling) is older than Registry.InactiveRegistrationTimeout,
+// deletes all registrations linked to those servers via services, then deletes the server rows.
+func LaunchInactiveRegistrationCleanup(ctx context.Context, egrp *errgroup.Group) {
+	egrp.Go(func() error {
+		ticker := time.NewTicker(param.Registry_InactiveRegistrationCleanupInterval.GetDuration())
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-ticker.C:
+				timeout := param.Registry_InactiveRegistrationTimeout.GetDuration()
+				cutoff := time.Now().UTC().Add(-timeout)
+				nRegs, nServers, err := deleteStaleServerRegistrations(cutoff)
+				if err != nil {
+					log.Warningf("Failed to clean up stale server registrations: %v", err)
+					continue
+				}
+				if nRegs > 0 || nServers > 0 {
+					log.Infof("Cleaned up %d registration(s) and %d server(s) with last_seen older than %s", nRegs, nServers, timeout)
+				}
+			}
+		}
+	})
+}
+
 func LaunchRegistryMetrics(ctx context.Context, egrp *errgroup.Group) {
 	egrp.Go(func() error {
 		ticker := time.NewTicker(time.Second * 15)

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -674,7 +674,9 @@ func AddRegistration(ns *server_structs.Registration) error {
 				if isCache {
 					existingServer.IsCache = true
 				}
-				existingServer.UpdatedAt = time.Now()
+				now := time.Now().UTC()
+				existingServer.UpdatedAt = now
+				existingServer.LastSeen = now
 
 				if err := tx.Save(&existingServer).Error; err != nil {
 					return errors.Wrapf(err, "failed to update server service(s): %s", ns.AdminMetadata.SiteName)
@@ -692,6 +694,21 @@ func AddRegistration(ns *server_structs.Registration) error {
 
 		return nil
 	})
+}
+
+// updateServerLastSeen sets servers.last_seen = now (UTC). Called from getServerByPrefixHandler
+// when a server polls its metadata (e.g. each advertisement cycle).
+func updateServerLastSeen(serverID string) error {
+	if serverID == "" {
+		return errors.New("server ID is required to update last_seen")
+	}
+	result := database.ServerDatabase.Model(&server_structs.Server{}).
+		Where("id = ?", serverID).
+		Update("last_seen", time.Now().UTC())
+	if result.Error != nil {
+		return errors.Wrapf(result.Error, "failed to update last_seen for server %q", serverID)
+	}
+	return nil
 }
 
 func updateRegistration(ns *server_structs.Registration) error {

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -239,6 +239,7 @@ func buildServerRegistration(server server_structs.Server, services []server_str
 		Note:      server.Note,
 		CreatedAt: server.CreatedAt,
 		UpdatedAt: server.UpdatedAt,
+		LastSeen:  server.LastSeen,
 	}
 
 	for _, service := range services {
@@ -303,6 +304,7 @@ func getServerByRegistrationID(registrationID int) (*server_structs.ServerRegist
 		Note:      service.Server.Note,
 		CreatedAt: service.Server.CreatedAt,
 		UpdatedAt: service.Server.UpdatedAt,
+		LastSeen:  service.Server.LastSeen,
 	}
 
 	for _, svc := range allServices {
@@ -709,6 +711,42 @@ func updateServerLastSeen(serverID string) error {
 		return errors.Wrapf(result.Error, "failed to update last_seen for server %q", serverID)
 	}
 	return nil
+}
+
+// deleteStaleServerRegistrations uses listServers to find servers whose last_seen
+// is older than cutoff and whose every registration is still Pending, then removes
+// each one via deleteServerByID. Servers with any non-Pending registration are
+// skipped; standalone namespace registrations (no servers row) are untouched.
+func deleteStaleServerRegistrations(cutoff time.Time) (regsDeleted, serversDeleted int64, err error) {
+	servers, err := listServers()
+	if err != nil {
+		return 0, 0, errors.Wrap(err, "failed to list servers for stale cleanup")
+	}
+
+	for _, srv := range servers {
+		if srv.LastSeen.IsZero() || !srv.LastSeen.Before(cutoff) {
+			continue
+		}
+
+		allPending := true
+		for _, reg := range srv.Registration {
+			if reg.AdminMetadata.Status != server_structs.RegPending {
+				allPending = false
+				break
+			}
+		}
+		if !allPending {
+			continue
+		}
+
+		if err := deleteServerByID(srv.ID); err != nil {
+			log.Warningf("Failed to delete stale server %s (%s): %v", srv.ID, srv.Name, err)
+			continue
+		}
+		regsDeleted += int64(len(srv.Registration))
+		serversDeleted++
+	}
+	return regsDeleted, serversDeleted, nil
 }
 
 func updateRegistration(ns *server_structs.Registration) error {

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -713,10 +713,17 @@ func updateServerLastSeen(serverID string) error {
 	return nil
 }
 
+// serverIdentity links the server with the namespaces it registered in the Registry.
+type serverIdentity struct {
+	siteName string
+	keys     jwk.Set
+}
+
 // deleteStaleServerRegistrations uses listServers to find servers whose last_seen
 // is older than cutoff and whose every registration is still Pending, then removes
 // each one via deleteServerByID. Servers with any non-Pending registration are
-// skipped; standalone namespace registrations (no servers row) are untouched.
+// skipped. After the stale servers are gone, reapOrphanedPendingNamespaces removes the
+// still-Pending namespace registered by those servers.
 func deleteStaleServerRegistrations(cutoff time.Time) (regsDeleted, serversDeleted int, err error) {
 	// The cleanup only runs when both Registry.RequireOriginApproval and
 	// Registry.RequireCacheApproval are true. When either is false, registrations of that
@@ -733,6 +740,7 @@ func deleteStaleServerRegistrations(cutoff time.Time) (regsDeleted, serversDelet
 		return 0, 0, errors.Wrap(err, "failed to list servers for stale pending registration cleanup")
 	}
 
+	staleServerIdentities := make([]serverIdentity, 0)
 	for _, srv := range servers {
 		// IsZero guards against servers migrated from DB versions before the last_seen column
 		// was introduced; those rows have a zero timestamp and should never be treated as stale.
@@ -751,14 +759,108 @@ func deleteStaleServerRegistrations(cutoff time.Time) (regsDeleted, serversDelet
 			continue
 		}
 
+		// Capture the server's identity before deleting it so we can reap the namespaces it
+		// auto-registered. servers.name is the SiteName the server used when registering,
+		// and all of a server's registrations share same issuer key(s), so we use the
+		// first registration's pubkey.
+		var keys jwk.Set
+		if len(srv.Registration) > 0 {
+			if parsed, perr := jwk.ParseString(srv.Registration[0].Pubkey); perr == nil {
+				keys = parsed
+			} else {
+				log.Warningf("Stale server %q (id %q): failed to parse pubkey for orphan namespace cleanup; its namespaces won't be reaped: %v", srv.Name, srv.ID, perr)
+			}
+		}
+
 		if err := deleteServerByID(srv.ID); err != nil {
 			log.Warningf("Failed to delete stale server registration (id: %q, name: %q): %v", srv.ID, srv.Name, err)
 			continue
 		}
 		regsDeleted += len(srv.Registration)
 		serversDeleted++
+
+		if keys != nil && srv.Name != "" {
+			staleServerIdentities = append(staleServerIdentities, serverIdentity{siteName: srv.Name, keys: keys})
+		}
 	}
+
+	// Reap orphaned pending namespaces registered by stale servers
+	if len(staleServerIdentities) > 0 {
+		if rerr := reapOrphanedPendingNamespaces(staleServerIdentities); rerr != nil {
+			// Reaping orphans is best-effort cleanup; the stale servers were already removed, so
+			// log and report failure rather than killing the whole job.
+			log.Warningf("Failed to reap orphaned pending namespaces after stale server cleanup: %v", rerr)
+		}
+	}
+
 	return regsDeleted, serversDeleted, nil
+}
+
+// getRegistrationsByServerIdentity returns the namespace registrations (excluding server registrations)
+// whose (SiteName, pubkey) pair matches one of the given server identities.
+func getRegistrationsByServerIdentity(identities []serverIdentity) ([]server_structs.Registration, error) {
+	// servers.name is unique, so each SiteName maps to exactly one identity's key set.
+	keysByName := make(map[string]jwk.Set, len(identities))
+	for _, s := range identities {
+		if s.siteName == "" || s.keys == nil {
+			continue
+		}
+		keysByName[s.siteName] = s.keys
+	}
+	if len(keysByName) == 0 {
+		return nil, nil
+	}
+
+	// namespaces candidates: every prefix that isn't a server prefix. SiteName lives inside the
+	// JSON-serialized admin_metadata column and Pubkey is a JWKS blob, so both are matched in Go
+	// rather than in SQL.
+	var candidates []server_structs.Registration
+	if err := database.ServerDatabase.
+		Where("NOT prefix LIKE ? AND NOT prefix LIKE ?", "/origins/%", "/caches/%").
+		Find(&candidates).Error; err != nil {
+		return nil, errors.Wrap(err, "failed to query candidate namespaces for orphan cleanup")
+	}
+
+	matches := make([]server_structs.Registration, 0)
+	for _, ns := range candidates {
+		// Empty SiteName never appears in keysByName (we skip empty-name servers above)
+		keys, ok := keysByName[ns.AdminMetadata.SiteName]
+		if !ok {
+			continue
+		}
+		nsKeys, perr := jwk.ParseString(ns.Pubkey)
+		if perr != nil {
+			log.Warningf("Skipping orphan check for namespace %q: failed to parse its pubkey: %v", ns.Prefix, perr)
+			continue
+		}
+		if !compareJwks(keys, nsKeys) {
+			continue
+		}
+		matches = append(matches, ns)
+	}
+	return matches, nil
+}
+
+// reapOrphanedPendingNamespaces deletes pending namespaces registered by stale servers
+func reapOrphanedPendingNamespaces(staleServers []serverIdentity) error {
+	candidates, err := getRegistrationsByServerIdentity(staleServers)
+	if err != nil {
+		return err
+	}
+
+	for _, ns := range candidates {
+		if ns.AdminMetadata.Status != server_structs.RegPending {
+			continue
+		}
+		// Deletions are best-effort: a failure on one namespace is logged and the rest continue.
+		if err := deleteRegistrationByID(ns.ID); err != nil {
+			log.Warningf("Failed to delete orphaned pending namespace %q (site %q): %v", ns.Prefix, ns.AdminMetadata.SiteName, err)
+			continue
+		}
+		log.Infof("Inactive registration cleanup: removed orphaned pending namespace %q previously registered by stale server %q", ns.Prefix, ns.AdminMetadata.SiteName)
+	}
+
+	return nil
 }
 
 func updateRegistration(ns *server_structs.Registration) error {

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -717,13 +717,15 @@ func updateServerLastSeen(serverID string) error {
 // is older than cutoff and whose every registration is still Pending, then removes
 // each one via deleteServerByID. Servers with any non-Pending registration are
 // skipped; standalone namespace registrations (no servers row) are untouched.
-func deleteStaleServerRegistrations(cutoff time.Time) (regsDeleted, serversDeleted int64, err error) {
+func deleteStaleServerRegistrations(cutoff time.Time) (regsDeleted, serversDeleted int, err error) {
 	servers, err := listServers()
 	if err != nil {
-		return 0, 0, errors.Wrap(err, "failed to list servers for stale cleanup")
+		return 0, 0, errors.Wrap(err, "failed to list servers for stale pending registration cleanup")
 	}
 
 	for _, srv := range servers {
+		// IsZero guards against servers migrated from DB versions before the last_seen column
+		// was introduced; those rows have a zero timestamp and should never be treated as stale.
 		if srv.LastSeen.IsZero() || !srv.LastSeen.Before(cutoff) {
 			continue
 		}
@@ -740,10 +742,10 @@ func deleteStaleServerRegistrations(cutoff time.Time) (regsDeleted, serversDelet
 		}
 
 		if err := deleteServerByID(srv.ID); err != nil {
-			log.Warningf("Failed to delete stale server %s (%s): %v", srv.ID, srv.Name, err)
+			log.Warningf("Failed to delete stale server registration (id: %q, name: %q): %v", srv.ID, srv.Name, err)
 			continue
 		}
-		regsDeleted += int64(len(srv.Registration))
+		regsDeleted += len(srv.Registration)
 		serversDeleted++
 	}
 	return regsDeleted, serversDeleted, nil
@@ -924,6 +926,9 @@ func deleteRegistrationByPrefix(prefix string) error {
 	return database.ServerDatabase.Where("prefix = ?", prefix).Delete(&server_structs.Registration{}).Error
 }
 
+// deleteServerByID removes a server and all of its associated data atomically,
+// including its row from the servers table, its prefix(es) and namespace(s) in
+// the registrations table, and its record(s) in the services and downtimes tables.
 func deleteServerByID(id string) error {
 	// Wrap all database operations in a transaction
 	// If any operation fails, all changes are reverted. No partial records left.

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -718,6 +718,16 @@ func updateServerLastSeen(serverID string) error {
 // each one via deleteServerByID. Servers with any non-Pending registration are
 // skipped; standalone namespace registrations (no servers row) are untouched.
 func deleteStaleServerRegistrations(cutoff time.Time) (regsDeleted, serversDeleted int, err error) {
+	// The cleanup only runs when both Registry.RequireOriginApproval and
+	// Registry.RequireCacheApproval are true. When either is false, registrations of that
+	// type stay Pending in the DB for the lifetime of a healthy server (the approval check
+	// reports Approved regardless of the stored status), so a stale Pending registration is
+	// no longer a reliable signal that a server was abandoned before approval. Skipping the
+	// whole cleanup in that mode avoids deleting legitimate servers.
+	if !param.Registry_RequireOriginApproval.GetBool() || !param.Registry_RequireCacheApproval.GetBool() {
+		return 0, 0, nil
+	}
+
 	servers, err := listServers()
 	if err != nil {
 		return 0, 0, errors.Wrap(err, "failed to list servers for stale pending registration cleanup")

--- a/registry/registry_db_server_test.go
+++ b/registry/registry_db_server_test.go
@@ -92,7 +92,7 @@ func createTestNamespaces(t *testing.T) []server_structs.Registration {
 func TestServerNamespaceOperations(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	setupMockRegistryDB(t)
-	defer teardownMockRegistryDB(t)
+	t.Cleanup(func() { teardownMockRegistryDB(t) })
 
 	testNamespaces := createTestNamespaces(t)
 
@@ -159,7 +159,7 @@ func TestServerNamespaceOperations(t *testing.T) {
 func TestAddNamespaceCreatesServers(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	setupMockRegistryDB(t)
-	defer teardownMockRegistryDB(t)
+	t.Cleanup(func() { teardownMockRegistryDB(t) })
 
 	t.Run("AddOriginServer", func(t *testing.T) {
 		ns := server_structs.Registration{
@@ -296,7 +296,7 @@ func TestAddNamespaceCreatesServers(t *testing.T) {
 func TestUpdateNamespaceWithServerTables(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	setupMockRegistryDB(t)
-	defer teardownMockRegistryDB(t)
+	t.Cleanup(func() { teardownMockRegistryDB(t) })
 
 	// Create initial namespace
 	ns := server_structs.Registration{
@@ -346,7 +346,7 @@ func TestUpdateNamespaceWithServerTables(t *testing.T) {
 func TestServerTableConstraints(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	setupMockRegistryDB(t)
-	defer teardownMockRegistryDB(t)
+	t.Cleanup(func() { teardownMockRegistryDB(t) })
 
 	t.Run("ServerNameUniqueness", func(t *testing.T) {
 		// Generate a proper JWKS for the unique server test
@@ -419,7 +419,7 @@ func TestServerTableConstraints(t *testing.T) {
 func TestServerTableCascadeDelete(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	setupMockRegistryDB(t)
-	defer teardownMockRegistryDB(t)
+	t.Cleanup(func() { teardownMockRegistryDB(t) })
 
 	// Create a namespace which will create a server
 	ns := server_structs.Registration{
@@ -480,7 +480,7 @@ func TestServerTableCascadeDelete(t *testing.T) {
 func TestServerWithMultipleServices(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	setupMockRegistryDB(t)
-	defer teardownMockRegistryDB(t)
+	t.Cleanup(func() { teardownMockRegistryDB(t) })
 
 	t.Run("ServerWithBothOriginAndCacheWithSameName", func(t *testing.T) {
 		defer resetMockRegistryDB(t)
@@ -712,8 +712,17 @@ func testDowntimeForServer(serverID, serverName string) server_structs.Downtime 
 
 // createPendingServerReg creates a Registration with RegPending status and returns it.
 // The AddRegistration call creates the server row automatically for /origins/ and /caches/ prefixes.
-func createPendingServerReg(t *testing.T, prefix, siteName, pubkey string) server_structs.Registration {
+// If pubkeyOpt is provided, that key is used; otherwise a fresh JWKS is generated automatically.
+func createPendingServerReg(t *testing.T, prefix, siteName string, pubkeyOpt ...string) server_structs.Registration {
 	t.Helper()
+	var pubkey string
+	if len(pubkeyOpt) > 0 {
+		pubkey = pubkeyOpt[0]
+	} else {
+		var err error
+		pubkey, err = test_utils.GenerateJWKS()
+		require.NoError(t, err)
+	}
 	reg := server_structs.Registration{
 		Prefix: prefix,
 		Pubkey: pubkey,
@@ -742,7 +751,7 @@ func setServerLastSeenDirect(t *testing.T, serverID string, ts time.Time) {
 func TestDeleteRegistrationByID_RemovesDowntimes(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	setupMockRegistryDB(t)
-	defer teardownMockRegistryDB(t)
+	t.Cleanup(func() { teardownMockRegistryDB(t) })
 
 	t.Run("deletes-downtimes-when-last-service-removed", func(t *testing.T) {
 		defer resetMockRegistryDB(t)
@@ -835,7 +844,7 @@ func TestDeleteRegistrationByID_RemovesDowntimes(t *testing.T) {
 func TestUpdateServerLastSeen(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	setupMockRegistryDB(t)
-	defer teardownMockRegistryDB(t)
+	t.Cleanup(func() { teardownMockRegistryDB(t) })
 
 	t.Run("ErrorOnEmptyID", func(t *testing.T) {
 		err := updateServerLastSeen("")
@@ -844,18 +853,29 @@ func TestUpdateServerLastSeen(t *testing.T) {
 	})
 
 	t.Run("NoErrorOnNonExistentServerID", func(t *testing.T) {
-		// The function updates 0 rows but does not return an error (GORM doesn't
-		// treat zero-row updates as errors by default).
+		defer resetMockRegistryDB(t)
+
+		// A 0-row update is not an error: GORM emits "UPDATE ... WHERE id = ?",
+		// which matches nothing, returns no error, and crucially does NOT insert.
+		// This is what keeps getServerByPrefixHandler race-safe: if the server row
+		// is deleted (e.g. by the inactive-registration cleanup goroutine) between
+		// the read and this last_seen refresh, the refresh silently no-ops instead
+		// of erroring or resurrecting the deleted server as a phantom row.
 		err := updateServerLastSeen("doesnotexist")
 		assert.NoError(t, err)
+
+		// No phantom row should have been created by the no-op update.
+		var count int64
+		err = database.ServerDatabase.Model(&server_structs.Server{}).
+			Where("id = ?", "doesnotexist").Count(&count).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), count, "update on a non-existent ID must not insert a row")
 	})
 
 	t.Run("UpdatesTimestampForExistingServer", func(t *testing.T) {
 		defer resetMockRegistryDB(t)
 
-		pubkey, err := test_utils.GenerateJWKS()
-		require.NoError(t, err)
-		reg := createPendingServerReg(t, "/origins/ts-update.edu", "ts-update.edu", pubkey)
+		reg := createPendingServerReg(t, "/origins/ts-update.edu", "ts-update.edu")
 
 		srv, err := getServerByRegistrationID(reg.ID)
 		require.NoError(t, err)
@@ -880,9 +900,7 @@ func TestUpdateServerLastSeen(t *testing.T) {
 	t.Run("TimestampIncreasesWithRepeatedCalls", func(t *testing.T) {
 		defer resetMockRegistryDB(t)
 
-		pubkey, err := test_utils.GenerateJWKS()
-		require.NoError(t, err)
-		reg := createPendingServerReg(t, "/origins/ts-progress.edu", "ts-progress.edu", pubkey)
+		reg := createPendingServerReg(t, "/origins/ts-progress.edu", "ts-progress.edu")
 
 		srv, err := getServerByRegistrationID(reg.ID)
 		require.NoError(t, err)
@@ -912,14 +930,12 @@ func TestUpdateServerLastSeen(t *testing.T) {
 func TestDeleteServerByID(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	setupMockRegistryDB(t)
-	defer teardownMockRegistryDB(t)
+	t.Cleanup(func() { teardownMockRegistryDB(t) })
 
 	t.Run("DeletesServerAndCascadedRecords", func(t *testing.T) {
 		defer resetMockRegistryDB(t)
 
-		pubkey, err := test_utils.GenerateJWKS()
-		require.NoError(t, err)
-		reg := createPendingServerReg(t, "/origins/del-cascade.edu", "del-cascade.edu", pubkey)
+		reg := createPendingServerReg(t, "/origins/del-cascade.edu", "del-cascade.edu")
 
 		srv, err := getServerByRegistrationID(reg.ID)
 		require.NoError(t, err)
@@ -962,11 +978,9 @@ func TestDeleteServerByID(t *testing.T) {
 	t.Run("DeletesDualServiceServer", func(t *testing.T) {
 		defer resetMockRegistryDB(t)
 
-		jwks, err := test_utils.GenerateJWKS()
-		require.NoError(t, err)
-
-		originReg := createPendingServerReg(t, "/origins/dual-del.edu", "dual-del.edu", jwks)
-		cacheReg := createPendingServerReg(t, "/caches/dual-del.edu", "dual-del.edu", jwks)
+		// Different services on a server must share the same key
+		originReg := createPendingServerReg(t, "/origins/dual-del.edu", "dual-del.edu")
+		cacheReg := createPendingServerReg(t, "/caches/dual-del.edu", "dual-del.edu", originReg.Pubkey)
 
 		srv, err := getServerByRegistrationID(originReg.ID)
 		require.NoError(t, err)
@@ -1007,7 +1021,7 @@ func withApprovalRequired(t *testing.T) {
 func TestDeleteStaleServerRegistrations(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	setupMockRegistryDB(t)
-	defer teardownMockRegistryDB(t)
+	t.Cleanup(func() { teardownMockRegistryDB(t) })
 	withApprovalRequired(t)
 
 	t.Run("EmptyDatabase", func(t *testing.T) {
@@ -1020,9 +1034,7 @@ func TestDeleteStaleServerRegistrations(t *testing.T) {
 	t.Run("DeletesPendingStaleServer", func(t *testing.T) {
 		defer resetMockRegistryDB(t)
 
-		pubkey, err := test_utils.GenerateJWKS()
-		require.NoError(t, err)
-		reg := createPendingServerReg(t, "/origins/stale-pending.edu", "stale-pending.edu", pubkey)
+		reg := createPendingServerReg(t, "/origins/stale-pending.edu", "stale-pending.edu")
 
 		srv, err := getServerByRegistrationID(reg.ID)
 		require.NoError(t, err)
@@ -1109,9 +1121,7 @@ func TestDeleteStaleServerRegistrations(t *testing.T) {
 	t.Run("PreservesRecentPendingServer", func(t *testing.T) {
 		defer resetMockRegistryDB(t)
 
-		pubkey, err := test_utils.GenerateJWKS()
-		require.NoError(t, err)
-		reg := createPendingServerReg(t, "/origins/recent-pending.edu", "recent-pending.edu", pubkey)
+		reg := createPendingServerReg(t, "/origins/recent-pending.edu", "recent-pending.edu")
 
 		srv, err := getServerByRegistrationID(reg.ID)
 		require.NoError(t, err)
@@ -1124,12 +1134,13 @@ func TestDeleteStaleServerRegistrations(t *testing.T) {
 		assert.Equal(t, int(0), serversDeleted, "recently active pending server should not be deleted")
 	})
 
+	// A pending server registration migrated from a DB version before the last_seen column
+	// was introduced will have a zero timestamp for last_seen. Such registrations should not
+	// be treated as stale.
 	t.Run("SkipsServerWithZeroLastSeen", func(t *testing.T) {
 		defer resetMockRegistryDB(t)
 
-		pubkey, err := test_utils.GenerateJWKS()
-		require.NoError(t, err)
-		reg := createPendingServerReg(t, "/origins/zero-lastseen.edu", "zero-lastseen.edu", pubkey)
+		reg := createPendingServerReg(t, "/origins/zero-lastseen.edu", "zero-lastseen.edu")
 
 		srv, err := getServerByRegistrationID(reg.ID)
 		require.NoError(t, err)
@@ -1148,22 +1159,19 @@ func TestDeleteStaleServerRegistrations(t *testing.T) {
 	t.Run("MixedStatusPreservesServerWithAnyNonPending", func(t *testing.T) {
 		defer resetMockRegistryDB(t)
 
-		jwks, err := test_utils.GenerateJWKS()
-		require.NoError(t, err)
-
 		// Register origin as pending, then cache as approved (same server name → same server row).
-		pendingReg := createPendingServerReg(t, "/origins/mixed-status.edu", "mixed-status.edu", jwks)
+		pendingReg := createPendingServerReg(t, "/origins/mixed-status.edu", "mixed-status.edu")
 
 		approvedReg := server_structs.Registration{
 			Prefix: "/caches/mixed-status.edu",
-			Pubkey: jwks,
+			Pubkey: pendingReg.Pubkey,
 			AdminMetadata: server_structs.AdminMetadata{
 				SiteName:    "mixed-status.edu",
 				Institution: "Test University",
 				Status:      server_structs.RegApproved,
 			},
 		}
-		err = AddRegistration(&approvedReg)
+		err := AddRegistration(&approvedReg)
 		require.NoError(t, err)
 
 		srv, err := getServerByRegistrationID(pendingReg.ID)
@@ -1179,13 +1187,8 @@ func TestDeleteStaleServerRegistrations(t *testing.T) {
 	t.Run("DeletesMultipleStaleServers", func(t *testing.T) {
 		defer resetMockRegistryDB(t)
 
-		jwks1, err := test_utils.GenerateJWKS()
-		require.NoError(t, err)
-		jwks2, err := test_utils.GenerateJWKS()
-		require.NoError(t, err)
-
-		reg1 := createPendingServerReg(t, "/origins/stale1.edu", "stale1.edu", jwks1)
-		reg2 := createPendingServerReg(t, "/origins/stale2.edu", "stale2.edu", jwks2)
+		reg1 := createPendingServerReg(t, "/origins/stale1.edu", "stale1.edu")
+		reg2 := createPendingServerReg(t, "/origins/stale2.edu", "stale2.edu")
 
 		srv1, err := getServerByRegistrationID(reg1.ID)
 		require.NoError(t, err)
@@ -1205,12 +1208,9 @@ func TestDeleteStaleServerRegistrations(t *testing.T) {
 	t.Run("ReturnCountsForDualServiceStaleServer", func(t *testing.T) {
 		defer resetMockRegistryDB(t)
 
-		jwks, err := test_utils.GenerateJWKS()
-		require.NoError(t, err)
-
 		// Same server, two registrations (both pending).
-		reg1 := createPendingServerReg(t, "/origins/dual-stale.edu", "dual-stale.edu", jwks)
-		createPendingServerReg(t, "/caches/dual-stale.edu", "dual-stale.edu", jwks)
+		reg1 := createPendingServerReg(t, "/origins/dual-stale.edu", "dual-stale.edu")
+		createPendingServerReg(t, "/caches/dual-stale.edu", "dual-stale.edu", reg1.Pubkey)
 
 		srv, err := getServerByRegistrationID(reg1.ID)
 		require.NoError(t, err)
@@ -1233,9 +1233,7 @@ func TestDeleteStaleServerRegistrations(t *testing.T) {
 		require.NoError(t, param.Registry_RequireOriginApproval.Set(false))
 		t.Cleanup(func() { require.NoError(t, param.Registry_RequireOriginApproval.Set(true)) })
 
-		pubkey, err := test_utils.GenerateJWKS()
-		require.NoError(t, err)
-		reg := createPendingServerReg(t, "/origins/no-approval.edu", "no-approval.edu", pubkey)
+		reg := createPendingServerReg(t, "/origins/no-approval.edu", "no-approval.edu")
 
 		srv, err := getServerByRegistrationID(reg.ID)
 		require.NoError(t, err)
@@ -1256,7 +1254,7 @@ func TestDeleteStaleServerRegistrations(t *testing.T) {
 func TestLaunchInactiveRegistrationCleanup(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	setupMockRegistryDB(t)
-	defer teardownMockRegistryDB(t)
+	t.Cleanup(func() { teardownMockRegistryDB(t) })
 	withApprovalRequired(t)
 
 	t.Run("StopsCleanlyOnContextCancellation", func(t *testing.T) {
@@ -1281,9 +1279,7 @@ func TestLaunchInactiveRegistrationCleanup(t *testing.T) {
 		require.NoError(t, param.Registry_InactiveRegistrationCleanupInterval.Set(10*time.Millisecond))
 		require.NoError(t, param.Registry_InactiveRegistrationTimeout.Set(time.Millisecond))
 
-		pubkey, err := test_utils.GenerateJWKS()
-		require.NoError(t, err)
-		reg := createPendingServerReg(t, "/origins/cleanup-goroutine.edu", "cleanup-goroutine.edu", pubkey)
+		reg := createPendingServerReg(t, "/origins/cleanup-goroutine.edu", "cleanup-goroutine.edu")
 
 		srv, err := getServerByRegistrationID(reg.ID)
 		require.NoError(t, err)

--- a/registry/registry_db_server_test.go
+++ b/registry/registry_db_server_test.go
@@ -989,16 +989,32 @@ func TestDeleteServerByID(t *testing.T) {
 	})
 }
 
+// withApprovalRequired turns on both registry approval flags for the duration of the
+// test and restores their prior values on cleanup. deleteStaleServerRegistrations is a
+// no-op unless both are set, so the deletion-path tests rely on this.
+func withApprovalRequired(t *testing.T) {
+	t.Helper()
+	origOrigin := param.Registry_RequireOriginApproval.GetBool()
+	origCache := param.Registry_RequireCacheApproval.GetBool()
+	require.NoError(t, param.Registry_RequireOriginApproval.Set(true))
+	require.NoError(t, param.Registry_RequireCacheApproval.Set(true))
+	t.Cleanup(func() {
+		require.NoError(t, param.Registry_RequireOriginApproval.Set(origOrigin))
+		require.NoError(t, param.Registry_RequireCacheApproval.Set(origCache))
+	})
+}
+
 func TestDeleteStaleServerRegistrations(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	setupMockRegistryDB(t)
 	defer teardownMockRegistryDB(t)
+	withApprovalRequired(t)
 
 	t.Run("EmptyDatabase", func(t *testing.T) {
 		regs, servers, err := deleteStaleServerRegistrations(time.Now().UTC())
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), regs)
-		assert.Equal(t, int64(0), servers)
+		assert.Equal(t, int(0), regs)
+		assert.Equal(t, int(0), servers)
 	})
 
 	t.Run("DeletesPendingStaleServer", func(t *testing.T) {
@@ -1017,8 +1033,8 @@ func TestDeleteStaleServerRegistrations(t *testing.T) {
 		cutoff := time.Now().UTC().Add(-1 * time.Hour) // older than 1h is stale
 		regsDeleted, serversDeleted, err := deleteStaleServerRegistrations(cutoff)
 		require.NoError(t, err)
-		assert.Equal(t, int64(1), regsDeleted)
-		assert.Equal(t, int64(1), serversDeleted)
+		assert.Equal(t, int(1), regsDeleted)
+		assert.Equal(t, int(1), serversDeleted)
 
 		// Verify removal.
 		var count int64
@@ -1054,8 +1070,8 @@ func TestDeleteStaleServerRegistrations(t *testing.T) {
 		cutoff := time.Now().UTC().Add(-1 * time.Hour)
 		regsDeleted, serversDeleted, err := deleteStaleServerRegistrations(cutoff)
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), regsDeleted, "approved server should not be deleted")
-		assert.Equal(t, int64(0), serversDeleted)
+		assert.Equal(t, int(0), regsDeleted, "approved server should not be deleted")
+		assert.Equal(t, int(0), serversDeleted)
 
 		var count int64
 		err = database.ServerDatabase.Model(&server_structs.Server{}).Where("id = ?", srv.ID).Count(&count).Error
@@ -1087,7 +1103,7 @@ func TestDeleteStaleServerRegistrations(t *testing.T) {
 
 		_, serversDeleted, err := deleteStaleServerRegistrations(time.Now().UTC().Add(-1 * time.Hour))
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), serversDeleted, "denied server should not be deleted")
+		assert.Equal(t, int(0), serversDeleted, "denied server should not be deleted")
 	})
 
 	t.Run("PreservesRecentPendingServer", func(t *testing.T) {
@@ -1105,7 +1121,7 @@ func TestDeleteStaleServerRegistrations(t *testing.T) {
 
 		_, serversDeleted, err := deleteStaleServerRegistrations(time.Now().UTC().Add(-1 * time.Hour))
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), serversDeleted, "recently active pending server should not be deleted")
+		assert.Equal(t, int(0), serversDeleted, "recently active pending server should not be deleted")
 	})
 
 	t.Run("SkipsServerWithZeroLastSeen", func(t *testing.T) {
@@ -1126,7 +1142,7 @@ func TestDeleteStaleServerRegistrations(t *testing.T) {
 
 		_, serversDeleted, err := deleteStaleServerRegistrations(time.Now().UTC())
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), serversDeleted, "server with zero last_seen should be skipped")
+		assert.Equal(t, int(0), serversDeleted, "server with zero last_seen should be skipped")
 	})
 
 	t.Run("MixedStatusPreservesServerWithAnyNonPending", func(t *testing.T) {
@@ -1156,7 +1172,7 @@ func TestDeleteStaleServerRegistrations(t *testing.T) {
 
 		_, serversDeleted, err := deleteStaleServerRegistrations(time.Now().UTC().Add(-1 * time.Hour))
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), serversDeleted,
+		assert.Equal(t, int(0), serversDeleted,
 			"server with at least one approved registration must not be deleted")
 	})
 
@@ -1182,8 +1198,8 @@ func TestDeleteStaleServerRegistrations(t *testing.T) {
 		cutoff := time.Now().UTC().Add(-1 * time.Hour)
 		regsDeleted, serversDeleted, err := deleteStaleServerRegistrations(cutoff)
 		require.NoError(t, err)
-		assert.Equal(t, int64(2), regsDeleted)
-		assert.Equal(t, int64(2), serversDeleted)
+		assert.Equal(t, int(2), regsDeleted)
+		assert.Equal(t, int(2), serversDeleted)
 	})
 
 	t.Run("ReturnCountsForDualServiceStaleServer", func(t *testing.T) {
@@ -1203,8 +1219,37 @@ func TestDeleteStaleServerRegistrations(t *testing.T) {
 		cutoff := time.Now().UTC().Add(-1 * time.Hour)
 		regsDeleted, serversDeleted, err := deleteStaleServerRegistrations(cutoff)
 		require.NoError(t, err)
-		assert.Equal(t, int64(1), serversDeleted)
-		assert.Equal(t, int64(2), regsDeleted, "both registrations for the dual server should be counted")
+		assert.Equal(t, int(1), serversDeleted)
+		assert.Equal(t, int(2), regsDeleted, "both registrations for the dual server should be counted")
+	})
+
+	t.Run("SkipsCleanupWhenApprovalNotRequired", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		// With approval turned off, a healthy server's registration stays Pending for its
+		// whole lifetime (the approval check reports Approved regardless of stored status),
+		// so a stale Pending registration is no longer a signal of abandonment. Disabling
+		// either flag must short-circuit the whole cleanup.
+		require.NoError(t, param.Registry_RequireOriginApproval.Set(false))
+		t.Cleanup(func() { require.NoError(t, param.Registry_RequireOriginApproval.Set(true)) })
+
+		pubkey, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+		reg := createPendingServerReg(t, "/origins/no-approval.edu", "no-approval.edu", pubkey)
+
+		srv, err := getServerByRegistrationID(reg.ID)
+		require.NoError(t, err)
+		setServerLastSeenDirect(t, srv.ID, time.Now().UTC().Add(-2*time.Hour))
+
+		regsDeleted, serversDeleted, err := deleteStaleServerRegistrations(time.Now().UTC().Add(-1 * time.Hour))
+		require.NoError(t, err)
+		assert.Equal(t, int(0), regsDeleted)
+		assert.Equal(t, int(0), serversDeleted, "cleanup must be skipped when approval is not required")
+
+		var count int64
+		err = database.ServerDatabase.Model(&server_structs.Server{}).Where("id = ?", srv.ID).Count(&count).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), count, "stale pending server must survive when approval is off")
 	})
 }
 
@@ -1212,6 +1257,7 @@ func TestLaunchInactiveRegistrationCleanup(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	setupMockRegistryDB(t)
 	defer teardownMockRegistryDB(t)
+	withApprovalRequired(t)
 
 	t.Run("StopsCleanlyOnContextCancellation", func(t *testing.T) {
 		// Use a long interval so the ticker never fires during this subtest.

--- a/registry/registry_db_server_test.go
+++ b/registry/registry_db_server_test.go
@@ -19,14 +19,17 @@
 package registry
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/pelicanplatform/pelican/database"
+	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/test_utils"
 )
@@ -707,6 +710,33 @@ func testDowntimeForServer(serverID, serverName string) server_structs.Downtime 
 	}
 }
 
+// createPendingServerReg creates a Registration with RegPending status and returns it.
+// The AddRegistration call creates the server row automatically for /origins/ and /caches/ prefixes.
+func createPendingServerReg(t *testing.T, prefix, siteName, pubkey string) server_structs.Registration {
+	t.Helper()
+	reg := server_structs.Registration{
+		Prefix: prefix,
+		Pubkey: pubkey,
+		AdminMetadata: server_structs.AdminMetadata{
+			SiteName:    siteName,
+			Institution: "Test University",
+			Status:      server_structs.RegPending,
+		},
+	}
+	err := AddRegistration(&reg)
+	require.NoError(t, err)
+	return reg
+}
+
+// setServerLastSeenDirect directly updates the last_seen column in the DB.
+func setServerLastSeenDirect(t *testing.T, serverID string, ts time.Time) {
+	t.Helper()
+	err := database.ServerDatabase.Model(&server_structs.Server{}).
+		Where("id = ?", serverID).
+		Update("last_seen", ts).Error
+	require.NoError(t, err)
+}
+
 // TestDeleteRegistrationByID_RemovesDowntimes covers explicit downtime cleanup when the last
 // service for a server is removed (no FK from downtimes to servers).
 func TestDeleteRegistrationByID_RemovesDowntimes(t *testing.T) {
@@ -799,5 +829,501 @@ func TestDeleteRegistrationByID_RemovesDowntimes(t *testing.T) {
 		err = database.ServerDatabase.Model(&server_structs.Server{}).Where("id = ?", server.ID).Count(&serverCount).Error
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), serverCount)
+	})
+}
+
+func TestUpdateServerLastSeen(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	setupMockRegistryDB(t)
+	defer teardownMockRegistryDB(t)
+
+	t.Run("ErrorOnEmptyID", func(t *testing.T) {
+		err := updateServerLastSeen("")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "server ID is required")
+	})
+
+	t.Run("NoErrorOnNonExistentServerID", func(t *testing.T) {
+		// The function updates 0 rows but does not return an error (GORM doesn't
+		// treat zero-row updates as errors by default).
+		err := updateServerLastSeen("doesnotexist")
+		assert.NoError(t, err)
+	})
+
+	t.Run("UpdatesTimestampForExistingServer", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		pubkey, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+		reg := createPendingServerReg(t, "/origins/ts-update.edu", "ts-update.edu", pubkey)
+
+		srv, err := getServerByRegistrationID(reg.ID)
+		require.NoError(t, err)
+		require.NotEmpty(t, srv.ID)
+
+		// Push last_seen far into the past so we can detect a change.
+		past := time.Now().UTC().Add(-1 * time.Hour)
+		setServerLastSeenDirect(t, srv.ID, past)
+
+		before := time.Now().UTC()
+		err = updateServerLastSeen(srv.ID)
+		require.NoError(t, err)
+
+		var updated server_structs.Server
+		err = database.ServerDatabase.Where("id = ?", srv.ID).First(&updated).Error
+		require.NoError(t, err)
+
+		assert.True(t, updated.LastSeen.After(before) || updated.LastSeen.Equal(before),
+			"last_seen should be updated to now, got %v", updated.LastSeen)
+	})
+
+	t.Run("TimestampIncreasesWithRepeatedCalls", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		pubkey, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+		reg := createPendingServerReg(t, "/origins/ts-progress.edu", "ts-progress.edu", pubkey)
+
+		srv, err := getServerByRegistrationID(reg.ID)
+		require.NoError(t, err)
+
+		err = updateServerLastSeen(srv.ID)
+		require.NoError(t, err)
+
+		var first server_structs.Server
+		err = database.ServerDatabase.Where("id = ?", srv.ID).First(&first).Error
+		require.NoError(t, err)
+
+		// Small sleep so clock advances.
+		time.Sleep(10 * time.Millisecond)
+
+		err = updateServerLastSeen(srv.ID)
+		require.NoError(t, err)
+
+		var second server_structs.Server
+		err = database.ServerDatabase.Where("id = ?", srv.ID).First(&second).Error
+		require.NoError(t, err)
+
+		assert.True(t, second.LastSeen.After(first.LastSeen),
+			"second last_seen (%v) should be after first (%v)", second.LastSeen, first.LastSeen)
+	})
+}
+
+func TestDeleteServerByID(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	setupMockRegistryDB(t)
+	defer teardownMockRegistryDB(t)
+
+	t.Run("DeletesServerAndCascadedRecords", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		pubkey, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+		reg := createPendingServerReg(t, "/origins/del-cascade.edu", "del-cascade.edu", pubkey)
+
+		srv, err := getServerByRegistrationID(reg.ID)
+		require.NoError(t, err)
+		require.NotEmpty(t, srv.ID)
+
+		// Add an endpoint and contact so cascade deletes can be verified.
+		ep := server_structs.Endpoint{ServerID: srv.ID, Endpoint: "https://del-cascade.edu:8443"}
+		err = database.ServerDatabase.Create(&ep).Error
+		require.NoError(t, err)
+
+		ct := server_structs.Contact{ServerID: srv.ID, FullName: "Admin", ContactInfo: "admin@del-cascade.edu"}
+		err = database.ServerDatabase.Create(&ct).Error
+		require.NoError(t, err)
+
+		err = deleteServerByID(srv.ID)
+		require.NoError(t, err)
+
+		// Server row gone.
+		var serverCount int64
+		err = database.ServerDatabase.Model(&server_structs.Server{}).Where("id = ?", srv.ID).Count(&serverCount).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), serverCount)
+
+		// Registration row gone.
+		var regCount int64
+		err = database.ServerDatabase.Model(&server_structs.Registration{}).Where("id = ?", reg.ID).Count(&regCount).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), regCount)
+
+		// Cascaded records gone.
+		var epCount, ctCount int64
+		err = database.ServerDatabase.Model(&server_structs.Endpoint{}).Where("server_id = ?", srv.ID).Count(&epCount).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), epCount)
+		err = database.ServerDatabase.Model(&server_structs.Contact{}).Where("server_id = ?", srv.ID).Count(&ctCount).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), ctCount)
+	})
+
+	t.Run("DeletesDualServiceServer", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		jwks, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+
+		originReg := createPendingServerReg(t, "/origins/dual-del.edu", "dual-del.edu", jwks)
+		cacheReg := createPendingServerReg(t, "/caches/dual-del.edu", "dual-del.edu", jwks)
+
+		srv, err := getServerByRegistrationID(originReg.ID)
+		require.NoError(t, err)
+
+		err = deleteServerByID(srv.ID)
+		require.NoError(t, err)
+
+		// Both registrations should be gone.
+		var regCount int64
+		err = database.ServerDatabase.Model(&server_structs.Registration{}).
+			Where("id IN ?", []int{originReg.ID, cacheReg.ID}).Count(&regCount).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), regCount)
+
+		// Services should be gone.
+		var svcCount int64
+		err = database.ServerDatabase.Model(&server_structs.Service{}).Where("server_id = ?", srv.ID).Count(&svcCount).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), svcCount)
+	})
+}
+
+func TestDeleteStaleServerRegistrations(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	setupMockRegistryDB(t)
+	defer teardownMockRegistryDB(t)
+
+	t.Run("EmptyDatabase", func(t *testing.T) {
+		regs, servers, err := deleteStaleServerRegistrations(time.Now().UTC())
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), regs)
+		assert.Equal(t, int64(0), servers)
+	})
+
+	t.Run("DeletesPendingStaleServer", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		pubkey, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+		reg := createPendingServerReg(t, "/origins/stale-pending.edu", "stale-pending.edu", pubkey)
+
+		srv, err := getServerByRegistrationID(reg.ID)
+		require.NoError(t, err)
+
+		// Set last_seen well in the past.
+		setServerLastSeenDirect(t, srv.ID, time.Now().UTC().Add(-2*time.Hour))
+
+		cutoff := time.Now().UTC().Add(-1 * time.Hour) // older than 1h is stale
+		regsDeleted, serversDeleted, err := deleteStaleServerRegistrations(cutoff)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), regsDeleted)
+		assert.Equal(t, int64(1), serversDeleted)
+
+		// Verify removal.
+		var count int64
+		err = database.ServerDatabase.Model(&server_structs.Server{}).Where("id = ?", srv.ID).Count(&count).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), count)
+	})
+
+	t.Run("PreservesApprovedServer", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		pubkey, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+
+		reg := server_structs.Registration{
+			Prefix: "/origins/approved-server.edu",
+			Pubkey: pubkey,
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName:    "approved-server.edu",
+				Institution: "Test University",
+				Status:      server_structs.RegApproved,
+			},
+		}
+		err = AddRegistration(&reg)
+		require.NoError(t, err)
+
+		srv, err := getServerByRegistrationID(reg.ID)
+		require.NoError(t, err)
+
+		// Make it look stale.
+		setServerLastSeenDirect(t, srv.ID, time.Now().UTC().Add(-2*time.Hour))
+
+		cutoff := time.Now().UTC().Add(-1 * time.Hour)
+		regsDeleted, serversDeleted, err := deleteStaleServerRegistrations(cutoff)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), regsDeleted, "approved server should not be deleted")
+		assert.Equal(t, int64(0), serversDeleted)
+
+		var count int64
+		err = database.ServerDatabase.Model(&server_structs.Server{}).Where("id = ?", srv.ID).Count(&count).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), count)
+	})
+
+	t.Run("PreservesDeniedServer", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		pubkey, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+
+		reg := server_structs.Registration{
+			Prefix: "/origins/denied-server.edu",
+			Pubkey: pubkey,
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName:    "denied-server.edu",
+				Institution: "Test University",
+				Status:      server_structs.RegDenied,
+			},
+		}
+		err = AddRegistration(&reg)
+		require.NoError(t, err)
+
+		srv, err := getServerByRegistrationID(reg.ID)
+		require.NoError(t, err)
+		setServerLastSeenDirect(t, srv.ID, time.Now().UTC().Add(-2*time.Hour))
+
+		_, serversDeleted, err := deleteStaleServerRegistrations(time.Now().UTC().Add(-1 * time.Hour))
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), serversDeleted, "denied server should not be deleted")
+	})
+
+	t.Run("PreservesRecentPendingServer", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		pubkey, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+		reg := createPendingServerReg(t, "/origins/recent-pending.edu", "recent-pending.edu", pubkey)
+
+		srv, err := getServerByRegistrationID(reg.ID)
+		require.NoError(t, err)
+
+		// last_seen is recent (5 minutes ago), cutoff is 1 hour ago.
+		setServerLastSeenDirect(t, srv.ID, time.Now().UTC().Add(-5*time.Minute))
+
+		_, serversDeleted, err := deleteStaleServerRegistrations(time.Now().UTC().Add(-1 * time.Hour))
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), serversDeleted, "recently active pending server should not be deleted")
+	})
+
+	t.Run("SkipsServerWithZeroLastSeen", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		pubkey, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+		reg := createPendingServerReg(t, "/origins/zero-lastseen.edu", "zero-lastseen.edu", pubkey)
+
+		srv, err := getServerByRegistrationID(reg.ID)
+		require.NoError(t, err)
+
+		// Explicitly zero out last_seen.
+		err = database.ServerDatabase.Model(&server_structs.Server{}).
+			Where("id = ?", srv.ID).
+			Update("last_seen", time.Time{}).Error
+		require.NoError(t, err)
+
+		_, serversDeleted, err := deleteStaleServerRegistrations(time.Now().UTC())
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), serversDeleted, "server with zero last_seen should be skipped")
+	})
+
+	t.Run("MixedStatusPreservesServerWithAnyNonPending", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		jwks, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+
+		// Register origin as pending, then cache as approved (same server name → same server row).
+		pendingReg := createPendingServerReg(t, "/origins/mixed-status.edu", "mixed-status.edu", jwks)
+
+		approvedReg := server_structs.Registration{
+			Prefix: "/caches/mixed-status.edu",
+			Pubkey: jwks,
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName:    "mixed-status.edu",
+				Institution: "Test University",
+				Status:      server_structs.RegApproved,
+			},
+		}
+		err = AddRegistration(&approvedReg)
+		require.NoError(t, err)
+
+		srv, err := getServerByRegistrationID(pendingReg.ID)
+		require.NoError(t, err)
+		setServerLastSeenDirect(t, srv.ID, time.Now().UTC().Add(-2*time.Hour))
+
+		_, serversDeleted, err := deleteStaleServerRegistrations(time.Now().UTC().Add(-1 * time.Hour))
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), serversDeleted,
+			"server with at least one approved registration must not be deleted")
+	})
+
+	t.Run("DeletesMultipleStaleServers", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		jwks1, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+		jwks2, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+
+		reg1 := createPendingServerReg(t, "/origins/stale1.edu", "stale1.edu", jwks1)
+		reg2 := createPendingServerReg(t, "/origins/stale2.edu", "stale2.edu", jwks2)
+
+		srv1, err := getServerByRegistrationID(reg1.ID)
+		require.NoError(t, err)
+		srv2, err := getServerByRegistrationID(reg2.ID)
+		require.NoError(t, err)
+
+		setServerLastSeenDirect(t, srv1.ID, time.Now().UTC().Add(-3*time.Hour))
+		setServerLastSeenDirect(t, srv2.ID, time.Now().UTC().Add(-3*time.Hour))
+
+		cutoff := time.Now().UTC().Add(-1 * time.Hour)
+		regsDeleted, serversDeleted, err := deleteStaleServerRegistrations(cutoff)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), regsDeleted)
+		assert.Equal(t, int64(2), serversDeleted)
+	})
+
+	t.Run("ReturnCountsForDualServiceStaleServer", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		jwks, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+
+		// Same server, two registrations (both pending).
+		reg1 := createPendingServerReg(t, "/origins/dual-stale.edu", "dual-stale.edu", jwks)
+		createPendingServerReg(t, "/caches/dual-stale.edu", "dual-stale.edu", jwks)
+
+		srv, err := getServerByRegistrationID(reg1.ID)
+		require.NoError(t, err)
+		setServerLastSeenDirect(t, srv.ID, time.Now().UTC().Add(-2*time.Hour))
+
+		cutoff := time.Now().UTC().Add(-1 * time.Hour)
+		regsDeleted, serversDeleted, err := deleteStaleServerRegistrations(cutoff)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), serversDeleted)
+		assert.Equal(t, int64(2), regsDeleted, "both registrations for the dual server should be counted")
+	})
+}
+
+func TestLaunchInactiveRegistrationCleanup(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	setupMockRegistryDB(t)
+	defer teardownMockRegistryDB(t)
+
+	t.Run("StopsCleanlyOnContextCancellation", func(t *testing.T) {
+		// Use a long interval so the ticker never fires during this subtest.
+		require.NoError(t, param.Registry_InactiveRegistrationCleanupInterval.Set(time.Minute))
+		require.NoError(t, param.Registry_InactiveRegistrationTimeout.Set(20*time.Minute))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		egrp, _ := errgroup.WithContext(ctx)
+
+		LaunchInactiveRegistrationCleanup(ctx, egrp)
+
+		cancel()
+		assert.NoError(t, egrp.Wait())
+	})
+
+	t.Run("RemovesStaleRegistrationsOnTick", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		// Fire the ticker every 10 ms; consider servers inactive after 1 ms so
+		// any server whose last_seen is in the past qualifies immediately.
+		require.NoError(t, param.Registry_InactiveRegistrationCleanupInterval.Set(10*time.Millisecond))
+		require.NoError(t, param.Registry_InactiveRegistrationTimeout.Set(time.Millisecond))
+
+		pubkey, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+		reg := createPendingServerReg(t, "/origins/cleanup-goroutine.edu", "cleanup-goroutine.edu", pubkey)
+
+		srv, err := getServerByRegistrationID(reg.ID)
+		require.NoError(t, err)
+		setServerLastSeenDirect(t, srv.ID, time.Now().UTC().Add(-time.Hour))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		egrp, _ := errgroup.WithContext(ctx)
+
+		LaunchInactiveRegistrationCleanup(ctx, egrp)
+
+		// Poll until the server row disappears, or fail after 5 s.
+		require.Eventually(t, func() bool {
+			var count int64
+			err := database.ServerDatabase.Model(&server_structs.Server{}).
+				Where("id = ?", srv.ID).Count(&count).Error
+			return err == nil && count == 0
+		}, 5*time.Second, 20*time.Millisecond, "stale pending server was not removed")
+
+		// Registration row must be gone too.
+		var regCount int64
+		err = database.ServerDatabase.Model(&server_structs.Registration{}).
+			Where("id = ?", reg.ID).Count(&regCount).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), regCount, "registration linked to deleted server must be removed")
+
+		cancel()
+		assert.NoError(t, egrp.Wait())
+	})
+
+	t.Run("PreservesApprovedRegistrationOnTick", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		require.NoError(t, param.Registry_InactiveRegistrationCleanupInterval.Set(10*time.Millisecond))
+		require.NoError(t, param.Registry_InactiveRegistrationTimeout.Set(time.Millisecond))
+
+		approvedKey, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+		pendingKey, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+
+		// Approved server — must survive.
+		approvedReg := server_structs.Registration{
+			Prefix: "/origins/approved-goroutine.edu",
+			Pubkey: approvedKey,
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName:    "approved-goroutine.edu",
+				Institution: "Test University",
+				Status:      server_structs.RegApproved,
+			},
+		}
+		err = AddRegistration(&approvedReg)
+		require.NoError(t, err)
+		approvedSrv, err := getServerByRegistrationID(approvedReg.ID)
+		require.NoError(t, err)
+		setServerLastSeenDirect(t, approvedSrv.ID, time.Now().UTC().Add(-time.Hour))
+
+		// Witness pending server — used to confirm the cleanup goroutine has
+		// fired at least once before we assert the approved server is still present.
+		witnessReg := createPendingServerReg(t, "/origins/witness-goroutine.edu", "witness-goroutine.edu", pendingKey)
+		witnessSrv, err := getServerByRegistrationID(witnessReg.ID)
+		require.NoError(t, err)
+		setServerLastSeenDirect(t, witnessSrv.ID, time.Now().UTC().Add(-time.Hour))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		egrp, _ := errgroup.WithContext(ctx)
+
+		LaunchInactiveRegistrationCleanup(ctx, egrp)
+
+		// Wait until the witness is gone — this proves cleanup ran at least once.
+		require.Eventually(t, func() bool {
+			var count int64
+			err := database.ServerDatabase.Model(&server_structs.Server{}).
+				Where("id = ?", witnessSrv.ID).Count(&count).Error
+			return err == nil && count == 0
+		}, 5*time.Second, 20*time.Millisecond, "witness pending server was not removed")
+
+		// Approved server must still be present.
+		var count int64
+		err = database.ServerDatabase.Model(&server_structs.Server{}).
+			Where("id = ?", approvedSrv.ID).Count(&count).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), count, "approved server must not be removed by cleanup")
+
+		cancel()
+		assert.NoError(t, egrp.Wait())
 	})
 }

--- a/registry/registry_db_server_test.go
+++ b/registry/registry_db_server_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -737,6 +738,34 @@ func createPendingServerReg(t *testing.T, prefix, siteName string, pubkeyOpt ...
 	return reg
 }
 
+// createPendingNamespaceReg adds a Pending data-namespace registration (a non-server prefix,
+// e.g. "/apple/juice") with the given SiteName and pubkey, mimicking what an origin
+// auto-registers for the namespaces it hosts. AddRegistration does not create a servers/services
+// row for such a prefix, so it is exactly the orphan that reapOrphanedPendingNamespaces targets.
+func createPendingNamespaceReg(t *testing.T, prefix, siteName, pubkey string) server_structs.Registration {
+	t.Helper()
+	reg := server_structs.Registration{
+		Prefix: prefix,
+		Pubkey: pubkey,
+		AdminMetadata: server_structs.AdminMetadata{
+			SiteName:    siteName,
+			Institution: "Test University",
+			Status:      server_structs.RegPending,
+		},
+	}
+	require.NoError(t, AddRegistration(&reg))
+	return reg
+}
+
+// registrationExists reports whether a registration row with the given ID is still present.
+func registrationExists(t *testing.T, id int) bool {
+	t.Helper()
+	var count int64
+	err := database.ServerDatabase.Model(&server_structs.Registration{}).Where("id = ?", id).Count(&count).Error
+	require.NoError(t, err)
+	return count > 0
+}
+
 // setServerLastSeenDirect directly updates the last_seen column in the DB.
 func setServerLastSeenDirect(t *testing.T, serverID string, ts time.Time) {
 	t.Helper()
@@ -1223,6 +1252,91 @@ func TestDeleteStaleServerRegistrations(t *testing.T) {
 		assert.Equal(t, int(2), regsDeleted, "both registrations for the dual server should be counted")
 	})
 
+	t.Run("ReapsOrphanedPendingNamespaces", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		key, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+
+		// Stale, all-pending origin and the two namespaces it auto-registered for itself
+		// (same SiteName + key, no services link).
+		originReg := createPendingServerReg(t, "/origins/apple.edu", "apple.edu", key)
+		juice := createPendingNamespaceReg(t, "/apple/juice", "apple.edu", key)
+		cider := createPendingNamespaceReg(t, "/apple/cider", "apple.edu", key)
+
+		// Control: an unrelated namespace under a different site name must survive.
+		otherKey, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+		banana := createPendingNamespaceReg(t, "/banana/bread", "banana.edu", otherKey)
+
+		srv, err := getServerByRegistrationID(originReg.ID)
+		require.NoError(t, err)
+		setServerLastSeenDirect(t, srv.ID, time.Now().UTC().Add(-2*time.Hour))
+
+		regsDeleted, serversDeleted, err := deleteStaleServerRegistrations(time.Now().UTC().Add(-1 * time.Hour))
+		require.NoError(t, err)
+		// Only the server's own registration is counted; reaped namespaces are not.
+		assert.Equal(t, int(1), regsDeleted, "reaped namespaces must not be counted as regsDeleted")
+		assert.Equal(t, int(1), serversDeleted)
+
+		assert.False(t, registrationExists(t, juice.ID), "orphaned pending namespace /apple/juice should be reaped")
+		assert.False(t, registrationExists(t, cider.ID), "orphaned pending namespace /apple/cider should be reaped")
+		assert.True(t, registrationExists(t, banana.ID), "namespace of a different site must be preserved")
+	})
+
+	t.Run("PreservesApprovedNamespaceOnReap", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		key, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+
+		originReg := createPendingServerReg(t, "/origins/apple.edu", "apple.edu", key)
+
+		// Same SiteName + key, but the namespace was independently approved: it must survive even
+		// though its origin is reaped.
+		approvedNs := server_structs.Registration{
+			Prefix: "/apple/juice",
+			Pubkey: key,
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName:    "apple.edu",
+				Institution: "Test University",
+				Status:      server_structs.RegApproved,
+			},
+		}
+		require.NoError(t, AddRegistration(&approvedNs))
+
+		srv, err := getServerByRegistrationID(originReg.ID)
+		require.NoError(t, err)
+		setServerLastSeenDirect(t, srv.ID, time.Now().UTC().Add(-2*time.Hour))
+
+		_, serversDeleted, err := deleteStaleServerRegistrations(time.Now().UTC().Add(-1 * time.Hour))
+		require.NoError(t, err)
+		assert.Equal(t, int(1), serversDeleted)
+		assert.True(t, registrationExists(t, approvedNs.ID), "approved namespace must not be reaped")
+	})
+
+	t.Run("PreservesNamespaceWithDifferentKey", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		originKey, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+		nsKey, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+
+		originReg := createPendingServerReg(t, "/origins/apple.edu", "apple.edu", originKey)
+		// Same SiteName but a different key — not owned by this origin, must survive.
+		ns := createPendingNamespaceReg(t, "/apple/juice", "apple.edu", nsKey)
+
+		srv, err := getServerByRegistrationID(originReg.ID)
+		require.NoError(t, err)
+		setServerLastSeenDirect(t, srv.ID, time.Now().UTC().Add(-2*time.Hour))
+
+		_, serversDeleted, err := deleteStaleServerRegistrations(time.Now().UTC().Add(-1 * time.Hour))
+		require.NoError(t, err)
+		assert.Equal(t, int(1), serversDeleted)
+		assert.True(t, registrationExists(t, ns.ID), "namespace registered under a different key must not be reaped")
+	})
+
 	t.Run("SkipsCleanupWhenApprovalNotRequired", func(t *testing.T) {
 		defer resetMockRegistryDB(t)
 
@@ -1248,6 +1362,43 @@ func TestDeleteStaleServerRegistrations(t *testing.T) {
 		err = database.ServerDatabase.Model(&server_structs.Server{}).Where("id = ?", srv.ID).Count(&count).Error
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), count, "stale pending server must survive when approval is off")
+	})
+}
+
+func TestReapOrphanedPendingNamespaces(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	setupMockRegistryDB(t)
+	t.Cleanup(func() { teardownMockRegistryDB(t) })
+
+	parseKeys := func(t *testing.T, jwks string) jwk.Set {
+		t.Helper()
+		set, err := jwk.ParseString(jwks)
+		require.NoError(t, err)
+		return set
+	}
+
+	t.Run("SkipsEmptySiteNameIdentity", func(t *testing.T) {
+		defer resetMockRegistryDB(t)
+
+		key, err := test_utils.GenerateJWKS()
+		require.NoError(t, err)
+
+		// A pending namespace with an empty SiteName, inserted directly because AddRegistration
+		// rejects an empty SiteName. An identity with an empty SiteName must never match it,
+		// otherwise one stale server with a blank name would sweep up unrelated rows.
+		ns := server_structs.Registration{
+			Prefix: "/apple/juice",
+			Pubkey: key,
+			AdminMetadata: server_structs.AdminMetadata{
+				Institution: "Test University",
+				Status:      server_structs.RegPending,
+			},
+		}
+		require.NoError(t, database.ServerDatabase.Create(&ns).Error)
+
+		err = reapOrphanedPendingNamespaces([]serverIdentity{{siteName: "", keys: parseKeys(t, key)}})
+		require.NoError(t, err)
+		assert.True(t, registrationExists(t, ns.ID), "namespace must survive an empty-SiteName identity")
 	})
 }
 

--- a/registry/registry_db_test.go
+++ b/registry/registry_db_test.go
@@ -57,6 +57,15 @@ func setupMockRegistryDB(t *testing.T) {
 	database.ServerDatabase = mockDB
 	require.NoError(t, err, "Error setting up mock namespace DB")
 
+	// A ":memory:" SQLite database is private to the connection that created it. Tests
+	// like the inactive registration cleanup run a goroutine that queries the DB
+	// concurrently with the main test, so if the pool opens a second connection it lands
+	// on a fresh, table-less database and queries fail intermittently with "no such
+	// table". Pin the pool to a single connection so every caller shares one DB.
+	sqlDB, err := mockDB.DB()
+	require.NoError(t, err, "Error getting underlying sql.DB from mock registry DB")
+	sqlDB.SetMaxOpenConns(1)
+
 	// Enable foreign key constraints for SQLite
 	err = database.ServerDatabase.Exec("PRAGMA foreign_keys = ON").Error
 	require.NoError(t, err, "Error enabling foreign key constraints")

--- a/server_structs/registry.go
+++ b/server_structs/registry.go
@@ -149,6 +149,9 @@ type Server struct {
 	Note      string    `json:"note"`
 	CreatedAt time.Time `json:"created_at" post:"exclude" gorm:"default:CURRENT_TIMESTAMP"`
 	UpdatedAt time.Time `json:"updated_at" post:"exclude" gorm:"default:CURRENT_TIMESTAMP"`
+	// LastSeen is updated when a server polls its metadata via GET .../registry/server/<prefix>
+	// (i.e. each advertisement cycle). Used by the inactive registration cleanup job.
+	LastSeen time.Time `json:"last_seen" post:"exclude" gorm:"column:last_seen"`
 }
 
 // Service maps a server to its registration

--- a/server_structs/registry.go
+++ b/server_structs/registry.go
@@ -219,6 +219,7 @@ type ServerRegistration struct {
 	Note      string    `json:"note"`
 	CreatedAt time.Time `json:"-" post:"exclude"`
 	UpdatedAt time.Time `json:"-" post:"exclude"`
+	LastSeen  time.Time `json:"-" post:"exclude"`
 
 	// Registration list
 	Registration []Registration `json:"registration"`


### PR DESCRIPTION
This PR implements a timeout-based cleanup based on observed Origin/Cache server activity.

### How it works

A new goroutine (LaunchInactiveRegistrationCleanup) runs every `Registry.InactiveRegistrationCleanupInterval` (default 5m). It finds servers whose `last_seen` is older than `Registry.InactiveRegistrationTimeout` (default 20m), deletes their linked Pending server registration, then removes the server rows. 

`last_seen` gets updated in the `servers` table in Registry database every time when the Origin/Cache server polls metadata from Registry.

### Backward compatibility

Existing DB rows on upgrade: Migration backfills last_seen from updated_at/created_at; active servers refresh within minutes. NULL rows are excluded from WHERE last_seen < ? (SQL three-valued logic), so they are never spuriously deleted.
Old origin/cache + new registry: Poll metadata from Registry on a regular basis → last_seen refreshes normally. No client changes needed.
New origin + old registry: Heartbeat calls succeed harmlessly; no cleanup goroutine exists on old registry.