### PR TITLE
Updated the error message for three '///' when using a pelican protocol

### DIFF
--- a/pelican_url/parse.go
+++ b/pelican_url/parse.go
@@ -181,9 +181,21 @@ func validateOsdfStashUrl(parsedUrl *url.URL) error {
 
 func validatePelicanUrl(parsedUrl *url.URL) error {
 	if parsedUrl.Host == "" {
-		return error_codes.NewParameterError(
-			fmt.Errorf("pelican URL '%s' is invalid because it has no host", parsedUrl.String()),
-		)
+		errMsg := fmt.Sprintf("pelican URL '%s' is invalid because it has no host", parsedUrl.String())
+		// If the path is non-empty, the user likely used pelican:/// (three slashes) instead of
+		// pelican:// (two slashes). Extract the first path segment as the likely intended host
+		// and suggest the corrected form.
+		if parsedUrl.Path != "" {
+			pathParts := strings.SplitN(strings.TrimPrefix(parsedUrl.Path, "/"), "/", 2)
+			if len(pathParts) > 0 && pathParts[0] != "" {
+				remainingPath := ""
+				if len(pathParts) > 1 {
+					remainingPath = "/" + pathParts[1]
+				}
+				errMsg = fmt.Sprintf("%s; did you mean 'pelican://%s%s'?", errMsg, pathParts[0], remainingPath)
+			}
+		}
+		return error_codes.NewParameterError(fmt.Errorf("%s", errMsg))
 	}
 	return nil
 }

--- a/pelican_url/parse_test.go
+++ b/pelican_url/parse_test.go
@@ -361,7 +361,7 @@ func TestParse(t *testing.T) {
 			dOpts:     []DiscoveryOption{},
 			pOpts:     []ParseOption{},
 			pUrl:      &PelicanURL{Scheme: "pelican", RawScheme: "pelican", Host: "bad-director.com", Path: "/foo/bar"},
-			errString: "pelican URL 'pelican:///foo/bar' is invalid because it has no host",
+			errString: "pelican URL 'pelican:///foo/bar' is invalid because it has no host; did you mean 'pelican://foo/bar'?",
 		},
 
 		// OSDF/Stash scheme tests. Most of the underlying machinery is shared, so only testing the things that are more likely


### PR DESCRIPTION
close #3255 