### PR TITLE
Make shutdown routines more robust

### DIFF
--- a/ssh_posixv2/helper.go
+++ b/ssh_posixv2/helper.go
@@ -174,14 +174,17 @@ func (c *SSHConnection) StartHelper(ctx context.Context, helperConfig *HelperCon
 		return errors.Wrap(err, "failed to write newline to helper stdin")
 	}
 
-	// Create errgroup for managing helper goroutines
-	egrp, egrpCtx := errgroup.WithContext(ctx)
+	// Create errgroup for managing helper goroutines. We layer a separate
+	// cancellable context on top of the caller's so StopHelper can actively
+	// wake ticker-driven goroutines (runPongMonitor / runStdinKeepalive)
+	// without waiting for their next tick. Without this, the SIGKILL
+	// fallback path nils helperIO while those goroutines are still ticking
+	// and they panic on the stale field deref.
+	cancelCtx, cancel := context.WithCancel(ctx)
+	egrp, egrpCtx := errgroup.WithContext(cancelCtx)
 	c.helperErrgroup = egrp
 	c.helperCtx = egrpCtx
-	c.helperCancel = func() {
-		// Signal shutdown via stdin before cancelling context
-		_ = c.sendShutdownMessage()
-	}
+	c.helperCancel = cancel
 
 	// Goroutine: Read helper stdout for pong responses
 	egrp.Go(func() error {
@@ -240,6 +243,14 @@ func (c *SSHConnection) StartHelper(ctx context.Context, helperConfig *HelperCon
 // readHelperStdout reads and processes stdout messages from the helper.
 // It parses JSON messages for pong responses and ready notifications.
 func (c *SSHConnection) readHelperStdout(ctx context.Context) error {
+	// Snapshot helperIO once. StopHelper nils c.helperIO during teardown;
+	// holding our own pointer keeps the underlying struct reachable for
+	// the rest of this goroutine's life and avoids a nil-deref race.
+	helperIO := c.helperIO
+	if helperIO == nil {
+		return nil
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -247,9 +258,9 @@ func (c *SSHConnection) readHelperStdout(ctx context.Context) error {
 		default:
 		}
 
-		c.helperIO.stdoutMu.Lock()
-		line, err := c.helperIO.stdoutReader.ReadBytes('\n')
-		c.helperIO.stdoutMu.Unlock()
+		helperIO.stdoutMu.Lock()
+		line, err := helperIO.stdoutReader.ReadBytes('\n')
+		helperIO.stdoutMu.Unlock()
 
 		if err != nil {
 			if err == io.EOF {
@@ -274,19 +285,19 @@ func (c *SSHConnection) readHelperStdout(ctx context.Context) error {
 		switch msg.Type {
 		case "ready":
 			sshLog.Info("Helper process is ready")
-			c.helperIO.helperReady.Store(true)
-			c.helperIO.lastPong.Store(time.Now())
+			helperIO.helperReady.Store(true)
+			helperIO.lastPong.Store(time.Now())
 
 		case "listening":
 			if msg.SocketPath != "" {
 				sshLog.Infof("Helper listening on unix socket %s (direct-listen mode)", msg.SocketPath)
-				c.helperIO.helperSocketPath.Store(msg.SocketPath)
+				helperIO.helperSocketPath.Store(msg.SocketPath)
 			}
 
 		case "pong":
-			c.helperIO.lastPong.Store(time.Now())
+			helperIO.lastPong.Store(time.Now())
 			if msg.Uptime != "" {
-				c.helperIO.helperUptime.Store(msg.Uptime)
+				helperIO.helperUptime.Store(msg.Uptime)
 			}
 			sshLog.Debugf("Received pong from helper (uptime: %s)", msg.Uptime)
 
@@ -420,19 +431,27 @@ func (c *SSHConnection) runStdinKeepalive(ctx context.Context) error {
 
 // sendPing sends a ping message to the helper via stdin
 func (c *SSHConnection) sendPing() error {
+	// Snapshot helperIO so a concurrent StopHelper that nils it (or its
+	// stdin) can't turn this into a nil deref. sendShutdownMessage uses
+	// the same pattern.
+	helperIO := c.helperIO
+	if helperIO == nil || helperIO.stdin == nil {
+		return errors.New("helper IO not initialized")
+	}
+
 	msg := StdinMessage{Type: "ping"}
 	data, err := json.Marshal(msg)
 	if err != nil {
 		return err
 	}
 
-	c.helperIO.stdinMu.Lock()
-	defer c.helperIO.stdinMu.Unlock()
+	helperIO.stdinMu.Lock()
+	defer helperIO.stdinMu.Unlock()
 
-	if _, err := c.helperIO.stdin.Write(data); err != nil {
+	if _, err := helperIO.stdin.Write(data); err != nil {
 		return err
 	}
-	if _, err := c.helperIO.stdin.Write([]byte("\n")); err != nil {
+	if _, err := helperIO.stdin.Write([]byte("\n")); err != nil {
 		return err
 	}
 	return nil
@@ -470,6 +489,15 @@ func (c *SSHConnection) runPongMonitor(ctx context.Context) error {
 		timeout = c.helperConfig.KeepaliveTimeout
 	}
 
+	// Snapshot helperIO once: StopHelper sets c.helperIO = nil during
+	// teardown, and a nil deref on c.helperIO.lastPong here is the panic
+	// reported in #3363. Holding our own pointer keeps the atomic.Value
+	// reachable for the rest of the goroutine's life.
+	helperIO := c.helperIO
+	if helperIO == nil {
+		return nil
+	}
+
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 
@@ -478,7 +506,14 @@ func (c *SSHConnection) runPongMonitor(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			lastPong := c.helperIO.lastPong.Load().(time.Time)
+			v := helperIO.lastPong.Load()
+			lastPong, ok := v.(time.Time)
+			if !ok {
+				// Never Stored (shouldn't happen — StartHelper Stores
+				// time.Now() before launching this goroutine — but treat
+				// as "just received" rather than panic).
+				continue
+			}
 			if time.Since(lastPong) > timeout {
 				sshLog.Warnf("Helper keepalive timeout exceeded (last pong: %v ago, timeout: %v)",
 					time.Since(lastPong), timeout)
@@ -562,11 +597,28 @@ func (c *SSHConnection) StopHelper(ctx context.Context) error {
 			}
 			c.session.Close()
 
+			// Cancel the helper context too, so ticker-driven goroutines
+			// (runPongMonitor / runStdinKeepalive) wake up immediately
+			// instead of waiting for their next tick.
+			if c.helperCancel != nil {
+				c.helperCancel()
+			}
+
 			select {
 			case <-done:
 				sshLog.Info("Helper process stopped after SIGKILL")
 			case <-time.After(5 * time.Second):
-				sshLog.Warn("Helper errgroup did not finish after SIGKILL, forcing cleanup")
+				// Last-resort wait so we don't nil helperIO out from
+				// under still-running goroutines and trigger nil-deref
+				// panics. Goroutines now snapshot helperIO and tolerate
+				// it being nil, but giving them a final chance to exit
+				// cleanly avoids spurious "stdin closed" errors in logs.
+				sshLog.Warn("Helper errgroup did not finish after SIGKILL; waiting briefly before forcing cleanup")
+				select {
+				case <-done:
+				case <-time.After(2 * time.Second):
+					sshLog.Warn("Helper errgroup did not finish; goroutines may leak")
+				}
 			}
 		}
 	}
@@ -578,6 +630,12 @@ func (c *SSHConnection) StopHelper(ctx context.Context) error {
 
 	if c.session != nil {
 		c.session.Close()
+	}
+	// Cancel the helper context if it hasn't been already, so anything
+	// still running notices we're shutting down.
+	if c.helperCancel != nil {
+		c.helperCancel()
+		c.helperCancel = nil
 	}
 	c.session = nil
 	c.helperIO = nil
@@ -620,7 +678,12 @@ func (c *SSHConnection) runSSHKeepalive(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if c.client == nil {
+			// Snapshot c.client once so a concurrent Close() that nils it
+			// can't turn a non-nil check into a nil-deref on SendRequest
+			// below. SendRequest on an already-closed *ssh.Client returns
+			// an error rather than panicking, so a stale snapshot is safe.
+			client := c.client
+			if client == nil {
 				continue
 			}
 
@@ -635,7 +698,7 @@ func (c *SSHConnection) runSSHKeepalive(ctx context.Context) {
 
 			// Send a keepalive request
 			// The "keepalive@openssh.com" request is a standard SSH keepalive
-			_, _, err := c.client.SendRequest("keepalive@openssh.com", true, nil)
+			_, _, err := client.SendRequest("keepalive@openssh.com", true, nil)
 			if err != nil {
 				sshLog.Warnf("SSH keepalive failed: %v", err)
 				// Don't immediately close - let the timeout handle it
@@ -651,14 +714,18 @@ func (c *SSHConnection) runSSHKeepalive(ctx context.Context) {
 // GetHelperStatus queries the helper for its status using the stdin/stdout protocol.
 // This does not require the helper to listen on any TCP port.
 func (c *SSHConnection) GetHelperStatus(ctx context.Context) (*HelperStatus, error) {
-	if c.session == nil || c.helperIO == nil {
+	// Snapshot helperIO once so a concurrent StopHelper that nils it
+	// can't turn the field reads below into a nil-deref or surface a
+	// type-assertion panic on a nil interface from Load().
+	helperIO := c.helperIO
+	if c.session == nil || helperIO == nil {
 		return &HelperStatus{
 			State:   HelperStateNotStarted,
 			Message: "Helper not started",
 		}, nil
 	}
 
-	if !c.helperIO.helperReady.Load() {
+	if !helperIO.helperReady.Load() {
 		return &HelperStatus{
 			State:   HelperStateStarting,
 			Message: "Helper starting",
@@ -666,7 +733,17 @@ func (c *SSHConnection) GetHelperStatus(ctx context.Context) (*HelperStatus, err
 	}
 
 	// Check if we've received a recent pong
-	lastPong := c.helperIO.lastPong.Load().(time.Time)
+	v := helperIO.lastPong.Load()
+	lastPong, ok := v.(time.Time)
+	if !ok {
+		// Should not happen — StartHelper Stores time.Now() before
+		// returning — but treat the absence as "starting" rather than
+		// panic.
+		return &HelperStatus{
+			State:   HelperStateStarting,
+			Message: "Helper starting",
+		}, nil
+	}
 	timeout := DefaultKeepaliveTimeout
 	if c.helperConfig != nil && c.helperConfig.KeepaliveTimeout > 0 {
 		timeout = c.helperConfig.KeepaliveTimeout
@@ -679,7 +756,7 @@ func (c *SSHConnection) GetHelperStatus(ctx context.Context) (*HelperStatus, err
 		}, nil
 	}
 
-	uptime := c.helperIO.helperUptime.Load().(string)
+	uptime, _ := helperIO.helperUptime.Load().(string)
 	return &HelperStatus{
 		State:   HelperStateRunning,
 		Uptime:  uptime,

--- a/ssh_posixv2/helper.go
+++ b/ssh_posixv2/helper.go
@@ -138,13 +138,16 @@ func (c *SSHConnection) StartHelper(ctx context.Context, helperConfig *HelperCon
 		return errors.Wrap(err, "failed to get stderr pipe")
 	}
 
-	// Initialize helper IO management
-	c.helperIO = &helperIO{
+	// Initialize helper IO management. Populate the struct fully before
+	// publishing it via Store so readers never observe a partially-built
+	// helperIO.
+	hio := &helperIO{
 		stdin:        stdin,
 		stdoutReader: bufio.NewReader(stdout),
 	}
-	c.helperIO.lastPong.Store(time.Now())
-	c.helperIO.helperUptime.Store("")
+	hio.lastPong.Store(time.Now())
+	hio.helperUptime.Store("")
+	c.helperIO.Store(hio)
 
 	// Serialize the helper configuration
 	configJSON, err := json.Marshal(helperConfig)
@@ -243,10 +246,10 @@ func (c *SSHConnection) StartHelper(ctx context.Context, helperConfig *HelperCon
 // readHelperStdout reads and processes stdout messages from the helper.
 // It parses JSON messages for pong responses and ready notifications.
 func (c *SSHConnection) readHelperStdout(ctx context.Context) error {
-	// Snapshot helperIO once. StopHelper nils c.helperIO during teardown;
+	// Snapshot helperIO once. StopHelper clears c.helperIO during teardown;
 	// holding our own pointer keeps the underlying struct reachable for
 	// the rest of this goroutine's life and avoids a nil-deref race.
-	helperIO := c.helperIO
+	helperIO := c.helperIO.Load()
 	if helperIO == nil {
 		return nil
 	}
@@ -431,10 +434,10 @@ func (c *SSHConnection) runStdinKeepalive(ctx context.Context) error {
 
 // sendPing sends a ping message to the helper via stdin
 func (c *SSHConnection) sendPing() error {
-	// Snapshot helperIO so a concurrent StopHelper that nils it (or its
+	// Snapshot helperIO so a concurrent StopHelper that clears it (or its
 	// stdin) can't turn this into a nil deref. sendShutdownMessage uses
 	// the same pattern.
-	helperIO := c.helperIO
+	helperIO := c.helperIO.Load()
 	if helperIO == nil || helperIO.stdin == nil {
 		return errors.New("helper IO not initialized")
 	}
@@ -459,7 +462,10 @@ func (c *SSHConnection) sendPing() error {
 
 // sendShutdownMessage sends a shutdown message to the helper via stdin
 func (c *SSHConnection) sendShutdownMessage() error {
-	if c.helperIO == nil {
+	// Snapshot helperIO so a concurrent StopHelper that clears it (or its
+	// stdin) can't turn this into a nil deref, mirroring sendPing.
+	helperIO := c.helperIO.Load()
+	if helperIO == nil || helperIO.stdin == nil {
 		return nil
 	}
 
@@ -469,13 +475,13 @@ func (c *SSHConnection) sendShutdownMessage() error {
 		return err
 	}
 
-	c.helperIO.stdinMu.Lock()
-	defer c.helperIO.stdinMu.Unlock()
+	helperIO.stdinMu.Lock()
+	defer helperIO.stdinMu.Unlock()
 
-	if _, err := c.helperIO.stdin.Write(data); err != nil {
+	if _, err := helperIO.stdin.Write(data); err != nil {
 		return err
 	}
-	if _, err := c.helperIO.stdin.Write([]byte("\n")); err != nil {
+	if _, err := helperIO.stdin.Write([]byte("\n")); err != nil {
 		return err
 	}
 	sshLog.Debug("Sent shutdown message to helper")
@@ -489,11 +495,11 @@ func (c *SSHConnection) runPongMonitor(ctx context.Context) error {
 		timeout = c.helperConfig.KeepaliveTimeout
 	}
 
-	// Snapshot helperIO once: StopHelper sets c.helperIO = nil during
-	// teardown, and a nil deref on c.helperIO.lastPong here is the panic
-	// reported in #3363. Holding our own pointer keeps the atomic.Value
-	// reachable for the rest of the goroutine's life.
-	helperIO := c.helperIO
+	// Snapshot helperIO once: StopHelper clears c.helperIO during teardown,
+	// and a nil deref on c.helperIO.lastPong here is the panic reported in
+	// #3363. Holding our own pointer keeps the atomic.Value reachable for
+	// the rest of the goroutine's life.
+	helperIO := c.helperIO.Load()
 	if helperIO == nil {
 		return nil
 	}
@@ -543,17 +549,20 @@ func (c *SSHConnection) StopHelper(ctx context.Context) error {
 	// Close stdin so the helper also sees EOF (belt-and-suspenders with
 	// the "shutdown" message above).  This also causes the origin-side
 	// runStdinKeepalive to fail its next Write and return.
-	if c.helperIO != nil && c.helperIO.stdin != nil {
-		c.helperIO.stdin.Close()
+	if hio := c.helperIO.Load(); hio != nil && hio.stdin != nil {
+		hio.stdin.Close()
 	}
 
 	// Start waiting for the errgroup to finish in the background.
-	// We must wait for all goroutines to exit before niling helperIO,
+	// We must wait for all goroutines to exit before clearing helperIO,
 	// otherwise goroutines like readHelperStdout will hit a nil pointer.
+	// Snapshot the errgroup under c.mu and hand it to the goroutine so the
+	// goroutine never reads c.helperErrgroup (which we nil below) directly.
+	egrp := c.helperErrgroup
 	done := make(chan error, 1)
 	go func() {
-		if c.helperErrgroup != nil {
-			done <- c.helperErrgroup.Wait()
+		if egrp != nil {
+			done <- egrp.Wait()
 		} else {
 			done <- nil
 		}
@@ -592,8 +601,8 @@ func (c *SSHConnection) StopHelper(ctx context.Context) error {
 
 			// Close stdin and session to force goroutines to unblock from
 			// their I/O reads, then wait for the errgroup to finish.
-			if c.helperIO != nil && c.helperIO.stdin != nil {
-				c.helperIO.stdin.Close()
+			if hio := c.helperIO.Load(); hio != nil && hio.stdin != nil {
+				hio.stdin.Close()
 			}
 			c.session.Close()
 
@@ -624,8 +633,8 @@ func (c *SSHConnection) StopHelper(ctx context.Context) error {
 	}
 
 	// Close stdin and session (may already be closed after SIGKILL path; double-close is safe)
-	if c.helperIO != nil && c.helperIO.stdin != nil {
-		c.helperIO.stdin.Close()
+	if hio := c.helperIO.Load(); hio != nil && hio.stdin != nil {
+		hio.stdin.Close()
 	}
 
 	if c.session != nil {
@@ -638,7 +647,7 @@ func (c *SSHConnection) StopHelper(ctx context.Context) error {
 		c.helperCancel = nil
 	}
 	c.session = nil
-	c.helperIO = nil
+	c.helperIO.Store(nil)
 	c.helperErrgroup = nil
 
 	if c.GetState() == StateRunningHelper {
@@ -714,11 +723,14 @@ func (c *SSHConnection) runSSHKeepalive(ctx context.Context) {
 // GetHelperStatus queries the helper for its status using the stdin/stdout protocol.
 // This does not require the helper to listen on any TCP port.
 func (c *SSHConnection) GetHelperStatus(ctx context.Context) (*HelperStatus, error) {
-	// Snapshot helperIO once so a concurrent StopHelper that nils it
+	// Snapshot helperIO once so a concurrent StopHelper that clears it
 	// can't turn the field reads below into a nil-deref or surface a
-	// type-assertion panic on a nil interface from Load().
-	helperIO := c.helperIO
-	if c.session == nil || helperIO == nil {
+	// type-assertion panic on a nil interface from Load(). helperIO is
+	// non-nil exactly when the helper is started (StartHelper/StopHelper
+	// set it together with c.session under c.mu), so it doubles as the
+	// "started?" check without a lock-free read of c.session.
+	helperIO := c.helperIO.Load()
+	if helperIO == nil {
 		return &HelperStatus{
 			State:   HelperStateNotStarted,
 			Message: "Helper not started",
@@ -768,6 +780,12 @@ func (c *SSHConnection) GetHelperStatus(ctx context.Context) (*HelperStatus, err
 func (c *SSHConnection) WaitForHelper(ctx context.Context, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 
+	// Snapshot the helper context once. It is published by StartHelper
+	// (under c.mu) before WaitForHelper is called and is not reassigned for
+	// this helper instance, so reading it once here avoids a lock-free read
+	// of c.helperCtx/c.helperErrgroup racing with StopHelper clearing them.
+	helperCtx := c.helperCtx
+
 	for time.Now().Before(deadline) {
 		select {
 		case <-ctx.Done():
@@ -775,28 +793,18 @@ func (c *SSHConnection) WaitForHelper(ctx context.Context, timeout time.Duration
 		default:
 		}
 
-		// Check if helper errgroup has an error
-		if c.helperErrgroup != nil {
-			// Check non-blocking if errgroup finished
-			done := make(chan struct{})
-			go func() {
-				// This will return quickly if errgroup is done
-				select {
-				case <-c.helperCtx.Done():
-					close(done)
-				default:
-				}
-			}()
+		// If the helper context is already cancelled, the helper goroutines
+		// have failed or exited; stop waiting.
+		if helperCtx != nil {
 			select {
-			case <-done:
-				// Context was cancelled, likely helper failed
+			case <-helperCtx.Done():
 				return errors.New("helper process failed during startup")
 			default:
 			}
 		}
 
 		// Check if helper is ready
-		if c.helperIO != nil && c.helperIO.helperReady.Load() {
+		if hio := c.helperIO.Load(); hio != nil && hio.helperReady.Load() {
 			return nil
 		}
 
@@ -818,8 +826,8 @@ func (c *SSHConnection) WaitForHelperSocket(ctx context.Context, timeout time.Du
 		default:
 		}
 
-		if c.helperIO != nil {
-			if v := c.helperIO.helperSocketPath.Load(); v != nil {
+		if hio := c.helperIO.Load(); hio != nil {
+			if v := hio.helperSocketPath.Load(); v != nil {
 				if sp, ok := v.(string); ok && sp != "" {
 					return sp, nil
 				}

--- a/ssh_posixv2/types.go
+++ b/ssh_posixv2/types.go
@@ -392,8 +392,13 @@ type SSHConnection struct {
 	// errChan is used to signal errors from the helper process
 	errChan chan error
 
-	// helperIO manages stdin/stdout communication with the remote helper
-	helperIO *helperIO
+	// helperIO manages stdin/stdout communication with the remote helper.
+	// Stored atomically: StopHelper clears it from under the long-lived
+	// helper goroutines (which read it without holding c.mu, since they
+	// can't — StopHelper holds c.mu while waiting on them in errgroup.Wait,
+	// so taking c.mu in a goroutine would deadlock). Load() gives each
+	// reader a stable snapshot for the rest of its critical section.
+	helperIO atomic.Pointer[helperIO]
 
 	// helperErrgroup manages goroutines for the helper process
 	helperErrgroup *errgroup.Group
@@ -401,7 +406,10 @@ type SSHConnection struct {
 	// helperCtx is the context for helper goroutines
 	helperCtx context.Context
 
-	// helperCancel cancels the helper context and triggers clean shutdown
+	// helperCancel cancels the helper context, waking the ticker-driven
+	// helper goroutines so they can exit promptly. It does not message the
+	// remote helper; StopHelper sends the shutdown message separately via
+	// sendShutdownMessage.
 	helperCancel func()
 }
 


### PR DESCRIPTION
- Actually cancel to shutdown various tickers.
- Add nil-checks and make copies of pointers to prevent a panic.

This fixes a potential segfault when the helper is shutting down.

Fixes #3363 