### PR TITLE
Register all issuer public keys at startup, not just the active one

### DIFF
--- a/cmd/registry_client.go
+++ b/cmd/registry_client.go
@@ -92,24 +92,8 @@ func registerANamespace(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	publicKey, err := config.GetIssuerPublicJWKS()
-	if err != nil {
-		log.Error("Error: Failed to retrieve public key: ", err)
-		os.Exit(1)
-	}
-
-	/*
-	 * TODO: For now, we only allow namespace registration to occur with a single key, but
-	 *       at some point we should expose an API for adding additional pubkeys to each
-	 *       namespace. There is a similar TODO listed in registry.go, as the choices made
-	 *       there mirror the choices made here.
-	 * To enforce that we're only trying to register one key, we check the length here
-	 */
-	if publicKey.Len() > 1 {
-		log.Errorf("Only one public key can be registered in this step, but %d were provided\n", publicKey.Len())
-		os.Exit(1)
-	}
-
+	// NamespaceRegister advertises every issuer key this server holds (with the
+	// signing key at index 0), and the registry records the full keyset
 	privateKey, err := config.GetIssuerPrivateJWK()
 	if err != nil {
 		log.Error("Failed to load private key", err)

--- a/launcher_utils/register_namespace.go
+++ b/launcher_utils/register_namespace.go
@@ -306,6 +306,15 @@ func RegisterNamespaceWithRetry(ctx context.Context, egrp *errgroup.Group, prefi
 	if isRegistered {
 		metrics.SetComponentHealthStatus(metrics.OriginCache_Registry, metrics.StatusOK, "")
 		log.Debugf("Origin already has prefix %v registered\n", prefix)
+		// Because the namespace is already registered, the all-keys initial registration
+		// below is skipped. If the issuer keyset gained keys while the server was down
+		// (e.g. a new .pem was added to the issuer-keys directory before this restart), the
+		// registry would still hold a stale subset of our keys. Reconcile by pushing the full
+		// public keyset; the registry no-ops when nothing changed. Best-effort: a failure here
+		// must not block startup, and the runtime key-refresh watcher will retry on changes.
+		if err := updateNamespacesPubKey(ctx, []string{prefix}); err != nil {
+			log.Warnf("Failed to reconcile registered issuer public keys for prefix %s: %v", prefix, err)
+		}
 		if err := origin.FetchAndSetRegStatus(prefix); err != nil {
 			return errors.Wrapf(err, "failed to fetch registration status for the prefix %s", prefix)
 		}

--- a/launcher_utils/register_namespace.go
+++ b/launcher_utils/register_namespace.go
@@ -237,20 +237,43 @@ func registerNamespacePrep(ctx context.Context, prefix string) (key jwk.Key, reg
 			return
 		}
 	}
-	keyStatus, err := keyIsRegistered(key, registrationUrl, prefix)
-	if err != nil {
-		err = errors.Wrap(err, "Failed to determine whether namespace is already registered")
+
+	// If there are multiple keys, the active key (used to sign the key-sign challenge)
+	// can differ from the one the namespace was originally registered under, but an older key
+	// still present in the issuer keyset. Check every key in the keyset: if any of them matches,
+	// the namespace is ours.
+	allKeys := config.GetIssuerPrivateKeys()
+	if len(allKeys) == 0 {
+		err = errors.New("The in-memory keyset hasn't been populated yet")
 		return
 	}
-	switch keyStatus {
-	case keyMatch:
-		isRegistered = true
-		return
-	case keyMismatch:
+
+	mismatch := false
+	for _, candidate := range allKeys {
+		// Every key in the keyset is loaded via config.LoadSinglePEM, which assigns a
+		// key ID, so candidate.KeyID() is already non-empty here.
+		var status keyStatus
+		status, err = keyIsRegistered(candidate, registrationUrl, prefix)
+		if err != nil {
+			err = errors.Wrap(err, "Failed to determine whether namespace is already registered")
+			return
+		}
+		switch status {
+		case keyMatch:
+			isRegistered = true
+			return
+		case noKeyPresent:
+			log.Infof("Namespace %v not registered; new registration will proceed\n", prefix)
+			return
+		case keyMismatch:
+			// This key doesn't match; keep trying the rest of the keyset.
+			mismatch = true
+		}
+	}
+
+	if mismatch {
 		err = errors.Errorf("Namespace %v already registered under a different key", prefix)
 		return
-	case noKeyPresent:
-		log.Infof("Namespace %v not registered; new registration will proceed\n", prefix)
 	}
 	return
 }

--- a/launcher_utils/register_namespace_test.go
+++ b/launcher_utils/register_namespace_test.go
@@ -29,6 +29,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -410,4 +411,123 @@ func TestRegistrationOldKeyStillInKeyset(t *testing.T) {
 	_, _, isRegistered, err = registerNamespacePrep(ctx, prefix)
 	require.NoError(t, err)
 	require.True(t, isRegistered)
+}
+
+// fetchRegistryKids returns the sorted key IDs the registry has recorded for a prefix.
+func fetchRegistryKids(t *testing.T, registryUrl, prefix string) []string {
+	t.Helper()
+	req, err := http.NewRequest("GET", registryUrl+"/api/v1.0/registry", nil)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{Transport: config.GetTransport()}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+
+	entries := []server_structs.Registration{}
+	require.NoError(t, json.Unmarshal(body, &entries))
+	kids := []string{}
+	for _, e := range entries {
+		if e.Prefix != prefix {
+			continue
+		}
+		keySet, err := jwk.Parse([]byte(e.Pubkey))
+		require.NoError(t, err)
+		for i := 0; i < keySet.Len(); i++ {
+			k, ok := keySet.Key(i)
+			require.True(t, ok)
+			kids = append(kids, k.KeyID())
+		}
+	}
+	sort.Strings(kids)
+	return kids
+}
+
+// TestReconcileKeysWhenAlreadyRegistered verifies that when an origin restarts with an
+// extra issuer key that was dropped into the issuer-keys directory while it was down, the
+// already-registered startup path reconciles the registry so it records the full keyset.
+// It also covers the case where the newly-added key is the active (signing) key while the
+// already-registered key is only a secondary key in the set.
+func TestReconcileKeysWhenAlreadyRegistered(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	t.Cleanup(func() {
+		server_utils.ResetTestState()
+	})
+
+	tempConfigDir, err := os.MkdirTemp("", "test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempConfigDir)
+
+	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	defer func() { require.NoError(t, egrp.Wait()) }()
+	defer cancel()
+
+	server_utils.ResetTestState()
+	require.NoError(t, param.ConfigDir.Set(tempConfigDir))
+
+	// MockFederationRoot must be called before setting IssuerKeysDirectory because that
+	// function overrides the IssuerKeysDirectory value if not already set.
+	test_utils.MockFederationRoot(t, nil, nil)
+
+	keysDir := filepath.Join(tempConfigDir, "issuer-keys")
+	require.NoError(t, param.IssuerKeysDirectory.Set(keysDir))
+
+	require.NoError(t, param.Registry_DbLocation.Set(""))
+	require.NoError(t, param.Server_DbLocation.Set(filepath.Join(tempConfigDir, "test.sql")))
+	require.NoError(t, config.InitServer(ctx, server_structs.OriginType))
+	require.NoError(t, database.InitServerDatabase(server_structs.RegistryType))
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.Default()
+	registry.RegisterRegistryAPI(engine.Group("/"))
+	svr := httptest.NewServer(engine)
+	defer svr.CloseClientConnections()
+	defer svr.Close()
+
+	require.NoError(t, param.Set(param.Federation_RegistryUrl, svr.URL))
+	require.NoError(t, param.Origin_FederationPrefix.Set("/test123"))
+	require.NoError(t, param.Xrootd_Sitename.Set("mock_site_name"))
+	require.NoError(t, config.InitServer(ctx, server_structs.OriginType))
+
+	prefix := param.Origin_FederationPrefix.GetString()
+
+	// Register the namespace under the origin's initial (and only) issuer key.
+	firstKey, registerURL, isRegistered, err := registerNamespacePrep(ctx, prefix)
+	require.NoError(t, err)
+	require.False(t, isRegistered)
+	require.NoError(t, registerNamespaceImpl(firstKey, prefix, "mock_site_name", registerURL))
+	registeredKid := firstKey.KeyID()
+
+	// The registry should currently hold exactly the first key.
+	require.Equal(t, []string{registeredKid}, fetchRegistryKids(t, svr.URL, prefix))
+
+	// Simulate a new key dropped into the issuer-keys directory while the origin was down.
+	// The "00_" filename sorts first, so it becomes the active/signing key, while the
+	// already-registered key becomes a secondary key in the set.
+	newKeyPath := filepath.Join(keysDir, "00_active.pem")
+	require.NoError(t, config.GeneratePrivateKey(newKeyPath, elliptic.P256(), false))
+	keysChange, err := config.RefreshKeys()
+	require.NoError(t, err)
+	require.True(t, keysChange)
+	newKey, err := config.LoadSinglePEM(newKeyPath)
+	require.NoError(t, err)
+	newKid := newKey.KeyID()
+
+	// The active key is now the new (unregistered) key.
+	activeKey, err := config.GetIssuerPrivateJWK()
+	require.NoError(t, err)
+	require.Equal(t, newKid, activeKey.KeyID())
+	require.NotEqual(t, registeredKid, newKid)
+
+	// "Restart": the namespace is already registered (under firstKey), so the all-keys
+	// initial registration is skipped -- the reconcile must push the full keyset instead.
+	require.NoError(t, RegisterNamespaceWithRetry(ctx, egrp, prefix))
+
+	// The registry should now record BOTH keys.
+	expected := []string{registeredKid, newKid}
+	sort.Strings(expected)
+	require.Equal(t, expected, fetchRegistryKids(t, svr.URL, prefix))
 }

--- a/launcher_utils/register_namespace_test.go
+++ b/launcher_utils/register_namespace_test.go
@@ -331,3 +331,83 @@ func TestMultiKeysRegistration(t *testing.T) {
 	assert.True(t, isRegistered)
 	assert.Equal(t, svr.URL+"/api/v1.0/registry", registerURL)
 }
+
+// TestRegistrationOldKeyStillInKeyset verifies that when a namespace was registered
+// under a key that is still present in the issuer keyset but is no longer the active
+// (lexicographically-first) key, registerNamespacePrep treats the namespace as
+// already registered instead of failing with "already registered under a different key".
+func TestRegistrationOldKeyStillInKeyset(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	t.Cleanup(func() {
+		server_utils.ResetTestState()
+	})
+
+	tempConfigDir, err := os.MkdirTemp("", "test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempConfigDir)
+
+	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	defer func() { require.NoError(t, egrp.Wait()) }()
+	defer cancel()
+
+	server_utils.ResetTestState()
+	require.NoError(t, param.ConfigDir.Set(tempConfigDir))
+
+	// MockFederationRoot must be called before setting IssuerKeysDirectory because that
+	// function overrides the IssuerKeysDirectory value if not already set.
+	test_utils.MockFederationRoot(t, nil, nil)
+
+	keysDir := filepath.Join(tempConfigDir, "issuer-keys")
+	require.NoError(t, param.IssuerKeysDirectory.Set(keysDir))
+
+	require.NoError(t, param.Registry_DbLocation.Set(""))
+	require.NoError(t, param.Server_DbLocation.Set(filepath.Join(tempConfigDir, "test.sql")))
+	require.NoError(t, config.InitServer(ctx, server_structs.OriginType))
+	require.NoError(t, database.InitServerDatabase(server_structs.RegistryType))
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.Default()
+	registry.RegisterRegistryAPI(engine.Group("/"))
+	svr := httptest.NewServer(engine)
+	defer svr.CloseClientConnections()
+	defer svr.Close()
+
+	require.NoError(t, param.Set(param.Federation_RegistryUrl, svr.URL))
+	require.NoError(t, param.Origin_FederationPrefix.Set("/test123"))
+	require.NoError(t, config.InitServer(ctx, server_structs.OriginType))
+
+	prefix := param.Origin_FederationPrefix.GetString()
+
+	// Register the namespace under the origin's current (and only) issuer key.
+	oldKey, registerURL, isRegistered, err := registerNamespacePrep(ctx, prefix)
+	require.NoError(t, err)
+	require.False(t, isRegistered)
+	require.NoError(t, registerNamespaceImpl(oldKey, prefix, "mock_site_name", registerURL))
+
+	// Add a new key whose filename sorts before the original so it becomes the active
+	// key, while keeping the original (registered) key in the keyset.
+	newKeyPath := filepath.Join(keysDir, "00_active.pem")
+	require.NoError(t, config.GeneratePrivateKey(newKeyPath, elliptic.P256(), false))
+	keysChange, err := config.RefreshKeys()
+	require.NoError(t, err)
+	require.True(t, keysChange)
+
+	// The active key should now differ from the key the namespace was registered under,
+	// and both keys should be present in the keyset.
+	activeKey, err := config.GetIssuerPrivateJWK()
+	require.NoError(t, err)
+	require.NotEqual(t, oldKey.KeyID(), activeKey.KeyID())
+	require.Equal(t, 2, len(config.GetIssuerPrivateKeys()))
+
+	// The active key alone does NOT match the registry entry...
+	status, err := keyIsRegistered(activeKey, registerURL, prefix)
+	require.NoError(t, err)
+	require.Equal(t, keyMismatch, status)
+
+	// ...but registerNamespacePrep must still recognize the namespace as ours because
+	// the old key remains in the keyset. Before the keyset-wide check this returned a
+	// "registered under a different key" error.
+	_, _, isRegistered, err = registerNamespacePrep(ctx, prefix)
+	require.NoError(t, err)
+	require.True(t, isRegistered)
+}

--- a/launcher_utils/register_namespace_test.go
+++ b/launcher_utils/register_namespace_test.go
@@ -352,7 +352,7 @@ func TestRegistrationOldKeyStillInKeyset(t *testing.T) {
 	defer cancel()
 
 	server_utils.ResetTestState()
-	require.NoError(t, param.ConfigDir.Set(tempConfigDir))
+	require.NoError(t, param.ConfigBase.Set(tempConfigDir))
 
 	// MockFederationRoot must be called before setting IssuerKeysDirectory because that
 	// function overrides the IssuerKeysDirectory value if not already set.
@@ -466,7 +466,7 @@ func TestReconcileKeysWhenAlreadyRegistered(t *testing.T) {
 	defer cancel()
 
 	server_utils.ResetTestState()
-	require.NoError(t, param.ConfigDir.Set(tempConfigDir))
+	require.NoError(t, param.ConfigBase.Set(tempConfigDir))
 
 	// MockFederationRoot must be called before setting IssuerKeysDirectory because that
 	// function overrides the IssuerKeysDirectory value if not already set.

--- a/registry/client_commands_test.go
+++ b/registry/client_commands_test.go
@@ -366,6 +366,90 @@ func TestMultiPubKeysRegisteredOnNamespace(t *testing.T) {
 	require.Equal(t, expectedKids, actualKids)
 }
 
+// TestNamespaceRegisterRecordsAllPubKeys verifies that when an origin already holds
+// multiple issuer keys on disk (e.g. keys present before process startup), a single
+// NamespaceRegister call records the public keys of ALL of them in the registry, not
+// just the key used to sign the registration challenge.
+func TestNamespaceRegisterRecordsAllPubKeys(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	server_utils.ResetTestState()
+	t.Cleanup(func() {
+		if r := recover(); r != nil {
+			t.Errorf("Test panicked: %v", r)
+		}
+
+		cancel()
+		assert.NoError(t, egrp.Wait())
+		server_utils.ResetTestState()
+	})
+
+	svr := registryMockup(ctx, t, "NamespaceRegisterRecordsAllPubKeys")
+	defer func() {
+		err := database.ShutdownDB()
+		assert.NoError(t, err)
+		svr.CloseClientConnections()
+		svr.Close()
+	}()
+
+	// Simulate an origin with several issuer keys already present on disk.
+	issuerKeysDir := param.IssuerKeysDirectory.GetString()
+	config.ResetIssuerPrivateKeys()
+	os.RemoveAll(issuerKeysDir)
+	require.Len(t, config.GetIssuerPrivateKeys(), 0)
+
+	for i := 0; i < 3; i++ {
+		_, err := config.GeneratePEM(issuerKeysDir)
+		require.NoError(t, err)
+	}
+	_, err := config.RefreshKeys()
+	require.NoError(t, err)
+
+	allKeys := config.GetIssuerPrivateKeys()
+	require.Len(t, allKeys, 3)
+
+	// Deliberately sign with a key that is NOT the current issuer key, so the test
+	// fails if NamespaceRegister does not place the signing key at index 0 (the
+	// registry verifies proof-of-possession against the first key only).
+	currentKey, err := config.GetIssuerPrivateJWK()
+	require.NoError(t, err)
+	var signingKey jwk.Key
+	for kid, key := range allKeys {
+		if kid != currentKey.KeyID() {
+			signingKey = key
+			break
+		}
+	}
+	require.NotNil(t, signingKey)
+	require.NotEqual(t, currentKey.KeyID(), signingKey.KeyID())
+
+	prefix := "/mascot/bucky"
+	err = registry_client.NamespaceRegister(signingKey, svr.URL+"/api/v1.0/registry", "", prefix, "mock_site_name")
+	require.NoError(t, err)
+
+	// The registry should have recorded the public keys of every local issuer key.
+	ns, err := getRegistrationByPrefix(prefix)
+	require.NoError(t, err)
+
+	expectedKids := make([]string, 0, len(allKeys))
+	for kid := range allKeys {
+		expectedKids = append(expectedKids, kid)
+	}
+	sort.Strings(expectedKids)
+
+	actualKids, err := getSortedKids(ctx, ns.Pubkey)
+	require.NoError(t, err)
+	require.Equal(t, expectedKids, actualKids)
+
+	// The signing key must be stored at index 0 so the registry's proof-of-possession
+	// check (which inspects only the first key) succeeds.
+	storedSet, err := jwk.Parse([]byte(ns.Pubkey))
+	require.NoError(t, err)
+	firstKey, ok := storedSet.Key(0)
+	require.True(t, ok)
+	require.Equal(t, signingKey.KeyID(), firstKey.KeyID())
+}
+
 func TestRegistryKeyChainingOSDF(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	server_utils.ResetTestState()

--- a/registry/registry_client/registry_client.go
+++ b/registry/registry_client/registry_client.go
@@ -107,20 +107,39 @@ func NamespaceRegisterWithIdentity(privateKey jwk.Key, namespaceRegistryEndpoint
 }
 
 func NamespaceRegister(privateKey jwk.Key, namespaceRegistryEndpoint string, accessToken string, prefix string, siteName string) error {
-	publicKey, err := privateKey.PublicKey()
+	// Advertise every issuer key this server holds so the registry records the full
+	// set in a single registration (covers keys already on disk before startup).
+	allKeys, err := config.GetIssuerPublicJWKS()
 	if err != nil {
-		return errors.Wrapf(err, "failed to generate public key for namespace registration")
+		return errors.Wrap(err, "failed to get issuer public JWKS")
 	}
-	err = jwk.AssignKeyID(publicKey)
+
+	// The registry verifies proof-of-possession against the key at index 0 only
+	// (see registry.validateJwks), but GetIssuerPublicJWKS returns keys in
+	// non-deterministic map-iteration order. Rebuild the set so the key we sign the
+	// challenge with is first.
+	signingPub, err := privateKey.PublicKey()
 	if err != nil {
-		return errors.Wrap(err, "failed to assign key ID to public key")
+		return errors.Wrap(err, "failed to derive signing public key")
 	}
-	if err = publicKey.Set("alg", "ES256"); err != nil {
-		return errors.Wrap(err, "failed to assign signature algorithm to public key")
+	if err = jwk.AssignKeyID(signingPub); err != nil {
+		return errors.Wrap(err, "failed to assign key ID to signing public key")
+	}
+	if err = signingPub.Set(jwk.AlgorithmKey, "ES256"); err != nil {
+		return errors.Wrap(err, "failed to assign algorithm to signing public key")
 	}
 	keySet := jwk.NewSet()
-	if err = keySet.AddKey(publicKey); err != nil {
-		return errors.Wrap(err, "failed to add public key to new JWKS")
+	if err = keySet.AddKey(signingPub); err != nil {
+		return errors.Wrap(err, "failed to add signing public key to JWKS")
+	}
+	for i := 0; i < allKeys.Len(); i++ {
+		key, ok := allKeys.Key(i)
+		if !ok || key.KeyID() == signingPub.KeyID() {
+			continue // skip the signing key, already at index 0
+		}
+		if err = keySet.AddKey(key); err != nil {
+			return errors.Wrapf(err, "failed to add public key %s to JWKS", key.KeyID())
+		}
 	}
 
 	if log.IsLevelEnabled(log.DebugLevel) {

--- a/registry/registry_client/registry_client.go
+++ b/registry/registry_client/registry_client.go
@@ -107,13 +107,23 @@ func NamespaceRegisterWithIdentity(privateKey jwk.Key, namespaceRegistryEndpoint
 }
 
 func NamespaceRegister(privateKey jwk.Key, namespaceRegistryEndpoint string, accessToken string, prefix string, siteName string) error {
-	publicKey, err := privateKey.PublicKey()
+	// Advertise every issuer key this server holds so the registry records the full
+	// set in a single registration (covers keys already on disk before startup).
+	allKeys, err := config.GetIssuerPublicJWKS()
 	if err != nil {
-		return errors.Wrapf(err, "failed to generate public key for namespace registration")
+		return errors.Wrap(err, "failed to get issuer public JWKS")
 	}
-	err = jwk.AssignKeyID(publicKey)
+
+	// The registry verifies proof-of-possession against the key at index 0 only
+	// (see registry.validateJwks), but GetIssuerPublicJWKS returns keys in
+	// non-deterministic map-iteration order. Rebuild the set so the key we sign the
+	// challenge with is first.
+	signingPub, err := privateKey.PublicKey()
 	if err != nil {
-		return errors.Wrap(err, "failed to assign key ID to public key")
+		return errors.Wrap(err, "failed to derive signing public key")
+	}
+	if err = jwk.AssignKeyID(signingPub); err != nil {
+		return errors.Wrap(err, "failed to assign key ID to signing public key")
 	}
 	alg, err := config.SigningAlgorithmForJWK(privateKey)
 	if err != nil {
@@ -123,8 +133,17 @@ func NamespaceRegister(privateKey jwk.Key, namespaceRegistryEndpoint string, acc
 		return errors.Wrap(err, "failed to assign signature algorithm to public key")
 	}
 	keySet := jwk.NewSet()
-	if err = keySet.AddKey(publicKey); err != nil {
-		return errors.Wrap(err, "failed to add public key to new JWKS")
+	if err = keySet.AddKey(signingPub); err != nil {
+		return errors.Wrap(err, "failed to add signing public key to JWKS")
+	}
+	for i := 0; i < allKeys.Len(); i++ {
+		key, ok := allKeys.Key(i)
+		if !ok || key.KeyID() == signingPub.KeyID() {
+			continue // skip the signing key, already at index 0
+		}
+		if err = keySet.AddKey(key); err != nil {
+			return errors.Wrapf(err, "failed to add public key %s to JWKS", key.KeyID())
+		}
 	}
 
 	if log.IsLevelEnabled(log.DebugLevel) {

--- a/registry/registry_client/registry_client.go
+++ b/registry/registry_client/registry_client.go
@@ -129,7 +129,7 @@ func NamespaceRegister(privateKey jwk.Key, namespaceRegistryEndpoint string, acc
 	if err != nil {
 		return errors.Wrap(err, "failed to determine signature algorithm for public key")
 	}
-	if err = publicKey.Set("alg", alg.String()); err != nil {
+	if err = signingPub.Set("alg", alg.String()); err != nil {
 		return errors.Wrap(err, "failed to assign signature algorithm to public key")
 	}
 	keySet := jwk.NewSet()

--- a/registry/registry_validation.go
+++ b/registry/registry_validation.go
@@ -166,13 +166,10 @@ func validateJwks(jwksStr string) (jwk.Key, error) {
 		log.Debugln("Client JWKS as seen by the registry server:", string(jsonbuf))
 	}
 
-	/*
-	 * TODO: This section makes the assumption that the incoming jwks only contains a single
-	 *       key, a property that is enforced by the client at the origin. Eventually we need
-	 *       to support the addition of other keys in the jwks stored for the origin. There is
-	 *       a similar TODO listed in client_commands.go, as the choices made there mirror the
-	 *       choices made here.
-	 */
+	// The submitted JWKS may contain multiple keys, but we force the client to
+	// place the key it used to sign the key-sign challenge at index 0. We verify
+	// proof-of-possession against that key; any remaining keys are recorded as
+	// additional valid issuer keys for the namespace.
 	key, exists := clientJwks.Key(0)
 	if !exists {
 		return nil, errors.New("There was no key at index 0 in the request pubKey's JWKS. Something is wrong")


### PR DESCRIPTION
An origin/cache only ever registered its active (lexicographically-first/smallest) issuer key. Additional keys already present in the issuer-keys directory before startup were never recorded by the registry, because initial registration sends a single key and the key-change-driven update only fires when a *new* key (a key with different key id) is later detected.

This PR records the full issuer keyset across three paths:

1. Initial registration: `NamespaceRegister` now advertises the full set from `GetIssuerPublicJWKS` so the Registry records every local issuer key in one registration. The signing key is forced to index 0, since `GetIssuerPublicJWKS` returns keys in non-deterministic map order and the registry verifies proof-of-possession against the first key only (`registry.validateJwks`). `validateJwks` keeps checking index-0 key for backward compatibility.
2. Startup match check: `registerNamespacePrep` now checks every key in the keyset and only fails if none match, fixing the spurious "already registered under a different key" error when the active key differs from the registered one. (The key used to register this namespace is no longer the active signing key, but still in the keys directory).
3. Restart reconcile: once a namespace is registered, initial registration is skipped, so keys added while the server was down were never pushed. `RegisterNamespaceWithRetry` now reconciles by pushing the full keyset via the update endpoint (a no-op when unchanged).