### PR TITLE
Update to node 26

### DIFF
--- a/.github/workflows/coverage-scheduled.yml
+++ b/.github/workflows/coverage-scheduled.yml
@@ -35,6 +35,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # actions/setup-node downloads its own Node.js binary, which (as of
+      # Node 24) dynamically links libatomic.so.1. The AlmaLinux-based container
+      # image may not ship it yet, so install it before setup-node runs Node.
+      # TODO: remove once the pelican-test image includes libatomic.
+      - name: Install libatomic (Node.js >= 24 runtime dependency)
+        run: dnf install -y libatomic
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -43,6 +43,13 @@ jobs:
         with:
           fetch-depth: 0  # GoReleaser needs history to look up the previous tag, and so on
 
+      # actions/setup-node downloads its own Node.js binary, which (as of
+      # Node 24) dynamically links libatomic.so.1. The AlmaLinux-based container
+      # image may not ship it yet, so install it before setup-node runs Node.
+      # TODO: remove once the pelican-test image includes libatomic.
+      - name: Install libatomic (Node.js >= 24 runtime dependency)
+        run: dnf install -y libatomic
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test-webui-e2e.yml
+++ b/.github/workflows/test-webui-e2e.yml
@@ -32,6 +32,13 @@ jobs:
         with:
           fetch-depth: 0  # GoReleaser needs tag history
 
+      # actions/setup-node downloads its own Node.js binary, which (as of
+      # Node 24) dynamically links libatomic.so.1. The pelican-dev image may
+      # not ship it yet, so install it before setup-node runs Node.
+      # TODO: remove once the pelican-dev image includes libatomic.
+      - name: Install libatomic (Node.js >= 24 runtime dependency)
+        run: dnf install -y libatomic
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
@@ -99,6 +106,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+
+      # actions/setup-node downloads its own Node.js binary, which (as of
+      # Node 24) dynamically links libatomic.so.1. The pelican-dev image may
+      # not ship it yet, so install it before setup-node runs Node.
+      # TODO: remove once the pelican-dev image includes libatomic.
+      - name: Install libatomic (Node.js >= 24 runtime dependency)
+        run: dnf install -y libatomic
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -161,8 +161,11 @@ RUN --mount=type=bind,source=go.mod,target=/context/go.mod \
   # We use npm to bootstrap the installation of the required Node.js version
   # and an updated version of npm itself. The `dnf remove` in the middle is to
   # avoid there being multiple, incompatible versions of npm.
+  #
+  # libatomic is a runtime dependency of the Node.js >= 24 binaries; the
+  # minimal AlmaLinux base image does not include it, so install it explicitly.
 
-  dnf install -y npm
+  dnf install -y libatomic npm
   npm install -g n
   n $(jq < /context/package.json -r .engines.node)
   dnf remove -y npm
@@ -837,8 +840,11 @@ RUN --mount=type=bind,source=go.mod,target=/context/go.mod \
   # We use npm to bootstrap the installation of the required Node.js version
   # and an updated version of npm itself. The `dnf remove` in the middle is to
   # avoid there being multiple, incompatible versions of npm.
+  #
+  # libatomic is a runtime dependency of the Node.js >= 24 binaries; the
+  # minimal AlmaLinux base image does not include it, so install it explicitly.
 
-  dnf install -y npm
+  dnf install -y libatomic npm
   npm install -g n
   n $(jq < /context/package.json -r .engines.node)
   dnf remove -y npm

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -284,10 +284,16 @@ RUN --mount=type=bind,source=images/pelican.yaml,target=/context/pelican.yaml \
 
   # Install common software.
 
+  # NOTE: libatomic is a runtime dependency of the Node.js >= 24 binaries.
+  # It is needed both by the Node.js that later stages install via `n` and by
+  # the Node.js that `actions/setup-node` downloads when CI jobs run inside
+  # images derived from this base. Installing it here covers every descendant
+  # image (test, dev, origin, cache, central services).
   dnf install -y \
     'dnf-command(versionlock)' \
     jq \
     less \
+    libatomic \
     osg-ca-certs \
     procps \
     psmisc \
@@ -840,11 +846,10 @@ RUN --mount=type=bind,source=go.mod,target=/context/go.mod \
   # We use npm to bootstrap the installation of the required Node.js version
   # and an updated version of npm itself. The `dnf remove` in the middle is to
   # avoid there being multiple, incompatible versions of npm.
-  #
-  # libatomic is a runtime dependency of the Node.js >= 24 binaries; the
-  # minimal AlmaLinux base image does not include it, so install it explicitly.
+  # (libatomic, a runtime dependency of Node.js >= 24, is inherited from
+  # pelican-software-base.)
 
-  dnf install -y libatomic npm
+  dnf install -y npm
   npm install -g n
   n $(jq < /context/package.json -r .engines.node)
   dnf remove -y npm

--- a/web_ui/frontend/package-lock.json
+++ b/web_ui/frontend/package-lock.json
@@ -70,7 +70,7 @@
         "typescript": "5.1.6"
       },
       "engines": {
-        "node": "20"
+        "node": "26"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3988,7 +3988,6 @@
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -12545,7 +12544,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/web_ui/frontend/package.json
+++ b/web_ui/frontend/package.json
@@ -82,6 +82,6 @@
     "typescript": "5.1.6"
   },
   "engines": {
-    "node": "20"
+    "node": "26"
   }
 }


### PR DESCRIPTION
Should be a easy review. I updated the build to use node 26. Very minimal changes in the package-lock.json.

Did have to add a new package to the build images which is a dependency of node >= 24. So that the tests pass here I rigged in some code to download that new dep before each of the actions. That can be taken out in the next release, I can make a ticket for that if this is approved.

Sorts out this issue in a roundabout way. 

https://github.com/PelicanPlatform/pelican/actions/runs/29164730320/job/86575788515?pr=2970

Instead of capping the npm version being downloaded lets just update node to match the latest version of npm.