### PR TITLE
Various and Sundry Cache V2 improvements

### DIFF
--- a/cache/advertise.go
+++ b/cache/advertise.go
@@ -301,7 +301,12 @@ func getTickerRate(tok string) time.Duration {
 	tokenLifetime, err := calcTokLifetime(tok)
 	if err != nil {
 		tokenLifetime = param.Director_FedTokenLifetime.GetDuration()
-		log.Errorf("Failed to calculate lifetime of federation token: %v.", err)
+		// An empty token is expected before the first fetch (e.g. when the
+		// persistent cache defers its initial fetch until after registration);
+		// only surface a genuine parse failure of a non-empty token.
+		if tok != "" {
+			log.Errorf("Failed to calculate lifetime of federation token: %v.", err)
+		}
 	}
 	tickerRate = tokenLifetime / 3
 	return validateTickerRate(tickerRate, tokenLifetime)
@@ -315,38 +320,16 @@ func getTickerRate(tok string) time.Duration {
 // new token is obtained.  The persistent cache uses this to keep the
 // token in memory.
 //
-// retryNow, if non-nil, is a channel that triggers an immediate token
-// fetch.  The launcher signals it after the cache is first registered
-// and advertised to the director so the token manager does not have to
-// wait for the next ticker fire.
+// retryNow, if non-nil, is a channel the launcher signals after the cache has
+// been registered and advertised to the director.  When it is provided, the
+// manager DEFERS its first token fetch until that signal, guaranteeing the
+// first getFedToken request is not made before the cache is registered (which
+// would fail).  When it is nil, the manager fetches immediately at startup.
 func LaunchFedTokManager(ctx context.Context, egrp *errgroup.Group, cache server_structs.XRootDServer, copyToXrootdDir server_utils.FedTokCopyToXrootdFunc, onTokenUpdate func(string), retryNow <-chan struct{}) {
-	// Do our initial token fetch+set, then turn things over to the ticker
-	tok, err := server_utils.CreateFedTok(ctx, cache)
-	if err != nil {
-		log.Errorf("Failed to get a federation token: %v", err)
-	}
-
-	// We want to fire the ticker at 1/3 the period of the token lifetime, or 1/3 the default
-	// lifetime for the token if we can't otherwise determine it. In most cases, the two values
-	// will be the same unless some fed administrator thinks they know better! This 1/3 period approach
-	// gives us a bit of buffer in the event the Director is down for a short period of time.
-	tickerRate := getTickerRate(tok)
-
-	// Set up the federation token directories in the cache
-	err = server_utils.SetupFedTokDirs(cache)
-	if err != nil {
+	// Set up the federation token directories in the cache.  This is
+	// independent of having a token, so do it up front.
+	if err := server_utils.SetupFedTokDirs(cache); err != nil {
 		log.Errorf("Failed to setup federation token directory: %v", err)
-	}
-
-	// Set the token in the cache
-	err = server_utils.SetFedTok(ctx, cache, tok, copyToXrootdDir)
-	if err != nil {
-		log.Errorf("Failed to set the federation token: %v", err)
-	}
-
-	// Deliver the initial token to the in-memory consumer (if any).
-	if onTokenUpdate != nil && tok != "" {
-		onTokenUpdate(tok)
 	}
 
 	// refreshFedTok performs a single fetch-and-set cycle, returning
@@ -375,25 +358,57 @@ func LaunchFedTokManager(ctx context.Context, egrp *errgroup.Group, cache server
 		return newRate, newTok
 	}
 
+	// We want to fire the ticker at 1/3 the period of the token lifetime, or 1/3 the default
+	// lifetime for the token if we can't otherwise determine it. In most cases, the two values
+	// will be the same unless some fed administrator thinks they know better! This 1/3 period approach
+	// gives us a bit of buffer in the event the Director is down for a short period of time.
+	tickerRate := getTickerRate("")
+
+	// When retryNow is nil there is no external "registered & advertised"
+	// signal to wait for (e.g. the XRootD cache), so fetch immediately as
+	// before.  When retryNow is provided (the persistent cache), we instead
+	// defer the first fetch until the launcher signals that the cache has been
+	// registered and advertised to the director — requesting a federation token
+	// before the cache is registered is guaranteed to fail and can leave stale
+	// negative state at the director.
+	if retryNow == nil {
+		tickerRate, _ = refreshFedTok(tickerRate)
+	}
+
 	// TODO: Figure out what to do if the Director starts issuing tokens with a different
 	// lifetime --> we can adjust ticker period dynamically, but what's the sensible thing to do?
 	fedTokTicker := time.NewTicker(tickerRate)
 	egrp.Go(func() error {
 		defer fedTokTicker.Stop()
+
+		doRefresh := func() {
+			newRate, _ := refreshFedTok(tickerRate)
+			if newRate != tickerRate {
+				fedTokTicker.Reset(newRate)
+				tickerRate = newRate
+			}
+		}
+
+		// Force the ordering: for the persistent cache, the first token fetch
+		// happens only after the launcher signals registration+advertisement
+		// (retryNow).  The ticker acts as a fallback so we still fetch even if
+		// the signal is somehow missed.
+		if retryNow != nil {
+			select {
+			case <-retryNow:
+			case <-fedTokTicker.C:
+			case <-ctx.Done():
+				return nil
+			}
+			doRefresh()
+		}
+
 		for {
 			select {
 			case <-fedTokTicker.C:
-				newRate, _ := refreshFedTok(tickerRate)
-				if newRate != tickerRate {
-					fedTokTicker.Reset(newRate)
-					tickerRate = newRate
-				}
+				doRefresh()
 			case <-retryNow:
-				newRate, _ := refreshFedTok(tickerRate)
-				if newRate != tickerRate {
-					fedTokTicker.Reset(newRate)
-					tickerRate = newRate
-				}
+				doRefresh()
 			case <-ctx.Done():
 				return nil
 			}

--- a/client/director_test.go
+++ b/client/director_test.go
@@ -227,6 +227,58 @@ func TestQueryDirector(t *testing.T) {
 	}
 }
 
+// TestQueryDirectorCacheMode verifies that the cacheMode flag controls which
+// director endpoint a request is routed through.  An embedded cache fetching
+// from origins uses cacheMode=true and must hit /api/v1.0/director/origin/...,
+// while a site-local cache (which appears to the federation as a client and
+// fetches from other caches) uses cacheMode=false and must hit the director's
+// default shortcut endpoint at the bare object path.
+func TestQueryDirectorCacheMode(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	defer server_utils.ResetTestState()
+	require.NoError(t, param.Client_DirectorRetries.Set(1))
+
+	testCases := []struct {
+		name         string
+		cacheMode    bool
+		expectedPath string
+	}{
+		{
+			name:         "embedded cache mode routes to origin endpoint",
+			cacheMode:    true,
+			expectedPath: "/api/v1.0/director/origin/foo/bar",
+		},
+		{
+			name:         "client (site-local) mode routes to shortcut endpoint",
+			cacheMode:    false,
+			expectedPath: "/foo/bar",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var requestedPath string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestedPath = r.URL.Path
+				w.WriteHeader(http.StatusTemporaryRedirect)
+			}))
+			defer server.Close()
+
+			pUrl := pelican_url.PelicanURL{
+				FedInfo: pelican_url.FederationDiscovery{
+					DirectorEndpoint: server.URL,
+				},
+				Path: "/foo/bar",
+			}
+
+			_, _, err := queryDirector(context.Background(), "GET", &pUrl, "", tc.cacheMode)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedPath, requestedPath)
+		})
+	}
+}
+
 func TestGetDirectorInfoForPath(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	server_utils.ResetTestState()

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1132,19 +1132,21 @@ func WithMetadataChannel(ch chan<- TransferMetadata) TransferOption {
 	return option.New(identTransferOptionMetadataChannel{}, ch)
 }
 
-// WithCacheEmbeddedClientMode sets the client into "cache-embedded"
-// mode.  In this mode, the client queries the director's origin
-// endpoint (/api/v1.0/director/origin/…) instead of the default
-// shortcut endpoint.  This causes the director to redirect to origins
-// rather than to caches, which is the correct behaviour when the
-// transfer client is itself embedded inside a cache process.
+// WithCacheEmbeddedClientMode controls whether the client runs in
+// "cache-embedded" mode.  When enabled, the client queries the
+// director's origin endpoint (/api/v1.0/director/origin/…) instead of
+// the default shortcut endpoint.  This causes the director to redirect
+// to origins rather than to caches, which is the correct behaviour when
+// the transfer client is itself embedded inside a cache process.
 //
-// Without this option, a GET for /test/file.txt is routed through the
-// director's shortcut middleware, which redirects to a cache.  With
-// this option, the same GET is explicitly routed to the origin
-// endpoint so the cache can fetch from the origin.
-func WithCacheEmbeddedClientMode() TransferOption {
-	return option.New(identTransferOptionCacheEmbeddedClientMode{}, true)
+// With it enabled, a GET for /test/file.txt is explicitly routed to the
+// origin endpoint so the cache can fetch from the origin.  When disabled
+// (enabled=false), the same GET is routed through the director's shortcut
+// middleware, which redirects to a cache — the correct behaviour for a
+// site-local cache, which appears to the federation as a client and
+// fetches from other caches rather than directly from origins.
+func WithCacheEmbeddedClientMode(enabled bool) TransferOption {
+	return option.New(identTransferOptionCacheEmbeddedClientMode{}, enabled)
 }
 
 // WithRequestId sets a caller-supplied request ID that is propagated as

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -774,7 +774,17 @@ func (tr TransferResults) ID() string {
 // Returns a new transfer engine object whose lifetime is tied
 // to the provided context.  Will launcher worker goroutines to
 // handle the underlying transfers
+// NewTransferEngine creates a transfer engine using the client's configured
+// worker count (Client.WorkerCount).
 func NewTransferEngine(ctx context.Context) (te *TransferEngine, err error) {
+	return NewTransferEngineWithWorkers(ctx, param.Client_WorkerCount.GetInt())
+}
+
+// NewTransferEngineWithWorkers creates a transfer engine with an explicit
+// number of transfer workers, overriding the Client.WorkerCount default.  This
+// lets embedded consumers (e.g. the cache) run with more concurrency than a
+// command-line client would.  A workerCount <= 0 is an error.
+func NewTransferEngineWithWorkers(ctx context.Context, workerCount int) (te *TransferEngine, err error) {
 	// If we did not initClient yet, we should fail to avoid unexpected/undesired behavior
 	if !config.IsClientInitialized() {
 		return nil, errors.New("client has not been initialized, unable to create transfer engine")
@@ -808,7 +818,6 @@ func NewTransferEngine(ctx context.Context) (te *TransferEngine, err error) {
 		dirRespCache:       NewDirRespCache(5 * time.Minute),
 		prestageAPISupport: make(map[string]bool),
 	}
-	workerCount := param.Client_WorkerCount.GetInt()
 	if workerCount <= 0 {
 		return nil, errors.New("worker count must be a positive integer")
 	}

--- a/client/transfer_engine_workers_test.go
+++ b/client/transfer_engine_workers_test.go
@@ -1,0 +1,64 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/test_utils"
+)
+
+// TestNewTransferEngineWorkerCount verifies that the worker count is taken from
+// Client.WorkerCount by default and can be overridden explicitly (as the cache
+// does with Cache.WorkerCount).
+func TestNewTransferEngineWorkerCount(t *testing.T) {
+	test_utils.InitClient(t, map[param.Param]any{
+		param.Client_WorkerCount: 3,
+	})
+
+	t.Run("default uses Client.WorkerCount", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		te, err := NewTransferEngine(ctx)
+		require.NoError(t, err)
+		defer func() { _ = te.Shutdown() }()
+		assert.Equal(t, 3, te.workersActive)
+	})
+
+	t.Run("explicit worker count overrides the client default", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		te, err := NewTransferEngineWithWorkers(ctx, 100)
+		require.NoError(t, err)
+		defer func() { _ = te.Shutdown() }()
+		assert.Equal(t, 100, te.workersActive)
+	})
+
+	t.Run("non-positive worker count is rejected", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_, err := NewTransferEngineWithWorkers(ctx, 0)
+		require.Error(t, err)
+	})
+}

--- a/cmd/cache_chaos.go
+++ b/cmd/cache_chaos.go
@@ -1,0 +1,235 @@
+//go:build server
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/pelicanplatform/pelican/local_cache"
+)
+
+var (
+	chaosEtag      string
+	chaosInstance  string
+	chaosJSON      bool
+	chaosBlock     uint32
+	chaosBytes     int
+	chaosChunk     int
+	chaosDropBytes int64
+
+	cacheChaosCmd = &cobra.Command{
+		Use:   "chaos",
+		Short: "Inject corruption into cached objects (fault-injection testing)",
+		Long: `Deliberately corrupt cached object data to exercise the cache's
+integrity-detection paths (the read-time AES-GCM check and the periodic
+data-integrity scan).
+
+This is a destructive testing/"chaos engineering" tool. It operates against a
+running cache server through its admin API, so the corruption is applied
+in-process (BadgerDB is single-process, so a CLI cannot touch the cache's
+database directly while the server holds it open).
+
+The endpoint is only available when the cache server is started with
+Cache.EnableChaosAPI set to true.`,
+		SilenceUsage: true,
+	}
+
+	cacheChaosCorruptCmd = &cobra.Command{
+		Use:   "corrupt <object-url>",
+		Short: "Flip bytes in a cached object's block",
+		Long: `Flip bytes in the on-disk (encrypted) representation of a block so that
+its authentication tag no longer validates. The cache detects this on the next
+cold read of the block or during the periodic data scan, which invalidates and
+re-fetches the object.
+
+By default the latest cached version is targeted; use --etag or --instance to
+select a specific version.
+
+Examples:
+  pelican cache chaos corrupt pelican://my-federation/data/file.dat
+  pelican cache chaos corrupt /data/file.dat --block 3 --bytes 32
+  pelican cache chaos corrupt --instance <hash> --block 0`,
+		Args:         cobra.MaximumNArgs(1),
+		RunE:         runCacheChaosCorrupt,
+		SilenceUsage: true,
+	}
+
+	cacheChaosTruncateCmd = &cobra.Command{
+		Use:   "truncate <object-url>",
+		Short: "Truncate a cached object's on-disk data",
+		Long: `Remove bytes from the end of one of a cached object's on-disk chunk files,
+dropping trailing block(s). The cache detects the missing/short data on a cold
+read or during the data scan.
+
+By default the last chunk is truncated by one block; use --chunk and
+--drop-bytes to control which chunk and how much is removed.
+
+Examples:
+  pelican cache chaos truncate pelican://my-federation/data/file.dat
+  pelican cache chaos truncate /data/file.dat --drop-bytes 65536
+  pelican cache chaos truncate --instance <hash> --chunk 0`,
+		Args:         cobra.MaximumNArgs(1),
+		RunE:         runCacheChaosTruncate,
+		SilenceUsage: true,
+	}
+)
+
+func init() {
+	cacheCmd.AddCommand(cacheChaosCmd)
+	cacheChaosCmd.AddCommand(cacheChaosCorruptCmd)
+	cacheChaosCmd.AddCommand(cacheChaosTruncateCmd)
+
+	cacheChaosCmd.PersistentFlags().StringVar(&chaosEtag, "etag", "", "Select the object version by ETag (default: latest)")
+	cacheChaosCmd.PersistentFlags().StringVar(&chaosInstance, "instance", "", "Select the object version by instance hash")
+	cacheChaosCmd.PersistentFlags().BoolVar(&chaosJSON, "json", false, "Output in JSON format")
+	cacheChaosCmd.PersistentFlags().StringVarP(&introspectToken, "token", "t", "", "Path to admin token file (auto-generated if not provided)")
+
+	cacheChaosCorruptCmd.Flags().Uint32Var(&chaosBlock, "block", 0, "Zero-based block number to corrupt")
+	cacheChaosCorruptCmd.Flags().IntVar(&chaosBytes, "bytes", 0, "Number of bytes to flip (default: the authentication-tag size)")
+
+	cacheChaosTruncateCmd.Flags().IntVar(&chaosChunk, "chunk", -1, "Chunk index to truncate (default: the last chunk)")
+	cacheChaosTruncateCmd.Flags().Int64Var(&chaosDropBytes, "drop-bytes", 0, "Bytes to remove from the end of the chunk file (default: one block)")
+}
+
+// chaosServerURL returns the running cache server's URL, or an error if the
+// cache is not running.  The chaos API operates exclusively against a live
+// cache server (there is no offline mode: BadgerDB is single-process).
+func chaosServerURL() (string, error) {
+	if err := initIntrospectConfig(); err != nil {
+		return "", errors.Wrap(err, "failed to initialize cache server config")
+	}
+	serverURL := discoverServerURL()
+	if serverURL == "" {
+		return "", errors.New("could not find a running cache server; the chaos API operates against a running cache (ensure the cache is up and started with Cache.EnableChaosAPI=true)")
+	}
+	return serverURL, nil
+}
+
+// chaosObjectQuery builds the object-selection query parameters shared by the
+// corrupt and truncate subcommands.
+func chaosObjectQuery(objectURL string) (url.Values, error) {
+	q := url.Values{}
+	if chaosInstance != "" {
+		q.Set("instance", chaosInstance)
+	} else if objectURL != "" {
+		q.Set("url", objectURL)
+		if chaosEtag != "" {
+			q.Set("etag", chaosEtag)
+		}
+	} else {
+		return nil, errors.New("either <object-url> or --instance is required")
+	}
+	return q, nil
+}
+
+func postChaos(query url.Values) (*local_cache.ChaosResult, error) {
+	serverURL, err := chaosServerURL()
+	if err != nil {
+		return nil, err
+	}
+	body, err := introspectHTTPPost(serverURL, "/api/v1.0/cache/introspect/chaos", query)
+	if err != nil {
+		return nil, err
+	}
+	var result local_cache.ChaosResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, errors.Wrap(err, "failed to parse response")
+	}
+	return &result, nil
+}
+
+func printChaosResult(result *local_cache.ChaosResult) error {
+	if chaosJSON {
+		data, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return errors.Wrap(err, "failed to marshal result")
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	fmt.Printf("Injected %s into cached object:\n", result.Operation)
+	fmt.Printf("  Instance:    %s\n", result.InstanceHash)
+	if result.SourceURL != "" {
+		fmt.Printf("  Source URL:  %s\n", result.SourceURL)
+	}
+	if result.ETag != "" {
+		fmt.Printf("  ETag:        %s\n", result.ETag)
+	}
+	fmt.Printf("  Chunk file:  %s (chunk %d)\n", result.FilePath, result.ChunkIndex)
+	switch result.Operation {
+	case "corrupt-block":
+		fmt.Printf("  Block:       %d (disk offset %d, flipped %d byte(s))\n", result.BlockNum, result.DiskOffset, result.BytesChanged)
+	case "truncate":
+		fmt.Printf("  Truncated:   %d -> %d bytes\n", result.OldFileSize, result.NewFileSize)
+	}
+	return nil
+}
+
+func runCacheChaosCorrupt(cmd *cobra.Command, args []string) error {
+	objectURL := ""
+	if len(args) > 0 {
+		objectURL = args[0]
+	}
+	query, err := chaosObjectQuery(objectURL)
+	if err != nil {
+		return err
+	}
+	query.Set("op", "corrupt")
+	query.Set("block", strconv.FormatUint(uint64(chaosBlock), 10))
+	if chaosBytes > 0 {
+		query.Set("bytes", strconv.Itoa(chaosBytes))
+	}
+
+	result, err := postChaos(query)
+	if err != nil {
+		return errors.Wrap(err, "failed to corrupt block")
+	}
+	return printChaosResult(result)
+}
+
+func runCacheChaosTruncate(cmd *cobra.Command, args []string) error {
+	objectURL := ""
+	if len(args) > 0 {
+		objectURL = args[0]
+	}
+	query, err := chaosObjectQuery(objectURL)
+	if err != nil {
+		return err
+	}
+	query.Set("op", "truncate")
+	query.Set("chunk", strconv.Itoa(chaosChunk))
+	if chaosDropBytes > 0 {
+		query.Set("drop-bytes", strconv.FormatInt(chaosDropBytes, 10))
+	}
+
+	result, err := postChaos(query)
+	if err != nil {
+		return errors.Wrap(err, "failed to truncate object")
+	}
+	return printChaosResult(result)
+}

--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -43,6 +43,10 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 	v.SetDefault(param.Cache_BlocksToPrefetch.GetName(), 0)
 	// Cache.ConcurrencyDegradedThreshold
 	v.SetDefault(param.Cache_ConcurrencyDegradedThreshold.GetName(), 90)
+	// Cache.DataScanMode
+	v.SetDefault(param.Cache_DataScanMode.GetName(), "all")
+	// Cache.DataScanResampleInterval
+	v.SetDefault(param.Cache_DataScanResampleInterval.GetName(), 100)
 	// Cache.DefaultCacheTimeout
 	v.SetDefault(param.Cache_DefaultCacheTimeout.GetName(), "9.5s")
 	// Cache.DirectorTest
@@ -51,6 +55,8 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 	v.SetDefault(param.Cache_DisableClientX509.GetName(), true)
 	// Cache.EnableBroker
 	v.SetDefault(param.Cache_EnableBroker.GetName(), true)
+	// Cache.EnableChaosAPI
+	v.SetDefault(param.Cache_EnableChaosAPI.GetName(), false)
 	// Cache.EnableEvictionMonitoring
 	v.SetDefault(param.Cache_EnableEvictionMonitoring.GetName(), true)
 	// Cache.EnableLotman

--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -158,6 +158,8 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 		val = strings.ReplaceAll(val, "${Cache.Port}", v.GetString(param.Cache_Port.GetName()))
 		v.SetDefault(param.Cache_Url.GetName(), val)
 	}
+	// Cache.WorkerCount
+	v.SetDefault(param.Cache_WorkerCount.GetName(), 100)
 	// Cache.XRootDPrefix
 	v.SetDefault(param.Cache_XRootDPrefix.GetName(), "cache")
 	// Client.AssumeDirectorServerHeader

--- a/database/server.go
+++ b/database/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -19,6 +20,17 @@ import (
 )
 
 var ServerDatabase *gorm.DB
+
+// openedServerDatabases tracks every handle InitServerDatabase has opened this
+// process. When several servers run in one process (the fed tests launch
+// origin+cache+director+registry together) each call reassigns the global
+// ServerDatabase, so a plain ShutdownDB that only closed the current global
+// would leak the earlier handles -- each a WAL SQLite database holding several
+// file descriptors. ShutdownDB closes all tracked handles instead.
+var (
+	openedServerDatabases   []*gorm.DB
+	openedServerDatabasesMu sync.Mutex
+)
 
 //go:embed universal_migrations/*.sql
 var EmbedUniversalMigrations embed.FS
@@ -53,6 +65,9 @@ func InitServerDatabase(serverType server_structs.ServerType) error {
 		return err
 	}
 	ServerDatabase = tdb
+	openedServerDatabasesMu.Lock()
+	openedServerDatabases = append(openedServerDatabases, tdb)
+	openedServerDatabasesMu.Unlock()
 
 	// Enable foreign key constraints for SQLite
 	if err := ServerDatabase.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
@@ -491,19 +506,34 @@ func GetDowntimeByUUID(uuid string) (*server_structs.Downtime, error) {
 }
 
 func ShutdownDB() error {
-	if ServerDatabase == nil {
-		return nil
+	// Close every handle opened this process, not just the current global. When
+	// several servers share the global in one process (the fed tests), a later
+	// InitServerDatabase reassigns ServerDatabase, so closing only the current
+	// one would leak the earlier handles' file descriptors across restarts.
+	openedServerDatabasesMu.Lock()
+	dbs := openedServerDatabases
+	openedServerDatabases = nil
+	openedServerDatabasesMu.Unlock()
+
+	var firstErr error
+	for _, db := range dbs {
+		sqldb, err := db.DB()
+		if err != nil {
+			log.Errorln("Failure when getting database instance from gorm:", err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if err = sqldb.Close(); err != nil {
+			log.Errorln("Failure when shutting down the database:", err)
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
 	}
-	sqldb, err := ServerDatabase.DB()
-	if err != nil {
-		log.Errorln("Failure when getting database instance from gorm:", err)
-		return err
-	}
-	err = sqldb.Close()
-	if err != nil {
-		log.Errorln("Failure when shutting down the database:", err)
-	}
-	return err
+	ServerDatabase = nil
+	return firstErr
 }
 
 // Convert IsOrigin/IsCache boolean to a string for the service_names table.

--- a/database/server.go
+++ b/database/server.go
@@ -515,6 +515,24 @@ func ShutdownDB() error {
 	openedServerDatabases = nil
 	openedServerDatabasesMu.Unlock()
 
+	// Also close the current global handle when it was assigned without going
+	// through InitServerDatabase (e.g. tests that set ServerDatabase directly
+	// from utils.InitSQLiteDB, and so never registered it above).  Otherwise its
+	// file handle leaks and, on Windows, the SQLite file cannot be removed by
+	// t.TempDir() cleanup ("being used by another process").
+	if ServerDatabase != nil {
+		alreadyTracked := false
+		for _, db := range dbs {
+			if db == ServerDatabase {
+				alreadyTracked = true
+				break
+			}
+		}
+		if !alreadyTracked {
+			dbs = append(dbs, ServerDatabase)
+		}
+	}
+
 	var firstErr error
 	for _, db := range dbs {
 		sqldb, err := db.DB()

--- a/director/director_advertise.go
+++ b/director/director_advertise.go
@@ -28,6 +28,7 @@ import (
 	"net/url"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -60,7 +61,12 @@ type (
 	// Structure representing a remote director and the
 	// channel to interact with the corresponding goroutine
 	directorInfo struct {
-		ad             *server_structs.DirectorAd
+		// ad is the most recent DirectorAd for this remote director.  It is
+		// replaced as newer ads arrive (under directorAdMutex) but is also read
+		// by the long-lived forwarding goroutines, which do NOT hold the lock;
+		// it is therefore an atomic.Pointer so those reads are race-free (and
+		// still observe ad updates).
+		ad             atomic.Pointer[server_structs.DirectorAd]
 		forwardAdChan  chan *forwardAdInfo // Channel for ads for forwarding from the director handler to the internal buffer
 		internalAdChan chan *forwardAdInfo // Channel for ads from the internal buffer to the HTTP client forwarder goroutine.
 		cancel         context.CancelFunc
@@ -147,8 +153,10 @@ func listDirectors(ctx *gin.Context) {
 			// Use Items() instead of Range() to avoid race conditions with the cache's internal eviction goroutine
 			items := directorAds.Items()
 			for _, item := range items {
-				if item.Value() != nil && item.Value().ad != nil {
-					ads = append(ads, *item.Value().ad)
+				if item.Value() != nil {
+					if ad := item.Value().ad.Load(); ad != nil {
+						ads = append(ads, *ad)
+					}
 				}
 			}
 		}
@@ -251,13 +259,14 @@ func forwardServiceAd(engineCtx context.Context, serviceAd *server_structs.Origi
 	items := directorAds.Items()
 	for _, item := range items {
 		dinfo := item.Value()
-		if dinfo.ad == nil {
+		ad := dinfo.ad.Load()
+		if ad == nil {
 			continue
 		}
-		if slices.Contains(seenBy, dinfo.ad.Name) {
+		if slices.Contains(seenBy, ad.Name) {
 			continue
 		}
-		if self, err := server_utils.IsDirectorAdFromSelf(engineCtx, dinfo.ad); err == nil && !self {
+		if self, err := server_utils.IsDirectorAdFromSelf(engineCtx, ad); err == nil && !self {
 			dinfo.forwardService(engineCtx, serviceAd, sType, seenBy)
 		}
 	}
@@ -268,6 +277,16 @@ func forwardServiceAd(engineCtx context.Context, serviceAd *server_structs.Origi
 // Note: the implementation is similar to `forwardService` but there are two
 // functions to avoid refactoring the DirectorAd and OriginAdvertiseV2 to have
 // a common interface.
+// advertiseURL returns the remote director's advertise URL from the current
+// ad, reading the atomic pointer so it is safe to call from the forwarding
+// goroutines without holding directorAdMutex.
+func (dir *directorInfo) advertiseURL() string {
+	if ad := dir.ad.Load(); ad != nil {
+		return ad.AdvertiseUrl
+	}
+	return ""
+}
+
 func (dir *directorInfo) forwardDirector(ad *server_structs.DirectorAd) {
 	forwardAd := &forwardAd{
 		DirectorAd: ad,
@@ -277,7 +296,7 @@ func (dir *directorInfo) forwardDirector(ad *server_structs.DirectorAd) {
 
 	var buf *bytes.Buffer
 	if adBytes, err := json.Marshal(forwardAd); err != nil {
-		log.Errorln("Failed to marshal director ad to JSON when sending to", dir.ad.AdvertiseUrl, ":", err)
+		log.Errorln("Failed to marshal director ad to JSON when sending to", dir.advertiseURL(), ":", err)
 		return
 	} else {
 		buf = bytes.NewBuffer(adBytes)
@@ -326,7 +345,7 @@ func (dir *directorInfo) forwardService(ctx context.Context, ad *server_structs.
 
 	var buf *bytes.Buffer
 	if adBytes, err := json.Marshal(forwardAd); err != nil {
-		log.Errorln("Failed to marshal service ad to JSON when sending to", dir.ad.AdvertiseUrl, ":", err)
+		log.Errorln("Failed to marshal service ad to JSON when sending to", dir.advertiseURL(), ":", err)
 		return
 	} else {
 		buf = bytes.NewBuffer(adBytes)
@@ -347,7 +366,7 @@ func (dir *directorInfo) forwardService(ctx context.Context, ad *server_structs.
 // ad per known director endpoint.  The second goroutine will read on ad off the
 // queue at a time and send it to the remote director
 func (dir *directorInfo) launchForwardAds(ctx context.Context, egrp *errgroup.Group) {
-	advertiseUrl := dir.ad.AdvertiseUrl
+	advertiseUrl := dir.advertiseURL()
 	dir.internalAdChan = make(chan *forwardAdInfo) // Note no buffering: we only send an ad to the director forwarding goroutine when it is ready
 
 	// This goroutine coalesces pending ads into only the latest update
@@ -407,7 +426,7 @@ func (dir *directorInfo) getDirectorToken(ctx context.Context) (string, error) {
 		return "", err
 	}
 	tokenCfg.Issuer = fedInfo.DiscoveryEndpoint
-	aud, err := token.GetWLCGAudience(dir.ad.AdvertiseUrl)
+	aud, err := token.GetWLCGAudience(dir.advertiseURL())
 	if err != nil {
 		return "", err
 	}
@@ -532,10 +551,11 @@ func sendMyAd(ctx context.Context) {
 	items := directorAds.Items()
 	for _, item := range items {
 		dinfo := item.Value()
-		if dinfo.ad == nil {
+		ad := dinfo.ad.Load()
+		if ad == nil {
 			continue
 		}
-		if self, err := server_utils.IsDirectorAdFromSelf(ctx, dinfo.ad); err == nil && !self {
+		if self, err := server_utils.IsDirectorAdFromSelf(ctx, ad); err == nil && !self {
 			dinfo.forwardDirector(directorAd)
 		}
 	}
@@ -567,16 +587,18 @@ func updateInternalDirectorCache(ctx context.Context, egrp *errgroup.Group, dire
 	}
 	if item, found := directorAds.GetOrSet(directorAd.Name, info, ttlcache.WithTTL[string, *directorInfo](adTTL)); found {
 		if item.Value() != nil {
-			if after := directorAd.After(item.Value().ad); after == server_structs.AdAfterTrue || after == server_structs.AdAfterUnknown {
-				item.Value().ad = directorAd
+			if after := directorAd.After(item.Value().ad.Load()); after == server_structs.AdAfterTrue || after == server_structs.AdAfterUnknown {
+				item.Value().ad.Store(directorAd)
 				directorAds.Set(directorAd.Name, item.Value(), adTTL)
 				if after == server_structs.AdAfterTrue {
 					// Use Items() instead of Range() to avoid race conditions with the cache's internal eviction goroutine
 					items := directorAds.Items()
 					for _, item := range items {
-						if item.Value() != nil && item.Value().ad != nil {
-							if self, err := server_utils.IsDirectorAdFromSelf(ctx, item.Value().ad); err == nil && !self {
-								item.Value().forwardDirector(directorAd)
+						if item.Value() != nil {
+							if ad := item.Value().ad.Load(); ad != nil {
+								if self, err := server_utils.IsDirectorAdFromSelf(ctx, ad); err == nil && !self {
+									item.Value().forwardDirector(directorAd)
+								}
 							}
 						}
 					}
@@ -584,7 +606,7 @@ func updateInternalDirectorCache(ctx context.Context, egrp *errgroup.Group, dire
 			}
 		}
 	} else {
-		info.ad = directorAd
+		info.ad.Store(directorAd)
 		var fwdCtx context.Context
 		fwdCtx, info.cancel = context.WithCancel(ctx)
 		info.forwardAdChan = make(chan *forwardAdInfo, 5)

--- a/director/director_advertise_self_test.go
+++ b/director/director_advertise_self_test.go
@@ -47,17 +47,24 @@ func TestSendMyAdInsertsIntoDirectorAds(t *testing.T) {
 	ResetState()
 	t.Cleanup(ResetState)
 
-	ctx, cancel, _ := test_utils.TestContext(context.Background(), t)
-	defer cancel()
+	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	// Cancel and wait for the ad-forwarding goroutines to exit before the test
+	// returns (and thus before the config.ResetConfig cleanup runs); otherwise
+	// a still-running getDirectorToken -> GetFederation reads viper while
+	// ResetConfig resets it, which the race detector flags.
+	defer func() {
+		cancel()
+		_ = egrp.Wait()
+	}()
 
 	sendMyAd(ctx)
 
 	item := directorAds.Get(selfName)
 	require.NotNil(t, item, "directorAds must contain the self-entry after sendMyAd")
 	require.NotNil(t, item.Value())
-	require.NotNil(t, item.Value().ad)
-	assert.Equal(t, selfName, item.Value().ad.Name)
-	assert.Equal(t, "http://self.example.com", item.Value().ad.AdvertiseUrl)
+	require.NotNil(t, item.Value().ad.Load())
+	assert.Equal(t, selfName, item.Value().ad.Load().Name)
+	assert.Equal(t, "http://self.example.com", item.Value().ad.Load().AdvertiseUrl)
 }
 
 // TestListDirectorsReturnsSelfAfterPeerExpires verifies the key
@@ -85,8 +92,15 @@ func TestListDirectorsReturnsSelfAfterPeerExpires(t *testing.T) {
 		return len(directorAds.Items()) == 0
 	}, 1*time.Second, 5*time.Millisecond, "peer ad should expire")
 
-	ctx, cancel, _ := test_utils.TestContext(context.Background(), t)
-	defer cancel()
+	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	// Cancel and wait for the ad-forwarding goroutines to exit before the test
+	// returns (and thus before the config.ResetConfig cleanup runs); otherwise
+	// a still-running getDirectorToken -> GetFederation reads viper while
+	// ResetConfig resets it, which the race detector flags.
+	defer func() {
+		cancel()
+		_ = egrp.Wait()
+	}()
 
 	sendMyAd(ctx)
 
@@ -95,6 +109,6 @@ func TestListDirectorsReturnsSelfAfterPeerExpires(t *testing.T) {
 	selfItem, ok := items[selfName]
 	require.True(t, ok, "self-entry must be keyed by the director name")
 	require.NotNil(t, selfItem.Value())
-	require.NotNil(t, selfItem.Value().ad)
-	assert.Equal(t, selfName, selfItem.Value().ad.Name)
+	require.NotNil(t, selfItem.Value().ad.Load())
+	assert.Equal(t, selfName, selfItem.Value().ad.Load().Name)
 }

--- a/director/director_advertise_testhelpers_test.go
+++ b/director/director_advertise_testhelpers_test.go
@@ -1,0 +1,32 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package director
+
+import "github.com/pelicanplatform/pelican/server_structs"
+
+// newTestDirectorInfo builds a directorInfo with the given ad stored.
+// directorInfo.ad is an atomic.Pointer, so it cannot be set via a struct
+// literal; tests use this helper instead.  It lives in an unconstrained file
+// (no build tag) so it is available to both the platform-agnostic tests
+// (e.g. ha_property_test.go) and the !windows tests (e.g. forward_service_test.go).
+func newTestDirectorInfo(ad *server_structs.DirectorAd) *directorInfo {
+	di := &directorInfo{}
+	di.ad.Store(ad)
+	return di
+}

--- a/director/forward_service_test.go
+++ b/director/forward_service_test.go
@@ -101,34 +101,30 @@ func TestForwardServiceAd(t *testing.T) {
 	require.NoError(t, param.Server_ExternalWebUrl.Set("http://director1.com"))
 
 	ch1 := make(chan *forwardAdInfo, 1)
-	dir1 := &directorInfo{
-		ad: &server_structs.DirectorAd{
-			AdvertiseUrl: "http://director-ad-url-1",
-			ServerBaseAd: server_structs.ServerBaseAd{
-				Name:         "dir1",
-				InstanceID:   "inst-id-1",
-				StartTime:    12345,
-				GenerationID: 1,
-				Version:      "v1",
-			},
+	dir1 := newTestDirectorInfo(&server_structs.DirectorAd{
+		AdvertiseUrl: "http://director-ad-url-1",
+		ServerBaseAd: server_structs.ServerBaseAd{
+			Name:         "dir1",
+			InstanceID:   "inst-id-1",
+			StartTime:    12345,
+			GenerationID: 1,
+			Version:      "v1",
 		},
-		forwardAdChan: ch1,
-	}
+	})
+	dir1.forwardAdChan = ch1
 
 	ch2 := make(chan *forwardAdInfo, 1)
-	dir2 := &directorInfo{
-		ad: &server_structs.DirectorAd{
-			AdvertiseUrl: "http://director-ad-url-2",
-			ServerBaseAd: server_structs.ServerBaseAd{
-				Name:         "dir2",
-				InstanceID:   "inst-id-2",
-				StartTime:    12345,
-				GenerationID: 1,
-				Version:      "v1",
-			},
+	dir2 := newTestDirectorInfo(&server_structs.DirectorAd{
+		AdvertiseUrl: "http://director-ad-url-2",
+		ServerBaseAd: server_structs.ServerBaseAd{
+			Name:         "dir2",
+			InstanceID:   "inst-id-2",
+			StartTime:    12345,
+			GenerationID: 1,
+			Version:      "v1",
 		},
-		forwardAdChan: ch2,
-	}
+	})
+	dir2.forwardAdChan = ch2
 
 	directorAds.Set("dir1", dir1, 15*time.Minute)
 	directorAds.Set("dir2", dir2, 15*time.Minute)
@@ -146,7 +142,7 @@ func TestForwardServiceAd(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	forwardServiceAd(ctx, svcAd, server_structs.OriginType, []string{dir1.ad.Name})
+	forwardServiceAd(ctx, svcAd, server_structs.OriginType, []string{dir1.ad.Load().Name})
 
 	// We should have received an ad on channel 2 but not channel 1
 	select {
@@ -177,49 +173,43 @@ func TestForwardServiceAdSeenByPreventsLoop(t *testing.T) {
 	require.NoError(t, param.Server_ExternalWebUrl.Set("http://director1.com"))
 
 	ch1 := make(chan *forwardAdInfo, 1)
-	dir1 := &directorInfo{
-		ad: &server_structs.DirectorAd{
-			AdvertiseUrl: "http://director-ad-url-1",
-			ServerBaseAd: server_structs.ServerBaseAd{
-				Name:         "dir1",
-				InstanceID:   "inst-id-1",
-				StartTime:    12345,
-				GenerationID: 1,
-				Version:      "v1",
-			},
+	dir1 := newTestDirectorInfo(&server_structs.DirectorAd{
+		AdvertiseUrl: "http://director-ad-url-1",
+		ServerBaseAd: server_structs.ServerBaseAd{
+			Name:         "dir1",
+			InstanceID:   "inst-id-1",
+			StartTime:    12345,
+			GenerationID: 1,
+			Version:      "v1",
 		},
-		forwardAdChan: ch1,
-	}
+	})
+	dir1.forwardAdChan = ch1
 
 	ch2 := make(chan *forwardAdInfo, 1)
-	dir2 := &directorInfo{
-		ad: &server_structs.DirectorAd{
-			AdvertiseUrl: "http://director-ad-url-2",
-			ServerBaseAd: server_structs.ServerBaseAd{
-				Name:         "dir2",
-				InstanceID:   "inst-id-2",
-				StartTime:    12345,
-				GenerationID: 1,
-				Version:      "v1",
-			},
+	dir2 := newTestDirectorInfo(&server_structs.DirectorAd{
+		AdvertiseUrl: "http://director-ad-url-2",
+		ServerBaseAd: server_structs.ServerBaseAd{
+			Name:         "dir2",
+			InstanceID:   "inst-id-2",
+			StartTime:    12345,
+			GenerationID: 1,
+			Version:      "v1",
 		},
-		forwardAdChan: ch2,
-	}
+	})
+	dir2.forwardAdChan = ch2
 
 	ch3 := make(chan *forwardAdInfo, 1)
-	dir3 := &directorInfo{
-		ad: &server_structs.DirectorAd{
-			AdvertiseUrl: "http://director-ad-url-3",
-			ServerBaseAd: server_structs.ServerBaseAd{
-				Name:         "dir3",
-				InstanceID:   "inst-id-3",
-				StartTime:    12345,
-				GenerationID: 1,
-				Version:      "v1",
-			},
+	dir3 := newTestDirectorInfo(&server_structs.DirectorAd{
+		AdvertiseUrl: "http://director-ad-url-3",
+		ServerBaseAd: server_structs.ServerBaseAd{
+			Name:         "dir3",
+			InstanceID:   "inst-id-3",
+			StartTime:    12345,
+			GenerationID: 1,
+			Version:      "v1",
 		},
-		forwardAdChan: ch3,
-	}
+	})
+	dir3.forwardAdChan = ch3
 
 	directorAds.Set("dir1", dir1, 15*time.Minute)
 	directorAds.Set("dir2", dir2, 15*time.Minute)
@@ -329,19 +319,17 @@ func TestForwardServiceAdSimulation(t *testing.T) {
 			for _, name := range names {
 				ch := make(chan *forwardAdInfo, 1000)
 				channels[name] = ch
-				info := &directorInfo{
-					ad: &server_structs.DirectorAd{
-						AdvertiseUrl: "http://" + name + ".example.com",
-						ServerBaseAd: server_structs.ServerBaseAd{
-							Name:         name,
-							InstanceID:   "inst-" + name,
-							StartTime:    12345,
-							GenerationID: 1,
-							Version:      "v1",
-						},
+				info := newTestDirectorInfo(&server_structs.DirectorAd{
+					AdvertiseUrl: "http://" + name + ".example.com",
+					ServerBaseAd: server_structs.ServerBaseAd{
+						Name:         name,
+						InstanceID:   "inst-" + name,
+						StartTime:    12345,
+						GenerationID: 1,
+						Version:      "v1",
 					},
-					forwardAdChan: ch,
-				}
+				})
+				info.forwardAdChan = ch
 				directorAds.Set(name, info, 15*time.Minute)
 			}
 

--- a/director/ha_property_test.go
+++ b/director/ha_property_test.go
@@ -249,19 +249,17 @@ func setupForwardingState(t *testing.T) {
 func makeTestDirector(t *testing.T, name string, ttl time.Duration) chan *forwardAdInfo {
 	t.Helper()
 	ch := make(chan *forwardAdInfo, 20)
-	info := &directorInfo{
-		ad: &server_structs.DirectorAd{
-			AdvertiseUrl: "http://" + name + ".example.com",
-			ServerBaseAd: server_structs.ServerBaseAd{
-				Name:         name,
-				InstanceID:   "inst-" + name,
-				StartTime:    12345,
-				GenerationID: 1,
-				Version:      "v1",
-			},
+	info := newTestDirectorInfo(&server_structs.DirectorAd{
+		AdvertiseUrl: "http://" + name + ".example.com",
+		ServerBaseAd: server_structs.ServerBaseAd{
+			Name:         name,
+			InstanceID:   "inst-" + name,
+			StartTime:    12345,
+			GenerationID: 1,
+			Version:      "v1",
 		},
-		forwardAdChan: ch,
-	}
+	})
+	info.forwardAdChan = ch
 	directorAds.Set(name, info, ttl)
 	return ch
 }
@@ -558,19 +556,17 @@ func TestForwardingReachesAllDirectors(t *testing.T) {
 			for _, name := range names {
 				ch := make(chan *forwardAdInfo, 1000)
 				channels[name] = ch
-				info := &directorInfo{
-					ad: &server_structs.DirectorAd{
-						AdvertiseUrl: "http://" + name + ".example.com",
-						ServerBaseAd: server_structs.ServerBaseAd{
-							Name:         name,
-							InstanceID:   "inst-" + name,
-							StartTime:    12345,
-							GenerationID: 1,
-							Version:      "v1",
-						},
+				info := newTestDirectorInfo(&server_structs.DirectorAd{
+					AdvertiseUrl: "http://" + name + ".example.com",
+					ServerBaseAd: server_structs.ServerBaseAd{
+						Name:         name,
+						InstanceID:   "inst-" + name,
+						StartTime:    12345,
+						GenerationID: 1,
+						Version:      "v1",
 					},
-					forwardAdChan: ch,
-				}
+				})
+				info.forwardAdChan = ch
 				directorAds.Set(name, info, 15*time.Minute)
 			}
 

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2660,6 +2660,22 @@ type: bool
 default: true
 components: ["cache"]
 ---
+name: Cache.EnableChaosAPI
+description: |+
+  Enable the V2 cache's chaos/fault-injection admin API.
+
+  When true, the cache server registers an admin-authenticated endpoint
+  (POST /api/v1.0/cache/introspect/chaos) that deliberately corrupts or truncates
+  the on-disk data of a cached object. This is used by `pelican cache chaos` to
+  exercise the cache's integrity-detection paths.
+
+  This is a destructive testing feature and is disabled by default; it should
+  only be enabled in test/staging environments.
+type: bool
+default: false
+components: ["cache"]
+hidden: true
+---
 name: Cache.DataScanMode
 description: |+
   Controls how the V2 (persistent) cache's periodic data-integrity scan re-verifies on-disk object data.

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2689,9 +2689,30 @@ description: |+
       already guarantees at-rest integrity (for example ZFS with scrubbing), where repeatedly re-reading every object is
       wasteful but recording an initial baseline checksum is still desired.
 
+  Important: "once" mode trusts the underlying storage to detect bitrot after the initial check. The cache cannot verify
+  that the storage actually scrubs, so it emits a loud startup warning and exports the `pelican_cache_data_scan_mode_once`
+  metric (set to 1) whenever this mode is active. To retain a floor of at-rest detection even in this mode, the scan still
+  re-verifies a small fraction of already-checked objects each cycle (see ${Cache.DataScanResampleInterval}).
+
+  Note that "once" mode cannot detect corruption that was present at ingest (before the first scan): the first scan records
+  whatever is on disk as the baseline. Detecting bad-at-ingest data requires a full-file or origin checksum on the
+  download/completion path, which is independent of this setting.
+
   Unrecognized values are treated as "all".
 type: string
 default: all
+components: ["cache"]
+---
+name: Cache.DataScanResampleInterval
+description: |+
+  When ${Cache.DataScanMode} is "once", the data-integrity scan still re-verifies roughly 1 in N already-checked objects
+  on each cycle, so there is a nonzero floor of at-rest corruption detection rather than none. This is the value of N.
+
+  The default of 100 re-checks about 1% of already-verified objects per scan cycle. Set to 0 to disable re-sampling
+  entirely (pure "once": each object is verified exactly once and never re-checked). Has no effect when
+  ${Cache.DataScanMode} is "all".
+type: int
+default: 100
 components: ["cache"]
 ---
 name: Cache.EvictionMonitoringInterval

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2660,6 +2660,24 @@ type: bool
 default: true
 components: ["cache"]
 ---
+name: Cache.DataScanMode
+description: |+
+  Controls how the V2 (persistent) cache's periodic data-integrity scan re-verifies on-disk object data.
+
+  Valid values:
+    - "all" (default): every scan cycle re-reads and re-checksums all complete objects. Recommended when the cache
+      relies on Pelican for at-rest integrity.
+    - "once": each object's on-disk data is read back and checksummed exactly once (recording the checksum in the cache
+      database, and comparing it against the origin's reported checksum when one is available). Objects that have already
+      been verified are skipped on subsequent scan cycles. This is intended for deployments whose underlying storage
+      already guarantees at-rest integrity (for example ZFS with scrubbing), where repeatedly re-reading every object is
+      wasteful but recording an initial baseline checksum is still desired.
+
+  Unrecognized values are treated as "all".
+type: string
+default: all
+components: ["cache"]
+---
 name: Cache.EvictionMonitoringInterval
 description: |+
   The interval at which the eviction monitoring will be reported.

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2537,6 +2537,18 @@ default: false
 components: ["cache"]
 hidden: true
 ---
+name: Cache.WorkerCount
+description: |+
+  The number of concurrent transfer workers the V2 (persistent) cache uses to fetch objects from upstream
+  origins/caches on a cache miss.
+
+  The cache embeds the Pelican transfer engine, which otherwise defaults to the command-line client's
+  ${Client.WorkerCount} (a small value tuned for a single interactive client). That is far too low for a busy cache
+  serving many clients concurrently, so the cache uses this larger default instead.
+type: int
+default: 100
+components: ["cache"]
+---
 name: Cache.AllowedFederations
 description: |+
   A list of federation discovery URLs (or host:port values) that this cache is allowed to serve.

--- a/e2e_fed_tests/persistent_cache_site_local_test.go
+++ b/e2e_fed_tests/persistent_cache_site_local_test.go
@@ -1,0 +1,339 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package fed_tests
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/fed_test_utils"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/test_utils"
+	"github.com/pelicanplatform/pelican/token"
+	"github.com/pelicanplatform/pelican/token_scopes"
+)
+
+// webEngineAddrRe matches the address the web engine binds to, e.g.
+// "Starting web engine at address my-host:55309".  The child is told to bind
+// port 0 (any free port), and pelican rewrites Server.WebPort to the chosen
+// value before logging this line — so reading it back avoids racily
+// pre-selecting a port that another process could grab before the child binds.
+var webEngineAddrRe = regexp.MustCompile(`web engine at address \S*?:(\d+)`)
+
+// upstreamCacheHasObject probes a cache via HTTP HEAD with
+// Cache-Control: only-if-cached (RFC 7234 §5.2.1.7): the cache returns 200 if
+// it already holds the object and 504 if it does not, without ever contacting
+// the origin.  This lets the test inspect cache contents through the public
+// cache API rather than poking at on-disk storage.
+//
+// cacheDataBase is the cache's /api/v1.0/cache/data/<discovery> endpoint.
+// It returns (true, nil) when the cache holds the object, (false, nil) when it
+// does not, and a non-nil error on transport failures or an unexpected status.
+// Returning an error (rather than failing the test) keeps it safe to call from
+// inside a require.Eventually closure, which runs on a separate goroutine.
+func upstreamCacheHasObject(ctx context.Context, httpClient *http.Client, cacheDataBase, objectPath, token string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, cacheDataBase+objectPath, nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Cache-Control", "only-if-cached")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusGatewayTimeout:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected only-if-cached status %d for %s", resp.StatusCode, objectPath)
+	}
+}
+
+// TestPersistentCacheSiteLocalFetchesFromCache verifies the site-local-mode
+// behaviour of the V2 (persistent) cache: a site-local cache must appear to the
+// federation as a client and fetch objects from other caches rather than
+// directly from origins (matching the V1 XRD_PELICANDIRECTORYQUERYMODE=cache
+// behaviour).
+//
+// Topology:
+//   - An in-process federation (director + origin + an advertised V2 cache).
+//     This advertised cache is the "upstream" cache.
+//   - A separate `pelican cache serve` child process running a V2 cache with
+//     Cache.EnableSiteLocalMode=true.  It is NOT advertised to the director.
+//
+// The test downloads a public object through the site-local cache and then
+// asserts (via Cache-Control: only-if-cached) that the *upstream* cache also
+// ended up holding the object.  That can only happen if the site-local cache
+// fetched the object through the upstream cache (client mode); if it had
+// fetched directly from the origin (the pre-fix embedded-cache behaviour), the
+// upstream cache would never have seen the object.
+func TestPersistentCacheSiteLocalFetchesFromCache(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	defer server_utils.ResetTestState()
+
+	// Build the pelican binary used for the site-local cache child process.
+	cliPath := getPelicanBinary(t)
+
+	// Enable the persistent cache for the in-process (upstream) cache.
+	require.NoError(t, param.Cache_EnableV2.Set(true))
+
+	// Start the federation: director + origin + advertised V2 cache.
+	ft := fed_test_utils.NewFedTest(t, persistentCacheConfig)
+	require.NotNil(t, ft)
+	require.Greater(t, len(ft.Exports), 0, "Federation should have at least one export")
+
+	// Capture the configuration the child process needs to inherit from the
+	// running federation.  By reusing the federation's CA and host certificate
+	// (the host certificate is for the hostname and is not port-specific) the
+	// child cache is mutually trusted with the test process and the rest of the
+	// federation.
+	hostname := param.Server_Hostname.GetString()
+	discoveryUrl := param.Federation_DiscoveryUrl.GetString()
+	caCert := param.Server_TLSCACertificateFile.GetString()
+	caKey := param.Server_TLSCAKey.GetString()
+	tlsCert := param.Server_TLSCertificateChain.GetString()
+	tlsKey := param.Server_TLSKey.GetString()
+	issuerKeysDir := param.IssuerKeysDirectory.GetString()
+
+	// Directories for the site-local cache child process.  The child binds an
+	// arbitrary free port (Server.WebPort: 0); its actual URL is discovered
+	// from its output once it starts.
+	childDir := t.TempDir()
+	childStorage := filepath.Join(childDir, "storage")
+
+	// Build a config file for the child cache.  It inherits federation
+	// discovery and TLS material from the parent and overrides ports,
+	// storage locations and the cache flags under test.
+	childConfig := map[string]any{
+		"Federation": map[string]any{
+			"DiscoveryUrl": discoveryUrl,
+		},
+		"Logging": map[string]any{
+			"Level": "debug",
+		},
+		"TLSSkipVerify":       false,
+		"ConfigDir":           childDir,
+		"RuntimeDir":          childDir,
+		"IssuerKeysDirectory": issuerKeysDir,
+		"Server": map[string]any{
+			"Hostname": hostname,
+			// Bind any free port; pelican rewrites WebPort/ExternalWebUrl to
+			// the chosen value, which we read back from the child's output.
+			"WebPort":              0,
+			"ExternalWebUrl":       "https://" + hostname,
+			"EnableUI":             false,
+			"TLSCACertificateFile": caCert,
+			"TLSCAKey":             caKey,
+			"TLSCertificateChain":  tlsCert,
+			"TLSKey":               tlsKey,
+		},
+		"Cache": map[string]any{
+			"EnableV2":                 true,
+			"EnableSiteLocalMode":      true,
+			"StorageLocation":          childStorage,
+			"DbLocation":               filepath.Join(childDir, "cache.sqlite"),
+			"RunLocation":              filepath.Join(childDir, "run"),
+			"Port":                     0,
+			"EnableLotman":             false,
+			"EnableEvictionMonitoring": false,
+			"SelfTest":                 false,
+		},
+	}
+
+	childConfigBytes, err := yaml.Marshal(childConfig)
+	require.NoError(t, err)
+	childConfigPath := filepath.Join(childDir, "site-local-cache.yaml")
+	require.NoError(t, os.WriteFile(childConfigPath, childConfigBytes, 0644))
+
+	// Launch the site-local cache child process.  It is tied to the federation
+	// context so it is torn down when the test's context is cancelled.
+	var childOutput bytes.Buffer
+	var outputMu sync.Mutex
+	cmd := exec.CommandContext(ft.Ctx, cliPath, "cache", "serve", "--config", childConfigPath)
+	cmd.Env = os.Environ()
+	cmd.Stdout = &lockedWriter{w: &childOutput, mu: &outputMu}
+	cmd.Stderr = cmd.Stdout
+	require.NoError(t, cmd.Start(), "failed to start site-local cache process")
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+		outputMu.Lock()
+		defer outputMu.Unlock()
+		if t.Failed() {
+			t.Logf("site-local cache process output:\n%s", childOutput.String())
+		}
+	})
+	childOutputSnapshot := func() string {
+		outputMu.Lock()
+		defer outputMu.Unlock()
+		return childOutput.String()
+	}
+
+	// Discover the port the child bound to by reading it back from its output,
+	// then build its URL.  This avoids pre-selecting a port (which would race
+	// with other processes between selection and the child's bind).
+	var childCacheUrl string
+	require.Eventually(t, func() bool {
+		m := webEngineAddrRe.FindStringSubmatch(childOutputSnapshot())
+		if m == nil {
+			return false
+		}
+		childCacheUrl = fmt.Sprintf("https://%s:%s", hostname, m[1])
+		return true
+	}, 60*time.Second, 200*time.Millisecond, "site-local cache never reported its web port")
+
+	// Wait for the site-local cache's object-serving handlers to be registered.
+	// The /api/v1.0/cache/stats endpoint is registered by RegisterCacheHandlers,
+	// so a 200 there means the cache (not just the bare web engine, which serves
+	// /api/v1.0/health much earlier) is ready to serve objects.
+	httpClient := &http.Client{Transport: config.GetTransport()}
+	readyUrl := childCacheUrl + "/api/v1.0/cache/stats"
+	require.Eventually(t, func() bool {
+		req, reqErr := http.NewRequestWithContext(ft.Ctx, http.MethodGet, readyUrl, nil)
+		if reqErr != nil {
+			return false
+		}
+		resp, doErr := httpClient.Do(req)
+		if doErr != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 90*time.Second, 500*time.Millisecond, "site-local cache did not become ready")
+
+	// Mint a read token for the object (signed by the federation's issuer key,
+	// which both caches validate via the issuer's published JWKS).
+	readToken := mintReadToken(t)
+
+	// The upstream cache's public object endpoint.  We probe it with
+	// only-if-cached to inspect its contents without triggering an origin fetch.
+	// The cache keys its federation off the director/web URL host (which, in
+	// this harness, differs from the separate discovery server's host), so that
+	// is the value used in the /cache/data/<discovery> path segment.
+	discoveryHost := hostnameFromDiscovery(t, discoveryUrl)
+	webUrl := param.Server_ExternalWebUrl.GetString()
+	webHost := hostnameFromDiscovery(t, webUrl)
+	upstreamCacheData := webUrl + "/api/v1.0/cache/data/" + url.PathEscape(webHost)
+	const objectPath = "/test/hello_world.txt"
+
+	// Precondition: the upstream cache must not already hold the object.
+	cached, err := upstreamCacheHasObject(ft.Ctx, httpClient, upstreamCacheData, objectPath, readToken)
+	require.NoError(t, err)
+	require.False(t, cached, "upstream cache should not hold the object before the download")
+
+	// Download the public object through the site-local cache by forcing the
+	// client to use it as the (only) cache.  Client.PreferredCaches takes a bare
+	// cache host:port and the client fills in the object path, so the override
+	// URL is just the site-local cache's host:port.
+	objectURL := fmt.Sprintf("pelican://%s%s", discoveryHost, objectPath)
+	childCacheParsed, err := url.Parse(childCacheUrl)
+	require.NoError(t, err)
+
+	downloadDir := t.TempDir()
+	downloadFile := filepath.Join(downloadDir, "hello_world.txt")
+	results, err := client.DoGet(ft.Ctx, objectURL, downloadFile, false,
+		client.WithCaches(childCacheParsed), client.WithToken(readToken))
+	require.NoError(t, err, "download through site-local cache failed")
+	require.NotEmpty(t, results)
+
+	content, err := os.ReadFile(downloadFile)
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, World!", string(content), "downloaded content should match origin")
+
+	// The decisive assertion: the upstream cache must now hold the object,
+	// proving the site-local cache fetched it through the upstream cache rather
+	// than directly from the origin (the latter being the pre-fix embedded-cache
+	// behaviour).  Caching upstream is asynchronous, so poll via only-if-cached.
+	require.Eventually(t, func() bool {
+		has, probeErr := upstreamCacheHasObject(ft.Ctx, httpClient, upstreamCacheData, objectPath, readToken)
+		return probeErr == nil && has
+	}, 30*time.Second, 500*time.Millisecond,
+		"upstream cache never received the object; site-local cache appears to have fetched directly from the origin")
+}
+
+// mintReadToken creates a short-lived WLCG read token signed by the running
+// federation's issuer key.  Unlike getTempTokenForTest it does NOT reset
+// IssuerKeysDirectory, so the token is signed by the key the federation
+// actually published (and which the child cache can therefore verify).
+func mintReadToken(t testing.TB) string {
+	t.Helper()
+	issuer, err := config.GetServerIssuerURL()
+	require.NoError(t, err)
+
+	tokConf := token.NewWLCGToken()
+	tokConf.Lifetime = 5 * time.Minute
+	tokConf.Issuer = issuer
+	tokConf.Subject = "test"
+	tokConf.AddAudienceAny()
+	readScope, err := token_scopes.Wlcg_Storage_Read.Path("/")
+	require.NoError(t, err)
+	tokConf.AddScopes(readScope)
+
+	tkn, err := tokConf.CreateToken()
+	require.NoError(t, err)
+	return tkn
+}
+
+// hostnameFromDiscovery extracts the host:port of the federation from its
+// discovery URL so object URLs can be addressed against it.
+func hostnameFromDiscovery(t testing.TB, discoveryUrl string) string {
+	t.Helper()
+	u, err := url.Parse(discoveryUrl)
+	require.NoError(t, err)
+	return u.Host
+}
+
+// lockedWriter serialises writes to an underlying buffer so the child
+// process's stdout and stderr can share one buffer safely.
+type lockedWriter struct {
+	w  *bytes.Buffer
+	mu *sync.Mutex
+}
+
+func (lw *lockedWriter) Write(p []byte) (int, error) {
+	lw.mu.Lock()
+	defer lw.mu.Unlock()
+	return lw.w.Write(p)
+}

--- a/github_scripts/osx_install.sh
+++ b/github_scripts/osx_install.sh
@@ -46,7 +46,7 @@ pushd dependencies
 # Install scitokens first, which our xrootd build relies on
 git clone https://github.com/scitokens/scitokens-cpp.git
 pushd scitokens-cpp
-git checkout v1.1.3
+git checkout v1.4.1
 mkdir build
 cd build
 export SCITOKENS_CPP_DIR=$PWD/release_dir

--- a/launchers/cache_serve.go
+++ b/launchers/cache_serve.go
@@ -92,6 +92,16 @@ func cacheServeWithPersistentCache(ctx context.Context, engine *gin.Engine, egrp
 		return nil, err
 	}
 
+	// The persistent cache has no XRootD process to launch the monitoring
+	// shoveler (which the XRootD-based cache does via xrootd config), so start
+	// it here when enabled.  This lets the in-process XRootD-style monitoring
+	// packets emitted on each served request reach the configured collectors.
+	if param.Shoveler_Enable.GetBool() {
+		if _, err := metrics.LaunchShoveler(ctx, egrp); err != nil {
+			return nil, errors.Wrap(err, "failed to launch monitoring shoveler for persistent cache")
+		}
+	}
+
 	cache.RegisterCacheAPI(engine, ctx, egrp)
 
 	cacheServer := &cache.CacheServer{}

--- a/local_cache/block_fetcher.go
+++ b/local_cache/block_fetcher.go
@@ -175,7 +175,7 @@ func NewBlockFetcherV2(
 	// Create a dedicated TransferClient so this fetcher's doFetch goroutines
 	// have their own Results() channel and cannot steal results intended for
 	// other callers sharing the same TransferEngine.
-	tc, err := te.NewClient(client.WithAcquireToken(false), client.WithCacheEmbeddedClientMode())
+	tc, err := te.NewClient(client.WithAcquireToken(false), client.WithCacheEmbeddedClientMode(useEmbeddedCacheMode()))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create transfer client for block fetcher")
 	}
@@ -531,9 +531,11 @@ func (bf *BlockFetcherV2) doFetch(ctx context.Context, op *fetchOperation, key f
 		return
 	}
 	sourceURL.Scheme = "pelican"
-	// The client's cache mode (set on the transfer client) causes
-	// queryDirector to route through the director's origin endpoint,
-	// so origins that disable direct clients are reachable.
+	// The client's cache mode (set on the transfer client, see
+	// useEmbeddedCacheMode) causes queryDirector to route through the
+	// director's origin endpoint, so origins that disable direct clients are
+	// reachable.  In site-local mode embedded mode is disabled and the
+	// director redirects us to other caches instead.
 
 	// Build transfer options with a byte range so we only download the
 	// blocks we actually need instead of the entire object.

--- a/local_cache/cache_internal_test.go
+++ b/local_cache/cache_internal_test.go
@@ -24,9 +24,30 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/token_scopes"
 )
+
+// TestUseEmbeddedCacheMode verifies that the embedded transfer client only runs
+// in cache-embedded mode (fetching directly from origins) when the cache is a
+// normal federation member.  In site-local mode the cache appears to the
+// federation as a client and must fetch from other caches, so embedded mode is
+// disabled.
+func TestUseEmbeddedCacheMode(t *testing.T) {
+	server_utils.ResetTestState()
+	defer server_utils.ResetTestState()
+
+	// Default (federation member): embedded mode is on.
+	assert.True(t, useEmbeddedCacheMode())
+
+	// Site-local mode: embedded mode is off so the director redirects us to
+	// other caches rather than origins.
+	require.NoError(t, param.Cache_EnableSiteLocalMode.Set(true))
+	assert.False(t, useEmbeddedCacheMode())
+}
 
 func TestCalcResources(t *testing.T) {
 	tests := []struct {

--- a/local_cache/chaos.go
+++ b/local_cache/chaos.go
@@ -22,9 +22,29 @@ package local_cache
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 )
+
+// isHexHash reports whether h consists solely of hexadecimal characters.
+// Instance/object hashes are hex-encoded HMAC-SHA256 digests, so validating
+// this before using a hash to build a filesystem path prevents path traversal
+// from a caller-supplied --instance value.
+func isHexHash(h InstanceHash) bool {
+	if len(h) == 0 {
+		return false
+	}
+	for _, c := range h {
+		switch {
+		case c >= '0' && c <= '9', c >= 'a' && c <= 'f', c >= 'A' && c <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
 
 // ChaosInjector injects corruption into a running cache's already-open
 // database and storage, for fault-injection ("chaos") testing of the cache's
@@ -88,6 +108,12 @@ func (ci *ChaosInjector) resolveInstanceHash(objectURL, etag, instanceHash strin
 		hash = ci.db.InstanceHash(etag, objectHash)
 	}
 
+	// Guard against path traversal from a caller-supplied instance hash before
+	// the hash is ever used to construct a filesystem path.
+	if !isHexHash(hash) {
+		return "", nil, errors.Errorf("invalid instance hash %q: must be hexadecimal", hash)
+	}
+
 	meta, err := ci.storage.GetMetadata(hash)
 	if err != nil {
 		return "", nil, errors.Wrap(err, "failed to read object metadata")
@@ -96,6 +122,21 @@ func (ci *ChaosInjector) resolveInstanceHash(objectURL, etag, instanceHash strin
 		return "", nil, errors.Errorf("no cached object found for instance %s", hash)
 	}
 	return hash, meta, nil
+}
+
+// safeChunkPath resolves the on-disk chunk file path and verifies it stays
+// within its storage directory, defending against path traversal.
+func (ci *ChaosInjector) safeChunkPath(storageID StorageID, hash InstanceHash, chunkIndex int) (string, error) {
+	root, ok := ci.storage.GetDirs()[storageID]
+	if !ok {
+		return "", errors.Errorf("unknown storage id %d", storageID)
+	}
+	cleanRoot := filepath.Clean(root)
+	cleanPath := filepath.Clean(ci.storage.getChunkPath(storageID, hash, chunkIndex))
+	if cleanPath != cleanRoot && !strings.HasPrefix(cleanPath, cleanRoot+string(os.PathSeparator)) {
+		return "", errors.Errorf("resolved chunk path %q escapes storage directory %q", cleanPath, cleanRoot)
+	}
+	return cleanPath, nil
 }
 
 // chunkFileForBlock maps a global block number to the on-disk chunk file that
@@ -112,7 +153,10 @@ func (ci *ChaosInjector) chunkFileForBlock(hash InstanceHash, meta *CacheMetadat
 	if storageID == StorageIDInline {
 		return "", 0, 0, errors.Errorf("chunk %d is not yet allocated on disk", chunkIndex)
 	}
-	chunkPath = ci.storage.getChunkPath(storageID, hash, chunkIndex)
+	chunkPath, err = ci.safeChunkPath(storageID, hash, chunkIndex)
+	if err != nil {
+		return "", 0, 0, err
+	}
 
 	// The on-disk offset is the (zero-based) block index within this chunk file
 	// times the encrypted block size.
@@ -172,7 +216,10 @@ func (ci *ChaosInjector) CorruptBlock(objectURL, etag, instanceHash string, bloc
 		numBytes = int(info.Size() - diskOffset)
 	}
 
-	buf := make([]byte, numBytes)
+	// numBytes is bounded by BlockTotalSize above, so a fixed-size stack buffer
+	// suffices and avoids a caller-influenced dynamic allocation.
+	var blockBuf [BlockTotalSize]byte
+	buf := blockBuf[:numBytes]
 	if _, err := f.ReadAt(buf, diskOffset); err != nil {
 		return nil, errors.Wrap(err, "failed to read block bytes")
 	}
@@ -223,7 +270,10 @@ func (ci *ChaosInjector) TruncateObject(objectURL, etag, instanceHash string, ch
 	if storageID == StorageIDInline {
 		return nil, errors.Errorf("chunk %d is not yet allocated on disk", chunkIndex)
 	}
-	chunkPath := ci.storage.getChunkPath(storageID, hash, chunkIndex)
+	chunkPath, err := ci.safeChunkPath(storageID, hash, chunkIndex)
+	if err != nil {
+		return nil, err
+	}
 
 	if dropBytes <= 0 {
 		dropBytes = BlockTotalSize

--- a/local_cache/chaos.go
+++ b/local_cache/chaos.go
@@ -1,0 +1,262 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package local_cache
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+// ChaosInjector injects corruption into a running cache's already-open
+// database and storage, for fault-injection ("chaos") testing of the cache's
+// integrity-detection paths.
+//
+// BadgerDB is single-process, so corruption must be performed in-process by the
+// cache server itself (a CLI cannot open the database while the server holds
+// it).  The injector therefore wraps the live handles and does not own them —
+// there is nothing to close.
+type ChaosInjector struct {
+	db      *CacheDB
+	storage *StorageManager
+}
+
+// NewChaosInjector wraps a live cache's database and storage manager.
+func NewChaosInjector(db *CacheDB, storage *StorageManager) *ChaosInjector {
+	return &ChaosInjector{db: db, storage: storage}
+}
+
+// ChaosResult describes a corruption injected into a cached object by the
+// chaos-testing helpers.  It is intended for fault-injection testing of the
+// cache's integrity scan and read-time corruption detection.
+type ChaosResult struct {
+	InstanceHash string `json:"instance_hash"`
+	SourceURL    string `json:"source_url,omitempty"`
+	ETag         string `json:"etag,omitempty"`
+	Operation    string `json:"operation"` // "corrupt-block" or "truncate"
+	ChunkIndex   int    `json:"chunk_index"`
+	FilePath     string `json:"file_path"`
+	BlockNum     int64  `json:"block_num,omitempty"` // global block number (corrupt-block)
+	DiskOffset   int64  `json:"disk_offset"`
+	BytesChanged int    `json:"bytes_changed,omitempty"`
+	OldFileSize  int64  `json:"old_file_size"`
+	NewFileSize  int64  `json:"new_file_size"`
+}
+
+// resolveInstanceHash resolves an object instance from either an explicit
+// instance hash, or an object URL plus optional ETag (defaulting to the latest
+// cached version).  It returns the instance hash and its metadata.
+func (ci *ChaosInjector) resolveInstanceHash(objectURL, etag, instanceHash string) (InstanceHash, *CacheMetadata, error) {
+	var hash InstanceHash
+	if instanceHash != "" {
+		hash = InstanceHash(instanceHash)
+	} else {
+		normalized := NormalizePelicanURL(objectURL)
+		if normalized == "" {
+			return "", nil, errors.New("either an object URL or an instance hash is required")
+		}
+		objectHash := ci.db.ObjectHash(normalized)
+		if etag == "" {
+			var found bool
+			var err error
+			etag, found, err = ci.db.GetLatestETag(objectHash)
+			if err != nil {
+				return "", nil, errors.Wrap(err, "failed to get latest ETag")
+			}
+			if !found {
+				return "", nil, errors.New("no cached version found for this object")
+			}
+		}
+		hash = ci.db.InstanceHash(etag, objectHash)
+	}
+
+	meta, err := ci.storage.GetMetadata(hash)
+	if err != nil {
+		return "", nil, errors.Wrap(err, "failed to read object metadata")
+	}
+	if meta == nil {
+		return "", nil, errors.Errorf("no cached object found for instance %s", hash)
+	}
+	return hash, meta, nil
+}
+
+// chunkFileForBlock maps a global block number to the on-disk chunk file that
+// stores it and the byte offset of the (encrypted) block within that file.
+func (ci *ChaosInjector) chunkFileForBlock(hash InstanceHash, meta *CacheMetadata, blockNum uint32) (chunkPath string, chunkIndex int, diskOffset int64, err error) {
+	contentOffset := int64(blockNum) * BlockDataSize
+	if contentOffset >= meta.ContentLength {
+		return "", 0, 0, errors.Errorf("block %d is past the end of the object (%d block(s), %d bytes)",
+			blockNum, CalculateBlockCount(meta.ContentLength), meta.ContentLength)
+	}
+
+	chunkIndex = ContentOffsetToChunk(contentOffset, meta.ChunkSizeCode)
+	storageID := meta.GetChunkStorageID(chunkIndex)
+	if storageID == StorageIDInline {
+		return "", 0, 0, errors.Errorf("chunk %d is not yet allocated on disk", chunkIndex)
+	}
+	chunkPath = ci.storage.getChunkPath(storageID, hash, chunkIndex)
+
+	// The on-disk offset is the (zero-based) block index within this chunk file
+	// times the encrypted block size.
+	localBlock := uint32(OffsetInChunk(contentOffset, meta.ChunkSizeCode) / BlockDataSize)
+	diskOffset = BlockOffset(localBlock)
+	return chunkPath, chunkIndex, diskOffset, nil
+}
+
+// CorruptBlock flips the first numBytes bytes of the on-disk (encrypted)
+// representation of the given block.  This makes the block's AES-GCM
+// authentication tag fail to validate, which the cache detects on the next
+// read of that block or during the periodic data-integrity scan.
+//
+// blockNum is a global, zero-based block number.  numBytes <= 0 defaults to the
+// authentication-tag size (the minimum needed to guarantee detection).
+//
+// Detection is not necessarily immediate: a block whose plaintext is still in
+// the cache's in-memory caches will continue to read successfully until those
+// entries are evicted; the corruption is caught on the next cold read of the
+// block, the periodic data-integrity scan, or after a restart.
+func (ci *ChaosInjector) CorruptBlock(objectURL, etag, instanceHash string, blockNum uint32, numBytes int) (*ChaosResult, error) {
+	hash, meta, err := ci.resolveInstanceHash(objectURL, etag, instanceHash)
+	if err != nil {
+		return nil, err
+	}
+	if meta.IsInline() {
+		return nil, errors.New("object is stored inline in the database; chaos injection only supports disk-backed objects")
+	}
+
+	chunkPath, chunkIndex, diskOffset, err := ci.chunkFileForBlock(hash, meta, blockNum)
+	if err != nil {
+		return nil, err
+	}
+
+	if numBytes <= 0 {
+		numBytes = AuthTagSize
+	}
+	if numBytes > BlockTotalSize {
+		numBytes = BlockTotalSize
+	}
+
+	f, err := os.OpenFile(chunkPath, os.O_RDWR, 0)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open chunk file %s", chunkPath)
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to stat chunk file")
+	}
+	if diskOffset >= info.Size() {
+		return nil, errors.Errorf("block %d is not present on disk (chunk file is %d bytes)", blockNum, info.Size())
+	}
+	// Do not read past EOF for a short final block.
+	if diskOffset+int64(numBytes) > info.Size() {
+		numBytes = int(info.Size() - diskOffset)
+	}
+
+	buf := make([]byte, numBytes)
+	if _, err := f.ReadAt(buf, diskOffset); err != nil {
+		return nil, errors.Wrap(err, "failed to read block bytes")
+	}
+	for i := range buf {
+		buf[i] ^= 0xFF
+	}
+	if _, err := f.WriteAt(buf, diskOffset); err != nil {
+		return nil, errors.Wrap(err, "failed to write corrupted bytes")
+	}
+
+	return &ChaosResult{
+		InstanceHash: string(hash),
+		SourceURL:    meta.SourceURL,
+		ETag:         meta.ETag,
+		Operation:    "corrupt-block",
+		ChunkIndex:   chunkIndex,
+		FilePath:     chunkPath,
+		BlockNum:     int64(blockNum),
+		DiskOffset:   diskOffset,
+		BytesChanged: numBytes,
+		OldFileSize:  info.Size(),
+		NewFileSize:  info.Size(),
+	}, nil
+}
+
+// TruncateObject removes dropBytes bytes from the end of one of the object's
+// on-disk chunk files (the last chunk by default, when chunkIndex < 0).  This
+// drops trailing block(s), which the cache detects on a cold read or during
+// the data scan.  dropBytes <= 0 defaults to a single encrypted block
+// (BlockTotalSize).
+func (ci *ChaosInjector) TruncateObject(objectURL, etag, instanceHash string, chunkIndex int, dropBytes int64) (*ChaosResult, error) {
+	hash, meta, err := ci.resolveInstanceHash(objectURL, etag, instanceHash)
+	if err != nil {
+		return nil, err
+	}
+	if meta.IsInline() {
+		return nil, errors.New("object is stored inline in the database; chaos injection only supports disk-backed objects")
+	}
+
+	chunkCount := meta.ChunkCount()
+	if chunkIndex < 0 {
+		chunkIndex = chunkCount - 1
+	}
+	if chunkIndex >= chunkCount {
+		return nil, errors.Errorf("chunk %d is out of range (object has %d chunk(s))", chunkIndex, chunkCount)
+	}
+	storageID := meta.GetChunkStorageID(chunkIndex)
+	if storageID == StorageIDInline {
+		return nil, errors.Errorf("chunk %d is not yet allocated on disk", chunkIndex)
+	}
+	chunkPath := ci.storage.getChunkPath(storageID, hash, chunkIndex)
+
+	if dropBytes <= 0 {
+		dropBytes = BlockTotalSize
+	}
+
+	f, err := os.OpenFile(chunkPath, os.O_RDWR, 0)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open chunk file %s", chunkPath)
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to stat chunk file")
+	}
+	oldSize := info.Size()
+	newSize := oldSize - dropBytes
+	if newSize < 0 {
+		newSize = 0
+	}
+	if err := f.Truncate(newSize); err != nil {
+		return nil, errors.Wrap(err, "failed to truncate chunk file")
+	}
+
+	return &ChaosResult{
+		InstanceHash: string(hash),
+		SourceURL:    meta.SourceURL,
+		ETag:         meta.ETag,
+		Operation:    "truncate",
+		ChunkIndex:   chunkIndex,
+		FilePath:     chunkPath,
+		DiskOffset:   newSize,
+		OldFileSize:  oldSize,
+		NewFileSize:  newSize,
+	}, nil
+}

--- a/local_cache/chaos.go
+++ b/local_cache/chaos.go
@@ -21,28 +21,17 @@ package local_cache
 import (
 	"os"
 	"path/filepath"
-	"strings"
+	"regexp"
 
 	"github.com/pkg/errors"
 )
 
-// isHexHash reports whether h consists solely of hexadecimal characters.
-// Instance/object hashes are hex-encoded HMAC-SHA256 digests, so validating
-// this before using a hash to build a filesystem path prevents path traversal
-// from a caller-supplied --instance value.
-func isHexHash(h InstanceHash) bool {
-	if len(h) == 0 {
-		return false
-	}
-	for _, c := range h {
-		switch {
-		case c >= '0' && c <= '9', c >= 'a' && c <= 'f', c >= 'A' && c <= 'F':
-		default:
-			return false
-		}
-	}
-	return true
-}
+// hexHashPattern matches a non-empty hexadecimal string.  Instance/object
+// hashes are hex-encoded HMAC-SHA256 digests, so validating a hash against this
+// (anchored) pattern before it is used to build a filesystem path prevents path
+// traversal from a caller-supplied instance value — a hex-only string cannot
+// contain a path separator or "..".
+var hexHashPattern = regexp.MustCompile(`^[0-9a-fA-F]+$`)
 
 // ChaosInjector injects corruption into a running cache's already-open
 // database and storage, for fault-injection ("chaos") testing of the cache's
@@ -108,7 +97,7 @@ func (ci *ChaosInjector) resolveInstanceHash(objectURL, etag, instanceHash strin
 
 	// Guard against path traversal from a caller-supplied instance hash before
 	// the hash is ever used to construct a filesystem path.
-	if !isHexHash(hash) {
+	if !hexHashPattern.MatchString(string(hash)) {
 		return "", nil, errors.Errorf("invalid instance hash %q: must be hexadecimal", hash)
 	}
 
@@ -123,18 +112,20 @@ func (ci *ChaosInjector) resolveInstanceHash(objectURL, etag, instanceHash strin
 }
 
 // safeChunkPath resolves the on-disk chunk file path and verifies it stays
-// within its storage directory, defending against path traversal.
+// within its storage directory, defending against path traversal.  The
+// object-relative portion is built from the (already hex-validated) instance
+// hash; filepath.IsLocal confirms it cannot escape the storage root before it
+// is joined to the trusted directory.
 func (ci *ChaosInjector) safeChunkPath(storageID StorageID, hash InstanceHash, chunkIndex int) (string, error) {
 	root, ok := ci.storage.GetDirs()[storageID]
 	if !ok {
 		return "", errors.Errorf("unknown storage id %d", storageID)
 	}
-	cleanRoot := filepath.Clean(root)
-	cleanPath := filepath.Clean(ci.storage.getChunkPath(storageID, hash, chunkIndex))
-	if cleanPath != cleanRoot && !strings.HasPrefix(cleanPath, cleanRoot+string(os.PathSeparator)) {
-		return "", errors.Errorf("resolved chunk path %q escapes storage directory %q", cleanPath, cleanRoot)
+	rel := GetChunkPath(GetInstanceStoragePath(hash), chunkIndex)
+	if !filepath.IsLocal(rel) {
+		return "", errors.Errorf("refusing non-local chunk path %q for instance %s", rel, hash)
 	}
-	return cleanPath, nil
+	return filepath.Join(root, rel), nil
 }
 
 // chunkFileForBlock maps a global block number to the on-disk chunk file that

--- a/local_cache/chaos.go
+++ b/local_cache/chaos.go
@@ -1,5 +1,3 @@
-//go:build !windows
-
 /***************************************************************
  *
  * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research

--- a/local_cache/chaos_test.go
+++ b/local_cache/chaos_test.go
@@ -1,0 +1,125 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package local_cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+// newChaosTestCache opens a read-write cache (database + storage) and returns
+// it along with a disk storage ID.  The chaos injector wraps these same live
+// handles, mirroring how the cache server uses it in-process.
+func newChaosTestCache(t *testing.T) (*CacheDB, *StorageManager, StorageID) {
+	t.Helper()
+	InitIssuerKeyForTests(t)
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+
+	db, err := NewCacheDB(ctx, tmpDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	egrp, _ := errgroup.WithContext(ctx)
+	storage, err := NewStorageManager(db, []string{tmpDir}, 0, egrp)
+	require.NoError(t, err)
+	t.Cleanup(storage.Close)
+
+	var diskID StorageID
+	for id := range storage.GetDirs() {
+		diskID = id
+	}
+	return db, storage, diskID
+}
+
+// TestChaosCorruptBlock verifies that CorruptBlock flips on-disk bytes such
+// that the targeted block can no longer be read back (its authentication tag
+// fails).  Block 1 is corrupted and read cold (it is never read before
+// corruption, so it is not served from the in-memory plaintext cache).
+func TestChaosCorruptBlock(t *testing.T) {
+	db, storage, diskID := newChaosTestCache(t)
+	ctx := context.Background()
+
+	data := make([]byte, 2*BlockDataSize)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	hash := InstanceHash("abab000000000000000000000000000000000000000000000000000000000001")
+	storeTestObject(t, ctx, storage, hash, data, diskID, NamespaceID(1))
+
+	ci := NewChaosInjector(db, storage)
+	res, err := ci.CorruptBlock("", "", string(hash), 1, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "corrupt-block", res.Operation)
+	assert.Equal(t, int64(1), res.BlockNum)
+	assert.Equal(t, AuthTagSize, res.BytesChanged)
+	assert.Equal(t, res.OldFileSize, res.NewFileSize)
+
+	// Block 1 (never read before corruption) now fails to decrypt.
+	_, err = storage.ReadBlocks(hash, BlockDataSize, BlockDataSize)
+	require.Error(t, err, "reading a corrupted block should fail the authentication check")
+}
+
+// TestChaosTruncateObject verifies that TruncateObject drops trailing blocks so
+// that a removed block can no longer be read back.
+func TestChaosTruncateObject(t *testing.T) {
+	db, storage, diskID := newChaosTestCache(t)
+	ctx := context.Background()
+
+	data := make([]byte, 2*BlockDataSize)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	hash := InstanceHash("baba000000000000000000000000000000000000000000000000000000000001")
+	storeTestObject(t, ctx, storage, hash, data, diskID, NamespaceID(1))
+
+	ci := NewChaosInjector(db, storage)
+	res, err := ci.TruncateObject("", "", string(hash), -1, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "truncate", res.Operation)
+	assert.Equal(t, res.OldFileSize-BlockTotalSize, res.NewFileSize,
+		"default truncation drops one encrypted block")
+
+	// The dropped (last) block can no longer be read.
+	_, err = storage.ReadBlocks(hash, BlockDataSize, BlockDataSize)
+	require.Error(t, err, "reading a truncated-away block should fail")
+}
+
+// TestChaosInlineRejected verifies that chaos injection refuses inline objects,
+// which live in the database rather than on disk.
+func TestChaosInlineRejected(t *testing.T) {
+	db, storage, _ := newChaosTestCache(t)
+	ctx := context.Background()
+
+	hash := InstanceHash("acdc000000000000000000000000000000000000000000000000000000000001")
+	small := []byte("small inline payload")
+	meta := &CacheMetadata{ContentLength: int64(len(small)), StorageID: StorageIDInline, NamespaceID: NamespaceID(1)}
+	require.NoError(t, storage.StoreInline(ctx, hash, meta, small))
+
+	ci := NewChaosInjector(db, storage)
+	_, err := ci.CorruptBlock("", "", string(hash), 0, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inline")
+}

--- a/local_cache/consistency.go
+++ b/local_cache/consistency.go
@@ -107,6 +107,19 @@ var (
 		Name: "pelican_cache_data_scan_bytes_processed_total",
 		Help: "Total bytes processed during data scans",
 	})
+	// dataScanModeOnce is 1 when the data scan is in "once" mode (verify each
+	// object once then skip), which relies on the underlying storage for
+	// ongoing at-rest integrity.  Exported so a misconfigured cache is visible.
+	dataScanModeOnce = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "pelican_cache_data_scan_mode_once",
+		Help: "1 when the data-integrity scan is in \"once\" mode (Cache.DataScanMode=once); 0 for full re-verification each cycle",
+	})
+	// chaosAPIEnabled is 1 when the destructive chaos/fault-injection admin API
+	// is registered (Cache.EnableChaosAPI).  It should be 0 in production.
+	chaosAPIEnabled = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "pelican_cache_chaos_api_enabled",
+		Help: "1 when the cache chaos/fault-injection admin API is enabled (Cache.EnableChaosAPI); should be 0 in production",
+	})
 )
 
 // ConsistencyChecker verifies cache consistency between database and disk.
@@ -122,6 +135,7 @@ type ConsistencyChecker struct {
 	minAgeForCleanup    time.Duration  // Minimum age before cleanup to avoid races
 	checksumTypes       []ChecksumType // Checksum algorithms to calculate/verify
 	skipVerifiedData    bool           // When true, the data scan verifies each object once then skips it
+	resampleInterval    int            // In skip mode, re-verify ~1/N already-verified objects (0 disables)
 
 	// Statistics
 	stats   ConsistencyStats
@@ -154,6 +168,11 @@ type ConsistencyConfig struct {
 	// guarantee at-rest integrity (e.g. ZFS).  When false (default) every scan
 	// re-verifies all objects.
 	SkipVerifiedData bool
+	// ResampleInterval, when SkipVerifiedData is true, makes the scan still
+	// re-verify roughly 1 in N already-verified objects each cycle, so there is
+	// a nonzero floor of at-rest corruption detection even in "once" mode.
+	// 0 disables re-sampling (pure once).
+	ResampleInterval int
 }
 
 // ConsistencyStats holds statistics from consistency checks
@@ -197,7 +216,7 @@ func NewConsistencyChecker(db *CacheDB, storage *StorageManager, config Consiste
 	metadataScanLastStartTime.Set(now)
 	dataScanLastStartTime.Set(now)
 
-	return &ConsistencyChecker{
+	cc := &ConsistencyChecker{
 		db:                  db,
 		storage:             storage,
 		metadataScanLimiter: limiter,
@@ -205,8 +224,26 @@ func NewConsistencyChecker(db *CacheDB, storage *StorageManager, config Consiste
 		minAgeForCleanup:    config.MinAgeForCleanup,
 		checksumTypes:       checksumTypes,
 		skipVerifiedData:    config.SkipVerifiedData,
+		resampleInterval:    config.ResampleInterval,
 		stopCh:              make(chan struct{}),
 	}
+
+	// Surface the data-scan mode so a misconfigured cache is visible: emit a
+	// loud warning and export a metric when running in "once" mode, which
+	// relies on the underlying storage (e.g. ZFS scrubbing) for ongoing at-rest
+	// integrity rather than re-reading every object.
+	if config.SkipVerifiedData {
+		dataScanModeOnce.Set(1)
+		if config.ResampleInterval > 0 {
+			log.Warnf("Cache data-integrity scan is in \"once\" mode: each object's on-disk data is verified once and then skipped (re-sampling ~1/%d per cycle). This relies on the underlying storage to detect at-rest corruption; ensure it scrubs (e.g. ZFS).", config.ResampleInterval)
+		} else {
+			log.Warn("Cache data-integrity scan is in \"once\" mode with re-sampling disabled: each object's on-disk data is verified once and then never re-checked. This relies entirely on the underlying storage to detect at-rest corruption; ensure it scrubs (e.g. ZFS).")
+		}
+	} else {
+		dataScanModeOnce.Set(0)
+	}
+
+	return cc
 }
 
 // Start begins the background consistency checking goroutines
@@ -1298,8 +1335,13 @@ func (cc *ConsistencyChecker) verifyObjectChecksum(
 
 	// In "verify once" mode, skip objects whose on-disk data has already been
 	// read back and verified.  The expensive read+hash is avoided entirely.
+	// A small fraction (~1/resampleInterval) is still re-verified each cycle so
+	// there is a nonzero floor of at-rest corruption detection rather than zero.
 	if cc.skipVerifiedData && !meta.DataVerified.IsZero() {
-		return errChecksumAlreadyVerified
+		if cc.resampleInterval <= 0 || rand.Intn(cc.resampleInterval) != 0 {
+			return errChecksumAlreadyVerified
+		}
+		// Otherwise fall through and re-verify this object (re-sampled).
 	}
 
 	// If no checksums available, calculate and store them

--- a/local_cache/consistency.go
+++ b/local_cache/consistency.go
@@ -54,6 +54,10 @@ var (
 	errChannelFull         = errors.New("channel_full")
 	errScanDone            = errors.New("scan_done")
 	errChecksumSkipped     = errors.New("checksum_skipped")
+	// errChecksumAlreadyVerified is returned (in "once" data-scan mode) for an
+	// object whose on-disk data has already been verified, so it is skipped
+	// without being re-read.
+	errChecksumAlreadyVerified = errors.New("checksum_already_verified")
 
 	metadataScanInconsistentObjects = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "pelican_cache_metadata_scan_inconsistent_objects_total",
@@ -117,6 +121,7 @@ type ConsistencyChecker struct {
 	dataScanBytesPerSec int64          // Max bytes per second for data scanning
 	minAgeForCleanup    time.Duration  // Minimum age before cleanup to avoid races
 	checksumTypes       []ChecksumType // Checksum algorithms to calculate/verify
+	skipVerifiedData    bool           // When true, the data scan verifies each object once then skips it
 
 	// Statistics
 	stats   ConsistencyStats
@@ -142,6 +147,13 @@ type ConsistencyConfig struct {
 	// ChecksumTypes specifies which checksums to calculate and verify.
 	// When empty, defaults to []ChecksumType{ChecksumSHA256}.
 	ChecksumTypes []ChecksumType
+	// SkipVerifiedData, when true, makes the data scan verify each object's
+	// on-disk data exactly once (recording the checksum and comparing it
+	// against the origin's reported value when available) and then skip that
+	// object on subsequent scans.  Intended for storage backends that already
+	// guarantee at-rest integrity (e.g. ZFS).  When false (default) every scan
+	// re-verifies all objects.
+	SkipVerifiedData bool
 }
 
 // ConsistencyStats holds statistics from consistency checks
@@ -192,6 +204,7 @@ func NewConsistencyChecker(db *CacheDB, storage *StorageManager, config Consiste
 		dataScanBytesPerSec: config.DataScanBytesPerSec,
 		minAgeForCleanup:    config.MinAgeForCleanup,
 		checksumTypes:       checksumTypes,
+		skipVerifiedData:    config.SkipVerifiedData,
 		stopCh:              make(chan struct{}),
 	}
 }
@@ -1235,8 +1248,8 @@ func (cc *ConsistencyChecker) processBatchForDataScan(
 		prevObjects := *objectsVerified
 
 		if err := cc.verifyObjectChecksum(ctx, item.instanceHash, item.meta, bytesLimiter, checksumMismatches, inconsistentBytes, bytesVerified, objectsVerified); err != nil {
-			if errors.Is(err, errChecksumSkipped) {
-				continue // Incomplete object — don't count as verified
+			if errors.Is(err, errChecksumSkipped) || errors.Is(err, errChecksumAlreadyVerified) {
+				continue // Incomplete or already-verified object — don't count as verified
 			}
 			sl.WithError(err).WithField("instanceHash", item.instanceHash).Warn("Error verifying object")
 		}
@@ -1283,11 +1296,18 @@ func (cc *ConsistencyChecker) verifyObjectChecksum(
 		}
 	}
 
+	// In "verify once" mode, skip objects whose on-disk data has already been
+	// read back and verified.  The expensive read+hash is avoided entirely.
+	if cc.skipVerifiedData && !meta.DataVerified.IsZero() {
+		return errChecksumAlreadyVerified
+	}
+
 	// If no checksums available, calculate and store them
 	if len(meta.Checksums) == 0 {
 		if err := cc.calculateAndStoreChecksums(ctx, instanceHash, meta, bytesLimiter); err != nil {
 			return err
 		}
+		cc.markDataVerified(instanceHash)
 		*objectsVerified++
 		return nil
 	}
@@ -1323,8 +1343,23 @@ func (cc *ConsistencyChecker) verifyObjectChecksum(
 	}
 
 	*bytesVerified += verified
+	cc.markDataVerified(instanceHash)
 	*objectsVerified++
 	return nil
+}
+
+// markDataVerified records that an object's on-disk data has just been read
+// back and checksum-verified.  It is only persisted in "verify once" mode,
+// where the recorded timestamp causes subsequent scans to skip the object;
+// in the default mode it is a no-op to avoid a metadata write per object per
+// scan cycle.
+func (cc *ConsistencyChecker) markDataVerified(instanceHash InstanceHash) {
+	if !cc.skipVerifiedData {
+		return
+	}
+	if err := cc.db.MergeMetadata(instanceHash, &CacheMetadata{DataVerified: time.Now()}); err != nil {
+		log.Warnf("Failed to record data-verified timestamp for %s: %v", instanceHash, err)
+	}
 }
 
 // hashObjectData reads all object data through the storage manager and

--- a/local_cache/database.go
+++ b/local_cache/database.go
@@ -417,6 +417,9 @@ func mergeMetadataFields(existing, incoming *CacheMetadata) error {
 	if incoming.Completed.After(existing.Completed) {
 		existing.Completed = incoming.Completed
 	}
+	if incoming.DataVerified.After(existing.DataVerified) {
+		existing.DataVerified = incoming.DataVerified
+	}
 
 	// --- Additive: Checksums ---
 	existing.Checksums = mergeChecksums(existing.Checksums, incoming.Checksums)

--- a/local_cache/monitoring_test.go
+++ b/local_cache/monitoring_test.go
@@ -1,0 +1,117 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package local_cache
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/metrics"
+	"github.com/pelicanplatform/pelican/param"
+)
+
+func drainMonitorChan(ch chan []byte) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
+}
+
+// TestEmitTransferMonitoring verifies that serving a GET emits XRootD-style
+// monitoring packets to the shoveler's internal channel when monitoring is
+// enabled.
+func TestEmitTransferMonitoring(t *testing.T) {
+	require.NoError(t, param.Shoveler_Enable.Set(true))
+	defer func() { require.NoError(t, param.Shoveler_Enable.Set(false)) }()
+
+	ch := metrics.GetInternalMonitorChan()
+	drainMonitorChan(ch)
+
+	pc := &PersistentCache{}
+	req := httptest.NewRequest("GET", "http://cache.example/test/foo.dat", nil)
+	req.Header.Set("User-Agent", "pelican-client/7.0 project/myproj")
+	req.RemoteAddr = "192.0.2.10:54321"
+
+	pc.emitTransferMonitoring(req, "/test/foo.dat", 4096, time.Now().Add(-time.Second), "")
+
+	select {
+	case pkt := <-ch:
+		assert.NotEmpty(t, pkt, "expected a non-empty monitoring packet")
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a monitoring packet to be emitted")
+	}
+}
+
+// TestEmitTransferMonitoring_NoOp verifies no packets are emitted when the
+// shoveler is disabled or when nothing was served.
+func TestEmitTransferMonitoring_NoOp(t *testing.T) {
+	ch := metrics.GetInternalMonitorChan()
+
+	pc := &PersistentCache{}
+	req := httptest.NewRequest("GET", "http://cache.example/test/foo.dat", nil)
+
+	// Shoveler disabled (default): no packets even with bytes served.
+	require.NoError(t, param.Shoveler_Enable.Set(false))
+	drainMonitorChan(ch)
+	pc.emitTransferMonitoring(req, "/test/foo.dat", 4096, time.Now(), "")
+
+	// Shoveler enabled but zero bytes served (e.g. a 304): no packets.
+	require.NoError(t, param.Shoveler_Enable.Set(true))
+	defer func() { require.NoError(t, param.Shoveler_Enable.Set(false)) }()
+	pc.emitTransferMonitoring(req, "/test/foo.dat", 0, time.Now(), "")
+
+	select {
+	case <-ch:
+		t.Fatal("did not expect a monitoring packet")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestCacheClientIP(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		headers    map[string]string
+		expected   string
+	}{
+		{"remote addr", "192.0.2.5:1234", nil, "192.0.2.5"},
+		{"x-forwarded-for single", "10.0.0.1:1", map[string]string{"X-Forwarded-For": "203.0.113.7"}, "203.0.113.7"},
+		{"x-forwarded-for list", "10.0.0.1:1", map[string]string{"X-Forwarded-For": "203.0.113.7, 10.0.0.1"}, "203.0.113.7"},
+		{"x-real-ip", "10.0.0.1:1", map[string]string{"X-Real-IP": "198.51.100.2"}, "198.51.100.2"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "http://cache/test/x", nil)
+			req.RemoteAddr = tc.remoteAddr
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+			assert.Equal(t, tc.expected, cacheClientIP(req))
+		})
+	}
+}

--- a/local_cache/monitoring_udp_test.go
+++ b/local_cache/monitoring_udp_test.go
@@ -1,0 +1,188 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package local_cache
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/metrics"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/pelican_url"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
+)
+
+// TestCacheMonitoringUDPCapture is a full handler-level end-to-end test: it
+// stands up a real persistent cache, serves an HTTP GET through serveObject,
+// runs the real monitoring shoveler forwarding to a UDP collector, and asserts
+// that the XRootD-style monitoring packets are captured off the wire.
+//
+// It deliberately avoids the (slow) e2e_fed_tests federation harness: the cache
+// is built with DeferConfig (no director fetch) against a stub federation, and
+// a public namespace is injected directly so a tokenless GET is served.
+func TestCacheMonitoringUDPCapture(t *testing.T) {
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+	InitIssuerKeyForTests(t) // must follow ResetTestState, which clears the issuer key dir
+
+	ctx, cancel := context.WithCancel(context.Background())
+	egrp, _ := errgroup.WithContext(ctx)
+	t.Cleanup(func() {
+		cancel()
+		_ = egrp.Wait()
+	})
+
+	// Stub federation so NewPersistentCache resolves offline (no discovery).
+	config.SetFederation(pelican_url.FederationDiscovery{
+		DiscoveryEndpoint: "https://cache.example:8443",
+		DirectorEndpoint:  "https://cache.example:8443",
+	})
+
+	// UDP collector that stands in for a monitoring aggregator.
+	collector, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1")})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = collector.Close() })
+	collectorPort := collector.LocalAddr().(*net.UDPAddr).Port
+
+	// Configure and launch the real shoveler, forwarding to our collector.  The
+	// message queue is required by config but we only use the UDP-forwarding
+	// path; the STOMP backend points at an unreachable URL and merely retries in
+	// the background.
+	require.NoError(t, param.Logging_Level.Set("error")) // configShoveler parses this
+	require.NoError(t, param.Shoveler_Enable.Set(true))
+	require.NoError(t, param.Shoveler_MessageQueueProtocol.Set("stomp"))
+	require.NoError(t, param.Shoveler_URL.Set("stomp://127.0.0.1:1"))
+	require.NoError(t, param.Shoveler_OutputDestinations.Set([]string{fmt.Sprintf("127.0.0.1:%d", collectorPort)}))
+	// Let the shoveler's own UDP listener bind an arbitrary free port.
+	require.NoError(t, param.Shoveler_PortLower.Set(0))
+	require.NoError(t, param.Shoveler_PortHigher.Set(1))
+	_, err = metrics.LaunchShoveler(ctx, egrp)
+	require.NoError(t, err)
+
+	// Build a real persistent cache offline.  DeferConfig skips the initial
+	// director namespace fetch; everything else (db, storage, transfer engine,
+	// authorizer) is wired normally.
+	tmpDir := t.TempDir()
+	pc, err := NewPersistentCache(ctx, egrp, PersistentCacheConfig{
+		Mode:        CacheModeServer,
+		BaseDir:     tmpDir,
+		StorageDirs: []StorageDirConfig{{Path: tmpDir}},
+		DeferConfig: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pc.Close() })
+
+	// Inject a public namespace so the tokenless GET authorizes.
+	require.NoError(t, pc.ac.updateConfig([]server_structs.NamespaceAdV2{{
+		Path: "/test",
+		Caps: server_structs.Capabilities{PublicReads: true, Reads: true},
+	}}))
+
+	// Pre-store a cached object under the instance hash that resolveObject will
+	// look up for this path (latest ETag is empty since none is recorded).
+	const objectPath = "/test/hello_world.txt"
+	const etag = "monitoring-test-etag"
+	normalized := pc.normalizePath(objectPath)
+	objectHash := pc.db.ObjectHash(normalized)
+	instanceHash := pc.db.InstanceHash(etag, objectHash)
+	var diskID StorageID
+	for id := range pc.storage.GetDirs() {
+		diskID = id
+	}
+	data := bytes.Repeat([]byte("monitoring-udp-capture-test\n"), 500) // ~14 KiB, multiple blocks
+	storeTestObject(t, ctx, pc.storage, instanceHash, data, diskID, NamespaceID(1))
+	// Register the latest-ETag mapping so resolveObject treats this as a cache
+	// hit (it only loads metadata when a latest ETag is recorded).
+	require.NoError(t, pc.db.SetLatestETag(objectHash, etag, time.Now()))
+
+	// Serve the cache's object handler over real HTTP.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pc.serveObject(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	// Issue the GET that should produce monitoring packets.
+	resp, err := http.Get(srv.URL + objectPath)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "GET failed: %s", string(body))
+	require.Equal(t, data, body, "served body should match the cached object")
+
+	// Capture forwarded datagrams from the collector and decode the raw XRootD
+	// monitoring packets out of the shoveler's JSON envelope.
+	var rawPackets [][]byte
+	deadline := time.Now().Add(5 * time.Second)
+	require.NoError(t, collector.SetReadDeadline(deadline))
+	buf := make([]byte, 65536)
+	sawUser, sawFStream, sawPath := false, false, false
+	for {
+		n, _, rerr := collector.ReadFromUDP(buf)
+		if rerr != nil {
+			break // deadline reached
+		}
+		var env struct {
+			Data string `json:"data"`
+		}
+		if jsonErr := json.Unmarshal(buf[:n], &env); jsonErr != nil {
+			continue
+		}
+		pkt, decErr := base64.StdEncoding.DecodeString(env.Data)
+		if decErr != nil || len(pkt) == 0 {
+			continue
+		}
+		rawPackets = append(rawPackets, pkt)
+		switch pkt[0] {
+		case 'u':
+			sawUser = true
+		case 'f':
+			sawFStream = true
+			if bytes.Contains(pkt, []byte(objectPath)) {
+				sawPath = true
+			}
+		}
+		if sawUser && sawFStream && sawPath {
+			break
+		}
+		require.NoError(t, collector.SetReadDeadline(deadline))
+	}
+
+	require.NotEmpty(t, rawPackets, "expected to capture monitoring packets over UDP")
+	assert.True(t, sawUser, "expected a user-login ('u') packet")
+	assert.True(t, sawFStream, "expected an f-stream ('f') packet")
+	assert.True(t, sawPath, "expected the object path to appear in an f-stream packet")
+}

--- a/local_cache/persistent_cache.go
+++ b/local_cache/persistent_cache.go
@@ -590,6 +590,7 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 	consistency := NewConsistencyChecker(db, storage, ConsistencyConfig{
 		MinAgeForCleanup: -1, // Use default grace period
 		SkipVerifiedData: scanOnce,
+		ResampleInterval: param.Cache_DataScanResampleInterval.GetInt(),
 	})
 
 	// Get federation info

--- a/local_cache/persistent_cache.go
+++ b/local_cache/persistent_cache.go
@@ -349,6 +349,18 @@ const (
 	CacheModeServer
 )
 
+// useEmbeddedCacheMode reports whether the embedded transfer client should
+// run in cache-embedded mode, i.e. route its upstream fetches through the
+// director's origin endpoint and pull directly from origins.
+//
+// In site-local mode (Cache.EnableSiteLocalMode) the cache deliberately does
+// not join the federation and instead appears to it as a client, fetching
+// objects from other caches rather than from origins.  In that case we
+// disable embedded mode so the director redirects us to caches.
+func useEmbeddedCacheMode() bool {
+	return !param.Cache_EnableSiteLocalMode.GetBool()
+}
+
 // PersistentCacheConfig holds configuration for the persistent cache
 type PersistentCacheConfig struct {
 	// Mode selects which configuration namespace to use for defaults.
@@ -1273,7 +1285,7 @@ func (pc *PersistentCache) HeadObject(objectPath, token string) (*HeadResult, er
 
 	opts := []client.TransferOption{
 		client.WithToken(token),
-		client.WithCacheEmbeddedClientMode(),
+		client.WithCacheEmbeddedClientMode(useEmbeddedCacheMode()),
 		client.WithRequestChecksums(client.KnownChecksumTypes()),
 	}
 	if ft := pc.getFedToken(); ft != "" {
@@ -1392,7 +1404,7 @@ func (pc *PersistentCache) stat(objectPath, token string, cachedOnly bool) (uint
 	dUrl.Path = objectPath
 	dUrl.Scheme = "pelican"
 
-	opts := []client.TransferOption{client.WithToken(token), client.WithCacheEmbeddedClientMode()}
+	opts := []client.TransferOption{client.WithToken(token), client.WithCacheEmbeddedClientMode(useEmbeddedCacheMode())}
 	if ft := pc.getFedToken(); ft != "" {
 		opts = append(opts, client.WithFedToken(pc.fedTokenAsProvider()))
 	}
@@ -1451,7 +1463,7 @@ func (pc *PersistentCache) doInitObjectFromStat(
 	}
 	dUrl.Scheme = "pelican"
 
-	opts := []client.TransferOption{client.WithToken(token), client.WithCacheEmbeddedClientMode()}
+	opts := []client.TransferOption{client.WithToken(token), client.WithCacheEmbeddedClientMode(useEmbeddedCacheMode())}
 	if ft := pc.getFedToken(); ft != "" {
 		opts = append(opts, client.WithFedToken(pc.fedTokenAsProvider()))
 	}
@@ -1718,10 +1730,12 @@ func (pc *PersistentCache) performDownload(ctx context.Context, dl *persistentDo
 		return errors.Wrap(err, "invalid source URL")
 	}
 
-	// Route the request through the director's origin endpoint so that the
-	// director redirects us to the origin.  The client's cache mode causes
-	// queryDirector to use the /api/v1.0/director/origin/ prefix, avoiding
-	// the need for the origin to have the DirectReads capability.
+	// By default, route the request through the director's origin endpoint so
+	// that the director redirects us to the origin.  The client's cache mode
+	// (see useEmbeddedCacheMode) causes queryDirector to use the
+	// /api/v1.0/director/origin/ prefix, avoiding the need for the origin to
+	// have the DirectReads capability.  In site-local mode embedded mode is
+	// disabled and the director instead redirects us to other caches.
 	sourceURL.Scheme = "pelican"
 
 	// Pass the user token and federation token as separate options.
@@ -1752,7 +1766,7 @@ func (pc *PersistentCache) performDownload(ctx context.Context, dl *persistentDo
 	}
 
 	// Create per-request transfer client
-	tc, err := pc.te.NewClient(client.WithAcquireToken(false), client.WithCallback(progressCallback), client.WithCacheEmbeddedClientMode())
+	tc, err := pc.te.NewClient(client.WithAcquireToken(false), client.WithCallback(progressCallback), client.WithCacheEmbeddedClientMode(useEmbeddedCacheMode()))
 	if err != nil {
 		return errors.Wrap(err, "failed to create transfer client")
 	}
@@ -1958,7 +1972,7 @@ func (pc *PersistentCache) performDownload(ctx context.Context, dl *persistentDo
 				// size instead of blocking for the entire download.
 				statOpts := []client.TransferOption{
 					client.WithToken(userToken),
-					client.WithCacheEmbeddedClientMode(),
+					client.WithCacheEmbeddedClientMode(useEmbeddedCacheMode()),
 				}
 				if fedTP != nil {
 					statOpts = append(statOpts, client.WithFedToken(fedTP))

--- a/local_cache/persistent_cache.go
+++ b/local_cache/persistent_cache.go
@@ -581,9 +581,15 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 	// Safe: this runs during single-threaded init, before any downloads.
 	storage.chooseDir = eviction.ChooseDiskStorage
 
-	// Initialize consistency checker
+	// Initialize consistency checker.  In "once" data-scan mode the periodic
+	// integrity scan verifies each object's on-disk data a single time and
+	// then skips it, for deployments whose storage already guarantees at-rest
+	// integrity (e.g. ZFS).  Any value other than "once" keeps the default
+	// behaviour of re-verifying every object on each scan cycle.
+	scanOnce := strings.EqualFold(param.Cache_DataScanMode.GetString(), "once")
 	consistency := NewConsistencyChecker(db, storage, ConsistencyConfig{
 		MinAgeForCleanup: -1, // Use default grace period
+		SkipVerifiedData: scanOnce,
 	})
 
 	// Get federation info

--- a/local_cache/persistent_cache.go
+++ b/local_cache/persistent_cache.go
@@ -627,7 +627,20 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 		return nil, errors.Wrap(err, "failed to initialize client")
 	}
 
-	te, err := client.NewTransferEngine(ctx)
+	// The cache server serves many clients concurrently, so it needs far more
+	// transfer workers than the command-line client's small default
+	// (Client.WorkerCount).  Use Cache.WorkerCount for the server; the
+	// client-side local cache keeps the client default.
+	var te *client.TransferEngine
+	if cfg.Mode == CacheModeServer {
+		workers := param.Cache_WorkerCount.GetInt()
+		if workers <= 0 {
+			workers = 100
+		}
+		te, err = client.NewTransferEngineWithWorkers(ctx, workers)
+	} else {
+		te, err = client.NewTransferEngine(ctx)
+	}
 	if err != nil {
 		db.Close()
 		return nil, errors.Wrap(err, "failed to create transfer engine")

--- a/local_cache/persistent_cache_api.go
+++ b/local_cache/persistent_cache_api.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -1792,21 +1791,29 @@ func (pc *PersistentCache) introspectChaosHandler(c *gin.Context) {
 		return
 	}
 
-	// atoiQuery parses a query parameter as an integer and enforces an explicit
-	// [min, max] range, so the value can be safely narrowed below.
-	atoiQuery := func(name string, def, min, max int64) (int64, error) {
+	// Parsing helpers that bound each value to its target type's width via the
+	// bitSize argument, so the subsequent narrowing conversion is provably safe.
+	parseU32 := func(name string, def uint32) (uint32, error) {
 		v := c.Query(name)
 		if v == "" {
 			return def, nil
 		}
-		n, perr := strconv.ParseInt(v, 10, 64)
+		n, perr := strconv.ParseUint(v, 10, 32)
 		if perr != nil {
-			return 0, perr
+			return 0, errors.Errorf("invalid %s parameter", name)
 		}
-		if n < min || n > max {
-			return 0, errors.Errorf("%s=%d is out of range [%d, %d]", name, n, min, max)
+		return uint32(n), nil
+	}
+	parseI32 := func(name string, def int32) (int32, error) {
+		v := c.Query(name)
+		if v == "" {
+			return def, nil
 		}
-		return n, nil
+		n, perr := strconv.ParseInt(v, 10, 32)
+		if perr != nil {
+			return 0, errors.Errorf("invalid %s parameter", name)
+		}
+		return int32(n), nil
 	}
 
 	injector := NewChaosInjector(pc.db, pc.storage)
@@ -1815,25 +1822,29 @@ func (pc *PersistentCache) introspectChaosHandler(c *gin.Context) {
 	var err error
 	switch op {
 	case "corrupt":
-		var block, nbytes int64
-		if block, err = atoiQuery("block", 0, 0, math.MaxUint32); err != nil {
+		var block uint32
+		var nbytes int32
+		if block, err = parseU32("block", 0); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
-		if nbytes, err = atoiQuery("bytes", 0, 0, BlockTotalSize); err != nil {
+		if nbytes, err = parseI32("bytes", 0); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
-		result, err = injector.CorruptBlock(objectURL, etag, instance, uint32(block), int(nbytes))
+		result, err = injector.CorruptBlock(objectURL, etag, instance, block, int(nbytes))
 	case "truncate":
-		var chunk, drop int64
-		if chunk, err = atoiQuery("chunk", -1, -1, math.MaxInt32); err != nil {
+		var chunk int32
+		if chunk, err = parseI32("chunk", -1); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
-		if drop, err = atoiQuery("drop-bytes", 0, 0, math.MaxInt64); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-			return
+		var drop int64
+		if v := c.Query("drop-bytes"); v != "" {
+			if drop, err = strconv.ParseInt(v, 10, 64); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid drop-bytes parameter"})
+				return
+			}
 		}
 		result, err = injector.TruncateObject(objectURL, etag, instance, int(chunk), drop)
 	default:

--- a/local_cache/persistent_cache_api.go
+++ b/local_cache/persistent_cache_api.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -1506,7 +1507,10 @@ func (pc *PersistentCache) RegisterCacheHandlers(engine *gin.Engine, directorEna
 	// cached data.  It is admin-authenticated like the rest of introspect.
 	if param.Cache_EnableChaosAPI.GetBool() {
 		adminIntrospect.POST("/chaos", pc.introspectChaosHandler)
+		chaosAPIEnabled.Set(1)
 		log.Warn("Cache chaos/fault-injection API is ENABLED at /api/v1.0/cache/introspect/chaos (Cache.EnableChaosAPI); this can corrupt cached data and should only be used for testing")
+	} else {
+		chaosAPIEnabled.Set(0)
 	}
 
 	return nil
@@ -1788,12 +1792,21 @@ func (pc *PersistentCache) introspectChaosHandler(c *gin.Context) {
 		return
 	}
 
-	atoiQuery := func(name string, def int64) (int64, error) {
+	// atoiQuery parses a query parameter as an integer and enforces an explicit
+	// [min, max] range, so the value can be safely narrowed below.
+	atoiQuery := func(name string, def, min, max int64) (int64, error) {
 		v := c.Query(name)
 		if v == "" {
 			return def, nil
 		}
-		return strconv.ParseInt(v, 10, 64)
+		n, perr := strconv.ParseInt(v, 10, 64)
+		if perr != nil {
+			return 0, perr
+		}
+		if n < min || n > max {
+			return 0, errors.Errorf("%s=%d is out of range [%d, %d]", name, n, min, max)
+		}
+		return n, nil
 	}
 
 	injector := NewChaosInjector(pc.db, pc.storage)
@@ -1803,23 +1816,23 @@ func (pc *PersistentCache) introspectChaosHandler(c *gin.Context) {
 	switch op {
 	case "corrupt":
 		var block, nbytes int64
-		if block, err = atoiQuery("block", 0); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid block parameter"})
+		if block, err = atoiQuery("block", 0, 0, math.MaxUint32); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
-		if nbytes, err = atoiQuery("bytes", 0); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid bytes parameter"})
+		if nbytes, err = atoiQuery("bytes", 0, 0, BlockTotalSize); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
 		result, err = injector.CorruptBlock(objectURL, etag, instance, uint32(block), int(nbytes))
 	case "truncate":
 		var chunk, drop int64
-		if chunk, err = atoiQuery("chunk", -1); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid chunk parameter"})
+		if chunk, err = atoiQuery("chunk", -1, -1, math.MaxInt32); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
-		if drop, err = atoiQuery("drop-bytes", 0); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid drop-bytes parameter"})
+		if drop, err = atoiQuery("drop-bytes", 0, 0, math.MaxInt64); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
 		result, err = injector.TruncateObject(objectURL, etag, instance, int(chunk), drop)

--- a/local_cache/persistent_cache_api.go
+++ b/local_cache/persistent_cache_api.go
@@ -1441,6 +1441,14 @@ func (pc *PersistentCache) RegisterCacheHandlers(engine *gin.Engine, directorEna
 	adminIntrospect.POST("/consistency", pc.introspectConsistencyHandler)
 	log.Info("Cache introspection API registered at /api/v1.0/cache/introspect/")
 
+	// Register the destructive chaos/fault-injection endpoint only when
+	// explicitly enabled (Cache.EnableChaosAPI), since it deliberately corrupts
+	// cached data.  It is admin-authenticated like the rest of introspect.
+	if param.Cache_EnableChaosAPI.GetBool() {
+		adminIntrospect.POST("/chaos", pc.introspectChaosHandler)
+		log.Warn("Cache chaos/fault-injection API is ENABLED at /api/v1.0/cache/introspect/chaos (Cache.EnableChaosAPI); this can corrupt cached data and should only be used for testing")
+	}
+
 	return nil
 }
 
@@ -1698,6 +1706,72 @@ func (pc *PersistentCache) introspectVerifyHandler(c *gin.Context) {
 		}
 	}
 
+	c.JSON(http.StatusOK, result)
+}
+
+// introspectChaosHandler injects corruption into a cached object for
+// fault-injection testing.  It is only registered when Cache.EnableChaosAPI is
+// true and is admin-authenticated.
+//
+// POST /api/v1.0/cache/introspect/chaos?op=corrupt|truncate&url=...&etag=...&instance=...
+//
+//	corrupt:  &block=<n>&bytes=<n>
+//	truncate: &chunk=<n>&drop-bytes=<n>
+func (pc *PersistentCache) introspectChaosHandler(c *gin.Context) {
+	op := c.Query("op")
+	objectURL := c.Query("url")
+	etag := c.Query("etag")
+	instance := c.Query("instance")
+
+	if objectURL == "" && instance == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "url or instance query parameter is required"})
+		return
+	}
+
+	atoiQuery := func(name string, def int64) (int64, error) {
+		v := c.Query(name)
+		if v == "" {
+			return def, nil
+		}
+		return strconv.ParseInt(v, 10, 64)
+	}
+
+	injector := NewChaosInjector(pc.db, pc.storage)
+
+	var result *ChaosResult
+	var err error
+	switch op {
+	case "corrupt":
+		var block, nbytes int64
+		if block, err = atoiQuery("block", 0); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid block parameter"})
+			return
+		}
+		if nbytes, err = atoiQuery("bytes", 0); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid bytes parameter"})
+			return
+		}
+		result, err = injector.CorruptBlock(objectURL, etag, instance, uint32(block), int(nbytes))
+	case "truncate":
+		var chunk, drop int64
+		if chunk, err = atoiQuery("chunk", -1); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid chunk parameter"})
+			return
+		}
+		if drop, err = atoiQuery("drop-bytes", 0); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid drop-bytes parameter"})
+			return
+		}
+		result, err = injector.TruncateObject(objectURL, etag, instance, int(chunk), drop)
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"error": "op must be 'corrupt' or 'truncate'"})
+		return
+	}
+
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 	c.JSON(http.StatusOK, result)
 }
 

--- a/local_cache/persistent_cache_api.go
+++ b/local_cache/persistent_cache_api.go
@@ -45,10 +45,12 @@ import (
 	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/error_codes"
+	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
+	"github.com/pelicanplatform/pelican/utils"
 	"github.com/pelicanplatform/pelican/web_ui"
 )
 
@@ -123,8 +125,9 @@ func isConnectionError(err error) bool {
 // chunked transfer-encoding, which is required for HTTP/1.1 trailers.
 type trailerWriter struct {
 	http.ResponseWriter
-	writeErr    *error
-	sendTrailer bool
+	writeErr     *error
+	sendTrailer  bool
+	bytesWritten int64
 }
 
 func (tw *trailerWriter) Header() http.Header {
@@ -142,6 +145,7 @@ func (tw *trailerWriter) WriteHeader(code int) {
 
 func (tw *trailerWriter) Write(p []byte) (int, error) {
 	n, err := tw.ResponseWriter.Write(p)
+	tw.bytesWritten += int64(n)
 	if err != nil && *tw.writeErr == nil {
 		*tw.writeErr = err
 	}
@@ -539,7 +543,8 @@ func (pc *PersistentCache) serveObject(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 
 		var writeErr error
-		if _, err := io.Copy(w, reader); err != nil {
+		nServed, err := io.Copy(w, reader)
+		if err != nil {
 			writeErr = err
 		}
 		if sendTrailer {
@@ -549,6 +554,7 @@ func (pc *PersistentCache) serveObject(w http.ResponseWriter, r *http.Request) {
 			}
 			w.Header().Set("X-Transfer-Status", trailerVal)
 		}
+		pc.emitTransferMonitoring(r, objectPath, nServed, startTime, bearerToken)
 		reqLog.WithFields(log.Fields{
 			"status":   200,
 			"cache":    "pass-through",
@@ -616,10 +622,64 @@ func (pc *PersistentCache) serveObject(w http.ResponseWriter, r *http.Request) {
 	if meta != nil && !meta.Completed.IsZero() && meta.Completed.Before(startTime) {
 		cacheStatus = "hit"
 	}
+	pc.emitTransferMonitoring(r, objectPath, wrappedWriter.bytesWritten, startTime, bearerToken)
 	reqLog.WithFields(log.Fields{
 		"cache":    cacheStatus,
 		"duration": time.Since(startTime).Round(time.Millisecond).String(),
 	}).Info("Request complete")
+}
+
+// emitTransferMonitoring emits an XRootD-style monitoring record for a served
+// GET, mirroring what the POSIXv2 origin emits.  It is a no-op when the
+// monitoring shoveler is disabled or when no bytes were served (e.g. a 304).
+// The packets flow to the shoveler's internal channel and on to the configured
+// monitoring collectors.
+func (pc *PersistentCache) emitTransferMonitoring(r *http.Request, objectPath string, bytesServed int64, start time.Time, bearerToken string) {
+	if bytesServed <= 0 || !param.Shoveler_Enable.GetBool() {
+		return
+	}
+
+	event := metrics.TransferEvent{
+		Path:         objectPath,
+		ReadBytes:    bytesServed,
+		ReadOps:      1,
+		ClientIP:     cacheClientIP(r),
+		AuthProtocol: "https",
+		UserAgent:    r.UserAgent(),
+		Project:      utils.ExtractProjectFromUserAgent(r.Header.Values("User-Agent")),
+		StartTime:    start,
+		EndTime:      time.Now(),
+	}
+
+	// Best-effort user attribution from the (already-authorized) token.  The
+	// token signature is not re-verified here; it is used only for monitoring.
+	if bearerToken != "" {
+		if tok, err := token.UnsafeParseClaims(bearerToken); err == nil {
+			event.UserDN = tok.Subject()
+			event.Issuer = tok.Issuer()
+		}
+	}
+
+	metrics.EmitTransferEvent(event)
+}
+
+// cacheClientIP extracts the client IP from a request, preferring the
+// X-Forwarded-For / X-Real-IP headers set by a fronting proxy and falling back
+// to the connection's remote address.
+func cacheClientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if idx := strings.IndexByte(xff, ','); idx >= 0 {
+			return strings.TrimSpace(xff[:idx])
+		}
+		return strings.TrimSpace(xff)
+	}
+	if xrip := r.Header.Get("X-Real-IP"); xrip != "" {
+		return strings.TrimSpace(xrip)
+	}
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
 }
 
 // servePropfindFromCache synthesizes a WebDAV multistatus response from

--- a/local_cache/persistent_cache_test.go
+++ b/local_cache/persistent_cache_test.go
@@ -1917,6 +1917,55 @@ func TestDataScan_SkipVerifiedData(t *testing.T) {
 	assert.Equal(t, firstVerified, meta.DataVerified, "DataVerified should not change on a skipped scan")
 }
 
+// TestDataScan_SkipVerifiedResample confirms that "once" mode still re-verifies
+// already-checked objects when ResampleInterval is set, providing a floor of
+// at-rest corruption detection rather than zero.  With ResampleInterval=1 every
+// already-verified object is re-checked, so a second scan re-verifies it.
+func TestDataScan_SkipVerifiedResample(t *testing.T) {
+	InitIssuerKeyForTests(t)
+	tmpDir := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	db, err := NewCacheDB(ctx, tmpDir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	egrp, _ := errgroup.WithContext(ctx)
+	storage, err := NewStorageManager(db, []string{tmpDir}, 0, egrp)
+	require.NoError(t, err)
+	defer storage.Close()
+
+	var diskID StorageID
+	for id := range storage.GetDirs() {
+		diskID = id
+	}
+
+	data := make([]byte, BlockDataSize+500)
+	for i := range data {
+		data[i] = byte(i % 211)
+	}
+	hash := InstanceHash("eded000000000000000000000000000000000000000000000000000000000001")
+	storeTestObject(t, ctx, storage, hash, data, diskID, NamespaceID(1))
+
+	checker := NewConsistencyChecker(db, storage, ConsistencyConfig{
+		MetadataScanActiveMs: 1000,
+		DataScanBytesPerSec:  1 << 30,
+		MinAgeForCleanup:     0,
+		ChecksumTypes:        []ChecksumType{ChecksumSHA256},
+		SkipVerifiedData:     true,
+		ResampleInterval:     1, // re-verify every already-checked object
+	})
+
+	require.NoError(t, checker.RunDataScan(ctx, nil))
+	require.NoError(t, checker.RunDataScan(ctx, nil))
+	// With ResampleInterval=1 the object is re-verified on both scans rather
+	// than being permanently skipped after the first.
+	assert.Equal(t, int64(2), checker.GetStats().ObjectsVerified,
+		"ResampleInterval=1 should re-verify the object every cycle")
+}
+
 // TestDataScan_AllModeReverifies confirms that the default (non-skip) mode
 // re-verifies an object on every scan, in contrast to SkipVerifiedData.
 func TestDataScan_AllModeReverifies(t *testing.T) {

--- a/local_cache/persistent_cache_test.go
+++ b/local_cache/persistent_cache_test.go
@@ -1856,6 +1856,115 @@ func TestDataScan_MissingChecksum(t *testing.T) {
 		"stored checksum should match SHA-256 of original data")
 }
 
+// TestDataScan_SkipVerifiedData verifies the "verify once" data-scan mode
+// (SkipVerifiedData): the first scan reads back and checksums the object,
+// records a DataVerified timestamp, and counts it as verified; subsequent
+// scans skip the already-verified object instead of re-reading it.
+func TestDataScan_SkipVerifiedData(t *testing.T) {
+	InitIssuerKeyForTests(t)
+	tmpDir := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	db, err := NewCacheDB(ctx, tmpDir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	egrp, _ := errgroup.WithContext(ctx)
+	storage, err := NewStorageManager(db, []string{tmpDir}, 0, egrp)
+	require.NoError(t, err)
+	defer storage.Close()
+
+	var diskID StorageID
+	for id := range storage.GetDirs() {
+		diskID = id
+	}
+
+	data := make([]byte, BlockDataSize+500)
+	for i := range data {
+		data[i] = byte(i % 211)
+	}
+	hash := InstanceHash("dddd000000000000000000000000000000000000000000000000000000000001")
+	storeTestObject(t, ctx, storage, hash, data, diskID, NamespaceID(1))
+
+	checker := NewConsistencyChecker(db, storage, ConsistencyConfig{
+		MetadataScanActiveMs: 1000,
+		DataScanBytesPerSec:  1 << 30,
+		MinAgeForCleanup:     0,
+		ChecksumTypes:        []ChecksumType{ChecksumSHA256},
+		SkipVerifiedData:     true,
+	})
+
+	// First scan: the object has no checksum, so it is read back, checksummed,
+	// marked verified, and counted.
+	require.NoError(t, checker.RunDataScan(ctx, nil))
+	assert.Equal(t, int64(1), checker.GetStats().ObjectsVerified, "first scan should verify the object once")
+
+	meta, err := storage.GetMetadata(hash)
+	require.NoError(t, err)
+	require.Len(t, meta.Checksums, 1, "first scan should record a checksum")
+	require.False(t, meta.DataVerified.IsZero(), "first scan should record a DataVerified timestamp")
+	firstVerified := meta.DataVerified
+
+	// Second scan: the object is already verified, so it must be skipped — the
+	// verified counter does not advance and DataVerified is unchanged.
+	require.NoError(t, checker.RunDataScan(ctx, nil))
+	assert.Equal(t, int64(1), checker.GetStats().ObjectsVerified, "second scan should skip the already-verified object")
+
+	meta, err = storage.GetMetadata(hash)
+	require.NoError(t, err)
+	assert.Equal(t, firstVerified, meta.DataVerified, "DataVerified should not change on a skipped scan")
+}
+
+// TestDataScan_AllModeReverifies confirms that the default (non-skip) mode
+// re-verifies an object on every scan, in contrast to SkipVerifiedData.
+func TestDataScan_AllModeReverifies(t *testing.T) {
+	InitIssuerKeyForTests(t)
+	tmpDir := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	db, err := NewCacheDB(ctx, tmpDir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	egrp, _ := errgroup.WithContext(ctx)
+	storage, err := NewStorageManager(db, []string{tmpDir}, 0, egrp)
+	require.NoError(t, err)
+	defer storage.Close()
+
+	var diskID StorageID
+	for id := range storage.GetDirs() {
+		diskID = id
+	}
+
+	data := make([]byte, BlockDataSize+500)
+	for i := range data {
+		data[i] = byte(i % 211)
+	}
+	hash := InstanceHash("cccc000000000000000000000000000000000000000000000000000000000001")
+	storeTestObject(t, ctx, storage, hash, data, diskID, NamespaceID(1))
+
+	checker := NewConsistencyChecker(db, storage, ConsistencyConfig{
+		MetadataScanActiveMs: 1000,
+		DataScanBytesPerSec:  1 << 30,
+		MinAgeForCleanup:     0,
+		ChecksumTypes:        []ChecksumType{ChecksumSHA256},
+		// SkipVerifiedData defaults to false ("all" mode).
+	})
+
+	require.NoError(t, checker.RunDataScan(ctx, nil))
+	require.NoError(t, checker.RunDataScan(ctx, nil))
+	assert.Equal(t, int64(2), checker.GetStats().ObjectsVerified, "all mode should re-verify on every scan")
+
+	// In all mode the DataVerified timestamp is never recorded.
+	meta, err := storage.GetMetadata(hash)
+	require.NoError(t, err)
+	assert.True(t, meta.DataVerified.IsZero(), "all mode should not record DataVerified")
+}
+
 // TestMultiDirStoragePlacement verifies that multi-directory storage works
 // end-to-end: objects land in different directories, per-directory size stats
 // are correct, and storage IDs are persisted in metadata.

--- a/local_cache/schema.go
+++ b/local_cache/schema.go
@@ -322,7 +322,8 @@ type Checksum struct {
 // are reconciled:
 //
 //   - Max-time: LastModified, LastValidated, LastAccessTime, Expires,
-//     Completed — only advance forward (keep the later timestamp).
+//     Completed, DataVerified — only advance forward (keep the later
+//     timestamp).
 //   - Additive: Checksums — union by algorithm; prefer OriginVerified.
 //   - Last-writer-wins: ContentType, ContentLength, VaryHeaders,
 //     CCFlags, CCMaxAge — the incoming value always replaces the old one.
@@ -341,6 +342,7 @@ type CacheMetadata struct {
 	LastValidated time.Time  `msgpack:"lv"`           // When we last validated with origin
 	Completed     time.Time  `msgpack:"c"`            // When download was completed
 	Checksums     []Checksum `msgpack:"ck,omitempty"` // Object checksums
+	DataVerified  time.Time  `msgpack:"dv,omitempty"` // When the on-disk data was last read back and checksum-verified
 
 	// Identification fields
 	ContentType   string   `msgpack:"ct"`            // MIME type

--- a/origin/broker_client.go
+++ b/origin/broker_client.go
@@ -178,7 +178,12 @@ func LaunchBrokerListener(ctx context.Context, egrp *errgroup.Group, engine *gin
 				// the test harness, leaving us blind when the tunnel's TLS
 				// handshake silently times out (a challenge during TestBrokerApi
 				// flakiness).
-				srvLogger := stdlog.New(log.StandardLogger().WriterLevel(log.WarnLevel), "broker-server: ", 0)
+				// WriterLevel starts a background scanner goroutine backed by an
+				// os.Pipe; keep a handle so it is closed when this one-shot
+				// connection finishes, otherwise every broker connection leaks
+				// the goroutine and the pipe's file descriptors.
+				brokerWarnWriter := log.StandardLogger().WriterLevel(log.WarnLevel)
+				srvLogger := stdlog.New(brokerWarnWriter, "broker-server: ", 0)
 				srv := http.Server{
 					Handler:           http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) { proxyOrigin(resp, req, engine) }),
 					ErrorLog:          srvLogger,
@@ -189,6 +194,7 @@ func LaunchBrokerListener(ctx context.Context, egrp *errgroup.Group, engine *gin
 				// race on a shared named return; the data race detector
 				// flagged this in TestBrokerApi.
 				go func(fields log.Fields) {
+					defer brokerWarnWriter.Close()
 					// A one-shot listener should do a single "accept" then shutdown.
 					log.WithFields(fields).Debug("Origin starting to serve broker reverse connection")
 					serveErr := srv.Serve(listener)

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -105,6 +105,7 @@ var runtimeConfigurableMap = map[string]bool{
 	"Cache.DataLocation": false,
 	"Cache.DataLocations": false,
 	"Cache.DataScanMode": false,
+	"Cache.DataScanResampleInterval": false,
 	"Cache.DbLocation": false,
 	"Cache.DefaultCacheTimeout": false,
 	"Cache.DirectorTest": false,
@@ -859,6 +860,7 @@ var intAccessors = map[string]func(*Config) int{
 	"Cache.BlocksToPrefetch": func(c *Config) int { return c.Cache.BlocksToPrefetch },
 	"Cache.Concurrency": func(c *Config) int { return c.Cache.Concurrency },
 	"Cache.ConcurrencyDegradedThreshold": func(c *Config) int { return c.Cache.ConcurrencyDegradedThreshold },
+	"Cache.DataScanResampleInterval": func(c *Config) int { return c.Cache.DataScanResampleInterval },
 	"Cache.EvictionMonitoringMaxDepth": func(c *Config) int { return c.Cache.EvictionMonitoringMaxDepth },
 	"Cache.Port": func(c *Config) int { return c.Cache.Port },
 	"ClientAgent.HistoryRetentionDays": func(c *Config) int { return c.ClientAgent.HistoryRetentionDays },
@@ -1266,6 +1268,7 @@ var allParameterNames = []string{
 	"Cache.DataLocation",
 	"Cache.DataLocations",
 	"Cache.DataScanMode",
+	"Cache.DataScanResampleInterval",
 	"Cache.DbLocation",
 	"Cache.DefaultCacheTimeout",
 	"Cache.DirectorTest",
@@ -1937,6 +1940,7 @@ var (
 	Cache_BlocksToPrefetch = IntParam{"Cache.BlocksToPrefetch"}
 	Cache_Concurrency = IntParam{"Cache.Concurrency"}
 	Cache_ConcurrencyDegradedThreshold = IntParam{"Cache.ConcurrencyDegradedThreshold"}
+	Cache_DataScanResampleInterval = IntParam{"Cache.DataScanResampleInterval"}
 	Cache_EvictionMonitoringMaxDepth = IntParam{"Cache.EvictionMonitoringMaxDepth"}
 	Cache_Port = IntParam{"Cache.Port"}
 	ClientAgent_HistoryRetentionDays = IntParam{"ClientAgent.HistoryRetentionDays"}
@@ -2410,6 +2414,7 @@ func init() {
 		"Cache.BlocksToPrefetch": Cache_BlocksToPrefetch,
 		"Cache.Concurrency": Cache_Concurrency,
 		"Cache.ConcurrencyDegradedThreshold": Cache_ConcurrencyDegradedThreshold,
+		"Cache.DataScanResampleInterval": Cache_DataScanResampleInterval,
 		"Cache.EvictionMonitoringMaxDepth": Cache_EvictionMonitoringMaxDepth,
 		"Cache.Port": Cache_Port,
 		"ClientAgent.HistoryRetentionDays": ClientAgent_HistoryRetentionDays,

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -105,6 +105,7 @@ var runtimeConfigurableMap = map[string]bool{
 	"Cache.DataLocation": false,
 	"Cache.DataLocations": false,
 	"Cache.DataScanMode": false,
+	"Cache.DataScanResampleInterval": false,
 	"Cache.DbLocation": false,
 	"Cache.DefaultCacheTimeout": false,
 	"Cache.DirectorTest": false,
@@ -837,6 +838,7 @@ var intAccessors = map[string]func(*Config) int{
 	"Cache.BlocksToPrefetch": func(c *Config) int { return c.Cache.BlocksToPrefetch },
 	"Cache.Concurrency": func(c *Config) int { return c.Cache.Concurrency },
 	"Cache.ConcurrencyDegradedThreshold": func(c *Config) int { return c.Cache.ConcurrencyDegradedThreshold },
+	"Cache.DataScanResampleInterval": func(c *Config) int { return c.Cache.DataScanResampleInterval },
 	"Cache.EvictionMonitoringMaxDepth": func(c *Config) int { return c.Cache.EvictionMonitoringMaxDepth },
 	"Cache.Port": func(c *Config) int { return c.Cache.Port },
 	"ClientAgent.HistoryRetentionDays": func(c *Config) int { return c.ClientAgent.HistoryRetentionDays },
@@ -1240,6 +1242,7 @@ var allParameterNames = []string{
 	"Cache.DataLocation",
 	"Cache.DataLocations",
 	"Cache.DataScanMode",
+	"Cache.DataScanResampleInterval",
 	"Cache.DbLocation",
 	"Cache.DefaultCacheTimeout",
 	"Cache.DirectorTest",
@@ -1889,6 +1892,7 @@ var (
 	Cache_BlocksToPrefetch = IntParam{"Cache.BlocksToPrefetch"}
 	Cache_Concurrency = IntParam{"Cache.Concurrency"}
 	Cache_ConcurrencyDegradedThreshold = IntParam{"Cache.ConcurrencyDegradedThreshold"}
+	Cache_DataScanResampleInterval = IntParam{"Cache.DataScanResampleInterval"}
 	Cache_EvictionMonitoringMaxDepth = IntParam{"Cache.EvictionMonitoringMaxDepth"}
 	Cache_Port = IntParam{"Cache.Port"}
 	ClientAgent_HistoryRetentionDays = IntParam{"ClientAgent.HistoryRetentionDays"}
@@ -2349,6 +2353,7 @@ func init() {
 		"Cache.BlocksToPrefetch": Cache_BlocksToPrefetch,
 		"Cache.Concurrency": Cache_Concurrency,
 		"Cache.ConcurrencyDegradedThreshold": Cache_ConcurrencyDegradedThreshold,
+		"Cache.DataScanResampleInterval": Cache_DataScanResampleInterval,
 		"Cache.EvictionMonitoringMaxDepth": Cache_EvictionMonitoringMaxDepth,
 		"Cache.Port": Cache_Port,
 		"ClientAgent.HistoryRetentionDays": ClientAgent_HistoryRetentionDays,

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -104,6 +104,7 @@ var runtimeConfigurableMap = map[string]bool{
 	"Cache.ConcurrencyDegradedThreshold": false,
 	"Cache.DataLocation": false,
 	"Cache.DataLocations": false,
+	"Cache.DataScanMode": false,
 	"Cache.DbLocation": false,
 	"Cache.DefaultCacheTimeout": false,
 	"Cache.DirectorTest": false,
@@ -559,6 +560,7 @@ func paramNameToEnvVar(paramName string) string {
 var stringAccessors = map[string]func(*Config) string{
 	"Cache.ClientStatisticsLocation": func(c *Config) string { return c.Cache.ClientStatisticsLocation },
 	"Cache.DataLocation": func(c *Config) string { return c.Cache.DataLocation },
+	"Cache.DataScanMode": func(c *Config) string { return c.Cache.DataScanMode },
 	"Cache.DbLocation": func(c *Config) string { return c.Cache.DbLocation },
 	"Cache.ExportLocation": func(c *Config) string { return c.Cache.ExportLocation },
 	"Cache.FedTokenLocation": func(c *Config) string { return c.Cache.FedTokenLocation },
@@ -1235,6 +1237,7 @@ var allParameterNames = []string{
 	"Cache.ConcurrencyDegradedThreshold",
 	"Cache.DataLocation",
 	"Cache.DataLocations",
+	"Cache.DataScanMode",
 	"Cache.DbLocation",
 	"Cache.DefaultCacheTimeout",
 	"Cache.DirectorTest",
@@ -1663,6 +1666,7 @@ var allParameterNames = []string{
 var (
 	Cache_ClientStatisticsLocation = StringParam{"Cache.ClientStatisticsLocation"}
 	Cache_DataLocation = StringParam{"Cache.DataLocation"}
+	Cache_DataScanMode = StringParam{"Cache.DataScanMode"}
 	Cache_DbLocation = StringParam{"Cache.DbLocation"}
 	Cache_ExportLocation = StringParam{"Cache.ExportLocation"}
 	Cache_FedTokenLocation = StringParam{"Cache.FedTokenLocation"}
@@ -2127,6 +2131,7 @@ func init() {
 	paramByName = map[string]Param{
 		"Cache.ClientStatisticsLocation": Cache_ClientStatisticsLocation,
 		"Cache.DataLocation": Cache_DataLocation,
+		"Cache.DataScanMode": Cache_DataScanMode,
 		"Cache.DbLocation": Cache_DbLocation,
 		"Cache.ExportLocation": Cache_ExportLocation,
 		"Cache.FedTokenLocation": Cache_FedTokenLocation,

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -110,6 +110,7 @@ var runtimeConfigurableMap = map[string]bool{
 	"Cache.DirectorTest": false,
 	"Cache.DisableClientX509": false,
 	"Cache.EnableBroker": false,
+	"Cache.EnableChaosAPI": false,
 	"Cache.EnableEvictionMonitoring": false,
 	"Cache.EnableLotman": false,
 	"Cache.EnableOIDC": false,
@@ -960,6 +961,7 @@ var boolAccessors = map[string]func(*Config) bool{
 	"Cache.DirectorTest": func(c *Config) bool { return c.Cache.DirectorTest },
 	"Cache.DisableClientX509": func(c *Config) bool { return c.Cache.DisableClientX509 },
 	"Cache.EnableBroker": func(c *Config) bool { return c.Cache.EnableBroker },
+	"Cache.EnableChaosAPI": func(c *Config) bool { return c.Cache.EnableChaosAPI },
 	"Cache.EnableEvictionMonitoring": func(c *Config) bool { return c.Cache.EnableEvictionMonitoring },
 	"Cache.EnableLotman": func(c *Config) bool { return c.Cache.EnableLotman },
 	"Cache.EnableOIDC": func(c *Config) bool { return c.Cache.EnableOIDC },
@@ -1243,6 +1245,7 @@ var allParameterNames = []string{
 	"Cache.DirectorTest",
 	"Cache.DisableClientX509",
 	"Cache.EnableBroker",
+	"Cache.EnableChaosAPI",
 	"Cache.EnableEvictionMonitoring",
 	"Cache.EnableLotman",
 	"Cache.EnableOIDC",
@@ -1945,6 +1948,7 @@ var (
 	Cache_DirectorTest = BoolParam{"Cache.DirectorTest"}
 	Cache_DisableClientX509 = BoolParam{"Cache.DisableClientX509"}
 	Cache_EnableBroker = BoolParam{"Cache.EnableBroker"}
+	Cache_EnableChaosAPI = BoolParam{"Cache.EnableChaosAPI"}
 	Cache_EnableEvictionMonitoring = BoolParam{"Cache.EnableEvictionMonitoring"}
 	Cache_EnableLotman = BoolParam{"Cache.EnableLotman"}
 	Cache_EnableOIDC = BoolParam{"Cache.EnableOIDC"}
@@ -2398,6 +2402,7 @@ func init() {
 		"Cache.DirectorTest": Cache_DirectorTest,
 		"Cache.DisableClientX509": Cache_DisableClientX509,
 		"Cache.EnableBroker": Cache_EnableBroker,
+		"Cache.EnableChaosAPI": Cache_EnableChaosAPI,
 		"Cache.EnableEvictionMonitoring": Cache_EnableEvictionMonitoring,
 		"Cache.EnableLotman": Cache_EnableLotman,
 		"Cache.EnableOIDC": Cache_EnableOIDC,

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -144,6 +144,7 @@ var runtimeConfigurableMap = map[string]bool{
 	"Cache.SentinelLocation": false,
 	"Cache.StorageLocation": false,
 	"Cache.Url": false,
+	"Cache.WorkerCount": false,
 	"Cache.XRootDPrefix": false,
 	"Client.AssumeDirectorServerHeader": false,
 	"Client.CredentialFile": false,
@@ -863,6 +864,7 @@ var intAccessors = map[string]func(*Config) int{
 	"Cache.DataScanResampleInterval": func(c *Config) int { return c.Cache.DataScanResampleInterval },
 	"Cache.EvictionMonitoringMaxDepth": func(c *Config) int { return c.Cache.EvictionMonitoringMaxDepth },
 	"Cache.Port": func(c *Config) int { return c.Cache.Port },
+	"Cache.WorkerCount": func(c *Config) int { return c.Cache.WorkerCount },
 	"ClientAgent.HistoryRetentionDays": func(c *Config) int { return c.ClientAgent.HistoryRetentionDays },
 	"ClientAgent.MaxConcurrentJobs": func(c *Config) int { return c.ClientAgent.MaxConcurrentJobs },
 	"Client.DirectorRetries": func(c *Config) int { return c.Client.DirectorRetries },
@@ -1307,6 +1309,7 @@ var allParameterNames = []string{
 	"Cache.SentinelLocation",
 	"Cache.StorageLocation",
 	"Cache.Url",
+	"Cache.WorkerCount",
 	"Cache.XRootDPrefix",
 	"Client.AssumeDirectorServerHeader",
 	"Client.CredentialFile",
@@ -1943,6 +1946,7 @@ var (
 	Cache_DataScanResampleInterval = IntParam{"Cache.DataScanResampleInterval"}
 	Cache_EvictionMonitoringMaxDepth = IntParam{"Cache.EvictionMonitoringMaxDepth"}
 	Cache_Port = IntParam{"Cache.Port"}
+	Cache_WorkerCount = IntParam{"Cache.WorkerCount"}
 	ClientAgent_HistoryRetentionDays = IntParam{"ClientAgent.HistoryRetentionDays"}
 	ClientAgent_MaxConcurrentJobs = IntParam{"ClientAgent.MaxConcurrentJobs"}
 	Client_DirectorRetries = IntParam{"Client.DirectorRetries"}
@@ -2417,6 +2421,7 @@ func init() {
 		"Cache.DataScanResampleInterval": Cache_DataScanResampleInterval,
 		"Cache.EvictionMonitoringMaxDepth": Cache_EvictionMonitoringMaxDepth,
 		"Cache.Port": Cache_Port,
+		"Cache.WorkerCount": Cache_WorkerCount,
 		"ClientAgent.HistoryRetentionDays": ClientAgent_HistoryRetentionDays,
 		"ClientAgent.MaxConcurrentJobs": ClientAgent_MaxConcurrentJobs,
 		"Client.DirectorRetries": Client_DirectorRetries,

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -110,6 +110,7 @@ var runtimeConfigurableMap = map[string]bool{
 	"Cache.DirectorTest": false,
 	"Cache.DisableClientX509": false,
 	"Cache.EnableBroker": false,
+	"Cache.EnableChaosAPI": false,
 	"Cache.EnableEvictionMonitoring": false,
 	"Cache.EnableLotman": false,
 	"Cache.EnableOIDC": false,
@@ -982,6 +983,7 @@ var boolAccessors = map[string]func(*Config) bool{
 	"Cache.DirectorTest": func(c *Config) bool { return c.Cache.DirectorTest },
 	"Cache.DisableClientX509": func(c *Config) bool { return c.Cache.DisableClientX509 },
 	"Cache.EnableBroker": func(c *Config) bool { return c.Cache.EnableBroker },
+	"Cache.EnableChaosAPI": func(c *Config) bool { return c.Cache.EnableChaosAPI },
 	"Cache.EnableEvictionMonitoring": func(c *Config) bool { return c.Cache.EnableEvictionMonitoring },
 	"Cache.EnableLotman": func(c *Config) bool { return c.Cache.EnableLotman },
 	"Cache.EnableOIDC": func(c *Config) bool { return c.Cache.EnableOIDC },
@@ -1269,6 +1271,7 @@ var allParameterNames = []string{
 	"Cache.DirectorTest",
 	"Cache.DisableClientX509",
 	"Cache.EnableBroker",
+	"Cache.EnableChaosAPI",
 	"Cache.EnableEvictionMonitoring",
 	"Cache.EnableLotman",
 	"Cache.EnableOIDC",
@@ -1993,6 +1996,7 @@ var (
 	Cache_DirectorTest = BoolParam{"Cache.DirectorTest"}
 	Cache_DisableClientX509 = BoolParam{"Cache.DisableClientX509"}
 	Cache_EnableBroker = BoolParam{"Cache.EnableBroker"}
+	Cache_EnableChaosAPI = BoolParam{"Cache.EnableChaosAPI"}
 	Cache_EnableEvictionMonitoring = BoolParam{"Cache.EnableEvictionMonitoring"}
 	Cache_EnableLotman = BoolParam{"Cache.EnableLotman"}
 	Cache_EnableOIDC = BoolParam{"Cache.EnableOIDC"}
@@ -2459,6 +2463,7 @@ func init() {
 		"Cache.DirectorTest": Cache_DirectorTest,
 		"Cache.DisableClientX509": Cache_DisableClientX509,
 		"Cache.EnableBroker": Cache_EnableBroker,
+		"Cache.EnableChaosAPI": Cache_EnableChaosAPI,
 		"Cache.EnableEvictionMonitoring": Cache_EnableEvictionMonitoring,
 		"Cache.EnableLotman": Cache_EnableLotman,
 		"Cache.EnableOIDC": Cache_EnableOIDC,

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -104,6 +104,7 @@ var runtimeConfigurableMap = map[string]bool{
 	"Cache.ConcurrencyDegradedThreshold": false,
 	"Cache.DataLocation": false,
 	"Cache.DataLocations": false,
+	"Cache.DataScanMode": false,
 	"Cache.DbLocation": false,
 	"Cache.DefaultCacheTimeout": false,
 	"Cache.DirectorTest": false,
@@ -572,6 +573,7 @@ func paramNameToEnvVar(paramName string) string {
 var stringAccessors = map[string]func(*Config) string{
 	"Cache.ClientStatisticsLocation": func(c *Config) string { return c.Cache.ClientStatisticsLocation },
 	"Cache.DataLocation": func(c *Config) string { return c.Cache.DataLocation },
+	"Cache.DataScanMode": func(c *Config) string { return c.Cache.DataScanMode },
 	"Cache.DbLocation": func(c *Config) string { return c.Cache.DbLocation },
 	"Cache.ExportLocation": func(c *Config) string { return c.Cache.ExportLocation },
 	"Cache.FedTokenLocation": func(c *Config) string { return c.Cache.FedTokenLocation },
@@ -1261,6 +1263,7 @@ var allParameterNames = []string{
 	"Cache.ConcurrencyDegradedThreshold",
 	"Cache.DataLocation",
 	"Cache.DataLocations",
+	"Cache.DataScanMode",
 	"Cache.DbLocation",
 	"Cache.DefaultCacheTimeout",
 	"Cache.DirectorTest",
@@ -1702,6 +1705,7 @@ var allParameterNames = []string{
 var (
 	Cache_ClientStatisticsLocation = StringParam{"Cache.ClientStatisticsLocation"}
 	Cache_DataLocation = StringParam{"Cache.DataLocation"}
+	Cache_DataScanMode = StringParam{"Cache.DataScanMode"}
 	Cache_DbLocation = StringParam{"Cache.DbLocation"}
 	Cache_ExportLocation = StringParam{"Cache.ExportLocation"}
 	Cache_FedTokenLocation = StringParam{"Cache.FedTokenLocation"}
@@ -2179,6 +2183,7 @@ func init() {
 	paramByName = map[string]Param{
 		"Cache.ClientStatisticsLocation": Cache_ClientStatisticsLocation,
 		"Cache.DataLocation": Cache_DataLocation,
+		"Cache.DataScanMode": Cache_DataScanMode,
 		"Cache.DbLocation": Cache_DbLocation,
 		"Cache.ExportLocation": Cache_ExportLocation,
 		"Cache.FedTokenLocation": Cache_FedTokenLocation,

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -35,6 +35,7 @@ type Config struct {
 		DataLocation string `mapstructure:"datalocation" yaml:"DataLocation"`
 		DataLocations []string `mapstructure:"datalocations" yaml:"DataLocations"`
 		DataScanMode string `mapstructure:"datascanmode" yaml:"DataScanMode"`
+		DataScanResampleInterval int `mapstructure:"datascanresampleinterval" yaml:"DataScanResampleInterval"`
 		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
 		DefaultCacheTimeout time.Duration `mapstructure:"defaultcachetimeout" yaml:"DefaultCacheTimeout"`
 		DirectorTest bool `mapstructure:"directortest" yaml:"DirectorTest"`
@@ -523,6 +524,7 @@ type configWithType struct {
 		DataLocation struct { Type string; Value string }
 		DataLocations struct { Type string; Value []string }
 		DataScanMode struct { Type string; Value string }
+		DataScanResampleInterval struct { Type string; Value int }
 		DbLocation struct { Type string; Value string }
 		DefaultCacheTimeout struct { Type string; Value time.Duration }
 		DirectorTest struct { Type string; Value bool }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -34,6 +34,7 @@ type Config struct {
 		ConcurrencyDegradedThreshold int `mapstructure:"concurrencydegradedthreshold" yaml:"ConcurrencyDegradedThreshold"`
 		DataLocation string `mapstructure:"datalocation" yaml:"DataLocation"`
 		DataLocations []string `mapstructure:"datalocations" yaml:"DataLocations"`
+		DataScanMode string `mapstructure:"datascanmode" yaml:"DataScanMode"`
 		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
 		DefaultCacheTimeout time.Duration `mapstructure:"defaultcachetimeout" yaml:"DefaultCacheTimeout"`
 		DirectorTest bool `mapstructure:"directortest" yaml:"DirectorTest"`
@@ -520,6 +521,7 @@ type configWithType struct {
 		ConcurrencyDegradedThreshold struct { Type string; Value int }
 		DataLocation struct { Type string; Value string }
 		DataLocations struct { Type string; Value []string }
+		DataScanMode struct { Type string; Value string }
 		DbLocation struct { Type string; Value string }
 		DefaultCacheTimeout struct { Type string; Value time.Duration }
 		DirectorTest struct { Type string; Value bool }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -40,6 +40,7 @@ type Config struct {
 		DirectorTest bool `mapstructure:"directortest" yaml:"DirectorTest"`
 		DisableClientX509 bool `mapstructure:"disableclientx509" yaml:"DisableClientX509"`
 		EnableBroker bool `mapstructure:"enablebroker" yaml:"EnableBroker"`
+		EnableChaosAPI bool `mapstructure:"enablechaosapi" yaml:"EnableChaosAPI"`
 		EnableEvictionMonitoring bool `mapstructure:"enableevictionmonitoring" yaml:"EnableEvictionMonitoring"`
 		EnableLotman bool `mapstructure:"enablelotman" yaml:"EnableLotman"`
 		EnableOIDC bool `mapstructure:"enableoidc" yaml:"EnableOIDC"`
@@ -527,6 +528,7 @@ type configWithType struct {
 		DirectorTest struct { Type string; Value bool }
 		DisableClientX509 struct { Type string; Value bool }
 		EnableBroker struct { Type string; Value bool }
+		EnableChaosAPI struct { Type string; Value bool }
 		EnableEvictionMonitoring struct { Type string; Value bool }
 		EnableLotman struct { Type string; Value bool }
 		EnableOIDC struct { Type string; Value bool }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -40,6 +40,7 @@ type Config struct {
 		DirectorTest bool `mapstructure:"directortest" yaml:"DirectorTest"`
 		DisableClientX509 bool `mapstructure:"disableclientx509" yaml:"DisableClientX509"`
 		EnableBroker bool `mapstructure:"enablebroker" yaml:"EnableBroker"`
+		EnableChaosAPI bool `mapstructure:"enablechaosapi" yaml:"EnableChaosAPI"`
 		EnableEvictionMonitoring bool `mapstructure:"enableevictionmonitoring" yaml:"EnableEvictionMonitoring"`
 		EnableLotman bool `mapstructure:"enablelotman" yaml:"EnableLotman"`
 		EnableOIDC bool `mapstructure:"enableoidc" yaml:"EnableOIDC"`
@@ -540,6 +541,7 @@ type configWithType struct {
 		DirectorTest struct { Type string; Value bool }
 		DisableClientX509 struct { Type string; Value bool }
 		EnableBroker struct { Type string; Value bool }
+		EnableChaosAPI struct { Type string; Value bool }
 		EnableEvictionMonitoring struct { Type string; Value bool }
 		EnableLotman struct { Type string; Value bool }
 		EnableOIDC struct { Type string; Value bool }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -35,6 +35,7 @@ type Config struct {
 		DataLocation string `mapstructure:"datalocation" yaml:"DataLocation"`
 		DataLocations []string `mapstructure:"datalocations" yaml:"DataLocations"`
 		DataScanMode string `mapstructure:"datascanmode" yaml:"DataScanMode"`
+		DataScanResampleInterval int `mapstructure:"datascanresampleinterval" yaml:"DataScanResampleInterval"`
 		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
 		DefaultCacheTimeout time.Duration `mapstructure:"defaultcachetimeout" yaml:"DefaultCacheTimeout"`
 		DirectorTest bool `mapstructure:"directortest" yaml:"DirectorTest"`
@@ -536,6 +537,7 @@ type configWithType struct {
 		DataLocation struct { Type string; Value string }
 		DataLocations struct { Type string; Value []string }
 		DataScanMode struct { Type string; Value string }
+		DataScanResampleInterval struct { Type string; Value int }
 		DbLocation struct { Type string; Value string }
 		DefaultCacheTimeout struct { Type string; Value time.Duration }
 		DirectorTest struct { Type string; Value bool }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -74,6 +74,7 @@ type Config struct {
 		SentinelLocation string `mapstructure:"sentinellocation" yaml:"SentinelLocation"`
 		StorageLocation string `mapstructure:"storagelocation" yaml:"StorageLocation"`
 		Url string `mapstructure:"url" yaml:"Url"`
+		WorkerCount int `mapstructure:"workercount" yaml:"WorkerCount"`
 		XRootDPrefix string `mapstructure:"xrootdprefix" yaml:"XRootDPrefix"`
 	} `mapstructure:"cache" yaml:"Cache"`
 	Client struct {
@@ -576,6 +577,7 @@ type configWithType struct {
 		SentinelLocation struct { Type string; Value string }
 		StorageLocation struct { Type string; Value string }
 		Url struct { Type string; Value string }
+		WorkerCount struct { Type string; Value int }
 		XRootDPrefix struct { Type string; Value string }
 	}
 	Client struct {

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -34,6 +34,7 @@ type Config struct {
 		ConcurrencyDegradedThreshold int `mapstructure:"concurrencydegradedthreshold" yaml:"ConcurrencyDegradedThreshold"`
 		DataLocation string `mapstructure:"datalocation" yaml:"DataLocation"`
 		DataLocations []string `mapstructure:"datalocations" yaml:"DataLocations"`
+		DataScanMode string `mapstructure:"datascanmode" yaml:"DataScanMode"`
 		DbLocation string `mapstructure:"dblocation" yaml:"DbLocation"`
 		DefaultCacheTimeout time.Duration `mapstructure:"defaultcachetimeout" yaml:"DefaultCacheTimeout"`
 		DirectorTest bool `mapstructure:"directortest" yaml:"DirectorTest"`
@@ -533,6 +534,7 @@ type configWithType struct {
 		ConcurrencyDegradedThreshold struct { Type string; Value int }
 		DataLocation struct { Type string; Value string }
 		DataLocations struct { Type string; Value []string }
+		DataScanMode struct { Type string; Value string }
 		DbLocation struct { Type string; Value string }
 		DefaultCacheTimeout struct { Type string; Value time.Duration }
 		DirectorTest struct { Type string; Value bool }

--- a/web_ui/middleware.go
+++ b/web_ui/middleware.go
@@ -4,6 +4,7 @@ package web_ui
 import (
 	"net/http"
 	"slices"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -15,6 +16,30 @@ import (
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
 )
+
+// loginRateLimitStores caches one rate-limit store per limit value.
+// gin-rate-limit's InMemoryStore starts a background cleanup goroutine that it
+// never stops, and RegisterAuthEndpoints runs on every web-engine launch, so a
+// fresh store per call would leak a goroutine each time. Reuse one store per
+// limit for the lifetime of the process instead.
+var (
+	loginRateLimitStores   = map[int]ratelimit.Store{}
+	loginRateLimitStoresMu sync.Mutex
+)
+
+func loginRateLimitStore(limit int) ratelimit.Store {
+	loginRateLimitStoresMu.Lock()
+	defer loginRateLimitStoresMu.Unlock()
+	if store, ok := loginRateLimitStores[limit]; ok {
+		return store
+	}
+	store := ratelimit.InMemoryStore(&ratelimit.InMemoryOptions{
+		Rate:  time.Second,
+		Limit: uint(limit),
+	})
+	loginRateLimitStores[limit] = store
+	return store
+}
 
 func ServerHeaderMiddleware(ctx *gin.Context) {
 	ctx.Writer.Header().Add("Server", "pelican/"+config.GetVersion())
@@ -63,10 +88,7 @@ func loginRateLimitMiddleware(limit int) gin.HandlerFunc {
 		limit = 1
 	}
 
-	store := ratelimit.InMemoryStore(&ratelimit.InMemoryOptions{
-		Rate:  time.Second,
-		Limit: uint(limit),
-	})
+	store := loginRateLimitStore(limit)
 
 	return ratelimit.RateLimiter(store, &ratelimit.Options{
 		ErrorHandler: func(ctx *gin.Context, info ratelimit.Info) {

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -1226,8 +1226,12 @@ func runEngineWithListener(ctx context.Context, ln net.Listener, engine *gin.Eng
 	config := &tls.Config{
 		GetCertificate: getCert,
 	}
+	// WriterLevel spins up a background scanner goroutine backed by an os.Pipe;
+	// keep a handle so it can be closed on shutdown, otherwise every web-engine
+	// launch leaks the goroutine and the pipe's file descriptors.
+	warnWriter := log.StandardLogger().WriterLevel(log.WarnLevel)
 	logWriter := builtin_log.New(
-		log.StandardLogger().WriterLevel(log.WarnLevel),
+		warnWriter,
 		"",
 		0,
 	)
@@ -1245,6 +1249,8 @@ func runEngineWithListener(ctx context.Context, ln net.Listener, engine *gin.Eng
 		<-ctx.Done()
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
+		// Stop the ErrorLog's WriterLevel scanner goroutine and release its pipe.
+		defer warnWriter.Close()
 		err = server.Shutdown(ctx)
 		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 			log.Errorln("Failed to shutdown server:", err)


### PR DESCRIPTION
This branch has a grab-bag of improvements in the (unreleased) Cache V2.  Highlights:

- Site-local mode now works for cache V2.
- Addition of a new "verify once" data-scan mode.  If you have ZFS data scrubbing enabled, there's no point in periodically recalculating the checksum: do it once and it should be fine subsequently.
- Add a "chaos monkey" API that will corrupt cached files in admin-specified ways.
- Add XRootD-compatible monitoring packets so we don't lose monitoring info when we start updating services.