### PR TITLE
Allow Clients, Caches and Origins to declare their own locations

### DIFF
--- a/cache/advertise.go
+++ b/cache/advertise.go
@@ -68,6 +68,21 @@ func (server *CacheServer) CreateAdvertisement(name, id, originUrl, originWebUrl
 	}
 	ad.Initialize(name)
 
+	if geoStr := param.GeoLocation.GetString(); geoStr != "" {
+		if lat, long, err := utils.ParseCoordinateStr(geoStr); err == nil {
+			coord := server_structs.Coordinate{
+				Lat:    lat,
+				Long:   long,
+				Source: server_structs.CoordinateSourceDeclared,
+				// The service has given us a coordinate, so we assume no accuracy radius
+				AccuracyRadius: 0,
+			}
+			ad.Coordinate = &coord
+		} else {
+			log.Warningf("Ignoring invalid %s value %q: %v", param.GeoLocation.GetName(), geoStr, err)
+		}
+	}
+
 	// Extract prefixes from namespace ads for broker configuration
 	var prefixes []string
 	for _, nsAd := range nsAds {

--- a/client/director.go
+++ b/client/director.go
@@ -121,6 +121,10 @@ func queryDirector(ctx context.Context, verb string, pUrl *pelican_url.PelicanUR
 		// cannot.
 		req.Header.Set("User-Agent", getUserAgent(""))
 
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+
 		// If the client has a declared GeoLocation, send it as X-Pelican-Coordinate
 		// so the director can use it for client-server matchmaking.
 		if geoStr := param.GeoLocation.GetString(); geoStr != "" {

--- a/client/director.go
+++ b/client/director.go
@@ -21,6 +21,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"math/rand"
 	"net"
@@ -120,8 +121,15 @@ func queryDirector(ctx context.Context, verb string, pUrl *pelican_url.PelicanUR
 		// cannot.
 		req.Header.Set("User-Agent", getUserAgent(""))
 
-		if token != "" {
-			req.Header.Set("Authorization", "Bearer "+token)
+		// If the client has a declared GeoLocation, send it as X-Pelican-Coordinate
+		// so the director can use it for client-server matchmaking.
+		if geoStr := param.GeoLocation.GetString(); geoStr != "" {
+			if lat, long, geoErr := utils.ParseCoordinateStr(geoStr); geoErr == nil {
+				req.Header.Set(string(server_structs.XPelicanCoordinateHeaderName),
+					fmt.Sprintf("lat=%g,long=%g", lat, long))
+			} else {
+				log.Warningf("Ignoring invalid %s value %q: %v", param.GeoLocation.GetName(), geoStr, geoErr)
+			}
 		}
 
 		forceDebug, _ := ctx.Value(directorDebugCtxKey{}).(bool)
@@ -352,7 +360,7 @@ func getDirectorInfoForPath(ctx context.Context, pUrl *pelican_url.PelicanURL, h
 // servers.
 func ParseDirectorInfo(dirResp *http.Response) (server_structs.DirectorResponse, error) {
 	var xPelNs server_structs.XPelNs
-	if err := (&xPelNs).ParseRawResponse(dirResp); err != nil {
+	if err := (&xPelNs).ParseRawHeader(&dirResp.Header); err != nil {
 		// Only suppress the specific "header not present" error.  If the header
 		// exists but is malformed, return an error so the caller knows something
 		// is wrong rather than silently continuing with default values.
@@ -369,12 +377,12 @@ func ParseDirectorInfo(dirResp *http.Response) (server_structs.DirectorResponse,
 	}
 
 	var xPelAuth server_structs.XPelAuth
-	if err := (&xPelAuth).ParseRawResponse(dirResp); err != nil {
+	if err := (&xPelAuth).ParseRawHeader(&dirResp.Header); err != nil {
 		return server_structs.DirectorResponse{}, errors.Wrapf(err, "failed to parse %s header", xPelAuth.GetName())
 	}
 
 	var xPelTokGen server_structs.XPelTokGen
-	if err := (&xPelTokGen).ParseRawResponse(dirResp); err != nil {
+	if err := (&xPelTokGen).ParseRawHeader(&dirResp.Header); err != nil {
 		return server_structs.DirectorResponse{}, errors.Wrapf(err, "failed to parse %s header", xPelTokGen.GetName())
 	}
 

--- a/client/director_test.go
+++ b/client/director_test.go
@@ -531,3 +531,57 @@ func TestDirectorTimeout(t *testing.T) {
 	// Verify the error message contains "i/o timeout"
 	assert.Contains(t, err.Error(), "i/o timeout")
 }
+
+// TestQueryDirectorGeoLocationHeader verifies that when GeoLocation is configured,
+// queryDirector attaches the X-Pelican-Coordinate header with the correct value, and
+// that no header is sent when GeoLocation is empty or invalid.
+func TestQueryDirectorGeoLocationHeader(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+
+	test_utils.InitClient(t, map[param.Param]any{
+		param.Client_DirectorRetries: 1,
+	})
+
+	var receivedCoordHeader string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedCoordHeader = r.Header.Get("X-Pelican-Coordinate")
+		http.Redirect(w, r, "http://cache.example.com:8443/foo/bar", http.StatusTemporaryRedirect)
+	}))
+	defer ts.Close()
+
+	pUrl := &pelican_url.PelicanURL{
+		FedInfo: pelican_url.FederationDiscovery{DirectorEndpoint: ts.URL},
+		Path:    "/foo/bar",
+	}
+
+	t.Run("HeaderSentWhenGeoLocationSet", func(t *testing.T) {
+		receivedCoordHeader = ""
+		require.NoError(t, param.GeoLocation.Set("43.0739,-89.3848"))
+		t.Cleanup(func() { require.NoError(t, param.GeoLocation.Set("")) })
+
+		_, _, err := queryDirector(context.Background(), http.MethodGet, pUrl, "", false)
+		require.NoError(t, err)
+		assert.Equal(t, "lat=43.0739,long=-89.3848", receivedCoordHeader)
+	})
+
+	t.Run("HeaderNotSentWhenGeoLocationEmpty", func(t *testing.T) {
+		receivedCoordHeader = "sentinel"
+		require.NoError(t, param.GeoLocation.Set(""))
+
+		_, _, err := queryDirector(context.Background(), http.MethodGet, pUrl, "", false)
+		require.NoError(t, err)
+		assert.Empty(t, receivedCoordHeader, "X-Pelican-Coordinate should not be sent when GeoLocation is empty")
+	})
+
+	t.Run("HeaderNotSentWhenGeoLocationInvalid", func(t *testing.T) {
+		receivedCoordHeader = "sentinel"
+		require.NoError(t, param.GeoLocation.Set("not-valid"))
+		t.Cleanup(func() { require.NoError(t, param.GeoLocation.Set("")) })
+
+		_, _, err := queryDirector(context.Background(), http.MethodGet, pUrl, "", false)
+		require.NoError(t, err)
+		assert.Empty(t, receivedCoordHeader, "X-Pelican-Coordinate should not be sent when GeoLocation is invalid")
+	})
+}

--- a/director/director.go
+++ b/director/director.go
@@ -1498,6 +1498,10 @@ func finishRegisterServeAd(engineCtx context.Context, ctx *gin.Context, adV2 *se
 		Downtimes:           adV2.Downtimes,
 		Status:              adV2.Status,
 	}
+	// If the server declared its own geolocation via GeoLocation config, honor it.
+	if adV2.Coordinate != nil {
+		sAd.Coordinate = *adV2.Coordinate
+	}
 	sAd.CopyFrom(adV2)
 
 	recordAd(engineCtx, sAd, &adV2.Namespaces)

--- a/director/sort_algorithms.go
+++ b/director/sort_algorithms.go
@@ -363,7 +363,7 @@ func (rs *DistanceSort) String() string {
 }
 func (ds *DistanceSort) Sort(sAds []server_structs.ServerAd, sCtx SortContext) ([]server_structs.ServerAd, error) {
 	// getClientCoordinate is guaranteed to give us _some_ coordinate, even if it's random.
-	clientCoord := getClientCoordinate(sCtx.Ctx, sCtx.ClientAddr)
+	clientCoord := getClientCoordinate(sCtx.Ctx, sCtx.ClientAddr, sCtx.GinCtx)
 	sCtx.RedirectInfo.ClientInfo.Coordinate = clientCoord
 
 	dWeights := computeWeights(sAds, func(_ int, ad server_structs.ServerAd) (float64, bool) {
@@ -396,7 +396,7 @@ func (rs *AdaptiveSort) String() string {
 	return string(server_structs.AdaptiveType)
 }
 func (as *AdaptiveSort) Sort(sAds []server_structs.ServerAd, sCtx SortContext) ([]server_structs.ServerAd, error) {
-	clientCoord := getClientCoordinate(sCtx.Ctx, sCtx.ClientAddr)
+	clientCoord := getClientCoordinate(sCtx.Ctx, sCtx.ClientAddr, sCtx.GinCtx)
 	sCtx.RedirectInfo.ClientInfo.Coordinate = clientCoord
 
 	// Helper function to template computing weights and storing them

--- a/director/sort_utilities.go
+++ b/director/sort_utilities.go
@@ -343,6 +343,13 @@ func getProjectLabel(ctx context.Context) (project string) {
 // 1. Configured GeoIP Overrides
 // 2. MaxMind Lookups
 func getServerCoordinate(sAd server_structs.ServerAd) (coord server_structs.Coordinate, err error) {
+	// If the server declared its own coordinate via GeoLocation config (propagated
+	// through the ad), use it at highest precedence — before GeoIP overrides or MaxMind.
+	if sAd.Coordinate.Source == server_structs.CoordinateSourceDeclared {
+		log.Tracef("Using server-declared coordinate for %s (lat=%f long=%f)", sAd.Name, sAd.Coordinate.Lat, sAd.Coordinate.Long)
+		return sAd.Coordinate, nil
+	}
+
 	// Get the IP from the server ad's hostname
 	hostname := sAd.URL.Hostname()
 	addr, err := getIPFromHostname(hostname)

--- a/director/sort_utilities.go
+++ b/director/sort_utilities.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
@@ -383,11 +384,23 @@ func getServerCoordinate(sAd server_structs.ServerAd) (coord server_structs.Coor
 // so any GeoIP/MaxMind errors generated during the lookup process are handled internally.
 //
 // Coordinates are determined in order of precedence:
-// 1. Configured GeoIP Overrides
-// 2. MaxMind Lookups
-// 3. Random, Geo-Bounded Assignments (when (1), (2) are not available)
-func getClientCoordinate(ctx context.Context, addr netip.Addr) (coord server_structs.Coordinate) {
-	// Check for overrides
+// 1. Client-provided override (from X-Pelican-Coordinate header)
+// 2. Configured GeoIP Overrides
+// 3. MaxMind Lookups
+// 4. Random, Geo-Bounded Assignments (when (1), (2) are not available)
+func getClientCoordinate(ctx context.Context, addr netip.Addr, ginCtx *gin.Context) (coord server_structs.Coordinate) {
+	// Check for a client-provided coordinate in the X-Pelican-Coordinate header.
+	// This takes highest precedence — if present and well-formed, use it immediately.
+	if ginCtx != nil {
+		var pelicanCoord server_structs.XPelCoordinate
+		if err := pelicanCoord.ParseRawHeader(&ginCtx.Request.Header); err == nil {
+			coord = pelicanCoord.Coordinate
+			log.Tracef("Using client-provided coordinate from %s header: lat=%f long=%f",
+				pelicanCoord.GetName(), coord.Lat, coord.Long)
+			return
+		}
+	}
+
 	if overrideCoord, exists := checkOverrides(addr); exists {
 		// All coordinate provenance fields should have been handled on GeoOverride unmarshal or cache insertion
 		coord = overrideCoord

--- a/director/sort_utilities.go
+++ b/director/sort_utilities.go
@@ -34,6 +34,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
@@ -411,6 +412,13 @@ func resolveServerGeoIPCoordinate(sAd server_structs.ServerAd) (coord server_str
 //
 // TODO: surface this discrepancy in the director web UI as a follow-up (see issue-2709 next step).
 func logServerLocationDiscrepancy(sAd server_structs.ServerAd) {
+	// Until we have a better way to surface these discrepancies, we'll only do the extra work of getting
+	// GeoIP info via reverse DNS + MaxMind lookup if we intend to log it
+	logLevel := config.GetEffectiveLogLevel()
+	if logLevel < log.DebugLevel {
+		return
+	}
+
 	declared := sAd.Coordinate
 
 	geo, err := resolveServerGeoIPCoordinate(sAd)

--- a/director/sort_utilities.go
+++ b/director/sort_utilities.go
@@ -80,6 +80,11 @@ var (
 
 const (
 	earthRadiusToMilesFactor = 3960
+	earthRadiusToKmFactor    = 6371.0 // mean Earth radius in km, to turn angular distance into km
+
+	// Minimum distance (km) between a server's declared coordinate and its GeoIP-resolved
+	// coordinate before the director logs a location discrepancy.
+	locationDiscrepancyThresholdKm = 100.0
 
 	// A rough lat/long bounding box for the contiguous US. We might eventually make this box
 	// a configurable value, but for now it's hardcoded
@@ -347,9 +352,23 @@ func getServerCoordinate(sAd server_structs.ServerAd) (coord server_structs.Coor
 	// through the ad), use it at highest precedence — before GeoIP overrides or MaxMind.
 	if sAd.Coordinate.Source == server_structs.CoordinateSourceDeclared {
 		log.Tracef("Using server-declared coordinate for %s (lat=%f long=%f)", sAd.Name, sAd.Coordinate.Lat, sAd.Coordinate.Long)
+		// The declared coordinate bypasses GeoIP, so the director never gets to "check"
+		// where the server actually appears to be. Compute what GeoIP would have resolved
+		// and log if the declared location is suspiciously far from it.
+		logServerLocationDiscrepancy(sAd)
 		return sAd.Coordinate, nil
 	}
 
+	return resolveServerGeoIPCoordinate(sAd)
+}
+
+// resolveServerGeoIPCoordinate resolves a server's coordinate purely from its hostname via
+// DNS + GeoIP (configured overrides, then MaxMind), ignoring any server-declared coordinate.
+//
+// Coordinates are determined in order of precedence:
+// 1. Configured GeoIP Overrides
+// 2. MaxMind Lookups
+func resolveServerGeoIPCoordinate(sAd server_structs.ServerAd) (coord server_structs.Coordinate, err error) {
 	// Get the IP from the server ad's hostname
 	hostname := sAd.URL.Hostname()
 	addr, err := getIPFromHostname(hostname)
@@ -383,6 +402,43 @@ func getServerCoordinate(sAd server_structs.ServerAd) (coord server_structs.Coor
 	}
 
 	return
+}
+
+// logServerLocationDiscrepancy compares a server-declared coordinate against the coordinate the
+// director would have resolved from GeoIP, and logs (at debug level) when they differ by more
+// than locationDiscrepancyThresholdKm. This is purely observational -- it does not change the
+// coordinate used for sorting/redirects.
+//
+// TODO: surface this discrepancy in the director web UI as a follow-up (see issue-2709 next step).
+func logServerLocationDiscrepancy(sAd server_structs.ServerAd) {
+	declared := sAd.Coordinate
+
+	geo, err := resolveServerGeoIPCoordinate(sAd)
+	if err != nil {
+		// No GeoIP fix available (DNS failure, no MaxMind DB, IP not in DB, etc.), so there's
+		// nothing to compare the declared coordinate against.
+		log.Debugf("Cannot compute location discrepancy for declared server %s: %v", sAd.Name, err)
+		return
+	}
+
+	distKm := angularDistanceOnSphere(declared.Lat, declared.Long, geo.Lat, geo.Long) * earthRadiusToKmFactor
+	if distKm <= locationDiscrepancyThresholdKm {
+		return
+	}
+
+	log.WithFields(log.Fields{
+		"server_name":       sAd.Name,
+		"server_type":       string(sAd.Type),
+		"server_url":        sAd.URL.String(),
+		"declared_lat":      declared.Lat,
+		"declared_long":     declared.Long,
+		"geoip_lat":         geo.Lat,
+		"geoip_long":        geo.Long,
+		"geoip_source":      geo.Source,
+		"geoip_accuracy_km": geo.AccuracyRadius,
+		"discrepancy_km":    math.Round(distKm),
+	}).Debugf("Server-declared location for %q differs from its GeoIP-resolved location by %.0f km (threshold %.0f km)",
+		sAd.Name, distKm, locationDiscrepancyThresholdKm)
 }
 
 // Given a client IP address, retrieve the associated geolocation coordinate

--- a/director/sort_utilities_test.go
+++ b/director/sort_utilities_test.go
@@ -836,3 +836,22 @@ func TestGetClientCoordinateFromHeader(t *testing.T) {
 	})
 }
 
+// TestGetServerCoordinateDeclared verifies that a server ad with a pre-populated
+// Coordinate (Source == CoordinateSourceDeclared) is used without any GeoIP lookup.
+func TestGetServerCoordinateDeclared(t *testing.T) {
+	// No MaxMind or override stubs needed — declared coordinate must win outright.
+	sAd := server_structs.ServerAd{URL: mustUrl("cache.example.com")}
+	sAd.Initialize("declared-cache")
+	sAd.Coordinate = server_structs.Coordinate{
+		Lat:    43.0739,
+		Long:   -89.3848,
+		Source: server_structs.CoordinateSourceDeclared,
+	}
+
+	coord, err := getServerCoordinate(sAd)
+	assert.NoError(t, err)
+	assert.Equal(t, server_structs.CoordinateSource(server_structs.CoordinateSourceDeclared), coord.Source)
+	assert.InDelta(t, 43.0739, coord.Lat, 1e-9)
+	assert.InDelta(t, -89.3848, coord.Long, 1e-9)
+	assert.Equal(t, uint16(0), coord.AccuracyRadius)
+}

--- a/director/sort_utilities_test.go
+++ b/director/sort_utilities_test.go
@@ -23,12 +23,15 @@ import (
 	_ "embed"
 	"math"
 	"math/rand"
+	"net/http"
+	"net/http/httptest"
 	"net/netip"
 	"net/url"
 	"strings"
 	"sync"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -766,7 +769,7 @@ func TestGetClientCoordinate(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			coord := getClientCoordinate(ctx, tc.addr)
+				coord := getClientCoordinate(ctx, tc.addr, nil)
 			assert.Equal(t, tc.expectedCoord.Source, coord.Source)
 			if tc.expectedCoord.Source != server_structs.CoordinateSourceRandom {
 				// For non-random sources, check full equality
@@ -781,3 +784,55 @@ func TestGetClientCoordinate(t *testing.T) {
 		})
 	}
 }
+
+// makeGinCtxWithHeader builds a minimal gin.Context whose Request carries the given header value.
+func makeGinCtxWithHeader(headerName, headerValue string) *gin.Context {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(headerName, headerValue)
+	c.Request = req
+	return c
+}
+
+// TestGetClientCoordinateFromHeader verifies that a well-formed X-Pelican-Coordinate header
+// takes highest precedence over all other coordinate sources.
+func TestGetClientCoordinateFromHeader(t *testing.T) {
+	setupGetIPStub(t)
+	setupGetMaxMindStub(t)
+	setupOverrideCache(t)
+	setUpRandAssignmentCache(t)
+
+	ctx := context.Background()
+
+	t.Run("ValidHeaderTakesPrecedenceOverMaxMind", func(t *testing.T) {
+		ginCtx := makeGinCtxWithHeader("X-Pelican-Coordinate", "lat=43.0739,long=-89.3848")
+		// Use an IP that would normally resolve via MaxMind.
+		coord := getClientCoordinate(ctx, ipInMaxMindSmallRadius, ginCtx)
+		assert.Equal(t, server_structs.CoordinateSource(server_structs.CoordinateSourceDeclared), coord.Source)
+		assert.InDelta(t, 43.0739, coord.Lat, 1e-9)
+		assert.InDelta(t, -89.3848, coord.Long, 1e-9)
+		assert.Equal(t, uint16(0), coord.AccuracyRadius)
+	})
+
+	t.Run("ValidHeaderTakesPrecedenceOverOverride", func(t *testing.T) {
+		ginCtx := makeGinCtxWithHeader("X-Pelican-Coordinate", "lat=10.0,long=20.0")
+		coord := getClientCoordinate(ctx, ipFromOverride, ginCtx)
+		assert.Equal(t, server_structs.CoordinateSource(server_structs.CoordinateSourceDeclared), coord.Source)
+		assert.InDelta(t, 10.0, coord.Lat, 1e-9)
+		assert.InDelta(t, 20.0, coord.Long, 1e-9)
+	})
+
+	t.Run("MalformedHeaderFallsThroughToNextSource", func(t *testing.T) {
+		ginCtx := makeGinCtxWithHeader("X-Pelican-Coordinate", "not-valid-at-all")
+		// The IP resolves fine via MaxMind, so we should get a MaxMind coordinate.
+		coord := getClientCoordinate(ctx, ipInMaxMindSmallRadius, ginCtx)
+		assert.Equal(t, server_structs.CoordinateSource(server_structs.CoordinateSourceMaxMind), coord.Source)
+	})
+
+	t.Run("NilGinCtxStillWorks", func(t *testing.T) {
+		coord := getClientCoordinate(ctx, ipInMaxMindSmallRadius, nil)
+		assert.Equal(t, server_structs.CoordinateSource(server_structs.CoordinateSourceMaxMind), coord.Source)
+	})
+}
+

--- a/director/sort_utilities_test.go
+++ b/director/sort_utilities_test.go
@@ -33,9 +33,12 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jellydator/ttlcache/v3"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
@@ -717,6 +720,78 @@ func TestGetServerCoordinate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// When a server declares its own coordinate, getServerCoordinate still returns the declared
+// value but should additionally compute the discrepancy versus what GeoIP would have resolved
+// and emit a debug log when that discrepancy exceeds locationDiscrepancyThresholdKm.
+func TestServerLocationDiscrepancy(t *testing.T) {
+	setupGetIPStub(t)
+	setupGetMaxMindStub(t)
+	setupOverrideCache(t)
+
+	// The discrepancy line is logged at debug level, so capture debug entries.
+	hook := test.NewGlobal()
+	origLevel := config.GetEffectiveLogLevel()
+	config.SetLogging(logrus.DebugLevel)
+	t.Cleanup(func() { config.SetLogging(origLevel) })
+
+	const discrepancyMsg = "differs from its GeoIP-resolved location"
+
+	// smallRadiusHostname resolves (via the stubbed MaxMind) to Madison, WI.
+	const madisonLat, madisonLong = 43.07296, -89.40831
+
+	declaredAd := func(name, hostname string, lat, long float64) server_structs.ServerAd {
+		ad := server_structs.ServerAd{URL: mustUrl(hostname)}
+		ad.Initialize(name)
+		ad.Coordinate = server_structs.Coordinate{
+			Lat:    lat,
+			Long:   long,
+			Source: server_structs.CoordinateSourceDeclared,
+		}
+		return ad
+	}
+
+	loggedDiscrepancy := func() bool {
+		for _, e := range hook.AllEntries() {
+			if strings.Contains(e.Message, discrepancyMsg) {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("large discrepancy is logged", func(t *testing.T) {
+		hook.Reset()
+		// Declared in NYC (~1200 km from the GeoIP-resolved Madison).
+		ad := declaredAd("declared-far", smallRadiusHostname, 40.7128, -74.0060)
+		coord, err := getServerCoordinate(ad)
+		assert.NoError(t, err)
+		// Behavior is unchanged: the declared coordinate is still what's returned.
+		assert.EqualValues(t, server_structs.CoordinateSourceDeclared, coord.Source)
+		assert.Equal(t, 40.7128, coord.Lat)
+		assert.True(t, loggedDiscrepancy(), "expected a discrepancy debug log for a far-off declared location")
+	})
+
+	t.Run("small discrepancy is silent", func(t *testing.T) {
+		hook.Reset()
+		// Declared only a few km from the GeoIP-resolved Madison location.
+		ad := declaredAd("declared-near", smallRadiusHostname, madisonLat+0.05, madisonLong+0.05)
+		_, err := getServerCoordinate(ad)
+		assert.NoError(t, err)
+		assert.False(t, loggedDiscrepancy(), "did not expect a discrepancy log within the threshold")
+	})
+
+	t.Run("no log when GeoIP cannot resolve", func(t *testing.T) {
+		hook.Reset()
+		// notInMaxMindHostname resolves to an IP the stubbed MaxMind can't place, so there's
+		// no GeoIP coordinate to compare against.
+		ad := declaredAd("declared-nogeoip", notInMaxMindHostname, 40.7128, -74.0060)
+		coord, err := getServerCoordinate(ad)
+		assert.NoError(t, err)
+		assert.EqualValues(t, server_structs.CoordinateSourceDeclared, coord.Source)
+		assert.False(t, loggedDiscrepancy(), "should not log a discrepancy when GeoIP can't resolve a coordinate")
+	})
 }
 
 func TestGetClientCoordinate(t *testing.T) {

--- a/director/sort_utilities_test.go
+++ b/director/sort_utilities_test.go
@@ -769,7 +769,7 @@ func TestGetClientCoordinate(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-				coord := getClientCoordinate(ctx, tc.addr, nil)
+			coord := getClientCoordinate(ctx, tc.addr, nil)
 			assert.Equal(t, tc.expectedCoord.Source, coord.Source)
 			if tc.expectedCoord.Source != server_structs.CoordinateSourceRandom {
 				// For non-random sources, check full equality

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+# Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you
 # may not use this file except in compliance with the License.  You may
@@ -53,6 +53,20 @@ description: |+
 type: filename
 default: ""
 components: ["cache", "director", "origin", "registry"]
+---
+name: GeoLocation
+description: |+
+  A comma-separated string used to configure the lat/lon coordinates of all services that read from the configuration file.
+  When set, this value is used to declare a location to the federation central services, which affects client-server matchmaking decisions and GeoIP-based features.
+  The format of the string should be "lat,lon" where lat and lon are decimal values representing the latitude and longitude, respectively.
+  For example, `GeoLocation: "43.0739,-89.3848"` would indicate a location in Madison, WI.
+  In general, lat/lon coordinates should be restricted to at most 4 decimal places, which are sufficient to provide accuracy to within about 10 meters.
+
+  This provides an alternative to configuring GeoIP overrides for specific IP addresses and is intended for use in environments where GeoIP information is not available or not accurate.
+  When an admin/user-provided geolocation comes from an IP address that also has a configured GeoIP override, the admin/user-provided geolocation will take precedence.
+type: string
+default: ""
+components: ["cache", "client", "origin"]
 ---
 name: Debug
 description: |+

--- a/origin/advertise.go
+++ b/origin/advertise.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/token"
+	"github.com/pelicanplatform/pelican/utils"
 )
 
 type (
@@ -223,6 +224,21 @@ func (server *OriginServer) CreateAdvertisement(name, id, originUrlStr, originWe
 		Downtimes:           downtimes,
 	}
 	ad.Initialize(name)
+
+	if geoStr := param.GeoLocation.GetString(); geoStr != "" {
+		if lat, long, err := utils.ParseCoordinateStr(geoStr); err == nil {
+			coord := server_structs.Coordinate{
+				Lat:    lat,
+				Long:   long,
+				Source: server_structs.CoordinateSourceDeclared,
+				// The service has given us a coordinate, so we assume no accuracy radius
+				AccuracyRadius: 0,
+			}
+			ad.Coordinate = &coord
+		} else {
+			log.Warningf("Ignoring invalid %s value %q: %v", param.GeoLocation.GetName(), geoStr, err)
+		}
+	}
 
 	if len(prefixes) == 0 {
 		if isGlobusBackend {

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -210,6 +210,7 @@ var runtimeConfigurableMap = map[string]bool{
 	"Federation.TopologyReloadInterval": false,
 	"Federation.TopologyUrl": false,
 	"GeoIPOverrides": false,
+	"GeoLocation": false,
 	"Issuer.AccessTokenLifetime": false,
 	"Issuer.AuthenticationSource": false,
 	"Issuer.AuthorizationCodeLifetime": false,
@@ -590,6 +591,7 @@ var stringAccessors = map[string]func(*Config) string{
 	"Federation.TopologyDowntimeUrl": func(c *Config) string { return c.Federation.TopologyDowntimeUrl },
 	"Federation.TopologyNamespaceUrl": func(c *Config) string { return c.Federation.TopologyNamespaceUrl },
 	"Federation.TopologyUrl": func(c *Config) string { return c.Federation.TopologyUrl },
+	"GeoLocation": func(c *Config) string { return c.GeoLocation },
 	"IssuerKey": func(c *Config) string { return c.IssuerKey },
 	"IssuerKeysDirectory": func(c *Config) string { return c.IssuerKeysDirectory },
 	"Issuer.AuthenticationSource": func(c *Config) string { return c.Issuer.AuthenticationSource },
@@ -1337,6 +1339,7 @@ var allParameterNames = []string{
 	"Federation.TopologyReloadInterval",
 	"Federation.TopologyUrl",
 	"GeoIPOverrides",
+	"GeoLocation",
 	"Issuer.AccessTokenLifetime",
 	"Issuer.AuthenticationSource",
 	"Issuer.AuthorizationCodeLifetime",
@@ -1690,6 +1693,7 @@ var (
 	Federation_TopologyDowntimeUrl = StringParam{"Federation.TopologyDowntimeUrl"}
 	Federation_TopologyNamespaceUrl = StringParam{"Federation.TopologyNamespaceUrl"}
 	Federation_TopologyUrl = StringParam{"Federation.TopologyUrl"}
+	GeoLocation = StringParam{"GeoLocation"}
 	IssuerKey = StringParam{"IssuerKey"}
 	IssuerKeysDirectory = StringParam{"IssuerKeysDirectory"}
 	Issuer_AuthenticationSource = StringParam{"Issuer.AuthenticationSource"}
@@ -2152,6 +2156,7 @@ func init() {
 		"Federation.TopologyDowntimeUrl": Federation_TopologyDowntimeUrl,
 		"Federation.TopologyNamespaceUrl": Federation_TopologyNamespaceUrl,
 		"Federation.TopologyUrl": Federation_TopologyUrl,
+		"GeoLocation": GeoLocation,
 		"IssuerKey": IssuerKey,
 		"IssuerKeysDirectory": IssuerKeysDirectory,
 		"Issuer.AuthenticationSource": Issuer_AuthenticationSource,

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -150,6 +150,7 @@ type Config struct {
 		TopologyUrl string `mapstructure:"topologyurl" yaml:"TopologyUrl"`
 	} `mapstructure:"federation" yaml:"Federation"`
 	GeoIPOverrides any `mapstructure:"geoipoverrides" yaml:"GeoIPOverrides"`
+	GeoLocation string `mapstructure:"geolocation" yaml:"GeoLocation"`
 	Issuer struct {
 		AccessTokenLifetime time.Duration `mapstructure:"accesstokenlifetime" yaml:"AccessTokenLifetime"`
 		AuthenticationSource string `mapstructure:"authenticationsource" yaml:"AuthenticationSource"`
@@ -635,6 +636,7 @@ type configWithType struct {
 		TopologyUrl struct { Type string; Value string }
 	}
 	GeoIPOverrides struct { Type string; Value any }
+	GeoLocation struct { Type string; Value string }
 	Issuer struct {
 		AccessTokenLifetime struct { Type string; Value time.Duration }
 		AuthenticationSource struct { Type string; Value string }

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -227,7 +227,7 @@ type (
 	}
 
 	XPelHeaderName string
-	XPelHeader interface {
+	XPelHeader     interface {
 		GetName() string
 		ParseRawHeader(*http.Header) error
 	}
@@ -392,10 +392,10 @@ func (x *XPelCoordinate) ParseRawHeader(header *http.Header) error {
 func (x XPelNs) GetName() string {
 	return string(XPelicanNamespaceHeaderName)
 }
-func (x *XPelNs)ParseRawHeader(header *http.Header) error {
+func (x *XPelNs) ParseRawHeader(header *http.Header) error {
 	raw := header.Values(x.GetName())
 	if len(raw) == 0 {
-		return errors.Errorf("No %s header found.", x.GetName())
+		return errors.Errorf("no %s header found.", x.GetName())
 	}
 	keyDict := utils.HeaderParser(raw[0])
 	x.Namespace = keyDict["namespace"]

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -222,9 +222,17 @@ type (
 		AuthorizationEndpoint string   `json:"authorization_endpoint,omitempty"`
 	}
 
+	XPelHeaderName string
 	XPelHeader interface {
 		GetName() string
-		ParseRawHeader(*http.Response) error
+		ParseRawHeader(*http.Header) error
+	}
+
+	// A coordinate override supplied by Clients in the X-Pelican-Coordinate header.
+	// This is used when Clients want to provide their own geolocation information to the Director
+	// (e.g. for testing, or if they have more accurate information than MaxMind).
+	XPelCoordinate struct {
+		Coordinate Coordinate
 	}
 
 	XPelAuth struct {
@@ -306,6 +314,7 @@ const (
 	CoordinateSourceOverride = "override"
 	CoordinateSourceRandom   = "random"
 	CoordinateSourceMaxMind  = "maxmind"
+	CoordinateSourceDeclared = "declared"
 )
 
 const (
@@ -324,11 +333,63 @@ const (
 // We chose -1 to avoid the default value (0) of the int64 type
 const IndefiniteEndTime int64 = -1
 
-func (x XPelNs) GetName() string {
-	return "X-Pelican-Namespace"
+const (
+	XPelicanCoordinateHeaderName      XPelHeaderName = "X-Pelican-Coordinate"
+	XPelicanNamespaceHeaderName       XPelHeaderName = "X-Pelican-Namespace"
+	XPelicanAuthHeaderName            XPelHeaderName = "X-Pelican-Authorization"
+	XPelicanTokenGenerationHeaderName XPelHeaderName = "X-Pelican-Token-Generation"
+)
+
+func (x XPelCoordinate) GetName() string {
+	return string(XPelicanCoordinateHeaderName)
 }
-func (x *XPelNs) ParseRawResponse(resp *http.Response) error {
-	raw := resp.Header.Values(x.GetName())
+func (x *XPelCoordinate) ParseRawHeader(header *http.Header) error {
+	raw := header.Values(x.GetName())
+	if len(raw) == 0 {
+		return errors.Errorf("no %s header found.", x.GetName())
+	}
+
+	// Assume there's only one value here.
+	keyDict := utils.HeaderParser(raw[0])
+
+	latStr, exists := keyDict["lat"]
+	if !exists {
+		return errors.Errorf("no latitude found in %s header", x.GetName())
+	}
+
+	longStr, exists := keyDict["long"]
+	if !exists {
+		return errors.Errorf("no longitude found in %s header", x.GetName())
+	}
+
+	lat, err := strconv.ParseFloat(latStr, 64)
+	if err != nil {
+		return errors.Errorf("failed to parse latitude %s from %s header: %v", latStr, x.GetName(), err)
+	}
+	long, err := strconv.ParseFloat(longStr, 64)
+	if err != nil {
+		return errors.Errorf("failed to parse longitude %s from %s header: %v", longStr, x.GetName(), err)
+	}
+
+	if err := utils.ValidateLatLong(lat, long); err != nil {
+		return errors.Errorf("invalid coordinates from %s header: %v", x.GetName(), err)
+	}
+
+	x.Coordinate.Lat = lat
+	x.Coordinate.Long = long
+	x.Coordinate.Source = CoordinateSourceDeclared
+	// When the the client or server declares its own coordinate, we assume they've
+	// provided exactly the coordinate they want.
+	x.Coordinate.AccuracyRadius = 0
+
+	return nil
+}
+
+func (x XPelNs) GetName() string {
+	return string(XPelicanNamespaceHeaderName)
+}
+func (x *XPelNs)ParseRawHeader(header *http.Header) error {
+	raw := header.Values(x.GetName())
 	if len(raw) == 0 {
 		return errors.Errorf("No %s header found.", x.GetName())
 	}
@@ -342,11 +403,11 @@ func (x *XPelNs) ParseRawResponse(resp *http.Response) error {
 }
 
 func (x XPelAuth) GetName() string {
-	return "X-Pelican-Authorization"
+	return string(XPelicanAuthHeaderName)
 }
-func (x *XPelAuth) ParseRawResponse(resp *http.Response) error {
+func (x *XPelAuth) ParseRawHeader(header *http.Header) error {
 	// If the director provides an auth header, raw will have an array of length 1.
-	raw := resp.Header.Values(x.GetName())
+	raw := header.Values(x.GetName())
 	if len(raw) > 0 {
 		x.Issuers = make([]*url.URL, 0)
 		// clean up the string and split it by commas to fetch each issuer. Can't use
@@ -357,7 +418,7 @@ func (x *XPelAuth) ParseRawResponse(resp *http.Response) error {
 			issuerUrlStr := strings.TrimPrefix(issuer, "issuer=")
 			issuerUrl, err := url.Parse(issuerUrlStr)
 			if err != nil {
-				return errors.Errorf("Failed to parse issuer URL %s from Director's %s header: %v", issuerUrlStr, x.GetName(), err)
+				return errors.Errorf("failed to parse issuer URL %s from Director's %s header: %v", issuerUrlStr, x.GetName(), err)
 			}
 			x.Issuers = append(x.Issuers, issuerUrl)
 		}
@@ -366,10 +427,10 @@ func (x *XPelAuth) ParseRawResponse(resp *http.Response) error {
 }
 
 func (x XPelTokGen) GetName() string {
-	return "X-Pelican-Token-Generation"
+	return string(XPelicanTokenGenerationHeaderName)
 }
-func (x *XPelTokGen) ParseRawResponse(resp *http.Response) error {
-	raw := resp.Header.Values(x.GetName())
+func (x *XPelTokGen) ParseRawHeader(header *http.Header) error {
+	raw := header.Values(x.GetName())
 	if len(raw) > 0 {
 		// Parse issuer, for now assuming a single value but eventually may be multiple
 		x.Issuers = make([]*url.URL, 0)

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -176,6 +176,10 @@ type (
 		BrokerURL      string `json:"broker-url,omitempty"`
 		DataURL        string `json:"data-url" binding:"required"`
 		WebURL         string `json:"web-url,omitempty"`
+		// Coordinate allows a server to declare its own geolocation, which takes
+		// highest priority over GeoIP overrides and MaxMind lookups on the director.
+		// Set this via the GeoLocation config parameter ("lat,lon" string).
+		Coordinate *Coordinate `json:"coordinate,omitempty"`
 		// TODO: Deprecate top level "Origin" caps -- each namespace should have its own caps that
 		// express what the origin is willing to do on the namespace's behalf. This helps us work
 		// around the lack of a concept for "globally-defined" namespaces.

--- a/server_structs/director_test.go
+++ b/server_structs/director_test.go
@@ -198,7 +198,7 @@ func TestXPelNsParsing(t *testing.T) {
 		h := http.Header{"X-Pelican-foo": {"bar"}}
 		err := xPelNs.ParseRawHeader(&h)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), fmt.Sprintf("No %s header found.", xPelNs.GetName()))
+		assert.Contains(t, err.Error(), fmt.Sprintf("o %s header found.", xPelNs.GetName()))
 	})
 }
 
@@ -279,7 +279,7 @@ func TestXPelCoordinateParsing(t *testing.T) {
 		h := http.Header{"X-Pelican-foo": {"bar"}}
 		err := xPelCoord.ParseRawHeader(&h)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), fmt.Sprintf("No %s header found.", xPelCoord.GetName()))
+		assert.Contains(t, err.Error(), fmt.Sprintf("no %s header found.", xPelCoord.GetName()))
 	})
 
 	t.Run("ParseMissingLat", func(t *testing.T) {

--- a/server_structs/director_test.go
+++ b/server_structs/director_test.go
@@ -175,11 +175,8 @@ func TestValidTokenStrategy(t *testing.T) {
 func TestXPelNsParsing(t *testing.T) {
 	t.Run("ParseValidRawResponse", func(t *testing.T) {
 		xPelNs := XPelNs{}
-		err := xPelNs.ParseRawResponse(&http.Response{
-			Header: map[string][]string{
-				"X-Pelican-Namespace": {"namespace=foo, require-token=true, collections-url=https://collections-url.org"},
-			},
-		})
+		h := http.Header{"X-Pelican-Namespace": {"namespace=foo, require-token=true, collections-url=https://collections-url.org"}}
+		err := xPelNs.ParseRawHeader(&h)
 		assert.NoError(t, err)
 		assert.Equal(t, "foo", xPelNs.Namespace)
 		assert.True(t, xPelNs.RequireToken)
@@ -188,11 +185,8 @@ func TestXPelNsParsing(t *testing.T) {
 
 	t.Run("ParseMissingCollectionsUrl", func(t *testing.T) { // Signifies origins that don't enable listings
 		xPelNs := XPelNs{}
-		err := xPelNs.ParseRawResponse(&http.Response{
-			Header: map[string][]string{
-				"X-Pelican-Namespace": {"namespace=foo, require-token=true"},
-			},
-		})
+		h := http.Header{"X-Pelican-Namespace": {"namespace=foo, require-token=true"}}
+		err := xPelNs.ParseRawHeader(&h)
 		assert.NoError(t, err)
 		assert.Equal(t, "foo", xPelNs.Namespace)
 		assert.True(t, xPelNs.RequireToken)
@@ -201,11 +195,8 @@ func TestXPelNsParsing(t *testing.T) {
 
 	t.Run("ParseMissingHeader", func(t *testing.T) {
 		xPelNs := XPelNs{}
-		err := xPelNs.ParseRawResponse(&http.Response{
-			Header: map[string][]string{
-				"X-Pelican-foo": {"bar"},
-			},
-		})
+		h := http.Header{"X-Pelican-foo": {"bar"}}
+		err := xPelNs.ParseRawHeader(&h)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), fmt.Sprintf("No %s header found.", xPelNs.GetName()))
 	})
@@ -214,11 +205,8 @@ func TestXPelNsParsing(t *testing.T) {
 func TestXPelAuthParsing(t *testing.T) {
 	t.Run("ParseValidRawResponse", func(t *testing.T) {
 		xPelAuth := XPelAuth{}
-		err := xPelAuth.ParseRawResponse(&http.Response{
-			Header: map[string][]string{
-				"X-Pelican-Authorization": {"issuer=https://issuer1.com, issuer=https://issuer2.com"},
-			},
-		})
+		h := http.Header{"X-Pelican-Authorization": {"issuer=https://issuer1.com, issuer=https://issuer2.com"}}
+		err := xPelAuth.ParseRawHeader(&h)
 		assert.NoError(t, err)
 		assert.Len(t, xPelAuth.Issuers, 2)
 		assert.Equal(t, "https://issuer1.com", xPelAuth.Issuers[0].String())
@@ -227,11 +215,8 @@ func TestXPelAuthParsing(t *testing.T) {
 
 	t.Run("ParseMissingHeader", func(t *testing.T) {
 		xPelAuth := XPelAuth{}
-		err := xPelAuth.ParseRawResponse(&http.Response{
-			Header: map[string][]string{
-				"X-Pelican-foo": {"foo"},
-			},
-		})
+		h := http.Header{"X-Pelican-foo": {"foo"}}
+		err := xPelAuth.ParseRawHeader(&h)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(xPelAuth.Issuers))
 	})
@@ -240,11 +225,8 @@ func TestXPelAuthParsing(t *testing.T) {
 func TestXPelTokGenParsing(t *testing.T) {
 	t.Run("ParseValidRawResponse", func(t *testing.T) {
 		xPelTokGen := XPelTokGen{}
-		err := xPelTokGen.ParseRawResponse(&http.Response{
-			Header: map[string][]string{
-				"X-Pelican-Token-Generation": {"strategy=OAuth2, max-scope-depth=3, issuer=https://issuer.com, base-path=/foo/bar"},
-			},
-		})
+		h := http.Header{"X-Pelican-Token-Generation": {"strategy=OAuth2, max-scope-depth=3, issuer=https://issuer.com, base-path=/foo/bar"}}
+		err := xPelTokGen.ParseRawHeader(&h)
 		assert.NoError(t, err)
 		assert.Equal(t, OAuthStrategy, xPelTokGen.Strategy)
 		assert.Equal(t, uint(3), xPelTokGen.MaxScopeDepth)
@@ -257,11 +239,8 @@ func TestXPelTokGenParsing(t *testing.T) {
 
 	t.Run("ParseMissingBasePath", func(t *testing.T) {
 		xPelTokGen := XPelTokGen{}
-		err := xPelTokGen.ParseRawResponse(&http.Response{
-			Header: map[string][]string{
-				"X-Pelican-Token-Generation": {"strategy=OAuth2, max-scope-depth=3, issuer=https://issuer.com"},
-			},
-		})
+		h := http.Header{"X-Pelican-Token-Generation": {"strategy=OAuth2, max-scope-depth=3, issuer=https://issuer.com"}}
+		err := xPelTokGen.ParseRawHeader(&h)
 		assert.NoError(t, err)
 		assert.Equal(t, OAuthStrategy, xPelTokGen.Strategy)
 		assert.Equal(t, uint(3), xPelTokGen.MaxScopeDepth)
@@ -273,16 +252,66 @@ func TestXPelTokGenParsing(t *testing.T) {
 
 	t.Run("ParseMissingHeader", func(t *testing.T) {
 		xPelTokGen := XPelTokGen{}
-		err := xPelTokGen.ParseRawResponse(&http.Response{
-			Header: map[string][]string{
-				"X-Pelican-foo": {"foo"},
-			},
-		})
+		h := http.Header{"X-Pelican-foo": {"foo"}}
+		err := xPelTokGen.ParseRawHeader(&h)
 		assert.NoError(t, err)
 		assert.Equal(t, StrategyType(""), xPelTokGen.Strategy)
 		assert.Equal(t, uint(0), xPelTokGen.MaxScopeDepth)
 		assert.Len(t, xPelTokGen.Issuers, 0)
 		assert.Len(t, xPelTokGen.BasePaths, 0)
+	})
+}
+
+func TestXPelCoordinateParsing(t *testing.T) {
+	t.Run("ParseValidCoordinate", func(t *testing.T) {
+		xPelCoord := XPelCoordinate{}
+		h := http.Header{"X-Pelican-Coordinate": {"lat=43.0739,long=-89.3848"}}
+		err := xPelCoord.ParseRawHeader(&h)
+		assert.NoError(t, err)
+		assert.InDelta(t, 43.0739, xPelCoord.Coordinate.Lat, 1e-9)
+		assert.InDelta(t, -89.3848, xPelCoord.Coordinate.Long, 1e-9)
+		assert.Equal(t, CoordinateSource(CoordinateSourceDeclared), xPelCoord.Coordinate.Source)
+		assert.Equal(t, uint16(0), xPelCoord.Coordinate.AccuracyRadius)
+	})
+
+	t.Run("ParseMissingHeader", func(t *testing.T) {
+		xPelCoord := XPelCoordinate{}
+		h := http.Header{"X-Pelican-foo": {"bar"}}
+		err := xPelCoord.ParseRawHeader(&h)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), fmt.Sprintf("No %s header found.", xPelCoord.GetName()))
+	})
+
+	t.Run("ParseMissingLat", func(t *testing.T) {
+		xPelCoord := XPelCoordinate{}
+		h := http.Header{"X-Pelican-Coordinate": {"long=-89.3848"}}
+		err := xPelCoord.ParseRawHeader(&h)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "latitude")
+	})
+
+	t.Run("ParseMissingLong", func(t *testing.T) {
+		xPelCoord := XPelCoordinate{}
+		h := http.Header{"X-Pelican-Coordinate": {"lat=43.0739"}}
+		err := xPelCoord.ParseRawHeader(&h)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "longitude")
+	})
+
+	t.Run("ParseInvalidLat", func(t *testing.T) {
+		xPelCoord := XPelCoordinate{}
+		h := http.Header{"X-Pelican-Coordinate": {"lat=not-a-number,long=-89.3848"}}
+		err := xPelCoord.ParseRawHeader(&h)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "latitude")
+	})
+
+	t.Run("ParseOutOfBoundsCoordinates", func(t *testing.T) {
+		xPelCoord := XPelCoordinate{}
+		h := http.Header{"X-Pelican-Coordinate": {"lat=91,long=0"}}
+		err := xPelCoord.ParseRawHeader(&h)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid coordinates")
 	})
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -317,3 +317,40 @@ func ParseBytes(sizeStr string) (uint64, error) {
 	}
 	return num, nil
 }
+
+// ParseGeoLocationString parses a "lat,lon" string (e.g. "43.0739,-89.3848") into
+// its component float64 values, validating the range via ValidateLatLong.
+func ParseCoordinateStr(s string) (lat, long float64, err error) {
+	parts := strings.SplitN(s, ",", 2)
+	if len(parts) != 2 {
+		return 0, 0, errors.Errorf("coordinate value %q is not in the expected \"lat,lon\" format", s)
+	}
+	lat, err = strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
+	if err != nil {
+		return 0, 0, errors.Errorf("failed to parse latitude from coordinate value %q: %v", s, err)
+	}
+	long, err = strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+	if err != nil {
+		return 0, 0, errors.Errorf("failed to parse longitude from coordinate value %q: %v", s, err)
+	}
+	if err = ValidateLatLong(lat, long); err != nil {
+		return 0, 0, errors.Errorf("invalid coordinates in value %q: %v", s, err)
+	}
+	return lat, long, nil
+}
+
+// Validate the contents of a lat/lon coordinate pair, returning an error if the coordinates are out of bounds
+func ValidateLatLong(lat, long float64) error {
+	// Only return an error after checking both components so that we can report all issues with the provided coordinates at once
+	var errStrings []string
+	if lat < -90 || lat > 90 {
+		errStrings = append(errStrings, fmt.Sprintf("latitude %f is out of bounds (must be between -90 and 90)", lat))
+	}
+	if long < -180 || long > 180 {
+		errStrings = append(errStrings, fmt.Sprintf("longitude %f is out of bounds (must be between -180 and 180)", long))
+	}
+	if len(errStrings) > 0 {
+		return errors.New(strings.Join(errStrings, "; "))
+	}
+	return nil
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -203,3 +203,68 @@ func TestValidateWatermark(t *testing.T) {
 		})
 	}
 }
+func TestValidateLatLong(t *testing.T) {
+	tests := []struct {
+		name    string
+		lat     float64
+		long    float64
+		wantErr bool
+		errMsg  string
+	}{
+		{"valid Madison WI", 43.0739, -89.3848, false, ""},
+		{"valid equator/prime meridian", 0, 0, false, ""},
+		{"valid extremes", 90, 180, false, ""},
+		{"valid negative extremes", -90, -180, false, ""},
+		{"lat too high", 91, 0, true, "latitude"},
+		{"lat too low", -91, 0, true, "latitude"},
+		{"long too high", 0, 181, true, "longitude"},
+		{"long too low", 0, -181, true, "longitude"},
+		{"both out of bounds", 100, 200, true, "latitude"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateLatLong(tc.lat, tc.long)
+			if tc.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestParseGeoLocationString(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantLat   float64
+		wantLong  float64
+		wantErr   bool
+		errSubstr string
+	}{
+		{"valid Madison WI", "43.0739,-89.3848", 43.0739, -89.3848, false, ""},
+		{"valid with spaces", " 43.0739 , -89.3848 ", 43.0739, -89.3848, false, ""},
+		{"valid equator", "0,0", 0, 0, false, ""},
+		{"valid poles", "90,180", 90, 180, false, ""},
+		{"missing comma", "43.0739", 0, 0, true, "expected \"lat,lon\" format"},
+		{"bad lat", "abc,-89.3848", 0, 0, true, "latitude"},
+		{"bad long", "43.0739,xyz", 0, 0, true, "longitude"},
+		{"lat out of bounds", "91,0", 0, 0, true, "invalid coordinates"},
+		{"long out of bounds", "0,181", 0, 0, true, "invalid coordinates"},
+		{"empty string", "", 0, 0, true, "expected \"lat,lon\" format"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lat, long, err := ParseCoordinateStr(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errSubstr)
+			} else {
+				assert.NoError(t, err)
+				assert.InDelta(t, tc.wantLat, lat, 1e-9)
+				assert.InDelta(t, tc.wantLong, long, 1e-9)
+			}
+		})
+	}
+}

--- a/utils/web_utils.go
+++ b/utils/web_utils.go
@@ -105,8 +105,12 @@ func HeaderParser(values string) (retMap map[string]string) {
 		// Remove any unwanted spaces
 		pair = strings.ReplaceAll(pair, " ", "")
 
-		// Break out key/value pairs and put in the map
-		split := strings.Split(pair, "=")
+		// Break out key/value pairs and put in the map.
+		// Skip pairs that don't contain "=" to avoid panicking on malformed input.
+		split := strings.SplitN(pair, "=", 2)
+		if len(split) < 2 {
+			continue
+		}
 		retMap[split[0]] = split[1]
 	}
 


### PR DESCRIPTION
This PR adds a new top-level param "GeoLocation" that, when configured, is used by clients, caches and origins to declare their own physical locations to a federation. This is picked up the Director and used for routing/matchmaking.

I decided this should be a top-level knob because I assume that multiple services reading from the same yaml configuration file are co-located.

When configured, the declared location from a client or server takes precedence over central services ip-based overrides. I chose this precedence because I viewed location information as part of how users of a federation declare they want to interact with that federation -- if a fed admin disagrees with a server's choice of lat/long, it should place that service into downtime until the service admin takes corrective action.

I tested this in my local federation by starting up two caches with different settings for `GeoLocation` alongside a client with it's own `GeoLocation` override. When I pulled an object in debug mode, the Director's redirect JSON confirmed the "declared" lat/long choices were used all around:
```
{
  "clientInfo": {
    "Coordinate": {
      "Lat": 51.500786,
      "Long": -0.124681,
      "AccuracyRadius": 0,
      "Source": "declared",
      "FromTTLCache": false
    },
    "ipAddr": "172.17.0.3"
  },
  "serversInfo": {
    "https://0ee241b2e244:8881": {
      "Coordinate": {
        "Lat": 55.75212,
        "Long": 37.61766,
        "AccuracyRadius": 0,
        "Source": "declared",
        "FromTTLCache": false
      },
      "RedirectWeights": {
        "distanceWeight": 0.004575618912398561,
        "ioLoadWeight": 1,
        "statusWeight": 0.3975739370572201,
        "availabilityWeight": 0.5
      }
    },
    "https://0ee241b2e244:8891": {
      "Coordinate": {
        "Lat": 48.8583,
        "Long": 2.2945,
        "AccuracyRadius": 0,
        "Source": "declared",
        "FromTTLCache": false
      },
      "RedirectWeights": {
        "distanceWeight": 0.4801634804408707,
        "ioLoadWeight": 1,
        "statusWeight": 0.5,
        "availabilityWeight": 0.5
      }
    }
  },
  "directorSortMethod": "adaptive"
}
```

Closes #2709 