### PR TITLE
Hide rclone and SSH origin from docs navigation while keeping pages reachable

### DIFF
--- a/cmd/doc_gen.go
+++ b/cmd/doc_gen.go
@@ -29,12 +29,37 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 )
 
 // angleTagRe matches bare angle-bracket identifiers that MDX would interpret as
 // JSX tags (e.g. <client-id>, <path>, <pelican-url>).
 var angleTagRe = regexp.MustCompile(`<([a-zA-Z][a-zA-Z0-9_-]*)>`)
+
+// hiddenFromDocs lists command paths (relative to the docs root, using forward
+// slashes) whose generated documentation pages should remain on disk and
+// remain reachable by direct URL, but should not be discoverable via the
+// site's navigation. Use this for features that are not yet ready for general
+// use but where targeted users (e.g., bug-fix testers) still need a link to
+// the docs.
+//
+// Effects of inclusion:
+//   - The on-disk page.mdx files for the command (and its subcommands) are
+//     still generated, so links like /commands-reference/<cmd>/ continue to
+//     resolve and can be shared directly. This works even when the cobra
+//     command itself is marked Hidden (so it doesn't appear in `pelican -h`):
+//     during doc generation we temporarily flip Hidden off so cobra's
+//     generator descends into the command and emits all its pages.
+//   - The corresponding entry is omitted from the parent's _meta.js sidebar.
+//   - The corresponding "SEE ALSO" bullet line is stripped from the parent
+//     command's page.mdx so the page does not advertise the hidden command.
+var hiddenFromDocs = map[string]bool{
+	// rclone integration is not yet functional.
+	"rclone": true,
+	// SSH origin backend is not yet functional.
+	"origin/ssh-auth": true,
+}
 
 // generateCLIDocs creates per-command docs under the given directory. If the path
 // is relative, it is resolved against the repository root (directory containing go.mod).
@@ -88,6 +113,13 @@ func generateCLIDocs(outputDir string) error {
 		return fmt.Sprintf("---\ntitle: %s\n---\n\n", title)
 	}
 
+	// Cobra's doc generator skips commands whose Hidden field is true (and,
+	// transitively, all of their subcommands). For features in hiddenFromDocs
+	// we still want the pages generated so testers can reach them via direct
+	// URLs, so temporarily un-hide them for the duration of generation.
+	restoreHidden := temporarilyUnhideForDocs(rootCmd)
+	defer restoreHidden()
+
 	// Cobra writes files directly to the destination directory (with .md extension)
 	if err := doc.GenMarkdownTreeCustom(rootCmd, resolvedDir, filePrepender, linkHandler); err != nil {
 		return err
@@ -107,7 +139,7 @@ func generateCLIDocs(outputDir string) error {
 		return err
 	}
 
-	if err := postProcessMdxFiles(resolvedDir); err != nil {
+	if err := postProcessMdxFiles(resolvedDir, docPathRoot); err != nil {
 		return err
 	}
 
@@ -239,9 +271,10 @@ func generateMetaFiles(dir string) error {
 
 		var subdirs []string
 		for _, entry := range entries {
-			if entry.IsDir() {
-				subdirs = append(subdirs, entry.Name())
+			if !entry.IsDir() {
+				continue
 			}
+			subdirs = append(subdirs, entry.Name())
 		}
 
 		if len(subdirs) > 0 {
@@ -259,8 +292,18 @@ func generateMetaFiles(dir string) error {
 
 			content := "export default {\n"
 			for _, subdir := range subdirs {
-				title := commandPrefix + " " + subdir
-				content += fmt.Sprintf("    \"%s\": \"%s\",\n", subdir, title)
+				relEntry, err := filepath.Rel(dir, filepath.Join(path, subdir))
+				if err != nil {
+					return err
+				}
+				if hiddenFromDocs[filepath.ToSlash(relEntry)] {
+					// Nextra 4: { display: 'hidden' } keeps the page reachable
+					// by direct URL but removes it from the sidebar navigation.
+					content += fmt.Sprintf("    \"%s\": { display: 'hidden' },\n", subdir)
+				} else {
+					title := commandPrefix + " " + subdir
+					content += fmt.Sprintf("    \"%s\": \"%s\",\n", subdir, title)
+				}
 			}
 			content += "}\n"
 
@@ -272,7 +315,14 @@ func generateMetaFiles(dir string) error {
 	})
 }
 
-func postProcessMdxFiles(dir string) error {
+func postProcessMdxFiles(dir string, docPathRoot string) error {
+	// Build the set of doc-root-relative URL paths whose SEE ALSO references
+	// should be stripped from generated page.mdx files.
+	hiddenURLs := make(map[string]bool, len(hiddenFromDocs))
+	for relPath := range hiddenFromDocs {
+		hiddenURLs[fmt.Sprintf("/%s/%s/", docPathRoot, relPath)] = true
+	}
+
 	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -287,12 +337,18 @@ func postProcessMdxFiles(dir string) error {
 				return nil
 			}
 
-			// Trim trailing spaces on each line
+			// Trim trailing spaces on each line, and drop SEE ALSO bullets that
+			// reference hidden-from-docs commands.
 			lines := strings.Split(string(content), "\n")
-			for i, line := range lines {
-				lines[i] = strings.TrimRight(line, " \t")
+			filtered := make([]string, 0, len(lines))
+			for _, line := range lines {
+				trimmed := strings.TrimRight(line, " \t")
+				if isHiddenSeeAlsoLine(trimmed, hiddenURLs) {
+					continue
+				}
+				filtered = append(filtered, trimmed)
 			}
-			fullContent := strings.Join(lines, "\n")
+			fullContent := strings.Join(filtered, "\n")
 
 			// Ensure single newline at EOF
 			fullContent = strings.TrimRight(fullContent, "\n") + "\n"
@@ -335,4 +391,64 @@ func escapeMdxAngleBrackets(content string) string {
 		}
 	}
 	return strings.Join(lines, "\n")
+}
+
+// isHiddenSeeAlsoLine reports whether the given line is a generated SEE ALSO
+// bullet referencing one of the hidden-from-docs URL paths.
+func isHiddenSeeAlsoLine(line string, hiddenURLs map[string]bool) bool {
+	if !strings.HasPrefix(line, "* [") {
+		return false
+	}
+	open := strings.Index(line, "](")
+	if open < 0 {
+		return false
+	}
+	rest := line[open+2:]
+	close := strings.Index(rest, ")")
+	if close < 0 {
+		return false
+	}
+	url := rest[:close]
+	return hiddenURLs[url]
+}
+
+// temporarilyUnhideForDocs flips Hidden=false on the cobra commands whose
+// docs-relative paths appear in hiddenFromDocs, so cobra's documentation
+// generator emits pages for them and their subcommands. The returned function
+// restores the original Hidden value on each affected command.
+func temporarilyUnhideForDocs(root *cobra.Command) func() {
+	var toRestore []*cobra.Command
+	for relPath := range hiddenFromDocs {
+		c := findCommandByPath(root, relPath)
+		if c != nil && c.Hidden {
+			c.Hidden = false
+			toRestore = append(toRestore, c)
+		}
+	}
+	return func() {
+		for _, c := range toRestore {
+			c.Hidden = true
+		}
+	}
+}
+
+// findCommandByPath walks the command tree under root following the given
+// slash-separated path of command names. Returns nil if any segment is not
+// found.
+func findCommandByPath(root *cobra.Command, path string) *cobra.Command {
+	cur := root
+	for _, seg := range strings.Split(path, "/") {
+		var next *cobra.Command
+		for _, child := range cur.Commands() {
+			if child.Name() == seg {
+				next = child
+				break
+			}
+		}
+		if next == nil {
+			return nil
+		}
+		cur = next
+	}
+	return cur
 }

--- a/cmd/origin_ssh_auth.go
+++ b/cmd/origin_ssh_auth.go
@@ -36,8 +36,9 @@ import (
 )
 
 var sshAuthCmd = &cobra.Command{
-	Use:   "ssh-auth",
-	Short: "SSH authentication tools for the SSH backend",
+	Use:    "ssh-auth",
+	Hidden: true,
+	Short:  "SSH authentication tools for the SSH backend",
 	Long: `Tools for SSH backend authentication and testing.
 
 Sub-commands:

--- a/cmd/rclone.go
+++ b/cmd/rclone.go
@@ -26,8 +26,9 @@ import (
 
 var (
 	rcloneCmd = &cobra.Command{
-		Use:   "rclone",
-		Short: "Commands for integrating Pelican with rclone",
+		Use:    "rclone",
+		Hidden: true,
+		Short:  "Commands for integrating Pelican with rclone",
 		Long: `The rclone subcommands help integrate Pelican with the rclone tool
 for syncing files to and from Pelican federations.
 

--- a/docs/app/commands-reference/pelican-server/origin/_meta.js
+++ b/docs/app/commands-reference/pelican-server/origin/_meta.js
@@ -3,7 +3,7 @@ export default {
     "config": "pelican-server origin config",
     "issuer": "pelican-server origin issuer",
     "serve": "pelican-server origin serve",
-    "ssh-auth": "pelican-server origin ssh-auth",
+    "ssh-auth": { display: 'hidden' },
     "token": "pelican-server origin token",
     "web-ui": "pelican-server origin web-ui",
 }

--- a/docs/app/commands-reference/pelican-server/origin/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/page.mdx
@@ -30,6 +30,5 @@ Operate a Pelican origin service
 * [pelican-server origin config](/commands-reference/pelican-server/origin/config/)	 - Launch the Pelican web service in configuration mode
 * [pelican-server origin issuer](/commands-reference/pelican-server/origin/issuer/)	 - Manage the origin's embedded OIDC token issuer
 * [pelican-server origin serve](/commands-reference/pelican-server/origin/serve/)	 - Start the origin service
-* [pelican-server origin ssh-auth](/commands-reference/pelican-server/origin/ssh-auth/)	 - SSH authentication tools for the SSH backend
 * [pelican-server origin token](/commands-reference/pelican-server/origin/token/)	 - Manage Pelican origin tokens
 * [pelican-server origin web-ui](/commands-reference/pelican-server/origin/web-ui/)	 - Manage the Pelican origin web UI

--- a/docs/app/commands-reference/pelican-server/origin/ssh-auth/login/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/ssh-auth/login/page.mdx
@@ -48,5 +48,3 @@ pelican-server origin ssh-auth login [flags]
 ```
 
 ### SEE ALSO
-
-* [pelican-server origin ssh-auth](/commands-reference/pelican-server/origin/ssh-auth/)	 - SSH authentication tools for the SSH backend

--- a/docs/app/commands-reference/pelican-server/origin/ssh-auth/status/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/ssh-auth/status/page.mdx
@@ -42,5 +42,3 @@ pelican-server origin ssh-auth status [flags]
 ```
 
 ### SEE ALSO
-
-* [pelican-server origin ssh-auth](/commands-reference/pelican-server/origin/ssh-auth/)	 - SSH authentication tools for the SSH backend

--- a/docs/app/commands-reference/pelican-server/origin/ssh-auth/test/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/ssh-auth/test/page.mdx
@@ -90,5 +90,3 @@ pelican-server origin ssh-auth test [user@]host [flags]
 ```
 
 ### SEE ALSO
-
-* [pelican-server origin ssh-auth](/commands-reference/pelican-server/origin/ssh-auth/)	 - SSH authentication tools for the SSH backend

--- a/docs/app/commands-reference/pelican-server/origin/token/create/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/token/create/page.mdx
@@ -9,8 +9,8 @@ Create a Pelican origin token
 ### Synopsis
 
 Create a JSON web token (JWT) using the origin's signing keys:
-Usage: pelican origin token create [FLAGS] claims
-E.g. pelican origin token create --profile scitokens2 aud=my-audience scope="read:/storage" scope="write:/storage"
+Usage: pelican-server origin token create [FLAGS] claims
+E.g. pelican-server origin token create --profile scitokens2 aud=my-audience scope="read:/storage" scope="write:/storage"
 
 Pelican origins use JWTs as bearer tokens for authorizing specific requests,
 such as reading from or writing to the origin's underlying storage, advertising

--- a/docs/app/commands-reference/pelican/_meta.js
+++ b/docs/app/commands-reference/pelican/_meta.js
@@ -6,6 +6,6 @@ export default {
     "namespace": "pelican namespace",
     "object": "pelican object",
     "plugin": "pelican plugin",
-    "rclone": "pelican rclone",
+    "rclone": { display: 'hidden' },
     "token": "pelican token",
 }

--- a/docs/app/commands-reference/pelican/page.mdx
+++ b/docs/app/commands-reference/pelican/page.mdx
@@ -33,5 +33,4 @@ across multiple dataset providers.
 * [pelican namespace](/commands-reference/pelican/namespace/)	 - Work with namespaces
 * [pelican object](/commands-reference/pelican/object/)	 - Interact with objects in the federation
 * [pelican plugin](/commands-reference/pelican/plugin/)	 - Plugin management for HTCSS
-* [pelican rclone](/commands-reference/pelican/rclone/)	 - Commands for integrating Pelican with rclone
 * [pelican token](/commands-reference/pelican/token/)	 - Interact with tokens used to interact with objects in Pelican

--- a/docs/app/commands-reference/pelican/rclone/install/page.mdx
+++ b/docs/app/commands-reference/pelican/rclone/install/page.mdx
@@ -42,5 +42,3 @@ pelican rclone install [flags]
 ```
 
 ### SEE ALSO
-
-* [pelican rclone](/commands-reference/pelican/rclone/)	 - Commands for integrating Pelican with rclone

--- a/docs/app/commands-reference/pelican/rclone/setup/page.mdx
+++ b/docs/app/commands-reference/pelican/rclone/setup/page.mdx
@@ -65,5 +65,3 @@ pelican rclone setup <pelican-url> [flags]
 ```
 
 ### SEE ALSO
-
-* [pelican rclone](/commands-reference/pelican/rclone/)	 - Commands for integrating Pelican with rclone

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1675,6 +1675,7 @@ description: |+
   When Origin.StorageType is set to "ssh", this parameter is required.
 type: string
 default: none
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.Port
@@ -1682,6 +1683,7 @@ description: |+
   The SSH port to connect to on the remote server.
 type: int
 default: 22
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.User
@@ -1689,6 +1691,7 @@ description: |+
   The SSH username to use for authentication.
 type: string
 default: none
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.AuthMethods
@@ -1703,6 +1706,7 @@ description: |+
   If not specified, defaults to trying: publickey, agent, keyboard-interactive, password
 type: stringSlice
 default: ["publickey", "agent", "keyboard-interactive", "password"]
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.PasswordFile
@@ -1713,6 +1717,7 @@ description: |+
   Used when "password" is in the AuthMethods list.
 type: filename
 default: none
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.PrivateKeyFile
@@ -1722,6 +1727,7 @@ description: |+
   Supports RSA, ECDSA, and Ed25519 keys.
 type: filename
 default: none
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.PrivateKeyPassphraseFile
@@ -1731,6 +1737,7 @@ description: |+
   Only needed if the private key is encrypted.
 type: filename
 default: none
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.KnownHostsFile
@@ -1740,6 +1747,7 @@ description: |+
   The remote host must be present in this file for the connection to succeed (unless Origin.SSH.AutoAddHostKey is true).
 type: filename
 default: none
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.AutoAddHostKey
@@ -1750,6 +1758,7 @@ description: |+
   Set to true only in test/development environments where the risk is acceptable.
 type: bool
 default: false
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.PelicanBinaryPath
@@ -1759,6 +1768,7 @@ description: |+
   This must be compatible with the remote host's OS and architecture.
 type: filename
 default: none
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.RemotePelicanBinaryDir
@@ -1781,6 +1791,7 @@ description: |+
   The platform is detected by running "uname -s" and "uname -m" on the remote host.
 type: stringSlice
 default: []
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.MaxRetries
@@ -1789,6 +1800,7 @@ description: |+
   After exceeding this limit, the origin will fail to start.
 type: int
 default: 5
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.ConnectTimeout
@@ -1796,6 +1808,7 @@ description: |+
   Timeout for establishing the SSH connection.
 type: duration
 default: 30s
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.KeepaliveInterval
@@ -1803,6 +1816,7 @@ description: |+
   How often to send SSH keepalive packets to verify the connection is still alive.
 type: duration
 default: 5s
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.KeepaliveTimeout
@@ -1812,6 +1826,7 @@ description: |+
   Both the SSH connection and the HTTP connection to the helper are monitored.
 type: duration
 default: 20s
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.ChallengeTimeout
@@ -1821,6 +1836,7 @@ description: |+
   The overall authentication timeout is controlled by Origin.SSH.ConnectTimeout.
 type: duration
 default: 1m
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.ProxyJump
@@ -1831,6 +1847,7 @@ description: |+
   This allows connecting to a remote host through one or more intermediate hosts.
 type: string
 default: none
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.SessionEstablishTimeout
@@ -1842,6 +1859,7 @@ description: |+
   This is an end-to-end timeout that bounds all session establishment operations.
 type: duration
 default: 5m
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.TunnelCallback
@@ -1858,6 +1876,7 @@ description: |+
   origin's external URL.
 type: bool
 default: false
+hidden: true
 components: ["origin"]
 ---
 ############################


### PR DESCRIPTION
The rclone integration and SSH origin backend are not yet functional. Their documentation and config parameters should not be discoverable by regular users, but testers working on bug fixes still need shareable links to the relevant pages.

To accomplish this, the commands are marked as hidden, which prevents our docs generator from producing their pages. However, the docs generation code has a map of which commands should result in generated-but-unlinked docs, and it uses this to un-hide those commands temporarily while their docs are generated. After generation, they're re-hidden and their `_meta.js` entries are skipped, preventing any links from appearing in the docs.

Closes #3400 