### PR TITLE
Issue 3095

### DIFF
--- a/client_agent/store/store.go
+++ b/client_agent/store/store.go
@@ -95,6 +95,10 @@ func (s *Store) runMigrations() error {
 // Close closes the database connection
 func (s *Store) Close() error {
 	if s.db != nil {
+		// Checkpoint and truncate the WAL before closing so that the -wal and -shm
+		// sidecar files are removed. Without this, os.RemoveAll (e.g. t.TempDir cleanup)
+		// fails because those files are still present on disk.
+		_, _ = s.db.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
 		return s.db.Close()
 	}
 	return nil

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -358,8 +358,21 @@ func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]
 	}
 
 	if ad.DisableDirectorTest {
-		log.Debugf("%s server %s at %s has DisableDirectorTest set. Skip health test for this server.", ad.Type, ad.Name, ad.URL.String())
-		return
+		log.Debugf("%s.DirectorTest is set to false for %s server %s at %s. Skipping health tests.", ad.Type, ad.Type, ad.Name, ad.URL.String())
+		// Clean up any stale health test utilities from a previous registration
+		// where tests may have been enabled. This ensures advertisementToServerResponse()
+		// correctly reports HealthStatusDisabled instead of using a stale status.
+		func() {
+			healthTestUtilsMutex.Lock()
+			defer healthTestUtilsMutex.Unlock()
+			if existingUtil, ok := healthTestUtils[ad.URL.String()]; ok {
+				if existingUtil.Cancel != nil {
+					existingUtil.Cancel()
+				}
+				delete(healthTestUtils, ad.URL.String())
+			}
+		}()
+		return sAd
 	}
 
 	// Prepare and launch the director file transfer tests to the origins/caches if it's not from the topology AND it's not already been registered

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -282,6 +282,55 @@ func TestRecordAd(t *testing.T) {
 		_, ok := healthTestUtils[mockUrl.String()]
 		assert.True(t, ok)
 	})
+
+	t.Run("disabled-director-test-cleans-up-stale-health-utils", func(t *testing.T) {
+		t.Cleanup(func() {
+			resetHealthTests()
+			shutdownStatUtils()
+			serverAds.DeleteAll()
+		})
+		resetHealthTests()
+		shutdownStatUtils()
+		serverAds.DeleteAll()
+
+		mockUrl := url.URL{Scheme: "https", Host: "origin-s3.example.com"}
+
+		// Simulate a pre-existing health test entry (as if tests were previously enabled)
+		healthTestUtilsMutex.Lock()
+		errgrp, errgrpCtx := errgroup.WithContext(context.Background())
+		_, cancel := context.WithCancel(errgrpCtx)
+		healthTestUtils[mockUrl.String()] = &healthTestUtil{
+			Cancel:        cancel,
+			ErrGrp:        errgrp,
+			ErrGrpContext: errgrpCtx,
+			Status:        HealthStatusError,
+		}
+		healthTestUtilsMutex.Unlock()
+
+		// Verify the stale entry exists
+		healthTestUtilsMutex.RLock()
+		_, ok := healthTestUtils[mockUrl.String()]
+		healthTestUtilsMutex.RUnlock()
+		require.True(t, ok, "stale healthTestUtil entry should exist before recordAd")
+
+		// Now register with DisableDirectorTest=true
+		serverAd := server_structs.ServerAd{
+			URL:                 mockUrl,
+			WebURL:              mockUrl,
+			FromTopology:        false,
+			DisableDirectorTest: true,
+			Type:                server_structs.OriginType.String(),
+		}
+		serverAd.Initialize("TEST_S3_ORIGIN")
+		emptyNS := []server_structs.NamespaceAdV2{}
+		recordAd(context.Background(), serverAd, &emptyNS)
+
+		// The stale health test entry should have been cleaned up
+		healthTestUtilsMutex.RLock()
+		_, ok = healthTestUtils[mockUrl.String()]
+		healthTestUtilsMutex.RUnlock()
+		assert.False(t, ok, "stale healthTestUtil entry should be removed when DisableDirectorTest is true")
+	})
 }
 
 func TestGetRawStatusWeight(t *testing.T) {

--- a/director/director_ui.go
+++ b/director/director_ui.go
@@ -245,7 +245,13 @@ func advertisementToServerResponse(ad *server_structs.Advertisement) serverRespo
 		healthStatus = healthUtil.Status
 	} else {
 		if ad.DisableDirectorTest {
-			healthStatus = HealthStatusDisabled
+			// If the federation requires director tests and this cache has disabled them,
+			// surface that as an error so the director UI flags it red.
+			if param.Director_RequireDirectorTests.GetBool() && ad.Type == server_structs.CacheType.String() {
+				healthStatus = HealthStatusError
+			} else {
+				healthStatus = HealthStatusDisabled
+			}
 		} else {
 			if !ad.FromTopology {
 				log.Debugf("advertisementToServerResponse: healthTestUtils not found for server at %s", ad.URL.String())

--- a/director/director_ui_test.go
+++ b/director/director_ui_test.go
@@ -27,9 +27,11 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jellydator/ttlcache/v3"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/test_utils"
 )
@@ -467,4 +469,104 @@ func TestGetNamespaces(t *testing.T) {
 			assert.Contains(t, got, ns, "Response data does not match expected")
 		}
 	})
+}
+
+func TestAdvertisementToServerResponse(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	t.Cleanup(func() {
+		resetHealthTests()
+	})
+
+	testCases := []struct {
+		name string
+		// setup is called before the test to configure viper; cleanup is handled via t.Cleanup
+		setup func(t *testing.T)
+		// If non-nil, seed a healthTestUtil entry keyed by the ad's URL before running
+		seedHealthUtil *healthTestUtil
+		ad             server_structs.ServerAd
+		expectedStatus HealthTestStatus
+	}{
+		{
+			name: "disabled-test-origin-returns-health-status-disabled",
+			ad: server_structs.ServerAd{
+				URL:                 url.URL{Host: "origin-s3.example.com", Scheme: "https"},
+				Type:                server_structs.OriginType.String(),
+				DisableDirectorTest: true,
+			},
+			expectedStatus: HealthStatusDisabled,
+		},
+		{
+			name: "enabled-test-server-returns-unknown-without-util",
+			ad: server_structs.ServerAd{
+				URL:                 url.URL{Host: "origin-normal.example.com", Scheme: "https"},
+				Type:                server_structs.OriginType.String(),
+				DisableDirectorTest: false,
+				FromTopology:        true, // suppress the debug log
+			},
+			expectedStatus: HealthStatusUnknown,
+		},
+		{
+			name: "server-with-ok-health-util",
+			seedHealthUtil: &healthTestUtil{
+				Status: HealthStatusOK,
+			},
+			ad: server_structs.ServerAd{
+				URL:  url.URL{Host: "cache-ok.example.com", Scheme: "https"},
+				Type: server_structs.CacheType.String(),
+			},
+			expectedStatus: HealthStatusOK,
+		},
+		{
+			name: "disabled-test-cache-shows-error-when-director-requires-tests",
+			setup: func(t *testing.T) {
+				config.ResetConfig()
+				t.Cleanup(config.ResetConfig)
+				viper.Set("Director.RequireDirectorTests", true)
+			},
+			ad: server_structs.ServerAd{
+				URL:                 url.URL{Host: "cache-no-test.example.com", Scheme: "https"},
+				Type:                server_structs.CacheType.String(),
+				DisableDirectorTest: true,
+			},
+			expectedStatus: HealthStatusError,
+		},
+		{
+			name: "disabled-test-origin-stays-disabled-when-director-requires-tests",
+			setup: func(t *testing.T) {
+				config.ResetConfig()
+				t.Cleanup(config.ResetConfig)
+				viper.Set("Director.RequireDirectorTests", true)
+			},
+			ad: server_structs.ServerAd{
+				URL:                 url.URL{Host: "origin-no-test.example.com", Scheme: "https"},
+				Type:                server_structs.OriginType.String(),
+				DisableDirectorTest: true,
+			},
+			expectedStatus: HealthStatusDisabled,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetHealthTests()
+
+			if tc.setup != nil {
+				tc.setup(t)
+			}
+
+			if tc.seedHealthUtil != nil {
+				healthTestUtilsMutex.Lock()
+				healthTestUtils[tc.ad.URL.String()] = tc.seedHealthUtil
+				healthTestUtilsMutex.Unlock()
+			}
+
+			tc.ad.Initialize("test-server")
+			ad := &server_structs.Advertisement{
+				ServerAd: tc.ad,
+			}
+
+			res := advertisementToServerResponse(ad)
+			assert.Equal(t, tc.expectedStatus, res.HealthStatus)
+		})
+	}
 }

--- a/director/sort.go
+++ b/director/sort.go
@@ -419,6 +419,13 @@ func cacheNotInErrorState() AdPredicate {
 	}
 }
 
+// If the federation requires director tests and the cache has disabled them, filter it out.
+func cacheDirectorTestEnabled() AdPredicate {
+	return func(ctx *gin.Context, ad copyAd) bool {
+		return !ad.ServerAd.DisableDirectorTest
+	}
+}
+
 // classifyAds is a generic helper to classify ads into groups in a single pass.
 // It first applies the common predicates (for example, topology, err state) to every ad.
 // Then, for each ad that passes the common check, it tests a list of group predicates.
@@ -499,6 +506,9 @@ func getSortedAds(ctx *gin.Context, requestId uuid.UUID) (sortedOrigins, sortedC
 	commonPredicates := []AdPredicate{cacheNotFromTopoIfPubReads()}
 	if param.Director_FilterCachesInErrorState.GetBool() {
 		commonPredicates = append(commonPredicates, cacheNotInErrorState())
+	}
+	if param.Director_RequireDirectorTests.GetBool() {
+		commonPredicates = append(commonPredicates, cacheDirectorTestEnabled())
 	}
 	supportedPredicates := []AdPredicate{cacheSupportsFeature(requiredFeatures)}
 	unknownPredicates := []AdPredicate{cacheMightSupportFeature(requiredFeatures)}

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -884,6 +884,39 @@ func TestCacheNotInErrorState(t *testing.T) {
 	}
 }
 
+func TestCacheDirectorTestEnabled(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	testCases := []struct {
+		name                string
+		disableDirectorTest bool
+		expected            bool
+	}{
+		{
+			name:                "Cache with director tests enabled is included",
+			disableDirectorTest: false,
+			expected:            true,
+		},
+		{
+			name:                "Cache with director tests disabled is excluded",
+			disableDirectorTest: true,
+			expected:            false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ad := copyAd{
+				ServerAd: server_structs.ServerAd{
+					DisableDirectorTest: tc.disableDirectorTest,
+				},
+			}
+
+			ctx := &gin.Context{}
+			assert.Equal(t, tc.expected, cacheDirectorTestEnabled()(ctx, ad))
+		})
+	}
+}
+
 func TestFilterCaches(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2479,6 +2479,17 @@ default: true
 hidden: true
 components: ["director"]
 ---
+name: Director.RequireDirectorTests
+description: |+
+  If true, the Director will filter out any caches that have disabled director health tests when deciding which caches
+  might fulfill a client request.
+  This allows federation operators to enforce that all caches in the federation participate in director health testing.
+  Caches that disable director tests will not receive any client traffic until they re-enable the tests.
+  Origins are not affected by this setting since disabling director tests is expected for non-POSIX backends (e.g., S3, Globus).
+type: bool
+default: false
+components: ["director"]
+---
 name: Director.AdaptiveSortEWMATimeConstant
 description: |+
   The time constant used for calculating alpha in the Director's EWMA smoothing of server status weights.

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -573,6 +573,9 @@ RUN --mount=type=bind,source=oa4mp/resources,target=/context \
   set -eux
   set -o pipefail
 
+  # Some XRootD multi-user setups require sssd-client.
+  dnf install -y sssd-client
+
   # OA4MP and Apache Tomcat both require a Java runtime.
   dnf install -y java-${JAVA_VER}-openjdk-headless
 
@@ -707,20 +710,7 @@ ENTRYPOINT ["/entrypoint.sh", "pelican-server", "origin"]
 CMD ["serve"]
 
 FROM origin AS osdf-origin
-ARG TARGETPLATFORM
-RUN --mount=type=cache,id=dnf-${TARGETPLATFORM},target=/var/cache/dnf,sharing=locked <<ENDRUN
-  set -eux
-  set -o pipefail
-
-  ln -s pelican-server /usr/local/sbin/osdf-server
-
-  # Some XRootD multi-user setups require sssd-client.
-  # The IDs here are chosen to match OSG's sssd sidecar containers.
-
-  groupadd -r -g 990 sssd
-  useradd -r -u 990 -g 990 -d / -s /sbin/nologin -c "System user for sssd" sssd
-  dnf install -y sssd-client
-ENDRUN
+RUN ln -s pelican-server /usr/local/sbin/osdf-server
 ENTRYPOINT ["/entrypoint.sh", "osdf-server", "origin"]
 CMD ["serve"]
 

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -189,6 +189,7 @@ var runtimeConfigurableMap = map[string]bool{
 	"Director.OriginCacheHealthTestInterval": false,
 	"Director.OriginResponseHostnames": false,
 	"Director.RegistryQueryInterval": false,
+	"Director.RequireDirectorTests": false,
 	"Director.StatConcurrencyLimit": false,
 	"Director.StatTimeout": false,
 	"Director.SupportContactEmail": false,
@@ -927,6 +928,7 @@ var boolAccessors = map[string]func(*Config) bool{
 	"Director.EnableOIDC": func(c *Config) bool { return c.Director.EnableOIDC },
 	"Director.EnableStat": func(c *Config) bool { return c.Director.EnableStat },
 	"Director.FilterCachesInErrorState": func(c *Config) bool { return c.Director.FilterCachesInErrorState },
+	"Director.RequireDirectorTests": func(c *Config) bool { return c.Director.RequireDirectorTests },
 	"DisableHttpProxy": func(c *Config) bool { return c.DisableHttpProxy },
 	"DisableProxyFallback": func(c *Config) bool { return c.DisableProxyFallback },
 	"Issuer.OIDCPreferClaimsFromIDToken": func(c *Config) bool { return c.Issuer.OIDCPreferClaimsFromIDToken },
@@ -1245,6 +1247,7 @@ var allParameterNames = []string{
 	"Director.OriginCacheHealthTestInterval",
 	"Director.OriginResponseHostnames",
 	"Director.RegistryQueryInterval",
+	"Director.RequireDirectorTests",
 	"Director.StatConcurrencyLimit",
 	"Director.StatTimeout",
 	"Director.SupportContactEmail",
@@ -1835,6 +1838,7 @@ var (
 	Director_EnableOIDC = BoolParam{"Director.EnableOIDC"}
 	Director_EnableStat = BoolParam{"Director.EnableStat"}
 	Director_FilterCachesInErrorState = BoolParam{"Director.FilterCachesInErrorState"}
+	Director_RequireDirectorTests = BoolParam{"Director.RequireDirectorTests"}
 	DisableHttpProxy = BoolParam{"DisableHttpProxy"}
 	DisableProxyFallback = BoolParam{"DisableProxyFallback"}
 	Issuer_OIDCPreferClaimsFromIDToken = BoolParam{"Issuer.OIDCPreferClaimsFromIDToken"}
@@ -2252,6 +2256,7 @@ func init() {
 		"Director.EnableOIDC": Director_EnableOIDC,
 		"Director.EnableStat": Director_EnableStat,
 		"Director.FilterCachesInErrorState": Director_FilterCachesInErrorState,
+		"Director.RequireDirectorTests": Director_RequireDirectorTests,
 		"DisableHttpProxy": DisableHttpProxy,
 		"DisableProxyFallback": DisableProxyFallback,
 		"Issuer.OIDCPreferClaimsFromIDToken": Issuer_OIDCPreferClaimsFromIDToken,

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -128,6 +128,7 @@ type Config struct {
 		OriginCacheHealthTestInterval time.Duration `mapstructure:"origincachehealthtestinterval" yaml:"OriginCacheHealthTestInterval"`
 		OriginResponseHostnames []string `mapstructure:"originresponsehostnames" yaml:"OriginResponseHostnames"`
 		RegistryQueryInterval time.Duration `mapstructure:"registryqueryinterval" yaml:"RegistryQueryInterval"`
+		RequireDirectorTests bool `mapstructure:"requiredirectortests" yaml:"RequireDirectorTests"`
 		StatConcurrencyLimit int `mapstructure:"statconcurrencylimit" yaml:"StatConcurrencyLimit"`
 		StatTimeout time.Duration `mapstructure:"stattimeout" yaml:"StatTimeout"`
 		SupportContactEmail string `mapstructure:"supportcontactemail" yaml:"SupportContactEmail"`
@@ -578,6 +579,7 @@ type configWithType struct {
 		OriginCacheHealthTestInterval struct { Type string; Value time.Duration }
 		OriginResponseHostnames struct { Type string; Value []string }
 		RegistryQueryInterval struct { Type string; Value time.Duration }
+		RequireDirectorTests struct { Type string; Value bool }
 		StatConcurrencyLimit struct { Type string; Value int }
 		StatTimeout struct { Type string; Value time.Duration }
 		SupportContactEmail struct { Type string; Value string }

--- a/web_ui/frontend/app/director/components/DirectorDropdown.tsx
+++ b/web_ui/frontend/app/director/components/DirectorDropdown.tsx
@@ -1,5 +1,5 @@
 import { CapabilitiesChip, Dropdown, InformationSpan } from '@/components';
-import { Box, Grid } from '@mui/material';
+import { Box, Grid, Typography } from '@mui/material';
 import React from 'react';
 import { SinglePointMap } from '@/components/Map';
 import { ServerCapabilitiesTable } from '@/components/ServerCapabilitiesTable';
@@ -38,6 +38,15 @@ export const DirectorDropdown = ({
               name={'XRootD Health Test'}
               value={server.healthStatus}
             />
+            {server.disableDirectorTest && (
+              <Box sx={{ px: '6px', py: '2px' }}>
+                <Typography variant={'caption'} color={'text.secondary'}>
+                  {server.type === 'Origin'
+                    ? 'Director tests are disabled. This is expected for non-POSIX origins (S3, Globus, etc.).'
+                    : 'Director tests are disabled. Cache health cannot be verified by the director.'}
+                </Typography>
+              </Box>
+            )}
             <InformationSpan name={'URL'} value={server.url} />
             <InformationSpan
               name={'Longitude'}


### PR DESCRIPTION
This will close #3095 

Origins will now no longer read as critical or be marked red in the UI when they have director health tests disabled.

Cache's however, will.

When testing this, in order to ensure no other errors are showing up, I recommend setting

```
  EnablePrometheus: false
```

If the origin does still how up red, look at the other health metrics to ensure there isn't a warning or other status beyond the director health tests causing issues using: 

```
curl -sk https://localhost:8446/api/v1.0/metrics/health | python3 -m json.tool
```

Also assigning Cannon because there are some frontend UI changes.