### PR TITLE
Add built-in log rotation for file logging

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -42,7 +42,12 @@ var cliExecErrorHook func(err error)
 //go:generate go run -tags server . generate-docs docs/app/commands-reference/pelican-server
 func main() {
 	logging.SetupLogBuffering()
+	// On a panic (or any unwind), flip the log writer to synchronous mode first
+	// so buffered lines are flushed and late lines reach the log file, then run
+	// the normal flush. Defers run LIFO, so EnterSyncMode (registered last) runs
+	// before FlushLogs.
 	defer logging.FlushLogs(false)
+	defer logging.EnterSyncMode()
 	if len(os.Args) > 1 && os.Args[1] == "generate-docs" {
 		outputDir := "docs/app/commands-reference"
 		if len(os.Args) > 2 {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,14 +55,24 @@ func main() {
 		}
 		err := generateCLIDocs(outputDir)
 		if err != nil {
-			os.Exit(1)
+			exitWithFlush(1)
 		}
 		return
 	}
 	err := handleCLI(os.Args)
 	if err != nil {
-		os.Exit(1)
+		exitWithFlush(1)
 	}
+}
+
+// exitWithFlush terminates the process after draining the log writer. The
+// deferred flush in main covers a normal return and a panic unwind, but
+// os.Exit runs no defers, so every explicit exit has to drain for itself or
+// lose whatever is still buffered -- including the line explaining the exit.
+func exitWithFlush(code int) {
+	logging.EnterSyncMode()
+	logging.FlushLogs(false)
+	os.Exit(code)
 }
 
 func handleCLI(args []string) error {
@@ -94,7 +104,7 @@ func handleCLI(args []string) error {
 		cliExecErrorHook(err)
 	}
 	if err != nil {
-		os.Exit(1)
+		exitWithFlush(1)
 	}
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -109,13 +109,10 @@ var egrpPostHandler func(error) (bool, error)
 func Execute() error {
 	egrp, egrpCtx := errgroup.WithContext(context.Background())
 	ctx := context.WithValue(egrpCtx, config.EgrpKey, egrp)
-	// Register the errgroup with the logging subsystem so the
-	// asynchronous log writer stops when the context is cancelled.
+	// Register the errgroup with the logging subsystem so the asynchronous log
+	// writer (and its compression worker) run under the errgroup and stop when
+	// the context is cancelled.
 	logging.SetErrgroup(ctx, egrp)
-	// Wait for any in-flight background log rotation to finish before the
-	// process exits, so a graceful shutdown does not abandon a compression
-	// mid-write.
-	defer logging.AwaitCompression()
 	exeErr := rootCmd.ExecuteContext(ctx)
 	if exeErr != nil {
 		log.Debugln("Fatal error occurred at the start of the program. Cleanup started:", exeErr)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -109,10 +109,20 @@ var egrpPostHandler func(error) (bool, error)
 func Execute() error {
 	egrp, egrpCtx := errgroup.WithContext(context.Background())
 	ctx := context.WithValue(egrpCtx, config.EgrpKey, egrp)
+	// Register the errgroup with the logging subsystem so the asynchronous log
+	// writer (and its compression worker) run under the errgroup and stop when
+	// the context is cancelled.
+	logging.SetErrgroup(ctx, egrp)
 	exeErr := rootCmd.ExecuteContext(ctx)
 	if exeErr != nil {
 		log.Debugln("Fatal error occurred at the start of the program. Cleanup started:", exeErr)
 	}
+	// Stop the async log writer's drain goroutine and flip it to synchronous mode
+	// so egrp.Wait below does not block on it (notably for one-shot commands whose
+	// context is never cancelled) and any log lines emitted during the remaining
+	// shutdown go straight to the log file rather than being buffered. It blocks
+	// only until the writer has flushed and exited.
+	logging.EnterSyncMode()
 	// Wait until all goroutines in errgroup finish their clean up
 	egrpErr := egrp.Wait()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -109,10 +109,22 @@ var egrpPostHandler func(error) (bool, error)
 func Execute() error {
 	egrp, egrpCtx := errgroup.WithContext(context.Background())
 	ctx := context.WithValue(egrpCtx, config.EgrpKey, egrp)
+	// Register the errgroup with the logging subsystem so the asynchronous log
+	// writer (if file logging is enabled) runs as an errgroup-managed goroutine.
+	logging.SetErrgroup(ctx, egrp)
 	exeErr := rootCmd.ExecuteContext(ctx)
 	if exeErr != nil {
 		log.Debugln("Fatal error occurred at the start of the program. Cleanup started:", exeErr)
 	}
+	// Signal the async log writer to drain and switch to synchronous mode. The
+	// writer goroutine already does this on its own when the context is cancelled
+	// (e.g. on a signal-driven server shutdown); this call covers the case where
+	// the command returned without the context being cancelled (notably one-shot
+	// commands with file logging), so egrp.Wait below does not block on the
+	// still-running writer goroutine. It also guarantees any log lines emitted
+	// during the remaining shutdown go straight to the log file rather than being
+	// buffered. It blocks only until the writer has flushed and exited.
+	logging.EnterSyncMode()
 	// Wait until all goroutines in errgroup finish their clean up
 	egrpErr := egrp.Wait()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -109,21 +109,22 @@ var egrpPostHandler func(error) (bool, error)
 func Execute() error {
 	egrp, egrpCtx := errgroup.WithContext(context.Background())
 	ctx := context.WithValue(egrpCtx, config.EgrpKey, egrp)
-	// Register the errgroup with the logging subsystem so the asynchronous log
-	// writer (if file logging is enabled) runs as an errgroup-managed goroutine.
+	// Register the errgroup with the logging subsystem so the
+	// asynchronous log writer stops when the context is cancelled.
 	logging.SetErrgroup(ctx, egrp)
+	// Wait for any in-flight background log rotation to finish before the
+	// process exits, so a graceful shutdown does not abandon a compression
+	// mid-write.
+	defer logging.AwaitCompression()
 	exeErr := rootCmd.ExecuteContext(ctx)
 	if exeErr != nil {
 		log.Debugln("Fatal error occurred at the start of the program. Cleanup started:", exeErr)
 	}
-	// Signal the async log writer to drain and switch to synchronous mode. The
-	// writer goroutine already does this on its own when the context is cancelled
-	// (e.g. on a signal-driven server shutdown); this call covers the case where
-	// the command returned without the context being cancelled (notably one-shot
-	// commands with file logging), so egrp.Wait below does not block on the
-	// still-running writer goroutine. It also guarantees any log lines emitted
-	// during the remaining shutdown go straight to the log file rather than being
-	// buffered. It blocks only until the writer has flushed and exited.
+	// Stop the async log writer's drain goroutine and flip it to synchronous mode
+	// so egrp.Wait below does not block on it (notably for one-shot commands whose
+	// context is never cancelled) and any log lines emitted during the remaining
+	// shutdown go straight to the log file rather than being buffered. It blocks
+	// only until the writer has flushed and exited.
 	logging.EnterSyncMode()
 	// Wait until all goroutines in errgroup finish their clean up
 	egrpErr := egrp.Wait()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -107,6 +107,13 @@ func (i *uint16Value) String() string { return strconv.FormatUint(uint64(*i), 10
 var egrpPostHandler func(error) (bool, error)
 
 func Execute() error {
+	// log.Fatal writes the entry and then calls os.Exit, which runs no defers.
+	// Without this the fatal line -- the one explaining why the process died --
+	// sits in the async writer's buffer and is never written. logrus runs exit
+	// handlers after the entry has been handed to the writer, so the flush sees
+	// it. Registered before any command can log.
+	log.RegisterExitHandler(logging.EnterSyncMode)
+
 	egrp, egrpCtx := errgroup.WithContext(context.Background())
 	ctx := context.WithValue(egrpCtx, config.EgrpKey, egrp)
 	// Register the errgroup with the logging subsystem so the asynchronous log

--- a/config/config.go
+++ b/config/config.go
@@ -2134,6 +2134,9 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 	// be done in sequence because the web UI may change the log location.
 	logging.FlushLogs(true)
 
+	// The in-memory log ring buffer is server-only.
+	StartLogRingBuffer(ctx)
+
 	runtimeDir, cleanupRuntimeDir, err := ensureRuntimeDir(viper.GetViper())
 	if err != nil {
 		return err
@@ -2771,6 +2774,11 @@ func ClearServerAds() {
 
 // This function resets most states for test cases, including 1. viper settings, 2. preferred prefix, 3. transport object, 4. Federation metadata back to their default
 func ResetConfig() {
+	// Detach the in-memory log ring buffer (hook + compression worker) so a
+	// subsequent InitServer installs a fresh one and tests don't accumulate
+	// hooks or leak the compression goroutine across cases.
+	StopLogRingBuffer()
+
 	// Close any open log files and reset logger output
 	logging.CloseLogger()
 	if err := param.Reset(); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -1733,7 +1733,13 @@ func ensureRuntimeDir(v *viper.Viper) (string, bool, error) {
 		return runtimeDir, false, nil
 	}
 
-	runtimeDir, err := os.MkdirTemp("", "pelican-xrootd-*")
+	// Base directory for the MkdirTemp'd runtime dir. Empty means "use
+	// os.TempDir()" (the standard behavior). Overridden per-OS in
+	// config_default.go: macOS's $TMPDIR resolves to a deeply-nested
+	// /var/folders/xx/yy/T/ path that eats most of the 104-byte AF_UNIX
+	// socket-path budget before XRootD gets to append "xrootd/<role>/.xrd/",
+	// so darwin steers this to a short alternate ("/tmp") instead.
+	runtimeDir, err := os.MkdirTemp(osShortRuntimeTempBase(), "pelican-xrootd-*")
 	if err != nil {
 		return "", false, errors.Wrap(err, "Failed to create temporary runtime directory for Pelican")
 	}
@@ -1862,10 +1868,25 @@ func SetServerDefaults(v *viper.Viper) error {
 	}
 
 	// Create runtime directory (side effect: creates dirs on filesystem).
-	_, _, err := ensureRuntimeDir(v)
+	runtimeDir, _, err := ensureRuntimeDir(v)
 	if err != nil {
 		return err
 	}
+
+	// On platforms where the generated $XDG_RUNTIME_DIR-derived defaults
+	// expanded to a broken "/pelican/..." root path (macOS or Windows
+	// without XDG_RUNTIME_DIR set), rebase those sub-paths so they live
+	// under the RuntimeDir we just picked. This runs AFTER
+	// ensureRuntimeDir so it can piggyback on whatever cleanup
+	// behavior that function attached (MkdirTemp'd runtime dirs get
+	// scheduled for shutdown cleanup by cleanupDirOnShutdown; per-user
+	// XDG dirs don't need cleanup at all). Linux with a working
+	// XDG_RUNTIME_DIR sees no broken paths and this is a no-op.
+	//
+	// Called from SetServerDefaults (not SetBaseDefaultsInConfig) so the
+	// client, which does not need any of these paths and does not call
+	// ensureRuntimeDir, never even computes the alternate locations.
+	ApplyOSDefaultsOverride(v, runtimeDir)
 	// When Lotman manages the cache's space, xrootd's pfc.diskusage requires the
 	// "files" purge band (base < nominal < max). Rather than make operators hand-size
 	// three more values just to turn Lotman on, default them as percentages of total

--- a/config/config_default.go
+++ b/config/config_default.go
@@ -23,11 +23,104 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/spf13/viper"
 
 	"github.com/pelicanplatform/pelican/param"
 )
+
+// osShortRuntimeTempBase returns the base directory ensureRuntimeDir should
+// hand to os.MkdirTemp on this OS. Empty means "let os.MkdirTemp default to
+// os.TempDir()".
+//
+// On darwin, $TMPDIR is a per-user path like
+// /var/folders/xx/yyyyyyyyyyyyyy/T/, which by itself eats ~35 bytes of the
+// 104-byte AF_UNIX socket-path limit. XRootD's admin path adds another
+// "pelican-xrootd-<random>/xrootd/<role>/<role>/.xrd/socket" on top, going
+// past the limit. Use /tmp instead so the runtime tree is smaller.
+//
+// On Windows, no such AF_UNIX limit applies and os.TempDir() is fine.
+func osShortRuntimeTempBase() string {
+	if runtime.GOOS == "darwin" {
+		return "/tmp"
+	}
+	return ""
+}
+
+// ApplyOSDefaultsOverride rebases the xrootd runtime sub-path defaults when
+// the generated $XDG_RUNTIME_DIR env var is empty, which leaves config paths
+// starting with "/pelican/...".
+//
+//   - client commands never call this and don't compute any of these paths;
+//   - the server picks runtimeDir first (whether from XDG, MkdirTemp, or an
+//     operator-configured value), and this function just re-anchors sub-path
+//     defaults to that same runtimeDir.
+//
+// A sub-path is only rewritten when both:
+//
+//  1. its value's source is SourceDefault (i.e. the operator did not set
+//     it themselves).
+//  2. XDG_RUNTIME_DIR is empty in the process environment. If XDG_RUNTIME_DIR
+//     is set then we use it.
+//
+// Cache.StorageLocation is intentionally NOT anchored under runtimeDir when
+// runtimeDir is ephemeral -- the cache backing store must survive restarts.
+// On non-Linux we redirect it to os.UserCacheDir()/pelican/cache instead.
+func ApplyOSDefaultsOverride(v *viper.Viper, runtimeDir string) {
+	if runtimeDir == "" {
+		return
+	}
+	if os.Getenv("XDG_RUNTIME_DIR") != "" {
+		return
+	}
+	st := GetSourceTracker()
+	isDefaultSourced := func(paramName string) bool {
+		src, has := st.Get(strings.ToLower(paramName))
+		return !has || src.Type == SourceDefault
+	}
+	rebase := func(paramName, newValue string) {
+		// Consult the SourceTracker: only overwrite when the current
+		// value is default-sourced.
+		if !isDefaultSourced(paramName) {
+			return
+		}
+		v.SetDefault(paramName, newValue)
+	}
+	// Sub-paths that belong under the ephemeral runtime dir. AF_UNIX socket
+	// paths are 104 bytes on macOS, so keep the layout shallow.
+	rebase(param.Origin_RunLocation.GetName(), filepath.Join(runtimeDir, "xrootd", "origin"))
+	rebase(param.Cache_RunLocation.GetName(), filepath.Join(runtimeDir, "xrootd", "cache"))
+	rebase(param.LocalCache_RunLocation.GetName(), filepath.Join(runtimeDir, "localcache"))
+	rebase(param.Origin_GlobusConfigLocation.GetName(), filepath.Join(runtimeDir, "xrootd", "origin", "globus"))
+
+	// Persistent cache backing store: os.UserCacheDir on macOS resolves to
+	// ~/Library/Caches, on Windows to %LocalAppData%. Fall back to the
+	// runtime dir if the OS refuses to tell us a persistent location.
+	persistCache := filepath.Join(runtimeDir, "cache")
+	if cache, err := os.UserCacheDir(); err == nil {
+		persistCache = filepath.Join(cache, "pelican", "cache")
+	}
+	rebase(param.Cache_StorageLocation.GetName(), persistCache)
+
+	// Cache.StorageLocation feeds three interpolated defaults that
+	// ApplyDerivedDefaults resolved earlier from the collapsed
+	// "/pelican/cache" value: DataLocations, MetaLocations, and
+	// NamespaceLocation. Re-derive them from the just-rewritten
+	// Cache.StorageLocation so the whole cache tree lives under the
+	// same rebased root. Same SourceTracker guard as above.
+	// (${Cache.StorageLocation}/{data,meta,namespace}).
+	if isDefaultSourced(param.Cache_DataLocations.GetName()) {
+		v.SetDefault(param.Cache_DataLocations.GetName(), []string{filepath.Join(persistCache, "data")})
+	}
+	if isDefaultSourced(param.Cache_MetaLocations.GetName()) {
+		v.SetDefault(param.Cache_MetaLocations.GetName(), []string{filepath.Join(persistCache, "meta")})
+	}
+	if isDefaultSourced(param.Cache_NamespaceLocation.GetName()) {
+		v.SetDefault(param.Cache_NamespaceLocation.GetName(), filepath.Join(persistCache, "namespace"))
+	}
+}
 
 func InitServerOSDefaults(v *viper.Viper) error {
 	// Windows / Mac don't have a default set of CAs installed at

--- a/config/config_linux.go
+++ b/config/config_linux.go
@@ -28,6 +28,21 @@ import (
 	"github.com/pelicanplatform/pelican/param"
 )
 
+// ApplyOSDefaultsOverride is a no-op on Linux. The generated defaults in
+// parameter_defaults.go -- /run/pelican/... when root, $XDG_RUNTIME_DIR/...
+// when unprivileged -- expand correctly under systemd (which always
+// populates XDG_RUNTIME_DIR for logged-in users) and under root. The
+// non-Linux implementation rebases sub-paths whose $XDG_RUNTIME_DIR
+// expansion collapsed to "/pelican/..." when the env var is empty; see
+// config_default.go for the details.
+func ApplyOSDefaultsOverride(v *viper.Viper, runtimeDir string) {}
+
+// osShortRuntimeTempBase returns the empty string on Linux. Linux's
+// os.TempDir() is /tmp, which is already short enough for AF_UNIX socket
+// paths to fit under the 108-byte limit even with XRootD's admin-path
+// suffix. See config_default.go for the darwin override.
+func osShortRuntimeTempBase() string { return "" }
+
 func InitServerOSDefaults(v *viper.Viper) error {
 	// For Linux, even if we have well-known system CAs, we don't want to
 	// use them, because we want to always generate our own CA if Server_TLSCertificateChain (host certificate chain)

--- a/config/log_buffer.go
+++ b/config/log_buffer.go
@@ -27,6 +27,7 @@ import (
 	"math"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/pierrec/lz4/v4"
 	"github.com/pkg/errors"
@@ -57,6 +58,12 @@ type logRingBatch struct {
 	State     LogRingBatchState
 	Payload   []byte // LZ4-compressed or raw depending on State
 	RawSize   int    // decompressed byte count (matches on-disk text size)
+	// FirstTime and LastTime are the logrus entry times of the batch's first
+	// and last lines. Recorded at write time from the entry itself rather than
+	// parsed back out of the formatted text, so reporting the buffer's span
+	// costs nothing and never has to decompress a payload.
+	FirstTime time.Time
+	LastTime  time.Time
 }
 
 // lastSeq is the sequence number of the last line in the batch (inclusive).
@@ -91,6 +98,11 @@ type LogRingBuffer struct {
 	pendingFirstSeq int64 // seq of the first line in the current pending buffer (0 when empty)
 	nextSeq         int64 // seq to assign to the next incoming line
 	formatter       log.Formatter
+	// Entry times of the first and last line sitting in the pending buffer.
+	// Together with the batches' own times these give the span of everything
+	// held; see Span.
+	pendingFirstTime time.Time
+	pendingLastTime  time.Time
 
 	// The compression worker owns compressQueue exclusively; producers use a
 	// non-blocking select-with-default so a slow compressor never blocks the
@@ -356,6 +368,18 @@ func (b *LogRingBuffer) Fire(entry *log.Entry) error {
 	if b.pendingCount == 0 {
 		b.pendingFirstSeq = seq
 	}
+	// Only a dated entry moves the pending window's ends. logrus stamps every
+	// entry it produces, but a hand-built one carries the zero value, and
+	// letting that through would hand Span a zero end -- suppressing the whole
+	// reported range over one undated line. finalizeLocked clears both fields
+	// with the rest of the pending state, so the zero value here always means
+	// "nothing dated in this window yet".
+	if !entry.Time.IsZero() {
+		if b.pendingFirstTime.IsZero() {
+			b.pendingFirstTime = entry.Time
+		}
+		b.pendingLastTime = entry.Time
+	}
 	b.pending.Write(line)
 	b.pendingCount++
 
@@ -422,10 +446,14 @@ func (b *LogRingBuffer) finalizeLocked() *logRingBatch {
 		State:     logRingBatchRaw,
 		Payload:   payload,
 		RawSize:   len(payload),
+		FirstTime: b.pendingFirstTime,
+		LastTime:  b.pendingLastTime,
 	}
 	b.pending.Reset()
 	b.pendingCount = 0
 	b.pendingFirstSeq = 0
+	b.pendingFirstTime = time.Time{}
+	b.pendingLastTime = time.Time{}
 	return batch
 }
 
@@ -491,12 +519,18 @@ func (b *LogRingBuffer) compressOne(batch *logRingBatch) {
 	// reader that holds the original pointer (with or without the mutex)
 	// sees a consistent Raw view -- fields never observe a partial
 	// update.
+	// Every field except State and Payload is carried across verbatim. A field
+	// left out here is silently lost the moment a batch is compressed -- which
+	// is the normal path, milliseconds after it is sealed -- so anything added
+	// to logRingBatch has to be added here too.
 	replacement := &logRingBatch{
 		FirstSeq:  batch.FirstSeq,
 		LineCount: batch.LineCount,
 		State:     logRingBatchCompressed,
 		Payload:   compressed,
 		RawSize:   batch.RawSize,
+		FirstTime: batch.FirstTime,
+		LastTime:  batch.LastTime,
 	}
 
 	b.mu.Lock()
@@ -886,6 +920,58 @@ func skipNLines(buf []byte, n int) []byte {
 	return buf
 }
 
+// Span returns the entry times of the oldest and newest lines the buffer
+// currently holds, and false when it holds nothing datable. This is what a
+// download of the buffer would cover, which is strictly more than any one
+// reader has necessarily paged in: it is the answer to "what is in the file I
+// am about to download", so it is reported from the buffer's own extent rather
+// than derived from a tail response.
+//
+// Both ends read off the ends of what is held -- the oldest surviving batch
+// and, ahead of it, the pending buffer -- so this needs no decompression and
+// no scan of the contents. The loops stop on their first iteration for any
+// entry that carried a time, which is every entry logrus itself produces; they
+// only step further for an entry constructed without one, so that a single
+// undated line at one end does not blank the whole range.
+//
+// Time is recorded per batch, so this is unaffected by eviction: the oldest
+// batch is simply whichever one survived.
+func (b *LogRingBuffer) Span() (oldest, newest time.Time, ok bool) {
+	if b == nil {
+		return time.Time{}, time.Time{}, false
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for _, batch := range b.batches {
+		if !batch.FirstTime.IsZero() {
+			oldest = batch.FirstTime
+			break
+		}
+	}
+	for i := len(b.batches) - 1; i >= 0; i-- {
+		if !b.batches[i].LastTime.IsZero() {
+			newest = b.batches[i].LastTime
+			break
+		}
+	}
+	// Lines not yet sealed into a batch are held too, and on a quiet server
+	// they may be everything there is. They are newer than every batch, so
+	// they always win the newest end.
+	if b.pendingCount > 0 {
+		if oldest.IsZero() {
+			oldest = b.pendingFirstTime
+		}
+		if !b.pendingLastTime.IsZero() {
+			newest = b.pendingLastTime
+		}
+	}
+	if oldest.IsZero() || newest.IsZero() {
+		return time.Time{}, time.Time{}, false
+	}
+	return oldest, newest, true
+}
+
 // StoredBytes returns the current byte total across all held batches. Not
 // part of the public API; test-only.
 func (b *LogRingBuffer) StoredBytes() int {
@@ -906,6 +992,25 @@ func (b *LogRingBuffer) BatchCount() int {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return len(b.batches)
+}
+
+// CompressedBatchCount returns how many held batches have been through the
+// compression worker. Lets a test wait for compression to actually happen
+// rather than sleep, which matters because compressOne replaces the batch it
+// compresses and so has to carry every field across. Test-only.
+func (b *LogRingBuffer) CompressedBatchCount() int {
+	if b == nil {
+		return 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	n := 0
+	for _, batch := range b.batches {
+		if batch.State == logRingBatchCompressed {
+			n++
+		}
+	}
+	return n
 }
 
 // PendingLineCount returns the number of lines currently in the pending

--- a/config/log_buffer.go
+++ b/config/log_buffer.go
@@ -216,7 +216,12 @@ func StartLogRingBuffer(ctx context.Context) {
 	go buf.compressLoop()
 
 	globalLogBuffer.Store(buf)
+	// Installing the hook mutates the same global set SetLogging and
+	// removeLogRingBufferHook rebuild; take the lock they take so an
+	// install cannot be dropped by a rebuild running alongside it.
+	globalTransformMu.Lock()
 	log.AddHook(&logRingBufferHook{buf: buf})
+	globalTransformMu.Unlock()
 }
 
 // StopLogRingBuffer detaches the ring buffer's hook from logrus, marks the
@@ -246,8 +251,25 @@ func StopLogRingBuffer() {
 // logger while preserving all other hooks. logrus exposes no per-hook removal,
 // so we rebuild the hook set without ours (mirrors logging.removeBufferedHook).
 func removeLogRingBufferHook() {
-	oldHooks := log.StandardLogger().ReplaceHooks(log.LevelHooks{})
-	filtered := make(log.LevelHooks)
+	// Serialize against the other rebuilders of this set (SetLogging,
+	// initFilterLogging): each of them is a read-modify-write on the same
+	// global, so two running at once lose whichever finishes first.
+	globalTransformMu.Lock()
+	defer globalTransformMu.Unlock()
+
+	// logrus offers no way to read the hook set without swapping something
+	// in, and while the empty set is installed the logger has no hooks at
+	// all -- with output going to io.Discard, entries emitted in that
+	// window are not merely unbuffered, they are lost. Put a copy back at
+	// once so the gap spans no work, then install the filtered set in one
+	// further atomic swap. The copy matters: the map that comes back from
+	// ReplaceHooks is read below, and reinstalling that same map would
+	// leave it being read here while logrus writes to it.
+	logger := log.StandardLogger()
+	oldHooks := logger.ReplaceHooks(log.LevelHooks{})
+	logger.ReplaceHooks(copyLevelHooks(oldHooks))
+
+	filtered := make(log.LevelHooks, len(oldHooks))
 	for lvl, hooks := range oldHooks {
 		for _, h := range hooks {
 			if _, ok := h.(*logRingBufferHook); ok {
@@ -256,7 +278,17 @@ func removeLogRingBufferHook() {
 			filtered[lvl] = append(filtered[lvl], h)
 		}
 	}
-	log.StandardLogger().ReplaceHooks(filtered)
+	logger.ReplaceHooks(filtered)
+}
+
+// copyLevelHooks returns a hook set that shares no map or slice storage with
+// the original, so the two can be handed to different owners.
+func copyLevelHooks(src log.LevelHooks) log.LevelHooks {
+	dst := make(log.LevelHooks, len(src))
+	for lvl, hooks := range src {
+		dst[lvl] = append([]log.Hook(nil), hooks...)
+	}
+	return dst
 }
 
 // logRingBufferHook is the logrus hook that pumps entries into the buffer.

--- a/config/log_buffer.go
+++ b/config/log_buffer.go
@@ -1,0 +1,784 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"io"
+	"math"
+	"sync"
+	"sync/atomic"
+
+	"github.com/pierrec/lz4/v4"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/utils"
+)
+
+// LogRingBatchState marks whether a batch's payload has been LZ4-compressed
+// yet. Uncompressed batches occur when the compression worker is behind the
+// producer -- see LogRingBuffer.finalize.
+type LogRingBatchState int
+
+const (
+	logRingBatchRaw        LogRingBatchState = iota // payload is stored uncompressed
+	logRingBatchCompressed                          // payload is stored as LZ4 frame
+)
+
+// logRingBatch is one immutable slab of log lines held by LogRingBuffer.
+// FirstSeq is the sequence number of the first line in the batch; combined
+// with LineCount it identifies the seq range [FirstSeq, FirstSeq+LineCount)
+// covered by the batch. The API layer never sees these -- callers use the
+// TailSince cursor (an opaque seq) instead.
+type logRingBatch struct {
+	FirstSeq  int64
+	LineCount int
+	State     LogRingBatchState
+	Payload   []byte // LZ4-compressed or raw depending on State
+	RawSize   int    // decompressed byte count (matches on-disk text size)
+}
+
+// lastSeq is the sequence number of the last line in the batch (inclusive).
+func (b *logRingBatch) lastSeq() int64 {
+	return b.FirstSeq + int64(b.LineCount) - 1
+}
+
+// LogRingBuffer captures a bounded window of recent log lines in memory so
+// a server admin can read them back through the web UI or the log-read API
+// without having to shell in and tail the log file. The buffer is only
+// activated inside a server process and it is entirely off when the client
+// is running standalone.
+//
+// Every line is assigned a monotonic seq. Consumers page through the buffer
+// with TailSince(since): everything with seq > since is returned. seq is
+// opaque to consumers; the buffer's internal layout (batches, pending
+// buffer, LZ4 compression) is not exposed.
+type LogRingBuffer struct {
+	// instanceID is a random hex token generated at StartLogRingBuffer.
+	// It's returned on every read so a client watching this buffer can
+	// tell when the server was restarted (the ID changes) and reset its
+	// local state. Immutable after construction, so no lock needed.
+	instanceID string
+
+	mu              sync.Mutex
+	maxBytes        int
+	batchLines      int
+	batches         []*logRingBatch
+	total           int // sum of len(batch.Payload) across all batches; drives eviction
+	pending         *bytes.Buffer
+	pendingCount    int
+	pendingFirstSeq int64 // seq of the first line in the current pending buffer (0 when empty)
+	nextSeq         int64 // seq to assign to the next incoming line
+	formatter       log.Formatter
+
+	// The compression worker owns compressQueue exclusively; producers use a
+	// non-blocking select-with-default so a slow compressor never blocks the
+	// hot log path. When the send fails we mark the batch as Raw and skip
+	// compression entirely -- exactly the behavior called for by the design.
+	compressQueue chan *logRingBatch
+	workerCtx     context.Context
+	workerCancel  context.CancelFunc
+	workerWG      sync.WaitGroup
+
+	closed atomic.Bool
+}
+
+// globalLogBuffer is the process-wide ring installed via StartLogRingBuffer.
+// Nil (via the atomic.Pointer zero value) until the server calls
+// StartLogRingBuffer, and cleared in StopLogRingBuffer so tests and clean
+// shutdowns don't leak the compression goroutine.
+var globalLogBuffer atomic.Pointer[LogRingBuffer]
+
+// GlobalLogRingBuffer returns the server-side log ring buffer if it has been
+// installed. nil indicates "buffering is off".
+func GlobalLogRingBuffer() *LogRingBuffer {
+	return globalLogBuffer.Load()
+}
+
+// InstanceID returns the random token assigned when this buffer was
+// started. Returns "" for a nil receiver so the API layer can serve
+// disabled/uninstalled buffers uniformly.
+func (b *LogRingBuffer) InstanceID() string {
+	if b == nil {
+		return ""
+	}
+	return b.instanceID
+}
+
+// StartLogRingBuffer wires the ring buffer into logrus and starts its
+// background compression worker. Idempotent for repeat InitServer callers
+// -- a second call finds the buffer already installed and returns. Not
+// safe against concurrent callers; InitServer is invoked serially so we
+// don't guard for that.
+//
+// ctx is the server-lifetime context; when it fires, the worker shuts down
+// and any pending compression drains.
+//
+// The buffer's memory footprint is bounded by Logging.Buffer.MaxSize
+// (default 1 MB) and the compression worker is a single goroutine that
+// sleeps when idle.
+func StartLogRingBuffer(ctx context.Context) {
+	if existing := globalLogBuffer.Load(); existing != nil {
+		return
+	}
+
+	// MaxSize is a human-readable byte-size string (e.g. "1MB", "512K") so
+	// operators don't have to think in raw bytes. A malformed value falls
+	// back to the 1 MiB default rather than refusing to install the buffer
+	// -- log-viewer misconfiguration should not block server startup, and
+	// the failure is logged so the operator sees it.
+	const defaultMaxBytes = 1 << 20
+	maxBytes := defaultMaxBytes
+	if raw := param.Logging_Buffer_MaxSize.GetString(); raw != "" {
+		parsed, err := utils.ParseBytes(raw)
+		// The upper-bound check keeps the uint64→int conversion safe on
+		// every platform: on 32-bit builds int is 31-bit signed, so
+		// anything above ~2 GB would wrap; on 64-bit builds a value
+		// with the top bit set (an operator setting "16EB") would go
+		// negative. Refuse absurd sizes explicitly rather than
+		// silently misinterpreting them.
+		switch {
+		case err != nil, parsed == 0:
+			log.Warnf("invalid %s value %q; falling back to 1MB: %v",
+				param.Logging_Buffer_MaxSize.GetName(), raw, err)
+		case parsed > math.MaxInt:
+			log.Warnf("%s value %q exceeds addressable range; falling back to 1MB",
+				param.Logging_Buffer_MaxSize.GetName(), raw)
+		default:
+			maxBytes = int(parsed)
+		}
+	}
+	batchLines := param.Logging_Buffer_BatchLines.GetInt()
+	if batchLines <= 0 {
+		batchLines = 10000
+	}
+
+	// 8 random bytes → 16 hex chars is plenty of uniqueness for restart
+	// detection.
+	var idBytes [8]byte
+	if _, err := rand.Read(idBytes[:]); err != nil {
+		// crypto/rand.Read can't actually fail on any platform we
+		// support -- but if it does, fall back to a fixed marker
+		// rather than blocking server startup.
+		log.Warnf("log buffer: crypto/rand.Read failed: %v; instance ID will be static", err)
+	}
+	instanceID := hex.EncodeToString(idBytes[:])
+
+	workerCtx, cancel := context.WithCancel(ctx)
+	buf := &LogRingBuffer{
+		instanceID: instanceID,
+		maxBytes:   maxBytes,
+		batchLines: batchLines,
+		pending:    &bytes.Buffer{},
+		// Seq numbering starts at 1 so a cursor of 0 means "give me everything
+		// currently held".
+		nextSeq: 1,
+		// A private DisableColors formatter so buffered payloads never carry
+		// ANSI escapes -- the viewer and gzip download stay diff-clean and
+		// human-readable.
+		formatter: &log.TextFormatter{
+			DisableColors:          true,
+			DisableLevelTruncation: true,
+			FullTimestamp:          true,
+		},
+		// One-slot channel: if the compressor is still busy on the previous
+		// batch when a new one is ready, the send fails and we skip
+		// compression -- the "skip if backlogged" behavior called for by
+		// the design.
+		compressQueue: make(chan *logRingBatch, 1),
+		workerCtx:     workerCtx,
+		workerCancel:  cancel,
+	}
+	buf.workerWG.Add(1)
+	go buf.compressLoop()
+
+	globalLogBuffer.Store(buf)
+	log.AddHook(&logRingBufferHook{buf: buf})
+}
+
+// StopLogRingBuffer detaches the ring buffer's hook from logrus, marks the
+// buffer closed so any in-flight Fire becomes a no-op, and drains the
+// compression worker. Safe to call multiple times.
+func StopLogRingBuffer() {
+	buf := globalLogBuffer.Swap(nil)
+	if buf == nil {
+		return
+	}
+	// Mark closed first so a Fire that has already passed its nil/closed check
+	// still stops as soon as it observes the flag, then detach the hook so no
+	// new entries are delivered.
+	buf.closed.Store(true)
+	removeLogRingBufferHook()
+	// Stop the compression worker. Cancelling the worker context is sufficient
+	// on its own: compressLoop selects on workerCtx.Done(). We deliberately do
+	// NOT close compressQueue -- Fire performs a non-blocking send on it under
+	// buf.mu without synchronizing against this teardown, so closing here would
+	// race a concurrent Fire into a send-on-closed-channel panic. The buffered,
+	// non-blocking send means an un-closed queue neither leaks nor blocks.
+	buf.workerCancel()
+	buf.workerWG.Wait()
+}
+
+// removeLogRingBufferHook detaches every logRingBufferHook from the standard
+// logger while preserving all other hooks. logrus exposes no per-hook removal,
+// so we rebuild the hook set without ours (mirrors logging.removeBufferedHook).
+func removeLogRingBufferHook() {
+	oldHooks := log.StandardLogger().ReplaceHooks(log.LevelHooks{})
+	filtered := make(log.LevelHooks)
+	for lvl, hooks := range oldHooks {
+		for _, h := range hooks {
+			if _, ok := h.(*logRingBufferHook); ok {
+				continue
+			}
+			filtered[lvl] = append(filtered[lvl], h)
+		}
+	}
+	log.StandardLogger().ReplaceHooks(filtered)
+}
+
+// logRingBufferHook is the logrus hook that pumps entries into the buffer.
+// Kept as a small stub struct so we can add/remove the hook via pointer
+// identity without dragging LogRingBuffer's internals into logrus's hook
+// interface.
+type logRingBufferHook struct {
+	buf *LogRingBuffer
+}
+
+// Levels returns every log level so the buffer sees the full stream. Actual
+// level gating happens inside Fire so the buffer can decide to only buffer
+// debug/trace when it is currently enabled.
+func (h *logRingBufferHook) Levels() []log.Level {
+	return log.AllLevels
+}
+
+func (h *logRingBufferHook) Fire(entry *log.Entry) error {
+	return h.buf.Fire(entry)
+}
+
+// shouldBuffer implements the level gate:
+//
+//	info, warn, error, fatal, panic: always buffered
+//	debug, trace:                    only when they are actually enabled
+//
+// The effective level comes from GetEffectiveLogLevel (which knows about
+// the hook-based filtering initFilterLogging installs); logrus's own
+// GetLevel is often pinned to TraceLevel so hooks see everything even when
+// the operator asked for info-only output.
+func shouldBuffer(level log.Level) bool {
+	if level <= log.InfoLevel {
+		return true
+	}
+	return level <= GetEffectiveLogLevel()
+}
+
+// Fire is the hot path for the buffer. It formats the entry, assigns a seq,
+// appends it to the pending buffer, and finalizes when we hit batchLines.
+// All serialization happens under buf.mu; compression itself runs in the
+// worker goroutine so the caller returns promptly.
+func (b *LogRingBuffer) Fire(entry *log.Entry) error {
+	if b == nil || b.closed.Load() {
+		return nil
+	}
+	if !shouldBuffer(entry.Level) {
+		return nil
+	}
+	line, err := b.formatter.Format(entry)
+	if err != nil {
+		return errors.Wrap(err, "log buffer: formatting entry")
+	}
+
+	b.mu.Lock()
+	seq := b.nextSeq
+	b.nextSeq++
+	if b.pendingCount == 0 {
+		b.pendingFirstSeq = seq
+	}
+	b.pending.Write(line)
+	b.pendingCount++
+
+	if b.pendingCount >= b.batchLines {
+		batch := b.finalizeLocked()
+		b.batches = append(b.batches, batch)
+		b.total += len(batch.Payload)
+		// Try to hand the raw batch off for compression. A failed send means
+		// the worker is still busy with the previous batch, so we skip
+		// compression on this one and leave it Raw.
+		select {
+		case b.compressQueue <- batch:
+		default:
+		}
+		b.evictLocked()
+	}
+	b.mu.Unlock()
+	return nil
+}
+
+// finalizeLocked seals the pending buffer into a logRingBatch. Caller must
+// hold b.mu.
+func (b *LogRingBuffer) finalizeLocked() *logRingBatch {
+	payload := make([]byte, b.pending.Len())
+	copy(payload, b.pending.Bytes())
+	batch := &logRingBatch{
+		FirstSeq:  b.pendingFirstSeq,
+		LineCount: b.pendingCount,
+		State:     logRingBatchRaw,
+		Payload:   payload,
+		RawSize:   len(payload),
+	}
+	b.pending.Reset()
+	b.pendingCount = 0
+	b.pendingFirstSeq = 0
+	return batch
+}
+
+// evictLocked drops the oldest batches until total <= maxBytes. The byte
+// cap is a soft target: we never drop the last surviving batch. Under
+// heavy write pressure with one very large batch, that means the buffer
+// can hold more than maxBytes.
+//
+// Caller holds b.mu.
+func (b *LogRingBuffer) evictLocked() {
+	for b.total > b.maxBytes && len(b.batches) > 1 {
+		oldest := b.batches[0]
+		b.total -= len(oldest.Payload)
+		b.batches = b.batches[1:]
+	}
+}
+
+// compressLoop is the sole reader of compressQueue. It picks up one batch
+// at a time, compresses it with LZ4, and swaps the compressed payload back
+// into the batch in place. If the batch has been evicted while compression
+// was running (possible under heavy load), the swap is a no-op.
+func (b *LogRingBuffer) compressLoop() {
+	defer b.workerWG.Done()
+	for {
+		select {
+		case <-b.workerCtx.Done():
+			return
+		case batch, ok := <-b.compressQueue:
+			if !ok {
+				return
+			}
+			b.compressOne(batch)
+		}
+	}
+}
+
+func (b *LogRingBuffer) compressOne(batch *logRingBatch) {
+	// Take a stable snapshot of the raw bytes without holding the mutex --
+	// batch payloads are immutable after finalize (compressLoop is the only
+	// writer of Payload) so a lock-free read is safe.
+	raw := batch.Payload
+	if raw == nil {
+		return
+	}
+	var out bytes.Buffer
+	w := lz4.NewWriter(&out)
+	if _, err := w.Write(raw); err != nil {
+		log.Debugln("log buffer: LZ4 write failed; leaving batch uncompressed:", err)
+		return
+	}
+	if err := w.Close(); err != nil {
+		log.Debugln("log buffer: LZ4 close failed; leaving batch uncompressed:", err)
+		return
+	}
+	compressed := out.Bytes()
+
+	// Build a REPLACEMENT batch rather than mutating `batch` in place.
+	// Batches are treated as immutable once they land in b.batches, so a
+	// reader that holds the original pointer (with or without the mutex)
+	// sees a consistent Raw view -- fields never observe a partial
+	// update.
+	replacement := &logRingBatch{
+		FirstSeq:  batch.FirstSeq,
+		LineCount: batch.LineCount,
+		State:     logRingBatchCompressed,
+		Payload:   compressed,
+		RawSize:   batch.RawSize,
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	// Locate the batch by pointer identity. If it was evicted while we
+	// were compressing, drop the compressed result on the floor.
+	for i, existing := range b.batches {
+		if existing == batch {
+			b.total = b.total - len(batch.Payload) + len(compressed)
+			b.batches[i] = replacement
+			b.evictLocked()
+			return
+		}
+	}
+}
+
+// LogTail is one page of TailSince / TailBefore output. Content is the
+// raw log text (newline-terminated lines concatenated in seq order); the
+// two seq fields describe the range covered by that content.
+//
+//   - FirstSeq is the oldest seq in Content; pass it back as the next
+//     TailBefore call's `before` to page further backwards.
+//   - LastSeq is the newest seq in Content; pass it back as the next
+//     TailSince call's `since` to page forward.
+//
+// When Content is empty, both FirstSeq and LastSeq collapse to the
+// caller's input cursor -- polling remains anchored at the same point.
+//
+// Reached is true when TailBefore has walked off the oldest line the
+// buffer currently holds: FirstSeq == oldest-held seq at the time of the
+// call, so a subsequent TailBefore with the same cursor would return
+// nothing new. Callers use this to disable a "load older" affordance
+// once history is exhausted.
+type LogTail struct {
+	Content  []byte
+	FirstSeq int64
+	LastSeq  int64
+	Reached  bool
+}
+
+// TailSince returns lines held by the buffer with seq > since. A `since`
+// of 0 (or any value below the oldest currently-held seq) yields the
+// entire currently-held content. `limit` caps the number of lines
+// returned; when the delta exceeds `limit`, the OLDEST lines are
+// dropped and only the newest `limit` lines are returned (so a client
+// resuming after a long absence still sees "the latest activity"
+// without a mega-response). A `limit` of 0 or less means unbounded.
+// The response is a single []byte -- newline-terminated log lines
+// concatenated in seq order -- so the API layer can hand it straight
+// to the wire.
+func (b *LogRingBuffer) TailSince(since int64, limit int) LogTail {
+	if b == nil {
+		return LogTail{}
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	out := &bytes.Buffer{}
+	firstSeqInContent := int64(-1)
+
+	// Walk finalized batches in insertion order. Skip batches entirely
+	// consumed by the caller; for a batch straddling `since`, drop the
+	// already-seen prefix by counting newlines in the payload.
+	for _, batch := range b.batches {
+		if batch.lastSeq() <= since {
+			continue
+		}
+		payload, err := decodeBatchPayload(batch)
+		if err != nil {
+			// A decompress failure on a batch we just stored is a
+			// server-side bug rather than a caller problem; drop this
+			// slab from the response instead of failing the whole call
+			// so a corrupted batch doesn't blank the viewer.
+			log.Debugln("log buffer: TailSince skipping unreadable batch:", err)
+			continue
+		}
+		effectiveFirst := batch.FirstSeq
+		if since >= batch.FirstSeq {
+			// `since` is inside this batch: skip (since - FirstSeq + 1)
+			// lines, keep the rest.
+			skip := int(since - batch.FirstSeq + 1)
+			payload = skipNLines(payload, skip)
+			effectiveFirst = since + 1
+		}
+		if firstSeqInContent < 0 {
+			firstSeqInContent = effectiveFirst
+		}
+		out.Write(payload)
+	}
+
+	// Pending buffer -- the tail that hasn't been finalized yet.
+	if b.pendingCount > 0 {
+		pendingLastSeq := b.pendingFirstSeq + int64(b.pendingCount) - 1
+		if pendingLastSeq > since {
+			payload := b.pending.Bytes()
+			effectiveFirst := b.pendingFirstSeq
+			if since >= b.pendingFirstSeq {
+				skip := int(since - b.pendingFirstSeq + 1)
+				payload = skipNLines(payload, skip)
+				effectiveFirst = since + 1
+			}
+			if firstSeqInContent < 0 {
+				firstSeqInContent = effectiveFirst
+			}
+			out.Write(payload)
+		}
+	}
+
+	content := out.Bytes()
+	newest := b.newestSeqLocked()
+
+	// Apply the limit: if we've accumulated more than `limit` lines,
+	// drop the OLDEST lines and advance firstSeqInContent accordingly.
+	// This gives a client resuming from a stale cursor a bounded reply
+	// focused on the most recent activity; the older lines they
+	// technically requested can still be reached via TailBefore.
+	if limit > 0 && firstSeqInContent >= 0 {
+		totalLines := int(newest - firstSeqInContent + 1)
+		if totalLines > limit {
+			drop := totalLines - limit
+			content = skipNLines(content, drop)
+			firstSeqInContent += int64(drop)
+		}
+	}
+
+	tail := LogTail{
+		Content:  content,
+		FirstSeq: since,
+		LastSeq:  since,
+	}
+	if firstSeqInContent >= 0 {
+		tail.FirstSeq = firstSeqInContent
+	}
+	if newest > since {
+		tail.LastSeq = newest
+	}
+	// TailSince's `Reached` is meaningful only for the scroll-up path
+	// (TailBefore), so leave it at its zero value here -- the forward
+	// tail never runs out of "newer" history in a well-defined sense.
+	return tail
+}
+
+// TailBefore returns log lines with seq < before, accumulating at least
+// `count` lines by walking batches from newest to oldest. Whole batches
+// are the unit of decompression: if a batch straddles the cursor, its
+// trailing (already-seen) lines are trimmed but the rest of the batch's
+// content is included in a single decompress. Subsequent TailBefore
+// calls with a smaller `before` cursor never revisit the same batch, so
+// the same LZ4 frame is decompressed at most once per scroll session.
+//
+// A `count` of 0 (or negative) uses the buffer's batchLines setting as
+// the default, so the natural pagination unit is "one batch's worth" of
+// history.
+//
+// FirstSeq in the response is the oldest seq included -- pass it back
+// as the next TailBefore call's `before` to page further backwards.
+// Reached is true when the returned content includes the oldest line the
+// buffer currently holds; the caller can disable its scroll-up affordance
+// at that point.
+func (b *LogRingBuffer) TailBefore(before int64, count int) LogTail {
+	if b == nil {
+		return LogTail{}
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if count <= 0 {
+		count = b.batchLines
+	}
+
+	// chunks are collected NEWEST-first (matching the reverse walk) and
+	// reversed at the end for the wire, which stays oldest-first.
+	type chunk struct {
+		bytes    []byte
+		firstSeq int64
+		lines    int
+	}
+	var chunks []chunk
+	totalLines := 0
+
+	// Pending first (it lives at the newest end of the buffer). Only
+	// relevant when `before` is high enough that any pending seq falls
+	// under it -- unusual for a scroll-up call but correct if it happens.
+	if b.pendingCount > 0 && b.pendingFirstSeq < before {
+		pendingLastSeq := b.pendingFirstSeq + int64(b.pendingCount) - 1
+		payload := append([]byte(nil), b.pending.Bytes()...)
+		lines := b.pendingCount
+		if pendingLastSeq >= before {
+			keep := int(before - b.pendingFirstSeq)
+			payload = takeFirstNLines(payload, keep)
+			lines = keep
+		}
+		if lines > 0 {
+			chunks = append(chunks, chunk{
+				bytes:    payload,
+				firstSeq: b.pendingFirstSeq,
+				lines:    lines,
+			})
+			totalLines += lines
+		}
+	}
+
+	// Now walk finalized batches newest-to-oldest until we've collected
+	// at least `count` lines. Each batch is decompressed at most once.
+	for i := len(b.batches) - 1; i >= 0 && totalLines < count; i-- {
+		batch := b.batches[i]
+		if batch.FirstSeq >= before {
+			continue
+		}
+		payload, err := decodeBatchPayload(batch)
+		if err != nil {
+			log.Debugln("log buffer: TailBefore skipping unreadable batch:", err)
+			continue
+		}
+		lines := batch.LineCount
+		if batch.lastSeq() >= before {
+			// Straddle: trim to lines with seq < before.
+			keep := int(before - batch.FirstSeq)
+			payload = takeFirstNLines(payload, keep)
+			lines = keep
+		}
+		if lines <= 0 {
+			continue
+		}
+		chunks = append(chunks, chunk{
+			bytes:    payload,
+			firstSeq: batch.FirstSeq,
+			lines:    lines,
+		})
+		totalLines += lines
+	}
+
+	oldestHeld := b.oldestSeqLocked()
+	tail := LogTail{
+		FirstSeq: before,
+		LastSeq:  before,
+		// If the caller's cursor is already at (or below) the wall, the
+		// caller has exhausted history even before we return anything.
+		Reached: before <= oldestHeld,
+	}
+	if len(chunks) == 0 {
+		return tail
+	}
+	// Emit chunks in oldest-first order (reverse of collection order).
+	out := &bytes.Buffer{}
+	for i := len(chunks) - 1; i >= 0; i-- {
+		out.Write(chunks[i].bytes)
+	}
+	tail.Content = out.Bytes()
+	tail.FirstSeq = chunks[len(chunks)-1].firstSeq
+	// LastSeq of returned content is (before - 1) at most -- but if a
+	// straddling chunk was trimmed, its last kept seq equals (before-1),
+	// and non-straddling chunks span up to their batch's lastSeq. The
+	// first chunk we collected (newest-side) carries the newest seq.
+	newestChunk := chunks[0]
+	tail.LastSeq = newestChunk.firstSeq + int64(newestChunk.lines) - 1
+	// Reached: we walked back until FirstSeq is at (or below) the oldest
+	// held line -- there's nothing older to fetch on the next call.
+	tail.Reached = tail.FirstSeq <= oldestHeld
+	return tail
+}
+
+// takeFirstNLines returns the first n newline-terminated lines from buf.
+// If buf contains fewer than n lines, the whole slice is returned.
+func takeFirstNLines(buf []byte, n int) []byte {
+	idx := 0
+	for k := 0; k < n && idx < len(buf); k++ {
+		j := bytes.IndexByte(buf[idx:], '\n')
+		if j < 0 {
+			return buf
+		}
+		idx += j + 1
+	}
+	return buf[:idx]
+}
+
+// oldestSeqLocked returns the seq of the oldest line the buffer holds. When
+// the buffer is empty, returns nextSeq so callers can detect "nothing to
+// prune" by comparing against their own tracked oldest. Caller holds b.mu.
+func (b *LogRingBuffer) oldestSeqLocked() int64 {
+	if len(b.batches) > 0 {
+		return b.batches[0].FirstSeq
+	}
+	if b.pendingCount > 0 {
+		return b.pendingFirstSeq
+	}
+	return b.nextSeq
+}
+
+// newestSeqLocked returns the seq of the newest line the buffer holds, or
+// 0 when the buffer is empty. Caller holds b.mu.
+func (b *LogRingBuffer) newestSeqLocked() int64 {
+	if b.pendingCount > 0 {
+		return b.pendingFirstSeq + int64(b.pendingCount) - 1
+	}
+	if len(b.batches) > 0 {
+		last := b.batches[len(b.batches)-1]
+		return last.lastSeq()
+	}
+	return 0
+}
+
+// decodeBatchPayload returns a fresh copy of the batch's uncompressed
+// bytes. Callers own the returned slice.
+func decodeBatchPayload(batch *logRingBatch) ([]byte, error) {
+	if batch.State == logRingBatchRaw {
+		out := make([]byte, len(batch.Payload))
+		copy(out, batch.Payload)
+		return out, nil
+	}
+	r := lz4.NewReader(bytes.NewReader(batch.Payload))
+	out := bytes.NewBuffer(make([]byte, 0, batch.RawSize))
+	if _, err := io.Copy(out, r); err != nil {
+		return nil, errors.Wrap(err, "log buffer: LZ4 decompress")
+	}
+	return out.Bytes(), nil
+}
+
+// skipNLines advances past the first n newline-terminated lines in buf and
+// returns the trailing slice. If buf contains fewer than n lines, returns
+// an empty slice. Log lines are always \n-terminated (the logrus text
+// formatter appends one), so this is exact rather than heuristic.
+func skipNLines(buf []byte, n int) []byte {
+	for n > 0 && len(buf) > 0 {
+		i := bytes.IndexByte(buf, '\n')
+		if i < 0 {
+			return nil
+		}
+		buf = buf[i+1:]
+		n--
+	}
+	return buf
+}
+
+// StoredBytes returns the current byte total across all held batches. Not
+// part of the public API; test-only.
+func (b *LogRingBuffer) StoredBytes() int {
+	if b == nil {
+		return 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.total
+}
+
+// BatchCount returns how many finalized batches are currently held. Not
+// part of the public API; test-only.
+func (b *LogRingBuffer) BatchCount() int {
+	if b == nil {
+		return 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.batches)
+}
+
+// PendingLineCount returns the number of lines currently in the pending
+// buffer (not yet finalized into a batch). Test-only.
+func (b *LogRingBuffer) PendingLineCount() int {
+	if b == nil {
+		return 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.pendingCount
+}

--- a/config/log_buffer.go
+++ b/config/log_buffer.go
@@ -95,7 +95,9 @@ type LogRingBuffer struct {
 	// The compression worker owns compressQueue exclusively; producers use a
 	// non-blocking select-with-default so a slow compressor never blocks the
 	// hot log path. When the send fails we mark the batch as Raw and skip
-	// compression entirely -- exactly the behavior called for by the design.
+	// compression entirely: a raw batch costs more memory against maxBytes
+	// than a compressed one, but it is fully readable, and both TailSince and
+	// TailBefore decode either state.
 	compressQueue chan *logRingBatch
 	workerCtx     context.Context
 	workerCancel  context.CancelFunc
@@ -203,9 +205,9 @@ func StartLogRingBuffer(ctx context.Context) {
 			FullTimestamp:          true,
 		},
 		// One-slot channel: if the compressor is still busy on the previous
-		// batch when a new one is ready, the send fails and we skip
-		// compression -- the "skip if backlogged" behavior called for by
-		// the design.
+		// batch when a new one is ready, the send fails and the batch is left
+		// uncompressed. Falling behind costs memory, never latency on the
+		// logging path.
 		compressQueue: make(chan *logRingBatch, 1),
 		workerCtx:     workerCtx,
 		workerCancel:  cancel,
@@ -303,10 +305,18 @@ func (b *LogRingBuffer) Fire(entry *log.Entry) error {
 	if !shouldBuffer(entry.Level) {
 		return nil
 	}
-	line, err := b.formatter.Format(entry)
+	// Censor credentials before the line is stored. The buffer is served back
+	// to anyone holding pelican.log_read, so it must not retain material the
+	// on-disk log redacts: XRootD's forwarded output routinely carries
+	// "authz=Bearer <token>" query parameters. Redacting here rather than
+	// relying on the censor hook keeps the guarantee independent of hook
+	// ordering, which SetLogging is free to rearrange.
+	line, err := b.formatter.Format(redactEntryCopy(entry))
 	if err != nil {
 		return errors.Wrap(err, "log buffer: formatting entry")
 	}
+
+	line = capLineLength(line)
 
 	b.mu.Lock()
 	seq := b.nextSeq
@@ -317,7 +327,7 @@ func (b *LogRingBuffer) Fire(entry *log.Entry) error {
 	b.pending.Write(line)
 	b.pendingCount++
 
-	if b.pendingCount >= b.batchLines {
+	if b.pendingCount >= b.batchLines || b.pending.Len() >= b.pendingCap() {
 		batch := b.finalizeLocked()
 		b.batches = append(b.batches, batch)
 		b.total += len(batch.Payload)
@@ -328,10 +338,45 @@ func (b *LogRingBuffer) Fire(entry *log.Entry) error {
 		case b.compressQueue <- batch:
 		default:
 		}
-		b.evictLocked()
 	}
+	b.evictLocked()
 	b.mu.Unlock()
 	return nil
+}
+
+// maxBufferedLineBytes bounds a single buffered line. Log lines are
+// attacker-influenced -- request paths and user agents reach the buffer
+// through the web server's access log -- and one very long line would
+// otherwise consume the whole buffer and evict every line an operator
+// actually wants to read. The log file keeps the untruncated text; the
+// buffer is a bounded window over recent history, not the record of what
+// was logged.
+const maxBufferedLineBytes = 64 << 10
+
+// capLineLength truncates an over-long formatted line, preserving the
+// trailing newline that TailSince/TailBefore rely on to count lines. The
+// returned slice never aliases a truncated input, so the caller's buffer
+// stays intact.
+func capLineLength(line []byte) []byte {
+	if len(line) <= maxBufferedLineBytes {
+		return line
+	}
+	const marker = "...[truncated]\n"
+	out := make([]byte, 0, maxBufferedLineBytes)
+	out = append(out, line[:maxBufferedLineBytes-len(marker)]...)
+	return append(out, marker...)
+}
+
+// pendingCap is the byte size at which the pending buffer is sealed into a
+// batch. Sized as a fraction of the buffer's overall budget so that a
+// sealed batch is small enough for eviction to be responsive, while still
+// large enough that compression has something worthwhile to work on.
+func (b *LogRingBuffer) pendingCap() int {
+	limit := b.maxBytes / 8
+	if limit < maxBufferedLineBytes {
+		limit = maxBufferedLineBytes
+	}
+	return limit
 }
 
 // finalizeLocked seals the pending buffer into a logRingBatch. Caller must
@@ -352,14 +397,18 @@ func (b *LogRingBuffer) finalizeLocked() *logRingBatch {
 	return batch
 }
 
-// evictLocked drops the oldest batches until total <= maxBytes. The byte
-// cap is a soft target: we never drop the last surviving batch. Under
-// heavy write pressure with one very large batch, that means the buffer
-// can hold more than maxBytes.
+// evictLocked drops the oldest batches until the buffer fits in maxBytes.
+// The pending buffer counts against the budget: it holds live lines that
+// occupy memory just as a sealed batch does, and it can reach pendingCap
+// between seals.
+//
+// The byte cap is a soft target: we never drop the last surviving batch, so
+// a single batch larger than maxBytes keeps the buffer above budget until
+// the next seal replaces it.
 //
 // Caller holds b.mu.
 func (b *LogRingBuffer) evictLocked() {
-	for b.total > b.maxBytes && len(b.batches) > 1 {
+	for b.total+b.pending.Len() > b.maxBytes && len(b.batches) > 1 {
 		oldest := b.batches[0]
 		b.total -= len(oldest.Payload)
 		b.batches = b.batches[1:]
@@ -432,6 +481,42 @@ func (b *LogRingBuffer) compressOne(batch *logRingBatch) {
 	}
 }
 
+// logBufferSnapshot is a consistent view of the buffer's contents taken in
+// one critical section. Reads work from a snapshot so that decompression --
+// which is unbounded work proportional to how much history the operator
+// configured -- happens outside b.mu. Fire takes that same mutex on every
+// log line in the process, so a read that decompressed under it would stall
+// all logging, including the web server's per-request access log.
+type logBufferSnapshot struct {
+	// batches is a private copy of the slice header. The batches it points
+	// at are immutable once stored -- compression installs a replacement
+	// rather than rewriting one in place -- so they can be decoded safely
+	// after the lock is dropped.
+	batches         []*logRingBatch
+	pending         []byte
+	pendingFirstSeq int64
+	pendingCount    int
+	batchLines      int
+	oldestSeq       int64
+	newestSeq       int64
+}
+
+func (b *LogRingBuffer) snapshot() logBufferSnapshot {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return logBufferSnapshot{
+		batches: append([]*logRingBatch(nil), b.batches...),
+		// The pending buffer is still being appended to, so it has to be
+		// copied rather than aliased.
+		pending:         append([]byte(nil), b.pending.Bytes()...),
+		pendingFirstSeq: b.pendingFirstSeq,
+		pendingCount:    b.pendingCount,
+		batchLines:      b.batchLines,
+		oldestSeq:       b.oldestSeqLocked(),
+		newestSeq:       b.newestSeqLocked(),
+	}
+}
+
 // LogTail is one page of TailSince / TailBefore output. Content is the
 // raw log text (newline-terminated lines concatenated in seq order); the
 // two seq fields describe the range covered by that content.
@@ -454,6 +539,13 @@ type LogTail struct {
 	FirstSeq int64
 	LastSeq  int64
 	Reached  bool
+	// Dropped counts lines that fell between the caller's cursor and the
+	// start of Content: either evicted before the caller came back for them,
+	// or trimmed to honor a limit. A reader that ignores this field silently
+	// presents a truncated history as a complete one, which during an
+	// incident is the difference between "nothing happened" and "we stopped
+	// keeping up".
+	Dropped int64
 }
 
 // TailSince returns lines held by the buffer with seq > since. A `since`
@@ -470,8 +562,7 @@ func (b *LogRingBuffer) TailSince(since int64, limit int) LogTail {
 	if b == nil {
 		return LogTail{}
 	}
-	b.mu.Lock()
-	defer b.mu.Unlock()
+	snap := b.snapshot()
 
 	out := &bytes.Buffer{}
 	firstSeqInContent := int64(-1)
@@ -479,7 +570,7 @@ func (b *LogRingBuffer) TailSince(since int64, limit int) LogTail {
 	// Walk finalized batches in insertion order. Skip batches entirely
 	// consumed by the caller; for a batch straddling `since`, drop the
 	// already-seen prefix by counting newlines in the payload.
-	for _, batch := range b.batches {
+	for _, batch := range snap.batches {
 		if batch.lastSeq() <= since {
 			continue
 		}
@@ -507,13 +598,13 @@ func (b *LogRingBuffer) TailSince(since int64, limit int) LogTail {
 	}
 
 	// Pending buffer -- the tail that hasn't been finalized yet.
-	if b.pendingCount > 0 {
-		pendingLastSeq := b.pendingFirstSeq + int64(b.pendingCount) - 1
+	if snap.pendingCount > 0 {
+		pendingLastSeq := snap.pendingFirstSeq + int64(snap.pendingCount) - 1
 		if pendingLastSeq > since {
-			payload := b.pending.Bytes()
-			effectiveFirst := b.pendingFirstSeq
-			if since >= b.pendingFirstSeq {
-				skip := int(since - b.pendingFirstSeq + 1)
+			payload := snap.pending
+			effectiveFirst := snap.pendingFirstSeq
+			if since >= snap.pendingFirstSeq {
+				skip := int(since - snap.pendingFirstSeq + 1)
 				payload = skipNLines(payload, skip)
 				effectiveFirst = since + 1
 			}
@@ -525,7 +616,16 @@ func (b *LogRingBuffer) TailSince(since int64, limit int) LogTail {
 	}
 
 	content := out.Bytes()
-	newest := b.newestSeqLocked()
+	newest := snap.newestSeq
+
+	// Lines the caller's cursor asked for that the buffer no longer holds:
+	// they were evicted between this call and the last one. The caller
+	// cannot work this out for itself -- cursors are opaque by contract --
+	// so the count has to be reported explicitly.
+	var dropped int64
+	if since > 0 && snap.oldestSeq > since+1 {
+		dropped = snap.oldestSeq - since - 1
+	}
 
 	// Apply the limit: if we've accumulated more than `limit` lines,
 	// drop the OLDEST lines and advance firstSeqInContent accordingly.
@@ -538,6 +638,10 @@ func (b *LogRingBuffer) TailSince(since int64, limit int) LogTail {
 			drop := totalLines - limit
 			content = skipNLines(content, drop)
 			firstSeqInContent += int64(drop)
+			// Trimming to the limit is a gap too. It is recoverable via
+			// TailBefore, unlike an eviction, but the caller still must not
+			// render the result as contiguous.
+			dropped += int64(drop)
 		}
 	}
 
@@ -545,6 +649,7 @@ func (b *LogRingBuffer) TailSince(since int64, limit int) LogTail {
 		Content:  content,
 		FirstSeq: since,
 		LastSeq:  since,
+		Dropped:  dropped,
 	}
 	if firstSeqInContent >= 0 {
 		tail.FirstSeq = firstSeqInContent
@@ -579,11 +684,10 @@ func (b *LogRingBuffer) TailBefore(before int64, count int) LogTail {
 	if b == nil {
 		return LogTail{}
 	}
-	b.mu.Lock()
-	defer b.mu.Unlock()
+	snap := b.snapshot()
 
 	if count <= 0 {
-		count = b.batchLines
+		count = snap.batchLines
 	}
 
 	// chunks are collected NEWEST-first (matching the reverse walk) and
@@ -599,19 +703,19 @@ func (b *LogRingBuffer) TailBefore(before int64, count int) LogTail {
 	// Pending first (it lives at the newest end of the buffer). Only
 	// relevant when `before` is high enough that any pending seq falls
 	// under it -- unusual for a scroll-up call but correct if it happens.
-	if b.pendingCount > 0 && b.pendingFirstSeq < before {
-		pendingLastSeq := b.pendingFirstSeq + int64(b.pendingCount) - 1
-		payload := append([]byte(nil), b.pending.Bytes()...)
-		lines := b.pendingCount
+	if snap.pendingCount > 0 && snap.pendingFirstSeq < before {
+		pendingLastSeq := snap.pendingFirstSeq + int64(snap.pendingCount) - 1
+		payload := snap.pending
+		lines := snap.pendingCount
 		if pendingLastSeq >= before {
-			keep := int(before - b.pendingFirstSeq)
+			keep := int(before - snap.pendingFirstSeq)
 			payload = takeFirstNLines(payload, keep)
 			lines = keep
 		}
 		if lines > 0 {
 			chunks = append(chunks, chunk{
 				bytes:    payload,
-				firstSeq: b.pendingFirstSeq,
+				firstSeq: snap.pendingFirstSeq,
 				lines:    lines,
 			})
 			totalLines += lines
@@ -620,8 +724,8 @@ func (b *LogRingBuffer) TailBefore(before int64, count int) LogTail {
 
 	// Now walk finalized batches newest-to-oldest until we've collected
 	// at least `count` lines. Each batch is decompressed at most once.
-	for i := len(b.batches) - 1; i >= 0 && totalLines < count; i-- {
-		batch := b.batches[i]
+	for i := len(snap.batches) - 1; i >= 0 && totalLines < count; i-- {
+		batch := snap.batches[i]
 		if batch.FirstSeq >= before {
 			continue
 		}
@@ -648,7 +752,7 @@ func (b *LogRingBuffer) TailBefore(before int64, count int) LogTail {
 		totalLines += lines
 	}
 
-	oldestHeld := b.oldestSeqLocked()
+	oldestHeld := snap.oldestSeq
 	tail := LogTail{
 		FirstSeq: before,
 		LastSeq:  before,
@@ -781,4 +885,15 @@ func (b *LogRingBuffer) PendingLineCount() int {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.pendingCount
+}
+
+// PendingBytes returns the byte size of the pending buffer. Together with
+// StoredBytes it accounts for everything the buffer holds. Test-only.
+func (b *LogRingBuffer) PendingBytes() int {
+	if b == nil {
+		return 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.pending.Len()
 }

--- a/config/log_buffer_test.go
+++ b/config/log_buffer_test.go
@@ -1,0 +1,428 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestBuffer builds a LogRingBuffer wired to the production hot path but
+// with hand-picked batchLines/maxBytes so a unit test can push the
+// eviction/compression logic without piping in megabytes of synthetic log
+// data. The returned buffer does NOT install a logrus hook -- tests call
+// Fire directly to preserve determinism.
+func newTestBuffer(t *testing.T, batchLines, maxBytes int) *LogRingBuffer {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	buf := &LogRingBuffer{
+		maxBytes:   maxBytes,
+		batchLines: batchLines,
+		pending:    &bytes.Buffer{},
+		nextSeq:    1,
+		formatter: &log.TextFormatter{
+			DisableColors:          true,
+			DisableLevelTruncation: true,
+			FullTimestamp:          true,
+		},
+		compressQueue: make(chan *logRingBatch, 1),
+		workerCtx:     ctx,
+		workerCancel:  cancel,
+	}
+	buf.workerWG.Add(1)
+	go buf.compressLoop()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-buf.compressQueue:
+		default:
+		}
+		close(buf.compressQueue)
+		buf.workerWG.Wait()
+	})
+	return buf
+}
+
+// fire feeds a single entry into the buffer. Level is passed explicitly so
+// the tests can drive the buffer through both the "always buffer" and
+// "gate on effective level" branches of shouldBuffer.
+func fire(t *testing.T, buf *LogRingBuffer, level log.Level, msg string) {
+	t.Helper()
+	entry := log.NewEntry(log.StandardLogger())
+	entry.Level = level
+	entry.Message = msg
+	entry.Time = time.Now()
+	require.NoError(t, buf.Fire(entry))
+}
+
+// TestLogBuffer_BatchFinalization checks the primary invariant: once
+// batchLines entries have been fed in, a batch is finalized and the
+// pending buffer resets. Subsequent lines land in a fresh pending buffer.
+func TestLogBuffer_BatchFinalization(t *testing.T) {
+	buf := newTestBuffer(t, 5, 1<<20)
+	for i := 0; i < 5; i++ {
+		fire(t, buf, log.InfoLevel, fmt.Sprintf("line %d", i))
+	}
+	assert.Equal(t, 1, buf.BatchCount(), "one full batch should finalize at batchLines")
+	assert.Equal(t, 0, buf.PendingLineCount(), "pending must reset after finalize")
+
+	fire(t, buf, log.InfoLevel, "post-finalize")
+	assert.Equal(t, 1, buf.PendingLineCount(), "the next line lands in a fresh pending batch")
+}
+
+// TestLogBuffer_EvictionRespectsCap confirms the buffer honors the byte cap
+// by dropping oldest batches. We push far more lines than the cap allows,
+// then assert (a) many batches were evicted, (b) the surviving batches are
+// the newest ones (by comparing the oldest surviving seq against the seq
+// of the very first push).
+func TestLogBuffer_EvictionRespectsCap(t *testing.T) {
+	buf := newTestBuffer(t, 5, 300)
+	for round := 0; round < 20; round++ {
+		for i := 0; i < 5; i++ {
+			fire(t, buf, log.InfoLevel, fmt.Sprintf("round %d line %d filler", round, i))
+		}
+	}
+	require.GreaterOrEqual(t, buf.BatchCount(), 1, "the tail batch is never evicted")
+	require.Less(t, buf.BatchCount(), 20, "many earlier batches must have been evicted")
+
+	// The oldest seq the buffer still returns must be well past 1
+	// (which was the seq of the very first push). We use TailSince(0)
+	// to get whatever content is currently held and read its FirstSeq.
+	tail := buf.TailSince(0, 0)
+	assert.Greater(t, tail.FirstSeq, int64(1),
+		"eviction must have advanced the oldest seq past the very first push")
+}
+
+// TestLogBuffer_LevelGating exercises the always-buffer-info+ rule.
+func TestLogBuffer_LevelGating(t *testing.T) {
+	buf := newTestBuffer(t, 100, 1<<20)
+	for _, lvl := range []log.Level{log.PanicLevel, log.FatalLevel, log.ErrorLevel, log.WarnLevel, log.InfoLevel} {
+		fire(t, buf, lvl, fmt.Sprintf("%s message", lvl))
+	}
+	assert.Equal(t, 5, buf.PendingLineCount(),
+		"info and above must always be buffered regardless of effective level")
+}
+
+// TestShouldBufferReadsEffectiveLevel covers the debug/trace side of the
+// gate: shouldBuffer must return true for debug when the effective level
+// is debug, false when the effective level is info. GetEffectiveLogLevel
+// is served from an atomic cache updated only by SetLogging (and the
+// other level-changing sites), so the test drives it via SetLogging
+// rather than log.SetLevel -- the latter bypasses the cache by design
+// (that's how the hook-based filter tree keeps logrus's level pinned to
+// TraceLevel while the effective level tracks the operator's ask).
+func TestShouldBufferReadsEffectiveLevel(t *testing.T) {
+	prev := GetEffectiveLogLevel()
+	t.Cleanup(func() { SetLogging(prev) })
+
+	SetLogging(log.InfoLevel)
+	assert.True(t, shouldBuffer(log.InfoLevel), "info always buffered")
+	assert.False(t, shouldBuffer(log.DebugLevel), "debug excluded when effective is info")
+
+	SetLogging(log.DebugLevel)
+	assert.True(t, shouldBuffer(log.DebugLevel), "debug included when effective is debug")
+	assert.False(t, shouldBuffer(log.TraceLevel), "trace excluded when effective is debug")
+
+	SetLogging(log.TraceLevel)
+	assert.True(t, shouldBuffer(log.TraceLevel), "trace included when effective is trace")
+}
+
+// TestLogBuffer_CompressorSkipOnBacklog: with the compression queue
+// perpetually blocked (no worker draining it), every finalized batch must
+// remain Raw. TailSince still returns correct content because its decoder
+// handles both states.
+func TestLogBuffer_CompressorSkipOnBacklog(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	buf := &LogRingBuffer{
+		maxBytes:   1 << 20,
+		batchLines: 2,
+		pending:    &bytes.Buffer{},
+		nextSeq:    1,
+		formatter: &log.TextFormatter{
+			DisableColors:          true,
+			DisableLevelTruncation: true,
+			FullTimestamp:          true,
+		},
+		compressQueue: make(chan *logRingBatch, 1),
+		workerCtx:     ctx,
+		workerCancel:  cancel,
+	}
+	t.Cleanup(cancel)
+
+	// Fill the slot so every send-in-Fire selects the default branch.
+	buf.compressQueue <- &logRingBatch{}
+
+	for i := 0; i < 6; i++ {
+		fire(t, buf, log.InfoLevel, fmt.Sprintf("padded content line %d", i))
+	}
+	require.GreaterOrEqual(t, buf.BatchCount(), 1)
+	// TailSince still returns intelligible content even though nothing
+	// has been compressed.
+	tail := buf.TailSince(0, 0)
+	assert.Contains(t, string(tail.Content), "padded content")
+}
+
+// TestLogBuffer_TailSinceRoundTrips checks that TailSince content is
+// consistent with what was fed in: firing N lines and requesting
+// TailSince(0) yields exactly N newline-terminated lines with the source
+// text embedded.
+func TestLogBuffer_TailSinceRoundTrips(t *testing.T) {
+	buf := newTestBuffer(t, 10, 1<<20)
+	for i := 0; i < 25; i++ {
+		fire(t, buf, log.InfoLevel, fmt.Sprintf("line %02d marker", i))
+	}
+	require.Eventually(t, func() bool {
+		// Wait for at least one batch to compress -- exercises the
+		// decompress path inside TailSince.
+		tail := buf.TailSince(0, 0)
+		return bytes.Count(tail.Content, []byte("\n")) == 25
+	}, time.Second, 5*time.Millisecond)
+
+	tail := buf.TailSince(0, 0)
+	for i := 0; i < 25; i++ {
+		assert.Contains(t, string(tail.Content), fmt.Sprintf("line %02d marker", i),
+			"TailSince(0) must include every fired line")
+	}
+	assert.Equal(t, int64(25), tail.LastSeq,
+		"LastSeq must equal the seq of the newest line")
+	assert.Equal(t, int64(1), tail.FirstSeq,
+		"nothing has been evicted so FirstSeq matches the first-assigned seq")
+}
+
+// TestLogBuffer_TailSinceIsIncremental exercises the cursor semantics: a
+// second TailSince call passing the first call's cursor must return only
+// the lines emitted after the first call, and the cursor advances to the
+// new newest seq.
+func TestLogBuffer_TailSinceIsIncremental(t *testing.T) {
+	buf := newTestBuffer(t, 100, 1<<20)
+	for i := 0; i < 5; i++ {
+		fire(t, buf, log.InfoLevel, fmt.Sprintf("first-batch line %d", i))
+	}
+	first := buf.TailSince(0, 0)
+	require.Equal(t, 5, bytes.Count(first.Content, []byte("\n")))
+	require.Equal(t, int64(5), first.LastSeq)
+
+	// Nothing new: same cursor in, empty content back.
+	empty := buf.TailSince(first.LastSeq, 0)
+	assert.Empty(t, empty.Content, "no new lines means empty content")
+	assert.Equal(t, first.LastSeq, empty.LastSeq, "cursor stays put when nothing is new")
+
+	// Fire more lines; second TailSince returns only the delta.
+	for i := 0; i < 3; i++ {
+		fire(t, buf, log.InfoLevel, fmt.Sprintf("second-batch line %d", i))
+	}
+	second := buf.TailSince(first.LastSeq, 0)
+	assert.Equal(t, 3, bytes.Count(second.Content, []byte("\n")),
+		"only the 3 new lines should come back")
+	assert.Contains(t, string(second.Content), "second-batch line 0")
+	assert.NotContains(t, string(second.Content), "first-batch",
+		"lines already delivered must not appear again")
+	assert.Equal(t, int64(8), second.LastSeq)
+}
+
+// TestLogBuffer_TailSinceSkipsInsideBatch exercises the case where the
+// caller's cursor falls in the middle of a finalized batch: TailSince
+// must skip the already-seen prefix by walking newlines within the
+// payload, not just returning the whole batch.
+func TestLogBuffer_TailSinceSkipsInsideBatch(t *testing.T) {
+	buf := newTestBuffer(t, 5, 1<<20)
+	// Two full batches: seqs 1-5 and 6-10.
+	for i := 0; i < 10; i++ {
+		fire(t, buf, log.InfoLevel, fmt.Sprintf("body-%02d", i+1))
+	}
+	require.Equal(t, 2, buf.BatchCount())
+
+	// Cursor at seq 7 -- inside the second batch. Expect seqs 8, 9, 10.
+	tail := buf.TailSince(7, 0)
+	assert.Equal(t, 3, bytes.Count(tail.Content, []byte("\n")))
+	assert.NotContains(t, string(tail.Content), "body-07",
+		"the line already seen at the cursor must not be re-emitted")
+	assert.Contains(t, string(tail.Content), "body-08")
+	assert.Contains(t, string(tail.Content), "body-10")
+	assert.Equal(t, int64(10), tail.LastSeq)
+}
+
+// TestLogBuffer_TailSincePendingOnly checks that TailSince includes lines
+// in the pending buffer even before they've been finalized into a batch.
+func TestLogBuffer_TailSincePendingOnly(t *testing.T) {
+	buf := newTestBuffer(t, 100, 1<<20)
+	for i := 0; i < 3; i++ {
+		fire(t, buf, log.InfoLevel, fmt.Sprintf("pending-only-%d", i))
+	}
+	assert.Equal(t, 0, buf.BatchCount(), "nothing finalized yet")
+	assert.Equal(t, 3, buf.PendingLineCount())
+
+	tail := buf.TailSince(0, 0)
+	assert.Equal(t, 3, bytes.Count(tail.Content, []byte("\n")))
+	assert.Contains(t, string(tail.Content), "pending-only-0")
+	assert.Contains(t, string(tail.Content), "pending-only-2")
+	assert.Equal(t, int64(3), tail.LastSeq)
+}
+
+// TestLogBuffer_TailSinceReportsEviction confirms that the oldest seq
+// still visible via TailSince advances after eviction, so a caller
+// resuming from a stale cursor sees the buffer's current window rather
+// than duplicates.
+func TestLogBuffer_TailSinceReportsEviction(t *testing.T) {
+	buf := newTestBuffer(t, 5, 200)
+	for round := 0; round < 20; round++ {
+		for i := 0; i < 5; i++ {
+			fire(t, buf, log.InfoLevel, strings.Repeat("filler ", 10))
+		}
+	}
+	tail := buf.TailSince(0, 0)
+	assert.Greater(t, tail.FirstSeq, int64(1),
+		"FirstSeq must advance past 1 once early batches are evicted")
+	assert.LessOrEqual(t, tail.FirstSeq, tail.LastSeq,
+		"FirstSeq and LastSeq must be consistent (FirstSeq <= LastSeq)")
+}
+
+// TestLogBuffer_TailSinceHonorsLimit confirms that when the buffer
+// contains far more lines than the caller's limit, TailSince drops the
+// oldest and returns exactly `limit` newest lines. LastSeq stays at the
+// buffer's newest and FirstSeq advances to reflect the truncated window
+// so a subsequent scroll-up (TailBefore(FirstSeq)) picks up the dropped
+// history.
+func TestLogBuffer_TailSinceHonorsLimit(t *testing.T) {
+	buf := newTestBuffer(t, 10, 1<<20)
+	for i := 0; i < 100; i++ {
+		fire(t, buf, log.InfoLevel, fmt.Sprintf("body-%03d", i+1))
+	}
+
+	tail := buf.TailSince(0, 30)
+	assert.Equal(t, 30, bytes.Count(tail.Content, []byte("\n")),
+		"limit=30 must return exactly 30 lines")
+	assert.Equal(t, int64(100), tail.LastSeq,
+		"LastSeq must point at the newest fired line")
+	assert.Equal(t, int64(71), tail.FirstSeq,
+		"FirstSeq must advance to the first seq in the truncated window")
+	assert.Contains(t, string(tail.Content), "body-071")
+	assert.Contains(t, string(tail.Content), "body-100")
+	assert.NotContains(t, string(tail.Content), "body-070",
+		"lines older than the truncation must not appear in the response")
+
+	// limit=0 must behave exactly like the pre-limit API -- return
+	// everything held.
+	full := buf.TailSince(0, 0)
+	assert.Equal(t, 100, bytes.Count(full.Content, []byte("\n")))
+	assert.Equal(t, int64(1), full.FirstSeq)
+}
+
+// TestLogBuffer_TailBeforeRoundsToBatch confirms that TailBefore returns
+// whole batches even when the caller asks for fewer lines than the batch
+// contains -- so the same batch is not decompressed twice as the user
+// scrolls further backwards.
+func TestLogBuffer_TailBeforeRoundsToBatch(t *testing.T) {
+	buf := newTestBuffer(t, 10, 1<<20)
+	// Three full batches of 10 lines each -- seqs 1-10, 11-20, 21-30.
+	for i := 0; i < 30; i++ {
+		fire(t, buf, log.InfoLevel, fmt.Sprintf("body-%02d", i+1))
+	}
+	require.Equal(t, 3, buf.BatchCount())
+
+	// Ask for just 3 lines before seq 21 (i.e. the seq range that opens
+	// with the batch containing seqs 11-20). The server must round up to
+	// the whole 10-line batch.
+	tail := buf.TailBefore(21, 3)
+	assert.Equal(t, 10, bytes.Count(tail.Content, []byte("\n")),
+		"count is a hint; whole batches are the pagination unit")
+	assert.Equal(t, int64(11), tail.FirstSeq)
+	assert.Equal(t, int64(20), tail.LastSeq)
+	assert.Contains(t, string(tail.Content), "body-11")
+	assert.Contains(t, string(tail.Content), "body-20")
+	assert.NotContains(t, string(tail.Content), "body-21",
+		"batch straddling the cursor must be clipped to seq < before")
+}
+
+// TestLogBuffer_TailBeforeSpansMultipleBatches: when count exceeds one
+// batch's worth, TailBefore accumulates whole batches oldest-side until
+// the total covers the request.
+func TestLogBuffer_TailBeforeSpansMultipleBatches(t *testing.T) {
+	buf := newTestBuffer(t, 5, 1<<20)
+	// Six batches of 5 lines each -- seqs 1-5, 6-10, ..., 26-30.
+	for i := 0; i < 30; i++ {
+		fire(t, buf, log.InfoLevel, fmt.Sprintf("body-%02d", i+1))
+	}
+	require.Equal(t, 6, buf.BatchCount())
+
+	// Ask for 12 lines before seq 31; expect 3 whole batches (seqs 16-30).
+	tail := buf.TailBefore(31, 12)
+	assert.Equal(t, 15, bytes.Count(tail.Content, []byte("\n")),
+		"12-line request must round up to 3 whole 5-line batches (15 lines)")
+	assert.Equal(t, int64(16), tail.FirstSeq)
+	assert.Equal(t, int64(30), tail.LastSeq)
+}
+
+// TestLogBuffer_TailBeforePaginates: successive TailBefore calls anchored
+// at the previous call's FirstSeq walk backwards batch-by-batch and
+// eventually reach the wall (Reached == true).
+func TestLogBuffer_TailBeforePaginates(t *testing.T) {
+	buf := newTestBuffer(t, 5, 1<<20)
+	for i := 0; i < 20; i++ {
+		fire(t, buf, log.InfoLevel, fmt.Sprintf("body-%02d", i+1))
+	}
+	require.Equal(t, 4, buf.BatchCount())
+
+	seen := map[int64]bool{}
+	before := int64(21) // "give me content older than the newest line"
+	for step := 0; step < 10; step++ {
+		tail := buf.TailBefore(before, 5)
+		if len(tail.Content) == 0 {
+			break
+		}
+		require.Greater(t, tail.LastSeq, int64(0))
+		for seq := tail.FirstSeq; seq <= tail.LastSeq; seq++ {
+			require.False(t, seen[seq], "TailBefore must not resend the same seq twice")
+			seen[seq] = true
+		}
+		if tail.Reached {
+			break
+		}
+		before = tail.FirstSeq
+	}
+	assert.Equal(t, 20, len(seen), "pagination must cover every seq 1..20 exactly once")
+}
+
+// TestLogBuffer_TailBeforePendingStraddle covers the unusual case where
+// `before` falls inside the pending buffer: no batches have finalized
+// yet and the caller asks for older content. TailBefore should return
+// pending lines with seq < before.
+func TestLogBuffer_TailBeforePendingStraddle(t *testing.T) {
+	buf := newTestBuffer(t, 100, 1<<20)
+	for i := 0; i < 5; i++ {
+		fire(t, buf, log.InfoLevel, fmt.Sprintf("pending-%d", i))
+	}
+	tail := buf.TailBefore(4, 10)
+	// Lines with seq < 4 -- seqs 1, 2, 3.
+	assert.Equal(t, 3, bytes.Count(tail.Content, []byte("\n")))
+	assert.Contains(t, string(tail.Content), "pending-0")
+	assert.Contains(t, string(tail.Content), "pending-2")
+	assert.NotContains(t, string(tail.Content), "pending-3")
+	assert.Equal(t, int64(1), tail.FirstSeq)
+	assert.Equal(t, int64(3), tail.LastSeq)
+}

--- a/config/log_buffer_test.go
+++ b/config/log_buffer_test.go
@@ -427,6 +427,42 @@ func TestLogBuffer_TailBeforePendingStraddle(t *testing.T) {
 	assert.Equal(t, int64(3), tail.LastSeq)
 }
 
+// Detaching the buffer rebuilds logrus's global hook set, as does every
+// level change. Both are read-modify-write over the same global, so they
+// have to be serialized: an interleaving drops whichever set was written
+// first, which would silently take the log file's writer hook with it.
+func TestLogBuffer_StopIsSafeAgainstConcurrentLevelChanges(t *testing.T) {
+	prev := GetEffectiveLogLevel()
+	t.Cleanup(func() {
+		StopLogRingBuffer()
+		SetLogging(prev)
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 25; j++ {
+				if i%2 == 0 {
+					StartLogRingBuffer(context.Background())
+					StopLogRingBuffer()
+				} else {
+					SetLogging(log.InfoLevel)
+					SetLogging(log.DebugLevel)
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// The censor must still be installed: losing it is the failure this
+	// guards against, and it is the hook that writes the log file.
+	StartLogRingBuffer(context.Background())
+	log.Info("after concurrent teardown")
+	assert.NotNil(t, GlobalLogRingBuffer(), "the buffer should be installed")
+}
+
 // A client polling with a cursor whose lines have since been evicted must be
 // told how many it missed. Cursors are opaque, so this is the only way it can
 // distinguish "nothing has happened" from "the server outran me".

--- a/config/log_buffer_test.go
+++ b/config/log_buffer_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -326,8 +327,7 @@ func TestLogBuffer_TailSinceHonorsLimit(t *testing.T) {
 	assert.NotContains(t, string(tail.Content), "body-070",
 		"lines older than the truncation must not appear in the response")
 
-	// limit=0 must behave exactly like the pre-limit API -- return
-	// everything held.
+	// A limit of 0 means unbounded: everything held is returned.
 	full := buf.TailSince(0, 0)
 	assert.Equal(t, 100, bytes.Count(full.Content, []byte("\n")))
 	assert.Equal(t, int64(1), full.FirstSeq)
@@ -425,4 +425,197 @@ func TestLogBuffer_TailBeforePendingStraddle(t *testing.T) {
 	assert.NotContains(t, string(tail.Content), "pending-3")
 	assert.Equal(t, int64(1), tail.FirstSeq)
 	assert.Equal(t, int64(3), tail.LastSeq)
+}
+
+// A client polling with a cursor whose lines have since been evicted must be
+// told how many it missed. Cursors are opaque, so this is the only way it can
+// distinguish "nothing has happened" from "the server outran me".
+func TestLogBuffer_ReportsEvictedLinesAsDropped(t *testing.T) {
+	buf := newTestBuffer(t, 5, 200)
+	for i := 0; i < 5; i++ {
+		fire(t, buf, log.InfoLevel, fmt.Sprintf("early line %d", i))
+	}
+	// Read once so we hold a realistic cursor, then outrun it by enough to
+	// force eviction of everything it covered.
+	cursor := buf.TailSince(0, 0).LastSeq
+	require.Greater(t, cursor, int64(0))
+	for i := 0; i < 100; i++ {
+		fire(t, buf, log.InfoLevel, fmt.Sprintf("later line %d with filler text", i))
+	}
+
+	tail := buf.TailSince(cursor, 0)
+	assert.Positive(t, tail.Dropped, "eviction past the caller's cursor must be reported")
+	assert.Equal(t, tail.FirstSeq-cursor-1, tail.Dropped,
+		"the count must be exactly the seq range missing between the cursor and the content")
+}
+
+// Trimming to `limit` also leaves a hole, and the caller has to be able to
+// tell -- otherwise a bounded initial load looks like the whole history.
+func TestLogBuffer_ReportsLimitTrimAsDropped(t *testing.T) {
+	buf := newTestBuffer(t, 1000, 1<<20)
+	for i := 0; i < 100; i++ {
+		fire(t, buf, log.InfoLevel, fmt.Sprintf("line %d", i))
+	}
+
+	tail := buf.TailSince(0, 10)
+	assert.Equal(t, 10, bytes.Count(tail.Content, []byte("\n")))
+	assert.Equal(t, int64(90), tail.Dropped, "the 90 trimmed lines must be reported")
+}
+
+// A caller that is keeping up sees no gap, so the viewer must not show a
+// break in an unbroken stream.
+func TestLogBuffer_NoDropReportedWhenCallerKeepsUp(t *testing.T) {
+	buf := newTestBuffer(t, 1000, 1<<20)
+	for i := 0; i < 10; i++ {
+		fire(t, buf, log.InfoLevel, fmt.Sprintf("line %d", i))
+	}
+	cursor := buf.TailSince(0, 0).LastSeq
+
+	// An idle poll, then a poll that picks up new lines: neither is a gap.
+	assert.Zero(t, buf.TailSince(cursor, 0).Dropped)
+	fire(t, buf, log.InfoLevel, "fresh line")
+	tail := buf.TailSince(cursor, 0)
+	assert.Zero(t, tail.Dropped)
+	assert.Contains(t, string(tail.Content), "fresh line")
+
+	// A first load (no cursor) is not a gap either: the caller never had
+	// the older lines to lose.
+	assert.Zero(t, buf.TailSince(0, 0).Dropped)
+}
+
+// Fire runs on every log line in the process while readers serve the log-read
+// API concurrently, so the two paths must be safe together and reads must not
+// hold the buffer's mutex across their decompression work.
+func TestLogBuffer_ConcurrentFireAndTail(t *testing.T) {
+	buf := newTestBuffer(t, 50, 64<<10)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				fire(t, buf, log.InfoLevel, fmt.Sprintf("writer-%d-line-%d", id, i))
+			}
+		}(w)
+	}
+	for r := 0; r < 3; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				buf.TailSince(0, 100)
+				buf.TailBefore(buf.TailSince(0, 0).LastSeq, 20)
+			}
+		}()
+	}
+
+	// Readers run until the writers are done, then drain.
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		close(stop)
+	}()
+	wg.Wait()
+
+	assert.LessOrEqual(t, buf.StoredBytes()+buf.PendingBytes(), 2*(64<<10),
+		"concurrent writers must not push the buffer past its budget")
+}
+
+// The web server logs every request path at Info, including for requests that
+// match no route, so line content and line length are both attacker-chosen.
+// Memory must stay bounded by Logging.Buffer.MaxSize no matter how few lines
+// it takes to get there -- eviction works in whole batches, so a pending
+// buffer that only seals on a line count never reclaims anything.
+func TestLogBuffer_BoundedByMaxSizeWithLongLines(t *testing.T) {
+	const maxBytes = 1 << 20
+	// Production defaults: a line budget high enough that byte pressure
+	// arrives long before the line counter would seal a batch.
+	buf := newTestBuffer(t, 10000, maxBytes)
+
+	huge := strings.Repeat("A", 500<<10)
+	for i := 0; i < 200; i++ {
+		fire(t, buf, log.InfoLevel, huge)
+	}
+
+	held := buf.StoredBytes() + buf.PendingBytes()
+	assert.LessOrEqual(t, held, 2*maxBytes,
+		"the buffer must stay near its configured cap regardless of line length")
+}
+
+// A single over-long line must not be able to flush every other line out of
+// the buffer, which would let a caller erase recent history on demand.
+func TestLogBuffer_TruncatesOverlongLines(t *testing.T) {
+	buf := newTestBuffer(t, 100, 1<<20)
+	fire(t, buf, log.InfoLevel, "keep-me")
+	fire(t, buf, log.InfoLevel, strings.Repeat("B", 1<<20))
+
+	content := buf.TailSince(0, 0).Content
+	assert.Contains(t, string(content), "keep-me",
+		"an over-long line should not evict the lines around it")
+	assert.Contains(t, string(content), "...[truncated]")
+	// Line-oriented paging depends on every stored line ending in a newline.
+	assert.Equal(t, 2, bytes.Count(content, []byte("\n")))
+	assert.Less(t, len(content), 2*maxBufferedLineBytes)
+}
+
+// sampleBearerToken is shaped to satisfy bearerTokenRegexStr: two "ey"-prefixed
+// segments of at least 18 characters and a signature of at least 64.
+const sampleBearerToken = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9." +
+	"eyJzdWIiOiJ1c2VyMSIsInNjb3BlIjoic3RvcmFnZS5yZWFkOi8ifQ." +
+	"c2lnbmF0dXJlYnl0ZXNjMmxuYm1GMGRYSmxZbmwwWlhOemFXZHVZWFIxY21WaWVYUmxjdw"
+
+// The buffer is readable by anyone holding pelican.log_read, a lesser
+// privilege than admin, so it must not retain credentials the on-disk log
+// censors. XRootD's forwarded output carries these tokens as query
+// parameters, and the signature is the part that makes a token replayable.
+func TestLogBuffer_RedactsBearerTokensInMessage(t *testing.T) {
+	buf := newTestBuffer(t, 100, 1<<20)
+	fire(t, buf, log.InfoLevel,
+		"XrdPfc_Cache: info Attach() pelican://example.com/foo?&authz=Bearer%20"+sampleBearerToken)
+
+	content := string(buf.TailSince(0, 0).Content)
+	assert.NotContains(t, content, sampleBearerToken)
+	assert.Contains(t, content, "REDACTED")
+	// The header and payload survive: they identify the issuer and subject,
+	// which is what makes a censored log useful for triage.
+	assert.Contains(t, content, "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9")
+}
+
+// The censor rewrites the "url" field as well as the message, so the buffer
+// must cover both.
+func TestLogBuffer_RedactsBearerTokensInURLField(t *testing.T) {
+	buf := newTestBuffer(t, 100, 1<<20)
+	entry := log.NewEntry(log.StandardLogger())
+	entry.Level = log.InfoLevel
+	entry.Time = time.Now()
+	entry.Message = "GET"
+	entry.Data = log.Fields{"url": "https://example.com/f?authz=Bearer%20" + sampleBearerToken}
+	require.NoError(t, buf.Fire(entry))
+
+	content := string(buf.TailSince(0, 0).Content)
+	assert.NotContains(t, content, sampleBearerToken)
+	assert.Contains(t, content, "REDACTED")
+}
+
+// Redaction must not disturb the entry logrus goes on to hand the remaining
+// hooks; the buffer censors a copy.
+func TestLogBuffer_RedactionLeavesCallerEntryIntact(t *testing.T) {
+	buf := newTestBuffer(t, 100, 1<<20)
+	raw := "authz=Bearer%20" + sampleBearerToken
+	entry := log.NewEntry(log.StandardLogger())
+	entry.Level = log.InfoLevel
+	entry.Time = time.Now()
+	entry.Message = raw
+	entry.Data = log.Fields{"url": "https://example.com/?" + raw}
+	require.NoError(t, buf.Fire(entry))
+
+	assert.Equal(t, raw, entry.Message)
+	assert.Equal(t, "https://example.com/?"+raw, entry.Data["url"])
 }

--- a/config/log_buffer_test.go
+++ b/config/log_buffer_test.go
@@ -81,6 +81,97 @@ func fire(t *testing.T, buf *LogRingBuffer, level log.Level, msg string) {
 	require.NoError(t, buf.Fire(entry))
 }
 
+// fireAt feeds an entry stamped with a caller-chosen time, so a test can
+// assert on the buffer's reported span rather than on wall-clock timing.
+func fireAt(t *testing.T, buf *LogRingBuffer, when time.Time, msg string) {
+	t.Helper()
+	entry := log.NewEntry(log.StandardLogger())
+	entry.Level = log.InfoLevel
+	entry.Message = msg
+	entry.Time = when
+	require.NoError(t, buf.Fire(entry))
+}
+
+// TestLogBuffer_SpanSurvivesCompression is the regression guard for the field
+// copy in compressOne: that function replaces the batch it compresses instead
+// of mutating it, so a field it forgets to carry across is lost within
+// milliseconds of the batch being sealed -- long before any operator reads it.
+// The test therefore waits for compression to have actually happened rather
+// than reading the span straight after the seal.
+func TestLogBuffer_SpanSurvivesCompression(t *testing.T) {
+	buf := newTestBuffer(t, 5, 1<<20)
+	first := time.Date(2026, 7, 20, 8, 0, 0, 0, time.UTC)
+	for i := 0; i < 5; i++ {
+		fireAt(t, buf, first.Add(time.Duration(i)*time.Minute), fmt.Sprintf("line %d", i))
+	}
+	require.Equal(t, 1, buf.BatchCount(), "five lines at batchLines=5 seal one batch")
+	require.Eventually(t, func() bool { return buf.CompressedBatchCount() == 1 },
+		2*time.Second, 5*time.Millisecond, "the worker should compress the sealed batch")
+
+	oldest, newest, ok := buf.Span()
+	require.True(t, ok, "a buffer holding dated lines must report a span")
+	assert.True(t, oldest.Equal(first), "oldest must be the first line's time, got %v", oldest)
+	assert.True(t, newest.Equal(first.Add(4*time.Minute)),
+		"newest must be the last line's time, got %v", newest)
+}
+
+// TestLogBuffer_SpanCoversPendingLines covers the other end: lines that have
+// not been sealed into a batch are held just as much as batched ones, and on a
+// quiet server they are all there is.
+func TestLogBuffer_SpanCoversPendingLines(t *testing.T) {
+	buf := newTestBuffer(t, 100, 1<<20)
+	first := time.Date(2026, 7, 20, 8, 0, 0, 0, time.UTC)
+	fireAt(t, buf, first, "only line")
+	fireAt(t, buf, first.Add(time.Minute), "second line")
+	require.Equal(t, 0, buf.BatchCount(), "batchLines=100 keeps these pending")
+
+	oldest, newest, ok := buf.Span()
+	require.True(t, ok)
+	assert.True(t, oldest.Equal(first))
+	assert.True(t, newest.Equal(first.Add(time.Minute)))
+}
+
+// TestLogBuffer_SpanFollowsEviction confirms the span describes what is still
+// held rather than what was ever written: the oldest end has to advance as
+// batches are evicted, or the viewer would offer a download of history the
+// buffer no longer has.
+func TestLogBuffer_SpanFollowsEviction(t *testing.T) {
+	buf := newTestBuffer(t, 5, 300)
+	first := time.Date(2026, 7, 20, 8, 0, 0, 0, time.UTC)
+	for i := 0; i < 100; i++ {
+		fireAt(t, buf, first.Add(time.Duration(i)*time.Minute),
+			fmt.Sprintf("line %d with enough text to fill the cap", i))
+	}
+	require.Less(t, buf.BatchCount(), 20, "the cap must have evicted early batches")
+
+	oldest, _, ok := buf.Span()
+	require.True(t, ok)
+	assert.True(t, oldest.After(first),
+		"the oldest end must advance past evicted lines, got %v", oldest)
+}
+
+// TestLogBuffer_SpanIgnoresUndatedLines covers an entry constructed without a
+// time -- not something logrus itself produces, but the zero value is what a
+// hand-built entry carries. One undated line must not blank the range, and a
+// buffer of nothing but undated lines must report no range at all rather than
+// year zero.
+func TestLogBuffer_SpanIgnoresUndatedLines(t *testing.T) {
+	buf := newTestBuffer(t, 100, 1<<20)
+	dated := time.Date(2026, 7, 20, 8, 0, 0, 0, time.UTC)
+	fireAt(t, buf, dated, "dated line")
+	fireAt(t, buf, time.Time{}, "undated line")
+
+	oldest, newest, ok := buf.Span()
+	require.True(t, ok, "one undated line must not suppress the whole span")
+	assert.True(t, oldest.Equal(dated))
+	assert.True(t, newest.Equal(dated), "the undated line must not become the newest end")
+
+	empty := newTestBuffer(t, 100, 1<<20)
+	fireAt(t, empty, time.Time{}, "undated only")
+	_, _, ok = empty.Span()
+	assert.False(t, ok, "a buffer with nothing datable reports no span")
+}
+
 // TestLogBuffer_BatchFinalization checks the primary invariant: once
 // batchLines entries have been fed in, a batch is finalized and the
 // pending buffer resets. Subsequent lines land in a fresh pending buffer.

--- a/config/logging.go
+++ b/config/logging.go
@@ -77,6 +77,16 @@ var (
 
 	// Track whether we've already configured the formatter to avoid resetting it
 	formatterConfigured bool
+
+	// effectiveLogLevel is the fast-path cache for GetEffectiveLogLevel.
+	// Read on the hot log-buffer path (shouldBuffer runs on every incoming
+	// log line), so the original mutex+atomic-load+slice-walk implementation
+	// was expensive under trace/debug loads. Every level-changing site --
+	// SetLogging (called by the param-callback registered via
+	// RegisterLoggingCallback), initFilterLogging, and
+	// ResetGlobalLoggingHooks -- writes the new level here, so a plain
+	// atomic load is enough to answer the query.
+	effectiveLogLevel atomic.Uint32
 )
 
 func (sw *syncWriter) Write(p []byte) (n int, err error) {
@@ -124,6 +134,10 @@ func init() {
 	globalTransform.hook.Store(initialHook)
 	initialRegex := regexp.MustCompile(bearerTokenRegexStr)
 	globalTransform.regex.Store(initialRegex)
+	// Seed the effective-level cache with logrus's boot default (info)
+	// so GetEffectiveLogLevel returns something sane between package
+	// init and the first SetLogging call.
+	effectiveLogLevel.Store(uint32(log.GetLevel()))
 }
 
 func (fh *RegexpFilterHook) Levels() []log.Level {
@@ -190,6 +204,14 @@ func initFilterLogging() {
 	filters := make([]*RegexpFilter, 0)
 	globalFilters.filters.Store(&filters)
 
+	// On the FIRST init pass, log.GetLevel() reflects the operator's
+	// configured level. On subsequent passes (unit-test reinit, config
+	// reload paths that re-enter this function) it reflects the pinned
+	// TraceLevel we set below -- reading it then would clobber the
+	// effective-level cache with Trace and cause the log buffer to
+	// silently capture trace lines the operator never asked for.
+	// Guard the cache update behind the same first-time-only gate that
+	// installs the hooks.
 	configLevel := log.GetLevel()
 	log.SetLevel(log.TraceLevel)
 	hookLevel := make([]log.Level, 0)
@@ -204,6 +226,7 @@ func initFilterLogging() {
 	globalTransformMu.Lock()
 	if !addedGlobalFilters {
 		addedGlobalFilters = true
+		effectiveLogLevel.Store(uint32(configLevel))
 		globalTransformMu.Unlock()
 		// Set the writer to what logrus has
 		newHook := &writer.Hook{
@@ -237,6 +260,11 @@ func ResetGlobalLoggingHooks() {
 		}
 		globalTransform.hook.Store(newHook)
 	}
+	// The hook was just widened back to AllLevels, so anything through
+	// TraceLevel is now nominally "effective". Match that in the cache
+	// so GetEffectiveLogLevel doesn't return a stale narrower level from
+	// the previous test.
+	effectiveLogLevel.Store(uint32(log.TraceLevel))
 }
 
 func AddFilter(newFilter *RegexpFilter) {
@@ -263,6 +291,11 @@ func RemoveFilter(name string) {
 }
 
 func SetLogging(logLevel log.Level) {
+	// Update the fast-path cache first so any log-buffer Fire that fires
+	// mid-reconfiguration reads at worst a slightly-early-but-still-valid
+	// value rather than a stale one from before this call.
+	effectiveLogLevel.Store(uint32(logLevel))
+
 	// Only configure the formatter once to preserve formatting across log level changes
 	if !formatterConfigured {
 		textFormatter := log.TextFormatter{}
@@ -332,31 +365,16 @@ func SetLogging(logLevel log.Level) {
 	}
 }
 
-// GetEffectiveLogLevel returns the effective log level based on the transform hook.
-// When global filters are active, logrus's log.GetLevel() is set to TraceLevel to allow
-// filters to see all messages, while the actual filtering happens via hooks. This function
-// returns the true effective level by examining what levels the hook is configured to output.
+// GetEffectiveLogLevel returns the effective log level -- the level the
+// operator asked for, as opposed to logrus's internal log.GetLevel()
+// which is pinned to TraceLevel whenever the hook-based filter tree is
+// active (so hooks see every entry). The value is served from an atomic
+// cache updated by SetLogging, initFilterLogging, and
+// ResetGlobalLoggingHooks; the hot path (LogRingBuffer.shouldBuffer,
+// invoked on every entry) is therefore a single atomic load with no
+// mutex contention or slice walk.
 func GetEffectiveLogLevel() log.Level {
-	globalTransformMu.Lock()
-	defer globalTransformMu.Unlock()
-	if addedGlobalFilters && globalTransform != nil {
-		hook := globalTransform.hook.Load()
-		if hook == nil {
-			return log.GetLevel()
-		}
-		// Find the highest (most verbose) level in the hook's configured levels.
-		// In logrus, higher numeric values = more verbose (Trace=6 > Debug=5 > ... > Panic=0).
-		// The hook's LogLevels contains all levels that should be output, so the max
-		// value represents the effective log level.
-		var maxLevel log.Level
-		for _, hookLvl := range hook.LogLevels {
-			if hookLvl > maxLevel {
-				maxLevel = hookLvl
-			}
-		}
-		return maxLevel
-	}
-	return log.GetLevel()
+	return log.Level(effectiveLogLevel.Load())
 }
 
 // Disable the logging censor functionality

--- a/config/logging.go
+++ b/config/logging.go
@@ -75,8 +75,10 @@ var (
 
 	globalTransform *regexpTransformHook
 
-	// Track whether we've already configured the formatter to avoid resetting it
-	formatterConfigured bool
+	// Guards the one-time formatter setup. SetLogging is reachable
+	// concurrently -- the runtime log-level API calls it per request -- so
+	// the "have we done this yet" flag cannot be a plain bool.
+	formatterOnce sync.Once
 
 	// effectiveLogLevel is the fast-path cache for GetEffectiveLogLevel.
 	// shouldBuffer reads it on every incoming log line, so answering the
@@ -356,7 +358,7 @@ func SetLogging(logLevel log.Level) {
 	effectiveLogLevel.Store(uint32(logLevel))
 
 	// Only configure the formatter once to preserve formatting across log level changes
-	if !formatterConfigured {
+	formatterOnce.Do(func() {
 		textFormatter := log.TextFormatter{}
 		textFormatter.DisableLevelTruncation = true
 		textFormatter.FullTimestamp = true
@@ -365,8 +367,7 @@ func SetLogging(logLevel log.Level) {
 		// and provide our check. Note that when calling SetLogging, io.Out hasn't been changed yet.
 		textFormatter.ForceColors = term.IsTerminal(log.StandardLogger().Out)
 		log.SetFormatter(&textFormatter)
-		formatterConfigured = true
-	}
+	})
 
 	// When global filters are active, we use hook-based filtering instead of logrus's
 	// internal level filtering. We set logrus to TraceLevel (the most permissive) so

--- a/config/logging.go
+++ b/config/logging.go
@@ -79,13 +79,14 @@ var (
 	formatterConfigured bool
 
 	// effectiveLogLevel is the fast-path cache for GetEffectiveLogLevel.
-	// Read on the hot log-buffer path (shouldBuffer runs on every incoming
-	// log line), so the original mutex+atomic-load+slice-walk implementation
-	// was expensive under trace/debug loads. Every level-changing site --
-	// SetLogging (called by the param-callback registered via
-	// RegisterLoggingCallback), initFilterLogging, and
-	// ResetGlobalLoggingHooks -- writes the new level here, so a plain
-	// atomic load is enough to answer the query.
+	// shouldBuffer reads it on every incoming log line, so answering the
+	// query must stay a single atomic load: it cannot take
+	// globalTransformMu or walk the transform hook's LogLevels slice, which
+	// is what the level would otherwise have to be derived from. Keeping
+	// that true is the job of every level-changing site -- SetLogging
+	// (called by the param-callback registered via RegisterLoggingCallback),
+	// initFilterLogging, and ResetGlobalLoggingHooks -- each of which writes
+	// the new level here.
 	effectiveLogLevel atomic.Uint32
 )
 
@@ -181,19 +182,77 @@ func (rt *regexpTransformHook) Fire(entry *log.Entry) (err error) {
 		return nil
 	}
 
-	regex := rt.regex.Load()
-	if regex != nil {
-		entry.Message = regex.ReplaceAllString(entry.Message, rt.template)
-		for key, value := range entry.Data {
-			if key != "url" {
-				continue
-			}
-			if s, ok := value.(string); ok {
-				entry.Data[key] = regex.ReplaceAllString(s, rt.template)
-			}
+	redactEntryInPlace(entry)
+	return hook.Fire(entry)
+}
+
+// redactEntryInPlace censors credentials in an entry's message and "url"
+// field. Mutating the caller's entry is what makes the censor effective for
+// logrus's own output path: this hook owns the writer, so every consumer
+// downstream of it sees the censored text.
+//
+// Any consumer that reads an entry WITHOUT going through this hook -- a hook
+// registered ahead of this one, or one that formats the entry itself -- sees
+// the raw credential and must call redactEntryCopy instead. Hook order is not
+// a durable guarantee: SetLogging rebuilds the hook set and re-appends the
+// global hooks last, so a hook installed earlier stays ahead of this one.
+func redactEntryInPlace(entry *log.Entry) {
+	regex := globalTransform.regex.Load()
+	if regex == nil {
+		return
+	}
+	entry.Message = regex.ReplaceAllString(entry.Message, globalTransform.template)
+	for key, value := range entry.Data {
+		if key != "url" {
+			continue
+		}
+		if s, ok := value.(string); ok {
+			entry.Data[key] = regex.ReplaceAllString(s, globalTransform.template)
 		}
 	}
-	return hook.Fire(entry)
+}
+
+// redactEntryCopy returns a censored copy of entry, leaving the caller's entry
+// untouched so hooks that run later still observe what logrus handed them.
+// The copy is shallow apart from Data, which is cloned only when it holds a
+// field the censor rewrites.
+//
+// Callers that format an entry into storage a user can read back -- rather
+// than into the writer redactEntryInPlace already covers -- must route it
+// through here first.
+func redactEntryCopy(entry *log.Entry) *log.Entry {
+	regex := globalTransform.regex.Load()
+	if regex == nil {
+		return entry
+	}
+	template := globalTransform.template
+
+	message := regex.ReplaceAllString(entry.Message, template)
+	// Rewrite "url" only when the censor actually changes it, so the common
+	// case (no credential in the entry) allocates nothing.
+	var data log.Fields
+	if raw, ok := entry.Data["url"].(string); ok {
+		if censored := regex.ReplaceAllString(raw, template); censored != raw {
+			data = make(log.Fields, len(entry.Data))
+			for k, v := range entry.Data {
+				data[k] = v
+			}
+			data["url"] = censored
+		}
+	}
+	if message == entry.Message && data == nil {
+		return entry
+	}
+
+	dup := *entry
+	dup.Message = message
+	if data != nil {
+		dup.Data = data
+	}
+	// The formatter writes into Buffer when it is non-nil; that buffer belongs
+	// to logrus's own write path and must not be shared with a copy.
+	dup.Buffer = nil
+	return &dup
 }
 
 func initFilterLogging() {

--- a/config/logging_rotation_test.go
+++ b/config/logging_rotation_test.go
@@ -1,0 +1,101 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/logging"
+	"github.com/pelicanplatform/pelican/param"
+)
+
+// TestFileLoggingThroughRedactionFilter is the belt-and-suspenders check that the
+// asynchronous, rotating file writer is correctly wired as the sink for the
+// redaction/filter hook path used in production.
+//
+// It mirrors the production init order (FlushLogs(true) installs the async file
+// writer as the logrus output, then initFilterLogging() captures that output as
+// the transform hook's writer) and asserts that a log line containing a bearer
+// token is (a) written to the on-disk log file and (b) redacted on the way.
+func TestFileLoggingThroughRedactionFilter(t *testing.T) {
+	require.NoError(t, param.Reset())
+
+	t.Cleanup(func() {
+		logging.CloseLogger()
+		logging.ResetLogFlush()
+		ResetGlobalLoggingHooks()
+		// Re-establish the censor regex for any later tests in this package.
+		globalTransform.regex.Store(regexp.MustCompile(bearerTokenRegexStr))
+		log.SetOutput(os.Stderr)
+		log.SetLevel(log.InfoLevel)
+		_ = param.Reset()
+	})
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "pelican.log")
+
+	require.NoError(t, param.Logging_LogLocation.Set(logPath))
+	require.NoError(t, param.Logging_Rotation_Frequency.Set("daily"))
+	require.NoError(t, param.Logging_Rotation_DisableCompress.Set(true))
+
+	// Start from a clean logging state, then mirror the production sequence.
+	logging.ResetLogFlush()
+	logging.SetupLogBuffering()
+
+	egrp, egrpCtx := errgroup.WithContext(context.Background())
+	logging.SetErrgroup(egrpCtx, egrp)
+
+	// Ensure the censor is active and the configured level admits Info.
+	globalTransform.regex.Store(regexp.MustCompile(bearerTokenRegexStr))
+	log.SetLevel(log.InfoLevel)
+
+	// 1) Install the async (rotating) file writer as the logrus output.
+	logging.FlushLogs(true)
+	// 2) Install the redaction/filter hooks, which capture the current output
+	//    (the async writer) as the transform hook's sink -- exactly as InitServer
+	//    and InitClient do (FlushLogs runs before initFilterLogging).
+	initFilterLogging()
+
+	// A bearer token embedded in a URL, like the ones the censor targets.
+	signature := strings.Repeat("a", 64)
+	token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0dXNlciIsImlhdCI6MTUxNjIzOTAyMn0." + signature
+	log.Infof("transfer marker-line url=pelican://example.org/data?authz=Bearer%%20%s", token)
+
+	// Drain + flip to synchronous mode so everything is on disk.
+	logging.EnterSyncMode()
+	require.NoError(t, egrp.Wait())
+
+	content, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	got := string(content)
+
+	assert.Contains(t, got, "marker-line", "the log line should be written to the rotating file")
+	assert.Contains(t, got, "REDACTED", "the bearer token should be redacted by the filter hook")
+	assert.NotContains(t, got, signature, "the raw token signature must not appear in the log file")
+}

--- a/config/logging_rotation_test.go
+++ b/config/logging_rotation_test.go
@@ -1,0 +1,101 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/logging"
+	"github.com/pelicanplatform/pelican/param"
+)
+
+// TestFileLoggingThroughRedactionFilter is the belt-and-suspenders check that the
+// asynchronous, rotating file writer is correctly wired as the sink for the
+// redaction/filter hook path used in production.
+//
+// It mirrors the production init order (FlushLogs(true) installs the async file
+// writer as the logrus output, then initFilterLogging() captures that output as
+// the transform hook's writer) and asserts that a log line containing a bearer
+// token is (a) written to the on-disk log file and (b) redacted on the way.
+func TestFileLoggingThroughRedactionFilter(t *testing.T) {
+	require.NoError(t, param.Reset())
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "pelican.log")
+
+	t.Cleanup(func() {
+		logging.CloseLogger()
+		logging.ResetLogFlush()
+		ResetGlobalLoggingHooks()
+		// Re-establish the censor regex for any later tests in this package.
+		globalTransform.regex.Store(regexp.MustCompile(bearerTokenRegexStr))
+		log.SetOutput(os.Stderr)
+		log.SetLevel(log.InfoLevel)
+		_ = param.Reset()
+	})
+
+	require.NoError(t, param.Logging_LogLocation.Set(logPath))
+	require.NoError(t, param.Logging_Rotation_Frequency.Set("daily"))
+	require.NoError(t, param.Logging_Rotation_DisableCompress.Set(true))
+
+	// Start from a clean logging state, then mirror the production sequence.
+	logging.ResetLogFlush()
+	logging.SetupLogBuffering()
+
+	egrp, egrpCtx := errgroup.WithContext(context.Background())
+	logging.SetErrgroup(egrpCtx, egrp)
+
+	// Ensure the censor is active and the configured level admits Info.
+	globalTransform.regex.Store(regexp.MustCompile(bearerTokenRegexStr))
+	log.SetLevel(log.InfoLevel)
+
+	// 1) Install the async (rotating) file writer as the logrus output.
+	logging.FlushLogs(true)
+	// 2) Install the redaction/filter hooks, which capture the current output
+	//    (the async writer) as the transform hook's sink -- exactly as InitServer
+	//    and InitClient do (FlushLogs runs before initFilterLogging).
+	initFilterLogging()
+
+	// A bearer token embedded in a URL, like the ones the censor targets.
+	signature := strings.Repeat("a", 64)
+	token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0dXNlciIsImlhdCI6MTUxNjIzOTAyMn0." + signature
+	log.Infof("transfer marker-line url=pelican://example.org/data?authz=Bearer%%20%s", token)
+
+	// Drain + flip to synchronous mode so everything is on disk.
+	logging.EnterSyncMode()
+	require.NoError(t, egrp.Wait())
+
+	content, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	got := string(content)
+
+	assert.Contains(t, got, "marker-line", "the log line should be written to the rotating file")
+	assert.Contains(t, got, "REDACTED", "the bearer token should be redacted by the filter hook")
+	assert.NotContains(t, got, signature, "the raw token signature must not appear in the log file")
+}

--- a/config/logging_rotation_test.go
+++ b/config/logging_rotation_test.go
@@ -46,6 +46,9 @@ import (
 func TestFileLoggingThroughRedactionFilter(t *testing.T) {
 	require.NoError(t, param.Reset())
 
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "pelican.log")
+
 	t.Cleanup(func() {
 		logging.CloseLogger()
 		logging.ResetLogFlush()
@@ -56,9 +59,6 @@ func TestFileLoggingThroughRedactionFilter(t *testing.T) {
 		log.SetLevel(log.InfoLevel)
 		_ = param.Reset()
 	})
-
-	dir := t.TempDir()
-	logPath := filepath.Join(dir, "pelican.log")
 
 	require.NoError(t, param.Logging_LogLocation.Set(logPath))
 	require.NoError(t, param.Logging_Rotation_Frequency.Set("daily"))

--- a/config/logging_rotation_test.go
+++ b/config/logging_rotation_test.go
@@ -99,3 +99,42 @@ func TestFileLoggingThroughRedactionFilter(t *testing.T) {
 	assert.Contains(t, got, "REDACTED", "the bearer token should be redacted by the filter hook")
 	assert.NotContains(t, got, signature, "the raw token signature must not appear in the log file")
 }
+
+// The in-memory buffer is served back over the log-read API, so it must hold
+// the same censored text the log file does. This asserts that with the hook
+// installation order InitServer actually uses: the ring buffer is installed
+// well before the censor, so it cannot depend on the censor having already
+// rewritten the entry.
+func TestLogRingBufferRedactsUnderProductionHookOrder(t *testing.T) {
+	require.NoError(t, param.Reset())
+
+	t.Cleanup(func() {
+		StopLogRingBuffer()
+		ResetGlobalLoggingHooks()
+		globalTransform.regex.Store(regexp.MustCompile(bearerTokenRegexStr))
+		log.SetOutput(os.Stderr)
+		log.SetLevel(log.InfoLevel)
+		_ = param.Reset()
+	})
+
+	globalTransform.regex.Store(regexp.MustCompile(bearerTokenRegexStr))
+	log.SetLevel(log.InfoLevel)
+
+	// InitServer installs the ring buffer first and the censor afterwards;
+	// logrus fires hooks in installation order.
+	StartLogRingBuffer(context.Background())
+	initFilterLogging()
+
+	signature := strings.Repeat("b", 64)
+	token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0dXNlciIsImlhdCI6MTUxNjIzOTAyMn0." + signature
+	log.Infof("XrdPfc_Cache: info Attach() pelican://example.org/data?&authz=Bearer%%20%s", token)
+
+	buf := GlobalLogRingBuffer()
+	require.NotNil(t, buf, "the ring buffer should be installed")
+	got := string(buf.TailSince(0, 0).Content)
+
+	assert.Contains(t, got, "XrdPfc_Cache", "the line should reach the buffer")
+	assert.Contains(t, got, "REDACTED")
+	assert.NotContains(t, got, signature,
+		"a pelican.log_read holder must not be able to read a replayable token out of the buffer")
+}

--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -366,6 +366,10 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 		val = strings.ReplaceAll(val, "${LocalCache.RunLocation}", v.GetString(param.LocalCache_RunLocation.GetName()))
 		v.SetDefault(param.LocalCache_Socket.GetName(), val)
 	}
+	// Logging.Buffer.BatchLines
+	v.SetDefault(param.Logging_Buffer_BatchLines.GetName(), 10000)
+	// Logging.Buffer.MaxSize
+	v.SetDefault(param.Logging_Buffer_MaxSize.GetName(), "1MB")
 	// Logging.Cache.Http
 	v.SetDefault(param.Logging_Cache_Http.GetName(), "error")
 	// Logging.Cache.Lotman

--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -417,9 +417,9 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 	// Logging.Rotation.MaxRetentionPeriod
 	v.SetDefault(param.Logging_Rotation_MaxRetentionPeriod.GetName(), "720h")
 	// Logging.Rotation.MaxRetentionSize
-	v.SetDefault(param.Logging_Rotation_MaxRetentionSize.GetName(), "10GB")
+	v.SetDefault(param.Logging_Rotation_MaxRetentionSize.GetName(), "1GB")
 	// Logging.Rotation.MaxSize
-	v.SetDefault(param.Logging_Rotation_MaxSize.GetName(), "1GB")
+	v.SetDefault(param.Logging_Rotation_MaxSize.GetName(), "100MB")
 	// Lotman.DefaultLotDeletionLifetime
 	v.SetDefault(param.Lotman_DefaultLotDeletionLifetime.GetName(), "48h")
 	// Lotman.DefaultLotExpirationLifetime

--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -402,6 +402,20 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 	v.SetDefault(param.Logging_Origin_Xrd.GetName(), "error")
 	// Logging.Origin.Xrootd
 	v.SetDefault(param.Logging_Origin_Xrootd.GetName(), "info")
+	// Logging.Rotation.Disable
+	v.SetDefault(param.Logging_Rotation_Disable.GetName(), false)
+	// Logging.Rotation.DisableCompress
+	v.SetDefault(param.Logging_Rotation_DisableCompress.GetName(), false)
+	// Logging.Rotation.FlushInterval
+	v.SetDefault(param.Logging_Rotation_FlushInterval.GetName(), "50ms")
+	// Logging.Rotation.Frequency
+	v.SetDefault(param.Logging_Rotation_Frequency.GetName(), "daily")
+	// Logging.Rotation.MaxRetentionPeriod
+	v.SetDefault(param.Logging_Rotation_MaxRetentionPeriod.GetName(), "720h")
+	// Logging.Rotation.MaxRetentionSize
+	v.SetDefault(param.Logging_Rotation_MaxRetentionSize.GetName(), "10GB")
+	// Logging.Rotation.MaxSize
+	v.SetDefault(param.Logging_Rotation_MaxSize.GetName(), "1GB")
 	// Lotman.DefaultLotDeletionLifetime
 	v.SetDefault(param.Lotman_DefaultLotDeletionLifetime.GetName(), "48h")
 	// Lotman.DefaultLotExpirationLifetime

--- a/config/resources/defaults.yaml
+++ b/config/resources/defaults.yaml
@@ -17,6 +17,12 @@
 Logging:
   Client:
     ProgressInterval: 1m
+  Rotation:
+    Frequency: daily
+    MaxSize: 1GB
+    MaxRetentionSize: 10GB
+    MaxRetentionPeriod: 720h
+    FlushInterval: 50ms
 Client:
   SlowTransferRampupTime: 100s
   SlowTransferWindow: 30s

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -217,6 +217,94 @@ type: filename
 default: none
 components: ["*"]
 ---
+name: Logging.Rotation.Disable
+description: |+
+  By default, when ${Logging.LogLocation} points at a regular file, Pelican
+  manages log rotation itself: the active log file is rotated whenever either the
+  calendar boundary (set by ${Logging.Rotation.Frequency}) is crossed or the size
+  threshold set by ${Logging.Rotation.MaxSize} is reached; rotated files are
+  compressed (unless ${Logging.Rotation.DisableCompress} is set) and old files
+  pruned per ${Logging.Rotation.MaxRetentionSize} and
+  ${Logging.Rotation.MaxRetentionPeriod}. Set this to true to disable Pelican's
+  built-in rotation entirely (for example, when an external service such as
+  logrotate manages the file).
+
+  Rotation is also automatically disabled when the log target is not a regular
+  file (for example, the empty default which logs to `stderr`, or a special file
+  such as `/dev/stdout`, a pipe, or a device), regardless of this setting.
+  Pelican assumes it is the only process rotating the file; multiple daemons on
+  the same file may be problematic.
+type: bool
+default: false
+components: ["*"]
+---
+name: Logging.Rotation.Frequency
+description: |+
+  How often the active log file is rotated on a calendar boundary, so
+  administrators can find logs by date. Accepted values are "daily", "hourly",
+  and "none" (case-insensitive); use "none" to disable time-based rotation and
+  rely solely on ${Logging.Rotation.MaxSize}.
+
+  Time-based rotation happens at the calendar boundary (local time): "daily"
+  rotates at midnight, "hourly" at the top of each hour. Each rotated file is
+  named for the period during which it was written -- the active file is renamed
+  with a suffix of the period's start: "<logfile>.2006-01-02" for daily and
+  "<logfile>.2006-01-02T15" for hourly. When time-based rotation is disabled
+  ("none"), size-triggered rotations are named with a full timestamp suffix
+  "<logfile>.2006-01-02T15-04-05". If more than one rotation occurs within the
+  same suffix, an incrementing "-N" is appended to keep names unique.
+type: string
+default: daily
+components: ["*"]
+---
+name: Logging.Rotation.MaxSize
+description: |+
+  The size threshold at which the active log file is rotated, e.g. "100MB" or
+  "1GB". Set to "0" to disable size-based rotation and rely solely on
+  ${Logging.Rotation.Frequency}. Size- and time-based rotation may be combined.
+type: string
+default: 1GB
+components: ["*"]
+---
+name: Logging.Rotation.MaxRetentionSize
+description: |+
+  The maximum total size of retained rotated (and compressed) log files, e.g.
+  "10GB". When the combined size of the rotated files would exceed this, the
+  oldest are deleted until it fits (the most recent rotated file is always kept).
+  Set to "0" to not limit retention by size. Applied independently of
+  ${Logging.Rotation.MaxRetentionPeriod}.
+type: string
+default: 10GB
+components: ["*"]
+---
+name: Logging.Rotation.MaxRetentionPeriod
+description: |+
+  The maximum age of retained rotated log files; rotated files older than this
+  are deleted. Set to 0 to not limit retention by age. Applied independently of
+  ${Logging.Rotation.MaxRetentionSize}.
+type: duration
+default: 720h
+components: ["*"]
+---
+name: Logging.Rotation.DisableCompress
+description: |+
+  By default, rotated log files are compressed with gzip (producing a `.gz`
+  suffix) by a background worker after rotation. Set this to true to keep rotated
+  files uncompressed.
+type: bool
+default: false
+components: ["*"]
+---
+name: Logging.Rotation.FlushInterval
+description: |+
+  The maximum interval the asynchronous log writer waits before flushing
+  buffered log lines to the log file. Lower values reduce the window in which
+  buffered lines could be lost; higher values reduce wakeups and syscalls.
+type: duration
+hidden: true
+default: 50ms
+components: ["*"]
+---
 name: Logging.Client.DisableProgressBars
 description: |+
   A bool defining whether the client should emit progress bars to track download progress.

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -327,6 +327,94 @@ type: filename
 default: none
 components: ["*"]
 ---
+name: Logging.Rotation.Disable
+description: |+
+  By default, when ${Logging.LogLocation} points at a regular file, Pelican
+  manages log rotation itself: the active log file is rotated whenever either the
+  calendar boundary (set by ${Logging.Rotation.Frequency}) is crossed or the size
+  threshold set by ${Logging.Rotation.MaxSize} is reached; rotated files are
+  compressed (unless ${Logging.Rotation.DisableCompress} is set) and old files
+  pruned per ${Logging.Rotation.MaxRetentionSize} and
+  ${Logging.Rotation.MaxRetentionPeriod}. Set this to true to disable Pelican's
+  built-in rotation entirely (for example, when an external service such as
+  logrotate manages the file).
+
+  Rotation is also automatically disabled when the log target is not a regular
+  file (for example, the empty default which logs to `stderr`, or a special file
+  such as `/dev/stdout`, a pipe, or a device), regardless of this setting.
+  Pelican assumes it is the only process rotating the file; multiple daemons on
+  the same file may be problematic.
+type: bool
+default: false
+components: ["*"]
+---
+name: Logging.Rotation.Frequency
+description: |+
+  How often the active log file is rotated on a calendar boundary, so
+  administrators can find logs by date. Accepted values are "daily", "hourly",
+  and "none" (case-insensitive); use "none" to disable time-based rotation and
+  rely solely on ${Logging.Rotation.MaxSize}.
+
+  Time-based rotation happens at the calendar boundary (local time): "daily"
+  rotates at midnight, "hourly" at the top of each hour. Each rotated file is
+  named for the period during which it was written -- the active file is renamed
+  with a suffix of the period's start: "<logfile>.2006-01-02" for daily and
+  "<logfile>.2006-01-02T15" for hourly. When time-based rotation is disabled
+  ("none"), size-triggered rotations are named with a full timestamp suffix
+  "<logfile>.2006-01-02T15-04-05". If more than one rotation occurs within the
+  same suffix, an incrementing "-N" is appended to keep names unique.
+type: string
+default: daily
+components: ["*"]
+---
+name: Logging.Rotation.MaxSize
+description: |+
+  The size threshold at which the active log file is rotated, e.g. "100MB" or
+  "1GB". Set to "0" to disable size-based rotation and rely solely on
+  ${Logging.Rotation.Frequency}. Size- and time-based rotation may be combined.
+type: string
+default: 1GB
+components: ["*"]
+---
+name: Logging.Rotation.MaxRetentionSize
+description: |+
+  The maximum total size of retained rotated (and compressed) log files, e.g.
+  "10GB". When the combined size of the rotated files would exceed this, the
+  oldest are deleted until it fits (the most recent rotated file is always kept).
+  Set to "0" to not limit retention by size. Applied independently of
+  ${Logging.Rotation.MaxRetentionPeriod}.
+type: string
+default: 10GB
+components: ["*"]
+---
+name: Logging.Rotation.MaxRetentionPeriod
+description: |+
+  The maximum age of retained rotated log files; rotated files older than this
+  are deleted. Set to 0 to not limit retention by age. Applied independently of
+  ${Logging.Rotation.MaxRetentionSize}.
+type: duration
+default: 720h
+components: ["*"]
+---
+name: Logging.Rotation.DisableCompress
+description: |+
+  By default, rotated log files are compressed with gzip (producing a `.gz`
+  suffix) by a background worker after rotation. Set this to true to keep rotated
+  files uncompressed.
+type: bool
+default: false
+components: ["*"]
+---
+name: Logging.Rotation.FlushInterval
+description: |+
+  The maximum interval the asynchronous log writer waits before flushing
+  buffered log lines to the log file. Lower values reduce the window in which
+  buffered lines could be lost; higher values reduce wakeups and syscalls.
+type: duration
+hidden: true
+default: 50ms
+components: ["*"]
+---
 name: Logging.Client.DisableProgressBars
 description: |+
   A bool defining whether the client should emit progress bars to track download progress.

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -415,6 +415,27 @@ hidden: true
 default: 50ms
 components: ["*"]
 ---
+name: Logging.Buffer.MaxSize
+description: |+
+  Upper bound on the size of the memory buffer for recent log lines, e.g.
+  "1MB" or "512K". Older log lines are evicted as newer ones arrive so the
+  buffer stays at or below this size. The larger the value, the more logging
+  history is available via the web interface.
+type: string
+default: 1MB
+components: ["*"]
+---
+name: Logging.Buffer.BatchLines
+description: |+
+  Number of log lines accumulated before the in-memory log buffer finalizes a
+  batch (making it visible to readers and eligible for eviction). Higher
+  values compress better and evict more coarsely; lower values stay uncompressed
+  for longer.
+type: int
+hidden: true
+default: 10000
+components: ["*"]
+---
 name: Logging.Client.DisableProgressBars
 description: |+
   A bool defining whether the client should emit progress bars to track download progress.

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -372,8 +372,14 @@ description: |+
   The size threshold at which the active log file is rotated, e.g. "100MB" or
   "1GB". Set to "0" to disable size-based rotation and rely solely on
   ${Logging.Rotation.Frequency}. Size- and time-based rotation may be combined.
+
+  Together with ${Logging.Rotation.MaxRetentionSize} this bounds the disk the
+  logs may occupy: the default pair reserves a little over 1GB. Raise both on a
+  server whose logs are worth keeping longer; the defaults are chosen to be
+  unobtrusive on a workstation, where the client agent writes under the user's
+  own directory.
 type: string
-default: 1GB
+default: 100MB
 components: ["*"]
 ---
 name: Logging.Rotation.MaxRetentionSize
@@ -383,8 +389,13 @@ description: |+
   oldest are deleted until it fits (the most recent rotated file is always kept).
   Set to "0" to not limit retention by size. Applied independently of
   ${Logging.Rotation.MaxRetentionPeriod}.
+
+  This is also the ceiling on the active log file when rotation is failing:
+  with nothing able to rotate it, the active file is the only log on disk, and
+  growth past this budget is treated as fatal rather than allowed to fill the
+  filesystem.
 type: string
-default: 10GB
+default: 1GB
 components: ["*"]
 ---
 name: Logging.Rotation.MaxRetentionPeriod

--- a/docs/scopes.yaml
+++ b/docs/scopes.yaml
@@ -128,6 +128,15 @@ description: >-
 issuedBy: ["*"]
 acceptedBy: ["*"]
 ---
+name: pelican.log_read
+description: >-
+  Permits the reading of the server's buffer of recent log lines.
+  Required for the web UI's log viewer and for programmatic log
+  fetches.
+issuedBy: ["web_ui"]
+acceptedBy: ["web_ui"]
+userGrantable: true
+---
 ############################
 #     Registry Scopes      #
 ############################

--- a/docs/scopes.yaml
+++ b/docs/scopes.yaml
@@ -130,9 +130,13 @@ acceptedBy: ["*"]
 ---
 name: pelican.log_read
 description: >-
-  Permits the reading of the server's buffer of recent log lines.
-  Required for the web UI's log viewer and for programmatic log
-  fetches.
+  Permits the reading of the server's buffer of recent log lines,
+  through the web UI's log viewer or the /api/v1.0/logs endpoints.
+  Granting it is equivalent to granting sight of everything the server
+  logs, which is why it is separable from server.admin rather than
+  implied by every lesser role. The scope is resolved from the user's
+  grants when a request arrives, so it governs what an account may
+  reach and not what any particular credential may do.
 issuedBy: ["web_ui"]
 acceptedBy: ["web_ui"]
 userGrantable: true

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/opensciencegrid/xrootd-monitoring-shoveler v1.3.0
 	github.com/ory/fosite v0.49.0
 	github.com/oschwald/geoip2-golang/v2 v2.0.0-beta.4
+	github.com/pierrec/lz4/v4 v4.1.27
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/xattr v0.4.12
 	github.com/pressly/goose/v3 v3.18.0

--- a/go.sum
+++ b/go.sum
@@ -886,8 +886,8 @@ github.com/paulmach/orb v0.10.0/go.mod h1:5mULz1xQfs3bmQm63QEJA6lNGujuRafwA5S/En
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
-github.com/pierrec/lz4/v4 v4.1.18 h1:xaKrnTkyoqfh1YItXl56+6KJNVYWlEEPuAQW9xsplYQ=
-github.com/pierrec/lz4/v4 v4.1.18/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pierrec/lz4/v4 v4.1.27 h1:+PhzhWDrjRj89TH2sw43nE3+4+W8lSxIuQadEHZyjUk=
+github.com/pierrec/lz4/v4 v4.1.27/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/logging/async_writer.go
+++ b/logging/async_writer.go
@@ -120,14 +120,25 @@ type asyncWriter struct {
 	now func() time.Time
 
 	// lifecycle
-	started    atomic.Bool // true once the drain goroutine has been launched
-	stopCh     chan struct{}
-	stopOnce   sync.Once
-	doneCh     chan struct{}
-	doneOnce   sync.Once
-	selfMgd    bool           // true when not registered with an errgroup
-	wg         sync.WaitGroup // tracks the self-managed drain goroutine
-	compressWg sync.WaitGroup
+	started  atomic.Bool // true once the drain goroutine has been launched
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	doneCh   chan struct{}
+	doneOnce sync.Once
+	selfMgd  bool           // true when not registered with an errgroup
+	wg       sync.WaitGroup // tracks self-managed goroutines
+
+	// Compression worker: one permanent goroutine (started alongside the drain
+	// goroutine when rotation+compression is enabled) compresses rotated files
+	// handed to it on compressCh. The drain goroutine is the sole sender and
+	// closes the channel when it stops; the worker then drains the queue and
+	// exits, closing compressDone. In synchronous mode the worker is drained and
+	// compression is performed inline instead.
+	compressCh       chan string
+	compressDone     chan struct{}
+	compressStarted  atomic.Bool
+	compressChClosed atomic.Bool
+	compressChOnce   sync.Once
 }
 
 // rotationFrequency is the calendar cadence at which logs are rotated. freqNone
@@ -206,6 +217,10 @@ const (
 	// compressTempSuffix is appended to a rotated file's name while its gzip
 	// archive is being written; it is renamed to ".gz" once complete.
 	compressTempSuffix = ".gz.tmp"
+	// compressQueueDepth bounds how many rotated files may await compression
+	// before the drain goroutine blocks on rotation (which in turn applies
+	// backpressure to writers). Rotations are infrequent, so this is generous.
+	compressQueueDepth = 8
 )
 
 // newAsyncWriter opens (creating if necessary, appending if present) the log
@@ -242,6 +257,8 @@ func newAsyncWriter(path string, cfg rotateConfig, flushInterval time.Duration) 
 		now:           time.Now,
 		stopCh:        make(chan struct{}),
 		doneCh:        make(chan struct{}),
+		compressCh:    make(chan string, compressQueueDepth),
+		compressDone:  make(chan struct{}),
 	}
 	w.roomCond = sync.NewCond(&w.mu)
 
@@ -327,15 +344,25 @@ func nonBlockingSignal(ch chan struct{}) {
 	}
 }
 
-// start launches the drain goroutine. When egrp is non-nil the goroutine is
-// registered with it (so a fatal write error cancels the shutdown context);
-// otherwise the writer self-manages the goroutine and panics on a fatal error.
+// start launches the drain goroutine (and, when rotation+compression is enabled,
+// the permanent compression worker). When egrp is non-nil the goroutines are
+// registered with it (so a fatal write error cancels the shutdown context, and
+// egrp.Wait covers the worker); otherwise the writer self-manages them and the
+// drain goroutine panics on a fatal error.
 func (w *asyncWriter) start(ctx context.Context, egrp errGroup) {
 	w.started.Store(true)
+	if w.rotateOK && w.rot.compress {
+		w.compressStarted.Store(true)
+	}
+
 	if egrp != nil {
 		egrp.Go(func() error { return w.run(ctx) })
+		if w.compressStarted.Load() {
+			egrp.Go(w.compressLoop)
+		}
 		return
 	}
+
 	w.selfMgd = true
 	w.wg.Add(1)
 	go func() {
@@ -344,6 +371,71 @@ func (w *asyncWriter) start(ctx context.Context, egrp errGroup) {
 			panic(fmt.Sprintf("pelican logging: fatal error writing to log file %q: %v", w.path, err))
 		}
 	}()
+	if w.compressStarted.Load() {
+		w.wg.Add(1)
+		go func() {
+			defer w.wg.Done()
+			_ = w.compressLoop()
+		}()
+	}
+}
+
+// compressLoop is the permanent compression worker. It compresses each rotated
+// file handed to it until the drain goroutine closes compressCh, then drains any
+// remaining queued files and exits.
+func (w *asyncWriter) compressLoop() error {
+	defer close(w.compressDone)
+	for base := range w.compressCh {
+		w.compressAndPrune(base)
+	}
+	return nil
+}
+
+// stopCompression closes compressCh so the worker drains its queue and exits.
+// The drain goroutine is the sole sender, so it is the only caller (from
+// finalDrain or fail); idempotent.
+func (w *asyncWriter) stopCompression() {
+	if !w.compressStarted.Load() {
+		return
+	}
+	w.compressChOnce.Do(func() {
+		w.compressChClosed.Store(true)
+		close(w.compressCh)
+	})
+}
+
+// compressAndPrune compresses rotatedBase to "<base>.gz", removes the source on
+// success, and applies the retention budgets.
+func (w *asyncWriter) compressAndPrune(rotatedBase string) {
+	if err := w.compressBackup(rotatedBase); err != nil {
+		log.Warnf("Failed to compress rotated log %q: %v", filepath.Join(w.dir, rotatedBase), err)
+	} else if err := w.root.Remove(rotatedBase); err != nil {
+		log.Warnf("Failed to remove %q after compression (leaving an uncompressed copy): %v",
+			filepath.Join(w.dir, rotatedBase), err)
+	}
+	w.pruneRetention()
+}
+
+// afterRotate schedules the post-rotation work for a freshly rotated file.
+// Callers must hold fileMu. In asynchronous mode the compression is handed to
+// the permanent worker; once the worker has been stopped (synchronous mode) or
+// was never started, compression is performed inline -- after waiting for the
+// worker to finish so the two never touch the directory concurrently.
+func (w *asyncWriter) afterRotate(rotatedBase string) {
+	if !w.rot.compress {
+		w.pruneRetention()
+		return
+	}
+	if w.compressStarted.Load() && !w.compressChClosed.Load() {
+		w.compressCh <- rotatedBase
+		return
+	}
+	if w.compressStarted.Load() {
+		// The worker was told to stop; let it fully drain before we compress
+		// inline so we do not operate on the directory concurrently.
+		<-w.compressDone
+	}
+	w.compressAndPrune(rotatedBase)
 }
 
 // errGroup is the minimal subset of *errgroup.Group the writer needs; using an
@@ -410,28 +502,36 @@ func (w *asyncWriter) flushOnce() error {
 	return w.writeRotatingLocked(batch)
 }
 
-// finalDrain writes any remaining batch and atomically flips the writer to
-// synchronous mode so that subsequent Write calls go straight to the file. It is
-// only ever called from the drain goroutine.
+// finalDrain writes any remaining batch, stops the compression worker, and
+// flips the writer to synchronous mode so subsequent Write calls go straight to
+// the file. Everything is done under fileMu so a producer that later observes
+// synchronous==true (and calls writeDirect) cannot race ahead of this final
+// batch -- and, by the time it can, the worker has been told to stop and
+// compressChClosed is visible, so its rotations compress inline rather than
+// sending on a channel the drain goroutine is closing.
 func (w *asyncWriter) finalDrain() error {
-	// Hold fileMu across the flip so a producer that observes synchronous==true
-	// and calls writeDirect cannot race ahead of this final batch.
 	w.fileMu.Lock()
 	w.mu.Lock()
 	batch := w.buf
 	w.buf = nil
-	w.synchronous = true
-	// Wake any callers blocked on backpressure; they will re-check synchronous
-	// and fall through to a direct write.
-	w.roomCond.Broadcast()
 	w.mu.Unlock()
 
+	// Flush the last batch while still asynchronous, so any rotation it triggers
+	// hands compression to the worker.
 	var err error
 	if len(batch) > 0 {
 		err = w.writeRotatingLocked(batch)
 	}
 	// Best-effort durability at shutdown.
 	_ = w.file.Sync()
+
+	// The drain goroutine is the sole sender and is done sending; stop the worker
+	// so it drains its queue and exits, then flip to synchronous mode.
+	w.stopCompression()
+	w.mu.Lock()
+	w.synchronous = true
+	w.roomCond.Broadcast()
+	w.mu.Unlock()
 	w.fileMu.Unlock()
 	return err
 }
@@ -452,6 +552,8 @@ func (w *asyncWriter) writeDirect(p []byte) (int, error) {
 // is propagated to the owning errgroup.
 func (w *asyncWriter) fail(err error) error {
 	fmt.Fprintf(os.Stderr, "pelican logging: fatal error writing to log file %q: %v\n", w.path, err)
+	// The drain goroutine is exiting; stop the worker so it drains and exits too.
+	w.stopCompression()
 	w.mu.Lock()
 	w.synchronous = true
 	// Release any callers blocked on backpressure so they don't hang now that the
@@ -472,27 +574,33 @@ func (w *asyncWriter) markDone() {
 func (w *asyncWriter) enterSyncMode() {
 	w.stopOnce.Do(func() { close(w.stopCh) })
 	if w.started.Load() {
-		// The drain goroutine will flush, flip to sync mode, and close doneCh.
+		// The drain goroutine will flush, stop the worker, flip to sync mode, and
+		// close doneCh.
 		<-w.doneCh
-		return
+	} else {
+		// No drain goroutine was ever launched (e.g. file logging that opened the
+		// writer but never started it). Perform the final flush/flip inline so the
+		// writer is left in a consistent synchronous state.
+		w.doneOnce.Do(func() {
+			_ = w.finalDrain()
+			close(w.doneCh)
+		})
 	}
-	// No drain goroutine was ever launched (e.g. file logging that opened the
-	// writer but never started it). Perform the final flush/flip inline so the
-	// writer is left in a consistent synchronous state.
-	w.doneOnce.Do(func() {
-		_ = w.finalDrain()
-		close(w.doneCh)
-	})
+	// Wait for the compression worker to finish draining its queue and exit, so a
+	// graceful shutdown never abandons an in-flight compression.
+	if w.compressStarted.Load() {
+		<-w.compressDone
+	}
 }
 
-// close stops the writer (if not already), waits for any compression workers,
-// and closes the file and directory handles. Intended for tests and ResetConfig.
+// close stops the writer (if not already) and closes the file and directory
+// handles. Intended for tests and ResetConfig. enterSyncMode has already drained
+// the compression worker.
 func (w *asyncWriter) close() {
 	w.enterSyncMode()
 	if w.selfMgd {
 		w.wg.Wait()
 	}
-	w.compressWg.Wait()
 	w.fileMu.Lock()
 	if w.file != nil {
 		_ = w.file.Close()
@@ -626,25 +734,9 @@ func (w *asyncWriter) rotate() error {
 	w.written = 0
 	w.periodStart = w.rot.frequency.truncate(w.now())
 
-	if w.rot.compress {
-		w.compressWg.Add(1)
-		go func() {
-			defer w.compressWg.Done()
-			// compressBackup produces "<base>.gz"; on success the uncompressed
-			// source is removed. Both failure modes leave the (readable)
-			// uncompressed source in place.
-			if cerr := w.compressBackup(rotatedBase); cerr != nil {
-				log.Warnf("Failed to compress rotated log %q: %v", filepath.Join(w.dir, rotatedBase), cerr)
-			} else if rerr := w.root.Remove(rotatedBase); rerr != nil {
-				log.Warnf("Failed to remove %q after compression (leaving an uncompressed copy): %v",
-					filepath.Join(w.dir, rotatedBase), rerr)
-			}
-			w.pruneRetention()
-		}()
-	} else {
-		w.pruneRetention()
-	}
-
+	// Hand the (slow) compression to the permanent worker, or do it inline in
+	// synchronous mode; afterRotate also applies retention.
+	w.afterRotate(rotatedBase)
 	return nil
 }
 

--- a/logging/async_writer.go
+++ b/logging/async_writer.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -32,6 +33,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // asyncWriter is an io.Writer that decouples the (synchronous) logging call
@@ -200,6 +203,9 @@ const (
 	// logFileFlags is how the active log file is (re)opened: write-only, created
 	// if absent, appending to preserve any existing content.
 	logFileFlags = os.O_WRONLY | os.O_CREATE | os.O_APPEND
+	// compressTempSuffix is appended to a rotated file's name while its gzip
+	// archive is being written; it is renamed to ".gz" once complete.
+	compressTempSuffix = ".gz.tmp"
 )
 
 // newAsyncWriter opens (creating if necessary, appending if present) the log
@@ -268,6 +274,9 @@ func newAsyncWriter(path string, cfg rotateConfig, flushInterval time.Duration) 
 			return nil, fmt.Errorf("failed to open log directory %q for rotation: %w", dir, rerr)
 		}
 		w.root = root
+		// Remove any leftover compression temp files from a previous run that was
+		// killed mid-compression. No compression is running yet, so this is safe.
+		w.cleanupStaleTempFiles()
 	}
 
 	return w, nil
@@ -344,7 +353,8 @@ type errGroup interface {
 }
 
 // run is the drain loop. It returns nil on a clean stop and a non-nil error if
-// writing to the log file fails (which is fatal).
+// writing to the log file fails (which is fatal). It stops when the context is
+// cancelled (process shutdown) or when explicitly stopped via stopCh.
 func (w *asyncWriter) run(ctx context.Context) error {
 	defer w.markDone()
 	for {
@@ -423,25 +433,18 @@ func (w *asyncWriter) finalDrain() error {
 	// Best-effort durability at shutdown.
 	_ = w.file.Sync()
 	w.fileMu.Unlock()
-
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "pelican logging: failed to flush log file %q on shutdown: %v\n", w.path, err)
-		return err
-	}
-	return nil
+	return err
 }
 
-// writeDirect writes straight to the file descriptor under fileMu. Used in
-// synchronous mode (after shutdown) for late-arriving log lines.
+// writeDirect writes straight to the file descriptor under fileMu, used in
+// synchronous mode for lines written by their calling goroutine.
 func (w *asyncWriter) writeDirect(p []byte) (int, error) {
 	w.fileMu.Lock()
 	defer w.fileMu.Unlock()
-	n, err := w.file.Write(p)
-	w.written += int64(n)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "pelican logging: failed to write log line directly to %q: %v\n", w.path, err)
+	if err := w.writeRotatingLocked(p); err != nil {
+		return 0, err
 	}
-	return n, err
+	return len(p), nil
 }
 
 // fail records a fatal write error: it emits to stderr and flips to synchronous
@@ -593,9 +596,8 @@ func firstLineEnd(b []byte) int {
 // opens a fresh one for the current period, and kicks off (optional) compression
 // and retention pruning. Callers must hold fileMu.
 func (w *asyncWriter) rotate() error {
-	if err := w.file.Sync(); err != nil {
-		return fmt.Errorf("failed to sync log file before rotation: %w", err)
-	}
+	// fsync is best-effort: a failure must not abort rotation.
+	_ = w.file.Sync()
 	if err := w.file.Close(); err != nil {
 		return fmt.Errorf("failed to close log file before rotation: %w", err)
 	}
@@ -628,10 +630,14 @@ func (w *asyncWriter) rotate() error {
 		w.compressWg.Add(1)
 		go func() {
 			defer w.compressWg.Done()
-			// compressBackup produces the ".gz" and removes the source itself.
+			// compressBackup produces "<base>.gz"; on success the uncompressed
+			// source is removed. Both failure modes leave the (readable)
+			// uncompressed source in place.
 			if cerr := w.compressBackup(rotatedBase); cerr != nil {
-				fmt.Fprintf(os.Stderr, "pelican logging: failed to compress rotated log %q: %v\n",
-					filepath.Join(w.dir, rotatedBase), cerr)
+				log.Warnf("Failed to compress rotated log %q: %v", filepath.Join(w.dir, rotatedBase), cerr)
+			} else if rerr := w.root.Remove(rotatedBase); rerr != nil {
+				log.Warnf("Failed to remove %q after compression (leaving an uncompressed copy): %v",
+					filepath.Join(w.dir, rotatedBase), rerr)
 			}
 			w.pruneRetention()
 		}()
@@ -724,18 +730,36 @@ func (w *asyncWriter) pruneRetention() {
 	}
 }
 
+// cleanupStaleTempFiles removes leftover compression temp files (named
+// "<base>.*<compressTempSuffix>") in the log directory. These are left behind
+// only when a process is killed while a compression is in progress; on startup
+// none can be legitimately in use.
+func (w *asyncWriter) cleanupStaleTempFiles() {
+	entries, err := fs.ReadDir(w.root.FS(), ".")
+	if err != nil {
+		return
+	}
+	prefix := w.base + "."
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, compressTempSuffix) {
+			continue
+		}
+		if rerr := w.root.Remove(name); rerr != nil && !errors.Is(rerr, fs.ErrNotExist) {
+			log.Warnf("Failed to remove stale compression temp file %q: %v", filepath.Join(w.dir, name), rerr)
+		}
+	}
+}
+
 // compressBackup gzips the rotated file named base (relative to the log
-// directory) to base+".gz" and removes the uncompressed source. All I/O is done
-// through the held os.Root.
+// directory) to base+".gz", leaving the uncompressed source for the caller to
+// remove.
 //
-// Two properties matter for correctness:
-//   - Atomicity: the gzip is written to a temporary file and renamed into place,
-//     so a crash never leaves a partial ".gz".
-//   - The source is always removed once a complete ".gz" is in place. In
-//     particular, fsync is best-effort: a complete gzip already holds the data,
-//     so a spurious fsync error (seen on some macOS filesystems) must not abort
-//     the removal -- otherwise a valid ".gz" would be stranded next to its
-//     identical uncompressed source.
+// Compression is atomic: the gzip is written to a temporary file and renamed
+// into place, so a crash never leaves a partial ".gz". fsync is best-effort: a
+// complete gzip already holds the data, so a sync failure must not fail the
+// operation, which would otherwise leave the caller to skip removing the source
+// and strand a valid ".gz" next to its identical uncompressed copy.
 func (w *asyncWriter) compressBackup(base string) error {
 	in, err := w.root.Open(base)
 	if err != nil {
@@ -743,7 +767,7 @@ func (w *asyncWriter) compressBackup(base string) error {
 	}
 	defer in.Close()
 
-	tmp := base + ".gz.tmp"
+	tmp := base + compressTempSuffix
 	out, err := w.root.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
 	if err != nil {
 		return err
@@ -762,18 +786,16 @@ func (w *asyncWriter) compressBackup(base string) error {
 		return cerr
 	}
 	// Best-effort durability; do not let a sync failure strand the source.
-	if serr := out.Sync(); serr != nil {
-		fmt.Fprintf(os.Stderr, "pelican logging: warning: fsync of %s failed: %v\n",
-			filepath.Join(w.dir, tmp), serr)
-	}
+	_ = out.Sync()
 	if cerr := out.Close(); cerr != nil {
 		_ = w.root.Remove(tmp)
 		return cerr
 	}
-	// Put the finished archive in place atomically, then drop the source.
+	// Put the finished archive in place atomically. The caller removes the
+	// (still-present) uncompressed source.
 	if cerr := w.root.Rename(tmp, base+".gz"); cerr != nil {
 		_ = w.root.Remove(tmp)
 		return cerr
 	}
-	return w.root.Remove(base)
+	return nil
 }

--- a/logging/async_writer.go
+++ b/logging/async_writer.go
@@ -1,0 +1,779 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package logging
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// asyncWriter is an io.Writer that decouples the (synchronous) logging call
+// sites from disk I/O. Log lines handed to Write are copied into an in-memory
+// batch; a dedicated goroutine (managed by the process errgroup when available)
+// drains the batch to the log file every flushInterval, or sooner once enough
+// bytes accumulate. This keeps wakeups/syscalls low while bounding the window in
+// which a buffered line could be lost. The buffer is bounded (maxBufBytes): once
+// it fills, Write blocks (backpressure) so callers cannot outrun a slow or
+// stalled log device instead of growing memory without bound.
+//
+// When the target is a regular file, the writer also manages log rotation on
+// calendar boundaries (daily or hourly) so administrators can find logs by date.
+// At each boundary the active file is renamed with a suffix naming the period it
+// covers (e.g. "pelican.log.2026-06-08" for daily, "pelican.log.2026-06-08T15"
+// for hourly), optionally gzip-compressed, and old files pruned per the size and
+// age retention budgets.
+// Rotation is disabled automatically when the target is not a regular file
+// (e.g. a terminal, pipe, or device such as /dev/stdout).
+//
+// On shutdown the writer is flipped to "synchronous mode" (see enterSyncMode):
+// the background goroutine drains any remaining batch, fsyncs, and exits, after
+// which any late-arriving log line is written straight to the file descriptor by
+// the calling goroutine. This avoids losing logs that are emitted while the
+// process is tearing down (e.g. during signal handling or a panic).
+//
+// A failure to write the log file is treated as fatal: the writer surfaces the
+// error so the owning errgroup cancels the shutdown context (and, when the
+// writer is self-managed, panics). Pelican should not keep operating if it can
+// no longer record what it is doing.
+type asyncWriter struct {
+	// flushBytes is the buffered-byte threshold that triggers an early flush
+	// (before the flushInterval timer); flushInterval bounds flush latency.
+	flushBytes    int
+	flushInterval time.Duration
+	// maxBufBytes is the backpressure high-water mark: once this many bytes are
+	// buffered, Write blocks until the drain goroutine makes room, so callers
+	// cannot outrun a slow or stalled log device.
+	maxBufBytes int
+
+	// mu guards buf and synchronous; roomCond (on mu) wakes Write calls that are
+	// blocked on backpressure once the buffer drains or sync mode is entered.
+	mu          sync.Mutex
+	roomCond    *sync.Cond
+	buf         []byte
+	synchronous bool
+
+	// thresholdCrossed mirrors "batch is full" for lock-free checks in the
+	// drain loop; thresholdCh/wakeCh wake the drain goroutine.
+	thresholdCrossed atomic.Bool
+	wakeCh           chan struct{}
+	thresholdCh      chan struct{}
+
+	// fileMu guards all access to the file descriptor and rotation state. It is
+	// held during batch writes, direct (synchronous-mode) writes, and rotation.
+	fileMu sync.Mutex
+	file   *os.File
+	// written is the number of bytes written to the active file since it was
+	// opened/last rotated; drives size-based rotation.
+	written int64
+	// periodStart is the calendar period (truncated to the rotation interval)
+	// during which the active file began accumulating lines. When the current
+	// period advances past it, the file is rotated and named for periodStart.
+	// Only meaningful when time-based rotation is active.
+	periodStart time.Time
+
+	// dir is the directory containing the log file. root, when non-nil, is an
+	// os.Root handle to that directory: it holds an open directory descriptor and
+	// performs rotation operations relative to it (open/rename/remove/stat), so
+	// rotation keeps working after a privilege drop changes path traversability.
+	path string
+	dir  string
+	base string
+	root *os.Root
+
+	// rotation configuration; rotateOK reports whether the target is eligible
+	// (a regular file with rotation enabled).
+	rot      rotateConfig
+	rotateOK bool
+
+	// now returns the current time; overridable in tests for deterministic
+	// boundary crossing. Defaults to time.Now.
+	now func() time.Time
+
+	// lifecycle
+	started    atomic.Bool // true once the drain goroutine has been launched
+	stopCh     chan struct{}
+	stopOnce   sync.Once
+	doneCh     chan struct{}
+	doneOnce   sync.Once
+	selfMgd    bool           // true when not registered with an errgroup
+	wg         sync.WaitGroup // tracks the self-managed drain goroutine
+	compressWg sync.WaitGroup
+}
+
+// rotationFrequency is the calendar cadence at which logs are rotated. freqNone
+// disables time-based rotation (size-based rotation may still apply).
+type rotationFrequency int
+
+const (
+	freqDaily rotationFrequency = iota
+	freqHourly
+	freqNone
+)
+
+// parseRotationFrequency maps an admin-facing string to a rotationFrequency; any
+// unrecognized value falls back to daily.
+func parseRotationFrequency(s string) rotationFrequency {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "hourly":
+		return freqHourly
+	case "none", "":
+		return freqNone
+	default:
+		return freqDaily
+	}
+}
+
+// timeBased reports whether this interval triggers calendar-boundary rotation.
+func (ri rotationFrequency) timeBased() bool {
+	return ri == freqDaily || ri == freqHourly
+}
+
+// truncate returns t rounded down to the start of its period (local time), so
+// boundaries align with the calendar rather than with an arbitrary epoch offset.
+func (ri rotationFrequency) truncate(t time.Time) time.Time {
+	switch ri {
+	case freqHourly:
+		return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), 0, 0, 0, t.Location())
+	default:
+		return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+	}
+}
+
+// format renders the suffix used to name a rotated file. For time-based
+// intervals t is the period start; when time-based rotation is disabled, a
+// size-triggered rotation names the file with a full timestamp instead.
+func (ri rotationFrequency) format(t time.Time) string {
+	switch ri {
+	case freqHourly:
+		return t.Format("2006-01-02T15")
+	case freqNone:
+		return t.Format("2006-01-02T15-04-05")
+	default:
+		return t.Format("2006-01-02")
+	}
+}
+
+// rotateConfig captures the admin-facing rotation knobs in already-parsed form.
+type rotateConfig struct {
+	enable    bool
+	frequency rotationFrequency
+	maxSize   int64 // active-file size that triggers rotation; 0 disables size-based rotation
+	// Retention budgets, applied independently to the set of rotated files:
+	maxRetentionSize   int64         // total bytes of rotated files to keep; 0 = unlimited
+	maxRetentionPeriod time.Duration // max age of rotated files to keep; 0 = unlimited
+	compress           bool
+}
+
+const (
+	defaultFlushBytes = 64 * 1024
+	// defaultMaxBufBytes bounds how much log data may buffer before Write applies
+	// backpressure. Generous enough to absorb normal bursts, small enough to cap
+	// memory if the log device stalls.
+	defaultMaxBufBytes = 1 * 1024 * 1024
+	// logFileFlags is how the active log file is (re)opened: write-only, created
+	// if absent, appending to preserve any existing content.
+	logFileFlags = os.O_WRONLY | os.O_CREATE | os.O_APPEND
+)
+
+// newAsyncWriter opens (creating if necessary, appending if present) the log
+// file at path and returns a writer ready to be started. Rotation is enabled
+// only when the target is a regular file and cfg.enable is true.
+func newAsyncWriter(path string, cfg rotateConfig, flushInterval time.Duration) (*asyncWriter, error) {
+	dir := filepath.Dir(path)
+	if dir != "" {
+		if err := os.MkdirAll(dir, 0750); err != nil {
+			return nil, fmt.Errorf("failed to access/create log directory %q: %w", dir, err)
+		}
+	}
+
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open log file %q: %w", path, err)
+	}
+
+	if flushInterval <= 0 {
+		flushInterval = 50 * time.Millisecond
+	}
+
+	w := &asyncWriter{
+		flushBytes:    defaultFlushBytes,
+		flushInterval: flushInterval,
+		maxBufBytes:   defaultMaxBufBytes,
+		wakeCh:        make(chan struct{}, 1),
+		thresholdCh:   make(chan struct{}, 1),
+		file:          f,
+		path:          path,
+		dir:           dir,
+		base:          filepath.Base(path),
+		rot:           cfg,
+		now:           time.Now,
+		stopCh:        make(chan struct{}),
+		doneCh:        make(chan struct{}),
+	}
+	w.roomCond = sync.NewCond(&w.mu)
+
+	// Determine whether the target is a regular file. Only regular files are
+	// eligible for rotation; special files (devices, pipes, terminals) are
+	// written through untouched.
+	periodAnchor := time.Now()
+	if fi, statErr := f.Stat(); statErr == nil && fi.Mode().IsRegular() {
+		w.rotateOK = cfg.enable
+		// If the file already holds content, account for its current size
+		// (size-based rotation) and anchor the current period on its
+		// last-modified time so a restart after a boundary rotates the existing
+		// data under the period it was actually written in.
+		if fi.Size() > 0 {
+			w.written = fi.Size()
+			periodAnchor = fi.ModTime()
+		}
+	}
+	w.periodStart = cfg.frequency.truncate(periodAnchor)
+
+	// When rotation is possible, keep an os.Root handle to the log directory so
+	// rotation operates relative to a held directory descriptor, surviving a
+	// later privilege drop. The directory was just created/opened above, so a
+	// failure here is unexpected and surfaced loudly rather than silently
+	// disabling the configured rotation.
+	if w.rotateOK {
+		root, rerr := os.OpenRoot(dir)
+		if rerr != nil {
+			_ = f.Close()
+			return nil, fmt.Errorf("failed to open log directory %q for rotation: %w", dir, rerr)
+		}
+		w.root = root
+	}
+
+	return w, nil
+}
+
+// Write implements io.Writer. It is safe for concurrent use and must not call
+// into logrus (to avoid reentrancy).
+func (w *asyncWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	// Backpressure: once the buffer reaches the high-water mark, block until the
+	// drain goroutine makes room (or the writer flips to synchronous mode on
+	// shutdown). This is what slows callers down when the log device cannot keep
+	// up, rather than letting the buffer grow without bound. roomCond.Wait
+	// releases mu while parked and reacquires it on wake.
+	for !w.synchronous && len(w.buf) >= w.maxBufBytes {
+		w.roomCond.Wait()
+	}
+	if w.synchronous {
+		w.mu.Unlock()
+		return w.writeDirect(p)
+	}
+	wasEmpty := len(w.buf) == 0
+	// p may be reused by the caller after Write returns, so copy it.
+	w.buf = append(w.buf, p...)
+	crossed := len(w.buf) >= w.flushBytes
+	if crossed {
+		w.thresholdCrossed.Store(true)
+	}
+	w.mu.Unlock()
+
+	// Wake the drain goroutine to start the batch timer on the first line, and
+	// again (separately) the moment the batch is full so it can flush early.
+	if wasEmpty {
+		nonBlockingSignal(w.wakeCh)
+	}
+	if crossed {
+		nonBlockingSignal(w.thresholdCh)
+	}
+	return len(p), nil
+}
+
+// nonBlockingSignal pokes a capacity-1 channel without blocking; a pending
+// signal is sufficient, so a full channel is fine to drop.
+func nonBlockingSignal(ch chan struct{}) {
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
+}
+
+// start launches the drain goroutine. When egrp is non-nil the goroutine is
+// registered with it (so a fatal write error cancels the shutdown context);
+// otherwise the writer self-manages the goroutine and panics on a fatal error.
+func (w *asyncWriter) start(ctx context.Context, egrp errGroup) {
+	w.started.Store(true)
+	if egrp != nil {
+		egrp.Go(func() error { return w.run(ctx) })
+		return
+	}
+	w.selfMgd = true
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+		if err := w.run(ctx); err != nil {
+			panic(fmt.Sprintf("pelican logging: fatal error writing to log file %q: %v", w.path, err))
+		}
+	}()
+}
+
+// errGroup is the minimal subset of *errgroup.Group the writer needs; using an
+// interface keeps this file free of an errgroup import and eases testing.
+type errGroup interface {
+	Go(func() error)
+}
+
+// run is the drain loop. It returns nil on a clean stop and a non-nil error if
+// writing to the log file fails (which is fatal).
+func (w *asyncWriter) run(ctx context.Context) error {
+	defer w.markDone()
+	for {
+		select {
+		case <-w.stopCh:
+			return w.finalDrain()
+		case <-ctx.Done():
+			return w.finalDrain()
+		case <-w.wakeCh:
+		}
+
+		// A line is buffered. Batch for up to flushInterval unless the batch is
+		// already full, in which case flush immediately.
+		if !w.thresholdCrossed.Load() {
+			t := time.NewTimer(w.flushInterval)
+			select {
+			case <-t.C:
+			case <-w.thresholdCh:
+				t.Stop()
+			case <-w.stopCh:
+				t.Stop()
+				return w.finalDrain()
+			case <-ctx.Done():
+				t.Stop()
+				return w.finalDrain()
+			}
+		}
+
+		if err := w.flushOnce(); err != nil {
+			return w.fail(err)
+		}
+	}
+}
+
+// flushOnce swaps out the current batch and writes it to the file. The rotation
+// check happens before the write so the batch is attributed to the file for the
+// current calendar period.
+func (w *asyncWriter) flushOnce() error {
+	w.mu.Lock()
+	if len(w.buf) == 0 {
+		w.mu.Unlock()
+		return nil
+	}
+	batch := w.buf
+	w.buf = nil
+	w.thresholdCrossed.Store(false)
+	// The buffer is now empty; wake any callers blocked on backpressure.
+	w.roomCond.Broadcast()
+	w.mu.Unlock()
+
+	w.fileMu.Lock()
+	defer w.fileMu.Unlock()
+	return w.writeRotatingLocked(batch)
+}
+
+// finalDrain writes any remaining batch and atomically flips the writer to
+// synchronous mode so that subsequent Write calls go straight to the file. It is
+// only ever called from the drain goroutine.
+func (w *asyncWriter) finalDrain() error {
+	// Hold fileMu across the flip so a producer that observes synchronous==true
+	// and calls writeDirect cannot race ahead of this final batch.
+	w.fileMu.Lock()
+	w.mu.Lock()
+	batch := w.buf
+	w.buf = nil
+	w.synchronous = true
+	// Wake any callers blocked on backpressure; they will re-check synchronous
+	// and fall through to a direct write.
+	w.roomCond.Broadcast()
+	w.mu.Unlock()
+
+	var err error
+	if len(batch) > 0 {
+		err = w.writeRotatingLocked(batch)
+	}
+	// Best-effort durability at shutdown.
+	_ = w.file.Sync()
+	w.fileMu.Unlock()
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pelican logging: failed to flush log file %q on shutdown: %v\n", w.path, err)
+		return err
+	}
+	return nil
+}
+
+// writeDirect writes straight to the file descriptor under fileMu. Used in
+// synchronous mode (after shutdown) for late-arriving log lines.
+func (w *asyncWriter) writeDirect(p []byte) (int, error) {
+	w.fileMu.Lock()
+	defer w.fileMu.Unlock()
+	n, err := w.file.Write(p)
+	w.written += int64(n)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pelican logging: failed to write log line directly to %q: %v\n", w.path, err)
+	}
+	return n, err
+}
+
+// fail records a fatal write error: it emits to stderr and flips to synchronous
+// mode (so any further lines at least attempt a direct write) before the error
+// is propagated to the owning errgroup.
+func (w *asyncWriter) fail(err error) error {
+	fmt.Fprintf(os.Stderr, "pelican logging: fatal error writing to log file %q: %v\n", w.path, err)
+	w.mu.Lock()
+	w.synchronous = true
+	// Release any callers blocked on backpressure so they don't hang now that the
+	// drain goroutine is exiting; they'll re-check synchronous and write directly.
+	w.roomCond.Broadcast()
+	w.mu.Unlock()
+	return err
+}
+
+func (w *asyncWriter) markDone() {
+	w.doneOnce.Do(func() { close(w.doneCh) })
+}
+
+// enterSyncMode is the shutdown handler. It stops the drain goroutine, waits for
+// it to flush and flip the writer to synchronous mode, after which late log
+// lines are written directly by their calling goroutine. Safe to call multiple
+// times and from any goroutine.
+func (w *asyncWriter) enterSyncMode() {
+	w.stopOnce.Do(func() { close(w.stopCh) })
+	if w.started.Load() {
+		// The drain goroutine will flush, flip to sync mode, and close doneCh.
+		<-w.doneCh
+		return
+	}
+	// No drain goroutine was ever launched (e.g. file logging that opened the
+	// writer but never started it). Perform the final flush/flip inline so the
+	// writer is left in a consistent synchronous state.
+	w.doneOnce.Do(func() {
+		_ = w.finalDrain()
+		close(w.doneCh)
+	})
+}
+
+// close stops the writer (if not already), waits for any compression workers,
+// and closes the file and directory handles. Intended for tests and ResetConfig.
+func (w *asyncWriter) close() {
+	w.enterSyncMode()
+	if w.selfMgd {
+		w.wg.Wait()
+	}
+	w.compressWg.Wait()
+	w.fileMu.Lock()
+	if w.file != nil {
+		_ = w.file.Close()
+		w.file = nil
+	}
+	if w.root != nil {
+		_ = w.root.Close()
+		w.root = nil
+	}
+	w.fileMu.Unlock()
+}
+
+// shouldRotateTime reports whether the calendar period has advanced past the one
+// the active file belongs to. Callers must hold fileMu.
+func (w *asyncWriter) shouldRotateTime(now time.Time) bool {
+	return w.rot.frequency.timeBased() && w.rot.frequency.truncate(now).After(w.periodStart)
+}
+
+// writeRotatingLocked writes batch to the active log file, rotating as needed:
+// once before the write if the calendar period has advanced (time-based), and
+// during the write whenever the active file reaches MaxSize (size-based). Size
+// rotation never splits a log line: the file is cut at the last newline that
+// fits, and the next line starts a fresh file. A single line larger than MaxSize
+// is written whole into its own file (the only case a file may exceed MaxSize).
+// Callers must hold fileMu.
+func (w *asyncWriter) writeRotatingLocked(batch []byte) error {
+	// Time-based rotation happens before the write so the batch lands in the new
+	// period's file.
+	if w.rotateOK && w.shouldRotateTime(w.now()) {
+		if err := w.rotate(); err != nil {
+			return err
+		}
+	}
+
+	// No size cap (or rotation disabled): a single write.
+	if !w.rotateOK || w.rot.maxSize <= 0 {
+		n, err := w.file.Write(batch)
+		w.written += int64(n)
+		return err
+	}
+
+	for len(batch) > 0 {
+		capacity := w.rot.maxSize - w.written
+		if capacity <= 0 {
+			// Active file is full; start a fresh one.
+			if err := w.rotate(); err != nil {
+				return err
+			}
+			capacity = w.rot.maxSize
+		}
+
+		cut := lineCutWithin(batch, capacity)
+		if cut == 0 {
+			// The next line does not fit in the remaining capacity.
+			if w.written > 0 {
+				// Give the line a fresh file rather than overshoot the current one.
+				if err := w.rotate(); err != nil {
+					return err
+				}
+				continue
+			}
+			// Fresh file but a single line is larger than MaxSize: it cannot be
+			// split, so write it whole (this file will exceed MaxSize).
+			cut = firstLineEnd(batch)
+		}
+
+		n, err := w.file.Write(batch[:cut])
+		w.written += int64(n)
+		if err != nil {
+			return err
+		}
+		batch = batch[cut:]
+	}
+	return nil
+}
+
+// lineCutWithin returns the end offset (just past a '\n') of the longest run of
+// complete lines in b whose total length is <= capacity. It returns len(b) when
+// the whole buffer fits, or 0 when not even the first line fits.
+func lineCutWithin(b []byte, capacity int64) int {
+	if int64(len(b)) <= capacity {
+		return len(b)
+	}
+	// capacity < len(b) here, so it fits in an int index.
+	if i := bytes.LastIndexByte(b[:capacity], '\n'); i >= 0 {
+		return i + 1
+	}
+	return 0
+}
+
+// firstLineEnd returns the offset just past the first '\n' in b, or len(b) if b
+// has no newline.
+func firstLineEnd(b []byte) int {
+	if i := bytes.IndexByte(b, '\n'); i >= 0 {
+		return i + 1
+	}
+	return len(b)
+}
+
+// rotate renames the active log file aside (named for the period it covered),
+// opens a fresh one for the current period, and kicks off (optional) compression
+// and retention pruning. Callers must hold fileMu.
+func (w *asyncWriter) rotate() error {
+	if err := w.file.Sync(); err != nil {
+		return fmt.Errorf("failed to sync log file before rotation: %w", err)
+	}
+	if err := w.file.Close(); err != nil {
+		return fmt.Errorf("failed to close log file before rotation: %w", err)
+	}
+
+	// Name the rotated file for the period it covered (time-based), or with a
+	// full timestamp when only size-based rotation is configured.
+	suffixTime := w.periodStart
+	if !w.rot.frequency.timeBased() {
+		suffixTime = w.now()
+	}
+	rotatedBase := w.uniqueRotatedBase(w.base + "." + w.rot.frequency.format(suffixTime))
+	if err := w.root.Rename(w.base, rotatedBase); err != nil {
+		// Try to reopen the original so logging can continue even if the rename
+		// failed; report the rename error regardless.
+		if f, oerr := w.root.OpenFile(w.base, logFileFlags, 0640); oerr == nil {
+			w.file = f
+		}
+		return fmt.Errorf("failed to rotate log file %q: %w", w.path, err)
+	}
+
+	f, err := w.root.OpenFile(w.base, logFileFlags, 0640)
+	if err != nil {
+		return fmt.Errorf("failed to open new log file after rotation: %w", err)
+	}
+	w.file = f
+	w.written = 0
+	w.periodStart = w.rot.frequency.truncate(w.now())
+
+	if w.rot.compress {
+		w.compressWg.Add(1)
+		go func() {
+			defer w.compressWg.Done()
+			// compressBackup produces the ".gz" and removes the source itself.
+			if cerr := w.compressBackup(rotatedBase); cerr != nil {
+				fmt.Fprintf(os.Stderr, "pelican logging: failed to compress rotated log %q: %v\n",
+					filepath.Join(w.dir, rotatedBase), cerr)
+			}
+			w.pruneRetention()
+		}()
+	} else {
+		w.pruneRetention()
+	}
+
+	return nil
+}
+
+// uniqueRotatedBase returns base unchanged if no rotated file with that name
+// (or its compressed form) already exists, otherwise it appends an incrementing
+// "-N" suffix. This guards against name collisions when a process restarts and
+// rotates more than once within the same period.
+func (w *asyncWriter) uniqueRotatedBase(base string) string {
+	exists := func(name string) bool {
+		if _, err := w.root.Stat(name); err == nil {
+			return true
+		}
+		if _, err := w.root.Stat(name + ".gz"); err == nil {
+			return true
+		}
+		return false
+	}
+	if !exists(base) {
+		return base
+	}
+	for i := 1; ; i++ {
+		candidate := fmt.Sprintf("%s-%d", base, i)
+		if !exists(candidate) {
+			return candidate
+		}
+	}
+}
+
+// pruneRetention enforces the retention budgets on the set of rotated files.
+// The two budgets are applied independently: a rotated file is deleted if it is
+// older than maxRetentionPeriod, or if keeping it would push the total size of
+// retained rotated files past maxRetentionSize (most-recent files are kept
+// first; the single most recent rotated file is always retained). A budget of 0
+// disables that dimension.
+func (w *asyncWriter) pruneRetention() {
+	maxSize := w.rot.maxRetentionSize
+	maxAge := w.rot.maxRetentionPeriod
+	if maxSize <= 0 && maxAge <= 0 {
+		return
+	}
+
+	entries, err := fs.ReadDir(w.root.FS(), ".")
+	if err != nil {
+		return
+	}
+	prefix := w.base + "."
+	type backup struct {
+		name string
+		size int64
+		mod  time.Time
+	}
+	backups := make([]backup, 0)
+	for _, e := range entries {
+		name := e.Name()
+		if name == w.base || !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		info, ierr := e.Info()
+		if ierr != nil {
+			continue
+		}
+		backups = append(backups, backup{name: name, size: info.Size(), mod: info.ModTime()})
+	}
+
+	// Sort newest first. Rotated names embed a sortable period/timestamp suffix,
+	// so reverse-lexical order is reverse-chronological.
+	sort.Slice(backups, func(i, j int) bool { return backups[i].name > backups[j].name })
+
+	now := w.now()
+	var kept int64
+	for i, b := range backups {
+		if maxAge > 0 && now.Sub(b.mod) > maxAge {
+			_ = w.root.Remove(b.name)
+			continue
+		}
+		// Always keep the most recent rotated file (i == 0) regardless of size,
+		// so a too-small budget can't delete a just-rotated log.
+		if maxSize > 0 && i > 0 && kept+b.size > maxSize {
+			_ = w.root.Remove(b.name)
+			continue
+		}
+		kept += b.size
+	}
+}
+
+// compressBackup gzips the rotated file named base (relative to the log
+// directory) to base+".gz" and removes the uncompressed source. All I/O is done
+// through the held os.Root.
+//
+// Two properties matter for correctness:
+//   - Atomicity: the gzip is written to a temporary file and renamed into place,
+//     so a crash never leaves a partial ".gz".
+//   - The source is always removed once a complete ".gz" is in place. In
+//     particular, fsync is best-effort: a complete gzip already holds the data,
+//     so a spurious fsync error (seen on some macOS filesystems) must not abort
+//     the removal -- otherwise a valid ".gz" would be stranded next to its
+//     identical uncompressed source.
+func (w *asyncWriter) compressBackup(base string) error {
+	in, err := w.root.Open(base)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	tmp := base + ".gz.tmp"
+	out, err := w.root.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
+	if err != nil {
+		return err
+	}
+
+	gz := gzip.NewWriter(out)
+	if _, cerr := io.Copy(gz, in); cerr != nil {
+		_ = gz.Close()
+		_ = out.Close()
+		_ = w.root.Remove(tmp)
+		return cerr
+	}
+	if cerr := gz.Close(); cerr != nil {
+		_ = out.Close()
+		_ = w.root.Remove(tmp)
+		return cerr
+	}
+	// Best-effort durability; do not let a sync failure strand the source.
+	if serr := out.Sync(); serr != nil {
+		fmt.Fprintf(os.Stderr, "pelican logging: warning: fsync of %s failed: %v\n",
+			filepath.Join(w.dir, tmp), serr)
+	}
+	if cerr := out.Close(); cerr != nil {
+		_ = w.root.Remove(tmp)
+		return cerr
+	}
+	// Put the finished archive in place atomically, then drop the source.
+	if cerr := w.root.Rename(tmp, base+".gz"); cerr != nil {
+		_ = w.root.Remove(tmp)
+		return cerr
+	}
+	return w.root.Remove(base)
+}

--- a/logging/async_writer.go
+++ b/logging/async_writer.go
@@ -1,0 +1,893 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package logging
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// asyncWriter is an io.Writer that decouples the (synchronous) logging call
+// sites from disk I/O. Log lines handed to Write are copied into an in-memory
+// batch; a dedicated goroutine (managed by the process errgroup when available)
+// drains the batch to the log file every flushInterval, or sooner once enough
+// bytes accumulate. This keeps wakeups/syscalls low while bounding the window in
+// which a buffered line could be lost. The buffer is bounded (maxBufBytes): once
+// it fills, Write blocks (backpressure) so callers cannot outrun a slow or
+// stalled log device instead of growing memory without bound.
+//
+// When the target is a regular file, the writer also manages log rotation on
+// calendar boundaries (daily or hourly) so administrators can find logs by date.
+// At each boundary the active file is renamed with a suffix naming the period it
+// covers (e.g. "pelican.log.2026-06-08" for daily, "pelican.log.2026-06-08T15"
+// for hourly), optionally gzip-compressed, and old files pruned per the size and
+// age retention budgets.
+// Rotation is disabled automatically when the target is not a regular file
+// (e.g. a terminal, pipe, or device such as /dev/stdout).
+//
+// On shutdown the writer is flipped to "synchronous mode" (see enterSyncMode):
+// the background goroutine drains any remaining batch, fsyncs, and exits, after
+// which any late-arriving log line is written straight to the file descriptor by
+// the calling goroutine. This avoids losing logs that are emitted while the
+// process is tearing down (e.g. during signal handling or a panic).
+//
+// A failure to write the log file is treated as fatal: the writer surfaces the
+// error so the owning errgroup cancels the shutdown context (and, when the
+// writer is self-managed, panics). Pelican should not keep operating if it can
+// no longer record what it is doing.
+type asyncWriter struct {
+	// flushBytes is the buffered-byte threshold that triggers an early flush
+	// (before the flushInterval timer); flushInterval bounds flush latency.
+	flushBytes    int
+	flushInterval time.Duration
+	// maxBufBytes is the backpressure high-water mark: once this many bytes are
+	// buffered, Write blocks until the drain goroutine makes room, so callers
+	// cannot outrun a slow or stalled log device.
+	maxBufBytes int
+
+	// mu guards buf and synchronous; roomCond (on mu) wakes Write calls that are
+	// blocked on backpressure once the buffer drains or sync mode is entered.
+	mu          sync.Mutex
+	roomCond    *sync.Cond
+	buf         []byte
+	synchronous bool
+
+	// thresholdCrossed mirrors "batch is full" for lock-free checks in the
+	// drain loop; thresholdCh/wakeCh wake the drain goroutine.
+	thresholdCrossed atomic.Bool
+	wakeCh           chan struct{}
+	thresholdCh      chan struct{}
+
+	// fileMu guards all access to the file descriptor and rotation state. It is
+	// held during batch writes, direct (synchronous-mode) writes, and rotation.
+	fileMu sync.Mutex
+	file   *os.File
+	// written is the number of bytes written to the active file since it was
+	// opened/last rotated; drives size-based rotation.
+	written int64
+	// periodStart is the calendar period (truncated to the rotation interval)
+	// during which the active file began accumulating lines. When the current
+	// period advances past it, the file is rotated and named for periodStart.
+	// Only meaningful when time-based rotation is active.
+	periodStart time.Time
+
+	// dir is the directory containing the log file. root, when non-nil, is an
+	// os.Root handle to that directory: it holds an open directory descriptor and
+	// performs rotation operations relative to it (open/rename/remove/stat), so
+	// rotation keeps working after a privilege drop changes path traversability.
+	path string
+	dir  string
+	base string
+	root *os.Root
+
+	// rotation configuration; rotateOK reports whether the target is eligible
+	// (a regular file with rotation enabled).
+	rot      rotateConfig
+	rotateOK bool
+
+	// now returns the current time; overridable in tests for deterministic
+	// boundary crossing. Defaults to time.Now.
+	now func() time.Time
+
+	// lifecycle
+	started  atomic.Bool // true once the drain goroutine has been launched
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	doneCh   chan struct{}
+	doneOnce sync.Once
+	selfMgd  bool           // true when not registered with an errgroup
+	wg       sync.WaitGroup // tracks self-managed goroutines
+
+	// Compression worker: one permanent goroutine (started alongside the drain
+	// goroutine when rotation+compression is enabled) compresses rotated files
+	// handed to it on compressCh. The drain goroutine is the sole sender and
+	// closes the channel when it stops; the worker then drains the queue and
+	// exits, closing compressDone. In synchronous mode the worker is drained and
+	// compression is performed inline instead.
+	compressCh       chan string
+	compressDone     chan struct{}
+	compressStarted  atomic.Bool
+	compressChClosed atomic.Bool
+	compressChOnce   sync.Once
+}
+
+// rotationFrequency is the calendar cadence at which logs are rotated. freqNone
+// disables time-based rotation (size-based rotation may still apply).
+type rotationFrequency int
+
+const (
+	freqDaily rotationFrequency = iota
+	freqHourly
+	freqNone
+)
+
+// parseRotationFrequency maps an admin-facing string to a rotationFrequency; any
+// unrecognized value falls back to daily.
+func parseRotationFrequency(s string) rotationFrequency {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "hourly":
+		return freqHourly
+	case "none", "":
+		return freqNone
+	default:
+		return freqDaily
+	}
+}
+
+// timeBased reports whether this interval triggers calendar-boundary rotation.
+func (ri rotationFrequency) timeBased() bool {
+	return ri == freqDaily || ri == freqHourly
+}
+
+// truncate returns t rounded down to the start of its period (local time), so
+// boundaries align with the calendar rather than with an arbitrary epoch offset.
+func (ri rotationFrequency) truncate(t time.Time) time.Time {
+	switch ri {
+	case freqHourly:
+		return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), 0, 0, 0, t.Location())
+	default:
+		return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+	}
+}
+
+// format renders the suffix used to name a rotated file. For time-based
+// intervals t is the period start; when time-based rotation is disabled, a
+// size-triggered rotation names the file with a full timestamp instead.
+func (ri rotationFrequency) format(t time.Time) string {
+	switch ri {
+	case freqHourly:
+		return t.Format("2006-01-02T15")
+	case freqNone:
+		return t.Format("2006-01-02T15-04-05")
+	default:
+		return t.Format("2006-01-02")
+	}
+}
+
+// rotateConfig captures the admin-facing rotation knobs in already-parsed form.
+type rotateConfig struct {
+	enable    bool
+	frequency rotationFrequency
+	maxSize   int64 // active-file size that triggers rotation; 0 disables size-based rotation
+	// Retention budgets, applied independently to the set of rotated files:
+	maxRetentionSize   int64         // total bytes of rotated files to keep; 0 = unlimited
+	maxRetentionPeriod time.Duration // max age of rotated files to keep; 0 = unlimited
+	compress           bool
+}
+
+const (
+	defaultFlushBytes = 64 * 1024
+	// defaultMaxBufBytes bounds how much log data may buffer before Write applies
+	// backpressure. Generous enough to absorb normal bursts, small enough to cap
+	// memory if the log device stalls.
+	defaultMaxBufBytes = 1 * 1024 * 1024
+	// logFileFlags is how the active log file is (re)opened: write-only, created
+	// if absent, appending to preserve any existing content.
+	logFileFlags = os.O_WRONLY | os.O_CREATE | os.O_APPEND
+	// compressTempSuffix is appended to a rotated file's name while its gzip
+	// archive is being written; it is renamed to ".gz" once complete.
+	compressTempSuffix = ".gz.tmp"
+	// compressQueueDepth bounds how many rotated files may await compression
+	// before the drain goroutine blocks on rotation (which in turn applies
+	// backpressure to writers). Rotations are infrequent, so this is generous.
+	compressQueueDepth = 8
+)
+
+// newAsyncWriter opens (creating if necessary, appending if present) the log
+// file at path and returns a writer ready to be started. Rotation is enabled
+// only when the target is a regular file and cfg.enable is true.
+func newAsyncWriter(path string, cfg rotateConfig, flushInterval time.Duration) (*asyncWriter, error) {
+	dir := filepath.Dir(path)
+	if dir != "" {
+		if err := os.MkdirAll(dir, 0750); err != nil {
+			return nil, fmt.Errorf("failed to access/create log directory %q: %w", dir, err)
+		}
+	}
+
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open log file %q: %w", path, err)
+	}
+
+	if flushInterval <= 0 {
+		flushInterval = 50 * time.Millisecond
+	}
+
+	w := &asyncWriter{
+		flushBytes:    defaultFlushBytes,
+		flushInterval: flushInterval,
+		maxBufBytes:   defaultMaxBufBytes,
+		wakeCh:        make(chan struct{}, 1),
+		thresholdCh:   make(chan struct{}, 1),
+		file:          f,
+		path:          path,
+		dir:           dir,
+		base:          filepath.Base(path),
+		rot:           cfg,
+		now:           time.Now,
+		stopCh:        make(chan struct{}),
+		doneCh:        make(chan struct{}),
+		compressCh:    make(chan string, compressQueueDepth),
+		compressDone:  make(chan struct{}),
+	}
+	w.roomCond = sync.NewCond(&w.mu)
+
+	// Determine whether the target is a regular file. Only regular files are
+	// eligible for rotation; special files (devices, pipes, terminals) are
+	// written through untouched.
+	periodAnchor := time.Now()
+	if fi, statErr := f.Stat(); statErr == nil && fi.Mode().IsRegular() {
+		w.rotateOK = cfg.enable
+		// If the file already holds content, account for its current size
+		// (size-based rotation) and anchor the current period on its
+		// last-modified time so a restart after a boundary rotates the existing
+		// data under the period it was actually written in.
+		if fi.Size() > 0 {
+			w.written = fi.Size()
+			periodAnchor = fi.ModTime()
+		}
+	}
+	w.periodStart = cfg.frequency.truncate(periodAnchor)
+
+	// When rotation is possible, keep an os.Root handle to the log directory so
+	// rotation operates relative to a held directory descriptor, surviving a
+	// later privilege drop. The directory was just created/opened above, so a
+	// failure here is unexpected and surfaced loudly rather than silently
+	// disabling the configured rotation.
+	if w.rotateOK {
+		root, rerr := os.OpenRoot(dir)
+		if rerr != nil {
+			_ = f.Close()
+			return nil, fmt.Errorf("failed to open log directory %q for rotation: %w", dir, rerr)
+		}
+		w.root = root
+		// Remove any leftover compression temp files from a previous run that was
+		// killed mid-compression. No compression is running yet, so this is safe.
+		w.cleanupStaleTempFiles()
+	}
+
+	return w, nil
+}
+
+// Write implements io.Writer. It is safe for concurrent use and must not call
+// into logrus (to avoid reentrancy).
+func (w *asyncWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	// Backpressure: once the buffer reaches the high-water mark, block until the
+	// drain goroutine makes room (or the writer flips to synchronous mode on
+	// shutdown). This is what slows callers down when the log device cannot keep
+	// up, rather than letting the buffer grow without bound. roomCond.Wait
+	// releases mu while parked and reacquires it on wake.
+	for !w.synchronous && len(w.buf) >= w.maxBufBytes {
+		w.roomCond.Wait()
+	}
+	if w.synchronous {
+		w.mu.Unlock()
+		return w.writeDirect(p)
+	}
+	wasEmpty := len(w.buf) == 0
+	// p may be reused by the caller after Write returns, so copy it.
+	w.buf = append(w.buf, p...)
+	crossed := len(w.buf) >= w.flushBytes
+	if crossed {
+		w.thresholdCrossed.Store(true)
+	}
+	w.mu.Unlock()
+
+	// Wake the drain goroutine to start the batch timer on the first line, and
+	// again (separately) the moment the batch is full so it can flush early.
+	if wasEmpty {
+		nonBlockingSignal(w.wakeCh)
+	}
+	if crossed {
+		nonBlockingSignal(w.thresholdCh)
+	}
+	return len(p), nil
+}
+
+// nonBlockingSignal pokes a capacity-1 channel without blocking; a pending
+// signal is sufficient, so a full channel is fine to drop.
+func nonBlockingSignal(ch chan struct{}) {
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
+}
+
+// start launches the drain goroutine (and, when rotation+compression is enabled,
+// the permanent compression worker). When egrp is non-nil the goroutines are
+// registered with it (so a fatal write error cancels the shutdown context, and
+// egrp.Wait covers the worker); otherwise the writer self-manages them and the
+// drain goroutine panics on a fatal error.
+func (w *asyncWriter) start(ctx context.Context, egrp errGroup) {
+	w.started.Store(true)
+	if w.rotateOK && w.rot.compress {
+		w.compressStarted.Store(true)
+	}
+
+	if egrp != nil {
+		egrp.Go(func() error { return w.run(ctx) })
+		if w.compressStarted.Load() {
+			egrp.Go(w.compressLoop)
+		}
+		return
+	}
+
+	w.selfMgd = true
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+		if err := w.run(ctx); err != nil {
+			panic(fmt.Sprintf("pelican logging: fatal error writing to log file %q: %v", w.path, err))
+		}
+	}()
+	if w.compressStarted.Load() {
+		w.wg.Add(1)
+		go func() {
+			defer w.wg.Done()
+			_ = w.compressLoop()
+		}()
+	}
+}
+
+// compressLoop is the permanent compression worker. It compresses each rotated
+// file handed to it until the drain goroutine closes compressCh, then drains any
+// remaining queued files and exits.
+func (w *asyncWriter) compressLoop() error {
+	defer close(w.compressDone)
+	for base := range w.compressCh {
+		w.compressAndPrune(base)
+	}
+	return nil
+}
+
+// stopCompression closes compressCh so the worker drains its queue and exits.
+// The drain goroutine is the sole sender, so it is the only caller (from
+// finalDrain or fail); idempotent.
+func (w *asyncWriter) stopCompression() {
+	if !w.compressStarted.Load() {
+		return
+	}
+	w.compressChOnce.Do(func() {
+		w.compressChClosed.Store(true)
+		close(w.compressCh)
+	})
+}
+
+// compressAndPrune compresses rotatedBase to "<base>.gz", removes the source on
+// success, and applies the retention budgets.
+func (w *asyncWriter) compressAndPrune(rotatedBase string) {
+	if err := w.compressBackup(rotatedBase); err != nil {
+		log.Warnf("Failed to compress rotated log %q: %v", filepath.Join(w.dir, rotatedBase), err)
+	} else if err := w.root.Remove(rotatedBase); err != nil {
+		log.Warnf("Failed to remove %q after compression (leaving an uncompressed copy): %v",
+			filepath.Join(w.dir, rotatedBase), err)
+	}
+	w.pruneRetention()
+}
+
+// afterRotate schedules the post-rotation work for a freshly rotated file.
+// Callers must hold fileMu. In asynchronous mode the compression is handed to
+// the permanent worker; once the worker has been stopped (synchronous mode) or
+// was never started, compression is performed inline -- after waiting for the
+// worker to finish so the two never touch the directory concurrently.
+func (w *asyncWriter) afterRotate(rotatedBase string) {
+	if !w.rot.compress {
+		w.pruneRetention()
+		return
+	}
+	if w.compressStarted.Load() && !w.compressChClosed.Load() {
+		w.compressCh <- rotatedBase
+		return
+	}
+	if w.compressStarted.Load() {
+		// The worker was told to stop; let it fully drain before we compress
+		// inline so we do not operate on the directory concurrently.
+		<-w.compressDone
+	}
+	w.compressAndPrune(rotatedBase)
+}
+
+// errGroup is the minimal subset of *errgroup.Group the writer needs; using an
+// interface keeps this file free of an errgroup import and eases testing.
+type errGroup interface {
+	Go(func() error)
+}
+
+// run is the drain loop. It returns nil on a clean stop and a non-nil error if
+// writing to the log file fails (which is fatal). It stops when the context is
+// cancelled (process shutdown) or when explicitly stopped via stopCh.
+func (w *asyncWriter) run(ctx context.Context) error {
+	defer w.markDone()
+	for {
+		select {
+		case <-w.stopCh:
+			return w.finalDrain()
+		case <-ctx.Done():
+			return w.finalDrain()
+		case <-w.wakeCh:
+		}
+
+		// A line is buffered. Batch for up to flushInterval unless the batch is
+		// already full, in which case flush immediately.
+		if !w.thresholdCrossed.Load() {
+			t := time.NewTimer(w.flushInterval)
+			select {
+			case <-t.C:
+			case <-w.thresholdCh:
+				t.Stop()
+			case <-w.stopCh:
+				t.Stop()
+				return w.finalDrain()
+			case <-ctx.Done():
+				t.Stop()
+				return w.finalDrain()
+			}
+		}
+
+		if err := w.flushOnce(); err != nil {
+			return w.fail(err)
+		}
+	}
+}
+
+// flushOnce swaps out the current batch and writes it to the file. The rotation
+// check happens before the write so the batch is attributed to the file for the
+// current calendar period.
+func (w *asyncWriter) flushOnce() error {
+	w.mu.Lock()
+	if len(w.buf) == 0 {
+		w.mu.Unlock()
+		return nil
+	}
+	batch := w.buf
+	w.buf = nil
+	w.thresholdCrossed.Store(false)
+	// The buffer is now empty; wake any callers blocked on backpressure.
+	w.roomCond.Broadcast()
+	w.mu.Unlock()
+
+	w.fileMu.Lock()
+	defer w.fileMu.Unlock()
+	return w.writeRotatingLocked(batch)
+}
+
+// finalDrain writes any remaining batch, stops the compression worker, and
+// flips the writer to synchronous mode so subsequent Write calls go straight to
+// the file. Everything is done under fileMu so a producer that later observes
+// synchronous==true (and calls writeDirect) cannot race ahead of this final
+// batch -- and, by the time it can, the worker has been told to stop and
+// compressChClosed is visible, so its rotations compress inline rather than
+// sending on a channel the drain goroutine is closing.
+func (w *asyncWriter) finalDrain() error {
+	w.fileMu.Lock()
+	w.mu.Lock()
+	batch := w.buf
+	w.buf = nil
+	w.mu.Unlock()
+
+	// Flush the last batch while still asynchronous, so any rotation it triggers
+	// hands compression to the worker.
+	var err error
+	if len(batch) > 0 {
+		err = w.writeRotatingLocked(batch)
+	}
+	// Best-effort durability at shutdown.
+	_ = w.file.Sync()
+
+	// The drain goroutine is the sole sender and is done sending; stop the worker
+	// so it drains its queue and exits, then flip to synchronous mode.
+	w.stopCompression()
+	w.mu.Lock()
+	w.synchronous = true
+	w.roomCond.Broadcast()
+	w.mu.Unlock()
+	w.fileMu.Unlock()
+	return err
+}
+
+// writeDirect writes straight to the file descriptor under fileMu, used in
+// synchronous mode for lines written by their calling goroutine.
+func (w *asyncWriter) writeDirect(p []byte) (int, error) {
+	w.fileMu.Lock()
+	defer w.fileMu.Unlock()
+	if err := w.writeRotatingLocked(p); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+// fail records a fatal write error: it emits to stderr and flips to synchronous
+// mode (so any further lines at least attempt a direct write) before the error
+// is propagated to the owning errgroup.
+func (w *asyncWriter) fail(err error) error {
+	fmt.Fprintf(os.Stderr, "pelican logging: fatal error writing to log file %q: %v\n", w.path, err)
+	// The drain goroutine is exiting; stop the worker so it drains and exits too.
+	w.stopCompression()
+	w.mu.Lock()
+	w.synchronous = true
+	// Release any callers blocked on backpressure so they don't hang now that the
+	// drain goroutine is exiting; they'll re-check synchronous and write directly.
+	w.roomCond.Broadcast()
+	w.mu.Unlock()
+	return err
+}
+
+func (w *asyncWriter) markDone() {
+	w.doneOnce.Do(func() { close(w.doneCh) })
+}
+
+// enterSyncMode is the shutdown handler. It stops the drain goroutine, waits for
+// it to flush and flip the writer to synchronous mode, after which late log
+// lines are written directly by their calling goroutine. Safe to call multiple
+// times and from any goroutine.
+func (w *asyncWriter) enterSyncMode() {
+	w.stopOnce.Do(func() { close(w.stopCh) })
+	if w.started.Load() {
+		// The drain goroutine will flush, stop the worker, flip to sync mode, and
+		// close doneCh.
+		<-w.doneCh
+	} else {
+		// No drain goroutine was ever launched (e.g. file logging that opened the
+		// writer but never started it). Perform the final flush/flip inline so the
+		// writer is left in a consistent synchronous state.
+		w.doneOnce.Do(func() {
+			_ = w.finalDrain()
+			close(w.doneCh)
+		})
+	}
+	// Wait for the compression worker to finish draining its queue and exit, so a
+	// graceful shutdown never abandons an in-flight compression.
+	if w.compressStarted.Load() {
+		<-w.compressDone
+	}
+}
+
+// close stops the writer (if not already) and closes the file and directory
+// handles. Intended for tests and ResetConfig. enterSyncMode has already drained
+// the compression worker.
+func (w *asyncWriter) close() {
+	w.enterSyncMode()
+	if w.selfMgd {
+		w.wg.Wait()
+	}
+	w.fileMu.Lock()
+	if w.file != nil {
+		_ = w.file.Close()
+		w.file = nil
+	}
+	if w.root != nil {
+		_ = w.root.Close()
+		w.root = nil
+	}
+	w.fileMu.Unlock()
+}
+
+// shouldRotateTime reports whether the calendar period has advanced past the one
+// the active file belongs to. Callers must hold fileMu.
+func (w *asyncWriter) shouldRotateTime(now time.Time) bool {
+	return w.rot.frequency.timeBased() && w.rot.frequency.truncate(now).After(w.periodStart)
+}
+
+// writeRotatingLocked writes batch to the active log file, rotating as needed:
+// once before the write if the calendar period has advanced (time-based), and
+// during the write whenever the active file reaches MaxSize (size-based). Size
+// rotation never splits a log line: the file is cut at the last newline that
+// fits, and the next line starts a fresh file. A single line larger than MaxSize
+// is written whole into its own file (the only case a file may exceed MaxSize).
+// Callers must hold fileMu.
+func (w *asyncWriter) writeRotatingLocked(batch []byte) error {
+	// Time-based rotation happens before the write so the batch lands in the new
+	// period's file.
+	if w.rotateOK && w.shouldRotateTime(w.now()) {
+		if err := w.rotate(); err != nil {
+			return err
+		}
+	}
+
+	// No size cap (or rotation disabled): a single write.
+	if !w.rotateOK || w.rot.maxSize <= 0 {
+		n, err := w.file.Write(batch)
+		w.written += int64(n)
+		return err
+	}
+
+	for len(batch) > 0 {
+		capacity := w.rot.maxSize - w.written
+		if capacity <= 0 {
+			// Active file is full; start a fresh one.
+			if err := w.rotate(); err != nil {
+				return err
+			}
+			capacity = w.rot.maxSize
+		}
+
+		cut := lineCutWithin(batch, capacity)
+		if cut == 0 {
+			// The next line does not fit in the remaining capacity.
+			if w.written > 0 {
+				// Give the line a fresh file rather than overshoot the current one.
+				if err := w.rotate(); err != nil {
+					return err
+				}
+				continue
+			}
+			// Fresh file but a single line is larger than MaxSize: it cannot be
+			// split, so write it whole (this file will exceed MaxSize).
+			cut = firstLineEnd(batch)
+		}
+
+		n, err := w.file.Write(batch[:cut])
+		w.written += int64(n)
+		if err != nil {
+			return err
+		}
+		batch = batch[cut:]
+	}
+	return nil
+}
+
+// lineCutWithin returns the end offset (just past a '\n') of the longest run of
+// complete lines in b whose total length is <= capacity. It returns len(b) when
+// the whole buffer fits, or 0 when not even the first line fits.
+func lineCutWithin(b []byte, capacity int64) int {
+	if int64(len(b)) <= capacity {
+		return len(b)
+	}
+	// capacity < len(b) here, so it fits in an int index.
+	if i := bytes.LastIndexByte(b[:capacity], '\n'); i >= 0 {
+		return i + 1
+	}
+	return 0
+}
+
+// firstLineEnd returns the offset just past the first '\n' in b, or len(b) if b
+// has no newline.
+func firstLineEnd(b []byte) int {
+	if i := bytes.IndexByte(b, '\n'); i >= 0 {
+		return i + 1
+	}
+	return len(b)
+}
+
+// rotate renames the active log file aside (named for the period it covered),
+// opens a fresh one for the current period, and kicks off (optional) compression
+// and retention pruning. Callers must hold fileMu.
+func (w *asyncWriter) rotate() error {
+	// fsync is best-effort: a failure must not abort rotation.
+	_ = w.file.Sync()
+	if err := w.file.Close(); err != nil {
+		return fmt.Errorf("failed to close log file before rotation: %w", err)
+	}
+
+	// Name the rotated file for the period it covered (time-based), or with a
+	// full timestamp when only size-based rotation is configured.
+	suffixTime := w.periodStart
+	if !w.rot.frequency.timeBased() {
+		suffixTime = w.now()
+	}
+	rotatedBase := w.uniqueRotatedBase(w.base + "." + w.rot.frequency.format(suffixTime))
+	if err := w.root.Rename(w.base, rotatedBase); err != nil {
+		// Try to reopen the original so logging can continue even if the rename
+		// failed; report the rename error regardless.
+		if f, oerr := w.root.OpenFile(w.base, logFileFlags, 0640); oerr == nil {
+			w.file = f
+		}
+		return fmt.Errorf("failed to rotate log file %q: %w", w.path, err)
+	}
+
+	f, err := w.root.OpenFile(w.base, logFileFlags, 0640)
+	if err != nil {
+		return fmt.Errorf("failed to open new log file after rotation: %w", err)
+	}
+	w.file = f
+	w.written = 0
+	w.periodStart = w.rot.frequency.truncate(w.now())
+
+	// Hand the (slow) compression to the permanent worker, or do it inline in
+	// synchronous mode; afterRotate also applies retention.
+	w.afterRotate(rotatedBase)
+	return nil
+}
+
+// uniqueRotatedBase returns base unchanged if no rotated file with that name
+// (or its compressed form) already exists, otherwise it appends an incrementing
+// "-N" suffix. This guards against name collisions when a process restarts and
+// rotates more than once within the same period.
+func (w *asyncWriter) uniqueRotatedBase(base string) string {
+	exists := func(name string) bool {
+		if _, err := w.root.Stat(name); err == nil {
+			return true
+		}
+		if _, err := w.root.Stat(name + ".gz"); err == nil {
+			return true
+		}
+		return false
+	}
+	if !exists(base) {
+		return base
+	}
+	for i := 1; ; i++ {
+		candidate := fmt.Sprintf("%s-%d", base, i)
+		if !exists(candidate) {
+			return candidate
+		}
+	}
+}
+
+// pruneRetention enforces the retention budgets on the set of rotated files.
+// The two budgets are applied independently: a rotated file is deleted if it is
+// older than maxRetentionPeriod, or if keeping it would push the total size of
+// retained rotated files past maxRetentionSize (most-recent files are kept
+// first; the single most recent rotated file is always retained). A budget of 0
+// disables that dimension.
+func (w *asyncWriter) pruneRetention() {
+	maxSize := w.rot.maxRetentionSize
+	maxAge := w.rot.maxRetentionPeriod
+	if maxSize <= 0 && maxAge <= 0 {
+		return
+	}
+
+	entries, err := fs.ReadDir(w.root.FS(), ".")
+	if err != nil {
+		return
+	}
+	prefix := w.base + "."
+	type backup struct {
+		name string
+		size int64
+		mod  time.Time
+	}
+	backups := make([]backup, 0)
+	for _, e := range entries {
+		name := e.Name()
+		if name == w.base || !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		info, ierr := e.Info()
+		if ierr != nil {
+			continue
+		}
+		backups = append(backups, backup{name: name, size: info.Size(), mod: info.ModTime()})
+	}
+
+	// Sort newest first. Rotated names embed a sortable period/timestamp suffix,
+	// so reverse-lexical order is reverse-chronological.
+	sort.Slice(backups, func(i, j int) bool { return backups[i].name > backups[j].name })
+
+	now := w.now()
+	var kept int64
+	for i, b := range backups {
+		if maxAge > 0 && now.Sub(b.mod) > maxAge {
+			_ = w.root.Remove(b.name)
+			continue
+		}
+		// Always keep the most recent rotated file (i == 0) regardless of size,
+		// so a too-small budget can't delete a just-rotated log.
+		if maxSize > 0 && i > 0 && kept+b.size > maxSize {
+			_ = w.root.Remove(b.name)
+			continue
+		}
+		kept += b.size
+	}
+}
+
+// cleanupStaleTempFiles removes leftover compression temp files (named
+// "<base>.*<compressTempSuffix>") in the log directory. These are left behind
+// only when a process is killed while a compression is in progress; on startup
+// none can be legitimately in use.
+func (w *asyncWriter) cleanupStaleTempFiles() {
+	entries, err := fs.ReadDir(w.root.FS(), ".")
+	if err != nil {
+		return
+	}
+	prefix := w.base + "."
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, compressTempSuffix) {
+			continue
+		}
+		if rerr := w.root.Remove(name); rerr != nil && !errors.Is(rerr, fs.ErrNotExist) {
+			log.Warnf("Failed to remove stale compression temp file %q: %v", filepath.Join(w.dir, name), rerr)
+		}
+	}
+}
+
+// compressBackup gzips the rotated file named base (relative to the log
+// directory) to base+".gz", leaving the uncompressed source for the caller to
+// remove.
+//
+// Compression is atomic: the gzip is written to a temporary file and renamed
+// into place, so a crash never leaves a partial ".gz". fsync is best-effort: a
+// complete gzip already holds the data, so a sync failure must not fail the
+// operation, which would otherwise leave the caller to skip removing the source
+// and strand a valid ".gz" next to its identical uncompressed copy.
+func (w *asyncWriter) compressBackup(base string) error {
+	in, err := w.root.Open(base)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	tmp := base + compressTempSuffix
+	out, err := w.root.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
+	if err != nil {
+		return err
+	}
+
+	gz := gzip.NewWriter(out)
+	if _, cerr := io.Copy(gz, in); cerr != nil {
+		_ = gz.Close()
+		_ = out.Close()
+		_ = w.root.Remove(tmp)
+		return cerr
+	}
+	if cerr := gz.Close(); cerr != nil {
+		_ = out.Close()
+		_ = w.root.Remove(tmp)
+		return cerr
+	}
+	// Best-effort durability; do not let a sync failure strand the source.
+	_ = out.Sync()
+	if cerr := out.Close(); cerr != nil {
+		_ = w.root.Remove(tmp)
+		return cerr
+	}
+	// Put the finished archive in place atomically. The caller removes the
+	// (still-present) uncompressed source.
+	if cerr := w.root.Rename(tmp, base+".gz"); cerr != nil {
+		_ = w.root.Remove(tmp)
+		return cerr
+	}
+	return nil
+}

--- a/logging/async_writer.go
+++ b/logging/async_writer.go
@@ -28,14 +28,20 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
-
-	log "github.com/sirupsen/logrus"
 )
+
+// This file deliberately does not import logrus. Everything here runs
+// underneath logrus -- it is the writer logrus hands lines to -- so calling
+// back into it would re-enter the writer, at best recursing and at worst
+// deadlocking against a mutex the calling path already holds. Problems are
+// reported with reportProblem, which writes to stderr.
 
 // asyncWriter is an io.Writer that decouples the (synchronous) logging call
 // sites from disk I/O. Log lines handed to Write are copied into an in-memory
@@ -100,6 +106,15 @@ type asyncWriter struct {
 	// period advances past it, the file is rotated and named for periodStart.
 	// Only meaningful when time-based rotation is active.
 	periodStart time.Time
+	// rotateRetryAfter suppresses rotation attempts until this instant. Set after
+	// a failed rotation so a persistent failure neither spins on syscalls nor
+	// floods stderr on every flush; zero when rotation is healthy.
+	rotateRetryAfter time.Time
+	// mode is the permission mode the active log file is (re)opened with, and the
+	// mode given to a compressed rotated copy. It tracks the mode of the file
+	// rotation replaces, so an operator's chmod on the log survives a rotation
+	// instead of reverting to the default.
+	mode os.FileMode
 
 	// dir is the directory containing the log file. root, when non-nil, is an
 	// os.Root handle to that directory: it holds an open directory descriptor and
@@ -109,6 +124,13 @@ type asyncWriter struct {
 	dir  string
 	base string
 	root *os.Root
+	// rename and openFile are the two filesystem operations a rotation can fail
+	// on. They are reached through the struct rather than through root directly so
+	// those failure paths -- a rename losing to a handle held elsewhere, a
+	// directory that has become unwritable -- can be driven deterministically;
+	// both default to the corresponding os.Root method.
+	rename   func(oldName, newName string) error
+	openFile func(name string, flag int, perm os.FileMode) (*os.File, error)
 
 	// rotation configuration; rotateOK reports whether the target is eligible
 	// (a regular file with rotation enabled).
@@ -151,16 +173,19 @@ const (
 	freqNone
 )
 
-// parseRotationFrequency maps an admin-facing string to a rotationFrequency; any
-// unrecognized value falls back to daily.
-func parseRotationFrequency(s string) rotationFrequency {
+// parseRotationFrequency maps an admin-facing string to a rotationFrequency. An
+// unrecognized value is an error rather than a fallback: silently rotating on a
+// cadence the administrator did not ask for is worse than refusing to start.
+func parseRotationFrequency(s string) (rotationFrequency, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "daily":
+		return freqDaily, nil
 	case "hourly":
-		return freqHourly
+		return freqHourly, nil
 	case "none", "":
-		return freqNone
+		return freqNone, nil
 	default:
-		return freqDaily
+		return freqDaily, fmt.Errorf("unrecognized rotation frequency %q (expected \"daily\", \"hourly\", or \"none\")", s)
 	}
 }
 
@@ -194,6 +219,75 @@ func (ri rotationFrequency) format(t time.Time) string {
 	}
 }
 
+// rotatedSuffixRe matches everything rotate() appends to the log file's name:
+// the period/instant stamp produced by rotationFrequency.format, the optional
+// collision counter added by uniqueRotatedBase, and the optional compression
+// extension -- "<stamp>[-N][.gz]". The three stamp formats are distinguished by
+// length, and the greedy inner group resolves the one ambiguity, "T15-04-05"
+// (a size-only stamp) versus "T15" followed by a counter.
+var rotatedSuffixRe = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2}(?:T\d{2}(?:-\d{2}-\d{2})?)?)(?:-(\d+))?(?:\.gz)?$`)
+
+// rotatedStampLayouts are the time layouts rotationFrequency.format emits, one
+// per frequency; they are mutually distinguishable by length.
+var rotatedStampLayouts = []string{"2006-01-02T15-04-05", "2006-01-02T15", "2006-01-02"}
+
+// rotatedStamp locates a rotated file in the rotation order: the period it
+// covers, plus the collision counter that separates rotations sharing a period.
+type rotatedStamp struct {
+	period time.Time
+	seq    int
+}
+
+// before reports whether s covers an earlier rotation than other.
+func (s rotatedStamp) before(other rotatedStamp) bool {
+	if !s.period.Equal(other.period) {
+		return s.period.Before(other.period)
+	}
+	return s.seq < other.seq
+}
+
+// parseRotatedName reports whether name is a file this writer produced by
+// rotating the log file named base and, if so, where it falls in the rotation
+// order. Two properties depend on going through this parse rather than comparing
+// names directly: only names matching the rotated grammar may be deleted by
+// retention (a sibling such as "pelican.log.incident-4471" belongs to whoever
+// made it), and rotated names are not lexically ordered -- the stamp formats
+// differ in granularity between frequencies and the collision counter is
+// unpadded decimal, so "-9" sorts after "-12".
+func parseRotatedName(base, name string) (rotatedStamp, bool) {
+	suffix, ok := strings.CutPrefix(name, base+".")
+	if !ok {
+		return rotatedStamp{}, false
+	}
+	m := rotatedSuffixRe.FindStringSubmatch(suffix)
+	if m == nil {
+		return rotatedStamp{}, false
+	}
+	var period time.Time
+	parsed := false
+	for _, layout := range rotatedStampLayouts {
+		if len(m[1]) != len(layout) {
+			continue
+		}
+		if t, err := time.ParseInLocation(layout, m[1], time.Local); err == nil {
+			period, parsed = t, true
+		}
+		break
+	}
+	if !parsed {
+		return rotatedStamp{}, false
+	}
+	seq := 0
+	if m[2] != "" {
+		var err error
+		// A counter too large to be one of ours means the name is not ours.
+		if seq, err = strconv.Atoi(m[2]); err != nil {
+			return rotatedStamp{}, false
+		}
+	}
+	return rotatedStamp{period: period, seq: seq}, true
+}
+
 // rotateConfig captures the admin-facing rotation knobs in already-parsed form.
 type rotateConfig struct {
 	enable    bool
@@ -214,6 +308,11 @@ const (
 	// logFileFlags is how the active log file is (re)opened: write-only, created
 	// if absent, appending to preserve any existing content.
 	logFileFlags = os.O_WRONLY | os.O_CREATE | os.O_APPEND
+	// defaultLogFileMode is the mode a log file is created with when there is
+	// no existing file whose permissions should be carried forward. Readable
+	// by the owning group so a log-shipping account can be given access
+	// without granting it write.
+	defaultLogFileMode os.FileMode = 0640
 	// compressTempSuffix is appended to a rotated file's name while its gzip
 	// archive is being written; it is renamed to ".gz" once complete.
 	compressTempSuffix = ".gz.tmp"
@@ -234,7 +333,7 @@ func newAsyncWriter(path string, cfg rotateConfig, flushInterval time.Duration) 
 		}
 	}
 
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, defaultLogFileMode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open log file %q: %w", path, err)
 	}
@@ -266,8 +365,13 @@ func newAsyncWriter(path string, cfg rotateConfig, flushInterval time.Duration) 
 	// eligible for rotation; special files (devices, pipes, terminals) are
 	// written through untouched.
 	periodAnchor := time.Now()
+	w.mode = defaultLogFileMode
 	if fi, statErr := f.Stat(); statErr == nil && fi.Mode().IsRegular() {
 		w.rotateOK = cfg.enable
+		// Carry the existing file's permissions forward so a hardened log
+		// (an operator's chmod 0600 after an incident) keeps its mode when
+		// rotation replaces it.
+		w.mode = fi.Mode().Perm()
 		// If the file already holds content, account for its current size
 		// (size-based rotation) and anchor the current period on its
 		// last-modified time so a restart after a boundary rotates the existing
@@ -291,9 +395,17 @@ func newAsyncWriter(path string, cfg rotateConfig, flushInterval time.Duration) 
 			return nil, fmt.Errorf("failed to open log directory %q for rotation: %w", dir, rerr)
 		}
 		w.root = root
+		w.rename = root.Rename
+		w.openFile = root.OpenFile
 		// Remove any leftover compression temp files from a previous run that was
 		// killed mid-compression. No compression is running yet, so this is safe.
 		w.cleanupStaleTempFiles()
+		// Enforce the retention budgets against what is already on disk.
+		// Retention is otherwise only applied as a side effect of rotating, so
+		// a process that never reaches a rotation -- size-based only on a quiet
+		// server, or one that restarts often -- would let old logs accumulate
+		// past the budget indefinitely.
+		w.pruneRetention()
 	}
 
 	return w, nil
@@ -404,13 +516,26 @@ func (w *asyncWriter) stopCompression() {
 	})
 }
 
+// reportProblem reports a log-maintenance failure straight to stderr.
+//
+// Nothing on the writer's own maintenance paths may report through logrus.
+// Those paths run while fileMu is held, and a logrus call would come back
+// round through Write into writeDirect, which wants that same mutex; in
+// synchronous mode, where the compression worker's caller is waiting on the
+// worker to finish, that is a deadlock rather than a delay. Compression and
+// removal failures are exactly the kind that happen when the disk is full,
+// which is when this path matters most.
+func reportProblem(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "pelican logging: "+format+"\n", args...)
+}
+
 // compressAndPrune compresses rotatedBase to "<base>.gz", removes the source on
 // success, and applies the retention budgets.
 func (w *asyncWriter) compressAndPrune(rotatedBase string) {
 	if err := w.compressBackup(rotatedBase); err != nil {
-		log.Warnf("Failed to compress rotated log %q: %v", filepath.Join(w.dir, rotatedBase), err)
+		reportProblem("failed to compress rotated log %q: %v", filepath.Join(w.dir, rotatedBase), err)
 	} else if err := w.root.Remove(rotatedBase); err != nil {
-		log.Warnf("Failed to remove %q after compression (leaving an uncompressed copy): %v",
+		reportProblem("failed to remove %q after compression (leaving an uncompressed copy): %v",
 			filepath.Join(w.dir, rotatedBase), err)
 	}
 	w.pruneRetention()
@@ -627,16 +752,32 @@ func (w *asyncWriter) shouldRotateTime(now time.Time) bool {
 // is written whole into its own file (the only case a file may exceed MaxSize).
 // Callers must hold fileMu.
 func (w *asyncWriter) writeRotatingLocked(batch []byte) error {
+	// A previous rotation may have left the writer without a file.
+	if err := w.ensureFileLocked(); err != nil {
+		return err
+	}
+
+	// A rotation that failed recently is left alone for a while, during
+	// which the active file keeps growing with nothing to cap it. That is
+	// tolerable only while it stays inside the operator's disk budget.
+	if w.rotateOK && w.rotationSuppressed() {
+		if err := w.checkUnrotatedGrowth(); err != nil {
+			return err
+		}
+	}
+
+	rotationOK := w.rotateOK && !w.rotationSuppressed()
+
 	// Time-based rotation happens before the write so the batch lands in the new
 	// period's file.
-	if w.rotateOK && w.shouldRotateTime(w.now()) {
-		if err := w.rotate(); err != nil {
+	if rotationOK && w.shouldRotateTime(w.now()) {
+		if err := w.tryRotate(); err != nil {
 			return err
 		}
 	}
 
 	// No size cap (or rotation disabled): a single write.
-	if !w.rotateOK || w.rot.maxSize <= 0 {
+	if !rotationOK || w.rot.maxSize <= 0 {
 		n, err := w.file.Write(batch)
 		w.written += int64(n)
 		return err
@@ -646,10 +787,22 @@ func (w *asyncWriter) writeRotatingLocked(batch []byte) error {
 		capacity := w.rot.maxSize - w.written
 		if capacity <= 0 {
 			// Active file is full; start a fresh one.
-			if err := w.rotate(); err != nil {
+			if err := w.tryRotate(); err != nil {
 				return err
 			}
-			capacity = w.rot.maxSize
+			capacity = w.rot.maxSize - w.written
+		}
+		if w.rotationSuppressed() {
+			// Rotation just failed and is being left alone. Overshooting
+			// MaxSize is the lesser evil: the alternative is to loop asking
+			// for capacity that nothing is going to reclaim. Growth is only
+			// tolerated up to the total the operator budgeted for logs.
+			if err := w.checkUnrotatedGrowth(); err != nil {
+				return err
+			}
+			n, werr := w.file.Write(batch)
+			w.written += int64(n)
+			return werr
 		}
 
 		cut := lineCutWithin(batch, capacity)
@@ -657,7 +810,7 @@ func (w *asyncWriter) writeRotatingLocked(batch []byte) error {
 			// The next line does not fit in the remaining capacity.
 			if w.written > 0 {
 				// Give the line a fresh file rather than overshoot the current one.
-				if err := w.rotate(); err != nil {
+				if err := w.tryRotate(); err != nil {
 					return err
 				}
 				continue
@@ -704,10 +857,22 @@ func firstLineEnd(b []byte) int {
 // opens a fresh one for the current period, and kicks off (optional) compression
 // and retention pruning. Callers must hold fileMu.
 func (w *asyncWriter) rotate() error {
+	// Re-read the mode from the file about to be rotated so a chmod applied to
+	// a running server is carried onto its successor, not just one applied
+	// before startup.
+	if fi, serr := w.file.Stat(); serr == nil && fi.Mode().IsRegular() {
+		w.mode = fi.Mode().Perm()
+	}
+
 	// fsync is best-effort: a failure must not abort rotation.
 	_ = w.file.Sync()
-	if err := w.file.Close(); err != nil {
-		return fmt.Errorf("failed to close log file before rotation: %w", err)
+	closeErr := w.file.Close()
+	// The descriptor is gone whether or not Close reported a problem, so drop
+	// it: a closed *os.File left in place would silently swallow every
+	// subsequent write, and w.file == nil is the signal to reopen.
+	w.file = nil
+	if closeErr != nil {
+		return fmt.Errorf("failed to close log file before rotation: %w", closeErr)
 	}
 
 	// Name the rotated file for the period it covered (time-based), or with a
@@ -717,27 +882,102 @@ func (w *asyncWriter) rotate() error {
 		suffixTime = w.now()
 	}
 	rotatedBase := w.uniqueRotatedBase(w.base + "." + w.rot.frequency.format(suffixTime))
-	if err := w.root.Rename(w.base, rotatedBase); err != nil {
-		// Try to reopen the original so logging can continue even if the rename
-		// failed; report the rename error regardless.
-		if f, oerr := w.root.OpenFile(w.base, logFileFlags, 0640); oerr == nil {
-			w.file = f
-		}
+	if err := w.rename(w.base, rotatedBase); err != nil {
 		return fmt.Errorf("failed to rotate log file %q: %w", w.path, err)
 	}
 
-	f, err := w.root.OpenFile(w.base, logFileFlags, 0640)
+	// Past the rename the old file is gone, so the byte counter no longer
+	// describes anything and must not survive into a retry.
+	w.written = 0
+	w.periodStart = w.rot.frequency.truncate(w.now())
+
+	f, err := w.openFile(w.base, logFileFlags, w.mode)
 	if err != nil {
 		return fmt.Errorf("failed to open new log file after rotation: %w", err)
 	}
 	w.file = f
-	w.written = 0
-	w.periodStart = w.rot.frequency.truncate(w.now())
 
 	// Hand the (slow) compression to the permanent worker, or do it inline in
 	// synchronous mode; afterRotate also applies retention.
 	w.afterRotate(rotatedBase)
 	return nil
+}
+
+// rotateRetryInterval is how long rotation is left alone after it fails.
+// Rotation failures are usually transient but not brief -- a handle held open
+// by another process on Windows, a directory that has gone read-only -- so
+// retrying on the very next flush would burn syscalls and fill stderr to no
+// purpose.
+const rotateRetryInterval = time.Minute
+
+// tryRotate rotates the log file, treating a rotation failure as a degraded
+// condition rather than a fatal one: the process keeps logging to whatever
+// file it can open, and rotation is retried later. Losing the ability to
+// start a new file is not a reason to stop a data server, and rotation
+// failures are dominated by transient causes.
+//
+// An error is returned only when the writer is left with no usable file at
+// all, which is a genuine inability to record what the process is doing.
+// Callers must hold fileMu.
+func (w *asyncWriter) tryRotate() error {
+	err := w.rotate()
+	if err == nil {
+		w.rotateRetryAfter = time.Time{}
+		return nil
+	}
+	w.rotateRetryAfter = w.now().Add(rotateRetryInterval)
+	reportProblem("%v; continuing without rotating, will retry in %s", err, rotateRetryInterval)
+	return w.ensureFileLocked()
+}
+
+// ensureFileLocked reopens the active log file when rotation left the writer
+// without one. Callers must hold fileMu.
+func (w *asyncWriter) ensureFileLocked() error {
+	if w.file != nil {
+		return nil
+	}
+	f, err := w.openFile(w.base, logFileFlags, w.mode)
+	if err != nil {
+		return fmt.Errorf("failed to reopen log file %q: %w", w.path, err)
+	}
+	w.file = f
+	// The reopened file may be the pre-rotation one (rename failed) or a fresh
+	// one (rename succeeded, the open did not); either way its real size is
+	// what size-based rotation must count from.
+	if fi, serr := f.Stat(); serr == nil {
+		w.written = fi.Size()
+	}
+	return nil
+}
+
+// rotationSuppressed reports whether a recent rotation failure means rotation
+// should be left alone for now. Callers must hold fileMu.
+func (w *asyncWriter) rotationSuppressed() bool {
+	return !w.rotateRetryAfter.IsZero() && w.now().Before(w.rotateRetryAfter)
+}
+
+// checkUnrotatedGrowth decides how long a broken rotation may be tolerated.
+//
+// Failing to rotate is survivable: the process can keep recording into the
+// file it already has, and the cause is usually transient. Failing to respect
+// the disk the operator set aside for logs is not, because the next thing to
+// fill the filesystem takes the rest of the service down with it -- and an
+// unrotatable log grows without any bound of its own.
+//
+// MaxRetentionSize is that budget: it is what the administrator said all
+// logs may occupy, and with rotation broken the active file is all the logs
+// there are. Leaving it unset asks for unlimited retention, which is equally
+// an answer for this case.
+//
+// Callers must hold fileMu.
+func (w *asyncWriter) checkUnrotatedGrowth() error {
+	budget := w.rot.maxRetentionSize
+	if budget <= 0 || w.written <= budget {
+		return nil
+	}
+	return fmt.Errorf(
+		"log file %q has grown to %d bytes, past the %s budget of %d, and cannot be rotated",
+		w.path, w.written, "Logging.Rotation.MaxRetentionSize", budget)
 }
 
 // uniqueRotatedBase returns base unchanged if no rotated file with that name
@@ -782,28 +1022,34 @@ func (w *asyncWriter) pruneRetention() {
 	if err != nil {
 		return
 	}
-	prefix := w.base + "."
 	type backup struct {
-		name string
-		size int64
-		mod  time.Time
+		name  string
+		size  int64
+		mod   time.Time
+		stamp rotatedStamp
 	}
 	backups := make([]backup, 0)
 	for _, e := range entries {
 		name := e.Name()
-		if name == w.base || !strings.HasPrefix(name, prefix) {
+		// Only files this writer produced are subject to retention. A name
+		// that merely starts with the log's name -- an operator's saved copy,
+		// or another role's log in a shared directory -- belongs to whoever
+		// created it.
+		stamp, ok := parseRotatedName(w.base, name)
+		if !ok {
 			continue
 		}
 		info, ierr := e.Info()
 		if ierr != nil {
 			continue
 		}
-		backups = append(backups, backup{name: name, size: info.Size(), mod: info.ModTime()})
+		backups = append(backups, backup{name: name, size: info.Size(), mod: info.ModTime(), stamp: stamp})
 	}
 
-	// Sort newest first. Rotated names embed a sortable period/timestamp suffix,
-	// so reverse-lexical order is reverse-chronological.
-	sort.Slice(backups, func(i, j int) bool { return backups[i].name > backups[j].name })
+	// Sort newest first by rotation order. Rotated names are not lexically
+	// ordered: stamp granularity differs between frequencies and the collision
+	// counter is unpadded, so "-9" would sort after "-12".
+	sort.Slice(backups, func(i, j int) bool { return backups[j].stamp.before(backups[i].stamp) })
 
 	now := w.now()
 	var kept int64
@@ -838,7 +1084,7 @@ func (w *asyncWriter) cleanupStaleTempFiles() {
 			continue
 		}
 		if rerr := w.root.Remove(name); rerr != nil && !errors.Is(rerr, fs.ErrNotExist) {
-			log.Warnf("Failed to remove stale compression temp file %q: %v", filepath.Join(w.dir, name), rerr)
+			reportProblem("failed to remove stale compression temp file %q: %v", filepath.Join(w.dir, name), rerr)
 		}
 	}
 }
@@ -859,8 +1105,17 @@ func (w *asyncWriter) compressBackup(base string) error {
 	}
 	defer in.Close()
 
+	// Take the archive's permissions from the file being compressed rather
+	// than from the writer, both because it is the mode being preserved and
+	// because this runs on the compression worker, which shares no mutex with
+	// the rotation path that maintains the writer's copy.
+	mode := defaultLogFileMode
+	if fi, serr := in.Stat(); serr == nil && fi.Mode().IsRegular() {
+		mode = fi.Mode().Perm()
+	}
+
 	tmp := base + compressTempSuffix
-	out, err := w.root.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
+	out, err := w.root.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
 		return err
 	}

--- a/logging/async_writer.go
+++ b/logging/async_writer.go
@@ -115,6 +115,12 @@ type asyncWriter struct {
 	// rotation replaces, so an operator's chmod on the log survives a rotation
 	// instead of reverting to the default.
 	mode os.FileMode
+	// rotateSeqBase is the rotated name (without any collision counter) that
+	// rotateSeqNext counts within, and rotateSeqNext is the next counter to
+	// try for it. Together they keep repeated rotations inside one period
+	// from rescanning the names already taken.
+	rotateSeqBase string
+	rotateSeqNext int
 
 	// dir is the directory containing the log file. root, when non-nil, is an
 	// os.Root handle to that directory: it holds an open directory descriptor and
@@ -133,9 +139,15 @@ type asyncWriter struct {
 	openFile func(name string, flag int, perm os.FileMode) (*os.File, error)
 
 	// rotation configuration; rotateOK reports whether the target is eligible
-	// (a regular file with rotation enabled).
-	rot      rotateConfig
-	rotateOK bool
+	// (a regular file with rotation enabled). regularFile records only the
+	// first half of that test, because a regular file whose rotation is left
+	// to an external tool still needs the replacement check below.
+	rot         rotateConfig
+	rotateOK    bool
+	regularFile bool
+	// lastReplaceCheck is when the active file was last compared against the
+	// path it was opened from, throttling that stat off the flush path.
+	lastReplaceCheck time.Time
 
 	// now returns the current time; overridable in tests for deterministic
 	// boundary crossing. Defaults to time.Now.
@@ -367,6 +379,7 @@ func newAsyncWriter(path string, cfg rotateConfig, flushInterval time.Duration) 
 	periodAnchor := time.Now()
 	w.mode = defaultLogFileMode
 	if fi, statErr := f.Stat(); statErr == nil && fi.Mode().IsRegular() {
+		w.regularFile = true
 		w.rotateOK = cfg.enable
 		// Carry the existing file's permissions forward so a hardened log
 		// (an operator's chmod 0600 after an incident) keeps its mode when
@@ -756,6 +769,8 @@ func (w *asyncWriter) writeRotatingLocked(batch []byte) error {
 	if err := w.ensureFileLocked(); err != nil {
 		return err
 	}
+	// Something outside this process may have moved the log aside.
+	w.reopenIfReplaced()
 
 	// A rotation that failed recently is left alone for a while, during
 	// which the active file keeps growing with nothing to cap it. That is
@@ -950,6 +965,62 @@ func (w *asyncWriter) ensureFileLocked() error {
 	return nil
 }
 
+// replaceCheckInterval is how often the active file is compared against the
+// path it was opened from. External rotation runs on the order of hours, so
+// noticing within this window is prompt enough to be worth only one stat.
+const replaceCheckInterval = 10 * time.Second
+
+// reopenIfReplaced reopens the log when the path no longer refers to the file
+// currently held open.
+//
+// An external rotator -- the logrotate configuration Logging.Rotation.Disable
+// exists to defer to -- renames the log aside and creates a new one. Nothing
+// about that invalidates the descriptor already open, so a writer that never
+// looks keeps appending to the renamed inode: the file the administrator now
+// sees stays empty, and the bytes go somewhere only this process can reach,
+// until they vanish when the rotator eventually deletes the old file. The
+// same applies to copytruncate, which leaves the descriptor's offset past the
+// new end of file.
+//
+// Callers must hold fileMu.
+func (w *asyncWriter) reopenIfReplaced() {
+	if !w.regularFile || w.file == nil {
+		return
+	}
+	now := w.now()
+	if !w.lastReplaceCheck.IsZero() && now.Sub(w.lastReplaceCheck) < replaceCheckInterval {
+		return
+	}
+	w.lastReplaceCheck = now
+
+	onDisk, statErr := os.Stat(w.path)
+	held, heldErr := w.file.Stat()
+	if heldErr != nil {
+		return
+	}
+	// A missing path is the rename-and-not-yet-recreated case; opening it
+	// below recreates it.
+	if statErr == nil && os.SameFile(onDisk, held) {
+		return
+	}
+
+	f, err := os.OpenFile(w.path, logFileFlags, w.mode)
+	if err != nil {
+		// Keep writing to the descriptor we have: it is the only one that
+		// works, and losing lines is worse than writing them somewhere
+		// inconvenient.
+		reportProblem("failed to reopen %q after it was replaced: %v", w.path, err)
+		return
+	}
+	_ = w.file.Sync()
+	_ = w.file.Close()
+	w.file = f
+	w.written = 0
+	if fi, ferr := f.Stat(); ferr == nil {
+		w.written = fi.Size()
+	}
+}
+
 // rotationSuppressed reports whether a recent rotation failure means rotation
 // should be left alone for now. Callers must hold fileMu.
 func (w *asyncWriter) rotationSuppressed() bool {
@@ -994,15 +1065,60 @@ func (w *asyncWriter) uniqueRotatedBase(base string) string {
 		}
 		return false
 	}
-	if !exists(base) {
+
+	// Probing upward from 1 on every rotation costs two stats per name
+	// already taken, so a small MaxSize -- which produces many rotations
+	// inside one period -- makes each rotation more expensive than the last.
+	// Resume from the counter this period reached instead, and pay the scan
+	// only when the period changes or the process has just started.
+	if base != w.rotateSeqBase {
+		w.rotateSeqBase = base
+		w.rotateSeqNext = w.highestRotatedSeq(base) + 1
+	}
+	if w.rotateSeqNext == 0 && !exists(base) {
+		w.rotateSeqNext = 1
 		return base
 	}
-	for i := 1; ; i++ {
-		candidate := fmt.Sprintf("%s-%d", base, i)
+	for {
+		candidate := fmt.Sprintf("%s-%d", base, w.rotateSeqNext)
+		w.rotateSeqNext++
+		// The counter is a hint, not an authority: a file could have been
+		// put there by something other than this writer.
 		if !exists(candidate) {
 			return candidate
 		}
 	}
+}
+
+// highestRotatedSeq returns the largest collision counter already used for
+// base, or 0 when only the unsuffixed name exists and -1 when nothing does.
+// Reads the directory once rather than probing name by name.
+func (w *asyncWriter) highestRotatedSeq(base string) int {
+	entries, err := fs.ReadDir(w.root.FS(), ".")
+	if err != nil {
+		// Fall back to probing; a directory we cannot read is a problem
+		// rotation itself will report soon enough.
+		return 0
+	}
+	highest := -1
+	for _, e := range entries {
+		name := strings.TrimSuffix(e.Name(), ".gz")
+		if name == base {
+			if highest < 0 {
+				highest = 0
+			}
+			continue
+		}
+		suffix, ok := strings.CutPrefix(name, base+"-")
+		if !ok {
+			continue
+		}
+		n, cerr := strconv.Atoi(suffix)
+		if cerr == nil && n > highest {
+			highest = n
+		}
+	}
+	return highest
 }
 
 // pruneRetention enforces the retention budgets on the set of rotated files.

--- a/logging/async_writer_test.go
+++ b/logging/async_writer_test.go
@@ -1,0 +1,776 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package logging
+
+import (
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+// fakeEgrp is a minimal errGroup that records the first non-nil error returned
+// by a goroutine, so tests can assert the writer surfaces fatal write errors.
+type fakeEgrp struct {
+	wg  sync.WaitGroup
+	mu  sync.Mutex
+	err error
+}
+
+func (f *fakeEgrp) Go(fn func() error) {
+	f.wg.Add(1)
+	go func() {
+		defer f.wg.Done()
+		if e := fn(); e != nil {
+			f.mu.Lock()
+			if f.err == nil {
+				f.err = e
+			}
+			f.mu.Unlock()
+		}
+	}()
+}
+
+func (f *fakeEgrp) firstErr() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.err
+}
+
+func noRotate() rotateConfig { return rotateConfig{enable: false} }
+
+// fakeClock is a controllable time source for deterministic rotation tests.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	c.t = c.t.Add(d)
+	c.mu.Unlock()
+}
+
+// TestAsyncWriterBasicFlush verifies that lines written through the writer are
+// batched and end up in the file once the writer is drained.
+func TestAsyncWriterBasicFlush(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	w, err := newAsyncWriter(path, noRotate(), 5*time.Millisecond)
+	require.NoError(t, err)
+
+	egrp := &fakeEgrp{}
+	w.start(context.Background(), egrp)
+
+	for i := 0; i < 10; i++ {
+		_, err := w.Write([]byte(fmt.Sprintf("line %d\n", i)))
+		require.NoError(t, err)
+	}
+
+	// Draining (enterSyncMode) must flush everything buffered.
+	w.enterSyncMode()
+	egrp.wg.Wait()
+	require.NoError(t, egrp.firstErr())
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	for i := 0; i < 10; i++ {
+		assert.Contains(t, string(content), fmt.Sprintf("line %d\n", i))
+	}
+	w.close()
+}
+
+// TestAsyncWriterAppends confirms an existing log file is appended to (not
+// truncated) and the initial size is accounted for.
+func TestAsyncWriterAppends(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	require.NoError(t, os.WriteFile(path, []byte("preexisting\n"), 0640))
+
+	w, err := newAsyncWriter(path, noRotate(), time.Millisecond)
+	require.NoError(t, err)
+
+	w.start(context.Background(), &fakeEgrp{})
+	_, _ = w.Write([]byte("new line\n"))
+	w.close()
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "preexisting\nnew line\n", string(content))
+}
+
+// TestAsyncWriterSyncModeDirectWrite verifies that after enterSyncMode, a
+// late-arriving line is written directly (by the calling goroutine) and still
+// lands in the file, in order.
+func TestAsyncWriterSyncModeDirectWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	w, err := newAsyncWriter(path, noRotate(), 5*time.Millisecond)
+	require.NoError(t, err)
+	w.start(context.Background(), &fakeEgrp{})
+
+	_, _ = w.Write([]byte("before-shutdown\n"))
+	w.enterSyncMode()
+
+	// In sync mode synchronous must be set and Write goes straight to disk.
+	w.mu.Lock()
+	require.True(t, w.synchronous)
+	w.mu.Unlock()
+
+	_, err = w.Write([]byte("after-shutdown\n"))
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "before-shutdown\nafter-shutdown\n", string(content))
+	w.close()
+}
+
+// TestAsyncWriterBackpressure verifies that Write blocks once the buffer reaches
+// the high-water mark (no drain making room) and is released when the writer
+// enters synchronous mode, after which the blocked line is written directly.
+func TestAsyncWriterBackpressure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	// Long flush interval and no started drain goroutine, so nothing relieves the
+	// buffer until we force it.
+	w, err := newAsyncWriter(path, noRotate(), time.Hour)
+	require.NoError(t, err)
+	w.maxBufBytes = 16 // tiny high-water mark for the test
+
+	// Fill the buffer to/over the high-water mark (does not block: buffer started empty).
+	_, err = w.Write([]byte("0123456789ABCDEF\n")) // 17 bytes >= 16
+	require.NoError(t, err)
+
+	// The next Write must block because the buffer is full and nothing drains it.
+	done := make(chan struct{})
+	go func() {
+		_, _ = w.Write([]byte("blocked\n"))
+		close(done)
+	}()
+	select {
+	case <-done:
+		t.Fatal("Write should block while the buffer is at the high-water mark")
+	case <-time.After(100 * time.Millisecond):
+		// Expected: still blocked.
+	}
+
+	// Entering synchronous mode (shutdown) must release the blocked writer, which
+	// then falls through to a direct write.
+	w.enterSyncMode()
+	select {
+	case <-done:
+		// Released as expected.
+	case <-time.After(2 * time.Second):
+		t.Fatal("blocked Write was not released after entering synchronous mode")
+	}
+
+	w.close()
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "blocked", "the previously-blocked line should reach the file")
+}
+
+// TestAsyncWriterCompressionWorkerGracefulShutdown verifies the permanent
+// compression worker model: rotations hand compression to a worker registered
+// in the errgroup, and a graceful shutdown (enterSyncMode followed by
+// egrp.Wait) finishes all in-flight compression with no separate "await" call --
+// leaving no stale ".gz.tmp" and no uncompressed rotated sources behind.
+func TestAsyncWriterCompressionWorkerGracefulShutdown(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	cfg := rotateConfig{enable: true, frequency: freqNone, maxSize: 100, compress: true}
+	w, err := newAsyncWriter(path, cfg, time.Millisecond)
+	require.NoError(t, err)
+
+	egrp, ctx := errgroup.WithContext(context.Background())
+	w.start(ctx, egrp) // launches the drain goroutine and the compression worker
+
+	for i := 0; i < 200; i++ {
+		_, err := w.Write([]byte(fmt.Sprintf("line-%04d-padding-xxxx\n", i)))
+		require.NoError(t, err)
+		if i%20 == 0 {
+			time.Sleep(2 * time.Millisecond)
+		}
+	}
+
+	// Graceful shutdown: enterSyncMode drains the worker; egrp.Wait then returns
+	// with no AwaitCompression-style call needed.
+	w.enterSyncMode()
+	require.NoError(t, egrp.Wait())
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		name := e.Name()
+		assert.Falsef(t, strings.HasSuffix(name, compressTempSuffix),
+			"a graceful shutdown must not leave a stale temp file: %s", name)
+		if strings.HasPrefix(name, "test.log.") && !strings.HasSuffix(name, ".gz") {
+			t.Errorf("uncompressed rotated source lingered after compression: %s", name)
+		}
+	}
+	w.close()
+}
+
+// TestAsyncWriterContinuousRotation drives the drain goroutine with a steady stream
+// of writes and asserts rotation keeps working past the first few.
+func TestAsyncWriterContinuousRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	cfg := rotateConfig{enable: true, frequency: freqNone, maxSize: 200, compress: true}
+	w, err := newAsyncWriter(path, cfg, 2*time.Millisecond)
+	require.NoError(t, err)
+	w.start(context.Background(), &fakeEgrp{}) // real drain goroutine
+
+	// ~20 bytes/line; 500 lines -> 10KB -> ~50 rotations at MaxSize=200.
+	for i := 0; i < 500; i++ {
+		_, err := w.Write([]byte(fmt.Sprintf("line-%05d-xxxx\n", i)))
+		require.NoError(t, err)
+		if i%25 == 0 {
+			time.Sleep(3 * time.Millisecond) // let the drain goroutine flush + rotate
+		}
+	}
+	w.enterSyncMode()
+
+	// If rotation kept working, the active file is bounded near MaxSize.
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.LessOrEqualf(t, fi.Size(), int64(400),
+		"active file grew to %d bytes -- rotation appears to have stopped", fi.Size())
+
+	w.close()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var backups int
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "test.log.") {
+			backups++
+		}
+	}
+	assert.Greaterf(t, backups, 5, "expected many rotated files, got %d", backups)
+}
+
+// newRotatingTestWriter builds a writer with rotation enabled and an injected
+// clock anchored at start, so calendar-boundary rotation can be driven
+// deterministically.
+func newRotatingTestWriter(t *testing.T, path string, cfg rotateConfig, clk *fakeClock) *asyncWriter {
+	t.Helper()
+	w, err := newAsyncWriter(path, cfg, time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, w.rotateOK, "regular file with rotation enabled should be eligible")
+	w.now = clk.now
+	// Re-anchor the period to the fake clock (newAsyncWriter used the real one).
+	w.periodStart = cfg.frequency.truncate(clk.now())
+	return w
+}
+
+// TestAsyncWriterDailyRotation verifies a daily rotation at the midnight
+// boundary names the rotated file for the day it covered, and that no rotation
+// happens within the same day.
+func TestAsyncWriterDailyRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 6, 8, 10, 0, 0, 0, time.Local)}
+	cfg := rotateConfig{enable: true, frequency: freqDaily, compress: false}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	// Two writes the same day: no rotation.
+	_, _ = w.Write([]byte("day8-morning\n"))
+	require.NoError(t, w.flushOnce())
+	clk.advance(3 * time.Hour) // still 2026-06-08
+	_, _ = w.Write([]byte("day8-afternoon\n"))
+	require.NoError(t, w.flushOnce())
+
+	_, err := os.Stat(filepath.Join(dir, "test.log.2026-06-08"))
+	assert.True(t, os.IsNotExist(err), "no rotation should occur within the same day")
+
+	// Cross midnight into 2026-06-09: the next flush rotates.
+	clk.advance(14 * time.Hour) // now 2026-06-09 03:00
+	_, _ = w.Write([]byte("day9-line\n"))
+	require.NoError(t, w.flushOnce())
+	w.close()
+
+	// The rotated file is named for the day it covered and holds that day's logs.
+	rotated, err := os.ReadFile(filepath.Join(dir, "test.log.2026-06-08"))
+	require.NoError(t, err, "rotated file should be named for the period it covered")
+	assert.Contains(t, string(rotated), "day8-morning")
+	assert.Contains(t, string(rotated), "day8-afternoon")
+	assert.NotContains(t, string(rotated), "day9-line")
+
+	// The active file holds the new day's logs.
+	active, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(active), "day9-line")
+	assert.NotContains(t, string(active), "day8")
+}
+
+// TestAsyncWriterHourlyRotation verifies the hourly cadence and naming.
+func TestAsyncWriterHourlyRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 6, 8, 9, 30, 0, 0, time.Local)}
+	cfg := rotateConfig{enable: true, frequency: freqHourly, compress: false}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	_, _ = w.Write([]byte("hour9-line\n"))
+	require.NoError(t, w.flushOnce())
+
+	clk.advance(45 * time.Minute) // now 10:15, a new hour
+	_, _ = w.Write([]byte("hour10-line\n"))
+	require.NoError(t, w.flushOnce())
+	w.close()
+
+	rotated, err := os.ReadFile(filepath.Join(dir, "test.log.2026-06-08T09"))
+	require.NoError(t, err, "rotated file should carry the hourly period suffix")
+	assert.Contains(t, string(rotated), "hour9-line")
+
+	active, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(active), "hour10-line")
+}
+
+// TestAsyncWriterSizeRotation verifies size-based rotation combined with a daily
+// interval: within a single day the file rotates each time it reaches MaxSize,
+// and the backups are named for that day (with -N uniqueness).
+func TestAsyncWriterSizeRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 6, 8, 10, 0, 0, 0, time.Local)}
+	cfg := rotateConfig{enable: true, frequency: freqDaily, maxSize: 50, compress: false}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	// 11 bytes per line, flushed individually; the clock never crosses midnight,
+	// so only the size trigger fires.
+	for i := 0; i < 20; i++ {
+		_, _ = w.Write([]byte("0123456789\n"))
+		require.NoError(t, w.flushOnce())
+	}
+	w.close()
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var active, backups int
+	for _, e := range entries {
+		if e.Name() == "test.log" {
+			active++
+		} else if strings.HasPrefix(e.Name(), "test.log.") {
+			backups++
+		}
+	}
+	assert.Equal(t, 1, active, "active log file should exist")
+	assert.GreaterOrEqual(t, backups, 3, "size-based rotation should produce multiple same-day backups")
+
+	// Backups are named for the day; the first keeps the bare date.
+	_, err = os.Stat(filepath.Join(dir, "test.log.2026-06-08"))
+	assert.NoError(t, err, "first same-day backup should use the bare date suffix")
+}
+
+// TestAsyncWriterSizeRotationLineBoundary verifies that when a single drained
+// batch crosses the size threshold, the file is split at line boundaries (never
+// mid-line), each rotated file stays within MaxSize, and the reassembled content
+// matches what was written.
+func TestAsyncWriterSizeRotationLineBoundary(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 6, 9, 12, 0, 0, 0, time.Local)}
+	// Size-only rotation, no compression so files are easy to read.
+	cfg := rotateConfig{enable: true, frequency: freqNone, maxSize: 20, compress: false}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	// One batch of fixed-width 4-char lines (5 bytes each with '\n') that crosses
+	// the 20-byte limit several times.
+	const lineWidth = 4
+	want := ""
+	var batch []byte
+	for _, s := range []string{"aaaa", "bbbb", "cccc", "dddd", "eeee", "ffff", "gggg"} {
+		want += s + "\n"
+		batch = append(batch, []byte(s+"\n")...)
+	}
+	_, err := w.Write(batch)
+	require.NoError(t, err)
+	require.NoError(t, w.flushOnce())
+	w.close()
+
+	// Gather every log file: rotated backups (chronological) then the active file.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var backups []string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "test.log.") {
+			backups = append(backups, e.Name())
+		}
+	}
+	sort.Strings(backups)
+	ordered := append(append([]string{}, backups...), "test.log")
+
+	reassembled := ""
+	for _, name := range ordered {
+		content, rerr := os.ReadFile(filepath.Join(dir, name))
+		require.NoError(t, rerr)
+		if len(content) == 0 {
+			continue
+		}
+		// Every file must stay within MaxSize (no line here exceeds it).
+		assert.LessOrEqualf(t, len(content), 20, "file %s exceeds MaxSize", name)
+		// Every line must be a whole 4-char line — proof nothing was split mid-line.
+		require.Equal(t, byte('\n'), content[len(content)-1], "file %s must end on a line boundary", name)
+		for _, line := range strings.Split(strings.TrimSuffix(string(content), "\n"), "\n") {
+			assert.Lenf(t, line, lineWidth, "file %s contains a split/partial line %q", name, line)
+		}
+		reassembled += string(content)
+	}
+	assert.Equal(t, want, reassembled, "reassembled rotated content should match what was written")
+}
+
+// TestAsyncWriterSizeOnlyRotation verifies size-based rotation with time-based
+// rotation disabled (interval "none"); rotated files get a timestamp suffix.
+func TestAsyncWriterSizeOnlyRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 6, 8, 10, 0, 0, 0, time.Local)}
+	cfg := rotateConfig{enable: true, frequency: freqNone, maxSize: 50, compress: false}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	// Advance the clock a second per flush so timestamp-named backups are unique.
+	for i := 0; i < 18; i++ {
+		_, _ = w.Write([]byte("0123456789\n"))
+		require.NoError(t, w.flushOnce())
+		clk.advance(time.Second)
+	}
+	w.close()
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var backups, timestamped int
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "test.log.") {
+			backups++
+			if strings.HasPrefix(e.Name(), "test.log.2026-06-08T10-00-") {
+				timestamped++
+			}
+		}
+	}
+	assert.GreaterOrEqual(t, backups, 2, "size-only rotation should produce backups")
+	assert.Equal(t, backups, timestamped, "size-only backups should use the timestamp suffix")
+}
+
+// TestAsyncWriterRetentionBySize verifies the total-size retention budget keeps
+// the newest rotated files within the budget and deletes older ones.
+func TestAsyncWriterRetentionBySize(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 1, 1, 12, 0, 0, 0, time.Local)}
+	// 10 bytes/day; keep at most 25 bytes of rotated files (age budget off).
+	cfg := rotateConfig{enable: true, frequency: freqDaily, maxRetentionSize: 25, compress: false}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	// Advance one day per iteration so each write rotates the previous day,
+	// producing several 10-byte backups (2026-01-01 .. 2026-01-04).
+	for i := 0; i < 5; i++ {
+		_, _ = w.Write([]byte("012345678\n")) // 10 bytes
+		require.NoError(t, w.flushOnce())
+		clk.advance(24 * time.Hour)
+	}
+	w.close()
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var backups int
+	var total int64
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "test.log.") {
+			backups++
+			info, ierr := e.Info()
+			require.NoError(t, ierr)
+			total += info.Size()
+		}
+	}
+	assert.Equal(t, 2, backups, "size budget of 25 bytes should retain the 2 newest 10-byte backups")
+	assert.LessOrEqual(t, total, int64(25), "retained rotated files must fit the size budget")
+	// The two most recent days are the ones kept.
+	_, err = os.Stat(filepath.Join(dir, "test.log.2026-01-04"))
+	assert.NoError(t, err, "newest backup should be retained")
+	_, err = os.Stat(filepath.Join(dir, "test.log.2026-01-01"))
+	assert.True(t, os.IsNotExist(err), "oldest backup should be pruned by the size budget")
+}
+
+// TestAsyncWriterRetentionByAge verifies the age retention budget deletes rotated
+// files older than MaxRetentionPeriod and keeps newer ones. Backup mtimes are set
+// explicitly so the policy can be checked deterministically.
+func TestAsyncWriterRetentionByAge(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.Local)
+	clk := &fakeClock{t: now}
+	cfg := rotateConfig{enable: true, frequency: freqDaily, maxRetentionPeriod: 48 * time.Hour}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	mk := func(name string, age time.Duration) {
+		p := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(p, []byte("x"), 0640))
+		mt := now.Add(-age)
+		require.NoError(t, os.Chtimes(p, mt, mt))
+	}
+	mk("test.log.2026-06-07", 24*time.Hour)    // within 48h -> keep
+	mk("test.log.2026-06-05", 72*time.Hour)    // older than 48h -> delete
+	mk("test.log.2026-06-04.gz", 96*time.Hour) // older than 48h -> delete
+
+	w.pruneRetention()
+
+	exists := func(name string) bool {
+		_, err := os.Stat(filepath.Join(dir, name))
+		return err == nil
+	}
+	assert.True(t, exists("test.log.2026-06-07"), "backup within the age budget should be kept")
+	assert.False(t, exists("test.log.2026-06-05"), "backup older than the age budget should be deleted")
+	assert.False(t, exists("test.log.2026-06-04.gz"), "old compressed backup should be deleted too")
+	w.close()
+}
+
+// TestAsyncWriterCompression verifies rotated files are gzipped and the
+// uncompressed original removed.
+func TestAsyncWriterCompression(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 3, 1, 8, 0, 0, 0, time.Local)}
+	cfg := rotateConfig{enable: true, frequency: freqDaily, compress: true}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	_, _ = w.Write([]byte("hello-rotation\n"))
+	require.NoError(t, w.flushOnce())
+	clk.advance(24 * time.Hour) // next day -> rotate on next flush
+	_, _ = w.Write([]byte("next-day\n"))
+	require.NoError(t, w.flushOnce())
+
+	// close() waits for compression workers.
+	w.close()
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var gzCount, plainBackups int
+	var gzName string
+	for _, e := range entries {
+		switch {
+		case strings.HasSuffix(e.Name(), ".gz"):
+			gzCount++
+			gzName = e.Name()
+		case strings.HasPrefix(e.Name(), "test.log."):
+			plainBackups++
+		}
+	}
+	require.GreaterOrEqual(t, gzCount, 1, "expected at least one compressed backup")
+	assert.Equal(t, 0, plainBackups, "uncompressed rotated files should be removed after compression")
+	assert.Equal(t, "test.log.2026-03-01.gz", gzName, "compressed backup keeps the period-named suffix")
+
+	// The gzip content should decompress to the original payload.
+	f, err := os.Open(filepath.Join(dir, gzName))
+	require.NoError(t, err)
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	require.NoError(t, err)
+	decompressed, err := io.ReadAll(gz)
+	require.NoError(t, err)
+	assert.Contains(t, string(decompressed), "hello-rotation")
+}
+
+// TestAsyncWriterCompressionNoDuplicate stress-tests rapid same-day size
+// rotations with concurrent compression and asserts that no uncompressed rotated
+// file is left behind alongside its .gz (and that no two rotations collide on a
+// name).
+func TestAsyncWriterCompressionNoDuplicate(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 6, 9, 12, 0, 0, 0, time.Local)}
+	cfg := rotateConfig{enable: true, frequency: freqDaily, maxSize: 50, compress: true}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	// Many small writes, each flushed, so the file rotates repeatedly within the
+	// same day while compression goroutines run concurrently.
+	for i := 0; i < 300; i++ {
+		_, _ = w.Write([]byte("0123456789\n")) // 11 bytes
+		require.NoError(t, w.flushOnce())
+	}
+	w.close() // waits for compression workers
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	present := make(map[string]bool)
+	for _, e := range entries {
+		present[e.Name()] = true
+	}
+	var lingering []string
+	for name := range present {
+		if !strings.HasPrefix(name, "test.log.") || strings.HasSuffix(name, ".gz") {
+			continue
+		}
+		if name == "test.log" {
+			continue
+		}
+		// An uncompressed rotated file remained after close().
+		lingering = append(lingering, name)
+	}
+	assert.Emptyf(t, lingering, "uncompressed rotated files lingered after compression: %v", lingering)
+}
+
+// TestAsyncWriterSyncModeStillRotates verifies that once the writer is in
+// synchronous mode (drain goroutine stopped, e.g. shutdown context cancelled
+// mid-run), writes still rotate by size -- otherwise the log would grow without
+// bound during the shutdown routines (which can still be chatty).
+func TestAsyncWriterSyncModeStillRotates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 6, 9, 12, 0, 0, 0, time.Local)}
+	cfg := rotateConfig{enable: true, frequency: freqNone, maxSize: 50, compress: false}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	// Flip to synchronous mode without ever starting the drain goroutine, so
+	// every Write goes through the direct (synchronous) path.
+	w.mu.Lock()
+	w.synchronous = true
+	w.mu.Unlock()
+
+	for i := 0; i < 30; i++ {
+		clk.advance(time.Second)                  // unique timestamp suffixes for size-only naming
+		_, err := w.Write([]byte("0123456789\n")) // 11 bytes
+		require.NoError(t, err)
+	}
+	w.close()
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var backups int
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "test.log.") {
+			backups++
+		}
+	}
+	assert.GreaterOrEqual(t, backups, 3, "synchronous-mode writes must still rotate by size")
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.LessOrEqualf(t, fi.Size(), int64(50), "active file must stay within MaxSize in synchronous mode")
+}
+
+// TestAsyncWriterCleansStaleTempFiles verifies that a leftover compression temp
+// file (from a process killed mid-compression) is removed on startup, while real
+// rotated files are left alone.
+func TestAsyncWriterCleansStaleTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	stale := filepath.Join(dir, "test.log.2026-06-09-1.gz.tmp")
+	require.NoError(t, os.WriteFile(stale, []byte("\x1f\x8b"), 0640)) // partial gzip
+	keep := filepath.Join(dir, "test.log.2026-06-09-1")
+	require.NoError(t, os.WriteFile(keep, []byte("data\n"), 0640))
+	keepGz := filepath.Join(dir, "test.log.2026-06-09.gz")
+	require.NoError(t, os.WriteFile(keepGz, []byte("\x1f\x8bcompressed"), 0640))
+
+	cfg := rotateConfig{enable: true, frequency: freqDaily, maxSize: 1000}
+	w, err := newAsyncWriter(path, cfg, time.Millisecond)
+	require.NoError(t, err)
+	defer w.close()
+
+	_, err = os.Stat(stale)
+	assert.Truef(t, os.IsNotExist(err), "stale %s should be removed on startup", filepath.Base(stale))
+	_, err = os.Stat(keep)
+	assert.NoErrorf(t, err, "rotated source %s must not be removed", filepath.Base(keep))
+	_, err = os.Stat(keepGz)
+	assert.NoErrorf(t, err, "compressed backup %s must not be removed", filepath.Base(keepGz))
+}
+
+// TestAsyncWriterNonRegularNoRotation verifies that a non-regular target
+// (a device file) is never marked rotation-eligible, yet still accepts writes.
+func TestAsyncWriterNonRegularNoRotation(t *testing.T) {
+	cfg := rotateConfig{enable: true, frequency: freqHourly}
+	w, err := newAsyncWriter("/dev/null", cfg, 5*time.Millisecond)
+	require.NoError(t, err)
+	assert.False(t, w.rotateOK, "/dev/null is not a regular file and must not be rotated")
+	assert.Nil(t, w.root, "no directory handle should be opened when rotation is disabled")
+
+	w.start(context.Background(), &fakeEgrp{})
+	_, err = w.Write([]byte("to the void\n"))
+	require.NoError(t, err)
+	w.close()
+}
+
+// TestAsyncWriterWriteErrorIsFatal verifies that a write failure is surfaced
+// through the errgroup (so the process can shut down).
+func TestAsyncWriterWriteErrorIsFatal(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	w, err := newAsyncWriter(path, noRotate(), 5*time.Millisecond)
+	require.NoError(t, err)
+
+	egrp := &fakeEgrp{}
+	w.start(context.Background(), egrp)
+
+	// Close the underlying descriptor so the next flush fails with EBADF.
+	w.fileMu.Lock()
+	_ = w.file.Close()
+	w.fileMu.Unlock()
+
+	// Trigger writes; the drain goroutine will flush (on its timer) and fail.
+	for i := 0; i < 5; i++ {
+		_, _ = w.Write([]byte("doomed\n"))
+	}
+
+	require.Eventually(t, func() bool {
+		return egrp.firstErr() != nil
+	}, 2*time.Second, 10*time.Millisecond, "a fatal write error should be surfaced via the errgroup")
+
+	// The writer should have flipped to synchronous mode after the failure.
+	w.mu.Lock()
+	synchronous := w.synchronous
+	w.mu.Unlock()
+	assert.True(t, synchronous, "writer should enter synchronous mode after a fatal error")
+}
+
+// TestAsyncWriterFlushOnceReturnsErrorOnClosedFile is a direct check of the
+// flush error path used by the drain loop.
+func TestAsyncWriterFlushOnceReturnsErrorOnClosedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	w, err := newAsyncWriter(path, noRotate(), time.Millisecond)
+	require.NoError(t, err)
+
+	_, _ = w.Write([]byte("data\n"))
+	w.fileMu.Lock()
+	_ = w.file.Close()
+	w.fileMu.Unlock()
+
+	assert.Error(t, w.flushOnce(), "flushOnce should report the underlying write error")
+}

--- a/logging/async_writer_test.go
+++ b/logging/async_writer_test.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 // fakeEgrp is a minimal errGroup that records the first non-nil error returned
@@ -203,6 +204,47 @@ func TestAsyncWriterBackpressure(t *testing.T) {
 	content, err := os.ReadFile(path)
 	require.NoError(t, err)
 	assert.Contains(t, string(content), "blocked", "the previously-blocked line should reach the file")
+}
+
+// TestAsyncWriterCompressionWorkerGracefulShutdown verifies the permanent
+// compression worker model: rotations hand compression to a worker registered
+// in the errgroup, and a graceful shutdown (enterSyncMode followed by
+// egrp.Wait) finishes all in-flight compression with no separate "await" call --
+// leaving no stale ".gz.tmp" and no uncompressed rotated sources behind.
+func TestAsyncWriterCompressionWorkerGracefulShutdown(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	cfg := rotateConfig{enable: true, frequency: freqNone, maxSize: 100, compress: true}
+	w, err := newAsyncWriter(path, cfg, time.Millisecond)
+	require.NoError(t, err)
+
+	egrp, ctx := errgroup.WithContext(context.Background())
+	w.start(ctx, egrp) // launches the drain goroutine and the compression worker
+
+	for i := 0; i < 200; i++ {
+		_, err := w.Write([]byte(fmt.Sprintf("line-%04d-padding-xxxx\n", i)))
+		require.NoError(t, err)
+		if i%20 == 0 {
+			time.Sleep(2 * time.Millisecond)
+		}
+	}
+
+	// Graceful shutdown: enterSyncMode drains the worker; egrp.Wait then returns
+	// with no AwaitCompression-style call needed.
+	w.enterSyncMode()
+	require.NoError(t, egrp.Wait())
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		name := e.Name()
+		assert.Falsef(t, strings.HasSuffix(name, compressTempSuffix),
+			"a graceful shutdown must not leave a stale temp file: %s", name)
+		if strings.HasPrefix(name, "test.log.") && !strings.HasSuffix(name, ".gz") {
+			t.Errorf("uncompressed rotated source lingered after compression: %s", name)
+		}
+	}
+	w.close()
 }
 
 // TestAsyncWriterContinuousRotation drives the drain goroutine with a steady stream

--- a/logging/async_writer_test.go
+++ b/logging/async_writer_test.go
@@ -205,6 +205,44 @@ func TestAsyncWriterBackpressure(t *testing.T) {
 	assert.Contains(t, string(content), "blocked", "the previously-blocked line should reach the file")
 }
 
+// TestAsyncWriterContinuousRotation drives the drain goroutine with a steady stream
+// of writes and asserts rotation keeps working past the first few.
+func TestAsyncWriterContinuousRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	cfg := rotateConfig{enable: true, frequency: freqNone, maxSize: 200, compress: true}
+	w, err := newAsyncWriter(path, cfg, 2*time.Millisecond)
+	require.NoError(t, err)
+	w.start(context.Background(), &fakeEgrp{}) // real drain goroutine
+
+	// ~20 bytes/line; 500 lines -> 10KB -> ~50 rotations at MaxSize=200.
+	for i := 0; i < 500; i++ {
+		_, err := w.Write([]byte(fmt.Sprintf("line-%05d-xxxx\n", i)))
+		require.NoError(t, err)
+		if i%25 == 0 {
+			time.Sleep(3 * time.Millisecond) // let the drain goroutine flush + rotate
+		}
+	}
+	w.enterSyncMode()
+
+	// If rotation kept working, the active file is bounded near MaxSize.
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.LessOrEqualf(t, fi.Size(), int64(400),
+		"active file grew to %d bytes -- rotation appears to have stopped", fi.Size())
+
+	w.close()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var backups int
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "test.log.") {
+			backups++
+		}
+	}
+	assert.Greaterf(t, backups, 5, "expected many rotated files, got %d", backups)
+}
+
 // newRotatingTestWriter builds a writer with rotation enabled and an injected
 // clock anchored at start, so calendar-boundary rotation can be driven
 // deterministically.
@@ -565,6 +603,71 @@ func TestAsyncWriterCompressionNoDuplicate(t *testing.T) {
 		lingering = append(lingering, name)
 	}
 	assert.Emptyf(t, lingering, "uncompressed rotated files lingered after compression: %v", lingering)
+}
+
+// TestAsyncWriterSyncModeStillRotates verifies that once the writer is in
+// synchronous mode (drain goroutine stopped, e.g. shutdown context cancelled
+// mid-run), writes still rotate by size -- otherwise the log would grow without
+// bound during the shutdown routines (which can still be chatty).
+func TestAsyncWriterSyncModeStillRotates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 6, 9, 12, 0, 0, 0, time.Local)}
+	cfg := rotateConfig{enable: true, frequency: freqNone, maxSize: 50, compress: false}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	// Flip to synchronous mode without ever starting the drain goroutine, so
+	// every Write goes through the direct (synchronous) path.
+	w.mu.Lock()
+	w.synchronous = true
+	w.mu.Unlock()
+
+	for i := 0; i < 30; i++ {
+		clk.advance(time.Second)                  // unique timestamp suffixes for size-only naming
+		_, err := w.Write([]byte("0123456789\n")) // 11 bytes
+		require.NoError(t, err)
+	}
+	w.close()
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var backups int
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "test.log.") {
+			backups++
+		}
+	}
+	assert.GreaterOrEqual(t, backups, 3, "synchronous-mode writes must still rotate by size")
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.LessOrEqualf(t, fi.Size(), int64(50), "active file must stay within MaxSize in synchronous mode")
+}
+
+// TestAsyncWriterCleansStaleTempFiles verifies that a leftover compression temp
+// file (from a process killed mid-compression) is removed on startup, while real
+// rotated files are left alone.
+func TestAsyncWriterCleansStaleTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	stale := filepath.Join(dir, "test.log.2026-06-09-1.gz.tmp")
+	require.NoError(t, os.WriteFile(stale, []byte("\x1f\x8b"), 0640)) // partial gzip
+	keep := filepath.Join(dir, "test.log.2026-06-09-1")
+	require.NoError(t, os.WriteFile(keep, []byte("data\n"), 0640))
+	keepGz := filepath.Join(dir, "test.log.2026-06-09.gz")
+	require.NoError(t, os.WriteFile(keepGz, []byte("\x1f\x8bcompressed"), 0640))
+
+	cfg := rotateConfig{enable: true, frequency: freqDaily, maxSize: 1000}
+	w, err := newAsyncWriter(path, cfg, time.Millisecond)
+	require.NoError(t, err)
+	defer w.close()
+
+	_, err = os.Stat(stale)
+	assert.Truef(t, os.IsNotExist(err), "stale %s should be removed on startup", filepath.Base(stale))
+	_, err = os.Stat(keep)
+	assert.NoErrorf(t, err, "rotated source %s must not be removed", filepath.Base(keep))
+	_, err = os.Stat(keepGz)
+	assert.NoErrorf(t, err, "compressed backup %s must not be removed", filepath.Base(keepGz))
 }
 
 // TestAsyncWriterNonRegularNoRotation verifies that a non-regular target

--- a/logging/async_writer_test.go
+++ b/logging/async_writer_test.go
@@ -1,0 +1,631 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package logging
+
+import (
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeEgrp is a minimal errGroup that records the first non-nil error returned
+// by a goroutine, so tests can assert the writer surfaces fatal write errors.
+type fakeEgrp struct {
+	wg  sync.WaitGroup
+	mu  sync.Mutex
+	err error
+}
+
+func (f *fakeEgrp) Go(fn func() error) {
+	f.wg.Add(1)
+	go func() {
+		defer f.wg.Done()
+		if e := fn(); e != nil {
+			f.mu.Lock()
+			if f.err == nil {
+				f.err = e
+			}
+			f.mu.Unlock()
+		}
+	}()
+}
+
+func (f *fakeEgrp) firstErr() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.err
+}
+
+func noRotate() rotateConfig { return rotateConfig{enable: false} }
+
+// fakeClock is a controllable time source for deterministic rotation tests.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	c.t = c.t.Add(d)
+	c.mu.Unlock()
+}
+
+// TestAsyncWriterBasicFlush verifies that lines written through the writer are
+// batched and end up in the file once the writer is drained.
+func TestAsyncWriterBasicFlush(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	w, err := newAsyncWriter(path, noRotate(), 5*time.Millisecond)
+	require.NoError(t, err)
+
+	egrp := &fakeEgrp{}
+	w.start(context.Background(), egrp)
+
+	for i := 0; i < 10; i++ {
+		_, err := w.Write([]byte(fmt.Sprintf("line %d\n", i)))
+		require.NoError(t, err)
+	}
+
+	// Draining (enterSyncMode) must flush everything buffered.
+	w.enterSyncMode()
+	egrp.wg.Wait()
+	require.NoError(t, egrp.firstErr())
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	for i := 0; i < 10; i++ {
+		assert.Contains(t, string(content), fmt.Sprintf("line %d\n", i))
+	}
+	w.close()
+}
+
+// TestAsyncWriterAppends confirms an existing log file is appended to (not
+// truncated) and the initial size is accounted for.
+func TestAsyncWriterAppends(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	require.NoError(t, os.WriteFile(path, []byte("preexisting\n"), 0640))
+
+	w, err := newAsyncWriter(path, noRotate(), time.Millisecond)
+	require.NoError(t, err)
+
+	w.start(context.Background(), &fakeEgrp{})
+	_, _ = w.Write([]byte("new line\n"))
+	w.close()
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "preexisting\nnew line\n", string(content))
+}
+
+// TestAsyncWriterSyncModeDirectWrite verifies that after enterSyncMode, a
+// late-arriving line is written directly (by the calling goroutine) and still
+// lands in the file, in order.
+func TestAsyncWriterSyncModeDirectWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	w, err := newAsyncWriter(path, noRotate(), 5*time.Millisecond)
+	require.NoError(t, err)
+	w.start(context.Background(), &fakeEgrp{})
+
+	_, _ = w.Write([]byte("before-shutdown\n"))
+	w.enterSyncMode()
+
+	// In sync mode synchronous must be set and Write goes straight to disk.
+	w.mu.Lock()
+	require.True(t, w.synchronous)
+	w.mu.Unlock()
+
+	_, err = w.Write([]byte("after-shutdown\n"))
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "before-shutdown\nafter-shutdown\n", string(content))
+	w.close()
+}
+
+// TestAsyncWriterBackpressure verifies that Write blocks once the buffer reaches
+// the high-water mark (no drain making room) and is released when the writer
+// enters synchronous mode, after which the blocked line is written directly.
+func TestAsyncWriterBackpressure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	// Long flush interval and no started drain goroutine, so nothing relieves the
+	// buffer until we force it.
+	w, err := newAsyncWriter(path, noRotate(), time.Hour)
+	require.NoError(t, err)
+	w.maxBufBytes = 16 // tiny high-water mark for the test
+
+	// Fill the buffer to/over the high-water mark (does not block: buffer started empty).
+	_, err = w.Write([]byte("0123456789ABCDEF\n")) // 17 bytes >= 16
+	require.NoError(t, err)
+
+	// The next Write must block because the buffer is full and nothing drains it.
+	done := make(chan struct{})
+	go func() {
+		_, _ = w.Write([]byte("blocked\n"))
+		close(done)
+	}()
+	select {
+	case <-done:
+		t.Fatal("Write should block while the buffer is at the high-water mark")
+	case <-time.After(100 * time.Millisecond):
+		// Expected: still blocked.
+	}
+
+	// Entering synchronous mode (shutdown) must release the blocked writer, which
+	// then falls through to a direct write.
+	w.enterSyncMode()
+	select {
+	case <-done:
+		// Released as expected.
+	case <-time.After(2 * time.Second):
+		t.Fatal("blocked Write was not released after entering synchronous mode")
+	}
+
+	w.close()
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "blocked", "the previously-blocked line should reach the file")
+}
+
+// newRotatingTestWriter builds a writer with rotation enabled and an injected
+// clock anchored at start, so calendar-boundary rotation can be driven
+// deterministically.
+func newRotatingTestWriter(t *testing.T, path string, cfg rotateConfig, clk *fakeClock) *asyncWriter {
+	t.Helper()
+	w, err := newAsyncWriter(path, cfg, time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, w.rotateOK, "regular file with rotation enabled should be eligible")
+	w.now = clk.now
+	// Re-anchor the period to the fake clock (newAsyncWriter used the real one).
+	w.periodStart = cfg.frequency.truncate(clk.now())
+	return w
+}
+
+// TestAsyncWriterDailyRotation verifies a daily rotation at the midnight
+// boundary names the rotated file for the day it covered, and that no rotation
+// happens within the same day.
+func TestAsyncWriterDailyRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 6, 8, 10, 0, 0, 0, time.Local)}
+	cfg := rotateConfig{enable: true, frequency: freqDaily, compress: false}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	// Two writes the same day: no rotation.
+	_, _ = w.Write([]byte("day8-morning\n"))
+	require.NoError(t, w.flushOnce())
+	clk.advance(3 * time.Hour) // still 2026-06-08
+	_, _ = w.Write([]byte("day8-afternoon\n"))
+	require.NoError(t, w.flushOnce())
+
+	_, err := os.Stat(filepath.Join(dir, "test.log.2026-06-08"))
+	assert.True(t, os.IsNotExist(err), "no rotation should occur within the same day")
+
+	// Cross midnight into 2026-06-09: the next flush rotates.
+	clk.advance(14 * time.Hour) // now 2026-06-09 03:00
+	_, _ = w.Write([]byte("day9-line\n"))
+	require.NoError(t, w.flushOnce())
+	w.close()
+
+	// The rotated file is named for the day it covered and holds that day's logs.
+	rotated, err := os.ReadFile(filepath.Join(dir, "test.log.2026-06-08"))
+	require.NoError(t, err, "rotated file should be named for the period it covered")
+	assert.Contains(t, string(rotated), "day8-morning")
+	assert.Contains(t, string(rotated), "day8-afternoon")
+	assert.NotContains(t, string(rotated), "day9-line")
+
+	// The active file holds the new day's logs.
+	active, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(active), "day9-line")
+	assert.NotContains(t, string(active), "day8")
+}
+
+// TestAsyncWriterHourlyRotation verifies the hourly cadence and naming.
+func TestAsyncWriterHourlyRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 6, 8, 9, 30, 0, 0, time.Local)}
+	cfg := rotateConfig{enable: true, frequency: freqHourly, compress: false}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	_, _ = w.Write([]byte("hour9-line\n"))
+	require.NoError(t, w.flushOnce())
+
+	clk.advance(45 * time.Minute) // now 10:15, a new hour
+	_, _ = w.Write([]byte("hour10-line\n"))
+	require.NoError(t, w.flushOnce())
+	w.close()
+
+	rotated, err := os.ReadFile(filepath.Join(dir, "test.log.2026-06-08T09"))
+	require.NoError(t, err, "rotated file should carry the hourly period suffix")
+	assert.Contains(t, string(rotated), "hour9-line")
+
+	active, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(active), "hour10-line")
+}
+
+// TestAsyncWriterSizeRotation verifies size-based rotation combined with a daily
+// interval: within a single day the file rotates each time it reaches MaxSize,
+// and the backups are named for that day (with -N uniqueness).
+func TestAsyncWriterSizeRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 6, 8, 10, 0, 0, 0, time.Local)}
+	cfg := rotateConfig{enable: true, frequency: freqDaily, maxSize: 50, compress: false}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	// 11 bytes per line, flushed individually; the clock never crosses midnight,
+	// so only the size trigger fires.
+	for i := 0; i < 20; i++ {
+		_, _ = w.Write([]byte("0123456789\n"))
+		require.NoError(t, w.flushOnce())
+	}
+	w.close()
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var active, backups int
+	for _, e := range entries {
+		if e.Name() == "test.log" {
+			active++
+		} else if strings.HasPrefix(e.Name(), "test.log.") {
+			backups++
+		}
+	}
+	assert.Equal(t, 1, active, "active log file should exist")
+	assert.GreaterOrEqual(t, backups, 3, "size-based rotation should produce multiple same-day backups")
+
+	// Backups are named for the day; the first keeps the bare date.
+	_, err = os.Stat(filepath.Join(dir, "test.log.2026-06-08"))
+	assert.NoError(t, err, "first same-day backup should use the bare date suffix")
+}
+
+// TestAsyncWriterSizeRotationLineBoundary verifies that when a single drained
+// batch crosses the size threshold, the file is split at line boundaries (never
+// mid-line), each rotated file stays within MaxSize, and the reassembled content
+// matches what was written.
+func TestAsyncWriterSizeRotationLineBoundary(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 6, 9, 12, 0, 0, 0, time.Local)}
+	// Size-only rotation, no compression so files are easy to read.
+	cfg := rotateConfig{enable: true, frequency: freqNone, maxSize: 20, compress: false}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	// One batch of fixed-width 4-char lines (5 bytes each with '\n') that crosses
+	// the 20-byte limit several times.
+	const lineWidth = 4
+	want := ""
+	var batch []byte
+	for _, s := range []string{"aaaa", "bbbb", "cccc", "dddd", "eeee", "ffff", "gggg"} {
+		want += s + "\n"
+		batch = append(batch, []byte(s+"\n")...)
+	}
+	_, err := w.Write(batch)
+	require.NoError(t, err)
+	require.NoError(t, w.flushOnce())
+	w.close()
+
+	// Gather every log file: rotated backups (chronological) then the active file.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var backups []string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "test.log.") {
+			backups = append(backups, e.Name())
+		}
+	}
+	sort.Strings(backups)
+	ordered := append(append([]string{}, backups...), "test.log")
+
+	reassembled := ""
+	for _, name := range ordered {
+		content, rerr := os.ReadFile(filepath.Join(dir, name))
+		require.NoError(t, rerr)
+		if len(content) == 0 {
+			continue
+		}
+		// Every file must stay within MaxSize (no line here exceeds it).
+		assert.LessOrEqualf(t, len(content), 20, "file %s exceeds MaxSize", name)
+		// Every line must be a whole 4-char line — proof nothing was split mid-line.
+		require.Equal(t, byte('\n'), content[len(content)-1], "file %s must end on a line boundary", name)
+		for _, line := range strings.Split(strings.TrimSuffix(string(content), "\n"), "\n") {
+			assert.Lenf(t, line, lineWidth, "file %s contains a split/partial line %q", name, line)
+		}
+		reassembled += string(content)
+	}
+	assert.Equal(t, want, reassembled, "reassembled rotated content should match what was written")
+}
+
+// TestAsyncWriterSizeOnlyRotation verifies size-based rotation with time-based
+// rotation disabled (interval "none"); rotated files get a timestamp suffix.
+func TestAsyncWriterSizeOnlyRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 6, 8, 10, 0, 0, 0, time.Local)}
+	cfg := rotateConfig{enable: true, frequency: freqNone, maxSize: 50, compress: false}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	// Advance the clock a second per flush so timestamp-named backups are unique.
+	for i := 0; i < 18; i++ {
+		_, _ = w.Write([]byte("0123456789\n"))
+		require.NoError(t, w.flushOnce())
+		clk.advance(time.Second)
+	}
+	w.close()
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var backups, timestamped int
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "test.log.") {
+			backups++
+			if strings.HasPrefix(e.Name(), "test.log.2026-06-08T10-00-") {
+				timestamped++
+			}
+		}
+	}
+	assert.GreaterOrEqual(t, backups, 2, "size-only rotation should produce backups")
+	assert.Equal(t, backups, timestamped, "size-only backups should use the timestamp suffix")
+}
+
+// TestAsyncWriterRetentionBySize verifies the total-size retention budget keeps
+// the newest rotated files within the budget and deletes older ones.
+func TestAsyncWriterRetentionBySize(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 1, 1, 12, 0, 0, 0, time.Local)}
+	// 10 bytes/day; keep at most 25 bytes of rotated files (age budget off).
+	cfg := rotateConfig{enable: true, frequency: freqDaily, maxRetentionSize: 25, compress: false}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	// Advance one day per iteration so each write rotates the previous day,
+	// producing several 10-byte backups (2026-01-01 .. 2026-01-04).
+	for i := 0; i < 5; i++ {
+		_, _ = w.Write([]byte("012345678\n")) // 10 bytes
+		require.NoError(t, w.flushOnce())
+		clk.advance(24 * time.Hour)
+	}
+	w.close()
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var backups int
+	var total int64
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "test.log.") {
+			backups++
+			info, ierr := e.Info()
+			require.NoError(t, ierr)
+			total += info.Size()
+		}
+	}
+	assert.Equal(t, 2, backups, "size budget of 25 bytes should retain the 2 newest 10-byte backups")
+	assert.LessOrEqual(t, total, int64(25), "retained rotated files must fit the size budget")
+	// The two most recent days are the ones kept.
+	_, err = os.Stat(filepath.Join(dir, "test.log.2026-01-04"))
+	assert.NoError(t, err, "newest backup should be retained")
+	_, err = os.Stat(filepath.Join(dir, "test.log.2026-01-01"))
+	assert.True(t, os.IsNotExist(err), "oldest backup should be pruned by the size budget")
+}
+
+// TestAsyncWriterRetentionByAge verifies the age retention budget deletes rotated
+// files older than MaxRetentionPeriod and keeps newer ones. Backup mtimes are set
+// explicitly so the policy can be checked deterministically.
+func TestAsyncWriterRetentionByAge(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.Local)
+	clk := &fakeClock{t: now}
+	cfg := rotateConfig{enable: true, frequency: freqDaily, maxRetentionPeriod: 48 * time.Hour}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	mk := func(name string, age time.Duration) {
+		p := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(p, []byte("x"), 0640))
+		mt := now.Add(-age)
+		require.NoError(t, os.Chtimes(p, mt, mt))
+	}
+	mk("test.log.2026-06-07", 24*time.Hour)    // within 48h -> keep
+	mk("test.log.2026-06-05", 72*time.Hour)    // older than 48h -> delete
+	mk("test.log.2026-06-04.gz", 96*time.Hour) // older than 48h -> delete
+
+	w.pruneRetention()
+
+	exists := func(name string) bool {
+		_, err := os.Stat(filepath.Join(dir, name))
+		return err == nil
+	}
+	assert.True(t, exists("test.log.2026-06-07"), "backup within the age budget should be kept")
+	assert.False(t, exists("test.log.2026-06-05"), "backup older than the age budget should be deleted")
+	assert.False(t, exists("test.log.2026-06-04.gz"), "old compressed backup should be deleted too")
+	w.close()
+}
+
+// TestAsyncWriterCompression verifies rotated files are gzipped and the
+// uncompressed original removed.
+func TestAsyncWriterCompression(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 3, 1, 8, 0, 0, 0, time.Local)}
+	cfg := rotateConfig{enable: true, frequency: freqDaily, compress: true}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	_, _ = w.Write([]byte("hello-rotation\n"))
+	require.NoError(t, w.flushOnce())
+	clk.advance(24 * time.Hour) // next day -> rotate on next flush
+	_, _ = w.Write([]byte("next-day\n"))
+	require.NoError(t, w.flushOnce())
+
+	// close() waits for compression workers.
+	w.close()
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var gzCount, plainBackups int
+	var gzName string
+	for _, e := range entries {
+		switch {
+		case strings.HasSuffix(e.Name(), ".gz"):
+			gzCount++
+			gzName = e.Name()
+		case strings.HasPrefix(e.Name(), "test.log."):
+			plainBackups++
+		}
+	}
+	require.GreaterOrEqual(t, gzCount, 1, "expected at least one compressed backup")
+	assert.Equal(t, 0, plainBackups, "uncompressed rotated files should be removed after compression")
+	assert.Equal(t, "test.log.2026-03-01.gz", gzName, "compressed backup keeps the period-named suffix")
+
+	// The gzip content should decompress to the original payload.
+	f, err := os.Open(filepath.Join(dir, gzName))
+	require.NoError(t, err)
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	require.NoError(t, err)
+	decompressed, err := io.ReadAll(gz)
+	require.NoError(t, err)
+	assert.Contains(t, string(decompressed), "hello-rotation")
+}
+
+// TestAsyncWriterCompressionNoDuplicate stress-tests rapid same-day size
+// rotations with concurrent compression and asserts that no uncompressed rotated
+// file is left behind alongside its .gz (and that no two rotations collide on a
+// name).
+func TestAsyncWriterCompressionNoDuplicate(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 6, 9, 12, 0, 0, 0, time.Local)}
+	cfg := rotateConfig{enable: true, frequency: freqDaily, maxSize: 50, compress: true}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	// Many small writes, each flushed, so the file rotates repeatedly within the
+	// same day while compression goroutines run concurrently.
+	for i := 0; i < 300; i++ {
+		_, _ = w.Write([]byte("0123456789\n")) // 11 bytes
+		require.NoError(t, w.flushOnce())
+	}
+	w.close() // waits for compression workers
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	present := make(map[string]bool)
+	for _, e := range entries {
+		present[e.Name()] = true
+	}
+	var lingering []string
+	for name := range present {
+		if !strings.HasPrefix(name, "test.log.") || strings.HasSuffix(name, ".gz") {
+			continue
+		}
+		if name == "test.log" {
+			continue
+		}
+		// An uncompressed rotated file remained after close().
+		lingering = append(lingering, name)
+	}
+	assert.Emptyf(t, lingering, "uncompressed rotated files lingered after compression: %v", lingering)
+}
+
+// TestAsyncWriterNonRegularNoRotation verifies that a non-regular target
+// (a device file) is never marked rotation-eligible, yet still accepts writes.
+func TestAsyncWriterNonRegularNoRotation(t *testing.T) {
+	cfg := rotateConfig{enable: true, frequency: freqHourly}
+	w, err := newAsyncWriter("/dev/null", cfg, 5*time.Millisecond)
+	require.NoError(t, err)
+	assert.False(t, w.rotateOK, "/dev/null is not a regular file and must not be rotated")
+	assert.Nil(t, w.root, "no directory handle should be opened when rotation is disabled")
+
+	w.start(context.Background(), &fakeEgrp{})
+	_, err = w.Write([]byte("to the void\n"))
+	require.NoError(t, err)
+	w.close()
+}
+
+// TestAsyncWriterWriteErrorIsFatal verifies that a write failure is surfaced
+// through the errgroup (so the process can shut down).
+func TestAsyncWriterWriteErrorIsFatal(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	w, err := newAsyncWriter(path, noRotate(), 5*time.Millisecond)
+	require.NoError(t, err)
+
+	egrp := &fakeEgrp{}
+	w.start(context.Background(), egrp)
+
+	// Close the underlying descriptor so the next flush fails with EBADF.
+	w.fileMu.Lock()
+	_ = w.file.Close()
+	w.fileMu.Unlock()
+
+	// Trigger writes; the drain goroutine will flush (on its timer) and fail.
+	for i := 0; i < 5; i++ {
+		_, _ = w.Write([]byte("doomed\n"))
+	}
+
+	require.Eventually(t, func() bool {
+		return egrp.firstErr() != nil
+	}, 2*time.Second, 10*time.Millisecond, "a fatal write error should be surfaced via the errgroup")
+
+	// The writer should have flipped to synchronous mode after the failure.
+	w.mu.Lock()
+	synchronous := w.synchronous
+	w.mu.Unlock()
+	assert.True(t, synchronous, "writer should enter synchronous mode after a fatal error")
+}
+
+// TestAsyncWriterFlushOnceReturnsErrorOnClosedFile is a direct check of the
+// flush error path used by the drain loop.
+func TestAsyncWriterFlushOnceReturnsErrorOnClosedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	w, err := newAsyncWriter(path, noRotate(), time.Millisecond)
+	require.NoError(t, err)
+
+	_, _ = w.Write([]byte("data\n"))
+	w.fileMu.Lock()
+	_ = w.file.Close()
+	w.fileMu.Unlock()
+
+	assert.Error(t, w.flushOnce(), "flushOnce should report the underlying write error")
+}

--- a/logging/async_writer_test.go
+++ b/logging/async_writer_test.go
@@ -292,6 +292,18 @@ func TestAsyncWriterContinuousRotation(t *testing.T) {
 // newRotatingTestWriter builds a writer with rotation enabled and an injected
 // clock anchored at start, so calendar-boundary rotation can be driven
 // deterministically.
+// newAsyncWriterForTest builds a writer on the fake clock without requiring
+// that rotation be eligible, for the cases where rotation is deliberately
+// left to something outside the process.
+func newAsyncWriterForTest(t *testing.T, path string, cfg rotateConfig, clk *fakeClock) *asyncWriter {
+	t.Helper()
+	w, err := newAsyncWriter(path, cfg, time.Millisecond)
+	require.NoError(t, err)
+	w.now = clk.now
+	w.periodStart = cfg.frequency.truncate(clk.now())
+	return w
+}
+
 func newRotatingTestWriter(t *testing.T, path string, cfg rotateConfig, clk *fakeClock) *asyncWriter {
 	t.Helper()
 	w, err := newAsyncWriter(path, cfg, time.Millisecond)
@@ -860,6 +872,124 @@ func mkBackup(t *testing.T, dir, name string, size int, mod time.Time) string {
 // The collision counter is unpadded decimal, so the names are not lexically
 // ordered ("-9" sorts after "-12") and the retained set must be chosen by the
 // period/counter the name encodes.
+// TestAsyncWriterCollisionCounterResumes verifies repeated rotations inside
+// one period keep allocating distinct names without re-probing the ones
+// already taken. A small MaxSize produces many rotations per period, so a
+// scan that restarted at 1 each time would make every rotation dearer than
+// the one before it.
+// TestAsyncWriterReopensAfterExternalRotation covers the deployment
+// Logging.Rotation.Disable is meant for: an external logrotate renames the
+// log aside and creates a fresh one. Holding the old descriptor open would
+// send every subsequent line to an inode nobody can read and the rotator
+// will eventually delete.
+func TestAsyncWriterReopensAfterExternalRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 6, 8, 10, 0, 0, 0, time.Local)}
+	// Rotation disabled: this writer must not rotate, only notice.
+	w := newAsyncWriterForTest(t, path, rotateConfig{}, clk)
+
+	_, _ = w.Write([]byte("before\n"))
+	require.NoError(t, w.flushOnce())
+
+	// What logrotate does: rename the live file, leave the path free.
+	require.NoError(t, os.Rename(path, filepath.Join(dir, "test.log.1")))
+
+	// Move past the throttle so the next flush re-examines the path.
+	clk.advance(2 * replaceCheckInterval)
+	_, _ = w.Write([]byte("after\n"))
+	require.NoError(t, w.flushOnce())
+	w.close()
+
+	current, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(current), "after",
+		"lines written after an external rotation must land in the recreated file")
+	assert.NotContains(t, string(current), "before")
+
+	rotated, err := os.ReadFile(filepath.Join(dir, "test.log.1"))
+	require.NoError(t, err)
+	assert.Contains(t, string(rotated), "before",
+		"lines written before the rename stay with the renamed file")
+	assert.NotContains(t, string(rotated), "after",
+		"the renamed file must stop receiving writes")
+}
+
+// The check must not fire when nothing has happened: reopening on every
+// flush would reset the size counter that drives size-based rotation.
+func TestAsyncWriterDoesNotReopenAnUntouchedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 6, 8, 10, 0, 0, 0, time.Local)}
+	w := newAsyncWriterForTest(t, path, rotateConfig{}, clk)
+	defer w.close()
+
+	_, _ = w.Write([]byte("one\n"))
+	require.NoError(t, w.flushOnce())
+
+	w.fileMu.Lock()
+	before, err := w.file.Stat()
+	w.fileMu.Unlock()
+	require.NoError(t, err)
+
+	clk.advance(2 * replaceCheckInterval)
+	_, _ = w.Write([]byte("two\n"))
+	require.NoError(t, w.flushOnce())
+
+	w.fileMu.Lock()
+	after, serr := w.file.Stat()
+	written := w.written
+	w.fileMu.Unlock()
+	require.NoError(t, serr)
+	assert.True(t, os.SameFile(before, after), "an untouched log must keep its descriptor")
+	assert.Equal(t, int64(len("one\ntwo\n")), written,
+		"the byte counter must keep accumulating rather than restart")
+}
+
+func TestAsyncWriterCollisionCounterResumes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	now := time.Date(2026, 1, 1, 9, 0, 0, 0, time.Local)
+	clk := &fakeClock{t: now}
+	cfg := rotateConfig{enable: true, frequency: freqDaily}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+	defer w.close()
+
+	// Names already on disk from an earlier run must not be handed out again.
+	mkBackup(t, dir, "test.log.2026-01-01", 10, now)
+	mkBackup(t, dir, "test.log.2026-01-01-1", 10, now)
+	mkBackup(t, dir, "test.log.2026-01-01-2", 10, now)
+
+	base := "test.log.2026-01-01"
+	assert.Equal(t, "test.log.2026-01-01-3", w.uniqueRotatedBase(base),
+		"allocation must resume past the highest counter already present")
+	assert.Equal(t, "test.log.2026-01-01-4", w.uniqueRotatedBase(base))
+	assert.Equal(t, "test.log.2026-01-01-5", w.uniqueRotatedBase(base))
+
+	// A new period starts its own counter, and the unsuffixed name is free.
+	nextDay := "test.log.2026-01-02"
+	assert.Equal(t, nextDay, w.uniqueRotatedBase(nextDay))
+	assert.Equal(t, "test.log.2026-01-02-1", w.uniqueRotatedBase(nextDay))
+}
+
+// A name the writer did not create must still be stepped over: the counter
+// is a hint about where to resume, not a promise the name is free.
+func TestAsyncWriterCollisionCounterYieldsToForeignFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	now := time.Date(2026, 1, 1, 9, 0, 0, 0, time.Local)
+	clk := &fakeClock{t: now}
+	w := newRotatingTestWriter(t, path, rotateConfig{enable: true, frequency: freqDaily}, clk)
+	defer w.close()
+
+	base := "test.log.2026-01-01"
+	require.Equal(t, base, w.uniqueRotatedBase(base))
+
+	// Something else claims the name the counter was about to use.
+	mkBackup(t, dir, base+"-1", 10, now)
+	assert.Equal(t, base+"-2", w.uniqueRotatedBase(base))
+}
+
 func TestAsyncWriterRetentionKeepsNewestCollisions(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.log")

--- a/logging/async_writer_test.go
+++ b/logging/async_writer_test.go
@@ -21,8 +21,10 @@
 package logging
 
 import (
+	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -33,6 +35,7 @@ import (
 	"testing"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -229,8 +232,9 @@ func TestAsyncWriterCompressionWorkerGracefulShutdown(t *testing.T) {
 		}
 	}
 
-	// Graceful shutdown: enterSyncMode drains the worker; egrp.Wait then returns
-	// with no AwaitCompression-style call needed.
+	// Graceful shutdown: the worker runs in the errgroup, so enterSyncMode
+	// drains it and egrp.Wait joins it. No further wait is needed to know
+	// compression has finished.
 	w.enterSyncMode()
 	require.NoError(t, egrp.Wait())
 
@@ -729,6 +733,72 @@ func TestAsyncWriterNonRegularNoRotation(t *testing.T) {
 
 // TestAsyncWriterWriteErrorIsFatal verifies that a write failure is surfaced
 // through the errgroup (so the process can shut down).
+// TestAsyncWriterTolveratesRotationFailureWithinBudget pins the first half of
+// the rotation-failure policy: a process that cannot rotate keeps recording.
+// Losing the ability to start a new file is not a reason to stop serving data,
+// and the usual causes (a handle held open elsewhere, a briefly unwritable
+// directory) clear on their own.
+func TestAsyncWriterToleratesRotationFailureWithinBudget(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 6, 8, 10, 0, 0, 0, time.Local)}
+	cfg := rotateConfig{
+		enable:           true,
+		frequency:        freqNone,
+		maxSize:          64,
+		maxRetentionSize: 1 << 20,
+	}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+	defer w.close()
+
+	// Every rotation attempt fails from here on.
+	w.rename = func(string, string) error { return errors.New("rename refused") }
+
+	for i := 0; i < 20; i++ {
+		_, err := w.Write([]byte(strings.Repeat("x", 40) + "\n"))
+		require.NoError(t, err)
+		require.NoError(t, w.flushOnce(), "a failed rotation must not fail the write")
+	}
+
+	// The lines are still on disk: the file simply grew past MaxSize.
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, 20, bytes.Count(content, []byte("\n")),
+		"no log line may be lost because rotation is broken")
+	assert.Greater(t, int64(len(content)), cfg.maxSize,
+		"the file is expected to overshoot MaxSize while rotation is unavailable")
+}
+
+// TestAsyncWriterRotationFailureBecomesFatalPastBudget pins the second half:
+// tolerance ends at the disk the operator set aside. An unrotatable log has no
+// bound of its own, and filling the filesystem takes down more than logging.
+func TestAsyncWriterRotationFailureBecomesFatalPastBudget(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 6, 8, 10, 0, 0, 0, time.Local)}
+	cfg := rotateConfig{
+		enable:           true,
+		frequency:        freqNone,
+		maxSize:          64,
+		maxRetentionSize: 512,
+	}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+	defer w.close()
+
+	w.rename = func(string, string) error { return errors.New("rename refused") }
+
+	var flushErr error
+	for i := 0; i < 100 && flushErr == nil; i++ {
+		_, err := w.Write([]byte(strings.Repeat("y", 40) + "\n"))
+		require.NoError(t, err)
+		flushErr = w.flushOnce()
+	}
+
+	require.Error(t, flushErr,
+		"growth past MaxRetentionSize with rotation broken must be surfaced as fatal")
+	assert.Contains(t, flushErr.Error(), "cannot be rotated")
+}
+
 func TestAsyncWriterWriteErrorIsFatal(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.log")
@@ -773,4 +843,298 @@ func TestAsyncWriterFlushOnceReturnsErrorOnClosedFile(t *testing.T) {
 	w.fileMu.Unlock()
 
 	assert.Error(t, w.flushOnce(), "flushOnce should report the underlying write error")
+}
+
+// mkBackup writes a rotated-log stand-in of the given size with an explicit
+// mtime, so retention policy can be checked without driving real rotations.
+func mkBackup(t *testing.T, dir, name string, size int, mod time.Time) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(p, make([]byte, size), 0640))
+	require.NoError(t, os.Chtimes(p, mod, mod))
+	return p
+}
+
+// TestAsyncWriterRetentionKeepsNewestCollisions verifies the size budget retains
+// the most recent rotated files when more than nine rotations share a period.
+// The collision counter is unpadded decimal, so the names are not lexically
+// ordered ("-9" sorts after "-12") and the retained set must be chosen by the
+// period/counter the name encodes.
+func TestAsyncWriterRetentionKeepsNewestCollisions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	now := time.Date(2026, 1, 1, 23, 0, 0, 0, time.Local)
+	clk := &fakeClock{t: now}
+	// 10 bytes per backup, budget of 25 -> the two newest are retained.
+	cfg := rotateConfig{enable: true, frequency: freqDaily, maxRetentionSize: 25}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+	defer w.close()
+
+	mkBackup(t, dir, "test.log.2026-01-01", 10, now)
+	for i := 1; i <= 12; i++ {
+		mkBackup(t, dir, fmt.Sprintf("test.log.2026-01-01-%d", i), 10, now)
+	}
+
+	w.pruneRetention()
+
+	exists := func(name string) bool {
+		_, err := os.Stat(filepath.Join(dir, name))
+		return err == nil
+	}
+	assert.True(t, exists("test.log.2026-01-01-12"), "the newest rotated file must be retained")
+	assert.True(t, exists("test.log.2026-01-01-11"), "the second-newest rotated file must be retained")
+	assert.False(t, exists("test.log.2026-01-01-9"), "an older rotated file must not outlive newer ones")
+	assert.False(t, exists("test.log.2026-01-01"), "the oldest rotated file must be pruned first")
+}
+
+// TestAsyncWriterRetentionOrdersAcrossFormats verifies retention orders rotated
+// files by the period they encode even when the directory mixes the daily,
+// hourly and size-only suffix formats (a frequency change leaves both behind).
+func TestAsyncWriterRetentionOrdersAcrossFormats(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.Local)
+	clk := &fakeClock{t: now}
+	cfg := rotateConfig{enable: true, frequency: freqHourly, maxRetentionSize: 25}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+	defer w.close()
+
+	mkBackup(t, dir, "test.log.2026-06-08", 10, now)             // oldest (daily)
+	mkBackup(t, dir, "test.log.2026-06-09T23", 10, now)          // hourly
+	mkBackup(t, dir, "test.log.2026-06-10T11-30-00.gz", 10, now) // newest (size-only)
+
+	w.pruneRetention()
+
+	exists := func(name string) bool {
+		_, err := os.Stat(filepath.Join(dir, name))
+		return err == nil
+	}
+	assert.True(t, exists("test.log.2026-06-10T11-30-00.gz"), "newest rotated file must be retained")
+	assert.True(t, exists("test.log.2026-06-09T23"), "second-newest rotated file must be retained")
+	assert.False(t, exists("test.log.2026-06-08"), "oldest rotated file must be pruned first")
+}
+
+// TestAsyncWriterRetentionIgnoresForeignFiles verifies retention only deletes
+// files matching the rotated-name grammar. Anything else sharing the log's name
+// prefix -- an operator's incident copy, a note, an unrelated log -- belongs to
+// somebody else and must be left alone by both budgets.
+func TestAsyncWriterRetentionIgnoresForeignFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.Local)
+	clk := &fakeClock{t: now}
+	cfg := rotateConfig{enable: true, frequency: freqDaily, maxRetentionSize: 1, maxRetentionPeriod: time.Hour}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+	defer w.close()
+
+	foreign := []string{
+		"test.log.incident-4471",
+		"test.log.bak",
+		"test.log.2026-13-45", // prefix-shaped but not a real date
+		"test.log.old.gz",
+	}
+	for _, name := range foreign {
+		mkBackup(t, dir, name, 4096, now.Add(-72*time.Hour))
+	}
+	mkBackup(t, dir, "test.log.2026-06-07", 4096, now.Add(-72*time.Hour))
+
+	w.pruneRetention()
+
+	for _, name := range foreign {
+		_, err := os.Stat(filepath.Join(dir, name))
+		assert.NoErrorf(t, err, "retention must not delete %q: it is not a rotated log file", name)
+	}
+	_, err := os.Stat(filepath.Join(dir, "test.log.2026-06-07"))
+	assert.True(t, os.IsNotExist(err), "a genuine rotated file outside both budgets should be pruned")
+}
+
+// TestAsyncWriterPrunesAtStartup verifies retention is enforced when the writer
+// is constructed. Rotation is the only other trigger, so a process configured
+// with Frequency "none" (or one that restarts often) would otherwise never
+// enforce the budgets.
+func TestAsyncWriterPrunesAtStartup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	now := time.Now()
+
+	mkBackup(t, dir, "test.log.2026-06-07", 10, now.Add(-72*time.Hour))
+	mkBackup(t, dir, "test.log.2026-06-09", 10, now.Add(-time.Hour))
+
+	cfg := rotateConfig{enable: true, frequency: freqNone, maxRetentionPeriod: 48 * time.Hour}
+	w, err := newAsyncWriter(path, cfg, time.Millisecond)
+	require.NoError(t, err)
+	defer w.close()
+
+	_, err = os.Stat(filepath.Join(dir, "test.log.2026-06-07"))
+	assert.True(t, os.IsNotExist(err), "a rotated file past the age budget should be pruned at startup")
+	_, err = os.Stat(filepath.Join(dir, "test.log.2026-06-09"))
+	assert.NoError(t, err, "a rotated file within the age budget must survive startup pruning")
+}
+
+// TestAsyncWriterRotationPreservesFileMode verifies rotation does not widen the
+// permission bits of the log: an operator who tightens the active file must find
+// the same mode on its successor, and on the compressed rotated copy.
+func TestAsyncWriterRotationPreservesFileMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 6, 8, 10, 0, 0, 0, time.Local)}
+	cfg := rotateConfig{enable: true, frequency: freqDaily, compress: true}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	require.NoError(t, os.Chmod(path, 0600))
+
+	_, _ = w.Write([]byte("day8\n"))
+	require.NoError(t, w.flushOnce())
+	clk.advance(24 * time.Hour)
+	_, _ = w.Write([]byte("day9\n"))
+	require.NoError(t, w.flushOnce())
+	w.close()
+
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), fi.Mode().Perm(),
+		"the log file opened after rotation must keep the mode of the one it replaces")
+
+	gz, err := os.Stat(filepath.Join(dir, "test.log.2026-06-08.gz"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), gz.Mode().Perm(),
+		"a compressed rotated file must keep the mode of its source")
+}
+
+// reentrantLogHook routes every logrus entry back into the writer under test.
+// In production the writer *is* logrus's output, so anything the writer logs
+// re-enters it; logrus fires hooks without holding its own mutex, so a hook that
+// blocks reproduces that reentrancy without wedging the standard logger for the
+// rest of the suite.
+type reentrantLogHook struct{ w *asyncWriter }
+
+func (h *reentrantLogHook) Levels() []log.Level { return log.AllLevels }
+
+func (h *reentrantLogHook) Fire(*log.Entry) error {
+	_, _ = h.w.Write([]byte("reentrant\n"))
+	return nil
+}
+
+// removeHook drops a specific hook from the standard logger, leaving any others
+// (notably the test hook) in place.
+func removeHook(target log.Hook) {
+	old := log.StandardLogger().ReplaceHooks(log.LevelHooks{})
+	filtered := make(log.LevelHooks)
+	for lvl, hooks := range old {
+		for _, h := range hooks {
+			if h == target {
+				continue
+			}
+			filtered[lvl] = append(filtered[lvl], h)
+		}
+	}
+	log.StandardLogger().ReplaceHooks(filtered)
+}
+
+// TestAsyncWriterCompressionFailureDuringShutdownDoesNotDeadlock verifies that a
+// compression failure on the synchronous-mode path (the ENOSPC-at-shutdown case)
+// is reported without re-entering the writer. Post-rotation work runs under
+// fileMu, so anything it emits through logrus would come straight back to
+// writeDirect and self-deadlock the rotating goroutine.
+func TestAsyncWriterCompressionFailureDuringShutdownDoesNotDeadlock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	clk := &fakeClock{t: time.Date(2026, 6, 9, 12, 0, 0, 0, time.Local)}
+	cfg := rotateConfig{enable: true, frequency: freqNone, maxSize: 10, compress: true}
+	w := newRotatingTestWriter(t, path, cfg, clk)
+
+	egrp, ctx := errgroup.WithContext(context.Background())
+	w.start(ctx, egrp)
+	// Drain and flip to synchronous mode, so the next rotation compresses inline
+	// on the writing goroutine while it holds fileMu.
+	w.enterSyncMode()
+	require.NoError(t, egrp.Wait())
+
+	// One oversized line fills the active file without rotating it.
+	_, err := w.Write([]byte("aaaaaaaaaa\n"))
+	require.NoError(t, err)
+
+	// A directory where the compression temp file belongs makes the next
+	// rotation's compression fail.
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "test.log.2026-06-09T12-00-00"+compressTempSuffix), 0750))
+
+	hook := &reentrantLogHook{w: w}
+	log.AddHook(hook)
+	defer removeHook(hook)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = w.Write([]byte("bbbbbbbbbb\n"))
+	}()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("a rotation whose compression fails must not block: post-rotation work must never re-enter the writer")
+	}
+
+	// The failure left the uncompressed rotated file in place rather than losing it.
+	_, err = os.Stat(filepath.Join(dir, "test.log.2026-06-09T12-00-00"))
+	assert.NoError(t, err, "a failed compression must leave the rotated source behind")
+
+	_, err = w.Write([]byte("cccccccccc\n"))
+	assert.NoError(t, err, "the writer must keep serving after a compression failure")
+	w.close()
+}
+
+// TestAsyncWriterConcurrentWriters drives the writer from many goroutines at once
+// while rotation is active, so the race detector actually exercises fileMu and
+// the backpressure condition variable. Every line must survive somewhere in the
+// rotated set, intact and unsplit.
+func TestAsyncWriterConcurrentWriters(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+	cfg := rotateConfig{enable: true, frequency: freqNone, maxSize: 4096, compress: false}
+	w, err := newAsyncWriter(path, cfg, time.Millisecond)
+	require.NoError(t, err)
+
+	egrp, ctx := errgroup.WithContext(context.Background())
+	w.start(ctx, egrp)
+	w.maxBufBytes = 8 * 1024 // small enough that writers actually hit backpressure
+
+	const writers, perWriter = 16, 200
+	var wg sync.WaitGroup
+	for g := 0; g < writers; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				_, werr := w.Write([]byte(fmt.Sprintf("writer-%02d-line-%04d-padding\n", g, i)))
+				assert.NoError(t, werr)
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	w.enterSyncMode()
+	require.NoError(t, egrp.Wait())
+	w.close()
+
+	// Reassemble every log file in the directory and confirm nothing was lost or
+	// interleaved mid-line.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	seen := make(map[string]bool, writers*perWriter)
+	for _, e := range entries {
+		content, rerr := os.ReadFile(filepath.Join(dir, e.Name()))
+		require.NoError(t, rerr)
+		for _, line := range strings.Split(strings.TrimSuffix(string(content), "\n"), "\n") {
+			if line == "" {
+				continue
+			}
+			assert.Falsef(t, seen[line], "line written once appeared twice: %q", line)
+			seen[line] = true
+		}
+	}
+	for g := 0; g < writers; g++ {
+		for i := 0; i < perWriter; i++ {
+			line := fmt.Sprintf("writer-%02d-line-%04d-padding", g, i)
+			assert.Truef(t, seen[line], "line lost by concurrent writers: %q", line)
+		}
+	}
 }

--- a/logging/level_manager_test.go
+++ b/logging/level_manager_test.go
@@ -40,8 +40,8 @@ func TestLogLevelManager_AddChange(t *testing.T) {
 	config.RegisterLoggingCallback()
 
 	// Save original level
-	origLevel := log.GetLevel()
-	defer log.SetLevel(origLevel)
+	origLevel := config.GetEffectiveLogLevel()
+	defer config.SetLogging(origLevel)
 
 	manager := logging.GetLogLevelManager()
 	defer func() {
@@ -51,7 +51,7 @@ func TestLogLevelManager_AddChange(t *testing.T) {
 	}()
 
 	// Set base level to Info
-	log.SetLevel(log.InfoLevel)
+	config.SetLogging(log.InfoLevel)
 	manager.SetBaseLevel(log.InfoLevel)
 	require.Eventually(t,
 		func() bool { return log.InfoLevel == config.GetEffectiveLogLevel() },
@@ -84,8 +84,8 @@ func TestLogLevelManager_RemoveChange(t *testing.T) {
 	config.RegisterLoggingCallback()
 
 	// Save original level
-	origLevel := log.GetLevel()
-	defer log.SetLevel(origLevel)
+	origLevel := config.GetEffectiveLogLevel()
+	defer config.SetLogging(origLevel)
 
 	manager := logging.GetLogLevelManager()
 	defer func() {
@@ -95,7 +95,7 @@ func TestLogLevelManager_RemoveChange(t *testing.T) {
 	}()
 
 	// Set base level to Info
-	log.SetLevel(log.InfoLevel)
+	config.SetLogging(log.InfoLevel)
 	manager.SetBaseLevel(log.InfoLevel)
 	require.Eventually(t,
 		func() bool { return log.InfoLevel == config.GetEffectiveLogLevel() },
@@ -137,8 +137,8 @@ func TestLogLevelManager_MultipleChanges(t *testing.T) {
 	config.RegisterLoggingCallback()
 
 	// Save original level
-	origLevel := log.GetLevel()
-	defer log.SetLevel(origLevel)
+	origLevel := config.GetEffectiveLogLevel()
+	defer config.SetLogging(origLevel)
 
 	manager := logging.GetLogLevelManager()
 	defer func() {
@@ -148,7 +148,7 @@ func TestLogLevelManager_MultipleChanges(t *testing.T) {
 	}()
 
 	// Set base level to Info
-	log.SetLevel(log.InfoLevel)
+	config.SetLogging(log.InfoLevel)
 	manager.SetBaseLevel(log.InfoLevel)
 	require.Eventually(t,
 		func() bool { return log.InfoLevel == config.GetEffectiveLogLevel() },
@@ -218,8 +218,8 @@ func TestLogLevelManager_ExpiredChanges(t *testing.T) {
 	config.RegisterLoggingCallback()
 
 	// Save original level
-	origLevel := log.GetLevel()
-	defer log.SetLevel(origLevel)
+	origLevel := config.GetEffectiveLogLevel()
+	defer config.SetLogging(origLevel)
 
 	manager := logging.GetLogLevelManager()
 	defer func() {
@@ -229,7 +229,7 @@ func TestLogLevelManager_ExpiredChanges(t *testing.T) {
 	}()
 
 	// Set base level to Info
-	log.SetLevel(log.InfoLevel)
+	config.SetLogging(log.InfoLevel)
 	manager.SetBaseLevel(log.InfoLevel)
 	require.Eventually(t,
 		func() bool { return log.InfoLevel == config.GetEffectiveLogLevel() },
@@ -241,7 +241,7 @@ func TestLogLevelManager_ExpiredChanges(t *testing.T) {
 	require.NoError(t, manager.AddChange("test-1", "Logging.Level", log.DebugLevel, 100*time.Millisecond))
 
 	require.Eventually(t,
-		func() bool { return log.DebugLevel == log.GetLevel() },
+		func() bool { return log.DebugLevel == config.GetEffectiveLogLevel() },
 		1*time.Second,
 		10*time.Millisecond,
 	)
@@ -269,8 +269,8 @@ func TestLogLevelManager_SetBaseLevel(t *testing.T) {
 	config.RegisterLoggingCallback()
 
 	// Save original level
-	origLevel := log.GetLevel()
-	defer log.SetLevel(origLevel)
+	origLevel := config.GetEffectiveLogLevel()
+	defer config.SetLogging(origLevel)
 
 	manager := logging.GetLogLevelManager()
 	defer func() {
@@ -291,7 +291,7 @@ func TestLogLevelManager_SetBaseLevel(t *testing.T) {
 	require.NoError(t, manager.AddChange("test-1", "Logging.Level", log.DebugLevel, 1*time.Hour))
 
 	require.Eventually(t,
-		func() bool { return log.DebugLevel == log.GetLevel() },
+		func() bool { return log.DebugLevel == config.GetEffectiveLogLevel() },
 		1*time.Second,
 		10*time.Millisecond,
 	)
@@ -323,8 +323,8 @@ func TestLogLevelManager_BackgroundExpiry(t *testing.T) {
 	require.NoError(t, param.Reset())
 	config.RegisterLoggingCallback()
 
-	origLevel := log.GetLevel()
-	defer log.SetLevel(origLevel)
+	origLevel := config.GetEffectiveLogLevel()
+	defer config.SetLogging(origLevel)
 
 	manager := logging.GetLogLevelManager()
 	defer func() {

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,11 +57,11 @@ var (
 	loggingEgrp *errgroup.Group
 )
 
-// SetErrgroup registers the process-wide errgroup (and its context) used to
-// manage the asynchronous log-writer goroutine. When set, the writer goroutine
-// runs under the errgroup so a fatal write error cancels the shutdown context;
-// the context's cancellation also stops the writer. Call this once, early
-// (e.g. from cmd.Execute), before file logging is initialized.
+// SetErrgroup registers the process-wide errgroup (and its context) used to run
+// the asynchronous log-writer goroutine: the goroutine runs under the errgroup
+// so a fatal write error propagates, and stops when the context is cancelled at
+// shutdown. Call this once, early (e.g. from cmd.Execute), before file logging
+// is initialized.
 func SetErrgroup(ctx context.Context, egrp *errgroup.Group) {
 	asyncMu.Lock()
 	defer asyncMu.Unlock()
@@ -70,7 +71,7 @@ func SetErrgroup(ctx context.Context, egrp *errgroup.Group) {
 
 // buildRotateConfig reads the Logging.Rotation.* parameters into the parsed form
 // used by the async writer. It returns an error on a malformed value (e.g. an
-// unparseable size) so the caller can fail loudly at startup rather than
+// unparsable size) so the caller can fail loudly at startup rather than
 // silently disabling a misconfigured knob.
 func buildRotateConfig() (rotateConfig, error) {
 	// The admin-facing knobs are phrased as "Disable..." so their zero value is
@@ -101,9 +102,24 @@ func buildRotateConfig() (rotateConfig, error) {
 		if err != nil {
 			return cfg, fmt.Errorf("invalid %s value %q: %w", k.name, k.val, err)
 		}
+		if size > math.MaxInt64 {
+			return cfg, fmt.Errorf("%s value %q is too large", k.name, k.val)
+		}
 		*k.dst = int64(size)
 	}
 	return cfg, nil
+}
+
+// AwaitCompression blocks until any in-flight background log compression has
+// finished.  This ensures a graceful exit does not abandon a compression
+// mid-write, which would leave a stale ".gz.tmp" file.
+func AwaitCompression() {
+	asyncMu.Lock()
+	w := asyncW
+	asyncMu.Unlock()
+	if w != nil {
+		w.compressWg.Wait()
+	}
 }
 
 // EnterSyncMode is the logging shutdown handler. It drains and flushes the

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -19,8 +19,10 @@
 package logging
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,8 +32,10 @@ import (
 	"github.com/go-kit/log/term"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/utils"
 )
 
 // BufferedLogHook buffers log entries until they are flushed
@@ -45,11 +49,94 @@ var (
 	bufferedHook atomic.Pointer[BufferedLogHook]
 	flushOnce    sync.Once
 	logFHandle   *os.File
+
+	// asyncMu guards asyncW, loggingCtx, and loggingEgrp.
+	asyncMu     sync.Mutex
+	asyncW      *asyncWriter
+	loggingCtx  context.Context = context.Background()
+	loggingEgrp *errgroup.Group
 )
+
+// SetErrgroup registers the process-wide errgroup (and its context) used to run
+// the asynchronous log-writer goroutine: the goroutine runs under the errgroup
+// so a fatal write error propagates, and stops when the context is cancelled at
+// shutdown. Call this once, early (e.g. from cmd.Execute), before file logging
+// is initialized.
+func SetErrgroup(ctx context.Context, egrp *errgroup.Group) {
+	asyncMu.Lock()
+	defer asyncMu.Unlock()
+	loggingCtx = ctx
+	loggingEgrp = egrp
+}
+
+// buildRotateConfig reads the Logging.Rotation.* parameters into the parsed form
+// used by the async writer. It returns an error on a malformed value (e.g. an
+// unparsable size) so the caller can fail loudly at startup rather than
+// silently disabling a misconfigured knob.
+func buildRotateConfig() (rotateConfig, error) {
+	// The admin-facing knobs are phrased as "Disable..." so their zero value is
+	// the desired default (rotation on, compression on); invert them here so the
+	// writer's internal logic stays positive.
+	cfg := rotateConfig{
+		enable:             !param.Logging_Rotation_Disable.GetBool(),
+		frequency:          parseRotationFrequency(param.Logging_Rotation_Frequency.GetString()),
+		maxRetentionPeriod: param.Logging_Rotation_MaxRetentionPeriod.GetDuration(),
+		compress:           !param.Logging_Rotation_DisableCompress.GetBool(),
+	}
+	// Parse the byte-size knobs, failing loudly on a malformed value rather than
+	// silently disabling it: a typo'd value must not be ignored until a disk
+	// fills at 3am.
+	sizeKnobs := []struct {
+		name string
+		val  string
+		dst  *int64
+	}{
+		{param.Logging_Rotation_MaxSize.GetName(), param.Logging_Rotation_MaxSize.GetString(), &cfg.maxSize},
+		{param.Logging_Rotation_MaxRetentionSize.GetName(), param.Logging_Rotation_MaxRetentionSize.GetString(), &cfg.maxRetentionSize},
+	}
+	for _, k := range sizeKnobs {
+		if k.val == "" {
+			continue
+		}
+		size, err := utils.ParseBytes(k.val)
+		if err != nil {
+			return cfg, fmt.Errorf("invalid %s value %q: %w", k.name, k.val, err)
+		}
+		if size > math.MaxInt64 {
+			return cfg, fmt.Errorf("%s value %q is too large", k.name, k.val)
+		}
+		*k.dst = int64(size)
+	}
+	return cfg, nil
+}
+
+// EnterSyncMode is the logging shutdown handler. It drains and flushes the
+// asynchronous log writer, then flips it to synchronous mode so that any
+// late-arriving log line (e.g. emitted during signal handling or a panic) is
+// written directly to the log file by its calling goroutine. Safe to call
+// multiple times; a no-op when file logging is not active.
+func EnterSyncMode() {
+	asyncMu.Lock()
+	w := asyncW
+	asyncMu.Unlock()
+	if w != nil {
+		w.enterSyncMode()
+	}
+}
 
 // Reset function intended for unit tests to be able to
 // reset log flush state.
 func ResetLogFlush() {
+	asyncMu.Lock()
+	if asyncW != nil {
+		asyncW.close()
+		asyncW = nil
+	}
+	// Also drop any registered errgroup/context so a later FlushLogs in a
+	// different test does not reuse a stale (already-finished) errgroup.
+	loggingCtx = context.Background()
+	loggingEgrp = nil
+	asyncMu.Unlock()
 	if logFHandle != nil {
 		_ = logFHandle.Close()
 		logFHandle = nil
@@ -126,20 +213,30 @@ func FlushLogs(pushToFile bool) {
 
 		logLocation := param.Logging_LogLocation.GetString()
 		if pushToFile && logLocation != "" {
-			dir := filepath.Dir(logLocation)
-			if dir != "" {
-				if err := os.MkdirAll(dir, 0750); err != nil {
-					cobra.CheckErr(fmt.Errorf("failed to access/create specified directory: %w", err))
-				}
+			// The asynchronous writer opens (creating/appending) the log file,
+			// decouples logging call sites from disk I/O, and -- for regular
+			// files -- manages rotation/compression/retention.
+			rotCfg, err := buildRotateConfig()
+			if err != nil {
+				cobra.CheckErr(err)
+			}
+			w, err := newAsyncWriter(logLocation, rotCfg, param.Logging_Rotation_FlushInterval.GetDuration())
+			if err != nil {
+				cobra.CheckErr(err)
 			}
 
-			f, err := os.OpenFile(logLocation, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
-			if err != nil {
-				cobra.CheckErr(fmt.Errorf("failed to access specified log file: %w", err))
+			asyncMu.Lock()
+			asyncW = w
+			ctx, egrp := loggingCtx, loggingEgrp
+			asyncMu.Unlock()
+			if egrp != nil {
+				w.start(ctx, egrp)
+			} else {
+				w.start(ctx, nil)
 			}
-			logFHandle = f
+
 			fmt.Fprintf(os.Stderr, "%s is set to %s. All logs are redirected to the log file.\n", param.Logging_LogLocation.GetName(), logLocation)
-			log.SetOutput(f)
+			log.SetOutput(w)
 
 			// Disable colors for log files
 			log.SetFormatter(&log.TextFormatter{
@@ -187,6 +284,20 @@ func FlushLogs(pushToFile bool) {
 // should clean up the file handle when the process exits. Invoking this outside
 // a test will prevent the log file from being written to!!
 func CloseLogger() {
+	asyncMu.Lock()
+	w := asyncW
+	asyncW = nil
+	asyncMu.Unlock()
+	if w != nil {
+		// Stop the writer goroutine, flush, and close the file handle.
+		w.close()
+		// Reset log output to prevent writing to the closed writer.
+		if isTestProcess() {
+			log.SetOutput(io.Discard)
+		} else {
+			log.SetOutput(os.Stderr)
+		}
+	}
 	if logFHandle != nil {
 		_ = logFHandle.Close()
 		logFHandle = nil

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -19,6 +19,7 @@
 package logging
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -30,8 +31,10 @@ import (
 	"github.com/go-kit/log/term"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/utils"
 )
 
 // BufferedLogHook buffers log entries until they are flushed
@@ -45,11 +48,91 @@ var (
 	bufferedHook atomic.Pointer[BufferedLogHook]
 	flushOnce    sync.Once
 	logFHandle   *os.File
+
+	// asyncMu guards asyncW, loggingCtx, and loggingEgrp.
+	asyncMu     sync.Mutex
+	asyncW      *asyncWriter
+	loggingCtx  context.Context = context.Background()
+	loggingEgrp *errgroup.Group
 )
+
+// SetErrgroup registers the process-wide errgroup (and its context) used to
+// manage the asynchronous log-writer goroutine. When set, the writer goroutine
+// runs under the errgroup so a fatal write error cancels the shutdown context;
+// the context's cancellation also stops the writer. Call this once, early
+// (e.g. from cmd.Execute), before file logging is initialized.
+func SetErrgroup(ctx context.Context, egrp *errgroup.Group) {
+	asyncMu.Lock()
+	defer asyncMu.Unlock()
+	loggingCtx = ctx
+	loggingEgrp = egrp
+}
+
+// buildRotateConfig reads the Logging.Rotation.* parameters into the parsed form
+// used by the async writer. It returns an error on a malformed value (e.g. an
+// unparseable size) so the caller can fail loudly at startup rather than
+// silently disabling a misconfigured knob.
+func buildRotateConfig() (rotateConfig, error) {
+	// The admin-facing knobs are phrased as "Disable..." so their zero value is
+	// the desired default (rotation on, compression on); invert them here so the
+	// writer's internal logic stays positive.
+	cfg := rotateConfig{
+		enable:             !param.Logging_Rotation_Disable.GetBool(),
+		frequency:          parseRotationFrequency(param.Logging_Rotation_Frequency.GetString()),
+		maxRetentionPeriod: param.Logging_Rotation_MaxRetentionPeriod.GetDuration(),
+		compress:           !param.Logging_Rotation_DisableCompress.GetBool(),
+	}
+	// Parse the byte-size knobs, failing loudly on a malformed value rather than
+	// silently disabling it: a typo'd value must not be ignored until a disk
+	// fills at 3am.
+	sizeKnobs := []struct {
+		name string
+		val  string
+		dst  *int64
+	}{
+		{param.Logging_Rotation_MaxSize.GetName(), param.Logging_Rotation_MaxSize.GetString(), &cfg.maxSize},
+		{param.Logging_Rotation_MaxRetentionSize.GetName(), param.Logging_Rotation_MaxRetentionSize.GetString(), &cfg.maxRetentionSize},
+	}
+	for _, k := range sizeKnobs {
+		if k.val == "" {
+			continue
+		}
+		size, err := utils.ParseBytes(k.val)
+		if err != nil {
+			return cfg, fmt.Errorf("invalid %s value %q: %w", k.name, k.val, err)
+		}
+		*k.dst = int64(size)
+	}
+	return cfg, nil
+}
+
+// EnterSyncMode is the logging shutdown handler. It drains and flushes the
+// asynchronous log writer, then flips it to synchronous mode so that any
+// late-arriving log line (e.g. emitted during signal handling or a panic) is
+// written directly to the log file by its calling goroutine. Safe to call
+// multiple times; a no-op when file logging is not active.
+func EnterSyncMode() {
+	asyncMu.Lock()
+	w := asyncW
+	asyncMu.Unlock()
+	if w != nil {
+		w.enterSyncMode()
+	}
+}
 
 // Reset function intended for unit tests to be able to
 // reset log flush state.
 func ResetLogFlush() {
+	asyncMu.Lock()
+	if asyncW != nil {
+		asyncW.close()
+		asyncW = nil
+	}
+	// Also drop any registered errgroup/context so a later FlushLogs in a
+	// different test does not reuse a stale (already-finished) errgroup.
+	loggingCtx = context.Background()
+	loggingEgrp = nil
+	asyncMu.Unlock()
 	if logFHandle != nil {
 		_ = logFHandle.Close()
 		logFHandle = nil
@@ -126,20 +209,30 @@ func FlushLogs(pushToFile bool) {
 
 		logLocation := param.Logging_LogLocation.GetString()
 		if pushToFile && logLocation != "" {
-			dir := filepath.Dir(logLocation)
-			if dir != "" {
-				if err := os.MkdirAll(dir, 0750); err != nil {
-					cobra.CheckErr(fmt.Errorf("failed to access/create specified directory: %w", err))
-				}
+			// The asynchronous writer opens (creating/appending) the log file,
+			// decouples logging call sites from disk I/O, and -- for regular
+			// files -- manages rotation/compression/retention.
+			rotCfg, err := buildRotateConfig()
+			if err != nil {
+				cobra.CheckErr(err)
+			}
+			w, err := newAsyncWriter(logLocation, rotCfg, param.Logging_Rotation_FlushInterval.GetDuration())
+			if err != nil {
+				cobra.CheckErr(err)
 			}
 
-			f, err := os.OpenFile(logLocation, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
-			if err != nil {
-				cobra.CheckErr(fmt.Errorf("failed to access specified log file: %w", err))
+			asyncMu.Lock()
+			asyncW = w
+			ctx, egrp := loggingCtx, loggingEgrp
+			asyncMu.Unlock()
+			if egrp != nil {
+				w.start(ctx, egrp)
+			} else {
+				w.start(ctx, nil)
 			}
-			logFHandle = f
+
 			fmt.Fprintf(os.Stderr, "%s is set to %s. All logs are redirected to the log file.\n", param.Logging_LogLocation.GetName(), logLocation)
-			log.SetOutput(f)
+			log.SetOutput(w)
 
 			// Disable colors for log files
 			log.SetFormatter(&log.TextFormatter{
@@ -187,6 +280,20 @@ func FlushLogs(pushToFile bool) {
 // should clean up the file handle when the process exits. Invoking this outside
 // a test will prevent the log file from being written to!!
 func CloseLogger() {
+	asyncMu.Lock()
+	w := asyncW
+	asyncW = nil
+	asyncMu.Unlock()
+	if w != nil {
+		// Stop the writer goroutine, flush, and close the file handle.
+		w.close()
+		// Reset log output to prevent writing to the closed writer.
+		if isTestProcess() {
+			log.SetOutput(io.Discard)
+		} else {
+			log.SetOutput(os.Stderr)
+		}
+	}
 	if logFHandle != nil {
 		_ = logFHandle.Close()
 		logFHandle = nil

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -110,18 +110,6 @@ func buildRotateConfig() (rotateConfig, error) {
 	return cfg, nil
 }
 
-// AwaitCompression blocks until any in-flight background log compression has
-// finished.  This ensures a graceful exit does not abandon a compression
-// mid-write, which would leave a stale ".gz.tmp" file.
-func AwaitCompression() {
-	asyncMu.Lock()
-	w := asyncW
-	asyncMu.Unlock()
-	if w != nil {
-		w.compressWg.Wait()
-	}
-}
-
 // EnterSyncMode is the logging shutdown handler. It drains and flushes the
 // asynchronous log writer, then flips it to synchronous mode so that any
 // late-arriving log line (e.g. emitted during signal handling or a panic) is

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -77,9 +77,13 @@ func buildRotateConfig() (rotateConfig, error) {
 	// The admin-facing knobs are phrased as "Disable..." so their zero value is
 	// the desired default (rotation on, compression on); invert them here so the
 	// writer's internal logic stays positive.
+	frequency, err := parseRotationFrequency(param.Logging_Rotation_Frequency.GetString())
+	if err != nil {
+		return rotateConfig{}, fmt.Errorf("invalid %s: %w", param.Logging_Rotation_Frequency.GetName(), err)
+	}
 	cfg := rotateConfig{
 		enable:             !param.Logging_Rotation_Disable.GetBool(),
-		frequency:          parseRotationFrequency(param.Logging_Rotation_Frequency.GetString()),
+		frequency:          frequency,
 		maxRetentionPeriod: param.Logging_Rotation_MaxRetentionPeriod.GetDuration(),
 		compress:           !param.Logging_Rotation_DisableCompress.GetBool(),
 	}
@@ -97,6 +101,14 @@ func buildRotateConfig() (rotateConfig, error) {
 	for _, k := range sizeKnobs {
 		if k.val == "" {
 			continue
+		}
+		// A leading "-" is rejected here rather than by the parser: a negative
+		// quantity converts to an enormous unsigned value, which then either
+		// wraps to zero -- silently disabling the very limit the administrator
+		// was configuring -- or trips the overflow check below and reports a
+		// misleading "too large" for a value that is too small.
+		if strings.HasPrefix(strings.TrimSpace(k.val), "-") {
+			return cfg, fmt.Errorf("invalid %s value %q: size must not be negative", k.name, k.val)
 		}
 		size, err := utils.ParseBytes(k.val)
 		if err != nil {

--- a/logging/logging_file_test.go
+++ b/logging/logging_file_test.go
@@ -1,0 +1,110 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package logging
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/param"
+)
+
+// TestFlushLogsToFileAndSyncMode exercises the real wiring: FlushLogs(true)
+// installs the async writer as the logrus output, log lines reach the file once
+// drained, and EnterSyncMode flushes + flips to synchronous mode so that a
+// line emitted afterward is written directly and still lands in the file.
+func TestFlushLogsToFileAndSyncMode(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "pelican.log")
+
+	// Snapshot/restore the global logging state touched by this test.
+	t.Cleanup(func() {
+		CloseLogger()
+		ResetLogFlush()
+	})
+
+	require.NoError(t, param.Logging_LogLocation.Set(logPath))
+	require.NoError(t, param.Logging_Rotation_Frequency.Set("daily"))
+	require.NoError(t, param.Logging_Rotation_DisableCompress.Set(true))
+	require.NoError(t, param.Logging_Rotation_FlushInterval.Set(5*time.Millisecond))
+
+	ResetLogFlush()
+	SetupLogBuffering()
+
+	egrp, egrpCtx := errgroup.WithContext(context.Background())
+	SetErrgroup(egrpCtx, egrp)
+
+	log.SetLevel(log.InfoLevel)
+	log.Info("before-flush buffered line")
+
+	FlushLogs(true)
+
+	log.Info("after-flush async line")
+
+	// Shutdown handler: drain + flip to synchronous mode.
+	EnterSyncMode()
+
+	// A line emitted after EnterSyncMode is written directly by this goroutine.
+	log.Info("post-shutdown direct line")
+
+	// The errgroup-managed writer goroutine should have exited cleanly.
+	require.NoError(t, egrp.Wait())
+
+	content, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	got := string(content)
+	assert.Contains(t, got, "before-flush buffered line", "buffered pre-flush lines should reach the file")
+	assert.Contains(t, got, "after-flush async line", "async lines should reach the file")
+	assert.Contains(t, got, "post-shutdown direct line", "post-shutdown lines should be written directly to the file")
+}
+
+// TestBuildRotateConfigRejectsBadSize verifies a malformed MaxSize is reported
+// as an error (so the caller can fail loudly at startup) rather than being
+// silently ignored.
+func TestBuildRotateConfigRejectsBadSize(t *testing.T) {
+	t.Cleanup(func() { _ = param.Reset() })
+
+	require.NoError(t, param.Logging_Rotation_MaxSize.Set("100 bananas"))
+	_, err := buildRotateConfig()
+	require.Error(t, err, "an unparsable MaxSize must surface an error, not be silently dropped")
+	assert.Contains(t, err.Error(), param.Logging_Rotation_MaxSize.GetName())
+
+	// A value that exceeds int64 (but still fits uint64) must error, not wrap to
+	// a negative size. 1e10 GB ~= 1.07e19 bytes, above MaxInt64 (~9.2e18).
+	require.NoError(t, param.Logging_Rotation_MaxSize.Set("10000000000GB"))
+	_, err = buildRotateConfig()
+	require.Error(t, err, "an out-of-range MaxSize must surface an error")
+	assert.Contains(t, err.Error(), "too large")
+
+	// A valid size parses cleanly.
+	require.NoError(t, param.Logging_Rotation_MaxSize.Set("250MB"))
+	cfg, err := buildRotateConfig()
+	require.NoError(t, err)
+	assert.Equal(t, int64(250*1024*1024), cfg.maxSize)
+}

--- a/logging/logging_file_test.go
+++ b/logging/logging_file_test.go
@@ -1,0 +1,103 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package logging
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/param"
+)
+
+// TestFlushLogsToFileAndSyncMode exercises the real wiring: FlushLogs(true)
+// installs the async writer as the logrus output, log lines reach the file once
+// drained, and EnterSyncMode flushes + flips to synchronous mode so that a
+// line emitted afterward is written directly and still lands in the file.
+func TestFlushLogsToFileAndSyncMode(t *testing.T) {
+	// Snapshot/restore the global logging state touched by this test.
+	t.Cleanup(func() {
+		CloseLogger()
+		ResetLogFlush()
+	})
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "pelican.log")
+
+	require.NoError(t, param.Logging_LogLocation.Set(logPath))
+	require.NoError(t, param.Logging_Rotation_Frequency.Set("daily"))
+	require.NoError(t, param.Logging_Rotation_DisableCompress.Set(true))
+	require.NoError(t, param.Logging_Rotation_FlushInterval.Set(5*time.Millisecond))
+
+	ResetLogFlush()
+	SetupLogBuffering()
+
+	egrp, egrpCtx := errgroup.WithContext(context.Background())
+	SetErrgroup(egrpCtx, egrp)
+
+	log.SetLevel(log.InfoLevel)
+	log.Info("before-flush buffered line")
+
+	FlushLogs(true)
+
+	log.Info("after-flush async line")
+
+	// Shutdown handler: drain + flip to synchronous mode.
+	EnterSyncMode()
+
+	// A line emitted after EnterSyncMode is written directly by this goroutine.
+	log.Info("post-shutdown direct line")
+
+	// The errgroup-managed writer goroutine should have exited cleanly.
+	require.NoError(t, egrp.Wait())
+
+	content, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	got := string(content)
+	assert.Contains(t, got, "before-flush buffered line", "buffered pre-flush lines should reach the file")
+	assert.Contains(t, got, "after-flush async line", "async lines should reach the file")
+	assert.Contains(t, got, "post-shutdown direct line", "post-shutdown lines should be written directly to the file")
+}
+
+// TestBuildRotateConfigRejectsBadSize verifies a malformed MaxSize is reported
+// as an error (so the caller can fail loudly at startup) rather than being
+// silently ignored.
+func TestBuildRotateConfigRejectsBadSize(t *testing.T) {
+	t.Cleanup(func() { _ = param.Reset() })
+
+	require.NoError(t, param.Logging_Rotation_MaxSize.Set("100 bananas"))
+	_, err := buildRotateConfig()
+	require.Error(t, err, "an unparseable MaxSize must surface an error, not be silently dropped")
+	assert.Contains(t, err.Error(), param.Logging_Rotation_MaxSize.GetName())
+
+	// A valid size parses cleanly.
+	require.NoError(t, param.Logging_Rotation_MaxSize.Set("250MB"))
+	cfg, err := buildRotateConfig()
+	require.NoError(t, err)
+	assert.Equal(t, int64(250*1024*1024), cfg.maxSize)
+}

--- a/logging/logging_file_test.go
+++ b/logging/logging_file_test.go
@@ -92,8 +92,15 @@ func TestBuildRotateConfigRejectsBadSize(t *testing.T) {
 
 	require.NoError(t, param.Logging_Rotation_MaxSize.Set("100 bananas"))
 	_, err := buildRotateConfig()
-	require.Error(t, err, "an unparseable MaxSize must surface an error, not be silently dropped")
+	require.Error(t, err, "an unparsable MaxSize must surface an error, not be silently dropped")
 	assert.Contains(t, err.Error(), param.Logging_Rotation_MaxSize.GetName())
+
+	// A value that exceeds int64 (but still fits uint64) must error, not wrap to
+	// a negative size. 1e10 GB ~= 1.07e19 bytes, above MaxInt64 (~9.2e18).
+	require.NoError(t, param.Logging_Rotation_MaxSize.Set("10000000000GB"))
+	_, err = buildRotateConfig()
+	require.Error(t, err, "an out-of-range MaxSize must surface an error")
+	assert.Contains(t, err.Error(), "too large")
 
 	// A valid size parses cleanly.
 	require.NoError(t, param.Logging_Rotation_MaxSize.Set("250MB"))

--- a/logging/logging_file_test.go
+++ b/logging/logging_file_test.go
@@ -40,14 +40,14 @@ import (
 // drained, and EnterSyncMode flushes + flips to synchronous mode so that a
 // line emitted afterward is written directly and still lands in the file.
 func TestFlushLogsToFileAndSyncMode(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "pelican.log")
+
 	// Snapshot/restore the global logging state touched by this test.
 	t.Cleanup(func() {
 		CloseLogger()
 		ResetLogFlush()
 	})
-
-	dir := t.TempDir()
-	logPath := filepath.Join(dir, "pelican.log")
 
 	require.NoError(t, param.Logging_LogLocation.Set(logPath))
 	require.NoError(t, param.Logging_Rotation_Frequency.Set("daily"))

--- a/logging/logging_file_test.go
+++ b/logging/logging_file_test.go
@@ -102,9 +102,36 @@ func TestBuildRotateConfigRejectsBadSize(t *testing.T) {
 	require.Error(t, err, "an out-of-range MaxSize must surface an error")
 	assert.Contains(t, err.Error(), "too large")
 
+	// A negative size must be rejected rather than turning rotation off: the
+	// unsigned parse it would otherwise reach yields 0, which reads as
+	// "no size limit".
+	require.NoError(t, param.Logging_Rotation_MaxSize.Set("-1GB"))
+	_, err = buildRotateConfig()
+	require.Error(t, err, "a negative MaxSize must surface an error, not silently disable rotation")
+	assert.Contains(t, err.Error(), "negative")
+
 	// A valid size parses cleanly.
 	require.NoError(t, param.Logging_Rotation_MaxSize.Set("250MB"))
 	cfg, err := buildRotateConfig()
 	require.NoError(t, err)
 	assert.Equal(t, int64(250*1024*1024), cfg.maxSize)
+}
+
+// TestBuildRotateConfigRejectsUnknownFrequency verifies an unrecognized
+// Frequency is reported rather than quietly treated as daily: an administrator
+// who asked for "weekly" must learn that no such cadence exists instead of
+// discovering months later that logs rotated every night.
+func TestBuildRotateConfigRejectsUnknownFrequency(t *testing.T) {
+	t.Cleanup(func() { _ = param.Reset() })
+
+	require.NoError(t, param.Logging_Rotation_Frequency.Set("weekly"))
+	_, err := buildRotateConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), param.Logging_Rotation_Frequency.GetName())
+
+	for _, valid := range []string{"daily", "hourly", "none", "DAILY", ""} {
+		require.NoError(t, param.Logging_Rotation_Frequency.Set(valid))
+		_, err := buildRotateConfig()
+		assert.NoError(t, err, "%q must be accepted", valid)
+	}
 }

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -272,6 +272,13 @@ var runtimeConfigurableMap = map[string]bool{
 	"Logging.Origin.Scitokens": true,
 	"Logging.Origin.Xrd": true,
 	"Logging.Origin.Xrootd": true,
+	"Logging.Rotation.Disable": false,
+	"Logging.Rotation.DisableCompress": false,
+	"Logging.Rotation.FlushInterval": false,
+	"Logging.Rotation.Frequency": false,
+	"Logging.Rotation.MaxRetentionPeriod": false,
+	"Logging.Rotation.MaxRetentionSize": false,
+	"Logging.Rotation.MaxSize": false,
 	"Lotman.DbLocation": false,
 	"Lotman.DefaultLotDeletionLifetime": false,
 	"Lotman.DefaultLotExpirationLifetime": false,
@@ -628,6 +635,9 @@ var stringAccessors = map[string]func(*Config) string{
 	"Logging.Origin.Scitokens": func(c *Config) string { return c.Logging.Origin.Scitokens },
 	"Logging.Origin.Xrd": func(c *Config) string { return c.Logging.Origin.Xrd },
 	"Logging.Origin.Xrootd": func(c *Config) string { return c.Logging.Origin.Xrootd },
+	"Logging.Rotation.Frequency": func(c *Config) string { return c.Logging.Rotation.Frequency },
+	"Logging.Rotation.MaxRetentionSize": func(c *Config) string { return c.Logging.Rotation.MaxRetentionSize },
+	"Logging.Rotation.MaxSize": func(c *Config) string { return c.Logging.Rotation.MaxSize },
 	"Lotman.DbLocation": func(c *Config) string { return c.Lotman.DbLocation },
 	"Lotman.EnabledPolicy": func(c *Config) string { return c.Lotman.EnabledPolicy },
 	"Lotman.LibLocation": func(c *Config) string { return c.Lotman.LibLocation },
@@ -984,6 +994,8 @@ var boolAccessors = map[string]func(*Config) bool{
 	"Issuer.UserStripDomain": func(c *Config) bool { return c.Issuer.UserStripDomain },
 	"Logging.Client.DisableProgressBars": func(c *Config) bool { return c.Logging.Client.DisableProgressBars },
 	"Logging.DisableProgressBars": func(c *Config) bool { return c.Logging.DisableProgressBars },
+	"Logging.Rotation.Disable": func(c *Config) bool { return c.Logging.Rotation.Disable },
+	"Logging.Rotation.DisableCompress": func(c *Config) bool { return c.Logging.Rotation.DisableCompress },
 	"Lotman.EnableAPI": func(c *Config) bool { return c.Lotman.EnableAPI },
 	"Monitoring.EnablePrometheus": func(c *Config) bool { return c.Monitoring.EnablePrometheus },
 	"Monitoring.MetricAuthorization": func(c *Config) bool { return c.Monitoring.MetricAuthorization },
@@ -1094,6 +1106,8 @@ var durationAccessors = map[string]func(*Config) time.Duration{
 	"LocalCache.DefaultMaxAge": func(c *Config) time.Duration { return c.LocalCache.DefaultMaxAge },
 	"LocalCache.PrefetchTimeout": func(c *Config) time.Duration { return c.LocalCache.PrefetchTimeout },
 	"Logging.Client.ProgressInterval": func(c *Config) time.Duration { return c.Logging.Client.ProgressInterval },
+	"Logging.Rotation.FlushInterval": func(c *Config) time.Duration { return c.Logging.Rotation.FlushInterval },
+	"Logging.Rotation.MaxRetentionPeriod": func(c *Config) time.Duration { return c.Logging.Rotation.MaxRetentionPeriod },
 	"Lotman.DefaultLotDeletionLifetime": func(c *Config) time.Duration { return c.Lotman.DefaultLotDeletionLifetime },
 	"Lotman.DefaultLotExpirationLifetime": func(c *Config) time.Duration { return c.Lotman.DefaultLotExpirationLifetime },
 	"Lotman.GarbageCollectionInterval": func(c *Config) time.Duration { return c.Lotman.GarbageCollectionInterval },
@@ -1399,6 +1413,13 @@ var allParameterNames = []string{
 	"Logging.Origin.Scitokens",
 	"Logging.Origin.Xrd",
 	"Logging.Origin.Xrootd",
+	"Logging.Rotation.Disable",
+	"Logging.Rotation.DisableCompress",
+	"Logging.Rotation.FlushInterval",
+	"Logging.Rotation.Frequency",
+	"Logging.Rotation.MaxRetentionPeriod",
+	"Logging.Rotation.MaxRetentionSize",
+	"Logging.Rotation.MaxSize",
 	"Lotman.DbLocation",
 	"Lotman.DefaultLotDeletionLifetime",
 	"Lotman.DefaultLotExpirationLifetime",
@@ -1728,6 +1749,9 @@ var (
 	Logging_Origin_Scitokens = StringParam{"Logging.Origin.Scitokens"}
 	Logging_Origin_Xrd = StringParam{"Logging.Origin.Xrd"}
 	Logging_Origin_Xrootd = StringParam{"Logging.Origin.Xrootd"}
+	Logging_Rotation_Frequency = StringParam{"Logging.Rotation.Frequency"}
+	Logging_Rotation_MaxRetentionSize = StringParam{"Logging.Rotation.MaxRetentionSize"}
+	Logging_Rotation_MaxSize = StringParam{"Logging.Rotation.MaxSize"}
 	Lotman_DbLocation = StringParam{"Lotman.DbLocation"}
 	Lotman_EnabledPolicy = StringParam{"Lotman.EnabledPolicy"}
 	Lotman_LibLocation = StringParam{"Lotman.LibLocation"}
@@ -1963,6 +1987,8 @@ var (
 	Issuer_UserStripDomain = BoolParam{"Issuer.UserStripDomain"}
 	Logging_Client_DisableProgressBars = BoolParam{"Logging.Client.DisableProgressBars"}
 	Logging_DisableProgressBars = BoolParam{"Logging.DisableProgressBars"}
+	Logging_Rotation_Disable = BoolParam{"Logging.Rotation.Disable"}
+	Logging_Rotation_DisableCompress = BoolParam{"Logging.Rotation.DisableCompress"}
 	Lotman_EnableAPI = BoolParam{"Lotman.EnableAPI"}
 	Monitoring_EnablePrometheus = BoolParam{"Monitoring.EnablePrometheus"}
 	Monitoring_MetricAuthorization = BoolParam{"Monitoring.MetricAuthorization"}
@@ -2045,6 +2071,8 @@ var (
 	LocalCache_DefaultMaxAge = DurationParam{"LocalCache.DefaultMaxAge"}
 	LocalCache_PrefetchTimeout = DurationParam{"LocalCache.PrefetchTimeout"}
 	Logging_Client_ProgressInterval = DurationParam{"Logging.Client.ProgressInterval"}
+	Logging_Rotation_FlushInterval = DurationParam{"Logging.Rotation.FlushInterval"}
+	Logging_Rotation_MaxRetentionPeriod = DurationParam{"Logging.Rotation.MaxRetentionPeriod"}
 	Lotman_DefaultLotDeletionLifetime = DurationParam{"Lotman.DefaultLotDeletionLifetime"}
 	Lotman_DefaultLotExpirationLifetime = DurationParam{"Lotman.DefaultLotExpirationLifetime"}
 	Lotman_GarbageCollectionInterval = DurationParam{"Lotman.GarbageCollectionInterval"}
@@ -2190,6 +2218,9 @@ func init() {
 		"Logging.Origin.Scitokens": Logging_Origin_Scitokens,
 		"Logging.Origin.Xrd": Logging_Origin_Xrd,
 		"Logging.Origin.Xrootd": Logging_Origin_Xrootd,
+		"Logging.Rotation.Frequency": Logging_Rotation_Frequency,
+		"Logging.Rotation.MaxRetentionSize": Logging_Rotation_MaxRetentionSize,
+		"Logging.Rotation.MaxSize": Logging_Rotation_MaxSize,
 		"Lotman.DbLocation": Lotman_DbLocation,
 		"Lotman.EnabledPolicy": Lotman_EnabledPolicy,
 		"Lotman.LibLocation": Lotman_LibLocation,
@@ -2413,6 +2444,8 @@ func init() {
 		"Issuer.UserStripDomain": Issuer_UserStripDomain,
 		"Logging.Client.DisableProgressBars": Logging_Client_DisableProgressBars,
 		"Logging.DisableProgressBars": Logging_DisableProgressBars,
+		"Logging.Rotation.Disable": Logging_Rotation_Disable,
+		"Logging.Rotation.DisableCompress": Logging_Rotation_DisableCompress,
 		"Lotman.EnableAPI": Lotman_EnableAPI,
 		"Monitoring.EnablePrometheus": Monitoring_EnablePrometheus,
 		"Monitoring.MetricAuthorization": Monitoring_MetricAuthorization,
@@ -2492,6 +2525,8 @@ func init() {
 		"LocalCache.DefaultMaxAge": LocalCache_DefaultMaxAge,
 		"LocalCache.PrefetchTimeout": LocalCache_PrefetchTimeout,
 		"Logging.Client.ProgressInterval": Logging_Client_ProgressInterval,
+		"Logging.Rotation.FlushInterval": Logging_Rotation_FlushInterval,
+		"Logging.Rotation.MaxRetentionPeriod": Logging_Rotation_MaxRetentionPeriod,
 		"Lotman.DefaultLotDeletionLifetime": Lotman_DefaultLotDeletionLifetime,
 		"Lotman.DefaultLotExpirationLifetime": Lotman_DefaultLotExpirationLifetime,
 		"Lotman.GarbageCollectionInterval": Lotman_GarbageCollectionInterval,

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -263,6 +263,8 @@ var runtimeConfigurableMap = map[string]bool{
 	"LocalCache.Size": false,
 	"LocalCache.Socket": false,
 	"LocalCache.StorageDirs": false,
+	"Logging.Buffer.BatchLines": false,
+	"Logging.Buffer.MaxSize": false,
 	"Logging.Cache.Http": true,
 	"Logging.Cache.Lotman": true,
 	"Logging.Cache.Ofs": true,
@@ -660,6 +662,7 @@ var stringAccessors = map[string]func(*Config) string{
 	"LocalCache.RunLocation": func(c *Config) string { return c.LocalCache.RunLocation },
 	"LocalCache.Size": func(c *Config) string { return c.LocalCache.Size },
 	"LocalCache.Socket": func(c *Config) string { return c.LocalCache.Socket },
+	"Logging.Buffer.MaxSize": func(c *Config) string { return c.Logging.Buffer.MaxSize },
 	"Logging.Cache.Http": func(c *Config) string { return c.Logging.Cache.Http },
 	"Logging.Cache.Lotman": func(c *Config) string { return c.Logging.Cache.Lotman },
 	"Logging.Cache.Ofs": func(c *Config) string { return c.Logging.Cache.Ofs },
@@ -923,6 +926,7 @@ var intAccessors = map[string]func(*Config) int{
 	"LocalCache.LowWaterMarkPercentage": func(c *Config) int { return c.LocalCache.LowWaterMarkPercentage },
 	"LocalCache.MaxConcurrentPrefetch": func(c *Config) int { return c.LocalCache.MaxConcurrentPrefetch },
 	"LocalCache.RevalidationJitter": func(c *Config) int { return c.LocalCache.RevalidationJitter },
+	"Logging.Buffer.BatchLines": func(c *Config) int { return c.Logging.Buffer.BatchLines },
 	"MinimumDownloadSpeed": func(c *Config) int { return c.MinimumDownloadSpeed },
 	"Monitoring.LabelLimit": func(c *Config) int { return c.Monitoring.LabelLimit },
 	"Monitoring.LabelNameLengthLimit": func(c *Config) int { return c.Monitoring.LabelNameLengthLimit },
@@ -1484,6 +1488,8 @@ var allParameterNames = []string{
 	"LocalCache.Size",
 	"LocalCache.Socket",
 	"LocalCache.StorageDirs",
+	"Logging.Buffer.BatchLines",
+	"Logging.Buffer.MaxSize",
 	"Logging.Cache.Http",
 	"Logging.Cache.Lotman",
 	"Logging.Cache.Ofs",
@@ -1854,6 +1860,7 @@ var (
 	LocalCache_RunLocation = StringParam{"LocalCache.RunLocation"}
 	LocalCache_Size = StringParam{"LocalCache.Size"}
 	LocalCache_Socket = StringParam{"LocalCache.Socket"}
+	Logging_Buffer_MaxSize = StringParam{"Logging.Buffer.MaxSize"}
 	Logging_Cache_Http = StringParam{"Logging.Cache.Http"}
 	Logging_Cache_Lotman = StringParam{"Logging.Cache.Lotman"}
 	Logging_Cache_Ofs = StringParam{"Logging.Cache.Ofs"}
@@ -2061,6 +2068,7 @@ var (
 	LocalCache_LowWaterMarkPercentage = IntParam{"LocalCache.LowWaterMarkPercentage"}
 	LocalCache_MaxConcurrentPrefetch = IntParam{"LocalCache.MaxConcurrentPrefetch"}
 	LocalCache_RevalidationJitter = IntParam{"LocalCache.RevalidationJitter"}
+	Logging_Buffer_BatchLines = IntParam{"Logging.Buffer.BatchLines"}
 	MinimumDownloadSpeed = IntParam{"MinimumDownloadSpeed"}
 	Monitoring_LabelLimit = IntParam{"Monitoring.LabelLimit"}
 	Monitoring_LabelNameLengthLimit = IntParam{"Monitoring.LabelNameLengthLimit"}
@@ -2363,6 +2371,7 @@ func init() {
 		"LocalCache.RunLocation": LocalCache_RunLocation,
 		"LocalCache.Size": LocalCache_Size,
 		"LocalCache.Socket": LocalCache_Socket,
+		"Logging.Buffer.MaxSize": Logging_Buffer_MaxSize,
 		"Logging.Cache.Http": Logging_Cache_Http,
 		"Logging.Cache.Lotman": Logging_Cache_Lotman,
 		"Logging.Cache.Ofs": Logging_Cache_Ofs,
@@ -2564,6 +2573,7 @@ func init() {
 		"LocalCache.LowWaterMarkPercentage": LocalCache_LowWaterMarkPercentage,
 		"LocalCache.MaxConcurrentPrefetch": LocalCache_MaxConcurrentPrefetch,
 		"LocalCache.RevalidationJitter": LocalCache_RevalidationJitter,
+		"Logging.Buffer.BatchLines": Logging_Buffer_BatchLines,
 		"MinimumDownloadSpeed": MinimumDownloadSpeed,
 		"Monitoring.LabelLimit": Monitoring_LabelLimit,
 		"Monitoring.LabelNameLengthLimit": Monitoring_LabelNameLengthLimit,

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -284,6 +284,13 @@ var runtimeConfigurableMap = map[string]bool{
 	"Logging.Origin.Scitokens": true,
 	"Logging.Origin.Xrd": true,
 	"Logging.Origin.Xrootd": true,
+	"Logging.Rotation.Disable": false,
+	"Logging.Rotation.DisableCompress": false,
+	"Logging.Rotation.FlushInterval": false,
+	"Logging.Rotation.Frequency": false,
+	"Logging.Rotation.MaxRetentionPeriod": false,
+	"Logging.Rotation.MaxRetentionSize": false,
+	"Logging.Rotation.MaxSize": false,
 	"Lotman.DbLocation": false,
 	"Lotman.DefaultLotDeletionLifetime": false,
 	"Lotman.DefaultLotExpirationLifetime": false,
@@ -671,6 +678,9 @@ var stringAccessors = map[string]func(*Config) string{
 	"Logging.Origin.Scitokens": func(c *Config) string { return c.Logging.Origin.Scitokens },
 	"Logging.Origin.Xrd": func(c *Config) string { return c.Logging.Origin.Xrd },
 	"Logging.Origin.Xrootd": func(c *Config) string { return c.Logging.Origin.Xrootd },
+	"Logging.Rotation.Frequency": func(c *Config) string { return c.Logging.Rotation.Frequency },
+	"Logging.Rotation.MaxRetentionSize": func(c *Config) string { return c.Logging.Rotation.MaxRetentionSize },
+	"Logging.Rotation.MaxSize": func(c *Config) string { return c.Logging.Rotation.MaxSize },
 	"Lotman.DbLocation": func(c *Config) string { return c.Lotman.DbLocation },
 	"Lotman.EnabledPolicy": func(c *Config) string { return c.Lotman.EnabledPolicy },
 	"Lotman.LibLocation": func(c *Config) string { return c.Lotman.LibLocation },
@@ -1051,6 +1061,8 @@ var boolAccessors = map[string]func(*Config) bool{
 	"Issuer.UserStripDomain": func(c *Config) bool { return c.Issuer.UserStripDomain },
 	"Logging.Client.DisableProgressBars": func(c *Config) bool { return c.Logging.Client.DisableProgressBars },
 	"Logging.DisableProgressBars": func(c *Config) bool { return c.Logging.DisableProgressBars },
+	"Logging.Rotation.Disable": func(c *Config) bool { return c.Logging.Rotation.Disable },
+	"Logging.Rotation.DisableCompress": func(c *Config) bool { return c.Logging.Rotation.DisableCompress },
 	"Lotman.EnableAPI": func(c *Config) bool { return c.Lotman.EnableAPI },
 	"Monitoring.EnablePrometheus": func(c *Config) bool { return c.Monitoring.EnablePrometheus },
 	"Monitoring.MetricAuthorization": func(c *Config) bool { return c.Monitoring.MetricAuthorization },
@@ -1169,6 +1181,8 @@ var durationAccessors = map[string]func(*Config) time.Duration{
 	"LocalCache.DefaultMaxAge": func(c *Config) time.Duration { return c.LocalCache.DefaultMaxAge },
 	"LocalCache.PrefetchTimeout": func(c *Config) time.Duration { return c.LocalCache.PrefetchTimeout },
 	"Logging.Client.ProgressInterval": func(c *Config) time.Duration { return c.Logging.Client.ProgressInterval },
+	"Logging.Rotation.FlushInterval": func(c *Config) time.Duration { return c.Logging.Rotation.FlushInterval },
+	"Logging.Rotation.MaxRetentionPeriod": func(c *Config) time.Duration { return c.Logging.Rotation.MaxRetentionPeriod },
 	"Lotman.DefaultLotDeletionLifetime": func(c *Config) time.Duration { return c.Lotman.DefaultLotDeletionLifetime },
 	"Lotman.DefaultLotExpirationLifetime": func(c *Config) time.Duration { return c.Lotman.DefaultLotExpirationLifetime },
 	"Lotman.GarbageCollectionInterval": func(c *Config) time.Duration { return c.Lotman.GarbageCollectionInterval },
@@ -1491,6 +1505,13 @@ var allParameterNames = []string{
 	"Logging.Origin.Scitokens",
 	"Logging.Origin.Xrd",
 	"Logging.Origin.Xrootd",
+	"Logging.Rotation.Disable",
+	"Logging.Rotation.DisableCompress",
+	"Logging.Rotation.FlushInterval",
+	"Logging.Rotation.Frequency",
+	"Logging.Rotation.MaxRetentionPeriod",
+	"Logging.Rotation.MaxRetentionSize",
+	"Logging.Rotation.MaxSize",
 	"Lotman.DbLocation",
 	"Lotman.DefaultLotDeletionLifetime",
 	"Lotman.DefaultLotExpirationLifetime",
@@ -1851,6 +1872,9 @@ var (
 	Logging_Origin_Scitokens = StringParam{"Logging.Origin.Scitokens"}
 	Logging_Origin_Xrd = StringParam{"Logging.Origin.Xrd"}
 	Logging_Origin_Xrootd = StringParam{"Logging.Origin.Xrootd"}
+	Logging_Rotation_Frequency = StringParam{"Logging.Rotation.Frequency"}
+	Logging_Rotation_MaxRetentionSize = StringParam{"Logging.Rotation.MaxRetentionSize"}
+	Logging_Rotation_MaxSize = StringParam{"Logging.Rotation.MaxSize"}
 	Lotman_DbLocation = StringParam{"Lotman.DbLocation"}
 	Lotman_EnabledPolicy = StringParam{"Lotman.EnabledPolicy"}
 	Lotman_LibLocation = StringParam{"Lotman.LibLocation"}
@@ -2110,6 +2134,8 @@ var (
 	Issuer_UserStripDomain = BoolParam{"Issuer.UserStripDomain"}
 	Logging_Client_DisableProgressBars = BoolParam{"Logging.Client.DisableProgressBars"}
 	Logging_DisableProgressBars = BoolParam{"Logging.DisableProgressBars"}
+	Logging_Rotation_Disable = BoolParam{"Logging.Rotation.Disable"}
+	Logging_Rotation_DisableCompress = BoolParam{"Logging.Rotation.DisableCompress"}
 	Lotman_EnableAPI = BoolParam{"Lotman.EnableAPI"}
 	Monitoring_EnablePrometheus = BoolParam{"Monitoring.EnablePrometheus"}
 	Monitoring_MetricAuthorization = BoolParam{"Monitoring.MetricAuthorization"}
@@ -2200,6 +2226,8 @@ var (
 	LocalCache_DefaultMaxAge = DurationParam{"LocalCache.DefaultMaxAge"}
 	LocalCache_PrefetchTimeout = DurationParam{"LocalCache.PrefetchTimeout"}
 	Logging_Client_ProgressInterval = DurationParam{"Logging.Client.ProgressInterval"}
+	Logging_Rotation_FlushInterval = DurationParam{"Logging.Rotation.FlushInterval"}
+	Logging_Rotation_MaxRetentionPeriod = DurationParam{"Logging.Rotation.MaxRetentionPeriod"}
 	Lotman_DefaultLotDeletionLifetime = DurationParam{"Lotman.DefaultLotDeletionLifetime"}
 	Lotman_DefaultLotExpirationLifetime = DurationParam{"Lotman.DefaultLotExpirationLifetime"}
 	Lotman_GarbageCollectionInterval = DurationParam{"Lotman.GarbageCollectionInterval"}
@@ -2353,6 +2381,9 @@ func init() {
 		"Logging.Origin.Scitokens": Logging_Origin_Scitokens,
 		"Logging.Origin.Xrd": Logging_Origin_Xrd,
 		"Logging.Origin.Xrootd": Logging_Origin_Xrootd,
+		"Logging.Rotation.Frequency": Logging_Rotation_Frequency,
+		"Logging.Rotation.MaxRetentionSize": Logging_Rotation_MaxRetentionSize,
+		"Logging.Rotation.MaxSize": Logging_Rotation_MaxSize,
 		"Lotman.DbLocation": Lotman_DbLocation,
 		"Lotman.EnabledPolicy": Lotman_EnabledPolicy,
 		"Lotman.LibLocation": Lotman_LibLocation,
@@ -2600,6 +2631,8 @@ func init() {
 		"Issuer.UserStripDomain": Issuer_UserStripDomain,
 		"Logging.Client.DisableProgressBars": Logging_Client_DisableProgressBars,
 		"Logging.DisableProgressBars": Logging_DisableProgressBars,
+		"Logging.Rotation.Disable": Logging_Rotation_Disable,
+		"Logging.Rotation.DisableCompress": Logging_Rotation_DisableCompress,
 		"Lotman.EnableAPI": Lotman_EnableAPI,
 		"Monitoring.EnablePrometheus": Monitoring_EnablePrometheus,
 		"Monitoring.MetricAuthorization": Monitoring_MetricAuthorization,
@@ -2687,6 +2720,8 @@ func init() {
 		"LocalCache.DefaultMaxAge": LocalCache_DefaultMaxAge,
 		"LocalCache.PrefetchTimeout": LocalCache_PrefetchTimeout,
 		"Logging.Client.ProgressInterval": Logging_Client_ProgressInterval,
+		"Logging.Rotation.FlushInterval": Logging_Rotation_FlushInterval,
+		"Logging.Rotation.MaxRetentionPeriod": Logging_Rotation_MaxRetentionPeriod,
 		"Lotman.DefaultLotDeletionLifetime": Lotman_DefaultLotDeletionLifetime,
 		"Lotman.DefaultLotExpirationLifetime": Lotman_DefaultLotExpirationLifetime,
 		"Lotman.GarbageCollectionInterval": Lotman_GarbageCollectionInterval,

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -223,6 +223,15 @@ type Config struct {
 			Xrd string `mapstructure:"xrd" yaml:"Xrd"`
 			Xrootd string `mapstructure:"xrootd" yaml:"Xrootd"`
 		} `mapstructure:"origin" yaml:"Origin"`
+		Rotation struct {
+			Disable bool `mapstructure:"disable" yaml:"Disable"`
+			DisableCompress bool `mapstructure:"disablecompress" yaml:"DisableCompress"`
+			FlushInterval time.Duration `mapstructure:"flushinterval" yaml:"FlushInterval"`
+			Frequency string `mapstructure:"frequency" yaml:"Frequency"`
+			MaxRetentionPeriod time.Duration `mapstructure:"maxretentionperiod" yaml:"MaxRetentionPeriod"`
+			MaxRetentionSize string `mapstructure:"maxretentionsize" yaml:"MaxRetentionSize"`
+			MaxSize string `mapstructure:"maxsize" yaml:"MaxSize"`
+		} `mapstructure:"rotation" yaml:"Rotation"`
 	} `mapstructure:"logging" yaml:"Logging"`
 	Lotman struct {
 		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
@@ -707,6 +716,15 @@ type configWithType struct {
 			Scitokens struct { Type string; Value string }
 			Xrd struct { Type string; Value string }
 			Xrootd struct { Type string; Value string }
+		}
+		Rotation struct {
+			Disable struct { Type string; Value bool }
+			DisableCompress struct { Type string; Value bool }
+			FlushInterval struct { Type string; Value time.Duration }
+			Frequency struct { Type string; Value string }
+			MaxRetentionPeriod struct { Type string; Value time.Duration }
+			MaxRetentionSize struct { Type string; Value string }
+			MaxSize struct { Type string; Value string }
 		}
 	}
 	Lotman struct {

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -209,6 +209,10 @@ type Config struct {
 		StorageDirs any `mapstructure:"storagedirs" yaml:"StorageDirs"`
 	} `mapstructure:"localcache" yaml:"LocalCache"`
 	Logging struct {
+		Buffer struct {
+			BatchLines int `mapstructure:"batchlines" yaml:"BatchLines"`
+			MaxSize string `mapstructure:"maxsize" yaml:"MaxSize"`
+		} `mapstructure:"buffer" yaml:"Buffer"`
 		Cache struct {
 			Http string `mapstructure:"http" yaml:"Http"`
 			Lotman string `mapstructure:"lotman" yaml:"Lotman"`
@@ -746,6 +750,10 @@ type configWithType struct {
 		StorageDirs struct { Type string; Value any }
 	}
 	Logging struct {
+		Buffer struct {
+			BatchLines struct { Type string; Value int }
+			MaxSize struct { Type string; Value string }
+		}
 		Cache struct {
 			Http struct { Type string; Value string }
 			Lotman struct { Type string; Value string }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -236,6 +236,15 @@ type Config struct {
 			Xrd string `mapstructure:"xrd" yaml:"Xrd"`
 			Xrootd string `mapstructure:"xrootd" yaml:"Xrootd"`
 		} `mapstructure:"origin" yaml:"Origin"`
+		Rotation struct {
+			Disable bool `mapstructure:"disable" yaml:"Disable"`
+			DisableCompress bool `mapstructure:"disablecompress" yaml:"DisableCompress"`
+			FlushInterval time.Duration `mapstructure:"flushinterval" yaml:"FlushInterval"`
+			Frequency string `mapstructure:"frequency" yaml:"Frequency"`
+			MaxRetentionPeriod time.Duration `mapstructure:"maxretentionperiod" yaml:"MaxRetentionPeriod"`
+			MaxRetentionSize string `mapstructure:"maxretentionsize" yaml:"MaxRetentionSize"`
+			MaxSize string `mapstructure:"maxsize" yaml:"MaxSize"`
+		} `mapstructure:"rotation" yaml:"Rotation"`
 	} `mapstructure:"logging" yaml:"Logging"`
 	Lotman struct {
 		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
@@ -763,6 +772,15 @@ type configWithType struct {
 			Scitokens struct { Type string; Value string }
 			Xrd struct { Type string; Value string }
 			Xrootd struct { Type string; Value string }
+		}
+		Rotation struct {
+			Disable struct { Type string; Value bool }
+			DisableCompress struct { Type string; Value bool }
+			FlushInterval struct { Type string; Value time.Duration }
+			Frequency struct { Type string; Value string }
+			MaxRetentionPeriod struct { Type string; Value time.Duration }
+			MaxRetentionSize struct { Type string; Value string }
+			MaxSize struct { Type string; Value string }
 		}
 	}
 	Lotman struct {

--- a/swagger/pelican-swagger.yaml
+++ b/swagger/pelican-swagger.yaml
@@ -98,6 +98,56 @@ definitions:
         type: string
         default: ""
         description: The response message
+  LogTailResponse:
+    type: object
+    description: >-
+      Page of buffered log lines returned by `GET /api/v1.0/logs/tail`.
+      `content` is raw text (newline-terminated log lines concatenated in
+      order); `firstCursor` and `lastCursor` bracket the range covered.
+      Pass `lastCursor` back as the next request's `since` to continue
+      live tailing, or `firstCursor` back as the next request's `before`
+      to scroll further into older history. `reached` is true when
+      scroll-up has hit the wall — no content older than `firstCursor` is
+      currently held. Cursors are opaque URL-safe base64 tokens; clients
+      MUST NOT interpret them beyond echoing them back verbatim.
+    properties:
+      enabled:
+        type: boolean
+        description: >-
+          False when the in-memory log buffer has not been initialized on
+          this server (transient during startup); when false the other
+          fields are absent or empty.
+      content:
+        type: string
+        description: Newline-terminated log lines concatenated in order.
+      firstCursor:
+        type: string
+        description: >-
+          Opaque cursor for the oldest line in `content`. Pass back as
+          the next request's `before` to page further into history. Empty
+          when `content` is empty.
+      lastCursor:
+        type: string
+        description: >-
+          Opaque cursor for the newest line in `content`. Pass back as
+          the next request's `since` for live tail. Empty when the
+          buffer has no lines at all.
+      reached:
+        type: boolean
+        description: >-
+          True when `firstCursor` refers to the oldest line the buffer
+          currently holds — a further `before` request with the same
+          cursor will return nothing. Callers use this to disable a
+          scroll-up affordance.
+      instanceId:
+        type: string
+        description: >-
+          Identifier for the buffer instance that produced this
+          response. Regenerated when the server restarts (or the buffer
+          is otherwise re-initialized). Clients should treat a change
+          as a signal to drop all locally-cached cursors and start
+          fresh — cursors from the previous instance are meaningless
+          against the new one.
   SimpleApiResp:
     type: object
     description: >-
@@ -2765,6 +2815,12 @@ tags:
     description: Acceptable Use Policy — public reads (current and versioned), admin edit, and persisted version history
   - name: issuer-admin
     description: Admin APIs for managing the embedded OIDC issuer clients and token exchange
+  - name: logs
+    description: >-
+      Read the server's in-memory log buffer. Gated by the
+      `pelican.log_read` scope; the buffer is bounded by
+      `Logging.Buffer.MaxSize` and older lines are evicted as new ones
+      arrive.
 paths:
   /health:
     get:
@@ -9237,3 +9293,112 @@ paths:
           description: Job not found or not owned by this user
           schema:
             $ref: "#/definitions/TransferErrorResponse"
+  /api/v1.0/logs/tail:
+    get:
+      tags: ["logs"]
+      summary: Read a page of buffered log lines
+      description: |
+        Returns log lines from the server's in-memory buffer relative to an
+        opaque cursor. The caller supplies exactly one of `since` or `before`:
+
+        - `?since=<cursor>` returns lines newer than the cursor (live tail
+          / forward polling); pass the response's `lastCursor` back as the
+          next request's `since`. An empty (or omitted) `since` yields
+          every line the buffer currently holds.
+        - `?before=<cursor>&count=<n>` returns lines older than the
+          cursor, walking older content. `count` is a lower-bound hint;
+          the server rounds up to whole internal storage units so the
+          same content is not reprocessed if the client scrolls further
+          backwards later. Pass the response's `firstCursor` back as the
+          next request's `before`.
+
+        Cursors are opaque URL-safe base64 tokens; callers MUST NOT
+        interpret them beyond echoing them back to the server. Internal
+        structure (batching, LZ4 compression, pending buffer) is not part
+        of the API contract.
+
+        Access requires either the `server.admin` role or a session/token
+        carrying the `pelican.log_read` scope.
+      produces: [application/json]
+      parameters:
+        - in: query
+          name: since
+          required: false
+          type: string
+          description: >-
+            Opaque cursor. Return lines strictly newer than this cursor.
+            Mutually exclusive with `before`. Omit or pass an empty string
+            for a fresh read.
+        - in: query
+          name: before
+          required: false
+          type: string
+          description: >-
+            Opaque cursor. Return lines strictly older than this cursor.
+            Mutually exclusive with `since`. Typically the previous
+            response's `firstCursor` when paging backwards.
+        - in: query
+          name: count
+          required: false
+          type: integer
+          description: >-
+            Lower bound on how many lines to return when using `before`.
+            The server rounds up to whole internal storage units. Ignored
+            when `since` is used. Defaults to one storage unit's worth.
+        - in: query
+          name: limit
+          required: false
+          type: integer
+          description: >-
+            Upper bound on how many lines to return when using `since`.
+            When the delta exceeds `limit`, only the newest `limit` lines
+            are returned; older lines that fall outside the window can
+            still be reached via `before=<firstCursor>`. Ignored when
+            `before` is used. Zero or absent means unbounded.
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: "#/definitions/LogTailResponse"
+        "400":
+          description: Bad Request (invalid or mutually exclusive cursors)
+          schema:
+            $ref: "#/definitions/SimpleApiResp"
+        "401":
+          description: Unauthorized (no active session)
+          schema:
+            $ref: "#/definitions/SimpleApiResp"
+        "403":
+          description: >-
+            Forbidden — caller lacks the `server.admin` role or the
+            `pelican.log_read` scope
+          schema:
+            $ref: "#/definitions/SimpleApiResp"
+  /api/v1.0/logs/download:
+    get:
+      tags: ["logs"]
+      summary: Download the current buffered logs as a gzip archive
+      description: |
+        Streams every log line the buffer currently holds as a gzip file.
+        The `Content-Disposition` filename embeds the server hostname and
+        a UTC timestamp so downloads saved into the same directory from
+        different servers or times don't collide.
+
+        Access requires either the `server.admin` role or a session/token
+        carrying the `pelican.log_read` scope.
+      produces: [application/gzip]
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: file
+        "401":
+          description: Unauthorized (no active session)
+          schema:
+            $ref: "#/definitions/SimpleApiResp"
+        "403":
+          description: >-
+            Forbidden — caller lacks the `server.admin` role or the
+            `pelican.log_read` scope
+          schema:
+            $ref: "#/definitions/SimpleApiResp"

--- a/swagger/pelican-swagger.yaml
+++ b/swagger/pelican-swagger.yaml
@@ -2831,9 +2831,10 @@ tags:
   - name: logs
     description: >-
       Read the server's in-memory log buffer. Gated by the
-      `pelican.log_read` scope; the buffer is bounded by
-      `Logging.Buffer.MaxSize` and older lines are evicted as new ones
-      arrive.
+      `pelican.log_read` scope, or by the `server.admin` role, which
+      carries it. The buffer is bounded by `Logging.Buffer.MaxSize`;
+      older lines are evicted as new ones arrive, and a read reports how
+      many it missed.
 paths:
   /health:
     get:
@@ -9330,8 +9331,13 @@ paths:
         structure (batching, LZ4 compression, pending buffer) is not part
         of the API contract.
 
-        Access requires either the `server.admin` role or a session/token
-        carrying the `pelican.log_read` scope.
+        Access requires either the `server.admin` role or the
+        `pelican.log_read` scope. The scope is resolved from the
+        authenticated user's grants, not read out of the presented
+        credential, so it cannot be used to narrow what a credential may
+        do. Authentication is by browser session or by a locally-issued
+        JWT; Pelican API tokens (`id.secret`) are not accepted on these
+        endpoints.
       produces: [application/json]
       parameters:
         - in: query
@@ -9397,8 +9403,13 @@ paths:
         a UTC timestamp so downloads saved into the same directory from
         different servers or times don't collide.
 
-        Access requires either the `server.admin` role or a session/token
-        carrying the `pelican.log_read` scope.
+        Access requires either the `server.admin` role or the
+        `pelican.log_read` scope. The scope is resolved from the
+        authenticated user's grants, not read out of the presented
+        credential, so it cannot be used to narrow what a credential may
+        do. Authentication is by browser session or by a locally-issued
+        JWT; Pelican API tokens (`id.secret`) are not accepted on these
+        endpoints.
       produces: [application/gzip]
       responses:
         "200":

--- a/swagger/pelican-swagger.yaml
+++ b/swagger/pelican-swagger.yaml
@@ -139,6 +139,19 @@ definitions:
           currently holds — a further `before` request with the same
           cursor will return nothing. Callers use this to disable a
           scroll-up affordance.
+      dropped:
+        type: integer
+        format: int64
+        description: >-
+          Number of lines missing between the caller's `since` cursor and
+          the start of `content`, because they were evicted from the
+          buffer before the caller requested them or trimmed to satisfy
+          `limit`. `content` is contiguous with what the caller already
+          holds only when this is 0. Because cursors are opaque, a client
+          cannot compute this itself and MUST read it here to know
+          whether the history it is presenting has holes in it. Always 0
+          for a `before=` (scroll-up) request, which reports exhaustion
+          through `reached` instead.
       instanceId:
         type: string
         description: >-

--- a/token_scopes/token_scopes.go
+++ b/token_scopes/token_scopes.go
@@ -136,7 +136,7 @@ var scopeDescriptions = map[TokenScope]string{
 	Server_UserAdmin: `Manage non-admin users and unprivileged groups. Holders can create users, mint password-set invites, and run the user-onboarding flows, but cannot modify system-admin accounts.`,
 	Server_CollectionAdmin: `Create, modify, and delete collections and manage their ACLs.`,
 	Pelican_LoggingModify: `Permits modification of server log levels at runtime`,
-	Pelican_LogRead: `Permits the reading of the server's buffer of recent log lines. Required for the web UI's log viewer and for programmatic log fetches.`,
+	Pelican_LogRead: `Permits the reading of the server's buffer of recent log lines, through the web UI's log viewer or the /api/v1.0/logs endpoints. Granting it is equivalent to granting sight of everything the server logs, which is why it is separable from server.admin rather than implied by every lesser role. The scope is resolved from the user's grants when a request arrives, so it governs what an account may reach and not what any particular credential may do.`,
 	Registry_EditRegistration: `For origin admin to edit namespace registration at the registry`,
 	Monitoring_Scrape: `For server's Prometheus instance to scrape its Prometheus http data exporter at /metrics`,
 	Monitoring_Query: `View server metrics. Required for the web UI's metrics dashboards and for external monitoring tools (e.g. Grafana) to read this server's metrics through its Prometheus-compatible query endpoint.`,

--- a/token_scopes/token_scopes.go
+++ b/token_scopes/token_scopes.go
@@ -40,6 +40,7 @@ const (
 	Server_UserAdmin TokenScope = "server.user_admin"
 	Server_CollectionAdmin TokenScope = "server.collection_admin"
 	Pelican_LoggingModify TokenScope = "pelican.logging_modify"
+	Pelican_LogRead TokenScope = "pelican.log_read"
 	Registry_EditRegistration TokenScope = "registry.edit_registration"
 	Monitoring_Scrape TokenScope = "monitoring.scrape"
 	Monitoring_Query TokenScope = "monitoring.query"
@@ -99,6 +100,7 @@ var UserGrantableScopes = []TokenScope{
 	Server_Admin,
 	Server_UserAdmin,
 	Server_CollectionAdmin,
+	Pelican_LogRead,
 	Monitoring_Query,
 	Pelican_Transfer,
 }
@@ -134,6 +136,7 @@ var scopeDescriptions = map[TokenScope]string{
 	Server_UserAdmin: `Manage non-admin users and unprivileged groups. Holders can create users, mint password-set invites, and run the user-onboarding flows, but cannot modify system-admin accounts.`,
 	Server_CollectionAdmin: `Create, modify, and delete collections and manage their ACLs.`,
 	Pelican_LoggingModify: `Permits modification of server log levels at runtime`,
+	Pelican_LogRead: `Permits the reading of the server's buffer of recent log lines. Required for the web UI's log viewer and for programmatic log fetches.`,
 	Registry_EditRegistration: `For origin admin to edit namespace registration at the registry`,
 	Monitoring_Scrape: `For server's Prometheus instance to scrape its Prometheus http data exporter at /metrics`,
 	Monitoring_Query: `View server metrics. Required for the web UI's metrics dashboards and for external monitoring tools (e.g. Grafana) to read this server's metrics through its Prometheus-compatible query endpoint.`,

--- a/web_ui/frontend/app/navigation.tsx
+++ b/web_ui/frontend/app/navigation.tsx
@@ -9,6 +9,7 @@ import {
   Cached,
   CalendarMonth,
   Dashboard,
+  Description,
   Equalizer,
   FolderOpen,
   Lock,
@@ -23,6 +24,18 @@ import {
   VpnKey,
 } from '@mui/icons-material';
 import { NavigationConfiguration } from '@/components/layout/Navigation';
+
+// SettingsShellScopes is the union of scopes admitted into the /settings/
+// shell by app/settings/layout.tsx. Anyone the shell would let in needs a
+// visible path there from every subsystem sidebar, otherwise a scope-only
+// holder can reach Settings only by typing the URL. Keep this list and the
+// layout's `anyScopes` in sync; both surfaces import from here so a future
+// scope addition lands in one place.
+//
+// Excluded on purpose: server.admin. Admins are admitted by the role gate
+// (`allowedRoles: ['admin']`), so listing the scope here would be
+// redundant.
+export const SettingsShellScopes = ['server.user_admin', 'pelican.log_read'];
 
 const NavigationConfig: NavigationConfiguration = {
   settings: [
@@ -68,6 +81,17 @@ const NavigationConfig: NavigationConfiguration = {
       href: '/settings/aup/',
       icon: <Article />,
       allowedRoles: ['admin'],
+    },
+    {
+      // Log viewer: live in-memory tail of server logs. Reachable by
+      // admins AND holders of the dedicated pelican.log_read scope
+      // (typically granted via a group), so a user can watch logs
+      // without also inheriting admin privileges.
+      title: 'Logs',
+      href: '/settings/logs/',
+      icon: <Description />,
+      allowedRoles: ['admin'],
+      anyScopes: ['pelican.log_read'],
     },
   ],
   registry: [
@@ -117,6 +141,7 @@ const NavigationConfig: NavigationConfiguration = {
       href: '/settings/',
       icon: <Settings />,
       allowedRoles: ['admin'],
+      anyScopes: SettingsShellScopes,
     },
   ],
   origin: [
@@ -174,6 +199,7 @@ const NavigationConfig: NavigationConfiguration = {
       href: '/settings/',
       icon: <Settings />,
       allowedRoles: ['admin'],
+      anyScopes: SettingsShellScopes,
     },
   ],
   director: [
@@ -197,6 +223,7 @@ const NavigationConfig: NavigationConfiguration = {
       href: '/settings/',
       icon: <Settings />,
       allowedRoles: ['admin'],
+      anyScopes: SettingsShellScopes,
     },
   ],
   cache: [
@@ -219,6 +246,7 @@ const NavigationConfig: NavigationConfiguration = {
       href: '/settings/',
       icon: <Settings />,
       allowedRoles: ['admin'],
+      anyScopes: SettingsShellScopes,
     },
   ],
   transfer: [
@@ -233,6 +261,18 @@ const NavigationConfig: NavigationConfiguration = {
     { title: 'Director', href: '/director/', icon: <AssistantDirection /> },
     { title: 'Registry', href: '/registry/', icon: <AppRegistration /> },
     { title: 'Cache', href: '/cache/', icon: <Cached /> },
+    // The shared nav is what /settings/ (and every other server-level
+    // page) sees when the process runs multiple server modules. Without
+    // a Settings entry here, once a caller lands on a server-level page
+    // there's no primary-nav path back into /settings/. Same admittance
+    // as the per-subsystem sidebars: admin OR any settings-shell scope.
+    {
+      title: 'Settings',
+      href: '/settings/',
+      icon: <Settings />,
+      allowedRoles: ['admin'],
+      anyScopes: SettingsShellScopes,
+    },
   ],
 };
 

--- a/web_ui/frontend/app/settings/layout.tsx
+++ b/web_ui/frontend/app/settings/layout.tsx
@@ -22,6 +22,7 @@ import { PaddedContent } from '@/components/layout';
 import { Navigation } from '@/components/layout/Navigation';
 import SubNavigation from '@/app/settings/components/SubNavigation';
 import AuthenticatedContent from '@/components/layout/AuthenticatedContent';
+import { SettingsShellScopes } from '@/app/navigation';
 
 export const metadata = {
   title: {
@@ -43,12 +44,14 @@ export default function RootLayout({
           redirect
           trustThenValidate
           allowedRoles={['admin']}
-          // server.user_admin (granted directly or via group membership)
-          // also gets into the settings shell. Per-page gates below
-          // tighten back to system-admin where appropriate (AUP editor,
-          // API tokens, etc.). The Users sub-page is the headline use
-          // case; SubNavigation hides items the caller can't reach.
-          anyScopes={['server.user_admin']}
+          // Admits scope-only holders (server.user_admin for the Users
+          // sub-page, pelican.log_read for the Logs sub-page). Per-page
+          // gates below tighten back to system-admin where appropriate
+          // (AUP editor, API tokens, etc.); SubNavigation hides items
+          // the caller can't reach. The scope list is shared with the
+          // subsystem sidebars' "Settings" entries so both surfaces
+          // admit the same set.
+          anyScopes={SettingsShellScopes}
           boxProps={{ width: '100%' }}
         >
           <PaddedContent>

--- a/web_ui/frontend/app/settings/logs/components/LogViewer.tsx
+++ b/web_ui/frontend/app/settings/logs/components/LogViewer.tsx
@@ -1,0 +1,585 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+'use client';
+
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  FormControlLabel,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import DownloadIcon from '@mui/icons-material/Download';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import useSWR from 'swr';
+
+import { secureFetch } from '@/helpers/login';
+import { API_V1_BASE_URL } from '@/helpers/api/constants';
+
+// -----------------------------------------------------------------------------
+// Server payload shape -- one endpoint, two directions.
+//
+// The tail endpoint takes either ?since=<cursor> (forward polling / live
+// tail) or ?before=<cursor>&count=<n> (scroll-up into older history).
+// Cursors are opaque URL-safe base64 tokens: the client stores them as
+// strings, echoes them back, and never interprets or does arithmetic on
+// them. Reached is true when scroll-up has hit the wall.
+// -----------------------------------------------------------------------------
+
+interface LogTailResponse {
+  enabled: boolean;
+  content: string;
+  firstCursor: string;
+  lastCursor: string;
+  reached: boolean;
+  // instanceId identifies the server's buffer. It changes on restart;
+  // the viewer resets local state when it changes so cursors from a
+  // previous instance don't leak into requests against the new one.
+  instanceId: string;
+}
+
+// -----------------------------------------------------------------------------
+// Level filter -- keep in the fixed logrus order (panic..trace) so the chip
+// row reads left-to-right the way an operator expects.
+// -----------------------------------------------------------------------------
+
+const LOG_LEVELS = [
+  'panic',
+  'fatal',
+  'error',
+  'warning',
+  'info',
+  'debug',
+  'trace',
+];
+
+const LEVEL_COLORS: Record<string, string> = {
+  panic: '#ff5252',
+  fatal: '#ff5252',
+  error: '#ff8a80',
+  warning: '#ffb74d',
+  info: '#82b1ff',
+  // Debug and trace read as off-white on the dark panel so they stay
+  // legible without stealing focus from warning/error rows above.
+  debug: '#e0e0e0',
+  trace: '#bdbdbd',
+};
+
+// Regex that pulls the level token out of a formatted line. Logrus's
+// TextFormatter emits `level=<name>`; DisableColors on the server side
+// means no ANSI escapes to strip. A line with no level=... is treated as
+// "info" so continuation lines from stack traces don't get hidden by a
+// level filter.
+const LEVEL_REGEX = /\blevel=([a-z]+)\b/;
+
+function extractLevel(line: string): string {
+  const m = LEVEL_REGEX.exec(line);
+  if (!m) return 'info';
+  const raw = m[1];
+  // Logrus emits "warning" but many tools shorten to "warn"; normalize.
+  return raw === 'warn' ? 'warning' : raw;
+}
+
+// -----------------------------------------------------------------------------
+// LogViewer -- single-endpoint polling with an opaque cursor. State is
+// deliberately simple: a flat list of accumulated Lines plus the current
+// cursor/oldestSeq pair.
+// -----------------------------------------------------------------------------
+
+interface Line {
+  text: string;
+  level: string;
+  // Client-local monotonic id (assigned in arrival order) used for
+  // React keys and for eviction ordering. Unrelated to any server
+  // seq; the cursor is opaque to the client.
+  id: number;
+}
+
+const POLL_INTERVAL_MS = 2000;
+// Client-side memory cap on the accumulated log text. A very long-running
+// viewer session can otherwise keep growing local state indefinitely --
+// the server-side buffer is a small window, but the client has no such
+// cap unless we impose one. When we're over, we drop lines from the oldest
+// end until we're back under. The list is virtualized (see ROW_HEIGHT
+// below), so the DOM is bounded regardless of how many lines are retained;
+// this cap bounds only the JS-side memory held for scroll-back.
+const MAX_CLIENT_BYTES = 64 * 1024 * 1024;
+
+// Virtualization: only the rows visible in the viewport (plus a small
+// overscan) are mounted in the DOM. Rows are a fixed height so the total
+// scroll height is exactly rowCount * ROW_HEIGHT and off-screen rows are
+// replaced by top/bottom spacer divs. Without this, a busy server drives
+// the accumulated-line count into the hundreds of thousands and mounting
+// one DOM node per line freezes or OOMs the tab. ROW_HEIGHT must match the
+// per-row lineHeight set in the render below.
+const ROW_HEIGHT = 18;
+const OVERSCAN_ROWS = 30;
+
+// TAIL_LIMIT bounds each forward-poll response. The initial load (empty
+// cursor) is the primary reason: on a server configured with a large
+// buffer, an unbounded initial fetch could send tens of MB in one go.
+// With TAIL_LIMIT the viewer shows the newest N lines immediately;
+// older content is available on scroll-up. Steady-state polls are far
+// under this cap and remain full-fidelity deltas.
+const TAIL_LIMIT = 10000;
+
+async function fetchSince(cursor: string): Promise<LogTailResponse> {
+  const resp = await secureFetch(
+    `${API_V1_BASE_URL}/logs/tail?since=${encodeURIComponent(
+      cursor
+    )}&limit=${TAIL_LIMIT}`
+  );
+  if (!resp.ok) {
+    throw new Error(`log tail fetch failed: ${resp.status}`);
+  }
+  return await resp.json();
+}
+
+async function fetchBefore(
+  cursor: string,
+  count: number
+): Promise<LogTailResponse> {
+  const resp = await secureFetch(
+    `${API_V1_BASE_URL}/logs/tail?before=${encodeURIComponent(
+      cursor
+    )}&count=${encodeURIComponent(count.toString())}`
+  );
+  if (!resp.ok) {
+    throw new Error(`log tail fetch failed: ${resp.status}`);
+  }
+  return await resp.json();
+}
+
+// splitLines splits the server's raw content into per-line records,
+// assigning a client-local id from an increasing counter. The counter is
+// caller-owned so appends and prepends can share it without collision --
+// prepend uses IDs strictly below the smallest live id; append uses IDs
+// strictly above the largest.
+function splitLines(text: string, ids: () => number): Line[] {
+  const raw = text.split('\n').filter((l) => l.length > 0);
+  return raw.map((t) => ({
+    text: t,
+    level: extractLevel(t),
+    id: ids(),
+  }));
+}
+
+// Requested backlog per "load older" click. The server rounds up to whole
+// batches, so the client's count is only a lower bound -- keeping it small
+// means each scroll-up gesture consumes just one batch's worth of history.
+const OLDER_FETCH_COUNT = 100;
+
+// pruneToByteCap drops entries from the head of lines[] until the running
+// character total (a proxy for bytes -- accurate for ASCII log output)
+// fits within MAX_CLIENT_BYTES. Returns the input unchanged when already
+// under cap. Called after both appends (live tail) and prepends (scroll-up).
+function pruneToByteCap(lines: Line[]): Line[] {
+  let total = 0;
+  for (const line of lines) total += line.text.length + 1;
+  if (total <= MAX_CLIENT_BYTES) return lines;
+  let dropUntil = 0;
+  while (dropUntil < lines.length && total > MAX_CLIENT_BYTES) {
+    total -= lines[dropUntil].text.length + 1;
+    dropUntil++;
+  }
+  return lines.slice(dropUntil);
+}
+
+export default function LogViewer() {
+  const [lines, setLines] = useState<Line[]>([]);
+  const [selectedLevels, setSelectedLevels] = useState<string[]>(LOG_LEVELS);
+  const [textFilter, setTextFilter] = useState('');
+  const [autoScroll, setAutoScroll] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [enabled, setEnabled] = useState(true);
+  const [loadingOlder, setLoadingOlder] = useState(false);
+  const [reachedOldest, setReachedOldest] = useState(false);
+  // Virtualization viewport: the current scroll offset and the pane's pixel
+  // height drive which slice of lines is mounted. Updated on scroll and on
+  // resize.
+  const [viewport, setViewport] = useState({ scrollTop: 0, height: 0 });
+
+  // Cursors: opaque strings the server echoes back. sinceRef advances on
+  // every live-tail poll; beforeRef is anchored on first content and
+  // walks backwards each "load older" click.
+  const sinceRef = useRef<string>('');
+  const beforeRef = useRef<string>('');
+  // Client-local id counters: appendIdRef increments as new lines arrive
+  // via live tail; prependIdRef decrements as older lines arrive via
+  // scroll-up. The two never collide because they start on opposite
+  // sides of the same number line.
+  const appendIdRef = useRef<number>(0);
+  const prependIdRef = useRef<number>(0);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  // instanceIdRef tracks the server buffer we're talking to. A change
+  // indicates a restart -- our cursors are meaningless against the new
+  // buffer, so we clear local state before applying the response.
+  const instanceIdRef = useRef<string>('');
+
+  useSWR(
+    'log-viewer-tail',
+    async () => {
+      let resp: LogTailResponse;
+      try {
+        resp = await fetchSince(sinceRef.current);
+      } catch (e) {
+        setError((e as Error).message);
+        return null;
+      }
+      setError(null);
+      setEnabled(resp.enabled);
+      if (!resp.enabled) return resp;
+
+      // Restart detection: the buffer answering us is not the one we were
+      // reading. Everything held describes a server that is gone, so it is
+      // discarded here rather than by reloading the page -- the viewer
+      // picks the new server's log up on the following poll.
+      if (
+        instanceIdRef.current !== '' &&
+        resp.instanceId !== instanceIdRef.current
+      ) {
+        setLines([]);
+        beforeRef.current = '';
+        appendIdRef.current = 0;
+        prependIdRef.current = 0;
+        setReachedOldest(false);
+        // The cursor must go too. The server does not know a cursor
+        // belongs to a previous instance -- it only compares sequence
+        // numbers, and a restarted buffer numbers from the beginning
+        // again. A cursor carried across a restart is therefore ahead of
+        // everything the new buffer holds, so the server keeps returning
+        // nothing and echoing the cursor back, and the viewer stays empty
+        // for as long as it takes the new server to out-count the old
+        // one. Start from an empty cursor instead.
+        sinceRef.current = '';
+        instanceIdRef.current = resp.instanceId;
+        // This response was computed against a cursor that meant nothing
+        // to the server that answered; discard it and let the next poll
+        // load the new buffer from the start.
+        return resp;
+      }
+      instanceIdRef.current = resp.instanceId;
+
+      const fresh = splitLines(resp.content, () => ++appendIdRef.current);
+
+      if (fresh.length > 0) {
+        setLines((prev) => pruneToByteCap(prev.concat(fresh)));
+      }
+      sinceRef.current = resp.lastCursor;
+      // Anchor the "before" cursor to the earliest content the server
+      // gave us on the first response. Subsequent live-tail responses
+      // don't move it -- scroll-up walks it further back independently.
+      if (beforeRef.current === '' && fresh.length > 0) {
+        beforeRef.current = resp.firstCursor;
+      }
+      return resp;
+    },
+    { refreshInterval: POLL_INTERVAL_MS, revalidateOnFocus: true }
+  );
+
+  // Load-older: fetch a batch of lines before `beforeRef` and prepend
+  // them. Turns off auto-scroll for the duration of the scroll-up
+  // session so the incoming live-tail poll doesn't yank the viewport
+  // back to the bottom while the user is reading older content.
+  const loadOlder = useCallback(async () => {
+    if (loadingOlder || reachedOldest) return;
+    const before = beforeRef.current;
+    if (!before) return;
+    // Pin the instance we're paging within. If the server restarts (or a
+    // concurrent live-tail poll resets our state) while this fetch is in
+    // flight, the response belongs to a previous buffer instance and must be
+    // discarded rather than spliced into the freshly reset list.
+    const requestInstanceId = instanceIdRef.current;
+    setAutoScroll(false);
+    setLoadingOlder(true);
+    try {
+      const resp = await fetchBefore(before, OLDER_FETCH_COUNT);
+      if (!resp.enabled) {
+        setEnabled(false);
+        return;
+      }
+      if (
+        requestInstanceId !== '' &&
+        (resp.instanceId !== requestInstanceId ||
+          instanceIdRef.current !== requestInstanceId)
+      ) {
+        return;
+      }
+      const fresh = splitLines(resp.content, () => --prependIdRef.current);
+      if (fresh.length > 0) {
+        // Preserve scroll offset: remember the current geometry, then
+        // restore the scroll delta so the user's viewport doesn't jump.
+        const el = scrollRef.current;
+        const priorScrollHeight = el ? el.scrollHeight : 0;
+        const priorScrollTop = el ? el.scrollTop : 0;
+        setLines((prev) => pruneToByteCap(fresh.concat(prev)));
+        beforeRef.current = resp.firstCursor;
+        requestAnimationFrame(() => {
+          if (!el) return;
+          el.scrollTop = priorScrollTop + (el.scrollHeight - priorScrollHeight);
+        });
+      }
+      // Off-the-wall detection: server reports no history left.
+      if (resp.reached) {
+        setReachedOldest(true);
+      }
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoadingOlder(false);
+    }
+  }, [loadingOlder, reachedOldest]);
+
+  // Level counts across the accumulated buffer (not filtered) so chip
+  // labels can render "info (12,345)" alongside each option.
+  const levelCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const lvl of LOG_LEVELS) counts[lvl] = 0;
+    for (const line of lines)
+      counts[line.level] = (counts[line.level] || 0) + 1;
+    return counts;
+  }, [lines]);
+
+  const visibleLines = useMemo(() => {
+    const levelSet = new Set(selectedLevels);
+    const filter = textFilter.toLowerCase();
+    return lines.filter((line) => {
+      if (!levelSet.has(line.level)) return false;
+      if (filter && !line.text.toLowerCase().includes(filter)) return false;
+      return true;
+    });
+  }, [lines, selectedLevels, textFilter]);
+
+  // Measure the scroll pane so virtualization knows the viewport height.
+  // Runs on mount and on window resize.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const measure = () =>
+      setViewport((v) => ({ ...v, height: el.clientHeight }));
+    measure();
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+  }, []);
+
+  // Auto-scroll: pin to bottom whenever new content arrives, unless the
+  // user has scrolled up. Setting scrollTop fires onScroll, which refreshes
+  // the virtualization viewport so the bottom slice mounts.
+  useEffect(() => {
+    if (!autoScroll || !scrollRef.current) return;
+    const el = scrollRef.current;
+    el.scrollTop = el.scrollHeight;
+  }, [visibleLines, autoScroll]);
+
+  // Virtualization window: the contiguous slice of visibleLines currently
+  // mounted, with pixel spacers standing in for the rows above and below.
+  const rowCount = visibleLines.length;
+  const viewportHeight = viewport.height || 600;
+  const startIdx = Math.max(
+    0,
+    Math.floor(viewport.scrollTop / ROW_HEIGHT) - OVERSCAN_ROWS
+  );
+  const endIdx = Math.min(
+    rowCount,
+    Math.ceil((viewport.scrollTop + viewportHeight) / ROW_HEIGHT) +
+      OVERSCAN_ROWS
+  );
+  const topPad = startIdx * ROW_HEIGHT;
+  const bottomPad = Math.max(0, (rowCount - endIdx) * ROW_HEIGHT);
+  const windowLines = visibleLines.slice(startIdx, endIdx);
+
+  const onDownload = useCallback(() => {
+    window.location.assign(`${API_V1_BASE_URL}/logs/download`);
+  }, []);
+
+  const scrollToBottom = useCallback(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+    setAutoScroll(true);
+  }, []);
+
+  if (!enabled) {
+    return (
+      <Alert severity='info' sx={{ mt: 1 }}>
+        In-memory log capture is not yet available on this server. This is
+        normally a transient condition during startup; if it persists, confirm
+        the server finished initializing.
+      </Alert>
+    );
+  }
+
+  return (
+    <Box display='flex' flexDirection='column' gap={2} width='100%'>
+      {error && (
+        <Alert severity='warning' onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      <Stack
+        direction={{ xs: 'column', md: 'row' }}
+        spacing={2}
+        alignItems={{ md: 'center' }}
+      >
+        {/*
+          One chip per level, always in the fixed LOG_LEVELS order. Clicking
+          toggles that level in / out of the selected set.
+        */}
+        <Box display='flex' flexWrap='wrap' gap={0.75}>
+          {LOG_LEVELS.map((lvl) => {
+            const active = selectedLevels.includes(lvl);
+            const count = levelCounts[lvl] ?? 0;
+            return (
+              <Chip
+                key={lvl}
+                size='small'
+                clickable
+                onClick={() =>
+                  setSelectedLevels((prev) =>
+                    prev.includes(lvl)
+                      ? prev.filter((v) => v !== lvl)
+                      : [...prev, lvl]
+                  )
+                }
+                label={`${lvl} (${count.toLocaleString()})`}
+                sx={{
+                  backgroundColor: active
+                    ? LEVEL_COLORS[lvl] || '#616161'
+                    : 'transparent',
+                  color: active ? '#000' : 'text.secondary',
+                  border: `1px solid ${LEVEL_COLORS[lvl] || '#616161'}`,
+                  fontWeight: active ? 600 : 400,
+                }}
+              />
+            );
+          })}
+        </Box>
+
+        <TextField
+          size='small'
+          label='Text filter'
+          value={textFilter}
+          onChange={(e) => setTextFilter(e.target.value)}
+          sx={{ flexGrow: 1, minWidth: 220 }}
+        />
+
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={autoScroll}
+              onChange={(e) => setAutoScroll(e.target.checked)}
+            />
+          }
+          label='Auto-scroll'
+        />
+
+        <Button
+          variant='outlined'
+          size='small'
+          startIcon={<ArrowDownwardIcon />}
+          onClick={scrollToBottom}
+        >
+          Scroll to bottom
+        </Button>
+
+        <Button
+          variant='outlined'
+          startIcon={<DownloadIcon />}
+          onClick={onDownload}
+        >
+          Download .log.gz
+        </Button>
+      </Stack>
+
+      <Typography variant='body2' color='text.secondary'>
+        Showing {visibleLines.length.toLocaleString()} of{' '}
+        {lines.length.toLocaleString()} lines.
+        {loadingOlder && ' Loading older…'}
+        {reachedOldest && ' No more history.'}
+      </Typography>
+
+      <Box
+        ref={scrollRef}
+        sx={{
+          fontFamily: 'monospace',
+          fontSize: '0.8rem',
+          backgroundColor: '#101418',
+          color: '#e0e0e0',
+          padding: 1,
+          borderRadius: 1,
+          height: '60vh',
+          overflow: 'auto',
+        }}
+        onScroll={(e) => {
+          const el = e.currentTarget;
+          setViewport({ scrollTop: el.scrollTop, height: el.clientHeight });
+          const bottomGap = el.scrollHeight - el.scrollTop - el.clientHeight;
+          if (bottomGap > 20 && autoScroll) setAutoScroll(false);
+          if (bottomGap <= 20 && !autoScroll) setAutoScroll(true);
+          // Infinite scroll: when the user gets close to the top of the
+          // pane, fetch a chunk of older history. Concurrent fetches
+          // are blocked by the loadingOlder guard inside loadOlder, and
+          // the fetch is a no-op once reachedOldest is set. The 200 px
+          // threshold gives us headroom to load and restore scroll
+          // before the user actually hits scrollTop === 0.
+          if (el.scrollTop < 200) {
+            loadOlder();
+          }
+        }}
+      >
+        {/*
+          Virtualized rows: only windowLines are mounted; topPad/bottomPad
+          reserve the scroll height of the rows outside the viewport so the
+          scrollbar and scroll-offset math stay exact. Each row is fixed at
+          ROW_HEIGHT and keeps whiteSpace: 'pre' so long lines scroll
+          horizontally within the pane.
+        */}
+        <Box sx={{ height: topPad }} />
+        {windowLines.map((line) => (
+          <Box
+            key={line.id}
+            component='div'
+            sx={{
+              height: ROW_HEIGHT,
+              lineHeight: `${ROW_HEIGHT}px`,
+              whiteSpace: 'pre',
+              wordBreak: 'keep-all',
+              color: LEVEL_COLORS[line.level] || undefined,
+            }}
+          >
+            {line.text}
+          </Box>
+        ))}
+        <Box sx={{ height: bottomPad }} />
+      </Box>
+    </Box>
+  );
+}

--- a/web_ui/frontend/app/settings/logs/components/LogViewer.tsx
+++ b/web_ui/frontend/app/settings/logs/components/LogViewer.tsx
@@ -59,6 +59,10 @@ interface LogTailResponse {
   firstCursor: string;
   lastCursor: string;
   reached: boolean;
+  // Count of lines missing between our cursor and the start of `content`,
+  // evicted or trimmed before we asked for them. Non-zero means the
+  // content is not contiguous with what we already hold.
+  dropped: number;
   // instanceId identifies the server's buffer. It changes on restart;
   // the viewer resets local state when it changes so cursors from a
   // previous instance don't leak into requests against the new one.
@@ -120,6 +124,23 @@ interface Line {
   // React keys and for eviction ordering. Unrelated to any server
   // seq; the cursor is opaque to the client.
   id: number;
+  // Marks a placeholder standing in for lines the server dropped before
+  // this client could read them, rather than a line the server sent. It
+  // occupies a row so the break is visible where it happened; without it
+  // the lines on either side read as consecutive.
+  gap?: boolean;
+}
+
+// gapLine builds the placeholder shown where the server reported missing
+// lines.
+function gapLine(dropped: number, id: number): Line {
+  const plural = dropped === 1 ? 'line' : 'lines';
+  return {
+    text: `--- ${dropped.toLocaleString()} ${plural} dropped: the server's buffer filled faster than this view could read it ---`,
+    level: 'gap',
+    id,
+    gap: true,
+  };
 }
 
 const POLL_INTERVAL_MS = 2000;
@@ -287,8 +308,22 @@ export default function LogViewer() {
       }
       instanceIdRef.current = resp.instanceId;
 
+      // A reported gap is only meaningful once something is already on
+      // screen: on the very first load, and on the reset that follows a
+      // server restart, there is no earlier content for the missing lines
+      // to be missing from. Claim the marker's id before splitting the new
+      // content so ids stay in list order.
+      const gap =
+        resp.dropped > 0 && sinceRef.current !== ''
+          ? gapLine(resp.dropped, ++appendIdRef.current)
+          : null;
       const fresh = splitLines(resp.content, () => ++appendIdRef.current);
 
+      if (gap) {
+        setLines((prev) =>
+          prev.length > 0 ? pruneToByteCap(prev.concat(gap)) : prev
+        );
+      }
       if (fresh.length > 0) {
         setLines((prev) => pruneToByteCap(prev.concat(fresh)));
       }
@@ -362,8 +397,10 @@ export default function LogViewer() {
   const levelCounts = useMemo(() => {
     const counts: Record<string, number> = {};
     for (const lvl of LOG_LEVELS) counts[lvl] = 0;
-    for (const line of lines)
+    for (const line of lines) {
+      if (line.gap) continue;
       counts[line.level] = (counts[line.level] || 0) + 1;
+    }
     return counts;
   }, [lines]);
 
@@ -371,11 +408,26 @@ export default function LogViewer() {
     const levelSet = new Set(selectedLevels);
     const filter = textFilter.toLowerCase();
     return lines.filter((line) => {
+      // Gap markers are not log lines and carry no level; hiding one
+      // behind a level or text filter would restore the very illusion of
+      // contiguity it exists to break.
+      if (line.gap) return true;
       if (!levelSet.has(line.level)) return false;
       if (filter && !line.text.toLowerCase().includes(filter)) return false;
       return true;
     });
   }, [lines, selectedLevels, textFilter]);
+
+  // Gap markers occupy a row but are not log lines, so they are excluded
+  // from the counts an operator reads as "how much am I looking at".
+  const visibleLineCount = useMemo(
+    () => visibleLines.reduce((n, line) => n + (line.gap ? 0 : 1), 0),
+    [visibleLines]
+  );
+  const totalLineCount = useMemo(
+    () => lines.reduce((n, line) => n + (line.gap ? 0 : 1), 0),
+    [lines]
+  );
 
   // Measure the scroll pane so virtualization knows the viewport height.
   // Runs on mount and on window resize.
@@ -520,14 +572,18 @@ export default function LogViewer() {
       </Stack>
 
       <Typography variant='body2' color='text.secondary'>
-        Showing {visibleLines.length.toLocaleString()} of{' '}
-        {lines.length.toLocaleString()} lines.
+        Showing {visibleLineCount.toLocaleString()} of{' '}
+        {totalLineCount.toLocaleString()} lines.
         {loadingOlder && ' Loading older…'}
         {reachedOldest && ' No more history.'}
       </Typography>
 
       <Box
         ref={scrollRef}
+        // Stable hooks for the end-to-end suite. Scoping row assertions to
+        // the pane is what lets a test tell "filtered out" apart from
+        // "virtualized off-screen" -- a page-wide text query cannot.
+        data-testid='log-pane'
         sx={{
           fontFamily: 'monospace',
           fontSize: '0.8rem',
@@ -567,12 +623,17 @@ export default function LogViewer() {
           <Box
             key={line.id}
             component='div'
+            data-testid={line.gap ? 'log-gap' : 'log-row'}
             sx={{
               height: ROW_HEIGHT,
               lineHeight: `${ROW_HEIGHT}px`,
               whiteSpace: 'pre',
               wordBreak: 'keep-all',
-              color: LEVEL_COLORS[line.level] || undefined,
+              // A gap is a statement about the record rather than part of
+              // it, so it is styled to stand apart from every level colour.
+              ...(line.gap
+                ? { color: '#ffd54f', fontStyle: 'italic' }
+                : { color: LEVEL_COLORS[line.level] || undefined }),
             }}
           >
             {line.text}

--- a/web_ui/frontend/app/settings/logs/components/LogViewer.tsx
+++ b/web_ui/frontend/app/settings/logs/components/LogViewer.tsx
@@ -24,6 +24,7 @@ import {
   Button,
   Checkbox,
   Chip,
+  CircularProgress,
   FormControlLabel,
   Stack,
   TextField,
@@ -33,6 +34,7 @@ import DownloadIcon from '@mui/icons-material/Download';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import React, {
   useCallback,
+  useDeferredValue,
   useEffect,
   useMemo,
   useRef,
@@ -67,6 +69,11 @@ interface LogTailResponse {
   // the viewer resets local state when it changes so cursors from a
   // previous instance don't leak into requests against the new one.
   instanceId: string;
+  // RFC3339 stamps bracketing everything the server's buffer holds -- what a
+  // download would contain, which is more than this viewer has necessarily
+  // paged in. Absent when the buffer holds nothing datable.
+  bufferOldest?: string;
+  bufferNewest?: string;
 }
 
 // -----------------------------------------------------------------------------
@@ -111,6 +118,37 @@ function extractLevel(line: string): string {
   return raw === 'warn' ? 'warning' : raw;
 }
 
+// Logrus's TextFormatter leads every formatted line with the timestamp:
+// `time="2026-07-25T10:00:04Z" level=info msg="..."`. The value is quoted
+// whenever it contains characters logrus escapes (an RFC3339 stamp always
+// does), but the unquoted form is accepted too so a differently-configured
+// formatter still lines up.
+const TIME_PREFIX_REGEX = /^time=(?:"([^"]*)"|(\S+))\s*/;
+
+// extractStamp returns the leading timestamp as the server wrote it, or ''
+// for a line that has none (a stack trace's continuation lines, for
+// instance). It is kept only to date the buffer in the summary line; the row
+// itself renders the formatted line unchanged, timestamp included.
+function extractStamp(line: string): string {
+  const m = TIME_PREFIX_REGEX.exec(line);
+  if (!m) return '';
+  return m[1] ?? m[2] ?? '';
+}
+
+// formatStamp renders a stamp as a local "YYYY-MM-DD HH:MM", or '' if it
+// isn't a date this browser can parse -- an unparsable stamp should leave the
+// range blank rather than put "Invalid Date" in the summary.
+function formatStamp(stamp: string): string {
+  if (stamp === '') return '';
+  const d = new Date(stamp);
+  if (Number.isNaN(d.getTime())) return '';
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+    ` ${pad(d.getHours())}:${pad(d.getMinutes())}`
+  );
+}
+
 // -----------------------------------------------------------------------------
 // LogViewer -- single-endpoint polling with an opaque cursor. State is
 // deliberately simple: a flat list of accumulated Lines plus the current
@@ -120,6 +158,10 @@ function extractLevel(line: string): string {
 interface Line {
   text: string;
   level: string;
+  // The line's own timestamp, exactly as the server wrote it, or '' when the
+  // line carries none. Used to date the buffer in the summary line; see
+  // extractStamp.
+  stamp: string;
   // Client-local monotonic id (assigned in arrival order) used for
   // React keys and for eviction ordering. Unrelated to any server
   // seq; the cursor is opaque to the client.
@@ -135,9 +177,13 @@ interface Line {
 // lines.
 function gapLine(dropped: number, id: number): Line {
   const plural = dropped === 1 ? 'line' : 'lines';
+  const text = `--- ${dropped.toLocaleString()} ${plural} dropped: the server's buffer filled faster than this view could read it ---`;
   return {
-    text: `--- ${dropped.toLocaleString()} ${plural} dropped: the server's buffer filled faster than this view could read it ---`,
+    text,
     level: 'gap',
+    // A gap is not a record and has no time of its own, so it never dates
+    // the buffer.
+    stamp: '',
     id,
     gap: true,
   };
@@ -162,6 +208,40 @@ const MAX_CLIENT_BYTES = 64 * 1024 * 1024;
 // per-row lineHeight set in the render below.
 const ROW_HEIGHT = 18;
 const OVERSCAN_ROWS = 30;
+
+// Floor for the width of the row area, in pixels; see the width calculation
+// in the render for why the row area is sized explicitly at all.
+const CONTENT_MIN_WIDTH = 1600;
+
+// Fixed width of each level chip, in pixels, and the abbreviation that keeps
+// its label inside that width.
+//
+// This is load-bearing for the pane's width, not just for the toolbar's
+// tidiness. The chip label is `nowrap` (MUI clips and ellipsizes it rather
+// than wrapping), so a chip's min-content width is its whole label -- and the
+// settings shell puts this component in a MUI Grid item, whose `min-width` is
+// `auto`, so the item cannot be narrower than the min-content width of what
+// is inside it. A chip that grows from "info (2)" to "info (237,394)" therefore
+// widens the toolbar, overrides the Grid item's size percentage, and takes the
+// log pane's width with it. A fixed width plus a bounded label breaks that
+// chain: nothing in the toolbar changes size as the counts climb.
+const LEVEL_CHIP_WIDTH = 128;
+
+// formatCount abbreviates a level count so the chip label has a bounded
+// length: exact below a thousand, then "12k" / "1.2M". The precise figure is
+// in the chip's tooltip, and the summary line under the toolbar always
+// carries exact numbers.
+function formatCount(n: number): string {
+  if (n < 1000) return n.toString();
+  if (n < 1_000_000) return `${Math.round(n / 1000)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}
+
+// Slack, in characters, added to the widest line when sizing the row area.
+// Covers the occasional glyph that is not exactly one character advance wide
+// (a non-ASCII byte in a log message, say) so a line still cannot overrun the
+// width computed for it.
+const CONTENT_WIDTH_SLACK_CH = 4;
 
 // TAIL_LIMIT bounds each forward-poll response. The initial load (empty
 // cursor) is the primary reason: on a server configured with a large
@@ -208,6 +288,7 @@ function splitLines(text: string, ids: () => number): Line[] {
   return raw.map((t) => ({
     text: t,
     level: extractLevel(t),
+    stamp: extractStamp(t),
     id: ids(),
   }));
 }
@@ -235,13 +316,30 @@ function pruneToByteCap(lines: Line[]): Line[] {
 
 export default function LogViewer() {
   const [lines, setLines] = useState<Line[]>([]);
-  const [selectedLevels, setSelectedLevels] = useState<string[]>(LOG_LEVELS);
+  // null means "no level filter" -- every level is shown. It is a distinct
+  // state from an explicit selection that happens to list all seven levels,
+  // and the distinction is what lets the first click on a chip narrow to that
+  // level while a later click on an already-selected chip removes it. See
+  // onLevelClick.
+  const [selectedLevels, setSelectedLevels] = useState<string[] | null>(null);
   const [textFilter, setTextFilter] = useState('');
   const [autoScroll, setAutoScroll] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [enabled, setEnabled] = useState(true);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const [reachedOldest, setReachedOldest] = useState(false);
+  // Running total of lines the server reported dropped before this view
+  // could read them. Each one is marked in place by a gap row; the total is
+  // also summarized above the pane, because that is where an operator looks
+  // to find out whether the numbers they are reading are the whole story.
+  const [droppedTotal, setDroppedTotal] = useState(0);
+  // What the server's whole buffer spans, straight from the last poll -- the
+  // extent of a download, which is not something this viewer can work out from
+  // the lines it happens to hold. Reported under the download control.
+  const [bufferSpan, setBufferSpan] = useState<{
+    oldest: string;
+    newest: string;
+  } | null>(null);
   // Virtualization viewport: the current scroll offset and the pane's pixel
   // height drive which slice of lines is mounted. Updated on scroll and on
   // resize.
@@ -278,6 +376,15 @@ export default function LogViewer() {
       setEnabled(resp.enabled);
       if (!resp.enabled) return resp;
 
+      // Applies whatever the server just said its buffer spans, including
+      // across a restart: it describes the buffer that answered this poll, not
+      // the local state being reset below.
+      setBufferSpan(
+        resp.bufferOldest && resp.bufferNewest
+          ? { oldest: resp.bufferOldest, newest: resp.bufferNewest }
+          : null
+      );
+
       // Restart detection: the buffer answering us is not the one we were
       // reading. Everything held describes a server that is gone, so it is
       // discarded here rather than by reloading the page -- the viewer
@@ -291,6 +398,8 @@ export default function LogViewer() {
         appendIdRef.current = 0;
         prependIdRef.current = 0;
         setReachedOldest(false);
+        // The drop total described the previous instance's buffer.
+        setDroppedTotal(0);
         // The cursor must go too. The server does not know a cursor
         // belongs to a previous instance -- it only compares sequence
         // numbers, and a restarted buffer numbers from the beginning
@@ -323,6 +432,7 @@ export default function LogViewer() {
         setLines((prev) =>
           prev.length > 0 ? pruneToByteCap(prev.concat(gap)) : prev
         );
+        setDroppedTotal((prev) => prev + resp.dropped);
       }
       if (fresh.length > 0) {
         setLines((prev) => pruneToByteCap(prev.concat(fresh)));
@@ -404,19 +514,41 @@ export default function LogViewer() {
     return counts;
   }, [lines]);
 
+  // Filtering runs over every accumulated line, and the accumulated set
+  // reaches the hundreds of thousands on a busy server -- enough for one
+  // re-filter to cost long enough to feel. Deferring the filter inputs lets
+  // React paint the keystroke (and the "Filtering…" indicator) against the
+  // previous result first, then re-render with the new one at lower
+  // priority, so the controls never feel stuck. `filtering` is true exactly
+  // while the displayed rows are still the pre-change ones.
+  const deferredLevels = useDeferredValue(selectedLevels);
+  const deferredTextFilter = useDeferredValue(textFilter);
+  const filtering =
+    deferredLevels !== selectedLevels || deferredTextFilter !== textFilter;
+
   const visibleLines = useMemo(() => {
-    const levelSet = new Set(selectedLevels);
-    const filter = textFilter.toLowerCase();
+    // No selection means no level test at all, rather than a test against the
+    // seven levels in LOG_LEVELS. The difference matters for a line whose
+    // level is none of them -- `level=notice`, or whatever a library logging
+    // through Pelican emits -- which a whitelist would hide by default, with
+    // no chip on screen to turn it back on. The default view shows everything
+    // the server sent.
+    const levelSet = deferredLevels === null ? null : new Set(deferredLevels);
+    const filter = deferredTextFilter.toLowerCase();
     return lines.filter((line) => {
       // Gap markers are not log lines and carry no level; hiding one
       // behind a level or text filter would restore the very illusion of
       // contiguity it exists to break.
       if (line.gap) return true;
-      if (!levelSet.has(line.level)) return false;
+      if (levelSet && !levelSet.has(line.level)) return false;
+      // Matched against the line as the server formatted it, which is a
+      // superset of what the row displays: the timestamp moves to the
+      // gutter but is still on screen, so a match there is still a match
+      // the operator can see.
       if (filter && !line.text.toLowerCase().includes(filter)) return false;
       return true;
     });
-  }, [lines, selectedLevels, textFilter]);
+  }, [lines, deferredLevels, deferredTextFilter]);
 
   // Gap markers occupy a row but are not log lines, so they are excluded
   // from the counts an operator reads as "how much am I looking at".
@@ -428,6 +560,69 @@ export default function LogViewer() {
     () => lines.reduce((n, line) => n + (line.gap ? 0 : 1), 0),
     [lines]
   );
+
+  // The dates the buffer spans, for the right-hand end of the summary line:
+  // "which days am I looking at" is the other half of "how many lines am I
+  // looking at", and it is not otherwise answerable without scrolling to both
+  // ends of the pane.
+  //
+  // Just the two ends of lines[]: the list is in arrival order, so the first
+  // and last entry date the whole of it -- no scan. The only reason this is
+  // not literally lines[0] and lines[at(-1)] is that not every entry carries a
+  // timestamp: a stack trace's continuation lines don't, and neither do gap
+  // markers, so an end that has no date falls inward to the next line that
+  // does. In practice that stops on the first or second try.
+  //
+  // Both ends are always shown, to the minute: at this buffer size they are
+  // usually the same day, and the times are what distinguish them.
+  const dateRange = useMemo(() => {
+    let first = '';
+    for (const line of lines) {
+      first = formatStamp(line.stamp);
+      if (first !== '') break;
+    }
+    let last = '';
+    for (let i = lines.length - 1; i >= 0; i--) {
+      last = formatStamp(lines[i].stamp);
+      if (last !== '') break;
+    }
+    if (first === '' || last === '') return '';
+    return `${first} - ${last}`;
+  }, [lines]);
+
+  // Levels that get a chip: the ones actually present in what the viewer
+  // holds. A "panic (0)" chip is a control that can only ever empty the pane,
+  // and on a healthy server most of the row is those -- the levels that do
+  // have lines are what an operator is scanning for. A level still in the
+  // selection keeps its chip even at zero, so a selection is always
+  // explainable by the chips on screen (and can always be undone), which
+  // matters when a level's last line ages out of the buffer while it is
+  // selected.
+  // Levels outside LOG_LEVELS get a chip too, after the known ones: they are
+  // in the buffer and therefore on screen by default, so they need to be
+  // filterable like anything else.
+  const chipLevels = useMemo(() => {
+    const worthShowing = (lvl: string) =>
+      (levelCounts[lvl] ?? 0) > 0 || (selectedLevels?.includes(lvl) ?? false);
+    const known = LOG_LEVELS.filter(worthShowing);
+    const unknown = Object.keys(levelCounts)
+      .filter((lvl) => !LOG_LEVELS.includes(lvl) && worthShowing(lvl))
+      .sort();
+    return [...known, ...unknown];
+  }, [levelCounts, selectedLevels]);
+
+  // Character count of the longest line held, which is what the row area is
+  // sized from. Measured over everything accumulated rather than over the
+  // filtered or mounted subset on purpose: a width that depends on which
+  // rows are on screen is exactly the width that moves while you scroll.
+  const maxLineChars = useMemo(() => {
+    let max = 0;
+    for (const line of lines) {
+      const len = line.text.length;
+      if (len > max) max = len;
+    }
+    return max;
+  }, [lines]);
 
   // Measure the scroll pane so virtualization knows the viewport height.
   // Runs on mount and on window resize.
@@ -450,18 +645,43 @@ export default function LogViewer() {
     el.scrollTop = el.scrollHeight;
   }, [visibleLines, autoScroll]);
 
+  // Re-sync the stored scroll offset with the pane's real one whenever the
+  // number of rows changes. A filter that shortens the content makes the
+  // browser clamp scrollTop without firing a scroll event we listen for, so
+  // the state would otherwise stay stale until the user scrolled -- with
+  // auto-scroll off, that means an empty pane that never recovers on its
+  // own. Only writes when something actually moved, so this cannot loop.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setViewport((v) =>
+      v.scrollTop === el.scrollTop && v.height === el.clientHeight
+        ? v
+        : { scrollTop: el.scrollTop, height: el.clientHeight }
+    );
+  }, [visibleLines.length]);
+
   // Virtualization window: the contiguous slice of visibleLines currently
   // mounted, with pixel spacers standing in for the rows above and below.
   const rowCount = visibleLines.length;
   const viewportHeight = viewport.height || 600;
+  // The offset is clamped to what the filtered content can actually scroll
+  // to. Applying a filter shrinks the content, and the browser silently
+  // clamps the pane's real scrollTop to the new maximum -- but the offset
+  // this render works from is React state, still holding the pre-filter
+  // value. Left unclamped it puts the window past the end of the filtered
+  // list, so the pane renders no rows at all while the summary above it
+  // reports matches: the filter looks broken when it worked. The effect
+  // below re-syncs the state; this keeps the render in between correct.
+  const maxScrollTop = Math.max(0, rowCount * ROW_HEIGHT - viewportHeight);
+  const scrollTop = Math.min(viewport.scrollTop, maxScrollTop);
   const startIdx = Math.max(
     0,
-    Math.floor(viewport.scrollTop / ROW_HEIGHT) - OVERSCAN_ROWS
+    Math.floor(scrollTop / ROW_HEIGHT) - OVERSCAN_ROWS
   );
   const endIdx = Math.min(
     rowCount,
-    Math.ceil((viewport.scrollTop + viewportHeight) / ROW_HEIGHT) +
-      OVERSCAN_ROWS
+    Math.ceil((scrollTop + viewportHeight) / ROW_HEIGHT) + OVERSCAN_ROWS
   );
   const topPad = startIdx * ROW_HEIGHT;
   const bottomPad = Math.max(0, (rowCount - endIdx) * ROW_HEIGHT);
@@ -470,6 +690,40 @@ export default function LogViewer() {
   const onDownload = useCallback(() => {
     window.location.assign(`${API_V1_BASE_URL}/logs/download`);
   }, []);
+
+  // Chip click semantics. A plain click isolates: you get only the level you
+  // clicked, which is what clicking one item out of a row of them reads as.
+  // Clicking the level you are already isolated on is the way back to all
+  // levels. Holding a modifier keeps the old additive behaviour, for building
+  // up a combination like error+warning; that is the only way to reach a
+  // multi-level selection, and the only way to end up with none selected.
+  const onLevelClick = useCallback(
+    (lvl: string, additive: boolean) => {
+      setSelectedLevels((prev) => {
+        // Nothing filtered yet: narrow to the level clicked. Clicking one item
+        // out of a row of them reads as "show me this one".
+        if (prev === null) {
+          return additive ? chipLevels.filter((v) => v !== lvl) : [lvl];
+        }
+        // A filter is already active, so a level not in it is being added:
+        // error then warning gives error+warning, no modifier needed. The
+        // selection is rebuilt in chip order -- not LOG_LEVELS order, which
+        // would drop any level outside the seven known ones from a selection
+        // that already held it -- so it never depends on click order either.
+        if (!prev.includes(lvl)) {
+          const next = new Set(prev);
+          next.add(lvl);
+          return chipLevels.filter((v) => next.has(v));
+        }
+        // Clicking the last level still selected clears the filter -- the way
+        // back to everything. Under a modifier it deselects instead, which is
+        // the only route to a selection of nothing.
+        if (prev.length === 1 && !additive) return null;
+        return prev.filter((v) => v !== lvl);
+      });
+    },
+    [chipLevels]
+  );
 
   const scrollToBottom = useCallback(() => {
     if (scrollRef.current) {
@@ -488,40 +742,66 @@ export default function LogViewer() {
     );
   }
 
+  // The root carries minWidth: 0 so this component can never be the reason
+  // its container is wider than the container's own layout says it should be:
+  // everything inside is either wrappable, shrinkable, or a scroll container.
   return (
-    <Box display='flex' flexDirection='column' gap={2} width='100%'>
+    <Box
+      display='flex'
+      flexDirection='column'
+      gap={2}
+      width='100%'
+      minWidth={0}
+      id={'log-viewer'}
+    >
       {error && (
         <Alert severity='warning' onClose={() => setError(null)}>
           {error}
         </Alert>
       )}
 
+      {/*
+        Top row: everything that narrows what the pane shows -- the level chips
+        and the text filter.
+
+        flexWrap and the minWidth: 0 here and on the children below are the
+        other half of the fix described on LEVEL_CHIP_WIDTH: a row of controls
+        that refuses to wrap or shrink reports a large min-content width, and
+        the Grid item this component sits in (min-width: auto) then sizes
+        itself to that instead of to its own size percentage -- so the toolbar
+        would set the log pane's width. Allowed to wrap, it grows downwards
+        instead, which changes nothing horizontally.
+      */}
       <Stack
         direction={{ xs: 'column', md: 'row' }}
         spacing={2}
         alignItems={{ md: 'center' }}
+        flexWrap='wrap'
+        useFlexGap
+        sx={{ minWidth: 0 }}
       >
         {/*
-          One chip per level, always in the fixed LOG_LEVELS order. Clicking
-          toggles that level in / out of the selected set.
+          One chip per level present in the buffer, in the fixed LOG_LEVELS
+          order. See onLevelClick for what a click does, which the tooltip
+          advertises; and chipLevels for why a level with no lines has no chip.
         */}
-        <Box display='flex' flexWrap='wrap' gap={0.75}>
-          {LOG_LEVELS.map((lvl) => {
-            const active = selectedLevels.includes(lvl);
+        <Box display='flex' flexWrap='wrap' gap={0.75} minWidth={0}>
+          {chipLevels.map((lvl) => {
+            // A null selection means no level filter, so every chip reads as
+            // included.
+            const active =
+              selectedLevels === null || selectedLevels.includes(lvl);
             const count = levelCounts[lvl] ?? 0;
             return (
               <Chip
                 key={lvl}
                 size='small'
                 clickable
-                onClick={() =>
-                  setSelectedLevels((prev) =>
-                    prev.includes(lvl)
-                      ? prev.filter((v) => v !== lvl)
-                      : [...prev, lvl]
-                  )
+                title={`${count.toLocaleString()} ${lvl} lines held. Click to show only ${lvl}; click again for all levels; hold Ctrl/⌘ or Shift to add or remove one level at a time.`}
+                onClick={(e) =>
+                  onLevelClick(lvl, e.ctrlKey || e.metaKey || e.shiftKey)
                 }
-                label={`${lvl} (${count.toLocaleString()})`}
+                label={`${lvl} (${formatCount(count)})`}
                 sx={{
                   backgroundColor: active
                     ? LEVEL_COLORS[lvl] || '#616161'
@@ -529,6 +809,11 @@ export default function LogViewer() {
                   color: active ? '#000' : 'text.secondary',
                   border: `1px solid ${LEVEL_COLORS[lvl] || '#616161'}`,
                   fontWeight: active ? 600 : 400,
+                  // Fixed, not a floor: see LEVEL_CHIP_WIDTH. Tabular figures
+                  // keep the digits from jittering inside it.
+                  width: LEVEL_CHIP_WIDTH,
+                  flex: '0 0 auto',
+                  fontVariantNumeric: 'tabular-nums',
                 }}
               />
             );
@@ -540,9 +825,27 @@ export default function LogViewer() {
           label='Text filter'
           value={textFilter}
           onChange={(e) => setTextFilter(e.target.value)}
-          sx={{ flexGrow: 1, minWidth: 220 }}
+          // minWidth: 0 rather than a 220px floor: the floor is a min-content
+          // width the Grid item would have to honour, and this field is the
+          // widest thing in the row. flexBasis gives it the same comfortable
+          // size when there is room, without insisting on it when there
+          // isn't.
+          sx={{ flexGrow: 1, flexBasis: 220, minWidth: 0 }}
         />
+      </Stack>
 
+      {/*
+        Bottom row: the controls that act on the view rather than filter it.
+        Same wrap-and-shrink rules as the row above.
+      */}
+      <Stack
+        direction='row'
+        spacing={2}
+        alignItems='center'
+        flexWrap='wrap'
+        useFlexGap
+        sx={{ minWidth: 0 }}
+      >
         <FormControlLabel
           control={
             <Checkbox
@@ -562,21 +865,106 @@ export default function LogViewer() {
           Scroll to bottom
         </Button>
 
-        <Button
-          variant='outlined'
-          startIcon={<DownloadIcon />}
-          onClick={onDownload}
-        >
-          Download .log.gz
-        </Button>
+        {/*
+          The download covers the server's whole buffer, which is typically
+          more than this viewer has paged in, so its extent is reported from
+          what the server said rather than from the lines on screen -- an admin
+          deciding whether to download wants to know what is in the file, not
+          what happens to be in this tab. Absent until a poll has reported a
+          span, so the button never claims a range it doesn't have.
+        */}
+        <Stack spacing={0.25} minWidth={0}>
+          <Button
+            variant='outlined'
+            size='small'
+            startIcon={<DownloadIcon />}
+            onClick={onDownload}
+          >
+            Download Logs In Buffer
+          </Button>
+          {bufferSpan && (
+            <Typography
+              variant='caption'
+              color='text.secondary'
+              data-testid='log-download-span'
+              sx={{ fontVariantNumeric: 'tabular-nums' }}
+            >
+              Available: {formatStamp(bufferSpan.oldest)} -{' '}
+              {formatStamp(bufferSpan.newest)}
+            </Typography>
+          )}
+        </Stack>
       </Stack>
 
-      <Typography variant='body2' color='text.secondary'>
-        Showing {visibleLineCount.toLocaleString()} of{' '}
-        {totalLineCount.toLocaleString()} lines.
-        {loadingOlder && ' Loading older…'}
-        {reachedOldest && ' No more history.'}
-      </Typography>
+      {/*
+        The denominator names its own set. "of 237,394 lines" alone invites
+        the reading that the server has 237,394 lines to look at, when what
+        it counts is the lines this page has fetched and is still holding --
+        a window that starts when the page opens, grows as polls arrive and
+        as scroll-up pulls history in, and is trimmed from the oldest end at
+        MAX_CLIENT_BYTES. Lines the server dropped before this view could
+        read them were never part of it, so they are reported separately
+        rather than folded into a count of what is here to read.
+      */}
+      <Stack
+        direction='row'
+        spacing={1}
+        alignItems='center'
+        flexWrap='wrap'
+        useFlexGap
+        sx={{ minWidth: 0 }}
+      >
+        <Typography
+          variant='body2'
+          color='text.secondary'
+          data-testid='log-summary'
+          sx={{ fontVariantNumeric: 'tabular-nums' }}
+        >
+          Showing {visibleLineCount.toLocaleString()} of{' '}
+          {totalLineCount.toLocaleString()} lines held in this browser.
+          {droppedTotal > 0 &&
+            ` ${droppedTotal.toLocaleString()} dropped before this view could read them.`}
+          {loadingOlder && ' Loading older…'}
+          {reachedOldest && ' No more history.'}
+        </Typography>
+        {filtering && (
+          <Stack
+            direction='row'
+            spacing={0.75}
+            alignItems='center'
+            data-testid='log-filtering'
+          >
+            <CircularProgress size={12} thickness={6} />
+            <Typography variant='body2' color='text.secondary'>
+              Filtering…
+            </Typography>
+          </Stack>
+        )}
+
+        {/*
+          The span the buffer covers, right-justified on the same line: ml:auto
+          takes up all the free space to its left. Absent until something
+          dateable has arrived, so the label never appears with nothing after
+          it. nowrap keeps a range from breaking mid-timestamp -- the parent
+          wraps this whole span to its own line instead when the row is tight.
+        */}
+        {dateRange !== '' && (
+          <Typography
+            variant='body2'
+            color='text.secondary'
+            data-testid='log-range'
+            sx={{
+              ml: 'auto',
+              pl: 2,
+              textAlign: 'right',
+              whiteSpace: 'nowrap',
+              fontVariantNumeric: 'tabular-nums',
+            }}
+          >
+            Logs in time range: {dateRange}
+          </Typography>
+        )}
+      </Stack>
 
       <Box
         ref={scrollRef}
@@ -592,7 +980,18 @@ export default function LogViewer() {
           padding: 1,
           borderRadius: 1,
           height: '60vh',
+          // Explicit width plus minWidth: 0: the pane takes the width its
+          // container gives it and reports no opinion of its own upward. Being
+          // a scroll container, the rows inside it cannot reach past it
+          // either, however long they are.
+          width: '100%',
+          minWidth: 0,
           overflow: 'auto',
+          // Reserve the vertical scrollbar's width at all times. Without it
+          // the row area's usable width changes the moment the content
+          // becomes taller than the pane, re-wrapping nothing but shifting
+          // everything.
+          scrollbarGutter: 'stable',
         }}
         onScroll={(e) => {
           const el = e.currentTarget;
@@ -618,28 +1017,52 @@ export default function LogViewer() {
           ROW_HEIGHT and keeps whiteSpace: 'pre' so long lines scroll
           horizontally within the pane.
         */}
-        <Box sx={{ height: topPad }} />
-        {windowLines.map((line) => (
-          <Box
-            key={line.id}
-            component='div'
-            data-testid={line.gap ? 'log-gap' : 'log-row'}
-            sx={{
-              height: ROW_HEIGHT,
-              lineHeight: `${ROW_HEIGHT}px`,
-              whiteSpace: 'pre',
-              wordBreak: 'keep-all',
-              // A gap is a statement about the record rather than part of
-              // it, so it is styled to stand apart from every level colour.
-              ...(line.gap
-                ? { color: '#ffd54f', fontStyle: 'italic' }
-                : { color: LEVEL_COLORS[line.level] || undefined }),
-            }}
-          >
-            {line.text}
-          </Box>
-        ))}
-        <Box sx={{ height: bottomPad }} />
+        {/*
+          The row area is given an explicit width, wide enough for the longest
+          line held, so the pane's scrollable extent stops depending on which
+          rows happen to be mounted.
+
+          Neither `width: 100%` nor a `min-width` floor achieves that: rows are
+          `white-space: pre` and overrun their parent freely, so whichever long
+          line is on screen sets the extent and gives it back when it scrolls
+          out -- the horizontal scrollbar grows, shifts and disappears under
+          the content as the virtualization window moves.
+
+          Sizing in `ch` works here because the pane is monospace: one ch is
+          one character advance, so maxLineChars ch is the width of the longest
+          line. The floor keeps a nearly-empty buffer from rendering a narrow
+          pane; the `100%` term keeps a wider pane filled.
+        */}
+        <Box
+          sx={{
+            width: `max(100%, ${CONTENT_MIN_WIDTH}px, ${
+              maxLineChars + CONTENT_WIDTH_SLACK_CH
+            }ch)`,
+          }}
+        >
+          <Box sx={{ height: topPad }} />
+          {windowLines.map((line) => (
+            <Box
+              key={line.id}
+              component='div'
+              data-testid={line.gap ? 'log-gap' : 'log-row'}
+              sx={{
+                height: ROW_HEIGHT,
+                lineHeight: `${ROW_HEIGHT}px`,
+                whiteSpace: 'pre',
+                wordBreak: 'keep-all',
+                // A gap is a statement about the record rather than part of
+                // it, so it is styled to stand apart from every level colour.
+                ...(line.gap
+                  ? { color: '#ffd54f', fontStyle: 'italic' }
+                  : { color: LEVEL_COLORS[line.level] || undefined }),
+              }}
+            >
+              {line.text}
+            </Box>
+          ))}
+          <Box sx={{ height: bottomPad }} />
+        </Box>
       </Box>
     </Box>
   );

--- a/web_ui/frontend/app/settings/logs/page.tsx
+++ b/web_ui/frontend/app/settings/logs/page.tsx
@@ -1,0 +1,51 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+'use client';
+
+import { Box } from '@mui/material';
+
+import SettingHeader from '@/app/settings/components/SettingHeader';
+import AuthenticatedContent from '@/components/layout/AuthenticatedContent';
+import LogViewer from '@/app/settings/logs/components/LogViewer';
+
+// The log viewer is accessible to either a full server admin OR a caller
+// holding the dedicated pelican.log_read scope (typically granted via a
+// group to a triage-only user). The backend enforces the same union in
+// LogReadAuthHandler; keeping the client-side gate in sync avoids showing
+// a page that will immediately 403 on every fetch.
+export default function Page() {
+  return (
+    <AuthenticatedContent
+      redirect
+      allowedRoles={['admin']}
+      anyScopes={['pelican.log_read']}
+    >
+      <Box width={'100%'}>
+        <SettingHeader
+          title={'Server Logs'}
+          description={
+            'Live view of the most recent server log lines. Older lines ' +
+            'are dropped as new ones arrive.'
+          }
+        />
+        <LogViewer />
+      </Box>
+    </AuthenticatedContent>
+  );
+}

--- a/web_ui/frontend/app/settings/page.tsx
+++ b/web_ui/frontend/app/settings/page.tsx
@@ -19,31 +19,77 @@
 'use client';
 
 import { Box } from '@mui/material';
-import React, { useContext } from 'react';
+import React, { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import useSWR from 'swr';
 
-import { AlertDispatchContext } from '@/components/AlertProvider';
 import SettingHeader from '@/app/settings/components/SettingHeader';
 import { RestartBox } from '@/app/config/components';
 import AuthenticatedContent from '@/components/layout/AuthenticatedContent';
+import NavigationConfig, { SettingsShellScopes } from '@/app/navigation';
+import { getUser } from '@/helpers/login';
+import { hasScope } from '@/index';
+import { evaluateOrReturn } from '@/helpers/util';
 
-// Restart-server is a system-admin-only operation. The /settings
-// layout now admits user_admin too (so /settings/users is reachable),
-// so this page re-tightens to ['admin'] — without it a user-admin
-// would see a "Restart" button that 403s.
+// The default /settings/ page is the Restart Server surface, which is
+// system-admin-only. Users who reach the shell via a scope grant
+// (server.user_admin, pelican.log_read; see SettingsShellScopes) need
+// somewhere to land other than an "Insufficient privileges" card, so we
+// redirect them to the first sub-page they can actually reach.
 export default function Home() {
-  const dispatch = useContext(AlertDispatchContext);
+  const router = useRouter();
+  const { data: user } = useSWR('getUser', getUser);
 
+  useEffect(() => {
+    // Don't redirect until we know who the caller is. Admin gets the
+    // native restart page and stays put.
+    if (!user?.authenticated) return;
+    if (user.role === 'admin') return;
+
+    // Find the first settings-sidebar item the caller can reach that
+    // isn't /settings/ itself. Mirrors the visibility check
+    // SubNavigation uses so the redirect target always matches what
+    // the sidebar shows.
+    const target = NavigationConfig.settings.find((item) => {
+      if (!('href' in item)) return false;
+      const href = evaluateOrReturn(item.href);
+      if (href === '/settings/') return false;
+      if (!item.allowedRoles && !item.anyScopes) return true;
+      const roleOk =
+        !!item.allowedRoles &&
+        !!user.role &&
+        item.allowedRoles.includes(user.role);
+      const scopeOk =
+        !!item.anyScopes && item.anyScopes.some((s) => hasScope(user, s));
+      return roleOk || scopeOk;
+    });
+    if (target && 'href' in target) {
+      router.replace(evaluateOrReturn(target.href));
+    }
+  }, [user, router]);
+
+  // Admit everyone the shell admits so the redirect fires from inside
+  // the protected surface (instead of AuthenticatedContent showing
+  // "Insufficient privileges" for the split-second before the effect
+  // runs). Non-admins get an empty box while the effect resolves the
+  // redirect target; admins see the restart page as before.
   return (
-    <AuthenticatedContent redirect allowedRoles={['admin']}>
-      <Box width={'100%'}>
-        <SettingHeader
-          title={'Restart Server'}
-          description={
-            'Restarting the server will cause a temporary service outage, please use with caution.'
-          }
-        />
-        <RestartBox />
-      </Box>
+    <AuthenticatedContent
+      redirect
+      allowedRoles={['admin']}
+      anyScopes={SettingsShellScopes}
+    >
+      {user?.role === 'admin' && (
+        <Box width={'100%'}>
+          <SettingHeader
+            title={'Restart Server'}
+            description={
+              'Restarting the server will cause a temporary service outage, please use with caution.'
+            }
+          />
+          <RestartBox />
+        </Box>
+      )}
     </AuthenticatedContent>
   );
 }

--- a/web_ui/frontend/components/layout/Navigation/AppBar/AppBar.tsx
+++ b/web_ui/frontend/components/layout/Navigation/AppBar/AppBar.tsx
@@ -20,6 +20,7 @@ function ResponsiveAppBar({
   config,
   exportType,
   role,
+  scopes,
   topOffset = 0,
 }: NavigationProps) {
   const [navOpen, setNavOpen] = React.useState(false);
@@ -106,6 +107,7 @@ function ResponsiveAppBar({
             config={config}
             exportType={exportType}
             role={role}
+            scopes={scopes}
             onClose={() => setNavOpen(false)}
           />
         </Collapse>

--- a/web_ui/frontend/components/layout/Navigation/AppBar/BurgerMenu.tsx
+++ b/web_ui/frontend/components/layout/Navigation/AppBar/BurgerMenu.tsx
@@ -58,6 +58,7 @@ const BurgerMenu: React.FC<BurgerMenuProps> = ({
   config,
   exportType,
   role,
+  scopes,
   onClose,
 }) => {
   return (
@@ -133,6 +134,7 @@ const BurgerMenu: React.FC<BurgerMenuProps> = ({
             key={index}
             config={item}
             role={role}
+            scopes={scopes}
             exportType={exportType}
             onClose={onClose}
           />

--- a/web_ui/frontend/components/layout/Navigation/AppBar/NavigationItem.tsx
+++ b/web_ui/frontend/components/layout/Navigation/AppBar/NavigationItem.tsx
@@ -24,9 +24,21 @@ import {
 import { ExportRes } from '@/components/DataExportTable';
 import { evaluateOrReturn } from '@/helpers/util';
 
+// hasAnyMatchingScope returns true when the caller holds at least one of the
+// scopes an item lists in its anyScopes. Undefined on either side means "no
+// scope-based admittance", so we return false and let the role check decide.
+const hasAnyMatchingScope = (
+  itemScopes: string[] | undefined,
+  userScopes: string[] | undefined
+): boolean => {
+  if (!itemScopes || !userScopes) return false;
+  return itemScopes.some((s) => userScopes.includes(s));
+};
+
 export const NavigationItem = ({
   exportType,
   role,
+  scopes,
   config,
   onClose,
 }: { onClose: () => void } & NavigationItemProps) => {
@@ -36,10 +48,17 @@ export const NavigationItem = ({
   // /origin_ui/exports fetch is skipped for them), so a role-based
   // rejection has to be able to short-circuit before the exportType
   // skeleton branch below would otherwise sit forever.
+  //
+  // anyScopes: an item that admits scope holders in addition to a role
+  // (e.g. the log viewer is reachable via server.admin OR pelican.log_read)
+  // must NOT be hidden by a bare role mismatch when the caller does hold
+  // one of the listed scopes. Match the AuthenticatedContent gate so a
+  // user who can visit the page can also see it in the burger menu.
   if (
     config?.allowedRoles &&
     role !== undefined &&
-    !config.allowedRoles.includes(role)
+    !config.allowedRoles.includes(role) &&
+    !hasAnyMatchingScope(config?.anyScopes, scopes)
   ) {
     return null;
   }

--- a/web_ui/frontend/components/layout/Navigation/Navigation.tsx
+++ b/web_ui/frontend/components/layout/Navigation/Navigation.tsx
@@ -146,6 +146,7 @@ const Navigation = ({
           <Sidebar
             exportType={exports?.type}
             role={user?.role}
+            scopes={user?.scopes}
             config={config as StaticNavigationItemProps[]}
             topOffset={topOffset}
           />
@@ -158,6 +159,7 @@ const Navigation = ({
           <AppBar
             exportType={exports?.type}
             role={user?.role}
+            scopes={user?.scopes}
             config={config as StaticNavigationItemProps[]}
             topOffset={topOffset}
           />

--- a/web_ui/frontend/components/layout/Navigation/Navigation.tsx
+++ b/web_ui/frontend/components/layout/Navigation/Navigation.tsx
@@ -90,7 +90,7 @@ const Navigation = ({
   const topOffset = isAdmin ? ADMIN_BANNER_HEIGHT_PX : 0;
 
   return (
-    <>
+    <Box id={'navigation'}>
       {isAdmin && (
         <Box
           sx={{
@@ -128,14 +128,15 @@ const Navigation = ({
         </Box>
       )}
       <Box
+        id={'header'}
         sx={{
-          display: 'flex',
           flexDirection: { xs: 'column', md: 'row' },
           // Push *non-fixed* descendants below the banner. The
           // sidebar and burger drawer manage their own offset via
           // the topOffset prop because they're position: fixed and
           // don't honor parent padding.
           pt: `${topOffset}px`,
+          width: '100%',
         }}
       >
         <Box
@@ -166,7 +167,7 @@ const Navigation = ({
         </Box>
         {children}
       </Box>
-    </>
+    </Box>
   );
 };
 

--- a/web_ui/frontend/components/layout/Navigation/Sidebar/NavigationItem.tsx
+++ b/web_ui/frontend/components/layout/Navigation/Sidebar/NavigationItem.tsx
@@ -13,9 +13,21 @@ import { ExportRes } from '@/components/DataExportTable';
 import NavigationMenu from '@/components/layout/Navigation/Sidebar/Menu';
 import { evaluateOrReturn } from '@/helpers/util';
 
+// hasAnyMatchingScope returns true when the caller holds at least one of the
+// scopes an item lists in its anyScopes. Undefined on either side means "no
+// scope-based admittance", so we return false and let the role check decide.
+const hasAnyMatchingScope = (
+  itemScopes: string[] | undefined,
+  userScopes: string[] | undefined
+): boolean => {
+  if (!itemScopes || !userScopes) return false;
+  return itemScopes.some((s) => userScopes.includes(s));
+};
+
 export const NavigationItem = ({
   exportType,
   role,
+  scopes,
   config,
 }: NavigationItemProps) => {
   // Hard rejections first: when role or exportType are known and don't
@@ -24,10 +36,17 @@ export const NavigationItem = ({
   // /origin_ui/exports fetch is skipped for them), so a role-based
   // rejection has to be able to short-circuit before the exportType
   // skeleton branch below would otherwise sit forever.
+  //
+  // anyScopes: an item that admits scope holders in addition to a role
+  // (e.g. the log viewer is reachable via server.admin OR pelican.log_read)
+  // must NOT be hidden by a bare role mismatch when the caller does hold
+  // one of the listed scopes. Match the AuthenticatedContent gate so a
+  // user who can visit the page can also see it in the sidebar.
   if (
     config?.allowedRoles &&
     role !== undefined &&
-    !config.allowedRoles.includes(role)
+    !config.allowedRoles.includes(role) &&
+    !hasAnyMatchingScope(config?.anyScopes, scopes)
   ) {
     return null;
   }

--- a/web_ui/frontend/components/layout/Navigation/Sidebar/Sidebar.tsx
+++ b/web_ui/frontend/components/layout/Navigation/Sidebar/Sidebar.tsx
@@ -34,6 +34,7 @@ export const Sidebar = ({
   config,
   exportType,
   role,
+  scopes,
   topOffset = 0,
 }: NavigationProps) => {
   return (
@@ -79,6 +80,7 @@ export const Sidebar = ({
                     key={evaluateOrReturn(navItem.title)}
                     config={navItem}
                     role={role}
+                    scopes={scopes}
                     exportType={exportType}
                   />
                 );

--- a/web_ui/frontend/components/layout/Navigation/index.ts
+++ b/web_ui/frontend/components/layout/Navigation/index.ts
@@ -40,12 +40,17 @@ export type StaticNavigationParentItemProps = StaticNavigationBaseItemProps & {
 export type NavigationItemProps = {
   exportType?: ExportRes['type'];
   role?: User['role'];
+  // scopes carries the caller's effective scope set so nav items marked
+  // with anyScopes can override an otherwise role-based rejection. Empty /
+  // undefined means "no scope-based override is possible for this caller".
+  scopes?: string[];
   config: StaticNavigationItemProps;
 };
 
 export type NavigationProps = {
   exportType?: ExportRes['type'];
   role?: User['role'];
+  scopes?: string[];
   config: StaticNavigationItemProps[];
   // topOffset (px) is the vertical space reserved above the navigation
   // by an out-of-flow banner sitting at the top of the viewport (e.g.

--- a/web_ui/frontend/e2e/cache/logs.spec.ts
+++ b/web_ui/frontend/e2e/cache/logs.spec.ts
@@ -18,7 +18,9 @@
 
 import { test } from '@playwright/test';
 import { registerLogViewerTests } from '../shared_tests/logViewerTests';
+import { registerLogViewerAccessTests } from '../shared_tests/logViewerAccessTests';
 
 test.describe('Cache Server Logs', () => {
   registerLogViewerTests('./view/settings/logs/');
+  registerLogViewerAccessTests('./view/settings/logs/');
 });

--- a/web_ui/frontend/e2e/cache/logs.spec.ts
+++ b/web_ui/frontend/e2e/cache/logs.spec.ts
@@ -1,0 +1,24 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+import { test } from '@playwright/test';
+import { registerLogViewerTests } from '../shared_tests/logViewerTests';
+
+test.describe('Cache Server Logs', () => {
+  registerLogViewerTests('./view/settings/logs/');
+});

--- a/web_ui/frontend/e2e/mocks/api/v1.0/auth/whoami.ts
+++ b/web_ui/frontend/e2e/mocks/api/v1.0/auth/whoami.ts
@@ -1,0 +1,81 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+import { Page } from '@playwright/test';
+
+const WHOAMI_URL_PATTERN = '**/api/v1.0/auth/whoami**';
+
+export interface WhoamiOptions {
+  authenticated?: boolean;
+  user?: string;
+  /** 'admin' takes every role gate; 'user' relies on `scopes`. */
+  role?: 'admin' | 'user' | '';
+  /** Effective user-grantable scopes, as EffectiveScopesForIdentity emits. */
+  scopes?: string[];
+  displayName?: string;
+  requiresAup?: boolean;
+  aupVersion?: string;
+}
+
+/**
+ * Intercepts GET /api/v1.0/auth/whoami so a test can pin the caller's role
+ * and effective scope set, which is the only input every client-side access
+ * gate (AuthenticatedContent, SubNavigation, both NavigationItem copies)
+ * reads.
+ *
+ * The X-CSRF-Token response header is load-bearing, not decoration:
+ * helpers/login.ts stashes it in sessionStorage on the first whoami and
+ * secureFetch sends it on every subsequent API call. A whoami mock that
+ * omits it leaves the token null and the failures surface far from here.
+ */
+export async function mockWhoami(
+  page: Page,
+  {
+    authenticated = true,
+    user = 'e2e-user',
+    role = 'user',
+    scopes = [],
+    displayName,
+    requiresAup = false,
+    aupVersion,
+  }: WhoamiOptions = {}
+) {
+  await page.unroute(WHOAMI_URL_PATTERN);
+  await page.route(WHOAMI_URL_PATTERN, (route) => {
+    if (route.request().method() !== 'GET') {
+      route.continue();
+      return;
+    }
+    route.fulfill({
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': 'e2e-csrf-token',
+      },
+      body: JSON.stringify({
+        authenticated,
+        user: authenticated ? user : '',
+        role: authenticated ? role : '',
+        scopes,
+        displayName,
+        requires_aup: requiresAup,
+        aup_version: aupVersion,
+      }),
+    });
+  });
+}

--- a/web_ui/frontend/e2e/mocks/api/v1.0/logs/download.ts
+++ b/web_ui/frontend/e2e/mocks/api/v1.0/logs/download.ts
@@ -1,0 +1,70 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+import { gzipSync } from 'zlib';
+import { Page } from '@playwright/test';
+
+import { DEFAULT_LOG_LINES } from './tail';
+
+const DOWNLOAD_URL_PATTERN = '**/api/v1.0/logs/download**';
+
+/**
+ * Builds the filename web_ui.HandleLogTailDownload puts in the
+ * Content-Disposition header: the sanitized server hostname plus a UTC
+ * timestamp, so downloads from different servers or times don't collide.
+ */
+export function logDownloadFilename(host = 'e2e-server'): string {
+  const stamp = new Date()
+    .toISOString()
+    .replace(/[-:]/g, '')
+    .replace(/\.\d+Z$/, 'Z')
+    .replace('T', '-');
+  return `pelican-logs-${host}-${stamp}.log.gz`;
+}
+
+/**
+ * Intercepts GET /api/v1.0/logs/download and serves a gzip attachment.
+ *
+ * Without this the Download button navigates to the real server, so the
+ * only thing a test could assert was that the button exists. With it the
+ * browser performs an actual download and the filename contract is
+ * observable.
+ */
+export async function mockLogDownload(
+  page: Page,
+  lines: string[] = DEFAULT_LOG_LINES
+) {
+  await page.unroute(DOWNLOAD_URL_PATTERN);
+  await page.route(DOWNLOAD_URL_PATTERN, (route) => {
+    if (route.request().method() !== 'GET') {
+      route.continue();
+      return;
+    }
+    const body = gzipSync(
+      Buffer.from(lines.length > 0 ? lines.join('\n') + '\n' : '')
+    );
+    route.fulfill({
+      status: 200,
+      headers: {
+        'Content-Type': 'application/gzip',
+        'Content-Disposition': `attachment; filename="${logDownloadFilename()}"`,
+      },
+      body,
+    });
+  });
+}

--- a/web_ui/frontend/e2e/mocks/api/v1.0/logs/tail.ts
+++ b/web_ui/frontend/e2e/mocks/api/v1.0/logs/tail.ts
@@ -1,0 +1,140 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+import { Page } from '@playwright/test';
+
+// Mirrors web_ui.LogTailResponse (the JSON returned by GET
+// /api/v1.0/logs/tail). Kept local to the e2e suite so the tests don't
+// depend on the app's internal types.
+export interface LogTailResponse {
+  enabled: boolean;
+  content: string;
+  firstCursor: string;
+  lastCursor: string;
+  reached: boolean;
+  instanceId: string;
+}
+
+// Opaque cursor/instance markers. Their exact values don't matter to the
+// client (it only echoes them back); they just need to be stable within a
+// run so restart-detection in the viewer doesn't trip.
+const INSTANCE_ID = 'e2e-log-instance';
+const FIRST_CURSOR = 'e2e-first';
+const LAST_CURSOR = 'e2e-last';
+
+// A small, deterministic fixture spanning several log levels so the viewer's
+// level chips get non-trivial counts and text filtering has something to
+// match. Formatted the way logrus's TextFormatter emits (DisableColors on
+// the server), so the client's `level=<name>` extraction works unchanged.
+export const DEFAULT_LOG_LINES = [
+  'time="2026-07-25T10:00:00Z" level=info msg="Pelican origin started"',
+  'time="2026-07-25T10:00:01Z" level=warning msg="Disk space is running low"',
+  'time="2026-07-25T10:00:02Z" level=error msg="Failed to connect to backend storage"',
+  'time="2026-07-25T10:00:03Z" level=info msg="Recovered connection to backend storage"',
+];
+
+/**
+ * Intercepts GET /api/v1.0/logs/tail and serves a stable fixture.
+ *
+ * The viewer loads once with an empty `since` cursor and then polls forward
+ * every couple of seconds. To keep the rendered content stable across polls
+ * we return the full fixture only on the initial (empty-cursor) load; forward
+ * polls and scroll-up (`before=`) requests return no new content, so the four
+ * seeded lines stay put for the duration of the test.
+ *
+ * Pass an empty `lines` array to exercise a buffer that is enabled but empty.
+ */
+export async function mockLogTail(
+  page: Page,
+  lines: string[] = DEFAULT_LOG_LINES
+) {
+  const content = lines.length > 0 ? lines.join('\n') + '\n' : '';
+  await page.route('**/api/v1.0/logs/tail**', (route) => {
+    const req = route.request();
+    if (req.method() !== 'GET') {
+      route.continue();
+      return;
+    }
+    const url = new URL(req.url());
+    const since = url.searchParams.get('since');
+    const before = url.searchParams.get('before');
+
+    let body: LogTailResponse;
+    if (before !== null) {
+      // Scroll-up: the mock holds no history older than the initial load.
+      body = {
+        enabled: true,
+        content: '',
+        firstCursor: before,
+        lastCursor: before,
+        reached: true,
+        instanceId: INSTANCE_ID,
+      };
+    } else if (since) {
+      // Steady-state forward poll after the initial load: nothing new.
+      body = {
+        enabled: true,
+        content: '',
+        firstCursor: '',
+        lastCursor: since,
+        reached: false,
+        instanceId: INSTANCE_ID,
+      };
+    } else {
+      // Initial load: hand back the whole fixture.
+      body = {
+        enabled: true,
+        content,
+        firstCursor: FIRST_CURSOR,
+        lastCursor: LAST_CURSOR,
+        reached: false,
+        instanceId: INSTANCE_ID,
+      };
+    }
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    });
+  });
+}
+
+/**
+ * Intercepts GET /api/v1.0/logs/tail and reports the buffer as disabled,
+ * so the viewer renders its "not available" notice instead of a log pane.
+ */
+export async function mockLogTailDisabled(page: Page) {
+  await page.route('**/api/v1.0/logs/tail**', (route) => {
+    if (route.request().method() !== 'GET') {
+      route.continue();
+      return;
+    }
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        enabled: false,
+        content: '',
+        firstCursor: '',
+        lastCursor: '',
+        reached: false,
+        instanceId: '',
+      } satisfies LogTailResponse),
+    });
+  });
+}

--- a/web_ui/frontend/e2e/mocks/api/v1.0/logs/tail.ts
+++ b/web_ui/frontend/e2e/mocks/api/v1.0/logs/tail.ts
@@ -92,10 +92,12 @@ export function parseLogCursor(raw: string | null): number {
 class MockLogBuffer {
   private lines: string[];
   private firstSeq: number;
+  private readonly instanceId: string;
 
-  constructor(lines: string[], firstSeq = 1) {
+  constructor(lines: string[], firstSeq = 1, instanceId = INSTANCE_ID) {
     this.lines = [...lines];
     this.firstSeq = firstSeq;
+    this.instanceId = instanceId;
   }
 
   append(lines: string[]) {
@@ -159,7 +161,7 @@ class MockLogBuffer {
       // The forward tail never runs off the end of history.
       reached: false,
       dropped,
-      instanceId: INSTANCE_ID,
+      instanceId: this.instanceId,
     };
   }
 
@@ -193,7 +195,7 @@ class MockLogBuffer {
       // `dropped` describes the forward tail only; scroll-up reports the
       // wall through `reached`.
       dropped: 0,
-      instanceId: INSTANCE_ID,
+      instanceId: this.instanceId,
     };
   }
 }
@@ -446,5 +448,33 @@ export async function mockLogTailDisabled(page: Page) {
       dropped: 0,
       instanceId: '',
     } satisfies LogTailResponse);
+  });
+}
+
+export interface LogTailRestartOptions {
+  /** Buffer contents before the restart. */
+  initial?: string[];
+  /** Buffer contents the restarted server reports. */
+  afterRestart?: string[];
+}
+
+/**
+ * Intercepts GET /api/v1.0/logs/tail and swaps in a different buffer, with a
+ * different instanceId, on the first forward poll -- what a client sees when
+ * the server it is tailing restarts. The cursors it holds refer to a buffer
+ * that no longer exists, so it has to discard them along with the lines they
+ * describe rather than stitch the two servers' output together.
+ */
+export async function mockLogTailRestarting(
+  page: Page,
+  { initial = DEFAULT_LOG_LINES, afterRestart = [] }: LogTailRestartOptions = {}
+) {
+  const before = new MockLogBuffer(initial);
+  const after = new MockLogBuffer(afterRestart, 1, INSTANCE_ID + '-restarted');
+  let requests = 0;
+  await routeTail(page, (route, url) => {
+    requests++;
+    const isForwardPoll = url.searchParams.get('before') === null;
+    serveTail(route, url, isForwardPoll && requests > 1 ? after : before);
   });
 }

--- a/web_ui/frontend/e2e/mocks/api/v1.0/logs/tail.ts
+++ b/web_ui/frontend/e2e/mocks/api/v1.0/logs/tail.ts
@@ -16,7 +16,7 @@
  *
  ***************************************************************/
 
-import { Page } from '@playwright/test';
+import { Page, Route } from '@playwright/test';
 
 // Mirrors web_ui.LogTailResponse (the JSON returned by GET
 // /api/v1.0/logs/tail). Kept local to the e2e suite so the tests don't
@@ -27,15 +27,183 @@ export interface LogTailResponse {
   firstCursor: string;
   lastCursor: string;
   reached: boolean;
+  dropped: number;
   instanceId: string;
 }
 
-// Opaque cursor/instance markers. Their exact values don't matter to the
-// client (it only echoes them back); they just need to be stable within a
-// run so restart-detection in the viewer doesn't trip.
+const TAIL_URL_PATTERN = '**/api/v1.0/logs/tail**';
+
+// Opaque instance marker. Its exact value doesn't matter to the client (it
+// only compares it against the previous response); it just needs to be
+// stable within a run so restart-detection in the viewer doesn't trip.
 const INSTANCE_ID = 'e2e-log-instance';
-const FIRST_CURSOR = 'e2e-first';
-const LAST_CURSOR = 'e2e-last';
+
+// The `limit=` the viewer sends on every forward poll (LogViewer's
+// TAIL_LIMIT). Fixtures larger than this get their initial load truncated
+// by the server-side limit rule, which is the only way real scroll-up
+// history exists.
+export const CLIENT_TAIL_LIMIT = 10000;
+
+// What the server substitutes when a before= request omits count=. The
+// viewer always sends one, so this only covers hand-built requests.
+const DEFAULT_BEFORE_COUNT = 100;
+
+/**
+ * Encodes a seq the way web_ui.logTailCursor does: seq 0 is the empty
+ * string ("give me everything"), every other seq is the RawURLEncoding
+ * base64 of its 8-byte big-endian representation. Tests never need to read
+ * a cursor, but producing the real wire shape means a client that started
+ * parsing (rather than echoing) cursors would fail here the same way it
+ * fails against a real server.
+ */
+export function logCursor(seq: number): string {
+  if (seq <= 0) return '';
+  const buf = Buffer.alloc(8);
+  buf.writeBigUInt64BE(BigInt(seq));
+  return buf.toString('base64url');
+}
+
+/** Inverse of logCursor; mirrors web_ui.parseLogTailCursor. */
+export function parseLogCursor(raw: string | null): number {
+  if (!raw) return 0;
+  const buf = Buffer.from(raw, 'base64url');
+  if (buf.length !== 8) return 0;
+  return Number(buf.readBigUInt64BE());
+}
+
+/**
+ * An in-memory stand-in for config.LogRingBuffer that reproduces the
+ * TailSince / TailBefore semantics the Go implementation actually has:
+ *
+ *   - Every held line carries a monotonic seq; `lines[i]` is seq
+ *     `firstSeq + i`.
+ *   - TailSince returns lines with seq > since, then drops the OLDEST
+ *     lines when the delta exceeds `limit`. With nothing new to send it
+ *     still reports firstCursor == lastCursor == the caller's cursor,
+ *     which is NOT the empty string once the client has polled once.
+ *   - TailBefore returns lines with seq < before and can report content
+ *     and `reached` in the same response -- that is the response shape a
+ *     viewer sees on the last scroll-up before history runs out.
+ *
+ * The one deliberate simplification: the real server rounds `count` up to
+ * whole compressed batches, so it may return more than asked. The client
+ * treats count as a lower bound either way.
+ */
+class MockLogBuffer {
+  private lines: string[];
+  private firstSeq: number;
+
+  constructor(lines: string[], firstSeq = 1) {
+    this.lines = [...lines];
+    this.firstSeq = firstSeq;
+  }
+
+  append(lines: string[]) {
+    this.lines.push(...lines);
+  }
+
+  /**
+   * Drops the oldest `n` lines, advancing firstSeq past them, the way the
+   * real buffer's eviction does. Seqs are never reused, which is what lets
+   * a caller's stale cursor be recognized as pointing below the wall.
+   */
+  evictOldest(n: number) {
+    const removed = this.lines.splice(0, n);
+    this.firstSeq += removed.length;
+  }
+
+  private get oldestSeq(): number {
+    return this.lines.length > 0 ? this.firstSeq : 0;
+  }
+
+  private get newestSeq(): number {
+    return this.lines.length > 0 ? this.firstSeq + this.lines.length - 1 : 0;
+  }
+
+  tailSince(since: number, limit: number): LogTailResponse {
+    const newest = this.newestSeq;
+    const startIdx = Math.max(
+      0,
+      Math.min(this.lines.length, since - this.firstSeq + 1)
+    );
+    let selected = this.lines.slice(startIdx);
+    let firstSeqInContent = selected.length > 0 ? this.firstSeq + startIdx : -1;
+
+    // Lines the caller's cursor covered that are no longer held: they were
+    // evicted before the caller came back for them.
+    let dropped = 0;
+    if (since > 0 && this.oldestSeq > since + 1) {
+      dropped = this.oldestSeq - since - 1;
+    }
+
+    // limit keeps only the newest `limit` lines of the delta, advancing the
+    // first cursor past the lines it dropped. Those are still reachable
+    // through TailBefore, but they are a gap in this response all the same.
+    if (limit > 0 && firstSeqInContent >= 0) {
+      const totalLines = newest - firstSeqInContent + 1;
+      if (totalLines > limit) {
+        const drop = totalLines - limit;
+        selected = selected.slice(drop);
+        firstSeqInContent += drop;
+        dropped += drop;
+      }
+    }
+
+    return {
+      enabled: true,
+      content: joinLines(selected),
+      firstCursor: logCursor(
+        firstSeqInContent >= 0 ? firstSeqInContent : since
+      ),
+      lastCursor: logCursor(newest > since ? newest : since),
+      // The forward tail never runs off the end of history.
+      reached: false,
+      dropped,
+      instanceId: INSTANCE_ID,
+    };
+  }
+
+  tailBefore(before: number, count: number): LogTailResponse {
+    const effectiveCount = count > 0 ? count : DEFAULT_BEFORE_COUNT;
+    const oldestHeld = this.oldestSeq;
+    const endIdx = Math.max(
+      0,
+      Math.min(this.lines.length, before - this.firstSeq)
+    );
+    const startIdx = Math.max(0, endIdx - effectiveCount);
+    const selected = this.lines.slice(startIdx, endIdx);
+
+    let firstSeqOut = before;
+    let lastSeqOut = before;
+    // A cursor already at (or below) the wall means history is exhausted
+    // even before we return anything.
+    let reached = before <= oldestHeld;
+    if (selected.length > 0) {
+      firstSeqOut = this.firstSeq + startIdx;
+      lastSeqOut = this.firstSeq + endIdx - 1;
+      reached = firstSeqOut <= oldestHeld;
+    }
+
+    return {
+      enabled: true,
+      content: joinLines(selected),
+      firstCursor: logCursor(firstSeqOut),
+      lastCursor: logCursor(lastSeqOut),
+      reached,
+      // `dropped` describes the forward tail only; scroll-up reports the
+      // wall through `reached`.
+      dropped: 0,
+      instanceId: INSTANCE_ID,
+    };
+  }
+}
+
+// Log content on the wire is newline-TERMINATED, not newline-separated:
+// logrus writes a trailing newline on every entry and the buffer stores
+// the bytes verbatim.
+function joinLines(lines: string[]): string {
+  return lines.length > 0 ? lines.join('\n') + '\n' : '';
+}
 
 // A small, deterministic fixture spanning several log levels so the viewer's
 // level chips get non-trivial counts and text filtering has something to
@@ -49,13 +217,82 @@ export const DEFAULT_LOG_LINES = [
 ];
 
 /**
- * Intercepts GET /api/v1.0/logs/tail and serves a stable fixture.
- *
- * The viewer loads once with an empty `since` cursor and then polls forward
- * every couple of seconds. To keep the rendered content stable across polls
- * we return the full fixture only on the initial (empty-cursor) load; forward
- * polls and scroll-up (`before=`) requests return no new content, so the four
- * seeded lines stay put for the duration of the test.
+ * Builds `count` distinct info-level lines in the server's wire format.
+ * Used by the fixtures that have to be larger than the viewer's own
+ * TAIL_LIMIT (virtualization, scroll-up history).
+ */
+export function makeLogLines(count: number, startIndex = 1): string[] {
+  const lines: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const n = startIndex + i;
+    lines.push(
+      `time="2026-07-25T11:00:00Z" level=info msg="e2e generated log line ${n}"`
+    );
+  }
+  return lines;
+}
+
+/**
+ * Registers a GET handler on the tail endpoint, replacing any handler a
+ * previous call left behind so re-mocking inside a test is deterministic
+ * rather than dependent on route-stacking order.
+ */
+async function routeTail(
+  page: Page,
+  handler: (route: Route, url: URL) => void
+) {
+  await page.unroute(TAIL_URL_PATTERN);
+  await page.route(TAIL_URL_PATTERN, (route) => {
+    const req = route.request();
+    if (req.method() !== 'GET') {
+      route.continue();
+      return;
+    }
+    handler(route, new URL(req.url()));
+  });
+}
+
+function fulfillJson(route: Route, status: number, body: unknown) {
+  route.fulfill({
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  });
+}
+
+// Dispatches one request against the buffer exactly as HandleLogTail does:
+// before= wins over since=, and each direction reads its own count/limit.
+function serveTail(route: Route, url: URL, buffer: MockLogBuffer) {
+  const before = url.searchParams.get('before');
+  if (before !== null) {
+    const count = Number(url.searchParams.get('count') ?? '0');
+    fulfillJson(
+      route,
+      200,
+      buffer.tailBefore(
+        parseLogCursor(before),
+        Number.isFinite(count) ? count : 0
+      )
+    );
+    return;
+  }
+  const limit = Number(url.searchParams.get('limit') ?? '0');
+  fulfillJson(
+    route,
+    200,
+    buffer.tailSince(
+      parseLogCursor(url.searchParams.get('since')),
+      Number.isFinite(limit) ? limit : 0
+    )
+  );
+}
+
+/**
+ * Intercepts GET /api/v1.0/logs/tail and serves a fixed set of lines from a
+ * faithful buffer: the initial (empty-cursor) load returns the newest
+ * `limit` lines, forward polls return only what arrived since the caller's
+ * cursor (nothing, here), and scroll-up walks backwards through whatever
+ * the initial load's limit truncated away.
  *
  * Pass an empty `lines` array to exercise a buffer that is enabled but empty.
  */
@@ -63,53 +300,133 @@ export async function mockLogTail(
   page: Page,
   lines: string[] = DEFAULT_LOG_LINES
 ) {
-  const content = lines.length > 0 ? lines.join('\n') + '\n' : '';
-  await page.route('**/api/v1.0/logs/tail**', (route) => {
-    const req = route.request();
-    if (req.method() !== 'GET') {
-      route.continue();
+  const buffer = new MockLogBuffer(lines);
+  await routeTail(page, (route, url) => serveTail(route, url, buffer));
+}
+
+export interface LogTailStreamOptions {
+  /** Lines already in the buffer when the viewer first loads. */
+  initial?: string[];
+  /**
+   * One batch of new lines per forward poll, in order. Once exhausted,
+   * further polls report nothing new.
+   */
+  batches?: string[][];
+}
+
+/**
+ * Intercepts GET /api/v1.0/logs/tail and grows the buffer as the viewer
+ * polls: the Nth forward poll after the initial load publishes
+ * `batches[N-1]`. This is what makes the live-tail accumulate-and-advance
+ * loop observable -- a mock that only answers the initial load cannot tell
+ * a working cursor handoff from a broken one.
+ */
+export async function mockLogTailStreaming(
+  page: Page,
+  { initial = DEFAULT_LOG_LINES, batches = [] }: LogTailStreamOptions = {}
+) {
+  const buffer = new MockLogBuffer(initial);
+  let requests = 0;
+  let delivered = 0;
+  await routeTail(page, (route, url) => {
+    requests++;
+    const isForwardPoll = url.searchParams.get('before') === null;
+    if (isForwardPoll && requests > 1 && delivered < batches.length) {
+      buffer.append(batches[delivered++]);
+    }
+    serveTail(route, url, buffer);
+  });
+}
+
+export interface LogTailEvictionOptions {
+  /** Buffer contents served on the initial load. */
+  initial?: string[];
+  /** Lines appended on the poll that also evicts. */
+  arriving?: string[];
+  /** How many of the oldest lines the buffer drops on that poll. */
+  evict?: number;
+}
+
+/**
+ * Intercepts GET /api/v1.0/logs/tail and, on the first forward poll,
+ * appends new lines while evicting older ones out from under the client's
+ * cursor -- what a real buffer does when the server logs faster than the
+ * viewer polls. The response then reports a non-zero `dropped`, which is
+ * the only signal the client has that its view is no longer contiguous.
+ */
+export async function mockLogTailEvicting(
+  page: Page,
+  {
+    initial = DEFAULT_LOG_LINES,
+    arriving = [],
+    evict = 0,
+  }: LogTailEvictionOptions = {}
+) {
+  const buffer = new MockLogBuffer(initial);
+  let requests = 0;
+  let evicted = false;
+  await routeTail(page, (route, url) => {
+    requests++;
+    const isForwardPoll = url.searchParams.get('before') === null;
+    if (isForwardPoll && requests > 1 && !evicted) {
+      evicted = true;
+      buffer.append(arriving);
+      buffer.evictOldest(evict);
+    }
+    serveTail(route, url, buffer);
+  });
+}
+
+export interface LogTailFailureOptions {
+  /** Buffer contents served by the requests that do succeed. */
+  lines?: string[];
+  /** Number of leading requests served normally before failures start. */
+  failAfter?: number;
+  /** How many consecutive requests fail; omit for "never recovers". */
+  failCount?: number;
+  /** HTTP status served while failing. */
+  status?: number;
+}
+
+/**
+ * Intercepts GET /api/v1.0/logs/tail and injects a window of failing
+ * responses, so a test can watch the viewer surface the error, hold on to
+ * the lines it already has, and recover when polling succeeds again.
+ */
+export async function mockLogTailFailing(
+  page: Page,
+  {
+    lines = DEFAULT_LOG_LINES,
+    failAfter = 1,
+    failCount = Number.MAX_SAFE_INTEGER,
+    status = 500,
+  }: LogTailFailureOptions = {}
+) {
+  const buffer = new MockLogBuffer(lines);
+  let requests = 0;
+  await routeTail(page, (route, url) => {
+    requests++;
+    if (requests > failAfter && requests <= failAfter + failCount) {
+      fulfillJson(route, status, {
+        status: 'error',
+        msg: 'log buffer temporarily unavailable',
+      });
       return;
     }
-    const url = new URL(req.url());
-    const since = url.searchParams.get('since');
-    const before = url.searchParams.get('before');
+    serveTail(route, url, buffer);
+  });
+}
 
-    let body: LogTailResponse;
-    if (before !== null) {
-      // Scroll-up: the mock holds no history older than the initial load.
-      body = {
-        enabled: true,
-        content: '',
-        firstCursor: before,
-        lastCursor: before,
-        reached: true,
-        instanceId: INSTANCE_ID,
-      };
-    } else if (since) {
-      // Steady-state forward poll after the initial load: nothing new.
-      body = {
-        enabled: true,
-        content: '',
-        firstCursor: '',
-        lastCursor: since,
-        reached: false,
-        instanceId: INSTANCE_ID,
-      };
-    } else {
-      // Initial load: hand back the whole fixture.
-      body = {
-        enabled: true,
-        content,
-        firstCursor: FIRST_CURSOR,
-        lastCursor: LAST_CURSOR,
-        reached: false,
-        instanceId: INSTANCE_ID,
-      };
-    }
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(body),
+/**
+ * Intercepts GET /api/v1.0/logs/tail and answers the way
+ * LogReadAuthHandler does for a caller without server.admin or
+ * pelican.log_read.
+ */
+export async function mockLogTailForbidden(page: Page) {
+  await routeTail(page, (route) => {
+    fulfillJson(route, 403, {
+      status: 'error',
+      msg: 'You do not have permission to read server logs',
     });
   });
 }
@@ -119,22 +436,15 @@ export async function mockLogTail(
  * so the viewer renders its "not available" notice instead of a log pane.
  */
 export async function mockLogTailDisabled(page: Page) {
-  await page.route('**/api/v1.0/logs/tail**', (route) => {
-    if (route.request().method() !== 'GET') {
-      route.continue();
-      return;
-    }
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        enabled: false,
-        content: '',
-        firstCursor: '',
-        lastCursor: '',
-        reached: false,
-        instanceId: '',
-      } satisfies LogTailResponse),
-    });
+  await routeTail(page, (route) => {
+    fulfillJson(route, 200, {
+      enabled: false,
+      content: '',
+      firstCursor: '',
+      lastCursor: '',
+      reached: false,
+      dropped: 0,
+      instanceId: '',
+    } satisfies LogTailResponse);
   });
 }

--- a/web_ui/frontend/e2e/mocks/api/v1.0/logs/tail.ts
+++ b/web_ui/frontend/e2e/mocks/api/v1.0/logs/tail.ts
@@ -29,6 +29,8 @@ export interface LogTailResponse {
   reached: boolean;
   dropped: number;
   instanceId: string;
+  bufferOldest?: string;
+  bufferNewest?: string;
 }
 
 const TAIL_URL_PATTERN = '**/api/v1.0/logs/tail**';
@@ -162,7 +164,24 @@ class MockLogBuffer {
       reached: false,
       dropped,
       instanceId: this.instanceId,
+      ...this.span,
     };
+  }
+
+  /**
+   * The stamps bracketing everything held, mirroring the real buffer's Span():
+   * the extent of a download, which is independent of what any one response
+   * returns. The server reads these off the logrus entries; a fixture only has
+   * the formatted lines, so they come from the first and last line's own
+   * `time=` token.
+   */
+  private get span(): Pick<LogTailResponse, 'bufferOldest' | 'bufferNewest'> {
+    const stamp = (line: string | undefined) =>
+      line?.match(/^time="([^"]*)"/)?.[1] ?? '';
+    const oldest = stamp(this.lines[0]);
+    const newest = stamp(this.lines[this.lines.length - 1]);
+    if (oldest === '' || newest === '') return {};
+    return { bufferOldest: oldest, bufferNewest: newest };
   }
 
   tailBefore(before: number, count: number): LogTailResponse {
@@ -196,6 +215,7 @@ class MockLogBuffer {
       // wall through `reached`.
       dropped: 0,
       instanceId: this.instanceId,
+      ...this.span,
     };
   }
 }

--- a/web_ui/frontend/e2e/origin/logs.spec.ts
+++ b/web_ui/frontend/e2e/origin/logs.spec.ts
@@ -1,0 +1,24 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+import { test } from '@playwright/test';
+import { registerLogViewerTests } from '../shared_tests/logViewerTests';
+
+test.describe('Origin Server Logs', () => {
+  registerLogViewerTests('./view/settings/logs/');
+});

--- a/web_ui/frontend/e2e/origin/logs.spec.ts
+++ b/web_ui/frontend/e2e/origin/logs.spec.ts
@@ -18,7 +18,9 @@
 
 import { test } from '@playwright/test';
 import { registerLogViewerTests } from '../shared_tests/logViewerTests';
+import { registerLogViewerAccessTests } from '../shared_tests/logViewerAccessTests';
 
 test.describe('Origin Server Logs', () => {
   registerLogViewerTests('./view/settings/logs/');
+  registerLogViewerAccessTests('./view/settings/logs/');
 });

--- a/web_ui/frontend/e2e/shared_pages/LogViewerPage.ts
+++ b/web_ui/frontend/e2e/shared_pages/LogViewerPage.ts
@@ -32,9 +32,17 @@ export class LogViewerPage {
   readonly heading: Locator;
   readonly textFilter: Locator;
   readonly downloadButton: Locator;
+  readonly scrollToBottomButton: Locator;
   readonly autoScrollCheckbox: Locator;
-  // "Showing X of Y lines." — the count summary above the log pane.
+  // The scrolling log pane. Every row assertion is scoped to it so a match
+  // means "mounted in the pane", not "this string appears somewhere on the
+  // page".
+  readonly pane: Locator;
+  // "Showing X of Y lines." — the count summary above the log pane. Also
+  // carries the "Loading older…" / "No more history." suffixes.
   readonly summary: Locator;
+  // The dismissible warning the viewer raises when a tail fetch fails.
+  readonly fetchErrorAlert: Locator;
   // The "In-memory log capture is not yet available" notice shown when the
   // server reports the buffer disabled.
   readonly unavailableNotice: Locator;
@@ -46,10 +54,17 @@ export class LogViewerPage {
     this.heading = page.getByRole('heading', { name: 'Server Logs' });
     this.textFilter = page.getByLabel('Text filter');
     this.downloadButton = page.getByRole('button', { name: /Download/ });
+    this.scrollToBottomButton = page.getByRole('button', {
+      name: 'Scroll to bottom',
+    });
     this.autoScrollCheckbox = page.getByRole('checkbox', {
       name: 'Auto-scroll',
     });
+    this.pane = page.getByTestId('log-pane');
     this.summary = page.getByText(/Showing .* of .* lines\./);
+    this.fetchErrorAlert = page
+      .locator('.MuiAlert-root')
+      .filter({ hasText: /log tail fetch failed/ });
     this.unavailableNotice = page.getByText(
       /In-memory log capture is not yet available/
     );
@@ -61,11 +76,32 @@ export class LogViewerPage {
   }
 
   /**
-   * Returns a locator for a rendered log row that contains the given text.
-   * Matches a substring of the formatted line.
+   * Every log row currently mounted in the pane. With virtualization this is
+   * the window around the viewport, not the whole buffer — compare against
+   * `summary` for the full count.
+   */
+  rows(): Locator {
+    return this.pane.getByTestId('log-row');
+  }
+
+  /**
+   * Placeholders marking lines the server dropped before this view could
+   * read them. Distinct from `rows()`: a gap is a statement about the
+   * record rather than part of it, and it survives the level and text
+   * filters that log rows are subject to.
+   */
+  gaps(): Locator {
+    return this.pane.getByTestId('log-gap');
+  }
+
+  /**
+   * Returns a locator for a mounted log row containing the given text.
+   * Matches a substring of the formatted line. A row that is filtered out
+   * and a row that is merely scrolled out of the virtualization window both
+   * resolve to zero elements, so pair negative assertions with a count.
    */
   logLine(text: string): Locator {
-    return this.page.getByText(text);
+    return this.rows().filter({ hasText: text });
   }
 
   /**
@@ -82,5 +118,39 @@ export class LogViewerPage {
   /** Toggles a level chip in / out of the selected set. */
   async toggleLevel(level: string) {
     await this.levelChip(level).click();
+  }
+
+  /** Dismisses the tail-fetch warning via its Close button. */
+  async dismissFetchError() {
+    await this.fetchErrorAlert.getByRole('button', { name: 'Close' }).click();
+  }
+
+  /** Current scroll offset of the pane, in pixels from the top. */
+  paneScrollTop(): Promise<number> {
+    return this.pane.evaluate((el) => el.scrollTop);
+  }
+
+  /**
+   * Pixels of un-scrolled content below the viewport. The viewer treats
+   * anything at or under 20 px as "pinned to the bottom".
+   */
+  paneBottomGap(): Promise<number> {
+    return this.pane.evaluate(
+      (el) => el.scrollHeight - el.scrollTop - el.clientHeight
+    );
+  }
+
+  /** Scrolls the pane to the very top, which is what triggers a history load. */
+  async scrollPaneToTop() {
+    await this.pane.evaluate((el) => {
+      el.scrollTop = 0;
+    });
+  }
+
+  /** Scrolls the pane up by `px`, clamped at the top. */
+  async scrollPaneUpBy(px: number) {
+    await this.pane.evaluate((el, delta) => {
+      el.scrollTop = Math.max(0, el.scrollTop - delta);
+    }, px);
   }
 }

--- a/web_ui/frontend/e2e/shared_pages/LogViewerPage.ts
+++ b/web_ui/frontend/e2e/shared_pages/LogViewerPage.ts
@@ -1,0 +1,86 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+import { Page, Locator, expect } from '@playwright/test';
+
+/**
+ * Page Object Model for the Server Logs settings page
+ * (/settings/logs -> ./view/settings/logs/).
+ *
+ * Encapsulates the selectors and interactions for the in-memory log viewer so
+ * tests stay readable and resilient to minor UI changes.
+ */
+export class LogViewerPage {
+  readonly page: Page;
+  readonly pageUrl: string;
+
+  readonly heading: Locator;
+  readonly textFilter: Locator;
+  readonly downloadButton: Locator;
+  readonly autoScrollCheckbox: Locator;
+  // "Showing X of Y lines." — the count summary above the log pane.
+  readonly summary: Locator;
+  // The "In-memory log capture is not yet available" notice shown when the
+  // server reports the buffer disabled.
+  readonly unavailableNotice: Locator;
+
+  constructor(page: Page, pageUrl: string) {
+    this.page = page;
+    this.pageUrl = pageUrl;
+
+    this.heading = page.getByRole('heading', { name: 'Server Logs' });
+    this.textFilter = page.getByLabel('Text filter');
+    this.downloadButton = page.getByRole('button', { name: /Download/ });
+    this.autoScrollCheckbox = page.getByRole('checkbox', {
+      name: 'Auto-scroll',
+    });
+    this.summary = page.getByText(/Showing .* of .* lines\./);
+    this.unavailableNotice = page.getByText(
+      /In-memory log capture is not yet available/
+    );
+  }
+
+  async goto() {
+    await this.page.goto(this.pageUrl);
+    await expect(this.heading).toBeVisible();
+  }
+
+  /**
+   * Returns a locator for a rendered log row that contains the given text.
+   * Matches a substring of the formatted line.
+   */
+  logLine(text: string): Locator {
+    return this.page.getByText(text);
+  }
+
+  /**
+   * Returns the level-filter chip whose label starts with the given level
+   * name (e.g. 'info', 'error'). Chips render as `info (2)`, so this matches
+   * on the leading level token and ignores the trailing count.
+   */
+  levelChip(level: string): Locator {
+    return this.page
+      .locator('.MuiChip-root')
+      .filter({ hasText: new RegExp(`^${level} \\(`) });
+  }
+
+  /** Toggles a level chip in / out of the selected set. */
+  async toggleLevel(level: string) {
+    await this.levelChip(level).click();
+  }
+}

--- a/web_ui/frontend/e2e/shared_pages/LogViewerPage.ts
+++ b/web_ui/frontend/e2e/shared_pages/LogViewerPage.ts
@@ -38,9 +38,13 @@ export class LogViewerPage {
   // means "mounted in the pane", not "this string appears somewhere on the
   // page".
   readonly pane: Locator;
-  // "Showing X of Y lines." — the count summary above the log pane. Also
-  // carries the "Loading older…" / "No more history." suffixes.
+  // "Showing X of Y lines held in this browser." — the count summary above
+  // the log pane. Also carries the dropped-line total and the
+  // "Loading older…" / "No more history." suffixes.
   readonly summary: Locator;
+  // The "Filtering…" indicator shown while the pane's rows are still the
+  // pre-change ones after a filter edit.
+  readonly filteringIndicator: Locator;
   // The dismissible warning the viewer raises when a tail fetch fails.
   readonly fetchErrorAlert: Locator;
   // The "In-memory log capture is not yet available" notice shown when the
@@ -61,7 +65,8 @@ export class LogViewerPage {
       name: 'Auto-scroll',
     });
     this.pane = page.getByTestId('log-pane');
-    this.summary = page.getByText(/Showing .* of .* lines\./);
+    this.summary = page.getByTestId('log-summary');
+    this.filteringIndicator = page.getByTestId('log-filtering');
     this.fetchErrorAlert = page
       .locator('.MuiAlert-root')
       .filter({ hasText: /log tail fetch failed/ });
@@ -115,9 +120,39 @@ export class LogViewerPage {
       .filter({ hasText: new RegExp(`^${level} \\(`) });
   }
 
-  /** Toggles a level chip in / out of the selected set. */
-  async toggleLevel(level: string) {
+  /**
+   * Plain-clicks a level chip. From no filter that narrows to the level
+   * clicked; with a filter active it adds the level, or removes it if it was
+   * already selected; and on the last remaining level it clears the filter.
+   */
+  async clickLevel(level: string) {
     await this.levelChip(level).click();
+  }
+
+  /**
+   * Modifier-clicks a level chip, which adds it to or removes it from the
+   * current selection rather than isolating it.
+   */
+  async toggleLevel(level: string) {
+    await this.levelChip(level).click({ modifiers: ['ControlOrMeta'] });
+  }
+
+  /**
+   * The "Available: …" subtext under the download control, reporting what the
+   * server's whole buffer spans — i.e. what a download would contain, which is
+   * not the same set as the lines this page holds.
+   */
+  downloadSpan(): Locator {
+    return this.page.getByTestId('log-download-span');
+  }
+
+  /**
+   * The right-justified span at the end of the summary line: "Logs in time
+   * range: YYYY-MM-DD HH:MM - YYYY-MM-DD HH:MM", in the viewer's local zone.
+   * Absent entirely when nothing held carries a timestamp.
+   */
+  dateRange(): Locator {
+    return this.page.getByTestId('log-range');
   }
 
   /** Dismisses the tail-fetch warning via its Close button. */

--- a/web_ui/frontend/e2e/shared_tests/logViewerAccessTests.ts
+++ b/web_ui/frontend/e2e/shared_tests/logViewerAccessTests.ts
@@ -1,0 +1,152 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+import { test, expect } from '@playwright/test';
+import { LogViewerPage } from '../shared_pages/LogViewerPage';
+import { mockLogTail } from '../mocks/api/v1.0/logs/tail';
+import { mockWhoami } from '../mocks/api/v1.0/auth/whoami';
+
+/**
+ * Registers the access-control tests for the log viewer.
+ *
+ * The log viewer is the first surface reachable with a scope grant instead
+ * of the admin role, so who may see it is a property worth pinning:
+ * `pelican.log_read` must be enough to reach the page and no more than that,
+ * and an account without it must not reach the page at all.
+ *
+ * These drive the client-side gates only — they pin who is offered the page,
+ * not who the server will serve. The server's own gate is enforced by
+ * LogReadAuthHandler and covered by the Go tests; the two are independent on
+ * purpose, and a test here passing says nothing about that one.
+ *
+ * @param serviceUrl  The relative URL for the log viewer page
+ *                    (e.g. './view/settings/logs/').
+ */
+export function registerLogViewerAccessTests(serviceUrl: string) {
+  const settingsRootUrl = serviceUrl.replace(/logs\/?$/, '');
+
+  test.describe('scope-only log reader', () => {
+    test.beforeEach(async ({ page }) => {
+      await mockWhoami(page, {
+        user: 'triage',
+        role: 'user',
+        scopes: ['pelican.log_read'],
+      });
+      await mockLogTail(page);
+    });
+
+    test('reaches the log viewer without the admin role @mocked', async ({
+      page,
+    }) => {
+      const logs = new LogViewerPage(page, serviceUrl);
+      await logs.goto();
+
+      await expect(logs.heading).toBeVisible();
+      await expect(logs.pane).toBeVisible();
+    });
+
+    test('is offered Logs but not the admin-only settings pages @mocked', async ({
+      page,
+    }) => {
+      await page.goto(serviceUrl);
+
+      await expect(
+        page.getByRole('link', { name: 'Logs', exact: true })
+      ).toBeVisible();
+      // Pages gated on the admin role alone. Asserting the Logs link is
+      // present in the same breath keeps this from passing on a sidebar
+      // that failed to render at all.
+      await expect(
+        page.getByRole('link', { name: 'AUP', exact: true })
+      ).toHaveCount(0);
+      await expect(
+        page.getByRole('link', { name: 'API', exact: true })
+      ).toHaveCount(0);
+    });
+
+    test('is moved off the admin-only settings index @mocked', async ({
+      page,
+    }) => {
+      await page.goto(settingsRootUrl);
+
+      // The settings index is the Restart Server surface, which this caller
+      // cannot use, so it must send them somewhere they can reach rather
+      // than show them a privileges error. Which page that is follows from
+      // the order of the settings sidebar and is not pinned here; what
+      // matters is that they are neither stranded on the index nor refused.
+      await expect(page).not.toHaveURL(/settings\/?$/);
+      await expect(page.getByText(/Insufficient privileges/i)).toHaveCount(0);
+      await expect(
+        page.getByRole('heading', { name: 'Restart Server' })
+      ).toHaveCount(0);
+    });
+  });
+
+  test.describe('user without the log-read scope', () => {
+    test('is not shown the log viewer @mocked', async ({ page }) => {
+      await mockWhoami(page, { user: 'nobody', role: 'user', scopes: [] });
+      await mockLogTail(page);
+
+      // Navigated directly rather than through LogViewerPage.goto, which
+      // waits for the heading this caller must never be shown.
+      const logs = new LogViewerPage(page, serviceUrl);
+      await page.goto(serviceUrl);
+
+      // AuthenticatedContent redirects an unauthorized caller away rather
+      // than rendering the shell, so the pane must never appear.
+      await expect(logs.pane).toHaveCount(0);
+      await expect(logs.heading).toHaveCount(0);
+    });
+
+    test('is not offered a Logs link @mocked', async ({ page }) => {
+      await mockWhoami(page, { user: 'nobody', role: 'user', scopes: [] });
+      await mockLogTail(page);
+
+      await page.goto(settingsRootUrl);
+      await expect(
+        page.getByRole('link', { name: 'Logs', exact: true })
+      ).toHaveCount(0);
+    });
+  });
+
+  test.describe('admin', () => {
+    test('reaches the log viewer through the role gate @mocked', async ({
+      page,
+    }) => {
+      // An admin holds no explicit pelican.log_read grant; the role alone
+      // has to be sufficient, both for the sidebar entry and for the page.
+      await mockWhoami(page, { user: 'admin', role: 'admin', scopes: [] });
+      await mockLogTail(page);
+
+      const logs = new LogViewerPage(page, serviceUrl);
+      await logs.goto();
+      await expect(logs.heading).toBeVisible();
+      await expect(logs.pane).toBeVisible();
+    });
+
+    test('stays on the settings index rather than being redirected @mocked', async ({
+      page,
+    }) => {
+      await mockWhoami(page, { user: 'admin', role: 'admin', scopes: [] });
+      await mockLogTail(page);
+
+      await page.goto(settingsRootUrl);
+      await expect(page).toHaveURL(/settings\/?$/);
+    });
+  });
+}

--- a/web_ui/frontend/e2e/shared_tests/logViewerTests.ts
+++ b/web_ui/frontend/e2e/shared_tests/logViewerTests.ts
@@ -20,12 +20,14 @@ import { test, expect, Page } from '@playwright/test';
 import { LogViewerPage } from '../shared_pages/LogViewerPage';
 import {
   CLIENT_TAIL_LIMIT,
+  DEFAULT_LOG_LINES,
   makeLogLines,
   mockLogTail,
   mockLogTailDisabled,
   mockLogTailEvicting,
   mockLogTailFailing,
   mockLogTailForbidden,
+  mockLogTailRestarting,
   mockLogTailStreaming,
 } from '../mocks/api/v1.0/logs/tail';
 import { mockLogDownload } from '../mocks/api/v1.0/logs/download';
@@ -173,6 +175,78 @@ export function registerLogViewerTests(serviceUrl: string) {
     await logs.goto();
     await expect(logs.unavailableNotice).toBeVisible();
     await expect(logs.logLine(INFO_LINE)).not.toBeVisible();
+  });
+
+  test('distinguishes an empty buffer from a disabled one @mocked', async ({
+    page,
+  }) => {
+    // Both states show no log lines, and only one of them is a problem an
+    // operator can act on.
+    await mockLogTail(page, []);
+    await logs.goto();
+
+    await expect(logs.summary).toContainText('Showing 0 of 0 lines.');
+    await expect(logs.unavailableNotice).not.toBeVisible();
+    for (const level of ['info', 'warning', 'error']) {
+      await expect(logs.levelChip(level)).toContainText(`${level} (0)`);
+    }
+  });
+
+  test('treats short-form and level-less lines consistently @mocked', async ({
+    page,
+  }) => {
+    // logrus emits "warning", but plenty of tools that log through Pelican
+    // write "warn"; and a stack trace's continuation lines carry no level at
+    // all, so they must inherit one rather than disappear.
+    await mockLogTail(page, [
+      ...DEFAULT_LOG_LINES,
+      'time="2026-07-25T10:00:04Z" level=warn msg="Short form warning"',
+      '    /usr/lib/pelican/foo.go:42 +0x1a',
+    ]);
+    await logs.goto();
+
+    await expect(logs.levelChip('warning')).toContainText('warning (2)');
+    await expect(logs.levelChip('info')).toContainText('info (3)');
+
+    // The continuation line counts as info, so hiding info hides it too.
+    await logs.toggleLevel('info');
+    await expect(logs.logLine('foo.go:42')).toHaveCount(0);
+    await expect(logs.summary).toContainText('Showing 3 of 6 lines.');
+  });
+
+  test('empties and restores the pane as levels are toggled @mocked', async () => {
+    for (const level of ['panic', 'fatal', 'error', 'warning', 'info']) {
+      await logs.toggleLevel(level);
+    }
+    await expect(logs.summary).toContainText('Showing 0 of 4 lines.');
+    await expect(logs.rows()).toHaveCount(0);
+
+    await logs.toggleLevel('info');
+    await expect(logs.summary).toContainText('Showing 2 of 4 lines.');
+    await expect(logs.logLine(INFO_LINE)).toBeVisible();
+  });
+
+  test('starts over when the server it is tailing restarts @mocked @slow', async ({
+    page,
+  }) => {
+    // Cursors belong to one buffer instance. After a restart the viewer's
+    // are meaningless, so it must drop what it holds rather than append the
+    // new server's lines to the old server's.
+    await mockLogTailRestarting(page, {
+      afterRestart: [
+        'time="2026-07-25T11:00:00Z" level=info msg="Pelican origin restarted"',
+      ],
+    });
+    await logs.goto();
+    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+
+    await expect(logs.logLine('Pelican origin restarted')).toBeVisible({
+      timeout: POLL_TIMEOUT,
+    });
+    await expect(logs.summary).toContainText('Showing 1 of 1 lines.');
+    await expect(logs.logLine(INFO_LINE)).toHaveCount(0);
+    // A restart is not a dropped-line event; the marker would be misleading.
+    await expect(logs.gaps()).toHaveCount(0);
   });
 
   // ---------------------------------------------------------------------

--- a/web_ui/frontend/e2e/shared_tests/logViewerTests.ts
+++ b/web_ui/frontend/e2e/shared_tests/logViewerTests.ts
@@ -16,9 +16,19 @@
  *
  ***************************************************************/
 
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { LogViewerPage } from '../shared_pages/LogViewerPage';
-import { mockLogTail, mockLogTailDisabled } from '../mocks/api/v1.0/logs/tail';
+import {
+  CLIENT_TAIL_LIMIT,
+  makeLogLines,
+  mockLogTail,
+  mockLogTailDisabled,
+  mockLogTailEvicting,
+  mockLogTailFailing,
+  mockLogTailForbidden,
+  mockLogTailStreaming,
+} from '../mocks/api/v1.0/logs/tail';
+import { mockLogDownload } from '../mocks/api/v1.0/logs/download';
 
 // Distinctive substrings of the fixture lines (see DEFAULT_LOG_LINES). Chosen
 // so each matches exactly one seeded line -- note both a warning/error and an
@@ -29,6 +39,68 @@ const WARNING_LINE = 'Disk space is running low';
 const ERROR_LINE = 'Failed to connect to backend storage';
 const INFO_LINE_2 = 'Recovered connection to backend storage';
 
+// Lines the streaming fixture publishes on later polls -- i.e. content the
+// viewer can only be holding if it advanced its cursor and appended.
+const STREAMED_LINE_1 =
+  'time="2026-07-25T10:00:04Z" level=info msg="Origin export refreshed"';
+const STREAMED_LINE_2 =
+  'time="2026-07-25T10:00:05Z" level=warning msg="Cache miss rate is elevated"';
+const STREAMED_TEXT_1 = 'Origin export refreshed';
+const STREAMED_TEXT_2 = 'Cache miss rate is elevated';
+
+// Drives the eviction case, where the server discards lines the viewer has
+// not read yet. The arithmetic is worth spelling out, because the expected
+// gap size follows from it and not from `evict` directly:
+//
+//   the 4 fixture lines are seqs 1-4, so after the initial load the viewer's
+//   cursor sits at seq 4; `arriving` adds seqs 5-10; evicting the oldest 7
+//   leaves seqs 8-10 held. Seqs 5-7 therefore existed but are gone before
+//   the viewer ever asked for them -- a gap of 3. Seqs 1-4 are evicted too,
+//   but the viewer already holds those, so they are not part of the gap.
+//
+// Only the last arriving line is an error, so a level filter can hide the
+// post-gap content while leaving the marker to be asserted on.
+const EVICTION_FIXTURE = {
+  arriving: [
+    'time="2026-07-25T10:05:00Z" level=info msg="Missed line one"',
+    'time="2026-07-25T10:05:01Z" level=info msg="Missed line two"',
+    'time="2026-07-25T10:05:02Z" level=info msg="Missed line three"',
+    'time="2026-07-25T10:05:03Z" level=info msg="Survivor one"',
+    'time="2026-07-25T10:05:04Z" level=info msg="Survivor two"',
+    'time="2026-07-25T10:05:05Z" level=error msg="After the gap"',
+  ],
+  evict: 7,
+};
+const EXPECTED_DROPPED = 3;
+
+// The viewer polls every POLL_INTERVAL_MS (2 s), so anything that depends on
+// a later poll needs several intervals of headroom.
+const POLL_TIMEOUT = 10000;
+// Fixtures at or above the viewer's TAIL_LIMIT take noticeably longer to
+// serialize, transfer and mount.
+const LARGE_FIXTURE_TIMEOUT = 30000;
+
+/**
+ * Resolves on the next forward (`since=<cursor>`) poll, i.e. a poll the
+ * viewer issued with a cursor it learned from an earlier response. Used to
+ * advance a deterministic number of poll cycles instead of sleeping.
+ */
+function waitForForwardPoll(page: Page) {
+  return page.waitForResponse(
+    (response) => {
+      try {
+        const url = new URL(response.url());
+        return (
+          url.pathname.endsWith('/logs/tail') && !!url.searchParams.get('since')
+        );
+      } catch {
+        return false;
+      }
+    },
+    { timeout: POLL_TIMEOUT }
+  );
+}
+
 /**
  * Registers the shared log-viewer tests for a given service URL. Call this
  * inside a `test.describe` block in each service's spec file.
@@ -37,6 +109,9 @@ const INFO_LINE_2 = 'Recovered connection to backend storage';
  *                    (e.g. './view/settings/logs/').
  */
 export function registerLogViewerTests(serviceUrl: string) {
+  // The settings shell that hosts the viewer; used to prove the sidebar
+  // entry actually reaches the page.
+  const settingsRootUrl = serviceUrl.replace(/logs\/?$/, '');
   let logs: LogViewerPage;
 
   test.beforeEach(async ({ page }) => {
@@ -93,10 +168,288 @@ export function registerLogViewerTests(serviceUrl: string) {
     page,
   }) => {
     // Re-route to report the buffer disabled, then reload so the initial fetch
-    // sees enabled=false. The later route registration takes precedence.
+    // sees enabled=false.
     await mockLogTailDisabled(page);
     await logs.goto();
     await expect(logs.unavailableNotice).toBeVisible();
     await expect(logs.logLine(INFO_LINE)).not.toBeVisible();
+  });
+
+  // ---------------------------------------------------------------------
+  // Live tail
+  // ---------------------------------------------------------------------
+
+  test('appends lines that arrive on later polls @mocked @slow', async ({
+    page,
+  }) => {
+    // Guarantees the accumulate-and-advance loop: each poll's lastCursor is
+    // carried into the next request, and content that arrives after the
+    // initial load is appended to (not swapped for) what is already shown.
+    await mockLogTailStreaming(page, {
+      batches: [[STREAMED_LINE_1], [STREAMED_LINE_2]],
+    });
+    await logs.goto();
+    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+
+    await expect(logs.logLine(STREAMED_TEXT_1)).toBeVisible({
+      timeout: POLL_TIMEOUT,
+    });
+    await expect(logs.summary).toContainText('Showing 5 of 5 lines.', {
+      timeout: POLL_TIMEOUT,
+    });
+
+    await expect(logs.logLine(STREAMED_TEXT_2)).toBeVisible({
+      timeout: POLL_TIMEOUT,
+    });
+    await expect(logs.summary).toContainText('Showing 6 of 6 lines.', {
+      timeout: POLL_TIMEOUT,
+    });
+    // The original lines survived the appends.
+    await expect(logs.logLine(INFO_LINE)).toBeVisible();
+  });
+
+  test('does not re-deliver lines it already holds @mocked @slow', async ({
+    page,
+  }) => {
+    // Guarantees the viewer advances `since` past what it has already
+    // received: a viewer that kept re-sending the empty cursor would be
+    // handed the whole fixture again on every poll and duplicate it.
+    await mockLogTailStreaming(page, { batches: [] });
+    await logs.goto();
+    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+
+    await waitForForwardPoll(page);
+    await waitForForwardPoll(page);
+
+    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+    await expect(logs.rows()).toHaveCount(4);
+    await expect(logs.logLine(INFO_LINE)).toHaveCount(1);
+  });
+
+  // ---------------------------------------------------------------------
+  // Dropped lines
+  // ---------------------------------------------------------------------
+
+  test('marks the point where the server dropped lines @mocked @slow', async ({
+    page,
+  }) => {
+    // A server logging faster than the viewer polls evicts lines the
+    // viewer never saw. Without a marker the surviving lines render as
+    // consecutive, which during an incident reads as a quiet period rather
+    // than as lost evidence.
+    await mockLogTailEvicting(page, EVICTION_FIXTURE);
+    await logs.goto();
+    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+
+    await expect(logs.gaps()).toHaveCount(1, { timeout: POLL_TIMEOUT });
+    await expect(logs.gaps().first()).toContainText(
+      `${EXPECTED_DROPPED} lines dropped`
+    );
+    await expect(logs.logLine('After the gap')).toBeVisible();
+    // The marker occupies a row but is not itself a log line, so the
+    // count covers only the 4 original plus the 3 that survived.
+    await expect(logs.summary).toContainText('Showing 7 of 7 lines.');
+  });
+
+  test('keeps the dropped-lines marker visible under a level filter @mocked @slow', async ({
+    page,
+  }) => {
+    // The marker describes the record rather than belonging to it, so a
+    // level filter must not be able to hide the fact that lines are
+    // missing.
+    await mockLogTailEvicting(page, EVICTION_FIXTURE);
+    await logs.goto();
+    await expect(logs.gaps()).toHaveCount(1, { timeout: POLL_TIMEOUT });
+
+    await logs.toggleLevel('error');
+    await expect(logs.logLine('After the gap')).toHaveCount(0);
+    await expect(logs.gaps()).toHaveCount(1);
+  });
+
+  test('shows no gap marker while the viewer keeps up @mocked @slow', async ({
+    page,
+  }) => {
+    // The counterpart to the two above: an uninterrupted stream must not
+    // acquire a marker, or the signal means nothing.
+    await mockLogTailStreaming(page, {
+      batches: [[STREAMED_LINE_1], [STREAMED_LINE_2]],
+    });
+    await logs.goto();
+    await expect(logs.logLine(STREAMED_TEXT_2)).toBeVisible({
+      timeout: POLL_TIMEOUT,
+    });
+    await expect(logs.gaps()).toHaveCount(0);
+  });
+
+  // ---------------------------------------------------------------------
+  // Fetch failures
+  // ---------------------------------------------------------------------
+
+  test('surfaces a failed poll and keeps the lines already shown @mocked @slow', async ({
+    page,
+  }) => {
+    // Guarantees a transport failure is reported rather than silently
+    // blanking the pane, and that the warning is dismissible.
+    await mockLogTailFailing(page, { failAfter: 1 });
+    await logs.goto();
+    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+
+    await expect(logs.fetchErrorAlert).toBeVisible({ timeout: POLL_TIMEOUT });
+    await expect(logs.logLine(INFO_LINE)).toBeVisible();
+    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+
+    await logs.dismissFetchError();
+    await expect(logs.fetchErrorAlert).not.toBeVisible();
+    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+  });
+
+  test('clears the failure warning once polling recovers @mocked @slow', async ({
+    page,
+  }) => {
+    // Guarantees the viewer heals itself: no reload is needed after a
+    // transient server-side failure.
+    await mockLogTailFailing(page, { failAfter: 1, failCount: 3 });
+    await logs.goto();
+    await expect(logs.fetchErrorAlert).toBeVisible({ timeout: POLL_TIMEOUT });
+    await expect(logs.fetchErrorAlert).not.toBeVisible({ timeout: 15000 });
+    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+  });
+
+  test('surfaces a 403 from the log-read gate @mocked', async ({ page }) => {
+    // Guarantees a caller the server refuses sees why, instead of an empty
+    // pane that reads as "there are no logs".
+    await mockLogTailForbidden(page);
+    await logs.goto();
+    await expect(logs.fetchErrorAlert).toBeVisible({ timeout: POLL_TIMEOUT });
+    await expect(logs.fetchErrorAlert).toContainText('403');
+    // The pane itself still renders -- this is a refusal, not the
+    // buffer-disabled notice.
+    await expect(logs.summary).toContainText('Showing 0 of 0 lines.');
+    await expect(logs.unavailableNotice).not.toBeVisible();
+  });
+
+  // ---------------------------------------------------------------------
+  // Scrolling
+  // ---------------------------------------------------------------------
+
+  test('pins the pane to the bottom while auto-scroll is on @mocked', async ({
+    page,
+  }) => {
+    // Guarantees a freshly loaded buffer shows its newest lines, not its
+    // oldest.
+    await mockLogTail(page, makeLogLines(200));
+    await logs.goto();
+    await expect(logs.summary).toContainText('Showing 200 of 200 lines.');
+    await expect(logs.autoScrollCheckbox).toBeChecked();
+    // The pin runs off an effect, so poll rather than reading once.
+    await expect
+      .poll(() => logs.paneBottomGap(), { timeout: POLL_TIMEOUT })
+      .toBeLessThanOrEqual(20);
+  });
+
+  test('releases and re-takes the scroll pin @mocked', async ({ page }) => {
+    // Guarantees scrolling up stops the viewer from yanking the viewport
+    // back down, and that "Scroll to bottom" restores the pin.
+    await mockLogTail(page, makeLogLines(200));
+    await logs.goto();
+    await expect(logs.summary).toContainText('Showing 200 of 200 lines.');
+    await expect
+      .poll(() => logs.paneBottomGap(), { timeout: POLL_TIMEOUT })
+      .toBeLessThanOrEqual(20);
+
+    await logs.scrollPaneUpBy(300);
+    await expect(logs.autoScrollCheckbox).not.toBeChecked();
+    await expect
+      .poll(() => logs.paneBottomGap(), { timeout: POLL_TIMEOUT })
+      .toBeGreaterThan(20);
+
+    await logs.scrollToBottomButton.click();
+    await expect(logs.autoScrollCheckbox).toBeChecked();
+    await expect
+      .poll(() => logs.paneBottomGap(), { timeout: POLL_TIMEOUT })
+      .toBeLessThanOrEqual(20);
+  });
+
+  test('mounts only a window of rows for a large buffer @mocked @slow', async ({
+    page,
+  }) => {
+    test.slow();
+    // Guarantees virtualization: the pane holds the whole buffer in state
+    // but keeps the DOM to the rows around the viewport. Without it a busy
+    // server freezes the tab.
+    await mockLogTail(page, makeLogLines(CLIENT_TAIL_LIMIT));
+    await logs.goto();
+    await expect(logs.summary).toContainText(
+      'Showing 10,000 of 10,000 lines.',
+      {
+        timeout: LARGE_FIXTURE_TIMEOUT,
+      }
+    );
+    const mounted = await logs.rows().count();
+    expect(mounted).toBeGreaterThan(0);
+    expect(mounted).toBeLessThan(200);
+  });
+
+  test('loads the remaining history and stops at the wall @mocked @slow', async ({
+    page,
+  }) => {
+    test.slow();
+    // Guarantees the scroll-up path: a buffer holding more than the
+    // viewer's initial-load limit has history to fetch, the response that
+    // carries the last of it also reports `reached`, and the viewer stops
+    // asking once it has.
+    await mockLogTail(page, makeLogLines(CLIENT_TAIL_LIMIT + 50));
+    await logs.goto();
+    await expect(logs.summary).toContainText(
+      'Showing 10,000 of 10,000 lines.',
+      {
+        timeout: LARGE_FIXTURE_TIMEOUT,
+      }
+    );
+    await expect(logs.summary).not.toContainText('No more history.');
+
+    await logs.scrollPaneToTop();
+    await expect(logs.summary).toContainText('No more history.', {
+      timeout: POLL_TIMEOUT,
+    });
+    await expect(logs.summary).toContainText('Showing 10,050 of 10,050 lines.');
+
+    // Re-hitting the top must not re-fetch or duplicate the history.
+    await logs.scrollPaneToTop();
+    await waitForForwardPoll(page);
+    await logs.scrollPaneToTop();
+    await waitForForwardPoll(page);
+    await expect(logs.summary).toContainText('Showing 10,050 of 10,050 lines.');
+  });
+
+  // ---------------------------------------------------------------------
+  // Download and navigation
+  // ---------------------------------------------------------------------
+
+  test('downloads the buffered log as a gzip attachment @mocked', async ({
+    page,
+  }) => {
+    // Guarantees the Download button performs a real download with the
+    // filename the API promises -- asserting the button is visible would
+    // pass even if the navigation 404'd.
+    await mockLogDownload(page);
+    const downloadPromise = page.waitForEvent('download');
+    await logs.downloadButton.click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(
+      /^pelican-logs-.+-\d{8}-\d{6}Z\.log\.gz$/
+    );
+  });
+
+  test('reaches the log viewer from the settings sidebar @smoke', async ({
+    page,
+  }) => {
+    // Guarantees the Logs entry in the settings sidebar points at a page
+    // that exists and renders.
+    await page.goto(settingsRootUrl);
+    await page.getByRole('link', { name: 'Logs', exact: true }).click();
+    await expect(page).toHaveURL(/\/settings\/logs\//);
+    await expect(logs.heading).toBeVisible();
+    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
   });
 }

--- a/web_ui/frontend/e2e/shared_tests/logViewerTests.ts
+++ b/web_ui/frontend/e2e/shared_tests/logViewerTests.ts
@@ -134,7 +134,38 @@ export function registerLogViewerTests(serviceUrl: string) {
     await expect(logs.logLine(ERROR_LINE)).toBeVisible();
     await expect(logs.logLine(INFO_LINE_2)).toBeVisible();
     // Two info lines, one warning, one error.
-    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 4 of 4 lines held in this browser.'
+    );
+  });
+
+  test('shows every line it holds until a filter is applied @mocked', async ({
+    page,
+  }) => {
+    // No level filter is not the same thing as "all seven known levels
+    // selected": a line whose level is outside that list must still be on
+    // screen by default, and must get a chip of its own so it can be filtered
+    // like any other. A whitelisted default hides such lines with no visible
+    // cause and no control to bring them back.
+    await mockLogTail(page, [
+      ...DEFAULT_LOG_LINES,
+      'time="2026-07-25T10:00:06Z" level=notice msg="Unusual level here"',
+    ]);
+    await logs.goto();
+
+    await expect(logs.logLine('Unusual level here')).toBeVisible();
+    await expect(logs.summary).toContainText(
+      'Showing 5 of 5 lines held in this browser.'
+    );
+    await expect(logs.levelChip('notice')).toContainText('notice (1)');
+
+    // And it filters like any other level.
+    await logs.clickLevel('notice');
+    await expect(logs.logLine('Unusual level here')).toBeVisible();
+    await expect(logs.logLine(INFO_LINE)).toHaveCount(0);
+    await expect(logs.summary).toContainText(
+      'Showing 1 of 5 lines held in this browser.'
+    );
   });
 
   test('shows per-level counts in the filter chips @mocked', async () => {
@@ -150,7 +181,89 @@ export function registerLogViewerTests(serviceUrl: string) {
     await expect(logs.logLine(INFO_LINE_2)).toBeVisible();
     await expect(logs.logLine(INFO_LINE)).not.toBeVisible();
     await expect(logs.logLine(WARNING_LINE)).not.toBeVisible();
-    await expect(logs.summary).toContainText('Showing 2 of 4 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 2 of 4 lines held in this browser.'
+    );
+  });
+
+  test('shows only the clicked level, and restores it on a second click @mocked', async () => {
+    // A row of level buttons reads as "pick the one you want to look at", so
+    // the first click narrows to that level rather than subtracting it.
+    await logs.clickLevel('error');
+    await expect(logs.logLine(ERROR_LINE)).toBeVisible();
+    await expect(logs.logLine(INFO_LINE)).toHaveCount(0);
+    await expect(logs.logLine(WARNING_LINE)).toHaveCount(0);
+    await expect(logs.summary).toContainText(
+      'Showing 1 of 4 lines held in this browser.'
+    );
+
+    // Clicking the last level still selected is the way back to all of them.
+    await logs.clickLevel('error');
+    await expect(logs.summary).toContainText(
+      'Showing 4 of 4 lines held in this browser.'
+    );
+    await expect(logs.logLine(INFO_LINE)).toBeVisible();
+  });
+
+  test('adds each further level clicked to the selection @mocked', async () => {
+    // Once a filter is active, a plain click on another level combines rather
+    // than replaces: error, then warning, shows both.
+    await logs.clickLevel('error');
+    await logs.clickLevel('warning');
+    await expect(logs.logLine(ERROR_LINE)).toBeVisible();
+    await expect(logs.logLine(WARNING_LINE)).toBeVisible();
+    await expect(logs.logLine(INFO_LINE)).toHaveCount(0);
+    await expect(logs.summary).toContainText(
+      'Showing 2 of 4 lines held in this browser.'
+    );
+
+    // And a click on a level that is already in the selection takes it out
+    // again.
+    await logs.clickLevel('error');
+    await expect(logs.logLine(ERROR_LINE)).toHaveCount(0);
+    await expect(logs.logLine(WARNING_LINE)).toBeVisible();
+    await expect(logs.summary).toContainText(
+      'Showing 1 of 4 lines held in this browser.'
+    );
+  });
+
+  test('combines levels with a modifier-click @mocked', async () => {
+    // The modifier is a plain toggle, so it reaches the same combination.
+    await logs.clickLevel('error');
+    await logs.toggleLevel('warning');
+    await expect(logs.logLine(ERROR_LINE)).toBeVisible();
+    await expect(logs.logLine(WARNING_LINE)).toBeVisible();
+    await expect(logs.logLine(INFO_LINE)).toHaveCount(0);
+    await expect(logs.summary).toContainText(
+      'Showing 2 of 4 lines held in this browser.'
+    );
+  });
+
+  test('dates the rows on screen next to the line count @mocked', async ({
+    page,
+  }) => {
+    // The rows themselves are the server's formatted lines, timestamp
+    // included; the range beside the count is what says which days they
+    // cover without scrolling to both ends of the pane.
+    await expect(logs.logLine('time="2026-07-25T10:00:00Z"')).toBeVisible();
+    // Rendered in the viewer's local zone, so assert the shape rather than the
+    // value.
+    const rangePattern =
+      /^Logs in time range: \d{4}-\d{2}-\d{2} \d{2}:\d{2} - \d{4}-\d{2}-\d{2} \d{2}:\d{2}$/;
+    await expect(logs.dateRange()).toHaveText(rangePattern);
+
+    // A buffer spanning two days reports two different dates, whatever zone
+    // the viewer renders them in -- these fixture stamps are 25 hours apart.
+    await mockLogTail(page, [
+      'time="2026-07-25T23:30:00Z" level=info msg="Late on the first day"',
+      'time="2026-07-27T00:30:00Z" level=info msg="Early on the third"',
+    ]);
+    await logs.goto();
+    await expect(logs.dateRange()).toHaveText(rangePattern);
+    const [from, to] = (await logs.dateRange().innerText())
+      .replace('Logs in time range: ', '')
+      .split(' - ');
+    expect(from.split(' ')[0]).not.toEqual(to.split(' ')[0]);
   });
 
   test('hides a level when its chip is toggled off @mocked', async () => {
@@ -159,11 +272,58 @@ export function registerLogViewerTests(serviceUrl: string) {
     await expect(logs.logLine(ERROR_LINE)).not.toBeVisible();
     // The non-error lines remain.
     await expect(logs.logLine(INFO_LINE)).toBeVisible();
-    await expect(logs.summary).toContainText('Showing 3 of 4 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 3 of 4 lines held in this browser.'
+    );
   });
 
   test('offers a log download control @smoke', async () => {
     await expect(logs.downloadButton).toBeVisible();
+  });
+
+  test('reports what a download would cover, not what is on screen @mocked @slow', async ({
+    page,
+  }) => {
+    test.slow();
+    // The buffer holds more than the viewer's initial load takes, so the two
+    // spans genuinely differ: the download subtext must describe the server's
+    // whole buffer, which is the question an admin is asking before they click
+    // it. Deriving it from the lines on screen would understate the history
+    // available by everything the initial limit truncated away.
+    const older = makeLogLines(CLIENT_TAIL_LIMIT, 1).map((line) =>
+      line.replace('2026-07-25T11:00:00Z', '2026-07-20T08:00:00Z')
+    );
+    await mockLogTail(page, [
+      ...older,
+      'time="2026-07-25T11:30:00Z" level=info msg="Newest line held"',
+    ]);
+    await logs.goto();
+    await expect(logs.summary).toContainText(
+      'Showing 10,000 of 10,000 lines held in this browser.',
+      { timeout: LARGE_FIXTURE_TIMEOUT }
+    );
+
+    // The oldest line the viewer holds is from the 20th, but the buffer's own
+    // extent starts there too -- what matters is that the subtext reports the
+    // buffer's ends rather than the response's.
+    const spanPattern =
+      /^Available: \d{4}-\d{2}-\d{2} \d{2}:\d{2} - \d{4}-\d{2}-\d{2} \d{2}:\d{2}$/;
+    await expect(logs.downloadSpan()).toHaveText(spanPattern);
+    const [from, to] = (await logs.downloadSpan().innerText())
+      .replace('Available: ', '')
+      .split(' - ');
+    expect(from.split(' ')[0]).not.toEqual(to.split(' ')[0]);
+  });
+
+  test('omits the download span when the buffer reports none @mocked', async ({
+    page,
+  }) => {
+    // A line with no timestamp of its own leaves the server unable to date its
+    // buffer; the control must then say nothing rather than show a half-range.
+    await mockLogTail(page, ['a line with no timestamp at all']);
+    await logs.goto();
+    await expect(logs.downloadButton).toBeVisible();
+    await expect(logs.downloadSpan()).toHaveCount(0);
   });
 
   test('shows a notice when the buffer is disabled @mocked', async ({
@@ -185,11 +345,36 @@ export function registerLogViewerTests(serviceUrl: string) {
     await mockLogTail(page, []);
     await logs.goto();
 
-    await expect(logs.summary).toContainText('Showing 0 of 0 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 0 of 0 lines held in this browser.'
+    );
     await expect(logs.unavailableNotice).not.toBeVisible();
+    // A level with no lines has no chip: the chip row describes what is in
+    // the buffer, and every chip in it can narrow the view to something.
     for (const level of ['info', 'warning', 'error']) {
-      await expect(logs.levelChip(level)).toContainText(`${level} (0)`);
+      await expect(logs.levelChip(level)).toHaveCount(0);
     }
+  });
+
+  test('offers a chip only for the levels present @mocked', async ({
+    page,
+  }) => {
+    await mockLogTail(page, [
+      'time="2026-07-25T10:00:00Z" level=info msg="Only info here"',
+    ]);
+    await logs.goto();
+
+    await expect(logs.levelChip('info')).toContainText('info (1)');
+    for (const absent of ['panic', 'fatal', 'error', 'warning', 'debug']) {
+      await expect(logs.levelChip(absent)).toHaveCount(0);
+    }
+
+    // A selected level keeps its chip whatever its count, so the selection
+    // stays explainable -- and undoable -- from the chips on screen.
+    await logs.clickLevel('info');
+    await logs.toggleLevel('info');
+    await expect(logs.levelChip('info')).toContainText('info (1)');
+    await expect(logs.rows()).toHaveCount(0);
   });
 
   test('treats short-form and level-less lines consistently @mocked', async ({
@@ -211,18 +396,26 @@ export function registerLogViewerTests(serviceUrl: string) {
     // The continuation line counts as info, so hiding info hides it too.
     await logs.toggleLevel('info');
     await expect(logs.logLine('foo.go:42')).toHaveCount(0);
-    await expect(logs.summary).toContainText('Showing 3 of 6 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 3 of 6 lines held in this browser.'
+    );
   });
 
   test('empties and restores the pane as levels are toggled @mocked', async () => {
-    for (const level of ['panic', 'fatal', 'error', 'warning', 'info']) {
+    // Only the levels the fixture actually contains have chips to click; the
+    // rest are already contributing nothing.
+    for (const level of ['error', 'warning', 'info']) {
       await logs.toggleLevel(level);
     }
-    await expect(logs.summary).toContainText('Showing 0 of 4 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 0 of 4 lines held in this browser.'
+    );
     await expect(logs.rows()).toHaveCount(0);
 
     await logs.toggleLevel('info');
-    await expect(logs.summary).toContainText('Showing 2 of 4 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 2 of 4 lines held in this browser.'
+    );
     await expect(logs.logLine(INFO_LINE)).toBeVisible();
   });
 
@@ -238,12 +431,16 @@ export function registerLogViewerTests(serviceUrl: string) {
       ],
     });
     await logs.goto();
-    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 4 of 4 lines held in this browser.'
+    );
 
     await expect(logs.logLine('Pelican origin restarted')).toBeVisible({
       timeout: POLL_TIMEOUT,
     });
-    await expect(logs.summary).toContainText('Showing 1 of 1 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 1 of 1 lines held in this browser.'
+    );
     await expect(logs.logLine(INFO_LINE)).toHaveCount(0);
     // A restart is not a dropped-line event; the marker would be misleading.
     await expect(logs.gaps()).toHaveCount(0);
@@ -263,21 +460,29 @@ export function registerLogViewerTests(serviceUrl: string) {
       batches: [[STREAMED_LINE_1], [STREAMED_LINE_2]],
     });
     await logs.goto();
-    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 4 of 4 lines held in this browser.'
+    );
 
     await expect(logs.logLine(STREAMED_TEXT_1)).toBeVisible({
       timeout: POLL_TIMEOUT,
     });
-    await expect(logs.summary).toContainText('Showing 5 of 5 lines.', {
-      timeout: POLL_TIMEOUT,
-    });
+    await expect(logs.summary).toContainText(
+      'Showing 5 of 5 lines held in this browser.',
+      {
+        timeout: POLL_TIMEOUT,
+      }
+    );
 
     await expect(logs.logLine(STREAMED_TEXT_2)).toBeVisible({
       timeout: POLL_TIMEOUT,
     });
-    await expect(logs.summary).toContainText('Showing 6 of 6 lines.', {
-      timeout: POLL_TIMEOUT,
-    });
+    await expect(logs.summary).toContainText(
+      'Showing 6 of 6 lines held in this browser.',
+      {
+        timeout: POLL_TIMEOUT,
+      }
+    );
     // The original lines survived the appends.
     await expect(logs.logLine(INFO_LINE)).toBeVisible();
   });
@@ -290,12 +495,16 @@ export function registerLogViewerTests(serviceUrl: string) {
     // handed the whole fixture again on every poll and duplicate it.
     await mockLogTailStreaming(page, { batches: [] });
     await logs.goto();
-    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 4 of 4 lines held in this browser.'
+    );
 
     await waitForForwardPoll(page);
     await waitForForwardPoll(page);
 
-    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 4 of 4 lines held in this browser.'
+    );
     await expect(logs.rows()).toHaveCount(4);
     await expect(logs.logLine(INFO_LINE)).toHaveCount(1);
   });
@@ -313,7 +522,9 @@ export function registerLogViewerTests(serviceUrl: string) {
     // than as lost evidence.
     await mockLogTailEvicting(page, EVICTION_FIXTURE);
     await logs.goto();
-    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 4 of 4 lines held in this browser.'
+    );
 
     await expect(logs.gaps()).toHaveCount(1, { timeout: POLL_TIMEOUT });
     await expect(logs.gaps().first()).toContainText(
@@ -322,7 +533,9 @@ export function registerLogViewerTests(serviceUrl: string) {
     await expect(logs.logLine('After the gap')).toBeVisible();
     // The marker occupies a row but is not itself a log line, so the
     // count covers only the 4 original plus the 3 that survived.
-    await expect(logs.summary).toContainText('Showing 7 of 7 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 7 of 7 lines held in this browser.'
+    );
   });
 
   test('keeps the dropped-lines marker visible under a level filter @mocked @slow', async ({
@@ -366,15 +579,21 @@ export function registerLogViewerTests(serviceUrl: string) {
     // blanking the pane, and that the warning is dismissible.
     await mockLogTailFailing(page, { failAfter: 1 });
     await logs.goto();
-    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 4 of 4 lines held in this browser.'
+    );
 
     await expect(logs.fetchErrorAlert).toBeVisible({ timeout: POLL_TIMEOUT });
     await expect(logs.logLine(INFO_LINE)).toBeVisible();
-    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 4 of 4 lines held in this browser.'
+    );
 
     await logs.dismissFetchError();
     await expect(logs.fetchErrorAlert).not.toBeVisible();
-    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 4 of 4 lines held in this browser.'
+    );
   });
 
   test('clears the failure warning once polling recovers @mocked @slow', async ({
@@ -386,7 +605,9 @@ export function registerLogViewerTests(serviceUrl: string) {
     await logs.goto();
     await expect(logs.fetchErrorAlert).toBeVisible({ timeout: POLL_TIMEOUT });
     await expect(logs.fetchErrorAlert).not.toBeVisible({ timeout: 15000 });
-    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 4 of 4 lines held in this browser.'
+    );
   });
 
   test('surfaces a 403 from the log-read gate @mocked', async ({ page }) => {
@@ -398,7 +619,9 @@ export function registerLogViewerTests(serviceUrl: string) {
     await expect(logs.fetchErrorAlert).toContainText('403');
     // The pane itself still renders -- this is a refusal, not the
     // buffer-disabled notice.
-    await expect(logs.summary).toContainText('Showing 0 of 0 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 0 of 0 lines held in this browser.'
+    );
     await expect(logs.unavailableNotice).not.toBeVisible();
   });
 
@@ -413,7 +636,9 @@ export function registerLogViewerTests(serviceUrl: string) {
     // oldest.
     await mockLogTail(page, makeLogLines(200));
     await logs.goto();
-    await expect(logs.summary).toContainText('Showing 200 of 200 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 200 of 200 lines held in this browser.'
+    );
     await expect(logs.autoScrollCheckbox).toBeChecked();
     // The pin runs off an effect, so poll rather than reading once.
     await expect
@@ -426,7 +651,9 @@ export function registerLogViewerTests(serviceUrl: string) {
     // back down, and that "Scroll to bottom" restores the pin.
     await mockLogTail(page, makeLogLines(200));
     await logs.goto();
-    await expect(logs.summary).toContainText('Showing 200 of 200 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 200 of 200 lines held in this browser.'
+    );
     await expect
       .poll(() => logs.paneBottomGap(), { timeout: POLL_TIMEOUT })
       .toBeLessThanOrEqual(20);
@@ -444,6 +671,35 @@ export function registerLogViewerTests(serviceUrl: string) {
       .toBeLessThanOrEqual(20);
   });
 
+  test('shows the matching rows when filtering from a scrolled-up position @mocked @slow', async ({
+    page,
+  }) => {
+    // Regression: filtering shortens the content, and the browser clamps the
+    // pane's scroll offset to fit -- but the viewer kept virtualizing from
+    // the offset it had recorded before the filter, which now points past
+    // the end of the filtered list. The pane rendered no rows at all while
+    // the summary above it reported matches, so a filter that had worked
+    // read as a filter that had found nothing.
+    await mockLogTail(page, makeLogLines(2000).concat(DEFAULT_LOG_LINES));
+    await logs.goto();
+    await expect(logs.summary).toContainText(
+      'Showing 2,004 of 2,004 lines held in this browser.',
+      { timeout: LARGE_FIXTURE_TIMEOUT }
+    );
+
+    // Scroll away from the bottom: with the pin released, nothing else will
+    // move the offset back into range on the viewer's behalf.
+    await logs.scrollPaneUpBy(400);
+    await expect(logs.autoScrollCheckbox).not.toBeChecked();
+
+    await logs.textFilter.fill(WARNING_LINE);
+    await expect(logs.summary).toContainText(
+      'Showing 1 of 2,004 lines held in this browser.'
+    );
+    await expect(logs.rows()).toHaveCount(1);
+    await expect(logs.logLine(WARNING_LINE)).toBeVisible();
+  });
+
   test('mounts only a window of rows for a large buffer @mocked @slow', async ({
     page,
   }) => {
@@ -454,7 +710,7 @@ export function registerLogViewerTests(serviceUrl: string) {
     await mockLogTail(page, makeLogLines(CLIENT_TAIL_LIMIT));
     await logs.goto();
     await expect(logs.summary).toContainText(
-      'Showing 10,000 of 10,000 lines.',
+      'Showing 10,000 of 10,000 lines held in this browser.',
       {
         timeout: LARGE_FIXTURE_TIMEOUT,
       }
@@ -475,7 +731,7 @@ export function registerLogViewerTests(serviceUrl: string) {
     await mockLogTail(page, makeLogLines(CLIENT_TAIL_LIMIT + 50));
     await logs.goto();
     await expect(logs.summary).toContainText(
-      'Showing 10,000 of 10,000 lines.',
+      'Showing 10,000 of 10,000 lines held in this browser.',
       {
         timeout: LARGE_FIXTURE_TIMEOUT,
       }
@@ -486,14 +742,18 @@ export function registerLogViewerTests(serviceUrl: string) {
     await expect(logs.summary).toContainText('No more history.', {
       timeout: POLL_TIMEOUT,
     });
-    await expect(logs.summary).toContainText('Showing 10,050 of 10,050 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 10,050 of 10,050 lines held in this browser.'
+    );
 
     // Re-hitting the top must not re-fetch or duplicate the history.
     await logs.scrollPaneToTop();
     await waitForForwardPoll(page);
     await logs.scrollPaneToTop();
     await waitForForwardPoll(page);
-    await expect(logs.summary).toContainText('Showing 10,050 of 10,050 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 10,050 of 10,050 lines held in this browser.'
+    );
   });
 
   // ---------------------------------------------------------------------
@@ -524,6 +784,8 @@ export function registerLogViewerTests(serviceUrl: string) {
     await page.getByRole('link', { name: 'Logs', exact: true }).click();
     await expect(page).toHaveURL(/\/settings\/logs\//);
     await expect(logs.heading).toBeVisible();
-    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+    await expect(logs.summary).toContainText(
+      'Showing 4 of 4 lines held in this browser.'
+    );
   });
 }

--- a/web_ui/frontend/e2e/shared_tests/logViewerTests.ts
+++ b/web_ui/frontend/e2e/shared_tests/logViewerTests.ts
@@ -1,0 +1,102 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+import { test, expect } from '@playwright/test';
+import { LogViewerPage } from '../shared_pages/LogViewerPage';
+import { mockLogTail, mockLogTailDisabled } from '../mocks/api/v1.0/logs/tail';
+
+// Distinctive substrings of the fixture lines (see DEFAULT_LOG_LINES). Chosen
+// so each matches exactly one seeded line -- note both a warning/error and an
+// info line mention "backend storage", so we always assert on the fuller
+// phrase.
+const INFO_LINE = 'Pelican origin started';
+const WARNING_LINE = 'Disk space is running low';
+const ERROR_LINE = 'Failed to connect to backend storage';
+const INFO_LINE_2 = 'Recovered connection to backend storage';
+
+/**
+ * Registers the shared log-viewer tests for a given service URL. Call this
+ * inside a `test.describe` block in each service's spec file.
+ *
+ * @param serviceUrl  The relative URL for the log viewer page
+ *                    (e.g. './view/settings/logs/').
+ */
+export function registerLogViewerTests(serviceUrl: string) {
+  let logs: LogViewerPage;
+
+  test.beforeEach(async ({ page }) => {
+    logs = new LogViewerPage(page, serviceUrl);
+    // Seed a stable fixture before navigating so the initial fetch (and every
+    // poll thereafter) is served from the mock and never the real server.
+    await mockLogTail(page);
+    await logs.goto();
+  });
+
+  test('shows the Server Logs heading @smoke', async () => {
+    await expect(logs.heading).toBeVisible();
+  });
+
+  test('renders the log lines returned by the API @smoke @mocked', async () => {
+    await expect(logs.logLine(INFO_LINE)).toBeVisible();
+    await expect(logs.logLine(WARNING_LINE)).toBeVisible();
+    await expect(logs.logLine(ERROR_LINE)).toBeVisible();
+    await expect(logs.logLine(INFO_LINE_2)).toBeVisible();
+    // Two info lines, one warning, one error.
+    await expect(logs.summary).toContainText('Showing 4 of 4 lines.');
+  });
+
+  test('shows per-level counts in the filter chips @mocked', async () => {
+    await expect(logs.levelChip('info')).toContainText('info (2)');
+    await expect(logs.levelChip('warning')).toContainText('warning (1)');
+    await expect(logs.levelChip('error')).toContainText('error (1)');
+  });
+
+  test('filters visible lines by the text filter @mocked', async () => {
+    // "backend storage" appears in the error line and the second info line.
+    await logs.textFilter.fill('backend storage');
+    await expect(logs.logLine(ERROR_LINE)).toBeVisible();
+    await expect(logs.logLine(INFO_LINE_2)).toBeVisible();
+    await expect(logs.logLine(INFO_LINE)).not.toBeVisible();
+    await expect(logs.logLine(WARNING_LINE)).not.toBeVisible();
+    await expect(logs.summary).toContainText('Showing 2 of 4 lines.');
+  });
+
+  test('hides a level when its chip is toggled off @mocked', async () => {
+    await expect(logs.logLine(ERROR_LINE)).toBeVisible();
+    await logs.toggleLevel('error');
+    await expect(logs.logLine(ERROR_LINE)).not.toBeVisible();
+    // The non-error lines remain.
+    await expect(logs.logLine(INFO_LINE)).toBeVisible();
+    await expect(logs.summary).toContainText('Showing 3 of 4 lines.');
+  });
+
+  test('offers a log download control @smoke', async () => {
+    await expect(logs.downloadButton).toBeVisible();
+  });
+
+  test('shows a notice when the buffer is disabled @mocked', async ({
+    page,
+  }) => {
+    // Re-route to report the buffer disabled, then reload so the initial fetch
+    // sees enabled=false. The later route registration takes precedence.
+    await mockLogTailDisabled(page);
+    await logs.goto();
+    await expect(logs.unavailableNotice).toBeVisible();
+    await expect(logs.logLine(INFO_LINE)).not.toBeVisible();
+  });
+}

--- a/web_ui/log_buffer_api.go
+++ b/web_ui/log_buffer_api.go
@@ -74,6 +74,13 @@ type LogTailResponse struct {
 	FirstCursor string `json:"firstCursor"`
 	LastCursor  string `json:"lastCursor"`
 	Reached     bool   `json:"reached"`
+	// Dropped is how many lines are missing between the caller's `since`
+	// cursor and the start of Content, because they were evicted from the
+	// buffer before the caller asked for them or trimmed to satisfy
+	// `limit`. Content is contiguous only when this is 0. Cursors are
+	// opaque, so a client cannot derive this and must read it here to know
+	// whether what it is displaying has holes in it.
+	Dropped int64 `json:"dropped"`
 	// InstanceID identifies the buffer that produced this response. It
 	// changes when the server restarts (or the buffer is otherwise
 	// re-initialized); clients use a change here as a signal to drop
@@ -222,6 +229,7 @@ func HandleLogTail(ctx *gin.Context) {
 		FirstCursor: logTailCursor(tail.FirstSeq),
 		LastCursor:  logTailCursor(tail.LastSeq),
 		Reached:     tail.Reached,
+		Dropped:     tail.Dropped,
 		InstanceID:  buf.InstanceID(),
 	})
 }

--- a/web_ui/log_buffer_api.go
+++ b/web_ui/log_buffer_api.go
@@ -1,0 +1,279 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package web_ui
+
+import (
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/token_scopes"
+)
+
+// logTailCursor encodes an int64 seq as a URL-safe base64 string so the
+// wire format stays opaque. The zero seq round-trips to the empty string,
+// so a client with no cursor sends `?since=` and gets everything.
+func logTailCursor(seq int64) string {
+	if seq == 0 {
+		return ""
+	}
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], uint64(seq))
+	return base64.RawURLEncoding.EncodeToString(buf[:])
+}
+
+// parseLogTailCursor decodes what logTailCursor produced. The empty
+// string is a valid "give me everything" cursor and maps to seq 0.
+func parseLogTailCursor(s string) (int64, error) {
+	if s == "" {
+		return 0, nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil || len(raw) != 8 {
+		return 0, fmt.Errorf("invalid cursor")
+	}
+	return int64(binary.BigEndian.Uint64(raw)), nil
+}
+
+// LogTailResponse is the payload of GET /logs/tail. FirstCursor and
+// LastCursor are opaque tokens that bracket the seq range covered by
+// Content -- pass LastCursor back as the next `since=` for forward
+// polling, or FirstCursor back as the next `before=` for scrolling into
+// older history. Reached is true when scroll-up has hit the wall: no
+// content older than FirstCursor is currently held.
+type LogTailResponse struct {
+	Enabled     bool   `json:"enabled"`
+	Content     string `json:"content"`
+	FirstCursor string `json:"firstCursor"`
+	LastCursor  string `json:"lastCursor"`
+	Reached     bool   `json:"reached"`
+	// InstanceID identifies the buffer that produced this response. It
+	// changes when the server restarts (or the buffer is otherwise
+	// re-initialized); clients use a change here as a signal to drop
+	// their local state and start fresh -- cursors from a previous
+	// instance are meaningless against the new one.
+	InstanceID string `json:"instanceId"`
+}
+
+// LogReadAuthHandler is the middleware that gates every log-read endpoint.
+// Requires either server.admin (already implies everything) or the
+// dedicated pelican.log_read scope.
+func LogReadAuthHandler(ctx *gin.Context) {
+	user := ctx.GetString("User")
+	if user == "" {
+		ctx.AbortWithStatusJSON(http.StatusUnauthorized,
+			server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "Login required to view server logs",
+			})
+		return
+	}
+	var groups []string
+	if v, exists := ctx.Get("Groups"); exists {
+		if s, ok := v.([]string); ok {
+			groups = s
+		}
+	}
+	identity := UserIdentity{
+		Username: user,
+		Groups:   groups,
+		ID:       ctx.GetString("UserId"),
+		Sub:      ctx.GetString("OIDCSub"),
+	}
+	// server.admin implies all lower scopes -- match the pattern
+	// EffectiveScopesForIdentity uses in the derivation path.
+	if isAdmin, _ := CheckAdmin(identity); isAdmin {
+		ctx.Next()
+		return
+	}
+	if hasScope(identity, token_scopes.Pelican_LogRead) {
+		ctx.Next()
+		return
+	}
+	ctx.AbortWithStatusJSON(http.StatusForbidden,
+		server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "You do not have permission to read server logs",
+		})
+}
+
+// HandleLogTail returns log lines relative to an opaque cursor. The
+// caller supplies exactly one of:
+//
+//	?since=<cursor>              -- lines strictly after cursor (forward
+//	                                polling / live tail); pass
+//	                                response.lastCursor back as the next
+//	                                since. Empty (or absent) since yields
+//	                                every line currently held.
+//	?before=<cursor>&count=<N>   -- lines strictly before cursor
+//	                                (scroll-up into older history); pass
+//	                                response.firstCursor back as the
+//	                                next before. count is a hint
+//	                                (default: one batch's worth) -- the
+//	                                server rounds up to whole batches so
+//	                                a batch is decompressed at most once
+//	                                per scroll session.
+//
+// Providing both since and before is a bad request. Cursors are opaque
+// URL-safe base64 tokens; internal structure (batching, LZ4 compression,
+// pending buffer) is not part of the API contract and clients must not
+// interpret cursors beyond echoing them.
+func HandleLogTail(ctx *gin.Context) {
+	buf := config.GlobalLogRingBuffer()
+	if buf == nil {
+		ctx.JSON(http.StatusOK, LogTailResponse{Enabled: false})
+		return
+	}
+
+	sinceRaw := ctx.Query("since")
+	beforeRaw := ctx.Query("before")
+	countRaw := ctx.Query("count")
+	limitRaw := ctx.Query("limit")
+
+	if sinceRaw != "" && beforeRaw != "" {
+		ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "since= and before= are mutually exclusive",
+		})
+		return
+	}
+
+	var tail config.LogTail
+	switch {
+	case beforeRaw != "":
+		before, err := parseLogTailCursor(beforeRaw)
+		if err != nil {
+			ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "invalid before= cursor",
+			})
+			return
+		}
+		count := 0
+		if countRaw != "" {
+			n, err := parseCount(countRaw)
+			if err != nil {
+				ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+					Status: server_structs.RespFailed,
+					Msg:    err.Error(),
+				})
+				return
+			}
+			count = n
+		}
+		tail = buf.TailBefore(before, count)
+	default:
+		since, err := parseLogTailCursor(sinceRaw)
+		if err != nil {
+			ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "invalid since= cursor",
+			})
+			return
+		}
+		// limit caps the number of newest lines returned (used by the
+		// viewer to bound its initial load when the server is
+		// configured with a large buffer). 0 means unbounded.
+		limit := 0
+		if limitRaw != "" {
+			n, err := parseCount(limitRaw)
+			if err != nil {
+				ctx.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+					Status: server_structs.RespFailed,
+					Msg:    "invalid limit=",
+				})
+				return
+			}
+			limit = n
+		}
+		tail = buf.TailSince(since, limit)
+	}
+
+	ctx.JSON(http.StatusOK, LogTailResponse{
+		Enabled:     true,
+		Content:     string(tail.Content),
+		FirstCursor: logTailCursor(tail.FirstSeq),
+		LastCursor:  logTailCursor(tail.LastSeq),
+		Reached:     tail.Reached,
+		InstanceID:  buf.InstanceID(),
+	})
+}
+
+// parseCount decodes the `count=` hint that accompanies a before= scroll-up
+// request. Negative or non-numeric input is rejected. strconv.Atoi parses
+// strictly (unlike fmt.Sscanf, which would accept a partly-numeric "100abc").
+func parseCount(raw string) (int, error) {
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("invalid count=")
+	}
+	return n, nil
+}
+
+// downloadFilenameSanitizer strips characters from a hostname that would
+// need shell-quoting in a Content-Disposition filename. A conservative
+// allow-list keeps the download filename copy-pastable on every shell.
+var downloadFilenameSanitizer = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+// HandleLogTailDownload gzip-streams every log line the buffer currently
+// holds. The filename embeds the server hostname and a UTC timestamp so
+// downloads from different servers or times don't collide when saved
+// into the same directory.
+func HandleLogTailDownload(ctx *gin.Context) {
+	// buf may be nil when buffering is disabled. Rather than return a JSON
+	// body (which the browser, navigated here via window.location, would just
+	// display), fall through and serve a valid but empty .gz -- TailSince is
+	// nil-safe and yields empty content, so the client still gets a file.
+	buf := config.GlobalLogRingBuffer()
+	host := downloadFilenameSanitizer.ReplaceAllString(param.Server_Hostname.GetString(), "-")
+	if host == "" {
+		host = "server"
+	}
+	stamp := time.Now().UTC().Format("20060102-150405Z")
+	fname := fmt.Sprintf("pelican-logs-%s-%s.log.gz", host, stamp)
+	ctx.Header("Content-Type", "application/gzip")
+	ctx.Header("Content-Disposition", `attachment; filename="`+fname+`"`)
+
+	gz := gzip.NewWriter(ctx.Writer)
+	defer func() {
+		if err := gz.Close(); err != nil {
+			log.Debugln("log buffer: gzip close failed:", err)
+		}
+	}()
+
+	// TailSince(0) returns everything the buffer currently holds in a
+	// single call: batches concatenated in seq order, followed by the
+	// pending body. Handing the whole thing to gzip is fine at the
+	// buffer's cap (default 1 MB compressed / ~5 MB raw).
+	tail := buf.TailSince(0, 0)
+	if _, err := gz.Write(tail.Content); err != nil {
+		log.Debugln("log buffer: gzip write failed:", err)
+	}
+}

--- a/web_ui/log_buffer_api.go
+++ b/web_ui/log_buffer_api.go
@@ -87,6 +87,14 @@ type LogTailResponse struct {
 	// their local state and start fresh -- cursors from a previous
 	// instance are meaningless against the new one.
 	InstanceID string `json:"instanceId"`
+	// BufferOldest and BufferNewest bracket everything the buffer holds --
+	// i.e. what GET /logs/download would return -- as RFC3339 timestamps,
+	// empty when the buffer holds nothing datable. This is deliberately not
+	// the range covered by Content: a reader has usually paged in only the
+	// newest lines, so it cannot tell from its own state how much history a
+	// download would give it.
+	BufferOldest string `json:"bufferOldest,omitempty"`
+	BufferNewest string `json:"bufferNewest,omitempty"`
 }
 
 // LogReadAuthHandler is the middleware that gates every log-read endpoint.
@@ -223,7 +231,7 @@ func HandleLogTail(ctx *gin.Context) {
 		tail = buf.TailSince(since, limit)
 	}
 
-	ctx.JSON(http.StatusOK, LogTailResponse{
+	resp := LogTailResponse{
 		Enabled:     true,
 		Content:     string(tail.Content),
 		FirstCursor: logTailCursor(tail.FirstSeq),
@@ -231,7 +239,12 @@ func HandleLogTail(ctx *gin.Context) {
 		Reached:     tail.Reached,
 		Dropped:     tail.Dropped,
 		InstanceID:  buf.InstanceID(),
-	})
+	}
+	if oldest, newest, ok := buf.Span(); ok {
+		resp.BufferOldest = oldest.Format(time.RFC3339)
+		resp.BufferNewest = newest.Format(time.RFC3339)
+	}
+	ctx.JSON(http.StatusOK, resp)
 }
 
 // parseCount decodes the `count=` hint that accompanies a before= scroll-up

--- a/web_ui/log_buffer_api_test.go
+++ b/web_ui/log_buffer_api_test.go
@@ -1,0 +1,76 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package web_ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid values", func(t *testing.T) {
+		for _, tc := range []struct {
+			in   string
+			want int
+		}{
+			{"0", 0},
+			{"1", 1},
+			{"100", 100},
+			{"10000", 10000},
+		} {
+			got, err := parseCount(tc.in)
+			require.NoError(t, err, "input %q", tc.in)
+			assert.Equal(t, tc.want, got, "input %q", tc.in)
+		}
+	})
+
+	t.Run("rejects invalid values", func(t *testing.T) {
+		// The strict strconv.Atoi parse must reject partly-numeric input
+		// (the reason we moved off fmt.Sscanf), negatives, and non-numbers.
+		for _, in := range []string{"", "100abc", "abc", "-1", "-100", "1.5", " 100", "0x10"} {
+			_, err := parseCount(in)
+			assert.Error(t, err, "input %q should be rejected", in)
+		}
+	})
+}
+
+func TestLogTailCursorRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// The empty cursor is the "give me everything" sentinel and maps to seq 0.
+	got, err := parseLogTailCursor("")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), got)
+	assert.Equal(t, "", logTailCursor(0))
+
+	for _, seq := range []int64{1, 42, 1 << 20, 1<<63 - 1} {
+		encoded := logTailCursor(seq)
+		assert.NotEmpty(t, encoded, "seq %d should encode to a non-empty cursor", seq)
+		decoded, err := parseLogTailCursor(encoded)
+		require.NoError(t, err, "seq %d", seq)
+		assert.Equal(t, seq, decoded, "seq %d should round-trip", seq)
+	}
+
+	_, err = parseLogTailCursor("not-valid-base64!!")
+	assert.Error(t, err)
+}

--- a/web_ui/log_buffer_api_test.go
+++ b/web_ui/log_buffer_api_test.go
@@ -19,11 +19,104 @@
 package web_ui
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/test_utils"
 )
+
+// TestLogReadAuthHandler pins who may read the server's logs. The buffer this
+// gate protects holds recent log lines from every subsystem, so admitting the
+// wrong caller discloses far more than the log-viewer page itself; the
+// dedicated pelican.log_read scope exists so an operator can grant log access
+// without granting administration, and it must not work in reverse.
+func TestLogReadAuthHandler(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+
+	testCases := []struct {
+		name          string
+		setupUserFunc func(*gin.Context)
+		expectedCode  int
+		expectedError string
+	}{
+		{
+			name: "anonymous-caller-rejected",
+			setupUserFunc: func(ctx *gin.Context) {
+				ctx.Set("User", "")
+			},
+			expectedCode:  http.StatusUnauthorized,
+			expectedError: "Login required to view server logs",
+		},
+		{
+			name: "authenticated-user-without-scope-rejected",
+			setupUserFunc: func(ctx *gin.Context) {
+				require.NoError(t, param.Server_UIAdminUsers.Set([]string{"admin1"}))
+				ctx.Set("User", "someone")
+			},
+			expectedCode:  http.StatusForbidden,
+			expectedError: "You do not have permission to read server logs",
+		},
+		{
+			name: "admin-admitted-without-an-explicit-grant",
+			setupUserFunc: func(ctx *gin.Context) {
+				require.NoError(t, param.Server_UIAdminUsers.Set([]string{"admin1"}))
+				ctx.Set("User", "admin1")
+			},
+			expectedCode: http.StatusOK,
+		},
+		{
+			name: "admin-group-member-admitted",
+			setupUserFunc: func(ctx *gin.Context) {
+				require.NoError(t, param.Server_UIAdminUsers.Set([]string{}))
+				require.NoError(t, param.Server_AdminGroups.Set([]string{"pelican-admins"}))
+				ctx.Set("User", "user1")
+				ctx.Set("Groups", []string{"pelican-admins"})
+			},
+			expectedCode: http.StatusOK,
+		},
+		{
+			name: "non-admin-group-member-rejected",
+			setupUserFunc: func(ctx *gin.Context) {
+				require.NoError(t, param.Server_UIAdminUsers.Set([]string{}))
+				require.NoError(t, param.Server_AdminGroups.Set([]string{"pelican-admins"}))
+				ctx.Set("User", "user1")
+				ctx.Set("Groups", []string{"pelican-users"})
+			},
+			expectedCode:  http.StatusForbidden,
+			expectedError: "You do not have permission to read server logs",
+		},
+	}
+
+	gin.SetMode(gin.TestMode)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			router := gin.Default()
+			router.GET("/test",
+				func(ctx *gin.Context) { tc.setupUserFunc(ctx) },
+				LogReadAuthHandler,
+				func(ctx *gin.Context) { ctx.AbortWithStatus(http.StatusOK) },
+			)
+			req, err := http.NewRequest("GET", "/test", nil)
+			require.NoError(t, err)
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tc.expectedCode, w.Code)
+			if tc.expectedError != "" {
+				assert.Contains(t, w.Body.String(), tc.expectedError)
+			}
+			server_utils.ResetTestState()
+		})
+	}
+}
 
 func TestParseCount(t *testing.T) {
 	t.Parallel()
@@ -45,8 +138,8 @@ func TestParseCount(t *testing.T) {
 	})
 
 	t.Run("rejects invalid values", func(t *testing.T) {
-		// The strict strconv.Atoi parse must reject partly-numeric input
-		// (the reason we moved off fmt.Sscanf), negatives, and non-numbers.
+		// parseCount is strict: partly-numeric input ("100abc"), negatives,
+		// and non-numbers are all rejected rather than silently truncated.
 		for _, in := range []string{"", "100abc", "abc", "-1", "-100", "1.5", " 100", "0x10"} {
 			_, err := parseCount(in)
 			assert.Error(t, err, "input %q should be rejected", in)

--- a/web_ui/server_api.go
+++ b/web_ui/server_api.go
@@ -18,6 +18,7 @@
 package web_ui
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -218,7 +219,7 @@ func HandleCreateDowntime(ctx *gin.Context) {
 
 	// Mirror to Registry when running as Origin/Cache so downtime persists centrally (Director polls Registry for all sources)
 	// If mirroring fails, we proceed with the local operation and rely on eventual consistency through server advertisements.
-	if err := mirrorDowntimeToRegistry(ctx, downtime, http.MethodPost, idStr); err != nil {
+	if err := mirrorDowntimeToRegistry(ctx.Request.Context(), downtime, http.MethodPost, idStr); err != nil {
 		log.Warningf("Failed to sync downtime creation to the Registry immediately; synchronization will occur during the next server advertisement: %v", err)
 	}
 
@@ -375,7 +376,7 @@ func HandleUpdateDowntime(ctx *gin.Context) {
 
 	// Mirror updates to the Registry to keep the central downtime records consistent with local changes.
 	// If mirroring fails, we proceed with the local operation and rely on eventual consistency through server advertisements.
-	if err := mirrorDowntimeToRegistry(ctx, updatedDowntime, http.MethodPut, uuid); err != nil {
+	if err := mirrorDowntimeToRegistry(ctx.Request.Context(), updatedDowntime, http.MethodPut, uuid); err != nil {
 		log.Warningf("Failed to sync downtime update to the Registry immediately; synchronization will occur during the next server advertisement: %v", err)
 	}
 
@@ -409,7 +410,7 @@ func HandleDeleteDowntime(ctx *gin.Context) {
 
 	// Mirror deletion to the Registry so the central DB removes the downtime as well.
 	// If mirroring fails, we proceed with the local operation and rely on eventual consistency through server advertisements.
-	if err := mirrorDowntimeToRegistry(ctx, *existingDowntime, http.MethodDelete, uuid); err != nil {
+	if err := mirrorDowntimeToRegistry(ctx.Request.Context(), *existingDowntime, http.MethodDelete, uuid); err != nil {
 		log.Warningf("Failed to sync downtime deletion to the Registry immediately; synchronization will occur during the next server advertisement: %v", err)
 	}
 
@@ -497,7 +498,13 @@ func HandleGetServerLocalMetadataHistory(ctx *gin.Context) {
 // mirrorDowntimeToRegistry forwards a downtime CRUD to the Registry, if the
 // current server has an Origin or Cache service. It uses the server's issuer key to mint a short-lived
 // service token and sets Authorization: Bearer <token>.
-func mirrorDowntimeToRegistry(ctx *gin.Context, dt server_structs.Downtime, method string, id string) error {
+// The context must NOT be the *gin.Context. Gin pools its contexts and
+// reuses them for later requests, while net/http's transport keeps a
+// reference to whatever context an outbound request was built from until
+// that connection's read loop finishes -- reaching back into a context that
+// by then belongs to a different request. Pass ctx.Request.Context(), which
+// has the lifetime of the request being served.
+func mirrorDowntimeToRegistry(ctx context.Context, dt server_structs.Downtime, method string, id string) error {
 	if id == "" {
 		return errors.New("downtime ID is required")
 	}

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -691,6 +691,20 @@ func registerCommonEndpoints(routerGroup *gin.RouterGroup) error {
 		loggingAPI.DELETE("/level/:changeId", HandleDeleteLogLevel)
 	}
 
+	// In-memory log buffer viewer/download API. Gated by the dedicated
+	// pelican.log_read scope so a triage user can be granted read-only access
+	// without also picking up admin privileges (or vice versa -- an admin
+	// keeps access via CheckAdmin inside LogReadAuthHandler).
+	//
+	// The public surface is intentionally two endpoints: tail (with an
+	// opaque cursor) and download. Internal structure (batches, LZ4
+	// compression, pending buffer) is not part of the API contract.
+	logBufferAPI := routerGroup.Group("/logs", AuthHandler, LogReadAuthHandler)
+	{
+		logBufferAPI.GET("/tail", HandleLogTail)
+		logBufferAPI.GET("/download", HandleLogTailDownload)
+	}
+
 	downtimeAPI := routerGroup.Group("/downtime")
 	{
 		downtimeAPI.POST("", DowntimeAuthHandler, HandleCreateDowntime)


### PR DESCRIPTION
Picked at a long-running irritation over the weekend: lack of log rotation. What
started there grew into the surrounding pieces an operator needs before rotated
logs are actually useful — somewhere to read them from without shelling in, and
a way to hand out that access without handing out administration.

Four things ship here.

## 1. Built-in, asynchronous log writing and rotation

When `Logging.LogLocation` points at a regular file, Pelican now manages its own
log writing and rotation, so it "just works" on hosts with no external
log-rotation service — notably the user-level client agent.

A dedicated, errgroup-managed goroutine drains an in-memory batch to the log file
(flushing on a byte threshold or every `Logging.Rotation.FlushInterval`),
decoupling logging call sites from disk I/O. The buffer is bounded: once it
fills, `Write` applies backpressure so callers cannot outrun a slow or stalled
log device. On shutdown the writer flips to synchronous mode so late lines — from
signal handling, a panic, or `log.Fatal` — are written directly. A failed write is
fatal: the goroutine surfaces it so the errgroup cancels shutdown. Pelican should
not keep serving data it can no longer account for.

Rotation applies to regular files only, never to stderr, `/dev/stdout`, pipes or
devices:

- `Logging.Rotation.Frequency`: daily/hourly/none, on the calendar boundary in
  local time. Rotated files are named for the period they cover (e.g.
  `pelican.log.2026-06-08`) so an administrator can find logs by date.
- `Logging.Rotation.MaxSize`: size-triggered rotation, combinable with time.
- `Logging.Rotation.MaxRetentionSize` / `MaxRetentionPeriod`: independent size
  and age budgets, replacing a file-count cap.
- `Logging.Rotation.Disable` / `DisableCompress`: zero-value-friendly toggles.

Rotation holds an `os.Root` handle on the log directory, so it keeps working
after a privilege drop, and it survives restarts: a stale active file is rotated
under the period it was last written in. When rotation is left to an external
tool, the writer notices that the path no longer refers to the file it holds open
and reopens — otherwise `logrotate`'s rename would leave Pelican writing to an
unlinked inode forever.

Failing to rotate is tolerated: it is usually transient, and it is not a reason to
stop serving data. It is retried, and the growth it causes is bounded by
`MaxRetentionSize` — past that the log would fill the filesystem, which is fatal.

## 2. An in-memory log buffer and a browser log viewer

`config.LogRingBuffer` keeps a bounded window of recent lines in memory
(`Logging.Buffer.MaxSize`, `Logging.Buffer.BatchLines`), batched and LZ4-compressed,
so an administrator can read recent logs from the web UI instead of shelling into
the host. A new page at **Settings → Logs** tails it live, filters by level and
text, virtualizes its row list so a busy server cannot freeze the tab, and offers
the whole buffer as a gzip download.

The buffer holds what the log file holds, including the censoring: lines are
passed through the bearer-token redaction before being stored, so the buffer
never becomes a source of credentials the log file was careful not to keep.

Reads report what they could not show. The buffer evicts, so a client that falls
behind has lines disappear from under its cursor; because cursors are opaque, it
cannot work that out for itself. Responses carry a `dropped` count and the viewer
marks the break, rather than presenting a truncated history as a complete one.

## 3. A new user-grantable scope: `pelican.log_read`

**This adds a permission.** `pelican.log_read` is `userGrantable`, and it admits
its holder to the log viewer and the two new endpoints below without making them
an administrator. Granting it is equivalent to granting sight of everything the
server logs, which is exactly why it is separate: reading logs is a common
triage need, and it should not require handing over the server.

Only a full `server.admin` can grant it. `server.admin` carries it implicitly.
The scope is resolved from the user's grants when a request arrives, so it
governs what an account may reach rather than what a particular credential may
do.

New endpoints, both behind that gate:

- `GET /api/v1.0/logs/tail` — a page of buffered lines, addressed by an opaque
  cursor, forwards for live tail or backwards to scroll into history.
- `GET /api/v1.0/logs/download` — the whole buffer, gzipped.

Because the scope-only route into `/settings/` is new, the settings shell and the
subsystem sidebars now admit scope holders and hide the sub-pages they cannot
reach, and `/settings/` sends them to the first page they can.

## 4. Non-Linux runtime path defaults

`Origin.RunLocation`, `Cache.RunLocation`, `Cache.StorageLocation`,
`Cache.DataLocations`, `Cache.MetaLocations`, `Cache.NamespaceLocation` and
`LocalCache.RunLocation` get sane defaults on macOS and Windows, where the Linux
`/run` layout does not exist and the `AF_UNIX` path budget is tight enough to
matter. Configured values are respected; only the defaults move.

## Default changes worth noting

`Logging.Rotation.MaxSize` drops from 1GB to 100MB and
`Logging.Rotation.MaxRetentionSize` from 10GB to 1GB. The previous pair reserved
roughly 11GB of disk by default, which is a lot to claim without being asked —
particularly for the client agent, which writes under the user's own directory.

## Testing

Go tests cover the writer's rotation, retention, compression, shutdown and
failure paths (including concurrent writers under `-race`), the ring buffer's
cursor arithmetic, eviction accounting and redaction, and the authorization gate
on the new endpoints. Playwright tests cover the viewer end to end — live tail,
error and recovery, virtualization, scroll-back, dropped-line marking, download,
and who is and is not offered the page — on both the origin and cache suites.
