### PR TITLE
Improve apikey cli

### DIFF
--- a/cmd/api_key_generate.go
+++ b/cmd/api_key_generate.go
@@ -46,8 +46,27 @@ var (
 	apiKeyGenerateCmd = &cobra.Command{
 		Use:   "generate",
 		Short: "Generate a new API key for the server",
-		Long:  "Generate a new API key with specified scopes.",
-		RunE:  generateApiKey,
+		Long: `Generate a new API key with specified scopes.
+
+Common scopes for API keys:
+  monitoring.query    Query the server's Prometheus endpoints
+  monitoring.scrape   Scrape the server's /metrics endpoint
+
+The --expiration flag accepts the following formats:
+  - 'never'                       Token does not expire
+  - RFC3339 timestamp             e.g. 2025-12-31T23:59:59Z
+  - Date only (ISO 8601)          e.g. 2025-12-31 (interpreted as midnight UTC)
+
+Examples:
+  # Generate an API key that never expires
+  pelican apikey generate --server https://my-origin.com:8447 --scopes "monitoring.query" --expiration never
+
+  # Generate an API key expiring on a specific date
+  pelican apikey generate --server https://my-origin.com:8447 --scopes "monitoring.query,monitoring.scrape" --expiration 2025-12-31
+
+  # Generate an API key with a precise expiration
+  pelican apikey generate --server https://my-origin.com:8447 --scopes "monitoring.query" --expiration 2025-12-31T23:59:59Z`,
+		RunE: generateApiKey,
 	}
 
 	apiKeyScopes     string
@@ -60,7 +79,7 @@ func init() {
 
 	apiKeyGenerateCmd.Flags().StringVar(&apiKeyScopes, "scopes", "", "Comma-separated list of scopes (e.g., monitoring.query,monitoring.scrape) (required)")
 	apiKeyGenerateCmd.Flags().StringVar(&apiKeyName, "name", "", "Name for the API key (defaults to cli-generated-{timestamp})")
-	apiKeyGenerateCmd.Flags().StringVar(&apiKeyExpiration, "expiration", "", "Expiration time in RFC3339 format")
+	apiKeyGenerateCmd.Flags().StringVar(&apiKeyExpiration, "expiration", "", "Expiration: 'never', a date (2025-12-31), or RFC3339 (2025-12-31T23:59:59Z) (required)")
 
 	// Mark scopes as required
 	err := apiKeyGenerateCmd.MarkFlagRequired("scopes")
@@ -72,6 +91,28 @@ func init() {
 	if err != nil {
 		log.Errorln("Failed to mark expiration flag as required:", err)
 	}
+}
+
+// parseExpiration validates and normalizes the expiration flag value.
+// It accepts "never", RFC3339 timestamps, or date-only strings (YYYY-MM-DD),
+// which are interpreted as midnight UTC on that date.
+// The returned string is either "never" or a valid RFC3339 timestamp.
+func parseExpiration(raw string) (string, error) {
+	if raw == "" {
+		return "", errors.New("--expiration flag is required")
+	}
+	if raw == "never" {
+		return "never", nil
+	}
+	// Try RFC3339 first
+	if _, err := time.Parse(time.RFC3339, raw); err == nil {
+		return raw, nil
+	}
+	// Try date-only (ISO 8601: YYYY-MM-DD), interpreted as midnight UTC
+	if t, err := time.Parse("2006-01-02", raw); err == nil {
+		return t.UTC().Format(time.RFC3339), nil
+	}
+	return "", fmt.Errorf("expiration must be 'never', a date (e.g., 2025-12-31), or RFC3339 (e.g., 2025-12-31T23:59:59Z)")
 }
 
 func generateApiKey(cmd *cobra.Command, args []string) error {
@@ -103,15 +144,10 @@ func generateApiKey(cmd *cobra.Command, args []string) error {
 		name = fmt.Sprintf("cli-generated-%d", time.Now().Unix())
 	}
 
-	// Validate expiration format if provided
-	expiration := apiKeyExpiration
-	if expiration == "" {
-		return errors.New("--expiration flag is required")
-	}
-	// Try to parse as RFC3339 to validate format
-	_, err := time.Parse(time.RFC3339, expiration)
+	// Validate and normalize expiration
+	expiration, err := parseExpiration(apiKeyExpiration)
 	if err != nil {
-		return errors.Wrapf(err, "expiration must be in RFC3339 format (e.g., 2025-12-31T23:59:59Z) or 'never'")
+		return err
 	}
 
 	// Construct API URL

--- a/cmd/api_key_generate.go
+++ b/cmd/api_key_generate.go
@@ -54,8 +54,11 @@ Common scopes for API keys:
 
 The --expiration flag accepts the following formats:
   - 'never'                       Token does not expire
-  - RFC3339 timestamp             e.g. 2025-12-31T23:59:59Z
+  - RFC3339 in UTC                e.g. 2025-12-31T23:59:59Z
+  - RFC3339 with timezone offset  e.g. 2025-12-31T18:59:59-05:00
   - Date only (ISO 8601)          e.g. 2025-12-31 (interpreted as midnight UTC)
+
+Note: Use either 'Z' for UTC or a timezone offset like '-05:00', not both.
 
 Examples:
   # Generate an API key that never expires
@@ -64,8 +67,11 @@ Examples:
   # Generate an API key expiring on a specific date
   pelican apikey generate --server https://my-origin.com:8447 --scopes "monitoring.query,monitoring.scrape" --expiration 2025-12-31
 
-  # Generate an API key with a precise expiration
-  pelican apikey generate --server https://my-origin.com:8447 --scopes "monitoring.query" --expiration 2025-12-31T23:59:59Z`,
+  # Generate an API key with a precise expiration in UTC
+  pelican apikey generate --server https://my-origin.com:8447 --scopes "monitoring.query" --expiration 2025-12-31T23:59:59Z
+
+  # Generate an API key with a timezone offset
+  pelican apikey generate --server https://my-origin.com:8447 --scopes "monitoring.query" --expiration 2025-12-31T18:59:59-05:00`,
 		RunE: generateApiKey,
 	}
 
@@ -112,7 +118,7 @@ func parseExpiration(raw string) (string, error) {
 	if t, err := time.Parse("2006-01-02", raw); err == nil {
 		return t.UTC().Format(time.RFC3339), nil
 	}
-	return "", fmt.Errorf("expiration must be 'never', a date (e.g., 2025-12-31), or RFC3339 (e.g., 2025-12-31T23:59:59Z)")
+	return "", fmt.Errorf("expiration must be 'never', a date (e.g., 2025-12-31), or RFC3339 (e.g., 2025-12-31T23:59:59Z or 2025-12-31T18:59:59-05:00)")
 }
 
 func generateApiKey(cmd *cobra.Command, args []string) error {

--- a/cmd/api_key_generate.go
+++ b/cmd/api_key_generate.go
@@ -58,10 +58,8 @@ The --expiration flag accepts the following formats:
   - RFC3339 with timezone offset  e.g. 2025-12-31T18:59:59-05:00
   - Date only (ISO 8601)          e.g. 2025-12-31 (interpreted as midnight UTC)
 
-Note: Use either 'Z' for UTC or a timezone offset like '-05:00', not both.
-
-Examples:
-  # Generate an API key that never expires
+Note: Use either 'Z' for UTC or a timezone offset like '-05:00', not both.`,
+		Example: `  # Generate an API key that never expires
   pelican apikey generate --server https://my-origin.com:8447 --scopes "monitoring.query" --expiration never
 
   # Generate an API key expiring on a specific date
@@ -72,7 +70,8 @@ Examples:
 
   # Generate an API key with a timezone offset
   pelican apikey generate --server https://my-origin.com:8447 --scopes "monitoring.query" --expiration 2025-12-31T18:59:59-05:00`,
-		RunE: generateApiKey,
+		RunE:         generateApiKey,
+		SilenceUsage: true,
 	}
 
 	apiKeyScopes     string

--- a/cmd/api_key_test.go
+++ b/cmd/api_key_test.go
@@ -190,14 +190,14 @@ func TestApiKeyGenerateValidation(t *testing.T) {
 
 	t.Run("invalid-expiration-format", func(t *testing.T) {
 		apiKeyScopes = "monitoring.query"
-		apiKeyExpiration = "2026-12-31"
+		apiKeyExpiration = "12/31/2026"
 		apiKeyServerURLStr = "https://example.com:8447"
 		apiKeyTokenLocation = ""
 
 		cmd := &cobra.Command{}
 		err := generateApiKey(cmd, []string{})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "expiration must be in RFC3339 format")
+		assert.Contains(t, err.Error(), "expiration must be 'never', a date")
 	})
 
 	t.Run("invalid-expiration-natural-language", func(t *testing.T) {
@@ -209,7 +209,33 @@ func TestApiKeyGenerateValidation(t *testing.T) {
 		cmd := &cobra.Command{}
 		err := generateApiKey(cmd, []string{})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "expiration must be in RFC3339 format")
+		assert.Contains(t, err.Error(), "expiration must be 'never', a date")
+	})
+
+	t.Run("date-only-expiration-accepted", func(t *testing.T) {
+		apiKeyScopes = "monitoring.query"
+		apiKeyExpiration = "2026-12-31"
+		apiKeyServerURLStr = "https://example.com:8447"
+		apiKeyTokenLocation = "/nonexistent/path"
+
+		cmd := &cobra.Command{}
+		err := generateApiKey(cmd, []string{})
+		// Should pass expiration validation and fail at token fetch instead
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Token file not found")
+	})
+
+	t.Run("never-expiration-accepted", func(t *testing.T) {
+		apiKeyScopes = "monitoring.query"
+		apiKeyExpiration = "never"
+		apiKeyServerURLStr = "https://example.com:8447"
+		apiKeyTokenLocation = "/nonexistent/path"
+
+		cmd := &cobra.Command{}
+		err := generateApiKey(cmd, []string{})
+		// Should pass expiration validation and fail at token fetch instead
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Token file not found")
 	})
 
 	t.Run("missing-server-url", func(t *testing.T) {
@@ -402,6 +428,67 @@ func TestApiKeyGenerateWithMockServer(t *testing.T) {
 		// Should fail at token fetch, not at scope validation
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "Token file not found")
+	})
+}
+
+func TestParseExpiration(t *testing.T) {
+	t.Run("empty-returns-error", func(t *testing.T) {
+		_, err := parseExpiration("")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--expiration flag is required")
+	})
+
+	t.Run("never", func(t *testing.T) {
+		result, err := parseExpiration("never")
+		require.NoError(t, err)
+		assert.Equal(t, "never", result)
+	})
+
+	t.Run("rfc3339", func(t *testing.T) {
+		result, err := parseExpiration("2026-12-31T23:59:59Z")
+		require.NoError(t, err)
+		assert.Equal(t, "2026-12-31T23:59:59Z", result)
+	})
+
+	t.Run("rfc3339-with-offset", func(t *testing.T) {
+		result, err := parseExpiration("2026-12-31T23:59:59+05:00")
+		require.NoError(t, err)
+		assert.Equal(t, "2026-12-31T23:59:59+05:00", result)
+	})
+
+	t.Run("date-only-converts-to-midnight-utc", func(t *testing.T) {
+		result, err := parseExpiration("2026-12-31")
+		require.NoError(t, err)
+		assert.Equal(t, "2026-12-31T00:00:00Z", result)
+	})
+
+	t.Run("date-only-another-date", func(t *testing.T) {
+		result, err := parseExpiration("2025-06-15")
+		require.NoError(t, err)
+		assert.Equal(t, "2025-06-15T00:00:00Z", result)
+	})
+
+	t.Run("invalid-format", func(t *testing.T) {
+		_, err := parseExpiration("next week")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expiration must be 'never', a date")
+	})
+
+	t.Run("invalid-date-format-slash", func(t *testing.T) {
+		_, err := parseExpiration("12/31/2026")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expiration must be 'never', a date")
+	})
+
+	t.Run("invalid-partial-date", func(t *testing.T) {
+		_, err := parseExpiration("2026-12")
+		require.Error(t, err)
+	})
+
+	t.Run("invalid-z-with-offset", func(t *testing.T) {
+		_, err := parseExpiration("2026-06-30T09:00:00Z-05:00")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "RFC3339 (e.g., 2025-12-31T23:59:59Z or 2025-12-31T18:59:59-05:00)")
 	})
 }
 

--- a/docs/app/commands-reference/pelican-server/apikey/generate/page.mdx
+++ b/docs/app/commands-reference/pelican-server/apikey/generate/page.mdx
@@ -10,6 +10,31 @@ Generate a new API key for the server
 
 Generate a new API key with specified scopes.
 
+Common scopes for API keys:
+  monitoring.query    Query the server's Prometheus endpoints
+  monitoring.scrape   Scrape the server's /metrics endpoint
+
+The --expiration flag accepts the following formats:
+  - 'never'                       Token does not expire
+  - RFC3339 in UTC                e.g. 2025-12-31T23:59:59Z
+  - RFC3339 with timezone offset  e.g. 2025-12-31T18:59:59-05:00
+  - Date only (ISO 8601)          e.g. 2025-12-31 (interpreted as midnight UTC)
+
+Note: Use either 'Z' for UTC or a timezone offset like '-05:00', not both.
+
+Examples:
+  # Generate an API key that never expires
+  pelican apikey generate --server https://my-origin.com:8447 --scopes "monitoring.query" --expiration never
+
+  # Generate an API key expiring on a specific date
+  pelican apikey generate --server https://my-origin.com:8447 --scopes "monitoring.query,monitoring.scrape" --expiration 2025-12-31
+
+  # Generate an API key with a precise expiration in UTC
+  pelican apikey generate --server https://my-origin.com:8447 --scopes "monitoring.query" --expiration 2025-12-31T23:59:59Z
+
+  # Generate an API key with a timezone offset
+  pelican apikey generate --server https://my-origin.com:8447 --scopes "monitoring.query" --expiration 2025-12-31T18:59:59-05:00
+
 ```
 pelican-server apikey generate [flags]
 ```
@@ -17,7 +42,7 @@ pelican-server apikey generate [flags]
 ### Options
 
 ```
-      --expiration string   Expiration time in RFC3339 format
+      --expiration string   Expiration: 'never', a date (2025-12-31), or RFC3339 (2025-12-31T23:59:59Z) (required)
   -h, --help                help for generate
       --name string         Name for the API key (defaults to cli-generated-{timestamp})
       --scopes string       Comma-separated list of scopes (e.g., monitoring.query,monitoring.scrape) (required)

--- a/docs/app/commands-reference/pelican-server/apikey/generate/page.mdx
+++ b/docs/app/commands-reference/pelican-server/apikey/generate/page.mdx
@@ -22,7 +22,13 @@ The --expiration flag accepts the following formats:
 
 Note: Use either 'Z' for UTC or a timezone offset like '-05:00', not both.
 
-Examples:
+```
+pelican-server apikey generate [flags]
+```
+
+### Examples
+
+```
   # Generate an API key that never expires
   pelican apikey generate --server https://my-origin.com:8447 --scopes "monitoring.query" --expiration never
 
@@ -34,9 +40,6 @@ Examples:
 
   # Generate an API key with a timezone offset
   pelican apikey generate --server https://my-origin.com:8447 --scopes "monitoring.query" --expiration 2025-12-31T18:59:59-05:00
-
-```
-pelican-server apikey generate [flags]
 ```
 
 ### Options

--- a/docs/app/monitoring-pelican-services/grafana/page.mdx
+++ b/docs/app/monitoring-pelican-services/grafana/page.mdx
@@ -119,9 +119,27 @@ This section describes how to configure Grafana to have proper authentication cr
 
 ### Authenticated Prometheus
 
-By default, Pelican protects the Prometheus endpoint by asking for a [JWT](https://jwt.io/introduction) to verify the user accessing the endpoint. It reads `Bearer <token>` from `Authorization` header during any HTTPS request to `/api/v1.0/prometheus` and its subpath. You need to create a JWT using the Pelican CLI and pass it to Grafana.
+By default, Pelican protects the Prometheus endpoint by asking for a [JWT](https://jwt.io/introduction) to verify the user accessing the endpoint. It reads `Bearer <token>` from the `Authorization` header during any HTTPS request to `/api/v1.0/prometheus` and its subpath. You need to create a token using the Pelican CLI and pass it to Grafana.
 
-1. Run the following command
+1. **Generate a token** using one of the two methods below:
+
+    #### Using an API key (recommended)
+
+    API keys are persisted in the server database and can be set to never expire, making them ideal for long-running services like Grafana. Run the following command on the machine where your Pelican server is running:
+
+    * Replace `<server-web-url>` with the URL to your Pelican server Web UI. By default, it's `https://localhost:8444`.
+
+    * The `--expiration` flag accepts `never` (no expiration), a date like `2026-12-31` (midnight UTC), or a full RFC3339 timestamp like `2026-12-31T23:59:59Z`.
+
+    ```bash
+    $ pelican apikey generate --server <server-web-url> --scopes "monitoring.query" --name "Grafana monitoring" --expiration never
+
+    Key:  <your-api-key>
+    ```
+
+    #### Using a short-lived token
+
+    Alternatively, you can generate a short-lived token using `pelican origin token create`. This token is not stored on the server and will expire after the specified lifetime, requiring you to regenerate it periodically.
 
     * Replace `<server-web-url>` with the URL to your Pelican server Web UI. By default, it's `https://localhost:8444`.
 
@@ -133,13 +151,13 @@ By default, Pelican protects the Prometheus endpoint by asking for a [JWT](https
     eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwiaWF0IjoxNzA5NjUwMjMyLCJleHAiOjE3NDExODYyMzIsImF1ZCI6Imh0dHBzOi8vZXhhbXBsZS5jb20iLCJzdWIiOiJncmFmYW5hIiwic2NvcGUiOiJtb25pdG9yaW5nLnF1ZXJ5Iiwid2xjZy52ZXIiOiIxLjAifQ.cK5QyYJinn3QCPa6YB10Wn37MEEKzt_kyDMR9meN1Ec
     ```
 
-2. Copy the generated token. Note that your token will be different from the example above.
+2. Copy the generated key or token. Note that your value will be different from the examples above.
 
-3. In the Grafana data source configuration page, go to the **Authentication** section, expand the **HTTP Headers** subsection, and click **Add header**
+3. In the Grafana data source configuration page, go to the **Authentication** section, expand the **HTTP Headers** subsection, and click **Add header**.
 
-4. Fill in `Authorization` for the **Header** field and `Bearer <token>` for the **Value** field with your generated token. Note that there is a whitespace between `Bearer` and your token.
+4. Fill in `Authorization` for the **Header** field and `Bearer <your-key-or-token>` for the **Value** field. Note that there is a whitespace between `Bearer` and your key/token.
 
-That's it! Now you can scroll to the bottom of the configuration page and click **Save & Test**. There should be green alert with a title **Successfully queried the Prometheus API.**
+Now you can scroll to the bottom of the configuration page and click **Save & Test**. There should be a green alert with a title **Successfully queried the Prometheus API.**
 
 ### Unauthenticated Prometheus
 


### PR DESCRIPTION
Closes #3227 

- Fix --expiration 'never' not working despite being documented as valid (fixes #3227)
- Accept ISO 8601 date-only format (e.g., 2025-12-31), interpreted as midnight UTC
- Improve --help text with expiration format docs, common scopes, and usage examples
- Update Grafana monitoring docs to recommend pelican apikey generate for token creation