### PR TITLE
cache: per-origin fair scheduler to survive a slow upstream

### DIFF
--- a/client/error_helpers.go
+++ b/client/error_helpers.go
@@ -116,18 +116,12 @@ func parseThrottleReason(body string) string {
 	return ""
 }
 
-// sanitizeErrorDetail makes a server-provided message safe to embed in log
-// lines and error strings: control characters (including CR/LF, which would
-// permit forging log records) are replaced with spaces and the result is
-// truncated.
-func sanitizeErrorDetail(detail string) string {
+// truncateErrorDetail bounds a server-provided message before it is retained
+// on an error value. Escaping for safe display happens at formatting time
+// (the detail is rendered with %q, so control characters a hostile server
+// embeds cannot forge log records).
+func truncateErrorDetail(detail string) string {
 	const maxDetail = 512
-	detail = strings.Map(func(r rune) rune {
-		if r < 0x20 || r == 0x7f {
-			return ' '
-		}
-		return r
-	}, detail)
 	if len(detail) > maxDetail {
 		detail = detail[:maxDetail] + "…"
 	}
@@ -473,23 +467,30 @@ type CacheThrottleError struct {
 }
 
 func (e *CacheThrottleError) Error() string {
-	msg := "request throttled by cache"
+	var sb strings.Builder
+	sb.WriteString("request throttled by cache")
 	if e.Endpoint != "" {
-		msg += " " + e.Endpoint
+		sb.WriteString(" ")
+		sb.WriteString(e.Endpoint)
 	}
 	if e.Reason != "" {
-		msg += " (" + e.Reason + ")"
+		sb.WriteString(" (")
+		sb.WriteString(e.Reason)
+		sb.WriteString(")")
 	}
 	if e.RetryAfter > 0 {
-		msg += fmt.Sprintf("; retry after %s", e.RetryAfter)
+		fmt.Fprintf(&sb, "; retry after %s", e.RetryAfter)
 	}
 	if e.detail != "" {
-		msg += ": " + e.detail
+		// The detail is server-provided text: render it quoted so embedded
+		// control characters cannot forge log records downstream.
+		fmt.Fprintf(&sb, ": %q", e.detail)
 	}
 	if e.Err != nil {
-		msg += ": " + e.Err.Error()
+		sb.WriteString(": ")
+		sb.WriteString(e.Err.Error())
 	}
-	return msg
+	return sb.String()
 }
 
 func (e *CacheThrottleError) Unwrap() error {
@@ -516,8 +517,8 @@ func newThrottleErrorFromResponse(resp *http.Response, body, endpoint string) *C
 
 // newCacheThrottleError builds a CacheThrottleError from a cache's 429
 // response: the reason parsed from the JSON body's "error" field, the
-// Retry-After header, the endpoint host, and the body detail (sanitized
-// here — it is server-controlled text headed for logs and error strings).
+// Retry-After header, the endpoint host, and the body detail (truncated
+// here; quoted at display time since it is server-controlled text).
 func newCacheThrottleError(reason, detail, endpoint string, retryAfter time.Duration) *CacheThrottleError {
 	base := fmt.Errorf("cache %s throttled the request (%s)", endpoint, reason)
 	return &CacheThrottleError{
@@ -525,7 +526,7 @@ func newCacheThrottleError(reason, detail, endpoint string, retryAfter time.Dura
 		RetryAfter: retryAfter,
 		Endpoint:   endpoint,
 		Err:        throttleErrorForReason(reason, base),
-		detail:     sanitizeErrorDetail(detail),
+		detail:     truncateErrorDetail(detail),
 	}
 }
 

--- a/client/error_helpers.go
+++ b/client/error_helpers.go
@@ -91,29 +91,48 @@ func throttleErrorForReason(reason string, err error) error {
 	}
 }
 
-// parseThrottleReason extracts the machine-parseable reason from a cache's 429
-// JSON body of the form {"error": "<reason>", "detail": "..."}. The value is
-// validated against the known ShedReason constants — the body comes from a
-// remote peer, and an arbitrary string must not flow into logs or error
-// messages. Returns "" if the body is not JSON, has no "error" field, or
-// carries an unrecognized reason; callers then fall back to the generic
-// throttle classification.
-func parseThrottleReason(body string) string {
+// parseThrottleBody extracts the machine-parseable reason and the
+// human-readable detail from a cache's 429 JSON body of the form
+// {"error": "<reason>", "detail": "..."}.
+//
+// The reason is validated against the known ShedReason constants — the body
+// comes from a remote peer, and an arbitrary string must not flow into logs,
+// HTCondor ClassAds, or error messages. It is "" when the body is not JSON,
+// has no "error" field, or carries an unrecognized reason; callers then fall
+// back to the generic throttle classification.
+//
+// The detail is free-form server text and is not validated (it is bounded by
+// truncateErrorDetail and quoted at display time). A body that is not the
+// expected JSON shape is passed through whole as the detail so an error
+// message from some other kind of server is not silently dropped.
+func parseThrottleBody(body string) (reason, detail string) {
 	body = strings.TrimSpace(body)
 	if body == "" {
-		return ""
+		return "", ""
 	}
 	var parsed struct {
-		Error string `json:"error"`
+		Error  string `json:"error"`
+		Detail string `json:"detail"`
 	}
 	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
-		return ""
+		return "", body
+	}
+	if parsed.Detail != "" {
+		detail = parsed.Detail
+	} else {
+		detail = body
 	}
 	switch ShedReason(parsed.Error) {
 	case ShedOriginUnresponsive, ShedOriginSlow, ShedCacheOverloaded:
-		return parsed.Error
+		return parsed.Error, detail
 	}
-	return ""
+	return "", detail
+}
+
+// parseThrottleReason returns just the validated reason from a 429 body.
+func parseThrottleReason(body string) string {
+	reason, _ := parseThrottleBody(body)
+	return reason
 }
 
 // truncateErrorDetail bounds a server-provided message before it is retained
@@ -133,14 +152,21 @@ func truncateErrorDetail(detail string) string {
 // if absent or unparsable; values are clamped to maxRetryAfter.
 func parseRetryAfter(v string) time.Duration {
 	v = strings.TrimSpace(v)
-	var d time.Duration
 	if v == "" {
 		return 0
-	} else if secs, err := strconv.Atoi(v); err == nil {
+	}
+	var d time.Duration
+	// ParseInt rather than Atoi: Atoi is int-wide, so on a 32-bit build a
+	// perfectly ordinary "3000000000" would be a range error. On overflow
+	// ParseInt still returns the saturated bound, which the clamps below turn
+	// into maxRetryAfter (or 0) instead of falling through to the date parse
+	// and yielding no hint at all.
+	secs, err := strconv.ParseInt(v, 10, 64)
+	if err == nil || errors.Is(err, strconv.ErrRange) {
 		if secs < 0 {
 			return 0
 		}
-		if secs > int(maxRetryAfter/time.Second) {
+		if secs > int64(maxRetryAfter/time.Second) {
 			return maxRetryAfter
 		}
 		d = time.Duration(secs) * time.Second
@@ -510,9 +536,19 @@ func (e *CacheThrottleError) Is(target error) bool {
 // hint from the Retry-After header. body may be empty when the response
 // body was unavailable (e.g. HEAD).
 func newThrottleErrorFromResponse(resp *http.Response, body, endpoint string) *CacheThrottleError {
-	reason := parseThrottleReason(body)
+	reason, detail := parseThrottleBody(body)
 	retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
-	return newCacheThrottleError(reason, strings.TrimSpace(body), endpoint, retryAfter)
+	return newCacheThrottleError(reason, detail, endpoint, retryAfter)
+}
+
+// newThrottleErrorNoResponse builds the structured throttle error for a 429
+// observed through a library that does not expose the response, so neither the
+// body's reason nor the Retry-After header is available (the WebDAV client used
+// for stat is the case in point). The result still classifies as retryable and
+// still satisfies errors.Is(err, ErrTooManyRequests); it just carries no reason
+// or backoff hint.
+func newThrottleErrorNoResponse(endpoint, detail string) *CacheThrottleError {
+	return newCacheThrottleError("", detail, endpoint, 0)
 }
 
 // newCacheThrottleError builds a CacheThrottleError from a cache's 429

--- a/client/error_helpers.go
+++ b/client/error_helpers.go
@@ -117,16 +117,16 @@ func parseThrottleBody(body string) (reason, detail string) {
 	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
 		return "", body
 	}
-	if parsed.Detail != "" {
-		detail = parsed.Detail
-	} else {
-		detail = body
-	}
 	switch ShedReason(parsed.Error) {
 	case ShedOriginUnresponsive, ShedOriginSlow, ShedCacheOverloaded:
-		return parsed.Error, detail
+		// The reason is reported on its own, so falling back to the raw body
+		// here would just print it a second time.
+		return parsed.Error, parsed.Detail
 	}
-	return "", detail
+	if parsed.Detail != "" {
+		return "", parsed.Detail
+	}
+	return "", body
 }
 
 // parseThrottleReason returns just the validated reason from a 429 body.
@@ -556,7 +556,13 @@ func newThrottleErrorNoResponse(endpoint, detail string) *CacheThrottleError {
 // Retry-After header, the endpoint host, and the body detail (truncated
 // here; quoted at display time since it is server-controlled text).
 func newCacheThrottleError(reason, detail, endpoint string, retryAfter time.Duration) *CacheThrottleError {
-	base := fmt.Errorf("cache %s throttled the request (%s)", endpoint, reason)
+	// Not every 429 carries a reason -- a HEAD response has no body, and the
+	// WebDAV client hides the response entirely -- so omit the parenthetical
+	// rather than rendering an empty one.
+	base := fmt.Errorf("cache %s throttled the request", endpoint)
+	if reason != "" {
+		base = fmt.Errorf("cache %s throttled the request (%s)", endpoint, reason)
+	}
 	return &CacheThrottleError{
 		Reason:     reason,
 		RetryAfter: retryAfter,

--- a/client/error_helpers.go
+++ b/client/error_helpers.go
@@ -64,17 +64,27 @@ func wrapErrorByStatusCode(code int, err error) error {
 	}
 }
 
+// maxErrorBodySize bounds how much of an error-response body the client reads
+// and retains. Error bodies come from remote peers that are not necessarily
+// trustworthy; without a cap, a hostile server could feed each transfer worker
+// an arbitrarily large body.
+const maxErrorBodySize = 64 << 10
+
+// maxRetryAfter clamps the Retry-After hint carried on throttle errors so a
+// misbehaving server cannot push an absurd backoff to external retriers.
+const maxRetryAfter = time.Hour
+
 // throttleErrorForReason maps the machine-parseable reason string carried in a
 // cache's 429 response body (the "error" field written by the cache's
 // handleError) to the specific retryable Pelican error type. Unknown or empty
 // reasons fall back to the generic cache-overloaded classification.
 func throttleErrorForReason(reason string, err error) error {
-	switch reason {
-	case "origin_unresponsive":
+	switch ShedReason(reason) {
+	case ShedOriginUnresponsive:
 		return error_codes.NewTransfer_OriginUnresponsiveError(err)
-	case "origin_slow":
+	case ShedOriginSlow:
 		return error_codes.NewTransfer_OriginSlowError(err)
-	case "cache_overloaded":
+	case ShedCacheOverloaded:
 		return error_codes.NewTransfer_CacheOverloadedError(err)
 	default:
 		return error_codes.NewTransfer_CacheOverloadedError(err)
@@ -82,9 +92,12 @@ func throttleErrorForReason(reason string, err error) error {
 }
 
 // parseThrottleReason extracts the machine-parseable reason from a cache's 429
-// JSON body of the form {"error": "<reason>", "detail": "..."}. Returns "" if
-// the body is not JSON or has no "error" field, in which case callers fall back
-// to the generic throttle classification.
+// JSON body of the form {"error": "<reason>", "detail": "..."}. The value is
+// validated against the known ShedReason constants — the body comes from a
+// remote peer, and an arbitrary string must not flow into logs or error
+// messages. Returns "" if the body is not JSON, has no "error" field, or
+// carries an unrecognized reason; callers then fall back to the generic
+// throttle classification.
 func parseThrottleReason(body string) string {
 	body = strings.TrimSpace(body)
 	if body == "" {
@@ -96,29 +109,57 @@ func parseThrottleReason(body string) string {
 	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
 		return ""
 	}
-	return parsed.Error
+	switch ShedReason(parsed.Error) {
+	case ShedOriginUnresponsive, ShedOriginSlow, ShedCacheOverloaded:
+		return parsed.Error
+	}
+	return ""
+}
+
+// sanitizeErrorDetail makes a server-provided message safe to embed in log
+// lines and error strings: control characters (including CR/LF, which would
+// permit forging log records) are replaced with spaces and the result is
+// truncated.
+func sanitizeErrorDetail(detail string) string {
+	const maxDetail = 512
+	detail = strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return ' '
+		}
+		return r
+	}, detail)
+	if len(detail) > maxDetail {
+		detail = detail[:maxDetail] + "…"
+	}
+	return strings.TrimSpace(detail)
 }
 
 // parseRetryAfter parses an HTTP Retry-After header value. Per RFC 7231 it may
-// be a number of seconds or an HTTP date; the cache emits seconds. Returns 0 if
-// absent or unparsable.
+// be a number of seconds or an HTTP date; the cache emits seconds. Returns 0
+// if absent or unparsable; values are clamped to maxRetryAfter.
 func parseRetryAfter(v string) time.Duration {
 	v = strings.TrimSpace(v)
+	var d time.Duration
 	if v == "" {
 		return 0
-	}
-	if secs, err := strconv.Atoi(v); err == nil {
+	} else if secs, err := strconv.Atoi(v); err == nil {
 		if secs < 0 {
 			return 0
 		}
-		return time.Duration(secs) * time.Second
-	}
-	if t, err := http.ParseTime(v); err == nil {
-		if d := time.Until(t); d > 0 {
-			return d
+		if secs > int(maxRetryAfter/time.Second) {
+			return maxRetryAfter
 		}
+		d = time.Duration(secs) * time.Second
+	} else if t, err := http.ParseTime(v); err == nil {
+		d = time.Until(t)
 	}
-	return 0
+	if d < 0 {
+		return 0
+	}
+	if d > maxRetryAfter {
+		return maxRetryAfter
+	}
+	return d
 }
 
 // wrapStatusCodeError wraps a StatusCodeError with the appropriate PelicanError based on the status code
@@ -455,9 +496,28 @@ func (e *CacheThrottleError) Unwrap() error {
 	return e.Err
 }
 
+// Is reports a match for ErrTooManyRequests so a throttle observed as a
+// remote 429 satisfies the same errors.Is check as a shed performed by
+// this process's own scheduler.
+func (e *CacheThrottleError) Is(target error) bool {
+	return target == ErrTooManyRequests
+}
+
+// newThrottleErrorFromResponse builds the structured throttle error for an
+// HTTP 429 from any request flavor (GET, PUT, HEAD, COPY): the reason is
+// parsed (and validated) from the already-read response body, the backoff
+// hint from the Retry-After header. body may be empty when the response
+// body was unavailable (e.g. HEAD).
+func newThrottleErrorFromResponse(resp *http.Response, body, endpoint string) *CacheThrottleError {
+	reason := parseThrottleReason(body)
+	retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+	return newCacheThrottleError(reason, strings.TrimSpace(body), endpoint, retryAfter)
+}
+
 // newCacheThrottleError builds a CacheThrottleError from a cache's 429
 // response: the reason parsed from the JSON body's "error" field, the
-// Retry-After header, the endpoint host, and the raw body detail.
+// Retry-After header, the endpoint host, and the body detail (sanitized
+// here — it is server-controlled text headed for logs and error strings).
 func newCacheThrottleError(reason, detail, endpoint string, retryAfter time.Duration) *CacheThrottleError {
 	base := fmt.Errorf("cache %s throttled the request (%s)", endpoint, reason)
 	return &CacheThrottleError{
@@ -465,7 +525,7 @@ func newCacheThrottleError(reason, detail, endpoint string, retryAfter time.Dura
 		RetryAfter: retryAfter,
 		Endpoint:   endpoint,
 		Err:        throttleErrorForReason(reason, base),
-		detail:     detail,
+		detail:     sanitizeErrorDetail(detail),
 	}
 }
 

--- a/client/error_helpers.go
+++ b/client/error_helpers.go
@@ -21,11 +21,13 @@ package client
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -40,6 +42,13 @@ func wrapErrorByStatusCode(code int, err error) error {
 		return error_codes.NewSpecification_FileNotFoundError(err)
 	case code == http.StatusGatewayTimeout:
 		return error_codes.NewTransfer_TimedOutError(err)
+	case code == http.StatusTooManyRequests:
+		// 429 means the serving cache's fair scheduler shed the request. It is
+		// retryable. This is the generic fallback used when the response body
+		// carries no structured reason; the download path parses the body and
+		// substitutes a more specific origin_unresponsive / origin_slow
+		// classification via throttleErrorForReason.
+		return error_codes.NewTransfer_CacheOverloadedError(err)
 	case code == http.StatusUnauthorized || code == http.StatusForbidden:
 		// 401/403 are authorization errors
 		return error_codes.NewAuthorizationError(err)
@@ -53,6 +62,63 @@ func wrapErrorByStatusCode(code int, err error) error {
 		// For other status codes, wrap as Transfer error
 		return error_codes.NewTransferError(err)
 	}
+}
+
+// throttleErrorForReason maps the machine-parseable reason string carried in a
+// cache's 429 response body (the "error" field written by the cache's
+// handleError) to the specific retryable Pelican error type. Unknown or empty
+// reasons fall back to the generic cache-overloaded classification.
+func throttleErrorForReason(reason string, err error) error {
+	switch reason {
+	case "origin_unresponsive":
+		return error_codes.NewTransfer_OriginUnresponsiveError(err)
+	case "origin_slow":
+		return error_codes.NewTransfer_OriginSlowError(err)
+	case "cache_overloaded":
+		return error_codes.NewTransfer_CacheOverloadedError(err)
+	default:
+		return error_codes.NewTransfer_CacheOverloadedError(err)
+	}
+}
+
+// parseThrottleReason extracts the machine-parseable reason from a cache's 429
+// JSON body of the form {"error": "<reason>", "detail": "..."}. Returns "" if
+// the body is not JSON or has no "error" field, in which case callers fall back
+// to the generic throttle classification.
+func parseThrottleReason(body string) string {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return ""
+	}
+	var parsed struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		return ""
+	}
+	return parsed.Error
+}
+
+// parseRetryAfter parses an HTTP Retry-After header value. Per RFC 7231 it may
+// be a number of seconds or an HTTP date; the cache emits seconds. Returns 0 if
+// absent or unparsable.
+func parseRetryAfter(v string) time.Duration {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil {
+		if secs < 0 {
+			return 0
+		}
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
 }
 
 // wrapStatusCodeError wraps a StatusCodeError with the appropriate PelicanError based on the status code
@@ -345,6 +411,62 @@ func (e *HttpErrResp) Error() string {
 
 func (e *HttpErrResp) Unwrap() error {
 	return e.Err
+}
+
+// CacheThrottleError is returned when a cache responds with HTTP 429 because
+// its fair scheduler shed the request. It carries the machine-parseable Reason
+// (from the response body) and the RetryAfter hint (from the Retry-After
+// header) so callers and external retriers can distinguish an unresponsive
+// origin from a merely-slow one and honor the advertised backoff. It wraps the
+// specific retryable Pelican error type, so errors.As(err, &error_codes.PelicanError{})
+// and IsRetryable both work through the chain.
+type CacheThrottleError struct {
+	Reason     string
+	RetryAfter time.Duration
+	// Endpoint is the cache host that shed the request.
+	Endpoint string
+	// Err is the wrapped, specific retryable PelicanError.
+	Err error
+	// detail is the server-provided human-readable message.
+	detail string
+}
+
+func (e *CacheThrottleError) Error() string {
+	msg := "request throttled by cache"
+	if e.Endpoint != "" {
+		msg += " " + e.Endpoint
+	}
+	if e.Reason != "" {
+		msg += " (" + e.Reason + ")"
+	}
+	if e.RetryAfter > 0 {
+		msg += fmt.Sprintf("; retry after %s", e.RetryAfter)
+	}
+	if e.detail != "" {
+		msg += ": " + e.detail
+	}
+	if e.Err != nil {
+		msg += ": " + e.Err.Error()
+	}
+	return msg
+}
+
+func (e *CacheThrottleError) Unwrap() error {
+	return e.Err
+}
+
+// newCacheThrottleError builds a CacheThrottleError from a cache's 429
+// response: the reason parsed from the JSON body's "error" field, the
+// Retry-After header, the endpoint host, and the raw body detail.
+func newCacheThrottleError(reason, detail, endpoint string, retryAfter time.Duration) *CacheThrottleError {
+	base := fmt.Errorf("cache %s throttled the request (%s)", endpoint, reason)
+	return &CacheThrottleError{
+		Reason:     reason,
+		RetryAfter: retryAfter,
+		Endpoint:   endpoint,
+		Err:        throttleErrorForReason(reason, base),
+		detail:     detail,
+	}
 }
 
 // SlowTransferError methods

--- a/client/evict.go
+++ b/client/evict.go
@@ -167,9 +167,14 @@ func DoEvict(ctx context.Context, remoteObject string, immediate bool, options .
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	// Bound the read: the body comes from a remote cache, and an unbounded
+	// ReadAll here would be an allocation primitive for a hostile peer.
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
 	bodyStr := strings.TrimSpace(string(body))
 
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return "", newThrottleErrorFromResponse(resp, bodyStr, apiUrl.Host)
+	}
 	if resp.StatusCode >= 300 {
 		return "", errors.Errorf("eviction failed (%d): %s", resp.StatusCode, bodyStr)
 	}

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1700,6 +1700,14 @@ func (te *TransferEngine) runJobHandler() error {
 		case job, ok := <-te.work:
 			if !ok {
 				log.Debugln("Job handler has been shutdown")
+				// If a scheduler is configured it is a producer on
+				// te.files; stop it first so the close below cannot
+				// race with a scheduler dispatch and panic on a
+				// send-on-closed channel. Stop() is idempotent —
+				// engine.Shutdown() may call it again, harmlessly.
+				if te.scheduler != nil {
+					te.scheduler.Stop()
+				}
 				close(te.files)
 				return nil
 			}

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -5989,8 +5989,11 @@ func objectCached(ctx context.Context, objectUrl *url.URL, token *tokenGenerator
 	if err != nil {
 		return
 	}
-	// Allow response body to fail to read; we are only interested in the headers
-	// of the response, not the contents.
+	// The probe wants headers, but an error response's body carries the
+	// structured reason that tells a throttle apart from any other refusal, so
+	// keep a bounded prefix of it. Reading is allowed to fail; whatever is left
+	// is drained so the connection can be reused.
+	bodyPrefix, _ := io.ReadAll(io.LimitReader(headResponse.Body, maxErrorBodySize))
 	if _, err := io.Copy(io.Discard, headResponse.Body); err != nil {
 		log.Debugln("Failure when reading the one-byte-response body - expected because the body is discarded:", err)
 	}
@@ -6019,14 +6022,14 @@ func objectCached(ctx context.Context, objectUrl *url.URL, token *tokenGenerator
 		}
 	} else if headResponse.StatusCode == http.StatusTooManyRequests {
 		// Throttled: classify as the retryable throttle type, carrying the
-		// Retry-After hint (no body is available on this path).
+		// reason from the body and the Retry-After hint.
 		//
 		// Return rather than falling through to the HEAD retry below. The
 		// cache answers HEAD without going through its fair scheduler, so a
 		// HEAD would likely succeed and overwrite this error, reporting the
 		// object's cache status as authoritative when in fact the request
 		// that would tell us was shed.
-		err = newThrottleErrorFromResponse(headResponse, "", objectUrl.Host)
+		err = newThrottleErrorFromResponse(headResponse, string(bodyPrefix), objectUrl.Host)
 		return
 	} else {
 		sce := StatusCodeError(headResponse.StatusCode)

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -873,6 +873,18 @@ func NewTransferEngineWithScheduler(ctx context.Context, workerCount int, schedu
 		return te, nil
 	}
 	te.scheduler = scheduler
+	// Transfers still queued in the scheduler when it stops would
+	// otherwise vanish without a result, leaving their jobs' active
+	// counts permanently non-zero (and result waiters blocked until ctx
+	// cancellation). Synthesize a failure result for each, exactly as
+	// submitFile does for an admission rejection.
+	scheduler.onDrop = func(file *clientTransferFile) {
+		res := synthesizeRejectionResult(file, errors.New("transfer engine shut down before the transfer could be dispatched"))
+		select {
+		case te.results <- res:
+		case <-te.ctx.Done():
+		}
+	}
 	scheduler.Start(te.ctx, te.files)
 	return te, nil
 }
@@ -2794,10 +2806,22 @@ func runTransferWorkerFile(ctx context.Context, file *clientTransferFile, result
 	var err error
 	var transferResults TransferResults
 	switch file.file.xferType {
-	case transferTypeUpload:
-		transferResults, err = uploadObject(file.file)
-	case transferTypeCopy:
-		transferResults, err = copyHTTP(file.file)
+	case transferTypeUpload, transferTypeCopy:
+		// The scheduler's "starving" bucket tracks transfers that have not
+		// yet produced a first byte of downloaded body; uploads and
+		// third-party copies have no wiring to report data progress back to
+		// the scheduler. Mark them non-starving at dispatch — otherwise the
+		// (much smaller) starving cap would silently become their effective
+		// per-tag concurrency limit. The cost is that the unresponsive-
+		// destination protection does not apply to these transfer types.
+		if file.file.schedFirstByte != nil {
+			file.file.schedFirstByte()
+		}
+		if file.file.xferType == transferTypeUpload {
+			transferResults, err = uploadObject(file.file)
+		} else {
+			transferResults, err = copyHTTP(file.file)
+		}
 	default:
 		transferResults, err = downloadObject(file.file)
 	}
@@ -3815,7 +3839,10 @@ func downloadHTTP(ctx context.Context, te *TransferEngine, callback TransferCall
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
 		log.WithFields(fields).Debugln("Got failure status code:", resp.StatusCode)
-		bodyBytes, readErr := io.ReadAll(resp.Body)
+		// Cap the error-body read: the peer is not necessarily trustworthy,
+		// and the body is copied into error strings that outlive the
+		// request. Anything useful fits well within the cap.
+		bodyBytes, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
 		if readErr != nil {
 			log.WithFields(fields).Debugln("Failed to read response body for error:", readErr)
 		}
@@ -3839,11 +3866,9 @@ func downloadHTTP(ctx context.Context, te *TransferEngine, callback TransferCall
 			// error is classified as the specific retryable throttle type and
 			// the advertised backoff is carried to the caller / external
 			// retrier.
-			reason := parseThrottleReason(bodyStr)
-			retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
-			throttleErr := newCacheThrottleError(reason, strings.TrimSpace(bodyStr), transfer.Url.Host, retryAfter)
-			log.WithFields(fields).Warnf("Cache %s throttled the request (reason=%s, retry-after=%s)",
-				transfer.Url.Host, reason, retryAfter)
+			throttleErr := newThrottleErrorFromResponse(resp, bodyStr, transfer.Url.Host)
+			log.WithFields(fields).Warnf("Server %s throttled the request (reason=%s, retry-after=%s)",
+				transfer.Url.Host, throttleErr.Reason, throttleErr.RetryAfter)
 			return 0, 0, -1, serverVersion, "", throttleErr
 		}
 		sce := StatusCodeError(resp.StatusCode)
@@ -4628,6 +4653,15 @@ Loop:
 			// older versions of XRootD incorrectly use 200.
 			if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusCreated {
 				log.Errorln("Got failure status code:", response.StatusCode)
+				if response.StatusCode == http.StatusTooManyRequests {
+					// The destination throttled the upload; classify it with
+					// the structured reason + Retry-After hint so the error is
+					// the same retryable throttle type a download would get.
+					// runPut re-buffered the (bounded) error body for us.
+					bodyBytes, _ := io.ReadAll(io.LimitReader(response.Body, maxErrorBodySize))
+					lastError = newThrottleErrorFromResponse(response, string(bodyBytes), request.URL.Host)
+					break Loop
+				}
 				sce := StatusCodeError(response.StatusCode)
 				// Wrap StatusCodeError with appropriate PelicanError based on status code
 				wrappedErr := wrapStatusCodeError(&sce)
@@ -4792,13 +4826,17 @@ func runPut(request *http.Request, responseChan chan<- *http.Response, errorChan
 	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusCreated {
 		log.Errorln("Error status code:", response.Status)
 		log.Debugln("From the server:")
-		textResponse, err := io.ReadAll(response.Body)
+		textResponse, err := io.ReadAll(io.LimitReader(response.Body, maxErrorBodySize))
 		if err != nil {
 			log.Errorln("Error reading response from server:", err)
 			responseChan <- response
 			return
 		}
 		log.Debugln(string(textResponse))
+		// Re-buffer the (bounded) body so the consumer on responseChan can
+		// still inspect it — e.g. to extract the structured reason from a
+		// 429 throttle response.
+		response.Body = io.NopCloser(strings.NewReader(string(textResponse)))
 	}
 	responseChan <- response
 
@@ -4961,6 +4999,12 @@ func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfer
 						transferAttempts[i].Url = fileURL
 						log.Debugln("Constructed attempt URL for download:", fileURL.String(), "remote path:", remotePath)
 					}
+					// totalXfer must be counted before submission: a scheduler
+					// rejection pushes a synthetic failure result for this
+					// file, and runMux treats totalXfer == 0 as "job created
+					// no transfers" and closes the results channel — racing
+					// the synthetic result's delivery.
+					job.job.totalXfer += 1
 					job.job.activeXfer.Add(1)
 					if err := te.submitFile(job.job.ctx, &clientTransferFile{
 						uuid:  job.uuid,
@@ -4986,8 +5030,6 @@ func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfer
 						}
 						// 429 already reported to te.results by submitFile;
 						// continue enumerating the collection.
-					} else {
-						job.job.totalXfer += 1
 					}
 				}
 			}
@@ -5045,6 +5087,10 @@ func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfer
 				transferAttempts[i].Url = fileURL
 				log.Debugln("Constructed attempt URL for download:", fileURL.String(), "remote path:", remotePath)
 			}
+			// totalXfer is counted before submission so a scheduler
+			// rejection's synthetic result cannot race runMux's
+			// "no transfers created" close of the results channel.
+			job.job.totalXfer += 1
 			job.job.activeXfer.Add(1)
 			if err := te.submitFile(job.job.ctx, &clientTransferFile{
 				uuid:  job.uuid,
@@ -5068,8 +5114,6 @@ func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfer
 				if !errors.Is(err, ErrTooManyRequests) {
 					return err
 				}
-			} else {
-				job.job.totalXfer += 1
 			}
 		}
 	}
@@ -5099,6 +5143,10 @@ func (te *TransferEngine) walkDirUpload(job *clientTransferJob, transfers []tran
 			if remotePath := path.Join(job.job.remoteURL.Path, strings.TrimPrefix(localPath, job.job.localPath)); skipUpload(job.job, localPath, job.job.remoteURL) {
 				log.Infoln("Skipping upload of object", remotePath, "as it already exists at the destination")
 			} else if info.Mode().Type().IsRegular() {
+				// totalXfer is counted before submission so a scheduler
+				// rejection's synthetic result cannot race runMux's
+				// "no transfers created" close of the results channel.
+				job.job.totalXfer += 1
 				job.job.activeXfer.Add(1)
 				if err := te.submitFile(job.job.ctx, &clientTransferFile{
 					uuid:  job.uuid,
@@ -5119,8 +5167,6 @@ func (te *TransferEngine) walkDirUpload(job *clientTransferJob, transfers []tran
 					if !errors.Is(err, ErrTooManyRequests) {
 						return err
 					}
-				} else {
-					job.job.totalXfer += 1
 				}
 			}
 			return nil
@@ -5146,6 +5192,10 @@ func (te *TransferEngine) walkDirUpload(job *clientTransferJob, transfers []tran
 		} else if skipUpload(job.job, newPath, remoteUrl) {
 			log.Infoln("Skipping upload of object", remoteUrl.Path, "as it already exists at the destination")
 		} else if info.Type().IsRegular() {
+			// totalXfer is counted before submission so a scheduler
+			// rejection's synthetic result cannot race runMux's
+			// "no transfers created" close of the results channel.
+			job.job.totalXfer += 1
 			job.job.activeXfer.Add(1)
 			if err := te.submitFile(job.job.ctx, &clientTransferFile{
 				uuid:  job.uuid,
@@ -5166,8 +5216,6 @@ func (te *TransferEngine) walkDirUpload(job *clientTransferJob, transfers []tran
 				if !errors.Is(err, ErrTooManyRequests) {
 					return err
 				}
-			} else {
-				job.job.totalXfer += 1
 			}
 		}
 	}
@@ -5833,6 +5881,10 @@ func objectCached(ctx context.Context, objectUrl *url.URL, token *tokenGenerator
 				age = ageParsed
 			}
 		}
+	} else if headResponse.StatusCode == http.StatusTooManyRequests {
+		// Throttled: classify as the retryable throttle type, carrying the
+		// Retry-After hint (no body is available on this path).
+		err = newThrottleErrorFromResponse(headResponse, "", objectUrl.Host)
 	} else {
 		sce := StatusCodeError(headResponse.StatusCode)
 		err = &HttpErrResp{
@@ -5874,6 +5926,8 @@ func objectCached(ctx context.Context, objectUrl *url.URL, token *tokenGenerator
 
 			}
 		}
+	} else if headResponse.StatusCode == http.StatusTooManyRequests {
+		err = newThrottleErrorFromResponse(headResponse, "", objectUrl.Host)
 	} else {
 		sce := StatusCodeError(headResponse.StatusCode)
 		err = &HttpErrResp{

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -968,6 +968,25 @@ func (te *TransferEngine) submitFile(ctx context.Context, file *clientTransferFi
 	}
 }
 
+// workerFailureResult builds the result a transfer worker reports for a file it
+// declines to run.
+//
+// The job pointer matters: runMux dereferences it on every result it routes, to
+// decrement the job's active-transfer count and decide whether the job is
+// finished. A result without it is a nil dereference on the runMux goroutine,
+// which takes the process down -- and does so *after* the result has already
+// been handed to the client, so the crash does not even look related to the
+// transfer that caused it.
+func workerFailureResult(file *clientTransferFile, err error) TransferResults {
+	if file.file == nil || file.file.job == nil {
+		return TransferResults{JobId: file.jobId, Error: err}
+	}
+	res := newTransferResults(file.file.job)
+	res.JobId = file.jobId
+	res.Error = err
+	return res
+}
+
 // uncountSubmission undoes the activeXfer increment a caller made just before
 // a submission that then failed for a reason other than a scheduler shed.
 //
@@ -1508,7 +1527,12 @@ func (te *TransferEngine) Close() {
 
 // If we've detected a job is done, clean up the active job state map
 func (te *TransferEngine) finishJob(activeJobs *map[uuid.UUID][]*TransferJob, job *TransferJob, id uuid.UUID) {
-	if len((*activeJobs)[id]) == 1 {
+	// Retiring the client's last job -- or being handed a job that is no longer
+	// in the list at all -- has to leave no entry behind. Storing an
+	// empty-but-non-nil slice would make the client look permanently active:
+	// the close-time check tests that entry against nil, so the results channel
+	// would never close and Shutdown() would wait forever.
+	if len((*activeJobs)[id]) <= 1 {
 		log.Debugln("Job", job.ID(), "is done for client", id.String(), "which has no active jobs remaining")
 		// Delete the job from the list of active jobs
 		delete(*activeJobs, id)
@@ -2844,11 +2868,8 @@ func runTransferWorkerFile(ctx context.Context, file *clientTransferFile, result
 		case <-ctx.Done():
 			return ctx.Err()
 		case results <- &clientTransferResults{
-			id: file.uuid,
-			results: TransferResults{
-				JobId: file.jobId,
-				Error: file.file.ctx.Err(),
-			},
+			id:      file.uuid,
+			results: workerFailureResult(file, file.file.ctx.Err()),
 		}:
 		}
 		return nil
@@ -2858,11 +2879,8 @@ func runTransferWorkerFile(ctx context.Context, file *clientTransferFile, result
 		case <-ctx.Done():
 			return ctx.Err()
 		case results <- &clientTransferResults{
-			id: file.uuid,
-			results: TransferResults{
-				JobId: file.jobId,
-				Error: file.file.err,
-			},
+			id:      file.uuid,
+			results: workerFailureResult(file, file.file.err),
 		}:
 		}
 		return nil

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -969,6 +969,23 @@ func (te *TransferEngine) submitFile(ctx context.Context, file *clientTransferFi
 	}
 }
 
+// uncountSubmission undoes the totalXfer/activeXfer increment a caller made
+// just before a submission that then failed for a reason other than a
+// scheduler shed.
+//
+// Those counts have to be taken before submitting, because a shed produces a
+// synthetic result immediately and runMux reads totalXfer == 0 as "this job
+// created no transfers". Any other failure produces no result at all, so the
+// counts have to come back off: a job whose active count never drains is never
+// finished, and the client's results channel stays open forever.
+//
+// Only safe to call from the goroutine that owns the job's lookup, since
+// totalXfer is a plain int written only there.
+func (tj *TransferJob) uncountSubmission() {
+	tj.totalXfer -= 1
+	tj.activeXfer.Add(-1)
+}
+
 // deriveSchedulerTag chooses the tag under which a transfer is admitted.
 // The tag is the hostname of the first attempt (the primary upstream
 // origin); the key is opaque to the scheduler, so a username or prefix can
@@ -2784,11 +2801,9 @@ func (te *TransferEngine) createTransferFiles(job *clientTransferJob) (err error
 			log.Debugln("Scheduler rejected transfer for", remoteUrl.String(), ":", submitErr)
 			return
 		}
-		// Nothing was queued and no result will ever be produced, so undo the
-		// bookkeeping above; leaving it in place would keep activeXfer
-		// permanently non-zero and the client's results channel open forever.
-		job.job.totalXfer -= 1
-		job.job.activeXfer.Add(-1)
+		// Nothing was queued and no result is coming, so this file must not
+		// stay on the job's books.
+		job.job.uncountSubmission()
 		err = submitErr
 		return
 	}
@@ -5152,6 +5167,9 @@ func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfer
 						},
 					}); err != nil {
 						if !errors.Is(err, ErrTooManyRequests) {
+							// Nothing was queued and no result is coming, so this
+							// file must not stay on the job's books.
+							job.job.uncountSubmission()
 							return err
 						}
 						// 429 already reported to te.results by submitFile;
@@ -5238,6 +5256,9 @@ func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfer
 				},
 			}); err != nil {
 				if !errors.Is(err, ErrTooManyRequests) {
+					// Nothing was queued and no result is coming, so this
+					// file must not stay on the job's books.
+					job.job.uncountSubmission()
 					return err
 				}
 			}
@@ -5291,6 +5312,9 @@ func (te *TransferEngine) walkDirUpload(job *clientTransferJob, transfers []tran
 					},
 				}); err != nil {
 					if !errors.Is(err, ErrTooManyRequests) {
+						// Nothing was queued and no result is coming, so this
+						// file must not stay on the job's books.
+						job.job.uncountSubmission()
 						return err
 					}
 				}
@@ -5340,6 +5364,9 @@ func (te *TransferEngine) walkDirUpload(job *clientTransferJob, transfers []tran
 				},
 			}); err != nil {
 				if !errors.Is(err, ErrTooManyRequests) {
+					// Nothing was queued and no result is coming, so this
+					// file must not stay on the job's books.
+					job.job.uncountSubmission()
 					return err
 				}
 			}

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -274,11 +274,13 @@ type (
 		// TagScheduler hooks: nil unless the engine was constructed with a
 		// scheduler. schedFirstByte fires once (idempotent) as soon as the
 		// remote end proves responsive: for downloads, the first non-empty
-		// body byte written to the local sink; for uploads, a negotiated
-		// 100-continue or the first byte of the PUT response; for
-		// third-party copies, the first byte of the COPY response or the
-		// first performance marker, whichever arrives first. schedDone
-		// fires exactly once when the worker is done with this file.
+		// body byte written to the local sink; for uploads, the earliest of
+		// a negotiated 100-continue, the first byte of the PUT response, or
+		// uploadNonStarvingSentBytes of body consumed by the transport (the
+		// far end must be draining it); for third-party copies, the first
+		// byte of the COPY response or the first performance marker,
+		// whichever arrives first. schedDone fires exactly once when the
+		// worker is done with this file.
 		schedFirstByte func()
 		schedDone      func()
 	}
@@ -4329,12 +4331,29 @@ func (cs *ConstantSizer) BytesComplete() int64 {
 	return cs.read.Load()
 }
 
+// uploadNonStarvingSentBytes is the volume of request body the transport must
+// have consumed before an upload destination is presumed to be draining the
+// connection. Kernel socket buffers plus the transport's own buffering can
+// absorb a few megabytes from a peer that has stopped reading, so a small
+// number of sent bytes proves nothing; once this many bytes have gone out,
+// the far end must actually be consuming them.
+const uploadNonStarvingSentBytes = 4 << 20
+
 // progressReader wraps the io.Reader to get progress
 // Adapted from https://stackoverflow.com/questions/26050380/go-tracking-post-request-progress
 type progressReader struct {
 	reader io.ReadCloser
 	sizer  Sizer
 	closed chan bool
+
+	// sentBytes counts what the HTTP transport has consumed from the
+	// reader (a close proxy for bytes sent on the wire — the transport's
+	// write buffering is a few KiB). When it crosses sentThreshold,
+	// onSentThreshold fires once. Both are touched only from Read, which
+	// the transport calls from a single goroutine, so no locking.
+	sentBytes       int64
+	sentThreshold   int64
+	onSentThreshold func()
 }
 
 // Read implements the common read function for io.Reader
@@ -4342,6 +4361,13 @@ func (pr *progressReader) Read(p []byte) (n int, err error) {
 	n, err = pr.reader.Read(p)
 	if cs, ok := pr.sizer.(*ConstantSizer); ok {
 		cs.read.Add(int64(n))
+	}
+	if pr.onSentThreshold != nil {
+		pr.sentBytes += int64(n)
+		if pr.sentBytes >= pr.sentThreshold {
+			pr.onSentThreshold()
+			pr.onSentThreshold = nil
+		}
 	}
 	return n, err
 }
@@ -4577,22 +4603,28 @@ func uploadObject(transfer *transferFile) (transferResult TransferResults, err e
 	closed := make(chan bool, 1)
 	errorChan := make(chan error, 1)
 	responseChan := make(chan *http.Response)
-	reader := &progressReader{ioreader, sizer, closed}
+	reader := &progressReader{reader: ioreader, sizer: sizer, closed: closed}
 	// This will write to the checksum hashes as we read from the file
 	tee := io.TeeReader(reader, hashesWriter)
 	putContext, cancel := context.WithCancel(transfer.ctx)
 	transferStartTime := time.Now()
 	defer cancel()
 	log.Debugln("Full destination URL:", dest.String())
-	// Tell the scheduler (if any) the destination is alive as soon as it says
-	// anything back: a negotiated 100-continue is the earliest such proof,
-	// otherwise the first byte of the final response is.  The trace is scoped
-	// to the PUT itself, not to the checksum fetch that reuses putContext.
-	// Note that we do not send an Expect: 100-continue header, so
-	// Got100Continue only fires when the transport negotiates it on its own.
+	// Tell the scheduler (if any) the destination is alive on the earliest of
+	// three signals: a negotiated 100-continue, the first byte of the final
+	// response, or enough request body consumed that the far end must be
+	// draining it (without 100-continue, a server that only answers after the
+	// whole body would otherwise leave a long upload "starving" for its
+	// entire duration). The hook is CAS-guarded upstream, so the three paths
+	// firing in any combination is harmless. The trace is scoped to the PUT
+	// itself, not to the checksum fetch that reuses putContext. Note that we
+	// do not send an Expect: 100-continue header, so Got100Continue only
+	// fires when the transport negotiates it on its own.
 	requestContext := putContext
 	if transfer.schedFirstByte != nil {
 		schedFirstByte := transfer.schedFirstByte
+		reader.sentThreshold = uploadNonStarvingSentBytes
+		reader.onSentThreshold = schedFirstByte
 		requestContext = httptrace.WithClientTrace(putContext, &httptrace.ClientTrace{
 			Got100Continue:       func() { schedFirstByte() },
 			GotFirstResponseByte: func() { schedFirstByte() },

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -3833,6 +3833,19 @@ func downloadHTTP(ctx context.Context, te *TransferEngine, callback TransferCall
 			}
 			return 0, 0, -1, serverVersion, "", error_codes.NewAuthorizationError(pde)
 		}
+		if resp.StatusCode == http.StatusTooManyRequests {
+			// The serving cache's fair scheduler shed this request. Parse the
+			// structured reason from the body and the Retry-After hint so the
+			// error is classified as the specific retryable throttle type and
+			// the advertised backoff is carried to the caller / external
+			// retrier.
+			reason := parseThrottleReason(bodyStr)
+			retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+			throttleErr := newCacheThrottleError(reason, strings.TrimSpace(bodyStr), transfer.Url.Host, retryAfter)
+			log.WithFields(fields).Warnf("Cache %s throttled the request (reason=%s, retry-after=%s)",
+				transfer.Url.Host, reason, retryAfter)
+			return 0, 0, -1, serverVersion, "", throttleErr
+		}
 		sce := StatusCodeError(resp.StatusCode)
 		// Wrap StatusCodeError with appropriate PelicanError based on status code
 		wrappedErr := wrapStatusCodeError(&sce)

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -970,11 +970,17 @@ func (te *TransferEngine) submitFile(ctx context.Context, file *clientTransferFi
 }
 
 // deriveSchedulerTag chooses the tag under which a transfer is admitted.
-// For now we tag by the hostname of the first attempt (the primary
-// upstream origin). We deliberately do not retag on failover: if the
-// transfer moves from origin A to origin B mid-flight, it keeps A's
-// slot for the duration of the transfer. This is a small fairness leak
-// bounded by the transfer's lifetime.
+// The tag is the hostname of the first attempt (the primary upstream
+// origin); the key is opaque to the scheduler, so a username or prefix can
+// be composed into it later without a scheduler change. We deliberately do
+// not retag on failover: if the transfer moves from origin A to origin B
+// mid-flight, it keeps A's slot for the duration of the transfer. This is a
+// small fairness leak bounded by the transfer's lifetime.
+//
+// A transfer with no usable attempt URL falls back to the empty tag. Every
+// such transfer then shares one tag and therefore one set of caps, so log
+// it: callers are expected to have resolved at least one attempt by now, and
+// silently collapsing them together would look like unexplained throttling.
 func deriveSchedulerTag(file *clientTransferFile) string {
 	if file == nil || file.file == nil {
 		return ""
@@ -982,6 +988,7 @@ func deriveSchedulerTag(file *clientTransferFile) string {
 	if len(file.file.attempts) > 0 && file.file.attempts[0].Url != nil {
 		return file.file.attempts[0].Url.Host
 	}
+	log.Warningln("Transfer has no attempt URL to derive a scheduler tag from; it will share the fallback tag's share of the worker pool")
 	return ""
 }
 
@@ -2737,6 +2744,10 @@ func (te *TransferEngine) createTransferFiles(job *clientTransferJob) (err error
 	}
 
 	log.Debugln("Queuing transfer for object", remoteUrl.String(), "with first transfer URL:", transfers[0].Url.String())
+	// totalXfer must be counted before submission: a scheduler rejection
+	// pushes a synthetic failure result for this file, and runMux treats
+	// totalXfer == 0 as "job created no transfers" and closes the results
+	// channel — racing the synthetic result's delivery.
 	job.job.totalXfer += 1
 	job.job.activeXfer.Add(1)
 	submitErr := te.submitFile(job.job.ctx, &clientTransferFile{
@@ -2766,13 +2777,20 @@ func (te *TransferEngine) createTransferFiles(job *clientTransferJob) (err error
 		},
 	})
 	if submitErr != nil {
-		// ErrTooManyRequests already reported to te.results by submitFile;
-		// other errors (ctx cancellation) are surfaced by the caller.
 		if errors.Is(submitErr, ErrTooManyRequests) {
+			// submitFile already pushed a synthetic failure result for this
+			// file, so the counts above are matched and the job completes
+			// normally with a 429 result.
 			log.Debugln("Scheduler rejected transfer for", remoteUrl.String(), ":", submitErr)
-		} else {
-			log.Debugln("Transfer engine has been cancelled, not queuing new transfer file information")
+			return
 		}
+		// Nothing was queued and no result will ever be produced, so undo the
+		// bookkeeping above; leaving it in place would keep activeXfer
+		// permanently non-zero and the client's results channel open forever.
+		job.job.totalXfer -= 1
+		job.job.activeXfer.Add(-1)
+		err = submitErr
+		return
 	}
 
 	return
@@ -4602,7 +4620,11 @@ func uploadObject(transfer *transferFile) (transferResult TransferResults, err e
 	// Create the wrapped reader and send it to the request
 	closed := make(chan bool, 1)
 	errorChan := make(chan error, 1)
-	responseChan := make(chan *http.Response)
+	// Buffered: the loop below abandons the upload on several paths (stopped
+	// transfer, error on the side channel) without ever receiving here, and an
+	// unbuffered channel would wedge runPut's goroutine — and with it the
+	// transport still reading the source file — for the life of the process.
+	responseChan := make(chan *http.Response, 1)
 	reader := &progressReader{reader: ioreader, sizer: sizer, closed: closed}
 	// This will write to the checksum hashes as we read from the file
 	tee := io.TeeReader(reader, hashesWriter)
@@ -4668,7 +4690,20 @@ func uploadObject(transfer *transferFile) (transferResult TransferResults, err e
 
 	useProxy := transfer.attempts[0].Proxy
 
-	go runPut(request, responseChan, errorChan, useProxy)
+	putDone := make(chan struct{})
+	go func() {
+		defer close(putDone)
+		runPut(request, responseChan, errorChan, useProxy)
+	}()
+	// The transport reads the source file until the request finishes, so the
+	// PUT has to be stopped and joined before the deferred file.Close() above
+	// can run; otherwise abandoning the upload early turns a clean abort into
+	// a read from a closed file. Registered after `defer cancel()`, so it runs
+	// before it -- cancel here to make the join prompt.
+	defer func() {
+		cancel()
+		<-putDone
+	}()
 	var lastError error = nil
 
 	tickerDuration := 100 * time.Millisecond
@@ -4905,7 +4940,11 @@ func runPut(request *http.Request, responseChan chan<- *http.Response, errorChan
 		close(errorChan)
 		return
 	}
-	dump, _ = httputil.DumpResponse(response, true)
+	// Headers only: dumping the body would io.ReadAll it into memory, which
+	// defeats the bounded read below and hands a hostile destination an
+	// unbounded allocation per upload worker. Error bodies are logged (and
+	// bounded) a few lines down.
+	dump, _ = httputil.DumpResponse(response, false)
 	log.Debugf("Dumping response: %s", dump)
 	// Note: XRootD used to always return 200 (OK) on upload, even when it was supposed to turn
 	// HTTP 201 (Created).  Check for both here; in the future we may want to remove the 200 check
@@ -5827,6 +5866,16 @@ func statHttpImpl(dest *pelican_url.PelicanURL, dirResp server_structs.DirectorR
 					err = error_codes.NewSpecification_FileNotFoundError(err)
 					resultsChan <- statResults{FileInfo{}, err}
 					return
+				} else if gowebdav.IsErrCode(err, http.StatusTooManyRequests) {
+					// The endpoint shed the request. Classify it so it is
+					// retryable rather than falling through to the generic
+					// (non-retryable) bucket below; the WebDAV client does not
+					// surface the response, so there is no reason or
+					// Retry-After hint to carry.
+					err = newThrottleErrorNoResponse(endpoint.Host,
+						fmt.Sprintf("stat of %s was throttled at endpoint %s", dest.String(), endpoint.String()))
+					resultsChan <- statResults{FileInfo{}, err}
+					return
 				} else if gowebdav.IsErrCode(err, http.StatusInternalServerError) {
 					// 500 is NOT "not found"; report it as a server error so
 					// callers (e.g. uploadObject) can distinguish a genuine
@@ -5971,7 +6020,14 @@ func objectCached(ctx context.Context, objectUrl *url.URL, token *tokenGenerator
 	} else if headResponse.StatusCode == http.StatusTooManyRequests {
 		// Throttled: classify as the retryable throttle type, carrying the
 		// Retry-After hint (no body is available on this path).
+		//
+		// Return rather than falling through to the HEAD retry below. The
+		// cache answers HEAD without going through its fair scheduler, so a
+		// HEAD would likely succeed and overwrite this error, reporting the
+		// object's cache status as authoritative when in fact the request
+		// that would tell us was shed.
 		err = newThrottleErrorFromResponse(headResponse, "", objectUrl.Host)
+		return
 	} else {
 		sce := StatusCodeError(headResponse.StatusCode)
 		err = &HttpErrResp{

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -4495,6 +4495,12 @@ func uploadObject(transfer *transferFile) (transferResult TransferResults, err e
 				}
 				return transferResult, transferResult.Error
 			}
+			// Nothing else closes this handle: the request body below is a
+			// TeeReader (not a ReadCloser), so the HTTP transport wraps it
+			// in a NopCloser and never closes the underlying file. Without
+			// this, every filesystem upload leaks a file descriptor — and
+			// on Windows leaves the source file locked.
+			defer file.Close()
 			ioreader = file
 			sizer = &ConstantSizer{size: fileInfo.Size()}
 			fileSizeHint = fileInfo.Size()

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -269,6 +269,13 @@ type (
 		reader             io.ReadCloser           // Optional reader for uploads
 		byteRange          *ByteRange              // Optional byte range for partial downloads
 		metadataChan       chan<- TransferMetadata // Optional channel to receive early transfer metadata
+
+		// TagScheduler hooks: nil unless the engine was constructed with a
+		// scheduler. schedFirstByte fires once, on the first non-empty body
+		// byte written to the local sink (idempotent). schedDone fires
+		// exactly once when the worker is done with this file.
+		schedFirstByte func()
+		schedDone      func()
 	}
 
 	// A representation of a "transfer job".  The job
@@ -357,6 +364,7 @@ type (
 		dirRespCache       *DirRespCache   // Prefix-matching cache for director responses
 		prestageAPISupport map[string]bool // Lookup table for caches that support the Pelican prestage API (key: host)
 		prestageAPIMutex   sync.RWMutex    // Protects the prestageAPISupport map
+		scheduler          *TagScheduler   // Optional fair-scheduler; when set, admits before te.files
 	}
 
 	TransferCallbackFunc = func(path string, downloaded int64, totalSize int64, completed bool)
@@ -440,6 +448,10 @@ type (
 		closed         atomic.Bool
 		bytesPerSecond atomic.Int64
 		lastRateSample time.Time
+		// onFirstByte, if non-nil, fires exactly once when the first
+		// non-empty write lands. Used by TagScheduler to promote a
+		// transfer from the starving bucket to the active bucket.
+		onFirstByte func()
 	}
 )
 
@@ -841,6 +853,81 @@ func NewTransferEngineWithWorkers(ctx context.Context, workerCount int) (te *Tra
 	egrp.Go(te.runMux)
 	egrp.Go(te.runJobHandler)
 	return
+}
+
+// NewTransferEngineWithScheduler creates a transfer engine like
+// NewTransferEngineWithWorkers, but wires it to a TagScheduler that
+// admits transfers into per-tag FIFOs and dispatches them to workers
+// with a weighted random draw. Callers that don't want per-tag fairness
+// (e.g., single-user CLI transfers) should keep using
+// NewTransferEngineWithWorkers.
+//
+// The scheduler must have been created with NewTagScheduler; it will be
+// started by this function and stopped when the engine shuts down.
+func NewTransferEngineWithScheduler(ctx context.Context, workerCount int, scheduler *TagScheduler) (te *TransferEngine, err error) {
+	te, err = NewTransferEngineWithWorkers(ctx, workerCount)
+	if err != nil {
+		return nil, err
+	}
+	if scheduler == nil {
+		return te, nil
+	}
+	te.scheduler = scheduler
+	scheduler.Start(te.ctx, te.files)
+	return te, nil
+}
+
+// submitFile hands a clientTransferFile off to the worker pool. When a
+// scheduler is configured, the file goes through per-tag admission
+// (which may return ErrTooManyRequests); otherwise it goes straight to
+// the workers via te.files.
+//
+// On a scheduler rejection the function pushes a synthetic
+// clientTransferResults to te.results so the job-completion machinery
+// observes the failure exactly as it would for any other transfer
+// error, then returns the rejection error to the caller.
+func (te *TransferEngine) submitFile(ctx context.Context, file *clientTransferFile) error {
+	if te.scheduler != nil {
+		tag := deriveSchedulerTag(file)
+		err := te.scheduler.Submit(ctx, tag, file)
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, ErrTooManyRequests) {
+			select {
+			case te.results <- synthesizeRejectionResult(file, err):
+			case <-te.ctx.Done():
+				return te.ctx.Err()
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		return err
+	}
+	select {
+	case te.files <- file:
+		return nil
+	case <-te.ctx.Done():
+		return te.ctx.Err()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// deriveSchedulerTag chooses the tag under which a transfer is admitted.
+// For now we tag by the hostname of the first attempt (the primary
+// upstream origin). We deliberately do not retag on failover: if the
+// transfer moves from origin A to origin B mid-flight, it keeps A's
+// slot for the duration of the transfer. This is a small fairness leak
+// bounded by the transfer's lifetime.
+func deriveSchedulerTag(file *clientTransferFile) string {
+	if file == nil || file.file == nil {
+		return ""
+	}
+	if len(file.file.attempts) > 0 && file.file.attempts[0].Url != nil {
+		return file.file.attempts[0].Url.Host
+	}
+	return ""
 }
 
 // Create an option that provides a callback for a TransferClient
@@ -1326,6 +1413,9 @@ func (te *TransferEngine) Shutdown() error {
 	te.cancel()
 
 	err := te.egrp.Wait()
+	if te.scheduler != nil {
+		te.scheduler.Stop()
+	}
 	if err != nil && err != context.Canceled {
 		return err
 	}
@@ -2519,7 +2609,7 @@ func (te *TransferEngine) createTransferFiles(job *clientTransferJob) (err error
 			// federation namespace, https://example.com/prefix/ in this case.
 			remotePath := transfers[0].Url.Path
 			transfers[0].Url.Path = strings.TrimSuffix(path.Clean(remotePath), path.Clean(job.job.remoteURL.Path))
-			return te.walkDirUpload(job, transfers, te.files, job.job.localPath)
+			return te.walkDirUpload(job, transfers, job.job.localPath)
 		} else if job.job.xferType == transferTypeDownload {
 			// For recursive downloads, stat the remote path.
 			var statInfo FileInfo
@@ -2538,7 +2628,7 @@ func (te *TransferEngine) createTransferFiles(job *clientTransferJob) (err error
 				return errors.Wrap(statErr, "failed to stat remote path for recursive download")
 			}
 			if statInfo.IsCollection {
-				return te.walkDirDownload(job, transfers, te.files, remoteUrl)
+				return te.walkDirDownload(job, transfers, remoteUrl)
 			}
 		} else if job.job.xferType == transferTypeCopy {
 			// For copy, stat the SOURCE to see if it's a collection.
@@ -2559,7 +2649,7 @@ func (te *TransferEngine) createTransferFiles(job *clientTransferJob) (err error
 			}
 
 			if statInfo.IsCollection {
-				return te.walkDirCopy(job, transfers, te.files, srcUrl)
+				return te.walkDirCopy(job, transfers, srcUrl)
 			}
 		}
 		log.Debugln("Remote path is not a collection; proceeding with single file transfer")
@@ -2578,7 +2668,7 @@ func (te *TransferEngine) createTransferFiles(job *clientTransferJob) (err error
 				return
 			}
 			if statInfo.IsCollection {
-				return te.walkDirDownload(job, transfers, te.files, remoteUrl)
+				return te.walkDirDownload(job, transfers, remoteUrl)
 			}
 		}
 	}
@@ -2586,10 +2676,7 @@ func (te *TransferEngine) createTransferFiles(job *clientTransferJob) (err error
 	log.Debugln("Queuing transfer for object", remoteUrl.String(), "with first transfer URL:", transfers[0].Url.String())
 	job.job.totalXfer += 1
 	job.job.activeXfer.Add(1)
-	select {
-	case <-te.ctx.Done():
-		log.Debugln("Transfer engine has been cancelled, not queuing new transfer file information")
-	case te.files <- &clientTransferFile{
+	submitErr := te.submitFile(job.job.ctx, &clientTransferFile{
 		uuid:  job.uuid,
 		jobId: job.job.uuid,
 		file: &transferFile{
@@ -2614,7 +2701,15 @@ func (te *TransferEngine) createTransferFiles(job *clientTransferJob) (err error
 			byteRange:          job.job.byteRange,
 			metadataChan:       job.job.metadataChan,
 		},
-	}:
+	})
+	if submitErr != nil {
+		// ErrTooManyRequests already reported to te.results by submitFile;
+		// other errors (ctx cancellation) are surfaced by the caller.
+		if errors.Is(submitErr, ErrTooManyRequests) {
+			log.Debugln("Scheduler rejected transfer for", remoteUrl.String(), ":", submitErr)
+		} else {
+			log.Debugln("Transfer engine has been cancelled, not queuing new transfer file information")
+		}
 	}
 
 	return
@@ -2640,63 +2735,81 @@ func runTransferWorker(ctx context.Context, workChan <-chan *clientTransferFile,
 					return nil
 				}
 			}
-			if file.file.ctx.Err() == context.Canceled {
-				select {
-				case <-ctx.Done():
-					return ctx.Err()
-				case results <- &clientTransferResults{
-					id: file.uuid,
-					results: TransferResults{
-						JobId: file.jobId,
-						Error: file.file.ctx.Err(),
-					},
-				}:
-				}
-				break
-			}
-			if file.file.err != nil {
-				select {
-				case <-ctx.Done():
-					return ctx.Err()
-
-				case results <- &clientTransferResults{
-					id: file.uuid,
-					results: TransferResults{
-						JobId: file.jobId,
-						Error: file.file.err,
-					},
-				}:
-				}
-				break
-			}
-			var err error
-			var transferResults TransferResults
-			switch file.file.xferType {
-			case transferTypeUpload:
-				transferResults, err = uploadObject(file.file)
-			case transferTypeCopy:
-				transferResults, err = copyHTTP(file.file)
-			default:
-				transferResults, err = downloadObject(file.file)
-			}
-			transferResults.JobId = file.jobId
-			transferResults.Scheme = file.file.remoteURL.Scheme
-			if err != nil {
-				log.Errorf("Error when attempting to transfer object %s for client %s: %v", file.file.remoteURL, file.uuid.String(), err)
-				transferResults = newTransferResults(file.file.job)
-				transferResults.Scheme = file.file.remoteURL.Scheme
-				transferResults.Error = err
-			}
-			if file.file.job != nil && file.file.job.dirResp.RedirectInfo != nil {
-				transferResults.DirectorDecision = file.file.job.dirResp.RedirectInfo
-			}
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case results <- &clientTransferResults{id: file.uuid, results: transferResults}:
+			// Wrap the per-file body in a closure so the scheduler's
+			// schedDone hook (if any) fires exactly once per file via
+			// defer, not once for the worker's entire lifetime.
+			if err := runTransferWorkerFile(ctx, file, results); err != nil {
+				return err
 			}
 		}
 	}
+}
+
+// runTransferWorkerFile processes one file dequeued by a transfer
+// worker. It always fires file.file.schedDone (if set) on exit.
+// Returns a non-nil error only if the worker itself should exit (e.g.
+// ctx cancellation while we were trying to write results).
+func runTransferWorkerFile(ctx context.Context, file *clientTransferFile, results chan<- *clientTransferResults) error {
+	if file.file != nil && file.file.schedDone != nil {
+		schedDone := file.file.schedDone
+		file.file.schedDone = nil
+		defer schedDone()
+	}
+	if file.file.ctx.Err() == context.Canceled {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case results <- &clientTransferResults{
+			id: file.uuid,
+			results: TransferResults{
+				JobId: file.jobId,
+				Error: file.file.ctx.Err(),
+			},
+		}:
+		}
+		return nil
+	}
+	if file.file.err != nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case results <- &clientTransferResults{
+			id: file.uuid,
+			results: TransferResults{
+				JobId: file.jobId,
+				Error: file.file.err,
+			},
+		}:
+		}
+		return nil
+	}
+	var err error
+	var transferResults TransferResults
+	switch file.file.xferType {
+	case transferTypeUpload:
+		transferResults, err = uploadObject(file.file)
+	case transferTypeCopy:
+		transferResults, err = copyHTTP(file.file)
+	default:
+		transferResults, err = downloadObject(file.file)
+	}
+	transferResults.JobId = file.jobId
+	transferResults.Scheme = file.file.remoteURL.Scheme
+	if err != nil {
+		log.Errorf("Error when attempting to transfer object %s for client %s: %v", file.file.remoteURL, file.uuid.String(), err)
+		transferResults = newTransferResults(file.file.job)
+		transferResults.Scheme = file.file.remoteURL.Scheme
+		transferResults.Error = err
+	}
+	if file.file.job != nil && file.file.job.dirResp.RedirectInfo != nil {
+		transferResults.DirectorDecision = file.file.job.dirResp.RedirectInfo
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case results <- &clientTransferResults{id: file.uuid, results: transferResults}:
+	}
+	return nil
 }
 
 // attemptSorter pairs a responsiveness score with a transfer attempt for sorting.
@@ -3145,7 +3258,7 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 			byteRangeEnd = transfer.byteRange.End
 		}
 		attemptDownloaded, timeToFirstByte, cacheAge, serverVersion, attemptETag, err := downloadHTTP(
-			ctx, transfer.engine, transfer.callback, transferEndpoint, writeDestination, fileWriter, rangeStart+downloaded, byteRangeEnd, size, tokenContents, transfer.project, transfer.metadataChan,
+			ctx, transfer.engine, transfer.callback, transferEndpoint, writeDestination, fileWriter, rangeStart+downloaded, byteRangeEnd, size, tokenContents, transfer.project, transfer.metadataChan, transfer.schedFirstByte,
 		)
 		// Clear metadata channel after first attempt - we only want to send metadata once
 		transfer.metadataChan = nil
@@ -3536,7 +3649,7 @@ func verifyFileSize(dest string, expectedSize int64, fields log.Fields) error {
 //   - metadataChan: optional channel to receive early transfer metadata (ETag, size, etc.) before data transfer.
 //
 // Returns the downloaded size, time to 1st byte downloaded, serverVersion and an error if there is one
-func downloadHTTP(ctx context.Context, te *TransferEngine, callback TransferCallbackFunc, transfer transferAttemptDetails, dest string, writer io.Writer, bytesSoFar int64, byteRangeEnd int64, totalSize int64, token string, project string, metadataChan chan<- TransferMetadata) (downloaded int64, timeToFirstByte time.Duration, cacheAge time.Duration, serverVersion string, etag string, err error) {
+func downloadHTTP(ctx context.Context, te *TransferEngine, callback TransferCallbackFunc, transfer transferAttemptDetails, dest string, writer io.Writer, bytesSoFar int64, byteRangeEnd int64, totalSize int64, token string, project string, metadataChan chan<- TransferMetadata, onFirstByte func()) (downloaded int64, timeToFirstByte time.Duration, cacheAge time.Duration, serverVersion string, etag string, err error) {
 	fields, ok := ctx.Value(logFields("fields")).(log.Fields)
 	if !ok {
 		fields = log.Fields{}
@@ -3897,7 +4010,8 @@ func downloadHTTP(ctx context.Context, te *TransferEngine, callback TransferCall
 	// In a deferred function, we wait on the done channel to get the signal that the download is done
 	done := make(chan error, 1)
 	pw := &progressWriter{
-		writer: writer,
+		writer:      writer,
+		onFirstByte: onFirstByte,
 	}
 
 	go func() {
@@ -4174,6 +4288,9 @@ func (pw *progressWriter) Write(p []byte) (n int, err error) {
 	}
 	if pw.firstByteTime.IsZero() && len(p) > 0 {
 		pw.firstByteTime = time.Now()
+		if pw.onFirstByte != nil {
+			pw.onFirstByte()
+		}
 	}
 	now := time.Now()
 	startupTime := now.Sub(pw.firstByteTime)
@@ -4744,7 +4861,7 @@ func skipUpload(job *TransferJob, localPath string, remoteUrl *pelican_url.Pelic
 }
 
 // Walk a remote collection in a WebDAV server, emitting the files discovered
-func (te *TransferEngine) walkDirDownload(job *clientTransferJob, transfers []transferAttemptDetails, files chan *clientTransferFile, url *url.URL) error {
+func (te *TransferEngine) walkDirDownload(job *clientTransferJob, transfers []transferAttemptDetails, url *url.URL) error {
 	// Create the client to walk the filesystem
 	collUrl := job.job.dirResp.XPelNsHdr.CollectionsUrl
 	if collUrl == nil {
@@ -4753,14 +4870,14 @@ func (te *TransferEngine) walkDirDownload(job *clientTransferJob, transfers []tr
 	log.Debugln("Trying collections URL: ", collUrl.String())
 
 	client := createWebDavClient(collUrl, job.job.token, job.job.project)
-	return te.walkDirDownloadHelper(job, transfers, files, url.Path, client)
+	return te.walkDirDownloadHelper(job, transfers, url.Path, client)
 }
 
 // Helper function for the `walkDirDownload`.
 //
 // Recursively walks through the remote server collection, emitting transfer files
 // for the engine to process.
-func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfers []transferAttemptDetails, files chan *clientTransferFile, remotePath string, client *gowebdav.Client) error {
+func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfers []transferAttemptDetails, remotePath string, client *gowebdav.Client) error {
 	// Check for cancelation since the client does not respect the context
 	if err := job.job.ctx.Err(); err != nil {
 		return err
@@ -4824,10 +4941,7 @@ func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfer
 						log.Debugln("Constructed attempt URL for download:", fileURL.String(), "remote path:", remotePath)
 					}
 					job.job.activeXfer.Add(1)
-					select {
-					case <-job.job.ctx.Done():
-						return job.job.ctx.Err()
-					case files <- &clientTransferFile{
+					if err := te.submitFile(job.job.ctx, &clientTransferFile{
 						uuid:  job.uuid,
 						jobId: job.job.uuid,
 						file: &transferFile{
@@ -4845,7 +4959,13 @@ func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfer
 							fedToken:           job.job.fedToken,
 							attempts:           transferAttempts,
 						},
-					}:
+					}); err != nil {
+						if !errors.Is(err, ErrTooManyRequests) {
+							return err
+						}
+						// 429 already reported to te.results by submitFile;
+						// continue enumerating the collection.
+					} else {
 						job.job.totalXfer += 1
 					}
 				}
@@ -4859,7 +4979,7 @@ func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfer
 	for _, info := range infos {
 		newPath := path.Join(remotePath, info.Name())
 		if info.IsDir() {
-			err := te.walkDirDownloadHelper(job, transfers, files, newPath, client)
+			err := te.walkDirDownloadHelper(job, transfers, newPath, client)
 			if err != nil {
 				return err
 			}
@@ -4905,10 +5025,7 @@ func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfer
 				log.Debugln("Constructed attempt URL for download:", fileURL.String(), "remote path:", remotePath)
 			}
 			job.job.activeXfer.Add(1)
-			select {
-			case <-job.job.ctx.Done():
-				return job.job.ctx.Err()
-			case files <- &clientTransferFile{
+			if err := te.submitFile(job.job.ctx, &clientTransferFile{
 				uuid:  job.uuid,
 				jobId: job.job.uuid,
 				file: &transferFile{
@@ -4926,7 +5043,11 @@ func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfer
 					fedToken:           job.job.fedToken,
 					attempts:           transferAttempts,
 				},
-			}:
+			}); err != nil {
+				if !errors.Is(err, ErrTooManyRequests) {
+					return err
+				}
+			} else {
 				job.job.totalXfer += 1
 			}
 		}
@@ -4935,7 +5056,7 @@ func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfer
 }
 
 // Helper function for walkDirUpload; not to be called directly
-func (te *TransferEngine) walkDirUpload(job *clientTransferJob, transfers []transferAttemptDetails, files chan *clientTransferFile, localPath string) error {
+func (te *TransferEngine) walkDirUpload(job *clientTransferJob, transfers []transferAttemptDetails, localPath string) error {
 	if job.job.ctx.Err() != nil {
 		return job.job.ctx.Err()
 	}
@@ -4958,10 +5079,7 @@ func (te *TransferEngine) walkDirUpload(job *clientTransferJob, transfers []tran
 				log.Infoln("Skipping upload of object", remotePath, "as it already exists at the destination")
 			} else if info.Mode().Type().IsRegular() {
 				job.job.activeXfer.Add(1)
-				select {
-				case <-job.job.ctx.Done():
-					return job.job.ctx.Err()
-				case files <- &clientTransferFile{
+				if err := te.submitFile(job.job.ctx, &clientTransferFile{
 					uuid:  job.uuid,
 					jobId: job.job.uuid,
 					file: &transferFile{
@@ -4976,7 +5094,11 @@ func (te *TransferEngine) walkDirUpload(job *clientTransferJob, transfers []tran
 						token:      job.job.token,
 						attempts:   transfers,
 					},
-				}:
+				}); err != nil {
+					if !errors.Is(err, ErrTooManyRequests) {
+						return err
+					}
+				} else {
 					job.job.totalXfer += 1
 				}
 			}
@@ -4996,7 +5118,7 @@ func (te *TransferEngine) walkDirUpload(job *clientTransferJob, transfers []tran
 
 		if info.IsDir() {
 			// Recursively call this function to create any nested dir's as well as list their files
-			err := te.walkDirUpload(job, transfers, files, newPath)
+			err := te.walkDirUpload(job, transfers, newPath)
 			if err != nil {
 				return err
 			}
@@ -5004,10 +5126,7 @@ func (te *TransferEngine) walkDirUpload(job *clientTransferJob, transfers []tran
 			log.Infoln("Skipping upload of object", remoteUrl.Path, "as it already exists at the destination")
 		} else if info.Type().IsRegular() {
 			job.job.activeXfer.Add(1)
-			select {
-			case <-job.job.ctx.Done():
-				return job.job.ctx.Err()
-			case files <- &clientTransferFile{
+			if err := te.submitFile(job.job.ctx, &clientTransferFile{
 				uuid:  job.uuid,
 				jobId: job.job.uuid,
 				file: &transferFile{
@@ -5022,7 +5141,11 @@ func (te *TransferEngine) walkDirUpload(job *clientTransferJob, transfers []tran
 					token:      job.job.token,
 					attempts:   transfers,
 				},
-			}:
+			}); err != nil {
+				if !errors.Is(err, ErrTooManyRequests) {
+					return err
+				}
+			} else {
 				job.job.totalXfer += 1
 			}
 		}

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -300,7 +300,6 @@ type (
 		lookupDone         atomic.Bool
 		lookupErr          error
 		activeXfer         atomic.Int64
-		totalXfer          int
 		skipped403         sync.Mutex // Protects skipped403Objs slice
 		skipped403Objs     []string   // List of object paths skipped due to 403 during sync
 		localPath          string
@@ -969,20 +968,17 @@ func (te *TransferEngine) submitFile(ctx context.Context, file *clientTransferFi
 	}
 }
 
-// uncountSubmission undoes the totalXfer/activeXfer increment a caller made
-// just before a submission that then failed for a reason other than a
-// scheduler shed.
+// uncountSubmission undoes the activeXfer increment a caller made just before
+// a submission that then failed for a reason other than a scheduler shed.
 //
-// Those counts have to be taken before submitting, because a shed produces a
-// synthetic result immediately and runMux reads totalXfer == 0 as "this job
-// created no transfers". Any other failure produces no result at all, so the
-// counts have to come back off: a job whose active count never drains is never
-// finished, and the client's results channel stays open forever.
-//
-// Only safe to call from the goroutine that owns the job's lookup, since
-// totalXfer is a plain int written only there.
+// The count has to be taken before submitting: a shed produces a synthetic
+// result immediately, and runMux both decrements on every result and retires
+// the job when the count reaches zero, so counting afterwards would let the
+// result be processed against a count that had not been taken yet. Any other
+// failure produces no result at all, so the count has to come back off -- a
+// job whose active count never drains is never finished, and the client's
+// results channel stays open forever.
 func (tj *TransferJob) uncountSubmission() {
-	tj.totalXfer -= 1
 	tj.activeXfer.Add(-1)
 }
 
@@ -2755,11 +2751,9 @@ func (te *TransferEngine) createTransferFiles(job *clientTransferJob) (err error
 	}
 
 	log.Debugln("Queuing transfer for object", remoteUrl.String(), "with first transfer URL:", transfers[0].Url.String())
-	// totalXfer must be counted before submission: a scheduler rejection
-	// pushes a synthetic failure result for this file, and runMux treats
-	// totalXfer == 0 as "job created no transfers" and closes the results
-	// channel — racing the synthetic result's delivery.
-	job.job.totalXfer += 1
+	// Counted before submission: a scheduler rejection produces a synthetic
+	// result right away, and runMux decrements on every result, so counting
+	// afterwards would race that result's delivery.
 	job.job.activeXfer.Add(1)
 	submitErr := te.submitFile(job.job.ctx, &clientTransferFile{
 		uuid:  job.uuid,
@@ -4704,14 +4698,31 @@ func uploadObject(transfer *transferFile) (transferResult TransferResults, err e
 		defer close(putDone)
 		runPut(request, responseChan, errorChan, useProxy)
 	}()
-	// The transport reads the source file until the request finishes, so the
-	// PUT has to be stopped and joined before the deferred file.Close() above
-	// can run; otherwise abandoning the upload early turns a clean abort into
-	// a read from a closed file. Registered after `defer cancel()`, so it runs
-	// before it -- cancel here to make the join prompt.
+	// The transport reads the source file until the request finishes, so cancel
+	// the PUT and join its goroutine before the deferred file.Close() above can
+	// run. Registered after `defer cancel()`, so it runs before it -- cancelling
+	// here is what makes the join prompt.
+	//
+	// This narrows rather than eliminates the overlap: client.Do returns once
+	// response headers arrive, so on an early server response the transport's
+	// write loop can still be reading the body when runPut returns, and
+	// cancellation is asynchronous. os.File tolerates that (the read fails with
+	// ErrFileClosing rather than hitting a reused descriptor) and the transfer
+	// has already latched its error, so the remaining window is benign.
+	//
+	// Also drain the response the abandoned PUT may have deposited: nothing
+	// else is going to receive it, and its body holds a connection open until
+	// the cancel tears it down.
 	defer func() {
 		cancel()
 		<-putDone
+		select {
+		case resp := <-responseChan:
+			if resp != nil && resp.Body != nil {
+				resp.Body.Close()
+			}
+		default:
+		}
 	}()
 	var lastError error = nil
 
@@ -5134,12 +5145,9 @@ func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfer
 						transferAttempts[i].Url = fileURL
 						log.Debugln("Constructed attempt URL for download:", fileURL.String(), "remote path:", remotePath)
 					}
-					// totalXfer must be counted before submission: a scheduler
-					// rejection pushes a synthetic failure result for this
-					// file, and runMux treats totalXfer == 0 as "job created
-					// no transfers" and closes the results channel — racing
-					// the synthetic result's delivery.
-					job.job.totalXfer += 1
+					// Counted before submission: a scheduler rejection produces a
+					// synthetic result right away, and runMux decrements on every
+					// result, so counting afterwards would race its delivery.
 					job.job.activeXfer.Add(1)
 					if err := te.submitFile(job.job.ctx, &clientTransferFile{
 						uuid:  job.uuid,
@@ -5225,10 +5233,9 @@ func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfer
 				transferAttempts[i].Url = fileURL
 				log.Debugln("Constructed attempt URL for download:", fileURL.String(), "remote path:", remotePath)
 			}
-			// totalXfer is counted before submission so a scheduler
-			// rejection's synthetic result cannot race runMux's
-			// "no transfers created" close of the results channel.
-			job.job.totalXfer += 1
+			// Counted before submission: a scheduler rejection produces a
+			// synthetic result right away, and runMux decrements on every
+			// result, so counting afterwards would race its delivery.
 			job.job.activeXfer.Add(1)
 			if err := te.submitFile(job.job.ctx, &clientTransferFile{
 				uuid:  job.uuid,
@@ -5284,10 +5291,9 @@ func (te *TransferEngine) walkDirUpload(job *clientTransferJob, transfers []tran
 			if remotePath := path.Join(job.job.remoteURL.Path, strings.TrimPrefix(localPath, job.job.localPath)); skipUpload(job.job, localPath, job.job.remoteURL) {
 				log.Infoln("Skipping upload of object", remotePath, "as it already exists at the destination")
 			} else if info.Mode().Type().IsRegular() {
-				// totalXfer is counted before submission so a scheduler
-				// rejection's synthetic result cannot race runMux's
-				// "no transfers created" close of the results channel.
-				job.job.totalXfer += 1
+				// Counted before submission: a scheduler rejection produces a
+				// synthetic result right away, and runMux decrements on every
+				// result, so counting afterwards would race its delivery.
 				job.job.activeXfer.Add(1)
 				if err := te.submitFile(job.job.ctx, &clientTransferFile{
 					uuid:  job.uuid,
@@ -5336,10 +5342,9 @@ func (te *TransferEngine) walkDirUpload(job *clientTransferJob, transfers []tran
 		} else if skipUpload(job.job, newPath, remoteUrl) {
 			log.Infoln("Skipping upload of object", remoteUrl.Path, "as it already exists at the destination")
 		} else if info.Type().IsRegular() {
-			// totalXfer is counted before submission so a scheduler
-			// rejection's synthetic result cannot race runMux's
-			// "no transfers created" close of the results channel.
-			job.job.totalXfer += 1
+			// Counted before submission: a scheduler rejection produces a
+			// synthetic result right away, and runMux decrements on every
+			// result, so counting afterwards would race its delivery.
 			job.job.activeXfer.Add(1)
 			if err := te.submitFile(job.job.ctx, &clientTransferFile{
 				uuid:  job.uuid,
@@ -6010,11 +6015,18 @@ func objectCached(ctx context.Context, objectUrl *url.URL, token *tokenGenerator
 	if err != nil {
 		return
 	}
-	// The probe wants headers, but an error response's body carries the
+	// The probe wants headers, but an *error* response's body carries the
 	// structured reason that tells a throttle apart from any other refusal, so
-	// keep a bounded prefix of it. Reading is allowed to fail; whatever is left
-	// is drained so the connection can be reused.
-	bodyPrefix, _ := io.ReadAll(io.LimitReader(headResponse.Body, maxErrorBodySize))
+	// keep a bounded prefix in that case only. On the success path the body is
+	// streamed to Discard through a reusable buffer instead, which matters
+	// because this request's "Range: 0-0" omits the required "bytes=" unit --
+	// servers routinely ignore it and send the whole object, and retaining
+	// 64 KiB of that per probe would be a needless cost. Reading is allowed to
+	// fail; whatever is left is drained so the connection can be reused.
+	var bodyPrefix []byte
+	if headResponse.StatusCode >= 400 {
+		bodyPrefix, _ = io.ReadAll(io.LimitReader(headResponse.Body, maxErrorBodySize))
+	}
 	if _, err := io.Copy(io.Discard, headResponse.Body); err != nil {
 		log.Debugln("Failure when reading the one-byte-response body - expected because the body is discarded:", err)
 	}

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1715,27 +1715,21 @@ func (te *TransferEngine) runMux() error {
 			// Notification that a job has been processed into files (or failed)
 			job := recv.Interface().(*clientTransferJob)
 			job.job.lookupDone.Store(true)
-			// If no transfers were created or we have an error, the job is no
-			// longer active
-			if job.job.lookupErr != nil || job.job.totalXfer == 0 {
-				// Remove this job from the list of active jobs for the client.
-				activeJobs[job.uuid] = slices.DeleteFunc(activeJobs[job.uuid], func(oldJob *TransferJob) bool {
-					return oldJob.uuid == job.job.uuid
-				})
-				if len(activeJobs[job.uuid]) == 0 {
-					func() {
-						te.clientLock.Lock()
-						defer te.clientLock.Unlock()
-						// If the client is closed and there are no remaining
-						// jobs for that client, we can close the results channel.
-						if te.workMap[job.uuid] == nil {
-							close(te.resultsMap[job.uuid])
-						}
-					}()
-				}
-			} else if job.job.activeXfer.Load() == 0 {
-				// Transfer jobs were created but they all completed before the recursive directory
-				// walk finished.
+			// A job is finished once its lookup is done AND every transfer the
+			// lookup handed to the workers has reported back.
+			//
+			// A lookup failure does not by itself end the job. A recursive walk
+			// can fail partway through, after it has already submitted files
+			// that are now in flight, and each of those still owes the client a
+			// result. Retiring the job here on the strength of lookupErr alone
+			// would close the client's results channel out from under them:
+			// the next result to arrive is then a send on a closed channel,
+			// which takes down the process.
+			//
+			// The same predicate is applied as each result arrives, so whichever
+			// happens last -- the lookup finishing or the final result landing --
+			// is what retires the job.
+			if job.job.activeXfer.Load() == 0 {
 				te.finishJob(&activeJobs, job.job, job.uuid)
 			}
 		} else if chosen == len(workMap)+len(resultsMap)+5 {

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -33,6 +33,7 @@ import (
 	"math"
 	"net"
 	"net/http"
+	"net/http/httptrace"
 	"net/http/httputil"
 	"net/url"
 	"os"
@@ -271,9 +272,13 @@ type (
 		metadataChan       chan<- TransferMetadata // Optional channel to receive early transfer metadata
 
 		// TagScheduler hooks: nil unless the engine was constructed with a
-		// scheduler. schedFirstByte fires once, on the first non-empty body
-		// byte written to the local sink (idempotent). schedDone fires
-		// exactly once when the worker is done with this file.
+		// scheduler. schedFirstByte fires once (idempotent) as soon as the
+		// remote end proves responsive: for downloads, the first non-empty
+		// body byte written to the local sink; for uploads, a negotiated
+		// 100-continue or the first byte of the PUT response; for
+		// third-party copies, the first byte of the COPY response or the
+		// first performance marker, whichever arrives first. schedDone
+		// fires exactly once when the worker is done with this file.
 		schedFirstByte func()
 		schedDone      func()
 	}
@@ -794,23 +799,74 @@ func (tr TransferResults) ID() string {
 	return tr.JobId.String()
 }
 
-// Returns a new transfer engine object whose lifetime is tied
-// to the provided context.  Will launcher worker goroutines to
-// handle the underlying transfers
-// NewTransferEngine creates a transfer engine using the client's configured
-// worker count (Client.WorkerCount).
-func NewTransferEngine(ctx context.Context) (te *TransferEngine, err error) {
-	return NewTransferEngineWithWorkers(ctx, param.Client_WorkerCount.GetInt())
+// transferEngineConfig collects the settings assembled from the
+// TransferEngineOption arguments handed to NewTransferEngine.
+type transferEngineConfig struct {
+	workerCount int
+	scheduler   *TagScheduler
+}
+
+// TransferEngineOption customizes the engine returned by NewTransferEngine.
+//
+// Unlike TransferOption (an alias for the option package's untyped
+// interface), engine options are a distinct function type; the two sets are
+// therefore not interchangeable, so a per-transfer option such as
+// WithCallback cannot be handed to the constructor and silently dropped.
+type TransferEngineOption func(*transferEngineConfig)
+
+// WithWorkerCount sets the number of transfer workers the engine launches,
+// overriding the Client.WorkerCount default.  This lets embedded consumers
+// (e.g. the cache) run with more concurrency than a command-line client
+// would.  A workerCount <= 0 is an error at construction.
+func WithWorkerCount(workerCount int) TransferEngineOption {
+	return func(cfg *transferEngineConfig) {
+		cfg.workerCount = workerCount
+	}
+}
+
+// WithScheduler wires the engine to a TagScheduler that admits transfers
+// into per-tag FIFOs and dispatches them to workers with a weighted random
+// draw.  Callers that don't want per-tag fairness (e.g., single-user CLI
+// transfers) should omit this option.
+//
+// The scheduler must have been created with NewTagScheduler; it is started
+// by NewTransferEngine and stopped when the engine shuts down.  A nil
+// scheduler is ignored.
+func WithScheduler(scheduler *TagScheduler) TransferEngineOption {
+	return func(cfg *transferEngineConfig) {
+		cfg.scheduler = scheduler
+	}
 }
 
 // NewTransferEngineWithWorkers creates a transfer engine with an explicit
-// number of transfer workers, overriding the Client.WorkerCount default.  This
-// lets embedded consumers (e.g. the cache) run with more concurrency than a
-// command-line client would.  A workerCount <= 0 is an error.
+// number of transfer workers.
+//
+// Deprecated: use NewTransferEngine with WithWorkerCount.
 func NewTransferEngineWithWorkers(ctx context.Context, workerCount int) (te *TransferEngine, err error) {
+	return NewTransferEngine(ctx, WithWorkerCount(workerCount))
+}
+
+// Returns a new transfer engine object whose lifetime is tied
+// to the provided context.  Will launcher worker goroutines to
+// handle the underlying transfers
+//
+// With no options the engine runs the client's configured number of workers
+// (Client.WorkerCount) and hands transfers straight to them; see
+// WithWorkerCount and WithScheduler to change either behavior.
+func NewTransferEngine(ctx context.Context, opts ...TransferEngineOption) (te *TransferEngine, err error) {
 	// If we did not initClient yet, we should fail to avoid unexpected/undesired behavior
 	if !config.IsClientInitialized() {
 		return nil, errors.New("client has not been initialized, unable to create transfer engine")
+	}
+
+	cfg := transferEngineConfig{workerCount: param.Client_WorkerCount.GetInt()}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	// Validate before anything is allocated so a bad worker count cannot leak
+	// the derived context or the URL cache's goroutine.
+	if cfg.workerCount <= 0 {
+		return nil, errors.New("worker count must be a positive integer")
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -841,52 +897,37 @@ func NewTransferEngineWithWorkers(ctx context.Context, workerCount int) (te *Tra
 		dirRespCache:       NewDirRespCache(5 * time.Minute),
 		prestageAPISupport: make(map[string]bool),
 	}
-	if workerCount <= 0 {
-		return nil, errors.New("worker count must be a positive integer")
-	}
-	for idx := 0; idx < workerCount; idx++ {
+	for idx := 0; idx < cfg.workerCount; idx++ {
 		egrp.Go(func() error {
 			return runTransferWorker(ctx, te.files, te.results)
 		})
 	}
-	te.workersActive = workerCount
+	te.workersActive = cfg.workerCount
 	egrp.Go(te.runMux)
 	egrp.Go(te.runJobHandler)
-	return
-}
 
-// NewTransferEngineWithScheduler creates a transfer engine like
-// NewTransferEngineWithWorkers, but wires it to a TagScheduler that
-// admits transfers into per-tag FIFOs and dispatches them to workers
-// with a weighted random draw. Callers that don't want per-tag fairness
-// (e.g., single-user CLI transfers) should keep using
-// NewTransferEngineWithWorkers.
-//
-// The scheduler must have been created with NewTagScheduler; it will be
-// started by this function and stopped when the engine shuts down.
-func NewTransferEngineWithScheduler(ctx context.Context, workerCount int, scheduler *TagScheduler) (te *TransferEngine, err error) {
-	te, err = NewTransferEngineWithWorkers(ctx, workerCount)
-	if err != nil {
-		return nil, err
-	}
-	if scheduler == nil {
-		return te, nil
-	}
-	te.scheduler = scheduler
-	// Transfers still queued in the scheduler when it stops would
-	// otherwise vanish without a result, leaving their jobs' active
-	// counts permanently non-zero (and result waiters blocked until ctx
-	// cancellation). Synthesize a failure result for each, exactly as
-	// submitFile does for an admission rejection.
-	scheduler.onDrop = func(file *clientTransferFile) {
-		res := synthesizeRejectionResult(file, errors.New("transfer engine shut down before the transfer could be dispatched"))
-		select {
-		case te.results <- res:
-		case <-te.ctx.Done():
+	if cfg.scheduler != nil {
+		scheduler := cfg.scheduler
+		te.scheduler = scheduler
+		// Transfers still queued in the scheduler when it stops would
+		// otherwise vanish without a result, leaving their jobs' active
+		// counts permanently non-zero (and result waiters blocked until ctx
+		// cancellation). Synthesize a failure result for each, exactly as
+		// submitFile does for an admission rejection.
+		scheduler.onDrop = func(file *clientTransferFile) {
+			res := synthesizeRejectionResult(file, errors.New("transfer engine shut down before the transfer could be dispatched"))
+			select {
+			case te.results <- res:
+			case <-te.ctx.Done():
+			}
 		}
+		// The scheduler goroutine joins the engine's errgroup. It cannot make
+		// Shutdown's egrp.Wait() hang: runJobHandler — also in that group —
+		// calls scheduler.Stop() before closing te.files, so run() has already
+		// returned by the time the group drains.
+		scheduler.Start(te.ctx, te.egrp, te.files)
 	}
-	scheduler.Start(te.ctx, te.files)
-	return te, nil
+	return
 }
 
 // submitFile hands a clientTransferFile off to the worker pool. When a
@@ -2807,16 +2848,10 @@ func runTransferWorkerFile(ctx context.Context, file *clientTransferFile, result
 	var transferResults TransferResults
 	switch file.file.xferType {
 	case transferTypeUpload, transferTypeCopy:
-		// The scheduler's "starving" bucket tracks transfers that have not
-		// yet produced a first byte of downloaded body; uploads and
-		// third-party copies have no wiring to report data progress back to
-		// the scheduler. Mark them non-starving at dispatch — otherwise the
-		// (much smaller) starving cap would silently become their effective
-		// per-tag concurrency limit. The cost is that the unresponsive-
-		// destination protection does not apply to these transfer types.
-		if file.file.schedFirstByte != nil {
-			file.file.schedFirstByte()
-		}
+		// Both of these report their own first-byte signal to the scheduler
+		// (see the schedFirstByte docs on transferFile), so they stay in the
+		// "starving" bucket — and thus under the smaller starving cap — until
+		// the destination proves it is responding.
 		if file.file.xferType == transferTypeUpload {
 			transferResults, err = uploadObject(file.file)
 		} else {
@@ -4549,12 +4584,26 @@ func uploadObject(transfer *transferFile) (transferResult TransferResults, err e
 	transferStartTime := time.Now()
 	defer cancel()
 	log.Debugln("Full destination URL:", dest.String())
+	// Tell the scheduler (if any) the destination is alive as soon as it says
+	// anything back: a negotiated 100-continue is the earliest such proof,
+	// otherwise the first byte of the final response is.  The trace is scoped
+	// to the PUT itself, not to the checksum fetch that reuses putContext.
+	// Note that we do not send an Expect: 100-continue header, so
+	// Got100Continue only fires when the transport negotiates it on its own.
+	requestContext := putContext
+	if transfer.schedFirstByte != nil {
+		schedFirstByte := transfer.schedFirstByte
+		requestContext = httptrace.WithClientTrace(putContext, &httptrace.ClientTrace{
+			Got100Continue:       func() { schedFirstByte() },
+			GotFirstResponseByte: func() { schedFirstByte() },
+		})
+	}
 	var request *http.Request
 	// For files that are 0 length, we need to send a PUT request with an nil body
 	if nonZeroSize {
-		request, err = http.NewRequestWithContext(putContext, http.MethodPut, dest.String(), tee)
+		request, err = http.NewRequestWithContext(requestContext, http.MethodPut, dest.String(), tee)
 	} else {
-		request, err = http.NewRequestWithContext(putContext, http.MethodPut, dest.String(), http.NoBody)
+		request, err = http.NewRequestWithContext(requestContext, http.MethodPut, dest.String(), http.NoBody)
 	}
 	if err != nil {
 		log.Errorln("Error creating request:", err)

--- a/client/handle_http_copy.go
+++ b/client/handle_http_copy.go
@@ -640,11 +640,9 @@ func (te *TransferEngine) emitCopyJob(job *clientTransferJob, transfers []transf
 		log.Debugln("Constructed source attempt URL for TPC copy:", fileURL.String(), "file:", srcFilePath)
 	}
 
-	// totalXfer must be counted before submission: a scheduler rejection
-	// pushes a synthetic failure result for this file, and runMux treats
-	// totalXfer == 0 as "job created no transfers" and closes the results
-	// channel — racing the synthetic result's delivery.
-	job.job.totalXfer += 1
+	// Counted before submission: a scheduler rejection produces a
+	// synthetic result right away, and runMux decrements on every
+	// result, so counting afterwards would race its delivery.
 	job.job.activeXfer.Add(1)
 	if err := te.submitFile(job.job.ctx, &clientTransferFile{
 		uuid:  job.uuid,

--- a/client/handle_http_copy.go
+++ b/client/handle_http_copy.go
@@ -153,7 +153,9 @@ func copyHTTP(xfer *transferFile) (transferResults TransferResults, err error) {
 	// won't appear here.  Reject anything other than 200 OK.
 	if resp.StatusCode == http.StatusTooManyRequests {
 		// Source throttled the request; carry the Retry-After hint on the
-		// retryable throttle error (the body was not read on this path).
+		// retryable throttle error. A response to HEAD never carries a body,
+		// so there is no structured reason to read here -- the error is
+		// classified generically, which is still retryable.
 		err = newThrottleErrorFromResponse(resp, "", xfer.attempts[0].Url.Host)
 		return
 	}

--- a/client/handle_http_copy.go
+++ b/client/handle_http_copy.go
@@ -479,7 +479,7 @@ func skipCopy(syncLevel SyncLevel, sourceInfo fs.FileInfo, destPath string, dest
 
 // walkDirCopy walks the remote source directory and emits individual TPC copy jobs
 // for each file found. This is used for recursive third-party-copy operations.
-func (te *TransferEngine) walkDirCopy(job *clientTransferJob, transfers []transferAttemptDetails, files chan *clientTransferFile, srcUrl *url.URL) error {
+func (te *TransferEngine) walkDirCopy(job *clientTransferJob, transfers []transferAttemptDetails, srcUrl *url.URL) error {
 	// Use the source director response to get the collections URL for listing
 	collUrl := job.job.srcDirResp.XPelNsHdr.CollectionsUrl
 	if collUrl == nil {
@@ -501,7 +501,7 @@ func (te *TransferEngine) walkDirCopy(job *clientTransferJob, transfers []transf
 		}
 	}
 
-	return te.walkDirCopyHelper(job, transfers, files, srcUrl.Path, srcClient, destClient)
+	return te.walkDirCopyHelper(job, transfers, srcUrl.Path, srcClient, destClient)
 }
 
 // walkDirCopyHelper recursively walks the remote source directory and emits individual
@@ -509,7 +509,7 @@ func (te *TransferEngine) walkDirCopy(job *clientTransferJob, transfers []transf
 // server URLs point to the individual file and the destination (via dirResp.ObjectServers)
 // is also adjusted to the corresponding destination path.
 // destWebDavClient may be nil if sync skip is disabled; used to stat destination files.
-func (te *TransferEngine) walkDirCopyHelper(job *clientTransferJob, transfers []transferAttemptDetails, files chan *clientTransferFile, remotePath string, webdavClient *gowebdav.Client, destWebDavClient *gowebdav.Client) error {
+func (te *TransferEngine) walkDirCopyHelper(job *clientTransferJob, transfers []transferAttemptDetails, remotePath string, webdavClient *gowebdav.Client, destWebDavClient *gowebdav.Client) error {
 	// Check for cancellation
 	if err := job.job.ctx.Err(); err != nil {
 		return err
@@ -537,7 +537,7 @@ func (te *TransferEngine) walkDirCopyHelper(job *clientTransferJob, transfers []
 				return errors.Wrap(err, "failed to stat source path for copy")
 			}
 			if !info.IsDir() {
-				return te.emitCopyJob(job, transfers, files, remotePath, info, destWebDavClient)
+				return te.emitCopyJob(job, transfers, remotePath, info, destWebDavClient)
 			}
 			return nil
 		}
@@ -547,12 +547,12 @@ func (te *TransferEngine) walkDirCopyHelper(job *clientTransferJob, transfers []
 	for _, info := range infos {
 		newPath := path.Join(remotePath, info.Name())
 		if info.IsDir() {
-			err := te.walkDirCopyHelper(job, transfers, files, newPath, webdavClient, destWebDavClient)
+			err := te.walkDirCopyHelper(job, transfers, newPath, webdavClient, destWebDavClient)
 			if err != nil {
 				return err
 			}
 		} else {
-			if err := te.emitCopyJob(job, transfers, files, newPath, info, destWebDavClient); err != nil {
+			if err := te.emitCopyJob(job, transfers, newPath, info, destWebDavClient); err != nil {
 				return err
 			}
 		}
@@ -565,7 +565,7 @@ func (te *TransferEngine) walkDirCopyHelper(job *clientTransferJob, transfers []
 // to point at the individual file, computing the relative path within the source directory.
 // sourceInfo is the fs.FileInfo for the source file, used for sync skip checks.
 // destCollClient may be nil if sync skip is disabled; used to stat the destination file.
-func (te *TransferEngine) emitCopyJob(job *clientTransferJob, transfers []transferAttemptDetails, files chan *clientTransferFile, srcFilePath string, sourceInfo fs.FileInfo, destCollClient *gowebdav.Client) error {
+func (te *TransferEngine) emitCopyJob(job *clientTransferJob, transfers []transferAttemptDetails, srcFilePath string, sourceInfo fs.FileInfo, destCollClient *gowebdav.Client) error {
 	// Compute relative path of this file within the source directory
 	relPath := strings.TrimPrefix(srcFilePath, job.job.srcURL.Path)
 	relPath = strings.TrimPrefix(relPath, "/")
@@ -607,10 +607,7 @@ func (te *TransferEngine) emitCopyJob(job *clientTransferJob, transfers []transf
 	}
 
 	job.job.activeXfer.Add(1)
-	select {
-	case <-job.job.ctx.Done():
-		return job.job.ctx.Err()
-	case files <- &clientTransferFile{
+	if err := te.submitFile(job.job.ctx, &clientTransferFile{
 		uuid:  job.uuid,
 		jobId: job.job.uuid,
 		file: &transferFile{
@@ -629,7 +626,11 @@ func (te *TransferEngine) emitCopyJob(job *clientTransferJob, transfers []transf
 			srcToken: job.job.srcToken,
 			attempts: srcAttempts,
 		},
-	}:
+	}); err != nil {
+		if !errors.Is(err, ErrTooManyRequests) {
+			return err
+		}
+	} else {
 		job.job.totalXfer += 1
 	}
 	return nil

--- a/client/handle_http_copy.go
+++ b/client/handle_http_copy.go
@@ -667,6 +667,9 @@ func (te *TransferEngine) emitCopyJob(job *clientTransferJob, transfers []transf
 		},
 	}); err != nil {
 		if !errors.Is(err, ErrTooManyRequests) {
+			// Nothing was queued and no result is coming, so this
+			// file must not stay on the job's books.
+			job.job.uncountSubmission()
 			return err
 		}
 	}

--- a/client/handle_http_copy.go
+++ b/client/handle_http_copy.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
+	"net/http/httptrace"
 	"net/url"
 	"path"
 	"strconv"
@@ -202,7 +203,18 @@ func copyHTTP(xfer *transferFile) (transferResults TransferResults, err error) {
 	}
 
 	// COPY request to the destination
-	req, err = http.NewRequestWithContext(ctx, "COPY", resolvedDestUrl.String(), nil)
+	//
+	// Tell the scheduler (if any) the destination is alive as soon as the first
+	// byte of its response arrives.  The trace is scoped to the COPY so the
+	// earlier HEAD — which contacts the *source* — cannot satisfy it.
+	copyContext := ctx
+	if xfer.schedFirstByte != nil {
+		schedFirstByte := xfer.schedFirstByte
+		copyContext = httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+			GotFirstResponseByte: func() { schedFirstByte() },
+		})
+	}
+	req, err = http.NewRequestWithContext(copyContext, "COPY", resolvedDestUrl.String(), nil)
 	if err != nil {
 		err = error_codes.NewParameterError(
 			errors.Wrapf(err, "unable to create COPY request for third-party-copy to %s", xfer.remoteURL.String()),
@@ -274,6 +286,7 @@ func copyHTTP(xfer *transferFile) (transferResults TransferResults, err error) {
 	defer ticker.Stop()
 
 	gotFirstByte := false
+	schedFirstByteSent := false
 MessageHandler:
 	for {
 		select {
@@ -291,6 +304,15 @@ MessageHandler:
 					err = error_codes.NewTransferError(msg.err)
 				}
 				break MessageHandler
+			}
+			// A parsed performance marker proves the destination is talking to
+			// us even if it reports no bytes moved yet, so it is a valid
+			// first-byte signal for the scheduler.  The hook is CAS-guarded by
+			// the scheduler, so firing here as well as from the httptrace on
+			// the COPY request is harmless — whichever happens first wins.
+			if !schedFirstByteSent && xfer.schedFirstByte != nil {
+				schedFirstByteSent = true
+				xfer.schedFirstByte()
 			}
 			downloaded = int64(msg.xferred)
 			if !gotFirstByte && downloaded > 0 {

--- a/client/handle_http_copy.go
+++ b/client/handle_http_copy.go
@@ -150,6 +150,12 @@ func copyHTTP(xfer *transferFile) (transferResults TransferResults, err error) {
 	resp.Body.Close()
 	// Go's http.Client follows redirects automatically, so 3XX codes
 	// won't appear here.  Reject anything other than 200 OK.
+	if resp.StatusCode == http.StatusTooManyRequests {
+		// Source throttled the request; carry the Retry-After hint on the
+		// retryable throttle error (the body was not read on this path).
+		err = newThrottleErrorFromResponse(resp, "", xfer.attempts[0].Url.Host)
+		return
+	}
 	if resp.StatusCode != http.StatusOK {
 		httpErr := &HttpErrResp{resp.StatusCode, fmt.Sprintf("HEAD request to source failed (HTTP status %d)", resp.StatusCode),
 			wrapErrorByStatusCode(resp.StatusCode, fmt.Errorf("source HEAD returned HTTP %d", resp.StatusCode))}
@@ -228,7 +234,7 @@ func copyHTTP(xfer *transferFile) (transferResults TransferResults, err error) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusCreated {
 		var respBytes []byte
-		respBytes, err = io.ReadAll(resp.Body)
+		respBytes, err = io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
 		if err != nil {
 			log.Errorf("TPC COPY to %s failed (HTTP status %d); additionally, reading the response body failed: %s", resolvedDestUrl.String(), resp.StatusCode, err.Error())
 			err = error_codes.NewContactError(
@@ -247,6 +253,10 @@ func copyHTTP(xfer *transferFile) (transferResults TransferResults, err error) {
 					resolvedDestUrl.String(), resp.StatusCode, string(respBytes))
 				err = &HttpErrResp{Code: resp.StatusCode, Str: fmt.Sprintf("TPC COPY failed (HTTP status %d)",
 					resp.StatusCode), Err: statusErr}
+			} else if resp.StatusCode == http.StatusTooManyRequests {
+				// Destination throttled the copy; classify with the structured
+				// reason + Retry-After hint like any other throttle response.
+				err = newThrottleErrorFromResponse(resp, string(respBytes), resolvedDestUrl.Host)
 			} else {
 				log.Errorf("TPC COPY to %s failed (HTTP status %d): %q", resolvedDestUrl.String(), resp.StatusCode, string(respBytes))
 				err = &HttpErrResp{Code: resp.StatusCode, Str: fmt.Sprintf("TPC COPY failed (HTTP status %d)",
@@ -606,6 +616,11 @@ func (te *TransferEngine) emitCopyJob(job *clientTransferJob, transfers []transf
 		log.Debugln("Constructed source attempt URL for TPC copy:", fileURL.String(), "file:", srcFilePath)
 	}
 
+	// totalXfer must be counted before submission: a scheduler rejection
+	// pushes a synthetic failure result for this file, and runMux treats
+	// totalXfer == 0 as "job created no transfers" and closes the results
+	// channel — racing the synthetic result's delivery.
+	job.job.totalXfer += 1
 	job.job.activeXfer.Add(1)
 	if err := te.submitFile(job.job.ctx, &clientTransferFile{
 		uuid:  job.uuid,
@@ -630,8 +645,6 @@ func (te *TransferEngine) emitCopyJob(job *clientTransferJob, transfers []transf
 		if !errors.Is(err, ErrTooManyRequests) {
 			return err
 		}
-	} else {
-		job.job.totalXfer += 1
 	}
 	return nil
 }

--- a/client/handle_http_test.go
+++ b/client/handle_http_test.go
@@ -251,7 +251,7 @@ func TestSlowTransfers(t *testing.T) {
 		writer, err = os.OpenFile(fname, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 		assert.NoError(t, err)
 		defer writer.Close()
-		_, _, _, _, _, err = downloadHTTP(ctx, nil, nil, transfers[0], fname, writer, 0, -1, -1, "", "", nil)
+		_, _, _, _, _, err = downloadHTTP(ctx, nil, nil, transfers[0], fname, writer, 0, -1, -1, "", "", nil, nil)
 		finishedChannel <- true
 	}()
 
@@ -341,7 +341,7 @@ func TestStoppedTransfer(t *testing.T) {
 		assert.NoError(t, err)
 		defer writer.Close()
 
-		_, _, _, _, _, err = downloadHTTP(ctx, nil, nil, transfers[0], fname, writer, 0, -1, -1, "", "", nil)
+		_, _, _, _, _, err = downloadHTTP(ctx, nil, nil, transfers[0], fname, writer, 0, -1, -1, "", "", nil, nil)
 		finishedChannel <- true
 	}()
 
@@ -392,7 +392,7 @@ func TestConnectionError(t *testing.T) {
 
 	_, _, _, _, _, err = downloadHTTP(ctx, nil, nil,
 		transferAttemptDetails{Url: &url.URL{Host: addr, Scheme: "http"}, Proxy: false},
-		fname, writer, 0, -1, -1, "", "", nil,
+		fname, writer, 0, -1, -1, "", "", nil, nil,
 	)
 
 	// downloadHTTP returns unwrapped ConnectionSetupError; wrapping happens in the download loop
@@ -506,7 +506,7 @@ func TestNetworkResetError(t *testing.T) {
 	// Call downloadHTTP which should trigger NetworkResetError when connection is reset
 	_, _, _, _, _, err = downloadHTTP(ctx, nil, nil,
 		transferAttemptDetails{Url: &url.URL{Scheme: "http", Host: serverAddr}, Proxy: false},
-		fname, writer, 0, -1, -1, "", "", nil,
+		fname, writer, 0, -1, -1, "", "", nil, nil,
 	)
 
 	// The error should be wrapped as Contact.ConnectionReset in the download loop
@@ -633,7 +633,7 @@ func TestTrailerError(t *testing.T) {
 	assert.NoError(t, err)
 	defer writer.Close()
 
-	_, _, _, _, _, err = downloadHTTP(ctx, nil, nil, transfers[0], fname, writer, 0, -1, -1, "", "", nil)
+	_, _, _, _, _, err = downloadHTTP(ctx, nil, nil, transfers[0], fname, writer, 0, -1, -1, "", "", nil, nil)
 
 	assert.NotNil(t, err)
 	// Check that it's wrapped in a PelicanError
@@ -992,7 +992,7 @@ func TestTimeoutHeaderSetForDownload(t *testing.T) {
 	assert.NoError(t, err)
 	defer writer.Close()
 	_, _, _, _, _, err = downloadHTTP(ctx, nil, nil, transferAttemptDetails{Url: serverURL, Proxy: false},
-		fname, writer, 0, -1, -1, "", "", nil,
+		fname, writer, 0, -1, -1, "", "", nil, nil,
 	)
 	assert.NoError(t, err)
 	server_utils.ResetTestState()
@@ -1040,7 +1040,7 @@ func TestJobIdHeaderSetForDownload(t *testing.T) {
 	assert.NoError(t, err)
 	defer writer.Close()
 	_, _, _, _, _, err = downloadHTTP(ctx, nil, nil, transferAttemptDetails{Url: serverURL, Proxy: false},
-		fname, writer, 0, -1, -1, "", "", nil,
+		fname, writer, 0, -1, -1, "", "", nil, nil,
 	)
 	assert.NoError(t, err)
 	server_utils.ResetTestState()
@@ -1082,7 +1082,7 @@ func TestProjInUserAgent(t *testing.T) {
 	assert.NoError(t, err)
 	defer writer.Close()
 	_, _, _, _, _, err = downloadHTTP(ctx, nil, nil, transferAttemptDetails{Url: serverURL, Proxy: false},
-		fname, writer, 0, -1, -1, "", "test", nil)
+		fname, writer, 0, -1, -1, "", "test", nil, nil)
 	assert.NoError(t, err)
 
 	// Test the user-agent header is what we expect it to be
@@ -1769,7 +1769,7 @@ func TestInvalidByteInChunkLengthError(t *testing.T) {
 	// Call downloadHTTP which should trigger InvalidByteInChunkLengthError
 	_, _, _, _, _, err = downloadHTTP(ctx, nil, nil,
 		transferAttemptDetails{Url: &url.URL{Scheme: "http", Host: serverAddr}, Proxy: false},
-		fname, writer, 0, -1, -1, "", "", nil,
+		fname, writer, 0, -1, -1, "", "", nil, nil,
 	)
 
 	require.Error(t, err, "Should have an error from invalid chunk length")
@@ -3009,7 +3009,7 @@ func TestInvalidByteInChunkLength(t *testing.T) {
 	require.NoError(t, err)
 	defer writer.Close()
 
-	_, _, _, _, _, err = downloadHTTP(ctx, nil, nil, transfers[0], fname, writer, 0, -1, -1, "", "", nil)
+	_, _, _, _, _, err = downloadHTTP(ctx, nil, nil, transfers[0], fname, writer, 0, -1, -1, "", "", nil, nil)
 	require.Error(t, err)
 	t.Logf("error: %v", err)
 
@@ -3048,7 +3048,7 @@ func TestUnexpectedEOFInTransferStatus(t *testing.T) {
 	require.NoError(t, err)
 	defer writer.Close()
 
-	_, _, _, _, _, err = downloadHTTP(ctx, nil, nil, transfers[0], fname, writer, 0, -1, -1, "", "", nil)
+	_, _, _, _, _, err = downloadHTTP(ctx, nil, nil, transfers[0], fname, writer, 0, -1, -1, "", "", nil, nil)
 	require.Error(t, err)
 	t.Logf("error: %v", err)
 	assert.True(t, IsRetryable(err), "Unexpected EOF error should be retryable")
@@ -4397,12 +4397,21 @@ func TestRecursiveUpload403WithSync(t *testing.T) {
 	tsURL, err := url.Parse(ts.URL)
 	require.NoError(t, err)
 
-	// Create a transfer engine and client
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	te, err := NewTransferEngine(ctx)
-	require.NoError(t, err)
+	// Build a minimal, worker-free transfer engine.  walkDirUpload hands
+	// each queued file to te.submitFile, which (with no scheduler
+	// configured) sends onto te.files.  We deliberately do NOT use
+	// NewTransferEngine here: its worker goroutines would drain te.files
+	// concurrently and actually perform the uploads, whereas this test
+	// wants to drive uploadObject by hand to observe the 403-skip
+	// bookkeeping.  A buffered te.files lets walkDirUpload complete
+	// without a consumer.
+	te := &TransferEngine{
+		ctx:   ctx,
+		files: make(chan *clientTransferFile, 10),
+	}
 
 	// Create a transfer job for recursive upload with sync enabled
 	remoteURL, err := pelican_url.Parse("pelican://"+tsURL.Host+"/test/dir", nil, nil)
@@ -4427,18 +4436,15 @@ func TestRecursiveUpload403WithSync(t *testing.T) {
 	// Manually create the transfer attempts
 	transfers := []transferAttemptDetails{{Url: tsURL, Proxy: false}}
 
-	// Create channel for files
-	files := make(chan *clientTransferFile, 10)
-
-	// Run walkDirUpload to queue files
-	err = te.walkDirUpload(&clientTransferJob{uuid: uuid.New(), job: tj}, transfers, files, tempDir)
+	// Run walkDirUpload to queue files onto te.files.
+	err = te.walkDirUpload(&clientTransferJob{uuid: uuid.New(), job: tj}, transfers, tempDir)
 	require.NoError(t, err)
 
-	close(files)
+	close(te.files)
 
 	// Process all queued files
 	var results []TransferResults
-	for file := range files {
+	for file := range te.files {
 		result, err := uploadObject(file.file)
 		require.NoError(t, err, "uploadObject should not return error")
 		results = append(results, result)
@@ -4518,7 +4524,7 @@ func TestDownloadHTTPETag(t *testing.T) {
 
 	downloaded, _, _, _, etag, err := downloadHTTP(ctx, nil, nil,
 		transferAttemptDetails{Url: serverURL, Proxy: false},
-		fname, writer, 0, -1, -1, "", "", nil,
+		fname, writer, 0, -1, -1, "", "", nil, nil,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(len(body)), downloaded)
@@ -4555,7 +4561,7 @@ func TestDownloadHTTPETagMissing(t *testing.T) {
 
 	_, _, _, _, etag, err := downloadHTTP(ctx, nil, nil,
 		transferAttemptDetails{Url: serverURL, Proxy: false},
-		fname, writer, 0, -1, -1, "", "", nil,
+		fname, writer, 0, -1, -1, "", "", nil, nil,
 	)
 	assert.NoError(t, err)
 	assert.Empty(t, etag, "ETag should be empty when the server doesn't provide one")
@@ -4594,7 +4600,7 @@ func TestMetadataChannel(t *testing.T) {
 
 	_, _, _, _, _, err = downloadHTTP(ctx, nil, nil,
 		transferAttemptDetails{Url: serverURL, Proxy: false},
-		fname, writer, 0, -1, -1, "", "", metadataChan,
+		fname, writer, 0, -1, -1, "", "", metadataChan, nil,
 	)
 	assert.NoError(t, err)
 
@@ -4636,7 +4642,7 @@ func TestMetadataChannelNil(t *testing.T) {
 
 	_, _, _, _, _, err = downloadHTTP(ctx, nil, nil,
 		transferAttemptDetails{Url: serverURL, Proxy: false},
-		fname, writer, 0, -1, -1, "", "", nil,
+		fname, writer, 0, -1, -1, "", "", nil, nil,
 	)
 	assert.NoError(t, err, "downloadHTTP should not panic when metadataChan is nil")
 }
@@ -4679,7 +4685,7 @@ func TestDownloadHTTPByteRange(t *testing.T) {
 	// bytesSoFar=0, byteRangeEnd=9 → Range: bytes=0-9
 	downloaded, _, _, _, _, err := downloadHTTP(ctx, nil, nil,
 		transferAttemptDetails{Url: serverURL, Proxy: false},
-		fname, writer, 0, rangeEnd, -1, "", "", nil,
+		fname, writer, 0, rangeEnd, -1, "", "", nil, nil,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, rangeEnd+1, downloaded, "downloaded bytes should equal the range size")
@@ -4732,7 +4738,7 @@ func TestDownloadHTTPResume(t *testing.T) {
 
 	downloaded, _, _, _, _, err := downloadHTTP(ctx, nil, nil,
 		transferAttemptDetails{Url: serverURL, Proxy: false},
-		fname, writer, resumeOffset, -1, -1, "", "", nil,
+		fname, writer, resumeOffset, -1, -1, "", "", nil, nil,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(len(fullBody))-resumeOffset, downloaded, "should download remaining bytes after resume offset")
@@ -4841,7 +4847,7 @@ func TestMetadataChannelByteRange(t *testing.T) {
 
 	downloaded, _, _, _, _, err := downloadHTTP(ctx, nil, nil,
 		transferAttemptDetails{Url: serverURL, Proxy: false},
-		"", &buf, rangeStart, rangeEnd, -1, "", "", metadataChan,
+		"", &buf, rangeStart, rangeEnd, -1, "", "", metadataChan, nil,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, rangeEnd-rangeStart+1, downloaded, "downloaded should be the range length")

--- a/client/prestage_api.go
+++ b/client/prestage_api.go
@@ -126,8 +126,19 @@ func invokePrestageAPI(ctx context.Context, cacheUrl *url.URL, remotePath string
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return 0, errors.Errorf("prestage API returned status %d: %s", resp.StatusCode, string(bodyBytes))
+		// Bound the read: the body comes from a remote cache, and an
+		// unbounded ReadAll here would be an allocation primitive for a
+		// hostile peer.
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
+		body := string(bodyBytes)
+		if resp.StatusCode == http.StatusTooManyRequests {
+			// The cache shed the request (its prestage queue is full or its
+			// fair scheduler refused the upstream fetch). Classify it so the
+			// caller sees a retryable error carrying the advertised backoff
+			// rather than an opaque status-code string.
+			return 0, newThrottleErrorFromResponse(resp, body, resp.Request.URL.Host)
+		}
+		return 0, errors.Errorf("prestage API returned status %d: %s", resp.StatusCode, body)
 	}
 
 	// Read the chunked response and parse progress updates

--- a/client/run_mux_hazard_test.go
+++ b/client/run_mux_hazard_test.go
@@ -108,7 +108,6 @@ func TestRunMuxPartialLookupFailureKeepsInFlightResults(t *testing.T) {
 
 	// The walk submitted two files and then failed listing a subdirectory.
 	// Both transfers are in flight and will report back.
-	job.totalXfer = 2
 	job.activeXfer.Store(2)
 	job.lookupErr = errors.New("failed to read remote collection")
 	te.jobLookupDone <- &clientTransferJob{uuid: clientID, job: job}

--- a/client/run_mux_hazard_test.go
+++ b/client/run_mux_hazard_test.go
@@ -1,0 +1,209 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/VividCortex/ewma"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newMuxTestEngine builds the minimum TransferEngine that runMux touches.
+//
+// Every mux channel is unbuffered on purpose: a send that completes proves
+// runMux has already taken the previous message and finished acting on it,
+// since it services them one at a time. That is what makes the ordering in
+// these tests exact without waiting on the clock.
+func newMuxTestEngine(ctx context.Context) *TransferEngine {
+	return &TransferEngine{
+		ctx:           ctx,
+		work:          make(chan *clientTransferJob),
+		results:       make(chan *clientTransferResults),
+		jobLookupDone: make(chan *clientTransferJob),
+		notifyChan:    make(chan bool),
+		closeChan:     make(chan bool),
+		closeDoneChan: make(chan bool, 1),
+		resultsMap:    make(map[uuid.UUID]chan *TransferResults),
+		workMap:       make(map[uuid.UUID]chan *TransferJob),
+		// Long enough that the statistics tick never fires mid-test.
+		ewmaTick: time.NewTicker(time.Hour),
+		ewma:     ewma.NewMovingAverage(),
+	}
+}
+
+// TestRunMuxPartialLookupFailureKeepsInFlightResults pins what happens when a
+// recursive walk fails after it has already handed files to the workers.
+//
+// Those transfers are still running and each still owes the client a result.
+// Treating the lookup error as the end of the job closes the client's results
+// channel while they are in flight, and the next result to arrive is then a
+// send on a closed channel -- which takes down the process, not just the
+// transfer. A user hits this with `pelican object get -r` on a collection
+// holding a large object alongside a subdirectory the origin will not list.
+func TestRunMuxPartialLookupFailureKeepsInFlightResults(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	te := newMuxTestEngine(ctx)
+
+	clientID := uuid.New()
+	workChan := make(chan *TransferJob)
+	resultsChan := make(chan *TransferResults)
+	te.workMap[clientID] = workChan
+	te.resultsMap[clientID] = resultsChan
+
+	// runMux's panic would otherwise kill the test binary rather than report.
+	muxPanic := make(chan any, 1)
+	muxDone := make(chan struct{})
+	go func() {
+		defer close(muxDone)
+		defer func() {
+			if r := recover(); r != nil {
+				muxPanic <- r
+			}
+		}()
+		_ = te.runMux()
+	}()
+
+	job := &TransferJob{uuid: uuid.New(), ctx: ctx}
+
+	// Submit the job, then take it off te.work the way the job handler would.
+	// Once received, the job is in the mux's active list.
+	workChan <- job
+	select {
+	case <-te.work:
+	case <-ctx.Done():
+		t.Fatal("runMux never forwarded the job to the lookup handler")
+	}
+
+	// The client closes its submission channel -- the shape every CLI
+	// invocation takes, since Shutdown() closes it before waiting for results.
+	close(workChan)
+	require.Eventually(t, func() bool {
+		te.clientLock.RLock()
+		defer te.clientLock.RUnlock()
+		return te.workMap[clientID] == nil
+	}, 10*time.Second, time.Millisecond, "runMux never observed the client's close")
+
+	// The walk submitted two files and then failed listing a subdirectory.
+	// Both transfers are in flight and will report back.
+	job.totalXfer = 2
+	job.activeXfer.Store(2)
+	job.lookupErr = errors.New("failed to read remote collection")
+	te.jobLookupDone <- &clientTransferJob{uuid: clientID, job: job}
+
+	// The first in-flight transfer finishes.
+	te.results <- &clientTransferResults{
+		id:      clientID,
+		results: TransferResults{JobId: job.uuid, job: job},
+	}
+
+	select {
+	case r := <-resultsChan:
+		assert.Equal(t, job.uuid, r.JobId)
+	case p := <-muxPanic:
+		t.Fatalf("runMux panicked routing an in-flight result: %v", p)
+	case <-ctx.Done():
+		t.Fatal("the in-flight result was never delivered to the client")
+	}
+
+	// The second finishes, which is what actually completes the job; only then
+	// may the client's results channel close.
+	te.results <- &clientTransferResults{
+		id:      clientID,
+		results: TransferResults{JobId: job.uuid, job: job},
+	}
+	select {
+	case r := <-resultsChan:
+		assert.Equal(t, job.uuid, r.JobId)
+	case p := <-muxPanic:
+		t.Fatalf("runMux panicked routing the final result: %v", p)
+	case <-ctx.Done():
+		t.Fatal("the final result was never delivered to the client")
+	}
+
+	// With every transfer accounted for and the client closed, the results
+	// channel is closed so Shutdown() can return.
+	select {
+	case _, ok := <-resultsChan:
+		assert.False(t, ok, "results channel should be closed once the job is done")
+	case p := <-muxPanic:
+		t.Fatalf("runMux panicked closing out the job: %v", p)
+	case <-ctx.Done():
+		t.Fatal("results channel never closed; TransferClient.Shutdown would hang here")
+	}
+
+	cancel()
+	<-muxDone
+}
+
+// TestRunMuxEmptyJobClosesResults pins the neighbouring case that the
+// completion rule also has to cover: a lookup that produced no transfers at
+// all. Nothing will ever arrive to retire such a job, so the lookup
+// notification itself has to close the client out -- otherwise Shutdown()
+// waits forever on a job that was over before it started.
+func TestRunMuxEmptyJobClosesResults(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	te := newMuxTestEngine(ctx)
+
+	clientID := uuid.New()
+	workChan := make(chan *TransferJob)
+	resultsChan := make(chan *TransferResults)
+	te.workMap[clientID] = workChan
+	te.resultsMap[clientID] = resultsChan
+
+	muxDone := make(chan struct{})
+	go func() {
+		defer close(muxDone)
+		_ = te.runMux()
+	}()
+
+	job := &TransferJob{uuid: uuid.New(), ctx: ctx}
+	workChan <- job
+	select {
+	case <-te.work:
+	case <-ctx.Done():
+		t.Fatal("runMux never forwarded the job to the lookup handler")
+	}
+	close(workChan)
+	require.Eventually(t, func() bool {
+		te.clientLock.RLock()
+		defer te.clientLock.RUnlock()
+		return te.workMap[clientID] == nil
+	}, 10*time.Second, time.Millisecond)
+
+	// The lookup matched nothing: no transfers, no error.
+	te.jobLookupDone <- &clientTransferJob{uuid: clientID, job: job}
+
+	select {
+	case _, ok := <-resultsChan:
+		assert.False(t, ok, "a job that created no transfers must close the client out")
+	case <-ctx.Done():
+		t.Fatal("results channel never closed for a job with no transfers")
+	}
+
+	cancel()
+	<-muxDone
+}

--- a/client/run_mux_hazard_test.go
+++ b/client/run_mux_hazard_test.go
@@ -34,8 +34,7 @@ import (
 //
 // Every mux channel is unbuffered on purpose: a send that completes proves
 // runMux has already taken the previous message and finished acting on it,
-// since it services them one at a time. That is what makes the ordering in
-// these tests exact without waiting on the clock.
+// since it services them one at a time.
 func newMuxTestEngine(ctx context.Context) *TransferEngine {
 	return &TransferEngine{
 		ctx:           ctx,
@@ -120,6 +119,10 @@ func TestRunMuxPartialLookupFailureKeepsInFlightResults(t *testing.T) {
 
 	select {
 	case r := <-resultsChan:
+		// A nil here means the channel was closed rather than delivered on --
+		// which is the regression. Fail on it rather than dereferencing, so a
+		// broken runMux reports instead of taking down the whole package.
+		require.NotNil(t, r, "results channel was closed while a transfer was still in flight")
 		assert.Equal(t, job.uuid, r.JobId)
 	case p := <-muxPanic:
 		t.Fatalf("runMux panicked routing an in-flight result: %v", p)
@@ -135,6 +138,7 @@ func TestRunMuxPartialLookupFailureKeepsInFlightResults(t *testing.T) {
 	}
 	select {
 	case r := <-resultsChan:
+		require.NotNil(t, r, "results channel was closed before the final result")
 		assert.Equal(t, job.uuid, r.JobId)
 	case p := <-muxPanic:
 		t.Fatalf("runMux panicked routing the final result: %v", p)

--- a/client/tag_scheduler.go
+++ b/client/tag_scheduler.go
@@ -148,6 +148,13 @@ type SchedulerConfig struct {
 	// PendingBufferSize — total number of pending transfers the
 	// scheduler will queue across all tags before shedding new admits
 	// with ErrTooManyRequests. 0 disables the cap (unbounded queue).
+	//
+	// Note that the cache-level knob of the same name,
+	// Cache.Throttle.PendingBufferSize, reads 0 as "do not build a
+	// scheduler at all" -- it never reaches this field. The two zeroes
+	// mean opposite things because they act at different layers: here
+	// there is a scheduler and its queue is unbounded; there, there is no
+	// scheduler.
 	PendingBufferSize int
 	// PerTagPendingSize — number of pending transfers the scheduler
 	// will queue for any single tag before rejecting new admits with

--- a/client/tag_scheduler.go
+++ b/client/tag_scheduler.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -89,12 +90,17 @@ type PerTagStats struct {
 	// the configured EMAWindow. Used as the weight input for the
 	// per-tag round-robin dispatch decision.
 	EMA float64
-	// Admits and Rejects are monotonic totals since scheduler start.
+	// Admits and Rejects count admissions/rejections for this tag since
+	// the tag was first seen — or since it was last evicted: a tag idle
+	// long enough is dropped entirely (see evictIdleTags), and starts
+	// from zero if it returns. Lifetime totals live in GlobalStats.
 	Admits  uint64
 	Rejects uint64
 }
 
-// GlobalStats is the pool-wide scheduler snapshot.
+// GlobalStats is the pool-wide scheduler snapshot. The Total* counters
+// are monotonic for the scheduler's lifetime (unlike PerTagStats, whose
+// counters reset when an idle tag is evicted).
 type GlobalStats struct {
 	WorkerCount        int
 	StarvingCap        int
@@ -147,27 +153,38 @@ type TagScheduler struct {
 	cfg         SchedulerConfig
 	workerCount int
 
+	// onDrop, when set, is invoked (on the scheduler goroutine, during
+	// shutdown) for every admitted-but-never-dispatched transfer so the
+	// owner can synthesize a failure result instead of silently losing
+	// the file. Must be set before Start.
+	onDrop func(*clientTransferFile)
+
 	// Communication channels. Every field below the channels is owned
 	// by the scheduler goroutine and MUST NOT be touched from outside.
 	admit    chan *admitReq
 	events   chan schedulerEvent
 	snapReqs chan chan<- SchedulerSnapshot
 	stop     chan struct{}
+	stopOnce sync.Once
+	started  atomic.Bool
 	stopped  chan struct{}
 	out      chan<- *clientTransferFile
 	rng      *rand.Rand
 
 	fifos    map[string]*list.List // tag → FIFO of *clientTransferFile
-	active   map[string]int        // tag → in-flight (any state)
-	starving map[string]int        // tag → in-flight without first byte
+	active   map[string]int        // tag → in-flight (any state); zero entries are deleted
+	starving map[string]int        // tag → in-flight without first byte; zero entries are deleted
 	ema      map[string]float64    // tag → EMA of active
-	admits   map[string]uint64     // tag → monotonic admit count
-	rejects  map[string]uint64     // tag → monotonic rejection count
+	admits   map[string]uint64     // tag → admit count since the tag was last evicted
+	rejects  map[string]uint64     // tag → rejection count since the tag was last evicted
+	lastSeen map[string]time.Time  // tag → last admit/reject/dispatch/event, for idle eviction
 	lastTick time.Time
 	pending  int
 
-	// Global monotonic counters, broken down by why we rejected.
-	// TotalAdmits = sum(admits values); TotalRejects = same for rejects.
+	// Global monotonic counters. Unlike the per-tag maps these are never
+	// reset: idle tags are evicted from the maps (see evictIdleTags) so
+	// per-tag totals cannot serve as lifetime counters.
+	totalAdmits        uint64
 	totalRejectsGlobal uint64 // rejected because global pending was full
 	totalRejectsPerTag uint64 // rejected because per-tag pending was full
 }
@@ -198,11 +215,19 @@ func NewTagScheduler(workerCount int, cfg SchedulerConfig) *TagScheduler {
 	if workerCount < 1 {
 		workerCount = 1
 	}
+	// Each in-flight transfer produces at most two events (first-byte and
+	// done), so sizing the buffer to 2× the worker pool (with a floor)
+	// guarantees the hooks fired from transfer workers never block on a
+	// busy scheduler goroutine.
+	eventBuf := 2 * workerCount
+	if eventBuf < 256 {
+		eventBuf = 256
+	}
 	return &TagScheduler{
 		cfg:         cfg,
 		workerCount: workerCount,
 		admit:       make(chan *admitReq),
-		events:      make(chan schedulerEvent, 256),
+		events:      make(chan schedulerEvent, eventBuf),
 		snapReqs:    make(chan chan<- SchedulerSnapshot),
 		stop:        make(chan struct{}),
 		stopped:     make(chan struct{}),
@@ -213,25 +238,30 @@ func NewTagScheduler(workerCount int, cfg SchedulerConfig) *TagScheduler {
 		ema:         make(map[string]float64),
 		admits:      make(map[string]uint64),
 		rejects:     make(map[string]uint64),
+		lastSeen:    make(map[string]time.Time),
 	}
 }
 
 // Start begins the scheduler goroutine, dispatching admitted transfers on
-// the out channel. Stop() blocks until the goroutine exits.
+// the out channel. Stop() blocks until the goroutine exits. Start may be
+// called at most once per scheduler; a second call panics (programming
+// error, not a runtime condition).
 func (s *TagScheduler) Start(ctx context.Context, out chan<- *clientTransferFile) {
+	if !s.started.CompareAndSwap(false, true) {
+		panic("TagScheduler.Start called more than once")
+	}
 	s.out = out
 	go s.run(ctx)
 }
 
-// Stop signals the scheduler to exit and waits for the goroutine.
+// Stop signals the scheduler to exit and waits for the goroutine. It is
+// safe to call multiple times, including concurrently, and safe to call
+// on a scheduler that was never started.
 func (s *TagScheduler) Stop() {
-	select {
-	case <-s.stop:
-		// Already stopped
-	default:
-		close(s.stop)
+	s.stopOnce.Do(func() { close(s.stop) })
+	if s.started.Load() {
+		<-s.stopped
 	}
-	<-s.stopped
 }
 
 // Submit asks the scheduler to admit `file`, tagged with `tag`. Returns
@@ -250,14 +280,21 @@ func (s *TagScheduler) Submit(ctx context.Context, tag string, file *clientTrans
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-s.stop:
-		return errors.New("transfer scheduler is shut down")
+		// Shutting down: shed with a SchedulerRejection so the caller takes
+		// the same synthesize-a-result path as any other shed and the
+		// remote client gets a retryable 429 rather than a silent drop.
+		return &SchedulerRejection{
+			Reason: ShedCacheOverloaded,
+			Tag:    tag,
+			msg:    fmt.Sprintf("%s: transfer scheduler is shutting down", ErrTooManyRequests.Error()),
+		}
 	}
-	select {
-	case err := <-reply:
-		return err
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+	// Once the admit request has been received, handleAdmit always writes
+	// the (buffered) reply before the scheduler goroutine does anything
+	// else, so this receive cannot block for long and must not be raced
+	// against ctx: abandoning the reply would leave an admitted file in
+	// the FIFO while telling the caller it was never submitted.
+	return <-reply
 }
 
 func (s *TagScheduler) attachHooks(tag string, file *clientTransferFile) {
@@ -309,6 +346,22 @@ func (s *TagScheduler) activeCap() int {
 // / done events, and dispatch attempts, and periodically ticks the EMA.
 func (s *TagScheduler) run(ctx context.Context) {
 	defer close(s.stopped)
+	// On exit, hand every admitted-but-undispatched transfer to onDrop so
+	// its job still observes a completion (otherwise the owning job's
+	// active-transfer count never drains and its results channel never
+	// closes). Registered after the close(s.stopped) defer so it runs
+	// first, i.e. Stop() does not return until the drain is complete.
+	defer func() {
+		for tag, q := range s.fifos {
+			for e := q.Front(); e != nil; e = e.Next() {
+				if s.onDrop != nil {
+					s.onDrop(e.Value.(*clientTransferFile))
+				}
+			}
+			delete(s.fifos, tag)
+		}
+		s.pending = 0
+	}()
 
 	tickInterval := s.cfg.EMAWindow / 8
 	if tickInterval < 250*time.Millisecond {
@@ -333,7 +386,7 @@ func (s *TagScheduler) run(ctx context.Context) {
 			case reply := <-s.snapReqs:
 				reply <- s.buildSnapshot()
 			case <-tick.C:
-				s.tickEMA()
+				s.onTick()
 			case <-s.stop:
 				return
 			case <-ctx.Done():
@@ -348,7 +401,7 @@ func (s *TagScheduler) run(ctx context.Context) {
 			case reply := <-s.snapReqs:
 				reply <- s.buildSnapshot()
 			case <-tick.C:
-				s.tickEMA()
+				s.onTick()
 			case <-s.stop:
 				return
 			case <-ctx.Done():
@@ -358,16 +411,63 @@ func (s *TagScheduler) run(ctx context.Context) {
 	}
 }
 
+// onTick advances the EMA and evicts fully-idle tags. Runs on the
+// scheduler goroutine at the tick cadence.
+func (s *TagScheduler) onTick() {
+	s.tickEMA()
+	s.evictIdleTags(time.Now())
+}
+
+// classifyShed inspects a tag's own in-flight composition to decide why a
+// submission for it is being shed. If the tag itself is holding a
+// starving-cap worth of first-byte-less fetches, the origin looks
+// unresponsive; if it is at its active cap, it is delivering data but
+// already holds its fair share (merely slow). If the tag's own counters
+// are under both caps, the shed is due to pool-wide contention — blaming
+// the origin would be wrong, so report the cache as overloaded.
+func (s *TagScheduler) classifyShed(tag string) ShedReason {
+	if s.starving[tag] >= s.starvingCap() {
+		return ShedOriginUnresponsive
+	}
+	if s.active[tag] >= s.activeCap() {
+		return ShedOriginSlow
+	}
+	return ShedCacheOverloaded
+}
+
 func (s *TagScheduler) handleAdmit(req *admitReq) {
-	if s.cfg.PendingBufferSize > 0 && s.pending >= s.cfg.PendingBufferSize {
+	s.lastSeen[req.tag] = time.Now()
+	qLen := 0
+	if q, ok := s.fifos[req.tag]; ok {
+		qLen = q.Len()
+	}
+	// Per-tag cap is checked before the global one so a rejection is
+	// attributed to the tag's own state whenever its own queue is the
+	// limit.
+	if s.cfg.PerTagPendingSize > 0 && qLen >= s.cfg.PerTagPendingSize {
+		s.rejects[req.tag]++
+		s.totalRejectsPerTag++
+		reason := s.classifyShed(req.tag)
+		req.reply <- &SchedulerRejection{
+			Reason: reason,
+			Tag:    req.tag,
+			msg:    fmt.Sprintf("%s: origin %q pending queue is full (%s)", ErrTooManyRequests.Error(), req.tag, reason),
+		}
+		return
+	}
+	// Global buffer full. A tag with nothing queued may still enqueue one
+	// entry past the global cap: without that reservation, a handful of
+	// saturated origins could pin the global buffer and starve every
+	// healthy origin out of admission entirely. The overshoot is bounded
+	// by one entry per distinct tag.
+	if s.cfg.PendingBufferSize > 0 && s.pending >= s.cfg.PendingBufferSize && qLen > 0 {
 		s.rejects[req.tag]++
 		s.totalRejectsGlobal++
-		// Global buffer full: the cache is saturated across all origins,
-		// not just this one.
+		reason := s.classifyShed(req.tag)
 		req.reply <- &SchedulerRejection{
-			Reason: ShedCacheOverloaded,
+			Reason: reason,
 			Tag:    req.tag,
-			msg:    fmt.Sprintf("%s: cache pending queue is full", ErrTooManyRequests.Error()),
+			msg:    fmt.Sprintf("%s: cache pending queue is full (%s)", ErrTooManyRequests.Error(), reason),
 		}
 		return
 	}
@@ -376,44 +476,35 @@ func (s *TagScheduler) handleAdmit(req *admitReq) {
 		q = list.New()
 		s.fifos[req.tag] = q
 	}
-	if s.cfg.PerTagPendingSize > 0 && q.Len() >= s.cfg.PerTagPendingSize {
-		s.rejects[req.tag]++
-		s.totalRejectsPerTag++
-		// Per-tag FIFO full: dispatch for this origin is blocked because it
-		// is at one of its caps.  Classify by which: if the origin is holding
-		// its starving-cap worth of first-byte-less fetches it looks
-		// unresponsive; otherwise it is delivering data but at its active
-		// share, i.e. merely slow.
-		reason := ShedOriginSlow
-		if s.starving[req.tag] >= s.starvingCap() {
-			reason = ShedOriginUnresponsive
-		}
-		req.reply <- &SchedulerRejection{
-			Reason: reason,
-			Tag:    req.tag,
-			msg:    fmt.Sprintf("%s: origin %q pending queue is full (%s)", ErrTooManyRequests.Error(), req.tag, reason),
-		}
-		return
-	}
 	q.PushBack(req.file)
 	s.pending++
 	s.admits[req.tag]++
+	s.totalAdmits++
 	req.reply <- nil
 }
 
 func (s *TagScheduler) handleEvent(ev schedulerEvent) {
+	s.lastSeen[ev.tag] = time.Now()
 	switch ev.kind {
 	case evFirstByte:
-		if s.starving[ev.tag] > 0 {
-			s.starving[ev.tag]--
-		}
+		s.decrementCounter(s.starving, ev.tag)
 	case evDone:
-		if s.active[ev.tag] > 0 {
-			s.active[ev.tag]--
+		s.decrementCounter(s.active, ev.tag)
+		if ev.stillStarving {
+			s.decrementCounter(s.starving, ev.tag)
 		}
-		if ev.stillStarving && s.starving[ev.tag] > 0 {
-			s.starving[ev.tag]--
-		}
+	}
+}
+
+// decrementCounter lowers a per-tag counter by one, deleting the map
+// entry when it reaches zero so idle tags do not accumulate in memory
+// (or in the monitoring snapshot) forever.
+func (s *TagScheduler) decrementCounter(m map[string]int, tag string) {
+	switch v := m[tag]; {
+	case v > 1:
+		m[tag] = v - 1
+	case v == 1:
+		delete(m, tag)
 	}
 }
 
@@ -468,6 +559,7 @@ func (s *TagScheduler) onDispatched(tag string) {
 	s.pending--
 	s.active[tag]++
 	s.starving[tag]++
+	s.lastSeen[tag] = time.Now()
 }
 
 // tickEMA advances the per-tag exponentially-weighted moving average of
@@ -498,6 +590,42 @@ func (s *TagScheduler) tickEMA() {
 		if s.active[tag] > 0 {
 			s.ema[tag] = alpha * float64(s.active[tag])
 		}
+	}
+}
+
+// evictIdleTags drops all per-tag state for tags with no queued or
+// in-flight work, no still-decaying EMA, and no activity for at least a
+// grace period. Without eviction, every origin ever contacted would stay
+// in the maps (and thus in every monitoring snapshot) for the process
+// lifetime — unbounded memory and Prometheus label cardinality, plus an
+// ever-growing O(tags) snapshot cost paid on this goroutine.
+//
+// The grace period is at least the EMA window so the metrics publisher
+// (which samples every few seconds) reliably observes a tag's final
+// admit/reject totals before the tag disappears. Evicted tags that
+// return start their per-tag counters from zero; the metrics layer
+// treats per-tag totals as delta sources and handles the reset.
+func (s *TagScheduler) evictIdleTags(now time.Time) {
+	grace := s.cfg.EMAWindow
+	if grace < 10*time.Second {
+		grace = 10 * time.Second
+	}
+	for tag, seen := range s.lastSeen {
+		if now.Sub(seen) < grace {
+			continue
+		}
+		if _, ok := s.fifos[tag]; ok {
+			continue
+		}
+		if s.active[tag] > 0 || s.starving[tag] > 0 {
+			continue
+		}
+		if _, ok := s.ema[tag]; ok {
+			continue
+		}
+		delete(s.lastSeen, tag)
+		delete(s.admits, tag)
+		delete(s.rejects, tag)
 	}
 }
 
@@ -534,14 +662,16 @@ func (s *TagScheduler) buildSnapshot() SchedulerSnapshot {
 			StarvingCap:        s.starvingCap(),
 			ActiveCap:          s.activeCap(),
 			TotalPending:       s.pending,
+			TotalAdmits:        s.totalAdmits,
+			TotalRejects:       s.totalRejectsGlobal + s.totalRejectsPerTag,
 			TotalRejectsGlobal: s.totalRejectsGlobal,
 			TotalRejectsPerTag: s.totalRejectsPerTag,
 		},
 	}
 	// Collect the union of every tag we know about — a tag may have
 	// pending entries in `fifos`, active/starving counters even after
-	// its FIFO drained, an EMA that's still decaying, or lifetime
-	// admit/reject totals long after all its in-flight work is done.
+	// its FIFO drained, an EMA that's still decaying, or admit/reject
+	// totals awaiting idle eviction after its in-flight work is done.
 	seen := make(map[string]struct{})
 	add := func(m map[string]struct{}, k string) { m[k] = struct{}{} }
 	for tag := range s.fifos {
@@ -564,13 +694,12 @@ func (s *TagScheduler) buildSnapshot() SchedulerSnapshot {
 	}
 
 	snap.Tags = make(map[string]PerTagStats, len(seen))
-	var totalAdmits, totalRejects uint64
 	for tag := range seen {
 		var pending int
 		if q, ok := s.fifos[tag]; ok {
 			pending = q.Len()
 		}
-		p := PerTagStats{
+		snap.Tags[tag] = PerTagStats{
 			Pending:  pending,
 			Active:   s.active[tag],
 			Starving: s.starving[tag],
@@ -578,35 +707,33 @@ func (s *TagScheduler) buildSnapshot() SchedulerSnapshot {
 			Admits:   s.admits[tag],
 			Rejects:  s.rejects[tag],
 		}
-		snap.Tags[tag] = p
-		totalAdmits += p.Admits
-		totalRejects += p.Rejects
 	}
 	snap.Global.TotalTags = len(snap.Tags)
-	snap.Global.TotalAdmits = totalAdmits
-	snap.Global.TotalRejects = totalRejects
 	return snap
 }
 
-// synthesizeRejectionResult builds a TransferResults that surfaces a 429
-// rejection to callers. Exposed so wire code can push it to te.results
-// without special-casing.
+// synthesizeRejectionResult builds a TransferResults that surfaces a
+// scheduler rejection to callers. Exposed so wire code can push it to
+// te.results without special-casing.
 func synthesizeRejectionResult(file *clientTransferFile, err error) *clientTransferResults {
 	res := TransferResults{
 		JobId: file.jobId,
 		Error: err,
 	}
-	if file.file != nil {
-		// runMux's results-side branch (client/handle_http.go around
-		// the tmpResults[id] processing) unconditionally dereferences
+	if file.file != nil && file.file.job != nil {
+		// Populate the same base fields newTransferResults would: the
+		// results are consumed by job status displays and the client
+		// agent API, which expect Source to be set and Attempts to be
+		// non-nil. runMux also unconditionally dereferences
 		// TransferResults.job to decrement activeXfer and check
-		// completion.  Wire the job here so a scheduler-rejected
-		// transfer doesn't panic on shutdown.
-		res.job = file.file.job
+		// completion, so a scheduler-rejected transfer must carry it.
+		res = newTransferResults(file.file.job)
+		res.JobId = file.jobId
+		res.Error = err
 		if file.file.remoteURL != nil {
 			res.Scheme = file.file.remoteURL.Scheme
 		}
-		if file.file.job != nil && file.file.job.dirResp.RedirectInfo != nil {
+		if file.file.job.dirResp.RedirectInfo != nil {
 			res.DirectorDecision = file.file.job.dirResp.RedirectInfo
 		}
 	}

--- a/client/tag_scheduler.go
+++ b/client/tag_scheduler.go
@@ -21,6 +21,7 @@ package client
 import (
 	"container/list"
 	"context"
+	"fmt"
 	"math"
 	"math/rand"
 	"sync/atomic"
@@ -34,7 +35,47 @@ import (
 // refuses admission because the tag (typically an upstream origin) is
 // already at its share of the transfer engine's worker pool. It mirrors
 // HTTP 429.
+//
+// Every rejection wraps this sentinel (see SchedulerRejection), so callers can
+// continue to use errors.Is(err, ErrTooManyRequests) to detect a shed while
+// errors.As(err, &SchedulerRejection{}) recovers the specific reason.
 var ErrTooManyRequests = errors.New("too many requests: origin is over its share of the transfer pool")
+
+// ShedReason categorizes why the scheduler refused admission. The reason is
+// derived at the moment of shedding from the tag's in-flight composition and
+// the global pending buffer state, and is carried out to the cache's HTTP
+// layer so the client can be told whether the upstream origin is unresponsive,
+// merely slow, or the cache as a whole is saturated.
+type ShedReason string
+
+const (
+	// ShedOriginUnresponsive: the tag's held worker slots are dominated by
+	// "starving" fetches (accepted the connection but produced no first byte).
+	// The origin looks unresponsive.
+	ShedOriginUnresponsive ShedReason = "origin_unresponsive"
+	// ShedOriginSlow: the tag is at its active-transfer cap — the origin is
+	// delivering data but already holds its fair share of the pool.
+	ShedOriginSlow ShedReason = "origin_slow"
+	// ShedCacheOverloaded: the global pending buffer is full — the cache is
+	// saturated across all origins, not just this one.
+	ShedCacheOverloaded ShedReason = "cache_overloaded"
+)
+
+// SchedulerRejection is the error returned when the scheduler sheds a
+// submission. It wraps ErrTooManyRequests (so errors.Is still matches) and
+// carries the categorized reason plus the tag (upstream origin host) so the
+// downstream HTTP layer can build a structured 429.
+type SchedulerRejection struct {
+	Reason ShedReason
+	Tag    string
+	msg    string
+}
+
+func (e *SchedulerRejection) Error() string { return e.msg }
+
+// Unwrap returns ErrTooManyRequests so errors.Is(err, ErrTooManyRequests)
+// continues to hold for every rejection.
+func (e *SchedulerRejection) Unwrap() error { return ErrTooManyRequests }
 
 // PerTagStats is a per-origin snapshot of scheduler state, intended for
 // monitoring / debugging. Values are consistent (all taken under one
@@ -321,7 +362,13 @@ func (s *TagScheduler) handleAdmit(req *admitReq) {
 	if s.cfg.PendingBufferSize > 0 && s.pending >= s.cfg.PendingBufferSize {
 		s.rejects[req.tag]++
 		s.totalRejectsGlobal++
-		req.reply <- errors.Wrap(ErrTooManyRequests, "pending queue is full")
+		// Global buffer full: the cache is saturated across all origins,
+		// not just this one.
+		req.reply <- &SchedulerRejection{
+			Reason: ShedCacheOverloaded,
+			Tag:    req.tag,
+			msg:    fmt.Sprintf("%s: cache pending queue is full", ErrTooManyRequests.Error()),
+		}
 		return
 	}
 	q, ok := s.fifos[req.tag]
@@ -332,7 +379,20 @@ func (s *TagScheduler) handleAdmit(req *admitReq) {
 	if s.cfg.PerTagPendingSize > 0 && q.Len() >= s.cfg.PerTagPendingSize {
 		s.rejects[req.tag]++
 		s.totalRejectsPerTag++
-		req.reply <- errors.Wrapf(ErrTooManyRequests, "origin %q pending queue is full", req.tag)
+		// Per-tag FIFO full: dispatch for this origin is blocked because it
+		// is at one of its caps.  Classify by which: if the origin is holding
+		// its starving-cap worth of first-byte-less fetches it looks
+		// unresponsive; otherwise it is delivering data but at its active
+		// share, i.e. merely slow.
+		reason := ShedOriginSlow
+		if s.starving[req.tag] >= s.starvingCap() {
+			reason = ShedOriginUnresponsive
+		}
+		req.reply <- &SchedulerRejection{
+			Reason: reason,
+			Tag:    req.tag,
+			msg:    fmt.Sprintf("%s: origin %q pending queue is full (%s)", ErrTooManyRequests.Error(), req.tag, reason),
+		}
 		return
 	}
 	q.PushBack(req.file)

--- a/client/tag_scheduler.go
+++ b/client/tag_scheduler.go
@@ -23,13 +23,14 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 )
 
 // ErrTooManyRequests is returned by TagScheduler.Submit when the scheduler
@@ -145,6 +146,40 @@ type SchedulerConfig struct {
 	EMAWindow time.Duration
 }
 
+const (
+	// emaFloor is the value below which a decaying EMA is treated as zero.
+	// The decay is asymptotic, so without a floor an idle tag would never
+	// satisfy the "no residual EMA" precondition for eviction.
+	emaFloor = 1e-6
+	// minEvictionGrace is the lower bound on how long a tag must be idle
+	// before its state is dropped (see evictIdleTags).
+	minEvictionGrace = 10 * time.Second
+)
+
+// tagState is the complete scheduler state for one tag. Holding it in a
+// single struct rather than a set of parallel maps keeps a tag's queue,
+// counters, and bookkeeping created, updated, and evicted together, and
+// lets a snapshot be built with one map iteration.
+//
+// Owned by the scheduler goroutine; no field may be touched from outside.
+type tagState struct {
+	fifo     *list.List // FIFO of *clientTransferFile awaiting dispatch; never nil
+	active   int        // in-flight transfers (any state)
+	starving int        // in-flight transfers without a first byte yet
+	ema      float64    // EMA of active over the configured EMAWindow
+	weight   float64    // dispatch weight, 1/(1+ema); refreshed once per tick
+	admits   uint64     // admissions since the tag was last evicted
+	rejects  uint64     // rejections since the tag was last evicted
+	lastSeen time.Time  // last admit/reject/dispatch/event, for idle eviction
+}
+
+// dispatchCandidate is one entry in the weighted draw performed by
+// pickForDispatch. The backing slice is reused across dispatches.
+type dispatchCandidate struct {
+	st *tagState
+	w  float64
+}
+
 // TagScheduler admits transfers into a bounded per-tag FIFO and dispatches
 // them to workers with a weighted random draw across tags. It exists to
 // keep one misbehaving origin from monopolising the transfer engine's
@@ -171,18 +206,16 @@ type TagScheduler struct {
 	out      chan<- *clientTransferFile
 	rng      *rand.Rand
 
-	fifos    map[string]*list.List // tag → FIFO of *clientTransferFile
-	active   map[string]int        // tag → in-flight (any state); zero entries are deleted
-	starving map[string]int        // tag → in-flight without first byte; zero entries are deleted
-	ema      map[string]float64    // tag → EMA of active
-	admits   map[string]uint64     // tag → admit count since the tag was last evicted
-	rejects  map[string]uint64     // tag → rejection count since the tag was last evicted
-	lastSeen map[string]time.Time  // tag → last admit/reject/dispatch/event, for idle eviction
+	// tags holds all per-tag state. Entries are created on first contact
+	// and removed only by evictIdleTags, so the map cannot grow without
+	// bound as origins come and go.
+	tags     map[string]*tagState
+	cands    []dispatchCandidate // scratch space for pickForDispatch
 	lastTick time.Time
 	pending  int
 
-	// Global monotonic counters. Unlike the per-tag maps these are never
-	// reset: idle tags are evicted from the maps (see evictIdleTags) so
+	// Global monotonic counters. Unlike the per-tag state these are never
+	// reset: idle tags are evicted from the map (see evictIdleTags) so
 	// per-tag totals cannot serve as lifetime counters.
 	totalAdmits        uint64
 	totalRejectsGlobal uint64 // rejected because global pending was full
@@ -231,27 +264,45 @@ func NewTagScheduler(workerCount int, cfg SchedulerConfig) *TagScheduler {
 		snapReqs:    make(chan chan<- SchedulerSnapshot),
 		stop:        make(chan struct{}),
 		stopped:     make(chan struct{}),
-		rng:         rand.New(rand.NewSource(time.Now().UnixNano())),
-		fifos:       make(map[string]*list.List),
-		active:      make(map[string]int),
-		starving:    make(map[string]int),
-		ema:         make(map[string]float64),
-		admits:      make(map[string]uint64),
-		rejects:     make(map[string]uint64),
-		lastSeen:    make(map[string]time.Time),
+		// The math/rand/v2 top-level generator is automatically seeded, so
+		// it can seed this scheduler's private generator. Kept private (and
+		// as a field) so dispatch draws neither contend on the global
+		// generator nor resist deterministic seeding in tests.
+		rng:  rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())),
+		tags: make(map[string]*tagState),
 	}
 }
 
-// Start begins the scheduler goroutine, dispatching admitted transfers on
-// the out channel. Stop() blocks until the goroutine exits. Start may be
-// called at most once per scheduler; a second call panics (programming
-// error, not a runtime condition).
-func (s *TagScheduler) Start(ctx context.Context, out chan<- *clientTransferFile) {
+// tagFor returns the state for `tag`, creating it on first contact. Must
+// be called on the scheduler goroutine.
+func (s *TagScheduler) tagFor(tag string) *tagState {
+	if st, ok := s.tags[tag]; ok {
+		return st
+	}
+	// A new tag has an EMA of zero, whose dispatch weight is 1/(1+0); seed
+	// it so a tag admitted between two ticks competes on equal footing
+	// before its first weight refresh.
+	st := &tagState{fifo: list.New(), weight: 1.0}
+	s.tags[tag] = st
+	return st
+}
+
+// Start begins the scheduler goroutine under `egrp`, dispatching admitted
+// transfers on the out channel. Stop() blocks until the goroutine exits.
+// Start may be called at most once per scheduler; a second call panics
+// (programming error, not a runtime condition).
+//
+// The goroutine never returns an error: a scheduler shutdown is not a
+// failure of the group it runs in.
+func (s *TagScheduler) Start(ctx context.Context, egrp *errgroup.Group, out chan<- *clientTransferFile) {
 	if !s.started.CompareAndSwap(false, true) {
 		panic("TagScheduler.Start called more than once")
 	}
 	s.out = out
-	go s.run(ctx)
+	egrp.Go(func() error {
+		s.run(ctx)
+		return nil
+	})
 }
 
 // Stop signals the scheduler to exit and waits for the goroutine. It is
@@ -352,13 +403,13 @@ func (s *TagScheduler) run(ctx context.Context) {
 	// closes). Registered after the close(s.stopped) defer so it runs
 	// first, i.e. Stop() does not return until the drain is complete.
 	defer func() {
-		for tag, q := range s.fifos {
-			for e := q.Front(); e != nil; e = e.Next() {
+		for _, st := range s.tags {
+			for e := st.fifo.Front(); e != nil; e = e.Next() {
 				if s.onDrop != nil {
 					s.onDrop(e.Value.(*clientTransferFile))
 				}
 			}
-			delete(s.fifos, tag)
+			st.fifo.Init()
 		}
 		s.pending = 0
 	}()
@@ -374,11 +425,11 @@ func (s *TagScheduler) run(ctx context.Context) {
 	for {
 		// If we have a candidate to dispatch AND caps allow, try to
 		// hand it off to a worker while still servicing other events.
-		if tag, ok := s.pickForDispatch(); ok {
-			head := s.fifos[tag].Front().Value.(*clientTransferFile)
+		if st, ok := s.pickForDispatch(); ok {
+			head := st.fifo.Front().Value.(*clientTransferFile)
 			select {
 			case s.out <- head:
-				s.onDispatched(tag)
+				s.onDispatched(st)
 			case req := <-s.admit:
 				s.handleAdmit(req)
 			case ev := <-s.events:
@@ -426,26 +477,28 @@ func (s *TagScheduler) onTick() {
 // are under both caps, the shed is due to pool-wide contention — blaming
 // the origin would be wrong, so report the cache as overloaded.
 func (s *TagScheduler) classifyShed(tag string) ShedReason {
-	if s.starving[tag] >= s.starvingCap() {
+	st, ok := s.tags[tag]
+	if !ok {
+		return ShedCacheOverloaded
+	}
+	if st.starving >= s.starvingCap() {
 		return ShedOriginUnresponsive
 	}
-	if s.active[tag] >= s.activeCap() {
+	if st.active >= s.activeCap() {
 		return ShedOriginSlow
 	}
 	return ShedCacheOverloaded
 }
 
 func (s *TagScheduler) handleAdmit(req *admitReq) {
-	s.lastSeen[req.tag] = time.Now()
-	qLen := 0
-	if q, ok := s.fifos[req.tag]; ok {
-		qLen = q.Len()
-	}
+	st := s.tagFor(req.tag)
+	st.lastSeen = time.Now()
+	qLen := st.fifo.Len()
 	// Per-tag cap is checked before the global one so a rejection is
 	// attributed to the tag's own state whenever its own queue is the
 	// limit.
 	if s.cfg.PerTagPendingSize > 0 && qLen >= s.cfg.PerTagPendingSize {
-		s.rejects[req.tag]++
+		st.rejects++
 		s.totalRejectsPerTag++
 		reason := s.classifyShed(req.tag)
 		req.reply <- &SchedulerRejection{
@@ -461,7 +514,7 @@ func (s *TagScheduler) handleAdmit(req *admitReq) {
 	// healthy origin out of admission entirely. The overshoot is bounded
 	// by one entry per distinct tag.
 	if s.cfg.PendingBufferSize > 0 && s.pending >= s.cfg.PendingBufferSize && qLen > 0 {
-		s.rejects[req.tag]++
+		st.rejects++
 		s.totalRejectsGlobal++
 		reason := s.classifyShed(req.tag)
 		req.reply <- &SchedulerRejection{
@@ -471,40 +524,28 @@ func (s *TagScheduler) handleAdmit(req *admitReq) {
 		}
 		return
 	}
-	q, ok := s.fifos[req.tag]
-	if !ok {
-		q = list.New()
-		s.fifos[req.tag] = q
-	}
-	q.PushBack(req.file)
+	st.fifo.PushBack(req.file)
 	s.pending++
-	s.admits[req.tag]++
+	st.admits++
 	s.totalAdmits++
 	req.reply <- nil
 }
 
 func (s *TagScheduler) handleEvent(ev schedulerEvent) {
-	s.lastSeen[ev.tag] = time.Now()
+	st := s.tagFor(ev.tag)
+	st.lastSeen = time.Now()
 	switch ev.kind {
 	case evFirstByte:
-		s.decrementCounter(s.starving, ev.tag)
-	case evDone:
-		s.decrementCounter(s.active, ev.tag)
-		if ev.stillStarving {
-			s.decrementCounter(s.starving, ev.tag)
+		if st.starving > 0 {
+			st.starving--
 		}
-	}
-}
-
-// decrementCounter lowers a per-tag counter by one, deleting the map
-// entry when it reaches zero so idle tags do not accumulate in memory
-// (or in the monitoring snapshot) forever.
-func (s *TagScheduler) decrementCounter(m map[string]int, tag string) {
-	switch v := m[tag]; {
-	case v > 1:
-		m[tag] = v - 1
-	case v == 1:
-		delete(m, tag)
+	case evDone:
+		if st.active > 0 {
+			st.active--
+		}
+		if ev.stillStarving && st.starving > 0 {
+			st.starving--
+		}
 	}
 }
 
@@ -512,58 +553,60 @@ func (s *TagScheduler) decrementCounter(m map[string]int, tag string) {
 // hand off to a worker, using a weighted random draw across eligible
 // tags (those under both the starving and active caps). Weight is
 // 1/(1+EMA) so tags that have used less of the pool recently are more
-// likely to be picked. Returns "", false if nothing is dispatchable.
-func (s *TagScheduler) pickForDispatch() (string, bool) {
+// likely to be picked; it is refreshed once per tick (see tickEMA)
+// because dispatch decisions are far more frequent than ticks. Cap
+// eligibility, by contrast, must be evaluated live: the counters move
+// with every transfer event. Returns nil, false if nothing is
+// dispatchable.
+func (s *TagScheduler) pickForDispatch() (*tagState, bool) {
 	starvingCap := s.starvingCap()
 	activeCap := s.activeCap()
 
-	type cand struct {
-		tag string
-		w   float64
-	}
-	var cands []cand
+	cands := s.cands[:0]
 	totalW := 0.0
-	for tag, q := range s.fifos {
-		if q.Len() == 0 {
+	for _, st := range s.tags {
+		if st.fifo.Len() == 0 {
 			continue
 		}
-		if s.starving[tag] >= starvingCap {
+		if st.starving >= starvingCap {
 			continue
 		}
-		if s.active[tag] >= activeCap {
+		if st.active >= activeCap {
 			continue
 		}
-		w := 1.0 / (1.0 + s.ema[tag])
-		cands = append(cands, cand{tag, w})
-		totalW += w
+		cands = append(cands, dispatchCandidate{st: st, w: st.weight})
+		totalW += st.weight
 	}
+	// Retain the grown backing array; the scheduler goroutine is the sole
+	// user, so it can be reused on the next dispatch decision.
+	s.cands = cands
 	if len(cands) == 0 {
-		return "", false
+		return nil, false
 	}
 	r := s.rng.Float64() * totalW
-	for _, c := range cands {
-		r -= c.w
+	for i := range cands {
+		r -= cands[i].w
 		if r <= 0 {
-			return c.tag, true
+			return cands[i].st, true
 		}
 	}
-	return cands[len(cands)-1].tag, true
+	return cands[len(cands)-1].st, true
 }
 
-func (s *TagScheduler) onDispatched(tag string) {
-	q := s.fifos[tag]
-	q.Remove(q.Front())
-	if q.Len() == 0 {
-		delete(s.fifos, tag)
-	}
+func (s *TagScheduler) onDispatched(st *tagState) {
+	st.fifo.Remove(st.fifo.Front())
 	s.pending--
-	s.active[tag]++
-	s.starving[tag]++
-	s.lastSeen[tag] = time.Now()
+	st.active++
+	st.starving++
+	st.lastSeen = time.Now()
 }
 
 // tickEMA advances the per-tag exponentially-weighted moving average of
-// active workers. Called at a fixed cadence (roughly EMAWindow/8).
+// active workers and refreshes the cached dispatch weight derived from
+// it. Called at a fixed cadence (roughly EMAWindow/8).
+//
+// A tag first seen since the last tick starts from an EMA of zero, so the
+// same update rule bootstraps it correctly.
 func (s *TagScheduler) tickEMA() {
 	now := time.Now()
 	dt := now.Sub(s.lastTick)
@@ -572,33 +615,27 @@ func (s *TagScheduler) tickEMA() {
 		return
 	}
 	alpha := 1.0 - math.Exp(-float64(dt)/float64(s.cfg.EMAWindow))
-	seen := make(map[string]struct{}, len(s.ema))
-	for tag, e := range s.ema {
-		next := (1-alpha)*e + alpha*float64(s.active[tag])
-		if next < 1e-6 && s.active[tag] == 0 {
-			delete(s.ema, tag)
-		} else {
-			s.ema[tag] = next
+	for _, st := range s.tags {
+		next := (1-alpha)*st.ema + alpha*float64(st.active)
+		if next < emaFloor && st.active == 0 {
+			// Snap the tail of the decay to zero: an exponential never
+			// reaches it, and an idle tag must be able to become evictable.
+			next = 0
 		}
-		seen[tag] = struct{}{}
-	}
-	// Bootstrap EMA for tags that appeared since the last tick.
-	for tag := range s.active {
-		if _, ok := seen[tag]; ok {
-			continue
-		}
-		if s.active[tag] > 0 {
-			s.ema[tag] = alpha * float64(s.active[tag])
-		}
+		st.ema = next
+		st.weight = 1.0 / (1.0 + st.ema)
 	}
 }
 
-// evictIdleTags drops all per-tag state for tags with no queued or
-// in-flight work, no still-decaying EMA, and no activity for at least a
-// grace period. Without eviction, every origin ever contacted would stay
-// in the maps (and thus in every monitoring snapshot) for the process
-// lifetime — unbounded memory and Prometheus label cardinality, plus an
-// ever-growing O(tags) snapshot cost paid on this goroutine.
+// evictIdleTags drops all state for tags with no queued or in-flight
+// work, no still-decaying EMA, and no activity for at least a grace
+// period. This periodic sweep is the only place tag state is removed:
+// counters reaching zero are left alone, because a tag that just finished
+// a transfer is very likely to start another one. Without eviction,
+// though, every origin ever contacted would stay in the map (and thus in
+// every monitoring snapshot) for the process lifetime — unbounded memory
+// and Prometheus label cardinality, plus an ever-growing O(tags) snapshot
+// cost paid on this goroutine.
 //
 // The grace period is at least the EMA window so the metrics publisher
 // (which samples every few seconds) reliably observes a tag's final
@@ -607,25 +644,23 @@ func (s *TagScheduler) tickEMA() {
 // treats per-tag totals as delta sources and handles the reset.
 func (s *TagScheduler) evictIdleTags(now time.Time) {
 	grace := s.cfg.EMAWindow
-	if grace < 10*time.Second {
-		grace = 10 * time.Second
+	if grace < minEvictionGrace {
+		grace = minEvictionGrace
 	}
-	for tag, seen := range s.lastSeen {
-		if now.Sub(seen) < grace {
+	for tag, st := range s.tags {
+		if now.Sub(st.lastSeen) < grace {
 			continue
 		}
-		if _, ok := s.fifos[tag]; ok {
+		if st.fifo.Len() > 0 {
 			continue
 		}
-		if s.active[tag] > 0 || s.starving[tag] > 0 {
+		if st.active > 0 || st.starving > 0 {
 			continue
 		}
-		if _, ok := s.ema[tag]; ok {
+		if st.ema >= emaFloor {
 			continue
 		}
-		delete(s.lastSeen, tag)
-		delete(s.admits, tag)
-		delete(s.rejects, tag)
+		delete(s.tags, tag)
 	}
 }
 
@@ -652,9 +687,9 @@ func (s *TagScheduler) Snapshot(ctx context.Context) SchedulerSnapshot {
 }
 
 // buildSnapshot must be called on the scheduler goroutine (all state
-// reads are lock-free because we're the sole writer). Copies every
-// map value; the returned SchedulerSnapshot never aliases scheduler
-// state.
+// reads are lock-free because we're the sole writer). Every per-tag
+// value is copied out; the returned SchedulerSnapshot never aliases
+// scheduler state.
 func (s *TagScheduler) buildSnapshot() SchedulerSnapshot {
 	snap := SchedulerSnapshot{
 		Global: GlobalStats{
@@ -668,44 +703,18 @@ func (s *TagScheduler) buildSnapshot() SchedulerSnapshot {
 			TotalRejectsPerTag: s.totalRejectsPerTag,
 		},
 	}
-	// Collect the union of every tag we know about — a tag may have
-	// pending entries in `fifos`, active/starving counters even after
-	// its FIFO drained, an EMA that's still decaying, or admit/reject
-	// totals awaiting idle eviction after its in-flight work is done.
-	seen := make(map[string]struct{})
-	add := func(m map[string]struct{}, k string) { m[k] = struct{}{} }
-	for tag := range s.fifos {
-		add(seen, tag)
-	}
-	for tag := range s.active {
-		add(seen, tag)
-	}
-	for tag := range s.starving {
-		add(seen, tag)
-	}
-	for tag := range s.ema {
-		add(seen, tag)
-	}
-	for tag := range s.admits {
-		add(seen, tag)
-	}
-	for tag := range s.rejects {
-		add(seen, tag)
-	}
-
-	snap.Tags = make(map[string]PerTagStats, len(seen))
-	for tag := range seen {
-		var pending int
-		if q, ok := s.fifos[tag]; ok {
-			pending = q.Len()
-		}
+	// Every tag the scheduler knows about is reported, including ones whose
+	// queue has drained and whose transfers have finished: their
+	// admit/reject totals stay visible until the tag is evicted.
+	snap.Tags = make(map[string]PerTagStats, len(s.tags))
+	for tag, st := range s.tags {
 		snap.Tags[tag] = PerTagStats{
-			Pending:  pending,
-			Active:   s.active[tag],
-			Starving: s.starving[tag],
-			EMA:      s.ema[tag],
-			Admits:   s.admits[tag],
-			Rejects:  s.rejects[tag],
+			Pending:  st.fifo.Len(),
+			Active:   st.active,
+			Starving: st.starving,
+			EMA:      st.ema,
+			Admits:   st.admits,
+			Rejects:  st.rejects,
 		}
 	}
 	snap.Global.TotalTags = len(snap.Tags)

--- a/client/tag_scheduler.go
+++ b/client/tag_scheduler.go
@@ -536,11 +536,19 @@ func synthesizeRejectionResult(file *clientTransferFile, err error) *clientTrans
 		JobId: file.jobId,
 		Error: err,
 	}
-	if file.file != nil && file.file.remoteURL != nil {
-		res.Scheme = file.file.remoteURL.Scheme
-	}
-	if file.file != nil && file.file.job != nil && file.file.job.dirResp.RedirectInfo != nil {
-		res.DirectorDecision = file.file.job.dirResp.RedirectInfo
+	if file.file != nil {
+		// runMux's results-side branch (client/handle_http.go around
+		// the tmpResults[id] processing) unconditionally dereferences
+		// TransferResults.job to decrement activeXfer and check
+		// completion.  Wire the job here so a scheduler-rejected
+		// transfer doesn't panic on shutdown.
+		res.job = file.file.job
+		if file.file.remoteURL != nil {
+			res.Scheme = file.file.remoteURL.Scheme
+		}
+		if file.file.job != nil && file.file.job.dirResp.RedirectInfo != nil {
+			res.DirectorDecision = file.file.job.dirResp.RedirectInfo
+		}
 	}
 	log.Debugf("Scheduler rejected transfer for %v: %v", file.uuid, err)
 	return &clientTransferResults{id: file.uuid, results: res}

--- a/client/tag_scheduler.go
+++ b/client/tag_scheduler.go
@@ -73,11 +73,25 @@ type SchedulerRejection struct {
 	msg    string
 }
 
-func (e *SchedulerRejection) Error() string { return e.msg }
+func (e *SchedulerRejection) Error() string {
+	if e.msg != "" {
+		return e.msg
+	}
+	if e.Tag != "" {
+		return fmt.Sprintf("%s: %s (%s)", ErrTooManyRequests.Error(), e.Tag, e.Reason)
+	}
+	return ErrTooManyRequests.Error()
+}
 
-// Unwrap returns ErrTooManyRequests so errors.Is(err, ErrTooManyRequests)
-// continues to hold for every rejection.
-func (e *SchedulerRejection) Unwrap() error { return ErrTooManyRequests }
+// Unwrap returns the typed, retryable Pelican error for this rejection's
+// reason, which in turn wraps ErrTooManyRequests. Going through the typed
+// error rather than straight to the sentinel is what makes a locally-shed
+// transfer retryable under IsRetryable, matching how the same shed is
+// classified when it is observed remotely as a 429 (CacheThrottleError).
+// errors.Is(err, ErrTooManyRequests) still holds, one link further down.
+func (e *SchedulerRejection) Unwrap() error {
+	return throttleErrorForReason(string(e.Reason), ErrTooManyRequests)
+}
 
 // PerTagStats is a per-origin snapshot of scheduler state, intended for
 // monitoring / debugging. Values are consistent (all taken under one
@@ -356,7 +370,15 @@ func (s *TagScheduler) attachHooks(tag string, file *clientTransferFile) {
 		}
 	}
 	file.file.schedDone = func() {
-		stillStarving := !firstByteFired.Load()
+		// CompareAndSwap, not Load: completion and the first-byte signal are
+		// not mutually exclusive. An upload can abandon the transfer (stopped-
+		// transfer timeout, error on the side channel) while the transport is
+		// still running, and the transport may then report 100-continue, a
+		// first response byte, or having drained enough request body. Claiming
+		// the flag here means that later signal is a no-op instead of a second
+		// starving decrement, which would release some other in-flight
+		// transfer's slot.
+		stillStarving := firstByteFired.CompareAndSwap(false, true)
 		s.sendEvent(schedulerEvent{kind: evDone, tag: tag, stillStarving: stillStarving})
 	}
 }
@@ -368,17 +390,16 @@ func (s *TagScheduler) sendEvent(ev schedulerEvent) {
 	}
 }
 
+// starvingCap and activeCap convert the configured percentages into absolute
+// slot counts. Both round up, so a small pool cannot produce a cap of zero
+// and wedge the tag entirely: workerCount is at least 1 (the constructor
+// clamps it) and pct is at least 1 here, so the result is at least 1.
 func (s *TagScheduler) starvingCap() int {
 	pct := s.cfg.PerTagStarvingPercent
 	if pct <= 0 || pct >= 100 {
 		return s.workerCount
 	}
-	// Ceiling division so small pools (say 4 workers, 25%) always allow at least 1.
-	cap := (s.workerCount*pct + 99) / 100
-	if cap < 1 {
-		cap = 1
-	}
-	return cap
+	return (s.workerCount*pct + 99) / 100
 }
 
 func (s *TagScheduler) activeCap() int {
@@ -386,17 +407,19 @@ func (s *TagScheduler) activeCap() int {
 	if pct <= 0 || pct >= 100 {
 		return s.workerCount
 	}
-	cap := (s.workerCount*pct + 99) / 100
-	if cap < 1 {
-		cap = 1
-	}
-	return cap
+	return (s.workerCount*pct + 99) / 100
 }
 
 // run is the scheduler goroutine. It multiplexes admissions, first-byte
 // / done events, and dispatch attempts, and periodically ticks the EMA.
 func (s *TagScheduler) run(ctx context.Context) {
 	defer close(s.stopped)
+	// Everything that waits on the scheduler — Submit, Snapshot, sendEvent —
+	// uses s.stop as its escape hatch, so it has to be closed however run()
+	// exits, not just when Stop() is the thing that ended it. Without this a
+	// ctx-driven exit would leave those waiters relying on a later Stop() call
+	// to release them.
+	defer s.stopOnce.Do(func() { close(s.stop) })
 	// On exit, hand every admitted-but-undispatched transfer to onDrop so
 	// its job still observes a completion (otherwise the owning job's
 	// active-transfer count never drains and its results channel never

--- a/client/tag_scheduler.go
+++ b/client/tag_scheduler.go
@@ -36,6 +36,42 @@ import (
 // HTTP 429.
 var ErrTooManyRequests = errors.New("too many requests: origin is over its share of the transfer pool")
 
+// PerTagStats is a per-origin snapshot of scheduler state, intended for
+// monitoring / debugging. Values are consistent (all taken under one
+// lock) but stale as soon as they're read.
+type PerTagStats struct {
+	// Pending, Active, Starving are the current counts at snapshot time.
+	Pending  int
+	Active   int
+	Starving int
+	// EMA is the exponentially-weighted moving average of Active over
+	// the configured EMAWindow. Used as the weight input for the
+	// per-tag round-robin dispatch decision.
+	EMA float64
+	// Admits and Rejects are monotonic totals since scheduler start.
+	Admits  uint64
+	Rejects uint64
+}
+
+// GlobalStats is the pool-wide scheduler snapshot.
+type GlobalStats struct {
+	WorkerCount        int
+	StarvingCap        int
+	ActiveCap          int
+	TotalPending       int
+	TotalTags          int
+	TotalAdmits        uint64
+	TotalRejects       uint64
+	TotalRejectsGlobal uint64 // subset of TotalRejects: rejected because global pending was full
+	TotalRejectsPerTag uint64 // subset of TotalRejects: rejected because per-tag pending was full
+}
+
+// SchedulerSnapshot is a full snapshot of scheduler state.
+type SchedulerSnapshot struct {
+	Global GlobalStats
+	Tags   map[string]PerTagStats
+}
+
 // SchedulerConfig configures a TagScheduler. Zero-values disable the
 // corresponding limit.
 type SchedulerConfig struct {
@@ -74,6 +110,7 @@ type TagScheduler struct {
 	// by the scheduler goroutine and MUST NOT be touched from outside.
 	admit    chan *admitReq
 	events   chan schedulerEvent
+	snapReqs chan chan<- SchedulerSnapshot
 	stop     chan struct{}
 	stopped  chan struct{}
 	out      chan<- *clientTransferFile
@@ -83,8 +120,15 @@ type TagScheduler struct {
 	active   map[string]int        // tag → in-flight (any state)
 	starving map[string]int        // tag → in-flight without first byte
 	ema      map[string]float64    // tag → EMA of active
+	admits   map[string]uint64     // tag → monotonic admit count
+	rejects  map[string]uint64     // tag → monotonic rejection count
 	lastTick time.Time
 	pending  int
+
+	// Global monotonic counters, broken down by why we rejected.
+	// TotalAdmits = sum(admits values); TotalRejects = same for rejects.
+	totalRejectsGlobal uint64 // rejected because global pending was full
+	totalRejectsPerTag uint64 // rejected because per-tag pending was full
 }
 
 // Sentinel event kinds for use over the events channel.
@@ -118,6 +162,7 @@ func NewTagScheduler(workerCount int, cfg SchedulerConfig) *TagScheduler {
 		workerCount: workerCount,
 		admit:       make(chan *admitReq),
 		events:      make(chan schedulerEvent, 256),
+		snapReqs:    make(chan chan<- SchedulerSnapshot),
 		stop:        make(chan struct{}),
 		stopped:     make(chan struct{}),
 		rng:         rand.New(rand.NewSource(time.Now().UnixNano())),
@@ -125,6 +170,8 @@ func NewTagScheduler(workerCount int, cfg SchedulerConfig) *TagScheduler {
 		active:      make(map[string]int),
 		starving:    make(map[string]int),
 		ema:         make(map[string]float64),
+		admits:      make(map[string]uint64),
+		rejects:     make(map[string]uint64),
 	}
 }
 
@@ -242,6 +289,8 @@ func (s *TagScheduler) run(ctx context.Context) {
 				s.handleAdmit(req)
 			case ev := <-s.events:
 				s.handleEvent(ev)
+			case reply := <-s.snapReqs:
+				reply <- s.buildSnapshot()
 			case <-tick.C:
 				s.tickEMA()
 			case <-s.stop:
@@ -255,6 +304,8 @@ func (s *TagScheduler) run(ctx context.Context) {
 				s.handleAdmit(req)
 			case ev := <-s.events:
 				s.handleEvent(ev)
+			case reply := <-s.snapReqs:
+				reply <- s.buildSnapshot()
 			case <-tick.C:
 				s.tickEMA()
 			case <-s.stop:
@@ -268,6 +319,8 @@ func (s *TagScheduler) run(ctx context.Context) {
 
 func (s *TagScheduler) handleAdmit(req *admitReq) {
 	if s.cfg.PendingBufferSize > 0 && s.pending >= s.cfg.PendingBufferSize {
+		s.rejects[req.tag]++
+		s.totalRejectsGlobal++
 		req.reply <- errors.Wrap(ErrTooManyRequests, "pending queue is full")
 		return
 	}
@@ -277,11 +330,14 @@ func (s *TagScheduler) handleAdmit(req *admitReq) {
 		s.fifos[req.tag] = q
 	}
 	if s.cfg.PerTagPendingSize > 0 && q.Len() >= s.cfg.PerTagPendingSize {
+		s.rejects[req.tag]++
+		s.totalRejectsPerTag++
 		req.reply <- errors.Wrapf(ErrTooManyRequests, "origin %q pending queue is full", req.tag)
 		return
 	}
 	q.PushBack(req.file)
 	s.pending++
+	s.admits[req.tag]++
 	req.reply <- nil
 }
 
@@ -383,6 +439,93 @@ func (s *TagScheduler) tickEMA() {
 			s.ema[tag] = alpha * float64(s.active[tag])
 		}
 	}
+}
+
+// Snapshot returns a consistent snapshot of scheduler state suitable
+// for driving monitoring metrics. Runs on the scheduler goroutine so
+// counters, gauges, and per-tag maps agree with one another.
+//
+// Returns the zero snapshot if the scheduler has already stopped.
+func (s *TagScheduler) Snapshot(ctx context.Context) SchedulerSnapshot {
+	reply := make(chan SchedulerSnapshot, 1)
+	select {
+	case s.snapReqs <- reply:
+	case <-ctx.Done():
+		return SchedulerSnapshot{}
+	case <-s.stop:
+		return SchedulerSnapshot{}
+	}
+	select {
+	case snap := <-reply:
+		return snap
+	case <-ctx.Done():
+		return SchedulerSnapshot{}
+	}
+}
+
+// buildSnapshot must be called on the scheduler goroutine (all state
+// reads are lock-free because we're the sole writer). Copies every
+// map value; the returned SchedulerSnapshot never aliases scheduler
+// state.
+func (s *TagScheduler) buildSnapshot() SchedulerSnapshot {
+	snap := SchedulerSnapshot{
+		Global: GlobalStats{
+			WorkerCount:        s.workerCount,
+			StarvingCap:        s.starvingCap(),
+			ActiveCap:          s.activeCap(),
+			TotalPending:       s.pending,
+			TotalRejectsGlobal: s.totalRejectsGlobal,
+			TotalRejectsPerTag: s.totalRejectsPerTag,
+		},
+	}
+	// Collect the union of every tag we know about — a tag may have
+	// pending entries in `fifos`, active/starving counters even after
+	// its FIFO drained, an EMA that's still decaying, or lifetime
+	// admit/reject totals long after all its in-flight work is done.
+	seen := make(map[string]struct{})
+	add := func(m map[string]struct{}, k string) { m[k] = struct{}{} }
+	for tag := range s.fifos {
+		add(seen, tag)
+	}
+	for tag := range s.active {
+		add(seen, tag)
+	}
+	for tag := range s.starving {
+		add(seen, tag)
+	}
+	for tag := range s.ema {
+		add(seen, tag)
+	}
+	for tag := range s.admits {
+		add(seen, tag)
+	}
+	for tag := range s.rejects {
+		add(seen, tag)
+	}
+
+	snap.Tags = make(map[string]PerTagStats, len(seen))
+	var totalAdmits, totalRejects uint64
+	for tag := range seen {
+		var pending int
+		if q, ok := s.fifos[tag]; ok {
+			pending = q.Len()
+		}
+		p := PerTagStats{
+			Pending:  pending,
+			Active:   s.active[tag],
+			Starving: s.starving[tag],
+			EMA:      s.ema[tag],
+			Admits:   s.admits[tag],
+			Rejects:  s.rejects[tag],
+		}
+		snap.Tags[tag] = p
+		totalAdmits += p.Admits
+		totalRejects += p.Rejects
+	}
+	snap.Global.TotalTags = len(snap.Tags)
+	snap.Global.TotalAdmits = totalAdmits
+	snap.Global.TotalRejects = totalRejects
+	return snap
 }
 
 // synthesizeRejectionResult builds a TransferResults that surfaces a 429

--- a/client/tag_scheduler.go
+++ b/client/tag_scheduler.go
@@ -669,9 +669,16 @@ func (s *TagScheduler) tickEMA() {
 //
 // The grace period is at least the EMA window so the metrics publisher
 // (which samples every few seconds) reliably observes a tag's final
-// admit/reject totals before the tag disappears. Evicted tags that
-// return start their per-tag counters from zero; the metrics layer
-// treats per-tag totals as delta sources and handles the reset.
+// admit/reject totals before the tag disappears, and then observes the
+// tag's absence and forgets its last-published totals. Evicted tags that
+// return start their per-tag counters from zero.
+//
+// That ordering is what keeps the published counters honest, not the
+// metrics layer's reset handling on its own: it detects a reset by the
+// totals going *down*, so a tag that were to vanish and climb back past
+// its old total between two samples would have the difference counted as
+// if it were continuous activity. Keeping the grace period comfortably
+// longer than the publish interval is what makes that unreachable.
 func (s *TagScheduler) evictIdleTags(now time.Time) {
 	grace := s.cfg.EMAWindow
 	if grace < minEvictionGrace {

--- a/client/tag_scheduler.go
+++ b/client/tag_scheduler.go
@@ -1,0 +1,404 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package client
+
+import (
+	"container/list"
+	"context"
+	"math"
+	"math/rand"
+	"sync/atomic"
+	"time"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// ErrTooManyRequests is returned by TagScheduler.Submit when the scheduler
+// refuses admission because the tag (typically an upstream origin) is
+// already at its share of the transfer engine's worker pool. It mirrors
+// HTTP 429.
+var ErrTooManyRequests = errors.New("too many requests: origin is over its share of the transfer pool")
+
+// SchedulerConfig configures a TagScheduler. Zero-values disable the
+// corresponding limit.
+type SchedulerConfig struct {
+	// PerTagStarvingPercent — upper bound (percentage of worker pool) on
+	// how many workers a single tag may hold while its transfers have
+	// not yet produced a first byte of data. 0 or ≥100 disables.
+	PerTagStarvingPercent int
+	// PerTagActivePercent — upper bound (percentage of worker pool) on
+	// how many workers a single tag may hold in total (starving +
+	// actively-transferring). 0 or ≥100 disables.
+	PerTagActivePercent int
+	// PendingBufferSize — total number of pending transfers the
+	// scheduler will queue across all tags before shedding new admits
+	// with ErrTooManyRequests. 0 disables the cap (unbounded queue).
+	PendingBufferSize int
+	// PerTagPendingSize — number of pending transfers the scheduler
+	// will queue for any single tag before rejecting new admits with
+	// ErrTooManyRequests. 0 disables the per-tag cap.
+	PerTagPendingSize int
+	// EMAWindow — time constant of the per-tag active-worker EMA used
+	// to weight the round-robin. Shorter = more reactive, longer =
+	// smoother. 0 disables EMA updates (all eligible tags get equal
+	// weight).
+	EMAWindow time.Duration
+}
+
+// TagScheduler admits transfers into a bounded per-tag FIFO and dispatches
+// them to workers with a weighted random draw across tags. It exists to
+// keep one misbehaving origin from monopolising the transfer engine's
+// worker pool.
+type TagScheduler struct {
+	cfg         SchedulerConfig
+	workerCount int
+
+	// Communication channels. Every field below the channels is owned
+	// by the scheduler goroutine and MUST NOT be touched from outside.
+	admit    chan *admitReq
+	events   chan schedulerEvent
+	stop     chan struct{}
+	stopped  chan struct{}
+	out      chan<- *clientTransferFile
+	rng      *rand.Rand
+
+	fifos    map[string]*list.List // tag → FIFO of *clientTransferFile
+	active   map[string]int        // tag → in-flight (any state)
+	starving map[string]int        // tag → in-flight without first byte
+	ema      map[string]float64    // tag → EMA of active
+	lastTick time.Time
+	pending  int
+}
+
+// Sentinel event kinds for use over the events channel.
+type schedulerEventKind int
+
+const (
+	evFirstByte schedulerEventKind = iota
+	evDone
+)
+
+type schedulerEvent struct {
+	kind          schedulerEventKind
+	tag           string
+	stillStarving bool // used by evDone
+}
+
+type admitReq struct {
+	tag   string
+	file  *clientTransferFile
+	reply chan error
+}
+
+// NewTagScheduler builds a scheduler for a pool of `workerCount` workers.
+// Call Start to run its goroutine.
+func NewTagScheduler(workerCount int, cfg SchedulerConfig) *TagScheduler {
+	if workerCount < 1 {
+		workerCount = 1
+	}
+	return &TagScheduler{
+		cfg:         cfg,
+		workerCount: workerCount,
+		admit:       make(chan *admitReq),
+		events:      make(chan schedulerEvent, 256),
+		stop:        make(chan struct{}),
+		stopped:     make(chan struct{}),
+		rng:         rand.New(rand.NewSource(time.Now().UnixNano())),
+		fifos:       make(map[string]*list.List),
+		active:      make(map[string]int),
+		starving:    make(map[string]int),
+		ema:         make(map[string]float64),
+	}
+}
+
+// Start begins the scheduler goroutine, dispatching admitted transfers on
+// the out channel. Stop() blocks until the goroutine exits.
+func (s *TagScheduler) Start(ctx context.Context, out chan<- *clientTransferFile) {
+	s.out = out
+	go s.run(ctx)
+}
+
+// Stop signals the scheduler to exit and waits for the goroutine.
+func (s *TagScheduler) Stop() {
+	select {
+	case <-s.stop:
+		// Already stopped
+	default:
+		close(s.stop)
+	}
+	<-s.stopped
+}
+
+// Submit asks the scheduler to admit `file`, tagged with `tag`. Returns
+// nil on accept (the transfer will be dispatched when a worker is free
+// and the tag is under its caps), ErrTooManyRequests on rejection.
+//
+// Submit attaches hooks to file.file so the workers can signal
+// first-byte and completion back to the scheduler.
+func (s *TagScheduler) Submit(ctx context.Context, tag string, file *clientTransferFile) error {
+	s.attachHooks(tag, file)
+
+	reply := make(chan error, 1)
+	req := &admitReq{tag: tag, file: file, reply: reply}
+	select {
+	case s.admit <- req:
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-s.stop:
+		return errors.New("transfer scheduler is shut down")
+	}
+	select {
+	case err := <-reply:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *TagScheduler) attachHooks(tag string, file *clientTransferFile) {
+	var firstByteFired atomic.Bool
+	file.file.schedFirstByte = func() {
+		if firstByteFired.CompareAndSwap(false, true) {
+			s.sendEvent(schedulerEvent{kind: evFirstByte, tag: tag})
+		}
+	}
+	file.file.schedDone = func() {
+		stillStarving := !firstByteFired.Load()
+		s.sendEvent(schedulerEvent{kind: evDone, tag: tag, stillStarving: stillStarving})
+	}
+}
+
+func (s *TagScheduler) sendEvent(ev schedulerEvent) {
+	select {
+	case s.events <- ev:
+	case <-s.stop:
+	}
+}
+
+func (s *TagScheduler) starvingCap() int {
+	pct := s.cfg.PerTagStarvingPercent
+	if pct <= 0 || pct >= 100 {
+		return s.workerCount
+	}
+	// Ceiling division so small pools (say 4 workers, 25%) always allow at least 1.
+	cap := (s.workerCount*pct + 99) / 100
+	if cap < 1 {
+		cap = 1
+	}
+	return cap
+}
+
+func (s *TagScheduler) activeCap() int {
+	pct := s.cfg.PerTagActivePercent
+	if pct <= 0 || pct >= 100 {
+		return s.workerCount
+	}
+	cap := (s.workerCount*pct + 99) / 100
+	if cap < 1 {
+		cap = 1
+	}
+	return cap
+}
+
+// run is the scheduler goroutine. It multiplexes admissions, first-byte
+// / done events, and dispatch attempts, and periodically ticks the EMA.
+func (s *TagScheduler) run(ctx context.Context) {
+	defer close(s.stopped)
+
+	tickInterval := s.cfg.EMAWindow / 8
+	if tickInterval < 250*time.Millisecond {
+		tickInterval = 250 * time.Millisecond
+	}
+	tick := time.NewTicker(tickInterval)
+	defer tick.Stop()
+	s.lastTick = time.Now()
+
+	for {
+		// If we have a candidate to dispatch AND caps allow, try to
+		// hand it off to a worker while still servicing other events.
+		if tag, ok := s.pickForDispatch(); ok {
+			head := s.fifos[tag].Front().Value.(*clientTransferFile)
+			select {
+			case s.out <- head:
+				s.onDispatched(tag)
+			case req := <-s.admit:
+				s.handleAdmit(req)
+			case ev := <-s.events:
+				s.handleEvent(ev)
+			case <-tick.C:
+				s.tickEMA()
+			case <-s.stop:
+				return
+			case <-ctx.Done():
+				return
+			}
+		} else {
+			select {
+			case req := <-s.admit:
+				s.handleAdmit(req)
+			case ev := <-s.events:
+				s.handleEvent(ev)
+			case <-tick.C:
+				s.tickEMA()
+			case <-s.stop:
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+func (s *TagScheduler) handleAdmit(req *admitReq) {
+	if s.cfg.PendingBufferSize > 0 && s.pending >= s.cfg.PendingBufferSize {
+		req.reply <- errors.Wrap(ErrTooManyRequests, "pending queue is full")
+		return
+	}
+	q, ok := s.fifos[req.tag]
+	if !ok {
+		q = list.New()
+		s.fifos[req.tag] = q
+	}
+	if s.cfg.PerTagPendingSize > 0 && q.Len() >= s.cfg.PerTagPendingSize {
+		req.reply <- errors.Wrapf(ErrTooManyRequests, "origin %q pending queue is full", req.tag)
+		return
+	}
+	q.PushBack(req.file)
+	s.pending++
+	req.reply <- nil
+}
+
+func (s *TagScheduler) handleEvent(ev schedulerEvent) {
+	switch ev.kind {
+	case evFirstByte:
+		if s.starving[ev.tag] > 0 {
+			s.starving[ev.tag]--
+		}
+	case evDone:
+		if s.active[ev.tag] > 0 {
+			s.active[ev.tag]--
+		}
+		if ev.stillStarving && s.starving[ev.tag] > 0 {
+			s.starving[ev.tag]--
+		}
+	}
+}
+
+// pickForDispatch selects the next tag whose queue head we'd like to
+// hand off to a worker, using a weighted random draw across eligible
+// tags (those under both the starving and active caps). Weight is
+// 1/(1+EMA) so tags that have used less of the pool recently are more
+// likely to be picked. Returns "", false if nothing is dispatchable.
+func (s *TagScheduler) pickForDispatch() (string, bool) {
+	starvingCap := s.starvingCap()
+	activeCap := s.activeCap()
+
+	type cand struct {
+		tag string
+		w   float64
+	}
+	var cands []cand
+	totalW := 0.0
+	for tag, q := range s.fifos {
+		if q.Len() == 0 {
+			continue
+		}
+		if s.starving[tag] >= starvingCap {
+			continue
+		}
+		if s.active[tag] >= activeCap {
+			continue
+		}
+		w := 1.0 / (1.0 + s.ema[tag])
+		cands = append(cands, cand{tag, w})
+		totalW += w
+	}
+	if len(cands) == 0 {
+		return "", false
+	}
+	r := s.rng.Float64() * totalW
+	for _, c := range cands {
+		r -= c.w
+		if r <= 0 {
+			return c.tag, true
+		}
+	}
+	return cands[len(cands)-1].tag, true
+}
+
+func (s *TagScheduler) onDispatched(tag string) {
+	q := s.fifos[tag]
+	q.Remove(q.Front())
+	if q.Len() == 0 {
+		delete(s.fifos, tag)
+	}
+	s.pending--
+	s.active[tag]++
+	s.starving[tag]++
+}
+
+// tickEMA advances the per-tag exponentially-weighted moving average of
+// active workers. Called at a fixed cadence (roughly EMAWindow/8).
+func (s *TagScheduler) tickEMA() {
+	now := time.Now()
+	dt := now.Sub(s.lastTick)
+	s.lastTick = now
+	if s.cfg.EMAWindow <= 0 || dt <= 0 {
+		return
+	}
+	alpha := 1.0 - math.Exp(-float64(dt)/float64(s.cfg.EMAWindow))
+	seen := make(map[string]struct{}, len(s.ema))
+	for tag, e := range s.ema {
+		next := (1-alpha)*e + alpha*float64(s.active[tag])
+		if next < 1e-6 && s.active[tag] == 0 {
+			delete(s.ema, tag)
+		} else {
+			s.ema[tag] = next
+		}
+		seen[tag] = struct{}{}
+	}
+	// Bootstrap EMA for tags that appeared since the last tick.
+	for tag := range s.active {
+		if _, ok := seen[tag]; ok {
+			continue
+		}
+		if s.active[tag] > 0 {
+			s.ema[tag] = alpha * float64(s.active[tag])
+		}
+	}
+}
+
+// synthesizeRejectionResult builds a TransferResults that surfaces a 429
+// rejection to callers. Exposed so wire code can push it to te.results
+// without special-casing.
+func synthesizeRejectionResult(file *clientTransferFile, err error) *clientTransferResults {
+	res := TransferResults{
+		JobId: file.jobId,
+		Error: err,
+	}
+	if file.file != nil && file.file.remoteURL != nil {
+		res.Scheme = file.file.remoteURL.Scheme
+	}
+	if file.file != nil && file.file.job != nil && file.file.job.dirResp.RedirectInfo != nil {
+		res.DirectorDecision = file.file.job.dirResp.RedirectInfo
+	}
+	log.Debugf("Scheduler rejected transfer for %v: %v", file.uuid, err)
+	return &clientTransferResults{id: file.uuid, results: res}
+}

--- a/client/tag_scheduler_test.go
+++ b/client/tag_scheduler_test.go
@@ -502,3 +502,220 @@ func TestTagSchedulerRejectClassifiesOriginSlow(t *testing.T) {
 	require.ErrorAs(t, err, &rej)
 	assert.Equal(t, ShedOriginSlow, rej.Reason)
 }
+
+// A transfer that fails before producing any body must release both its
+// active and starving slots; otherwise a string of early failures would
+// permanently consume the tag's (small) starving budget and wedge the tag.
+func TestTagSchedulerStarvingReleasedOnEarlyFailure(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	sched := NewTagScheduler(4, SchedulerConfig{
+		PerTagStarvingPercent: 25, // starving cap = 1: the limiter
+		PerTagActivePercent:   90,
+		PendingBufferSize:     100,
+		PerTagPendingSize:     100,
+		EMAWindow:             5 * time.Second,
+	})
+	out := make(chan *clientTransferFile)
+	sched.Start(ctx, out)
+	t.Cleanup(sched.Stop)
+
+	require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+
+	// First dispatch holds the whole starving budget. Fail it without a
+	// first byte; the queued transfer must then dispatch.
+	first := <-out
+	first.file.schedDone()
+	select {
+	case second := <-out:
+		second.file.schedFirstByte()
+		second.file.schedDone()
+	case <-ctx.Done():
+		t.Fatal("second transfer never dispatched: early failure did not release the starving slot")
+	}
+
+	// All slots must drain back to zero (no double-decrement, no leak).
+	require.Eventually(t, func() bool {
+		snap := sched.Snapshot(ctx)
+		st := snap.Tags["originA"]
+		return st.Active == 0 && st.Starving == 0
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+// Transfers still queued when the scheduler stops must be handed to the
+// onDrop hook (which the engine uses to synthesize failure results) rather
+// than silently discarded — otherwise their jobs would wait forever.
+func TestTagSchedulerStopDrainsQueued(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	sched := NewTagScheduler(4, SchedulerConfig{
+		PendingBufferSize: 100,
+		PerTagPendingSize: 100,
+		EMAWindow:         5 * time.Second,
+	})
+	var dropped []*clientTransferFile
+	sched.onDrop = func(f *clientTransferFile) { dropped = append(dropped, f) }
+	// No reader on out: everything admitted stays queued.
+	out := make(chan *clientTransferFile)
+	sched.Start(ctx, out)
+
+	const N = 3
+	for i := 0; i < N; i++ {
+		require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	}
+	// Stop returns only after the scheduler goroutine has drained the
+	// FIFOs, so reading `dropped` afterwards is race-free.
+	sched.Stop()
+	assert.Len(t, dropped, N, "every queued transfer must be surfaced via onDrop at shutdown")
+}
+
+// Submissions racing shutdown must shed like any other rejection (so the
+// caller synthesizes a failure result) instead of dropping the transfer.
+func TestTagSchedulerSubmitAfterStop(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sched := NewTagScheduler(4, SchedulerConfig{PendingBufferSize: 10})
+	out := make(chan *clientTransferFile)
+	sched.Start(ctx, out)
+	sched.Stop()
+
+	err := sched.Submit(ctx, "originA", makeFile("originA"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTooManyRequests)
+	var rej *SchedulerRejection
+	require.ErrorAs(t, err, &rej)
+	assert.Equal(t, ShedCacheOverloaded, rej.Reason)
+}
+
+// Stop is safe to call repeatedly, concurrently, and on a scheduler that was
+// never started.
+func TestTagSchedulerStopIsIdempotent(t *testing.T) {
+	// Never started: must return promptly rather than wait on a goroutine
+	// that does not exist.
+	neverStarted := NewTagScheduler(4, SchedulerConfig{})
+	done := make(chan struct{})
+	go func() { neverStarted.Stop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop on a never-started scheduler hung")
+	}
+
+	// Started: concurrent Stops must all return without panicking.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sched := NewTagScheduler(4, SchedulerConfig{})
+	sched.Start(ctx, make(chan *clientTransferFile))
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); sched.Stop() }()
+	}
+	wg.Wait()
+}
+
+// Fully-idle tags must be evicted after the grace period so the per-tag maps
+// (and the monitoring snapshot / Prometheus label set derived from them) do
+// not grow forever with every origin the cache has ever contacted. Tags with
+// queued or in-flight work, a still-decaying EMA, or recent activity stay.
+func TestTagSchedulerEvictsIdleTags(t *testing.T) {
+	sched := NewTagScheduler(4, SchedulerConfig{}) // EMAWindow 0 → grace floor (10s)
+	now := time.Now()
+	stale := now.Add(-time.Minute)
+
+	// Idle: counters only, no other state — must be evicted.
+	sched.admits["idle"] = 5
+	sched.rejects["idle"] = 2
+	sched.lastSeen["idle"] = stale
+	// In-flight: active transfer pins the tag.
+	sched.admits["busy"] = 1
+	sched.active["busy"] = 1
+	sched.lastSeen["busy"] = stale
+	// Decaying: EMA still present pins the tag.
+	sched.admits["decaying"] = 1
+	sched.ema["decaying"] = 0.5
+	sched.lastSeen["decaying"] = stale
+	// Recent: activity within the grace period pins the tag.
+	sched.admits["recent"] = 1
+	sched.lastSeen["recent"] = now
+
+	sched.evictIdleTags(now)
+
+	assert.NotContains(t, sched.admits, "idle")
+	assert.NotContains(t, sched.rejects, "idle")
+	assert.NotContains(t, sched.lastSeen, "idle")
+	assert.Contains(t, sched.admits, "busy")
+	assert.Contains(t, sched.admits, "decaying")
+	assert.Contains(t, sched.admits, "recent")
+
+	// The evicted tag no longer appears in snapshots (buildSnapshot runs on
+	// the scheduler goroutine; calling it directly is safe on a scheduler
+	// that was never started).
+	snap := sched.buildSnapshot()
+	assert.NotContains(t, snap.Tags, "idle")
+	assert.Contains(t, snap.Tags, "busy")
+}
+
+// When the global pending buffer is full, a tag with an empty queue may
+// still enqueue one entry. Without this reservation, a few saturated origins
+// could pin the global buffer and starve every healthy origin out of
+// admission entirely — inverting the fairness the scheduler exists for.
+func TestTagSchedulerGlobalBufferReservesForIdleTags(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sched := NewTagScheduler(4, SchedulerConfig{
+		PerTagStarvingPercent: 25, // starving cap 1: originA's queue backs up
+		PerTagActivePercent:   90,
+		PendingBufferSize:     2,
+		PerTagPendingSize:     100,
+		EMAWindow:             5 * time.Second,
+	})
+	// No consumer on out: dispatched work parks, queues build.
+	sched.out = make(chan *clientTransferFile)
+	sched.stopped = make(chan struct{})
+	sched.started.Store(true)
+	go sched.run(ctx)
+	t.Cleanup(sched.Stop)
+
+	// Saturate the global buffer with one origin.
+	require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	// Same origin again: global buffer is full and its queue is non-empty →
+	// shed.
+	err := sched.Submit(ctx, "originA", makeFile("originA"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTooManyRequests)
+
+	// A different, idle origin must still get its one reserved slot…
+	require.NoError(t, sched.Submit(ctx, "originB", makeFile("originB")),
+		"an idle origin must not be locked out by other origins pinning the global buffer")
+	// …but only one: with something queued it is subject to the global cap
+	// like everyone else.
+	err = sched.Submit(ctx, "originB", makeFile("originB"))
+	require.Error(t, err)
+	var rej *SchedulerRejection
+	require.ErrorAs(t, err, &rej)
+	assert.Equal(t, ShedCacheOverloaded, rej.Reason,
+		"an origin under its own caps must not be blamed for pool-wide saturation")
+}
+
+// classifyShed attributes a shed to the origin only when the origin's own
+// in-flight composition is the limit; a tag whose queue backed up purely
+// because of pool-wide contention is reported as cache_overloaded, not
+// blamed as slow.
+func TestTagSchedulerClassifyShedHonesty(t *testing.T) {
+	sched := NewTagScheduler(4, SchedulerConfig{
+		PerTagStarvingPercent: 25, // starving cap 1
+		PerTagActivePercent:   50, // active cap 2
+	})
+	// Idle tag: nothing in flight → pool contention, not the origin's fault.
+	assert.Equal(t, ShedCacheOverloaded, sched.classifyShed("idleTag"))
+	// At the starving cap: first-byte-less fetches dominate → unresponsive.
+	sched.active["starved"] = 1
+	sched.starving["starved"] = 1
+	assert.Equal(t, ShedOriginUnresponsive, sched.classifyShed("starved"))
+	// At the active cap, delivering data → merely slow.
+	sched.active["slow"] = 2
+	assert.Equal(t, ShedOriginSlow, sched.classifyShed("slow"))
+}

--- a/client/tag_scheduler_test.go
+++ b/client/tag_scheduler_test.go
@@ -21,12 +21,14 @@ package client
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"net/url"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/pelicanplatform/pelican/error_codes"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -205,8 +207,18 @@ func TestTagSchedulerStarvingCap(t *testing.T) {
 	// FIFO, and stay there — nothing releases a starving slot.
 	require.Eventually(t, func() bool { return len(out) == 3 }, time.Second, 10*time.Millisecond,
 		"starving cap should hold dispatch at ceil(30%)")
-	assert.Never(t, func() bool { return len(out) != 3 }, 300*time.Millisecond, 10*time.Millisecond,
-		"no further dispatch until first byte or done")
+
+	// Assert the resting state rather than watching the clock for a
+	// non-event: a tag at its starving cap with a non-empty FIFO is not
+	// eligible for dispatch, so nothing more can come out until a first-byte
+	// or done event arrives, and none is coming.
+	var snap SchedulerSnapshot
+	require.Eventually(t, func() bool {
+		snap = sched.Snapshot(ctx)
+		return snap.Tags["originA"].Starving == 3 && snap.Tags["originA"].Pending == 7
+	}, time.Second, 10*time.Millisecond, "expected 3 starving and 7 queued, got %+v", snap.Tags["originA"])
+	assert.Equal(t, 3, snap.Tags["originA"].Active, "every dispatched transfer is still in flight")
+	assert.Equal(t, 3, len(out))
 }
 
 // TestTagSchedulerFirstByteReleasesStarvingSlot: once a dispatched
@@ -264,10 +276,20 @@ func TestTagSchedulerActiveCap(t *testing.T) {
 		firstFour[i] = <-out
 		firstFour[i].file.schedFirstByte()
 	}
-	// Active cap should hold at 4; nothing more dispatches until a
-	// schedDone fires.
-	assert.Never(t, func() bool { return len(out) > 0 }, 300*time.Millisecond, 10*time.Millisecond,
-		"active cap should prevent further dispatch until a done")
+	// Active cap should hold at 4; nothing more dispatches until a schedDone
+	// fires. As above, assert the resting state instead of waiting out a
+	// non-event: a tag at its active cap with a non-empty FIFO cannot be
+	// picked for dispatch.
+	var snap SchedulerSnapshot
+	require.Eventually(t, func() bool {
+		snap = sched.Snapshot(ctx)
+		st := snap.Tags["originA"]
+		// Starving reaching 0 is what proves all four first-byte events have
+		// been processed; active and pending alone were already at these
+		// values before any of them landed.
+		return st.Active == 4 && st.Starving == 0 && st.Pending == 6
+	}, time.Second, 10*time.Millisecond, "expected 4 active, 0 starving and 6 queued, got %+v", snap.Tags["originA"])
+	assert.Equal(t, 0, len(out), "active cap should prevent further dispatch until a done")
 
 	firstFour[0].file.schedDone()
 	require.Eventually(t, func() bool { return len(out) == 1 }, time.Second, 10*time.Millisecond)
@@ -735,4 +757,395 @@ func TestTagSchedulerClassifyShedHonesty(t *testing.T) {
 	// At the active cap, delivering data → merely slow.
 	sched.tagFor("slow").active = 2
 	assert.Equal(t, ShedOriginSlow, sched.classifyShed("slow"))
+}
+
+// TestTagSchedulerCapRounding pins the percent-to-slots conversion across
+// pool sizes and percentages. The caps round up, so a small pool can never
+// produce a cap of zero — which would make the tag permanently ineligible
+// for dispatch and wedge every transfer for that origin. Out-of-range
+// percentages mean "no per-tag limit" and yield the whole pool.
+func TestTagSchedulerCapRounding(t *testing.T) {
+	for _, tc := range []struct {
+		workers int
+		pct     int
+		want    int
+	}{
+		{workers: 1, pct: 1, want: 1},
+		{workers: 1, pct: 25, want: 1},
+		{workers: 1, pct: 99, want: 1},
+		{workers: 2, pct: 25, want: 1},
+		{workers: 3, pct: 25, want: 1},
+		{workers: 4, pct: 25, want: 1},
+		{workers: 5, pct: 25, want: 2},
+		{workers: 100, pct: 25, want: 25},
+		{workers: 100, pct: 90, want: 90},
+		{workers: 100, pct: 33, want: 33},
+		// A non-positive or >=100 percentage disables the cap.
+		{workers: 10, pct: 0, want: 10},
+		{workers: 10, pct: -1, want: 10},
+		{workers: 10, pct: 100, want: 10},
+		{workers: 10, pct: 150, want: 10},
+		// The constructor floors the pool at one worker.
+		{workers: 0, pct: 25, want: 1},
+		{workers: -5, pct: 50, want: 1},
+	} {
+		t.Run(fmt.Sprintf("workers=%d_pct=%d", tc.workers, tc.pct), func(t *testing.T) {
+			starving := NewTagScheduler(tc.workers, SchedulerConfig{PerTagStarvingPercent: tc.pct})
+			assert.Equal(t, tc.want, starving.starvingCap())
+			active := NewTagScheduler(tc.workers, SchedulerConfig{PerTagActivePercent: tc.pct})
+			assert.Equal(t, tc.want, active.activeCap())
+			assert.GreaterOrEqual(t, starving.starvingCap(), 1, "a cap of zero would wedge the tag")
+		})
+	}
+}
+
+// TestTagSchedulerLateFirstByteDoesNotDoubleRelease pins that a first-byte
+// signal arriving after the transfer already completed is ignored.
+//
+// Completion and first-byte are not mutually exclusive: an upload can
+// abandon its transfer (stopped-transfer timeout, error on the side channel)
+// while the transport is still running, and the transport may afterwards
+// report a negotiated 100-continue, a first response byte, or enough request
+// body drained. If schedDone merely read the flag instead of claiming it,
+// that late signal would decrement the tag's starving count a second time
+// and hand some other in-flight transfer's slot away.
+func TestTagSchedulerLateFirstByteDoesNotDoubleRelease(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sched := NewTagScheduler(10, SchedulerConfig{
+		PerTagStarvingPercent: 20, // starving cap = 2
+		PerTagActivePercent:   90,
+		PendingBufferSize:     100,
+		PerTagPendingSize:     100,
+		EMAWindow:             5 * time.Second,
+	})
+	out := make(chan *clientTransferFile, 100)
+	startScheduler(t, ctx, sched, out)
+
+	for i := 0; i < 6; i++ {
+		require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	}
+	require.Eventually(t, func() bool { return len(out) == 2 }, time.Second, 10*time.Millisecond,
+		"starving cap should hold dispatch at 2")
+	fileA := <-out
+	fileB := <-out
+
+	// A completes without ever producing a byte: it gives back one starving
+	// slot, which lets exactly one more transfer dispatch.
+	fileA.file.schedDone()
+	require.Eventually(t, func() bool { return len(out) == 1 }, time.Second, 10*time.Millisecond)
+	fileC := <-out
+
+	// Now A's transport reports a first byte, too late to mean anything.
+	// Nothing may be released on the strength of it.
+	fileA.file.schedFirstByte()
+
+	var snap SchedulerSnapshot
+	require.Eventually(t, func() bool {
+		snap = sched.Snapshot(ctx)
+		return snap.Tags["originA"].Active == 2
+	}, time.Second, 10*time.Millisecond, "expected B and C in flight, got %+v", snap.Tags["originA"])
+	assert.Equal(t, 2, snap.Tags["originA"].Starving,
+		"B and C are still starving; A's late first byte must not release a slot")
+	assert.Equal(t, 3, snap.Tags["originA"].Pending)
+	assert.Equal(t, 0, len(out), "the tag is back at its starving cap, so nothing more dispatches")
+
+	// The accounting is still sound: real progress still releases slots.
+	fileB.file.schedFirstByte()
+	require.Eventually(t, func() bool { return len(out) == 1 }, time.Second, 10*time.Millisecond)
+	fileC.file.schedDone()
+}
+
+// TestTagSchedulerDoneFiresOncePerFile pins that the per-file completion
+// hook is fired exactly once per dispatched file rather than once for the
+// worker's whole lifetime: a worker that processes several files in a row
+// must return every one of their slots.
+func TestTagSchedulerDoneFiresOncePerFile(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	sched := NewTagScheduler(4, SchedulerConfig{
+		PerTagStarvingPercent: 25, // starving cap = 1, so files go through one at a time
+		PerTagActivePercent:   90,
+		PendingBufferSize:     100,
+		PerTagPendingSize:     100,
+		EMAWindow:             5 * time.Second,
+	})
+	out := make(chan *clientTransferFile)
+	startScheduler(t, ctx, sched, out)
+
+	const N = 8
+	for i := 0; i < N; i++ {
+		require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	}
+	// Run them the way runTransferWorkerFile does: take one, finish it, take
+	// the next. If a slot were ever not returned, the starving cap would
+	// block and this drain would time out.
+	drainOut(ctx, t, out, N, func(_ string, f *clientTransferFile) {
+		f.file.schedDone()
+	})
+
+	var snap SchedulerSnapshot
+	require.Eventually(t, func() bool {
+		snap = sched.Snapshot(ctx)
+		return snap.Global.TotalAdmits == N && snap.Global.TotalPending == 0
+	}, time.Second, 10*time.Millisecond, "expected all %d admitted and drained, got %+v", N, snap.Global)
+	// The tag may already have been evicted; if it is still present every
+	// counter must be back at zero.
+	if st, ok := snap.Tags["originA"]; ok {
+		assert.Zero(t, st.Active, "every dispatched file returned its slot")
+		assert.Zero(t, st.Starving)
+		assert.Zero(t, st.Pending)
+	}
+}
+
+// TestTagSchedulerEMAWeighting pins that the fairness draw actually consults
+// the EMA: a tag that has been holding workers recently carries a higher EMA
+// and therefore a smaller weight, so it is picked less often than a tag that
+// has been quiet. Without this the "fair" scheduler would be plain random
+// selection among eligible tags.
+func TestTagSchedulerEMAWeighting(t *testing.T) {
+	sched := NewTagScheduler(100, SchedulerConfig{
+		PerTagStarvingPercent: 90,
+		PerTagActivePercent:   90,
+		EMAWindow:             time.Second,
+	})
+	// Drive the EMA directly rather than through dispatch so the test states
+	// the weighting rule itself: "busy" has been holding workers, "quiet"
+	// has not.
+	busy := sched.tagFor("busy")
+	quiet := sched.tagFor("quiet")
+	busy.active = 50
+	quiet.active = 0
+	sched.lastTick = time.Now().Add(-time.Second)
+	sched.tickEMA()
+
+	require.Greater(t, busy.ema, quiet.ema, "the busy tag should carry the larger EMA")
+	require.Less(t, busy.weight, quiet.weight, "a larger EMA must mean a smaller draw weight")
+	assert.InDelta(t, 1.0/(1.0+busy.ema), busy.weight, 1e-9, "weight is 1/(1+EMA)")
+	assert.InDelta(t, 1.0, quiet.weight, 1e-9, "an idle tag draws at full weight")
+
+	// With both tags backlogged and eligible, the quiet tag must win the
+	// draw markedly more often. Seed the generator so the assertion is
+	// reproducible rather than flaky.
+	sched.rng = rand.New(rand.NewPCG(1, 2))
+	busy.active, quiet.active = 0, 0 // eligible for dispatch, EMA retained
+	for i := 0; i < 4; i++ {
+		busy.fifo.PushBack(makeFile("busy"))
+		quiet.fifo.PushBack(makeFile("quiet"))
+	}
+	picks := map[string]int{}
+	for i := 0; i < 1000; i++ {
+		st, ok := sched.pickForDispatch()
+		require.True(t, ok)
+		switch st {
+		case busy:
+			picks["busy"]++
+		case quiet:
+			picks["quiet"]++
+		default:
+			t.Fatal("pickForDispatch returned an unknown tag")
+		}
+	}
+	assert.Greater(t, picks["quiet"], picks["busy"],
+		"the tag with the lower EMA should be drawn more often (quiet=%d busy=%d)",
+		picks["quiet"], picks["busy"])
+
+	// A zero EMAWindow disables the weighting entirely: every tag keeps the
+	// full weight it was created with.
+	flat := NewTagScheduler(10, SchedulerConfig{EMAWindow: 0})
+	a, b := flat.tagFor("a"), flat.tagFor("b")
+	a.active = 9
+	flat.lastTick = time.Now().Add(-time.Second)
+	flat.tickEMA()
+	assert.Equal(t, a.weight, b.weight, "EMA updates are disabled, so weights stay equal")
+}
+
+// TestTagSchedulerGlobalBufferOvershootIsBounded pins the size of the
+// reservation that lets a tag with an empty FIFO enqueue past the global
+// pending limit. The reservation exists so a handful of saturated origins
+// cannot pin the global buffer and lock every healthy origin out of
+// admission, but it does mean the real ceiling is the configured buffer plus
+// one entry per distinct tag rather than the configured buffer alone.
+func TestTagSchedulerGlobalBufferOvershootIsBounded(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	sched := NewTagScheduler(10, SchedulerConfig{
+		PerTagStarvingPercent: 10, // starving cap = 1
+		PerTagActivePercent:   90,
+		PendingBufferSize:     2,
+		PerTagPendingSize:     100,
+		EMAWindow:             5 * time.Second,
+	})
+	// Nothing reads `out`, so everything admitted stays queued.
+	out := make(chan *clientTransferFile)
+	startScheduler(t, ctx, sched, out)
+
+	const tags = 10
+	admitted := 0
+	for i := 0; i < tags; i++ {
+		tag := fmt.Sprintf("origin-%02d", i)
+		// Each tag's first submission is always admitted (the reservation);
+		// the second competes for the global buffer.
+		for j := 0; j < 2; j++ {
+			if err := sched.Submit(ctx, tag, makeFile(tag)); err == nil {
+				admitted++
+			}
+		}
+	}
+
+	var snap SchedulerSnapshot
+	require.Eventually(t, func() bool {
+		snap = sched.Snapshot(ctx)
+		return snap.Global.TotalAdmits == uint64(admitted)
+	}, time.Second, 10*time.Millisecond)
+
+	// Every tag got at least its one reserved entry, so no origin was locked
+	// out. (The first tag submitted gets both of its entries in, because the
+	// global buffer still had room when they arrived.)
+	assert.GreaterOrEqual(t, admitted, tags,
+		"each distinct tag must be able to enqueue one entry even with the global buffer full")
+	for i := 0; i < tags; i++ {
+		tag := fmt.Sprintf("origin-%02d", i)
+		assert.NotZero(t, snap.Tags[tag].Pending+snap.Tags[tag].Active,
+			"tag %s was locked out of admission entirely", tag)
+	}
+	// ...and the overshoot is exactly that: at most one entry per tag on top
+	// of the configured buffer, never unbounded.
+	assert.LessOrEqual(t, snap.Global.TotalPending, sched.cfg.PendingBufferSize+tags,
+		"overshoot must stay bounded by one entry per distinct tag")
+}
+
+// TestTagSchedulerSnapshotAfterStop pins that a snapshot requested after the
+// scheduler has stopped returns the zero value promptly instead of blocking
+// on a goroutine that will never answer. The cache's metrics publisher races
+// shutdown on every restart, and a blocked Snapshot there would wedge the
+// errgroup.
+func TestTagSchedulerSnapshotAfterStop(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sched := NewTagScheduler(4, SchedulerConfig{
+		PerTagStarvingPercent: 50,
+		PerTagActivePercent:   90,
+		PendingBufferSize:     10,
+		PerTagPendingSize:     10,
+		EMAWindow:             time.Second,
+	})
+	out := make(chan *clientTransferFile, 4)
+	egrp, _ := errgroup.WithContext(ctx)
+	sched.Start(ctx, egrp, out)
+	require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	sched.Stop()
+	require.NoError(t, egrp.Wait())
+
+	done := make(chan SchedulerSnapshot, 1)
+	go func() { done <- sched.Snapshot(ctx) }()
+	select {
+	case snap := <-done:
+		assert.Zero(t, snap.Global.WorkerCount, "a stopped scheduler reports the zero snapshot")
+		assert.Nil(t, snap.Tags)
+	case <-ctx.Done():
+		t.Fatal("Snapshot blocked after the scheduler stopped")
+	}
+}
+
+// TestTagSchedulerRunExitOnContextReleasesWaiters pins that the scheduler
+// releases everything waiting on it when its context is cancelled, not only
+// when Stop() is what ended it. Submit, Snapshot, and the event hooks all
+// use the same internal stop signal as their escape hatch, so a run loop
+// that exited without closing it would leave those callers stuck until some
+// later Stop() call happened to arrive.
+func TestTagSchedulerRunExitOnContextReleasesWaiters(t *testing.T) {
+	outer, outerCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer outerCancel()
+	schedCtx, schedCancel := context.WithCancel(outer)
+
+	sched := NewTagScheduler(4, SchedulerConfig{
+		PerTagStarvingPercent: 50,
+		PerTagActivePercent:   90,
+		PendingBufferSize:     10,
+		PerTagPendingSize:     10,
+		EMAWindow:             time.Second,
+	})
+	out := make(chan *clientTransferFile)
+	egrp, _ := errgroup.WithContext(outer)
+	sched.Start(schedCtx, egrp, out)
+
+	schedCancel()
+	require.NoError(t, egrp.Wait())
+
+	// Submitting against a context that is still live must still return
+	// promptly, shedding rather than hanging.
+	done := make(chan error, 1)
+	go func() { done <- sched.Submit(outer, "originA", makeFile("originA")) }()
+	select {
+	case err := <-done:
+		require.Error(t, err, "a submission to a dead scheduler must shed, not succeed")
+		assert.ErrorIs(t, err, ErrTooManyRequests)
+	case <-outer.Done():
+		t.Fatal("Submit blocked after the scheduler's context was cancelled")
+	}
+
+	// Snapshot likewise, and Stop() must remain safe to call afterwards.
+	snapDone := make(chan SchedulerSnapshot, 1)
+	go func() { snapDone <- sched.Snapshot(outer) }()
+	select {
+	case <-snapDone:
+	case <-outer.Done():
+		t.Fatal("Snapshot blocked after the scheduler's context was cancelled")
+	}
+	assert.NotPanics(t, sched.Stop)
+}
+
+// TestSchedulerRejectionIsRetryable pins that a shed performed by this
+// process's own scheduler is classified the same way as the identical shed
+// observed remotely as an HTTP 429: retryable, carrying the typed Pelican
+// error for its reason. The whole point of the shed is that the caller tries
+// again elsewhere or later, so a rejection that reads as fatal would defeat
+// it.
+func TestSchedulerRejectionIsRetryable(t *testing.T) {
+	for _, tc := range []struct {
+		reason   ShedReason
+		wantCode int
+	}{
+		{ShedOriginUnresponsive, 6008},
+		{ShedOriginSlow, 6009},
+		{ShedCacheOverloaded, 6010},
+	} {
+		t.Run(string(tc.reason), func(t *testing.T) {
+			rej := &SchedulerRejection{Reason: tc.reason, Tag: "originA"}
+			assert.True(t, IsRetryable(rej), "a shed must be retryable")
+			assert.ErrorIs(t, rej, ErrTooManyRequests, "existing sentinel checks must keep working")
+			var pe *error_codes.PelicanError
+			require.ErrorAs(t, rej, &pe)
+			assert.Equal(t, tc.wantCode, pe.Code())
+			assert.True(t, pe.IsRetryable())
+			assert.NotEmpty(t, rej.Error(), "a rejection built as a literal still renders a message")
+		})
+	}
+}
+
+// TestDeriveSchedulerTag pins the tag derivation, including the degenerate
+// inputs. Everything that cannot name an upstream host shares the empty tag,
+// and therefore shares one set of caps, so the fallback needs to be
+// deliberate rather than incidental.
+func TestDeriveSchedulerTag(t *testing.T) {
+	assert.Equal(t, "originA", deriveSchedulerTag(makeFile("originA")))
+
+	assert.Empty(t, deriveSchedulerTag(nil), "nil file")
+	assert.Empty(t, deriveSchedulerTag(&clientTransferFile{}), "nil inner file")
+	assert.Empty(t, deriveSchedulerTag(&clientTransferFile{file: &transferFile{}}), "no attempts")
+
+	noUrl := &clientTransferFile{file: &transferFile{
+		attempts: []transferAttemptDetails{{Url: nil}},
+	}}
+	assert.Empty(t, deriveSchedulerTag(noUrl), "attempt with no URL")
+
+	// The tag is the host alone: the same origin serving different paths is
+	// one tag, and the same host on a different scheme is still that host.
+	withPort := &clientTransferFile{file: &transferFile{
+		attempts: []transferAttemptDetails{
+			{Url: &url.URL{Scheme: "https", Host: "origin.example.com:8443", Path: "/deep/path"}},
+		},
+	}}
+	assert.Equal(t, "origin.example.com:8443", deriveSchedulerTag(withPort))
 }

--- a/client/tag_scheduler_test.go
+++ b/client/tag_scheduler_test.go
@@ -1,0 +1,336 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package client
+
+import (
+	"context"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeFile builds a minimal *clientTransferFile whose first attempt
+// targets `host`. Suitable for feeding TagScheduler in tests.
+func makeFile(host string) *clientTransferFile {
+	return &clientTransferFile{
+		uuid:  uuid.New(),
+		jobId: uuid.New(),
+		file: &transferFile{
+			attempts: []transferAttemptDetails{
+				{Url: &url.URL{Scheme: "https", Host: host, Path: "/x"}},
+			},
+			remoteURL: &url.URL{Scheme: "pelican", Host: "ns", Path: "/x"},
+		},
+	}
+}
+
+// drainOut consumes files from `out` and, for each one, invokes any
+// scheduler hooks the caller asked for. It returns a slice of
+// "host of dispatched file" strings, in dispatch order.
+//
+// The caller controls how each dispatched file "completes" via the
+// per-file callback: it receives the host string and returns true
+// once the test wants that transfer to fire schedDone. The callback
+// may also fire schedFirstByte at its own discretion.
+func drainOut(ctx context.Context, t *testing.T, out <-chan *clientTransferFile, n int, complete func(host string, f *clientTransferFile)) []string {
+	t.Helper()
+	got := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		select {
+		case f := <-out:
+			host := f.file.attempts[0].Url.Host
+			got = append(got, host)
+			if complete != nil {
+				complete(host, f)
+			}
+		case <-ctx.Done():
+			t.Fatalf("timed out after %d dispatches (wanted %d)", len(got), n)
+		}
+	}
+	return got
+}
+
+// TestTagSchedulerAcceptsAndDispatches: with generous caps, all
+// admitted transfers should be dispatched in-order to the worker
+// channel.
+func TestTagSchedulerAcceptsAndDispatches(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	sched := NewTagScheduler(100, SchedulerConfig{
+		PerTagStarvingPercent: 90,
+		PerTagActivePercent:   90,
+		PendingBufferSize:     100,
+		PerTagPendingSize:     50,
+		EMAWindow:             5 * time.Second,
+	})
+	out := make(chan *clientTransferFile)
+	sched.Start(ctx, out)
+	t.Cleanup(sched.Stop)
+
+	const N = 10
+	for i := 0; i < N; i++ {
+		require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	}
+	got := drainOut(ctx, t, out, N, func(_ string, f *clientTransferFile) {
+		// Simulate the transfer completing immediately.
+		f.file.schedDone()
+	})
+	assert.Len(t, got, N)
+	for _, h := range got {
+		assert.Equal(t, "originA", h)
+	}
+}
+
+// TestTagSchedulerGlobalBufferFullRejects: when total pending reaches
+// PendingBufferSize, further submissions are rejected with 429.
+func TestTagSchedulerGlobalBufferFullRejects(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sched := NewTagScheduler(4, SchedulerConfig{
+		PerTagStarvingPercent: 50, // caps at 2, so files accumulate in the queue
+		PerTagActivePercent:   50,
+		PendingBufferSize:     3,
+		PerTagPendingSize:     100, // large; hit the global cap first
+		EMAWindow:             5 * time.Second,
+	})
+	// Don't Start yet — we want submissions to enqueue without a worker
+	// draining them.
+	sched.out = make(chan *clientTransferFile)
+	sched.stopped = make(chan struct{})
+	go sched.run(ctx)
+	t.Cleanup(sched.Stop)
+
+	// Fill the buffer with 3 admits; the scheduler will hold them
+	// (starving cap = 2, so at most 2 dispatch attempts fire before a
+	// worker is consumed — but we have no workers, so they sit).
+	for i := 0; i < 3; i++ {
+		require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	}
+	// The 4th should be rejected.
+	err := sched.Submit(ctx, "originA", makeFile("originA"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTooManyRequests)
+}
+
+// TestTagSchedulerPerTagPendingFullRejects: when a single tag's FIFO
+// hits PerTagPendingSize, further submissions FOR THAT TAG are 429'd
+// even if the global buffer still has room.
+func TestTagSchedulerPerTagPendingFullRejects(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sched := NewTagScheduler(4, SchedulerConfig{
+		PerTagStarvingPercent: 25, // 1 slot; ensures nothing drains
+		PerTagActivePercent:   25,
+		PendingBufferSize:     100,
+		PerTagPendingSize:     2,
+		EMAWindow:             5 * time.Second,
+	})
+	sched.out = make(chan *clientTransferFile)
+	sched.stopped = make(chan struct{})
+	go sched.run(ctx)
+	t.Cleanup(sched.Stop)
+
+	require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	// Third for originA should 429.
+	err := sched.Submit(ctx, "originA", makeFile("originA"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTooManyRequests)
+	// A different tag with an empty queue should still be admitted.
+	require.NoError(t, sched.Submit(ctx, "originB", makeFile("originB")))
+}
+
+// TestTagSchedulerStarvingCap: the scheduler will not dispatch more
+// than PerTagStarvingPercent% of the pool for a tag whose transfers
+// haven't produced a first byte.
+func TestTagSchedulerStarvingCap(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sched := NewTagScheduler(10, SchedulerConfig{
+		PerTagStarvingPercent: 30, // cap = ceil(10*0.30) = 3
+		PerTagActivePercent:   90,
+		PendingBufferSize:     100,
+		PerTagPendingSize:     100,
+		EMAWindow:             5 * time.Second,
+	})
+	out := make(chan *clientTransferFile, 100)
+	sched.Start(ctx, out)
+	t.Cleanup(sched.Stop)
+
+	// Admit 10 transfers for one tag.  Do NOT fire first-byte or done.
+	for i := 0; i < 10; i++ {
+		require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	}
+	// Give the scheduler a moment to attempt to dispatch.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) && len(out) < 3 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	// Only 3 should be dispatched (starving cap); the other 7 sit
+	// in the FIFO.
+	assert.Equal(t, 3, len(out), "starving cap should hold dispatch at ceil(30%%)")
+	// Wait an extra beat and confirm we still don't overshoot.
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, 3, len(out), "no further dispatch until first byte or done")
+}
+
+// TestTagSchedulerFirstByteReleasesStarvingSlot: once a dispatched
+// transfer fires schedFirstByte, the starving count drops and the
+// scheduler can dispatch another transfer for that tag.
+func TestTagSchedulerFirstByteReleasesStarvingSlot(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sched := NewTagScheduler(10, SchedulerConfig{
+		PerTagStarvingPercent: 30,
+		PerTagActivePercent:   90,
+		PendingBufferSize:     100,
+		PerTagPendingSize:     100,
+		EMAWindow:             5 * time.Second,
+	})
+	out := make(chan *clientTransferFile, 100)
+	sched.Start(ctx, out)
+	t.Cleanup(sched.Stop)
+
+	for i := 0; i < 10; i++ {
+		require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	}
+	// Wait for 3 dispatches to land.
+	require.Eventually(t, func() bool { return len(out) == 3 }, time.Second, 10*time.Millisecond)
+	// Signal first-byte on all three; scheduler should then release
+	// them from the starving bucket and dispatch 3 more.
+	for i := 0; i < 3; i++ {
+		(<-out).file.schedFirstByte()
+	}
+	require.Eventually(t, func() bool { return len(out) == 3 }, time.Second, 10*time.Millisecond)
+}
+
+// TestTagSchedulerActiveCap: even after first-byte, no more than
+// PerTagActivePercent% of the pool may hold a single tag's transfers.
+func TestTagSchedulerActiveCap(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sched := NewTagScheduler(10, SchedulerConfig{
+		PerTagStarvingPercent: 90, // cap at 9
+		PerTagActivePercent:   40, // active cap at ceil(10*0.40) = 4
+		PendingBufferSize:     100,
+		PerTagPendingSize:     100,
+		EMAWindow:             5 * time.Second,
+	})
+	out := make(chan *clientTransferFile, 100)
+	sched.Start(ctx, out)
+	t.Cleanup(sched.Stop)
+
+	for i := 0; i < 10; i++ {
+		require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	}
+	// Wait for 4 to dispatch and fire first-byte on each so we move
+	// out of the starving bucket, but do NOT fire schedDone.
+	require.Eventually(t, func() bool { return len(out) == 4 }, time.Second, 10*time.Millisecond)
+	firstFour := make([]*clientTransferFile, 4)
+	for i := 0; i < 4; i++ {
+		firstFour[i] = <-out
+		firstFour[i].file.schedFirstByte()
+	}
+	// Active cap should hold at 4; nothing more dispatches until a
+	// schedDone fires.
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, 0, len(out), "active cap should prevent further dispatch until a done")
+
+	firstFour[0].file.schedDone()
+	require.Eventually(t, func() bool { return len(out) == 1 }, time.Second, 10*time.Millisecond)
+}
+
+// TestTagSchedulerFairnessAcrossTags: with two tags each backlogged
+// far past the starving cap, both should progress in an interleaved
+// fashion (no tag monopolises the pool).
+func TestTagSchedulerFairnessAcrossTags(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sched := NewTagScheduler(10, SchedulerConfig{
+		PerTagStarvingPercent: 25, // cap = 3 per tag
+		PerTagActivePercent:   90,
+		PendingBufferSize:     100,
+		PerTagPendingSize:     100,
+		EMAWindow:             5 * time.Second,
+	})
+	out := make(chan *clientTransferFile, 100)
+	sched.Start(ctx, out)
+	t.Cleanup(sched.Stop)
+
+	for i := 0; i < 10; i++ {
+		require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	}
+	for i := 0; i < 10; i++ {
+		require.NoError(t, sched.Submit(ctx, "originB", makeFile("originB")))
+	}
+	// Wait for 6 total dispatches (3 per tag under starving caps).
+	require.Eventually(t, func() bool { return len(out) == 6 }, time.Second, 10*time.Millisecond)
+
+	got := make(map[string]int)
+	for len(out) > 0 {
+		f := <-out
+		got[f.file.attempts[0].Url.Host]++
+	}
+	assert.Equal(t, 3, got["originA"], "each tag caps at 3 while starving")
+	assert.Equal(t, 3, got["originB"], "each tag caps at 3 while starving")
+}
+
+// TestTagSchedulerConcurrentSubmit: many submissions from parallel
+// goroutines should each get a deterministic accept-or-429 answer
+// without deadlock.
+func TestTagSchedulerConcurrentSubmit(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	sched := NewTagScheduler(20, SchedulerConfig{
+		PerTagStarvingPercent: 100,
+		PerTagActivePercent:   100,
+		PendingBufferSize:     50,
+		PerTagPendingSize:     50,
+		EMAWindow:             time.Second,
+	})
+	out := make(chan *clientTransferFile, 500)
+	sched.Start(ctx, out)
+	t.Cleanup(sched.Stop)
+
+	var wg sync.WaitGroup
+	var accepted, rejected int64
+	var mu sync.Mutex
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := sched.Submit(ctx, "originA", makeFile("originA"))
+			mu.Lock()
+			defer mu.Unlock()
+			if err == nil {
+				accepted++
+			} else if errors.Is(err, ErrTooManyRequests) {
+				rejected++
+			}
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int64(200), accepted+rejected, "every submission should resolve")
+}

--- a/client/tag_scheduler_test.go
+++ b/client/tag_scheduler_test.go
@@ -297,6 +297,79 @@ func TestTagSchedulerFairnessAcrossTags(t *testing.T) {
 	assert.Equal(t, 3, got["originB"], "each tag caps at 3 while starving")
 }
 
+// TestTagSchedulerSnapshot: Snapshot() returns a coherent view whose
+// invariants match what we drove in — admits + rejects add up to the
+// submit attempts, per-tag pending/active/starving are non-negative,
+// and rejects show up in the global reject reason breakdown.
+//
+// Exact per-step counts race with the scheduler goroutine's dispatch
+// loop, so we assert on the sum rather than the split.
+func TestTagSchedulerSnapshot(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	// Small pool + tight per-tag caps so we're guaranteed to see
+	// per-tag pending-queue rejections after enough submits.
+	sched := NewTagScheduler(4, SchedulerConfig{
+		PerTagStarvingPercent: 25, // starving cap = 1
+		PerTagActivePercent:   50, // active cap = 2
+		PendingBufferSize:     100,
+		PerTagPendingSize:     3,
+		EMAWindow:             5 * time.Second,
+	})
+	// No consumer on `out`; buffered so dispatch doesn't block.
+	out := make(chan *clientTransferFile, 100)
+	sched.Start(ctx, out)
+	t.Cleanup(sched.Stop)
+
+	// Submit enough for originA that we're guaranteed to see rejects
+	// once its FIFO fills (starving cap = 1, active cap = 2 ⇒ at
+	// most 2 in-flight; with per-tag FIFO = 3 the extras eventually
+	// 429).
+	const nSubmits = 20
+	accepted, rejected := 0, 0
+	for i := 0; i < nSubmits; i++ {
+		if err := sched.Submit(ctx, "originA", makeFile("originA")); err == nil {
+			accepted++
+		} else {
+			require.ErrorIs(t, err, ErrTooManyRequests)
+			rejected++
+		}
+	}
+	require.Greater(t, rejected, 0, "at least one 429 expected once the per-tag FIFO fills")
+
+	snap := sched.Snapshot(ctx)
+	require.NotNil(t, snap.Tags)
+
+	// Global invariants.
+	assert.Equal(t, 4, snap.Global.WorkerCount)
+	assert.Equal(t, 1, snap.Global.StarvingCap, "starving cap = ceil(25%%×4)")
+	assert.Equal(t, 2, snap.Global.ActiveCap, "active cap = ceil(50%%×4)")
+	assert.Equal(t, uint64(accepted), snap.Global.TotalAdmits,
+		"scheduler-tracked admits should match the Submit-side accepted count")
+	assert.Equal(t, uint64(rejected), snap.Global.TotalRejects,
+		"scheduler-tracked rejects should match the Submit-side rejected count")
+	assert.Equal(t, snap.Global.TotalRejects,
+		snap.Global.TotalRejectsGlobal+snap.Global.TotalRejectsPerTag,
+		"rejects split into global + per_tag adds up to the total")
+
+	// Per-tag: only originA touched.
+	a, ok := snap.Tags["originA"]
+	require.True(t, ok)
+	assert.Equal(t, uint64(accepted), a.Admits)
+	assert.Equal(t, uint64(rejected), a.Rejects)
+	assert.GreaterOrEqual(t, a.Pending, 0)
+	assert.GreaterOrEqual(t, a.Active, 0)
+	assert.GreaterOrEqual(t, a.Starving, 0)
+	assert.LessOrEqual(t, a.Starving, a.Active,
+		"starving is a subset of active — never larger")
+	assert.LessOrEqual(t, a.Active, snap.Global.ActiveCap,
+		"active respects the per-tag active cap")
+
+	// A never-mentioned tag should be absent from the snapshot.
+	_, present := snap.Tags["originB"]
+	assert.False(t, present, "tags with zero activity should not appear in the snapshot")
+}
+
 // TestTagSchedulerConcurrentSubmit: many submissions from parallel
 // goroutines should each get a deterministic accept-or-429 answer
 // without deadlock.

--- a/client/tag_scheduler_test.go
+++ b/client/tag_scheduler_test.go
@@ -28,11 +28,12 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/pelicanplatform/pelican/error_codes"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/error_codes"
 )
 
 // makeFile builds a minimal *clientTransferFile whose first attempt

--- a/client/tag_scheduler_test.go
+++ b/client/tag_scheduler_test.go
@@ -811,7 +811,7 @@ func TestTagSchedulerCapRounding(t *testing.T) {
 // that late signal would decrement the tag's starving count a second time
 // and hand some other in-flight transfer's slot away.
 func TestTagSchedulerLateFirstByteDoesNotDoubleRelease(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	sched := NewTagScheduler(10, SchedulerConfig{
 		PerTagStarvingPercent: 20, // starving cap = 2
@@ -823,44 +823,59 @@ func TestTagSchedulerLateFirstByteDoesNotDoubleRelease(t *testing.T) {
 	out := make(chan *clientTransferFile, 100)
 	startScheduler(t, ctx, sched, out)
 
-	for i := 0; i < 6; i++ {
+	// Exactly three, so that once all three are dispatched the tag's queue is
+	// empty. That matters: with nothing left to dispatch, a wrongly released
+	// slot cannot be immediately refilled, so it stays visible in the counters
+	// instead of being masked by the replacement transfer.
+	for i := 0; i < 3; i++ {
 		require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
 	}
-	require.Eventually(t, func() bool { return len(out) == 2 }, time.Second, 10*time.Millisecond,
+	require.Eventually(t, func() bool { return len(out) == 2 }, 5*time.Second, time.Millisecond,
 		"starving cap should hold dispatch at 2")
 	fileA := <-out
 	fileB := <-out
 
 	// A completes without ever producing a byte: it gives back one starving
-	// slot, which lets exactly one more transfer dispatch.
+	// slot, which lets the last queued transfer dispatch.
 	fileA.file.schedDone()
-	require.Eventually(t, func() bool { return len(out) == 1 }, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return len(out) == 1 }, 5*time.Second, time.Millisecond)
 	fileC := <-out
 
-	// Now A's transport reports a first byte, too late to mean anything.
-	// Nothing may be released on the strength of it.
+	// Now A's transport reports a first byte, too late to mean anything. If
+	// that were honored it would release a second slot for a transfer that has
+	// already finished.
 	fileA.file.schedFirstByte()
 
-	var snap SchedulerSnapshot
+	// B completing is the discriminator. It is a real event, so it is queued
+	// behind anything A's late call may have emitted and is processed after it.
+	//
+	// Both of B's counts come off together, so the tag lands on one active and
+	// one starving (C). Had A's late call also been honored, the starving count
+	// would already have been decremented once too often, and the tag would
+	// land on one active and *zero* starving -- a state this wait never
+	// accepts, and one the correct sequence never passes through.
+	fileB.file.schedDone()
 	require.Eventually(t, func() bool {
-		snap = sched.Snapshot(ctx)
-		return snap.Tags["originA"].Active == 2
-	}, time.Second, 10*time.Millisecond, "expected B and C in flight, got %+v", snap.Tags["originA"])
-	assert.Equal(t, 2, snap.Tags["originA"].Starving,
-		"B and C are still starving; A's late first byte must not release a slot")
-	assert.Equal(t, 3, snap.Tags["originA"].Pending)
-	assert.Equal(t, 0, len(out), "the tag is back at its starving cap, so nothing more dispatches")
+		st := sched.Snapshot(ctx).Tags["originA"]
+		return st.Active == 1 && st.Starving == 1
+	}, 5*time.Second, time.Millisecond,
+		"expected one in flight and still starving; a late first byte must not release a slot")
 
-	// The accounting is still sound: real progress still releases slots.
-	fileB.file.schedFirstByte()
-	require.Eventually(t, func() bool { return len(out) == 1 }, time.Second, 10*time.Millisecond)
+	st := sched.Snapshot(ctx).Tags["originA"]
+	assert.Zero(t, st.Pending, "all three were dispatched, so nothing is queued")
+	assert.Equal(t, 0, len(out), "with an empty queue there is nothing left to dispatch")
+
 	fileC.file.schedDone()
 }
 
-// TestTagSchedulerDoneFiresOncePerFile pins that the per-file completion
-// hook is fired exactly once per dispatched file rather than once for the
-// worker's whole lifetime: a worker that processes several files in a row
-// must return every one of their slots.
+// TestTagSchedulerDoneFiresOncePerFile pins the scheduler's side of the
+// completion contract: one schedDone returns exactly one slot, so a tag whose
+// files are run one after another keeps making progress rather than stalling
+// at its cap.
+//
+// This drives the hook directly. That a worker fires it once per file rather
+// than once for its whole lifetime is runTransferWorkerFile's side of the
+// contract and is not exercised here.
 func TestTagSchedulerDoneFiresOncePerFile(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -878,9 +893,8 @@ func TestTagSchedulerDoneFiresOncePerFile(t *testing.T) {
 	for i := 0; i < N; i++ {
 		require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
 	}
-	// Run them the way runTransferWorkerFile does: take one, finish it, take
-	// the next. If a slot were ever not returned, the starving cap would
-	// block and this drain would time out.
+	// Take one, finish it, take the next. If a slot were ever not returned the
+	// starving cap would block and this drain would time out.
 	drainOut(ctx, t, out, N, func(_ string, f *clientTransferFile) {
 		f.file.schedDone()
 	})
@@ -922,12 +936,19 @@ func TestTagSchedulerEMAWeighting(t *testing.T) {
 
 	require.Greater(t, busy.ema, quiet.ema, "the busy tag should carry the larger EMA")
 	require.Less(t, busy.weight, quiet.weight, "a larger EMA must mean a smaller draw weight")
+	// A tag holding half the pool for a full window should end up with an EMA
+	// on that order, not a token amount -- the weighting is only meaningful if
+	// the EMA actually tracks occupancy.
+	assert.Greater(t, busy.ema, 25.0, "EMA should approach the ~50 workers held")
 	assert.InDelta(t, 1.0/(1.0+busy.ema), busy.weight, 1e-9, "weight is 1/(1+EMA)")
+	assert.Zero(t, quiet.ema, "a tag that held nothing decays to zero")
 	assert.InDelta(t, 1.0, quiet.weight, 1e-9, "an idle tag draws at full weight")
 
-	// With both tags backlogged and eligible, the quiet tag must win the
-	// draw markedly more often. Seed the generator so the assertion is
-	// reproducible rather than flaky.
+	// With both tags backlogged and eligible, the quiet tag must win the draw
+	// markedly more often. The seed does not make the sequence reproducible --
+	// map iteration order still varies -- so this rests on the margin instead:
+	// the weights differ by ~30x, which puts the observed split (roughly 975 to
+	// 25) tens of standard deviations away from the assertion boundary.
 	sched.rng = rand.New(rand.NewPCG(1, 2))
 	busy.active, quiet.active = 0, 0 // eligible for dispatch, EMA retained
 	for i := 0; i < 4; i++ {
@@ -951,13 +972,15 @@ func TestTagSchedulerEMAWeighting(t *testing.T) {
 		"the tag with the lower EMA should be drawn more often (quiet=%d busy=%d)",
 		picks["quiet"], picks["busy"])
 
-	// A zero EMAWindow disables the weighting entirely: every tag keeps the
-	// full weight it was created with.
+	// A zero EMAWindow disables the weighting entirely: a tag holding the pool
+	// keeps the full weight it was created with, so the draw stays uniform.
 	flat := NewTagScheduler(10, SchedulerConfig{EMAWindow: 0})
 	a, b := flat.tagFor("a"), flat.tagFor("b")
 	a.active = 9
 	flat.lastTick = time.Now().Add(-time.Second)
 	flat.tickEMA()
+	assert.Zero(t, a.ema, "a zero window must leave the EMA untouched")
+	assert.Equal(t, 1.0, a.weight, "and therefore the weight at its initial value")
 	assert.Equal(t, a.weight, b.weight, "EMA updates are disabled, so weights stay equal")
 }
 
@@ -1127,8 +1150,9 @@ func TestSchedulerRejectionIsRetryable(t *testing.T) {
 
 // TestDeriveSchedulerTag pins the tag derivation, including the degenerate
 // inputs. Everything that cannot name an upstream host shares the empty tag,
-// and therefore shares one set of caps, so the fallback needs to be
-// deliberate rather than incidental.
+// and therefore shares one set of caps -- so what each degenerate input maps to
+// is worth stating explicitly, even though every one of them is unreachable
+// from the current call sites.
 func TestDeriveSchedulerTag(t *testing.T) {
 	assert.Equal(t, "originA", deriveSchedulerTag(makeFile("originA")))
 

--- a/client/tag_scheduler_test.go
+++ b/client/tag_scheduler_test.go
@@ -20,6 +20,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"sync"
 	"testing"
@@ -29,6 +30,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 // makeFile builds a minimal *clientTransferFile whose first attempt
@@ -44,6 +46,20 @@ func makeFile(host string) *clientTransferFile {
 			remoteURL: &url.URL{Scheme: "pelican", Host: "ns", Path: "/x"},
 		},
 	}
+}
+
+// startScheduler starts `sched` under a throwaway errgroup, dispatching to
+// `out`, and registers cleanup that stops it and waits for the goroutine.
+// Tests that want submissions to pile up in the FIFOs simply pass an
+// unbuffered `out` that nothing reads.
+func startScheduler(t *testing.T, ctx context.Context, sched *TagScheduler, out chan *clientTransferFile) {
+	t.Helper()
+	egrp, _ := errgroup.WithContext(ctx)
+	sched.Start(ctx, egrp, out)
+	t.Cleanup(func() {
+		sched.Stop()
+		require.NoError(t, egrp.Wait())
+	})
 }
 
 // drainOut consumes files from `out` and, for each one, invokes any
@@ -73,8 +89,9 @@ func drainOut(ctx context.Context, t *testing.T, out <-chan *clientTransferFile,
 }
 
 // TestTagSchedulerAcceptsAndDispatches: with generous caps, all
-// admitted transfers should be dispatched in-order to the worker
-// channel.
+// admitted transfers should be dispatched to the worker channel, and a
+// single tag's transfers must come out in submission order (the per-tag
+// queue is a FIFO; only the choice *between* tags is randomized).
 func TestTagSchedulerAcceptsAndDispatches(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -86,14 +103,21 @@ func TestTagSchedulerAcceptsAndDispatches(t *testing.T) {
 		EMAWindow:             5 * time.Second,
 	})
 	out := make(chan *clientTransferFile)
-	sched.Start(ctx, out)
-	t.Cleanup(sched.Stop)
+	startScheduler(t, ctx, sched, out)
 
+	// Each file carries a distinct remote path so the dispatch order can be
+	// compared against the submission order.
 	const N = 10
+	submitted := make([]string, 0, N)
 	for i := 0; i < N; i++ {
-		require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+		f := makeFile("originA")
+		f.file.remoteURL.Path = fmt.Sprintf("/obj-%d", i)
+		submitted = append(submitted, f.file.remoteURL.Path)
+		require.NoError(t, sched.Submit(ctx, "originA", f))
 	}
+	dispatched := make([]string, 0, N)
 	got := drainOut(ctx, t, out, N, func(_ string, f *clientTransferFile) {
+		dispatched = append(dispatched, f.file.remoteURL.Path)
 		// Simulate the transfer completing immediately.
 		f.file.schedDone()
 	})
@@ -101,6 +125,7 @@ func TestTagSchedulerAcceptsAndDispatches(t *testing.T) {
 	for _, h := range got {
 		assert.Equal(t, "originA", h)
 	}
+	assert.Equal(t, submitted, dispatched, "a single tag must be dispatched in FIFO order")
 }
 
 // TestTagSchedulerGlobalBufferFullRejects: when total pending reaches
@@ -115,12 +140,9 @@ func TestTagSchedulerGlobalBufferFullRejects(t *testing.T) {
 		PerTagPendingSize:     100, // large; hit the global cap first
 		EMAWindow:             5 * time.Second,
 	})
-	// Don't Start yet — we want submissions to enqueue without a worker
-	// draining them.
-	sched.out = make(chan *clientTransferFile)
-	sched.stopped = make(chan struct{})
-	go sched.run(ctx)
-	t.Cleanup(sched.Stop)
+	// Nothing reads `out`, so submissions enqueue without a worker draining
+	// them.
+	startScheduler(t, ctx, sched, make(chan *clientTransferFile))
 
 	// Fill the buffer with 3 admits; the scheduler will hold them
 	// (starving cap = 2, so at most 2 dispatch attempts fire before a
@@ -147,10 +169,7 @@ func TestTagSchedulerPerTagPendingFullRejects(t *testing.T) {
 		PerTagPendingSize:     2,
 		EMAWindow:             5 * time.Second,
 	})
-	sched.out = make(chan *clientTransferFile)
-	sched.stopped = make(chan struct{})
-	go sched.run(ctx)
-	t.Cleanup(sched.Stop)
+	startScheduler(t, ctx, sched, make(chan *clientTransferFile))
 
 	require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
 	require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
@@ -176,24 +195,18 @@ func TestTagSchedulerStarvingCap(t *testing.T) {
 		EMAWindow:             5 * time.Second,
 	})
 	out := make(chan *clientTransferFile, 100)
-	sched.Start(ctx, out)
-	t.Cleanup(sched.Stop)
+	startScheduler(t, ctx, sched, out)
 
 	// Admit 10 transfers for one tag.  Do NOT fire first-byte or done.
 	for i := 0; i < 10; i++ {
 		require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
 	}
-	// Give the scheduler a moment to attempt to dispatch.
-	deadline := time.Now().Add(500 * time.Millisecond)
-	for time.Now().Before(deadline) && len(out) < 3 {
-		time.Sleep(10 * time.Millisecond)
-	}
-	// Only 3 should be dispatched (starving cap); the other 7 sit
-	// in the FIFO.
-	assert.Equal(t, 3, len(out), "starving cap should hold dispatch at ceil(30%%)")
-	// Wait an extra beat and confirm we still don't overshoot.
-	time.Sleep(200 * time.Millisecond)
-	assert.Equal(t, 3, len(out), "no further dispatch until first byte or done")
+	// Only 3 should be dispatched (starving cap); the other 7 sit in the
+	// FIFO, and stay there — nothing releases a starving slot.
+	require.Eventually(t, func() bool { return len(out) == 3 }, time.Second, 10*time.Millisecond,
+		"starving cap should hold dispatch at ceil(30%)")
+	assert.Never(t, func() bool { return len(out) != 3 }, 300*time.Millisecond, 10*time.Millisecond,
+		"no further dispatch until first byte or done")
 }
 
 // TestTagSchedulerFirstByteReleasesStarvingSlot: once a dispatched
@@ -210,8 +223,7 @@ func TestTagSchedulerFirstByteReleasesStarvingSlot(t *testing.T) {
 		EMAWindow:             5 * time.Second,
 	})
 	out := make(chan *clientTransferFile, 100)
-	sched.Start(ctx, out)
-	t.Cleanup(sched.Stop)
+	startScheduler(t, ctx, sched, out)
 
 	for i := 0; i < 10; i++ {
 		require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
@@ -239,8 +251,7 @@ func TestTagSchedulerActiveCap(t *testing.T) {
 		EMAWindow:             5 * time.Second,
 	})
 	out := make(chan *clientTransferFile, 100)
-	sched.Start(ctx, out)
-	t.Cleanup(sched.Stop)
+	startScheduler(t, ctx, sched, out)
 
 	for i := 0; i < 10; i++ {
 		require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
@@ -255,8 +266,8 @@ func TestTagSchedulerActiveCap(t *testing.T) {
 	}
 	// Active cap should hold at 4; nothing more dispatches until a
 	// schedDone fires.
-	time.Sleep(200 * time.Millisecond)
-	assert.Equal(t, 0, len(out), "active cap should prevent further dispatch until a done")
+	assert.Never(t, func() bool { return len(out) > 0 }, 300*time.Millisecond, 10*time.Millisecond,
+		"active cap should prevent further dispatch until a done")
 
 	firstFour[0].file.schedDone()
 	require.Eventually(t, func() bool { return len(out) == 1 }, time.Second, 10*time.Millisecond)
@@ -276,8 +287,7 @@ func TestTagSchedulerFairnessAcrossTags(t *testing.T) {
 		EMAWindow:             5 * time.Second,
 	})
 	out := make(chan *clientTransferFile, 100)
-	sched.Start(ctx, out)
-	t.Cleanup(sched.Stop)
+	startScheduler(t, ctx, sched, out)
 
 	for i := 0; i < 10; i++ {
 		require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
@@ -318,8 +328,7 @@ func TestTagSchedulerSnapshot(t *testing.T) {
 	})
 	// No consumer on `out`; buffered so dispatch doesn't block.
 	out := make(chan *clientTransferFile, 100)
-	sched.Start(ctx, out)
-	t.Cleanup(sched.Stop)
+	startScheduler(t, ctx, sched, out)
 
 	// Submit enough for originA that we're guaranteed to see rejects
 	// once its FIFO fills (starving cap = 1, active cap = 2 ⇒ at
@@ -384,8 +393,7 @@ func TestTagSchedulerConcurrentSubmit(t *testing.T) {
 		EMAWindow:             time.Second,
 	})
 	out := make(chan *clientTransferFile, 500)
-	sched.Start(ctx, out)
-	t.Cleanup(sched.Stop)
+	startScheduler(t, ctx, sched, out)
 
 	var wg sync.WaitGroup
 	var accepted, rejected int64
@@ -421,10 +429,7 @@ func TestTagSchedulerRejectClassifiesCacheOverloaded(t *testing.T) {
 		EMAWindow:             5 * time.Second,
 	})
 	// No worker draining out, so submissions enqueue and fill the buffer.
-	sched.out = make(chan *clientTransferFile)
-	sched.stopped = make(chan struct{})
-	go sched.run(ctx)
-	t.Cleanup(sched.Stop)
+	startScheduler(t, ctx, sched, make(chan *clientTransferFile))
 
 	for i := 0; i < 3; i++ {
 		require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
@@ -451,8 +456,7 @@ func TestTagSchedulerRejectClassifiesOriginUnresponsive(t *testing.T) {
 		EMAWindow:             5 * time.Second,
 	})
 	out := make(chan *clientTransferFile, 100)
-	sched.Start(ctx, out)
-	t.Cleanup(sched.Stop)
+	startScheduler(t, ctx, sched, out)
 
 	// First submit dispatches and becomes starving (no first-byte fired).
 	require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
@@ -485,8 +489,7 @@ func TestTagSchedulerRejectClassifiesOriginSlow(t *testing.T) {
 		EMAWindow:             5 * time.Second,
 	})
 	out := make(chan *clientTransferFile, 100)
-	sched.Start(ctx, out)
-	t.Cleanup(sched.Stop)
+	startScheduler(t, ctx, sched, out)
 
 	// One dispatches (active == 1 == activeCap). starving (1) stays below the
 	// high starving cap, so the FIFO-full reject classifies as slow, not
@@ -517,8 +520,7 @@ func TestTagSchedulerStarvingReleasedOnEarlyFailure(t *testing.T) {
 		EMAWindow:             5 * time.Second,
 	})
 	out := make(chan *clientTransferFile)
-	sched.Start(ctx, out)
-	t.Cleanup(sched.Stop)
+	startScheduler(t, ctx, sched, out)
 
 	require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
 	require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
@@ -557,8 +559,7 @@ func TestTagSchedulerStopDrainsQueued(t *testing.T) {
 	var dropped []*clientTransferFile
 	sched.onDrop = func(f *clientTransferFile) { dropped = append(dropped, f) }
 	// No reader on out: everything admitted stays queued.
-	out := make(chan *clientTransferFile)
-	sched.Start(ctx, out)
+	startScheduler(t, ctx, sched, make(chan *clientTransferFile))
 
 	const N = 3
 	for i := 0; i < N; i++ {
@@ -576,8 +577,7 @@ func TestTagSchedulerSubmitAfterStop(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	sched := NewTagScheduler(4, SchedulerConfig{PendingBufferSize: 10})
-	out := make(chan *clientTransferFile)
-	sched.Start(ctx, out)
+	startScheduler(t, ctx, sched, make(chan *clientTransferFile))
 	sched.Stop()
 
 	err := sched.Submit(ctx, "originA", makeFile("originA"))
@@ -606,7 +606,7 @@ func TestTagSchedulerStopIsIdempotent(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	sched := NewTagScheduler(4, SchedulerConfig{})
-	sched.Start(ctx, make(chan *clientTransferFile))
+	startScheduler(t, ctx, sched, make(chan *clientTransferFile))
 	var wg sync.WaitGroup
 	for i := 0; i < 8; i++ {
 		wg.Add(1)
@@ -615,45 +615,63 @@ func TestTagSchedulerStopIsIdempotent(t *testing.T) {
 	wg.Wait()
 }
 
-// Fully-idle tags must be evicted after the grace period so the per-tag maps
-// (and the monitoring snapshot / Prometheus label set derived from them) do
+// Fully-idle tags must be evicted after the grace period so per-tag state
+// (and the monitoring snapshot / Prometheus label set derived from it) does
 // not grow forever with every origin the cache has ever contacted. Tags with
-// queued or in-flight work, a still-decaying EMA, or recent activity stay.
+// queued or in-flight work, a still-decaying EMA, or recent activity stay:
+// the periodic sweep is the only thing that removes a tag, so counters
+// hitting zero on their own must not.
 func TestTagSchedulerEvictsIdleTags(t *testing.T) {
 	sched := NewTagScheduler(4, SchedulerConfig{}) // EMAWindow 0 → grace floor (10s)
 	now := time.Now()
 	stale := now.Add(-time.Minute)
 
 	// Idle: counters only, no other state — must be evicted.
-	sched.admits["idle"] = 5
-	sched.rejects["idle"] = 2
-	sched.lastSeen["idle"] = stale
+	idle := sched.tagFor("idle")
+	idle.admits, idle.rejects, idle.lastSeen = 5, 2, stale
+	// Queued: a pending transfer pins the tag.
+	queued := sched.tagFor("queued")
+	queued.admits, queued.lastSeen = 1, stale
+	queued.fifo.PushBack(makeFile("queued"))
 	// In-flight: active transfer pins the tag.
-	sched.admits["busy"] = 1
-	sched.active["busy"] = 1
-	sched.lastSeen["busy"] = stale
-	// Decaying: EMA still present pins the tag.
-	sched.admits["decaying"] = 1
-	sched.ema["decaying"] = 0.5
-	sched.lastSeen["decaying"] = stale
+	busy := sched.tagFor("busy")
+	busy.admits, busy.active, busy.lastSeen = 1, 1, stale
+	// Starving: a dispatched transfer still awaiting a first byte pins it.
+	starved := sched.tagFor("starved")
+	starved.admits, starved.active, starved.starving, starved.lastSeen = 1, 1, 1, stale
+	// Decaying: a residual EMA pins the tag.
+	decaying := sched.tagFor("decaying")
+	decaying.admits, decaying.ema, decaying.lastSeen = 1, 0.5, stale
 	// Recent: activity within the grace period pins the tag.
-	sched.admits["recent"] = 1
-	sched.lastSeen["recent"] = now
+	recent := sched.tagFor("recent")
+	recent.admits, recent.lastSeen = 1, now
 
 	sched.evictIdleTags(now)
 
-	assert.NotContains(t, sched.admits, "idle")
-	assert.NotContains(t, sched.rejects, "idle")
-	assert.NotContains(t, sched.lastSeen, "idle")
-	assert.Contains(t, sched.admits, "busy")
-	assert.Contains(t, sched.admits, "decaying")
-	assert.Contains(t, sched.admits, "recent")
+	assert.NotContains(t, sched.tags, "idle")
+	assert.Contains(t, sched.tags, "queued")
+	assert.Contains(t, sched.tags, "busy")
+	assert.Contains(t, sched.tags, "starved")
+	assert.Contains(t, sched.tags, "decaying")
+	assert.Contains(t, sched.tags, "recent")
+
+	// A tag whose transfers have all finished is not evicted on the spot —
+	// only once it has been idle through the grace period.
+	settled := sched.tagFor("settled")
+	settled.admits, settled.lastSeen = 3, now
+	sched.evictIdleTags(now)
+	assert.Contains(t, sched.tags, "settled",
+		"a tag that just went idle keeps its counters until the grace period elapses")
+	settled.lastSeen = stale
+	sched.evictIdleTags(now)
+	assert.NotContains(t, sched.tags, "settled")
 
 	// The evicted tag no longer appears in snapshots (buildSnapshot runs on
 	// the scheduler goroutine; calling it directly is safe on a scheduler
 	// that was never started).
 	snap := sched.buildSnapshot()
 	assert.NotContains(t, snap.Tags, "idle")
+	assert.NotContains(t, snap.Tags, "settled")
 	assert.Contains(t, snap.Tags, "busy")
 }
 
@@ -672,11 +690,7 @@ func TestTagSchedulerGlobalBufferReservesForIdleTags(t *testing.T) {
 		EMAWindow:             5 * time.Second,
 	})
 	// No consumer on out: dispatched work parks, queues build.
-	sched.out = make(chan *clientTransferFile)
-	sched.stopped = make(chan struct{})
-	sched.started.Store(true)
-	go sched.run(ctx)
-	t.Cleanup(sched.Stop)
+	startScheduler(t, ctx, sched, make(chan *clientTransferFile))
 
 	// Saturate the global buffer with one origin.
 	require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
@@ -709,13 +723,16 @@ func TestTagSchedulerClassifyShedHonesty(t *testing.T) {
 		PerTagStarvingPercent: 25, // starving cap 1
 		PerTagActivePercent:   50, // active cap 2
 	})
-	// Idle tag: nothing in flight → pool contention, not the origin's fault.
+	// Unknown tag: nothing in flight → pool contention, not the origin's fault.
+	assert.Equal(t, ShedCacheOverloaded, sched.classifyShed("unknownTag"))
+	// Known but wholly idle: same verdict.
+	sched.tagFor("idleTag")
 	assert.Equal(t, ShedCacheOverloaded, sched.classifyShed("idleTag"))
 	// At the starving cap: first-byte-less fetches dominate → unresponsive.
-	sched.active["starved"] = 1
-	sched.starving["starved"] = 1
+	starved := sched.tagFor("starved")
+	starved.active, starved.starving = 1, 1
 	assert.Equal(t, ShedOriginUnresponsive, sched.classifyShed("starved"))
 	// At the active cap, delivering data → merely slow.
-	sched.active["slow"] = 2
+	sched.tagFor("slow").active = 2
 	assert.Equal(t, ShedOriginSlow, sched.classifyShed("slow"))
 }

--- a/client/tag_scheduler_test.go
+++ b/client/tag_scheduler_test.go
@@ -407,3 +407,98 @@ func TestTagSchedulerConcurrentSubmit(t *testing.T) {
 	wg.Wait()
 	assert.Equal(t, int64(200), accepted+rejected, "every submission should resolve")
 }
+
+// TestTagSchedulerRejectClassifiesCacheOverloaded: a rejection due to the
+// global pending buffer being full is classified as ShedCacheOverloaded.
+func TestTagSchedulerRejectClassifiesCacheOverloaded(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sched := NewTagScheduler(4, SchedulerConfig{
+		PerTagStarvingPercent: 50,
+		PerTagActivePercent:   50,
+		PendingBufferSize:     3,
+		PerTagPendingSize:     100, // large; hit the global cap first
+		EMAWindow:             5 * time.Second,
+	})
+	// No worker draining out, so submissions enqueue and fill the buffer.
+	sched.out = make(chan *clientTransferFile)
+	sched.stopped = make(chan struct{})
+	go sched.run(ctx)
+	t.Cleanup(sched.Stop)
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	}
+	err := sched.Submit(ctx, "originA", makeFile("originA"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTooManyRequests)
+	var rej *SchedulerRejection
+	require.ErrorAs(t, err, &rej)
+	assert.Equal(t, ShedCacheOverloaded, rej.Reason)
+}
+
+// TestTagSchedulerRejectClassifiesOriginUnresponsive: when a per-tag FIFO fills
+// while the origin is holding its starving cap (dispatched fetches that never
+// produced a first byte), the rejection is classified as ShedOriginUnresponsive.
+func TestTagSchedulerRejectClassifiesOriginUnresponsive(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sched := NewTagScheduler(4, SchedulerConfig{
+		PerTagStarvingPercent: 25, // starving cap = 1 (the limiter)
+		PerTagActivePercent:   90, // active cap high, not the limiter
+		PendingBufferSize:     100,
+		PerTagPendingSize:     2,
+		EMAWindow:             5 * time.Second,
+	})
+	out := make(chan *clientTransferFile, 100)
+	sched.Start(ctx, out)
+	t.Cleanup(sched.Stop)
+
+	// First submit dispatches and becomes starving (no first-byte fired).
+	require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	require.Eventually(t, func() bool { return len(out) == 1 }, time.Second, 10*time.Millisecond)
+	// Two more fill the per-tag FIFO (dispatch blocked by the starving cap).
+	require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	// Fourth overflows the FIFO -> reject. starving == starvingCap -> unresponsive.
+	err := sched.Submit(ctx, "originA", makeFile("originA"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTooManyRequests)
+	var rej *SchedulerRejection
+	require.ErrorAs(t, err, &rej)
+	assert.Equal(t, ShedOriginUnresponsive, rej.Reason)
+	assert.Equal(t, "originA", rej.Tag)
+}
+
+// TestTagSchedulerRejectClassifiesOriginSlow: when a per-tag FIFO fills while
+// the origin is at its active cap (delivering data, but holding its share of
+// the pool) rather than its starving cap, the rejection is classified as
+// ShedOriginSlow.
+func TestTagSchedulerRejectClassifiesOriginSlow(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sched := NewTagScheduler(4, SchedulerConfig{
+		PerTagStarvingPercent: 90, // starving cap high, not the limiter
+		PerTagActivePercent:   25, // active cap = 1 (the limiter)
+		PendingBufferSize:     100,
+		PerTagPendingSize:     2,
+		EMAWindow:             5 * time.Second,
+	})
+	out := make(chan *clientTransferFile, 100)
+	sched.Start(ctx, out)
+	t.Cleanup(sched.Stop)
+
+	// One dispatches (active == 1 == activeCap). starving (1) stays below the
+	// high starving cap, so the FIFO-full reject classifies as slow, not
+	// unresponsive.
+	require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	require.Eventually(t, func() bool { return len(out) == 1 }, time.Second, 10*time.Millisecond)
+	require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	require.NoError(t, sched.Submit(ctx, "originA", makeFile("originA")))
+	err := sched.Submit(ctx, "originA", makeFile("originA"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTooManyRequests)
+	var rej *SchedulerRejection
+	require.ErrorAs(t, err, &rej)
+	assert.Equal(t, ShedOriginSlow, rej.Reason)
+}

--- a/client/throttle_classify_test.go
+++ b/client/throttle_classify_test.go
@@ -1,0 +1,196 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/pelican_url"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/test_utils"
+)
+
+// A cache sheds a request with 429 to say "come back later". Every request
+// flavor the client issues has to recognize that, because an unclassified 429
+// lands in the generic 4xx bucket, which is not retryable: the transfer would
+// be reported as a permanent client error and the job would give up on a cache
+// that was merely busy.
+
+// TestObjectCachedThrottleIsClassified pins the cache-status probe. It issues
+// a one-byte ranged GET and, when that does not answer the question, falls
+// back to a HEAD.
+//
+// The fallback is the trap: a cache answers HEAD without consulting its fair
+// scheduler, so the HEAD very likely succeeds even while the GET is being
+// shed. If the throttle from the GET were discarded, the probe would report
+// the object's cache status as authoritative on the strength of a request that
+// never went through the scheduler.
+func TestObjectCachedThrottleIsClassified(t *testing.T) {
+	test_utils.InitClient(t, map[param.Param]any{})
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var headCount atomic.Int32
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			// A healthy-looking HEAD: this is what would overwrite the
+			// throttle if the GET's classification were dropped.
+			headCount.Add(1)
+			w.Header().Set("Content-Length", "1024")
+			w.Header().Set("Age", "42")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "17")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"origin_unresponsive","detail":"origin is not delivering data"}`))
+	}))
+	defer svr.Close()
+
+	svrURL, err := url.Parse(svr.URL)
+	require.NoError(t, err)
+	svrURL.Path = "/ns/object"
+
+	age, size, err := objectCached(ctx, svrURL, nil)
+
+	require.Error(t, err, "a shed cache-status probe must not be reported as an answer")
+	var throttled *CacheThrottleError
+	require.ErrorAs(t, err, &throttled)
+	assert.Equal(t, string(ShedOriginUnresponsive), throttled.Reason)
+	assert.Equal(t, 17*time.Second, throttled.RetryAfter)
+	assert.ErrorIs(t, err, ErrTooManyRequests)
+	assert.True(t, IsRetryable(err), "a throttled probe must be retryable")
+
+	assert.Zero(t, headCount.Load(),
+		"the HEAD fallback must not run after a shed; its answer would overwrite the throttle")
+	assert.Equal(t, -1, age, "no cache age was learned")
+	assert.Zero(t, size, "no size was learned")
+}
+
+// TestObjectCachedHeadThrottleIsClassified covers the second request the probe
+// can make: when the ranged GET succeeds but carries no Content-Range, the
+// probe falls back to a HEAD, and that HEAD can be shed too.
+func TestObjectCachedHeadThrottleIsClassified(t *testing.T) {
+	test_utils.InitClient(t, map[param.Param]any{})
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.Header().Set("Retry-After", "5")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		// 200 with no Content-Range, so the probe still needs the HEAD.
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	svrURL, err := url.Parse(svr.URL)
+	require.NoError(t, err)
+	svrURL.Path = "/ns/object"
+
+	_, _, err = objectCached(ctx, svrURL, nil)
+	require.Error(t, err)
+	var throttled *CacheThrottleError
+	require.ErrorAs(t, err, &throttled)
+	assert.Equal(t, 5*time.Second, throttled.RetryAfter)
+	assert.True(t, IsRetryable(err))
+}
+
+// TestStatHttpThrottleIsClassified pins the stat path, which reaches a cache
+// through a WebDAV PROPFIND rather than the plain HTTP client.
+//
+// This is the path the cache itself takes to answer a HEAD request
+// (HeadObject -> DoStat), so an unclassified throttle here has two victims: a
+// client's stat is reported as a permanent failure, and the cache turns its
+// upstream's 429 into a 500, telling its own client that something went wrong
+// internally rather than to retry.
+func TestStatHttpThrottleIsClassified(t *testing.T) {
+	test_utils.InitClient(t, map[param.Param]any{})
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer svr.Close()
+
+	svrURL, err := url.Parse(svr.URL)
+	require.NoError(t, err)
+
+	dest := &pelican_url.PelicanURL{
+		Scheme: "pelican://",
+		Host:   "example-federation.org",
+		Path:   "/ns/object",
+	}
+	dirResp := server_structs.DirectorResponse{
+		ObjectServers: []*url.URL{{Scheme: svrURL.Scheme, Host: svrURL.Host, Path: "/ns/object"}},
+	}
+
+	_, err = statHttp(dest, dirResp, nil, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTooManyRequests,
+		"a shed stat must satisfy the same sentinel check as any other throttle")
+	var throttled *CacheThrottleError
+	require.ErrorAs(t, err, &throttled)
+	assert.Equal(t, svrURL.Host, throttled.Endpoint)
+	assert.True(t, IsRetryable(err),
+		"an unclassified 429 would be a non-retryable specification error")
+}
+
+// TestStatHttpNotFoundStillClassified guards the neighbouring branches: adding
+// the throttle case must not disturb how a genuinely missing object is
+// reported, which is the answer that tells a client to stop rather than retry.
+func TestStatHttpNotFoundStillClassified(t *testing.T) {
+	test_utils.InitClient(t, map[param.Param]any{})
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer svr.Close()
+
+	svrURL, err := url.Parse(svr.URL)
+	require.NoError(t, err)
+
+	dest := &pelican_url.PelicanURL{
+		Scheme: "pelican://",
+		Host:   "example-federation.org",
+		Path:   "/ns/object",
+	}
+	dirResp := server_structs.DirectorResponse{
+		ObjectServers: []*url.URL{{Scheme: svrURL.Scheme, Host: svrURL.Host, Path: "/ns/object"}},
+	}
+
+	_, err = statHttp(dest, dirResp, nil, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrObjectNotFound)
+	assert.NotErrorIs(t, err, ErrTooManyRequests)
+	assert.False(t, IsRetryable(err), "a missing object is not worth retrying")
+}

--- a/client/throttle_classify_test.go
+++ b/client/throttle_classify_test.go
@@ -27,8 +27,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/pelican_url"
@@ -193,4 +195,108 @@ func TestStatHttpNotFoundStillClassified(t *testing.T) {
 	assert.ErrorIs(t, err, ErrObjectNotFound)
 	assert.NotErrorIs(t, err, ErrTooManyRequests)
 	assert.False(t, IsRetryable(err), "a missing object is not worth retrying")
+}
+
+// newTPCTestToken returns a token generator with the value already set, so
+// nothing tries to acquire one from a federation that does not exist.
+func newTPCTestToken() *tokenGenerator {
+	tg := &tokenGenerator{Sync: new(singleflight.Group)}
+	tg.SetToken("test-token")
+	return tg
+}
+
+// newTPCTestTransfer builds the minimal transferFile copyHTTP needs: a source
+// to HEAD and a destination to COPY to.
+func newTPCTestTransfer(ctx context.Context, srcURL, destURL *url.URL) *transferFile {
+	return &transferFile{
+		ctx:       ctx,
+		remoteURL: &url.URL{Scheme: "pelican", Host: "example-federation.org", Path: "/ns/object"},
+		attempts:  []transferAttemptDetails{{Url: srcURL}},
+		token:     newTPCTestToken(),
+		job: &TransferJob{
+			uuid:     uuid.New(),
+			xferType: transferTypeCopy,
+			remoteURL: &pelican_url.PelicanURL{
+				Scheme: "pelican://",
+				Host:   "example-federation.org",
+				Path:   "/ns/object",
+			},
+			destDirResp: server_structs.DirectorResponse{
+				ObjectServers: []*url.URL{destURL},
+			},
+		},
+	}
+}
+
+// TestCopyHTTPSourceThrottleIsClassified pins the third-party-copy source
+// probe. A copy starts by HEADing the source to learn its size; a source that
+// sheds that HEAD has not refused the copy permanently, it has asked for a
+// retry.
+func TestCopyHTTPSourceThrottleIsClassified(t *testing.T) {
+	test_utils.InitClient(t, map[param.Param]any{})
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	src := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "12")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer src.Close()
+	dest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("the destination must not be contacted after the source shed the request")
+	}))
+	defer dest.Close()
+
+	srcURL, err := url.Parse(src.URL + "/ns/object")
+	require.NoError(t, err)
+	destURL, err := url.Parse(dest.URL + "/ns/object")
+	require.NoError(t, err)
+
+	_, err = copyHTTP(newTPCTestTransfer(ctx, srcURL, destURL))
+	require.Error(t, err)
+	var throttled *CacheThrottleError
+	require.ErrorAs(t, err, &throttled)
+	assert.Equal(t, 12*time.Second, throttled.RetryAfter)
+	// A response to HEAD carries no body, so there is no structured reason to
+	// report on this leg -- only that the source shed the request.
+	assert.Empty(t, throttled.Reason)
+	assert.Equal(t, srcURL.Host, throttled.Endpoint)
+	assert.ErrorIs(t, err, ErrTooManyRequests)
+	assert.True(t, IsRetryable(err))
+}
+
+// TestCopyHTTPDestinationThrottleIsClassified pins the other half: the source
+// is healthy, but the destination sheds the COPY itself.
+func TestCopyHTTPDestinationThrottleIsClassified(t *testing.T) {
+	test_utils.InitClient(t, map[param.Param]any{})
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	src := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "2048")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer src.Close()
+	dest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "45")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"cache_overloaded","detail":"pending buffer is full"}`))
+	}))
+	defer dest.Close()
+
+	srcURL, err := url.Parse(src.URL + "/ns/object")
+	require.NoError(t, err)
+	destURL, err := url.Parse(dest.URL + "/ns/object")
+	require.NoError(t, err)
+
+	_, err = copyHTTP(newTPCTestTransfer(ctx, srcURL, destURL))
+	require.Error(t, err)
+	var throttled *CacheThrottleError
+	require.ErrorAs(t, err, &throttled)
+	assert.Equal(t, string(ShedCacheOverloaded), throttled.Reason)
+	assert.Equal(t, 45*time.Second, throttled.RetryAfter)
+	assert.Equal(t, destURL.Host, throttled.Endpoint)
+	assert.True(t, IsRetryable(err),
+		"a shed copy must be retried rather than reported as a permanent failure")
 }

--- a/client/throttle_error_test.go
+++ b/client/throttle_error_test.go
@@ -326,3 +326,81 @@ func TestUploadObject429(t *testing.T) {
 	assert.Equal(t, 60*time.Second, throttled.RetryAfter)
 	assert.True(t, ShouldRetry(transferResult.Error), "a throttled upload must be retryable")
 }
+
+// TestParseRetryAfterSaturates pins the out-of-range path. A value too large
+// for a 64-bit integer must still yield the clamp: parsing it as an error and
+// falling through to the date parser would drop the hint entirely, so a server
+// could suppress the backoff advice with a nonsense number rather than an
+// absurd one.
+func TestParseRetryAfterSaturates(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  time.Duration
+	}{
+		{"BeyondInt64", "99999999999999999999", maxRetryAfter},
+		{"FarBeyondInt64", "1" + strings.Repeat("0", 40), maxRetryAfter},
+		{"NegativeBeyondInt64", "-99999999999999999999", 0},
+		{"MaxInt64", "9223372036854775807", maxRetryAfter},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseRetryAfter(tt.value))
+		})
+	}
+}
+
+// TestParseThrottleBodyDetail pins which text is kept as the human-readable
+// detail. It is rendered into error messages, so a body that is not the shape
+// the cache emits must not be silently dropped, and the reason must not be
+// repeated as its own detail.
+func TestParseThrottleBodyDetail(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantReason string
+		wantDetail string
+	}{
+		{
+			name:       "ReasonAndDetail",
+			body:       `{"error":"origin_slow","detail":"origin already holds its share"}`,
+			wantReason: "origin_slow",
+			wantDetail: "origin already holds its share",
+		},
+		{
+			// The reason is reported on its own, so echoing the raw body here
+			// would just print it twice.
+			name:       "ReasonWithoutDetail",
+			body:       `{"error":"origin_slow"}`,
+			wantReason: "origin_slow",
+			wantDetail: "",
+		},
+		{
+			// Not the shape we emit, but a person still needs to see it.
+			name:       "NonJSONPassedThroughWhole",
+			body:       "upstream proxy refused the connection",
+			wantReason: "",
+			wantDetail: "upstream proxy refused the connection",
+		},
+		{
+			name:       "UnknownReasonKeepsDetail",
+			body:       `{"error":"please_stop","detail":"go away"}`,
+			wantReason: "",
+			wantDetail: "go away",
+		},
+		{
+			name:       "JSONWithNeitherField",
+			body:       `{"something":"else"}`,
+			wantReason: "",
+			wantDetail: `{"something":"else"}`,
+		},
+		{"Empty", "   ", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, detail := parseThrottleBody(tt.body)
+			assert.Equal(t, tt.wantReason, reason)
+			assert.Equal(t, tt.wantDetail, detail)
+		})
+	}
+}

--- a/client/throttle_error_test.go
+++ b/client/throttle_error_test.go
@@ -19,8 +19,17 @@
 package client
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,7 +37,26 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pelicanplatform/pelican/error_codes"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/pelican_url"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/test_utils"
 )
+
+// shedReasonTypes is the contract between the scheduler's shed reasons (the
+// "error" field a cache writes into its 429 JSON body) and the Pelican error
+// type the client classifies each into. It is deliberately keyed on the
+// ShedReason constants rather than fresh string literals: if a constant's
+// value is renamed on the producer side, these tests fail instead of the
+// client silently degrading every shed to the generic fallback.
+//
+// If a new ShedReason constant is added, it must be added here (and to
+// throttleErrorForReason / parseThrottleReason) as well.
+var shedReasonTypes = map[ShedReason]string{
+	ShedOriginUnresponsive: "Transfer.OriginUnresponsive",
+	ShedOriginSlow:         "Transfer.OriginSlow",
+	ShedCacheOverloaded:    "Transfer.CacheOverloaded",
+}
 
 // wrapErrorByStatusCode maps HTTP 429 to a retryable Pelican error, so a cache
 // shed is no longer mis-classified as a fatal specification error.
@@ -40,38 +68,46 @@ func TestWrapStatusCode429IsRetryable(t *testing.T) {
 	assert.True(t, IsRetryable(wrapped), "IsRetryable must report 429 as retryable")
 }
 
-// throttleErrorForReason maps the structured reason string to the specific
-// retryable Pelican error type; unknown reasons fall back to cache-overloaded.
+// Every declared ShedReason must map to its own specific retryable error
+// type; unknown or empty reasons fall back to cache-overloaded.
 func TestThrottleErrorForReason(t *testing.T) {
-	cases := []struct {
-		reason  string
-		errType string
-	}{
-		{"origin_unresponsive", "Transfer.OriginUnresponsive"},
-		{"origin_slow", "Transfer.OriginSlow"},
-		{"cache_overloaded", "Transfer.CacheOverloaded"},
-		{"", "Transfer.CacheOverloaded"},
-		{"garbage", "Transfer.CacheOverloaded"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.reason, func(t *testing.T) {
-			err := throttleErrorForReason(tc.reason, errors.New("x"))
+	for reason, errType := range shedReasonTypes {
+		t.Run(string(reason), func(t *testing.T) {
+			err := throttleErrorForReason(string(reason), errors.New("x"))
 			var pe *error_codes.PelicanError
 			require.ErrorAs(t, err, &pe)
-			assert.Equal(t, tc.errType, pe.ErrorType())
+			assert.Equal(t, errType, pe.ErrorType())
+			assert.True(t, pe.IsRetryable())
+		})
+	}
+	for _, reason := range []string{"", "garbage"} {
+		t.Run("fallback/"+reason, func(t *testing.T) {
+			err := throttleErrorForReason(reason, errors.New("x"))
+			var pe *error_codes.PelicanError
+			require.ErrorAs(t, err, &pe)
+			assert.Equal(t, "Transfer.CacheOverloaded", pe.ErrorType())
 			assert.True(t, pe.IsRetryable())
 		})
 	}
 }
 
 func TestParseThrottleReason(t *testing.T) {
-	assert.Equal(t, "origin_unresponsive",
-		parseThrottleReason(`{"error":"origin_unresponsive","detail":"..."}`))
-	assert.Equal(t, "cache_overloaded",
-		parseThrottleReason(`{"error":"cache_overloaded"}`))
+	// Round-trip every ShedReason constant through the same JSON shape the
+	// cache's handleError writes; this welds the producer constants to the
+	// consumer's parser.
+	for reason := range shedReasonTypes {
+		body, err := json.Marshal(map[string]string{"error": string(reason), "detail": "..."})
+		require.NoError(t, err)
+		assert.Equal(t, string(reason), parseThrottleReason(string(body)))
+	}
+	// Anything that is not a known reason is rejected: the body comes from
+	// a remote peer, and an arbitrary string must not flow into logs or
+	// error messages.
 	assert.Equal(t, "", parseThrottleReason(""))
 	assert.Equal(t, "", parseThrottleReason("not json"))
 	assert.Equal(t, "", parseThrottleReason(`{"other":"field"}`))
+	assert.Equal(t, "", parseThrottleReason(`{"error":"made_up_reason"}`))
+	assert.Equal(t, "", parseThrottleReason(`{"error":"origin_slow\nfake log line"}`))
 }
 
 func TestParseRetryAfter(t *testing.T) {
@@ -79,19 +115,41 @@ func TestParseRetryAfter(t *testing.T) {
 	assert.Equal(t, time.Duration(0), parseRetryAfter(""))
 	assert.Equal(t, time.Duration(0), parseRetryAfter("-5"))
 	assert.Equal(t, time.Duration(0), parseRetryAfter("garbage"))
-	// HTTP-date form: a time in the future yields a positive duration.
+	// Values are clamped so a misbehaving server cannot push an absurd
+	// backoff (or overflow the duration into a negative) downstream.
+	assert.Equal(t, maxRetryAfter, parseRetryAfter("7200"))
+	assert.Equal(t, maxRetryAfter, parseRetryAfter("9223372036854775807"))
+	// HTTP-date form: a time in the future yields a positive duration; a
+	// past date yields zero; a far-future date is clamped.
 	future := time.Now().Add(30 * time.Second).UTC().Format(http.TimeFormat)
 	d := parseRetryAfter(future)
 	assert.Greater(t, d, time.Duration(0))
 	assert.LessOrEqual(t, d, 30*time.Second)
+	past := time.Now().Add(-30 * time.Second).UTC().Format(http.TimeFormat)
+	assert.Equal(t, time.Duration(0), parseRetryAfter(past))
+	farFuture := time.Now().Add(48 * time.Hour).UTC().Format(http.TimeFormat)
+	assert.Equal(t, maxRetryAfter, parseRetryAfter(farFuture))
+}
+
+// Server-provided detail strings are sanitized before they can reach logs or
+// error messages: control characters (which would let a hostile server forge
+// log records) become spaces, and over-long bodies are truncated.
+func TestSanitizeErrorDetail(t *testing.T) {
+	assert.Equal(t, "a b c", sanitizeErrorDetail("a\nb\rc"))
+	assert.Equal(t, "tab here", sanitizeErrorDetail("tab\there"))
+	long := strings.Repeat("x", 2048)
+	sanitized := sanitizeErrorDetail(long)
+	assert.LessOrEqual(t, len(sanitized), 512+len("…"))
+	assert.True(t, strings.HasSuffix(sanitized, "…"))
 }
 
 // A CacheThrottleError built from a cache's 429 wraps the specific retryable
-// Pelican error, so both errors.Is(ErrTooManyRequests-adjacent) checks via the
-// PelicanError chain and IsRetryable hold, and it carries the reason + hint.
+// Pelican error and matches ErrTooManyRequests, so a remote shed satisfies
+// the same errors.Is check as a shed by this process's own scheduler, and
+// IsRetryable/ShouldRetry hold; it carries the reason + backoff hint.
 func TestCacheThrottleErrorIsRetryable(t *testing.T) {
-	err := newCacheThrottleError("origin_unresponsive", "origin is over its share", "cache.example.org:8443", 60*time.Second)
-	assert.Equal(t, "origin_unresponsive", err.Reason)
+	err := newCacheThrottleError(string(ShedOriginUnresponsive), "origin is over its share", "cache.example.org:8443", 60*time.Second)
+	assert.Equal(t, string(ShedOriginUnresponsive), err.Reason)
 	assert.Equal(t, 60*time.Second, err.RetryAfter)
 	assert.Equal(t, "cache.example.org:8443", err.Endpoint)
 
@@ -100,9 +158,167 @@ func TestCacheThrottleErrorIsRetryable(t *testing.T) {
 	assert.Equal(t, "Transfer.OriginUnresponsive", pe.ErrorType())
 	assert.True(t, IsRetryable(err), "a cache throttle must be retryable")
 	assert.True(t, ShouldRetry(err), "ShouldRetry must honor a cache throttle")
+	assert.True(t, errors.Is(err, ErrTooManyRequests),
+		"a remote 429 must satisfy the same errors.Is check as a local scheduler shed")
 
 	// Recoverable as a typed error so external retriers can read RetryAfter.
 	var throttled *CacheThrottleError
 	require.ErrorAs(t, err, &throttled)
 	assert.Equal(t, 60*time.Second, throttled.RetryAfter)
+}
+
+// wrapDownloadError must pass a CacheThrottleError through unmodified: the
+// typed reason and Retry-After hint must survive to the caller even as other
+// error kinds get rewrapped.
+func TestWrapDownloadErrorPreservesThrottle(t *testing.T) {
+	orig := newCacheThrottleError(string(ShedOriginSlow), "detail", "cache.example.org:8443", 60*time.Second)
+	wrapped, _, _ := wrapDownloadError(orig, "https://cache.example.org:8443", "", "")
+	var throttled *CacheThrottleError
+	require.ErrorAs(t, wrapped, &throttled,
+		"wrapDownloadError must not bury the CacheThrottleError type")
+	assert.Equal(t, string(ShedOriginSlow), throttled.Reason)
+	assert.Equal(t, 60*time.Second, throttled.RetryAfter)
+	assert.True(t, ShouldRetry(wrapped))
+}
+
+// A 429 observed by the actual download path must come back as a typed,
+// retryable CacheThrottleError carrying the parsed reason, the Retry-After
+// hint, and the serving host.
+func TestDownloadHTTP429(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	test_utils.InitClient(t, map[param.Param]any{})
+
+	cases := []struct {
+		name       string
+		body       string
+		retryAfter string
+		wantReason string
+		wantHint   time.Duration
+		wantType   string
+	}{
+		{
+			name:       "StructuredReason",
+			body:       fmt.Sprintf(`{"error":%q,"detail":"origin is over its share"}`, string(ShedOriginUnresponsive)),
+			retryAfter: "60",
+			wantReason: string(ShedOriginUnresponsive),
+			wantHint:   60 * time.Second,
+			wantType:   "Transfer.OriginUnresponsive",
+		},
+		{
+			name:       "EmptyBody",
+			body:       "",
+			retryAfter: "60",
+			wantReason: "",
+			wantHint:   60 * time.Second,
+			wantType:   "Transfer.CacheOverloaded",
+		},
+		{
+			name:       "GarbageBodyNoRetryAfter",
+			body:       "<html>not json</html>",
+			retryAfter: "",
+			wantReason: "",
+			wantHint:   0,
+			wantType:   "Transfer.CacheOverloaded",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, _, _ := test_utils.TestContext(context.Background(), t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.retryAfter != "" {
+					w.Header().Set("Retry-After", tc.retryAfter)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+			serverURL, err := url.Parse(server.URL)
+			require.NoError(t, err)
+
+			fname := filepath.Join(t.TempDir(), "test.txt")
+			writer, err := os.OpenFile(fname, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
+			require.NoError(t, err)
+			defer writer.Close()
+
+			_, _, _, _, _, err = downloadHTTP(ctx, nil, nil,
+				transferAttemptDetails{Url: serverURL, Proxy: false},
+				fname, writer, 0, -1, -1, "", "", nil, nil)
+			require.Error(t, err)
+
+			var throttled *CacheThrottleError
+			require.ErrorAs(t, err, &throttled, "429 must produce a CacheThrottleError")
+			assert.Equal(t, tc.wantReason, throttled.Reason)
+			assert.Equal(t, tc.wantHint, throttled.RetryAfter)
+			assert.Equal(t, serverURL.Host, throttled.Endpoint)
+			var pe *error_codes.PelicanError
+			require.ErrorAs(t, err, &pe)
+			assert.Equal(t, tc.wantType, pe.ErrorType())
+			assert.True(t, ShouldRetry(err), "a throttled download must be retryable")
+			assert.True(t, errors.Is(err, ErrTooManyRequests))
+		})
+	}
+}
+
+// A 429 on the upload (PUT) path must get the same typed classification as a
+// download: reason parsed from the body, Retry-After hint carried, retryable.
+func TestUploadObject429(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	test_utils.InitClient(t, map[param.Param]any{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Report the destination object as absent for the pre-upload stat.
+		if r.Method == "PROPFIND" || r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		// Drain the PUT body before answering: otherwise the client-side
+		// transport may still hold the upload file open when the test's
+		// TempDir cleanup runs, which fails on Windows (open files cannot
+		// be deleted there).
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Retry-After", "60")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"error":%q,"detail":"cache is saturated"}`, string(ShedCacheOverloaded))))
+	}))
+	defer server.Close()
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	localFile := filepath.Join(t.TempDir(), "upload.txt")
+	require.NoError(t, os.WriteFile(localFile, []byte("upload me"), 0o644))
+
+	transfer := &transferFile{
+		ctx:       context.Background(),
+		localPath: localFile,
+		remoteURL: serverURL,
+		xferType:  transferTypeUpload,
+		job: &TransferJob{
+			remoteURL: &pelican_url.PelicanURL{
+				Scheme: "pelican://",
+				Host:   serverURL.Host,
+				Path:   "/test/upload.txt",
+			},
+			dirResp: server_structs.DirectorResponse{
+				XPelNsHdr: server_structs.XPelNs{
+					CollectionsUrl: serverURL,
+				},
+			},
+		},
+		attempts: []transferAttemptDetails{{Url: serverURL, Proxy: false}},
+	}
+
+	// uploadObject reports per-attempt failures via transferResult.Error (a
+	// TransferErrors accumulator), not its error return; asserting through
+	// it also proves the throttle type survives the accumulator's unwrap
+	// chain — the same path the plugin's retryable-exit logic walks.
+	transferResult, err := uploadObject(transfer)
+	require.NoError(t, err)
+	require.Error(t, transferResult.Error)
+	var throttled *CacheThrottleError
+	require.ErrorAs(t, transferResult.Error, &throttled, "a 429 on PUT must produce a CacheThrottleError")
+	assert.Equal(t, string(ShedCacheOverloaded), throttled.Reason)
+	assert.Equal(t, 60*time.Second, throttled.RetryAfter)
+	assert.True(t, ShouldRetry(transferResult.Error), "a throttled upload must be retryable")
 }

--- a/client/throttle_error_test.go
+++ b/client/throttle_error_test.go
@@ -131,16 +131,18 @@ func TestParseRetryAfter(t *testing.T) {
 	assert.Equal(t, maxRetryAfter, parseRetryAfter(farFuture))
 }
 
-// Server-provided detail strings are sanitized before they can reach logs or
-// error messages: control characters (which would let a hostile server forge
-// log records) become spaces, and over-long bodies are truncated.
-func TestSanitizeErrorDetail(t *testing.T) {
-	assert.Equal(t, "a b c", sanitizeErrorDetail("a\nb\rc"))
-	assert.Equal(t, "tab here", sanitizeErrorDetail("tab\there"))
+// Server-provided detail strings are truncated at storage and quoted at
+// display: control characters a hostile server embeds render as escapes
+// (\n, \r) in the error message, so they cannot forge log records.
+func TestThrottleDetailQuotedAndTruncated(t *testing.T) {
+	err := newCacheThrottleError(string(ShedOriginSlow), "line one\nFAKE-LOG-LINE", "cache.example.org:8443", 0)
+	msg := err.Error()
+	assert.NotContains(t, msg, "\n", "raw newlines must not survive into the error message")
+	assert.Contains(t, msg, `line one\nFAKE-LOG-LINE`, "detail must be rendered with escapes, not dropped")
+
 	long := strings.Repeat("x", 2048)
-	sanitized := sanitizeErrorDetail(long)
-	assert.LessOrEqual(t, len(sanitized), 512+len("…"))
-	assert.True(t, strings.HasSuffix(sanitized, "…"))
+	assert.LessOrEqual(t, len(truncateErrorDetail(long)), 512+len("…"))
+	assert.True(t, strings.HasSuffix(truncateErrorDetail(long), "…"))
 }
 
 // A CacheThrottleError built from a cache's 429 wraps the specific retryable

--- a/client/throttle_error_test.go
+++ b/client/throttle_error_test.go
@@ -58,8 +58,10 @@ var shedReasonTypes = map[ShedReason]string{
 	ShedCacheOverloaded:    "Transfer.CacheOverloaded",
 }
 
-// wrapErrorByStatusCode maps HTTP 429 to a retryable Pelican error, so a cache
-// shed is no longer mis-classified as a fatal specification error.
+// wrapErrorByStatusCode maps HTTP 429 to a retryable Pelican error rather than
+// to the generic Specification bucket the other 4xx codes land in. A shed says
+// "come back later", so classifying it as a fatal client error would make the
+// caller give up on a server that was merely busy.
 func TestWrapStatusCode429IsRetryable(t *testing.T) {
 	wrapped := wrapErrorByStatusCode(http.StatusTooManyRequests, errors.New("shed"))
 	var pe *error_codes.PelicanError

--- a/client/throttle_error_test.go
+++ b/client/throttle_error_test.go
@@ -1,0 +1,108 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package client
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/error_codes"
+)
+
+// wrapErrorByStatusCode maps HTTP 429 to a retryable Pelican error, so a cache
+// shed is no longer mis-classified as a fatal specification error.
+func TestWrapStatusCode429IsRetryable(t *testing.T) {
+	wrapped := wrapErrorByStatusCode(http.StatusTooManyRequests, errors.New("shed"))
+	var pe *error_codes.PelicanError
+	require.ErrorAs(t, wrapped, &pe)
+	assert.True(t, pe.IsRetryable(), "429 must be retryable")
+	assert.True(t, IsRetryable(wrapped), "IsRetryable must report 429 as retryable")
+}
+
+// throttleErrorForReason maps the structured reason string to the specific
+// retryable Pelican error type; unknown reasons fall back to cache-overloaded.
+func TestThrottleErrorForReason(t *testing.T) {
+	cases := []struct {
+		reason  string
+		errType string
+	}{
+		{"origin_unresponsive", "Transfer.OriginUnresponsive"},
+		{"origin_slow", "Transfer.OriginSlow"},
+		{"cache_overloaded", "Transfer.CacheOverloaded"},
+		{"", "Transfer.CacheOverloaded"},
+		{"garbage", "Transfer.CacheOverloaded"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.reason, func(t *testing.T) {
+			err := throttleErrorForReason(tc.reason, errors.New("x"))
+			var pe *error_codes.PelicanError
+			require.ErrorAs(t, err, &pe)
+			assert.Equal(t, tc.errType, pe.ErrorType())
+			assert.True(t, pe.IsRetryable())
+		})
+	}
+}
+
+func TestParseThrottleReason(t *testing.T) {
+	assert.Equal(t, "origin_unresponsive",
+		parseThrottleReason(`{"error":"origin_unresponsive","detail":"..."}`))
+	assert.Equal(t, "cache_overloaded",
+		parseThrottleReason(`{"error":"cache_overloaded"}`))
+	assert.Equal(t, "", parseThrottleReason(""))
+	assert.Equal(t, "", parseThrottleReason("not json"))
+	assert.Equal(t, "", parseThrottleReason(`{"other":"field"}`))
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	assert.Equal(t, 60*time.Second, parseRetryAfter("60"))
+	assert.Equal(t, time.Duration(0), parseRetryAfter(""))
+	assert.Equal(t, time.Duration(0), parseRetryAfter("-5"))
+	assert.Equal(t, time.Duration(0), parseRetryAfter("garbage"))
+	// HTTP-date form: a time in the future yields a positive duration.
+	future := time.Now().Add(30 * time.Second).UTC().Format(http.TimeFormat)
+	d := parseRetryAfter(future)
+	assert.Greater(t, d, time.Duration(0))
+	assert.LessOrEqual(t, d, 30*time.Second)
+}
+
+// A CacheThrottleError built from a cache's 429 wraps the specific retryable
+// Pelican error, so both errors.Is(ErrTooManyRequests-adjacent) checks via the
+// PelicanError chain and IsRetryable hold, and it carries the reason + hint.
+func TestCacheThrottleErrorIsRetryable(t *testing.T) {
+	err := newCacheThrottleError("origin_unresponsive", "origin is over its share", "cache.example.org:8443", 60*time.Second)
+	assert.Equal(t, "origin_unresponsive", err.Reason)
+	assert.Equal(t, 60*time.Second, err.RetryAfter)
+	assert.Equal(t, "cache.example.org:8443", err.Endpoint)
+
+	var pe *error_codes.PelicanError
+	require.ErrorAs(t, err, &pe)
+	assert.Equal(t, "Transfer.OriginUnresponsive", pe.ErrorType())
+	assert.True(t, IsRetryable(err), "a cache throttle must be retryable")
+	assert.True(t, ShouldRetry(err), "ShouldRetry must honor a cache throttle")
+
+	// Recoverable as a typed error so external retriers can read RetryAfter.
+	var throttled *CacheThrottleError
+	require.ErrorAs(t, err, &throttled)
+	assert.Equal(t, 60*time.Second, throttled.RetryAfter)
+}

--- a/client/transfer_engine_submit_test.go
+++ b/client/transfer_engine_submit_test.go
@@ -30,8 +30,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/pelican_url"
 	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/test_utils"
 )
 
 // newSubmitTestEngine builds the smallest TransferEngine that
@@ -188,7 +190,9 @@ func TestSchedulerShutdownDrainsQueuedFilesToResults(t *testing.T) {
 		EMAWindow:             time.Second,
 	})
 	te.scheduler = sched
-	// Wire the same drain hook NewTransferEngine installs.
+	// Stands in for the hook NewTransferEngine installs; that the engine
+	// actually installs it is asserted separately, by
+	// TestTransferEngineInstallsSchedulerDrainHook.
 	sched.onDrop = func(file *clientTransferFile) {
 		select {
 		case te.results <- synthesizeRejectionResult(file, errors.New("transfer engine shut down before the transfer could be dispatched")):
@@ -198,8 +202,8 @@ func TestSchedulerShutdownDrainsQueuedFilesToResults(t *testing.T) {
 	egrp, _ := errgroup.WithContext(ctx)
 	sched.Start(ctx, egrp, te.files)
 
-	// Queue several files for a job. Nothing reads te.files, so at most one
-	// can be in flight and the rest stay in the FIFO.
+	// Queue several files for a job. Nothing reads te.files, so the scheduler
+	// parks on its first dispatch and the rest stay in the FIFO.
 	job := newSubmitTestJob(ctx, "origin.example.com")
 	const queued = 5
 	for i := 0; i < queued; i++ {
@@ -216,12 +220,12 @@ func TestSchedulerShutdownDrainsQueuedFilesToResults(t *testing.T) {
 	sched.Stop()
 	require.NoError(t, egrp.Wait())
 
-	// Every file that was still queued produced a result. One file may have
-	// been handed to te.files instead, so the drained count is the remainder.
+	// Every file the scheduler was still holding owes its job a result. The
+	// one it had parked on mid-dispatch is not in the FIFO any more, so it is
+	// the only one that does not come back this way.
 	drained := len(te.results)
-	assert.Positive(t, drained, "queued transfers must not vanish without a result")
-	assert.Equal(t, queued, drained+len(te.files),
-		"every submitted file is accounted for, either dispatched or drained")
+	assert.GreaterOrEqual(t, drained, queued-1,
+		"queued transfers must not vanish without a result; their job would wait on them forever")
 	for i := 0; i < drained; i++ {
 		res := <-te.results
 		assert.Equal(t, job.job.uuid, res.results.JobId)
@@ -229,4 +233,34 @@ func TestSchedulerShutdownDrainsQueuedFilesToResults(t *testing.T) {
 		assert.NotNil(t, res.results.Attempts,
 			"a drained transfer still needs the fields job status displays read")
 	}
+}
+
+// TestTransferEngineInstallsSchedulerDrainHook pins the wiring the test above
+// stands in for: without it, transfers still queued when the engine shuts down
+// are dropped silently and the jobs waiting on them never complete.
+func TestTransferEngineInstallsSchedulerDrainHook(t *testing.T) {
+	// The real constructor refuses to build an engine until the client is
+	// initialized; without this the test only passes when some earlier test in
+	// the package happened to do it.
+	test_utils.InitClient(t, map[param.Param]any{})
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	sched := NewTagScheduler(1, SchedulerConfig{
+		PerTagStarvingPercent: 50,
+		PerTagActivePercent:   50,
+		PendingBufferSize:     10,
+		PerTagPendingSize:     10,
+		EMAWindow:             time.Second,
+	})
+	te, err := NewTransferEngine(ctx, WithWorkerCount(1), WithScheduler(sched))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cancel()
+		_ = te.Shutdown()
+	})
+
+	require.Same(t, sched, te.scheduler, "the configured scheduler must be the one the engine uses")
+	require.NotNil(t, sched.onDrop,
+		"the engine must give the scheduler somewhere to hand undispatched transfers at shutdown")
 }

--- a/client/transfer_engine_submit_test.go
+++ b/client/transfer_engine_submit_test.go
@@ -1,0 +1,235 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package client
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/pelican_url"
+	"github.com/pelicanplatform/pelican/server_structs"
+)
+
+// newSubmitTestEngine builds the smallest TransferEngine that
+// createTransferFiles and submitFile actually touch. Nothing reads te.files,
+// so a submission that reaches the raw channel parks there until its context
+// is cancelled -- which is the state this file needs to exercise.
+func newSubmitTestEngine(ctx context.Context) *TransferEngine {
+	return &TransferEngine{
+		ctx:     ctx,
+		files:   make(chan *clientTransferFile),
+		results: make(chan *clientTransferResults, 16),
+	}
+}
+
+// newSubmitTestJob builds a non-recursive download job pointed at one object
+// server. createTransferFiles takes the straight-line path for this shape:
+// build the attempt list, count the file, submit it.
+func newSubmitTestJob(ctx context.Context, host string) *clientTransferJob {
+	return &clientTransferJob{
+		uuid: uuid.New(),
+		job: &TransferJob{
+			uuid:      uuid.New(),
+			ctx:       ctx,
+			xferType:  transferTypeDownload,
+			localPath: "/dev/null",
+			remoteURL: &pelican_url.PelicanURL{
+				Scheme: "pelican://",
+				Host:   "example-federation.org",
+				Path:   "/ns/object",
+			},
+			dirResp: server_structs.DirectorResponse{
+				ObjectServers: []*url.URL{{Scheme: "https", Host: host, Path: "/ns/object"}},
+			},
+		},
+	}
+}
+
+// TestCreateTransferFilesSubmitErrorDoesNotOrphanJob pins what happens when a
+// file is counted against a job and then fails to reach the worker pool for a
+// reason other than a scheduler shed -- in practice, the job's context being
+// cancelled while the job handler is parked handing the file off.
+//
+// No result is ever produced for such a file. If the job kept the file in its
+// totalXfer/activeXfer counts and reported no lookup error, the job would
+// never be considered finished: activeXfer would never reach zero, the
+// client's results channel would never close, and TransferClient.Shutdown()
+// would block forever. The cache hits this path per download, so the leak is
+// one goroutine and one wedged job per cancelled request.
+func TestCreateTransferFilesSubmitErrorDoesNotOrphanJob(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	te := newSubmitTestEngine(ctx)
+
+	jobCtx, jobCancel := context.WithCancel(ctx)
+	job := newSubmitTestJob(jobCtx, "origin.example.com")
+
+	// createTransferFiles parks in the handoff because nothing reads te.files.
+	errCh := make(chan error, 1)
+	go func() { errCh <- te.createTransferFiles(job) }()
+
+	// Wait until the file has actually been counted and the handoff is under
+	// way; cancelling before that would exercise a different path.
+	require.Eventually(t, func() bool { return job.job.activeXfer.Load() == 1 },
+		5*time.Second, time.Millisecond, "expected the file to be counted before submission")
+
+	jobCancel()
+
+	var err error
+	select {
+	case err = <-errCh:
+	case <-ctx.Done():
+		t.Fatal("createTransferFiles never returned after the job context was cancelled")
+	}
+
+	// The error has to reach the caller: runJobHandler stores it as the job's
+	// lookupErr, which is what tells runMux the job is over.
+	require.Error(t, err, "a submission failure must be reported, not swallowed")
+	assert.ErrorIs(t, err, context.Canceled)
+
+	// And the bookkeeping has to be undone, because no result is coming for a
+	// file that was never queued.
+	assert.Zero(t, job.job.activeXfer.Load(), "active count must not outlive the failed submission")
+	assert.Zero(t, job.job.totalXfer, "total count must not outlive the failed submission")
+	assert.Empty(t, te.results, "a submission that never happened produces no result")
+}
+
+// TestCreateTransferFilesSchedulerRejectionCompletesJob pins the other half of
+// the contract. A scheduler shed is not a lookup failure: submitFile has
+// already pushed a synthetic failure result for the file, so the counts must
+// stay as they are and the job must be allowed to complete normally through
+// that result. Reporting a lookup error here instead would double-count the
+// failure; rolling the counts back would leave a result with nothing to
+// decrement.
+func TestCreateTransferFilesSchedulerRejectionCompletesJob(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	te := newSubmitTestEngine(ctx)
+
+	// A scheduler with no room at all: every submission is shed.
+	sched := NewTagScheduler(1, SchedulerConfig{
+		PerTagStarvingPercent: 50,
+		PerTagActivePercent:   50,
+		PendingBufferSize:     1,
+		PerTagPendingSize:     1,
+		EMAWindow:             time.Second,
+	})
+	te.scheduler = sched
+	egrp, _ := errgroup.WithContext(ctx)
+	sched.Start(ctx, egrp, te.files)
+	t.Cleanup(func() {
+		sched.Stop()
+		require.NoError(t, egrp.Wait())
+	})
+
+	// Fill the one pending slot so the next submission has nowhere to go. The
+	// scheduler cannot dispatch it because nothing reads te.files.
+	require.NoError(t, sched.Submit(ctx, "origin.example.com", makeFile("origin.example.com")))
+	require.Eventually(t, func() bool {
+		return sched.Snapshot(ctx).Global.TotalAdmits == 1
+	}, 5*time.Second, time.Millisecond)
+
+	job := newSubmitTestJob(ctx, "origin.example.com")
+	require.NoError(t, te.createTransferFiles(job),
+		"a shed is reported through the results channel, not as a lookup failure")
+
+	assert.Equal(t, 1, job.job.totalXfer, "the shed file is still one of the job's transfers")
+	assert.Equal(t, int64(1), job.job.activeXfer.Load(),
+		"the synthetic result has not been consumed yet, so it is still outstanding")
+
+	// Exactly one result, carrying the retryable throttle error and enough
+	// context for the job-status displays that consume it.
+	require.Len(t, te.results, 1, "a shed file produces exactly one synthetic result")
+	res := <-te.results
+	assert.Equal(t, job.job.uuid, res.results.JobId)
+	assert.ErrorIs(t, res.results.Error, ErrTooManyRequests)
+	assert.True(t, IsRetryable(res.results.Error), "a shed must be retryable")
+	assert.NotNil(t, res.results.Attempts, "job status displays expect a non-nil attempt list")
+}
+
+// TestSchedulerShutdownDrainsQueuedFilesToResults pins the drain that runs
+// when a scheduler stops with transfers still queued. Those transfers will
+// never run, and their jobs are waiting on a result for each one, so the
+// scheduler hands them to the engine's onDrop hook which turns each into a
+// synthetic failure result. Without it a cache shutting down would leave
+// every queued transfer's job waiting forever.
+func TestSchedulerShutdownDrainsQueuedFilesToResults(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	te := newSubmitTestEngine(ctx)
+
+	sched := NewTagScheduler(1, SchedulerConfig{
+		PerTagStarvingPercent: 50,
+		PerTagActivePercent:   50,
+		PendingBufferSize:     10,
+		PerTagPendingSize:     10,
+		EMAWindow:             time.Second,
+	})
+	te.scheduler = sched
+	// Wire the same drain hook NewTransferEngine installs.
+	sched.onDrop = func(file *clientTransferFile) {
+		select {
+		case te.results <- synthesizeRejectionResult(file, errors.New("transfer engine shut down before the transfer could be dispatched")):
+		case <-te.ctx.Done():
+		}
+	}
+	egrp, _ := errgroup.WithContext(ctx)
+	sched.Start(ctx, egrp, te.files)
+
+	// Queue several files for a job. Nothing reads te.files, so at most one
+	// can be in flight and the rest stay in the FIFO.
+	job := newSubmitTestJob(ctx, "origin.example.com")
+	const queued = 5
+	for i := 0; i < queued; i++ {
+		f := makeFile("origin.example.com")
+		f.jobId = job.job.uuid
+		f.file.job = job.job
+		job.job.totalXfer++
+		job.job.activeXfer.Add(1)
+		require.NoError(t, sched.Submit(ctx, "origin.example.com", f))
+	}
+	require.Eventually(t, func() bool {
+		return sched.Snapshot(ctx).Global.TotalAdmits == queued
+	}, 5*time.Second, time.Millisecond)
+
+	sched.Stop()
+	require.NoError(t, egrp.Wait())
+
+	// Every file that was still queued produced a result. One file may have
+	// been handed to te.files instead, so the drained count is the remainder.
+	drained := len(te.results)
+	assert.Positive(t, drained, "queued transfers must not vanish without a result")
+	assert.Equal(t, queued, drained+len(te.files),
+		"every submitted file is accounted for, either dispatched or drained")
+	for i := 0; i < drained; i++ {
+		res := <-te.results
+		assert.Equal(t, job.job.uuid, res.results.JobId)
+		require.Error(t, res.results.Error)
+		assert.NotNil(t, res.results.Attempts,
+			"a drained transfer still needs the fields job status displays read")
+	}
+}

--- a/client/transfer_engine_submit_test.go
+++ b/client/transfer_engine_submit_test.go
@@ -75,7 +75,7 @@ func newSubmitTestJob(ctx context.Context, host string) *clientTransferJob {
 // cancelled while the job handler is parked handing the file off.
 //
 // No result is ever produced for such a file. If the job kept the file in its
-// totalXfer/activeXfer counts and reported no lookup error, the job would
+// activeXfer count and reported no lookup error, the job would
 // never be considered finished: activeXfer would never reach zero, the
 // client's results channel would never close, and TransferClient.Shutdown()
 // would block forever. The cache hits this path per download, so the leak is
@@ -114,7 +114,6 @@ func TestCreateTransferFilesSubmitErrorDoesNotOrphanJob(t *testing.T) {
 	// And the bookkeeping has to be undone, because no result is coming for a
 	// file that was never queued.
 	assert.Zero(t, job.job.activeXfer.Load(), "active count must not outlive the failed submission")
-	assert.Zero(t, job.job.totalXfer, "total count must not outlive the failed submission")
 	assert.Empty(t, te.results, "a submission that never happened produces no result")
 }
 
@@ -157,7 +156,6 @@ func TestCreateTransferFilesSchedulerRejectionCompletesJob(t *testing.T) {
 	require.NoError(t, te.createTransferFiles(job),
 		"a shed is reported through the results channel, not as a lookup failure")
 
-	assert.Equal(t, 1, job.job.totalXfer, "the shed file is still one of the job's transfers")
 	assert.Equal(t, int64(1), job.job.activeXfer.Load(),
 		"the synthetic result has not been consumed yet, so it is still outstanding")
 
@@ -208,7 +206,6 @@ func TestSchedulerShutdownDrainsQueuedFilesToResults(t *testing.T) {
 		f := makeFile("origin.example.com")
 		f.jobId = job.job.uuid
 		f.file.job = job.job
-		job.job.totalXfer++
 		job.job.activeXfer.Add(1)
 		require.NoError(t, sched.Submit(ctx, "origin.example.com", f))
 	}

--- a/client/upload_first_byte_test.go
+++ b/client/upload_first_byte_test.go
@@ -1,0 +1,159 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/pelican_url"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/test_utils"
+)
+
+// The sent-bytes threshold callback fires exactly once, on the read that
+// crosses the threshold, no matter how many reads follow.
+func TestProgressReaderSentThreshold(t *testing.T) {
+	fired := 0
+	pr := &progressReader{
+		reader:          io.NopCloser(strings.NewReader(strings.Repeat("x", 1024))),
+		sizer:           &ConstantSizer{size: 1024},
+		closed:          make(chan bool, 1),
+		sentThreshold:   512,
+		onSentThreshold: func() { fired++ },
+	}
+	buf := make([]byte, 128)
+	for {
+		if _, err := pr.Read(buf); err == io.EOF {
+			break
+		} else {
+			require.NoError(t, err)
+		}
+	}
+	assert.Equal(t, 1, fired, "threshold callback must fire exactly once")
+}
+
+// An upload destination that consumes the request body but does not answer
+// until the body is complete (no 100-continue negotiated) must still be
+// marked non-starving once uploadNonStarvingSentBytes have been consumed —
+// otherwise a long upload to a healthy-but-quiet destination would hold a
+// starving-cap slot for its whole duration.
+func TestUploadSentBytesMarksNonStarving(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	test_utils.InitClient(t, map[param.Param]any{})
+
+	const payloadSize = 6 << 20 // comfortably past the 4 MiB threshold
+
+	var fired atomic.Bool
+	firedCh := make(chan struct{})
+	release := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Report the destination object as absent for the pre-upload stat.
+		if r.Method == "PROPFIND" || r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if r.Method != http.MethodPut {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		// Consume most of the body, then stall without sending a single
+		// response byte until the test has observed the signal. This pins
+		// the sent-bytes path: neither Got100Continue nor
+		// GotFirstResponseByte can have fired yet.
+		if _, err := io.CopyN(io.Discard, r.Body, 5<<20); err != nil {
+			return
+		}
+		<-release
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	localFile := filepath.Join(t.TempDir(), "upload.bin")
+	require.NoError(t, os.WriteFile(localFile, bytes.Repeat([]byte("u"), payloadSize), 0o644))
+
+	transfer := &transferFile{
+		ctx:       context.Background(),
+		localPath: localFile,
+		remoteURL: serverURL,
+		xferType:  transferTypeUpload,
+		job: &TransferJob{
+			remoteURL: &pelican_url.PelicanURL{
+				Scheme: "pelican://",
+				Host:   serverURL.Host,
+				Path:   "/test/upload.bin",
+			},
+			dirResp: server_structs.DirectorResponse{
+				XPelNsHdr: server_structs.XPelNs{
+					CollectionsUrl: serverURL,
+				},
+			},
+		},
+		attempts: []transferAttemptDetails{{Url: serverURL, Proxy: false}},
+		schedFirstByte: func() {
+			if fired.CompareAndSwap(false, true) {
+				close(firedCh)
+			}
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		result, err := uploadObject(transfer)
+		if err == nil {
+			err = result.Error
+		}
+		done <- err
+	}()
+
+	// The non-starving signal must arrive while the server is still mute.
+	select {
+	case <-firedCh:
+	case err := <-done:
+		t.Fatalf("upload finished (err=%v) before the sent-bytes signal fired", err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("sent-bytes threshold never marked the upload non-starving")
+	}
+
+	close(release)
+	select {
+	case err := <-done:
+		require.NoError(t, err, "upload should complete cleanly once the server drains")
+	case <-time.After(30 * time.Second):
+		t.Fatal("upload did not complete after the server was released")
+	}
+}

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -870,6 +870,24 @@ func createTransferError(err error) (transferError *classad.ClassAd) {
 
 	isRetryable := client.IsRetryable(err)
 
+	// A cache throttle (HTTP 429) carries a machine-parseable reason and a
+	// Retry-After hint. The plugin protocol has no retry-delay field and the
+	// plugin must never sleep (HTCondor is timing it), so surface both in
+	// DeveloperData for external retriers and operators reading the job ad.
+	var throttled *client.CacheThrottleError
+	if errors.As(err, &throttled) {
+		if throttled.RetryAfter > 0 {
+			if adErr := developerData.Set("RetryAfterSeconds", int64(throttled.RetryAfter.Seconds())); adErr != nil {
+				log.Errorf("Failed to set RetryAfterSeconds: %s", adErr)
+			}
+		}
+		if throttled.Reason != "" {
+			if adErr := developerData.Set("ThrottleReason", throttled.Reason); adErr != nil {
+				log.Errorf("Failed to set ThrottleReason: %s", adErr)
+			}
+		}
+	}
+
 	var pe *error_codes.PelicanError
 	if errors.As(err, &pe) {
 		err := developerData.Set("PelicanErrorCode", int64(pe.Code()))

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -877,7 +877,10 @@ func createTransferError(err error) (transferError *classad.ClassAd) {
 	var throttled *client.CacheThrottleError
 	if errors.As(err, &throttled) {
 		if throttled.RetryAfter > 0 {
-			if adErr := developerData.Set("RetryAfterSeconds", int64(throttled.RetryAfter.Seconds())); adErr != nil {
+			// Round up: a sub-second hint would truncate to 0, which reads as
+			// "no hint given" rather than "retry almost immediately".
+			secs := int64((throttled.RetryAfter + time.Second - 1) / time.Second)
+			if adErr := developerData.Set("RetryAfterSeconds", secs); adErr != nil {
 				log.Errorf("Failed to set RetryAfterSeconds: %s", adErr)
 			}
 		}

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -2252,3 +2252,128 @@ func TestTransferErrorHeaderTimeout(t *testing.T) {
 		}
 	}
 }
+
+// TestCreateTransferErrorThrottle pins the HTCondor result-ad contract for a
+// transfer shed by a cache's fair scheduler (HTTP 429).
+//
+// The plugin protocol has no retry-delay field and the plugin must never sleep
+// (HTCondor is timing it), so the backoff hint and the machine-parseable shed
+// reason are only visible to external retriers and operators if they are
+// carried in DeveloperData. Dropping either one leaves the job ad saying
+// nothing more than "it failed", and a retrier has no way to distinguish an
+// overloaded cache from an origin that is genuinely broken.
+func TestCreateTransferErrorThrottle(t *testing.T) {
+	newThrottle := func(reason string, retryAfter time.Duration, inner error) *client.CacheThrottleError {
+		return &client.CacheThrottleError{
+			Reason:     reason,
+			RetryAfter: retryAfter,
+			Endpoint:   "cache.example.org:8443",
+			Err:        inner,
+		}
+	}
+
+	t.Run("ReasonAndBackoffSurfaced", func(t *testing.T) {
+		originSlow := error_codes.NewTransfer_OriginSlowError(errors.New("origin is over its share of the transfer pool"))
+		throttled := newThrottle(string(client.ShedOriginSlow), 30*time.Second, originSlow)
+
+		transferError := createTransferError(throttled)
+		devData, ok := classad.GetAs[*classad.ClassAd](transferError, "DeveloperData")
+		require.True(t, ok)
+
+		retryAfterSeconds, ok := classad.GetAs[int64](devData, "RetryAfterSeconds")
+		require.True(t, ok, "a throttled transfer must advertise its backoff hint")
+		assert.Equal(t, int64(30), retryAfterSeconds)
+
+		throttleReason, ok := classad.GetAs[string](devData, "ThrottleReason")
+		require.True(t, ok, "a throttled transfer must advertise the shed reason")
+		assert.Equal(t, string(client.ShedOriginSlow), throttleReason)
+
+		// The shed classification must survive as the Pelican error code, so
+		// the job ad distinguishes a slow origin from a generic transfer
+		// failure.
+		pelicanErrorCode, ok := classad.GetAs[int64](devData, "PelicanErrorCode")
+		require.True(t, ok)
+		assert.Equal(t, int64(6009), pelicanErrorCode)
+		assert.Equal(t, int64(originSlow.Code()), pelicanErrorCode)
+
+		// A shed request is worth retrying; if the ad said otherwise HTCondor
+		// would give up on a transfer that would have succeeded moments later.
+		retryable, ok := classad.GetAs[bool](devData, "Retryable")
+		require.True(t, ok)
+		assert.True(t, retryable)
+
+		errorType, ok := classad.GetAs[string](devData, "ErrorType")
+		require.True(t, ok)
+		assert.Equal(t, "Transfer.OriginSlow", errorType)
+		topErrorType, ok := classad.GetAs[string](transferError, "ErrorType")
+		require.True(t, ok)
+		assert.Equal(t, "Transfer", topErrorType)
+	})
+
+	t.Run("SubSecondBackoffRoundsUp", func(t *testing.T) {
+		// Retry-After is whole seconds. A sub-second hint truncated to 0 reads
+		// as "no hint given" rather than "retry almost immediately", so it must
+		// round up.
+		throttled := newThrottle(string(client.ShedCacheOverloaded), 500*time.Millisecond,
+			error_codes.NewTransfer_CacheOverloadedError(errors.New("cache is shedding load")))
+
+		devData, ok := classad.GetAs[*classad.ClassAd](createTransferError(throttled), "DeveloperData")
+		require.True(t, ok)
+		retryAfterSeconds, ok := classad.GetAs[int64](devData, "RetryAfterSeconds")
+		require.True(t, ok)
+		assert.Equal(t, int64(1), retryAfterSeconds)
+	})
+
+	t.Run("NoHintMeansNoAttribute", func(t *testing.T) {
+		// A cache that shed the request without a Retry-After header leaves the
+		// attribute out entirely rather than claiming a zero-second backoff.
+		throttled := newThrottle(string(client.ShedOriginUnresponsive), 0,
+			error_codes.NewTransfer_OriginUnresponsiveError(errors.New("origin is not answering")))
+
+		devData, ok := classad.GetAs[*classad.ClassAd](createTransferError(throttled), "DeveloperData")
+		require.True(t, ok)
+		_, ok = classad.GetAs[int64](devData, "RetryAfterSeconds")
+		assert.False(t, ok, "no backoff hint means no RetryAfterSeconds attribute")
+		throttleReason, ok := classad.GetAs[string](devData, "ThrottleReason")
+		require.True(t, ok)
+		assert.Equal(t, string(client.ShedOriginUnresponsive), throttleReason)
+	})
+
+	t.Run("NonThrottleErrorHasNoThrottleAttributes", func(t *testing.T) {
+		// The throttle attributes must be specific to a shed request; a
+		// retrier keying off them would otherwise back off on failures that
+		// have nothing to do with load.
+		notFound := error_codes.NewSpecification_FileNotFoundError(errors.New("object does not exist"))
+
+		devData, ok := classad.GetAs[*classad.ClassAd](createTransferError(notFound), "DeveloperData")
+		require.True(t, ok)
+		_, ok = classad.GetAs[int64](devData, "RetryAfterSeconds")
+		assert.False(t, ok)
+		_, ok = classad.GetAs[string](devData, "ThrottleReason")
+		assert.False(t, ok)
+	})
+
+	t.Run("RetryableReachesTheExitCode", func(t *testing.T) {
+		// The retryable flag on the result ad is what the plugin turns into
+		// exit code 11, which is how HTCondor learns to reschedule the
+		// transfer instead of holding the job.
+		throttled := newThrottle(string(client.ShedOriginSlow), 30*time.Second,
+			error_codes.NewTransfer_OriginSlowError(errors.New("origin is over its share of the transfer pool")))
+
+		results := make(chan *classad.ClassAd, 1)
+		failTransfer("pelican://example.org/namespace/object.txt", "/path/to/local.txt", results, false, throttled)
+		resultAd := <-results
+
+		transferRetryable, ok := classad.GetAs[bool](resultAd, "TransferRetryable")
+		require.True(t, ok)
+		assert.True(t, transferRetryable)
+
+		tempFile, err := os.Create(filepath.Join(t.TempDir(), "results.ad"))
+		require.NoError(t, err)
+		defer tempFile.Close()
+		success, retryable, err := writeOutfile(nil, []*classad.ClassAd{resultAd}, tempFile)
+		require.NoError(t, err)
+		assert.False(t, success)
+		assert.True(t, retryable, "a shed transfer must be reported to HTCondor as retryable (exit code 11)")
+	})
+}

--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -161,6 +161,8 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 	v.SetDefault(param.Cache_Throttle_PerOriginPendingSize.GetName(), 50)
 	// Cache.Throttle.PerOriginStarvingPercent
 	v.SetDefault(param.Cache_Throttle_PerOriginStarvingPercent.GetName(), 25)
+	// Cache.Throttle.RetryAfter
+	v.SetDefault(param.Cache_Throttle_RetryAfter.GetName(), "60s")
 	// Cache.Url
 	{
 		val := "https://${Server.Hostname}:${Cache.Port}"

--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -151,6 +151,16 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 		val = strings.ReplaceAll(val, "${Cache.StorageLocation}", v.GetString(param.Cache_StorageLocation.GetName()))
 		v.SetDefault(param.Cache_NamespaceLocation.GetName(), val)
 	}
+	// Cache.Throttle.EMAWindow
+	v.SetDefault(param.Cache_Throttle_EMAWindow.GetName(), "30s")
+	// Cache.Throttle.PendingBufferSize
+	v.SetDefault(param.Cache_Throttle_PendingBufferSize.GetName(), 200)
+	// Cache.Throttle.PerOriginActivePercent
+	v.SetDefault(param.Cache_Throttle_PerOriginActivePercent.GetName(), 90)
+	// Cache.Throttle.PerOriginPendingSize
+	v.SetDefault(param.Cache_Throttle_PerOriginPendingSize.GetName(), 50)
+	// Cache.Throttle.PerOriginStarvingPercent
+	v.SetDefault(param.Cache_Throttle_PerOriginStarvingPercent.GetName(), 25)
 	// Cache.Url
 	{
 		val := "https://${Server.Hostname}:${Cache.Port}"

--- a/docs/error_codes.yaml
+++ b/docs/error_codes.yaml
@@ -265,7 +265,9 @@ description: >-
   A cache refused to admit the upstream fetch because the origin has accepted
   connections but is not delivering data (the origin appears unresponsive). The
   cache shed the request to keep its worker pool available for healthy origins.
-  The client should back off (honoring Retry-After) before trying again.
+  The Retry-After hint is surfaced
+  on the client's typed throttle error for external retriers to honor; the
+  Pelican client itself does not sleep on it.
 retryable: true
 ---
 type: Transfer.OriginSlow
@@ -274,8 +276,9 @@ clientExitCode: 9
 description: >-
   A cache refused to admit the upstream fetch because the origin is transferring
   data but is already holding its fair share of the cache's worker pool. The
-  cache shed the request to keep the pool available for other origins. The client
-  should back off (honoring Retry-After) before trying again.
+  cache shed the request to keep the pool available for other origins. The Retry-After hint is surfaced
+  on the client's typed throttle error for external retriers to honor; the
+  Pelican client itself does not sleep on it.
 retryable: true
 ---
 type: Transfer.CacheOverloaded
@@ -283,6 +286,7 @@ code: 6010
 clientExitCode: 9
 description: >-
   A cache refused to admit the upstream fetch because its global pending buffer
-  is full; the cache is saturated across all origins it is serving. The client
-  should back off (honoring Retry-After) before trying again.
+  is full; the cache is saturated across all origins it is serving. The Retry-After hint is surfaced
+  on the client's typed throttle error for external retriers to honor; the
+  Pelican client itself does not sleep on it.
 retryable: true

--- a/docs/error_codes.yaml
+++ b/docs/error_codes.yaml
@@ -265,9 +265,8 @@ description: >-
   A cache refused to admit the upstream fetch because the origin has accepted
   connections but is not delivering data (the origin appears unresponsive). The
   cache shed the request to keep its worker pool available for healthy origins.
-  The Retry-After hint is surfaced
-  on the client's typed throttle error for external retriers to honor; the
-  Pelican client itself does not sleep on it.
+  The Retry-After hint is surfaced on the client's typed throttle error for
+  external retriers to honor; the Pelican client itself does not sleep on it.
 retryable: true
 ---
 type: Transfer.OriginSlow
@@ -276,17 +275,21 @@ clientExitCode: 9
 description: >-
   A cache refused to admit the upstream fetch because the origin is transferring
   data but is already holding its fair share of the cache's worker pool. The
-  cache shed the request to keep the pool available for other origins. The Retry-After hint is surfaced
-  on the client's typed throttle error for external retriers to honor; the
-  Pelican client itself does not sleep on it.
+  cache shed the request to keep the pool available for other origins. The
+  Retry-After hint is surfaced on the client's typed throttle error for external
+  retriers to honor; the Pelican client itself does not sleep on it.
 retryable: true
 ---
 type: Transfer.CacheOverloaded
 code: 6010
 clientExitCode: 9
 description: >-
-  A cache refused to admit the upstream fetch because its global pending buffer
-  is full; the cache is saturated across all origins it is serving. The Retry-After hint is surfaced
-  on the client's typed throttle error for external retriers to honor; the
-  Pelican client itself does not sleep on it.
+  A server rejected the request because it was at capacity. When a cache's fair
+  scheduler reports this reason, its global pending buffer was full and the
+  cache is saturated across all the origins it serves rather than being held up
+  by any single one of them. This is also the generic classification for a 429
+  that carries no more specific reason, including one from a Pelican service
+  other than a cache. The Retry-After hint is surfaced on the client's typed
+  throttle error for external retriers to honor; the Pelican client itself does
+  not sleep on it.
 retryable: true

--- a/docs/error_codes.yaml
+++ b/docs/error_codes.yaml
@@ -257,3 +257,32 @@ description: >-
   The client required checksum verification but the server did not provide any
   checksum information or only provided unsupported algorithms.
 retryable: true
+---
+type: Transfer.OriginUnresponsive
+code: 6008
+clientExitCode: 9
+description: >-
+  A cache refused to admit the upstream fetch because the origin has accepted
+  connections but is not delivering data (the origin appears unresponsive). The
+  cache shed the request to keep its worker pool available for healthy origins.
+  The client should back off (honoring Retry-After) before trying again.
+retryable: true
+---
+type: Transfer.OriginSlow
+code: 6009
+clientExitCode: 9
+description: >-
+  A cache refused to admit the upstream fetch because the origin is transferring
+  data but is already holding its fair share of the cache's worker pool. The
+  cache shed the request to keep the pool available for other origins. The client
+  should back off (honoring Retry-After) before trying again.
+retryable: true
+---
+type: Transfer.CacheOverloaded
+code: 6010
+clientExitCode: 9
+description: >-
+  A cache refused to admit the upstream fetch because its global pending buffer
+  is full; the cache is saturated across all origins it is serving. The client
+  should back off (honoring Retry-After) before trying again.
+retryable: true

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2654,6 +2654,80 @@ type: int
 default: 100
 components: ["cache"]
 ---
+name: Cache.Throttle.PerOriginStarvingPercent
+description: |+
+  Upper bound, as a percentage of ${Cache.WorkerCount}, that any single upstream origin may
+  hold while its fetches are still "starving" (have not yet received a first byte of data).
+
+  A single misbehaving origin that accepts connections but never delivers bytes can, without
+  this limit, hold every worker until each connection times out (minutes), which makes the
+  cache unresponsive to healthy origins. When this percentage is reached for an origin, further
+  requests targeting that origin are subject to per-origin queueing and eventual 429 shedding.
+
+  Expressed as an integer 0-100. Set to 0 or a value >= 100 to disable this cap (any origin
+  may hold the entire pool).
+type: int
+default: 25
+hidden: true
+components: ["cache"]
+---
+name: Cache.Throttle.PerOriginActivePercent
+description: |+
+  Upper bound, as a percentage of ${Cache.WorkerCount}, that any single upstream origin may
+  hold in total (both starving and actively-transferring fetches).
+
+  This is the higher-limit sibling of ${Cache.Throttle.PerOriginStarvingPercent}: once a
+  fetch has produced at least one byte we consider it healthy and give it a larger share, but
+  we still cap the percentage so that a very large single origin cannot fully monopolise the
+  cache pool.
+
+  Expressed as an integer 0-100. Set to 0 or a value >= 100 to disable this cap.
+type: int
+default: 90
+hidden: true
+components: ["cache"]
+---
+name: Cache.Throttle.PendingBufferSize
+description: |+
+  Total number of upstream-fetch requests the cache's fair scheduler may hold in memory
+  waiting for a worker before it starts shedding load with HTTP 429 responses.
+
+  When the total pending count reaches this value, any additional incoming request is
+  failed immediately with a "too many requests" error rather than being enqueued.
+
+  Set to 0 to disable the fair scheduler entirely (the cache falls back to the raw
+  first-come-first-served channel).
+type: int
+default: 200
+components: ["cache"]
+---
+name: Cache.Throttle.PerOriginPendingSize
+description: |+
+  Per-origin upper bound on the number of pending requests the cache's fair scheduler will
+  queue before it starts shedding load with HTTP 429 responses for that origin.
+
+  This is a per-origin sibling of ${Cache.Throttle.PendingBufferSize}: it prevents a single
+  bad origin from consuming the entire global pending buffer with requests that will never
+  be dispatched.
+type: int
+default: 50
+hidden: true
+components: ["cache"]
+---
+name: Cache.Throttle.EMAWindow
+description: |+
+  Time constant used when computing the exponentially-weighted moving average of active
+  workers per upstream origin. The EMA is used to weight the fair scheduler's random draw
+  across ready origins: origins that have consumed less of the pool recently are more
+  likely to be picked next.
+
+  Shorter values react faster to bursts; longer values are more stable but slower to
+  re-balance after a change.
+type: duration
+default: 30s
+hidden: true
+components: ["cache"]
+---
 name: Cache.AllowedFederations
 description: |+
   A list of federation discovery URLs (or host:port values) that this cache is allowed to serve.

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2733,9 +2733,12 @@ components: ["cache"]
 ---
 name: Cache.Throttle.RetryAfter
 description: |+
-  The backoff duration advertised in the Retry-After header when the cache sheds a
-  request with HTTP 429. This is a hint for clients and external retriers; the cache
-  does not enforce it. Rounded up to whole seconds on the wire.
+  The backoff duration advertised in the Retry-After header on any HTTP 429 the cache
+  returns: a fair-scheduler shed, a 429 passed through from the upstream it was fetching
+  from, or a prestage request refused because the prestage queue is full.
+
+  This is a hint for clients and external retriers; the cache does not enforce it, and
+  the Pelican client does not sleep on it. Rounded up to whole seconds on the wire.
 type: duration
 default: 60s
 hidden: true

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2731,6 +2731,16 @@ default: 30s
 hidden: true
 components: ["cache"]
 ---
+name: Cache.Throttle.RetryAfter
+description: |+
+  The backoff duration advertised in the Retry-After header when the cache sheds a
+  request with HTTP 429. This is a hint for clients and external retriers; the cache
+  does not enforce it. Rounded up to whole seconds on the wire.
+type: duration
+default: 60s
+hidden: true
+components: ["cache"]
+---
 name: Cache.AllowedFederations
 description: |+
   A list of federation discovery URLs (or host:port values) that this cache is allowed to serve.

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -2693,7 +2693,10 @@ description: |+
   waiting for a worker before it starts shedding load with HTTP 429 responses.
 
   When the total pending count reaches this value, any additional incoming request is
-  failed immediately with a "too many requests" error rather than being enqueued.
+  failed immediately with a "too many requests" error rather than being enqueued — except
+  that an origin with nothing queued may always enqueue one request, so a few saturated
+  origins cannot lock every healthy origin out of admission (the buffer may transiently
+  exceed this value by up to one entry per active origin).
 
   Set to 0 to disable the fair scheduler entirely (the cache falls back to the raw
   first-come-first-served channel).

--- a/e2e_fed_tests/scheduler_burst_test.go
+++ b/e2e_fed_tests/scheduler_burst_test.go
@@ -1,0 +1,196 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package fed_tests
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/fed_test_utils"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/test_utils"
+)
+
+// TestScheduler_BurstRejects429 exercises the whole fed under a
+// scheduler tightened enough that a concurrent burst of cache-miss
+// requests forces per-origin admission rejections. The test asserts
+// that at least some of those rejections surface as HTTP 429 with
+// Retry-After: 60 — i.e. the wire contract the cache advertises to
+// clients under overload actually fires under real load, not just in
+// unit-level mocks.
+//
+// Configuration knobs (set via param before NewFedTest):
+//   - Cache.WorkerCount:                    4  — tiny pool
+//   - Cache.Throttle.PerOriginStarvingPercent: 25% (starving cap = 1)
+//   - Cache.Throttle.PerOriginActivePercent:   25% (active cap = 1)
+//   - Cache.Throttle.PendingBufferSize:     2  — very tight
+//   - Cache.Throttle.PerOriginPendingSize:  2
+//   - Cache.Throttle.EMAWindow:             1s
+//
+// With those knobs and a burst of N=30 concurrent requests for
+// distinct objects on the same origin, at most ~3 requests can be
+// admitted at any moment (1 in-flight + 2 pending); the rest fill
+// the FIFO faster than transfers can complete and get 429'd.
+func TestScheduler_BurstRejects429(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	defer server_utils.ResetTestState()
+
+	// Enable the persistent cache and clamp the fair scheduler down.
+	// Params must be set BEFORE NewFedTest starts the servers, since
+	// NewPersistentCache reads them at construction time.
+	require.NoError(t, param.Cache_EnableV2.Set(true))
+	require.NoError(t, param.Cache_WorkerCount.Set(2))
+	require.NoError(t, param.Cache_Throttle_PerOriginStarvingPercent.Set(25))
+	require.NoError(t, param.Cache_Throttle_PerOriginActivePercent.Set(25))
+	require.NoError(t, param.Cache_Throttle_PendingBufferSize.Set(1))
+	require.NoError(t, param.Cache_Throttle_PerOriginPendingSize.Set(1))
+	require.NoError(t, param.Cache_Throttle_EMAWindow.Set(time.Second))
+
+	ft := fed_test_utils.NewFedTest(t, persistentCacheConfig)
+	require.NotNil(t, ft)
+	require.Greater(t, len(ft.Exports), 0)
+
+	// Upload N distinct objects to the origin, one per burst request.
+	// Distinct paths mean distinct persistentDownload entries in the
+	// cache — each has to independently reach scheduler admission
+	// rather than piggybacking on the same in-flight download.
+	//
+	// A modest 256 KiB payload gives the origin enough real transfer
+	// time that concurrent scheduler admissions overlap.
+	const nRequests = 30
+	payload := bytes.Repeat([]byte("scheduler-burst-test-"), 256*1024/21+1)[:256*1024]
+	localDir := t.TempDir()
+	testToken := getTempTokenForTest(t)
+	for i := 0; i < nRequests; i++ {
+		localFile := filepath.Join(localDir, fmt.Sprintf("burst-%d.bin", i))
+		require.NoError(t, os.WriteFile(localFile, payload, 0644))
+		uploadURL := fmt.Sprintf("pelican://%s:%d/test/burst-%d.bin",
+			param.Server_Hostname.GetString(), param.Server_WebPort.GetInt(), i)
+		_, err := client.DoPut(ft.Ctx, localFile, uploadURL, false, client.WithToken(testToken))
+		require.NoError(t, err)
+	}
+
+	// Resolve one director-provided cache URL, then derive the per-
+	// object URL template from it. The redirect looks like:
+	//   https://<cache>/api/v1.0/cache/data/<origin>/test/burst-0.bin?authz=…
+	// so we split at /test/ to pull out the (scheme+host+API+origin)
+	// prefix and the query string, then rebuild for each object.
+	cacheObj0URL := getCacheRedirectURL(ft.Ctx, t, "/test/burst-0.bin", testToken)
+	parsed, err := url.Parse(cacheObj0URL)
+	require.NoError(t, err)
+	require.True(t, strings.HasSuffix(parsed.Path, "/test/burst-0.bin"),
+		"redirect path %q must end with the object path we asked for", parsed.Path)
+	prefix := strings.TrimSuffix(parsed.Path, "/test/burst-0.bin")
+	query := parsed.RawQuery
+	t.Logf("cache base URL: %s://%s%s (query %q)", parsed.Scheme, parsed.Host, prefix, query)
+
+	// Fire the burst.
+	type result struct {
+		status     int
+		retryAfter string
+		err        error
+	}
+	results := make([]result, nRequests)
+	httpClient := &http.Client{
+		Transport: config.GetTransport(),
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			// Follow redirects, but preserve Authorization on same-host hops
+			// so we don't lose the token when the cache HEADs upstream.
+			if len(via) > 5 {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		},
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < nRequests; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			reqURL := &url.URL{
+				Scheme:   parsed.Scheme,
+				Host:     parsed.Host,
+				Path:     fmt.Sprintf("%s/test/burst-%d.bin", prefix, i),
+				RawQuery: query,
+			}
+			req, err := http.NewRequestWithContext(ft.Ctx, http.MethodGet, reqURL.String(), nil)
+			if err != nil {
+				results[i] = result{err: err}
+				return
+			}
+			req.Header.Set("Authorization", "Bearer "+testToken)
+			resp, err := httpClient.Do(req)
+			if err != nil {
+				results[i] = result{err: err}
+				return
+			}
+			defer resp.Body.Close()
+			_, _ = io.Copy(io.Discard, resp.Body)
+			results[i] = result{
+				status:     resp.StatusCode,
+				retryAfter: resp.Header.Get("Retry-After"),
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Tally outcomes.
+	histogram := map[int]int{}
+	var status429, withRetryAfter, errCount int
+	for _, r := range results {
+		if r.err != nil {
+			errCount++
+			continue
+		}
+		histogram[r.status]++
+		if r.status == http.StatusTooManyRequests {
+			status429++
+			if r.retryAfter == "60" {
+				withRetryAfter++
+			}
+		}
+	}
+	t.Logf("burst results: 429=%d (with Retry-After=%d), errors=%d, histogram=%v",
+		status429, withRetryAfter, errCount, histogram)
+
+	require.Greater(t, status429, 0,
+		"tight fair scheduler must produce at least one HTTP 429 across a %d-way concurrent burst; instead got histogram=%v (errors=%d)",
+		nRequests, histogram, errCount)
+	assert.Equal(t, status429, withRetryAfter,
+		"every 429 response must include the documented Retry-After: 60 header")
+}

--- a/e2e_fed_tests/scheduler_burst_test.go
+++ b/e2e_fed_tests/scheduler_burst_test.go
@@ -22,7 +22,6 @@ package fed_tests
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -69,6 +68,27 @@ func isPerOriginShedReason(reason string) bool {
 		reason == string(client.ShedOriginSlow)
 }
 
+// burstOriginConfig is this test's private copy of the persistent-cache origin
+// configuration (resources/persistent_cache_config.yaml) plus one addition:
+// Origin.TransferRateLimit. The shared resource file is used by many other
+// tests that do not want a slow origin, so the knob is added here instead of
+// there.
+//
+// posixv2 is the origin backend that honors the rate limit (see
+// origin_serve/rate_limited_fs.go), and 40 KB/s against a 256 KiB object makes
+// every cache-miss fetch take ~6.5 s. That is what turns this test from a race
+// into arithmetic: the fetch the scheduler admits first is still holding its
+// tag's only active slot when the remaining requests of the burst arrive.
+const burstOriginConfig = `Origin:
+  StorageType: "posixv2"
+  EnableDirectReads: true
+  TransferRateLimit: 40KB/s
+  Exports:
+    - StoragePrefix: /<SHOULD BE OVERRIDDEN>
+      FederationPrefix: /test
+      Capabilities: ["PublicReads", "Writes", "DirectReads", "Listings"]
+`
+
 // burstObjectPath is the federation path of the i'th object of a burst set.
 func burstObjectPath(prefix string, i int) string {
 	return fmt.Sprintf("/test/%s-%d.bin", prefix, i)
@@ -81,19 +101,24 @@ func burstObjectURL(prefix string, i int) string {
 		burstObjectPath(prefix, i))
 }
 
-// uploadBurstObjects uploads n objects with identical contents but distinct
-// paths to the origin. Distinct paths are what make a burst interesting: each
+// stageBurstObjects places n objects with identical contents but distinct
+// paths on the origin. Distinct paths are what make a burst interesting: each
 // one becomes its own cache-miss download inside the cache and therefore has
 // to independently clear scheduler admission, rather than coalescing onto a
 // single in-flight fetch.
-func uploadBurstObjects(ctx context.Context, t *testing.T, prefix string, payload []byte, n int, token string) {
+//
+// The objects are written straight into the origin's storage directory instead
+// of being uploaded through the origin's HTTP interface, because the origin's
+// rate limiter is a single bucket shared by reads and writes: pushing
+// nRequests * 256 KiB through it at 40 KB/s would take minutes and outlive the
+// upload tokens. The rate limit exists to slow the cache's fetches down, not
+// the staging of the test data.
+func stageBurstObjects(t *testing.T, ft *fed_test_utils.FedTest, prefix string, payload []byte, n int) {
 	t.Helper()
-	localDir := t.TempDir()
+	storageDir := ft.Exports[0].StoragePrefix
 	for i := 0; i < n; i++ {
-		localFile := filepath.Join(localDir, fmt.Sprintf("%s-%d.bin", prefix, i))
-		require.NoError(t, os.WriteFile(localFile, payload, 0644))
-		_, err := client.DoPut(ctx, localFile, burstObjectURL(prefix, i), false, client.WithToken(token))
-		require.NoError(t, err)
+		objectFile := filepath.Join(storageDir, fmt.Sprintf("%s-%d.bin", prefix, i))
+		require.NoError(t, os.WriteFile(objectFile, payload, 0644))
 	}
 }
 
@@ -124,12 +149,25 @@ func uploadBurstObjects(ctx context.Context, t *testing.T, prefix string, payloa
 //	Cache.Throttle.PerOriginPendingSize      1
 //	Cache.Throttle.EMAWindow                 1s
 //
+// plus, on the origin side (burstOriginConfig):
+//
+//	Origin.TransferRateLimit                 40KB/s
+//
 // Why that configuration sheds: every object in a burst lives on the same
 // origin, so all admissions share one scheduler tag. That tag may hold a
 // single in-flight transfer (active cap 1) and queue a single pending one
 // (per-origin pending 1), so at most two of a 30-request burst are in the
 // system at any moment and the other ~28 arrive to find the tag's FIFO already
 // full.
+//
+// The rate limit is what makes that deterministic rather than timing-dependent.
+// A 256 KiB object at 40 KB/s takes ~6.5 s to fetch, so the admitted transfer
+// still holds the tag's only active slot for seconds after the burst is issued
+// — the shed count follows from the caps instead of from how fast the origin
+// happens to be. It also keeps the successful requests comfortably inside the
+// budget: only two fetches ever run, back to back, so the slowest 200 response
+// lands ~13 s in, well under the 60 s HTTP client timeout below and under
+// ft.Ctx's deadline (inherited from the go-test timeout).
 //
 // Those rejections are attributed to the origin rather than the cache: the
 // per-origin pending cap is checked before the global pending buffer, and the
@@ -153,19 +191,20 @@ func TestScheduler_BurstRejects429(t *testing.T) {
 	require.NoError(t, param.Cache_Throttle_PerOriginPendingSize.Set(1))
 	require.NoError(t, param.Cache_Throttle_EMAWindow.Set(time.Second))
 
-	ft := fed_test_utils.NewFedTest(t, persistentCacheConfig)
+	ft := fed_test_utils.NewFedTest(t, burstOriginConfig)
 	require.NotNil(t, ft)
 	require.Greater(t, len(ft.Exports), 0)
 
-	// A modest 256 KiB payload gives the origin enough real transfer time that
-	// concurrent scheduler admissions overlap.
+	// A 256 KiB payload against the origin's 40 KB/s limit makes each
+	// cache-miss fetch take ~6.5 s, so an admitted transfer is guaranteed to
+	// still hold its tag's active slot while the rest of the burst arrives.
 	const nRequests = 30
 	const httpPrefix = "burst"
 	const clientPrefix = "client-burst"
 	payload := bytes.Repeat([]byte("scheduler-burst-test-"), 256*1024/21+1)[:256*1024]
 
 	testToken := getTempTokenForTest(t)
-	uploadBurstObjects(ft.Ctx, t, httpPrefix, payload, nRequests, testToken)
+	stageBurstObjects(t, ft, httpPrefix, payload, nRequests)
 
 	// Phase 1: raw HTTP against the cache.
 	//
@@ -300,9 +339,10 @@ func TestScheduler_BurstRejects429(t *testing.T) {
 	//
 	// A fresh object set keeps these downloads on the cache-miss path (a hit
 	// is served from local storage and never reaches the scheduler), and a
-	// fresh token avoids the one-minute lifetime of the phase-1 token.
+	// fresh token avoids the one-minute lifetime of the phase-1 token, which
+	// phase 1 may well have burned through waiting on 40 KB/s fetches.
 	clientToken := getTempTokenForTest(t)
-	uploadBurstObjects(ft.Ctx, t, clientPrefix, payload, nRequests, clientToken)
+	stageBurstObjects(t, ft, clientPrefix, payload, nRequests)
 
 	downloadDir := t.TempDir()
 	clientErrs := make([]error, nRequests)

--- a/e2e_fed_tests/scheduler_burst_test.go
+++ b/e2e_fed_tests/scheduler_burst_test.go
@@ -22,6 +22,9 @@ package fed_tests
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -45,39 +48,108 @@ import (
 	"github.com/pelicanplatform/pelican/test_utils"
 )
 
-// TestScheduler_BurstRejects429 exercises the whole fed under a
-// scheduler tightened enough that a concurrent burst of cache-miss
-// requests forces per-origin admission rejections. The test asserts
-// that at least some of those rejections surface as HTTP 429 with
-// Retry-After: 60 — i.e. the wire contract the cache advertises to
-// clients under overload actually fires under real load, not just in
-// unit-level mocks.
+// validShedReasons is the closed set of machine-parseable reasons a cache may
+// put in the "error" field of a 429 body. The values come from the
+// client.ShedReason constants rather than fresh string literals on purpose:
+// the scheduler, the cache's HTTP layer, and the client's body parser must all
+// agree on the same spelling, and reusing the constants makes any future
+// rename break here instead of silently degrading a production 429 into an
+// unclassifiable throttle.
+var validShedReasons = []string{
+	string(client.ShedOriginUnresponsive),
+	string(client.ShedOriginSlow),
+	string(client.ShedCacheOverloaded),
+}
+
+// isPerOriginShedReason reports whether a reason blames the upstream origin
+// (as opposed to cache-wide saturation). These are the reasons produced by the
+// scheduler's per-origin pending path.
+func isPerOriginShedReason(reason string) bool {
+	return reason == string(client.ShedOriginUnresponsive) ||
+		reason == string(client.ShedOriginSlow)
+}
+
+// burstObjectPath is the federation path of the i'th object of a burst set.
+func burstObjectPath(prefix string, i int) string {
+	return fmt.Sprintf("/test/%s-%d.bin", prefix, i)
+}
+
+// burstObjectURL is the pelican:// URL of the i'th object of a burst set.
+func burstObjectURL(prefix string, i int) string {
+	return fmt.Sprintf("pelican://%s:%d%s",
+		param.Server_Hostname.GetString(), param.Server_WebPort.GetInt(),
+		burstObjectPath(prefix, i))
+}
+
+// uploadBurstObjects uploads n objects with identical contents but distinct
+// paths to the origin. Distinct paths are what make a burst interesting: each
+// one becomes its own cache-miss download inside the cache and therefore has
+// to independently clear scheduler admission, rather than coalescing onto a
+// single in-flight fetch.
+func uploadBurstObjects(ctx context.Context, t *testing.T, prefix string, payload []byte, n int, token string) {
+	t.Helper()
+	localDir := t.TempDir()
+	for i := 0; i < n; i++ {
+		localFile := filepath.Join(localDir, fmt.Sprintf("%s-%d.bin", prefix, i))
+		require.NoError(t, os.WriteFile(localFile, payload, 0644))
+		_, err := client.DoPut(ctx, localFile, burstObjectURL(prefix, i), false, client.WithToken(token))
+		require.NoError(t, err)
+	}
+}
+
+// TestScheduler_BurstRejects429 drives a real federation hard enough that the
+// cache's fair scheduler sheds admissions, then follows a shed out through
+// both surfaces it has to satisfy:
 //
-// Configuration knobs (set via param before NewFedTest):
-//   - Cache.WorkerCount:                    4  — tiny pool
-//   - Cache.Throttle.PerOriginStarvingPercent: 25% (starving cap = 1)
-//   - Cache.Throttle.PerOriginActivePercent:   25% (active cap = 1)
-//   - Cache.Throttle.PendingBufferSize:     2  — very tight
-//   - Cache.Throttle.PerOriginPendingSize:  2
-//   - Cache.Throttle.EMAWindow:             1s
+//  1. Raw HTTP against the cache: status 429, Retry-After: 60, and a JSON body
+//     {"error": <reason>, "detail": ...} whose reason is one of the three
+//     client.ShedReason values.
+//  2. The Pelican client: client.DoGet turns that response into a typed
+//     *client.CacheThrottleError carrying the reason, the parsed Retry-After
+//     duration, and a retryable classification.
 //
-// With those knobs and a burst of N=30 concurrent requests for
-// distinct objects on the same origin, at most ~3 requests can be
-// admitted at any moment (1 in-flight + 2 pending); the rest fill
-// the FIFO faster than transfers can complete and get 429'd.
+// Taken together the phases weld one cross-component contract end to end:
+// scheduler shed reason → cache 429 header + JSON → client body/header
+// parsing → typed retryable error. Unit tests can cover each hop in
+// isolation; only a fed test shows that the hops line up under real load.
+//
+// Configuration (all set before NewFedTest, because NewPersistentCache reads
+// these once at construction time):
+//
+//	Cache.EnableV2                           true — the persistent cache owns the scheduler
+//	Cache.WorkerCount                        2
+//	Cache.Throttle.PerOriginStarvingPercent  25   → starving cap = ceil(2 * 25/100) = 1
+//	Cache.Throttle.PerOriginActivePercent    25   → active cap   = ceil(2 * 25/100) = 1
+//	Cache.Throttle.PendingBufferSize         16
+//	Cache.Throttle.PerOriginPendingSize      1
+//	Cache.Throttle.EMAWindow                 1s
+//
+// Why that configuration sheds: every object in a burst lives on the same
+// origin, so all admissions share one scheduler tag. That tag may hold a
+// single in-flight transfer (active cap 1) and queue a single pending one
+// (per-origin pending 1), so at most two of a 30-request burst are in the
+// system at any moment and the other ~28 arrive to find the tag's FIFO already
+// full.
+//
+// Those rejections are attributed to the origin rather than the cache: the
+// per-origin pending cap is checked before the global pending buffer, and the
+// 16-entry global buffer is comfortably larger than anything one origin can
+// occupy here, so it never becomes the binding limit. The reason is then
+// origin_unresponsive while the tag's in-flight fetch has yet to produce a
+// first byte, or origin_slow once it has. A cache_overloaded verdict is
+// legal but not expected: it requires the tag's FIFO to be full at an instant
+// when the tag holds no in-flight transfer at all.
 func TestScheduler_BurstRejects429(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	server_utils.ResetTestState()
 	defer server_utils.ResetTestState()
 
 	// Enable the persistent cache and clamp the fair scheduler down.
-	// Params must be set BEFORE NewFedTest starts the servers, since
-	// NewPersistentCache reads them at construction time.
 	require.NoError(t, param.Cache_EnableV2.Set(true))
 	require.NoError(t, param.Cache_WorkerCount.Set(2))
 	require.NoError(t, param.Cache_Throttle_PerOriginStarvingPercent.Set(25))
 	require.NoError(t, param.Cache_Throttle_PerOriginActivePercent.Set(25))
-	require.NoError(t, param.Cache_Throttle_PendingBufferSize.Set(1))
+	require.NoError(t, param.Cache_Throttle_PendingBufferSize.Set(16))
 	require.NoError(t, param.Cache_Throttle_PerOriginPendingSize.Set(1))
 	require.NoError(t, param.Cache_Throttle_EMAWindow.Set(time.Second))
 
@@ -85,52 +157,50 @@ func TestScheduler_BurstRejects429(t *testing.T) {
 	require.NotNil(t, ft)
 	require.Greater(t, len(ft.Exports), 0)
 
-	// Upload N distinct objects to the origin, one per burst request.
-	// Distinct paths mean distinct persistentDownload entries in the
-	// cache — each has to independently reach scheduler admission
-	// rather than piggybacking on the same in-flight download.
-	//
-	// A modest 256 KiB payload gives the origin enough real transfer
-	// time that concurrent scheduler admissions overlap.
+	// A modest 256 KiB payload gives the origin enough real transfer time that
+	// concurrent scheduler admissions overlap.
 	const nRequests = 30
+	const httpPrefix = "burst"
+	const clientPrefix = "client-burst"
 	payload := bytes.Repeat([]byte("scheduler-burst-test-"), 256*1024/21+1)[:256*1024]
-	localDir := t.TempDir()
-	testToken := getTempTokenForTest(t)
-	for i := 0; i < nRequests; i++ {
-		localFile := filepath.Join(localDir, fmt.Sprintf("burst-%d.bin", i))
-		require.NoError(t, os.WriteFile(localFile, payload, 0644))
-		uploadURL := fmt.Sprintf("pelican://%s:%d/test/burst-%d.bin",
-			param.Server_Hostname.GetString(), param.Server_WebPort.GetInt(), i)
-		_, err := client.DoPut(ft.Ctx, localFile, uploadURL, false, client.WithToken(testToken))
-		require.NoError(t, err)
-	}
 
-	// Resolve one director-provided cache URL, then derive the per-
-	// object URL template from it. The redirect looks like:
+	testToken := getTempTokenForTest(t)
+	uploadBurstObjects(ft.Ctx, t, httpPrefix, payload, nRequests, testToken)
+
+	// Phase 1: raw HTTP against the cache.
+	//
+	// Resolve one director-provided cache URL, then derive the per-object URL
+	// template from it. The redirect looks like:
 	//   https://<cache>/api/v1.0/cache/data/<origin>/test/burst-0.bin?authz=…
-	// so we split at /test/ to pull out the (scheme+host+API+origin)
+	// so we split at the object path to pull out the (scheme+host+API+origin)
 	// prefix and the query string, then rebuild for each object.
-	cacheObj0URL := getCacheRedirectURL(ft.Ctx, t, "/test/burst-0.bin", testToken)
+	firstObject := burstObjectPath(httpPrefix, 0)
+	cacheObj0URL := getCacheRedirectURL(ft.Ctx, t, firstObject, testToken)
 	parsed, err := url.Parse(cacheObj0URL)
 	require.NoError(t, err)
-	require.True(t, strings.HasSuffix(parsed.Path, "/test/burst-0.bin"),
+	require.True(t, strings.HasSuffix(parsed.Path, firstObject),
 		"redirect path %q must end with the object path we asked for", parsed.Path)
-	prefix := strings.TrimSuffix(parsed.Path, "/test/burst-0.bin")
+	prefix := strings.TrimSuffix(parsed.Path, firstObject)
 	query := parsed.RawQuery
 	t.Logf("cache base URL: %s://%s%s (query %q)", parsed.Scheme, parsed.Host, prefix, query)
 
-	// Fire the burst.
 	type result struct {
 		status     int
 		retryAfter string
-		err        error
+		// reason is the "error" field of a 429 JSON body.
+		reason string
+		err    error
 	}
 	results := make([]result, nRequests)
 	httpClient := &http.Client{
 		Transport: config.GetTransport(),
+		// Bound every request so a stalled cache fails this test with a clear
+		// transport error instead of consuming the package-level go-test
+		// timeout and taking unrelated tests down with it.
+		Timeout: 60 * time.Second,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			// Follow redirects, but preserve Authorization on same-host hops
-			// so we don't lose the token when the cache HEADs upstream.
+			// Follow redirects, but stop after a handful of hops and hand back
+			// the last response rather than erroring out.
 			if len(via) > 5 {
 				return http.ErrUseLastResponse
 			}
@@ -145,7 +215,7 @@ func TestScheduler_BurstRejects429(t *testing.T) {
 			reqURL := &url.URL{
 				Scheme:   parsed.Scheme,
 				Host:     parsed.Host,
-				Path:     fmt.Sprintf("%s/test/burst-%d.bin", prefix, i),
+				Path:     prefix + burstObjectPath(httpPrefix, i),
 				RawQuery: query,
 			}
 			req, err := http.NewRequestWithContext(ft.Ctx, http.MethodGet, reqURL.String(), nil)
@@ -160,21 +230,42 @@ func TestScheduler_BurstRejects429(t *testing.T) {
 				return
 			}
 			defer resp.Body.Close()
-			_, _ = io.Copy(io.Discard, resp.Body)
-			results[i] = result{
+			res := result{
 				status:     resp.StatusCode,
 				retryAfter: resp.Header.Get("Retry-After"),
 			}
+			if resp.StatusCode == http.StatusTooManyRequests {
+				// The reason is the whole point of the 429 body; parse it
+				// rather than discarding it like a successful payload.
+				body, readErr := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+				if readErr != nil {
+					results[i] = result{err: readErr}
+					return
+				}
+				var parsedBody struct {
+					Error  string `json:"error"`
+					Detail string `json:"detail"`
+				}
+				if jsonErr := json.Unmarshal(body, &parsedBody); jsonErr != nil {
+					results[i] = result{err: fmt.Errorf("429 body %q is not JSON: %w", string(body), jsonErr)}
+					return
+				}
+				res.reason = parsedBody.Error
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			results[i] = res
 		}(i)
 	}
 	wg.Wait()
 
 	// Tally outcomes.
 	histogram := map[int]int{}
-	var status429, withRetryAfter, errCount int
+	reasons := map[string]int{}
+	var status429, withRetryAfter, perOriginReasons, errCount int
 	for _, r := range results {
 		if r.err != nil {
 			errCount++
+			t.Logf("transport error during raw burst: %v", r.err)
 			continue
 		}
 		histogram[r.status]++
@@ -183,14 +274,77 @@ func TestScheduler_BurstRejects429(t *testing.T) {
 			if r.retryAfter == "60" {
 				withRetryAfter++
 			}
+			reasons[r.reason]++
+			assert.Contains(t, validShedReasons, r.reason,
+				"429 body must carry one of the machine-parseable shed reasons")
+			if isPerOriginShedReason(r.reason) {
+				perOriginReasons++
+			}
 		}
 	}
-	t.Logf("burst results: 429=%d (with Retry-After=%d), errors=%d, histogram=%v",
-		status429, withRetryAfter, errCount, histogram)
+	t.Logf("raw burst results: 429=%d (with Retry-After=%d), errors=%d, histogram=%v, reasons=%v",
+		status429, withRetryAfter, errCount, histogram, reasons)
 
+	require.Zero(t, errCount,
+		"every raw burst request must complete at the HTTP layer; %d failed in transport", errCount)
 	require.Greater(t, status429, 0,
-		"tight fair scheduler must produce at least one HTTP 429 across a %d-way concurrent burst; instead got histogram=%v (errors=%d)",
-		nRequests, histogram, errCount)
+		"tight fair scheduler must produce at least one HTTP 429 across a %d-way concurrent burst; instead got histogram=%v",
+		nRequests, histogram)
 	assert.Equal(t, status429, withRetryAfter,
 		"every 429 response must include the documented Retry-After: 60 header")
+	assert.Greater(t, perOriginReasons, 0,
+		"the per-origin pending cap must shed at least one request with an origin-specific reason (%s or %s); saw reasons=%v",
+		client.ShedOriginUnresponsive, client.ShedOriginSlow, reasons)
+
+	// Phase 2: the same shed as seen through the Pelican client.
+	//
+	// A fresh object set keeps these downloads on the cache-miss path (a hit
+	// is served from local storage and never reaches the scheduler), and a
+	// fresh token avoids the one-minute lifetime of the phase-1 token.
+	clientToken := getTempTokenForTest(t)
+	uploadBurstObjects(ft.Ctx, t, clientPrefix, payload, nRequests, clientToken)
+
+	downloadDir := t.TempDir()
+	clientErrs := make([]error, nRequests)
+	var clientWg sync.WaitGroup
+	for i := 0; i < nRequests; i++ {
+		clientWg.Add(1)
+		go func(i int) {
+			defer clientWg.Done()
+			dest := filepath.Join(downloadDir, fmt.Sprintf("%s-%d.bin", clientPrefix, i))
+			_, err := client.DoGet(ft.Ctx, burstObjectURL(clientPrefix, i), dest, false,
+				client.WithToken(clientToken))
+			clientErrs[i] = err
+		}(i)
+	}
+	clientWg.Wait()
+
+	var throttledCount, otherErrCount, okCount int
+	clientReasons := map[string]int{}
+	for _, err := range clientErrs {
+		if err == nil {
+			okCount++
+			continue
+		}
+		var throttleErr *client.CacheThrottleError
+		if !errors.As(err, &throttleErr) {
+			otherErrCount++
+			t.Logf("non-throttle client error: %v", err)
+			continue
+		}
+		throttledCount++
+		clientReasons[throttleErr.Reason]++
+		assert.Contains(t, validShedReasons, throttleErr.Reason,
+			"throttle error must carry a reason parsed from the cache's 429 body")
+		assert.Equal(t, 60*time.Second, throttleErr.RetryAfter,
+			"throttle error must carry the cache's Retry-After: 60 as a duration")
+		assert.True(t, client.ShouldRetry(err),
+			"a throttle is transient by construction and must be classified retryable: %v", err)
+	}
+	t.Logf("client burst results: throttled=%d (reasons=%v), other errors=%d, succeeded=%d",
+		throttledCount, clientReasons, otherErrCount, okCount)
+
+	require.Greater(t, throttledCount, 0,
+		"at least one client.DoGet in a %d-way burst must fail with *client.CacheThrottleError; instead got %d successes and %d other errors",
+		nRequests, okCount, otherErrCount)
 }

--- a/error_codes/error_codes.go
+++ b/error_codes/error_codes.go
@@ -346,7 +346,7 @@ func NewTransfer_CacheOverloadedError(err error) *PelicanError {
 		exitCode:    9,
 		code:        6010,
 		retryable:   true,
-		description: "A cache refused to admit the upstream fetch because its global pending buffer is full; the cache is saturated across all origins it is serving. The Retry-After hint is surfaced on the client's typed throttle error for external retriers to honor; the Pelican client itself does not sleep on it.",
+		description: "A server rejected the request because it was at capacity. When a cache's fair scheduler reports this reason, its global pending buffer was full and the cache is saturated across all the origins it serves rather than being held up by any single one of them. This is also the generic classification for a 429 that carries no more specific reason, including one from a Pelican service other than a cache. The Retry-After hint is surfaced on the client's typed throttle error for external retriers to honor; the Pelican client itself does not sleep on it.",
 		err:         err,
 	}
 }

--- a/error_codes/error_codes.go
+++ b/error_codes/error_codes.go
@@ -324,7 +324,7 @@ func NewTransfer_OriginUnresponsiveError(err error) *PelicanError {
 		exitCode:    9,
 		code:        6008,
 		retryable:   true,
-		description: "A cache refused to admit the upstream fetch because the origin has accepted connections but is not delivering data (the origin appears unresponsive). The cache shed the request to keep its worker pool available for healthy origins. The client should back off (honoring Retry-After) before trying again.",
+		description: "A cache refused to admit the upstream fetch because the origin has accepted connections but is not delivering data (the origin appears unresponsive). The cache shed the request to keep its worker pool available for healthy origins. The Retry-After hint is surfaced on the client's typed throttle error for external retriers to honor; the Pelican client itself does not sleep on it.",
 		err:         err,
 	}
 }
@@ -335,7 +335,7 @@ func NewTransfer_OriginSlowError(err error) *PelicanError {
 		exitCode:    9,
 		code:        6009,
 		retryable:   true,
-		description: "A cache refused to admit the upstream fetch because the origin is transferring data but is already holding its fair share of the cache's worker pool. The cache shed the request to keep the pool available for other origins. The client should back off (honoring Retry-After) before trying again.",
+		description: "A cache refused to admit the upstream fetch because the origin is transferring data but is already holding its fair share of the cache's worker pool. The cache shed the request to keep the pool available for other origins. The Retry-After hint is surfaced on the client's typed throttle error for external retriers to honor; the Pelican client itself does not sleep on it.",
 		err:         err,
 	}
 }
@@ -346,7 +346,7 @@ func NewTransfer_CacheOverloadedError(err error) *PelicanError {
 		exitCode:    9,
 		code:        6010,
 		retryable:   true,
-		description: "A cache refused to admit the upstream fetch because its global pending buffer is full; the cache is saturated across all origins it is serving. The client should back off (honoring Retry-After) before trying again.",
+		description: "A cache refused to admit the upstream fetch because its global pending buffer is full; the cache is saturated across all origins it is serving. The Retry-After hint is surfaced on the client's typed throttle error for external retriers to honor; the Pelican client itself does not sleep on it.",
 		err:         err,
 	}
 }

--- a/error_codes/error_codes.go
+++ b/error_codes/error_codes.go
@@ -318,6 +318,39 @@ func NewTransfer_ChecksumMissingError(err error) *PelicanError {
 	}
 }
 
+func NewTransfer_OriginUnresponsiveError(err error) *PelicanError {
+	return &PelicanError{
+		errorType:   "Transfer.OriginUnresponsive",
+		exitCode:    9,
+		code:        6008,
+		retryable:   true,
+		description: "A cache refused to admit the upstream fetch because the origin has accepted connections but is not delivering data (the origin appears unresponsive). The cache shed the request to keep its worker pool available for healthy origins. The client should back off (honoring Retry-After) before trying again.",
+		err:         err,
+	}
+}
+
+func NewTransfer_OriginSlowError(err error) *PelicanError {
+	return &PelicanError{
+		errorType:   "Transfer.OriginSlow",
+		exitCode:    9,
+		code:        6009,
+		retryable:   true,
+		description: "A cache refused to admit the upstream fetch because the origin is transferring data but is already holding its fair share of the cache's worker pool. The cache shed the request to keep the pool available for other origins. The client should back off (honoring Retry-After) before trying again.",
+		err:         err,
+	}
+}
+
+func NewTransfer_CacheOverloadedError(err error) *PelicanError {
+	return &PelicanError{
+		errorType:   "Transfer.CacheOverloaded",
+		exitCode:    9,
+		code:        6010,
+		retryable:   true,
+		description: "A cache refused to admit the upstream fetch because its global pending buffer is full; the cache is saturated across all origins it is serving. The client should back off (honoring Retry-After) before trying again.",
+		err:         err,
+	}
+}
+
 // function that maps the error to the exit code
 func (e *PelicanError) ExitCode() int {
 	return e.exitCode

--- a/local_cache/persistent_cache.go
+++ b/local_cache/persistent_cache.go
@@ -59,6 +59,7 @@ import (
 
 	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/token_scopes"
@@ -176,6 +177,11 @@ type PersistentCache struct {
 
 	// Transfer engine for creating per-request clients
 	te *client.TransferEngine
+
+	// Optional fair scheduler installed on te. Held here so the
+	// per-origin monitoring publisher can Snapshot() it on a fixed
+	// cadence.  nil when Cache.Throttle.PendingBufferSize == 0.
+	scheduler *client.TagScheduler
 
 	// Federation configuration
 	directorURL *url.URL
@@ -636,6 +642,7 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 	// single misbehaving upstream origin cannot monopolise the worker pool
 	// (see Cache.Throttle.* params for the caps).
 	var te *client.TransferEngine
+	var pcScheduler *client.TagScheduler
 	if cfg.Mode == CacheModeServer {
 		workers := param.Cache_WorkerCount.GetInt()
 		if workers <= 0 {
@@ -649,8 +656,8 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 			EMAWindow:             param.Cache_Throttle_EMAWindow.GetDuration(),
 		}
 		if schedCfg.PendingBufferSize > 0 {
-			sched := client.NewTagScheduler(workers, schedCfg)
-			te, err = client.NewTransferEngineWithScheduler(ctx, workers, sched)
+			pcScheduler = client.NewTagScheduler(workers, schedCfg)
+			te, err = client.NewTransferEngineWithScheduler(ctx, workers, pcScheduler)
 		} else {
 			te, err = client.NewTransferEngineWithWorkers(ctx, workers)
 		}
@@ -673,6 +680,7 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 		eviction:        eviction,
 		consistency:     consistency,
 		te:              te,
+		scheduler:       pcScheduler,
 		directorURL:     directorURL,
 		defaultFed:      defaultFed,
 		ac:              newAuthConfig(ctx, egrp),
@@ -711,6 +719,13 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 		return nil
 	})
 
+	// Publish per-origin fair-scheduler metrics to Prometheus on a fixed
+	// cadence. Snapshot() is a channel round-trip through the scheduler
+	// goroutine, so it costs one context switch every tick.
+	if pcScheduler != nil {
+		egrp.Go(func() error { return pc.runSchedulerMetricsPublisher(ctx) })
+	}
+
 	// Register with config's pre-cleanup hook so that the temp-directory
 	// errgroup goroutine waits for BadgerDB to flush before it calls
 	// os.RemoveAll.  pc.Close() is wait-safe: if the errgroup goroutine
@@ -727,6 +742,55 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 	log.Infof("Persistent cache initialized: %s (%d storage dir(s))", cfg.BaseDir, len(storageDirs))
 
 	return pc, nil
+}
+
+// schedulerMetricsPublishInterval is how often the fair-scheduler
+// snapshot gets pushed into Prometheus gauges. Kept short enough
+// that a Prometheus scrape (default 15 s) always sees a fresh value.
+const schedulerMetricsPublishInterval = 5 * time.Second
+
+// runSchedulerMetricsPublisher periodically snapshots pc.scheduler
+// and translates it into the pelican_cache_scheduler_* Prometheus
+// metrics. Exits on ctx cancellation.
+func (pc *PersistentCache) runSchedulerMetricsPublisher(ctx context.Context) error {
+	ticker := time.NewTicker(schedulerMetricsPublishInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			snap := pc.scheduler.Snapshot(ctx)
+			// Snapshot returns zero when the scheduler is stopping;
+			// don't clobber the last-published gauges with zeroes.
+			if snap.Tags == nil && snap.Global.WorkerCount == 0 {
+				continue
+			}
+			global := metrics.SchedulerGlobalStats{
+				WorkerCount:        snap.Global.WorkerCount,
+				StarvingCap:        snap.Global.StarvingCap,
+				ActiveCap:          snap.Global.ActiveCap,
+				TotalPending:       snap.Global.TotalPending,
+				TotalTags:          snap.Global.TotalTags,
+				TotalAdmits:        snap.Global.TotalAdmits,
+				TotalRejects:       snap.Global.TotalRejects,
+				TotalRejectsGlobal: snap.Global.TotalRejectsGlobal,
+				TotalRejectsPerTag: snap.Global.TotalRejectsPerTag,
+			}
+			tags := make(map[string]metrics.SchedulerPerTagStats, len(snap.Tags))
+			for tag, s := range snap.Tags {
+				tags[tag] = metrics.SchedulerPerTagStats{
+					Pending:  s.Pending,
+					Active:   s.Active,
+					Starving: s.Starving,
+					EMA:      s.EMA,
+					Admits:   s.Admits,
+					Rejects:  s.Rejects,
+				}
+			}
+			metrics.PublishCacheSchedulerSnapshot(global, tags)
+		}
+	}
 }
 
 // Config configures the cache and starts periodic updates

--- a/local_cache/persistent_cache.go
+++ b/local_cache/persistent_cache.go
@@ -751,24 +751,36 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 // turning the scheduler off; the engine then runs on the plain
 // first-come-first-served channel.
 func newCacheScheduler(mode CacheMode) (workers int, sched *client.TagScheduler) {
+	workers, schedCfg := cacheSchedulerConfig(mode)
+	if workers <= 0 || schedCfg.PendingBufferSize <= 0 {
+		return workers, nil
+	}
+	return workers, client.NewTagScheduler(workers, schedCfg)
+}
+
+// cacheSchedulerConfig reads the worker count and the fair-scheduler settings
+// for `mode` out of the Cache.* parameters. Split out from newCacheScheduler
+// so the parameter-to-field mapping can be asserted directly: a scheduler that
+// has been handed the wrong knob still constructs and still looks healthy, so
+// nothing downstream would notice a transposed pair.
+//
+// A zero worker count means this mode runs unscheduled on the engine's own
+// default.
+func cacheSchedulerConfig(mode CacheMode) (workers int, cfg client.SchedulerConfig) {
 	if mode != CacheModeServer {
-		return 0, nil
+		return 0, client.SchedulerConfig{}
 	}
 	workers = param.Cache_WorkerCount.GetInt()
 	if workers <= 0 {
 		workers = 100
 	}
-	schedCfg := client.SchedulerConfig{
+	return workers, client.SchedulerConfig{
 		PerTagStarvingPercent: param.Cache_Throttle_PerOriginStarvingPercent.GetInt(),
 		PerTagActivePercent:   param.Cache_Throttle_PerOriginActivePercent.GetInt(),
 		PendingBufferSize:     param.Cache_Throttle_PendingBufferSize.GetInt(),
 		PerTagPendingSize:     param.Cache_Throttle_PerOriginPendingSize.GetInt(),
 		EMAWindow:             param.Cache_Throttle_EMAWindow.GetDuration(),
 	}
-	if schedCfg.PendingBufferSize <= 0 {
-		return workers, nil
-	}
-	return workers, client.NewTagScheduler(workers, schedCfg)
 }
 
 // schedulerMetricsPublishInterval is how often the fair-scheduler

--- a/local_cache/persistent_cache.go
+++ b/local_cache/persistent_cache.go
@@ -755,6 +755,12 @@ const schedulerMetricsPublishInterval = 5 * time.Second
 func (pc *PersistentCache) runSchedulerMetricsPublisher(ctx context.Context) error {
 	ticker := time.NewTicker(schedulerMetricsPublishInterval)
 	defer ticker.Stop()
+	// The scheduler gauges describe instantaneous state; once this cache is
+	// gone they would otherwise keep reporting whatever was true at the last
+	// tick. Clearing them also resets the counter-delta bookkeeping, which
+	// matters when another cache is created in the same process (tests do
+	// this routinely).
+	defer metrics.ResetCacheSchedulerMetrics()
 	for {
 		select {
 		case <-ctx.Done():

--- a/local_cache/persistent_cache.go
+++ b/local_cache/persistent_cache.go
@@ -631,13 +631,29 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 	// transfer workers than the command-line client's small default
 	// (Client.WorkerCount).  Use Cache.WorkerCount for the server; the
 	// client-side local cache keeps the client default.
+	//
+	// The server-mode engine is also wired with a TagScheduler so that a
+	// single misbehaving upstream origin cannot monopolise the worker pool
+	// (see Cache.Throttle.* params for the caps).
 	var te *client.TransferEngine
 	if cfg.Mode == CacheModeServer {
 		workers := param.Cache_WorkerCount.GetInt()
 		if workers <= 0 {
 			workers = 100
 		}
-		te, err = client.NewTransferEngineWithWorkers(ctx, workers)
+		schedCfg := client.SchedulerConfig{
+			PerTagStarvingPercent: param.Cache_Throttle_PerOriginStarvingPercent.GetInt(),
+			PerTagActivePercent:   param.Cache_Throttle_PerOriginActivePercent.GetInt(),
+			PendingBufferSize:     param.Cache_Throttle_PendingBufferSize.GetInt(),
+			PerTagPendingSize:     param.Cache_Throttle_PerOriginPendingSize.GetInt(),
+			EMAWindow:             param.Cache_Throttle_EMAWindow.GetDuration(),
+		}
+		if schedCfg.PendingBufferSize > 0 {
+			sched := client.NewTagScheduler(workers, schedCfg)
+			te, err = client.NewTransferEngineWithScheduler(ctx, workers, sched)
+		} else {
+			te, err = client.NewTransferEngineWithWorkers(ctx, workers)
+		}
 	} else {
 		te, err = client.NewTransferEngine(ctx)
 	}

--- a/local_cache/persistent_cache.go
+++ b/local_cache/persistent_cache.go
@@ -657,9 +657,9 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 		}
 		if schedCfg.PendingBufferSize > 0 {
 			pcScheduler = client.NewTagScheduler(workers, schedCfg)
-			te, err = client.NewTransferEngineWithScheduler(ctx, workers, pcScheduler)
+			te, err = client.NewTransferEngine(ctx, client.WithWorkerCount(workers), client.WithScheduler(pcScheduler))
 		} else {
-			te, err = client.NewTransferEngineWithWorkers(ctx, workers)
+			te, err = client.NewTransferEngine(ctx, client.WithWorkerCount(workers))
 		}
 	} else {
 		te, err = client.NewTransferEngine(ctx)

--- a/local_cache/persistent_cache.go
+++ b/local_cache/persistent_cache.go
@@ -633,36 +633,17 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 		return nil, errors.Wrap(err, "failed to initialize client")
 	}
 
-	// The cache server serves many clients concurrently, so it needs far more
-	// transfer workers than the command-line client's small default
-	// (Client.WorkerCount).  Use Cache.WorkerCount for the server; the
-	// client-side local cache keeps the client default.
-	//
-	// The server-mode engine is also wired with a TagScheduler so that a
-	// single misbehaving upstream origin cannot monopolise the worker pool
-	// (see Cache.Throttle.* params for the caps).
+	// Initialize the transfer engine, sized and (for a cache server) governed
+	// by newCacheScheduler.
 	var te *client.TransferEngine
-	var pcScheduler *client.TagScheduler
-	if cfg.Mode == CacheModeServer {
-		workers := param.Cache_WorkerCount.GetInt()
-		if workers <= 0 {
-			workers = 100
-		}
-		schedCfg := client.SchedulerConfig{
-			PerTagStarvingPercent: param.Cache_Throttle_PerOriginStarvingPercent.GetInt(),
-			PerTagActivePercent:   param.Cache_Throttle_PerOriginActivePercent.GetInt(),
-			PendingBufferSize:     param.Cache_Throttle_PendingBufferSize.GetInt(),
-			PerTagPendingSize:     param.Cache_Throttle_PerOriginPendingSize.GetInt(),
-			EMAWindow:             param.Cache_Throttle_EMAWindow.GetDuration(),
-		}
-		if schedCfg.PendingBufferSize > 0 {
-			pcScheduler = client.NewTagScheduler(workers, schedCfg)
-			te, err = client.NewTransferEngine(ctx, client.WithWorkerCount(workers), client.WithScheduler(pcScheduler))
-		} else {
-			te, err = client.NewTransferEngine(ctx, client.WithWorkerCount(workers))
-		}
-	} else {
+	workers, pcScheduler := newCacheScheduler(cfg.Mode)
+	switch {
+	case workers <= 0:
 		te, err = client.NewTransferEngine(ctx)
+	case pcScheduler != nil:
+		te, err = client.NewTransferEngine(ctx, client.WithWorkerCount(workers), client.WithScheduler(pcScheduler))
+	default:
+		te, err = client.NewTransferEngine(ctx, client.WithWorkerCount(workers))
 	}
 	if err != nil {
 		db.Close()
@@ -742,6 +723,44 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 	log.Infof("Persistent cache initialized: %s (%d storage dir(s))", cfg.BaseDir, len(storageDirs))
 
 	return pc, nil
+}
+
+// newCacheScheduler decides how the persistent cache's transfer engine is
+// sized and whether it gets a per-origin fair scheduler.
+//
+// A cache server serves many clients concurrently, so it needs far more
+// transfer workers than the command-line client's small default
+// (Client.WorkerCount); it uses Cache.WorkerCount instead. It also gets a
+// TagScheduler, so that one misbehaving upstream origin cannot hold the whole
+// worker pool on stalled connections and make the cache look unresponsive to
+// every client (see the Cache.Throttle.* parameters for the caps).
+//
+// The local (client-side) cache serves a single process rather than many
+// tenants, so it keeps the client defaults and runs unscheduled: a zero worker
+// count means "let the engine choose".
+//
+// Setting Cache.Throttle.PendingBufferSize to 0 is the operator's switch for
+// turning the scheduler off; the engine then runs on the plain
+// first-come-first-served channel.
+func newCacheScheduler(mode CacheMode) (workers int, sched *client.TagScheduler) {
+	if mode != CacheModeServer {
+		return 0, nil
+	}
+	workers = param.Cache_WorkerCount.GetInt()
+	if workers <= 0 {
+		workers = 100
+	}
+	schedCfg := client.SchedulerConfig{
+		PerTagStarvingPercent: param.Cache_Throttle_PerOriginStarvingPercent.GetInt(),
+		PerTagActivePercent:   param.Cache_Throttle_PerOriginActivePercent.GetInt(),
+		PendingBufferSize:     param.Cache_Throttle_PendingBufferSize.GetInt(),
+		PerTagPendingSize:     param.Cache_Throttle_PerOriginPendingSize.GetInt(),
+		EMAWindow:             param.Cache_Throttle_EMAWindow.GetDuration(),
+	}
+	if schedCfg.PendingBufferSize <= 0 {
+		return workers, nil
+	}
+	return workers, client.NewTagScheduler(workers, schedCfg)
 }
 
 // schedulerMetricsPublishInterval is how often the fair-scheduler

--- a/local_cache/persistent_cache.go
+++ b/local_cache/persistent_cache.go
@@ -532,6 +532,20 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 		return nil, errors.Wrap(err, "failed to initialize storage manager")
 	}
 
+	// From here on the storage manager owns eviction-loop goroutines running on
+	// the caller's errgroup, and those loops only exit on Close() -- cancelling
+	// the context does not reach them. Every failure past this point therefore
+	// has to shut the storage manager down as well as the database, or the
+	// errgroup never drains: the caller is left waiting on workers belonging to
+	// a cache that was never returned. In `pelican cache serve` that wait
+	// happens before the logs are flushed and the exit code is chosen, so a
+	// startup failure would wedge the process without reporting anything.
+	failInit := func(err error) (*PersistentCache, error) {
+		storage.Close()
+		db.Close()
+		return nil, err
+	}
+
 	// Build eviction dir configs now that we know storageID → path mapping.
 	// GetDirs() returns paths with /objects appended; strip the suffix to
 	// match against the original config paths.
@@ -541,8 +555,7 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 		sd, ok := sdCfgByPath[basePath]
 		if !ok {
 			// Should not happen — every directory in GetDirs was passed in.
-			db.Close()
-			return nil, errors.Errorf("storage directory %q not found in config", basePath)
+			return failInit(errors.Errorf("storage directory %q not found in config", basePath))
 		}
 
 		// Resolve per-dir size.  0 means auto-detect from filesystem.
@@ -553,8 +566,7 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 		if maxSz == 0 {
 			cs, err := getCacheSize(sd.Path, db, id)
 			if err != nil {
-				db.Close()
-				return nil, errors.Wrapf(err, "failed to determine size for storage dir %q", sd.Path)
+				return failInit(errors.Wrapf(err, "failed to determine size for storage dir %q", sd.Path))
 			}
 			maxSz = cs
 		}
@@ -602,14 +614,12 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 	// Get federation info
 	fedInfo, err := config.GetFederation(ctx)
 	if err != nil {
-		db.Close()
-		return nil, errors.Wrap(err, "failed to get federation info")
+		return failInit(errors.Wrap(err, "failed to get federation info"))
 	}
 
 	directorURL, err := url.Parse(fedInfo.DirectorEndpoint)
 	if err != nil {
-		db.Close()
-		return nil, errors.Wrap(err, "failed to parse director URL")
+		return failInit(errors.Wrap(err, "failed to parse director URL"))
 	}
 
 	// Derive the default federation identity from the discovery endpoint.
@@ -629,8 +639,7 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 
 	// Initialize transfer engine
 	if err := config.InitClient(); err != nil {
-		db.Close()
-		return nil, errors.Wrap(err, "failed to initialize client")
+		return failInit(errors.Wrap(err, "failed to initialize client"))
 	}
 
 	// Initialize the transfer engine, sized and (for a cache server) governed
@@ -646,8 +655,7 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 		te, err = client.NewTransferEngine(ctx, client.WithWorkerCount(workers))
 	}
 	if err != nil {
-		db.Close()
-		return nil, errors.Wrap(err, "failed to create transfer engine")
+		return failInit(errors.Wrap(err, "failed to create transfer engine"))
 	}
 
 	downloadCtx, downloadCancel := context.WithCancel(ctx)

--- a/local_cache/persistent_cache_api.go
+++ b/local_cache/persistent_cache_api.go
@@ -263,6 +263,21 @@ func anyAttemptNotFound(err error) bool {
 // fileNotFoundErrorCode is error_codes' Specification.FileNotFound.
 const fileNotFoundErrorCode = 5011
 
+// validShedReason returns reason if it is one of the known shed reasons, and
+// the generic "too_many_requests" otherwise.
+//
+// The value is written to the machine-parseable "error" field of a 429 body,
+// so it must come from a fixed vocabulary. Callers can reach here holding a
+// reason that arrived from an upstream server, and an arbitrary string echoed
+// to a client would flow onward into its logs and job ads.
+func validShedReason(reason string) string {
+	switch client.ShedReason(reason) {
+	case client.ShedOriginUnresponsive, client.ShedOriginSlow, client.ShedCacheOverloaded:
+		return reason
+	}
+	return "too_many_requests"
+}
+
 // handleError writes a structured JSON error response based on the error type.
 // The reqLog entry carries request-scoped fields (method, path, reqId) so that
 // every log line emitted here is correlated with the original request.
@@ -308,9 +323,14 @@ func handleError(w http.ResponseWriter, getErr error, sendTrailer bool, reqLog *
 		var rej *client.SchedulerRejection
 		var throttled *client.CacheThrottleError
 		if errors.As(getErr, &rej) {
-			errCode = string(rej.Reason)
+			errCode = validShedReason(string(rej.Reason))
 		} else if errors.As(getErr, &throttled) && throttled.Reason != "" {
-			errCode = throttled.Reason
+			// This reason originated at whatever upstream answered our fetch.
+			// It is validated where the response is parsed, but it reaches here
+			// through an exported field on an exported type, so re-check it
+			// rather than trusting a caller elsewhere to have done so: it is
+			// about to be echoed to a client as a machine-parseable value.
+			errCode = validShedReason(throttled.Reason)
 		}
 		reqLog.Warnf("Rejecting fetch with 429 (%s): %v", errCode, getErr)
 		w.Header().Set("Retry-After", retryAfterValue())

--- a/local_cache/persistent_cache_api.go
+++ b/local_cache/persistent_cache_api.go
@@ -213,10 +213,18 @@ func handleError(w http.ResponseWriter, getErr error, sendTrailer bool, reqLog *
 	} else if errors.Is(getErr, client.ErrTooManyRequests) {
 		// The cache's fair scheduler refused to admit this upstream fetch
 		// because the origin (or the global pending buffer) is at its cap.
-		// Ask the client to retry after a moment.
-		reqLog.Warn("Cache scheduler rejected upstream fetch: ", getErr)
+		// Ask the client to retry after a moment, and surface the specific
+		// reason so the client can distinguish an unresponsive origin from a
+		// merely-slow one or a cache-wide overload.  The "error" field is the
+		// machine-parseable reason; the client maps it to a Pelican error code.
+		errCode := "too_many_requests"
+		var rej *client.SchedulerRejection
+		if errors.As(getErr, &rej) {
+			errCode = string(rej.Reason)
+		}
+		reqLog.Warnf("Cache scheduler rejected upstream fetch (%s): %v", errCode, getErr)
 		w.Header().Set("Retry-After", "60")
-		writeJSON(http.StatusTooManyRequests, "too_many_requests", getErr.Error())
+		writeJSON(http.StatusTooManyRequests, errCode, getErr.Error())
 		return
 	}
 

--- a/local_cache/persistent_cache_api.go
+++ b/local_cache/persistent_cache_api.go
@@ -191,7 +191,7 @@ func retryAfterValue() string {
 
 // onlyThrottled reports whether err represents throttling and nothing else.
 //
-// A cache fetch accumulates one error per object server it tried
+// A download accumulates one error per object server it tried
 // (client.TransferErrors implements Unwrap() []error), so a plain
 // errors.Is(err, ErrTooManyRequests) is true when *any* single attempt was
 // shed. Answering 429 on that basis would let one throttled origin mask a
@@ -199,6 +199,12 @@ func retryAfterValue() string {
 // A returns 404 and B is throttled would be reported to the client as "retry
 // later", and it would retry forever for an object that does not exist. Only
 // take the throttle path when there is no more specific failure to report.
+//
+// Note this only helps where the errors are actually accumulated. statHttp
+// keeps just the first error across its endpoints rather than building a
+// multi-error, so on the HEAD/stat path a throttle from whichever endpoint
+// answered first still hides another endpoint's not-found. Fixing that means
+// changing how stat aggregates, not how the result is classified here.
 func onlyThrottled(err error) bool {
 	if err == nil {
 		return false
@@ -238,6 +244,10 @@ func onlyThrottled(err error) bool {
 // origin was throttled and another answered "not found", that ordering decides
 // whether the client is told 404 or something far less useful, so the
 // definitive answer is searched for explicitly instead.
+//
+// This only ranks not-found above the *unclassified* remainder. A status code
+// relayed from upstream, and an authorization failure, still win: they say
+// something about the object that a sibling's 404 does not.
 func anyAttemptNotFound(err error) bool {
 	for cur := err; cur != nil; {
 		if pe, ok := cur.(*error_codes.PelicanError); ok && pe.Code() == fileNotFoundErrorCode {
@@ -342,22 +352,24 @@ func handleError(w http.ResponseWriter, getErr error, sendTrailer bool, reqLog *
 	var sce *client.StatusCodeError
 	var pe *error_codes.PelicanError
 	var netErr net.Error
-	if anyAttemptNotFound(getErr) {
-		// A definitive "the object is not here" from any object server beats
-		// the transient failures the other attempts may have reported: a 404
-		// tells the client to stop, where a 429 or 500 tells it to come back
-		// for an object that will never exist.
-		writeJSON(http.StatusNotFound, "not_found", getErr.Error())
-	} else if errors.As(getErr, &sce) {
+	if errors.As(getErr, &sce) {
 		code := int(*sce)
 		writeJSON(code, http.StatusText(code), getErr.Error())
 	} else if errors.As(getErr, &pe) {
 		// Map Pelican error codes to HTTP status codes
 		switch {
-		case pe.Code() == fileNotFoundErrorCode:
-			writeJSON(http.StatusNotFound, "not_found", getErr.Error())
 		case pe.Code()/1000 == 4: // Authorization family (4000, 4010, ...)
+			// Ranked above not-found: "you may not read this" is actionable
+			// (refresh a credential) and, unlike a sibling's 404, does not
+			// claim the object is absent.
 			writeJSON(http.StatusForbidden, "authorization_denied", getErr.Error())
+		case pe.Code() == fileNotFoundErrorCode || anyAttemptNotFound(getErr):
+			// A definitive "the object is not here" from any attempt beats a
+			// sibling attempt's transient failure, whichever one errors.As
+			// happened to reach first. Without the second test, a throttle
+			// recorded ahead of the not-found decides the response and the
+			// client is told to come back for an object that will never exist.
+			writeJSON(http.StatusNotFound, "not_found", getErr.Error())
 		default:
 			writeJSON(http.StatusInternalServerError, "internal_error", getErr.Error())
 		}

--- a/local_cache/persistent_cache_api.go
+++ b/local_cache/persistent_cache_api.go
@@ -189,6 +189,44 @@ func retryAfterValue() string {
 	return strconv.FormatInt(secs, 10)
 }
 
+// onlyThrottled reports whether err represents throttling and nothing else.
+//
+// A cache fetch accumulates one error per object server it tried
+// (client.TransferErrors implements Unwrap() []error), so a plain
+// errors.Is(err, ErrTooManyRequests) is true when *any* single attempt was
+// shed. Answering 429 on that basis would let one throttled origin mask a
+// definitive answer from another: a namespace served by origins A and B where
+// A returns 404 and B is throttled would be reported to the client as "retry
+// later", and it would retry forever for an object that does not exist. Only
+// take the throttle path when there is no more specific failure to report.
+func onlyThrottled(err error) bool {
+	if err == nil {
+		return false
+	}
+	if multi, ok := err.(interface{ Unwrap() []error }); ok {
+		children := multi.Unwrap()
+		if len(children) == 0 {
+			return false
+		}
+		for _, child := range children {
+			if !onlyThrottled(child) {
+				return false
+			}
+		}
+		return true
+	}
+	// Descend through a single wrapper so an accumulator nested inside one is
+	// still examined per-attempt rather than collapsed by errors.Is below.
+	if single, ok := err.(interface{ Unwrap() error }); ok {
+		if inner := single.Unwrap(); inner != nil {
+			if _, isMulti := inner.(interface{ Unwrap() []error }); isMulti {
+				return onlyThrottled(inner)
+			}
+		}
+	}
+	return errors.Is(err, client.ErrTooManyRequests)
+}
+
 // handleError writes a structured JSON error response based on the error type.
 // The reqLog entry carries request-scoped fields (method, path, reqId) so that
 // every log line emitted here is correlated with the original request.
@@ -222,7 +260,7 @@ func handleError(w http.ResponseWriter, getErr error, sendTrailer bool, reqLog *
 		reqLog.Warn("Upstream response timeout")
 		writeJSON(http.StatusGatewayTimeout, "upstream_timeout", "upstream response timeout")
 		return
-	} else if errors.Is(getErr, client.ErrTooManyRequests) {
+	} else if onlyThrottled(getErr) {
 		// Either the cache's own fair scheduler refused to admit this
 		// upstream fetch (SchedulerRejection), or the upstream server
 		// answered the fetch with a 429 of its own (CacheThrottleError).

--- a/local_cache/persistent_cache_api.go
+++ b/local_cache/persistent_cache_api.go
@@ -203,29 +203,65 @@ func onlyThrottled(err error) bool {
 	if err == nil {
 		return false
 	}
-	if multi, ok := err.(interface{ Unwrap() []error }); ok {
-		children := multi.Unwrap()
-		if len(children) == 0 {
-			return false
-		}
-		for _, child := range children {
-			if !onlyThrottled(child) {
+	// Walk down the single-error wrappers looking for an accumulator. The
+	// chain can be several links long -- github.com/pkg/errors.Wrap alone adds
+	// two -- so this has to loop rather than peek one level down, or a wrapped
+	// accumulator would collapse into the errors.Is below and lose the
+	// per-attempt detail this function exists to inspect.
+	for cur := err; cur != nil; {
+		if multi, ok := cur.(interface{ Unwrap() []error }); ok {
+			children := multi.Unwrap()
+			if len(children) == 0 {
 				return false
 			}
-		}
-		return true
-	}
-	// Descend through a single wrapper so an accumulator nested inside one is
-	// still examined per-attempt rather than collapsed by errors.Is below.
-	if single, ok := err.(interface{ Unwrap() error }); ok {
-		if inner := single.Unwrap(); inner != nil {
-			if _, isMulti := inner.(interface{ Unwrap() []error }); isMulti {
-				return onlyThrottled(inner)
+			for _, child := range children {
+				if !onlyThrottled(child) {
+					return false
+				}
 			}
+			return true
 		}
+		single, ok := cur.(interface{ Unwrap() error })
+		if !ok {
+			break
+		}
+		cur = single.Unwrap()
 	}
 	return errors.Is(err, client.ErrTooManyRequests)
 }
+
+// anyAttemptNotFound reports whether any attempt in err definitively found the
+// object missing.
+//
+// errors.As stops at the first PelicanError in tree order, which for an
+// accumulator is whatever the first object server happened to return. When one
+// origin was throttled and another answered "not found", that ordering decides
+// whether the client is told 404 or something far less useful, so the
+// definitive answer is searched for explicitly instead.
+func anyAttemptNotFound(err error) bool {
+	for cur := err; cur != nil; {
+		if pe, ok := cur.(*error_codes.PelicanError); ok && pe.Code() == fileNotFoundErrorCode {
+			return true
+		}
+		if multi, ok := cur.(interface{ Unwrap() []error }); ok {
+			for _, child := range multi.Unwrap() {
+				if anyAttemptNotFound(child) {
+					return true
+				}
+			}
+			return false
+		}
+		single, ok := cur.(interface{ Unwrap() error })
+		if !ok {
+			return false
+		}
+		cur = single.Unwrap()
+	}
+	return false
+}
+
+// fileNotFoundErrorCode is error_codes' Specification.FileNotFound.
+const fileNotFoundErrorCode = 5011
 
 // handleError writes a structured JSON error response based on the error type.
 // The reqLog entry carries request-scoped fields (method, path, reqId) so that
@@ -286,13 +322,19 @@ func handleError(w http.ResponseWriter, getErr error, sendTrailer bool, reqLog *
 	var sce *client.StatusCodeError
 	var pe *error_codes.PelicanError
 	var netErr net.Error
-	if errors.As(getErr, &sce) {
+	if anyAttemptNotFound(getErr) {
+		// A definitive "the object is not here" from any object server beats
+		// the transient failures the other attempts may have reported: a 404
+		// tells the client to stop, where a 429 or 500 tells it to come back
+		// for an object that will never exist.
+		writeJSON(http.StatusNotFound, "not_found", getErr.Error())
+	} else if errors.As(getErr, &sce) {
 		code := int(*sce)
 		writeJSON(code, http.StatusText(code), getErr.Error())
 	} else if errors.As(getErr, &pe) {
 		// Map Pelican error codes to HTTP status codes
 		switch {
-		case pe.Code() == 5011: // FileNotFound
+		case pe.Code() == fileNotFoundErrorCode:
 			writeJSON(http.StatusNotFound, "not_found", getErr.Error())
 		case pe.Code()/1000 == 4: // Authorization family (4000, 4010, ...)
 			writeJSON(http.StatusForbidden, "authorization_denied", getErr.Error())

--- a/local_cache/persistent_cache_api.go
+++ b/local_cache/persistent_cache_api.go
@@ -211,18 +211,22 @@ func handleError(w http.ResponseWriter, getErr error, sendTrailer bool, reqLog *
 		writeJSON(http.StatusGatewayTimeout, "upstream_timeout", "upstream response timeout")
 		return
 	} else if errors.Is(getErr, client.ErrTooManyRequests) {
-		// The cache's fair scheduler refused to admit this upstream fetch
-		// because the origin (or the global pending buffer) is at its cap.
+		// Either the cache's own fair scheduler refused to admit this
+		// upstream fetch (SchedulerRejection), or the upstream server
+		// answered the fetch with a 429 of its own (CacheThrottleError).
 		// Ask the client to retry after a moment, and surface the specific
 		// reason so the client can distinguish an unresponsive origin from a
 		// merely-slow one or a cache-wide overload.  The "error" field is the
 		// machine-parseable reason; the client maps it to a Pelican error code.
 		errCode := "too_many_requests"
 		var rej *client.SchedulerRejection
+		var throttled *client.CacheThrottleError
 		if errors.As(getErr, &rej) {
 			errCode = string(rej.Reason)
+		} else if errors.As(getErr, &throttled) && throttled.Reason != "" {
+			errCode = throttled.Reason
 		}
-		reqLog.Warnf("Cache scheduler rejected upstream fetch (%s): %v", errCode, getErr)
+		reqLog.Warnf("Rejecting fetch with 429 (%s): %v", errCode, getErr)
 		w.Header().Set("Retry-After", "60")
 		writeJSON(http.StatusTooManyRequests, errCode, getErr.Error())
 		return

--- a/local_cache/persistent_cache_api.go
+++ b/local_cache/persistent_cache_api.go
@@ -210,6 +210,14 @@ func handleError(w http.ResponseWriter, getErr error, sendTrailer bool, reqLog *
 		reqLog.Warn("Upstream response timeout")
 		writeJSON(http.StatusGatewayTimeout, "upstream_timeout", "upstream response timeout")
 		return
+	} else if errors.Is(getErr, client.ErrTooManyRequests) {
+		// The cache's fair scheduler refused to admit this upstream fetch
+		// because the origin (or the global pending buffer) is at its cap.
+		// Ask the client to retry after a moment.
+		reqLog.Warn("Cache scheduler rejected upstream fetch: ", getErr)
+		w.Header().Set("Retry-After", "60")
+		writeJSON(http.StatusTooManyRequests, "too_many_requests", getErr.Error())
+		return
 	}
 
 	reqLog.Errorln("Failed to get file from cache:", getErr)

--- a/local_cache/persistent_cache_api.go
+++ b/local_cache/persistent_cache_api.go
@@ -177,6 +177,18 @@ func (etr *errorTrackingReader) Read(p []byte) (int, error) {
 	return n, err
 }
 
+// retryAfterValue returns the whole-seconds Retry-After header value
+// advertised on shed (429) responses, from Cache.Throttle.RetryAfter.
+// Unset or non-positive values fall back to 60 seconds.
+func retryAfterValue() string {
+	d := param.Cache_Throttle_RetryAfter.GetDuration()
+	if d <= 0 {
+		d = 60 * time.Second
+	}
+	secs := int64((d + time.Second - 1) / time.Second)
+	return strconv.FormatInt(secs, 10)
+}
+
 // handleError writes a structured JSON error response based on the error type.
 // The reqLog entry carries request-scoped fields (method, path, reqId) so that
 // every log line emitted here is correlated with the original request.
@@ -227,7 +239,7 @@ func handleError(w http.ResponseWriter, getErr error, sendTrailer bool, reqLog *
 			errCode = throttled.Reason
 		}
 		reqLog.Warnf("Rejecting fetch with 429 (%s): %v", errCode, getErr)
-		w.Header().Set("Retry-After", "60")
+		w.Header().Set("Retry-After", retryAfterValue())
 		writeJSON(http.StatusTooManyRequests, errCode, getErr.Error())
 		return
 	}

--- a/local_cache/persistent_cache_api_test.go
+++ b/local_cache/persistent_cache_api_test.go
@@ -101,6 +101,27 @@ func TestHandleErrorTooManyRequests(t *testing.T) {
 		require.Equal(t, "60", rec.Header().Get("Retry-After"))
 	})
 
+	t.Run("StructuredReasonSurfaced", func(t *testing.T) {
+		// A classified SchedulerRejection surfaces its specific reason in
+		// the JSON body's "error" field so the client can distinguish an
+		// unresponsive origin from a merely-slow one.
+		for _, reason := range []client.ShedReason{
+			client.ShedOriginUnresponsive,
+			client.ShedOriginSlow,
+			client.ShedCacheOverloaded,
+		} {
+			rec := httptest.NewRecorder()
+			rej := &client.SchedulerRejection{Reason: reason, Tag: "originA"}
+			handleError(rec, rej, false, reqLog)
+			require.Equal(t, 429, rec.Code)
+			require.Equal(t, "60", rec.Header().Get("Retry-After"))
+			var body map[string]string
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+			assert.Equal(t, string(reason), body["error"],
+				"the structured shed reason must be the machine-parseable error field")
+		}
+	})
+
 	t.Run("UnrelatedErrorStaysNon429", func(t *testing.T) {
 		// A regression guard: any bare error should still take the
 		// existing internal_error / not_found / etc. paths, not fall

--- a/local_cache/persistent_cache_api_test.go
+++ b/local_cache/persistent_cache_api_test.go
@@ -19,9 +19,16 @@
 package local_cache
 
 import (
+	"encoding/json"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/client"
 )
 
 func TestIsFederationAllowed(t *testing.T) {
@@ -57,5 +64,50 @@ func TestIsFederationAllowed(t *testing.T) {
 	t.Run("ListEntryCaseInsensitive", func(t *testing.T) {
 		list := []string{"Allowed.Example.COM:443"}
 		assert.True(t, isFederationAllowed("allowed.example.com:443", primary, list))
+	})
+}
+
+// TestHandleErrorTooManyRequests pins the wire contract for the fair
+// scheduler's shedding path: when the upstream fetch returns
+// client.ErrTooManyRequests, the cache's serveObject error path must
+// answer the client with HTTP 429 and a Retry-After header, not the
+// generic 500. If this test breaks, dashboards and clients relying on
+// the 429 backoff signal will silently degrade.
+func TestHandleErrorTooManyRequests(t *testing.T) {
+	reqLog := log.NewEntry(log.New())
+
+	t.Run("BareSentinel", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		handleError(rec, client.ErrTooManyRequests, false, reqLog)
+		require.Equal(t, 429, rec.Code)
+		require.Equal(t, "60", rec.Header().Get("Retry-After"),
+			"Retry-After should tell the client to back off for 60 seconds")
+		require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+		var body map[string]string
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+		assert.Equal(t, "too_many_requests", body["error"])
+		assert.NotEmpty(t, body["detail"])
+	})
+
+	t.Run("WrappedSentinel", func(t *testing.T) {
+		// The transfer engine wraps the sentinel with a per-origin
+		// context ("pending queue is full", "origin \"…\" pending
+		// queue is full", …); handleError must still recognise it
+		// via errors.Is.
+		rec := httptest.NewRecorder()
+		wrapped := errors.Wrapf(client.ErrTooManyRequests, "origin %q pending queue is full", "originA")
+		handleError(rec, wrapped, false, reqLog)
+		require.Equal(t, 429, rec.Code)
+		require.Equal(t, "60", rec.Header().Get("Retry-After"))
+	})
+
+	t.Run("UnrelatedErrorStaysNon429", func(t *testing.T) {
+		// A regression guard: any bare error should still take the
+		// existing internal_error / not_found / etc. paths, not fall
+		// through the new 429 branch.
+		rec := httptest.NewRecorder()
+		handleError(rec, errors.New("some other error"), false, reqLog)
+		assert.NotEqual(t, 429, rec.Code, "non-scheduler errors must not accidentally map to 429")
+		assert.Empty(t, rec.Header().Get("Retry-After"))
 	})
 }

--- a/local_cache/persistent_cache_api_test.go
+++ b/local_cache/persistent_cache_api_test.go
@@ -401,3 +401,90 @@ func TestHandleErrorShedReasonIsValidated(t *testing.T) {
 		})
 	}
 }
+
+// TestHandleErrorNotFoundDoesNotMaskSpecificFailures pins the other side of the
+// precedence rule: preferring a definitive not-found must not let it swallow an
+// answer that says something more useful about the object.
+//
+// A namespace served by two origins where one holds the object but rejects the
+// caller's token, and the other simply does not have it, has to report the
+// authorization failure. Reporting 404 there tells the client the object does
+// not exist, so it stops rather than refreshing its credential -- the mirror of
+// the masking the not-found preference exists to prevent.
+func TestHandleErrorNotFoundDoesNotMaskSpecificFailures(t *testing.T) {
+	reqLog := log.NewEntry(log.New())
+
+	accumulate := func(errs ...error) error {
+		te := client.NewTransferErrors()
+		for _, err := range errs {
+			te.AddError(err)
+		}
+		return te
+	}
+	notFound := func() error {
+		return error_codes.NewSpecification_FileNotFoundError(errors.New("object does not exist at origin"))
+	}
+	// relayed builds the shape a download produces for an upstream status code:
+	// a StatusCodeError wrapped by the transfer machinery.
+	relayed := func(code int) error {
+		sce := client.StatusCodeError(code)
+		return error_codes.NewTransferError(&client.HttpErrResp{
+			Code: code,
+			Str:  fmt.Sprintf("request failed (HTTP status %d)", code),
+			Err:  &sce,
+		})
+	}
+	unauthorized := func() error {
+		return error_codes.NewAuthorizationError(errors.New("token rejected by origin"))
+	}
+
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{
+			// The object exists behind an origin that refused the token.
+			name:       "RelayedForbiddenBeatsNotFound",
+			err:        accumulate(relayed(http.StatusForbidden), notFound()),
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "RelayedServerErrorBeatsNotFound",
+			err:        accumulate(relayed(http.StatusInternalServerError), notFound()),
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "RelayedRangeNotSatisfiableBeatsNotFound",
+			err:        accumulate(relayed(http.StatusRequestedRangeNotSatisfiable), notFound()),
+			wantStatus: http.StatusRequestedRangeNotSatisfiable,
+		},
+		{
+			// Ordering must not decide it either way.
+			name:       "NotFoundRecordedFirstStillYieldsForbidden",
+			err:        accumulate(notFound(), relayed(http.StatusForbidden)),
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			// An authorization failure carried as a Pelican error, not a
+			// relayed status code, also outranks a sibling's not-found.
+			name:       "AuthorizationBeatsNotFound",
+			err:        accumulate(unauthorized(), notFound()),
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			// And with nothing more specific to say, the not-found stands.
+			name:       "NotFoundAloneIsStillNotFound",
+			err:        accumulate(notFound()),
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			handleError(rec, tt.err, false, reqLog)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}

--- a/local_cache/persistent_cache_api_test.go
+++ b/local_cache/persistent_cache_api_test.go
@@ -20,15 +20,21 @@ package local_cache
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/error_codes"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
 )
 
 func TestIsFederationAllowed(t *testing.T) {
@@ -144,5 +150,197 @@ func TestHandleErrorTooManyRequests(t *testing.T) {
 		handleError(rec, errors.New("some other error"), false, reqLog)
 		assert.NotEqual(t, 429, rec.Code, "non-scheduler errors must not accidentally map to 429")
 		assert.Empty(t, rec.Header().Get("Retry-After"))
+	})
+}
+
+// TestHandleErrorThrottlePrecedence pins the precedence between a throttle and
+// a definitive failure when a fetch tried several object servers.
+//
+// A cache fetch accumulates one error per server it contacted
+// (client.TransferErrors implements Unwrap() []error), so errors.Is finds
+// ErrTooManyRequests as soon as a *single* attempt was shed. Answering 429 on
+// that basis lets a throttled origin mask a definitive answer from another one:
+// a namespace served by origins A and B where A says "not found" and B is
+// throttled would be reported as "retry later", and the client would retry
+// forever for an object that does not exist. The 429 path is only correct when
+// throttling is the *whole* story.
+func TestHandleErrorThrottlePrecedence(t *testing.T) {
+	reqLog := log.NewEntry(log.New())
+
+	// accumulate builds the multi-error the transfer engine hands back after
+	// trying several object servers, one child per attempt.
+	accumulate := func(errs ...error) error {
+		te := client.NewTransferErrors()
+		for _, err := range errs {
+			te.AddError(err)
+		}
+		return te
+	}
+
+	notFound := func() error {
+		return error_codes.NewSpecification_FileNotFoundError(errors.New("object does not exist at origin"))
+	}
+	shed := func() error {
+		return &client.SchedulerRejection{Reason: client.ShedOriginSlow, Tag: "originB"}
+	}
+
+	tests := []struct {
+		name string
+		err  error
+		// wantStatus is the exact status expected; 0 means the only
+		// requirement is that the response is not a 429.
+		wantStatus int
+	}{
+		{
+			// Every server tried was shed: there is nothing more specific to
+			// report, so "retry later" is the honest answer.
+			name:       "AllAttemptsThrottled",
+			err:        accumulate(errors.Wrap(client.ErrTooManyRequests, "origin \"originA\" pending queue is full"), shed()),
+			wantStatus: http.StatusTooManyRequests,
+		},
+		{
+			// One server said the object does not exist. That answer is
+			// definitive and must reach the client, even though a sibling
+			// attempt was shed.
+			name:       "ThrottleDoesNotMaskNotFound",
+			err:        accumulate(client.ErrTooManyRequests, notFound()),
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			// Same, with the attempts recorded in the other order: precedence
+			// must not depend on which server happened to answer first.
+			name:       "NotFoundBeforeThrottle",
+			err:        accumulate(notFound(), client.ErrTooManyRequests),
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			// The accumulator reaches handleError wrapped with transfer
+			// context; the per-attempt errors must still be examined
+			// individually rather than collapsed by errors.Is.
+			name:       "WrappedAccumulatorDoesNotMaskNotFound",
+			err:        fmt.Errorf("failed to download object: %w", accumulate(client.ErrTooManyRequests, notFound())),
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			// errors.Wrap inserts two links (withStack around withMessage),
+			// and this path is wrapped that way in practice. Peeking only a
+			// single level below the top would miss the accumulator entirely
+			// and fall back to the errors.Is answer, which is exactly the
+			// masking this test exists to prevent.
+			name:       "PkgErrorsWrappedAccumulatorDoesNotMaskNotFound",
+			err:        errors.Wrap(accumulate(client.ErrTooManyRequests, notFound()), "failed to download object"),
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			// A structured rejection unwraps to a typed PelicanError, so a
+			// plain errors.As scan finds *its* code first and would answer
+			// 500. The definitive not-found from the sibling attempt still has
+			// to win.
+			name:       "StructuredThrottleDoesNotMaskNotFound",
+			err:        accumulate(shed(), notFound()),
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			// A non-throttle failure of any kind is enough to disqualify the
+			// 429 path: the client is told about the real failure instead of
+			// being sent into an unbounded retry loop.
+			name:       "ThrottleDoesNotMaskOtherFailure",
+			err:        accumulate(shed(), errors.New("connection reset by peer")),
+			wantStatus: 0,
+		},
+		{
+			// The common case: a single shed attempt, not accumulated.
+			name:       "SingleThrottle",
+			err:        shed(),
+			wantStatus: http.StatusTooManyRequests,
+		},
+		{
+			// A lone accumulated throttle is still purely a throttle.
+			name:       "SingleAccumulatedThrottle",
+			err:        accumulate(shed()),
+			wantStatus: http.StatusTooManyRequests,
+		},
+		{
+			// An accumulator with no attempts recorded carries no evidence of
+			// throttling, so it must not be advertised as retryable.
+			name:       "EmptyAccumulator",
+			err:        accumulate(),
+			wantStatus: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			handleError(rec, tt.err, false, reqLog)
+			if tt.wantStatus == 0 {
+				assert.NotEqual(t, http.StatusTooManyRequests, rec.Code,
+					"a throttled attempt must not mask a more specific failure")
+			} else {
+				assert.Equal(t, tt.wantStatus, rec.Code)
+			}
+			if rec.Code == http.StatusTooManyRequests {
+				assert.Equal(t, "60", rec.Header().Get("Retry-After"),
+					"a 429 must always carry the backoff hint")
+			} else {
+				assert.Empty(t, rec.Header().Get("Retry-After"),
+					"only a 429 advertises a backoff")
+			}
+		})
+	}
+}
+
+// TestRetryAfterValue verifies that the advertised backoff comes from
+// Cache.Throttle.RetryAfter. Operators tune this to match how long their cache
+// actually needs to drain; if the parameter were ignored, every deployment
+// would silently advertise the 60s fallback and clients would retry on a
+// schedule unrelated to the cache's real recovery time.
+func TestRetryAfterValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{
+			name:  "ConfiguredValue",
+			value: "90s",
+			want:  "90",
+		},
+		{
+			// Retry-After is whole seconds on the wire. A sub-second setting
+			// must round up: truncating to "0" tells the client to retry
+			// immediately, which turns a shed request into a hot loop against
+			// an already-overloaded cache.
+			name:  "SubSecondRoundsUp",
+			value: "500ms",
+			want:  "1",
+		},
+		{
+			name:  "ZeroFallsBackToDefault",
+			value: "0s",
+			want:  "60",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server_utils.ResetTestState()
+			t.Cleanup(server_utils.ResetTestState)
+			viper.Set(param.Cache_Throttle_RetryAfter.GetName(), tt.value)
+			assert.Equal(t, tt.want, retryAfterValue())
+
+			// The same value is what a shed request actually advertises.
+			rec := httptest.NewRecorder()
+			handleError(rec, client.ErrTooManyRequests, false, log.NewEntry(log.New()))
+			require.Equal(t, http.StatusTooManyRequests, rec.Code)
+			assert.Equal(t, tt.want, rec.Header().Get("Retry-After"))
+		})
+	}
+
+	t.Run("UnsetFallsBackToDefault", func(t *testing.T) {
+		server_utils.ResetTestState()
+		t.Cleanup(server_utils.ResetTestState)
+		assert.Equal(t, "60", retryAfterValue(),
+			"an unconfigured cache must still advertise a sane backoff")
 	})
 }

--- a/local_cache/persistent_cache_api_test.go
+++ b/local_cache/persistent_cache_api_test.go
@@ -344,3 +344,60 @@ func TestRetryAfterValue(t *testing.T) {
 			"an unconfigured cache must still advertise a sane backoff")
 	})
 }
+
+// TestHandleErrorShedReasonIsValidated pins that the machine-parseable "error"
+// field of a 429 body only ever carries a known shed reason.
+//
+// The reason on a CacheThrottleError originated at whatever upstream answered
+// the cache's own fetch. It is validated where that response is parsed, but it
+// travels here on an exported field of an exported type, so nothing structural
+// stops a future caller from setting it to anything at all. Echoing an
+// arbitrary upstream string to a client would hand it onward into that
+// client's logs and HTCondor job ads, where an embedded newline forges records.
+func TestHandleErrorShedReasonIsValidated(t *testing.T) {
+	reqLog := log.NewEntry(log.New())
+
+	known := []string{"origin_unresponsive", "origin_slow", "cache_overloaded"}
+	for _, reason := range known {
+		t.Run("known/"+reason, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			handleError(rec, &client.CacheThrottleError{
+				Reason: reason,
+				Err:    client.ErrTooManyRequests,
+			}, false, reqLog)
+			require.Equal(t, http.StatusTooManyRequests, rec.Code)
+
+			var body map[string]string
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+			assert.Equal(t, reason, body["error"], "a known reason is passed through verbatim")
+		})
+	}
+
+	hostile := []struct {
+		name   string
+		reason string
+	}{
+		{"NewlineInjection", "origin_slow\nlevel=fatal msg=\"forged record\""},
+		{"UnknownVocabulary", "please_stop"},
+		{"CarriageReturn", "origin_slow\r\nSet-Cookie: x=y"},
+		{"Empty", " "},
+	}
+	for _, tt := range hostile {
+		t.Run("rejected/"+tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			handleError(rec, &client.CacheThrottleError{
+				Reason: tt.reason,
+				Err:    client.ErrTooManyRequests,
+			}, false, reqLog)
+			require.Equal(t, http.StatusTooManyRequests, rec.Code,
+				"the response is still a throttle; only the reason is discarded")
+
+			var body map[string]string
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+			assert.Equal(t, "too_many_requests", body["error"],
+				"an unrecognized reason must fall back to the generic vocabulary")
+			assert.NotContains(t, body["error"], "\n")
+			assert.NotContains(t, body["error"], "\r")
+		})
+	}
+}

--- a/local_cache/persistent_cache_api_test.go
+++ b/local_cache/persistent_cache_api_test.go
@@ -122,6 +122,20 @@ func TestHandleErrorTooManyRequests(t *testing.T) {
 		}
 	})
 
+	t.Run("UpstreamThrottlePassesThrough", func(t *testing.T) {
+		// When the upstream server 429s the cache's own fetch, the resulting
+		// client.CacheThrottleError must surface to the remote client as a
+		// 429 with the upstream's reason — not as a misleading 500.
+		rec := httptest.NewRecorder()
+		throttled := &client.CacheThrottleError{Reason: string(client.ShedOriginSlow)}
+		handleError(rec, throttled, false, reqLog)
+		require.Equal(t, 429, rec.Code)
+		require.Equal(t, "60", rec.Header().Get("Retry-After"))
+		var body map[string]string
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+		assert.Equal(t, string(client.ShedOriginSlow), body["error"])
+	})
+
 	t.Run("UnrelatedErrorStaysNon429", func(t *testing.T) {
 		// A regression guard: any bare error should still take the
 		// existing internal_error / not_found / etc. paths, not fall

--- a/local_cache/persistent_cache_leak_test.go
+++ b/local_cache/persistent_cache_leak_test.go
@@ -67,6 +67,11 @@ func TestPersistentCacheFailedInitDrainsErrgroup(t *testing.T) {
 	})
 	require.Error(t, err, "expected construction to fail without a configured federation")
 	require.Nil(t, pc)
+	// Pin where it failed. The point is that construction gets *past* the
+	// storage manager before giving up; if it ever started failing earlier the
+	// errgroup would drain trivially and this test would pass while covering
+	// nothing.
+	require.ErrorContains(t, err, "failed to get federation info")
 
 	// Cancelling the context is the only shutdown lever the caller has left:
 	// the failure returned no handle to close.
@@ -114,6 +119,8 @@ func TestStorageManagerCloseIsSafeWithoutEvictionLoops(t *testing.T) {
 	// variant loads actually exist.
 	writable, err := NewStorageManager(db, []string{tmpDir}, InlineThreshold, egrp)
 	require.NoError(t, err)
+	// First close stops the eviction loops; the goroutine below closes it a
+	// second time.
 	writable.Close()
 
 	readOnly, err := NewStorageManagerReadOnly(tmpDir, db)
@@ -126,6 +133,12 @@ func TestStorageManagerCloseIsSafeWithoutEvictionLoops(t *testing.T) {
 		// A second Close must be safe too: the eviction loops are gone either
 		// way, and a caller that closes defensively should not hang.
 		readOnly.Close()
+		// And on a manager whose loops *were* started: the first Close stopped
+		// them, so the second finds no reader for its stop signal. This is the
+		// case the claim on Close is really about -- the read-only pair above
+		// never had the loops running, so both of its calls are declined by the
+		// same condition.
+		writable.Close()
 	}()
 
 	waitCtx, waitCancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/local_cache/persistent_cache_leak_test.go
+++ b/local_cache/persistent_cache_leak_test.go
@@ -1,0 +1,142 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package local_cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/server_utils"
+)
+
+// TestPersistentCacheFailedInitDrainsErrgroup asserts that a failed
+// NewPersistentCache leaves nothing running in the caller's errgroup.
+//
+// NewPersistentCache launches background workers (the storage manager's TTL
+// eviction loops) partway through construction, before setup steps that can
+// still fail — federation discovery, client init, transfer-engine creation.
+// Those workers are launched on the caller's errgroup and only ever exit when
+// something calls Stop() on them; cancelling the context does not reach them.
+//
+// This matters because callers own that errgroup and eventually block on
+// egrp.Wait(). If a construction failure leaves workers behind, Wait() never
+// returns, so a caller that correctly handles the error still hangs at
+// shutdown: the process cannot exit, and a test binary runs to its timeout
+// instead of reporting the failure.
+func TestPersistentCacheFailedInitDrainsErrgroup(t *testing.T) {
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+	InitIssuerKeyForTests(t) // must follow ResetTestState, which clears the issuer key dir
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	egrp, _ := errgroup.WithContext(ctx)
+
+	// No federation is configured, so the federation lookup partway through
+	// NewPersistentCache fails.  Everything before it — the database and the
+	// storage manager, including its background workers — has already been
+	// built by then.
+	tmpDir := t.TempDir()
+	pc, err := NewPersistentCache(ctx, egrp, PersistentCacheConfig{
+		Mode:        CacheModeServer,
+		BaseDir:     tmpDir,
+		StorageDirs: []StorageDirConfig{{Path: tmpDir}},
+		DeferConfig: true,
+	})
+	require.Error(t, err, "expected construction to fail without a configured federation")
+	require.Nil(t, pc)
+
+	// Cancelling the context is the only shutdown lever the caller has left:
+	// the failure returned no handle to close.
+	cancel()
+
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		_ = egrp.Wait()
+	}()
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer waitCancel()
+	select {
+	case <-drained:
+	case <-waitCtx.Done():
+		t.Fatal("errgroup did not drain after context cancellation: NewPersistentCache " +
+			"left background workers running when it returned an error")
+	}
+}
+
+// TestStorageManagerCloseIsSafeWithoutEvictionLoops asserts that closing a
+// storage manager returns even when its TTL eviction loops were never started,
+// and that closing twice is safe.
+//
+// Stopping a ttlcache hands the eviction loop a value over an unbuffered
+// channel and waits for it to be received, so it blocks forever with no loop
+// running. A read-only manager -- what the offline introspection subcommands
+// build -- never starts those loops, so an unguarded Close deadlocks on exit
+// after the command has already done its work and printed its output.
+func TestStorageManagerCloseIsSafeWithoutEvictionLoops(t *testing.T) {
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+	InitIssuerKeyForTests(t) // must follow ResetTestState, which clears the issuer key dir
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	egrp, _ := errgroup.WithContext(ctx)
+
+	tmpDir := t.TempDir()
+	db, err := NewCacheDB(ctx, tmpDir)
+	require.NoError(t, err)
+
+	// Build a writable manager first so the disk mappings the read-only
+	// variant loads actually exist.
+	writable, err := NewStorageManager(db, []string{tmpDir}, InlineThreshold, egrp)
+	require.NoError(t, err)
+	writable.Close()
+
+	readOnly, err := NewStorageManagerReadOnly(tmpDir, db)
+	require.NoError(t, err)
+
+	closed := make(chan struct{})
+	go func() {
+		defer close(closed)
+		readOnly.Close()
+		// A second Close must be safe too: the eviction loops are gone either
+		// way, and a caller that closes defensively should not hang.
+		readOnly.Close()
+	}()
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer waitCancel()
+	select {
+	case <-closed:
+	case <-waitCtx.Done():
+		t.Fatal("Close blocked on a storage manager whose eviction loops were never started")
+	}
+
+	require.NoError(t, db.Close())
+	cancel()
+	require.NoError(t, egrp.Wait())
+}

--- a/local_cache/prestage_evict_api.go
+++ b/local_cache/prestage_evict_api.go
@@ -392,7 +392,7 @@ func (pc *PersistentCache) prestageHandler(w http.ResponseWriter, r *http.Reques
 
 	// Submit to the per-identity worker pool.
 	if !pc.prestageManager.Submit(ident, req) {
-		w.Header().Set("Retry-After", "60")
+		w.Header().Set("Retry-After", retryAfterValue())
 		http.Error(w, "Too many prestage requests at server", http.StatusTooManyRequests)
 		return
 	}

--- a/local_cache/scheduler_disable_test.go
+++ b/local_cache/scheduler_disable_test.go
@@ -1,0 +1,105 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package local_cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
+)
+
+// setThrottleParams applies a full set of fair-scheduler parameters.
+// newCacheScheduler reads them once, so they all have to be in place first.
+func setThrottleParams(t *testing.T, pendingBuffer int) {
+	t.Helper()
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+	require.NoError(t, param.Cache_WorkerCount.Set(4))
+	require.NoError(t, param.Cache_Throttle_PerOriginStarvingPercent.Set(25))
+	require.NoError(t, param.Cache_Throttle_PerOriginActivePercent.Set(90))
+	require.NoError(t, param.Cache_Throttle_PendingBufferSize.Set(pendingBuffer))
+	require.NoError(t, param.Cache_Throttle_PerOriginPendingSize.Set(8))
+	require.NoError(t, param.Cache_Throttle_EMAWindow.Set(time.Second))
+}
+
+// TestCacheSchedulerDisabledByZeroPendingBuffer pins the escape hatch.
+// Operators need a way to turn the fair scheduler off entirely -- to rule it
+// out while diagnosing something, or because their cache fronts a single
+// origin and admission control only adds latency. Setting
+// Cache.Throttle.PendingBufferSize to 0 is that switch, and it has to leave
+// the engine on the plain unscheduled path rather than merely widening the
+// caps.
+//
+// Note that 0 means something different one layer down: on
+// client.SchedulerConfig the same field name means "queue without a bound".
+// The translation happens here, and getting it backwards would silently turn
+// the operator's "off" into an unbounded queue.
+func TestCacheSchedulerDisabledByZeroPendingBuffer(t *testing.T) {
+	setThrottleParams(t, 0)
+
+	workers, sched := newCacheScheduler(CacheModeServer)
+	assert.Nil(t, sched, "PendingBufferSize=0 must leave the cache with no scheduler at all")
+	assert.Equal(t, 4, workers, "the pool is still sized from Cache.WorkerCount")
+}
+
+// TestCacheSchedulerEnabledInServerMode is the other half of the switch: a
+// cache server with a positive pending buffer gets a scheduler, sized from
+// Cache.WorkerCount. (How the configured percentages become absolute slot
+// counts is the scheduler's own contract, covered in the client package.)
+func TestCacheSchedulerEnabledInServerMode(t *testing.T) {
+	setThrottleParams(t, 16)
+
+	workers, sched := newCacheScheduler(CacheModeServer)
+	require.NotNil(t, sched, "a cache server must get a fair scheduler")
+	assert.Equal(t, 4, workers, "the pool the scheduler shares is Cache.WorkerCount")
+}
+
+// TestCacheSchedulerWorkerCountFallback pins that an unset or nonsensical
+// Cache.WorkerCount does not produce a zero-worker pool, which would deadlock
+// every transfer rather than merely running them slowly.
+func TestCacheSchedulerWorkerCountFallback(t *testing.T) {
+	for _, configured := range []int{0, -1} {
+		setThrottleParams(t, 16)
+		require.NoError(t, param.Cache_WorkerCount.Set(configured))
+
+		workers, sched := newCacheScheduler(CacheModeServer)
+		assert.Positive(t, workers, "worker count %d must fall back to a usable default", configured)
+		require.NotNil(t, sched)
+	}
+}
+
+// TestCacheSchedulerNotWiredOutsideServerMode pins that the local
+// (client-side) cache is left alone. It serves one process rather than many
+// tenants, so per-origin admission control would only get in the way of the
+// very transfers it exists to make fast. A zero worker count tells the engine
+// to keep its own client-side default.
+func TestCacheSchedulerNotWiredOutsideServerMode(t *testing.T) {
+	// Generous throttle settings: the mode, not the configuration, is what
+	// decides whether a scheduler is wired in.
+	setThrottleParams(t, 64)
+
+	workers, sched := newCacheScheduler(CacheModeLocal)
+	assert.Nil(t, sched, "the local cache runs without a fair scheduler")
+	assert.Zero(t, workers, "the local cache keeps the client-side worker default")
+}

--- a/local_cache/scheduler_disable_test.go
+++ b/local_cache/scheduler_disable_test.go
@@ -75,6 +75,33 @@ func TestCacheSchedulerEnabledInServerMode(t *testing.T) {
 	assert.Equal(t, 4, workers, "the pool the scheduler shares is Cache.WorkerCount")
 }
 
+// TestCacheSchedulerConfigMapping pins which parameter feeds which scheduler
+// setting.
+//
+// A scheduler handed the wrong knob still constructs and still looks perfectly
+// healthy -- it just enforces the wrong limit -- so nothing downstream would
+// notice. Transposing the starving and active percentages, for instance, would
+// silently invert the two caps. Every value here is distinct so a swapped pair
+// cannot go unnoticed.
+func TestCacheSchedulerConfigMapping(t *testing.T) {
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+	require.NoError(t, param.Cache_WorkerCount.Set(64))
+	require.NoError(t, param.Cache_Throttle_PerOriginStarvingPercent.Set(11))
+	require.NoError(t, param.Cache_Throttle_PerOriginActivePercent.Set(22))
+	require.NoError(t, param.Cache_Throttle_PendingBufferSize.Set(33))
+	require.NoError(t, param.Cache_Throttle_PerOriginPendingSize.Set(44))
+	require.NoError(t, param.Cache_Throttle_EMAWindow.Set(55*time.Second))
+
+	workers, cfg := cacheSchedulerConfig(CacheModeServer)
+	assert.Equal(t, 64, workers, "Cache.WorkerCount")
+	assert.Equal(t, 11, cfg.PerTagStarvingPercent, "Cache.Throttle.PerOriginStarvingPercent")
+	assert.Equal(t, 22, cfg.PerTagActivePercent, "Cache.Throttle.PerOriginActivePercent")
+	assert.Equal(t, 33, cfg.PendingBufferSize, "Cache.Throttle.PendingBufferSize")
+	assert.Equal(t, 44, cfg.PerTagPendingSize, "Cache.Throttle.PerOriginPendingSize")
+	assert.Equal(t, 55*time.Second, cfg.EMAWindow, "Cache.Throttle.EMAWindow")
+}
+
 // TestCacheSchedulerWorkerCountFallback pins that an unset or nonsensical
 // Cache.WorkerCount does not produce a zero-worker pool, which would deadlock
 // every transfer rather than merely running them slowly.

--- a/local_cache/scheduler_shed_test.go
+++ b/local_cache/scheduler_shed_test.go
@@ -1,0 +1,428 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package local_cache
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/pelican_url"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/test_utils"
+)
+
+const (
+	// slowOriginByteInterval is how long the slow origin waits between the
+	// single bytes it dribbles out. With slowOriginObjectSize below it means a
+	// fetch from that origin cannot possibly finish inside the test: the
+	// transfer is still holding its scheduler slot when every assertion runs.
+	slowOriginByteInterval = 100 * time.Millisecond
+	// slowOriginObjectSize is the advertised size of every object on the slow
+	// origin: 4 KiB at one byte per 100 ms is ~7 minutes of dribbling, which
+	// the test aborts long before it completes.
+	slowOriginObjectSize = 4 * 1024
+
+	// slowRequestCount is how many distinct slow objects are requested at
+	// once. Distinct paths matter: each one becomes its own cache-miss fetch
+	// that must independently clear scheduler admission, instead of coalescing
+	// onto a single in-flight download.
+	slowRequestCount = 10
+)
+
+// TestSchedulerShedPerOriginIsolation proves the central promise of the cache's
+// fair scheduler — one misbehaving origin cannot deny service to the others —
+// without standing up a federation.
+//
+// Two stub origins are put behind a stub director:
+//
+//   - the slow origin accepts every request and then dribbles one byte per
+//     100 ms, so a fetch from it holds a worker slot indefinitely;
+//   - the healthy origin answers immediately with a small object.
+//
+// Because the scheduler tags admissions by the upstream host (see
+// deriveSchedulerTag), and the two stubs listen on different loopback ports,
+// they land on two independent tags whose caps are enforced separately:
+//
+//	Cache.WorkerCount                        2
+//	Cache.Throttle.PerOriginStarvingPercent  25 → starving cap = ceil(2 * 25/100) = 1
+//	Cache.Throttle.PerOriginActivePercent    25 → active cap   = ceil(2 * 25/100) = 1
+//	Cache.Throttle.PerOriginPendingSize      1
+//	Cache.Throttle.PendingBufferSize         16
+//	Cache.Throttle.EMAWindow                 1s
+//
+// So the slow origin's tag may hold one in-flight fetch plus one queued one,
+// and the remaining eight of a ten-way burst arrive to find its FIFO full and
+// are shed with a 429. The global pending buffer (16) is never the binding
+// limit, which is what makes the shed reason a per-origin one
+// (origin_unresponsive while the in-flight fetch has yet to produce a first
+// byte, origin_slow once it has) rather than cache_overloaded.
+//
+// The isolation property is the second assertion: while those slow fetches are
+// still dribbling, a request for an object on the healthy origin is admitted
+// under its own tag and served in full. The third assertion closes the loop
+// through the scheduler's own bookkeeping: every rejection is attributed to the
+// slow origin's tag and none to the healthy one's.
+func TestSchedulerShedPerOriginIsolation(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+	InitIssuerKeyForTests(t) // must follow ResetTestState, which clears the issuer key dir
+
+	ctx, cancel := context.WithCancel(context.Background())
+	egrp, _ := errgroup.WithContext(ctx)
+	// Registered first so it runs last: the origin stubs and the cache have to
+	// be torn down before the errgroup is drained.
+	t.Cleanup(func() {
+		cancel()
+		_ = egrp.Wait()
+	})
+
+	// The transfers here fail on purpose (they are shed, or aborted at
+	// teardown), so keep the log volume down to what a failure needs.
+	require.NoError(t, param.Logging_Level.Set("error"))
+
+	// Clamp the fair scheduler. NewPersistentCache reads these once, at
+	// construction time, so they must all be set before it is called.
+	require.NoError(t, param.Cache_WorkerCount.Set(2))
+	require.NoError(t, param.Cache_Throttle_PerOriginStarvingPercent.Set(25))
+	require.NoError(t, param.Cache_Throttle_PerOriginActivePercent.Set(25))
+	require.NoError(t, param.Cache_Throttle_PendingBufferSize.Set(16))
+	require.NoError(t, param.Cache_Throttle_PerOriginPendingSize.Set(1))
+	require.NoError(t, param.Cache_Throttle_EMAWindow.Set(time.Second))
+	// The stub director and origins are httptest TLS servers with self-signed
+	// certificates; federation discovery is hard-wired to https, so the
+	// transport has to tolerate them.
+	require.NoError(t, param.TLSSkipVerify.Set(true))
+
+	// release aborts every in-flight slow response. Its cleanup is registered
+	// at the end of setup so that it runs *before* the httptest servers are
+	// closed -- Server.Close waits for outstanding handlers to return.
+	release := make(chan struct{})
+
+	// The slow origin: accepts everything, then dribbles.
+	slowSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprint(slowOriginObjectSize))
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.Header().Set("ETag", `"slow-origin-etag"`)
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		flusher, canFlush := w.(http.Flusher)
+		for sent := 0; sent < slowOriginObjectSize; sent++ {
+			select {
+			case <-release:
+				return
+			case <-r.Context().Done():
+				return
+			case <-time.After(slowOriginByteInterval):
+			}
+			if _, err := w.Write([]byte{'s'}); err != nil {
+				return
+			}
+			if canFlush {
+				flusher.Flush()
+			}
+		}
+	}))
+	t.Cleanup(slowSrv.Close)
+
+	// The healthy origin: a small object, served instantly. ServeContent
+	// handles HEAD, Range and the size/ETag headers the way a real origin
+	// would.
+	healthyPayload := bytes.Repeat([]byte("healthy-origin-payload\n"), 64) // ~1.4 KiB, a single block
+	healthyModTime := time.Now().Add(-time.Hour)
+	healthySrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"healthy-origin-etag"`)
+		http.ServeContent(w, r, "obj.bin", healthyModTime, bytes.NewReader(healthyPayload))
+	}))
+	t.Cleanup(healthySrv.Close)
+
+	slowHost := mustHost(t, slowSrv.URL)
+	healthyHost := mustHost(t, healthySrv.URL)
+
+	// The stub director. It answers federation discovery (pointing at itself)
+	// and routes object requests to one of the two origins by path prefix. The
+	// client accepts either a Link header or a bare Location on a 307; sending
+	// both keeps the stub honest against either code path.
+	//
+	// It is created unstarted so its own URL is known before any handler can
+	// run, which keeps the closure below race-free.
+	directorSrv := httptest.NewUnstartedServer(nil)
+	directorURL := "https://" + directorSrv.Listener.Addr().String()
+	directorSrv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The Server header is how the client tells a real director from an
+		// ingress proxy standing in for one that is rebooting.
+		w.Header().Set("Server", "pelican/7.99.0")
+
+		if r.URL.Path == "/.well-known/pelican-configuration" {
+			w.Header().Set("Content-Type", "application/json")
+			// t.Errorf rather than require: this runs on a server goroutine,
+			// where a FailNow would abandon the test instead of failing it.
+			if encErr := json.NewEncoder(w).Encode(pelican_url.FederationDiscovery{
+				DiscoveryEndpoint: directorURL,
+				DirectorEndpoint:  directorURL,
+			}); encErr != nil {
+				t.Errorf("failed to write the discovery document: %v", encErr)
+			}
+			return
+		}
+
+		// A cache fetching on behalf of a client asks the director's origin
+		// endpoint (see useEmbeddedCacheMode), so strip that prefix to recover
+		// the federation path.
+		objectPath := strings.TrimPrefix(r.URL.Path, "/api/v1.0/director/origin")
+		var target, namespace string
+		switch {
+		case strings.HasPrefix(objectPath, "/slow/"):
+			target, namespace = slowSrv.URL+objectPath, "/slow"
+		case strings.HasPrefix(objectPath, "/healthy/"):
+			target, namespace = healthySrv.URL+objectPath, "/healthy"
+		default:
+			http.Error(w, "no origin for "+objectPath, http.StatusNotFound)
+			return
+		}
+		// The namespace header is not optional: the client refuses a redirect it
+		// cannot attribute to a namespace. require-token=false keeps these
+		// objects public, which also leaves the origin URLs on the scheme the
+		// Link header names rather than forcing them to https.
+		w.Header().Set(string(server_structs.XPelicanNamespaceHeaderName),
+			"namespace="+namespace+", require-token=false")
+		w.Header().Set("Link", "<"+target+`>; rel="duplicate"; pri=1; depth=1`)
+		w.Header().Set("Location", target)
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	})
+	directorSrv.StartTLS()
+	t.Cleanup(directorSrv.Close)
+
+	// Point the cache at the stub director so upstream resolution stays offline.
+	config.SetFederation(pelican_url.FederationDiscovery{
+		DiscoveryEndpoint: directorURL,
+		DirectorEndpoint:  directorURL,
+	})
+
+	// Build a real persistent cache in server mode -- the mode that wires a
+	// TagScheduler onto the transfer engine. DeferConfig skips the initial
+	// director namespace fetch; the namespaces are injected below instead.
+	tmpDir := t.TempDir()
+	pc, err := NewPersistentCache(ctx, egrp, PersistentCacheConfig{
+		Mode:        CacheModeServer,
+		BaseDir:     tmpDir,
+		StorageDirs: []StorageDirConfig{{Path: tmpDir}},
+		DeferConfig: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pc.Close() })
+	require.NotNil(t, pc.scheduler, "server-mode cache must construct a fair scheduler")
+
+	// Public namespaces so the tokenless GETs below authorize.
+	require.NoError(t, pc.ac.updateConfig([]server_structs.NamespaceAd{
+		{Path: "/slow", Caps: server_structs.Capabilities{PublicReads: true, Reads: true}},
+		{Path: "/healthy", Caps: server_structs.Capabilities{PublicReads: true, Reads: true}},
+	}))
+
+	// Serve the cache's object handler over real HTTP.
+	cacheSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pc.serveObject(w, r)
+	}))
+	t.Cleanup(cacheSrv.Close)
+
+	// Everything is built, so this is the last cleanup registered and hence
+	// the first to run: unblock the dribbling handlers so the server closes
+	// and the errgroup drains promptly.
+	t.Cleanup(func() { close(release) })
+
+	// The requests that are admitted stream (slowly) for as long as the test
+	// runs; this context lets them be abandoned at the end instead of waited
+	// for.
+	reqCtx, reqCancel := context.WithCancel(ctx)
+	defer reqCancel()
+	httpClient := &http.Client{}
+
+	type shedResult struct {
+		status     int
+		retryAfter string
+		// reason and detail are the "error" and "detail" fields of an error
+		// (non-200) JSON body.
+		reason string
+		detail string
+		err    error
+	}
+	results := make(chan shedResult, slowRequestCount)
+
+	// Phase 1: burst the slow origin.
+	for i := 0; i < slowRequestCount; i++ {
+		go func(i int) {
+			objURL := fmt.Sprintf("%s/slow/obj-%d.bin", cacheSrv.URL, i)
+			req, reqErr := http.NewRequestWithContext(reqCtx, http.MethodGet, objURL, nil)
+			if reqErr != nil {
+				results <- shedResult{err: reqErr}
+				return
+			}
+			resp, doErr := httpClient.Do(req)
+			if doErr != nil {
+				results <- shedResult{err: doErr}
+				return
+			}
+			defer resp.Body.Close()
+			res := shedResult{
+				status:     resp.StatusCode,
+				retryAfter: resp.Header.Get("Retry-After"),
+			}
+			if resp.StatusCode != http.StatusOK {
+				// The reason is the whole point of the 429 body; parse it. Any
+				// other error status gets the same treatment so a failure of
+				// this test reports what the cache actually said.
+				body, readErr := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+				if readErr != nil {
+					results <- shedResult{err: readErr}
+					return
+				}
+				var parsedBody struct {
+					Error  string `json:"error"`
+					Detail string `json:"detail"`
+				}
+				if jsonErr := json.Unmarshal(body, &parsedBody); jsonErr != nil {
+					results <- shedResult{err: fmt.Errorf("HTTP %d body %q is not JSON: %w", resp.StatusCode, string(body), jsonErr)}
+					return
+				}
+				res.reason = parsedBody.Error
+				res.detail = parsedBody.Detail
+			}
+			results <- res
+		}(i)
+	}
+
+	// Collect the sheds. With one active plus one pending slot on the slow
+	// origin's tag, eight of the ten requests must be rejected; wait for a
+	// clear majority of them rather than for all ten goroutines, because the
+	// admitted ones do not return until the test tears down.
+	const wantSheds = slowRequestCount - 2
+	var sheds []shedResult
+	var otherStatuses []string
+	var transportErrs []error
+	collectDeadline := time.After(20 * time.Second)
+collect:
+	for len(sheds) < wantSheds {
+		select {
+		case res := <-results:
+			switch {
+			case res.err != nil:
+				transportErrs = append(transportErrs, res.err)
+			case res.status == http.StatusTooManyRequests:
+				sheds = append(sheds, res)
+			default:
+				otherStatuses = append(otherStatuses,
+					fmt.Sprintf("%d (%s: %s)", res.status, res.reason, res.detail))
+			}
+		case <-collectDeadline:
+			break collect
+		}
+	}
+	t.Logf("slow-origin burst: %d sheds, other statuses %v, transport errors %v",
+		len(sheds), otherStatuses, transportErrs)
+
+	require.Empty(t, transportErrs, "every burst request must complete at the HTTP layer")
+	require.NotEmpty(t, sheds,
+		"a %d-way burst against an origin capped at one active and one pending transfer must be shed", slowRequestCount)
+	perOriginReasons := map[string]int{}
+	for _, shed := range sheds {
+		assert.Equal(t, "60", shed.retryAfter, "every 429 must carry the documented Retry-After header")
+		// Compare against the constants rather than fresh literals: the
+		// scheduler, the cache's HTTP layer and the client's parser must all
+		// agree on the spelling, and a rename should break here.
+		assert.Contains(t,
+			[]string{string(client.ShedOriginUnresponsive), string(client.ShedOriginSlow)},
+			shed.reason,
+			"a shed caused by one origin's own cap must blame that origin, not the cache")
+		perOriginReasons[shed.reason]++
+	}
+	t.Logf("shed reasons: %v", perOriginReasons)
+
+	// Phase 2: the isolation property. The slow origin's fetches are still
+	// dribbling (4 KiB at one byte per 100 ms cannot have finished), yet the
+	// healthy origin has its own tag, its own caps, and a free worker.
+	// Bounded so that a cache which wrongly makes this request wait behind the
+	// slow origin fails the test promptly instead of hanging it.
+	healthyCtx, healthyCancel := context.WithTimeout(reqCtx, 20*time.Second)
+	defer healthyCancel()
+	healthyReq, err := http.NewRequestWithContext(healthyCtx, http.MethodGet, cacheSrv.URL+"/healthy/obj.bin", nil)
+	require.NoError(t, err)
+	healthyResp, err := httpClient.Do(healthyReq)
+	require.NoError(t, err, "a healthy origin must remain reachable while another origin is being shed")
+	healthyBody, err := io.ReadAll(healthyResp.Body)
+	require.NoError(t, err)
+	require.NoError(t, healthyResp.Body.Close())
+	require.Equal(t, http.StatusOK, healthyResp.StatusCode,
+		"healthy-origin GET was not served (body: %s)", string(healthyBody))
+	assert.Equal(t, healthyPayload, healthyBody, "healthy-origin GET must return the whole object")
+
+	// Phase 3: the scheduler's own books agree with what the clients saw.
+	snap := pc.scheduler.Snapshot(ctx)
+	t.Logf("scheduler snapshot: global=%+v tags=%+v", snap.Global, snap.Tags)
+
+	slowStats, ok := snap.Tags[slowHost]
+	require.True(t, ok, "expected a scheduler tag for the slow origin %q; tags=%+v", slowHost, snap.Tags)
+	assert.Greater(t, slowStats.Rejects, uint64(0), "the slow origin's tag must own the rejections")
+
+	healthyStats, ok := snap.Tags[healthyHost]
+	require.True(t, ok, "expected a scheduler tag for the healthy origin %q; tags=%+v", healthyHost, snap.Tags)
+	assert.Zero(t, healthyStats.Rejects, "the healthy origin must not be charged for the slow origin's congestion")
+	assert.Greater(t, healthyStats.Admits, uint64(0), "the healthy origin's fetch must have been admitted")
+
+	for tag, stats := range snap.Tags {
+		if tag == slowHost {
+			continue
+		}
+		assert.Zero(t, stats.Rejects, "tag %q must have no rejections; only %q was over its cap", tag, slowHost)
+	}
+	assert.Greater(t, snap.Global.TotalRejectsPerTag, uint64(0),
+		"the rejections must come from the per-origin cap, not the global pending buffer")
+	assert.Zero(t, snap.Global.TotalRejectsGlobal,
+		"the global pending buffer (16) must never have been the binding limit")
+}
+
+// mustHost returns the host:port of a server URL, which is also the tag the
+// scheduler files that server's transfers under (see deriveSchedulerTag).
+func mustHost(t *testing.T, rawURL string) string {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	return parsed.Host
+}

--- a/local_cache/storage.go
+++ b/local_cache/storage.go
@@ -305,6 +305,11 @@ func (ct *chunkTracker) releaseAll() {
 type StorageManager struct {
 	db *CacheDB
 
+	// evictionRunning records whether the TTL caches' eviction loops were
+	// started, so Close knows whether there is anything to stop. Read-only
+	// managers never start them.
+	evictionRunning atomic.Bool
+
 	// dirs maps storageID → objects directory (e.g. "/data1/objects").
 	// StorageIDFirstDisk is always present; additional dirs have
 	// sequential IDs.
@@ -589,6 +594,7 @@ func NewStorageManager(db *CacheDB, dirs []string, inlineMax int, egrp *errgroup
 	// Start the TTL cache eviction goroutines so idle entries are reaped
 	// automatically.  They are stopped when the StorageManager is closed.
 	// Launching through the errgroup prevents goroutine leaks in tests.
+	sm.evictionRunning.Store(true)
 	egrp.Go(func() error { sm.blockStates.Start(); return nil })
 	egrp.Go(func() error { sm.diskCrypto.Start(); return nil })
 	egrp.Go(func() error { sm.openFiles.Start(); return nil })
@@ -603,9 +609,16 @@ func (sm *StorageManager) GetDirs() map[StorageID]string {
 
 // Close stops TTL cache eviction goroutines and releases cached resources.
 func (sm *StorageManager) Close() {
-	sm.blockStates.Stop()
-	sm.diskCrypto.Stop()
-	sm.openFiles.Stop()
+	// Stop() hands the eviction loop a value over an unbuffered channel and
+	// waits for it to be received, so it blocks forever if the loop is not
+	// running -- which is the case for a read-only manager (it never starts
+	// them) and for a second Close(). Only signal loops that are live, and
+	// claim them so a concurrent or repeated Close() cannot signal again.
+	if sm.evictionRunning.CompareAndSwap(true, false) {
+		sm.blockStates.Stop()
+		sm.diskCrypto.Stop()
+		sm.openFiles.Stop()
+	}
 	// Closing caches evicts all entries, triggering OnEviction which
 	// closes each file descriptor.
 	sm.openFiles.DeleteAll()

--- a/local_cache/storage.go
+++ b/local_cache/storage.go
@@ -613,7 +613,11 @@ func (sm *StorageManager) Close() {
 	// waits for it to be received, so it blocks forever if the loop is not
 	// running -- which is the case for a read-only manager (it never starts
 	// them) and for a second Close(). Only signal loops that are live, and
-	// claim them so a concurrent or repeated Close() cannot signal again.
+	// claim them so a repeated Close() cannot signal again.
+	//
+	// This makes Close repeatable, not concurrency-safe: the work below the CAS
+	// is unguarded, and ristretto's Close is itself not safe to call twice at
+	// once. Every caller today closes from a single goroutine.
 	if sm.evictionRunning.CompareAndSwap(true, false) {
 		sm.blockStates.Stop()
 		sm.diskCrypto.Stop()

--- a/metrics/scheduler.go
+++ b/metrics/scheduler.go
@@ -124,10 +124,17 @@ var schedulerTracker = newSchedulerCounterTracker()
 // previously published total and the current one.
 //
 // Both are unsigned, so the subtraction must not be done blind: a current
-// total below the previous one means the source counters restarted (a fresh
-// TagScheduler begins at zero, e.g. a cache re-created in the same process),
-// and `current - last` would wrap to something near 2^64. Treat that case as
-// a reset and count the current value as entirely new.
+// total below the previous one means the source counters restarted, and
+// `current - last` would wrap to something near 2^64. Treat that case as a
+// reset and count the current value as entirely new. Per-origin totals restart
+// whenever the scheduler evicts an idle tag and the origin later returns;
+// pool-wide totals restart when a whole scheduler is replaced in-process.
+//
+// This detects a reset only by the total going down, so it relies on the reset
+// being observed while the new total is still below the old one. For per-origin
+// counters that holds because the eviction grace period is comfortably longer
+// than the publish interval, so the tag's absence is always sampled in between
+// and its tracked total forgotten (see the prune below).
 func counterDelta(current, last uint64) float64 {
 	if current < last {
 		return float64(current)

--- a/metrics/scheduler.go
+++ b/metrics/scheduler.go
@@ -26,8 +26,9 @@ import (
 )
 
 // Metrics exposed by the cache's per-origin fair scheduler
-// (client.TagScheduler). See docs/object-transfer-semantics.md and
-// docs/tag-scheduler-design.md for what each cap and EMA mean.
+// (client.TagScheduler in client/tag_scheduler.go). The starving/active
+// caps and the EMA weighting are documented on client.SchedulerConfig and
+// in the Cache.Throttle.* parameter descriptions in docs/parameters.yaml.
 var (
 	CacheSchedulerActive = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "pelican_cache_scheduler_active",
@@ -56,7 +57,7 @@ var (
 
 	CacheSchedulerRejectsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "pelican_cache_scheduler_rejects_total",
-		Help: "Per-origin count of upstream fetches rejected by the cache's fair scheduler with a 429-equivalent error. reason=\"global\": the global pending buffer was full; reason=\"per_tag\": this origin's own pending queue was full.",
+		Help: "Count of upstream fetches rejected by the cache's fair scheduler with a 429-equivalent error. Per-origin series carry reason=\"any\" (the per-origin snapshot does not break rejections down by cause). The cause breakdown is published only on the synthetic origin=\"*\" series: reason=\"global\" (the global pending buffer was full) and reason=\"per_tag\" (that origin's own pending queue was full).",
 	}, []string{"origin", "reason"})
 
 	// Pool-wide aggregates. Handy for a single-panel overview even if
@@ -71,7 +72,7 @@ var (
 	})
 	CacheSchedulerPoolTags = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "pelican_cache_scheduler_pool_tags_total",
-		Help: "Number of distinct origins the scheduler is currently tracking (either in-flight, queued, or with a still-decaying EMA).",
+		Help: "Number of distinct origins the scheduler is currently tracking (in-flight, queued, with a still-decaying EMA, or awaiting idle eviction). Idle origins are evicted after a grace period, so this can shrink.",
 	})
 	CacheSchedulerPoolStarvingCap = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "pelican_cache_scheduler_pool_starving_cap",

--- a/metrics/scheduler.go
+++ b/metrics/scheduler.go
@@ -57,8 +57,18 @@ var (
 
 	CacheSchedulerRejectsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "pelican_cache_scheduler_rejects_total",
-		Help: "Count of upstream fetches rejected by the cache's fair scheduler with a 429-equivalent error. Per-origin series carry reason=\"any\" (the per-origin snapshot does not break rejections down by cause). The cause breakdown is published only on the synthetic origin=\"*\" series: reason=\"global\" (the global pending buffer was full) and reason=\"per_tag\" (that origin's own pending queue was full).",
-	}, []string{"origin", "reason"})
+		Help: "Per-origin count of upstream fetches rejected by the cache's fair scheduler with a 429-equivalent error.",
+	}, []string{"origin"})
+
+	// The cause breakdown is a separate metric rather than an extra label
+	// on the per-origin counter: the scheduler's per-origin snapshot does
+	// not attribute rejections to a cause, so publishing both views under
+	// one name would make the obvious sum() over that name count every
+	// rejection twice.
+	CacheSchedulerRejectsByCauseTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "pelican_cache_scheduler_rejects_by_cause_total",
+		Help: "Pool-wide count of upstream fetches rejected by the cache's fair scheduler, broken down by cause: \"global\" (the global pending buffer was full) or \"per_tag\" (the origin's own pending queue was full).",
+	}, []string{"cause"})
 
 	// Pool-wide aggregates. Handy for a single-panel overview even if
 	// no per-origin labels are being scraped.
@@ -85,28 +95,44 @@ var (
 )
 
 // schedulerCounterTracker remembers the last observed monotonic total
-// per (origin, reason) tuple so we can Add the delta to the underlying
-// Prometheus counter without double-counting on republish.
+// per origin so we can Add the delta to the underlying Prometheus
+// counter without double-counting on republish.
 type schedulerCounterTracker struct {
-	mu           sync.Mutex
-	lastAdmits   map[string]uint64
-	lastRejects  map[schedulerRejectKey]uint64
-	knownAdmits  map[string]struct{} // set of tags that currently have an Admits > 0 series
-	knownRejects map[schedulerRejectKey]struct{}
-	knownGauges  map[string]struct{} // set of tags that currently have any gauge value published
+	mu                 sync.Mutex
+	lastAdmits         map[string]uint64
+	lastRejects        map[string]uint64
+	lastRejectsByCause map[string]uint64
+	knownAdmits        map[string]struct{} // set of tags that currently have an Admits > 0 series
+	knownRejects       map[string]struct{}
+	knownGauges        map[string]struct{} // set of tags that currently have any gauge value published
 }
 
-type schedulerRejectKey struct {
-	origin string
-	reason string // "global" or "per_tag"
+func newSchedulerCounterTracker() *schedulerCounterTracker {
+	return &schedulerCounterTracker{
+		lastAdmits:         make(map[string]uint64),
+		lastRejects:        make(map[string]uint64),
+		lastRejectsByCause: make(map[string]uint64),
+		knownAdmits:        make(map[string]struct{}),
+		knownRejects:       make(map[string]struct{}),
+		knownGauges:        make(map[string]struct{}),
+	}
 }
 
-var schedulerTracker = &schedulerCounterTracker{
-	lastAdmits:   make(map[string]uint64),
-	lastRejects:  make(map[schedulerRejectKey]uint64),
-	knownAdmits:  make(map[string]struct{}),
-	knownRejects: make(map[schedulerRejectKey]struct{}),
-	knownGauges:  make(map[string]struct{}),
+var schedulerTracker = newSchedulerCounterTracker()
+
+// counterDelta computes how much to Add to a Prometheus counter given the
+// previously published total and the current one.
+//
+// Both are unsigned, so the subtraction must not be done blind: a current
+// total below the previous one means the source counters restarted (a fresh
+// TagScheduler begins at zero, e.g. a cache re-created in the same process),
+// and `current - last` would wrap to something near 2^64. Treat that case as
+// a reset and count the current value as entirely new.
+func counterDelta(current, last uint64) float64 {
+	if current < last {
+		return float64(current)
+	}
+	return float64(current - last)
 }
 
 // SchedulerGlobalStats mirrors client.GlobalStats but lives in the
@@ -158,7 +184,7 @@ func PublishCacheSchedulerSnapshot(global SchedulerGlobalStats, tags map[string]
 
 	nowKnownGauges := make(map[string]struct{}, len(tags))
 	nowKnownAdmits := make(map[string]struct{}, len(tags))
-	nowKnownRejects := make(map[schedulerRejectKey]struct{}, len(tags))
+	nowKnownRejects := make(map[string]struct{}, len(tags))
 
 	for origin, s := range tags {
 		nowKnownGauges[origin] = struct{}{}
@@ -169,44 +195,31 @@ func PublishCacheSchedulerSnapshot(global SchedulerGlobalStats, tags map[string]
 
 		if s.Admits > 0 {
 			nowKnownAdmits[origin] = struct{}{}
-			last := schedulerTracker.lastAdmits[origin]
-			if s.Admits > last {
-				CacheSchedulerAdmitsTotal.WithLabelValues(origin).Add(float64(s.Admits - last))
+			if delta := counterDelta(s.Admits, schedulerTracker.lastAdmits[origin]); delta > 0 {
+				CacheSchedulerAdmitsTotal.WithLabelValues(origin).Add(delta)
 			}
 			schedulerTracker.lastAdmits[origin] = s.Admits
 		}
 		if s.Rejects > 0 {
-			// The snapshot only reports the sum across reasons per
-			// tag; we can only tell them apart via the global
-			// totals. For per-origin labels, publish the full delta
-			// under a synthetic reason="any" so the per-origin view
-			// still works. The reason=global/per_tag detail is
-			// available via the pool-wide counters.
-			key := schedulerRejectKey{origin: origin, reason: "any"}
-			nowKnownRejects[key] = struct{}{}
-			last := schedulerTracker.lastRejects[key]
-			if s.Rejects > last {
-				CacheSchedulerRejectsTotal.WithLabelValues(origin, "any").Add(float64(s.Rejects - last))
+			nowKnownRejects[origin] = struct{}{}
+			if delta := counterDelta(s.Rejects, schedulerTracker.lastRejects[origin]); delta > 0 {
+				CacheSchedulerRejectsTotal.WithLabelValues(origin).Add(delta)
 			}
-			schedulerTracker.lastRejects[key] = s.Rejects
+			schedulerTracker.lastRejects[origin] = s.Rejects
 		}
 	}
 
-	// Publish pool-wide reject totals under a special "*" origin so
-	// operators get the reason breakdown without paying a per-origin
-	// cardinality cost.
-	poolAllOriginKeyGlobal := schedulerRejectKey{origin: "*", reason: "global"}
-	poolAllOriginKeyPerTag := schedulerRejectKey{origin: "*", reason: "per_tag"}
-	nowKnownRejects[poolAllOriginKeyGlobal] = struct{}{}
-	nowKnownRejects[poolAllOriginKeyPerTag] = struct{}{}
-	if delta := global.TotalRejectsGlobal - schedulerTracker.lastRejects[poolAllOriginKeyGlobal]; delta > 0 {
-		CacheSchedulerRejectsTotal.WithLabelValues("*", "global").Add(float64(delta))
+	// The per-origin snapshot does not attribute a rejection to a cause, so
+	// the breakdown is only available pool-wide.
+	for cause, total := range map[string]uint64{
+		"global":  global.TotalRejectsGlobal,
+		"per_tag": global.TotalRejectsPerTag,
+	} {
+		if delta := counterDelta(total, schedulerTracker.lastRejectsByCause[cause]); delta > 0 {
+			CacheSchedulerRejectsByCauseTotal.WithLabelValues(cause).Add(delta)
+		}
+		schedulerTracker.lastRejectsByCause[cause] = total
 	}
-	schedulerTracker.lastRejects[poolAllOriginKeyGlobal] = global.TotalRejectsGlobal
-	if delta := global.TotalRejectsPerTag - schedulerTracker.lastRejects[poolAllOriginKeyPerTag]; delta > 0 {
-		CacheSchedulerRejectsTotal.WithLabelValues("*", "per_tag").Add(float64(delta))
-	}
-	schedulerTracker.lastRejects[poolAllOriginKeyPerTag] = global.TotalRejectsPerTag
 
 	// Prune labels for tags that disappeared from the snapshot.
 	for origin := range schedulerTracker.knownGauges {
@@ -223,13 +236,48 @@ func PublishCacheSchedulerSnapshot(global SchedulerGlobalStats, tags map[string]
 			delete(schedulerTracker.lastAdmits, origin)
 		}
 	}
-	for key := range schedulerTracker.knownRejects {
-		if _, still := nowKnownRejects[key]; !still {
-			CacheSchedulerRejectsTotal.DeleteLabelValues(key.origin, key.reason)
-			delete(schedulerTracker.lastRejects, key)
+	for origin := range schedulerTracker.knownRejects {
+		if _, still := nowKnownRejects[origin]; !still {
+			CacheSchedulerRejectsTotal.DeleteLabelValues(origin)
+			delete(schedulerTracker.lastRejects, origin)
 		}
 	}
 	schedulerTracker.knownGauges = nowKnownGauges
 	schedulerTracker.knownAdmits = nowKnownAdmits
 	schedulerTracker.knownRejects = nowKnownRejects
+}
+
+// ResetCacheSchedulerMetrics drops every scheduler series and zeroes the
+// pool-wide gauges. Call it when a cache's scheduler goes away: the gauges
+// describe instantaneous state, so leaving the final pre-shutdown values in
+// the exposition would misreport a scheduler that no longer exists.
+//
+// The delta bookkeeping is reset too, so a scheduler created afterwards in
+// the same process starts its counters from zero rather than being diffed
+// against a dead instance's totals.
+func ResetCacheSchedulerMetrics() {
+	schedulerTracker.mu.Lock()
+	defer schedulerTracker.mu.Unlock()
+
+	CacheSchedulerActive.Reset()
+	CacheSchedulerStarving.Reset()
+	CacheSchedulerPending.Reset()
+	CacheSchedulerEMA.Reset()
+	CacheSchedulerAdmitsTotal.Reset()
+	CacheSchedulerRejectsTotal.Reset()
+	CacheSchedulerRejectsByCauseTotal.Reset()
+
+	CacheSchedulerPoolSize.Set(0)
+	CacheSchedulerPoolPending.Set(0)
+	CacheSchedulerPoolTags.Set(0)
+	CacheSchedulerPoolStarvingCap.Set(0)
+	CacheSchedulerPoolActiveCap.Set(0)
+
+	fresh := newSchedulerCounterTracker()
+	schedulerTracker.lastAdmits = fresh.lastAdmits
+	schedulerTracker.lastRejects = fresh.lastRejects
+	schedulerTracker.lastRejectsByCause = fresh.lastRejectsByCause
+	schedulerTracker.knownAdmits = fresh.knownAdmits
+	schedulerTracker.knownRejects = fresh.knownRejects
+	schedulerTracker.knownGauges = fresh.knownGauges
 }

--- a/metrics/scheduler.go
+++ b/metrics/scheduler.go
@@ -1,0 +1,234 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package metrics
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Metrics exposed by the cache's per-origin fair scheduler
+// (client.TagScheduler). See docs/object-transfer-semantics.md and
+// docs/tag-scheduler-design.md for what each cap and EMA mean.
+var (
+	CacheSchedulerActive = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pelican_cache_scheduler_active",
+		Help: "Per-origin count of upstream fetches currently held by the cache's fair scheduler (starving + actively transferring).",
+	}, []string{"origin"})
+
+	CacheSchedulerStarving = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pelican_cache_scheduler_starving",
+		Help: "Per-origin count of upstream fetches currently held by the cache's fair scheduler that have not yet received a first byte of body from the origin.",
+	}, []string{"origin"})
+
+	CacheSchedulerPending = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pelican_cache_scheduler_pending",
+		Help: "Per-origin count of upstream fetches queued for dispatch to a worker.",
+	}, []string{"origin"})
+
+	CacheSchedulerEMA = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pelican_cache_scheduler_ema",
+		Help: "Per-origin exponentially-weighted moving average of the active-worker count. Used to weight the fair scheduler's round-robin: lower value → more likely to be picked next.",
+	}, []string{"origin"})
+
+	CacheSchedulerAdmitsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "pelican_cache_scheduler_admits_total",
+		Help: "Per-origin count of upstream fetches admitted into the cache's fair scheduler.",
+	}, []string{"origin"})
+
+	CacheSchedulerRejectsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "pelican_cache_scheduler_rejects_total",
+		Help: "Per-origin count of upstream fetches rejected by the cache's fair scheduler with a 429-equivalent error. reason=\"global\": the global pending buffer was full; reason=\"per_tag\": this origin's own pending queue was full.",
+	}, []string{"origin", "reason"})
+
+	// Pool-wide aggregates. Handy for a single-panel overview even if
+	// no per-origin labels are being scraped.
+	CacheSchedulerPoolSize = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "pelican_cache_scheduler_pool_size",
+		Help: "The cache's worker-pool size that the scheduler is sharing (usually Cache.WorkerCount).",
+	})
+	CacheSchedulerPoolPending = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "pelican_cache_scheduler_pool_pending_total",
+		Help: "Total number of upstream fetches queued for dispatch across all origins.",
+	})
+	CacheSchedulerPoolTags = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "pelican_cache_scheduler_pool_tags_total",
+		Help: "Number of distinct origins the scheduler is currently tracking (either in-flight, queued, or with a still-decaying EMA).",
+	})
+	CacheSchedulerPoolStarvingCap = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "pelican_cache_scheduler_pool_starving_cap",
+		Help: "Absolute count of worker slots any single origin may hold while starving (derived from Cache.Throttle.PerOriginStarvingPercent).",
+	})
+	CacheSchedulerPoolActiveCap = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "pelican_cache_scheduler_pool_active_cap",
+		Help: "Absolute count of worker slots any single origin may hold in total (derived from Cache.Throttle.PerOriginActivePercent).",
+	})
+)
+
+// schedulerCounterTracker remembers the last observed monotonic total
+// per (origin, reason) tuple so we can Add the delta to the underlying
+// Prometheus counter without double-counting on republish.
+type schedulerCounterTracker struct {
+	mu           sync.Mutex
+	lastAdmits   map[string]uint64
+	lastRejects  map[schedulerRejectKey]uint64
+	knownAdmits  map[string]struct{} // set of tags that currently have an Admits > 0 series
+	knownRejects map[schedulerRejectKey]struct{}
+	knownGauges  map[string]struct{} // set of tags that currently have any gauge value published
+}
+
+type schedulerRejectKey struct {
+	origin string
+	reason string // "global" or "per_tag"
+}
+
+var schedulerTracker = &schedulerCounterTracker{
+	lastAdmits:   make(map[string]uint64),
+	lastRejects:  make(map[schedulerRejectKey]uint64),
+	knownAdmits:  make(map[string]struct{}),
+	knownRejects: make(map[schedulerRejectKey]struct{}),
+	knownGauges:  make(map[string]struct{}),
+}
+
+// SchedulerGlobalStats mirrors client.GlobalStats but lives in the
+// metrics package so callers can convert once and hand it in.
+type SchedulerGlobalStats struct {
+	WorkerCount        int
+	StarvingCap        int
+	ActiveCap          int
+	TotalPending       int
+	TotalTags          int
+	TotalAdmits        uint64
+	TotalRejects       uint64
+	TotalRejectsGlobal uint64
+	TotalRejectsPerTag uint64
+}
+
+// SchedulerPerTagStats mirrors client.PerTagStats.
+type SchedulerPerTagStats struct {
+	Pending  int
+	Active   int
+	Starving int
+	EMA      float64
+	Admits   uint64
+	Rejects  uint64
+}
+
+// PublishCacheSchedulerSnapshot updates the Prometheus scheduler
+// metrics from a snapshot taken by (client.TagScheduler).Snapshot().
+// It is expected to be called on a fixed cadence (say 5 s) from the
+// cache's monitor goroutine.
+//
+// Tags that disappear from the snapshot (because their EMA decayed
+// out and they have no queued or in-flight work) have their labeled
+// gauges deleted. Their monotonic admit/reject counters are also
+// deleted from the CounterVec so the (origin=…) series no longer
+// counts against Prometheus cardinality once the origin has been
+// idle long enough to drop out. Since Prometheus preserves the last
+// scraped value until the series ages out, occasional flicker at
+// the tail is acceptable.
+func PublishCacheSchedulerSnapshot(global SchedulerGlobalStats, tags map[string]SchedulerPerTagStats) {
+	CacheSchedulerPoolSize.Set(float64(global.WorkerCount))
+	CacheSchedulerPoolPending.Set(float64(global.TotalPending))
+	CacheSchedulerPoolTags.Set(float64(global.TotalTags))
+	CacheSchedulerPoolStarvingCap.Set(float64(global.StarvingCap))
+	CacheSchedulerPoolActiveCap.Set(float64(global.ActiveCap))
+
+	schedulerTracker.mu.Lock()
+	defer schedulerTracker.mu.Unlock()
+
+	nowKnownGauges := make(map[string]struct{}, len(tags))
+	nowKnownAdmits := make(map[string]struct{}, len(tags))
+	nowKnownRejects := make(map[schedulerRejectKey]struct{}, len(tags))
+
+	for origin, s := range tags {
+		nowKnownGauges[origin] = struct{}{}
+		CacheSchedulerActive.WithLabelValues(origin).Set(float64(s.Active))
+		CacheSchedulerStarving.WithLabelValues(origin).Set(float64(s.Starving))
+		CacheSchedulerPending.WithLabelValues(origin).Set(float64(s.Pending))
+		CacheSchedulerEMA.WithLabelValues(origin).Set(s.EMA)
+
+		if s.Admits > 0 {
+			nowKnownAdmits[origin] = struct{}{}
+			last := schedulerTracker.lastAdmits[origin]
+			if s.Admits > last {
+				CacheSchedulerAdmitsTotal.WithLabelValues(origin).Add(float64(s.Admits - last))
+			}
+			schedulerTracker.lastAdmits[origin] = s.Admits
+		}
+		if s.Rejects > 0 {
+			// The snapshot only reports the sum across reasons per
+			// tag; we can only tell them apart via the global
+			// totals. For per-origin labels, publish the full delta
+			// under a synthetic reason="any" so the per-origin view
+			// still works. The reason=global/per_tag detail is
+			// available via the pool-wide counters.
+			key := schedulerRejectKey{origin: origin, reason: "any"}
+			nowKnownRejects[key] = struct{}{}
+			last := schedulerTracker.lastRejects[key]
+			if s.Rejects > last {
+				CacheSchedulerRejectsTotal.WithLabelValues(origin, "any").Add(float64(s.Rejects - last))
+			}
+			schedulerTracker.lastRejects[key] = s.Rejects
+		}
+	}
+
+	// Publish pool-wide reject totals under a special "*" origin so
+	// operators get the reason breakdown without paying a per-origin
+	// cardinality cost.
+	poolAllOriginKeyGlobal := schedulerRejectKey{origin: "*", reason: "global"}
+	poolAllOriginKeyPerTag := schedulerRejectKey{origin: "*", reason: "per_tag"}
+	nowKnownRejects[poolAllOriginKeyGlobal] = struct{}{}
+	nowKnownRejects[poolAllOriginKeyPerTag] = struct{}{}
+	if delta := global.TotalRejectsGlobal - schedulerTracker.lastRejects[poolAllOriginKeyGlobal]; delta > 0 {
+		CacheSchedulerRejectsTotal.WithLabelValues("*", "global").Add(float64(delta))
+	}
+	schedulerTracker.lastRejects[poolAllOriginKeyGlobal] = global.TotalRejectsGlobal
+	if delta := global.TotalRejectsPerTag - schedulerTracker.lastRejects[poolAllOriginKeyPerTag]; delta > 0 {
+		CacheSchedulerRejectsTotal.WithLabelValues("*", "per_tag").Add(float64(delta))
+	}
+	schedulerTracker.lastRejects[poolAllOriginKeyPerTag] = global.TotalRejectsPerTag
+
+	// Prune labels for tags that disappeared from the snapshot.
+	for origin := range schedulerTracker.knownGauges {
+		if _, still := nowKnownGauges[origin]; !still {
+			CacheSchedulerActive.DeleteLabelValues(origin)
+			CacheSchedulerStarving.DeleteLabelValues(origin)
+			CacheSchedulerPending.DeleteLabelValues(origin)
+			CacheSchedulerEMA.DeleteLabelValues(origin)
+		}
+	}
+	for origin := range schedulerTracker.knownAdmits {
+		if _, still := nowKnownAdmits[origin]; !still {
+			CacheSchedulerAdmitsTotal.DeleteLabelValues(origin)
+			delete(schedulerTracker.lastAdmits, origin)
+		}
+	}
+	for key := range schedulerTracker.knownRejects {
+		if _, still := nowKnownRejects[key]; !still {
+			CacheSchedulerRejectsTotal.DeleteLabelValues(key.origin, key.reason)
+			delete(schedulerTracker.lastRejects, key)
+		}
+	}
+	schedulerTracker.knownGauges = nowKnownGauges
+	schedulerTracker.knownAdmits = nowKnownAdmits
+	schedulerTracker.knownRejects = nowKnownRejects
+}

--- a/metrics/scheduler_test.go
+++ b/metrics/scheduler_test.go
@@ -26,19 +26,23 @@ import (
 )
 
 // The scheduler metrics are package-level collectors on the default
-// Prometheus registry and the delta bookkeeping lives in the
-// package-level schedulerTracker, so state survives from one test to
-// the next. Every test below therefore uses origin label values unique
-// to itself and never assumes the tracker (or the registry) started out
-// empty. The one label value that is inherently shared is the synthetic
-// origin="*" series, so assertions on it are written as deltas.
+// Prometheus registry and the delta bookkeeping lives in the package-level
+// schedulerTracker, so state would otherwise survive from one test to the
+// next. Each test starts from a clean slate instead, which is also what a
+// cache shutting down does.
+func resetSchedulerMetrics(t *testing.T) {
+	t.Helper()
+	ResetCacheSchedulerMetrics()
+	t.Cleanup(ResetCacheSchedulerMetrics)
+}
 
 // TestPublishCacheSchedulerSnapshotGauges pins that the gauges are a
 // straight mirror of the snapshot: whatever the scheduler reported for a
 // tag is what the per-origin gauges read, and the GlobalStats fields land
 // on the pool-wide gauges.
 func TestPublishCacheSchedulerSnapshotGauges(t *testing.T) {
-	const origin = "TestPublishCacheSchedulerSnapshotGauges.example.com"
+	resetSchedulerMetrics(t)
+	const origin = "gauges.example.com"
 
 	global := SchedulerGlobalStats{
 		WorkerCount:  16,
@@ -85,28 +89,76 @@ func TestPublishCacheSchedulerSnapshotGauges(t *testing.T) {
 // idle between two scrapes of the same counter values) must not
 // double-count.
 func TestPublishCacheSchedulerSnapshotCounterDeltas(t *testing.T) {
-	const origin = "TestPublishCacheSchedulerSnapshotCounterDeltas.example.com"
+	resetSchedulerMetrics(t)
+	const origin = "deltas.example.com"
 	global := SchedulerGlobalStats{WorkerCount: 4, StarvingCap: 1, ActiveCap: 2, TotalTags: 1}
 
 	first := map[string]SchedulerPerTagStats{origin: {Active: 1, Admits: 5, Rejects: 5}}
 	PublishCacheSchedulerSnapshot(global, first)
 	assert.Equal(t, float64(5), testutil.ToFloat64(CacheSchedulerAdmitsTotal.WithLabelValues(origin)))
-	// The per-origin snapshot carries no cause breakdown, so the whole
-	// per-origin reject total shows up under reason="any".
-	assert.Equal(t, float64(5), testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues(origin, "any")))
+	assert.Equal(t, float64(5), testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues(origin)))
 
 	// Republishing the identical totals is a no-op.
 	PublishCacheSchedulerSnapshot(global, first)
 	PublishCacheSchedulerSnapshot(global, first)
 	assert.Equal(t, float64(5), testutil.ToFloat64(CacheSchedulerAdmitsTotal.WithLabelValues(origin)))
-	assert.Equal(t, float64(5), testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues(origin, "any")))
+	assert.Equal(t, float64(5), testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues(origin)))
 
 	// Growing the totals adds exactly the delta.
 	PublishCacheSchedulerSnapshot(global, map[string]SchedulerPerTagStats{
 		origin: {Active: 1, Admits: 8, Rejects: 8},
 	})
 	assert.Equal(t, float64(8), testutil.ToFloat64(CacheSchedulerAdmitsTotal.WithLabelValues(origin)))
-	assert.Equal(t, float64(8), testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues(origin, "any")))
+	assert.Equal(t, float64(8), testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues(origin)))
+}
+
+// TestPublishCacheSchedulerSnapshotCounterRestart pins the behavior when the
+// totals a snapshot reports are *lower* than the ones already published,
+// which happens whenever a scheduler is replaced by a fresh one in the same
+// process: the new instance starts counting from zero while the package-level
+// tracker still holds the dead instance's high-water marks.
+//
+// The totals are unsigned, so subtracting them blind wraps to something near
+// 2^64 and feeds Prometheus a garbage increment. The pool-wide series are
+// especially unforgiving because nothing ever prunes them, so a single bad
+// Add corrupts them for the life of the process.
+func TestPublishCacheSchedulerSnapshotCounterRestart(t *testing.T) {
+	resetSchedulerMetrics(t)
+	const origin = "restart.example.com"
+	high := SchedulerGlobalStats{
+		WorkerCount:        4,
+		TotalTags:          1,
+		TotalRejects:       30,
+		TotalRejectsGlobal: 20,
+		TotalRejectsPerTag: 10,
+	}
+	PublishCacheSchedulerSnapshot(high, map[string]SchedulerPerTagStats{
+		origin: {Active: 1, Admits: 40, Rejects: 30},
+	})
+	assert.Equal(t, float64(40), testutil.ToFloat64(CacheSchedulerAdmitsTotal.WithLabelValues(origin)))
+	assert.Equal(t, float64(20), testutil.ToFloat64(CacheSchedulerRejectsByCauseTotal.WithLabelValues("global")))
+	assert.Equal(t, float64(10), testutil.ToFloat64(CacheSchedulerRejectsByCauseTotal.WithLabelValues("per_tag")))
+
+	// A brand-new scheduler reports much smaller totals for the same origin,
+	// with no intervening publish that would have pruned the tracker.
+	low := SchedulerGlobalStats{
+		WorkerCount:        4,
+		TotalTags:          1,
+		TotalRejects:       3,
+		TotalRejectsGlobal: 2,
+		TotalRejectsPerTag: 1,
+	}
+	PublishCacheSchedulerSnapshot(low, map[string]SchedulerPerTagStats{
+		origin: {Active: 1, Admits: 4, Rejects: 3},
+	})
+
+	// The restart is counted as new activity on top of what came before.
+	// What must not happen is a decrease, or a jump of ~1.8e19 from an
+	// unsigned wrap.
+	assert.Equal(t, float64(44), testutil.ToFloat64(CacheSchedulerAdmitsTotal.WithLabelValues(origin)))
+	assert.Equal(t, float64(33), testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues(origin)))
+	assert.Equal(t, float64(22), testutil.ToFloat64(CacheSchedulerRejectsByCauseTotal.WithLabelValues("global")))
+	assert.Equal(t, float64(11), testutil.ToFloat64(CacheSchedulerRejectsByCauseTotal.WithLabelValues("per_tag")))
 }
 
 // TestPublishCacheSchedulerSnapshotPrunesVanishedOrigins pins that an
@@ -120,30 +172,22 @@ func TestPublishCacheSchedulerSnapshotCounterDeltas(t *testing.T) {
 // than by reading a value: ToFloat64(vec.WithLabelValues(...)) would
 // create the very series whose absence is under test.
 func TestPublishCacheSchedulerSnapshotPrunesVanishedOrigins(t *testing.T) {
-	const origin = "TestPublishCacheSchedulerSnapshotPrunesVanishedOrigins.example.com"
-	const other = "TestPublishCacheSchedulerSnapshotPrunesVanishedOrigins.other.example.com"
+	resetSchedulerMetrics(t)
+	const origin = "prunes.example.com"
+	const other = "prunes.other.example.com"
 	global := SchedulerGlobalStats{WorkerCount: 4, StarvingCap: 1, ActiveCap: 2, TotalTags: 1}
-
-	// The synthetic origin="*" reject series are never pruned, and they
-	// only come into existence once the pool has actually rejected
-	// something. Whether they are already present depends on what ran
-	// before, so count them once and treat that as the floor for the
-	// rejects collector.
-	PublishCacheSchedulerSnapshot(global, map[string]SchedulerPerTagStats{})
-	poolRejectSeries := testutil.CollectAndCount(CacheSchedulerRejectsTotal)
 
 	PublishCacheSchedulerSnapshot(global, map[string]SchedulerPerTagStats{
 		origin: {Pending: 1, Active: 2, Starving: 1, EMA: 2.5, Admits: 9, Rejects: 3},
 	})
 	// Only this origin is in the snapshot, so exactly one series per
-	// gauge exists.
+	// collector exists.
 	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerActive))
 	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerStarving))
 	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerPending))
 	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerEMA))
 	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerAdmitsTotal))
-	// One per-origin reason="any" series on top of the pool-wide floor.
-	assert.Equal(t, poolRejectSeries+1, testutil.CollectAndCount(CacheSchedulerRejectsTotal))
+	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerRejectsTotal))
 
 	// The origin drops out of the snapshot entirely: replaced by an
 	// unrelated origin so the publish is a realistic one rather than an
@@ -156,10 +200,9 @@ func TestPublishCacheSchedulerSnapshotPrunesVanishedOrigins(t *testing.T) {
 	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerPending))
 	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerEMA))
 	assert.Equal(t, float64(1), testutil.ToFloat64(CacheSchedulerActive.WithLabelValues(other)))
-	// "other" reported no admits or rejects, so the admits vec is now
-	// empty and the rejects vec is back down to the pool-wide floor.
+	// "other" reported no admits or rejects, so both counter vecs are empty.
 	assert.Equal(t, 0, testutil.CollectAndCount(CacheSchedulerAdmitsTotal))
-	assert.Equal(t, poolRejectSeries, testutil.CollectAndCount(CacheSchedulerRejectsTotal))
+	assert.Equal(t, 0, testutil.CollectAndCount(CacheSchedulerRejectsTotal))
 
 	// Dropping every origin empties the labeled collectors completely.
 	PublishCacheSchedulerSnapshot(global, map[string]SchedulerPerTagStats{})
@@ -168,7 +211,7 @@ func TestPublishCacheSchedulerSnapshotPrunesVanishedOrigins(t *testing.T) {
 	assert.Equal(t, 0, testutil.CollectAndCount(CacheSchedulerPending))
 	assert.Equal(t, 0, testutil.CollectAndCount(CacheSchedulerEMA))
 	assert.Equal(t, 0, testutil.CollectAndCount(CacheSchedulerAdmitsTotal))
-	assert.Equal(t, poolRejectSeries, testutil.CollectAndCount(CacheSchedulerRejectsTotal))
+	assert.Equal(t, 0, testutil.CollectAndCount(CacheSchedulerRejectsTotal))
 }
 
 // TestPublishCacheSchedulerSnapshotResetsAfterReappearance pins the
@@ -179,14 +222,15 @@ func TestPublishCacheSchedulerSnapshotPrunesVanishedOrigins(t *testing.T) {
 // totals at prune time too; otherwise the smaller total would look like a
 // negative delta (and Prometheus counters cannot go backwards).
 func TestPublishCacheSchedulerSnapshotResetsAfterReappearance(t *testing.T) {
-	const origin = "TestPublishCacheSchedulerSnapshotResetsAfterReappearance.example.com"
+	resetSchedulerMetrics(t)
+	const origin = "reappears.example.com"
 	global := SchedulerGlobalStats{WorkerCount: 4, StarvingCap: 1, ActiveCap: 2, TotalTags: 1}
 
 	PublishCacheSchedulerSnapshot(global, map[string]SchedulerPerTagStats{
 		origin: {Active: 1, Admits: 10, Rejects: 10},
 	})
 	assert.Equal(t, float64(10), testutil.ToFloat64(CacheSchedulerAdmitsTotal.WithLabelValues(origin)))
-	assert.Equal(t, float64(10), testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues(origin, "any")))
+	assert.Equal(t, float64(10), testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues(origin)))
 
 	// Idle long enough to be evicted.
 	PublishCacheSchedulerSnapshot(global, map[string]SchedulerPerTagStats{})
@@ -198,25 +242,25 @@ func TestPublishCacheSchedulerSnapshotResetsAfterReappearance(t *testing.T) {
 		})
 	})
 	assert.Equal(t, float64(2), testutil.ToFloat64(CacheSchedulerAdmitsTotal.WithLabelValues(origin)))
-	assert.Equal(t, float64(2), testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues(origin, "any")))
+	assert.Equal(t, float64(2), testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues(origin)))
 	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerAdmitsTotal))
 }
 
 // TestPublishCacheSchedulerSnapshotPoolRejectBreakdown pins the cause
-// breakdown for rejections. The per-tag snapshot cannot say why a fetch
-// was rejected, so the "global pending buffer was full" versus "this
-// origin's own queue was full" split is published only on the synthetic
-// origin="*" series, and like the per-origin counters it is fed the
-// difference between successive snapshots.
+// breakdown for rejections. The per-tag snapshot cannot say why a fetch was
+// rejected, so the "global pending buffer was full" versus "this origin's own
+// queue was full" split is published pool-wide on its own metric, and like
+// the per-origin counters it is fed the difference between successive
+// snapshots.
 //
-// The "*" series is shared by the whole package (it has no per-test label
-// to make unique), so the assertions below compare against the value read
-// just before the incrementing publish instead of an absolute total.
+// The breakdown deliberately does not share a metric name with the
+// per-origin rejections: publishing both views under one name would make
+// sum(rate(...)) over that name double every rejection.
 func TestPublishCacheSchedulerSnapshotPoolRejectBreakdown(t *testing.T) {
-	const origin = "TestPublishCacheSchedulerSnapshotPoolRejectBreakdown.example.com"
-	tags := map[string]SchedulerPerTagStats{origin: {Active: 1}}
+	resetSchedulerMetrics(t)
+	const origin = "breakdown.example.com"
+	tags := map[string]SchedulerPerTagStats{origin: {Active: 1, Rejects: 30}}
 
-	// Establish a baseline for the tracker's last-seen totals.
 	PublishCacheSchedulerSnapshot(SchedulerGlobalStats{
 		WorkerCount:        4,
 		StarvingCap:        1,
@@ -226,9 +270,8 @@ func TestPublishCacheSchedulerSnapshotPoolRejectBreakdown(t *testing.T) {
 		TotalRejectsGlobal: 20,
 		TotalRejectsPerTag: 10,
 	}, tags)
-
-	beforeGlobal := testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues("*", "global"))
-	beforePerTag := testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues("*", "per_tag"))
+	assert.Equal(t, float64(20), testutil.ToFloat64(CacheSchedulerRejectsByCauseTotal.WithLabelValues("global")))
+	assert.Equal(t, float64(10), testutil.ToFloat64(CacheSchedulerRejectsByCauseTotal.WithLabelValues("per_tag")))
 
 	PublishCacheSchedulerSnapshot(SchedulerGlobalStats{
 		WorkerCount:        4,
@@ -238,10 +281,10 @@ func TestPublishCacheSchedulerSnapshotPoolRejectBreakdown(t *testing.T) {
 		TotalRejects:       37,
 		TotalRejectsGlobal: 23,
 		TotalRejectsPerTag: 14,
-	}, tags)
+	}, map[string]SchedulerPerTagStats{origin: {Active: 1, Rejects: 37}})
 
-	assert.Equal(t, beforeGlobal+3, testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues("*", "global")))
-	assert.Equal(t, beforePerTag+4, testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues("*", "per_tag")))
+	assert.Equal(t, float64(23), testutil.ToFloat64(CacheSchedulerRejectsByCauseTotal.WithLabelValues("global")))
+	assert.Equal(t, float64(14), testutil.ToFloat64(CacheSchedulerRejectsByCauseTotal.WithLabelValues("per_tag")))
 
 	// Unchanged pool totals add nothing.
 	PublishCacheSchedulerSnapshot(SchedulerGlobalStats{
@@ -252,11 +295,65 @@ func TestPublishCacheSchedulerSnapshotPoolRejectBreakdown(t *testing.T) {
 		TotalRejects:       37,
 		TotalRejectsGlobal: 23,
 		TotalRejectsPerTag: 14,
-	}, tags)
-	assert.Equal(t, beforeGlobal+3, testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues("*", "global")))
-	assert.Equal(t, beforePerTag+4, testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues("*", "per_tag")))
+	}, map[string]SchedulerPerTagStats{origin: {Active: 1, Rejects: 37}})
+	assert.Equal(t, float64(23), testutil.ToFloat64(CacheSchedulerRejectsByCauseTotal.WithLabelValues("global")))
+	assert.Equal(t, float64(14), testutil.ToFloat64(CacheSchedulerRejectsByCauseTotal.WithLabelValues("per_tag")))
 
-	// An origin reporting no rejections of its own gets no per-origin
-	// series, so the breakdown stands alone in the rejects collector.
-	assert.Equal(t, 2, testutil.CollectAndCount(CacheSchedulerRejectsTotal))
+	// The two views live in separate metrics, so summing either one alone
+	// gives the true count rather than twice it.
+	assert.Equal(t, float64(37), testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues(origin)))
+	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerRejectsTotal))
+	assert.Equal(t, 2, testutil.CollectAndCount(CacheSchedulerRejectsByCauseTotal))
+}
+
+// TestResetCacheSchedulerMetrics pins that shutting a scheduler down clears
+// the exposition. The gauges describe instantaneous state, so leaving the
+// last pre-shutdown values in place would report a scheduler that no longer
+// exists as though it were still holding transfers.
+func TestResetCacheSchedulerMetrics(t *testing.T) {
+	resetSchedulerMetrics(t)
+	const origin = "reset.example.com"
+
+	PublishCacheSchedulerSnapshot(SchedulerGlobalStats{
+		WorkerCount:        8,
+		StarvingCap:        2,
+		ActiveCap:          7,
+		TotalPending:       3,
+		TotalTags:          1,
+		TotalRejectsGlobal: 5,
+		TotalRejectsPerTag: 6,
+	}, map[string]SchedulerPerTagStats{
+		origin: {Pending: 3, Active: 4, Starving: 1, EMA: 2.0, Admits: 11, Rejects: 11},
+	})
+	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerActive))
+
+	ResetCacheSchedulerMetrics()
+
+	assert.Equal(t, 0, testutil.CollectAndCount(CacheSchedulerActive))
+	assert.Equal(t, 0, testutil.CollectAndCount(CacheSchedulerStarving))
+	assert.Equal(t, 0, testutil.CollectAndCount(CacheSchedulerPending))
+	assert.Equal(t, 0, testutil.CollectAndCount(CacheSchedulerEMA))
+	assert.Equal(t, 0, testutil.CollectAndCount(CacheSchedulerAdmitsTotal))
+	assert.Equal(t, 0, testutil.CollectAndCount(CacheSchedulerRejectsTotal))
+	assert.Equal(t, 0, testutil.CollectAndCount(CacheSchedulerRejectsByCauseTotal))
+	assert.Equal(t, float64(0), testutil.ToFloat64(CacheSchedulerPoolSize))
+	assert.Equal(t, float64(0), testutil.ToFloat64(CacheSchedulerPoolPending))
+	assert.Equal(t, float64(0), testutil.ToFloat64(CacheSchedulerPoolTags))
+	assert.Equal(t, float64(0), testutil.ToFloat64(CacheSchedulerPoolStarvingCap))
+	assert.Equal(t, float64(0), testutil.ToFloat64(CacheSchedulerPoolActiveCap))
+
+	// The delta bookkeeping was reset too, so a scheduler created afterwards
+	// counts from zero rather than being diffed against the dead instance.
+	PublishCacheSchedulerSnapshot(SchedulerGlobalStats{
+		WorkerCount:        8,
+		TotalTags:          1,
+		TotalRejectsGlobal: 1,
+		TotalRejectsPerTag: 1,
+	}, map[string]SchedulerPerTagStats{
+		origin: {Active: 1, Admits: 2, Rejects: 2},
+	})
+	assert.Equal(t, float64(2), testutil.ToFloat64(CacheSchedulerAdmitsTotal.WithLabelValues(origin)))
+	assert.Equal(t, float64(2), testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues(origin)))
+	assert.Equal(t, float64(1), testutil.ToFloat64(CacheSchedulerRejectsByCauseTotal.WithLabelValues("global")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(CacheSchedulerRejectsByCauseTotal.WithLabelValues("per_tag")))
 }

--- a/metrics/scheduler_test.go
+++ b/metrics/scheduler_test.go
@@ -1,0 +1,262 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+// The scheduler metrics are package-level collectors on the default
+// Prometheus registry and the delta bookkeeping lives in the
+// package-level schedulerTracker, so state survives from one test to
+// the next. Every test below therefore uses origin label values unique
+// to itself and never assumes the tracker (or the registry) started out
+// empty. The one label value that is inherently shared is the synthetic
+// origin="*" series, so assertions on it are written as deltas.
+
+// TestPublishCacheSchedulerSnapshotGauges pins that the gauges are a
+// straight mirror of the snapshot: whatever the scheduler reported for a
+// tag is what the per-origin gauges read, and the GlobalStats fields land
+// on the pool-wide gauges.
+func TestPublishCacheSchedulerSnapshotGauges(t *testing.T) {
+	const origin = "TestPublishCacheSchedulerSnapshotGauges.example.com"
+
+	global := SchedulerGlobalStats{
+		WorkerCount:  16,
+		StarvingCap:  4,
+		ActiveCap:    8,
+		TotalPending: 7,
+		TotalTags:    1,
+	}
+	PublishCacheSchedulerSnapshot(global, map[string]SchedulerPerTagStats{
+		origin: {
+			Pending:  7,
+			Active:   3,
+			Starving: 2,
+			EMA:      1.5,
+		},
+	})
+
+	assert.Equal(t, float64(3), testutil.ToFloat64(CacheSchedulerActive.WithLabelValues(origin)))
+	assert.Equal(t, float64(2), testutil.ToFloat64(CacheSchedulerStarving.WithLabelValues(origin)))
+	assert.Equal(t, float64(7), testutil.ToFloat64(CacheSchedulerPending.WithLabelValues(origin)))
+	assert.Equal(t, 1.5, testutil.ToFloat64(CacheSchedulerEMA.WithLabelValues(origin)))
+
+	assert.Equal(t, float64(16), testutil.ToFloat64(CacheSchedulerPoolSize))
+	assert.Equal(t, float64(7), testutil.ToFloat64(CacheSchedulerPoolPending))
+	assert.Equal(t, float64(1), testutil.ToFloat64(CacheSchedulerPoolTags))
+	assert.Equal(t, float64(4), testutil.ToFloat64(CacheSchedulerPoolStarvingCap))
+	assert.Equal(t, float64(8), testutil.ToFloat64(CacheSchedulerPoolActiveCap))
+
+	// A later snapshot with new values overwrites rather than accumulates:
+	// gauges are absolute readings, unlike the admit/reject counters.
+	PublishCacheSchedulerSnapshot(global, map[string]SchedulerPerTagStats{
+		origin: {Pending: 0, Active: 1, Starving: 0, EMA: 0.25},
+	})
+	assert.Equal(t, float64(1), testutil.ToFloat64(CacheSchedulerActive.WithLabelValues(origin)))
+	assert.Equal(t, float64(0), testutil.ToFloat64(CacheSchedulerStarving.WithLabelValues(origin)))
+	assert.Equal(t, float64(0), testutil.ToFloat64(CacheSchedulerPending.WithLabelValues(origin)))
+	assert.Equal(t, 0.25, testutil.ToFloat64(CacheSchedulerEMA.WithLabelValues(origin)))
+}
+
+// TestPublishCacheSchedulerSnapshotCounterDeltas pins that the snapshot's
+// Admits/Rejects are treated as monotonic totals, not as increments. The
+// publisher must add only the difference since the last snapshot, so
+// republishing an unchanged snapshot (which happens whenever the cache is
+// idle between two scrapes of the same counter values) must not
+// double-count.
+func TestPublishCacheSchedulerSnapshotCounterDeltas(t *testing.T) {
+	const origin = "TestPublishCacheSchedulerSnapshotCounterDeltas.example.com"
+	global := SchedulerGlobalStats{WorkerCount: 4, StarvingCap: 1, ActiveCap: 2, TotalTags: 1}
+
+	first := map[string]SchedulerPerTagStats{origin: {Active: 1, Admits: 5, Rejects: 5}}
+	PublishCacheSchedulerSnapshot(global, first)
+	assert.Equal(t, float64(5), testutil.ToFloat64(CacheSchedulerAdmitsTotal.WithLabelValues(origin)))
+	// The per-origin snapshot carries no cause breakdown, so the whole
+	// per-origin reject total shows up under reason="any".
+	assert.Equal(t, float64(5), testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues(origin, "any")))
+
+	// Republishing the identical totals is a no-op.
+	PublishCacheSchedulerSnapshot(global, first)
+	PublishCacheSchedulerSnapshot(global, first)
+	assert.Equal(t, float64(5), testutil.ToFloat64(CacheSchedulerAdmitsTotal.WithLabelValues(origin)))
+	assert.Equal(t, float64(5), testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues(origin, "any")))
+
+	// Growing the totals adds exactly the delta.
+	PublishCacheSchedulerSnapshot(global, map[string]SchedulerPerTagStats{
+		origin: {Active: 1, Admits: 8, Rejects: 8},
+	})
+	assert.Equal(t, float64(8), testutil.ToFloat64(CacheSchedulerAdmitsTotal.WithLabelValues(origin)))
+	assert.Equal(t, float64(8), testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues(origin, "any")))
+}
+
+// TestPublishCacheSchedulerSnapshotPrunesVanishedOrigins pins that an
+// origin the scheduler has evicted (its EMA decayed away and it has no
+// queued or in-flight work, so it is simply absent from the snapshot's
+// tag map) loses all of its label series. Otherwise every origin the
+// cache ever contacted would stay in the exposition forever and the
+// cardinality would only grow.
+//
+// Existence is checked by counting the series in each collector rather
+// than by reading a value: ToFloat64(vec.WithLabelValues(...)) would
+// create the very series whose absence is under test.
+func TestPublishCacheSchedulerSnapshotPrunesVanishedOrigins(t *testing.T) {
+	const origin = "TestPublishCacheSchedulerSnapshotPrunesVanishedOrigins.example.com"
+	const other = "TestPublishCacheSchedulerSnapshotPrunesVanishedOrigins.other.example.com"
+	global := SchedulerGlobalStats{WorkerCount: 4, StarvingCap: 1, ActiveCap: 2, TotalTags: 1}
+
+	// The synthetic origin="*" reject series are never pruned, and they
+	// only come into existence once the pool has actually rejected
+	// something. Whether they are already present depends on what ran
+	// before, so count them once and treat that as the floor for the
+	// rejects collector.
+	PublishCacheSchedulerSnapshot(global, map[string]SchedulerPerTagStats{})
+	poolRejectSeries := testutil.CollectAndCount(CacheSchedulerRejectsTotal)
+
+	PublishCacheSchedulerSnapshot(global, map[string]SchedulerPerTagStats{
+		origin: {Pending: 1, Active: 2, Starving: 1, EMA: 2.5, Admits: 9, Rejects: 3},
+	})
+	// Only this origin is in the snapshot, so exactly one series per
+	// gauge exists.
+	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerActive))
+	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerStarving))
+	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerPending))
+	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerEMA))
+	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerAdmitsTotal))
+	// One per-origin reason="any" series on top of the pool-wide floor.
+	assert.Equal(t, poolRejectSeries+1, testutil.CollectAndCount(CacheSchedulerRejectsTotal))
+
+	// The origin drops out of the snapshot entirely: replaced by an
+	// unrelated origin so the publish is a realistic one rather than an
+	// empty pool.
+	PublishCacheSchedulerSnapshot(global, map[string]SchedulerPerTagStats{
+		other: {Pending: 0, Active: 1, Starving: 0, EMA: 0.5},
+	})
+	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerActive))
+	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerStarving))
+	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerPending))
+	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerEMA))
+	assert.Equal(t, float64(1), testutil.ToFloat64(CacheSchedulerActive.WithLabelValues(other)))
+	// "other" reported no admits or rejects, so the admits vec is now
+	// empty and the rejects vec is back down to the pool-wide floor.
+	assert.Equal(t, 0, testutil.CollectAndCount(CacheSchedulerAdmitsTotal))
+	assert.Equal(t, poolRejectSeries, testutil.CollectAndCount(CacheSchedulerRejectsTotal))
+
+	// Dropping every origin empties the labeled collectors completely.
+	PublishCacheSchedulerSnapshot(global, map[string]SchedulerPerTagStats{})
+	assert.Equal(t, 0, testutil.CollectAndCount(CacheSchedulerActive))
+	assert.Equal(t, 0, testutil.CollectAndCount(CacheSchedulerStarving))
+	assert.Equal(t, 0, testutil.CollectAndCount(CacheSchedulerPending))
+	assert.Equal(t, 0, testutil.CollectAndCount(CacheSchedulerEMA))
+	assert.Equal(t, 0, testutil.CollectAndCount(CacheSchedulerAdmitsTotal))
+	assert.Equal(t, poolRejectSeries, testutil.CollectAndCount(CacheSchedulerRejectsTotal))
+}
+
+// TestPublishCacheSchedulerSnapshotResetsAfterReappearance pins the
+// behavior when an evicted origin comes back. The scheduler forgets an
+// idle tag's per-tag counters when it evicts it, so the next snapshot
+// reports small totals again rather than continuing from where the old
+// tag left off. The publisher must have forgotten its own last-seen
+// totals at prune time too; otherwise the smaller total would look like a
+// negative delta (and Prometheus counters cannot go backwards).
+func TestPublishCacheSchedulerSnapshotResetsAfterReappearance(t *testing.T) {
+	const origin = "TestPublishCacheSchedulerSnapshotResetsAfterReappearance.example.com"
+	global := SchedulerGlobalStats{WorkerCount: 4, StarvingCap: 1, ActiveCap: 2, TotalTags: 1}
+
+	PublishCacheSchedulerSnapshot(global, map[string]SchedulerPerTagStats{
+		origin: {Active: 1, Admits: 10, Rejects: 10},
+	})
+	assert.Equal(t, float64(10), testutil.ToFloat64(CacheSchedulerAdmitsTotal.WithLabelValues(origin)))
+	assert.Equal(t, float64(10), testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues(origin, "any")))
+
+	// Idle long enough to be evicted.
+	PublishCacheSchedulerSnapshot(global, map[string]SchedulerPerTagStats{})
+
+	// Back with freshly zeroed per-tag counters.
+	assert.NotPanics(t, func() {
+		PublishCacheSchedulerSnapshot(global, map[string]SchedulerPerTagStats{
+			origin: {Active: 1, Admits: 2, Rejects: 2},
+		})
+	})
+	assert.Equal(t, float64(2), testutil.ToFloat64(CacheSchedulerAdmitsTotal.WithLabelValues(origin)))
+	assert.Equal(t, float64(2), testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues(origin, "any")))
+	assert.Equal(t, 1, testutil.CollectAndCount(CacheSchedulerAdmitsTotal))
+}
+
+// TestPublishCacheSchedulerSnapshotPoolRejectBreakdown pins the cause
+// breakdown for rejections. The per-tag snapshot cannot say why a fetch
+// was rejected, so the "global pending buffer was full" versus "this
+// origin's own queue was full" split is published only on the synthetic
+// origin="*" series, and like the per-origin counters it is fed the
+// difference between successive snapshots.
+//
+// The "*" series is shared by the whole package (it has no per-test label
+// to make unique), so the assertions below compare against the value read
+// just before the incrementing publish instead of an absolute total.
+func TestPublishCacheSchedulerSnapshotPoolRejectBreakdown(t *testing.T) {
+	const origin = "TestPublishCacheSchedulerSnapshotPoolRejectBreakdown.example.com"
+	tags := map[string]SchedulerPerTagStats{origin: {Active: 1}}
+
+	// Establish a baseline for the tracker's last-seen totals.
+	PublishCacheSchedulerSnapshot(SchedulerGlobalStats{
+		WorkerCount:        4,
+		StarvingCap:        1,
+		ActiveCap:          2,
+		TotalTags:          1,
+		TotalRejects:       30,
+		TotalRejectsGlobal: 20,
+		TotalRejectsPerTag: 10,
+	}, tags)
+
+	beforeGlobal := testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues("*", "global"))
+	beforePerTag := testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues("*", "per_tag"))
+
+	PublishCacheSchedulerSnapshot(SchedulerGlobalStats{
+		WorkerCount:        4,
+		StarvingCap:        1,
+		ActiveCap:          2,
+		TotalTags:          1,
+		TotalRejects:       37,
+		TotalRejectsGlobal: 23,
+		TotalRejectsPerTag: 14,
+	}, tags)
+
+	assert.Equal(t, beforeGlobal+3, testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues("*", "global")))
+	assert.Equal(t, beforePerTag+4, testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues("*", "per_tag")))
+
+	// Unchanged pool totals add nothing.
+	PublishCacheSchedulerSnapshot(SchedulerGlobalStats{
+		WorkerCount:        4,
+		StarvingCap:        1,
+		ActiveCap:          2,
+		TotalTags:          1,
+		TotalRejects:       37,
+		TotalRejectsGlobal: 23,
+		TotalRejectsPerTag: 14,
+	}, tags)
+	assert.Equal(t, beforeGlobal+3, testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues("*", "global")))
+	assert.Equal(t, beforePerTag+4, testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues("*", "per_tag")))
+
+	// An origin reporting no rejections of its own gets no per-origin
+	// series, so the breakdown stands alone in the rejects collector.
+	assert.Equal(t, 2, testutil.CollectAndCount(CacheSchedulerRejectsTotal))
+}

--- a/metrics/scheduler_test.go
+++ b/metrics/scheduler_test.go
@@ -344,16 +344,21 @@ func TestResetCacheSchedulerMetrics(t *testing.T) {
 
 	// The delta bookkeeping was reset too, so a scheduler created afterwards
 	// counts from zero rather than being diffed against the dead instance.
+	//
+	// The totals here are deliberately LARGER than the dead instance's. Smaller
+	// ones would prove nothing: counterDelta already treats a decrease as a
+	// restart, so they would come out right whether or not the tracker was
+	// cleared. Diffing 20 against a retained 11 would yield 9.
 	PublishCacheSchedulerSnapshot(SchedulerGlobalStats{
 		WorkerCount:        8,
 		TotalTags:          1,
-		TotalRejectsGlobal: 1,
-		TotalRejectsPerTag: 1,
+		TotalRejectsGlobal: 9,
+		TotalRejectsPerTag: 12,
 	}, map[string]SchedulerPerTagStats{
-		origin: {Active: 1, Admits: 2, Rejects: 2},
+		origin: {Active: 1, Admits: 20, Rejects: 20},
 	})
-	assert.Equal(t, float64(2), testutil.ToFloat64(CacheSchedulerAdmitsTotal.WithLabelValues(origin)))
-	assert.Equal(t, float64(2), testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues(origin)))
-	assert.Equal(t, float64(1), testutil.ToFloat64(CacheSchedulerRejectsByCauseTotal.WithLabelValues("global")))
-	assert.Equal(t, float64(1), testutil.ToFloat64(CacheSchedulerRejectsByCauseTotal.WithLabelValues("per_tag")))
+	assert.Equal(t, float64(20), testutil.ToFloat64(CacheSchedulerAdmitsTotal.WithLabelValues(origin)))
+	assert.Equal(t, float64(20), testutil.ToFloat64(CacheSchedulerRejectsTotal.WithLabelValues(origin)))
+	assert.Equal(t, float64(9), testutil.ToFloat64(CacheSchedulerRejectsByCauseTotal.WithLabelValues("global")))
+	assert.Equal(t, float64(12), testutil.ToFloat64(CacheSchedulerRejectsByCauseTotal.WithLabelValues("per_tag")))
 }

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -143,6 +143,11 @@ var runtimeConfigurableMap = map[string]bool{
 	"Cache.SelfTestMaxAge": false,
 	"Cache.SentinelLocation": false,
 	"Cache.StorageLocation": false,
+	"Cache.Throttle.EMAWindow": false,
+	"Cache.Throttle.PendingBufferSize": false,
+	"Cache.Throttle.PerOriginActivePercent": false,
+	"Cache.Throttle.PerOriginPendingSize": false,
+	"Cache.Throttle.PerOriginStarvingPercent": false,
 	"Cache.Url": false,
 	"Cache.WorkerCount": false,
 	"Cache.XRootDPrefix": false,
@@ -885,6 +890,10 @@ var intAccessors = map[string]func(*Config) int{
 	"Cache.DataScanResampleInterval": func(c *Config) int { return c.Cache.DataScanResampleInterval },
 	"Cache.EvictionMonitoringMaxDepth": func(c *Config) int { return c.Cache.EvictionMonitoringMaxDepth },
 	"Cache.Port": func(c *Config) int { return c.Cache.Port },
+	"Cache.Throttle.PendingBufferSize": func(c *Config) int { return c.Cache.Throttle.PendingBufferSize },
+	"Cache.Throttle.PerOriginActivePercent": func(c *Config) int { return c.Cache.Throttle.PerOriginActivePercent },
+	"Cache.Throttle.PerOriginPendingSize": func(c *Config) int { return c.Cache.Throttle.PerOriginPendingSize },
+	"Cache.Throttle.PerOriginStarvingPercent": func(c *Config) int { return c.Cache.Throttle.PerOriginStarvingPercent },
 	"Cache.WorkerCount": func(c *Config) int { return c.Cache.WorkerCount },
 	"ClientAgent.HistoryRetentionDays": func(c *Config) int { return c.ClientAgent.HistoryRetentionDays },
 	"ClientAgent.MaxConcurrentJobs": func(c *Config) int { return c.ClientAgent.MaxConcurrentJobs },
@@ -1131,6 +1140,7 @@ var durationAccessors = map[string]func(*Config) time.Duration{
 	"Cache.MinDirectorRefreshInterval": func(c *Config) time.Duration { return c.Cache.MinDirectorRefreshInterval },
 	"Cache.SelfTestInterval": func(c *Config) time.Duration { return c.Cache.SelfTestInterval },
 	"Cache.SelfTestMaxAge": func(c *Config) time.Duration { return c.Cache.SelfTestMaxAge },
+	"Cache.Throttle.EMAWindow": func(c *Config) time.Duration { return c.Cache.Throttle.EMAWindow },
 	"ClientAgent.IdleTimeout": func(c *Config) time.Duration { return c.ClientAgent.IdleTimeout },
 	"ClientAgent.ProgressUpdateInterval": func(c *Config) time.Duration { return c.ClientAgent.ProgressUpdateInterval },
 	"Client.SlowTransferRampupTime": func(c *Config) time.Duration { return c.Client.SlowTransferRampupTime },
@@ -1336,6 +1346,11 @@ var allParameterNames = []string{
 	"Cache.SelfTestMaxAge",
 	"Cache.SentinelLocation",
 	"Cache.StorageLocation",
+	"Cache.Throttle.EMAWindow",
+	"Cache.Throttle.PendingBufferSize",
+	"Cache.Throttle.PerOriginActivePercent",
+	"Cache.Throttle.PerOriginPendingSize",
+	"Cache.Throttle.PerOriginStarvingPercent",
 	"Cache.Url",
 	"Cache.WorkerCount",
 	"Cache.XRootDPrefix",
@@ -1995,6 +2010,10 @@ var (
 	Cache_DataScanResampleInterval = IntParam{"Cache.DataScanResampleInterval"}
 	Cache_EvictionMonitoringMaxDepth = IntParam{"Cache.EvictionMonitoringMaxDepth"}
 	Cache_Port = IntParam{"Cache.Port"}
+	Cache_Throttle_PendingBufferSize = IntParam{"Cache.Throttle.PendingBufferSize"}
+	Cache_Throttle_PerOriginActivePercent = IntParam{"Cache.Throttle.PerOriginActivePercent"}
+	Cache_Throttle_PerOriginPendingSize = IntParam{"Cache.Throttle.PerOriginPendingSize"}
+	Cache_Throttle_PerOriginStarvingPercent = IntParam{"Cache.Throttle.PerOriginStarvingPercent"}
 	Cache_WorkerCount = IntParam{"Cache.WorkerCount"}
 	ClientAgent_HistoryRetentionDays = IntParam{"ClientAgent.HistoryRetentionDays"}
 	ClientAgent_MaxConcurrentJobs = IntParam{"ClientAgent.MaxConcurrentJobs"}
@@ -2148,6 +2167,7 @@ var (
 	Cache_MinDirectorRefreshInterval = DurationParam{"Cache.MinDirectorRefreshInterval"}
 	Cache_SelfTestInterval = DurationParam{"Cache.SelfTestInterval"}
 	Cache_SelfTestMaxAge = DurationParam{"Cache.SelfTestMaxAge"}
+	Cache_Throttle_EMAWindow = DurationParam{"Cache.Throttle.EMAWindow"}
 	ClientAgent_IdleTimeout = DurationParam{"ClientAgent.IdleTimeout"}
 	ClientAgent_ProgressUpdateInterval = DurationParam{"ClientAgent.ProgressUpdateInterval"}
 	Client_SlowTransferRampupTime = DurationParam{"Client.SlowTransferRampupTime"}
@@ -2484,6 +2504,10 @@ func init() {
 		"Cache.DataScanResampleInterval": Cache_DataScanResampleInterval,
 		"Cache.EvictionMonitoringMaxDepth": Cache_EvictionMonitoringMaxDepth,
 		"Cache.Port": Cache_Port,
+		"Cache.Throttle.PendingBufferSize": Cache_Throttle_PendingBufferSize,
+		"Cache.Throttle.PerOriginActivePercent": Cache_Throttle_PerOriginActivePercent,
+		"Cache.Throttle.PerOriginPendingSize": Cache_Throttle_PerOriginPendingSize,
+		"Cache.Throttle.PerOriginStarvingPercent": Cache_Throttle_PerOriginStarvingPercent,
 		"Cache.WorkerCount": Cache_WorkerCount,
 		"ClientAgent.HistoryRetentionDays": ClientAgent_HistoryRetentionDays,
 		"ClientAgent.MaxConcurrentJobs": ClientAgent_MaxConcurrentJobs,
@@ -2628,6 +2652,7 @@ func init() {
 		"Cache.MinDirectorRefreshInterval": Cache_MinDirectorRefreshInterval,
 		"Cache.SelfTestInterval": Cache_SelfTestInterval,
 		"Cache.SelfTestMaxAge": Cache_SelfTestMaxAge,
+		"Cache.Throttle.EMAWindow": Cache_Throttle_EMAWindow,
 		"ClientAgent.IdleTimeout": ClientAgent_IdleTimeout,
 		"ClientAgent.ProgressUpdateInterval": ClientAgent_ProgressUpdateInterval,
 		"Client.SlowTransferRampupTime": Client_SlowTransferRampupTime,

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -148,6 +148,7 @@ var runtimeConfigurableMap = map[string]bool{
 	"Cache.Throttle.PerOriginActivePercent": false,
 	"Cache.Throttle.PerOriginPendingSize": false,
 	"Cache.Throttle.PerOriginStarvingPercent": false,
+	"Cache.Throttle.RetryAfter": false,
 	"Cache.Url": false,
 	"Cache.WorkerCount": false,
 	"Cache.XRootDPrefix": false,
@@ -1141,6 +1142,7 @@ var durationAccessors = map[string]func(*Config) time.Duration{
 	"Cache.SelfTestInterval": func(c *Config) time.Duration { return c.Cache.SelfTestInterval },
 	"Cache.SelfTestMaxAge": func(c *Config) time.Duration { return c.Cache.SelfTestMaxAge },
 	"Cache.Throttle.EMAWindow": func(c *Config) time.Duration { return c.Cache.Throttle.EMAWindow },
+	"Cache.Throttle.RetryAfter": func(c *Config) time.Duration { return c.Cache.Throttle.RetryAfter },
 	"ClientAgent.IdleTimeout": func(c *Config) time.Duration { return c.ClientAgent.IdleTimeout },
 	"ClientAgent.ProgressUpdateInterval": func(c *Config) time.Duration { return c.ClientAgent.ProgressUpdateInterval },
 	"Client.SlowTransferRampupTime": func(c *Config) time.Duration { return c.Client.SlowTransferRampupTime },
@@ -1351,6 +1353,7 @@ var allParameterNames = []string{
 	"Cache.Throttle.PerOriginActivePercent",
 	"Cache.Throttle.PerOriginPendingSize",
 	"Cache.Throttle.PerOriginStarvingPercent",
+	"Cache.Throttle.RetryAfter",
 	"Cache.Url",
 	"Cache.WorkerCount",
 	"Cache.XRootDPrefix",
@@ -2168,6 +2171,7 @@ var (
 	Cache_SelfTestInterval = DurationParam{"Cache.SelfTestInterval"}
 	Cache_SelfTestMaxAge = DurationParam{"Cache.SelfTestMaxAge"}
 	Cache_Throttle_EMAWindow = DurationParam{"Cache.Throttle.EMAWindow"}
+	Cache_Throttle_RetryAfter = DurationParam{"Cache.Throttle.RetryAfter"}
 	ClientAgent_IdleTimeout = DurationParam{"ClientAgent.IdleTimeout"}
 	ClientAgent_ProgressUpdateInterval = DurationParam{"ClientAgent.ProgressUpdateInterval"}
 	Client_SlowTransferRampupTime = DurationParam{"Client.SlowTransferRampupTime"}
@@ -2653,6 +2657,7 @@ func init() {
 		"Cache.SelfTestInterval": Cache_SelfTestInterval,
 		"Cache.SelfTestMaxAge": Cache_SelfTestMaxAge,
 		"Cache.Throttle.EMAWindow": Cache_Throttle_EMAWindow,
+		"Cache.Throttle.RetryAfter": Cache_Throttle_RetryAfter,
 		"ClientAgent.IdleTimeout": ClientAgent_IdleTimeout,
 		"ClientAgent.ProgressUpdateInterval": ClientAgent_ProgressUpdateInterval,
 		"Client.SlowTransferRampupTime": Client_SlowTransferRampupTime,

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -79,6 +79,7 @@ type Config struct {
 			PerOriginActivePercent int `mapstructure:"peroriginactivepercent" yaml:"PerOriginActivePercent"`
 			PerOriginPendingSize int `mapstructure:"peroriginpendingsize" yaml:"PerOriginPendingSize"`
 			PerOriginStarvingPercent int `mapstructure:"peroriginstarvingpercent" yaml:"PerOriginStarvingPercent"`
+			RetryAfter time.Duration `mapstructure:"retryafter" yaml:"RetryAfter"`
 		} `mapstructure:"throttle" yaml:"Throttle"`
 		Url string `mapstructure:"url" yaml:"Url"`
 		WorkerCount int `mapstructure:"workercount" yaml:"WorkerCount"`
@@ -605,6 +606,7 @@ type configWithType struct {
 			PerOriginActivePercent struct { Type string; Value int }
 			PerOriginPendingSize struct { Type string; Value int }
 			PerOriginStarvingPercent struct { Type string; Value int }
+			RetryAfter struct { Type string; Value time.Duration }
 		}
 		Url struct { Type string; Value string }
 		WorkerCount struct { Type string; Value int }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -73,6 +73,13 @@ type Config struct {
 		SelfTestMaxAge time.Duration `mapstructure:"selftestmaxage" yaml:"SelfTestMaxAge"`
 		SentinelLocation string `mapstructure:"sentinellocation" yaml:"SentinelLocation"`
 		StorageLocation string `mapstructure:"storagelocation" yaml:"StorageLocation"`
+		Throttle struct {
+			EMAWindow time.Duration `mapstructure:"emawindow" yaml:"EMAWindow"`
+			PendingBufferSize int `mapstructure:"pendingbuffersize" yaml:"PendingBufferSize"`
+			PerOriginActivePercent int `mapstructure:"peroriginactivepercent" yaml:"PerOriginActivePercent"`
+			PerOriginPendingSize int `mapstructure:"peroriginpendingsize" yaml:"PerOriginPendingSize"`
+			PerOriginStarvingPercent int `mapstructure:"peroriginstarvingpercent" yaml:"PerOriginStarvingPercent"`
+		} `mapstructure:"throttle" yaml:"Throttle"`
 		Url string `mapstructure:"url" yaml:"Url"`
 		WorkerCount int `mapstructure:"workercount" yaml:"WorkerCount"`
 		XRootDPrefix string `mapstructure:"xrootdprefix" yaml:"XRootDPrefix"`
@@ -592,6 +599,13 @@ type configWithType struct {
 		SelfTestMaxAge struct { Type string; Value time.Duration }
 		SentinelLocation struct { Type string; Value string }
 		StorageLocation struct { Type string; Value string }
+		Throttle struct {
+			EMAWindow struct { Type string; Value time.Duration }
+			PendingBufferSize struct { Type string; Value int }
+			PerOriginActivePercent struct { Type string; Value int }
+			PerOriginPendingSize struct { Type string; Value int }
+			PerOriginStarvingPercent struct { Type string; Value int }
+		}
 		Url struct { Type string; Value string }
 		WorkerCount struct { Type string; Value int }
 		XRootDPrefix struct { Type string; Value string }


### PR DESCRIPTION
## Motivation

A single unresponsive upstream origin — one that accepts the TCP connection but never sends bytes — can currently hold every one of the cache's transfer-worker slots on stalled connections until each request times out (order of a minute). During that window the cache looks unresponsive to **every** client, even those reading from healthy origins.

This PR adds a **per-origin fair scheduler** (`client.TagScheduler`) in front of the transfer engine's worker pool, enabled by default on cache servers and disabled by setting `Cache.Throttle.PendingBufferSize=0`. It bounds how much of the pool any single origin may hold, sheds overflow immediately with an HTTP 429 + `Retry-After` rather than queueing it behind the stalled origin, and exposes per-origin activity as Prometheus metrics so operators can see which origin is driving rejections.

## Design

`TagScheduler` is an admission + dispatch layer between the engine's transfer-file producers (`createTransferFiles`, the recursive walkers, TPC copy) and the workers reading from `te.files`. Every submission is tagged; today the tag is the upstream origin hostname, and the key is opaque to the scheduler so a username or prefix can be composed into it later without a scheduler change. Each tag gets its own FIFO.

Two caps bound a single tag's share of the pool:

- **`PerOriginStarvingPercent`** (default 25%) — while a transfer has not yet produced its first byte of body it counts against this smaller cap. The first-byte signal (fired from `progressWriter.Write` on the initial non-empty payload) releases the starving slot. Uploads leave the starving bucket when the destination proves responsive — the earliest of a negotiated `100 Continue`, the first response byte (via `httptrace`), or 4 MiB of request body consumed by the transport (past any plausible socket buffering, so the far end must be draining it; without 100-continue, a destination that only answers after the full body would otherwise leave a long upload starving for its whole duration). TPC copies leave it on the earlier of the COPY response's first byte and the first parsed transfer progress marker.
- **`PerOriginActivePercent`** (default 90%) — total (starving + active) ceiling, so even healthy transfers can't fully monopolise the pool.

Both caps round up, and the worker count is floored at 1, so a small pool can never produce a cap of zero and wedge a tag entirely.

Admission checks the per-tag pending cap (**`PerOriginPendingSize`**, default 50) first, then the global **`PendingBufferSize`** (default 200). A tag with an empty FIFO may enqueue one entry even when the global buffer is full: without that reservation, a handful of saturated origins could pin the global buffer and lock every healthy origin out of admission entirely (the overshoot is bounded by one entry per distinct tag). Anything already queued is dispatched via a weighted probabilistic draw across eligible tags with weight `1/(1+EMA)`, where EMA is the active-worker count for that tag over the last **`EMAWindow`** (default 30s) — so tags that have been quiet get priority. FIFO order within a tag is preserved.

Failover: a transfer keeps its first-attempt tag for its whole lifetime even if it retries against a different origin. Small bounded accounting leak; retagging mid-flight isn't worth the complexity.

Tag state is bounded: per-tag counters for a fully idle tag (nothing queued or in flight, EMA decayed, no activity for at least the EMA window) are evicted, so neither scheduler memory nor Prometheus label cardinality grows with every origin the cache has ever contacted.

Lifecycle: `Stop` is idempotent and concurrency-safe; the internal stop signal is closed however the run loop exits, including on context cancellation, so nothing waiting on the scheduler (`Submit`, `Snapshot`, the event hooks) depends on a later `Stop()` call to be released. Transfers still queued at shutdown are drained into synthetic failure results, so no job waits forever on a transfer that will never run, and submissions racing shutdown shed with a 429 like any other rejection.

## Structured, retryable shed errors

Shedding is only useful if the client understands the shed. Previously a shed 429's context was discarded by the client — the download path read only the status code, mapped 429 into the generic 4xx bucket (`Specification`, **non-retryable**), and ignored `Retry-After`. So a Pelican/OSDF client treated a shed as a fatal "bad request" (plugin exit 1) and gave up, defeating the point of shedding.

This PR wires the shed through the client's error categorization and splits the single condition into the three the scheduler can distinguish:

- **Scheduler** returns a typed `*SchedulerRejection` carrying a `ShedReason` + origin tag. It unwraps through the typed retryable error for its reason (and thence to `ErrTooManyRequests`, so existing `errors.Is` checks hold), which means a locally-shed transfer is classified exactly like the same shed observed remotely as a 429. The reason reflects the *tag's own* in-flight composition, so an origin is never blamed for pool-wide contention:
  - the tag holds its **starving** cap of first-byte-less fetches → `origin_unresponsive`
  - the tag is at its **active** cap (delivering, at fair share) → `origin_slow`
  - otherwise (global buffer full / pool contention) → `cache_overloaded`
- **Error taxonomy**: three new retryable types — `Transfer.OriginUnresponsive` (6008), `Transfer.OriginSlow` (6009), `Transfer.CacheOverloaded` (6010). 6010 doubles as the generic classification for a 429 that carries no more specific reason, including one from a service other than a cache.
- **Cache** emits the specific reason as the machine-parseable `error` field of the 429 JSON body (bare sentinel still → `too_many_requests`). If the cache's *own* upstream fetch was 429'd, that reason passes through instead of surfacing as a misleading 500. A throttle never masks a more definitive answer: when a fetch tried several object servers and one of them said "not found", the cache answers 404 rather than telling the client to retry forever for an object that does not exist.
- **Client**: every request flavor — GET (all download variants), PUT, HEAD/stat, the cache-status probe, TPC COPY, and the prestage/evict APIs — classifies a 429 into a `CacheThrottleError` that wraps the specific retryable type and carries the parsed reason + `Retry-After` hint (fixing `IsRetryable`/`ShouldRetry`/plugin exit 11). The two paths that reach a peer through a library which hides the response (the WebDAV stat client) or via a bodiless HEAD still classify as retryable; they simply carry no reason.

**Untrusted-peer hardening on the client side:** error-response bodies are read through a 64 KiB `LimitReader` (a hostile peer previously had an unbounded-allocation primitive per worker), including the paths that reach a cache through the prestage and evict clients; `httputil.DumpResponse` no longer reads PUT error bodies in full, which had been defeating that bound. The parsed reason is validated against the known constants (an arbitrary server string can no longer flow into logs or HTCondor ClassAds, where embedded newlines would forge log records); the retained detail is the body's `detail` field, truncated at storage and rendered with `%q` at display so embedded control characters print as escapes; and `Retry-After` is parsed as a 64-bit value so an out-of-range one clamps to the 1-hour ceiling instead of being dropped.

**On honoring `Retry-After`:** the data-transfer path has no in-process whole-transfer retry — the attempt loop rotates across object servers once, and retryability drives the *external* retrier (condor plugin, exit 11). Sleeping inside a bounded transfer worker would hold the exact resource the scheduler exists to protect (and 429s arrive in bursts), so an in-worker backoff is a deliberate non-goal. Instead the hint is surfaced everywhere a retrier can see it: on the typed error (`RetryAfter` field), in the HTCondor result ad (`DeveloperData.RetryAfterSeconds`, rounded up so a sub-second hint doesn't read as "none", plus `ThrottleReason` — the plugin ad protocol has no retry-delay attribute, so `DeveloperData` is the available channel), and in logs; the error-code docs state this contract explicitly. The advertised value is configurable via `Cache.Throttle.RetryAfter`, which governs the `Retry-After` on every 429 the cache emits, including the prestage queue's. A non-blocking delay queue in the client agent would be the natural future home for actually scheduling by the hint; that machinery does not exist yet and is left to a future change.

## Wiring

- `TransferEngine` gains an optional scheduler field. `NewTransferEngine` now takes With-style variadic options — `WithWorkerCount(n)` and `WithScheduler(s)` — with no-option behavior unchanged; `NewTransferEngineWithWorkers` is deprecated in favor of the options. A configured scheduler is started by the constructor (under the engine's errgroup) and stopped during `Shutdown`. Every dispatch site that used to send on `te.files` now routes through `TransferEngine.submitFile`, which either goes through the scheduler (admission returning `nil` or `ErrTooManyRequests`) or falls back to the raw send when no scheduler is configured.
- On 429 rejection `submitFile` pushes a synthetic `clientTransferResults` (built via `newTransferResults`, so `Source`/`Attempts` are populated for job-status displays) and every submit site counts `totalXfer` *before* submission — otherwise an all-shed recursive job would take `runMux`'s "no transfers created" path and close the results channel while synthetic results were still queued (send-on-closed-channel panic). A submission that fails for any *other* reason produces no result at all, so all six submit sites roll the counts back (`uncountSubmission`) and report the error as a lookup failure; leaving them in place would keep the job's active count permanently non-zero and its results channel open forever.
- `local_cache/persistent_cache.go`: `newCacheScheduler` decides how the engine is sized and whether it gets a scheduler — a cache server uses `Cache.WorkerCount` and gets one, the local (client-side) cache keeps the client defaults and does not. **Setting `Cache.Throttle.PendingBufferSize=0` disables the scheduler entirely** and falls back to today's raw channel.
- `local_cache/persistent_cache_api.go`: `handleError` maps a throttle to HTTP 429 with a `Retry-After` derived from `Cache.Throttle.RetryAfter`, so remote clients get a proper backoff signal instead of a generic 500.

Also fixed along the way, both reachable independently of the scheduler: the local file opened for an upload was never closed (an fd leak per filesystem upload, and a held lock on Windows), and the PUT goroutine could block forever on an unbuffered response channel when the upload was abandoned early — which, with the new `defer file.Close()`, would have turned a clean abort into a read from a closed file. The response channel is buffered and the goroutine is now joined before the file is closed.

## Pre-existing hangs fixed here too

Two bugs found while tracing the accounting above. Neither is caused by the scheduler, but the first is what makes the second one's fix safe, so they travel together.

**`runMux` retired a job while its transfers were still running** (`client/handle_http.go`). A lookup error, or a lookup that produced no transfers, was treated as the end of the job without checking whether anything was still in flight. A recursive walk can fail *after* it has already handed files to the workers; those transfers still owe the client a result, but the job was dropped from the client's active list and — since `Shutdown()` closes the submission channel before waiting for results — the results channel was closed along with it. The next result to arrive is then a send on a closed channel inside `reflect.Select`, which kills the process rather than failing the transfer. `pelican object get -r` on a collection holding a large object next to a subdirectory the origin will not list reaches it. The same shortcut could also make `finishJob` close a sibling job's channel out from under it, and left an empty non-nil slice behind that could make `Shutdown()` wait forever. Jobs are now retired on one rule — the lookup is done and every transfer it created has reported — which is already the rule applied as each result arrives.

**A failed cache startup wedged the process** (`local_cache/`). `NewStorageManager` starts three TTL eviction loops on the caller's errgroup, and `ttlcache`'s `Start()` selects only on its own stop channel, so cancelling the context never reaches them. Six failure paths in `NewPersistentCache` closed the database but not the storage manager, leaving the errgroup unable to drain. In `pelican cache serve` that wait is `egrp.Wait()` in `cmd/root.go`, which runs *before* the logs are flushed and the exit code is chosen — so an unreachable director at boot, or an unset `Federation.DiscoveryUrl`, hangs the process with nothing printed. `Close()` had the mirror-image problem: `Stop()` is a bare send on an unbuffered channel, so it blocks when no loop is running, which is exactly the case for the read-only manager the offline `pelican cache introspect` subcommands build (they all `defer api.Close()`). Both are fixed and both are covered by tests that block for their full timeout without the change.

## Parameters (new)

| Parameter | Type | Default | Meaning |
|---|---|---|---|
| `Cache.Throttle.PerOriginStarvingPercent` | int | 25 | Per-origin cap (% of `Cache.WorkerCount`) on transfers not yet producing a first byte |
| `Cache.Throttle.PerOriginActivePercent` | int | 90 | Per-origin cap (% of `Cache.WorkerCount`) on total in-flight transfers |
| `Cache.Throttle.PendingBufferSize` | int | 200 | Global pending-admissions buffer; **0 disables the scheduler** |
| `Cache.Throttle.PerOriginPendingSize` | int | 50 | Per-origin pending-admissions cap |
| `Cache.Throttle.EMAWindow` | duration | 30s | Time constant for the per-origin active-worker EMA used to weight the fairness draw |
| `Cache.Throttle.RetryAfter` | duration | 60s | Backoff hint advertised in the `Retry-After` header on the cache's 429 responses |

## Observability

`metrics/scheduler.go` publishes a promauto-registered set with an `origin` label:

```
pelican_cache_scheduler_active{origin}          gauge
pelican_cache_scheduler_starving{origin}        gauge
pelican_cache_scheduler_pending{origin}         gauge
pelican_cache_scheduler_ema{origin}             gauge
pelican_cache_scheduler_admits_total{origin}    counter
pelican_cache_scheduler_rejects_total{origin}   counter
pelican_cache_scheduler_rejects_by_cause_total{cause}  counter
```

The scheduler's per-origin snapshot does not attribute a rejection to a cause, so the `global` (pool buffer full) vs `per_tag` (that origin's own queue full) breakdown is published pool-wide under its own metric name rather than as an extra label on the per-origin counter — sharing a name would make the obvious `sum(rate(...))` count every rejection twice. Pool-wide aggregates (`pelican_cache_scheduler_pool_{size,pending_total,tags_total,starving_cap,active_cap}`) never carry the `origin` label.

A periodic (5s) publisher goroutine samples the scheduler via `TagScheduler.Snapshot(ctx)` (a single context-switch round-trip through the scheduler goroutine for a consistent read). Snapshot totals are monotonic per scheduler instance, so the publisher treats a *decrease* as a restart rather than subtracting unsigned totals blind — which would otherwise wrap to an increment near 2^64 whenever a cache is re-created in the same process. Idle origins are evicted from the scheduler's own state after a grace period and their labeled series deleted, and the whole set is cleared when the cache shuts down, so cardinality doesn't accumulate and the gauges never describe a scheduler that no longer exists.

## Known limitations

- The caps are per-origin with no pool-wide starving bound, so an actor controlling several registered origin hostnames can hold several origins' worth of slots; and a single byte of body promotes a transfer out of the starving bucket, so an origin that dribbles one byte and stalls is bounded by the (larger) active cap rather than the starving cap. In both cases `Client.StoppedTransferTimeout` still reclaims the stalled slots, so the exposure is time-bounded — the scheduler narrows the damage window relative to today but is not a complete defense against adversarial origins.
- **The caps are per-origin, not per-requester.** All clients of a shared cache draw on one origin's budget, so a single client issuing enough concurrent requests for distinct uncached objects on one origin can hold that origin's whole active + pending allowance and cause every other client of *that origin* to be shed for the duration. The cache keeps fetching after a client disconnects, so the requests need not even be held open. This is a narrower blast radius than the pool-wide slowdown the same load causes today, but it is a sharper, more targeted one; a per-requester fairness dimension inside a tag is the natural follow-up.
- Shed reasons are advisory attribution, not evidence. `origin_unresponsive` / `origin_slow` are derived from the cache's own in-flight composition, which a client influences by what it asks for (deep byte ranges, tape-staged objects). Operators should not auto-triage an origin as unhealthy on the strength of these alone.
- `Retry-After` is advisory: nothing in-process sleeps on it (see above), so a fleet of shed clients may retry elsewhere immediately.

## Tests

- `client/tag_scheduler_test.go` — accept/dispatch, global + per-tag rejection, starving/active caps and their rounding across pool sizes, first-byte promotion, cross-tag fairness, EMA weighting of the dispatch draw (and that a zero window disables it), 200-goroutine stress, snapshot invariants, reason classification (including honest attribution under pool contention), starving-slot release on early failure, a late first-byte after completion not double-releasing a slot, `schedDone` firing once per file rather than once per worker, shutdown drain via `onDrop`, submit-after-stop shedding, idempotent/concurrent `Stop`, `Snapshot` after `Stop`, release of waiters when the run loop exits on context cancellation, idle-tag eviction, the global-buffer reservation for idle tags and its bounded overshoot, `SchedulerRejection` retryability, and tag derivation including degenerate inputs.
- `client/transfer_engine_submit_test.go` — a non-429 submit failure must be reported and its bookkeeping rolled back (an orphaned job otherwise blocks `Shutdown` forever); a shed produces exactly one synthetic result and lets the job complete; the shutdown drain reaches the engine's results channel, not just `onDrop`.
- `client/throttle_classify_test.go` — 429 classification for the cache-status probe (including that the HEAD fallback must not overwrite it), the WebDAV stat path, and both legs of TPC; plus a not-found regression guard on the stat path.
- `client/throttle_error_test.go` — the reason-string contract is driven from the `ShedReason` constants (a one-sided rename now fails tests instead of silently degrading classification); 429 → retryable; `Retry-After` parsing incl. overflow/clamp; detail sanitization; `errors.Is(…, ErrTooManyRequests)` for remote 429s; `wrapDownloadError` pass-through; `downloadHTTP` 429 → `CacheThrottleError` via httptest (structured, empty, and garbage bodies); PUT 429 through `uploadObject` and its `TransferErrors` accumulator.
- `client/upload_first_byte_test.go` — the 4 MiB sent-bytes threshold and its effect on the starving bucket.
- `metrics/scheduler_test.go` — gauge mirroring, monotonic-delta counter accounting (no double-count on republish), the counter-restart case, label pruning when an origin vanishes, counter reset on reappearance, the pool-wide cause breakdown, and that shutdown clears the series.
- `local_cache/persistent_cache_api_test.go` — throttle → 429 + `Retry-After` (bare, wrapped, structured-reason, upstream-throttle pass-through, non-429 regression guard); precedence against a definitive failure, including an accumulator behind `errors.Wrap`'s two links; and that `Cache.Throttle.RetryAfter` is actually honored rather than every assertion passing on the identical fallback.
- `local_cache/scheduler_disable_test.go` — the on/off switch and worker sizing per cache mode.
- `cmd/plugin_test.go` — the HTCondor result-ad contract for a throttle: `RetryAfterSeconds` (including the sub-second round-up), `ThrottleReason`, the error code, and retryability.
- `client/run_mux_hazard_test.go` — a walk that fails after submitting files must still deliver those transfers' results and only then close the client out; and a job that created no transfers must close it immediately. The first panics with `send on closed channel` without the fix.
- `local_cache/persistent_cache_leak_test.go` — a failed `NewPersistentCache` must leave nothing running in the caller's errgroup, and closing a storage manager whose eviction loops were never started must return. Both block for their full timeout without the fix.
- `e2e_fed_tests/scheduler_burst_test.go` — full-fed burst made deterministic with `Origin.TransferRateLimit: 40KB/s` (the existing afero rate-limited-fs test knob), so the sheds are produced by arithmetic rather than by timing. The raw-HTTP phase asserts 429 + `Retry-After` + structured JSON reasons; a `client.DoGet` phase asserts the errors surface as retryable `CacheThrottleError`s — the full chain from scheduler shed to client classification.
- `local_cache/scheduler_shed_test.go` — federation-less isolation test (~4s, no XRootD): a dribbling httptest origin and a healthy one behind a stub director drive a real server-mode cache + scheduler; asserts per-origin 429 reasons for the slow origin, a concurrent 200 from the healthy origin while the slow fetches are still dribbling, and snapshot reject attribution to the slow tag only.

## Related

The XRootD-client half of this contract (the C++ `XrdClCurl::TagScheduler`, matching `XRD_CURL*` env knobs, and an HTTP-level burst test) landed separately in [PelicanPlatform/xrdcl-pelican#121](https://github.com/PelicanPlatform/xrdcl-pelican/pull/121). This PR is the Go-side / persistent-cache half.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./client/... ./local_cache/... ./metrics/...` and `go vet -tags client ./cmd/` clean
- [x] `gofmt` clean on hand-written files; `param/*.go` and `error_codes/error_codes.go` regenerate identically from the yamls (`go run ../generate` from `generate/`)
- [x] `go test -race ./client/ ./local_cache/ ./metrics/` green locally
- [ ] `TestScheduler_BurstRejects429` green in CI (full-fed; requires an XRootD environment and does not run in the default local sweep; it asserts at least one shed with a per-origin reason rather than an exact split)
