### PR TITLE
Add missing nextra import

### DIFF
--- a/docs/app/operating-a-federation/cache/page.mdx
+++ b/docs/app/operating-a-federation/cache/page.mdx
@@ -1,3 +1,5 @@
+import { Callout } from 'nextra/components'
+
 # Serving a Pelican Cache
 
 The Pelican [*Cache*](../about-pelican/core-concepts.mdx#caches) creates a cache that connects to a Pelican data federation to allow faster data access. It stores data that is accessed via a Pelican origin until it gets evicted. The Cache has the potential to both be faster and physically closer to your location than the Pelican Origin you access the data from. This allows for faster data access when running complex workflows.


### PR DESCRIPTION
7.25 docs builds are broken because of a missing nextra import.

(cherry picked from commit 304af8c0498194e60e25653bde098b49d3d22f21)