### PR TITLE
Hide docs for broken features, don't generate angle brackets in CLI references

### DIFF
--- a/cmd/doc_gen.go
+++ b/cmd/doc_gen.go
@@ -324,6 +324,11 @@ func postProcessMdxFiles(dir string, docPathRoot string) error {
 			// Ensure single newline at EOF
 			fullContent = strings.TrimRight(fullContent, "\n") + "\n"
 
+			// Escape bare angle-bracket identifiers in prose sections so
+			// MDX does not try to parse them as JSX tags. Code fences are
+			// left untouched.
+			fullContent = escapeMdxAngleBrackets(fullContent)
+
 			if string(content) != fullContent {
 				info, err := d.Info()
 				if err != nil {

--- a/cmd/doc_gen.go
+++ b/cmd/doc_gen.go
@@ -6,10 +6,40 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 )
+
+// angleTagRe matches bare angle-bracket identifiers that MDX would interpret as
+// JSX tags (e.g. <client-id>, <path>, <pelican-url>).
+var angleTagRe = regexp.MustCompile(`<([a-zA-Z][a-zA-Z0-9_-]*)>`)
+
+// hiddenFromDocs lists command paths (relative to the docs root, using forward
+// slashes) whose generated documentation pages should remain on disk and
+// remain reachable by direct URL, but should not be discoverable via the
+// site's navigation. Use this for features that are not yet ready for general
+// use but where targeted users (e.g., bug-fix testers) still need a link to
+// the docs.
+//
+// Effects of inclusion:
+//   - The on-disk page.mdx files for the command (and its subcommands) are
+//     still generated, so links like /commands-reference/<cmd>/ continue to
+//     resolve and can be shared directly. This works even when the cobra
+//     command itself is marked Hidden (so it doesn't appear in `pelican -h`):
+//     during doc generation we temporarily flip Hidden off so cobra's
+//     generator descends into the command and emits all its pages.
+//   - The corresponding entry is omitted from the parent's _meta.js sidebar.
+//   - The corresponding "SEE ALSO" bullet line is stripped from the parent
+//     command's page.mdx so the page does not advertise the hidden command.
+var hiddenFromDocs = map[string]bool{
+	// rclone integration is not yet functional.
+	"rclone": true,
+	// SSH origin backend is not yet functional.
+	"origin/ssh-auth": true,
+}
 
 // generateCLIDocs creates per-command docs under the given directory. If the path
 // is relative, it is resolved against the repository root (directory containing go.mod).
@@ -54,6 +84,13 @@ func generateCLIDocs(outputDir string) error {
 		return fmt.Sprintf("---\ntitle: %s\n---\n\n", title)
 	}
 
+	// Cobra's doc generator skips commands whose Hidden field is true (and,
+	// transitively, all of their subcommands). For features in hiddenFromDocs
+	// we still want the pages generated so testers can reach them via direct
+	// URLs, so temporarily un-hide them for the duration of generation.
+	restoreHidden := temporarilyUnhideForDocs(rootCmd)
+	defer restoreHidden()
+
 	// Cobra writes files directly to the destination directory (with .md extension)
 	if err := doc.GenMarkdownTreeCustom(rootCmd, resolvedDir, filePrepender, linkHandler); err != nil {
 		return err
@@ -73,7 +110,7 @@ func generateCLIDocs(outputDir string) error {
 		return err
 	}
 
-	if err := postProcessMdxFiles(resolvedDir); err != nil {
+	if err := postProcessMdxFiles(resolvedDir, docPathRoot); err != nil {
 		return err
 	}
 
@@ -205,9 +242,10 @@ func generateMetaFiles(dir string) error {
 
 		var subdirs []string
 		for _, entry := range entries {
-			if entry.IsDir() {
-				subdirs = append(subdirs, entry.Name())
+			if !entry.IsDir() {
+				continue
 			}
+			subdirs = append(subdirs, entry.Name())
 		}
 
 		if len(subdirs) > 0 {
@@ -225,8 +263,18 @@ func generateMetaFiles(dir string) error {
 
 			content := "export default {\n"
 			for _, subdir := range subdirs {
-				title := commandPrefix + " " + subdir
-				content += fmt.Sprintf("    \"%s\": \"%s\",\n", subdir, title)
+				relEntry, err := filepath.Rel(dir, filepath.Join(path, subdir))
+				if err != nil {
+					return err
+				}
+				if hiddenFromDocs[filepath.ToSlash(relEntry)] {
+					// Nextra 4: { display: 'hidden' } keeps the page reachable
+					// by direct URL but removes it from the sidebar navigation.
+					content += fmt.Sprintf("    \"%s\": { display: 'hidden' },\n", subdir)
+				} else {
+					title := commandPrefix + " " + subdir
+					content += fmt.Sprintf("    \"%s\": \"%s\",\n", subdir, title)
+				}
 			}
 			content += "}\n"
 
@@ -238,7 +286,14 @@ func generateMetaFiles(dir string) error {
 	})
 }
 
-func postProcessMdxFiles(dir string) error {
+func postProcessMdxFiles(dir string, docPathRoot string) error {
+	// Build the set of doc-root-relative URL paths whose SEE ALSO references
+	// should be stripped from generated page.mdx files.
+	hiddenURLs := make(map[string]bool, len(hiddenFromDocs))
+	for relPath := range hiddenFromDocs {
+		hiddenURLs[fmt.Sprintf("/%s/%s/", docPathRoot, relPath)] = true
+	}
+
 	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -253,12 +308,18 @@ func postProcessMdxFiles(dir string) error {
 				return nil
 			}
 
-			// Trim trailing spaces on each line
+			// Trim trailing spaces on each line, and drop SEE ALSO bullets that
+			// reference hidden-from-docs commands.
 			lines := strings.Split(string(content), "\n")
-			for i, line := range lines {
-				lines[i] = strings.TrimRight(line, " \t")
+			filtered := make([]string, 0, len(lines))
+			for _, line := range lines {
+				trimmed := strings.TrimRight(line, " \t")
+				if isHiddenSeeAlsoLine(trimmed, hiddenURLs) {
+					continue
+				}
+				filtered = append(filtered, trimmed)
 			}
-			fullContent := strings.Join(lines, "\n")
+			fullContent := strings.Join(filtered, "\n")
 
 			// Ensure single newline at EOF
 			fullContent = strings.TrimRight(fullContent, "\n") + "\n"
@@ -275,4 +336,85 @@ func postProcessMdxFiles(dir string) error {
 		}
 		return nil
 	})
+}
+
+// escapeMdxAngleBrackets replaces bare angle-bracket identifiers (e.g. <path>,
+// <client-id>) with HTML entities so that MDX/JSX parsers do not interpret them
+// as JSX tags. Lines inside code fences (delimited by ```) are left unchanged
+// because their content is rendered literally by the markdown renderer.
+func escapeMdxAngleBrackets(content string) string {
+	lines := strings.Split(content, "\n")
+	inCodeFence := false
+	for i, line := range lines {
+		trimmed := strings.TrimLeft(line, " \t")
+		if strings.HasPrefix(trimmed, "```") {
+			inCodeFence = !inCodeFence
+			// Don't modify the fence delimiter line itself.
+			continue
+		}
+		if !inCodeFence {
+			lines[i] = angleTagRe.ReplaceAllString(line, "&lt;$1&gt;")
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// isHiddenSeeAlsoLine reports whether the given line is a generated SEE ALSO
+// bullet referencing one of the hidden-from-docs URL paths.
+func isHiddenSeeAlsoLine(line string, hiddenURLs map[string]bool) bool {
+	if !strings.HasPrefix(line, "* [") {
+		return false
+	}
+	open := strings.Index(line, "](")
+	if open < 0 {
+		return false
+	}
+	rest := line[open+2:]
+	close := strings.Index(rest, ")")
+	if close < 0 {
+		return false
+	}
+	url := rest[:close]
+	return hiddenURLs[url]
+}
+
+// temporarilyUnhideForDocs flips Hidden=false on the cobra commands whose
+// docs-relative paths appear in hiddenFromDocs, so cobra's documentation
+// generator emits pages for them and their subcommands. The returned function
+// restores the original Hidden value on each affected command.
+func temporarilyUnhideForDocs(root *cobra.Command) func() {
+	var toRestore []*cobra.Command
+	for relPath := range hiddenFromDocs {
+		c := findCommandByPath(root, relPath)
+		if c != nil && c.Hidden {
+			c.Hidden = false
+			toRestore = append(toRestore, c)
+		}
+	}
+	return func() {
+		for _, c := range toRestore {
+			c.Hidden = true
+		}
+	}
+}
+
+// findCommandByPath walks the command tree under root following the given
+// slash-separated path of command names. Returns nil if any segment is not
+// found.
+func findCommandByPath(root *cobra.Command, path string) *cobra.Command {
+	cur := root
+	for _, seg := range strings.Split(path, "/") {
+		var next *cobra.Command
+		for _, child := range cur.Commands() {
+			if child.Name() == seg {
+				next = child
+				break
+			}
+		}
+		if next == nil {
+			return nil
+		}
+		cur = next
+	}
+	return cur
 }

--- a/cmd/origin_ssh_auth.go
+++ b/cmd/origin_ssh_auth.go
@@ -34,8 +34,9 @@ import (
 )
 
 var sshAuthCmd = &cobra.Command{
-	Use:   "ssh-auth",
-	Short: "SSH authentication tools for the SSH backend",
+	Use:    "ssh-auth",
+	Hidden: true,
+	Short:  "SSH authentication tools for the SSH backend",
 	Long: `Tools for SSH backend authentication and testing.
 
 Sub-commands:

--- a/cmd/rclone.go
+++ b/cmd/rclone.go
@@ -26,8 +26,9 @@ import (
 
 var (
 	rcloneCmd = &cobra.Command{
-		Use:   "rclone",
-		Short: "Commands for integrating Pelican with rclone",
+		Use:    "rclone",
+		Hidden: true,
+		Short:  "Commands for integrating Pelican with rclone",
 		Long: `The rclone subcommands help integrate Pelican with the rclone tool
 for syncing files to and from Pelican federations.
 

--- a/docs/app/commands-reference/_meta.js
+++ b/docs/app/commands-reference/_meta.js
@@ -13,7 +13,7 @@ export default {
     "object": "pelican object",
     "origin": "pelican origin",
     "plugin": "pelican plugin",
-    "rclone": "pelican rclone",
+    "rclone": { display: 'hidden' },
     "registry": "pelican registry",
     "server": "pelican server",
     "token": "pelican token",

--- a/docs/app/commands-reference/origin/_meta.js
+++ b/docs/app/commands-reference/origin/_meta.js
@@ -3,7 +3,7 @@ export default {
     "config": "pelican origin config",
     "issuer": "pelican origin issuer",
     "serve": "pelican origin serve",
-    "ssh-auth": "pelican origin ssh-auth",
+    "ssh-auth": { display: 'hidden' },
     "token": "pelican origin token",
     "web-ui": "pelican origin web-ui",
 }

--- a/docs/app/commands-reference/origin/issuer/client/update/page.mdx
+++ b/docs/app/commands-reference/origin/issuer/client/update/page.mdx
@@ -14,7 +14,7 @@ Only the flags you provide are changed; omitted fields are left unchanged.
 
 Example — add token-exchange grant and narrow scopes:
   pelican origin issuer client update --server https://my-origin:8447 \
-    --id <client-id> \
+    --id &lt;client-id&gt; \
     --grant-types "urn:ietf:params:oauth:grant-type:token-exchange,refresh_token" \
     --scopes "openid,storage.read:/"
 

--- a/docs/app/commands-reference/origin/page.mdx
+++ b/docs/app/commands-reference/origin/page.mdx
@@ -30,6 +30,5 @@ Operate a Pelican origin service
 * [pelican origin config](/commands-reference/origin/config/)	 - Launch the Pelican web service in configuration mode
 * [pelican origin issuer](/commands-reference/origin/issuer/)	 - Manage the origin's embedded OIDC token issuer
 * [pelican origin serve](/commands-reference/origin/serve/)	 - Start the origin service
-* [pelican origin ssh-auth](/commands-reference/origin/ssh-auth/)	 - SSH authentication tools for the SSH backend
 * [pelican origin token](/commands-reference/origin/token/)	 - Manage Pelican origin tokens
 * [pelican origin web-ui](/commands-reference/origin/web-ui/)	 - Manage the Pelican origin web UI

--- a/docs/app/commands-reference/origin/ssh-auth/login/page.mdx
+++ b/docs/app/commands-reference/origin/ssh-auth/login/page.mdx
@@ -48,5 +48,3 @@ pelican origin ssh-auth login [flags]
 ```
 
 ### SEE ALSO
-
-* [pelican origin ssh-auth](/commands-reference/origin/ssh-auth/)	 - SSH authentication tools for the SSH backend

--- a/docs/app/commands-reference/origin/ssh-auth/status/page.mdx
+++ b/docs/app/commands-reference/origin/ssh-auth/status/page.mdx
@@ -42,5 +42,3 @@ pelican origin ssh-auth status [flags]
 ```
 
 ### SEE ALSO
-
-* [pelican origin ssh-auth](/commands-reference/origin/ssh-auth/)	 - SSH authentication tools for the SSH backend

--- a/docs/app/commands-reference/origin/ssh-auth/test/page.mdx
+++ b/docs/app/commands-reference/origin/ssh-auth/test/page.mdx
@@ -90,5 +90,3 @@ pelican origin ssh-auth test [user@]host [flags]
 ```
 
 ### SEE ALSO
-
-* [pelican origin ssh-auth](/commands-reference/origin/ssh-auth/)	 - SSH authentication tools for the SSH backend

--- a/docs/app/commands-reference/page.mdx
+++ b/docs/app/commands-reference/page.mdx
@@ -40,7 +40,6 @@ across multiple dataset providers.
 * [pelican object](/commands-reference/object/)	 - Interact with objects in the federation
 * [pelican origin](/commands-reference/origin/)	 - Operate a Pelican origin service
 * [pelican plugin](/commands-reference/plugin/)	 - Plugin management for HTCSS
-* [pelican rclone](/commands-reference/rclone/)	 - Commands for integrating Pelican with rclone
 * [pelican registry](/commands-reference/registry/)	 - Interact with a Pelican registry service
 * [pelican server](/commands-reference/server/)	 - Manage server operations
 * [pelican token](/commands-reference/token/)	 - Interact with tokens used to interact with objects in Pelican

--- a/docs/app/commands-reference/rclone/install/page.mdx
+++ b/docs/app/commands-reference/rclone/install/page.mdx
@@ -42,5 +42,3 @@ pelican rclone install [flags]
 ```
 
 ### SEE ALSO
-
-* [pelican rclone](/commands-reference/rclone/)	 - Commands for integrating Pelican with rclone

--- a/docs/app/commands-reference/rclone/setup/page.mdx
+++ b/docs/app/commands-reference/rclone/setup/page.mdx
@@ -65,5 +65,3 @@ pelican rclone setup <pelican-url> [flags]
 ```
 
 ### SEE ALSO
-
-* [pelican rclone](/commands-reference/rclone/)	 - Commands for integrating Pelican with rclone

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1634,6 +1634,7 @@ description: |+
   When Origin.StorageType is set to "ssh", this parameter is required.
 type: string
 default: none
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.Port
@@ -1641,6 +1642,7 @@ description: |+
   The SSH port to connect to on the remote server.
 type: int
 default: 22
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.User
@@ -1648,6 +1650,7 @@ description: |+
   The SSH username to use for authentication.
 type: string
 default: none
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.AuthMethods
@@ -1662,6 +1665,7 @@ description: |+
   If not specified, defaults to trying: publickey, agent, keyboard-interactive, password
 type: stringSlice
 default: ["publickey", "agent", "keyboard-interactive", "password"]
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.PasswordFile
@@ -1672,6 +1676,7 @@ description: |+
   Used when "password" is in the AuthMethods list.
 type: filename
 default: none
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.PrivateKeyFile
@@ -1681,6 +1686,7 @@ description: |+
   Supports RSA, ECDSA, and Ed25519 keys.
 type: filename
 default: none
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.PrivateKeyPassphraseFile
@@ -1690,6 +1696,7 @@ description: |+
   Only needed if the private key is encrypted.
 type: filename
 default: none
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.KnownHostsFile
@@ -1699,6 +1706,7 @@ description: |+
   The remote host must be present in this file for the connection to succeed (unless Origin.SSH.AutoAddHostKey is true).
 type: filename
 default: none
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.AutoAddHostKey
@@ -1709,6 +1717,7 @@ description: |+
   Set to true only in test/development environments where the risk is acceptable.
 type: bool
 default: false
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.PelicanBinaryPath
@@ -1718,6 +1727,7 @@ description: |+
   This must be compatible with the remote host's OS and architecture.
 type: filename
 default: none
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.RemotePelicanBinaryDir
@@ -1740,6 +1750,7 @@ description: |+
   The platform is detected by running "uname -s" and "uname -m" on the remote host.
 type: stringSlice
 default: []
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.MaxRetries
@@ -1748,6 +1759,7 @@ description: |+
   After exceeding this limit, the origin will fail to start.
 type: int
 default: 5
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.ConnectTimeout
@@ -1755,6 +1767,7 @@ description: |+
   Timeout for establishing the SSH connection.
 type: duration
 default: 30s
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.KeepaliveInterval
@@ -1762,6 +1775,7 @@ description: |+
   How often to send SSH keepalive packets to verify the connection is still alive.
 type: duration
 default: 5s
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.KeepaliveTimeout
@@ -1771,6 +1785,7 @@ description: |+
   Both the SSH connection and the HTTP connection to the helper are monitored.
 type: duration
 default: 20s
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.ChallengeTimeout
@@ -1780,6 +1795,7 @@ description: |+
   The overall authentication timeout is controlled by Origin.SSH.ConnectTimeout.
 type: duration
 default: 1m
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.ProxyJump
@@ -1790,6 +1806,7 @@ description: |+
   This allows connecting to a remote host through one or more intermediate hosts.
 type: string
 default: none
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.SessionEstablishTimeout
@@ -1801,6 +1818,7 @@ description: |+
   This is an end-to-end timeout that bounds all session establishment operations.
 type: duration
 default: 5m
+hidden: true
 components: ["origin"]
 ---
 name: Origin.SSH.TunnelCallback
@@ -1817,6 +1835,7 @@ description: |+
   origin's external URL.
 type: bool
 default: false
+hidden: true
 components: ["origin"]
 ---
 ############################


### PR DESCRIPTION
I built the docs here locally and confirmed the newly-generated code does not display the offending commands (`pelican rclone`, `pelican origin ssh`):
<img width="256" height="533" alt="Screenshot 2026-05-01 at 13 18 09" src="https://github.com/user-attachments/assets/f0ead17f-e4d2-46aa-806b-82098f03bcf3" />

Note that there's some stuff spread across these commits that also fixes a bug preventing our docs from building because they contained special MDX characters. That I could build the docs at all is proof that is also fixed.