### PR TITLE
Classify result-level errors in transfer ads (fix missing ErrorType)

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -1026,6 +1026,25 @@ func addDataToClassAd(resultAd *classad.ClassAd, result *client.TransferResults,
 		transferErrorData = append(transferErrorData, transferError)
 	}
 
+	// Handle result-level (post-transfer) errors that aren't attached to any individual
+	// attempt, e.g. a checksum mismatch: the download attempts all succeeded, so the
+	// error lives only on result.Error and neither the per-attempt loop nor the early-
+	// failure block above captured it. Without this, such a result would be reported as
+	// TransferSuccess=false with no ErrorType/PelicanErrorCode. Only add it when nothing
+	// was already recorded so a normal per-attempt failure still yields a single entry.
+	if result != nil && result.Error != nil && len(transferErrorData) == 0 {
+		adErr = developerData.Set("TransferError1", result.Error.Error())
+		if adErr != nil {
+			log.Errorf("Failed to set TransferError1: %s", adErr)
+		}
+		adErr = developerData.Set("IsRetryable1", client.IsRetryable(result.Error))
+		if adErr != nil {
+			log.Errorf("Failed to set IsRetryable1: %s", adErr)
+		}
+		transferError := createTransferError(result.Error)
+		transferErrorData = append(transferErrorData, transferError)
+	}
+
 	// Add checksum information if provided
 	if len(clientChecksums) > 0 {
 		clientChecksumsData := classad.New()

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -1027,12 +1027,24 @@ func addDataToClassAd(resultAd *classad.ClassAd, result *client.TransferResults,
 	}
 
 	// Handle result-level (post-transfer) errors that aren't attached to any individual
-	// attempt, e.g. a checksum mismatch: the download attempts all succeeded, so the
-	// error lives only on result.Error and neither the per-attempt loop nor the early-
-	// failure block above captured it. Without this, such a result would be reported as
-	// TransferSuccess=false with no ErrorType/PelicanErrorCode. Only add it when nothing
-	// was already recorded so a normal per-attempt failure still yields a single entry.
-	if result != nil && result.Error != nil && len(transferErrorData) == 0 {
+	// attempt, e.g. a checksum mismatch: the download itself succeeded, so the error lives
+	// only on result.Error and neither the per-attempt loop nor the early-failure block
+	// above captured it. Without this, such a result would be reported as
+	// TransferSuccess=false with no ErrorType/PelicanErrorCode.
+	//
+	// The discriminator is whether the download succeeded, not whether transferErrorData is
+	// empty. On a failed download the client sets result.Error to the aggregate of the
+	// per-attempt errors we already recorded above, so re-adding it would double-count. On a
+	// successful download the client clears result.Error and only re-sets it from
+	// post-transfer verification, so it's a genuinely uncaptured result-level error. A
+	// successful download always ends on a passing attempt (the loop breaks on success),
+	// hence a nil Error on the last attempt. This also covers the failover case (an early
+	// attempt fails, a later one succeeds, then the checksum fails) that a len==0 guard
+	// would miss, leaving the fatal error unclassified while a recovered attempt's error
+	// stood in for it.
+	lastAttemptSucceeded := result != nil && len(result.Attempts) > 0 &&
+		result.Attempts[len(result.Attempts)-1].Error == nil
+	if result != nil && result.Error != nil && lastAttemptSucceeded {
 		adErr = developerData.Set("TransferError1", result.Error.Error())
 		if adErr != nil {
 			log.Errorf("Failed to set TransferError1: %s", adErr)

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -1264,6 +1264,62 @@ func TestCreateTransferError(t *testing.T) {
 	})
 }
 
+// Test that addDataToClassAd classifies result-level (post-transfer) errors.
+// A checksum mismatch is set on result.Error after the download attempts have all
+// succeeded (attempt.Error == nil), so it must still populate TransferErrorData with
+// the proper ErrorType/PelicanErrorCode rather than being reported with no code.
+func TestAddDataToClassAdResultLevelError(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+
+	// Checksum mismatch: attempts succeeded, error lives only on result.Error.
+	t.Run("ChecksumMismatch", func(t *testing.T) {
+		checksumErr := error_codes.NewTransfer_ChecksumMismatchError(errors.New("checksum mismatch for md5"))
+		result := &client.TransferResults{
+			Error: checksumErr,
+			Attempts: []client.TransferResult{
+				{Number: 0, Endpoint: "cache.example.com", TransferFileBytes: 1024},
+			},
+		}
+		resultAd := classad.New()
+		addDataToClassAd(resultAd, result, result.Error, len(result.Attempts), nil, nil)
+
+		errorDataList, ok := classad.GetAs[[]*classad.ClassAd](resultAd, "TransferErrorData")
+		require.True(t, ok)
+		require.Len(t, errorDataList, 1)
+
+		errorType, ok := classad.GetAs[string](errorDataList[0], "ErrorType")
+		require.True(t, ok)
+		assert.Equal(t, "Transfer", errorType)
+
+		teDevData, ok := classad.GetAs[*classad.ClassAd](errorDataList[0], "DeveloperData")
+		require.True(t, ok)
+		errorCode, ok := classad.GetAs[int64](teDevData, "PelicanErrorCode")
+		require.True(t, ok)
+		assert.Equal(t, int64(checksumErr.Code()), errorCode)
+		devErrType, ok := classad.GetAs[string](teDevData, "ErrorType")
+		require.True(t, ok)
+		assert.Equal(t, checksumErr.ErrorType(), devErrType)
+	})
+
+	// Regression: when a per-attempt error already captured the failure, the
+	// result-level branch must not add a duplicate TransferErrorData entry.
+	t.Run("PerAttemptErrorNotDuplicated", func(t *testing.T) {
+		attemptErr := error_codes.NewContact_ConnectionSetupError(errors.New("connection refused"))
+		result := &client.TransferResults{
+			Error: attemptErr,
+			Attempts: []client.TransferResult{
+				{Number: 0, Endpoint: "cache.example.com", Error: attemptErr},
+			},
+		}
+		resultAd := classad.New()
+		addDataToClassAd(resultAd, result, result.Error, len(result.Attempts), nil, nil)
+
+		errorDataList, ok := classad.GetAs[[]*classad.ClassAd](resultAd, "TransferErrorData")
+		require.True(t, ok)
+		require.Len(t, errorDataList, 1)
+	})
+}
+
 // Test recursive downloads from the plugin
 func TestPluginRecursiveDownload(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -1358,6 +1358,50 @@ func TestAddDataToClassAdResultLevelError(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, int64(checksumErr.Code()), errorCode)
 	})
+
+	// Same as above but with multiple failed attempts before the successful one
+	// (cacheA fails, cacheB fails, originC succeeds, then the checksum fails). Every
+	// per-attempt error is recorded, followed by the fatal result-level error, all in
+	// the order they occurred.
+	t.Run("MultipleFailoversThenChecksumMismatch", func(t *testing.T) {
+		cacheAErr := error_codes.NewContact_ConnectionSetupError(errors.New("cacheA: connection refused"))
+		cacheBErr := error_codes.NewContact_ConnectionSetupError(errors.New("cacheB: connection reset"))
+		checksumErr := error_codes.NewTransfer_ChecksumMismatchError(errors.New("checksum mismatch for md5"))
+		result := &client.TransferResults{
+			// The download ultimately succeeded on originC, so result.Error carries only
+			// the post-transfer checksum failure, not the earlier attempt errors.
+			Error: checksumErr,
+			Attempts: []client.TransferResult{
+				{Number: 0, Endpoint: "cacheA.example.com", Error: cacheAErr},
+				{Number: 1, Endpoint: "cacheB.example.com", Error: cacheBErr},
+				{Number: 2, Endpoint: "originC.example.com", TransferFileBytes: 1024},
+			},
+		}
+		resultAd := classad.New()
+		addDataToClassAd(resultAd, result, result.Error, len(result.Attempts), nil, nil)
+
+		errorDataList, ok := classad.GetAs[[]*classad.ClassAd](resultAd, "TransferErrorData")
+		require.True(t, ok)
+		require.Len(t, errorDataList, 3)
+
+		// Entries 0 and 1: the two recovered per-attempt connection errors.
+		for i := 0; i < 2; i++ {
+			attemptType, ok := classad.GetAs[string](errorDataList[i], "ErrorType")
+			require.True(t, ok)
+			assert.Equal(t, "Contact", attemptType)
+		}
+
+		// Entry 2: the fatal result-level checksum error, carrying its ErrorType/code.
+		lastType, ok := classad.GetAs[string](errorDataList[2], "ErrorType")
+		require.True(t, ok)
+		assert.Equal(t, "Transfer", lastType)
+
+		teDevData, ok := classad.GetAs[*classad.ClassAd](errorDataList[2], "DeveloperData")
+		require.True(t, ok)
+		errorCode, ok := classad.GetAs[int64](teDevData, "PelicanErrorCode")
+		require.True(t, ok)
+		assert.Equal(t, int64(checksumErr.Code()), errorCode)
+	})
 }
 
 // Test recursive downloads from the plugin

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -1318,6 +1318,46 @@ func TestAddDataToClassAdResultLevelError(t *testing.T) {
 		require.True(t, ok)
 		require.Len(t, errorDataList, 1)
 	})
+
+	// Failover then post-transfer failure: an early attempt fails (e.g. a stale cache
+	// connection), a later attempt succeeds, and only then does the checksum fail. The
+	// download-level error must not stand in for the fatal result-level error; both are
+	// recorded, in the order they occurred (attempt errors first, result-level error last).
+	t.Run("FailoverThenChecksumMismatch", func(t *testing.T) {
+		connErr := error_codes.NewContact_ConnectionSetupError(errors.New("connection refused"))
+		checksumErr := error_codes.NewTransfer_ChecksumMismatchError(errors.New("checksum mismatch for md5"))
+		result := &client.TransferResults{
+			// On a successful download the client clears the aggregate error and sets
+			// result.Error only from post-transfer verification (the checksum failure).
+			Error: checksumErr,
+			Attempts: []client.TransferResult{
+				{Number: 0, Endpoint: "cache.example.com", Error: connErr},
+				{Number: 1, Endpoint: "origin.example.com", TransferFileBytes: 1024},
+			},
+		}
+		resultAd := classad.New()
+		addDataToClassAd(resultAd, result, result.Error, len(result.Attempts), nil, nil)
+
+		errorDataList, ok := classad.GetAs[[]*classad.ClassAd](resultAd, "TransferErrorData")
+		require.True(t, ok)
+		require.Len(t, errorDataList, 2)
+
+		// Entry 0: the recovered per-attempt connection error.
+		firstType, ok := classad.GetAs[string](errorDataList[0], "ErrorType")
+		require.True(t, ok)
+		assert.Equal(t, "Contact", firstType)
+
+		// Entry 1: the fatal result-level checksum error, carrying its ErrorType/code.
+		secondType, ok := classad.GetAs[string](errorDataList[1], "ErrorType")
+		require.True(t, ok)
+		assert.Equal(t, "Transfer", secondType)
+
+		teDevData, ok := classad.GetAs[*classad.ClassAd](errorDataList[1], "DeveloperData")
+		require.True(t, ok)
+		errorCode, ok := classad.GetAs[int64](teDevData, "PelicanErrorCode")
+		require.True(t, ok)
+		assert.Equal(t, int64(checksumErr.Code()), errorCode)
+	})
 }
 
 // Test recursive downloads from the plugin


### PR DESCRIPTION
A checksum mismatch fails a transfer *after* all download attempts have succeeded: the error is set on the top-level result.Error, and no individual attempt.Error is populated. addDataToClassAd only built the structured TransferErrorData (which carries ErrorType/PelicanErrorCode) from per-attempt errors or zero-attempt early failures, so such a result was reported as TransferSuccess=false with a TransferError message but no error code or ErrorType.

Add a branch that classifies result.Error when no per-attempt error already captured the failure, guarding against double-counting so a normal per-attempt failure still yields a single TransferErrorData entry.

closes #3534 