### PR TITLE
Additional fixes for user and group

### DIFF
--- a/database/collection.go
+++ b/database/collection.go
@@ -618,7 +618,14 @@ func GetOrCreateUser(db *gorm.DB, username string, sub string, issuer string) (*
 	user := &User{}
 	err := db.Where("sub = ? AND issuer = ?", sub, issuer).First(user).Error
 	if err == nil {
-		// User found, return existing user
+		// User found — refresh display name if OIDC provider returned a different one
+		if user.Username != username && username != "" {
+			err = db.Model(user).Update("username", username).Error
+			if err != nil {
+				return nil, err
+			}
+			user.Username = username
+		}
 		return user, nil
 	}
 	if !errors.Is(err, gorm.ErrRecordNotFound) {

--- a/database/collection.go
+++ b/database/collection.go
@@ -216,10 +216,10 @@ func CreateCollectionWithMetadata(db *gorm.DB, name, description, owner, namespa
 	return collection, nil
 }
 
-func ListCollections(db *gorm.DB, user string, groups []string) ([]Collection, error) {
+func ListCollections(db *gorm.DB, userId string, groups []string) ([]Collection, error) {
 	collections := []Collection{}
-	// Every user is part of their own user group, ensure this is in the slice
-	userGroup := "user-" + user
+	// Every user is part of their own personal group (keyed by user ID)
+	userGroup := "user-" + userId
 	if !slices.Contains(groups, userGroup) {
 		groups = append(groups, userGroup)
 	}
@@ -579,14 +579,14 @@ func DeleteCollection(db *gorm.DB, id string, owner string, groups []string, isA
 	})
 }
 
-func validateACL(collection *Collection, user string, groups []string, scope token_scopes.TokenScope) error {
+func validateACL(collection *Collection, userId string, groups []string, scope token_scopes.TokenScope) error {
 	roles, ok := ScopeToRole[scope]
 	if !ok {
 		return fmt.Errorf("invalid scope: %s", scope.String())
 	}
 
-	// Every user is part of their own user group, ensure this is in the slice
-	userGroup := "user-" + user
+	// Every user is part of their own personal group (keyed by user ID)
+	userGroup := "user-" + userId
 	if !slices.Contains(groups, userGroup) {
 		groups = append(groups, userGroup)
 	}
@@ -891,7 +891,7 @@ func DeleteUser(db *gorm.DB, userID, requestorUserID string, isAdmin bool) error
 			return ErrForbidden
 		}
 
-		personalGroup := "user-" + user.Username
+		personalGroup := "user-" + user.ID
 
 		// Remove any ACL entries referencing the user's personal group name.
 		if err := tx.Where("group_id = ?", personalGroup).Delete(&CollectionACL{}).Error; err != nil {

--- a/database/server.go
+++ b/database/server.go
@@ -83,6 +83,12 @@ func InitServerDatabase(serverType server_structs.ServerType) error {
 		}
 	}
 
+	// Ensure admin users exist in the database so their identifiers are "claimed"
+	// before any potential attacker can register them via OIDC login.
+	if err := EnsureAdminUsersExist(ServerDatabase); err != nil {
+		log.Warnf("Failed to ensure admin users exist: %v", err)
+	}
+
 	// Data migration - this block could be removed after the Registry upgrade is complete
 	if serverType == server_structs.RegistryType {
 		// Run data migration from old registry.sqlite to new pelican.sqlite
@@ -570,5 +576,50 @@ func SoftDeleteServerLocalMetadata(id string) error {
 		return gorm.ErrRecordNotFound
 	}
 
+	return nil
+}
+
+// EnsureAdminUsersExist pre-creates user records for configured admin identifiers
+// (Server.UIAdminUsers) so that their OIDC sub values are "claimed" in the database
+// before any attacker can register them. This closes the window where an admin who
+// hasn't logged in yet could have their identity hijacked.
+func EnsureAdminUsersExist(db *gorm.DB) error {
+	adminUsers := param.Server_UIAdminUsers.GetStringSlice()
+	if !param.Server_UIAdminUsers.IsSet() || len(adminUsers) == 0 {
+		return nil
+	}
+
+	// Determine the issuer for pre-created admin records.
+	// OIDC.Issuer defaults to "https://cilogon.org" in defaults.yaml,
+	// so GetString() will return a value even if not explicitly set.
+	issuer := param.OIDC_Issuer.GetString()
+	if issuer == "" {
+		log.Errorf("Cannot pre-create admin users: OIDC.Issuer is not configured")
+		return nil
+	}
+
+	for _, adminSub := range adminUsers {
+		if adminSub == "" || adminSub == "admin" {
+			continue // "admin" is the built-in password user, handled separately
+		}
+
+		// Check if a user with this sub+issuer already exists
+		var user User
+		err := db.Where("sub = ? AND issuer = ?", adminSub, issuer).First(&user).Error
+		if err == nil {
+			continue // Already exists
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return errors.Wrapf(err, "failed to check for existing admin user '%s'", adminSub)
+		}
+
+		// Create placeholder admin user record
+		log.Infof("Pre-creating admin user record for sub='%s' (issuer: %s)", adminSub, issuer)
+		_, err = CreateUser(db, adminSub, adminSub, issuer)
+		if err != nil {
+			log.Errorf("Failed to pre-create admin user '%s': %v", adminSub, err)
+			// Continue with other admin users rather than failing entirely
+		}
+	}
 	return nil
 }

--- a/database/universal_migrations/20260420000000_personal_group_userid.sql
+++ b/database/universal_migrations/20260420000000_personal_group_userid.sql
@@ -40,6 +40,11 @@ WHERE EXISTS (
     SELECT 1 FROM users u WHERE collections.owner = u.username
 );
 
+-- Drop the (username, issuer) unique constraint. Username is a mutable display
+-- name, not an identity key. The real identity uniqueness is (sub, issuer)
+-- which is enforced by idx_user_sub_issuer.
+DROP INDEX IF EXISTS idx_user_issuer;
+
 -- +goose StatementEnd
 
 -- +goose Down

--- a/database/universal_migrations/20260420000000_personal_group_userid.sql
+++ b/database/universal_migrations/20260420000000_personal_group_userid.sql
@@ -1,0 +1,47 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Migrate personal group references from "user-<username>" to "user-<user_id>".
+-- Personal groups are virtual (never stored in the groups table). The only
+-- persisted reference is in collection_acls.group_id, plus collections.owner
+-- and collection_acls.granted_by which store the username directly.
+
+-- Migrate collection ACLs that reference personal groups.
+UPDATE collection_acls SET group_id = 'user-' || (
+    SELECT u.id FROM users u
+    WHERE collection_acls.group_id = 'user-' || u.username
+    ORDER BY u.created_at ASC 
+    LIMIT 1
+)
+WHERE group_id LIKE 'user-%'
+  AND EXISTS (
+    SELECT 1 FROM users u WHERE collection_acls.group_id = 'user-' || u.username
+);
+
+-- Migrate collection_acls.granted_by from username to user ID where applicable.
+UPDATE collection_acls SET granted_by = (
+    SELECT u.id FROM users u
+    WHERE collection_acls.granted_by = u.username
+    ORDER BY u.created_at ASC 
+    LIMIT 1
+)
+WHERE EXISTS (
+    SELECT 1 FROM users u WHERE collection_acls.granted_by = u.username
+);
+
+-- Migrate collections.owner from username to user ID.
+UPDATE collections SET owner = (
+    SELECT u.id FROM users u
+    WHERE collections.owner = u.username
+    ORDER BY u.created_at ASC 
+    LIMIT 1
+)
+WHERE EXISTS (
+    SELECT 1 FROM users u WHERE collections.owner = u.username
+);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- +goose StatementEnd

--- a/database/universal_migrations/20260420000000_personal_group_userid.sql
+++ b/database/universal_migrations/20260420000000_personal_group_userid.sql
@@ -10,7 +10,7 @@
 UPDATE collection_acls SET group_id = 'user-' || (
     SELECT u.id FROM users u
     WHERE collection_acls.group_id = 'user-' || u.username
-    ORDER BY u.created_at ASC 
+    ORDER BY u.created_at ASC
     LIMIT 1
 )
 WHERE group_id LIKE 'user-%'
@@ -22,7 +22,7 @@ WHERE group_id LIKE 'user-%'
 UPDATE collection_acls SET granted_by = (
     SELECT u.id FROM users u
     WHERE collection_acls.granted_by = u.username
-    ORDER BY u.created_at ASC 
+    ORDER BY u.created_at ASC
     LIMIT 1
 )
 WHERE EXISTS (
@@ -33,7 +33,7 @@ WHERE EXISTS (
 UPDATE collections SET owner = (
     SELECT u.id FROM users u
     WHERE collections.owner = u.username
-    ORDER BY u.created_at ASC 
+    ORDER BY u.created_at ASC
     LIMIT 1
 )
 WHERE EXISTS (

--- a/e2e_fed_tests/downtime_test.go
+++ b/e2e_fed_tests/downtime_test.go
@@ -148,7 +148,11 @@ func TestServerDowntimeDirectorForwarding(t *testing.T) {
 	tk.Lifetime = 5 * time.Minute
 	tk.AddAudiences(fedInfo.DiscoveryEndpoint)
 	tk.AddScopes(token_scopes.WebUi_Access)
-	tk.Claims = map[string]string{"user_id": "test-user-id"} // Required by GetUserGroups
+	tk.Claims = map[string]string{
+		"user_id":  "test-user-id", // Required by GetUserGroups
+		"oidc_sub": "admin-user",   // Must match Server_UIAdminUsers entry
+		"oidc_iss": param.OIDC_Issuer.GetString(),
+	}
 	tok, err := tk.CreateToken()
 	require.NoError(t, err)
 	downtimeCreationReq, _ := http.NewRequest("POST", cacheWebUrl.String(), bytes.NewBuffer(body))

--- a/oa4mp/proxy.go
+++ b/oa4mp/proxy.go
@@ -260,7 +260,7 @@ func CalculateAllowedScopesWithRules(rules []*CompiledAuthz, user string, userId
 // The matched groups are groups that have ACLs on collections, which should be
 // included in the token's wlcg.groups claim for collection ACL checking.
 // GetUserCollectionScopes returns collection scopes and matched groups for a user.
-func GetUserCollectionScopes(db *gorm.DB, user string, groupsList []string) (scopes []string, matchedGroups []string, err error) {
+func GetUserCollectionScopes(db *gorm.DB, userId string, groupsList []string) (scopes []string, matchedGroups []string, err error) {
 	scopes = make([]string, 0)
 	matchedGroupSet := make(map[string]struct{})
 
@@ -272,7 +272,7 @@ func GetUserCollectionScopes(db *gorm.DB, user string, groupsList []string) (sco
 	// is handled at the database level based on ACLs and visibility.
 	scopes = append(scopes, token_scopes.Collection_Read.String()+":/")
 
-	userGroup := "user-" + user
+	userGroup := "user-" + userId
 	if !slices.Contains(groupsList, userGroup) {
 		groupsList = append(groupsList, userGroup)
 	}
@@ -377,7 +377,7 @@ func oa4mpProxy(ctx *gin.Context) {
 		userInfo := make(map[string]interface{})
 		userInfo["u"] = user
 		allowedScopes, authzMatchedGroups := CalculateAllowedScopes(user, userId, groupsList)
-		userCollectionScopes, collectionMatchedGroups, err := GetUserCollectionScopes(database.ServerDatabase, user, groupsList)
+		userCollectionScopes, collectionMatchedGroups, err := GetUserCollectionScopes(database.ServerDatabase, userId, groupsList)
 		if err != nil {
 			ctx.AbortWithStatusJSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 				Status: server_structs.RespFailed,

--- a/oauth2/issuer/handlers.go
+++ b/oauth2/issuer/handlers.go
@@ -396,7 +396,7 @@ func handleAuthorize(provider *OIDCProvider) gin.HandlerFunc {
 		if serverDB == nil {
 			serverDB = provider.storage.db
 		}
-		collectionScopes, collectionGroups, colErr := oa4mp.GetUserCollectionScopes(serverDB, user, groups)
+		collectionScopes, collectionGroups, colErr := oa4mp.GetUserCollectionScopes(serverDB, userID, groups)
 		if colErr != nil {
 			log.WithError(colErr).Warn("Embedded issuer: failed to get collection scopes")
 		} else {
@@ -670,7 +670,7 @@ func handleDeviceVerifySubmit(provider *OIDCProvider) gin.HandlerFunc {
 		if serverDB == nil {
 			serverDB = provider.storage.db
 		}
-		collectionScopes, collectionGroups, colErr := oa4mp.GetUserCollectionScopes(serverDB, user, groups)
+		collectionScopes, collectionGroups, colErr := oa4mp.GetUserCollectionScopes(serverDB, userID, groups)
 		if colErr == nil {
 			allowedScopes = append(allowedScopes, collectionScopes...)
 			matchedGroups = oa4mp.MergeGroups(matchedGroups, collectionGroups)

--- a/origin/collections.go
+++ b/origin/collections.go
@@ -324,7 +324,7 @@ func handleListCollections(ctx *gin.Context) {
 		return
 	}
 
-	user, _, groups, err := web_ui.GetUserGroups(ctx)
+	_, userId, groups, err := web_ui.GetUserGroups(ctx)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
@@ -332,7 +332,7 @@ func handleListCollections(ctx *gin.Context) {
 		})
 		return
 	}
-	if user == "" {
+	if userId == "" {
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    "Failed to get user from context",
@@ -340,7 +340,7 @@ func handleListCollections(ctx *gin.Context) {
 		return
 	}
 
-	collections, err := database.ListCollections(database.ServerDatabase, user, groups)
+	collections, err := database.ListCollections(database.ServerDatabase, userId, groups)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
@@ -418,14 +418,14 @@ func handleCreateCollection(ctx *gin.Context) {
 		return
 	}
 
-	user, _, _, err := web_ui.GetUserGroups(ctx)
+	_, userId, _, err := web_ui.GetUserGroups(ctx)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    fmt.Sprintf("Failed to get user from context: %v", err),
 		})
 	}
-	if user == "" {
+	if userId == "" {
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    "Failed to get user from context",
@@ -442,7 +442,7 @@ func handleCreateCollection(ctx *gin.Context) {
 		return
 	}
 
-	coll, err := database.CreateCollectionWithMetadata(database.ServerDatabase, req.Name, req.Description, user, req.Namespace, visibility, req.Metadata)
+	coll, err := database.CreateCollectionWithMetadata(database.ServerDatabase, req.Name, req.Description, userId, req.Namespace, visibility, req.Metadata)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
@@ -524,7 +524,7 @@ func handleUpdateCollection(ctx *gin.Context) {
 		visPtr = &visibility
 	}
 
-	err = database.UpdateCollection(database.ServerDatabase, ctx.Param("id"), user, groups, req.Name, req.Description, visPtr, isAdmin)
+	err = database.UpdateCollection(database.ServerDatabase, ctx.Param("id"), userId, groups, req.Name, req.Description, visPtr, isAdmin)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
 			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
@@ -569,7 +569,7 @@ func handleRemoveCollectionMembers(ctx *gin.Context) {
 		return
 	}
 
-	user, groups, err := web_ui.GetUserGroups(ctx)
+	user, userId, groups, err := web_ui.GetUserGroups(ctx)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
@@ -584,9 +584,14 @@ func handleRemoveCollectionMembers(ctx *gin.Context) {
 		return
 	}
 
-	isAdmin, _ := web_ui.CheckAdmin(user)
+	isAdmin, _ := web_ui.CheckAdmin(web_ui.UserIdentity{
+		Username: user,
+		ID:       userId,
+		Groups:   groups,
+		Sub:      ctx.GetString("OIDCSub"),
+	})
 
-	err = database.RemoveCollectionMembers(database.ServerDatabase, ctx.Param("id"), req.Members, user, groups, isAdmin)
+	err = database.RemoveCollectionMembers(database.ServerDatabase, ctx.Param("id"), req.Members, userId, groups, isAdmin)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
 			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
@@ -630,7 +635,7 @@ func handleRemoveCollectionMember(ctx *gin.Context) {
 		return
 	}
 
-	user, groups, err := web_ui.GetUserGroups(ctx)
+	user, userId, groups, err := web_ui.GetUserGroups(ctx)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
@@ -645,9 +650,14 @@ func handleRemoveCollectionMember(ctx *gin.Context) {
 		return
 	}
 
-	isAdmin, _ := web_ui.CheckAdmin(user)
+	isAdmin, _ := web_ui.CheckAdmin(web_ui.UserIdentity{
+		Username: user,
+		ID:       userId,
+		Groups:   groups,
+		Sub:      ctx.GetString("OIDCSub"),
+	})
 
-	err = database.RemoveCollectionMembers(database.ServerDatabase, ctx.Param("id"), []string{objectURL}, user, groups, isAdmin)
+	err = database.RemoveCollectionMembers(database.ServerDatabase, ctx.Param("id"), []string{objectURL}, userId, groups, isAdmin)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
 			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
@@ -703,7 +713,7 @@ func handleAddCollectionMembers(ctx *gin.Context) {
 		}
 	}
 
-	user, groups, err := web_ui.GetUserGroups(ctx)
+	user, userId, groups, err := web_ui.GetUserGroups(ctx)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
@@ -718,9 +728,14 @@ func handleAddCollectionMembers(ctx *gin.Context) {
 		return
 	}
 
-	isAdmin, _ := web_ui.CheckAdmin(user)
+	isAdmin, _ := web_ui.CheckAdmin(web_ui.UserIdentity{
+		Username: user,
+		ID:       userId,
+		Groups:   groups,
+		Sub:      ctx.GetString("OIDCSub"),
+	})
 
-	err = database.AddCollectionMembers(database.ServerDatabase, ctx.Param("id"), req.Members, user, groups, isAdmin)
+	err = database.AddCollectionMembers(database.ServerDatabase, ctx.Param("id"), req.Members, userId, groups, isAdmin)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
 			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
@@ -754,14 +769,14 @@ func handleListCollectionMembers(ctx *gin.Context) {
 		return
 	}
 
-	user, groups, err := web_ui.GetUserGroups(ctx)
+	_, userId, groups, err := web_ui.GetUserGroups(ctx)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    fmt.Sprintf("Failed to get user from context: %v", err),
 		})
 	}
-	if user == "" {
+	if userId == "" {
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    "Failed to get user from context",
@@ -801,7 +816,7 @@ func handleListCollectionMembers(ctx *gin.Context) {
 		}
 	}
 
-	members, err := database.GetCollectionMembers(database.ServerDatabase, ctx.Param("id"), user, groups, since, limit)
+	members, err := database.GetCollectionMembers(database.ServerDatabase, ctx.Param("id"), userId, groups, since, limit)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
 			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
@@ -832,14 +847,14 @@ func handleGetCollectionMetadata(ctx *gin.Context) {
 		return
 	}
 
-	user, _, groups, err := web_ui.GetUserGroups(ctx)
+	_, userId, groups, err := web_ui.GetUserGroups(ctx)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    fmt.Sprintf("Failed to get user from context: %v", err),
 		})
 	}
-	if user == "" {
+	if userId == "" {
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    "Failed to get user from context",
@@ -847,7 +862,7 @@ func handleGetCollectionMetadata(ctx *gin.Context) {
 		return
 	}
 
-	metadata, err := database.GetCollectionMetadata(database.ServerDatabase, ctx.Param("id"), user, groups)
+	metadata, err := database.GetCollectionMetadata(database.ServerDatabase, ctx.Param("id"), userId, groups)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
 			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
@@ -933,7 +948,7 @@ func handlePutCollectionMetadata(ctx *gin.Context) {
 	}
 	isAdmin, _ := web_ui.CheckAdmin(identity)
 
-	err = database.UpsertCollectionMetadata(database.ServerDatabase, ctx.Param("id"), user, groups, key, value, isAdmin)
+	err = database.UpsertCollectionMetadata(database.ServerDatabase, ctx.Param("id"), userId, groups, key, value, isAdmin)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
 			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
@@ -995,7 +1010,7 @@ func handleDeleteCollectionMetadata(ctx *gin.Context) {
 	}
 	isAdmin, _ := web_ui.CheckAdmin(identity)
 
-	err = database.DeleteCollectionMetadata(database.ServerDatabase, ctx.Param("id"), user, groups, key, isAdmin)
+	err = database.DeleteCollectionMetadata(database.ServerDatabase, ctx.Param("id"), userId, groups, key, isAdmin)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
 			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
@@ -1025,14 +1040,14 @@ func handleGetCollection(ctx *gin.Context) {
 		return
 	}
 
-	user, _, groups, err := web_ui.GetUserGroups(ctx)
+	_, userId, groups, err := web_ui.GetUserGroups(ctx)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    fmt.Sprintf("Failed to get user from context: %v", err),
 		})
 	}
-	if user == "" {
+	if userId == "" {
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    "Failed to get user from context",
@@ -1040,7 +1055,7 @@ func handleGetCollection(ctx *gin.Context) {
 		return
 	}
 
-	coll, err := database.GetCollection(database.ServerDatabase, ctx.Param("id"), user, groups)
+	coll, err := database.GetCollection(database.ServerDatabase, ctx.Param("id"), userId, groups)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
 			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{Status: server_structs.RespFailed, Msg: "collection not found"})
@@ -1116,7 +1131,7 @@ func handleDeleteCollection(ctx *gin.Context) {
 	}
 	isAdmin, _ := web_ui.CheckAdmin(identity)
 
-	err = database.DeleteCollection(database.ServerDatabase, ctx.Param("id"), user, groups, isAdmin)
+	err = database.DeleteCollection(database.ServerDatabase, ctx.Param("id"), userId, groups, isAdmin)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
 			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
@@ -1146,14 +1161,14 @@ func handleGetCollectionAcls(ctx *gin.Context) {
 		return
 	}
 
-	user, _, groups, err := web_ui.GetUserGroups(ctx)
+	_, userId, groups, err := web_ui.GetUserGroups(ctx)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    fmt.Sprintf("Failed to get user from context: %v", err),
 		})
 	}
-	if user == "" {
+	if userId == "" {
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    "Failed to get user from context",
@@ -1161,7 +1176,7 @@ func handleGetCollectionAcls(ctx *gin.Context) {
 		return
 	}
 
-	acls, err := database.GetCollectionAcls(database.ServerDatabase, ctx.Param("id"), user, groups)
+	acls, err := database.GetCollectionAcls(database.ServerDatabase, ctx.Param("id"), userId, groups)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
 			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
@@ -1241,7 +1256,7 @@ func handleGrantCollectionAcl(ctx *gin.Context) {
 	}
 	isAdmin, _ := web_ui.CheckAdmin(identity)
 
-	err = database.GrantCollectionAcl(database.ServerDatabase, ctx.Param("id"), user, groups, req.GroupID, role, req.ExpiresAt, isAdmin)
+	err = database.GrantCollectionAcl(database.ServerDatabase, ctx.Param("id"), userId, groups, req.GroupID, role, req.ExpiresAt, isAdmin)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
 			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
@@ -1320,7 +1335,7 @@ func handleRevokeCollectionAcl(ctx *gin.Context) {
 	}
 	isAdmin, _ := web_ui.CheckAdmin(identity)
 
-	err = database.RevokeCollectionAcl(database.ServerDatabase, ctx.Param("id"), user, groups, req.GroupID, role, isAdmin)
+	err = database.RevokeCollectionAcl(database.ServerDatabase, ctx.Param("id"), userId, groups, req.GroupID, role, isAdmin)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, database.ErrForbidden) {
 			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{

--- a/origin/collections.go
+++ b/origin/collections.go
@@ -172,10 +172,15 @@ func verifyCollectionScope(ctx *gin.Context, expectedScope token_scopes.TokenSco
 				}
 			}
 
-			// Extract oidc_sub claim
+			// Extract oidc_sub and oidc_iss claims
 			if oidcSubIface, ok := parsed.Get("oidc_sub"); ok {
 				if oidcSub, ok := oidcSubIface.(string); ok && oidcSub != "" {
 					ctx.Set("OIDCSub", oidcSub)
+				}
+			}
+			if oidcIssIface, ok := parsed.Get("oidc_iss"); ok {
+				if oidcIss, ok := oidcIssIface.(string); ok && oidcIss != "" {
+					ctx.Set("OIDCIss", oidcIss)
 				}
 			}
 
@@ -503,6 +508,7 @@ func handleUpdateCollection(ctx *gin.Context) {
 		ID:       userId,
 		Groups:   groups,
 		Sub:      ctx.GetString("OIDCSub"),
+		Issuer:   ctx.GetString("OIDCIss"),
 	}
 	isAdmin, _ := web_ui.CheckAdmin(identity)
 
@@ -589,6 +595,7 @@ func handleRemoveCollectionMembers(ctx *gin.Context) {
 		ID:       userId,
 		Groups:   groups,
 		Sub:      ctx.GetString("OIDCSub"),
+		Issuer:   ctx.GetString("OIDCIss"),
 	})
 
 	err = database.RemoveCollectionMembers(database.ServerDatabase, ctx.Param("id"), req.Members, userId, groups, isAdmin)
@@ -655,6 +662,7 @@ func handleRemoveCollectionMember(ctx *gin.Context) {
 		ID:       userId,
 		Groups:   groups,
 		Sub:      ctx.GetString("OIDCSub"),
+		Issuer:   ctx.GetString("OIDCIss"),
 	})
 
 	err = database.RemoveCollectionMembers(database.ServerDatabase, ctx.Param("id"), []string{objectURL}, userId, groups, isAdmin)
@@ -733,6 +741,7 @@ func handleAddCollectionMembers(ctx *gin.Context) {
 		ID:       userId,
 		Groups:   groups,
 		Sub:      ctx.GetString("OIDCSub"),
+		Issuer:   ctx.GetString("OIDCIss"),
 	})
 
 	err = database.AddCollectionMembers(database.ServerDatabase, ctx.Param("id"), req.Members, userId, groups, isAdmin)
@@ -945,6 +954,7 @@ func handlePutCollectionMetadata(ctx *gin.Context) {
 		ID:       userId,
 		Groups:   groups,
 		Sub:      ctx.GetString("OIDCSub"),
+		Issuer:   ctx.GetString("OIDCIss"),
 	}
 	isAdmin, _ := web_ui.CheckAdmin(identity)
 
@@ -1007,6 +1017,7 @@ func handleDeleteCollectionMetadata(ctx *gin.Context) {
 		ID:       userId,
 		Groups:   groups,
 		Sub:      ctx.GetString("OIDCSub"),
+		Issuer:   ctx.GetString("OIDCIss"),
 	}
 	isAdmin, _ := web_ui.CheckAdmin(identity)
 
@@ -1128,6 +1139,7 @@ func handleDeleteCollection(ctx *gin.Context) {
 		ID:       userId,
 		Groups:   groups,
 		Sub:      ctx.GetString("OIDCSub"),
+		Issuer:   ctx.GetString("OIDCIss"),
 	}
 	isAdmin, _ := web_ui.CheckAdmin(identity)
 
@@ -1253,6 +1265,7 @@ func handleGrantCollectionAcl(ctx *gin.Context) {
 		ID:       userId,
 		Groups:   groups,
 		Sub:      ctx.GetString("OIDCSub"),
+		Issuer:   ctx.GetString("OIDCIss"),
 	}
 	isAdmin, _ := web_ui.CheckAdmin(identity)
 
@@ -1332,6 +1345,7 @@ func handleRevokeCollectionAcl(ctx *gin.Context) {
 		ID:       userId,
 		Groups:   groups,
 		Sub:      ctx.GetString("OIDCSub"),
+		Issuer:   ctx.GetString("OIDCIss"),
 	}
 	isAdmin, _ := web_ui.CheckAdmin(identity)
 

--- a/origin/origin_ui_test.go
+++ b/origin/origin_ui_test.go
@@ -47,9 +47,14 @@ func generateToken(t *testing.T, scopes []token_scopes.TokenScope, subject strin
 	if len(groups) > 0 {
 		tk.AddGroups(groups...)
 	}
-	// Add OIDC claims required by GetUserGroups
+	// oidc_iss must match OIDC.Issuer (the identity provider), not the Pelican server URL.
+	// CheckAdmin compares identity.Issuer against param.OIDC_Issuer to prevent (sub, issuer)
+	// collisions when an operator switches identity providers.
+	oidcIssuer := param.OIDC_Issuer.GetString()
 	tk.Claims = map[string]string{
-		"user_id": subject,
+		"user_id":  subject,
+		"oidc_sub": subject,
+		"oidc_iss": oidcIssuer,
 	}
 	tok, err := tk.CreateToken()
 	require.NoError(t, err, "Failed to create token")

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -356,6 +356,7 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 		ID:       userId,
 		Groups:   groups,
 		Sub:      ctx.GetString("OIDCSub"),
+		Issuer:   ctx.GetString("OIDCIss"),
 	}
 	isAdmin, _ := web_ui.CheckAdmin(identity)
 
@@ -706,6 +707,7 @@ func getNamespace(ctx *gin.Context) {
 		ID:       userId,
 		Groups:   groups,
 		Sub:      ctx.GetString("OIDCSub"),
+		Issuer:   ctx.GetString("OIDCIss"),
 	}
 	isAdmin, _ := web_ui.CheckAdmin(identity)
 	belongsTo := false

--- a/web_ui/authentication.go
+++ b/web_ui/authentication.go
@@ -410,7 +410,7 @@ type UserIdentity struct {
 // The function checks the following in order:
 //  1. If user == "admin" (built-in admin)
 //  2. If any of the user's groups match Server.AdminGroups
-//  3. If any of the user's identifiers (Username, ID, Sub) match Server.UIAdminUsers
+//  3. If any of the user's identifier (Sub) match Server.UIAdminUsers
 //
 // Note: If you have a custom list of admin identifiers to check, set Server.UIAdminUsers.
 // If you want to grant admin privileges based on group membership, set Server.AdminGroups.
@@ -433,17 +433,12 @@ func CheckAdmin(identity UserIdentity) (isAdmin bool, message string) {
 		}
 	}
 
-	// Check admin users against all user identifiers
+	// Check admin users against the user's OIDC subject
 	adminList := param.Server_UIAdminUsers.GetStringSlice()
 	if param.Server_UIAdminUsers.IsSet() {
-		// Build list of all identifiers to check
-		identifiers := []string{identity.Username, identity.ID, identity.Sub}
-
 		for _, admin := range adminList {
-			for _, identifier := range identifiers {
-				if identifier != "" && identifier == admin {
-					return true, ""
-				}
+			if identity.Sub != "" && identity.Sub == admin {
+				return true, ""
 			}
 		}
 	}

--- a/web_ui/authentication.go
+++ b/web_ui/authentication.go
@@ -174,10 +174,15 @@ func extractUserFromBearerToken(ctx *gin.Context, tokenStr string) (user string,
 		}
 	}
 
-	// Extract oidc_sub claim for admin checks against UIAdminUsers
+	// Extract oidc_sub and oidc_iss for admin checks against UIAdminUsers
 	if oidcSubIface, ok := verified.Get("oidc_sub"); ok {
 		if oidcSub, ok := oidcSubIface.(string); ok && oidcSub != "" {
 			ctx.Set("OIDCSub", oidcSub)
+		}
+	}
+	if oidcIssIface, ok := verified.Get("oidc_iss"); ok {
+		if oidcIss, ok := oidcIssIface.(string); ok && oidcIss != "" {
+			ctx.Set("OIDCIss", oidcIss)
 		}
 	}
 
@@ -281,11 +286,15 @@ func GetUserGroups(ctx *gin.Context) (user string, userId string, groups []strin
 		return
 	}
 
-	// Extract oidc_sub claim (the OIDC subject identifier)
-	// This is set in context so admin checks can match against UIAdminUsers
+	// Extract oidc_sub and oidc_iss so admin checks can match against UIAdminUsers
 	if oidcSubIface, ok := parsed.Get("oidc_sub"); ok {
 		if oidcSub, ok := oidcSubIface.(string); ok && oidcSub != "" {
 			ctx.Set("OIDCSub", oidcSub)
+		}
+	}
+	if oidcIssIface, ok := parsed.Get("oidc_iss"); ok {
+		if oidcIss, ok := oidcIssIface.(string); ok && oidcIss != "" {
+			ctx.Set("OIDCIss", oidcIss)
 		}
 	}
 
@@ -324,6 +333,7 @@ func setLoginCookie(ctx *gin.Context, userRecord *database.User, groups []string
 		Username: loginCookieTokenCfg.Subject,
 		ID:       userRecord.ID,
 		Sub:      userRecord.Sub,
+		Issuer:   userRecord.Issuer,
 		Groups:   groups,
 	}
 	if isAdmin, _ := CheckAdmin(identity); isAdmin {
@@ -401,6 +411,7 @@ type UserIdentity struct {
 	Username string
 	ID       string
 	Sub      string // OIDC Subject
+	Issuer   string // OIDC Issuer (the "iss" claim from the identity provider)
 	Groups   []string
 }
 
@@ -410,9 +421,12 @@ type UserIdentity struct {
 // The function checks the following in order:
 //  1. If user == "admin" (built-in admin)
 //  2. If any of the user's groups match Server.AdminGroups
-//  3. If any of the user's identifier (Sub) match Server.UIAdminUsers
+//  3. If the user's (Sub, Issuer) pair matches an entry in Server.UIAdminUsers and OIDC.Issuer
 //
-// Note: If you have a custom list of admin identifiers to check, set Server.UIAdminUsers.
+// Note: For OIDC users, both the subject claim and the issuer must be present and the issuer
+// must match the configured OIDC.Issuer. This prevents sub-claim collisions across identity
+// providers if the server ever switches issuers.
+// If you have a custom list of admin identifiers to check, set Server.UIAdminUsers.
 // If you want to grant admin privileges based on group membership, set Server.AdminGroups.
 func CheckAdmin(identity UserIdentity) (isAdmin bool, message string) {
 	if identity.Username == "admin" {
@@ -433,13 +447,27 @@ func CheckAdmin(identity UserIdentity) (isAdmin bool, message string) {
 		}
 	}
 
-	// Check admin users against the user's OIDC subject
+	// Check admin users against the user's OIDC (sub, issuer) pair.
+	// Both must be present and the issuer must match the configured OIDC issuer to
+	// prevent a user from a different identity provider from gaining access if their
+	// sub happens to collide with a configured admin's sub.
 	adminList := param.Server_UIAdminUsers.GetStringSlice()
 	if param.Server_UIAdminUsers.IsSet() {
+		configuredIssuer := param.OIDC_Issuer.GetString()
 		for _, admin := range adminList {
-			if identity.Sub != "" && identity.Sub == admin {
-				return true, ""
+			if identity.Sub == "" || identity.Issuer == "" {
+				continue
 			}
+			if identity.Sub != admin {
+				continue
+			}
+			// Sub matches — also verify the issuer matches the configured OIDC provider.
+			// We use GetString() (not IsSet()) so that the default issuer (cilogon.org)
+			// is enforced even when OIDC.Issuer is not explicitly set in config.
+			if configuredIssuer != "" && identity.Issuer != configuredIssuer {
+				continue
+			}
+			return true, ""
 		}
 	}
 
@@ -477,6 +505,7 @@ func AdminAuthHandler(ctx *gin.Context) {
 		Groups:   groups,
 		ID:       ctx.GetString("UserId"),
 		Sub:      ctx.GetString("OIDCSub"),
+		Issuer:   ctx.GetString("OIDCIss"),
 	}
 
 	isAdmin, msg := CheckAdmin(identity)
@@ -504,6 +533,7 @@ func DowntimeAuthHandler(ctx *gin.Context) {
 			ID:       userId,
 			Groups:   groups,
 			Sub:      ctx.GetString("OIDCSub"),
+			Issuer:   ctx.GetString("OIDCIss"),
 		}
 
 		// User has valid cookie, check if admin
@@ -752,6 +782,7 @@ func whoamiHandler(ctx *gin.Context) {
 			ID:       userId,
 			Groups:   groups,
 			Sub:      ctx.GetString("OIDCSub"),
+			Issuer:   ctx.GetString("OIDCIss"),
 		}
 		isAdmin, _ := CheckAdmin(identity)
 		if isAdmin {

--- a/web_ui/authentication_test.go
+++ b/web_ui/authentication_test.go
@@ -539,13 +539,24 @@ func TestCheckAdmin(t *testing.T) {
 			expectedMsg:   "",
 		},
 		{
-			name:          "user-in-admin-users-list",
+			name:          "user-in-admin-users-list-by-sub",
 			user:          "admin1",
+			sub:           "admin1-oidc-sub",
 			groups:        nil,
-			adminUsers:    []string{"admin1", "admin2"},
+			adminUsers:    []string{"admin1-oidc-sub", "admin2-oidc-sub"},
 			adminGroups:   nil,
 			expectedAdmin: true,
 			expectedMsg:   "",
+		},
+		{
+			name:          "username-in-admin-users-but-sub-is-not",
+			user:          "admin1",
+			sub:           "different-oidc-sub",
+			groups:        nil,
+			adminUsers:    []string{"admin1", "admin2"},
+			adminGroups:   nil,
+			expectedAdmin: false,
+			expectedMsg:   "You don't have permission to perform this action",
 		},
 		{
 			name:          "user-not-in-admin-users-list",
@@ -584,10 +595,11 @@ func TestCheckAdmin(t *testing.T) {
 			expectedMsg:   "You don't have permission to perform this action",
 		},
 		{
-			name:          "user-in-admin-group-and-admin-users",
+			name:          "user-in-admin-group-and-admin-users-by-sub",
 			user:          "user1",
+			sub:           "user1-oidc-sub",
 			groups:        []string{"pelican-admins"},
-			adminUsers:    []string{"user1"},
+			adminUsers:    []string{"user1-oidc-sub"},
 			adminGroups:   []string{"pelican-admins"},
 			expectedAdmin: true,
 			expectedMsg:   "",
@@ -602,10 +614,11 @@ func TestCheckAdmin(t *testing.T) {
 			expectedMsg:   "",
 		},
 		{
-			name:          "user-in-admin-users-not-in-admin-group",
+			name:          "user-sub-in-admin-users-not-in-admin-group",
 			user:          "user1",
+			sub:           "user1-oidc-sub",
 			groups:        []string{"pelican-users"},
-			adminUsers:    []string{"user1"},
+			adminUsers:    []string{"user1-oidc-sub"},
 			adminGroups:   []string{"pelican-admins"},
 			expectedAdmin: true,
 			expectedMsg:   "",
@@ -655,15 +668,15 @@ func TestCheckAdmin(t *testing.T) {
 			expectedAdmin: false,
 			expectedMsg:   "You don't have permission to perform this action",
 		},
-		// Test cases for ID-based admin matching (#3050)
+		// Test cases verifying only Sub is used for admin matching
 		{
-			name:          "user-matched-by-id",
+			name:          "id-in-admin-users-but-sub-is-not",
 			user:          "user1",
 			id:            "internal-id-123",
 			adminUsers:    []string{"internal-id-123"},
 			adminGroups:   nil,
-			expectedAdmin: true,
-			expectedMsg:   "",
+			expectedAdmin: false,
+			expectedMsg:   "You don't have permission to perform this action",
 		},
 		{
 			name:          "user-matched-by-sub",
@@ -675,13 +688,13 @@ func TestCheckAdmin(t *testing.T) {
 			expectedMsg:   "",
 		},
 		{
-			name:          "user-matched-by-id-not-username",
+			name:          "id-in-admin-users-sub-absent",
 			user:          "user1",
 			id:            "internal-id-456",
 			adminUsers:    []string{"internal-id-456", "other-admin"},
 			adminGroups:   nil,
-			expectedAdmin: true,
-			expectedMsg:   "",
+			expectedAdmin: false,
+			expectedMsg:   "You don't have permission to perform this action",
 		},
 		{
 			name:          "user-matched-by-sub-not-username",
@@ -723,11 +736,11 @@ func TestCheckAdmin(t *testing.T) {
 			expectedMsg:   "You don't have permission to perform this action",
 		},
 		{
-			name:          "username-changed-but-id-still-matches",
+			name:          "username-changed-but-sub-still-matches",
 			user:          "new-display-name",
 			id:            "stable-id-001",
 			sub:           "oidc-sub-001",
-			adminUsers:    []string{"stable-id-001"},
+			adminUsers:    []string{"oidc-sub-001"},
 			adminGroups:   nil,
 			expectedAdmin: true,
 			expectedMsg:   "",
@@ -799,16 +812,18 @@ func TestAdminAuthHandler(t *testing.T) {
 		{
 			name: "specific-admin-user-access",
 			setupUserFunc: func(ctx *gin.Context) {
-				require.NoError(t, param.Server_UIAdminUsers.Set([]string{"admin1", "admin2"}))
+				require.NoError(t, param.Server_UIAdminUsers.Set([]string{"admin1-oidc-sub", "admin2-oidc-sub"}))
 				ctx.Set("User", "admin1")
+				ctx.Set("OIDCSub", "admin1-oidc-sub")
 			},
 			expectedCode: http.StatusOK,
 		},
 		{
 			name: "non-admin-user-access",
 			setupUserFunc: func(ctx *gin.Context) {
-				require.NoError(t, param.Server_UIAdminUsers.Set([]string{"admin1", "admin2"}))
+				require.NoError(t, param.Server_UIAdminUsers.Set([]string{"admin1-oidc-sub", "admin2-oidc-sub"}))
 				ctx.Set("User", "user")
+				ctx.Set("OIDCSub", "user-oidc-sub")
 			},
 			expectedCode:  http.StatusForbidden,
 			expectedError: "You don't have permission to perform this action",
@@ -825,8 +840,9 @@ func TestAdminAuthHandler(t *testing.T) {
 		{
 			name: "admin-list-multiple-users",
 			setupUserFunc: func(ctx *gin.Context) {
-				require.NoError(t, param.Server_UIAdminUsers.Set([]string{"admin1", "admin2", "admin3"}))
+				require.NoError(t, param.Server_UIAdminUsers.Set([]string{"admin1-sub", "admin2-sub", "admin3-sub"}))
 				ctx.Set("User", "admin2")
+				ctx.Set("OIDCSub", "admin2-sub")
 			},
 			expectedCode: http.StatusOK,
 		},

--- a/web_ui/authentication_test.go
+++ b/web_ui/authentication_test.go
@@ -523,9 +523,11 @@ func TestCheckAdmin(t *testing.T) {
 		user          string
 		id            string
 		sub           string
+		issuer        string
 		groups        []string
 		adminUsers    []string
 		adminGroups   []string
+		oidcIssuer    string // when set, configures OIDC.Issuer param
 		expectedAdmin bool
 		expectedMsg   string
 	}{
@@ -542,6 +544,7 @@ func TestCheckAdmin(t *testing.T) {
 			name:          "user-in-admin-users-list-by-sub",
 			user:          "admin1",
 			sub:           "admin1-oidc-sub",
+			issuer:        "https://cilogon.org",
 			groups:        nil,
 			adminUsers:    []string{"admin1-oidc-sub", "admin2-oidc-sub"},
 			adminGroups:   nil,
@@ -598,6 +601,7 @@ func TestCheckAdmin(t *testing.T) {
 			name:          "user-in-admin-group-and-admin-users-by-sub",
 			user:          "user1",
 			sub:           "user1-oidc-sub",
+			issuer:        "https://cilogon.org",
 			groups:        []string{"pelican-admins"},
 			adminUsers:    []string{"user1-oidc-sub"},
 			adminGroups:   []string{"pelican-admins"},
@@ -617,6 +621,7 @@ func TestCheckAdmin(t *testing.T) {
 			name:          "user-sub-in-admin-users-not-in-admin-group",
 			user:          "user1",
 			sub:           "user1-oidc-sub",
+			issuer:        "https://cilogon.org",
 			groups:        []string{"pelican-users"},
 			adminUsers:    []string{"user1-oidc-sub"},
 			adminGroups:   []string{"pelican-admins"},
@@ -682,6 +687,7 @@ func TestCheckAdmin(t *testing.T) {
 			name:          "user-matched-by-sub",
 			user:          "user1",
 			sub:           "http://cilogon.org/serverA/users/12345",
+			issuer:        "https://cilogon.org",
 			adminUsers:    []string{"http://cilogon.org/serverA/users/12345"},
 			adminGroups:   nil,
 			expectedAdmin: true,
@@ -700,6 +706,7 @@ func TestCheckAdmin(t *testing.T) {
 			name:          "user-matched-by-sub-not-username",
 			user:          "user1",
 			sub:           "oidc-sub-789",
+			issuer:        "https://cilogon.org",
 			adminUsers:    []string{"oidc-sub-789"},
 			adminGroups:   nil,
 			expectedAdmin: true,
@@ -740,10 +747,32 @@ func TestCheckAdmin(t *testing.T) {
 			user:          "new-display-name",
 			id:            "stable-id-001",
 			sub:           "oidc-sub-001",
+			issuer:        "https://cilogon.org",
 			adminUsers:    []string{"oidc-sub-001"},
 			adminGroups:   nil,
 			expectedAdmin: true,
 			expectedMsg:   "",
+		},
+		{
+			name:          "sub-matches-but-issuer-mismatch-when-oidc-issuer-configured",
+			user:          "user1",
+			sub:           "oidc-sub-001",
+			issuer:        "https://evil-provider.example.com",
+			adminUsers:    []string{"oidc-sub-001"},
+			adminGroups:   nil,
+			oidcIssuer:    "https://cilogon.org",
+			expectedAdmin: false,
+			expectedMsg:   "You don't have permission to perform this action",
+		},
+		{
+			name:          "sub-matches-issuer-absent-denied",
+			user:          "user1",
+			sub:           "oidc-sub-001",
+			issuer:        "",
+			adminUsers:    []string{"oidc-sub-001"},
+			adminGroups:   nil,
+			expectedAdmin: false,
+			expectedMsg:   "You don't have permission to perform this action",
 		},
 	}
 
@@ -763,6 +792,11 @@ func TestCheckAdmin(t *testing.T) {
 				require.NoError(t, param.Server_AdminGroups.Set(tc.adminGroups))
 			}
 
+			// Configure OIDC.Issuer if specified (used to validate issuer in CheckAdmin)
+			if tc.oidcIssuer != "" {
+				require.NoError(t, param.OIDC_Issuer.Set(tc.oidcIssuer))
+			}
+
 			// Call CheckAdmin
 			var isAdmin bool
 			var msg string
@@ -770,6 +804,7 @@ func TestCheckAdmin(t *testing.T) {
 				Username: tc.user,
 				ID:       tc.id,
 				Sub:      tc.sub,
+				Issuer:   tc.issuer,
 				Groups:   tc.groups,
 			}
 			isAdmin, msg = CheckAdmin(identity)
@@ -815,6 +850,7 @@ func TestAdminAuthHandler(t *testing.T) {
 				require.NoError(t, param.Server_UIAdminUsers.Set([]string{"admin1-oidc-sub", "admin2-oidc-sub"}))
 				ctx.Set("User", "admin1")
 				ctx.Set("OIDCSub", "admin1-oidc-sub")
+				ctx.Set("OIDCIss", "https://test-issuer.example.com")
 			},
 			expectedCode: http.StatusOK,
 		},
@@ -843,6 +879,7 @@ func TestAdminAuthHandler(t *testing.T) {
 				require.NoError(t, param.Server_UIAdminUsers.Set([]string{"admin1-sub", "admin2-sub", "admin3-sub"}))
 				ctx.Set("User", "admin2")
 				ctx.Set("OIDCSub", "admin2-sub")
+				ctx.Set("OIDCIss", "https://test-issuer.example.com")
 			},
 			expectedCode: http.StatusOK,
 		},

--- a/web_ui/groups.go
+++ b/web_ui/groups.go
@@ -205,6 +205,7 @@ func handleUpdateGroup(ctx *gin.Context) {
 		ID:       userId,
 		Groups:   groups,
 		Sub:      ctx.GetString("OIDCSub"),
+		Issuer:   ctx.GetString("OIDCIss"),
 	})
 
 	if err := database.UpdateGroup(database.ServerDatabase, id, req.Name, req.Description, userId, isAdmin); err != nil {
@@ -331,6 +332,7 @@ func handleAddGroupMember(ctx *gin.Context) {
 		ID:       userId,
 		Groups:   groups,
 		Sub:      ctx.GetString("OIDCSub"),
+		Issuer:   ctx.GetString("OIDCIss"),
 	}
 	isAdmin, _ := CheckAdmin(identity)
 
@@ -462,6 +464,7 @@ func handleRemoveGroupMember(ctx *gin.Context) {
 		ID:       userId,
 		Groups:   groups,
 		Sub:      ctx.GetString("OIDCSub"),
+		Issuer:   ctx.GetString("OIDCIss"),
 	}
 	isAdmin, _ := CheckAdmin(identity)
 
@@ -620,6 +623,7 @@ func handleUpdateUser(ctx *gin.Context) {
 		ID:       userId,
 		Groups:   groups,
 		Sub:      ctx.GetString("OIDCSub"),
+		Issuer:   ctx.GetString("OIDCIss"),
 	})
 
 	// Verify authorization: only the user themselves or an admin can update
@@ -704,6 +708,7 @@ func handleDeleteGroup(ctx *gin.Context) {
 		ID:       userId,
 		Groups:   groups,
 		Sub:      ctx.GetString("OIDCSub"),
+		Issuer:   ctx.GetString("OIDCIss"),
 	})
 
 	if err := database.DeleteGroup(database.ServerDatabase, id, userId, isAdmin); err != nil {
@@ -766,6 +771,7 @@ func handleDeleteUser(ctx *gin.Context) {
 		ID:       userId,
 		Groups:   groups,
 		Sub:      ctx.GetString("OIDCSub"),
+		Issuer:   ctx.GetString("OIDCIss"),
 	})
 
 	if err := database.DeleteUser(database.ServerDatabase, id, userId, isAdmin); err != nil {

--- a/web_ui/oauth2_client.go
+++ b/web_ui/oauth2_client.go
@@ -295,6 +295,12 @@ func generateUserGroupInfo(userInfo map[string]interface{}, idToken map[string]i
 	}
 	username := displayName
 
+	if username == "admin" {
+		log.Errorln("OIDC login rejected: username 'admin' is reserved by the system")
+		err = errors.New("username 'admin' is reserved; configure your identity provider to use a different name")
+		return
+	}
+
 	// Get the subject (sub) claim - this uniquely identifies the user at the identity provider
 	// For OIDC, this is the standard "sub" claim. For OAuth2 providers like GitHub, we may need
 	// to use a different claim (e.g., "id" for GitHub)

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -339,6 +339,7 @@ func handleWebUIAuth(ctx *gin.Context) {
 			ID:       userId,
 			Groups:   groups,
 			Sub:      ctx.GetString("OIDCSub"),
+			Issuer:   ctx.GetString("OIDCIss"),
 		}
 		isAdmin, _ := CheckAdmin(identity)
 		if isAdmin {

--- a/web_ui/ui_test.go
+++ b/web_ui/ui_test.go
@@ -511,16 +511,21 @@ func TestServerHostRestart(t *testing.T) {
 func generateTestAdminUserToken(t *testing.T) string {
 	// Create token for admin user in test
 	tk := token.NewWLCGToken()
-	issuer := param.Server_ExternalWebUrl.GetString()
-	require.NotEmpty(t, issuer, "Server ExternalWebUrl must be set for tests")
-	tk.Issuer = issuer
+	serverIssuer := param.Server_ExternalWebUrl.GetString()
+	require.NotEmpty(t, serverIssuer, "Server ExternalWebUrl must be set for tests")
+	tk.Issuer = serverIssuer
 	tk.Subject = "admin-user"
 	tk.Lifetime = 5 * time.Minute
-	tk.AddAudiences(param.Server_ExternalWebUrl.GetString())
+	tk.AddAudiences(serverIssuer)
 	tk.AddScopes(token_scopes.WebUi_Access)
-	// Add OIDC claims required by GetUserGroups
+	// oidc_iss must match OIDC.Issuer (the identity provider), not the Pelican server URL.
+	// CheckAdmin compares identity.Issuer against param.OIDC_Issuer to prevent (sub, issuer)
+	// collisions when an operator switches identity providers.
+	oidcIssuer := param.OIDC_Issuer.GetString()
 	tk.Claims = map[string]string{
-		"user_id": "admin-user",
+		"user_id":  "admin-user",
+		"oidc_sub": "admin-user",
+		"oidc_iss": oidcIssuer,
 	}
 	tok, err := tk.CreateToken()
 	if err != nil {
@@ -531,16 +536,19 @@ func generateTestAdminUserToken(t *testing.T) string {
 
 func generateToken(t *testing.T, scopes []token_scopes.TokenScope, subject string) string {
 	tk := token.NewWLCGToken()
-	issuer := param.Server_ExternalWebUrl.GetString()
-	require.NotEmpty(t, issuer, "Server ExternalWebUrl must be set for tests")
-	tk.Issuer = issuer
+	serverIssuer := param.Server_ExternalWebUrl.GetString()
+	require.NotEmpty(t, serverIssuer, "Server ExternalWebUrl must be set for tests")
+	tk.Issuer = serverIssuer
 	tk.Subject = subject
 	tk.Lifetime = 5 * time.Minute
-	tk.AddAudiences(param.Server_ExternalWebUrl.GetString())
+	tk.AddAudiences(serverIssuer)
 	tk.AddScopes(scopes...)
-	// Add OIDC claims required by GetUserGroups
+	// oidc_iss must match OIDC.Issuer (the identity provider), not the Pelican server URL.
+	oidcIssuer := param.OIDC_Issuer.GetString()
 	tk.Claims = map[string]string{
-		"user_id": subject,
+		"user_id":  subject,
+		"oidc_sub": subject,
+		"oidc_iss": oidcIssuer,
 	}
 	tok, err := tk.CreateToken()
 	if err != nil {

--- a/web_ui/ui_test.go
+++ b/web_ui/ui_test.go
@@ -1168,8 +1168,8 @@ func TestGroupManagementAPI(t *testing.T) {
 		userID := createUserResp["id"]
 		require.NotEmpty(t, userID)
 
-		// Create a collection ACL entry referencing the user's implicit personal group name
-		personalGroup := "user-" + username
+		// Create a collection ACL entry referencing the user's implicit personal group (keyed by user ID)
+		personalGroup := "user-" + userID
 		col, err := database.CreateCollection(database.ServerDatabase, "col-for-user-delete", "desc", "owner-user2", "/test2", database.VisibilityPrivate)
 		require.NoError(t, err)
 		acl := database.CollectionACL{


### PR DESCRIPTION
When I was working on this PR, I noticed plenty of confusing concepts and behavior in user and group logics. In this PR description, I am going write them down and the fixes I made, also why I came up with that fix.

### `username` is a display name, not an identity key

Pelican resolves username from the OIDC UserInfo response by trying these claims in order: preferred_username, name, nickname, email, and finally sub as a last resort. The result is mutable — the provider can change it, and before this PR an admin could change it too. It is also not globally unique: two users from different issuers can share the same display name.

The real, stable identity of an OIDC user is the (sub, issuer) pair, enforced by the idx_user_sub_issuer unique constraint. Pelican also assigns an internal userId (an 8-character hex slug) at user creation that never changes. These are the correct handles to use when referring to a specific user persistently.

### Replace username with userId in personal group names and collection references

Problem: personal groups follow the pattern "user-\<identifier\>". Before this PR, identifier was the mutable username. A display name change — at the OIDC provider or via the admin API — silently orphaned the old "user-<username>" entries in collection_acls, causing the user to lose access to their own collections with no error.

Implementation note: personal groups are virtual. They are never stored as rows in the groups table. The "user-\<identifier\>" string is computed at runtime in ListCollections and validateACL and injected into the groups slice before any ACL lookup. The only persisted reference is in collection_acls.group_id (despite the column name, it stores a group name string, not a foreign key).

Fix: switch identifier to userId.  The DB migration updates the following fields:
a) collection_acls.group_id where it matches "user-\<username\>" → "user-\<userId\>"
b) collection_acls.granted_by from username → userId
c) collections.owner from username → userId

### Auto create user records for everyone in `Server.UIAdminUsers` (a list of OIDC subs)

Let the pre-set admin's OIDC sub values to be "claimed" in the database on startup, before any attacker can register them. When this user actually logs in, the placeholder username (defaults to OIDC sub) will be overwritten by this user's real username (a.k.a display name).

### Reject "admin" username for OIDC users

Before this commit, any OIDC user could gain superadmin privileges if their OIDC claim (preferred_username, name, nickname, or email, checked in that order) resolved to 'admin'. This occurred due to a hardcoded username check in the CheckAdmin function.

### Drop the (username, issuer) unique constraint

The users table had a composite unique index idx_user_issuer on (username, issuer). This implicitly treated username as part of the identity key — it prevented two accounts at the same provider from sharing a display name. That assumption is wrong. Display names can legitimately collide, and the constraint would also reject the username-refresh behavior introduced in this PR (refreshing username on each login to reflect the latest OIDC value fails if another user at the same issuer already holds that display name).

The correct identity uniqueness is already enforced by idx_user_sub_issuer on (sub, issuer), which is unchanged.

### Only check `identity.Sub` against `UIAdminUsers` in CheckAdmin

Before, CheckAdmin matched all three of Username, ID (the internal hex slug), and Sub against Server.UIAdminUsers. The intent was flexibility, but checking Username meant the list was effectively matched by mutable display name. 

Now, only Sub is checked against UIAdminUsers, which is a list consist by OIDC sub values.
