### PR TITLE
Prevent registry-fetch failure from aborting origin/cache advertisement

### DIFF
--- a/server_utils/sitename.go
+++ b/server_utils/sitename.go
@@ -111,12 +111,14 @@ func GetServerMetadata(ctx context.Context, server server_structs.ServerType) (m
 		metadata, err = getServerMetadataFromReg(ctx, originPrefix)
 		if err != nil {
 			log.Errorf("Failed to get metadata from the registry for the origin. Will fallback to using %s: %v", param.Xrootd_Sitename.GetName(), err)
+			err = nil
 		}
 	} else if server.IsEnabled(server_structs.CacheType) {
 		cachePrefix := server_structs.GetCacheNs(param.Xrootd_Sitename.GetString())
 		metadata, err = getServerMetadataFromReg(ctx, cachePrefix)
 		if err != nil {
 			log.Errorf("Failed to get metadata from the registry for the cache. Will fallback to use %s: %v", param.Xrootd_Sitename.GetName(), err)
+			err = nil
 		}
 	}
 

--- a/server_utils/sitename.go
+++ b/server_utils/sitename.go
@@ -89,7 +89,9 @@ func getServerMetadataFromReg(ctx context.Context, prefix string) (server server
 // under /origins; otherwise, we look it up under /caches.
 func GetServerMetadata(ctx context.Context, server server_structs.ServerType) (metadata server_structs.ServerRegistration, err error) {
 
-	// Fetch server metadata from the registry, if not, fall back server name to Xrootd.Sitename.
+	// Fetch server metadata from the registry. A failed lookup is logged and
+	// swallowedy. After the fetch, a non-empty Xrootd.Sitename takes priority
+	// over the registry-fetched name
 	if server.IsEnabled(server_structs.DirectorType) {
 		exturlStr := param.Server_ExternalWebUrl.GetString()
 		var extUrl *url.URL
@@ -122,18 +124,17 @@ func GetServerMetadata(ctx context.Context, server server_structs.ServerType) (m
 		}
 	}
 
-	if metadata.Name == "" {
-		log.Infof("Server name from the registry is empty, fall back to %s: %s", param.Xrootd_Sitename.GetName(), param.Xrootd_Sitename.GetString())
-		metadata.Name = param.Xrootd_Sitename.GetString()
-	} else {
+	// Prioritize the server name from the local configuration over the registry
+	if param.Xrootd_Sitename.GetString() != "" {
 		// Warn the user if the server name from the registry does not match the local configuration
-		if metadata.Name != param.Xrootd_Sitename.GetString() && param.Xrootd_Sitename.GetString() != "" {
+		if metadata.Name != param.Xrootd_Sitename.GetString() {
 			log.Warningf("Server name mismatch detected:\n"+
 				"  Registered server name: %q\n"+
 				"  Local sitename:      %q\n"+
-				"Pelican will use the registered server name as your server name.\n"+
+				"Pelican will use the local sitename as your server name.\n"+
 				"Contact the federation administrator to update the registered server name or update your local config to maintain consistency.",
 				metadata.Name, param.Xrootd_Sitename.GetString())
+			metadata.Name = param.Xrootd_Sitename.GetString()
 		}
 	}
 	if metadata.Name == "" {

--- a/server_utils/sitename.go
+++ b/server_utils/sitename.go
@@ -90,7 +90,7 @@ func getServerMetadataFromReg(ctx context.Context, prefix string) (server server
 func GetServerMetadata(ctx context.Context, server server_structs.ServerType) (metadata server_structs.ServerRegistration, err error) {
 
 	// Fetch server metadata from the registry. A failed lookup is logged and
-	// swallowedy. After the fetch, a non-empty Xrootd.Sitename takes priority
+	// swallowed. After the fetch, a non-empty Xrootd.Sitename takes priority
 	// over the registry-fetched name
 	if server.IsEnabled(server_structs.DirectorType) {
 		exturlStr := param.Server_ExternalWebUrl.GetString()

--- a/server_utils/sitename_test.go
+++ b/server_utils/sitename_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/pelican_url"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/test_utils"
@@ -83,5 +84,119 @@ func TestGetServerMetadataFromReg(t *testing.T) {
 		server, err := getServerMetadataFromReg(context.Background(), "/foo")
 		require.NoError(t, err)
 		assert.Equal(t, "bar", server.Name)
+	})
+}
+
+// Covers the name-resolution behavior of GetServerMetadata for origin/cache:
+//   - A failed registry lookup must not propagate an error to the caller
+//     (otherwise the advertise cycle in launcher_utils/advertise.go aborts).
+//   - When Xrootd.Sitename is set locally, it takes priority over whatever
+//     the registry returns.
+//   - When Xrootd.Sitename is unset and the registry lookup fails, the
+//     caller must see an error (no name available from any source).
+func TestGetServerMetadataFallbackOnRegistryError(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	t.Cleanup(func() {
+		ResetTestState()
+	})
+
+	// Registry that always responds with 500 so getServerMetadataFromReg
+	// returns an error, exercising the fallback path.
+	failingRegistry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer failingRegistry.Close()
+
+	t.Run("origin-falls-back-to-sitename-without-error", func(t *testing.T) {
+		ResetTestState()
+		config.ResetFederationForTest()
+		config.SetFederation(pelican_url.FederationDiscovery{RegistryEndpoint: failingRegistry.URL})
+		require.NoError(t, param.Server_ExternalWebUrl.Set("https://origin.example.com:8444"))
+		require.NoError(t, param.Xrootd_Sitename.Set("local-origin-name"))
+
+		serverType := server_structs.NewServerType()
+		serverType.Set(server_structs.OriginType)
+		metadata, err := GetServerMetadata(context.Background(), serverType)
+		require.NoError(t, err, "registry failure must not propagate; fallback is expected")
+		assert.Equal(t, "local-origin-name", metadata.Name)
+	})
+
+	t.Run("cache-falls-back-to-sitename-without-error", func(t *testing.T) {
+		ResetTestState()
+		config.ResetFederationForTest()
+		config.SetFederation(pelican_url.FederationDiscovery{RegistryEndpoint: failingRegistry.URL})
+		require.NoError(t, param.Xrootd_Sitename.Set("local-cache-name"))
+
+		serverType := server_structs.NewServerType()
+		serverType.Set(server_structs.CacheType)
+		metadata, err := GetServerMetadata(context.Background(), serverType)
+		require.NoError(t, err, "registry failure must not propagate; fallback is expected")
+		assert.Equal(t, "local-cache-name", metadata.Name)
+	})
+
+	t.Run("origin-local-sitename-overrides-registry-name", func(t *testing.T) {
+		ResetTestState()
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if strings.HasPrefix(req.URL.Path, "/api/v1.0/registry") {
+				ns := server_structs.ServerRegistration{Name: "registered-origin", ID: "testsvrid"}
+				bytes, err := json.Marshal(ns)
+				require.NoError(t, err)
+				_, err = w.Write(bytes)
+				require.NoError(t, err)
+			} else {
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer ts.Close()
+		config.ResetFederationForTest()
+		config.SetFederation(pelican_url.FederationDiscovery{RegistryEndpoint: ts.URL})
+		require.NoError(t, param.Server_ExternalWebUrl.Set("https://origin.example.com:8444"))
+		require.NoError(t, param.Xrootd_Sitename.Set("local-origin-name"))
+
+		serverType := server_structs.NewServerType()
+		serverType.Set(server_structs.OriginType)
+		metadata, err := GetServerMetadata(context.Background(), serverType)
+		require.NoError(t, err)
+		assert.Equal(t, "local-origin-name", metadata.Name,
+			"local Xrootd.Sitename must take precedence over the registry's Name")
+	})
+
+	t.Run("origin-registry-name-used-when-sitename-unset", func(t *testing.T) {
+		ResetTestState()
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if strings.HasPrefix(req.URL.Path, "/api/v1.0/registry") {
+				ns := server_structs.ServerRegistration{Name: "registered-origin", ID: "testsvrid"}
+				bytes, err := json.Marshal(ns)
+				require.NoError(t, err)
+				_, err = w.Write(bytes)
+				require.NoError(t, err)
+			} else {
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer ts.Close()
+		config.ResetFederationForTest()
+		config.SetFederation(pelican_url.FederationDiscovery{RegistryEndpoint: ts.URL})
+		require.NoError(t, param.Server_ExternalWebUrl.Set("https://origin.example.com:8444"))
+
+		serverType := server_structs.NewServerType()
+		serverType.Set(server_structs.OriginType)
+		metadata, err := GetServerMetadata(context.Background(), serverType)
+		require.NoError(t, err)
+		assert.Equal(t, "registered-origin", metadata.Name,
+			"with no local sitename, the registry-supplied Name must be used")
+	})
+
+	t.Run("origin-registry-fails-and-sitename-unset-returns-error", func(t *testing.T) {
+		ResetTestState()
+		config.ResetFederationForTest()
+		config.SetFederation(pelican_url.FederationDiscovery{RegistryEndpoint: failingRegistry.URL})
+		require.NoError(t, param.Server_ExternalWebUrl.Set("https://origin.example.com:8444"))
+
+		serverType := server_structs.NewServerType()
+		serverType.Set(server_structs.OriginType)
+		_, err := GetServerMetadata(context.Background(), serverType)
+		require.Error(t, err, "with no registry name and no sitename, GetServerMetadata must surface an error")
+		assert.Contains(t, err.Error(), param.Xrootd_Sitename.GetName())
 	})
 }


### PR DESCRIPTION
This PR clears the `err` after logging the error message, so the registry-fetch failure no longer propagates up and aborts the advertise cycle.

There is a unresolved discussion in the GitHub issue. Regardless of the outcome, the changes in this PR remain necessary.