### PR TITLE
Allow Registry startup when institutions API is down

### DIFF
--- a/registry/custom_reg_fields.go
+++ b/registry/custom_reg_fields.go
@@ -248,10 +248,19 @@ func InitInstConfig(ctx context.Context, egrp *errgroup.Group) error {
 		instCacheTTL := param.Registry_InstitutionsUrlReloadMinutes.GetDuration()
 		institutions, err := getCachedOptions(param.Registry_InstitutionsUrl.GetString(), instCacheTTL)
 		if err != nil {
-			return err
+			// Don't block startup on an unavailable institution API.
+			// OptionsUrl is still set above, so once that API recovers, subsequent
+			// requests (getNamespaceRegFields, validateInstitution, listInstitutions)
+			// will fetch and cache the list normally. Until then, those endpoints
+			// should return errors for institution-dependent operations.
+			log.Warningf(
+				"Failed to fetch institutions from %s during startup: %v. "+
+					"Registry will start without a pre-populated institutions list.",
+				param.Registry_InstitutionsUrl.GetString(), err,
+			)
+		} else {
+			registrationFields[instRegIdx].Options = institutions
 		}
-
-		registrationFields[instRegIdx].Options = institutions
 	}
 
 	if isUnique, err := checkUniqueOptions(institutions); !isUnique {

--- a/registry/custom_reg_fields_test.go
+++ b/registry/custom_reg_fields_test.go
@@ -19,6 +19,7 @@
 package registry
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -28,6 +29,10 @@ import (
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/test_utils"
 )
 
 func TestGetCachedOptions(t *testing.T) {
@@ -201,5 +206,77 @@ func TestConvertCustomRegFields(t *testing.T) {
 		require.Equal(t, 1, len(regField))
 		assert.Equal(t, "Department Name", regField[0].DisplayedName)
 		assert.Equal(t, "custom_fields.department_name", regField[0].Name)
+	})
+}
+
+func TestInitInstConfig(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+
+	resetInstField := func() {
+		for idx, field := range registrationFields {
+			if field.Name == "admin_metadata.institution" {
+				registrationFields[idx].OptionsUrl = ""
+				registrationFields[idx].Options = nil
+			}
+		}
+	}
+
+	t.Run("api-down-does-not-fail-startup", func(t *testing.T) {
+		t.Cleanup(func() {
+			server_utils.ResetTestState()
+			optionsCache.DeleteAll()
+			resetInstField()
+		})
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer ts.Close()
+
+		require.NoError(t, param.Registry_InstitutionsUrl.Set(ts.URL))
+
+		err := InitInstConfig(context.Background(), nil)
+		require.NoError(t, err, "registry startup must not fail when institution API is unreachable")
+
+		for _, field := range registrationFields {
+			if field.Name == "admin_metadata.institution" {
+				assert.Equal(t, ts.URL, field.OptionsUrl, "OptionsUrl should be set for on-demand fetching")
+				assert.Empty(t, field.Options, "Options should be empty when API is down at startup")
+				return
+			}
+		}
+		t.Fatal("admin_metadata.institution not found in registrationFields")
+	})
+
+	t.Run("api-up-populates-options", func(t *testing.T) {
+		t.Cleanup(func() {
+			server_utils.ResetTestState()
+			optionsCache.DeleteAll()
+			resetInstField()
+		})
+
+		mockInsts := []registrationFieldOption{{Name: "University of Foo", ID: "001"}}
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			res, err := json.Marshal(mockInsts)
+			require.NoError(t, err)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(res)
+		}))
+		defer ts.Close()
+
+		require.NoError(t, param.Registry_InstitutionsUrl.Set(ts.URL))
+
+		err := InitInstConfig(context.Background(), nil)
+		require.NoError(t, err)
+
+		for _, field := range registrationFields {
+			if field.Name == "admin_metadata.institution" {
+				assert.Equal(t, ts.URL, field.OptionsUrl)
+				assert.EqualValues(t, mockInsts, field.Options)
+				return
+			}
+		}
+		t.Fatal("admin_metadata.institution not found in registrationFields")
 	})
 }

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -324,6 +324,7 @@ func getNamespaceRegFields(ctx *gin.Context) {
 						Status: server_structs.RespFailed,
 						Msg:    fmt.Sprintf("failed to get options from optionsUrl %s for key %s", field.OptionsUrl, field.Name),
 					})
+				return
 			}
 			registrationFields[idx].Options = options
 		}


### PR DESCRIPTION
Closes #3458 

This PR allows Registry to start when institutions API is down. Instead of throwing an error on startup, it will startup normally, only the features related to institution create/update/list will fail:

1. Registration form fails to load. `getNamespaceRegFields` gets a 500 error with "Couldn't fetch registration fields"
2. Namespace create/update fails. `validateInstitution` gets a 400 with `Validation for Institution failed: Error fetching institutions from TTL cache`
3. Institution dropdown endpoint (GET /api/v1.0/registry_ui/institutions) fails to get data. `listInstitutions` gets 500 error.