### PR TITLE
Add CI check enforcing documentation updates on PRs

### DIFF
--- a/.github/workflows/enforce-docs-updates.yml
+++ b/.github/workflows/enforce-docs-updates.yml
@@ -1,0 +1,89 @@
+name: Enforce Documentation Updates
+
+on:
+  pull_request:
+    branches: [main]
+    # Re-run on label add/remove so toggling `no-docs-required` flips the
+    # check immediately without needing a new push. `synchronize` covers
+    # subsequent pushes; `opened`/`reopened` cover PR creation/reopen.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-docs-updates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Short-circuit if `no-docs-required` label is present
+        id: check_label
+        run: |
+          set -euo pipefail
+          if jq -e '.pull_request.labels[]?.name | select(. == "no-docs-required")' \
+              "$GITHUB_EVENT_PATH" > /dev/null; then
+            echo "✅ `no-docs-required` label is set; skipping documentation check."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check out repository with full history
+        if: steps.check_label.outputs.skip != 'true'
+        uses: actions/checkout@v6
+        with:
+          # Need full history so we can diff against the PR base branch.
+          fetch-depth: 0
+
+      - name: Verify documentation changes are present
+        if: steps.check_label.outputs.skip != 'true'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+
+          ALL_CHANGED=$(git diff --name-only "origin/${BASE_REF}...HEAD")
+
+          echo "All files changed in this PR vs. origin/${BASE_REF}:"
+          echo "$ALL_CHANGED" | sed 's/^/  /'
+          echo
+
+          # Filter for qualifying documentation changes:
+          #   - must live under docs/app/
+          #   - exclude docs/app/commands-reference/ (auto-generated CLI docs)
+          #   - exclude any _meta.js files (navigation/index scaffolding only)
+          DOC_CHANGES=$(echo "$ALL_CHANGED" \
+            | grep -E '^docs/app/' \
+            | grep -Ev '^docs/app/commands-reference/' \
+            | grep -Ev '(^|/)_meta\.js$' \
+            || true)
+
+          echo "Qualifying documentation changes:"
+          if [ -n "$DOC_CHANGES" ]; then
+            echo "$DOC_CHANGES" | sed 's/^/  /'
+            echo
+            echo "✅ Documentation changes detected; check passes."
+            exit 0
+          fi
+
+          echo "  (none)"
+          echo
+          echo "❌ No qualifying documentation changes detected for this PR."
+          echo
+          echo "Pelican requires that PRs introducing user-visible features or"
+          echo "behavior changes also update the documentation. To resolve this:"
+          echo
+          echo "  1. Add or update content under docs/app/ describing your"
+          echo "     change. Files under docs/app/commands-reference/ and any"
+          echo "     _meta.js navigation files do NOT count toward this check."
+          echo
+          echo "  OR"
+          echo
+          echo "  2. If your PR genuinely does not require documentation"
+          echo "     updates (e.g. a small bug fix, an internal-only refactor,"
+          echo "     CI changes), apply the `no-docs-required` label to this"
+          echo "     PR. The check will re-run and pass automatically."
+          echo
+          echo "See CONTRIBUTE.md for the full documentation policy:"
+          echo "  https://github.com/PelicanPlatform/pelican/blob/main/CONTRIBUTE.md#pull-requests"
+          exit 1

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -17,6 +17,7 @@ If anything doesn't make sense, or doesn't work when you run it, please open a [
 - [Getting Started](#getting-started)
   - [Issues](#issues)
   - [Pull Requests](#pull-requests)
+    - [Documentation Requirements](#documentation-requirements)
   - [Pull Requests that Modify Pelican's Dependencies](#pull-requests-that-modify-pelicans-dependencies)
 - [Development Environment Setup](#development-environment-setup)
 - [Code Quality Tools](#code-quality-tools)
@@ -80,9 +81,24 @@ PRs to our software are always welcome and can be a quick way to get your fix or
 - Only fix/add the functionality in question **OR** address wide-spread whitespace/style issues, not both.
 - Add unit or integration tests for fixed or changed functionality (if a test suite already exists).
 - Address a single concern in the least number of changed lines as possible.
-- Include documentation in the repo under the [docs](./docs/) folder.
+- Include documentation in the repo under the [docs](./docs/) folder (see [Documentation Requirements](#documentation-requirements) below).
 
 For changes that address core functionality or would require breaking changes (e.g. a major release), it's best to open an Issue to discuss your proposal first. This is not required but can save time creating and reviewing changes.
+
+#### Documentation Requirements
+
+Every PR is expected to ship with corresponding documentation updates so that user-facing behavior, configuration, and features stay discoverable. To make this expectation actionable, we enforce it via a CI check (see [`.github/workflows/enforce-docs-updates.yml`](./.github/workflows/enforce-docs-updates.yml)) that runs on every PR.
+
+The check passes when **either** of the following is true:
+
+1. The PR modifies at least one file under [`docs/app/`](./docs/app/), excluding:
+   - anything under `docs/app/commands-reference/` (auto-generated CLI reference, not a substitute for real documentation), and
+   - any `_meta.js` file (navigation/index scaffolding only).
+1. The PR carries the `no-docs-required` label.
+
+When you open a PR, take a moment to assess honestly whether your change needs documentation. If the answer is "no" — for example, a small bug fix, an internal-only refactor, a CI tweak, or a test-only change — apply the `no-docs-required` label and the check will pass. The label is intentionally cheap to apply; the friction exists so that the assessment is a deliberate step rather than an oversight.
+
+The check re-runs automatically when the label is added or removed, so you do not need to push a new commit just to flip the status.
 
 After you open the PR, it is required that at least one core contributor reviews and approves your changes. We monitor and triage new PRs and assign reviewers based on the scope of the PR. If your open PR is not reviewed after a week since it's open, please ping any of the core contributors as a reminder.
 


### PR DESCRIPTION
The idea for this PR came out of a discussion with @williamnswanson. It introduces .github/workflows/enforce-docs-updates.yml, a GitHub Actions workflow that fails any PR against main which neither updates the Pelican docs nor carries a `no-docs-required` label. While nothing can truly _force_ that we developers write documentation, this at least creates some fiction when we don't (and leaves an audit trail for any of us that decide to blow off documentation writing)

This new check:
- Triggers on opened/synchronize/reopened/labeled/unlabeled events so the status is always present and re-runs immediately when the label is toggled
- Requires at least one change under `docs/app/`, excluding the auto-generated `docs/app/commands-reference/` directory and any `_meta.js` navigation files. While this isn't perfect (for example, it doesn't mean you've added anything useful or related to the feature you're working on), it's a starting point.

The `no-docs-required` label provides a low-friction opt-out for PRs that genuinely don't warrant documentation updates (small bug fixes, internal-only changes, CI tweaks, etc.).