### PR TITLE
Ignore non-YAML files in ConfigLocations directories

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -822,6 +822,19 @@ func setupTranslation() error {
 // files in those directories according to directory-scoped lexicographical order. This allows users/admins to split
 // their configuration across multiple directories/files.
 //
+// isSupportedConfigExt reports whether the file extension of name is one of
+// the formats that Pelican's config parser understands. Only files that pass
+// this check are loaded from a ConfigLocations directory; everything else
+// (editor backup files such as "~" or ".bak", package-manager saves such as
+// ".rpmsave"/".rpmnew", etc.) is silently skipped.
+//
+// If Pelican ever gains support for an additional config format (e.g. TOML),
+// add the corresponding extension here.
+func isSupportedConfigExt(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	return ext == ".yaml" || ext == ".yml"
+}
+
 // Config merging is handled by viper. For more information, see https://pkg.go.dev/github.com/spf13/viper#MergeConfig
 func handleContinuedCfg() error {
 	cfgDirs := viper.GetStringSlice("ConfigLocations")
@@ -846,7 +859,7 @@ func handleContinuedCfg() error {
 			if err != nil {
 				return err
 			}
-			if !d.IsDir() && path != "." {
+			if !d.IsDir() && path != "." && isSupportedConfigExt(path) {
 				configFiles = append(configFiles, path)
 			}
 			return nil

--- a/config/config.go
+++ b/config/config.go
@@ -818,23 +818,18 @@ func setupTranslation() error {
 	})
 }
 
+// isSupportedConfigExt returns whether the file extension of path
+// corresponds to a format that Pelican's config parser understands
+// and considers to be a "real" file and not a backup.
+func isSupportedConfigExt(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	return ext == ".yaml" || ext == ".yml"
+}
+
 // If the config file defines a "ConfigLocations" key and a list of corresponding directories, we parse all the yaml
 // files in those directories according to directory-scoped lexicographical order. This allows users/admins to split
 // their configuration across multiple directories/files.
 //
-// isSupportedConfigExt reports whether the file extension of name is one of
-// the formats that Pelican's config parser understands. Only files that pass
-// this check are loaded from a ConfigLocations directory; everything else
-// (editor backup files such as "~" or ".bak", package-manager saves such as
-// ".rpmsave"/".rpmnew", etc.) is silently skipped.
-//
-// If Pelican ever gains support for an additional config format (e.g. TOML),
-// add the corresponding extension here.
-func isSupportedConfigExt(name string) bool {
-	ext := strings.ToLower(filepath.Ext(name))
-	return ext == ".yaml" || ext == ".yml"
-}
-
 // Config merging is handled by viper. For more information, see https://pkg.go.dev/github.com/spf13/viper#MergeConfig
 func handleContinuedCfg() error {
 	cfgDirs := viper.GetStringSlice("ConfigLocations")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -506,6 +506,38 @@ func TestExtraCfg(t *testing.T) {
 		assert.Equal(t, "bar", viper.GetString("otherVal"))
 	})
 
+	t.Run("test-backup-files-ignored", func(t *testing.T) {
+		// Verify that editor/package-manager backup files in a ConfigLocations
+		// directory are silently ignored. Only .yaml/.yml files should be read.
+		ResetConfig()
+		dir1 := t.TempDir()
+		setupConfigLocations(t, []string{dir1})
+
+		// The valid YAML file sets the expected value.
+		err := os.WriteFile(filepath.Join(dir1, "config.yaml"), []byte("TestVal: correct"), 0644)
+		require.NoError(t, err)
+
+		// Each backup variant carries a conflicting value that must NOT be loaded.
+		backupFiles := map[string]string{
+			"config.yaml~":       "TestVal: from-tilde",
+			"config.yaml.bak":    "TestVal: from-bak",
+			"config.rpmsave":     "TestVal: from-rpmsave",
+			"config.rpmnew":      "TestVal: from-rpmnew",
+			"config.dpkg-old":    "TestVal: from-dpkg-old",
+			"config.dpkg-dist":   "TestVal: from-dpkg-dist",
+			"config.cfsave":      "TestVal: from-cfsave",
+			"config.noextension": "TestVal: from-noext",
+		}
+		for name, content := range backupFiles {
+			err = os.WriteFile(filepath.Join(dir1, name), []byte(content), 0644)
+			require.NoError(t, err)
+		}
+
+		err = handleContinuedCfg()
+		assert.NoError(t, err)
+		assert.Equal(t, "correct", viper.GetString("TestVal"), "backup files must not override the YAML config")
+	})
+
 	t.Run("test-bad-directory", func(t *testing.T) {
 		ResetConfig()
 		continueDir := t.TempDir()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -521,15 +521,15 @@ func TestExtraCfg(t *testing.T) {
 		// Files are processed in lexicographic order,
 		// so ensure that their names come after "config.yaml".
 		backupFiles := map[string]string{
-			"extra_config.yaml.swp":        "TestVal: from-swp",
-			"extra_config.yaml~":           "TestVal: from-tilde",
-			"extra_config.yaml.bak":        "TestVal: from-bak",
-			"extra_config.yaml.rpmsave":    "TestVal: from-rpmsave",
-			"extra_config.yaml.rpmnew":     "TestVal: from-rpmnew",
-			"extra_config.yaml.dpkg-old":   "TestVal: from-dpkg-old",
-			"extra_config.yaml.dpkg-dist":  "TestVal: from-dpkg-dist",
-			"extra_config.yaml.cfsave":     "TestVal: from-cfsave",
-			"extra_config":                 "TestVal: from-noext",
+			"extra_config.yaml.swp":       "TestVal: from-swp",
+			"extra_config.yaml~":          "TestVal: from-tilde",
+			"extra_config.yaml.bak":       "TestVal: from-bak",
+			"extra_config.yaml.rpmsave":   "TestVal: from-rpmsave",
+			"extra_config.yaml.rpmnew":    "TestVal: from-rpmnew",
+			"extra_config.yaml.dpkg-old":  "TestVal: from-dpkg-old",
+			"extra_config.yaml.dpkg-dist": "TestVal: from-dpkg-dist",
+			"extra_config.yaml.cfsave":    "TestVal: from-cfsave",
+			"extra_config":                "TestVal: from-noext",
 		}
 		for name, content := range backupFiles {
 			err = os.WriteFile(filepath.Join(dir1, name), []byte(content), 0644)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -518,15 +518,18 @@ func TestExtraCfg(t *testing.T) {
 		require.NoError(t, err)
 
 		// Each backup variant carries a conflicting value that must NOT be loaded.
+		// Files are processed in lexicographic order,
+		// so ensure that their names come after "config.yaml".
 		backupFiles := map[string]string{
-			"config.yaml~":       "TestVal: from-tilde",
-			"config.yaml.bak":    "TestVal: from-bak",
-			"config.rpmsave":     "TestVal: from-rpmsave",
-			"config.rpmnew":      "TestVal: from-rpmnew",
-			"config.dpkg-old":    "TestVal: from-dpkg-old",
-			"config.dpkg-dist":   "TestVal: from-dpkg-dist",
-			"config.cfsave":      "TestVal: from-cfsave",
-			"config.noextension": "TestVal: from-noext",
+			"extra_config.yaml.swp":    "TestVal: from-swp",
+			"extra_config.yaml~":       "TestVal: from-tilde",
+			"extra_config.yaml.bak":    "TestVal: from-bak",
+			"extra_config.rpmsave":     "TestVal: from-rpmsave",
+			"extra_config.rpmnew":      "TestVal: from-rpmnew",
+			"extra_config.dpkg-old":    "TestVal: from-dpkg-old",
+			"extra_config.dpkg-dist":   "TestVal: from-dpkg-dist",
+			"extra_config.cfsave":      "TestVal: from-cfsave",
+			"extra_config.noextension": "TestVal: from-noext",
 		}
 		for name, content := range backupFiles {
 			err = os.WriteFile(filepath.Join(dir1, name), []byte(content), 0644)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -521,15 +521,15 @@ func TestExtraCfg(t *testing.T) {
 		// Files are processed in lexicographic order,
 		// so ensure that their names come after "config.yaml".
 		backupFiles := map[string]string{
-			"extra_config.yaml.swp":    "TestVal: from-swp",
-			"extra_config.yaml~":       "TestVal: from-tilde",
-			"extra_config.yaml.bak":    "TestVal: from-bak",
-			"extra_config.rpmsave":     "TestVal: from-rpmsave",
-			"extra_config.rpmnew":      "TestVal: from-rpmnew",
-			"extra_config.dpkg-old":    "TestVal: from-dpkg-old",
-			"extra_config.dpkg-dist":   "TestVal: from-dpkg-dist",
-			"extra_config.cfsave":      "TestVal: from-cfsave",
-			"extra_config.noextension": "TestVal: from-noext",
+			"extra_config.yaml.swp":        "TestVal: from-swp",
+			"extra_config.yaml~":           "TestVal: from-tilde",
+			"extra_config.yaml.bak":        "TestVal: from-bak",
+			"extra_config.yaml.rpmsave":    "TestVal: from-rpmsave",
+			"extra_config.yaml.rpmnew":     "TestVal: from-rpmnew",
+			"extra_config.yaml.dpkg-old":   "TestVal: from-dpkg-old",
+			"extra_config.yaml.dpkg-dist":  "TestVal: from-dpkg-dist",
+			"extra_config.yaml.cfsave":     "TestVal: from-cfsave",
+			"extra_config":                 "TestVal: from-noext",
 		}
 		for name, content := range backupFiles {
 			err = os.WriteFile(filepath.Join(dir1, name), []byte(content), 0644)


### PR DESCRIPTION
_(With a tip of the hat to [Copilot](https://github.com/apps/github-copilot-cli))_

Pelican reads every file it finds in each `ConfigLocations` directory. This means editor backup files (e.g., `~`, `.bak`) and package-manager saves (e.g., `.rpmsave`, `.rpmnew`) are silently merged into the configuration, causing admin changes to appear to have no effect.

- Add `isSupportedConfigExt` in `config/config.go` — an allowlist predicate that accepts `.yaml` and `.yml` (case-insensitive). This is the single place to update if Pelican ever gains support for additional config formats.
- Update `handleContinuedCfg` to skip any file that does not pass the check.
- Add a `test-backup-files-ignored` subtest to `TestExtraCfg` that places every backup-suffix variant mentioned in the issue alongside a valid YAML file and asserts only the YAML value is loaded.

Fixes #2703.
