### PR TITLE
Touch up usage of client-configured caches

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2294,19 +2294,28 @@ func generateTransferDetails(remoteOServer string, opts transferDetailsOptions) 
 // the same cache more than once to force repeated attempts); those duplicates are honored here rather than collapsed.
 // nPreferred indicates how many entries at the start of sortedObjectServers came from the user's PreferredCaches
 // configuration; those entries will have Preferred=true in the returned details.
-func getObjectServersToTry(sortedObjectServers []string, job *TransferJob, oServersToTry int, packOption string, nPreferred int) (transfers []transferAttemptDetails) {
+//
+// directorServersToTry caps only the director-discovered servers. Every user-supplied preferred cache is always tried:
+// the user asked for those endpoints explicitly, so we honor the full list in order rather than truncating it.
+func getObjectServersToTry(sortedObjectServers []string, job *TransferJob, directorServersToTry int, packOption string, nPreferred int) (transfers []transferAttemptDetails) {
 	oServers := make([]string, 0)
 
+	directorListed := 0
 	for idx, oServer := range sortedObjectServers {
-		if len(oServers) == oServersToTry {
-			break
+		isPreferred := idx < nPreferred
+		if !isPreferred {
+			// The attempt cap applies only to director-discovered servers; preferred caches
+			// (which all sort ahead of director servers) are exempt and always included.
+			if directorListed == directorServersToTry {
+				break
+			}
+			directorListed++
 		}
 		oServers = append(oServers, oServer)
 		td := transferDetailsOptions{
 			NeedsToken: job.dirResp.XPelNsHdr.RequireToken,
 			PackOption: packOption,
 		}
-		isPreferred := idx < nPreferred
 		newTransfers := generateTransferDetails(oServer, td)
 		for i := range newTransfers {
 			newTransfers[i].Preferred = isPreferred
@@ -2363,13 +2372,9 @@ func buildDownloadTransfers(job *clientTransferJob, packOption string) ([]transf
 		sortedServerStrings = append(sortedServerStrings, serverUrl.String())
 	}
 
-	// Make sure we only try as many object servers as we have
-	objectServersToTry := ObjectServersToTry
-	if objectServersToTry > len(sortedServers) {
-		objectServersToTry = len(sortedServers)
-	}
-	log.Debugf("Trying the first %d object servers", objectServersToTry)
-	transfers := getObjectServersToTry(sortedServerStrings, job.job, objectServersToTry, packOption, nPreferred)
+	// The cap applies only to director-discovered servers; all preferred caches are always tried.
+	log.Debugf("Trying all %d preferred object servers plus up to %d director-provided servers", nPreferred, ObjectServersToTry)
+	transfers := getObjectServersToTry(sortedServerStrings, job.job, ObjectServersToTry, packOption, nPreferred)
 
 	if len(transfers) > 0 {
 		log.Traceln("First transfer in list:", transfers[0].Url)

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2288,37 +2288,30 @@ func generateTransferDetails(remoteOServer string, opts transferDetailsOptions) 
 	return details
 }
 
-// Generate the unique list of object servers (caches or origins) that will be attempted for a single transfer job and populate this info
-// in the slice of transferAttemptDetails structs.
+// Generate the list of object servers (caches or origins) that will be attempted for a single transfer job and populate this info
+// in the slice of transferAttemptDetails structs. The incoming sortedObjectServers list is expected to be deduplicated by
+// generateSortedObjServers, except that intentional duplicates among the user's preferred caches are preserved (a user may list
+// the same cache more than once to force repeated attempts); those duplicates are honored here rather than collapsed.
 // nPreferred indicates how many entries at the start of sortedObjectServers came from the user's PreferredCaches
 // configuration; those entries will have Preferred=true in the returned details.
 func getObjectServersToTry(sortedObjectServers []string, job *TransferJob, oServersToTry int, packOption string, nPreferred int) (transfers []transferAttemptDetails) {
-	oServersListed := 0
-	oServerList := make(map[string]bool)
 	oServers := make([]string, 0)
 
 	for idx, oServer := range sortedObjectServers {
-		if oServersListed == oServersToTry {
+		if len(oServers) == oServersToTry {
 			break
 		}
-		// Handle deduplication of any object servers
-		if oServerList[oServer] {
-			continue
-		} else {
-			oServersListed++
-			oServers = append(oServers, oServer)
-			oServerList[oServer] = true
-			td := transferDetailsOptions{
-				NeedsToken: job.dirResp.XPelNsHdr.RequireToken,
-				PackOption: packOption,
-			}
-			isPreferred := idx < nPreferred
-			newTransfers := generateTransferDetails(oServer, td)
-			for i := range newTransfers {
-				newTransfers[i].Preferred = isPreferred
-			}
-			transfers = append(transfers, newTransfers...)
+		oServers = append(oServers, oServer)
+		td := transferDetailsOptions{
+			NeedsToken: job.dirResp.XPelNsHdr.RequireToken,
+			PackOption: packOption,
 		}
+		isPreferred := idx < nPreferred
+		newTransfers := generateTransferDetails(oServer, td)
+		for i := range newTransfers {
+			newTransfers[i].Preferred = isPreferred
+		}
+		transfers = append(transfers, newTransfers...)
 	}
 	log.Debugln("Trying the object servers:", oServers)
 	return transfers

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -1172,12 +1172,65 @@ func TestGetObjectServersToTry(t *testing.T) {
 		job := &TransferJob{
 			dirResp: directorResponse,
 		}
-		// nPreferred=2: cache-1 and cache-2 are preferred; cache-3 is director.
+		// nPreferred=2: cache-1 and cache-2 are preferred; cache-3/4/5 are director.
+		// The cap of 3 applies only to the director servers, so all 5 are returned.
 		transfers := getObjectServersToTry(sortedServers, job, 3, "", 2)
-		require.Len(t, transfers, 3)
+		require.Len(t, transfers, 5)
 		assert.True(t, transfers[0].Preferred, "cache-1 (idx 0) should be marked preferred")
 		assert.True(t, transfers[1].Preferred, "cache-2 (idx 1) should be marked preferred")
 		assert.False(t, transfers[2].Preferred, "cache-3 (idx 2) should not be marked preferred (director-provided)")
+		assert.False(t, transfers[3].Preferred, "cache-4 (idx 3) should not be marked preferred (director-provided)")
+		assert.False(t, transfers[4].Preferred, "cache-5 (idx 4) should not be marked preferred (director-provided)")
+	})
+
+	// The attempt cap restricts only director-provided servers. If the user supplies more
+	// preferred caches than the cap, every one of them must still be tried, in order.
+	t.Run("AllPreferredTriedRegardlessOfCap", func(t *testing.T) {
+		directorResponse := server_structs.DirectorResponse{
+			XPelNsHdr: server_structs.XPelNs{
+				RequireToken: true,
+			},
+		}
+		job := &TransferJob{
+			dirResp: directorResponse,
+		}
+		// 6 preferred caches, no director servers, director cap of 3: all 6 are tried.
+		preferredServers := []string{
+			"https://cache-1.com",
+			"https://cache-2.com",
+			"https://cache-3.com",
+			"https://cache-4.com",
+			"https://cache-5.com",
+			"https://cache-6.com",
+		}
+		transfers := getObjectServersToTry(preferredServers, job, 3, "", len(preferredServers))
+		require.Len(t, transfers, 6)
+		for i, transfer := range transfers {
+			assert.True(t, transfer.Preferred, "preferred cache at idx %d should be marked preferred", i)
+		}
+		assert.Equal(t, "https://cache-6.com", transfers[5].Url.String())
+	})
+
+	// With preferred caches exceeding the cap AND director fallbacks present, all preferred
+	// caches are tried plus up to the cap's worth of director servers.
+	t.Run("AllPreferredPlusCappedDirector", func(t *testing.T) {
+		directorResponse := server_structs.DirectorResponse{
+			XPelNsHdr: server_structs.XPelNs{
+				RequireToken: true,
+			},
+		}
+		job := &TransferJob{
+			dirResp: directorResponse,
+		}
+		// 4 preferred + 4 director, director cap of 3 => 4 preferred + 3 director = 7.
+		servers := []string{
+			"https://pref-1.com", "https://pref-2.com", "https://pref-3.com", "https://pref-4.com",
+			"https://dir-1.com", "https://dir-2.com", "https://dir-3.com", "https://dir-4.com",
+		}
+		transfers := getObjectServersToTry(servers, job, 3, "", 4)
+		require.Len(t, transfers, 7)
+		assert.Equal(t, "https://dir-3.com", transfers[6].Url.String())
+		assert.False(t, transfers[6].Preferred)
 	})
 }
 

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -1089,14 +1089,14 @@ func TestProjInUserAgent(t *testing.T) {
 	assert.Equal(t, "pelican-client/"+config.GetVersion()+" project/test", *server_test.user_agent)
 }
 
-// The test should prove that the function getObjectServersToTry returns the correct number of servers,
-// and that any duplicates are removed
+// The test should prove that the function getObjectServersToTry returns the correct number of servers.
+// Deduplication is handled upstream in generateSortedObjServers (by host:port); this function preserves
+// the list it is given, including intentional duplicates among the user's preferred caches.
 func TestGetObjectServersToTry(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	sortedServers := []string{
 		"http://cache-1.com", // set an HTTP scheme to check that it's switched to https
 		"https://cache-2.com",
-		"https://cache-2.com", // make sure duplicates are removed
 		"https://cache-3.com",
 		"https://cache-4.com",
 		"https://cache-5.com",
@@ -1113,14 +1113,6 @@ func TestGetObjectServersToTry(t *testing.T) {
 		}
 		transfers := getObjectServersToTry(sortedServers, job, 3, "", 0)
 
-		// Check that there are no duplicates in the result
-		cacheSet := make(map[string]bool)
-		for _, transfer := range transfers {
-			if cacheSet[transfer.Url.String()] {
-				t.Errorf("Found duplicate cache: %v", transfer.Url.String())
-			}
-			cacheSet[transfer.Url.String()] = true
-		}
 		// Verify we got the correct caches in our transfer attempt details
 		require.Len(t, transfers, 3)
 		assert.Equal(t, "https://cache-1.com", transfers[0].Url.String())
@@ -1139,18 +1131,33 @@ func TestGetObjectServersToTry(t *testing.T) {
 		}
 		transfers := getObjectServersToTry(sortedServers, job, 3, "", 0)
 
-		cacheSet := make(map[string]bool)
-		for _, transfer := range transfers {
-			if cacheSet[transfer.Url.String()] {
-				t.Errorf("Found duplicate cache: %v", transfer.Url.String())
-			}
-			cacheSet[transfer.Url.String()] = true
-		}
-
 		require.Len(t, transfers, 3)
 		assert.Equal(t, "http://cache-1.com", transfers[0].Url.String())
 		assert.Equal(t, "https://cache-2.com", transfers[1].Url.String())
 		assert.Equal(t, "https://cache-3.com", transfers[2].Url.String())
+	})
+
+	// williamnswanson's concern: intentional duplicates in the preferred list must be honored
+	// here rather than collapsed, so the client retries that cache as many times as requested.
+	t.Run("IntentionalDuplicatesPreserved", func(t *testing.T) {
+		directorResponse := server_structs.DirectorResponse{
+			XPelNsHdr: server_structs.XPelNs{
+				RequireToken: true,
+			},
+		}
+		job := &TransferJob{
+			dirResp: directorResponse,
+		}
+		// Both preferred entries point at cache-1; both must be tried, in order.
+		dupServers := []string{"https://cache-1.com", "https://cache-1.com", "https://cache-2.com"}
+		transfers := getObjectServersToTry(dupServers, job, 3, "", 2)
+		require.Len(t, transfers, 3)
+		assert.Equal(t, "https://cache-1.com", transfers[0].Url.String())
+		assert.Equal(t, "https://cache-1.com", transfers[1].Url.String())
+		assert.Equal(t, "https://cache-2.com", transfers[2].Url.String())
+		assert.True(t, transfers[0].Preferred)
+		assert.True(t, transfers[1].Preferred)
+		assert.False(t, transfers[2].Preferred)
 	})
 
 	// Test that the Preferred flag is set correctly based on nPreferred.

--- a/client/main.go
+++ b/client/main.go
@@ -358,6 +358,16 @@ func getUserAgent(project string) (agent string) {
 	return
 }
 
+// objServerKey returns the host:port identity used to deduplicate object servers.
+// For well-formed URLs this is the Host field (which includes the port when present);
+// we fall back to the full string for unusual inputs that don't parse a host.
+func objServerKey(u *url.URL) string {
+	if u.Host != "" {
+		return u.Host
+	}
+	return u.String()
+}
+
 // Given a response from the director with sorted object servers, incorporate any "preferred" servers (origins/caches) that
 // may be passed in from the command line. This should handle the special '+' logic -- if the user provides a list of servers
 // and no +, it means they ONLY want to use the provided servers. Otherwise, we prefer those servers, but also incorporate the
@@ -401,8 +411,25 @@ func generateSortedObjServers(dirResp server_structs.DirectorResponse, preferred
 	}
 
 	log.Debugln("Using the returned sources from the director")
-	// We may have some servers from the preferred list
-	objectServers = append(objectServers, dirResp.ObjectServers...)
+	// Append the director-provided servers, but skip any whose host:port collides with
+	// a server we've already included. This keeps the '+' fallback from re-adding a
+	// user-configured preferred cache (issue #3526) and drops duplicates within the
+	// director's own list. We intentionally do NOT deduplicate the preferred servers
+	// against each other: a user may list the same cache multiple times to force
+	// repeated attempts (e.g. when testing or troubleshooting a specific cache).
+	seenHosts := make(map[string]bool, len(objectServers))
+	for _, oServer := range objectServers {
+		seenHosts[objServerKey(oServer)] = true
+	}
+	for _, oServer := range dirResp.ObjectServers {
+		key := objServerKey(oServer)
+		if seenHosts[key] {
+			log.Debugf("Skipping director-provided server (%s) that duplicates an already-listed cache\n", oServer)
+			continue
+		}
+		seenHosts[key] = true
+		objectServers = append(objectServers, oServer)
+	}
 
 	if log.IsLevelEnabled(log.DebugLevel) || log.IsLevelEnabled(log.TraceLevel) {
 		oHosts := make([]string, len(objectServers))

--- a/client/main.go
+++ b/client/main.go
@@ -413,7 +413,7 @@ func generateSortedObjServers(dirResp server_structs.DirectorResponse, preferred
 	log.Debugln("Using the returned sources from the director")
 	// Append the director-provided servers, but skip any whose host:port collides with
 	// a server we've already included. This keeps the '+' fallback from re-adding a
-	// user-configured preferred cache (issue #3526) and drops duplicates within the
+	// user-configured preferred cache and drops duplicates within the
 	// director's own list. We intentionally do NOT deduplicate the preferred servers
 	// against each other: a user may list the same cache multiple times to force
 	// repeated attempts (e.g. when testing or troubleshooting a specific cache).

--- a/client/main_test.go
+++ b/client/main_test.go
@@ -134,6 +134,82 @@ func TestGenerateSortedObjectServers(t *testing.T) {
 		assert.Equal(t, "https://server3.com/foo", oServers[4].String())
 	})
 
+	// A preferred cache that also appears in the director's list must not be
+	// duplicated when the '+' fallback re-incorporates the director servers. The director
+	// copy (matched by host:port) is dropped; the preferred copy is kept up front.
+	t.Run("testPreferredCacheDedupedAgainstDirector", func(t *testing.T) {
+		preferredOServers := []*url.URL{
+			{Scheme: "https", Host: "server2.com", Path: "/"},
+			{Scheme: "", Host: "", Path: "+"},
+		}
+		oServers, nPreferred, err := generateSortedObjServers(dirResp, preferredOServers)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, nPreferred)
+		require.Len(t, oServers, 3)
+		// The preferred server2.com stays first (with the user's path), and the director's
+		// server2.com is filtered out, leaving server1.com and server3.com as fallbacks.
+		assert.Equal(t, "https://server2.com/", oServers[0].String())
+		assert.Equal(t, "https://server1.com/foo", oServers[1].String())
+		assert.Equal(t, "https://server3.com/foo", oServers[2].String())
+	})
+
+	// A user may intentionally list the same cache more than once force repeated attempts.
+	// Those duplicates must be preserved, even though the director
+	// copy of that cache is still filtered out.
+	t.Run("testIntentionalPreferredDuplicatesPreserved", func(t *testing.T) {
+		preferredOServers := []*url.URL{
+			{Scheme: "https", Host: "server1.com", Path: "/"},
+			{Scheme: "https", Host: "server1.com", Path: "/"},
+			{Scheme: "", Host: "", Path: "+"},
+		}
+		oServers, nPreferred, err := generateSortedObjServers(dirResp, preferredOServers)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, nPreferred)
+		require.Len(t, oServers, 4)
+		assert.Equal(t, "https://server1.com/", oServers[0].String())
+		assert.Equal(t, "https://server1.com/", oServers[1].String())
+		// Director's server1.com is dropped; server2.com and server3.com remain as fallbacks.
+		assert.Equal(t, "https://server2.com/foo", oServers[2].String())
+		assert.Equal(t, "https://server3.com/foo", oServers[3].String())
+	})
+
+	// The same host on a different port is a distinct cache and must not be deduplicated.
+	t.Run("testSameHostDifferentPortNotDeduped", func(t *testing.T) {
+		portDirResp := server_structs.DirectorResponse{
+			ObjectServers: []*url.URL{
+				{Scheme: "https", Host: "server1.com:8443", Path: "/foo"},
+				{Scheme: "https", Host: "server1.com:8444", Path: "/foo"},
+			},
+		}
+		preferredOServers := []*url.URL{
+			{Scheme: "https", Host: "server1.com:8443", Path: "/"},
+			{Scheme: "", Host: "", Path: "+"},
+		}
+		oServers, nPreferred, err := generateSortedObjServers(portDirResp, preferredOServers)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, nPreferred)
+		require.Len(t, oServers, 2)
+		assert.Equal(t, "https://server1.com:8443/", oServers[0].String())
+		assert.Equal(t, "https://server1.com:8444/foo", oServers[1].String())
+	})
+
+	// Duplicates within the director's own list are collapsed even when no preferred caches are set.
+	t.Run("testDirectorDuplicatesDeduped", func(t *testing.T) {
+		dupDirResp := server_structs.DirectorResponse{
+			ObjectServers: []*url.URL{
+				{Scheme: "https", Host: "server1.com", Path: "/foo"},
+				{Scheme: "https", Host: "server1.com", Path: "/bar"},
+				{Scheme: "https", Host: "server2.com", Path: "/foo"},
+			},
+		}
+		oServers, nPreferred, err := generateSortedObjServers(dupDirResp, []*url.URL{})
+		assert.NoError(t, err)
+		assert.Equal(t, 0, nPreferred)
+		require.Len(t, oServers, 2)
+		assert.Equal(t, "https://server1.com/foo", oServers[0].String())
+		assert.Equal(t, "https://server2.com/foo", oServers[1].String())
+	})
+
 	// Test the function fails if the + character is not at the end of the list
 	t.Run("testPlusNotAtEnd", func(t *testing.T) {
 		preferredOServers := []*url.URL{


### PR DESCRIPTION
This PR does two things:
1. When a user supplies the client with a cache and also requests to fall back to Director cache choices, we now skip over Director-supplied caches if they match one provided by the user.
2. The "try 3 times" logic now only applies to Director-supplied caches; if the user gives a list of 10 servers to try, we'll iterate through them all until we succeed or have exhausted the list. If they provide 10 servers and also choose to fall back to the Director, we'll first try the user-preferred choices and then up to 3 suggestions from the Director.

Note that users can provide the same server arbitrarily many times in their client requests, and the client should _not_ collapse them down to a single request. This comes as a request from @williamnswanson, who sometimes wants to hit the same service multiple times during his testing workflows.

Closes #3526 