### PR TITLE
Fix (some) data races found by `-race`

### DIFF
--- a/client/acquire_token.go
+++ b/client/acquire_token.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -1070,10 +1070,14 @@ func generateToken(destination *url.URL, dirResp server_structs.DirectorResponse
 	}
 	tc.AddResourceScopes(scopes...)
 
-	err = key.Set("kid", keyId)
+	signingKey, err := key.Clone()
 	if err != nil {
 		return
 	}
-	tkn, err = tc.CreateTokenWithKey(key)
+	err = signingKey.Set("kid", keyId)
+	if err != nil {
+		return
+	}
+	tkn, err = tc.CreateTokenWithKey(signingKey)
 	return
 }

--- a/client/pelican_fs_test.go
+++ b/client/pelican_fs_test.go
@@ -793,11 +793,10 @@ func TestPelicanFS_StressTest(t *testing.T) {
 			close(stopChan)
 		}()
 
-		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-
 		for g := 0; g < numGoroutines; g++ {
 			go func(goroutineID int) {
 				defer func() { done <- struct{}{} }()
+				rng := rand.New(rand.NewSource(time.Now().UnixNano() + int64(goroutineID)))
 
 				for {
 					select {

--- a/config/config.go
+++ b/config/config.go
@@ -2276,8 +2276,8 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 	if err := GenerateSessionSecret(); err != nil {
 		return err
 	}
-	// After we know we have the certs we need, call setupTransport (which uses those certs for its TLSConfig)
-	setupTransport()
+	// After we know we have the certs we need, call initTransport (which uses those certs for its TLSConfig)
+	initTransport()
 
 	// Setup CSRF middleware. To use it, you need to add this middleware to your chain
 	// of http handlers by calling config.GetCSRFHandler()
@@ -2432,9 +2432,7 @@ func ResetConfig() {
 	logging.ResetLogFlush()
 
 	// Clear cached transport object
-	onceTransport = sync.Once{}
-	transport = nil
-	basicTransport = nil
+	resetTransport()
 
 	// Clear cached SSRF transport object
 	ResetSSRFTransportForTest()

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,6 @@
 /***************************************************************
 *
-* Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+* Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
 *
 * Licensed under the Apache License, Version 2.0 (the "License"); you
 * may not use this file except in compliance with the License.  You may
@@ -173,6 +173,7 @@ var (
 	// until it's first needed, avoiding a web lookup for invoking configuration
 	// Note the 'once' object is a pointer so we can reset the client multiple
 	// times during unit tests
+	fedDiscoveryMu   sync.Mutex
 	fedDiscoveryOnce *sync.Once
 	globalFedInfo    atomic.Pointer[pelican_url.FederationDiscovery]
 	globalFedErr     error
@@ -219,6 +220,22 @@ var (
 	// Production code should NOT modify this value.
 	sysConfigLocation string = filepath.Join("/etc", "pelican")
 )
+
+func resetFederationDiscoveryState() {
+	fedDiscoveryMu.Lock()
+	defer fedDiscoveryMu.Unlock()
+
+	fedDiscoveryOnce = &sync.Once{}
+}
+
+func clearGlobalFederationState() {
+	fedDiscoveryMu.Lock()
+	defer fedDiscoveryMu.Unlock()
+
+	fedDiscoveryOnce = &sync.Once{}
+	globalFedInfo.Store(&pelican_url.FederationDiscovery{})
+	globalFedErr = nil
+}
 
 func init() {
 	en := en.New()
@@ -611,9 +628,9 @@ func discoverFederationImpl(ctx context.Context) (fedInfo pelican_url.Federation
 }
 
 // Reset the fedDiscoveryOnce to update federation metadata values for GetFederation().
-// Should only used for unit tests
+// Should only be used for unit tests.
 func ResetFederationForTest() {
-	fedDiscoveryOnce = &sync.Once{}
+	resetFederationDiscoveryState()
 }
 
 // Retrieve the federation service information from the configuration.
@@ -623,6 +640,9 @@ func ResetFederationForTest() {
 // If invoked before things are configured, it must be done from a single-threaded
 // context.
 func GetFederation(ctx context.Context) (pelican_url.FederationDiscovery, error) {
+	fedDiscoveryMu.Lock()
+	defer fedDiscoveryMu.Unlock()
+
 	if fedDiscoveryOnce == nil {
 		fedDiscoveryOnce = &sync.Once{}
 	}
@@ -655,6 +675,9 @@ func SetFederation(fd pelican_url.FederationDiscovery) {
 	}); err != nil {
 		log.WithError(err).Warn("Failed to update federation configuration")
 	}
+
+	fedDiscoveryMu.Lock()
+	defer fedDiscoveryMu.Unlock()
 
 	globalFedInfo.Store(&fd)
 	globalFedErr = nil
@@ -2268,7 +2291,7 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 
 	// Sets (or resets) the federation info. Unlike in clients, we do this at startup
 	// instead of deferring it.
-	fedDiscoveryOnce = &sync.Once{}
+	resetFederationDiscoveryState()
 	if _, err := GetFederation(ctx); err != nil {
 		return err
 	}
@@ -2363,7 +2386,7 @@ func InitClient() error {
 	}
 
 	// Set (or reset) the deferred federation lookup
-	fedDiscoveryOnce = &sync.Once{}
+	resetFederationDiscoveryState()
 
 	// Set up the log filter mechanisms, e.g., for sensitive secrets
 	initFilterLogging()
@@ -2423,9 +2446,7 @@ func ResetConfig() {
 	ClearServerAds()
 
 	// Reset federation metadata
-	fedDiscoveryOnce = &sync.Once{}
-	globalFedInfo.Store(&pelican_url.FederationDiscovery{})
-	globalFedErr = nil
+	clearGlobalFederationState()
 
 	warnDeprecatedOnce = sync.Once{}
 	warnDebugOnce = sync.Once{}

--- a/config/config.go
+++ b/config/config.go
@@ -164,13 +164,13 @@ var (
 	preCleanupFuncs map[string]func()
 
 	// Global discovery info.  Using the "once" allows us to delay discovery
-	// until it's first needed, avoiding a web lookup for invoking configuration
-	// Note the 'once' object is a pointer so we can reset the client multiple
-	// times during unit tests
-	fedDiscoveryMu   sync.Mutex
-	fedDiscoveryOnce *sync.Once
-	globalFedInfo    atomic.Pointer[pelican_url.FederationDiscovery]
-	globalFedErr     error
+	// until it's first needed, avoiding a web lookup for invoking configuration.
+	// Both the once and the discovery result are held in atomic pointers so
+	// they can be published, read, and reset without a mutex: swapping in a
+	// fresh sync.Once (during unit tests, or after SetFederation) is a single
+	// atomic store, and readers snapshot the result via a single atomic load.
+	fedDiscoveryOnce atomic.Pointer[sync.Once]
+	globalFedInfo    atomic.Pointer[fedDiscoveryResult]
 
 	// Global struct validator
 	validate *validator.Validate
@@ -215,20 +215,37 @@ var (
 	sysConfigLocation string = filepath.Join("/etc", "pelican")
 )
 
-func resetFederationDiscoveryState() {
-	fedDiscoveryMu.Lock()
-	defer fedDiscoveryMu.Unlock()
+// fedDiscoveryResult bundles the outcome of a federation discovery so that the
+// info and its error are published as a single atomic value.  Readers get a
+// consistent (info, err) pair from one atomic load rather than reading two
+// separate fields that could tear across a concurrent writer.
+type fedDiscoveryResult struct {
+	info pelican_url.FederationDiscovery
+	err  error
+}
 
-	fedDiscoveryOnce = &sync.Once{}
+// loadOrInitFedDiscoveryOnce returns the current discovery sync.Once, creating
+// and publishing a fresh one if none has been set yet.  It is lock-free: the
+// CompareAndSwap guarantees exactly one Once wins even under concurrent first
+// callers.
+func loadOrInitFedDiscoveryOnce() *sync.Once {
+	if once := fedDiscoveryOnce.Load(); once != nil {
+		return once
+	}
+	once := &sync.Once{}
+	if fedDiscoveryOnce.CompareAndSwap(nil, once) {
+		return once
+	}
+	return fedDiscoveryOnce.Load()
+}
+
+func resetFederationDiscoveryState() {
+	fedDiscoveryOnce.Store(&sync.Once{})
 }
 
 func clearGlobalFederationState() {
-	fedDiscoveryMu.Lock()
-	defer fedDiscoveryMu.Unlock()
-
-	fedDiscoveryOnce = &sync.Once{}
-	globalFedInfo.Store(&pelican_url.FederationDiscovery{})
-	globalFedErr = nil
+	fedDiscoveryOnce.Store(&sync.Once{})
+	globalFedInfo.Store(&fedDiscoveryResult{})
 }
 
 func init() {
@@ -634,22 +651,15 @@ func ResetFederationForTest() {
 // If invoked before things are configured, it must be done from a single-threaded
 // context.
 func GetFederation(ctx context.Context) (pelican_url.FederationDiscovery, error) {
-	fedDiscoveryMu.Lock()
-	defer fedDiscoveryMu.Unlock()
-
-	if fedDiscoveryOnce == nil {
-		fedDiscoveryOnce = &sync.Once{}
-	}
-	fedDiscoveryOnce.Do(func() {
-		var fedInfo pelican_url.FederationDiscovery
-		fedInfo, globalFedErr = discoverFederationImpl(ctx)
-		globalFedInfo.Store(&fedInfo)
+	loadOrInitFedDiscoveryOnce().Do(func() {
+		info, err := discoverFederationImpl(ctx)
+		globalFedInfo.Store(&fedDiscoveryResult{info: info, err: err})
 	})
-	loadedInfo := globalFedInfo.Load()
-	if loadedInfo == nil {
-		return pelican_url.FederationDiscovery{}, globalFedErr
+	loaded := globalFedInfo.Load()
+	if loaded == nil {
+		return pelican_url.FederationDiscovery{}, nil
 	}
-	return *loadedInfo, globalFedErr
+	return loaded.info, loaded.err
 }
 
 // Set the current global federation metadata.
@@ -670,18 +680,13 @@ func SetFederation(fd pelican_url.FederationDiscovery) {
 		log.WithError(err).Warn("Failed to update federation configuration")
 	}
 
-	fedDiscoveryMu.Lock()
-	defer fedDiscoveryMu.Unlock()
+	globalFedInfo.Store(&fedDiscoveryResult{info: fd})
 
-	globalFedInfo.Store(&fd)
-	globalFedErr = nil
-
-	// Consume the sync.Once so that subsequent GetFederation calls return the
-	// stored value directly instead of re-running discovery.
-	if fedDiscoveryOnce == nil {
-		fedDiscoveryOnce = &sync.Once{}
-	}
-	fedDiscoveryOnce.Do(func() {})
+	// Publish an already-consumed sync.Once so that subsequent GetFederation
+	// calls return the stored value directly instead of re-running discovery.
+	once := &sync.Once{}
+	once.Do(func() {})
+	fedDiscoveryOnce.Store(once)
 }
 
 // RegisterPreCleanup adds a named callback that will be invoked before
@@ -2445,7 +2450,14 @@ func InitClient() error {
 		log.Debugln("Failed to compute Server.ExternalWebUrl:", err)
 	}
 
-	setupTransport()
+	// Invalidate any cached transports now that the client configuration is
+	// loaded, so the next getter lazily rebuilds them (under transportMu) with
+	// the final config -- including a CA certificate that may still be
+	// configured after InitClient.  resetTransport() takes transportMu, so this
+	// no longer races concurrent transport getters the way the previous direct
+	// setupTransport() call did, and it must not eagerly rebuild here (that
+	// would freeze the transport before late CA configuration is applied).
+	resetTransport()
 
 	// Unmarshal Viper config into a Go struct
 	unmarshalledConfig, err := param.UnmarshalConfig()

--- a/config/config.go
+++ b/config/config.go
@@ -167,6 +167,7 @@ var (
 	// until it's first needed, avoiding a web lookup for invoking configuration
 	// Note the 'once' object is a pointer so we can reset the client multiple
 	// times during unit tests
+	fedDiscoveryMu   sync.Mutex
 	fedDiscoveryOnce *sync.Once
 	globalFedInfo    atomic.Pointer[pelican_url.FederationDiscovery]
 	globalFedErr     error
@@ -213,6 +214,22 @@ var (
 	// Production code should NOT modify this value.
 	sysConfigLocation string = filepath.Join("/etc", "pelican")
 )
+
+func resetFederationDiscoveryState() {
+	fedDiscoveryMu.Lock()
+	defer fedDiscoveryMu.Unlock()
+
+	fedDiscoveryOnce = &sync.Once{}
+}
+
+func clearGlobalFederationState() {
+	fedDiscoveryMu.Lock()
+	defer fedDiscoveryMu.Unlock()
+
+	fedDiscoveryOnce = &sync.Once{}
+	globalFedInfo.Store(&pelican_url.FederationDiscovery{})
+	globalFedErr = nil
+}
 
 func init() {
 	en := en.New()
@@ -605,9 +622,9 @@ func discoverFederationImpl(ctx context.Context) (fedInfo pelican_url.Federation
 }
 
 // Reset the fedDiscoveryOnce to update federation metadata values for GetFederation().
-// Should only used for unit tests
+// Should only be used for unit tests.
 func ResetFederationForTest() {
-	fedDiscoveryOnce = &sync.Once{}
+	resetFederationDiscoveryState()
 }
 
 // Retrieve the federation service information from the configuration.
@@ -617,6 +634,9 @@ func ResetFederationForTest() {
 // If invoked before things are configured, it must be done from a single-threaded
 // context.
 func GetFederation(ctx context.Context) (pelican_url.FederationDiscovery, error) {
+	fedDiscoveryMu.Lock()
+	defer fedDiscoveryMu.Unlock()
+
 	if fedDiscoveryOnce == nil {
 		fedDiscoveryOnce = &sync.Once{}
 	}
@@ -649,6 +669,9 @@ func SetFederation(fd pelican_url.FederationDiscovery) {
 	}); err != nil {
 		log.WithError(err).Warn("Failed to update federation configuration")
 	}
+
+	fedDiscoveryMu.Lock()
+	defer fedDiscoveryMu.Unlock()
 
 	globalFedInfo.Store(&fd)
 	globalFedErr = nil
@@ -2342,7 +2365,7 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 
 	// Sets (or resets) the federation info. Unlike in clients, we do this at startup
 	// instead of deferring it.
-	fedDiscoveryOnce = &sync.Once{}
+	resetFederationDiscoveryState()
 	if _, err := GetFederation(ctx); err != nil {
 		return err
 	}
@@ -2431,7 +2454,7 @@ func InitClient() error {
 	}
 
 	// Set (or reset) the deferred federation lookup
-	fedDiscoveryOnce = &sync.Once{}
+	resetFederationDiscoveryState()
 
 	// Set up the log filter mechanisms, e.g., for sensitive secrets
 	initFilterLogging()
@@ -2491,9 +2514,7 @@ func ResetConfig() {
 	ClearServerAds()
 
 	// Reset federation metadata
-	fedDiscoveryOnce = &sync.Once{}
-	globalFedInfo.Store(&pelican_url.FederationDiscovery{})
-	globalFedErr = nil
+	clearGlobalFederationState()
 
 	warnDeprecatedOnce = sync.Once{}
 	warnDebugOnce = sync.Once{}

--- a/config/config.go
+++ b/config/config.go
@@ -2350,8 +2350,8 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 	if err := GenerateSessionSecret(); err != nil {
 		return err
 	}
-	// After we know we have the certs we need, call setupTransport (which uses those certs for its TLSConfig)
-	setupTransport()
+	// After we know we have the certs we need, call initTransport (which uses those certs for its TLSConfig)
+	initTransport()
 
 	// Setup CSRF middleware. To use it, you need to add this middleware to your chain
 	// of http handlers by calling config.GetCSRFHandler()
@@ -2500,9 +2500,7 @@ func ResetConfig() {
 	logging.ResetLogFlush()
 
 	// Clear cached transport object
-	onceTransport = sync.Once{}
-	transport = nil
-	basicTransport = nil
+	resetTransport()
 
 	// Clear cached SSRF transport object
 	ResetSSRFTransportForTest()

--- a/config/net_config.go
+++ b/config/net_config.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -22,7 +22,6 @@ import (
 	"net"
 	"net/url"
 	"strconv"
-	"sync"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -65,7 +64,7 @@ func UpdateConfigFromListener(ln net.Listener) {
 						log.WithError(err).Warn("Failed to update Federation.BrokerUrl from listener")
 					}
 				}
-				fedDiscoveryOnce = &sync.Once{}
+				ResetFederationForTest()
 				log.Debugln("Random web port used; updated external web URL to", param.Server_ExternalWebUrl.GetString())
 			} else {
 				log.Errorln("Unable to update external web URL for random port; unable to parse existing URL:", serverUrlStr)

--- a/config/net_config.go
+++ b/config/net_config.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -22,7 +22,6 @@ import (
 	"net"
 	"net/url"
 	"strconv"
-	"sync"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -76,7 +75,7 @@ func UpdateConfigFromListener(ln net.Listener) {
 						log.WithError(err).Warn("Failed to update Federation.BrokerUrl from listener")
 					}
 				}
-				fedDiscoveryOnce = &sync.Once{}
+				ResetFederationForTest()
 				log.Debugln("Random web port used; updated external web URL to", param.Server_ExternalWebUrl.GetString())
 			} else {
 				log.Errorln("Unable to update external web URL for random port; unable to parse existing URL:", serverUrlStr)

--- a/config/ssrf_transport.go
+++ b/config/ssrf_transport.go
@@ -33,6 +33,12 @@ import (
 var (
 	ssrfTransport     *SSRFTransport
 	onceSSRFTransport sync.Once
+	// ssrfTransportMu guards onceSSRFTransport and ssrfTransport for the same
+	// reason transportMu guards the default transport: sync.Once serializes
+	// callers through Do, but does not protect a concurrent
+	// ResetSSRFTransportForTest from overwriting the Once (or the singleton
+	// pointer) while a getter reads it.
+	ssrfTransportMu sync.Mutex
 )
 
 // SSRFTransport is an http.Transport wrapper that prevents server-side request
@@ -207,17 +213,17 @@ func (t *SSRFTransport) ssrfDialContext(ctx context.Context, network, addr strin
 //
 // The transport is initialised once; subsequent calls return the same instance.
 func GetSSRFTransport() *SSRFTransport {
-	onceSSRFTransport.Do(func() {
-		setupSSRFTransport()
-	})
+	ssrfTransportMu.Lock()
+	defer ssrfTransportMu.Unlock()
+	onceSSRFTransport.Do(setupSSRFTransport)
 	return ssrfTransport
 }
 
 func setupSSRFTransport() {
-	// Ensure the base transport is initialised.
-	onceTransport.Do(func() {
-		setupTransport()
-	})
+	// Ensure the base transport is initialised.  Route through initTransport so
+	// the base onceTransport/transport pointers are touched under transportMu
+	// rather than raced against a concurrent resetTransport.
+	initTransport()
 
 	disabled := param.Server_SSRFProtection_Disabled.GetBool()
 	skipDefaultBlocks := param.Server_SSRFProtection_SkipDefaultBlocks.GetBool()
@@ -254,6 +260,8 @@ func GetSSRFHttpTransport() *http.Transport {
 // ResetSSRFTransportForTest resets the SSRF transport singleton so it can be
 // re-initialised with different config values in tests.
 func ResetSSRFTransportForTest() {
+	ssrfTransportMu.Lock()
+	defer ssrfTransportMu.Unlock()
 	onceSSRFTransport = sync.Once{}
 	ssrfTransport = nil
 }

--- a/config/transport.go
+++ b/config/transport.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -53,6 +53,7 @@ var (
 	clientNoProxy *http.Client
 
 	// Once to ensure we only set up the transport once
+	transportMu   sync.Mutex
 	onceTransport sync.Once
 
 	// Static dialer for the transport
@@ -64,9 +65,7 @@ var (
 // This transport will use the global dialer function set by SetTransportDialer,
 // allowing it to be broker-aware.
 func GetTransport() *http.Transport {
-	onceTransport.Do(func() {
-		setupTransport()
-	})
+	initTransport()
 	return transport
 }
 
@@ -75,25 +74,19 @@ func GetTransport() *http.Transport {
 // This uses the global dialer function set by SetTransportDialer, allowing it
 // to be broker-aware
 func GetClient() *http.Client {
-	onceTransport.Do(func() {
-		setupTransport()
-	})
+	initTransport()
 	return client
 }
 
 // Returns a basic transport object that does not use the broker-aware dialer.
 func GetBasicTransport() *http.Transport {
-	onceTransport.Do(func() {
-		setupTransport()
-	})
+	initTransport()
 	return basicTransport
 }
 
 // Returns a transport object that does not use any HTTP(S) proxy
 func GetTransportNoProxy() *http.Transport {
-	onceTransport.Do(func() {
-		setupTransport()
-	})
+	initTransport()
 	return transportNoProxy
 }
 
@@ -101,9 +94,7 @@ func GetTransportNoProxy() *http.Transport {
 //
 // This allows special handling of redirect headers by the client
 func GetClientNoRedirect() *http.Client {
-	onceTransport.Do(func() {
-		setupTransport()
-	})
+	initTransport()
 	return clientNoRedirect
 }
 
@@ -111,9 +102,7 @@ func GetClientNoRedirect() *http.Client {
 //
 // This allows bypassing of proxies for the GET/PUT in the client methods
 func GetClientNoProxy() *http.Client {
-	onceTransport.Do(func() {
-		setupTransport()
-	})
+	initTransport()
 	return clientNoProxy
 }
 
@@ -121,10 +110,37 @@ func GetClientNoProxy() *http.Client {
 //
 // This uses the golang default dialer and will not use the broker.
 func GetBasicClient() *http.Client {
-	onceTransport.Do(func() {
-		setupTransport()
-	})
+	initTransport()
 	return basicClient
+}
+
+// initTransport runs setupTransport at most once per init cycle, under
+// transportMu. The mutex is necessary because sync.Once serializes
+// concurrent calls *through* it, but does not protect against a concurrent
+// resetTransport overwriting the onceTransport variable itself or the
+// transport pointers.
+func initTransport() {
+	transportMu.Lock()
+	defer transportMu.Unlock()
+	onceTransport.Do(setupTransport)
+}
+
+// resetTransport clears all cached transports and resets the once guard so
+// the next call to initTransport rebuilds them. It must hold transportMu
+// for the same reason initTransport does: a plain write to onceTransport or
+// to the transport pointer variables races with concurrent reads in the
+// getters.
+func resetTransport() {
+	transportMu.Lock()
+	defer transportMu.Unlock()
+	onceTransport = sync.Once{}
+	transport = nil
+	transportNoProxy = nil
+	basicTransport = nil
+	client = nil
+	basicClient = nil
+	clientNoRedirect = nil
+	clientNoProxy = nil
 }
 
 // Override the global transport's dialer function.

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -294,7 +294,11 @@ func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]
 			sAd.IOLoad = existing.Value().GetIOLoad() // we copy the value from the existing serverAD to be consistent
 		}
 
-		populateEWMAStatusWeight(&sAd, &(existing.Value().ServerAd))
+		// Snapshot the existing ad under its lock; populateEWMAStatusWeight only
+		// reads the previous status weight, so a copy is equivalent and avoids
+		// racing a concurrent SetIOLoad on the cached advertisement.
+		existingAd := existing.Value().GetServerAd()
+		populateEWMAStatusWeight(&sAd, &existingAd)
 	} else {
 		// If there is no existing ad, the status weight will be set to the current raw weight
 		populateEWMAStatusWeight(&sAd, nil)

--- a/director/director_advertise.go
+++ b/director/director_advertise.go
@@ -550,7 +550,6 @@ func updateInternalDirectorCache(ctx context.Context, egrp *errgroup.Group, dire
 		return
 	}
 
-	info := &directorInfo{}
 	if directorAd.Name == "" {
 		log.Debugln("Received director ad with empty name, skipping update")
 		return
@@ -565,7 +564,14 @@ func updateInternalDirectorCache(ctx context.Context, egrp *errgroup.Group, dire
 	} else if adTTL <= 0 {
 		return
 	}
+	fwdCtx, cancel := context.WithCancel(ctx)
+	info := &directorInfo{
+		ad:            directorAd,
+		cancel:        cancel,
+		forwardAdChan: make(chan *forwardAdInfo, 5),
+	}
 	if item, found := directorAds.GetOrSet(directorAd.Name, info, ttlcache.WithTTL[string, *directorInfo](adTTL)); found {
+		cancel()
 		if item.Value() != nil {
 			if after := directorAd.After(item.Value().ad); after == server_structs.AdAfterTrue || after == server_structs.AdAfterUnknown {
 				item.Value().ad = directorAd
@@ -584,10 +590,6 @@ func updateInternalDirectorCache(ctx context.Context, egrp *errgroup.Group, dire
 			}
 		}
 	} else {
-		info.ad = directorAd
-		var fwdCtx context.Context
-		fwdCtx, info.cancel = context.WithCancel(ctx)
-		info.forwardAdChan = make(chan *forwardAdInfo, 5)
 		go info.launchForwardAds(fwdCtx, egrp)
 	}
 }

--- a/director/director_advertise.go
+++ b/director/director_advertise.go
@@ -570,7 +570,6 @@ func updateInternalDirectorCache(ctx context.Context, egrp *errgroup.Group, dire
 		return
 	}
 
-	info := &directorInfo{}
 	if directorAd.Name == "" {
 		log.Debugln("Received director ad with empty name, skipping update")
 		return
@@ -585,7 +584,14 @@ func updateInternalDirectorCache(ctx context.Context, egrp *errgroup.Group, dire
 	} else if adTTL <= 0 {
 		return
 	}
+	fwdCtx, cancel := context.WithCancel(ctx)
+	info := &directorInfo{
+		cancel:        cancel,
+		forwardAdChan: make(chan *forwardAdInfo, 5),
+	}
+	info.ad.Store(directorAd)
 	if item, found := directorAds.GetOrSet(directorAd.Name, info, ttlcache.WithTTL[string, *directorInfo](adTTL)); found {
+		cancel()
 		if item.Value() != nil {
 			if after := directorAd.After(item.Value().ad.Load()); after == server_structs.AdAfterTrue || after == server_structs.AdAfterUnknown {
 				item.Value().ad.Store(directorAd)
@@ -606,10 +612,6 @@ func updateInternalDirectorCache(ctx context.Context, egrp *errgroup.Group, dire
 			}
 		}
 	} else {
-		info.ad.Store(directorAd)
-		var fwdCtx context.Context
-		fwdCtx, info.cancel = context.WithCancel(ctx)
-		info.forwardAdChan = make(chan *forwardAdInfo, 5)
 		go info.launchForwardAds(fwdCtx, egrp)
 	}
 }

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -103,7 +103,7 @@ func LaunchTTLCache(ctx context.Context, egrp *errgroup.Group) {
 	go directorAds.Start()
 
 	serverAds.OnEviction(func(ctx context.Context, er ttlcache.EvictionReason, i *ttlcache.Item[string, *server_structs.Advertisement]) {
-		serverAd := i.Value().ServerAd
+		serverAd := i.Value().GetServerAd()
 		serverUrl := i.Key()
 		log.Debugf("serverAds for %s server %s is evicted. Clean up started.", string(serverAd.Type), serverAd.Name)
 

--- a/director/monitor.go
+++ b/director/monitor.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -181,7 +181,7 @@ func LaunchPeriodicDirectorTest(ctx context.Context, serverUrlStr string) {
 			log.Infof("The Director doesn't have any advertisements for server with URL %s. Stopping director tests.", serverUrlStr)
 			return false
 		}
-		currentServerAd := adItem.Value().ServerAd
+		currentServerAd := adItem.Value().GetServerAd()
 
 		// Check if the server is in downtime by checking the filteredServers map
 		if isServerInDowntime(currentServerAd.Name) {

--- a/director/monitor.go
+++ b/director/monitor.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -176,7 +176,7 @@ func LaunchPeriodicDirectorTest(ctx context.Context, serverUrlStr string) {
 			log.Infof("The Director doesn't have any advertisements for server with URL %s. Stopping director tests.", serverUrlStr)
 			return false
 		}
-		currentServerAd := adItem.Value().ServerAd
+		currentServerAd := adItem.Value().GetServerAd()
 
 		// Check if the server is in downtime by checking the filteredServers map
 		if isServerInDowntime(currentServerAd.Name) {

--- a/director/sort.go
+++ b/director/sort.go
@@ -1,6 +1,6 @@
 /***************************************************************
 *
-* Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+* Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
 *
 * Licensed under the Apache License, Version 2.0 (the "License"); you
 * may not use this file except in compliance with the License.  You may

--- a/director/stat.go
+++ b/director/stat.go
@@ -1,6 +1,6 @@
 /***************************************************************
 *
-* Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+* Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
 *
 * Licensed under the Apache License, Version 2.0 (the "License"); you
 * may not use this file except in compliance with the License.  You may
@@ -337,6 +337,7 @@ func (stat *ObjectStat) queryServersForObject(ctx context.Context, objectName st
 	for _, option := range options {
 		option(&cfg)
 	}
+	reqHandler := stat.ReqHandler
 
 	ads := []server_structs.ServerAd{}
 
@@ -429,7 +430,7 @@ func (stat *ObjectStat) queryServersForObject(ctx context.Context, objectName st
 				metrics.PelicanDirectorStatActive.With(activeLabels).Inc()
 				defer metrics.PelicanDirectorStatActive.With(activeLabels).Dec()
 
-				metadata, err = stat.ReqHandler(maxCancelCtx, objectName, baseUrl, true, cfg.token, timeout)
+				metadata, err = reqHandler(maxCancelCtx, objectName, baseUrl, true, cfg.token, timeout)
 
 				var reqNotFound *headReqNotFoundErr
 				cancelErr := &headReqCancelledErr{}
@@ -437,7 +438,7 @@ func (stat *ObjectStat) queryServersForObject(ctx context.Context, objectName st
 					// If the request returns 403 or 500, it could be because we request a digest and xrootd
 					// does not have this turned on, or had trouble calculating the checksum
 					// Retry without digest
-					metadata, err = stat.ReqHandler(maxCancelCtx, objectName, baseUrl, false, cfg.token, timeout)
+					metadata, err = reqHandler(maxCancelCtx, objectName, baseUrl, false, cfg.token, timeout)
 				}
 
 				// If get a 404, record it in the cache.

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -329,17 +329,18 @@ func LaunchModules(ctx context.Context, modules server_structs.ServerType) (serv
 				defer wg.Done()
 				// Probably no need to incur another err check since we already checked the director URL.
 				urlToCheck, _ := url.Parse(directorUrl.String())
-				urlToCheck.Path, err = url.JoinPath("/api/v1.0/director/origin", prefix)
+				path, localErr := url.JoinPath("/api/v1.0/director/origin", prefix)
 				// Skip stat check. Otherwise it will return 404
 				query := urlToCheck.Query()
 				query.Add("skipstat", "")
 				urlToCheck.RawQuery = query.Encode()
-				if err != nil {
-					errCh <- errors.Wrapf(err, "Failed to join path %s for origin advertisement check", prefix)
+				if localErr != nil {
+					errCh <- errors.Wrapf(localErr, "Failed to join path %s for origin advertisement check", prefix)
 					return
 				}
-				if err = server_utils.WaitUntilWorking(ctx, "GET", urlToCheck.String(), "director", 307, false); err != nil {
-					errCh <- errors.Wrapf(err, "The prefix %s does not seem to have advertised correctly", prefix)
+				urlToCheck.Path = path
+				if localErr = server_utils.WaitUntilWorking(ctx, "GET", urlToCheck.String(), "director", 307, false); localErr != nil {
+					errCh <- errors.Wrapf(localErr, "The prefix %s does not seem to have advertised correctly", prefix)
 				}
 
 			}(export.FederationPrefix)

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -337,17 +337,18 @@ func LaunchModules(ctx context.Context, modules server_structs.ServerType) (serv
 				defer wg.Done()
 				// Probably no need to incur another err check since we already checked the director URL.
 				urlToCheck, _ := url.Parse(directorUrl.String())
-				urlToCheck.Path, err = url.JoinPath("/api/v1.0/director/origin", prefix)
+				path, localErr := url.JoinPath("/api/v1.0/director/origin", prefix)
 				// Skip stat check. Otherwise it will return 404
 				query := urlToCheck.Query()
 				query.Add("skipstat", "")
 				urlToCheck.RawQuery = query.Encode()
-				if err != nil {
-					errCh <- errors.Wrapf(err, "Failed to join path %s for origin advertisement check", prefix)
+				if localErr != nil {
+					errCh <- errors.Wrapf(localErr, "Failed to join path %s for origin advertisement check", prefix)
 					return
 				}
-				if err = server_utils.WaitUntilWorking(ctx, "GET", urlToCheck.String(), "director", 307, false); err != nil {
-					errCh <- errors.Wrapf(err, "The prefix %s does not seem to have advertised correctly", prefix)
+				urlToCheck.Path = path
+				if localErr = server_utils.WaitUntilWorking(ctx, "GET", urlToCheck.String(), "director", 307, false); localErr != nil {
+					errCh <- errors.Wrapf(localErr, "The prefix %s does not seem to have advertised correctly", prefix)
 				}
 
 			}(export.FederationPrefix)

--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -990,7 +990,9 @@ var (
 		Help: "Statistics about connection calls.",
 	}, []string{"type"})
 
+	lastStatsMu      sync.Mutex
 	lastStats        SummaryStat
+	lastOssStatsMu   sync.Mutex
 	lastOssStats     OSSStatsGs
 	lastS3CacheStats OssS3CacheGs
 	lastXrdCurlStats struct {
@@ -1902,6 +1904,8 @@ func HandleSummaryPacket(packet []byte) error {
 		// We only care about the xrootd summary packets
 		return nil
 	}
+	lastStatsMu.Lock()
+	defer lastStatsMu.Unlock()
 	for _, stat := range summaryStats.Stats {
 		switch stat.Id {
 
@@ -2212,6 +2216,8 @@ func handleOSSStats(blobs [][]byte) error {
 	}
 	// we need to process the blobs backwards to ensure that we are processing the last valid event
 	// the most relevant data is the last valid event in the sequence of blobs
+	lastOssStatsMu.Lock()
+	defer lastOssStatsMu.Unlock()
 	for i := len(blobs) - 1; i >= 0; i-- {
 		blob := blobs[i]
 		ossStats := OSSStatsGs{}
@@ -2306,7 +2312,6 @@ func handleOSSStats(blobs [][]byte) error {
 		// Found and processed the last valid event, so we are done
 		break
 	}
-
 	return nil
 }
 

--- a/metrics/xrootd_metrics.go
+++ b/metrics/xrootd_metrics.go
@@ -990,12 +990,13 @@ var (
 		Help: "Statistics about connection calls.",
 	}, []string{"type"})
 
-	lastStatsMu      sync.Mutex
-	lastStats        SummaryStat
-	lastOssStatsMu   sync.Mutex
-	lastOssStats     OSSStatsGs
-	lastS3CacheStats OssS3CacheGs
-	lastXrdCurlStats struct {
+	lastStatsMu        sync.Mutex
+	lastStats          SummaryStat
+	lastOssStatsMu     sync.Mutex
+	lastOssStats       OSSStatsGs
+	lastS3CacheStatsMu sync.Mutex
+	lastS3CacheStats   OssS3CacheGs
+	lastXrdCurlStats   struct {
 		File    XrdCurlFileStats
 		Queues  XrdCurlQueueStats
 		Workers map[string]float64
@@ -2086,6 +2087,10 @@ func handleS3CacheStats(blobs [][]byte) error {
 
 	// we need to process the blobs backwards to ensure that we are processing the last valid event
 	// the most relevant data is the last valid event in the sequence of blobs
+	// lastS3CacheStats has the same concurrent exposure as lastOssStats (both are
+	// reached through handleOSSPacket), so guard it the same way.
+	lastS3CacheStatsMu.Lock()
+	defer lastS3CacheStatsMu.Unlock()
 	for i := len(blobs) - 1; i >= 0; i-- {
 		blob := blobs[i]
 		s3fileStats := OssS3CacheGs{}

--- a/oauth2/issuer/admin_handlers.go
+++ b/oauth2/issuer/admin_handlers.go
@@ -92,7 +92,7 @@ var allowedGrantTypes = map[string]bool{
 //	@Router       /issuer/admin/clients [get]
 func handleAdminListClients(provider *OIDCProvider) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		clients, err := provider.Storage().ListClients(ctx)
+		clients, err := provider.Storage().ListClients(requestBoundContext(ctx))
 		if err != nil {
 			log.WithError(err).Warn("Embedded issuer admin: failed to list clients")
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "server_error", "error_description": "Failed to list clients"})
@@ -116,7 +116,7 @@ func handleAdminListClients(provider *OIDCProvider) gin.HandlerFunc {
 func handleAdminGetClient(provider *OIDCProvider) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		clientID := ctx.Param("id")
-		detail, err := provider.Storage().GetClientDetail(ctx, clientID)
+		detail, err := provider.Storage().GetClientDetail(requestBoundContext(ctx), clientID)
 		if err != nil {
 			if err == fosite.ErrNotFound {
 				ctx.JSON(http.StatusNotFound, gin.H{"error": "not_found", "error_description": "Client not found"})
@@ -214,7 +214,7 @@ func handleAdminCreateClient(provider *OIDCProvider) gin.HandlerFunc {
 			Public:        req.Public,
 		}
 
-		if err := provider.Storage().CreateClient(ctx, client); err != nil {
+		if err := provider.Storage().CreateClient(requestBoundContext(ctx), client); err != nil {
 			log.WithError(err).Warn("Embedded issuer admin: failed to create client")
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "server_error", "error_description": "Failed to create client"})
 			return
@@ -252,7 +252,7 @@ func handleAdminDeleteClient(provider *OIDCProvider) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		clientID := ctx.Param("id")
 
-		deleted, err := provider.Storage().DeleteClient(ctx, clientID)
+		deleted, err := provider.Storage().DeleteClient(requestBoundContext(ctx), clientID)
 		if err != nil {
 			log.WithError(err).Warn("Embedded issuer admin: failed to delete client")
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "server_error", "error_description": "Failed to delete client"})
@@ -325,7 +325,7 @@ func handleAdminUpdateClient(provider *OIDCProvider) gin.HandlerFunc {
 			Scopes:        req.Scopes,
 		}
 
-		updated, err := provider.Storage().UpdateClient(ctx, clientID, update)
+		updated, err := provider.Storage().UpdateClient(requestBoundContext(ctx), clientID, update)
 		if err != nil {
 			if err == fosite.ErrNotFound {
 				ctx.JSON(http.StatusNotFound, gin.H{"error": "not_found", "error_description": "Client not found"})

--- a/oauth2/issuer/handlers.go
+++ b/oauth2/issuer/handlers.go
@@ -19,6 +19,7 @@
 package issuer
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -48,6 +49,16 @@ const (
 	// maxClientNameLen is the maximum length (in bytes) of a client_name.
 	maxClientNameLen = 128
 )
+
+// requestBoundContext returns the net/http request context from a Gin
+// handler. *gin.Context implements context.Context but is mutable request
+// state that Gin modifies throughout the request lifecycle; passing it
+// where a context.Context is needed exposes that mutable state to callers
+// that may hold it concurrently. ctx.Request.Context() is the safe,
+// immutable context that carries only cancellation and deadline semantics.
+func requestBoundContext(ctx *gin.Context) context.Context {
+	return ctx.Request.Context()
+}
 
 // IssuerURL returns the base issuer URL for this server (without any namespace path).
 // It is simply the server's external web URL.
@@ -323,7 +334,7 @@ func handleClientCredentialsPing(ctx *gin.Context, provider *OIDCProvider) {
 		return
 	}
 
-	client, err := provider.Storage().GetClient(ctx, clientID)
+	client, err := provider.Storage().GetClient(requestBoundContext(ctx), clientID)
 	if err != nil {
 		ctx.Header("WWW-Authenticate", "Basic")
 		ctx.JSON(http.StatusUnauthorized, gin.H{
@@ -464,7 +475,7 @@ func handleDeviceAuthorization(provider *OIDCProvider) gin.HandlerFunc {
 			return
 		}
 
-		client, err := provider.Storage().GetClient(ctx, clientID)
+		client, err := provider.Storage().GetClient(requestBoundContext(ctx), clientID)
 		if err != nil {
 			ctx.JSON(http.StatusUnauthorized, gin.H{"error": "invalid_client", "error_description": "Unknown client"})
 			return
@@ -555,13 +566,13 @@ func handleDeviceVerify(provider *OIDCProvider) gin.HandlerFunc {
 		// can show the requested scopes and client info on the consent page.
 		if userCode := ctx.Query("user_code"); userCode != "" {
 			userCode = strings.ToUpper(strings.TrimSpace(userCode))
-			if dc, err := provider.Storage().GetDeviceCodeSessionByUserCode(ctx, userCode); err == nil {
+			if dc, err := provider.Storage().GetDeviceCodeSessionByUserCode(requestBoundContext(ctx), userCode); err == nil {
 				var scopes []string
 				if jsonErr := json.Unmarshal([]byte(dc.Scopes), &scopes); jsonErr == nil {
 					resp["scopes"] = scopes
 				}
 				resp["client_id"] = dc.ClientID
-				if rec, err := provider.Storage().GetClientRecord(ctx, dc.ClientID); err == nil && rec.ClientName != "" {
+				if rec, err := provider.Storage().GetClientRecord(requestBoundContext(ctx), dc.ClientID); err == nil && rec.ClientName != "" {
 					resp["client_name"] = rec.ClientName
 				}
 			}
@@ -624,7 +635,7 @@ func handleDeviceVerifySubmit(provider *OIDCProvider) gin.HandlerFunc {
 		userCode = strings.ToUpper(strings.TrimSpace(userCode))
 
 		if action == "deny" {
-			if err := provider.Storage().DenyDeviceCodeSession(ctx, userCode); err != nil {
+			if err := provider.Storage().DenyDeviceCodeSession(requestBoundContext(ctx), userCode); err != nil {
 				log.WithError(err).Warn("Embedded issuer: failed to deny device code")
 			}
 			ctx.JSON(http.StatusOK, gin.H{"status": "denied"})
@@ -632,7 +643,7 @@ func handleDeviceVerifySubmit(provider *OIDCProvider) gin.HandlerFunc {
 		}
 
 		// Look up the device code
-		dc, err := provider.Storage().GetDeviceCodeSessionByUserCode(ctx, userCode)
+		dc, err := provider.Storage().GetDeviceCodeSessionByUserCode(requestBoundContext(ctx), userCode)
 		if err != nil {
 			ctx.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "Invalid or expired user code"})
 			return
@@ -652,7 +663,7 @@ func handleDeviceVerifySubmit(provider *OIDCProvider) gin.HandlerFunc {
 		// The first user to approve a device code for this client becomes the
 		// only user who can ever use it.  For statically registered clients
 		// BindClientToUser is a no-op.
-		if err := provider.Storage().BindClientToUser(ctx, dc.ClientID, user); err != nil {
+		if err := provider.Storage().BindClientToUser(requestBoundContext(ctx), dc.ClientID, user); err != nil {
 			log.WithError(err).Warnf("Embedded issuer: user %s cannot use client %s (bound to different user)", user, dc.ClientID)
 			ctx.JSON(http.StatusForbidden, gin.H{"status": "error", "error": "This client is registered to a different user"})
 			return
@@ -701,7 +712,7 @@ func handleDeviceVerifySubmit(provider *OIDCProvider) gin.HandlerFunc {
 		// Also enforce the client's configured scope allow-list: a device
 		// client limited to certain scopes must not obtain broader scopes
 		// even if the user's authorization rules would permit them.
-		clientObj, clientErr := provider.Storage().GetClient(ctx, dc.ClientID)
+		clientObj, clientErr := provider.Storage().GetClient(requestBoundContext(ctx), dc.ClientID)
 		if clientErr != nil {
 			log.WithError(clientErr).Warn("Embedded issuer: failed to load client for scope filtering")
 			ctx.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "Failed to load client"})
@@ -720,7 +731,7 @@ func handleDeviceVerifySubmit(provider *OIDCProvider) gin.HandlerFunc {
 		session := DefaultOIDCSession(user, issuerURL, matchedGroups, grantedScopes)
 		sessionData, _ := json.Marshal(session)
 
-		if err := provider.Storage().ApproveDeviceCodeSession(ctx, userCode, user, grantedScopes, sessionData); err != nil {
+		if err := provider.Storage().ApproveDeviceCodeSession(requestBoundContext(ctx), userCode, user, grantedScopes, sessionData); err != nil {
 			log.WithError(err).Warn("Embedded issuer: failed to approve device code")
 			ctx.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "Failed to approve device code"})
 			return
@@ -747,7 +758,7 @@ func handleDeviceTokenExchange(ctx *gin.Context, provider *OIDCProvider) {
 		return
 	}
 
-	client, err := provider.Storage().GetClient(ctx, clientID)
+	client, err := provider.Storage().GetClient(requestBoundContext(ctx), clientID)
 	if err != nil {
 		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "invalid_client"})
 		return
@@ -1137,7 +1148,7 @@ func handleDynamicClientRegistration(provider *OIDCProvider) gin.HandlerFunc {
 			Public:        false,
 		}
 
-		if err := provider.Storage().CreateDynamicClient(ctx, client, clientIP, hashedRAT, req.ClientName); err != nil {
+		if err := provider.Storage().CreateDynamicClient(requestBoundContext(ctx), client, clientIP, hashedRAT, req.ClientName); err != nil {
 			log.WithError(err).Warn("Embedded issuer: failed to register client")
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "server_error"})
 			return
@@ -1185,7 +1196,7 @@ func handleClientConfigurationRead(provider *OIDCProvider) gin.HandlerFunc {
 			return
 		}
 
-		record, err := provider.Storage().ValidateRegistrationAccessToken(ctx, clientID, rat)
+		record, err := provider.Storage().ValidateRegistrationAccessToken(requestBoundContext(ctx), clientID, rat)
 		if err != nil {
 			ctx.JSON(http.StatusUnauthorized, gin.H{"error": "invalid_token", "error_description": "Invalid registration access token"})
 			return
@@ -1225,7 +1236,7 @@ func handleClientConfigurationUpdate(provider *OIDCProvider) gin.HandlerFunc {
 			return
 		}
 
-		record, err := provider.Storage().ValidateRegistrationAccessToken(ctx, clientID, rat)
+		record, err := provider.Storage().ValidateRegistrationAccessToken(requestBoundContext(ctx), clientID, rat)
 		if err != nil {
 			ctx.JSON(http.StatusUnauthorized, gin.H{"error": "invalid_token", "error_description": "Invalid registration access token"})
 			return
@@ -1271,7 +1282,7 @@ func handleClientConfigurationUpdate(provider *OIDCProvider) gin.HandlerFunc {
 		}
 
 		if len(updates) > 0 {
-			if err := provider.Storage().UpdateDynamicClient(ctx, clientID, updates); err != nil {
+			if err := provider.Storage().UpdateDynamicClient(requestBoundContext(ctx), clientID, updates); err != nil {
 				log.WithError(err).Warn("Embedded issuer: failed to update dynamic client")
 				ctx.JSON(http.StatusInternalServerError, gin.H{"error": "server_error"})
 				return
@@ -1279,7 +1290,7 @@ func handleClientConfigurationUpdate(provider *OIDCProvider) gin.HandlerFunc {
 		}
 
 		// Re-read and return updated metadata
-		updated, err := provider.Storage().GetClientRecord(ctx, clientID)
+		updated, err := provider.Storage().GetClientRecord(requestBoundContext(ctx), clientID)
 		if err != nil {
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "server_error"})
 			return
@@ -1318,7 +1329,7 @@ func handleClientConfigurationDelete(provider *OIDCProvider) gin.HandlerFunc {
 			return
 		}
 
-		record, err := provider.Storage().ValidateRegistrationAccessToken(ctx, clientID, rat)
+		record, err := provider.Storage().ValidateRegistrationAccessToken(requestBoundContext(ctx), clientID, rat)
 		if err != nil {
 			ctx.JSON(http.StatusUnauthorized, gin.H{"error": "invalid_token", "error_description": "Invalid registration access token"})
 			return
@@ -1329,7 +1340,7 @@ func handleClientConfigurationDelete(provider *OIDCProvider) gin.HandlerFunc {
 			return
 		}
 
-		deleted, err := provider.Storage().DeleteClient(ctx, clientID)
+		deleted, err := provider.Storage().DeleteClient(requestBoundContext(ctx), clientID)
 		if err != nil || !deleted {
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "server_error"})
 			return

--- a/oauth2/issuer/handlers.go
+++ b/oauth2/issuer/handlers.go
@@ -19,6 +19,7 @@
 package issuer
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -48,6 +49,16 @@ const (
 	// maxClientNameLen is the maximum length (in bytes) of a client_name.
 	maxClientNameLen = 128
 )
+
+// requestBoundContext returns the net/http request context from a Gin
+// handler. *gin.Context implements context.Context but is mutable request
+// state that Gin modifies throughout the request lifecycle; passing it
+// where a context.Context is needed exposes that mutable state to callers
+// that may hold it concurrently. ctx.Request.Context() is the safe,
+// immutable context that carries only cancellation and deadline semantics.
+func requestBoundContext(ctx *gin.Context) context.Context {
+	return ctx.Request.Context()
+}
 
 // IssuerURL returns the base issuer URL for this server (without any namespace path).
 // It is simply the server's external web URL.
@@ -340,7 +351,7 @@ func handleClientCredentialsPing(ctx *gin.Context, provider *OIDCProvider) {
 		return
 	}
 
-	client, err := provider.Storage().GetClient(ctx, clientID)
+	client, err := provider.Storage().GetClient(requestBoundContext(ctx), clientID)
 	if err != nil {
 		ctx.Header("WWW-Authenticate", "Basic")
 		ctx.JSON(http.StatusUnauthorized, gin.H{
@@ -481,7 +492,7 @@ func handleDeviceAuthorization(provider *OIDCProvider) gin.HandlerFunc {
 			return
 		}
 
-		client, err := provider.Storage().GetClient(ctx, clientID)
+		client, err := provider.Storage().GetClient(requestBoundContext(ctx), clientID)
 		if err != nil {
 			ctx.JSON(http.StatusUnauthorized, gin.H{"error": "invalid_client", "error_description": "Unknown client"})
 			return
@@ -572,13 +583,13 @@ func handleDeviceVerify(provider *OIDCProvider) gin.HandlerFunc {
 		// can show the requested scopes and client info on the consent page.
 		if userCode := ctx.Query("user_code"); userCode != "" {
 			userCode = strings.ToUpper(strings.TrimSpace(userCode))
-			if dc, err := provider.Storage().GetDeviceCodeSessionByUserCode(ctx, userCode); err == nil {
+			if dc, err := provider.Storage().GetDeviceCodeSessionByUserCode(requestBoundContext(ctx), userCode); err == nil {
 				var scopes []string
 				if jsonErr := json.Unmarshal([]byte(dc.Scopes), &scopes); jsonErr == nil {
 					resp["scopes"] = scopes
 				}
 				resp["client_id"] = dc.ClientID
-				if rec, err := provider.Storage().GetClientRecord(ctx, dc.ClientID); err == nil && rec.ClientName != "" {
+				if rec, err := provider.Storage().GetClientRecord(requestBoundContext(ctx), dc.ClientID); err == nil && rec.ClientName != "" {
 					resp["client_name"] = rec.ClientName
 				}
 			}
@@ -641,7 +652,7 @@ func handleDeviceVerifySubmit(provider *OIDCProvider) gin.HandlerFunc {
 		userCode = strings.ToUpper(strings.TrimSpace(userCode))
 
 		if action == "deny" {
-			if err := provider.Storage().DenyDeviceCodeSession(ctx, userCode); err != nil {
+			if err := provider.Storage().DenyDeviceCodeSession(requestBoundContext(ctx), userCode); err != nil {
 				log.WithError(err).Warn("Embedded issuer: failed to deny device code")
 			}
 			ctx.JSON(http.StatusOK, gin.H{"status": "denied"})
@@ -649,7 +660,7 @@ func handleDeviceVerifySubmit(provider *OIDCProvider) gin.HandlerFunc {
 		}
 
 		// Look up the device code
-		dc, err := provider.Storage().GetDeviceCodeSessionByUserCode(ctx, userCode)
+		dc, err := provider.Storage().GetDeviceCodeSessionByUserCode(requestBoundContext(ctx), userCode)
 		if err != nil {
 			ctx.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "Invalid or expired user code"})
 			return
@@ -669,7 +680,7 @@ func handleDeviceVerifySubmit(provider *OIDCProvider) gin.HandlerFunc {
 		// The first user to approve a device code for this client becomes the
 		// only user who can ever use it.  For statically registered clients
 		// BindClientToUser is a no-op.
-		if err := provider.Storage().BindClientToUser(ctx, dc.ClientID, user); err != nil {
+		if err := provider.Storage().BindClientToUser(requestBoundContext(ctx), dc.ClientID, user); err != nil {
 			log.WithError(err).Warnf("Embedded issuer: user %s cannot use client %s (bound to different user)", user, dc.ClientID)
 			ctx.JSON(http.StatusForbidden, gin.H{"status": "error", "error": "This client is registered to a different user"})
 			return
@@ -718,7 +729,7 @@ func handleDeviceVerifySubmit(provider *OIDCProvider) gin.HandlerFunc {
 		// Also enforce the client's configured scope allow-list: a device
 		// client limited to certain scopes must not obtain broader scopes
 		// even if the user's authorization rules would permit them.
-		clientObj, clientErr := provider.Storage().GetClient(ctx, dc.ClientID)
+		clientObj, clientErr := provider.Storage().GetClient(requestBoundContext(ctx), dc.ClientID)
 		if clientErr != nil {
 			log.WithError(clientErr).Warn("Embedded issuer: failed to load client for scope filtering")
 			ctx.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "Failed to load client"})
@@ -737,7 +748,7 @@ func handleDeviceVerifySubmit(provider *OIDCProvider) gin.HandlerFunc {
 		session := DefaultOIDCSession(user, issuerURL, matchedGroups, grantedScopes)
 		sessionData, _ := json.Marshal(session)
 
-		if err := provider.Storage().ApproveDeviceCodeSession(ctx, userCode, user, grantedScopes, sessionData); err != nil {
+		if err := provider.Storage().ApproveDeviceCodeSession(requestBoundContext(ctx), userCode, user, grantedScopes, sessionData); err != nil {
 			log.WithError(err).Warn("Embedded issuer: failed to approve device code")
 			ctx.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "Failed to approve device code"})
 			return
@@ -764,7 +775,7 @@ func handleDeviceTokenExchange(ctx *gin.Context, provider *OIDCProvider) {
 		return
 	}
 
-	client, err := provider.Storage().GetClient(ctx, clientID)
+	client, err := provider.Storage().GetClient(requestBoundContext(ctx), clientID)
 	if err != nil {
 		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "invalid_client"})
 		return
@@ -1154,7 +1165,7 @@ func handleDynamicClientRegistration(provider *OIDCProvider) gin.HandlerFunc {
 			Public:        false,
 		}
 
-		if err := provider.Storage().CreateDynamicClient(ctx, client, clientIP, hashedRAT, req.ClientName); err != nil {
+		if err := provider.Storage().CreateDynamicClient(requestBoundContext(ctx), client, clientIP, hashedRAT, req.ClientName); err != nil {
 			log.WithError(err).Warn("Embedded issuer: failed to register client")
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "server_error"})
 			return
@@ -1202,7 +1213,7 @@ func handleClientConfigurationRead(provider *OIDCProvider) gin.HandlerFunc {
 			return
 		}
 
-		record, err := provider.Storage().ValidateRegistrationAccessToken(ctx, clientID, rat)
+		record, err := provider.Storage().ValidateRegistrationAccessToken(requestBoundContext(ctx), clientID, rat)
 		if err != nil {
 			ctx.JSON(http.StatusUnauthorized, gin.H{"error": "invalid_token", "error_description": "Invalid registration access token"})
 			return
@@ -1242,7 +1253,7 @@ func handleClientConfigurationUpdate(provider *OIDCProvider) gin.HandlerFunc {
 			return
 		}
 
-		record, err := provider.Storage().ValidateRegistrationAccessToken(ctx, clientID, rat)
+		record, err := provider.Storage().ValidateRegistrationAccessToken(requestBoundContext(ctx), clientID, rat)
 		if err != nil {
 			ctx.JSON(http.StatusUnauthorized, gin.H{"error": "invalid_token", "error_description": "Invalid registration access token"})
 			return
@@ -1288,7 +1299,7 @@ func handleClientConfigurationUpdate(provider *OIDCProvider) gin.HandlerFunc {
 		}
 
 		if len(updates) > 0 {
-			if err := provider.Storage().UpdateDynamicClient(ctx, clientID, updates); err != nil {
+			if err := provider.Storage().UpdateDynamicClient(requestBoundContext(ctx), clientID, updates); err != nil {
 				log.WithError(err).Warn("Embedded issuer: failed to update dynamic client")
 				ctx.JSON(http.StatusInternalServerError, gin.H{"error": "server_error"})
 				return
@@ -1296,7 +1307,7 @@ func handleClientConfigurationUpdate(provider *OIDCProvider) gin.HandlerFunc {
 		}
 
 		// Re-read and return updated metadata
-		updated, err := provider.Storage().GetClientRecord(ctx, clientID)
+		updated, err := provider.Storage().GetClientRecord(requestBoundContext(ctx), clientID)
 		if err != nil {
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "server_error"})
 			return
@@ -1335,7 +1346,7 @@ func handleClientConfigurationDelete(provider *OIDCProvider) gin.HandlerFunc {
 			return
 		}
 
-		record, err := provider.Storage().ValidateRegistrationAccessToken(ctx, clientID, rat)
+		record, err := provider.Storage().ValidateRegistrationAccessToken(requestBoundContext(ctx), clientID, rat)
 		if err != nil {
 			ctx.JSON(http.StatusUnauthorized, gin.H{"error": "invalid_token", "error_description": "Invalid registration access token"})
 			return
@@ -1346,7 +1357,7 @@ func handleClientConfigurationDelete(provider *OIDCProvider) gin.HandlerFunc {
 			return
 		}
 
-		deleted, err := provider.Storage().DeleteClient(ctx, clientID)
+		deleted, err := provider.Storage().DeleteClient(requestBoundContext(ctx), clientID)
 		if err != nil || !deleted {
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "server_error"})
 			return

--- a/origin_serve/handlers.go
+++ b/origin_serve/handlers.go
@@ -30,6 +30,7 @@ import (
 	"path"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -50,6 +51,7 @@ import (
 )
 
 var (
+	handlersMu          sync.Mutex
 	backends            map[string]server_utils.OriginBackend
 	webdavHandlers      map[string]*webdav.Handler
 	exportPrefixMap     map[string]string // Maps federation prefix to storage prefix
@@ -186,6 +188,9 @@ func init() {
 
 // ResetHandlers resets the handler state (for testing)
 func ResetHandlers() {
+	handlersMu.Lock()
+	defer handlersMu.Unlock()
+
 	backends = nil
 	webdavHandlers = nil
 	exportPrefixMap = nil
@@ -662,6 +667,9 @@ func InitializeHandlers(ctx context.Context, exports []server_utils.OriginExport
 // and the origin's file serving. Otherwise, handlers are registered directly at the
 // federation prefix for standalone origins.
 func RegisterHandlers(engine *gin.Engine, directorEnabled bool) error {
+	handlersMu.Lock()
+	defer handlersMu.Unlock()
+
 	// Prevent double registration when both director and POSIXv2 origin are running
 	if handlersRegistered {
 		log.Debug("POSIXv2 handlers already registered, skipping")

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -605,6 +605,12 @@ func (ad *Advertisement) GetIOLoad() float64 {
 	ad.RLock()
 	defer ad.RUnlock()
 	return ad.IOLoad
+}
+
+func (ad *Advertisement) GetServerAd() ServerAd {
+	ad.RLock()
+	defer ad.RUnlock()
+	return ad.ServerAd
 }
 
 func ConvertNamespaceAdsV2ToV1(nsV2 []NamespaceAdV2) []NamespaceAdV1 {

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -689,6 +689,17 @@ func (ad *Advertisement) GetIOLoad() float64 {
 	return ad.IOLoad
 }
 
+// GetServerAd returns a copy of the embedded ServerAd taken under the
+// advertisement's read lock. This is the required, race-free way to read the
+// ServerAd out of an Advertisement: reading adItem.Value().ServerAd (or
+// otherwise copying the embedded ServerAd directly) is prohibited because it
+// races with SetIOLoad and any other mutation guarded by the lock.
+func (ad *Advertisement) GetServerAd() ServerAd {
+	ad.RLock()
+	defer ad.RUnlock()
+	return ad.ServerAd
+}
+
 func ServerAdsToServerNameURL(ads []ServerAd) (output string) {
 	for _, ad := range ads {
 		output += ad.Name + ":" + ad.URL.String() + "\n"

--- a/server_utils/server_utils.go
+++ b/server_utils/server_utils.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -375,9 +375,11 @@ func ResetTestState() {
 	ResetOriginExports()
 	logging.ResetLogFlush()
 	logging.ResetGlobalManager()
+	baseAdMu.Lock()
 	baseAdOnce = sync.Once{}
 	baseAd = server_structs.ServerBaseAd{}
 	baseAdErr = nil
+	baseAdMu.Unlock()
 	directorEndpoints.Store(nil)
 	if err := database.ShutdownDB(); err != nil {
 		log.Errorf("Failed to shutdown the database: %v", err)

--- a/server_utils/sitename.go
+++ b/server_utils/sitename.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -36,6 +36,12 @@ import (
 )
 
 var (
+	// baseAdMu guards baseAdOnce, baseAd, and baseAdErr. sync.Once serializes
+	// concurrent calls through it, but does not protect against a concurrent
+	// assignment to the Once variable itself. ResetTestState zeroes all three
+	// with plain assignments; without baseAdMu those writes race with
+	// concurrent calls to IsDirectorAdFromSelf that are reading the same vars.
+	baseAdMu   sync.Mutex
 	baseAdOnce sync.Once
 	baseAd     server_structs.ServerBaseAd
 	baseAdErr  error
@@ -150,6 +156,9 @@ func IsDirectorAdFromSelf(ctx context.Context, ad server_structs.ServerBaseAdInt
 	if ad == nil {
 		return false, fmt.Errorf("received nil advertisement")
 	}
+
+	baseAdMu.Lock()
+	defer baseAdMu.Unlock()
 
 	baseAdOnce.Do(func() {
 		var metadata server_structs.ServerRegistration

--- a/server_utils/sitename.go
+++ b/server_utils/sitename.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -36,6 +36,12 @@ import (
 )
 
 var (
+	// baseAdMu guards baseAdOnce, baseAd, and baseAdErr. sync.Once serializes
+	// concurrent calls through it, but does not protect against a concurrent
+	// assignment to the Once variable itself. ResetTestState zeroes all three
+	// with plain assignments; without baseAdMu those writes race with
+	// concurrent calls to IsDirectorAdFromSelf that are reading the same vars.
+	baseAdMu   sync.Mutex
 	baseAdOnce sync.Once
 	baseAd     server_structs.ServerBaseAd
 	baseAdErr  error
@@ -147,6 +153,9 @@ func IsDirectorAdFromSelf(ctx context.Context, ad server_structs.ServerBaseAdInt
 	if ad == nil {
 		return false, fmt.Errorf("received nil advertisement")
 	}
+
+	baseAdMu.Lock()
+	defer baseAdMu.Unlock()
 
 	baseAdOnce.Do(func() {
 		var metadata server_structs.ServerRegistration

--- a/test_utils/utils.go
+++ b/test_utils/utils.go
@@ -592,7 +592,7 @@ func SetupTestLogging(t testing.TB) func() {
 // surfaces the originating call site to make test output readable.
 func formatEntry(entry *logrus.Entry) string {
 	loc := ""
-	if entry.HasCaller() && entry.Caller != nil {
+	if entry.Caller != nil {
 		loc = fmt.Sprintf("%s:%d: ", filepath.Base(entry.Caller.File), entry.Caller.Line)
 	}
 

--- a/test_utils/utils.go
+++ b/test_utils/utils.go
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -592,7 +592,7 @@ func SetupTestLogging(t testing.TB) func() {
 // surfaces the originating call site to make test output readable.
 func formatEntry(entry *logrus.Entry) string {
 	loc := ""
-	if entry.HasCaller() && entry.Caller != nil {
+	if entry.Caller != nil {
 		loc = fmt.Sprintf("%s:%d: ", filepath.Base(entry.Caller.File), entry.Caller.Line)
 	}
 

--- a/web_ui/server_api.go
+++ b/web_ui/server_api.go
@@ -453,13 +453,14 @@ func mirrorDowntimeToRegistry(ctx *gin.Context, dt server_structs.Downtime, meth
 	if id == "" {
 		return errors.New("downtime ID is required")
 	}
+	reqCtx := ctx.Request.Context()
 
 	// Only mirror downtime to Registry when this server is an Origin or Cache
 	if !config.ValidateServerType([]server_structs.ServerType{server_structs.OriginType, server_structs.CacheType}) {
 		return nil
 	}
 
-	fed, err := config.GetFederation(ctx)
+	fed, err := config.GetFederation(reqCtx)
 	if err != nil || fed.RegistryEndpoint == "" {
 		return errors.Wrap(err, "failed to load federation configuration")
 	}
@@ -516,7 +517,7 @@ func mirrorDowntimeToRegistry(ctx *gin.Context, dt server_structs.Downtime, meth
 		}
 	}
 	tr := config.GetTransport()
-	if _, err := utils.MakeRequest(ctx, tr, regURL.String(), method, data, headers); err != nil {
+	if _, err := utils.MakeRequest(reqCtx, tr, regURL.String(), method, data, headers); err != nil {
 		return errors.Wrapf(err, "failed to mirror downtime to registry at %s", regURL.String())
 	}
 

--- a/web_ui/server_api.go
+++ b/web_ui/server_api.go
@@ -501,13 +501,14 @@ func mirrorDowntimeToRegistry(ctx *gin.Context, dt server_structs.Downtime, meth
 	if id == "" {
 		return errors.New("downtime ID is required")
 	}
+	reqCtx := ctx.Request.Context()
 
 	// Only mirror downtime to Registry when this server is an Origin or Cache
 	if !config.ValidateServerType([]server_structs.ServerType{server_structs.OriginType, server_structs.CacheType}) {
 		return nil
 	}
 
-	fed, err := config.GetFederation(ctx)
+	fed, err := config.GetFederation(reqCtx)
 	if err != nil || fed.RegistryEndpoint == "" {
 		return errors.Wrap(err, "failed to load federation configuration")
 	}
@@ -564,7 +565,7 @@ func mirrorDowntimeToRegistry(ctx *gin.Context, dt server_structs.Downtime, meth
 		}
 	}
 	tr := config.GetTransport()
-	if _, err := utils.MakeRequest(ctx, tr, regURL.String(), method, data, headers); err != nil {
+	if _, err := utils.MakeRequest(reqCtx, tr, regURL.String(), method, data, headers); err != nil {
 		return errors.Wrapf(err, "failed to mirror downtime to registry at %s", regURL.String())
 	}
 


### PR DESCRIPTION
Fixes the races described in #3489.

## Design notes by change

### `sync.Once` + reset races (`config`, `server_utils`)

Three caches follow the same broken pattern: a `sync.Once` guards lazy initialization, but test-reset paths overwrite the `Once` variable and the cached values with bare assignments, racing with concurrent readers.

`sync.Once` serializes concurrent calls *through* it, but provides no protection against a concurrent assignment to the `Once` variable itself. The fix in all three cases is the same: introduce a `sync.Mutex` that is held by both the init path and the reset path, making them mutually exclusive. The `Once` continues to do its job (run setup at most once per cycle); the mutex closes the gap.

Helper functions (`initTransport`/`resetTransport`, `resetFederationDiscoveryState`/`clearGlobalFederationState`) encapsulate the lock scope so call sites stay linear. The lock is *not* held across the entire `Do` callback — only across the `Do` call and the variable assignments — which keeps the critical sections short.

For the federation discovery case, `globalFedInfo` was already an `atomic.Pointer` and remains so; only `fedDiscoveryOnce` and `globalFedErr` needed the new mutex.

### Director ad cache initialization (`director/director_advertise.go`)

`updateInternalDirectorCache` was publishing a zero-value `*directorInfo` into the TTL cache via `GetOrSet`, then populating its fields afterward. Any reader that obtained the entry between `GetOrSet` and field population would see nil `forwardAdChan`, nil `cancel`, and an empty ad.

The fix constructs a fully initialized `directorInfo` — including `context.WithCancel`, `forwardAdChan`, and the ad itself — before calling `GetOrSet`. If `GetOrSet` reports that an existing entry won the race, the newly created cancel function is called immediately to release the unused context.

### `Advertisement.IOLoad` read outside lock (`director/monitor.go`)

`Advertisement` already has an `RWMutex` used by `SetIOLoad`/`GetIOLoad`. Copying the embedded `ServerAd` struct directly bypassed that lock because Go struct copies are not atomic. The fix adds `GetServerAd()` which holds the read lock for the duration of the copy, mirroring the existing `GetIOLoad` pattern.

### `*gin.Context` escaping to storage and I/O callers (`oauth2/issuer`, `web_ui`)

`*gin.Context` implements `context.Context`, so it compiles where a `context.Context` is expected. It is, however, mutable request state that gin reads and writes throughout the request lifecycle; passing it to storage or outbound-HTTP calls gives those callees a reference to that state, which races with gin's own concurrent modifications.

The fix passes `ctx.Request.Context()` instead — the underlying `net/http` request context, whose lifetime is tied to the HTTP request and which is safe to share with any goroutine. A small unexported helper `requestBoundContext` is introduced in the `oauth2/issuer` package to make the right choice explicit and to document the reason at the definition site. `mirrorDowntimeToRegistry` in `web_ui` follows the same pattern inline (`reqCtx := ctx.Request.Context()`) rather than calling the helper, because the helper is unexported and in a different package.

### JWK key cloning (`client/acquire_token.go`)

The cached `jwk.Key` was treated as effectively immutable for the purposes of signing, but `key.Set("kid", ...)` mutates an internal map. The fix calls `key.Clone()` before setting the key ID, leaving the cached key untouched.

### Director TTL cache snapshot (`director/sort.go`)

The repository already contains a comment in `director_api.go` noting that `Range` races with the eviction goroutine and that `Items()` should be used instead. This change applies the same fix to `getAdsForPath` in `sort.go`.

### Narrow-scope fixes

- **XRootD metric accumulators (`metrics/xrootd_metrics.go`):** Two separate mutexes, one per accumulator family, rather than one coarse lock. This avoids serializing unrelated metric families while keeping each read-modify-write sequence atomic.

- **Origin handler registration (`origin_serve/handlers.go`):** A single mutex around the check-and-set of `handlersRegistered`. The registration path can return errors and tests need to reset the flag, so a mutex is less surprising than a `sync.Once` or `atomic.Bool`.

- **Launcher error capture (`launchers/launcher.go`):** Goroutine-local error variables instead of capturing the outer `err`. The existing error channel is unchanged; only the intermediate local assignments are made goroutine-local.

- **PelicanFS stress test RNG (`client/pelican_fs_test.go`):** Per-goroutine `rand.Rand` instances. No production code is affected.

- **Test log hook (`test_utils/utils.go`):** The cleanup hook checks `entry.Caller` directly rather than `entry.Logger.ReportCaller`. The global logger flag is only needed to decide whether to populate `entry.Caller` in the first place; by the time the hook fires, `entry.Caller` is already set or nil.

---

_(Brian A: With a tip of the hat to Copilot.)_
