### PR TITLE
Improve computation of the ETag and checksums

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -3326,6 +3326,13 @@ func parseDigestHeader(header http.Header, fields log.Fields) (result []Checksum
 	}
 	for _, val := range header.Values("Digest") {
 		for _, entry := range strings.Split(val, ",") {
+			// Per RFC 7230 §7, list elements may be separated by a comma
+			// followed by optional whitespace (e.g. "md5=...., crc32c=....").
+			// Trim it so the algorithm name doesn't carry a leading space.
+			entry = strings.TrimSpace(entry)
+			if entry == "" {
+				continue
+			}
 			info := strings.SplitN(entry, "=", 2)
 			if len(info) != 2 {
 				continue

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -4725,3 +4725,47 @@ func TestMetadataChannelByteRange(t *testing.T) {
 		t.Fatal("expected metadata on channel but none was sent")
 	}
 }
+
+// TestFetchChecksumParsesMultipleDigests verifies that fetchChecksum parses
+// every entry in a multi-digest RFC 3230 Digest header, including when the
+// server separates entries with ", " (comma + optional whitespace, permitted
+// by RFC 7230 §7).  This guards against a regression where a leading space
+// caused every entry after the first to be treated as an unknown algorithm and
+// dropped.
+func TestFetchChecksumParsesMultipleDigests(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+
+	// md5 (base64) + crc32c (hex) + crc32 (hex) + sha (base64), comma-SPACE
+	// separated.
+	const digestHeader = "md5=67pYXTv4sRZpetpg60PJgg==, crc32c=574a2bf2, crc32=e59f820e, sha=zJWslQTLm4LKR9NF/ksIOV5Rfag="
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodHead, r.Method, "fetchChecksum should use HEAD")
+		w.Header().Set("Digest", digestHeader)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL + "/test/object.bin")
+	require.NoError(t, err)
+
+	got, err := fetchChecksum(context.Background(), KnownChecksumTypes(), u, "", "")
+	require.NoError(t, err)
+
+	byAlg := make(map[ChecksumType][]byte, len(got))
+	for _, ci := range got {
+		byAlg[ci.Algorithm] = ci.Value
+	}
+
+	// All four algorithms must be present.
+	require.Contains(t, byAlg, AlgMD5, "md5 should parse")
+	require.Contains(t, byAlg, AlgCRC32C, "crc32c must survive the ', ' separator")
+	require.Contains(t, byAlg, AlgCRC32, "crc32 must survive the ', ' separator")
+	require.Contains(t, byAlg, AlgSHA1, "sha must survive the ', ' separator")
+
+	// Spot-check decoded values: crc32c is hex 574a2bf2 -> 4 big-endian bytes.
+	assert.Equal(t, []byte{0x57, 0x4a, 0x2b, 0xf2}, byAlg[AlgCRC32C])
+	// md5 is a 16-byte digest; sha1 is 20 bytes.
+	assert.Len(t, byAlg[AlgMD5], 16)
+	assert.Len(t, byAlg[AlgSHA1], 20)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1739,20 +1739,26 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 	// Output warnings before the defaults are set. The SetServerDefaults function sets the default values
 	// of Origin.StorageType to "posix" and Origin.SelfTest to true. After these defaults are applied,
 	// it becomes impossible to determine if the values are coming from the default settings or from user input.
-	if currentServers.IsEnabled(server_structs.OriginType) && param.Origin_StorageType.GetString() != "posix" {
-		updates := make(map[string]interface{})
-		if param.Origin_SelfTest.GetBool() {
-			log.Warningf("%s may not be enabled when the origin is configured with non-posix backends. Turning off...", param.Origin_SelfTest.GetName())
-			updates[param.Origin_SelfTest.GetName()] = false
-		}
-		if param.Origin_DirectorTest.GetBool() {
-			log.Warningf("%s may not be enabled when the origin is configured with non-posix backends. Turning off...", param.Origin_DirectorTest.GetName())
-			updates[param.Origin_DirectorTest.GetName()] = false
-		}
-		if len(updates) > 0 {
-			if err := param.MultiSet(updates); err != nil {
-				logging.FlushLogs(true)
-				return err
+	//
+	// Self-test and director-test write a probe file and read it back, so they require a
+	// POSIX-like backend (posix, posixv2). Disable them on remote-protocol backends.
+	if currentServers.IsEnabled(server_structs.OriginType) {
+		storageType := server_structs.OriginStorageType(param.Origin_StorageType.GetString())
+		if !storageType.IsPosixLike() {
+			updates := make(map[string]interface{})
+			if param.Origin_SelfTest.GetBool() {
+				log.Warningf("%s may not be enabled when the origin is configured with non-POSIX-like backends. Turning off...", param.Origin_SelfTest.GetName())
+				updates[param.Origin_SelfTest.GetName()] = false
+			}
+			if param.Origin_DirectorTest.GetBool() {
+				log.Warningf("%s may not be enabled when the origin is configured with non-POSIX-like backends. Turning off...", param.Origin_DirectorTest.GetName())
+				updates[param.Origin_DirectorTest.GetName()] = false
+			}
+			if len(updates) > 0 {
+				if err := param.MultiSet(updates); err != nil {
+					logging.FlushLogs(true)
+					return err
+				}
 			}
 		}
 	}

--- a/director/director.go
+++ b/director/director.go
@@ -1446,8 +1446,10 @@ func finishRegisterServeAd(engineCtx context.Context, ctx *gin.Context, adV2 *se
 	if st == "" {
 		st = server_structs.OriginStoragePosix
 	}
-	// Disable director test if the server isn't POSIX
-	if st != server_structs.OriginStoragePosix && !adV2.DisableDirectorTest {
+	// Disable director test if the server isn't POSIX-like (posix / posixv2).
+	// Remote-protocol backends (S3, HTTPS, Globus, etc.) cannot accept the
+	// probe-file write/read that the director test relies on.
+	if !st.IsPosixLike() && !adV2.DisableDirectorTest {
 		log.Warningf("%s server '%s' with storage type '%s' enabled director test. This is not supported.", sType, adV2.Name, string(st))
 		adV2.DisableDirectorTest = true
 	}

--- a/e2e_fed_tests/posixv2_advanced_test.go
+++ b/e2e_fed_tests/posixv2_advanced_test.go
@@ -456,36 +456,22 @@ Director:
 	digestHeader := resp.Header.Get("Digest")
 	assert.NotEmpty(t, digestHeader, "HEAD response should include Digest header with default checksum")
 
-	// Verify digest header contains crc32c with correct value (RFC 3230 format: algorithm=value)
-	// Note: Currently the origin returns MD5 even when DefaultChecksumTypes is set to crc32c.
-	// This test is updated to verify the actual checksum value rather than just presence.
-	if strings.Contains(digestHeader, "crc32c=") {
-		// Compute expected CRC32C and verify
-		crc32cHash := crc32.New(crc32.MakeTable(crc32.Castagnoli))
-		_, _ = crc32cHash.Write(testContent)
-		expectedCRC32C := base64.StdEncoding.EncodeToString(crc32cHash.Sum(nil))
-		for _, part := range strings.Split(digestHeader, ",") {
-			part = strings.TrimSpace(part)
-			if strings.HasPrefix(part, "crc32c=") {
-				actualCRC32C := strings.TrimPrefix(part, "crc32c=")
-				assert.Equal(t, expectedCRC32C, actualCRC32C, "CRC32C value in Digest header should match expected")
-				break
-			}
+	// The origin defaults its HEAD Want-Digest to the first algorithm in
+	// Origin.DefaultChecksumTypes (here, crc32c). Verify the header carries
+	// the expected algorithm and the correct value. CRC32C values are encoded
+	// as 8-char lowercase hex per the origin's RFC 3230 formatter.
+	require.Contains(t, digestHeader, "crc32c=",
+		"Digest header should advertise crc32c when DefaultChecksumTypes starts with crc32c; got: %s", digestHeader)
+	crc32cHash := crc32.New(crc32.MakeTable(crc32.Castagnoli))
+	_, _ = crc32cHash.Write(testContent)
+	expectedCRC32C := fmt.Sprintf("%08x", crc32cHash.Sum32())
+	for _, part := range strings.Split(digestHeader, ",") {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, "crc32c=") {
+			actualCRC32C := strings.TrimPrefix(part, "crc32c=")
+			assert.Equal(t, expectedCRC32C, actualCRC32C, "CRC32C value in Digest header should match expected")
+			break
 		}
-	} else if strings.Contains(digestHeader, "md5=") {
-		// If MD5 is returned instead, verify it's correct (fallback behavior)
-		md5Hash := md5.Sum(testContent)
-		expectedMD5 := base64.StdEncoding.EncodeToString(md5Hash[:])
-		for _, part := range strings.Split(digestHeader, ",") {
-			part = strings.TrimSpace(part)
-			if strings.HasPrefix(part, "md5=") {
-				actualMD5 := strings.TrimPrefix(part, "md5=")
-				assert.Equal(t, expectedMD5, actualMD5, "MD5 value in Digest header should match expected (fallback)")
-				break
-			}
-		}
-	} else {
-		t.Errorf("Digest header should contain either crc32c or md5 checksum, got: %s", digestHeader)
 	}
 }
 

--- a/e2e_fed_tests/posixv2_checksum_e2e_test.go
+++ b/e2e_fed_tests/posixv2_checksum_e2e_test.go
@@ -1,0 +1,382 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// E2E coverage for POSIXv2 checksum behavior and the ETag uniqueness fix.
+//
+// These tests focus on three related properties:
+//
+//  1. POSIXv2 defaults checksums to CRC32C even when the operator has not set
+//     Origin.DefaultChecksumTypes -- this matches the Pelican client's own
+//     default and avoids paying the cost of an extra MD5 pass on every HEAD.
+//  2. The same checksum infrastructure works under the multiuser variant of
+//     POSIXv2 (the inner filesystem wrapped by multiuser_fs).
+//  3. ETags for different files are actually distinct -- previously two files
+//     with the same size and mtime could collapse to the same ETag.
+
+package fed_tests
+
+import (
+	"crypto/tls"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pkg/xattr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/fed_test_utils"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/test_utils"
+)
+
+// originServerURL returns the https://host:port string for the running origin.
+func originServerURL() string {
+	return fmt.Sprintf("https://%s:%d",
+		param.Server_Hostname.GetString(), param.Server_WebPort.GetInt())
+}
+
+// insecureClient is a non-redirecting http.Client that skips TLS verification,
+// suitable for talking directly to a test origin's self-signed cert.
+func insecureClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+// skipUnlessXattrs ensures the filesystem under tmpPath supports user xattrs,
+// which the checksum-cache layer requires. macOS tmpfs / some Linux mounts
+// silently reject these.
+func skipUnlessXattrs(t *testing.T, tmpPath string) {
+	t.Helper()
+	probe := filepath.Join(tmpPath, ".xattr-probe")
+	if err := os.WriteFile(probe, []byte("x"), 0o644); err != nil {
+		t.Skipf("could not write probe file: %v", err)
+	}
+	defer os.Remove(probe)
+	if err := xattr.Set(probe, "user.test.pelican", []byte("y")); err != nil {
+		t.Skipf("xattrs not supported on this filesystem: %v", err)
+	}
+}
+
+// expectedCRC32CHex returns the RFC 3230-style 8-char lowercase hex CRC32C
+// digest of the given content, matching origin_serve.rfc3230Value's encoding.
+func expectedCRC32CHex(content []byte) string {
+	h := crc32.New(crc32.MakeTable(crc32.Castagnoli))
+	_, _ = h.Write(content)
+	return fmt.Sprintf("%08x", h.Sum32())
+}
+
+// TestPosixv2_DefaultDigestIsCRC32C verifies that, with no explicit
+// Origin.DefaultChecksumTypes set, a HEAD request that omits Want-Digest still
+// receives a CRC32C digest -- not the legacy MD5 fallback. This is the
+// behavior the Pelican client relies on (AlgDefault = AlgCRC32C).
+func TestPosixv2_DefaultDigestIsCRC32C(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+
+	storage := t.TempDir()
+	skipUnlessXattrs(t, storage)
+
+	originConfig := fmt.Sprintf(`
+Origin:
+  StorageType: posixv2
+  Exports:
+    - FederationPrefix: /test
+      StoragePrefix: %s
+      Capabilities: ["PublicReads", "Writes", "Listings"]
+Director:
+  MinStatResponse: 1
+  MaxStatResponse: 1
+`, storage)
+
+	ft := fed_test_utils.NewFedTest(t, originConfig)
+	require.NotNil(t, ft)
+
+	content := []byte("default crc32c content")
+	backendFile := filepath.Join(ft.Exports[0].StoragePrefix, "default_crc32c.txt")
+	require.NoError(t, os.WriteFile(backendFile, content, 0o644))
+
+	tok := getTempTokenForTest(t)
+	httpClient := insecureClient()
+
+	req, err := http.NewRequest(http.MethodHead,
+		originServerURL()+"/api/v1.0/origin/data/test/default_crc32c.txt", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	// Deliberately omit Want-Digest so the server has to pick the default.
+
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "HEAD should succeed")
+
+	digest := resp.Header.Get("Digest")
+	require.NotEmpty(t, digest, "Digest header should be populated by default")
+
+	// Strict: the default must be CRC32C, not MD5.
+	require.Contains(t, digest, "crc32c=",
+		"Default digest should be CRC32C (matches Pelican client default); got %q", digest)
+	require.NotContains(t, digest, "md5=",
+		"Default digest must not silently fall back to MD5 anymore; got %q", digest)
+
+	// Verify the value as well.
+	want := expectedCRC32CHex(content)
+	for _, part := range strings.Split(digest, ",") {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, "crc32c=") {
+			assert.Equal(t, want, strings.TrimPrefix(part, "crc32c="),
+				"CRC32C digest value should match the actual content checksum")
+		}
+	}
+
+	// And the same checksum should be cached as an xattr next to the file
+	// (so subsequent HEADs are O(1) rather than re-hashing the file).
+	xattrData, err := xattr.Get(backendFile, "user.XrdCks.crc32c")
+	require.NoError(t, err, "CRC32C xattr should be persisted by the default HEAD path")
+	assert.NotEmpty(t, xattrData)
+}
+
+// TestPosixv2_UploadCachesDefaultChecksum exercises the full client round-trip
+// to confirm that a Pelican PUT followed by a client.DoStat with the default
+// CRC32C algorithm returns the matching value, and that the value persists in
+// the xattr cache (i.e. POSIXv2's checksum behavior matches what Pelican
+// clients expect by default).
+func TestPosixv2_UploadCachesDefaultChecksum(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+
+	storage := t.TempDir()
+	skipUnlessXattrs(t, storage)
+
+	originConfig := fmt.Sprintf(`
+Origin:
+  StorageType: posixv2
+  Exports:
+    - FederationPrefix: /test
+      StoragePrefix: %s
+      Capabilities: ["PublicReads", "Writes", "Listings"]
+Director:
+  MinStatResponse: 1
+  MaxStatResponse: 1
+`, storage)
+
+	ft := fed_test_utils.NewFedTest(t, originConfig)
+	require.NotNil(t, ft)
+
+	content := []byte("payload that should yield a stable CRC32C digest")
+	localDir := t.TempDir()
+	local := filepath.Join(localDir, "obj.bin")
+	require.NoError(t, os.WriteFile(local, content, 0o644))
+
+	uploadURL := fmt.Sprintf("pelican://%s:%d/test/obj.bin",
+		param.Server_Hostname.GetString(), param.Server_WebPort.GetInt())
+
+	tok := getTempTokenForTest(t)
+	_, err := client.DoPut(ft.Ctx, local, uploadURL, false, client.WithToken(tok))
+	require.NoError(t, err)
+
+	statInfo, err := client.DoStat(ft.Ctx, uploadURL, client.WithToken(tok),
+		client.WithRequestChecksums([]client.ChecksumType{client.AlgCRC32C}))
+	require.NoError(t, err)
+	require.NotNil(t, statInfo)
+	require.NotNil(t, statInfo.Checksums, "Checksums must be present when requested")
+	got, ok := statInfo.Checksums["crc32c"]
+	require.True(t, ok, "CRC32C entry should be present: %+v", statInfo.Checksums)
+
+	// statInfo.Checksums values are hex-encoded raw digest bytes (see
+	// client/main.go: hex.EncodeToString(info.Value)). That's the same
+	// encoding as expectedCRC32CHex.
+	assert.Equal(t, expectedCRC32CHex(content), got,
+		"CRC32C value reported via Stat must match the actual content checksum")
+
+	// xattr should be cached for fast subsequent reads.
+	backendFile := filepath.Join(ft.Exports[0].StoragePrefix, "obj.bin")
+	xattrData, err := xattr.Get(backendFile, "user.XrdCks.crc32c")
+	require.NoError(t, err)
+	assert.NotEmpty(t, xattrData)
+}
+
+// TestPosixv2_ETagDistinctForDifferentObjects is the E2E manifestation of the
+// reported bug: previously, the ETag of every POSIXv2 object "looked nearly
+// the same" because it was just `mtime|size` concatenated as hex. With the
+// inode included, two distinct files -- even with identical size and mtime --
+// have observably distinct ETags over the wire.
+func TestPosixv2_ETagDistinctForDifferentObjects(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+
+	storage := t.TempDir()
+
+	originConfig := fmt.Sprintf(`
+Origin:
+  StorageType: posixv2
+  Exports:
+    - FederationPrefix: /test
+      StoragePrefix: %s
+      Capabilities: ["PublicReads", "Writes", "Listings"]
+Director:
+  MinStatResponse: 1
+  MaxStatResponse: 1
+`, storage)
+
+	ft := fed_test_utils.NewFedTest(t, originConfig)
+	require.NotNil(t, ft)
+
+	// Three files: same size, two with the same mtime forced to a fixed value,
+	// one with a naturally-fresh mtime. The first two are the "collision" case
+	// that the old size+mtime ETag could not distinguish.
+	const sz = 5
+	a := filepath.Join(storage, "a.bin")
+	b := filepath.Join(storage, "b.bin")
+	c := filepath.Join(storage, "c.bin")
+	require.NoError(t, os.WriteFile(a, []byte("AAAAA"), 0o644))
+	require.NoError(t, os.WriteFile(b, []byte("BBBBB"), 0o644))
+	require.NoError(t, os.WriteFile(c, []byte("CCCCC"), 0o644))
+	fixed := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	require.NoError(t, os.Chtimes(a, fixed, fixed))
+	require.NoError(t, os.Chtimes(b, fixed, fixed))
+
+	require.Equal(t, int64(sz), mustSize(t, a))
+	require.Equal(t, int64(sz), mustSize(t, b))
+
+	tok := getTempTokenForTest(t)
+	httpClient := insecureClient()
+
+	etagOf := func(name string) string {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodGet,
+			originServerURL()+"/api/v1.0/origin/data/test/"+name, nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+tok)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode, "GET %s should succeed", name)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		etag := resp.Header.Get("ETag")
+		require.NotEmpty(t, etag, "GET %s should return an ETag header", name)
+		return etag
+	}
+
+	etagA := etagOf("a.bin")
+	etagB := etagOf("b.bin")
+	etagC := etagOf("c.bin")
+
+	// The core regression check: two files with the same size+mtime must not
+	// share an ETag any more.
+	assert.NotEqual(t, etagA, etagB,
+		"two files with identical size and mtime must have distinct ETags (a=%q b=%q)", etagA, etagB)
+	// And c must differ from both, since its mtime is different.
+	assert.NotEqual(t, etagA, etagC)
+	assert.NotEqual(t, etagB, etagC)
+}
+
+// TestPosixv2_ETagIfNoneMatch_RoundTrip verifies the conditional-request
+// happy path: a fresh ETag yields 304 on a repeat GET, and the ETag returned
+// in the 304 response matches the original. Hand-wired (not e2e-fed) tests
+// already cover the format itself; this test guards against a regression in
+// the integration with the federation's router and TLS path.
+func TestPosixv2_ETagIfNoneMatch_RoundTrip(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+
+	storage := t.TempDir()
+
+	originConfig := fmt.Sprintf(`
+Origin:
+  StorageType: posixv2
+  Exports:
+    - FederationPrefix: /test
+      StoragePrefix: %s
+      Capabilities: ["PublicReads", "Writes", "Listings"]
+Director:
+  MinStatResponse: 1
+  MaxStatResponse: 1
+`, storage)
+
+	ft := fed_test_utils.NewFedTest(t, originConfig)
+	require.NotNil(t, ft)
+
+	path := filepath.Join(storage, "etag_rt.bin")
+	require.NoError(t, os.WriteFile(path, []byte("conditional payload"), 0o644))
+
+	tok := getTempTokenForTest(t)
+	httpClient := insecureClient()
+
+	url := originServerURL() + "/api/v1.0/origin/data/test/etag_rt.bin"
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "initial GET should succeed, body=%q", string(body))
+	etag := resp.Header.Get("ETag")
+	require.NotEmpty(t, etag, "POSIXv2 GET must return an ETag")
+
+	// The new ETag is an opaque, quoted 16-char hex digest. We don't assert
+	// the bytes, but we do guard against regressing to a format that lets
+	// two files with the same size and mtime collide.
+	require.True(t, strings.HasPrefix(etag, `"`) && strings.HasSuffix(etag, `"`),
+		"ETag must be quoted: %q", etag)
+	require.Equal(t, 16, len(strings.Trim(etag, `"`)),
+		"ETag should be a 16-char opaque hex digest: %q", etag)
+
+	req2, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+	req2.Header.Set("Authorization", "Bearer "+tok)
+	req2.Header.Set("If-None-Match", etag)
+	resp2, err := httpClient.Do(req2)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	assert.Equal(t, http.StatusNotModified, resp2.StatusCode,
+		"matching If-None-Match should yield 304")
+	assert.Equal(t, etag, resp2.Header.Get("ETag"),
+		"304 response should echo the matching ETag")
+}
+
+// ---- small helpers -----------------------------------------------------
+
+func mustSize(t *testing.T, path string) int64 {
+	t.Helper()
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	return info.Size()
+}

--- a/e2e_fed_tests/posixv2_checksum_e2e_test.go
+++ b/e2e_fed_tests/posixv2_checksum_e2e_test.go
@@ -33,7 +33,8 @@
 package fed_tests
 
 import (
-	"crypto/tls"
+	"crypto/md5"
+	"encoding/binary"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -49,6 +50,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/fed_test_utils"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_utils"
@@ -59,19 +61,6 @@ import (
 func originServerURL() string {
 	return fmt.Sprintf("https://%s:%d",
 		param.Server_Hostname.GetString(), param.Server_WebPort.GetInt())
-}
-
-// insecureClient is a non-redirecting http.Client that skips TLS verification,
-// suitable for talking directly to a test origin's self-signed cert.
-func insecureClient() *http.Client {
-	return &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
 }
 
 // skipUnlessXattrs ensures the filesystem under tmpPath supports user xattrs,
@@ -95,6 +84,34 @@ func expectedCRC32CHex(content []byte) string {
 	h := crc32.New(crc32.MakeTable(crc32.Castagnoli))
 	_, _ = h.Write(content)
 	return fmt.Sprintf("%08x", h.Sum32())
+}
+
+// expectedCRC32CRaw returns the 4-byte big-endian CRC32C digest of content,
+// in the same shape the client decodes into ChecksumInfo.Value.
+func expectedCRC32CRaw(content []byte) []byte {
+	h := crc32.New(crc32.MakeTable(crc32.Castagnoli))
+	_, _ = h.Write(content)
+	buf := make([]byte, 4)
+	binary.BigEndian.PutUint32(buf, h.Sum32())
+	return buf
+}
+
+// expectedMD5Raw returns the raw 16-byte MD5 digest of content.
+func expectedMD5Raw(content []byte) []byte {
+	sum := md5.Sum(content)
+	return sum[:]
+}
+
+// summarizeChecksums turns a slice of ChecksumInfo into a logging-friendly
+// list of (algorithm name, byte count) pairs so test failures are diagnosable
+// without dumping raw digest bytes.
+func summarizeChecksums(cks []client.ChecksumInfo) []string {
+	out := make([]string, 0, len(cks))
+	for _, c := range cks {
+		out = append(out, fmt.Sprintf("%s(%d bytes)",
+			client.HttpDigestFromChecksum(c.Algorithm), len(c.Value)))
+	}
+	return out
 }
 
 // TestPosixv2_DefaultDigestIsCRC32C verifies that, with no explicit
@@ -129,7 +146,7 @@ Director:
 	require.NoError(t, os.WriteFile(backendFile, content, 0o644))
 
 	tok := getTempTokenForTest(t)
-	httpClient := insecureClient()
+	httpClient := config.GetClientNoRedirect()
 
 	req, err := http.NewRequest(http.MethodHead,
 		originServerURL()+"/api/v1.0/origin/data/test/default_crc32c.txt", nil)
@@ -229,11 +246,131 @@ Director:
 	assert.NotEmpty(t, xattrData)
 }
 
-// TestPosixv2_ETagDistinctForDifferentObjects is the E2E manifestation of the
-// reported bug: previously, the ETag of every POSIXv2 object "looked nearly
-// the same" because it was just `mtime|size` concatenated as hex. With the
-// inode included, two distinct files -- even with identical size and mtime --
-// have observably distinct ETags over the wire.
+// Download a POSIXv2-served object *through the cache* (V1 XRootD-based and
+// V2 Pelican-native) with WithRequireChecksum() so the client must successfully
+// verify the digest returned by the cache against the file it just downloaded.
+func TestPosixv2_DoGetVerifiesChecksum_ThroughCache(t *testing.T) {
+	cases := []struct {
+		name        string
+		enableV2    bool
+		description string
+	}{
+		{
+			name:        "V1_XRootD_cache",
+			enableV2:    false,
+			description: "Default cache implementation backed by XRootD",
+		},
+		{
+			name:        "V2_Pelican_cache",
+			enableV2:    true,
+			description: "Pelican-native cache implementation (Cache.EnableV2)",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(test_utils.SetupTestLogging(t))
+			server_utils.ResetTestState()
+			t.Cleanup(server_utils.ResetTestState)
+
+			if tc.enableV2 {
+				require.NoError(t, param.Cache_EnableV2.Set(true))
+			}
+
+			storage := t.TempDir()
+			skipUnlessXattrs(t, storage)
+
+			originConfig := fmt.Sprintf(`
+Origin:
+  DefaultChecksumTypes: ["crc32c", "md5"]
+  Exports:
+    - FederationPrefix: /test
+      StoragePrefix: %s
+      Capabilities: ["PublicReads", "Writes", "Listings"]
+Director:
+  MinStatResponse: 1
+  MaxStatResponse: 1
+`, storage)
+
+			ft := fed_test_utils.NewFedTest(t, originConfig)
+			require.NotNil(t, ft)
+
+			content := []byte("POSIXv2 checksum-verify through " + tc.name + ": " +
+				strings.Repeat("x", 4096))
+
+			localDir := t.TempDir()
+			local := filepath.Join(localDir, "verify.bin")
+			require.NoError(t, os.WriteFile(local, content, 0o644))
+
+			objectURL := fmt.Sprintf("pelican://%s:%d/test/verify.bin",
+				param.Server_Hostname.GetString(), param.Server_WebPort.GetInt())
+
+			tok := getTempTokenForTest(t)
+			_, err := client.DoPut(ft.Ctx, local, objectURL, false, client.WithToken(tok))
+			require.NoError(t, err)
+
+			// Download via the cache. WithRequireChecksum() makes the client
+			// return ErrServerChecksumMissing if no algorithm verified.
+			dst := filepath.Join(t.TempDir(), "got.bin")
+			results, err := client.DoGet(ft.Ctx, objectURL, dst, false,
+				client.WithToken(tok),
+				client.WithRequestChecksums([]client.ChecksumType{client.AlgCRC32C}),
+				client.WithRequireChecksum(),
+			)
+			require.NoError(t, err,
+				"%s: DoGet with WithRequireChecksum must succeed -- "+
+					"a failure indicates the cache failed to relay a verifiable digest "+
+					"from POSIXv2 to the client", tc.description)
+			require.NotEmpty(t, results)
+			r := results[0]
+
+			// Body must round-trip intact.
+			got, err := os.ReadFile(dst)
+			require.NoError(t, err)
+			require.Equal(t, content, got, "downloaded bytes must match uploaded bytes")
+
+			clientByAlg := map[client.ChecksumType][]byte{
+				client.AlgCRC32C: expectedCRC32CRaw(content),
+				client.AlgMD5:    expectedMD5Raw(content),
+			}
+
+			t.Logf("%s: cache returned digests: %v",
+				tc.name, summarizeChecksums(r.ServerChecksums))
+
+			// Both cache implementations must relay at least one digest from
+			// POSIXv2. (V1/XRootD computes its own digest of the served bytes;
+			// V2/Pelican relays the digests it persisted at download time.)
+			require.NotEmpty(t, r.ServerChecksums,
+				"%s: cache must relay at least one digest from POSIXv2 to the client", tc.name)
+
+			matched := 0
+			for _, sck := range r.ServerChecksums {
+				wantBytes, known := clientByAlg[sck.Algorithm]
+				if !known {
+					// SHA-1 / CRC32 are not asserted here, but log them
+					// so a future regression is easy to spot.
+					t.Logf("%s: cache returned %s digest of %d bytes (not asserted): %x",
+						tc.name, client.HttpDigestFromChecksum(sck.Algorithm),
+						len(sck.Value), sck.Value)
+					continue
+				}
+				assert.Equal(t, wantBytes, sck.Value,
+					"%s: %s digest from cache must equal locally-computed %s",
+					tc.name, client.HttpDigestFromChecksum(sck.Algorithm),
+					client.HttpDigestFromChecksum(sck.Algorithm))
+				matched++
+			}
+			assert.Greater(t, matched, 0,
+				"%s: at least one of CRC32C/MD5 should round-trip from POSIXv2 through the cache; "+
+					"got server entries: %v", tc.name, summarizeChecksums(r.ServerChecksums))
+		})
+	}
+}
+
+// Previously, the ETag of every POSIXv2 object looked the same because it was
+// just `mtime|size` concatenated as hex. With the inode included, two distinct
+// files -- even with identical size and mtime -- have observably distinct ETags
+// over the wire.
 func TestPosixv2_ETagDistinctForDifferentObjects(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	server_utils.ResetTestState()
@@ -256,13 +393,15 @@ Director:
 	ft := fed_test_utils.NewFedTest(t, originConfig)
 	require.NotNil(t, ft)
 
+	exportRoot := ft.Exports[0].StoragePrefix
+
 	// Three files: same size, two with the same mtime forced to a fixed value,
 	// one with a naturally-fresh mtime. The first two are the "collision" case
 	// that the old size+mtime ETag could not distinguish.
 	const sz = 5
-	a := filepath.Join(storage, "a.bin")
-	b := filepath.Join(storage, "b.bin")
-	c := filepath.Join(storage, "c.bin")
+	a := filepath.Join(exportRoot, "a.bin")
+	b := filepath.Join(exportRoot, "b.bin")
+	c := filepath.Join(exportRoot, "c.bin")
 	require.NoError(t, os.WriteFile(a, []byte("AAAAA"), 0o644))
 	require.NoError(t, os.WriteFile(b, []byte("BBBBB"), 0o644))
 	require.NoError(t, os.WriteFile(c, []byte("CCCCC"), 0o644))
@@ -274,7 +413,7 @@ Director:
 	require.Equal(t, int64(sz), mustSize(t, b))
 
 	tok := getTempTokenForTest(t)
-	httpClient := insecureClient()
+	httpClient := config.GetClientNoRedirect()
 
 	etagOf := func(name string) string {
 		t.Helper()
@@ -332,11 +471,12 @@ Director:
 	ft := fed_test_utils.NewFedTest(t, originConfig)
 	require.NotNil(t, ft)
 
-	path := filepath.Join(storage, "etag_rt.bin")
+	// NewFedTest may rewrite the StoragePrefix; use the effective value.
+	path := filepath.Join(ft.Exports[0].StoragePrefix, "etag_rt.bin")
 	require.NoError(t, os.WriteFile(path, []byte("conditional payload"), 0o644))
 
 	tok := getTempTokenForTest(t)
-	httpClient := insecureClient()
+	httpClient := config.GetClientNoRedirect()
 
 	url := originServerURL() + "/api/v1.0/origin/data/test/etag_rt.bin"
 
@@ -371,8 +511,6 @@ Director:
 	assert.Equal(t, etag, resp2.Header.Get("ETag"),
 		"304 response should echo the matching ETag")
 }
-
-// ---- small helpers -----------------------------------------------------
 
 func mustSize(t *testing.T, path string) int64 {
 	t.Helper()

--- a/e2e_fed_tests/posixv2_multiuser_checksum_test.go
+++ b/e2e_fed_tests/posixv2_multiuser_checksum_test.go
@@ -27,7 +27,9 @@ package fed_tests
 import (
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/pkg/xattr"
@@ -60,28 +62,45 @@ func TestPosixv2_MultiuserPreservesChecksums(t *testing.T) {
 	server_utils.ResetTestState()
 	t.Cleanup(server_utils.ResetTestState)
 
-	storage := t.TempDir()
-	skipUnlessXattrs(t, storage)
-	// Multiuser switches to the request's UID for I/O, so the storage dir must
-	// be writable by that user.
-	require.NoError(t, os.Chmod(storage, 0o777))
-
-	originConfig := fmt.Sprintf(`
+	// NewFedTest ignores the StoragePrefix below and creates its own export
+	// root via os.MkdirTemp("") -- i.e. directly under os.TempDir() (/tmp on
+	// Linux). That shallow location matters for multiuser: alice must be able
+	// to traverse every ancestor of the export root, which works for /tmp
+	// (mode 1777) but not for a deeply-nested t.TempDir() hierarchy whose
+	// intermediate directories aren't world-traversable.
+	originConfig := `
 Origin:
   StorageType: posixv2
   Multiuser: true
   ScitokensMapSubject: true
   Exports:
     - FederationPrefix: /test
-      StoragePrefix: %s
+      StoragePrefix: /this-is-overridden-by-NewFedTest
       Capabilities: ["Reads", "Writes", "Listings"]
 Director:
   MinStatResponse: 1
   MaxStatResponse: 1
-`, storage)
+`
 
 	ft := fed_test_utils.NewFedTest(t, originConfig)
 	require.NotNil(t, ft)
+
+	// Probe xattr support on the *actual* export root, not a separate
+	// t.TempDir() that may live on a different filesystem.
+	skipUnlessXattrs(t, ft.Exports[0].StoragePrefix)
+
+	// The export root NewFedTest created is mode 0755. In multiuser mode the
+	// origin switches to the request's UID (alice) for I/O, so it must be
+	// writable by that user. Rather than making it world-writable, hand
+	// ownership to alice and keep the restrictive 0755 permissions -- only
+	// alice (and root) can then write.
+	aliceUser, err := user.Lookup("alice")
+	require.NoError(t, err)
+	aliceUID, err := strconv.Atoi(aliceUser.Uid)
+	require.NoError(t, err)
+	aliceGID, err := strconv.Atoi(aliceUser.Gid)
+	require.NoError(t, err)
+	require.NoError(t, os.Chown(ft.Exports[0].StoragePrefix, aliceUID, aliceGID))
 
 	content := []byte("multiuser POSIXv2 should still cache checksums")
 
@@ -113,7 +132,7 @@ Director:
 	assert.Equal(t, expectedCRC32CHex(content), got)
 
 	// The xattr lands on the underlying file regardless of which UID owns it.
-	backendFile := filepath.Join(storage, "alice.bin")
+	backendFile := filepath.Join(ft.Exports[0].StoragePrefix, "alice.bin")
 	xattrData, err := xattr.Get(backendFile, "user.XrdCks.crc32c")
 	require.NoError(t, err, "CRC32C xattr should be present under multiuser POSIXv2")
 	assert.NotEmpty(t, xattrData)

--- a/e2e_fed_tests/posixv2_multiuser_checksum_test.go
+++ b/e2e_fed_tests/posixv2_multiuser_checksum_test.go
@@ -1,0 +1,120 @@
+//go:build linux
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Linux-only: the POSIXv2 multiuser variant relies on setfsuid/setfsgid which
+// only exist on Linux, and the test-utility helpers SkipUnlessPrivileged /
+// SkipUnlessTestUsers are themselves Linux-only.
+
+package fed_tests
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pkg/xattr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/fed_test_utils"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/test_utils"
+	"github.com/pelicanplatform/pelican/token_scopes"
+)
+
+// TestPosixv2_MultiuserPreservesChecksums covers the POSIXv2 multiuser variant
+// (Origin.Multiuser = true with StorageType posixv2). The multiuser filesystem
+// wraps the base osRoot filesystem and switches identities via setfsuid/
+// setfsgid before each operation; this test pins down that, after a PUT under
+// multiuser mode, the CRC32C xattr still lands on disk and a subsequent Stat
+// returns the matching value -- the same contract that non-multiuser POSIXv2
+// already provides.
+//
+// Requires Linux + CAP_SETUID/CAP_SETGID and the test user "alice"; skips
+// automatically when those aren't available.
+func TestPosixv2_MultiuserPreservesChecksums(t *testing.T) {
+	test_utils.SkipUnlessPrivileged(t)
+	test_utils.SkipUnlessTestUsers(t, "alice")
+
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+
+	storage := t.TempDir()
+	skipUnlessXattrs(t, storage)
+	// Multiuser switches to the request's UID for I/O, so the storage dir must
+	// be writable by that user.
+	require.NoError(t, os.Chmod(storage, 0o777))
+
+	originConfig := fmt.Sprintf(`
+Origin:
+  StorageType: posixv2
+  Multiuser: true
+  ScitokensMapSubject: true
+  Exports:
+    - FederationPrefix: /test
+      StoragePrefix: %s
+      Capabilities: ["Reads", "Writes", "Listings"]
+Director:
+  MinStatResponse: 1
+  MaxStatResponse: 1
+`, storage)
+
+	ft := fed_test_utils.NewFedTest(t, originConfig)
+	require.NotNil(t, ft)
+
+	content := []byte("multiuser POSIXv2 should still cache checksums")
+
+	createScope, err := token_scopes.Wlcg_Storage_Create.Path("/")
+	require.NoError(t, err)
+	modifyScope, err := token_scopes.Wlcg_Storage_Modify.Path("/")
+	require.NoError(t, err)
+	readScope, err := token_scopes.Wlcg_Storage_Read.Path("/")
+	require.NoError(t, err)
+	tok := createTokenWithSubject(t, "alice",
+		[]token_scopes.TokenScope{createScope, modifyScope, readScope})
+
+	localDir := t.TempDir()
+	local := filepath.Join(localDir, "alice.bin")
+	require.NoError(t, os.WriteFile(local, content, 0o644))
+
+	uploadURL := fmt.Sprintf("pelican://%s:%d/test/alice.bin",
+		param.Server_Hostname.GetString(), param.Server_WebPort.GetInt())
+
+	_, err = client.DoPut(ft.Ctx, local, uploadURL, false, client.WithToken(tok))
+	require.NoError(t, err)
+
+	statInfo, err := client.DoStat(ft.Ctx, uploadURL, client.WithToken(tok),
+		client.WithRequestChecksums([]client.ChecksumType{client.AlgCRC32C}))
+	require.NoError(t, err)
+	require.NotNil(t, statInfo.Checksums)
+	got, ok := statInfo.Checksums["crc32c"]
+	require.True(t, ok, "CRC32C should be returned for multiuser POSIXv2 stat")
+	assert.Equal(t, expectedCRC32CHex(content), got)
+
+	// The xattr lands on the underlying file regardless of which UID owns it.
+	backendFile := filepath.Join(storage, "alice.bin")
+	xattrData, err := xattr.Get(backendFile, "user.XrdCks.crc32c")
+	require.NoError(t, err, "CRC32C xattr should be present under multiuser POSIXv2")
+	assert.NotEmpty(t, xattrData)
+}

--- a/e2e_fed_tests/transfer_status_test.go
+++ b/e2e_fed_tests/transfer_status_test.go
@@ -365,3 +365,110 @@ func TestTransferStatus_Failure_NonExistent(t *testing.T) {
 		"Non-existent object should return error status, got %d", r.statusCode)
 	t.Logf("Non-existent object: status=%d, trailer=%q", r.statusCode, r.transferStatus)
 }
+
+// populateOriginChecksums issues a HEAD directly to the origin requesting
+// every algorithm the cache will later request, forcing the origin to compute
+// and persist all four checksum xattrs (md5, crc32c, crc32, sha) for the
+// file's current contents.
+func populateOriginChecksums(ctx context.Context, t *testing.T, name, token string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead,
+		originServerURL()+"/api/v1.0/origin/data/test/"+name, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Want-Digest", "md5,crc32c,crc32,sha")
+
+	resp, err := config.GetClientNoRedirect().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Sanity-check that the origin really advertised all four algorithms, so
+	// that after the content swap *every* reported digest is stale (and the
+	// mismatch can't be masked by an algorithm the origin recomputes fresh).
+	dg := resp.Header.Get("Digest")
+	for _, alg := range []string{"md5=", "crc32c=", "crc32=", "sha="} {
+		require.Contains(t, dg, alg,
+			"origin should advertise %s so all xattrs are populated; got %q", alg, dg)
+	}
+}
+
+// doOnlyIfCached issues a GET with "Cache-Control: only-if-cached", which the
+// cache answers from local storage only -- returning 504 Gateway Timeout on a
+// miss rather than fetching from the origin.
+func doOnlyIfCached(ctx context.Context, url, token string) int {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Cache-Control", "only-if-cached")
+	resp, err := (&http.Client{Transport: config.GetTransport()}).Do(req)
+	if err != nil {
+		return 0
+	}
+	defer resp.Body.Close()
+	_, _ = io.ReadAll(resp.Body)
+	return resp.StatusCode
+}
+
+// TestTransferStatus_Failure_OriginChecksumMismatch verifies that when the
+// bytes the cache downloads disagree with the digest the origin advertises,
+// the cache (a) reports the failure to the client via the X-Transfer-Status
+// trailer instead of silently serving the bad data, and (b) does NOT retain
+// the poisoned object in its cache.
+//
+// We induce the disagreement without corrupting the cache's own storage: the
+// origin caches checksums for content A, then the file is rewritten with
+// content B of the same length while its mtime is restored so the origin still
+// reports A's (now stale) digests. The origin therefore serves B's bytes while
+// advertising A's checksums -- the cache computes a checksum over B that
+// disagrees with the advertised digest.
+//
+// This is the disk-storage analogue of the inline path, which already discards
+// an object whose transfer result carries a checksum error.
+func TestTransferStatus_Failure_OriginChecksumMismatch(t *testing.T) {
+	env := setupTSEnv(t)
+	skipUnlessXattrs(t, env.ft.Exports[0].StoragePrefix)
+
+	const name = "ts_origin_mismatch.bin"
+	originFile := filepath.Join(env.ft.Exports[0].StoragePrefix, name)
+
+	// Content A: what the origin will cache checksums for. 16KB -> disk mode.
+	contentA := generateTestData(16384)
+	require.NoError(t, os.WriteFile(originFile, contentA, 0o644))
+
+	// Populate all four checksum xattrs for content A.
+	populateOriginChecksums(env.ft.Ctx, t, name, env.token)
+
+	infoA, err := os.Stat(originFile)
+	require.NoError(t, err)
+	mtimeA := infoA.ModTime()
+
+	// Rewrite with content B (same length) and restore the mtime so the
+	// origin's cached (A) checksums are not treated as stale. The origin now
+	// serves B while advertising the digests of A.
+	contentB := make([]byte, len(contentA))
+	for i := range contentB {
+		contentB[i] = contentA[i] ^ 0xFF
+	}
+	require.NoError(t, os.WriteFile(originFile, contentB, 0o644))
+	require.NoError(t, os.Chtimes(originFile, mtimeA, mtimeA))
+
+	// Drive a cache-miss GET through the V2 cache with trailer opt-in.
+	cacheURL := waitForCacheRedirectURL(t, env.ft, "/test/"+name, env.token)
+	r := doRangeRead(env.ft.Ctx, cacheURL, env.token, "", "")
+	require.NoError(t, r.err,
+		"HTTP transport should succeed; any checksum error is reported in the trailer")
+
+	// (a) The cache must surface the mismatch in the trailer, not "200: OK".
+	assert.NotEqual(t, "200: OK", r.transferStatus,
+		"a checksum mismatch must not produce a success trailer")
+	assert.True(t, strings.HasPrefix(r.transferStatus, "500:"),
+		"expected a 500 trailer for an origin/local checksum mismatch, got %q", r.transferStatus)
+
+	// (b) The poisoned object must not remain cached: an only-if-cached probe
+	// should miss (504) rather than serve the bad copy.
+	assert.Equal(t, http.StatusGatewayTimeout, doOnlyIfCached(env.ft.Ctx, cacheURL, env.token),
+		"a verification-failed object must not be retained in the cache")
+}

--- a/local_cache/block_fetcher.go
+++ b/local_cache/block_fetcher.go
@@ -733,10 +733,29 @@ func (bf *BlockFetcherV2) AdoptTransfer(
 					op.err = result.Error
 					log.Warnf("Adopted transfer failed for %s: %v", bf.instanceHash, result.Error)
 				}
-				// Store checksums from the transfer result on the download
-				// so that onComplete can persist them in metadata.
-				if result != nil {
-					dw.dl.checksums = clientChecksumsToCache(result)
+				// Persist checksums from the transfer result into the cache
+				// metadata.  We must do this here -- when the result arrives
+				// -- rather than relying on the BlockWriter's onComplete
+				// callback: the client only knows the checksums after the
+				// body finishes downloading (it fetches the origin's Digest
+				// and finalizes its own hashes post-transfer), but onComplete
+				// fires the moment the final block is written, before the
+				// result is delivered.  Persisting here (via the additive
+				// MergeMetadata) guarantees a subsequent HEAD/GET can relay a
+				// Digest header.
+				//
+				// Skip on transfer error -- those checksums describe a body we
+				// are about to discard (see PersistentCache's AdoptTransfer
+				// onExit, which evicts the failed-verification instance).
+				if result != nil && result.Error == nil {
+					checksums := clientChecksumsToCache(result)
+					dw.dl.checksums = checksums
+					if len(checksums) > 0 {
+						if err := bf.storage.MergeMetadata(bf.instanceHash,
+							&CacheMetadata{Checksums: checksums}); err != nil {
+							log.Warnf("Failed to persist checksums for %s: %v", bf.instanceHash, err)
+						}
+					}
 				}
 				bf.notifyAllChunks(op)
 				return nil

--- a/local_cache/digest_relay_test.go
+++ b/local_cache/digest_relay_test.go
@@ -1,0 +1,158 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package local_cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/client"
+)
+
+// TestFormatDigestHeader checks the RFC 3230 encoding per algorithm: MD5/SHA
+// are base64, CRC32/CRC32C are lowercase hex, and unknown types are skipped.
+func TestFormatDigestHeader(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		assert.Equal(t, "", formatDigestHeader(nil))
+		assert.Equal(t, "", formatDigestHeader([]Checksum{}))
+	})
+
+	t.Run("crc32c is hex", func(t *testing.T) {
+		got := formatDigestHeader([]Checksum{
+			{Type: ChecksumCRC32C, Value: []byte{0x57, 0x4a, 0x2b, 0xf2}},
+		})
+		assert.Equal(t, "crc32c=574a2bf2", got)
+	})
+
+	t.Run("md5 is base64", func(t *testing.T) {
+		// 16 zero bytes -> base64 of all-zero MD5-length input.
+		got := formatDigestHeader([]Checksum{
+			{Type: ChecksumMD5, Value: make([]byte, 16)},
+		})
+		assert.Equal(t, "md5=AAAAAAAAAAAAAAAAAAAAAA==", got)
+	})
+
+	t.Run("multiple joined with comma-space", func(t *testing.T) {
+		got := formatDigestHeader([]Checksum{
+			{Type: ChecksumMD5, Value: make([]byte, 16)},
+			{Type: ChecksumCRC32C, Value: []byte{0x00, 0x00, 0x00, 0x01}},
+		})
+		assert.Equal(t, "md5=AAAAAAAAAAAAAAAAAAAAAA==, crc32c=00000001", got)
+	})
+}
+
+// TestClientChecksumsToCache verifies algorithm mapping and that a server
+// (OriginVerified) checksum wins over a client-computed one of the same type,
+// so the same algorithm is never emitted twice.
+func TestClientChecksumsToCache(t *testing.T) {
+	t.Run("nil result", func(t *testing.T) {
+		assert.Nil(t, clientChecksumsToCache(nil))
+	})
+
+	t.Run("dedups crc32c across server and client", func(t *testing.T) {
+		res := &client.TransferResults{
+			ServerChecksums: []client.ChecksumInfo{
+				{Algorithm: client.AlgMD5, Value: []byte("0123456789abcdef")},
+				{Algorithm: client.AlgCRC32C, Value: []byte{1, 2, 3, 4}},
+			},
+			ClientChecksums: []client.ChecksumInfo{
+				// Same algorithm as a server entry -- must be dropped.
+				{Algorithm: client.AlgCRC32C, Value: []byte{9, 9, 9, 9}},
+			},
+		}
+		out := clientChecksumsToCache(res)
+		require.Len(t, out, 2, "crc32c should appear exactly once")
+
+		byType := map[ChecksumType]Checksum{}
+		for _, c := range out {
+			byType[c.Type] = c
+		}
+		// The server's crc32c (OriginVerified) must win.
+		crc, ok := byType[ChecksumCRC32C]
+		require.True(t, ok)
+		assert.True(t, crc.OriginVerified, "server checksum should win over client")
+		assert.Equal(t, []byte{1, 2, 3, 4}, crc.Value)
+		assert.True(t, byType[ChecksumMD5].OriginVerified)
+	})
+
+	t.Run("client-only checksum is kept and not origin-verified", func(t *testing.T) {
+		res := &client.TransferResults{
+			ClientChecksums: []client.ChecksumInfo{
+				{Algorithm: client.AlgCRC32C, Value: []byte{5, 6, 7, 8}},
+			},
+		}
+		out := clientChecksumsToCache(res)
+		require.Len(t, out, 1)
+		assert.Equal(t, ChecksumCRC32C, out[0].Type)
+		assert.False(t, out[0].OriginVerified)
+	})
+}
+
+// TestStatChecksumsToCache verifies the hex-decode + name mapping for the
+// digests returned by client.DoStat (used on an uncached HEAD), and that
+// malformed/unknown entries are skipped without error.
+func TestStatChecksumsToCache(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		assert.Nil(t, statChecksumsToCache(nil))
+		assert.Nil(t, statChecksumsToCache(map[string]string{}))
+	})
+
+	t.Run("decodes known algorithms", func(t *testing.T) {
+		out := statChecksumsToCache(map[string]string{
+			"crc32c": "574a2bf2",
+			"md5":    "00112233445566778899aabbccddeeff",
+		})
+		byType := map[ChecksumType]Checksum{}
+		for _, c := range out {
+			byType[c.Type] = c
+			assert.True(t, c.OriginVerified, "origin stat checksums are origin-verified")
+		}
+		require.Contains(t, byType, ChecksumCRC32C)
+		assert.Equal(t, []byte{0x57, 0x4a, 0x2b, 0xf2}, byType[ChecksumCRC32C].Value)
+		require.Contains(t, byType, ChecksumMD5)
+		assert.Len(t, byType[ChecksumMD5].Value, 16)
+	})
+
+	t.Run("skips unknown algorithm and malformed hex", func(t *testing.T) {
+		out := statChecksumsToCache(map[string]string{
+			"crc32c":    "574a2bf2",
+			"bogus-alg": "deadbeef",
+			"md5":       "nothexnothex", // odd length / non-hex
+		})
+		// Only crc32c survives.
+		require.Len(t, out, 1)
+		assert.Equal(t, ChecksumCRC32C, out[0].Type)
+	})
+}
+
+// TestFormatDigestHeaderRoundTrip ties the two halves together: checksums that
+// the cache persisted (via clientChecksumsToCache) format into a valid RFC 3230
+// header that mirrors what the POSIXv2 origin emits (crc32c as hex).
+func TestFormatDigestHeaderRoundTrip(t *testing.T) {
+	res := &client.TransferResults{
+		ServerChecksums: []client.ChecksumInfo{
+			{Algorithm: client.AlgCRC32C, Value: []byte{0x57, 0x4a, 0x2b, 0xf2}},
+		},
+	}
+	cks := clientChecksumsToCache(res)
+	header := formatDigestHeader(cks)
+	assert.Equal(t, "crc32c=574a2bf2", header)
+}

--- a/local_cache/persistent_cache.go
+++ b/local_cache/persistent_cache.go
@@ -37,6 +37,7 @@ package local_cache
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -104,16 +105,58 @@ func clientChecksumsToCache(result *client.TransferResults) []Checksum {
 		client.AlgCRC32C: ChecksumCRC32C,
 	}
 
+	// Server-supplied checksums take precedence over client-computed ones for
+	// the same algorithm (they carry OriginVerified), so add them first and
+	// skip any algorithm we've already recorded. This avoids emitting the same
+	// algorithm twice in the Digest header (e.g. crc32c from both sources).
 	var out []Checksum
-	for _, ci := range result.ServerChecksums {
-		if ct, ok := algMap[ci.Algorithm]; ok {
-			out = append(out, Checksum{Type: ct, Value: ci.Value, OriginVerified: true})
+	seen := make(map[ChecksumType]struct{})
+	add := func(alg client.ChecksumType, value []byte, originVerified bool) {
+		ct, ok := algMap[alg]
+		if !ok {
+			return
 		}
+		if _, dup := seen[ct]; dup {
+			return
+		}
+		seen[ct] = struct{}{}
+		out = append(out, Checksum{Type: ct, Value: value, OriginVerified: originVerified})
+	}
+	for _, ci := range result.ServerChecksums {
+		add(ci.Algorithm, ci.Value, true)
 	}
 	for _, ci := range result.ClientChecksums {
-		if ct, ok := algMap[ci.Algorithm]; ok {
-			out = append(out, Checksum{Type: ct, Value: ci.Value})
+		add(ci.Algorithm, ci.Value, false)
+	}
+	return out
+}
+
+// statChecksumsToCache converts the checksum map returned by client.DoStat
+// (HTTP digest name -> hex-encoded value) into the local cache schema.  These
+// come from the origin's HEAD response, so they are marked OriginVerified.
+// Unrecognised algorithms and malformed hex are silently skipped.
+func statChecksumsToCache(checksums map[string]string) []Checksum {
+	if len(checksums) == 0 {
+		return nil
+	}
+	nameMap := map[string]ChecksumType{
+		"md5":    ChecksumMD5,
+		"sha":    ChecksumSHA1,
+		"crc32":  ChecksumCRC32,
+		"crc32c": ChecksumCRC32C,
+	}
+	var out []Checksum
+	for name, hexVal := range checksums {
+		ct, ok := nameMap[name]
+		if !ok {
+			continue
 		}
+		raw, err := hex.DecodeString(hexVal)
+		if err != nil {
+			log.Debugf("Skipping malformed %s checksum %q from origin stat: %v", name, hexVal, err)
+			continue
+		}
+		out = append(out, Checksum{Type: ct, Value: raw, OriginVerified: true})
 	}
 	return out
 }
@@ -992,6 +1035,23 @@ func (pc *PersistentCache) newFetchingRangeReader(
 		return nil, err
 	}
 
+	// If a download is backing this reader, expose its terminal state so
+	// the serving path can fail the response with an X-Transfer-Status
+	// trailer when verification (e.g. an origin/local checksum mismatch)
+	// fails.  The error is set by AdoptTransfer's onExit, which fires after
+	// the body has been fully streamed.  See RangeReader.WaitForCompletion
+	// for the full-vs-partial blocking policy.
+	if res.dl != nil {
+		dl := res.dl
+		rr.completionDone = dl.completionDone
+		rr.completionErr = func() error {
+			if err, _ := dl.completionErr.Load().(error); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+
 	rr.onClose = func() {
 		if dlClientDone != nil {
 			dlClientDone()
@@ -1171,6 +1231,10 @@ func (pc *PersistentCache) StatCachedOnly(objectPath, token string) (uint64, err
 type HeadResult struct {
 	ContentLength int64
 	Meta          *CacheMetadata // non-nil when the object is cached
+	// Checksums carries the object's digests for the RFC 3230 Digest header.
+	// Populated from cached metadata on a hit, or from the origin's stat
+	// response on a miss, so a HEAD always relays a Digest when one is known.
+	Checksums []Checksum
 }
 
 // HeadObject returns metadata for an object without triggering a download.
@@ -1196,16 +1260,22 @@ func (pc *PersistentCache) HeadObject(objectPath, token string) (*HeadResult, er
 			return nil, errors.Wrap(mErr, "failed to check cache")
 		}
 		if meta != nil {
-			return &HeadResult{ContentLength: meta.ContentLength, Meta: meta}, nil
+			return &HeadResult{ContentLength: meta.ContentLength, Meta: meta, Checksums: meta.Checksums}, nil
 		}
 	}
 
-	// Not cached — query the origin for size only.
+	// Not cached — query the origin for size and checksums so the HEAD
+	// response can still carry a Digest header (clients fetch checksums via
+	// HEAD before/independent of downloading).
 	dUrl := *pc.directorURL
 	dUrl.Path = objectPath
 	dUrl.Scheme = "pelican"
 
-	opts := []client.TransferOption{client.WithToken(token), client.WithCacheEmbeddedClientMode()}
+	opts := []client.TransferOption{
+		client.WithToken(token),
+		client.WithCacheEmbeddedClientMode(),
+		client.WithRequestChecksums(client.KnownChecksumTypes()),
+	}
 	if ft := pc.getFedToken(); ft != "" {
 		opts = append(opts, client.WithFedToken(pc.fedTokenAsProvider()))
 	}
@@ -1214,7 +1284,12 @@ func (pc *PersistentCache) HeadObject(objectPath, token string) (*HeadResult, er
 		return nil, err
 	}
 
-	return &HeadResult{ContentLength: statInfo.Size}, nil
+	// The object isn't cached, so we leave Meta nil (no ETag/Cache-Control
+	// synthesized) but still relay any origin-provided checksums as a Digest.
+	return &HeadResult{
+		ContentLength: statInfo.Size,
+		Checksums:     statChecksumsToCache(statInfo.Checksums),
+	}, nil
 }
 
 // ErrNotCached is returned when an object is not in the cache
@@ -2018,6 +2093,22 @@ func (pc *PersistentCache) performDownload(ctx context.Context, dl *persistentDo
 			}
 			if err != nil {
 				dl.completionErr.Store(err)
+				// The download finished but failed verification (e.g. the
+				// origin's reported digest doesn't match the bytes we
+				// received).  By the time we get here, BlockWriter.Close has
+				// already fired onComplete -- which unconditionally marked
+				// the instance Completed and stored the latest-ETag mapping.
+				// Tear that down now so the poisoned object is not served as
+				// a cache hit to future requests; the next request will miss
+				// and re-fetch from the origin.
+				if delErr := pc.storage.Delete(dl.instanceHash); delErr != nil {
+					log.Warnf("Failed to evict failed-verification instance %s: %v",
+						dl.instanceHash, delErr)
+				}
+				if delErr := pc.db.DeleteLatestETag(dl.objectHash); delErr != nil {
+					log.Warnf("Failed to clear latest-ETag for failed-verification %s: %v",
+						dl.objectHash, delErr)
+				}
 			}
 			close(dl.completionDone)
 		},
@@ -2312,7 +2403,12 @@ func (w *decisionWriter) SetDiskMode(ctx context.Context, size int64) error {
 			}
 		}
 
-		// Persist any checksums the transfer client collected.
+		// Persist any checksums the transfer client collected.  For adopted
+		// (disk) transfers the checksums usually aren't known yet at this
+		// point -- they're persisted by the fetcher when the transfer result
+		// arrives (see BlockFetcherV2.AdoptTransfer).  This remains as a
+		// best-effort fast path for any flow that does set dl.checksums
+		// before completion.
 		if len(w.dl.checksums) > 0 {
 			checksumMeta := &CacheMetadata{Checksums: w.dl.checksums}
 			if err := w.pc.storage.MergeMetadata(w.dl.instanceHash, checksumMeta); err != nil {

--- a/local_cache/persistent_cache_api.go
+++ b/local_cache/persistent_cache_api.go
@@ -379,6 +379,14 @@ func (pc *PersistentCache) serveObject(w http.ResponseWriter, r *http.Request) {
 		}
 		w.Header().Set("Content-Length", strconv.FormatInt(result.ContentLength, 10))
 		w.Header().Set("Accept-Ranges", "bytes")
+		// Relay checksums as an RFC 3230 Digest header so clients can verify
+		// downloads -- they fetch checksums via HEAD. This applies whether the
+		// object is cached (checksums from metadata) or not (checksums from the
+		// origin's stat response); without it a client's WithRequireChecksum
+		// download through the cache has nothing to verify against.
+		if digest := formatDigestHeader(result.Checksums); digest != "" {
+			w.Header().Set("Digest", digest)
+		}
 		if result.Meta != nil {
 			if result.Meta.ETag != "" {
 				w.Header().Set("ETag", result.Meta.ETag)
@@ -580,12 +588,23 @@ func (pc *PersistentCache) serveObject(w http.ResponseWriter, r *http.Request) {
 
 	http.ServeContent(wrappedWriter, r, objectPath, modTime, wrappedReader)
 
+	// After the body has streamed, surface any post-download verification
+	// failure -- e.g. an origin/local checksum mismatch detected only after
+	// the body fully arrives from the origin -- in the trailer.  This blocks
+	// only for full-object reads (where the client was already waiting for
+	// the whole download); for partial range reads it returns immediately so
+	// a tiny range of a multi-GB object doesn't have to wait for the rest of
+	// the backing fill to complete.  See RangeReader.WaitForCompletion.
+	verifyErr := reader.WaitForCompletion(r.Context())
+
 	if sendTrailer {
 		trailerVal := "200: OK"
 		if writeErr != nil {
 			trailerVal = fmt.Sprintf("%d: %s", 500, writeErr)
 		} else if readErr != nil {
 			trailerVal = fmt.Sprintf("%d: %s", 500, readErr)
+		} else if verifyErr != nil {
+			trailerVal = fmt.Sprintf("%d: %s", 500, verifyErr)
 		}
 		w.Header().Set("X-Transfer-Status", trailerVal)
 	}

--- a/local_cache/range_reader.go
+++ b/local_cache/range_reader.go
@@ -172,6 +172,20 @@ type RangeReader struct {
 	// from the BlockFetcherV2 client tracking).
 	onClose func()
 
+	// completionDone / completionErr expose the terminal state of the
+	// backing download (if any).  completionDone is closed when the
+	// download finishes (success or error); completionErr returns its
+	// terminal error and is safe to call only after completionDone closes.
+	//
+	// These are consumed by WaitForCompletion to surface verification
+	// failures -- the origin's reported digest disagreeing with the bytes
+	// we received -- in the X-Transfer-Status trailer.  The failure is
+	// only known *after* the full body has been downloaded from the origin
+	// and the post-download digest comparison runs; a successful read of
+	// the cached blocks alone would otherwise mask it.
+	completionDone <-chan struct{}
+	completionErr  func() error
+
 	// repairAttempted is set after a repair cycle completes without fixing
 	// every corrupt block (i.e. the 32 MB cap was exhausted).  It prevents
 	// unbounded re-fetch loops on persistent disk corruption.  After a
@@ -580,6 +594,61 @@ func (rr *RangeReader) Close() error {
 		rr.onClose()
 	}
 	return err
+}
+
+// WaitForCompletion returns the terminal error of the backing download (if
+// any).  Intended to be called by the serving path *after* the body has
+// finished streaming, so that a post-download verification failure -- e.g.
+// the origin's reported digest disagreeing with the bytes received -- can be
+// surfaced to the client through the X-Transfer-Status trailer rather than
+// being silently masked by an otherwise-successful read of the cached blocks.
+//
+// Behavior depends on what the reader was asked to read:
+//
+//   - Full-object reads block until the download finishes (subject to ctx).
+//     The client is already waiting for the whole body, so the small extra
+//     wait for the post-body digest comparison is acceptable and necessary
+//     to detect verification failures.
+//
+//   - Partial-range reads do NOT block.  The client only asked for a slice
+//     (which may be a few KB of a multi-GB object); the backing download
+//     may still have far more body to fetch.  We only surface an error if
+//     verification has *already* completed -- never make the range response
+//     wait for the rest of the download.
+//
+// Returns nil when there is no backing download, the download completed
+// successfully, ctx is cancelled while waiting, or (in the partial-range
+// case) verification hasn't completed yet.
+func (rr *RangeReader) WaitForCompletion(ctx context.Context) error {
+	if rr == nil || rr.completionDone == nil {
+		return nil
+	}
+	if rr.isFullRead() {
+		select {
+		case <-rr.completionDone:
+			return rr.completionErr()
+		case <-ctx.Done():
+			return nil
+		}
+	}
+	// Partial range: non-blocking peek.
+	select {
+	case <-rr.completionDone:
+		return rr.completionErr()
+	default:
+		return nil
+	}
+}
+
+// isFullRead reports whether this reader's range covers the entire object,
+// which is the condition under which WaitForCompletion may block.  An object
+// with unknown ContentLength (chunked / -1) is conservatively treated as
+// "not full" so we never block indefinitely waiting for a size we don't know.
+func (rr *RangeReader) isFullRead() bool {
+	return rr.meta != nil &&
+		rr.meta.ContentLength > 0 &&
+		rr.start == 0 &&
+		rr.end == rr.meta.ContentLength-1
 }
 
 // Seek implements io.Seeker (limited to within the range)

--- a/local_cache/range_reader_completion_test.go
+++ b/local_cache/range_reader_completion_test.go
@@ -1,0 +1,230 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package local_cache
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin down the blocking policy of RangeReader.WaitForCompletion.
+// The serving path calls it after http.ServeContent so a verification failure
+// detected only after the body finishes (e.g. an origin/local checksum
+// mismatch) can be surfaced via the X-Transfer-Status trailer.
+//
+// The critical invariant: a partial range read must NEVER block on the
+// completion of the backing download.  A 1 KB range of a multi-GB object
+// cannot wait for the remaining gigabytes to finish downloading just to learn
+// that the trailer should say "200: OK".
+
+// TestRangeReader_WaitForCompletion_PartialRangeDoesNotBlock is the regression
+// test for a bug that was almost introduced: simulate an origin whose backing
+// download never finishes (the completion channel is never closed, modelling
+// an origin that hangs before the last byte), then call WaitForCompletion on
+// a reader that asked for a tiny slice.  It must return ~immediately.
+func TestRangeReader_WaitForCompletion_PartialRangeDoesNotBlock(t *testing.T) {
+	// Never-closing channel simulates a backing full-object download that
+	// never completes -- exactly the "origin that never sends the last
+	// byte" scenario.
+	neverDone := make(chan struct{})
+
+	rr := &RangeReader{
+		meta:           &CacheMetadata{ContentLength: 1_000_000_000}, // 1 GB object
+		start:          1024,
+		end:            2047, // 1 KB slice; not a full read
+		completionDone: neverDone,
+		completionErr:  func() error { return errors.New("should never be observed") },
+	}
+
+	// A generous bound -- the call must return essentially instantly.  If
+	// the policy is wrong (e.g. always-block), the test would hang here and
+	// the wrapping go-test timeout would fire, but we want a clear failure.
+	done := make(chan error, 1)
+	go func() {
+		done <- rr.WaitForCompletion(context.Background())
+	}()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err,
+			"partial range read must not surface a completion error before "+
+				"the download has finished (verification hasn't run yet)")
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForCompletion blocked on a partial-range read while " +
+			"the backing download was incomplete -- a 1 KB range of a multi-GB " +
+			"object must never wait for the rest of the download")
+	}
+}
+
+// TestRangeReader_WaitForCompletion_PartialRangeSurfacesCompletedError verifies
+// the other half of the policy: when verification has *already* completed
+// before WaitForCompletion is called (e.g. the range request happened to come
+// in just after the backing download finished), the partial read should still
+// surface the error -- it just won't wait for it.
+func TestRangeReader_WaitForCompletion_PartialRangeSurfacesCompletedError(t *testing.T) {
+	done := make(chan struct{})
+	close(done) // download already done at the time of the call
+	wantErr := errors.New("origin/local checksum mismatch")
+
+	rr := &RangeReader{
+		meta:           &CacheMetadata{ContentLength: 1_000_000_000},
+		start:          1024,
+		end:            2047,
+		completionDone: done,
+		completionErr:  func() error { return wantErr },
+	}
+
+	assert.ErrorIs(t, rr.WaitForCompletion(context.Background()), wantErr,
+		"partial range read should surface an error that has already been "+
+			"recorded by the backing download")
+}
+
+// TestRangeReader_WaitForCompletion_FullReadBlocksAndReportsError verifies
+// the active case: a full-object read DOES block on completion (so the
+// verification error can be reported in the trailer), and returns the error
+// once the download closes the completion channel.
+func TestRangeReader_WaitForCompletion_FullReadBlocksAndReportsError(t *testing.T) {
+	done := make(chan struct{})
+	const size = 16384
+	var observed error
+	rr := &RangeReader{
+		meta:           &CacheMetadata{ContentLength: size},
+		start:          0,
+		end:            size - 1, // full read
+		completionDone: done,
+		completionErr:  func() error { return errors.New("checksum mismatch") },
+	}
+
+	finished := make(chan struct{})
+	go func() {
+		observed = rr.WaitForCompletion(context.Background())
+		close(finished)
+	}()
+
+	// Should still be blocked because the download hasn't completed.
+	select {
+	case <-finished:
+		t.Fatal("full-read WaitForCompletion returned before the backing download finished")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Closing the completion channel must unblock the waiter and surface
+	// the error.
+	close(done)
+	select {
+	case <-finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("full-read WaitForCompletion did not unblock after the download completed")
+	}
+	require.Error(t, observed)
+	assert.Contains(t, observed.Error(), "checksum mismatch")
+}
+
+// TestRangeReader_WaitForCompletion_FullReadHonorsContextCancel verifies that
+// the full-read wait respects the caller's context so a client disconnect or
+// server shutdown doesn't strand the response on a hung backing download.
+// Cancellation returns nil -- we don't fabricate a "500" trailer just because
+// the client gave up waiting.
+func TestRangeReader_WaitForCompletion_FullReadHonorsContextCancel(t *testing.T) {
+	const size = 16384
+	rr := &RangeReader{
+		meta:           &CacheMetadata{ContentLength: size},
+		start:          0,
+		end:            size - 1,
+		completionDone: make(chan struct{}), // never closed
+		completionErr:  func() error { return errors.New("should not be reported on ctx cancel") },
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- rr.WaitForCompletion(ctx)
+	}()
+
+	// Confirm it's actually blocked before cancellation.
+	select {
+	case <-done:
+		t.Fatal("full-read WaitForCompletion returned before context cancel")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.NoError(t, err,
+			"context cancel should return nil, not a synthesised error")
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForCompletion did not respect context cancellation")
+	}
+}
+
+// TestRangeReader_WaitForCompletion_NoBackingDownload covers the cache-hit
+// path: a reader with no completion channel (no in-flight download) must
+// return nil immediately and not panic.
+func TestRangeReader_WaitForCompletion_NoBackingDownload(t *testing.T) {
+	rr := &RangeReader{
+		meta:  &CacheMetadata{ContentLength: 16384},
+		start: 0,
+		end:   16383,
+		// completionDone / completionErr deliberately unset
+	}
+	assert.NoError(t, rr.WaitForCompletion(context.Background()))
+}
+
+// TestRangeReader_WaitForCompletion_NilReceiverIsSafe is a defensive
+// check; callers shouldn't pass nil but it's cheap to guard.
+func TestRangeReader_WaitForCompletion_NilReceiverIsSafe(t *testing.T) {
+	var rr *RangeReader
+	assert.NoError(t, rr.WaitForCompletion(context.Background()))
+}
+
+// TestRangeReader_isFullRead pins down which ranges count as "full" for the
+// blocking-policy decision.
+func TestRangeReader_isFullRead(t *testing.T) {
+	cases := []struct {
+		name           string
+		contentLength  int64
+		start, end     int64
+		expectFullRead bool
+	}{
+		{"full range of known size", 1000, 0, 999, true},
+		{"start past zero", 1000, 1, 999, false},
+		{"end before final byte", 1000, 0, 998, false},
+		{"single-byte range from start", 1000, 0, 0, false},
+		// Unknown size (chunked) is conservatively NOT a full read so the
+		// waiter never blocks indefinitely on a length it doesn't know.
+		{"unknown content length", -1, 0, 999, false},
+		{"zero content length", 0, 0, -1, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := &RangeReader{
+				meta:  &CacheMetadata{ContentLength: tc.contentLength},
+				start: tc.start,
+				end:   tc.end,
+			}
+			assert.Equal(t, tc.expectFullRead, rr.isFullRead())
+		})
+	}
+}

--- a/origin_serve/etag_test.go
+++ b/origin_serve/etag_test.go
@@ -1,0 +1,259 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package origin_serve
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/webdav"
+)
+
+// statHelper stats a file directly (not through os.Root) so that the resulting
+// FileInfo.Sys() carries a *syscall.Stat_t (FileInode succeeds on unix).
+func statHelper(t *testing.T, path string) os.FileInfo {
+	t.Helper()
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	return info
+}
+
+// TestComputeETag_Format checks the opaque, fixed-width layout: a quoted
+// 16-char lowercase hex string (the first 8 bytes of a SHA-256 digest).
+func TestComputeETag_Format(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "f.txt")
+	require.NoError(t, os.WriteFile(path, []byte("hello"), 0o644))
+
+	etag := computeETag(statHelper(t, path))
+
+	require.True(t, strings.HasPrefix(etag, `"`), "ETag should be quoted")
+	require.True(t, strings.HasSuffix(etag, `"`), "ETag should be quoted")
+	inner := strings.Trim(etag, `"`)
+	require.Equal(t, 16, len(inner),
+		"opaque ETag should be 16 hex chars (8 bytes of SHA-256); got %q", etag)
+	for _, r := range inner {
+		require.True(t,
+			(r >= '0' && r <= '9') || (r >= 'a' && r <= 'f'),
+			"ETag body must be lowercase hex: %q", etag)
+	}
+}
+
+// TestComputeETag_DistinguishesFilesWithSameSizeAndMTime is the bug the
+// developer reported: two files with the same size and mtime previously
+// collapsed to identical ETags. Including the inode fixes that.
+func TestComputeETag_DistinguishesFilesWithSameSizeAndMTime(t *testing.T) {
+	tmpDir := t.TempDir()
+	a := filepath.Join(tmpDir, "a.txt")
+	b := filepath.Join(tmpDir, "b.txt")
+
+	// Same byte length, deliberately different content.
+	require.NoError(t, os.WriteFile(a, []byte("AAAAA"), 0o644))
+	require.NoError(t, os.WriteFile(b, []byte("BBBBB"), 0o644))
+
+	// Force identical modification timestamps so size+mtime alone cannot
+	// distinguish them. We pick a wall-clock time in the past so that we know
+	// the value persists exactly across both files.
+	fixed := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	require.NoError(t, os.Chtimes(a, fixed, fixed))
+	require.NoError(t, os.Chtimes(b, fixed, fixed))
+
+	infoA := statHelper(t, a)
+	infoB := statHelper(t, b)
+	require.Equal(t, infoA.Size(), infoB.Size(), "test setup: sizes must match")
+	require.Equal(t, infoA.ModTime().UnixNano(), infoB.ModTime().UnixNano(),
+		"test setup: mtimes must match")
+
+	etagA := computeETag(infoA)
+	etagB := computeETag(infoB)
+	assert.NotEqual(t, etagA, etagB,
+		"two files with the same size+mtime must still have distinct ETags (got %q for both)", etagA)
+}
+
+// TestComputeETag_ChangesOnRewrite verifies that rewriting an existing file
+// (which preserves the inode but updates mtime) produces a new ETag.
+func TestComputeETag_ChangesOnRewrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "f.txt")
+	require.NoError(t, os.WriteFile(path, []byte("v1"), 0o644))
+	etag1 := computeETag(statHelper(t, path))
+
+	// Wait long enough that even coarsely-tracked filesystems update mtime.
+	time.Sleep(15 * time.Millisecond)
+	require.NoError(t, os.WriteFile(path, []byte("v22"), 0o644))
+	etag2 := computeETag(statHelper(t, path))
+
+	assert.NotEqual(t, etag1, etag2,
+		"rewriting a file should change its ETag (mtime/size differ)")
+}
+
+// TestComputeETag_StableForSameFile verifies that two stats of the same file
+// produce identical ETags (no entropy / time-of-call dependency).
+func TestComputeETag_StableForSameFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "f.txt")
+	require.NoError(t, os.WriteFile(path, []byte("payload"), 0o644))
+
+	first := computeETag(statHelper(t, path))
+	time.Sleep(5 * time.Millisecond)
+	second := computeETag(statHelper(t, path))
+	assert.Equal(t, first, second, "ETag for an unmodified file must be stable")
+}
+
+// TestComputeETag_FallbackWhenNoInode covers the Windows / synthesized-FileInfo
+// path by passing an afero in-memory FileInfo, whose Sys() does not return a
+// *syscall.Stat_t. The output shape is still a quoted 16-char opaque tag --
+// the inode simply isn't mixed into the hash.
+func TestComputeETag_FallbackWhenNoInode(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/x.txt", []byte("data"), 0o644))
+	info, err := fs.Stat("/x.txt")
+	require.NoError(t, err)
+
+	etag := computeETag(info)
+	require.True(t, strings.HasPrefix(etag, `"`) && strings.HasSuffix(etag, `"`),
+		"ETag should be quoted: %q", etag)
+	inner := strings.Trim(etag, `"`)
+	assert.Equal(t, 16, len(inner),
+		"opaque ETag should be 16 hex chars even without an inode: %q", etag)
+}
+
+// --- End-to-end checks through the GET/PUT handlers -------------------------
+
+// newTestGetServer wires up a minimal handler chain that mimics how RegisterHandlers
+// dispatches GET requests, without bringing up a full federation. The Gin router
+// strips the /test prefix; the WebDAV handler serves files from storageDir.
+func newTestGetServer(t *testing.T, storageDir string) *httptest.Server {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	wd := &webdav.Handler{
+		FileSystem: webdav.Dir(storageDir),
+		LockSystem: webdav.NewMemLS(),
+		Prefix:     "/test",
+	}
+	r.GET("/test/*path", func(c *gin.Context) {
+		handleGetWithETag(c, wd, c.Request, c.Param("path"), storageDir)
+	})
+	return httptest.NewServer(r)
+}
+
+func doGet(t *testing.T, url string, headers map[string]string) (*http.Response, []byte) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	require.NoError(t, err)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	return resp, body
+}
+
+// TestGetETag_DistinctForSameSizeAndMTime is the HTTP-level analogue of
+// TestComputeETag_DistinguishesFilesWithSameSizeAndMTime.
+func TestGetETag_DistinctForSameSizeAndMTime(t *testing.T) {
+	storage := t.TempDir()
+	a := filepath.Join(storage, "a.bin")
+	b := filepath.Join(storage, "b.bin")
+	require.NoError(t, os.WriteFile(a, []byte("AAAAA"), 0o644))
+	require.NoError(t, os.WriteFile(b, []byte("BBBBB"), 0o644))
+
+	fixed := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	require.NoError(t, os.Chtimes(a, fixed, fixed))
+	require.NoError(t, os.Chtimes(b, fixed, fixed))
+
+	srv := newTestGetServer(t, storage)
+	defer srv.Close()
+
+	respA, _ := doGet(t, srv.URL+"/test/a.bin", nil)
+	require.Equal(t, http.StatusOK, respA.StatusCode)
+	etagA := respA.Header.Get("ETag")
+	require.NotEmpty(t, etagA, "GET should expose ETag")
+
+	respB, _ := doGet(t, srv.URL+"/test/b.bin", nil)
+	require.Equal(t, http.StatusOK, respB.StatusCode)
+	etagB := respB.Header.Get("ETag")
+	require.NotEmpty(t, etagB)
+
+	assert.NotEqual(t, etagA, etagB,
+		"two files with the same size+mtime served over HTTP must have distinct ETags")
+}
+
+// TestGetIfNoneMatch_NewFormat verifies the conditional-request path still
+// produces a 304 after the format change.
+func TestGetIfNoneMatch_NewFormat(t *testing.T) {
+	storage := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(storage, "f.txt"), []byte("hi"), 0o644))
+
+	srv := newTestGetServer(t, storage)
+	defer srv.Close()
+
+	resp, _ := doGet(t, srv.URL+"/test/f.txt", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	etag := resp.Header.Get("ETag")
+	require.NotEmpty(t, etag)
+
+	resp2, body := doGet(t, srv.URL+"/test/f.txt", map[string]string{"If-None-Match": etag})
+	assert.Equal(t, http.StatusNotModified, resp2.StatusCode,
+		"matching If-None-Match should return 304 (body=%q, etag=%q)", string(body), etag)
+}
+
+// TestGetETag_ChangesAfterRewrite is the HTTP-level analogue of
+// TestComputeETag_ChangesOnRewrite.
+func TestGetETag_ChangesAfterRewrite(t *testing.T) {
+	storage := t.TempDir()
+	path := filepath.Join(storage, "f.txt")
+	require.NoError(t, os.WriteFile(path, []byte("v1"), 0o644))
+
+	srv := newTestGetServer(t, storage)
+	defer srv.Close()
+
+	resp, _ := doGet(t, srv.URL+"/test/f.txt", nil)
+	etag1 := resp.Header.Get("ETag")
+	require.NotEmpty(t, etag1)
+
+	time.Sleep(15 * time.Millisecond)
+	require.NoError(t, os.WriteFile(path, []byte("v2 longer"), 0o644))
+
+	resp2, _ := doGet(t, srv.URL+"/test/f.txt", nil)
+	etag2 := resp2.Header.Get("ETag")
+	require.NotEmpty(t, etag2)
+
+	assert.NotEqual(t, etag1, etag2)
+	// And the previously-issued ETag should no longer satisfy If-None-Match.
+	resp3, _ := doGet(t, srv.URL+"/test/f.txt", map[string]string{"If-None-Match": etag1})
+	assert.Equal(t, http.StatusOK, resp3.StatusCode,
+		"stale ETag must not yield 304 after rewrite")
+}

--- a/origin_serve/handlers.go
+++ b/origin_serve/handlers.go
@@ -20,6 +20,8 @@ package origin_serve
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
 	"html"
 	"io"
@@ -756,11 +758,18 @@ func RegisterHandlers(engine *gin.Engine, directorEnabled bool) error {
 
 // handleHeadWithChecksum handles HEAD requests and adds checksum headers per RFC 3230
 func handleHeadWithChecksum(c *gin.Context, handler *webdav.Handler, req *http.Request, relativePath string, backend server_utils.OriginBackend) {
-	// Check if client requested checksums via Want-Digest header
+	// Check if client requested checksums via Want-Digest header. When the
+	// client does not specify, fall back to the first algorithm in
+	// Origin.DefaultChecksumTypes -- which itself defaults to CRC32C, matching
+	// the Pelican client's preferred algorithm. The previous behavior (always
+	// MD5) forced an extra hash pass on the server and caused HEAD responses
+	// to ignore the operator's DefaultChecksumTypes setting.
 	wantDigest := c.GetHeader("Want-Digest")
 	if wantDigest == "" {
-		// Default to MD5 if not specified
-		wantDigest = "md5"
+		wantDigest = string(ChecksumTypeCRC32C)
+		if cfg := param.Origin_DefaultChecksumTypes.GetStringSlice(); len(cfg) > 0 {
+			wantDigest = cfg[0]
+		}
 	}
 
 	// Ask the backend for digest values.  Backends that do not support
@@ -778,10 +787,43 @@ func handleHeadWithChecksum(c *gin.Context, handler *webdav.Handler, req *http.R
 	handler.ServeHTTP(c.Writer, req)
 }
 
-// computeETag generates an ETag string based on file metadata (mtime and size).
-// This matches the default ETag format used by golang.org/x/net/webdav.
-func computeETag(modTime int64, size int64) string {
-	return fmt.Sprintf(`"%x%x"`, modTime, size)
+// computeETag generates an opaque, quoted ETag string that uniquely identifies
+// a specific instance of a file on disk.
+//
+// The ETag is the first 8 bytes of SHA-256 over (dev, inode, size, mtime),
+// rendered as 16 hex characters. The (dev, inode) pair is a VFS-level file
+// identifier: inodes alone are only unique within a single filesystem, so
+// including the device id keeps the ETag distinct when an origin exports
+// multiple volumes (separate disks, bind mounts, etc.) that happen to reuse
+// the same inode number. mtime ensures the ETag changes when a file is
+// rewritten in place. Size is folded in for cheap collision insurance.
+//
+// On platforms that don't expose a stable VFS id (Windows, or synthesized
+// FileInfo values such as afero's in-memory FS), the dev/inode portion is
+// omitted and only (size, mtime) feed the hash. The output width and shape
+// are unchanged in that case.
+//
+// The previous format -- size and mtime concatenated as a single hex blob --
+// matched the golang.org/x/net/webdav default but caused two different files
+// with the same size and mtime (common for empty/freshly-created files on
+// filesystems with second-precision mtime, or batches of fixed-size records)
+// to receive identical ETags. Mixing in the VFS id and running the tuple
+// through a hash fixes that.
+func computeETag(info os.FileInfo) string {
+	h := sha256.New()
+	var buf [8]byte
+	if dev, ino, ok := utils.FileVFSID(info); ok {
+		binary.BigEndian.PutUint64(buf[:], dev)
+		h.Write(buf[:])
+		binary.BigEndian.PutUint64(buf[:], ino)
+		h.Write(buf[:])
+	}
+	binary.BigEndian.PutUint64(buf[:], uint64(info.Size()))
+	h.Write(buf[:])
+	binary.BigEndian.PutUint64(buf[:], uint64(info.ModTime().UnixNano()))
+	h.Write(buf[:])
+	sum := h.Sum(nil)
+	return fmt.Sprintf(`"%x"`, sum[:8])
 }
 
 // handlePutWithETag handles PUT requests and returns the ETag of the newly
@@ -806,7 +848,7 @@ func handlePutWithETag(c *gin.Context, handler *webdav.Handler, req *http.Reques
 				normalizedPath = "."
 			}
 			if info, statErr := root.Stat(normalizedPath); statErr == nil {
-				etag := computeETag(info.ModTime().UnixNano(), info.Size())
+				etag := computeETag(info)
 				dw.Header().Set("ETag", etag)
 			}
 		}
@@ -896,8 +938,11 @@ func handleGetWithETag(c *gin.Context, handler *webdav.Handler, req *http.Reques
 	}
 
 	modTime := info.ModTime()
-	// Compute ETag based on mtime and size (same as WebDAV default)
-	etag := computeETag(modTime.UnixNano(), info.Size())
+	// Compute ETag from inode + size + mtime so that two files with the same
+	// size and modification timestamp (e.g. batches of fixed-size records, or
+	// freshly-created files on a filesystem with second-precision mtime) still
+	// receive distinct ETags.
+	etag := computeETag(info)
 	lastModifiedStr := modTime.UTC().Format(http.TimeFormat)
 
 	// Check for conditional request (If-None-Match) - takes precedence per RFC 7232

--- a/server_structs/origin.go
+++ b/server_structs/origin.go
@@ -38,6 +38,23 @@ var (
 	ErrUnknownOriginStorageType = errors.New("unknown origin storage type")
 )
 
+// IsPosixLike reports whether the storage type is a "POSIX-like" backend whose
+// data lives on a locally-mounted filesystem (as opposed to a remote-protocol
+// backend such as S3, HTTPS, Globus, SSH, or XRoot). POSIX-like backends share
+// behavior in several places: the origin can run its own self-test and the
+// director can probe it; atomic uploads (POSC) work because rename(2) is
+// available; checksum xattrs can be stored on local files; etc. New POSIX-like
+// backends should be added here rather than growing the list of `==` checks
+// scattered across the codebase.
+func (t OriginStorageType) IsPosixLike() bool {
+	switch t {
+	case OriginStoragePosix, OriginStoragePosixv2:
+		return true
+	default:
+		return false
+	}
+}
+
 // Convert a string to an OriginStorageType
 func ParseOriginStorageType(storageType string) (ost OriginStorageType, err error) {
 	switch storageType {

--- a/server_structs/origin_test.go
+++ b/server_structs/origin_test.go
@@ -1,0 +1,54 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package server_structs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestOriginStorageType_IsPosixLike pins down which backends count as
+// "POSIX-like" so a future contributor can't silently flip an entry and have
+// every downstream call site (self-test, director-test, etc.) start treating
+// a remote-protocol backend as local.
+func TestOriginStorageType_IsPosixLike(t *testing.T) {
+	cases := []struct {
+		in       OriginStorageType
+		expected bool
+	}{
+		{OriginStoragePosix, true},
+		{OriginStoragePosixv2, true},
+
+		{OriginStorageSSH, false},
+		{OriginStorageS3, false},
+		{OriginStorageHTTPS, false},
+		{OriginStorageGlobus, false},
+		{OriginStorageXRoot, false},
+
+		// Unknown / unset values must not be treated as POSIX-like.
+		{OriginStorageType(""), false},
+		{OriginStorageType("does-not-exist"), false},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.in), func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.in.IsPosixLike())
+		})
+	}
+}

--- a/utils/fs_unix.go
+++ b/utils/fs_unix.go
@@ -36,6 +36,23 @@ func FileOwnerIDs(info os.FileInfo) (uid, gid int, err error) {
 	return int(stat.Uid), int(stat.Gid), nil
 }
 
+// FileVFSID returns the (device, inode) pair from a FileInfo's underlying
+// syscall.Stat_t, or (0, 0, false) when that's unavailable (e.g. synthesized
+// FileInfo values from afero memory-backed filesystems, or Windows).
+//
+// The (dev, ino) pair uniquely identifies a file on a single host: inodes
+// alone are only unique within a filesystem, so two files on separate volumes
+// (bind mounts, multiple exports on different disks, etc.) can share an
+// inode. Callers that need a stable per-file identifier should combine both
+// fields.
+func FileVFSID(info os.FileInfo) (dev, ino uint64, ok bool) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, 0, false
+	}
+	return uint64(stat.Dev), uint64(stat.Ino), true
+}
+
 // SameFilesystem returns true if both paths reside on the same filesystem
 // (i.e. share the same device ID). This is important because rename(2) cannot
 // move files across filesystem boundaries (returns EXDEV).

--- a/utils/fs_windows.go
+++ b/utils/fs_windows.go
@@ -32,6 +32,14 @@ func FileOwnerIDs(_ os.FileInfo) (uid, gid int, err error) {
 	return 0, 0, errors.New("POSIX file ownership (uid/gid) is not available on Windows")
 }
 
+// FileVFSID is not implemented on Windows. POSIX-like origins are not
+// meaningfully supported on Windows, and FileInfo from os.Stat does not
+// expose a stable per-file identifier in the same form as syscall.Stat_t.
+// Callers should fall back to (size, mtime) when this returns (_, _, false).
+func FileVFSID(_ os.FileInfo) (dev, ino uint64, ok bool) {
+	return 0, 0, false
+}
+
 // SameFilesystem on Windows optimistically returns true. POSIX Origins are not
 // meaningfully supported on Windows, so the cross-filesystem check is skipped.
 func SameFilesystem(_, _ string) (bool, error) {


### PR DESCRIPTION
When Matyas was reviewing the POSIXv2 backend, we saw scary-looking behavior around the ETag and checksums:

1.  The checksums defaulted to MD5 whereas we use crc32c by default elsewhere.
2.  The ETags all looked the same.  This appears because ETag is based only on mtime / size which were the same for all our test files.

This defaults the checksum to crc32c and mixes in the dev / inode into the ETag computation.

Fixes #3476