### PR TITLE
Skip activation flow when admins are pre-configured

### DIFF
--- a/server_utils/server_utils.go
+++ b/server_utils/server_utils.go
@@ -60,6 +60,7 @@ var posixv2Reset func()
 var sshBackendReset func()
 var brokerReset func()
 var pelicanUrlReset func()
+var webUIReset func()
 
 // RegisterXrootdReset allows the xrootd package to provide a reset hook without introducing import cycles.
 func RegisterXrootdReset(fn func()) {
@@ -84,6 +85,11 @@ func RegisterBrokerReset(fn func()) {
 // RegisterPelicanUrlReset allows the pelican_url package to provide a reset hook without introducing import cycles.
 func RegisterPelicanUrlReset(fn func()) {
 	pelicanUrlReset = fn
+}
+
+// RegisterWebUIReset allows the web_ui package to provide a reset hook without introducing import cycles.
+func RegisterWebUIReset(fn func()) {
+	webUIReset = fn
 }
 
 // GetTopologyJSON returns the namespaces and caches from OSDF topology
@@ -362,6 +368,9 @@ func ResetTestState() {
 	}
 	if pelicanUrlReset != nil {
 		pelicanUrlReset()
+	}
+	if webUIReset != nil {
+		webUIReset()
 	}
 	ResetOriginExports()
 	logging.ResetLogFlush()

--- a/web_ui/authentication.go
+++ b/web_ui/authentication.go
@@ -555,6 +555,13 @@ func DowntimeAuthHandler(ctx *gin.Context) {
 func loginHandler(ctx *gin.Context) {
 	db := authDB.Load()
 	if db == nil {
+		if hasConfiguredAdmins() {
+			ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "Password login is not available",
+			})
+			return
+		}
 		newPath := path.Join(ctx.Request.URL.Path, "..", "initLogin")
 		initUrl := ctx.Request.URL
 		initUrl.Path = newPath
@@ -634,6 +641,13 @@ func loginHandler(ctx *gin.Context) {
 
 // Handle initial code-based login for admin
 func initLoginHandler(ctx *gin.Context) {
+	if hasConfiguredAdmins() {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Activation code login is not available",
+		})
+		return
+	}
 	db := authDB.Load()
 	if db != nil {
 		ctx.JSON(400,

--- a/web_ui/authentication.go
+++ b/web_ui/authentication.go
@@ -642,10 +642,11 @@ func loginHandler(ctx *gin.Context) {
 // Handle initial code-based login for admin
 func initLoginHandler(ctx *gin.Context) {
 	if hasConfiguredAdmins() {
-		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
-			Status: server_structs.RespFailed,
-			Msg:    "Activation code login is not available",
-		})
+		ctx.JSON(http.StatusBadRequest,
+			server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "Code-based login is not available",
+			})
 		return
 	}
 	db := authDB.Load()

--- a/web_ui/reset_register.go
+++ b/web_ui/reset_register.go
@@ -1,0 +1,33 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package web_ui
+
+import (
+	"sync"
+
+	"github.com/pelicanplatform/pelican/server_utils"
+)
+
+func init() {
+	server_utils.RegisterWebUIReset(func() {
+		authDB.Store(nil)
+		configuredAdminsOnce = sync.Once{}
+		configuredAdminsVal = false
+	})
+}

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -35,6 +35,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -273,7 +274,6 @@ func handleWebUIRedirect(ctx *gin.Context) {
 
 func handleWebUIAuth(ctx *gin.Context) {
 	requestPath := ctx.Param("requestPath")
-	db := authDB.Load()
 	user, userId, groups, err := GetUserGroups(ctx)
 
 	// Skip auth check for static files other than html pages
@@ -282,9 +282,10 @@ func handleWebUIAuth(ctx *gin.Context) {
 		return
 	}
 
-	// Handle initialization. If db is nill, then redirect user to the initialization page
+	// Handle initialization.
+	// If the web UI is not yet initialized, redirect to the initialization page.
 	if strings.HasPrefix(requestPath, "/initialization") {
-		if db != nil { // Password initialized, redirect away from the init page
+		if shouldSkipActivationFlow() {
 			ctx.Redirect(http.StatusFound, "/view/")
 			ctx.Abort()
 			return
@@ -292,7 +293,7 @@ func handleWebUIAuth(ctx *gin.Context) {
 			ctx.Next()
 			return
 		}
-	} else if db == nil { // For all other paths, if the password is not initialized
+	} else if !shouldSkipActivationFlow() {
 		ctx.Redirect(http.StatusFound, "/view/initialization/code/")
 		ctx.Abort()
 		return
@@ -721,10 +722,40 @@ func configureMetrics(engine *gin.Engine) error {
 	return nil
 }
 
+// hasConfiguredAdmins reports whether at least one admin identity
+// is configured via Server.UIAdminUsers or Server.AdminGroups.
+// The result is computed once and cached: admin configuration is a
+// startup-time decision, and caching prevents live Viper state from
+// affecting the activation-flow gate mid-run.
+var (
+	configuredAdminsOnce sync.Once
+	configuredAdminsVal  bool
+)
+
+func hasConfiguredAdmins() bool {
+	configuredAdminsOnce.Do(func() {
+		configuredAdminsVal = len(param.Server_UIAdminUsers.GetStringSlice()) > 0 ||
+			len(param.Server_AdminGroups.GetStringSlice()) > 0
+	})
+	return configuredAdminsVal
+}
+
+// shouldSkipActivationFlow reports whether the one-time activation-code
+// flow should be skipped. It returns true if the htpasswd file has been
+// bootstrapped or if at least one admin identity has been configured
+// (meaning an admin can log in without completing the activation flow).
+func shouldSkipActivationFlow() bool {
+	return authDB.Load() != nil || hasConfiguredAdmins()
+}
+
 // Send the one-time code for initial web UI login to stdout and periodically
 // re-generate one-time code if user hasn't finished setup
 func waitUntilLogin(ctx context.Context) error {
-	if authDB.Load() != nil {
+	activationFile := param.Server_UIActivationCodeFile.GetString()
+
+	if shouldSkipActivationFlow() {
+		// Remove any stale activation file left from a previous run.
+		_ = os.Remove(activationFile)
 		return nil
 	}
 	sigs := make(chan os.Signal, 1)
@@ -737,7 +768,6 @@ func waitUntilLogin(ctx context.Context) error {
 		isTTY = true
 		fmt.Printf("\n\n\n\n")
 	}
-	activationFile := param.Server_UIActivationCodeFile.GetString()
 
 	defer func() {
 		if err := os.Remove(activationFile); err != nil {
@@ -774,7 +804,7 @@ func waitUntilLogin(ctx context.Context) error {
 			default:
 				time.Sleep(100 * time.Millisecond)
 			}
-			if authDB.Load() != nil {
+			if shouldSkipActivationFlow() {
 				return nil
 			}
 		}

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -283,7 +283,8 @@ func handleWebUIAuth(ctx *gin.Context) {
 	}
 
 	// Handle initialization.
-	// If the web UI is not yet initialized, redirect to the initialization page.
+	// If the web UI is not yet initialized and no admin identities
+	// are pre-configured, redirect to the initialization page.
 	if strings.HasPrefix(requestPath, "/initialization") {
 		if shouldSkipActivationFlow() {
 			ctx.Redirect(http.StatusFound, "/view/")
@@ -755,7 +756,9 @@ func waitUntilLogin(ctx context.Context) error {
 
 	if shouldSkipActivationFlow() {
 		// Remove any stale activation file left from a previous run.
-		_ = os.Remove(activationFile)
+		if activationFile != "" {
+			_ = os.Remove(activationFile)
+		}
 		return nil
 	}
 	sigs := make(chan os.Signal, 1)
@@ -770,8 +773,10 @@ func waitUntilLogin(ctx context.Context) error {
 	}
 
 	defer func() {
-		if err := os.Remove(activationFile); err != nil {
-			log.Warningf("Failed to remove activation code file (%v): %v\n", activationFile, err)
+		if activationFile != "" {
+			if err := os.Remove(activationFile); err != nil {
+				log.Warningf("Failed to remove activation code file (%v): %v\n", activationFile, err)
+			}
 		}
 	}()
 	for {

--- a/web_ui/ui_test.go
+++ b/web_ui/ui_test.go
@@ -185,7 +185,7 @@ func TestHandleWebUIAuth(t *testing.T) {
 	t.Run("no-redirect-to-login-with-db-initialized", func(t *testing.T) {
 		// We let the frontend to handle unauthorized user (if the password is initialized)
 		setupTestAuthDB(t)
-		t.Cleanup(cleanupAuthDB)
+		t.Cleanup(server_utils.ResetTestState)
 
 		r := httptest.NewRecorder()
 		// This route is not in ui.go/adminAccessPages, so we will pass the admin check and return 200
@@ -209,18 +209,13 @@ func TestHandleWebUIAuth(t *testing.T) {
 		route.ServeHTTP(r, req)
 
 		assert.Equal(t, http.StatusFound, r.Result().StatusCode)
-
-		authDB.Store(nil)
 	})
 
 	t.Run("403-for-logged-in-non-admin-user", func(t *testing.T) {
 		server_utils.ResetTestState()
 		// We let the frontend to handle unauthorized user (if the password is initialized)
 		setupTestAuthDB(t)
-		t.Cleanup(func() {
-			cleanupAuthDB()
-			server_utils.ResetTestState()
-		})
+		t.Cleanup(server_utils.ResetTestState)
 
 		tmpDir := t.TempDir()
 		issuerDirectory := filepath.Join(tmpDir, "issuer-keys")
@@ -277,13 +272,11 @@ func TestHandleWebUIAuth(t *testing.T) {
 		req.AddCookie(&http.Cookie{Name: "login", Value: tok})
 		route.ServeHTTP(r, req)
 		assert.Equal(t, http.StatusFound, r.Result().StatusCode)
-
-		authDB.Store(nil)
 	})
 
 	t.Run("init-page-redirect-to-root-with-db-initialized", func(t *testing.T) {
 		setupTestAuthDB(t)
-		t.Cleanup(cleanupAuthDB)
+		t.Cleanup(server_utils.ResetTestState)
 
 		r := httptest.NewRecorder()
 		req, err := http.NewRequest("GET", "/view/initialization/code/", nil)
@@ -298,8 +291,6 @@ func TestHandleWebUIAuth(t *testing.T) {
 		route.ServeHTTP(r, req)
 
 		assert.Equal(t, "/view/", r.Result().Header.Get("Location"))
-
-		authDB.Store(nil)
 	})
 
 	t.Run("skip-check-on-non-html-file", func(t *testing.T) {
@@ -315,7 +306,7 @@ func TestHandleWebUIAuth(t *testing.T) {
 
 	t.Run("pass-check-on-director", func(t *testing.T) {
 		setupTestAuthDB(t)
-		t.Cleanup(cleanupAuthDB)
+		t.Cleanup(server_utils.ResetTestState)
 
 		r := httptest.NewRecorder()
 		req, err := http.NewRequest("GET", "/view/director/index.html", nil)
@@ -328,7 +319,7 @@ func TestHandleWebUIAuth(t *testing.T) {
 
 	t.Run("pass-check-on-registry", func(t *testing.T) {
 		setupTestAuthDB(t)
-		t.Cleanup(cleanupAuthDB)
+		t.Cleanup(server_utils.ResetTestState)
 
 		r := httptest.NewRecorder()
 		req, err := http.NewRequest("GET", "/view/registry/index.html", nil)
@@ -337,6 +328,90 @@ func TestHandleWebUIAuth(t *testing.T) {
 
 		assert.Equal(t, 200, r.Result().StatusCode)
 		assert.Equal(t, "", r.Result().Header.Get("Location"))
+	})
+}
+
+func TestShouldSkipActivationFlow(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+
+	t.Run("false-without-db-or-admins", func(t *testing.T) {
+		cleanupAuthDB()
+		t.Cleanup(server_utils.ResetTestState)
+		assert.False(t, shouldSkipActivationFlow())
+	})
+
+	t.Run("true-with-authdb-set", func(t *testing.T) {
+		setupTestAuthDB(t)
+		t.Cleanup(func() {
+			cleanupAuthDB()
+			server_utils.ResetTestState()
+		})
+		assert.True(t, shouldSkipActivationFlow())
+	})
+
+	t.Run("true-with-admin-users-configured", func(t *testing.T) {
+		cleanupAuthDB()
+		t.Cleanup(server_utils.ResetTestState)
+		require.NoError(t, param.Server_UIAdminUsers.Set([]string{"admin@example.com"}))
+		assert.True(t, shouldSkipActivationFlow())
+	})
+
+	t.Run("true-with-admin-groups-configured", func(t *testing.T) {
+		cleanupAuthDB()
+		t.Cleanup(server_utils.ResetTestState)
+		require.NoError(t, param.Server_AdminGroups.Set([]string{"admins"}))
+		assert.True(t, shouldSkipActivationFlow())
+	})
+
+	t.Run("false-with-empty-admin-slices", func(t *testing.T) {
+		cleanupAuthDB()
+		t.Cleanup(server_utils.ResetTestState)
+		require.NoError(t, param.Server_UIAdminUsers.Set([]string{}))
+		require.NoError(t, param.Server_AdminGroups.Set([]string{}))
+		assert.False(t, shouldSkipActivationFlow())
+	})
+
+	t.Run("latch-caches-result", func(t *testing.T) {
+		cleanupAuthDB()
+		t.Cleanup(server_utils.ResetTestState)
+		// First call should return false (no admins, no authDB).
+		assert.False(t, hasConfiguredAdmins())
+		// Setting admins after the latch fires must not change the result.
+		require.NoError(t, param.Server_UIAdminUsers.Set([]string{"admin@example.com"}))
+		assert.False(t, hasConfiguredAdmins(), "latch should have cached the initial false result")
+	})
+}
+
+func TestHandleWebUIAuthWithConfiguredAdmins(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	route := gin.New()
+	route.GET("/view/*requestPath", handleWebUIAuth, func(ctx *gin.Context) { ctx.Status(200) })
+
+	t.Run("no-redirect-to-init-when-admins-configured", func(t *testing.T) {
+		cleanupAuthDB()
+		t.Cleanup(server_utils.ResetTestState)
+		require.NoError(t, param.Server_UIAdminUsers.Set([]string{"admin@example.com"}))
+
+		r := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/view/test.html", nil)
+		require.NoError(t, err)
+		route.ServeHTTP(r, req)
+
+		assert.Equal(t, http.StatusOK, r.Result().StatusCode)
+		assert.Empty(t, r.Result().Header.Get("Location"))
+	})
+
+	t.Run("init-page-redirects-to-root-when-admins-configured", func(t *testing.T) {
+		cleanupAuthDB()
+		t.Cleanup(server_utils.ResetTestState)
+		require.NoError(t, param.Server_UIAdminUsers.Set([]string{"admin@example.com"}))
+
+		r := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/view/initialization/code/", nil)
+		require.NoError(t, err)
+		route.ServeHTTP(r, req)
+
+		assert.Equal(t, "/view/", r.Result().Header.Get("Location"))
 	})
 }
 

--- a/web_ui/ui_test.go
+++ b/web_ui/ui_test.go
@@ -342,10 +342,7 @@ func TestShouldSkipActivationFlow(t *testing.T) {
 
 	t.Run("true-with-authdb-set", func(t *testing.T) {
 		setupTestAuthDB(t)
-		t.Cleanup(func() {
-			cleanupAuthDB()
-			server_utils.ResetTestState()
-		})
+		t.Cleanup(server_utils.ResetTestState)
 		assert.True(t, shouldSkipActivationFlow())
 	})
 


### PR DESCRIPTION
## Summary

htpasswd file present | Admins pre-configured | Activation flow
-- | -- | --
No | No | Required — activation code printed to stdout; server waits for login
Yes | No | Skipped — htpasswd already bootstrapped
No | Yes | Skipped — admin can log in via OAuth2
Yes | Yes | Skipped — both paths available

## Details

_(With a tip of the hat to [Copilot](https://github.com/apps/github-copilot-cli))_

Closes #1747.

When `Server.UIAdminUsers` or `Server.AdminGroups` is set, at least one admin can already authenticate via OAuth2, so the one-time activation-code flow serves no purpose. This PR skips that flow in those cases:

- `handleWebUIAuth` no longer redirects to the initialization page, and visiting the initialization page redirects away to `/view/`.
- `waitUntilLogin` exits immediately, cleaning up any stale activation file from a prior run.
- `loginHandler` and `initLoginHandler` return HTTP 400, since password-based login is not meaningful in this mode.

A `sync.Once`-guarded helper, `hasConfiguredAdmins()`, reads the two config slices once at startup and caches the result. A reset hook is registered with `server_utils` so that `ResetTestState` clears the latch between tests.