### PR TITLE
Avoid duplicate OIDC metadata endpoints registration

### DIFF
--- a/launchers/origin_serve.go
+++ b/launchers/origin_serve.go
@@ -147,13 +147,6 @@ func OriginServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, 
 		}
 	}
 
-	// Register OIDC metadata endpoints
-	// Director also registers this metadata URL; avoid registering twice.
-	if !modules.IsEnabled(server_structs.DirectorType) {
-		OIDCAPIGroup := engine.Group("/", web_ui.ServerHeaderMiddleware, web_ui.ReadOnlyMiddleware)
-		server_utils.RegisterOIDCAPI(OIDCAPIGroup, false)
-	}
-
 	// Handle XRootD-specific initialization
 	if useXRootD {
 		configPath, err := xrootd.ConfigXrootd(ctx, true)


### PR DESCRIPTION
- Remove duplicate OIDC metadata endpoints registration
- Also drop ReadOnlyMiddleware from the OIDC route group, because it's a functional no-op for these routes.
  - ReadOnlyMiddleware only rejects requests when both `Server.WebReadOnly=true` AND the method is outside {GET, HEAD, OPTIONS, TRACE, PROPFIND}.
  - RegisterOIDCAPI registers `/.well-known/openid-configuration` and JWKS. They are all GETs. They're already in the safe-methods list, so the middleware can never fire on these paths.

Closes #3455 