### PR TITLE
Fix HA director cascade-failure bugs in peer discovery and self-advertisement

### DIFF
--- a/director/director_advertise.go
+++ b/director/director_advertise.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -517,6 +517,13 @@ func sendMyAd(ctx context.Context) {
 		AdvertiseUrl: adUrl,
 	}
 	directorAd.Initialize(name)
+
+	// Insert the current director's ad into directorAds so that its
+	// lifetime is independent of any gossip round-trip through a peer.
+	egrp := ctx.Value(config.EgrpKey).(*errgroup.Group)
+	directorAdMutex.Lock()
+	updateInternalDirectorCache(ctx, egrp, directorAd)
+	directorAdMutex.Unlock()
 
 	directorAdMutex.RLock()
 	defer directorAdMutex.RUnlock()

--- a/director/director_advertise_self_test.go
+++ b/director/director_advertise_self_test.go
@@ -1,0 +1,100 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package director
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/test_utils"
+)
+
+// TestSendMyAdInsertsIntoDirectorAds verifies that sendMyAd inserts the
+// local director's own entry into directorAds without requiring a gossip
+// round-trip from a peer.
+func TestSendMyAdInsertsIntoDirectorAds(t *testing.T) {
+	config.ResetConfig()
+	t.Cleanup(config.ResetConfig)
+
+	const selfName = "test-self-director"
+	require.NoError(t, param.Server_ExternalWebUrl.Set("http://self.example.com"))
+
+	setupForwardingState(t)
+	directorName = selfName
+
+	ResetState()
+	t.Cleanup(ResetState)
+
+	ctx, cancel, _ := test_utils.TestContext(context.Background(), t)
+	defer cancel()
+
+	sendMyAd(ctx)
+
+	item := directorAds.Get(selfName)
+	require.NotNil(t, item, "directorAds must contain the self-entry after sendMyAd")
+	require.NotNil(t, item.Value())
+	require.NotNil(t, item.Value().ad)
+	assert.Equal(t, selfName, item.Value().ad.Name)
+	assert.Equal(t, "http://self.example.com", item.Value().ad.AdvertiseUrl)
+}
+
+// TestListDirectorsReturnsSelfAfterPeerExpires verifies the key
+// recoverability invariant: after all peer ads expire, the next sendMyAd
+// call ensures the self-entry is present in directorAds so that
+// listDirectors returns it.
+func TestListDirectorsReturnsSelfAfterPeerExpires(t *testing.T) {
+	config.ResetConfig()
+	t.Cleanup(config.ResetConfig)
+
+	const selfName = "test-self-director"
+	require.NoError(t, param.Server_ExternalWebUrl.Set("http://self.example.com"))
+
+	setupForwardingState(t)
+	directorName = selfName
+
+	ResetState()
+	t.Cleanup(ResetState)
+
+	// Register a peer with a very short TTL to simulate it expiring.
+	makeTestDirector(t, "peer-director", 1*time.Millisecond)
+
+	// Wait for the peer entry to be lazily evicted via Items() — no time.Sleep.
+	require.Eventually(t, func() bool {
+		return len(directorAds.Items()) == 0
+	}, 1*time.Second, 5*time.Millisecond, "peer ad should expire")
+
+	ctx, cancel, _ := test_utils.TestContext(context.Background(), t)
+	defer cancel()
+
+	sendMyAd(ctx)
+
+	items := directorAds.Items()
+	require.Len(t, items, 1, "directorAds must contain exactly the self-entry")
+	selfItem, ok := items[selfName]
+	require.True(t, ok, "self-entry must be keyed by the director name")
+	require.NotNil(t, selfItem.Value())
+	require.NotNil(t, selfItem.Value().ad)
+	assert.Equal(t, selfName, selfItem.Value().ad.Name)
+}

--- a/director/director_advertise_test.go
+++ b/director/director_advertise_test.go
@@ -51,17 +51,9 @@ func TestDirectorShutdown(t *testing.T) {
 	dirAd := &server_structs.DirectorAd{}
 	dirAd.Initialize("fake-director")
 
-	// firstContactCh is closed once the fake director has been
-	// queried at least once, confirming the initial discovery round
-	// has run successfully.
-	firstContactCh := make(chan struct{}, 1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		log.Debugln("Fake director received", req.Method, "for path", req.URL.Path)
 		if req.Method == "GET" && req.URL.Path == "/api/v1.0/director/directors" {
-			select {
-			case firstContactCh <- struct{}{}:
-			default:
-			}
 			// Set Expiration dynamically per-response so the entry in directorAds
 			// has a short, finite lifetime. Without this, Initialize above stamps
 			// the ad with the default expiration time (15m).
@@ -90,12 +82,17 @@ func TestDirectorShutdown(t *testing.T) {
 	require.NoError(t, param.Server_AdLifetime.SetString("300ms"))
 	fed_test_utils.NewFedTest(t, "")
 
-	// Wait for at least one successful discovery contact before simulating shutdown.
-	select {
-	case <-firstContactCh:
-	case <-time.After(10 * time.Second):
-		t.Fatal("fake director was never contacted during discovery")
-	}
+	// Confirm the fake director's ad is visible in directorEndpoints
+	// before simulating its shutdown.
+	require.Eventually(t, func() bool {
+		for _, ad := range server_utils.GetDirectorAds() {
+			if ad.AdvertiseUrl == ts.URL {
+				return true
+			}
+		}
+		return false
+	}, 10*time.Second, 50*time.Millisecond,
+		"fake director should appear in directorEndpoints after initial contact")
 
 	// Close the listener to simulate a real peer shutdown (connection refused).
 	ts.Close()

--- a/director/director_advertise_test.go
+++ b/director/director_advertise_test.go
@@ -2,7 +2,7 @@
 
 /***************************************************************
  *
- * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -40,24 +40,34 @@ import (
 	"github.com/pelicanplatform/pelican/test_utils"
 )
 
-// Test for a director disappearing
+// TestDirectorShutdown verifies that a peer director which was previously
+// known disappears from directorEndpoints after it shuts down (connection
+// refused).
 func TestDirectorShutdown(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	server_utils.ResetTestState()
 	defer server_utils.ResetTestState()
 
-	var listDirectorCount atomic.Int32
 	dirAd := &server_structs.DirectorAd{}
 	dirAd.Initialize("fake-director")
+
+	// firstContactCh is closed once the fake director has been
+	// queried at least once, confirming the initial discovery round
+	// has run successfully.
+	firstContactCh := make(chan struct{}, 1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		log.Debugln("Fake director received", req.Method, "for path", req.URL.Path)
 		if req.Method == "GET" && req.URL.Path == "/api/v1.0/director/directors" {
-			newVal := listDirectorCount.Add(1)
-			ads := make([]server_structs.DirectorAd, 0, 1)
-			if newVal == 1 {
-				ads = append(ads, *dirAd)
+			select {
+			case firstContactCh <- struct{}{}:
+			default:
 			}
-			buf, err := json.Marshal(ads)
+			// Set Expiration dynamically per-response so the entry in directorAds
+			// has a short, finite lifetime. Without this, Initialize above stamps
+			// the ad with the default expiration time (15m).
+			adCopy := *dirAd
+			adCopy.Expiration = time.Now().Add(param.Server_AdLifetime.GetDuration())
+			buf, err := json.Marshal([]server_structs.DirectorAd{adCopy})
 			require.NoError(t, err)
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
@@ -74,11 +84,37 @@ func TestDirectorShutdown(t *testing.T) {
 	require.NoError(t, param.Server_DirectorUrls.Set([]string{ts.URL}))
 	defer ts.Close()
 
-	require.NoError(t, param.Server_AdLifetime.SetString("100ms"))
+	// AdLifetime of 300ms: discovery ticker fires every ~100ms; the
+	// fake-director ad expires after 300ms, giving the test comfortable
+	// margins.
+	require.NoError(t, param.Server_AdLifetime.SetString("300ms"))
 	fed_test_utils.NewFedTest(t, "")
-	time.Sleep(time.Duration(110 * time.Millisecond))
+
+	// Wait for at least one successful discovery contact before simulating shutdown.
+	select {
+	case <-firstContactCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("fake director was never contacted during discovery")
+	}
+
+	// Close the listener to simulate a real peer shutdown (connection refused).
+	ts.Close()
+
+	// After shutdown, every subsequent discovery attempt for ts.URL will
+	// fail at the transport level.
+	require.Eventually(t, func() bool {
+		for _, ad := range server_utils.GetDirectorAds() {
+			if ad.AdvertiseUrl == ts.URL {
+				return false
+			}
+		}
+		return true
+	}, 10*time.Second, 50*time.Millisecond,
+		"fake director should disappear from directorEndpoints after shutdown")
+
+	// Only the local director's own self-entry should remain.
 	ads := server_utils.GetDirectorAds()
-	assert.Equal(t, 1, len(ads), "Unexpected directors showing up in response: %+v", ads)
+	assert.Equal(t, 1, len(ads), "only local director should remain after peer shutdown, got: %+v", ads)
 }
 
 // Significantly decrease the ad lifetime; ensure forwarding from director and

--- a/server_utils/director_discovery.go
+++ b/server_utils/director_discovery.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -117,6 +117,7 @@ func doDiscovery(ctx context.Context, isDirector bool) (endpoints []server_struc
 
 	// For each statically-defined endpoint, query it for all its known directors
 	var allErrors error = nil
+	contacted := make(map[string]bool)
 	for endpoint := range endpointsTemp {
 		var directorUrl *url.URL
 		directorUrl, err = url.Parse(endpoint)
@@ -148,9 +149,14 @@ func doDiscovery(ctx context.Context, isDirector bool) (endpoints []server_struc
 			allErrors = errors.Join(allErrors, err)
 			continue
 		}
+		contacted[endpoint] = true
+		now := time.Now()
 		for _, directorEndpoint := range directorResponse {
 			existingAd := endpointMap[directorEndpoint.AdvertiseUrl]
 			if directorEndpoint.Name == "" {
+				continue
+			}
+			if !directorEndpoint.Expiration.IsZero() && now.After(directorEndpoint.Expiration) {
 				continue
 			}
 			if after := directorEndpoint.After(existingAd); existingAd.Name == "" || after == server_structs.AdAfterTrue || after == server_structs.AdAfterUnknown {
@@ -159,17 +165,30 @@ func doDiscovery(ctx context.Context, isDirector bool) (endpoints []server_struc
 		}
 	}
 
+	// Ensure every seed we successfully contacted but that no peer
+	// reported is kept in endpointMap as a synthetic entry. A seed may
+	// legitimately omit its own URL from its /directors response
+	// (e.g., it is an older director that still relies on getting its
+	// own ad back from a peer).
+	for endpoint := range contacted {
+		if _, ok := endpointMap[endpoint]; !ok {
+			endpointMap[endpoint] = server_structs.DirectorAd{AdvertiseUrl: endpoint}
+		}
+	}
+
 	// No endpoints were found and the federation director endpoint is nil
 	if len(endpointMap) == 0 && fed.DirectorEndpoint == "" {
 		newError := errors.New("failed to find director endpoint")
 		err = errors.Join(newError, allErrors)
 	} else if len(endpointMap) == 0 { // Fall back to director endpoint
+		err = nil
 		endpoints = []server_structs.DirectorAd{
 			{
 				AdvertiseUrl: fed.DirectorEndpoint,
 			},
 		}
 	} else { // ad discovery succeeded, so use that
+		err = nil
 		endpoints = make([]server_structs.DirectorAd, 0, len(endpointMap))
 		for _, ad := range endpointMap {
 			endpoints = append(endpoints, ad)

--- a/server_utils/director_discovery_test.go
+++ b/server_utils/director_discovery_test.go
@@ -1,0 +1,174 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package server_utils
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
+)
+
+// TestDoDiscoveryAddsSyntheticSeedMissingFromPeerResponse verifies that
+// when a configured seed URL is successfully contacted but is not mentioned
+// in any peer's /directors response, doDiscovery still includes it as
+// a synthetic DirectorAd so that clients can still reach it.
+func TestDoDiscoveryAddsSyntheticSeedMissingFromPeerResponse(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+
+	// Director B is online and only reports itself.
+	var serverBURL string
+	serverB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ads := []server_structs.DirectorAd{
+			{
+				AdvertiseUrl: serverBURL,
+				ServerBaseAd: server_structs.ServerBaseAd{
+					Name:       "dir-b",
+					InstanceID: "inst-b",
+					StartTime:  1,
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(ads)
+	}))
+	defer serverB.Close()
+	serverBURL = serverB.URL
+
+	// Director A is online but returns an empty list.
+	serverA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]server_structs.DirectorAd{})
+	}))
+	defer serverA.Close()
+	serverAURL := serverA.URL
+
+	require.NoError(t, param.Server_DirectorUrls.Set([]string{serverAURL, serverBURL}))
+
+	endpoints, err := doDiscovery(context.Background(), false)
+	require.NoError(t, err)
+
+	urls := make(map[string]bool, len(endpoints))
+	for _, ep := range endpoints {
+		urls[ep.AdvertiseUrl] = true
+	}
+	assert.True(t, urls[serverBURL], "server B (peer-reported) must be in endpoints")
+	assert.True(t, urls[serverAURL], "server A (synthetic seed) must be in endpoints even though it didn't report itself")
+}
+
+// TestDoDiscoveryNoSyntheticEntryForOfflineSeed verifies that a configured
+// seed which is genuinely offline is NOT added as a synthetic entry.
+func TestDoDiscoveryNoSyntheticEntryForOfflineSeed(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+
+	var serverBURL string
+	serverB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ads := []server_structs.DirectorAd{
+			{
+				AdvertiseUrl: serverBURL,
+				ServerBaseAd: server_structs.ServerBaseAd{
+					Name:       "dir-b",
+					InstanceID: "inst-b",
+					StartTime:  1,
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(ads)
+	}))
+	defer serverB.Close()
+	serverBURL = serverB.URL
+
+	// Create and immediately close server A to simulate a refused connection.
+	serverA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	serverAURL := serverA.URL
+	serverA.Close()
+
+	require.NoError(t, param.Server_DirectorUrls.Set([]string{serverAURL, serverBURL}))
+
+	endpoints, err := doDiscovery(context.Background(), false)
+	require.NoError(t, err, "one reachable peer is sufficient; error must not propagate")
+
+	urls := make(map[string]bool, len(endpoints))
+	for _, ep := range endpoints {
+		urls[ep.AdvertiseUrl] = true
+	}
+	assert.True(t, urls[serverBURL], "server B (peer-reported) must be in endpoints")
+	assert.False(t, urls[serverAURL], "server A (genuinely offline) must NOT be added as a synthetic entry")
+}
+
+// TestDoDiscoveryFiltersExpiredPeerEntries verifies that entries returned
+// by a peer's /directors response with a past Expiration timestamp are
+// excluded from the endpointMap, preventing a stale-state self-sustaining
+// loop.
+func TestDoDiscoveryFiltersExpiredPeerEntries(t *testing.T) {
+	ResetTestState()
+	t.Cleanup(ResetTestState)
+
+	expiredTime := time.Now().Add(-1 * time.Minute)
+	liveTime := time.Now().Add(15 * time.Minute)
+
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ads := []server_structs.DirectorAd{
+			{
+				AdvertiseUrl: "http://expired.example.com",
+				ServerBaseAd: server_structs.ServerBaseAd{
+					Name:       "dir-expired",
+					InstanceID: "inst-expired",
+					StartTime:  1,
+					Expiration: expiredTime,
+				},
+			},
+			{
+				AdvertiseUrl: serverURL,
+				ServerBaseAd: server_structs.ServerBaseAd{
+					Name:       "dir-live",
+					InstanceID: "inst-live",
+					StartTime:  1,
+					Expiration: liveTime,
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(ads)
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	require.NoError(t, param.Server_DirectorUrls.Set([]string{serverURL}))
+
+	endpoints, err := doDiscovery(context.Background(), false)
+	require.NoError(t, err)
+
+	urls := make(map[string]bool, len(endpoints))
+	for _, ep := range endpoints {
+		urls[ep.AdvertiseUrl] = true
+	}
+	assert.False(t, urls["http://expired.example.com"],
+		"entry with past Expiration must be filtered out")
+	assert.True(t, urls[serverURL],
+		"entry with future Expiration must be present")
+}


### PR DESCRIPTION
Fixes #3449.

## What broke and why

In a two-director federation (A and B), if A goes offline, B can enter a self-sustaining broken state: B's `/directors` API returns only A, origins and caches redirect all advertisements to the offline A, B's namespace store empties, and clients receive HTTP 404 "No sources found." Recovery requires A to come back online, a restart of B, or manual intervention. This was observed in the OSDF production federation on 2026-05-13.

Three independent design flaws compose into the cascade.

**Flaw 1 — B's self-entry in `directorAds` depends on a peer round-trip.**
`sendMyAd` forwards B's ad to peers but never inserts it into the local `directorAds`. B's self-entry is refreshed only when a peer gossips it back via `/registerDirector`. With A offline, that round-trip is broken. B's self-entry expires, and B's `/directors` starts returning only A.

**Flaw 2 — `doDiscovery` discards seeds that peers fail to confirm.**
The discovery loop merges peer `/directors` responses into `endpointMap`, but never inserts the configured seed URLs themselves. When B's `/directors` returns `[A only]`, `doDiscovery` produces `directorEndpoints = [A only]`. Origins, caches, and B itself all stop advertising to B.

**Flaw 3 — Expired entries circulate indefinitely.**
`doDiscovery` accepts entries from peer responses without checking `Expiration`. `listDirectors` falls back to `directorEndpoints` (which has no expiry filter) when `directorAds` is empty. Together, these form a closed loop where stale entries in `directorEndpoints` are fed back through `doDiscovery` and written back unchanged, with no way to break the cycle.

## Fixes

**Fix 1** (`doDiscovery`) — After the query loop, insert any successfully-contacted seed URL that no peer reported as a synthetic entry in `endpointMap`. This restores B as a viable advertisement target for origins and caches. Only seeds that returned HTTP 200 with valid JSON are synthesized; offline seeds are not.

**Fix 2** (`sendMyAd`) — Self-insert the freshly-built ad into the local `directorAds` under the write lock before forwarding to peers. B's self-entry is now independent of any peer round-trip, so the `[A only]` window cannot open in the first place.

**Fix 3** (`doDiscovery`) — Skip entries in peer responses whose `Expiration` is in the past. This breaks the stale-gossip loop and serves as a defense-in-depth safety net for edge cases such as a director restarting after a long outage.

## Tests

- `TestSendMyAdInsertsIntoDirectorAds` — Fix 2: self-entry present in `directorAds` immediately after `sendMyAd`.
- `TestListDirectorsReturnsSelfAfterPeerExpires` — Fix 2: self-entry still present after all peer ads expire.
- `TestDoDiscoveryAddsSyntheticSeedMissingFromPeerResponse` — Fix 1: online seed omitted from all peer responses appears as a synthetic entry.
- `TestDoDiscoveryNoSyntheticEntryForOfflineSeed` — Fix 1: genuinely offline seed is not synthesized.
- `TestDoDiscoveryFiltersExpiredPeerEntries` — Fix 3: peer-reported entries with a past `Expiration` are excluded.
- `TestDirectorShutdown` (rewritten) — end-to-end: a peer whose listener is closed (connection refused) disappears from `directorEndpoints` within one ad lifetime.

---

With a tip of the hat to Copilot.