### PR TITLE
Make devcontainer's hostname static

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 	"name": "Pelican",
 	"image": "hub.opensciencegrid.org/pelican_platform/pelican-dev:latest-itb",
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+	"runArgs": [ "--hostname", "pelican-dev" ],
 	"forwardPorts": [
 		8444,
 		8443,


### PR DESCRIPTION
Add `runArgs` to devcontainer file to inject `--hostname pelican-dev` CLI argument for `docker run`.

In this way, container will have a static hostname `pelican-dev`, instead of a dynamic one (e.g., ade3467fac78), which eliminates some repetitive work like changing hostname in `/etc/pelican/pelican.yaml` every time a container is torn down and rebuilt.

Remember that some configurable parameters like `Federation.DirectorUrl` contains the hostname of the container.