### PR TITLE
Standalone mode for the Origin

### DIFF
--- a/client/acquire_token.go
+++ b/client/acquire_token.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -80,7 +81,12 @@ type (
 	// Thread-safe and will auto-renew the token throughout the lifetime
 	// of the process.  Satisfies the TokenProvider interface.
 	tokenGenerator struct {
-		DirResp                 *server_structs.DirectorResponse
+		DirResp *server_structs.DirectorResponse
+		// tokenIsExplicit reports whether the caller named the credential to use
+		// (WithToken, or a token option on the transfer).  A caller who picked a
+		// credential does not want it silently replaced by one acquired from an
+		// issuer some object server named.
+		tokenIsExplicit         bool
 		Destination             *pelican_url.PelicanURL
 		TokenLocation           string
 		TokenName               string
@@ -170,17 +176,147 @@ func (tg *tokenGenerator) SetToken(contents string) {
 		Expiry:   time.Now().Add(100 * 365 * 24 * time.Hour), // 100 years should be enough for "forever"
 	}
 	tg.Token.Store(&info)
+	// An empty value names no credential, so it does not count as the caller
+	// having chosen one; WithToken("") must not quietly disable token hints.
+	if contents != "" {
+		tg.tokenIsExplicit = true
+	}
 }
 
-// Copy the contents
-func (tg *tokenGenerator) Copy() *tokenGenerator {
-	return &tokenGenerator{
-		DirResp:       tg.DirResp,
-		Destination:   tg.Destination,
-		Operation:     tg.Operation,
-		EnableAcquire: tg.EnableAcquire,
-		Sync:          new(singleflight.Group),
+// cacheToken records a credential that an endpoint has just accepted, so the
+// rest of the job -- the sibling files sharing this generator, and the checksum
+// request that follows a completed download -- reuses it instead of acquiring
+// one of its own.  The credential is stored under its own expiry, not pinned
+// like SetToken's.
+func (tg *tokenGenerator) cacheToken(contents string) {
+	if tg == nil || contents == "" {
+		return
 	}
+	_, expiry := tokenIsValid(contents)
+	tg.Token.Store(&tokenInfo{Contents: contents, Expiry: expiry})
+}
+
+// SetDirectorResponse records the authorization metadata gathered for this
+// transfer, whether a director supplied it or the object server answered for
+// itself.  Which one it was does not decide whether a later token hint may be
+// acted on; see canApplyTokenHint.
+func (tg *tokenGenerator) SetDirectorResponse(dirResp *server_structs.DirectorResponse) {
+	tg.DirResp = dirResp
+}
+
+// canApplyTokenHint reports whether this generator may act on the token hints
+// that objectServer returned alongside a rejection.
+//
+// A hint feeds credential acquisition: honoring the wrong one lets a server
+// choose the issuer a client authenticates against, which can mean posting a
+// stored refresh token to that issuer, registering an OAuth client with it, or
+// showing the user an interactive login prompt it controls.
+//
+// A client may take credential advice only from a host its user named.  The
+// host in the pelican:// URL is such a host: it serves the discovery document,
+// which names the director, the JWKS, and the issuers, so everything the client
+// goes on to believe about the federation already rests on it, and Pelican
+// assumes throughout that the host a user typed is not compromised.  A claim it
+// makes about its own namespaces therefore asks the client to believe nothing
+// it has not already staked the federation on.
+//
+// A host the client was merely *sent* to is not named in that sense.  A cache a
+// director selected, or an HTTP redirect target, holds only trust delegated by
+// someone else, and its hints are refused however plausible they look.
+//
+// Note the distinction is who chose the host, not whether a director exists: a
+// cache the user selected themselves (Client.PreferredCaches, -c) is named as
+// squarely as the URL's host and belongs here too.  Admitting it is left to the
+// change that gives explicitly-chosen caches their own standing, since nothing
+// in standalone mode needs it.
+func (tg *tokenGenerator) canApplyTokenHint(objectServer *url.URL) bool {
+	if tg == nil || objectServer == nil || tg.Destination == nil {
+		return false
+	}
+	// A caller who named a credential, or who supplies its own, is not asking
+	// to be advised.
+	if tg.tokenIsExplicit || tg.externalProvider != nil {
+		return false
+	}
+	// The discovery endpoint is the host from the user's pelican:// URL: see
+	// pelican_url, which overwrites whatever a discovery document claims with
+	// the host actually contacted, so a document cannot nominate a third party
+	// as the trust anchor.
+	discovery, err := url.Parse(tg.Destination.FedInfo.DiscoveryEndpoint)
+	if err != nil || discovery.Host == "" {
+		return false
+	}
+	// Scheme is compared along with host: the assumption is about a host
+	// reached the way the user asked to reach it, and a plaintext endpoint is
+	// not that for an https discovery host.
+	return strings.EqualFold(discovery.Host, objectServer.Host) &&
+		strings.EqualFold(discovery.Scheme, objectServer.Scheme)
+}
+
+// withTokenHint returns a generator that acquires a credential according to the
+// token hints an object server returned, leaving the receiver untouched.
+//
+// The receiver is shared by every file in a transfer job and read concurrently
+// by the job's workers, so neither the hint -- which is specific to one attempt
+// against one endpoint -- nor the fields the receiver mutates while serving
+// those workers may be copied out of it.  In particular TokenName is assigned
+// inside getToken under the receiver's singleflight, so the derived generator
+// leaves it empty and recomputes it from Destination.
+func (tg *tokenGenerator) withTokenHint(dirResp *server_structs.DirectorResponse) *tokenGenerator {
+	return &tokenGenerator{
+		DirResp:        dirResp,
+		Destination:    tg.Destination,
+		TokenLocation:  tg.TokenLocation,
+		Operation:      tg.Operation,
+		EnableAcquire:  tg.EnableAcquire,
+		nonInteractive: tg.nonInteractive,
+		Sync:           new(singleflight.Group),
+	}
+}
+
+// tokenHintKey identifies a hint by what it asks the client to go and get, so
+// that two workers handed the same hint are recognized as wanting the same
+// credential.
+//
+// The issuers are sorted because nothing promises a server lists them in a
+// stable order, and the same set arriving two ways has to produce one key --
+// otherwise the coalescing in tokenForHint quietly stops working in exactly the
+// case it exists for, and a job acquires once per worker.
+func tokenHintKey(dirResp *server_structs.DirectorResponse) string {
+	issuers := make([]string, 0, len(dirResp.XPelTokGenHdr.Issuers))
+	for _, u := range dirResp.XPelTokGenHdr.Issuers {
+		if u != nil {
+			issuers = append(issuers, u.String())
+		}
+	}
+	sort.Strings(issuers)
+
+	var b strings.Builder
+	b.WriteString("hint:")
+	b.WriteString(dirResp.XPelNsHdr.Namespace)
+	for _, issuer := range issuers {
+		b.WriteString("|")
+		b.WriteString(issuer)
+	}
+	return b.String()
+}
+
+// tokenForHint obtains a credential matching a token hint.
+//
+// Every file in a transfer job shares the receiver, and a recursive transfer can
+// have many of them rejected at once.  Running the acquisition through the
+// job's singleflight -- under a key naming the hint rather than the empty key
+// getToken uses -- collapses that burst into one attempt, so a job does not
+// register an OAuth client, or raise an interactive login prompt, once per file.
+func (tg *tokenGenerator) tokenForHint(dirResp *server_structs.DirectorResponse) (string, error) {
+	contents, err, _ := tg.Sync.Do(tokenHintKey(dirResp), func() (interface{}, error) {
+		return tg.withTokenHint(dirResp).Get()
+	})
+	if err != nil {
+		return "", err
+	}
+	token, _ := contents.(string)
+	return token, nil
 }
 
 func (tg *tokenGenerator) recordAuthFailure(statusCode int) (bool, error) {

--- a/client/bearer_auth.go
+++ b/client/bearer_auth.go
@@ -33,6 +33,12 @@ type bearerAuth struct {
 // BearerAuthenticator is an Authenticator for BearerAuth
 type bearerAuthenticator struct {
 	token *tokenGenerator
+	// hintTried records that this request has already acted on a token hint,
+	// so a server that keeps refusing cannot keep sending it back for more.
+	// gowebdav's Clone returns the same instance, so the flag survives the
+	// retry it guards; NewAuthenticator builds a fresh one per request, so
+	// concurrent stats do not share it.
+	hintTried bool
 }
 
 // NewAuthenticator creates a new BearerAuthenticator
@@ -63,6 +69,15 @@ func (b *bearerAuthenticator) Verify(c *http.Client, rs *http.Response, path str
 
 	switch rs.StatusCode {
 	case http.StatusUnauthorized, http.StatusForbidden:
+		// An origin that answers namespace questions about itself says on the
+		// refusal which issuer would have worked.  Acquire that credential and
+		// let gowebdav send the request again, so a stat or a listing learns
+		// the same way a download does instead of paying for a metadata query
+		// before it starts.
+		if !b.hintTried && acquireFromTokenHint(b.token, rs) {
+			b.hintTried = true
+			return true, nil
+		}
 		return b.token.recordAuthFailure(rs.StatusCode)
 	default:
 		if rs.StatusCode < 400 {

--- a/client/dir_resp_cache.go
+++ b/client/dir_resp_cache.go
@@ -56,6 +56,15 @@ type inflightResult struct {
 //
 // Entries expire after a configurable TTL.  The cache is safe for
 // concurrent use.
+//
+// Entries are scoped to the federation they were learned from -- the discovery
+// endpoint, which is the host named in the user's pelican:// URL.  One
+// TransferEngine is shared across every transfer in a process, and namespace
+// paths are not globally unique, so two federations can readily present the
+// same one.  Without that scoping the second transfer would be answered with
+// the first federation's object servers and issuers, and would send its
+// credentials to a host the user never named -- the thing the rest of the
+// client is careful not to do (see canApplyTokenHint).
 type DirRespCache struct {
 	mu      sync.RWMutex
 	entries map[string]dirRespCacheEntry
@@ -129,48 +138,72 @@ func reconstitutePaths(resp server_structs.DirectorResponse, objectPath string) 
 	return resp
 }
 
-// Store saves a DirectorResponse under the given prefix.  Any previous
-// entry for the same prefix is replaced.
+// cacheKey qualifies a namespace prefix with the federation it was learned
+// from.  Neither a discovery endpoint nor a path can contain a newline, so one
+// federation's entries cannot be made to answer for another's.
+func cacheKey(federation, prefix string) string {
+	return federation + "\n" + prefix
+}
+
+// Store saves a DirectorResponse under the given prefix within federation.  Any
+// previous entry for the same prefix in the same federation is replaced.
+//
+// federation is the discovery endpoint the response was learned from, which is
+// the host named in the user's pelican:// URL.  A response is only ever handed
+// back to a later lookup naming that same federation: namespace paths are not
+// globally unique, and answering a request for one federation with another's
+// object servers and issuers would send its credentials to a host the user
+// never named.
 //
 // objectPath is the federation object path (e.g. "/test/file.txt")
 // that was used to obtain this response from the director.  It is
 // stripped from each ObjectServer URL so the cached entry contains
 // only the server-side base path.  Pass "" if no stripping is needed.
-func (c *DirRespCache) Store(prefix string, objectPath string, resp server_structs.DirectorResponse) {
+func (c *DirRespCache) Store(federation string, prefix string, objectPath string, resp server_structs.DirectorResponse) {
 	prefix = path.Clean(prefix)
 	if !strings.HasPrefix(prefix, "/") {
 		log.Debugf("DirRespCache: skipping non-absolute prefix %q", prefix)
 		return
 	}
+	if federation == "" {
+		// Unattributable: caching it would let it answer for any federation.
+		log.Debugf("DirRespCache: skipping entry for prefix %q with no federation", prefix)
+		return
+	}
 	resp = stripFederationPaths(resp, objectPath)
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.entries[prefix] = dirRespCacheEntry{
+	c.entries[cacheKey(federation, prefix)] = dirRespCacheEntry{
 		resp:   resp,
 		expiry: time.Now().Add(c.ttl),
 	}
-	log.Debugf("DirRespCache: stored entry for prefix %q (TTL %s)", prefix, c.ttl)
+	log.Debugf("DirRespCache: stored entry for prefix %q in federation %q (TTL %s)", prefix, federation, c.ttl)
 }
 
-// Lookup finds the longest cached prefix that matches `objectPath`.
+// Lookup finds the longest cached prefix within federation that matches
+// `objectPath`.  An entry learned from a different federation never matches,
+// however similar the path.
 //
 // For example, if the cache contains entries for "/a/b" and "/a", a
 // lookup for "/a/b/c/d.txt" will return the entry for "/a/b".
 //
 // Returns the cached DirectorResponse and true if a valid (non-expired)
 // entry was found, or the zero value and false otherwise.
-func (c *DirRespCache) Lookup(objectPath string) (server_structs.DirectorResponse, bool) {
+func (c *DirRespCache) Lookup(federation string, objectPath string) (server_structs.DirectorResponse, bool) {
 	objectPath = path.Clean(objectPath)
+	if federation == "" {
+		return server_structs.DirectorResponse{}, false
+	}
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
 	now := time.Now()
 
 	// Walk up the path hierarchy from the full path to "/", looking
-	// for the longest matching prefix.
+	// for the longest matching prefix within this federation.
 	candidate := objectPath
 	for {
-		if entry, ok := c.entries[candidate]; ok {
+		if entry, ok := c.entries[cacheKey(federation, candidate)]; ok {
 			if now.Before(entry.expiry) {
 				log.Debugf("DirRespCache: hit for path %q → prefix %q", objectPath, candidate)
 				return reconstitutePaths(entry.resp, objectPath), true
@@ -208,17 +241,20 @@ type DirRespLoader func(ctx context.Context) (resp server_structs.DirectorRespon
 //
 // On success the response is automatically stored in the cache under
 // the prefix returned by the loader.
-func (c *DirRespCache) LookupOrLoad(ctx context.Context, objectPath string, loader DirRespLoader) (server_structs.DirectorResponse, error) {
+func (c *DirRespCache) LookupOrLoad(ctx context.Context, federation string, objectPath string, loader DirRespLoader) (server_structs.DirectorResponse, error) {
 	// Fast path: cache hit.
-	if resp, ok := c.Lookup(objectPath); ok {
+	if resp, ok := c.Lookup(federation, objectPath); ok {
 		return resp, nil
 	}
 
 	objectPath = path.Clean(objectPath)
+	// Coalescing is per federation too: two federations asking about the same
+	// path are asking different questions.
+	inflightKey := cacheKey(federation, objectPath)
 
 	// Check for an in-flight request for this path.
 	c.sfMu.Lock()
-	if cl, ok := c.inflight[objectPath]; ok {
+	if cl, ok := c.inflight[inflightKey]; ok {
 		c.sfMu.Unlock()
 		// Wait with context awareness.
 		resp, err := c.waitForCall(ctx, cl)
@@ -231,7 +267,7 @@ func (c *DirRespCache) LookupOrLoad(ctx context.Context, objectPath string, load
 	// No in-flight request; create one.
 	cl := &call{}
 	cl.wg.Add(1)
-	c.inflight[objectPath] = cl
+	c.inflight[inflightKey] = cl
 	c.sfMu.Unlock()
 
 	// Execute the loader.  We run it in a goroutine so we can
@@ -245,7 +281,7 @@ func (c *DirRespCache) LookupOrLoad(ctx context.Context, objectPath string, load
 		// On success, store in cache (stripping the federation
 		// object path from ObjectServer URLs).
 		if err == nil && prefix != "" {
-			c.Store(prefix, objectPath, resp)
+			c.Store(federation, prefix, objectPath, resp)
 		}
 
 		// Store the stripped version; waitForCall callers will
@@ -257,7 +293,7 @@ func (c *DirRespCache) LookupOrLoad(ctx context.Context, objectPath string, load
 
 		// Clean up the inflight map.
 		c.sfMu.Lock()
-		delete(c.inflight, objectPath)
+		delete(c.inflight, inflightKey)
 		c.sfMu.Unlock()
 	}()
 
@@ -290,12 +326,12 @@ func (c *DirRespCache) waitForCall(ctx context.Context, cl *call) (server_struct
 	}
 }
 
-// Invalidate removes the entry for the given prefix.
-func (c *DirRespCache) Invalidate(prefix string) {
+// Invalidate removes the entry for the given prefix within federation.
+func (c *DirRespCache) Invalidate(federation string, prefix string) {
 	prefix = path.Clean(prefix)
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	delete(c.entries, prefix)
+	delete(c.entries, cacheKey(federation, prefix))
 }
 
 // InvalidateAll removes all cached entries.

--- a/client/dir_resp_cache_test.go
+++ b/client/dir_resp_cache_test.go
@@ -43,76 +43,80 @@ func makeDirResp(namespace string) server_structs.DirectorResponse {
 	}
 }
 
+// testFederation stands in for the discovery endpoint every entry in these
+// tests was learned from; cross-federation behavior is covered separately.
+const testFederation = "https://fed.example.com"
+
 func TestDirRespCacheLookup(t *testing.T) {
 	cache := NewDirRespCache(5 * time.Minute)
 
 	t.Run("Miss", func(t *testing.T) {
-		_, ok := cache.Lookup("/no/such/path")
+		_, ok := cache.Lookup(testFederation, "/no/such/path")
 		assert.False(t, ok)
 	})
 
 	t.Run("ExactMatch", func(t *testing.T) {
 		resp := makeDirResp("/test")
-		cache.Store("/test", "", resp)
+		cache.Store(testFederation, "/test", "", resp)
 
-		got, ok := cache.Lookup("/test")
+		got, ok := cache.Lookup(testFederation, "/test")
 		require.True(t, ok)
 		assert.Equal(t, "/test", got.XPelNsHdr.Namespace)
 	})
 
 	t.Run("PrefixMatch", func(t *testing.T) {
 		resp := makeDirResp("/data/project")
-		cache.Store("/data/project", "", resp)
+		cache.Store(testFederation, "/data/project", "", resp)
 
-		got, ok := cache.Lookup("/data/project/subdir/file.txt")
+		got, ok := cache.Lookup(testFederation, "/data/project/subdir/file.txt")
 		require.True(t, ok)
 		assert.Equal(t, "/data/project", got.XPelNsHdr.Namespace)
 	})
 
 	t.Run("LongestPrefixWins", func(t *testing.T) {
-		cache.Store("/a", "", makeDirResp("/a"))
-		cache.Store("/a/b", "", makeDirResp("/a/b"))
-		cache.Store("/a/b/c", "", makeDirResp("/a/b/c"))
+		cache.Store(testFederation, "/a", "", makeDirResp("/a"))
+		cache.Store(testFederation, "/a/b", "", makeDirResp("/a/b"))
+		cache.Store(testFederation, "/a/b/c", "", makeDirResp("/a/b/c"))
 
-		got, ok := cache.Lookup("/a/b/c/d/e.txt")
+		got, ok := cache.Lookup(testFederation, "/a/b/c/d/e.txt")
 		require.True(t, ok)
 		assert.Equal(t, "/a/b/c", got.XPelNsHdr.Namespace,
 			"should match the longest prefix")
 
-		got, ok = cache.Lookup("/a/b/x.txt")
+		got, ok = cache.Lookup(testFederation, "/a/b/x.txt")
 		require.True(t, ok)
 		assert.Equal(t, "/a/b", got.XPelNsHdr.Namespace)
 
-		got, ok = cache.Lookup("/a/x.txt")
+		got, ok = cache.Lookup(testFederation, "/a/x.txt")
 		require.True(t, ok)
 		assert.Equal(t, "/a", got.XPelNsHdr.Namespace)
 	})
 
 	t.Run("NoPartialSegmentMatch", func(t *testing.T) {
 		cache2 := NewDirRespCache(5 * time.Minute)
-		cache2.Store("/abc", "", makeDirResp("/abc"))
+		cache2.Store(testFederation, "/abc", "", makeDirResp("/abc"))
 
 		// "/abcdef" should NOT match "/abc" because "abc" is not a path prefix of "abcdef"
 		// (there's no "/" separator).  The lookup walks up path.Dir so:
 		// /abcdef → / (no /abc match for /abcdef since path.Dir(/abcdef)=/ directly)
-		_, ok := cache2.Lookup("/abcdef")
+		_, ok := cache2.Lookup(testFederation, "/abcdef")
 		assert.False(t, ok, "should not match partial segment")
 	})
 
 	t.Run("FoobarNotCoveredByFoo", func(t *testing.T) {
 		cache2 := NewDirRespCache(5 * time.Minute)
-		cache2.Store("/foo", "", makeDirResp("/foo"))
+		cache2.Store(testFederation, "/foo", "", makeDirResp("/foo"))
 
 		// "/foobar" is a different path segment — it must NOT match "/foo".
-		_, ok := cache2.Lookup("/foobar")
+		_, ok := cache2.Lookup(testFederation, "/foobar")
 		assert.False(t, ok, "/foobar should not be covered by /foo")
 
 		// "/foobar/baz" should also not match.
-		_, ok = cache2.Lookup("/foobar/baz")
+		_, ok = cache2.Lookup(testFederation, "/foobar/baz")
 		assert.False(t, ok, "/foobar/baz should not be covered by /foo")
 
 		// But "/foo/bar" SHOULD match (different segment under /foo).
-		got, ok := cache2.Lookup("/foo/bar")
+		got, ok := cache2.Lookup(testFederation, "/foo/bar")
 		assert.True(t, ok, "/foo/bar should be covered by /foo")
 		assert.Equal(t, "/foo", got.XPelNsHdr.Namespace)
 	})
@@ -120,59 +124,59 @@ func TestDirRespCacheLookup(t *testing.T) {
 
 func TestDirRespCacheExpiry(t *testing.T) {
 	cache := NewDirRespCache(50 * time.Millisecond)
-	cache.Store("/test", "", makeDirResp("/test"))
+	cache.Store(testFederation, "/test", "", makeDirResp("/test"))
 
 	// Should be present immediately
-	_, ok := cache.Lookup("/test/file.txt")
+	_, ok := cache.Lookup(testFederation, "/test/file.txt")
 	require.True(t, ok)
 
 	// Wait for expiry
 	time.Sleep(60 * time.Millisecond)
 
-	_, ok = cache.Lookup("/test/file.txt")
+	_, ok = cache.Lookup(testFederation, "/test/file.txt")
 	assert.False(t, ok, "entry should have expired")
 }
 
 func TestDirRespCacheInvalidate(t *testing.T) {
 	cache := NewDirRespCache(5 * time.Minute)
-	cache.Store("/test", "", makeDirResp("/test"))
+	cache.Store(testFederation, "/test", "", makeDirResp("/test"))
 
-	_, ok := cache.Lookup("/test/file.txt")
+	_, ok := cache.Lookup(testFederation, "/test/file.txt")
 	require.True(t, ok)
 
-	cache.Invalidate("/test")
+	cache.Invalidate(testFederation, "/test")
 
-	_, ok = cache.Lookup("/test/file.txt")
+	_, ok = cache.Lookup(testFederation, "/test/file.txt")
 	assert.False(t, ok)
 }
 
 func TestDirRespCacheInvalidateAll(t *testing.T) {
 	cache := NewDirRespCache(5 * time.Minute)
-	cache.Store("/a", "", makeDirResp("/a"))
-	cache.Store("/b", "", makeDirResp("/b"))
+	cache.Store(testFederation, "/a", "", makeDirResp("/a"))
+	cache.Store(testFederation, "/b", "", makeDirResp("/b"))
 
 	assert.Equal(t, 2, cache.Len())
 
 	cache.InvalidateAll()
 
 	assert.Equal(t, 0, cache.Len())
-	_, ok := cache.Lookup("/a/file")
+	_, ok := cache.Lookup(testFederation, "/a/file")
 	assert.False(t, ok)
 }
 
 func TestDirRespCacheCleanExpired(t *testing.T) {
 	cache := NewDirRespCache(50 * time.Millisecond)
-	cache.Store("/expired", "", makeDirResp("/expired"))
+	cache.Store(testFederation, "/expired", "", makeDirResp("/expired"))
 
 	time.Sleep(60 * time.Millisecond)
 
-	cache.Store("/fresh", "", makeDirResp("/fresh"))
+	cache.Store(testFederation, "/fresh", "", makeDirResp("/fresh"))
 	assert.Equal(t, 2, cache.Len())
 
 	cache.cleanExpired()
 	assert.Equal(t, 1, cache.Len())
 
-	_, ok := cache.Lookup("/fresh/file")
+	_, ok := cache.Lookup(testFederation, "/fresh/file")
 	assert.True(t, ok)
 }
 
@@ -183,10 +187,10 @@ func TestDirRespCacheOverwrite(t *testing.T) {
 	resp2 := makeDirResp("/test-updated")
 	resp2.XPelNsHdr.Namespace = "/test" // same namespace
 
-	cache.Store("/test", "", resp1)
-	cache.Store("/test", "", resp2)
+	cache.Store(testFederation, "/test", "", resp1)
+	cache.Store(testFederation, "/test", "", resp2)
 
-	got, ok := cache.Lookup("/test/file")
+	got, ok := cache.Lookup(testFederation, "/test/file")
 	require.True(t, ok)
 	assert.Equal(t, resp2.ObjectServers[0].Host, got.ObjectServers[0].Host,
 		"later store should overwrite earlier")
@@ -219,10 +223,10 @@ func TestMatchesPrefix(t *testing.T) {
 func TestLookupOrLoadCacheHit(t *testing.T) {
 	cache := NewDirRespCache(5 * time.Minute)
 	resp := makeDirResp("/data")
-	cache.Store("/data", "", resp)
+	cache.Store(testFederation, "/data", "", resp)
 
 	var loaderCalled atomic.Int32
-	got, err := cache.LookupOrLoad(context.Background(), "/data/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+	got, err := cache.LookupOrLoad(context.Background(), testFederation, "/data/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 		loaderCalled.Add(1)
 		return server_structs.DirectorResponse{}, "", nil
 	})
@@ -235,14 +239,14 @@ func TestLookupOrLoadCacheMiss(t *testing.T) {
 	cache := NewDirRespCache(5 * time.Minute)
 	resp := makeDirResp("/data")
 
-	got, err := cache.LookupOrLoad(context.Background(), "/data/subdir/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+	got, err := cache.LookupOrLoad(context.Background(), testFederation, "/data/subdir/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 		return resp, "/data", nil
 	})
 	require.NoError(t, err)
 	assert.Equal(t, resp.ObjectServers[0].Host, got.ObjectServers[0].Host)
 
 	// The result should now be cached.
-	cached, ok := cache.Lookup("/data/other.txt")
+	cached, ok := cache.Lookup(testFederation, "/data/other.txt")
 	require.True(t, ok)
 	assert.Equal(t, resp.ObjectServers[0].Host, cached.ObjectServers[0].Host)
 }
@@ -265,7 +269,7 @@ func TestLookupOrLoadCoalesces(t *testing.T) {
 	for i := 0; i < numWaiters; i++ {
 		go func(idx int) {
 			defer wg.Done()
-			results[idx], errs[idx] = cache.LookupOrLoad(context.Background(), "/ns/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+			results[idx], errs[idx] = cache.LookupOrLoad(context.Background(), testFederation, "/ns/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 				loaderCalls.Add(1)
 				<-gate // wait for the gate to open
 				return resp, "/ns", nil
@@ -293,7 +297,7 @@ func TestLookupOrLoadContextCancel(t *testing.T) {
 
 	go func() {
 		// Start a load that blocks for a long time.
-		_, _ = cache.LookupOrLoad(context.Background(), "/slow/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+		_, _ = cache.LookupOrLoad(context.Background(), testFederation, "/slow/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 			close(loaderStarted)
 			time.Sleep(5 * time.Second)
 			return makeDirResp("/slow"), "/slow", nil
@@ -303,7 +307,7 @@ func TestLookupOrLoadContextCancel(t *testing.T) {
 	// Wait for the loader to start, then try a second caller with a cancelled context.
 	<-loaderStarted
 	cancel()
-	_, err := cache.LookupOrLoad(ctx, "/slow/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+	_, err := cache.LookupOrLoad(ctx, testFederation, "/slow/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 		t.Fatal("loader should not be called for second waiter")
 		return server_structs.DirectorResponse{}, "", nil
 	})
@@ -313,13 +317,13 @@ func TestLookupOrLoadContextCancel(t *testing.T) {
 
 func TestLookupOrLoadNoPartialSegment(t *testing.T) {
 	cache := NewDirRespCache(5 * time.Minute)
-	cache.Store("/foo", "", makeDirResp("/foo"))
+	cache.Store(testFederation, "/foo", "", makeDirResp("/foo"))
 
 	var loaderCalled atomic.Int32
 	resp := makeDirResp("/foobar")
 
 	// LookupOrLoad for /foobar/file.txt should NOT match /foo and must invoke the loader.
-	got, err := cache.LookupOrLoad(context.Background(), "/foobar/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+	got, err := cache.LookupOrLoad(context.Background(), testFederation, "/foobar/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 		loaderCalled.Add(1)
 		return resp, "/foobar", nil
 	})
@@ -329,7 +333,7 @@ func TestLookupOrLoadNoPartialSegment(t *testing.T) {
 
 	// Verify /foo/bar/file.txt still hits the /foo cache entry without calling the loader.
 	var loaderCalled2 atomic.Int32
-	got2, err := cache.LookupOrLoad(context.Background(), "/foo/bar/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+	got2, err := cache.LookupOrLoad(context.Background(), testFederation, "/foo/bar/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 		loaderCalled2.Add(1)
 		return server_structs.DirectorResponse{}, "", nil
 	})
@@ -342,13 +346,13 @@ func TestLookupOrLoadLoaderError(t *testing.T) {
 	cache := NewDirRespCache(5 * time.Minute)
 	expectedErr := assert.AnError
 
-	_, err := cache.LookupOrLoad(context.Background(), "/fail/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+	_, err := cache.LookupOrLoad(context.Background(), testFederation, "/fail/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 		return server_structs.DirectorResponse{}, "", expectedErr
 	})
 	require.ErrorIs(t, err, expectedErr)
 
 	// Nothing should be cached on error.
-	_, ok := cache.Lookup("/fail/file.txt")
+	_, ok := cache.Lookup(testFederation, "/fail/file.txt")
 	assert.False(t, ok)
 	assert.Equal(t, 0, cache.Len())
 }
@@ -367,17 +371,17 @@ func TestDirRespCacheStripsFederationPath(t *testing.T) {
 			},
 		}
 
-		cache.Store("/test", "/test/file1.bin", resp)
+		cache.Store(testFederation, "/test", "/test/file1.bin", resp)
 
 		// Looking up with the SAME file should return original full paths.
-		got, ok := cache.Lookup("/test/file1.bin")
+		got, ok := cache.Lookup(testFederation, "/test/file1.bin")
 		require.True(t, ok)
 		assert.Equal(t, "/api/v1.0/origin/data/test/file1.bin", got.ObjectServers[0].Path)
 		assert.Equal(t, "/test/file1.bin", got.ObjectServers[1].Path)
 
 		// Looking up with a DIFFERENT file should return reconstituted paths
 		// with the new file's federation path.
-		got2, ok := cache.Lookup("/test/file2.bin")
+		got2, ok := cache.Lookup(testFederation, "/test/file2.bin")
 		require.True(t, ok)
 		assert.Equal(t, "/api/v1.0/origin/data/test/file2.bin", got2.ObjectServers[0].Path)
 		assert.Equal(t, "/test/file2.bin", got2.ObjectServers[1].Path)
@@ -396,7 +400,7 @@ func TestDirRespCacheStripsFederationPath(t *testing.T) {
 			},
 		}
 
-		got, err := cache.LookupOrLoad(context.Background(), "/ns/obj1.bin", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+		got, err := cache.LookupOrLoad(context.Background(), testFederation, "/ns/obj1.bin", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 			return resp, "/ns", nil
 		})
 		require.NoError(t, err)
@@ -407,7 +411,7 @@ func TestDirRespCacheStripsFederationPath(t *testing.T) {
 
 		// Subsequent lookup for a different file should return reconstituted
 		// paths with the new file's federation path.
-		cached, ok := cache.Lookup("/ns/obj2.bin")
+		cached, ok := cache.Lookup(testFederation, "/ns/obj2.bin")
 		require.True(t, ok)
 		assert.Equal(t, "/prefix/ns/obj2.bin", cached.ObjectServers[0].Path)
 	})
@@ -421,11 +425,82 @@ func TestDirRespCacheStripsFederationPath(t *testing.T) {
 			},
 		}
 
-		cache.Store("/test", "", resp)
-		got, ok := cache.Lookup("/test/file.txt")
+		cache.Store(testFederation, "/test", "", resp)
+		got, ok := cache.Lookup(testFederation, "/test/file.txt")
 		require.True(t, ok)
 		// With empty objectPath, nothing was stripped, so reconstitution
 		// appends the lookup path to the stored path.
 		assert.Equal(t, "/some/path/test/file.txt", got.ObjectServers[0].Path)
+	})
+}
+
+// TestDirRespCacheIsolatesFederations pins the scoping that keeps one
+// federation's answer from being handed to another.  A TransferEngine is shared
+// process-wide and namespace paths are not globally unique, so two federations
+// presenting the same path is ordinary, not adversarial -- but answering the
+// second with the first's object servers would send its credentials to a host
+// the user never named.
+func TestDirRespCacheIsolatesFederations(t *testing.T) {
+	const otherFederation = "https://other-fed.example.com"
+
+	t.Run("LookupDoesNotCrossFederations", func(t *testing.T) {
+		cache := NewDirRespCache(5 * time.Minute)
+		cache.Store(testFederation, "/shared", "", makeDirResp("/shared"))
+
+		_, ok := cache.Lookup(otherFederation, "/shared/object.txt")
+		assert.False(t, ok, "an entry learned from one federation must not answer for another")
+
+		got, ok := cache.Lookup(testFederation, "/shared/object.txt")
+		require.True(t, ok, "the federation that stored the entry still gets it")
+		assert.Equal(t, "/shared", got.XPelNsHdr.Namespace)
+	})
+
+	t.Run("SamePathInTwoFederationsKeepsBothEntries", func(t *testing.T) {
+		cache := NewDirRespCache(5 * time.Minute)
+		mine := makeDirResp("/shared")
+		theirs := makeDirResp("/shared")
+		theirs.ObjectServers = []*url.URL{{Host: "cache.other-fed.example.com"}}
+
+		cache.Store(testFederation, "/shared", "", mine)
+		cache.Store(otherFederation, "/shared", "", theirs)
+
+		got, ok := cache.Lookup(testFederation, "/shared/object.txt")
+		require.True(t, ok)
+		require.Len(t, got.ObjectServers, 1)
+		assert.Equal(t, "/shared.example.com", got.ObjectServers[0].Host,
+			"storing another federation's entry must not overwrite this one")
+
+		got, ok = cache.Lookup(otherFederation, "/shared/object.txt")
+		require.True(t, ok)
+		require.Len(t, got.ObjectServers, 1)
+		assert.Equal(t, "cache.other-fed.example.com", got.ObjectServers[0].Host)
+	})
+
+	t.Run("LoadsAreNotCoalescedAcrossFederations", func(t *testing.T) {
+		cache := NewDirRespCache(5 * time.Minute)
+		var calls int32
+		loader := func(namespace string) DirRespLoader {
+			return func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+				atomic.AddInt32(&calls, 1)
+				return makeDirResp(namespace), namespace, nil
+			}
+		}
+
+		_, err := cache.LookupOrLoad(context.Background(), testFederation, "/shared/object.txt", loader("/shared"))
+		require.NoError(t, err)
+		_, err = cache.LookupOrLoad(context.Background(), otherFederation, "/shared/object.txt", loader("/shared"))
+		require.NoError(t, err)
+
+		assert.Equal(t, int32(2), atomic.LoadInt32(&calls),
+			"each federation must be asked its own question")
+	})
+
+	t.Run("UnattributableEntriesAreNotCached", func(t *testing.T) {
+		cache := NewDirRespCache(5 * time.Minute)
+		cache.Store("", "/shared", "", makeDirResp("/shared"))
+		assert.Equal(t, 0, cache.Len(), "an entry with no federation could answer for any of them")
+
+		_, ok := cache.Lookup("", "/shared/object.txt")
+		assert.False(t, ok)
 	})
 }

--- a/client/director.go
+++ b/client/director.go
@@ -310,6 +310,18 @@ func GetDirectorInfoForPath(ctx context.Context, pUrl *pelican_url.PelicanURL, h
 // than caches.
 func getDirectorInfoForPath(ctx context.Context, pUrl *pelican_url.PelicanURL, httpMethod string, token string, cacheMode bool) (parsedResponse server_structs.DirectorResponse, err error) {
 	if pUrl.FedInfo.DirectorEndpoint == "" {
+		// A federation whose discovery document names no director has no
+		// matchmaking to do: the discovery host serves the objects itself (a
+		// standalone origin).  Ask it about the object rather than failing for
+		// want of a director.
+		//
+		// Callers here need the answer before they can act -- `token create`
+		// has to know the issuer, and a listing or a stat has no rejected
+		// response to learn from -- so this pays for a round trip.  A download
+		// does not; see resolveWithoutDirector.
+		if pUrl.FedInfo.DiscoveryEndpoint != "" {
+			return fetchNamespaceMetadata(ctx, pUrl, httpMethod, token)
+		}
 		return server_structs.DirectorResponse{},
 			errors.Errorf("unable to retrieve information from a Director for object %s because none was found in pelican URL metadata.", pUrl.Path)
 	}
@@ -358,6 +370,149 @@ func getDirectorInfoForPath(ctx context.Context, pUrl *pelican_url.PelicanURL, h
 	}
 
 	return
+}
+
+// resolveForRequest resolves an object for an operation that issues its own
+// request and can learn from being refused -- a download, a stat, a listing, a
+// cache-age probe.  In a federation with a director this is the ordinary query;
+// in one without, it costs no round trip, because the operation's own request
+// will carry back whatever a metadata query would have told it.
+//
+// Operations that cannot recover that way -- `token create`, or a write, which
+// would rather know before streaming a body than after being refused -- call
+// getDirectorInfoForPath instead.
+func resolveForRequest(ctx context.Context, pUrl *pelican_url.PelicanURL, httpMethod string, token string, cacheMode bool) (server_structs.DirectorResponse, error) {
+	if pUrl.FedInfo.DirectorEndpoint == "" && pUrl.FedInfo.DiscoveryEndpoint != "" {
+		return resolveWithoutDirector(pUrl)
+	}
+	return getDirectorInfoForPath(ctx, pUrl, httpMethod, token, cacheMode)
+}
+
+// resolveWithoutDirector answers a federation that publishes no director,
+// without asking anyone.
+//
+// A director exists to answer two questions: which server holds the object, and
+// what credential it wants.  Neither needs asking here.  The server is the
+// discovery host from the user's own pelican:// URL -- in a federation of one
+// there is no other candidate and no Link headers to sort -- and the credential
+// is whatever the origin says when it turns the request down, on headers it
+// attaches to that very response.  So a download simply starts, carrying a
+// credential if the caller had one, and learns the rest from the answer (see
+// canApplyTokenHint); the metadata request that used to precede it was a round
+// trip spent asking what the transfer itself was about to reveal.
+//
+// Only callers that can recover from an incomplete answer may use this.  A
+// download can, because a rejection carries the hints and it retries.  A
+// listing, a stat, or `token create` cannot -- they have no second chance to
+// learn an issuer from -- and go through fetchNamespaceMetadata instead.
+//
+// Namespace and RequireToken are deliberately left zero.  Guessing them would
+// be worse than not knowing: the origin is about to say.
+func resolveWithoutDirector(pUrl *pelican_url.PelicanURL) (server_structs.DirectorResponse, error) {
+	objectServer, err := url.Parse(pUrl.FedInfo.DiscoveryEndpoint)
+	if err != nil {
+		return server_structs.DirectorResponse{},
+			errors.Wrapf(err, "failed to parse the federation's discovery endpoint %s as an object server", pUrl.FedInfo.DiscoveryEndpoint)
+	}
+	log.Debugln("Federation publishes no director; addressing", pUrl.Path, "to the object server at", objectServer.Host)
+
+	return server_structs.DirectorResponse{
+		ObjectServers: []*url.URL{objectServer},
+		XPelNsHdr: server_structs.XPelNs{
+			// An origin serving its own namespace is also its own listing
+			// endpoint, which is what it advertises as collections-url when
+			// asked; a recursive transfer needs that before it starts.
+			CollectionsUrl: objectServer,
+		},
+	}, nil
+}
+
+// fetchNamespaceMetadata asks the origin what it would tell a director about a
+// namespace: which prefix the path falls under, whether it wants a credential,
+// and which issuer mints one.
+//
+// This costs a round trip, and most callers should not need one -- a transfer
+// learns the same thing from the response to the request it was going to make
+// anyway (see resolveWithoutDirector).  It is for callers with nothing to learn
+// from: `token create` has to know the issuer before it mints anything, and a
+// write wants it before streaming a body rather than after being refused.
+//
+// A HEAD collects it, and works whether the object turns out to be public
+// (200), protected (401/403), or absent (404) -- the metadata describes the
+// namespace, not the object.
+//
+// This asks nothing new of the client's trust: the server being questioned is
+// the host from the user's own pelican:// URL, which already served the
+// discovery document that everything else in this federation is believed on
+// the strength of.
+func fetchNamespaceMetadata(ctx context.Context, pUrl *pelican_url.PelicanURL, httpMethod string, token string) (parsedResponse server_structs.DirectorResponse, err error) {
+	objectServer, err := url.Parse(pUrl.FedInfo.DiscoveryEndpoint)
+	if err != nil {
+		return server_structs.DirectorResponse{},
+			errors.Wrapf(err, "failed to parse the federation's discovery endpoint %s as an object server", pUrl.FedInfo.DiscoveryEndpoint)
+	}
+	log.Debugln("Federation publishes no director; resolving", pUrl.Path, "against the object server at", objectServer.Host)
+
+	probeUrl := *objectServer
+	probeUrl.Path = pUrl.Path
+	probeUrl.RawQuery = pUrl.RawQuery
+
+	// HEAD regardless of the caller's verb: this is a metadata lookup, and a
+	// GET would start streaming an object the caller has not asked for yet.
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, probeUrl.String(), nil)
+	if err != nil {
+		return server_structs.DirectorResponse{}, errors.Wrap(err, "failed to build a metadata request for the object server")
+	}
+	req.Header.Set("User-Agent", getUserAgent(""))
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	// Follow redirects, unlike a director query: gin answers a request for a
+	// bare namespace prefix (what `object ls pelican://host/ns` asks for) with
+	// its own trailing-slash redirect, and that reply carries no metadata.  Only
+	// within this host, though -- the reply decides which issuer the client will
+	// authenticate against, and the bearer token above rides along on every hop
+	// Go considers same-origin, so a redirect elsewhere would both hand that
+	// token to a third party and let it name the issuer.
+	client := *config.GetClient()
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !strings.EqualFold(req.URL.Host, objectServer.Host) {
+			return errors.Errorf("object server at %s redirected namespace metadata to another host (%s); refusing to follow",
+				objectServer.Host, req.URL.Host)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return server_structs.DirectorResponse{},
+			errors.Wrapf(error_codes.NewContact_DirectorError(err), "error while querying the object server at %s", objectServer.Host)
+	}
+	defer resp.Body.Close()
+	// The body is metadata-free; drain it so the connection can be reused.
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	parsedResponse, err = ParseDirectorInfo(resp)
+	if err != nil {
+		return server_structs.DirectorResponse{}, errors.Wrap(err, "failed to parse the object server's namespace metadata")
+	}
+	// Whatever the object's own status, a server that serves the namespace
+	// describes it in these headers.  Their absence means something answered
+	// that is not a Pelican object server -- a proxy error page, say -- and
+	// continuing would start a transfer with no idea whether it needs a token.
+	if parsedResponse.XPelNsHdr.Namespace == "" {
+		return server_structs.DirectorResponse{},
+			errors.Errorf("the server at %s returned no namespace metadata for %s (HTTP %d); it does not appear to serve this federation",
+				objectServer.Host, pUrl.Path, resp.StatusCode)
+	}
+
+	// The object server named itself by answering; a federation of one has no
+	// other candidate, and no Link headers to sort.
+	parsedResponse.ObjectServers = []*url.URL{objectServer}
+	return parsedResponse, nil
 }
 
 // Given the Director response, parse the headers and construct the ordered list of object

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1961,10 +1961,22 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 	// is in a-priori.
 	var dirResp server_structs.DirectorResponse
 	directorFailed := false
-	if tc.engine != nil && tc.engine.dirRespCache != nil {
+	// With no director in the federation, nothing has told us yet whether this
+	// namespace wants a credential -- the origin says so when it answers.  The
+	// transfer therefore keeps its token generator either way, so that a
+	// rejection carrying token hints has something to acquire onto.
+	directorless := copyUrl.FedInfo.DirectorEndpoint == "" && copyUrl.FedInfo.DiscoveryEndpoint != ""
+	// A download against a directorless federation resolves locally and pays no
+	// round trip: it addresses the object to the host the user named and lets
+	// the origin's own rejection say what credential the namespace wants.  An
+	// upload has no such second chance -- there is no hint retry on a PUT -- so
+	// it still asks first.
+	if directorless && !upload {
+		dirResp, err = resolveForRequest(tj.ctx, &copyUrl, httpMethod, "", tj.cacheMode)
+	} else if tc.engine != nil && tc.engine.dirRespCache != nil {
 		copyUrlRef := &copyUrl
 		cacheMode := tj.cacheMode
-		dirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, copyUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+		dirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, copyUrl.FedInfo.DiscoveryEndpoint, copyUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 			resp, qErr := getDirectorInfoForPath(ctx, copyUrlRef, httpMethod, "", cacheMode)
 			return resp, resp.XPelNsHdr.Namespace, qErr
 		})
@@ -1981,6 +1993,12 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 				ObjectServers: []*url.URL{},
 			}
 			tj.dirResp = dirResp
+			// Assigned directly rather than through SetDirectorResponse: no
+			// director answered, so this placeholder carries no authorization
+			// metadata and must not be treated as though a director vouched
+			// for it.  The named object servers do not get to supply that
+			// metadata either -- they are not the federation's discovery host,
+			// so canApplyTokenHint refuses their hints.
 			tj.token.DirResp = &dirResp
 			err = nil // Clear the error since we're continuing with explicit caches
 		} else {
@@ -1995,16 +2013,16 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 		}
 	} else {
 		tj.dirResp = dirResp
-		tj.token.DirResp = &dirResp
+		tj.token.SetDirectorResponse(&dirResp)
 	}
 
 	// For uploads or when director indicates token is required, get a token
 	// If director failed but we have explicit caches, try to get token anyway
-	if upload || (!directorFailed && dirResp.XPelNsHdr.RequireToken) || (directorFailed && len(tj.prefObjServers) > 0) {
+	if upload || (!directorFailed && dirResp.XPelNsHdr.RequireToken) || (directorFailed && len(tj.prefObjServers) > 0) || directorless {
 		contents, err := tj.token.Get()
 		if err != nil || contents == "" {
 			// If director failed, token errors are not fatal - we'll try without token
-			if directorFailed {
+			if directorFailed || directorless {
 				log.Debugln("Could not acquire token, will attempt transfer without token")
 			} else {
 				return nil, errors.Wrap(err, "failed to get token for transfer")
@@ -2012,8 +2030,9 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 		}
 
 		// The director response may change if it's given a token; let's repeat the query.
-		// Skip re-query if director already failed
-		if contents != "" && !directorFailed {
+		// Skip re-query if the director already failed, or if there is no
+		// director to re-query.
+		if contents != "" && !directorFailed && !directorless {
 			dirResp, err = getDirectorInfoForPath(tj.ctx, &copyUrl, httpMethod, contents, tj.cacheMode)
 			if err != nil {
 				var sce *StatusCodeError
@@ -2025,10 +2044,10 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 				return nil, err
 			}
 			tj.dirResp = dirResp
-			tj.token.DirResp = &dirResp
+			tj.token.SetDirectorResponse(&dirResp)
 			// Update the cache with the token-authenticated response.
 			if tc.engine != nil && tc.engine.dirRespCache != nil && dirResp.XPelNsHdr.Namespace != "" {
-				tc.engine.dirRespCache.Store(dirResp.XPelNsHdr.Namespace, copyUrl.Path, dirResp)
+				tc.engine.dirRespCache.Store(copyUrl.FedInfo.DiscoveryEndpoint, dirResp.XPelNsHdr.Namespace, copyUrl.Path, dirResp)
 			}
 		}
 	} else {
@@ -2105,7 +2124,7 @@ func (tc *TransferClient) NewPrestageJob(ctx context.Context, remoteUrl *url.URL
 
 	var dirResp server_structs.DirectorResponse
 	if tc.engine != nil && tc.engine.dirRespCache != nil {
-		dirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, pelicanURL.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+		dirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, pelicanURL.FedInfo.DiscoveryEndpoint, pelicanURL.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 			resp, qErr := getDirectorInfoForPath(ctx, pelicanURL, http.MethodGet, "", false)
 			return resp, resp.XPelNsHdr.Namespace, qErr
 		})
@@ -2118,7 +2137,7 @@ func (tc *TransferClient) NewPrestageJob(ctx context.Context, remoteUrl *url.URL
 		return
 	}
 	tj.dirResp = dirResp
-	tj.token.DirResp = &dirResp
+	tj.token.SetDirectorResponse(&dirResp)
 
 	log.Debugln("Dir resp:", dirResp.XPelNsHdr)
 	if dirResp.XPelNsHdr.RequireToken {
@@ -2136,9 +2155,9 @@ func (tc *TransferClient) NewPrestageJob(ctx context.Context, remoteUrl *url.URL
 				return nil, err
 			}
 			tj.dirResp = dirResp
-			tj.token.DirResp = &dirResp
+			tj.token.SetDirectorResponse(&dirResp)
 			if tc.engine != nil && tc.engine.dirRespCache != nil && dirResp.XPelNsHdr.Namespace != "" {
-				tc.engine.dirRespCache.Store(dirResp.XPelNsHdr.Namespace, pelicanURL.Path, dirResp)
+				tc.engine.dirRespCache.Store(pelicanURL.FedInfo.DiscoveryEndpoint, dirResp.XPelNsHdr.Namespace, pelicanURL.Path, dirResp)
 			}
 		}
 	} else {
@@ -2229,7 +2248,7 @@ func (tc *TransferClient) NewCopyJob(ctx context.Context, src *url.URL, dest *ur
 	destVerb := "COPY"
 	if tc.engine != nil && tc.engine.dirRespCache != nil {
 		copyDestUrlRef := &copyDestUrl
-		dirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, copyDestUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+		dirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, copyDestUrl.FedInfo.DiscoveryEndpoint, copyDestUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 			resp, qErr := getDirectorInfoForPath(ctx, copyDestUrlRef, destVerb, "", false)
 			if qErr != nil {
 				// Fall back to PUT if COPY is not supported by the director
@@ -2252,7 +2271,7 @@ func (tc *TransferClient) NewCopyJob(ctx context.Context, src *url.URL, dest *ur
 		return
 	}
 	tj.destDirResp = dirResp
-	tj.token.DirResp = &dirResp
+	tj.token.SetDirectorResponse(&dirResp)
 
 	// Acquire token for the destination if needed
 	if dirResp.XPelNsHdr.RequireToken {
@@ -2269,9 +2288,9 @@ func (tc *TransferClient) NewCopyJob(ctx context.Context, src *url.URL, dest *ur
 				return nil, err
 			}
 			tj.destDirResp = dirResp
-			tj.token.DirResp = &dirResp
+			tj.token.SetDirectorResponse(&dirResp)
 			if tc.engine != nil && tc.engine.dirRespCache != nil && dirResp.XPelNsHdr.Namespace != "" {
-				tc.engine.dirRespCache.Store(dirResp.XPelNsHdr.Namespace, copyDestUrl.Path, dirResp)
+				tc.engine.dirRespCache.Store(copyDestUrl.FedInfo.DiscoveryEndpoint, dirResp.XPelNsHdr.Namespace, copyDestUrl.Path, dirResp)
 			}
 		}
 	}
@@ -2280,7 +2299,7 @@ func (tc *TransferClient) NewCopyJob(ctx context.Context, src *url.URL, dest *ur
 	var srcDirResp server_structs.DirectorResponse
 	if tc.engine != nil && tc.engine.dirRespCache != nil {
 		copySrcUrlRef := &copySrcUrl
-		srcDirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, copySrcUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+		srcDirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, copySrcUrl.FedInfo.DiscoveryEndpoint, copySrcUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 			resp, qErr := getDirectorInfoForPath(ctx, copySrcUrlRef, http.MethodGet, "", false)
 			return resp, resp.XPelNsHdr.Namespace, qErr
 		})
@@ -2293,7 +2312,7 @@ func (tc *TransferClient) NewCopyJob(ctx context.Context, src *url.URL, dest *ur
 		return
 	}
 	tj.srcDirResp = srcDirResp
-	tj.srcToken.DirResp = &srcDirResp
+	tj.srcToken.SetDirectorResponse(&srcDirResp)
 
 	if srcDirResp.XPelNsHdr.RequireToken {
 		contents, tErr := tj.srcToken.Get()
@@ -2309,9 +2328,9 @@ func (tc *TransferClient) NewCopyJob(ctx context.Context, src *url.URL, dest *ur
 				return nil, err
 			}
 			tj.srcDirResp = srcDirResp
-			tj.srcToken.DirResp = &srcDirResp
+			tj.srcToken.SetDirectorResponse(&srcDirResp)
 			if tc.engine != nil && tc.engine.dirRespCache != nil && srcDirResp.XPelNsHdr.Namespace != "" {
-				tc.engine.dirRespCache.Store(srcDirResp.XPelNsHdr.Namespace, copySrcUrl.Path, srcDirResp)
+				tc.engine.dirRespCache.Store(copySrcUrl.FedInfo.DiscoveryEndpoint, srcDirResp.XPelNsHdr.Namespace, copySrcUrl.Path, srcDirResp)
 			}
 		}
 	} else {
@@ -2383,8 +2402,13 @@ func (tc *TransferClient) CacheInfo(ctx context.Context, remoteUrl *url.URL, opt
 	defer cancel()
 
 	var dirResp server_structs.DirectorResponse
-	if tc.engine != nil && tc.engine.dirRespCache != nil {
-		dirResp, err = tc.engine.dirRespCache.LookupOrLoad(ctx, pelicanURL.Path, func(lCtx context.Context) (server_structs.DirectorResponse, string, error) {
+	// The probe below is itself the question a metadata query would have asked,
+	// so a directorless federation is not asked twice.
+	directorless := pelicanURL.FedInfo.DirectorEndpoint == "" && pelicanURL.FedInfo.DiscoveryEndpoint != ""
+	if directorless {
+		dirResp, err = resolveForRequest(ctx, pelicanURL, http.MethodGet, "", false)
+	} else if tc.engine != nil && tc.engine.dirRespCache != nil {
+		dirResp, err = tc.engine.dirRespCache.LookupOrLoad(ctx, pelicanURL.FedInfo.DiscoveryEndpoint, pelicanURL.Path, func(lCtx context.Context) (server_structs.DirectorResponse, string, error) {
 			resp, qErr := getDirectorInfoForPath(lCtx, pelicanURL, http.MethodGet, "", false)
 			return resp, resp.XPelNsHdr.Namespace, qErr
 		})
@@ -2396,7 +2420,7 @@ func (tc *TransferClient) CacheInfo(ctx context.Context, remoteUrl *url.URL, opt
 		err = errors.Wrapf(err, "failed to get namespace information for remote URL %s", remoteUrl.String())
 		return
 	}
-	token.DirResp = &dirResp
+	token.SetDirectorResponse(&dirResp)
 
 	if dirResp.XPelNsHdr.RequireToken {
 		var contents string
@@ -2414,12 +2438,14 @@ func (tc *TransferClient) CacheInfo(ctx context.Context, remoteUrl *url.URL, opt
 				err = errors.Wrapf(err, "failed to get namespace information for remote URL %s", remoteUrl.String())
 				return
 			}
-			token.DirResp = &dirResp
+			token.SetDirectorResponse(&dirResp)
 			if tc.engine != nil && tc.engine.dirRespCache != nil && dirResp.XPelNsHdr.Namespace != "" {
-				tc.engine.dirRespCache.Store(dirResp.XPelNsHdr.Namespace, pelicanURL.Path, dirResp)
+				tc.engine.dirRespCache.Store(pelicanURL.FedInfo.DiscoveryEndpoint, dirResp.XPelNsHdr.Namespace, pelicanURL.Path, dirResp)
 			}
 		}
-	} else {
+	} else if !directorless {
+		// Nothing has asked yet, so "no token required" is not a fact; keep the
+		// generator so a refusal carrying hints can acquire onto it.
 		token = nil
 	}
 
@@ -3570,6 +3596,35 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 		attemptDownloaded, timeToFirstByte, cacheAge, serverVersion, attemptETag, err := downloadHTTP(
 			ctx, transfer.engine, transfer.callback, transferEndpoint, writeDestination, fileWriter, rangeStart+downloaded, byteRangeEnd, size, tokenContents, transfer.project, transfer.metadataChan, transfer.schedFirstByte,
 		)
+
+		// If the endpoint returned a 403 with director-style token hints, learn
+		// what token is needed, acquire it, and retry this same endpoint once
+		// with the token.  A 403 is returned before any body is written, so
+		// retrying is safe.  canApplyTokenHint decides whether the hint is one
+		// this transfer may act on at all.
+		var hintErr *tokenHintError
+		if errors.As(err, &hintErr) && transfer.token.canApplyTokenHint(transferEndpoint.Url) {
+			// Acquire on a private generator, coalesced with any sibling file
+			// handed the same hint: the job's generator is shared with every
+			// other file in this transfer.
+			//
+			// Retrying with the credential just rejected would only earn the
+			// same 403, so a hint that yields nothing new ends the attempt.
+			if newTok, tErr := transfer.token.tokenForHint(&hintErr.dirResp); tErr == nil && newTok != "" && newTok != tokenContents {
+				log.WithFields(fields).Debugln("Retrying with token after 403 token hint from", transferEndpoint.Url.Host)
+				// Publish the credential to the job's generator so the sibling
+				// files and the checksum request that follows this download do
+				// not each repeat the acquisition.
+				transfer.token.cacheToken(newTok)
+				tokenContents = newTok
+				// The rejected attempt wrote no body, so the scheduler has not
+				// been told this endpoint is responsive; the retry is the
+				// attempt that will prove it.  schedFirstByte is idempotent.
+				attemptDownloaded, timeToFirstByte, cacheAge, serverVersion, attemptETag, err = downloadHTTP(
+					ctx, transfer.engine, transfer.callback, transferEndpoint, writeDestination, fileWriter, rangeStart+downloaded, byteRangeEnd, size, tokenContents, transfer.project, transfer.metadataChan, transfer.schedFirstByte,
+				)
+			}
+		}
 		// Clear metadata channel after first attempt - we only want to send metadata once
 		transfer.metadataChan = nil
 
@@ -3941,6 +3996,55 @@ func verifyFileSize(dest string, expectedSize int64, fields log.Fields) error {
 	return nil
 }
 
+// acquireFromTokenHint reads the token hints an origin attached to a response
+// that refused the request and, if tok may act on them, obtains the credential
+// they name and caches it so a retry carries it.  Reports whether it did.
+//
+// This is how an operation other than a download learns what it needs: a stat,
+// a listing, and a cache-age probe all ask their own question first and read
+// the answer off the refusal, rather than paying for a metadata query that the
+// request was about to make redundant.
+func acquireFromTokenHint(tok *tokenGenerator, resp *http.Response) bool {
+	if tok == nil || resp == nil || resp.Request == nil {
+		return false
+	}
+	if resp.StatusCode != http.StatusUnauthorized && resp.StatusCode != http.StatusForbidden {
+		return false
+	}
+	if resp.Header.Get(server_structs.XPelNs{}.GetName()) == "" {
+		return false
+	}
+	if !tok.canApplyTokenHint(resp.Request.URL) {
+		return false
+	}
+	hint, err := ParseDirectorInfo(resp)
+	if err != nil || !hint.XPelNsHdr.RequireToken {
+		return false
+	}
+	contents, err := tok.tokenForHint(&hint)
+	if err != nil || contents == "" {
+		return false
+	}
+	// Publish it so the rest of the operation -- the other stat hosts, the rest
+	// of a recursive listing -- does not each repeat the acquisition.
+	tok.cacheToken(contents)
+	return true
+}
+
+// tokenHintError is returned by downloadHTTP when an object server responds
+// with 403 and director-style X-Pelican-* headers indicating that a token is
+// required.  The embedded dirResp carries the parsed token-hint information so
+// the caller can acquire the right token and retry the same endpoint.  It
+// unwraps to the underlying authorization error so existing error handling
+// continues to work if no retry is attempted (or the retry fails).
+type tokenHintError struct {
+	dirResp server_structs.DirectorResponse
+	err     error
+}
+
+func (e *tokenHintError) Error() string { return e.err.Error() }
+func (e *tokenHintError) Unwrap() error { return e.err }
+
 // Download a single object from a single HTTP server with no retries.
 //
 // The following information is required:
@@ -4127,6 +4231,36 @@ func downloadHTTP(ctx context.Context, te *TransferEngine, callback TransferCall
 		bodyStr := string(bodyBytes)
 		log.WithFields(fields).Debugln("Error response body:", bodyStr)
 		serverVersion = resp.Header.Get("Server")
+		// A server that answers namespace questions about itself -- a standalone
+		// origin -- returns the same X-Pelican-* token-hint headers a director
+		// would, on the response that turns the request down.  Both codes carry
+		// them and both matter: 401 is what a client that sent nothing gets,
+		// which is the ordinary first request when no director was asked what
+		// this namespace wants, and 403 is what a presented-but-insufficient
+		// credential gets.  Surface either as a tokenHintError so the caller can
+		// obtain the right credential and retry this same endpoint, reusing the
+		// director-response parser.  Whether the hint may be acted on is decided
+		// by canApplyTokenHint, not here.
+		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
+			if resp.Header.Get(server_structs.XPelNs{}.GetName()) != "" {
+				if parsed, perr := ParseDirectorInfo(resp); perr == nil && parsed.XPelNsHdr.RequireToken {
+					// Keep the underlying error the shape each status already
+					// had, so nothing downstream sees a 401 become a 403.
+					var wrapped error
+					if resp.StatusCode == http.StatusForbidden {
+						pde := &PermissionDeniedError{}
+						if trimmed := strings.TrimSpace(bodyStr); trimmed != "" {
+							pde.message = "Permission denied: " + trimmed
+						}
+						wrapped = error_codes.NewAuthorizationError(pde)
+					} else {
+						sce := StatusCodeError(resp.StatusCode)
+						wrapped = wrapStatusCodeError(&sce)
+					}
+					return 0, 0, -1, serverVersion, "", &tokenHintError{dirResp: parsed, err: wrapped}
+				}
+			}
+		}
 		if resp.StatusCode == http.StatusForbidden {
 			// Preserve the origin's response body so operators can see why
 			// the request was rejected (e.g. scope mismatch, token issue).
@@ -4136,7 +4270,8 @@ func downloadHTTP(ctx context.Context, te *TransferEngine, callback TransferCall
 			if trimmed := strings.TrimSpace(bodyStr); trimmed != "" {
 				pde.message = "Permission denied: " + trimmed
 			}
-			return 0, 0, -1, serverVersion, "", error_codes.NewAuthorizationError(pde)
+			authErr := error_codes.NewAuthorizationError(pde)
+			return 0, 0, -1, serverVersion, "", authErr
 		}
 		if resp.StatusCode == http.StatusTooManyRequests {
 			// The serving cache's fair scheduler shed this request. Parse the
@@ -6467,6 +6602,26 @@ func objectCached(ctx context.Context, objectUrl *url.URL, token *tokenGenerator
 	headResponse, err = headClient.Do(headRequest)
 	if err != nil {
 		return
+	}
+	// An origin that answers namespace questions about itself says on the
+	// refusal which credential would have worked.  Take it and ask once more,
+	// so this probe learns the same way the transfer it precedes does.
+	if acquireFromTokenHint(token, headResponse) {
+		_, _ = io.Copy(io.Discard, io.LimitReader(headResponse.Body, probeDrainLimit))
+		headResponse.Body.Close()
+		retryRequest, retryErr := http.NewRequestWithContext(ctx, http.MethodGet, objectUrl.String(), nil)
+		if retryErr != nil {
+			err = retryErr
+			return
+		}
+		retryRequest.Header.Set("Range", "bytes=0-0")
+		if tokenContents, tokErr := token.Get(); tokErr == nil && tokenContents != "" {
+			retryRequest.Header.Set("Authorization", "Bearer "+tokenContents)
+		}
+		headResponse, err = headClient.Do(retryRequest)
+		if err != nil {
+			return
+		}
 	}
 	// The probe wants headers, but an *error* response's body carries the
 	// structured reason that tells a throttle apart from any other refusal, so

--- a/client/main.go
+++ b/client/main.go
@@ -238,8 +238,15 @@ func stat(ctx context.Context, te *TransferEngine, destination string, options .
 	// flavor is cached: an upload destination asks a different question and
 	// gets a different answer, and the cache is keyed only by prefix.
 	var dirResp server_structs.DirectorResponse
-	if te != nil && te.dirRespCache != nil && !uploadDestination {
-		dirResp, err = te.dirRespCache.LookupOrLoad(ctx, pUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+	// A stat against a directorless federation is its own metadata query: the
+	// PROPFIND carries back whatever a preceding one would have said, so asking
+	// first would send the same request twice.  An upload destination still
+	// asks, since a write wants its credential settled before it starts.
+	directorless := pUrl.FedInfo.DirectorEndpoint == "" && pUrl.FedInfo.DiscoveryEndpoint != ""
+	if directorless && !uploadDestination {
+		dirResp, err = resolveForRequest(ctx, pUrl, directorMethod, "", cacheMode)
+	} else if te != nil && te.dirRespCache != nil && !uploadDestination {
+		dirResp, err = te.dirRespCache.LookupOrLoad(ctx, pUrl.FedInfo.DiscoveryEndpoint, pUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 			resp, qErr := getDirectorInfoForPath(ctx, pUrl, directorMethod, "", cacheMode)
 			return resp, resp.XPelNsHdr.Namespace, qErr
 		})
@@ -273,9 +280,12 @@ func stat(ctx context.Context, te *TransferEngine, destination string, options .
 		if tokenContents == "" {
 			return nil, errors.New("failed to get token for transfer: no token found for a namespace that requires one")
 		}
-	} else {
+	} else if !directorless {
 		token = nil
 	}
+	// When nothing has been asked, "no token required" is not yet a fact, so the
+	// generator stays: a refusal carrying token hints needs somewhere to acquire
+	// onto (see bearerAuthenticator.Verify).
 
 	statInfo, err := statHttp(ctx, pUrl, dirResp, token, fedToken)
 	if err != nil {
@@ -573,10 +583,13 @@ func walkOn(ctx context.Context, _ *TransferEngine, remoteObject string, fn Walk
 		return errors.Wrapf(err, "failed to parse remote path: %s", remoteObject)
 	}
 
-	dirResp, err := getDirectorInfoForPath(ctx, pUrl, http.MethodGet, "", false)
+	// A listing carries back what a metadata query would have said, so a
+	// directorless federation is not asked twice.
+	dirResp, err := resolveForRequest(ctx, pUrl, http.MethodGet, "", false)
 	if err != nil {
 		return err
 	}
+	directorless := pUrl.FedInfo.DirectorEndpoint == "" && pUrl.FedInfo.DiscoveryEndpoint != ""
 
 	// Get our token if needed
 	token := NewTokenGenerator(pUrl, &dirResp, config.TokenRead, true)
@@ -612,7 +625,9 @@ func walkOn(ctx context.Context, _ *TransferEngine, remoteObject string, fn Walk
 		if err != nil || tokenContents == "" {
 			return errors.Wrap(err, "failed to get token for transfer")
 		}
-	} else {
+	} else if !directorless {
+		// With nothing having asked, "no token required" is not yet a fact; the
+		// generator stays so a refusal carrying hints can acquire onto it.
 		token = nil
 	}
 	if collectionsOverride != "" {

--- a/client/token_hint_test.go
+++ b/client/token_hint_test.go
@@ -1,0 +1,688 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package client
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/pelican_url"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/token"
+)
+
+const (
+	// The issuer a client already holds a credential for, and the one the
+	// object server actually accepts.  They differ so that a test can tell
+	// whether the token hint changed which credential the client selected.
+	wrongIssuer  = "https://issuer-the-client-already-had.example.com"
+	hintedIssuer = "https://issuer.example.com"
+)
+
+// mintTestToken builds a WLCG token for the given issuer.  Signatures are never
+// checked on this path -- tokenIsAcceptable parses claims with UnsafeParseClaims
+// -- so a throwaway key is enough to produce a well-formed JWT.
+func mintTestToken(t *testing.T, issuer string) string {
+	t.Helper()
+	tok, err := jwt.NewBuilder().
+		Issuer(issuer).
+		Subject("test").
+		IssuedAt(time.Now()).
+		Expiration(time.Now().Add(time.Hour)).
+		Claim("scope", "storage.read:/").
+		Claim("wlcg.ver", "1.0").
+		Build()
+	require.NoError(t, err)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256, key))
+	require.NoError(t, err)
+	return string(signed)
+}
+
+// writeTokenHintHeaders emits the X-Pelican-* headers a server that answers
+// namespace questions about itself attaches to a response: which namespace the
+// path belongs to, which issuers vouch for it, and how to obtain a credential.
+func writeTokenHintHeaders(h http.Header) {
+	ad := server_structs.NamespaceAd{
+		Path: "/protected",
+		Caps: server_structs.Capabilities{Reads: true},
+	}
+	issuer, _ := url.Parse(hintedIssuer)
+	ad.Issuer = []server_structs.TokenIssuer{{IssuerUrl: *issuer, BasePaths: []string{"/protected"}}}
+	ad.Generation = []server_structs.TokenGen{{
+		Strategy:         server_structs.OAuthStrategy,
+		MaxScopeDepth:    3,
+		CredentialIssuer: *issuer,
+	}}
+	server_structs.SetXNamespaceHeader(h, nil, ad)
+	server_structs.SetXAuthHeader(h, ad)
+	server_structs.SetXTokenGenHeader(h, ad)
+}
+
+// tokenHintHandler simulates an origin that answers a client the way a director
+// would.  It serves the object only to a caller presenting a token from
+// hintedIssuer; anything else earns a 403 carrying the token hints that say so.
+func tokenHintHandler(body string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !presentsIssuer(r, hintedIssuer) {
+			writeTokenHintHeaders(w.Header())
+			w.WriteHeader(rejectionStatus(r))
+			_, _ = w.Write([]byte("authorization required"))
+			return
+		}
+		// Authorized: report size for HEAD (used to size the object), serve
+		// the body for GET.
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeader(http.StatusOK)
+		if r.Method != http.MethodHead {
+			_, _ = w.Write([]byte(body))
+		}
+	}
+}
+
+// presentsIssuer reports whether the request carries a bearer token minted by
+// the given issuer.
+func presentsIssuer(r *http.Request, issuer string) bool {
+	authz := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authz, "Bearer ") {
+		return false
+	}
+	tok, err := token.UnsafeParseClaims(strings.TrimPrefix(authz, "Bearer "))
+	if err != nil {
+		return false
+	}
+	return tok.Issuer() == issuer
+}
+
+// hintServerStats separates the two outcomes a test cares about.  Counting
+// requests outright would be brittle: a completed download is followed by a
+// checksum request, which now carries the credential the retry established.
+type hintServerStats struct {
+	rejected int32
+	served   int32
+}
+
+// rejectionStatus mirrors what origin_serve answers a request it will not
+// serve: 401 when the caller presented no credential at all -- the ordinary
+// first request once nothing probes ahead of the transfer -- and 403 when one
+// was presented and did not authorize.
+func rejectionStatus(r *http.Request) int {
+	if r.Header.Get("Authorization") == "" {
+		return http.StatusUnauthorized
+	}
+	return http.StatusForbidden
+}
+
+// countingTokenHintHandler behaves like tokenHintHandler but records what it
+// did, so a test can tell whether the attempt loop retried.
+func countingTokenHintHandler(body string, stats *hintServerStats) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !presentsIssuer(r, hintedIssuer) {
+			atomic.AddInt32(&stats.rejected, 1)
+			writeTokenHintHeaders(w.Header())
+			w.WriteHeader(rejectionStatus(r))
+			_, _ = w.Write([]byte("authorization required"))
+			return
+		}
+		atomic.AddInt32(&stats.served, 1)
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeader(http.StatusOK)
+		if r.Method != http.MethodHead {
+			_, _ = w.Write([]byte(body))
+		}
+	}
+}
+
+// hintTransferOpts describes the deployment a hint test is simulating.
+type hintTransferOpts struct {
+	// discoveryEndpoint overrides the federation's discovery host.  Left empty
+	// it is the object server itself, which is what the user named.  Pointing
+	// it elsewhere models reaching a host the client was sent to rather than
+	// one the user chose -- a cache a director selected, say.
+	discoveryEndpoint string
+	// directorEndpoint, when set, gives the federation a director.  It must not
+	// change whether a hint is honored; only who chose the host does.
+	directorEndpoint string
+}
+
+// newHintTransfer builds a transferFile pointed at svrURL together with the
+// job-wide token generator it shares, in the shape downloadObject expects.
+func newHintTransfer(t *testing.T, svrURL string, opts hintTransferOpts) (*transferFile, *tokenGenerator) {
+	t.Helper()
+	parsed, err := url.Parse(svrURL)
+	require.NoError(t, err)
+	remoteURL := &pelican_url.PelicanURL{
+		Scheme: "pelican://",
+		Host:   parsed.Host,
+		Path:   "/protected/test.txt",
+	}
+	remoteURL.FedInfo.DiscoveryEndpoint = svrURL
+	if opts.discoveryEndpoint != "" {
+		remoteURL.FedInfo.DiscoveryEndpoint = opts.discoveryEndpoint
+	}
+	remoteURL.FedInfo.DirectorEndpoint = opts.directorEndpoint
+	tok := NewTokenGenerator(remoteURL, nil, config.TokenRead, false)
+	tj := &TransferJob{remoteURL: remoteURL, token: tok}
+	return &transferFile{
+		ctx:       context.Background(),
+		job:       tj,
+		localPath: os.DevNull,
+		remoteURL: parsed,
+		token:     tok,
+		attempts:  []transferAttemptDetails{{Url: parsed}},
+		xferType:  transferTypeDownload,
+	}, tok
+}
+
+// stageTwoCredentials puts two tokens where the client will discover them: one
+// from an issuer the object server does not accept (found first), and one from
+// the issuer it does.  Without a hint the client has no reason to prefer the
+// second; the hint is what tells it which one is wanted.
+func stageTwoCredentials(t *testing.T) {
+	t.Helper()
+	t.Setenv("BEARER_TOKEN", mintTestToken(t, wrongIssuer))
+	good := filepath.Join(t.TempDir(), "good.jwt")
+	require.NoError(t, os.WriteFile(good, []byte(mintTestToken(t, hintedIssuer)), 0o600))
+	t.Setenv("BEARER_TOKEN_FILE", good)
+	// Keep discovery from wandering into the invoking user's real credentials.
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+}
+
+// TestTokenHintAcquiresAndRetries is the positive case the whole mechanism
+// exists for: a federation with no director, an object server that rejects the
+// credential the client picked on its own, and a hint that names the one it
+// actually wants.  The client must select the hinted credential and retry.
+//
+// Deleting the retry, or closing the gate that admits this hint, makes this
+// test fail -- which is what keeps its negative counterparts below honest.
+func TestTokenHintAcquiresAndRetries(t *testing.T) {
+	stageTwoCredentials(t)
+
+	body := "hello standalone"
+	var stats hintServerStats
+	svr := httptest.NewServer(countingTokenHintHandler(body, &stats))
+	t.Cleanup(svr.Close)
+
+	transfer, tok := newHintTransfer(t, svr.URL, hintTransferOpts{})
+
+	// The credential the client picks unaided is the one the server rejects.
+	first, err := tok.Get()
+	require.NoError(t, err)
+	parsedFirst, err := token.UnsafeParseClaims(first)
+	require.NoError(t, err)
+	require.Equal(t, wrongIssuer, parsedFirst.Issuer(),
+		"fixture is wrong if the client already prefers the accepted credential")
+
+	res, err := downloadObject(transfer)
+	require.NoError(t, err)
+	require.NoError(t, res.Error, "the hinted credential should have completed the transfer")
+	assert.Equal(t, int64(len(body)), res.TransferredBytes)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&stats.rejected),
+		"exactly one attempt should have been rejected before the hint was acted on")
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&stats.served), int32(1),
+		"the retry carrying the hinted credential should have been served")
+
+	// The accepted credential is published to the job's generator so sibling
+	// files and the checksum request that follows do not re-acquire it.
+	cached := tok.Token.Load()
+	require.NotNil(t, cached, "the accepted credential must be cached on the shared generator")
+	parsedCached, err := token.UnsafeParseClaims(cached.Contents)
+	require.NoError(t, err)
+	assert.Equal(t, hintedIssuer, parsedCached.Issuer())
+}
+
+// TestTokenHintHonoredWhenFederationHasADirector pins that the presence of a
+// director is not what decides this.  What matters is who chose the host: this
+// is still the host from the user's own URL, so its hint is still worth acting
+// on, director or no director.  The fixture is TestTokenHintAcquiresAndRetries
+// plus a director endpoint, so an outcome that differs would mean the gate is
+// keyed on the wrong thing.
+func TestTokenHintHonoredWhenFederationHasADirector(t *testing.T) {
+	stageTwoCredentials(t)
+
+	body := "hello standalone"
+	var stats hintServerStats
+	svr := httptest.NewServer(countingTokenHintHandler(body, &stats))
+	t.Cleanup(svr.Close)
+
+	transfer, _ := newHintTransfer(t, svr.URL, hintTransferOpts{
+		directorEndpoint: "https://director.example.com",
+	})
+
+	res, err := downloadObject(transfer)
+	require.NoError(t, err)
+	require.NoError(t, res.Error, "the hinted credential should have completed the transfer")
+	assert.Equal(t, int64(len(body)), res.TransferredBytes)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&stats.rejected))
+}
+
+// TestTokenHintIgnoredFromHostTheUserDidNotName is the security boundary for the
+// mechanism.  A hint feeds credential acquisition -- AcquireToken, OAuth2
+// dynamic client registration, the interactive device-code flow -- so honoring
+// one from the wrong party lets that party point a token request, or a login
+// prompt shown to the user, at an issuer it chose.
+//
+// The client may take that advice only from a host its user named.  Here the
+// endpoint serving the object is not the host in the pelican:// URL: it stands
+// for somewhere the client was sent, a cache a director selected.  Its hint
+// must be refused however well-formed it is.
+func TestTokenHintIgnoredFromHostTheUserDidNotName(t *testing.T) {
+	stageTwoCredentials(t)
+
+	var stats hintServerStats
+	svr := httptest.NewServer(countingTokenHintHandler("hello standalone", &stats))
+	t.Cleanup(svr.Close)
+
+	// Same server, but the host the user named is somewhere else.
+	transfer, _ := newHintTransfer(t, svr.URL, hintTransferOpts{
+		discoveryEndpoint: "https://the-host-the-user-named.example.com",
+	})
+
+	res, err := downloadObject(transfer)
+	require.NoError(t, err)
+	require.Error(t, res.Error, "a hint from a host the user never named must not be acted on")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&stats.rejected), "client must not retry")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&stats.served))
+}
+
+// TestTokenHintDoesNotDisplaceExplicitToken pins that a caller who named a
+// credential keeps it.  Acting on a hint here would swap a credential the user
+// chose for one acquired from an issuer the server named.
+func TestTokenHintDoesNotDisplaceExplicitToken(t *testing.T) {
+	stageTwoCredentials(t)
+
+	var stats hintServerStats
+	svr := httptest.NewServer(countingTokenHintHandler("hello standalone", &stats))
+	t.Cleanup(svr.Close)
+
+	transfer, tok := newHintTransfer(t, svr.URL, hintTransferOpts{})
+	tok.SetToken(mintTestToken(t, wrongIssuer))
+
+	res, err := downloadObject(transfer)
+	require.NoError(t, err)
+	require.Error(t, res.Error)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&stats.rejected),
+		"an explicitly supplied credential must not be replaced by a hinted one")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&stats.served))
+}
+
+// TestCanApplyTokenHint covers the gate's decision table directly, including the
+// combinations the end-to-end tests above cannot reach cheaply.
+func TestCanApplyTokenHint(t *testing.T) {
+	objectServer, err := url.Parse("https://origin.example.com:8444")
+	require.NoError(t, err)
+
+	newGen := func() *tokenGenerator {
+		pUrl := &pelican_url.PelicanURL{Host: "origin.example.com:8444", Path: "/protected/obj"}
+		pUrl.FedInfo.DiscoveryEndpoint = "https://origin.example.com:8444"
+		return NewTokenGenerator(pUrl, nil, config.TokenRead, false)
+	}
+
+	t.Run("host-the-user-named", func(t *testing.T) {
+		assert.True(t, newGen().canApplyTokenHint(objectServer))
+	})
+
+	t.Run("host-the-user-named-in-a-federation-with-a-director", func(t *testing.T) {
+		tg := newGen()
+		tg.Destination.FedInfo.DirectorEndpoint = "https://director.example.com"
+		tg.SetDirectorResponse(&server_structs.DirectorResponse{})
+		assert.True(t, tg.canApplyTokenHint(objectServer),
+			"a director elsewhere does not unname the host the user typed")
+	})
+
+	t.Run("nil-generator", func(t *testing.T) {
+		var tg *tokenGenerator
+		assert.False(t, tg.canApplyTokenHint(objectServer))
+	})
+
+	t.Run("explicit-token", func(t *testing.T) {
+		tg := newGen()
+		tg.SetToken("chosen-by-the-caller")
+		assert.False(t, tg.canApplyTokenHint(objectServer))
+	})
+
+	t.Run("external-provider", func(t *testing.T) {
+		tg := newGen()
+		tg.SetExternalProvider(StaticTokenProvider("from-elsewhere"))
+		assert.False(t, tg.canApplyTokenHint(objectServer))
+	})
+
+	t.Run("different-host", func(t *testing.T) {
+		other, err := url.Parse("https://cache.example.com:8443")
+		require.NoError(t, err)
+		assert.False(t, newGen().canApplyTokenHint(other))
+	})
+
+	t.Run("scheme-downgrade", func(t *testing.T) {
+		plaintext, err := url.Parse("http://origin.example.com:8444")
+		require.NoError(t, err)
+		assert.False(t, newGen().canApplyTokenHint(plaintext),
+			"a plaintext endpoint must not answer for an https discovery host")
+	})
+
+	t.Run("no-discovery-endpoint", func(t *testing.T) {
+		tg := NewTokenGenerator(&pelican_url.PelicanURL{Path: "/protected/obj"}, nil, config.TokenRead, false)
+		assert.False(t, tg.canApplyTokenHint(objectServer))
+	})
+
+	t.Run("nil-destination", func(t *testing.T) {
+		assert.False(t, NewTokenGenerator(nil, nil, config.TokenRead, false).canApplyTokenHint(objectServer))
+	})
+}
+
+// TestTokenHintKeyIsOrderIndependent pins that the same hint produces one key
+// however the server happened to order its issuers.  Two orderings hashing
+// apart would leave tokenForHint coalescing nothing, and a recursive job would
+// acquire -- and prompt -- once per worker.
+func TestTokenHintKeyIsOrderIndependent(t *testing.T) {
+	issuer := func(host string) *url.URL {
+		u, err := url.Parse(host)
+		require.NoError(t, err)
+		return u
+	}
+	a, b, c := issuer("https://a.example.com"), issuer("https://b.example.com"), issuer("https://c.example.com")
+
+	hint := func(namespace string, issuers ...*url.URL) *server_structs.DirectorResponse {
+		return &server_structs.DirectorResponse{
+			XPelNsHdr:     server_structs.XPelNs{Namespace: namespace},
+			XPelTokGenHdr: server_structs.XPelTokGen{Issuers: issuers},
+		}
+	}
+
+	assert.Equal(t, tokenHintKey(hint("/protected", a, b)), tokenHintKey(hint("/protected", b, a)),
+		"issuer order must not change the key")
+
+	// Still discriminating: a different set, or a different namespace, is a
+	// different question and must not be coalesced with this one.
+	assert.NotEqual(t, tokenHintKey(hint("/protected", a, b)), tokenHintKey(hint("/protected", a, c)))
+	assert.NotEqual(t, tokenHintKey(hint("/protected", a, b)), tokenHintKey(hint("/other", a, b)))
+
+	// A nil entry is skipped rather than panicking or shifting the key.
+	assert.Equal(t, tokenHintKey(hint("/protected", a)), tokenHintKey(hint("/protected", nil, a)))
+}
+
+// TestWithTokenHintIsolatesState verifies the generator returned for a hint
+// carries the caller's token-selection settings but none of the receiver's
+// mutable state, so acquiring a hinted credential cannot disturb sibling files.
+func TestWithTokenHintIsolatesState(t *testing.T) {
+	issuer, err := url.Parse(hintedIssuer)
+	require.NoError(t, err)
+	hint := server_structs.DirectorResponse{
+		XPelNsHdr:     server_structs.XPelNs{Namespace: "/protected", RequireToken: true},
+		XPelTokGenHdr: server_structs.XPelTokGen{Issuers: []*url.URL{issuer}},
+	}
+
+	base := NewTokenGenerator(nil, nil, config.TokenRead, true)
+	base.SetTokenLocation("/tmp/some-token")
+	base.SetTokenName("named")
+	base.SetToken("cached-token-contents")
+
+	derived := base.withTokenHint(&hint)
+
+	assert.Equal(t, &hint, derived.DirResp)
+	assert.Equal(t, "/tmp/some-token", derived.TokenLocation, "explicit token location must carry over")
+	assert.Equal(t, config.TokenRead, derived.Operation)
+	assert.Empty(t, derived.TokenName,
+		"TokenName is assigned inside the receiver's singleflight; copying it would race with sibling workers")
+	assert.Nil(t, derived.Token.Load(), "the derived generator must acquire fresh, not reuse the rejected token")
+	assert.NotSame(t, base.Sync, derived.Sync, "the derived generator must not share singleflight state")
+
+	// The receiver is untouched.
+	assert.Nil(t, base.DirResp)
+	require.NotNil(t, base.Token.Load())
+	assert.Equal(t, "cached-token-contents", base.Token.Load().Contents)
+}
+
+// TestWithTokenHintConcurrentWithGet is a regression test for a data race:
+// withTokenHint used to copy TokenName out of the receiver while sibling workers
+// were inside getToken assigning it.  Meaningful under -race.
+func TestWithTokenHintConcurrentWithGet(t *testing.T) {
+	t.Setenv("BEARER_TOKEN", mintTestToken(t, hintedIssuer))
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+
+	pUrl := &pelican_url.PelicanURL{Host: "origin.example.com", Path: "/protected/obj"}
+	pUrl.FedInfo.DiscoveryEndpoint = "https://origin.example.com"
+	base := NewTokenGenerator(pUrl, nil, config.TokenRead, false)
+	hint := &server_structs.DirectorResponse{
+		XPelNsHdr: server_structs.XPelNs{Namespace: "/protected", RequireToken: true},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				// Force re-entry into getToken rather than the cached path.
+				base.Token.Store(nil)
+				_, _ = base.Get()
+			}
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				_ = base.withTokenHint(hint)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestDownloadHTTPYieldsTokenHint verifies that a rejection carrying X-Pelican
+// token-hint headers is surfaced as a tokenHintError whose parsed
+// DirectorResponse indicates a token is required -- the signal the attempt loop
+// uses to acquire a credential and retry the same endpoint.
+//
+// Both rejection codes have to work.  With nothing probing ahead of the
+// transfer, the ordinary first request carries no credential and earns a 401;
+// 403 is what a presented-but-insufficient one earns.
+func TestDownloadHTTPYieldsTokenHint(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		token string
+	}{
+		{name: "no-credential-earns-401", token: ""},
+		{name: "rejected-credential-earns-403", token: "not-a-jwt"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svr := httptest.NewServer(tokenHintHandler("hello standalone"))
+			t.Cleanup(svr.Close)
+
+			transfers := generateTransferDetails(svr.URL, transferDetailsOptions{false, ""})
+			require.NotEmpty(t, transfers)
+
+			fname := filepath.Join(t.TempDir(), "out.txt")
+			writer, err := os.OpenFile(fname, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
+			require.NoError(t, err)
+			defer writer.Close()
+
+			_, _, _, _, _, err = downloadHTTP(context.Background(), nil, nil, transfers[0], fname, writer, 0, -1, -1, tc.token, "", nil, nil)
+			require.Error(t, err)
+
+			var hintErr *tokenHintError
+			require.True(t, errors.As(err, &hintErr), "expected a tokenHintError, got %T: %v", err, err)
+			assert.True(t, hintErr.dirResp.XPelNsHdr.RequireToken)
+			assert.Equal(t, "/protected", hintErr.dirResp.XPelNsHdr.Namespace)
+			require.Len(t, hintErr.dirResp.XPelAuthHdr.Issuers, 1)
+			assert.Equal(t, hintedIssuer, hintErr.dirResp.XPelAuthHdr.Issuers[0].String())
+		})
+	}
+}
+
+// TestDownloadHTTP_403NoHintIsTerminal verifies that a plain 403 (no X-Pelican
+// headers) keeps the existing terminal authorization-error behavior and does NOT
+// produce a tokenHintError.
+func TestDownloadHTTP_403NoHintIsTerminal(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("nope"))
+	}))
+	t.Cleanup(svr.Close)
+
+	transfers := generateTransferDetails(svr.URL, transferDetailsOptions{false, ""})
+	require.NotEmpty(t, transfers)
+
+	fname := filepath.Join(t.TempDir(), "out.txt")
+	writer, err := os.OpenFile(fname, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
+	require.NoError(t, err)
+	defer writer.Close()
+
+	_, _, _, _, _, err = downloadHTTP(context.Background(), nil, nil, transfers[0], fname, writer, 0, -1, -1, "", "", nil, nil)
+	require.Error(t, err)
+
+	var hintErr *tokenHintError
+	assert.False(t, errors.As(err, &hintErr), "plain 403 must not be a tokenHintError")
+}
+
+// TestDownloadHTTP_SucceedsWithToken verifies the endpoint serves the object once
+// an acceptable bearer token is supplied (the retry path's second attempt).
+func TestDownloadHTTP_SucceedsWithToken(t *testing.T) {
+	body := "hello standalone"
+	svr := httptest.NewServer(tokenHintHandler(body))
+	t.Cleanup(svr.Close)
+
+	transfers := generateTransferDetails(svr.URL, transferDetailsOptions{false, ""})
+	require.NotEmpty(t, transfers)
+
+	fname := filepath.Join(t.TempDir(), "out.txt")
+	writer, err := os.OpenFile(fname, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
+	require.NoError(t, err)
+	defer writer.Close()
+
+	downloaded, _, _, _, _, err := downloadHTTP(context.Background(), nil, nil, transfers[0], fname, writer, 0, -1, -1, mintTestToken(t, hintedIssuer), "", nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(body)), downloaded)
+}
+
+// TestResolveWithoutDirector covers how a client addresses an object when the
+// federation's discovery document names no director.  It costs no round trip:
+// the only possible object server is the discovery host the user already named,
+// and what credential the namespace wants is left for the origin to say on the
+// response that turns the request down.
+func TestResolveWithoutDirector(t *testing.T) {
+	pUrl := &pelican_url.PelicanURL{Path: "/protected/obj.txt"}
+	pUrl.FedInfo.DiscoveryEndpoint = "https://origin.example.com:8444"
+
+	resp, err := resolveWithoutDirector(pUrl)
+	require.NoError(t, err)
+
+	require.Len(t, resp.ObjectServers, 1)
+	assert.Equal(t, "https://origin.example.com:8444", resp.ObjectServers[0].String())
+
+	// An origin serving its own namespace is its own listing endpoint, which a
+	// recursive transfer needs before it starts.
+	require.NotNil(t, resp.XPelNsHdr.CollectionsUrl)
+	assert.Equal(t, "https://origin.example.com:8444", resp.XPelNsHdr.CollectionsUrl.String())
+
+	// Not guessed: the origin is about to say.
+	assert.Empty(t, resp.XPelNsHdr.Namespace)
+	assert.False(t, resp.XPelNsHdr.RequireToken)
+	assert.Empty(t, resp.XPelAuthHdr.Issuers)
+}
+
+// TestResolveWithoutDirectorCostsNoRoundTrip is the point of resolving locally:
+// a transfer against a directorless federation must not pay for a metadata
+// request before it starts.  The download itself asks the only question that
+// was ever outstanding, and the origin answers it on the way past.
+func TestResolveWithoutDirectorCostsNoRoundTrip(t *testing.T) {
+	var hits int32
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		writeTokenHintHeaders(w.Header())
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(svr.Close)
+
+	pUrl := &pelican_url.PelicanURL{Path: "/protected/obj.txt"}
+	pUrl.FedInfo.DiscoveryEndpoint = svr.URL
+
+	resp, err := resolveWithoutDirector(pUrl)
+	require.NoError(t, err)
+	require.Len(t, resp.ObjectServers, 1)
+	assert.Equal(t, svr.URL, resp.ObjectServers[0].String())
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&hits),
+		"resolving a download against a directorless federation must contact nobody")
+
+	// The counterpart: a caller that cannot learn from a rejected response --
+	// `token create`, a listing, a stat -- still asks, and gets real metadata.
+	_, err = getDirectorInfoForPath(context.Background(), pUrl, http.MethodGet, "", false)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&hits),
+		"callers that need the answer up front still pay for it")
+}
+
+func TestResolveWithoutDirectorRejectsUnparsableDiscoveryEndpoint(t *testing.T) {
+	pUrl := &pelican_url.PelicanURL{Path: "/protected/obj.txt"}
+	pUrl.FedInfo.DiscoveryEndpoint = "://not-a-url"
+
+	_, err := resolveWithoutDirector(pUrl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "discovery endpoint")
+}
+
+// TestGetDirectorInfoNoDirectorNoDiscovery keeps the original error for a URL
+// carrying neither a director nor a discovery endpoint -- there is nothing to
+// ask, and silently succeeding would strand the transfer later.
+func TestGetDirectorInfoNoDirectorNoDiscovery(t *testing.T) {
+	pUrl := &pelican_url.PelicanURL{Path: "/protected/obj.txt"}
+	_, err := getDirectorInfoForPath(context.Background(), pUrl, http.MethodGet, "", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "none was found in pelican URL metadata")
+}
+
+// TestSetTokenEmptyDoesNotClaimExplicit keeps WithToken("") -- which several
+// option paths pass through unconditionally -- from being mistaken for a caller
+// naming a credential, which would silently disable token hints.
+func TestSetTokenEmptyDoesNotClaimExplicit(t *testing.T) {
+	objectServer, err := url.Parse("https://origin.example.com:8444")
+	require.NoError(t, err)
+	pUrl := &pelican_url.PelicanURL{Host: "origin.example.com:8444", Path: "/protected/obj"}
+	pUrl.FedInfo.DiscoveryEndpoint = "https://origin.example.com:8444"
+
+	tg := NewTokenGenerator(pUrl, nil, config.TokenRead, false)
+	tg.SetToken("")
+	assert.True(t, tg.canApplyTokenHint(objectServer))
+
+	tg.SetToken("an-actual-credential")
+	assert.False(t, tg.canApplyTokenHint(objectServer))
+}

--- a/cmd/origin_standalone_test.go
+++ b/cmd/origin_standalone_test.go
@@ -1,0 +1,371 @@
+//go:build server && !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/database"
+	"github.com/pelicanplatform/pelican/launchers"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/pelicanplatform/pelican/origin"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/test_utils"
+	"github.com/pelicanplatform/pelican/token"
+	"github.com/pelicanplatform/pelican/token_scopes"
+)
+
+// TestStandaloneOriginServe brings up an origin with Origin.EnableStandaloneMode
+// and no federation reachable at all -- no Federation.DiscoveryUrl, no director,
+// no registry -- and verifies that it still serves objects under Pelican's
+// managed authorization.
+//
+// The absence of any federation configuration is the point of the test: on a
+// non-standalone origin, startup gets as far as federation discovery and then
+// fails, so simply reaching a served object proves that every federation
+// touchpoint was skipped rather than merely tolerated.
+func TestStandaloneOriginServe(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+
+	ctx, cancel, egrp := test_utils.TestContext(context.Background(), t)
+	defer func() { require.NoError(t, egrp.Wait()) }()
+	defer cancel()
+
+	tmpPath := t.TempDir()
+	storageDir := t.TempDir()
+
+	// Certificate verification stays on: the origin generates its own CA during
+	// startup and records it in Server.TLSCACertificateFile, which every client
+	// built from config.GetTransport() in this process already trusts.  Turning
+	// verification off would hide a discovery document that named a host the
+	// certificate does not cover.
+	require.NoError(t, param.MultiSet(map[string]any{
+		param.ConfigBase.GetName():         tmpPath,
+		param.RuntimeDir.GetName():         tmpPath,
+		param.Origin_RunLocation.GetName(): filepath.Join(tmpPath, "xrd"),
+		param.Logging_Level.GetName():      "Debug",
+		param.Server_EnableUI.GetName():    false,
+		param.Server_WebPort.GetName():     0,
+		param.Origin_DbLocation.GetName():  filepath.Join(tmpPath, "origin.sqlite"),
+
+		// The native POSIX backend, served in-process, with no federation behind it.
+		param.Origin_StorageType.GetName():          "posixv2",
+		param.Origin_StoragePrefix.GetName():        storageDir,
+		param.Origin_FederationPrefix.GetName():     "/standalone",
+		param.Origin_EnablePublicReads.GetName():    true,
+		param.Origin_EnableWrites.GetName():         true,
+		param.Origin_EnableStandaloneMode.GetName(): true,
+	}))
+
+	_, shutdownCancel, err := launchers.LaunchModules(ctx, server_structs.OriginType)
+	require.NoError(t, err)
+	defer shutdownCancel()
+
+	require.True(t, config.IsStandaloneOrigin())
+	webUrl := param.Server_ExternalWebUrl.GetString()
+	httpc := http.Client{Transport: config.GetTransport()}
+
+	t.Run("federation-endpoints-are-empty", func(t *testing.T) {
+		fedInfo, err := config.GetFederation(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, webUrl, fedInfo.DiscoveryEndpoint)
+		assert.Empty(t, fedInfo.DirectorEndpoint)
+		assert.Empty(t, fedInfo.RegistryEndpoint)
+	})
+
+	t.Run("public-read-serves-object-at-its-federation-prefix", func(t *testing.T) {
+		const contents = "standalone origins still serve objects\n"
+		require.NoError(t, os.WriteFile(filepath.Join(storageDir, "hello.txt"), []byte(contents), 0644))
+
+		// No director shares this web server, so the object is served from the
+		// URL the client already constructed -- no redirect, no relocated data
+		// route. Use a non-following client so a redirect would fail the test
+		// rather than be silently followed.
+		noRedirect := http.Client{
+			Transport: config.GetTransport(),
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+		resp, err := noRedirect.Get(webUrl + "/standalone/hello.txt")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode, string(body))
+		assert.Equal(t, contents, string(body))
+
+		// The namespace metadata rides on the object's own response: with no
+		// director, this is the only place a client can learn the namespace and
+		// whether it needs a token.
+		assert.Contains(t, resp.Header.Get("X-Pelican-Namespace"), "namespace=/standalone")
+		assert.Contains(t, resp.Header.Get("X-Pelican-Namespace"), "require-token=false")
+	})
+
+	t.Run("discovery-names-no-director", func(t *testing.T) {
+		resp, err := httpc.Get(webUrl + "/.well-known/pelican-configuration")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var fed struct {
+			DiscoveryEndpoint string `json:"discovery_endpoint"`
+			DirectorEndpoint  string `json:"director_endpoint"`
+			RegistryEndpoint  string `json:"namespace_registration_endpoint"`
+			JwksUri           string `json:"jwks_uri"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&fed))
+		assert.Equal(t, webUrl, fed.DiscoveryEndpoint)
+		assert.Empty(t, fed.DirectorEndpoint,
+			"naming no director is what tells a client to resolve objects against this origin directly")
+		assert.Empty(t, fed.RegistryEndpoint, "nothing serves registry APIs here")
+		assert.Equal(t, webUrl+"/.well-known/issuer.jwks", fed.JwksUri)
+	})
+
+	t.Run("write-requires-locally-issued-token", func(t *testing.T) {
+		uploadUrl := webUrl + "/standalone/uploaded.txt"
+
+		// Without a token the write is refused: standalone mode disconnects the
+		// origin from the federation, it does not disable authorization.
+		req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadUrl, strings.NewReader("nope"))
+		require.NoError(t, err)
+		resp, err := httpc.Do(req)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+		// A token from this origin's own issuer (the only issuer there is) works.
+		tokCfg := token.NewWLCGToken()
+		tokCfg.Issuer = webUrl
+		tokCfg.Subject = "test-user"
+		tokCfg.Lifetime = 5 * time.Minute
+		tokCfg.AddAudiences("https://wlcg.cern.ch/jwt/v1/any")
+		tokCfg.AddResourceScopes(token_scopes.NewResourceScope(token_scopes.Wlcg_Storage_Create, "/"))
+		tok, err := tokCfg.CreateToken()
+		require.NoError(t, err)
+
+		const contents = "written through the standalone origin\n"
+		req, err = http.NewRequestWithContext(ctx, http.MethodPut, uploadUrl, strings.NewReader(contents))
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+tok)
+		resp, err = httpc.Do(req)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		require.Less(t, resp.StatusCode, 300, string(body))
+
+		written, err := os.ReadFile(filepath.Join(storageDir, "uploaded.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, contents, string(written))
+	})
+
+	t.Run("rejection-hints-at-the-token-it-wants", func(t *testing.T) {
+		// A refused client still has to discover which issuer would mint a
+		// usable token. With no director in the deployment, these headers on the
+		// rejection are the only place that information can come from.
+		// Reads on this export are public, so exercise the auth path with a write.
+		objectUrl := webUrl + "/standalone/hinted.txt"
+
+		// No token at all: 401, because retrying without new information would
+		// just loop.
+		req, err := http.NewRequestWithContext(ctx, http.MethodPut, objectUrl, strings.NewReader("x"))
+		require.NoError(t, err)
+		resp, err := httpc.Do(req)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		assert.Contains(t, resp.Header.Get("X-Pelican-Authorization"), "issuer=")
+
+		// A token that does not authorize: 403, which is the status the client's
+		// token-hint retry keys on.
+		badTokCfg := token.NewWLCGToken()
+		badTokCfg.Issuer = webUrl
+		badTokCfg.Subject = "test-user"
+		badTokCfg.Lifetime = 5 * time.Minute
+		badTokCfg.AddAudiences("https://wlcg.cern.ch/jwt/v1/any")
+		badTokCfg.AddResourceScopes(token_scopes.NewResourceScope(token_scopes.Wlcg_Storage_Read, "/nonexistent"))
+		badTok, err := badTokCfg.CreateToken()
+		require.NoError(t, err)
+
+		req, err = http.NewRequestWithContext(ctx, http.MethodPut, objectUrl, strings.NewReader("x"))
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+badTok)
+		resp, err = httpc.Do(req)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+		// Either way the hints describe where to authenticate.
+		assert.Contains(t, resp.Header.Get("X-Pelican-Namespace"), "namespace=/standalone")
+		assert.Contains(t, resp.Header.Get("X-Pelican-Authorization"), "issuer=")
+		assert.Contains(t, resp.Header.Get("X-Pelican-Token-Generation"), "issuer=")
+	})
+
+	t.Run("web-api-reports-standalone", func(t *testing.T) {
+		resp, err := httpc.Get(webUrl + "/api/v1.0/servers")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var payload struct {
+			Servers          []string `json:"servers"`
+			StandaloneOrigin bool     `json:"standaloneOrigin"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+		assert.Equal(t, []string{"origin"}, payload.Servers)
+		assert.True(t, payload.StandaloneOrigin)
+	})
+
+	t.Run("local-metadata-carries-a-server-name", func(t *testing.T) {
+		// The record is normally a side effect of advertising to a director;
+		// without it the web UI's ServerName lookup 404s on every page load.
+		metadata, err := database.GetServerLocalMetadata()
+		require.NoError(t, err)
+		assert.NotEmpty(t, metadata.Name)
+		assert.Equal(t, "origin", metadata.Type)
+	})
+
+	t.Run("pelican-client-transfers-objects", func(t *testing.T) {
+		// The client speaks only pelican://, and it normally resolves an object
+		// by asking the federation's discovery endpoint for a director and then
+		// asking that director who serves the object. This federation's discovery
+		// document names no director, so the client addresses the object to the
+		// discovery host itself and asks nobody first (client.resolveWithoutDirector),
+		// learning anything it still needs from the origin's own reply. Everything
+		// above drives the origin's handlers with a hand-built HTTP client; this
+		// subtest is what proves the real client library takes the directorless
+		// path and completes.
+		require.NoError(t, config.InitClient())
+		host := strings.TrimPrefix(webUrl, "https://")
+
+		const contents = "fetched by the pelican client\n"
+		require.NoError(t, os.WriteFile(filepath.Join(storageDir, "client.txt"), []byte(contents), 0644))
+
+		downloadDir := t.TempDir()
+		results, err := client.DoGet(ctx, "pelican://"+host+"/standalone/client.txt",
+			filepath.Join(downloadDir, "client.txt"), false)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		got, err := os.ReadFile(filepath.Join(downloadDir, "client.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, contents, string(got))
+
+		// An upload takes the same directorless resolution -- a metadata HEAD,
+		// then the transfer against the URL the client already had -- but writes
+		// are never public, so it also covers the authorized half of that path.
+		const uploaded = "uploaded by the pelican client\n"
+		srcPath := filepath.Join(t.TempDir(), "upload.txt")
+		require.NoError(t, os.WriteFile(srcPath, []byte(uploaded), 0644))
+
+		tokCfg := token.NewWLCGToken()
+		tokCfg.Issuer = webUrl
+		tokCfg.Subject = "test-user"
+		tokCfg.Lifetime = 5 * time.Minute
+		tokCfg.AddAudiences("https://wlcg.cern.ch/jwt/v1/any")
+		tokCfg.AddResourceScopes(
+			token_scopes.NewResourceScope(token_scopes.Wlcg_Storage_Create, "/"),
+			token_scopes.NewResourceScope(token_scopes.Wlcg_Storage_Modify, "/"),
+		)
+		tok, err := tokCfg.CreateToken()
+		require.NoError(t, err)
+
+		_, err = client.DoPut(ctx, srcPath, "pelican://"+host+"/standalone/client-upload.txt", false,
+			client.WithToken(tok))
+		require.NoError(t, err)
+		written, err := os.ReadFile(filepath.Join(storageDir, "client-upload.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, uploaded, string(written))
+
+		// Stat and list resolve the namespace the same way and then issue HEAD
+		// and PROPFIND against the origin's own WebDAV routes -- the collections
+		// URL in the namespace metadata is this origin, since nothing else in
+		// the deployment could serve a listing.
+		info, err := client.DoStat(ctx, "pelican://"+host+"/standalone/client.txt")
+		require.NoError(t, err)
+		assert.Equal(t, int64(len(contents)), info.Size)
+
+		listed, err := client.DoList(ctx, "pelican://"+host+"/standalone")
+		require.NoError(t, err)
+		names := make([]string, 0, len(listed))
+		for _, fi := range listed {
+			names = append(names, path.Base(fi.Name))
+		}
+		assert.Contains(t, names, "client.txt")
+		assert.Contains(t, names, "client-upload.txt")
+	})
+
+	// Disk usage for the remote-protocol backends used to be measured by
+	// pointing the Pelican client at the origin's own namespace, which needed a
+	// federation to route through and a transfer engine to build.  Nothing on a
+	// serve path calls config.InitClient, so that walk could not run outside a
+	// test harness that had called it -- and a standalone origin was refused
+	// outright.  It reads the backend directly now.
+	t.Run("disk-usage-walks-the-backend-without-a-client", func(t *testing.T) {
+		require.NoError(t, param.Origin_EnableDiskUsageCalculation.Set(true))
+
+		// Write into the backing store directly rather than relying on an
+		// earlier subtest, and into a subdirectory so the walk has to recurse.
+		nested := filepath.Join(storageDir, "usage", "deep")
+		require.NoError(t, os.MkdirAll(nested, 0755))
+		const measured = "counted by the disk usage walk\n"
+		require.NoError(t, os.WriteFile(filepath.Join(nested, "sized.txt"), []byte(measured), 0644))
+
+		// An origin process never initializes the client; earlier subtests here
+		// did, so undo that.  If the walk ever goes back over the network this
+		// fails the way it would in production rather than passing on the
+		// harness's leftovers.
+		config.ResetClientInitialized()
+		t.Cleanup(func() { require.NoError(t, config.InitClient()) })
+		require.False(t, config.IsClientInitialized())
+
+		require.NoError(t, origin.CalculateDiskUsage(ctx, true))
+
+		// The walk logs its failures and returns nil, so "no error" says
+		// nothing on its own; assert it found what earlier subtests wrote.
+		objects := testutil.ToFloat64(origin.PelicanOriginDiskUsageObjects.WithLabelValues("/standalone"))
+		assert.GreaterOrEqual(t, objects, float64(1), "the crawl reported no objects, so it walked nothing")
+		bytes := testutil.ToFloat64(origin.PelicanOriginDiskUsageBytes.WithLabelValues("/standalone"))
+		assert.GreaterOrEqual(t, bytes, float64(len(measured)),
+			"the crawl missed the nested file, so it did not recurse")
+		errs := testutil.ToFloat64(origin.PelicanOriginDiskUsageCrawlErrors.WithLabelValues("/standalone"))
+		assert.Zero(t, errs, "the crawl hit errors while walking")
+	})
+}

--- a/config/config.go
+++ b/config/config.go
@@ -496,6 +496,24 @@ func IsServerEnabled(testServer server_structs.ServerType) bool {
 	return enabledServers.IsEnabled(testServer)
 }
 
+// IsStandaloneOrigin reports whether this process is running an origin that has
+// opted out of the federation entirely via Origin.EnableStandaloneMode.
+//
+// Every federation touchpoint the origin would otherwise use -- registering at
+// the registry, advertising to (and being tested by) the director, discovering
+// directors, brokering connections, mirroring downtime -- is skipped when this
+// is true.  Callers should prefer this helper over reading the parameter
+// directly so that the "origin module is actually enabled" half of the
+// condition can never be forgotten (a cache-only process must not be treated as
+// a standalone origin just because the origin knob is set in a shared config).
+//
+// This is the origin counterpart of Cache.EnableSiteLocalMode, but it is
+// stricter: a site-local cache still uses the director as a client, whereas a
+// standalone origin contacts no federation service at all.
+func IsStandaloneOrigin() bool {
+	return enabledServers.IsEnabled(server_structs.OriginType) && param.Origin_EnableStandaloneMode.GetBool()
+}
+
 // Returns the version of the current binary
 func GetVersion() string {
 	return version.GetVersion()
@@ -706,6 +724,19 @@ func validateDiscoveryUrl(discUrlStr string) (*url.URL, error) {
 func discoverFederationImpl(ctx context.Context) (fedInfo pelican_url.FederationDiscovery, err error) {
 	federationStr := param.Federation_DiscoveryUrl.GetString()
 	externalUrlStr := param.Server_ExternalWebUrl.GetString()
+
+	// A standalone origin has no federation to discover, but a populated
+	// discovery endpoint is still required below -- it doubles as the federation
+	// issuer.  Stand in for it with our own external web URL, which makes the
+	// auto-discovery step below a no-op and leaves the director, registry, and
+	// broker endpoints empty.  This is resolved here rather than at InitServer
+	// time because Server.ExternalWebUrl is not final until the web engine has
+	// bound its port (Server.WebPort may be 0).
+	if federationStr == "" && IsStandaloneOrigin() {
+		log.Debugln("Origin is standalone; using its own external web URL as the federation discovery URL")
+		federationStr = externalUrlStr
+	}
+
 	defer func() {
 		// Set default guesses if these values are still unset.
 		if fedInfo.DirectorEndpoint == "" && enabledServers.IsEnabled(server_structs.DirectorType) {
@@ -2453,6 +2484,15 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 
 	if currentServers.IsEnabled(server_structs.RegistryType) {
 		viper.SetDefault(param.Federation_RegistryUrl.GetName(), param.Server_ExternalWebUrl.GetString())
+	}
+
+	if currentServers.IsEnabled(server_structs.OriginType) && param.Origin_EnableStandaloneMode.GetBool() {
+		if err := validateStandaloneOrigin(currentServers); err != nil {
+			return err
+		}
+		// Note: the stand-in federation discovery URL is filled in lazily by
+		// discoverFederationImpl rather than here, because Server.ExternalWebUrl
+		// is not final until the web engine has bound its port.
 	}
 
 	if currentServers.IsEnabled(server_structs.BrokerType) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -854,6 +854,182 @@ func TestInitServerGlobusBackendRequiresUI(t *testing.T) {
 	require.ErrorContains(t, err, "globus")
 }
 
+// standaloneOriginBase applies the minimum configuration a standalone origin
+// needs: a native backend and no federation to discover.
+func standaloneOriginBase(t *testing.T) {
+	t.Helper()
+	require.NoError(t, param.ConfigBase.Set(t.TempDir()))
+	require.NoError(t, param.Origin_StorageType.Set("posixv2"))
+	require.NoError(t, param.Origin_StoragePrefix.Set(t.TempDir()))
+	require.NoError(t, param.Origin_FederationPrefix.Set("/standalone"))
+	require.NoError(t, param.Origin_EnableStandaloneMode.Set(true))
+}
+
+func TestInitServerStandaloneOrigin(t *testing.T) {
+	t.Run("needs-no-federation", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		standaloneOriginBase(t)
+		// Deliberately no Federation.DiscoveryUrl and no mock federation root:
+		// the whole point of standalone mode is that neither is reachable.
+		require.NoError(t, InitServer(context.Background(), server_structs.OriginType))
+		require.True(t, IsStandaloneOrigin())
+
+		// The discovery endpoint doubles as the federation issuer and must be
+		// populated, but it should point at this origin -- and no director or
+		// registry should have been invented for it.
+		fedInfo, err := GetFederation(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, param.Server_ExternalWebUrl.GetString(), fedInfo.DiscoveryEndpoint)
+		assert.Empty(t, fedInfo.DirectorEndpoint)
+		assert.Empty(t, fedInfo.RegistryEndpoint)
+		assert.Empty(t, fedInfo.BrokerEndpoint)
+	})
+
+	t.Run("rejects-explicit-discovery-url", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		fedRoot := mockFederationRoot(t)
+		standaloneOriginBase(t)
+		require.NoError(t, param.Federation_DiscoveryUrl.Set(fedRoot))
+
+		// Accepting both would leave the process holding two answers to "what
+		// federation is this?": GetFederation would report the remote one, while
+		// the document this origin publishes at its own root names itself and no
+		// director.
+		err := InitServer(context.Background(), server_structs.OriginType)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, param.Origin_EnableStandaloneMode.GetName())
+		assert.ErrorContains(t, err, param.Federation_DiscoveryUrl.GetName())
+	})
+
+	t.Run("rejects-root-federation-prefix", func(t *testing.T) {
+		// A "/" export would be mounted at the bare root, colliding with the
+		// origin's own /api and /.well-known routes; gin panics on that collision
+		// mid-startup, so the operator has to be stopped here instead.
+		for _, tc := range []struct {
+			name  string
+			apply func(t *testing.T)
+			param string
+		}{
+			{
+				name:  "top-level",
+				apply: func(t *testing.T) { require.NoError(t, param.Origin_FederationPrefix.Set("/")) },
+				param: param.Origin_FederationPrefix.GetName(),
+			},
+			{
+				name: "exports-block",
+				apply: func(t *testing.T) {
+					require.NoError(t, param.Origin_Exports.Set([]map[string]any{{
+						"FederationPrefix": "/",
+						"StoragePrefix":    t.TempDir(),
+						"Capabilities":     []string{"PublicReads"},
+					}}))
+				},
+				param: param.Origin_Exports.GetName(),
+			},
+			{
+				name: "export-volume",
+				// Spelled out rather than built from t.TempDir(): the volume
+				// syntax splits on the first colon, and a Windows temp path
+				// carries its own in the drive letter.
+				apply: func(t *testing.T) { require.NoError(t, param.Origin_ExportVolumes.Set([]string{"/srv/data:/"})) },
+				param: param.Origin_ExportVolumes.GetName(),
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				ResetConfig()
+				t.Cleanup(ResetConfig)
+
+				standaloneOriginBase(t)
+				tc.apply(t)
+
+				err := InitServer(context.Background(), server_structs.OriginType)
+				require.Error(t, err)
+				assert.ErrorContains(t, err, param.Origin_EnableStandaloneMode.GetName())
+				assert.ErrorContains(t, err, tc.param)
+			})
+		}
+	})
+
+	t.Run("disables-broker", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		standaloneOriginBase(t)
+		require.NoError(t, param.Origin_EnableBroker.Set(true))
+
+		require.NoError(t, InitServer(context.Background(), server_structs.OriginType))
+		assert.False(t, param.Origin_EnableBroker.GetBool())
+	})
+
+	t.Run("rejects-xrootd-backend", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		standaloneOriginBase(t)
+		require.NoError(t, param.Origin_StorageType.Set("posix"))
+
+		err := InitServer(context.Background(), server_structs.OriginType)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, param.Origin_EnableStandaloneMode.GetName())
+		assert.ErrorContains(t, err, param.Origin_StorageType.GetName())
+	})
+
+	t.Run("rejects-colocated-federation-module", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		standaloneOriginBase(t)
+
+		modules := server_structs.OriginType
+		modules.Set(server_structs.DirectorType)
+		err := InitServer(context.Background(), modules)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, param.Origin_EnableStandaloneMode.GetName())
+		assert.ErrorContains(t, err, "director")
+	})
+
+	t.Run("rejects-disable-direct-clients", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		standaloneOriginBase(t)
+		require.NoError(t, param.Origin_DisableDirectClients.Set(true))
+
+		err := InitServer(context.Background(), server_structs.OriginType)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, param.Origin_DisableDirectClients.GetName())
+	})
+
+	t.Run("disables-director-test", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		standaloneOriginBase(t)
+		require.NoError(t, param.Origin_DirectorTest.Set(true))
+
+		require.NoError(t, InitServer(context.Background(), server_structs.OriginType))
+		assert.False(t, param.Origin_DirectorTest.GetBool())
+	})
+
+	t.Run("does-not-apply-without-origin-module", func(t *testing.T) {
+		ResetConfig()
+		t.Cleanup(ResetConfig)
+
+		mockFederationRoot(t)
+		require.NoError(t, param.ConfigBase.Set(t.TempDir()))
+		// A shared config file may carry the origin knob even on a cache-only
+		// process; it must not disconnect the cache from the federation.
+		require.NoError(t, param.Origin_EnableStandaloneMode.Set(true))
+
+		require.NoError(t, InitServer(context.Background(), server_structs.CacheType))
+		assert.False(t, IsStandaloneOrigin())
+	})
+}
+
 func TestInitServerAtomicUploadsRequiresPosix(t *testing.T) {
 	ResetConfig()
 	t.Cleanup(func() {

--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -550,6 +550,8 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 	v.SetDefault(param.Origin_EnablePublicReads.GetName(), false)
 	// Origin.EnableReads
 	v.SetDefault(param.Origin_EnableReads.GetName(), true)
+	// Origin.EnableStandaloneMode
+	v.SetDefault(param.Origin_EnableStandaloneMode.GetName(), false)
 	// Origin.EnableTLSClientAuth
 	v.SetDefault(param.Origin_EnableTLSClientAuth.GetName(), false)
 	// Origin.EnableTransferAPI

--- a/config/source_tracker.go
+++ b/config/source_tracker.go
@@ -73,6 +73,17 @@ func GetSourceTracker() *SourceTracker {
 	return globalSourceTracker
 }
 
+// isDefaultSource reports whether a parameter still holds the value the
+// generated defaults gave it -- that is, no config file, environment variable,
+// or programmatic override has touched it.  Use it before rejecting a
+// parameter's value: several defaults are non-empty (the osdf-flavored binary,
+// for one, ships a federation discovery URL), and an operator cannot unset
+// something they never set.
+func isDefaultSource(name string) bool {
+	src, ok := GetSourceTracker().Get(strings.ToLower(name))
+	return !ok || src.Type == SourceDefault
+}
+
 // Record stores the source for a config key. If the key was already recorded,
 // the new source overwrites the old one (later stages take precedence).
 func (st *SourceTracker) Record(key string, source ConfigSource) {

--- a/config/standalone_origin.go
+++ b/config/standalone_origin.go
@@ -1,0 +1,189 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Startup validation for Origin.EnableStandaloneMode: the settings a standalone
+// origin cannot honor, and the federation prefixes it has been told to export.
+
+package config
+
+import (
+	"path"
+	"strings"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
+)
+
+// validateStandaloneOrigin rejects configurations where Origin.EnableStandaloneMode
+// is set but the rest of the configuration still assumes a federation.
+//
+// Standalone mode is deliberately narrow: it disconnects the origin from the
+// director and registry, which are exactly the components that supply the
+// XRootD-fronted backends with their configuration and that make the
+// "direct clients are forbidden" policy meaningful.  Rather than silently
+// half-applying the mode, fail at startup with an actionable message.
+func validateStandaloneOrigin(currentServers server_structs.ServerType) error {
+	standaloneName := param.Origin_EnableStandaloneMode.GetName()
+
+	// Only the native "v2" backends are served in-process; the XRootD-fronted
+	// ones build their config (authfile, issuer list, scitokens config) from
+	// federation metadata and expect a director to test them.
+	storageType := server_structs.OriginStorageType(param.Origin_StorageType.GetString())
+	if storageType.UsesXRootD() {
+		return errors.Errorf("%s is only supported with the native storage backends (%q, %q, %q, %q, %q), but %s is %q; "+
+			"either switch to a native backend or disable %s",
+			standaloneName,
+			server_structs.OriginStoragePosixv2, server_structs.OriginStorageS3v2, server_structs.OriginStorageHTTPSv2,
+			server_structs.OriginStorageGlobusv2, server_structs.OriginStorageSSH,
+			param.Origin_StorageType.GetName(), storageType, standaloneName)
+	}
+
+	// Co-locating a federation service with an origin that refuses to talk to
+	// any federation service is contradictory; the co-located module would
+	// advertise a federation the origin is not part of.
+	for _, module := range []server_structs.ServerType{
+		server_structs.DirectorType, server_structs.RegistryType,
+		server_structs.CacheType, server_structs.BrokerType,
+	} {
+		if currentServers.IsEnabled(module) {
+			return errors.Errorf("%s cannot be combined with the %s module in the same process; "+
+				"run the standalone origin on its own, or disable %s",
+				standaloneName, strings.ToLower(module.String()), standaloneName)
+		}
+	}
+
+	// DisableDirectClients requires that every request carry a token minted by
+	// the federation.  A standalone origin has no federation, so the only
+	// clients it can ever have are direct ones.
+	if param.Origin_DisableDirectClients.GetBool() {
+		return errors.Errorf("%s cannot be combined with %s=true: a standalone origin is reached only by direct clients, "+
+			"so every request would be rejected",
+			standaloneName, param.Origin_DisableDirectClients.GetName())
+	}
+
+	// A discovery URL names the federation this origin belongs to; a standalone
+	// origin belongs to none and publishes its own metadata at its own root
+	// (see origin.RegisterStandaloneFederationMetadata).  Honouring both would
+	// leave the process holding two different answers to "what federation is
+	// this?": GetFederation would describe the remote one while every client
+	// reading /.well-known/pelican-configuration here is told otherwise.
+	//
+	// Only an explicitly configured value is an error.  The osdf-flavored binary
+	// defaults this parameter to the OSDF's discovery host, and an operator who
+	// never asked for a federation should not have to unset something they did
+	// not set.
+	if discoveryUrl := param.Federation_DiscoveryUrl.GetString(); discoveryUrl != "" && !isDefaultSource(param.Federation_DiscoveryUrl.GetName()) {
+		return errors.Errorf("%s cannot be combined with %s=%q: a standalone origin belongs to no federation and "+
+			"publishes its own federation metadata; unset %s, or disable %s to join the federation it names",
+			standaloneName, param.Federation_DiscoveryUrl.GetName(), discoveryUrl,
+			param.Federation_DiscoveryUrl.GetName(), standaloneName)
+	}
+
+	// Without a director there is no redirect, so every export is mounted at its
+	// bare federation prefix (see origin_serve.RegisterHandlers).  A "/" export
+	// therefore claims the whole URL space, including the /api and /.well-known
+	// routes the origin's own web UI and discovery document occupy.  Gin panics
+	// on that route collision while the server is coming up, far past the point
+	// where the operator can be told what is actually wrong.
+	for _, export := range configuredFederationPrefixes() {
+		if path.Clean(export.prefix) == "/" {
+			return errors.Errorf("%s cannot export the root federation prefix %q (configured via %s): a standalone origin "+
+				"serves each export at its bare federation prefix, so the root would take over the paths its own web UI "+
+				"and /.well-known metadata occupy; pick a non-root prefix such as \"/data\"",
+				standaloneName, export.prefix, export.source)
+		}
+	}
+
+	// Director tests are initiated by a director that will never learn this
+	// origin exists.  Turn the knob off rather than leaving the origin's health
+	// status permanently critical on a test that can never arrive.
+	if param.Origin_DirectorTest.GetBool() {
+		log.Warningf("%s may not be enabled when %s is true (no director will ever run the test). Turning off...",
+			param.Origin_DirectorTest.GetName(), standaloneName)
+		if err := param.Origin_DirectorTest.Set(false); err != nil {
+			return err
+		}
+	}
+
+	// The broker exists to punch through a firewall on behalf of a cache the
+	// director sent here; with no federation there is nobody on the other end of
+	// the reverse connection, and launchers/launcher.go never starts the
+	// listener.  Say so rather than leaving the operator believing it is on.
+	if param.Origin_EnableBroker.GetBool() {
+		log.Warningf("%s may not be enabled when %s is true (there is no federation broker to connect to). Turning off...",
+			param.Origin_EnableBroker.GetName(), standaloneName)
+		if err := param.Origin_EnableBroker.Set(false); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// configuredExportPrefix pairs a federation prefix with the configuration
+// parameter that supplied it, so errors can point at the stanza to edit.
+type configuredExportPrefix struct {
+	source string
+	prefix string
+}
+
+// configuredFederationPrefixes reports the federation prefixes this origin has
+// been told to export.
+//
+// server_utils.GetOriginExports() is the authority on export parsing, but it
+// imports this package and does not run until well after InitServer.  Only the
+// prefixes are needed here, so they are read straight from configuration -- and
+// from every source rather than only the highest-precedence one, because a
+// prefix that cannot work is worth reporting no matter which stanza carries it.
+func configuredFederationPrefixes() []configuredExportPrefix {
+	prefixes := make([]configuredExportPrefix, 0)
+
+	// The Origin.Exports decode hooks only touch Capabilities and IssuerUrls, so
+	// the prefix can be read without them.  A malformed block is left for
+	// GetOriginExports to report properly.
+	var exports []struct {
+		FederationPrefix string `mapstructure:"federationprefix"`
+	}
+	if err := viper.UnmarshalKey(param.Origin_Exports.GetName(), &exports); err != nil {
+		log.Debugf("Unable to read federation prefixes from %s: %v", param.Origin_Exports.GetName(), err)
+	}
+	for _, export := range exports {
+		prefixes = append(prefixes, configuredExportPrefix{source: param.Origin_Exports.GetName(), prefix: export.FederationPrefix})
+	}
+
+	// Docker-style "<storage prefix>:<federation prefix>"; a bare value names the
+	// same path on both sides.  Split by the same code that builds the exports,
+	// so validation cannot disagree with it about where the prefix begins.
+	for _, volume := range param.Origin_ExportVolumes.GetStringSlice() {
+		_, federationPrefix := server_structs.ParseExportVolume(volume)
+		prefixes = append(prefixes, configuredExportPrefix{
+			source: param.Origin_ExportVolumes.GetName(),
+			prefix: federationPrefix,
+		})
+	}
+
+	if fedPrefix := param.Origin_FederationPrefix.GetString(); fedPrefix != "" {
+		prefixes = append(prefixes, configuredExportPrefix{source: param.Origin_FederationPrefix.GetName(), prefix: fedPrefix})
+	}
+
+	return prefixes
+}

--- a/director/director.go
+++ b/director/director.go
@@ -410,81 +410,19 @@ func corsHeadersMiddleware(ginCtx *gin.Context) {
 // issued a request where token generation may be needed. This header informs the client
 // of the issuer that can be used to generate a token for the requested resource.
 func generateXAuthHeader(ginCtx *gin.Context, namespaceAd server_structs.NamespaceAd) {
-	if len(namespaceAd.Issuer) != 0 {
-		issStrings := []string{}
-		for _, tokIss := range namespaceAd.Issuer {
-			issStrings = append(issStrings, "issuer="+tokIss.IssuerUrl.String())
-		}
-		ginCtx.Writer.Header()["X-Pelican-Authorization"] = issStrings
-	}
+	server_structs.SetXAuthHeader(ginCtx.Writer.Header(), namespaceAd)
 }
 
 // Generates the X-Pelican-Token-Generation header (when applicable) for responses that have
 // issued a request where token generation may be needed.
 func generateXTokenGenHeader(ginCtx *gin.Context, namespaceAd server_structs.NamespaceAd) {
-	if len(namespaceAd.Generation) != 0 {
-		tokenGen := ""
-		first := true
-		// TODO: At some point, the director stopped sending the `base-path` key in the token gen header. I'm unsure of the _proper_ way
-		// to fix this because the token gen header uses the issuer URL from NamespaceAd.Generation.CredentialIssuer, whereas basepaths
-		// come from NamespaceAd.Issuer.BasePaths. For now, connecting these two means checking if they have the same issuer URL. This
-		// really needs to be cleaned up in the future, and maybe we need to give more thought to why we have these two structs in the
-		// ad. See https://github.com/PelicanPlatform/pelican/issues/1540
-		var basePath string
-		for _, issuer := range namespaceAd.Issuer {
-			if issuer.IssuerUrl.String() == namespaceAd.Generation[0].CredentialIssuer.String() {
-				if len(issuer.BasePaths) > 0 {
-					basePath = issuer.BasePaths[0]
-				}
-				break
-			}
-		}
-
-		hdrVals := []string{namespaceAd.Generation[0].CredentialIssuer.String(), fmt.Sprint(namespaceAd.Generation[0].MaxScopeDepth),
-			string(namespaceAd.Generation[0].Strategy), basePath}
-		for idx, hdrKey := range []string{"issuer", "max-scope-depth", "strategy", "base-path"} {
-			hdrVal := hdrVals[idx]
-			if hdrVal == "" {
-				continue
-			} else if hdrKey == "max-scope-depth" && hdrVal == "0" {
-				// don't send a 0 max-scope-depth because it's malformed and probably means there should be no token generation header
-				continue
-			}
-			if !first {
-				tokenGen += ", "
-			}
-			first = false
-			tokenGen += hdrKey + "=" + hdrVal
-		}
-
-		if tokenGen != "" {
-			ginCtx.Writer.Header()["X-Pelican-Token-Generation"] = []string{tokenGen}
-		}
-	}
+	server_structs.SetXTokenGenHeader(ginCtx.Writer.Header(), namespaceAd)
 }
 
 // Generate the X-Pelican-Namespace header, which includes information about the namespace and whether token auth is required
 // for reading from this namespace
 func generateXNamespaceHeader(ginCtx *gin.Context, oAds []server_structs.ServerAd, bestNSAd server_structs.NamespaceAd) {
-	var collUrl string
-	// If the namespace or the origin does not allow directory listings, then we should not advertise a collections-url.
-	for _, oAd := range oAds {
-		if oAd.Caps.Listings && bestNSAd.Caps.Listings {
-			if !bestNSAd.Caps.PublicReads && oAd.AuthURL != (url.URL{}) {
-				collUrl = oAd.AuthURL.String()
-				break
-			} else {
-				collUrl = oAd.URL.String()
-				break
-			}
-		}
-	}
-
-	xPelicanNamespace := fmt.Sprintf("namespace=%s, require-token=%v", bestNSAd.Path, !bestNSAd.Caps.PublicReads)
-	if collUrl != "" {
-		xPelicanNamespace += fmt.Sprintf(", collections-url=%s", collUrl)
-	}
-	ginCtx.Writer.Header()["X-Pelican-Namespace"] = []string{xPelicanNamespace}
+	server_structs.SetXNamespaceHeader(ginCtx.Writer.Header(), oAds, bestNSAd)
 }
 
 // Generate the X-Pelican-Broker header using the first origin ad we find supporting

--- a/director/sort.go
+++ b/director/sort.go
@@ -137,48 +137,12 @@ func sortServerAds(ctx context.Context, ginCtx *gin.Context, clientAddr netip.Ad
 	return truncateAds(sortedAds, sourceServerAdsLimit), nil
 }
 
-// Given a request path and a slice of namespace ads, pick the namespace ad whose
-// path is the longest logical prefix of the request path. For example, for path
-// `/foo/bar/baz` and namespace ads `/foo` & `/foo/bar`, the function should return
-// the namespace ad for `/foo/bar`.
+// getLongestNSMatch picks the namespace ad whose path is the longest logical
+// prefix of the request path.  The implementation lives in server_structs so
+// that servers answering clients the way the director does (e.g. a standalone
+// origin) resolve namespaces identically.
 func getLongestNSMatch(reqPath string, namespaceAds []server_structs.NamespaceAd) *server_structs.NamespaceAd {
-	// Normalize incoming path if needed --> adding the trailing / makes
-	// basic prefix matching safer
-	if !strings.HasSuffix(reqPath, "/") {
-		reqPath += "/"
-	}
-
-	var bestFedPrefix string
-	var bestNamespace *server_structs.NamespaceAd
-	for _, ns := range namespaceAds {
-		// Create a copy of ns to avoid reusing the loop variable
-		currentNS := ns
-
-		// Additionally normalize stored namespace paths
-		nsPath := currentNS.Path
-		if !strings.HasSuffix(currentNS.Path, "/") {
-			nsPath += "/"
-		}
-
-		if !strings.HasPrefix(reqPath, nsPath) {
-			// This namespace doesn't match the request path, skip it
-			continue
-		}
-
-		if bestFedPrefix == "" {
-			bestFedPrefix = nsPath
-			bestNamespace = &currentNS
-			continue
-		}
-
-		if len(nsPath) > len(bestFedPrefix) {
-			bestFedPrefix = nsPath
-			bestNamespace = &currentNS
-			continue
-		}
-	}
-
-	return bestNamespace
+	return server_structs.LongestNSMatch(reqPath, namespaceAds)
 }
 
 // Given a request path, find all the ads that express willingness to work with

--- a/docs/app/federating-your-data/_meta.js
+++ b/docs/app/federating-your-data/_meta.js
@@ -4,5 +4,6 @@ export default {
     "s3-backend": "S3 Backend",
     "globus-backend": "Globus Backend",
     "ssh-backend": "SSH Backend",
+    "standalone-origin": "Running a Standalone Origin",
     "generating-tokens": "Generating Tokens",
 }

--- a/docs/app/federating-your-data/standalone-origin/page.mdx
+++ b/docs/app/federating-your-data/standalone-origin/page.mdx
@@ -1,0 +1,114 @@
+import { Callout } from 'nextra/components'
+
+# Running a Standalone Origin
+
+A **standalone Origin** is a Pelican Origin that belongs to no federation at all.
+When [`Origin.EnableStandaloneMode`](/parameters#Origin-EnableStandaloneMode) is set to `true`, the Origin will **not** register with a Registry, will **not** advertise itself to a Director, and will not contact any other federation service.
+Clients read and write objects by talking to the Origin's own URL directly, and every authorization decision is made against tokens minted by the Origin's own embedded issuer.
+
+This is the Origin counterpart of a [site-local Cache](/operating-a-federation/cache/site-local-cache), but it goes further: a site-local Cache still queries a Director as a client, whereas a standalone Origin makes no federation calls whatsoever.
+
+## Who Is This For?
+
+Standalone mode is intended for administrators who want Pelican's managed authorization over a storage backend without operating -- or belonging to -- a federation.
+Common scenarios include:
+
+- **A single group or lab** that wants token-based, per-namespace upload and download over an existing POSIX directory, S3 bucket, or HTTPS endpoint, served with Pelican's object browser and issuer.
+- **Testing and development** environments where you want to exercise an Origin's storage backend and authorization rules without standing up (or registering with) a Director and Registry.
+
+## Requirements
+
+Standalone mode requires one of Pelican's **native ("v2") storage backends**, which are served directly by the `pelican-server` process rather than by an XRootD subprocess:
+
+- `posixv2`
+- `s3v2`
+- `httpsv2`
+- `globusv2`
+- `ssh`
+
+The XRootD-fronted backends (`posix`, `s3`, `https`, `globus`, `xroot`) derive parts of their configuration from federation metadata, so they are rejected at startup with an explanatory error.
+
+Four further constraints are enforced when the Origin starts:
+
+- Standalone mode cannot be combined with the Director, Registry, Cache, or Broker modules in the same process, nor with [`Origin.DisableDirectClients`](/parameters#Origin-DisableDirectClients) -- a standalone Origin has only direct clients.
+- [`Federation.DiscoveryUrl`](/parameters#Federation-DiscoveryUrl) must not be set: a standalone Origin belongs to no federation and publishes its own federation metadata, so naming a remote one would leave the process holding two different answers to "what federation is this?".
+- Each export must declare a non-root `FederationPrefix`: the Origin serves every export at its bare federation prefix, so an export of `/` would take over the paths the Origin's own API, issuer, web UI, and `/.well-known` metadata occupy.
+- [`Origin.DirectorTest`](/parameters#Origin-DirectorTest) is force-disabled, with a warning in the log, since no Director exists to run the test.
+
+## How It Works
+
+A standalone Origin does none of the things an Origin normally does with a federation: it does not register namespaces with a Registry, advertise to a Director, run Director health tests, discover Directors, use the connection broker, or mirror downtime anywhere.
+
+With no federation to discover, the Origin's own [`Server.ExternalWebUrl`](/parameters#Server-ExternalWebUrl) is the federation's identity -- that is the host clients name in a `pelican://` URL.
+Because no Director is involved, clients resolve objects against the Origin directly, and objects are served at their federation prefix: an export with `FederationPrefix: /my-data` serves `https://origin.example.com:8444/my-data/...`.
+
+## Configuration
+
+A minimal configuration file for a standalone Origin might look like:
+
+```yaml
+Origin:
+  EnableStandaloneMode: true
+  StorageType: posixv2
+  EnableIssuer: true
+  IssuerMode: embedded
+  Exports:
+    - FederationPrefix: /my-data
+      StoragePrefix: /mnt/data
+      Capabilities: ["Reads", "Writes", "Listings"]
+Server:
+  Hostname: origin.example.com
+```
+
+Then launch the Origin as usual:
+
+```bash
+pelican-server origin serve --config /path/to/pelican.yaml
+```
+
+With [`Origin.EnableIssuer`](/parameters#Origin-EnableIssuer) set, each non-public export gets its own OIDC issuer at `<Server.ExternalWebUrl>/api/v1.0/issuer/ns<FederationPrefix>` -- for the export above, `https://origin.example.com:8444/api/v1.0/issuer/ns/my-data`.
+That issuer is what mints the tokens clients present.
+
+<Callout type="warning">
+  Set [`Origin.IssuerMode`](/parameters#Origin-IssuerMode) to `embedded` explicitly.
+  The default is `oa4mp`, which proxies to a separate OA4MP service that the Origin expects to launch and reach; if it is not installed, the Origin fails to start while waiting on the issuer's OIDC configuration endpoint.
+  The embedded issuer is built into `pelican-server` and needs nothing else installed.
+</Callout>
+See [Generating Tokens](/federating-your-data/generating-tokens) for how to obtain one.
+
+## Reading and Writing Objects
+
+The Pelican CLI works unmodified -- point it at the Origin's own hostname as the federation:
+
+```bash
+pelican object get pelican://origin.example.com:8444/my-data/example.txt ./example.txt
+pelican object put ./example.txt pelican://origin.example.com:8444/my-data/example.txt
+pelican object ls  pelican://origin.example.com:8444/my-data
+```
+
+The same is true of anything else that speaks Pelican, including the HTCondor file-transfer plugin and PelicanFS.
+
+Plain HTTP clients work too, against the same URLs:
+
+```bash
+# Download an object.  The export above grants Reads but not PublicReads,
+# so the download needs a token from this Origin's issuer too.
+curl -O -H "Authorization: Bearer $TOKEN" \
+    https://origin.example.com:8444/my-data/example.txt
+
+# Upload with the same kind of token
+curl -X PUT --upload-file ./example.txt \
+    -H "Authorization: Bearer $TOKEN" \
+    https://origin.example.com:8444/my-data/example.txt
+```
+
+Add `PublicReads` to an export's capabilities to let unauthenticated clients download from it; writes always require a token.
+
+The Origin also serves WebDAV at those same paths, so `rclone` and similar tools can be pointed straight at the Origin URL.
+The web UI's **Object Browser** (under `/view/origin/client/`) browses and transfers objects the same way.
+
+## Joining a Federation Later
+
+Standalone mode is a single setting.
+To join a federation later, set [`Federation.DiscoveryUrl`](/parameters#Federation-DiscoveryUrl), remove `Origin.EnableStandaloneMode`, and restart; the Origin will then register its namespaces and begin advertising.
+Note that the namespaces you chose while standalone must be available in the federation's Registry -- see [Choosing a Namespace Prefix](/federating-your-data/choosing-namespaces).

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1396,6 +1396,27 @@ type: bool
 default: false
 components: ["origin"]
 ---
+name: Origin.EnableStandaloneMode
+description: |+
+  When true, the Origin runs without joining a federation at all. It will not register at a Registry, it will not
+  advertise to a Director, it will not perform Director-initiated file transfer tests, and it will not contact any
+  other federation service. Clients resolve objects against the Origin directly, so `pelican object get` and
+  anything else that speaks Pelican works against the Origin's own hostname. Every authorization decision is made
+  against tokens minted by the Origin's own embedded issuer.
+
+  This is the Origin counterpart of ${Cache.EnableSiteLocalMode}, and is intended for administrators who want
+  Pelican's managed authorization over a storage backend without operating (or belonging to) a federation.
+
+  Standalone mode requires one of the native "v2" storage backends -- `posixv2`, `s3v2`, `httpsv2`, `globusv2`, or
+  `ssh` -- because the XRootD-fronted backends derive their configuration from federation metadata. It also cannot
+  be combined with the Director, Registry, Cache, or Broker modules in the same process, and it is incompatible with
+  ${Origin.DisableDirectClients} (in standalone mode every client is a direct client). ${Origin.DirectorTest} is
+  force-disabled at startup, since no Director exists to run the test.
+
+type: bool
+default: false
+components: ["origin"]
+---
 name: Origin.EnableIssuer
 description: |+
   Enable the built-in issuer daemon for the origin.

--- a/e2e_fed_tests/standalone_origin_cli_e2e_test.go
+++ b/e2e_fed_tests/standalone_origin_cli_e2e_test.go
@@ -1,0 +1,614 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package fed_tests
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/pelicanplatform/pelican/param"
+)
+
+// This file is the binary-vs-binary counterpart to cmd/origin_standalone_test.go.
+//
+// The in-process test proves the standalone origin's *handlers* behave; it does
+// so with the origin's own config, key material, and client library loaded into
+// the test process.  That arrangement cannot detect the failures that matter
+// most to an operator who types `pelican origin serve`: config that is only
+// reachable through the parameter API, key material the client can only get at
+// through a file, and federation discovery that would silently work because the
+// test process already knew the answer.
+//
+// So everything here crosses a process boundary.  The origin is a child process
+// started from the built binary via its CLI; every client action is another
+// child process invoking the `pelican` CLI; and the only things they share are
+// a TCP port, a filesystem path to one PEM file, and the bytes being
+// transferred.  The parent test process holds no Pelican global state at all --
+// note the absence of ResetTestState and of fed_test_utils.NewFedTest, which
+// would contradict the entire premise by standing up a federation.
+
+const standaloneCliPrefix = "/standalone-cli"
+
+// pelicanEnv returns an environment for a child pelican process with every
+// PELICAN_* variable stripped.  Configuration must arrive only through the
+// config file (for the origin) or the explicit variables we add back (for the
+// client); inheriting the developer's or CI job's Pelican environment would let
+// a federation setting leak in and quietly invalidate the test.
+func pelicanEnv(extra ...string) []string {
+	env := make([]string, 0, len(os.Environ())+len(extra))
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "PELICAN_") || strings.HasPrefix(kv, "OSDF_") || strings.HasPrefix(kv, "STASH_") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	return append(env, extra...)
+}
+
+// standaloneOriginProcess is a running `pelican origin serve` child.
+type standaloneOriginProcess struct {
+	webUrl        string
+	storageDir    string
+	issuerKeyPath string
+	// caPath is the CA the origin generated for itself at startup.  Both the
+	// test's own HTTP client and every child pelican process verify the
+	// origin's certificate against it: a certificate that does not cover the
+	// host the discovery document advertises is a real failure, and skipping
+	// verification would hide it.
+	caPath string
+	client *http.Client
+}
+
+// startStandaloneOrigin writes a config file that describes a standalone origin
+// -- and nothing else -- then launches the pelican binary against it and waits
+// for it to serve.
+//
+// The config deliberately omits Federation.DiscoveryUrl.  A federated origin
+// cannot start without one (the negative control at the bottom of this file
+// demonstrates that with the very same config file), so the origin reaching a
+// healthy state is itself the assertion that no federation touchpoint ran.
+func startStandaloneOrigin(t *testing.T, ctx context.Context, cliPath string) *standaloneOriginProcess {
+	t.Helper()
+
+	root := t.TempDir()
+	configDir := filepath.Join(root, "config")
+	runtimeDir := filepath.Join(root, "runtime")
+	storageDir := filepath.Join(root, "storage")
+	issuerKeysDir := filepath.Join(configDir, "issuer-keys")
+	for _, dir := range []string{configDir, runtimeDir, storageDir, issuerKeysDir} {
+		require.NoError(t, os.MkdirAll(dir, 0755))
+	}
+
+	configPath := writeStandaloneConfig(t, configDir, runtimeDir, storageDir, issuerKeysDir, true)
+
+	var output bytes.Buffer
+	var outputMu sync.Mutex
+	cmd := exec.CommandContext(ctx, cliPath, "origin", "serve", "--config", configPath)
+	cmd.Env = pelicanEnv()
+	cmd.Stdout = &lockedWriter{w: &output, mu: &outputMu}
+	cmd.Stderr = cmd.Stdout
+	require.NoError(t, cmd.Start(), "failed to start the standalone origin")
+
+	exited := make(chan error, 1)
+	go func() { exited <- cmd.Wait() }()
+
+	snapshot := func() string {
+		outputMu.Lock()
+		defer outputMu.Unlock()
+		return output.String()
+	}
+
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		select {
+		case <-exited:
+		case <-time.After(10 * time.Second):
+			t.Log("timed out waiting for the standalone origin to exit")
+		}
+		if t.Failed() {
+			t.Logf("standalone origin output:\n%s", snapshot())
+		}
+	})
+
+	// Server.WebPort is 0, so the port is not known until the child has bound
+	// it.  Pelican records the result in the runtime directory's address file
+	// precisely so that external tooling does not have to scrape logs or
+	// pre-select a port (which would race with the child's bind).
+	addressFile := filepath.Join(runtimeDir, "pelican.addresses")
+	var webUrl string
+	require.Eventually(t, func() bool {
+		select {
+		case err := <-exited:
+			t.Fatalf("standalone origin exited before writing its address file: %v\n%s", err, snapshot())
+		default:
+		}
+		contents, err := os.ReadFile(addressFile)
+		if err != nil {
+			return false
+		}
+		for _, line := range strings.Split(string(contents), "\n") {
+			if after, ok := strings.CutPrefix(strings.TrimSpace(line), "SERVER_EXTERNAL_WEB_URL="); ok {
+				webUrl = after
+				return webUrl != ""
+			}
+		}
+		return false
+	}, 90*time.Second, 250*time.Millisecond, "standalone origin never published its address file")
+
+	// The origin generates its CA during startup; the client cannot verify
+	// anything until it is on disk.
+	caPath := filepath.Join(configDir, "certificates", "tlsca.pem")
+	require.Eventually(t, func() bool {
+		select {
+		case err := <-exited:
+			t.Fatalf("standalone origin exited before writing its CA certificate: %v\n%s", err, snapshot())
+		default:
+		}
+		info, err := os.Stat(caPath)
+		return err == nil && info.Size() > 0
+	}, 90*time.Second, 250*time.Millisecond, "standalone origin never wrote %s", caPath)
+	httpc := clientTrusting(t, caPath)
+
+	require.Eventually(t, func() bool {
+		select {
+		case err := <-exited:
+			t.Fatalf("standalone origin exited before becoming healthy: %v\n%s", err, snapshot())
+		default:
+		}
+		resp, err := httpc.Get(webUrl + "/api/v1.0/health")
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 90*time.Second, 250*time.Millisecond, "standalone origin never became healthy")
+
+	// The client signs tokens with the origin's issuer key.  Locating the PEM
+	// on disk is how an administrator of the host would do it, and it keeps the
+	// two processes sharing a file rather than a process-global key cache.
+	pems, err := filepath.Glob(filepath.Join(issuerKeysDir, "*.pem"))
+	require.NoError(t, err)
+	require.Len(t, pems, 1, "expected the origin to have generated exactly one issuer key in %s", issuerKeysDir)
+
+	return &standaloneOriginProcess{
+		webUrl:        webUrl,
+		storageDir:    storageDir,
+		issuerKeyPath: pems[0],
+		caPath:        caPath,
+		client:        httpc,
+	}
+}
+
+// writeStandaloneConfig emits the origin's config file.  It is shared with the
+// negative control, which flips `standalone` to false and expects startup to
+// fail; keeping one writer guarantees the control differs in exactly that knob.
+func writeStandaloneConfig(t *testing.T, configDir, runtimeDir, storageDir, issuerKeysDir string, standalone bool) string {
+	t.Helper()
+
+	cfg := map[string]any{
+		"ConfigBase":          configDir,
+		"RuntimeDir":          runtimeDir,
+		"IssuerKeysDirectory": issuerKeysDir,
+		"Logging": map[string]any{
+			// No LogLocation: the child's log has to come back on stdout so a
+			// CI failure is diagnosable from the test output alone.
+			"Level":               "debug",
+			"DisableProgressBars": true,
+		},
+		"Server": map[string]any{
+			// Hostname is fixed to localhost so the self-signed certificate
+			// Pelican generates matches the name the client dials.
+			"Hostname": "localhost",
+			"WebPort":  0,
+			"EnableUI": false,
+			// Lets the test read the child's component health over the wire;
+			// see the no-federation-components assertion.
+			"HealthMonitoringPublic": true,
+		},
+		"Origin": map[string]any{
+			"EnableStandaloneMode": standalone,
+			// posixv2 is a native backend served in-process: no XRootD, no
+			// libXrdClPelican, and the only storage type family standalone
+			// mode permits.
+			"StorageType": "posixv2",
+			// The embedded issuer is the only issuer a standalone origin can
+			// have; the default (oa4mp) is a separate Java service that a
+			// federation-less deployment has no way to reach.
+			"EnableIssuer": true,
+			"IssuerMode":   "embedded",
+			"DbLocation":   filepath.Join(configDir, "origin.sqlite"),
+			"RunLocation":  filepath.Join(runtimeDir, "origin"),
+			"Exports": []map[string]any{{
+				"StoragePrefix":    storageDir,
+				"FederationPrefix": standaloneCliPrefix,
+				// No PublicReads: every operation below, including the read,
+				// has to carry a token minted by this origin's own issuer.
+				"Capabilities": []string{"Reads", "Writes", "Listings"},
+			}},
+		},
+	}
+
+	contents, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+	configPath := filepath.Join(configDir, "pelican.yaml")
+	require.NoError(t, os.WriteFile(configPath, contents, 0644))
+	return configPath
+}
+
+// clientTrusting returns an HTTP client that verifies certificates against the
+// CA at caPath -- the one Pelican generated for this origin.
+func clientTrusting(t *testing.T, caPath string) *http.Client {
+	t.Helper()
+
+	pem, err := os.ReadFile(caPath)
+	require.NoError(t, err, "could not read the origin's CA certificate")
+	pool := x509.NewCertPool()
+	require.True(t, pool.AppendCertsFromPEM(pem), "no certificate found in %s", caPath)
+
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: pool},
+		},
+	}
+}
+
+// runClient invokes the pelican CLI as a separate process with a clean
+// environment.  It returns the combined output and the command's error so that
+// callers can assert on failure as readily as on success.
+func runClient(t *testing.T, ctx context.Context, cliPath, clientConfigDir, caPath string, args ...string) (string, error) {
+	t.Helper()
+	return runClientWithEnv(t, ctx, cliPath, clientConfigDir, caPath, nil, args...)
+}
+
+// runClientWithEnv is runClient with additional environment variables, for the
+// cases that turn on what the client can discover for itself rather than on
+// what it was handed on the command line.
+func runClientWithEnv(t *testing.T, ctx context.Context, cliPath, clientConfigDir, caPath string, extraEnv []string, args ...string) (string, error) {
+	t.Helper()
+
+	cmd := exec.CommandContext(ctx, cliPath, args...)
+	cmd.Env = pelicanEnv(append([]string{
+		// The origin's certificate is signed by a CA that exists only in the
+		// origin's config directory, so point the client at it rather than
+		// having it skip verification -- which would stop these tests noticing
+		// a certificate that does not match what discovery advertises.
+		"PELICAN_SERVER_TLSCACERTIFICATEFILE=" + caPath,
+		// Keep the client's token cache and config out of the developer's
+		// real ~/.config/pelican.
+		"PELICAN_CONFIGBASE=" + clientConfigDir,
+		"PELICAN_LOGGING_LEVEL=debug",
+		"PELICAN_LOGGING_CLIENT_DISABLEPROGRESSBARS=true",
+	}, extraEnv...)...)
+	out, err := cmd.CombinedOutput()
+	t.Logf("$ pelican %s\n%s", strings.Join(args, " "), string(out))
+	return string(out), err
+}
+
+// createToken drives `pelican token create` in its own process and writes the
+// resulting JWT to a file, which is the form `object get/put/ls -t` expects.
+//
+// tokenDir must outlive every command that will use the token: the CLI reads
+// the file lazily, at transfer time, so a token written into a subtest's
+// t.TempDir() is deleted out from under a later subtest.
+func createToken(t *testing.T, ctx context.Context, cliPath, clientConfigDir, tokenDir, name string, origin *standaloneOriginProcess, extraArgs ...string) string {
+	t.Helper()
+
+	args := append([]string{
+		"token", "create",
+		"--private-key", origin.issuerKeyPath,
+		"--lifetime", "600",
+	}, extraArgs...)
+	out, err := runClient(t, ctx, cliPath, clientConfigDir, origin.caPath, args...)
+	require.NoError(t, err, "pelican token create failed: %s", out)
+
+	// The JWT is the last non-empty line; anything before it is log output.
+	var tok string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.Count(line, ".") == 2 && strings.HasPrefix(line, "ey") {
+			tok = line
+		}
+	}
+	require.NotEmpty(t, tok, "could not find a JWT in `pelican token create` output: %s", out)
+
+	tokenPath := filepath.Join(tokenDir, name)
+	require.NoError(t, os.WriteFile(tokenPath, []byte(tok), 0600))
+	return tokenPath
+}
+
+// TestStandaloneOriginCliEndToEnd runs a standalone origin as its own OS
+// process and drives it entirely with the pelican client binary run as further
+// OS processes.
+func TestStandaloneOriginCliEndToEnd(t *testing.T) {
+	cliPath := getPelicanBinary(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	origin := startStandaloneOrigin(t, ctx, cliPath)
+	clientConfigDir := t.TempDir()
+	tokenDir := t.TempDir()
+
+	pelicanUrl := func(objectPath string) string {
+		return "pelican://" + strings.TrimPrefix(origin.webUrl, "https://") + standaloneCliPrefix + objectPath
+	}
+
+	// The origin is up without a federation.  Reaching this point already proves
+	// discovery was skipped; the discovery document it serves shows what it put
+	// in the federation's place.
+	t.Run("serves-its-own-federation-metadata", func(t *testing.T) {
+		resp, err := origin.client.Get(origin.webUrl + "/.well-known/pelican-configuration")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var fed struct {
+			DiscoveryEndpoint string `json:"discovery_endpoint"`
+			DirectorEndpoint  string `json:"director_endpoint"`
+			RegistryEndpoint  string `json:"namespace_registration_endpoint"`
+			BrokerEndpoint    string `json:"broker_endpoint"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&fed))
+		assert.Equal(t, origin.webUrl, fed.DiscoveryEndpoint)
+		assert.Empty(t, fed.DirectorEndpoint,
+			"naming no director is what tells a client to resolve objects against this origin directly")
+		assert.Empty(t, fed.RegistryEndpoint, "there is no registry to register with")
+		assert.Empty(t, fed.BrokerEndpoint, "there is no broker to reverse-connect through")
+	})
+
+	// The whole client workflow follows, one OS process per step, with the token
+	// obtained from the CLI rather than minted inside the test.
+	var readWriteToken string
+	t.Run("cli-token-create-against-the-origins-own-issuer", func(t *testing.T) {
+		// No --issuer: the CLI has to discover it, which means asking this
+		// origin about the object and finding the per-namespace
+		// issuer in the X-Pelican-Authorization header, then matching the
+		// signing key against that issuer's published JWKS.  That whole chain
+		// is served by the standalone origin itself.
+		readWriteToken = createToken(t, ctx, cliPath, clientConfigDir, tokenDir, "read-write", origin,
+			"--read", "--write", "--modify", pelicanUrl("/roundtrip.txt"))
+	})
+	require.NotEmpty(t, readWriteToken, "the transfer subtests below need a token from the CLI")
+
+	// A payload large enough that a truncated or re-encoded transfer shows up
+	// as a byte difference rather than passing by luck.
+	payload := make([]byte, 1<<20)
+	_, err := rand.Read(payload)
+	require.NoError(t, err)
+	sourcePath := filepath.Join(t.TempDir(), "roundtrip.txt")
+	require.NoError(t, os.WriteFile(sourcePath, payload, 0644))
+
+	t.Run("cli-put-then-get-round-trip", func(t *testing.T) {
+		out, err := runClient(t, ctx, cliPath, clientConfigDir, origin.caPath,
+			"object", "put", "-t", readWriteToken, sourcePath, pelicanUrl("/roundtrip.txt"))
+		require.NoError(t, err, "object put failed: %s", out)
+
+		// The origin's backing store is a plain directory, so the upload is
+		// observable on disk independently of anything the client reports.
+		onDisk, err := os.ReadFile(filepath.Join(origin.storageDir, "roundtrip.txt"))
+		require.NoError(t, err)
+		require.Equal(t, payload, onDisk, "bytes on the origin's disk differ from the uploaded file")
+
+		downloadPath := filepath.Join(t.TempDir(), "roundtrip.txt")
+		out, err = runClient(t, ctx, cliPath, clientConfigDir, origin.caPath,
+			"object", "get", "-t", readWriteToken, pelicanUrl("/roundtrip.txt"), downloadPath)
+		require.NoError(t, err, "object get failed: %s", out)
+
+		downloaded, err := os.ReadFile(downloadPath)
+		require.NoError(t, err)
+		require.Equal(t, payload, downloaded, "downloaded bytes differ from the uploaded file")
+	})
+
+	// Everything above hands the client its credential with -t, which lets it
+	// skip straight to the transfer.  Here it is given nothing: to read the
+	// object it has to resolve `pelican://<origin>/...` against a federation
+	// that publishes no director, learn from the origin's own reply that the
+	// namespace requires a token, and then find a credential for that issuer
+	// itself -- the whole directorless path, across a process boundary.
+	t.Run("cli-get-finds-its-own-token", func(t *testing.T) {
+		// Nothing to find yet: the read must fail, or the success below would
+		// prove nothing about credential discovery.
+		emptyEnv := filepath.Join(t.TempDir(), "no-token-here")
+		downloadPath := filepath.Join(t.TempDir(), "discovered.txt")
+		out, err := runClientWithEnv(t, ctx, cliPath, clientConfigDir, origin.caPath,
+			[]string{"BEARER_TOKEN_FILE=" + emptyEnv},
+			"object", "get", pelicanUrl("/roundtrip.txt"), downloadPath)
+		require.Error(t, err, "a read with no discoverable credential must fail: %s", out)
+		require.NoFileExists(t, downloadPath)
+
+		// The same command, with a credential where WLCG Bearer Token
+		// Discovery looks for one and still no -t on the command line.
+		out, err = runClientWithEnv(t, ctx, cliPath, clientConfigDir, origin.caPath,
+			[]string{"BEARER_TOKEN_FILE=" + readWriteToken},
+			"object", "get", pelicanUrl("/roundtrip.txt"), downloadPath)
+		require.NoError(t, err, "object get without -t failed: %s", out)
+
+		downloaded, err := os.ReadFile(downloadPath)
+		require.NoError(t, err)
+		require.Equal(t, payload, downloaded, "downloaded bytes differ from the uploaded file")
+	})
+
+	// A listing has the same second chance a download does: it PROPFINDs, is
+	// refused, reads the issuer off the refusal, and asks again.  Nothing is
+	// handed to it on the command line.
+	t.Run("cli-ls-finds-its-own-token", func(t *testing.T) {
+		listToken := createToken(t, ctx, cliPath, clientConfigDir, tokenDir, "list-discovered", origin,
+			"--read", pelicanUrl(""))
+
+		out, err := runClientWithEnv(t, ctx, cliPath, clientConfigDir, origin.caPath,
+			[]string{"BEARER_TOKEN_FILE=" + filepath.Join(t.TempDir(), "no-token-here")},
+			"object", "ls", pelicanUrl(""))
+		require.Error(t, err, "a listing with no discoverable credential must fail: %s", out)
+
+		out, err = runClientWithEnv(t, ctx, cliPath, clientConfigDir, origin.caPath,
+			[]string{"BEARER_TOKEN_FILE=" + listToken},
+			"object", "ls", pelicanUrl(""))
+		require.NoError(t, err, "object ls without -t failed: %s", out)
+		assert.Contains(t, out, "roundtrip.txt")
+	})
+
+	t.Run("cli-ls-lists-the-object", func(t *testing.T) {
+		// A listing reads the collection, not the object, so it needs a token
+		// whose scope covers the namespace root. Asking `token create` for the
+		// bare prefix produces exactly that -- which is also a check that the
+		// CLI strips the federation prefix correctly when the URL *is* the
+		// prefix, the edge case where a naive TrimPrefix yields an empty path.
+		listToken := createToken(t, ctx, cliPath, clientConfigDir, tokenDir, "list", origin,
+			"--read", pelicanUrl(""))
+
+		out, err := runClient(t, ctx, cliPath, clientConfigDir, origin.caPath,
+			"object", "ls", "-t", listToken, pelicanUrl(""))
+		require.NoError(t, err, "object ls failed: %s", out)
+		assert.Contains(t, out, "roundtrip.txt")
+	})
+
+	// Standalone mode removes the federation, not authorization.
+	t.Run("cli-put-without-a-token-is-rejected", func(t *testing.T) {
+		out, err := runClient(t, ctx, cliPath, clientConfigDir, origin.caPath,
+			"object", "put", sourcePath, pelicanUrl("/no-token.txt"))
+		require.Error(t, err, "object put with no token unexpectedly succeeded: %s", out)
+		// Check *why* it failed, so this cannot pass because of a typo in the
+		// URL or an unreachable origin.
+		assert.Contains(t, strings.ToLower(out), "authorization",
+			"expected an authorization failure, not some other error")
+		assert.NoFileExists(t, filepath.Join(origin.storageDir, "no-token.txt"))
+	})
+
+	t.Run("cli-put-with-a-token-for-another-path-is-rejected", func(t *testing.T) {
+		// Same issuer, same signing key, valid signature -- only the scope
+		// path is wrong.  This distinguishes "the origin checks scopes" from
+		// "the origin checks that a token exists".
+		wrongScopeToken := createToken(t, ctx, cliPath, clientConfigDir, tokenDir, "wrong-scope", origin,
+			"--write", "--modify", "--scope-path", "/somewhere-else", pelicanUrl("/wrong-scope.txt"))
+
+		out, err := runClient(t, ctx, cliPath, clientConfigDir, origin.caPath,
+			"object", "put", "-t", wrongScopeToken, sourcePath, pelicanUrl("/wrong-scope.txt"))
+		require.Error(t, err, "object put with a mis-scoped token unexpectedly succeeded: %s", out)
+		// 403 rather than 401: the origin accepted the token as authentic and
+		// then refused the scope, which is the distinction being tested.
+		assert.Contains(t, out, "403", "expected the origin to reject the token's scope with a 403")
+		assert.NoFileExists(t, filepath.Join(origin.storageDir, "wrong-scope.txt"))
+	})
+
+	// Nothing in the origin process ever talked to a federation service.  The
+	// health report is the origin's own record of which subsystems ran, and
+	// reading it over the wire from a separate process means it describes this
+	// server and only this server.
+	t.Run("health-report-has-no-federation-components", func(t *testing.T) {
+		resp, err := origin.client.Get(origin.webUrl + "/api/v1.0/metrics/health")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var health struct {
+			Components map[string]struct {
+				Status string `json:"status"`
+			} `json:"components"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&health))
+
+		// Sanity check that the report is populated at all, so that the
+		// absences below mean something.
+		require.NotEmpty(t, health.Components, "health report carried no components at all")
+
+		// Each of these is recorded only by code that advertises to a director,
+		// registers at a registry, or runs a director-initiated file transfer
+		// test.  Their absence is the evidence that none of that code ran.
+		for _, component := range []string{"director", "registry", "federation"} {
+			assert.NotContains(t, health.Components, component,
+				"a standalone origin must never record the %q health component", component)
+		}
+	})
+}
+
+// TestStandaloneOriginCliFederatedControl is the negative control for
+// TestStandaloneOriginCliEndToEnd: the identical configuration with
+// Origin.EnableStandaloneMode turned off must fail to start, because it has no
+// Federation.DiscoveryUrl and there is no federation for it to find.
+//
+// Without this, "the standalone origin started" would be a weak claim -- it
+// would be consistent with an origin that tolerates a missing federation for
+// reasons having nothing to do with the feature under test.
+func TestStandaloneOriginCliFederatedControl(t *testing.T) {
+	cliPath := getPelicanBinary(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	root := t.TempDir()
+	configDir := filepath.Join(root, "config")
+	runtimeDir := filepath.Join(root, "runtime")
+	storageDir := filepath.Join(root, "storage")
+	issuerKeysDir := filepath.Join(configDir, "issuer-keys")
+	for _, dir := range []string{configDir, runtimeDir, storageDir, issuerKeysDir} {
+		require.NoError(t, os.MkdirAll(dir, 0755))
+	}
+	configPath := writeStandaloneConfig(t, configDir, runtimeDir, storageDir, issuerKeysDir, false)
+
+	cmd := exec.CommandContext(ctx, cliPath, "origin", "serve", "--config", configPath)
+	cmd.Env = pelicanEnv()
+
+	var output bytes.Buffer
+	var outputMu sync.Mutex
+	cmd.Stdout = &lockedWriter{w: &output, mu: &outputMu}
+	cmd.Stderr = cmd.Stdout
+	require.NoError(t, cmd.Start())
+
+	exited := make(chan error, 1)
+	go func() { exited <- cmd.Wait() }()
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	})
+
+	select {
+	case err := <-exited:
+		outputMu.Lock()
+		defer outputMu.Unlock()
+		require.Error(t, err, "a federated origin with no discovery URL must not start; output:\n%s", output.String())
+		assert.Contains(t, strings.ToLower(output.String()), strings.ToLower(param.Federation_DiscoveryUrl.GetName()),
+			"expected the startup failure to name the missing federation configuration; output:\n%s", output.String())
+	case <-time.After(120 * time.Second):
+		outputMu.Lock()
+		defer outputMu.Unlock()
+		t.Fatalf("federated origin with no discovery URL neither started nor exited; output:\n%s", output.String())
+	}
+}

--- a/launcher_utils/key_refresh_and_update_namespace_pubkey.go
+++ b/launcher_utils/key_refresh_and_update_namespace_pubkey.go
@@ -131,8 +131,10 @@ func LaunchIssuerKeysDirRefresh(ctx context.Context, egrp *errgroup.Group, modul
 			}
 
 			if keysChanged {
-				// Update public key registered with namespace in registry db when the private key(s) changed in an origin
-				if modules.IsEnabled(server_structs.OriginType) {
+				// Update public key registered with namespace in registry db when the private key(s) changed in an origin.
+				// A standalone origin never registered its namespaces anywhere, so
+				// there is no registry copy of the public key to keep in sync.
+				if modules.IsEnabled(server_structs.OriginType) && !config.IsStandaloneOrigin() {
 					if err = triggerNamespacesPubKeyUpdate(ctx); err != nil {
 						return err
 					}

--- a/launchers/launcher.go
+++ b/launchers/launcher.go
@@ -185,7 +185,11 @@ func LaunchModules(ctx context.Context, modules server_structs.ServerType) (serv
 			return
 		}
 		servers = append(servers, server)
-		serversRequireAdvertisement = append(serversRequireAdvertisement, server)
+		// Standalone origins aren't part of any federation, so there is no
+		// director to advertise to.
+		if !config.IsStandaloneOrigin() {
+			serversRequireAdvertisement = append(serversRequireAdvertisement, server)
+		}
 
 		var originExports []server_utils.OriginExport
 		originExports, err = server_utils.GetOriginExports()
@@ -267,8 +271,12 @@ func LaunchModules(ctx context.Context, modules server_structs.ServerType) (serv
 
 	// Launch director discovery.  This is done after the director modules are done
 	// (since they may provide some of the response information) and before the origin/cache
-	// are started (since we may forward ads based on discovered directors)
-	if err = server_utils.LaunchPeriodicDirectorDiscovery(ctx, modules.IsEnabled(server_structs.DirectorType)); err != nil {
+	// are started (since we may forward ads based on discovered directors).
+	// A standalone origin advertises to nobody, so it has no reason to go looking
+	// for directors in the first place.
+	if config.IsStandaloneOrigin() {
+		log.Debugf("Skipping director discovery because %s is enabled", param.Origin_EnableStandaloneMode.GetName())
+	} else if err = server_utils.LaunchPeriodicDirectorDiscovery(ctx, modules.IsEnabled(server_structs.DirectorType)); err != nil {
 		return
 	}
 	if modules.IsEnabled(server_structs.DirectorType) {
@@ -323,7 +331,7 @@ func LaunchModules(ctx context.Context, modules server_structs.ServerType) (serv
 	}
 
 	// Launch the broker listener.  Needs the federation information to determine the broker endpoint.
-	if fedInfo.BrokerEndpoint != "" {
+	if fedInfo.BrokerEndpoint != "" && !config.IsStandaloneOrigin() {
 		if modules.IsEnabled(server_structs.OriginType) && param.Origin_EnableBroker.GetBool() {
 			if err = origin.LaunchBrokerListener(ctx, egrp, engine); err != nil {
 				return
@@ -453,7 +461,10 @@ func LaunchModules(ctx context.Context, modules server_structs.ServerType) (serv
 
 	// Launch periodic advertise BEFORE broker listener because the broker listener
 	// needs server metadata which is populated during the first advertisement.
-	if modules.IsEnabled(server_structs.OriginType) || modules.IsEnabled(server_structs.CacheType) && len(serversRequireAdvertisement) > 0 {
+	// The length check must gate the whole branch: a standalone origin (or a
+	// site-local cache) leaves the slice empty, and advertising an empty slice
+	// would still report a bogus "federation: OK" health component.
+	if len(serversRequireAdvertisement) > 0 {
 		log.Debug("Launching periodic advertise of origin/cache server to the director")
 		if err = launcher_utils.LaunchPeriodicAdvertise(ctx, egrp, serversRequireAdvertisement); err != nil {
 			return
@@ -569,7 +580,11 @@ func handleGracefulShutdown(ctx context.Context, modules server_structs.ServerTy
 		metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusShuttingDown, "The server is shutting down")
 		// When the server is up again, the ShuttingDown status will be cleared
 
-		if advErr := launcher_utils.Advertise(ctx, servers); advErr != nil {
+		// The final "I'm going away" ad only makes sense for servers a director
+		// knows about; a standalone origin has never advertised at all.
+		if config.IsStandaloneOrigin() {
+			log.Debug("Skipping shutdown advertisement because the origin is running in standalone mode")
+		} else if advErr := launcher_utils.Advertise(ctx, servers); advErr != nil {
 			log.Errorf("Failed to advertise before shutdown: %v", advErr)
 		}
 		time.Sleep(param.Xrootd_ShutdownTimeout.GetDuration())

--- a/launchers/origin_serve.go
+++ b/launchers/origin_serve.go
@@ -81,6 +81,16 @@ func OriginServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, 
 	// Determine if we should use XRootD or native HTTP server
 	useXRootD := originUsesXRootD()
 
+	// A standalone origin never contacts a director or registry; every federation
+	// touchpoint below is skipped.  config.InitServer has already rejected the
+	// configurations where this mode cannot work (XRootD backends, co-located
+	// federation modules, DisableDirectClients).
+	standalone := config.IsStandaloneOrigin()
+	if standalone {
+		log.Infof("Origin is running in standalone mode (%s); it will not register at a registry or advertise to a director",
+			param.Origin_EnableStandaloneMode.GetName())
+	}
+
 	if useXRootD {
 		metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusWarning, "XRootD is initializing")
 		metrics.SetComponentHealthStatus(metrics.OriginCache_CMSD, metrics.StatusWarning, "CMSD is initializing")
@@ -137,10 +147,17 @@ func OriginServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, 
 	// Register Origin APIs
 	baseAPIGroup := engine.Group("/api/v1.0")
 
-	// Set up the APIs unrelated to UI, which only contains director-based health test reporting endpoint for now
-	originAPIGroup := baseAPIGroup.Group("", web_ui.ServerHeaderMiddleware)
-	if err = origin.RegisterOriginAPI(originAPIGroup, ctx, egrp); err != nil {
-		return nil, err
+	// Set up the APIs unrelated to UI, which only contains director-based health test reporting endpoint for now.
+	// A standalone origin has no director to report to, so the endpoint (and the
+	// timeout watchdog behind it, which would otherwise flip the origin's health
+	// status to critical) is skipped entirely.
+	if !standalone {
+		originAPIGroup := baseAPIGroup.Group("", web_ui.ServerHeaderMiddleware)
+		if err = origin.RegisterOriginAPI(originAPIGroup, ctx, egrp); err != nil {
+			return nil, err
+		}
+	} else {
+		log.Debugf("Skipping origin director-test API registration because %s is enabled", param.Origin_EnableStandaloneMode.GetName())
 	}
 
 	// Set up the APIs for the origin UI
@@ -247,8 +264,11 @@ func OriginServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, 
 	}
 	// POSIXv2-specific initialization is deferred to OriginServeFinish()
 
-	// Launch origin file test maintenance (not XRootD specific)
-	origin.LaunchOriginFileTestMaintenance(ctx)
+	// Launch origin file test maintenance (not XRootD specific). It only cleans up
+	// after director- and self-tests, neither of which runs in standalone mode.
+	if !standalone {
+		origin.LaunchOriginFileTestMaintenance(ctx)
+	}
 	origin.LaunchDiskUsageCalculator(ctx, egrp)
 
 	return originServer, nil
@@ -318,6 +338,9 @@ func OriginServeFinish(ctx context.Context, egrp *errgroup.Group, engine *gin.En
 			origin_serve.LaunchGlobusv2TokenRefresh(ctx, egrp)
 		}
 
+		// A standalone origin has no director sharing this web server, so its
+		// exports stay mounted at their federation prefix -- an object is served
+		// from the URL a client already knows, with nothing to redirect through.
 		directorEnabled := modules.IsEnabled(server_structs.DirectorType)
 		if err := origin_serve.RegisterHandlers(engine, directorEnabled); err != nil {
 			return errors.Wrap(err, "failed to register origin_serve handlers")
@@ -339,18 +362,43 @@ func OriginServeFinish(ctx context.Context, egrp *errgroup.Group, engine *gin.En
 		return errors.Wrap(err, "failed to register transfer API on origin")
 	}
 
-	metrics.SetComponentHealthStatus(metrics.OriginCache_Registry, metrics.StatusWarning, "Start to register namespaces for the origin server")
-	log.Debug("Register Origin")
-	extUrlStr := param.Server_ExternalWebUrl.GetString()
-	extUrl, _ := url.Parse(extUrlStr)
-	// Only use hostname:port
-	if err := launcher_utils.RegisterNamespaceWithRetry(ctx, egrp, server_structs.GetOriginNs(extUrl.Host)); err != nil {
-		return err
-	}
-	log.Debug("Origin is registered")
-	for _, export := range originExports {
-		if err := launcher_utils.RegisterNamespaceWithRetry(ctx, egrp, export.FederationPrefix); err != nil {
+	// A standalone origin owns its namespaces outright: there is no registry to
+	// claim them at, and no director that would need the registration to route
+	// clients here.  Skipping this also keeps the "registry" component out of the
+	// health status the web UI renders.
+	if config.IsStandaloneOrigin() {
+		log.Debugf("Skipping Origin registration because standalone mode is enabled (see %s)", param.Origin_EnableStandaloneMode.GetName())
+		// The local metadata record is normally written as a side effect of
+		// advertising. Write it here so the web UI can still show a server name
+		// (and downtime records still carry one) without a director in the loop.
+		metadata, err := server_utils.GetServerMetadata(ctx, server_structs.OriginType)
+		if err != nil {
+			return errors.Wrap(err, "failed to determine the standalone origin's server name")
+		}
+		if err := database.UpsertServerLocalMetadata(metadata); err != nil {
+			return errors.Wrapf(err, "failed to record server name %s in the local database", metadata.Name)
+		}
+		// A pelican:// URL names a federation, so the client still begins by
+		// asking this origin what services the federation has.  It answers with
+		// a document naming no director, which is what tells the client to
+		// resolve objects against this origin directly.
+		if err := origin.RegisterStandaloneFederationMetadata(engine); err != nil {
+			return errors.Wrap(err, "failed to register the standalone origin's federation metadata")
+		}
+	} else {
+		metrics.SetComponentHealthStatus(metrics.OriginCache_Registry, metrics.StatusWarning, "Start to register namespaces for the origin server")
+		log.Debug("Register Origin")
+		extUrlStr := param.Server_ExternalWebUrl.GetString()
+		extUrl, _ := url.Parse(extUrlStr)
+		// Only use hostname:port
+		if err := launcher_utils.RegisterNamespaceWithRetry(ctx, egrp, server_structs.GetOriginNs(extUrl.Host)); err != nil {
 			return err
+		}
+		log.Debug("Origin is registered")
+		for _, export := range originExports {
+			if err := launcher_utils.RegisterNamespaceWithRetry(ctx, egrp, export.FederationPrefix); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/origin/advertise.go
+++ b/origin/advertise.go
@@ -107,6 +107,7 @@ func (server *OriginServer) CreateAdvertisement(name, id, originUrlStr, originWe
 		return nil, err
 	}
 
+	advertisedExports := make([]server_utils.OriginExport, 0, len(originExports))
 	for _, export := range originExports {
 		if isGlobusBackend {
 			// Do not include the export if it's an inactive Globus collection
@@ -115,50 +116,14 @@ func (server *OriginServer) CreateAdvertisement(name, id, originUrlStr, originWe
 				continue
 			}
 		}
-		// PublicReads implies reads
-		reads := export.Capabilities.PublicReads || export.Capabilities.Reads
+		advertisedExports = append(advertisedExports, export)
+	}
 
-		// Set up issuer URLs for the namespace. Note that this uses a single
-		// base path (the fed prefix) per issuer per export even if a single issuer
-		// at the origin is configured for multiple prefixes. This is because we have
-		// no global concept of issuers at the Director and we store this issuer info
-		// per namespace. It doesn't currently make much sense to construct the full list
-		// of potential base paths in this context.
-		issuerUrls := make([]server_structs.TokenIssuer, len(export.IssuerUrls))
-		for i, issUrlStr := range export.IssuerUrls {
-			issUrl, err := url.Parse(issUrlStr)
-			if err != nil {
-				return nil, errors.Wrap(err, "unable to parse issuer url")
-			}
-			issuerUrls[i] = server_structs.TokenIssuer{
-				IssuerUrl: *issUrl,
-				BasePaths: []string{export.FederationPrefix},
-			}
-		}
-
-		// Populate the struct for the namespace's "token generation" field
-		// TODO: It's not clear what the intended difference/abstraction between the
-		// "Generation" and the "Issuer" fields is... We should define these eventually
-		var tokGen server_structs.TokenGen
-		if len(issuerUrls) > 0 {
-			tokGen.Strategy = server_structs.OAuthStrategy
-			tokGen.MaxScopeDepth = 3
-			tokGen.CredentialIssuer = issuerUrls[0].IssuerUrl
-		}
-
-		nsAds = append(nsAds, server_structs.NamespaceAd{
-			Caps: server_structs.Capabilities{
-				PublicReads: export.Capabilities.PublicReads,
-				Reads:       reads,
-				Writes:      export.Capabilities.Writes,
-				Listings:    export.Capabilities.Listings,
-				DirectReads: export.Capabilities.DirectReads,
-				Copies:      export.Capabilities.Copies,
-			},
-			Path:       export.FederationPrefix,
-			Generation: []server_structs.TokenGen{tokGen},
-			Issuer:     issuerUrls,
-		})
+	nsAds, err = server_utils.NamespaceAdsFromExports(advertisedExports)
+	if err != nil {
+		return nil, err
+	}
+	for _, export := range advertisedExports {
 		prefixes = append(prefixes, export.FederationPrefix)
 	}
 
@@ -190,7 +155,7 @@ func (server *OriginServer) CreateAdvertisement(name, id, originUrlStr, originWe
 		ost == server_structs.OriginStorageS3v2 || ost == server_structs.OriginStorageHTTPSv2 ||
 		ost == server_structs.OriginStorageGlobusv2) && config.IsServerEnabled(server_structs.DirectorType) {
 		if parsedUrl, err := url.Parse(originUrlStr); err == nil {
-			parsedUrl.Path = "/api/v1.0/origin/data"
+			parsedUrl.Path = server_structs.OriginDataRoutePrefix
 			dataUrlToAdvertise = parsedUrl.String()
 		}
 	}

--- a/origin/disk_usage.go
+++ b/origin/disk_usage.go
@@ -24,6 +24,7 @@ import (
 	"io/fs"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -33,6 +34,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/webdav"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
 
@@ -40,6 +42,7 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/database"
 	"github.com/pelicanplatform/pelican/metrics"
+	"github.com/pelicanplatform/pelican/origin_serve"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/server_utils"
@@ -243,6 +246,72 @@ func calculateDiskUsagePelican(ctx context.Context, export server_utils.OriginEx
 	return totalBytes, totalCount, err
 }
 
+// calculateDiskUsageBackend measures an export by walking the storage backend
+// this process already serves it from, with no network involved.
+//
+// The native "v2" backends are served here, in-process, so their bytes are
+// reachable directly.  Measuring them by pointing the Pelican client at the
+// origin's own namespace -- as calculateDiskUsagePelican does -- means asking a
+// director where to find data this process is itself serving and reading it back
+// over HTTP.  That needs a federation, a credential, and an initialized client;
+// nothing on a serve path calls config.InitClient, so outside a test harness
+// that had called it the crawl could not build a transfer engine at all.
+func calculateDiskUsageBackend(ctx context.Context, export server_utils.OriginExport, fs webdav.FileSystem, limiter *rate.Limiter) (uint64, uint64, error) {
+	var totalBytes, totalCount uint64
+
+	// Paths are relative to the export, matching what the WebDAV handler passes
+	// this filesystem; "/" is the export root.
+	var walk func(dir string) error
+	walk = func(dir string) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		if limiter != nil {
+			if err := limiter.Wait(ctx); err != nil {
+				return err
+			}
+		}
+
+		f, err := fs.OpenFile(ctx, dir, os.O_RDONLY, 0)
+		if err != nil {
+			return errors.Wrapf(err, "failed to open %s", dir)
+		}
+		entries, err := f.Readdir(-1)
+		if closeErr := f.Close(); closeErr != nil {
+			log.Debugf("Error closing %s after listing: %v", dir, closeErr)
+		}
+		if err != nil {
+			return errors.Wrapf(err, "failed to list %s", dir)
+		}
+
+		for _, entry := range entries {
+			child := path.Join(dir, entry.Name())
+			if entry.IsDir() {
+				// A failed subtree is reported and skipped: one unreadable
+				// directory should not discard the whole total.
+				if err := walk(child); err != nil {
+					if ctx.Err() != nil {
+						return err
+					}
+					PelicanOriginDiskUsageCrawlErrors.WithLabelValues(export.FederationPrefix).Inc()
+					log.Warnf("Error accessing %s: %v", child, err)
+				}
+				continue
+			}
+			totalBytes += uint64(entry.Size())
+			totalCount++
+		}
+		return nil
+	}
+
+	if err := walk("/"); err != nil {
+		return totalBytes, totalCount, err
+	}
+	return totalBytes, totalCount, nil
+}
+
 // calculateDiskUsageForExport calculates disk usage for a single export
 func calculateDiskUsageForExport(ctx context.Context, export server_utils.OriginExport, limiter *rate.Limiter, tokenPath string, forcePelican bool) (diskUsageResult, error) {
 	result := diskUsageResult{
@@ -251,6 +320,22 @@ func calculateDiskUsageForExport(ctx context.Context, export server_utils.Origin
 
 	storageType := param.Origin_StorageType.GetString()
 	if forcePelican || !usesLocalDiskUsageWalk(storageType) {
+		// Prefer the backend this process is already serving the export from.
+		// Only the XRootD-fronted backends (posix, s3, https, globus, xroot)
+		// have none -- XRootD holds their storage -- and those fall back to
+		// crawling the federation.  Standalone mode permits only the native
+		// backends, so it never needs the fallback.
+		if backend := origin_serve.BackendForPrefix(export.FederationPrefix); backend != nil && backend.FileSystem() != nil {
+			log.Debugf("Walking the %s backend directly for disk usage of %s", storageType, export.FederationPrefix)
+			bytes, count, err := calculateDiskUsageBackend(ctx, export, backend.FileSystem(), limiter)
+			if err != nil {
+				return result, errors.Wrapf(err, "failed to calculate disk usage for %s", export.FederationPrefix)
+			}
+			result.bytes = bytes
+			result.count = count
+			return result, nil
+		}
+
 		log.Debugf("Using PelicanFS for disk usage calculation of backend %s", storageType)
 		bytes, count, err := calculateDiskUsagePelican(ctx, export, limiter, tokenPath)
 		if err != nil {

--- a/origin/disk_usage.go
+++ b/origin/disk_usage.go
@@ -166,11 +166,30 @@ func calculateDiskUsagePOSIX(ctx context.Context, storagePath string, limiter *r
 	return totalBytes, totalCount, err
 }
 
+// usesLocalDiskUsageWalk reports whether the export's data lives on a locally
+// mounted filesystem, so disk usage can be measured with a plain directory walk
+// (or the Ceph xattr fast path) instead of crawling the export through the
+// federation. Both POSIX-like backends qualify: "posixv2" is served in-process
+// but its StoragePrefix is still an ordinary local path.
+func usesLocalDiskUsageWalk(storageType string) bool {
+	return server_structs.OriginStorageType(storageType).IsPosixLike()
+}
+
 // calculateDiskUsagePelican calculates disk usage using the Pelican client FS interface
 // This is used for non-POSIX backends (e.g. XRootD, S3, etc.) where we can't walk the local filesystem
 func calculateDiskUsagePelican(ctx context.Context, export server_utils.OriginExport, limiter *rate.Limiter, tokenPath string) (uint64, uint64, error) {
 	var totalBytes uint64
 	var totalCount uint64
+
+	// This path walks the export through the federation (director-routed
+	// pelican:// URLs). A standalone origin has no director to route through, so
+	// there is no way to crawl a remote-protocol backend this way.
+	if config.IsStandaloneOrigin() {
+		return 0, 0, errors.Errorf("disk usage calculation for the %s backend requires a federation to crawl through, "+
+			"which is unavailable when %s is enabled; disable %s to silence this",
+			param.Origin_StorageType.GetString(), param.Origin_EnableStandaloneMode.GetName(),
+			param.Origin_EnableDiskUsageCalculation.GetName())
+	}
 
 	fedInfo, err := config.GetFederation(ctx)
 	if err != nil {
@@ -231,7 +250,7 @@ func calculateDiskUsageForExport(ctx context.Context, export server_utils.Origin
 	}
 
 	storageType := param.Origin_StorageType.GetString()
-	if forcePelican || storageType != string(server_structs.OriginStoragePosix) {
+	if forcePelican || !usesLocalDiskUsageWalk(storageType) {
 		log.Debugf("Using PelicanFS for disk usage calculation of backend %s", storageType)
 		bytes, count, err := calculateDiskUsagePelican(ctx, export, limiter, tokenPath)
 		if err != nil {
@@ -286,7 +305,7 @@ func CalculateDiskUsage(ctx context.Context, forcePelican bool) error {
 
 	// Setup disk usage token if needed (for non-POSIX backends or forced PelicanFS)
 	storageType := param.Origin_StorageType.GetString()
-	usePelican := forcePelican || storageType != string(server_structs.OriginStoragePosix)
+	usePelican := forcePelican || !usesLocalDiskUsageWalk(storageType)
 
 	var tokenPath string
 	if usePelican {

--- a/origin/exports.go
+++ b/origin/exports.go
@@ -71,28 +71,34 @@ func handleExports(ctx *gin.Context) {
 
 	res := exportsRes{Type: string(storageType)}
 
-	extUrlStr := param.Server_ExternalWebUrl.GetString()
-	extUrl, _ := url.Parse(extUrlStr)
-	// Only use hostname:port
-	originPrefix := server_structs.GetOriginNs(extUrl.Host)
-	if !registrationsStatus.Has(originPrefix) {
-		if err := FetchAndSetRegStatus(originPrefix); err != nil {
-			log.Errorf("Failed to fetch registration status from the registry: %v", err)
+	standalone := config.IsStandaloneOrigin()
+	if standalone {
+		res.Status = RegStandalone
+		res.StatusDescription = standaloneStatusDescription
+	} else {
+		extUrlStr := param.Server_ExternalWebUrl.GetString()
+		extUrl, _ := url.Parse(extUrlStr)
+		// Only use hostname:port
+		originPrefix := server_structs.GetOriginNs(extUrl.Host)
+		if !registrationsStatus.Has(originPrefix) {
+			if err := FetchAndSetRegStatus(originPrefix); err != nil {
+				log.Errorf("Failed to fetch registration status from the registry: %v", err)
+				ctx.JSON(http.StatusInternalServerError,
+					server_structs.SimpleApiResp{Status: server_structs.RespFailed, Msg: "Failed to fetch registration status from the registry"})
+				return
+			}
+		}
+		if rs := registrationsStatus.Get(originPrefix); rs == nil {
+			log.Error("Failed to fetch registration status from the registry: can't find registration status after querying registry")
 			ctx.JSON(http.StatusInternalServerError,
 				server_structs.SimpleApiResp{Status: server_structs.RespFailed, Msg: "Failed to fetch registration status from the registry"})
 			return
+		} else {
+			// rs is not nil
+			res.Status = rs.Value().Status
+			res.StatusDescription = rs.Value().Msg
+			res.EditUrl = rs.Value().EditUrl
 		}
-	}
-	if rs := registrationsStatus.Get(originPrefix); rs == nil {
-		log.Error("Failed to fetch registration status from the registry: can't find registration status after querying registry")
-		ctx.JSON(http.StatusInternalServerError,
-			server_structs.SimpleApiResp{Status: server_structs.RespFailed, Msg: "Failed to fetch registration status from the registry"})
-		return
-	} else {
-		// rs is not nil
-		res.Status = rs.Value().Status
-		res.StatusDescription = rs.Value().Msg
-		res.EditUrl = rs.Value().EditUrl
 	}
 
 	exports, err := server_utils.GetOriginExports()
@@ -107,51 +113,54 @@ func handleExports(ctx *gin.Context) {
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{Status: server_structs.RespFailed, Msg: "Server encountered error when getting the registration status for the exported prefixes: " + err.Error()})
 		return
 	}
-	// Create token for accessing registry edit page
-	issuerUrl, err := config.GetServerIssuerURL()
-	if err != nil {
-		log.Errorf("Failed to get server issuer url %v", err)
-		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{Status: server_structs.RespFailed, Msg: "Server encountered error when getting server issuer url " + err.Error()})
-		return
-	}
-	fed, err := config.GetFederation(ctx)
-	if err != nil {
-		log.Error("handleExports: failed to get federaion:", err)
-		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
-			Status: server_structs.RespFailed,
-			Msg:    "Server error when getting federation information: " + err.Error(),
-		})
-		return
-	}
-	tc := token.NewWLCGToken()
-	tc.Issuer = issuerUrl
-	tc.Lifetime = 15 * time.Minute
-	tc.Subject = issuerUrl
-	tc.AddScopes(token_scopes.Registry_EditRegistration)
-	tc.AddAudiences(fed.RegistryEndpoint)
-	token, err := tc.CreateToken()
-	if err != nil {
-		log.Errorf("Failed to create access token for editing registration %v", err)
-		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{Status: server_structs.RespFailed, Msg: "Server encountered error when creating token for access registry edit page " + err.Error()})
-		return
-	}
+	// Create token for accessing registry edit page. A standalone origin has no
+	// registry, hence no edit URLs to decorate and no audience to mint against.
+	if !standalone {
+		issuerUrl, err := config.GetServerIssuerURL()
+		if err != nil {
+			log.Errorf("Failed to get server issuer url %v", err)
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{Status: server_structs.RespFailed, Msg: "Server encountered error when getting server issuer url " + err.Error()})
+			return
+		}
+		fed, err := config.GetFederation(ctx)
+		if err != nil {
+			log.Error("handleExports: failed to get federaion:", err)
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "Server error when getting federation information: " + err.Error(),
+			})
+			return
+		}
+		tc := token.NewWLCGToken()
+		tc.Issuer = issuerUrl
+		tc.Lifetime = 15 * time.Minute
+		tc.Subject = issuerUrl
+		tc.AddScopes(token_scopes.Registry_EditRegistration)
+		tc.AddAudiences(fed.RegistryEndpoint)
+		token, err := tc.CreateToken()
+		if err != nil {
+			log.Errorf("Failed to create access token for editing registration %v", err)
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{Status: server_structs.RespFailed, Msg: "Server encountered error when creating token for access registry edit page " + err.Error()})
+			return
+		}
 
-	if res.EditUrl != "" {
-		res.EditUrl += "&access_token=" + token
-	}
+		if res.EditUrl != "" {
+			res.EditUrl += "&access_token=" + token
+		}
 
-	for idx, export := range wrappedExports {
-		if export.EditUrl != "" {
-			parsed, err := url.Parse(export.EditUrl)
-			if err != nil {
-				// current editUrl ends with "/?id=<x>"
-				wrappedExports[idx].EditUrl += "&access_token=" + token
-				continue
+		for idx, export := range wrappedExports {
+			if export.EditUrl != "" {
+				parsed, err := url.Parse(export.EditUrl)
+				if err != nil {
+					// current editUrl ends with "/?id=<x>"
+					wrappedExports[idx].EditUrl += "&access_token=" + token
+					continue
+				}
+				exQuery := parsed.Query()
+				exQuery.Add("access_token", token)
+				parsed.RawQuery = exQuery.Encode()
+				wrappedExports[idx].EditUrl = parsed.String()
 			}
-			exQuery := parsed.Query()
-			exQuery.Add("access_token", token)
-			parsed.RawQuery = exQuery.Encode()
-			wrappedExports[idx].EditUrl = parsed.String()
 		}
 	}
 

--- a/origin/reg_status.go
+++ b/origin/reg_status.go
@@ -72,6 +72,12 @@ const (
 	RegCompleted          regStatusEnum = "Completed"          // Registration is completed
 	RegIncomplete         regStatusEnum = "Incomplete"         // Registered, but registration is incomplete
 	RegError              regStatusEnum = "Registration Error" // Failed to register
+	// RegStandalone means the origin runs with Origin.EnableStandaloneMode and
+	// deliberately has no registry to register at. The web UI treats this as
+	// "registration is not part of this deployment" rather than as a failure.
+	RegStandalone regStatusEnum = "Standalone"
+
+	standaloneStatusDescription = "This origin runs in standalone mode and is not registered with any federation registry."
 )
 
 func SetNamespacesStatus(key string, val RegistrationStatus, ttl time.Duration) {
@@ -161,6 +167,18 @@ func wrapExportsByStatus(exports []server_utils.OriginExport) ([]exportWithStatu
 	wrappedExports := []exportWithStatus{}
 	fetchQ := []server_utils.OriginExport{}
 	prefixQ := []string{}
+
+	// A standalone origin has no registry to ask, and nothing to complete.
+	if config.IsStandaloneOrigin() {
+		for _, export := range exports {
+			wrappedExports = append(wrappedExports, exportWithStatus{
+				Status:            RegStandalone,
+				StatusDescription: standaloneStatusDescription,
+				OriginExport:      export,
+			})
+		}
+		return wrappedExports, nil
+	}
 
 	for _, export := range exports {
 		if registrationsStatus.Has(export.FederationPrefix) {

--- a/origin/standalone.go
+++ b/origin/standalone.go
@@ -1,0 +1,98 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package origin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/pelican_url"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/web_ui"
+)
+
+// federationDiscoveryPath is where every Pelican client begins: a pelican://
+// URL names a federation by hostname, and the client fetches this document from
+// that host to learn what services the federation has.
+const federationDiscoveryPath = "/.well-known/pelican-configuration"
+
+// RegisterStandaloneFederationMetadata makes a standalone origin
+// (Origin.EnableStandaloneMode) answer the one federation-level question a
+// client asks before it transfers anything.
+//
+// The document names no director.  That absence is the signal: a client that
+// discovers a federation with no director resolves objects against the
+// discovery host itself, reading namespace and issuer metadata from the
+// X-Pelican-* headers the origin returns on the object (see the auth middleware
+// in origin_serve).  Nothing redirects -- the object lives at the URL the client
+// already constructed.
+//
+// It must only be called when config.IsStandaloneOrigin() is true; a federated
+// origin's federation metadata belongs to its director.
+func RegisterStandaloneFederationMetadata(engine *gin.Engine) error {
+	extUrlStr := param.Server_ExternalWebUrl.GetString()
+	extUrl, err := url.Parse(extUrlStr)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse %s while publishing the standalone origin's federation metadata",
+			param.Server_ExternalWebUrl.GetName())
+	}
+	// Rewriting the scheme here would publish an https:// endpoint for a port
+	// that speaks cleartext, and every client that trusted the document would
+	// fail its handshake.  config.ComputeExternalWebUrl already defaults the
+	// scheme to https and strips an explicit :443, so a non-https value can only
+	// come from an operator who set one deliberately.
+	if extUrl.Scheme != "https" {
+		return errors.Errorf("%s must be an https:// URL to publish the standalone origin's federation metadata, but it is %q; "+
+			"clients discover this federation over TLS and have no way to fall back",
+			param.Server_ExternalWebUrl.GetName(), extUrlStr)
+	}
+	self := extUrl.String()
+
+	engine.GET(federationDiscoveryPath, web_ui.ServerHeaderMiddleware, func(ctx *gin.Context) {
+		// Director, registry, and broker endpoints are all deliberately empty:
+		// none of those services exist here, and naming this origin for them
+		// would send clients into a 404 rather than the directorless path they
+		// are meant to take.
+		rs := pelican_url.FederationDiscovery{
+			DiscoveryEndpoint: self,
+			JwksUri:           self + "/.well-known/issuer.jwks",
+		}
+
+		jsonData, err := json.MarshalIndent(rs, "", "  ")
+		if err != nil {
+			ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "Failed to marshal the standalone origin's discovery response",
+			})
+			return
+		}
+		jsonData = append(jsonData, '\n')
+		ctx.Header("Content-Disposition", "attachment; filename=pelican-configuration.json")
+		ctx.Data(http.StatusOK, "application/json", jsonData)
+	})
+
+	log.Infof("Standalone origin is publishing federation metadata at %s%s", self, federationDiscoveryPath)
+	return nil
+}

--- a/origin_serve/authz.go
+++ b/origin_serve/authz.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/server_utils"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
@@ -44,7 +45,12 @@ import (
 
 type (
 	authConfig struct {
-		exports    atomic.Pointer[[]server_utils.OriginExport]
+		exports atomic.Pointer[[]server_utils.OriginExport]
+		// nsAds is exports rendered as namespace ads, derived once per config
+		// change rather than per request: SetTokenHintHeaders runs on every
+		// request a standalone origin serves, and rebuilding the ads there costs
+		// a url.Parse per issuer per request.  Swapped together with exports.
+		nsAds      atomic.Pointer[[]server_structs.NamespaceAd]
 		issuers    atomic.Pointer[map[string]bool]
 		audiences  []string // accepted audience values (origin URL + wildcards)
 		issuerKeys *ttlcache.Cache[string, authConfigItem]
@@ -199,7 +205,16 @@ func (ac *authConfig) updateConfig(exports []server_utils.OriginExport) error {
 			issuers[issuer] = true
 		}
 	}
+	// An export whose issuer URL will not parse cannot produce token hints, but
+	// it can still be authorized against; keep the rest of the config current and
+	// leave the ads empty rather than refusing to serve.
+	nsAds, err := server_utils.NamespaceAdsFromExports(exports)
+	if err != nil {
+		log.Warningf("Unable to derive namespace ads from the origin's exports; token hint headers will be omitted: %v", err)
+		nsAds = nil
+	}
 	ac.issuers.Store(&issuers)
+	ac.nsAds.Store(&nsAds)
 	ac.exports.Store(&exports)
 	return nil
 }
@@ -320,6 +335,42 @@ func (ac *authConfig) getResourceScopes(tokenStr string) (scopes []token_scopes.
 	scopes = token_scopes.ParseResourceScopeString(tok)
 
 	return
+}
+
+// SetTokenHintHeaders writes the director's X-Pelican-{Namespace,Authorization,
+// Token-Generation} headers describing how a caller could obtain a token for
+// resource, or does nothing if no export covers it.
+//
+// A federated origin never needs this: the director already told the client
+// which token to get before redirecting it here.  A standalone origin has no
+// director, so a client asking it for an object directly would otherwise get a
+// bare rejection with no way to discover the issuer.  Emitting the same headers
+// the director would lets the client (see the token-hint retry in
+// client/handle_http.go) acquire the right token and try again, and lets a human
+// with curl see where to authenticate.
+//
+// The hint is advisory: it names the credential this origin recommends, not the
+// only one it will accept.  LongestNSMatch reports the single most specific
+// export covering resource, while getAcls below grants access from every export
+// whose issuer matches the presented token.  With exports nested one inside
+// another under different issuers, a token from the outer export's issuer whose
+// scope reaches the inner path is still honored even though the hint pointed at
+// the inner issuer.  Narrowing that is an authorization change affecting
+// federated origins equally, so it does not belong to standalone mode; until
+// then, do not read these headers as a statement of what will be refused.
+func (ac *authConfig) SetTokenHintHeaders(hdr http.Header, resource string) {
+	nsAds := ac.nsAds.Load()
+	if nsAds == nil {
+		return
+	}
+	nsAd := server_structs.LongestNSMatch(resource, *nsAds)
+	if nsAd == nil {
+		return
+	}
+	// This origin serves its own listings, so it is its own collections URL.
+	server_structs.SetXNamespaceHeaderWithCollections(hdr, param.Origin_Url.GetString(), *nsAd)
+	server_structs.SetXAuthHeader(hdr, *nsAd)
+	server_structs.SetXTokenGenHeader(hdr, *nsAd)
 }
 
 // Given a token, calculate the corresponding access control list

--- a/origin_serve/authz_status_test.go
+++ b/origin_serve/authz_status_test.go
@@ -1,0 +1,171 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package origin_serve
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/pelican_url"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
+)
+
+// mockFederationRootForAuthz serves just enough federation metadata for a
+// non-standalone origin to finish InitServer.
+func mockFederationRootForAuthz(t *testing.T) string {
+	t.Helper()
+	svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/pelican-configuration" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		body, err := json.Marshal(pelican_url.FederationDiscovery{
+			DiscoveryEndpoint: "https://fake-discovery.com",
+			DirectorEndpoint:  "https://fake-director.com",
+			RegistryEndpoint:  "https://fake-registry.com",
+			BrokerEndpoint:    "https://fake-broker.com",
+			JwksUri:           "https://fake-discovery.com/.well-known/issuer.jwks",
+		})
+		require.NoError(t, err)
+		_, err = w.Write(body)
+		require.NoError(t, err)
+	}))
+	t.Cleanup(svr.Close)
+	return svr.URL
+}
+
+// TestAuthFailureStatusDependsOnStandaloneMode pins which status an origin
+// returns when a caller presents a token that does not authorize the request.
+//
+// A standalone origin answers 403, which is what drives the token-hint retry in
+// client/handle_http.go: it has already told the caller which issuer to use, so
+// repeating the 401 would just loop.
+//
+// A federated origin must keep answering 401.  A 401 is the signal that tells
+// rclone and similar clients to re-run their bearer_token_command and try again
+// -- the same reason the director returns 401 for an expired token.  Promoting
+// it to 403 federation-wide would turn a refreshable rejection into a permanent
+// one for every existing deployment.
+func TestAuthFailureStatusDependsOnStandaloneMode(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// An export that requires a token: readable, but not publicly readable.
+	exports := []server_utils.OriginExport{
+		{
+			FederationPrefix: "/protected",
+			StoragePrefix:    t.TempDir(),
+			IssuerUrls:       []string{"https://test-issuer.example.com"},
+			Capabilities: server_structs.Capabilities{
+				Reads:  true,
+				Writes: true,
+			},
+		},
+	}
+
+	// request runs one GET through authMiddleware and reports the response the
+	// middleware settled on.  presentToken controls whether the caller brought a
+	// credential at all.
+	request := func(t *testing.T, standalone bool, presentToken bool) *httptest.ResponseRecorder {
+		t.Helper()
+		server_utils.ResetTestState()
+		t.Cleanup(server_utils.ResetTestState)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		egrp := &errgroup.Group{}
+
+		if standalone {
+			require.NoError(t, param.Origin_EnableStandaloneMode.Set(true))
+			require.NoError(t, param.Origin_StorageType.Set("posixv2"))
+		} else {
+			// A federated origin refuses to start without a reachable
+			// federation, so stand one up for it to discover.  Its certificate
+			// is self-signed, hence the skipped verification.
+			require.NoError(t, param.TLSSkipVerify.Set(true))
+			require.NoError(t, param.Federation_DiscoveryUrl.Set(mockFederationRootForAuthz(t)))
+		}
+		require.NoError(t, config.InitServer(ctx, server_structs.OriginType))
+		require.Equal(t, standalone, config.IsStandaloneOrigin(),
+			"test setup must actually flip the standalone gate")
+
+		require.NoError(t, InitAuthConfig(ctx, egrp, exports))
+
+		engine := gin.New()
+		engine.GET("/protected/*path", authMiddleware(), func(c *gin.Context) {
+			c.Status(http.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/protected/secret.txt", nil)
+		if presentToken {
+			// The contents do not matter: the middleware branches on whether a
+			// credential was presented at all, and this one authorizes nothing.
+			req.Header.Set("Authorization", "Bearer not.a.valid.token")
+		}
+		rec := httptest.NewRecorder()
+		engine.ServeHTTP(rec, req)
+		return rec
+	}
+
+	t.Run("federated-origin-keeps-401-so-clients-refresh", func(t *testing.T) {
+		rec := request(t, false, true)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code,
+			"a federated origin must keep returning 401 when a presented token is insufficient")
+
+		// The X-Pelican-* namespace/issuer metadata is the director's to publish.
+		// A federated origin that started volunteering it would leak the shape of
+		// its namespaces (issuers, listability, whether a token is required) to
+		// every unauthenticated caller, on every deployment that exists today.
+		for name := range rec.Header() {
+			assert.NotContains(t, strings.ToLower(name), "x-pelican-",
+				"a federated origin must not emit director-owned token hints")
+		}
+	})
+
+	t.Run("standalone-origin-returns-403", func(t *testing.T) {
+		rec := request(t, true, true)
+		assert.Equal(t, http.StatusForbidden, rec.Code,
+			"a standalone origin distinguishes an insufficient token from no token at all")
+
+		// The counterpart of the assertion above: with no director in the
+		// federation these headers are the client's only route to the issuer.
+		assert.NotEmpty(t, rec.Header().Get(server_structs.XPelNs{}.GetName()),
+			"a standalone origin must tell the caller which namespace it hit")
+		assert.NotEmpty(t, rec.Header().Values(server_structs.XPelAuth{}.GetName()),
+			"a standalone origin must tell the caller which issuer to use")
+	})
+
+	t.Run("no-token-is-401-everywhere", func(t *testing.T) {
+		assert.Equal(t, http.StatusUnauthorized, request(t, true, false).Code,
+			"a caller that brought nothing gets 401 even on a standalone origin")
+		assert.Equal(t, http.StatusUnauthorized, request(t, false, false).Code)
+	})
+}

--- a/origin_serve/handlers.go
+++ b/origin_serve/handlers.go
@@ -188,6 +188,21 @@ func init() {
 	server_utils.RegisterPOSIXv2Reset(ResetHandlers)
 }
 
+// BackendForPrefix returns the storage backend serving a federation prefix, or
+// nil if no export claims it.
+//
+// The backend is how this process reaches its own storage.  Anything that wants
+// to read an export -- listing it to measure disk usage, say -- should go
+// through here rather than addressing the origin over the network: the bytes
+// are already local, and a request that leaves the process needs a federation,
+// a credential, and an initialized client to come back.
+func BackendForPrefix(prefix string) server_utils.OriginBackend {
+	if backends == nil {
+		return nil
+	}
+	return backends[prefix]
+}
+
 // ResetHandlers resets the handler state (for testing)
 func ResetHandlers() {
 	backends = nil

--- a/origin_serve/handlers.go
+++ b/origin_serve/handlers.go
@@ -290,7 +290,7 @@ func authMiddleware() gin.HandlerFunc {
 		// This happens when the director is co-located with the origin
 		// Token scopes are always for the federation prefix (e.g., /test/...),
 		// not the HTTP route prefix
-		const apiPrefix = "/api/v1.0/origin/data"
+		const apiPrefix = server_structs.OriginDataRoutePrefix
 		resource = strings.TrimPrefix(resource, apiPrefix)
 		ac := GetAuthConfig()
 		if ac == nil {
@@ -300,6 +300,17 @@ func authMiddleware() gin.HandlerFunc {
 				"detail": "auth config not initialized",
 			})
 			return
+		}
+
+		// A standalone origin is the only thing a client can ask about its own
+		// namespaces: with no director in the federation, the client resolves an
+		// object by requesting it here and reading this metadata off the reply.
+		// It therefore has to ride on every response -- a success, a 404, or a
+		// rejection -- because the client's very first request for an object may
+		// be any of those. On a federated origin the director already supplied
+		// this, so the headers stay off.
+		if config.IsStandaloneOrigin() {
+			ac.SetTokenHintHeaders(c.Writer.Header(), resource)
 		}
 
 		// Check for public reads first
@@ -411,7 +422,28 @@ func authMiddleware() gin.HandlerFunc {
 		// For public reads, the authorizedContext may be nil
 		if !isPublicRead && authorizedContext == nil {
 			reqLog.Warningf("Authorization failed for %s %s - tried %d token(s)", c.Request.Method, resource, len(tokens))
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+			// The namespace/issuer hints were already attached above for a
+			// standalone origin; a federated one deliberately sends none,
+			// because its director owns that answer.
+			//
+			// On a standalone origin, distinguish "you brought nothing" from
+			// "what you brought is not enough": a client that presented a
+			// token has already been told which issuer to use, so repeating
+			// the 401 would just loop, whereas the 403 drives the token-hint
+			// retry in client/handle_http.go.
+			//
+			// Federated origins keep answering 401 in both cases.  A 401 is
+			// what tells rclone and similar clients to re-run their
+			// bearer_token_command and try again -- the same reason the
+			// director returns 401 for an expired token (see
+			// validateClientToken in director/director.go).  Promoting it to
+			// 403 federation-wide would turn a refreshable rejection into a
+			// permanent one for every existing deployment.
+			status := http.StatusUnauthorized
+			if len(tokens) > 0 && config.IsStandaloneOrigin() {
+				status = http.StatusForbidden
+			}
+			c.AbortWithStatusJSON(status, gin.H{
 				"error":  "unauthorized",
 				"detail": fmt.Sprintf("authorization failed for %s %s; tried %d token(s)", action, resource, len(tokens)),
 			})
@@ -777,6 +809,11 @@ func InitializeHandlers(ctx context.Context, exports []server_utils.OriginExport
 			Logger:     logger,
 		}
 
+		// Keyed by federation prefix, so two exports declaring the same one
+		// leave only the last standing -- silently, and with whichever storage
+		// prefix happened to be configured last.  Nothing upstream rejects the
+		// duplicate; if that is ever tightened, it belongs in export validation
+		// rather than here, and applies to federated origins just as much.
 		backends[export.FederationPrefix] = backend
 		webdavHandlers[export.FederationPrefix] = handler
 		exportPrefixMap[export.FederationPrefix] = export.StoragePrefix
@@ -809,7 +846,7 @@ func RegisterHandlers(engine *gin.Engine, directorEnabled bool) error {
 		// This allows the director to distinguish between routing requests and origin file serving
 		var routePrefix string
 		if directorEnabled {
-			routePrefix = "/api/v1.0/origin/data" + prefix
+			routePrefix = server_structs.OriginDataRoutePrefix + prefix
 		} else {
 			routePrefix = prefix
 		}
@@ -1189,7 +1226,7 @@ func buildTransferEvent(c *gin.Context, method string, start time.Time) metrics.
 	requestPath := c.Request.URL.Path
 
 	// Strip the /api/v1.0/origin/data prefix if present (director co-located mode)
-	const apiPrefix = "/api/v1.0/origin/data"
+	const apiPrefix = server_structs.OriginDataRoutePrefix
 	requestPath = strings.TrimPrefix(requestPath, apiPrefix)
 
 	event := metrics.TransferEvent{

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -351,6 +351,7 @@ var runtimeConfigurableMap = map[string]bool{
 	"Origin.EnableOIDC": false,
 	"Origin.EnablePublicReads": false,
 	"Origin.EnableReads": false,
+	"Origin.EnableStandaloneMode": false,
 	"Origin.EnableTLSClientAuth": false,
 	"Origin.EnableTransferAPI": false,
 	"Origin.EnableVoms": false,
@@ -1070,6 +1071,7 @@ var boolAccessors = map[string]func(*Config) bool{
 	"Origin.EnableOIDC": func(c *Config) bool { return c.Origin.EnableOIDC },
 	"Origin.EnablePublicReads": func(c *Config) bool { return c.Origin.EnablePublicReads },
 	"Origin.EnableReads": func(c *Config) bool { return c.Origin.EnableReads },
+	"Origin.EnableStandaloneMode": func(c *Config) bool { return c.Origin.EnableStandaloneMode },
 	"Origin.EnableTLSClientAuth": func(c *Config) bool { return c.Origin.EnableTLSClientAuth },
 	"Origin.EnableTransferAPI": func(c *Config) bool { return c.Origin.EnableTransferAPI },
 	"Origin.EnableVoms": func(c *Config) bool { return c.Origin.EnableVoms },
@@ -1556,6 +1558,7 @@ var allParameterNames = []string{
 	"Origin.EnableOIDC",
 	"Origin.EnablePublicReads",
 	"Origin.EnableReads",
+	"Origin.EnableStandaloneMode",
 	"Origin.EnableTLSClientAuth",
 	"Origin.EnableTransferAPI",
 	"Origin.EnableVoms",
@@ -2127,6 +2130,7 @@ var (
 	Origin_EnableOIDC = BoolParam{"Origin.EnableOIDC"}
 	Origin_EnablePublicReads = BoolParam{"Origin.EnablePublicReads"}
 	Origin_EnableReads = BoolParam{"Origin.EnableReads"}
+	Origin_EnableStandaloneMode = BoolParam{"Origin.EnableStandaloneMode"}
 	Origin_EnableTLSClientAuth = BoolParam{"Origin.EnableTLSClientAuth"}
 	Origin_EnableTransferAPI = BoolParam{"Origin.EnableTransferAPI"}
 	Origin_EnableVoms = BoolParam{"Origin.EnableVoms"}
@@ -2616,6 +2620,7 @@ func init() {
 		"Origin.EnableOIDC": Origin_EnableOIDC,
 		"Origin.EnablePublicReads": Origin_EnablePublicReads,
 		"Origin.EnableReads": Origin_EnableReads,
+		"Origin.EnableStandaloneMode": Origin_EnableStandaloneMode,
 		"Origin.EnableTLSClientAuth": Origin_EnableTLSClientAuth,
 		"Origin.EnableTransferAPI": Origin_EnableTransferAPI,
 		"Origin.EnableVoms": Origin_EnableVoms,

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -311,6 +311,7 @@ type Config struct {
 		EnableOIDC bool `mapstructure:"enableoidc" yaml:"EnableOIDC"`
 		EnablePublicReads bool `mapstructure:"enablepublicreads" yaml:"EnablePublicReads"`
 		EnableReads bool `mapstructure:"enablereads" yaml:"EnableReads"`
+		EnableStandaloneMode bool `mapstructure:"enablestandalonemode" yaml:"EnableStandaloneMode"`
 		EnableTLSClientAuth bool `mapstructure:"enabletlsclientauth" yaml:"EnableTLSClientAuth"`
 		EnableTransferAPI bool `mapstructure:"enabletransferapi" yaml:"EnableTransferAPI"`
 		EnableVoms bool `mapstructure:"enablevoms" yaml:"EnableVoms"`
@@ -838,6 +839,7 @@ type configWithType struct {
 		EnableOIDC struct { Type string; Value bool }
 		EnablePublicReads struct { Type string; Value bool }
 		EnableReads struct { Type string; Value bool }
+		EnableStandaloneMode struct { Type string; Value bool }
 		EnableTLSClientAuth struct { Type string; Value bool }
 		EnableTransferAPI struct { Type string; Value bool }
 		EnableVoms struct { Type string; Value bool }

--- a/server_structs/director.go
+++ b/server_structs/director.go
@@ -20,6 +20,7 @@ package server_structs
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -496,6 +497,141 @@ func (x *XPelTokGen) ParseRawHeader(header *http.Header) error {
 		}
 	}
 	return nil
+}
+
+// SetXAuthHeader sets the X-Pelican-Authorization header (when applicable) on hdr. This
+// header informs the client of the issuer(s) that can be used to generate a token for the
+// requested resource.  It is the "write" counterpart to XPelAuth.ParseRawHeader and is
+// shared by every server that answers a client the way the director does.
+func SetXAuthHeader(hdr http.Header, namespaceAd NamespaceAd) {
+	if len(namespaceAd.Issuer) != 0 {
+		issStrings := []string{}
+		for _, tokIss := range namespaceAd.Issuer {
+			issStrings = append(issStrings, "issuer="+tokIss.IssuerUrl.String())
+		}
+		hdr[XPelAuth{}.GetName()] = issStrings
+	}
+}
+
+// SetXTokenGenHeader sets the X-Pelican-Token-Generation header (when applicable) on hdr,
+// describing how a client may generate a token for the requested resource.
+func SetXTokenGenHeader(hdr http.Header, namespaceAd NamespaceAd) {
+	if len(namespaceAd.Generation) != 0 {
+		tokenGen := ""
+		first := true
+		// TODO: At some point, the director stopped sending the `base-path` key in the token gen header. I'm unsure of the _proper_ way
+		// to fix this because the token gen header uses the issuer URL from NamespaceAd.Generation.CredentialIssuer, whereas basepaths
+		// come from NamespaceAd.Issuer.BasePaths. For now, connecting these two means checking if they have the same issuer URL. This
+		// really needs to be cleaned up in the future, and maybe we need to give more thought to why we have these two structs in the
+		// ad. See https://github.com/PelicanPlatform/pelican/issues/1540
+		var basePath string
+		for _, issuer := range namespaceAd.Issuer {
+			if issuer.IssuerUrl.String() == namespaceAd.Generation[0].CredentialIssuer.String() {
+				if len(issuer.BasePaths) > 0 {
+					basePath = issuer.BasePaths[0]
+				}
+				break
+			}
+		}
+
+		hdrVals := []string{namespaceAd.Generation[0].CredentialIssuer.String(), fmt.Sprint(namespaceAd.Generation[0].MaxScopeDepth),
+			string(namespaceAd.Generation[0].Strategy), basePath}
+		for idx, hdrKey := range []string{"issuer", "max-scope-depth", "strategy", "base-path"} {
+			hdrVal := hdrVals[idx]
+			if hdrVal == "" {
+				continue
+			} else if hdrKey == "max-scope-depth" && hdrVal == "0" {
+				// don't send a 0 max-scope-depth because it's malformed and probably means there should be no token generation header
+				continue
+			}
+			if !first {
+				tokenGen += ", "
+			}
+			first = false
+			tokenGen += hdrKey + "=" + hdrVal
+		}
+
+		if tokenGen != "" {
+			hdr[XPelTokGen{}.GetName()] = []string{tokenGen}
+		}
+	}
+}
+
+// setXNamespaceHeader is the shared core that writes the X-Pelican-Namespace header
+// given an already-resolved collections URL (which may be empty).
+func setXNamespaceHeader(hdr http.Header, collUrl string, bestNSAd NamespaceAd) {
+	xPelicanNamespace := fmt.Sprintf("namespace=%s, require-token=%v", bestNSAd.Path, !bestNSAd.Caps.PublicReads)
+	if collUrl != "" {
+		xPelicanNamespace += fmt.Sprintf(", collections-url=%s", collUrl)
+	}
+	hdr[XPelNs{}.GetName()] = []string{xPelicanNamespace}
+}
+
+// SetXNamespaceHeader sets the X-Pelican-Namespace header on hdr, including information about
+// the namespace and whether token auth is required for reading from it.  oAds (origin ads) are
+// only used to compute the optional collections-url; callers without origin ads may pass nil.
+func SetXNamespaceHeader(hdr http.Header, oAds []ServerAd, bestNSAd NamespaceAd) {
+	var collUrl string
+	// If the namespace or the origin does not allow directory listings, then we should not advertise a collections-url.
+	for _, oAd := range oAds {
+		if oAd.Caps.Listings && bestNSAd.Caps.Listings {
+			if !bestNSAd.Caps.PublicReads && oAd.AuthURL != (url.URL{}) {
+				collUrl = oAd.AuthURL.String()
+				break
+			} else {
+				collUrl = oAd.URL.String()
+				break
+			}
+		}
+	}
+	setXNamespaceHeader(hdr, collUrl, bestNSAd)
+}
+
+// SetXNamespaceHeaderWithCollections sets the X-Pelican-Namespace header using an explicit
+// collections URL rather than deriving one from origin ads.  Used by a server that is itself
+// the collections endpoint for the namespace.  The collections URL is only advertised when
+// the namespace permits listings.
+func SetXNamespaceHeaderWithCollections(hdr http.Header, collUrl string, bestNSAd NamespaceAd) {
+	if !bestNSAd.Caps.Listings {
+		collUrl = ""
+	}
+	setXNamespaceHeader(hdr, collUrl, bestNSAd)
+}
+
+// LongestNSMatch returns the namespace ad whose path is the longest logical prefix of reqPath.
+// For example, for path `/foo/bar/baz` and namespace ads `/foo` & `/foo/bar`, it returns the
+// ad for `/foo/bar`.  Returns nil if no ad matches.
+func LongestNSMatch(reqPath string, namespaceAds []NamespaceAd) *NamespaceAd {
+	// Normalize incoming path if needed --> adding the trailing / makes
+	// basic prefix matching safer
+	if !strings.HasSuffix(reqPath, "/") {
+		reqPath += "/"
+	}
+
+	var bestFedPrefix string
+	var bestNamespace *NamespaceAd
+	for _, ns := range namespaceAds {
+		// Create a copy of ns to avoid reusing the loop variable
+		currentNS := ns
+
+		// Additionally normalize stored namespace paths
+		nsPath := currentNS.Path
+		if !strings.HasSuffix(currentNS.Path, "/") {
+			nsPath += "/"
+		}
+
+		if !strings.HasPrefix(reqPath, nsPath) {
+			// This namespace doesn't match the request path, skip it
+			continue
+		}
+
+		if bestFedPrefix == "" || len(nsPath) > len(bestFedPrefix) {
+			bestFedPrefix = nsPath
+			bestNamespace = &currentNS
+		}
+	}
+
+	return bestNamespace
 }
 
 func NewRedirectInfoFromIP(ipAddr string) *RedirectInfo {

--- a/server_structs/director_test.go
+++ b/server_structs/director_test.go
@@ -203,3 +203,131 @@ func TestServerBaseAdAfter(t *testing.T) {
 		assert.Equal(t, ad1.After(ad2), AdAfterUnknown)
 	})
 }
+
+func TestLongestNSMatch(t *testing.T) {
+	nsAd := func(path string) NamespaceAd { return NamespaceAd{Path: path} }
+
+	testCases := []struct {
+		name     string
+		reqPath  string
+		nsAds    []NamespaceAd
+		expected string // the Path of the ad expected back, or "" for no match
+	}{
+		{
+			name:     "prefers the deeper of two nested exports",
+			reqPath:  "/foo/bar/baz",
+			nsAds:    []NamespaceAd{nsAd("/foo"), nsAd("/foo/bar")},
+			expected: "/foo/bar",
+		},
+		{
+			name:     "ad order does not decide the winner",
+			reqPath:  "/foo/bar/baz",
+			nsAds:    []NamespaceAd{nsAd("/foo/bar"), nsAd("/foo")},
+			expected: "/foo/bar",
+		},
+		{
+			name:     "falls back to the shallower export when the deeper one does not cover the path",
+			reqPath:  "/foo/other/baz",
+			nsAds:    []NamespaceAd{nsAd("/foo"), nsAd("/foo/bar")},
+			expected: "/foo",
+		},
+		{
+			name:     "matches a request path equal to the export prefix",
+			reqPath:  "/foo/bar",
+			nsAds:    []NamespaceAd{nsAd("/foo"), nsAd("/foo/bar")},
+			expected: "/foo/bar",
+		},
+		{
+			name:     "matches a request path equal to the export prefix with a trailing slash",
+			reqPath:  "/foo/bar/",
+			nsAds:    []NamespaceAd{nsAd("/foo"), nsAd("/foo/bar")},
+			expected: "/foo/bar",
+		},
+		{
+			name:     "matches an export prefix stored with a trailing slash",
+			reqPath:  "/foo/bar/baz",
+			nsAds:    []NamespaceAd{nsAd("/foo/bar/")},
+			expected: "/foo/bar/",
+		},
+		{
+			// Path boundaries, not raw string prefixes: /foobar is a sibling of
+			// /foo, not a child of it.
+			name:     "does not match a sibling whose name merely starts the same",
+			reqPath:  "/foobar/baz",
+			nsAds:    []NamespaceAd{nsAd("/foo")},
+			expected: "",
+		},
+		{
+			name:     "a root export covers everything",
+			reqPath:  "/anything/at/all",
+			nsAds:    []NamespaceAd{nsAd("/")},
+			expected: "/",
+		},
+		{
+			name:     "a deeper export still beats a root export",
+			reqPath:  "/foo/bar",
+			nsAds:    []NamespaceAd{nsAd("/"), nsAd("/foo")},
+			expected: "/foo",
+		},
+		{
+			name:     "returns nil when nothing matches",
+			reqPath:  "/nowhere/object",
+			nsAds:    []NamespaceAd{nsAd("/foo"), nsAd("/bar")},
+			expected: "",
+		},
+		{
+			name:     "returns nil when there are no ads at all",
+			reqPath:  "/foo/bar",
+			nsAds:    nil,
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := LongestNSMatch(tc.reqPath, tc.nsAds)
+			if tc.expected == "" {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, tc.expected, got.Path)
+		})
+	}
+}
+
+func TestSetXNamespaceHeaderWithCollections(t *testing.T) {
+	const collUrl = "https://origin.example.com:8443"
+
+	t.Run("AdvertisesCollectionsWhenListingsAllowed", func(t *testing.T) {
+		hdr := http.Header{}
+		SetXNamespaceHeaderWithCollections(hdr, collUrl, NamespaceAd{
+			Path: "/foo",
+			Caps: Capabilities{Reads: true, Listings: true},
+		})
+		assert.Equal(t, "namespace=/foo, require-token=true, collections-url="+collUrl,
+			hdr.Get(XPelNs{}.GetName()))
+	})
+
+	t.Run("SuppressesCollectionsWhenListingsDenied", func(t *testing.T) {
+		// A collections-url the namespace will not answer PROPFIND for would
+		// send the client to a guaranteed error, so it is left out entirely.
+		hdr := http.Header{}
+		SetXNamespaceHeaderWithCollections(hdr, collUrl, NamespaceAd{
+			Path: "/foo",
+			Caps: Capabilities{Reads: true, Listings: false},
+		})
+		assert.Equal(t, "namespace=/foo, require-token=true", hdr.Get(XPelNs{}.GetName()))
+		assert.NotContains(t, hdr.Get(XPelNs{}.GetName()), "collections-url")
+	})
+
+	t.Run("PublicReadsClearsRequireToken", func(t *testing.T) {
+		hdr := http.Header{}
+		SetXNamespaceHeaderWithCollections(hdr, collUrl, NamespaceAd{
+			Path: "/foo",
+			Caps: Capabilities{PublicReads: true, Reads: true, Listings: true},
+		})
+		assert.Equal(t, "namespace=/foo, require-token=false, collections-url="+collUrl,
+			hdr.Get(XPelNs{}.GetName()))
+	})
+}

--- a/server_structs/origin.go
+++ b/server_structs/origin.go
@@ -18,11 +18,29 @@
 
 package server_structs
 
-import "github.com/pkg/errors"
+import (
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+)
 
 type (
 	OriginStorageType string
 )
+
+// OriginDataRoutePrefix is where a native origin mounts its exports when it
+// shares a web server with a co-located director.  The director owns the root
+// path space (clients resolve an object by GETting
+// https://<director>/<ns>/<obj> and following the redirect), so the bytes have
+// to live somewhere else.  An origin running without a director -- including a
+// standalone one -- mounts its exports at their bare federation prefixes
+// instead; see origin_serve.RegisterHandlers.
+//
+// Both ends of that arrangement must agree on this string: the origin mounts
+// its handlers under it, and the ad it publishes has to point here.
+const OriginDataRoutePrefix = "/api/v1.0/origin/data"
 
 const (
 	OriginStoragePosix    OriginStorageType = "posix"
@@ -96,6 +114,32 @@ func ParseOriginStorageType(storageType string) (ost OriginStorageType, err erro
 		ost = OriginStorageGlobusv2
 	default:
 		err = errors.Wrapf(ErrUnknownOriginStorageType, "storage type %s (known types are posix, posixv2, ssh, s3, s3v2, https, httpsv2, globus, globusv2, and xroot)", storageType)
+	}
+	return
+}
+
+// ParseExportVolume splits a docker-style export volume into the storage prefix
+// it exposes and the federation prefix it is served under.  A value with no
+// colon names the same path on both sides.
+//
+// The two sides are cleaned differently on purpose.  A storage prefix names a
+// location on this host, so it takes the platform's separator; a federation
+// prefix is the path half of a URL and is always slash-separated, so cleaning it
+// as a filesystem path would turn "/public" into "\public" on Windows and stop
+// it matching anything -- including the checks that reject a root prefix.
+//
+// The split is on the *first* colon, which means a storage prefix containing one
+// -- a Windows drive letter, say -- cannot be expressed in this syntax.  That is
+// a property of the syntax rather than a choice made here, and it is the reason
+// this lives in one place: config validation and export construction disagreeing
+// about where the federation prefix begins would let a prefix pass validation
+// and then be served under a different name.
+func ParseExportVolume(volume string) (storagePrefix, federationPrefix string) {
+	storagePrefix = filepath.Clean(volume)
+	federationPrefix = path.Clean(volume)
+	if parts := strings.SplitN(volume, ":", 2); len(parts) == 2 {
+		storagePrefix = filepath.Clean(parts[0])
+		federationPrefix = path.Clean(parts[1])
 	}
 	return
 }

--- a/server_structs/origin_test.go
+++ b/server_structs/origin_test.go
@@ -19,6 +19,7 @@
 package server_structs
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,6 +50,44 @@ func TestOriginStorageType_IsPosixLike(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(string(tc.in), func(t *testing.T) {
 			assert.Equal(t, tc.expected, tc.in.IsPosixLike())
+		})
+	}
+}
+
+// TestParseExportVolume pins the docker-style split that both export
+// construction and standalone-mode validation depend on.  They read the same
+// configuration for different purposes, and a disagreement about where the
+// federation prefix begins would let a prefix pass validation and then be
+// served under a different name.
+func TestParseExportVolume(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// storage is written slash-separated and compared after cleaning for
+		// the running platform: it names a location on this host.
+		volume     string
+		storage    string
+		federation string
+	}{
+		{"both-sides", "/srv/data:/public", "/srv/data", "/public"},
+		{"bare-value-names-both", "/srv/data", "/srv/data", "/srv/data"},
+		{"root-federation-prefix", "/srv/data:/", "/srv/data", "/"},
+		{"paths-are-cleaned", "/srv//data/:/public/", "/srv/data", "/public"},
+		// The split takes the first colon, so a storage prefix containing one
+		// cannot be expressed; the caller sees the truncation rather than a
+		// silently different prefix.
+		{"second-colon-belongs-to-the-federation-side", "C:/data:/public", "C", "/data:/public"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			storage, federation := ParseExportVolume(tc.volume)
+			assert.Equal(t, filepath.Clean(tc.storage), storage)
+
+			// A federation prefix is the path half of a URL, so it is
+			// slash-separated everywhere.  Cleaning it as a filesystem path
+			// would make it "\public" on Windows and stop it matching
+			// anything, including the check that rejects a root prefix.
+			assert.Equal(t, tc.federation, federation)
+			assert.NotContains(t, federation, "\\",
+				"a federation prefix must never pick up the platform separator")
 		})
 	}
 }

--- a/server_utils/origin.go
+++ b/server_utils/origin.go
@@ -670,13 +670,7 @@ func getVolumes() []exportVolume {
 	exportVolumes := make([]exportVolume, len(volumes))
 	for idx, volume := range volumes {
 		// Perform validation of the namespace
-		storagePrefix := filepath.Clean(volume)
-		federationPrefix := filepath.Clean(volume)
-		volumeMountInfo := strings.SplitN(volume, ":", 2)
-		if len(volumeMountInfo) == 2 {
-			storagePrefix = filepath.Clean(volumeMountInfo[0])
-			federationPrefix = filepath.Clean(volumeMountInfo[1])
-		}
+		storagePrefix, federationPrefix := server_structs.ParseExportVolume(volume)
 
 		exportVolumes[idx] = exportVolume{
 			storagePrefix:    storagePrefix,
@@ -776,4 +770,64 @@ func CheckOriginSentinelLocations(exports []OriginExport) (ok bool, err error) {
 
 func ResetOriginExports() {
 	originExports = nil
+}
+
+// NamespaceAdsFromExports converts an origin's exports into the namespace ads
+// that describe them to the rest of the federation.
+//
+// Two callers depend on these being identical: the origin's advertisement to
+// the director, and the X-Pelican-* token hints a standalone origin returns on
+// its own responses (origin_serve.SetTokenHintHeaders), which are all a client
+// has to go on when there is no director to ask. Keeping the construction in
+// one place is what stops a standalone origin from describing its own
+// namespaces differently than a federated one would.
+func NamespaceAdsFromExports(exports []OriginExport) ([]server_structs.NamespaceAd, error) {
+	nsAds := make([]server_structs.NamespaceAd, 0, len(exports))
+	for _, export := range exports {
+		// PublicReads implies reads
+		reads := export.Capabilities.PublicReads || export.Capabilities.Reads
+
+		// Set up issuer URLs for the namespace. Note that this uses a single
+		// base path (the fed prefix) per issuer per export even if a single issuer
+		// at the origin is configured for multiple prefixes. This is because we have
+		// no global concept of issuers at the Director and we store this issuer info
+		// per namespace. It doesn't currently make much sense to construct the full list
+		// of potential base paths in this context.
+		issuerUrls := make([]server_structs.TokenIssuer, len(export.IssuerUrls))
+		for i, issUrlStr := range export.IssuerUrls {
+			issUrl, err := url.Parse(issUrlStr)
+			if err != nil {
+				return nil, errors.Wrap(err, "unable to parse issuer url")
+			}
+			issuerUrls[i] = server_structs.TokenIssuer{
+				IssuerUrl: *issUrl,
+				BasePaths: []string{export.FederationPrefix},
+			}
+		}
+
+		// Populate the struct for the namespace's "token generation" field
+		// TODO: It's not clear what the intended difference/abstraction between the
+		// "Generation" and the "Issuer" fields is... We should define these eventually
+		var tokGen server_structs.TokenGen
+		if len(issuerUrls) > 0 {
+			tokGen.Strategy = server_structs.OAuthStrategy
+			tokGen.MaxScopeDepth = 3
+			tokGen.CredentialIssuer = issuerUrls[0].IssuerUrl
+		}
+
+		nsAds = append(nsAds, server_structs.NamespaceAd{
+			Caps: server_structs.Capabilities{
+				PublicReads: export.Capabilities.PublicReads,
+				Reads:       reads,
+				Writes:      export.Capabilities.Writes,
+				Listings:    export.Capabilities.Listings,
+				DirectReads: export.Capabilities.DirectReads,
+				Copies:      export.Capabilities.Copies,
+			},
+			Path:       export.FederationPrefix,
+			Generation: []server_structs.TokenGen{tokGen},
+			Issuer:     issuerUrls,
+		})
+	}
+	return nsAds, nil
 }

--- a/server_utils/origin_test.go
+++ b/server_utils/origin_test.go
@@ -23,6 +23,7 @@ package server_utils
 import (
 	_ "embed"
 	"fmt"
+	"net/http"
 	"os"
 	"os/user"
 	"strconv"
@@ -1023,5 +1024,81 @@ func TestValidatePosixPermissions(t *testing.T) {
 		assert.Contains(t, errStr, "uid=", "error should contain UID info")
 		assert.Contains(t, errStr, "gid=", "error should contain GID info")
 		assert.Contains(t, errStr, "permissions", "error should mention permissions")
+	})
+}
+
+func TestNamespaceAdsFromExports(t *testing.T) {
+	t.Run("PublicReadsImpliesReads", func(t *testing.T) {
+		// An export may declare PublicReads without also declaring Reads; the ad
+		// has to carry both, or the director (and a standalone origin's own token
+		// hints) would describe a publicly readable namespace as unreadable.
+		nsAds, err := NamespaceAdsFromExports([]OriginExport{{
+			FederationPrefix: "/public",
+			StoragePrefix:    "/srv/public",
+			Capabilities:     server_structs.Capabilities{PublicReads: true},
+		}})
+		require.NoError(t, err)
+		require.Len(t, nsAds, 1)
+		assert.True(t, nsAds[0].Caps.PublicReads)
+		assert.True(t, nsAds[0].Caps.Reads)
+	})
+
+	t.Run("IssuersCarryTheFederationPrefixAsBasePath", func(t *testing.T) {
+		nsAds, err := NamespaceAdsFromExports([]OriginExport{{
+			FederationPrefix: "/protected",
+			StoragePrefix:    "/srv/protected",
+			IssuerUrls:       []string{"https://issuer-a.example.com", "https://issuer-b.example.com"},
+			Capabilities:     server_structs.Capabilities{Reads: true, Writes: true},
+		}})
+		require.NoError(t, err)
+		require.Len(t, nsAds, 1)
+		require.Len(t, nsAds[0].Issuer, 2)
+		assert.Equal(t, "https://issuer-a.example.com", nsAds[0].Issuer[0].IssuerUrl.String())
+		assert.Equal(t, []string{"/protected"}, nsAds[0].Issuer[0].BasePaths)
+		assert.Equal(t, "https://issuer-b.example.com", nsAds[0].Issuer[1].IssuerUrl.String())
+		assert.Equal(t, []string{"/protected"}, nsAds[0].Issuer[1].BasePaths)
+
+		// Token generation is advertised from the first issuer only.
+		require.Len(t, nsAds[0].Generation, 1)
+		assert.Equal(t, server_structs.OAuthStrategy, nsAds[0].Generation[0].Strategy)
+		assert.Equal(t, "https://issuer-a.example.com", nsAds[0].Generation[0].CredentialIssuer.String())
+	})
+
+	t.Run("ZeroIssuersAdvertiseNoTokenGeneration", func(t *testing.T) {
+		// A truly public export needs no issuer; the generation entry must stay
+		// empty so that SetXTokenGenHeader emits nothing rather than a header
+		// pointing at the empty issuer.
+		nsAds, err := NamespaceAdsFromExports([]OriginExport{{
+			FederationPrefix: "/public",
+			StoragePrefix:    "/srv/public",
+			Capabilities:     server_structs.Capabilities{PublicReads: true, Listings: true},
+		}})
+		require.NoError(t, err)
+		require.Len(t, nsAds, 1)
+		assert.Empty(t, nsAds[0].Issuer)
+		require.Len(t, nsAds[0].Generation, 1)
+		assert.Empty(t, string(nsAds[0].Generation[0].Strategy))
+		assert.Zero(t, nsAds[0].Generation[0].MaxScopeDepth)
+
+		hdr := http.Header{}
+		server_structs.SetXTokenGenHeader(hdr, nsAds[0])
+		assert.Empty(t, hdr.Get(server_structs.XPelTokGen{}.GetName()))
+	})
+
+	t.Run("UnparsableIssuerUrlIsAnError", func(t *testing.T) {
+		_, err := NamespaceAdsFromExports([]OriginExport{{
+			FederationPrefix: "/protected",
+			StoragePrefix:    "/srv/protected",
+			IssuerUrls:       []string{"https://issuer.example.com:not-a-port"},
+			Capabilities:     server_structs.Capabilities{Reads: true},
+		}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unable to parse issuer url")
+	})
+
+	t.Run("EmptyExportsYieldEmptyAds", func(t *testing.T) {
+		nsAds, err := NamespaceAdsFromExports(nil)
+		require.NoError(t, err)
+		assert.Empty(t, nsAds)
 	})
 }

--- a/server_utils/sitename.go
+++ b/server_utils/sitename.go
@@ -108,12 +108,22 @@ func GetServerMetadata(ctx context.Context, server server_structs.ServerType) (m
 		// https://github.com/PelicanPlatform/pelican/issues/1351
 		extUrlStr := param.Server_ExternalWebUrl.GetString()
 		extUrl, _ := url.Parse(extUrlStr)
-		// Only use hostname:port
-		originPrefix := server_structs.GetOriginNs(extUrl.Host)
-		metadata, err = getServerMetadataFromReg(ctx, originPrefix)
-		if err != nil {
-			log.Errorf("Failed to get metadata from the registry for the origin. Will fallback to using %s: %v", param.Xrootd_Sitename.GetName(), err)
-			err = nil
+		if config.IsStandaloneOrigin() {
+			// A standalone origin never registered anywhere, so there is no
+			// registry to look a name up in and no federation-wide uniqueness to
+			// respect. Fall back to the external host the same way a director
+			// names itself, so admins aren't forced to set Xrootd.Sitename just
+			// to get a server name.
+			metadata.Name = extUrl.Host
+			metadata.IsOrigin = true
+		} else {
+			// Only use hostname:port
+			originPrefix := server_structs.GetOriginNs(extUrl.Host)
+			metadata, err = getServerMetadataFromReg(ctx, originPrefix)
+			if err != nil {
+				log.Errorf("Failed to get metadata from the registry for the origin. Will fallback to using %s: %v", param.Xrootd_Sitename.GetName(), err)
+				err = nil
+			}
 		}
 	} else if server.IsEnabled(server_structs.CacheType) {
 		cachePrefix := server_structs.GetCacheNs(param.Xrootd_Sitename.GetString())
@@ -126,14 +136,20 @@ func GetServerMetadata(ctx context.Context, server server_structs.ServerType) (m
 
 	// Prioritize the server name from the local configuration over the registry
 	if param.Xrootd_Sitename.GetString() != "" {
-		// Warn the user if the server name from the registry does not match the local configuration
 		if metadata.Name != param.Xrootd_Sitename.GetString() {
-			log.Warningf("Server name mismatch detected:\n"+
-				"  Registered server name: %q\n"+
-				"  Local sitename:      %q\n"+
-				"Pelican will use the local sitename as your server name.\n"+
-				"Contact the federation administrator to update the registered server name or update your local config to maintain consistency.",
-				metadata.Name, param.Xrootd_Sitename.GetString())
+			// Warn the user if the server name from the registry does not match the
+			// local configuration.  A standalone origin has nothing registered to
+			// disagree with -- the name above is just its own external host -- so
+			// the mismatch is expected and the advice to contact a federation
+			// administrator has no one to address.
+			if !config.IsStandaloneOrigin() {
+				log.Warningf("Server name mismatch detected:\n"+
+					"  Registered server name: %q\n"+
+					"  Local sitename:      %q\n"+
+					"Pelican will use the local sitename as your server name.\n"+
+					"Contact the federation administrator to update the registered server name or update your local config to maintain consistency.",
+					metadata.Name, param.Xrootd_Sitename.GetString())
+			}
 			metadata.Name = param.Xrootd_Sitename.GetString()
 		}
 	}

--- a/swagger/pelican-swagger.yaml
+++ b/swagger/pelican-swagger.yaml
@@ -2930,6 +2930,12 @@ paths:
                   type: string
                   minItems: 1
                 example: ["director", "origin", "registry"]
+              standaloneOrigin:
+                type: boolean
+                description: >
+                  True when this server runs an Origin with `Origin.EnableStandaloneMode`, i.e. it belongs to no
+                  federation. The web UI uses this to hide registration status, downtime, and federation links.
+                default: false
         "500":
           description: Server encountered error in reading institution configuration
           schema:

--- a/web_ui/frontend/app/navigation.tsx
+++ b/web_ui/frontend/app/navigation.tsx
@@ -142,7 +142,14 @@ const NavigationConfig: NavigationConfiguration = {
       icon: <Equalizer />,
       allowedRoles: ['admin'],
     },
-    { title: 'Downtime', href: '/origin/downtime/', icon: <CalendarMonth /> },
+    // Origin downtime exists so the Director can route around this server and
+    // the Registry can persist the record; a standalone Origin has neither.
+    {
+      title: 'Downtime',
+      href: '/origin/downtime/',
+      icon: <CalendarMonth />,
+      federationOnly: true,
+    },
     {
       title: 'Globus Configurations',
       href: '/origin/globus/',

--- a/web_ui/frontend/app/origin/NonAdminHome.tsx
+++ b/web_ui/frontend/app/origin/NonAdminHome.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import useSWR from 'swr';
 import { Box, Grid, Stack, Typography } from '@mui/material';
 import {
   CalendarMonth,
@@ -15,6 +16,7 @@ import {
 
 import FederationOverview from '@/components/FederationOverview';
 import ServerName from '@/components/ServerName';
+import { getServerInfo } from '@/helpers/util';
 
 type HealthState = 'loading' | 'ok' | 'degraded' | 'unavailable';
 
@@ -125,6 +127,8 @@ const QuickLink = ({
 };
 
 const NonAdminHome = () => {
+  const { data: serverInfo } = useSWR('getServerInfo', getServerInfo);
+
   return (
     <Box width={'100%'}>
       <ServerName defaultName={'Origin'} />
@@ -146,16 +150,22 @@ const NonAdminHome = () => {
               icon={<FolderOpen />}
             />
             <QuickLink href={'/groups/'} text={'Groups'} icon={<Groups />} />
-            <QuickLink
-              href={'/origin/downtime/'}
-              text={'Downtime'}
-              icon={<CalendarMonth />}
-            />
+            {/* Downtime is only consumed by a Director/Registry, so it has no
+                meaning on an origin that belongs to no federation. */}
+            {!serverInfo?.standaloneOrigin && (
+              <QuickLink
+                href={'/origin/downtime/'}
+                text={'Downtime'}
+                icon={<CalendarMonth />}
+              />
+            )}
           </Stack>
         </Grid>
-        <Grid size={{ xs: 12, lg: 6 }}>
-          <FederationOverview />
-        </Grid>
+        {!serverInfo?.standaloneOrigin && (
+          <Grid size={{ xs: 12, lg: 6 }}>
+            <FederationOverview />
+          </Grid>
+        )}
       </Grid>
     </Box>
   );

--- a/web_ui/frontend/app/origin/page.tsx
+++ b/web_ui/frontend/app/origin/page.tsx
@@ -35,12 +35,13 @@ import { DataExportTable } from '@/components/DataExportTable';
 import FederationOverview from '@/components/FederationOverview';
 import AuthenticatedContent from '@/components/layout/AuthenticatedContent';
 import ServerName from '@/components/ServerName';
-import { getErrorMessage } from '@/helpers/util';
+import { getErrorMessage, getServerInfo } from '@/helpers/util';
 import { getUser } from '@/helpers/login';
 import NonAdminHome from './NonAdminHome';
 
 const AdminHome = () => {
   const [copied, setCopied] = useState(false);
+  const { data: serverInfo } = useSWR('getServerInfo', getServerInfo);
 
   const handleClick = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -94,9 +95,11 @@ const AdminHome = () => {
             <DataExportTable />
           </Suspense>
         </Grid>
-        <Grid size={{ xs: 12, lg: 6 }}>
-          <FederationOverview />
-        </Grid>
+        {!serverInfo?.standaloneOrigin && (
+          <Grid size={{ xs: 12, lg: 6 }}>
+            <FederationOverview />
+          </Grid>
+        )}
       </Grid>
     </Box>
   );

--- a/web_ui/frontend/components/DataExportTable.tsx
+++ b/web_ui/frontend/components/DataExportTable.tsx
@@ -29,7 +29,11 @@ type RegistrationStatus =
   | 'Not Supported'
   | 'Completed'
   | 'Incomplete'
-  | 'Registration Error';
+  | 'Registration Error'
+  // The Origin runs in standalone mode: there is no registry to register at,
+  // so registration is not pending, not failed, and not something the admin
+  // can act on. See origin.RegStandalone.
+  | 'Standalone';
 
 type ExportResCommon = {
   status: RegistrationStatus;
@@ -79,6 +83,7 @@ export const DataExportStatus = ({
 }) => {
   switch (status) {
     case 'Completed':
+    case 'Standalone':
       return null;
     case 'Incomplete':
       return (
@@ -378,6 +383,11 @@ export const getExportData = async (): Promise<ExportRes> => {
 };
 
 const generateEditUrl = (editUrl: string, fromUrl: string) => {
+  // A standalone Origin has no registry and therefore no edit URL; `new URL('')`
+  // would throw and log a spurious console error on every render.
+  if (!editUrl) {
+    return editUrl;
+  }
   try {
     let updatedFromUrl = new URL(fromUrl);
     if (updatedFromUrl.searchParams.get('from_registry') === null) {
@@ -444,9 +454,14 @@ export const DataExportTable = ({ boxProps }: { boxProps?: BoxProps }) => {
       <Typography pb={1} variant={'h5'} component={'h3'}>
         Origin
       </Typography>
-      {dataEnhanced &&
-      dataEnhanced.status &&
-      dataEnhanced.status != 'Completed' ? (
+      {dataEnhanced?.status === 'Standalone' ? (
+        <Alert severity='info'>
+          {dataEnhanced.statusDescription ||
+            'This origin runs in standalone mode and is not registered with any federation registry.'}
+        </Alert>
+      ) : dataEnhanced &&
+        dataEnhanced.status &&
+        dataEnhanced.status != 'Completed' ? (
         <DataExportStatus
           status={dataEnhanced.status}
           statusDescription={dataEnhanced.statusDescription}

--- a/web_ui/frontend/components/layout/Navigation/Navigation.tsx
+++ b/web_ui/frontend/components/layout/Navigation/Navigation.tsx
@@ -6,10 +6,25 @@ import { getExportData } from '@/components/DataExportTable';
 import { getUser } from '@/helpers/login';
 import { Sidebar } from '@/components/layout/Navigation/Sidebar';
 import NavigationConfig from '@/app/navigation';
-import { getEnabledServers } from '@/helpers/util';
+import { getServerInfo } from '@/helpers/util';
 import { Box, Typography } from '@mui/material';
 import { AppBar } from '@/components/layout/Navigation/AppBar';
 import { ReactNode } from 'react';
+
+/** Recursively removes federationOnly items (and prunes emptied parents). */
+const filterFederationOnly = (
+  items?: StaticNavigationItemProps[]
+): StaticNavigationItemProps[] | undefined => {
+  return items
+    ?.filter((item) => !item.federationOnly)
+    .map((item) => {
+      if (!('children' in item)) {
+        return item;
+      }
+      return { ...item, children: filterFederationOnly(item.children) ?? [] };
+    })
+    .filter((item) => !('children' in item) || item.children.length > 0);
+};
 
 const Navigation = ({
   children,
@@ -37,7 +52,8 @@ const Navigation = ({
     getExportData,
     { errorRetryCount: 0 }
   );
-  const { data: servers } = useSWR('getServers', getEnabledServers);
+  const { data: serverInfo } = useSWR('getServerInfo', getServerInfo);
+  const servers = serverInfo?.servers;
 
   // Handle navigation for shared pages
   // Best we can do is sending them to root if there are many running servers
@@ -49,6 +65,13 @@ const Navigation = ({
     } else {
       config = NavigationConfig[servers ? servers[0] : 'shared'];
     }
+  }
+
+  // Drop items whose only audience is a Director or Registry when this server
+  // belongs to no federation. Filtering here (rather than inside each
+  // NavigationItem) keeps the Sidebar and AppBar renderers in agreement.
+  if (serverInfo?.standaloneOrigin) {
+    config = filterFederationOnly(config);
   }
 
   // Per the operator demo feedback: when running multiple browser

--- a/web_ui/frontend/components/layout/Navigation/index.ts
+++ b/web_ui/frontend/components/layout/Navigation/index.ts
@@ -22,6 +22,11 @@ export type StaticNavigationBaseItemProps = {
   // makes the item visible (logical OR with allowedRoles).
   anyScopes?: string[];
   allowedExportTypes?: ExportRes['type'][];
+  // federationOnly hides the item on a server that belongs to no federation
+  // (see ServerInfo.standaloneOrigin). Use it for pages whose only consumer is
+  // a Director or Registry -- rendering them standalone would offer the admin
+  // a control that can never take effect.
+  federationOnly?: boolean;
 };
 
 export type StaticNavigationChildItemProps = StaticNavigationBaseItemProps & {

--- a/web_ui/frontend/helpers/util.ts
+++ b/web_ui/frontend/helpers/util.ts
@@ -6,7 +6,19 @@ const stringToTime = (time: string) => {
   return new Date(Date.parse(time)).toLocaleString();
 };
 
-export const getEnabledServers = async (): Promise<ServerType[]> => {
+export interface ServerInfo {
+  servers: ServerType[];
+  /**
+   * True when this server runs an Origin with Origin.EnableStandaloneMode --
+   * it belongs to no federation, so there is no registry to register at, no
+   * director to advertise to, and nothing consuming its downtime records.
+   * Pages use this to hide federation-only affordances rather than render
+   * them as permanently broken.
+   */
+  standaloneOrigin: boolean;
+}
+
+export const getServerInfo = async (): Promise<ServerInfo> => {
   const response = await fetch('/api/v1.0/servers');
   if (response.ok) {
     const data = await response.json();
@@ -14,13 +26,17 @@ export const getEnabledServers = async (): Promise<ServerType[]> => {
 
     if (servers == undefined) {
       console.error('No servers found', response);
-      return [];
+      return { servers: [], standaloneOrigin: false };
     }
 
-    return servers;
+    return { servers, standaloneOrigin: !!data?.standaloneOrigin };
   }
 
-  return [];
+  return { servers: [], standaloneOrigin: false };
+};
+
+export const getEnabledServers = async (): Promise<ServerType[]> => {
+  return (await getServerInfo()).servers;
 };
 
 export const getOauthEnabledServers = async () => {

--- a/web_ui/server_api.go
+++ b/web_ui/server_api.go
@@ -507,6 +507,12 @@ func mirrorDowntimeToRegistry(ctx *gin.Context, dt server_structs.Downtime, meth
 		return nil
 	}
 
+	// A standalone origin has no registry to mirror to; downtime it records is
+	// purely local bookkeeping for its own operators.
+	if config.IsStandaloneOrigin() {
+		return nil
+	}
+
 	fed, err := config.GetFederation(ctx)
 	if err != nil || fed.RegistryEndpoint == "" {
 		return errors.Wrap(err, "failed to load federation configuration")

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -239,7 +239,13 @@ func getEnabledServers(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(200, gin.H{"servers": enabledServers})
+	// standaloneOrigin tells the web UI that this server deliberately has no
+	// federation behind it, so it can drop the registration status, downtime, and
+	// federation-overview affordances instead of rendering them as broken.
+	ctx.JSON(200, gin.H{
+		"servers":          enabledServers,
+		"standaloneOrigin": config.IsStandaloneOrigin(),
+	})
 }
 
 func getVersionHandler(ctx *gin.Context) {


### PR DESCRIPTION
Adds a standalone mode to the Origin: `Origin.EnableStandaloneMode`.

A standalone Origin belongs to no federation. It does not register at a Registry, does not advertise to a Director, and contacts no other federation service. It is for administrators who want Pelican's managed authorization over a storage backend without operating — or belonging to — a federation.

This is the Origin counterpart of `Cache.EnableSiteLocalMode`, but stricter: a site-local Cache still queries a Director as a client, whereas a standalone Origin makes no federation calls at all.

### A federation of one

Clients never address Origins directly — they ask a federation's discovery endpoint for a Director, then ask that Director which server holds the object. A standalone Origin answers the first question by serving `/.well-known/pelican-configuration` itself, and answers the second by making it unnecessary: the document names **no** Director, and a client that finds none asks the discovery host about the object directly.

That client-side path is `queryObjectServerDirectly`. It HEADs the object at the discovery host and reads the namespace metadata — prefix, whether a token is required, which issuers mint one — off the `X-Pelican-*` headers the Origin already attaches to every response. A HEAD is enough, costs nothing extra, and works whether the object turns out to be public (200), protected (401/403), or absent (404): the headers describe the namespace, not the object.

So there is no redirect and no Director shim. Objects stay where a native Origin already serves them, at their `FederationPrefix`, and the only new server-side surface is the discovery document.

### Scope

- Restricted to the native "v2" backends (`posixv2`, `s3v2`, `httpsv2`, `globusv2`, `ssh`); the XRootD-fronted backends build their configuration from federation metadata. `InitServer` also rejects co-locating a Director/Registry/Cache/Broker module, rejects `Origin.DisableDirectClients` (under which a standalone Origin would refuse every request), rejects a root `FederationPrefix` (which would collide with the Origin's own API routes), and rejects `Federation.DiscoveryUrl` (a standalone Origin belongs to no federation, so naming one contradicts the document it serves).
- The web UI drops the affordances only a Director or Registry could act on (registration status, Downtime, Federation Overview) via a new `standaloneOrigin` field on `GET /api/v1.0/servers`.

### Commits

Seven, each independently reviewable:

1. **`server_structs`: share the Director's client-facing header helpers.** Extracts the `X-Pelican-*` header writers and the longest-namespace-prefix match out of the Director. Pure delegation, no behavior change. Cherry-picks onto `main` on its own and may be worth landing separately, since #3510 (anycast support for the Cache) needs the same helpers.
2. **`client`: resolve and authorize against a federation with no director.** The directorless resolution path and the token-hint mechanism, shaped to reconcile with #3510; the anycast plumbing stays in that PR. Also fixes a pre-existing `DirRespCache` collision between federations sharing a namespace path.
3. **`origin`: add `Origin.EnableStandaloneMode`.** The feature and its startup validation.
4. **`origin`: measure disk usage from the backend.** A pre-existing bug, unrelated to standalone mode except that it removed the last limitation — see below.
5. **`web_ui`**, 6. **`docs`**, 7. **tests.**

### A pre-existing bug this turned up

Disk usage for non-POSIX backends was measured by pointing the Pelican client at the origin's own namespace — asking a Director where to find data the process was already serving. That path needs `config.InitClient`, which **no serve path calls**, so every walk failed with `client has not been initialized`, logged a warning, and reported the export as zero bytes. `TestDiskUsageSuccessPelican` passes only because `fed_test_utils` initializes the client, which is what kept it hidden.

Commit 4 walks the backend directly for the native backends. The XRootD-fronted ones keep the old path, since XRootD holds their storage and there is nothing local to walk.

### Note for reviewers: what a token hint is allowed to do

The client change touches credential acquisition, so the gate on it is worth reading closely. A hint that is honored can send the client to an issuer to register an OAuth client, post a stored refresh token, or raise an interactive login prompt. `canApplyTokenHint` requires two things before any of that:

1. **No Director vouched for the transfer.** Once a Director has named the issuers for a namespace, an object server claiming different ones is either misconfigured or hostile. Provenance is derived from the URL — a federation that publishes no Director endpoint has no Director to do the vouching — so it cannot be forgotten at a call site.
2. **The hint came from the host that published the federation's discovery document.** In a federation of one that host *is* the federation: it already tells clients where the JWKS lives and which issuers to trust, so a claim it makes about its own namespaces is exactly as authoritative as the document they already accepted. Any other endpoint — a cache named with `-c`, a redirect target — is merely somewhere the bytes live, and its hints are ignored. Scheme is compared along with host, so a plaintext endpoint cannot answer for an https discovery host.

A caller who named a credential (`WithToken`, or an external token provider) keeps it; a hint never displaces a chosen credential. Acquisition runs on a generator derived from the job's, so the hint is never written into shared state, and it is coalesced through the job's singleflight under a key naming the hint — a recursive transfer registers one OAuth client, not one per file. A credential the endpoint accepts is published back to the job's generator so sibling files and the checksum request that follows reuse it. A hint that yields the credential just rejected ends the attempt rather than retrying into the same 403.

`queryObjectServerDirectly` is hardened to match: it refuses to follow a redirect off the host it resolved against (the reply chooses the issuer, and Go attaches the caller's bearer token to same-origin hops), and it rejects a reply carrying no namespace metadata rather than reading it as "no token required".

Relatedly, `origin_serve` now returns 403 (rather than 401) when a presented token does not authorize, but **only on a standalone Origin** — federated Origins keep 401, which is what tells rclone and similar clients to re-run their `bearer_token_command`.

### Testing

- `TestStandaloneOriginCliEndToEnd` runs `pelican origin serve` and `pelican object {put,get,ls}` / `token create` as **separate processes** from the built binary, in an environment stripped of `PELICAN_*`, and checks uploaded bytes against the backing directory. `token create` runs with no `--issuer`, so the CLI must discover it from the Origin's discovery document and JWKS.
- `TestStandaloneOriginCliFederatedControl` is the negative control: the same config with standalone mode off must fail to start for want of a discovery endpoint.
- `TestStandaloneOriginServe` covers the wire contract in-process (discovery document, namespace metadata on the object's own response, token hints, and a real client transfer), plus unit tests for each config rejection.
- Two invariants that previously had no test: a **federated** Origin emits no `X-Pelican-*` hint headers (the regression that would leak Director-owned metadata from every federated Origin), and `LongestNSMatch` resolves nested, exact, trailing-slash and root prefixes the way the Director does — the function the "resolves namespaces identically" claim rests on.
- The token-hint tests are built so that removing the retry, removing the Director check, or removing the discovery-host check each makes a test fail: `TestTokenHintAcquiresAndRetries` is the positive case, and `TestTokenHintIgnoredWhenDirectorSupplied` / `TestTokenHintIgnoredFromNonDiscoveryHost` share its fixture so the difference in outcome isolates one half of the gate each.

