### PR TITLE
Fix group issue in the validation for storage prefixes' permissions in posix origin

### DIFF
--- a/config/init_server_creds_unix.go
+++ b/config/init_server_creds_unix.go
@@ -21,9 +21,9 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"os/user"
+	"strconv"
 	"syscall"
 
 	"github.com/pkg/errors"
@@ -100,9 +100,9 @@ func UserInGroup(puser User, fileGid int) bool {
 		return false
 	}
 
-	fileGidStr := fmt.Sprintf("%d", fileGid)
 	for _, gidStr := range groupIds {
-		if gidStr == fileGidStr {
+		gid, err := strconv.Atoi(gidStr)
+		if err == nil && gid == fileGid {
 			return true
 		}
 	}

--- a/config/init_server_creds_unix.go
+++ b/config/init_server_creds_unix.go
@@ -60,7 +60,7 @@ func checkFileReadableByUser(filePath string, fileInfo os.FileInfo, puser User) 
 		if fileMode&0400 != 0 {
 			canRead = true
 		}
-	} else if fileMode&0040 != 0 && userInGroup(puser, fileGid) {
+	} else if fileMode&0040 != 0 && UserInGroup(puser, fileGid) {
 		// File has group read permission and the pelican user is in the file's group
 		// (either via primary GID or supplementary groups)
 		canRead = true
@@ -81,9 +81,9 @@ func checkFileReadableByUser(filePath string, fileInfo os.FileInfo, puser User) 
 	return nil
 }
 
-// userInGroup returns true if the user's primary GID matches fileGid, or if
+// UserInGroup returns true if the user's primary GID matches fileGid, or if
 // fileGid appears in the user's supplementary group list.
-func userInGroup(puser User, fileGid int) bool {
+func UserInGroup(puser User, fileGid int) bool {
 	if fileGid == puser.Gid {
 		return true
 	}

--- a/config/init_server_creds_windows.go
+++ b/config/init_server_creds_windows.go
@@ -26,6 +26,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// UserInGroup on Windows always returns false; Unix supplementary-group semantics
+// do not apply on Windows (which uses ACLs).
+func UserInGroup(_ User, _ int) bool {
+	return false
+}
+
 // checkFileReadableByUser on Windows logs a warning since Unix-style permission
 // checking doesn't apply. Windows uses ACLs which have a different permission model.
 // The Server.DropPrivileges feature is primarily designed for Unix systems.

--- a/server_utils/origin_posix.go
+++ b/server_utils/origin_posix.go
@@ -179,18 +179,13 @@ func (o *PosixOrigin) validateExtra(e *OriginExport, _ int) error {
 // on the given path to support the specified capabilities.
 func (o *PosixOrigin) validatePosixPermissions(storagePath string, caps server_structs.Capabilities, federationPrefix string) error {
 	// Get XRootD daemon user info
-	uid, err := config.GetDaemonUID()
+	daemonUser, err := config.GetDaemonUserInfo()
 	if err != nil {
-		return errors.Wrap(err, "failed to get XRootD daemon UID for permission validation")
+		return errors.Wrap(err, "failed to get XRootD daemon user info for permission validation")
 	}
-	gid, err := config.GetDaemonGID()
-	if err != nil {
-		return errors.Wrap(err, "failed to get XRootD daemon GID for permission validation")
-	}
-	username, err := config.GetDaemonUser()
-	if err != nil {
-		username = "username-unknown"
-	}
+	uid := daemonUser.Uid
+	gid := daemonUser.Gid
+	username := daemonUser.Username
 
 	// Check if the storage prefix exists
 	info, err := os.Stat(storagePath)
@@ -218,15 +213,18 @@ func (o *PosixOrigin) validatePosixPermissions(storagePath string, caps server_s
 	}
 	mode := info.Mode()
 
-	// Determine which permission bits apply to XRootD daemon user
+	// Determine which permission bits apply to XRootD daemon user.
+	// Check supplementary groups (not just the primary GID) so that a directory
+	// owned by a group the daemon user belongs to via a secondary membership is
+	// handled correctly — otherwise we'd incorrectly fall through to world bits.
 	var canRead, canWrite, canExecute bool
 	if uid == dirUID {
 		// User is owner - check owner bits
 		canRead = mode&0400 != 0
 		canWrite = mode&0200 != 0
 		canExecute = mode&0100 != 0
-	} else if gid == dirGID {
-		// User is in group - check group bits
+	} else if config.UserInGroup(daemonUser, dirGID) {
+		// User is in group (primary or supplementary) - check group bits
 		canRead = mode&0040 != 0
 		canWrite = mode&0020 != 0
 		canExecute = mode&0010 != 0

--- a/server_utils/origin_posix.go
+++ b/server_utils/origin_posix.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
@@ -168,8 +169,13 @@ func (o *PosixOrigin) validateExtra(e *OriginExport, _ int) error {
 	if err := o.validateAtomicUploadFilesystem(e); err != nil {
 		return err
 	}
-	if err := o.validatePosixPermissions(e.StoragePrefix, e.Capabilities, e.FederationPrefix); err != nil {
-		return err
+	if param.Origin_Multiuser.GetBool() {
+		log.Infof("Skipping directory permission validation for export %q because multiuser mode is enabled "+
+			"(files are accessed as the requesting user, not the XRootD daemon user)", e.FederationPrefix)
+	} else {
+		if err := o.validatePosixPermissions(e.StoragePrefix, e.Capabilities, e.FederationPrefix); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/server_utils/origin_test.go
+++ b/server_utils/origin_test.go
@@ -24,6 +24,8 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
+	"os/user"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -31,6 +33,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/test_utils"
@@ -929,6 +932,64 @@ func TestValidatePosixPermissions(t *testing.T) {
 		err = o.validatePosixPermissions(tmpDir, caps, "/test")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrInvalidOriginConfig)
+	})
+
+	// Regression test: directory owned by a group the daemon user belongs to via a
+	// supplementary membership (not the primary GID).  Before the fix, the check would
+	// fall through to world permission bits and incorrectly deny access.
+	t.Run("SupplementaryGroupAccess", func(t *testing.T) {
+		daemonUser, err := config.GetDaemonUserInfo()
+		require.NoError(t, err)
+
+		// Enumerate every group the daemon user belongs to.
+		u, err := user.Lookup(daemonUser.Username)
+		require.NoError(t, err)
+		groupIds, err := u.GroupIds()
+		require.NoError(t, err)
+
+		// Find a supplementary group — a GID that is in the list but is not the
+		// user's primary GID, so the primary-GID fast-path in the checker is bypassed.
+		primaryGIDStr := strconv.Itoa(daemonUser.Gid)
+		supplementaryGID := -1
+		for _, gidStr := range groupIds {
+			if gidStr == primaryGIDStr {
+				continue
+			}
+			gid, err := strconv.Atoi(gidStr)
+			if err == nil {
+				supplementaryGID = gid
+				break
+			}
+		}
+		if supplementaryGID == -1 {
+			t.Skip("daemon user has no supplementary groups; skipping supplementary group access test")
+		}
+
+		o := &PosixOrigin{}
+		tmpDir := t.TempDir()
+		// Directory owned by root:supplementaryGID with group-readable permissions but
+		// no world access (0750 = rwx r-x ---).
+		// The daemon user is not the owner, but IS in the group via supplementary membership.
+		require.NoError(t, os.Chown(tmpDir, 0, supplementaryGID))
+		require.NoError(t, os.Chmod(tmpDir, 0750))
+		defer func() { _ = os.Chmod(tmpDir, 0755) }()
+
+		// Reads should pass: before the fix this fell to world bits (none → error).
+		caps := server_structs.Capabilities{Reads: true}
+		err = o.validatePosixPermissions(tmpDir, caps, "/test")
+		assert.NoError(t, err, "reads should succeed via supplementary group membership")
+
+		// Listings should also pass for the same reason.
+		caps = server_structs.Capabilities{Listings: true}
+		err = o.validatePosixPermissions(tmpDir, caps, "/test")
+		assert.NoError(t, err, "listings should succeed via supplementary group membership")
+
+		// Writes should still fail: group bits have no write permission (0750).
+		caps = server_structs.Capabilities{Writes: true}
+		err = o.validatePosixPermissions(tmpDir, caps, "/test")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidOriginConfig)
+		assert.Contains(t, err.Error(), "Writes")
 	})
 
 	// Test error message contains useful information

--- a/server_utils/origin_test.go
+++ b/server_utils/origin_test.go
@@ -938,6 +938,12 @@ func TestValidatePosixPermissions(t *testing.T) {
 	// supplementary membership (not the primary GID).  Before the fix, the check would
 	// fall through to world permission bits and incorrectly deny access.
 	t.Run("SupplementaryGroupAccess", func(t *testing.T) {
+		// Chowning a file to a different UID requires root (or CAP_CHOWN on Linux);
+		// unprivileged CI runners will get EPERM.  Skip rather than fail there.
+		if os.Geteuid() != 0 {
+			t.Skip("requires root to chown the test directory to another user")
+		}
+
 		daemonUser, err := config.GetDaemonUserInfo()
 		require.NoError(t, err)
 


### PR DESCRIPTION
The old approach only matched if the daemon's primary GID equaled the directory's GID. If the directory was owned by another-group (GID 1234) and the xrootd user had xrootd-group as primary group (GID 1000) but also belonged to another-group as a supplementary group, the check fell through to world permissions.

The fix exports `config.userInGroup` as `config.UserInGroup`, and then use it to replaces the simple `gid == dirGID` comparison. It also adds a Windows stub (always returns false).