### PR TITLE
Default off origin tlsclientauth

### DIFF
--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -538,10 +538,12 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 	v.SetDefault(param.Origin_EnablePublicReads.GetName(), false)
 	// Origin.EnableReads
 	v.SetDefault(param.Origin_EnableReads.GetName(), true)
+	// Origin.EnableTLSClientAuth
+	v.SetDefault(param.Origin_EnableTLSClientAuth.GetName(), false)
 	// Origin.EnableTransferAPI
 	v.SetDefault(param.Origin_EnableTransferAPI.GetName(), false)
 	// Origin.EnableVoms
-	v.SetDefault(param.Origin_EnableVoms.GetName(), true)
+	v.SetDefault(param.Origin_EnableVoms.GetName(), false)
 	// Origin.EnableWrites
 	v.SetDefault(param.Origin_EnableWrites.GetName(), true)
 	// Origin.FedTokenLocation

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1542,8 +1542,25 @@ description: |+
   present X.509 client credentials in order to authenticate.  The configuration
   of the authorization for these clients must be done by the admin; Pelican
   does not support automatic VOMS authorization configuration.
+
+  This relies on the client presenting a certificate during the TLS handshake,
+  so Origin.EnableTLSClientAuth must also be set to true for VOMS authentication
+  to function.
 type: bool
-default: true
+default: false
+components: ["origin"]
+---
+name: Origin.EnableTLSClientAuth
+description: |+
+  Turns client certificate authentication on or off in xrootd for the HTTPS protocol. When false (default) the
+  origin will never request a TLS client certificate. When true, the origin will always request
+  a client certificate from the client.
+
+  Note that X.509/VOMS-based authentication (see Origin.EnableVoms) relies on the client presenting
+  a certificate during the TLS handshake; if the origin should authenticate clients via VOMS,
+  this parameter must be set to true.
+type: bool
+default: false
 components: ["origin"]
 ---
 name: Origin.EnableDirListing
@@ -2567,6 +2584,10 @@ description: |+
   to present X.509 client credentials in order to authenticate.  The configuration
   of the authorization for these clients must be done by the admin; Pelican
   does not support automatic VOMS authorization configuration.
+
+  This relies on the client presenting a certificate during the TLS handshake,
+  so Cache.EnableTLSClientAuth must also be set to true for VOMS authentication
+  to function.
 type: bool
 default: false
 components: ["cache"]

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1553,7 +1553,7 @@ components: ["origin"]
 name: Origin.EnableTLSClientAuth
 description: |+
   Turns client certificate authentication on or off in xrootd for the HTTPS protocol. When false (default) the
-  origin will never request a TLS client certificate. When true, the origin will always request
+  origin will never request a TLS client certificate. When true, the origin will sometimes request
   a client certificate from the client.
 
   Note that X.509/VOMS-based authentication (see Origin.EnableVoms) relies on the client presenting

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -345,6 +345,7 @@ var runtimeConfigurableMap = map[string]bool{
 	"Origin.EnableOIDC": false,
 	"Origin.EnablePublicReads": false,
 	"Origin.EnableReads": false,
+	"Origin.EnableTLSClientAuth": false,
 	"Origin.EnableTransferAPI": false,
 	"Origin.EnableVoms": false,
 	"Origin.EnableWrite": false,
@@ -1059,6 +1060,7 @@ var boolAccessors = map[string]func(*Config) bool{
 	"Origin.EnableOIDC": func(c *Config) bool { return c.Origin.EnableOIDC },
 	"Origin.EnablePublicReads": func(c *Config) bool { return c.Origin.EnablePublicReads },
 	"Origin.EnableReads": func(c *Config) bool { return c.Origin.EnableReads },
+	"Origin.EnableTLSClientAuth": func(c *Config) bool { return c.Origin.EnableTLSClientAuth },
 	"Origin.EnableTransferAPI": func(c *Config) bool { return c.Origin.EnableTransferAPI },
 	"Origin.EnableVoms": func(c *Config) bool { return c.Origin.EnableVoms },
 	"Origin.EnableWrite": func(c *Config) bool { return c.Origin.EnableWrite },
@@ -1536,6 +1538,7 @@ var allParameterNames = []string{
 	"Origin.EnableOIDC",
 	"Origin.EnablePublicReads",
 	"Origin.EnableReads",
+	"Origin.EnableTLSClientAuth",
 	"Origin.EnableTransferAPI",
 	"Origin.EnableVoms",
 	"Origin.EnableWrite",
@@ -2102,6 +2105,7 @@ var (
 	Origin_EnableOIDC = BoolParam{"Origin.EnableOIDC"}
 	Origin_EnablePublicReads = BoolParam{"Origin.EnablePublicReads"}
 	Origin_EnableReads = BoolParam{"Origin.EnableReads"}
+	Origin_EnableTLSClientAuth = BoolParam{"Origin.EnableTLSClientAuth"}
 	Origin_EnableTransferAPI = BoolParam{"Origin.EnableTransferAPI"}
 	Origin_EnableVoms = BoolParam{"Origin.EnableVoms"}
 	Origin_EnableWrite = BoolParam{"Origin.EnableWrite"}
@@ -2584,6 +2588,7 @@ func init() {
 		"Origin.EnableOIDC": Origin_EnableOIDC,
 		"Origin.EnablePublicReads": Origin_EnablePublicReads,
 		"Origin.EnableReads": Origin_EnableReads,
+		"Origin.EnableTLSClientAuth": Origin_EnableTLSClientAuth,
 		"Origin.EnableTransferAPI": Origin_EnableTransferAPI,
 		"Origin.EnableVoms": Origin_EnableVoms,
 		"Origin.EnableWrite": Origin_EnableWrite,

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -303,6 +303,7 @@ type Config struct {
 		EnableOIDC bool `mapstructure:"enableoidc" yaml:"EnableOIDC"`
 		EnablePublicReads bool `mapstructure:"enablepublicreads" yaml:"EnablePublicReads"`
 		EnableReads bool `mapstructure:"enablereads" yaml:"EnableReads"`
+		EnableTLSClientAuth bool `mapstructure:"enabletlsclientauth" yaml:"EnableTLSClientAuth"`
 		EnableTransferAPI bool `mapstructure:"enabletransferapi" yaml:"EnableTransferAPI"`
 		EnableVoms bool `mapstructure:"enablevoms" yaml:"EnableVoms"`
 		EnableWrite bool `mapstructure:"enablewrite" yaml:"EnableWrite"`
@@ -821,6 +822,7 @@ type configWithType struct {
 		EnableOIDC struct { Type string; Value bool }
 		EnablePublicReads struct { Type string; Value bool }
 		EnableReads struct { Type string; Value bool }
+		EnableTLSClientAuth struct { Type string; Value bool }
 		EnableTransferAPI struct { Type string; Value bool }
 		EnableVoms struct { Type string; Value bool }
 		EnableWrite struct { Type string; Value bool }

--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -28,6 +28,7 @@ xrd.tlsca certdir {{.Server.TLSCACertificateDirectory}}
 {{- else}}
 xrd.tlsca certfile {{.Server.TLSCACertificateFile}}
 {{- end}}
+http.tlsclientauth {{if .Origin.EnableTLSClientAuth -}} on {{else}} off {{- end -}}
 {{- if eq .Origin.EnableListings false}}
 http.listingdeny true
 {{- end}}

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -108,6 +108,7 @@ type (
 		EnableTPC           bool
 		AllowNonPublicTPC   bool
 		EnableAtomicUploads bool
+		EnableTLSClientAuth bool
 		SelfTest            bool
 		MonitoringPrefix    string
 		Concurrency         int
@@ -1260,6 +1261,16 @@ func ConfigXrootd(ctx context.Context, isOrigin bool) (string, error) {
 			}
 		}
 		xrdConfig.Cache.LotmanCfg = lotmanCfg
+
+		// VOMS authentication relies on the client presenting an X.509 certificate
+		// during the TLS handshake, which only happens when TLS client auth is
+		// requested. Enabling VOMS without TLS client auth yields a non-functional
+		// setup: the cache never asks for a client certificate, so VOMS has nothing
+		// to extract.
+		if xrdConfig.Cache.EnableVoms && !xrdConfig.Cache.EnableTLSClientAuth {
+			return "", errors.Errorf("%s is enabled but %s is disabled; VOMS/X.509 client authentication cannot function because the cache will not request a client certificate. Set %s to true, or disable %s.",
+				param.Cache_EnableVoms.GetName(), param.Cache_EnableTLSClientAuth.GetName(), param.Cache_EnableTLSClientAuth.GetName(), param.Cache_EnableVoms.GetName())
+		}
 	}
 
 	// To make sure we get the correct exports, we overwrite the exports in the xrdConfig struct with the exports
@@ -1311,6 +1322,16 @@ func ConfigXrootd(ctx context.Context, isOrigin bool) (string, error) {
 					xrdConfig.Origin.GlobusTransferTokenFile = globusExports[0].TransferTokenFile
 				}
 			}
+		}
+
+		// VOMS authentication relies on the client presenting an X.509 certificate
+		// during the TLS handshake, which only happens when TLS client auth is
+		// requested. Enabling VOMS without TLS client auth yields a non-functional
+		// setup: the origin never asks for a client certificate, so VOMS has nothing
+		// to extract.
+		if xrdConfig.Origin.EnableVoms && !xrdConfig.Origin.EnableTLSClientAuth {
+			return "", errors.Errorf("%s is enabled but %s is disabled; VOMS/X.509 client authentication cannot function because the origin will not request a client certificate. Set %s to true, or disable %s.",
+				param.Origin_EnableVoms.GetName(), param.Origin_EnableTLSClientAuth.GetName(), param.Origin_EnableTLSClientAuth.GetName(), param.Origin_EnableVoms.GetName())
 		}
 	}
 

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -208,6 +208,40 @@ func TestXrootDOriginConfig(t *testing.T) {
 
 		server_utils.ResetTestState()
 	})
+
+	// VOMS requires TLS client auth to request a client certificate; enabling VOMS
+	// without it is a non-functional setup and must be rejected.
+	t.Run("TestOriginVomsWithoutTLSClientAuthErrors", func(t *testing.T) {
+		defer server_utils.ResetTestState()
+		setupXrootd(t, ctx, server_structs.OriginType, egrp)
+
+		require.NoError(t, param.Origin_EnableVoms.Set(true))
+		require.NoError(t, param.Origin_EnableTLSClientAuth.Set(false))
+
+		_, err := ConfigXrootd(ctx, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), param.Origin_EnableTLSClientAuth.GetName())
+	})
+
+	t.Run("TestOriginTLSClientAuthRendering", func(t *testing.T) {
+		defer server_utils.ResetTestState()
+		setupXrootd(t, ctx, server_structs.OriginType, egrp)
+
+		// Off by default
+		configPath, err := ConfigXrootd(ctx, true)
+		require.NoError(t, err)
+		content, err := os.ReadFile(configPath)
+		require.NoError(t, err)
+		assert.Regexp(t, `http\.tlsclientauth\s+off`, string(content))
+
+		// On when enabled
+		require.NoError(t, param.Origin_EnableTLSClientAuth.Set(true))
+		configPath, err = ConfigXrootd(ctx, true)
+		require.NoError(t, err)
+		content, err = os.ReadFile(configPath)
+		require.NoError(t, err)
+		assert.Regexp(t, `http\.tlsclientauth\s+on`, string(content))
+	})
 }
 
 func TestShouldEnableTPC(t *testing.T) {
@@ -363,6 +397,40 @@ func TestXrootDCacheConfig(t *testing.T) {
 		err = CheckCacheXrootdEnv(cache, uid, gid)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "Please ensure these directories are not nested.")
+	})
+
+	// VOMS requires TLS client auth to request a client certificate; enabling VOMS
+	// without it is a non-functional setup and must be rejected.
+	t.Run("TestCacheVomsWithoutTLSClientAuthErrors", func(t *testing.T) {
+		defer server_utils.ResetTestState()
+		setupXrootd(t, ctx, server_structs.CacheType, egrp)
+
+		require.NoError(t, param.Cache_EnableVoms.Set(true))
+		require.NoError(t, param.Cache_EnableTLSClientAuth.Set(false))
+
+		_, err := ConfigXrootd(ctx, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), param.Cache_EnableTLSClientAuth.GetName())
+	})
+
+	t.Run("TestCacheTLSClientAuthRendering", func(t *testing.T) {
+		defer server_utils.ResetTestState()
+		setupXrootd(t, ctx, server_structs.CacheType, egrp)
+
+		// Off by default
+		configPath, err := ConfigXrootd(ctx, false)
+		require.NoError(t, err)
+		content, err := os.ReadFile(configPath)
+		require.NoError(t, err)
+		assert.Regexp(t, `http\.tlsclientauth\s+off`, string(content))
+
+		// On when enabled
+		require.NoError(t, param.Cache_EnableTLSClientAuth.Set(true))
+		configPath, err = ConfigXrootd(ctx, false)
+		require.NoError(t, err)
+		content, err = os.ReadFile(configPath)
+		require.NoError(t, err)
+		assert.Regexp(t, `http\.tlsclientauth\s+on`, string(content))
 	})
 }
 


### PR DESCRIPTION
Turns off `http.tlsclientauth` in Xrootd Origin's by default.

Copy what we had from the Cache to the Origin to remove the annoying pop-ups when PROPFIND hits the Origin in the web client.

I tested locally by turning it off and on in the configuration and checking if Xrootd would request a certificate from the client.