### PR TITLE
Upgrade more actions to versions that run on Node.js 24

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -467,7 +467,7 @@ jobs:
           password: ${{ secrets.PELICAN_HARBOR_ROBOT_PASSWORD }}
 
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: digests-${{ matrix.image }}-*
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean --config .goreleaser.generated.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -133,7 +133,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: build --single-target --clean --snapshot --config .goreleaser.generated.yml
 
       - name: Copy the pelican binaries for the end-to-end tests

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -111,5 +111,5 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: build --single-target --clean --snapshot --config .goreleaser.generated.yml

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -98,5 +98,5 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: build --single-target --clean --snapshot --config .goreleaser.generated.yml

--- a/github_scripts/osx_install.sh
+++ b/github_scripts/osx_install.sh
@@ -21,7 +21,7 @@ set -ex
 # Mac OS X instance in GitHub.
 #
 
-brew install minio ninja coreutils
+brew install ninja coreutils
 
 # Attempted fix to install xrootd-s3-http, which relies on a dependency (nlohmann-json)
 # that requires cmake 3.5...4.0. The version pointed at here is the highest 3.X at the time

--- a/github_scripts/osx_install.sh
+++ b/github_scripts/osx_install.sh
@@ -21,7 +21,7 @@ set -ex
 # Mac OS X instance in GitHub.
 #
 
-brew install ninja coreutils
+brew install coreutils
 
 # Attempted fix to install xrootd-s3-http, which relies on a dependency (nlohmann-json)
 # that requires cmake 3.5...4.0. The version pointed at here is the highest 3.X at the time

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -769,14 +769,6 @@ RUN --mount=type=cache,id=dnf-${TARGETPLATFORM},target=/var/cache/dnf,sharing=lo
   dnf install -y condor
   rpm -e --nodeps pelican pelican-osdf-compat
 
-  # Install the MinIO server and client for S3 tests.
-  if [ "$TARGETARCH" = "amd64" ]; then
-      PKG_ARCH=x86_64
-  elif [ "$TARGETARCH" = "arm64" ]; then
-      PKG_ARCH=aarch64
-  fi
-  dnf install -y https://dl.min.io/server/minio/release/${TARGETOS}-${TARGETARCH}/archive/minio-20231214185157.0.0-1.${PKG_ARCH}.rpm
-
   # Add some normal user accounts for testing.
   # The inspiration for their names: https://en.wikipedia.org/wiki/Alice_and_Bob#Cast_of_characters.
   for name in alice bob carol dave; do


### PR DESCRIPTION
This is a follow up to #3397 wherein I read the output from our plethora of actions more carefully.

I'm also taking the opportunity to address the warning from the GoReleaser action by locking the version of GoReleaser used to a specific major version.

I'm also taking the opportunity to address the Minio warning in the macOS tests be simply no longer installing it — we actually haven't used it since 0a7acb1fda5545f607d69ffe414f4bf3f7da604e!

I'm also taking the opportunity to address the brew's warning about (re)installing Ninja in the macOS tests by also no longer installing it — [it's officially already there](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md)!