### PR TITLE
Do not use an external container image layer cache (7.21)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -172,7 +172,6 @@ jobs:
           platforms: ${{ needs.set-build-parameters.outputs.platforms }}
           target: origin
           cache-from: |
-            type=registry,ref=hub.opensciencegrid.org/pelican_platform/pelican-dev:buildcache
             type=local,src=/tmp/.base-buildx-cache
           cache-to: type=local,dest=/tmp/.base-buildx-cache,mode=max
 
@@ -264,7 +263,6 @@ jobs:
           push: ${{ needs.set-build-parameters.outputs.push-server == 'true' }}
           tags: "${{ steps.generate-tag-list.outputs.taglist }}"
           cache-from: |
-            type=registry,ref=hub.opensciencegrid.org/pelican_platform/pelican-dev:buildcache
             type=local,src=/tmp/.base-buildx-cache
 
   build-devtest-images:
@@ -340,7 +338,6 @@ jobs:
           push: ${{ needs.set-build-parameters.outputs.push-dev == 'true' }}
           tags: ${{ steps.pelican-test-tags.outputs.tags }}
           cache-from: |
-            type=registry,ref=hub.opensciencegrid.org/pelican_platform/pelican-dev:buildcache
             type=local,src=/tmp/.base-buildx-cache
 
       - name: Build and push Docker images (pelican-dev)
@@ -353,9 +350,7 @@ jobs:
           push: ${{ needs.set-build-parameters.outputs.push-dev == 'true' }}
           tags: ${{ steps.pelican-dev-tags.outputs.tags }}
           cache-from: |
-            type=registry,ref=hub.opensciencegrid.org/pelican_platform/pelican-dev:buildcache
             type=local,src=/tmp/.base-buildx-cache
-          cache-to: type=registry,ref=hub.opensciencegrid.org/pelican_platform/pelican-dev:buildcache,mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true
 
   # The macOS and Windows tests do not depend on any of the images being
   # built above. Thus, there is a separate workflow for running the tests:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,17 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - name: Set Go version
+        # Determine the string to use in setup-go's "go-version" input.
+        id: go-version
+        run: |
+          version=$(grep -E '^go[[:space:]]*[0-9]+\.[0-9]+' go.mod | grep -oE '[0-9]+\.[0-9]+')
+          echo "version=${version}.x" >> $GITHUB_OUTPUT
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "${{ steps.go-version.outputs.version }}"
+          check-latest: true
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
We want the build stages to pick up the most recent version of the Go toolchain. The release workflow also needs to be updated to do the same.