### PR TITLE
Issuer cors addition

### DIFF
--- a/launchers/origin_serve.go
+++ b/launchers/origin_serve.go
@@ -122,10 +122,14 @@ func OriginServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, 
 	// When the director is co-located, it registers the root-level OIDC
 	// metadata (/.well-known/).  The origin registers its own copy under
 	// /api/v1.0/origin so its issuer URL is distinct from the
-	// federation's.  The standalone-origin case is handled by the
-	// root-level RegisterOIDCAPI call below.
+	// federation's.  On a standalone origin, nothing else provides the
+	// root-level metadata, so register it here -- notably, the embedded
+	// issuer's discovery document points its jwks_uri at the root-level
+	// /.well-known/issuer.jwks.
 	if modules.IsEnabled(server_structs.DirectorType) {
 		server_utils.RegisterOIDCAPI(engine.Group("/api/v1.0/origin", web_ui.ServerHeaderMiddleware), false)
+	} else {
+		server_utils.RegisterOIDCAPI(engine.Group("/", web_ui.ServerHeaderMiddleware), false)
 	}
 
 	// Configure the issuer (OA4MP proxy or embedded fosite) if enabled

--- a/oauth2/issuer/handlers.go
+++ b/oauth2/issuer/handlers.go
@@ -80,8 +80,12 @@ func ServiceURIForNamespace(issuerURL, namespace string) string {
 // Routes are registered under /api/v1.0/issuer/ns/*namespace so that each
 // federation namespace gets its own OIDC issuer with isolated clients and tokens.
 func RegisterRoutesWithMiddleware(engine *gin.Engine, registry *ProviderRegistry, middleware ...gin.HandlerFunc) {
-	// Combine the caller's middleware with the namespace-resolution middleware.
-	allMiddleware := append(middleware, NamespaceMiddleware(registry))
+	// corsMiddleware runs first so that CORS headers (and preflight responses)
+	// are produced even when a later middleware or handler aborts. It is
+	// followed by the caller's middleware and the namespace-resolution
+	// middleware.
+	allMiddleware := append([]gin.HandlerFunc{corsMiddleware}, middleware...)
+	allMiddleware = append(allMiddleware, NamespaceMiddleware(registry))
 	issuerGroup := engine.Group("/api/v1.0/issuer/ns", allMiddleware...)
 	{
 		// Gin's wildcard parameter captures everything after /ns, e.g.
@@ -92,6 +96,10 @@ func RegisterRoutesWithMiddleware(engine *gin.Engine, registry *ProviderRegistry
 		issuerGroup.GET("/*namespace", handleDispatch)
 		issuerGroup.PUT("/*namespace", handleDispatchPut)
 		issuerGroup.DELETE("/*namespace", handleDispatchDelete)
+		// Register OPTIONS so browser CORS preflights are routed through the
+		// group middleware; corsMiddleware answers them and aborts before this
+		// handler runs.
+		issuerGroup.OPTIONS("/*namespace", func(ctx *gin.Context) {})
 	}
 }
 
@@ -200,6 +208,15 @@ func handleIssuerDiscovery(provider *OIDCProvider) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		issuerURL := IssuerURLForNamespace(provider.Namespace)
 		serviceURI := ServiceURIForNamespace(IssuerURL(), provider.Namespace)
+
+		// The discovery document is public, non-sensitive metadata, so any
+		// browser origin may read it (matching the server-level discovery
+		// endpoint in server_utils/oidc.go). This is set here rather than in
+		// corsMiddleware so that only the genuinely-dispatched discovery
+		// action gets the wildcard -- other credentialed endpoints can be
+		// reached via URLs that also end in the discovery suffix (e.g. a
+		// client-configuration read for an id ending in ".well-known/...").
+		ctx.Header("Access-Control-Allow-Origin", "*")
 
 		ctx.JSON(http.StatusOK, gin.H{
 			"issuer":                        issuerURL,

--- a/oauth2/issuer/integration_test.go
+++ b/oauth2/issuer/integration_test.go
@@ -453,6 +453,120 @@ func TestIntegrationIssuerDiscovery(t *testing.T) {
 	assert.Equal(t, "ES256", algs[0], "discovery signing algorithm should match actual ECDSA P-256 key")
 }
 
+// TestIntegrationCORSHeaders verifies that browser-based applications can read
+// the issuer endpoints cross-origin: the public discovery document is readable
+// from any origin, while the credentialed endpoints only accept origins that
+// are registered in Issuer.RedirectUris.
+func TestIntegrationCORSHeaders(t *testing.T) {
+	_, ts := setupIntegration(t)
+	httpClient := ts.Client()
+
+	const browserOrigin = "https://app.example.com"
+	require.NoError(t, param.Issuer_RedirectUris.Set([]string{browserOrigin + "/callback"}))
+
+	discoveryURL := ts.URL + "/api/v1.0/issuer/ns/test/ns/.well-known/openid-configuration"
+	tokenURL := ts.URL + "/api/v1.0/issuer/ns/test/ns/token"
+
+	t.Run("discovery is readable from any origin", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, discoveryURL, nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "https://some-unregistered-site.example.org")
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("discovery preflight is allowed from any origin", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodOptions, discoveryURL, nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "https://some-unregistered-site.example.org")
+		req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("preflight from a registered origin is allowed", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodOptions, tokenURL, nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", browserOrigin)
+		req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+		assert.Equal(t, browserOrigin, resp.Header.Get("Access-Control-Allow-Origin"))
+		assert.Contains(t, resp.Header.Get("Access-Control-Allow-Methods"), "POST")
+		assert.Equal(t, "Origin", resp.Header.Get("Vary"),
+			"allowed responses vary by Origin, so caches must not share them across sites")
+	})
+
+	t.Run("preflight from an unregistered origin gets no allow-origin", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodOptions, tokenURL, nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "https://evil.example.org")
+		req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+		assert.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
+		assert.Equal(t, "Origin", resp.Header.Get("Vary"),
+			"denied responses also vary by Origin, so caches must not serve them to allowed sites")
+	})
+
+	t.Run("actual response from a registered origin echoes the origin", func(t *testing.T) {
+		// A failed token request still carries the CORS headers: the
+		// middleware runs before the handler, so the browser can read the
+		// OAuth error body (per RFC 6749 error responses are part of the
+		// protocol) instead of masking it as an opaque network error.
+		req, err := http.NewRequest(http.MethodPost, tokenURL,
+			strings.NewReader("grant_type=authorization_code"))
+		require.NoError(t, err)
+		req.Header.Set("Origin", browserOrigin)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, browserOrigin, resp.Header.Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("origin matching is case-insensitive in scheme and host", func(t *testing.T) {
+		require.NoError(t, param.Issuer_RedirectUris.Set([]string{"HTTPS://Mixed-Case.Example.COM/callback"}))
+		t.Cleanup(func() {
+			require.NoError(t, param.Issuer_RedirectUris.Set([]string{browserOrigin + "/callback"}))
+		})
+		// Browsers normalize the Origin header to lowercase.
+		req, err := http.NewRequest(http.MethodOptions, tokenURL, nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "https://mixed-case.example.com")
+		req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, "https://mixed-case.example.com", resp.Header.Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("credentialed path ending in the discovery suffix is not wildcarded", func(t *testing.T) {
+		// GET oidc-cm/<id> is a credentialed RFC 7592 client-configuration
+		// read, and <id> is attacker-controlled -- an id ending in
+		// ".well-known/openid-configuration" must not inherit the discovery
+		// document's allow-any-origin response header.
+		craftedURL := ts.URL + "/api/v1.0/issuer/ns/test/ns/oidc-cm/x" + "/.well-known/openid-configuration"
+		req, err := http.NewRequest(http.MethodGet, craftedURL, nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "https://evil.example.org")
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
+	})
+}
+
 func TestIntegrationTokenIntrospection(t *testing.T) {
 	provider, ts := setupIntegration(t)
 	httpClient := ts.Client()

--- a/oauth2/issuer/middleware.go
+++ b/oauth2/issuer/middleware.go
@@ -1,0 +1,96 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package issuer
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/pelicanplatform/pelican/param"
+)
+
+// oidcDiscoverySuffix is the path suffix of the per-namespace OIDC discovery
+// document, which is public, non-sensitive metadata.
+const oidcDiscoverySuffix = "/.well-known/openid-configuration"
+
+// corsMiddleware lets browser-based applications read the embedded issuer's
+// endpoints cross-origin. It follows the two CORS conventions already used
+// elsewhere in Pelican:
+//
+//   - The OIDC discovery document is public, non-sensitive metadata, so any
+//     origin may read it (Access-Control-Allow-Origin: *), matching the
+//     server-level discovery endpoint in server_utils/oidc.go. Because the
+//     namespace is not yet resolved when this middleware runs, a URL path
+//     ending in the discovery suffix may still dispatch to a different,
+//     credentialed handler (e.g. oidc-cm/<id>/.well-known/openid-configuration
+//     is a client-configuration read); the wildcard on the *response* is
+//     therefore set by handleIssuerDiscovery itself, and this middleware only
+//     approves the wildcard for the discovery-suffix *preflight*, which by
+//     itself grants no access to response data.
+//   - The credentialed endpoints (token, userinfo, introspection, ...) echo
+//     the request's Origin back only when it is one of the configured
+//     Issuer.RedirectUris, matching the OA4MP proxy in oa4mp/proxy.go, so
+//     untrusted sites cannot script them.
+//
+// It also answers CORS preflight (OPTIONS) requests directly, since the
+// dispatch handlers only cover GET/POST/PUT/DELETE.
+func corsMiddleware(ctx *gin.Context) {
+	origin := ctx.Request.Header.Get("Origin")
+	if origin != "" {
+		// All responses here depend on the request's Origin header, so caches
+		// must not reuse one site's response (allowed or denied) for another.
+		ctx.Header("Vary", "Origin")
+		if ctx.Request.Method == http.MethodOptions && strings.HasSuffix(ctx.Request.URL.Path, oidcDiscoverySuffix) {
+			ctx.Header("Access-Control-Allow-Origin", "*")
+		} else if isRegisteredOrigin(origin) {
+			ctx.Header("Access-Control-Allow-Origin", origin)
+		}
+		ctx.Header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+		ctx.Header("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, Authorization")
+	}
+
+	// Short-circuit preflight requests so they do not fall through to
+	// namespace resolution or the dispatch handlers.
+	if ctx.Request.Method == http.MethodOptions {
+		ctx.AbortWithStatus(http.StatusNoContent)
+	}
+}
+
+// isRegisteredOrigin reports whether the given browser Origin (scheme://host)
+// matches the scheme and host of one of the configured Issuer.RedirectUris.
+// Scheme and host are compared case-insensitively per RFC 3986 (browsers
+// normalize the Origin header to lowercase, but the configured redirect URIs
+// may use any case).
+func isRegisteredOrigin(origin string) bool {
+	for _, uri := range param.Issuer_RedirectUris.GetStringSlice() {
+		parsed, err := url.Parse(uri)
+		if err != nil {
+			log.Warningf("Skipping malformed Issuer.RedirectUris entry %q while evaluating CORS: %v", uri, err)
+			continue
+		}
+		if parsed.Scheme != "" && parsed.Host != "" && strings.EqualFold(parsed.Scheme+"://"+parsed.Host, origin) {
+			return true
+		}
+	}
+	return false
+}

--- a/server_utils/oidc.go
+++ b/server_utils/oidc.go
@@ -184,6 +184,12 @@ func exportIssuerJWKS(ctx *gin.Context) {
 		// Append a new line to the JSON data
 		jsonData = append(jsonData, '\n')
 		ctx.Header("Content-Disposition", "attachment; filename=public-signing-key.jwks")
+		// The public JWKS must be readable cross-origin: browser-based OIDC
+		// clients follow the discovery document's jwks_uri here to validate
+		// token signatures. The discovery endpoint above already allows any
+		// origin; without the same header on the JWKS, those clients fail on
+		// the very next fetch.
+		ctx.Header("Access-Control-Allow-Origin", "*")
 		ctx.Data(200, "application/json", jsonData)
 	}
 }

--- a/server_utils/oidc_test.go
+++ b/server_utils/oidc_test.go
@@ -180,6 +180,30 @@ Server:
 		assert.Empty(t, resp.DeviceEndpoint, "No device endpoint when issuer disabled")
 	})
 
+	t.Run("JWKSReadableCrossOrigin", func(t *testing.T) {
+		ResetTestState()
+		defer ResetTestState()
+
+		// Point key generation at a temp dir so GetIssuerPublicJWKS succeeds.
+		require.NoError(t, param.IssuerKeysDirectory.Set(t.TempDir()))
+
+		router := gin.New()
+		group := router.Group("")
+		RegisterOIDCAPI(group, false)
+
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/.well-known/issuer.jwks", nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "https://app.example.com")
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		// Browser-based OIDC clients follow the discovery document's jwks_uri
+		// here to validate token signatures, so the public JWKS must be
+		// readable from any origin like the discovery document itself.
+		assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+	})
+
 	t.Run("OA4MPModeLegacyPaths", func(t *testing.T) {
 		ResetTestState()
 		defer ResetTestState()


### PR DESCRIPTION
Add CORS headers to the embedded issuer in the same capacity that they are in the OA4MP issuer.

General practice is that I should be able to hit the endpoints and metadata that are attached from anywhere in the web so that I can complete the OAuth flows prescribed within.