### PR TITLE
Default cache file-usage purge bands as percentages of disk

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2067,12 +2067,14 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 				param.Cache_FilesBaseSize.GetString(), param.Cache_FilesNominalSize.GetString(), param.Cache_FilesMaxSize.GetString())
 		}
 
-		// xrootd additionally requires the max file-usage size to sit below the low
-		// watermark: the file-usage purge band must live inside the headroom the disk
-		// watermark leaves for metadata and any other tenant on the disk (the cache's
-		// data is necessarily a subset of total disk usage). When FilesMaxSize and the
-		// low watermark are expressed the same way we verify it here against a common
-		// basis; the mixed case again needs the disk total, so we defer it to xrootd.
+		// xrootd additionally requires FilesMaxSize to be below LowWaterark.
+		// FilesMaxSize bounds the cache's own data while LowWatermark bounds total
+		// disk usage, and the cache's data is necessarily a subset of total disk
+		// usage; keeping FilesMaxSize below LowWatermark leaves headroom under
+		// LowWatermark for metadata and any other tenant sharing the disk. When
+		// FilesMaxSize and LowWatermark are expressed the same way we verify it here
+		// against a common basis; the mixed case needs the disk total, so we defer
+		// it to xrootd.
 		lowWm, lwmIsAbs, err := utils.ValidateWatermark(param.Cache_LowWaterMark.GetString(), param.Cache_LowWaterMark.GetName(), false)
 		if err != nil {
 			return err

--- a/config/config.go
+++ b/config/config.go
@@ -1570,6 +1570,23 @@ func SetServerDefaults(v *viper.Viper) error {
 	if err != nil {
 		return err
 	}
+	// When Lotman manages the cache's space, xrootd's pfc.diskusage requires the
+	// "files" purge band (base < nominal < max). Rather than make operators hand-size
+	// three more values just to turn Lotman on, default them as percentages of total
+	// disk so they scale with any cache and stay ordered below the low watermark
+	// (default 85). They are defaulted only when Lotman is enabled and the operator
+	// hasn't set any of them, which leaves a plain cache untouched and preserves the
+	// existing "set all three or none" rule. Expressing them as percentages (rather
+	// than absolute sizes) is what makes a single set of defaults valid on caches of
+	// any disk size.
+	if v.GetBool(param.Cache_EnableLotman.GetName()) &&
+		!v.IsSet(param.Cache_FilesBaseSize.GetName()) &&
+		!v.IsSet(param.Cache_FilesNominalSize.GetName()) &&
+		!v.IsSet(param.Cache_FilesMaxSize.GetName()) {
+		v.SetDefault(param.Cache_FilesBaseSize.GetName(), "70")
+		v.SetDefault(param.Cache_FilesNominalSize.GetName(), "75")
+		v.SetDefault(param.Cache_FilesMaxSize.GetName(), "80")
+	}
 
 	v.SetDefault(param.Director_EnableFederationMetadataHosting.GetName(), true)
 	v.SetDefault(param.Director_CheckOriginPresence.GetName(), true)
@@ -2021,27 +2038,52 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 				param.Cache_FilesBaseSize.GetName(), param.Cache_FilesNominalSize.GetName(), param.Cache_FilesMaxSize.GetName())
 		}
 
-		var base, nominal, max float64
-		var err error
-		// Watermark validation will error if these parameters are not absolute, so we can ignore that output
-		if base, _, err = utils.ValidateWatermark(param.Cache_FilesBaseSize.GetString(), param.Cache_FilesBaseSize.GetName(), true); err != nil {
+		// Like the watermarks, each of these may be given as an integer percentage
+		// of total disk or as an absolute size with a k|m|g|t suffix, so accept both.
+		base, baseIsAbs, err := utils.ValidateWatermark(param.Cache_FilesBaseSize.GetString(), param.Cache_FilesBaseSize.GetName(), false)
+		if err != nil {
 			return err
 		}
-		if nominal, _, err = utils.ValidateWatermark(param.Cache_FilesNominalSize.GetString(), param.Cache_FilesNominalSize.GetName(), true); err != nil {
+		nominal, nominalIsAbs, err := utils.ValidateWatermark(param.Cache_FilesNominalSize.GetString(), param.Cache_FilesNominalSize.GetName(), false)
+		if err != nil {
 			return err
 		}
-		if max, _, err = utils.ValidateWatermark(param.Cache_FilesMaxSize.GetString(), param.Cache_FilesMaxSize.GetName(), true); err != nil {
+		max, maxIsAbs, err := utils.ValidateWatermark(param.Cache_FilesMaxSize.GetString(), param.Cache_FilesMaxSize.GetName(), false)
+		if err != nil {
 			return err
 		}
-		if base >= nominal || nominal >= max {
-			return errors.Errorf("invalid %s, %s and %s values. The base size must be less than the "+
-				"nominal size, and the nominal size must be less than the max size. Got %s (base), %s (nominal), and %s (max)",
-				param.Cache_FilesBaseSize.GetName(), param.Cache_FilesNominalSize.GetName(), param.Cache_FilesMaxSize.GetName(), param.Cache_FilesBaseSize.GetString(), param.Cache_FilesNominalSize.GetString(), param.Cache_FilesMaxSize.GetString())
+		// Enforce base < nominal < max. Two values are only directly comparable when
+		// expressed the same way (both percentages or both absolute sizes); a percentage
+		// and an absolute size can't be ordered without the disk total, which may span
+		// multiple disks and isn't known here. xrootd resolves everything to bytes against
+		// the real disk size and re-checks this ordering at startup, so deferring the
+		// mixed case to it is safe.
+		if (baseIsAbs == nominalIsAbs && base >= nominal) ||
+			(nominalIsAbs == maxIsAbs && nominal >= max) ||
+			(baseIsAbs == maxIsAbs && base >= max) {
+			return errors.Errorf("invalid %s/%s/%s values. The base size must be less than the nominal size, and the "+
+				"nominal size must be less than the max size. Got %s (base), %s (nominal), and %s (max)",
+				param.Cache_FilesBaseSize.GetName(), param.Cache_FilesNominalSize.GetName(), param.Cache_FilesMaxSize.GetName(),
+				param.Cache_FilesBaseSize.GetString(), param.Cache_FilesNominalSize.GetString(), param.Cache_FilesMaxSize.GetString())
 		}
 
-		// File sizes must also be less than the low watermark, but that's not straightforward to check, especially when the cache spread across
-		// multiple disks and the low watermark is configured as a relative value. If such bad config is passed, xrootd will fail to startup with
-		// a message about what to do, and as much as I'd like to handle that early, I'll leave it to xrootd for now.
+		// xrootd additionally requires the max file-usage size to sit below the low
+		// watermark: the file-usage purge band must live inside the headroom the disk
+		// watermark leaves for metadata and any other tenant on the disk (the cache's
+		// data is necessarily a subset of total disk usage). When FilesMaxSize and the
+		// low watermark are expressed the same way we verify it here against a common
+		// basis; the mixed case again needs the disk total, so we defer it to xrootd.
+		lowWm, lwmIsAbs, err := utils.ValidateWatermark(param.Cache_LowWaterMark.GetString(), param.Cache_LowWaterMark.GetName(), false)
+		if err != nil {
+			return err
+		}
+		if maxIsAbs == lwmIsAbs && max >= lowWm {
+			return errors.Errorf("invalid %s value. It must be less than %s so the cache's file-usage purge band stays "+
+				"below the disk low watermark. Got %s (%s) and %s (%s)",
+				param.Cache_FilesMaxSize.GetName(), param.Cache_LowWaterMark.GetName(),
+				param.Cache_FilesMaxSize.GetString(), param.Cache_FilesMaxSize.GetName(),
+				param.Cache_LowWaterMark.GetString(), param.Cache_LowWaterMark.GetName())
+		}
 	}
 	if param.Cache_EnableLotman.GetBool() {
 		// pfc.diskusage file directives _must_ be set.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1668,3 +1668,117 @@ func TestInitServerAcceptsLotmanMaxLotLifetimeAtBounds(t *testing.T) {
 		})
 	}
 }
+
+// The Cache.Files*Size parameters accept either an integer percentage of total
+// disk or an absolute size, and xrootd requires base < nominal < max < low
+// watermark. InitServer enforces that ordering when the operands are expressed
+// the same way (both percentages or both absolute) and otherwise defers to
+// xrootd, which knows the real disk total. These messages are emitted before
+// any Lotman-specific bounds, so the cases below assert on the files-validation
+// messages directly.
+func TestInitServerFilesSizeValidation(t *testing.T) {
+	const orderMsg = "base size must be less than the"
+	const maxBelowLwmMsg = "less than Cache.LowWaterMark"
+
+	cases := []struct {
+		name       string
+		low, high  string
+		base       string
+		nominal    string
+		max        string
+		rejectWith string // substring the error must contain; "" means the files checks must pass
+	}{
+		{"percent ordering below watermark accepted", "85", "89", "70", "75", "80", ""},
+		{"percent max equal to low watermark rejected", "80", "90", "60", "70", "80", maxBelowLwmMsg},
+		{"percent max above low watermark rejected", "80", "90", "60", "70", "85", maxBelowLwmMsg},
+		{"percent base not below nominal rejected", "85", "89", "75", "75", "80", orderMsg},
+		// Absolute files against a percentage watermark can't be ordered without
+		// the disk total, so the max-below-low-watermark check is deferred to xrootd.
+		{"absolute files with percent watermark deferred", "85", "89", "1g", "2g", "3g", ""},
+		// Both absolute: the max-below-low-watermark check can be evaluated here.
+		{"absolute max above absolute low watermark rejected", "2g", "90", "100m", "200m", "3g", maxBelowLwmMsg},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ResetConfig()
+			t.Cleanup(ResetConfig)
+			mockFederationRoot(t)
+
+			require.NoError(t, param.ConfigBase.Set(t.TempDir()))
+			require.NoError(t, param.Cache_EnableLotman.Set(true))
+			require.NoError(t, param.Cache_LowWaterMark.Set(tc.low))
+			require.NoError(t, param.Cache_HighWaterMark.Set(tc.high))
+			require.NoError(t, param.Cache_FilesBaseSize.Set(tc.base))
+			require.NoError(t, param.Cache_FilesNominalSize.Set(tc.nominal))
+			require.NoError(t, param.Cache_FilesMaxSize.Set(tc.max))
+
+			err := InitServer(context.Background(), server_structs.CacheType)
+			if tc.rejectWith != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.rejectWith)
+				return
+			}
+			// InitServer may still fail downstream (no xrootd in place); only
+			// assert that the files-size validators did not reject this config.
+			if err != nil {
+				require.NotContains(t, err.Error(), orderMsg)
+				require.NotContains(t, err.Error(), maxBelowLwmMsg)
+			}
+		})
+	}
+}
+
+// Enabling Lotman should not force operators to hand-size the file-usage purge
+// band: when none of the Cache.Files*Size values are set, SetServerDefaults
+// fills in percentage defaults that sit below the default low watermark. A plain
+// (non-Lotman) cache must be left untouched so its purge behaviour is unchanged.
+func TestLotmanScopedFilesSizeDefaults(t *testing.T) {
+	t.Run("applied when lotman enabled and unset", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+		mockFederationRoot(t)
+		require.NoError(t, param.ConfigBase.Set(t.TempDir()))
+		require.NoError(t, param.Cache_EnableLotman.Set(true))
+
+		// InitServer runs SetServerDefaults early; it may fail later for unrelated
+		// reasons, but the defaults are populated by then.
+		_ = InitServer(context.Background(), server_structs.CacheType)
+
+		assert.Equal(t, "70", param.Cache_FilesBaseSize.GetString())
+		assert.Equal(t, "75", param.Cache_FilesNominalSize.GetString())
+		assert.Equal(t, "80", param.Cache_FilesMaxSize.GetString())
+	})
+
+	t.Run("not applied when lotman disabled", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+		mockFederationRoot(t)
+		require.NoError(t, param.ConfigBase.Set(t.TempDir()))
+		require.NoError(t, param.Cache_EnableLotman.Set(false))
+
+		_ = InitServer(context.Background(), server_structs.CacheType)
+
+		assert.False(t, param.Cache_FilesBaseSize.IsSet())
+		assert.False(t, param.Cache_FilesNominalSize.IsSet())
+		assert.False(t, param.Cache_FilesMaxSize.IsSet())
+	})
+
+	t.Run("operator values are preserved", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+		mockFederationRoot(t)
+		require.NoError(t, param.ConfigBase.Set(t.TempDir()))
+		require.NoError(t, param.Cache_EnableLotman.Set(true))
+		require.NoError(t, param.Cache_FilesBaseSize.Set("1g"))
+		require.NoError(t, param.Cache_FilesNominalSize.Set("2g"))
+		require.NoError(t, param.Cache_FilesMaxSize.Set("3g"))
+
+		_ = InitServer(context.Background(), server_structs.CacheType)
+
+		assert.Equal(t, "1g", param.Cache_FilesBaseSize.GetString())
+		assert.Equal(t, "2g", param.Cache_FilesNominalSize.GetString())
+		assert.Equal(t, "3g", param.Cache_FilesMaxSize.GetString())
+	})
+}

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2386,7 +2386,7 @@ description: |+
   usages reaches this value. Note that "cache disk usage" is calculated based on the cache's entire set of
   configured disks, not just data directories from those disks.
 
-  The value should be either a percentage integer of total available disk space (default is 90),
+  The value should be either a percentage integer of total available disk space (default is 85),
   or a number suffixed by k, m, g, or t. In which case, they must be absolute sizes in k (kilo-),
   m (mega-), g (giga-), or t (tera-) bytes, respectively.
 
@@ -2401,7 +2401,7 @@ description: |+
   When the cache's disk usage exceeds this value, file purging is triggered. Note that "cache disk usage"
   is calculated based on the cache's entire set of configured disks, not just data directories from those disks.
 
-  The value should be either a percentage integer of total available disk space (default is 95),
+  The value should be either a percentage integer of total available disk space (default is 89),
   or a number suffixed by k, m, g, or t. In which case, they must be absolute sizes in k (kilo-),
   m (mega-), g (giga-), or t (tera-) bytes, respectively.
 
@@ -2418,9 +2418,15 @@ description: |+
   cache will begin purging files until it reaches the `Cache.FilesNominal` value. If the cache's disk usage is still in
   excess of the `Cache.LowWaterMark`, the cache will continue purging files until it reaches the `Cache.FilesBase` value.
 
-  Unlike watermark values, this value _must_ be suffixed by a unit of k, m, g, or t, which represent kilobytes, megabytes,
-  gigabytes, and terabytes, respectively. All `Cache.Files*Size` parameters must be less than the cache's calculated low
-  watermark, which may be configured as a percentage of total disk space from multiple disks.
+  Like the watermark values, this value may be given either as a percentage integer of total available disk space, or as
+  a number suffixed by k, m, g, or t (absolute sizes in kilo-, mega-, giga-, or tera- bytes). All `Cache.Files*Size`
+  parameters must be less than the cache's calculated low watermark, which may itself be configured as a percentage of
+  total disk space spanning multiple disks. Because these sizes must stay below the low watermark on a cache of any size,
+  percentages are usually the better choice.
+
+  This value is only used when `Cache.EnableLotman` is true. When Lotman is enabled and none of the `Cache.Files*Size`
+  parameters are set, they default to percentages of total disk that sit below the default low watermark (base 70,
+  nominal 75, max 80).
 
   For more information, see the [xrootd pfc documentation](https://xrootd.web.cern.ch/doc/dev56/pss_config.pdf) for
   `pfc.diskusage`.
@@ -2435,9 +2441,15 @@ description: |+
   the cache will begin purging files until it reaches this value. If the cache's disk usage is still in excess of the
   `Cache.LowWaterMark`, the cache will continue purging files until it reaches the `Cache.FilesBase`.
 
-  Unlike watermark values, this value _must_ be suffixed by a unit of k, m, g, or t, which represent kilobytes, megabytes,
-  gigabytes, and terabytes, respectively. All `Cache.Files*Size` parameters must be less than the cache's calculated low
-  watermark, which may be configured as a percentage of total disk space from multiple disks.
+  Like the watermark values, this value may be given either as a percentage integer of total available disk space, or as
+  a number suffixed by k, m, g, or t (absolute sizes in kilo-, mega-, giga-, or tera- bytes). All `Cache.Files*Size`
+  parameters must be less than the cache's calculated low watermark, which may itself be configured as a percentage of
+  total disk space spanning multiple disks. Because these sizes must stay below the low watermark on a cache of any size,
+  percentages are usually the better choice.
+
+  This value is only used when `Cache.EnableLotman` is true. When Lotman is enabled and none of the `Cache.Files*Size`
+  parameters are set, they default to percentages of total disk that sit below the default low watermark (base 70,
+  nominal 75, max 80).
 
   For more information, see the [xrootd pfc documentation](https://xrootd.web.cern.ch/doc/dev56/pss_config.pdf) for
   `pfc.diskusage`.
@@ -2450,9 +2462,15 @@ description: |+
   A value that sets the "base" cumulative size of files that can be stored in the cache's data directory. This is the
   stopping point for the cache's purging routines.
 
-  Unlike watermark values, this value _must_ be suffixed by a unit of k, m, g, or t, which represent kilobytes, megabytes,
-  gigabytes, and terabytes, respectively.All `Cache.Files*Size` parameters must be less than the cache's calculated low
-  watermark, which may be configured as a percentage of total disk space from multiple disks.
+  Like the watermark values, this value may be given either as a percentage integer of total available disk space, or as
+  a number suffixed by k, m, g, or t (absolute sizes in kilo-, mega-, giga-, or tera- bytes). All `Cache.Files*Size`
+  parameters must be less than the cache's calculated low watermark, which may itself be configured as a percentage of
+  total disk space spanning multiple disks. Because these sizes must stay below the low watermark on a cache of any size,
+  percentages are usually the better choice.
+
+  This value is only used when `Cache.EnableLotman` is true. When Lotman is enabled and none of the `Cache.Files*Size`
+  parameters are set, they default to percentages of total disk that sit below the default low watermark (base 70,
+  nominal 75, max 80).
 
   For more information, see the [xrootd pfc documentation](https://xrootd.web.cern.ch/doc/dev56/pss_config.pdf) for `pfc.diskusage`.
 type: string

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -1104,6 +1104,20 @@ func xrootdDecodeHook() mapstructure.DecodeHookFunc {
 	)
 }
 
+// cacheSizeToXrootd translates a Pelican cache watermark / file-usage size into
+// the form xrootd's pfc.diskusage expects. Pelican accepts these values either
+// as a bare integer percentage of total disk (e.g. "85") or as an absolute size
+// suffixed with k|m|g|t (e.g. "1t"). xrootd's cfg2bytes reads a bare number as a
+// decimal fraction of the disk and a suffixed number as an absolute size, so an
+// integer percentage is rewritten as its decimal fraction (85 -> "0.85") while
+// absolute sizes (and any already-fractional value) are passed through untouched.
+func cacheSizeToXrootd(val string) string {
+	if num, err := strconv.Atoi(val); err == nil && num > 0 && num <= 100 {
+		return strconv.FormatFloat(float64(num)/100, 'f', 2, 64)
+	}
+	return val
+}
+
 func ConfigXrootd(ctx context.Context, isOrigin bool) (string, error) {
 	gid, err := config.GetDaemonGID()
 	if err != nil {
@@ -1150,17 +1164,14 @@ func ConfigXrootd(ctx context.Context, isOrigin bool) (string, error) {
 		}
 		xrdConfig.Cache.PSSOrigin = pssOrigin
 
-		// For cache watermarks, convert integer percentage value [0,100] to decimal fraction [0.00, 1.00]
-		if num, err := strconv.Atoi(xrdConfig.Cache.HighWaterMark); err == nil {
-			if num <= 100 && num > 0 {
-				xrdConfig.Cache.HighWaterMark = strconv.FormatFloat(float64(num)/100, 'f', 2, 64)
-			}
-		}
-		if num, err := strconv.Atoi(xrdConfig.Cache.LowWaterMark); err == nil {
-			if num <= 100 && num > 0 {
-				xrdConfig.Cache.LowWaterMark = strconv.FormatFloat(float64(num)/100, 'f', 2, 64)
-			}
-		}
+		// The watermarks and the file-usage sizes may each be given as an integer
+		// percentage of total disk or as an absolute size; normalize the percentage
+		// form to the decimal fraction xrootd expects (absolute sizes pass through).
+		xrdConfig.Cache.HighWaterMark = cacheSizeToXrootd(xrdConfig.Cache.HighWaterMark)
+		xrdConfig.Cache.LowWaterMark = cacheSizeToXrootd(xrdConfig.Cache.LowWaterMark)
+		xrdConfig.Cache.FilesBaseSize = cacheSizeToXrootd(xrdConfig.Cache.FilesBaseSize)
+		xrdConfig.Cache.FilesNominalSize = cacheSizeToXrootd(xrdConfig.Cache.FilesNominalSize)
+		xrdConfig.Cache.FilesMaxSize = cacheSizeToXrootd(xrdConfig.Cache.FilesMaxSize)
 
 		// Set up Lotman config
 		lotmanCfg := LotmanCfg{Enabled: false}

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -1027,3 +1027,29 @@ func TestPurgeColdFilesAgeFromMaxLotLifetime(t *testing.T) {
 		})
 	}
 }
+
+// pfc.diskusage interprets a bare number as a fraction of disk and a suffixed
+// number as an absolute size. Pelican exposes watermarks and file-usage sizes
+// as integer percentages or suffixed sizes, so cacheSizeToXrootd must rewrite a
+// percentage to its decimal fraction and leave everything else alone.
+func TestCacheSizeToXrootd(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"integer percent becomes fraction", "85", "0.85"},
+		{"low integer percent", "5", "0.05"},
+		{"100 percent becomes 1.00", "100", "1.00"},
+		{"absolute gigabytes pass through", "100g", "100g"},
+		{"absolute terabytes pass through", "1t", "1t"},
+		{"already-decimal fraction passes through", "0.90", "0.90"},
+		{"zero passes through (not a percentage)", "0", "0"},
+		{"empty passes through", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, cacheSizeToXrootd(tc.in))
+		})
+	}
+}


### PR DESCRIPTION
Enabling Lotman is gated on also hand-sizing pfc.diskusage's file-usage band (Cache.FilesBaseSize/NominalSize/MaxSize), which xrootd requires to sit below the low watermark. No single absolute-size default can satisfy that on caches of differing disk sizes, so let these accept integer percentages (as the watermarks already do) and default them to percentages of total disk. Percentages scale with any cache and stay ordered below a percentage low watermark, which is the missing prerequisite for turning Lotman on without extra configuration.

Scope the defaults to when Lotman is enabled, and only when the operator set none of the three, so a plain cache's purge behaviour is unchanged and the existing all-or-none rule is preserved. Because the file sizes and the low watermark can now both be percentages, validate the max-below-low-watermark ordering up front when the two are expressed the same way and defer the mixed percentage/absolute case to xrootd, which alone knows the real disk total.

Also correct the documented low/high watermark defaults, which had drifted from the shipped 85/89 values.