### PR TITLE
Downgrade POSIX permission validation failure to a warning

### DIFF
--- a/server_utils/origin_posix.go
+++ b/server_utils/origin_posix.go
@@ -174,10 +174,12 @@ func (o *PosixOrigin) validateExtra(e *OriginExport, _ int) error {
 			"(files are accessed as the requesting user, not the XRootD daemon user)", e.FederationPrefix)
 	} else {
 		if err := o.validatePosixPermissions(e.StoragePrefix, e.Capabilities, e.FederationPrefix); err != nil {
-			log.Warningf("Permission validation failed on storage prefix %q for export %q. "+
-				"The origin will still start, but runtime errors may occur if the XRootD daemon user truly lacks access. "+
-				"This may also be a false positive on filesystems that synthesize ownership at system call stat(2) time (e.g. FUSE, NFS).",
-				e.StoragePrefix, e.FederationPrefix)
+			log.Warningf("Storage prefix %q may lack permissions for export %q: %v. "+
+				"The origin will still start, but runtime errors may occur "+
+				"if the XRootD daemon user truly lacks access. "+
+				"This may be a false positive on filesystems that don't store real uid/gid on disk "+
+				"and synthesize ownership at runtime (e.g. FUSE, NFS, etc.).",
+				e.StoragePrefix, e.FederationPrefix, err)
 		}
 	}
 
@@ -249,7 +251,7 @@ func (o *PosixOrigin) validatePosixPermissions(storagePath string, caps server_s
 		return errors.Wrapf(ErrInvalidOriginConfig,
 			"storage prefix %q for export %q requires %q permissions for the %q user (uid=%d, gid=%d) "+
 				"to support the %q capability, but the current permissions are %q (owner uid=%d, gid=%d). "+
-				"Please adjust the ownership or permissions of the directory so that the XRootD daemon user "+
+				"You may need to adjust the ownership or permissions of the directory so that the XRootD daemon user "+
 				"has the necessary access",
 			storagePath, federationPrefix, requiredPerms, username, uid, gid,
 			capability, mode.Perm().String(), dirUID, dirGID)

--- a/server_utils/origin_posix.go
+++ b/server_utils/origin_posix.go
@@ -174,7 +174,10 @@ func (o *PosixOrigin) validateExtra(e *OriginExport, _ int) error {
 			"(files are accessed as the requesting user, not the XRootD daemon user)", e.FederationPrefix)
 	} else {
 		if err := o.validatePosixPermissions(e.StoragePrefix, e.Capabilities, e.FederationPrefix); err != nil {
-			return err
+			log.Warningf("Permission validation failed on storage prefix %q for export %q. "+
+				"The origin will still start, but runtime errors may occur if the XRootD daemon user truly lacks access. "+
+				"This may also be a false positive on filesystems that synthesize ownership at system call stat(2) time (e.g. FUSE, NFS).",
+				e.StoragePrefix, e.FederationPrefix)
 		}
 	}
 
@@ -246,7 +249,8 @@ func (o *PosixOrigin) validatePosixPermissions(storagePath string, caps server_s
 		return errors.Wrapf(ErrInvalidOriginConfig,
 			"storage prefix %q for export %q requires %q permissions for the %q user (uid=%d, gid=%d) "+
 				"to support the %q capability, but the current permissions are %q (owner uid=%d, gid=%d). "+
-				"Please adjust the ownership or permissions of the directory",
+				"Please adjust the ownership or permissions of the directory so that the XRootD daemon user "+
+				"has the necessary access",
 			storagePath, federationPrefix, requiredPerms, username, uid, gid,
 			capability, mode.Perm().String(), dirUID, dirGID)
 	}


### PR DESCRIPTION
## Summary
- Change the per-export daemon-user permission check in `validateExtra` from a hard error (blocking origin startup) to a warning log, so origins on stat-unfriendly filesystems (FUSE, NFS, etc.) can still start. Because those filesystems don't store real uid/gid on disk; instead, they fabricate those values on the fly when system call `stat(2)` is called. As a result, the permission check in `validatePosixPermissions` can be a false positive: stat might report uid=0 (root) or some other synthesized value that doesn't match the XRootD daemon user, but the daemon can actually read/write the directory just fine at runtime.
- Refine the permission error message to include actionable context (daemon user, uid/gid, and the note about false positives on synthesized-ownership filesystems)
- Preserve the existing multiuser-mode skip path unchanged

Closes #3437.
Related prev. PR #3355.