### PR TITLE
Revert "Upgrade XRootD dependency to 5.9.5 (#3487)"

### DIFF
--- a/github_scripts/osx_install.sh
+++ b/github_scripts/osx_install.sh
@@ -59,7 +59,7 @@ popd
 # Add patches to xrootd source code if needed
 git clone https://github.com/PelicanPlatform/xrootd.git
 pushd xrootd
-git checkout v5.9.5-pelican
+git checkout v5.9.2-pelican
 mkdir xrootd_build
 cd xrootd_build
 cmake .. -GNinja

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -313,7 +313,7 @@ ARG XROOTD_GID
 # We install from osg-testing (which contains tested packages) and pin the version.
 # NOTE: If you update this version, you must also update the version in
 # github_scripts/osx_install.sh.
-ARG XROOTD_VER="5.9.5"
+ARG XROOTD_VER="5.9.2"
 ARG XROOTD_RELEASE="1.1.osg${OSG_SERIES}.${BASE_OS}"
 
 # The packages need to be installed in a single dnf command in


### PR DESCRIPTION
Reverts PelicanPlatform/pelican#3488
We've discovered issues with 5.9.5 and removed it from the osg-testing repos.