### PR TITLE
param: reject bare numbers for duration config fields

### DIFF
--- a/param/param.go
+++ b/param/param.go
@@ -19,10 +19,12 @@
 package param
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/mitchellh/mapstructure"
 
@@ -219,6 +221,47 @@ func stringToByteRateHookFunc() mapstructure.DecodeHookFunc {
 	}
 }
 
+// intToTimeDurationRejectHookFunc returns a DecodeHookFunc that rejects bare
+// integers and floats for time.Duration fields. Users must include a unit suffix
+// (e.g., "10s", "5m", "1h"); without one, a bare number would be silently
+// interpreted as nanoseconds due to WeaklyTypedInput.
+//
+// Values already typed as time.Duration (e.g., from param.Set or viper.SetDefault
+// with a time.Duration argument) are passed through unchanged.
+func intToTimeDurationRejectHookFunc() mapstructure.DecodeHookFunc {
+	durationType := reflect.TypeOf(time.Duration(0))
+	return func(f reflect.Type, t reflect.Type, data any) (any, error) {
+		if t != durationType {
+			return data, nil
+		}
+		// Allow time.Duration → time.Duration (programmatic values set via
+		// param.Set, viper.Set, or viper.SetDefault with a time.Duration).
+		if f == durationType {
+			return data, nil
+		}
+		switch f.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+			reflect.Float32, reflect.Float64:
+			return nil, fmt.Errorf("duration value must include a unit suffix "+
+				"(e.g., \"10s\", \"5m\", \"1h\"); got bare number: %v", data)
+		}
+		return data, nil
+	}
+}
+
+// buildDecodeHookFunc returns the standard composed decode hook used for all
+// mapstructure decoders in this package. Centralizing it here ensures that all
+// three decoder sites (DecodeConfig, getOrCreateConfig, MultiSet) stay in sync.
+func buildDecodeHookFunc() mapstructure.DecodeHookFunc {
+	return mapstructure.ComposeDecodeHookFunc(
+		intToTimeDurationRejectHookFunc(),
+		mapstructure.StringToTimeDurationHookFunc(),
+		stringToSliceHookFunc(),
+		stringToByteRateHookFunc(),
+	)
+}
+
 // DecodeConfig decodes the provided viper instance into a new Config struct.
 //
 // Unlike UnmarshalConfig/Refresh, this does NOT update the global atomic cache.
@@ -235,11 +278,7 @@ func DecodeConfig(v *viper.Viper) (*Config, error) {
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		TagName:          "mapstructure",
 		WeaklyTypedInput: true,
-		DecodeHook: mapstructure.ComposeDecodeHookFunc(
-			mapstructure.StringToTimeDurationHookFunc(),
-			stringToSliceHookFunc(),
-			stringToByteRateHookFunc(),
-		),
+		DecodeHook:       buildDecodeHookFunc(),
 		MatchName: func(mapKey, fieldName string) bool {
 			return strings.EqualFold(mapKey, fieldName)
 		},
@@ -424,11 +463,7 @@ func getOrCreateConfig() *Config {
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		TagName:          "mapstructure",
 		WeaklyTypedInput: true,
-		DecodeHook: mapstructure.ComposeDecodeHookFunc(
-			mapstructure.StringToTimeDurationHookFunc(),
-			stringToSliceHookFunc(),
-			stringToByteRateHookFunc(),
-		),
+		DecodeHook:       buildDecodeHookFunc(),
 		MatchName: func(mapKey, fieldName string) bool {
 			return strings.EqualFold(mapKey, fieldName)
 		},
@@ -488,11 +523,7 @@ func MultiSet(keyValues map[string]any) error {
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		TagName:          "mapstructure",
 		WeaklyTypedInput: true,
-		DecodeHook: mapstructure.ComposeDecodeHookFunc(
-			mapstructure.StringToTimeDurationHookFunc(),
-			stringToSliceHookFunc(),
-			stringToByteRateHookFunc(),
-		),
+		DecodeHook:       buildDecodeHookFunc(),
 		MatchName: func(mapKey, fieldName string) bool {
 			return strings.EqualFold(mapKey, fieldName)
 		},

--- a/param/param_test.go
+++ b/param/param_test.go
@@ -943,7 +943,159 @@ func TestConcurrentIsSetAndUnmarshalConfig(t *testing.T) {
 	assert.NotNil(t, config)
 }
 
-// TestConcurrentObjectParamUnmarshal verifies that ObjectParam.Unmarshal()
+// TestIntToTimeDurationRejectHookFunc verifies that bare integers and floats
+// are rejected for time.Duration fields, while strings with unit suffixes and
+// existing time.Duration values are accepted.
+func TestIntToTimeDurationRejectHookFunc(t *testing.T) {
+	durationType := reflect.TypeOf(time.Duration(0))
+	intType := reflect.TypeOf(int(0))
+	int64Type := reflect.TypeOf(int64(0))
+	float64Type := reflect.TypeOf(float64(0))
+	stringType := reflect.TypeOf("")
+
+	hook := intToTimeDurationRejectHookFunc()
+	fn := hook.(func(f reflect.Type, t reflect.Type, data any) (any, error))
+
+	t.Run("bare-int-rejected", func(t *testing.T) {
+		_, err := fn(intType, durationType, 600)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unit suffix")
+	})
+
+	t.Run("bare-int64-rejected", func(t *testing.T) {
+		_, err := fn(int64Type, durationType, int64(600))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unit suffix")
+	})
+
+	t.Run("bare-float64-rejected", func(t *testing.T) {
+		_, err := fn(float64Type, durationType, 600.0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unit suffix")
+	})
+
+	t.Run("time-duration-allowed", func(t *testing.T) {
+		result, err := fn(durationType, durationType, 10*time.Minute)
+		require.NoError(t, err)
+		assert.Equal(t, 10*time.Minute, result)
+	})
+
+	t.Run("string-passed-through", func(t *testing.T) {
+		// Strings are handled by StringToTimeDurationHookFunc; this hook passes them through.
+		result, err := fn(stringType, durationType, "10m")
+		require.NoError(t, err)
+		assert.Equal(t, "10m", result)
+	})
+
+	t.Run("non-duration-target-unaffected", func(t *testing.T) {
+		// Hook must not interfere with int → int conversions.
+		result, err := fn(intType, intType, 42)
+		require.NoError(t, err)
+		assert.Equal(t, 42, result)
+	})
+}
+
+// TestDurationDecoding verifies end-to-end YAML parsing behavior for
+// time.Duration configuration fields.
+func TestDurationDecoding(t *testing.T) {
+	t.Run("string-with-unit-suffix-accepted", func(t *testing.T) {
+		viper.Reset()
+		defer viper.Reset()
+
+		yamlContent := `Cache:
+  SelfTestInterval: 10m
+`
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "pelican.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(yamlContent), 0644))
+
+		v := viper.New()
+		v.SetConfigFile(configPath)
+		require.NoError(t, v.ReadInConfig())
+
+		cfg, err := DecodeConfig(v)
+		require.NoError(t, err)
+		assert.Equal(t, 10*time.Minute, cfg.Cache.SelfTestInterval)
+	})
+
+	t.Run("bare-integer-rejected", func(t *testing.T) {
+		viper.Reset()
+		defer viper.Reset()
+
+		yamlContent := `Cache:
+  SelfTestInterval: 600
+`
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "pelican.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(yamlContent), 0644))
+
+		v := viper.New()
+		v.SetConfigFile(configPath)
+		require.NoError(t, v.ReadInConfig())
+
+		_, err := DecodeConfig(v)
+		require.Error(t, err, "bare integer should be rejected for a duration field")
+		assert.Contains(t, err.Error(), "unit suffix")
+	})
+
+	t.Run("bare-float-rejected", func(t *testing.T) {
+		viper.Reset()
+		defer viper.Reset()
+
+		yamlContent := `Cache:
+  SelfTestInterval: 600.0
+`
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "pelican.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(yamlContent), 0644))
+
+		v := viper.New()
+		v.SetConfigFile(configPath)
+		require.NoError(t, v.ReadInConfig())
+
+		_, err := DecodeConfig(v)
+		require.Error(t, err, "bare float should be rejected for a duration field")
+		assert.Contains(t, err.Error(), "unit suffix")
+	})
+
+	t.Run("time-duration-via-viper-set-allowed", func(t *testing.T) {
+		viper.Reset()
+		defer viper.Reset()
+
+		v := viper.New()
+		v.Set("Cache.SelfTestInterval", 5*time.Minute)
+
+		cfg, err := DecodeConfig(v)
+		require.NoError(t, err)
+		assert.Equal(t, 5*time.Minute, cfg.Cache.SelfTestInterval)
+	})
+
+	t.Run("time-duration-via-unmarshalconfig-allowed", func(t *testing.T) {
+		viper.Reset()
+		defer viper.Reset()
+
+		viper.Set("Cache.SelfTestInterval", 15*time.Second)
+
+		cfg, err := UnmarshalConfig()
+		require.NoError(t, err)
+		assert.Equal(t, 15*time.Second, cfg.Cache.SelfTestInterval)
+	})
+
+	t.Run("time-duration-via-multiset-allowed", func(t *testing.T) {
+		viper.Reset()
+		defer viper.Reset()
+
+		err := MultiSet(map[string]any{
+			"Cache.SelfTestInterval": 30 * time.Second,
+		})
+		require.NoError(t, err)
+
+		cfg, err := GetUnmarshaledConfig()
+		require.NoError(t, err)
+		assert.Equal(t, 30*time.Second, cfg.Cache.SelfTestInterval)
+	})
+}
+
 // doesn't race with concurrent viper writes.
 func TestConcurrentObjectParamUnmarshal(t *testing.T) {
 	require.NoError(t, Reset())

--- a/param/param_test.go
+++ b/param/param_test.go
@@ -1096,6 +1096,7 @@ func TestDurationDecoding(t *testing.T) {
 	})
 }
 
+// TestConcurrentObjectParamUnmarshal verifies that ObjectParam.Unmarshal()
 // doesn't race with concurrent viper writes.
 func TestConcurrentObjectParamUnmarshal(t *testing.T) {
 	require.NoError(t, Reset())


### PR DESCRIPTION
_(With a tip of the hat to [Copilot](https://github.com/apps/github-copilot-cli))_

When a user sets a duration parameter in `pelican.yaml` with a bare integer — e.g., `Server.StartupTimeout: 600` — the value was silently accepted and interpreted as 600 **nanoseconds** rather than 600 seconds. No warning was emitted, and the resulting behavior was nearly impossible to diagnose.

The root cause is that `mapstructure`'s `StringToTimeDurationHookFunc` only converts *string* values (e.g., `"10m"`) via `time.ParseDuration`. A bare YAML integer arrives as a Go `int`, bypasses the hook entirely, and is coerced directly to `time.Duration` — which is an `int64` counting nanoseconds — by `WeaklyTypedInput: true`.

This PR adds a hook that intercepts any attempt to decode a bare integer or float into a `time.Duration` field and returns a clear error directing the user to include a unit suffix (e.g., `"10m"`, `"600s"`). Programmatically-set `time.Duration` values — from `param.Set`, `viper.Set`, or `viper.SetDefault` — are explicitly allowed through, so no existing behavior changes for code that sets durations correctly. The hook composition is also centralized into a single helper to prevent the three decoder sites from drifting out of sync in the future.