### PR TITLE
Upgrade actions to versions that run on Node.js 24

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -256,7 +256,7 @@ jobs:
 
       - name: Set up metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
@@ -287,25 +287,25 @@ jobs:
       # The new attempt will automatically use its own, fresh caches.
 
       - name: Create a cache for Docker Buildx
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ runner.temp }}/.base-buildx-cache
           key: base-buildx-${{ matrix.id }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Create a cache for the GitHub workspace
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}
           key: github-workspace-${{ matrix.id }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           buildkitd-flags: --debug
 
       - name: Log in to OSG Harbor
         if: ${{ contains(fromJson(needs.params.outputs.images-to-push), 'origin') }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: hub.opensciencegrid.org
           username: ${{ secrets.PELICAN_HARBOR_ROBOT_USER }}
@@ -320,7 +320,7 @@ jobs:
       # these layers multiple times over.
 
       - name: Build and push origin
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           file: ./images/Dockerfile
           target: origin
@@ -366,7 +366,7 @@ jobs:
     steps:
       - name: Set up metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
@@ -376,27 +376,27 @@ jobs:
             type=raw,enable=${{ needs.tags.outputs.IS_LATEST }},latest-${{ matrix.arch }}
 
       - name: Restore the cache for Docker Buildx
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ runner.temp }}/.base-buildx-cache
           key: base-buildx-${{ matrix.id }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           fail-on-cache-miss: true  # don't let cache-image-layers be for naught
 
       - name: Restore the cache for the GitHub workspace
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}
           key: github-workspace-${{ matrix.id }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           fail-on-cache-miss: true  # don't let cache-image-layers be for naught
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           buildkitd-flags: --debug
 
       - name: Log in to OSG Harbor
         if: ${{ contains(fromJson(needs.params.outputs.images-to-push), matrix.image) }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: hub.opensciencegrid.org
           username: ${{ secrets.PELICAN_HARBOR_ROBOT_USER }}
@@ -404,7 +404,7 @@ jobs:
 
       - name: Build and push image
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           file: ./images/Dockerfile
           target: ${{ matrix.image }}
@@ -428,7 +428,7 @@ jobs:
 
       - name: Upload digest
         if: ${{ contains(fromJson(needs.params.outputs.images-to-push), matrix.image) }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ matrix.image }}-${{ matrix.id }}
           path: ${{ runner.temp }}/digests/*
@@ -450,7 +450,7 @@ jobs:
     steps:
       - name: Set up metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
@@ -460,7 +460,7 @@ jobs:
             type=raw,enable=${{ needs.tags.outputs.IS_LATEST }},latest
 
       - name: Log in to OSG Harbor
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: hub.opensciencegrid.org
           username: ${{ secrets.PELICAN_HARBOR_ROBOT_USER }}

--- a/.github/workflows/check-large-objects.yml
+++ b/.github/workflows/check-large-objects.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/check-rebase-on-main.yml
+++ b/.github/workflows/check-rebase-on-main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history to check ancestry
 

--- a/.github/workflows/enforce-PR-labelling.yml
+++ b/.github/workflows/enforce-PR-labelling.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Validate PR has labels
         id: check_labels

--- a/.github/workflows/enforce-issue-labelling.yml
+++ b/.github/workflows/enforce-issue-labelling.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate that the closed issue still has at least one label
         id: check_labels

--- a/.github/workflows/pre-commit-linter.yml
+++ b/.github/workflows/pre-commit-linter.yml
@@ -40,7 +40,7 @@ jobs:
       # because pre-commit (below) isn't configured to run them within the
       # CI actions.
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.9.0
           args: --config=.golangci.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           make goreleaser-config
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -48,7 +48,7 @@ jobs:
           check-latest: true
 
       - name: Cache Next.js
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           # Reference: https://nextjs.org/docs/pages/guides/ci-build-caching#github-actions
           path: |
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload JUnit report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: junit-${{ matrix.binary_name }}-${{ runner.os }}
           path: junit-${{ matrix.binary_name }}.xml
@@ -130,7 +130,7 @@ jobs:
           make goreleaser-config
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -44,7 +44,7 @@ jobs:
           check-latest: true
 
       - name: Cache Next.js
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           # Reference: https://nextjs.org/docs/pages/guides/ci-build-caching#github-actions
           path: |
@@ -91,7 +91,7 @@ jobs:
 
       - name: Upload JUnit report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: junit-${{ matrix.binary_name }}-${{ runner.os }}
           path: junit-${{ matrix.binary_name }}.xml
@@ -108,7 +108,7 @@ jobs:
           make goreleaser-config
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload JUnit report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: junit-${{ matrix.binary_name }}-${{ runner.os }}
           path: junit-${{ matrix.binary_name }}.xml
@@ -95,7 +95,7 @@ jobs:
         run: ./scripts/generate_goreleaser.sh .goreleaser.in.yml .goreleaser.generated.yml
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
Exactly what it says on the tin. Addresses warnings such as the following:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, docker/build-push-action@v5, docker/metadata-action@v5, docker/setup-buildx-action@v3. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

I am unable to address `test-summary/action` here because an updated version is not yet available.

There's also one `actions/cache@v4` warning I am unable to address because it is being triggered by the internals of `golanci/golangci-lint-action`.