### PR TITLE
Logging metadata registry integration

### DIFF
--- a/config/config_validation.go
+++ b/config/config_validation.go
@@ -109,20 +109,29 @@ func validateConfigKeys() []string {
 // for all server types. It is a no-op if Logging.LogExports.Enabled is false.
 //
 // Rules enforced:
+//   - Xrootd.Sitename must be set (it is used as the logging namespace path segment).
 //   - Logging.LogLocation must be set to an absolute file path other than "/dev/null",
 //     because the virtual-object handler reads that file to assemble log responses.
 //   - If IssuerKeysDirectory is empty the server will not be able to auto-generate access
 //     tokens for the logging namespace; a warning is emitted but startup is not blocked.
 func ValidateLogExportsConfig() error {
-	if !param.Logging_LogExports_Enabled.GetBool() {
+	if !param.Logging_EnableLogExports.GetBool() {
 		return nil
+	}
+
+	if param.Xrootd_Sitename.GetString() == "" {
+		return fmt.Errorf(
+			"%s is true but %s must be set — it is used as the logging namespace path segment (/pelican/logging/{sitename})",
+			param.Logging_EnableLogExports.GetName(),
+			param.Xrootd_Sitename.GetName(),
+		)
 	}
 
 	logLocation := param.Logging_LogLocation.GetString()
 	if !filepath.IsAbs(logLocation) || logLocation == "/dev/null" {
 		return fmt.Errorf(
 			"%s is true but %s must be set to an absolute file path (not \"/dev/null\") to enable log export",
-			param.Logging_LogExports_Enabled.GetName(),
+			param.Logging_EnableLogExports.GetName(),
 			param.Logging_LogLocation.GetName(),
 		)
 	}
@@ -130,7 +139,7 @@ func ValidateLogExportsConfig() error {
 	if param.IssuerKeysDirectory.GetString() == "" {
 		log.Warningf("%s is true but %s is not configured; "+
 			"the server will not be able to auto-generate access tokens for the logging namespace",
-			param.Logging_LogExports_Enabled.GetName(),
+			param.Logging_EnableLogExports.GetName(),
 			param.IssuerKeysDirectory.GetName())
 	}
 

--- a/config/config_validation_test.go
+++ b/config/config_validation_test.go
@@ -102,8 +102,19 @@ func TestValidateLogExportsConfig(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("error when enabled but Sitename is empty", func(t *testing.T) {
+		t.Cleanup(func() { ResetConfig() })
+		require.NoError(t, param.Logging_EnableLogExports.Set(true))
+		// Xrootd.Sitename defaults to empty.
+		err := ValidateLogExportsConfig()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), param.Xrootd_Sitename.GetName())
+	})
+
 	t.Run("error when enabled but LogLocation is empty", func(t *testing.T) {
-		require.NoError(t, param.Logging_LogExports_Enabled.Set(true))
+		t.Cleanup(func() { ResetConfig() })
+		require.NoError(t, param.Logging_EnableLogExports.Set(true))
+		require.NoError(t, param.Xrootd_Sitename.Set("test-origin"))
 		// Logging.LogLocation defaults to empty string.
 		err := ValidateLogExportsConfig()
 		require.Error(t, err)
@@ -111,7 +122,9 @@ func TestValidateLogExportsConfig(t *testing.T) {
 	})
 
 	t.Run("error when enabled but LogLocation is /dev/null", func(t *testing.T) {
-		require.NoError(t, param.Logging_LogExports_Enabled.Set(true))
+		t.Cleanup(func() { ResetConfig() })
+		require.NoError(t, param.Logging_EnableLogExports.Set(true))
+		require.NoError(t, param.Xrootd_Sitename.Set("test-origin"))
 		require.NoError(t, param.Logging_LogLocation.Set("/dev/null"))
 		err := ValidateLogExportsConfig()
 		require.Error(t, err)
@@ -119,6 +132,7 @@ func TestValidateLogExportsConfig(t *testing.T) {
 	})
 
 	t.Run("warning when enabled and LogLocation set but IssuerKeysDirectory empty", func(t *testing.T) {
+		t.Cleanup(func() { ResetConfig() })
 		hook := test.NewGlobal()
 		defer hook.Reset()
 
@@ -127,7 +141,8 @@ func TestValidateLogExportsConfig(t *testing.T) {
 		require.NoError(t, err)
 		f.Close()
 
-		require.NoError(t, param.Logging_LogExports_Enabled.Set(true))
+		require.NoError(t, param.Logging_EnableLogExports.Set(true))
+		require.NoError(t, param.Xrootd_Sitename.Set("test-origin"))
 		require.NoError(t, param.Logging_LogLocation.Set(logFile))
 		// IssuerKeysDirectory is empty (default).
 
@@ -145,13 +160,15 @@ func TestValidateLogExportsConfig(t *testing.T) {
 	})
 
 	t.Run("success when enabled with real LogLocation and IssuerKeysDirectory", func(t *testing.T) {
+		t.Cleanup(func() { ResetConfig() })
 		tmpDir := t.TempDir()
 		logFile := filepath.Join(tmpDir, "pelican.log")
 		f, err := os.Create(logFile)
 		require.NoError(t, err)
 		f.Close()
 
-		require.NoError(t, param.Logging_LogExports_Enabled.Set(true))
+		require.NoError(t, param.Logging_EnableLogExports.Set(true))
+		require.NoError(t, param.Xrootd_Sitename.Set("test-origin"))
 		require.NoError(t, param.Logging_LogLocation.Set(logFile))
 		require.NoError(t, param.IssuerKeysDirectory.Set(tmpDir))
 

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -459,11 +459,12 @@ default: error
 components: ["cache"]
 runtime_configurable: true
 ---
-name: Logging.LogExports.Enabled
+name: Logging.EnableLogExports
 description: |+
-  When true, this server exports its logs via the Pelican logging namespace (`/pelican/logging/{Server.ID}`).
+  When true, this server exports its logs via the Pelican logging namespace (`/pelican/logging/{sitename}`).
   Clients with the appropriate token can retrieve log entries as virtual time-bucketed objects.
   Requires `${Logging.LogLocation}` to be set to a real file path (not empty or `/dev/null`).
+  Requires `${Xrootd.Sitename}` to be set — it is used as the path segment in the logging namespace URL.
   `${IssuerKeysDirectory}` must also be configured so the server can auto-generate access tokens for the logging namespace.
   Defaults to false — log export is opt-in.
 type: bool
@@ -474,7 +475,7 @@ name: Logging.LogExports.AllowFederationAdmin
 description: |+
   When true, the federation issuer URL is added as an authorized issuer for this server's logging namespace,
   allowing federation administrators to read logs from this server using a federation-issued token.
-  Has no effect when `${Logging.LogExports.Enabled}` is false.
+  Has no effect when `${Logging.EnableLogExports}` is false.
   Defaults to false.
 type: bool
 default: false
@@ -3171,11 +3172,11 @@ components: ["registry"]
 ---
 name: Registry.EnableAutoLoggingRegistration
 description: |+
-  When true, the Registry automatically approves logging namespace registrations (`/pelican/logging/{Server.ID}`)
-  submitted by Origins or Caches whose main server registration is already approved.
+  When true, the Registry automatically approves logging namespace registrations (`/pelican/logging/{sitename}`)
+  submitted by Origins whose main server registration is already approved.
   If the server registration is still pending at the time the logging namespace is submitted,
   approval is deferred until the server is approved.
-  This is a federation-level gate distinct from `${Logging.LogExports.Enabled}` on each individual server.
+  This is a federation-level gate distinct from `${Logging.EnableLogExports}` on each individual server.
   Defaults to false.
 type: bool
 default: false

--- a/launcher_utils/register_namespace.go
+++ b/launcher_utils/register_namespace.go
@@ -265,11 +265,15 @@ func registerNamespaceImpl(key jwk.Key, prefix string, siteName string, registra
 	return nil
 }
 
-// Register the namespace. If failed, retry every 10s (default)
-// RegisterLoggingNamespaceWithRetry registers the logging namespace /pelican/logging/{Server.ID}
-// for the origin server. It is a no-op when Logging.LogExports.Enabled is false.
-// Must be called after the origin prefix has been successfully registered so that GetServerMetadata
-// can retrieve the assigned Server.ID from the registry.
+// RegisterLoggingNamespaceWithRetry registers the logging namespace
+// /pelican/logging/{Server.ID} for the origin server.
+// It is a no-op when Logging.LogExports.Enabled is false.
+//
+// Must be called after the origin server prefix has been registered so that
+// the server record (and its Server.ID) exists in the registry.  If the
+// origin prefix registration is still retrying in the background, the server
+// ID will not yet be available; in that case this function spawns a goroutine
+// in egrp that polls until the ID appears, then calls RegisterNamespaceWithRetry.
 func RegisterLoggingNamespaceWithRetry(ctx context.Context, egrp *errgroup.Group) error {
 	if !param.Logging_LogExports_Enabled.GetBool() {
 		return nil
@@ -278,15 +282,50 @@ func RegisterLoggingNamespaceWithRetry(ctx context.Context, egrp *errgroup.Group
 	if err != nil {
 		return errors.Wrap(err, "failed to get server metadata for logging namespace registration")
 	}
+	// metadata.ID is the 7-character server ID assigned by the registry the
+	// first time the origin's namespace prefix is successfully registered.  It
+	// is empty when the registry has never seen this origin — for example
+	// because the initial namespace registration failed and is still retrying
+	// in the background.  In that case GetServerMetadata returns an empty
+	// ServerRegistration because no server record exists yet.  Spawn a goroutine
+	// that polls until the ID becomes available, then hands off to
+	// RegisterNamespaceWithRetry.
 	if metadata.ID == "" {
-		log.Warning("Server ID is empty; cannot register logging namespace. Log export will be unavailable until the server is restarted.")
+		log.Warning("Server ID is empty; logging namespace registration will be retried once the origin prefix is registered.")
+		retryInterval := param.Server_RegistrationRetryInterval.GetDuration()
+		if retryInterval == 0 {
+			retryInterval = 10 * time.Second
+		}
+		egrp.Go(func() error {
+			ticker := time.NewTicker(retryInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					md, err := server_utils.GetServerMetadata(ctx, server_structs.OriginType)
+					if err != nil {
+						log.Warningf("Failed to get server metadata while retrying logging namespace registration: %v", err)
+						continue
+					}
+					if md.ID == "" {
+						continue
+					}
+					loggingPrefix := server_structs.LoggingNamespaceForServer(md.ID)
+					log.Debugf("Registering logging namespace %s", loggingPrefix)
+					return RegisterNamespaceWithRetry(ctx, egrp, loggingPrefix)
+				case <-ctx.Done():
+					return nil
+				}
+			}
+		})
 		return nil
 	}
-	loggingPrefix := server_structs.LoggingNamespacePrefix + "/" + metadata.ID
+	loggingPrefix := server_structs.LoggingNamespaceForServer(metadata.ID)
 	log.Debugf("Registering logging namespace %s", loggingPrefix)
 	return RegisterNamespaceWithRetry(ctx, egrp, loggingPrefix)
 }
 
+// RegisterNamespaceWithRetry registers the namespace. If failed, retries every 10s (default)
 func RegisterNamespaceWithRetry(ctx context.Context, egrp *errgroup.Group, prefix string) error {
 	retryInterval := param.Server_RegistrationRetryInterval.GetDuration()
 	if retryInterval == 0 {

--- a/launcher_utils/register_namespace.go
+++ b/launcher_utils/register_namespace.go
@@ -40,7 +40,6 @@ import (
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/registry/registry_client"
 	"github.com/pelicanplatform/pelican/server_structs"
-	"github.com/pelicanplatform/pelican/server_utils"
 )
 
 type (
@@ -266,61 +265,26 @@ func registerNamespaceImpl(key jwk.Key, prefix string, siteName string, registra
 }
 
 // RegisterLoggingNamespaceWithRetry registers the logging namespace
-// /pelican/logging/{Server.ID} for the origin server.
-// It is a no-op when Logging.LogExports.Enabled is false.
+// /pelican/logging/{sitename} for the origin server, where sitename is
+// the value of Xrootd.Sitename (the human-readable unique server name).
+// It is a no-op when Logging.EnableLogExports is false.
 //
-// Must be called after the origin server prefix has been registered so that
-// the server record (and its Server.ID) exists in the registry.  If the
-// origin prefix registration is still retrying in the background, the server
-// ID will not yet be available; in that case this function spawns a goroutine
-// in egrp that polls until the ID appears, then calls RegisterNamespaceWithRetry.
+// The logging namespace prefix is derived entirely from local configuration
+// and does not require a registry lookup, so this can be called at any point
+// after server configuration is initialised.  The logging namespace will be
+// submitted as pending if the origin is still awaiting admin approval;
+// Registry.EnableAutoLoggingRegistration controls whether the registry
+// auto-approves it once the associated origin is approved.
 func RegisterLoggingNamespaceWithRetry(ctx context.Context, egrp *errgroup.Group) error {
-	if !param.Logging_LogExports_Enabled.GetBool() {
+	if !param.Logging_EnableLogExports.GetBool() {
 		return nil
 	}
-	metadata, err := server_utils.GetServerMetadata(ctx, server_structs.OriginType)
-	if err != nil {
-		return errors.Wrap(err, "failed to get server metadata for logging namespace registration")
+	sitename := param.Xrootd_Sitename.GetString()
+	if sitename == "" {
+		return errors.Errorf("cannot register logging namespace: %s must be set when %s is true",
+			param.Xrootd_Sitename.GetName(), param.Logging_EnableLogExports.GetName())
 	}
-	// metadata.ID is the 7-character server ID assigned by the registry the
-	// first time the origin's namespace prefix is successfully registered.  It
-	// is empty when the registry has never seen this origin — for example
-	// because the initial namespace registration failed and is still retrying
-	// in the background.  In that case GetServerMetadata returns an empty
-	// ServerRegistration because no server record exists yet.  Spawn a goroutine
-	// that polls until the ID becomes available, then hands off to
-	// RegisterNamespaceWithRetry.
-	if metadata.ID == "" {
-		log.Warning("Server ID is empty; logging namespace registration will be retried once the origin prefix is registered.")
-		retryInterval := param.Server_RegistrationRetryInterval.GetDuration()
-		if retryInterval == 0 {
-			retryInterval = 10 * time.Second
-		}
-		egrp.Go(func() error {
-			ticker := time.NewTicker(retryInterval)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-ticker.C:
-					md, err := server_utils.GetServerMetadata(ctx, server_structs.OriginType)
-					if err != nil {
-						log.Warningf("Failed to get server metadata while retrying logging namespace registration: %v", err)
-						continue
-					}
-					if md.ID == "" {
-						continue
-					}
-					loggingPrefix := server_structs.LoggingNamespaceForServer(md.ID)
-					log.Debugf("Registering logging namespace %s", loggingPrefix)
-					return RegisterNamespaceWithRetry(ctx, egrp, loggingPrefix)
-				case <-ctx.Done():
-					return nil
-				}
-			}
-		})
-		return nil
-	}
-	loggingPrefix := server_structs.LoggingNamespaceForServer(metadata.ID)
+	loggingPrefix := server_structs.LoggingNamespaceForServer(sitename)
 	log.Debugf("Registering logging namespace %s", loggingPrefix)
 	return RegisterNamespaceWithRetry(ctx, egrp, loggingPrefix)
 }

--- a/launcher_utils/register_namespace.go
+++ b/launcher_utils/register_namespace.go
@@ -40,6 +40,7 @@ import (
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/registry/registry_client"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 )
 
 type (
@@ -265,6 +266,27 @@ func registerNamespaceImpl(key jwk.Key, prefix string, siteName string, registra
 }
 
 // Register the namespace. If failed, retry every 10s (default)
+// RegisterLoggingNamespaceWithRetry registers the logging namespace /pelican/logging/{Server.ID}
+// for the origin server. It is a no-op when Logging.LogExports.Enabled is false.
+// Must be called after the origin prefix has been successfully registered so that GetServerMetadata
+// can retrieve the assigned Server.ID from the registry.
+func RegisterLoggingNamespaceWithRetry(ctx context.Context, egrp *errgroup.Group) error {
+	if !param.Logging_LogExports_Enabled.GetBool() {
+		return nil
+	}
+	metadata, err := server_utils.GetServerMetadata(ctx, server_structs.OriginType)
+	if err != nil {
+		return errors.Wrap(err, "failed to get server metadata for logging namespace registration")
+	}
+	if metadata.ID == "" {
+		log.Warning("Server ID is empty; cannot register logging namespace. Log export will be unavailable until the server is restarted.")
+		return nil
+	}
+	loggingPrefix := server_structs.LoggingNamespacePrefix + "/" + metadata.ID
+	log.Debugf("Registering logging namespace %s", loggingPrefix)
+	return RegisterNamespaceWithRetry(ctx, egrp, loggingPrefix)
+}
+
 func RegisterNamespaceWithRetry(ctx context.Context, egrp *errgroup.Group, prefix string) error {
 	retryInterval := param.Server_RegistrationRetryInterval.GetDuration()
 	if retryInterval == 0 {

--- a/launcher_utils/register_namespace_test.go
+++ b/launcher_utils/register_namespace_test.go
@@ -29,8 +29,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/lestrrat-go/jwx/v2/jwk"
@@ -117,8 +117,7 @@ func TestRegistration(t *testing.T) {
 	req, err := http.NewRequest("GET", svr.URL+"/api/v1.0/registry", nil)
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
-	tr := config.GetTransport()
-	client := &http.Client{Transport: tr}
+	client := config.GetClient()
 
 	resp, err := client.Do(req)
 	require.NoError(t, err)
@@ -279,8 +278,7 @@ func TestMultiKeysRegistration(t *testing.T) {
 	req, err := http.NewRequest("GET", svr.URL+"/api/v1.0/registry", nil)
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
-	tr := config.GetTransport()
-	client := &http.Client{Transport: tr}
+	client := config.GetClient()
 
 	resp, err := client.Do(req)
 	require.NoError(t, err)
@@ -343,18 +341,16 @@ func TestRegisterLoggingNamespaceWithRetry_NoopWhenDisabled(t *testing.T) {
 		require.NoError(t, egrp.Wait())
 	}()
 
-	// Logging.LogExports.Enabled is false by default.
-	// The function must return nil immediately without touching the network or
-	// adding any goroutines to the errgroup.
-	goroutinesBefore := runtime.NumGoroutine()
+	// Logging.EnableLogExports is false by default.
+	// The function must return nil immediately without adding any goroutines to
+	// egrp; the deferred egrp.Wait() above will catch any unexpected goroutines.
 	err := RegisterLoggingNamespaceWithRetry(ctx, egrp)
-	require.NoError(t, err, "RegisterLoggingNamespaceWithRetry should be a no-op when LogExports.Enabled is false")
-	require.Equal(t, goroutinesBefore, runtime.NumGoroutine(), "no goroutines should have been launched")
+	require.NoError(t, err, "RegisterLoggingNamespaceWithRetry should be a no-op when EnableLogExports is false")
 }
 
 // TestRegisterLoggingNamespaceWithRetry_WhenEnabled verifies that when
-// Logging.LogExports.Enabled is true, RegisterLoggingNamespaceWithRetry
-// registers /pelican/logging/{Server.ID} in the registry.
+// Logging.EnableLogExports is true, RegisterLoggingNamespaceWithRetry
+// registers /pelican/logging/{sitename} in the registry.
 func TestRegisterLoggingNamespaceWithRetry_WhenEnabled(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	t.Cleanup(server_utils.ResetTestState)
@@ -386,40 +382,100 @@ func TestRegisterLoggingNamespaceWithRetry_WhenEnabled(t *testing.T) {
 	defer svr.Close()
 
 	require.NoError(t, param.Set(param.Federation_RegistryUrl, svr.URL))
-	require.NoError(t, param.Xrootd_Sitename.Set("test-logging-origin"))
-	// Server_ExternalWebUrl's host is used by GetServerMetadata to derive the
-	// origin prefix (/origins/{host}) for the server metadata lookup.
+	// Xrootd.Sitename is used as the sitename in the logging namespace prefix
+	// (/pelican/logging/{sitename}).
+	const sitename = "test-logging-origin"
+	require.NoError(t, param.Xrootd_Sitename.Set(sitename))
 	const originHost = "testhost.example"
 	require.NoError(t, param.Server_ExternalWebUrl.Set("https://"+originHost))
 	require.NoError(t, config.InitServer(ctx, server_structs.OriginType))
 
-	// Register the origin prefix so a Server record (with ID) is created in
-	// the registry.  RegisterLoggingNamespaceWithRetry needs that ID.
+	// Register the origin prefix first (logging namespace gate requires the
+	// origin to be registered under the same sitename).
 	originPrefix := server_structs.GetOriginNs(originHost)
 	require.NoError(t, RegisterNamespaceWithRetry(ctx, egrp, originPrefix))
 
 	// Enable log exports and register the logging namespace.
-	require.NoError(t, param.Logging_LogExports_Enabled.Set(true))
+	require.NoError(t, param.Logging_EnableLogExports.Set(true))
 	require.NoError(t, RegisterLoggingNamespaceWithRetry(ctx, egrp))
 
-	// Get the server ID by querying the registry.
-	tr := config.GetTransport()
-	httpClient := &http.Client{Transport: tr}
-	serverResp, err := httpClient.Get(svr.URL + "/api/v1.0/registry/server" + originPrefix)
-	require.NoError(t, err)
-	defer serverResp.Body.Close()
-	require.Equal(t, http.StatusOK, serverResp.StatusCode)
-	serverBody, err := io.ReadAll(serverResp.Body)
-	require.NoError(t, err)
-	var serverMeta server_structs.ServerRegistration
-	require.NoError(t, json.Unmarshal(serverBody, &serverMeta))
-	require.NotEmpty(t, serverMeta.ID, "origin server should have an ID after registration")
-
-	// Verify the logging namespace registration exists.
-	loggingPrefix := server_structs.LoggingNamespaceForServer(serverMeta.ID)
+	// Verify the logging namespace registration exists using the sitename-based prefix.
+	loggingPrefix := server_structs.LoggingNamespaceForServer(sitename)
+	httpClient := config.GetClient()
 	loggingResp, err := httpClient.Get(svr.URL + "/api/v1.0/registry" + loggingPrefix)
 	require.NoError(t, err)
 	defer loggingResp.Body.Close()
 	assert.Equal(t, http.StatusOK, loggingResp.StatusCode,
 		"logging namespace %s should be registered after RegisterLoggingNamespaceWithRetry", loggingPrefix)
+}
+
+// TestRegisterLoggingNamespaceWithRetry_RetriesUntilOriginRegistered verifies
+// that calling RegisterLoggingNamespaceWithRetry before the origin namespace
+// has been registered does not return an error.  Instead it enters the retry
+// loop and eventually succeeds once the origin namespace is registered.
+func TestRegisterLoggingNamespaceWithRetry_RetriesUntilOriginRegistered(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	t.Cleanup(server_utils.ResetTestState)
+
+	tempConfigDir, err := os.MkdirTemp("", "test-logging-ns-retry-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempConfigDir)
+
+	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	defer func() {
+		cancel()
+		require.NoError(t, egrp.Wait())
+	}()
+
+	server_utils.ResetTestState()
+	require.NoError(t, param.ConfigDir.Set(tempConfigDir))
+	require.NoError(t, param.IssuerKeysDirectory.Set(filepath.Join(tempConfigDir, "issuer-keys")))
+	test_utils.MockFederationRoot(t, nil, nil)
+	require.NoError(t, param.Registry_DbLocation.Set(""))
+	require.NoError(t, param.Server_DbLocation.Set(filepath.Join(tempConfigDir, "test.sql")))
+	require.NoError(t, config.InitServer(ctx, server_structs.OriginType))
+	require.NoError(t, database.InitServerDatabase(server_structs.RegistryType))
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.Default()
+	registry.RegisterRegistryAPI(engine.Group("/"))
+	svr := httptest.NewServer(engine)
+	defer svr.CloseClientConnections()
+	defer svr.Close()
+
+	require.NoError(t, param.Set(param.Federation_RegistryUrl, svr.URL))
+	require.NoError(t, param.Xrootd_Sitename.Set("test-logging-retry-origin"))
+	const originHost = "retry-test.example"
+	require.NoError(t, param.Server_ExternalWebUrl.Set("https://"+originHost))
+	// Set a short retry interval so the test completes quickly.
+	require.NoError(t, param.Server_RegistrationRetryInterval.Set(200*time.Millisecond))
+	require.NoError(t, config.InitServer(ctx, server_structs.OriginType))
+
+	require.NoError(t, param.Logging_EnableLogExports.Set(true))
+
+	// Call RegisterLoggingNamespaceWithRetry WITHOUT registering the origin
+	// namespace first.  The registry will reject the logging namespace
+	// (origin not registered yet), but the function must return nil and
+	// enter the background retry loop instead of propagating the error.
+	err = RegisterLoggingNamespaceWithRetry(ctx, egrp)
+	require.NoError(t, err,
+		"RegisterLoggingNamespaceWithRetry must not return an error when the origin is not yet registered; it should retry in the background")
+
+	// Now register the origin namespace so the next retry attempt can succeed.
+	originPrefix := server_structs.GetOriginNs(originHost)
+	require.NoError(t, RegisterNamespaceWithRetry(ctx, egrp, originPrefix))
+
+	// The background retry goroutine should register the logging namespace
+	// once the origin is present.  Logging prefix is now sitename-based.
+	loggingPrefix := server_structs.LoggingNamespaceForServer("test-logging-retry-origin")
+	httpClient := config.GetClient()
+	require.Eventually(t, func() bool {
+		resp, err := httpClient.Get(svr.URL + "/api/v1.0/registry" + loggingPrefix)
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 10*time.Second, 300*time.Millisecond,
+		"logging namespace %s should eventually be registered by the retry loop", loggingPrefix)
 }

--- a/launcher_utils/register_namespace_test.go
+++ b/launcher_utils/register_namespace_test.go
@@ -332,11 +332,10 @@ func TestMultiKeysRegistration(t *testing.T) {
 	assert.True(t, isRegistered)
 	assert.Equal(t, svr.URL+"/api/v1.0/registry", registerURL)
 }
+
 func TestRegisterLoggingNamespaceWithRetry_NoopWhenDisabled(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
-	t.Cleanup(func() {
-		server_utils.ResetTestState()
-	})
+	t.Cleanup(server_utils.ResetTestState)
 
 	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
 	defer func() {
@@ -351,4 +350,76 @@ func TestRegisterLoggingNamespaceWithRetry_NoopWhenDisabled(t *testing.T) {
 	err := RegisterLoggingNamespaceWithRetry(ctx, egrp)
 	require.NoError(t, err, "RegisterLoggingNamespaceWithRetry should be a no-op when LogExports.Enabled is false")
 	require.Equal(t, goroutinesBefore, runtime.NumGoroutine(), "no goroutines should have been launched")
+}
+
+// TestRegisterLoggingNamespaceWithRetry_WhenEnabled verifies that when
+// Logging.LogExports.Enabled is true, RegisterLoggingNamespaceWithRetry
+// registers /pelican/logging/{Server.ID} in the registry.
+func TestRegisterLoggingNamespaceWithRetry_WhenEnabled(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	t.Cleanup(server_utils.ResetTestState)
+
+	tempConfigDir, err := os.MkdirTemp("", "test-logging-ns-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempConfigDir)
+
+	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	defer func() {
+		cancel()
+		require.NoError(t, egrp.Wait())
+	}()
+
+	server_utils.ResetTestState()
+	require.NoError(t, param.ConfigDir.Set(tempConfigDir))
+	require.NoError(t, param.IssuerKeysDirectory.Set(filepath.Join(tempConfigDir, "issuer-keys")))
+	test_utils.MockFederationRoot(t, nil, nil)
+	require.NoError(t, param.Registry_DbLocation.Set(""))
+	require.NoError(t, param.Server_DbLocation.Set(filepath.Join(tempConfigDir, "test.sql")))
+	require.NoError(t, config.InitServer(ctx, server_structs.OriginType))
+	require.NoError(t, database.InitServerDatabase(server_structs.RegistryType))
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.Default()
+	registry.RegisterRegistryAPI(engine.Group("/"))
+	svr := httptest.NewServer(engine)
+	defer svr.CloseClientConnections()
+	defer svr.Close()
+
+	require.NoError(t, param.Set(param.Federation_RegistryUrl, svr.URL))
+	require.NoError(t, param.Xrootd_Sitename.Set("test-logging-origin"))
+	// Server_ExternalWebUrl's host is used by GetServerMetadata to derive the
+	// origin prefix (/origins/{host}) for the server metadata lookup.
+	const originHost = "testhost.example"
+	require.NoError(t, param.Server_ExternalWebUrl.Set("https://"+originHost))
+	require.NoError(t, config.InitServer(ctx, server_structs.OriginType))
+
+	// Register the origin prefix so a Server record (with ID) is created in
+	// the registry.  RegisterLoggingNamespaceWithRetry needs that ID.
+	originPrefix := server_structs.GetOriginNs(originHost)
+	require.NoError(t, RegisterNamespaceWithRetry(ctx, egrp, originPrefix))
+
+	// Enable log exports and register the logging namespace.
+	require.NoError(t, param.Logging_LogExports_Enabled.Set(true))
+	require.NoError(t, RegisterLoggingNamespaceWithRetry(ctx, egrp))
+
+	// Get the server ID by querying the registry.
+	tr := config.GetTransport()
+	httpClient := &http.Client{Transport: tr}
+	serverResp, err := httpClient.Get(svr.URL + "/api/v1.0/registry/server" + originPrefix)
+	require.NoError(t, err)
+	defer serverResp.Body.Close()
+	require.Equal(t, http.StatusOK, serverResp.StatusCode)
+	serverBody, err := io.ReadAll(serverResp.Body)
+	require.NoError(t, err)
+	var serverMeta server_structs.ServerRegistration
+	require.NoError(t, json.Unmarshal(serverBody, &serverMeta))
+	require.NotEmpty(t, serverMeta.ID, "origin server should have an ID after registration")
+
+	// Verify the logging namespace registration exists.
+	loggingPrefix := server_structs.LoggingNamespaceForServer(serverMeta.ID)
+	loggingResp, err := httpClient.Get(svr.URL + "/api/v1.0/registry" + loggingPrefix)
+	require.NoError(t, err)
+	defer loggingResp.Body.Close()
+	assert.Equal(t, http.StatusOK, loggingResp.StatusCode,
+		"logging namespace %s should be registered after RegisterLoggingNamespaceWithRetry", loggingPrefix)
 }

--- a/launcher_utils/register_namespace_test.go
+++ b/launcher_utils/register_namespace_test.go
@@ -29,6 +29,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -330,4 +331,24 @@ func TestMultiKeysRegistration(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, isRegistered)
 	assert.Equal(t, svr.URL+"/api/v1.0/registry", registerURL)
+}
+func TestRegisterLoggingNamespaceWithRetry_NoopWhenDisabled(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	t.Cleanup(func() {
+		server_utils.ResetTestState()
+	})
+
+	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	defer func() {
+		cancel()
+		require.NoError(t, egrp.Wait())
+	}()
+
+	// Logging.LogExports.Enabled is false by default.
+	// The function must return nil immediately without touching the network or
+	// adding any goroutines to the errgroup.
+	goroutinesBefore := runtime.NumGoroutine()
+	err := RegisterLoggingNamespaceWithRetry(ctx, egrp)
+	require.NoError(t, err, "RegisterLoggingNamespaceWithRetry should be a no-op when LogExports.Enabled is false")
+	require.Equal(t, goroutinesBefore, runtime.NumGoroutine(), "no goroutines should have been launched")
 }

--- a/launchers/origin_serve.go
+++ b/launchers/origin_serve.go
@@ -287,7 +287,9 @@ func OriginServeFinish(ctx context.Context, egrp *errgroup.Group, engine *gin.En
 		return err
 	}
 	log.Debug("Origin is registered")
-	// Register the logging namespace after the origin prefix, so that Server.ID is available.
+	// Register the logging namespace after the origin prefix: the registry's
+	// key-match gate requires the origin to be registered first so it can verify
+	// the logging namespace is submitted with the origin's registered key.
 	if err := launcher_utils.RegisterLoggingNamespaceWithRetry(ctx, egrp); err != nil {
 		return err
 	}

--- a/launchers/origin_serve.go
+++ b/launchers/origin_serve.go
@@ -287,6 +287,10 @@ func OriginServeFinish(ctx context.Context, egrp *errgroup.Group, engine *gin.En
 		return err
 	}
 	log.Debug("Origin is registered")
+	// Register the logging namespace after the origin prefix, so that Server.ID is available.
+	if err := launcher_utils.RegisterLoggingNamespaceWithRetry(ctx, egrp); err != nil {
+		return err
+	}
 	for _, export := range originExports {
 		if err := launcher_utils.RegisterNamespaceWithRetry(ctx, egrp, export.FederationPrefix); err != nil {
 			return err

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -264,9 +264,9 @@ var runtimeConfigurableMap = map[string]bool{
 	"Logging.Client.DisableProgressBars": false,
 	"Logging.Client.ProgressInterval": false,
 	"Logging.DisableProgressBars": false,
+	"Logging.EnableLogExports": false,
 	"Logging.Level": true,
 	"Logging.LogExports.AllowFederationAdmin": false,
-	"Logging.LogExports.Enabled": false,
 	"Logging.LogLocation": false,
 	"Logging.Origin.Cms": true,
 	"Logging.Origin.Http": true,
@@ -989,8 +989,8 @@ var boolAccessors = map[string]func(*Config) bool{
 	"Issuer.UserStripDomain": func(c *Config) bool { return c.Issuer.UserStripDomain },
 	"Logging.Client.DisableProgressBars": func(c *Config) bool { return c.Logging.Client.DisableProgressBars },
 	"Logging.DisableProgressBars": func(c *Config) bool { return c.Logging.DisableProgressBars },
+	"Logging.EnableLogExports": func(c *Config) bool { return c.Logging.EnableLogExports },
 	"Logging.LogExports.AllowFederationAdmin": func(c *Config) bool { return c.Logging.LogExports.AllowFederationAdmin },
-	"Logging.LogExports.Enabled": func(c *Config) bool { return c.Logging.LogExports.Enabled },
 	"Lotman.EnableAPI": func(c *Config) bool { return c.Lotman.EnableAPI },
 	"Monitoring.EnablePrometheus": func(c *Config) bool { return c.Monitoring.EnablePrometheus },
 	"Monitoring.MetricAuthorization": func(c *Config) bool { return c.Monitoring.MetricAuthorization },
@@ -1399,9 +1399,9 @@ var allParameterNames = []string{
 	"Logging.Client.DisableProgressBars",
 	"Logging.Client.ProgressInterval",
 	"Logging.DisableProgressBars",
+	"Logging.EnableLogExports",
 	"Logging.Level",
 	"Logging.LogExports.AllowFederationAdmin",
-	"Logging.LogExports.Enabled",
 	"Logging.LogLocation",
 	"Logging.Origin.Cms",
 	"Logging.Origin.Http",
@@ -1976,8 +1976,8 @@ var (
 	Issuer_UserStripDomain = BoolParam{"Issuer.UserStripDomain"}
 	Logging_Client_DisableProgressBars = BoolParam{"Logging.Client.DisableProgressBars"}
 	Logging_DisableProgressBars = BoolParam{"Logging.DisableProgressBars"}
+	Logging_EnableLogExports = BoolParam{"Logging.EnableLogExports"}
 	Logging_LogExports_AllowFederationAdmin = BoolParam{"Logging.LogExports.AllowFederationAdmin"}
-	Logging_LogExports_Enabled = BoolParam{"Logging.LogExports.Enabled"}
 	Lotman_EnableAPI = BoolParam{"Lotman.EnableAPI"}
 	Monitoring_EnablePrometheus = BoolParam{"Monitoring.EnablePrometheus"}
 	Monitoring_MetricAuthorization = BoolParam{"Monitoring.MetricAuthorization"}
@@ -2430,8 +2430,8 @@ func init() {
 		"Issuer.UserStripDomain": Issuer_UserStripDomain,
 		"Logging.Client.DisableProgressBars": Logging_Client_DisableProgressBars,
 		"Logging.DisableProgressBars": Logging_DisableProgressBars,
+		"Logging.EnableLogExports": Logging_EnableLogExports,
 		"Logging.LogExports.AllowFederationAdmin": Logging_LogExports_AllowFederationAdmin,
-		"Logging.LogExports.Enabled": Logging_LogExports_Enabled,
 		"Lotman.EnableAPI": Lotman_EnableAPI,
 		"Monitoring.EnablePrometheus": Monitoring_EnablePrometheus,
 		"Monitoring.MetricAuthorization": Monitoring_MetricAuthorization,

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -213,10 +213,10 @@ type Config struct {
 			ProgressInterval time.Duration `mapstructure:"progressinterval" yaml:"ProgressInterval"`
 		} `mapstructure:"client" yaml:"Client"`
 		DisableProgressBars bool `mapstructure:"disableprogressbars" yaml:"DisableProgressBars"`
+		EnableLogExports bool `mapstructure:"enablelogexports" yaml:"EnableLogExports"`
 		Level string `mapstructure:"level" yaml:"Level"`
 		LogExports struct {
 			AllowFederationAdmin bool `mapstructure:"allowfederationadmin" yaml:"AllowFederationAdmin"`
-			Enabled bool `mapstructure:"enabled" yaml:"Enabled"`
 		} `mapstructure:"logexports" yaml:"LogExports"`
 		LogLocation string `mapstructure:"loglocation" yaml:"LogLocation"`
 		Origin struct {
@@ -704,10 +704,10 @@ type configWithType struct {
 			ProgressInterval struct { Type string; Value time.Duration }
 		}
 		DisableProgressBars struct { Type string; Value bool }
+		EnableLogExports struct { Type string; Value bool }
 		Level struct { Type string; Value string }
 		LogExports struct {
 			AllowFederationAdmin struct { Type string; Value bool }
-			Enabled struct { Type string; Value bool }
 		}
 		LogLocation struct { Type string; Value string }
 		Origin struct {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -407,6 +407,33 @@ func keySignChallengeCommit(ctx *gin.Context, data *registrationData) (bool, map
 		return false, nil, sysErr
 	}
 
+	// For logging namespace registrations, require the registrant to present the
+	// same public key as the origin already registered under that sitename.  This
+	// prevents namespace squatting: a server that knows a sitename cannot register
+	// /pelican/logging/{sitename} with a different key and ride the auto-approval path.
+	if sitename, ok := server_structs.LoggingNamespaceSitename(data.Prefix); ok {
+		serverReg, err := getServerByName(sitename)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return false, nil, permissionDeniedError{Message: fmt.Sprintf(
+					"cannot register logging namespace: no origin with name %q is registered", sitename)}
+			}
+			return false, nil, errors.Wrapf(err, "failed to look up server %q for logging namespace gate", sitename)
+		}
+		if serverReg == nil || len(serverReg.Registration) == 0 {
+			return false, nil, permissionDeniedError{Message: fmt.Sprintf(
+				"cannot register logging namespace: no origin with name %q is registered", sitename)}
+		}
+		originKey, err := validateJwks(serverReg.Registration[0].Pubkey)
+		if err != nil {
+			return false, nil, errors.Wrapf(err, "failed to parse registered pubkey for server %q", sitename)
+		}
+		if !jwk.Equal(key, originKey) {
+			return false, nil, permissionDeniedError{Message: fmt.Sprintf(
+				"cannot register logging namespace: public key does not match the registered key for server %q", sitename)}
+		}
+	}
+
 	var ns server_structs.Registration
 	ns.Prefix = data.Prefix
 
@@ -483,7 +510,7 @@ func keySignChallengeCommit(ctx *gin.Context, data *registrationData) (bool, map
 
 	// Tag logging namespace registrations so the auto-approval logic and API filters
 	// can identify them without parsing the prefix string.
-	if serverID, ok := server_structs.LoggingNamespaceServerID(data.Prefix); ok {
+	if sitename, ok := server_structs.LoggingNamespaceSitename(data.Prefix); ok {
 		if ns.CustomFields == nil {
 			ns.CustomFields = make(map[string]interface{})
 		}
@@ -491,7 +518,7 @@ func keySignChallengeCommit(ctx *gin.Context, data *registrationData) (bool, map
 
 		// Auto-approve when the associated origin is already approved and auto-registration is enabled.
 		if param.Registry_EnableAutoLoggingRegistration.GetBool() {
-			applyLoggingNamespaceAutoApproval(serverID, &ns)
+			applyLoggingNamespaceAutoApproval(sitename, &ns)
 		}
 	}
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -38,6 +38,7 @@ import (
 	"path"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
@@ -452,6 +453,28 @@ func keySignChallengeCommit(ctx *gin.Context, data *registrationData) (bool, map
 			ns.CustomFields = make(map[string]interface{})
 		}
 		ns.CustomFields[server_structs.RegistrationTypeKey] = server_structs.LoggingRegistrationType
+
+		// Auto-approve logging namespaces when the associated origin is already approved and
+		// auto-registration is enabled. The server ID is the suffix after the logging prefix.
+		if param.Registry_EnableAutoLoggingRegistration.GetBool() {
+			serverID := strings.TrimPrefix(data.Prefix, server_structs.LoggingNamespacePrefix+"/")
+			if serverID != "" {
+				serverReg, err := getServerByID(serverID)
+				if err != nil {
+					log.Errorf("Failed to look up server by ID %q for logging namespace auto-approval: %v", serverID, err)
+				} else if serverReg != nil {
+					for _, reg := range serverReg.Registration {
+						if reg.AdminMetadata.Status == server_structs.RegApproved {
+							ns.AdminMetadata.Status = server_structs.RegApproved
+							ns.AdminMetadata.ApproverID = "system"
+							ns.AdminMetadata.ApprovedAt = time.Now()
+							log.Debugf("Auto-approving logging namespace %s because origin server %s is approved", data.Prefix, serverID)
+							break
+						}
+					}
+				}
+			}
+		}
 	}
 
 	err = AddRegistration(&ns)

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -267,38 +267,122 @@ func keySignChallengeInit(data *registrationData) (map[string]interface{}, error
 }
 
 // applyLoggingNamespaceAutoApproval auto-approves ns if the origin server
-// identified by serverID already has an approved registration.  It mutates
-// ns.AdminMetadata in place on success.  The serverID must be a non-empty
-// 7-character ID from the servers table (the suffix after LoggingNamespacePrefix).
-func applyLoggingNamespaceAutoApproval(serverID string, ns *server_structs.Registration) {
-	// serverID should never be empty here: the only caller extracts it via
-	// LoggingNamespaceServerID, which rejects empty IDs and returns ok=false.
-	// An empty ID reaching this point indicates a programming error.
-	if serverID == "" {
-		log.Errorf("applyLoggingNamespaceAutoApproval called with empty serverID; this is a bug")
+// whose sitename matches the logging namespace prefix already has an approved
+// registration.  It mutates ns.AdminMetadata in place on success.
+// sitename is the Xrootd.Sitename segment extracted from the logging namespace prefix
+// (e.g. "my-origin" from "/pelican/logging/my-origin").
+func applyLoggingNamespaceAutoApproval(sitename string, ns *server_structs.Registration) {
+	// sitename should never be empty here: the only caller extracts it via
+	// LoggingNamespaceSitename, which rejects empty values and returns ok=false.
+	if sitename == "" {
+		log.Errorf("applyLoggingNamespaceAutoApproval called with empty sitename; this is a bug")
 		return
 	}
-	serverReg, err := getServerByID(serverID)
+	serverReg, err := getServerByName(sitename)
 	if err != nil {
-		log.Errorf("Failed to look up server by ID %q for logging namespace auto-approval: %v", serverID, err)
+		log.Errorf("Failed to look up server by name %q for logging namespace auto-approval: %v", sitename, err)
 		return
 	}
-	// getServerByID returns &ServerRegistration{} (ID == "") when the server is
-	// not found (ErrRecordNotFound), and a non-nil populated struct on success.
-	if serverReg.ID == "" {
-		log.Warningf("Server ID %q not found in registry; skipping auto-approval of logging namespace", serverID)
+	if serverReg == nil || serverReg.ID == "" {
+		log.Warningf("No server found with name %q; skipping auto-approval of logging namespace", sitename)
 		return
 	}
 	for _, reg := range serverReg.Registration {
 		if reg.AdminMetadata.Status == server_structs.RegApproved {
+			// Defense-in-depth: verify the incoming key matches the origin's registered
+			// key before auto-approving.  keySignChallengeCommit enforces this too, but
+			// an explicit check here ensures auto-approval is never granted to a
+			// mismatched key even if the call path changes in the future.
+			incomingKey, err := validateJwks(ns.Pubkey)
+			if err != nil {
+				log.Errorf("applyLoggingNamespaceAutoApproval: invalid pubkey on logging namespace registration for %s: %v", sitename, err)
+				return
+			}
+			originKey, err := validateJwks(reg.Pubkey)
+			if err != nil || !jwk.Equal(incomingKey, originKey) {
+				log.Warningf("Skipping logging namespace auto-approval: public key does not match registered key for server %s", sitename)
+				return
+			}
 			ns.AdminMetadata.Status = server_structs.RegApproved
 			ns.AdminMetadata.ApproverID = "system"
 			ns.AdminMetadata.ApprovedAt = time.Now()
-			log.Debugf("Auto-approving logging namespace because origin server %s is approved", serverID)
+			log.Debugf("Auto-approving logging namespace because server %s is approved", sitename)
 			return
 		}
 	}
-	log.Debugf("Skipping logging namespace auto-approval: origin server %s has no approved registration", serverID)
+	log.Debugf("Skipping logging namespace auto-approval: server %s has no approved registration", sitename)
+}
+
+// cascadeApproveLoggingNamespace checks whether an origin with the given sitename
+// has a corresponding logging namespace that is still pending, and if so,
+// auto-approves it.  It is called by the approval flow after an admin approves an
+// origin's primary registration, so that the logging namespace does not get stuck
+// in "pending" when the origin was already pending at the time of logging-namespace
+// registration (the common case for a freshly started origin).
+//
+// The function is best-effort: all failures are logged but not surfaced to the caller.
+func cascadeApproveLoggingNamespace(sitename string) {
+	loggingPrefix := server_structs.LoggingNamespaceForServer(sitename)
+	loggingReg, err := getRegistrationByPrefix(loggingPrefix)
+	if err != nil {
+		// Either the origin has no logging namespace yet, or a DB error.  Either
+		// way there is nothing to cascade-approve.
+		log.Debugf("cascadeApproveLoggingNamespace: no logging namespace found for %s (%v)", sitename, err)
+		return
+	}
+	if loggingReg.AdminMetadata.Status != server_structs.RegPending {
+		return
+	}
+
+	// Defense-in-depth: re-verify the key before cascade-approving using the
+	// server's current registered key (looked up by sitename).
+	serverReg, err := getServerByName(sitename)
+	if err != nil || serverReg == nil || len(serverReg.Registration) == 0 {
+		log.Errorf("cascadeApproveLoggingNamespace: cannot look up server %s: %v", sitename, err)
+		return
+	}
+	loggingKey, err := validateJwks(loggingReg.Pubkey)
+	if err != nil {
+		log.Errorf("cascadeApproveLoggingNamespace: invalid pubkey on logging namespace for %s: %v", sitename, err)
+		return
+	}
+	originKey, err := validateJwks(serverReg.Registration[0].Pubkey)
+	if err != nil || !jwk.Equal(loggingKey, originKey) {
+		log.Warningf("cascadeApproveLoggingNamespace: public key mismatch for logging namespace %s; skipping auto-approval", loggingPrefix)
+		return
+	}
+
+	if err := updateRegistrationStatusById(loggingReg.ID, server_structs.RegApproved, "system"); err != nil {
+		log.Errorf("cascadeApproveLoggingNamespace: failed to approve logging namespace %s: %v", loggingPrefix, err)
+		return
+	}
+	log.Debugf("Auto-approved logging namespace %s after server %s was approved", loggingPrefix, sitename)
+}
+
+// cascadeUpdateLoggingNamespaceKey updates the pubkey of the logging namespace
+// associated with the given sitename to match newPubkey.  It is called when an
+// admin edits an origin's registration and changes its public key, so that the
+// hidden logging namespace stays in sync and the origin can continue to
+// authenticate against it after a key rotation.
+//
+// The function is best-effort: if no logging namespace exists it is a no-op.
+func cascadeUpdateLoggingNamespaceKey(sitename string, newPubkey string) {
+	loggingPrefix := server_structs.LoggingNamespaceForServer(sitename)
+	loggingReg, err := getRegistrationByPrefix(loggingPrefix)
+	if err != nil {
+		// No logging namespace registered yet — nothing to do.
+		log.Debugf("cascadeUpdateLoggingNamespaceKey: no logging namespace found for %s (%v)", sitename, err)
+		return
+	}
+	if loggingReg.Pubkey == newPubkey {
+		return // Already in sync.
+	}
+	loggingReg.Pubkey = newPubkey
+	if err := updateRegistration(loggingReg); err != nil {
+		log.Errorf("cascadeUpdateLoggingNamespaceKey: failed to update pubkey for logging namespace %s: %v", loggingPrefix, err)
+		return
+	}
+	log.Debugf("Updated pubkey for logging namespace %s to match server %s", loggingPrefix, sitename)
 }
 
 // Add namespace prefix if the request passed client and server verification for nonce.

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -266,6 +266,41 @@ func keySignChallengeInit(data *registrationData) (map[string]interface{}, error
 	return res, nil
 }
 
+// applyLoggingNamespaceAutoApproval auto-approves ns if the origin server
+// identified by serverID already has an approved registration.  It mutates
+// ns.AdminMetadata in place on success.  The serverID must be a non-empty
+// 7-character ID from the servers table (the suffix after LoggingNamespacePrefix).
+func applyLoggingNamespaceAutoApproval(serverID string, ns *server_structs.Registration) {
+	// serverID should never be empty here: the only caller extracts it via
+	// LoggingNamespaceServerID, which rejects empty IDs and returns ok=false.
+	// An empty ID reaching this point indicates a programming error.
+	if serverID == "" {
+		log.Errorf("applyLoggingNamespaceAutoApproval called with empty serverID; this is a bug")
+		return
+	}
+	serverReg, err := getServerByID(serverID)
+	if err != nil {
+		log.Errorf("Failed to look up server by ID %q for logging namespace auto-approval: %v", serverID, err)
+		return
+	}
+	// getServerByID returns &ServerRegistration{} (ID == "") when the server is
+	// not found (ErrRecordNotFound), and a non-nil populated struct on success.
+	if serverReg.ID == "" {
+		log.Warningf("Server ID %q not found in registry; skipping auto-approval of logging namespace", serverID)
+		return
+	}
+	for _, reg := range serverReg.Registration {
+		if reg.AdminMetadata.Status == server_structs.RegApproved {
+			ns.AdminMetadata.Status = server_structs.RegApproved
+			ns.AdminMetadata.ApproverID = "system"
+			ns.AdminMetadata.ApprovedAt = time.Now()
+			log.Debugf("Auto-approving logging namespace because origin server %s is approved", serverID)
+			return
+		}
+	}
+	log.Debugf("Skipping logging namespace auto-approval: origin server %s has no approved registration", serverID)
+}
+
 // Add namespace prefix if the request passed client and server verification for nonce.
 // It returns whether registration is created, the response data, and an error if any
 func keySignChallengeCommit(ctx *gin.Context, data *registrationData) (bool, map[string]interface{}, error) {
@@ -448,32 +483,15 @@ func keySignChallengeCommit(ctx *gin.Context, data *registrationData) (bool, map
 
 	// Tag logging namespace registrations so the auto-approval logic and API filters
 	// can identify them without parsing the prefix string.
-	if strings.HasPrefix(data.Prefix, server_structs.LoggingNamespacePrefix+"/") {
+	if serverID, ok := server_structs.LoggingNamespaceServerID(data.Prefix); ok {
 		if ns.CustomFields == nil {
 			ns.CustomFields = make(map[string]interface{})
 		}
 		ns.CustomFields[server_structs.RegistrationTypeKey] = server_structs.LoggingRegistrationType
 
-		// Auto-approve logging namespaces when the associated origin is already approved and
-		// auto-registration is enabled. The server ID is the suffix after the logging prefix.
+		// Auto-approve when the associated origin is already approved and auto-registration is enabled.
 		if param.Registry_EnableAutoLoggingRegistration.GetBool() {
-			serverID := strings.TrimPrefix(data.Prefix, server_structs.LoggingNamespacePrefix+"/")
-			if serverID != "" {
-				serverReg, err := getServerByID(serverID)
-				if err != nil {
-					log.Errorf("Failed to look up server by ID %q for logging namespace auto-approval: %v", serverID, err)
-				} else if serverReg != nil {
-					for _, reg := range serverReg.Registration {
-						if reg.AdminMetadata.Status == server_structs.RegApproved {
-							ns.AdminMetadata.Status = server_structs.RegApproved
-							ns.AdminMetadata.ApproverID = "system"
-							ns.AdminMetadata.ApprovedAt = time.Now()
-							log.Debugf("Auto-approving logging namespace %s because origin server %s is approved", data.Prefix, serverID)
-							break
-						}
-					}
-				}
-			}
+			applyLoggingNamespaceAutoApproval(serverID, &ns)
 		}
 	}
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -445,6 +445,15 @@ func keySignChallengeCommit(ctx *gin.Context, data *registrationData) (bool, map
 		ns.CustomFields["server_id"] = data.ServerID // Pass the server ID to the CustomFields map, to fit in the registration workflow
 	}
 
+	// Tag logging namespace registrations so the auto-approval logic and API filters
+	// can identify them without parsing the prefix string.
+	if strings.HasPrefix(data.Prefix, server_structs.LoggingNamespacePrefix+"/") {
+		if ns.CustomFields == nil {
+			ns.CustomFields = make(map[string]interface{})
+		}
+		ns.CustomFields[server_structs.RegistrationTypeKey] = server_structs.LoggingRegistrationType
+	}
+
 	err = AddRegistration(&ns)
 	if err != nil {
 		// Check if it's a server ID conflict error

--- a/registry/registry_db_server_test.go
+++ b/registry/registry_db_server_test.go
@@ -19,10 +19,15 @@
 package registry
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -810,74 +815,377 @@ func TestApplyLoggingNamespaceAutoApproval(t *testing.T) {
 	setupMockRegistryDB(t)
 	defer teardownMockRegistryDB(t)
 
+	// genPubkeyJSON returns a JSON-encoded JWK set containing one freshly
+	// generated ECDSA P-256 public key.
+	genPubkeyJSON := func(t *testing.T) (string, jwk.Key) {
+		t.Helper()
+		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		pub, err := jwk.FromRaw(priv.PublicKey)
+		require.NoError(t, err)
+		require.NoError(t, jwk.AssignKeyID(pub))
+		set := jwk.NewSet()
+		require.NoError(t, set.AddKey(pub))
+		data, err := json.Marshal(set)
+		require.NoError(t, err)
+		return string(data), pub
+	}
+
 	t.Run("ApprovedOriginAutoApprovesLoggingNS", func(t *testing.T) {
+		pubkeyJSON, _ := genPubkeyJSON(t)
+		const sitename = "ApprovedAutoOrigin"
 		originNs := server_structs.Registration{
 			Prefix: "/origins/approved-auto-test.edu",
-			Pubkey: "pubkey-approved",
+			Pubkey: pubkeyJSON,
 			AdminMetadata: server_structs.AdminMetadata{
-				SiteName: "ApprovedAutoOrigin",
+				SiteName: sitename,
 				Status:   server_structs.RegApproved,
 			},
 		}
 		require.NoError(t, AddRegistration(&originNs))
 
-		server, err := getServerByRegistrationID(originNs.ID)
-		require.NoError(t, err)
-		require.NotEmpty(t, server.ID, "origin registration should have created a server record")
-
 		loggingNs := server_structs.Registration{
-			Prefix: server_structs.LoggingNamespaceForServer(server.ID),
+			Prefix: server_structs.LoggingNamespaceForServer(sitename),
+			Pubkey: pubkeyJSON,
 			AdminMetadata: server_structs.AdminMetadata{
-				SiteName: "ApprovedAutoOrigin",
+				SiteName: sitename,
 				Status:   server_structs.RegPending,
 			},
 		}
-		applyLoggingNamespaceAutoApproval(server.ID, &loggingNs)
+		applyLoggingNamespaceAutoApproval(sitename, &loggingNs)
 
 		assert.Equal(t, server_structs.RegApproved, loggingNs.AdminMetadata.Status)
 		assert.Equal(t, "system", loggingNs.AdminMetadata.ApproverID)
 		assert.False(t, loggingNs.AdminMetadata.ApprovedAt.IsZero())
 	})
 
+	t.Run("WrongKeyDoesNotAutoApprove", func(t *testing.T) {
+		// Register origin with key A; attempt auto-approval with key B.
+		// The approval should be denied even though the origin is approved.
+		pubkeyJSONA, _ := genPubkeyJSON(t)
+		pubkeyJSONB, _ := genPubkeyJSON(t)
+		const sitename = "WrongKeyOrigin"
+		originNs := server_structs.Registration{
+			Prefix: "/origins/wrong-key-test.edu",
+			Pubkey: pubkeyJSONA,
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName: sitename,
+				Status:   server_structs.RegApproved,
+			},
+		}
+		require.NoError(t, AddRegistration(&originNs))
+
+		loggingNs := server_structs.Registration{
+			Prefix: server_structs.LoggingNamespaceForServer(sitename),
+			Pubkey: pubkeyJSONB, // different key from origin
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName: sitename,
+				Status:   server_structs.RegPending,
+			},
+		}
+		applyLoggingNamespaceAutoApproval(sitename, &loggingNs)
+
+		assert.Equal(t, server_structs.RegPending, loggingNs.AdminMetadata.Status,
+			"mismatched key should not trigger auto-approval even when origin is approved")
+	})
+
 	t.Run("PendingOriginDoesNotAutoApproveLoggingNS", func(t *testing.T) {
+		pubkeyJSON, _ := genPubkeyJSON(t)
+		const sitename = "PendingAutoOrigin"
 		originNs := server_structs.Registration{
 			Prefix: "/origins/pending-auto-test.edu",
-			Pubkey: "pubkey-pending",
+			Pubkey: pubkeyJSON,
 			AdminMetadata: server_structs.AdminMetadata{
-				SiteName: "PendingAutoOrigin",
+				SiteName: sitename,
 				Status:   server_structs.RegPending,
 			},
 		}
 		require.NoError(t, AddRegistration(&originNs))
 
-		server, err := getServerByRegistrationID(originNs.ID)
-		require.NoError(t, err)
-		require.NotEmpty(t, server.ID)
-
 		loggingNs := server_structs.Registration{
-			Prefix: server_structs.LoggingNamespaceForServer(server.ID),
+			Prefix: server_structs.LoggingNamespaceForServer(sitename),
+			Pubkey: pubkeyJSON,
 			AdminMetadata: server_structs.AdminMetadata{
-				SiteName: "PendingAutoOrigin",
+				SiteName: sitename,
 				Status:   server_structs.RegPending,
 			},
 		}
-		applyLoggingNamespaceAutoApproval(server.ID, &loggingNs)
+		applyLoggingNamespaceAutoApproval(sitename, &loggingNs)
 
 		assert.Equal(t, server_structs.RegPending, loggingNs.AdminMetadata.Status,
 			"pending origin should not trigger auto-approval")
 	})
 
-	t.Run("UnknownServerIDDoesNotAutoApprove", func(t *testing.T) {
+	t.Run("UnknownSitenameDoesNotAutoApprove", func(t *testing.T) {
+		pubkeyJSON, _ := genPubkeyJSON(t)
+		const sitename = "GhostOrigin"
 		loggingNs := server_structs.Registration{
-			Prefix: server_structs.LoggingNamespaceForServer("notfound"),
+			Prefix: server_structs.LoggingNamespaceForServer(sitename),
+			Pubkey: pubkeyJSON,
 			AdminMetadata: server_structs.AdminMetadata{
-				SiteName: "Ghost",
+				SiteName: sitename,
 				Status:   server_structs.RegPending,
 			},
 		}
-		applyLoggingNamespaceAutoApproval("notfound", &loggingNs)
+		applyLoggingNamespaceAutoApproval(sitename, &loggingNs)
 
 		assert.Equal(t, server_structs.RegPending, loggingNs.AdminMetadata.Status,
-			"unknown server ID should not trigger auto-approval")
+			"unknown sitename should not trigger auto-approval")
+	})
+}
+
+// TestCascadeApproveLoggingNamespace verifies that when an admin approves an
+// origin's primary registration, a corresponding pending logging namespace is
+// automatically approved by cascadeApproveLoggingNamespace.
+func TestCascadeApproveLoggingNamespace(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	setupMockRegistryDB(t)
+	defer teardownMockRegistryDB(t)
+
+	genPubkeyJSON := func(t *testing.T) string {
+		t.Helper()
+		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		pub, err := jwk.FromRaw(priv.PublicKey)
+		require.NoError(t, err)
+		require.NoError(t, jwk.AssignKeyID(pub))
+		set := jwk.NewSet()
+		require.NoError(t, set.AddKey(pub))
+		data, err := json.Marshal(set)
+		require.NoError(t, err)
+		return string(data)
+	}
+
+	t.Run("ApprovesLoggingNSAfterOriginApproved", func(t *testing.T) {
+		pubkeyJSON := genPubkeyJSON(t)
+		const sitename = "cascade-test.edu"
+
+		// Register origin as pending (simulating startup before admin approval).
+		originNs := server_structs.Registration{
+			Prefix: "/origins/cascade-origin.edu",
+			Pubkey: pubkeyJSON,
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName: sitename,
+				Status:   server_structs.RegPending,
+			},
+		}
+		require.NoError(t, AddRegistration(&originNs))
+
+		// Register logging namespace — also pending because origin wasn't approved yet.
+		loggingNs := server_structs.Registration{
+			Prefix: server_structs.LoggingNamespaceForServer(sitename),
+			Pubkey: pubkeyJSON,
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName: sitename,
+				Status:   server_structs.RegPending,
+			},
+		}
+		require.NoError(t, AddRegistration(&loggingNs))
+
+		// Simulate admin approving the origin's primary registration.
+		require.NoError(t, updateRegistrationStatusById(originNs.ID, server_structs.RegApproved, "admin"))
+
+		// Now trigger the cascade (in production this is called by updateNamespaceStatus).
+		cascadeApproveLoggingNamespace(sitename)
+
+		// The logging namespace should now be approved.
+		updated, err := getRegistrationByPrefix(loggingNs.Prefix)
+		require.NoError(t, err)
+		assert.Equal(t, server_structs.RegApproved, updated.AdminMetadata.Status)
+		assert.Equal(t, "system", updated.AdminMetadata.ApproverID)
+		assert.False(t, updated.AdminMetadata.ApprovedAt.IsZero())
+	})
+
+	t.Run("DoesNotOverwriteAlreadyApproved", func(t *testing.T) {
+		pubkeyJSON := genPubkeyJSON(t)
+		const sitename = "already-approved-origin.edu"
+
+		originNs := server_structs.Registration{
+			Prefix: "/origins/already-approved-host.edu",
+			Pubkey: pubkeyJSON,
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName: sitename,
+				Status:   server_structs.RegApproved,
+			},
+		}
+		require.NoError(t, AddRegistration(&originNs))
+
+		approvedAt := time.Now().Add(-time.Hour)
+		loggingNs := server_structs.Registration{
+			Prefix: server_structs.LoggingNamespaceForServer(sitename),
+			Pubkey: pubkeyJSON,
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName:   sitename,
+				Status:     server_structs.RegApproved,
+				ApproverID: "human-admin",
+				ApprovedAt: approvedAt,
+			},
+		}
+		require.NoError(t, AddRegistration(&loggingNs))
+
+		// Cascade should be a no-op because logging NS is not pending.
+		cascadeApproveLoggingNamespace(sitename)
+
+		updated, err := getRegistrationByPrefix(loggingNs.Prefix)
+		require.NoError(t, err)
+		assert.Equal(t, "human-admin", updated.AdminMetadata.ApproverID,
+			"already-approved logging namespace should not be overwritten by cascade")
+	})
+
+	t.Run("SkipsWhenNoLoggingNS", func(t *testing.T) {
+		pubkeyJSON := genPubkeyJSON(t)
+		const sitename = "no-logging-ns-origin.edu"
+
+		originNs := server_structs.Registration{
+			Prefix: "/origins/no-logging-ns-host.edu",
+			Pubkey: pubkeyJSON,
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName: sitename,
+				Status:   server_structs.RegApproved,
+			},
+		}
+		require.NoError(t, AddRegistration(&originNs))
+
+		// Should not panic or error when no logging namespace exists.
+		assert.NotPanics(t, func() { cascadeApproveLoggingNamespace(sitename) })
+	})
+
+	t.Run("SkipsKeyMismatch", func(t *testing.T) {
+		pubkeyJSONA := genPubkeyJSON(t)
+		pubkeyJSONB := genPubkeyJSON(t)
+		const sitename = "key-mismatch-origin.edu"
+
+		originNs := server_structs.Registration{
+			Prefix: "/origins/key-mismatch-host.edu",
+			Pubkey: pubkeyJSONA,
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName: sitename,
+				Status:   server_structs.RegApproved,
+			},
+		}
+		require.NoError(t, AddRegistration(&originNs))
+
+		loggingNs := server_structs.Registration{
+			Prefix: server_structs.LoggingNamespaceForServer(sitename),
+			Pubkey: pubkeyJSONB, // different key
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName: sitename,
+				Status:   server_structs.RegPending,
+			},
+		}
+		require.NoError(t, AddRegistration(&loggingNs))
+
+		cascadeApproveLoggingNamespace(sitename)
+
+		updated, err := getRegistrationByPrefix(loggingNs.Prefix)
+		require.NoError(t, err)
+		assert.Equal(t, server_structs.RegPending, updated.AdminMetadata.Status,
+			"key mismatch should prevent cascade approval")
+	})
+}
+
+// TestCascadeUpdateLoggingNamespaceKey verifies that when an admin edits an
+// origin's public key, the associated logging namespace's pubkey is updated
+// in sync by cascadeUpdateLoggingNamespaceKey.
+func TestCascadeUpdateLoggingNamespaceKey(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	setupMockRegistryDB(t)
+	defer teardownMockRegistryDB(t)
+
+	genPubkeyJSON := func(t *testing.T) string {
+		t.Helper()
+		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		pub, err := jwk.FromRaw(priv.PublicKey)
+		require.NoError(t, err)
+		require.NoError(t, jwk.AssignKeyID(pub))
+		set := jwk.NewSet()
+		require.NoError(t, set.AddKey(pub))
+		data, err := json.Marshal(set)
+		require.NoError(t, err)
+		return string(data)
+	}
+
+	t.Run("UpdatesLoggingNSKeyWhenOriginKeyChanges", func(t *testing.T) {
+		oldKey := genPubkeyJSON(t)
+		newKey := genPubkeyJSON(t)
+		const sitename = "key-update-origin.edu"
+
+		originNs := server_structs.Registration{
+			Prefix: "/origins/key-update-host.edu",
+			Pubkey: oldKey,
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName: sitename,
+				Status:   server_structs.RegApproved,
+			},
+		}
+		require.NoError(t, AddRegistration(&originNs))
+
+		loggingNs := server_structs.Registration{
+			Prefix: server_structs.LoggingNamespaceForServer(sitename),
+			Pubkey: oldKey,
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName: sitename,
+				Status:   server_structs.RegApproved,
+			},
+		}
+		require.NoError(t, AddRegistration(&loggingNs))
+
+		// Cascade the new key to the logging namespace.
+		cascadeUpdateLoggingNamespaceKey(sitename, newKey)
+
+		updated, err := getRegistrationByPrefix(loggingNs.Prefix)
+		require.NoError(t, err)
+		assert.Equal(t, newKey, updated.Pubkey, "logging namespace pubkey should be updated to match new origin key")
+	})
+
+	t.Run("NoopWhenAlreadyInSync", func(t *testing.T) {
+		key := genPubkeyJSON(t)
+		const sitename = "in-sync-origin.edu"
+
+		originNs := server_structs.Registration{
+			Prefix: "/origins/in-sync-host.edu",
+			Pubkey: key,
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName: sitename,
+				Status:   server_structs.RegApproved,
+			},
+		}
+		require.NoError(t, AddRegistration(&originNs))
+
+		loggingNs := server_structs.Registration{
+			Prefix: server_structs.LoggingNamespaceForServer(sitename),
+			Pubkey: key,
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName: sitename,
+				Status:   server_structs.RegApproved,
+			},
+		}
+		require.NoError(t, AddRegistration(&loggingNs))
+
+		// Should be a no-op — key is already the same.
+		assert.NotPanics(t, func() { cascadeUpdateLoggingNamespaceKey(sitename, key) })
+
+		updated, err := getRegistrationByPrefix(loggingNs.Prefix)
+		require.NoError(t, err)
+		assert.Equal(t, key, updated.Pubkey)
+	})
+
+	t.Run("NoopWhenNoLoggingNS", func(t *testing.T) {
+		key := genPubkeyJSON(t)
+		const sitename = "no-logging-ns-key-update.edu"
+
+		originNs := server_structs.Registration{
+			Prefix: "/origins/no-logging-key-host.edu",
+			Pubkey: key,
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName: sitename,
+				Status:   server_structs.RegApproved,
+			},
+		}
+		require.NoError(t, AddRegistration(&originNs))
+
+		// Should not panic or error when no logging namespace exists.
+		assert.NotPanics(t, func() { cascadeUpdateLoggingNamespaceKey(sitename, genPubkeyJSON(t)) })
 	})
 }

--- a/registry/registry_db_server_test.go
+++ b/registry/registry_db_server_test.go
@@ -801,3 +801,72 @@ func TestDeleteRegistrationByID_RemovesDowntimes(t *testing.T) {
 		assert.Equal(t, int64(1), serverCount)
 	})
 }
+
+// TestLoggingNamespaceAutoApprovalCondition verifies that getServerByID correctly returns
+// the registration status of the parent origin, which is the key input to the auto-approval
+// logic in keySignChallengeCommit.
+func TestLoggingNamespaceAutoApprovalCondition(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	setupMockRegistryDB(t)
+	defer teardownMockRegistryDB(t)
+
+	t.Run("ApprovedOriginEnablesAutoApproval", func(t *testing.T) {
+		ns := server_structs.Registration{
+			Prefix: "/origins/auto-approve-test.edu",
+			Pubkey: "pubkey-auto",
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName: "AutoApproveOrigin",
+				Status:   server_structs.RegApproved,
+			},
+		}
+		require.NoError(t, AddRegistration(&ns))
+
+		// Look up the server as keySignChallengeCommit would
+		server, err := getServerByRegistrationID(ns.ID)
+		require.NoError(t, err)
+		require.NotEmpty(t, server.ID)
+
+		// Simulate the auto-approval condition
+		serverReg, err := getServerByID(server.ID)
+		require.NoError(t, err)
+		require.NotNil(t, serverReg)
+
+		hasApprovedRegistration := false
+		for _, reg := range serverReg.Registration {
+			if reg.AdminMetadata.Status == server_structs.RegApproved {
+				hasApprovedRegistration = true
+				break
+			}
+		}
+		assert.True(t, hasApprovedRegistration, "Origin with RegApproved should enable logging namespace auto-approval")
+	})
+
+	t.Run("PendingOriginDoesNotEnableAutoApproval", func(t *testing.T) {
+		ns := server_structs.Registration{
+			Prefix: "/origins/pending-logging-test.edu",
+			Pubkey: "pubkey-pending",
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName: "PendingOrigin",
+				Status:   server_structs.RegPending,
+			},
+		}
+		require.NoError(t, AddRegistration(&ns))
+
+		server, err := getServerByRegistrationID(ns.ID)
+		require.NoError(t, err)
+		require.NotEmpty(t, server.ID)
+
+		serverReg, err := getServerByID(server.ID)
+		require.NoError(t, err)
+		require.NotNil(t, serverReg)
+
+		hasApprovedRegistration := false
+		for _, reg := range serverReg.Registration {
+			if reg.AdminMetadata.Status == server_structs.RegApproved {
+				hasApprovedRegistration = true
+				break
+			}
+		}
+		assert.False(t, hasApprovedRegistration, "Pending origin should not enable logging namespace auto-approval")
+	})
+}

--- a/registry/registry_db_server_test.go
+++ b/registry/registry_db_server_test.go
@@ -802,71 +802,82 @@ func TestDeleteRegistrationByID_RemovesDowntimes(t *testing.T) {
 	})
 }
 
-// TestLoggingNamespaceAutoApprovalCondition verifies that getServerByID correctly returns
-// the registration status of the parent origin, which is the key input to the auto-approval
-// logic in keySignChallengeCommit.
-func TestLoggingNamespaceAutoApprovalCondition(t *testing.T) {
+// TestApplyLoggingNamespaceAutoApproval verifies the helper extracted from
+// keySignChallengeCommit that auto-approves logging namespace registrations
+// when Registry.EnableAutoLoggingRegistration is true.
+func TestApplyLoggingNamespaceAutoApproval(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	setupMockRegistryDB(t)
 	defer teardownMockRegistryDB(t)
 
-	t.Run("ApprovedOriginEnablesAutoApproval", func(t *testing.T) {
-		ns := server_structs.Registration{
-			Prefix: "/origins/auto-approve-test.edu",
-			Pubkey: "pubkey-auto",
+	t.Run("ApprovedOriginAutoApprovesLoggingNS", func(t *testing.T) {
+		originNs := server_structs.Registration{
+			Prefix: "/origins/approved-auto-test.edu",
+			Pubkey: "pubkey-approved",
 			AdminMetadata: server_structs.AdminMetadata{
-				SiteName: "AutoApproveOrigin",
+				SiteName: "ApprovedAutoOrigin",
 				Status:   server_structs.RegApproved,
 			},
 		}
-		require.NoError(t, AddRegistration(&ns))
+		require.NoError(t, AddRegistration(&originNs))
 
-		// Look up the server as keySignChallengeCommit would
-		server, err := getServerByRegistrationID(ns.ID)
+		server, err := getServerByRegistrationID(originNs.ID)
 		require.NoError(t, err)
-		require.NotEmpty(t, server.ID)
+		require.NotEmpty(t, server.ID, "origin registration should have created a server record")
 
-		// Simulate the auto-approval condition
-		serverReg, err := getServerByID(server.ID)
-		require.NoError(t, err)
-		require.NotNil(t, serverReg)
-
-		hasApprovedRegistration := false
-		for _, reg := range serverReg.Registration {
-			if reg.AdminMetadata.Status == server_structs.RegApproved {
-				hasApprovedRegistration = true
-				break
-			}
-		}
-		assert.True(t, hasApprovedRegistration, "Origin with RegApproved should enable logging namespace auto-approval")
-	})
-
-	t.Run("PendingOriginDoesNotEnableAutoApproval", func(t *testing.T) {
-		ns := server_structs.Registration{
-			Prefix: "/origins/pending-logging-test.edu",
-			Pubkey: "pubkey-pending",
+		loggingNs := server_structs.Registration{
+			Prefix: server_structs.LoggingNamespaceForServer(server.ID),
 			AdminMetadata: server_structs.AdminMetadata{
-				SiteName: "PendingOrigin",
+				SiteName: "ApprovedAutoOrigin",
 				Status:   server_structs.RegPending,
 			},
 		}
-		require.NoError(t, AddRegistration(&ns))
+		applyLoggingNamespaceAutoApproval(server.ID, &loggingNs)
 
-		server, err := getServerByRegistrationID(ns.ID)
+		assert.Equal(t, server_structs.RegApproved, loggingNs.AdminMetadata.Status)
+		assert.Equal(t, "system", loggingNs.AdminMetadata.ApproverID)
+		assert.False(t, loggingNs.AdminMetadata.ApprovedAt.IsZero())
+	})
+
+	t.Run("PendingOriginDoesNotAutoApproveLoggingNS", func(t *testing.T) {
+		originNs := server_structs.Registration{
+			Prefix: "/origins/pending-auto-test.edu",
+			Pubkey: "pubkey-pending",
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName: "PendingAutoOrigin",
+				Status:   server_structs.RegPending,
+			},
+		}
+		require.NoError(t, AddRegistration(&originNs))
+
+		server, err := getServerByRegistrationID(originNs.ID)
 		require.NoError(t, err)
 		require.NotEmpty(t, server.ID)
 
-		serverReg, err := getServerByID(server.ID)
-		require.NoError(t, err)
-		require.NotNil(t, serverReg)
-
-		hasApprovedRegistration := false
-		for _, reg := range serverReg.Registration {
-			if reg.AdminMetadata.Status == server_structs.RegApproved {
-				hasApprovedRegistration = true
-				break
-			}
+		loggingNs := server_structs.Registration{
+			Prefix: server_structs.LoggingNamespaceForServer(server.ID),
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName: "PendingAutoOrigin",
+				Status:   server_structs.RegPending,
+			},
 		}
-		assert.False(t, hasApprovedRegistration, "Pending origin should not enable logging namespace auto-approval")
+		applyLoggingNamespaceAutoApproval(server.ID, &loggingNs)
+
+		assert.Equal(t, server_structs.RegPending, loggingNs.AdminMetadata.Status,
+			"pending origin should not trigger auto-approval")
+	})
+
+	t.Run("UnknownServerIDDoesNotAutoApprove", func(t *testing.T) {
+		loggingNs := server_structs.Registration{
+			Prefix: server_structs.LoggingNamespaceForServer("notfound"),
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName: "Ghost",
+				Status:   server_structs.RegPending,
+			},
+		}
+		applyLoggingNamespaceAutoApproval("notfound", &loggingNs)
+
+		assert.Equal(t, server_structs.RegPending, loggingNs.AdminMetadata.Status,
+			"unknown server ID should not trigger auto-approval")
 	})
 }

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -20,14 +20,19 @@ package registry
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -41,6 +46,7 @@ import (
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
+	"github.com/pelicanplatform/pelican/utils"
 )
 
 func TestHandleWildcard(t *testing.T) {
@@ -552,5 +558,141 @@ func TestServerIdGenerationAndStorage(t *testing.T) {
 		if saved.CustomFields != nil {
 			assert.NotContains(t, saved.CustomFields, "server_id")
 		}
+	})
+}
+
+// TestLoggingNamespaceKeyMatchEnforcement verifies that keySignChallengeCommit
+// rejects logging namespace registrations whose public key does not match the
+// already-registered origin key, preventing namespace squatting.
+func TestLoggingNamespaceKeyMatchEnforcement(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	t.Cleanup(server_utils.ResetTestState)
+
+	tempDir, err := os.MkdirTemp("", "test-logging-squatting-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	ctx := context.Background()
+	require.NoError(t, param.ConfigDir.Set(tempDir))
+	require.NoError(t, param.IssuerKeysDirectory.Set(filepath.Join(tempDir, "issuer-keys")))
+	// Pre-populate all five federation fields so InitServer's internal
+	// discoverFederationImpl takes the "all values present" early-return
+	// path and does not attempt live HTTP discovery.
+	const fakeFed = "https://test.example"
+	require.NoError(t, param.Set(param.Federation_DiscoveryUrl, fakeFed))
+	require.NoError(t, param.Set(param.Federation_DirectorUrl, fakeFed))
+	require.NoError(t, param.Set(param.Federation_RegistryUrl, fakeFed))
+	require.NoError(t, param.Set(param.Federation_JwkUrl, fakeFed+"/.well-known/issuer.jwks"))
+	require.NoError(t, param.Set(param.Federation_BrokerUrl, fakeFed))
+	require.NoError(t, config.InitServer(ctx, server_structs.RegistryType))
+
+	// Reset the once-guard so loadServerKeys picks up the freshly generated key.
+	serverCredsLoad = sync.Once{}
+
+	setupMockRegistryDB(t)
+	defer teardownMockRegistryDB(t)
+
+	// Helper: build a JSON-encoded JWK set from an ECDSA key and return both.
+	makeKey := func(t *testing.T) (*ecdsa.PrivateKey, string) {
+		t.Helper()
+		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		pub, err := jwk.FromRaw(priv.PublicKey)
+		require.NoError(t, err)
+		require.NoError(t, jwk.AssignKeyID(pub))
+		set := jwk.NewSet()
+		require.NoError(t, set.AddKey(pub))
+		data, err := json.Marshal(set)
+		require.NoError(t, err)
+		return priv, string(data)
+	}
+
+	// Helper: build a fully-signed registrationData for a given prefix and key.
+	// Mirrors what RegisterNamespaceWithRetry does on the client side.
+	makeRegistrationData := func(t *testing.T, prefix string, clientPriv *ecdsa.PrivateKey, pubkeyJSON string) registrationData {
+		t.Helper()
+
+		clientNonce, err := utils.GenerateNonce()
+		require.NoError(t, err)
+
+		serverPriv, err := loadServerKeys()
+		require.NoError(t, err)
+
+		serverNonce, err := utils.GenerateNonce()
+		require.NoError(t, err)
+
+		serverPayload := []byte(clientNonce + serverNonce)
+		serverSig, err := utils.SignPayload(serverPayload, serverPriv)
+		require.NoError(t, err)
+
+		clientPayload := []byte(clientNonce + serverNonce)
+		clientSig, err := utils.SignPayload(clientPayload, clientPriv)
+		require.NoError(t, err)
+
+		return registrationData{
+			ClientNonce:     clientNonce,
+			ClientPayload:   hex.EncodeToString(clientPayload),
+			ClientSignature: hex.EncodeToString(clientSig),
+			ServerNonce:     serverNonce,
+			ServerPayload:   hex.EncodeToString(serverPayload),
+			ServerSignature: hex.EncodeToString(serverSig),
+			Pubkey:          json.RawMessage(pubkeyJSON),
+			Prefix:          prefix,
+			SiteName:        "test-site",
+		}
+	}
+
+	const originHost = "squatting-test.example"
+	originPrefix := server_structs.GetOriginNs(originHost)
+	loggingPrefix := server_structs.LoggingNamespaceForServer(originHost)
+
+	originPriv, originPubkeyJSON := makeKey(t)
+	attackerPriv, attackerPubkeyJSON := makeKey(t)
+
+	// Register the origin namespace with the legitimate key.
+	originNs := server_structs.Registration{
+		Prefix: originPrefix,
+		Pubkey: originPubkeyJSON,
+		AdminMetadata: server_structs.AdminMetadata{
+			// SiteName must match originHost so that AddRegistration creates a Server
+			// record with Name=originHost, which is what LoggingNamespaceSitename
+			// extracts from the logging prefix and getServerByName looks up.
+			SiteName: originHost,
+			Status:   server_structs.RegApproved,
+		},
+	}
+	require.NoError(t, AddRegistration(&originNs))
+
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+	t.Run("WrongKeyIsRejected", func(t *testing.T) {
+		// Attacker presents their own key and signs with it — nonce challenge passes
+		// (they own the private key) but the key-match check against the origin must reject them.
+		data := makeRegistrationData(t, loggingPrefix, attackerPriv, attackerPubkeyJSON)
+		_, _, err := keySignChallengeCommit(ginCtx, &data)
+		require.Error(t, err)
+		var permErr permissionDeniedError
+		require.ErrorAs(t, err, &permErr, "expected permissionDeniedError, got: %v", err)
+		assert.Contains(t, permErr.Message, "public key does not match")
+	})
+
+	t.Run("CorrectKeyIsAccepted", func(t *testing.T) {
+		// Legitimate origin registers its logging namespace with the same key.
+		data := makeRegistrationData(t, loggingPrefix, originPriv, originPubkeyJSON)
+		created, _, err := keySignChallengeCommit(ginCtx, &data)
+		require.NoError(t, err)
+		assert.True(t, created, "logging namespace should be created when key matches origin")
+	})
+
+	t.Run("UnregisteredOriginIsRejected", func(t *testing.T) {
+		// No origin registered for this host — must be rejected.
+		const ghostHost = "ghost.squatting-test.example"
+		ghostPriv, ghostPubJSON := makeKey(t)
+		data := makeRegistrationData(t, server_structs.LoggingNamespaceForServer(ghostHost), ghostPriv, ghostPubJSON)
+		_, _, err := keySignChallengeCommit(ginCtx, &data)
+		require.Error(t, err)
+		var permErr permissionDeniedError
+		require.ErrorAs(t, err, &permErr)
+		assert.Contains(t, permErr.Message, "is registered")
 	})
 }

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -887,10 +887,7 @@ func deleteNamespace(ctx *gin.Context) {
 
 func listServersHandler(ctx *gin.Context) {
 	nameQuery := ctx.Query("name")
-	var (
-		servers []server_structs.ServerRegistration
-		err     error
-	)
+	var servers []server_structs.ServerRegistration
 	if nameQuery != "" {
 		server, lookupErr := getServerByName(nameQuery)
 		if lookupErr != nil && !errors.Is(lookupErr, gorm.ErrRecordNotFound) {
@@ -904,14 +901,14 @@ func listServersHandler(ctx *gin.Context) {
 			servers = []server_structs.ServerRegistration{*server}
 		}
 	} else {
-		servers, err = listServers()
-	}
-	if err != nil {
-		log.Error(err)
-		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
-			Status: server_structs.RespFailed,
-			Msg:    "Failed to list servers"})
-		return
+		var err error
+		if servers, err = listServers(); err != nil {
+			log.Error(err)
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "Failed to list servers"})
+			return
+		}
 	}
 	ctx.JSON(http.StatusOK, servers)
 }

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -404,6 +404,19 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 	}
 	ns.Prefix = updated_prefix
 
+	// Logging namespaces may only be registered through the automated key-sign
+	// challenge flow (keySignChallengeCommit), which proves the registrant holds
+	// the origin's registered key before allowing /pelican/logging/{sitename}.
+	// This human-facing endpoint performs no such key-match check, so permitting
+	// it here would let any authenticated user squat or reserve another origin's
+	// logging namespace. Reject logging prefixes outright.
+	if _, ok := server_structs.LoggingNamespaceSitename(ns.Prefix); ok {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Logging namespaces are managed automatically by origin servers and cannot be registered or modified through this endpoint"})
+		return
+	}
+
 	if !isUpdate {
 		// Check if prefix exists before doing anything else. Skip check if it's update operation
 		exists, err := registrationExistsByPrefix(ns.Prefix)
@@ -641,12 +654,19 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 		}
 
 		// If the user has privilege to update, go ahead
+		oldNs, _ := getRegistrationById(ns.ID)
 		if err := updateRegistration(&ns); err != nil {
 			log.Errorf("Failed to update namespace with id %d. %v", ns.ID, err)
 			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 				Status: server_structs.RespFailed,
 				Msg:    "Fail to update namespace"})
 			return
+		}
+		// When an admin updates an origin's public key, cascade the new key to its
+		// logging namespace so the origin can still authenticate after key rotation.
+		if server_structs.IsOriginNS(ns.Prefix) && oldNs != nil && oldNs.Pubkey != ns.Pubkey {
+			sitename := ns.AdminMetadata.SiteName
+			cascadeUpdateLoggingNamespaceKey(sitename, ns.Pubkey)
 		}
 	}
 }
@@ -793,6 +813,19 @@ func updateNamespaceStatus(ctx *gin.Context, status server_structs.RegistrationS
 			Msg:    "Failed to update namespace"})
 		return
 	}
+
+	// When an origin's registration is approved by an admin and the auto-logging
+	// feature is enabled, cascade-approve any pending logging namespace for that
+	// origin.  The logging namespace is registered at origin startup before the
+	// admin has approved the origin's primary registration, so it cannot
+	// self-approve at registration time and would otherwise stay "pending" forever.
+	if status == server_structs.RegApproved && param.Registry_EnableAutoLoggingRegistration.GetBool() {
+		if reg, lookupErr := getRegistrationById(id); lookupErr == nil && server_structs.IsOriginNS(reg.Prefix) {
+			sitename := reg.AdminMetadata.SiteName
+			cascadeApproveLoggingNamespace(sitename)
+		}
+	}
+
 	ctx.JSON(http.StatusOK,
 		server_structs.SimpleApiResp{
 			Status: server_structs.RespOK,
@@ -909,6 +942,11 @@ func listServersHandler(ctx *gin.Context) {
 				Msg:    "Failed to list servers"})
 			return
 		}
+	}
+	if servers == nil {
+		// Both getServerByName (no match) and listServers (empty registry) yield a
+		// nil slice; normalize to an empty array so the response is "[]" not "null".
+		servers = []server_structs.ServerRegistration{}
 	}
 	ctx.JSON(http.StatusOK, servers)
 }

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -34,6 +34,7 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
@@ -885,7 +886,26 @@ func deleteNamespace(ctx *gin.Context) {
 }
 
 func listServersHandler(ctx *gin.Context) {
-	servers, err := listServers()
+	nameQuery := ctx.Query("name")
+	var (
+		servers []server_structs.ServerRegistration
+		err     error
+	)
+	if nameQuery != "" {
+		server, lookupErr := getServerByName(nameQuery)
+		if lookupErr != nil && !errors.Is(lookupErr, gorm.ErrRecordNotFound) {
+			log.Error(lookupErr)
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "Failed to list servers"})
+			return
+		}
+		if server != nil {
+			servers = []server_structs.ServerRegistration{*server}
+		}
+	} else {
+		servers, err = listServers()
+	}
 	if err != nil {
 		log.Error(err)
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{

--- a/registry/registry_ui_server_test.go
+++ b/registry/registry_ui_server_test.go
@@ -502,3 +502,75 @@ func TestDeleteServerHandler_RemovesDowntimes(t *testing.T) {
 		Where("id = ?", ns.ID).Count(&regCount).Error)
 	assert.Equal(t, int64(0), regCount, "registration should be removed with the server")
 }
+
+func TestListServersHandlerNameFilter(t *testing.T) {
+	t.Cleanup(func() {
+		server_utils.ResetTestState()
+	})
+
+	setupMockRegistryDB(t)
+	defer teardownMockRegistryDB(t)
+
+	namespaces := []server_structs.Registration{
+		{
+			Prefix: "/origins/alpha-filter.edu",
+			Pubkey: "pubkey-alpha-filter",
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName: "Alpha Filter",
+				Status:   server_structs.RegApproved,
+			},
+		},
+		{
+			Prefix: "/origins/beta-filter.edu",
+			Pubkey: "pubkey-beta-filter",
+			AdminMetadata: server_structs.AdminMetadata{
+				SiteName: "Beta Filter",
+				Status:   server_structs.RegApproved,
+			},
+		},
+	}
+	for i := range namespaces {
+		require.NoError(t, AddRegistration(&namespaces[i]))
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/servers", listServersHandler)
+
+	t.Run("FilterByName_ReturnsMatchingServer", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/servers?name=Alpha+Filter", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var servers []server_structs.ServerRegistration
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &servers))
+		require.Len(t, servers, 1)
+		assert.Equal(t, "Alpha Filter", servers[0].Name)
+	})
+
+	t.Run("FilterByName_NoMatch_ReturnsEmpty", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/servers?name=zzznomatch", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var servers []server_structs.ServerRegistration
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &servers))
+		assert.Len(t, servers, 0)
+	})
+
+	t.Run("NoNameParam_ReturnsAllServers", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/servers", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var servers []server_structs.ServerRegistration
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &servers))
+		assert.Len(t, servers, 2)
+	})
+}

--- a/registry/registry_ui_server_test.go
+++ b/registry/registry_ui_server_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -556,6 +557,10 @@ func TestListServersHandlerNameFilter(t *testing.T) {
 		router.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
+
+		// Pin the swagger contract: the body must be an empty JSON array "[]",
+		// not "null". Unmarshaling alone would accept both, so assert the raw body.
+		assert.Equal(t, "[]", strings.TrimSpace(w.Body.String()))
 
 		var servers []server_structs.ServerRegistration
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &servers))

--- a/registry/registry_ui_test.go
+++ b/registry/registry_ui_test.go
@@ -816,6 +816,27 @@ func TestCreateNamespace(t *testing.T) {
 		assert.Contains(t, string(body), "Validation for Pubkey failed:")
 	})
 
+	t.Run("logging-namespace-rejected", func(t *testing.T) {
+		resetMockRegistryDB(t)
+		// Logging namespaces must only be registered through the automated
+		// key-sign challenge flow (which enforces a key match against the
+		// origin). The human-facing create/update endpoint performs no such
+		// check, so it must reject logging prefixes outright to prevent
+		// squatting another origin's logging namespace.
+		mockNs := server_structs.Registration{Prefix: "/pelican/logging/victim.example.org"}
+		mockNsBytes, err := json.Marshal(mockNs)
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/namespaces", bytes.NewReader(mockNsBytes))
+		req.Header.Set("Context-Type", "application/json")
+		router.ServeHTTP(w, req)
+
+		body, err := io.ReadAll(w.Result().Body)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		assert.Contains(t, string(body), "Logging namespaces are managed automatically")
+	})
+
 	t.Run("missing-institution-returns-400", func(t *testing.T) {
 		require.NoError(t, param.Registry_Institutions.Set([]map[string]string{{"name": "Mock School", "id": "123"}}))
 		resetMockRegistryDB(t)

--- a/registry/registry_validation.go
+++ b/registry/registry_validation.go
@@ -50,9 +50,9 @@ func validatePrefix(nspath string) (string, error) {
 	} else if components[0] == "view" {
 		return "", errors.New("Cannot register a prefix starting with '/view'")
 	} else if components[0] == "pelican" {
-		// The /pelican namespace is reserved, but /pelican/logging/{serverID} is
+		// The /pelican namespace is reserved, but /pelican/logging/{sitename} is
 		// allowed for origin log-export registrations.
-		if _, ok := server_structs.LoggingNamespaceServerID(nspath); !ok {
+		if _, ok := server_structs.LoggingNamespaceSitename(nspath); !ok {
 			return "", errors.New("Cannot register a prefix starting with '/pelican'")
 		}
 	}

--- a/registry/registry_validation.go
+++ b/registry/registry_validation.go
@@ -50,7 +50,11 @@ func validatePrefix(nspath string) (string, error) {
 	} else if components[0] == "view" {
 		return "", errors.New("Cannot register a prefix starting with '/view'")
 	} else if components[0] == "pelican" {
-		return "", errors.New("Cannot register a prefix starting with '/pelican'")
+		// The /pelican namespace is reserved, but /pelican/logging/{serverID} is
+		// allowed for origin log-export registrations.
+		if _, ok := server_structs.LoggingNamespaceServerID(nspath); !ok {
+			return "", errors.New("Cannot register a prefix starting with '/pelican'")
+		}
 	}
 	result := ""
 	for _, component := range components {

--- a/registry/registry_validation_test.go
+++ b/registry/registry_validation_test.go
@@ -372,8 +372,8 @@ func TestValidatePrefix(t *testing.T) {
 	})
 
 	t.Run("logging-namespace-allowed", func(t *testing.T) {
-		got, err := validatePrefix("/pelican/logging/abc1234")
+		got, err := validatePrefix("/pelican/logging/myhost.example.org")
 		require.NoError(t, err)
-		assert.Equal(t, "/pelican/logging/abc1234", got)
+		assert.Equal(t, "/pelican/logging/myhost.example.org", got)
 	})
 }

--- a/registry/registry_validation_test.go
+++ b/registry/registry_validation_test.go
@@ -360,4 +360,20 @@ func TestValidatePrefix(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "/caches/192.168.5.21", got)
 	})
+
+	t.Run("pelican-prefix-blocked", func(t *testing.T) {
+		_, err := validatePrefix("/pelican/")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Cannot register a prefix starting with '/pelican'")
+
+		_, err = validatePrefix("/pelican/anythingelse")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Cannot register a prefix starting with '/pelican'")
+	})
+
+	t.Run("logging-namespace-allowed", func(t *testing.T) {
+		got, err := validatePrefix("/pelican/logging/abc1234")
+		require.NoError(t, err)
+		assert.Equal(t, "/pelican/logging/abc1234", got)
+	})
 }

--- a/server_structs/registry.go
+++ b/server_structs/registry.go
@@ -115,13 +115,14 @@ const (
 	// default data-namespace type.
 	RegistrationTypeKey = "type"
 
-	// LoggingRegistrationType is the CustomFields["type"] value written when an Origin or
-	// Cache auto-registers its logging namespace (/pelican/logging/{Server.ID}).
+	// LoggingRegistrationType is the CustomFields["type"] value written when an Origin
+	// auto-registers its logging namespace (/pelican/logging/{hostname}).
 	// Using the CustomFields map avoids any DB schema migration.
 	LoggingRegistrationType = "logging"
 
 	// LoggingNamespacePrefix is the path prefix shared by all logging namespace registrations.
-	// Each server's logging namespace is LoggingNamespacePrefix + "/" + Server.ID.
+	// Each server's logging namespace is LoggingNamespacePrefix + "/" + hostname,
+	// where hostname is the host (and optional port) portion of Server_ExternalWebUrl.
 	LoggingNamespacePrefix = "/pelican/logging"
 )
 
@@ -165,25 +166,31 @@ func (reg *Registration) IsLoggingNamespace() bool {
 }
 
 // LoggingNamespaceForServer returns the full logging namespace path for the
-// given server ID, i.e. LoggingNamespacePrefix + "/" + serverID.
-func LoggingNamespaceForServer(serverID string) string {
-	return LoggingNamespacePrefix + "/" + serverID
+// given server sitename (Xrootd.Sitename), i.e. LoggingNamespacePrefix + "/" + sitename.
+// sitename is the human-readable unique name of the server as registered in the Registry.
+func LoggingNamespaceForServer(sitename string) string {
+	return LoggingNamespacePrefix + "/" + sitename
 }
 
-// LoggingNamespaceServerID extracts the server ID embedded in a logging
-// namespace prefix (e.g. "/pelican/logging/abc1234" → "abc1234", true).
+// LoggingNamespaceSitename extracts the sitename embedded in a logging
+// namespace prefix (e.g. "/pelican/logging/my-origin" → "my-origin", true).
 // Returns "", false if prefix is not a direct child of LoggingNamespacePrefix
-// or has an empty server-ID segment.
-func LoggingNamespaceServerID(prefix string) (string, bool) {
+// or has an empty sitename segment.
+func LoggingNamespaceSitename(prefix string) (string, bool) {
 	const loggingParent = LoggingNamespacePrefix + "/"
 	if !strings.HasPrefix(prefix, loggingParent) {
 		return "", false
 	}
-	id := strings.TrimPrefix(prefix, loggingParent)
-	if id == "" {
+	sitename := strings.TrimPrefix(prefix, loggingParent)
+	if sitename == "" {
 		return "", false
 	}
-	return id, true
+	// Reject prefixes like "/pelican/logging/a/b" — a valid logging namespace
+	// is a direct child of LoggingNamespacePrefix (one path segment only).
+	if strings.Contains(sitename, "/") {
+		return "", false
+	}
+	return sitename, true
 }
 
 func IsValidRegStatus(s string) bool {

--- a/server_structs/registry.go
+++ b/server_structs/registry.go
@@ -109,6 +109,20 @@ const (
 	RegApproved RegistrationStatus = "Approved"
 	RegDenied   RegistrationStatus = "Denied"
 	RegUnknown  RegistrationStatus = "Unknown"
+
+	// RegistrationTypeKey is the key used in Registration.CustomFields to indicate the
+	// registration type.  It is set on namespace registrations that differ from the
+	// default data-namespace type.
+	RegistrationTypeKey = "type"
+
+	// LoggingRegistrationType is the CustomFields["type"] value written when an Origin or
+	// Cache auto-registers its logging namespace (/pelican/logging/{Server.ID}).
+	// Using the CustomFields map avoids any DB schema migration.
+	LoggingRegistrationType = "logging"
+
+	// LoggingNamespacePrefix is the path prefix shared by all logging namespace registrations.
+	// Each server's logging namespace is LoggingNamespacePrefix + "/" + Server.ID.
+	LoggingNamespacePrefix = "/pelican/logging"
 )
 
 func (rs RegistrationStatus) String() string {
@@ -134,6 +148,20 @@ func (a AdminMetadata) Equal(b AdminMetadata) bool {
 
 func (Registration) TableName() string {
 	return "registrations"
+}
+
+// IsLoggingNamespace reports whether reg is a logging namespace registration,
+// i.e. one whose CustomFields map contains {"type": "logging"}.
+func (reg *Registration) IsLoggingNamespace() bool {
+	if reg.CustomFields == nil {
+		return false
+	}
+	v, ok := reg.CustomFields[RegistrationTypeKey]
+	if !ok {
+		return false
+	}
+	s, ok := v.(string)
+	return ok && s == LoggingRegistrationType
 }
 
 func IsValidRegStatus(s string) bool {

--- a/server_structs/registry.go
+++ b/server_structs/registry.go
@@ -164,6 +164,28 @@ func (reg *Registration) IsLoggingNamespace() bool {
 	return ok && s == LoggingRegistrationType
 }
 
+// LoggingNamespaceForServer returns the full logging namespace path for the
+// given server ID, i.e. LoggingNamespacePrefix + "/" + serverID.
+func LoggingNamespaceForServer(serverID string) string {
+	return LoggingNamespacePrefix + "/" + serverID
+}
+
+// LoggingNamespaceServerID extracts the server ID embedded in a logging
+// namespace prefix (e.g. "/pelican/logging/abc1234" → "abc1234", true).
+// Returns "", false if prefix is not a direct child of LoggingNamespacePrefix
+// or has an empty server-ID segment.
+func LoggingNamespaceServerID(prefix string) (string, bool) {
+	const loggingParent = LoggingNamespacePrefix + "/"
+	if !strings.HasPrefix(prefix, loggingParent) {
+		return "", false
+	}
+	id := strings.TrimPrefix(prefix, loggingParent)
+	if id == "" {
+		return "", false
+	}
+	return id, true
+}
+
 func IsValidRegStatus(s string) bool {
 	return s == "Pending" || s == "Approved" || s == "Denied" || s == "Unknown"
 }

--- a/server_structs/registry_test.go
+++ b/server_structs/registry_test.go
@@ -1,0 +1,84 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package server_structs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsLoggingNamespace(t *testing.T) {
+	t.Run("NilCustomFields", func(t *testing.T) {
+		reg := &Registration{}
+		assert.False(t, reg.IsLoggingNamespace())
+	})
+
+	t.Run("EmptyCustomFields", func(t *testing.T) {
+		reg := &Registration{CustomFields: map[string]interface{}{}}
+		assert.False(t, reg.IsLoggingNamespace())
+	})
+
+	t.Run("WrongTypeValue", func(t *testing.T) {
+		reg := &Registration{CustomFields: map[string]interface{}{RegistrationTypeKey: "data"}}
+		assert.False(t, reg.IsLoggingNamespace())
+	})
+
+	t.Run("NonStringTypeValue", func(t *testing.T) {
+		reg := &Registration{CustomFields: map[string]interface{}{RegistrationTypeKey: 42}}
+		assert.False(t, reg.IsLoggingNamespace())
+	})
+
+	t.Run("LoggingTypeValue", func(t *testing.T) {
+		reg := &Registration{CustomFields: map[string]interface{}{RegistrationTypeKey: LoggingRegistrationType}}
+		assert.True(t, reg.IsLoggingNamespace())
+	})
+}
+
+func TestLoggingNamespaceServerID(t *testing.T) {
+	t.Run("ValidPath", func(t *testing.T) {
+		id, ok := LoggingNamespaceServerID("/pelican/logging/abc1234")
+		assert.True(t, ok)
+		assert.Equal(t, "abc1234", id)
+	})
+
+	t.Run("PrefixOnly", func(t *testing.T) {
+		_, ok := LoggingNamespaceServerID(LoggingNamespacePrefix)
+		assert.False(t, ok)
+	})
+
+	t.Run("PrefixWithTrailingSlashOnly", func(t *testing.T) {
+		_, ok := LoggingNamespaceServerID(LoggingNamespacePrefix + "/")
+		assert.False(t, ok)
+	})
+
+	t.Run("UnrelatedPath", func(t *testing.T) {
+		_, ok := LoggingNamespaceServerID("/origins/some.host")
+		assert.False(t, ok)
+	})
+
+	t.Run("EmptyString", func(t *testing.T) {
+		_, ok := LoggingNamespaceServerID("")
+		assert.False(t, ok)
+	})
+}
+
+func TestLoggingNamespaceForServer(t *testing.T) {
+	assert.Equal(t, "/pelican/logging/abc1234", LoggingNamespaceForServer("abc1234"))
+}

--- a/server_structs/registry_test.go
+++ b/server_structs/registry_test.go
@@ -51,34 +51,49 @@ func TestIsLoggingNamespace(t *testing.T) {
 	})
 }
 
-func TestLoggingNamespaceServerID(t *testing.T) {
+func TestLoggingNamespaceSitename(t *testing.T) {
 	t.Run("ValidPath", func(t *testing.T) {
-		id, ok := LoggingNamespaceServerID("/pelican/logging/abc1234")
+		site, ok := LoggingNamespaceSitename("/pelican/logging/my-origin")
 		assert.True(t, ok)
-		assert.Equal(t, "abc1234", id)
+		assert.Equal(t, "my-origin", site)
+	})
+
+	t.Run("SitenameWithDots", func(t *testing.T) {
+		site, ok := LoggingNamespaceSitename("/pelican/logging/uw-madison.edu")
+		assert.True(t, ok)
+		assert.Equal(t, "uw-madison.edu", site)
 	})
 
 	t.Run("PrefixOnly", func(t *testing.T) {
-		_, ok := LoggingNamespaceServerID(LoggingNamespacePrefix)
+		_, ok := LoggingNamespaceSitename(LoggingNamespacePrefix)
 		assert.False(t, ok)
 	})
 
 	t.Run("PrefixWithTrailingSlashOnly", func(t *testing.T) {
-		_, ok := LoggingNamespaceServerID(LoggingNamespacePrefix + "/")
+		_, ok := LoggingNamespaceSitename(LoggingNamespacePrefix + "/")
 		assert.False(t, ok)
 	})
 
 	t.Run("UnrelatedPath", func(t *testing.T) {
-		_, ok := LoggingNamespaceServerID("/origins/some.host")
+		_, ok := LoggingNamespaceSitename("/origins/some.host")
 		assert.False(t, ok)
 	})
 
 	t.Run("EmptyString", func(t *testing.T) {
-		_, ok := LoggingNamespaceServerID("")
+		_, ok := LoggingNamespaceSitename("")
+		assert.False(t, ok)
+	})
+
+	t.Run("MultipleSegments", func(t *testing.T) {
+		// A crafted prefix like /pelican/logging/my-origin/subpath must not be
+		// accepted — a valid logging namespace has exactly one path segment
+		// after the prefix.
+		_, ok := LoggingNamespaceSitename("/pelican/logging/my-origin/subpath")
 		assert.False(t, ok)
 	})
 }
 
 func TestLoggingNamespaceForServer(t *testing.T) {
-	assert.Equal(t, "/pelican/logging/abc1234", LoggingNamespaceForServer("abc1234"))
+	assert.Equal(t, "/pelican/logging/my-origin", LoggingNamespaceForServer("my-origin"))
+	assert.Equal(t, "/pelican/logging/uw-madison-cache", LoggingNamespaceForServer("uw-madison-cache"))
 }

--- a/swagger/pelican-swagger.yaml
+++ b/swagger/pelican-swagger.yaml
@@ -3140,6 +3140,12 @@ paths:
       description: Public API to get all registered servers (origins and caches) in the registry
       produces:
         - application/json
+      parameters:
+        - name: name
+          in: query
+          description: Filter results to the single server with this name. Returns an empty array if no match is found.
+          required: false
+          type: string
       responses:
         "200":
           description: OK

--- a/web_ui/frontend/app/registry/denied/page.tsx
+++ b/web_ui/frontend/app/registry/denied/page.tsx
@@ -46,7 +46,9 @@ export default function Home() {
   const deniedNamespaces = useMemo(
     () =>
       data?.filter(
-        ({ namespace }) => namespace.admin_metadata.status === 'Denied'
+        ({ namespace }) =>
+          namespace.admin_metadata.status === 'Denied' &&
+          namespace.type !== 'pelican'
       ),
     [data]
   );

--- a/web_ui/frontend/app/registry/page.tsx
+++ b/web_ui/frontend/app/registry/page.tsx
@@ -66,6 +66,7 @@ export default function Home() {
     return data?.filter(
       ({ namespace }) =>
         namespace.admin_metadata.status === 'Pending' &&
+        namespace.type !== 'pelican' &&
         (user?.user == namespace.admin_metadata.user_id ||
           user?.role == 'admin')
     );

--- a/web_ui/frontend/components/Namespace/Card.tsx
+++ b/web_ui/frontend/components/Namespace/Card.tsx
@@ -100,18 +100,18 @@ export const Card = ({ namespace, authenticated, onUpdate }: CardProps) => {
               {authenticated?.role == 'admin' && (
                 <>
                   {namespace.type !== 'pelican' && (
-                  <Tooltip title={'Edit Registration'}>
-                    <Link
-                      href={`/registry/${namespace.type}/edit/?id=${namespace.id}`}
-                    >
-                      <IconButton
-                        onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                        size={size}
+                    <Tooltip title={'Edit Registration'}>
+                      <Link
+                        href={`/registry/${namespace.type}/edit/?id=${namespace.id}`}
                       >
-                        <Edit fontSize={size} />
-                      </IconButton>
-                    </Link>
-                  </Tooltip>
+                        <IconButton
+                          onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                          size={size}
+                        >
+                          <Edit fontSize={size} />
+                        </IconButton>
+                      </Link>
+                    </Tooltip>
                   )}
                   {['origin', 'cache'].includes(namespace.type) && (
                     <Tooltip title={'Register Downtime'}>

--- a/web_ui/frontend/components/Namespace/Card.tsx
+++ b/web_ui/frontend/components/Namespace/Card.tsx
@@ -99,6 +99,7 @@ export const Card = ({ namespace, authenticated, onUpdate }: CardProps) => {
               </Tooltip>
               {authenticated?.role == 'admin' && (
                 <>
+                  {namespace.type !== 'pelican' && (
                   <Tooltip title={'Edit Registration'}>
                     <Link
                       href={`/registry/${namespace.type}/edit/?id=${namespace.id}`}
@@ -111,6 +112,7 @@ export const Card = ({ namespace, authenticated, onUpdate }: CardProps) => {
                       </IconButton>
                     </Link>
                   </Tooltip>
+                  )}
                   {['origin', 'cache'].includes(namespace.type) && (
                     <Tooltip title={'Register Downtime'}>
                       <Link

--- a/web_ui/frontend/components/Namespace/NamespaceIcon.tsx
+++ b/web_ui/frontend/components/Namespace/NamespaceIcon.tsx
@@ -8,7 +8,9 @@ const NamespaceIcon = ({
   color = 'white',
   bgcolor = 'primary.main',
 }: {
-  serverType: 'origin' | 'cache' | 'namespace';
+  // 'pelican' covers internal namespaces (e.g. /pelican/logging/*) that are
+  // intentionally hidden from the UI; the component renders nothing for them.
+  serverType: 'origin' | 'cache' | 'namespace' | 'pelican';
   size?: 'large' | 'medium' | 'small';
   color?: string;
   bgcolor?: string;

--- a/web_ui/frontend/components/Namespace/PendingCard.tsx
+++ b/web_ui/frontend/components/Namespace/PendingCard.tsx
@@ -124,19 +124,19 @@ export const PendingCard = ({
             {(authenticated?.role == 'admin' ||
               authenticated?.user == namespace.admin_metadata.user_id) &&
               namespace.type !== 'pelican' && (
-              <Tooltip title={'Edit Registration'}>
-                <Link
-                  href={`/registry/${namespace.type}/edit/?id=${namespace.id}`}
-                >
-                  <IconButton
-                    onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                    size={size}
+                <Tooltip title={'Edit Registration'}>
+                  <Link
+                    href={`/registry/${namespace.type}/edit/?id=${namespace.id}`}
                   >
-                    <Edit fontSize={size} />
-                  </IconButton>
-                </Link>
-              </Tooltip>
-            )}
+                    <IconButton
+                      onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                      size={size}
+                    >
+                      <Edit fontSize={size} />
+                    </IconButton>
+                  </Link>
+                </Tooltip>
+              )}
           </Box>
         </Box>
       </Box>

--- a/web_ui/frontend/components/Namespace/PendingCard.tsx
+++ b/web_ui/frontend/components/Namespace/PendingCard.tsx
@@ -122,7 +122,8 @@ export const PendingCard = ({
               </>
             )}
             {(authenticated?.role == 'admin' ||
-              authenticated?.user == namespace.admin_metadata.user_id) && (
+              authenticated?.user == namespace.admin_metadata.user_id) &&
+              namespace.type !== 'pelican' && (
               <Tooltip title={'Edit Registration'}>
                 <Link
                   href={`/registry/${namespace.type}/edit/?id=${namespace.id}`}

--- a/web_ui/frontend/helpers/extendPrefix.ts
+++ b/web_ui/frontend/helpers/extendPrefix.ts
@@ -19,6 +19,15 @@ const extendPrefix = (
     };
   }
 
+  if (prefix.startsWith('/pelican/logging/')) {
+    // Logging namespaces keep their full prefix (unlike origins/caches, which
+    // are stripped) because these entries are hidden from the UI.
+    return {
+      type: 'pelican',
+      adjustedPrefix: prefix,
+    };
+  }
+
   return {
     type: 'namespace',
     adjustedPrefix: prefix,

--- a/web_ui/frontend/helpers/get.ts
+++ b/web_ui/frontend/helpers/get.ts
@@ -66,6 +66,11 @@ export const getExtendedNamespaces = async (): Promise<
     } else if (namespace.prefix.startsWith('/origins/')) {
       namespace.type = 'origin';
       namespace.prefix = namespace.prefix.replace('/origins/', '');
+    } else if (namespace.prefix.startsWith('/pelican/logging/')) {
+      // Logging namespaces are intentionally left with their full prefix (not
+      // stripped like origins/caches) because these entries are hidden from the
+      // UI today.
+      namespace.type = 'pelican';
     } else {
       namespace.type = 'namespace';
     }

--- a/web_ui/frontend/index.ts
+++ b/web_ui/frontend/index.ts
@@ -39,7 +39,7 @@ export interface RegistryNamespace {
   prefix: string;
   adjustedPrefix?: string; // This value is the same when type is 'namespace' otherwise it removes the type value
   pubkey: string;
-  type: 'origin' | 'cache' | 'namespace';
+  type: 'origin' | 'cache' | 'namespace' | 'pelican';
   admin_metadata: NamespaceAdminMetadata;
   custom_fields?: Record<string, any>;
 }

--- a/web_ui/frontend/package-lock.json
+++ b/web_ui/frontend/package-lock.json
@@ -57,7 +57,7 @@
         "@types/semver": "^7.7.0",
         "@types/swagger-ui-react": "^4.18.3",
         "babel-jest": "^29.7.0",
-        "eslint": "^10",
+        "eslint": "^9",
         "eslint-config-next": "^16",
         "eslint-config-prettier": "^10",
         "if": "^2.0.0",
@@ -101,7 +101,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2292,68 +2291,180 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
-      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.5",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^10.2.4"
+        "minimatch": "^3.1.5"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1"
+        "@eslint/core": "^0.17.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
-      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@floating-ui/utils": {
@@ -3429,7 +3540,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.10.tgz",
       "integrity": "sha512-cHvGOk2ZEfbQt3LnGe0ZKd/ETs9gsUpkW66DCO+GSjMZhpdKU4XsuIr7zJ/B/2XaN8ihxuzHfYAR4zPtCN4RYg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "@mui/core-downloads-tracker": "^7.3.10",
@@ -3540,7 +3650,6 @@
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.10.tgz",
       "integrity": "sha512-/sfPpdpJaQn7BSF+avjIdHSYmxHp0UOBYNxSG9QGKfMOD6sLANCpRPCnanq1Pe0lFf0NHkO2iUk0TNzdWC1USQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "@mui/private-theming": "^7.3.10",
@@ -4628,7 +4737,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "node-addon-api": "^8.3.0",
         "node-gyp-build": "^4.8.4"
@@ -4791,13 +4899,6 @@
       "dependencies": {
         "@types/ms": "*"
       }
-    },
-    "node_modules/@types/esrecurse": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -5025,7 +5126,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5180,7 +5280,6 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -5664,7 +5763,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6197,7 +6295,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-19.1.0-rc.3.tgz",
       "integrity": "sha512-mjRn69WuTz4adL0bXGx8Rsyk1086zFJeKmes6aK0xPuK3aaXmDJdLHqwKKMrpm6KAI1MCoUK72d2VeqQbu8YIA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -6343,7 +6440,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6599,7 +6695,6 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -7543,31 +7638,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
-      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
-        "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^9.1.2",
-        "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.2.0",
-        "esquery": "^1.7.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -7577,7 +7674,8 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -7585,7 +7683,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -7951,19 +8049,17 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@types/esrecurse": "^4.3.1",
-        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -7977,6 +8073,37 @@
       "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -8015,6 +8142,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/eslint/node_modules/p-locate": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
@@ -8032,18 +8172,31 @@
       }
     },
     "node_modules/espree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.16.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -9282,7 +9435,6 @@
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
       "integrity": "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10056,7 +10208,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -10923,6 +11074,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -10974,7 +11132,6 @@
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
       "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11029,7 +11186,6 @@
       "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.7.1.tgz",
       "integrity": "sha512-lgL7XpIwsgICiL82ITplfS7IGwrB1OJIw/pCvprDp2dhmSSEBgmPzYRvwYYYvJGJD7fxUv1Tvpih4nZ6VrLuaA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -12758,7 +12914,6 @@
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -12807,7 +12962,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12852,7 +13006,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -13037,8 +13190,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-immutable": {
       "version": "4.0.0",
@@ -14524,7 +14676,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14624,7 +14775,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.8.0"
@@ -14931,7 +15081,6 @@
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15793,7 +15942,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web_ui/frontend/package.json
+++ b/web_ui/frontend/package.json
@@ -66,7 +66,7 @@
     "@types/semver": "^7.7.0",
     "@types/swagger-ui-react": "^4.18.3",
     "babel-jest": "^29.7.0",
-    "eslint": "^10",
+    "eslint": "^9",
     "eslint-config-next": "^16",
     "eslint-config-prettier": "^10",
     "if": "^2.0.0",


### PR DESCRIPTION
Origins with log exports enabled auto-register a `/pelican/logging/{ServerID}` namespace on startup; the registry can auto-approve it when the origin is already approved

Logging namespace registrations are tagged in the registry DB so they can be identified without parsing the prefix string

The name filter on the registry servers API now does an exact name lookup

Closes #3430 