### PR TITLE
Rerun flaky Go tests and move coverage reporting to its own workflow

### DIFF
--- a/.github/workflows/coverage-scheduled.yml
+++ b/.github/workflows/coverage-scheduled.yml
@@ -1,16 +1,22 @@
 ---
-name: Code Coverage [on schedule]
+name: Code Coverage
 
-# Runs the Go test suite once a day purely to measure code coverage, and
-# publishes the result as a JSON artifact ("code-coverage-json"). This is a
-# standalone workflow (rather than a hook into test-linux.yml) so that it runs
-# only "go test" with coverage instrumentation -- no GoReleaser build or
-# end-to-end scripts, none of which contribute to the coverage profile.
+# Runs the Go test suite purely to measure code coverage, and publishes the
+# result as a JSON artifact ("code-coverage-json") plus an action summary. This
+# is a standalone workflow (rather than a hook into test-linux.yml) so that it
+# runs only "go test" with coverage instrumentation -- no GoReleaser build or
+# end-to-end scripts, none of which contribute to the coverage profile. It also
+# does not re-run flaky tests, so (unlike test-linux.yml) the coverage profile
+# always reflects the whole suite in a single pass rather than being clobbered
+# by a partial re-run.
 #
-# Like the scheduled test workflow, it runs in the most recent published test
-# container image, since there is no per-run image build to depend on.
+# It runs on every pull request to report that PR's coverage, on a daily
+# schedule, and on manual dispatch. Like the scheduled test workflow, it runs
+# in the most recent published test container image, since there is no per-run
+# image build to depend on.
 
 on:
+  pull_request:
   schedule:
     - cron: "0 6 * * *"  # at 06:00 every day
   workflow_dispatch:

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -96,6 +96,9 @@ jobs:
             --format pkgname-and-test-fails \
             --hide-summary=output \
             --junitfile "$JUNIT_FILE" \
+            --rerun-fails=3 \
+            --rerun-fails-max-failures=15 \
+            --packages="./..." \
             -- \
             -p=4 \
             -timeout=${{ inputs.race_detection && '30m' || '15m' }} \
@@ -103,8 +106,7 @@ jobs:
             ${{ !inputs.race_detection && '-coverpkg=./...' || '' }} \
             ${{ !inputs.race_detection && '-covermode=count' || '' }} \
             ${{ !inputs.race_detection && format('-coverprofile={0}', matrix.coverprofile) || '' }} \
-            -tags=${{ matrix.tags }} \
-            ./...
+            -tags=${{ matrix.tags }}
 
       - name: Upload JUnit report
         if: always()
@@ -119,18 +121,6 @@ jobs:
         uses: test-summary/action@v2
         with:
           paths: junit-${{ matrix.binary_name }}.xml
-
-      - name: Get total code coverage
-        if: github.event_name == 'pull_request'
-        id: cc
-        run: |
-          set -x
-          cc_total=`go tool cover -func=${{ matrix.coverprofile }} | grep total | grep -Eo '[0-9]+\.[0-9]+'`
-          echo "cc_total=$cc_total" >> $GITHUB_OUTPUT
-
-      - name: Add coverage information to action summary
-        if: github.event_name == 'pull_request'
-        run: echo 'Code coverage ${{ steps.cc.outputs.cc_total }}%' >> $GITHUB_STEP_SUMMARY
 
       - name: Mark the checkout as safe
         # Because we're using a custom container image to run this workflow,

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -99,6 +99,9 @@ jobs:
             --format pkgname-and-test-fails \
             --hide-summary=output \
             --junitfile "$JUNIT_FILE" \
+            --rerun-fails=3 \
+            --rerun-fails-max-failures=15 \
+            --packages="./..." \
             -- \
             -p=4 \
             -timeout=${{ inputs.race_detection && '30m' || '15m' }} \
@@ -106,8 +109,7 @@ jobs:
             ${{ !inputs.race_detection && '-coverpkg=./...' || '' }} \
             ${{ !inputs.race_detection && '-covermode=count' || '' }} \
             ${{ !inputs.race_detection && format('-coverprofile={0}', matrix.coverprofile) || '' }} \
-            -tags=${{ matrix.tags }} \
-            ./...
+            -tags=${{ matrix.tags }}
 
       - name: Upload JUnit report
         if: always()

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -81,6 +81,9 @@ jobs:
             --format pkgname-and-test-fails \
             --hide-summary=output \
             --junitfile "$JUNIT_FILE" \
+            --rerun-fails=3 \
+            --rerun-fails-max-failures=15 \
+            --packages="./..." \
             -- \
             -p=4 \
             -timeout=${{ inputs.race_detection && '30m' || '15m' }} \
@@ -88,8 +91,7 @@ jobs:
             ${{ !inputs.race_detection && '-coverpkg=./...' || '' }} \
             ${{ !inputs.race_detection && '-covermode=count' || '' }} \
             ${{ !inputs.race_detection && format('-coverprofile={0}', matrix.coverprofile) || '' }} \
-            -tags=${{ matrix.tags }} \
-            ./...
+            -tags=${{ matrix.tags }}
 
       - name: Upload JUnit report
         if: always()


### PR DESCRIPTION
Tests are flaky! https://pelicanplatform.org/developer-zone/test-failures/

Let's attempt to rerun them automatically so that we can avoid having the manually do so.

This adds the commands to the test actions to rerun the tests and move code coverage outputs to the coverage action to prevent false reporting when reruns must be performed.