### PR TITLE
Now seeds rand with time to ensure actual randomness

### DIFF
--- a/client/director.go
+++ b/client/director.go
@@ -125,7 +125,7 @@ func queryDirector(ctx context.Context, verb string, pUrl *pelican_url.PelicanUR
 		}
 
 		forceDebug, _ := ctx.Value(directorDebugCtxKey{}).(bool)
-		if log.IsLevelEnabled(log.DebugLevel) || forceDebug {
+		if config.GetEffectiveLogLevel() >= log.DebugLevel || forceDebug {
 			req.Header.Set("X-Pelican-Debug", "true")
 		}
 

--- a/client/director_test.go
+++ b/client/director_test.go
@@ -24,6 +24,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -419,6 +421,81 @@ func TestDirectorDecisionInfo(t *testing.T) {
 		assert.Contains(t, body, "directorSortMethod")
 		assert.Contains(t, body, "distance")
 	})
+}
+
+// TestQueryDirectorDebugHeaderPercentage verifies that queryDirector sends the
+// X-Pelican-Debug header with the frequency determined by the caller's sampling
+// logic (mirroring Plugin.DirectorDecisionPercentage) — and no more.
+//
+// This test would have failed before the fix that replaced
+//
+//	log.IsLevelEnabled(log.DebugLevel)
+//
+// with
+//
+//	config.GetEffectiveLogLevel() >= log.DebugLevel
+//
+// in queryDirector. config.InitClient() calls initFilterLogging(), which
+// unconditionally sets logrus's global level to TraceLevel, making
+// log.IsLevelEnabled(log.DebugLevel) always return true. In the broken code the
+// header was therefore sent on every request, not just on the configured
+// percentage of requests.
+func TestQueryDirectorDebugHeaderPercentage(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+
+	// InitClient with a non-debug level. Critically, this calls initFilterLogging(),
+	// which sets logrus's global level to TraceLevel so that filter hooks see every
+	// message. Before the fix, log.IsLevelEnabled(log.DebugLevel) would return true
+	// here even though the configured level is "warning".
+	test_utils.InitClient(t, map[param.Param]any{
+		param.Client_DirectorRetries: 1,
+		param.Logging_Level:          "warning",
+	})
+
+	const pct = 20
+	require.NoError(t, param.Plugin_DirectorDecisionPercentage.Set(pct))
+
+	var debugHeaderCount int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Pelican-Debug") == "true" {
+			debugHeaderCount++
+		}
+		http.Redirect(w, r, "http://cache.example.com:8443/foo/bar", http.StatusTemporaryRedirect)
+	}))
+	defer ts.Close()
+
+	pUrl := &pelican_url.PelicanURL{
+		FedInfo: pelican_url.FederationDiscovery{DirectorEndpoint: ts.URL},
+		Path:    "/foo/bar",
+	}
+
+	// Use a fixed seed so the test is deterministic while still exercising the
+	// full sampling distribution.
+	const n = 10_000
+	for range n {
+		ctx := context.Background()
+		// Mirror the logic of shouldRequestDirectorDecision() in cmd/plugin.go:
+		// That function is tested separately, so here we use the shim to manually
+		// set the context value -- this test is really about testing the log level
+		// logic. While it'd be nice _not_ to shim things, the other function isn't
+		// exported from `cmd`.
+		if rand.Intn(100) < pct { //nolint:gosec
+			ctx = WithDirectorDebug(ctx)
+		}
+		_, _, err := queryDirector(ctx, http.MethodGet, pUrl, "", false)
+		require.NoError(t, err)
+	}
+
+	observed := float64(debugHeaderCount) / float64(n)
+	expected := float64(pct) / 100.0
+	// 6-sigma binomial tolerance: the probability of a spurious failure is ~1e-9.
+	sigma := math.Sqrt(expected * (1.0 - expected) / float64(n))
+	delta := 6.0*sigma + 0.002
+	assert.InDelta(t, expected, observed, delta,
+		"X-Pelican-Debug was set on %d/%d requests (%.1f%%), expected ~%d%%",
+		debugHeaderCount, n, observed*100, pct)
 }
 
 func TestDirectorTimeout(t *testing.T) {

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -77,7 +77,8 @@ const (
 	Retryable     = 11
 )
 
-func shouldRequestDirectorDecision(pct int) bool {
+func shouldRequestDirectorDecision() bool {
+	pct := param.Plugin_DirectorDecisionPercentage.GetInt()
 	if pct <= 0 {
 		return false
 	}
@@ -500,7 +501,7 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 
 			urlCopy := *(pUrl.GetRawUrl())
 			jobCtx := context.Background()
-			if shouldRequestDirectorDecision(param.Plugin_DirectorDecisionPercentage.GetInt()) {
+			if shouldRequestDirectorDecision() {
 				jobCtx = client.WithDirectorDebug(jobCtx)
 			}
 			tj, err = tc.NewTransferJob(jobCtx, &urlCopy, transfer.localFile, upload, recursive, client.WithAcquireToken(false), client.WithCaches(caches...))

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -77,6 +77,17 @@ const (
 	Retryable     = 11
 )
 
+func shouldRequestDirectorDecision(pct int) bool {
+	if pct <= 0 {
+		return false
+	}
+	if pct >= 100 {
+		return true
+	}
+	// We use [0,100) so pct=1 means ~1% and pct=99 means ~99%.
+	return rand.Intn(100) < pct
+}
+
 func init() {
 	rootCmd.AddCommand(rootPluginCmd)
 
@@ -489,7 +500,7 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 
 			urlCopy := *(pUrl.GetRawUrl())
 			jobCtx := context.Background()
-			if pct := param.Plugin_DirectorDecisionPercentage.GetInt(); pct > 0 && rand.Intn(100) < pct {
+			if shouldRequestDirectorDecision(param.Plugin_DirectorDecisionPercentage.GetInt()) {
 				jobCtx = client.WithDirectorDebug(jobCtx)
 			}
 			tj, err = tc.NewTransferJob(jobCtx, &urlCopy, transfer.localFile, upload, recursive, client.WithAcquireToken(false), client.WithCaches(caches...))

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -29,6 +29,8 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -70,6 +72,64 @@ var (
 	//go:embed resources/public-test-origin.yml
 	publicTestOrigin string
 )
+
+// Test that the configured percentage for requesting the Director's decision
+// information results in a corresponding fraction of transfers including
+// DeveloperData.DirectorDecision.
+//
+// This exercises the real production path in runPluginWorker that conditionally
+// applies client.WithDirectorDebug(...) based on Plugin.DirectorDecisionPercentage.
+func TestShouldRequestDirectorDecisionProbability(t *testing.T) {
+	// shouldRequestDirectorDecision uses the package-global RNG. Seed it so the
+	// behavior is deterministic and stable across runs.
+	rand.Seed(1)
+	t.Cleanup(func() { rand.Seed(time.Now().UnixNano()) })
+
+	t.Run("EdgeCases", func(t *testing.T) {
+		assert.False(t, shouldRequestDirectorDecision(-1))
+		assert.False(t, shouldRequestDirectorDecision(0))
+		assert.True(t, shouldRequestDirectorDecision(100))
+		assert.True(t, shouldRequestDirectorDecision(101))
+	})
+
+	t.Run("ProbabilityWithinDelta", func(t *testing.T) {
+		type tc struct {
+			pct int
+			n   int
+		}
+		cases := []tc{
+			{pct: 1, n: 200000},
+			{pct: 10, n: 100000},
+			{pct: 33, n: 100000},
+			{pct: 50, n: 80000},
+			{pct: 90, n: 100000},
+			{pct: 99, n: 200000},
+		}
+
+		for _, c := range cases {
+			t.Run(fmt.Sprintf("pct=%d", c.pct), func(t *testing.T) {
+				var hits int
+				for i := 0; i < c.n; i++ {
+					if shouldRequestDirectorDecision(c.pct) {
+						hits++
+					}
+				}
+
+				observed := float64(hits) / float64(c.n)
+				expected := float64(c.pct) / 100.0
+
+				// Binomial proportion std dev: sqrt(p(1-p)/n). Use a generous 6-sigma
+				// band + small constant to avoid pathological failures at extremes.
+				sigma := math.Sqrt(expected * (1.0 - expected) / float64(c.n))
+				delta := 6.0*sigma + 0.002
+
+				assert.InDelta(t, expected, observed, delta,
+					"observed rate %g should be within %g of expected %g (hits=%d n=%d)",
+					observed, delta, expected, hits, c.n)
+			})
+		}
+	})
+}
 
 // TestReadMultiTransfer test if we can read multiple transfers from stdin
 func TestReadMultiTransfer(t *testing.T) {

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -30,7 +30,6 @@ import (
 	"io"
 	"io/fs"
 	"math"
-	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -80,16 +79,15 @@ var (
 // This exercises the real production path in runPluginWorker that conditionally
 // applies client.WithDirectorDebug(...) based on Plugin.DirectorDecisionPercentage.
 func TestShouldRequestDirectorDecisionProbability(t *testing.T) {
-	// shouldRequestDirectorDecision uses the package-global RNG. Seed it so the
-	// behavior is deterministic and stable across runs.
-	rand.Seed(1)
-	t.Cleanup(func() { rand.Seed(time.Now().UnixNano()) })
-
 	t.Run("EdgeCases", func(t *testing.T) {
-		assert.False(t, shouldRequestDirectorDecision(-1))
-		assert.False(t, shouldRequestDirectorDecision(0))
-		assert.True(t, shouldRequestDirectorDecision(100))
-		assert.True(t, shouldRequestDirectorDecision(101))
+		require.NoError(t, param.Plugin_DirectorDecisionPercentage.Set(-1))
+		assert.False(t, shouldRequestDirectorDecision())
+		require.NoError(t, param.Plugin_DirectorDecisionPercentage.Set(0))
+		assert.False(t, shouldRequestDirectorDecision())
+		require.NoError(t, param.Plugin_DirectorDecisionPercentage.Set(100))
+		assert.True(t, shouldRequestDirectorDecision())
+		require.NoError(t, param.Plugin_DirectorDecisionPercentage.Set(101))
+		assert.True(t, shouldRequestDirectorDecision())
 	})
 
 	t.Run("ProbabilityWithinDelta", func(t *testing.T) {
@@ -97,20 +95,19 @@ func TestShouldRequestDirectorDecisionProbability(t *testing.T) {
 			pct int
 			n   int
 		}
-		cases := []tc{
-			{pct: 1, n: 200000},
-			{pct: 10, n: 100000},
-			{pct: 33, n: 100000},
-			{pct: 50, n: 80000},
-			{pct: 90, n: 100000},
-			{pct: 99, n: 200000},
-		}
+		// Use a large, constant n so this test is extremely unlikely to fail while
+		// still running quickly. With a 6-sigma tolerance, the false-fail rate is
+		// on the order of 1e-9 per case for a true binomial process.
+		const n = 1_000_000
+		cases := []tc{{pct: 1, n: n}, {pct: 10, n: n}, {pct: 33, n: n}, {pct: 50, n: n}, {pct: 90, n: n}, {pct: 99, n: n}}
 
 		for _, c := range cases {
 			t.Run(fmt.Sprintf("pct=%d", c.pct), func(t *testing.T) {
+				require.NoError(t, param.Plugin_DirectorDecisionPercentage.Set(c.pct))
+
 				var hits int
 				for i := 0; i < c.n; i++ {
-					if shouldRequestDirectorDecision(c.pct) {
+					if shouldRequestDirectorDecision() {
 						hits++
 					}
 				}


### PR DESCRIPTION
Actually ensures that the random seed isn't the same value repeated over and over again. Which caused the randomness not to be random. (So ~20% requests for new director info was turning up as 100% before this change).

