### PR TITLE
Adjust various storage param defaults to better align with one another

### DIFF
--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -73,8 +73,8 @@ Cache:
   EnablePrefetch: true
   SelfTest: true
   SelfTestInterval: 15s
-  LowWatermark: 90
-  HighWaterMark: 95
+  LowWatermark: 85
+  HighWaterMark: 89
   BlocksToPrefetch: 0
   EnableTLSClientAuth: false
   DisableClientX509: true
@@ -92,7 +92,7 @@ Lotman:
 LocalCache:
   DefaultMaxAge: 24h
   FDCacheSize: 500
-  HighWaterMarkPercentage: 95
+  HighWaterMarkPercentage: 89
   LowWaterMarkPercentage: 85
   MaxConcurrentPrefetch: 5
   PrefetchTimeout: 10s
@@ -138,8 +138,8 @@ Monitoring:
   LabelValueLengthLimit: 2048
   SampleLimit: 200
   StorageHealthCheckInterval: 5m
-  StorageWarningThreshold: 80
-  StorageCriticalThreshold: 90
+  StorageWarningThreshold: 92
+  StorageCriticalThreshold: 97
 Shoveler:
   MessageQueueProtocol: amqp
   PortLower: 9930

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1914,7 +1914,7 @@ description: |+
   of completed files hits the high water mark, files will be deleted until the usage hits the
   low water mark.
 type: int
-default: 95
+default: 89
 components: ["localcache"]
 ---
 name: LocalCache.LowWaterMarkPercentage
@@ -2023,7 +2023,7 @@ description: |+
     StorageDirs:
       - Path: /mnt/nvme/cache
         MaxSize: 500GB
-        HighWaterMarkPercentage: 95
+        HighWaterMarkPercentage: 89
         LowWaterMarkPercentage: 85
       - Path: /mnt/hdd/cache
         MaxSize: 2TB
@@ -2269,7 +2269,7 @@ description: |+
   For more information, see the [xrootd pfc documentation](https://xrootd.web.cern.ch/doc/dev56/pss_config.pdf) for
   `pfc.diskusage`.
 type: string
-default: 90
+default: 85
 components: ["cache"]
 ---
 name: Cache.HighWaterMark
@@ -2284,7 +2284,7 @@ description: |+
   For more information, see the [xrootd pfc documentation](https://xrootd.web.cern.ch/doc/dev56/pss_config.pdf) for
   `pfc.diskusage`.
 type: string
-default: 95
+default: 89
 components: ["cache"]
 ---
 name: Cache.FilesMaxSize
@@ -4279,7 +4279,7 @@ description: |+
   The storage usage percentage threshold at which a warning health status is reported.
   The value should be between 0 and 100 representing the percentage of storage used.
 type: int
-default: 80
+default: 92
 hidden: true
 components: ["origin", "cache", "director", "registry", "broker", "localcache"]
 ---
@@ -4288,7 +4288,7 @@ description: |+
   The storage usage percentage threshold at which a critical health status is reported.
   The value should be between 0 and 100 representing the percentage of storage used.
 type: int
-default: 90
+default: 97
 hidden: true
 components: ["origin", "cache", "director", "registry", "broker", "localcache"]
 ---

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/charmbracelet/glamour v0.8.0
 	github.com/cyphar/filepath-securejoin v0.4.1
 	github.com/dgraph-io/badger/v4 v4.9.1
+	github.com/dgraph-io/ristretto/v2 v2.2.0
 	github.com/ebitengine/purego v0.8.3
 	github.com/fatih/color v1.18.0
 	github.com/gin-gonic/gin v1.9.1
@@ -59,6 +60,7 @@ require (
 	golang.org/x/crypto v0.46.0
 	golang.org/x/net v0.48.0
 	golang.org/x/oauth2 v0.34.0
+	golang.org/x/sys v0.39.0
 	golang.org/x/term v0.38.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/gorm v1.25.7
@@ -76,7 +78,6 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/cristalhq/jwt/v4 v4.0.2 // indirect
 	github.com/dgraph-io/ristretto v1.0.0 // indirect
-	github.com/dgraph-io/ristretto/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
 	github.com/glebarez/go-sqlite v1.21.2 // indirect
@@ -136,7 +137,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/mod v0.30.0 // indirect
-	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/tools v0.39.0 // indirect
 	golang.org/x/tools/godoc v0.1.0-deprecated // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect


### PR DESCRIPTION
These params were out of sync because the monitoring values triggered alerts in caches that were operating in their normal storage bounds.

This adjust the values according to advice from John Thiltges and the ops team.

See issue #3451 