### PR TITLE
Fix JWT Clock Skew Tolerance

### DIFF
--- a/broker/token_utils.go
+++ b/broker/token_utils.go
@@ -158,8 +158,8 @@ func createToken(namespace, subject, audience string, desiredScope token_scopes.
 	return
 }
 
-func getCacheHostnameFromToken(token []byte) (hostname string, err error) {
-	tok, err := jwt.Parse(token, jwt.WithVerify(false), jwt.WithValidate(false))
+func getCacheHostnameFromToken(tokenBytes []byte) (hostname string, err error) {
+	tok, err := token.UnsafeParseClaims(string(tokenBytes))
 	if err != nil {
 		return
 	}
@@ -178,21 +178,15 @@ func getCacheHostnameFromToken(token []byte) (hostname string, err error) {
 
 // Given a token and a namespace prefix, determine if it has the desired scope
 // and audience.
-func verifyToken(ctx context.Context, token, namespace, audience string, requiredScope token_scopes.TokenScope) (ok bool, err error) {
+func verifyToken(ctx context.Context, tokenStr, namespace, audience string, requiredScope token_scopes.TokenScope) (ok bool, err error) {
 	issuerUrl, keyset, err := getRegistryIssuerInfo(ctx, namespace)
 	if err != nil {
 		err = errors.Wrapf(err, "failed to get issuer info for namespace %s", namespace)
 		return
 	}
 
-	tok, err := jwt.Parse([]byte(token), jwt.WithKeySet(keyset), jwt.WithValidate(true))
-	if err != nil {
-		err = errors.Wrap(err, "failed to parse token")
-		return
-	}
-
 	scopeValidator := token_scopes.CreateScopeValidator([]token_scopes.TokenScope{requiredScope}, false)
-	err = jwt.Validate(tok,
+	_, err = token.VerifyWithKeyset(tokenStr, keyset,
 		jwt.WithAudience(audience),
 		jwt.WithValidator(scopeValidator),
 		jwt.WithClaimValue("iss", issuerUrl),
@@ -200,7 +194,7 @@ func verifyToken(ctx context.Context, token, namespace, audience string, require
 	if err == nil {
 		ok = true
 	} else {
-		err = errors.Wrap(err, "failed to validate token")
+		err = errors.Wrap(err, "failed to verify token")
 	}
 	return
 }

--- a/cache/advertise.go
+++ b/cache/advertise.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -246,8 +245,8 @@ func (server *CacheServer) GetFedTokLocation() string {
 // Given a token, calculate the lifetime of the token
 func calcTokLifetime(tok string) (time.Duration, error) {
 	// I think verificationless parsing is fine here, because we already assume a strong
-	// trust relationship with the Director, and if its been compromised, we have bigger problems.
-	parsedTok, err := jwt.ParseInsecure([]byte(tok))
+	// trust relationship with the Director, and if it's been compromised, we have bigger problems.
+	parsedTok, err := token.UnsafeParseClaims(tok)
 	if err != nil {
 		return 0, err
 	}

--- a/client/acquire_token.go
+++ b/client/acquire_token.go
@@ -488,7 +488,7 @@ func (tg *tokenGenerator) Get() (token string, err error) {
 // Given jwtSerialized, a serialized JWT, return whether or not the scopes
 // would authorize the given objectName based on the information in dirResp.
 func tokenIsAcceptable(jwtSerialized string, objectName string, dirResp server_structs.DirectorResponse, opts config.TokenGenerationOpts) bool {
-	tok, err := jwt.Parse([]byte(jwtSerialized), jwt.WithVerify(false), jwt.WithValidate(false))
+	tok, err := token.UnsafeParseClaims(jwtSerialized)
 	if err != nil {
 		log.Warningln("Failed to parse token:", err)
 		return false
@@ -702,28 +702,32 @@ func isValidSciScope(authz string, operation config.TokenOperation) bool {
 //
 // If valid, then the function also returns the expiration time.
 func tokenIsValid(jwtSerialized string) (valid bool, expiry time.Time) {
-	token, err := jwt.Parse([]byte(jwtSerialized), jwt.WithVerify(false))
+	tok, err := token.UnsafeParseClaims(jwtSerialized)
 	if err != nil {
 		log.Warningln("Failed to parse token:", err)
 		return
 	}
 
-	if err := jwt.Validate(token); err != nil {
+	// Zero-skew validation is intentional here.
+	// Applying a leeway could allow the client to reuse a token
+	// that is just about to expire
+	// and might already be rejected by the server.
+	if err := jwt.Validate(tok); err != nil {
 		log.Warningln("Token is invalid:", err)
-		return false, token.Expiration()
+		return false, tok.Expiration()
 	}
 
 	valid = true
-	expiry = token.Expiration()
+	expiry = tok.Expiration()
 	return
 }
 
 func tokenIsExpired(jwtSerialized string) (expired bool, expiry time.Time, err error) {
-	token, err := jwt.Parse([]byte(jwtSerialized), jwt.WithVerify(false), jwt.WithValidate(false))
+	tok, err := token.UnsafeParseClaims(jwtSerialized)
 	if err != nil {
 		return
 	}
-	return token.Expiration().Before(time.Now()), token.Expiration(), nil
+	return tok.Expiration().Before(time.Now()), tok.Expiration(), nil
 }
 
 func registerClient(dirResp server_structs.DirectorResponse) (*config.PrefixEntry, error) {

--- a/director/director.go
+++ b/director/director.go
@@ -1,6 +1,6 @@
 /***************************************************************
 *
-* Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+* Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
 *
 * Licensed under the Apache License, Version 2.0 (the "License"); you
 * may not use this file except in compliance with the License.  You may
@@ -1317,7 +1317,7 @@ func registerServerAd(engineCtx context.Context, ctx *gin.Context, sType server_
 				metrics.PelicanDirectorRejectedAdvertisements.With(prometheus.Labels{"hostname": adV2.Name}).Inc()
 				return
 			} else {
-				log.Warningln("Failed to verify token:", err)
+				log.Warningf("Failed to verify advertise token for %s %q (prefix %q): %v", sType.String(), adV2.Name, registryPrefix, err)
 				ctx.JSON(http.StatusForbidden, server_structs.SimpleApiResp{
 					Status: server_structs.RespFailed,
 					Msg:    fmt.Sprintf("Authorization token verification failed %v", err),
@@ -1350,7 +1350,7 @@ func registerServerAd(engineCtx context.Context, ctx *gin.Context, sType server_
 					metrics.PelicanDirectorRejectedAdvertisements.With(prometheus.Labels{"hostname": adV2.Name}).Inc()
 					return
 				} else {
-					log.Warningln("Failed to verify token:", err)
+					log.Warningf("Failed to verify advertise token for namespace %q from %s %q: %v", namespace.Path, sType.String(), adV2.Name, err)
 					ctx.JSON(http.StatusForbidden, server_structs.SimpleApiResp{
 						Status: server_structs.RespFailed,
 						Msg:    fmt.Sprintf("Authorization token verification failed: %v", err),

--- a/director/director.go
+++ b/director/director.go
@@ -36,7 +36,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-version"
 	"github.com/jellydator/ttlcache/v3"
-	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
@@ -746,7 +745,7 @@ func validateClientToken(ctx *gin.Context, requestId uuid.UUID) (int, error) {
 	// Parse the token without signature verification — we only need the expiration claim.
 	// Not all bearer tokens are JWTs (e.g., opaque tokens, SciTokens v1); if parsing
 	// fails, treat the token as valid and let the origin/cache decide.
-	parsed, err := jwt.Parse([]byte(rawToken), jwt.WithVerify(false), jwt.WithValidate(false))
+	parsed, err := token.UnsafeParseClaims(rawToken)
 	if err != nil {
 		return http.StatusOK, nil
 	}

--- a/director/director_advertise.go
+++ b/director/director_advertise.go
@@ -164,6 +164,7 @@ func registerDirectorAd(appCtx context.Context, egrp *errgroup.Group, ctx *gin.C
 		Scopes:  []token_scopes.TokenScope{token_scopes.Pelican_DirectorAdvertise},
 	})
 	if !ok || err != nil {
+		log.Warningf("Failed to verify director advertise token from %s: %v", ctx.ClientIP(), err)
 		ctx.JSON(status, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    fmt.Sprint("Failed to verify the token: ", err),

--- a/director/fed_token_test.go
+++ b/director/fed_token_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/lestrrat-go/jwx/v2/jwt"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,6 +37,7 @@ import (
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
+	"github.com/pelicanplatform/pelican/token"
 )
 
 var setGinTestModeOnce sync.Once
@@ -174,7 +174,7 @@ func TestValidateRequest(t *testing.T) {
 
 func parseJWT(tokenString string) (scopes []string, issuer string, err error) {
 	// Parse without verification
-	tok, err := jwt.ParseInsecure([]byte(tokenString))
+	tok, err := token.UnsafeParseClaims(tokenString)
 	if err != nil {
 		return nil, "", err
 	}

--- a/director/origin_api.go
+++ b/director/origin_api.go
@@ -30,13 +30,13 @@ import (
 
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/lestrrat-go/jwx/v2/jwk"
-	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
 	"github.com/pelicanplatform/pelican/utils"
 	"github.com/pelicanplatform/pelican/utils/registry_jwks"
@@ -106,7 +106,7 @@ func checkNamespaceStatus(prefix string, registryWebUrlStr string) (bool, error)
 // Given a token and a location in the namespace to advertise in,
 // see if the entity is authorized to advertise an origin for the
 // namespace
-func verifyAdvertiseToken(ctx context.Context, token, namespace string) (bool, error) {
+func verifyAdvertiseToken(ctx context.Context, tokenStr, namespace string) (bool, error) {
 	issuerUrl, err := registry_jwks.GetNSIssuerURL(namespace)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to get issuer for namespace "+namespace)
@@ -151,7 +151,7 @@ func verifyAdvertiseToken(ctx context.Context, token, namespace string) (bool, e
 		namespaceKeys.Set(keyLoc, keyset, param.Director_AdvertisementTTL.GetDuration())
 	}
 
-	tok, err := jwt.Parse([]byte(token), jwt.WithKeySet(keyset), jwt.WithValidate(true))
+	tok, err := token.VerifyWithKeyset(tokenStr, keyset)
 	if err != nil {
 		return false, err
 	}

--- a/e2e_fed_tests/director_test.go
+++ b/e2e_fed_tests/director_test.go
@@ -33,7 +33,6 @@ import (
 	"time"
 
 	_ "github.com/glebarez/sqlite"
-	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -45,6 +44,7 @@ import (
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/test_utils"
+	"github.com/pelicanplatform/pelican/token"
 )
 
 //go:embed resources/both-public.yml
@@ -260,7 +260,7 @@ func TestDirectorFedTokenCacheAPI(t *testing.T) {
 			require.NoError(t, err, "Failed to get cache's advertisement token")
 			require.NotEmpty(t, tokStr, "Got an empty token")
 
-			tok, err := jwt.ParseInsecure([]byte(tokStr))
+			tok, err := token.UnsafeParseClaims(tokStr)
 			require.NoError(t, err, "Failed to parse token")
 			// The fed-test utility uses a separate HTTP server for hosting federation metadata,
 			// and sets it as the Discovery endpoint -- tokens need to be issued by that endpoint

--- a/local_cache/cache_authz.go
+++ b/local_cache/cache_authz.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/lestrrat-go/jwx/v2/jwk"
-	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -196,12 +195,12 @@ func nsAdsAuthzEqual(old, new []server_structs.NamespaceAdV2) bool {
 	return true
 }
 
-func (ac *authConfig) getResourceScopes(token string) (scopes []token_scopes.ResourceScope, issuer string, err error) {
-	if token == "" {
+func (ac *authConfig) getResourceScopes(tokenStr string) (scopes []token_scopes.ResourceScope, issuer string, err error) {
+	if tokenStr == "" {
 		return
 	}
 
-	tok, err := jwt.Parse([]byte(token), jwt.WithVerify(false))
+	tok, err := token.UnsafeParseClaims(tokenStr)
 	if err != nil {
 		err = errors.Wrap(err, "failed to parse incoming JWT when authorizing request")
 		return
@@ -235,14 +234,9 @@ func (ac *authConfig) getResourceScopes(token string) (scopes []token_scopes.Res
 		}
 		return
 	}
-	tok, err = jwt.Parse([]byte(token), jwt.WithKeySet(item.set))
+	tok, err = token.VerifyWithKeyset(tokenStr, item.set)
 	if err != nil {
-		return
-	}
-
-	err = jwt.Validate(tok)
-	if err != nil {
-		err = errors.Wrap(err, "unable to get resource scopes because validation failed")
+		err = errors.Wrap(err, "unable to get resource scopes because verification failed")
 		return
 	}
 

--- a/lotman/lotman_ui.go
+++ b/lotman/lotman_ui.go
@@ -61,7 +61,7 @@ func tokenSignedByAuthorizedCaller(strToken string, authorizedCallers *[]string)
 			log.Debugf("Error getting JWKS for owner %s: %v", owner, err)
 			continue
 		}
-		tok, err = jwt.Parse([]byte(strToken), jwt.WithKeySet(*kSet), jwt.WithValidate(true))
+		tok, err = token.VerifyWithKeyset(strToken, *kSet)
 		if err != nil {
 			log.Debugf("Token verification failed with owner %s: %v -- skipping", owner, err)
 			continue
@@ -126,7 +126,7 @@ func VerifyNewLotToken(lot *Lot, strToken string) (bool, error) {
 			return false, errors.Wrap(err, "Error getting JWKS from issuer URL")
 		}
 
-		tok, err = jwt.Parse([]byte(strToken), jwt.WithKeySet(*kSet), jwt.WithValidate(true))
+		tok, err = token.VerifyWithKeyset(strToken, *kSet)
 		if err != nil {
 			return false, errors.Wrap(err, "Error parsing token")
 		}
@@ -158,7 +158,7 @@ func VerifyNewLotToken(lot *Lot, strToken string) (bool, error) {
 				log.Debugf("Error getting JWKS for owner %s: %v", owner, err)
 				continue
 			}
-			tok, err = jwt.Parse([]byte(strToken), jwt.WithKeySet(*kSet), jwt.WithValidate(true))
+			tok, err = token.VerifyWithKeyset(strToken, *kSet)
 			if err != nil {
 				log.Debugf("Token verification failed with owner %s: %v -- skipping", owner, err)
 				continue
@@ -348,8 +348,8 @@ func uiCreateLot(ctx *gin.Context) {
 
 	// TODO: Figure out the best way to inform the user that we ignore any owner or parent they set, because we handle that internally.
 
-	token := token.GetAuthzEscaped(ctx)
-	if token == "" {
+	tokenStr := token.GetAuthzEscaped(ctx)
+	if tokenStr == "" {
 		log.Debugln("No token provided in request")
 		ctx.AbortWithStatusJSON(http.StatusForbidden, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
@@ -362,7 +362,7 @@ func uiCreateLot(ctx *gin.Context) {
 	// need to handle a case where the lot for /foo/bar/baz is created before /foo/bar. Currently, if these are the
 	// first two lots we create with this endpoint, then both will be set to have "root" as a parent, and we'd like
 	// /foo/bar/baz to be modified to have /foo/bar as a parent. This gets complicated, so let's punt on it for now.
-	ok, err := VerifyNewLotToken(&lot, token)
+	ok, err := VerifyNewLotToken(&lot, tokenStr)
 
 	// TODO: Distinguish between true errors and unauthorized errors
 	if err != nil {
@@ -385,13 +385,14 @@ func uiCreateLot(ctx *gin.Context) {
 	// For creating lots, the Lotman caller must be set to an owner of a parent. Since the incoming token
 	// was presumably signed by someone with the necessary permissions, we can use the token's issuer as the
 	// Lotman caller.
-	tok, err := jwt.Parse([]byte(token), jwt.WithVerify(false), jwt.WithValidate(false))
+	tok, err := token.UnsafeParseClaims(tokenStr)
 	if err != nil {
 		log.Debugf("Failed to parse token while determining Lotman Caller: %v", err)
 		ctx.AbortWithStatusJSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    "Failed to parse token while determining Lotman Caller",
 		})
+		return
 	}
 	caller := tok.Issuer()
 
@@ -485,8 +486,8 @@ func uiUpdateLot(ctx *gin.Context) {
 		lotUpdate.Paths = nil
 	}
 
-	token := token.GetAuthzEscaped(ctx)
-	if token == "" {
+	tokenStr := token.GetAuthzEscaped(ctx)
+	if tokenStr == "" {
 		log.Debugln("No token provided in request")
 		ctx.AbortWithStatusJSON(http.StatusForbidden, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
@@ -495,7 +496,7 @@ func uiUpdateLot(ctx *gin.Context) {
 		return
 	}
 
-	ok, err := VerifyLotModTokens(lotUpdate.LotName, token, LotUpdateAction)
+	ok, err := VerifyLotModTokens(lotUpdate.LotName, tokenStr, LotUpdateAction)
 
 	// TODO: Distinguish between true errors and unauthorized errors
 	if err != nil {
@@ -518,13 +519,14 @@ func uiUpdateLot(ctx *gin.Context) {
 	// For updating lots, the Lotman caller must be set to an owner of a parent. Since the incoming token
 	// was presumably signed by someone with the necessary permissions, we can use the token's issuer as the
 	// Lotman caller.
-	tok, err := jwt.Parse([]byte(token), jwt.WithVerify(false), jwt.WithValidate(false))
+	tok, err := token.UnsafeParseClaims(tokenStr)
 	if err != nil {
 		log.Debugf("Failed to parse token while determining Lotman Caller: %v", err)
 		ctx.AbortWithStatusJSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    "Failed to parse token while determining Lotman Caller",
 		})
+		return
 	}
 
 	caller := tok.Issuer()
@@ -555,8 +557,8 @@ func uiDeleteLot(ctx *gin.Context) {
 		return
 	}
 
-	token := token.GetAuthzEscaped(ctx)
-	if token == "" {
+	tokenStr := token.GetAuthzEscaped(ctx)
+	if tokenStr == "" {
 		log.Debugln("No token provided in request")
 		ctx.AbortWithStatusJSON(http.StatusForbidden, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
@@ -565,7 +567,7 @@ func uiDeleteLot(ctx *gin.Context) {
 		return
 	}
 
-	ok, err := VerifyLotModTokens(lotName, token, LotDeleteAction)
+	ok, err := VerifyLotModTokens(lotName, tokenStr, LotDeleteAction)
 
 	// TODO: Distinguish between true errors and unauthorized errors
 	if err != nil {
@@ -588,13 +590,14 @@ func uiDeleteLot(ctx *gin.Context) {
 	// For creating lots, the Lotman caller must be set to an owner of a parent. Since the incoming token
 	// was presumably signed by someone with the necessary permissions, we can use the token's issuer as the
 	// Lotman caller.
-	tok, err := jwt.Parse([]byte(token), jwt.WithVerify(false), jwt.WithValidate(false))
+	tok, err := token.UnsafeParseClaims(tokenStr)
 	if err != nil {
 		log.Debugf("Failed to parse token while determining Lotman Caller: %v", err)
 		ctx.AbortWithStatusJSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    "Failed to parse token while determining Lotman Caller",
 		})
+		return
 	}
 	caller := tok.Issuer()
 

--- a/origin/collections.go
+++ b/origin/collections.go
@@ -94,8 +94,8 @@ func verifyCollectionScope(ctx *gin.Context, expectedScope token_scopes.TokenSco
 		return false
 	}
 
-	// Parse token (without verification first to check issuer)
-	tok, err := jwt.Parse([]byte(tokenStr), jwt.WithVerify(false))
+	// Parse token without verification first to check issuer
+	tok, err := token.UnsafeParseClaims(tokenStr)
 	if err != nil {
 		log.Debugf("verifyCollectionScope: Failed to parse token (no verify): %v", err)
 		return false
@@ -117,15 +117,9 @@ func verifyCollectionScope(ctx *gin.Context, expectedScope token_scopes.TokenSco
 		return false
 	}
 
-	parsed, err := jwt.Parse([]byte(tokenStr), jwt.WithKeySet(jwks))
+	parsed, err := token.VerifyWithKeyset(tokenStr, jwks)
 	if err != nil {
-		log.Debugf("verifyCollectionScope: Failed to parse token with signature verification: %v", err)
-		return false
-	}
-
-	// Basic validation
-	if err := jwt.Validate(parsed); err != nil {
-		log.Debugf("verifyCollectionScope: Token validation failed: %v", err)
+		log.Debugf("verifyCollectionScope: Failed to verify token signature or claims: %v", err)
 		return false
 	}
 

--- a/origin/collections.go
+++ b/origin/collections.go
@@ -117,7 +117,9 @@ func verifyCollectionScope(ctx *gin.Context, expectedScope token_scopes.TokenSco
 		return false
 	}
 
-	parsed, err := token.VerifyWithKeyset(tokenStr, jwks)
+	// Self-issued token: this server both signs and verifies it,
+	// so no inter-server clock skew is possible.
+	parsed, err := token.VerifyWithKeysetStrict(tokenStr, jwks)
 	if err != nil {
 		log.Debugf("verifyCollectionScope: Failed to verify token signature or claims: %v", err)
 		return false

--- a/origin_serve/authz.go
+++ b/origin_serve/authz.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/lestrrat-go/jwx/v2/jwk"
-	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -205,14 +204,14 @@ func (ac *authConfig) updateConfig(exports []server_utils.OriginExport) error {
 	return nil
 }
 
-func (ac *authConfig) getResourceScopes(token string) (scopes []token_scopes.ResourceScope, issuer string, err error) {
-	if token == "" {
+func (ac *authConfig) getResourceScopes(tokenStr string) (scopes []token_scopes.ResourceScope, issuer string, err error) {
+	if tokenStr == "" {
 		return
 	}
 
-	tok, err := jwt.Parse([]byte(token), jwt.WithVerify(false))
+	tok, err := token.UnsafeParseClaims(tokenStr)
 	if err != nil {
-		// Failed to parse token - mark as unverified since we couldn't verify it
+		// Failed to parse token — mark as unverified since we couldn't verify it
 		tokenErr := NewTokenValidationError("failed to parse incoming JWT when authorizing request").
 			WithVerified(false).
 			WithDetails(err.Error())
@@ -245,7 +244,7 @@ func (ac *authConfig) getResourceScopes(token string) (scopes []token_scopes.Res
 	}
 
 	if !trusted {
-		// Token was parsed without verification (jwt.WithVerify(false)), so issuer is unverified
+		// The issuer was read from an unverified token, so it is unverified at this point
 		trustedList := slices.Sorted(maps.Keys(*issuers))
 		tokenErr := NewTokenValidationError("token issuer is not one of the trusted issuers").
 			WithIssuer(issuer).
@@ -277,24 +276,12 @@ func (ac *authConfig) getResourceScopes(token string) (scopes []token_scopes.Res
 		}
 		return
 	}
-	tok, err = jwt.Parse([]byte(token), jwt.WithKeySet(item.set))
+	tok, err = token.VerifyWithKeyset(tokenStr, item.set)
 	if err != nil {
-		// Token signature verification failed - mark as unverified
-		tokenErr := NewTokenValidationError("failed to verify token signature").
+		// Token signature or claims validation failed — mark as unverified
+		tokenErr := NewTokenValidationError("failed to verify token signature or claims").
 			WithVerified(false).
-			WithDetails(err.Error())
-		err = tokenErr
-		return
-	}
-
-	err = jwt.Validate(tok)
-	if err != nil {
-		// Token was cryptographically verified but validation (exp, nbf, etc) failed
-		// Mark as verified since we successfully checked the signature
-		tokenErr := NewTokenValidationError("unable to get resource scopes because validation failed").
-			WithVerified(true).
 			WithIssuer(issuer).
-			WithSubject(tok.Subject()).
 			WithDetails(err.Error())
 		err = tokenErr
 		return
@@ -389,23 +376,23 @@ func (ac *authConfig) getAcls(token string) (newAcls acls, err error) {
 	return
 }
 
-func (ac *authConfig) loader(cache *ttlcache.Cache[string, cachedTokenInfo], token string) *ttlcache.Item[string, cachedTokenInfo] {
-	acls, err := ac.getAcls(token)
+func (ac *authConfig) loader(cache *ttlcache.Cache[string, cachedTokenInfo], tokenStr string) *ttlcache.Item[string, cachedTokenInfo] {
+	acls, err := ac.getAcls(tokenStr)
 	if err != nil {
 		// If the token is not a valid one signed by a known issuer, do not keep it in memory (avoids a DoS)
 		log.Warningln("Rejecting invalid token:", err)
 		return nil
 	}
 
-	// Extract issuer from the token
+	// Extract issuer from the token (claims are unverified at this point; used only for logging)
 	issuer := ""
-	if tok, err := jwt.Parse([]byte(token), jwt.WithVerify(false)); err == nil {
+	if tok, err := token.UnsafeParseClaims(tokenStr); err == nil {
 		issuer = tok.Issuer()
 	}
 
 	// Extract user information from the token at cache time (only once)
 	// Use the UserMapper to map JWT claims to local users/groups
-	userInfo := ac.userMapper.MapTokenToUser(token)
+	userInfo := ac.userMapper.MapTokenToUser(tokenStr)
 	if userInfo == nil {
 		// No mapfile rule matched and no default user configured; reject the token.
 		log.Warningln("Rejecting token: no mapfile rule matched and no default user configured")
@@ -417,7 +404,7 @@ func (ac *authConfig) loader(cache *ttlcache.Cache[string, cachedTokenInfo], tok
 		UserInfo: userInfo,
 		Issuer:   issuer,
 	}
-	item := cache.Set(token, info, ttlcache.DefaultTTL)
+	item := cache.Set(tokenStr, info, ttlcache.DefaultTTL)
 	return item
 }
 

--- a/origin_serve/user_mapfile.go
+++ b/origin_serve/user_mapfile.go
@@ -28,8 +28,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/lestrrat-go/jwx/v2/jwt"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/pelicanplatform/pelican/token"
 )
 
 // MapfileRule represents a single rule in the mapfile for username mapping
@@ -285,7 +286,7 @@ func (um *UserMapper) ExtractUserInfo(tokenClaims map[string]interface{}, reques
 // Returns a userInfo struct suitable for caching with token authorization information
 func (um *UserMapper) MapTokenToUser(tokenStr string) *userInfo {
 	// Parse token without verification (it should have been verified upstream by getAcls)
-	tok, err := jwt.Parse([]byte(tokenStr), jwt.WithVerify(false))
+	tok, err := token.UnsafeParseClaims(tokenStr)
 	if err != nil {
 		log.Debugf("Failed to parse token for user mapping: %v", err)
 		if um.unauthenticatedUser == "" {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -804,7 +804,7 @@ func deleteNamespaceHandler(ctx *gin.Context) {
 		ctx.JSON(http.StatusForbidden, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    "server could not verify the provided deletion token"})
-		log.Errorf("Failed to verify the token: %v", err)
+		log.Errorf("Failed to verify deletion token for prefix %q: %v", prefix, err)
 		return
 	}
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -51,6 +51,7 @@ import (
 	"github.com/pelicanplatform/pelican/oauth2"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
 	"github.com/pelicanplatform/pelican/utils"
 )
@@ -797,23 +798,13 @@ func deleteNamespaceHandler(ctx *gin.Context) {
 		return
 	}
 
-	// Use the JWKS to verify the token -- verification means signature integrity
-	parsed, err := jwt.Parse([]byte(delTokenStr), jwt.WithKeySet(originJwks))
-	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
-			Status: server_structs.RespFailed,
-			Msg:    "server could not verify/parse the provided deletion token"})
-		log.Errorf("Failed to parse the token: %v", err)
-		return
-	}
-
+	// Use the JWKS to verify the token's signature, timestamps, and scope.
 	scopeValidator := token_scopes.CreateScopeValidator([]token_scopes.TokenScope{token_scopes.Pelican_NamespaceDelete}, true)
-
-	if err = jwt.Validate(parsed, jwt.WithValidator(scopeValidator)); err != nil {
+	if _, err = token.VerifyWithKeyset(delTokenStr, originJwks, jwt.WithValidator(scopeValidator)); err != nil {
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
-			Msg:    "server could not validate the provided deletion token"})
-		log.Errorf("Failed to validate the token: %v", err)
+			Msg:    "server could not verify the provided deletion token"})
+		log.Errorf("Failed to verify the token: %v", err)
 		return
 	}
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -801,7 +801,7 @@ func deleteNamespaceHandler(ctx *gin.Context) {
 	// Use the JWKS to verify the token's signature, timestamps, and scope.
 	scopeValidator := token_scopes.CreateScopeValidator([]token_scopes.TokenScope{token_scopes.Pelican_NamespaceDelete}, true)
 	if _, err = token.VerifyWithKeyset(delTokenStr, originJwks, jwt.WithValidator(scopeValidator)); err != nil {
-		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+		ctx.JSON(http.StatusForbidden, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    "server could not verify the provided deletion token"})
 		log.Errorf("Failed to verify the token: %v", err)

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -597,28 +597,15 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 					return
 				}
 
-				accessJWT, err := jwt.Parse(
-					[]byte(accessToken),
-					jwt.WithKeySet(jwks),
-					jwt.WithVerify(true),
-				)
-				if err != nil {
+				scopeValidator := token_scopes.CreateScopeValidator([]token_scopes.TokenScope{token_scopes.Registry_EditRegistration}, false)
+				if _, err := token.VerifyWithKeyset(accessToken, jwks, jwt.WithValidator(scopeValidator)); err != nil {
+					log.Errorf("Failed to verify access token: %v", err)
 					ctx.JSON(http.StatusForbidden,
 						server_structs.SimpleApiResp{
 							Status: server_structs.RespFailed,
 							Msg:    fmt.Sprint("Invalid access token: ", err),
 						})
 					return
-				}
-
-				scopeValidator := token_scopes.CreateScopeValidator([]token_scopes.TokenScope{token_scopes.Registry_EditRegistration}, false)
-				if err = jwt.Validate(accessJWT, jwt.WithValidator(scopeValidator)); err != nil {
-					log.Errorf("Failed to verify the scope of the token: %v", err)
-					ctx.JSON(http.StatusForbidden,
-						server_structs.SimpleApiResp{
-							Status: server_structs.RespFailed,
-							Msg:    fmt.Sprintf("Failed to verify the scope of the token. Require %s", token_scopes.Registry_EditRegistration.String()),
-						})
 				}
 
 				if ns.AdminMetadata.UserID == "" {
@@ -755,28 +742,15 @@ func getNamespace(ctx *gin.Context) {
 			return
 		}
 
-		accessJWT, err := jwt.Parse(
-			[]byte(accessToken),
-			jwt.WithKeySet(jwks),
-			jwt.WithVerify(true),
-		)
-		if err != nil {
+		scopeValidator := token_scopes.CreateScopeValidator([]token_scopes.TokenScope{token_scopes.Registry_EditRegistration}, false)
+		if _, err := token.VerifyWithKeyset(accessToken, jwks, jwt.WithValidator(scopeValidator)); err != nil {
+			log.Errorf("Failed to verify access token: %v", err)
 			ctx.JSON(http.StatusForbidden,
 				server_structs.SimpleApiResp{
 					Status: server_structs.RespFailed,
 					Msg:    fmt.Sprint("Invalid access token: ", err),
 				})
 			return
-		}
-
-		scopeValidator := token_scopes.CreateScopeValidator([]token_scopes.TokenScope{token_scopes.Registry_EditRegistration}, false)
-		if err = jwt.Validate(accessJWT, jwt.WithValidator(scopeValidator)); err != nil {
-			log.Errorf("Failed to verify the scope of the token: %v", err)
-			ctx.JSON(http.StatusForbidden,
-				server_structs.SimpleApiResp{
-					Status: server_structs.RespFailed,
-					Msg:    fmt.Sprintf("Failed to verify the scope of the token. Require %s", token_scopes.Registry_EditRegistration.String()),
-				})
 		}
 	}
 

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -599,7 +599,7 @@ func createUpdateNamespace(ctx *gin.Context, isUpdate bool) {
 
 				scopeValidator := token_scopes.CreateScopeValidator([]token_scopes.TokenScope{token_scopes.Registry_EditRegistration}, false)
 				if _, err := token.VerifyWithKeyset(accessToken, jwks, jwt.WithValidator(scopeValidator)); err != nil {
-					log.Errorf("Failed to verify access token: %v", err)
+					log.Errorf("Failed to verify access token for namespace %q (ID %d) by user %q: %v", ns.Prefix, ns.ID, user, err)
 					ctx.JSON(http.StatusForbidden,
 						server_structs.SimpleApiResp{
 							Status: server_structs.RespFailed,
@@ -744,7 +744,7 @@ func getNamespace(ctx *gin.Context) {
 
 		scopeValidator := token_scopes.CreateScopeValidator([]token_scopes.TokenScope{token_scopes.Registry_EditRegistration}, false)
 		if _, err := token.VerifyWithKeyset(accessToken, jwks, jwt.WithValidator(scopeValidator)); err != nil {
-			log.Errorf("Failed to verify access token: %v", err)
+			log.Errorf("Failed to verify access token for namespace %q (ID %d) by user %q: %v", ns.Prefix, ns.ID, user, err)
 			ctx.JSON(http.StatusForbidden,
 				server_structs.SimpleApiResp{
 					Status: server_structs.RespFailed,

--- a/server_utils/monitor.go
+++ b/server_utils/monitor.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -110,6 +110,7 @@ func HandleDirectorTestResponse(ctx *gin.Context, nChan chan bool) {
 		Scopes:  []token_scopes.TokenScope{token_scopes.Pelican_DirectorTestReport},
 	})
 	if !ok || err != nil {
+		log.Warningf("Failed to verify director test report token from %s: %v", ctx.ClientIP(), err)
 		ctx.JSON(status, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    fmt.Sprint("Failed to verify the token: ", err),

--- a/token/token_create_test.go
+++ b/token/token_create_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -248,9 +247,9 @@ func TestCreateToken(t *testing.T) {
 	tokenConfig = TokenConfig{tokenProfile: WlcgProfile{}, audience: []string{"foo"}, Subject: "bar", Lifetime: time.Minute * 10, Claims: map[string]string{"foo": "bar"}}
 	token, err := tokenConfig.CreateToken()
 	require.NoError(t, err)
-	jwt, err := jwt.ParseString(token, jwt.WithVerify(false))
+	tok, err := UnsafeParseClaims(token)
 	require.NoError(t, err)
-	val, found := jwt.Get("foo")
+	val, found := tok.Get("foo")
 	assert.True(t, found)
 	assert.Equal(t, "bar", val)
 

--- a/token/token_verify.go
+++ b/token/token_verify.go
@@ -66,6 +66,11 @@ const (
 	Authz  TokenSource = "AuthzQueryParameter" // "authz" query parameter
 )
 
+// ClockSkewLeeway is the tolerance applied to JWT temporal claim validation
+// (iat, nbf, exp).
+// A value of 60s matches the WLCG Common JWT Profile recommendation.
+const ClockSkewLeeway = 60 * time.Second
+
 const (
 	FederationIssuer TokenIssuer = "FederationIssuer"
 	LocalIssuer      TokenIssuer = "LocalIssuer"
@@ -324,6 +329,48 @@ func (a AuthCheckImpl) checkRegisteredServer(ctx *gin.Context, strToken string, 
 	ctx.Set("AuthMethod", "registered-server-token")
 
 	return nil
+}
+
+// UnsafeParseClaims parses a JWT string without verifying the signature
+// or validating time-based claims (iat, nbf, exp).
+// The returned token carries no security guarantees and must never be used
+// for authorization decisions.
+func UnsafeParseClaims(tokenStr string) (jwt.Token, error) {
+	return jwt.Parse([]byte(tokenStr), jwt.WithVerify(false), jwt.WithValidate(false))
+}
+
+// VerifyWithKeyset verifies tokenStr's signature against jwks
+// and then validates its claims with ClockSkewLeeway applied.
+//
+// Additional jwt.ValidateOption values
+// (e.g., scope validators, jwt.WithAudience, jwt.WithClaimValue)
+// can be passed via opts;
+// they are evaluated in the same jwt.Validate call
+// as the skew-tolerant time checks
+// so that every claim check benefits from ClockSkewLeeway.
+//
+// The skew option is appended after any caller-supplied opts;
+// callers cannot override it with WithAcceptableSkew(0).
+func VerifyWithKeyset(tokenStr string, jwks jwk.Set, opts ...jwt.ValidateOption) (jwt.Token, error) {
+	tok, err := jwt.Parse([]byte(tokenStr), jwt.WithKeySet(jwks), jwt.WithValidate(false))
+	if err != nil {
+		return nil, err
+	}
+	// Build the final option slice with a defensive copy
+	// to avoid mutating the caller's backing array.
+	// WithResetValidators(false) and WithAcceptableSkew are appended last
+	// so that callers
+	// cannot disable the default temporal validators or shrink the skew window.
+	validateOpts := make([]jwt.ValidateOption, 0, len(opts)+2)
+	validateOpts = append(validateOpts, opts...)
+	validateOpts = append(validateOpts,
+		jwt.WithResetValidators(false),
+		jwt.WithAcceptableSkew(ClockSkewLeeway),
+	)
+	if err := jwt.Validate(tok, validateOpts...); err != nil {
+		return nil, err
+	}
+	return tok, nil
 }
 
 // Check token authentication with token obtained from authOption.Sources, found the first

--- a/token/token_verify.go
+++ b/token/token_verify.go
@@ -317,16 +317,23 @@ func UnsafeParseClaims(tokenStr string) (jwt.Token, error) {
 // VerifyWithKeysetStrict verifies tokenStr's signature against jwks
 // and then validates its claims with no clock-skew leeway.
 //
-// WithResetValidators(false) is appended after any caller-supplied opts
-// so that callers cannot disable the default temporal validators.
+// The following options are appended after any caller-supplied opts
+// so that callers cannot weaken the strict temporal validation:
+//   - WithResetValidators(false): callers cannot disable the default validators
+//   - WithClock(jwt.ClockFunc(time.Now)): callers cannot shift the clock
+//   - WithAcceptableSkew(0): callers cannot add skew tolerance
 func VerifyWithKeysetStrict(tokenStr string, jwks jwk.Set, opts ...jwt.ValidateOption) (jwt.Token, error) {
 	tok, err := jwt.Parse([]byte(tokenStr), jwt.WithKeySet(jwks), jwt.WithValidate(false))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to verify token signature")
 	}
-	validateOpts := make([]jwt.ValidateOption, 0, len(opts)+1)
+	validateOpts := make([]jwt.ValidateOption, 0, len(opts)+3)
 	validateOpts = append(validateOpts, opts...)
-	validateOpts = append(validateOpts, jwt.WithResetValidators(false))
+	validateOpts = append(validateOpts,
+		jwt.WithResetValidators(false),
+		jwt.WithClock(jwt.ClockFunc(time.Now)),
+		jwt.WithAcceptableSkew(0),
+	)
 	if err := jwt.Validate(tok, validateOpts...); err != nil {
 		return nil, errors.Wrap(err, "failed to validate token claims")
 	}
@@ -336,8 +343,11 @@ func VerifyWithKeysetStrict(tokenStr string, jwks jwk.Set, opts ...jwt.ValidateO
 // VerifyWithKeyset verifies tokenStr's signature against jwks
 // and then validates its claims with ClockSkewLeeway applied.
 //
-// The skew option is appended after any caller-supplied opts
-// so that callers cannot override it with WithAcceptableSkew(0).
+// The following options are appended after any caller-supplied opts
+// so that callers cannot weaken the intended leeway contract:
+//   - WithResetValidators(false): callers cannot disable the default validators
+//   - WithClock(jwt.ClockFunc(time.Now)): callers cannot shift the clock
+//   - WithAcceptableSkew(ClockSkewLeeway): callers cannot shrink or expand the window
 func VerifyWithKeyset(tokenStr string, jwks jwk.Set, opts ...jwt.ValidateOption) (jwt.Token, error) {
 	tok, err := jwt.Parse([]byte(tokenStr), jwt.WithKeySet(jwks), jwt.WithValidate(false))
 	if err != nil {
@@ -345,13 +355,11 @@ func VerifyWithKeyset(tokenStr string, jwks jwk.Set, opts ...jwt.ValidateOption)
 	}
 	// Build the final option slice with a defensive copy
 	// to avoid mutating the caller's backing array.
-	// WithResetValidators(false) and WithAcceptableSkew are appended last
-	// so that callers
-	// cannot disable the default temporal validators or shrink the skew window.
-	validateOpts := make([]jwt.ValidateOption, 0, len(opts)+2)
+	validateOpts := make([]jwt.ValidateOption, 0, len(opts)+3)
 	validateOpts = append(validateOpts, opts...)
 	validateOpts = append(validateOpts,
 		jwt.WithResetValidators(false),
+		jwt.WithClock(jwt.ClockFunc(time.Now)),
 		jwt.WithAcceptableSkew(ClockSkewLeeway),
 	)
 	if err := jwt.Validate(tok, validateOpts...); err != nil {

--- a/token/token_verify.go
+++ b/token/token_verify.go
@@ -351,7 +351,7 @@ func VerifyWithKeysetStrict(tokenStr string, jwks jwk.Set, opts ...jwt.ValidateO
 func VerifyWithKeyset(tokenStr string, jwks jwk.Set, opts ...jwt.ValidateOption) (jwt.Token, error) {
 	tok, err := jwt.Parse([]byte(tokenStr), jwt.WithKeySet(jwks), jwt.WithValidate(false))
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to verify token signature")
 	}
 	// Build the final option slice with a defensive copy
 	// to avoid mutating the caller's backing array.
@@ -363,7 +363,7 @@ func VerifyWithKeyset(tokenStr string, jwks jwk.Set, opts ...jwt.ValidateOption)
 		jwt.WithAcceptableSkew(ClockSkewLeeway),
 	)
 	if err := jwt.Validate(tok, validateOpts...); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to validate token claims")
 	}
 	return tok, nil
 }

--- a/token/token_verify.go
+++ b/token/token_verify.go
@@ -211,7 +211,7 @@ func (a AuthCheckImpl) checkLocalIssuer(c *gin.Context, strToken string, expecte
 	}
 
 	scopeValidator := token_scopes.CreateScopeValidator(expectedScopes, allScopes)
-	parsed, err := VerifyWithKeyset(strToken, jwks, jwt.WithValidator(scopeValidator))
+	parsed, err := VerifyWithKeysetStrict(strToken, jwks, jwt.WithValidator(scopeValidator))
 	if err != nil {
 		return errors.Wrap(err, "Failed to verify local issuer JWT signature or claims")
 	}
@@ -314,18 +314,30 @@ func UnsafeParseClaims(tokenStr string) (jwt.Token, error) {
 	return jwt.Parse([]byte(tokenStr), jwt.WithVerify(false), jwt.WithValidate(false))
 }
 
+// VerifyWithKeysetStrict verifies tokenStr's signature against jwks
+// and then validates its claims with no clock-skew leeway.
+//
+// WithResetValidators(false) is appended after any caller-supplied opts
+// so that callers cannot disable the default temporal validators.
+func VerifyWithKeysetStrict(tokenStr string, jwks jwk.Set, opts ...jwt.ValidateOption) (jwt.Token, error) {
+	tok, err := jwt.Parse([]byte(tokenStr), jwt.WithKeySet(jwks), jwt.WithValidate(false))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to verify token signature")
+	}
+	validateOpts := make([]jwt.ValidateOption, 0, len(opts)+1)
+	validateOpts = append(validateOpts, opts...)
+	validateOpts = append(validateOpts, jwt.WithResetValidators(false))
+	if err := jwt.Validate(tok, validateOpts...); err != nil {
+		return nil, errors.Wrap(err, "failed to validate token claims")
+	}
+	return tok, nil
+}
+
 // VerifyWithKeyset verifies tokenStr's signature against jwks
 // and then validates its claims with ClockSkewLeeway applied.
 //
-// Additional jwt.ValidateOption values
-// (e.g., scope validators, jwt.WithAudience, jwt.WithClaimValue)
-// can be passed via opts;
-// they are evaluated in the same jwt.Validate call
-// as the skew-tolerant time checks
-// so that every claim check benefits from ClockSkewLeeway.
-//
-// The skew option is appended after any caller-supplied opts;
-// callers cannot override it with WithAcceptableSkew(0).
+// The skew option is appended after any caller-supplied opts
+// so that callers cannot override it with WithAcceptableSkew(0).
 func VerifyWithKeyset(tokenStr string, jwks jwk.Set, opts ...jwt.ValidateOption) (jwt.Token, error) {
 	tok, err := jwt.Parse([]byte(tokenStr), jwt.WithKeySet(jwks), jwt.WithValidate(false))
 	if err != nil {

--- a/token/token_verify.go
+++ b/token/token_verify.go
@@ -132,7 +132,7 @@ func (a AuthCheckImpl) checkFederationIssuer(c *gin.Context, strToken string, ex
 		fedURL = dirURL
 	}
 
-	token, err := jwt.Parse([]byte(strToken), jwt.WithVerify(false))
+	token, err := UnsafeParseClaims(strToken)
 	if err != nil {
 		return err
 	}
@@ -160,15 +160,10 @@ func (a AuthCheckImpl) checkFederationIssuer(c *gin.Context, strToken string, ex
 		return errors.Wrap(err, "Failed to get federation's public JWKS")
 	}
 
-	parsed, err := jwt.Parse([]byte(strToken), jwt.WithKeySet(jwks))
-
-	if err != nil {
-		return errors.Wrap(err, "Failed to verify JWT by federation's key")
-	}
-
 	scopeValidator := token_scopes.CreateScopeValidator(expectedScopes, allScopes)
-	if err = jwt.Validate(parsed, jwt.WithValidator(scopeValidator)); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("Failed to verify the scope of the token. Require %v", expectedScopes))
+	parsed, err := VerifyWithKeyset(strToken, jwks, jwt.WithValidator(scopeValidator))
+	if err != nil {
+		return errors.Wrap(err, "Failed to verify federation JWT signature or claims")
 	}
 
 	c.Set("User", parsed.Subject())
@@ -194,7 +189,7 @@ func (a AuthCheckImpl) checkFederationIssuer(c *gin.Context, strToken string, ex
 // The expected issuer comes from config.GetLocalIssuerUrl() which accounts
 // for the co-located origin+director case.
 func (a AuthCheckImpl) checkLocalIssuer(c *gin.Context, strToken string, expectedScopes []token_scopes.TokenScope, allScopes bool) error {
-	token, err := jwt.Parse([]byte(strToken), jwt.WithVerify(false))
+	token, err := UnsafeParseClaims(strToken)
 	if err != nil {
 		return errors.Wrap(err, "Invalid JWT")
 	}
@@ -215,15 +210,10 @@ func (a AuthCheckImpl) checkLocalIssuer(c *gin.Context, strToken string, expecte
 		return errors.Wrap(err, "Failed to load issuer server's public key")
 	}
 
-	parsed, err := jwt.Parse([]byte(strToken), jwt.WithKeySet(jwks))
-
-	if err != nil {
-		return errors.Wrap(err, "Failed to verify JWT by issuer's key")
-	}
-
 	scopeValidator := token_scopes.CreateScopeValidator(expectedScopes, allScopes)
-	if err = jwt.Validate(parsed, jwt.WithValidator(scopeValidator)); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("Failed to verify the scope of the token. Require %v", expectedScopes))
+	parsed, err := VerifyWithKeyset(strToken, jwks, jwt.WithValidator(scopeValidator))
+	if err != nil {
+		return errors.Wrap(err, "Failed to verify local issuer JWT signature or claims")
 	}
 
 	c.Set("User", parsed.Subject())
@@ -248,8 +238,8 @@ func (a AuthCheckImpl) checkLocalIssuer(c *gin.Context, strToken string, expecte
 // Verify a token against a registered server's public key
 // The token's subject should identify the server (i.e. server id)
 func (a AuthCheckImpl) checkRegisteredServer(ctx *gin.Context, strToken string, expectedScopes []token_scopes.TokenScope, allScopes bool) error {
-	// First parse token without verification to extract claims
-	token, err := jwt.Parse([]byte(strToken), jwt.WithVerify(false))
+	// Parse without verification to extract claims for keyset lookup.
+	token, err := UnsafeParseClaims(strToken)
 	if err != nil {
 		return errors.Wrap(err, "invalid JWT")
 	}
@@ -262,7 +252,7 @@ func (a AuthCheckImpl) checkRegisteredServer(ctx *gin.Context, strToken string, 
 	// Expose subject for downstream handlers (e.g., ownership checks)
 	ctx.Set("TokenSubject", subject)
 
-	// Look up the server's public key set and metadata based on the the server id in the token subject
+	// Look up the server's public key set based on the server id in the token subject.
 	jwks, resolved, err := resolveRegisteredServerJWKS(ctx, subject)
 	if err != nil {
 		return errors.Wrap(err, "failed to resolve registered server JWKS")
@@ -271,18 +261,7 @@ func (a AuthCheckImpl) checkRegisteredServer(ctx *gin.Context, strToken string, 
 		return errors.New("no JWKS resolver is configured; unable to lookup registered server's key set")
 	}
 
-	// Now verify the token with the server's public key
-	parsed, err := jwt.Parse([]byte(strToken), jwt.WithKeySet(jwks))
-	if err != nil {
-		return errors.Wrap(err, "failed to verify JWT with server's registered key set")
-	}
-
-	// Validate expiration and other standard claims
-	if err := jwt.Validate(parsed); err != nil {
-		return errors.Wrap(err, "token validation failed")
-	}
-
-	// Validate audience. The audience should be Registry's host:port.
+	// Resolve the registry URL to derive the expected audience before verification.
 	federationInfo, err := config.GetFederation(context.Background())
 	if err != nil {
 		return errors.Wrap(err, "failed to get federation information")
@@ -291,25 +270,19 @@ func (a AuthCheckImpl) checkRegisteredServer(ctx *gin.Context, strToken string, 
 	if registryURL == "" {
 		return errors.New("registry URL is not set")
 	}
-	url, parseErr := url.Parse(registryURL)
+	parsedRegistryURL, parseErr := url.Parse(registryURL)
 	if parseErr != nil {
 		return errors.Wrapf(parseErr, "failed to parse registry URL %s", registryURL)
 	}
-	isAudienceValid := false
-	log.Tracef("Token audience: %v; Registry's 'host:port': %s", parsed.Audience(), url.Host)
-	for _, audience := range parsed.Audience() {
-		if audience == url.Host {
-			isAudienceValid = true
-			break
-		}
-	}
-	if !isAudienceValid {
-		return errors.New(fmt.Sprintf("failed to verify the audience of the token. Require %s", url.Host))
-	}
 
+	// Trace-log the pre-verification audience and scope claims for debugging.
+	// These come from the unsafe parse and are not yet trusted.
+	log.Tracef("Token audience: %v; Registry's 'host:port': %s", token.Audience(), parsedRegistryURL.Host)
+
+	validateOpts := []jwt.ValidateOption{jwt.WithAudience(parsedRegistryURL.Host)}
 	if len(expectedScopes) > 0 {
-		// Log the token scope for debugging
-		if scopeAny, present := parsed.Get("scope"); present {
+		// Log the token scope for debugging.
+		if scopeAny, present := token.Get("scope"); present {
 			if scopeStr, ok := scopeAny.(string); ok {
 				log.Tracef("Token scope: %s; expected scopes: %v", scopeStr, expectedScopes)
 			} else {
@@ -318,14 +291,16 @@ func (a AuthCheckImpl) checkRegisteredServer(ctx *gin.Context, strToken string, 
 		} else {
 			log.Tracef("Token has no 'scope' claim; expected scopes: %v", expectedScopes)
 		}
-		// Validate scopes
 		scopeValidator := token_scopes.CreateScopeValidator(expectedScopes, allScopes)
-		if err := jwt.Validate(parsed, jwt.WithValidator(scopeValidator)); err != nil {
-			return errors.Wrap(err, fmt.Sprintf("failed to verify the scope of the token. Require %v", expectedScopes))
-		}
+		validateOpts = append(validateOpts, jwt.WithValidator(scopeValidator))
 	}
 
-	// Set context variables for downstream handlers
+	// Verify the token (signature, timestamps, audience, scopes).
+	if _, err = VerifyWithKeyset(strToken, jwks, validateOpts...); err != nil {
+		return errors.Wrap(err, "failed to verify registered-server JWT signature or claims")
+	}
+
+	// Set context variables for downstream handlers.
 	ctx.Set("AuthMethod", "registered-server-token")
 
 	return nil

--- a/token/token_verify.go
+++ b/token/token_verify.go
@@ -307,7 +307,7 @@ func (a AuthCheckImpl) checkRegisteredServer(ctx *gin.Context, strToken string, 
 }
 
 // UnsafeParseClaims parses a JWT string without verifying the signature
-// or validating time-based claims (iat, nbf, exp).
+// or validating any claims (iat, nbf, exp, etc.).
 // The returned token carries no security guarantees and must never be used
 // for authorization decisions.
 func UnsafeParseClaims(tokenStr string) (jwt.Token, error) {

--- a/token/token_verify_test.go
+++ b/token/token_verify_test.go
@@ -621,12 +621,11 @@ func TestVerifyWithKeyset_WrongKeyRejected(t *testing.T) {
 	assert.Error(t, err, "token signed with wrong key should be rejected")
 }
 
-// TestVerify_AcceptsSkewedLocalToken verifies that Verify accepts a token
-// whose iat and nbf are slightly in the future (within ClockSkewLeeway)
+// TestVerify_RejectsSkewedLocalToken confirms
+// that Verify rejects a locally-issued token
+// whose iat and nbf are slightly in the future
 // when the LocalIssuer check is used.
-// Tokens from a remote issuer whose clock is up to ClockSkewLeeway ahead
-// must not be rejected by the local server.
-func TestVerify_AcceptsSkewedLocalToken(t *testing.T) {
+func TestVerify_RejectsSkewedLocalToken(t *testing.T) {
 	// Set up an isolated config state.
 	t.Cleanup(func() { config.ResetConfig() })
 	config.ResetConfig()
@@ -642,7 +641,7 @@ func TestVerify_AcceptsSkewedLocalToken(t *testing.T) {
 	require.NoError(t, err)
 
 	now := time.Now()
-	skew := ClockSkewLeeway / 2 // iat/nbf halfway into the future — within tolerance
+	skew := ClockSkewLeeway / 2 // half the leeway — safely inside the acceptance window (when not local)
 
 	tokenStr := makeSignedTokenWithIssuer(t, privKey,
 		now.Add(skew), now.Add(skew), now.Add(10*time.Minute),
@@ -657,12 +656,11 @@ func TestVerify_AcceptsSkewedLocalToken(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 	c.Request = req
 
-	_, ok, verifyErr := Verify(c, AuthOption{
+	_, ok, _ := Verify(c, AuthOption{
 		Sources: []TokenSource{Header},
 		Issuers: []TokenIssuer{LocalIssuer},
 	})
-	assert.NoError(t, verifyErr, "Verify should not return an error for a token whose iat/nbf are within ClockSkewLeeway")
-	assert.True(t, ok, "Verify should accept a token whose iat/nbf are within ClockSkewLeeway")
+	assert.False(t, ok, "Verify should reject a locally-issued token with a future iat/nbf: no skew tolerance for self-signed tokens")
 }
 
 // TestVerify_AcceptsSkewedRegisteredServerToken confirms

--- a/token/token_verify_test.go
+++ b/token/token_verify_test.go
@@ -37,6 +37,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
+	pelican_url "github.com/pelicanplatform/pelican/pelican_url"
 	"github.com/pelicanplatform/pelican/token_scopes"
 )
 
@@ -458,6 +461,23 @@ func makeSignedToken(t *testing.T, privKey jwk.Key, iat, nbf, exp time.Time) str
 	return string(signed)
 }
 
+// makeSignedTokenWithIssuer creates a signed JWT with the given iat, nbf, exp times,
+// and an explicit issuer.
+func makeSignedTokenWithIssuer(t *testing.T, privKey jwk.Key, iat, nbf, exp time.Time, issuer string) string {
+	t.Helper()
+	tok, err := jwt.NewBuilder().
+		IssuedAt(iat).
+		NotBefore(nbf).
+		Expiration(exp).
+		Subject("test-subject").
+		Issuer(issuer).
+		Build()
+	require.NoError(t, err)
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256, privKey))
+	require.NoError(t, err)
+	return string(signed)
+}
+
 // TestUnsafeParseClaims verifies that UnsafeParseClaims extracts claims
 // from tokens whose time claims would normally fail validation.
 func TestUnsafeParseClaims(t *testing.T) {
@@ -599,4 +619,107 @@ func TestVerifyWithKeyset_WrongKeyRejected(t *testing.T) {
 
 	_, err := VerifyWithKeyset(tokenStr, pubSet)
 	assert.Error(t, err, "token signed with wrong key should be rejected")
+}
+
+// TestVerify_AcceptsSkewedLocalToken verifies that Verify accepts a token
+// whose iat and nbf are slightly in the future (within ClockSkewLeeway)
+// when the LocalIssuer check is used.
+// Tokens from a remote issuer whose clock is up to ClockSkewLeeway ahead
+// must not be rejected by the local server.
+func TestVerify_AcceptsSkewedLocalToken(t *testing.T) {
+	// Set up an isolated config state.
+	t.Cleanup(func() { config.ResetConfig() })
+	config.ResetConfig()
+
+	issuerURL := "https://issuer.example.com:8443"
+	kDir := t.TempDir()
+
+	require.NoError(t, param.Server_ExternalWebUrl.Set(issuerURL))
+	require.NoError(t, param.IssuerKeysDirectory.Set(kDir))
+
+	// Generate a real key in kDir so GetIssuerPublicJWKS can read it.
+	privKey, err := config.GeneratePEM(kDir)
+	require.NoError(t, err)
+
+	now := time.Now()
+	skew := ClockSkewLeeway / 2 // iat/nbf halfway into the future — within tolerance
+
+	tokenStr := makeSignedTokenWithIssuer(t, privKey,
+		now.Add(skew), now.Add(skew), now.Add(10*time.Minute),
+		issuerURL,
+	)
+
+	req, err := http.NewRequest(http.MethodGet, "/test", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+tokenStr)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	_, ok, verifyErr := Verify(c, AuthOption{
+		Sources: []TokenSource{Header},
+		Issuers: []TokenIssuer{LocalIssuer},
+	})
+	assert.NoError(t, verifyErr, "Verify should not return an error for a token whose iat/nbf are within ClockSkewLeeway")
+	assert.True(t, ok, "Verify should accept a token whose iat/nbf are within ClockSkewLeeway")
+}
+
+// TestVerify_AcceptsSkewedRegisteredServerToken confirms
+// that Verify accepts a registered-server token
+// whose iat and nbf are slightly in the future (within ClockSkewLeeway)
+// when the RegisteredServer check is used.
+func TestVerify_AcceptsSkewedRegisteredServerToken(t *testing.T) {
+	t.Cleanup(func() {
+		// Clear the resolver so other tests are not affected.
+		RegisterServerJWKSResolver(nil)
+		config.ResetConfig()
+		config.ResetFederationForTest()
+	})
+	config.ResetConfig()
+	config.ResetFederationForTest()
+
+	registryURL := "https://registry.example.com:9999"
+	privKey, pubSet := makeTestKeyset(t)
+
+	// Register a JWKS resolver that returns our test public key for any server ID.
+	RegisterServerJWKSResolver(func(_ *gin.Context, _ string) (jwk.Set, error) {
+		return pubSet, nil
+	})
+
+	// Configure the federation so checkRegisteredServer can resolve the registry host.
+	config.SetFederation(pelican_url.FederationDiscovery{
+		RegistryEndpoint: registryURL,
+	})
+
+	now := time.Now()
+	skew := ClockSkewLeeway / 2 // half the leeway — safely inside the acceptance window
+
+	// Build a token whose audience is the registry host:port.
+	tok, err := jwt.NewBuilder().
+		IssuedAt(now.Add(skew)).
+		NotBefore(now.Add(skew)).
+		Expiration(now.Add(10 * time.Minute)).
+		Subject("test-server").
+		Audience([]string{"registry.example.com:9999"}).
+		Build()
+	require.NoError(t, err)
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256, privKey))
+	require.NoError(t, err)
+	tokenStr := string(signed)
+
+	req, err := http.NewRequest(http.MethodGet, "/test", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+tokenStr)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	_, ok, verifyErr := Verify(c, AuthOption{
+		Sources: []TokenSource{Header},
+		Issuers: []TokenIssuer{RegisteredServer},
+	})
+	assert.NoError(t, verifyErr, "Verify should not return an error for a token whose iat/nbf are within ClockSkewLeeway")
+	assert.True(t, ok, "Verify should accept a registered-server token whose iat/nbf are within ClockSkewLeeway")
 }

--- a/token/token_verify_test.go
+++ b/token/token_verify_test.go
@@ -20,12 +20,19 @@ package token
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -415,4 +422,181 @@ func TestGetAuthzEscaped(t *testing.T) {
 	ctx = &gin.Context{Request: req}
 	escapedToken = GetAuthzEscaped(ctx)
 	assert.Equal(t, escapedToken, "tokenstring")
+}
+
+// makeTestKeyset generates a fresh ECDSA P-256 key pair for use in tests.
+// It returns the private key (for signing) and a JWKS containing only the
+// public key (for verification).
+func makeTestKeyset(t *testing.T) (jwk.Key, jwk.Set) {
+	t.Helper()
+	privRaw, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	privKey, err := jwk.FromRaw(privRaw)
+	require.NoError(t, err)
+	require.NoError(t, privKey.Set(jwk.KeyIDKey, "test-key"))
+	require.NoError(t, privKey.Set(jwk.AlgorithmKey, jwa.ES256))
+
+	pubKey, err := privKey.PublicKey()
+	require.NoError(t, err)
+	pubSet := jwk.NewSet()
+	require.NoError(t, pubSet.AddKey(pubKey))
+	return privKey, pubSet
+}
+
+// makeSignedToken creates a signed JWT with the given iat, nbf, and exp times.
+func makeSignedToken(t *testing.T, privKey jwk.Key, iat, nbf, exp time.Time) string {
+	t.Helper()
+	tok, err := jwt.NewBuilder().
+		IssuedAt(iat).
+		NotBefore(nbf).
+		Expiration(exp).
+		Subject("test-subject").
+		Build()
+	require.NoError(t, err)
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256, privKey))
+	require.NoError(t, err)
+	return string(signed)
+}
+
+// TestUnsafeParseClaims verifies that UnsafeParseClaims extracts claims
+// from tokens whose time claims would normally fail validation.
+func TestUnsafeParseClaims(t *testing.T) {
+	privKey, _ := makeTestKeyset(t)
+	now := time.Now()
+
+	// Token with iat/nbf two hours in the future and exp two hours in the past.
+	tokenStr := makeSignedToken(t,
+		privKey,
+		now.Add(2*time.Hour),
+		now.Add(2*time.Hour),
+		now.Add(-2*time.Hour),
+	)
+
+	tok, err := UnsafeParseClaims(tokenStr)
+	require.NoError(t, err, "UnsafeParseClaims should succeed regardless of time claims")
+	assert.Equal(t, "test-subject", tok.Subject())
+}
+
+// TestVerifyWithKeyset_IatNbfWithinLeeway confirms that a token
+// whose iat and nbf are in the future but within ClockSkewLeeway is accepted.
+func TestVerifyWithKeyset_IatNbfWithinLeeway(t *testing.T) {
+	privKey, pubSet := makeTestKeyset(t)
+	now := time.Now()
+	skew := ClockSkewLeeway / 2 // half the leeway — safely inside the acceptance window
+
+	tokenStr := makeSignedToken(t,
+		privKey,
+		now.Add(skew),
+		now.Add(skew),
+		now.Add(10*time.Minute),
+	)
+
+	_, err := VerifyWithKeyset(tokenStr, pubSet)
+	assert.NoError(t, err, "token with iat/nbf within leeway should be accepted")
+}
+
+// TestVerifyWithKeyset_IatNbfExceedsLeeway confirms that a token
+// whose iat and nbf exceed ClockSkewLeeway is rejected.
+func TestVerifyWithKeyset_IatNbfExceedsLeeway(t *testing.T) {
+	privKey, pubSet := makeTestKeyset(t)
+	now := time.Now()
+	skew := ClockSkewLeeway + 2*time.Minute // well beyond the acceptance window
+
+	tokenStr := makeSignedToken(t,
+		privKey,
+		now.Add(skew),
+		now.Add(skew),
+		now.Add(10*time.Minute),
+	)
+
+	_, err := VerifyWithKeyset(tokenStr, pubSet)
+	assert.Error(t, err, "token with iat/nbf exceeding leeway should be rejected")
+}
+
+// TestVerifyWithKeyset_ExpWithinLeeway confirms that a token
+// whose exp is in the past but within ClockSkewLeeway is accepted.
+func TestVerifyWithKeyset_ExpWithinLeeway(t *testing.T) {
+	privKey, pubSet := makeTestKeyset(t)
+	now := time.Now()
+	skew := ClockSkewLeeway / 2 // half the leeway — safely inside the acceptance window
+
+	tokenStr := makeSignedToken(t,
+		privKey,
+		now.Add(-10*time.Minute),
+		now.Add(-10*time.Minute),
+		now.Add(-skew),
+	)
+
+	_, err := VerifyWithKeyset(tokenStr, pubSet)
+	assert.NoError(t, err, "token expired within leeway should be accepted")
+}
+
+// TestVerifyWithKeyset_ExpExceedsLeeway confirms that a token
+// whose exp exceeds ClockSkewLeeway in the past is rejected.
+func TestVerifyWithKeyset_ExpExceedsLeeway(t *testing.T) {
+	privKey, pubSet := makeTestKeyset(t)
+	now := time.Now()
+	skew := ClockSkewLeeway + 2*time.Minute // well beyond the acceptance window
+
+	tokenStr := makeSignedToken(t,
+		privKey,
+		now.Add(-10*time.Minute),
+		now.Add(-10*time.Minute),
+		now.Add(-skew),
+	)
+
+	_, err := VerifyWithKeyset(tokenStr, pubSet)
+	assert.Error(t, err, "token expired beyond leeway should be rejected")
+}
+
+// TestVerifyWithKeyset_CallerSkewCannotShrinkLeeway confirms that
+// a caller passing WithAcceptableSkew(0) does not override ClockSkewLeeway —
+// a token within ClockSkewLeeway must still be accepted.
+func TestVerifyWithKeyset_CallerSkewCannotShrinkLeeway(t *testing.T) {
+	privKey, pubSet := makeTestKeyset(t)
+	now := time.Now()
+	skew := ClockSkewLeeway / 2 // half the leeway — safely inside the acceptance window
+
+	tokenStr := makeSignedToken(t,
+		privKey,
+		now.Add(skew),
+		now.Add(skew),
+		now.Add(10*time.Minute),
+	)
+
+	_, err := VerifyWithKeyset(tokenStr, pubSet, jwt.WithAcceptableSkew(0))
+	assert.NoError(t, err, "caller WithAcceptableSkew(0) must not reduce the effective leeway below ClockSkewLeeway")
+}
+
+// TestVerifyWithKeyset_CallerSkewCannotExpandLeeway confirms that
+// a caller passing a large WithAcceptableSkew does not suppress a real rejection —
+// a token beyond ClockSkewLeeway must still be rejected.
+func TestVerifyWithKeyset_CallerSkewCannotExpandLeeway(t *testing.T) {
+	privKey, pubSet := makeTestKeyset(t)
+	now := time.Now()
+	skew := ClockSkewLeeway + 2*time.Minute // well beyond the acceptance window
+
+	tokenStr := makeSignedToken(t,
+		privKey,
+		now.Add(skew),
+		now.Add(skew),
+		now.Add(10*time.Minute),
+	)
+
+	_, err := VerifyWithKeyset(tokenStr, pubSet, jwt.WithAcceptableSkew(2*time.Hour))
+	assert.Error(t, err, "caller WithAcceptableSkew(2h) must not expand the effective leeway beyond ClockSkewLeeway")
+}
+
+// TestVerifyWithKeyset_WrongKeyRejected confirms
+// that a token signed with a different key is rejected,
+// verifying that the signature check is active.
+func TestVerifyWithKeyset_WrongKeyRejected(t *testing.T) {
+	_, pubSet := makeTestKeyset(t)
+	wrongPrivKey, _ := makeTestKeyset(t) // different key pair
+
+	now := time.Now()
+	tokenStr := makeSignedToken(t, wrongPrivKey, now, now, now.Add(10*time.Minute))
+
+	_, err := VerifyWithKeyset(tokenStr, pubSet)
+	assert.Error(t, err, "token signed with wrong key should be rejected")
 }

--- a/token/token_verify_test.go
+++ b/token/token_verify_test.go
@@ -607,23 +607,85 @@ func TestVerifyWithKeyset_CallerSkewCannotExpandLeeway(t *testing.T) {
 	assert.Error(t, err, "caller WithAcceptableSkew(2h) must not expand the effective leeway beyond ClockSkewLeeway")
 }
 
-// TestVerifyWithKeyset_WrongKeyRejected confirms
-// that a token signed with a different key is rejected,
-// verifying that the signature check is active.
-func TestVerifyWithKeyset_WrongKeyRejected(t *testing.T) {
+// keysetVerifyFunctions lists the keyset-based verification helpers so that
+// shared-behavior tests can exercise each in a single table-driven test.
+// Tests where the helpers differ (e.g., skew tolerance) must remain separate;
+// only behaviors that are identical across all helpers belong here.
+var keysetVerifyFunctions = []struct {
+	name string
+	fn   func(string, jwk.Set, ...jwt.ValidateOption) (jwt.Token, error)
+}{
+	{"VerifyWithKeyset", VerifyWithKeyset},
+	{"VerifyWithKeysetStrict", VerifyWithKeysetStrict},
+}
+
+// TestKeysetVerifyFunctions_AcceptValidToken confirms that all helpers
+// accept a well-formed token with current timestamps.
+func TestKeysetVerifyFunctions_AcceptValidToken(t *testing.T) {
+	privKey, pubSet := makeTestKeyset(t)
+	now := time.Now()
+	tokenStr := makeSignedToken(t, privKey, now, now, now.Add(10*time.Minute))
+
+	for _, tc := range keysetVerifyFunctions {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.fn(tokenStr, pubSet)
+			assert.NoError(t, err, "%s should accept a token with current timestamps", tc.name)
+		})
+	}
+}
+
+// TestKeysetVerifyFunctions_WrongKeyRejected confirms that all helpers
+// reject a token signed with a key not in the provided JWKS,
+// verifying that the signature check is active in each.
+func TestKeysetVerifyFunctions_WrongKeyRejected(t *testing.T) {
 	_, pubSet := makeTestKeyset(t)
 	wrongPrivKey, _ := makeTestKeyset(t) // different key pair
 
 	now := time.Now()
 	tokenStr := makeSignedToken(t, wrongPrivKey, now, now, now.Add(10*time.Minute))
 
-	_, err := VerifyWithKeyset(tokenStr, pubSet)
-	assert.Error(t, err, "token signed with wrong key should be rejected")
+	for _, tc := range keysetVerifyFunctions {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.fn(tokenStr, pubSet)
+			assert.Error(t, err, "%s should reject a token signed with a different key", tc.name)
+		})
+	}
+}
+
+// TestKeysetVerifyFunctions_CallerCannotShiftClock confirms that all helpers
+// reject a caller-supplied backdated clock.
+//
+// The token has already expired (exp well beyond ClockSkewLeeway),
+// and the caller passes a clock shifted back far enough that the token
+// would appear unexpired if the caller's clock were honored.
+// All helpers must reject because they override the clock with real time.
+func TestKeysetVerifyFunctions_CallerCannotShiftClock(t *testing.T) {
+	privKey, pubSet := makeTestKeyset(t)
+	now := time.Now()
+	// Token issued and valid in the past;
+	// expired 5 minutes ago, well beyond ClockSkewLeeway.
+	tokenStr := makeSignedToken(t,
+		privKey,
+		now.Add(-10*time.Minute),
+		now.Add(-10*time.Minute),
+		now.Add(-5*time.Minute),
+	)
+	// A clock shifted back 8 minutes: from its perspective, exp is in the future.
+	backdatedClock := jwt.ClockFunc(func() time.Time {
+		return now.Add(-8 * time.Minute)
+	})
+
+	for _, tc := range keysetVerifyFunctions {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.fn(tokenStr, pubSet, jwt.WithClock(backdatedClock))
+			assert.Error(t, err, "%s should reject the expired token even with a backdated caller clock", tc.name)
+		})
+	}
 }
 
 // TestVerify_RejectsSkewedLocalToken confirms
 // that Verify rejects a locally-issued token
-// whose iat and nbf are slightly in the future
+// whose iat and nbf are slightly in the future (within ClockSkewLeeway)
 // when the LocalIssuer check is used.
 func TestVerify_RejectsSkewedLocalToken(t *testing.T) {
 	// Set up an isolated config state.
@@ -643,8 +705,11 @@ func TestVerify_RejectsSkewedLocalToken(t *testing.T) {
 	now := time.Now()
 	skew := ClockSkewLeeway / 2 // half the leeway — safely inside the acceptance window (when not local)
 
-	tokenStr := makeSignedTokenWithIssuer(t, privKey,
-		now.Add(skew), now.Add(skew), now.Add(10*time.Minute),
+	tokenStr := makeSignedTokenWithIssuer(t,
+		privKey,
+		now.Add(skew),
+		now.Add(skew),
+		now.Add(10*time.Minute),
 		issuerURL,
 	)
 
@@ -720,4 +785,109 @@ func TestVerify_AcceptsSkewedRegisteredServerToken(t *testing.T) {
 	})
 	assert.NoError(t, verifyErr, "Verify should not return an error for a token whose iat/nbf are within ClockSkewLeeway")
 	assert.True(t, ok, "Verify should accept a registered-server token whose iat/nbf are within ClockSkewLeeway")
+}
+
+// TestVerifyWithKeysetStrict_RejectsSkewedIatNbf confirms that
+// VerifyWithKeysetStrict rejects a token whose iat and nbf are in the future,
+// even when the skew is within ClockSkewLeeway.
+func TestVerifyWithKeysetStrict_RejectsSkewedIatNbf(t *testing.T) {
+	privKey, pubSet := makeTestKeyset(t)
+	now := time.Now()
+	skew := ClockSkewLeeway / 2 // half the leeway — safely inside the acceptance window (when not strict)
+
+	tokenStr := makeSignedToken(t,
+		privKey,
+		now.Add(skew),
+		now.Add(skew),
+		now.Add(10*time.Minute),
+	)
+
+	_, err := VerifyWithKeysetStrict(tokenStr, pubSet)
+	assert.Error(t, err, "VerifyWithKeysetStrict should reject a token whose iat/nbf are in the future")
+}
+
+// TestVerifyWithKeysetStrict_RejectsSlightlyExpiredToken confirms that
+// VerifyWithKeysetStrict rejects a token that expired a few moments ago,
+// even when the gap is within ClockSkewLeeway.
+func TestVerifyWithKeysetStrict_RejectsSlightlyExpiredToken(t *testing.T) {
+	privKey, pubSet := makeTestKeyset(t)
+	now := time.Now()
+	pastSkew := ClockSkewLeeway / 2 // half the leeway — safely inside the acceptance window (when not strict)
+
+	tokenStr := makeSignedToken(t,
+		privKey,
+		now.Add(-2*time.Minute),
+		now.Add(-2*time.Minute),
+		now.Add(-pastSkew),
+	)
+
+	_, err := VerifyWithKeysetStrict(tokenStr, pubSet)
+	assert.Error(t, err, "VerifyWithKeysetStrict should reject a token that has recently expired")
+}
+
+// TestVerifyWithKeysetStrict_CallerCannotAddSkew confirms that
+// a caller passing jwt.WithAcceptableSkew(ClockSkewLeeway)
+// to VerifyWithKeysetStrict does not widen the acceptance window.
+func TestVerifyWithKeysetStrict_CallerCannotAddSkew(t *testing.T) {
+	privKey, pubSet := makeTestKeyset(t)
+	now := time.Now()
+	skew := ClockSkewLeeway / 2 // half the leeway — safely inside the acceptance window (when not strict)
+
+	tokenStr := makeSignedToken(t,
+		privKey,
+		now.Add(skew),
+		now.Add(skew),
+		now.Add(10*time.Minute),
+	)
+
+	_, err := VerifyWithKeysetStrict(tokenStr, pubSet, jwt.WithAcceptableSkew(ClockSkewLeeway))
+	assert.Error(t, err, "caller WithAcceptableSkew must not add skew tolerance to VerifyWithKeysetStrict")
+}
+
+// TestKeysetVerifyFunctions_CallerCannotResetValidators confirms that
+// all helpers neutralize a caller-supplied WithResetValidators(true).
+// If honored, that option would disable all default temporal validators,
+// causing a clearly-expired token to be accepted.
+func TestKeysetVerifyFunctions_CallerCannotResetValidators(t *testing.T) {
+	privKey, pubSet := makeTestKeyset(t)
+	now := time.Now()
+	// Token expired 5 minutes ago — clearly invalid even with ClockSkewLeeway.
+	tokenStr := makeSignedToken(t,
+		privKey,
+		now.Add(-10*time.Minute),
+		now.Add(-10*time.Minute),
+		now.Add(-5*time.Minute),
+	)
+
+	for _, tc := range keysetVerifyFunctions {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.fn(tokenStr, pubSet, jwt.WithResetValidators(true))
+			assert.Error(t, err, "%s should reject expired token even when caller passes WithResetValidators(true)", tc.name)
+		})
+	}
+}
+
+// TestSkewedTokenAcceptedByVerifyWithKeysetButRejectedByStrict is the primary
+// cross-path regression test for the clock-skew fix (issue #3254).
+// It constructs a single token with iat/nbf in the near future (within ClockSkewLeeway)
+// and asserts that:
+//   - VerifyWithKeyset accepts it (cross-server skew tolerance), and
+//   - VerifyWithKeysetStrict rejects it (self-issued, zero-skew path).
+func TestSkewedTokenAcceptedByVerifyWithKeysetButRejectedByStrict(t *testing.T) {
+	privKey, pubSet := makeTestKeyset(t)
+	now := time.Now()
+	skew := ClockSkewLeeway / 2 // within leeway for cross-server; out of tolerance for strict
+
+	tokenStr := makeSignedToken(t,
+		privKey,
+		now.Add(skew),
+		now.Add(skew),
+		now.Add(10*time.Minute),
+	)
+
+	_, withSkewErr := VerifyWithKeyset(tokenStr, pubSet)
+	assert.NoError(t, withSkewErr, "VerifyWithKeyset should accept a token within ClockSkewLeeway (cross-server path)")
+
+	_, strictErr := VerifyWithKeysetStrict(tokenStr, pubSet)
+	assert.Error(t, strictErr, "VerifyWithKeysetStrict should reject the same token (self-issued path, zero skew)")
 }

--- a/web_ui/authentication.go
+++ b/web_ui/authentication.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/csrf"
-	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/tg123/go-htpasswd"
@@ -135,14 +134,14 @@ func configureAuthDB() error {
 // Uses early-exit pattern for cleaner flow control.
 func extractUserFromBearerToken(ctx *gin.Context, tokenStr string) (user string, userId string, groups []string, err error) {
 	// Parse token without verification first to check issuer
-	parsed, err := jwt.Parse([]byte(tokenStr), jwt.WithVerify(false))
+	tok, err := token.UnsafeParseClaims(tokenStr)
 	if err != nil {
 		return "", "", nil, err
 	}
 
 	// Verify issuer matches local issuer
 	localIssuer := config.GetLocalIssuerUrl()
-	if parsed.Issuer() != localIssuer {
+	if tok.Issuer() != localIssuer {
 		return "", "", nil, errors.New("token issuer does not match server URL")
 	}
 
@@ -152,12 +151,10 @@ func extractUserFromBearerToken(ctx *gin.Context, tokenStr string) (user string,
 		return "", "", nil, err
 	}
 
-	verified, err := jwt.Parse([]byte(tokenStr), jwt.WithKeySet(jwks))
+	// Self-issued token: this server both signs and verifies it,
+	// so no inter-server clock skew is possible.
+	verified, err := token.VerifyWithKeysetStrict(tokenStr, jwks)
 	if err != nil {
-		return "", "", nil, err
-	}
-
-	if err = jwt.Validate(verified); err != nil {
 		return "", "", nil, err
 	}
 
@@ -242,8 +239,8 @@ func GetUserGroups(ctx *gin.Context) (user string, userId string, groups []strin
 		}
 	}
 
-	var token string
-	token, err = ctx.Cookie("login")
+	var loginToken string
+	loginToken, err = ctx.Cookie("login")
 	if err != nil {
 		if err == http.ErrNoCookie {
 			err = nil
@@ -252,7 +249,7 @@ func GetUserGroups(ctx *gin.Context) (user string, userId string, groups []strin
 			return
 		}
 	}
-	if token == "" {
+	if loginToken == "" {
 		err = errors.New("Login cookie is empty")
 		return
 	}
@@ -260,11 +257,10 @@ func GetUserGroups(ctx *gin.Context) (user string, userId string, groups []strin
 	if err != nil {
 		return
 	}
-	parsed, err := jwt.Parse([]byte(token), jwt.WithKeySet(jwks))
+	// Self-issued token: this server both signs and verifies it,
+	// so no inter-server clock skew is possible.
+	parsed, err := token.VerifyWithKeysetStrict(loginToken, jwks)
 	if err != nil {
-		return
-	}
-	if err = jwt.Validate(parsed); err != nil {
 		return
 	}
 	user = parsed.Subject()

--- a/web_ui/authentication.go
+++ b/web_ui/authentication.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -538,6 +538,7 @@ func DowntimeAuthHandler(ctx *gin.Context) {
 		Scopes:  []token_scopes.TokenScope{requiredScope},
 	})
 	if !ok || err != nil {
+		log.Warningf("Failed to verify %s token for downtime %s from %s: %v", requiredScope, ctx.Request.Method, ctx.ClientIP(), err)
 		ctx.AbortWithStatusJSON(status, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
 			Msg:    fmt.Sprint("Failed to verify the token: ", err),


### PR DESCRIPTION
Closes #3254.

## Background

Pelican servers exchange JWTs for authentication across multiple server-to-server flows. Clock skew between any two servers can cause a valid token to be rejected with `"iat" not satisfied` or `"nbf" not satisfied`.

**Root cause:** The JWT library (`github.com/lestrrat-go/jwx/v2/jwt`) validates temporal claims (`iat`, `nbf`, `exp`) during _every_ `jwt.Parse` call unless `jwt.WithValidate(false)` is explicitly passed — even when `jwt.WithVerify(false)` is used (which only disables cryptographic signature checking, not time-claim validation). With zero tolerance for clock skew (the library's default), any positive difference between the issuer's clock and the verifier's clock causes `iat`/`nbf` to appear to be in the future.

**Token profiles:** Pelican sets `iat` and `nbf` to the same value (`time.Now()`) at creation. The library validates both. A clock behind the issuer by any amount greater than zero seconds (after second-level truncation) can trigger the failure.

**`WithAcceptableSkew` semantics.** The skew value `s` widens the validity window symmetrically:

- `iat`: accept tokens where `iat ≤ now + s` (issuer clock up to `s` ahead)

- `nbf`: accept tokens where `nbf ≤ now + s` (same)

- `exp`: accept tokens where `exp > now - s` (verifier clock up to `s` ahead)


All comparisons are truncated to second precision regardless of skew.

## Solution

Introduce three shared primitives in the `token` package that standardise correct JWT handling across the codebase:

- **`UnsafeParseClaims(tokenStr string) (jwt.Token, error)`** — parses a token string with both signature verification and claim validation disabled (`WithVerify(false), WithValidate(false)`). The name signals that the result carries no security guarantees and must never be used for authorization decisions.

- **`VerifyWithKeyset(tokenStr string, jwks jwk.Set, opts ...jwt.ValidateOption) (jwt.Token, error)`** — implementation:
  1. `jwt.Parse([]byte(tokenStr), jwt.WithKeySet(jwks), jwt.WithValidate(false))` (signature only).
  2. One `jwt.Validate(tok, append(opts, jwt.WithAcceptableSkew(ClockSkewLeeway))...)` call — three options (`WithResetValidators(false)`, `WithClock(time.Now)`, `WithAcceptableSkew(ClockSkewLeeway)`) are appended **after** caller options so callers cannot silently override them.

     Splitting time-claim checks from later claim-specific validators is what currently allows skew failures to re-surface, since jwx runs the default `iat`/`nbf`/`exp` validators on **every** `jwt.Validate` call regardless of which extra validators are attached.

- **`VerifyWithKeysetStrict(tokenStr string, jwks jwk.Set, opts ...jwt.ValidateOption) (jwt.Token, error)`** — identical in structure to `VerifyWithKeyset` but applies zero skew tolerance.

  Use this for self-issued tokens — those signed by the local server's own key and validated by the same server — where only one clock is involved and there is no inter-server skew to tolerate.

The 60-second leeway matches the value recommended by the [WLCG Common JWT Profile](https://github.com/WLCG-AuthZ-WG/common-jwt-profile/blob/master/profile.md), which Pelican already targets for its server-to-server tokens, and is not configurable. `ClockSkewLeeway` also extends `exp` tolerance by 60 seconds — tokens expired up to 60 seconds ago will be accepted. This is the accepted tradeoff for clock-skew tolerance and is consistent with the same WLCG guidance.

Many call sites across the codebase reinvent the same parse-then-validate pattern. Consolidating onto these three primitives eliminates the duplication and makes it impossible to accidentally omit skew tolerance or `WithValidate(false)` in a future call site.

---

(_[Brian A](https://github.com/brianaydemir): With a tip of the hat to Copilot._)

The primary constraints here are:

- Backdating `iat` is not kosher with respect to the relevant RFCs.
- The JWT library Pelican uses validates `iat`, even though that is not strictly required by those same RFCs.

Combined with the fact that clock skew in a distributed system is a literal fact that must be dealt with, I've decided that the correct solution is for Pelican itself to account for clock skew when verifying/validating tokens.