### PR TITLE
Per-namespace IssuerJwks for the embedded OAuth2 issuer

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2915,6 +2915,10 @@ func ResetConfig() {
 	// Clear out director's ad cache
 	ClearServerAds()
 
+	// Clear cached JWKS file contents so a test that writes a new file at a
+	// path an earlier test used does not see the earlier projection
+	ResetJWKSFileCache()
+
 	// Reset federation metadata
 	resetFedDiscoveryOnce()
 	globalFedInfo.Store(&pelican_url.FederationDiscovery{})

--- a/config/configtest/jwks.go
+++ b/config/configtest/jwks.go
@@ -1,0 +1,46 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Package configtest provides shared test helpers for packages that
+// cannot import test_utils without creating an import cycle with config.
+package configtest
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/stretchr/testify/require"
+)
+
+// WriteJWKSFile serializes keys into a JWKS JSON file at dir/name
+// and returns the full path. Fails the test on any error.
+func WriteJWKSFile(t testing.TB, dir, name string, keys ...jwk.Key) string {
+	t.Helper()
+	set := jwk.NewSet()
+	for _, k := range keys {
+		require.NoError(t, set.AddKey(k))
+	}
+	data, err := json.Marshal(set)
+	require.NoError(t, err)
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, data, 0600))
+	return path
+}

--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -19,6 +19,7 @@
 package config
 
 import (
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -973,29 +974,34 @@ func loadIssuerPrivateKey(issuerKeysDir string) (jwk.Key, error) {
 // Helper function to load the issuer/server's public key for other servers
 // to verify the token signed by this server. Only intended to be called internally
 //
+// As a side effect, when no issuer private key is available (neither in memory
+// nor on disk) and neither existingJWKS nor keyPathOverridePEM is supplied, this
+// generates and persists a new private key under issuerKeysDir before returning
+// its public projection.
+//
 // The `keyPathOverridePEM` parameter is used to override the default locations by
 // providing a PEM file path.
 func loadIssuerPublicJWKS(existingJWKS string, issuerKeysDir string, keyPathOverridePEM ...string) (jwk.Set, error) {
 	jwks := jwk.NewSet()
 	if existingJWKS != "" {
-		var err error
-		jwks, err = jwk.ReadFile(existingJWKS)
+		raw, err := jwk.ReadFile(existingJWKS)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to read issuer JWKS file")
+		}
+		jwks, err = stripPrivateKeys(raw)
+		if err != nil {
+			return nil, errors.Wrap(err, "issuer JWKS file contains invalid keys")
 		}
 	} else if len(keyPathOverridePEM) > 0 && keyPathOverridePEM[0] != "" {
 		key, err := LoadSinglePEM(keyPathOverridePEM[0])
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to load signing key from %s", keyPathOverridePEM[0])
 		}
-		pkey, err := jwk.PublicKeyOf(key)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to generate public key from key %s", key.KeyID())
+		src := jwk.NewSet()
+		if err := src.AddKey(key); err != nil {
+			return nil, errors.Wrapf(err, "failed to add signing key %s to set", key.KeyID())
 		}
-		if err = jwks.AddKey(pkey); err != nil {
-			return nil, errors.Wrapf(err, "failed to add public key %s to new JWKS", key.KeyID())
-		}
-		return jwks, nil
+		return stripPrivateKeys(src)
 	}
 
 	keys := GetIssuerPrivateKeys()
@@ -1010,16 +1016,21 @@ func loadIssuerPublicJWKS(existingJWKS string, issuerKeysDir string, keyPathOver
 		keys = GetIssuerPrivateKeys()
 	}
 
-	// Traverse all private keys and add their public keys to the JWKS
+	// Project all private keys' public halves and merge them into the JWKS.
+	src := jwk.NewSet()
 	for _, key := range keys {
-		pkey, err := jwk.PublicKeyOf(key)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to generate public key from key %s", key.KeyID())
+		if err := src.AddKey(key); err != nil {
+			return nil, errors.Wrapf(err, "failed to add private key %s to set", key.KeyID())
 		}
-
-		if err = jwks.AddKey(pkey); err != nil {
-			return nil, errors.Wrapf(err, "failed to add public key %s to new JWKS", key.KeyID())
-		}
+	}
+	projected, err := stripPrivateKeys(src)
+	if err != nil {
+		return nil, err
+	}
+	if err := ForEachKey(projected, func(k jwk.Key) error {
+		return errors.Wrap(jwks.AddKey(k), "failed to add public key to JWKS")
+	}); err != nil {
+		return nil, err
 	}
 	return jwks, nil
 }
@@ -1059,14 +1070,87 @@ func GetIssuerPrivateJWK(keyPathOverridePEM ...string) (jwk.Key, error) {
 	return (*keysPtr).CurrentKey, nil
 }
 
-// Check if a valid JWKS file exists at Server_IssuerJwks, return that file if so;
-// otherwise, generate and store a private key at IssuerKey and return a public key of
-// that private key, encapsulated in the JWKS format
+// ForEachKey invokes fn once per key in set, in iteration order. If fn
+// returns a non-nil error, iteration stops and that error is returned to
+// the caller. It centralizes the jwk.Set iteration idiom (including the
+// key type assertion and context handling) so callers need not repeat it.
+func ForEachKey(set jwk.Set, fn func(jwk.Key) error) error {
+	ctx := context.Background()
+	for it := set.Keys(ctx); it.Next(ctx); {
+		if err := fn(it.Pair().Value.(jwk.Key)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ProjectPublicJWKS returns a new set containing the public projection of
+// every key in set, with all private key material removed via jwk.PublicKeyOf.
+// A key is unpublishable when it is symmetric (kty=oct, a shared secret with
+// no public projection) or when projection otherwise fails. For each such key,
+// onKeyError is invoked with the offending key and the reason: returning a
+// non-nil error aborts and is propagated to the caller; returning nil skips
+// the key and continues. The returned set contains only the keys that were
+// successfully projected.
 //
-// The private key generated is loaded to issuerPrivateJWK variable which is used for
-// this server to sign JWTs it issues. The public key returned will be exposed publicly
-// for other servers to verify JWTs signed by this server, typically via a well-known URL
-// i.e. "/.well-known/issuer.jwks"
+// This is the single source of truth for public-JWKS projection; callers
+// supply the abort-vs-skip policy via onKeyError.
+func ProjectPublicJWKS(set jwk.Set, onKeyError func(key jwk.Key, err error) error) (jwk.Set, error) {
+	out := jwk.NewSet()
+	if err := ForEachKey(set, func(k jwk.Key) error {
+		var perr error
+		if k.KeyType() == jwa.OctetSeq {
+			perr = errors.New(
+				"symmetric key (kty=oct) is a secret and cannot be published")
+		} else if pub, err := jwk.PublicKeyOf(k); err != nil {
+			perr = errors.Wrap(err, "failed to extract public key")
+		} else if err := out.AddKey(pub); err != nil {
+			perr = errors.Wrap(err, "failed to add public key to set")
+		}
+		if perr != nil {
+			return onKeyError(k, perr)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// stripPrivateKeys returns a sanitized copy of set suitable for serving on a
+// public JWKS endpoint. Every asymmetric key is replaced by its public
+// projection via jwk.PublicKeyOf, stripping any private key material.
+// Symmetric (kty=oct) keys are a shared secret with no public projection, so
+// publishing one would leak it; any such key is rejected as an error.
+//
+// It delegates to ProjectPublicJWKS with a hard-error policy: these are the
+// server's own trusted keys, so any unpublishable key is a fatal error rather
+// than something to skip past.
+func stripPrivateKeys(set jwk.Set) (jwk.Set, error) {
+	return ProjectPublicJWKS(set, func(_ jwk.Key, err error) error {
+		return err
+	})
+}
+
+// ReadPublicJWKSFile reads the JWKS file at path and returns a new set
+// containing only the public projection of each key. Symmetric (kty=oct)
+// keys are rejected. Private key material is stripped via jwk.PublicKeyOf.
+// This is the canonical way to load an operator-supplied key file for use
+// in a public JWKS endpoint.
+func ReadPublicJWKSFile(path string) (jwk.Set, error) {
+	raw, err := jwk.ReadFile(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read JWKS file %s", path)
+	}
+	out, err := stripPrivateKeys(raw)
+	if err != nil {
+		return nil, errors.Wrapf(err, "JWKS file %s is invalid", path)
+	}
+	return out, nil
+}
+
+// GetIssuerPublicJWKS returns the full server-level public JWKS.
+// See loadIssuerPublicJWKS for details on what keys are included.
 //
 // The `keyPathOverridePEM` parameter is used to override the default locations by
 // providing a PEM file path.
@@ -1074,6 +1158,107 @@ func GetIssuerPublicJWKS(keyPathOverridePEM ...string) (jwk.Set, error) {
 	existingJWKS := param.Server_IssuerJwks.GetString()
 	issuerKeysDir := param.IssuerKeysDirectory.GetString()
 	return loadIssuerPublicJWKS(existingJWKS, issuerKeysDir, keyPathOverridePEM...)
+}
+
+// GetIssuerPublicJWKSForNamespace returns the public JWKS for a per-namespace
+// issuer endpoint. It starts with the server's exported public key set (see
+// GetIssuerPublicJWKS) and appends any additional public keys read from
+// extraJwksPath. When extraJwksPath is empty the result is identical to
+// GetIssuerPublicJWKS.
+//
+// The base key set and the optional extra file fail independently. A failure
+// to load the base set is always returned as an error: there is no correct
+// subset left to serve. A failure to read or merge the extra file (unreadable
+// or corrupt file, a symmetric key, or a kid that collides with an already-
+// published key) is instead routed through onExtraError, which owns the
+// abort-vs-degrade policy: returning nil degrades to the base-only set;
+// returning a non-nil error propagates it. The extra file is optional and
+// operator-supplied, so a serve-time caller passes a policy that logs and
+// degrades rather than dropping the server's own valid keys.
+//
+// The extra file is merged all-or-nothing: it is fully validated before any
+// of its keys are added, so a degrade yields exactly the base set, never a
+// partially-merged set.
+func GetIssuerPublicJWKSForNamespace(extraJwksPath string, onExtraError func(error) error) (jwk.Set, error) {
+	base, err := GetIssuerPublicJWKS()
+	if err != nil {
+		return nil, err
+	}
+	// GetIssuerPublicJWKS builds a fresh set on every call, so with no extra
+	// keys to merge we can return it directly without a per-request copy.
+	if extraJwksPath == "" {
+		return base, nil
+	}
+	extraKeys, mergeErr := collectMergeableExtraKeys(base, extraJwksPath)
+	if mergeErr != nil {
+		if err := onExtraError(mergeErr); err != nil {
+			return nil, err
+		}
+		// Degrade: serve the base keys without the extra file's keys.
+		return base, nil
+	}
+	// Build a fresh set so that the merged keys cannot alias the base set and
+	// affect other callers (e.g., if GetIssuerPublicJWKS is ever changed to
+	// cache its result). collectMergeableExtraKeys never mutates base.
+	result := jwk.NewSet()
+	if err := ForEachKey(base, func(k jwk.Key) error {
+		return errors.Wrap(result.AddKey(k),
+			"failed to copy base key into namespace JWKS")
+	}); err != nil {
+		return nil, err
+	}
+	for _, k := range extraKeys {
+		if err := result.AddKey(k); err != nil {
+			return nil, errors.Wrap(err,
+				"failed to merge per-namespace key into JWKS")
+		}
+	}
+	return result, nil
+}
+
+// collectMergeableExtraKeys reads the JWKS file at extraJwksPath, strips any
+// private key material, and returns its keys after verifying that every key
+// carrying a kid has a kid unique against base and against the other extra
+// keys. It never mutates base; the caller merges the returned keys only once
+// the whole file has validated, which keeps the merge all-or-nothing.
+func collectMergeableExtraKeys(base jwk.Set, extraJwksPath string) ([]jwk.Key, error) {
+	extra, err := ReadPublicJWKSFile(extraJwksPath)
+	if err != nil {
+		return nil, err
+	}
+	// Seed the seen-kid set with the base keys so a collision against either
+	// the server's public key set or an earlier key in the extra file itself
+	// is caught the same way.
+	seen := make(map[string]bool)
+	_ = ForEachKey(base, func(k jwk.Key) error {
+		if kid := k.KeyID(); kid != "" {
+			seen[kid] = true
+		}
+		return nil
+	})
+	keys := make([]jwk.Key, 0, extra.Len())
+	if err := ForEachKey(extra, func(k jwk.Key) error {
+		// Only keys carrying a kid are checked for uniqueness. Keyless
+		// entries are still merged into and published in the namespace
+		// JWKS, and verifiers may try them for tokens with no matching kid,
+		// so they are not inert. The check is skipped for them only because
+		// there is no kid to compare, not because they are unusable.
+		if kid := k.KeyID(); kid != "" {
+			if seen[kid] {
+				return errors.Errorf(
+					"per-namespace JWKS file %s: key kid %q conflicts with"+
+						" another published key; each published key that"+
+						" carries a kid must have a unique kid",
+					extraJwksPath, kid)
+			}
+			seen[kid] = true
+		}
+		keys = append(keys, k)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return keys, nil
 }
 
 // Check if there is a session secret exists at param.Server_SessionSecretFile and is not empty if there is one.

--- a/config/init_server_creds.go
+++ b/config/init_server_creds.go
@@ -38,6 +38,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -984,13 +986,22 @@ func loadIssuerPrivateKey(issuerKeysDir string) (jwk.Key, error) {
 func loadIssuerPublicJWKS(existingJWKS string, issuerKeysDir string, keyPathOverridePEM ...string) (jwk.Set, error) {
 	jwks := jwk.NewSet()
 	if existingJWKS != "" {
-		raw, err := jwk.ReadFile(existingJWKS)
+		// This function is on the request path of every public JWKS endpoint,
+		// so go through the shared reader: bounded, throttled to one read per
+		// few seconds, permission-checked, and tolerant of a torn read while
+		// the file is being rewritten.
+		//
+		// The set the reader returns is shared and must not be mutated, and
+		// the private-key loop below adds to jwks, so copy it into a set of
+		// our own.
+		fileKeys, err := ReadPublicJWKSFile(existingJWKS)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to read issuer JWKS file")
 		}
-		jwks, err = stripPrivateKeys(raw)
-		if err != nil {
-			return nil, errors.Wrap(err, "issuer JWKS file contains invalid keys")
+		if err := ForEachKey(fileKeys, func(k jwk.Key) error {
+			return errors.Wrap(jwks.AddKey(k), "failed to add key from issuer JWKS file")
+		}); err != nil {
+			return nil, err
 		}
 	} else if len(keyPathOverridePEM) > 0 && keyPathOverridePEM[0] != "" {
 		key, err := LoadSinglePEM(keyPathOverridePEM[0])
@@ -1132,21 +1143,16 @@ func stripPrivateKeys(set jwk.Set) (jwk.Set, error) {
 	})
 }
 
-// ReadPublicJWKSFile reads the JWKS file at path and returns a new set
-// containing only the public projection of each key. Symmetric (kty=oct)
-// keys are rejected. Private key material is stripped via jwk.PublicKeyOf.
-// This is the canonical way to load an operator-supplied key file for use
-// in a public JWKS endpoint.
+// ReadPublicJWKSFile returns the public projection of every key in the JWKS
+// file at path. Symmetric (kty=oct) keys are rejected. Private key material is
+// stripped via jwk.PublicKeyOf. This is the canonical way to load an
+// operator-supplied key file for use in a public JWKS endpoint.
+//
+// Reads are bounded, throttled, and fall back to the last good contents on a
+// torn read; see readPublicJWKSFileCached for the details and for the
+// read-only contract on the returned set.
 func ReadPublicJWKSFile(path string) (jwk.Set, error) {
-	raw, err := jwk.ReadFile(path)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to read JWKS file %s", path)
-	}
-	out, err := stripPrivateKeys(raw)
-	if err != nil {
-		return nil, errors.Wrapf(err, "JWKS file %s is invalid", path)
-	}
-	return out, nil
+	return readPublicJWKSFileCached(path)
 }
 
 // GetIssuerPublicJWKS returns the full server-level public JWKS.
@@ -1166,15 +1172,21 @@ func GetIssuerPublicJWKS(keyPathOverridePEM ...string) (jwk.Set, error) {
 // extraJwksPath. When extraJwksPath is empty the result is identical to
 // GetIssuerPublicJWKS.
 //
+// A kid present in both the extra file and the base set is an override, not a
+// conflict: the per-namespace file is the more specific configuration, so its
+// key is published and the base key carrying that kid is not published for
+// this namespace. The override is logged, because it also means tokens signed
+// by the server's own key with that kid stop verifying here.
+//
 // The base key set and the optional extra file fail independently. A failure
 // to load the base set is always returned as an error: there is no correct
 // subset left to serve. A failure to read or merge the extra file (unreadable
-// or corrupt file, a symmetric key, or a kid that collides with an already-
-// published key) is instead routed through onExtraError, which owns the
-// abort-vs-degrade policy: returning nil degrades to the base-only set;
-// returning a non-nil error propagates it. The extra file is optional and
-// operator-supplied, so a serve-time caller passes a policy that logs and
-// degrades rather than dropping the server's own valid keys.
+// or corrupt file, a symmetric key, or one kid used twice within the file) is
+// instead routed through onExtraError, which owns the abort-vs-degrade policy:
+// returning nil degrades to the base-only set; returning a non-nil error
+// propagates it. The extra file is optional and operator-supplied, so a
+// serve-time caller passes a policy that logs and degrades rather than
+// dropping the server's own valid keys.
 //
 // The extra file is merged all-or-nothing: it is fully validated before any
 // of its keys are added, so a degrade yields exactly the base set, never a
@@ -1189,7 +1201,7 @@ func GetIssuerPublicJWKSForNamespace(extraJwksPath string, onExtraError func(err
 	if extraJwksPath == "" {
 		return base, nil
 	}
-	extraKeys, mergeErr := collectMergeableExtraKeys(base, extraJwksPath)
+	extraKeys, overridden, mergeErr := collectMergeableExtraKeys(base, extraJwksPath)
 	if mergeErr != nil {
 		if err := onExtraError(mergeErr); err != nil {
 			return nil, err
@@ -1197,11 +1209,29 @@ func GetIssuerPublicJWKSForNamespace(extraJwksPath string, onExtraError func(err
 		// Degrade: serve the base keys without the extra file's keys.
 		return base, nil
 	}
-	// Build a fresh set so that the merged keys cannot alias the base set and
-	// affect other callers (e.g., if GetIssuerPublicJWKS is ever changed to
-	// cache its result). collectMergeableExtraKeys never mutates base.
+	if len(overridden) > 0 {
+		kids := make([]string, 0, len(overridden))
+		for kid := range overridden {
+			kids = append(kids, kid)
+		}
+		sort.Strings(kids)
+		joined := strings.Join(kids, ", ")
+		logJWKSWarningOnChange(extraJwksPath, "kid-override", joined,
+			"Per-namespace JWKS file %s republishes kid(s) %s, which the server's own key "+
+				"set also publishes. The per-namespace key wins: the server's key with that "+
+				"kid is not published for this namespace, so tokens this server signed with "+
+				"it will no longer verify here. Give the per-namespace key a distinct kid if "+
+				"that was not intended.", extraJwksPath, joined)
+	}
+	// Build a fresh set so that the merged keys cannot alias the base set or
+	// the read cache's set and affect other callers.
+	// collectMergeableExtraKeys never mutates base.
 	result := jwk.NewSet()
 	if err := ForEachKey(base, func(k jwk.Key) error {
+		if kid := k.KeyID(); kid != "" && overridden[kid] {
+			// Superseded by the per-namespace key carrying the same kid.
+			return nil
+		}
 		return errors.Wrap(result.AddKey(k),
 			"failed to copy base key into namespace JWKS")
 	}); err != nil {
@@ -1217,48 +1247,55 @@ func GetIssuerPublicJWKSForNamespace(extraJwksPath string, onExtraError func(err
 }
 
 // collectMergeableExtraKeys reads the JWKS file at extraJwksPath, strips any
-// private key material, and returns its keys after verifying that every key
-// carrying a kid has a kid unique against base and against the other extra
-// keys. It never mutates base; the caller merges the returned keys only once
-// the whole file has validated, which keeps the merge all-or-nothing.
-func collectMergeableExtraKeys(base jwk.Set, extraJwksPath string) ([]jwk.Key, error) {
+// private key material, and returns its keys along with the set of kids that
+// the file takes over from base.
+//
+// Two kinds of kid reuse are treated differently. One kid used twice within
+// the extra file is an error: neither key is more specific than the other, so
+// there is no defensible way to pick a winner, and rejecting the file is
+// better than publishing an ambiguous set. A kid shared between the extra file
+// and base is an override: the per-namespace file is the more specific
+// configuration, so it wins and the colliding base kid is reported in
+// overridden for the caller to drop and log.
+//
+// It never mutates base; the caller merges the returned keys only once the
+// whole file has validated, which keeps the merge all-or-nothing.
+func collectMergeableExtraKeys(base jwk.Set, extraJwksPath string) (keys []jwk.Key, overridden map[string]bool, err error) {
 	extra, err := ReadPublicJWKSFile(extraJwksPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	// Seed the seen-kid set with the base keys so a collision against either
-	// the server's public key set or an earlier key in the extra file itself
-	// is caught the same way.
-	seen := make(map[string]bool)
-	_ = ForEachKey(base, func(k jwk.Key) error {
-		if kid := k.KeyID(); kid != "" {
-			seen[kid] = true
-		}
-		return nil
-	})
-	keys := make([]jwk.Key, 0, extra.Len())
+	claimed := make(map[string]bool)
+	keys = make([]jwk.Key, 0, extra.Len())
 	if err := ForEachKey(extra, func(k jwk.Key) error {
-		// Only keys carrying a kid are checked for uniqueness. Keyless
-		// entries are still merged into and published in the namespace
-		// JWKS, and verifiers may try them for tokens with no matching kid,
-		// so they are not inert. The check is skipped for them only because
-		// there is no kid to compare, not because they are unusable.
+		// Only keys carrying a kid are checked. Keyless entries are still
+		// merged into and published in the namespace JWKS, and verifiers may
+		// try them for tokens with no matching kid, so they are not inert.
+		// The check is skipped for them only because there is no kid to
+		// compare, not because they are unusable.
 		if kid := k.KeyID(); kid != "" {
-			if seen[kid] {
+			if claimed[kid] {
 				return errors.Errorf(
-					"per-namespace JWKS file %s: key kid %q conflicts with"+
-						" another published key; each published key that"+
-						" carries a kid must have a unique kid",
+					"per-namespace JWKS file %s: kid %q appears more than once"+
+						" in the same file; each key in the file that carries a"+
+						" kid must have a unique kid",
 					extraJwksPath, kid)
 			}
-			seen[kid] = true
+			claimed[kid] = true
 		}
 		keys = append(keys, k)
 		return nil
 	}); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return keys, nil
+	overridden = make(map[string]bool)
+	_ = ForEachKey(base, func(k jwk.Key) error {
+		if kid := k.KeyID(); kid != "" && claimed[kid] {
+			overridden[kid] = true
+		}
+		return nil
+	})
+	return keys, overridden, nil
 }
 
 // Check if there is a session secret exists at param.Server_SessionSecretFile and is not empty if there is one.

--- a/config/init_server_creds_test.go
+++ b/config/init_server_creds_test.go
@@ -24,6 +24,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"os"
 	"path/filepath"
@@ -35,6 +36,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pelicanplatform/pelican/config/configtest"
 	"github.com/pelicanplatform/pelican/param"
 )
 
@@ -514,5 +516,402 @@ func TestLoadSinglePEMAlgorithm(t *testing.T) {
 		key, err := LoadSinglePEM(keyFile)
 		require.NoError(t, err)
 		assert.Equal(t, jwa.KeyAlgorithmFrom(jwa.RS256), key.Algorithm())
+	})
+}
+
+// TestGetIssuerPublicJWKSForNamespace verifies the per-namespace JWKS helper:
+// empty path returns the server key set unchanged, a valid extra JWKS file
+// causes its keys to be merged in, and a missing or invalid file yields
+// an error.
+func TestGetIssuerPublicJWKSForNamespace(t *testing.T) {
+	t.Run("empty path returns server keys", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		tmpDir := t.TempDir()
+		require.NoError(t, param.IssuerKey.Set(filepath.Join(tmpDir, "issuer.jwk")))
+
+		base, err := GetIssuerPublicJWKS()
+		require.NoError(t, err)
+		got, err := GetIssuerPublicJWKSForNamespace("", strictExtra)
+		require.NoError(t, err)
+
+		// Should contain exactly the same key IDs.
+		baseKIDs := collectKIDs(t, base)
+		gotKIDs := collectKIDs(t, got)
+		assert.ElementsMatch(t, baseKIDs, gotKIDs)
+	})
+
+	t.Run("non-existent path returns error", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		tmpDir := t.TempDir()
+		require.NoError(t, param.IssuerKey.Set(filepath.Join(tmpDir, "issuer.jwk")))
+
+		_, err := GetIssuerPublicJWKSForNamespace("/nonexistent/path/extra.jwks", strictExtra)
+		require.Error(t, err)
+	})
+
+	t.Run("valid extra JWKS merges keys", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		tmpDir := t.TempDir()
+		require.NoError(t, param.IssuerKey.Set(filepath.Join(tmpDir, "issuer.jwk")))
+
+		extraPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		extraPub, err := jwk.FromRaw(extraPriv.PublicKey)
+		require.NoError(t, err)
+		require.NoError(t, extraPub.Set(jwk.KeyIDKey, "extra-test-key-merge"))
+		extraPath := configtest.WriteJWKSFile(t, tmpDir, "extra.jwks", extraPub)
+
+		base, err := GetIssuerPublicJWKS()
+		require.NoError(t, err)
+		got, err := GetIssuerPublicJWKSForNamespace(extraPath, strictExtra)
+		require.NoError(t, err)
+
+		// Result should have one more key than the base set.
+		assert.Equal(t, base.Len()+1, got.Len())
+
+		// The extra key's ID should be present.
+		gotKIDs := collectKIDs(t, got)
+		assert.Contains(t, gotKIDs, "extra-test-key-merge")
+	})
+
+	t.Run("private key in file strips private material", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		tmpDir := t.TempDir()
+		require.NoError(t, param.IssuerKey.Set(filepath.Join(tmpDir, "issuer.jwk")))
+
+		// Write a JWKS containing a private EC key (not just the public part).
+		privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		privJWK, err := jwk.FromRaw(privKey)
+		require.NoError(t, err)
+		require.NoError(t, privJWK.Set(jwk.KeyIDKey, "priv-key-should-become-public"))
+		privPath := configtest.WriteJWKSFile(t, tmpDir, "private.jwks", privJWK)
+
+		got, err := GetIssuerPublicJWKSForNamespace(privPath, strictExtra)
+		require.NoError(t, err)
+
+		// The key should be present, but only as its public projection:
+		// a public EC key has no "d" (private scalar) field.
+		rawJSON, err := json.Marshal(got)
+		require.NoError(t, err)
+		assert.NotContains(t, string(rawJSON), `"d":`,
+			"private key material must not be present in the JWKS response")
+		gotKIDs := collectKIDs(t, got)
+		assert.Contains(t, gotKIDs, "priv-key-should-become-public")
+	})
+
+	t.Run("symmetric key is rejected", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		tmpDir := t.TempDir()
+		require.NoError(t, param.IssuerKey.Set(filepath.Join(tmpDir, "issuer.jwk")))
+
+		symKey, err := jwk.FromRaw(make([]byte, 32))
+		require.NoError(t, err)
+		symPath := configtest.WriteJWKSFile(t, tmpDir, "sym.jwks", symKey)
+
+		_, err = GetIssuerPublicJWKSForNamespace(symPath, strictExtra)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "symmetric")
+	})
+
+	t.Run("duplicate kid is rejected", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		tmpDir := t.TempDir()
+		require.NoError(t, param.IssuerKey.Set(filepath.Join(tmpDir, "issuer.jwk")))
+
+		// Get the server's existing kid to use as a collision.
+		base, err := GetIssuerPublicJWKS()
+		require.NoError(t, err)
+		require.Positive(t, base.Len(), "expected at least one server key")
+
+		it := base.Keys(t.Context())
+		require.True(t, it.Next(t.Context()))
+		serverKID := it.Pair().Value.(jwk.Key).KeyID()
+		require.NotEmpty(t, serverKID, "server key should have a kid")
+
+		// Write an extra key that reuses the server's kid.
+		extraKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		extraJWK, err := jwk.FromRaw(extraKey.PublicKey)
+		require.NoError(t, err)
+		require.NoError(t, extraJWK.Set(jwk.KeyIDKey, serverKID))
+		dupPath := configtest.WriteJWKSFile(t, tmpDir, "dup.jwks", extraJWK)
+
+		_, err = GetIssuerPublicJWKSForNamespace(dupPath, strictExtra)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "conflicts")
+		assert.Contains(t, err.Error(), serverKID,
+			"the error should name the colliding kid")
+	})
+
+	t.Run("duplicate kid within the extra file is rejected", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		tmpDir := t.TempDir()
+		require.NoError(t, param.IssuerKey.Set(filepath.Join(tmpDir, "issuer.jwk")))
+
+		// Two distinct keys in the same file sharing one kid. This collides
+		// within the file, not with the server's key set.
+		const sharedKID = "dup-within-file"
+		makeKey := func() jwk.Key {
+			priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			require.NoError(t, err)
+			pub, err := jwk.FromRaw(priv.PublicKey)
+			require.NoError(t, err)
+			require.NoError(t, pub.Set(jwk.KeyIDKey, sharedKID))
+			return pub
+		}
+		dupPath := configtest.WriteJWKSFile(t, tmpDir, "dup-in-file.jwks", makeKey(), makeKey())
+
+		_, err := GetIssuerPublicJWKSForNamespace(dupPath, strictExtra)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "conflicts",
+			"an intra-file kid collision should still be reported as a conflict")
+		assert.Contains(t, err.Error(), sharedKID,
+			"the error should name the colliding kid")
+	})
+
+	t.Run("keyless extra keys are merged without a uniqueness check", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		tmpDir := t.TempDir()
+		require.NoError(t, param.IssuerKey.Set(filepath.Join(tmpDir, "issuer.jwk")))
+
+		base, err := GetIssuerPublicJWKS()
+		require.NoError(t, err)
+		baseLen := base.Len()
+
+		// Two distinct keys, neither carrying a kid. The uniqueness guard only
+		// applies to keys that carry a kid, so both are merged as-is.
+		makeKey := func() jwk.Key {
+			priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			require.NoError(t, err)
+			pub, err := jwk.FromRaw(priv.PublicKey)
+			require.NoError(t, err)
+			return pub
+		}
+		keylessPath := configtest.WriteJWKSFile(t, tmpDir, "keyless.jwks", makeKey(), makeKey())
+
+		got, err := GetIssuerPublicJWKSForNamespace(keylessPath, strictExtra)
+		require.NoError(t, err)
+		assert.Equal(t, baseLen+2, got.Len(),
+			"both keyless keys should be merged without a conflict error")
+	})
+
+	t.Run("missing file degrades to base keys when policy allows", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		tmpDir := t.TempDir()
+		require.NoError(t, param.IssuerKey.Set(filepath.Join(tmpDir, "issuer.jwk")))
+
+		base, err := GetIssuerPublicJWKS()
+		require.NoError(t, err)
+
+		var captured error
+		got, err := GetIssuerPublicJWKSForNamespace("/nonexistent/path/extra.jwks",
+			func(e error) error { captured = e; return nil })
+		require.NoError(t, err, "a degrading policy must not surface the extra-file error")
+		require.Error(t, captured, "the policy should have been handed the extra-file error")
+
+		// The result is exactly the base set: no extra keys, none dropped.
+		assert.ElementsMatch(t, collectKIDs(t, base), collectKIDs(t, got))
+	})
+
+	t.Run("kid collision degrades to base keys when policy allows", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		tmpDir := t.TempDir()
+		require.NoError(t, param.IssuerKey.Set(filepath.Join(tmpDir, "issuer.jwk")))
+
+		base, err := GetIssuerPublicJWKS()
+		require.NoError(t, err)
+		require.Positive(t, base.Len(), "expected at least one server key")
+		it := base.Keys(t.Context())
+		require.True(t, it.Next(t.Context()))
+		serverKID := it.Pair().Value.(jwk.Key).KeyID()
+
+		// An extra key that collides with a server kid. Under a degrading
+		// policy the whole extra file is dropped, never partially merged.
+		extraKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		extraJWK, err := jwk.FromRaw(extraKey.PublicKey)
+		require.NoError(t, err)
+		require.NoError(t, extraJWK.Set(jwk.KeyIDKey, serverKID))
+		dupPath := configtest.WriteJWKSFile(t, tmpDir, "dup.jwks", extraJWK)
+
+		var captured error
+		got, err := GetIssuerPublicJWKSForNamespace(dupPath,
+			func(e error) error { captured = e; return nil })
+		require.NoError(t, err)
+		require.Error(t, captured)
+		assert.ElementsMatch(t, collectKIDs(t, base), collectKIDs(t, got),
+			"a degraded result must be exactly the base set")
+	})
+}
+
+// strictExtra is the onExtraError policy that propagates any extra-file
+// failure as an error. Tests asserting the strict (non-degrading) behavior
+// pass it to GetIssuerPublicJWKSForNamespace.
+func strictExtra(e error) error { return e }
+
+// collectKIDs returns the key IDs from all keys in a jwk.Set.
+func collectKIDs(t *testing.T, s jwk.Set) []string {
+	t.Helper()
+	kids := make([]string, 0, s.Len())
+	for it := s.Keys(t.Context()); it.Next(t.Context()); {
+		kids = append(kids, it.Pair().Value.(jwk.Key).KeyID())
+	}
+	return kids
+}
+
+// TestReadPublicJWKSFile verifies the canonical JWKS-file loader directly.
+// Because ReadPublicJWKSFile enforces the security invariants used at both
+// validation time and request time, these tests confirm the contract
+// independently of the higher-level callers.
+func TestReadPublicJWKSFile(t *testing.T) {
+	t.Run("non-existent file returns error", func(t *testing.T) {
+		_, err := ReadPublicJWKSFile("/nonexistent/path/keys.jwks")
+		require.Error(t, err)
+	})
+
+	t.Run("invalid JSON returns error", func(t *testing.T) {
+		badPath := filepath.Join(t.TempDir(), "bad.jwks")
+		require.NoError(t, os.WriteFile(badPath, []byte("not json"), 0600))
+		_, err := ReadPublicJWKSFile(badPath)
+		require.Error(t, err)
+	})
+
+	t.Run("empty JWKS returns empty set", func(t *testing.T) {
+		emptyPath := configtest.WriteJWKSFile(t, t.TempDir(), "empty.jwks")
+		got, err := ReadPublicJWKSFile(emptyPath)
+		require.NoError(t, err)
+		assert.Equal(t, 0, got.Len())
+	})
+
+	t.Run("public EC key is accepted unchanged", func(t *testing.T) {
+		privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		pubJWK, err := jwk.FromRaw(privKey.PublicKey)
+		require.NoError(t, err)
+		require.NoError(t, pubJWK.Set(jwk.KeyIDKey, "pub-only-key"))
+		p := configtest.WriteJWKSFile(t, t.TempDir(), "pub.jwks", pubJWK)
+
+		got, err := ReadPublicJWKSFile(p)
+		require.NoError(t, err)
+		require.Equal(t, 1, got.Len())
+		kids := collectKIDs(t, got)
+		assert.Contains(t, kids, "pub-only-key")
+	})
+
+	t.Run("private EC key strips private material", func(t *testing.T) {
+		privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		privJWK, err := jwk.FromRaw(privKey)
+		require.NoError(t, err)
+		require.NoError(t, privJWK.Set(jwk.KeyIDKey, "private-key-stripped"))
+		p := configtest.WriteJWKSFile(t, t.TempDir(), "priv.jwks", privJWK)
+
+		got, err := ReadPublicJWKSFile(p)
+		require.NoError(t, err)
+		rawJSON, err := json.Marshal(got)
+		require.NoError(t, err)
+		assert.NotContains(t, string(rawJSON), `"d":`,
+			"private key material must be stripped")
+		kids := collectKIDs(t, got)
+		assert.Contains(t, kids, "private-key-stripped")
+	})
+
+	t.Run("symmetric key is rejected", func(t *testing.T) {
+		symKey, err := jwk.FromRaw(make([]byte, 32))
+		require.NoError(t, err)
+		p := configtest.WriteJWKSFile(t, t.TempDir(), "sym.jwks", symKey)
+
+		_, err = ReadPublicJWKSFile(p)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "symmetric")
+	})
+}
+
+// TestGetIssuerPublicJWKSWithServerIssuerJwks verifies that GetIssuerPublicJWKS
+// respects Server.IssuerJwks: private key material is stripped, and symmetric
+// keys (which are shared secrets with no public projection) are rejected so
+// they can never be published.
+func TestGetIssuerPublicJWKSWithServerIssuerJwks(t *testing.T) {
+	t.Run("private key in Server.IssuerJwks is stripped", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		tmpDir := t.TempDir()
+		require.NoError(t, param.IssuerKey.Set(filepath.Join(tmpDir, "issuer.jwk")))
+
+		privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		privJWK, err := jwk.FromRaw(privKey)
+		require.NoError(t, err)
+		require.NoError(t, privJWK.Set(jwk.KeyIDKey, "server-private-key"))
+		jwksPath := configtest.WriteJWKSFile(t, tmpDir, "server.jwks", privJWK)
+		require.NoError(t, param.Server_IssuerJwks.Set(jwksPath))
+
+		got, err := GetIssuerPublicJWKS()
+		require.NoError(t, err)
+		rawJSON, err := json.Marshal(got)
+		require.NoError(t, err)
+		assert.NotContains(t, string(rawJSON), `"d":`,
+			"private key material must not appear in the server JWKS")
+		kids := collectKIDs(t, got)
+		assert.Contains(t, kids, "server-private-key")
+	})
+
+	t.Run("symmetric key in Server.IssuerJwks is rejected", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		tmpDir := t.TempDir()
+		require.NoError(t, param.IssuerKey.Set(filepath.Join(tmpDir, "issuer.jwk")))
+
+		symKey, err := jwk.FromRaw(make([]byte, 32))
+		require.NoError(t, err)
+		require.NoError(t, symKey.Set(jwk.KeyIDKey, "server-sym-key"))
+		jwksPath := configtest.WriteJWKSFile(t, tmpDir, "server.jwks", symKey)
+		require.NoError(t, param.Server_IssuerJwks.Set(jwksPath))
+
+		_, err = GetIssuerPublicJWKS()
+		require.Error(t, err,
+			"a symmetric key in Server.IssuerJwks must not be publishable")
+		assert.Contains(t, err.Error(), "symmetric")
+	})
+
+	// A symmetric key held among the in-memory issuer private keys must be
+	// rejected too, exercising the private-keys loop in loadIssuerPublicJWKS
+	// (no Server.IssuerJwks and no PEM override), not just the file branch.
+	t.Run("symmetric key among issuer private keys is rejected", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		symKey, err := jwk.FromRaw(make([]byte, 32))
+		require.NoError(t, err)
+		require.NoError(t, symKey.Set(jwk.KeyIDKey, "issuer-sym-key"))
+		setIssuerKey(symKey)
+
+		_, err = GetIssuerPublicJWKS()
+		require.Error(t, err,
+			"a symmetric issuer private key must not be publishable")
+		assert.Contains(t, err.Error(), "symmetric")
 	})
 }

--- a/config/init_server_creds_test.go
+++ b/config/init_server_creds_test.go
@@ -624,36 +624,105 @@ func TestGetIssuerPublicJWKSForNamespace(t *testing.T) {
 		assert.Contains(t, err.Error(), "symmetric")
 	})
 
-	t.Run("duplicate kid is rejected", func(t *testing.T) {
+	t.Run("shared kid overrides the base key", func(t *testing.T) {
 		ResetConfig()
 		t.Cleanup(ResetConfig)
+		logged := captureLogs(t)
 
 		tmpDir := t.TempDir()
 		require.NoError(t, param.IssuerKey.Set(filepath.Join(tmpDir, "issuer.jwk")))
 
-		// Get the server's existing kid to use as a collision.
+		// Get the server's existing kid to reuse in the extra file.
 		base, err := GetIssuerPublicJWKS()
 		require.NoError(t, err)
 		require.Positive(t, base.Len(), "expected at least one server key")
 
 		it := base.Keys(t.Context())
 		require.True(t, it.Next(t.Context()))
-		serverKID := it.Pair().Value.(jwk.Key).KeyID()
+		serverKey := it.Pair().Value.(jwk.Key)
+		serverKID := serverKey.KeyID()
 		require.NotEmpty(t, serverKID, "server key should have a kid")
+		serverX, ok := serverKey.Get("x")
+		require.True(t, ok, "server EC key should carry an x coordinate")
 
-		// Write an extra key that reuses the server's kid.
+		// Write an extra key that reuses the server's kid. The per-namespace
+		// file is the more specific configuration, so its key wins.
 		extraKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		require.NoError(t, err)
 		extraJWK, err := jwk.FromRaw(extraKey.PublicKey)
 		require.NoError(t, err)
 		require.NoError(t, extraJWK.Set(jwk.KeyIDKey, serverKID))
+		extraX, ok := extraJWK.Get("x")
+		require.True(t, ok)
+		require.NotEqual(t, serverX, extraX, "the two keys must actually differ")
 		dupPath := configtest.WriteJWKSFile(t, tmpDir, "dup.jwks", extraJWK)
 
-		_, err = GetIssuerPublicJWKSForNamespace(dupPath, strictExtra)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "conflicts")
-		assert.Contains(t, err.Error(), serverKID,
-			"the error should name the colliding kid")
+		got, err := GetIssuerPublicJWKSForNamespace(dupPath, strictExtra)
+		require.NoError(t, err, "a shared kid is an override, not an error")
+
+		// Exactly one key carries the shared kid, and it is the extra file's.
+		matching := make([]jwk.Key, 0, 1)
+		require.NoError(t, ForEachKey(got, func(k jwk.Key) error {
+			if k.KeyID() == serverKID {
+				matching = append(matching, k)
+			}
+			return nil
+		}))
+		require.Len(t, matching, 1,
+			"the overridden base key must be dropped, not published alongside")
+		gotX, ok := matching[0].Get("x")
+		require.True(t, ok)
+		assert.Equal(t, extraX, gotX,
+			"the per-namespace key should win over the server's key with the same kid")
+
+		// The base set had only the one key, so the override replaced it
+		// rather than adding to it.
+		assert.Equal(t, base.Len(), got.Len(),
+			"an override should not change the number of published keys")
+
+		// Silently shadowing one of the server's own keys would be a bad
+		// surprise: tokens this origin signed with that kid stop verifying
+		// for this namespace, so the override has to be visible in the log.
+		assert.True(t, logged("republishes kid"),
+			"an override of a server key should be logged")
+		assert.True(t, logged(serverKID),
+			"the override log line should name the kid")
+	})
+
+	t.Run("shared kid overrides only the colliding base key", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		tmpDir := t.TempDir()
+		require.NoError(t, param.IssuerKey.Set(filepath.Join(tmpDir, "issuer.jwk")))
+
+		base, err := GetIssuerPublicJWKS()
+		require.NoError(t, err)
+		it := base.Keys(t.Context())
+		require.True(t, it.Next(t.Context()))
+		serverKID := it.Pair().Value.(jwk.Key).KeyID()
+
+		// One key collides with the server's kid, one does not.
+		mk := func(kid string) jwk.Key {
+			priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			require.NoError(t, err)
+			pub, err := jwk.FromRaw(priv.PublicKey)
+			require.NoError(t, err)
+			require.NoError(t, pub.Set(jwk.KeyIDKey, kid))
+			return pub
+		}
+		p := configtest.WriteJWKSFile(t, tmpDir, "mixed.jwks", mk(serverKID), mk("extra-distinct-kid"))
+
+		got, err := GetIssuerPublicJWKSForNamespace(p, strictExtra)
+		require.NoError(t, err)
+
+		kids := collectKIDs(t, got)
+		assert.Contains(t, kids, "extra-distinct-kid",
+			"a non-colliding extra key should still be merged")
+		assert.Equal(t, 1, countKID(kids, serverKID),
+			"the colliding kid should appear exactly once")
+		assert.Equal(t, base.Len()+1, got.Len(),
+			"one key overridden, one key added")
 	})
 
 	t.Run("duplicate kid within the extra file is rejected", func(t *testing.T) {
@@ -676,10 +745,13 @@ func TestGetIssuerPublicJWKSForNamespace(t *testing.T) {
 		}
 		dupPath := configtest.WriteJWKSFile(t, tmpDir, "dup-in-file.jwks", makeKey(), makeKey())
 
+		// Unlike an extra-vs-base collision, neither key here is the more
+		// specific configuration, so there is no defensible winner and the
+		// whole file is rejected.
 		_, err := GetIssuerPublicJWKSForNamespace(dupPath, strictExtra)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "conflicts",
-			"an intra-file kid collision should still be reported as a conflict")
+		assert.Contains(t, err.Error(), "appears more than once",
+			"an intra-file kid collision should still be an error")
 		assert.Contains(t, err.Error(), sharedKID,
 			"the error should name the colliding kid")
 	})
@@ -732,7 +804,7 @@ func TestGetIssuerPublicJWKSForNamespace(t *testing.T) {
 		assert.ElementsMatch(t, collectKIDs(t, base), collectKIDs(t, got))
 	})
 
-	t.Run("kid collision degrades to base keys when policy allows", func(t *testing.T) {
+	t.Run("intra-file kid collision degrades to base keys when policy allows", func(t *testing.T) {
 		ResetConfig()
 		t.Cleanup(ResetConfig)
 
@@ -742,18 +814,20 @@ func TestGetIssuerPublicJWKSForNamespace(t *testing.T) {
 		base, err := GetIssuerPublicJWKS()
 		require.NoError(t, err)
 		require.Positive(t, base.Len(), "expected at least one server key")
-		it := base.Keys(t.Context())
-		require.True(t, it.Next(t.Context()))
-		serverKID := it.Pair().Value.(jwk.Key).KeyID()
 
-		// An extra key that collides with a server kid. Under a degrading
-		// policy the whole extra file is dropped, never partially merged.
-		extraKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		require.NoError(t, err)
-		extraJWK, err := jwk.FromRaw(extraKey.PublicKey)
-		require.NoError(t, err)
-		require.NoError(t, extraJWK.Set(jwk.KeyIDKey, serverKID))
-		dupPath := configtest.WriteJWKSFile(t, tmpDir, "dup.jwks", extraJWK)
+		// Two keys in one file sharing a kid: a hard error, so under a
+		// degrading policy the whole extra file is dropped, never partially
+		// merged. (An extra-vs-base kid collision is an override instead and
+		// never reaches the degrade path.)
+		mk := func() jwk.Key {
+			priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			require.NoError(t, err)
+			pub, err := jwk.FromRaw(priv.PublicKey)
+			require.NoError(t, err)
+			require.NoError(t, pub.Set(jwk.KeyIDKey, "same-kid-twice"))
+			return pub
+		}
+		dupPath := configtest.WriteJWKSFile(t, tmpDir, "dup.jwks", mk(), mk())
 
 		var captured error
 		got, err := GetIssuerPublicJWKSForNamespace(dupPath,
@@ -778,6 +852,17 @@ func collectKIDs(t *testing.T, s jwk.Set) []string {
 		kids = append(kids, it.Pair().Value.(jwk.Key).KeyID())
 	}
 	return kids
+}
+
+// countKID returns how many entries of kids equal kid.
+func countKID(kids []string, kid string) int {
+	n := 0
+	for _, k := range kids {
+		if k == kid {
+			n++
+		}
+	}
+	return n
 }
 
 // TestReadPublicJWKSFile verifies the canonical JWKS-file loader directly.
@@ -846,6 +931,88 @@ func TestReadPublicJWKSFile(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "symmetric")
 	})
+
+	// An RSA private JWK carries its secret in p, q, dp, dq, and qi as well as
+	// d, so a projection that dropped only d would still publish enough to
+	// reconstruct the key. The other tests here exercise EC keys only and
+	// assert on the absence of the substring `"d":`, which would not catch
+	// that; this checks every private RSA parameter structurally.
+	t.Run("private RSA key strips every private parameter", func(t *testing.T) {
+		privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		privJWK, err := jwk.FromRaw(privKey)
+		require.NoError(t, err)
+		require.NoError(t, privJWK.Set(jwk.KeyIDKey, "rsa-private-key"))
+
+		// Sanity-check the fixture: the key really does carry the private
+		// parameters we expect to be stripped, so a pass cannot be vacuous.
+		for _, field := range rsaPrivateParams {
+			_, ok := privJWK.Get(field)
+			require.True(t, ok, "fixture RSA private key should carry %q", field)
+		}
+
+		p := configtest.WriteJWKSFile(t, t.TempDir(), "rsa-priv.jwks", privJWK)
+		got, err := ReadPublicJWKSFile(p)
+		require.NoError(t, err)
+		require.Equal(t, 1, got.Len())
+
+		pub, ok := got.LookupKeyID("rsa-private-key")
+		require.True(t, ok, "the key's public projection should still be served")
+		assertNoPrivateParams(t, pub, rsaPrivateParams)
+
+		// The public halves must survive, or the published key is useless.
+		for _, field := range []string{"n", "e"} {
+			_, ok := pub.Get(field)
+			assert.True(t, ok, "public RSA parameter %q must be preserved", field)
+		}
+	})
+
+	t.Run("private EC key strips its private parameter structurally", func(t *testing.T) {
+		privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		privJWK, err := jwk.FromRaw(privKey)
+		require.NoError(t, err)
+		require.NoError(t, privJWK.Set(jwk.KeyIDKey, "ec-private-key"))
+		_, ok := privJWK.Get("d")
+		require.True(t, ok, "fixture EC private key should carry d")
+
+		p := configtest.WriteJWKSFile(t, t.TempDir(), "ec-priv.jwks", privJWK)
+		got, err := ReadPublicJWKSFile(p)
+		require.NoError(t, err)
+
+		pub, ok := got.LookupKeyID("ec-private-key")
+		require.True(t, ok)
+		assertNoPrivateParams(t, pub, []string{"d"})
+		for _, field := range []string{"crv", "x", "y"} {
+			_, ok := pub.Get(field)
+			assert.True(t, ok, "public EC parameter %q must be preserved", field)
+		}
+	})
+}
+
+// rsaPrivateParams are the JWK members that carry RSA private key material.
+// Publishing any one of them leaks the key.
+var rsaPrivateParams = []string{"d", "p", "q", "dp", "dq", "qi"}
+
+// assertNoPrivateParams asserts that key carries none of the named members,
+// checking the parsed key rather than substring-matching serialized JSON so
+// that a differently-named private member cannot slip past.
+func assertNoPrivateParams(t *testing.T, key jwk.Key, fields []string) {
+	t.Helper()
+	for _, field := range fields {
+		_, ok := key.Get(field)
+		assert.False(t, ok, "published key must not carry private parameter %q", field)
+	}
+	// Belt and braces: the serialized form must not carry them either, in case
+	// a member is reachable through marshaling but not through Get.
+	raw, err := json.Marshal(key)
+	require.NoError(t, err)
+	var decoded map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	for _, field := range fields {
+		_, ok := decoded[field]
+		assert.False(t, ok, "serialized key must not carry private parameter %q", field)
+	}
 }
 
 // TestGetIssuerPublicJWKSWithServerIssuerJwks verifies that GetIssuerPublicJWKS

--- a/config/jwks_file_cache.go
+++ b/config/jwks_file_cache.go
@@ -170,16 +170,7 @@ func loadPublicJWKSFile(path string) (set jwk.Set, nonEmpty bool, err error) {
 	if !fi.Mode().IsRegular() {
 		return nil, false, errors.Errorf("JWKS file %s is not a regular file", path)
 	}
-	if perm := fi.Mode().Perm(); perm&0o002 != 0 {
-		// Every key in this file is published as trusted for its namespace, so
-		// write access to it is authority to mint accepted tokens. Warn rather
-		// than refuse: taking a namespace's keys away over a permission bit
-		// would be a worse outcome than serving them with a loud complaint.
-		logJWKSWarningOnChange(path, "world-writable", fi.Mode().Perm().String(),
-			"JWKS file %s is world-writable (mode %#o). Every key it holds is published "+
-				"as a trusted signing key, so any local user can mint tokens this server "+
-				"will accept. Restrict it to mode 0640 or tighter.", path, perm)
-	}
+	warnIfJWKSFileWorldWritable(path, fi.Mode().Perm())
 	// Check the stat size first so an oversized file is rejected without
 	// reading it at all.
 	if fi.Size() > MaxJWKSFileSize {

--- a/config/jwks_file_cache.go
+++ b/config/jwks_file_cache.go
@@ -1,0 +1,212 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package config
+
+import (
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// MaxJWKSFileSize bounds how much of an operator-supplied JWKS file is
+	// read. A JWKS holding even a few dozen RSA-4096 keys is well under this,
+	// so the limit only ever trips on a wrong path or a corrupt file, and it
+	// keeps an unauthenticated request that triggers a read from turning the
+	// file's size into the server's memory usage.
+	MaxJWKSFileSize = 1 << 20 // 1 MiB
+
+	// jwksFileCacheTTL is the minimum interval between filesystem reads of the
+	// same JWKS file. The public JWKS endpoints are unauthenticated, so without
+	// throttling every request would stat, read, parse, and project the file.
+	// Five seconds keeps an edit visible almost immediately while making the
+	// request rate irrelevant to the I/O rate.
+	jwksFileCacheTTL = 5 * time.Second
+)
+
+type jwksFileCacheEntry struct {
+	// keys is the last public projection that loaded successfully, or nil if
+	// no version of this file has ever loaded. It is retained so that a torn
+	// read of a file being rewritten in place can fall back to it.
+	keys jwk.Set
+	// err is the outcome of the most recent read attempt, or nil on success.
+	// Failures are cached alongside successes so that a persistently broken
+	// file is not re-read on every request.
+	err error
+	// checkedAt is when the most recent read attempt happened.
+	checkedAt time.Time
+}
+
+var (
+	jwksFileCacheMu sync.Mutex
+	jwksFileCache   = map[string]*jwksFileCacheEntry{}
+
+	// jwksFileCacheNow is the clock used for TTL decisions. It is a variable
+	// so that tests can advance time without sleeping.
+	jwksFileCacheNow = time.Now
+
+	jwksFileWarnMu sync.Mutex
+	// jwksFileWarnState remembers, per file path and warning kind, the last
+	// signature warned about. A misconfiguration that persists is worth one
+	// log line per change, not one per cache refresh.
+	jwksFileWarnState = map[string]map[string]string{}
+)
+
+// ResetJWKSFileCache drops all cached JWKS file contents and the record of
+// which warnings have already been logged. Called from ResetConfig so that a
+// test writing a new file at a path a previous test already used sees the new
+// contents rather than a cached projection.
+func ResetJWKSFileCache() {
+	jwksFileCacheMu.Lock()
+	jwksFileCache = map[string]*jwksFileCacheEntry{}
+	jwksFileCacheMu.Unlock()
+
+	jwksFileWarnMu.Lock()
+	jwksFileWarnState = map[string]map[string]string{}
+	jwksFileWarnMu.Unlock()
+}
+
+// logJWKSWarningOnChange logs at warning level the first time it sees
+// signature for the given path and kind, and thereafter only when signature
+// changes. Callers on a per-request path use this so that a standing
+// misconfiguration does not reprint on every cache refresh.
+func logJWKSWarningOnChange(path, kind, signature, format string, args ...interface{}) {
+	jwksFileWarnMu.Lock()
+	if byKind := jwksFileWarnState[path]; byKind != nil {
+		if prev, ok := byKind[kind]; ok && prev == signature {
+			jwksFileWarnMu.Unlock()
+			return
+		}
+	} else {
+		jwksFileWarnState[path] = map[string]string{}
+	}
+	jwksFileWarnState[path][kind] = signature
+	jwksFileWarnMu.Unlock()
+
+	log.Warnf(format, args...)
+}
+
+// readPublicJWKSFileCached returns the public projection of the JWKS file at
+// path, reading the file at most once per jwksFileCacheTTL.
+//
+// A file that exists and is non-empty but does not load -- a torn read of a
+// rewrite in progress, a corrupt document, an unpublishable key, or a file
+// past MaxJWKSFileSize -- falls back to the last version that loaded
+// successfully, if there is one, so that rewriting a key file in place cannot
+// momentarily drop a namespace's keys. A missing or zero-length file gets no
+// fallback: that is an unambiguous "these keys are gone" signal rather than a
+// transient read, and the remembered good version is discarded so a later
+// torn read cannot resurrect it.
+//
+// The returned set is shared with every other caller for the same path and
+// must be treated as read-only; callers that need to add keys must copy it
+// into a set of their own first.
+func readPublicJWKSFileCached(path string) (jwk.Set, error) {
+	jwksFileCacheMu.Lock()
+	defer jwksFileCacheMu.Unlock()
+
+	now := jwksFileCacheNow()
+	entry := jwksFileCache[path]
+	if entry != nil && now.Sub(entry.checkedAt) < jwksFileCacheTTL {
+		return entry.keys, entry.err
+	}
+
+	keys, nonEmpty, err := loadPublicJWKSFile(path)
+	if err != nil {
+		if nonEmpty && entry != nil && entry.keys != nil {
+			logJWKSWarningOnChange(path, "stale-fallback", err.Error(),
+				"JWKS file %s is present but could not be loaded; continuing to use the "+
+					"last version that loaded successfully. Until this is fixed, edits to "+
+					"the file will not take effect: %v", path, err)
+			entry.checkedAt = now
+			return entry.keys, nil
+		}
+		jwksFileCache[path] = &jwksFileCacheEntry{err: err, checkedAt: now}
+		return nil, err
+	}
+	jwksFileCache[path] = &jwksFileCacheEntry{keys: keys, checkedAt: now}
+	return keys, nil
+}
+
+// loadPublicJWKSFile reads, validates, and publicly projects the JWKS file at
+// path without consulting the cache.
+//
+// nonEmpty reports whether the file existed and held at least one byte. The
+// caller uses it to tell a file that is mid-rewrite or corrupt (worth falling
+// back to the previous contents for) from one that is missing or truncated to
+// nothing (not worth it).
+func loadPublicJWKSFile(path string) (set jwk.Set, nonEmpty bool, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, false, errors.Wrapf(err, "failed to open JWKS file %s", path)
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, false, errors.Wrapf(err, "failed to stat JWKS file %s", path)
+	}
+	if !fi.Mode().IsRegular() {
+		return nil, false, errors.Errorf("JWKS file %s is not a regular file", path)
+	}
+	if perm := fi.Mode().Perm(); perm&0o002 != 0 {
+		// Every key in this file is published as trusted for its namespace, so
+		// write access to it is authority to mint accepted tokens. Warn rather
+		// than refuse: taking a namespace's keys away over a permission bit
+		// would be a worse outcome than serving them with a loud complaint.
+		logJWKSWarningOnChange(path, "world-writable", fi.Mode().Perm().String(),
+			"JWKS file %s is world-writable (mode %#o). Every key it holds is published "+
+				"as a trusted signing key, so any local user can mint tokens this server "+
+				"will accept. Restrict it to mode 0640 or tighter.", path, perm)
+	}
+	// Check the stat size first so an oversized file is rejected without
+	// reading it at all.
+	if fi.Size() > MaxJWKSFileSize {
+		return nil, true, errors.Errorf("JWKS file %s is %d bytes, which exceeds the %d-byte limit",
+			path, fi.Size(), MaxJWKSFileSize)
+	}
+
+	// Bound the read independently of the stat above: the file may have grown
+	// between the two, and on some filesystems the reported size is a hint.
+	data, err := io.ReadAll(io.LimitReader(f, MaxJWKSFileSize+1))
+	if err != nil {
+		return nil, fi.Size() > 0, errors.Wrapf(err, "failed to read JWKS file %s", path)
+	}
+	if len(data) > MaxJWKSFileSize {
+		return nil, true, errors.Errorf("JWKS file %s exceeds the %d-byte limit", path, MaxJWKSFileSize)
+	}
+	if len(data) == 0 {
+		return nil, false, errors.Errorf("JWKS file %s is empty", path)
+	}
+
+	raw, err := jwk.Parse(data)
+	if err != nil {
+		return nil, true, errors.Wrapf(err, "failed to parse JWKS file %s", path)
+	}
+	out, err := stripPrivateKeys(raw)
+	if err != nil {
+		return nil, true, errors.Wrapf(err, "JWKS file %s is invalid", path)
+	}
+	return out, true, nil
+}

--- a/config/jwks_file_cache_test.go
+++ b/config/jwks_file_cache_test.go
@@ -1,0 +1,327 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package config
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	log "github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/config/configtest"
+)
+
+// fakeClock drives jwksFileCacheNow so TTL behavior can be tested by advancing
+// time explicitly rather than sleeping.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// useFakeClock installs a fake clock for the JWKS file cache and clears the
+// cache, restoring both when the test finishes.
+func useFakeClock(t *testing.T) *fakeClock {
+	t.Helper()
+	// A fixed, arbitrary start time; the cache only ever looks at differences.
+	clock := &fakeClock{now: time.Unix(1700000000, 0)}
+	prev := jwksFileCacheNow
+	jwksFileCacheNow = clock.Now
+	ResetJWKSFileCache()
+	t.Cleanup(func() {
+		jwksFileCacheNow = prev
+		ResetJWKSFileCache()
+	})
+	return clock
+}
+
+// newPublicJWK returns a fresh public EC key with the given kid.
+func newPublicJWK(t *testing.T, kid string) jwk.Key {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	pub, err := jwk.FromRaw(priv.PublicKey)
+	require.NoError(t, err)
+	require.NoError(t, pub.Set(jwk.KeyIDKey, kid))
+	return pub
+}
+
+// captureLogs installs a logrus test hook and returns a function that reports
+// whether any captured message contains substr.
+func captureLogs(t *testing.T) func(substr string) bool {
+	t.Helper()
+	hook := logrustest.NewLocal(log.StandardLogger())
+	prevLevel := log.GetLevel()
+	log.SetLevel(log.DebugLevel)
+	t.Cleanup(func() {
+		log.SetLevel(prevLevel)
+		hook.Reset()
+	})
+	return func(substr string) bool {
+		for _, entry := range hook.AllEntries() {
+			if strings.Contains(entry.Message, substr) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// TestJWKSFileCacheThrottlesReads verifies that the file is read at most once
+// per TTL: an edit written inside the window is not observed, and the same
+// edit is observed once the window has passed.
+func TestJWKSFileCacheThrottlesReads(t *testing.T) {
+	clock := useFakeClock(t)
+	dir := t.TempDir()
+
+	path := configtest.WriteJWKSFile(t, dir, "keys.jwks", newPublicJWK(t, "first"))
+
+	got, err := ReadPublicJWKSFile(path)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"first"}, collectKIDs(t, got))
+
+	// Rewrite the file with different contents, still inside the TTL window.
+	configtest.WriteJWKSFile(t, dir, "keys.jwks", newPublicJWK(t, "second"))
+
+	got, err = ReadPublicJWKSFile(path)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"first"}, collectKIDs(t, got),
+		"a read inside the TTL window must not hit the filesystem")
+
+	// Just short of the TTL: still cached.
+	clock.advance(jwksFileCacheTTL - time.Nanosecond)
+	got, err = ReadPublicJWKSFile(path)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"first"}, collectKIDs(t, got))
+
+	// Past the TTL: the new contents are picked up.
+	clock.advance(time.Nanosecond)
+	got, err = ReadPublicJWKSFile(path)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"second"}, collectKIDs(t, got),
+		"a read after the TTL window must observe the new contents")
+}
+
+// TestJWKSFileCacheThrottlesFailedReads verifies that a persistently broken
+// file is not re-read on every call either. Without caching the failure, an
+// unauthenticated request would drive a filesystem read every time.
+func TestJWKSFileCacheThrottlesFailedReads(t *testing.T) {
+	clock := useFakeClock(t)
+	path := filepath.Join(t.TempDir(), "missing.jwks")
+
+	_, err := ReadPublicJWKSFile(path)
+	require.Error(t, err)
+
+	// Create a valid file inside the TTL window; the cached failure stands.
+	dir := filepath.Dir(path)
+	configtest.WriteJWKSFile(t, dir, "missing.jwks", newPublicJWK(t, "appeared"))
+	_, err = ReadPublicJWKSFile(path)
+	require.Error(t, err, "a cached failure must not be retried inside the TTL window")
+
+	clock.advance(jwksFileCacheTTL)
+	got, err := ReadPublicJWKSFile(path)
+	require.NoError(t, err, "the retry after the TTL window should succeed")
+	assert.ElementsMatch(t, []string{"appeared"}, collectKIDs(t, got))
+}
+
+// TestJWKSFileCacheFallsBackOnTornRead verifies that a non-empty file which no
+// longer parses keeps serving the last version that loaded successfully. A
+// JWKS file rewritten in place can be read mid-write, and dropping a
+// namespace's keys for that instant would break token verification.
+func TestJWKSFileCacheFallsBackOnTornRead(t *testing.T) {
+	clock := useFakeClock(t)
+	logged := captureLogs(t)
+	dir := t.TempDir()
+
+	path := configtest.WriteJWKSFile(t, dir, "keys.jwks", newPublicJWK(t, "good"))
+	got, err := ReadPublicJWKSFile(path)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"good"}, collectKIDs(t, got))
+
+	// Simulate a torn read: a non-empty file holding a truncated document.
+	require.NoError(t, os.WriteFile(path, []byte(`{"keys":[{"kty":"E`), 0600))
+
+	clock.advance(jwksFileCacheTTL)
+	got, err = ReadPublicJWKSFile(path)
+	require.NoError(t, err, "a torn read must not surface as an error")
+	assert.ElementsMatch(t, []string{"good"}, collectKIDs(t, got),
+		"the last good version should still be served")
+	assert.True(t, logged("could not be loaded"),
+		"falling back to a stale version should be logged")
+
+	// Once the rewrite completes, the new contents take over.
+	configtest.WriteJWKSFile(t, dir, "keys.jwks", newPublicJWK(t, "rewritten"))
+	clock.advance(jwksFileCacheTTL)
+	got, err = ReadPublicJWKSFile(path)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"rewritten"}, collectKIDs(t, got))
+}
+
+// TestJWKSFileCacheNoFallbackForMissingOrEmpty verifies that the stale
+// fallback is scoped to non-empty files. A deleted or truncated-to-nothing
+// file is an unambiguous "these keys are gone" signal, so it must surface as
+// an error (the caller degrades to the base key set) rather than resurrecting
+// keys the operator removed.
+func TestJWKSFileCacheNoFallbackForMissingOrEmpty(t *testing.T) {
+	t.Run("emptied file", func(t *testing.T) {
+		clock := useFakeClock(t)
+		dir := t.TempDir()
+
+		path := configtest.WriteJWKSFile(t, dir, "keys.jwks", newPublicJWK(t, "good"))
+		_, err := ReadPublicJWKSFile(path)
+		require.NoError(t, err)
+
+		require.NoError(t, os.WriteFile(path, nil, 0600))
+		clock.advance(jwksFileCacheTTL)
+		_, err = ReadPublicJWKSFile(path)
+		require.Error(t, err, "an emptied file must not fall back to the previous contents")
+		assert.Contains(t, err.Error(), "empty")
+	})
+
+	t.Run("deleted file", func(t *testing.T) {
+		clock := useFakeClock(t)
+		dir := t.TempDir()
+
+		path := configtest.WriteJWKSFile(t, dir, "keys.jwks", newPublicJWK(t, "good"))
+		_, err := ReadPublicJWKSFile(path)
+		require.NoError(t, err)
+
+		require.NoError(t, os.Remove(path))
+		clock.advance(jwksFileCacheTTL)
+		_, err = ReadPublicJWKSFile(path)
+		require.Error(t, err, "a deleted file must not fall back to the previous contents")
+
+		// A later torn read must not resurrect the pre-deletion keys: the
+		// remembered good version is dropped on a hard failure.
+		require.NoError(t, os.WriteFile(path, []byte(`{"keys":[{"kty":"E`), 0600))
+		clock.advance(jwksFileCacheTTL)
+		_, err = ReadPublicJWKSFile(path)
+		require.Error(t, err,
+			"the good version from before the deletion must not come back")
+	})
+}
+
+// TestJWKSFileCacheBoundsReadSize verifies that an oversized file is rejected
+// without being read into memory.
+func TestJWKSFileCacheBoundsReadSize(t *testing.T) {
+	useFakeClock(t)
+	path := filepath.Join(t.TempDir(), "huge.jwks")
+
+	// A syntactically valid JWKS padded past the limit with whitespace, so the
+	// rejection can only be the size bound and not a parse failure.
+	body := []byte(`{"keys":[]}`)
+	padding := make([]byte, MaxJWKSFileSize+1-len(body))
+	for i := range padding {
+		padding[i] = ' '
+	}
+	require.NoError(t, os.WriteFile(path, append(body, padding...), 0600))
+
+	_, err := ReadPublicJWKSFile(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds")
+}
+
+// TestJWKSFileCacheWarnsOnWorldWritable verifies the permission check. Every
+// key in the file is published as a trusted signing key, so write access to it
+// is the authority to mint tokens the server accepts; that is worth a warning,
+// but not worth refusing to serve the namespace's keys over.
+func TestJWKSFileCacheWarnsOnWorldWritable(t *testing.T) {
+	t.Run("world-writable warns but still serves", func(t *testing.T) {
+		useFakeClock(t)
+		logged := captureLogs(t)
+		dir := t.TempDir()
+
+		path := configtest.WriteJWKSFile(t, dir, "loose.jwks", newPublicJWK(t, "loose-key"))
+		require.NoError(t, os.Chmod(path, 0666))
+
+		got, err := ReadPublicJWKSFile(path)
+		require.NoError(t, err, "a permission warning must not block the keys")
+		assert.ElementsMatch(t, []string{"loose-key"}, collectKIDs(t, got))
+		assert.True(t, logged("world-writable"),
+			"a world-writable JWKS file should be warned about")
+	})
+
+	t.Run("tightly permissioned file does not warn", func(t *testing.T) {
+		useFakeClock(t)
+		logged := captureLogs(t)
+		dir := t.TempDir()
+
+		path := configtest.WriteJWKSFile(t, dir, "tight.jwks", newPublicJWK(t, "tight-key"))
+		require.NoError(t, os.Chmod(path, 0640))
+
+		_, err := ReadPublicJWKSFile(path)
+		require.NoError(t, err)
+		assert.False(t, logged("world-writable"),
+			"a file that is not world-writable should not warn")
+	})
+}
+
+// TestJWKSFileWarningsDoNotRepeat verifies that a standing misconfiguration is
+// logged once rather than on every cache refresh. The JWKS endpoints are
+// unauthenticated and polled continuously, so a per-refresh warning would bury
+// the log.
+func TestJWKSFileWarningsDoNotRepeat(t *testing.T) {
+	clock := useFakeClock(t)
+	hook := logrustest.NewLocal(log.StandardLogger())
+	t.Cleanup(hook.Reset)
+
+	dir := t.TempDir()
+	path := configtest.WriteJWKSFile(t, dir, "loose.jwks", newPublicJWK(t, "loose-key"))
+	require.NoError(t, os.Chmod(path, 0666))
+
+	countWorldWritable := func() int {
+		n := 0
+		for _, entry := range hook.AllEntries() {
+			if strings.Contains(entry.Message, "world-writable") {
+				n++
+			}
+		}
+		return n
+	}
+
+	for i := 0; i < 5; i++ {
+		_, err := ReadPublicJWKSFile(path)
+		require.NoError(t, err)
+		clock.advance(jwksFileCacheTTL)
+	}
+	assert.Equal(t, 1, countWorldWritable(),
+		"a standing permission problem should be logged once, not once per refresh")
+}

--- a/config/jwks_file_cache_test.go
+++ b/config/jwks_file_cache_test.go
@@ -24,6 +24,7 @@ import (
 	"crypto/rand"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -102,6 +103,18 @@ func captureLogs(t *testing.T) func(substr string) bool {
 			}
 		}
 		return false
+	}
+}
+
+// skipIfNoUnixFilePerms skips a test that depends on the Unix permission bits.
+// Windows governs access through ACLs that os.FileInfo does not expose: os.Chmod
+// there only toggles the read-only attribute, and every writable file reports
+// mode 0666. The permission check is compiled out on that platform, so the tests
+// covering it have nothing to observe.
+func skipIfNoUnixFilePerms(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows: file permission bits are not meaningful there")
 	}
 }
 
@@ -264,6 +277,8 @@ func TestJWKSFileCacheBoundsReadSize(t *testing.T) {
 // is the authority to mint tokens the server accepts; that is worth a warning,
 // but not worth refusing to serve the namespace's keys over.
 func TestJWKSFileCacheWarnsOnWorldWritable(t *testing.T) {
+	skipIfNoUnixFilePerms(t)
+
 	t.Run("world-writable warns but still serves", func(t *testing.T) {
 		useFakeClock(t)
 		logged := captureLogs(t)
@@ -299,6 +314,8 @@ func TestJWKSFileCacheWarnsOnWorldWritable(t *testing.T) {
 // unauthenticated and polled continuously, so a per-refresh warning would bury
 // the log.
 func TestJWKSFileWarningsDoNotRepeat(t *testing.T) {
+	skipIfNoUnixFilePerms(t)
+
 	clock := useFakeClock(t)
 	hook := logrustest.NewLocal(log.StandardLogger())
 	t.Cleanup(hook.Reset)

--- a/config/jwks_file_perms.go
+++ b/config/jwks_file_perms.go
@@ -1,0 +1,40 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package config
+
+import "os"
+
+// warnIfJWKSFileWorldWritable logs a warning when the JWKS file at path is
+// writable by users other than its owner and group.
+//
+// Every key in the file is published as trusted for its namespace, so write
+// access to it is authority to mint accepted tokens. This warns rather than
+// refuses: taking a namespace's keys away over a permission bit would be a
+// worse outcome than serving them with a loud complaint.
+func warnIfJWKSFileWorldWritable(path string, perm os.FileMode) {
+	if perm&0o002 == 0 {
+		return
+	}
+	logJWKSWarningOnChange(path, "world-writable", perm.String(),
+		"JWKS file %s is world-writable (mode %#o). Every key it holds is published "+
+			"as a trusted signing key, so any local user can mint tokens this server "+
+			"will accept. Restrict it to mode 0640 or tighter.", path, perm)
+}

--- a/config/jwks_file_perms_windows.go
+++ b/config/jwks_file_perms_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package config
+
+import "os"
+
+// warnIfJWKSFileWorldWritable does nothing on Windows, where access is governed
+// by ACLs that os.FileInfo does not expose. Go synthesizes the permission bits
+// from the read-only attribute alone, reporting 0666 for every writable file
+// and 0444 for every read-only one, so the "other write" bit would warn about
+// every JWKS file on the system while saying nothing about who can actually
+// write it.
+func warnIfJWKSFileWorldWritable(path string, perm os.FileMode) {}

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1072,6 +1072,14 @@ description: |+
       When set, only these templates are used for scope calculation in this namespace;
       the global templates are ignored entirely (no merging).
       The template format is the same as `Issuer.AuthorizationTemplates`.
+  - IssuerJwks: [OPTIONAL] Path to a JWKS-formatted file containing additional
+      public keys to include in this namespace's per-namespace JWKS endpoint.
+      These keys are merged with the server's exported public key set
+      (see `Server.IssuerJwks` for details on that key set).
+      If unset, only the server's exported public key set is served.
+      This field mirrors `Server.IssuerJwks` but is scoped to a single export.
+      It only takes effect when the origin uses the embedded OAuth2 issuer
+      and the export requires authorization.
 
     Example:
 
@@ -1089,6 +1097,7 @@ description: |+
             - actions: ["read"]
               prefix: /data/$GROUP
               groups: ["/physics"]
+          IssuerJwks: /etc/pelican/extra-keys/ns.jwks
     ```
 
   If Origin.StorageType == "s3", the following additional fields are available:

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1078,8 +1078,20 @@ description: |+
       (see `Server.IssuerJwks` for details on that key set).
       If unset, only the server's exported public key set is served.
       This field mirrors `Server.IssuerJwks` but is scoped to a single export.
-      It only takes effect when the origin uses the embedded OAuth2 issuer
-      and the export requires authorization.
+      It only takes effect when the origin uses the embedded OAuth2 issuer,
+      the export requires authorization, and the export does not set its own
+      `IssuerUrls` (an export that names its issuers explicitly does not
+      advertise the per-namespace issuer, so nothing consults these keys).
+      A startup warning is logged when the setting cannot take effect.
+      If a key in this file carries the same `kid` as one of the server's own
+      published keys, the key in this file wins and the server's key with that
+      `kid` is not published for this namespace; the override is logged.
+      Every key in this file is published as a trusted signing key for this
+      namespace, so write access to the file is the authority to mint tokens
+      this origin accepts: keep it owned by the Pelican user and not
+      world-writable. The file is re-read at most once every few seconds, is
+      not read past 1 MiB, and if it is ever unreadable or unparsable the
+      last version that loaded successfully continues to be served.
 
     Example:
 
@@ -4310,6 +4322,16 @@ description: |+
   A filepath to a JWKS-formatted file containing pre-generated public keys. These keys will be
   appended to the public keys dynamically generated from the private keys in [Server.IssuerKeysDirectory](https://docs.pelicanplatform.org/parameters#IssuerKeysDirectory)
   and [Server.IssuerKey](https://docs.pelicanplatform.org/parameters#IssuerKey) (deprecated), to form the final exported public keys JWKS.
+
+  Private key material in this file is stripped before publication, and symmetric keys (`kty=oct`)
+  are rejected outright because they are shared secrets with no public half; a symmetric key here
+  will prevent the server from starting.
+
+  Every key in this file is published as a trusted signing key, so write access to the file is the
+  authority to mint tokens this server accepts: keep it owned by the Pelican user and not
+  world-writable. The file is re-read at most once every few seconds, is not read past 1 MiB, and
+  if it is ever unreadable or unparsable the last version that loaded successfully continues to be
+  served.
 type: filename
 default: none
 components: ["cache", "director", "origin", "registry"]

--- a/launchers/origin_serve.go
+++ b/launchers/origin_serve.go
@@ -528,6 +528,36 @@ func configureEmbeddedIssuer(ctx context.Context, egrp *errgroup.Group, engine *
 			return errors.Wrapf(err, "failed to create embedded OIDC provider for namespace %s", namespace)
 		}
 
+		// Attach any extra public keys this export wants merged into its
+		// per-namespace JWKS endpoint. The zero value (empty string)
+		// means "no extra keys" and is handled by the JWKS endpoint.
+		provider.ExtraJwksPath = export.IssuerJwks
+
+		// Probe the extra file once now so an unpublishable IssuerJwks
+		// (kid collision, unreadable/corrupt file, or symmetric key) shows
+		// up in the logs at startup rather than only on the first request.
+		// This is never fatal: the namespace still serves its base keys,
+		// and the JWKS endpoint degrades the same way at request time. The
+		// strict policy here (return the error) is used only to detect it.
+		if export.IssuerJwks != "" {
+			// The callback fires only for an extra-file merge failure; a
+			// base-key-set load failure returns before it is ever called.
+			// Tracking whether it fired lets us attribute the error to the
+			// right key set instead of always blaming the operator's file.
+			extraFailed := false
+			if _, err := config.GetIssuerPublicJWKSForNamespace(export.IssuerJwks,
+				func(e error) error { extraFailed = true; return e }); err != nil {
+				if extraFailed {
+					log.Errorf("Namespace %s: IssuerJwks %q is unpublishable; the namespace "+
+						"will serve base keys only until fixed: %v", namespace, export.IssuerJwks, err)
+				} else {
+					log.Errorf("Namespace %s: failed to load the server's base issuer key set; "+
+						"the per-namespace JWKS endpoint will be unavailable until fixed: %v",
+						namespace, err)
+				}
+			}
+		}
+
 		registry.Register(namespace, provider)
 
 		// If the export defines its own AuthorizationTemplates, compile

--- a/launchers/origin_serve.go
+++ b/launchers/origin_serve.go
@@ -517,6 +517,12 @@ func configureEmbeddedIssuer(ctx context.Context, egrp *errgroup.Group, engine *
 	for _, export := range originExports {
 		// Only create an issuer for exports that need authentication
 		if export.Capabilities.PublicReads && !export.Capabilities.Writes {
+			if export.IssuerJwks != "" {
+				log.Warnf("Export %s sets IssuerJwks (%q) but is public-read with no writes, so it "+
+					"gets no embedded issuer and no per-namespace JWKS endpoint. The file will not "+
+					"be read and its keys will not be published.",
+					export.FederationPrefix, export.IssuerJwks)
+			}
 			continue
 		}
 
@@ -534,12 +540,28 @@ func configureEmbeddedIssuer(ctx context.Context, egrp *errgroup.Group, engine *
 		provider.ExtraJwksPath = export.IssuerJwks
 
 		// Probe the extra file once now so an unpublishable IssuerJwks
-		// (kid collision, unreadable/corrupt file, or symmetric key) shows
-		// up in the logs at startup rather than only on the first request.
-		// This is never fatal: the namespace still serves its base keys,
-		// and the JWKS endpoint degrades the same way at request time. The
-		// strict policy here (return the error) is used only to detect it.
+		// (unreadable/corrupt file, a symmetric key, or one kid used twice
+		// within the file) shows up in the logs at startup rather than only
+		// on the first request. This is never fatal: the namespace still
+		// serves its base keys, and the JWKS endpoint degrades the same way
+		// at request time. The strict policy here (return the error) is used
+		// only to detect it.
 		if export.IssuerJwks != "" {
+			// The keys are only trusted by XRootD and by caches if this
+			// export actually advertises the per-namespace issuer whose JWKS
+			// endpoint publishes them. handleIssuersIfNeeded assigns that URL
+			// only to exports with no IssuerUrls of their own, so an export
+			// that names its issuers explicitly publishes these keys at an
+			// endpoint nothing consults.
+			if !slices.Contains(export.IssuerUrls, issuerURL) {
+				log.Warnf("Export %s sets IssuerJwks (%q) but its configured issuer URLs (%v) do "+
+					"not include this origin's per-namespace issuer %q. The keys will be published "+
+					"at that issuer's JWKS endpoint, but caches and XRootD resolve keys through the "+
+					"issuers named above, so the keys will not authorize anything. Remove the "+
+					"export's IssuerUrls to use the embedded per-namespace issuer.",
+					namespace, export.IssuerJwks, export.IssuerUrls, issuerURL)
+			}
+
 			// The callback fires only for an extra-file merge failure; a
 			// base-key-set load failure returns before it is ever called.
 			// Tracking whether it fired lets us attribute the error to the

--- a/oauth2/issuer/handlers.go
+++ b/oauth2/issuer/handlers.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pelicanplatform/pelican/oa4mp"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/token_scopes"
 )
 
@@ -223,31 +224,46 @@ func handleDispatchDelete(ctx *gin.Context) {
 	}
 }
 
-// handleNamespaceJWKS serves the public-key JWKS
-// for a per-namespace issuer endpoint.
+// handleNamespaceJWKS serves the public-key JWKS for a per-namespace
+// issuer endpoint. The response merges the server's exported public key
+// set with any extra public keys configured for this namespace via
+// OIDCProvider.ExtraJwksPath.
 func handleNamespaceJWKS(provider *OIDCProvider) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		key, err := config.GetIssuerPublicJWKS()
+		// The extra file is optional; if it cannot be published, degrade to
+		// the server's base keys and log rather than failing the whole
+		// endpoint. Only a failure to load the base keys, which leaves no
+		// correct subset to serve, reaches the 500 below.
+		key, err := config.GetIssuerPublicJWKSForNamespace(provider.ExtraJwksPath,
+			func(e error) error {
+				log.Errorf("Namespace %s: serving base keys only; per-namespace "+
+					"IssuerJwks is currently unpublishable: %v", provider.Namespace, e)
+				return nil
+			})
 		if err != nil {
-			log.Errorf("Failed to load server's public key for namespace %s: %v",
+			log.Errorf("Failed to load base JWKS for namespace %s: %v",
 				provider.Namespace, err)
-			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-				"error": "failed to load public key",
+			ctx.AbortWithStatusJSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "Failed to load public key",
 			})
 			return
 		}
-		jsonData, err := json.MarshalIndent(key, "", "  ")
-		if err != nil {
-			log.Errorf("Failed to marshal public key for namespace %s: %v",
-				provider.Namespace, err)
-			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-				"error": "failed to marshal public key",
-			})
-			return
-		}
-		jsonData = append(jsonData, '\n')
-		ctx.Header("Content-Disposition", "attachment; filename=public-signing-key.jwks")
-		ctx.Data(http.StatusOK, "application/json", jsonData)
+		// This endpoint is what the per-namespace discovery document advertises
+		// as its jwks_uri, so a browser-based OIDC client fetches it right
+		// after reading discovery. The key material is public, so any origin
+		// may read it, matching the discovery action above and the server-level
+		// JWKS endpoint in server_utils/oidc.go. Without this, those clients
+		// fail on the fetch that follows discovery. Set here rather than in
+		// corsMiddleware so only the genuinely-dispatched JWKS action gets the
+		// wildcard: a credentialed endpoint can be reached via a URL that also
+		// ends in this suffix (e.g. a client-configuration read for an id
+		// ending in ".well-known/issuer.jwks").
+		ctx.Header("Access-Control-Allow-Origin", "*")
+
+		// GetIssuerPublicJWKSForNamespace already returns public keys, and this
+		// is a machine-facing endpoint, so serve the body inline.
+		server_utils.WriteJWKS(ctx, key)
 	}
 }
 

--- a/oauth2/issuer/handlers.go
+++ b/oauth2/issuer/handlers.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/database"
 	"github.com/pelicanplatform/pelican/oa4mp"
 	"github.com/pelicanplatform/pelican/param"
@@ -173,6 +174,8 @@ func handleDispatch(ctx *gin.Context) {
 		clientID := strings.TrimPrefix(action, "oidc-cm/")
 		ctx.Params = append(ctx.Params, gin.Param{Key: "id", Value: clientID})
 		handleClientConfigurationRead(provider)(ctx)
+	case action == ".well-known/issuer.jwks" && ctx.Request.Method == http.MethodGet:
+		handleNamespaceJWKS(provider)(ctx)
 	case action == ".well-known/openid-configuration":
 		handleIssuerDiscovery(provider)(ctx)
 	default:
@@ -220,6 +223,34 @@ func handleDispatchDelete(ctx *gin.Context) {
 	}
 }
 
+// handleNamespaceJWKS serves the public-key JWKS
+// for a per-namespace issuer endpoint.
+func handleNamespaceJWKS(provider *OIDCProvider) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		key, err := config.GetIssuerPublicJWKS()
+		if err != nil {
+			log.Errorf("Failed to load server's public key for namespace %s: %v",
+				provider.Namespace, err)
+			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error": "failed to load public key",
+			})
+			return
+		}
+		jsonData, err := json.MarshalIndent(key, "", "  ")
+		if err != nil {
+			log.Errorf("Failed to marshal public key for namespace %s: %v",
+				provider.Namespace, err)
+			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"error": "failed to marshal public key",
+			})
+			return
+		}
+		jsonData = append(jsonData, '\n')
+		ctx.Header("Content-Disposition", "attachment; filename=public-signing-key.jwks")
+		ctx.Data(http.StatusOK, "application/json", jsonData)
+	}
+}
+
 // handleIssuerDiscovery returns the OIDC discovery document scoped to the issuer
 // prefix so that the health-check in launcher.go works identically for both
 // OA4MP and the embedded issuer.
@@ -246,7 +277,7 @@ func handleIssuerDiscovery(provider *OIDCProvider) gin.HandlerFunc {
 			"introspection_endpoint":        serviceURI + "/introspect",
 			"device_authorization_endpoint": serviceURI + "/device_authorization",
 			"registration_endpoint":         serviceURI + "/oidc-cm",
-			"jwks_uri":                      IssuerURL() + "/.well-known/issuer.jwks",
+			"jwks_uri":                      serviceURI + "/.well-known/issuer.jwks",
 			"grant_types_supported": []string{
 				"authorization_code",
 				"refresh_token",

--- a/oauth2/issuer/integration_test.go
+++ b/oauth2/issuer/integration_test.go
@@ -438,11 +438,13 @@ func TestIntegrationIssuerDiscovery(t *testing.T) {
 	var discovery map[string]interface{}
 	require.NoError(t, json.Unmarshal(body, &discovery))
 
+	serviceURI := ServiceURIForNamespace(IssuerURL(), testNamespace)
+
 	assert.Equal(t, IssuerURLForNamespace(testNamespace), discovery["issuer"])
-	assert.NotEmpty(t, discovery["token_endpoint"])
-	assert.NotEmpty(t, discovery["authorization_endpoint"])
-	assert.NotEmpty(t, discovery["device_authorization_endpoint"])
-	assert.NotEmpty(t, discovery["jwks_uri"])
+	assert.Equal(t, serviceURI+"/token", discovery["token_endpoint"])
+	assert.Equal(t, serviceURI+"/authorize", discovery["authorization_endpoint"])
+	assert.Equal(t, serviceURI+"/device_authorization", discovery["device_authorization_endpoint"])
+	assert.Equal(t, serviceURI+"/.well-known/issuer.jwks", discovery["jwks_uri"])
 
 	// Verify that the advertised signing algorithm matches the actual key type.
 	// This is critical: if the discovery document says RS256 but we sign with ES256,
@@ -565,6 +567,60 @@ func TestIntegrationCORSHeaders(t *testing.T) {
 		defer resp.Body.Close()
 		assert.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
 	})
+}
+
+// TestIntegrationNamespaceJWKS verifies that each namespace issuer
+// serves its own JWKS endpoint at .well-known/issuer.jwks.
+func TestIntegrationNamespaceJWKS(t *testing.T) {
+	_, ts := setupIntegration(t)
+	httpClient := ts.Client()
+
+	url := ts.URL + "/api/v1.0/issuer/ns/test/ns/.well-known/issuer.jwks"
+	resp, err := httpClient.Get(url)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &raw), "response should be valid JSON")
+
+	keys, ok := raw["keys"].([]interface{})
+	require.True(t, ok, "JWKS should have a 'keys' array")
+	require.NotEmpty(t, keys, "JWKS should contain at least one key")
+
+	for i, k := range keys {
+		km, ok := k.(map[string]interface{})
+		require.True(t, ok, "key %d should be a JSON object", i)
+		assert.NotEmpty(t, km["kid"], "key %d should have a kid", i)
+		assert.NotEmpty(t, km["kty"], "key %d should have a kty", i)
+	}
+
+	// The test setup registers no per-namespace IssuerJwks,
+	// so the namespace JWKS must contain exactly the server-level keys.
+	serverSet, err := config.GetIssuerPublicJWKS()
+	require.NoError(t, err)
+	serverKIDs := make([]string, 0, serverSet.Len())
+	for it := serverSet.Keys(t.Context()); it.Next(t.Context()); {
+		serverKIDs = append(serverKIDs, it.Pair().Value.(jwk.Key).KeyID())
+	}
+	nsKIDs := make([]string, 0, len(keys))
+	for _, k := range keys {
+		km, ok := k.(map[string]interface{})
+		require.True(t, ok)
+		nsKIDs = append(nsKIDs, km["kid"].(string))
+	}
+	assert.ElementsMatch(t, serverKIDs, nsKIDs)
+
+	// POST to the same URL should fail (JWKS is read-only).
+	resp2, err := httpClient.Post(url, "application/json", nil)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	assert.GreaterOrEqual(t, resp2.StatusCode, http.StatusBadRequest,
+		"POST to the JWKS endpoint should return an HTTP error")
 }
 
 func TestIntegrationTokenIntrospection(t *testing.T) {
@@ -1241,7 +1297,6 @@ func TestDiscoveryEndpointsReachable(t *testing.T) {
 
 	// Map of endpoint keys to their expected HTTP method.
 	// POST-only endpoints return 404 for GET in Gin, so we must use POST.
-	// jwks_uri is served by a different component, so we skip it.
 	endpointMethods := map[string]string{
 		"authorization_endpoint":        "GET",
 		"token_endpoint":                "POST",
@@ -1250,6 +1305,7 @@ func TestDiscoveryEndpointsReachable(t *testing.T) {
 		"registration_endpoint":         "POST",
 		"revocation_endpoint":           "POST",
 		"introspection_endpoint":        "POST",
+		"jwks_uri":                      "GET",
 	}
 
 	for key, method := range endpointMethods {

--- a/oauth2/issuer/integration_test.go
+++ b/oauth2/issuer/integration_test.go
@@ -471,6 +471,7 @@ func TestIntegrationCORSHeaders(t *testing.T) {
 	require.NoError(t, param.Issuer_RedirectUris.Set([]string{browserOrigin + "/callback"}))
 
 	discoveryURL := ts.URL + "/api/v1.0/issuer/ns/test/ns/.well-known/openid-configuration"
+	jwksURL := ts.URL + "/api/v1.0/issuer/ns/test/ns/.well-known/issuer.jwks"
 	tokenURL := ts.URL + "/api/v1.0/issuer/ns/test/ns/token"
 
 	t.Run("discovery is readable from any origin", func(t *testing.T) {
@@ -494,6 +495,49 @@ func TestIntegrationCORSHeaders(t *testing.T) {
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+	})
+
+	// The per-namespace discovery document advertises the per-namespace JWKS
+	// as its jwks_uri, so a browser client reads discovery and then fetches
+	// this immediately. If the JWKS is not readable from the same origins as
+	// discovery, that second fetch fails and the client cannot validate any
+	// token signature.
+	t.Run("namespace JWKS is readable from any origin", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, jwksURL, nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "https://some-unregistered-site.example.org")
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("namespace JWKS preflight is allowed from any origin", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodOptions, jwksURL, nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "https://some-unregistered-site.example.org")
+		req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("credentialed path ending in the JWKS suffix is not wildcarded", func(t *testing.T) {
+		// The same crafted-path concern as the discovery suffix below: an
+		// attacker-controlled client id ending in ".well-known/issuer.jwks"
+		// dispatches to the credentialed client-configuration read, which must
+		// not inherit the JWKS endpoint's allow-any-origin header.
+		craftedURL := ts.URL + "/api/v1.0/issuer/ns/test/ns/oidc-cm/x" + "/.well-known/issuer.jwks"
+		req, err := http.NewRequest(http.MethodGet, craftedURL, nil)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "https://evil.example.org")
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
 	})
 
 	t.Run("preflight from a registered origin is allowed", func(t *testing.T) {

--- a/oauth2/issuer/integration_test.go
+++ b/oauth2/issuer/integration_test.go
@@ -20,6 +20,9 @@ package issuer
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -45,6 +48,7 @@ import (
 	dbutils "github.com/pelicanplatform/pelican/database/utils"
 	"github.com/pelicanplatform/pelican/oa4mp"
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/test_utils"
 )
 
 const (
@@ -584,20 +588,8 @@ func TestIntegrationNamespaceJWKS(t *testing.T) {
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-
-	var raw map[string]interface{}
-	require.NoError(t, json.Unmarshal(body, &raw), "response should be valid JSON")
-
-	keys, ok := raw["keys"].([]interface{})
-	require.True(t, ok, "JWKS should have a 'keys' array")
-	require.NotEmpty(t, keys, "JWKS should contain at least one key")
-
-	for i, k := range keys {
-		km, ok := k.(map[string]interface{})
-		require.True(t, ok, "key %d should be a JSON object", i)
-		assert.NotEmpty(t, km["kid"], "key %d should have a kid", i)
-		assert.NotEmpty(t, km["kty"], "key %d should have a kty", i)
-	}
+	nsKIDs := extractWellFormedJWKSKIDs(t, body)
+	require.NotEmpty(t, nsKIDs, "JWKS should contain at least one key")
 
 	// The test setup registers no per-namespace IssuerJwks,
 	// so the namespace JWKS must contain exactly the server-level keys.
@@ -606,12 +598,6 @@ func TestIntegrationNamespaceJWKS(t *testing.T) {
 	serverKIDs := make([]string, 0, serverSet.Len())
 	for it := serverSet.Keys(t.Context()); it.Next(t.Context()); {
 		serverKIDs = append(serverKIDs, it.Pair().Value.(jwk.Key).KeyID())
-	}
-	nsKIDs := make([]string, 0, len(keys))
-	for _, k := range keys {
-		km, ok := k.(map[string]interface{})
-		require.True(t, ok)
-		nsKIDs = append(nsKIDs, km["kid"].(string))
 	}
 	assert.ElementsMatch(t, serverKIDs, nsKIDs)
 
@@ -1790,4 +1776,191 @@ func TestPerNamespaceAuthzRules(t *testing.T) {
 		assert.NotEqual(t, IssuerURLForNamespace(nsAlpha), iss,
 			"beta token iss must differ from alpha namespace")
 	})
+}
+
+// TestIntegrationNamespaceJWKSWithExtraKey verifies that setting ExtraJwksPath
+// on an OIDCProvider causes the per-namespace JWKS endpoint to include the
+// additional public keys alongside the server's own key set.
+func TestIntegrationNamespaceJWKSWithExtraKey(t *testing.T) {
+	provider, ts := setupIntegration(t)
+
+	// Generate an extra EC key and write it as a public-only JWKS file.
+	extraPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	extraPub, err := jwk.FromRaw(extraPriv.PublicKey)
+	require.NoError(t, err)
+	const extraKID = "extra-ns-test-key"
+	require.NoError(t, extraPub.Set(jwk.KeyIDKey, extraKID))
+	extraPath := test_utils.WriteJWKSFile(t, t.TempDir(), "extra.jwks", extraPub)
+
+	// The registry stores a pointer to the provider, so mutating
+	// ExtraJwksPath after setup still affects what handleNamespaceJWKS
+	// reads at request time.
+	provider.ExtraJwksPath = extraPath
+
+	url := ts.URL + "/api/v1.0/issuer/ns/test/ns/.well-known/issuer.jwks"
+	responseKIDs := fetchNamespaceJWKSKIDs(t, ts, url)
+
+	// The extra key must appear in the response.
+	assert.Contains(t, responseKIDs, extraKID,
+		"per-namespace JWKS should include the extra key from ExtraJwksPath")
+
+	// The server's own key(s) must also be present.
+	serverSet, err := config.GetIssuerPublicJWKS()
+	require.NoError(t, err)
+	for it := serverSet.Keys(t.Context()); it.Next(t.Context()); {
+		kid := it.Pair().Value.(jwk.Key).KeyID()
+		assert.Contains(t, responseKIDs, kid,
+			"per-namespace JWKS should still include server key %s", kid)
+	}
+}
+
+// TestIntegrationNamespaceJWKSBadExtraPathDegrades verifies that when
+// ExtraJwksPath points to a missing or unreadable file (e.g. it was deleted
+// after startup), the endpoint degrades to the server's base keys rather
+// than failing: the extra file is optional, so one broken supplemental file
+// must not take down verification for the server's own valid keys.
+func TestIntegrationNamespaceJWKSBadExtraPathDegrades(t *testing.T) {
+	provider, ts := setupIntegration(t)
+	provider.ExtraJwksPath = "/nonexistent/path/to/extra.jwks"
+
+	url := ts.URL + "/api/v1.0/issuer/ns/test/ns/.well-known/issuer.jwks"
+	responseKIDs := fetchNamespaceJWKSKIDs(t, ts, url)
+
+	// The server's base keys must still be served in full.
+	serverSet, err := config.GetIssuerPublicJWKS()
+	require.NoError(t, err)
+	for it := serverSet.Keys(t.Context()); it.Next(t.Context()); {
+		kid := it.Pair().Value.(jwk.Key).KeyID()
+		assert.Contains(t, responseKIDs, kid,
+			"degraded JWKS should still include server key %s", kid)
+	}
+}
+
+// TestIntegrationNamespaceJWKSIsolation verifies the central feature claim:
+// when two namespaces are served by the same origin, each one's
+// ExtraJwksPath is isolated to its own JWKS endpoint. A key configured for
+// namespace alpha must not appear in namespace beta's response, and vice
+// versa, while both responses still include the server's own public keys.
+func TestIntegrationNamespaceJWKSIsolation(t *testing.T) {
+	config.ResetConfig()
+	t.Cleanup(func() { config.ResetConfig() })
+
+	tmpDir := t.TempDir()
+	require.NoError(t, param.IssuerKey.Set(filepath.Join(tmpDir, "issuer.jwk")))
+	require.NoError(t, param.Server_ExternalWebUrl.Set("https://test-origin.example.com"))
+
+	dbPath := filepath.Join(tmpDir, "test-isolation.sqlite")
+	db, err := dbutils.InitSQLiteDB(dbPath)
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { sqlDB.Close() })
+	require.NoError(t, dbutils.MigrateDB(sqlDB, database.EmbedUniversalMigrations, "universal_migrations"))
+	require.NoError(t, dbutils.MigrateServerSpecificDB(sqlDB, database.EmbedOriginMigrations, "origin_migrations", "origin"))
+
+	const nsAlpha = "/ns/alpha"
+	const nsBeta = "/ns/beta"
+	gracePeriod := 5 * time.Minute
+
+	providerAlpha, err := NewOIDCProvider(db, IssuerURLForNamespace(nsAlpha), gracePeriod, nsAlpha)
+	require.NoError(t, err)
+	providerBeta, err := NewOIDCProvider(db, IssuerURLForNamespace(nsBeta), gracePeriod, nsBeta)
+	require.NoError(t, err)
+
+	makeExtraKey := func(kid string) string {
+		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		pub, err := jwk.FromRaw(priv.PublicKey)
+		require.NoError(t, err)
+		require.NoError(t, pub.Set(jwk.KeyIDKey, kid))
+		return test_utils.WriteJWKSFile(t, t.TempDir(), kid+".jwks", pub)
+	}
+	const kidAlpha = "alpha-only-key"
+	const kidBeta = "beta-only-key"
+	providerAlpha.ExtraJwksPath = makeExtraKey(kidAlpha)
+	providerBeta.ExtraJwksPath = makeExtraKey(kidBeta)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	registry := NewProviderRegistry()
+	registry.Register(nsAlpha, providerAlpha)
+	registry.Register(nsBeta, providerBeta)
+	RegisterRoutesWithMiddleware(engine, registry)
+
+	ts := httptest.NewTLSServer(engine)
+	t.Cleanup(ts.Close)
+
+	serverSet, err := config.GetIssuerPublicJWKS()
+	require.NoError(t, err)
+	var serverKIDs []string
+	for it := serverSet.Keys(t.Context()); it.Next(t.Context()); {
+		serverKIDs = append(serverKIDs, it.Pair().Value.(jwk.Key).KeyID())
+	}
+	require.NotEmpty(t, serverKIDs, "server should publish at least one key")
+
+	alphaKIDs := fetchNamespaceJWKSKIDs(t, ts,
+		ts.URL+"/api/v1.0/issuer/ns/ns/alpha/.well-known/issuer.jwks")
+	betaKIDs := fetchNamespaceJWKSKIDs(t, ts,
+		ts.URL+"/api/v1.0/issuer/ns/ns/beta/.well-known/issuer.jwks")
+
+	// Each namespace's own extra key is present.
+	assert.Contains(t, alphaKIDs, kidAlpha,
+		"alpha JWKS should include its own extra key")
+	assert.Contains(t, betaKIDs, kidBeta,
+		"beta JWKS should include its own extra key")
+
+	// Cross-namespace isolation: neither extra key leaks to the other.
+	assert.NotContains(t, alphaKIDs, kidBeta,
+		"alpha JWKS must not include beta's extra key")
+	assert.NotContains(t, betaKIDs, kidAlpha,
+		"beta JWKS must not include alpha's extra key")
+
+	// Server keys are still present in both responses.
+	for _, kid := range serverKIDs {
+		assert.Contains(t, alphaKIDs, kid,
+			"alpha JWKS should still include server key %s", kid)
+		assert.Contains(t, betaKIDs, kid,
+			"beta JWKS should still include server key %s", kid)
+	}
+}
+
+// fetchNamespaceJWKSKIDs GETs a namespace JWKS endpoint, asserts the
+// response is well-formed (HTTP 200, valid JWKS with a 'keys' array of
+// objects each having 'kid' and 'kty'), and returns the list of kids.
+func fetchNamespaceJWKSKIDs(t *testing.T, ts *httptest.Server, url string) []string {
+	t.Helper()
+	resp, err := ts.Client().Get(url)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "GET %s", url)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return extractWellFormedJWKSKIDs(t, body)
+}
+
+// extractWellFormedJWKSKIDs parses body as a JWKS document, asserts that
+// every key has string 'kid' and 'kty' fields, and returns the list of kids.
+// Used by tests that fetch the JWKS themselves but want to share the
+// well-formedness checks.
+func extractWellFormedJWKSKIDs(t *testing.T, body []byte) []string {
+	t.Helper()
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &raw),
+		"JWKS response should be valid JSON")
+	keys, ok := raw["keys"].([]interface{})
+	require.True(t, ok, "JWKS response should have a 'keys' array")
+
+	kids := make([]string, 0, len(keys))
+	for i, k := range keys {
+		km, ok := k.(map[string]interface{})
+		require.True(t, ok, "key %d should be a JSON object", i)
+		kid, ok := km["kid"].(string)
+		require.True(t, ok, "key %d should have a string 'kid'", i)
+		_, ok = km["kty"].(string)
+		require.True(t, ok, "key %d should have a string 'kty'", i)
+		kids = append(kids, kid)
+	}
+	return kids
 }

--- a/oauth2/issuer/middleware.go
+++ b/oauth2/issuer/middleware.go
@@ -33,20 +33,27 @@ import (
 // document, which is public, non-sensitive metadata.
 const oidcDiscoverySuffix = "/.well-known/openid-configuration"
 
+// oidcJWKSSuffix is the path suffix of the per-namespace JWKS endpoint. Like
+// the discovery document it is public metadata, and it is the jwks_uri that
+// document advertises, so a browser client that may read discovery must be
+// able to read this too.
+const oidcJWKSSuffix = "/.well-known/issuer.jwks"
+
 // corsMiddleware lets browser-based applications read the embedded issuer's
 // endpoints cross-origin. It follows the two CORS conventions already used
 // elsewhere in Pelican:
 //
-//   - The OIDC discovery document is public, non-sensitive metadata, so any
-//     origin may read it (Access-Control-Allow-Origin: *), matching the
-//     server-level discovery endpoint in server_utils/oidc.go. Because the
-//     namespace is not yet resolved when this middleware runs, a URL path
-//     ending in the discovery suffix may still dispatch to a different,
-//     credentialed handler (e.g. oidc-cm/<id>/.well-known/openid-configuration
-//     is a client-configuration read); the wildcard on the *response* is
-//     therefore set by handleIssuerDiscovery itself, and this middleware only
-//     approves the wildcard for the discovery-suffix *preflight*, which by
-//     itself grants no access to response data.
+//   - The OIDC discovery document and the JWKS it advertises as its jwks_uri
+//     are public, non-sensitive metadata, so any origin may read them
+//     (Access-Control-Allow-Origin: *), matching the server-level discovery
+//     and JWKS endpoints in server_utils/oidc.go. Because the namespace is not
+//     yet resolved when this middleware runs, a URL path ending in either
+//     suffix may still dispatch to a different, credentialed handler (e.g.
+//     oidc-cm/<id>/.well-known/openid-configuration is a client-configuration
+//     read); the wildcard on the *response* is therefore set by
+//     handleIssuerDiscovery and handleNamespaceJWKS themselves, and this
+//     middleware only approves the wildcard for those suffixes' *preflight*,
+//     which by itself grants no access to response data.
 //   - The credentialed endpoints (token, userinfo, introspection, ...) echo
 //     the request's Origin back only when it is one of the configured
 //     Issuer.RedirectUris, matching the OA4MP proxy in oa4mp/proxy.go, so
@@ -60,7 +67,9 @@ func corsMiddleware(ctx *gin.Context) {
 		// All responses here depend on the request's Origin header, so caches
 		// must not reuse one site's response (allowed or denied) for another.
 		ctx.Header("Vary", "Origin")
-		if ctx.Request.Method == http.MethodOptions && strings.HasSuffix(ctx.Request.URL.Path, oidcDiscoverySuffix) {
+		if ctx.Request.Method == http.MethodOptions &&
+			(strings.HasSuffix(ctx.Request.URL.Path, oidcDiscoverySuffix) ||
+				strings.HasSuffix(ctx.Request.URL.Path, oidcJWKSSuffix)) {
 			ctx.Header("Access-Control-Allow-Origin", "*")
 		} else if isRegisteredOrigin(origin) {
 			ctx.Header("Access-Control-Allow-Origin", origin)

--- a/oauth2/issuer/provider.go
+++ b/oauth2/issuer/provider.go
@@ -74,6 +74,11 @@ type OIDCProvider struct {
 	// oa4mp.InitAuthzRules().
 	AuthzRules []*oa4mp.CompiledAuthz
 
+	// ExtraJwksPath is an optional filesystem path to a JWKS file whose
+	// public keys are merged into the per-namespace JWKS endpoint alongside
+	// the server's exported public key set (see config.GetIssuerPublicJWKS).
+	ExtraJwksPath string
+
 	// DeviceCodeHandler handles RFC 8628 device authorization grant.
 	DeviceCodeHandler *DeviceCodeHandler
 

--- a/registry/jwks.go
+++ b/registry/jwks.go
@@ -1,0 +1,60 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package registry
+
+import (
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/pelicanplatform/pelican/config"
+)
+
+// publicJWKSForServing returns the public projection of a JWKS loaded from the
+// registry database, ready to publish. Registrants submit their own key
+// material, which is never validated to be public-only, so this degrades
+// gracefully: any symmetric (kty=oct) key or key that cannot be projected by
+// jwk.PublicKeyOf is logged and skipped rather than failing, so one malformed
+// stored key cannot turn a namespace's key endpoint into an HTTP 500. Private
+// key material is always removed via jwk.PublicKeyOf.
+//
+// Skipping individual keys is safe, but skipping *every* key is not: if a
+// non-empty stored set projects to nothing, there is no correct subset left to
+// serve, and returning an empty JWKS with HTTP 200 would silently break token
+// verification federation-wide while looking healthy. That case is a hard
+// error, mirroring the "no correct subset left to serve" rule in
+// config.GetIssuerPublicJWKSForNamespace. A genuinely empty input set is not an
+// error: it projects to an empty set, which callers serve as-is.
+//
+// This is deliberately more lenient than config.stripPrivateKeys, which is used
+// for the server's own trusted keys where any bad key is a hard error.
+func publicJWKSForServing(set jwk.Set) (jwk.Set, error) {
+	// The callback never returns an error, so ProjectPublicJWKS cannot fail
+	// here: every unpublishable key is logged and skipped.
+	out, _ := config.ProjectPublicJWKS(set, func(k jwk.Key, err error) error {
+		log.Warnf("Skipping key %q while publishing JWKS: %v", k.KeyID(), err)
+		return nil
+	})
+	if set.Len() > 0 && out.Len() == 0 {
+		return nil, errors.Errorf(
+			"all %d stored key(s) are unpublishable; refusing to serve an empty JWKS",
+			set.Len())
+	}
+	return out, nil
+}

--- a/registry/jwks_test.go
+++ b/registry/jwks_test.go
@@ -1,0 +1,114 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package registry
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/config"
+)
+
+// keyIDs returns the set of key IDs present in set.
+func keyIDs(t *testing.T, set jwk.Set) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	_ = config.ForEachKey(set, func(k jwk.Key) error {
+		out[k.KeyID()] = true
+		return nil
+	})
+	return out
+}
+
+// newTestPrivateJWK returns a fresh EC private key as a jwk.Key with the
+// given kid.
+func newTestPrivateJWK(t *testing.T, kid string) jwk.Key {
+	t.Helper()
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	privJWK, err := jwk.FromRaw(privKey)
+	require.NoError(t, err)
+	require.NoError(t, privJWK.Set(jwk.KeyIDKey, kid))
+	return privJWK
+}
+
+// newTestSymmetricJWK returns a symmetric (kty=oct) key with the given kid.
+// Such a key has no public projection and must never be published.
+func newTestSymmetricJWK(t *testing.T, kid string) jwk.Key {
+	t.Helper()
+	symKey, err := jwk.FromRaw(make([]byte, 32))
+	require.NoError(t, err)
+	require.NoError(t, symKey.Set(jwk.KeyIDKey, kid))
+	return symKey
+}
+
+// TestPublicJWKSForServing verifies that the registry's serving sanitizer
+// strips private material from a publishable key and silently skips a key it
+// cannot publish, so one bad registrant-submitted key cannot fail the whole
+// endpoint. It also verifies the hard-error boundary: a non-empty stored set
+// that projects to nothing is an error, while a genuinely empty set is not.
+// Private-key stripping through the HTTP handlers is covered by
+// jwks-strips-private-key (registry_test.go) and TestGetNamespaceJWKSStripsPrivateKey
+// (registry_ui_test.go); this focuses on the projection policy.
+func TestPublicJWKSForServing(t *testing.T) {
+	t.Run("skips-unpublishable-key-among-good", func(t *testing.T) {
+		set := jwk.NewSet()
+		require.NoError(t, set.AddKey(newTestPrivateJWK(t, "good-key")))
+		require.NoError(t, set.AddKey(newTestSymmetricJWK(t, "sym-key")))
+
+		out, err := publicJWKSForServing(set)
+		require.NoError(t, err)
+
+		present := keyIDs(t, out)
+		assert.True(t, present["good-key"],
+			"a publishable key must survive sanitization")
+		assert.False(t, present["sym-key"],
+			"a symmetric key must be skipped, not published")
+
+		// The surviving key must carry no private material.
+		good, ok := out.LookupKeyID("good-key")
+		require.True(t, ok)
+		_, hasPrivate := good.Get("d")
+		assert.False(t, hasPrivate,
+			"private key parameter must not be present on the published key")
+	})
+
+	t.Run("errors-when-all-keys-unpublishable", func(t *testing.T) {
+		set := jwk.NewSet()
+		require.NoError(t, set.AddKey(newTestSymmetricJWK(t, "sym-key")))
+
+		out, err := publicJWKSForServing(set)
+		require.Error(t, err,
+			"a non-empty set that projects to empty must be an error")
+		assert.Nil(t, out)
+	})
+
+	t.Run("empty-input-is-not-an-error", func(t *testing.T) {
+		out, err := publicJWKSForServing(jwk.NewSet())
+		require.NoError(t, err,
+			"an empty input set must not be treated as a fault")
+		assert.Equal(t, 0, out.Len())
+	})
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -51,6 +51,7 @@ import (
 	"github.com/pelicanplatform/pelican/oauth2"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
 	"github.com/pelicanplatform/pelican/utils"
@@ -919,7 +920,21 @@ func wildcardHandler(ctx *gin.Context) {
 				}
 			}
 		}
-		ctx.JSON(http.StatusOK, jwks)
+		// Registry-stored keys should already be public, but sanitize
+		// best-effort so a single malformed stored key is skipped rather
+		// than turning this federation-critical endpoint into a 500. Serve
+		// inline: the consumers here are machines, not browsers. If every
+		// stored key is unpublishable, fail loudly rather than serve an empty
+		// JWKS that would silently break token verification.
+		pub, err := publicJWKSForServing(jwks)
+		if err != nil {
+			log.Errorf("Refusing to serve JWKS for prefix %s: %v", prefix, err)
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "server has no publishable keys for this namespace"})
+			return
+		}
+		server_utils.WriteJWKS(ctx, pub)
 		return
 	} else if strings.HasSuffix(path, "/.well-known/openid-configuration") {
 		// Check that the namespace exists before constructing config JSON
@@ -936,6 +951,7 @@ func wildcardHandler(ctx *gin.Context) {
 			ctx.JSON(http.StatusNotFound, server_structs.SimpleApiResp{
 				Status: server_structs.RespFailed,
 				Msg:    fmt.Sprintf("The requested prefix %s does not exist in the registry's database", prefix)})
+			return
 		}
 		// Construct the openid-configuration JSON and return to the requester
 		// For a given namespace "foo", the jwks should be located at <registry url>/api/v1.0/registry/foo/.well-known/issuer.jwks

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -109,7 +109,92 @@ func TestHandleWildcard(t *testing.T) {
 
 		// Return 200 as by default Registry.RequireOriginApproval == false
 		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Equal(t, string(mockJWKSBytes), w.Body.String())
+		// The response is re-serialized through server_utils.WriteJWKS, so
+		// compare by parsed contents rather than raw bytes.
+		gotSet, err := jwk.Parse(w.Body.Bytes())
+		require.NoError(t, err)
+		assert.Equal(t, 0, gotSet.Len())
+	})
+
+	t.Run("jwks-strips-private-key", func(t *testing.T) {
+		server_utils.ResetTestState()
+		mockPrefix := "/testnamespace/priv"
+
+		setupMockRegistryDB(t)
+		defer teardownMockRegistryDB(t)
+
+		// Store a JWKS that contains full private key material; registrants
+		// supply this field and it is never validated to be public-only.
+		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		privJWK, err := jwk.FromRaw(priv)
+		require.NoError(t, err)
+		require.NoError(t, privJWK.Set(jwk.KeyIDKey, "wildcard-priv-key"))
+		privSet := jwk.NewSet()
+		require.NoError(t, privSet.AddKey(privJWK))
+		privBytes, err := json.Marshal(privSet)
+		require.NoError(t, err)
+		require.NoError(t, insertMockDBData([]server_structs.Registration{
+			{Prefix: mockPrefix, Pubkey: string(privBytes)},
+		}))
+
+		req, _ := http.NewRequest("GET", fmt.Sprintf("/registry%s/.well-known/issuer.jwks", mockPrefix), nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.NotContains(t, w.Body.String(), `"d":`,
+			"private key material must not be served by the registry")
+		got, err := jwk.Parse(w.Body.Bytes())
+		require.NoError(t, err)
+		_, found := got.LookupKeyID("wildcard-priv-key")
+		assert.True(t, found, "the key's public projection should still be served")
+	})
+
+	t.Run("jwks-all-keys-unpublishable-fails", func(t *testing.T) {
+		server_utils.ResetTestState()
+		mockPrefix := "/testnamespace/unpublishable"
+
+		setupMockRegistryDB(t)
+		defer teardownMockRegistryDB(t)
+
+		// Store a set whose only key is symmetric (kty=oct). Such a key has no
+		// public projection, so the projected set is empty. Serving HTTP 200
+		// with no keys would silently break token verification, so the endpoint
+		// must fail loudly instead.
+		symKey, err := jwk.FromRaw(make([]byte, 32))
+		require.NoError(t, err)
+		require.NoError(t, symKey.Set(jwk.KeyIDKey, "wildcard-sym-key"))
+		symSet := jwk.NewSet()
+		require.NoError(t, symSet.AddKey(symKey))
+		symBytes, err := json.Marshal(symSet)
+		require.NoError(t, err)
+		require.NoError(t, insertMockDBData([]server_structs.Registration{
+			{Prefix: mockPrefix, Pubkey: string(symBytes)},
+		}))
+
+		req, _ := http.NewRequest("GET", fmt.Sprintf("/registry%s/.well-known/issuer.jwks", mockPrefix), nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("openid-configuration-404-for-prefix-dne", func(t *testing.T) {
+		server_utils.ResetTestState()
+		setupMockRegistryDB(t)
+		defer teardownMockRegistryDB(t)
+
+		req, _ := http.NewRequest("GET", "/registry/no-such-prefix/.well-known/openid-configuration", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		// A nonexistent prefix must yield a single 404 response. The handler
+		// must not fall through and append an openid-configuration document
+		// (which would leak a jwks_uri for a prefix that does not exist).
+		assert.Equal(t, http.StatusNotFound, w.Code)
+		assert.NotContains(t, w.Body.String(), "jwks_uri",
+			"a 404 for a nonexistent prefix must not include a jwks_uri")
 	})
 
 	mockApprovalTcs := []struct {
@@ -190,7 +275,10 @@ func TestHandleWildcard(t *testing.T) {
 
 			assert.Equal(t, tc.ExpectedCode, w.Code)
 			if tc.ExpectedCode == 200 {
-				assert.Equal(t, string(mockJWKSBytes), w.Body.String())
+				// Re-serialized via server_utils.WriteJWKS; compare contents.
+				gotSet, err := jwk.Parse(w.Body.Bytes())
+				require.NoError(t, err)
+				assert.Equal(t, 0, gotSet.Len())
 			}
 		})
 	}

--- a/registry/registry_ui.go
+++ b/registry/registry_ui.go
@@ -19,7 +19,6 @@
 package registry
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -38,6 +37,7 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
 	"github.com/pelicanplatform/pelican/utils"
@@ -844,18 +844,19 @@ func getNamespaceJWKS(ctx *gin.Context) {
 			Msg:    fmt.Sprint("Error getting jwks by id:", err)})
 		return
 	}
-	jsonData, err := json.MarshalIndent(jwks, "", "  ")
+	// This is a human-facing UI download, so name the attachment; sanitize
+	// best-effort so one malformed stored key does not fail the download. If
+	// every stored key is unpublishable, fail loudly rather than hand back an
+	// empty key file that looks like a successful download.
+	pub, err := publicJWKSForServing(jwks)
 	if err != nil {
-		log.Errorf("Failed to marshall jwks. %v", err)
+		log.Errorf("Refusing to serve JWKS for namespace id %d: %v", id, err)
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
 			Status: server_structs.RespFailed,
-			Msg:    "Failed to marshal JWKS"})
+			Msg:    "server has no publishable keys for this namespace"})
 		return
 	}
-	// Append a new line to the JSON data
-	jsonData = append(jsonData, '\n')
-	ctx.Header("Content-Disposition", fmt.Sprintf("attachment; filename=public-key-server-%v.jwks", id))
-	ctx.Data(200, "application/json", jsonData)
+	server_utils.WriteJWKS(ctx, pub, fmt.Sprintf("public-key-server-%v.jwks", id))
 }
 
 func deleteNamespace(ctx *gin.Context) {

--- a/registry/registry_ui_test.go
+++ b/registry/registry_ui_test.go
@@ -21,7 +21,9 @@ package registry
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -630,10 +632,110 @@ func TestGetNamespaceJWKS(t *testing.T) {
 			require.Equal(t, tc.expectedCode, w.Code)
 
 			if tc.expectedCode == http.StatusOK {
-				assert.Equal(t, tc.expectedData, w.Body.String())
+				// The response is sanitized through publicJWKSForServing and
+				// re-serialized through server_utils.WriteJWKS (public
+				// projection + indent), so compare parsed contents and confirm
+				// no private material leaks rather than matching bytes.
+				want, err := jwk.Parse([]byte(tc.expectedData))
+				require.NoError(t, err)
+				got, err := jwk.Parse(w.Body.Bytes())
+				require.NoError(t, err)
+				assert.Equal(t, want.Len(), got.Len())
+				assert.NotContains(t, w.Body.String(), `"d":`,
+					"private key material must not be served")
 			}
 		})
 	}
+}
+
+// TestGetNamespaceJWKSStripsPrivateKey confirms that even if the registry
+// database holds private key material (registrants submit their own pubkey
+// field, which is never validated to be public-only), the per-id pubkey
+// endpoint serves only the public projection.
+func TestGetNamespaceJWKSStripsPrivateKey(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	_, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	defer func() { require.NoError(t, egrp.Wait()) }()
+	defer cancel()
+
+	setupMockRegistryDB(t)
+	defer teardownMockRegistryDB(t)
+
+	privJWKS := privateJWKSString(t, "registry-priv-key")
+	require.NoError(t, insertMockDBData([]server_structs.Registration{
+		{ID: 1, Prefix: "/origin1", Pubkey: privJWKS},
+	}))
+	defer resetMockRegistryDB(t)
+
+	router := gin.New()
+	router.GET("/test/:id/pubkey", getNamespaceJWKS)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test/1/pubkey", nil)
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.NotContains(t, w.Body.String(), `"d":`,
+		"private key material must not be served by the registry")
+	// The download filename is scoped to the namespace id so multiple
+	// downloads are distinctly named.
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "public-key-server-1.jwks",
+		"per-id endpoint should use an id-scoped download filename")
+	got, err := jwk.Parse(w.Body.Bytes())
+	require.NoError(t, err)
+	_, found := got.LookupKeyID("registry-priv-key")
+	assert.True(t, found, "the key's public projection should still be served")
+}
+
+// TestGetNamespaceJWKSAllKeysUnpublishable confirms that when every stored key
+// for a namespace is unpublishable (here, a lone symmetric key with no public
+// projection), the per-id download fails loudly with HTTP 500 rather than
+// handing back an empty key file that looks like a successful download.
+func TestGetNamespaceJWKSAllKeysUnpublishable(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	_, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	defer func() { require.NoError(t, egrp.Wait()) }()
+	defer cancel()
+
+	setupMockRegistryDB(t)
+	defer teardownMockRegistryDB(t)
+
+	symKey, err := jwk.FromRaw(make([]byte, 32))
+	require.NoError(t, err)
+	require.NoError(t, symKey.Set(jwk.KeyIDKey, "registry-sym-key"))
+	symSet := jwk.NewSet()
+	require.NoError(t, symSet.AddKey(symKey))
+	symBytes, err := json.Marshal(symSet)
+	require.NoError(t, err)
+	require.NoError(t, insertMockDBData([]server_structs.Registration{
+		{ID: 1, Prefix: "/origin1", Pubkey: string(symBytes)},
+	}))
+	defer resetMockRegistryDB(t)
+
+	router := gin.New()
+	router.GET("/test/:id/pubkey", getNamespaceJWKS)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test/1/pubkey", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// privateJWKSString returns a JWKS document (as a string) containing the full
+// private form of a freshly generated EC key with the given kid.
+func privateJWKSString(t *testing.T, kid string) string {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	privJWK, err := jwk.FromRaw(priv)
+	require.NoError(t, err)
+	require.NoError(t, privJWK.Set(jwk.KeyIDKey, kid))
+	set := jwk.NewSet()
+	require.NoError(t, set.AddKey(privJWK))
+	data, err := json.Marshal(set)
+	require.NoError(t, err)
+	return string(data)
 }
 
 func TestUpdateNamespaceStatus(t *testing.T) {

--- a/server_utils/jwks_response.go
+++ b/server_utils/jwks_response.go
@@ -1,0 +1,70 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package server_utils
+
+import (
+	"encoding/json"
+	"mime"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/pelicanplatform/pelican/server_structs"
+)
+
+// WriteJWKS marshals set as an indented JSON JWKS document and writes it to
+// ctx with HTTP 200. The set is written verbatim: this helper is only an HTTP
+// concern and does no key sanitization, so callers must pass a set that already
+// contains public key material (e.g. via config.GetIssuerPublicJWKS for the
+// server's own keys, or the registry's serving sanitizer for stored keys).
+//
+// By default the body is served inline, which is what machine consumers of a
+// JWKS endpoint (OIDC discovery libraries, jwk.Fetch, and the like) expect; the
+// Content-Disposition header they ignore is simply omitted. If a non-empty
+// filename is supplied, a "Content-Disposition: attachment" header naming that
+// file is added instead, for the endpoints that exist to hand a human a
+// downloadable key file. On marshal failure it aborts with HTTP 500 and a
+// SimpleApiResp body.
+func WriteJWKS(ctx *gin.Context, set jwk.Set, filename ...string) {
+	jsonData, err := json.MarshalIndent(set, "", "  ")
+	if err != nil {
+		log.Errorf("Failed to marshal public JWKS: %v", err)
+		ctx.AbortWithStatusJSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+			Status: server_structs.RespFailed,
+			Msg:    "Failed to marshal public key",
+		})
+		return
+	}
+	// Append a trailing newline so a downloaded file ends cleanly.
+	jsonData = append(jsonData, '\n')
+	if len(filename) > 0 && filename[0] != "" {
+		// Build the header via mime.FormatMediaType so a filename containing
+		// quotes, spaces, or CR/LF cannot break out of the header or inject
+		// a new one. If the name can't be represented, fall back to a bare
+		// "attachment" disposition rather than emitting a malformed header.
+		disposition := mime.FormatMediaType("attachment", map[string]string{"filename": filename[0]})
+		if disposition == "" {
+			disposition = "attachment"
+		}
+		ctx.Header("Content-Disposition", disposition)
+	}
+	ctx.Data(http.StatusOK, "application/json", jsonData)
+}

--- a/server_utils/jwks_response_test.go
+++ b/server_utils/jwks_response_test.go
@@ -1,0 +1,90 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package server_utils
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// publicKeySet builds a single-key public JWKS for use in the writer tests.
+func publicKeySet(t *testing.T, kid string) jwk.Set {
+	t.Helper()
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	pubJWK, err := jwk.PublicKeyOf(privKey)
+	require.NoError(t, err)
+	require.NoError(t, pubJWK.Set(jwk.KeyIDKey, kid))
+	set := jwk.NewSet()
+	require.NoError(t, set.AddKey(pubJWK))
+	return set
+}
+
+// TestWriteJWKS verifies the inline-by-default / attachment-when-named
+// contract of the shared JWKS response writer.
+func TestWriteJWKS(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("no filename serves inline with no attachment header", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rec)
+
+		WriteJWKS(ctx, publicKeySet(t, "inline-key"))
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		assert.Empty(t, rec.Header().Get("Content-Disposition"),
+			"machine-facing responses must not set an attachment disposition")
+		assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+		assert.Contains(t, rec.Body.String(), "inline-key")
+	})
+
+	t.Run("filename sets an attachment disposition", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rec)
+
+		WriteJWKS(ctx, publicKeySet(t, "download-key"), "public-key-server-7.jwks")
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, `attachment; filename=public-key-server-7.jwks`,
+			rec.Header().Get("Content-Disposition"))
+		assert.Contains(t, rec.Body.String(), "download-key")
+	})
+
+	t.Run("a filename with unsafe characters cannot inject a header", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rec)
+
+		WriteJWKS(ctx, publicKeySet(t, "safe-key"), "evil\r\nX-Injected: 1")
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		disposition := rec.Header().Get("Content-Disposition")
+		assert.NotContains(t, disposition, "\r")
+		assert.NotContains(t, disposition, "\n")
+		assert.Empty(t, rec.Header().Get("X-Injected"))
+	})
+}

--- a/server_utils/oidc.go
+++ b/server_utils/oidc.go
@@ -19,7 +19,6 @@
 package server_utils
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/url"
 	"strings"
@@ -172,24 +171,16 @@ func exportIssuerJWKS(ctx *gin.Context) {
 			Msg:    "Failed to load server's public key",
 		})
 	} else {
-		jsonData, err := json.MarshalIndent(key, "", "  ")
-		if err != nil {
-			ctx.AbortWithStatusJSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
-				Status: server_structs.RespFailed,
-				Msg:    "Failed to marshal server's public key",
-			})
-			return
-		}
-		// Append a new line to the JSON data
-		jsonData = append(jsonData, '\n')
-		ctx.Header("Content-Disposition", "attachment; filename=public-signing-key.jwks")
 		// The public JWKS must be readable cross-origin: browser-based OIDC
 		// clients follow the discovery document's jwks_uri here to validate
 		// token signatures. The discovery endpoint above already allows any
 		// origin; without the same header on the JWKS, those clients fail on
 		// the very next fetch.
 		ctx.Header("Access-Control-Allow-Origin", "*")
-		ctx.Data(200, "application/json", jsonData)
+		// This shipped as a downloadable attachment before the JWKS response
+		// writers were consolidated; preserve that header so the server-level
+		// endpoint's response is unchanged.
+		WriteJWKS(ctx, key, "public-signing-key.jwks")
 	}
 }
 

--- a/server_utils/origin.go
+++ b/server_utils/origin.go
@@ -68,6 +68,11 @@ type (
 		// for this export's namespace.
 		AuthorizationTemplates []interface{} `json:"authorizationTemplates,omitempty" mapstructure:"authorizationtemplates" yaml:"AuthorizationTemplates"`
 
+		// IssuerJwks is an optional path to a JWKS file whose public keys
+		// are merged into the per-namespace JWKS endpoint alongside the
+		// server's exported public key set.
+		IssuerJwks string `json:"issuerJwks,omitempty" mapstructure:"issuerjwks" yaml:"IssuerJwks"`
+
 		// Metadata holds per-export overrides for the object-commit publisher.
 		// When unset, the origin-wide Origin.Metadata.* settings apply.
 		Metadata *OriginExportMetadata `json:"metadata,omitempty" mapstructure:"metadata" yaml:"Metadata"`

--- a/server_utils/origin_test.go
+++ b/server_utils/origin_test.go
@@ -233,6 +233,13 @@ func TestGetExports(t *testing.T) {
 		assert.False(t, exports[1].Capabilities.Listings)
 		assert.False(t, exports[1].Capabilities.Reads)
 		assert.False(t, exports[1].Capabilities.DirectReads)
+
+		// IssuerJwks is plumbed through by mapstructure tag alone; without an
+		// assertion here a typo in the tag would silently make the
+		// per-namespace JWKS feature a no-op with no failing test.
+		assert.Empty(t, exports[0].IssuerJwks, "an export that omits IssuerJwks should get the zero value")
+		assert.Equal(t, "/etc/pelican/extra-keys/second.jwks", exports[1].IssuerJwks,
+			"IssuerJwks should be parsed from the export block")
 	})
 
 	t.Run("testTrailingSlashRemovalPosix", func(t *testing.T) {

--- a/server_utils/resources/posix-origins/multi-export-valid.yml
+++ b/server_utils/resources/posix-origins/multi-export-valid.yml
@@ -14,3 +14,4 @@ Origin:
     - StoragePrefix: /test2
       FederationPrefix: /second/namespace
       Capabilities: ["Writes"]
+      IssuerJwks: /etc/pelican/extra-keys/second.jwks

--- a/test_utils/utils.go
+++ b/test_utils/utils.go
@@ -49,6 +49,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/config/configtest"
 	"github.com/pelicanplatform/pelican/logging"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/pelican_url"
@@ -644,4 +645,11 @@ func ChownToDaemon(t testing.TB, paths ...string) {
 	for _, p := range paths {
 		require.NoError(t, os.Chown(p, uinfo.Uid, uinfo.Gid))
 	}
+}
+
+// WriteJWKSFile serializes keys into a JWKS JSON file at dir/name
+// and returns the full path. Fails the test on any error.
+// This is a thin shim over configtest.WriteJWKSFile.
+func WriteJWKSFile(t testing.TB, dir, name string, keys ...jwk.Key) string {
+	return configtest.WriteJWKSFile(t, dir, name, keys...)
 }


### PR DESCRIPTION
Fixes #3574.

## Summary

This PR adds a new configuration parameter, `Origin.Exports[].IssuerJwks`, which allows a public keys to be added to specific namespaces. These keys are merged with the server's public keys.

The linked issue contains additional background and motivation.

## Notable implementation decisions

Public keys are now validated before being published: No duplicate `kid`s. No symmetric keys. This affects _all_ services. (There should be no symmetric keys in the wild.)

When disallowed keys are present, degradation is "graceful": the service makes a best-effort at continuing to serve _something_. Errors are only logged. The assumption is that in practice, this feature serves niche use cases, and the operator/admin can reasonably be expected to check that their service correctly starts up and serves the expected public keys (and that they won't later mangle keys out from under a running service).