### PR TITLE
Revert "Hide some docs/CLI commands"

### DIFF
--- a/cmd/rclone.go
+++ b/cmd/rclone.go
@@ -26,9 +26,8 @@ import (
 
 var (
 	rcloneCmd = &cobra.Command{
-		Use:    "rclone",
-		Hidden: true,
-		Short:  "Commands for integrating Pelican with rclone",
+		Use:   "rclone",
+		Short: "Commands for integrating Pelican with rclone",
 		Long: `The rclone subcommands help integrate Pelican with the rclone tool
 for syncing files to and from Pelican federations.
 

--- a/docs/app/commands-reference/_meta.js
+++ b/docs/app/commands-reference/_meta.js
@@ -13,7 +13,7 @@ export default {
     "object": "pelican object",
     "origin": "pelican origin",
     "plugin": "pelican plugin",
-    // "rclone": "pelican rclone", // hidden: rclone integration not yet functional
+    "rclone": "pelican rclone",
     "registry": "pelican registry",
     "server": "pelican server",
     "token": "pelican token",

--- a/docs/app/commands-reference/origin/_meta.js
+++ b/docs/app/commands-reference/origin/_meta.js
@@ -3,7 +3,7 @@ export default {
     "config": "pelican origin config",
     "issuer": "pelican origin issuer",
     "serve": "pelican origin serve",
-    // "ssh-auth": "pelican origin ssh-auth", // hidden: SSH origin backend not yet functional
+    "ssh-auth": "pelican origin ssh-auth",
     "token": "pelican origin token",
     "web-ui": "pelican origin web-ui",
 }

--- a/docs/app/commands-reference/origin/page.mdx
+++ b/docs/app/commands-reference/origin/page.mdx
@@ -30,6 +30,6 @@ Operate a Pelican origin service
 * [pelican origin config](/commands-reference/origin/config/)	 - Launch the Pelican web service in configuration mode
 * [pelican origin issuer](/commands-reference/origin/issuer/)	 - Manage the origin's embedded OIDC token issuer
 * [pelican origin serve](/commands-reference/origin/serve/)	 - Start the origin service
-{/* * [pelican origin ssh-auth](/commands-reference/origin/ssh-auth/)	 - SSH authentication tools for the SSH backend */}
+* [pelican origin ssh-auth](/commands-reference/origin/ssh-auth/)	 - SSH authentication tools for the SSH backend
 * [pelican origin token](/commands-reference/origin/token/)	 - Manage Pelican origin tokens
 * [pelican origin web-ui](/commands-reference/origin/web-ui/)	 - Manage the Pelican origin web UI

--- a/docs/app/commands-reference/page.mdx
+++ b/docs/app/commands-reference/page.mdx
@@ -40,7 +40,7 @@ across multiple dataset providers.
 * [pelican object](/commands-reference/object/)	 - Interact with objects in the federation
 * [pelican origin](/commands-reference/origin/)	 - Operate a Pelican origin service
 * [pelican plugin](/commands-reference/plugin/)	 - Plugin management for HTCSS
-{/* * [pelican rclone](/commands-reference/rclone/)  - Commands for integrating Pelican with rclone */}
+* [pelican rclone](/commands-reference/rclone/)	 - Commands for integrating Pelican with rclone
 * [pelican registry](/commands-reference/registry/)	 - Interact with a Pelican registry service
 * [pelican server](/commands-reference/server/)	 - Manage server operations
 * [pelican token](/commands-reference/token/)	 - Interact with tokens used to interact with objects in Pelican

--- a/docs/app/federating-your-data/_meta.js
+++ b/docs/app/federating-your-data/_meta.js
@@ -3,6 +3,6 @@ export default {
     "origin": "Serving an Origin",
     "s3-backend": "S3 Backend",
     "globus-backend": "Globus Backend",
-    // "ssh-backend": "SSH Backend", // hidden: SSH origin backend not yet functional
+    "ssh-backend": "SSH Backend",
     "generating-tokens": "Generating Tokens",
 }

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1675,7 +1675,6 @@ description: |+
   When Origin.StorageType is set to "ssh", this parameter is required.
 type: string
 default: none
-hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.Port
@@ -1683,7 +1682,6 @@ description: |+
   The SSH port to connect to on the remote server.
 type: int
 default: 22
-hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.User
@@ -1691,7 +1689,6 @@ description: |+
   The SSH username to use for authentication.
 type: string
 default: none
-hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.AuthMethods
@@ -1706,7 +1703,6 @@ description: |+
   If not specified, defaults to trying: publickey, agent, keyboard-interactive, password
 type: stringSlice
 default: ["publickey", "agent", "keyboard-interactive", "password"]
-hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.PasswordFile
@@ -1717,7 +1713,6 @@ description: |+
   Used when "password" is in the AuthMethods list.
 type: filename
 default: none
-hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.PrivateKeyFile
@@ -1727,7 +1722,6 @@ description: |+
   Supports RSA, ECDSA, and Ed25519 keys.
 type: filename
 default: none
-hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.PrivateKeyPassphraseFile
@@ -1737,7 +1731,6 @@ description: |+
   Only needed if the private key is encrypted.
 type: filename
 default: none
-hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.KnownHostsFile
@@ -1747,7 +1740,6 @@ description: |+
   The remote host must be present in this file for the connection to succeed (unless Origin.SSH.AutoAddHostKey is true).
 type: filename
 default: none
-hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.AutoAddHostKey
@@ -1758,7 +1750,6 @@ description: |+
   Set to true only in test/development environments where the risk is acceptable.
 type: bool
 default: false
-hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.PelicanBinaryPath
@@ -1768,7 +1759,6 @@ description: |+
   This must be compatible with the remote host's OS and architecture.
 type: filename
 default: none
-hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.RemotePelicanBinaryDir
@@ -1791,7 +1781,6 @@ description: |+
   The platform is detected by running "uname -s" and "uname -m" on the remote host.
 type: stringSlice
 default: []
-hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.MaxRetries
@@ -1800,7 +1789,6 @@ description: |+
   After exceeding this limit, the origin will fail to start.
 type: int
 default: 5
-hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.ConnectTimeout
@@ -1808,7 +1796,6 @@ description: |+
   Timeout for establishing the SSH connection.
 type: duration
 default: 30s
-hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.KeepaliveInterval
@@ -1816,7 +1803,6 @@ description: |+
   How often to send SSH keepalive packets to verify the connection is still alive.
 type: duration
 default: 5s
-hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.KeepaliveTimeout
@@ -1826,7 +1812,6 @@ description: |+
   Both the SSH connection and the HTTP connection to the helper are monitored.
 type: duration
 default: 20s
-hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.ChallengeTimeout
@@ -1836,7 +1821,6 @@ description: |+
   The overall authentication timeout is controlled by Origin.SSH.ConnectTimeout.
 type: duration
 default: 1m
-hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.ProxyJump
@@ -1847,7 +1831,6 @@ description: |+
   This allows connecting to a remote host through one or more intermediate hosts.
 type: string
 default: none
-hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.SessionEstablishTimeout
@@ -1859,7 +1842,6 @@ description: |+
   This is an end-to-end timeout that bounds all session establishment operations.
 type: duration
 default: 5m
-hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.TunnelCallback
@@ -1876,7 +1858,6 @@ description: |+
   origin's external URL.
 type: bool
 default: false
-hidden: true
 components: ["origin"]
 ---
 ############################


### PR DESCRIPTION
Reverts PelicanPlatform/pelican#3402

This change is fighting with auto-generated docs and causing CI failures for "Check Go Generate" when merged into v7.25. I jumped the gun waiting for tests in the original PR, so I'm reverting this while I work on a more thorough fix.