### PR TITLE
Fix refresh token expiry in embedded issuer custom grant flows

### DIFF
--- a/oauth2/issuer/admin_handlers.go
+++ b/oauth2/issuer/admin_handlers.go
@@ -21,6 +21,7 @@ package issuer
 import (
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/ory/fosite"
@@ -553,6 +554,7 @@ func handleTokenExchange(ctx *gin.Context, provider *OIDCProvider) {
 	if hasRefreshGrant {
 		for _, s := range grantedScopes {
 			if s == "offline_access" {
+				ar.GetSession().SetExpiresAt(fosite.RefreshToken, time.Now().Add(provider.config.RefreshTokenLifespan))
 				rt, rtSig, rtErr := provider.strategy.CoreStrategy.GenerateRefreshToken(rCtx, ar)
 				if rtErr != nil {
 					log.WithError(rtErr).Warn("Embedded issuer: failed to generate token-exchange refresh token")

--- a/oauth2/issuer/handlers.go
+++ b/oauth2/issuer/handlers.go
@@ -874,6 +874,7 @@ func handleDeviceTokenExchange(ctx *gin.Context, provider *OIDCProvider) {
 	if hasRefreshGrant {
 		for _, s := range request.GetGrantedScopes() {
 			if s == "offline_access" {
+				ar.GetSession().SetExpiresAt(fosite.RefreshToken, time.Now().Add(provider.config.RefreshTokenLifespan))
 				refreshToken, refreshSignature, rtErr := provider.strategy.CoreStrategy.GenerateRefreshToken(rCtx, ar)
 				if rtErr != nil {
 					log.WithError(rtErr).Warn("Embedded issuer: failed to generate device code refresh token")


### PR DESCRIPTION
_(With a tip of the hat to [Copilot](https://github.com/apps/github-copilot-cli))_

Fixes #3388.

## Changes

In `handleDeviceTokenExchange` (`handlers.go`) and `handleTokenExchange` (`admin_handlers.go`), call `ar.GetSession().SetExpiresAt(fosite.RefreshToken, time.Now().Add(provider.config.RefreshTokenLifespan))` before `GenerateRefreshToken` so that `createTokenSession` stores the correct expiry instead of falling back to `now + 1h`.

The standard `authorization_code` and `refresh_token` flows go through fosite's built-in pipeline and are not affected.

## Testing

`go test ./oauth2/issuer/...` passes.