### PR TITLE
Clarify issuer token lifetime knobs

### DIFF
--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -4017,6 +4017,8 @@ components: ["origin", "registry", "cache", "director"]
 name: Issuer.AccessTokenLifetime
 description: |+
   Lifetime of access tokens issued by the embedded OAuth2 issuer.
+
+  Only takes effect when Origin.IssuerMode is set to "embedded".
 type: duration
 default: 1h
 hidden: true
@@ -4026,6 +4028,8 @@ name: Issuer.AuthorizationCodeLifetime
 description: |+
   Lifetime of authorization codes and device codes issued by the
   embedded OAuth2 issuer.
+
+  Only takes effect when Origin.IssuerMode is set to "embedded".
 type: duration
 default: 10m
 hidden: true
@@ -4034,6 +4038,8 @@ components: ["origin"]
 name: Issuer.IDTokenLifetime
 description: |+
   Lifetime of ID tokens issued by the embedded OAuth2 issuer.
+
+  Only takes effect when Origin.IssuerMode is set to "embedded".
 type: duration
 default: 1h
 hidden: true
@@ -4052,6 +4058,8 @@ components: ["origin"]
 name: Issuer.RefreshTokenLifetime
 description: |+
   Lifetime of refresh tokens issued by the embedded OAuth2 issuer.
+
+  Only takes effect when Origin.IssuerMode is set to "embedded".
 type: duration
 default: 168h
 hidden: true

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1407,7 +1407,7 @@ name: Origin.IssuerMode
 description: |+
   Select the issuer implementation to use when Origin.EnableIssuer is true.
   "embedded" uses the fosite-based OIDC provider built directly into Pelican,
-  which requires no external processes. This is under canary testing and 
+  which requires no external processes. This is under canary testing and
   is expected to become the default in a future release.
   "oa4mp" uses the external Java-based OA4MP issuer (legacy, will be deprecated in a future release).
   When switching between modes, state is not migrated between the two databases.

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1406,13 +1406,17 @@ components: ["origin"]
 name: Origin.IssuerMode
 description: |+
   Select the issuer implementation to use when Origin.EnableIssuer is true.
-  "embedded" uses the built-in fosite-based OIDC provider which requires
-  no external processes (default).
-  "oa4mp" uses the external Java-based OA4MP issuer (legacy).
+  "embedded" uses the fosite-based OIDC provider built directly into Pelican,
+  which requires no external processes. This is under canary testing and 
+  is expected to become the default in a future release.
+  "oa4mp" uses the external Java-based OA4MP issuer (legacy, will be deprecated in a future release).
   When switching between modes, state is not migrated between the two databases.
+
+  Note: the Issuer.AccessTokenLifetime, Issuer.AuthorizationCodeLifetime,
+  Issuer.IDTokenLifetime, and Issuer.RefreshTokenLifetime settings only take
+  effect when this is set to "embedded".
 type: string
 default: "oa4mp"
-hidden: true
 components: ["origin"]
 ---
 name: Origin.ScitokensRestrictedPaths

--- a/launchers/origin_serve.go
+++ b/launchers/origin_serve.go
@@ -25,6 +25,7 @@ import (
 	_ "embed"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -32,6 +33,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/daemon"
 	"github.com/pelicanplatform/pelican/database"
 	"github.com/pelicanplatform/pelican/launcher_utils"
@@ -137,6 +139,7 @@ func OriginServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, 
 				return nil, errors.Wrap(err, "failed to configure embedded OIDC issuer")
 			}
 		case "oa4mp":
+			warnUnusedIssuerLifetimesKnobs()
 			oa4mpRouterGroup := baseAPIGroup.Group("/issuer")
 			if err = oa4mp.RegisterOA4MPProxy(oa4mpRouterGroup); err != nil {
 				return nil, err
@@ -299,6 +302,39 @@ func OriginServeFinish(ctx context.Context, egrp *errgroup.Group, engine *gin.En
 	})
 
 	return nil
+}
+
+// warnUnusedIssuerLifetimesKnobs logs a warning when an origin admin
+// explicitly configured one of the embedded-issuer token lifetime knobs
+// while running with Origin.IssuerMode set to "oa4mp". Those knobs only
+// affect the fosite-based "embedded" issuer; they are silently ignored
+// by the external OA4MP issuer.
+func warnUnusedIssuerLifetimesKnobs() {
+	lifetimeParams := []param.DurationParam{
+		param.Issuer_AccessTokenLifetime,
+		param.Issuer_AuthorizationCodeLifetime,
+		param.Issuer_IDTokenLifetime,
+		param.Issuer_RefreshTokenLifetime,
+	}
+
+	var explicitlySet []string
+	for _, p := range lifetimeParams {
+		// SourceTracker (rather than a plain zero-value check) is used to tell a
+		// user-supplied value apart from the parameter's own default, since the
+		// default is also loaded into viper and would otherwise look identical to
+		// an explicit setting.
+		src, hasSrc := config.GetSourceTracker().Get(strings.ToLower(p.GetName()))
+		if hasSrc && src.Type != config.SourceDefault {
+			explicitlySet = append(explicitlySet, p.GetName())
+		}
+	}
+
+	if len(explicitlySet) > 0 {
+		log.Warnf("The following embedded-issuer token lifetime settings are configured but will have "+
+			"no effect because Origin.IssuerMode is \"oa4mp\": %s. These settings only apply when "+
+			"Origin.IssuerMode is set to \"embedded\"; the external OA4MP issuer manages its own token "+
+			"lifetimes independently.", strings.Join(explicitlySet, ", "))
+	}
 }
 
 // configureEmbeddedIssuer initializes the fosite-based embedded OIDC issuer,


### PR DESCRIPTION
This PR:

1. Correct the description of Origin.IssuerMode param and unhide it
2. Warn the origin admin if they misconfigures 

This PR needs to backport to 7.26