### PR TITLE
Make embedded issuer token lifespans configurable; fix refresh token tombstone security bug

### DIFF
--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -174,6 +174,10 @@ OIDC:
   UserInfoEndpoint: "https://cilogon.org/oauth2/userinfo"
   Scopes: ["openid", "email", "profile"]
 Issuer:
+  AccessTokenLifetime: 1h
+  AuthorizationCodeLifetime: 10m
+  IDTokenLifetime: 1h
+  RefreshTokenLifetime: 168h
   TomcatLocation: /opt/tomcat
   ScitokensServerLocation: /opt/scitokens-server
   QDLLocation: /opt/qdl

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -3631,6 +3631,31 @@ type: string
 default: iss
 components: ["origin", "registry", "cache", "director"]
 ---
+name: Issuer.AccessTokenLifetime
+description: |+
+  Lifetime of access tokens issued by the embedded OAuth2 issuer.
+type: duration
+default: 1h
+hidden: true
+components: ["origin"]
+---
+name: Issuer.AuthorizationCodeLifetime
+description: |+
+  Lifetime of authorization codes and device codes issued by the
+  embedded OAuth2 issuer.
+type: duration
+default: 10m
+hidden: true
+components: ["origin"]
+---
+name: Issuer.IDTokenLifetime
+description: |+
+  Lifetime of ID tokens issued by the embedded OAuth2 issuer.
+type: duration
+default: 1h
+hidden: true
+components: ["origin"]
+---
 name: Issuer.RefreshTokenGracePeriod
 description: |+
   Duration during which a used refresh token may still be reused.
@@ -3638,6 +3663,14 @@ description: |+
   instead it remains valid for this grace period.
 type: duration
 default: 5m
+hidden: true
+components: ["origin"]
+---
+name: Issuer.RefreshTokenLifetime
+description: |+
+  Lifetime of refresh tokens issued by the embedded OAuth2 issuer.
+type: duration
+default: 168h
 hidden: true
 components: ["origin"]
 ---

--- a/oauth2/issuer/admin_handlers.go
+++ b/oauth2/issuer/admin_handlers.go
@@ -507,7 +507,7 @@ func handleTokenExchange(ctx *gin.Context, provider *OIDCProvider) {
 	}
 
 	session := DefaultOIDCSession(subject, issuerURL, groups, grantedScopes)
-	session.SetExpiresAt(fosite.AccessToken, session.JWTClaims.ExpiresAt)
+	session.SetExpiresAt(fosite.AccessToken, time.Now().Add(provider.config.AccessTokenLifespan))
 	ar := fosite.NewAccessRequest(session)
 	ar.Client = client
 	ar.GrantedScope = grantedScopes

--- a/oauth2/issuer/device_code.go
+++ b/oauth2/issuer/device_code.go
@@ -77,7 +77,7 @@ func (h *DeviceCodeHandler) HandleDeviceAuthorizationRequest(ctx context.Context
 	request.RequestedScope = scopes
 	request.GrantedScope = scopes
 
-	expiresIn := 10 * time.Minute
+	expiresIn := h.config.AuthorizeCodeLifespan
 	expiresAt := time.Now().Add(expiresIn)
 
 	if err := h.storage.CreateDeviceCodeSession(ctx, deviceCode, userCode, request, expiresAt); err != nil {

--- a/oauth2/issuer/provider.go
+++ b/oauth2/issuer/provider.go
@@ -365,10 +365,8 @@ func (s *WLCGSession) GetExtraClaims() map[string]interface{} {
 // DefaultOIDCSession creates a new WLCG-compliant OIDC session with both
 // JWT access token claims and ID token claims.
 //
-// The 1-hour ExpiresAt values here are initial placeholders; fosite overrides
-// them with the actual AccessTokenLifespan / IDTokenLifespan from the provider
-// config when the token is issued.  The device-code path explicitly calls
-// SetExpiresAt before token generation for the same reason.
+// The 1-hour ExpiresAt values here are initial placeholders that are always
+// overridden with the configured lifespan before a token is issued.
 func DefaultOIDCSession(subject string, issuer string, groups []string, scopes []string) *WLCGSession {
 	now := time.Now()
 	extra := map[string]interface{}{}

--- a/oauth2/issuer/provider.go
+++ b/oauth2/issuer/provider.go
@@ -43,6 +43,7 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/database"
 	"github.com/pelicanplatform/pelican/oa4mp"
+	"github.com/pelicanplatform/pelican/param"
 )
 
 // hkdfPurposeIDPHMAC is the HKDF info string used to derive the HMAC
@@ -88,11 +89,32 @@ func NewOIDCProvider(db *gorm.DB, issuerURL string, refreshGracePeriod time.Dura
 
 	tokenURL := issuerURL + "/token"
 
+	// Read token lifespans from config. The zero-checks guard against unit
+	// tests that call NewOIDCProvider directly without initializing viper
+	// via InitConfigInternal (which is the only place defaults.yaml is
+	// loaded); in those environments GetDuration returns 0.
+	accessTokenLifespan := param.Issuer_AccessTokenLifetime.GetDuration()
+	if accessTokenLifespan == 0 {
+		accessTokenLifespan = 1 * time.Hour
+	}
+	refreshTokenLifespan := param.Issuer_RefreshTokenLifetime.GetDuration()
+	if refreshTokenLifespan == 0 {
+		refreshTokenLifespan = 7 * 24 * time.Hour
+	}
+	authorizeCodeLifespan := param.Issuer_AuthorizationCodeLifetime.GetDuration()
+	if authorizeCodeLifespan == 0 {
+		authorizeCodeLifespan = 10 * time.Minute
+	}
+	idTokenLifespan := param.Issuer_IDTokenLifetime.GetDuration()
+	if idTokenLifespan == 0 {
+		idTokenLifespan = time.Hour
+	}
+
 	fositeConfig := &fosite.Config{
-		AccessTokenLifespan:         time.Hour,
-		RefreshTokenLifespan:        7 * 24 * time.Hour,
-		AuthorizeCodeLifespan:       10 * time.Minute,
-		IDTokenLifespan:             time.Hour,
+		AccessTokenLifespan:         accessTokenLifespan,
+		RefreshTokenLifespan:        refreshTokenLifespan,
+		AuthorizeCodeLifespan:       authorizeCodeLifespan,
+		IDTokenLifespan:             idTokenLifespan,
 		TokenURL:                    tokenURL,
 		AccessTokenIssuer:           issuerURL,
 		ScopeStrategy:               sciTokensScopeStrategy,

--- a/oauth2/issuer/storage.go
+++ b/oauth2/issuer/storage.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/ory/fosite"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -339,10 +340,20 @@ func (s *OIDCStorage) DeleteExpiredTokenSessions(ctx context.Context) (int64, er
 	}
 	// Refresh tokens: expires_at may be NULL (never-expire), so only delete
 	// rows where expires_at is set and in the past, or where the token has
-	// been revoked (active=0) and its grace period is long past.
+	// been revoked (active=0), has no expiry set, and its grace period is
+	// long past.
+	//
+	// Rotated tokens (active=0) that DO have expires_at set are handled by
+	// the first condition: we keep them as tombstones until their natural
+	// expiry so that replays of rotated tokens return ErrInactiveToken
+	// (triggering family revocation) rather than ErrNotFound.
+	//
+	// Rotated tokens without expires_at are cleaned up after the grace
+	// period has long passed.
+	legacyCutoff := now.Add(-(s.RefreshTokenGracePeriod + 24*time.Hour))
 	result := s.db.WithContext(ctx).
-		Where("(expires_at IS NOT NULL AND expires_at < ?) OR (active = ? AND first_used_at IS NOT NULL AND first_used_at < ?)",
-			now, false, now.Add(-24*time.Hour)).
+		Where("(expires_at IS NOT NULL AND expires_at < ?) OR (active = ? AND first_used_at IS NOT NULL AND expires_at IS NULL AND first_used_at < ?)",
+			now, false, legacyCutoff).
 		Delete(&OIDCRefreshToken{})
 	if result.Error != nil {
 		return total, result.Error
@@ -802,10 +813,12 @@ func (s *OIDCStorage) createTokenSession(ctx context.Context, table, signature s
 		expiresAt = request.GetSession().GetExpiresAt(fosite.RefreshToken)
 	case "oidc_access_tokens":
 		expiresAt = request.GetSession().GetExpiresAt(fosite.AccessToken)
-	case "oidc_authorization_codes":
+	case "oidc_pkce_requests", "oidc_openid_sessions", "oidc_authorization_codes":
 		expiresAt = request.GetSession().GetExpiresAt(fosite.AuthorizeCode)
 	}
 	if expiresAt.IsZero() {
+		log.WithField("table", table).Warn("Embedded issuer: token session has no expiry set; " +
+			"falling back to 1h. SetExpiresAt should be called before CreateTokenSession.")
 		expiresAt = time.Now().Add(1 * time.Hour)
 	}
 

--- a/oauth2/issuer/storage.go
+++ b/oauth2/issuer/storage.go
@@ -794,7 +794,7 @@ func (s *OIDCStorage) createTokenSession(ctx context.Context, table, signature s
 	sessionData, _ := json.Marshal(request.GetSession())
 
 	// Derive expiration from the session's token-type-specific expiry when
-	// available, so that refresh tokens honour RefreshTokenLifespan (7d)
+	// available, so that refresh tokens honour RefreshTokenLifespan
 	// instead of always using a 1h default.
 	var expiresAt time.Time
 	switch table {

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -210,13 +210,16 @@ var runtimeConfigurableMap = map[string]bool{
 	"Federation.TopologyReloadInterval": false,
 	"Federation.TopologyUrl": false,
 	"GeoIPOverrides": false,
+	"Issuer.AccessTokenLifetime": false,
 	"Issuer.AuthenticationSource": false,
+	"Issuer.AuthorizationCodeLifetime": false,
 	"Issuer.AuthorizationTemplates": false,
 	"Issuer.DynamicClientStaleTimeout": false,
 	"Issuer.DynamicClientUnusedTimeout": false,
 	"Issuer.GroupFile": false,
 	"Issuer.GroupRequirements": false,
 	"Issuer.GroupSource": false,
+	"Issuer.IDTokenLifetime": false,
 	"Issuer.IssuerClaimValue": false,
 	"Issuer.OIDCAuthenticationRequirements": false,
 	"Issuer.OIDCAuthenticationUserClaim": false,
@@ -228,6 +231,7 @@ var runtimeConfigurableMap = map[string]bool{
 	"Issuer.QDLLocation": false,
 	"Issuer.RedirectUris": false,
 	"Issuer.RefreshTokenGracePeriod": false,
+	"Issuer.RefreshTokenLifetime": false,
 	"Issuer.ScitokensServerLocation": false,
 	"Issuer.TomcatLocation": false,
 	"Issuer.UserStripDomain": false,
@@ -1070,9 +1074,13 @@ var durationAccessors = map[string]func(*Config) time.Duration{
 	"Director.RegistryQueryInterval": func(c *Config) time.Duration { return c.Director.RegistryQueryInterval },
 	"Director.StatTimeout": func(c *Config) time.Duration { return c.Director.StatTimeout },
 	"Federation.TopologyReloadInterval": func(c *Config) time.Duration { return c.Federation.TopologyReloadInterval },
+	"Issuer.AccessTokenLifetime": func(c *Config) time.Duration { return c.Issuer.AccessTokenLifetime },
+	"Issuer.AuthorizationCodeLifetime": func(c *Config) time.Duration { return c.Issuer.AuthorizationCodeLifetime },
 	"Issuer.DynamicClientStaleTimeout": func(c *Config) time.Duration { return c.Issuer.DynamicClientStaleTimeout },
 	"Issuer.DynamicClientUnusedTimeout": func(c *Config) time.Duration { return c.Issuer.DynamicClientUnusedTimeout },
+	"Issuer.IDTokenLifetime": func(c *Config) time.Duration { return c.Issuer.IDTokenLifetime },
 	"Issuer.RefreshTokenGracePeriod": func(c *Config) time.Duration { return c.Issuer.RefreshTokenGracePeriod },
+	"Issuer.RefreshTokenLifetime": func(c *Config) time.Duration { return c.Issuer.RefreshTokenLifetime },
 	"LocalCache.DefaultMaxAge": func(c *Config) time.Duration { return c.LocalCache.DefaultMaxAge },
 	"LocalCache.PrefetchTimeout": func(c *Config) time.Duration { return c.LocalCache.PrefetchTimeout },
 	"Logging.Client.ProgressInterval": func(c *Config) time.Duration { return c.Logging.Client.ProgressInterval },
@@ -1319,13 +1327,16 @@ var allParameterNames = []string{
 	"Federation.TopologyReloadInterval",
 	"Federation.TopologyUrl",
 	"GeoIPOverrides",
+	"Issuer.AccessTokenLifetime",
 	"Issuer.AuthenticationSource",
+	"Issuer.AuthorizationCodeLifetime",
 	"Issuer.AuthorizationTemplates",
 	"Issuer.DynamicClientStaleTimeout",
 	"Issuer.DynamicClientUnusedTimeout",
 	"Issuer.GroupFile",
 	"Issuer.GroupRequirements",
 	"Issuer.GroupSource",
+	"Issuer.IDTokenLifetime",
 	"Issuer.IssuerClaimValue",
 	"Issuer.OIDCAuthenticationRequirements",
 	"Issuer.OIDCAuthenticationUserClaim",
@@ -1337,6 +1348,7 @@ var allParameterNames = []string{
 	"Issuer.QDLLocation",
 	"Issuer.RedirectUris",
 	"Issuer.RefreshTokenGracePeriod",
+	"Issuer.RefreshTokenLifetime",
 	"Issuer.ScitokensServerLocation",
 	"Issuer.TomcatLocation",
 	"Issuer.UserStripDomain",
@@ -2003,9 +2015,13 @@ var (
 	Director_RegistryQueryInterval = DurationParam{"Director.RegistryQueryInterval"}
 	Director_StatTimeout = DurationParam{"Director.StatTimeout"}
 	Federation_TopologyReloadInterval = DurationParam{"Federation.TopologyReloadInterval"}
+	Issuer_AccessTokenLifetime = DurationParam{"Issuer.AccessTokenLifetime"}
+	Issuer_AuthorizationCodeLifetime = DurationParam{"Issuer.AuthorizationCodeLifetime"}
 	Issuer_DynamicClientStaleTimeout = DurationParam{"Issuer.DynamicClientStaleTimeout"}
 	Issuer_DynamicClientUnusedTimeout = DurationParam{"Issuer.DynamicClientUnusedTimeout"}
+	Issuer_IDTokenLifetime = DurationParam{"Issuer.IDTokenLifetime"}
 	Issuer_RefreshTokenGracePeriod = DurationParam{"Issuer.RefreshTokenGracePeriod"}
+	Issuer_RefreshTokenLifetime = DurationParam{"Issuer.RefreshTokenLifetime"}
 	LocalCache_DefaultMaxAge = DurationParam{"LocalCache.DefaultMaxAge"}
 	LocalCache_PrefetchTimeout = DurationParam{"LocalCache.PrefetchTimeout"}
 	Logging_Client_ProgressInterval = DurationParam{"Logging.Client.ProgressInterval"}
@@ -2441,9 +2457,13 @@ func init() {
 		"Director.RegistryQueryInterval": Director_RegistryQueryInterval,
 		"Director.StatTimeout": Director_StatTimeout,
 		"Federation.TopologyReloadInterval": Federation_TopologyReloadInterval,
+		"Issuer.AccessTokenLifetime": Issuer_AccessTokenLifetime,
+		"Issuer.AuthorizationCodeLifetime": Issuer_AuthorizationCodeLifetime,
 		"Issuer.DynamicClientStaleTimeout": Issuer_DynamicClientStaleTimeout,
 		"Issuer.DynamicClientUnusedTimeout": Issuer_DynamicClientUnusedTimeout,
+		"Issuer.IDTokenLifetime": Issuer_IDTokenLifetime,
 		"Issuer.RefreshTokenGracePeriod": Issuer_RefreshTokenGracePeriod,
+		"Issuer.RefreshTokenLifetime": Issuer_RefreshTokenLifetime,
 		"LocalCache.DefaultMaxAge": LocalCache_DefaultMaxAge,
 		"LocalCache.PrefetchTimeout": LocalCache_PrefetchTimeout,
 		"Logging.Client.ProgressInterval": Logging_Client_ProgressInterval,

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -151,13 +151,16 @@ type Config struct {
 	} `mapstructure:"federation" yaml:"Federation"`
 	GeoIPOverrides any `mapstructure:"geoipoverrides" yaml:"GeoIPOverrides"`
 	Issuer struct {
+		AccessTokenLifetime time.Duration `mapstructure:"accesstokenlifetime" yaml:"AccessTokenLifetime"`
 		AuthenticationSource string `mapstructure:"authenticationsource" yaml:"AuthenticationSource"`
+		AuthorizationCodeLifetime time.Duration `mapstructure:"authorizationcodelifetime" yaml:"AuthorizationCodeLifetime"`
 		AuthorizationTemplates any `mapstructure:"authorizationtemplates" yaml:"AuthorizationTemplates"`
 		DynamicClientStaleTimeout time.Duration `mapstructure:"dynamicclientstaletimeout" yaml:"DynamicClientStaleTimeout"`
 		DynamicClientUnusedTimeout time.Duration `mapstructure:"dynamicclientunusedtimeout" yaml:"DynamicClientUnusedTimeout"`
 		GroupFile string `mapstructure:"groupfile" yaml:"GroupFile"`
 		GroupRequirements []string `mapstructure:"grouprequirements" yaml:"GroupRequirements"`
 		GroupSource string `mapstructure:"groupsource" yaml:"GroupSource"`
+		IDTokenLifetime time.Duration `mapstructure:"idtokenlifetime" yaml:"IDTokenLifetime"`
 		IssuerClaimValue string `mapstructure:"issuerclaimvalue" yaml:"IssuerClaimValue"`
 		OIDCAuthenticationRequirements any `mapstructure:"oidcauthenticationrequirements" yaml:"OIDCAuthenticationRequirements"`
 		OIDCAuthenticationUserClaim string `mapstructure:"oidcauthenticationuserclaim" yaml:"OIDCAuthenticationUserClaim"`
@@ -169,6 +172,7 @@ type Config struct {
 		QDLLocation string `mapstructure:"qdllocation" yaml:"QDLLocation"`
 		RedirectUris []string `mapstructure:"redirecturis" yaml:"RedirectUris"`
 		RefreshTokenGracePeriod time.Duration `mapstructure:"refreshtokengraceperiod" yaml:"RefreshTokenGracePeriod"`
+		RefreshTokenLifetime time.Duration `mapstructure:"refreshtokenlifetime" yaml:"RefreshTokenLifetime"`
 		ScitokensServerLocation string `mapstructure:"scitokensserverlocation" yaml:"ScitokensServerLocation"`
 		TomcatLocation string `mapstructure:"tomcatlocation" yaml:"TomcatLocation"`
 		UserStripDomain bool `mapstructure:"userstripdomain" yaml:"UserStripDomain"`
@@ -625,13 +629,16 @@ type configWithType struct {
 	}
 	GeoIPOverrides struct { Type string; Value any }
 	Issuer struct {
+		AccessTokenLifetime struct { Type string; Value time.Duration }
 		AuthenticationSource struct { Type string; Value string }
+		AuthorizationCodeLifetime struct { Type string; Value time.Duration }
 		AuthorizationTemplates struct { Type string; Value any }
 		DynamicClientStaleTimeout struct { Type string; Value time.Duration }
 		DynamicClientUnusedTimeout struct { Type string; Value time.Duration }
 		GroupFile struct { Type string; Value string }
 		GroupRequirements struct { Type string; Value []string }
 		GroupSource struct { Type string; Value string }
+		IDTokenLifetime struct { Type string; Value time.Duration }
 		IssuerClaimValue struct { Type string; Value string }
 		OIDCAuthenticationRequirements struct { Type string; Value any }
 		OIDCAuthenticationUserClaim struct { Type string; Value string }
@@ -643,6 +650,7 @@ type configWithType struct {
 		QDLLocation struct { Type string; Value string }
 		RedirectUris struct { Type string; Value []string }
 		RefreshTokenGracePeriod struct { Type string; Value time.Duration }
+		RefreshTokenLifetime struct { Type string; Value time.Duration }
 		ScitokensServerLocation struct { Type string; Value string }
 		TomcatLocation struct { Type string; Value string }
 		UserStripDomain struct { Type string; Value bool }


### PR DESCRIPTION
_(With a tip of the hat to [Copilot](https://github.com/apps/github-copilot-cli))_

The four token lifespans used by the embedded OAuth2 issuer (access token, refresh token, authorization/device code, and ID token) were previously hardcoded. This change exposes them as operator-configurable parameters under the `Issuer.*` namespace, with defaults matching the prior hardcoded values so existing deployments are unaffected.

A security bug in the refresh token cleanup logic is also fixed. Rotated refresh tokens are kept in the database as tombstones so that any replay of an already-used token is detected and triggers revocation of the entire token family, forcing re-authentication. The cleanup job was incorrectly removing these tombstones before their natural expiry, which meant a replay during that window would go undetected — the token would simply appear not to exist rather than being flagged as reused. Tombstones are now retained until their natural expiry passes, with a separate conservative cleanup path for older rows that predate the current scheme.

Two smaller correctness fixes are also included: a token-exchange code path that was ignoring the newly-configurable access token lifespan, and a gap in the per-token-type expiry logic that caused certain session types to always receive a hardcoded one-hour database lifetime.