### PR TITLE
Fix db token init panic

### DIFF
--- a/api_token/api_token.go
+++ b/api_token/api_token.go
@@ -44,6 +44,12 @@ var (
 	// API token format: <5-char ID>.<64-char secret>, total length = 70, alphanumeric
 	ApiTokenRegex = regexp.MustCompile(`^[a-zA-Z0-9]{5}\.[a-zA-Z0-9]{64}$`)
 
+	// DB returns the live server database handle. The web_ui layer
+	// wires this at init time; this package deliberately does not
+	// import database, so that the client binary never pulls in gorm
+	// and SQLite.
+	DB func() *gorm.DB = nil
+
 	// EffectiveScopesForUser is a hook the web_ui layer wires up at
 	// init time to expose the effective scope set for a user (the
 	// union of DB user_scopes / group_scopes plus config-derived
@@ -245,8 +251,21 @@ func VerifyApiKey(apiKey string) (bool, []string, string, error) {
 		return false, nil, "", errors.New("Failed to decode the secret")
 	}
 
+	// Resolve the database handle on every call rather than reading a
+	// value captured at startup; see the DB hook's docstring. Both
+	// branches below fail closed: token.Verify folds the error into its
+	// compound error and the request gets a 403, which is the same
+	// outcome as any other failed issuer check.
+	if DB == nil {
+		return false, nil, "", errors.New("API token verification unavailable: database hook is not wired")
+	}
+	db := DB()
+	if db == nil {
+		return false, nil, "", errors.New("API token verification unavailable: server database is not initialized")
+	}
+
 	var apiToken server_structs.ApiKey
-	result := ServerDatabase.First(&apiToken, "id = ?", id)
+	result := db.First(&apiToken, "id = ?", id)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return false, nil, "", errors.New("Token not found") // token not found
@@ -364,7 +383,3 @@ func ListApiKeys(db *gorm.DB) ([]server_structs.ApiKey, error) {
 
 	return apiKeys, nil
 }
-
-// ServerDatabase holds the gorm.DB reference for looking up API keys.
-// It is set by the caller (e.g. web_ui) before any token verification happens.
-var ServerDatabase *gorm.DB

--- a/api_token/api_token_test.go
+++ b/api_token/api_token_test.go
@@ -21,10 +21,14 @@ package api_token
 import (
 	"sort"
 	"testing"
+	"time"
 
+	"github.com/glebarez/sqlite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 
+	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/token_scopes"
 )
 
@@ -246,5 +250,154 @@ func TestValidateScopesForCreator(t *testing.T) {
 		}, "u-alice")
 		assert.NoError(t, err,
 			"the fail-closed posture is per-scope: bearer-token authority isn't derived from any user role, so the hook isn't required to authorize it")
+	})
+}
+
+// wellFormedToken is the minimal credential that reaches the database
+// lookup in VerifyApiKey. Both gates in front of the lookup have to be
+// cleared: ApiTokenRegex wants 5 alphanumerics, a dot, and 64
+// alphanumerics, and the secret is then hex-decoded — so the tail must
+// also be valid hex, or the call bails out one step early and never
+// touches the handle. No such key exists in any database; the point is
+// to reach the lookup, not to authenticate. Do not "simplify" this
+// value: a tail with a non-hex letter in it turns every test below
+// into a no-op that passes for the wrong reason.
+const wellFormedToken = "abcde.0000000000000000000000000000000000000000000000000000000000000000"
+
+// newTestDB opens a fresh in-memory SQLite database with the api_keys
+// table migrated.
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&server_structs.ApiKey{}))
+	return db
+}
+
+// withDBHook installs the DB hook for the duration of the subtest and
+// restores whatever was there before.
+//
+// It also clears VerifiedKeysCache at both ends. That cache is a
+// package global keyed by token ID and is consulted before the
+// database; a key verified in one subtest would short-circuit the
+// lookup in the next, skipping the exact code path these tests exist to
+// exercise.
+func withDBHook(t *testing.T, hook func() *gorm.DB) {
+	t.Helper()
+	prev := DB
+	DB = hook
+	VerifiedKeysCache.DeleteAll()
+	t.Cleanup(func() {
+		DB = prev
+		VerifiedKeysCache.DeleteAll()
+	})
+}
+
+// TestDBHookIsResolvedPerCall pins the fix for the nil-handle panic that
+// shipped in v7.26.0, introduced by 482348da9 ("Extract API token code
+// into api_token package").
+//
+// api_token used to hold a `ServerDatabase *gorm.DB` copied from
+// database.ServerDatabase by web_ui.ConfigureServerWebAPI. That runs at
+// launcher.go:97, ahead of every database.InitServerDatabase call site,
+// so the copy was nil for the entire life of every server process and
+// VerifyApiKey panicked inside gorm's getInstance() on the first real
+// API token presented. It was not a startup race — the ordering is
+// deterministic and single-threaded.
+//
+// The contract now: DB is a function resolved on every call, so a handle
+// that appears (or changes) after wiring is picked up, and an
+// unavailable handle produces an error rather than a panic.
+func TestDBHookIsResolvedPerCall(t *testing.T) {
+	scope := token_scopes.Monitoring_Scrape.String()
+
+	t.Run("handle assigned after wiring is seen", func(t *testing.T) {
+		// Mirrors production ordering exactly: the hook is wired while
+		// the underlying handle is still nil (web_ui's init()), and the
+		// database only materializes later (InitServerDatabase). Under
+		// the old snapshot this is precisely the sequence that yielded
+		// a permanently nil handle.
+		var live *gorm.DB
+		withDBHook(t, func() *gorm.DB { return live })
+
+		live = newTestDB(t)
+		tok, err := CreateApiKey(live, "late-db", "u-alice", scope, time.Time{})
+		require.NoError(t, err)
+
+		valid, caps, createdBy, err := VerifyApiKey(tok)
+		require.NoError(t, err)
+		assert.True(t, valid)
+		assert.Equal(t, []string{scope}, caps)
+		assert.Equal(t, "u-alice", createdBy)
+	})
+
+	t.Run("handle reassignment is seen", func(t *testing.T) {
+		// InitServerDatabase reassigns database.ServerDatabase and runs
+		// more than once in a process hosting several modules
+		// (serve --module director --module origin, and the fed tests,
+		// which launch four servers in-process). A captured handle would
+		// stay pinned to the first database even after the swap, so this
+		// case would fail even with the old snapshot correctly ordered.
+		first := newTestDB(t)
+		second := newTestDB(t)
+
+		live := first
+		withDBHook(t, func() *gorm.DB { return live })
+
+		// Mint the key into the SECOND database only.
+		tok, err := CreateApiKey(second, "reassigned", "u-alice", scope, time.Time{})
+		require.NoError(t, err)
+
+		valid, _, _, err := VerifyApiKey(tok)
+		require.Error(t, err, "key must not resolve while the hook still points at the first database")
+		assert.False(t, valid)
+
+		live = second
+		valid, _, _, err = VerifyApiKey(tok)
+		require.NoError(t, err, "the swap must be picked up on the next call")
+		assert.True(t, valid)
+	})
+
+	t.Run("unwired hook fails closed without panicking", func(t *testing.T) {
+		withDBHook(t, nil)
+
+		var valid bool
+		var err error
+		require.NotPanics(t, func() {
+			valid, _, _, err = VerifyApiKey(wellFormedToken)
+		}, "an unavailable database must never panic the request goroutine")
+		require.Error(t, err)
+		assert.False(t, valid)
+		assert.Contains(t, err.Error(), "not wired")
+	})
+
+	t.Run("nil handle fails closed without panicking", func(t *testing.T) {
+		// The v7.26.0 shape: the hook is present but the database behind
+		// it was never initialized.
+		withDBHook(t, func() *gorm.DB { return nil })
+
+		var valid bool
+		var err error
+		require.NotPanics(t, func() {
+			valid, _, _, err = VerifyApiKey(wellFormedToken)
+		}, "an uninitialized database must never panic the request goroutine")
+		require.Error(t, err)
+		assert.False(t, valid)
+		assert.Contains(t, err.Error(), "not initialized")
+	})
+
+	t.Run("Verify surfaces an unavailable database as an error", func(t *testing.T) {
+		// Verify is what token.CheckApiTokenIssuerFunc actually calls, so
+		// this is the entry point the panicking stack traces came in
+		// through. token.Verify folds the error into its compound error
+		// and the request gets a 403.
+		withDBHook(t, func() *gorm.DB { return nil })
+
+		var err error
+		require.NotPanics(t, func() {
+			err = Verify(wellFormedToken, []token_scopes.TokenScope{token_scopes.Monitoring_Scrape}, false)
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not initialized")
 	})
 }

--- a/database/director.go
+++ b/database/director.go
@@ -1,5 +1,0 @@
-package database
-
-import "gorm.io/gorm"
-
-var DirectorDB *gorm.DB

--- a/e2e_fed_tests/api_token_nil_db_test.go
+++ b/e2e_fed_tests/api_token_nil_db_test.go
@@ -1,0 +1,86 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package fed_tests
+
+import (
+	"crypto/tls"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/fed_test_utils"
+	"github.com/pelicanplatform/pelican/param"
+)
+
+// wellFormedApiToken is a syntactically valid API token that matches no
+// database row. Its shape matters and it must not be "simplified":
+//
+//   - api_token.ApiTokenRegex requires exactly 5 alphanumerics, a dot,
+//     then 64 alphanumerics. A JWT (three base64url segments, with '-'
+//     and '_') fails this and is rejected before the database is
+//     consulted.
+//   - VerifyApiKey then hex-decodes the 64-character secret, so the tail
+//     must also be valid hex. A single non-hex letter there short-circuits
+//     the call one step early.
+//
+// Only a credential clearing both gates reaches the database lookup,
+// which is the code path this test exists to cover. Swap in a JWT or a
+// non-hex tail and the test still passes -- for the wrong reason.
+const wellFormedApiToken = "abcde.0000000000000000000000000000000000000000000000000000000000000000"
+
+// TestDirectorApiTokenWithUninitializedDB is the end-to-end regression
+// guard for the nil-database panic.
+func TestDirectorApiTokenWithUninitializedDB(t *testing.T) {
+	fed := fed_test_utils.NewFedTest(t, bothPubNamespaces)
+
+	directorUrl := param.Server_ExternalWebUrl.GetString()
+	require.NotEmpty(t, directorUrl, "fed test did not populate the server web URL")
+
+	req, err := http.NewRequestWithContext(fed.Ctx, http.MethodGet,
+		directorUrl+"/api/v1.0/director/discoverServers", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+wellFormedApiToken)
+
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+		"a bogus API token must be rejected, not panic; a 500 here means api_token's database handle was nil and gorm panicked on it. Body: %s", string(body))
+
+	// Distinguish "rejected the token" from "could not reach the
+	// database". Both are non-200, so the status code alone would not
+	// catch a regression that swapped the panic for a fail-closed error
+	// while leaving the handle unwired.
+	assert.NotContains(t, string(body), "not initialized",
+		"the director reached the API-token check but had no database handle -- the hook is not wired through the real startup path")
+	assert.NotContains(t, string(body), "not wired",
+		"api_token.DB was never wired; web_ui's init() should have set it")
+}

--- a/web_ui/scopes.go
+++ b/web_ui/scopes.go
@@ -62,11 +62,25 @@ import (
 	"github.com/pelicanplatform/pelican/token_scopes"
 )
 
-// init wires the api_token package's EffectiveScopesForUser hook so
-// API-token verification can intersect a key's persisted scopes
-// against the creator's *current* authority on every use. Without
-// this, a user who lost server.user_admin would keep using the
-// scope through any API token they had previously minted.
+// init wires the two hooks the api_token package needs. Both are
+// resolved on every call rather than captured once, because
+// database.ServerDatabase is assigned (and reassigned) by
+// InitServerDatabase long after this init runs.
+//
+// api_token.DB hands over the live server database handle. api_token
+// deliberately does not import database — that separation keeps gorm
+// and SQLite out of the client binary — so it cannot read the global
+// itself. This used to be a plain pointer copy made from
+// ConfigureServerWebAPI, which runs before every InitServerDatabase
+// call site and therefore only ever copied nil; API-token
+// verification then panicked on the nil handle. See the DB hook's
+// docstring in api_token for the full story.
+//
+// EffectiveScopesForUser lets API-token verification intersect a
+// key's persisted scopes against the creator's *current* authority on
+// every use. Without this, a user who lost server.user_admin would
+// keep using the scope through any API token they had previously
+// minted.
 //
 // We resolve through EffectiveScopesForIdentity rather than the
 // pure DB-layer EffectiveScopes so config-derived grants
@@ -80,6 +94,8 @@ import (
 // gap is OIDC-asserted groups, which by definition aren't part of
 // an API token's audit trail.
 func init() {
+	api_token.DB = func() *gorm.DB { return database.ServerDatabase }
+
 	api_token.EffectiveScopesForUser = func(userID string) []token_scopes.TokenScope {
 		// Look up the user record so we can populate Username for
 		// config-derived matching. A deleted user → no scopes,

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -1042,9 +1042,6 @@ func waitUntilLogin(ctx context.Context) error {
 //
 // You need to mount the static resources for UI in a separate function
 func ConfigureServerWebAPI(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group) error {
-	// Give the API token package access to the server DB
-	api_token.ServerDatabase = database.ServerDatabase
-
 	// start the cache for verified API keys
 	egrp.Go(func() error {
 		api_token.VerifiedKeysCache.Start()

--- a/web_ui/ui_test.go
+++ b/web_ui/ui_test.go
@@ -44,7 +44,6 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
-	"github.com/pelicanplatform/pelican/api_token"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/database"
 	"github.com/pelicanplatform/pelican/param"
@@ -761,7 +760,6 @@ func TestApiToken(t *testing.T) {
 
 	mockDB, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	database.ServerDatabase = mockDB
-	api_token.ServerDatabase = mockDB
 	require.NoError(t, err, "Error setting up mock origin DB")
 	err = database.ServerDatabase.AutoMigrate(&server_structs.ApiKey{})
 	require.NoError(t, err, "Failed to migrate DB for API key table")


### PR DESCRIPTION
closes #3589 

Fix nil-database panic in API token verification

The api_token package held its own `ServerDatabase *gorm.DB`, copied
from database.ServerDatabase by web_ui.ConfigureServerWebAPI. That
call sits at launchers/launcher.go:97, ahead of every
database.InitServerDatabase call site -- the director's is in
DirectorServe, the registry's in RegistryServe, and so on. The copy
was therefore nil, and since it was a value rather than a live read,
it stayed nil for the life of the process.

This was not a startup race. Both statements run on the same
goroutine, in one function, in fixed order, so the handle was nil on
every server, every time. VerifyApiKey then dereferenced it and
panicked inside gorm's getInstance(). gin.Recovery() caught the panic
and returned 500, which is why it surfaced as stack traces in director
logs rather than a crashed process.

The panic required an actual API token to reach the check: issuers are
tried in order and APITokenIssuer is never first, and api_token's
format regex plus hex decode reject JWTs and garbage before the
database is consulted. That is why only some federations saw it.

Introduced by 482348da9, which replaced VerifyApiKey's explicit
`db *gorm.DB` parameter with the startup copy. First shipped in
v7.26.0; the v7.25.x line is unaffected.

Replace the copied handle with a `DB func() *gorm.DB` hook that web_ui
wires in its init(), mirroring the EffectiveScopesForUser hook already
in that file. Resolving through a function on every call fixes two
things at once: ordering no longer matters, and the handle cannot go
stale when InitServerDatabase reassigns the global in a process
running several modules. api_token still does not import database, so
the client binary keeps its independence from gorm and SQLite, and
api_token's init() still self-registers the verifier.

Guard both failure modes -- hook unwired, hook returning nil -- with
an error instead of a dereference, so a future ordering mistake
becomes a 403 and a log line rather than a panic.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>