### PR TITLE
Minor security fixups

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2417,13 +2417,27 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 			// Determine write destination - use temporary file unless inPlace is true
 			// Special case: os.DevNull should always use inPlace mode (no temp files)
 			writeDestination = localPath
-			if !transfer.job.inPlace && localPath != os.DevNull {
-				// Use rsync-style temporary naming: .filename.XXXXXX (random suffix)
-				writeDestination = generateTempPath(localPath)
+			if !transfer.job.inPlace && localPath != os.DevNull && localPath != "" {
+				// Use os.CreateTemp for secure atomic temp file creation in the
+				// destination directory, using an rsync-style .basename.* pattern.
+				dir := filepath.Dir(localPath)
+				base := filepath.Base(localPath)
+				fp, err = os.CreateTemp(dir, "."+base+".")
+				if err == nil {
+					writeDestination = fp.Name()
+					fileWriter = fp
+				} else {
+					return
+				}
 			}
 			// Ensure temporary file is cleaned up if we exit early (errors, panics, etc.)
+			// Also handles closing the file; on Windows, open files cannot be removed.
 			if !transfer.job.inPlace && writeDestination != localPath {
 				defer func() {
+					if fp != nil {
+						fp.Close()
+						fp = nil
+					}
 					// Only clean up if the temporary file still exists and wasn't renamed
 					if _, statErr := os.Stat(writeDestination); statErr == nil {
 						if removeErr := os.Remove(writeDestination); removeErr != nil {
@@ -2431,18 +2445,22 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 						}
 					}
 				}()
-			}
-			// If the destination is something strange, like a block device, then the OpenFile below
-			// will create the appropriate error message
-			if fp, err = os.OpenFile(writeDestination, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644); err == nil {
-				fileWriter = fp
+			} else {
 				defer func() {
 					if fp != nil {
 						fp.Close()
+						fp = nil
 					}
 				}()
-			} else {
-				return
+			}
+			if fp == nil {
+				// If the destination is something strange, like a block device, then the OpenFile below
+				// will create the appropriate error message
+				if fp, err = os.OpenFile(writeDestination, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644); err == nil {
+					fileWriter = fp
+				} else {
+					return
+				}
 			}
 		}
 	} else { // Prestage case

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -3487,6 +3487,7 @@ func TestPermissionDeniedError(t *testing.T) {
 	transfer := &transferFile{
 		ctx:       context.Background(),
 		job:       tj,
+		localPath: os.DevNull,
 		remoteURL: svrURL,
 		token:     tj.token,
 		attempts: []transferAttemptDetails{
@@ -3502,7 +3503,6 @@ func TestPermissionDeniedError(t *testing.T) {
 			expiredTime.Unix(), expiredTime.Add(-time.Hour).Unix())
 		transfer.job.token.SetToken(expiredJWT)
 
-		time.Sleep(time.Second * 4) // Sleep for longer than the token lifetime
 		res, err := downloadObject(transfer)
 		require.NoError(t, err)
 		require.Error(t, res.Error)

--- a/client/inplace_test.go
+++ b/client/inplace_test.go
@@ -94,21 +94,22 @@ func TestInPlaceDefault(t *testing.T) {
 		}
 	}()
 
-	// Give download time to start
-	time.Sleep(50 * time.Millisecond)
-
-	// Check for temporary file (should exist during download)
-	files, err := os.ReadDir(tempDir)
-	require.NoError(t, err)
-
-	for _, file := range files {
-		if strings.HasPrefix(file.Name(), ".testfile.txt.") {
-			tempFileSeen = true
-			// Verify temp file has expected format: .basename.XXXXXX
-			assert.Regexp(t, `^\.testfile\.txt\.[a-zA-Z0-9]{6}$`, file.Name())
-			break
+	// Wait for temp file to appear (replaces fixed sleep for reliability)
+	require.Eventually(t, func() bool {
+		files, readErr := os.ReadDir(tempDir)
+		if readErr != nil {
+			return false
 		}
-	}
+		for _, file := range files {
+			if strings.HasPrefix(file.Name(), ".testfile.txt.") {
+				tempFileSeen = true
+				// Verify temp file has expected format from os.CreateTemp: .basename.NNNNNNNNN
+				assert.Regexp(t, `^\.testfile\.txt\.\d+$`, file.Name())
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond, "Temporary file should appear during download")
 
 	// Wait for download to complete
 	err = <-doneChan
@@ -123,7 +124,7 @@ func TestInPlaceDefault(t *testing.T) {
 	assert.Equal(t, testContent, string(content))
 
 	// Verify temp file was cleaned up
-	files, err = os.ReadDir(tempDir)
+	files, err := os.ReadDir(tempDir)
 	require.NoError(t, err)
 	for _, file := range files {
 		assert.False(t, strings.HasPrefix(file.Name(), ".testfile.txt."),
@@ -186,8 +187,11 @@ func TestInPlaceFlag(t *testing.T) {
 		}
 	}()
 
-	// Give download time to start
-	time.Sleep(50 * time.Millisecond)
+	// Wait for inPlace download to start writing the final file directly
+	require.Eventually(t, func() bool {
+		_, statErr := os.Stat(finalPath)
+		return statErr == nil
+	}, 5*time.Second, 10*time.Millisecond, "Final file should appear when inPlace=true")
 
 	// Check that NO temporary file exists
 	files, err := os.ReadDir(tempDir)

--- a/client/util.go
+++ b/client/util.go
@@ -20,8 +20,6 @@ package client
 
 import (
 	"fmt"
-	"math/rand"
-	"path/filepath"
 )
 
 // Convert b bytes to a human-friendly string with SI units
@@ -39,23 +37,4 @@ func ByteCountSI(b int64) string {
 	}
 	return fmt.Sprintf("%.1f %cB",
 		float64(b)/float64(div), "KMGTPE"[exp])
-}
-
-// generateTempPath creates a temporary filename for a transfer
-// Uses rsync-style naming: .basename.XXXXXX where X is a random alphanumeric character
-func generateTempPath(finalPath string) string {
-	dir := filepath.Dir(finalPath)
-	base := filepath.Base(finalPath)
-	suffix := generateRandomSuffix(6)
-	return filepath.Join(dir, fmt.Sprintf(".%s.%s", base, suffix))
-}
-
-// generateRandomSuffix creates a random alphanumeric string of the specified length
-func generateRandomSuffix(length int) string {
-	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-	b := make([]byte, length)
-	for i := range b {
-		b[i] = charset[rand.Intn(len(charset))]
-	}
-	return string(b)
 }

--- a/client/util_test.go
+++ b/client/util_test.go
@@ -19,144 +19,24 @@
 package client
 
 import (
-	"fmt"
-	"path/filepath"
-	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestGenerateRandomSuffix(t *testing.T) {
-	suffix := generateRandomSuffix(6)
-
-	// Test that it produces exactly 6 characters
-	assert.Equal(t, 6, len(suffix), "Suffix should be 6 characters long")
-
-	// Test that it only contains alphanumeric characters
-	alphanumericPattern := regexp.MustCompile(`^[a-zA-Z0-9]+$`)
-	assert.True(t, alphanumericPattern.MatchString(suffix), "Suffix should only contain alphanumeric characters")
-}
-
-func TestGenerateRandomSuffixOnlyAlphanumeric(t *testing.T) {
-	// Generate multiple suffixes to ensure consistency
-	for i := 0; i < 100; i++ {
-		suffix := generateRandomSuffix(6)
-		for _, char := range suffix {
-			assert.True(t,
-				(char >= 'a' && char <= 'z') ||
-					(char >= 'A' && char <= 'Z') ||
-					(char >= '0' && char <= '9'),
-				"Character '%c' should be alphanumeric", char)
-		}
-	}
-}
-
-func TestGenerateRandomSuffixDifferentLengths(t *testing.T) {
-	testCases := []int{1, 6, 10, 20}
-
-	for _, length := range testCases {
-		suffix := generateRandomSuffix(length)
-		assert.Equal(t, length, len(suffix), "Suffix should be %d characters long", length)
-	}
-}
-
-func TestGenerateTempPath(t *testing.T) {
+func TestByteCountSI(t *testing.T) {
 	tests := []struct {
-		name           string
-		input          string
-		expectedDir    string
-		expectedPrefix string
+		input    int64
+		expected string
 	}{
-		{
-			name:           "simple filename",
-			input:          "/tmp/testfile.txt",
-			expectedDir:    "/tmp",
-			expectedPrefix: ".testfile.txt.",
-		},
-		{
-			name:           "filename without extension",
-			input:          "/var/data/myfile",
-			expectedDir:    "/var/data",
-			expectedPrefix: ".myfile.",
-		},
-		{
-			name:           "filename with multiple dots",
-			input:          "/home/user/archive.tar.gz",
-			expectedDir:    "/home/user",
-			expectedPrefix: ".archive.tar.gz.",
-		},
-		{
-			name:           "current directory",
-			input:          "localfile.dat",
-			expectedDir:    ".",
-			expectedPrefix: ".localfile.dat.",
-		},
-		{
-			name:           "nested directories",
-			input:          "/very/deep/nested/path/file.bin",
-			expectedDir:    "/very/deep/nested/path",
-			expectedPrefix: ".file.bin.",
-		},
+		{0, "0 B"},
+		{500, "500 B"},
+		{1000, "1.0 KB"},
+		{2000, "2.0 KB"},
+		{1000000, "1.0 MB"},
+		{1500000000, "1.5 GB"},
 	}
-
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Convert paths to platform-specific format (handles Windows)
-			input := filepath.FromSlash(tt.input)
-			expectedDir := filepath.FromSlash(tt.expectedDir)
-
-			tempPath := generateTempPath(input)
-
-			// Verify the directory part is correct
-			dir := filepath.Dir(tempPath)
-			assert.Equal(t, expectedDir, dir, "Directory should match")
-
-			// Verify the base name follows rsync pattern: .filename.XXXXXX
-			base := filepath.Base(tempPath)
-			assert.True(t, strings.HasPrefix(base, tt.expectedPrefix),
-				"Base name should start with '%s', got '%s'", tt.expectedPrefix, base)
-
-			// Verify the suffix is 6 characters
-			parts := strings.Split(base, ".")
-			require.GreaterOrEqual(t, len(parts), 2, "Should have at least 2 parts after splitting by '.'")
-			suffix := parts[len(parts)-1]
-			assert.Equal(t, 6, len(suffix), "Random suffix should be 6 characters")
-
-			// Verify suffix is alphanumeric
-			alphanumericPattern := regexp.MustCompile(`^[a-zA-Z0-9]+$`)
-			assert.True(t, alphanumericPattern.MatchString(suffix),
-				"Suffix should only contain alphanumeric characters")
-		})
+		assert.Equal(t, tt.expected, ByteCountSI(tt.input))
 	}
-}
-
-func TestGenerateTempPathUniqueness(t *testing.T) {
-	// Generate multiple temp paths for the same file and verify they're unique
-	input := "/tmp/testfile.txt"
-	seen := make(map[string]bool)
-
-	for i := 0; i < 100; i++ {
-		tempPath := generateTempPath(input)
-		assert.False(t, seen[tempPath], "Generated path should be unique")
-		seen[tempPath] = true
-	}
-}
-
-func TestGenerateTempPathFormat(t *testing.T) {
-	input := filepath.FromSlash("/data/myfile.dat")
-	tempPath := generateTempPath(input)
-
-	// Expected format: {separator}data{separator}.myfile.dat.XXXXXX
-	// Where XXXXXX is 6 alphanumeric characters
-	// Use filepath to construct platform-specific pattern
-	expectedDir := filepath.FromSlash("/data")
-	expectedBase := `.myfile\.dat\.[a-zA-Z0-9]{6}`
-	// Escape the separator for regex (Windows uses \ which needs to be escaped)
-	sep := regexp.QuoteMeta(string(filepath.Separator))
-	pattern := regexp.MustCompile(fmt.Sprintf(`^%s%s%s$`, regexp.QuoteMeta(expectedDir), sep, expectedBase))
-	assert.True(t, pattern.MatchString(tempPath),
-		"Temp path should match rsync pattern, got: %s", tempPath)
 }

--- a/director/maxmind.go
+++ b/director/maxmind.go
@@ -117,9 +117,18 @@ func downloadDB(localFile string) error {
 		if baseName != "GeoLite2-City.mmdb" {
 			continue
 		}
-		if _, err = io.Copy(fileHandle, tr); err != nil {
+		// Limit extraction to 512 MB to prevent a malicious or corrupted
+		// archive from exhausting disk space.
+		const maxDBSize = 512 * 1024 * 1024
+		limitedReader := io.LimitReader(tr, maxDBSize+1)
+		n, err := io.Copy(fileHandle, limitedReader)
+		if err != nil {
 			os.Remove(fileHandle.Name())
 			return err
+		}
+		if n > maxDBSize {
+			os.Remove(fileHandle.Name())
+			return errors.New("GeoIP database file exceeds maximum allowed size (512 MB)")
 		}
 		foundDB = true
 		break

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -3018,6 +3018,18 @@ type: int
 default: 8444
 components: ["cache", "director", "origin", "registry"]
 ---
+name: Server.TrustedProxies
+description: |+
+  A list of CIDR ranges or IP addresses of trusted reverse proxies.
+  When set, the Gin web engine will use X-Forwarded-For headers only from these trusted sources to determine the client IP.
+  When empty (the default), no proxies are trusted and the client IP is always taken from the network connection's remote address.
+  Use "*" to trust all sources (equivalent to 0.0.0.0/0 and ::/0).
+  Both IPv4 and IPv6 addresses and CIDR ranges are supported.
+  Example: ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "fd00::/8"]
+type: stringSlice
+default: []
+components: ["cache", "director", "origin", "registry"]
+---
 name: Server.WebHost
 description: |+
   A string-encoded IP address that the Pelican web engine is configured to listen on.

--- a/origin_serve/handlers.go
+++ b/origin_serve/handlers.go
@@ -191,17 +191,23 @@ func extractTokens(r *http.Request) []string {
 
 // getActionFromMethod determines the token scope action from HTTP method.
 //
-// Scope hierarchy (least to most privileged):
+// Scopes by mutation effect:
 //   - read:   no mutation (GET, HEAD, OPTIONS, PROPFIND)
-//   - create: mutation without data loss (PUT, POST, MKCOL, LOCK, UNLOCK, PROPPATCH)
-//   - modify: mutation that may cause data loss (DELETE, COPY, MOVE, and any unknown method)
+//   - create: mutation without data loss -- adds new state but does not
+//     destroy existing data (PUT, POST, MKCOL, LOCK, UNLOCK, PROPPATCH,
+//     and COPY: COPY only adds a resource at the destination; RFC 4918's
+//     Overwrite header would make it destructive but Pelican does not
+//     currently honor it, so today's COPY is purely additive. Promote
+//     to modify if we ever wire up overwrite-aware COPY.)
+//   - modify: mutation that may cause data loss (DELETE, MOVE, and any
+//     unknown method)
 func getActionFromMethod(method string) token_scopes.TokenScope {
 	switch method {
 	case http.MethodGet, http.MethodHead, http.MethodOptions, "PROPFIND":
 		return token_scopes.Wlcg_Storage_Read
-	case http.MethodPut, http.MethodPost, "MKCOL", "LOCK", "UNLOCK", "PROPPATCH":
+	case http.MethodPut, http.MethodPost, "MKCOL", "LOCK", "UNLOCK", "PROPPATCH", "COPY":
 		return token_scopes.Wlcg_Storage_Create
-	case http.MethodDelete, "COPY", "MOVE":
+	case http.MethodDelete, "MOVE":
 		return token_scopes.Wlcg_Storage_Modify
 	default:
 		// Unknown methods default to the most restrictive scope

--- a/origin_serve/handlers.go
+++ b/origin_serve/handlers.go
@@ -274,14 +274,15 @@ func authMiddleware() gin.HandlerFunc {
 		for _, tok := range tokens {
 			ctx, authorized := ac.authorizeWithContext(c.Request.Context(), action, resource, tok)
 			if authorized {
+				if authorizedContext == nil {
+					authorizedContext = ctx
+				}
 				// Check if this token is from the federation issuer (for DisableDirectClients tracking)
 				if disableDirectClients && fedDiscoveryURL != "" {
 					issuer, ok := ctx.Value(issuerContextKey{}).(string)
 					if ok && issuer == fedDiscoveryURL {
 						federationCtx = ctx
 					}
-				} else {
-					authorizedContext = ctx
 				}
 				if authorizedContext != nil && (!disableDirectClients || federationCtx != nil) {
 					break // No need to check more tokens

--- a/origin_serve/handlers.go
+++ b/origin_serve/handlers.go
@@ -189,19 +189,23 @@ func extractTokens(r *http.Request) []string {
 	return tokens
 }
 
-// getActionFromMethod determines the token scope action from HTTP method
+// getActionFromMethod determines the token scope action from HTTP method.
+//
+// Scope hierarchy (least to most privileged):
+//   - read:   no mutation (GET, HEAD, OPTIONS, PROPFIND)
+//   - create: mutation without data loss (PUT, POST, MKCOL, LOCK, UNLOCK, PROPPATCH)
+//   - modify: mutation that may cause data loss (DELETE, COPY, MOVE, and any unknown method)
 func getActionFromMethod(method string) token_scopes.TokenScope {
 	switch method {
-	case http.MethodGet, http.MethodHead:
+	case http.MethodGet, http.MethodHead, http.MethodOptions, "PROPFIND":
 		return token_scopes.Wlcg_Storage_Read
-	case http.MethodPut, http.MethodPost:
+	case http.MethodPut, http.MethodPost, "MKCOL", "LOCK", "UNLOCK", "PROPPATCH":
 		return token_scopes.Wlcg_Storage_Create
-	case http.MethodDelete:
+	case http.MethodDelete, "COPY", "MOVE":
 		return token_scopes.Wlcg_Storage_Modify
-	case "PROPFIND":
-		return token_scopes.Wlcg_Storage_Read
 	default:
-		return token_scopes.Wlcg_Storage_Read
+		// Unknown methods default to the most restrictive scope
+		return token_scopes.Wlcg_Storage_Modify
 	}
 }
 

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -426,6 +426,7 @@ var runtimeConfigurableMap = map[string]bool{
 	"Server.TLSCertificate": false,
 	"Server.TLSCertificateChain": false,
 	"Server.TLSKey": false,
+	"Server.TrustedProxies": false,
 	"Server.UIActivationCodeFile": false,
 	"Server.UIAdminUsers": false,
 	"Server.UILoginRateLimit": false,
@@ -755,6 +756,7 @@ var stringSliceAccessors = map[string]func(*Config) []string{
 	"Server.AdminGroups": func(c *Config) []string { return c.Server.AdminGroups },
 	"Server.DirectorUrls": func(c *Config) []string { return c.Server.DirectorUrls },
 	"Server.Modules": func(c *Config) []string { return c.Server.Modules },
+	"Server.TrustedProxies": func(c *Config) []string { return c.Server.TrustedProxies },
 	"Server.UIAdminUsers": func(c *Config) []string { return c.Server.UIAdminUsers },
 	"Shoveler.OutputDestinations": func(c *Config) []string { return c.Shoveler.OutputDestinations },
 }
@@ -1490,6 +1492,7 @@ var allParameterNames = []string{
 	"Server.TLSCertificate",
 	"Server.TLSCertificateChain",
 	"Server.TLSKey",
+	"Server.TrustedProxies",
 	"Server.UIActivationCodeFile",
 	"Server.UIAdminUsers",
 	"Server.UILoginRateLimit",
@@ -1764,6 +1767,7 @@ var (
 	Server_AdminGroups = StringSliceParam{"Server.AdminGroups"}
 	Server_DirectorUrls = StringSliceParam{"Server.DirectorUrls"}
 	Server_Modules = StringSliceParam{"Server.Modules"}
+	Server_TrustedProxies = StringSliceParam{"Server.TrustedProxies"}
 	Server_UIAdminUsers = StringSliceParam{"Server.UIAdminUsers"}
 	Shoveler_OutputDestinations = StringSliceParam{"Shoveler.OutputDestinations"}
 )
@@ -2194,6 +2198,7 @@ func init() {
 		"Server.AdminGroups": Server_AdminGroups,
 		"Server.DirectorUrls": Server_DirectorUrls,
 		"Server.Modules": Server_Modules,
+		"Server.TrustedProxies": Server_TrustedProxies,
 		"Server.UIAdminUsers": Server_UIAdminUsers,
 		"Shoveler.OutputDestinations": Shoveler_OutputDestinations,
 		"Cache.BlocksToPrefetch": Cache_BlocksToPrefetch,

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -397,6 +397,7 @@ type Config struct {
 		TLSCertificate string `mapstructure:"tlscertificate" yaml:"TLSCertificate"`
 		TLSCertificateChain string `mapstructure:"tlscertificatechain" yaml:"TLSCertificateChain"`
 		TLSKey string `mapstructure:"tlskey" yaml:"TLSKey"`
+		TrustedProxies []string `mapstructure:"trustedproxies" yaml:"TrustedProxies"`
 		UIActivationCodeFile string `mapstructure:"uiactivationcodefile" yaml:"UIActivationCodeFile"`
 		UIAdminUsers []string `mapstructure:"uiadminusers" yaml:"UIAdminUsers"`
 		UILoginRateLimit int `mapstructure:"uiloginratelimit" yaml:"UILoginRateLimit"`
@@ -851,6 +852,7 @@ type configWithType struct {
 		TLSCertificate struct { Type string; Value string }
 		TLSCertificateChain struct { Type string; Value string }
 		TLSKey struct { Type string; Value string }
+		TrustedProxies struct { Type string; Value []string }
 		UIActivationCodeFile struct { Type string; Value string }
 		UIAdminUsers struct { Type string; Value []string }
 		UILoginRateLimit struct { Type string; Value int }

--- a/registry/registry_db.go
+++ b/registry/registry_db.go
@@ -480,6 +480,7 @@ func getAllowedPrefixesForCaches() (map[string][]string, error) {
 // The rest of the AdminMetadata fields is matched by `==`
 func getRegistrationsByFilter(filterNs server_structs.Registration, pType prefixType, legacy bool) ([]server_structs.Registration, error) {
 	query := `SELECT id, prefix, pubkey, identity, admin_metadata FROM registrations WHERE 1=1 `
+	queryArgs := []interface{}{}
 	if pType == prefixForCache {
 		// Refer to the cache prefix name in cmd/cache_serve
 		query += ` AND prefix LIKE '/caches/%'`
@@ -504,7 +505,8 @@ func getRegistrationsByFilter(filterNs server_structs.Registration, pType prefix
 		return nil, errors.New("Unsupported operation: Can't filter against Pubkey field.")
 	}
 	if filterNs.Prefix != "" {
-		query += fmt.Sprintf(" AND prefix like '%%%s%%' ", filterNs.Prefix)
+		query += " AND prefix like ? "
+		queryArgs = append(queryArgs, "%"+filterNs.Prefix+"%")
 	}
 	if !filterNs.AdminMetadata.ApprovedAt.Equal(time.Time{}) || !filterNs.AdminMetadata.UpdatedAt.Equal(time.Time{}) || !filterNs.AdminMetadata.CreatedAt.Equal(time.Time{}) {
 		return nil, errors.New("Unsupported operation: Can't filter against date.")
@@ -513,7 +515,7 @@ func getRegistrationsByFilter(filterNs server_structs.Registration, pType prefix
 	query += " ORDER BY id ASC"
 
 	registrationsIn := []server_structs.Registration{}
-	if err := database.ServerDatabase.Raw(query).Scan(&registrationsIn).Error; err != nil {
+	if err := database.ServerDatabase.Raw(query, queryArgs...).Scan(&registrationsIn).Error; err != nil {
 		return nil, err
 	}
 

--- a/web_ui/oauth2_client.go
+++ b/web_ui/oauth2_client.go
@@ -628,7 +628,7 @@ func handleOAuthCallback(ctx *gin.Context) {
 	}
 
 	redirectLocation := "/"
-	if nextURL != "" {
+	if nextURL != "" && isSafeRedirectURL(nextURL) {
 		redirectLocation = nextURL
 	}
 

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -20,11 +20,12 @@ package web_ui
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/tls"
 	"embed"
 	"fmt"
 	builtin_log "log"
-	"math/rand"
+	"math/big"
 	"mime"
 	"net"
 	"net/http"
@@ -69,6 +70,20 @@ var (
 )
 
 const notFoundFilePath = "frontend/out/404/index.html"
+
+// isSafeRedirectURL checks whether a redirect target is a relative
+// path (no scheme or host), preventing open-redirect attacks.
+func isSafeRedirectURL(rawURL string) bool {
+	if rawURL == "" {
+		return false
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	// Reject absolute URLs (scheme or host set) and protocol-relative URLs (//evil.com)
+	return parsed.Scheme == "" && parsed.Host == "" && !strings.HasPrefix(rawURL, "//")
+}
 
 type CreateApiTokenReq struct {
 	Name       string   `json:"name"`
@@ -301,7 +316,7 @@ func handleWebUIAuth(ctx *gin.Context) {
 	// Redirect authenticated users from login pages
 	if strings.HasPrefix(requestPath, "/login") && err == nil && user != "" {
 		returnUrl := ctx.Query("returnURL")
-		if returnUrl == "" {
+		if !isSafeRedirectURL(returnUrl) {
 			returnUrl = "/view/"
 		}
 		ctx.Redirect(http.StatusFound, returnUrl)
@@ -746,7 +761,12 @@ func waitUntilLogin(ctx context.Context) error {
 	}()
 	for {
 		previousCode.Store(currentCode.Load())
-		newCode := fmt.Sprintf("%06v", rand.Intn(1000000))
+		randVal, err := rand.Int(rand.Reader, big.NewInt(1000000))
+		if err != nil {
+			log.Errorf("Failed to generate secure activation code: %v", err)
+			continue
+		}
+		newCode := fmt.Sprintf("%06v", randVal.Int64())
 		currentCode.Store(&newCode)
 		newCodeWithNewline := fmt.Sprintf("%v\n", newCode)
 		if err := os.WriteFile(activationFile, []byte(newCodeWithNewline), 0600); err != nil {

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -849,6 +849,31 @@ func GetEngine() (*gin.Engine, error) {
 	gin.SetMode(gin.ReleaseMode)
 	engine := gin.New()
 	engine.Use(gin.Recovery())
+
+	// Configure trusted proxies for accurate client IP detection.
+	// By default, trust no proxies so ctx.ClientIP() returns the
+	// network-level remote address and cannot be spoofed via
+	// X-Forwarded-For headers.
+	trustedProxies := param.Server_TrustedProxies.GetStringSlice()
+	if len(trustedProxies) > 0 {
+		// Expand wildcard "*" to trust all IPv4 and IPv6 addresses.
+		expanded := make([]string, 0, len(trustedProxies))
+		for _, entry := range trustedProxies {
+			if entry == "*" {
+				expanded = append(expanded, "0.0.0.0/0", "::/0")
+			} else {
+				expanded = append(expanded, entry)
+			}
+		}
+		if err := engine.SetTrustedProxies(expanded); err != nil {
+			return nil, errors.Wrap(err, "failed to set trusted proxies")
+		}
+	} else {
+		if err := engine.SetTrustedProxies(nil); err != nil {
+			return nil, errors.Wrap(err, "failed to disable trusted proxies")
+		}
+	}
+
 	webLogger := log.WithFields(log.Fields{"daemon": "gin"})
 	engine.Use(func(ctx *gin.Context) {
 		startTime := time.Now()

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -73,16 +73,44 @@ const notFoundFilePath = "frontend/out/404/index.html"
 
 // isSafeRedirectURL checks whether a redirect target is a relative
 // path (no scheme or host), preventing open-redirect attacks.
+//
+// We reject anything that:
+//   - is empty
+//   - has any leading whitespace (some browsers strip control chars
+//     before parsing the URL, so " //evil.com" can become "//evil.com"
+//     and turn into a same-protocol cross-origin redirect)
+//   - has a scheme (https://, javascript:, data:)
+//   - has a host (parsed.Host != "")
+//   - is a protocol-relative URL ("//evil.com")
+//   - starts with a backslash, which some browsers treat as a path
+//     separator and combine with a following slash to land on a host
 func isSafeRedirectURL(rawURL string) bool {
 	if rawURL == "" {
+		return false
+	}
+	// Strip nothing -- but reject if there is anything to strip. A leading
+	// control character (space, tab, newline, etc.) is a strong signal
+	// that something is trying to bypass the parser.
+	if rawURL != strings.TrimLeft(rawURL, " \t\r\n\v\f") {
+		return false
+	}
+	// "//host/path" is a protocol-relative URL; some parsers/browsers
+	// resolve it against the current scheme, which lets an attacker
+	// redirect to a same-protocol foreign host.
+	if strings.HasPrefix(rawURL, "//") {
+		return false
+	}
+	// Backslashes can be normalized to slashes by some browsers and turn
+	// "/\evil.com" into "//evil.com".
+	if strings.HasPrefix(rawURL, `\`) || strings.HasPrefix(rawURL, `/\`) {
 		return false
 	}
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
 		return false
 	}
-	// Reject absolute URLs (scheme or host set) and protocol-relative URLs (//evil.com)
-	return parsed.Scheme == "" && parsed.Host == "" && !strings.HasPrefix(rawURL, "//")
+	// Reject absolute URLs (scheme or host set).
+	return parsed.Scheme == "" && parsed.Host == ""
 }
 
 type CreateApiTokenReq struct {

--- a/web_ui/ui_test.go
+++ b/web_ui/ui_test.go
@@ -1257,3 +1257,55 @@ func TestReadOnlyMiddleware(t *testing.T) {
 		assert.Equal(t, http.StatusOK, r.Result().StatusCode)
 	})
 }
+
+// TestIsSafeRedirectURL exercises the open-redirect guard used by the
+// OAuth login flow. Anything that could send a user to a third-party
+// host on success must be rejected; only same-origin relative paths
+// are allowed.
+func TestIsSafeRedirectURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		safe bool
+	}{
+		// Allowed: relative paths (same-origin).
+		{name: "absolute-path", url: "/view/dashboard", safe: true},
+		{name: "absolute-path-with-query", url: "/view/dashboard?next=foo", safe: true},
+		{name: "absolute-path-with-fragment", url: "/view/dashboard#section", safe: true},
+		{name: "absolute-path-root", url: "/", safe: true},
+		{name: "relative-path", url: "view/dashboard", safe: true},
+		{name: "relative-path-with-dotdot", url: "../etc/passwd", safe: true}, // weird but same-origin
+
+		// Rejected: anything that could redirect off-host.
+		{name: "empty", url: "", safe: false},
+		{name: "https-absolute", url: "https://evil.com/login", safe: false},
+		{name: "http-absolute", url: "http://evil.com/login", safe: false},
+		{name: "scheme-relative", url: "//evil.com/login", safe: false},
+		{name: "scheme-relative-with-tab", url: "//\tevil.com/login", safe: false},
+		{name: "javascript-uri", url: "javascript:alert(1)", safe: false},
+		{name: "data-uri", url: "data:text/html,<script>alert(1)</script>", safe: false},
+		{name: "ftp-absolute", url: "ftp://evil.com/", safe: false},
+
+		// Backslash variants -- some browsers treat \ as a path separator,
+		// so /\evil.com or \\evil.com can become //evil.com after the
+		// browser's own normalization.
+		{name: "leading-backslash", url: `\\evil.com/login`, safe: false},
+		{name: "slash-backslash", url: `/\evil.com/login`, safe: false},
+
+		// Whitespace / control chars: Go's url.Parse rejects these in the
+		// scheme position, so they would otherwise fall through to the
+		// safe-by-empty-host path. Belt-and-suspenders: also reject if the
+		// raw URL begins with whitespace, which would mask a leading "//".
+		{name: "leading-space", url: " //evil.com/login", safe: false},
+		{name: "leading-tab", url: "\t//evil.com/login", safe: false},
+		{name: "leading-newline", url: "\n//evil.com/login", safe: false},
+		{name: "leading-cr", url: "\r//evil.com/login", safe: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isSafeRedirectURL(tt.url)
+			assert.Equal(t, tt.safe, got, "url=%q", tt.url)
+		})
+	}
+}


### PR DESCRIPTION
Various and sundry low-priority issues identified by #3322.  I don't think any of these are currently exploitable or in production code (hence the public PR) but all seem worth fixing.

**IMPORTANT THING WORTH NOTING** for @brianhlin and @williamnswanson: this causes Gin to ignore proxy headers (`X-Forwarded-For` and friends) unless the configuration file explicitly denotes that this component is behind a proxy (otherwise it becomes relatively straightforward to bypassing the IP rate-limiter).  Hence, when put in place, you'll want to enable the corresponding configuration knob (`Server.TrustedProxies`) otherwise a director behind traefik would only recognize the traefik IP address as the source.  There's a `*` option that is equivalent to any IPv4/v6 address; probably sufficient for the sake of the setup on Tiger.

Fixes: #3322