### PR TITLE
Clean up `pelican token` tooling

### DIFF
--- a/cmd/token.go
+++ b/cmd/token.go
@@ -120,50 +120,54 @@ These two flags are mutually exclusive.`,
 	}
 )
 
-var (
-	readFlag   bool
-	writeFlag  bool
-	modifyFlag bool
-)
-
 func addScopeFlags(cmd *cobra.Command) {
-	cmd.Flags().BoolVarP(&readFlag, "read", "r", false, "Indicate the requested token should provide the ability to read the specified resource.")
-	cmd.Flags().BoolVarP(&writeFlag, "write", "w", false, "Indicate the requested token should provide the ability to create/write the specified resource. "+
+	cmd.Flags().BoolP("read", "r", false, "Indicate the requested token should provide the ability to read the specified resource.")
+	cmd.Flags().BoolP("write", "w", false, "Indicate the requested token should provide the ability to create/write the specified resource. "+
 		"Does not grant the ability to overwrite/modify existing resources.")
-	cmd.Flags().BoolVarP(&modifyFlag, "modify", "m", false, "Indicate the requested token should provide the ability to modify/delete the specified resource.")
+	cmd.Flags().BoolP("modify", "m", false, "Indicate the requested token should provide the ability to modify/delete the specified resource.")
+}
+
+// addTokenCreateFlags registers every flag that the `token create` command and
+// its createToken handler read. It is the single source of truth for that flag
+// set, shared by init() and tests so the two cannot drift apart.
+func addTokenCreateFlags(cmd *cobra.Command) {
+	// Token capabilities
+	addScopeFlags(cmd)
+
+	cmd.Flags().BoolP("stage", "s", false, "Indicate the requested token should provide the ability to stage the specified resource.")
+	cmd.Flags().String("scope-path", "", "Specify the path to use when creating the token's scopes. This should generally be "+
+		"the object path without the namespace prefix.")
+
+	// Additional token fields
+	cmd.Flags().StringP("audience", "a", "", "Specify the token's 'audience/aud' claim. If not provided, the equivalent 'any' audience "+
+		"for the selected profile will be used (e.g. 'https://wlcg.cern.ch/jwt/v1/any' for the 'wlcg' profile).")
+	cmd.Flags().IntP("lifetime", "l", 1200, "Set the token's lifetime in seconds.")
+	cmd.Flags().String("expiration", "", "Set the token's expiration as an absolute RFC3339 timestamp (e.g., 2026-12-31T23:59:59Z). Mutually exclusive with --lifetime.")
+	cmd.MarkFlagsMutuallyExclusive("lifetime", "expiration")
+	cmd.Flags().String("subject", "", "Set token's 'subject/sub' claim. If not provided, the current user will be used as the default subject.")
+	cmd.Flags().StringP("issuer", "i", "", "Set the token's 'issuer/iss' claim. If not provided, the issuer will be discovered via the Director.")
+	cmd.Flags().StringArray("raw-claim", []string{}, "Set claims to be added to the token. Format: <claim_key>=<claim_value>. ")
+	cmd.Flags().StringArray("raw-scope", []string{}, "Set non-typical values for the token's 'scope' claim. Scopes should be space-separated, e.g. "+
+		"'storage.read:/ storage.create:/'.")
+	cmd.Flags().StringP("profile", "p", "wlcg", "Create a token with a specific JWT profile. Accepted values are scitokens2 and wlcg.")
+	cmd.Flags().StringP("private-key", "k", "", fmt.Sprintf("Path to the private key used to sign the token. If not provided, Pelican will look for "+
+		"the private key in the default location pointed to by the '%s' config parameter.", param.IssuerKeysDirectory))
 }
 
 func init() {
 	rootCmd.AddCommand(tokenCmd)
-	tokenCmd.AddCommand(tokenCreateCmd)
-	tokenCmd.AddCommand(tokenFetchCmd)
 
-	// Token capabilities
-	addScopeFlags(tokenCreateCmd)
+	// Token create command setup
+	tokenCmd.AddCommand(tokenCreateCmd)
+	addTokenCreateFlags(tokenCreateCmd)
+
+	// Token fetch command setup
+	tokenCmd.AddCommand(tokenFetchCmd)
 	addScopeFlags(tokenFetchCmd)
 
 	// Token fetch requires exactly one of read, write or modify
 	tokenFetchCmd.MarkFlagsMutuallyExclusive("read", "write", "modify")
 	tokenFetchCmd.MarkFlagsOneRequired("read", "write", "modify")
-
-	tokenCreateCmd.Flags().BoolP("stage", "s", false, "Indicate the requested token should provide the ability to stage the specified resource.")
-	tokenCreateCmd.Flags().String("scope-path", "", "Specify the path to use when creating the token's scopes. This should generally be "+
-		"the object path without the namespace prefix.")
-
-	// Additional token fields
-	tokenCreateCmd.Flags().StringP("audience", "a", "", "Specify the token's 'audience/aud' claim. If not provided, the equivalent 'any' audience "+
-		"for the selected profile will be used (e.g. 'https://wlcg.cern.ch/jwt/v1/any' for the 'wlcg' profile).")
-	tokenCreateCmd.Flags().IntP("lifetime", "l", 1200, "Set the token's lifetime in seconds.")
-	tokenCreateCmd.Flags().String("expiration", "", "Set the token's expiration as an absolute RFC3339 timestamp (e.g., 2026-12-31T23:59:59Z). Mutually exclusive with --lifetime.")
-	tokenCreateCmd.MarkFlagsMutuallyExclusive("lifetime", "expiration")
-	tokenCreateCmd.Flags().String("subject", "", "Set token's 'subject/sub' claim. If not provided, the current user will be used as the default subject.")
-	tokenCreateCmd.Flags().StringP("issuer", "i", "", "Set the token's 'issuer/iss' claim. If not provided, the issuer will be discovered via the Director.")
-	tokenCreateCmd.Flags().StringArray("raw-claim", []string{}, "Set claims to be added to the token. Format: <claim_key>=<claim_value>. ")
-	tokenCreateCmd.Flags().StringArray("raw-scope", []string{}, "Set non-typical values for the token's 'scope' claim. Scopes should be space-separated, e.g. "+
-		"'storage.read:/ storage.create:/'.")
-	tokenCreateCmd.Flags().StringP("profile", "p", "wlcg", "Create a token with a specific JWT profile. Accepted values are scitokens2 and wlcg.")
-	tokenCreateCmd.Flags().StringP("private-key", "k", "", fmt.Sprintf("Path to the private key used to sign the token. If not provided, Pelican will look for "+
-		"the private key in the default location pointed to by the '%s' config parameter.", param.IssuerKeysDirectory))
 }
 
 func splitClaim(claim string) (string, string, error) {
@@ -297,7 +301,6 @@ func getNsAd(directorInfo server_structs.DirectorResponse) (server_structs.Names
 	)
 }
 
-
 // Create a token using the provided flags/args
 func createToken(cmd *cobra.Command, args []string) error {
 	err := config.InitClient()
@@ -370,7 +373,13 @@ func createToken(cmd *cobra.Command, args []string) error {
 	}
 
 	// Grab the namespace ad from the Director -- we'll use this later to validate token scopes.
-	nsAd, err := getNsAd(directorInfo)
+	// This is best-effort: if we can't retrieve it (e.g. transient Director error), we skip the
+	// capability-based scope validation rather than driving it off a zero-value ad, which would
+	// emit misleading warnings.
+	nsAd, nsAdErr := getNsAd(directorInfo)
+	if nsAdErr != nil {
+		log.Warningf("Unable to retrieve namespace information from the Director; skipping validation of requested token scopes against namespace capabilities: %v", nsAdErr)
+	}
 
 	// Handle any raw scopes early -- may be useful for developers/admin who want to create arbitrarily-scoped tokens,
 	// and early handling lets us use this as another mechanism to avoid scope paths.
@@ -414,22 +423,24 @@ func createToken(cmd *cobra.Command, args []string) error {
 	// For each scope we want to add, check against the Director's opinion of which scopes are supported for this resource.
 	// Log an error for any requested scopes that aren't supported, but still add them to the token in case the user knows something we don't.
 	if read {
-		if nsAd.Caps.PublicReads {
-			// Read access is not behind token auth
-			log.Warningf("Director indicates that the resource at %s is publicly readable so a token is not actually required to read it, but the --read flag was provided; adding read scope to token anyway", rawUrl)
-		} else if !nsAd.Caps.Reads {
-			log.Warningf("Director indicates that the resource at %s does not support read operations, but --read flag was provided; adding read scope to token anyway", rawUrl)
+		if nsAdErr == nil {
+			if nsAd.Caps.PublicReads {
+				// Read access is not behind token auth
+				log.Warningf("Director indicates that the resource at %s is publicly readable so a token is not actually required to read it, but the --read flag was provided; adding read scope to token anyway", rawUrl)
+			} else if !nsAd.Caps.Reads {
+				log.Warningf("Director indicates that the resource at %s does not support read operations, but --read flag was provided; adding read scope to token anyway", rawUrl)
+			}
 		}
 		scopes = append(scopes, tokenProfile.ReadScope(sPath))
 	}
 	if write {
-		if !nsAd.Caps.Writes {
+		if nsAdErr == nil && !nsAd.Caps.Writes {
 			log.Warningf("Director indicates that the resource at %s does not support write/modify operations, but --write flag was provided; adding write scope to token anyway", rawUrl)
-		 }
+		}
 		scopes = append(scopes, tokenProfile.WriteScope(sPath))
 	}
 	if modify {
-		if !nsAd.Caps.Writes {
+		if nsAdErr == nil && !nsAd.Caps.Writes {
 			log.Warningf("Director indicates that the resource at %s does not support write/modify operations, but --modify flag was provided; adding modify scope to token anyway", rawUrl)
 		}
 		scopes = append(scopes, tokenProfile.ModifyScope(sPath))
@@ -467,12 +478,11 @@ func createToken(cmd *cobra.Command, args []string) error {
 	if keyLoadErr != nil {
 		// If the namespace doesn't require protected reads and doesn't support writes,
 		// a token probably isn't needed at all — give the user a more helpful hint.
-		if !(nsAd.Caps.Reads && !nsAd.Caps.PublicReads) && !nsAd.Caps.Writes {
+		if nsAdErr == nil && !(nsAd.Caps.Reads && !nsAd.Caps.PublicReads) && !nsAd.Caps.Writes {
 			return errors.Wrapf(keyLoadErr, "failed to load a local signing key; note that the Director reports namespace '%s' does not require auth for reads and does not support writes, so you may not need a token", nsAd.Path)
 		}
 		return keyLoadErr
 	}
-
 
 	kidSet := make(map[string]struct{}, myJWKS.Len())
 	it := myJWKS.Keys(context.Background())
@@ -489,7 +499,7 @@ func createToken(cmd *cobra.Command, args []string) error {
 			// If the namespace doesn't require protected reads and it doesn't support writes, there will likely have been no issuer to discover.
 			// In that case, we warn that the user probably doesn't need to create a token in the first place, but we provide instructions for
 			// supplying an issuer if they know better than we do.
-			if !(nsAd.Caps.Reads && !nsAd.Caps.PublicReads) && !nsAd.Caps.Writes {
+			if nsAdErr == nil && !(nsAd.Caps.Reads && !nsAd.Caps.PublicReads) && !nsAd.Caps.Writes {
 				return errors.Wrapf(err, "unable to determine issuer for resource %s. This is likely because the Director reports that this namespace does not require token issuance for reads and does not support writes. Are you sure you need a token? You may need to re-run with '--issuer <issuer URL>' to specify an issuer", rawUrl)
 			} else if len(directorInfo.XPelAuthHdr.Issuers) > 0 {
 				// Issuers were discovered but none match the local signing key — the inner error already

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -199,7 +200,7 @@ func issuerMatchesKey(issuer string, kidSet map[string]struct{}) (bool, error) {
 // Given a Pelican resource and a set of KIDs, discover issuers from the Director
 // and return the first whose JWKS contains a key matching one of the input KIDs
 //
-// This is use to handle multi-issuer namespaces where it may not be obvious to the user
+// This is used to handle multi-issuer namespaces where it may not be obvious to the user
 // which issuer aligns with their signing key.
 func getIssuer(directorInfo server_structs.DirectorResponse, kidSet map[string]struct{}) (string, error) {
 	if len(directorInfo.XPelAuthHdr.Issuers) == 0 {
@@ -236,6 +237,66 @@ func getIssuer(directorInfo server_structs.DirectorResponse, kidSet map[string]s
 	return "", errors.Errorf("none of the issuers discovered at the director match your signing key; issuers that were checked: %s",
 		combineUrls(directorInfo.XPelAuthHdr.Issuers))
 }
+
+// Given a Director's redirect response, re-query the Director's UI endpoint to get the full namespace ad information.
+// This can be used later to determine what capabilities the namespace supports in comparison with the requested
+// token scopes.
+func getNsAd(directorInfo server_structs.DirectorResponse) (server_structs.NamespaceAdV2Response, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	fedInfo, err := config.GetFederation(ctx)
+	if err != nil {
+		return server_structs.NamespaceAdV2Response{}, errors.Wrap(err, "unable to get federation info from config")
+	}
+
+	client := config.GetClient()
+
+	reqURL := strings.TrimRight(fedInfo.DirectorEndpoint, "/") + "/api/v1.0/director_ui/namespaces"
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return server_structs.NamespaceAdV2Response{}, errors.Wrapf(err,
+			"failed to create request for Director server lookup at %s", reqURL)
+	}
+
+	response, err := client.Do(request)
+	if err != nil {
+		return server_structs.NamespaceAdV2Response{}, errors.Wrapf(err,
+			"failed to query Director for server ads at %s", reqURL)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return server_structs.NamespaceAdV2Response{}, errors.Errorf(
+			"Director server lookup at %s returned status code %d",
+			reqURL,
+			response.StatusCode,
+		)
+	}
+
+	// Parse the response body into a slice of server ads
+	var nsAds []server_structs.NamespaceAdV2Response
+	err = json.NewDecoder(response.Body).Decode(&nsAds)
+	if err != nil {
+		return server_structs.NamespaceAdV2Response{}, errors.Wrapf(err,
+			"failed to decode Director response for namespace ads at %s", reqURL)
+	}
+
+	namespace := directorInfo.XPelNsHdr.Namespace
+	// Find the first server advertising this namespace
+	for _, nsAd := range nsAds {
+		if path.Clean(nsAd.Path) == path.Clean(namespace) {
+			return nsAd, nil
+		}
+	}
+
+	return server_structs.NamespaceAdV2Response{}, errors.Errorf(
+		"no namespace advertisement found for namespace %s",
+		namespace,
+	)
+}
+
 
 // Create a token using the provided flags/args
 func createToken(cmd *cobra.Command, args []string) error {
@@ -308,6 +369,9 @@ func createToken(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Grab the namespace ad from the Director -- we'll use this later to validate token scopes.
+	nsAd, err := getNsAd(directorInfo)
+
 	// Handle any raw scopes early -- may be useful for developers/admin who want to create arbitrarily-scoped tokens,
 	// and early handling lets us use this as another mechanism to avoid scope paths.
 	rawScopes, err := cmd.Flags().GetStringArray("raw-scope")
@@ -338,24 +402,77 @@ func createToken(cmd *cobra.Command, args []string) error {
 	}
 	log.Debugf("Using path %s for token scopes", sPath)
 
-	// Load the key and create a set of KIDs; we'll later check it against any issuers we may discover/be provided
+	// Start constructing the token scopes early -- we'll validate the scopes requested by the user
+	// against what we think the namespace supports later.
+	read, _ := cmd.Flags().GetBool("read")
+	write, _ := cmd.Flags().GetBool("write")
+	modify, _ := cmd.Flags().GetBool("modify")
+	stage, _ := cmd.Flags().GetBool("stage")
+
+	scopes := []token_scopes.TokenScope{}
+
+	// For each scope we want to add, check against the Director's opinion of which scopes are supported for this resource.
+	// Log an error for any requested scopes that aren't supported, but still add them to the token in case the user knows something we don't.
+	if read {
+		if nsAd.Caps.PublicReads {
+			// Read access is not behind token auth
+			log.Warningf("Director indicates that the resource at %s is publicly readable so a token is not actually required to read it, but the --read flag was provided; adding read scope to token anyway", rawUrl)
+		} else if !nsAd.Caps.Reads {
+			log.Warningf("Director indicates that the resource at %s does not support read operations, but --read flag was provided; adding read scope to token anyway", rawUrl)
+		}
+		scopes = append(scopes, tokenProfile.ReadScope(sPath))
+	}
+	if write {
+		if !nsAd.Caps.Writes {
+			log.Warningf("Director indicates that the resource at %s does not support write/modify operations, but --write flag was provided; adding write scope to token anyway", rawUrl)
+		 }
+		scopes = append(scopes, tokenProfile.WriteScope(sPath))
+	}
+	if modify {
+		if !nsAd.Caps.Writes {
+			log.Warningf("Director indicates that the resource at %s does not support write/modify operations, but --modify flag was provided; adding modify scope to token anyway", rawUrl)
+		}
+		scopes = append(scopes, tokenProfile.ModifyScope(sPath))
+	}
+	if stage {
+		scopes = append(scopes, tokenProfile.StageScope(sPath))
+	}
+	tokenConfig.AddScopes(scopes...)
+
+	if len(scopes)+len(rawScopes) == 0 {
+		log.Warningf("Detected creation of a token without any capabilities. Use flags like --read, --write, --modify, or --stage to add capabilities to the token.")
+	}
+
+	// Load the local signing key's public JWKS. We use the key IDs (KIDs) later to
+	// match our signing key against issuers discovered from the Director.
 	var myJWKS jwk.Set
 	keyPath, err := cmd.Flags().GetString("private-key")
+	var keyLoadErr error
 	if err != nil {
 		return errors.Wrap(err, "unable to get private key path")
 	} else if keyPath == "" {
 		myJWKS, err = config.GetIssuerPublicJWKS()
 		if err != nil {
-			return errors.Wrap(err, "unable to get issuer public JWKS from default locations")
+			keyLoadErr = errors.Wrap(err, "unable to load signing key from default location")
 		} else if myJWKS == nil {
-			return errors.New("internal error: config.GetIssuerPublicJWKS() returned nil")
+			keyLoadErr = errors.New("internal error: config.GetIssuerPublicJWKS() returned nil")
 		}
 	} else {
 		myJWKS, err = config.GetIssuerPublicJWKS(keyPath)
 		if err != nil {
-			return errors.Wrapf(err, "unable to get issuer public JWKS from %s", keyPath)
+			keyLoadErr = errors.Wrapf(err, "unable to load signing key from %s", keyPath)
 		}
 	}
+
+	if keyLoadErr != nil {
+		// If the namespace doesn't require protected reads and doesn't support writes,
+		// a token probably isn't needed at all — give the user a more helpful hint.
+		if !(nsAd.Caps.Reads && !nsAd.Caps.PublicReads) && !nsAd.Caps.Writes {
+			return errors.Wrapf(keyLoadErr, "failed to load a local signing key; note that the Director reports namespace '%s' does not require auth for reads and does not support writes, so you may not need a token", nsAd.Path)
+		}
+		return keyLoadErr
+	}
+
 
 	kidSet := make(map[string]struct{}, myJWKS.Len())
 	it := myJWKS.Keys(context.Background())
@@ -369,7 +486,18 @@ func createToken(cmd *cobra.Command, args []string) error {
 		// from the Director
 		issuer, err = getIssuer(directorInfo, kidSet)
 		if err != nil {
-			return errors.Wrapf(err, "unable to determine issuer for resource %s; you may need to re-run with '--issuer <issuer URL>' to specify an issuer", rawUrl)
+			// If the namespace doesn't require protected reads and it doesn't support writes, there will likely have been no issuer to discover.
+			// In that case, we warn that the user probably doesn't need to create a token in the first place, but we provide instructions for
+			// supplying an issuer if they know better than we do.
+			if !(nsAd.Caps.Reads && !nsAd.Caps.PublicReads) && !nsAd.Caps.Writes {
+				return errors.Wrapf(err, "unable to determine issuer for resource %s. This is likely because the Director reports that this namespace does not require token issuance for reads and does not support writes. Are you sure you need a token? You may need to re-run with '--issuer <issuer URL>' to specify an issuer", rawUrl)
+			} else if len(directorInfo.XPelAuthHdr.Issuers) > 0 {
+				// Issuers were discovered but none match the local signing key — the inner error already
+				// describes this clearly; avoid the misleading "unable to determine issuer" phrasing.
+				return errors.Wrapf(err, "no issuer for resource %s matches your signing key; re-run with '--issuer <issuer URL>' to specify one, or ensure you are using the correct private key", rawUrl)
+			} else {
+				return errors.Wrapf(err, "unable to determine issuer for resource %s; you may need to re-run with '--issuer <issuer URL>' to specify an issuer", rawUrl)
+			}
 		}
 	} else {
 		// If an issuer is provided, check whether it matches the signing key
@@ -383,32 +511,6 @@ func createToken(cmd *cobra.Command, args []string) error {
 		}
 	}
 	tokenConfig.Issuer = issuer
-
-	// Add token scopes for object manipulation
-	read, _ := cmd.Flags().GetBool("read")
-	write, _ := cmd.Flags().GetBool("write")
-	modify, _ := cmd.Flags().GetBool("modify")
-	stage, _ := cmd.Flags().GetBool("stage")
-
-	scopes := []token_scopes.TokenScope{}
-
-	if read {
-		scopes = append(scopes, tokenProfile.ReadScope(sPath))
-	}
-	if write {
-		scopes = append(scopes, tokenProfile.WriteScope(sPath))
-	}
-	if modify {
-		scopes = append(scopes, tokenProfile.ModifyScope(sPath))
-	}
-	if stage {
-		scopes = append(scopes, tokenProfile.StageScope(sPath))
-	}
-	tokenConfig.AddScopes(scopes...)
-
-	if len(scopes)+len(rawScopes) == 0 {
-		log.Warningf("Detected creation of a token without any capabilities. Use flags like --read, --write, --modify, or --stage to add capabilities to the token.")
-	}
 
 	// Set token lifetime — either via --expiration (RFC3339) or --lifetime (seconds).
 	// expirationStr was already validated above; here we just compute the duration.

--- a/cmd/token_test.go
+++ b/cmd/token_test.go
@@ -455,7 +455,7 @@ func setupTokenCmdTest(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	config.ResetConfig()
 	t.Cleanup(config.ResetConfig)
-	require.NoError(t, param.ConfigDir.Set(t.TempDir()))
+	require.NoError(t, param.ConfigBase.Set(t.TempDir()))
 }
 
 // TestCreateTokenEarlyValidation covers the fast-feedback validation that

--- a/cmd/token_test.go
+++ b/cmd/token_test.go
@@ -26,14 +26,17 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
 	pelican_url "github.com/pelicanplatform/pelican/pelican_url"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/test_utils"
@@ -432,6 +435,112 @@ func TestGetNsAdHTTPErrors(t *testing.T) {
 		_, err := getNsAd(directorInfo)
 		require.Error(t, err)
 	})
+}
+
+// newTokenCreateTestCmd builds a fresh `token create` command using the same
+// flag-registration code as the real CLI (addTokenCreateFlags), so the test
+// cannot drift from the actual command. Because the flags are registered on a
+// fresh command (and no longer bind to shared package globals), flag state does
+// not leak between test cases.
+func newTokenCreateTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "create"}
+	addTokenCreateFlags(cmd)
+	return cmd
+}
+
+// setupTokenCmdTest isolates global config/viper state for a createToken test
+// and quiets logging.
+func setupTokenCmdTest(t *testing.T) {
+	t.Helper()
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	config.ResetConfig()
+	t.Cleanup(config.ResetConfig)
+	require.NoError(t, param.ConfigDir.Set(t.TempDir()))
+}
+
+// TestCreateTokenEarlyValidation covers the fast-feedback validation that
+// happens before any network calls: profile parsing and --expiration handling.
+func TestCreateTokenEarlyValidation(t *testing.T) {
+	testCases := []struct {
+		name       string
+		profile    string
+		expiration string
+		expectErr  string
+	}{
+		{
+			name:      "unknown profile",
+			profile:   "not-a-profile",
+			expectErr: "unable to parse token profile",
+		},
+		{
+			name:       "malformed expiration",
+			profile:    "wlcg",
+			expiration: "tomorrow",
+			expectErr:  "RFC3339",
+		},
+		{
+			name:       "expiration in the past",
+			profile:    "wlcg",
+			expiration: "2000-01-01T00:00:00Z",
+			expectErr:  "already in the past",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setupTokenCmdTest(t)
+			cmd := newTokenCreateTestCmd()
+			require.NoError(t, cmd.Flags().Set("profile", tc.profile))
+			if tc.expiration != "" {
+				require.NoError(t, cmd.Flags().Set("expiration", tc.expiration))
+			}
+
+			// The arg is never reached for these cases, but createToken expects one.
+			err := createToken(cmd, []string{"pelican://example.com/foo/bar"})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.expectErr)
+		})
+	}
+}
+
+// TestCreateTokenDiscoveryFailure verifies that when the pelican URL cannot be
+// parsed/discovered and the user supplies neither --issuer nor --scope-path,
+// createToken surfaces the discovery failure rather than proceeding.
+func TestCreateTokenDiscoveryFailure(t *testing.T) {
+	setupTokenCmdTest(t)
+	cmd := newTokenCreateTestCmd()
+	require.NoError(t, cmd.Flags().Set("read", "true"))
+
+	// A host-less pelican URL fails to parse without any network access.
+	err := createToken(cmd, []string{"pelican:///no/host/path"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Failed to get director info")
+}
+
+// TestCreateTokenOfflineWithIssuer exercises the path where director discovery
+// fails but the user provides enough information (--issuer + --scope-path) for
+// createToken to mint a token without ever reaching a Director. The local
+// signing key is matched against a mock issuer's JWKS.
+func TestCreateTokenOfflineWithIssuer(t *testing.T) {
+	setupTokenCmdTest(t)
+
+	// Generate a local signing key and stand up a mock issuer that advertises it.
+	kDir := filepath.Join(t.TempDir(), "issuer-keys")
+	require.NoError(t, param.IssuerKeysDirectory.Set(kDir))
+	pubJWKS, err := config.GetIssuerPublicJWKS()
+	require.NoError(t, err)
+	issuerUrl := test_utils.MockIssuer(t, &pubJWKS)
+
+	cmd := newTokenCreateTestCmd()
+	require.NoError(t, cmd.Flags().Set("read", "true"))
+	require.NoError(t, cmd.Flags().Set("issuer", issuerUrl))
+	require.NoError(t, cmd.Flags().Set("scope-path", "/foo"))
+	require.NoError(t, cmd.Flags().Set("lifetime", "600"))
+
+	// The URL fails to parse, so discovery is skipped and the supplied
+	// --issuer/--scope-path are used instead.
+	err = createToken(cmd, []string{"pelican:///no/host/path"})
+	require.NoError(t, err)
 }
 
 func TestGetIssuerErrorMessages(t *testing.T) {

--- a/cmd/token_test.go
+++ b/cmd/token_test.go
@@ -22,13 +22,19 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pelicanplatform/pelican/config"
+	pelican_url "github.com/pelicanplatform/pelican/pelican_url"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/test_utils"
 )
@@ -245,4 +251,224 @@ func TestGetIssuer(t *testing.T) {
 			}
 		})
 	}
+}
+
+// mockDirectorNsEndpoint starts a test HTTP server that serves the Director UI
+// namespaces endpoint (/api/v1.0/director_ui/namespaces) with the provided
+// namespace ads. It injects the server URL directly into the federation config
+// so that getNsAd can reach it, and resets federation state on cleanup.
+func mockDirectorNsEndpoint(t *testing.T, nsAds []server_structs.NamespaceAdV2Response) string {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1.0/director_ui/namespaces" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(nsAds))
+	}))
+	t.Cleanup(func() {
+		server.Close()
+		config.ResetFederationForTest()
+	})
+	config.ResetFederationForTest()
+	config.SetFederation(pelican_url.FederationDiscovery{
+		DirectorEndpoint:  server.URL,
+		DiscoveryEndpoint: server.URL,
+	})
+	return server.URL
+}
+
+func TestGetNsAd(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	t.Cleanup(config.ResetFederationForTest)
+
+	// A minimal namespace ad used across several cases.
+	readNs := server_structs.NamespaceAdV2Response{
+		Path: "/test/prefix",
+		Caps: server_structs.Capabilities{Reads: true, Writes: false},
+	}
+	writeNs := server_structs.NamespaceAdV2Response{
+		Path: "/write/prefix",
+		Caps: server_structs.Capabilities{Reads: true, Writes: true},
+	}
+	publicNs := server_structs.NamespaceAdV2Response{
+		Path: "/public/prefix",
+		Caps: server_structs.Capabilities{PublicReads: true, Reads: true},
+	}
+
+	testCases := []struct {
+		name        string
+		nsAds       []server_structs.NamespaceAdV2Response
+		namespace   string // what the DirectorResponse reports as the namespace
+		expectError bool
+		expectCaps  server_structs.Capabilities
+		expectPath  string
+	}{
+		{
+			name:        "matching namespace found",
+			nsAds:       []server_structs.NamespaceAdV2Response{readNs, writeNs},
+			namespace:   "/test/prefix",
+			expectError: false,
+			expectCaps:  readNs.Caps,
+			expectPath:  readNs.Path,
+		},
+		{
+			name:        "matching namespace with trailing slash normalised",
+			nsAds:       []server_structs.NamespaceAdV2Response{readNs},
+			namespace:   "/test/prefix/",
+			expectError: false,
+			expectCaps:  readNs.Caps,
+			expectPath:  readNs.Path,
+		},
+		{
+			name:        "write-capable namespace found",
+			nsAds:       []server_structs.NamespaceAdV2Response{writeNs},
+			namespace:   "/write/prefix",
+			expectError: false,
+			expectCaps:  writeNs.Caps,
+			expectPath:  writeNs.Path,
+		},
+		{
+			name:        "public-read namespace found",
+			nsAds:       []server_structs.NamespaceAdV2Response{publicNs},
+			namespace:   "/public/prefix",
+			expectError: false,
+			expectCaps:  publicNs.Caps,
+			expectPath:  publicNs.Path,
+		},
+		{
+			name:        "namespace not in Director response",
+			nsAds:       []server_structs.NamespaceAdV2Response{readNs},
+			namespace:   "/does/not/exist",
+			expectError: true,
+		},
+		{
+			name:        "empty namespace list",
+			nsAds:       []server_structs.NamespaceAdV2Response{},
+			namespace:   "/test/prefix",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockDirectorNsEndpoint(t, tc.nsAds)
+
+			directorInfo := server_structs.DirectorResponse{}
+			directorInfo.XPelNsHdr.Namespace = tc.namespace
+
+			got, err := getNsAd(directorInfo)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectPath, got.Path)
+				assert.Equal(t, tc.expectCaps, got.Caps)
+			}
+		})
+	}
+}
+
+func TestGetNsAdHTTPErrors(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+
+	t.Run("director returns non-200", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		t.Cleanup(func() {
+			server.Close()
+			config.ResetFederationForTest()
+		})
+		config.ResetFederationForTest()
+		config.SetFederation(pelican_url.FederationDiscovery{
+			DirectorEndpoint:  server.URL,
+			DiscoveryEndpoint: server.URL,
+		})
+
+		directorInfo := server_structs.DirectorResponse{}
+		directorInfo.XPelNsHdr.Namespace = "/test/prefix"
+
+		_, err := getNsAd(directorInfo)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "500")
+	})
+
+	t.Run("director returns invalid JSON", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("not valid json"))
+		}))
+		t.Cleanup(func() {
+			server.Close()
+			config.ResetFederationForTest()
+		})
+		config.ResetFederationForTest()
+		config.SetFederation(pelican_url.FederationDiscovery{
+			DirectorEndpoint:  server.URL,
+			DiscoveryEndpoint: server.URL,
+		})
+
+		directorInfo := server_structs.DirectorResponse{}
+		directorInfo.XPelNsHdr.Namespace = "/test/prefix"
+
+		_, err := getNsAd(directorInfo)
+		require.Error(t, err)
+	})
+
+	t.Run("director unreachable", func(t *testing.T) {
+		t.Cleanup(config.ResetFederationForTest)
+		config.ResetFederationForTest()
+		config.SetFederation(pelican_url.FederationDiscovery{
+			DirectorEndpoint:  "http://127.0.0.1:1",
+			DiscoveryEndpoint: "http://127.0.0.1:1",
+		})
+
+		directorInfo := server_structs.DirectorResponse{}
+		directorInfo.XPelNsHdr.Namespace = "/test/prefix"
+
+		_, err := getNsAd(directorInfo)
+		require.Error(t, err)
+	})
+}
+
+func TestGetIssuerErrorMessages(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+
+	jwksStr, err := test_utils.GenerateJWKS()
+	require.NoError(t, err)
+	jwks, err := jwk.ParseString(jwksStr)
+	require.NoError(t, err)
+
+	mockIssuerUrl := test_utils.MockIssuer(t, &jwks)
+	mockIssuer, err := url.Parse(mockIssuerUrl)
+	require.NoError(t, err)
+
+	// A KID set that will never match the mock issuer's keys.
+	nonMatchingKidSet := map[string]struct{}{"notarealkid": {}}
+
+	t.Run("issuers found but none match key mentions issuers checked", func(t *testing.T) {
+		directorInfo := server_structs.DirectorResponse{}
+		directorInfo.XPelAuthHdr.Issuers = []*url.URL{mockIssuer}
+
+		_, err := getIssuer(directorInfo, nonMatchingKidSet)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), mockIssuerUrl,
+			"error should name the issuer(s) that were checked")
+		assert.True(t,
+			strings.Contains(err.Error(), "match") || strings.Contains(err.Error(), "signing key"),
+			"error should indicate the key-mismatch nature of the failure")
+	})
+
+	t.Run("no issuers in director response mentions namespace", func(t *testing.T) {
+		directorInfo := server_structs.DirectorResponse{}
+		directorInfo.XPelNsHdr.Namespace = "/my/namespace"
+		directorInfo.XPelAuthHdr.Issuers = []*url.URL{}
+
+		_, err := getIssuer(directorInfo, nonMatchingKidSet)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "/my/namespace")
+	})
 }

--- a/director/director_ui.go
+++ b/director/director_ui.go
@@ -106,43 +106,8 @@ type (
 		IOLoad                 float64                     `json:"ioLoad"`
 		StatusWeight           float64                     `json:"statusWeight"`           // The current EWMA-derived weight for this server's status, populated by the Director
 		StatusWeightLastUpdate int64                       `json:"statusWeightLastUpdate"` // The last time the status weight was updated, in epoch seconds
-		Namespaces             []NamespaceAdV2Response     `json:"namespaces"`
+		Namespaces             []server_structs.NamespaceAdV2Response     `json:"namespaces"`
 		Version                string                      `json:"version"`
-	}
-
-	// TokenIssuerResponse creates a response struct for TokenIssuer
-	TokenIssuerResponse struct {
-		BasePaths       []string `json:"basePaths"`
-		RestrictedPaths []string `json:"restrictedPaths"`
-		IssuerUrl       string   `json:"issuer"`
-	}
-
-	// TokenGenResponse creates a response struct for TokenGen
-	TokenGenResponse struct {
-		Strategy         server_structs.StrategyType `json:"strategy"`
-		VaultServer      string                      `json:"vaultServer"`
-		MaxScopeDepth    uint                        `json:"maxScopeDepth"`
-		CredentialIssuer string                      `json:"issuer"`
-	}
-
-	// NamespaceAdV2Response creates a response struct for NamespaceAdV2
-	NamespaceAdV2Response struct {
-		Path         string                      `json:"path"`
-		Caps         server_structs.Capabilities `json:"capabilities"`
-		Generation   []TokenGenResponse          `json:"tokenGeneration"`
-		Issuer       []TokenIssuerResponse       `json:"tokenIssuer"`
-		FromTopology bool                        `json:"fromTopology"`
-	}
-
-	// NamespaceAdV2MappedResponse creates a response struct for NamespaceAdV2 with mapped origins and caches
-	NamespaceAdV2MappedResponse struct {
-		Path         string                      `json:"path"`
-		Caps         server_structs.Capabilities `json:"capabilities"`
-		Generation   []TokenGenResponse          `json:"tokenGeneration"`
-		Issuer       []TokenIssuerResponse       `json:"tokenIssuer"`
-		FromTopology bool                        `json:"fromTopology"`
-		Origins      []string                    `json:"origins"`
-		Caches       []string                    `json:"caches"`
 	}
 
 	statRequest struct {
@@ -200,14 +165,14 @@ func listServers(ctx *gin.Context) {
 }
 
 // Convert NamespaceAdV2 to namespaceResponse
-func namespaceAdV2ToResponse(ns *server_structs.NamespaceAdV2) NamespaceAdV2Response {
-	res := NamespaceAdV2Response{
+func namespaceAdV2ToResponse(ns *server_structs.NamespaceAdV2) server_structs.NamespaceAdV2Response {
+	res := server_structs.NamespaceAdV2Response{
 		Path:         ns.Path,
 		Caps:         ns.Caps,
 		FromTopology: ns.FromTopology,
 	}
 	for _, gen := range ns.Generation {
-		res.Generation = append(res.Generation, TokenGenResponse{
+		res.Generation = append(res.Generation, server_structs.TokenGenResponse{
 			Strategy:         gen.Strategy,
 			VaultServer:      gen.VaultServer,
 			MaxScopeDepth:    gen.MaxScopeDepth,
@@ -215,7 +180,7 @@ func namespaceAdV2ToResponse(ns *server_structs.NamespaceAdV2) NamespaceAdV2Resp
 		})
 	}
 	for _, issuer := range ns.Issuer {
-		res.Issuer = append(res.Issuer, TokenIssuerResponse{
+		res.Issuer = append(res.Issuer, server_structs.TokenIssuerResponse{
 			BasePaths:       issuer.BasePaths,
 			RestrictedPaths: issuer.RestrictedPaths,
 			IssuerUrl:       issuer.IssuerUrl.String(),
@@ -225,9 +190,9 @@ func namespaceAdV2ToResponse(ns *server_structs.NamespaceAdV2) NamespaceAdV2Resp
 }
 
 // namespaceAdV2ToMappedResponse converts a NamespaceAdV2 to a NamespaceAdV2MappedResponse
-func namespaceAdV2ToMappedResponse(ns *server_structs.NamespaceAdV2) NamespaceAdV2MappedResponse {
+func namespaceAdV2ToMappedResponse(ns *server_structs.NamespaceAdV2) server_structs.NamespaceAdV2MappedResponse {
 	nsRes := namespaceAdV2ToResponse(ns)
-	return NamespaceAdV2MappedResponse{
+	return server_structs.NamespaceAdV2MappedResponse{
 		Path:       nsRes.Path,
 		Caps:       nsRes.Caps,
 		Generation: nsRes.Generation,
@@ -365,7 +330,7 @@ func listServerNamespaces(ctx *gin.Context) {
 		})
 		return
 	}
-	var nsRes []NamespaceAdV2Response
+	var nsRes []server_structs.NamespaceAdV2Response
 	for _, n := range server.NamespaceAds {
 		nsRes = append(nsRes, namespaceAdV2ToResponse(&n))
 	}
@@ -373,9 +338,9 @@ func listServerNamespaces(ctx *gin.Context) {
 }
 
 // Get list of all namespaces as a response
-func listNamespaceResponses() []NamespaceAdV2MappedResponse {
+func listNamespaceResponses() []server_structs.NamespaceAdV2MappedResponse {
 
-	namespaceMap := make(map[string]NamespaceAdV2MappedResponse)
+	namespaceMap := make(map[string]server_structs.NamespaceAdV2MappedResponse)
 
 	for _, a := range listAdvertisement([]server_structs.ServerType{server_structs.OriginType, server_structs.CacheType}) {
 		s := a.ServerAd

--- a/director/director_ui.go
+++ b/director/director_ui.go
@@ -88,26 +88,26 @@ type (
 		// AuthURL is Deprecated. For Pelican severs, URL is used as the base URL for object access.
 		// This is to maintain compatibility with the topology servers, where it uses AuthURL for
 		// accessing protected objects and URL for public objects.
-		AuthURL                string                      `json:"authUrl"`
-		BrokerURL              string                      `json:"brokerUrl"`
-		URL                    string                      `json:"url"`    // This is server's XRootD URL for file transfer
-		WebURL                 string                      `json:"webUrl"` // This is server's Web interface and API
-		Type                   string                      `json:"type"`
-		Coordinate             server_structs.Coordinate   `json:"coordinate"`
-		Latitude               float64                     `json:"latitude"`
-		Longitude              float64                     `json:"longitude"`
-		Caps                   server_structs.Capabilities `json:"capabilities"`
-		Filtered               bool                        `json:"filtered"`
-		FilteredType           string                      `json:"filteredType"`
-		Downtimes              []server_structs.Downtime   `json:"downtimes"`
-		FromTopology           bool                        `json:"fromTopology"`
-		HealthStatus           HealthTestStatus            `json:"healthStatus"`
-		ServerStatus           string                      `json:"serverStatus"` // see comment in listServerResponse
-		IOLoad                 float64                     `json:"ioLoad"`
-		StatusWeight           float64                     `json:"statusWeight"`           // The current EWMA-derived weight for this server's status, populated by the Director
-		StatusWeightLastUpdate int64                       `json:"statusWeightLastUpdate"` // The last time the status weight was updated, in epoch seconds
-		Namespaces             []server_structs.NamespaceAdV2Response     `json:"namespaces"`
-		Version                string                      `json:"version"`
+		AuthURL                string                                 `json:"authUrl"`
+		BrokerURL              string                                 `json:"brokerUrl"`
+		URL                    string                                 `json:"url"`    // This is server's XRootD URL for file transfer
+		WebURL                 string                                 `json:"webUrl"` // This is server's Web interface and API
+		Type                   string                                 `json:"type"`
+		Coordinate             server_structs.Coordinate              `json:"coordinate"`
+		Latitude               float64                                `json:"latitude"`
+		Longitude              float64                                `json:"longitude"`
+		Caps                   server_structs.Capabilities            `json:"capabilities"`
+		Filtered               bool                                   `json:"filtered"`
+		FilteredType           string                                 `json:"filteredType"`
+		Downtimes              []server_structs.Downtime              `json:"downtimes"`
+		FromTopology           bool                                   `json:"fromTopology"`
+		HealthStatus           HealthTestStatus                       `json:"healthStatus"`
+		ServerStatus           string                                 `json:"serverStatus"` // see comment in listServerResponse
+		IOLoad                 float64                                `json:"ioLoad"`
+		StatusWeight           float64                                `json:"statusWeight"`           // The current EWMA-derived weight for this server's status, populated by the Director
+		StatusWeightLastUpdate int64                                  `json:"statusWeightLastUpdate"` // The last time the status weight was updated, in epoch seconds
+		Namespaces             []server_structs.NamespaceAdV2Response `json:"namespaces"`
+		Version                string                                 `json:"version"`
 	}
 
 	statRequest struct {

--- a/director/director_ui_test.go
+++ b/director/director_ui_test.go
@@ -233,12 +233,12 @@ func TestGetServer(t *testing.T) {
 	require.True(t, serverAds.Has(mockOriginServerAd.URL.String()))
 	require.True(t, serverAds.Has(mockCacheServerAd.URL.String()))
 
-	expectedListOriginResNss := []NamespaceAdV2Response{}
+	expectedListOriginResNss := []server_structs.NamespaceAdV2Response{}
 	for _, ns := range mockOriginNamespace {
 		expectedListOriginResNss = append(expectedListOriginResNss, namespaceAdV2ToResponse(&ns))
 	}
 
-	expectedListCacheResNss := []NamespaceAdV2Response{}
+	expectedListCacheResNss := []server_structs.NamespaceAdV2Response{}
 	for _, ns := range mockCacheNamespace {
 		expectedListCacheResNss = append(expectedListCacheResNss, namespaceAdV2ToResponse(&ns))
 	}
@@ -325,7 +325,7 @@ func TestGetServer(t *testing.T) {
 		require.Equal(t, 200, w.Code)
 
 		// Check the data
-		var got []NamespaceAdV2Response
+		var got []server_structs.NamespaceAdV2Response
 		err := json.Unmarshal(w.Body.Bytes(), &got)
 		require.NoError(t, err)
 		require.Equal(t, len(mockOriginNamespace), len(got))
@@ -393,13 +393,13 @@ func TestGetNamespaces(t *testing.T) {
 		require.Equal(t, 200, w.Code)
 
 		// Check the data
-		var got []NamespaceAdV2MappedResponse
+		var got []server_structs.NamespaceAdV2MappedResponse
 		err := json.Unmarshal(w.Body.Bytes(), &got)
 		require.NoError(t, err)
 		require.Equal(t, len(mockOriginNamespace)+len(mockCacheNamespace), len(got))
 
 		// Create the list of expected responses we should see by adding origin/cache names
-		var expected []NamespaceAdV2MappedResponse
+		var expected []server_structs.NamespaceAdV2MappedResponse
 		for _, ns := range mockOriginNamespace {
 			nsRes := namespaceAdV2ToMappedResponse(&ns)
 			nsRes.Origins = append(nsRes.Origins, mockOriginServerAd.Name)
@@ -443,13 +443,13 @@ func TestGetNamespaces(t *testing.T) {
 		require.Equal(t, 200, w.Code)
 
 		// Check the data
-		var got []NamespaceAdV2MappedResponse
+		var got []server_structs.NamespaceAdV2MappedResponse
 		err := json.Unmarshal(w.Body.Bytes(), &got)
 		require.NoError(t, err)
 		require.Equal(t, len(mockNamespaceSet0)+len(mockNamespaceSet1), len(got))
 
 		// Create the list of expected responses we should see by adding origin/cache names
-		expected := make(map[string]NamespaceAdV2MappedResponse)
+		expected := make(map[string]server_structs.NamespaceAdV2MappedResponse)
 		for _, ns := range append(mockNamespaceSet1, mockNamespaceSet0...) {
 			nsRes := namespaceAdV2ToMappedResponse(&ns)
 			nsRes.Origins = append(nsRes.Origins, mockOriginServerAd.Name)

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -313,29 +313,29 @@ type (
 	// TokenGenResponse creates a response struct for TokenGen
 	TokenGenResponse struct {
 		Strategy         StrategyType `json:"strategy"`
-		VaultServer      string                      `json:"vaultServer"`
-		MaxScopeDepth    uint                        `json:"maxScopeDepth"`
-		CredentialIssuer string                      `json:"issuer"`
+		VaultServer      string       `json:"vaultServer"`
+		MaxScopeDepth    uint         `json:"maxScopeDepth"`
+		CredentialIssuer string       `json:"issuer"`
 	}
 
 	// NamespaceAdV2Response creates a response struct for NamespaceAdV2
 	NamespaceAdV2Response struct {
-		Path         string                      `json:"path"`
-		Caps         Capabilities `json:"capabilities"`
-		Generation   []TokenGenResponse          `json:"tokenGeneration"`
-		Issuer       []TokenIssuerResponse       `json:"tokenIssuer"`
-		FromTopology bool                        `json:"fromTopology"`
+		Path         string                `json:"path"`
+		Caps         Capabilities          `json:"capabilities"`
+		Generation   []TokenGenResponse    `json:"tokenGeneration"`
+		Issuer       []TokenIssuerResponse `json:"tokenIssuer"`
+		FromTopology bool                  `json:"fromTopology"`
 	}
 
 	// NamespaceAdV2MappedResponse creates a response struct for NamespaceAdV2 with mapped origins and caches
 	NamespaceAdV2MappedResponse struct {
-		Path         string                      `json:"path"`
-		Caps         Capabilities `json:"capabilities"`
-		Generation   []TokenGenResponse          `json:"tokenGeneration"`
-		Issuer       []TokenIssuerResponse       `json:"tokenIssuer"`
-		FromTopology bool                        `json:"fromTopology"`
-		Origins      []string                    `json:"origins"`
-		Caches       []string                    `json:"caches"`
+		Path         string                `json:"path"`
+		Caps         Capabilities          `json:"capabilities"`
+		Generation   []TokenGenResponse    `json:"tokenGeneration"`
+		Issuer       []TokenIssuerResponse `json:"tokenIssuer"`
+		FromTopology bool                  `json:"fromTopology"`
+		Origins      []string              `json:"origins"`
+		Caches       []string              `json:"caches"`
 	}
 )
 

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -300,6 +300,43 @@ type (
 	}
 
 	AdAfter int // Ternary logic for the `Ad.After` function
+
+	/////////////////////////
+	// Director UI structs //
+	/////////////////////////
+	TokenIssuerResponse struct {
+		BasePaths       []string `json:"basePaths"`
+		RestrictedPaths []string `json:"restrictedPaths"`
+		IssuerUrl       string   `json:"issuer"`
+	}
+
+	// TokenGenResponse creates a response struct for TokenGen
+	TokenGenResponse struct {
+		Strategy         StrategyType `json:"strategy"`
+		VaultServer      string                      `json:"vaultServer"`
+		MaxScopeDepth    uint                        `json:"maxScopeDepth"`
+		CredentialIssuer string                      `json:"issuer"`
+	}
+
+	// NamespaceAdV2Response creates a response struct for NamespaceAdV2
+	NamespaceAdV2Response struct {
+		Path         string                      `json:"path"`
+		Caps         Capabilities `json:"capabilities"`
+		Generation   []TokenGenResponse          `json:"tokenGeneration"`
+		Issuer       []TokenIssuerResponse       `json:"tokenIssuer"`
+		FromTopology bool                        `json:"fromTopology"`
+	}
+
+	// NamespaceAdV2MappedResponse creates a response struct for NamespaceAdV2 with mapped origins and caches
+	NamespaceAdV2MappedResponse struct {
+		Path         string                      `json:"path"`
+		Caps         Capabilities `json:"capabilities"`
+		Generation   []TokenGenResponse          `json:"tokenGeneration"`
+		Issuer       []TokenIssuerResponse       `json:"tokenIssuer"`
+		FromTopology bool                        `json:"fromTopology"`
+		Origins      []string                    `json:"origins"`
+		Caches       []string                    `json:"caches"`
+	}
 )
 
 var (

--- a/token/token_verify.go
+++ b/token/token_verify.go
@@ -20,10 +20,8 @@ package token
 
 import (
 	"context"
-	"encoding/json"
 	errors_default "errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -477,123 +475,6 @@ func GetAuthzEscaped(ctx *gin.Context) (authzEscaped string) {
 		authzEscaped = url.QueryEscape(authzCookie)
 	}
 	return
-}
-
-// For a given prefix, get the prefix's issuer URL, where we consider that the openid endpoint
-// we use to look up a key location. Note that this is NOT the same as the issuer key -- to
-// find that, follow openid-style discovery using the issuer URL as a base.
-func GetNSIssuerURL(prefix string) (string, error) {
-	if prefix == "" || !strings.HasPrefix(prefix, "/") {
-		return "", errors.New(fmt.Sprintf("the prefix \"%s\" is invalid", prefix))
-	}
-	fedInfo, err := config.GetFederation(context.Background())
-	if err != nil {
-		return "", err
-	}
-	registryUrlStr := fedInfo.RegistryEndpoint
-	if registryUrlStr == "" {
-		return "", errors.New("federation registry URL is not set and was not discovered")
-	}
-	registryUrl, err := url.Parse(registryUrlStr)
-	if err != nil {
-		return "", err
-	}
-
-	registryUrl.Path, err = url.JoinPath(registryUrl.Path, "api", "v1.0", "registry", prefix)
-
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to construct openid-configuration lookup URL for prefix %s", prefix)
-	}
-	return registryUrl.String(), nil
-}
-
-// Given an issuer url, lookup the JWKS URL from the openid-configuration
-// For example, if the issuer URL is https://registry.com:8446/api/v1.0/registry/test-namespace,
-// this function will return the key indicated by the openid-configuration JSON hosted at
-// https://registry.com:8446/api/v1.0/registry/test-namespace/.well-known/openid-configuration.
-func GetJWKSURLFromIssuerURL(issuerUrl string) (string, error) {
-	// Get/parse the openid-configuration JSON to lookup key location
-	issOpenIDUrl, err := url.Parse(issuerUrl)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to parse issuer URL")
-	}
-	issOpenIDUrl.Path, _ = url.JoinPath(issOpenIDUrl.Path, ".well-known", "openid-configuration")
-
-	client := &http.Client{Transport: config.GetTransport()}
-	openIDCfg, err := client.Get(issOpenIDUrl.String())
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to lookup openid-configuration for issuer %s", issuerUrl)
-	}
-	defer openIDCfg.Body.Close()
-
-	// If we hit an old registry, it may not have the openid-configuration. In that case, we fallback to the old
-	// behavior of looking for the key directly at the issuer URL.
-	if openIDCfg.StatusCode == http.StatusNotFound {
-		oldKeyLoc, err := url.JoinPath(issuerUrl, ".well-known", "issuer.jwks")
-		if err != nil {
-			return "", errors.Wrapf(err, "failed to construct key lookup URL for issuer %s", issuerUrl)
-		}
-		return oldKeyLoc, nil
-	}
-
-	body, err := io.ReadAll(openIDCfg.Body)
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to read response body from %s", issuerUrl)
-	}
-
-	var openIDCfgMap map[string]string
-	err = json.Unmarshal(body, &openIDCfgMap)
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to unmarshal openid-configuration for issuer %s", issuerUrl)
-	}
-
-	if keyLoc, ok := openIDCfgMap["jwks_uri"]; ok {
-		return keyLoc, nil
-	} else {
-		return "", errors.New(fmt.Sprintf("no key found in openid-configuration for issuer %s", issuerUrl))
-	}
-}
-
-func GetJWKSFromIssUrl(issuer string) (*jwk.Set, error) {
-	// Make sure our URL is solid
-	issuerUrl, err := url.Parse(issuer)
-	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintln("Invalid issuer URL: ", issuerUrl))
-	}
-
-	// Discover the JWKS URL from the issuer
-	pubkeyUrlStr, err := GetJWKSURLFromIssuerURL(issuerUrl.String())
-	if err != nil {
-		return nil, errors.Wrap(err, "Error getting JWKS URL from issuer URL")
-	}
-
-	// Query the JWKS URL for the public keys
-	httpClient := config.GetClient()
-	req, err := http.NewRequest("GET", pubkeyUrlStr, nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "Error creating request to issuer's JWKS URL")
-	}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Error querying issuer's key endpoint (%s)", pubkeyUrlStr)
-	}
-	defer resp.Body.Close()
-	// Check the response code, make sure it's not in the error ranges (400-500)
-	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		return nil, errors.Errorf("The issuer's JWKS endpoint returned an unexpected status: %s", resp.Status)
-	}
-
-	// Read the response body and parse the JWKs from it
-	jwksStr, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Error reading response body from %s", pubkeyUrlStr)
-	}
-	kSet, err := jwk.ParseString(string(jwksStr))
-	if err != nil {
-		return nil, errors.Wrapf(err, "Error parsing JWKs from %s", pubkeyUrlStr)
-	}
-
-	return &kSet, nil
 }
 
 // CheckApiTokenIssuerFunc is a hook for verifying API tokens against the database.

--- a/utils/registry_jwks/registry_jwks.go
+++ b/utils/registry_jwks/registry_jwks.go
@@ -95,17 +95,21 @@ func GetJWKSURLFromIssuerURL(issuerUrl string) (string, error) {
 		return "", errors.Wrapf(err, "failed to read response body from %s", issuerUrl)
 	}
 
-	var openIDCfgMap map[string]string
+	// Use a struct instead of map[string]string: some OpenID configuration fields
+	// (e.g. token_endpoint_auth_methods_supported) are JSON arrays, which would
+	// cause Unmarshal to fail if the target type is map[string]string.
+	var openIDCfgMap struct {
+		JwksUri string `json:"jwks_uri"`
+	}
 	err = json.Unmarshal(body, &openIDCfgMap)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to unmarshal openid-configuration for issuer %s", issuerUrl)
 	}
 
-	if keyLoc, ok := openIDCfgMap["jwks_uri"]; ok {
-		return keyLoc, nil
-	} else {
-		return "", errors.New(fmt.Sprintf("no key found in openid-configuration for issuer %s", issuerUrl))
+	if openIDCfgMap.JwksUri != "" {
+		return openIDCfgMap.JwksUri, nil
 	}
+	return "", errors.New(fmt.Sprintf("no key found in openid-configuration for issuer %s", issuerUrl))
 }
 
 // Given an issuer URL, get the JWKS from the issuer's JWKS URL

--- a/utils/registry_jwks/registry_jwks_test.go
+++ b/utils/registry_jwks/registry_jwks_test.go
@@ -1,0 +1,102 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package registry_jwks
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetJWKSURLFromIssuerURL(t *testing.T) {
+	t.Run("succeeds with minimal openid-configuration", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/.well-known/openid-configuration", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"jwks_uri": "https://example.com/jwks"}`)
+		}))
+		defer srv.Close()
+
+		got, err := GetJWKSURLFromIssuerURL(srv.URL)
+		require.NoError(t, err)
+		assert.Equal(t, "https://example.com/jwks", got)
+	})
+
+	// Regression test for https://github.com/PelicanPlatform/pelican/issues/2941:
+	// The previous map[string]string unmarshal target failed whenever the OpenID
+	// configuration document contained array-valued fields such as
+	// token_endpoint_auth_methods_supported. The struct-based approach only
+	// extracts jwks_uri and ignores all other fields regardless of their type.
+	t.Run("succeeds when openid-configuration contains array-valued fields", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{
+				"issuer": "https://example.com",
+				"jwks_uri": "https://example.com/jwks",
+				"token_endpoint_auth_methods_supported": ["client_secret_basic", "private_key_jwt"],
+				"scopes_supported": ["openid", "email", "profile"],
+				"claims_supported": ["sub", "iss", "aud"]
+			}`)
+		}))
+		defer srv.Close()
+
+		got, err := GetJWKSURLFromIssuerURL(srv.URL)
+		require.NoError(t, err)
+		assert.Equal(t, "https://example.com/jwks", got)
+	})
+
+	t.Run("returns error when jwks_uri is absent", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"issuer": "https://example.com"}`)
+		}))
+		defer srv.Close()
+
+		_, err := GetJWKSURLFromIssuerURL(srv.URL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no key found")
+	})
+
+	t.Run("falls back to issuer.jwks path on 404", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		got, err := GetJWKSURLFromIssuerURL(srv.URL)
+		require.NoError(t, err)
+		assert.Contains(t, got, ".well-known/issuer.jwks")
+	})
+
+	t.Run("returns error on invalid JSON body", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `not valid json`)
+		}))
+		defer srv.Close()
+
+		_, err := GetJWKSURLFromIssuerURL(srv.URL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to unmarshal")
+	})
+}


### PR DESCRIPTION
In addition to some general cleanup, this PR does the following:
- We now warn the user when they're trying to create a token with a scope that doesn't appear to be supported as determined by the namespace ad.
- We fix the issue where failure to match a KID against a supplied list of issuers manifested as "no issuer found". Now we more clearly say "there were issuers, but none of them matched the signing key you're using"
- When the namespace doesn't require token auth for reads and doesn't support writes, it may not advertise an issuer. Rather than reporting we couldn't find the issuer, we now report that the user likely doesn't need to create a token in the first place.

Here's a description of some of the hand testing I ran:
1. Set up a namespace that does not require any auth -- previously caused an error about missing issuers, now emits a warning that the namespace likely doesn't need a token:
```
$ pelican token create --read pelican://`hostname`:4443/my-prefix2/foo.txt
WARNING[2026-05-21T16:52:02Z] Director indicates that the resource at pelican://0ee241b2e244:4443/my-prefix2/foo.txt is publicly readable so a token is not actually required to read it, but the --read flag was provided; adding read scope to token anyway 
Error: unable to determine issuer for resource pelican://0ee241b2e244:4443/my-prefix2/foo.txt. This is likely because the Director reports that this namespace does not require token issuance for reads and does not support writes. Are you sure you need a token? You may need to re-run with '--issuer <issuer URL>' to specify an issuer: no issuers found for /my-prefix2 in the Director response
```
Note that in this example, an error is returned with no token because the tool lacks sufficient information to produce the token.
2. This is already demonstrated by the previous example, but the tool now emits a warning when requested scopes don't align with the namespace capabilities for the specified resource. To test, I set up a namespace with protected reads but no writes:
```
$ pelican token create --write --modify pelican://`hostname`:4443/my-prefix2/foo.txt
WARNING[2026-05-21T16:55:35Z] Director indicates that the resource at pelican://0ee241b2e244:4443/my-prefix2/foo.txt does not support write/modify operations, but --write flag was provided; adding write scope to token anyway 
WARNING[2026-05-21T16:55:35Z] Director indicates that the resource at pelican://0ee241b2e244:4443/my-prefix2/foo.txt does not support write/modify operations, but --modify flag was provided; adding modify scope to token anyway 
WARNING[2026-05-21T16:55:35Z] Unable to get current user, using 'pelican_client' as default token subject 
<the token>
```

Lastly, the setup to hand test fixes for #2941 were a bit more involved than I had energy for. For that I rely on the unit tests, which are evidence enough for me that the bug is fixed.

Closes #3233
Closes #2719
Closes #2941