### PR TITLE
Stop iterating the live serverAds cache under its own lock

### DIFF
--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -56,6 +56,9 @@ const (
 
 var (
 	// The in-memory cache of xrootd server advertisement, with the key being ServerAd.URL.String()
+	//
+	// To iterate this cache, use getServerAdsSnapshot (or Items when you also need the keys or
+	// Item wrappers). Do not use Range, which is not safe to iterate concurrently with cache writes.
 	serverAds = ttlcache.New(ttlcache.WithTTL[string, *server_structs.Advertisement](param.Director_AdvertisementTTL.GetDuration()),
 		ttlcache.WithDisableTouchOnHit[string, *server_structs.Advertisement]())
 	// The map holds servers that are disabled, with the key being the ServerAd.Name
@@ -78,6 +81,22 @@ var (
 	// a firewall.
 	brokerDialer *broker.BrokerDialer = nil
 )
+
+// getServerAdsSnapshot returns a point-in-time copy of every (non-expired) server
+// advertisement in the cache.
+//
+// Prefer this for iterating serverAds: callers walk their own slice and never hold the
+// cache lock across their work, so cache reads and writes can't be blocked by a slow
+// caller. Use Items directly only when you also need the keys or Item wrappers, and do
+// not use Range to iterate this cache.
+func getServerAdsSnapshot() []*server_structs.Advertisement {
+	items := serverAds.Items()
+	ads := make([]*server_structs.Advertisement, 0, len(items))
+	for _, item := range items {
+		ads = append(ads, item.Value())
+	}
+	return ads
+}
 
 func (f filterType) String() string {
 	switch f {
@@ -785,10 +804,13 @@ func updateDowntimeFromRegistry(ctx context.Context) error {
 	// or the downtime is expired (deleted). In either case, we still need to proceed to use
 	// it to update `filteredServers` and `federationDowntimes`, clearing out stale info.
 
+	// Snapshot serverAds before locking filteredServersMutex. The two have independent
+	// locks; never hold filteredServersMutex across a serverAds access, so that the order
+	// in which they are acquired can't vary between call sites.
+	ads := serverAds.Items() // only used to map server names below
+
 	filteredServersMutex.Lock()
 	defer filteredServersMutex.Unlock()
-
-	ads := serverAds.Items() // pull the cached server ads slice once
 
 	// Format downtimes to align server names with Director's in-memory state
 	allDowntimes, err := formatServerDowntimes(registryDowntimes, ads)

--- a/director/director.go
+++ b/director/director.go
@@ -1555,8 +1555,7 @@ func discoverOriginCache(ctx *gin.Context) {
 	}
 
 	promDiscoveryRes := make([]PromDiscoveryItem, 0)
-	for _, ad := range serverAds.Items() {
-		serverAd := ad.Value()
+	for _, serverAd := range getServerAdsSnapshot() {
 		if serverAd.WebURL.String() == "" {
 			// Origins and caches fetched from topology can't be scraped as they
 			// don't have a WebURL

--- a/director/director_api.go
+++ b/director/director_api.go
@@ -37,10 +37,9 @@ import (
 
 // List all namespaces from origins registered at the director
 func listNamespacesFromOrigins() []server_structs.NamespaceAdV2 {
-	serverAdItems := serverAds.Items()
-	namespaces := make([]server_structs.NamespaceAdV2, 0, len(serverAdItems))
-	for _, item := range serverAdItems {
-		ad := item.Value()
+	ads := getServerAdsSnapshot()
+	namespaces := make([]server_structs.NamespaceAdV2, 0, len(ads))
+	for _, ad := range ads {
 		if ad.Type == server_structs.OriginType.String() {
 			namespaces = append(namespaces, ad.NamespaceAds...)
 		}
@@ -51,8 +50,7 @@ func listNamespacesFromOrigins() []server_structs.NamespaceAdV2 {
 // List all advertisements in the TTL cache that match the serverType array
 func listAdvertisement(serverTypes []server_structs.ServerType) []*server_structs.Advertisement {
 	ads := make([]*server_structs.Advertisement, 0)
-	for _, item := range serverAds.Items() {
-		ad := item.Value()
+	for _, ad := range getServerAdsSnapshot() {
 		for _, serverType := range serverTypes {
 			if ad.Type == serverType.String() {
 				ads = append(ads, ad)
@@ -320,8 +318,8 @@ func LaunchServerIOQuery(ctx context.Context, egrp *errgroup.Group) {
 				queryResult, err := server_utils.QueryMyPrometheus(ddlCtx, query)
 				if err != nil || queryResult.ResultType != "vector" {
 					// If the query failed or returned the wrong type, set IOLoad=-1 for all servers
-					for _, item := range serverAds.Items() {
-						item.Value().SetIOLoad(-1)
+					for _, ad := range getServerAdsSnapshot() {
+						ad.SetIOLoad(-1)
 					}
 					if err != nil {
 						log.Debugf("Failed to update IO stat: querying Prometheus responded with an error: %v", err)

--- a/director/sort.go
+++ b/director/sort.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"github.com/jellydator/ttlcache/v3"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
@@ -191,12 +190,8 @@ func getAdsForPath(reqPath string) (oAds []copyAd, cAds []copyAd) {
 	// paths like /foo and /foobar with basic prefix matching because without the trailing /, these
 	// two would match.
 	reqPath = path.Clean(reqPath) + "/"
-	ads := make([]*server_structs.Advertisement, 0, serverAds.Len())
 
-	serverAds.Range(func(item *ttlcache.Item[string, *server_structs.Advertisement]) bool {
-		ads = append(ads, item.Value())
-		return true
-	})
+	ads := getServerAdsSnapshot()
 
 	// Move topo sorted ads to the end of our slice
 	sortServerAdsByTopo(ads)

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -519,7 +519,7 @@ RUN --mount=type=bind,from=xrootd-build,source=/xrootd-build,target=/xrootd-buil
     elif [ -n "${!RELEASE-}" ]; then
       dnf install -y --enablerepo=epel-testing --enablerepo=osg-testing ${REPO}-${!VER}-${!RELEASE}
     else
-      dnf install -y --enablerepo=epel-testing --enablerepo=osg-development --enablerepo=osg-testing --enablerepo=osg-upcoming-testing ${REPO}-${!VER}
+      dnf install -y --enablerepo=epel-testing --enablerepo=osg-development --enablerepo=osg-testing ${REPO}-${!VER}
     fi
   }
 


### PR DESCRIPTION
getAdsForPath walked serverAds with ttlcache's Range on every redirect. Range releases and re-acquires the cache's internal read lock around each element and leaks that lock if an entry is evicted or deleted mid-walk -- routine under registration churn plus TTL expiry. One leaked reader is fatal: the write-preferring RWMutex then blocks every reader and writer on the cache. And because updateDowntimeFromRegistry held the global filteredServersMutex while reading serverAds, that stall propagated into the registration path and piled up goroutines until the director was OOM-killed.

Fix the class of bug, not just the one call site:

- Make getServerAdsSnapshot the single idiom for walking the cache, backed by the atomically-locked Items(). Callers iterate their own copy with no cache lock held, so a slow or misbehaving cache can't wedge them. Both the helper and the serverAds declaration document why Range must never be used, so a future performance tweak doesn't reintroduce it. Items() stays only where the keys or Item wrappers are actually needed.

- Never hold filteredServersMutex across a serverAds access -- the two subsystems have independent locks and nesting them is an ABBA hazard. updateDowntimeFromRegistry now snapshots before locking.

The underlying Range lock-leak is an upstream ttlcache bug worth reporting separately; this change makes the director robust regardless.