### PR TITLE
Mitigate frontend build OOM (exit 137) in constrained containers

### DIFF
--- a/web_ui/frontend/next.config.js
+++ b/web_ui/frontend/next.config.js
@@ -1,9 +1,14 @@
 /** @type {import('next').NextConfig} */
+const path = require('path');
+
 let nextConfig = {
   output: 'export',
   basePath: '/view',
   trailingSlash: true,
   images: { unoptimized: true },
+  // Pin tracing root to this app so Next.js does not walk the monorepo
+  // (wrong root causes huge memory use and OOM / exit 137 in dev containers).
+  outputFileTracingRoot: path.join(__dirname),
 };
 
 const withBundleAnalyzer = require('@next/bundle-analyzer')({


### PR DESCRIPTION
The Next.js webUI frontend build gets OOM-killed (exit 137) on memory-constrained local dev containers. To mitigate this, this PR lowers memory demand by:

- Pin Next.js tracing root (next.config.js)
Set outputFileTracingRoot to the frontend app directory. Next.js otherwise picks a tracing root by walking up for lockfiles; with stray package-lock.json stubs and a monorepo-like layout it can select a root high in the tree and then trace/scan an enormous file set, ballooning memory. Pinning the root stops the walk.

I also tried a few other approaches (e.g. Cap V8's old-space heap by adding `WEB_BUILD_NODE_OPTIONS ?= --max-old-space-size=2048` in `Makefile`). This one plays the most crucial role. It's reliable for local build, Github CI and the release build run.

Closes #3556 