### PR TITLE
Unhide `Monitoring.StorageXXX` params

### DIFF
--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -4271,7 +4271,6 @@ description: |+
   The interval at which the server checks filesystem storage consumption for health monitoring.
 type: duration
 default: 5m
-hidden: true
 components: ["origin", "cache", "director", "registry", "broker", "localcache"]
 ---
 name: Monitoring.StorageWarningThreshold
@@ -4280,7 +4279,6 @@ description: |+
   The value should be between 0 and 100 representing the percentage of storage used.
 type: int
 default: 80
-hidden: true
 components: ["origin", "cache", "director", "registry", "broker", "localcache"]
 ---
 name: Monitoring.StorageCriticalThreshold
@@ -4289,7 +4287,6 @@ description: |+
   The value should be between 0 and 100 representing the percentage of storage used.
 type: int
 default: 90
-hidden: true
 components: ["origin", "cache", "director", "registry", "broker", "localcache"]
 ---
 ############################


### PR DESCRIPTION
The default values of these params are problematic because they cause the cache to enter a storage-related "critical" status before the cache hits its high watermark. Because of the critical status, the cache is filtered from the federation and never hits its HWM, and is thus never cleaned to a point that would take it out of that state.

This is the first of a set of patches to fix the issue -- in this pass we only unhide the params so we can advise cache admins how to mitigate the problem via configuration. We'll adjust the defaults in a different patch (so as not to hold up the current release candidate that's already 3 months late).

@h2zh this should be included in the `v7.25.x` branch before release of `v7.25.0` -- it should not require testing because it is docs-only
@turetske, this should also be patched into `v7.26.x`

See issue #3451 