### PR TITLE
Ensure safe UI rendering by using unique key

### DIFF
--- a/web_ui/frontend/app/director/components/DirectorCardList.tsx
+++ b/web_ui/frontend/app/director/components/DirectorCardList.tsx
@@ -147,7 +147,7 @@ export function DirectorCardList({ data, cardProps }: DirectorCardListProps) {
         data={filteredData}
         Card={DirectorCard}
         cardProps={cardProps}
-        keyGetter={(o) => o.server.name}
+        keyGetter={(o) => `${o.server.name}:${o.server.url}`}
       />
     </Box>
   );


### PR DESCRIPTION
Closes #2772 

A server from the Topology should not have the same name as another server. Even they do, this PR ensures the UI still get a unique key, which is composed by name and URL, so the UI can be rendered correctly.

Sidenote: The in-memory `serverAds` is keyed on `ad.URL.String()`, so the URL must be unique.

I also communicated this matter in #osdf-ops channel in [OSG slack](https://opensciencegrid.slack.com/archives/C05T5G2RUJ3/p1780071746233819).