### PR TITLE
pstore: use the cache V2 block store as an origin's data store

### DIFF
--- a/.github/scripts/validate-parameters/main.py
+++ b/.github/scripts/validate-parameters/main.py
@@ -40,6 +40,7 @@ VERIFIED_OBJECT_STRUCTURES = [
     "Issuer.AuthorizationTemplates",
     "Issuer.OIDCAuthenticationRequirements",
     "LocalCache.StorageDirs",
+    "Origin.PStoreStorageDirs",
     "Lotman.PolicyDefinitions",
     "Origin.Exports",
     "Registry.CustomRegistrationFields",

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -132,7 +132,10 @@ jobs:
         id: cc
         run: |
           set -x
-          cc_total=`go tool cover -func=${{ matrix.coverprofile }} | grep total | grep -Eo '[0-9]+\.[0-9]+'`
+          # Anchored to the summary line: an unanchored "total" also matches
+          # any function whose name contains it, which makes $GITHUB_OUTPUT
+          # multi-line and fails the step.
+          cc_total=`go tool cover -func=${{ matrix.coverprofile }} | grep -E '^total:' | grep -Eo '[0-9]+\.[0-9]+'`
           echo "cc_total=$cc_total" >> $GITHUB_OUTPUT
 
       - name: Add coverage information to action summary

--- a/backup_keys/backup_keys.go
+++ b/backup_keys/backup_keys.go
@@ -1,0 +1,124 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Package backup_keys derives backup encryption keys from a server's issuer
+// keys.
+//
+// Several subsystems back themselves up, and each one faces the same problem:
+// a backup has to be encrypted, and the key has to still exist when the backup
+// is needed.  Asking an operator to generate and escrow a key per subsystem
+// gets that wrong in both directions -- it is one more secret to lose, and
+// nothing enforces that it was ever set.  A server already holds a secret it
+// cannot function without and already protects carefully: its issuer keys.
+// Deriving from those means the encryption cannot be skipped, and rotating an
+// issuer key does not strand the archives written before the rotation.
+//
+// The derivation is one-way (HKDF-SHA256 over the issuer key's PKCS8 encoding),
+// so a leaked backup key does not yield the issuer key it came from.
+//
+// # Domain separation
+//
+// The label is what keeps subsystems apart.  Without it, every subsystem that
+// derived from the same issuer key would derive the *same* key pair, and
+// possession of any one subsystem's escrowed backup key would open every other
+// subsystem's archives.  Each caller passes its own label, so a key derived for
+// one domain is unrelated to the key derived for another.
+//
+// Labels are permanent: an archive is sealed to the key its label produced, so
+// changing a label makes every archive written under the old one unopenable.
+// Add a label; never edit one.
+package backup_keys
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"io"
+
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/curve25519"
+	"golang.org/x/crypto/hkdf"
+)
+
+const (
+	// LabelDatabase is the domain for the server database's backups.
+	//
+	// This value must never change: it is baked into every database backup
+	// ever written, and an archive whose label no longer derives the same key
+	// cannot be decrypted.
+	LabelDatabase = "pelican-backup-encryption"
+
+	// LabelPStore is the domain for a pstore origin's metadata snapshots.
+	LabelPStore = "pelican-pstore-backup"
+)
+
+// DeriveKeyPair derives a Curve25519 key pair from an issuer JWK for one
+// backup domain.
+//
+// The label provides domain separation, so a key derived for one subsystem
+// cannot open another's archives.  The same issuer key and label always
+// produce the same pair, which is what lets an operator print the private key
+// once and use it years later against archives written in between.
+func DeriveKeyPair(issuerKey jwk.Key, label string) (privateKey, publicKey *[32]byte, err error) {
+	if issuerKey == nil {
+		return nil, nil, errors.New("cannot derive a backup key pair from a nil issuer key")
+	}
+	if label == "" {
+		return nil, nil, errors.New("cannot derive a backup key pair without a domain label")
+	}
+
+	var rawKey any
+	if err := issuerKey.Raw(&rawKey); err != nil {
+		return nil, nil, errors.Wrap(err, "failed to extract raw key from JWK")
+	}
+
+	derPrivateKey, err := x509.MarshalPKCS8PrivateKey(rawKey)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to marshal private key to PKCS8")
+	}
+
+	// Use HKDF-SHA256 to derive a 32-byte Curve25519 private key.  The info
+	// string binds the derived key to one backup domain.
+	hkdfReader := hkdf.New(sha256.New, derPrivateKey, nil, []byte(label))
+
+	privateKey = new([32]byte)
+	if _, err := io.ReadFull(hkdfReader, privateKey[:]); err != nil {
+		return nil, nil, errors.Wrap(err, "failed to derive key via HKDF")
+	}
+
+	publicKey = new([32]byte)
+	curve25519.ScalarBaseMult(publicKey, privateKey)
+
+	return privateKey, publicKey, nil
+}
+
+// KeyPairFromPrivate recovers the public half of a Curve25519 private key.
+//
+// This is the disaster-recovery entry point: an operator who saved the private
+// key printed by a "backup-key" command can hand those 32 bytes back and open
+// an archive without the issuer key it was derived from.
+func KeyPairFromPrivate(private []byte) (privateKey, publicKey *[32]byte, err error) {
+	if len(private) != 32 {
+		return nil, nil, errors.Errorf("a backup private key must be 32 bytes, got %d", len(private))
+	}
+	privateKey = new([32]byte)
+	copy(privateKey[:], private)
+	publicKey = new([32]byte)
+	curve25519.ScalarBaseMult(publicKey, privateKey)
+	return privateKey, publicKey, nil
+}

--- a/backup_keys/backup_keys_test.go
+++ b/backup_keys/backup_keys_test.go
@@ -1,0 +1,155 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package backup_keys
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/hex"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/nacl/box"
+)
+
+// fixedIssuerKey returns a JWK with no randomness in it, so a derivation from
+// it can be pinned to a literal.
+func fixedIssuerKey(t *testing.T) jwk.Key {
+	t.Helper()
+	seed := make([]byte, ed25519.SeedSize)
+	for i := range seed {
+		seed[i] = byte(i)
+	}
+	key, err := jwk.FromRaw(ed25519.NewKeyFromSeed(seed))
+	require.NoError(t, err)
+	return key
+}
+
+func randomIssuerKey(t *testing.T) jwk.Key {
+	t.Helper()
+	raw, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	key, err := jwk.FromRaw(raw)
+	require.NoError(t, err)
+	return key
+}
+
+// TestDatabaseLabelDerivationIsFrozen is the one test in this package that
+// cannot be allowed to fail.
+//
+// Every database backup ever written was sealed to the key this derivation
+// produces.  If a refactor changes the marshalling, the hash, the salt, the
+// info string, or the order of any of it, those archives become undecryptable
+// -- and nothing else in the test suite would notice, because a round trip
+// through the changed code still round-trips.  The vector below was computed
+// with the original implementation in database/backup.go.
+func TestDatabaseLabelDerivationIsFrozen(t *testing.T) {
+	const (
+		wantPriv = "5951391ef185965fd0288a26f5995400e7ba67de89653be3cd4652933621a8e0"
+		wantPub  = "ff4a23a5047c2edc15da7f4c7288a566a34d3cc8a45c88a2fce0e15c9551d172"
+	)
+
+	priv, pub, err := DeriveKeyPair(fixedIssuerKey(t), LabelDatabase)
+	require.NoError(t, err)
+	assert.Equal(t, wantPriv, hex.EncodeToString(priv[:]),
+		"the database backup derivation changed; every existing database backup is now unreadable")
+	assert.Equal(t, wantPub, hex.EncodeToString(pub[:]),
+		"the database backup derivation changed; every existing database backup is now unreadable")
+
+	// The label constant itself is part of the frozen contract: an archive
+	// records nothing about which label sealed it, so renaming the value is
+	// indistinguishable from changing the algorithm.
+	assert.Equal(t, "pelican-backup-encryption", LabelDatabase)
+}
+
+// TestLabelsAreSeparateDomains is the point of taking a label at all: an
+// escrowed pstore backup key must not open a database archive.
+func TestLabelsAreSeparateDomains(t *testing.T) {
+	key := randomIssuerKey(t)
+
+	dbPriv, dbPub, err := DeriveKeyPair(key, LabelDatabase)
+	require.NoError(t, err)
+	psPriv, psPub, err := DeriveKeyPair(key, LabelPStore)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, *dbPriv, *psPriv, "one issuer key must yield unrelated keys per domain")
+	assert.NotEqual(t, *dbPub, *psPub, "one issuer key must yield unrelated keys per domain")
+
+	// Not merely different bytes: a message sealed in one domain must not open
+	// in the other.  This is the property an operator relies on when they hand
+	// a backup custodian one subsystem's key.
+	var nonce [24]byte
+	_, err = rand.Read(nonce[:])
+	require.NoError(t, err)
+	sealed := box.Seal(nil, []byte("database secret"), &nonce, dbPub, dbPriv)
+
+	opened, ok := box.Open(nil, sealed, &nonce, dbPub, dbPriv)
+	require.True(t, ok, "the sealing domain must open its own message")
+	assert.Equal(t, "database secret", string(opened))
+
+	_, ok = box.Open(nil, sealed, &nonce, psPub, psPriv)
+	assert.False(t, ok, "a pstore-domain key must not open a database-domain message")
+}
+
+// TestDerivationIsDeterministicAndKeyBound covers the two properties every
+// caller depends on: re-running the derivation reproduces the key (so it can be
+// printed once and escrowed), and a different issuer key yields a different one.
+func TestDerivationIsDeterministicAndKeyBound(t *testing.T) {
+	key := randomIssuerKey(t)
+
+	first, firstPub, err := DeriveKeyPair(key, LabelPStore)
+	require.NoError(t, err)
+	second, secondPub, err := DeriveKeyPair(key, LabelPStore)
+	require.NoError(t, err)
+	assert.Equal(t, *first, *second)
+	assert.Equal(t, *firstPub, *secondPub)
+
+	other, _, err := DeriveKeyPair(randomIssuerKey(t), LabelPStore)
+	require.NoError(t, err)
+	assert.NotEqual(t, *first, *other)
+}
+
+// TestKeyPairFromPrivate checks the disaster-recovery entry point reproduces
+// the public half, so an escrowed private key alone can open an archive.
+func TestKeyPairFromPrivate(t *testing.T) {
+	priv, pub, err := DeriveKeyPair(randomIssuerKey(t), LabelPStore)
+	require.NoError(t, err)
+
+	recoveredPriv, recoveredPub, err := KeyPairFromPrivate(priv[:])
+	require.NoError(t, err)
+	assert.Equal(t, *priv, *recoveredPriv)
+	assert.Equal(t, *pub, *recoveredPub)
+
+	_, _, err = KeyPairFromPrivate(priv[:31])
+	assert.Error(t, err, "a short key must be refused rather than silently padded")
+}
+
+// TestDeriveKeyPairRejectsBadInput keeps the two mistakes that would otherwise
+// produce a usable-looking key from being silent.
+func TestDeriveKeyPairRejectsBadInput(t *testing.T) {
+	_, _, err := DeriveKeyPair(nil, LabelPStore)
+	assert.Error(t, err)
+
+	_, _, err = DeriveKeyPair(randomIssuerKey(t), "")
+	assert.Error(t, err, "an empty label would silently merge every domain into one")
+}

--- a/cmd/cache_evict.go
+++ b/cmd/cache_evict.go
@@ -123,6 +123,22 @@ func getCacheEvictToken(serverURL, tokenFile string, scopes []token_scopes.Token
 	tc := token.NewWLCGToken()
 	tc.Lifetime = 5 * time.Minute
 	tc.Subject = "admin"
+
+	// This deliberately does *not* use webAPIAdminTokenIssuer, and the two must
+	// not be unified even though they look alike.
+	//
+	// The web API pins a token's issuer to the server's own local issuer URL
+	// (see extractUserFromBearerToken).  Eviction does not go through that
+	// path: it is authorized against the *namespace* ACL, which requires the
+	// issuer to be one the namespace trusts and to have published a JWKS the
+	// cache can fetch (authConfig.getResourceScopes rejects anything else with
+	// "token issuer %s is not one of the trusted issuers").  Those are
+	// different requirements, and the local issuer URL is not generally a
+	// registered issuer for a namespace a cache holds.
+	//
+	// GetServerIssuerURL is what makes the token acceptable here, and what the
+	// working reference in local_cache's makeEvictToken uses.  A test pins the
+	// agreement so a later tidy-up cannot quietly swap it.
 	issuerURL, issuerErr := config.GetServerIssuerURL()
 	if issuerErr != nil || issuerURL == "" {
 		issuerURL = serverURL

--- a/cmd/cache_introspect.go
+++ b/cmd/cache_introspect.go
@@ -72,8 +72,8 @@ The object URL should be a pelican:// or osdf:// URL, or a bare path
 if the federation context is known.
 
 Example:
-  pelican cache introspect etags pelican://my-federation/data/file.dat
-  pelican cache introspect etags /data/file.dat`,
+  pelican-server cache introspect etags pelican://my-federation/data/file.dat
+  pelican-server cache introspect etags /data/file.dat`,
 		Args:         cobra.ExactArgs(1),
 		RunE:         runCacheIntrospectEtags,
 		SilenceUsage: true,
@@ -88,9 +88,9 @@ By default shows the latest cached version. Use --etag to specify
 a particular version, or --instance to specify by instance hash.
 
 Example:
-  pelican cache introspect metadata pelican://my-federation/data/file.dat
-  pelican cache introspect metadata /data/file.dat --etag="abc123"
-  pelican cache introspect metadata --instance=<hash>`,
+  pelican-server cache introspect metadata pelican://my-federation/data/file.dat
+  pelican-server cache introspect metadata /data/file.dat --etag="abc123"
+  pelican-server cache introspect metadata --instance=<hash>`,
 		Args:         cobra.MaximumNArgs(1),
 		RunE:         runCacheIntrospectMetadata,
 		SilenceUsage: true,
@@ -105,8 +105,8 @@ This reads the entire object from disk, decrypts it, and verifies
 that stored checksums (if any) match the actual data.
 
 Example:
-  pelican cache introspect verify pelican://my-federation/data/file.dat
-  pelican cache introspect verify /data/file.dat --etag="abc123"`,
+  pelican-server cache introspect verify pelican://my-federation/data/file.dat
+  pelican-server cache introspect verify /data/file.dat --etag="abc123"`,
 		Args:         cobra.MaximumNArgs(1),
 		RunE:         runCacheIntrospectVerify,
 		SilenceUsage: true,
@@ -128,10 +128,10 @@ Warning: For large caches, this may return many results. Use --limit
 to restrict the number of entries returned.
 
 Examples:
-  pelican cache introspect list
-  pelican cache introspect list '/chtc/staging/**'
-  pelican cache introspect list '*.bin'
-  pelican cache introspect list --limit=50 'pelican://origin.example.com/data/*'`,
+  pelican-server cache introspect list
+  pelican-server cache introspect list '/chtc/staging/**'
+  pelican-server cache introspect list '*.bin'
+  pelican-server cache introspect list --limit=50 'pelican://origin.example.com/data/*'`,
 		Args:         cobra.MaximumNArgs(1),
 		RunE:         runCacheIntrospectList,
 		SilenceUsage: true,
@@ -147,8 +147,8 @@ entries, total bytes claimed by metadata, and per-storage-directory
 breakdown. This is a cheap operation that only scans metadata.
 
 Example:
-  pelican cache introspect stats
-  pelican cache introspect stats --json`,
+  pelican-server cache introspect stats
+  pelican-server cache introspect stats --json`,
 		RunE:         runCacheIntrospectStats,
 		SilenceUsage: true,
 	}
@@ -162,8 +162,8 @@ This is an EXPENSIVE operation that stats every file in the cache's
 storage directories. For large caches this may take significant time.
 
 Example:
-  pelican cache introspect disk-usage
-  pelican cache introspect disk-usage --json`,
+  pelican-server cache introspect disk-usage
+  pelican-server cache introspect disk-usage --json`,
 		RunE:         runCacheIntrospectDiskUsage,
 		SilenceUsage: true,
 	}
@@ -180,10 +180,10 @@ Use --metadata-only or --data-only to run only one scan type.
 The data scan is expensive as it reads and checksums every cached file.
 
 Example:
-  pelican cache introspect consistency
-  pelican cache introspect consistency --metadata-only
-  pelican cache introspect consistency --data-only
-  pelican cache introspect consistency --json`,
+  pelican-server cache introspect consistency
+  pelican-server cache introspect consistency --metadata-only
+  pelican-server cache introspect consistency --data-only
+  pelican-server cache introspect consistency --json`,
 		RunE:         runCacheIntrospectConsistency,
 		SilenceUsage: true,
 	}
@@ -364,13 +364,20 @@ func introspectHTTPPost(serverURL, apiPath string, query url.Values) ([]byte, er
 		return nil, errors.Wrap(err, "failed to read response")
 	}
 	if resp.StatusCode >= 300 {
+		// On 401, name the issuer of the token we minted: the most common
+		// cause is a mismatch with the server's local issuer URL, and a bare
+		// "401 Unauthorized" gives the operator nothing to act on.
+		hint := ""
+		if resp.StatusCode == http.StatusUnauthorized {
+			hint = adminTokenIssuerHint()
+		}
 		var errResp struct {
 			Error string `json:"error"`
 		}
 		if json.Unmarshal(body, &errResp) == nil && errResp.Error != "" {
-			return nil, errors.Errorf("server error (%d): %s", resp.StatusCode, errResp.Error)
+			return nil, errors.Errorf("server error (%d): %s%s", resp.StatusCode, errResp.Error, hint)
 		}
-		return nil, errors.Errorf("server error: %s", resp.Status)
+		return nil, errors.Errorf("server error: %s%s", resp.Status, hint)
 	}
 	return body, nil
 }
@@ -1073,7 +1080,11 @@ func runOnlineConsistencyCheck(serverURL string, query url.Values) (*local_cache
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, errors.Errorf("server responded with %s (body: %s)", resp.Status, strings.TrimSpace(string(body)))
+		hint := ""
+		if resp.StatusCode == http.StatusUnauthorized {
+			hint = adminTokenIssuerHint()
+		}
+		return nil, errors.Errorf("server responded with %s (body: %s)%s", resp.Status, strings.TrimSpace(string(body)), hint)
 	}
 
 	// Shared state for decorator closures (updated atomically by SSE loop).

--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -176,6 +176,127 @@ func constructApiKeyApiURL(serverURLStr string) (*url.URL, error) {
 	return targetURL, nil
 }
 
+// mintedAdminTokenIssuer records the issuer stamped into the admin token this
+// process minted (empty when the operator supplied a token file instead).  A
+// CLI invocation mints at most one such token, so a single package-level value
+// is enough; it exists purely so that an authorization failure can name the
+// issuer that was used.  See adminTokenIssuerHint.
+var mintedAdminTokenIssuer string
+
+// originAndDirectorColocated reports whether the server whose web API we are
+// about to call runs the origin and director modules in the *same* process.
+// That is the one topology where the server's local issuer URL is a sub-path
+// of the web URL instead of the bare web URL itself.
+//
+// A CLI cannot simply ask config.IsServerEnabled(): that state is only ever
+// populated by config.InitServer() inside the serving process.  A CLI runs
+// InitClient (or, as with `cache introspect`, InitServer for the single module
+// it is inspecting), so IsServerEnabled() reports the origin and director as
+// disabled no matter what the server on this host is actually running.  We
+// therefore re-derive the answer from configuration, which is the only channel
+// a separate process shares with the server: Server.Modules is the parameter
+// `pelican-server serve --module <name>` binds to, so a host that records its
+// module list in the config file (or in PELICAN_SERVER_MODULES) is detected
+// exactly.
+//
+// A host whose module list exists only in the serving process's argv leaves no
+// artifact on disk for the CLI to read, so co-location there is *not*
+// detectable from here.  Rather than guess, we report false and let
+// handleAdminApiResponse turn the resulting 401 into a message that names both
+// the issuer we used and the one a co-located server would demand.  (The
+// durable fix is for the server to publish its local issuer URL in the address
+// file it already writes at startup; see config.WriteAddressFile.)
+func originAndDirectorColocated() bool {
+	// If this process *is* the server (in-process callers and tests), its own
+	// module registration is authoritative and matches what the verifier sees.
+	if config.IsServerEnabled(server_structs.OriginType) && config.IsServerEnabled(server_structs.DirectorType) {
+		return true
+	}
+
+	modules := server_structs.NewServerType()
+	for _, name := range param.Server_Modules.GetStringSlice() {
+		// Unknown names are ignored here; `serve` is the command that rejects
+		// them, and a typo must not silently flip the issuer we mint against.
+		_ = modules.SetString(strings.TrimSpace(name))
+	}
+	return modules.IsEnabled(server_structs.OriginType) && modules.IsEnabled(server_structs.DirectorType)
+}
+
+// webAPIAdminTokenIssuer returns the issuer string that the server's web API
+// will require of a locally minted admin token, or "" if it cannot be
+// determined at all.
+//
+// The verifying side is web_ui.extractUserFromBearerToken, reached through
+// web_ui.AuthHandler -> web_ui.GetUserGroups.  It compares the token's `iss`
+// against config.GetLocalIssuerUrl() twice (once before checking the signature,
+// once inside jwt.Validate) and rejects every other value; there is no second
+// bearer-token path that would accept a different spelling.  So the minting
+// side has to reproduce GetLocalIssuerUrl(), *not* config.GetServerIssuerURL(),
+// which is what this helper used to call.  The two diverge in two ways:
+//
+//   - GetServerIssuerURL() honors Server.IssuerUrl and Server.IssuerHostname;
+//     GetLocalIssuerUrl() ignores both and always builds off
+//     Server.ExternalWebUrl.  On a host that sets Server.IssuerUrl, the minted
+//     token was rejected with a bare 401.
+//   - When the origin and director run in one process, the local issuer is
+//     "<Server.ExternalWebUrl>/api/v1.0/origin"; everywhere else it is
+//     Server.ExternalWebUrl verbatim.  A CLI cannot learn that from
+//     config.GetLocalIssuerUrl() either (see originAndDirectorColocated), so we
+//     rebuild the sub-path here.
+//
+// Widening the verifier to accept both spellings was considered and rejected:
+// that is an authorization path, and teaching it to trust a second issuer to
+// paper over a minting bug trades a diagnosable failure for a permanently
+// larger trusted set.  Fix the minter instead.
+//
+// config.GetLocalIssuerUrl() remains the authority for the format; this
+// function must track it, and TestWebAPIAdminTokenIssuerMatchesVerifier pins
+// the two together so a change on either side fails the build.
+func webAPIAdminTokenIssuer(serverURLStr string) string {
+	// Mirror GetLocalIssuerUrl(): build off Server.ExternalWebUrl and
+	// deliberately do not consult Server.IssuerUrl.  Falling back to the URL
+	// the caller is dialing keeps the case of a client-only configuration
+	// (no local server config at all) working as it did before.
+	base := param.Server_ExternalWebUrl.GetString()
+	if base == "" {
+		base = serverURLStr
+	}
+	if base == "" {
+		return ""
+	}
+	if !originAndDirectorColocated() {
+		return base
+	}
+
+	issuerURL, err := url.JoinPath(base, "/api/v1.0/origin")
+	if err != nil {
+		log.Warningf("Failed to construct the co-located origin issuer URL from %q: %v; falling back to %s", base, err, base)
+		return base
+	}
+	return issuerURL
+}
+
+// adminTokenIssuerHint explains, for an authorization failure, which issuer the
+// token this process minted carries and what the server may have wanted
+// instead.  Returns "" when the operator supplied the token, since then the
+// issuer is theirs to explain.
+func adminTokenIssuerHint() string {
+	if mintedAdminTokenIssuer == "" {
+		return ""
+	}
+	hint := fmt.Sprintf("; this CLI minted its own admin token with issuer %q, and the server accepts only tokens whose issuer equals its local issuer URL",
+		mintedAdminTokenIssuer)
+	if !originAndDirectorColocated() {
+		colocated, err := url.JoinPath(mintedAdminTokenIssuer, "/api/v1.0/origin")
+		if err != nil {
+			return hint
+		}
+		hint += fmt.Sprintf(". A server running the origin and director modules in one process expects %q instead; if that describes this host, list both modules under %s in the configuration this CLI reads, or pass a token file with --token",
+			colocated, param.Server_Modules.GetName())
+	}
+	return hint
+}
+
 // Helper function to load or generate token that could access server's web API with admin privileges
 func fetchOrGenerateWebAPIAdminToken(serverURLStr, tokenLocation string) (string, error) {
 	var tok string
@@ -194,18 +315,19 @@ func fetchOrGenerateWebAPIAdminToken(serverURLStr, tokenLocation string) (string
 	}
 	// If no token is provided, generate a new one with current issuer key
 	if tok == "" {
+		// The issuer must be exactly what the server's web API verifies
+		// against -- its local issuer URL -- or the request comes back 401.
+		// webAPIAdminTokenIssuer documents why that is not the same thing as
+		// config.GetServerIssuerURL(), which this used to call.
+		issuerURL := webAPIAdminTokenIssuer(serverURLStr)
+		if issuerURL == "" {
+			return "", errors.Errorf("Cannot determine the issuer for an auto-generated admin token: neither %s nor a server URL is configured; set %s or supply a token file",
+				param.Server_ExternalWebUrl.GetName(), param.Server_ExternalWebUrl.GetName())
+		}
+
 		tc := token.NewWLCGToken()
 		tc.Lifetime = 5 * time.Minute
 		tc.Subject = "admin"
-		// Use GetServerIssuerURL to determine the issuer.  When origin and
-		// director are co-located, the local issuer URL is a sub-path
-		// (e.g. .../api/v1.0/origin) that differs from the base server URL.
-		// GetServerIssuerURL checks Server.IssuerUrl first (which may have
-		// been set in the config file) and falls back to Server.ExternalWebUrl.
-		issuerURL, issuerErr := config.GetServerIssuerURL()
-		if issuerErr != nil || issuerURL == "" {
-			issuerURL = serverURLStr
-		}
 		tc.Issuer = issuerURL
 		tc.AddAudienceAny()
 		tc.AddScopes(token_scopes.WebUi_Access)
@@ -216,6 +338,8 @@ func fetchOrGenerateWebAPIAdminToken(serverURLStr, tokenLocation string) (string
 			log.Debugln("  Subject:", tc.Subject)
 			return "", errors.Wrap(err, "Failed to create the downtime operation token")
 		}
+		log.Debugf("Minted a short-lived web API admin token with issuer %q", issuerURL)
+		mintedAdminTokenIssuer = issuerURL
 		return tok, nil
 	}
 	return tok, nil
@@ -250,6 +374,7 @@ func handleAdminApiResponse(resp *http.Response) ([]byte, error) {
 	// Add specific messages for common auth errors
 	if resp.StatusCode == http.StatusUnauthorized { // 401
 		errMsg += " (check if token is valid or expired)"
+		errMsg += adminTokenIssuerHint()
 	} else if resp.StatusCode == http.StatusForbidden { // 403
 		errMsg += " (check if token has required admin privileges)"
 	}

--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -253,6 +253,15 @@ func originAndDirectorColocated() bool {
 // function must track it, and TestWebAPIAdminTokenIssuerMatchesVerifier pins
 // the two together so a change on either side fails the build.
 func webAPIAdminTokenIssuer(serverURLStr string) string {
+	// A running server records the issuer it will accept in its address file.
+	// That is authoritative and needs no inference, so prefer it: the module
+	// set a server was started with may exist only in its argv, where nothing
+	// this process can read will reveal it.  A server too old to write the key,
+	// or one that is not running, falls through to the derivation below.
+	if addr, err := config.ReadAddressFile(); err == nil && addr.LocalIssuerURL != "" {
+		return addr.LocalIssuerURL
+	}
+
 	// Mirror GetLocalIssuerUrl(): build off Server.ExternalWebUrl and
 	// deliberately do not consult Server.IssuerUrl.  Falling back to the URL
 	// the caller is dialing keeps the case of a client-only configuration

--- a/cmd/cmd_utils_test.go
+++ b/cmd/cmd_utils_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -234,4 +235,33 @@ func TestAdminTokenIssuerHintNamesBothIssuers(t *testing.T) {
 		assert.Contains(t, hint, minted)
 		assert.NotContains(t, hint, param.Server_Modules.GetName())
 	})
+}
+
+// TestEvictTokenIssuerIsNotTheWebAPIIssuer pins that the two admin-token
+// paths stay distinct.
+//
+// They look interchangeable and are not. The web API pins a token's issuer to
+// the server's local issuer URL; eviction is authorized against the namespace
+// ACL, which requires an issuer the namespace trusts and whose JWKS the cache
+// can fetch. Unifying them would produce a token that one verifier accepts and
+// the other rejects, and the symptom would be a 403 from a command that had
+// been working.
+func TestEvictTokenIssuerIsNotTheWebAPIIssuer(t *testing.T) {
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+
+	// A co-located origin+director is the case where the web API's issuer grows
+	// the /api/v1.0/origin sub-path and the two answers visibly diverge.
+	viper.Set("Server.ExternalWebUrl", "https://cache.example.com:8444")
+	viper.Set("Server.Modules", []string{"origin", "director"})
+
+	webAPI := webAPIAdminTokenIssuer("https://cache.example.com:8444")
+	evict, err := config.GetServerIssuerURL()
+	require.NoError(t, err)
+
+	require.NotEmpty(t, webAPI)
+	require.NotEmpty(t, evict)
+	assert.NotEqual(t, webAPI, evict,
+		"the web API and namespace-ACL paths require different issuers; if these have become "+
+			"equal, one of the two verifiers has changed and cache evict or the web API is about to break")
 }

--- a/cmd/cmd_utils_test.go
+++ b/cmd/cmd_utils_test.go
@@ -21,10 +21,19 @@
 package main
 
 import (
+	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/token"
 )
 
 func TestResolveTokenOptions(t *testing.T) {
@@ -75,5 +84,154 @@ func TestResolveTokenOptions(t *testing.T) {
 			"source-token": "/tmp/src",
 		}))
 		assert.Len(t, opts, 2)
+	})
+}
+
+// resetIssuerTestState gives a subtest a clean config with a usable issuer-key
+// directory, and puts the global config back the way it found it.
+func resetIssuerTestState(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		mintedAdminTokenIssuer = ""
+		server_utils.ResetTestState()
+	})
+	mintedAdminTokenIssuer = ""
+	server_utils.ResetTestState()
+	require.NoError(t, param.ConfigBase.Set(t.TempDir()))
+	// An empty key directory: the issuer key is generated on first use, which
+	// is the state of a server host that has not minted anything yet.
+	require.NoError(t, param.IssuerKeysDirectory.Set(filepath.Join(t.TempDir(), "issuer-keys")))
+}
+
+// mintedIssuer returns the `iss` of a freshly auto-generated admin token.
+func mintedIssuer(t *testing.T, serverURL string) string {
+	t.Helper()
+	raw, err := fetchOrGenerateWebAPIAdminToken(serverURL, "")
+	require.NoError(t, err)
+	tok, err := token.UnsafeParseClaims(raw)
+	require.NoError(t, err)
+	return tok.Issuer()
+}
+
+// TestWebAPIAdminTokenIssuerMatchesVerifier pins the minting side of the
+// auto-generated web-API admin token to the verifying side.
+//
+// web_ui.extractUserFromBearerToken (reached from web_ui.AuthHandler) accepts a
+// bearer token only when its issuer is exactly config.GetLocalIssuerUrl().  The
+// assertions below therefore compare against GetLocalIssuerUrl() rather than
+// any literal URL, so that if either side changes its notion of the local
+// issuer the test fails instead of quietly re-introducing the 401.
+func TestWebAPIAdminTokenIssuerMatchesVerifier(t *testing.T) {
+	t.Run("StandaloneServer", func(t *testing.T) {
+		resetIssuerTestState(t)
+		require.NoError(t, param.Server_ExternalWebUrl.Set("https://standalone.example.com:8444"))
+
+		assert.Equal(t, config.GetLocalIssuerUrl(), webAPIAdminTokenIssuer("https://dialed.example.com:8444"))
+		assert.Equal(t, config.GetLocalIssuerUrl(), mintedIssuer(t, "https://dialed.example.com:8444"))
+	})
+
+	t.Run("IgnoresServerIssuerUrl", func(t *testing.T) {
+		// The original bug: the token was minted from
+		// config.GetServerIssuerURL(), which honors Server.IssuerUrl, while the
+		// verifier pins config.GetLocalIssuerUrl(), which does not.
+		resetIssuerTestState(t)
+		require.NoError(t, param.Server_ExternalWebUrl.Set("https://server.example.com:8444"))
+		require.NoError(t, param.Server_IssuerUrl.Set("https://issuer.example.com"))
+
+		serverIssuer, err := config.GetServerIssuerURL()
+		require.NoError(t, err)
+		require.NotEqual(t, config.GetLocalIssuerUrl(), serverIssuer,
+			"test is vacuous unless the two issuer notions actually differ")
+
+		minted := mintedIssuer(t, "https://server.example.com:8444")
+		assert.Equal(t, config.GetLocalIssuerUrl(), minted)
+		assert.NotEqual(t, serverIssuer, minted)
+	})
+
+	t.Run("NoWebUrlFallsBackToDialedServer", func(t *testing.T) {
+		// A client-only configuration has no Server.ExternalWebUrl; the URL the
+		// operator pointed us at is the best available stand-in, and is what
+		// the remote server's own ExternalWebUrl normally is.
+		resetIssuerTestState(t)
+		require.Empty(t, param.Server_ExternalWebUrl.GetString())
+
+		assert.Equal(t, "https://remote.example.com:8444", webAPIAdminTokenIssuer("https://remote.example.com:8444"))
+	})
+
+	t.Run("NoIssuerAtAllIsAnError", func(t *testing.T) {
+		resetIssuerTestState(t)
+		_, err := fetchOrGenerateWebAPIAdminToken("", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Cannot determine the issuer")
+	})
+}
+
+// TestWebAPIAdminTokenIssuerColocatedOriginAndDirector covers the topology the
+// bug was actually reported on: an origin and a director in one process, where
+// the server's local issuer URL is a sub-path of the web URL.
+//
+// The expected value is not written out here.  It is captured from
+// config.GetLocalIssuerUrl() in a process that has registered both modules --
+// i.e. exactly what the serving process computes -- and the CLI-side derivation
+// is then required to reproduce it from configuration alone.
+func TestWebAPIAdminTokenIssuerColocatedOriginAndDirector(t *testing.T) {
+	const webUrl = "https://colocated.example.com:8444"
+
+	// Step 1: what the *server* will require.  InitServer is what registers the
+	// enabled modules, which is the input config.GetLocalIssuerUrl() keys off.
+	resetIssuerTestState(t)
+	require.NoError(t, param.Server_ExternalWebUrl.Set(webUrl))
+	require.NoError(t, config.InitServer(context.Background(),
+		server_structs.OriginType|server_structs.DirectorType))
+	expected := config.GetLocalIssuerUrl()
+	require.NotEqual(t, webUrl, expected,
+		"a co-located origin+director must use a local issuer distinct from the web URL")
+
+	// Step 2: what a CLI process on that host can work out.  No module is
+	// registered here -- config.InitServer was never called with them -- which
+	// is precisely why config.GetLocalIssuerUrl() cannot be used directly.
+	resetIssuerTestState(t)
+	require.NoError(t, param.Server_ExternalWebUrl.Set(webUrl))
+	require.NoError(t, param.Server_Modules.Set([]string{"origin", "director"}))
+
+	require.False(t, config.IsServerEnabled(server_structs.OriginType),
+		"a CLI process must not appear to have the origin module registered")
+	assert.NotEqual(t, expected, config.GetLocalIssuerUrl(),
+		"config.GetLocalIssuerUrl() alone cannot see the co-located topology from a CLI")
+
+	assert.Equal(t, expected, webAPIAdminTokenIssuer(webUrl))
+	assert.Equal(t, expected, mintedIssuer(t, webUrl))
+}
+
+// TestAdminTokenIssuerHintNamesBothIssuers checks that an authorization failure
+// is diagnosable: when the CLI cannot tell that the server is a co-located
+// origin+director, the 401 must at least report the issuer it used and the one
+// such a server would have wanted.
+func TestAdminTokenIssuerHintNamesBothIssuers(t *testing.T) {
+	t.Run("NoHintWhenOperatorSuppliedTheToken", func(t *testing.T) {
+		resetIssuerTestState(t)
+		assert.Empty(t, adminTokenIssuerHint())
+	})
+
+	t.Run("NamesTheMintedAndColocatedIssuers", func(t *testing.T) {
+		resetIssuerTestState(t)
+		require.NoError(t, param.Server_ExternalWebUrl.Set("https://server.example.com:8444"))
+		minted := mintedIssuer(t, "https://server.example.com:8444")
+
+		hint := adminTokenIssuerHint()
+		assert.Contains(t, hint, minted)
+		assert.Contains(t, hint, minted+"/api/v1.0/origin")
+		assert.Contains(t, hint, param.Server_Modules.GetName())
+	})
+
+	t.Run("NoColocatedAdviceWhenAlreadyColocated", func(t *testing.T) {
+		resetIssuerTestState(t)
+		require.NoError(t, param.Server_ExternalWebUrl.Set("https://server.example.com:8444"))
+		require.NoError(t, param.Server_Modules.Set([]string{"origin", "director"}))
+		minted := mintedIssuer(t, "https://server.example.com:8444")
+
+		hint := adminTokenIssuerHint()
+		assert.Contains(t, hint, minted)
+		assert.NotContains(t, hint, param.Server_Modules.GetName())
 	})
 }

--- a/cmd/origin_introspect.go
+++ b/cmd/origin_introspect.go
@@ -1,0 +1,373 @@
+//go:build server
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Introspecting a running origin's storage backend.
+//
+// The offline `pstore` commands need the origin stopped, because the store
+// holds an exclusive lock on its directory.  These ask the running origin
+// instead, over its administrative storage API.
+//
+// Only questions that are meaningful against a moving target are available.
+// Listing, stat, usage, and digests describe a moment.  A consistency check
+// does not -- scanning an index while it is being rewritten produces findings
+// that cannot be distinguished from real ones -- so fsck stays with the
+// offline commands, where its answers mean something.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/utils"
+)
+
+var (
+	originIntrospectServer string
+	originIntrospectToken  string
+	originIntrospectJSON   bool
+	originIntrospectLimit  int
+
+	originIntrospectCmd = &cobra.Command{
+		Use:   "introspect",
+		Short: "Inspect a running origin's storage backend",
+		Long: `Inspect the storage backend of an origin that is currently running.
+
+These commands ask the origin over its administrative API, so they work while
+it is serving. They are the live counterpart to "pelican-server origin pstore", which
+reads the store directly and therefore requires the origin to be stopped.
+
+CURRENTLY PSTORE ONLY. The endpoints these use exist only when the origin is
+configured with Origin.StorageType "pstore"; against any other backend the
+origin does not register them and these commands report that plainly. A POSIX
+origin's storage can be inspected with ordinary filesystem tools, which is why
+it has no equivalent.
+
+Consistency checking is deliberately absent here. Scanning an index while it is
+being written produces findings indistinguishable from real problems, so
+"pelican-server origin pstore fsck" remains an offline command.
+
+These commands authenticate to the origin as an administrator. Run on the
+origin host, no token is needed: a short-lived admin token is minted locally
+with the origin's issuer key. Elsewhere -- or when that key is not readable --
+pass --token pointing at a file holding an administrator token.`,
+		SilenceUsage: true,
+	}
+
+	originIntrospectLsCmd = &cobra.Command{
+		Use:          "ls [path]",
+		Short:        "List a directory in the running origin's store",
+		Args:         cobra.MaximumNArgs(1),
+		RunE:         runIntrospectLs,
+		SilenceUsage: true,
+	}
+
+	originIntrospectStatCmd = &cobra.Command{
+		Use:          "stat <path>",
+		Short:        "Show an object's metadata from the running origin",
+		Args:         cobra.ExactArgs(1),
+		RunE:         runIntrospectStat,
+		SilenceUsage: true,
+	}
+
+	originIntrospectDigestCmd = &cobra.Command{
+		Use:          "digest <path>",
+		Short:        "Show an object's recorded checksums from the running origin",
+		Args:         cobra.ExactArgs(1),
+		RunE:         runIntrospectDigest,
+		SilenceUsage: true,
+	}
+
+	originIntrospectUsageCmd = &cobra.Command{
+		Use:          "usage",
+		Short:        "Report how much of the store is in use",
+		Args:         cobra.NoArgs,
+		RunE:         runIntrospectUsage,
+		SilenceUsage: true,
+	}
+)
+
+func init() {
+	originCmd.AddCommand(originIntrospectCmd)
+	originIntrospectCmd.AddCommand(originIntrospectLsCmd)
+	originIntrospectCmd.AddCommand(originIntrospectStatCmd)
+	originIntrospectCmd.AddCommand(originIntrospectDigestCmd)
+	originIntrospectCmd.AddCommand(originIntrospectUsageCmd)
+
+	originIntrospectCmd.PersistentFlags().StringVar(&originIntrospectServer, "server", "",
+		"Origin web URL (defaults to this host's Server.ExternalWebUrl)")
+	originIntrospectCmd.PersistentFlags().StringVarP(&originIntrospectToken, "token", "t", "",
+		"Path to admin token file (auto-generated from the local issuer key if not provided)")
+	originIntrospectCmd.PersistentFlags().BoolVar(&originIntrospectJSON, "json", false,
+		"Emit raw JSON instead of a table")
+	originIntrospectLsCmd.Flags().IntVar(&originIntrospectLimit, "limit", 1000,
+		"Maximum entries to return per request")
+}
+
+// storageEntry mirrors the API's entry representation.
+type storageEntry struct {
+	Name     string    `json:"name"`
+	Path     string    `json:"path"`
+	IsDir    bool      `json:"isDir"`
+	Size     int64     `json:"size"`
+	Modified time.Time `json:"modified"`
+	ETag     string    `json:"etag"`
+}
+
+type storageListResult struct {
+	Backend string         `json:"backend"`
+	Path    string         `json:"path"`
+	Entries []storageEntry `json:"entries"`
+	More    bool           `json:"more"`
+}
+
+type storageUsageResult struct {
+	Backend       string `json:"backend"`
+	UsedBytes     int64  `json:"usedBytes"`
+	CapacityBytes int64  `json:"capacityBytes"`
+}
+
+type storageDigestResult struct {
+	Backend string `json:"backend"`
+	Path    string `json:"path"`
+	Digest  string `json:"digest"`
+}
+
+// introspectGet calls the origin's storage API and decodes the result.
+func introspectGet(cmd *cobra.Command, endpoint string, query url.Values, out any) error {
+	if err := config.InitClient(); err != nil {
+		return errors.Wrap(err, "failed to initialize configuration")
+	}
+
+	base := originIntrospectServer
+	if base == "" {
+		base = param.Server_ExternalWebUrl.GetString()
+	}
+	if base == "" {
+		return errors.New("no origin URL; pass --server or configure Server.ExternalWebUrl")
+	}
+	target, err := url.Parse(strings.TrimSuffix(base, "/") + "/api/v1.0/origin/storage/pstore" + endpoint)
+	if err != nil {
+		return errors.Wrap(err, "the origin URL is not valid")
+	}
+	if query != nil {
+		target.RawQuery = query.Encode()
+	}
+
+	// Standard admin-token discovery: read --token if given, otherwise mint a
+	// short-lived one with the local issuer key.  Same helper (and so the same
+	// contract) as the other administrative CLIs.
+	tok, err := fetchOrGenerateWebAPIAdminToken(base, originIntrospectToken)
+	if err != nil {
+		return errors.Wrap(err, "failed to obtain an administrator token")
+	}
+
+	req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet, target.String(), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+tok)
+
+	resp, err := config.GetClient().Do(req)
+	if err != nil {
+		return errors.Wrapf(err, "cannot reach the origin at %s", base)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "failed to read the origin's response")
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound:
+		// Distinguish "no such object" from "this origin has no storage API",
+		// which is what a non-pstore origin returns for every route here.
+		var apiResp server_structs.SimpleApiResp
+		if json.Unmarshal(body, &apiResp) == nil && apiResp.Msg != "" {
+			return errors.New(apiResp.Msg)
+		}
+		return errors.New("the origin has no storage introspection API; " +
+			"these commands require Origin.StorageType \"pstore\"")
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return errors.New("the origin rejected the token; these commands require an administrator, " +
+			"and the locally-minted token is only accepted by the origin whose issuer key signed it")
+	default:
+		var apiResp server_structs.SimpleApiResp
+		if json.Unmarshal(body, &apiResp) == nil && apiResp.Msg != "" {
+			return errors.Errorf("the origin returned %d: %s", resp.StatusCode, apiResp.Msg)
+		}
+		return errors.Errorf("the origin returned %d", resp.StatusCode)
+	}
+
+	if originIntrospectJSON {
+		fmt.Println(string(body))
+		return errSuppressOutput
+	}
+	return errors.Wrap(json.Unmarshal(body, out), "the origin's response could not be decoded")
+}
+
+// errSuppressOutput signals that --json already printed everything.
+var errSuppressOutput = errors.New("output already written")
+
+func introspectPathArg(args []string) string {
+	if len(args) == 0 {
+		return "/"
+	}
+	if !strings.HasPrefix(args[0], "/") {
+		return "/" + args[0]
+	}
+	return args[0]
+}
+
+// introspectEscapePath renders an object path as URL path segments.
+//
+// Object names are arbitrary bytes as far as the store is concerned, and a
+// path pasted straight into a URL stops being a path the moment it contains a
+// character the URL grammar claims.  A '?' turns the rest of the name into a
+// query string -- which the request then overwrites with its own -- so
+// `stat "/data/f?v=1"` would quietly stat `/data/f` and report on the wrong
+// object; '#' truncates the name the same way.  Escaping per segment (rather
+// than escaping the whole path, which would also escape the separators) keeps
+// the structure and neutralises the content.
+func introspectEscapePath(objectPath string) string {
+	var b strings.Builder
+	for _, segment := range strings.Split(objectPath, "/") {
+		if segment == "" {
+			continue
+		}
+		b.WriteByte('/')
+		b.WriteString(url.PathEscape(segment))
+	}
+	if b.Len() == 0 {
+		return "/"
+	}
+	return b.String()
+}
+
+func runIntrospectLs(cmd *cobra.Command, args []string) error {
+	path := introspectPathArg(args)
+	query := url.Values{}
+	query.Set("limit", fmt.Sprint(originIntrospectLimit))
+
+	var result storageListResult
+	if err := introspectGet(cmd, "/ls"+introspectEscapePath(path), query, &result); err != nil {
+		if errors.Is(err, errSuppressOutput) {
+			return nil
+		}
+		return err
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+	fmt.Fprintln(w, "MODE\tSIZE\tMODIFIED\tNAME")
+	for _, e := range result.Entries {
+		kind, size := "-", utils.HumanBytes(e.Size)
+		name := e.Name
+		if e.IsDir {
+			kind, size = "d", "-"
+			name += "/"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", kind, size, e.Modified.Format(time.RFC3339), name)
+	}
+	if result.More {
+		fmt.Fprintf(w, "\n(more entries; raise --limit or page with the API's \"after\")\n")
+	}
+	return nil
+}
+
+func runIntrospectStat(cmd *cobra.Command, args []string) error {
+	var e storageEntry
+	if err := introspectGet(cmd, "/stat"+introspectEscapePath(introspectPathArg(args)), nil, &e); err != nil {
+		if errors.Is(err, errSuppressOutput) {
+			return nil
+		}
+		return err
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+	fmt.Fprintf(w, "Path:\t%s\n", e.Path)
+	if e.IsDir {
+		fmt.Fprintf(w, "Type:\tdirectory\n")
+	} else {
+		fmt.Fprintf(w, "Type:\tobject\n")
+		fmt.Fprintf(w, "Size:\t%d (%s)\n", e.Size, utils.HumanBytes(e.Size))
+		if e.ETag != "" {
+			fmt.Fprintf(w, "ETag:\t%s\n", e.ETag)
+		}
+	}
+	fmt.Fprintf(w, "Modified:\t%s\n", e.Modified.Format(time.RFC3339))
+	return nil
+}
+
+func runIntrospectDigest(cmd *cobra.Command, args []string) error {
+	var result storageDigestResult
+	if err := introspectGet(cmd, "/digest"+introspectEscapePath(introspectPathArg(args)), nil, &result); err != nil {
+		if errors.Is(err, errSuppressOutput) {
+			return nil
+		}
+		return err
+	}
+	if result.Digest == "" {
+		return errors.Errorf("no checksums recorded for %s", result.Path)
+	}
+	for _, entry := range strings.Split(result.Digest, ", ") {
+		name, value, _ := strings.Cut(entry, "=")
+		fmt.Printf("%s\t%s\n", name, value)
+	}
+	return nil
+}
+
+func runIntrospectUsage(cmd *cobra.Command, args []string) error {
+	var result storageUsageResult
+	if err := introspectGet(cmd, "/usage", nil, &result); err != nil {
+		if errors.Is(err, errSuppressOutput) {
+			return nil
+		}
+		return err
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+	fmt.Fprintf(w, "Backend:\t%s\n", result.Backend)
+	fmt.Fprintf(w, "Used:\t%s\n", utils.HumanBytes(result.UsedBytes))
+	if result.CapacityBytes > 0 {
+		fmt.Fprintf(w, "Capacity:\t%s (%.1f%% used)\n", utils.HumanBytes(result.CapacityBytes),
+			100*float64(result.UsedBytes)/float64(result.CapacityBytes))
+	} else {
+		fmt.Fprintf(w, "Capacity:\tunbounded\n")
+	}
+	return nil
+}

--- a/cmd/origin_introspect_test.go
+++ b/cmd/origin_introspect_test.go
@@ -1,0 +1,186 @@
+//go:build server
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/token"
+	"github.com/pelicanplatform/pelican/token_scopes"
+)
+
+// setupIntrospectTest isolates the package-level flag variables and viper
+// state that `pelican-server origin introspect` reads, so each subtest starts clean
+// and leaves nothing behind for the rest of the cmd package.
+func setupIntrospectTest(t *testing.T) {
+	t.Helper()
+
+	origServer, origToken, origJSON := originIntrospectServer, originIntrospectToken, originIntrospectJSON
+	t.Cleanup(func() {
+		originIntrospectServer, originIntrospectToken, originIntrospectJSON = origServer, origToken, origJSON
+		server_utils.ResetTestState()
+	})
+
+	server_utils.ResetTestState()
+	originIntrospectServer, originIntrospectToken, originIntrospectJSON = "", "", false
+	require.NoError(t, param.ConfigBase.Set(t.TempDir()))
+}
+
+// introspectTestCmd is a stand-in for the real cobra command; introspectGet
+// only ever uses its Context.
+func introspectTestCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	return cmd
+}
+
+// captureAuthOrigin stands up a fake origin that records the Authorization
+// header it was handed and answers every request with a valid usage payload.
+func captureAuthOrigin(t *testing.T, authHeader *string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*authHeader = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"backend":"pstore","usedBytes":42,"capacityBytes":100}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestIntrospectUsesTokenFile confirms that --token is treated as a path to a
+// file holding a token (the convention shared with `pelican cache introspect`
+// and `pelican downtime`), and that the file's contents are what reaches the
+// origin.
+func TestIntrospectUsesTokenFile(t *testing.T) {
+	setupIntrospectTest(t)
+
+	var seen string
+	srv := captureAuthOrigin(t, &seen)
+
+	tokenFile := filepath.Join(t.TempDir(), "admin-token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("a-token-from-a-file\n"), 0600))
+
+	originIntrospectServer = srv.URL
+	originIntrospectToken = tokenFile
+
+	var result storageUsageResult
+	require.NoError(t, introspectGet(introspectTestCmd(), "/usage", nil, &result))
+
+	// The trailing newline must be trimmed, and the file's contents used
+	// verbatim -- not interpreted as a literal token, and not replaced by a
+	// freshly minted one.
+	assert.Equal(t, "Bearer a-token-from-a-file", seen)
+	assert.Equal(t, int64(42), result.UsedBytes)
+}
+
+// TestIntrospectMissingTokenFileErrors confirms that a --token pointing at
+// nothing is reported as an error, rather than being treated as a literal
+// token or quietly falling back to minting one.
+func TestIntrospectMissingTokenFileErrors(t *testing.T) {
+	setupIntrospectTest(t)
+
+	var seen string
+	srv := captureAuthOrigin(t, &seen)
+
+	originIntrospectServer = srv.URL
+	originIntrospectToken = filepath.Join(t.TempDir(), "does-not-exist")
+
+	var result storageUsageResult
+	err := introspectGet(introspectTestCmd(), "/usage", nil, &result)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to obtain an administrator token")
+	assert.Contains(t, err.Error(), "Token file not found")
+	// The request must never have been made.
+	assert.Empty(t, seen)
+}
+
+// TestIntrospectMintsAdminTokenWithoutFile is the point of the change: with no
+// --token at all, the command mints its own short-lived admin token from the
+// local issuer key. The minted token is checked against the same conditions
+// web_ui.AuthHandler and web_ui.AdminAuthHandler impose on the origin side --
+// signed by the issuer key, issuer pinned to the local issuer URL, and a
+// subject that maps to an administrator.
+func TestIntrospectMintsAdminTokenWithoutFile(t *testing.T) {
+	setupIntrospectTest(t)
+
+	var seen string
+	srv := captureAuthOrigin(t, &seen)
+
+	// A key directory with no key in it: the issuer key is generated on
+	// first use, which is what an origin host has.
+	require.NoError(t, param.IssuerKeysDirectory.Set(filepath.Join(t.TempDir(), "issuer-keys")))
+	require.NoError(t, param.Server_ExternalWebUrl.Set(srv.URL))
+
+	originIntrospectServer = srv.URL
+	originIntrospectToken = ""
+
+	var result storageUsageResult
+	require.NoError(t, introspectGet(introspectTestCmd(), "/usage", nil, &result))
+
+	raw, found := strings.CutPrefix(seen, "Bearer ")
+	require.True(t, found, "no bearer token was sent; got %q", seen)
+
+	// Signature must verify against this server's public JWKS -- the
+	// "private key is available" half of the fallback.
+	jwks, err := config.GetIssuerPublicJWKS()
+	require.NoError(t, err)
+	tok, err := token.VerifyWithKeysetStrict(raw, jwks)
+	require.NoError(t, err)
+
+	// web_ui.extractUserFromBearerToken pins the issuer to
+	// config.GetLocalIssuerUrl() before trusting the subject.
+	assert.Equal(t, config.GetLocalIssuerUrl(), tok.Issuer())
+
+	// web_ui.CheckAdmin grants server.admin to the built-in "admin"
+	// username, which is where this token's admin authority comes from.
+	assert.Equal(t, "admin", tok.Subject())
+
+	scope, ok := tok.Get("scope")
+	require.True(t, ok, "minted token carries no scope claim")
+	assert.Contains(t, scope, token_scopes.WebUi_Access.String())
+
+	assert.Equal(t, int64(42), result.UsedBytes)
+}
+
+// TestIntrospectTokenFlagIsAFileLocation guards the documented contract: the
+// flag is a path, it has the same `-t` shorthand as the sibling admin
+// commands, and no environment variable is advertised as a source of tokens.
+func TestIntrospectTokenFlagIsAFileLocation(t *testing.T) {
+	flag := originIntrospectCmd.PersistentFlags().Lookup("token")
+	require.NotNil(t, flag)
+	assert.Equal(t, "t", flag.Shorthand)
+	assert.Contains(t, flag.Usage, "file")
+	assert.NotContains(t, flag.Usage, "PELICAN_ADMIN_TOKEN")
+	assert.NotContains(t, originIntrospectCmd.Long, "PELICAN_ADMIN_TOKEN")
+}

--- a/cmd/origin_pstore.go
+++ b/cmd/origin_pstore.go
@@ -1,0 +1,976 @@
+//go:build server
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Operator commands for a pstore-backed origin.
+//
+// A pstore keeps its namespace in an encrypted embedded database and its
+// object data in encrypted block files, so none of it can be inspected with
+// ls, du, or md5sum the way a POSIX origin's storage can.  These commands are
+// the substitute.
+//
+// They all require the origin to be stopped: the store takes its directory
+// lock exclusively, and a consistency check against a live origin would be
+// racing writes anyway.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/local_cache"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/pstore"
+	"github.com/pelicanplatform/pelican/utils"
+)
+
+var (
+	pstoreRepair      bool
+	pstoreDeep        bool
+	pstoreKeyFile     string
+	pstoreFileKeyFile string
+
+	pstoreExportTo  string
+	pstoreVerify    bool
+	pstoreDryRun    bool
+	pstoreLongList  bool
+	pstoreRecursive bool
+	pstoreResume    bool
+
+	originPStoreCmd = &cobra.Command{
+		Use:   "pstore",
+		Short: "Inspect and repair a Pelican store",
+		Long: `Inspect the contents of an origin backed by the Pelican store ("pstore").
+
+A pstore keeps its namespace in an encrypted database and its objects in
+encrypted block files, so its contents cannot be examined with ordinary
+filesystem tools. These commands read the store directly.
+
+The origin must be stopped: the store holds its directory lock exclusively.
+
+The store location comes from Origin.PStoreLocation, or from --location.`,
+		SilenceUsage: true,
+	}
+
+	originPStoreLsCmd = &cobra.Command{
+		Use:   "ls [path]",
+		Short: "List a directory in the store",
+		Long: `List the direct children of a directory inside the store.
+
+Examples:
+  pelican-server origin pstore ls /
+  pelican-server origin pstore ls -l /data
+  pelican-server origin pstore ls -R /data`,
+		Args:         cobra.MaximumNArgs(1),
+		RunE:         runPStoreLs,
+		SilenceUsage: true,
+	}
+
+	originPStoreStatCmd = &cobra.Command{
+		Use:          "stat <path>",
+		Short:        "Show an object's metadata",
+		Args:         cobra.ExactArgs(1),
+		RunE:         runPStoreStat,
+		SilenceUsage: true,
+	}
+
+	originPStoreDuCmd = &cobra.Command{
+		Use:   "du [path]",
+		Short: "Report space used",
+		Long: `Report the space a subtree occupies, and the store's overall usage.
+
+Sizes are object content lengths; the store's total additionally reflects the
+per-block overhead that encrypted blocks carry on disk.`,
+		Args:         cobra.MaximumNArgs(1),
+		RunE:         runPStoreDu,
+		SilenceUsage: true,
+	}
+
+	originPStoreFsckCmd = &cobra.Command{
+		Use:   "fsck",
+		Short: "Check the store's internal consistency",
+		Long: `Check the store for inconsistencies and optionally repair them.
+
+Reports directory entries whose object data is missing, object versions no
+entry refers to, writes that never completed, and usage counters that have
+drifted.
+
+Without --repair nothing is modified. With it, unservable entries are removed,
+orphaned versions are queued for reclamation, and the counters are resynced.
+
+--deep additionally reads every object back and checks it against the
+checksums recorded when it was written. That is the only way to detect at-rest
+corruption -- a flipped bit in a block file -- since every other check reads
+only the catalog. It costs a full pass over the data.`,
+		Args:         cobra.NoArgs,
+		RunE:         runPStoreFsck,
+		SilenceUsage: true,
+	}
+
+	originPStoreBackupCmd = &cobra.Command{
+		Use:   "metadata-backup <file>",
+		Short: "Back up the store's metadata (not its object data)",
+		Long: `Back up the store's metadata to a file.
+
+THIS DOES NOT BACK UP OBJECT DATA. It covers the catalog: the directory tree,
+and each object's size, checksums, and where its blocks live. Restoring it
+gives back the namespace, not the bytes.
+
+An origin cannot re-fetch what it loses. Object data on disk is encrypted and
+named by hash; the namespace, each object's data key, its size, and its
+checksums all live in the catalog, so a store whose catalog is gone is a
+directory of unreadable bytes.
+
+A metadata backup covers the catalog only. Restoring one is useful only
+alongside:
+
+  - the object data, which ordinary filesystem backup tools handle; and
+  - masterkey.json in the store directory, which wraps the encryption key and
+    is itself protected by the origin's issuer keys.
+
+The backup is always encrypted. A snapshot is a logical dump: it holds every
+object path and the salt that keeps on-disk filenames unguessable, so there is
+no option to write one in the clear.
+
+The body is encrypted under a key belonging to this file alone, derived from the
+origin's backup key and a random salt stored in the file. The backup key itself
+travels inside the file, sealed to every issuer key that is current now, so any
+one of them opens it. Pass --key-file to seal it to a backup key of your own
+instead of the origin's issuer keys.
+
+Three things open the finished file: any of those issuer keys, the backup key
+from "pstore metadata-backup-key", or this one file's own key from "pstore
+metadata-backup-key <file>".
+
+Set Origin.PStoreMetadataBackupLocation to have the origin back itself up on a
+timer, which works while it is running. This command is for taking one by hand.`,
+		Args:         cobra.ExactArgs(1),
+		RunE:         runPStoreBackup,
+		SilenceUsage: true,
+	}
+
+	originPStoreRestoreCmd = &cobra.Command{
+		Use:   "metadata-restore <file>",
+		Short: "Restore a metadata backup into an empty store",
+		Long: `Restore a metadata backup taken by "pstore metadata-backup".
+
+This restores the namespace only. The object data must already be in place --
+a restore into an empty directory produces a store that lists every object and
+can serve none of them.
+
+The target store must be empty: restoring over live records would interleave
+two namespaces rather than replace one. Restore into a fresh directory
+alongside the object data and masterkey.json the backup was taken with, then
+point the origin at it.
+
+Every metadata backup is complete in itself; there are no incremental backups
+to chain, precisely because the target must be empty.
+
+The backup is opened with the origin's issuer keys, so on the origin itself
+nothing more is needed. Elsewhere -- or if those keys are gone -- pass either:
+
+  --key-file  the backup key from "pstore metadata-backup-key", which opens
+              every backup this origin has written; or
+  --file-key  this one file's own key, from "pstore metadata-backup-key <file>",
+              which opens this file and no other.
+
+Which container the file is in is read from the file itself. A backup written
+in a format version this build does not read is refused by version number
+rather than decoded.`,
+		Args:         cobra.ExactArgs(1),
+		RunE:         runPStoreRestore,
+		SilenceUsage: true,
+	}
+
+	originPStoreBackupKeyCmd = &cobra.Command{
+		Use:   "metadata-backup-key [backup-file]",
+		Short: "Print the key that opens this origin's metadata backups, or one file's own key",
+		Long: `Print a metadata backup key. There are two of them, and which one you get
+depends on whether you name a file.
+
+  metadata-backup-key            the BACKUP KEY: opens EVERY metadata backup
+                                 this origin has written or will write
+  metadata-backup-key <file>     that ONE FILE'S KEY: opens exactly the named
+                                 backup and no other
+
+Keys are DERIVED, not generated. The backup key comes from the origin's issuer
+keys, and a file's key comes from the backup key plus a random salt stored in
+that file, so running either form twice prints the same answer. There is nothing
+to create, configure, or lose track of, and metadata backups are always
+encrypted whether or not this command is ever run.
+
+WITHOUT A FILE -- the backup key, for escrow.
+
+Every backup carries this key inside it, sealed to each issuer key that was
+current when the backup was written, so a restore on the origin itself needs
+nothing but those issuer keys. This form exists for when they are gone too. Save
+what it prints somewhere the backups are not, and any backup can still be
+restored on a machine that has never seen this origin:
+
+  pelican-server origin pstore metadata-backup-key > /etc/pelican/pstore-backup.key
+  chmod 600 /etc/pelican/pstore-backup.key
+  pelican-server origin pstore metadata-restore --key-file /etc/pelican/pstore-backup.key <file>
+
+A metadata backup and this key together are equivalent to the store's namespace
+in cleartext, so keep them apart.
+
+WITH A FILE -- that file's own key, for handing out one backup.
+
+Each backup is encrypted under a key of its very own. This form reads the salt
+out of the named file and re-derives that key, using the origin's issuer keys or,
+with --key-file, an escrowed backup key -- so an operator holding only the
+escrowed key can still produce a specific file's key without the issuer keys:
+
+  pelican-server origin pstore metadata-backup-key /backups/pstore-metadata-....pmb
+  pelican-server origin pstore metadata-restore --file-key thatfile.key /backups/pstore-metadata-....pmb
+
+The printed key opens THAT file only. It says nothing about any other backup, so
+it is what to give to whoever is restoring one archive, rather than the backup
+key above.
+
+Rotating the origin's issuer keys changes what the no-file form prints. Backups
+written before the rotation are still opened by the key printed before it, and by
+the issuer keys they were sealed to that survived it -- so re-run this after a
+rotation and keep both.
+
+These keys are specific to pstore metadata backups. They descend from a
+different label than the server database's backup key and will not open a
+database backup.`,
+		Args:         cobra.MaximumNArgs(1),
+		RunE:         runPStoreBackupKey,
+		SilenceUsage: true,
+	}
+
+	originPStoreExportCmd = &cobra.Command{
+		Use:   "export [path]",
+		Short: "Write objects out as ordinary files",
+		Long: `Export a subtree from the store into a directory of plain files.
+
+This is the recovery path that does not need Pelican running: the objects come
+out as normal files in a normal directory tree, readable with anything.
+
+Objects that cannot be read are reported and skipped rather than aborting the
+export, because recovering most of a damaged store and knowing exactly what was
+lost is more useful than stopping at the first bad block.
+
+An export never overwrites what is already in the destination. Pass --resume to
+continue an interrupted export: files already written are skipped and counted
+separately rather than reported as failures.`,
+		Args:         cobra.MaximumNArgs(1),
+		RunE:         runPStoreExport,
+		SilenceUsage: true,
+	}
+
+	originPStoreDigestCmd = &cobra.Command{
+		Use:   "digest <path>",
+		Short: "Show the checksums recorded for an object",
+		Long: `Show the checksums computed when the object was written.
+
+These are the values the origin serves in response to Want-Digest.`,
+		Args:         cobra.ExactArgs(1),
+		RunE:         runPStoreDigest,
+		SilenceUsage: true,
+	}
+)
+
+func init() {
+	originCmd.AddCommand(originPStoreCmd)
+	originPStoreCmd.AddCommand(originPStoreLsCmd)
+	originPStoreCmd.AddCommand(originPStoreStatCmd)
+	originPStoreCmd.AddCommand(originPStoreDuCmd)
+	originPStoreCmd.AddCommand(originPStoreFsckCmd)
+	originPStoreCmd.AddCommand(originPStoreDigestCmd)
+	originPStoreCmd.AddCommand(originPStoreBackupCmd)
+	originPStoreCmd.AddCommand(originPStoreRestoreCmd)
+	originPStoreCmd.AddCommand(originPStoreBackupKeyCmd)
+	originPStoreCmd.AddCommand(originPStoreExportCmd)
+
+	originPStoreCmd.PersistentFlags().String("location", "",
+		"Store directory (defaults to Origin.PStoreLocation)")
+	originPStoreLsCmd.Flags().BoolVarP(&pstoreLongList, "long", "l", false,
+		"Show size, modification time, and ETag")
+	originPStoreLsCmd.Flags().BoolVarP(&pstoreRecursive, "recursive", "R", false,
+		"Descend into subdirectories")
+	originPStoreFsckCmd.Flags().BoolVar(&pstoreRepair, "repair", false,
+		"Repair the problems found instead of only reporting them")
+	originPStoreBackupCmd.Flags().StringVar(&pstoreKeyFile, "key-file", "",
+		"Seal the backup to the backup key in this file instead of the origin's issuer keys")
+	originPStoreRestoreCmd.Flags().StringVar(&pstoreKeyFile, "key-file", "",
+		"Open the backup with the backup key in this file instead of the origin's issuer "+
+			"keys (see `metadata-backup-key`)")
+	originPStoreRestoreCmd.Flags().StringVar(&pstoreFileKeyFile, "file-key", "",
+		"Open the backup with this one archive's own key, read from this file "+
+			"(see `metadata-backup-key <file>`)")
+	originPStoreBackupKeyCmd.Flags().StringVar(&pstoreKeyFile, "key-file", "",
+		"Derive the named file's key from the backup key in this file instead of the "+
+			"origin's issuer keys")
+	originPStoreExportCmd.Flags().StringVar(&pstoreExportTo, "to", "",
+		"Directory to write the exported files into (required)")
+	originPStoreExportCmd.Flags().BoolVar(&pstoreVerify, "verify", false,
+		"Check each object against its stored checksums as it is written")
+	originPStoreExportCmd.Flags().BoolVar(&pstoreDryRun, "dry-run", false,
+		"Report what would be written without writing it")
+	originPStoreExportCmd.Flags().BoolVar(&pstoreResume, "resume", false,
+		"Skip objects already present in the destination instead of reporting them")
+	originPStoreFsckCmd.Flags().BoolVar(&pstoreDeep, "deep", false,
+		"Also read every object back and verify it against its stored checksums")
+}
+
+// openPStoreForCLI opens the configured store for offline maintenance.
+//
+// Inspection commands pass allowWrites=false so a mistake cannot modify the
+// store; only fsck --repair asks for write access.
+func openPStoreForCLI(cmd *cobra.Command, allowWrites bool) (*pstore.Store, error) {
+	if err := config.InitClient(); err != nil {
+		return nil, errors.Wrap(err, "failed to initialize configuration")
+	}
+	// The catalog's master key is wrapped under the origin's issuer private
+	// keys, so they must be loaded before the store can be opened.  This
+	// deliberately avoids config.InitServer, which brings up far more of the
+	// origin than reading a database needs.
+	if _, err := config.GetIssuerPublicJWKS(); err != nil {
+		return nil, errors.Wrap(err,
+			"failed to load the origin's issuer keys, which the store is encrypted under")
+	}
+
+	location, err := cmd.Flags().GetString("location")
+	if err != nil {
+		return nil, err
+	}
+	if location == "" {
+		location = param.Origin_PStoreLocation.GetString()
+	}
+	if location == "" {
+		return nil, errors.Errorf("no store location; set %s or pass --location",
+			param.Origin_PStoreLocation.GetName())
+	}
+
+	store, err := pstore.OpenMaintenance(cmd.Context(), location, allowWrites)
+	if err != nil {
+		// A running origin holding the directory lock is the overwhelmingly
+		// likely cause, and BadgerDB's own message about it is not obvious.
+		return nil, errors.Wrapf(err,
+			"failed to open the store at %s (is the origin still running?)", location)
+	}
+	return store, nil
+}
+
+func pstorePathArg(args []string) string {
+	if len(args) == 0 {
+		return "/"
+	}
+	return args[0]
+}
+
+func runPStoreLs(cmd *cobra.Command, args []string) error {
+	store, err := openPStoreForCLI(cmd, false)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	root := pstorePathArg(args)
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+
+	if pstoreLongList {
+		fmt.Fprintln(w, "MODE\tSIZE\tMODIFIED\tETAG\tNAME")
+	}
+	return pstoreWalk(store, root, func(dir string, e pstore.ListEntry) {
+		name := e.Name
+		if pstoreRecursive && dir != "/" {
+			name = dir + "/" + e.Name
+		} else if pstoreRecursive {
+			name = "/" + e.Name
+		}
+		if !pstoreLongList {
+			if e.Dirent.IsDir() {
+				name += "/"
+			}
+			fmt.Fprintln(w, name)
+			return
+		}
+		kind := "-"
+		size := utils.HumanBytes(e.Dirent.Size)
+		if e.Dirent.IsDir() {
+			kind = "d"
+			size = "-"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			kind, size,
+			time.Unix(0, e.Dirent.MTimeNanos).Format(time.RFC3339),
+			shortETag(e.Dirent.Generation), name)
+	})
+}
+
+// pstoreWalkPageSize bounds how much of a directory is held at once.
+//
+// A pstore is built for millions of objects in a single directory, so
+// materialising a listing is not a shortcut -- `du /` on a real store would
+// hold the whole namespace, and with --recursive one page per level of depth
+// on top of that. The recovery export already pages for the same reason.
+const pstoreWalkPageSize = 512
+
+// pstoreWalk visits a directory, descending when --recursive is set.
+//
+// Recursion happens while the page is still in hand rather than after the
+// whole directory has been read, so the peak is one page per level of nesting
+// instead of one directory per level.
+func pstoreWalk(store *pstore.Store, dir string, visit func(string, pstore.ListEntry)) error {
+	after := ""
+	for {
+		entries, more, err := store.List(dir, after, pstoreWalkPageSize)
+		if err != nil {
+			return errors.Wrapf(err, "cannot list %s", dir)
+		}
+		if len(entries) == 0 {
+			return nil
+		}
+		for _, e := range entries {
+			visit(dir, e)
+		}
+		if pstoreRecursive {
+			for _, e := range entries {
+				if !e.Dirent.IsDir() {
+					continue
+				}
+				child := dir + "/" + e.Name
+				if dir == "/" {
+					child = "/" + e.Name
+				}
+				if err := pstoreWalk(store, child, visit); err != nil {
+					return err
+				}
+			}
+		}
+		if !more {
+			return nil
+		}
+		after = entries[len(entries)-1].Name
+	}
+}
+
+func runPStoreStat(cmd *cobra.Command, args []string) error {
+	store, err := openPStoreForCLI(cmd, false)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	d, err := store.Stat(args[0])
+	if err != nil {
+		return errors.Wrapf(err, "cannot stat %s", args[0])
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+	fmt.Fprintf(w, "Path:\t%s\n", args[0])
+	if d.IsDir() {
+		fmt.Fprintf(w, "Type:\tdirectory\n")
+	} else {
+		fmt.Fprintf(w, "Type:\tobject\n")
+		fmt.Fprintf(w, "Size:\t%d (%s)\n", d.Size, utils.HumanBytes(d.Size))
+		fmt.Fprintf(w, "ETag:\t\"%s\"\n", d.Generation)
+	}
+	fmt.Fprintf(w, "Modified:\t%s\n", time.Unix(0, d.MTimeNanos).Format(time.RFC3339))
+
+	if !d.IsDir() {
+		if atime, aErr := store.AccessTime(args[0]); aErr == nil && !atime.IsZero() {
+			fmt.Fprintf(w, "Accessed:\t%s\n", atime.Format(time.RFC3339))
+		} else if aErr == nil {
+			fmt.Fprintf(w, "Accessed:\tnever read since it was written\n")
+		}
+		if digests, dErr := store.Digests(args[0]); dErr == nil && len(digests) > 0 {
+			fmt.Fprintf(w, "Digests:\t%s\n", local_cache.FormatDigestHeader(digests))
+		}
+	}
+	return nil
+}
+
+func runPStoreDu(cmd *cobra.Command, args []string) error {
+	store, err := openPStoreForCLI(cmd, false)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	root := pstorePathArg(args)
+	var files, dirs int
+	var bytes int64
+	// Recurse regardless of the ls flag: du is inherently a subtree total.
+	prev := pstoreRecursive
+	pstoreRecursive = true
+	defer func() { pstoreRecursive = prev }()
+
+	if err := pstoreWalk(store, root, func(_ string, e pstore.ListEntry) {
+		if e.Dirent.IsDir() {
+			dirs++
+			return
+		}
+		files++
+		bytes += e.Dirent.Size
+	}); err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+	fmt.Fprintf(w, "Path:\t%s\n", root)
+	fmt.Fprintf(w, "Objects:\t%d\n", files)
+	fmt.Fprintf(w, "Directories:\t%d\n", dirs)
+	fmt.Fprintf(w, "Content bytes:\t%d (%s)\n", bytes, utils.HumanBytes(bytes))
+
+	used, max := store.Usage()
+	fmt.Fprintf(w, "\nStore used:\t%s\n", utils.HumanBytes(used))
+	if max > 0 {
+		fmt.Fprintf(w, "Store capacity:\t%s (%.1f%% used)\n",
+			utils.HumanBytes(max), 100*float64(used)/float64(max))
+	} else {
+		fmt.Fprintf(w, "Store capacity:\tunbounded\n")
+	}
+	return nil
+}
+
+func runPStoreFsck(cmd *cobra.Command, args []string) error {
+	store, err := openPStoreForCLI(cmd, pstoreRepair)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	report, err := store.FsckWith(cmd.Context(), pstore.FsckOptions{
+		Repair: pstoreRepair,
+		Deep:   pstoreDeep,
+	})
+	if err != nil {
+		return errors.Wrap(err, "consistency check failed")
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(w, "Entries scanned:\t%d\n", report.EntriesScanned)
+	fmt.Fprintf(w, "Directories:\t%d\n", report.DirectoriesScanned)
+	if pstoreDeep {
+		fmt.Fprintf(w, "Objects verified:\t%d\n", report.ObjectsVerified)
+	}
+	w.Flush()
+
+	if len(report.PendingInstances) > 0 {
+		// Not a fault: an object whose write is still in flight has metadata
+		// before it has a directory entry.  Shown so the count is not
+		// mistaken for something missing.
+		fmt.Fprintf(w, "Writes in flight:\t%d\n", len(report.PendingInstances))
+		w.Flush()
+	}
+
+	if report.Healthy() {
+		fmt.Println("\nNo problems found.")
+		return nil
+	}
+
+	// What repair acted on and what it did not are two different lists, and
+	// printing them under one heading is how an operator comes to believe a
+	// store with corrupt objects in it was fixed.
+	unresolved := report.Unresolved()
+	if resolved := report.Resolved(); len(resolved) > 0 {
+		fmt.Println("\nRepaired:")
+		for _, item := range resolved {
+			fmt.Printf("  %s\n", item)
+		}
+	}
+	if len(unresolved) > 0 {
+		if report.Repaired {
+			fmt.Println("\nNOT repaired -- these need a decision that fsck cannot make:")
+		} else {
+			fmt.Println("\nFound:")
+		}
+		for _, item := range unresolved {
+			fmt.Printf("  %s\n", item)
+		}
+	}
+
+	fmt.Println()
+	reportList("Entries whose object data is missing", report.DanglingEntries)
+	reportList("Writes that never completed", report.MissingData)
+	reportList("Object versions no entry refers to", report.OrphanedInstances)
+	reportList("Objects whose data no longer matches its checksums", report.CorruptObjects)
+	if len(report.UsageDrift) > 0 {
+		fmt.Println("Usage counter drift (actual minus recorded):")
+		ids := make([]int, 0, len(report.UsageDrift))
+		for id := range report.UsageDrift {
+			ids = append(ids, int(id))
+		}
+		sort.Ints(ids)
+		for _, id := range ids {
+			fmt.Printf("  storage directory %d: %+d bytes\n", id, report.UsageDrift[local_cache.StorageID(id)])
+		}
+		fmt.Println()
+	}
+
+	if report.Repaired && len(report.OrphanedInstances) > 0 {
+		fmt.Println("Reclamation of orphaned data happens on the origin's next run.")
+	}
+	if len(unresolved) == 0 {
+		return nil
+	}
+	// A non-zero exit lets this drive monitoring without parsing the output.
+	// It must stay non-zero after --repair when findings remain, or a
+	// monitoring script reads "success" off a store full of corrupt objects.
+	if report.Repaired {
+		return errors.Errorf("%d finding(s) could not be repaired; see above", len(unresolved))
+	}
+	return errors.New("the store has inconsistencies; re-run with --repair to fix them")
+}
+
+func reportList(title string, items []string) {
+	if len(items) == 0 {
+		return
+	}
+	fmt.Printf("%s (%d):\n", title, len(items))
+	const maxShown = 20
+	for i, item := range items {
+		if i == maxShown {
+			fmt.Printf("  ... and %d more\n", len(items)-maxShown)
+			break
+		}
+		fmt.Printf("  %s\n", item)
+	}
+	fmt.Println()
+}
+
+func runPStoreDigest(cmd *cobra.Command, args []string) error {
+	store, err := openPStoreForCLI(cmd, false)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	digests, err := store.Digests(args[0])
+	if err != nil {
+		return errors.Wrapf(err, "cannot read digests for %s", args[0])
+	}
+	if len(digests) == 0 {
+		// Every pstore write records checksums as it ingests, so an object
+		// without them did not finish being written -- there was never a
+		// released version that skipped the step.
+		return errors.Errorf("no checksums recorded for %s; its write did not complete. "+
+			"Run `pelican-server origin pstore fsck` to see whether the entry is servable at all",
+			args[0])
+	}
+
+	// Rendered exactly as the origin would serve them in a Digest header, so
+	// an operator can compare the two directly.
+	entries := make([]string, 0, len(digests))
+	for _, c := range digests {
+		if entry := local_cache.FormatDigestEntry(c); entry != "" {
+			entries = append(entries, entry)
+		}
+	}
+	sort.Strings(entries)
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+	for _, entry := range entries {
+		name, value, _ := strings.Cut(entry, "=")
+		fmt.Fprintf(w, "%s\t%s\n", name, value)
+	}
+	return nil
+}
+
+// shortETag abbreviates a generation for column output.
+func shortETag(generation string) string {
+	if generation == "" {
+		return "-"
+	}
+	if len(generation) > 12 {
+		return generation[:12] + "..."
+	}
+	return generation
+}
+
+func runPStoreBackup(cmd *cobra.Command, args []string) error {
+	store, err := openPStoreForCLI(cmd, false)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	// Exclusive create: silently overwriting a previous backup is not a
+	// mistake worth allowing in a recovery tool.
+	f, err := os.OpenFile(args[0], os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err != nil {
+		return errors.Wrapf(err, "cannot create %s", args[0])
+	}
+	defer f.Close()
+
+	keys, err := pstoreBackupKeys()
+	if err != nil {
+		return err
+	}
+	if _, err = store.BackupEncrypted(f, keys); err != nil {
+		// Leaving the fragment behind is worse than having written nothing:
+		// it has the name of a backup, and the next attempt refuses to
+		// overwrite it.
+		f.Close()
+		if rErr := os.Remove(args[0]); rErr != nil {
+			fmt.Fprintf(os.Stderr, "WARNING: could not remove the partial backup %s: %v\n",
+				args[0], rErr)
+		}
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		_ = os.Remove(args[0])
+		return errors.Wrapf(err, "failed to flush %s", args[0])
+	}
+
+	info, err := os.Stat(args[0])
+	if err == nil {
+		fmt.Printf("Wrote %s (%s)\n", args[0], utils.HumanBytes(info.Size()))
+	}
+	// Guidance goes to stderr so that redirecting stdout captures the result
+	// and not the advice.
+	fmt.Fprintln(os.Stderr, "This covers the catalog only. Keep the object data and "+
+		"masterkey.json from the same store alongside it.")
+	if pstoreKeyFile == "" {
+		fmt.Fprintln(os.Stderr, "It is sealed to this origin's issuer keys. To be able to "+
+			"restore it without them, save the key printed by `pelican-server origin pstore "+
+			"metadata-backup-key`. To let someone restore only this one file, give them "+
+			"`pelican-server origin pstore metadata-backup-key "+args[0]+"` instead.")
+	}
+	return nil
+}
+
+func runPStoreRestore(cmd *cobra.Command, args []string) error {
+	store, err := openPStoreForCLI(cmd, true)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	f, err := os.Open(args[0])
+	if err != nil {
+		return errors.Wrapf(err, "cannot read %s", args[0])
+	}
+	defer f.Close()
+
+	keys, err := pstoreBackupKeys()
+	if err != nil {
+		return err
+	}
+	// Restore decides from the file's own magic whether it is sealed and under
+	// which format version, so an operator does not have to know which release
+	// wrote the snapshot they are holding.
+	if err := store.Restore(f, keys); err != nil {
+		return err
+	}
+	fmt.Printf("Restored the catalog from %s.\n", args[0])
+	fmt.Fprintln(os.Stderr, "The catalog is only half of a recovery: the object data and "+
+		"masterkey.json from the same store must be in place too.")
+	fmt.Fprintln(os.Stderr,
+		"Verify with `pelican-server origin pstore fsck --deep` before starting the origin.")
+	return nil
+}
+
+// pstoreBackupKeys resolves the keys a hand-run backup or restore uses.
+//
+// openPStoreForCLI has already loaded the origin's issuer keys -- the store
+// itself cannot be opened without them -- so the default path needs no extra
+// setup.  Each flag replaces the issuer keys rather than adding to them: an
+// operator passing one either wants a backup that does not depend on this host,
+// or is restoring on a host that has never had its keys.
+//
+// --file-key is checked first because it is the narrowest thing an operator can
+// be holding: it opens the one archive it was printed for, so if it is present
+// it is what they mean.
+func pstoreBackupKeys() (pstore.BackupKeys, error) {
+	if pstoreFileKeyFile != "" {
+		key, err := pstoreReadKeyFile(pstoreFileKeyFile)
+		if err != nil {
+			return pstore.BackupKeys{}, err
+		}
+		return pstore.BackupKeys{FileKey: key}, nil
+	}
+	if pstoreKeyFile == "" {
+		return pstore.BackupKeys{IssuerKeys: config.GetIssuerPrivateKeys()}, nil
+	}
+	key, err := pstoreReadKeyFile(pstoreKeyFile)
+	if err != nil {
+		return pstore.BackupKeys{}, err
+	}
+	return pstore.BackupKeys{BackupKey: key}, nil
+}
+
+// pstoreReadKeyFile loads one base64 key from a file.
+func pstoreReadKeyFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot read the backup key from %s", path)
+	}
+	key, err := pstore.ParseBackupKey(string(data))
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot use the key in %s", path)
+	}
+	return key, nil
+}
+
+// pstoreEscrowBackupKey re-derives the level-2 backup private key for the
+// origin's active issuer key.
+//
+// Split out from the command so it can be exercised without going through
+// cobra and stdout: what matters about it is that it is reproducible.
+func pstoreEscrowBackupKey() ([]byte, error) {
+	issuerKey, err := config.GetIssuerPrivateJWK()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to load the origin's issuer key")
+	}
+	return pstore.DeriveBackupKey(issuerKey)
+}
+
+// pstoreFileBackupKey re-derives the level-3 key belonging to one backup file.
+//
+// Only the header is read, so the file may sit anywhere and be of any size.
+// Whatever pstoreBackupKeys resolved -- the origin's issuer keys, or an escrowed
+// backup key -- reaches the same answer, because the archive carries its own
+// backup key sealed to both.
+//
+// Split out from the command for the same reason as pstoreEscrowBackupKey: the
+// property worth testing is that the key it prints is the one that opens that
+// file, which has nothing to do with cobra.
+func pstoreFileBackupKey(path string) ([]byte, error) {
+	keys, err := pstoreBackupKeys()
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot read %s", path)
+	}
+	defer f.Close()
+	key, err := pstore.DeriveFileKey(f, keys)
+	return key, errors.Wrapf(err, "cannot derive the key for %s", path)
+}
+
+func runPStoreBackupKey(cmd *cobra.Command, args []string) error {
+	if err := config.InitClient(); err != nil {
+		return errors.Wrap(err, "failed to initialize configuration")
+	}
+
+	// The key alone goes to stdout so it can be redirected to a file; the
+	// guidance goes to stderr so it does not end up in that file.
+	if len(args) == 0 {
+		key, err := pstoreEscrowBackupKey()
+		if err != nil {
+			return err
+		}
+		fmt.Println(pstore.FormatBackupKey(key))
+		fmt.Fprintln(os.Stderr,
+			"This is the BACKUP KEY: it opens every metadata backup this origin has "+
+				"written. It is derived from this origin's issuer keys, so it is the same "+
+				"every time it is printed. Keep it somewhere the metadata backups are not: "+
+				"it is only needed if the issuer keys are lost, and alongside a backup it "+
+				"exposes the store's namespace. To hand out one archive instead, print that "+
+				"file's own key with `metadata-backup-key <file>`.")
+		return nil
+	}
+
+	// Deriving a named file's key needs the whole keyring, not just the active
+	// key: the archive may have been sealed before a rotation.  Loading it is
+	// skipped entirely when an escrowed backup key is supplied, which is the
+	// case where this host has no issuer keys to load.
+	if pstoreKeyFile == "" {
+		if _, err := config.GetIssuerPublicJWKS(); err != nil {
+			return errors.Wrap(err, "failed to load the origin's issuer keys; pass "+
+				"--key-file with the key from `metadata-backup-key` to derive this file's "+
+				"key without them")
+		}
+	}
+	key, err := pstoreFileBackupKey(args[0])
+	if err != nil {
+		return err
+	}
+	fmt.Println(pstore.FormatBackupKey(key))
+	fmt.Fprintf(os.Stderr,
+		"This is the key for %s ALONE -- NOT this origin's backup key. Every backup is "+
+			"encrypted under a key of its own, derived from the backup key and the salt "+
+			"stored in that file, so this one opens no other backup. Restore with "+
+			"`pelican-server origin pstore metadata-restore --file-key <this key in a file> %s`.\n",
+		args[0], args[0])
+	return nil
+}
+
+func runPStoreExport(cmd *cobra.Command, args []string) error {
+	if pstoreExportTo == "" {
+		return errors.New("--to is required: it names the directory to write into")
+	}
+	store, err := openPStoreForCLI(cmd, false)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	report, err := store.Export(cmd.Context(), pstore.ExportOptions{
+		Root:   pstorePathArg(args),
+		Dest:   pstoreExportTo,
+		Verify: pstoreVerify,
+		DryRun: pstoreDryRun,
+		Resume: pstoreResume,
+	})
+	if err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	if pstoreDryRun {
+		fmt.Fprintf(w, "Would write:\t%d files, %d directories\n",
+			report.FilesWritten, report.DirsCreated)
+	} else {
+		fmt.Fprintf(w, "Files written:\t%d\n", report.FilesWritten)
+		fmt.Fprintf(w, "Directories:\t%d\n", report.DirsCreated)
+	}
+	if report.AlreadyPresent > 0 {
+		fmt.Fprintf(w, "Already present:\t%d\n", report.AlreadyPresent)
+	}
+	fmt.Fprintf(w, "Bytes:\t%s\n", utils.HumanBytes(report.BytesWritten))
+	w.Flush()
+
+	if len(report.Failed) == 0 {
+		return nil
+	}
+
+	fmt.Printf("\n%d object(s) could not be exported:\n", len(report.Failed))
+	paths := make([]string, 0, len(report.Failed))
+	for p := range report.Failed {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		fmt.Printf("  %s: %s\n", p, report.Failed[p])
+	}
+	// Non-zero so a recovery script notices rather than assuming success.
+	return errors.Errorf("%d object(s) could not be exported", len(report.Failed))
+}

--- a/cmd/origin_pstore_test.go
+++ b/cmd/origin_pstore_test.go
@@ -1,0 +1,210 @@
+//go:build server
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/backup_keys"
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/local_cache"
+	"github.com/pelicanplatform/pelican/pstore"
+)
+
+// TestPStoreBackupKeyIsDerivedNotGenerated is the behavior change the command
+// exists to express.
+//
+// It used to mint a fresh random key, which meant an operator who lost the file
+// lost every backup taken with it. It now re-derives the key from the origin's
+// issuer keys, so printing it twice on the same origin gives the same answer
+// and a lost copy can simply be reprinted. A test that only checked the key
+// parsed would have passed under both behaviors.
+func TestPStoreBackupKeyIsDerivedNotGenerated(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+
+	first, err := pstoreEscrowBackupKey()
+	require.NoError(t, err)
+	second, err := pstoreEscrowBackupKey()
+	require.NoError(t, err)
+	assert.Equal(t, first, second,
+		"the key is derived, so re-running the command must reprint the same one")
+
+	// What the command writes to stdout has to be what --key-file accepts.
+	parsed, err := pstore.ParseBackupKey(pstore.FormatBackupKey(first))
+	require.NoError(t, err)
+	assert.Equal(t, first, parsed)
+}
+
+// TestPStoreBackupKeyDiffersFromTheDatabaseBackupKey is the domain separation
+// the repository owner asked for, checked at the level an operator sees: the
+// key printed for pstore backups is not the key that opens a server database
+// backup, so escrowing one does not hand over the other.
+func TestPStoreBackupKeyDiffersFromTheDatabaseBackupKey(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+
+	pstoreKey, err := pstoreEscrowBackupKey()
+	require.NoError(t, err)
+
+	issuerKey, err := config.GetIssuerPrivateJWK()
+	require.NoError(t, err)
+	databaseKey, _, err := backup_keys.DeriveKeyPair(issuerKey, backup_keys.LabelDatabase)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, databaseKey[:], pstoreKey,
+		"the pstore backup key must not be the database backup key")
+}
+
+// TestPStoreCLIBackupKeysResolution covers the three ways the CLI decides what
+// a backup is sealed to or opened with: the origin's issuer keys by default,
+// the backup key in --key-file, and the one archive's own key in --file-key.
+func TestPStoreCLIBackupKeysResolution(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+	t.Cleanup(func() { pstoreKeyFile, pstoreFileKeyFile = "", "" })
+
+	pstoreKeyFile, pstoreFileKeyFile = "", ""
+	keys, err := pstoreBackupKeys()
+	require.NoError(t, err)
+	assert.Empty(t, keys.BackupKey)
+	assert.Empty(t, keys.FileKey)
+	assert.NotEmpty(t, keys.IssuerKeys, "the default path seals to the origin's issuer keys")
+
+	escrowed, err := pstoreEscrowBackupKey()
+	require.NoError(t, err)
+	keyPath := filepath.Join(t.TempDir(), "pstore-backup.key")
+	require.NoError(t, os.WriteFile(keyPath, []byte(pstore.FormatBackupKey(escrowed)+"\n"), 0600))
+
+	pstoreKeyFile = keyPath
+	keys, err = pstoreBackupKeys()
+	require.NoError(t, err)
+	assert.Equal(t, escrowed, keys.BackupKey)
+	assert.Empty(t, keys.IssuerKeys, "a key file replaces the issuer keys rather than joining them")
+
+	// --file-key is the narrowest thing an operator can be holding, so it wins
+	// over both: if they passed it, it is what they meant.
+	pstoreFileKeyFile = keyPath
+	keys, err = pstoreBackupKeys()
+	require.NoError(t, err)
+	assert.Equal(t, escrowed, keys.FileKey)
+	assert.Empty(t, keys.BackupKey)
+	assert.Empty(t, keys.IssuerKeys)
+
+	pstoreFileKeyFile = ""
+	pstoreKeyFile = filepath.Join(t.TempDir(), "missing.key")
+	_, err = pstoreBackupKeys()
+	assert.Error(t, err, "a key file that cannot be read must fail rather than fall back")
+}
+
+// pstoreTestArchive writes a sealed metadata backup of a small store and
+// returns its path, standing in for a file an operator is holding.
+func pstoreTestArchive(t *testing.T, name string) string {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	egrp, _ := errgroup.WithContext(ctx)
+
+	store, err := pstore.Open(ctx, egrp, pstore.Config{BaseDir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	require.NoError(t, store.MkdirAll("/data"))
+
+	path := filepath.Join(t.TempDir(), name)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	require.NoError(t, err)
+	defer f.Close()
+
+	_, err = store.BackupEncrypted(f, pstore.BackupKeys{IssuerKeys: config.GetIssuerPrivateKeys()})
+	require.NoError(t, err)
+	return path
+}
+
+// TestPStoreBackupKeyForAFile is the distinction the repository owner asked to
+// be made obvious: naming a file must print THAT file's key, not the origin's
+// backup key.
+//
+// A command that quietly printed the backup key either way would pass every
+// "the key opens the file" assertion while handing out a key that opens the
+// whole series, so both halves are checked -- the key works on its own file,
+// and it is neither the backup key nor the neighbouring file's key.
+func TestPStoreBackupKeyForAFile(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+	t.Cleanup(func() { pstoreKeyFile, pstoreFileKeyFile = "", "" })
+	pstoreKeyFile, pstoreFileKeyFile = "", ""
+
+	first := pstoreTestArchive(t, "first.pmb")
+	second := pstoreTestArchive(t, "second.pmb")
+
+	firstKey, err := pstoreFileBackupKey(first)
+	require.NoError(t, err)
+	secondKey, err := pstoreFileBackupKey(second)
+	require.NoError(t, err)
+
+	backupKey, err := pstoreEscrowBackupKey()
+	require.NoError(t, err)
+	assert.NotEqual(t, backupKey, firstKey,
+		"naming a file must print that file's key, not the origin's backup key")
+	assert.NotEqual(t, firstKey, secondKey, "two archives must not share a key")
+
+	// The no-file form is stable across runs, which is what makes escrowing it
+	// worth anything.
+	again, err := pstoreEscrowBackupKey()
+	require.NoError(t, err)
+	assert.Equal(t, backupKey, again)
+
+	// And the printed key really is the one that opens that file -- and only
+	// that file.
+	opens := func(t *testing.T, archive string, key []byte) error {
+		t.Helper()
+		f, oErr := os.Open(archive)
+		require.NoError(t, oErr)
+		defer f.Close()
+		target, oErr := pstore.OpenMaintenance(t.Context(), t.TempDir(), true)
+		require.NoError(t, oErr)
+		defer target.Close()
+		return target.Restore(f, pstore.BackupKeys{FileKey: key})
+	}
+	assert.NoError(t, opens(t, first, firstKey))
+	assert.Error(t, opens(t, second, firstKey),
+		"one archive's key must not open its sibling")
+
+	t.Run("an operator holding only the escrowed backup key gets the same answer",
+		func(t *testing.T) {
+			// The issuer keys are deliberately not consulted here: --key-file is
+			// the path for a machine that has never held them.
+			keyPath := filepath.Join(t.TempDir(), "escrowed.key")
+			require.NoError(t, os.WriteFile(keyPath,
+				[]byte(pstore.FormatBackupKey(backupKey)+"\n"), 0600))
+
+			pstoreKeyFile = keyPath
+			t.Cleanup(func() { pstoreKeyFile = "" })
+
+			viaEscrow, dErr := pstoreFileBackupKey(first)
+			require.NoError(t, dErr)
+			assert.Equal(t, firstKey, viaEscrow)
+		})
+}

--- a/cmd/token_test.go
+++ b/cmd/token_test.go
@@ -335,7 +335,7 @@ func TestGetNsAd(t *testing.T) {
 			expectPath:  readNs.Path,
 		},
 		{
-			name:        "matching namespace with trailing slash normalised",
+			name:        "matching namespace with trailing slash normalized",
 			nsAds:       []server_structs.NamespaceAdResponse{readNs},
 			namespace:   "/test/prefix/",
 			expectError: false,

--- a/config/address_file.go
+++ b/config/address_file.go
@@ -51,6 +51,12 @@ func getServerRuntimeDir() (string, error) {
 //   - SERVER_EXTERNAL_WEB_URL: The main web UI/API endpoint
 //   - ORIGIN_URL: The origin's XRootD endpoint (if origin is enabled)
 //   - CACHE_URL: The cache's XRootD endpoint (if cache is enabled)
+//   - LOCAL_ISSUER_URL: The issuer this server accepts its own admin tokens
+//     under.  A CLI cannot derive this reliably: it depends on which modules
+//     the process was started with, which may exist only in its argv.
+//
+// Readers ignore keys they do not recognize, so adding one is backward
+// compatible in both directions.
 //
 // The file is written atomically using a temporary file and rename.
 func WriteAddressFile(modules server_structs.ServerType) error {
@@ -84,6 +90,13 @@ func WriteAddressFile(modules server_structs.ServerType) error {
 		}
 	}
 
+	// The issuer a token must carry to be accepted by this server's web API.
+	// Minting one is otherwise guesswork for a separate CLI process: the value
+	// depends on the module set, and `serve --module` leaves no trace on disk.
+	if localIssuer := GetLocalIssuerUrl(); localIssuer != "" {
+		content += fmt.Sprintf("LOCAL_ISSUER_URL=%s\n", localIssuer)
+	}
+
 	// Include cache URL if cache is enabled
 	if modules.IsEnabled(server_structs.CacheType) {
 		cacheUrl := param.Cache_Url.GetString()
@@ -113,6 +126,7 @@ type AddressFileContents struct {
 	ServerExternalWebURL string
 	OriginURL            string
 	CacheURL             string
+	LocalIssuerURL       string
 }
 
 // ReadAddressFile reads the pelican.addresses file from the runtime directory
@@ -154,6 +168,8 @@ func ReadAddressFile() (*AddressFileContents, error) {
 			result.OriginURL = value
 		case "CACHE_URL":
 			result.CacheURL = value
+		case "LOCAL_ISSUER_URL":
+			result.LocalIssuerURL = value
 		}
 	}
 

--- a/config/address_file_test.go
+++ b/config/address_file_test.go
@@ -235,3 +235,27 @@ func TestWriteAddressFile(t *testing.T) {
 		assert.Contains(t, err.Error(), "failed to read address file")
 	})
 }
+
+// TestAddressFileIgnoresUnknownKeys pins the property that makes this format
+// safe to extend: a reader older than the writer must skip what it does not
+// recognize rather than fail. Without it, adding a key would break every
+// deployed CLI reading a newer server's file.
+func TestAddressFileIgnoresUnknownKeys(t *testing.T) {
+	tmpDir := t.TempDir()
+	viper.Reset()
+	defer viper.Reset()
+	viper.Set(param.RuntimeDir.GetName(), tmpDir)
+
+	contents := "SERVER_EXTERNAL_WEB_URL=https://example.com:8444\n" +
+		"SOME_FUTURE_KEY=whatever it holds\n" +
+		"# a comment\n" +
+		"\n" +
+		"malformed line with no equals sign\n" +
+		"LOCAL_ISSUER_URL=https://example.com:8444/api/v1.0/origin\n"
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "pelican.addresses"), []byte(contents), 0600))
+
+	got, err := ReadAddressFile()
+	require.NoError(t, err, "an unknown key, a comment, and a malformed line must not make the file unreadable")
+	assert.Equal(t, "https://example.com:8444", got.ServerExternalWebURL)
+	assert.Equal(t, "https://example.com:8444/api/v1.0/origin", got.LocalIssuerURL)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -2107,7 +2107,7 @@ func InitServer(ctx context.Context, currentServers server_structs.ServerType) e
 	// POSIX-like backend (posix, posixv2). Disable them on remote-protocol backends.
 	if currentServers.IsEnabled(server_structs.OriginType) {
 		storageType := server_structs.OriginStorageType(param.Origin_StorageType.GetString())
-		if !storageType.IsPosixLike() {
+		if !storageType.SupportsSelfTest() {
 			updates := make(map[string]interface{})
 			if param.Origin_SelfTest.GetBool() {
 				log.Warningf("%s may not be enabled when the origin is configured with non-POSIX-like backends. Turning off...", param.Origin_SelfTest.GetName())

--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -612,6 +612,18 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 	v.SetDefault(param.Origin_MultiuserUmask.GetName(), -1)
 	// Origin.MultiuserVarlinkSocketPath
 	v.SetDefault(param.Origin_MultiuserVarlinkSocketPath.GetName(), "/run/systemd/userdb/io.systemd.UserDatabase")
+	// Origin.PStoreDataScanInterval
+	v.SetDefault(param.Origin_PStoreDataScanInterval.GetName(), "24h")
+	// Origin.PStoreDataScanRate
+	v.SetDefault(param.Origin_PStoreDataScanRate.GetName(), "100MB/s")
+	// Origin.PStoreIndexCheckInterval
+	v.SetDefault(param.Origin_PStoreIndexCheckInterval.GetName(), "1h")
+	// Origin.PStoreInlineMaxBytes
+	v.SetDefault(param.Origin_PStoreInlineMaxBytes.GetName(), 0)
+	// Origin.PStoreMetadataBackupInterval
+	v.SetDefault(param.Origin_PStoreMetadataBackupInterval.GetName(), "6h")
+	// Origin.PStoreMetadataBackupsToKeep
+	v.SetDefault(param.Origin_PStoreMetadataBackupsToKeep.GetName(), 24)
 	// Origin.Port
 	v.SetDefault(param.Origin_Port.GetName(), 8443)
 	// Origin.RunLocation

--- a/database/backup.go
+++ b/database/backup.go
@@ -23,8 +23,6 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
-	"crypto/x509"
 	"database/sql"
 	"encoding/binary"
 	"encoding/pem"
@@ -43,12 +41,11 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/crypto/curve25519"
-	"golang.org/x/crypto/hkdf"
 	"golang.org/x/crypto/nacl/box"
 	"golang.org/x/crypto/nacl/secretbox"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/pelicanplatform/pelican/backup_keys"
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/version"
@@ -223,30 +220,13 @@ func ReadBackupMetadata(backupPath string) (*BackupMetadata, error) {
 
 // deriveBackupKeyPair derives a Curve25519 key pair from an issuer JWK using
 // HKDF-SHA256.
+//
+// The derivation lives in backup_keys because the pstore origin needs the same
+// one; the label is what keeps the two subsystems' archives from opening with
+// each other's escrowed keys.  backup_keys.LabelDatabase is frozen -- it is
+// baked into every database backup ever written.
 func deriveBackupKeyPair(issuerKey jwk.Key) (privateKey, publicKey *[32]byte, err error) {
-	var rawKey any
-	if err := issuerKey.Raw(&rawKey); err != nil {
-		return nil, nil, errors.Wrap(err, "failed to extract raw key from JWK")
-	}
-
-	derPrivateKey, err := x509.MarshalPKCS8PrivateKey(rawKey)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to marshal private key to PKCS8")
-	}
-
-	// Use HKDF-SHA256 to derive a 32-byte Curve25519 private key.
-	// The info string binds the derived key to backup encryption usage.
-	hkdfReader := hkdf.New(sha256.New, derPrivateKey, nil, []byte("pelican-backup-encryption"))
-
-	privateKey = new([32]byte)
-	if _, err := io.ReadFull(hkdfReader, privateKey[:]); err != nil {
-		return nil, nil, errors.Wrap(err, "failed to derive key via HKDF")
-	}
-
-	publicKey = new([32]byte)
-	curve25519.ScalarBaseMult(publicKey, privateKey)
-
-	return privateKey, publicKey, nil
+	return backup_keys.DeriveKeyPair(issuerKey, backup_keys.LabelDatabase)
 }
 
 // encryptedChunkWriter implements io.WriteCloser. Data written to it is

--- a/director/director.go
+++ b/director/director.go
@@ -1378,7 +1378,7 @@ func finishRegisterServeAd(engineCtx context.Context, ctx *gin.Context, ad *serv
 	// Disable director test if the server isn't POSIX-like (posix / posixv2).
 	// Remote-protocol backends (S3, HTTPS, Globus, etc.) cannot accept the
 	// probe-file write/read that the director test relies on.
-	if !st.IsPosixLike() && !ad.DisableDirectorTest {
+	if !st.SupportsSelfTest() && !ad.DisableDirectorTest {
 		log.Warningf("%s server '%s' with storage type '%s' enabled director test. This is not supported.", sType, ad.Name, string(st))
 		ad.DisableDirectorTest = true
 	}

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -90,7 +90,7 @@
 #                      to "warn" for clients but "info" for servers.
 #
 #   server_default   - Applied after the base defaults for server commands only
-#                      (pelican origin serve, pelican cache serve, etc.). Use
+#                      (pelican-server origin serve, pelican cache serve, etc.). Use
 #                      this when a param needs a server-specific override.
 #                      Example: Logging.Level defaults to "info" for servers.
 #
@@ -1109,9 +1109,140 @@ components: ["origin"]
 ---
 name: Origin.StorageType
 description: |+
-  The type of storage underpinning the origin. Currently supported types are "posix", "https", "s3", "globus", and "xroot".
+  The type of storage underpinning the origin. Currently supported types are "posix", "posixv2", "https", "httpsv2", "s3",
+  "s3v2", "globus", "globusv2", "ssh", "pstore", and "xroot".
 type: string
 default: "posix"
+components: ["origin"]
+---
+name: Origin.PStoreLocation
+description: |+
+  The directory holding a "pstore" origin's catalog and, unless Origin.PStoreStorageDirs is set, its object data.
+
+  Only used when Origin.StorageType is "pstore", but effectively required there: the default of "none" is not usable,
+  and configuration validation fails unless either this or Origin.PStoreStorageDirs is set. When only
+  Origin.PStoreStorageDirs is set, the catalog lives alongside the first directory listed there.
+
+  The Pelican store keeps object data in encrypted, block-structured files and its namespace in an encrypted embedded
+  database, both keyed off the origin's issuer keys. The directory is owned exclusively by this origin while it runs
+  and must not be shared with a cache; the two use the same key space and each refuses to open a database the other
+  claimed.
+type: filename
+default: none
+components: ["origin"]
+---
+name: Origin.PStoreStorageDirs
+description: |+
+  Directories a "pstore" origin spreads object data across, letting a store span several devices without LVM or RAID.
+
+  Accepts either a list of paths or a list of objects with a Path and an optional MaxSize, matching the format of
+  LocalCache.StorageDirs. When unset, Origin.PStoreLocation holds the data as well as the catalog.
+
+  A pstore never evicts: once the configured size is reached, writes fail with 507 Insufficient Storage until something
+  is deleted. A directory with no MaxSize is unbounded, which makes the store as a whole unbounded.
+type: object
+default: none
+components: ["origin"]
+---
+name: Origin.PStoreMetadataBackupLocation
+description: |+
+  Directory receiving periodic metadata backups of a "pstore" origin.
+
+  A metadata backup covers the catalog only -- the namespace and each object's bookkeeping. It does NOT contain object
+  data. Restoring one gives back the directory tree and every object's size, checksums, and location, but the objects
+  themselves come from the block files, which need backing up separately.
+
+  Unlike a cache, an origin cannot re-fetch what it loses: object data on disk is encrypted and named by hash, and
+  everything needed to interpret it lives in the catalog, so a store whose catalog is gone is a directory of unreadable
+  bytes. The catalog is small next to the data and can be copied consistently while the origin runs, so backing it up
+  often is cheap insurance.
+
+  A metadata backup restores only the catalog. It is useful only alongside the object data, which ordinary filesystem
+  backup tools handle, and the masterkey.json file in the store directory, which wraps the encryption key and is itself
+  protected by the origin's issuer keys.
+
+  Every backup is complete; there are no incrementals. Each one is a verified container, so a truncated or damaged file
+  is refused rather than restored as a silently smaller catalog. Note that a restore which fails part-way cannot be
+  undone: the target directory is left holding a partial catalog and must be discarded, with the restore retried into a
+  fresh directory. Always restore into a new directory rather than over an existing store.
+
+  Backups are always encrypted, and there is no key to configure: a snapshot is a logical dump holding every object
+  path and the salt that keeps on-disk filenames unguessable, so there is no setting under which one is written in the
+  clear. Each backup is encrypted under a key of its own, derived from the origin's backup key and a random salt stored
+  in that file; the backup key in turn is derived from the origin's issuer keys and travels inside every backup, sealed
+  to each issuer key that was current when it was written. Three things therefore open a backup, and any one of them is
+  enough: any of those issuer keys, the origin's backup key -- printed for escrow by "pelican-server origin pstore
+  metadata-backup-key" -- or that one file's own key, printed by "pelican-server origin pstore metadata-backup-key <file>".
+  The last is what to hand to someone who should be able to restore one archive and no others.
+
+  Empty (the default) disables metadata backups.
+type: filename
+default: none
+components: ["origin"]
+---
+name: Origin.PStoreMetadataBackupInterval
+description: |+
+  How often a "pstore" origin writes a metadata backup to Origin.PStoreMetadataBackupLocation.
+
+  Each backup is complete rather than incremental, and objects smaller than Origin.PStoreInlineMaxBytes are stored in
+  the catalog itself rather than in a block file -- so a snapshot is not merely a list of names and can be
+  substantially larger than the namespace alone suggests. The default is spaced accordingly; shorten it only after
+  looking at what a snapshot of your store actually costs, and remember that Origin.PStoreMetadataBackupsToKeep copies
+  of it are retained.
+type: duration
+default: 6h
+components: ["origin"]
+---
+name: Origin.PStoreMetadataBackupsToKeep
+description: |+
+  How many metadata backups a "pstore" origin retains, oldest pruned first.
+
+  Keeping several allows rolling back to a point before a corruption rather than only forward from the most recent
+  backup. Zero keeps every backup.
+type: int
+default: 24
+components: ["origin"]
+---
+name: Origin.PStoreIndexCheckInterval
+description: |+
+  How often a "pstore" origin checks its catalog for internal inconsistencies.
+
+  This pass reads only the catalog, so it is cheap. It reports and does not repair; repair stays a deliberate operator
+  action through "pelican-server origin pstore fsck --repair". Zero disables it.
+type: duration
+default: 1h
+components: ["origin"]
+---
+name: Origin.PStoreDataScanInterval
+description: |+
+  How often a "pstore" origin reads every object back and verifies it against the checksums recorded when it was
+  written.
+
+  This is the only check that detects at-rest corruption, and an origin needs it more than a cache does: a cache that
+  finds a corrupt object re-fetches it, while an origin has nowhere to re-fetch from.
+
+  The scan never modifies the store. A corrupt object is reported and left in place, because deleting it would destroy
+  the only copy along with the only record of its path, size, and checksums; restoring or re-ingesting it is an
+  operator decision, taken through "pelican-server origin pstore fsck". Zero disables the scan.
+type: duration
+default: 24h
+components: ["origin"]
+---
+name: Origin.PStoreDataScanRate
+description: |+
+  The rate at which a "pstore" origin's data scan reads, so verification does not compete with serving.
+type: byterate
+default: 100MB/s
+components: ["origin"]
+---
+name: Origin.PStoreInlineMaxBytes
+description: |+
+  The largest object a "pstore" origin keeps directly in its catalog rather than in a block file on disk.
+
+  Small objects cost a whole file each on a conventional filesystem; storing them inline avoids that. Zero selects the
+  built-in default of 4096 bytes.
+type: int
+default: 0
 components: ["origin"]
 ---
 name: Origin.FederationPrefix
@@ -1216,7 +1347,7 @@ description: |+
   - `"no-cache, must-revalidate"` — caches may store the content but must revalidate with the origin via ETags before every use.
   - `"max-age=3600"` — content is considered fresh for one hour.
   - `""` (the default) — no Cache-Control header is sent, which gives the downstream cache full discretion over freshness.
-    This matches the behaviour of a plain XRootD origin.
+    This matches the behavior of a plain XRootD origin.
 type: string
 default: ""
 components: ["origin"]
@@ -1406,7 +1537,7 @@ name: Origin.MultiuserUmask
 description: |+
   The file-creation mask (umask) applied to the process at startup when multiuser mode is enabled.
   This umask controls which permission bits are masked off from the requested mode for all filesystem operations.
-  The umask is set once when the multiuser filesystem is initialised and left in place for the lifetime of the process.
+  The umask is set once when the multiuser filesystem is initialized and left in place for the lifetime of the process.
   A value of -1 (the default) means the process inherits the umask from its parent and does not change it.
   A value of 0 means the exact permissions requested by the caller are applied (no bits masked).
   Specify the value in YAML octal notation (e.g. 0o0022 removes group-write and other-write).

--- a/docs/pstore-design.md
+++ b/docs/pstore-design.md
@@ -1,0 +1,673 @@
+# Pelican Store (pstore) Design
+
+## 1. Overview
+
+`pstore` ("pelican store") is a new origin storage backend that uses the cache V2 data store as an origin's *primary* data store rather than as a cache.
+
+Today the block store in `local_cache` is only reachable through `PersistentCache`, which couples it to download orchestration, HTTP revalidation, and LRU eviction. The store underneath — encrypted 4080-byte blocks, multi-directory spreading, chunking for large objects, a file-descriptor cache, and a BadgerDB metadata catalog that is itself encrypted at rest — is a general-purpose object store that happens to be used by a cache. `pstore` uses it directly, adds the one thing a cache never needed (a directory index), and exposes the result as an `afero.Fs` so it drops into the existing origin serving stack.
+
+What an operator gets, relative to a POSIX origin:
+
+- **Encryption at rest** for both data and metadata, keyed off the origin's issuer keys, with no filesystem-level encryption setup.
+- **Atomic overwrite** without `Origin.EnableAtomicUploads`, rename-on-same-filesystem constraints, or a temp-upload directory.
+- **O(1) checksums** on `Want-Digest` HEAD requests, computed once at ingest, instead of re-reading the object or depending on xattr support.
+- **Multi-disk spreading** with per-directory size limits, without LVM or RAID.
+- **Millions of small objects** without the per-directory scaling behavior of the underlying filesystem, since object data is content-addressed into a two-level hash tree and the namespace lives in BadgerDB.
+- **Operational machinery an origin needs and a cache does not**: scheduled metadata backups, scheduled integrity checking that never deletes, a recovery export that does not need Pelican running, and a live administrative introspection API (§11).
+
+What it deliberately does *not* do:
+
+- No eviction. When the store reaches its configured size, writes fail with `ENOSPC` (HTTP 507) until something is deleted.
+- No mid-file edits. Pelican has no partial-update semantics; objects are immutable and overwrite replaces the whole object.
+- No version-addressed retrieval. Superseded object versions are garbage collected, not served (see §9).
+- No path-based quotas. The store enforces a total capacity bound; per-path quotas will come from the LotMan work landing in `local_cache` (see §7.2).
+
+### 1.1 Non-goals
+
+- Replacing the cache's use of the block store. `local_cache` gains new API surface and a small number of deliberate behavior changes, all enumerated in §10.
+- Multi-process or multi-host sharing of one store. Like the cache, a store is owned exclusively by one process.
+- POSIX semantics beyond what WebDAV and the Pelican client actually exercise: no hard links, no symlinks, no per-file ownership, no partial writes.
+
+## 2. Where it plugs in
+
+```
+   webdav.Handler                       (origin_serve/handlers.go, unchanged)
+        │
+   aferoFileSystem                      (origin_serve/filesystem.go)
+        │   ── metrics, HTB rate limiting, multiuser wrapping, dir pagination,
+        │      Content-Length hint (SizeHintFs), conditional writes
+        │
+   afero.Fs  ◄────────────────────────  pstore.FS            ← new
+        │
+   pstore.Store                                              ← new
+        │   ── path index, generation/commit protocol, capacity, GC,
+        │      checksums, fsck, backup, export
+        │
+   local_cache.StorageManager           (+ AppendWriter, pins, SetChooseDir)
+   local_cache.CacheDB                  (+ DB, EnsureStoreMode, ReloadSalt)
+```
+
+`aferoFileSystem` in `origin_serve/filesystem.go` already adapts any `afero.Fs` into a `webdav.FileSystem` and layers on Prometheus metrics, HTB rate limiting, and directory pagination. Implementing `afero.Fs` is therefore the cheapest correct integration: `origin_serve/backend_pstore.go` is a `server_utils.OriginBackend` mirroring `localBackend` in `origin_serve/backend.go`, plus the store lifecycle (opening, sharing between exports, starting the janitor, backups, and integrity checks, and closing on server shutdown).
+
+`CacheDB` and `StorageManager` are already constructible standalone — see `NewIntrospectAPI` in `local_cache/introspect.go` and the multi-directory tests in `local_cache/chunking_test.go` — and `EvictionManager` is opt-in, never started implicitly. "No eviction" is the default, not something that has to be removed.
+
+### 2.1 Code layout
+
+| Path                             | Contents                                                                                        |
+| -------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `pstore/store.go`                | `Store` lifecycle: open/close, mode marker, DB + `StorageManager` wiring, namespace ops, rename |
+| `pstore/index.go`                | `pd:` dirent encode/decode, key layout, lookup, list, subtree walk                              |
+| `pstore/object.go`               | Generation minting, `instanceHash` derivation, ETag rendering                                   |
+| `pstore/object_io.go`            | Write handle (three tiers, commit) and read handle                                              |
+| `pstore/detached.go`             | Masking for subtrees unlinked but not yet drained (§9.1)                                        |
+| `pstore/fs.go`                   | `afero.Fs` / `afero.File` adapter over the store, including `OpenFileSized`                     |
+| `pstore/capacity.go`             | Reservation counters, directory placement, `ENOSPC` enforcement                                 |
+| `pstore/gc.go`                   | `pg:` queue, janitor, inline and deferred subtree removal, reclamation                          |
+| `pstore/checksum.go`             | Ingest digests and `Want-Digest` lookup (§11.1)                                                 |
+| `pstore/fsck.go`                 | Consistency check and repair (§11.2)                                                            |
+| `pstore/integrity.go`            | Scheduled index check and data scan (§11.3)                                                     |
+| `pstore/backup.go`               | Catalog snapshot, restore, scheduled backups with retention (§11.4)                             |
+| `pstore/backup_crypto.go`        | Snapshot compression, the recipient envelope, and AES-GCM sealing (§11.4)                       |
+| `pstore/recover.go`              | Recovery export to plain files (§11.5)                                                          |
+| `pstore/maintenance.go`          | Offline open for the CLI, read-only enforcement (§11.6)                                         |
+| `pstore/errors.go`               | Sentinel errors and the status codes they map to                                                |
+| `backup_keys/backup_keys.go`     | Issuer-key backup derivation, shared with the server database's backups (§11.4)                 |
+| `local_cache/pin.go`             | Reader pin set, shared with the cache's eviction (§9)                                           |
+| `origin_serve/backend_pstore.go` | `OriginBackend` adapter, checksummer, capacity reporter                                         |
+| `origin_serve/storage_api.go`    | Administrative live-store HTTP API (§11.6)                                                      |
+| `server_utils/origin_pstore.go`  | Export configuration and validation                                                             |
+| `cmd/origin_pstore.go`           | `pelican-server origin pstore …` offline CLI                                                    |
+| `cmd/origin_introspect.go`       | `pelican-server origin introspect …` client for the live API                                    |
+
+`pstore` imports `local_cache` directly. The alternative — first extracting `database.go`, `storage.go`, `schema.go`, `encryption.go`, `chunking.go`, and `block_state.go` into a shared `blockstore/` package — is ~6k lines of mechanical churn across the cache and its tests for zero semantic change, and can be done later without touching `pstore` if the dependency weight becomes a problem.
+
+## 3. Key layout
+
+The store shares one BadgerDB with the same prefix namespace the cache uses. Two prefixes are new; the rest are reused unchanged.
+
+| Prefix | Owner      | Contents                                         |
+| ------ | ---------- | ------------------------------------------------ |
+| `pd:`  | **new**    | Directory entries, keyed by parent path and name |
+| `pg:`  | **new**    | Garbage queue: instances awaiting reclamation    |
+| `m:`   | reused     | `CacheMetadata` per object version               |
+| `s:`   | reused     | Roaring bitmap of written blocks                 |
+| `d:`   | reused     | Inline data for objects below `InlineThreshold`  |
+| `l:`   | reused     | Access-time index (see §8)                       |
+| `u:`   | reused     | Byte usage per `(storageID, namespaceID)`        |
+| `n:`   | reused     | Namespace prefix → `NamespaceID`                 |
+| `di:`  | reused     | Storage directory ID → path mapping              |
+| `e:`   | cache only | Latest-ETag pointer; `pstore` does not use it    |
+| `pf:`  | cache only | Purge-first marks; `pstore` does not use it      |
+
+A store and a cache must never open each other's database: the key spaces overlap by design and cross-opening would be silent corruption. `Store.Open` calls `CacheDB.EnsureStoreMode`, which writes and checks the `_mode` marker key (`KeyStoreMode`) and refuses to open a database whose marker disagrees. The `pd:`/`pg:` reservation is declared alongside the existing prefix constants in `local_cache/schema.go` (`PrefixDirent`, `PrefixGarbage`) so a future cache feature does not claim them.
+
+## 4. The path index
+
+### 4.1 Why path-keyed, keyed by parent
+
+Two families of layout were considered: inode-style (dirents map a name to an inode ID; object identity is independent of path) and path-keyed (the key is derived from the entry's path).
+
+Path-keyed wins because **path locality is what every bulk operation wants**. BadgerDB iterates in byte-sorted order, so path-derived keys put related entries next to each other and turn listings, `du`, quota recomputation, subtree fsck, and recursive delete into sequential scans. Under inode-style, entries are scattered in inode-allocation order and every one of those degrades into a recursive traversal of random seeks. Given that usage tracking and quotas are planned and are path-based (§7), this is decisive.
+
+Within the path-keyed family there is a further choice, and it matters more than it first appears:
+
+|                                | `pd:<full path>`                    | `pd:<parent>\x00<name>`       |
+| ------------------------------ | ----------------------------------- | ----------------------------- |
+| Direct children of a directory | **interleaved** with whole subtrees | **contiguous**                |
+| Readdir cost                   | O(children + subdirs) LSM seeks     | one sequential scan, no seeks |
+| Subtree                        | one contiguous range                | two contiguous ranges         |
+| Sorted listing                 | needs a NUL-terminated marker trick | automatic                     |
+| Empty directories              | need explicit marker records        | natural                       |
+
+Keying by full path makes a subtree contiguous but scatters a *single directory's* children across it, because every descendant sorts between them. Readdir then has to seek over each subtree, and those are real LSM repositionings with no read-ahead benefit — a directory with 1,000 subdirectories costs 1,000 seeks.
+
+Since listing one directory is the dominant operation, the store keys dirents by **parent path plus name**. Subtree scans become two contiguous ranges instead of one, which is immaterial for the background operations that use them.
+
+The cost of path-keying in general is that renaming a directory is O(descendants) rather than O(1). That is acceptable here:
+
+- The Pelican client never issues WebDAV `MOVE`. The origin routes it (in the route table built by `RegisterHandlers` in `origin_serve/handlers.go`, behind the `modify` authz scope), but it is reachable only from raw WebDAV clients.
+- The existing S3 origin backend already implements `Rename` as a best-effort, explicitly non-atomic subtree copy-then-delete that physically moves every byte (`blobFileSystem.Rename` in `origin_serve/backend_blob.go`). `HTTPSv2` returns `ErrNotSupported` unless the upstream speaks WebDAV.
+- `pstore`'s rename rewrites index keys and moves **zero bytes** (§4.4), so it is strictly better than the precedent it has to match.
+
+### 4.2 Layout
+
+```
+pd:<parent path>\x00<name>  → dirent
+```
+
+Both files and directories are entries under their parent, so a directory needs no separate marker record and an empty directory is as real as any other entry. The root is a single fixed key. Parent paths are absolute with no trailing slash, except the root, which is `/`:
+
+```
+/a       (dir)     →  pd:/\x00a
+/a.b     (file)    →  pd:/\x00a.b
+/a0b     (file)    →  pd:/\x00a0b
+/a/b     (dir)     →  pd:/a\x00b
+/a/b/c   (file)    →  pd:/a/b\x00c
+```
+
+The dirent value is msgpack:
+
+```go
+type dirent struct {
+    Type       uint8  `msgpack:"t"`   // file | dir
+    Generation string `msgpack:"g"`   // hex; files only — see §5
+    Size       int64  `msgpack:"s"`
+    MTimeNanos int64  `msgpack:"m"`
+    Mode       uint32 `msgpack:"o"`
+}
+```
+
+Size, mtime, and the generation (which is also the ETag) are **denormalized into the dirent** so that a listing is one scan. Without this, a PROPFIND over a 10,000-entry directory would be 10,000 additional point lookups to fetch each child's `m:` record. The denormalized fields are rewritten only on commit, which is a transaction the write path performs anyway.
+
+Because every key ends in the bare name, a directory's children sort by name with no special handling — files and directories interleave correctly and there is no terminator to reason about. The siblings `/a`, `/a.b`, and `/a0b` key as `pd:/\x00a`, `pd:/\x00a.b`, `pd:/\x00a0b` and come out as `a`, `a.b`, `a0b`.
+
+NUL is chosen as the separator because it is forbidden in path components (§4.5), so it can never appear inside a parent path or a name. That validation is therefore load-bearing for key unambiguity, not merely defensive, and is tested directly.
+
+Sorted output is a real benefit on the paginating path and a latent one otherwise: `pstore`'s `file.Readdir` serves a positive count straight from the index, one page per call, resuming from the last name returned and buffering nothing. `aferoFileSystem.Readdir` in the origin still calls `afero.ReadDir`, which buffers the whole directory via `Readdir(-1)` and re-sorts it by name, so the streaming property is only fully realised once that adapter is bypassed.
+
+### 4.3 Operations
+
+**Lookup / Stat** — split the path at its last `/` and do one point get on `pd:<parent>\x00<name>`. Size, mtime, and ETag come straight from the dirent, so `Stat` never touches `m:`.
+
+**Open (read)** — dirent → generation → `instanceHash` (§5) → `m:` → `StorageManager.NewObjectReader`. Two gets, no path walk.
+
+**Readdir** — prefix scan on `pd:<dir>\x00`. This yields **exactly** the direct children, already in name order: one sequential scan, no seeks, no filtering, and no subtree to skip over. Pagination is a matter of resuming the iterator.
+
+**Subtree scan** — two contiguous ranges:
+
+- `pd:<dir>\x00` — the direct children.
+- prefix `pd:<dir>/` — everything deeper, since every node below the direct children has a *parent path* beginning with `<dir>/`.
+
+For the root both collapse into a scan of the whole `pd:` space. Used by quota recompute, `du`, fsck, export, and recursive delete; all of them are order-independent, so splitting into two scans costs nothing.
+
+Sibling prefixes cannot leak into either range. For `/a`, the deeper range is prefix `pd:/a/`; a sibling `/a-b`'s children key as `pd:/a-b\x00…`, which differs at `-` (0x2D) versus `/` (0x2F). `/a`'s own grandchildren key as `pd:/a/q\x00r` and match correctly.
+
+**Mkdir** — write the entry under its parent. `MkdirAll` writes each missing ancestor.
+
+Uploads to a fresh path work without an explicit `MKCOL` because `pstore.FS` creates missing parents itself, in `createSizedWithParents`. It deliberately does **not** use the origin's shared `autoCreateDirFs` wrapper (`origin_serve/filesystem.go`): that wrapper derives the parent with `filepath.Dir`, and a pstore path is a namespace path that is always slash-separated, so on Windows it would ask for a directory literally named `\a\b\c`. Doing it inside `pstore.FS` keeps the separator right on every platform.
+
+### 4.4 Rename
+
+Renaming a file is a single transaction: delete the old dirent, write the new one with the same value. Nothing else moves — object identity does not depend on the path (§5).
+
+Renaming a directory walks both subtree ranges (§4.3) and rewrites each key with its parent-path component substituted (`moveSubtree` in `pstore/store.go`). Both ranges are sequential scans. No data file is touched, no bytes are copied, and no object metadata is rewritten: nothing in `m:` records the path.
+
+The whole rename — the destination checks, the subtree rewrite, the old dirent's removal, and the new dirent's write — runs inside **one** `bdb.Update`, so a directory rename is atomic. A crash mid-rename leaves the store exactly as it was.
+
+Atomicity has a size limit, which is BadgerDB's transaction size rather than anything in this design. Rather than discover it as an opaque transaction failure part-way through, `moveSubtree` bounds the descendant count at `renameSubtreeLimit` (50,000) and checks it during the **collect** phase, before anything is written: a subtree over the limit is refused with a typed `ErrNotSupported` carrying an actionable message, and the store is unchanged. Since the Pelican client never issues `MOVE`, this bound is reached only from raw WebDAV clients operating on very large trees, and the operator can move such a tree in pieces. If unbounded atomic rename is ever required, a rename journal record can be added without changing the layout.
+
+### 4.5 Constraints
+
+- Path components may not contain `/` or NUL, and `.`/`..` are rejected after `path.Clean`. This is enforced by `validatePath`/`cleanRelative` in `pstore/index.go` and covered by `TestValidatePath` and `TestCleanRelative` in `pstore/index_test.go`. Running the origin's existing `origin_serve/path_traversal_test.go` suite against `pstore` as well is intended but **not yet done**.
+- A file and a directory may not share a name.
+- Paths are **case-sensitive**. See §12.
+- Export `StoragePrefix` is a logical root inside the store, not a filesystem path; validation must not `os.Stat` it (`PStoreOrigin.validateStoragePrefix` in `server_utils/origin_pstore.go`).
+
+That last constraint is load-bearing beyond validation. `origin_serve` has host-filesystem fast paths that used to resolve any export's `StoragePrefix` with `os.OpenRoot`, on the assumption that it names a directory on this machine — true for POSIX, false for `pstore`, S3, HTTPS, and Globus alike. For a single-export pstore origin the natural `StoragePrefix` is `/`, and `os.OpenRoot("/")` succeeds: a browser GET became an HTML index of the *origin host's root directory*, and ETag/Last-Modified became an existence-and-mtime oracle for host files. The PUT path was worse, running checksum invalidation — which opens `O_RDWR` and strips xattrs — against unrelated local files. Backends now **opt in** to that resolution by implementing `localRootProvider` (`LocalStorageRoot() (*os.Root, error)`); anything that does not, `pstore` included, gets `errNotHostFilesystem` and the fast paths are skipped.
+
+## 5. Object identity and generations
+
+Every write mints a **generation**: 128 random bits, hex-encoded.
+
+```
+generation    = 128 random bits, minted per write
+instanceHash  = HMAC(salt, "gen:" + generation)
+ETag          = "<generation>"
+```
+
+The generation is the object version's identity, its HTTP ETag, and the input to its storage key. Because `instanceHash` derives from the generation *alone* and not from the path, `m:`, the block state, and the on-disk data file are all path-independent. That is what makes rename a pure index operation.
+
+This is the same two-level structure the cache uses — a "latest version" pointer plus a per-version record — with the dirent playing the role of `e:`. Since the dirent must exist for listings regardless, folding the pointer into it costs one index and one lookup less than reusing `e:` would.
+
+Data files remain hash-named on disk (`objects/xx/yy/rest`), so an attacker with the disks but not the master key still cannot tell what objects the store holds. Plaintext paths appear only in BadgerDB keys, and BadgerDB is encrypted at rest — `NewCacheDB` derives a separate database key from the master key via `DeriveDBKey` (`local_cache/database.go`). The catalog's plaintext exposure is the same shape the cache already had, which is why the metadata backup format is encrypted too (§11.4).
+
+## 6. Write path
+
+Objects are immutable. Pelican has no mid-file edits, so a write is always "create a complete new version, then swap it in".
+
+1. `OpenFile` with any write flag returns a write handle. Seek-then-write returns `ENOTSUP`; writes must be sequential from offset 0.
+1. Bytes accumulate in memory. Where they end up depends on how many arrive, or on the declared `Content-Length` when there is one — see the three tiers below.
+1. A rolling checksum is computed over the stream at no extra I/O cost (§11.1).
+1. On `Close` the content is materialised and, for streamed objects, `AppendWriter.Finalize()` (§10) records the true `ContentLength`, drops chunks the object never reached, and truncates the tail chunk file.
+1. **Commit** — one BadgerDB transaction:
+   - re-check the parent directory and any conditional-write precondition (§6.2);
+   - write the dirent `pd:<parent>\x00<name>` with the new generation, size, and mtime;
+   - if a previous generation existed, enqueue its `instanceHash` on `pg:`.
+
+Committing the swap and enqueuing the superseded version in the *same* transaction is what makes overwrite crash-safe: there is no window in which an orphaned version is both unreachable from the index and absent from the garbage queue. Space can leak only if the janitor never runs, and fsck (§11.2) is a backstop rather than a requirement.
+
+Aborting a write before `Close` — client disconnect, error — discards the partial instance and releases its capacity reservation, and never touches the dirent, so readers never observe it.
+
+### 6.1 Three write tiers
+
+How the content is materialised depends on how much of it actually arrives:
+
+| Size               | Path                                                                              |
+| ------------------ | --------------------------------------------------------------------------------- |
+| ≤ `InlineMaxBytes` | `StorageManager.StoreInline` — data lives in the catalog                          |
+| ≤ `spillThreshold` | buffered, then `InitDiskStorage` with the exact length and a single `WriteBlocks` |
+| > `spillThreshold` | `AppendWriter` (§10), streamed, length known at the end                           |
+
+`InlineMaxBytes` is `Origin.PStoreInlineMaxBytes`, defaulting to `local_cache.InlineThreshold`. `spillThreshold` and the chunk-size bounds are constants in `pstore/object_io.go`; treat those definitions as authoritative rather than repeating numbers here.
+
+The middle tier exists for capacity, and is worth keeping. `AppendWriter` allocates whole chunks while streaming, so routing a small object through it would reserve a full chunk and hold that reservation until `Finalize` refunded the difference — enough to spuriously fail a write on a near-full store. Buffering to the spill threshold means only genuinely large objects take that path, where the overshoot is proportionally small. It also lets the common case allocate exactly once, at the right size, with no truncation.
+
+The spill buffer is per in-flight write and cannot be evicted, so `spillThreshold` trades directly against write concurrency: a hundred concurrent uploads each hold up to that much. That is the reason it is set well below the smallest chunk the block store can encode.
+
+**The streaming chunk size is chosen per write, not fixed** (`streamChunkSizeCodeFor` in `pstore/object_io.go`), and the reason is capacity rather than file count. `AppendWriter` pre-allocates and charges a whole chunk the moment a stream touches it, so the chunk size *is* the minimum free space some single directory must have before an object above the spill threshold can be accepted (§7). A fixed large chunk would therefore make a bounded store refuse objects it has ample room for. So:
+
+- a **declared** length picks a chunk sized to the object, clamped between the block store's smallest encodable chunk and an upper cap — an object just past the spill threshold reserves megabytes rather than the largest chunk the encoding allows, while a genuinely large upload still gets large chunks, because a terabyte at the minimum chunk size would be half a million files and it needs the space anyway;
+- an **undeclared** length (a chunked transfer-encoding PUT) falls back to `defaultStreamChunkSize`, a small multiple above the spill threshold. There is no way to size the chunk from the object, so this is a deliberate compromise: a store needs only that much headroom in some directory to accept an unknown-length object, at the cost of more chunk files for a very large one.
+
+Keeping `minStreamChunkSize` within a small factor of `spillThreshold` is what makes the two tiers compose: crossing the spill threshold must not multiply the free space a write demands.
+
+One consequence for the pre-flight capacity check (§7.1): `HasCapacityFor` models the **declared-length** path, because that is the only case in which it is consulted at all. An undeclared write assumes the default chunk size and therefore reserves more than a same-sized declared write would — a second reason, beyond the 507 mapping, that a client should send a `Content-Length` when it has one.
+
+**The size hint.** Discovering the size by buffering is the fallback, not the normal case. `origin_serve` defines an optional interface
+
+```go
+type SizeHintFs interface {
+    OpenFileSized(name string, flag int, perm os.FileMode, size int64) (afero.File, error)
+}
+```
+
+in `origin_serve/filesystem.go`, and `aferoFileSystem.OpenFile` uses it when the backing `afero.Fs` implements it. `afero.Fs` has no context and no size argument, so without this a backend cannot see the `Content-Length` the WebDAV handler already has; the hint travels down through the request context (`ContextWithContentLength`) and out through this interface. `autoCreateDirFs` forwards it, so wrapping does not silently drop it.
+
+`pstore.FS.OpenFileSized` passes the hint to `Store.CreateSized`, which picks the streaming tier immediately when the declared size is at or above `spillThreshold` — so a large upload never buffers first. The hint is advisory: the object is stored at whatever length actually arrives, and a wrong or absent hint (a chunked-encoding PUT declares `-1`) costs only the buffering it would have avoided. Any origin backend that can do better with a known length can implement the same interface.
+
+### 6.2 Conditional writes
+
+Because commit is already a compare-and-swap on the dirent, RFC 7232 conditional PUTs are nearly free and worth having:
+
+- `If-Match: "<generation>"` — commit only if the dirent still holds that generation, else 412. Protects concurrent writers from lost updates.
+- `If-None-Match: *` — commit only if no dirent exists, else 412. Create-only.
+
+The handler evaluates preconditions for every backend before the write begins, which is inherently a stat-then-write race: two concurrent `If-None-Match: *` PUTs can both observe an absent object and both commit. `origin_serve` therefore defines a second optional interface, `ConditionalWriteFs` (`OpenFileConditional`), which carries the parsed precondition down to a backend that can re-check it *inside* its commit transaction. `WriteHandle.RequireAbsent` and `WriteHandle.RequireGeneration` are that re-check for `pstore`, and they are evaluated in the same `bdb.Update` that installs the dirent, so the race is closed rather than narrowed.
+
+**Two forms cannot be closed this way and stay best-effort on the early check:**
+
+- `If-Match: *` asserts that the target *exists*, not that it holds a particular version. There is no version to compare at commit, so the commit-time condition has nothing to test.
+- A multi-tag entity-tag list is a *membership* test. The commit-time condition carries one tag, because that is what a compare-and-swap on a single dirent can express.
+
+Both are vanishingly rare from real clients, and both still fail correctly under the pre-write check; what they lack is atomicity against a concurrent writer. A single-tag `If-Match` and `If-None-Match: *` — the two forms anything actually sends — are fully atomic.
+
+Two writers that reach commit simultaneously can also collide in BadgerDB itself. That surfaces as `pstore.ErrConflict`, which is retryable and distinct from a precondition failure: the write did not lose a race on *content*, it lost one on the transaction.
+
+## 7. Capacity
+
+There is no eviction: `EvictionManager` is never constructed, and the `l:` index is maintained for access time only (§8).
+
+**Capacity** is bounded by `StorageDirConfig.MaxSize` per storage directory — the same structure and parser `LocalCache.StorageDirs` uses (`StorageDirConfig` and `ParseStorageDirsValue` in `local_cache/schema.go`). Counters live in memory, seeded from the catalog's persisted usage at startup; a store owns its directories exclusively for its lifetime, so an in-process count is exact and costs no writes on the hot path.
+
+An **unset `MaxSize` makes that directory unbounded**, and one unbounded directory makes the store as a whole unbounded — the aggregate ceiling is the sum of the configured limits, or zero (meaning no ceiling) if any directory has none. This differs from the cache, which auto-detects a directory's size from the filesystem when the limit is unset; a store that silently adopted the filesystem's size would start refusing writes at a boundary the operator never chose. `docs/parameters.yaml` states the same rule under `Origin.PStoreStorageDirs`.
+
+Enforcement has **two** conditions, and checking only the first is not enough:
+
+- the aggregate must have room; and
+- some individual directory must have room for the **placement unit** — one chunk for a streamed object, the whole footprint for anything smaller — because the block store lays each chunk down whole in a single directory. Without the second check a write can pass an aggregate test with plenty of total headroom and then fail against a directory that is individually full.
+
+`pstore` controls placement rather than guessing at it: `Store.Open` installs `capacityTracker.chooseDir` through `StorageManager.SetChooseDir`, replacing the block store's default round-robin. Round-robin ignores how full each directory is, so a store spanning a small disk and a large one walks straight into the small one; the replacement prefers the directory with the most absolute headroom, and treats an unbounded directory as having unlimited headroom.
+
+Inline objects are charged to `StorageIDInline` rather than to a storage directory. They still occupy disk — in the catalog — so they count toward the aggregate; tracking them is what keeps a store from being filled without limit by objects that are each below the inline threshold. They carry no ceiling of their own and are excluded from the per-directory placement check.
+
+A write reserves its projected on-disk footprint as it grows (`WriteHandle.ensureReserved`) and settles up at commit, attributing the real bytes to whichever directories the block store chose (`CacheMetadata.PerDirectoryBytes`). Over-reservation is refunded; a failed or aborted write releases everything it claimed. Exceeding either ceiling returns `syscall.ENOSPC`.
+
+### 7.1 Getting a 507 out of the WebDAV handler
+
+Getting a 507 to the client takes more than returning `ENOSPC`, for two reasons.
+
+`origin_serve`'s `MapToHTTPStatus` handled `EDQUOT` but not `ENOSPC`, so the canonical out-of-space error fell through to string matching and surfaced as a 500 — for every backend, not just this one.
+
+The mapping now lives in `statusForBackendError` (`origin_serve/error_handling.go`), which is the single place a backend sentinel becomes a status:
+
+| Error                                      | Status                   |
+| ------------------------------------------ | ------------------------ |
+| `ENOSPC`, `EDQUOT`                         | 507 Insufficient Storage |
+| `pstore.ErrPreconditionFailed`             | 412 Precondition Failed  |
+| `pstore.ErrDraining`, `pstore.ErrConflict` | 409 Conflict             |
+| `fs.ErrPermission`                         | 403 Forbidden            |
+| `fs.ErrExist` on a conditional write       | 412 Precondition Failed  |
+
+The two 409s share a meaning worth spelling out — *this will work if you try again shortly* — which is far more useful to a client than the 500 an opaque index-transaction error would otherwise produce.
+
+More awkwardly, `golang.org/x/net/webdav` reports *any* copy, stat, or close failure during a PUT as `405 Method Not Allowed`. A client receiving that would conclude the origin does not support PUT at all, rather than that the store is full. The handler offers no hook to distinguish the cases, and the `Logger` callback fires after the status has already been written.
+
+So the origin refuses the request before the handler ever runs. `server_utils.CapacityReporter` is an optional interface that a fixed-size backend implements to answer "will `n` bytes fit"; the PUT path consults it and returns 507 with a reason. `pstoreBackend.HasCapacityFor` forwards to `Store.HasCapacityFor`. Backends that grow on demand do not implement it and are unaffected.
+
+Two limits:
+
+- The check needs a declared `Content-Length`. A chunked-encoding PUT has no length to test, runs until the write fails, and still surfaces as 405. Fixing that means changing how write errors are reported for every backend, which is out of scope here.
+- The check is advisory. A concurrent write can consume the headroom between the check and the reservation, so the store enforces its own limit independently; the pre-flight only improves the common case.
+
+### 7.2 Path-based quotas are out of scope
+
+`pstore` exposes **no quota API** in this design. Path-based usage tracking and quotas will arrive separately, from the in-flight work bringing the LotMan logic into `local_cache`. `lotman/` already models what is needed — a hierarchical, path-scoped lot tree (`lotman/lot_tree.go`) with scoped queries and purge policies (`lotman/timeline.go`, `lotman/lotman_api.go`) — so `pstore` should consume that rather than grow a parallel mechanism.
+
+Two constraints are recorded here so the index does not have to change later:
+
+- **Enforcement will be write-time, not lazy recompute.** Writes are refused when they would exceed a lot, rather than violations being detected on a later pass. Path-keying helps directly: a write already holds the full path string, so identifying the enclosing lots is a string operation against an in-memory lot tree with zero database reads. What needs design is the *accounting* side — whether ancestor byte counts are maintained synchronously (O(depth) writes per object) or held by LotMan itself.
+- **Bootstrapping lots needs its own design** and is not attempted here: deciding how lots are created for an existing store, how they map onto exports and federation prefixes, and what happens to paths covered by no lot.
+
+What `pstore` contributes toward that work, at no extra cost:
+
+- The subtree ranges of §4.3 make per-lot recomputation and initial population a pair of sequential scans rather than a traversal.
+- Per-export accounting is already possible: `u:` is keyed by `NamespaceID`, and the `n:` index maps a prefix to one. A store currently registers a single namespace covering the whole store, because capacity is enforced store-wide; splitting it per export is a change to `resolveNamespaceID` and nothing else.
+
+One open item for that design: `lotman` is currently Linux-only (`lotman/lot_tree.go` and its siblings build under `linux && !ppc64le`, with `lotman/lotman.go` as the stub for everything else). Whether `pstore` quotas inherit that restriction depends on how much of the logic the `local_cache` port reimplements in Go.
+
+## 8. Access time
+
+The `l:` LRU index and `CacheDB.UpdateLRU` are kept, purely to provide access times. `UpdateLRU` (`local_cache/database.go`) is one transaction doing a metadata read-modify-write plus a delete-old/set-new key pair, debounced against `CacheMetadata.LastAccessTime`; in steady state a read pays one get and skips the writes. `pstore` debounces at `atimeDebounce` (`pstore/store.go`).
+
+Access time is deliberately not surfaced through `FileInfo`: it lives on the object's `m:` record rather than its dirent, so reporting it from `Stat` would add a metadata read to every lookup to answer a question almost no caller asks. `Store.AccessTime` exposes it, and `pelican-server origin pstore stat` prints it.
+
+This also gives `l:<storageID>:<namespaceID>:<ts>:<instanceHash>` as a time-ordered index, so "the N coldest objects" would be a bounded scan from one end rather than a full sort. **No such report is implemented** — there is no CLI subcommand and no API route for it — but the index it would need is already maintained, so adding one is a scan and a formatter.
+
+Note what such a report would still be missing. `l:` is keyed by `instanceHash`, and **the store keeps no reverse mapping from an instance back to its path**: `CacheMetadata.SourceURL` is a cache field and `pstore` never writes it, so resolving cold objects to paths means walking `pd:` and building the mapping in memory. That is a sequential scan bounded by the number of objects, which is acceptable for a report, but it is a real cost and is the reason no such report exists yet.
+
+## 9. Deletion and garbage collection
+
+Three things produce garbage: overwrite (the superseded version), aborted writes, and deletion.
+
+**Delete a file** — remove its dirent and enqueue its `instanceHash` on `pg:`, in one transaction.
+
+**Delete a directory** — `RemoveAll` first tries to remove the whole subtree *inline*, in the same transaction that unlinks the directory from its parent (`deleteSubtreeInline` in `pstore/gc.go`), queueing each file's version for reclamation as it goes. The bound is deliberately the same batch size the janitor uses: a removal the janitor would finish in one pass may as well complete immediately. This covers nearly every real removal.
+
+Only a subtree too large for one transaction is deferred: the directory's own dirent is unlinked, making the subtree unreachable at once, and its root is enqueued on `pg:` for the janitor to drain. Deletion does not need to be atomic — a partially drained subtree must simply be invisible — so this is crash-safe without a journal.
+
+Finishing inline matters for more than latency. A detached subtree leaves its descendants in the index under keys that the same paths would reuse, so re-creating the tree before the drain completes would put new entries exactly where the drain is about to delete. Removing inline closes that window entirely, which is why the case §9.1 describes is rare in practice.
+
+### 9.1 Detached subtrees must be masked explicitly
+
+Unlinking the directory is **not** on its own enough to make the subtree unreachable. This is a direct consequence of path-derived keys, and it is the one place where the layout's cheapness has a cost that must be paid back explicitly.
+
+Under an inode index, descendants become unreachable the instant the parent's entry is gone, because reaching them requires walking through it. Here a lookup is a single point get computed from the path — which is precisely why listing a directory is cheap (§4.3) — and it never consults ancestors. So a descendant's key outlives its parent: after a deferred `RemoveAll("/tree")`, the key for `/tree/a/b/deep` is still present and still directly addressable.
+
+Verifying ancestors on every lookup would cost O(depth) gets on the hot path, which is the cost path-keying exists to avoid. Instead the store keeps the set of detached roots in memory (`detachedSet` in `pstore/detached.go`) and tests candidate paths against it. The set is empty except while a drain is in progress and holds one entry per deferred `RemoveAll`, so the check is an atomic load in the common case and a handful of string comparisons otherwise — and only on paths that should not resolve anyway. It is rebuilt from the `pg:` queue at open, so a store that stopped mid-drain does not expose a half-deleted tree when it comes back.
+
+Every path resolution goes through this check: `Stat`, `List`, opening for read or write, and the parent-directory checks in `Mkdir`, `MkdirAll`, and `Create`.
+
+**Reads inside a draining subtree report "not found"; writes report a distinct, retryable error.** Masking a read as `ErrNotExist` is correct — the object is gone. Masking a *create* the same way is not: the descendants still occupy the keys the new entries would use, and the drain will delete whatever it finds there, so a silently accepted write would be silently lost. `Create`, `Mkdir`, and `MkdirAll` therefore return `ErrDraining` (`pstore/errors.go`), which `statusForBackendError` in `origin_serve/error_handling.go` maps to **409 Conflict** — so a client can retry rather than treat the path as permanently broken or, worse, believe the write landed. The wait is bounded: the janitor accelerates while a backlog exists (§9.2), and only subtrees too large to remove inline are ever in this state.
+
+### 9.2 The janitor
+
+The janitor drains `pg:` in the background. For an object version it calls `StorageManager.DeleteIfUnpinned`, which removes the data files and releases the `u:` usage counters; for a detached subtree it removes a bounded batch of dirents per pass, queueing each file's version as it goes, and drops the queue entry once the subtree is empty.
+
+Its interval adapts to the backlog. Each sweep handles a bounded batch, so a fixed period would put a ceiling on how fast space can come back — deleting a tree of a million objects at one batch per resting period would take days, during which the store stays full and refuses writes. A sweep that fills its batch halves the wait, down to a floor; a sweep that does not steps back toward the resting period. Reclamation therefore accelerates exactly when there is something to reclaim and idles otherwise.
+
+**Reader pinning is mandatory, independent of any versioning feature.** Plain overwrite already lets the janitor reap an instance a reader is using. `refCountedFile` keeps the file descriptor alive across unlink on POSIX, but deleting `m:`, the data key, and the block state out from under a live `ObjectReader` breaks it. `local_cache/pin.go` therefore pins each `instanceHash` for the lifetime of its readers — `NewObjectReader` takes the pin itself, so there is no window between opening and being protected — and the janitor skips pinned entries and retries them on a later pass.
+
+Old versions are **not retrievable**. HTTP has no standard mechanism for requesting a specific historical ETag: `If-None-Match` is a negative precondition, `If-Match` returns 412 on mismatch rather than serving the named version, and RFC 7089 Memento is datetime-addressed and far heavier than this warrants. Rather than build a version index that nothing can address, superseded versions are garbage collected immediately. Nothing in the layout precludes adding retention later — it would be a new prefix plus a Pelican-specific addressing extension.
+
+## 10. Changes to `local_cache`
+
+Most of this is additive, but not all of it. The behavior changes are listed second, with their upgrade impact, because an operator upgrading a *cache* is affected by them even though they have no pstore.
+
+**Additive:**
+
+1. `AppendWriter` (`local_cache/append_writer.go`) — a streaming append helper over `InitLazyChunkedStorage`/`AllocateChunk`, so the write path does not have to reimplement chunk-crossing logic. `Finalize()` takes no arguments and returns `(*CacheMetadata, error)`: it flushes the buffered tail, records the true `ContentLength`, drops chunks the object never reached, and truncates the tail chunk file, refunding the over-allocation. It writes through `SetMetadata` rather than `MergeMetadata` because the merge-semantics comment on `CacheMetadata` (`local_cache/schema.go`) classifies `ChunkSizeCode` and `ChunkLocations` as **set-once**, so merging a trimmed chunk table over the allocated one would be rejected as a set-once violation rather than applied. (`MergeMetadata` is in `local_cache/database.go`.)
+1. Reader pinning (`local_cache/pin.go`) — a pin set on `StorageManager`, taken automatically by `NewObjectReader`, plus `DeleteIfUnpinned` and `IsObjectPinned`. It lives beside `NewObjectReader` and `Delete` because those are the two operations that must agree; a pin taken in a consumer could always be taken a moment too late.
+1. `CacheDB.DB()` — direct BadgerDB access for a sibling subsystem that needs read-your-writes transactions spanning several keys and prefix iteration with seeks. Callers must confine themselves to prefixes they own and must call `EnsureStoreMode` first.
+1. `CacheDB.EnsureStoreMode` and the `_mode` marker key, so a store and a cache cannot cross-open a database.
+1. `CacheDB.ReloadSalt`, so a restored catalog's hash salt replaces the one cached at open (§11.4).
+1. `StorageManager.SetChooseDir`, so a consumer without an `EvictionManager` can still control directory placement (§7).
+1. `ParseStorageDirsValue`, factored out of the `LocalCache.StorageDirs` parser so `Origin.PStoreStorageDirs` accepts the same two formats.
+1. `local_cache/checksum_format.go` — `ChecksumAlgorithmName`, `ParseChecksumAlgorithm`, `FormatChecksumValue`, `FormatDigestEntry`, `FormatDigestHeader`, and `NewChecksumHasher`, so the origin cannot drift from the value the cache would report for the same bytes.
+1. Documentation of the `pd:`/`pg:` prefix reservation next to the existing prefix constants.
+
+**Existing behavior that changed:**
+
+1. **`normalizeURL` folds only the scheme and host, never the path** (`local_cache/schema.go`), per RFC 3986 §6.2.2.1. Folding the path collapsed `/ns/Data.txt` and `/ns/data.txt` onto one cache entry, so a request for either returned whichever had been fetched most recently. The host is folded with IDNA rather than `strings.ToLower`, so the Unicode and punycode spellings of an internationalized name reach the same hash; a port is split off and preserved, and IP literals are left alone. See §12.
+1. **`StorageManager.EvictByLRU` gained a skip predicate and a fourth return value.** It now passes `pins.isPinned` down to `CacheDB.EvictByLRU` (whose signature gained the predicate and a skipped count) and reports how many candidates were spared. `EvictionManager.evictFromNamespace` changed signature to carry the count through, and both `checkAndEvict` and `forcePurgeToTargets` now stop a pass that freed nothing instead of looping until their timeout. **Upgrade impact:** none for an operator. A cache spares objects under a live reader that it would previously have deleted mid-transfer, and logs `skippedInUse` when it does.
+1. **`formatDigestHeader` and `ConsistencyChecker.createHasher` were extracted** into `local_cache/checksum_format.go` and now delegate. Pure refactor; the emitted header is unchanged.
+1. **`StorageManager.Close` no longer hangs on a read-only manager.** `ttlcache.Stop()` is an unbuffered send its `Start` loop receives, and `NewStorageManagerReadOnly` never spawns those loops, so stopping them blocked forever. This affected `pelican cache introspect` before pstore existed. **Upgrade impact:** a hang on exit goes away.
+
+**Announcing schema changes.** `_mode` says who owns a database; `_schema` (`KeySchemaVersion`, `CurrentSchemaVersion`) says what layout it uses. It is stamped when a database is created, and checked at open: a database written by a build with a *newer* schema is refused with both versions named, because reading a newer layout under older rules is exactly the corruption the marker exists to prevent. A database with no marker predates versioning and is adopted at the current version, so deployed caches keep starting. `migrateSchema` is the seam a future bump hooks into. The object-hash derivation in this branch changed once without such a marker to announce it, which is the gap `_schema` closes for the next one.
+
+Downgrade is safe in both directions that matter. An older build ignores the unknown `_mode` key, and `EnsureStoreMode` **adopts** a pre-existing unmarked cache database rather than refusing it (`local_cache/database.go`), so upgrading a running cache is a no-op at startup. The asymmetry is deliberate: an unmarked *non-empty* database can only be a legacy cache, since pstore always writes the marker, so it is adopted as a cache and refused as a pstore.
+
+**The permanent coupling this creates:** `CacheMetadata` and the block layout now have two consumers. Concretely, the set-once classification of the chunking fields is now load-bearing for `pstore`'s streaming write, and the block-level checksum machinery is shared. `pstore`'s tests run in the same CI, which is the mitigation.
+
+## 11. Integrity, backup, and recovery
+
+An origin cannot re-fetch what it loses. Every design decision in this section follows from that one asymmetry with the cache.
+
+### 11.1 Checksums at ingest
+
+A rolling checksum over the write stream costs no extra I/O and is stored in `CacheMetadata.Checksums` (`pstore/checksum.go`). MD5, SHA-1, and CRC32C are recorded for every object; the set is fixed rather than configurable, because computing one later would mean re-reading the object, which is the cost this exists to avoid.
+
+`Want-Digest` responses then become a metadata read instead of a full object re-read — a concrete advantage over the POSIX backend's xattr scheme, which depends on filesystem xattr support and on the checksum having been computed at some earlier point. Because the digests belong to the *version* rather than the path, an overwrite cannot leave a stale checksum behind the way an mtime-validated xattr cache can. Naming and encoding come from `local_cache/checksum_format.go`, so the origin cannot report a different string than the cache would for the same bytes.
+
+The checksummer is selected by the storage-type switch that builds each export's backend in `origin_serve/handlers.go`; `pstoreBackend.Checksummer` returns `pstoreChecksummer`, and the POSIX backend's xattr scheme is not involved.
+
+### 11.2 fsck
+
+`Store.Fsck` (`pstore/fsck.go`) walks the index rather than the storage directories, so it is bounded by the number of objects rather than by their size, and it reports before it repairs.
+
+**It is streaming and bounded in memory, deliberately.** A consistency check that needs the whole index resident is a check that stops being runnable exactly when a store gets big enough to need one. So neither the scan nor the comparison holds a whole-index view: `scanIndexBatched` and `scanMetadataHashes` reopen a read transaction every few thousand keys rather than pinning one for the duration — which also keeps a long check from holding back BadgerDB's compaction — and the one comparison that genuinely needs a set in memory, "which object versions does no entry refer to", is partitioned over hex prefixes of the instance-hash space against a **memory budget** rather than against the object count. A store too large for one pass degrades in scan time, not in footprint. The partitioning is exposed as an option, which is what lets the hourly scheduled check rotate through a fraction of the keyspace per pass (§11.3) instead of choosing between full coverage and affordability.
+
+It checks:
+
+- every dirent's generation resolves to an `m:` record whose write completed; an entry with no metadata is *dangling*, and one whose `Completed` is zero is an *incomplete write*;
+
+- every `m:` record is reachable from `pd:` — the index walk builds the set of reachable `instanceHash`es and a metadata scan diffs the catalog against it. (Reachability is computed from generations, not from any recorded path: `pstore` writes no `SourceURL`, and there is no reverse mapping from an instance back to a path.)
+
+  **Unreachable is not the same as abandoned**, and conflating the two would make fsck delete live uploads. A version that a write is building right now is also unreachable from the index — the dirent does not exist until commit. Three conditions must therefore all hold before a version is called an orphan: it is not on the `pg:i:` reclamation queue, it has no `aw:` append intent recorded against it, and its `Completed` timestamp is non-zero and older than `MinAge` (default five minutes; `FsckNoGracePeriod` waives it for tests and for an operator who has stopped the origin). Anything that fails only the age or intent test lands in a separate **`PendingInstances`** bucket, which is reported and **never repaired** — the honest answer for "this looks unreferenced but may simply be young".
+
+  Note also that `pg:i:` now carries two meanings: as well as versions awaiting reclamation, an entry may be a tombstone for a write still in flight. Consumers of that queue must respect reader pins and re-read state rather than assuming an entry is safe to free on sight.
+
+- orphans are enqueued on `pg:` when repairing, rather than deleted inline, so reclamation goes through the one path that respects reader pins.
+
+- usage counters agree with reality. This deliberately does **not** use `CacheDB.ComputeActualUsage`: that sums raw `ContentLength`, whereas the counters are charged `CalculateFileSize` — the on-disk size including each block's authentication tag. Comparing the two reports phantom drift of exactly the MAC overhead on every healthy store. fsck instead totals `CacheMetadata.PerDirectoryBytes`, which yields the same quantity the counters hold and is what the write and reclaim paths already use.
+
+- with `--deep`, stored checksums are verified against the data, through `local_cache.ConsistencyChecker.VerifyObject`. This is the only check that detects at-rest corruption, because everything else reads only the catalog.
+
+`--repair` unlinks dangling entries, queues orphans for the janitor, and corrects the catalog's usage counters before reseeding the in-memory ones from them. `PendingInstances` is never acted on.
+
+fsck is a backstop, not a load-bearing part of correctness: every mutation that makes data unreachable also queues it for reclamation in the same transaction.
+
+### 11.3 Scheduled integrity checks
+
+`pstore/integrity.go` runs two passes on independent schedules, because they cost very different amounts:
+
+| Pass        | Parameter                         | Default | Cost                   |
+| ----------- | --------------------------------- | ------- | ---------------------- |
+| Index check | `Origin.PStoreIndexCheckInterval` | 1h      | catalog only           |
+| Data scan   | `Origin.PStoreDataScanInterval`   | 24h     | reads every block back |
+
+`Origin.PStoreDataScanRate` (default 100MB/s) caps the verification read rate so the scan does not compete with serving. Zero disables either pass.
+
+Both intervals are a **minimum gap between the end of one pass and the start of the next**, not a fixed cadence. A data scan of a large store can legitimately take longer than its own interval, and a ticker would then start the next pass the moment the previous one finished, verifying continuously. A pass that outlasts its interval is logged at warn level so the operator can see that the configured frequency is not achievable at this store's size.
+
+The index check is `Fsck` in report-only mode; findings are logged at error level, because an inconsistent index means some object is either unreachable or holding space nothing accounts for. Because the orphan comparison is the expensive part (§11.2), the hourly check rotates through **one sixteenth of the instance-hash space per pass**, so the whole store is covered roughly daily at a fraction of the memory a single full pass would need — full coverage over time rather than a choice between full coverage and affordability. The data scan reuses the cache's `ConsistencyChecker.RunDataScan` for the reading and rate limiting, and reports how many objects *this pass* found mismatching (the checker's statistics are cumulative, so the count is taken as a difference).
+
+**Neither pass modifies anything, and for a pstore that is not a tuning choice but a correctness requirement.** This is the sharpest example of why a cache's integrity machinery cannot simply be reused by an origin. The cache's scan **deletes** an object whose data no longer matches its checksums, and for a cache that is not merely acceptable but correct: the next request re-fetches it and the object is repaired. An origin has no upstream, so the identical code path destroys the only copy — and with it the only record of the object's path, size, and checksums, after which `fsck --repair` would reclassify the surviving entry as dangling and remove that too. One flipped bit would become two deletions and a silently shorter namespace.
+
+The behavior is therefore pinned in code rather than by convention: `ConsistencyConfig.PreserveCorruptObjects` keeps the corrupt object, and `SkipChecksumBackfill` suppresses the one other write the scan would make (recording checksums for an object that has none). Both are set centrally by `newPStoreScanConfig`, which exists as a function rather than a literal at each call site precisely so that a future caller cannot forget them. The cache's own behavior is unchanged — it still deletes and re-fetches, because that is right for a cache.
+
+Repair stays a deliberate operator action through `pelican-server origin pstore fsck --repair`, because the right response to a corrupt object is a judgement call — restore it, re-ingest it, or accept the loss — and not one a background task should be making at three in the morning.
+
+### 11.4 Metadata backup and restore
+
+For a cache, losing the database is an inconvenience: every object in it can be fetched again. For an origin it is data loss. The block files are named by hash and encrypted, and everything needed to interpret them — the namespace, each object's data key, its size, its checksums — lives in the catalog. A store whose catalog is gone is a directory of unreadable bytes.
+
+So the catalog is backed up separately from the data, and far more often than its size would suggest is necessary. It is small (megabytes against terabytes of objects) and BadgerDB can stream a consistent snapshot of it at a fixed read timestamp while the origin is running, so a periodic backup costs almost nothing and is coherent even while writes continue.
+
+**Every backup is complete.** BadgerDB can emit only what changed since a given version, but a base-plus-incremental chain is unrestorable here: `Restore` refuses a store that already holds objects, which is exactly what applying an increment on top of a base would require. An incremental that cannot be restored is not a backup, so there is no incremental mode. The catalog is small enough that this costs little.
+
+**Scheduling.** `Store.StartBackups` (`pstore/backup.go`) writes a timestamped file into `Origin.PStoreMetadataBackupLocation` and prunes the oldest beyond `Origin.PStoreMetadataBackupsToKeep` (default 24). `Origin.PStoreMetadataBackupInterval` (default 6h) is measured **from the end of one snapshot to the start of the next**, not as a fixed cadence: a snapshot of a large catalog can take a while, and a fixed ticker would start the next one the moment a slow pass finished, leaving the origin snapshotting continuously. A pass that outlasts its own interval is logged at warn level, which is the operator's signal that the interval is tighter than the store's size allows. The interval is spaced rather than hourly because a snapshot is not merely a list of names: objects below `Origin.PStoreInlineMaxBytes` live in the catalog itself (§5.3), so a store holding many small objects has a catalog with all of their *contents* in it, and every snapshot is complete rather than incremental. Retention multiplies whatever that costs. Keeping several allows rolling *back* to a point before a corruption rather than only forward from the most recent. Each pass writes to a `.partial` name and renames on success, so a crash mid-write never leaves a truncated file that looks usable. A failed pass is logged and retried at the next interval: a backup problem must not take the origin down. An empty location disables the whole thing.
+
+**Encryption is unconditional.** BadgerDB's backup is a *logical* dump: values come back decrypted, so a raw snapshot is cleartext. It contains every object path, all the metadata, and the hash salt that makes on-disk filenames unguessable — writing that to a backup directory would undo the at-rest protection the store exists to provide. `pstore/backup_crypto.go` seals every snapshot with AES-256-GCM, and there is no code path that writes one any other way: `Store.BackupEncrypted` is the only exported writer, and it fails when it has nothing to seal to. An earlier design made encryption conditional on the operator having created a key and warned at startup when they had not; a startup warning is the weakest possible control for a file that leaks the whole namespace, and the failure it guards against is silent and permanent.
+
+**There are three levels of key, and any one of them opens an archive.** That is the shape of the scheme, and it exists because a recovery happens on whatever the operator still has, which cannot be known when the backup is written.
+
+| Level | What it is                                | Where it comes from                                                                                          | What it opens                |
+| ----- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| 1     | The origin's **issuer keys** (the master) | Already on the origin; nothing to create                                                                     | Everything this origin wrote |
+| 2     | The **backup key** (the intermediate)     | `HKDF-SHA256(issuer key PKCS8, info = LabelPStore)`                                                          | Everything this origin wrote |
+| 3     | The **per-file key**                      | `HKDF-SHA256(ikm = backup key, salt = the file's salt, info = "pelican pstore metadata backup file key v1")` | Exactly one archive          |
+
+**Level 2: the backup key.** `backup_keys.DeriveKeyPair` runs HKDF-SHA256 over the PKCS8 encoding of an issuer JWK and reads out a Curve25519 private key; `ScalarBaseMult` gives the public half. The info string is the *label*, which is the whole point of the shared package: `backup_keys.LabelPStore` (`pelican-pstore-backup`) and `backup_keys.LabelDatabase` (`pelican-backup-encryption`) derive unrelated keys from the same issuer key, so escrowing a pstore backup key with a custodian does not also hand them the server database's backups, and vice versa. `LabelDatabase` is frozen — it is baked into every database backup ever written — and `backup_keys` carries a known-vector test asserting so, because a refactor that changed the derivation would round-trip perfectly through its own tests while making every existing archive undecryptable.
+
+The derivation is one-way, so a leaked backup key does not yield the issuer key behind it.
+
+**Level 3: a key per archive.** The body is encrypted under a key belonging to that snapshot alone: HKDF-SHA256 over the backup key, salted with 32 random bytes drawn for that snapshot and stored in its header, under an info label distinct from the one that produced the backup key so the two levels are domain-separated. This is what makes it possible to hand out *one* backup. Giving somebody the level-2 key gives them the whole series; giving them a file's own key gives them that file, and reveals nothing about any other — the salts are independent, and HKDF is one-way in the input key material.
+
+It is also what keeps the nonce safe. With a key unique per archive the chunk nonce only has to be unique *within* one, so it can be a pure counter.
+
+**The backup key travels inside the archive, encrypted.** Each recipient gets its own envelope block — a NaCl box, sealed to itself so the private key alone opens it — carrying the archive's backup key, and any one of them opens it. This is the same multi-recipient shape `database/backup.go` uses, and it is what makes **key rotation free**: an archive written while an old and a new key were both live still opens after the old one is retired, and an archive written before the new key existed is still opened by the old one wherever it survives. When nothing available opens an archive, `pstore.ErrNoMatchingKey` reports the key IDs it *was* sealed to, which is the only thing that tells an operator what to go and find.
+
+The archive's backup key is the one derived from the first issuer key in sorted order, and it is itself one of the recipients. That detail makes the level-2 recovery path uniform: whichever escrowed backup key an operator produces, it opens *its own* envelope block, which yields the archive's backup key, which derives the per-file key. When the key produced happens to be the archive's own, that block hands it straight back — so there is one code path rather than a special case for "the operator has the right one of several backup keys".
+
+**The three ways in**, all exercised independently by `TestThreeWaysToOpenASnapshot`:
+
+```
+an issuer key   → derive its key pair → open the envelope → the backup key
+                  → HKDF with the salt in the header → the per-file key → decrypt
+a backup key    → open the envelope with it → the archive's backup key
+                  → HKDF with the salt in the header → the per-file key → decrypt
+a per-file key  → decrypt.  No derivation, no envelope, no issuer key present.
+```
+
+**Disaster recovery, and handing out one archive.** `pelican-server origin pstore metadata-backup-key` re-derives and prints a key rather than generating one, so running it twice on the same origin prints the same answer and an operator can file it away. With no argument it prints the **level-2 backup key**, whose 32 bytes restore any backup on a machine that has never held this origin's issuer keys (`pstore metadata-restore --key-file`). That answers the objection that motivated the original design: a backup outlives the machine it came from and usually leaves it, so it must not depend on keys that live only on that host. Deriving rather than generating gets that property *and* removes the secret an operator could fail to create.
+
+Given a **backup file**, the same command instead prints **that file's own key**: it reads the salt out of the named file and re-derives level 3, using the origin's issuer keys or — with `--key-file` — an escrowed backup key, so an operator holding only the escrowed key can still produce a specific file's key without the issuer keys ever being present. `pstore metadata-restore --file-key` consumes it. The two forms are deliberately hard to confuse: the output on stderr says which key it just printed and what that key does *not* open, because handing over the backup key when one file's key was meant is a silent over-disclosure of the whole series.
+
+There is deliberately **no configuration knob for the backup key**. The hierarchy leaves nothing for one to do: the escrowed level-2 key covers custody off the host, and the level-3 key covers giving a single archive away. A standing parameter would only add a second place for a secret to be mislaid. `pelican-server origin pstore metadata-backup --key-file` seals a one-off archive to a supplied key, which is an explicit operator action rather than configuration.
+
+Object *contents* are not exposed by any of this — each object's data key is stored already wrapped by the master key, so the block files stay protected even if a snapshot leaks. The namespace is what needs covering.
+
+**Format.** The snapshot is **compressed and then sealed**, which is the only order that works: ciphertext is incompressible, so compressing afterwards would achieve nothing, and a catalog of repetitive path strings and structurally similar records compresses extremely well. (The usual objection to compress-then-encrypt is a length side channel under adaptively chosen plaintext; a snapshot is written once, from data the attacker does not control interactively, with no oracle to query.)
+
+The file begins with a **versioned magic header** (`PELICAN-PSTORE-BACKUP\x00` plus a version byte, currently `\x01`), so a file that is not a snapshot, or is in a version this build does not read, is refused with something better than a decryption failure — the family prefix is matched rather than the exact version, so a snapshot whose version this build does not read is refused by number instead of being called corrupt. The magic is followed by the **32-byte salt** and then the **recipient envelope**: a count, and per recipient a key ID and the sealed backup key.
+
+The body is a sequence of sealed fixed-size chunks, each carrying its sealed length. Every chunk is bound to its position by the counter in its nonce and to *this* archive by the **whole header — magic, salt, and every envelope block — passed as additional authenticated data**; the terminating chunk is marked in both the framing and the nonce. So reordering, dropping, truncating, or splicing chunks between archives is detected rather than silently producing a short restore; the salt cannot be swapped, which would otherwise silently change which key the file claims to want; and recipients cannot be stripped, added, or lifted from another archive. `TestHeaderIsBoundToTheBody` splices each of those three regions between two same-shaped archives and requires every one to be refused. Chunking keeps memory flat for a snapshot of any size; the snapshot is piped from BadgerDB through the compressor to the sealer rather than buffered.
+
+One container version exists. The version byte is carried anyway so that a future format change has a mechanism already in place: a file whose version this build does not read is refused by number rather than decoded, which `TestAnUnsupportedFormatVersionIsRefused` pins along with the agreement between the magic's trailing byte and `backupFormatVersion`.
+
+**Restore.** `Store.Restore` is the single entry point for every archive the project has written, sealed or not: it reads the container from the file's own magic, so an operator never has to know which release produced the snapshot they are holding. It refuses a store that already holds objects: restoring over live records would interleave two namespaces rather than replace one. **The store must be reopened afterwards** — a restore replaces the whole database, including everything a store reads once at open and then caches: the hash salt every instance hash is derived from, and the storage-ID-to-directory mapping. `Restore` calls `ReloadSalt` and rebuilds the detached set so that a caller inspecting the namespace immediately afterwards sees the right thing, but reading object data requires a fresh open.
+
+**A failed restore is not a no-op, and cannot be unwound.** BadgerDB's loader writes as it reads, so a snapshot that turns out to be damaged part-way through leaves records in the directory *and* leaves the transaction watermark short of the timestamps it already wrote — so the handle blocks on the next read and the directory holds a fragment of a namespace. Nothing in `pstore` can undo either. What it can do is say so: the error tells the operator that the directory must be **discarded** and the restore started again into a fresh one, rather than letting a retry into the same directory build a chimera out of two catalogs. This is also the reason both containers verify eagerly — most damage is caught before a single record is written, and damage caught late at least reports what state it left behind. An operator should know this *before* a recovery, not during one.
+
+**A backup is only useful alongside two other things**, and the CLI and parameter documentation both say so rather than letting an operator discover it during a recovery:
+
+- the **block files**, which ordinary filesystem backup tools handle; and
+- **`masterkey.json`** in the store directory, which wraps the key everything is encrypted under. It is itself encrypted under the origin's issuer keys, so those must survive too.
+
+The normal recovery is therefore: restore a metadata backup into a fresh directory that already holds the block files and `masterkey.json`, then point the origin at it — or export from it (§11.5).
+
+### 11.5 Recovery export
+
+A store is not something an operator can read with ordinary tools, so the recovery path is part of the product rather than an exercise left to whoever is having the bad day. `Store.Export` (`pstore/recover.go`), driven by `pelican-server origin pstore export --to <dir>`, writes a subtree out as plain files in a normal directory tree: no Pelican, no origin, no client, just the data.
+
+It runs against a store opened for maintenance (§11.6), pages through listings rather than materialising them, and **continues past objects it cannot read**, collecting them in a report — on a damaged store, recovering most of the data and being told exactly what was lost is far more useful than stopping at the first bad block. `--verify` checks each object against its recorded checksums as it is written, so a recovery does not quietly reproduce corrupt data; `--dry-run` reports what would be written. Destinations are created exclusively, so a recovery never silently overwrites what is already there, and every destination path is re-checked against the export root, because a recovery may be run against a damaged or hand-edited catalog.
+
+### 11.6 Introspection: offline CLI and live API
+
+There are two, because they answer different questions.
+
+**Offline.** `pstore.OpenMaintenance` (`pstore/maintenance.go`) backs `pelican-server origin pstore {ls, stat, du, fsck, digest, metadata-backup, metadata-restore, export}`. The origin must be stopped: BadgerDB takes a directory lock on open, and a consistency check racing a live origin's writes would not mean anything. When writes are not allowed, every mutating entry point refuses in Go, so an inspection command cannot modify the store even by mistake. This deliberately does not use BadgerDB's `ReadOnly` mode — that takes a shared flock rather than an exclusive one, which buys no concurrency against a running origin, fails outright on some platforms, and would block `fsck --repair`.
+
+An inspection command takes a read-only mode check that never writes and so never adopts an unmarked database: a CLI pointed at the wrong directory should say so rather than claim it.
+
+**Live.** Because the database holds an exclusive lock while the origin runs, "what is in there right now" can only be answered by the running process. `origin_serve/storage_api.go` mounts, under `/api/v1.0/origin/storage/pstore`, four **administrator-only** routes: `ls/*path`, `stat/*path`, `digest/*path`, and `usage`. `cmd/origin_introspect.go` is the client (`pelican-server origin introspect …`).
+
+The path is chosen so the scope is obvious: this describes the storage backend, not the origin's role in a federation. Nothing here serves objects, participates in discovery, or is reachable by a federation client. Registering nothing at all when the backend is not a pstore is deliberate — a 404 tells an operator that this origin has no such interface, which is better than a route that exists and always fails.
+
+Only operations that are meaningful against a moving target are exposed. Listing, stat, usage, and digests all describe a moment and are honest about it. A consistency check is not: scanning an index while it is being rewritten produces findings indistinguishable from real ones, so fsck stays offline where its answers mean something. Repair is likewise absent — changing a store underneath a running origin is not something to offer over HTTP.
+
+### 11.7 Metrics
+
+The collectors live in `metrics/pstore.go`, `promauto`-registered at init like the rest of the package, and are fed from `pstore` at the points below. Registration is process-wide, which is what makes it safe for several exports to share one store — they do — and for a process to run both a cache and an origin.
+
+There is deliberately no `store` label. `Origin.PStoreLocation` is a single process-wide parameter, so a server process has exactly one store; the offline CLI opens its own, in a process nothing scrapes. Storage directories are owned exclusively by one store, so the `directory` label is unambiguous regardless.
+
+| Metric                                                                                                                                                                                                   | Type          | Fed from                                               |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | ------------------------------------------------------ |
+| `pelican_pstore_used_bytes`, `pelican_pstore_limit_bytes`                                                                                                                                                | gauge         | `Store.Open`, then every janitor sweep                 |
+| `pelican_pstore_directory_used_bytes{directory}`, `pelican_pstore_directory_limit_bytes{directory}`                                                                                                      | gauge         | the same, per storage directory plus `(inline)`        |
+| `pelican_pstore_objects`                                                                                                                                                                                 | gauge         | the index check's entry walk                           |
+| `pelican_pstore_scheduled_passes_total{pass}`, `..._pass_failures_total{pass}`, `..._pass_last_success_timestamp_seconds{pass}`, `..._pass_last_duration_seconds{pass}`, `..._pass_overruns_total{pass}` | counter/gauge | `passObserver`, around all three scheduled loops       |
+| `pelican_pstore_metadata_backup_last_size_bytes`                                                                                                                                                         | gauge         | `snapshotOnce`, after the rename publishes             |
+| `pelican_pstore_data_scan_mismatches_total`, `..._objects_total`, `..._bytes_total`                                                                                                                      | counter       | the checker's stats, differenced per pass              |
+| `pelican_pstore_fsck_findings{kind}`                                                                                                                                                                     | gauge         | end of every `FsckWith`                                |
+| `pelican_pstore_reclamation_pending{kind}`, `pelican_pstore_detached_subtrees`                                                                                                                           | gauge         | the janitor, once per resting interval                 |
+| `pelican_pstore_reclaimed_objects_total`, `..._bytes_total`, `pelican_pstore_abandoned_writes_reclaimed_total`                                                                                           | counter       | each `RunGC` sweep                                     |
+| `pelican_pstore_writes_total{tier}`                                                                                                                                                                      | counter       | `WriteHandle.Close`, from the tier `materialize` chose |
+| `pelican_pstore_write_failures_total{reason}`, `pelican_pstore_write_conflict_retries_total`                                                                                                             | counter       | `HasCapacityFor`, `ensureReserved`, `install`          |
+
+Four constraints shaped this, and they are worth stating because they are what a future addition has to respect.
+
+**A gauge describes a level, so it must be right after a restart rather than after the first event.** The capacity gauges are published at the end of `Store.Open`, from the figures `newCapacityTracker` has just recovered from the catalog. Left to the write path they would read zero for however long it took the next PUT to arrive — precisely the window in which somebody restarting a full origin looks at the dashboard.
+
+**Nothing is measured on a serving path, and nothing is measured with a syscall.** The capacity gauges are republished by the janitor, which runs whether or not anything is happening, so an idle store stays current and a busy one pays nothing; `chooseDir` and the reservation fast path are untouched. The one measurement that is not already in memory is the reclamation backlog, a keys-only scan of the `pg:` prefix — free on a healthy store, proportional to the backlog on a sick one, which is exactly the case that also makes the janitor sweep four times a second. So it is rate-limited to the resting interval rather than taken per sweep, and the gauge is at most that stale.
+
+**The queue depth is counted to the end.** `collectGarbage` stops at `janitorBatchSize` because it holds what it collects; `queueDepth` holds nothing and reports the real number. A count saturating at the batch size would make a queue of half a million look identical to a stable one of five hundred — the two cases the gauge exists to tell apart.
+
+**Failure to observe is never failure to serve.** A backlog measurement that errors leaves the gauge at its previous value rather than publishing a zero that would read as "the backlog cleared", and logs at debug.
+
+**The `pelican_cache_data_scan_*` overlap is resolved at the source.** pstore's scheduled data scan is `local_cache.ConsistencyChecker.RunDataScan`, which is also the cache's, so an origin used to report its integrity scan under cache-named series — and a process running both added the two together with no way to separate them. `ConsistencyConfig.SuppressCacheMetrics`, set by `newPStoreScanConfig`, stops the checker from touching those collectors; the checker's own `ConsistencyStats` are unaffected, and `observeDataScan` differences them into `pelican_pstore_data_scan_*` at the end of each pass. Nothing is counted twice, and nothing is lost except granularity: the cache updates its counters after every object, while these step once per completed pass. `pelican_pstore_scheduled_pass_last_success_timestamp_seconds{pass="data_scan"}` is what says a pass is in progress or stuck.
+
+Two label sets are narrower than they look, on purpose. `pelican_pstore_fsck_findings` is one gauge per class rather than one series per finding: the findings are paths, and a store with a hundred thousand dangling entries would otherwise put a hundred thousand series into the registry at the moment it can least afford it. And within that family, `orphaned_instances` and `pending_instances` are per *examined slice* of the instance-hash space, not store-wide totals, because the scheduled index check covers one sixteenth per pass to bound its memory (§11.3); publishing them only from an exhaustive pass would leave them frozen forever in a server process.
+
+## 12. Path case sensitivity
+
+Object paths are case-sensitive. `/ns/Data.txt` and `/ns/data.txt` are different objects, on every backend Pelican serves and therefore here.
+
+This is easy to get wrong in a hashing layer: case-folding the whole URL collapses two case-variant paths onto one cache entry, and a request for either returns whichever was fetched most recently. Only the scheme and host may be folded — those are case-insensitive per RFC 3986 §6.2.2.1 — and the path never. The host folding is IDNA rather than a plain lowercase, so an internationalized name hashes the same however it is spelled; see §10.
+
+`pstore` is structurally immune to a repeat, because an object's storage key derives from its generation rather than its path (§5); a path only ever indexes an entry. But `validatePath` and the key encoding still assume exact bytes, so any future normalization added to the index must fold nothing in the path.
+
+## 13. Configuration
+
+New storage type `pstore`:
+
+- `server_structs.OriginStoragePStore` added to `ParseOriginStorageType`.
+- `UsesXRootD()` returns false.
+
+### 13.1 `SupportsSelfTest()`
+
+`SupportsSelfTest()` (`server_structs/origin.go`) gates the origin's write-read self-test probe. It has exactly two non-test call sites, and both are that probe:
+
+- `config/config.go` — disables `Origin.SelfTest` and `Origin.DirectorTest` at startup for backends that cannot accept it.
+- `director/director.go` — forces `DisableDirectorTest` on the advertised ad for the same reason.
+
+It returns true for `posix`, `posixv2`, and `pstore`. The probe writes a small object and reads it back, which needs a local writable backend, not a POSIX one — which is why the predicate is named for what it decides rather than for a family of backends. `server_structs/origin_test.go` pins the truth table.
+
+Two adjacent gates are separate and unaffected:
+
+- **Atomic uploads (POSC)** gate on a direct `ost != OriginStoragePosix` equality in `config/config.go`. `pstore` is correctly rejected there, and that is the desired outcome — `pstore` has native atomic overwrite (§6) and must not use the rename-based POSC machinery.
+- **The xattr checksummer** is not gated by a predicate at all; it is selected by the storage-type switch that picks `newLocalBackend` in `origin_serve/handlers.go`. `pstore` supplies its own checksummer (§11.1).
+
+### 13.2 Parameters
+
+Added to `docs/parameters.yaml`, with the generated param files regenerated:
+
+| Parameter                             | Meaning                                                         |
+| ------------------------------------- | --------------------------------------------------------------- |
+| `Origin.PStoreLocation`               | Store root: catalog, and data unless `PStoreStorageDirs` is set |
+| `Origin.PStoreStorageDirs`            | Multi-directory form; same schema as `LocalCache.StorageDirs`   |
+| `Origin.PStoreInlineMaxBytes`         | Inline-vs-disk threshold (§6.1)                                 |
+| `Origin.PStoreMetadataBackupLocation` | Directory receiving scheduled metadata backups (§11.4)          |
+| `Origin.PStoreMetadataBackupInterval` | How often a metadata backup is written                          |
+| `Origin.PStoreMetadataBackupsToKeep`  | Retention count, oldest pruned first                            |
+| `Origin.PStoreIndexCheckInterval`     | Scheduled catalog-only consistency check (§11.3)                |
+| `Origin.PStoreDataScanInterval`       | Scheduled read-back verification of every object                |
+| `Origin.PStoreDataScanRate`           | Read rate cap for the data scan                                 |
+
+There is no total-size or reserved-space parameter: capacity comes from the per-directory `MaxSize` values in `Origin.PStoreStorageDirs` (§7).
+
+Either `Origin.PStoreLocation` or `Origin.PStoreStorageDirs` must be set when the storage type is `pstore`; `PStoreOrigin.validateExtra` refuses the configuration otherwise. Export configuration lives in `server_utils/origin_pstore.go`, following `origin_s3v2.go`. `StoragePrefix` defaults to `/` and is validated as a logical path only.
+
+## 14. Testing
+
+- **Unit** — index operations and key ordering (`pstore/index_test.go`), namespace operations and pagination (`store_test.go`), the write tiers, conditional writes, abort, rename, detached subtrees and recreation while draining (`object_io_test.go`), the afero adapter including `Readdir` pagination and `Stat` on an open write handle (`fs_test.go`), capacity and `ENOSPC` including per-directory placement (`capacity_test.go`), ingest checksums and fsck against deliberately corrupted state (`checksum_fsck_test.go`), offline maintenance (`maintenance_test.go`), and backup, restore, retention, and export (`backup_test.go`).
+- **`local_cache`** — `append_writer_test.go` covers the streaming writer including over-allocation refund; `pin_test.go` covers reader pinning and the eviction skip; `schema_test.go` pins the case-sensitivity fix.
+- **`origin_serve`** — `backend_pstore_test.go` covers serving through WebDAV, PROPFIND, storage prefixes, parent auto-creation, capacity reporting, and `ENOSPC` → 507; `storage_api_test.go` covers the live API including admin gating; `preconditions_test.go` covers conditional-write parsing.
+- **Concurrency** — `TestConcurrentWritesStayWithinTheCeiling` (sixteen in-flight writers against a bounded store, checking the reservation accounting never lets the ceiling be crossed and never leaks a reservation), `TestConcurrentOverwriteAndOpenNeverFailsSpuriously` (two thousand opens against a live overwriter with the janitor running — the pin/GC race), and `TestConcurrentWritesToOnePathElectOneWinner` (eight racing writers, exactly one winner) in `pstore`; `TestConcurrentConditionalWritesElectOneWinner` and `TestConcurrentCreateOnlyPutsElectOneWinner` in `origin_serve`, which exercise the same property through the WebDAV handler. `TestReaderSurvivesOverwrite` and `TestGCReclaimsSupersededVersionOnceUnpinned` cover the sequential forms.
+- **Reuse** — `origin_serve/pstore_serving_test.go` and `origin_serve/storage_api_authz_test.go` drive `pstore` through the origin's real serving and authorization stack. The pre-existing `directory_listing_test.go` and `path_traversal_test.go` suites are still **not** wired to `pstore`; `pstore` has its own path-constraint tests (`TestValidatePath`, `TestCleanRelative`, `TestSiblingPrefixIsolation`), so this is redundancy not yet taken rather than a gap in coverage.
+- **e2e** — `e2e_fed_tests/pstore_test.go` runs a federation with `Origin.StorageType: pstore` covering upload, download, an object past the spill threshold, overwrite, stat, list, and delete through the Pelican client.
+
+## 15. Follow-on design needed
+
+**Lot bootstrapping.** Before path-based quotas can be enforced, a separate design has to settle how lots are created for an existing store, how they map onto exports and federation prefixes, what happens to paths covered by no lot, and whether ancestor byte accounting is maintained synchronously by `pstore` or owned by LotMan. `lotman` being Linux-only (§7.2) belongs to that design too.

--- a/e2e_fed_tests/pstore_test.go
+++ b/e2e_fed_tests/pstore_test.go
@@ -1,0 +1,235 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package fed_tests
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/fed_test_utils"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/test_utils"
+	"github.com/pelicanplatform/pelican/token"
+	"github.com/pelicanplatform/pelican/token_scopes"
+)
+
+// pstoreOriginConfig builds an origin backed by the Pelican store.
+//
+// StoragePrefix is a logical path inside the store rather than a directory on
+// disk, but NewFedTest rewrites it to a temp path regardless; that is harmless
+// here because the store treats it as an opaque prefix and creates it on first
+// write.
+func pstoreOriginConfig(storeDir string) string {
+	return fmt.Sprintf(`
+Origin:
+  StorageType: pstore
+  PStoreLocation: %s
+  Exports:
+    - StoragePrefix: "/data"
+      FederationPrefix: "/test"
+      Capabilities: ["PublicReads", "Writes", "Listings"]
+Director:
+  MinStatResponse: 1
+  MaxStatResponse: 1
+`, storeDir)
+}
+
+// getPStoreToken mints a token with read, create, and modify scopes.
+func getPStoreToken(t *testing.T) string {
+	t.Helper()
+	issuer, err := config.GetServerIssuerURL()
+	require.NoError(t, err)
+
+	tokenConfig := token.NewWLCGToken()
+	tokenConfig.Lifetime = time.Minute
+	tokenConfig.Issuer = issuer
+	tokenConfig.Subject = "origin"
+	tokenConfig.AddAudienceAny()
+
+	readScope, err := token_scopes.Wlcg_Storage_Read.Path("/")
+	require.NoError(t, err)
+	createScope, err := token_scopes.Wlcg_Storage_Create.Path("/")
+	require.NoError(t, err)
+	modScope, err := token_scopes.Wlcg_Storage_Modify.Path("/")
+	require.NoError(t, err)
+	tokenConfig.AddScopes(readScope, createScope, modScope)
+
+	tkn, err := tokenConfig.CreateToken()
+	require.NoError(t, err)
+	return tkn
+}
+
+// TestPStoreFederation drives a pstore-backed origin through the Pelican
+// client over a real federation: upload, download, stat, list, and delete.
+//
+// The unit tests exercise the store and the WebDAV adapter directly; this
+// covers everything in between -- director redirect, token authorization, the
+// origin's handler chain, and the client's own transfer path.
+func TestPStoreFederation(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	defer server_utils.ResetTestState()
+
+	storeDir := t.TempDir()
+	ft := fed_test_utils.NewFedTest(t, pstoreOriginConfig(storeDir))
+	require.NotNil(t, ft)
+	require.NotEmpty(t, ft.Exports)
+
+	testToken := getPStoreToken(t)
+	localDir := t.TempDir()
+	discoveryHost := param.Server_Hostname.GetString()
+	discoveryPort := param.Server_WebPort.GetInt()
+
+	objectURL := func(name string) string {
+		return fmt.Sprintf("pelican://%s:%d/test/%s", discoveryHost, discoveryPort, name)
+	}
+
+	t.Run("UploadAndDownload", func(t *testing.T) {
+		content := "Hello from a pstore-backed origin!"
+		src := filepath.Join(localDir, "upload.txt")
+		require.NoError(t, os.WriteFile(src, []byte(content), 0644))
+
+		_, err := client.DoPut(ft.Ctx, src, objectURL("upload.txt"),
+			false, client.WithToken(testToken))
+		require.NoError(t, err, "upload to the pstore origin should succeed")
+
+		dst := filepath.Join(localDir, "download.txt")
+		_, err = client.DoGet(ft.Ctx, objectURL("upload.txt"), dst,
+			false, client.WithToken(testToken))
+		require.NoError(t, err)
+
+		got, err := os.ReadFile(dst)
+		require.NoError(t, err)
+		assert.Equal(t, content, string(got), "content survives the round trip")
+	})
+
+	t.Run("LargeObjectRoundTrip", func(t *testing.T) {
+		// Past the spill threshold, so the streaming write path and its
+		// chunk growth are exercised end to end rather than only in unit
+		// tests.
+		content := make([]byte, 10<<20)
+		for i := range content {
+			content[i] = byte(i % 251)
+		}
+		src := filepath.Join(localDir, "large.bin")
+		require.NoError(t, os.WriteFile(src, content, 0644))
+
+		_, err := client.DoPut(ft.Ctx, src, objectURL("large.bin"),
+			false, client.WithToken(testToken))
+		require.NoError(t, err)
+
+		dst := filepath.Join(localDir, "large-out.bin")
+		_, err = client.DoGet(ft.Ctx, objectURL("large.bin"), dst,
+			false, client.WithToken(testToken))
+		require.NoError(t, err)
+
+		got, err := os.ReadFile(dst)
+		require.NoError(t, err)
+		assert.Equal(t, len(content), len(got))
+		assert.True(t, string(content) == string(got), "large object round trips intact")
+	})
+
+	t.Run("Overwrite", func(t *testing.T) {
+		// The client refuses to clobber an existing object unless this is
+		// set. The subtest is about the origin swapping a new version in, not
+		// about the client's guard rail.
+		require.NoError(t, param.Client_EnableOverwrites.Set(true))
+		t.Cleanup(func() { _ = param.Client_EnableOverwrites.Set(false) })
+
+		src := filepath.Join(localDir, "over.txt")
+		require.NoError(t, os.WriteFile(src, []byte("first"), 0644))
+		_, err := client.DoPut(ft.Ctx, src, objectURL("over.txt"),
+			false, client.WithToken(testToken))
+		require.NoError(t, err)
+
+		require.NoError(t, os.WriteFile(src, []byte("second"), 0644))
+		_, err = client.DoPut(ft.Ctx, src, objectURL("over.txt"),
+			false, client.WithToken(testToken))
+		require.NoError(t, err)
+
+		dst := filepath.Join(localDir, "over-out.txt")
+		_, err = client.DoGet(ft.Ctx, objectURL("over.txt"), dst,
+			false, client.WithToken(testToken))
+		require.NoError(t, err)
+		got, err := os.ReadFile(dst)
+		require.NoError(t, err)
+		assert.Equal(t, "second", string(got), "the overwrite is what is served")
+	})
+
+	t.Run("StatAndList", func(t *testing.T) {
+		src := filepath.Join(localDir, "listed.txt")
+		require.NoError(t, os.WriteFile(src, []byte("listed"), 0644))
+		_, err := client.DoPut(ft.Ctx, src, objectURL("dir/listed.txt"),
+			false, client.WithToken(testToken))
+		require.NoError(t, err, "uploading into a fresh prefix must create it")
+
+		info, err := client.DoStat(ft.Ctx, objectURL("dir/listed.txt"),
+			client.WithToken(testToken))
+		require.NoError(t, err)
+		assert.EqualValues(t, len("listed"), info.Size)
+
+		entries, err := client.DoList(ft.Ctx, objectURL("dir"),
+			client.WithToken(testToken))
+		require.NoError(t, err)
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, filepath.Base(e.Name))
+		}
+		assert.Contains(t, names, "listed.txt")
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		src := filepath.Join(localDir, "doomed.txt")
+		require.NoError(t, os.WriteFile(src, []byte("doomed"), 0644))
+		_, err := client.DoPut(ft.Ctx, src, objectURL("doomed.txt"),
+			false, client.WithToken(testToken))
+		require.NoError(t, err)
+
+		require.NoError(t, client.DoDelete(ft.Ctx, objectURL("doomed.txt"),
+			false, client.WithToken(testToken)))
+
+		_, err = client.DoStat(ft.Ctx, objectURL("doomed.txt"),
+			client.WithToken(testToken))
+		assert.Error(t, err, "a deleted object is gone")
+	})
+
+	t.Run("DataPersistsInTheStore", func(t *testing.T) {
+		// The catalog and block files must actually be in the configured
+		// location, rather than the origin having quietly fallen back to a
+		// POSIX directory.
+		entries, err := os.ReadDir(storeDir)
+		require.NoError(t, err)
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		assert.Contains(t, names, "db", "the pstore catalog lives under PStoreLocation")
+	})
+}

--- a/launchers/origin_serve.go
+++ b/launchers/origin_serve.go
@@ -346,6 +346,18 @@ func OriginServeFinish(ctx context.Context, egrp *errgroup.Group, engine *gin.En
 			return errors.Wrap(err, "failed to register origin_serve handlers")
 		}
 
+		// Administrative introspection for the storage backend.  Registers
+		// nothing unless the backend actually has such an interface, so an
+		// origin on any other backend simply has no such routes.
+		//
+		// AuthHandler establishes who the caller is; AdminAuthHandler decides
+		// whether they are an administrator.  The pair is required: nothing
+		// else in this engine authenticates, and AdminAuthHandler alone reads
+		// an empty "User" from the context and 401s every request, so the
+		// routes would exist but be reachable by no one.
+		origin_serve.RegisterStorageAPI(engine.Group("/api/v1.0"),
+			web_ui.AuthHandler, web_ui.AdminAuthHandler)
+
 		// For POSIXv2, the origin serves files directly via the web server, not XRootD.
 		// Update Origin.Url to use the external web URL which is now set to the correct port.
 		externalWebUrl := param.Server_ExternalWebUrl.GetString()

--- a/local_cache/append_writer.go
+++ b/local_cache/append_writer.go
@@ -1,0 +1,489 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Streaming append support.
+//
+// The cache always knows an object's size before it stores it: a download
+// starts from a Content-Length or a HEAD.  An origin does not — a WebDAV PUT
+// may arrive with chunked transfer encoding and no length at all — so the
+// pstore backend needs to write an object whose size is discovered only at
+// the end.
+//
+// AppendWriter provides that.  It keeps the object's metadata carrying a
+// provisional ContentLength that is always a whole number of chunks and always
+// strictly greater than the bytes written so far, so every allocated chunk is
+// exactly full-size and the existing chunk bookkeeping applies unchanged.
+// Finalize then records the true length, truncates the tail chunk to fit, and
+// refunds the difference to the usage counters.
+//
+// The "strictly greater" part is load-bearing.  WriteBlocks marks an object
+// Completed as soon as every block of its recorded ContentLength is present,
+// which is right for a download of known length and wrong for a stream: an
+// interrupted append whose length happened to land on a chunk boundary would
+// otherwise be left in the database claiming to be a whole object at a length
+// the writer invented.  Keeping the provisional length one byte-range ahead of
+// the stream means only Finalize can ever set Completed.
+//
+// Writes must be sequential from offset 0.  Pelican has no mid-file edit
+// semantics, and neither does this writer.
+
+package local_cache
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// appendReclaimGrace is how long an append-in-flight record must have been
+// around before a reclamation pass will consider it abandoned, on top of the
+// requirement that no live writer in this process owns it.  The live-writer
+// registry is the real guard; the age is belt and braces for a consumer that
+// somehow creates records outside NewAppendWriter.
+const appendReclaimGrace = 10 * time.Minute
+
+// AppendWriter streams an object of unknown length into chunked storage.
+//
+// It is not safe for concurrent use; a single writer owns one object version
+// for the duration of the write.
+type AppendWriter struct {
+	sm           *StorageManager
+	ctx          context.Context
+	instanceHash InstanceHash
+	namespaceID  NamespaceID
+	chunkSize    int64
+	sizeCode     ChunkSizeCode
+
+	// written is the number of content bytes accepted from the caller.
+	written int64
+	// flushed is the number of content bytes already handed to WriteBlocks.
+	// It is always a multiple of BlockDataSize.
+	flushed int64
+	// pending holds bytes not yet block-aligned enough to write.
+	pending []byte
+
+	// provisional is the ContentLength currently recorded in metadata, always
+	// a whole number of chunks and always >= written.
+	provisional int64
+
+	closed bool
+}
+
+// NewAppendWriter initializes chunked storage for an object whose length is
+// not yet known and returns a writer positioned at offset 0.
+//
+// chunkSizeCode selects the chunk size; ChunkingDisabled is rejected because
+// growth is expressed in whole chunks.
+func (sm *StorageManager) NewAppendWriter(
+	ctx context.Context,
+	instanceHash InstanceHash,
+	namespaceID NamespaceID,
+	chunkSizeCode ChunkSizeCode,
+) (*AppendWriter, error) {
+	if chunkSizeCode == ChunkingDisabled {
+		return nil, errors.New("NewAppendWriter requires chunking enabled")
+	}
+	chunkSize := int64(ChunkSizeCodeToBytes(chunkSizeCode))
+	if chunkSize <= 0 {
+		return nil, errors.Errorf("invalid chunk size code %d", chunkSizeCode)
+	}
+
+	// Register before anything is persisted so that a reclamation pass which
+	// observes the intent record always also observes the live writer.
+	sm.liveAppends.Store(instanceHash, struct{}{})
+	rollback := func() { sm.liveAppends.Delete(instanceHash) }
+
+	// Start with a single chunk's worth of provisional length; growTo extends
+	// it as the stream advances.
+	meta, err := sm.InitLazyChunkedStorage(ctx, instanceHash, chunkSize, chunkSizeCode)
+	if err != nil {
+		rollback()
+		return nil, errors.Wrap(err, "failed to initialize chunked storage")
+	}
+	meta.NamespaceID = namespaceID
+	if err := sm.db.SetMetadata(instanceHash, meta); err != nil {
+		rollback()
+		return nil, errors.Wrap(err, "failed to record namespace on new object")
+	}
+
+	// The intent record is what makes an interrupted append reclaimable: the
+	// object has metadata and (soon) files but no LRU entry, so without it
+	// neither eviction nor the consistency checker would ever look at it.
+	if err := sm.db.SetAppendIntent(instanceHash, AppendIntent{
+		StartedAt:   time.Now(),
+		NamespaceID: namespaceID,
+	}); err != nil {
+		rollback()
+		// Leave nothing half-built: the object is unreachable without the
+		// writer we are declining to return.
+		if delErr := sm.Delete(instanceHash); delErr != nil {
+			log.Warnf("Failed to clean up %s after append-intent failure: %v", instanceHash, delErr)
+		}
+		return nil, errors.Wrap(err, "failed to record the append-in-flight marker")
+	}
+
+	return &AppendWriter{
+		sm:           sm,
+		ctx:          ctx,
+		instanceHash: instanceHash,
+		namespaceID:  namespaceID,
+		chunkSize:    chunkSize,
+		sizeCode:     chunkSizeCode,
+		provisional:  chunkSize,
+		pending:      make([]byte, 0, BlockDataSize*writeBatchBlocks),
+	}, nil
+}
+
+// Written returns the number of content bytes accepted so far.
+func (w *AppendWriter) Written() int64 { return w.written }
+
+// Write appends data to the object.  It always consumes the whole slice.
+//
+// A flush failure is reported with the full byte count, not zero: by then the
+// data is already in w.pending and already counted in w.written, so claiming
+// nothing was accepted would invite an io.Copy-style caller to resend bytes
+// this writer has already accounted for.  The writer is unusable after such an
+// error; the caller should Abort.
+func (w *AppendWriter) Write(p []byte) (int, error) {
+	if w.closed {
+		return 0, errors.New("write to a finalized AppendWriter")
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	w.pending = append(w.pending, p...)
+	w.written += int64(len(p))
+
+	// Write out whole blocks, holding back any partial tail: WriteBlocks
+	// requires block-aligned offsets and pstore never rewrites a block.
+	full := (len(w.pending) / BlockDataSize) * BlockDataSize
+	if full > 0 {
+		if err := w.flush(w.pending[:full]); err != nil {
+			return len(p), err
+		}
+		w.pending = append(w.pending[:0], w.pending[full:]...)
+	}
+	return len(p), nil
+}
+
+// flush writes a block-aligned run of bytes at the current offset, growing the
+// provisional length first so that every chunk the write touches is allocated
+// at full size.
+func (w *AppendWriter) flush(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	if err := w.growTo(w.flushed + int64(len(data))); err != nil {
+		return err
+	}
+	if err := w.sm.WriteBlocks(w.instanceHash, w.flushed, data); err != nil {
+		return errors.Wrapf(err, "failed to write %d bytes at offset %d", len(data), w.flushed)
+	}
+	w.flushed += int64(len(data))
+	return nil
+}
+
+// growTo raises the provisional ContentLength so that it covers endOffset with
+// at least one byte to spare, rounded up to a whole number of chunks, and
+// extends ChunkLocations to match.
+//
+// Keeping the provisional length chunk-aligned means ChunkContentLength
+// reports a full chunk for every allocated chunk, so AllocateChunk sizes each
+// file correctly without knowing the object's real length.
+//
+// Keeping it strictly greater than endOffset is what stops writeBlocks from
+// declaring the object finished.  Rounding endOffset *up* to a chunk boundary
+// would make provisional == flushed exactly when the stream length is a
+// multiple of the chunk size, at which point checkAndMarkComplete sees every
+// block of the recorded ContentLength present and merges a Completed stamp
+// onto a half-written object.  Only Finalize knows the real length, so only
+// Finalize may mark completion.
+//
+// The extra chunk costs nothing on disk: growTo only lengthens the chunk
+// table, and chunk files are created lazily by AllocateChunk when a write
+// actually lands in them.
+func (w *AppendWriter) growTo(endOffset int64) error {
+	if endOffset < w.provisional {
+		return nil
+	}
+	chunksNeeded := endOffset/w.chunkSize + 1
+	newLength := chunksNeeded * w.chunkSize
+
+	meta, err := w.sm.db.GetMetadata(w.instanceHash)
+	if err != nil {
+		return errors.Wrap(err, "failed to read metadata while growing object")
+	}
+	if meta == nil {
+		return errors.Errorf("object %s disappeared while being written", w.instanceHash)
+	}
+
+	meta.ContentLength = newLength
+	// ChunkLocations covers chunks 1..n-1; chunk 0 uses the base StorageID.
+	if want := int(chunksNeeded) - 1; want > len(meta.ChunkLocations) {
+		grown := make([]ChunkLocation, want)
+		copy(grown, meta.ChunkLocations)
+		meta.ChunkLocations = grown
+	}
+
+	if err := w.sm.db.SetMetadata(w.instanceHash, meta); err != nil {
+		return errors.Wrap(err, "failed to grow object metadata")
+	}
+	// The cached copy carries the old length and chunk table.
+	w.sm.diskCrypto.Delete(w.instanceHash)
+	w.provisional = newLength
+	return nil
+}
+
+// Finalize flushes any buffered tail, records the object's true length, trims
+// the over-allocated tail chunk, and returns the completed metadata.
+//
+// After Finalize the writer is closed and further writes are rejected.
+func (w *AppendWriter) Finalize() (*CacheMetadata, error) {
+	if w.closed {
+		return nil, errors.New("AppendWriter already finalized")
+	}
+
+	// The final partial block is written as-is; a short trailing block is
+	// exactly how a non-chunk-aligned object ends.
+	if len(w.pending) > 0 {
+		if err := w.flush(w.pending); err != nil {
+			return nil, err
+		}
+		w.pending = nil
+	}
+	w.closed = true
+
+	actual := w.written
+	meta, err := w.sm.db.GetMetadata(w.instanceHash)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read metadata at finalize")
+	}
+	if meta == nil {
+		return nil, errors.Errorf("object %s disappeared while being written", w.instanceHash)
+	}
+
+	if actual == 0 {
+		return w.finalizeEmpty(meta)
+	}
+
+	// Chunks beyond the real length were never written to and must be dropped
+	// so that reads and eviction see a consistent chunk table.
+	realChunks := CalculateChunkCount(actual, w.sizeCode)
+	if realChunks < 1 {
+		realChunks = 1
+	}
+	if want := realChunks - 1; want < len(meta.ChunkLocations) {
+		for i := want; i < len(meta.ChunkLocations); i++ {
+			w.releaseUnusedChunk(meta, i+1)
+		}
+		meta.ChunkLocations = meta.ChunkLocations[:want]
+	}
+
+	// Shrink the tail chunk from a full chunk to the bytes it actually holds,
+	// refunding the difference that AllocateChunk charged up front.
+	if err := w.truncateTail(meta, actual, realChunks); err != nil {
+		return nil, err
+	}
+
+	meta.ContentLength = actual
+	meta.Completed = time.Now()
+	if err := w.sm.db.SetMetadata(w.instanceHash, meta); err != nil {
+		return nil, errors.Wrap(err, "failed to record final object metadata")
+	}
+	w.sm.diskCrypto.Delete(w.instanceHash)
+	w.sm.invalidateObjectCaches(w.instanceHash, realChunks)
+	w.clearIntent()
+
+	return meta, nil
+}
+
+// finalizeEmpty completes an object that turned out to hold no bytes.
+//
+// Nothing was ever flushed, so no chunk was allocated and meta.StorageID is
+// still StorageIDInline -- but ChunkSizeCode is set, so IsInline() is false and
+// every reader takes the disk path and fails to open a file that was never
+// created.  A zero-length PUT followed by a GET is an ordinary operation, so
+// the object is instead stored the way the cache already stores a zero-byte
+// download: inline, with no chunking.  That keeps IsInline() and IsDisk()
+// exactly complementary rather than inventing a third state.
+func (w *AppendWriter) finalizeEmpty(meta *CacheMetadata) (*CacheMetadata, error) {
+	// Defensive: a chunk should not exist, but refund it if one does rather
+	// than orphan the file.
+	for i := len(meta.ChunkLocations); i >= 1; i-- {
+		w.releaseUnusedChunk(meta, i)
+	}
+	meta.ChunkLocations = nil
+	meta.ChunkSizeCode = ChunkingDisabled
+	meta.StorageID = StorageIDInline
+
+	if err := w.sm.StoreInline(w.ctx, w.instanceHash, meta, nil); err != nil {
+		return nil, errors.Wrap(err, "failed to store the empty object")
+	}
+	w.sm.diskCrypto.Delete(w.instanceHash)
+	w.sm.invalidateObjectCaches(w.instanceHash, 1)
+	w.clearIntent()
+
+	return meta, nil
+}
+
+// clearIntent drops the append-in-flight record and the live-writer
+// registration.  The object is now either finished or gone, so there is
+// nothing left for a reclamation pass to do.
+func (w *AppendWriter) clearIntent() {
+	w.sm.liveAppends.Delete(w.instanceHash)
+	if err := w.sm.db.DeleteAppendIntent(w.instanceHash); err != nil {
+		log.Warnf("Failed to clear the append-in-flight marker for %s: %v", w.instanceHash, err)
+	}
+}
+
+// truncateTail shrinks the last chunk file to the bytes the object actually
+// occupies and refunds the over-charge.
+func (w *AppendWriter) truncateTail(meta *CacheMetadata, actual int64, realChunks int) error {
+	tailIdx := realChunks - 1
+	if !meta.IsChunkAllocated(tailIdx) {
+		return nil
+	}
+	storageID := meta.GetChunkStorageID(tailIdx)
+
+	tailContent := actual - int64(tailIdx)*w.chunkSize
+	if tailContent < 0 {
+		tailContent = 0
+	}
+	wantSize := CalculateFileSize(tailContent)
+	haveSize := CalculateFileSize(w.chunkSize)
+	if wantSize >= haveSize {
+		return nil
+	}
+
+	path := w.sm.getChunkPath(storageID, w.instanceHash, tailIdx)
+	// Drop cached descriptors first so the truncation is not racing a reader
+	// holding a stale size.
+	w.sm.invalidateObjectCaches(w.instanceHash, realChunks)
+	if err := os.Truncate(path, wantSize); err != nil {
+		if os.IsNotExist(err) {
+			// Nothing was ever written to the tail chunk.
+			return nil
+		}
+		return errors.Wrapf(err, "failed to trim chunk %d to %d bytes", tailIdx, wantSize)
+	}
+	if err := w.sm.db.AddUsage(storageID, w.namespaceID, wantSize-haveSize); err != nil {
+		return errors.Wrap(err, "failed to refund usage for the trimmed chunk")
+	}
+	return nil
+}
+
+// releaseUnusedChunk removes a chunk file that the provisional length caused
+// to be allocated but which the finished object does not reach.
+func (w *AppendWriter) releaseUnusedChunk(meta *CacheMetadata, chunkIdx int) {
+	if !meta.IsChunkAllocated(chunkIdx) {
+		return
+	}
+	storageID := meta.GetChunkStorageID(chunkIdx)
+	path := w.sm.getChunkPath(storageID, w.instanceHash, chunkIdx)
+	if err := removeFileWithRetry(path); err != nil && !os.IsNotExist(err) {
+		log.Warnf("Failed to remove unused chunk %d of %s: %v", chunkIdx, w.instanceHash, err)
+		return
+	}
+	if err := w.sm.db.AddUsage(storageID, w.namespaceID, -CalculateFileSize(w.chunkSize)); err != nil {
+		log.Warnf("Failed to refund usage for unused chunk %d: %v", chunkIdx, err)
+	}
+}
+
+// Abort discards a partially written object, removing its files and metadata.
+func (w *AppendWriter) Abort() error {
+	w.closed = true
+	w.pending = nil
+	// Delete drops the intent record inside the same transaction as the
+	// metadata; this only clears the in-process registration.
+	w.sm.liveAppends.Delete(w.instanceHash)
+	return w.sm.Delete(w.instanceHash)
+}
+
+// ReclaimAbandonedAppends removes objects left behind by streaming appends
+// that never reached Finalize or Abort -- the process died, or a consumer
+// dropped the writer without cleaning up.
+//
+// Such an object is invisible to every other reclamation path: it has no LRU
+// entry, so eviction never sees it; its usage charge is recomputed from live
+// metadata, so the consistency checker re-affirms rather than releases it; and
+// it has both metadata and files, so neither half of the metadata scan fires.
+// The append-in-flight record written by NewAppendWriter is the only handle.
+//
+// A record is reclaimed only when no writer in this process owns it (the
+// registry is populated before the record is written, so a live append is
+// never mistaken for an orphan) and it is at least minAge old.  Pass 0 for
+// minAge to reclaim purely on the registry.
+//
+// A record whose object is already Completed is dropped without touching the
+// object: that is a Finalize that succeeded and then failed to tidy up.
+//
+// Returns the number of objects deleted.
+func (sm *StorageManager) ReclaimAbandonedAppends(minAge time.Duration) (int, error) {
+	cutoff := time.Now().Add(-minAge)
+
+	type orphan struct {
+		hash    InstanceHash
+		deleted bool
+	}
+	var orphans []orphan
+
+	err := sm.db.ScanAppendIntents(func(hash InstanceHash, intent AppendIntent) error {
+		if _, live := sm.liveAppends.Load(hash); live {
+			return nil
+		}
+		if intent.StartedAt.After(cutoff) {
+			return nil
+		}
+		meta, err := sm.db.GetMetadata(hash)
+		if err != nil {
+			log.Warnf("Failed to read metadata for abandoned append %s: %v", hash, err)
+			return nil
+		}
+		orphans = append(orphans, orphan{
+			hash:    hash,
+			deleted: meta != nil && meta.Completed.IsZero(),
+		})
+		return nil
+	})
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to scan append-in-flight records")
+	}
+
+	reclaimed := 0
+	for _, o := range orphans {
+		if o.deleted {
+			// Delete removes metadata, block state, chunk files, the usage
+			// charge, and the intent record itself.
+			if delErr := sm.Delete(o.hash); delErr != nil {
+				log.Warnf("Failed to reclaim abandoned append %s: %v", o.hash, delErr)
+				continue
+			}
+			log.Infof("Reclaimed abandoned streaming append %s", o.hash)
+			reclaimed++
+			continue
+		}
+		if delErr := sm.db.DeleteAppendIntent(o.hash); delErr != nil {
+			log.Warnf("Failed to drop a stale append-in-flight marker for %s: %v", o.hash, delErr)
+		}
+	}
+	return reclaimed, nil
+}

--- a/local_cache/append_writer_test.go
+++ b/local_cache/append_writer_test.go
@@ -1,0 +1,548 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package local_cache
+
+import (
+	"bytes"
+	"context"
+	crand "crypto/rand"
+	"encoding/hex"
+	"io"
+	"io/fs"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+// newAppendTestStorage builds a bare CacheDB + StorageManager pair, the same
+// standalone construction pstore uses.
+func newAppendTestStorage(t *testing.T, dirCount int) (*CacheDB, *StorageManager) {
+	t.Helper()
+	InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	db, err := NewCacheDB(ctx, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	dirs := make([]string, dirCount)
+	for i := range dirs {
+		dirs[i] = t.TempDir()
+	}
+	egrp, _ := errgroup.WithContext(ctx)
+	sm, err := NewStorageManager(db, dirs, 0, egrp)
+	require.NoError(t, err)
+	t.Cleanup(sm.Close)
+
+	return db, sm
+}
+
+// appendAndVerify streams size bytes of pseudo-random data through an
+// AppendWriter without declaring the length up front, then reads the object
+// back and compares.
+func appendAndVerify(t *testing.T, sm *StorageManager, chunkSize uint64, size int64, writeChunk int) {
+	t.Helper()
+	ctx := t.Context()
+
+	sizeCode := BytesToChunkSizeCode(chunkSize)
+	hash := InstanceHash(randomHexForTest(t, 32))
+
+	data := make([]byte, size)
+	rng := rand.New(rand.NewSource(size))
+	_, err := rng.Read(data)
+	require.NoError(t, err)
+
+	w, err := sm.NewAppendWriter(ctx, hash, NamespaceID(1), sizeCode)
+	require.NoError(t, err)
+
+	for off := 0; off < len(data); off += writeChunk {
+		end := off + writeChunk
+		if end > len(data) {
+			end = len(data)
+		}
+		n, wErr := w.Write(data[off:end])
+		require.NoError(t, wErr)
+		require.Equal(t, end-off, n)
+	}
+
+	meta, err := w.Finalize()
+	require.NoError(t, err)
+	assert.Equal(t, size, meta.ContentLength, "finalized length must be the bytes actually written")
+	assert.False(t, meta.Completed.IsZero(), "finalize marks the object complete")
+
+	reader, err := sm.NewObjectReader(hash)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	got, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, size, int64(len(got)), "read back the same number of bytes")
+	assert.True(t, bytes.Equal(data, got), "round-tripped content must match")
+}
+
+// randomHexForTest returns a fresh 2n-character hex string.
+//
+// It must actually be random, not derived from n: every caller passes the same
+// n, so a deterministic string would hand every subtest of every table-driven
+// test below the same instance hash in a shared store.  Each would silently
+// overwrite its predecessor, and no assertion here could notice.
+func randomHexForTest(t *testing.T, n int) string {
+	t.Helper()
+	buf := make([]byte, n)
+	_, err := crand.Read(buf)
+	require.NoError(t, err)
+	return hex.EncodeToString(buf)
+}
+
+// countStoredFiles returns the number of regular files across every configured
+// storage directory.  Used to prove a torn-off write leaves no chunk behind.
+func countStoredFiles(t *testing.T, sm *StorageManager) int {
+	t.Helper()
+	count := 0
+	for _, dir := range sm.dirs {
+		err := filepath.WalkDir(dir, func(_ string, d fs.DirEntry, err error) error {
+			if err != nil {
+				if os.IsNotExist(err) {
+					return nil
+				}
+				return err
+			}
+			if !d.IsDir() {
+				count++
+			}
+			return nil
+		})
+		require.NoError(t, err)
+	}
+	return count
+}
+
+// totalDirUsage sums the charged bytes across every namespace of a directory.
+func totalDirUsage(t *testing.T, db *CacheDB, storageID StorageID) int64 {
+	t.Helper()
+	usage, err := db.GetDirUsage(storageID)
+	require.NoError(t, err)
+	var total int64
+	for _, v := range usage {
+		total += v
+	}
+	return total
+}
+
+// TestAppendWriterUnknownLength is the core case: an origin PUT arrives with
+// no Content-Length, so the object's size is known only once the stream ends.
+func TestAppendWriterUnknownLength(t *testing.T) {
+	_, sm := newAppendTestStorage(t, 2)
+
+	const chunkSize = 2 * 1024 * 1024
+	cases := []struct {
+		name string
+		size int64
+	}{
+		{"partial block", 100},
+		{"exact block", BlockDataSize},
+		{"several blocks", BlockDataSize * 10},
+		{"just under a chunk", chunkSize - 1},
+		{"exactly one chunk", chunkSize},
+		{"just over a chunk", chunkSize + 1},
+		{"spanning three chunks", chunkSize*2 + 12345},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			appendAndVerify(t, sm, chunkSize, tc.size, 64*1024)
+		})
+	}
+}
+
+// TestAppendWriterOddWriteSizes exercises the block-alignment buffering: the
+// caller's write boundaries have no relationship to BlockDataSize.
+func TestAppendWriterOddWriteSizes(t *testing.T) {
+	_, sm := newAppendTestStorage(t, 1)
+
+	const chunkSize = 2 * 1024 * 1024
+	for _, writeSize := range []int{1, 7, BlockDataSize - 1, BlockDataSize + 1, 100000} {
+		t.Run("write size "+strconv.Itoa(writeSize), func(t *testing.T) {
+			appendAndVerify(t, sm, chunkSize, chunkSize+9999, writeSize)
+		})
+	}
+}
+
+// TestAppendWriterRefundsOverAllocation checks the accounting half of
+// Finalize.  The writer allocates whole chunks while streaming, so a small
+// object briefly reserves a full chunk; once the true length is known the
+// excess must be given back or the store would leak capacity on every write.
+func TestAppendWriterRefundsOverAllocation(t *testing.T) {
+	db, sm := newAppendTestStorage(t, 1)
+
+	const chunkSize = 2 * 1024 * 1024
+	sizeCode := BytesToChunkSizeCode(chunkSize)
+	hash := InstanceHash(randomHexForTest(t, 31))
+	nsID := NamespaceID(7)
+
+	w, err := sm.NewAppendWriter(t.Context(), hash, nsID, sizeCode)
+	require.NoError(t, err)
+
+	payload := make([]byte, 4096)
+	_, err = w.Write(payload)
+	require.NoError(t, err)
+
+	meta, err := w.Finalize()
+	require.NoError(t, err)
+	require.Equal(t, int64(len(payload)), meta.ContentLength)
+
+	total := totalDirUsage(t, db, meta.StorageID)
+
+	// 4096 content bytes span two 4080-byte blocks: a full block (4080 + a
+	// 16-byte tag) plus 16 content bytes and their tag.  Spelled out rather
+	// than recomputed with CalculateFileSize, which is the function the writer
+	// itself used -- deriving the expectation from the implementation would
+	// only prove two call sites agree.
+	assert.Equal(t, int64(4128), total,
+		"usage must reflect the finished object, not the chunk reserved while streaming")
+	assert.Less(t, total, int64(chunkSize),
+		"the over-allocated chunk must be refunded")
+}
+
+// TestAppendWriterAbort confirms a torn-off write leaves nothing behind: no
+// metadata, no chunk files, and no charged capacity.
+func TestAppendWriterAbort(t *testing.T) {
+	db, sm := newAppendTestStorage(t, 1)
+
+	sizeCode := BytesToChunkSizeCode(2 * 1024 * 1024)
+	hash := InstanceHash(randomHexForTest(t, 32))
+
+	baselineUsage := totalDirUsage(t, db, StorageIDFirstDisk)
+	baselineFiles := countStoredFiles(t, sm)
+
+	w, err := sm.NewAppendWriter(t.Context(), hash, NamespaceID(1), sizeCode)
+	require.NoError(t, err)
+	_, err = w.Write(make([]byte, 128*1024))
+	require.NoError(t, err)
+
+	// Sanity: the write really did reserve something, so the assertions below
+	// are not passing because nothing ever happened.
+	require.Greater(t, countStoredFiles(t, sm), baselineFiles,
+		"a partial append should have created a chunk file")
+
+	require.NoError(t, w.Abort())
+
+	got, err := db.GetMetadata(hash)
+	require.NoError(t, err)
+	assert.Nil(t, got, "an aborted write leaves no metadata behind")
+
+	intent, err := db.GetAppendIntent(hash)
+	require.NoError(t, err)
+	assert.Nil(t, intent, "an aborted write leaves no append-in-flight marker")
+
+	assert.Equal(t, baselineUsage, totalDirUsage(t, db, StorageIDFirstDisk),
+		"an aborted write must not leave capacity charged")
+	assert.Equal(t, baselineFiles, countStoredFiles(t, sm),
+		"an aborted write must not leave chunk files on disk")
+}
+
+func TestAppendWriterRejectsUseAfterFinalize(t *testing.T) {
+	_, sm := newAppendTestStorage(t, 1)
+
+	sizeCode := BytesToChunkSizeCode(2 * 1024 * 1024)
+	hash := InstanceHash(randomHexForTest(t, 32))
+
+	w, err := sm.NewAppendWriter(t.Context(), hash, NamespaceID(1), sizeCode)
+	require.NoError(t, err)
+	_, err = w.Write([]byte("hello"))
+	require.NoError(t, err)
+	_, err = w.Finalize()
+	require.NoError(t, err)
+
+	_, err = w.Write([]byte("more"))
+	assert.ErrorContains(t, err, "write to a finalized AppendWriter")
+	_, err = w.Finalize()
+	assert.ErrorContains(t, err, "already finalized")
+}
+
+func TestAppendWriterRejectsChunkingDisabled(t *testing.T) {
+	_, sm := newAppendTestStorage(t, 1)
+
+	_, err := sm.NewAppendWriter(t.Context(), InstanceHash(randomHexForTest(t, 32)),
+		NamespaceID(1), ChunkingDisabled)
+	assert.ErrorContains(t, err, "requires chunking enabled")
+}
+
+// TestAppendWriterZeroByteObject covers a zero-length PUT followed by a GET.
+//
+// Nothing is ever flushed, so no chunk is allocated and the object's StorageID
+// stays 0.  That combination has to resolve to exactly one storage mode: an
+// object that is neither inline (because ChunkSizeCode is set) nor readable
+// from disk (because no file was ever created) opens as "no such file or
+// directory".
+func TestAppendWriterZeroByteObject(t *testing.T) {
+	db, sm := newAppendTestStorage(t, 1)
+
+	sizeCode := BytesToChunkSizeCode(2 * 1024 * 1024)
+	hash := InstanceHash(randomHexForTest(t, 32))
+
+	w, err := sm.NewAppendWriter(t.Context(), hash, NamespaceID(1), sizeCode)
+	require.NoError(t, err)
+
+	meta, err := w.Finalize()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), meta.ContentLength)
+	assert.False(t, meta.Completed.IsZero(), "an empty object is still a finished object")
+	assert.True(t, meta.IsInline(), "a zero-byte object must land in exactly one storage mode")
+	assert.False(t, meta.IsDisk())
+
+	reader, err := sm.NewObjectReader(hash)
+	require.NoError(t, err, "a zero-byte object must be readable")
+	defer reader.Close()
+
+	got, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
+	// The stored metadata, not just the returned copy, has to be coherent.
+	stored, err := db.GetMetadata(hash)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.True(t, stored.IsInline())
+	assert.Equal(t, int64(0), stored.ContentLength)
+
+	// A zero-byte write also has to be a zero-byte charge.
+	assert.Zero(t, totalDirUsage(t, db, StorageIDFirstDisk))
+
+	intent, err := db.GetAppendIntent(hash)
+	require.NoError(t, err)
+	assert.Nil(t, intent, "finalize clears the append-in-flight marker")
+}
+
+// TestAppendWriterCompletedOnlyAtFinalize holds down that an in-flight object
+// is never stamped Completed at a length the writer merely reserved.
+//
+// growTo advances the provisional ContentLength as the stream arrives.  If it
+// ever advanced past what has been flushed -- by rounding up to a chunk
+// boundary, say -- then for a stream whose length lands on that boundary the
+// provisional length equals the flushed length, writeBlocks sees every block of
+// the recorded length present, and merges a Completed stamp.  A connection
+// dropped at that moment leaves the database claiming a whole object.
+func TestAppendWriterCompletedOnlyAtFinalize(t *testing.T) {
+	db, sm := newAppendTestStorage(t, 1)
+
+	const chunkSize = 2 * 1024 * 1024
+	sizeCode := BytesToChunkSizeCode(chunkSize)
+	// The chunk size in content bytes is rounded down to a whole number of
+	// blocks; this is the boundary the sizes below are chosen around.
+	chunkContent := int64(ChunkSizeCodeToBytes(sizeCode))
+	require.Positive(t, chunkContent)
+
+	cases := []struct {
+		name string
+		size int64
+	}{
+		{"exactly one chunk", chunkContent},
+		{"exactly two chunks", chunkContent * 2},
+		{"one block short of a chunk", chunkContent - BlockDataSize},
+		{"one block into the second chunk", chunkContent + BlockDataSize},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hash := InstanceHash(randomHexForTest(t, 32))
+			w, err := sm.NewAppendWriter(t.Context(), hash, NamespaceID(1), sizeCode)
+			require.NoError(t, err)
+
+			// Write in block-sized pieces so every byte is flushed; a
+			// tail left in the buffer would keep the flushed length short
+			// of the provisional one no matter what growTo did.
+			buf := make([]byte, BlockDataSize)
+			for written := int64(0); written < tc.size; written += BlockDataSize {
+				n, wErr := w.Write(buf)
+				require.NoError(t, wErr)
+				require.Equal(t, BlockDataSize, n)
+			}
+
+			// Abandon the writer here, exactly as a dropped connection would.
+			mid, err := db.GetMetadata(hash)
+			require.NoError(t, err)
+			require.NotNil(t, mid)
+			assert.True(t, mid.Completed.IsZero(),
+				"an unfinalized object must never be marked complete")
+			assert.Greater(t, mid.ContentLength, tc.size,
+				"the provisional length must stay ahead of the stream so no block set can look complete")
+
+			meta, err := w.Finalize()
+			require.NoError(t, err)
+			assert.Equal(t, tc.size, meta.ContentLength)
+			assert.False(t, meta.Completed.IsZero(), "finalize is what marks completion")
+		})
+	}
+}
+
+// TestReclaimAbandonedAppends covers the writer that is never finalized and
+// never aborted -- the process died mid-PUT.  Such an object has metadata and
+// chunk files but no LRU entry, so nothing else in the cache would ever free
+// it: eviction cannot see it, and the consistency checker recomputes its usage
+// charge from the very metadata that is the problem.
+func TestReclaimAbandonedAppends(t *testing.T) {
+	db, sm := newAppendTestStorage(t, 1)
+
+	const chunkSize = 2 * 1024 * 1024
+	sizeCode := BytesToChunkSizeCode(chunkSize)
+	hash := InstanceHash(randomHexForTest(t, 32))
+
+	baselineUsage := totalDirUsage(t, db, StorageIDFirstDisk)
+	baselineFiles := countStoredFiles(t, sm)
+
+	w, err := sm.NewAppendWriter(t.Context(), hash, NamespaceID(3), sizeCode)
+	require.NoError(t, err)
+	_, err = w.Write(make([]byte, int(ChunkSizeCodeToBytes(sizeCode))))
+	require.NoError(t, err)
+
+	require.Greater(t, totalDirUsage(t, db, StorageIDFirstDisk), baselineUsage,
+		"the in-flight append should have charged capacity")
+
+	// A live writer is never an orphan, however old the record looks.
+	reclaimed, err := sm.ReclaimAbandonedAppends(0)
+	require.NoError(t, err)
+	assert.Zero(t, reclaimed, "a writer this process still owns must not be reclaimed")
+	present, err := sm.HasObject(hash)
+	require.NoError(t, err)
+	assert.True(t, present)
+
+	// Simulate the process dying: the persisted record survives, the
+	// in-memory registration does not.
+	sm.liveAppends.Delete(hash)
+
+	reclaimed, err = sm.ReclaimAbandonedAppends(0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, reclaimed)
+
+	present, err = sm.HasObject(hash)
+	require.NoError(t, err)
+	assert.False(t, present, "the abandoned object's metadata must be gone")
+
+	intent, err := db.GetAppendIntent(hash)
+	require.NoError(t, err)
+	assert.Nil(t, intent, "the intent record must be gone too")
+
+	assert.Equal(t, baselineUsage, totalDirUsage(t, db, StorageIDFirstDisk),
+		"reclamation must return the charged capacity")
+	assert.Equal(t, baselineFiles, countStoredFiles(t, sm),
+		"reclamation must remove the chunk files")
+
+	// A second pass has nothing left to do.
+	reclaimed, err = sm.ReclaimAbandonedAppends(0)
+	require.NoError(t, err)
+	assert.Zero(t, reclaimed)
+}
+
+// TestReclaimAbandonedAppendsKeepsFinishedObjects guards the other direction:
+// a crash between Finalize's metadata write and its marker cleanup must not
+// cost the operator a complete object.
+func TestReclaimAbandonedAppendsKeepsFinishedObjects(t *testing.T) {
+	db, sm := newAppendTestStorage(t, 1)
+
+	sizeCode := BytesToChunkSizeCode(2 * 1024 * 1024)
+	hash := InstanceHash(randomHexForTest(t, 32))
+
+	w, err := sm.NewAppendWriter(t.Context(), hash, NamespaceID(1), sizeCode)
+	require.NoError(t, err)
+	_, err = w.Write([]byte("finished"))
+	require.NoError(t, err)
+	_, err = w.Finalize()
+	require.NoError(t, err)
+
+	// Re-create the marker Finalize removed, as a crash in between would.
+	require.NoError(t, db.SetAppendIntent(hash, AppendIntent{StartedAt: time.Now()}))
+
+	reclaimed, err := sm.ReclaimAbandonedAppends(0)
+	require.NoError(t, err)
+	assert.Zero(t, reclaimed, "a completed object must survive the janitor")
+
+	present, err := sm.HasObject(hash)
+	require.NoError(t, err)
+	assert.True(t, present)
+
+	intent, err := db.GetAppendIntent(hash)
+	require.NoError(t, err)
+	assert.Nil(t, intent, "the stale marker is still cleaned up")
+}
+
+// TestReclaimAbandonedAppendsHonorsMinAge checks that a young record is left
+// alone even when no writer claims it, so a reclamation pass cannot race a
+// consumer that builds writers some other way.
+func TestReclaimAbandonedAppendsHonorsMinAge(t *testing.T) {
+	db, sm := newAppendTestStorage(t, 1)
+
+	sizeCode := BytesToChunkSizeCode(2 * 1024 * 1024)
+	hash := InstanceHash(randomHexForTest(t, 32))
+
+	w, err := sm.NewAppendWriter(t.Context(), hash, NamespaceID(1), sizeCode)
+	require.NoError(t, err)
+	_, err = w.Write(make([]byte, 8192))
+	require.NoError(t, err)
+	sm.liveAppends.Delete(hash)
+
+	reclaimed, err := sm.ReclaimAbandonedAppends(time.Hour)
+	require.NoError(t, err)
+	assert.Zero(t, reclaimed, "a record younger than minAge must be left alone")
+
+	present, err := sm.HasObject(hash)
+	require.NoError(t, err)
+	assert.True(t, present)
+
+	// Backdate the record and it becomes reclaimable.
+	require.NoError(t, db.SetAppendIntent(hash, AppendIntent{
+		StartedAt: time.Now().Add(-2 * time.Hour),
+	}))
+	reclaimed, err = sm.ReclaimAbandonedAppends(time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 1, reclaimed)
+}
+
+// TestAppendWriterWriteReportsBytesOnError checks the io.Writer contract on a
+// failing flush: the bytes are already in the writer's buffer and already
+// counted, so reporting zero would invite an io.Copy-style caller to resend
+// them.
+func TestAppendWriterWriteReportsBytesOnError(t *testing.T) {
+	_, sm := newAppendTestStorage(t, 1)
+
+	sizeCode := BytesToChunkSizeCode(2 * 1024 * 1024)
+	hash := InstanceHash(randomHexForTest(t, 32))
+
+	w, err := sm.NewAppendWriter(t.Context(), hash, NamespaceID(1), sizeCode)
+	require.NoError(t, err)
+
+	// Delete the object out from under the writer so the next flush fails
+	// inside growTo, which reads metadata that is no longer there.
+	require.NoError(t, sm.Delete(hash))
+
+	payload := make([]byte, BlockDataSize*2)
+	n, err := w.Write(payload)
+	require.Error(t, err, "the flush must fail once the object is gone")
+	assert.Equal(t, len(payload), n,
+		"a failed write still reports the bytes it consumed and counted")
+	assert.Equal(t, int64(len(payload)), w.Written())
+}

--- a/local_cache/checksum_format.go
+++ b/local_cache/checksum_format.go
@@ -1,0 +1,150 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Shared checksum naming, encoding, and hashing.
+//
+// Four places need to agree on which algorithms exist and how they are written
+// down: the consistency checker, the cache API's Digest header, the
+// introspection output, and the pstore origin backend.  They live here rather
+// than in each of those, because four spellings of the same table is four
+// chances to disagree -- and the disagreement is not obvious when it happens.
+// A digest encoded as hex where RFC 3230 requires base64, for instance,
+// reaches the Pelican client as a checksum mismatch against a value identical
+// to its own.
+
+package local_cache
+
+import (
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"hash"
+	"hash/crc32"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// ChecksumAlgorithmName returns the RFC 3230 token for a checksum type, as it
+// appears in Want-Digest and Digest headers.  Unknown types return "".
+func ChecksumAlgorithmName(t ChecksumType) string {
+	switch t {
+	case ChecksumMD5:
+		return "md5"
+	case ChecksumSHA1:
+		return "sha"
+	case ChecksumSHA256:
+		return "sha-256"
+	case ChecksumCRC32:
+		return "crc32"
+	case ChecksumCRC32C:
+		return "crc32c"
+	default:
+		return ""
+	}
+}
+
+// ParseChecksumAlgorithm maps the spellings clients use in Want-Digest onto a
+// checksum type.  The second result reports whether the name was recognized.
+func ParseChecksumAlgorithm(name string) (ChecksumType, bool) {
+	switch strings.TrimSpace(strings.ToLower(name)) {
+	case "md5":
+		return ChecksumMD5, true
+	case "sha", "sha-1", "sha1":
+		return ChecksumSHA1, true
+	case "sha-256", "sha256":
+		return ChecksumSHA256, true
+	case "crc32":
+		return ChecksumCRC32, true
+	case "crc32c":
+		return ChecksumCRC32C, true
+	default:
+		return 0, false
+	}
+}
+
+// FormatChecksumValue renders a checksum the way RFC 3230 expects for its
+// algorithm: message digests are base64, CRCs are lowercase hex.  Unknown
+// types return "".
+//
+// Getting this wrong is not cosmetic.  A client compares the value it computed
+// against the one the origin reports and fails the transfer on a mismatch,
+// even when the underlying digests are identical.
+func FormatChecksumValue(c Checksum) string {
+	switch c.Type {
+	case ChecksumMD5, ChecksumSHA1, ChecksumSHA256:
+		return base64.StdEncoding.EncodeToString(c.Value)
+	case ChecksumCRC32, ChecksumCRC32C:
+		return hex.EncodeToString(c.Value)
+	default:
+		return ""
+	}
+}
+
+// FormatDigestEntry renders one checksum as an RFC 3230 "name=value" pair,
+// or "" when the algorithm is not recognized or the digest is empty.
+//
+// Skipping an empty digest is a deliberate change from the cache's previous
+// Digest-header code, which emitted a bare "md5=" for a zero-value
+// Checksum{Type: ChecksumMD5}.  Every algorithm here produces a fixed-length
+// digest, so an empty Value never means "the digest of nothing" -- it means the
+// checksum was never populated.  Advertising it anyway is worse than omitting
+// it: RFC 3230 gives a client no way to read "md5=" as "unknown", so the
+// Pelican client compares the digest it computed against an empty string and
+// fails an otherwise-good transfer as a checksum mismatch.  A missing entry, by
+// contrast, is exactly the "no digest available" signal clients already handle.
+func FormatDigestEntry(c Checksum) string {
+	name := ChecksumAlgorithmName(c.Type)
+	value := FormatChecksumValue(c)
+	if name == "" || value == "" {
+		return ""
+	}
+	return name + "=" + value
+}
+
+// FormatDigestHeader renders a set of checksums as an RFC 3230 Digest header
+// value.  Unknown algorithms are skipped.
+func FormatDigestHeader(checksums []Checksum) string {
+	parts := make([]string, 0, len(checksums))
+	for _, c := range checksums {
+		if entry := FormatDigestEntry(c); entry != "" {
+			parts = append(parts, entry)
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+// NewChecksumHasher returns a hash for the given checksum type.
+func NewChecksumHasher(t ChecksumType) (hash.Hash, error) {
+	switch t {
+	case ChecksumMD5:
+		return md5.New(), nil
+	case ChecksumSHA1:
+		return sha1.New(), nil
+	case ChecksumSHA256:
+		return sha256.New(), nil
+	case ChecksumCRC32:
+		return crc32.NewIEEE(), nil
+	case ChecksumCRC32C:
+		return crc32.New(crc32.MakeTable(crc32.Castagnoli)), nil
+	default:
+		return nil, errors.Errorf("unknown checksum type: %d", t)
+	}
+}

--- a/local_cache/chunking_test.go
+++ b/local_cache/chunking_test.go
@@ -376,7 +376,7 @@ func TestChunkedObjectEvictByLRU(t *testing.T) {
 	}
 
 	// Evict the oldest object (first one)
-	evicted, totalFreed, err := storage.EvictByLRU(StorageIDFirstDisk, 1, 1, actualChunkSize*2)
+	evicted, totalFreed, _, err := storage.EvictByLRU(StorageIDFirstDisk, 1, 1, actualChunkSize*2)
 	require.NoError(t, err)
 	assert.Len(t, evicted, 1, "Should evict 1 object")
 	assert.Greater(t, totalFreed, uint64(0), "Should free some bytes")
@@ -983,7 +983,7 @@ func TestLazyChunkedEviction(t *testing.T) {
 
 	// Evict the object.  Only chunks 0 and 2 are allocated, so
 	// totalFreed should be the sum of their on-disk file sizes.
-	evicted, totalFreed, err := storage.EvictByLRU(meta.GetChunkStorageID(0), 1, 1, objectSize)
+	evicted, totalFreed, _, err := storage.EvictByLRU(meta.GetChunkStorageID(0), 1, 1, objectSize)
 	require.NoError(t, err)
 	assert.Len(t, evicted, 1)
 	expectedFreed := uint64(CalculateFileSize(chunkSize)) * 2 // 2 allocated chunks

--- a/local_cache/consistency.go
+++ b/local_cache/consistency.go
@@ -21,13 +21,9 @@ package local_cache
 import (
 	"bytes"
 	"context"
-	"crypto/md5"
-	"crypto/sha1"
-	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"hash"
-	"hash/crc32"
 	"io/fs"
 	"math/rand"
 	"os"
@@ -137,6 +133,16 @@ type ConsistencyChecker struct {
 	skipVerifiedData    bool           // When true, the data scan verifies each object once then skips it
 	resampleInterval    int            // In skip mode, re-verify ~1/N already-verified objects (0 disables)
 
+	// preserveCorruptObjects suppresses the delete-on-mismatch that is right
+	// for a cache and catastrophic for a store holding the only copy.
+	preserveCorruptObjects bool
+	// skipChecksumBackfill suppresses the metadata write that records
+	// checksums for an object that has none.
+	skipChecksumBackfill bool
+	// suppressCacheMetrics leaves the cache-named collectors alone, for a
+	// consumer that is not a cache.  See ConsistencyConfig.
+	suppressCacheMetrics bool
+
 	// Statistics
 	stats   ConsistencyStats
 	statsMu sync.RWMutex
@@ -173,6 +179,38 @@ type ConsistencyConfig struct {
 	// a nonzero floor of at-rest corruption detection even in "once" mode.
 	// 0 disables re-sampling (pure once).
 	ResampleInterval int
+	// PreserveCorruptObjects, when true, makes the data scan report at-rest
+	// corruption without deleting the object.
+	//
+	// A cache must delete: the object is a copy, deleting it is how the next
+	// request repairs it from the origin.  A primary store (pstore) has no
+	// upstream, so deleting is the loss rather than the repair -- the block
+	// file and its metadata are the only record that the object ever existed,
+	// including its path, size, and checksums.  Set this for any store that is
+	// the last copy; leave it false for a cache.
+	PreserveCorruptObjects bool
+	// SkipChecksumBackfill, when true, makes the data scan leave objects that
+	// carry no recorded checksums alone rather than computing and storing them.
+	//
+	// The backfill is a metadata write, so a scan that sets it is not the
+	// read-only pass its callers may believe it to be.  For a cache the write
+	// is harmless; for a primary store it can persist a checksum derived from
+	// data that is already corrupt, or race a write that has not yet recorded
+	// its own checksums.
+	SkipChecksumBackfill bool
+	// SuppressCacheMetrics stops this checker from updating the
+	// pelican_cache_*_scan_* collectors above.
+	//
+	// Those names describe a cache, and this checker has a second consumer:
+	// pstore drives it to scan an *origin*.  Left on, an origin's integrity
+	// scan is reported as cache activity -- a process serving no cache at all
+	// publishes cache series, and one serving both adds the two together in
+	// the same graph with no way to separate them.  A consumer that sets this
+	// takes on publishing the equivalent figures under its own names; pstore
+	// does, as pelican_pstore_data_scan_*.
+	//
+	// It does not change what the scan does, only what it reports.
+	SuppressCacheMetrics bool
 }
 
 // ConsistencyStats holds statistics from consistency checks
@@ -211,10 +249,14 @@ func NewConsistencyChecker(db *CacheDB, storage *StorageManager, config Consiste
 	burstNs := 100 * 1_000_000                                // 100ms burst capacity
 	limiter := rate.NewLimiter(rate.Limit(activeNsPerSec), burstNs)
 
-	// Initialize metrics
-	now := float64(time.Now().Unix())
-	metadataScanLastStartTime.Set(now)
-	dataScanLastStartTime.Set(now)
+	// Initialize metrics.  Skipped entirely for a non-cache consumer: seeding
+	// the cache's scan timestamps from a pstore's checker would make a cache
+	// that is not running look like one that had just scanned.
+	if !config.SuppressCacheMetrics {
+		now := float64(time.Now().Unix())
+		metadataScanLastStartTime.Set(now)
+		dataScanLastStartTime.Set(now)
+	}
 
 	cc := &ConsistencyChecker{
 		db:                  db,
@@ -226,6 +268,10 @@ func NewConsistencyChecker(db *CacheDB, storage *StorageManager, config Consiste
 		skipVerifiedData:    config.SkipVerifiedData,
 		resampleInterval:    config.ResampleInterval,
 		stopCh:              make(chan struct{}),
+
+		preserveCorruptObjects: config.PreserveCorruptObjects,
+		skipChecksumBackfill:   config.SkipChecksumBackfill,
+		suppressCacheMetrics:   config.SuppressCacheMetrics,
 	}
 
 	// Surface the data-scan mode so a misconfigured cache is visible: emit a
@@ -233,13 +279,15 @@ func NewConsistencyChecker(db *CacheDB, storage *StorageManager, config Consiste
 	// relies on the underlying storage (e.g. ZFS scrubbing) for ongoing at-rest
 	// integrity rather than re-reading every object.
 	if config.SkipVerifiedData {
-		dataScanModeOnce.Set(1)
+		if !config.SuppressCacheMetrics {
+			dataScanModeOnce.Set(1)
+		}
 		if config.ResampleInterval > 0 {
 			log.Warnf("Cache data-integrity scan is in \"once\" mode: each object's on-disk data is verified once and then skipped (re-sampling ~1/%d per cycle). This relies on the underlying storage to detect at-rest corruption; ensure it scrubs (e.g. ZFS).", config.ResampleInterval)
 		} else {
 			log.Warn("Cache data-integrity scan is in \"once\" mode with re-sampling disabled: each object's on-disk data is verified once and then never re-checked. This relies entirely on the underlying storage to detect at-rest corruption; ensure it scrubs (e.g. ZFS).")
 		}
-	} else {
+	} else if !config.SuppressCacheMetrics {
 		dataScanModeOnce.Set(0)
 	}
 
@@ -361,7 +409,9 @@ func (cc *ConsistencyChecker) RunMetadataScan(ctx context.Context, progressCh ch
 	lastProgressLog := scanStartTime
 	lastProgressSend := scanStartTime
 	cc.lastMetadataScan.Store(scanStartTime.Unix())
-	metadataScanLastStartTime.Set(float64(scanStartTime.Unix()))
+	if !cc.suppressCacheMetrics {
+		metadataScanLastStartTime.Set(float64(scanStartTime.Unix()))
+	}
 
 	// Stream files from disk via channel.  Each directory's WalkDir
 	// produces entries in lexicographic order.  A k-way merge goroutine
@@ -856,8 +906,10 @@ func (cc *ConsistencyChecker) RunMetadataScan(ctx context.Context, progressCh ch
 				inconsistentCount++
 				inconsistentSize += del.size
 			}
-			metadataScanInconsistentObjects.Add(float64(inconsistentCount))
-			metadataScanInconsistentBytes.Add(float64(inconsistentSize))
+			if !cc.suppressCacheMetrics {
+				metadataScanInconsistentObjects.Add(float64(inconsistentCount))
+				metadataScanInconsistentBytes.Add(float64(inconsistentSize))
+			}
 		}
 
 		// Check if we've processed all DB entries (no entries in this transaction means we're done)
@@ -903,9 +955,11 @@ func (cc *ConsistencyChecker) RunMetadataScan(ctx context.Context, progressCh ch
 	cc.stats.OrphanedFiles += orphanedFiles
 	cc.statsMu.Unlock()
 
-	metadataScanDurationSeconds.Add(scanDuration.Seconds())
-	metadataScanFilesProcessed.Add(float64(filesScanned))
-	metadataScanDBEntriesProcessed.Add(float64(dbEntriesScanned))
+	if !cc.suppressCacheMetrics {
+		metadataScanDurationSeconds.Add(scanDuration.Seconds())
+		metadataScanFilesProcessed.Add(float64(filesScanned))
+		metadataScanDBEntriesProcessed.Add(float64(dbEntriesScanned))
+	}
 
 	log.Infof("Metadata scan complete in %v: scanned %d DB entries and %d files, found %d orphaned DB entries and %d orphaned files (%s)",
 		scanDuration, dbEntriesScanned, filesScanned, orphanedDBEntries, orphanedFiles, utils.HumanBytes(orphanedBytes))
@@ -1039,7 +1093,9 @@ func (cc *ConsistencyChecker) RunDataScan(ctx context.Context, progressCh chan<-
 	sl.Info("Starting data integrity scan")
 	scanStartTime := time.Now()
 	cc.lastDataScan.Store(scanStartTime.Unix())
-	dataScanLastStartTime.Set(float64(scanStartTime.Unix()))
+	if !cc.suppressCacheMetrics {
+		dataScanLastStartTime.Set(float64(scanStartTime.Unix()))
+	}
 
 	// Rate limiter for I/O
 	bytesLimiter := rate.NewLimiter(rate.Limit(cc.dataScanBytesPerSec), int(cc.dataScanBytesPerSec))
@@ -1249,7 +1305,9 @@ scanComplete:
 
 	// Final stats update (scan timing / log)
 	scanDuration := time.Since(scanStartTime)
-	dataScanDurationSeconds.Add(scanDuration.Seconds())
+	if !cc.suppressCacheMetrics {
+		dataScanDurationSeconds.Add(scanDuration.Seconds())
+	}
 
 	sl.WithFields(log.Fields{
 		"elapsed":            scanDuration.Truncate(time.Second),
@@ -1298,10 +1356,15 @@ func (cc *ConsistencyChecker) processBatchForDataScan(
 		deltaObjects := *objectsVerified - prevObjects
 
 		if deltaMismatches > 0 || deltaBytes > 0 || deltaObjects > 0 {
-			dataScanInconsistentObjects.Add(float64(deltaMismatches))
-			dataScanInconsistentBytes.Add(float64(deltaInconsistent))
-			dataScanObjectsProcessed.Add(float64(deltaObjects))
-			dataScanBytesProcessed.Add(float64(deltaBytes))
+			// The stats below are updated either way: they are this checker's
+			// own, and a consumer that suppressed the cache-named collectors
+			// reads them to publish its own.
+			if !cc.suppressCacheMetrics {
+				dataScanInconsistentObjects.Add(float64(deltaMismatches))
+				dataScanInconsistentBytes.Add(float64(deltaInconsistent))
+				dataScanObjectsProcessed.Add(float64(deltaObjects))
+				dataScanBytesProcessed.Add(float64(deltaBytes))
+			}
 
 			cc.statsMu.Lock()
 			cc.stats.LastDataScan = time.Now()
@@ -1346,6 +1409,13 @@ func (cc *ConsistencyChecker) verifyObjectChecksum(
 
 	// If no checksums available, calculate and store them
 	if len(meta.Checksums) == 0 {
+		// Unless the caller asked for a strictly read-only pass: the backfill
+		// is a metadata write, and for a store holding the only copy it can
+		// bless data that is already corrupt or race a write that has not yet
+		// recorded its own checksums.
+		if cc.skipChecksumBackfill {
+			return errChecksumSkipped
+		}
 		if err := cc.calculateAndStoreChecksums(ctx, instanceHash, meta, bytesLimiter); err != nil {
 			return err
 		}
@@ -1377,6 +1447,17 @@ func (cc *ConsistencyChecker) verifyObjectChecksum(
 			log.Warnf("Checksum mismatch for object %s (type %d)", instanceHash, cksum.Type)
 			*checksumMismatches++
 			*inconsistentBytes += meta.ContentLength
+			if cc.preserveCorruptObjects {
+				// Deleting is how a cache repairs itself; for a store that
+				// holds the only copy it *is* the data loss.  Report and keep
+				// the bytes so an operator can still restore, re-ingest, or at
+				// minimum see the object's path, size, and checksums.
+				log.Errorf("At-rest corruption in object %s (checksum type %d does not match "+
+					"what was recorded at ingest). The object has been LEFT IN PLACE because "+
+					"this store holds the only copy; it cannot be re-fetched. Restore it from "+
+					"backup or re-ingest it.", instanceHash, cksum.Type)
+				return nil
+			}
 			if err := cc.storage.Delete(instanceHash); err != nil {
 				log.Warnf("Failed to delete corrupted object %s: %v", instanceHash, err)
 			}
@@ -1520,20 +1601,7 @@ func (cc *ConsistencyChecker) calculateAndStoreChecksums(
 
 // createHasher creates a hash.Hash for the given checksum type
 func (cc *ConsistencyChecker) createHasher(checksumType ChecksumType) (hash.Hash, error) {
-	switch checksumType {
-	case ChecksumMD5:
-		return md5.New(), nil
-	case ChecksumSHA1:
-		return sha1.New(), nil
-	case ChecksumSHA256:
-		return sha256.New(), nil
-	case ChecksumCRC32:
-		return crc32.NewIEEE(), nil
-	case ChecksumCRC32C:
-		return crc32.New(crc32.MakeTable(crc32.Castagnoli)), nil
-	default:
-		return nil, errors.Errorf("unknown checksum type: %d", checksumType)
-	}
+	return NewChecksumHasher(checksumType)
 }
 
 // VerifyObject verifies a single object's integrity.

--- a/local_cache/database.go
+++ b/local_cache/database.go
@@ -41,7 +41,10 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/RoaringBitmap/roaring"
@@ -58,15 +61,79 @@ const (
 
 // CacheDB wraps BadgerDB with cache-specific operations
 type CacheDB struct {
-	db        *badger.DB
-	encMgr    *EncryptionManager
-	baseDir   string
-	salt      []byte // random salt for hashing object/instance names
+	db      *badger.DB
+	encMgr  *EncryptionManager
+	baseDir string
+	// salt is the random salt for hashing object/instance names.  Reads are
+	// on the hot path (every ObjectHash and InstanceHash call, from arbitrary
+	// goroutines) while writes happen twice at most -- at open, and again if
+	// a catalog restore replaces the database underneath us -- so it is held
+	// as an atomic pointer rather than under a lock.  A write publishes a
+	// whole new slice; the slice a reader already loaded is never mutated,
+	// which is what lets Salt hand it out directly.
+	salt      atomic.Pointer[[]byte]
 	closeOnce sync.Once
 
 	// usageMu protects usageMergeOps for lazy creation of merge operators
 	usageMu       sync.RWMutex
 	usageMergeOps map[StorageUsageKey]*badger.MergeOperator
+
+	// skipBudget overrides evictionSkipBudget when non-zero.  Set only by
+	// tests, so that budget exhaustion can be exercised without building a
+	// thousand protected objects.
+	skipBudget int
+
+	// readOnly marks a handle opened for offline introspection.  The
+	// underlying BadgerDB is writable -- see OpenCacheDBReadOnly for why --
+	// so this flag is what actually keeps an inspection tool from modifying
+	// the database: every mutating entry point checks it first.
+	readOnly bool
+}
+
+// ErrReadOnly is returned by every mutating CacheDB method when the handle was
+// opened for introspection.  Callers can test for it with errors.Is.
+var ErrReadOnly = errors.New("the cache database is open read-only")
+
+// checkWritable reports an error when this handle may not write.
+func (cdb *CacheDB) checkWritable() error {
+	if cdb.readOnly {
+		return errors.Wrapf(ErrReadOnly, "refusing to modify the cache database at %s", cdb.baseDir)
+	}
+	return nil
+}
+
+// ReadOnly reports whether this handle refuses mutations.
+func (cdb *CacheDB) ReadOnly() bool { return cdb.readOnly }
+
+// cacheDBOptions builds the BadgerDB options shared by every way of opening a
+// cache database.  Both the writable open and the introspection open must use
+// identical settings: they differ in what Pelican allows, not in how the
+// on-disk database is interpreted.
+func cacheDBOptions(dbPath string, dbKey []byte) badger.Options {
+	opts := badger.DefaultOptions(dbPath)
+
+	// Performance: Disable synchronous writes for cache data
+	// Risk: Power loss may lose last few seconds of 'access history' or 'download state'
+	// Mitigation: Cache is self-healing; missing blocks will simply be re-downloaded
+	opts.SyncWrites = false
+
+	// Storage: Force small values into LSM tree
+	// Bitmaps and usage counters need fast merge speeds
+	opts.ValueThreshold = 4096
+
+	// Reduce logging noise
+	opts.Logger = newBadgerLogger()
+
+	// Encrypt BadgerDB at rest so that metadata (ETags, URLs, timestamps)
+	// stored in LSM tree and WAL files is not readable without the key.
+	// We derive a separate key from the master key using HKDF for proper
+	// key separation (the master key itself encrypts data blocks).
+	opts.EncryptionKey = dbKey
+	opts.EncryptionKeyRotationDuration = 0 // Disable rotation; we manage keys ourselves
+	// BadgerDB requires IndexCacheSize > 0 when encryption is enabled
+	opts.IndexCacheSize = 64 << 20 // 64 MB
+
+	return opts
 }
 
 // NewCacheDB creates and initializes a new cache database.
@@ -87,36 +154,14 @@ func NewCacheDB(ctx context.Context, baseDir string) (*CacheDB, error) {
 		return nil, errors.Wrap(err, "failed to initialize encryption manager")
 	}
 
-	// Configure BadgerDB with optimized settings for cache workload
-	opts := badger.DefaultOptions(dbPath)
-
-	// Performance: Disable synchronous writes for cache data
-	// Risk: Power loss may lose last few seconds of 'access history' or 'download state'
-	// Mitigation: Cache is self-healing; missing blocks will simply be re-downloaded
-	opts.SyncWrites = false
-
-	// Storage: Force small values into LSM tree
-	// Bitmaps and usage counters need fast merge speeds
-	opts.ValueThreshold = 4096
-
-	// Reduce logging noise
-	opts.Logger = newBadgerLogger()
-
-	// Encrypt BadgerDB at rest so that metadata (ETags, URLs, timestamps)
-	// stored in LSM tree and WAL files is not readable without the key.
-	// We derive a separate key from the master key using HKDF for proper
-	// key separation (the master key itself encrypts data blocks).
+	// Derive the database encryption key
 	dbKey, err := encMgr.DeriveDBKey()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to derive database encryption key")
 	}
-	opts.EncryptionKey = dbKey
-	opts.EncryptionKeyRotationDuration = 0 // Disable rotation; we manage keys ourselves
-	// BadgerDB requires IndexCacheSize > 0 when encryption is enabled
-	opts.IndexCacheSize = 64 << 20 // 64 MB
 
 	// Open the database
-	db, err := badger.Open(opts)
+	db, err := badger.Open(cacheDBOptions(dbPath, dbKey))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open BadgerDB")
 	}
@@ -128,14 +173,22 @@ func NewCacheDB(ctx context.Context, baseDir string) (*CacheDB, error) {
 		usageMergeOps: make(map[StorageUsageKey]*badger.MergeOperator),
 	}
 
+	// Settle the schema version before writing anything else: a database
+	// written by a newer binary must be refused untouched, not amended with a
+	// salt or a store-mode marker on the way to failing.
+	if err := cdb.ensureSchemaVersion(); err != nil {
+		db.Close()
+		return nil, err
+	}
+
 	// Load or generate the hash salt.  The salt is persisted in the DB
 	// so that object/instance hashes are stable across restarts.
 	salt, err := cdb.loadOrCreateSalt()
 	if err != nil {
 		db.Close()
-		return nil, errors.Wrap(err, "failed to initialise hash salt")
+		return nil, errors.Wrap(err, "failed to initialize hash salt")
 	}
-	cdb.salt = salt
+	cdb.setSalt(salt)
 
 	log.Infof("Cache database initialized at %s", dbPath)
 	return cdb, nil
@@ -159,14 +212,60 @@ func (cdb *CacheDB) Close() error {
 	return closeErr
 }
 
-// OpenCacheDBReadOnly opens an existing cache database in read-only mode.
-// This is suitable for CLI introspection tools that need to inspect cache
-// contents without modifying anything.
+// OpenCacheDBReadOnly opens an existing cache database for introspection.
+// This is suitable for CLI tools that need to inspect cache contents without
+// modifying anything.
 //
 // Like NewCacheDB, this requires issuer keys to be available for decrypting
 // the database encryption key.
+//
+// "Read-only" is enforced by Pelican, not by BadgerDB.  BadgerDB's own
+// ReadOnly mode cannot be used here:
+//
+//   - On Linux and macOS it aborts the process.  Opening an *encrypted*
+//     database that has flushed at least one SST file read-only drives
+//     Table.fetchIndex into y.Check(err) -> log.Fatalf, which prints
+//     "err: invalid argument" and exits without returning an error or running
+//     a single defer.  Every database NewCacheDB creates is encrypted and
+//     every cache that has served an object has an SST, so this fired on
+//     every real cache.
+//   - On Windows it is refused outright ("Read-only mode is not supported on
+//     Windows").
+//
+// So the database is opened the ordinary way and mutation is refused in Go
+// instead, via the readOnly flag that checkWritable guards every writing entry
+// point with.  This is the same trade pstore.OpenMaintenance makes.
+//
+// What that costs is BadgerDB's exclusive directory lock, which an ordinary
+// open takes: introspection now fails while a cache is running rather than
+// opening alongside it.  That is acceptable -- offline introspection is only
+// reached when the cache is not running, since the CLI routes to the live
+// service otherwise -- and it is arguably better, because holding the lock
+// stops a cache from starting up underneath an introspection in progress.
+// A lock failure is translated into an explanation of exactly that, since
+// "another process is using this Badger database" is not something an operator
+// should have to decode.
+//
+// What it does not cost is the guarantee the read-only path exists for: this
+// open still never stamps a schema version (VerifySchemaVersion only checks)
+// and never claims a store mode (EnsureStoreMode is not called), so
+// inspecting a database leaves its header exactly as it was found.
 func OpenCacheDBReadOnly(baseDir string) (*CacheDB, error) {
 	dbPath := filepath.Join(baseDir, dbSubDir)
+
+	// An introspection open must not bring a database into existence.
+	// badger.Open would happily create the directory and an empty database in
+	// it, leaving the operator to wonder why their cache looks empty; a
+	// mistyped path should say so instead.
+	if info, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil, errors.Errorf("no cache database at %s; check that this is a cache "+
+				"storage location (Cache.StorageLocation)", dbPath)
+		}
+		return nil, errors.Wrapf(err, "failed to inspect the cache database at %s", dbPath)
+	} else if !info.IsDir() {
+		return nil, errors.Errorf("%s is not a directory, so it does not hold a cache database", dbPath)
+	}
 
 	// Initialize encryption manager to get the database key
 	encMgr, err := NewEncryptionManager(baseDir)
@@ -174,55 +273,101 @@ func OpenCacheDBReadOnly(baseDir string) (*CacheDB, error) {
 		return nil, errors.Wrap(err, "failed to initialize encryption manager")
 	}
 
-	// Configure BadgerDB for read-only access
-	opts := badger.DefaultOptions(dbPath)
-	opts.ReadOnly = true
-	opts.Logger = newBadgerLogger()
-
 	// Derive the database encryption key
 	dbKey, err := encMgr.DeriveDBKey()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to derive database encryption key")
 	}
-	opts.EncryptionKey = dbKey
-	opts.EncryptionKeyRotationDuration = 0
-	opts.IndexCacheSize = 64 << 20 // 64 MB
 
-	// Open the database in read-only mode
-	db, err := badger.Open(opts)
+	db, err := badger.Open(cacheDBOptions(dbPath, dbKey))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to open BadgerDB in read-only mode")
+		if locked := explainDirectoryLock(baseDir, err); locked != nil {
+			return nil, locked
+		}
+		return nil, errors.Wrap(err, "failed to open BadgerDB for introspection")
 	}
 
 	cdb := &CacheDB{
-		db:      db,
-		encMgr:  encMgr,
-		baseDir: baseDir,
+		db:            db,
+		encMgr:        encMgr,
+		baseDir:       baseDir,
+		readOnly:      true,
+		usageMergeOps: make(map[StorageUsageKey]*badger.MergeOperator),
 	}
 
-	// Load the hash salt (must exist for read operations to make sense)
+	// Refuse a database whose layout this binary does not understand before
+	// reading a single record out of it.  Unlike NewCacheDB this only
+	// verifies: an introspection tool must leave no fingerprints on a database
+	// it is merely looking at, so it neither stamps a version nor claims a
+	// store mode.  That is the same reasoning that keeps EnsureStoreMode out
+	// of this path.
+	if err := cdb.VerifySchemaVersion(); err != nil {
+		db.Close()
+		return nil, err
+	}
+
+	// Load the hash salt.  Unlike loadOrCreateSalt this refuses to generate
+	// one: without the original salt no stored hash can be recomputed, so a
+	// fresh salt would make every object in the database unfindable while
+	// looking like success -- and writing it would be a modification besides.
 	err = db.View(func(txn *badger.Txn) error {
 		item, err := txn.Get([]byte(KeySalt))
 		if err != nil {
 			return err
 		}
 		return item.Value(func(val []byte) error {
-			cdb.salt = make([]byte, len(val))
-			copy(cdb.salt, val)
+			salt := make([]byte, len(val))
+			copy(salt, val)
+			cdb.setSalt(salt)
 			return nil
 		})
 	})
 	if err != nil {
 		db.Close()
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			return nil, errors.Errorf("the database at %s carries no hash salt, so it holds no "+
+				"cache contents to inspect", dbPath)
+		}
 		return nil, errors.Wrap(err, "failed to load hash salt")
 	}
 
-	log.Debugf("Cache database opened in read-only mode at %s", dbPath)
+	log.Debugf("Cache database opened for introspection at %s", dbPath)
 	return cdb, nil
 }
 
-// StartGC starts the background garbage collection goroutine
+// explainDirectoryLock recognizes BadgerDB's directory-lock failure and
+// restates it in terms an operator can act on.  It returns nil when err is
+// some other failure.
+//
+// BadgerDB reports this as "Cannot acquire directory lock on %q.  Another
+// process is using this Badger database." (dir_unix.go) or "Cannot create lock
+// file %q.  Another process is using this Badger database" (dir_windows.go),
+// wrapping the underlying EWOULDBLOCK or sharing violation.  Neither says the
+// one thing the operator needs to know: the cache server is running, and the
+// same information is available from it.
+func explainDirectoryLock(baseDir string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if !strings.Contains(err.Error(), "Another process is using this Badger database") {
+		return nil
+	}
+	return errors.Wrapf(err,
+		"the cache database at %s is locked by another process, which almost always means "+
+			"the cache server is running; offline introspection requires the cache to be "+
+			"stopped, so either stop it or let the command query the running cache instead "+
+			"-- drop --offline if you passed it, and otherwise the running cache could not "+
+			"be found automatically, which usually means its address file is unreadable",
+		baseDir)
+}
+
+// StartGC starts the background garbage collection goroutine.
+//
+// Value-log GC rewrites the value log, so a read-only handle starts nothing.
 func (cdb *CacheDB) StartGC(ctx context.Context, egrp *errgroup.Group) {
+	if cdb.readOnly {
+		return
+	}
 	egrp.Go(func() error {
 		ticker := time.NewTicker(5 * time.Minute)
 		defer ticker.Stop()
@@ -282,16 +427,299 @@ func (cdb *CacheDB) loadOrCreateSalt() ([]byte, error) {
 }
 
 // Salt returns the per-database random salt used for hashing.
-func (cdb *CacheDB) Salt() []byte { return cdb.salt }
+//
+// The returned slice is shared with every other caller and with the database
+// itself; callers must treat it as read-only.  Nothing in the tree writes
+// through it -- both consumers hand it straight to hmac.New, which copies --
+// and a caller that did would corrupt every hash computed concurrently.
+func (cdb *CacheDB) Salt() []byte {
+	if p := cdb.salt.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// setSalt publishes a new salt.
+func (cdb *CacheDB) setSalt(salt []byte) {
+	cdb.salt.Store(&salt)
+}
+
+// ReloadSalt re-reads the hash salt from the database.
+//
+// The salt is cached at open because it is on the hot path, which is fine
+// until something replaces the database's contents underneath it.  Restoring
+// a backup does exactly that: the restored salt is the one every instance
+// hash in that catalog was derived from, so a consumer still holding the salt
+// generated at open computes different hashes and finds none of its objects.
+func (cdb *CacheDB) ReloadSalt() error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
+	salt, err := cdb.loadOrCreateSalt()
+	if err != nil {
+		return errors.Wrap(err, "failed to reload the hash salt")
+	}
+	cdb.setSalt(salt)
+	return nil
+}
+
+// DB exposes the underlying BadgerDB handle.
+//
+// This exists for sibling subsystems that store their own records in this
+// key space and need transactional semantics the typed helpers above do not
+// provide — read-your-writes transactions spanning several keys, and prefix
+// iteration with seeks.  The pstore origin backend
+// (see docs/pstore-design.md) is the only such consumer today.
+//
+// Callers must confine themselves to prefixes they own, and must call
+// EnsureStoreMode first so that a cache and a pstore can never operate on the
+// same database.
+//
+// This is the one way past the read-only guard: the handle it returns is a
+// writable BadgerDB even when ReadOnly reports true (see OpenCacheDBReadOnly
+// for why the underlying database is not opened read-only).  A consumer that
+// honors read-only opens must consult ReadOnly before writing through it --
+// pstore does, in Store.checkWritable.
+func (cdb *CacheDB) DB() *badger.DB { return cdb.db }
+
+// EnsureStoreMode records which subsystem owns this database, or verifies that
+// a previously recorded owner matches.
+//
+// Caches and pstore origins share one key space (see the prefix constants in
+// schema.go), so opening one as the other would silently corrupt it.  Every
+// consumer must call this immediately after opening.
+//
+// A database with no marker is adopted when it is empty.  A non-empty database
+// with no marker is necessarily a legacy cache — pstore always writes the
+// marker — so adopting it is allowed only for StoreModeCache.
+//
+// The other half of the database header, the schema version, is settled by
+// NewCacheDB before this runs: a layout this binary cannot read is refused
+// before anyone asks who owns it, because the ownership marker is itself just
+// another record written under that layout.
+func (cdb *CacheDB) EnsureStoreMode(mode StoreMode) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
+	return cdb.db.Update(func(txn *badger.Txn) error {
+		item, err := txn.Get([]byte(KeyStoreMode))
+		if err == nil {
+			var found StoreMode
+			if vErr := item.Value(func(val []byte) error {
+				found = StoreMode(val)
+				return nil
+			}); vErr != nil {
+				return errors.Wrap(vErr, "failed to read store mode marker")
+			}
+			if found != mode {
+				return errors.Errorf(
+					"database at %s belongs to a %q store but was opened as a %q store; "+
+						"refusing to continue because the two share a key space",
+					cdb.baseDir, string(found), string(mode))
+			}
+			return nil
+		}
+		if !errors.Is(err, badger.ErrKeyNotFound) {
+			return errors.Wrap(err, "failed to read store mode marker")
+		}
+
+		// No marker.  Adopt it only if that cannot mislabel existing data.
+		if mode != StoreModeCache {
+			empty, cErr := txnIsEmptyApartFromHeader(txn)
+			if cErr != nil {
+				return cErr
+			}
+			if !empty {
+				return errors.Errorf(
+					"database at %s holds data but no store mode marker, so it is a "+
+						"pre-existing cache; refusing to open it as a %q store",
+					cdb.baseDir, string(mode))
+			}
+		}
+		return txn.Set([]byte(KeyStoreMode), []byte(mode))
+	})
+}
+
+// ensureSchemaVersion records the schema version of this database, or verifies
+// that a previously recorded version is one this binary can work with.
+//
+// Called from NewCacheDB, so it covers every writable consumer of the block
+// store — the cache and the pstore origin backend alike — before either of
+// them interprets a record.
+//
+// Four cases:
+//
+//   - No version key.  Every database created before versioning existed is in
+//     this state, as is a brand new one.  Both are stamped with
+//     CurrentSchemaVersion: the layout an unversioned database holds is, by
+//     definition, the one the last unversioned binary wrote, which is the
+//     layout this binary reads.  Adopting rather than refusing is deliberate;
+//     the alternative would break every deployed cache on upgrade.  This
+//     mirrors how EnsureStoreMode adopts an unmarked database as a cache.
+//   - Version equals CurrentSchemaVersion.  Nothing to do.
+//   - Version is older.  Handed to migrateSchema, and re-stamped once that
+//     succeeds.  No release has ever written a version below the current one,
+//     so today this only happens to a hand-edited or damaged marker, and
+//     migrateSchema — having no migration to offer — refuses it.
+//   - Version is newer.  Refused: this binary would read the records with the
+//     wrong rules, which is precisely the corruption versioning exists to
+//     prevent.
+func (cdb *CacheDB) ensureSchemaVersion() error {
+	return cdb.db.Update(func(txn *badger.Txn) error {
+		found, ok, err := readSchemaVersion(txn)
+		if err != nil {
+			return err
+		}
+		switch {
+		case !ok:
+			empty, cErr := txnIsEmptyApartFromHeader(txn)
+			if cErr != nil {
+				return cErr
+			}
+			if !empty {
+				log.Infof("Block store database at %s predates schema versioning; "+
+					"adopting it as schema version %d", cdb.baseDir, CurrentSchemaVersion)
+			}
+		case found == CurrentSchemaVersion:
+			return nil
+		case found > CurrentSchemaVersion:
+			return cdb.errSchemaTooNew(found)
+		default:
+			if err := migrateSchema(txn, found); err != nil {
+				return errors.Wrapf(err, "failed to migrate the block store database at %s "+
+					"from schema version %d to %d", cdb.baseDir, found, CurrentSchemaVersion)
+			}
+			log.Infof("Migrated the block store database at %s from schema version %d to %d",
+				cdb.baseDir, found, CurrentSchemaVersion)
+		}
+		return txn.Set([]byte(KeySchemaVersion), formatSchemaVersion(CurrentSchemaVersion))
+	})
+}
+
+// VerifySchemaVersion is the read-only counterpart of ensureSchemaVersion: it
+// refuses a database written under a newer schema but never writes, so it can
+// run inside a read-only BadgerDB handle (see OpenCacheDBReadOnly).
+//
+// A database with no version key is accepted as CurrentSchemaVersion for the
+// same reason ensureSchemaVersion adopts one, minus the stamp — introspecting
+// a cache must not require write access to it.  An older version is likewise
+// accepted: the writable open is where migration happens, and refusing to
+// *look* at a database that a normal start would quietly upgrade helps nobody.
+//
+// It is exported for the same reason EnsureStoreMode is: a consumer that
+// replaces this database's contents wholesale — restoring a backup catalog
+// into it — has a database whose header keys came from wherever the backup did
+// and no longer describe what was checked at open, and should re-verify.
+func (cdb *CacheDB) VerifySchemaVersion() error {
+	return cdb.db.View(func(txn *badger.Txn) error {
+		found, ok, err := readSchemaVersion(txn)
+		if err != nil {
+			return err
+		}
+		if ok && found > CurrentSchemaVersion {
+			return cdb.errSchemaTooNew(found)
+		}
+		return nil
+	})
+}
+
+// errSchemaTooNew builds the error returned when the database was written by a
+// binary that understands a later layout than this one does.
+func (cdb *CacheDB) errSchemaTooNew(found SchemaVersion) error {
+	return errors.Errorf(
+		"database at %s uses block store schema version %d, but this build of Pelican "+
+			"supports up to version %d; refusing to open it because reading a newer "+
+			"layout with older rules would corrupt it -- upgrade Pelican to a release "+
+			"that supports schema version %d",
+		cdb.baseDir, found, CurrentSchemaVersion, found)
+}
+
+// readSchemaVersion reads the schema version marker.  ok is false when the
+// database carries no marker at all.
+func readSchemaVersion(txn *badger.Txn) (version SchemaVersion, ok bool, err error) {
+	item, err := txn.Get([]byte(KeySchemaVersion))
+	if err != nil {
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			return 0, false, nil
+		}
+		return 0, false, errors.Wrap(err, "failed to read the schema version marker")
+	}
+	if err = item.Value(func(val []byte) error {
+		parsed, pErr := strconv.ParseUint(string(val), 10, 32)
+		if pErr != nil {
+			return errors.Errorf("schema version marker holds %q, which is not a version number", string(val))
+		}
+		version = SchemaVersion(parsed)
+		return nil
+	}); err != nil {
+		return 0, false, errors.Wrap(err, "failed to read the schema version marker")
+	}
+	return version, true, nil
+}
+
+// formatSchemaVersion renders a version for storage, matching the plain-text
+// style of the other header keys.
+func formatSchemaVersion(v SchemaVersion) []byte {
+	return []byte(strconv.FormatUint(uint64(v), 10))
+}
+
+// migrateSchema brings a database written under schema version `from` up to
+// CurrentSchemaVersion.  Its caller re-stamps the marker once it returns.
+//
+// There is exactly one schema version today, so no database Pelican ever wrote
+// reaches this function and it has nothing to do but refuse; it is the seam a
+// future version hooks into.  Refusing rather than shrugging is the point of
+// the default: whoever bumps CurrentSchemaVersion without teaching this
+// function about the step gets a loud, specific failure instead of a binary
+// that reads old records under new rules.
+//
+// A migration to version N is expected to rewrite, in place, every record
+// whose layout changed between N-1 and N — and to be idempotent, since a crash
+// part-way through leaves the old stamp in place and the migration runs again
+// on the next open.  Handle each version step separately (`for v := from; v <
+// CurrentSchemaVersion; v++`) so that a database several versions behind is
+// carried forward one step at a time rather than needing a bespoke path per
+// starting point.
+//
+// A migration too large for one BadgerDB transaction should not be forced into
+// this txn: give it a method on CacheDB that batches its own writes, call that
+// from ensureSchemaVersion before the stamping transaction, and leave this
+// function for the cheap in-place cases.
+func migrateSchema(txn *badger.Txn, from SchemaVersion) error {
+	return errors.Errorf("no migration is available from schema version %d", from)
+}
+
+// txnIsEmptyApartFromHeader reports whether the database holds no records
+// other than the header keys that describe the database itself (the hash salt,
+// which NewCacheDB writes before any consumer runs, the schema version stamped
+// alongside it, and the store mode marker).  None of those says anything about
+// which subsystem's records the database holds, so a database carrying only
+// them is still up for adoption.
+func txnIsEmptyApartFromHeader(txn *badger.Txn) (bool, error) {
+	opts := badger.DefaultIteratorOptions
+	opts.PrefetchValues = false
+	it := txn.NewIterator(opts)
+	defer it.Close()
+
+	for it.Rewind(); it.Valid(); it.Next() {
+		switch string(it.Item().Key()) {
+		case KeySalt, KeySchemaVersion, KeyStoreMode:
+			continue
+		default:
+			return false, nil
+		}
+	}
+	return true, nil
+}
 
 // ObjectHash computes the salted SHA-256 hash for a pelican URL.
 func (cdb *CacheDB) ObjectHash(pelicanURL string) ObjectHash {
-	return ComputeObjectHash(cdb.salt, pelicanURL)
+	return ComputeObjectHash(cdb.Salt(), pelicanURL)
 }
 
 // InstanceHash computes the salted SHA-256 hash for (etag, objectHash).
 func (cdb *CacheDB) InstanceHash(etag string, objectHash ObjectHash) InstanceHash {
-	return ComputeInstanceHash(cdb.salt, etag, objectHash)
+	return ComputeInstanceHash(cdb.Salt(), etag, objectHash)
 }
 
 // --- Metadata Operations ---
@@ -326,6 +754,9 @@ func (cdb *CacheDB) GetMetadata(instanceHash InstanceHash) (*CacheMetadata, erro
 // metadata entry (e.g. InitDiskStorage, StoreInline); for subsequent updates
 // prefer MergeMetadata which applies field-level merge semantics.
 func (cdb *CacheDB) SetMetadata(instanceHash InstanceHash, meta *CacheMetadata) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
 	data, err := msgpack.Marshal(meta)
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal metadata")
@@ -358,6 +789,9 @@ func (cdb *CacheDB) SetMetadata(instanceHash InstanceHash, meta *CacheMetadata) 
 // multiple concurrent callers merge metadata for the same instance (e.g.
 // concurrent range-on-miss initialization via initObjectFromStat).
 func (cdb *CacheDB) MergeMetadata(instanceHash InstanceHash, incoming *CacheMetadata) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
 	const maxRetries = 20
 	backoff := 100 * time.Microsecond
 	for attempt := 0; ; attempt++ {
@@ -539,6 +973,9 @@ func mergeSetOnceComparable[T comparable](name string, existing *T, incoming T) 
 
 // DeleteMetadata removes metadata for a file
 func (cdb *CacheDB) DeleteMetadata(instanceHash InstanceHash) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
 	return cdb.db.Update(func(txn *badger.Txn) error {
 		return txn.Delete(MetaKey(instanceHash))
 	})
@@ -579,6 +1016,9 @@ func (cdb *CacheDB) GetLatestETag(objectHash ObjectHash) (string, bool, error) {
 // prevents a slow download that finishes late from clobbering a newer
 // ETag written by a more recent request.
 func (cdb *CacheDB) SetLatestETag(objectHash ObjectHash, etag string, observedAt time.Time) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
 	key := ETagKey(objectHash)
 	return cdb.db.Update(func(txn *badger.Txn) error {
 		// Read-modify-write: only update if newer.
@@ -601,6 +1041,9 @@ func (cdb *CacheDB) SetLatestETag(objectHash ObjectHash, etag string, observedAt
 
 // DeleteLatestETag removes the ETag entry for an object
 func (cdb *CacheDB) DeleteLatestETag(objectHash ObjectHash) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
 	return cdb.db.Update(func(txn *badger.Txn) error {
 		return txn.Delete(ETagKey(objectHash))
 	})
@@ -631,6 +1074,9 @@ func decodeETagEntry(val []byte) (string, time.Time) {
 // to a numeric ID.  This ensures the IDs survive restarts so that LRU
 // keys and usage counters remain valid.
 func (cdb *CacheDB) SetNamespaceMapping(prefix string, id NamespaceID) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
 	val := make([]byte, 4)
 	binary.LittleEndian.PutUint32(val, uint32(id))
 	return cdb.db.Update(func(txn *badger.Txn) error {
@@ -689,6 +1135,9 @@ func DiskMappingKey(storageID StorageID) []byte {
 
 // SaveDiskMapping persists a single storageID → (UUID, directory) mapping.
 func (cdb *CacheDB) SaveDiskMapping(dm DiskMapping) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
 	data, err := msgpack.Marshal(&dm)
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal disk mapping")
@@ -775,6 +1224,9 @@ func (cdb *CacheDB) GetBlockState(instanceHash InstanceHash) (*roaring.Bitmap, e
 
 // SetBlockState stores the bitmap of downloaded blocks
 func (cdb *CacheDB) SetBlockState(instanceHash InstanceHash, bitmap *roaring.Bitmap) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
 	data, err := bitmap.ToBytes()
 	if err != nil {
 		return errors.Wrap(err, "failed to serialize bitmap")
@@ -797,6 +1249,9 @@ func (cdb *CacheDB) SetBlockState(instanceHash InstanceHash, bitmap *roaring.Bit
 // The method retries on BadgerDB transaction conflicts, which can occur when
 // multiple concurrent block fetchers write to the same object's bitmap.
 func (cdb *CacheDB) MergeBlockStateWithUsage(instanceHash InstanceHash, newBlocks *roaring.Bitmap, storageID StorageID, namespaceID NamespaceID, contentLength int64) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
 	newData, err := newBlocks.ToBytes()
 	if err != nil {
 		return errors.Wrap(err, "failed to serialize new blocks bitmap")
@@ -974,6 +1429,9 @@ func (cdb *CacheDB) getUsageMergeOp(storageID StorageID, namespaceID NamespaceID
 // is append-only (no read-modify-write cycle) and cannot conflict with
 // concurrent transactions.
 func (cdb *CacheDB) AddUsage(storageID StorageID, namespaceID NamespaceID, delta int64) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
 	if delta == 0 {
 		return nil
 	}
@@ -1006,6 +1464,9 @@ func (cdb *CacheDB) MarkBlocksDownloaded(instanceHash InstanceHash, startBlock, 
 // will be re-fetched on the next read.  This is used during auto-repair when
 // corruption is detected.
 func (cdb *CacheDB) ClearBlocks(instanceHash InstanceHash, blocks []uint32) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
 	if len(blocks) == 0 {
 		return nil
 	}
@@ -1058,6 +1519,9 @@ func (cdb *CacheDB) GetDownloadedBlockCount(instanceHash InstanceHash) (uint64, 
 
 // DeleteBlockState removes block state for a file
 func (cdb *CacheDB) DeleteBlockState(instanceHash InstanceHash) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
 	return cdb.db.Update(func(txn *badger.Txn) error {
 		return txn.Delete(StateKey(instanceHash))
 	})
@@ -1096,8 +1560,90 @@ func (cdb *CacheDB) GetInlineData(instanceHash InstanceHash) ([]byte, error) {
 // The caller (StoreInline) is responsible for usage accounting via
 // ChargeUsage; this function does NOT adjust usage counters.
 func (cdb *CacheDB) SetInlineData(instanceHash InstanceHash, encryptedData []byte) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
 	return cdb.db.Update(func(txn *badger.Txn) error {
 		return txn.Set(InlineKey(instanceHash), encryptedData)
+	})
+}
+
+// --- Append intent operations ---
+
+// SetAppendIntent records that a streaming append is in flight for the given
+// object version.  See PrefixAppendIntent for why the record exists.
+func (cdb *CacheDB) SetAppendIntent(instanceHash InstanceHash, intent AppendIntent) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
+	encoded, err := msgpack.Marshal(&intent)
+	if err != nil {
+		return errors.Wrap(err, "failed to encode append intent")
+	}
+	return cdb.db.Update(func(txn *badger.Txn) error {
+		return txn.Set(AppendIntentKey(instanceHash), encoded)
+	})
+}
+
+// DeleteAppendIntent removes an append-in-flight record.
+func (cdb *CacheDB) DeleteAppendIntent(instanceHash InstanceHash) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
+	return cdb.db.Update(func(txn *badger.Txn) error {
+		return txn.Delete(AppendIntentKey(instanceHash))
+	})
+}
+
+// GetAppendIntent returns the append-in-flight record for an object version,
+// or nil when there is none.
+func (cdb *CacheDB) GetAppendIntent(instanceHash InstanceHash) (*AppendIntent, error) {
+	var intent AppendIntent
+	err := cdb.db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get(AppendIntentKey(instanceHash))
+		if err != nil {
+			return err
+		}
+		return item.Value(func(val []byte) error {
+			return msgpack.Unmarshal(val, &intent)
+		})
+	})
+	if err != nil {
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			return nil, nil
+		}
+		return nil, errors.Wrap(err, "failed to read append intent")
+	}
+	return &intent, nil
+}
+
+// ScanAppendIntents calls fn for every append-in-flight record.  Returning an
+// error from fn stops the scan and is returned to the caller.
+func (cdb *CacheDB) ScanAppendIntents(fn func(InstanceHash, AppendIntent) error) error {
+	return cdb.db.View(func(txn *badger.Txn) error {
+		prefix := []byte(PrefixAppendIntent)
+		opts := badger.DefaultIteratorOptions
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			item := it.Item()
+			hash := InstanceHash(string(item.Key())[len(PrefixAppendIntent):])
+			if hash == "" {
+				continue
+			}
+			var intent AppendIntent
+			if err := item.Value(func(val []byte) error {
+				return msgpack.Unmarshal(val, &intent)
+			}); err != nil {
+				log.Warnf("Skipping unreadable append intent for %s: %v", hash, err)
+				continue
+			}
+			if err := fn(hash, intent); err != nil {
+				return err
+			}
+		}
+		return nil
 	})
 }
 
@@ -1107,6 +1653,9 @@ func (cdb *CacheDB) SetInlineData(instanceHash InstanceHash, encryptedData []byt
 // Uses debouncing: only updates if last access was more than debounceTime ago
 // This is optimized to avoid iteration by storing the last access time in metadata
 func (cdb *CacheDB) UpdateLRU(instanceHash InstanceHash, debounceTime time.Duration) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
 	return cdb.db.Update(func(txn *badger.Txn) error {
 		// Get metadata to find prefixID and last access time
 		item, err := txn.Get(MetaKey(instanceHash))
@@ -1320,6 +1869,9 @@ func (cdb *CacheDB) getUsageByPrefix(prefix []byte) (map[StorageUsageKey]int64, 
 //
 // The next AddUsage call will lazily create a fresh MergeOperator.
 func (cdb *CacheDB) SetUsage(storageID StorageID, namespaceID NamespaceID, value int64) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
 	suk := StorageUsageKey{StorageID: storageID, NamespaceID: namespaceID}
 
 	cdb.usageMu.Lock()
@@ -1396,21 +1948,51 @@ func (cdb *CacheDB) ComputeActualUsage() (map[StorageUsageKey]int64, error) {
 // salt is required to recompute the ObjectHash from SourceURL for
 // ETag-table cleanup.
 func deleteObjectInTxn(txn *badger.Txn, salt []byte, instanceHash InstanceHash) (*CacheMetadata, error) {
-	var meta CacheMetadata
-	var hasMetadata bool
+	meta, err := readMetadataInTxn(txn, instanceHash)
+	if err != nil {
+		return nil, err
+	}
+	return deleteObjectWithMetaInTxn(txn, salt, instanceHash, meta)
+}
 
+// readMetadataInTxn decodes an object's metadata record inside an existing
+// transaction.  A missing or undecodable record yields (nil, nil): the object
+// still has keys and files worth reclaiming, and the deletion path is written
+// to proceed without metadata.  Only a genuine read failure is an error.
+func readMetadataInTxn(txn *badger.Txn, instanceHash InstanceHash) (*CacheMetadata, error) {
 	item, err := txn.Get(MetaKey(instanceHash))
-	if err == nil {
-		hasMetadata = true
-		err = item.Value(func(val []byte) error {
-			return msgpack.Unmarshal(val, &meta)
-		})
-		if err != nil {
-			log.Warnf("Failed to unmarshal metadata during object deletion: %v", err)
-			hasMetadata = false
+	if err != nil {
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			return nil, nil
 		}
-	} else if !errors.Is(err, badger.ErrKeyNotFound) {
 		return nil, errors.Wrap(err, "failed to get metadata for deletion")
+	}
+	var meta CacheMetadata
+	if err := item.Value(func(val []byte) error {
+		return msgpack.Unmarshal(val, &meta)
+	}); err != nil {
+		log.Warnf("Failed to unmarshal metadata during object deletion: %v", err)
+		return nil, nil
+	}
+	return &meta, nil
+}
+
+// deleteObjectWithMetaInTxn is deleteObjectInTxn for a caller that has already
+// decoded the object's metadata.
+//
+// Every phase of EvictByLRU but the plain LRU walk reads that record first, to
+// decide whether the object touches the storage directory being freed.  Passing
+// it in spares a second Get and a second msgpack decode of the same key inside
+// the same transaction -- BadgerDB does not memoize reads, so it really is a
+// repeat of both.
+//
+// known may be nil, meaning there is no usable metadata for the object; the
+// keys that do not depend on it are still removed.
+func deleteObjectWithMetaInTxn(txn *badger.Txn, salt []byte, instanceHash InstanceHash, known *CacheMetadata) (*CacheMetadata, error) {
+	var meta CacheMetadata
+	hasMetadata := known != nil
+	if hasMetadata {
+		meta = *known
 	}
 
 	// Delete LRU entry using metadata (before deleting metadata)
@@ -1422,15 +2004,25 @@ func deleteObjectInTxn(txn *badger.Txn, salt []byte, instanceHash InstanceHash) 
 	}
 
 	// Clean up ETag table if this was the latest version.
+	//
 	// ObjectHash is derived from SourceURL + salt rather than stored
-	// redundantly in metadata.
+	// redundantly in metadata.  The record is needed anyway -- for the LRU key
+	// above and for the caller's usage accounting -- so this costs one HMAC
+	// and one read of the e: key, not a metadata lookup of its own.
+	//
+	// The e: entry is deleted only when it names the version being removed;
+	// an older version going away must leave the pointer to the current one
+	// alone.  That comparison has to decode the entry (see decodeETagEntry) --
+	// the raw value carries an 8-byte timestamp prefix, so comparing it to
+	// meta.ETag byte-for-byte matches nothing and would leave a dangling e:
+	// key behind for every object the cache ever evicts.
 	if hasMetadata && meta.SourceURL != "" {
 		objectHash := ComputeObjectHash(salt, meta.SourceURL)
 		etagItem, err := txn.Get(ETagKey(objectHash))
 		if err == nil {
 			var currentETag string
 			err = etagItem.Value(func(val []byte) error {
-				currentETag = string(val)
+				currentETag, _ = decodeETagEntry(val)
 				return nil
 			})
 			if err == nil && currentETag == meta.ETag {
@@ -1461,6 +2053,10 @@ func deleteObjectInTxn(txn *badger.Txn, salt []byte, instanceHash InstanceHash) 
 	// Delete purge-first marker if present (best-effort, ignore not-found)
 	_ = txn.Delete(PurgeFirstKey(instanceHash))
 
+	// Likewise the append-in-flight marker: whatever removed the object also
+	// removed the thing the marker exists to let us reclaim.
+	_ = txn.Delete(AppendIntentKey(instanceHash))
+
 	if hasMetadata {
 		return &meta, nil
 	}
@@ -1473,10 +2069,13 @@ func deleteObjectInTxn(txn *badger.Txn, salt []byte, instanceHash InstanceHash) 
 // counters.  Usage is decremented via AddUsage after the transaction
 // commits so that the write cannot conflict.
 func (cdb *CacheDB) DeleteObject(instanceHash InstanceHash) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
 	var meta *CacheMetadata
 	err := cdb.db.Update(func(txn *badger.Txn) error {
 		var txnErr error
-		meta, txnErr = deleteObjectInTxn(txn, cdb.salt, instanceHash)
+		meta, txnErr = deleteObjectInTxn(txn, cdb.Salt(), instanceHash)
 		return txnErr
 	})
 	if err != nil {
@@ -1507,6 +2106,23 @@ type evictedObject struct {
 	chunkLocations []ChunkLocation // Locations of chunks 1, 2, ...
 }
 
+// evictionSkipBudget bounds how many protected objects the LRU walk (phases 2
+// and 3) will step over before giving up.
+//
+// A skipped object frees nothing, so without a bound a long run of protected
+// objects at the head of the LRU index would turn a bounded eviction into a
+// full index scan.  Reaching this budget means something pathological is
+// happening -- readers do not normally accumulate on the least-recently-used
+// objects -- so the right response is to stop and let the next pass retry,
+// not to keep scanning.
+//
+// The budget deliberately does NOT gate the purge-first drain.  That phase
+// walks the pf: index, which is not the LRU order but an explicit list an
+// operator (or the emergency low-space purge) asked to be removed; its length
+// is bounded by that request, and stopping it because unrelated LRU candidates
+// were pinned would silently ignore the admin evict API.
+const evictionSkipBudget = 1024
+
 // EvictByLRU evicts objects from a storage+namespace combination, draining
 // purge-first items before walking the regular LRU index — all within a
 // single BadgerDB transaction.
@@ -1516,15 +2132,36 @@ type evictedObject struct {
 // either limit means "no limit on that dimension".  The method is allowed
 // to go one object over the byte threshold so that progress is always
 // made even when only large objects remain.
-func (cdb *CacheDB) EvictByLRU(storageID StorageID, namespaceID NamespaceID, maxObjects int, maxBytes int64) ([]evictedObject, error) {
+//
+// skip, when non-nil, is consulted for every candidate; returning true leaves
+// the object in place.  It is how a caller protects objects that must not
+// disappear right now -- see StorageManager.EvictByLRU, which uses it to spare
+// objects under a live reader.  A skipped object is not counted against
+// maxObjects, because skipping frees nothing and counting it would let
+// eviction report a full batch while returning under target.
+//
+// Returns the evicted objects and the number that were skipped.
+func (cdb *CacheDB) EvictByLRU(storageID StorageID, namespaceID NamespaceID, maxObjects int, maxBytes int64, skip func(InstanceHash) bool) ([]evictedObject, int, error) {
+	if err := cdb.checkWritable(); err != nil {
+		return nil, 0, err
+	}
+
 	var evicted []evictedObject
+	// lruSkipped counts skips charged against evictionSkipBudget; pfSkipped
+	// counts purge-first skips, which are reported but never end a pass.
+	var lruSkipped, pfSkipped int
 	usageDeltas := make(map[StorageUsageKey]int64)
+
+	skipBudget := evictionSkipBudget
+	if cdb.skipBudget > 0 {
+		skipBudget = cdb.skipBudget
+	}
 
 	err := cdb.db.Update(func(txn *badger.Txn) error {
 		var freedBytes int64
 
-		// --- helper: returns true when we should stop evicting ---
-		limitReached := func() bool {
+		// --- helper: returns true when the caller's targets are met ---
+		quotaReached := func() bool {
 			if maxObjects > 0 && len(evicted) >= maxObjects {
 				return true
 			}
@@ -1534,9 +2171,29 @@ func (cdb *CacheDB) EvictByLRU(storageID StorageID, namespaceID NamespaceID, max
 			return false
 		}
 
+		// --- helper: returns true when the LRU walk should stop ---
+		limitReached := func() bool {
+			return lruSkipped >= skipBudget || quotaReached()
+		}
+
 		// --- helper: delete one object by hash, record results ---
-		evictOne := func(hash InstanceHash) {
-			meta, err := deleteObjectInTxn(txn, cdb.salt, hash)
+		//
+		// known is the object's metadata when the caller has already read it,
+		// and nil when it has not — in which case the record is read here.
+		evictOne := func(hash InstanceHash, known *CacheMetadata, skipCounter *int) {
+			// Checked before the metadata read: a protected object is not
+			// going anywhere this pass, so there is nothing to learn about it.
+			if skip != nil && skip(hash) {
+				*skipCounter++
+				return
+			}
+			var meta *CacheMetadata
+			var err error
+			if known != nil {
+				meta, err = deleteObjectWithMetaInTxn(txn, cdb.Salt(), hash, known)
+			} else {
+				meta, err = deleteObjectInTxn(txn, cdb.Salt(), hash)
+			}
 			if err != nil {
 				log.Warnf("Failed to delete object %s during eviction: %v", hash, err)
 				return
@@ -1593,7 +2250,9 @@ func (cdb *CacheDB) EvictByLRU(storageID StorageID, namespaceID NamespaceID, max
 			defer it.Close()
 
 			for it.Seek(pfPrefix); it.ValidForPrefix(pfPrefix); it.Next() {
-				if limitReached() {
+				// Only the caller's own targets end this phase; the skip
+				// budget is reserved for the LRU walk below.
+				if quotaReached() {
 					break
 				}
 				keyStr := string(it.Item().Key())
@@ -1602,25 +2261,25 @@ func (cdb *CacheDB) EvictByLRU(storageID StorageID, namespaceID NamespaceID, max
 					continue
 				}
 
-				// Peek at metadata to check storageID.
-				metaItem, err := txn.Get(MetaKey(hash))
+				// Peek at metadata to check storageID.  The same record
+				// decides what has to be deleted, so it is handed to
+				// evictOne rather than read again.
+				meta, err := readMetadataInTxn(txn, hash)
 				if err != nil {
-					// Object already gone — clean up stale marker.
+					return err
+				}
+				if meta == nil {
+					// Nothing this marker can act on -- the object is gone,
+					// or its record does not decode and the consistency
+					// checker owns it.  Either way the marker is stale.
 					_ = txn.Delete(it.Item().KeyCopy(nil))
 					continue
 				}
-				var meta CacheMetadata
-				err = metaItem.Value(func(val []byte) error {
-					return msgpack.Unmarshal(val, &meta)
-				})
-				if err != nil {
-					continue
-				}
-				if !objectUsesDir(&meta, storageID) {
+				if !objectUsesDir(meta, storageID) {
 					continue
 				}
 
-				evictOne(hash)
+				evictOne(hash, meta, &pfSkipped)
 			}
 		}
 
@@ -1639,7 +2298,10 @@ func (cdb *CacheDB) EvictByLRU(storageID StorageID, namespaceID NamespaceID, max
 				if err != nil {
 					continue
 				}
-				evictOne(hash)
+				// This phase has no reason of its own to read the record:
+				// the LRU key already says the object's base chunk is in
+				// this storage+namespace.
+				evictOne(hash, nil, &lruSkipped)
 				if limitReached() {
 					break
 				}
@@ -1677,25 +2339,22 @@ func (cdb *CacheDB) EvictByLRU(storageID StorageID, namespaceID NamespaceID, max
 					continue // already covered by Phase 2
 				}
 
-				// Peek at metadata to check chunk locations.
-				metaItem, err := txn.Get(MetaKey(hash))
+				// Peek at metadata to check chunk locations.  As in phase 1,
+				// the record read here is the one the deletion needs.
+				meta, err := readMetadataInTxn(txn, hash)
 				if err != nil {
-					continue
+					return err
 				}
-				var meta CacheMetadata
-				err = metaItem.Value(func(val []byte) error {
-					return msgpack.Unmarshal(val, &meta)
-				})
-				if err != nil {
+				if meta == nil {
 					continue
 				}
 				if !meta.IsChunked() {
 					continue
 				}
-				if !objectUsesDir(&meta, storageID) {
+				if !objectUsesDir(meta, storageID) {
 					continue
 				}
-				evictOne(hash)
+				evictOne(hash, meta, &lruSkipped)
 			}
 		}
 
@@ -1711,7 +2370,7 @@ func (cdb *CacheDB) EvictByLRU(storageID StorageID, namespaceID NamespaceID, max
 		}
 	}
 
-	return evicted, err
+	return evicted, lruSkipped + pfSkipped, err
 }
 
 // badgerLogger adapts Pelican's logrus to BadgerDB's logger interface
@@ -1809,25 +2468,40 @@ func (cdb *CacheDB) HasMetadata(instanceHash InstanceHash) (bool, error) {
 // Batch allows batching multiple writes for efficiency
 type Batch struct {
 	wb *badger.WriteBatch
+	// cdb is retained so the batch inherits the handle's read-only status;
+	// NewBatch cannot report the refusal itself, having no error to return.
+	cdb *CacheDB
 }
 
-// NewBatch creates a new write batch
+// NewBatch creates a new write batch.
+//
+// A batch taken from a read-only handle refuses at Set, Delete, and Flush
+// rather than here, because there is no error to return from this call.
 func (cdb *CacheDB) NewBatch() *Batch {
-	return &Batch{wb: cdb.db.NewWriteBatch()}
+	return &Batch{wb: cdb.db.NewWriteBatch(), cdb: cdb}
 }
 
 // Set adds a key-value pair to the batch
 func (b *Batch) Set(key, value []byte) error {
+	if err := b.cdb.checkWritable(); err != nil {
+		return err
+	}
 	return b.wb.Set(key, value)
 }
 
 // Delete adds a delete operation to the batch
 func (b *Batch) Delete(key []byte) error {
+	if err := b.cdb.checkWritable(); err != nil {
+		return err
+	}
 	return b.wb.Delete(key)
 }
 
 // Flush commits the batch
 func (b *Batch) Flush() error {
+	if err := b.cdb.checkWritable(); err != nil {
+		return err
+	}
 	return b.wb.Flush()
 }
 
@@ -1840,6 +2514,9 @@ func (b *Batch) Cancel() {
 
 // MarkPurgeFirst marks a file hash for priority eviction
 func (cdb *CacheDB) MarkPurgeFirst(instanceHash InstanceHash) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
 	return cdb.db.Update(func(txn *badger.Txn) error {
 		// Check if metadata exists first
 		_, err := txn.Get(MetaKey(instanceHash))
@@ -1856,6 +2533,9 @@ func (cdb *CacheDB) MarkPurgeFirst(instanceHash InstanceHash) error {
 
 // UnmarkPurgeFirst removes the purge first marker for a file hash
 func (cdb *CacheDB) UnmarkPurgeFirst(instanceHash InstanceHash) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
 	return cdb.db.Update(func(txn *badger.Txn) error {
 		return txn.Delete(PurgeFirstKey(instanceHash))
 	})
@@ -1934,6 +2614,9 @@ func (cdb *CacheDB) FindRecyclableStorageID(mountedDirs map[StorageID]string) (S
 // Objects are deleted in batches to avoid exceeding BadgerDB's
 // transaction size limit.
 func (cdb *CacheDB) PurgeStorageID(storageID StorageID) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
 	const batchSize = 500
 
 	lruPrefix := []byte(fmt.Sprintf("%s%d:", PrefixLRU, storageID))
@@ -1971,7 +2654,7 @@ func (cdb *CacheDB) PurgeStorageID(storageID StorageID) error {
 
 		err = cdb.db.Update(func(txn *badger.Txn) error {
 			for _, hash := range hashes {
-				if _, err := deleteObjectInTxn(txn, cdb.salt, hash); err != nil {
+				if _, err := deleteObjectInTxn(txn, cdb.Salt(), hash); err != nil {
 					log.Warnf("Failed to delete object %s during storage purge: %v", hash, err)
 				}
 			}

--- a/local_cache/encryption.go
+++ b/local_cache/encryption.go
@@ -53,7 +53,7 @@ const (
 //   - dekWrapKey  – wraps/unwraps per-object data encryption keys (DEKs)
 //   - the DB key  – returned by DeriveDBKey for BadgerDB encryption
 //
-// The mu mutex protects only the on-disk serialisation in saveMasterKey
+// The mu mutex protects only the on-disk serialization in saveMasterKey
 // (called by UpdateMasterKeyEncryption); reader methods are lock-free
 // because the fields they touch are immutable after construction.
 type EncryptionManager struct {

--- a/local_cache/eviction.go
+++ b/local_cache/eviction.go
@@ -47,7 +47,7 @@ type EvictionManager struct {
 	storage *StorageManager
 
 	// Per-directory size limits, keyed by storageID.  The map is
-	// read-only after construction and requires no synchronisation.
+	// read-only after construction and requires no synchronization.
 	dirLimits map[StorageID]*dirEvictionLimits
 
 	// Per-directory usage estimates, keyed by storageID.  The map itself
@@ -176,10 +176,23 @@ func (em *EvictionManager) Start(ctx context.Context, egrp *errgroup.Group) {
 	})
 }
 
+// appendReclaimInterval is how often the janitor looks for objects left
+// behind by interrupted streaming appends.  Orphans are rare and cost only
+// capacity, so a slow cadence is enough; on a cache (which has no AppendWriter
+// consumer at all) the scan is a single prefix seek that finds nothing.
+const appendReclaimInterval = 5 * time.Minute
+
 // evictionLoop runs the main eviction loop
 func (em *EvictionManager) evictionLoop(ctx context.Context) error {
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
+
+	// Reclaim once at startup: any append record present before this process
+	// registered a writer is by definition from a run that did not finish.
+	em.reclaimAbandonedAppends()
+
+	reclaimTicker := time.NewTicker(appendReclaimInterval)
+	defer reclaimTicker.Stop()
 
 	for {
 		select {
@@ -187,9 +200,28 @@ func (em *EvictionManager) evictionLoop(ctx context.Context) error {
 			return nil
 		case <-ticker.C:
 			em.checkAndEvict()
+		case <-reclaimTicker.C:
+			em.reclaimAbandonedAppends()
 		case <-em.evictChan:
 			em.checkAndEvict()
 		}
+	}
+}
+
+// reclaimAbandonedAppends releases capacity held by streaming appends whose
+// writer never finished.  See StorageManager.ReclaimAbandonedAppends.
+func (em *EvictionManager) reclaimAbandonedAppends() {
+	if em.storage == nil {
+		return
+	}
+	n, err := em.storage.ReclaimAbandonedAppends(appendReclaimGrace)
+	if err != nil {
+		log.Warnf("Failed to reclaim abandoned streaming appends: %v", err)
+		return
+	}
+	if n > 0 {
+		log.Infof("Reclaimed %d object(s) left behind by interrupted streaming appends", n)
+		em.recalculateDirUsage()
 	}
 }
 
@@ -328,6 +360,7 @@ func (em *EvictionManager) checkAndEvict() {
 	startTime := time.Now()
 	var totalEvictedBytes atomic.Uint64
 	var totalEvictedObjects atomic.Int64
+	var totalSkipped atomic.Int64
 	var totalConflicts atomic.Int64
 
 	var wg sync.WaitGroup
@@ -367,7 +400,7 @@ func (em *EvictionManager) checkAndEvict() {
 					"needToFree":  utils.HumanBytes(overhead),
 				}).Debug("Evicting from namespace")
 
-				bytes, count, conflicts, err := em.evictFromNamespace(rl, targetKey.StorageID, targetKey.NamespaceID, 0, overhead)
+				bytes, count, skipped, conflicts, err := em.evictFromNamespace(rl, targetKey.StorageID, targetKey.NamespaceID, 0, overhead)
 				totalConflicts.Add(int64(conflicts))
 				if err != nil {
 					rl.WithFields(log.Fields{
@@ -379,6 +412,22 @@ func (em *EvictionManager) checkAndEvict() {
 
 				totalEvictedBytes.Add(bytes)
 				totalEvictedObjects.Add(int64(count))
+				totalSkipped.Add(int64(skipped))
+
+				// A pass that freed nothing will pick the same namespace and
+				// do the same thing again, so looping only burns CPU until the
+				// timeout below.  Stop and let the next cycle try, by which
+				// time whatever blocked this one has usually cleared.
+				if count == 0 {
+					if skipped > 0 {
+						rl.WithFields(log.Fields{
+							"storageID":   targetKey.StorageID,
+							"namespaceID": targetKey.NamespaceID,
+							"skipped":     skipped,
+						}).Debug("Eviction made no progress; every candidate was in use")
+					}
+					break
+				}
 
 				// Safety: don't run for too long
 				if time.Since(startTime) > 30*time.Second {
@@ -391,11 +440,13 @@ func (em *EvictionManager) checkAndEvict() {
 	wg.Wait()
 
 	evicted := totalEvictedObjects.Load()
+	skipped := totalSkipped.Load()
 	conflicts := totalConflicts.Load()
-	if evicted > 0 || conflicts > 0 {
+	if evicted > 0 || conflicts > 0 || skipped > 0 {
 		rl.WithFields(log.Fields{
 			"freedBytes":     utils.HumanBytes(totalEvictedBytes.Load()),
 			"evictedObjects": evicted,
+			"skippedInUse":   skipped,
 			"conflicts":      conflicts,
 			"elapsed":        time.Since(startTime).String(),
 		}).Info("Eviction pass complete")
@@ -434,9 +485,12 @@ func (em *EvictionManager) findGreediestNamespaceInDir(storageID StorageID) (Sto
 //
 // On a BadgerDB transaction conflict the method retries with progressively
 // smaller batch sizes (50, then 10 objects) before giving up.
-// Returns total bytes freed, number of objects evicted, number of conflicts, and any
-// non-retryable error.
-func (em *EvictionManager) evictFromNamespace(rl *log.Entry, storageID StorageID, namespaceID NamespaceID, maxObjects int, maxBytes int64) (totalFreed uint64, totalCount int, conflicts int, err error) {
+// Objects under a live reader are spared and reported separately; see
+// StorageManager.EvictByLRU.
+//
+// Returns total bytes freed, number of objects evicted, number spared, number
+// of conflicts, and any non-retryable error.
+func (em *EvictionManager) evictFromNamespace(rl *log.Entry, storageID StorageID, namespaceID NamespaceID, maxObjects int, maxBytes int64) (totalFreed uint64, totalCount int, skipped int, conflicts int, err error) {
 	// batchCaps defines the decreasing batch sizes used on successive
 	// conflict retries.  The first attempt uses the caller's original
 	// limits; subsequent retries cap maxObjects to reduce the transaction
@@ -451,7 +505,7 @@ func (em *EvictionManager) evictFromNamespace(rl *log.Entry, storageID StorageID
 
 		var evicted []evictedObject
 		var freed uint64
-		evicted, freed, err = em.storage.EvictByLRU(storageID, namespaceID, effMaxObjects, maxBytes)
+		evicted, freed, skipped, err = em.storage.EvictByLRU(storageID, namespaceID, effMaxObjects, maxBytes)
 
 		if err != nil && errors.Is(err, badger.ErrConflict) {
 			conflicts++
@@ -474,7 +528,7 @@ func (em *EvictionManager) evictFromNamespace(rl *log.Entry, storageID StorageID
 			continue
 		}
 		if err != nil {
-			return 0, 0, conflicts, err
+			return 0, 0, skipped, conflicts, err
 		}
 
 		em.noteEvicted(evicted)
@@ -487,11 +541,11 @@ func (em *EvictionManager) evictFromNamespace(rl *log.Entry, storageID StorageID
 			}).Debug("Evicted object")
 		}
 
-		return freed, len(evicted), conflicts, nil
+		return freed, len(evicted), skipped, conflicts, nil
 	}
 
 	// All retries exhausted
-	return 0, 0, conflicts, err
+	return 0, 0, skipped, conflicts, err
 }
 
 // noteEvicted adjusts the per-directory in-memory atomic counters after
@@ -499,7 +553,7 @@ func (em *EvictionManager) evictFromNamespace(rl *log.Entry, storageID StorageID
 // counters were already decremented inside the transaction; this keeps
 // the in-memory estimates in sync.
 func (em *EvictionManager) noteEvicted(evicted []evictedObject) {
-	// Accumulate per-storageID totals to minimise atomic operations.
+	// Accumulate per-storageID totals to minimize atomic operations.
 	perDir := make(map[StorageID]int64, 2)
 	for _, obj := range evicted {
 		// For chunked objects, attribute bytes to each directory
@@ -780,7 +834,7 @@ func (em *EvictionManager) forcePurgeToTargets(label string, targets map[Storage
 				}
 
 				overhead := dirUsage - dirTarget
-				bytes, count, _, err := em.evictFromNamespace(rl, targetKey.StorageID, targetKey.NamespaceID, 0, overhead)
+				bytes, count, skipped, _, err := em.evictFromNamespace(rl, targetKey.StorageID, targetKey.NamespaceID, 0, overhead)
 				if err != nil {
 					rl.WithFields(log.Fields{
 						"storageID":   targetKey.StorageID,
@@ -791,6 +845,18 @@ func (em *EvictionManager) forcePurgeToTargets(label string, targets map[Storage
 
 				evictedBytes.Add(bytes)
 				evictedObjects.Add(int64(count))
+
+				// As in checkAndEvict: no progress means the next iteration
+				// would repeat this one exactly.
+				if count == 0 {
+					if skipped > 0 {
+						rl.WithFields(log.Fields{
+							"storageID": sid,
+							"skipped":   skipped,
+						}).Warnf("%s could not reach its target; every candidate was in use", label)
+					}
+					break
+				}
 
 				if time.Since(startTime) > 60*time.Second {
 					rl.Warn(label + " timeout - will continue next cycle")

--- a/local_cache/introspect.go
+++ b/local_cache/introspect.go
@@ -194,9 +194,17 @@ type IntrospectAPIOpen struct {
 
 // NewIntrospectAPI creates a new introspection API by opening the cache
 // database and storage manager in read-only mode.
+//
+// The cache must be stopped: OpenCacheDBReadOnly takes BadgerDB's directory
+// lock, and it explains as much when it cannot.  `pelican cache introspect`
+// only reaches this path when the cache is not running, routing to the live
+// service otherwise.
 func NewIntrospectAPI(baseDir string) (*IntrospectAPIOpen, error) {
-	// Open database (read-only is not directly supported by NewCacheDB,
-	// but we only perform read operations)
+	// Read-only here is enforced by CacheDB rather than by BadgerDB -- see
+	// OpenCacheDBReadOnly for why -- so every mutating method on the handle
+	// below refuses.  That covers the storage manager too: StorageManager
+	// reaches the database only through CacheDB's typed methods, never through
+	// the raw badger handle.
 	db, err := OpenCacheDBReadOnly(baseDir)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open cache database")

--- a/local_cache/introspect_open_test.go
+++ b/local_cache/introspect_open_test.go
@@ -1,0 +1,500 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package local_cache
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RoaringBitmap/roaring"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+// These tests cover OpenCacheDBReadOnly and NewIntrospectAPI -- the offline
+// half of `pelican cache introspect`, which had no coverage at all and was
+// broken on every platform as a result.
+//
+// The fault they exist to catch: OpenCacheDBReadOnly used to hand BadgerDB
+// opts.ReadOnly = true together with the database encryption key.  BadgerDB
+// v4.9.1 cannot read an *encrypted* database that has flushed at least one SST
+// file through a read-only handle; Table.fetchIndex reaches y.Check(err), which
+// is log.Fatalf, and the process exits printing only "err: invalid argument".
+// No error is returned and no defer runs.  Every database NewCacheDB creates is
+// encrypted and every cache that has served an object has an SST, so this fired
+// on every real cache.  On Windows the same call failed differently and
+// harmlessly: "Read-only mode is not supported on Windows".
+//
+// Because the pre-fix failure mode is a process abort rather than an error, a
+// test that trips it takes the whole package's test binary down with it -- that
+// is exactly what running TestOpenCacheDBReadOnlyPopulatedCache against the old
+// code does, and how the fault was confirmed.
+
+// populatedCacheDir builds a cache directory holding real records, closes it,
+// and returns the base directory.  The database is left in the state a stopped
+// cache leaves behind: encrypted (as every cache database is), with at least
+// one SST file on disk, which together are what BadgerDB's read-only mode could
+// not survive.
+func populatedCacheDir(t *testing.T) (baseDir string, instHash InstanceHash, sourceURL string) {
+	t.Helper()
+	InitIssuerKeyForTests(t)
+
+	baseDir = t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	egrp, egrpCtx := errgroup.WithContext(ctx)
+
+	db, err := NewCacheDB(egrpCtx, baseDir)
+	require.NoError(t, err)
+	require.NoError(t, db.EnsureStoreMode(StoreModeCache))
+
+	// A storage manager is what persists the disk mappings that
+	// NewStorageManagerReadOnly (and therefore NewIntrospectAPI) needs.
+	sm, err := NewStorageManager(db, []string{baseDir}, InlineThreshold, egrp)
+	require.NoError(t, err)
+
+	sourceURL = "pelican://example.com/ns/introspect-me.dat"
+	objHash := db.ObjectHash(sourceURL)
+	instHash = db.InstanceHash("etag-ro", objHash)
+
+	payload := []byte("cache introspection payload")
+	meta := &CacheMetadata{
+		ETag:          "etag-ro",
+		SourceURL:     sourceURL,
+		ContentLength: int64(len(payload)),
+		ContentType:   "application/octet-stream",
+		StorageID:     StorageIDInline,
+		NamespaceID:   NamespaceID(1),
+		LastModified:  time.Now().Add(-time.Hour),
+		Completed:     time.Now(),
+	}
+	require.NoError(t, sm.StoreInline(egrpCtx, instHash, meta, payload))
+	require.NoError(t, db.SetLatestETag(objHash, "etag-ro", time.Now()))
+	require.NoError(t, db.SetNamespaceMapping("/ns", NamespaceID(1)))
+
+	sm.Close()
+
+	// Flush the memtable so the database really has an SST on disk.  Without
+	// this a small test database can live entirely in the value log and the
+	// old read-only open would have survived, which would have made this test
+	// pass against the very code it exists to catch.
+	require.NoError(t, db.DB().Flatten(2))
+	require.NoError(t, db.Close())
+
+	cancel()
+	require.NoError(t, egrp.Wait())
+
+	ssts, err := filepath.Glob(filepath.Join(baseDir, dbSubDir, "*.sst"))
+	require.NoError(t, err)
+	require.NotEmpty(t, ssts, "test setup did not produce an SST file, so it does not "+
+		"reproduce the condition that broke read-only opens")
+
+	return baseDir, instHash, sourceURL
+}
+
+// TestOpenCacheDBReadOnlyPopulatedCache is the regression test for the abort:
+// opening a populated, encrypted cache database for introspection must succeed
+// and must be able to read records back.
+//
+// Against the pre-fix implementation this does not fail -- it kills the test
+// binary via log.Fatalf, so the whole package reports FAIL with no test result
+// line at all.  There is no way to assert on that from inside the process,
+// which is precisely why the fix stops using BadgerDB's read-only mode.
+func TestOpenCacheDBReadOnlyPopulatedCache(t *testing.T) {
+	baseDir, instHash, sourceURL := populatedCacheDir(t)
+
+	db, err := OpenCacheDBReadOnly(baseDir)
+	require.NoError(t, err, "an ordinary populated cache database must open for introspection")
+	defer db.Close()
+
+	assert.True(t, db.ReadOnly(), "an introspection handle must report itself read-only")
+
+	// The salt was read, not regenerated: a fresh salt would hash the same URL
+	// to a different instance and silently find nothing.
+	require.NotEmpty(t, db.Salt())
+	assert.Equal(t, instHash, db.InstanceHash("etag-ro", db.ObjectHash(sourceURL)),
+		"the introspection handle recomputed a different instance hash, so it did not "+
+			"load the salt the records were written under")
+
+	meta, err := db.GetMetadata(instHash)
+	require.NoError(t, err)
+	require.NotNil(t, meta, "introspection could not read back a record that is in the cache")
+	assert.Equal(t, sourceURL, meta.SourceURL)
+	assert.Equal(t, "etag-ro", meta.ETag)
+
+	etag, found, err := db.GetLatestETag(db.ObjectHash(sourceURL))
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "etag-ro", etag)
+
+	// And a scan works, which is what every list/stats subcommand runs.
+	var scanned int
+	require.NoError(t, db.ScanMetadata(func(InstanceHash, *CacheMetadata) error {
+		scanned++
+		return nil
+	}))
+	assert.Equal(t, 1, scanned)
+}
+
+// TestOpenCacheDBReadOnlyLeavesNoStamp is the property that must not regress
+// when the underlying BadgerDB handle stops being read-only: inspecting a
+// database must leave its header exactly as it was found.
+//
+// The database is stripped of both header markers first, so that a stamping
+// implementation has somewhere visible to write.  An unmarked database is the
+// realistic case too -- it is what every cache deployed before versioning and
+// before the store-mode marker looks like, and adopting one is a decision that
+// belongs to a writable open, not to a tool that is only looking.
+func TestOpenCacheDBReadOnlyLeavesNoStamp(t *testing.T) {
+	baseDir, instHash, _ := populatedCacheDir(t)
+
+	writable, err := NewCacheDB(t.Context(), baseDir)
+	require.NoError(t, err)
+	deleteRawKey(t, writable, KeySchemaVersion)
+	deleteRawKey(t, writable, KeyStoreMode)
+	require.NoError(t, writable.Close())
+
+	db, err := OpenCacheDBReadOnly(baseDir)
+	require.NoError(t, err, "an unmarked database must still be inspectable")
+	// Read something, so the open is not the only thing under test.
+	meta, err := db.GetMetadata(instHash)
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+	require.NoError(t, db.Close())
+
+	// Look behind CacheDB's back: neither marker may have appeared.
+	raw := openRawBadger(t, baseDir)
+	requireRawKeyAbsent(t, raw, KeySchemaVersion)
+	requireRawKeyAbsent(t, raw, KeyStoreMode)
+}
+
+// TestOpenCacheDBReadOnlyRefusesWrites checks the guard that replaced
+// BadgerDB's enforcement.  The underlying handle is writable now, so every
+// mutating entry point has to refuse on its own; one that forgets would let an
+// introspection command quietly modify the cache it was asked to report on.
+func TestOpenCacheDBReadOnlyRefusesWrites(t *testing.T) {
+	baseDir, instHash, sourceURL := populatedCacheDir(t)
+
+	db, err := OpenCacheDBReadOnly(baseDir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	objHash := db.ObjectHash(sourceURL)
+
+	mutations := map[string]func() error{
+		"SetMetadata":    func() error { return db.SetMetadata(instHash, &CacheMetadata{ETag: "nope"}) },
+		"MergeMetadata":  func() error { return db.MergeMetadata(instHash, &CacheMetadata{ETag: "nope"}) },
+		"DeleteMetadata": func() error { return db.DeleteMetadata(instHash) },
+		"SetLatestETag":  func() error { return db.SetLatestETag(objHash, "nope", time.Now()) },
+		"DeleteLatestETag": func() error {
+			return db.DeleteLatestETag(objHash)
+		},
+		"SetNamespaceMapping": func() error { return db.SetNamespaceMapping("/other", NamespaceID(2)) },
+		"SaveDiskMapping":     func() error { return db.SaveDiskMapping(DiskMapping{ID: 9, Directory: baseDir}) },
+		"SetBlockState":       func() error { return db.SetBlockState(instHash, roaring.New()) },
+		"MergeBlockStateWithUsage": func() error {
+			return db.MergeBlockStateWithUsage(instHash, roaring.New(), StorageIDInline, 1, -1)
+		},
+		"MarkBlocksDownloaded": func() error {
+			return db.MarkBlocksDownloaded(instHash, 0, 0, StorageIDInline, 1, -1)
+		},
+		"ClearBlocks":      func() error { return db.ClearBlocks(instHash, []uint32{0}) },
+		"DeleteBlockState": func() error { return db.DeleteBlockState(instHash) },
+		"SetInlineData":    func() error { return db.SetInlineData(instHash, []byte("nope")) },
+		"SetAppendIntent":  func() error { return db.SetAppendIntent(instHash, AppendIntent{}) },
+		"DeleteAppendIntent": func() error {
+			return db.DeleteAppendIntent(instHash)
+		},
+		"UpdateLRU":      func() error { return db.UpdateLRU(instHash, 0) },
+		"AddUsage":       func() error { return db.AddUsage(StorageIDInline, 1, 128) },
+		"ChargeUsage":    func() error { return db.ChargeUsage(StorageIDInline, 1, 128) },
+		"SetUsage":       func() error { return db.SetUsage(StorageIDInline, 1, 128) },
+		"DeleteObject":   func() error { return db.DeleteObject(instHash) },
+		"MarkPurgeFirst": func() error { return db.MarkPurgeFirst(instHash) },
+		"UnmarkPurgeFirst": func() error {
+			return db.UnmarkPurgeFirst(instHash)
+		},
+		"PurgeStorageID": func() error { return db.PurgeStorageID(StorageIDInline) },
+		"EnsureStoreMode": func() error {
+			return db.EnsureStoreMode(StoreModeCache)
+		},
+		"ReloadSalt": func() error { return db.ReloadSalt() },
+		"EvictByLRU": func() error {
+			_, _, err := db.EvictByLRU(StorageIDInline, 1, 1, 0, nil)
+			return err
+		},
+		// A batch holds an open BadgerDB write transaction, so each of these
+		// cancels the one it took -- the refusal is the assertion, not a reason
+		// to leak the transaction until Close.
+		"Batch.Set": func() error {
+			b := db.NewBatch()
+			defer b.Cancel()
+			return b.Set([]byte("x"), []byte("y"))
+		},
+		"Batch.Delete": func() error {
+			b := db.NewBatch()
+			defer b.Cancel()
+			return b.Delete([]byte("x"))
+		},
+		"Batch.Flush": func() error {
+			b := db.NewBatch()
+			defer b.Cancel()
+			return b.Flush()
+		},
+	}
+
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			err := mutate()
+			require.Error(t, err, "%s modified a read-only cache database", name)
+			assert.ErrorIs(t, err, ErrReadOnly)
+			assert.Contains(t, err.Error(), baseDir, "the refusal should name the database")
+		})
+	}
+
+	// The list above is written by hand, so it goes stale the moment someone
+	// adds a mutating method -- and a missing guard is invisible until an
+	// introspection command writes to a cache.  Check the list covers every
+	// exported method whose name says it writes.
+	t.Run("CoversEveryMutatingMethod", func(t *testing.T) {
+		writePrefixes := []string{"Set", "Save", "Delete", "Merge", "Mark", "Unmark",
+			"Purge", "Add", "Charge", "Evict", "Ensure", "Reload", "Clear", "Update"}
+		cacheDBType := reflect.TypeOf(db)
+		var found int
+		for i := 0; i < cacheDBType.NumMethod(); i++ {
+			name := cacheDBType.Method(i).Name
+			mutating := false
+			for _, prefix := range writePrefixes {
+				if strings.HasPrefix(name, prefix) {
+					mutating = true
+					break
+				}
+			}
+			if !mutating {
+				continue
+			}
+			found++
+			assert.Contains(t, mutations, name,
+				"CacheDB.%s looks like it writes but is not exercised against a read-only "+
+					"handle; add it to the table above (and give it a checkWritable guard)", name)
+		}
+		// Guard against the loop above quietly matching nothing -- a vacuous
+		// pass here would leave the whole table unpoliced.
+		require.Greater(t, found, 20, "the reflective scan found almost no mutating methods, "+
+			"so it is not actually checking anything")
+	})
+
+	// Nothing above reached the database.
+	meta, err := db.GetMetadata(instHash)
+	require.NoError(t, err)
+	require.NotNil(t, meta, "a refused mutation removed the record anyway")
+	assert.Equal(t, "etag-ro", meta.ETag)
+}
+
+// TestStartGCIsInertOnReadOnlyHandle covers the one mutating path that is not
+// an entry point returning an error: value-log GC rewrites the log, so a
+// read-only handle must not start it.  The errgroup draining on its own is the
+// observable consequence -- a started worker only exits on ctx.Done.
+func TestStartGCIsInertOnReadOnlyHandle(t *testing.T) {
+	baseDir, _, _ := populatedCacheDir(t)
+
+	db, err := OpenCacheDBReadOnly(baseDir)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// A context that is never cancelled: if StartGC launched its worker, the
+	// worker would still be sitting on its ticker and Wait would block.
+	egrp, egrpCtx := errgroup.WithContext(context.Background())
+	db.StartGC(egrpCtx, egrp)
+	require.NoError(t, egrp.Wait(), "a read-only handle started a garbage collector")
+}
+
+// TestOpenCacheDBReadOnlyReportsARunningCache pins the failure mode the fix
+// introduces.  An ordinary BadgerDB open takes the directory lock, so offline
+// introspection now fails while a cache is running instead of opening beside
+// it.  That is the right trade -- the lock also stops a cache from starting up
+// underneath an introspection in progress -- but only if the operator is told
+// what happened, since BadgerDB's own wording ("Another process is using this
+// Badger database") does not name the cache or the way out.
+func TestOpenCacheDBReadOnlyReportsARunningCache(t *testing.T) {
+	baseDir, _, _ := populatedCacheDir(t)
+
+	// Stand in for the running cache: hold the database open read-write.
+	running, err := NewCacheDB(t.Context(), baseDir)
+	require.NoError(t, err)
+	defer running.Close()
+
+	db, err := OpenCacheDBReadOnly(baseDir)
+	if db != nil {
+		db.Close()
+	}
+	require.Error(t, err, "introspection opened a database another process holds")
+	msg := err.Error()
+	assert.Contains(t, msg, baseDir, "the error should name the cache directory")
+	assert.Contains(t, msg, "cache server is running",
+		"the error should say why the database is locked")
+	assert.Contains(t, msg, "--offline",
+		"the error should point the operator at the live path")
+}
+
+// TestOpenCacheDBReadOnlyMissingDatabase checks that pointing the CLI at a
+// directory with no cache in it says so, rather than creating an empty
+// database there and reporting a cache with nothing in it.
+func TestOpenCacheDBReadOnlyMissingDatabase(t *testing.T) {
+	InitIssuerKeyForTests(t)
+	baseDir := t.TempDir()
+
+	db, err := OpenCacheDBReadOnly(baseDir)
+	if db != nil {
+		db.Close()
+	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no cache database at")
+
+	// And nothing was created on the way to failing: a mistyped path must not
+	// leave a stray empty cache database behind.
+	_, statErr := os.Stat(filepath.Join(baseDir, dbSubDir))
+	assert.True(t, os.IsNotExist(statErr),
+		"a failed introspection open created a database directory")
+}
+
+// TestOpenCacheDBReadOnlyRefusesNewerSchema keeps the version check on the
+// introspection path.  It runs on every platform now, unlike the handle-level
+// check in TestSchemaVersionReadOnlyPath, because the open no longer depends on
+// BadgerDB's read-only mode.
+func TestOpenCacheDBReadOnlyRefusesNewerSchema(t *testing.T) {
+	baseDir, _, _ := populatedCacheDir(t)
+
+	writable, err := NewCacheDB(t.Context(), baseDir)
+	require.NoError(t, err)
+	setRawKey(t, writable, KeySchemaVersion, []byte("999"))
+	require.NoError(t, writable.Close())
+
+	db, err := OpenCacheDBReadOnly(baseDir)
+	if db != nil {
+		db.Close()
+	}
+	require.Error(t, err, "introspection read a database written under a newer layout")
+	assert.Contains(t, err.Error(), "schema version 999")
+}
+
+// TestNewIntrospectAPIOffline is the end-to-end check: the constructor the
+// `--offline` subcommands call, against a real populated cache directory.
+//
+// This is the assembly that was broken -- NewIntrospectAPI is the only
+// non-test caller of OpenCacheDBReadOnly -- so it is worth exercising past the
+// open, through the queries the CLI actually issues.
+func TestNewIntrospectAPIOffline(t *testing.T) {
+	baseDir, instHash, sourceURL := populatedCacheDir(t)
+
+	api, err := NewIntrospectAPI(baseDir)
+	require.NoError(t, err, "offline introspection could not open a stopped cache")
+	defer api.Close()
+
+	// `introspect list`
+	objects, err := api.ListAllObjects(0, "")
+	require.NoError(t, err)
+	require.Len(t, objects, 1)
+	assert.Equal(t, sourceURL, objects[0].SourceURL)
+	assert.Equal(t, string(instHash), objects[0].InstanceHash)
+	assert.True(t, objects[0].IsInline)
+
+	// `introspect etags`
+	instances, err := api.ListObjectInstances(sourceURL)
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+	assert.Equal(t, "etag-ro", instances[0].ETag)
+	assert.True(t, instances[0].IsLatest, "the stored ETag pointer was not read back")
+
+	// `introspect metadata`
+	details, err := api.GetObjectDetails(string(instHash))
+	require.NoError(t, err)
+	require.NotNil(t, details)
+	assert.Equal(t, sourceURL, details.SourceURL)
+	assert.Equal(t, "application/octet-stream", details.ContentType)
+
+	// `introspect stats` -- reaches the storage manager's disk mappings and the
+	// namespace table as well as the metadata scan.
+	stats, err := api.GetCacheStats()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), stats.TotalMetadataEntries)
+	assert.Greater(t, stats.TotalInlineBytes, int64(0))
+	assert.Equal(t, "/ns", stats.NamespaceNames[1])
+	assert.Contains(t, stats.DirPaths, uint8(1), "the storage directory mapping was not loaded")
+
+	// `introspect disk-usage` walks the storage directories the read-only
+	// manager discovered.
+	usage, err := api.GetDiskUsage()
+	require.NoError(t, err)
+	assert.NotEmpty(t, usage.Directories)
+}
+
+// TestNewIntrospectAPILeavesNoStamp is TestOpenCacheDBReadOnlyLeavesNoStamp one
+// level up, through the constructor the CLI uses: NewIntrospectAPI also builds
+// a storage manager, and that must not write a header marker either.
+func TestNewIntrospectAPILeavesNoStamp(t *testing.T) {
+	baseDir, _, _ := populatedCacheDir(t)
+
+	writable, err := NewCacheDB(t.Context(), baseDir)
+	require.NoError(t, err)
+	deleteRawKey(t, writable, KeySchemaVersion)
+	deleteRawKey(t, writable, KeyStoreMode)
+	require.NoError(t, writable.Close())
+
+	api, err := NewIntrospectAPI(baseDir)
+	require.NoError(t, err)
+	_, err = api.ListAllObjects(0, "")
+	require.NoError(t, err)
+	require.NoError(t, api.Close())
+
+	raw := openRawBadger(t, baseDir)
+	requireRawKeyAbsent(t, raw, KeySchemaVersion)
+	requireRawKeyAbsent(t, raw, KeyStoreMode)
+}
+
+// TestIntrospectAPIClosesCleanly guards the shutdown path the CLI depends on:
+// every subcommand defers Close, and a Close that hangs leaves the command
+// wedged after it has already printed its answer.
+func TestIntrospectAPIClosesCleanly(t *testing.T) {
+	baseDir, _, _ := populatedCacheDir(t)
+
+	api, err := NewIntrospectAPI(baseDir)
+	require.NoError(t, err)
+
+	closed := make(chan error, 1)
+	go func() { closed <- api.Close() }()
+
+	select {
+	case err := <-closed:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("IntrospectAPIOpen.Close did not return")
+	}
+
+	// The directory lock is released with it, so the cache can start again.
+	reopened, err := NewCacheDB(t.Context(), baseDir)
+	require.NoError(t, err, "introspection did not release the database")
+	require.NoError(t, reopened.Close())
+}

--- a/local_cache/persistent_cache.go
+++ b/local_cache/persistent_cache.go
@@ -91,7 +91,7 @@ func isEvictedError(err error) bool {
 
 // clientChecksumsToCache converts transfer-client checksums into the local
 // cache schema.  Server-supplied checksums are marked OriginVerified; client-
-// computed checksums are not.  Unrecognised algorithms are silently dropped.
+// computed checksums are not.  Unrecognized algorithms are silently dropped.
 func clientChecksumsToCache(result *client.TransferResults) []Checksum {
 	if result == nil {
 		return nil
@@ -135,7 +135,7 @@ func clientChecksumsToCache(result *client.TransferResults) []Checksum {
 // statChecksumsToCache converts the checksum map returned by client.DoStat
 // (HTTP digest name -> hex-encoded value) into the local cache schema.  These
 // come from the origin's HEAD response, so they are marked OriginVerified.
-// Unrecognised algorithms and malformed hex are silently skipped.
+// Unrecognized algorithms and malformed hex are silently skipped.
 func statChecksumsToCache(checksums map[string]string) []Checksum {
 	if len(checksums) == 0 {
 		return nil
@@ -533,6 +533,13 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 		return nil, errors.Wrap(err, "failed to initialize cache database")
 	}
 
+	// Claim the database for the cache so that a pstore origin pointed at the
+	// same directory refuses to open it rather than corrupting it.
+	if err := db.EnsureStoreMode(StoreModeCache); err != nil {
+		db.Close()
+		return nil, err
+	}
+
 	// Initialize storage manager — assigns storageIDs internally via UUIDs.
 	storage, err := NewStorageManager(db, dirPaths, cfg.InlineStorageMaxBytes, egrp)
 	if err != nil {
@@ -611,7 +618,7 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 	// integrity scan verifies each object's on-disk data a single time and
 	// then skips it, for deployments whose storage already guarantees at-rest
 	// integrity (e.g. ZFS).  Any value other than "once" keeps the default
-	// behaviour of re-verifying every object on each scan cycle.
+	// behavior of re-verifying every object on each scan cycle.
 	scanOnce := strings.EqualFold(param.Cache_DataScanMode.GetString(), "once")
 	consistency := NewConsistencyChecker(db, storage, ConsistencyConfig{
 		MinAgeForCleanup: -1, // Use default grace period
@@ -1198,8 +1205,24 @@ func (pc *PersistentCache) newFetchingRangeReader(
 		dlClientDone = res.dl.RegisterClient()
 	}
 
+	// Pin the version for the life of the reader.  This is the cache's real
+	// serving path -- every HTTP GET arrives here via GetSeekableReader or
+	// GetRange -- so without a pin here the protection that
+	// StorageManager.EvictByLRU offers would only ever apply to the prestage
+	// worker's NewObjectReader.  Eviction removes an object's metadata, data
+	// key, and block state, none of which the open file descriptor replaces,
+	// so a reader that loses its object mid-stream fails the transfer.
+	//
+	// The release is chained into onClose below, and onClose is the same
+	// callback that already deregisters the download client and closes the
+	// lazy fetcher: if a caller leaks a RangeReader it leaks those too, so
+	// this adds no new lifetime requirement.  The pin's release function is
+	// idempotent, so a double Close is harmless.
+	unpin := pc.storage.PinObject(res.instanceHash)
+
 	rr, err := NewRangeReader(pc.storage, res.instanceHash, startByte, endByte, fetchCallback)
 	if err != nil {
+		unpin()
 		if dlClientDone != nil {
 			dlClientDone()
 		}
@@ -1232,6 +1255,7 @@ func (pc *PersistentCache) newFetchingRangeReader(
 		// reused-fetcher path (fetcher != nil), lazyBf is always nil
 		// so closeLazy is a no-op.
 		closeLazy()
+		unpin()
 	}
 
 	return rr, nil
@@ -1241,7 +1265,7 @@ func (pc *PersistentCache) newFetchingRangeReader(
 // This is designed for use with http.ServeContent which handles Range requests internally.
 //
 // When rangeOnly is true and the object is not yet cached, GetSeekableReader
-// uses a lightweight HEAD request to initialise on-disk storage instead of
+// uses a lightweight HEAD request to initialize on-disk storage instead of
 // starting a full sequential download.  This allows BlockFetcherV2 to fetch
 // only the blocks the caller actually reads, avoiding a potentially expensive
 // full transfer.  Callers should set rangeOnly when they know the request is
@@ -1632,7 +1656,7 @@ func (pc *PersistentCache) doInitObjectFromStat(
 		return nil, errors.Wrap(err, "stat failed for range-on-miss")
 	}
 	// The stat already knows; refusing here costs nothing and keeps a
-	// collection from being initialised as an object on disk.
+	// collection from being initialized as an object on disk.
 	if statInfo.IsCollection {
 		return nil, errors.Errorf("%s is a collection and cannot be cached as an object", pelicanURL)
 	}

--- a/local_cache/persistent_cache_api.go
+++ b/local_cache/persistent_cache_api.go
@@ -21,7 +21,6 @@ package local_cache
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"encoding/xml"
@@ -74,35 +73,7 @@ func requestLogger(r *http.Request, objectPath string) *log.Entry {
 // Digest header value.  If there are no checksums, it returns an empty string.
 // Example output: "md5=rL0Y20zC+Fzt72VPzMSk2A==, crc32c=abcd1234"
 func formatDigestHeader(checksums []Checksum) string {
-	if len(checksums) == 0 {
-		return ""
-	}
-
-	var parts []string
-	for _, ck := range checksums {
-		var algName, encodedVal string
-		switch ck.Type {
-		case ChecksumMD5:
-			algName = "md5"
-			encodedVal = base64.StdEncoding.EncodeToString(ck.Value)
-		case ChecksumSHA1:
-			algName = "sha"
-			encodedVal = base64.StdEncoding.EncodeToString(ck.Value)
-		case ChecksumSHA256:
-			algName = "sha-256"
-			encodedVal = base64.StdEncoding.EncodeToString(ck.Value)
-		case ChecksumCRC32:
-			algName = "crc32"
-			encodedVal = hex.EncodeToString(ck.Value)
-		case ChecksumCRC32C:
-			algName = "crc32c"
-			encodedVal = hex.EncodeToString(ck.Value)
-		default:
-			continue // skip unknown checksum types
-		}
-		parts = append(parts, algName+"="+encodedVal)
-	}
-	return strings.Join(parts, ", ")
+	return FormatDigestHeader(checksums)
 }
 
 // isConnectionError checks if an error is a connection error (reset, refused, etc.)
@@ -890,7 +861,7 @@ func writeXMLText(buf *bytes.Buffer, s string) {
 // ETag such as `</D:getetag><D:resourcetype><D:collection/></D:resourcetype>`
 // would otherwise forge properties in a document the cache serves to its own
 // clients under its own name — a forged resourcetype in particular now steers
-// client behaviour, since clients use it to decide whether a path is a
+// client behavior, since clients use it to decide whether a path is a
 // collection.
 func buildPropfindMultistatus(objectPath string, meta *CacheMetadata) []byte {
 	// Format Last-Modified per RFC 7232 §2.2 / HTTP-date.
@@ -1055,7 +1026,7 @@ func (pc *PersistentCache) proxyPropfind(w http.ResponseWriter, r *http.Request,
 // injection, and connection-error classification.  Switching to the transfer
 // engine would eliminate ~80 lines of manual HTTP plumbing here and in
 // proxyPropfind.  The trade-off is that proxyWrite needs cache-specific
-// behaviour the engine doesn't (yet) support: scope-aware authorization
+// behavior the engine doesn't (yet) support: scope-aware authorization
 // (storage.create vs storage.modify), streaming the origin's full response
 // back to the caller (status + headers + body), and post-success cache
 // invalidation with ETag-aware instance management.  Until the engine

--- a/local_cache/persistent_cache_api_test.go
+++ b/local_cache/persistent_cache_api_test.go
@@ -100,7 +100,7 @@ func TestHandleErrorTooManyRequests(t *testing.T) {
 	t.Run("WrappedSentinel", func(t *testing.T) {
 		// The transfer engine wraps the sentinel with a per-origin
 		// context ("pending queue is full", "origin \"…\" pending
-		// queue is full", …); handleError must still recognise it
+		// queue is full", …); handleError must still recognize it
 		// via errors.Is.
 		rec := httptest.NewRecorder()
 		wrapped := errors.Wrapf(client.ErrTooManyRequests, "origin %q pending queue is full", "originA")

--- a/local_cache/persistent_cache_test.go
+++ b/local_cache/persistent_cache_test.go
@@ -2239,7 +2239,7 @@ func TestPurgeStorageID(t *testing.T) {
 		require.NoError(t, storage.WriteBlocks(instanceHash, 0, data))
 
 		// Set ETag mapping
-		objectHash := ComputeObjectHash(db.salt, meta.SourceURL)
+		objectHash := ComputeObjectHash(db.Salt(), meta.SourceURL)
 		require.NoError(t, db.SetLatestETag(objectHash, meta.ETag, time.Now()))
 		// Usage is tracked automatically by WriteBlocks → MergeBlockStateWithUsage.
 		// Record LRU access

--- a/local_cache/pin.go
+++ b/local_cache/pin.go
@@ -1,0 +1,121 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Reader pinning.
+//
+// Deleting an object that a reader is part-way through breaks that reader.
+// refCountedFile keeps the file descriptor alive across the unlink, but the
+// reader also needs the object's metadata, its data key, and its block state,
+// and Delete removes all three.
+//
+// This lives beside the reader constructors and Delete rather than in a
+// consumer, because those are the operations that have to agree: a pin taken
+// anywhere else could always be taken a moment too late.  Every reader is
+// pinned automatically -- NewObjectReader does it directly, and the cache's
+// HTTP serving path does it in newFetchingRangeReader, which is where both
+// GetRange and GetSeekableReader build their RangeReader -- so a consumer only
+// has to decide whether its delete path respects pins.
+//
+// Both consumers respect it.  The pstore origin does through
+// DeleteIfUnpinned, because it deletes exactly the version most likely to be
+// under a reader: the one just superseded by an overwrite.  The cache's LRU
+// eviction does through the skip predicate it hands to CacheDB.EvictByLRU;
+// its victim is the least recently used object, so the overlap is small, but
+// LRU timestamps are debounced by ten minutes and a slow reader on a large
+// object can drift toward the head of the index.
+//
+// The cost is one mutex acquisition and one map operation per reader open and
+// close, and one more per eviction candidate.  A reader open already involves
+// a metadata read, a key unwrap, and a file open, and evicting an object
+// costs a Badger delete plus an unlink per chunk, so the check is not
+// measurable against either.  The map is sized by live readers, not by the
+// number of objects in the store.
+
+package local_cache
+
+import "sync"
+
+// pinSet counts live readers per object version.
+type pinSet struct {
+	mu    sync.Mutex
+	count map[InstanceHash]int
+}
+
+func newPinSet() *pinSet {
+	return &pinSet{count: make(map[InstanceHash]int)}
+}
+
+// pin registers a reader and returns the function that releases it.  The
+// returned function is idempotent, so a handle may safely Close twice.
+func (p *pinSet) pin(h InstanceHash) func() {
+	p.mu.Lock()
+	p.count[h]++
+	p.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			if n := p.count[h]; n <= 1 {
+				delete(p.count, h)
+			} else {
+				p.count[h] = n - 1
+			}
+		})
+	}
+}
+
+// isPinned reports whether any reader currently holds the version.
+func (p *pinSet) isPinned(h InstanceHash) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	_, ok := p.count[h]
+	return ok
+}
+
+// PinObject holds an object version open, preventing DeleteIfUnpinned from
+// reclaiming it, and returns the release function.
+//
+// NewObjectReader does this automatically; call it directly only when holding
+// a version across something other than an ObjectReader.
+func (sm *StorageManager) PinObject(instanceHash InstanceHash) func() {
+	return sm.pins.pin(instanceHash)
+}
+
+// IsObjectPinned reports whether a reader currently holds the version.
+func (sm *StorageManager) IsObjectPinned(instanceHash InstanceHash) bool {
+	return sm.pins.isPinned(instanceHash)
+}
+
+// DeleteIfUnpinned deletes an object version unless a reader holds it.
+//
+// Returns false without deleting when the version is pinned, leaving the
+// caller to retry later.  Use this wherever the object being deleted might
+// plausibly be one somebody is reading.
+func (sm *StorageManager) DeleteIfUnpinned(instanceHash InstanceHash) (bool, error) {
+	if sm.pins.isPinned(instanceHash) {
+		return false, nil
+	}
+	// A reader could still arrive between the check and the delete.  That
+	// race is unavoidable without serializing every read against every
+	// delete, and it is the same race the file descriptor already survives:
+	// the reader either opens before the delete and holds a live handle, or
+	// after it and gets a clean not-found.
+	return true, sm.Delete(instanceHash)
+}

--- a/local_cache/pin_test.go
+++ b/local_cache/pin_test.go
@@ -1,0 +1,359 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package local_cache
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+const pinTestNamespaceID = NamespaceID(1)
+
+// newPinTestStorage builds a single-directory store for the pinning tests.
+func newPinTestStorage(t *testing.T) (*StorageManager, *CacheDB, context.Context) {
+	t.Helper()
+	InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	db, err := NewCacheDB(ctx, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	egrp, _ := errgroup.WithContext(ctx)
+	storage, err := NewStorageManager(db, []string{t.TempDir()}, 0, egrp)
+	require.NoError(t, err)
+	t.Cleanup(storage.Close)
+
+	return storage, db, ctx
+}
+
+// writePinTestObject stores one complete object and returns its instance hash.
+// Hashes are ordered by idx, so the order these objects appear under a Badger
+// prefix scan is the order they were created in.
+func writePinTestObject(t *testing.T, sm *StorageManager, db *CacheDB, ctx context.Context, idx int) InstanceHash {
+	t.Helper()
+	return writePinTestObjectAs(t, sm, db, ctx, InstanceHash(fmt.Sprintf("%064x", idx+0x200)), idx, "")
+}
+
+// writePinTestObjectAs stores one complete object under a caller-chosen
+// instance hash, optionally recording a source URL and the ETag entry that
+// points at it -- the shape a real cached object has.
+func writePinTestObjectAs(t *testing.T, sm *StorageManager, db *CacheDB, ctx context.Context, instanceHash InstanceHash, idx int, sourceURL string) InstanceHash {
+	t.Helper()
+
+	const objectSize = 4096
+	chunkSizeCode := BytesToChunkSizeCode(uint64(2 * 1024 * 1024))
+
+	meta, err := sm.InitLazyChunkedStorage(ctx, instanceHash, objectSize, chunkSizeCode)
+	require.NoError(t, err)
+
+	// Record the namespace before allocating, so the usage counters are
+	// charged and refunded under the same key.  Setting it afterwards charges
+	// namespace 0 and credits pinTestNamespaceID, which leaves the directory
+	// permanently "full" and would make any usage assertion meaningless.
+	meta.NamespaceID = pinTestNamespaceID
+	meta.SourceURL = sourceURL
+	require.NoError(t, sm.SetMetadata(instanceHash, meta))
+
+	for ci := 0; ci < CalculateChunkCount(objectSize, chunkSizeCode); ci++ {
+		meta, err = sm.AllocateChunk(ctx, instanceHash, meta, ci)
+		require.NoError(t, err)
+	}
+
+	data := make([]byte, objectSize)
+	for j := range data {
+		data[j] = byte((idx + j) % 256)
+	}
+	require.NoError(t, sm.WriteBlocks(instanceHash, 0, data))
+
+	meta.Completed = time.Now()
+	require.NoError(t, sm.SetMetadata(instanceHash, meta))
+
+	// Without an LRU entry the object is invisible to eviction, and the tests
+	// below would pass for the wrong reason.
+	require.NoError(t, db.UpdateLRU(instanceHash, 0))
+
+	return instanceHash
+}
+
+func TestPinSetRefCounting(t *testing.T) {
+	p := newPinSet()
+	h := InstanceHash("abc")
+
+	assert.False(t, p.isPinned(h))
+
+	first := p.pin(h)
+	second := p.pin(h)
+	assert.True(t, p.isPinned(h))
+
+	first()
+	assert.True(t, p.isPinned(h), "the second reader still holds it")
+
+	// A handle may be closed twice; that must not drop the other reader.
+	first()
+	assert.True(t, p.isPinned(h), "a repeated release must be a no-op")
+
+	second()
+	assert.False(t, p.isPinned(h))
+}
+
+// TestEvictByLRUSparesPinnedObjects verifies that eviction steps over an
+// object with a live reader and takes the others instead.
+func TestEvictByLRUSparesPinnedObjects(t *testing.T) {
+	sm, db, ctx := newPinTestStorage(t)
+
+	kept := writePinTestObject(t, sm, db, ctx, 0)
+	for i := 1; i < 4; i++ {
+		writePinTestObject(t, sm, db, ctx, i)
+	}
+
+	release := sm.PinObject(kept)
+
+	// No object limit and a byte target large enough to take everything, so
+	// the pin is the only thing that can save an object.
+	evicted, _, skipped, err := sm.EvictByLRU(StorageIDFirstDisk, pinTestNamespaceID, 0, 1<<30)
+	require.NoError(t, err)
+	assert.Equal(t, 1, skipped, "the pinned object should have been stepped over")
+	assert.Len(t, evicted, 3, "every unpinned object should still go")
+	for _, obj := range evicted {
+		assert.NotEqual(t, kept, obj.instanceHash)
+	}
+
+	present, err := sm.HasObject(kept)
+	require.NoError(t, err)
+	assert.True(t, present, "a pinned object must survive eviction")
+
+	// Once the reader finishes, the object is an ordinary candidate again.
+	release()
+	evicted, _, skipped, err = sm.EvictByLRU(StorageIDFirstDisk, pinTestNamespaceID, 0, 1<<30)
+	require.NoError(t, err)
+	assert.Zero(t, skipped)
+	require.Len(t, evicted, 1)
+	assert.Equal(t, kept, evicted[0].instanceHash)
+}
+
+// TestEvictByLRUMakesNoProgressWhenAllPinned verifies that a pass where every
+// candidate is in use returns empty-handed rather than scanning indefinitely,
+// and that a skip is not charged against maxObjects.
+func TestEvictByLRUMakesNoProgressWhenAllPinned(t *testing.T) {
+	sm, db, ctx := newPinTestStorage(t)
+
+	var releases []func()
+	for i := 0; i < 4; i++ {
+		releases = append(releases, sm.PinObject(writePinTestObject(t, sm, db, ctx, i)))
+	}
+
+	evicted, freed, skipped, err := sm.EvictByLRU(StorageIDFirstDisk, pinTestNamespaceID, 2, 0)
+	require.NoError(t, err)
+	assert.Empty(t, evicted)
+	assert.Zero(t, freed)
+	assert.Equal(t, 4, skipped,
+		"a skip must not count against maxObjects, so all four are examined")
+
+	for _, release := range releases {
+		release()
+	}
+	evicted, _, _, err = sm.EvictByLRU(StorageIDFirstDisk, pinTestNamespaceID, 2, 0)
+	require.NoError(t, err)
+	assert.Len(t, evicted, 2, "maxObjects still bounds a pass that makes progress")
+}
+
+// TestDeleteIfUnpinnedRespectsReaders covers the pstore origin's delete path.
+func TestDeleteIfUnpinnedRespectsReaders(t *testing.T) {
+	sm, db, ctx := newPinTestStorage(t)
+	h := writePinTestObject(t, sm, db, ctx, 0)
+
+	release := sm.PinObject(h)
+	deleted, err := sm.DeleteIfUnpinned(h)
+	require.NoError(t, err)
+	assert.False(t, deleted, "a pinned version must not be deleted")
+
+	present, err := sm.HasObject(h)
+	require.NoError(t, err)
+	assert.True(t, present)
+
+	release()
+	deleted, err = sm.DeleteIfUnpinned(h)
+	require.NoError(t, err)
+	assert.True(t, deleted)
+
+	present, err = sm.HasObject(h)
+	require.NoError(t, err)
+	assert.False(t, present)
+}
+
+// TestObjectReaderPinsAutomatically verifies the guarantee the mechanism rests
+// on: opening a reader is enough to be protected, with no extra call.
+func TestObjectReaderPinsAutomatically(t *testing.T) {
+	sm, db, ctx := newPinTestStorage(t)
+	h := writePinTestObject(t, sm, db, ctx, 0)
+
+	reader, err := sm.NewObjectReader(h)
+	require.NoError(t, err)
+	assert.True(t, sm.IsObjectPinned(h), "opening a reader must pin the object")
+
+	_, _, skipped, err := sm.EvictByLRU(StorageIDFirstDisk, pinTestNamespaceID, 0, 1<<30)
+	require.NoError(t, err)
+	assert.Equal(t, 1, skipped)
+
+	require.NoError(t, reader.Close())
+	assert.False(t, sm.IsObjectPinned(h), "closing a reader must release the pin")
+}
+
+// TestEvictionClearsLatestETagPointer covers the ETag-table cleanup in
+// deleteObjectInTxn.
+//
+// The e: entry names the current version of an object.  Evicting that version
+// must take the entry with it -- an e: key is never itself evicted, so one left
+// behind for an object whose data is gone is a key the database keeps forever.
+// Evicting a superseded version must leave it alone, since it still points at
+// something that is there.
+//
+// The comparison that decides between those two cases has to decode the stored
+// entry: the value is [8-byte timestamp][etag] (see encodeETagEntry), so a raw
+// byte comparison against meta.ETag matches nothing and quietly turns the whole
+// cleanup into a no-op.
+func TestEvictionClearsLatestETagPointer(t *testing.T) {
+	sm, db, ctx := newPinTestStorage(t)
+
+	const sourceURL = "pelican://example.org/ns/Mixed/Case/Data.txt"
+	const oldETag = "\"v1\""
+	const currentETag = "\"v2\""
+
+	objectHash := db.ObjectHash(sourceURL)
+	oldInstance := ComputeInstanceHash(db.Salt(), oldETag, objectHash)
+	currentInstance := ComputeInstanceHash(db.Salt(), currentETag, objectHash)
+
+	writePinTestObjectAs(t, sm, db, ctx, oldInstance, 0, sourceURL)
+	writePinTestObjectAs(t, sm, db, ctx, currentInstance, 1, sourceURL)
+
+	// The object's ETag record has to match what a real download writes, or
+	// the metadata the deletion path compares against is not the one it sees.
+	require.NoError(t, db.SetLatestETag(objectHash, currentETag, time.Now()))
+	meta, err := sm.GetMetadata(oldInstance)
+	require.NoError(t, err)
+	meta.ETag = oldETag
+	require.NoError(t, sm.SetMetadata(oldInstance, meta))
+	meta, err = sm.GetMetadata(currentInstance)
+	require.NoError(t, err)
+	meta.ETag = currentETag
+	require.NoError(t, sm.SetMetadata(currentInstance, meta))
+
+	// Evicting the superseded version leaves the pointer to the current one.
+	require.NoError(t, db.DeleteObject(oldInstance))
+	etag, found, err := db.GetLatestETag(objectHash)
+	require.NoError(t, err)
+	assert.True(t, found, "an older version going away must not drop the pointer")
+	assert.Equal(t, currentETag, etag)
+
+	// Evicting the current version takes it.
+	evicted, _, skipped, err := sm.EvictByLRU(StorageIDFirstDisk, pinTestNamespaceID, 0, 1<<30)
+	require.NoError(t, err)
+	assert.Zero(t, skipped)
+	got := make(map[InstanceHash]bool, len(evicted))
+	for _, obj := range evicted {
+		got[obj.instanceHash] = true
+	}
+	require.True(t, got[currentInstance], "the current version must be an eviction candidate")
+
+	_, found, err = db.GetLatestETag(objectHash)
+	require.NoError(t, err)
+	assert.False(t, found, "evicting the current version must remove its ETag entry")
+
+	assert.Zero(t, totalDirUsage(t, db, StorageIDFirstDisk),
+		"the evicted objects' capacity must be returned")
+}
+
+// TestPurgeFirstDrainIgnoresSkipBudget covers the interaction between reader
+// pinning and the admin evict API.
+//
+// The skip budget exists to stop a long run of protected objects at the head of
+// the LRU index from turning a bounded eviction into a full index scan.  It has
+// no business ending the purge-first drain: those objects are on an explicit
+// list an operator (or the emergency low-space purge) asked to be removed, and
+// abandoning the list because some of its entries happen to be under a reader
+// silently ignores the request.
+func TestPurgeFirstDrainIgnoresSkipBudget(t *testing.T) {
+	sm, db, ctx := newPinTestStorage(t)
+
+	// Lower the budget so the exhaustion path is reachable without building a
+	// thousand objects.
+	db.skipBudget = 2
+
+	const total = 6
+	const pinnedCount = 4
+	hashes := make([]InstanceHash, total)
+	for i := range hashes {
+		hashes[i] = writePinTestObject(t, sm, db, ctx, i)
+		require.NoError(t, db.MarkPurgeFirst(hashes[i]))
+	}
+
+	// Pin the objects that sort first, so a drain that stops at the budget
+	// never reaches the two that could actually be freed.
+	for i := 0; i < pinnedCount; i++ {
+		release := sm.PinObject(hashes[i])
+		t.Cleanup(release)
+	}
+
+	evicted, freed, skipped, err := sm.EvictByLRU(StorageIDFirstDisk, pinTestNamespaceID, 0, 1<<30)
+	require.NoError(t, err)
+
+	got := make(map[InstanceHash]bool, len(evicted))
+	for _, obj := range evicted {
+		got[obj.instanceHash] = true
+	}
+	for i := pinnedCount; i < total; i++ {
+		assert.True(t, got[hashes[i]],
+			"purge-first object %d must be drained even though %d protected entries preceded it",
+			i, pinnedCount)
+	}
+	for i := 0; i < pinnedCount; i++ {
+		assert.False(t, got[hashes[i]], "a pinned object is still spared")
+	}
+	assert.Positive(t, freed)
+	assert.GreaterOrEqual(t, skipped, pinnedCount,
+		"every protected purge-first entry is still reported as skipped")
+}
+
+// TestEvictByLRUStopsLRUWalkAtSkipBudget is the other half of the split: the
+// budget must still bound the LRU walk, which is the runaway-scan case it was
+// added for.
+func TestEvictByLRUStopsLRUWalkAtSkipBudget(t *testing.T) {
+	sm, db, ctx := newPinTestStorage(t)
+	db.skipBudget = 2
+
+	for i := 0; i < 5; i++ {
+		release := sm.PinObject(writePinTestObject(t, sm, db, ctx, i))
+		t.Cleanup(release)
+	}
+
+	evicted, _, skipped, err := sm.EvictByLRU(StorageIDFirstDisk, pinTestNamespaceID, 0, 1<<30)
+	require.NoError(t, err)
+	assert.Empty(t, evicted)
+	assert.Equal(t, 2, skipped,
+		"the LRU walk must give up once the skip budget is spent rather than scan the whole index")
+}

--- a/local_cache/schema.go
+++ b/local_cache/schema.go
@@ -23,10 +23,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"net"
 	"net/url"
 	"path"
 	"strings"
 	"time"
+
+	"golang.org/x/net/idna"
 
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/utils"
@@ -62,10 +65,85 @@ const (
 	PrefixETag = "e:"
 	// PrefixNamespace stores namespace prefix -> ID mappings: n:<prefix> -> uint32
 	PrefixNamespace = "n:"
+	// PrefixAppendIntent records that an AppendWriter is part-way through
+	// building an object: aw:<instance_hash> -> msgpack(AppendIntent).
+	//
+	// A streaming append charges capacity for every chunk it allocates but has
+	// no LRU entry until it finishes, so an interrupted one would otherwise be
+	// invisible to both eviction and the consistency checker -- it has metadata
+	// *and* files, so neither half of RunMetadataScan fires.  This marker is
+	// the reclamation handle: NewAppendWriter writes it, Finalize and Abort
+	// remove it, and anything left over belongs to a writer that did not
+	// survive.  See StorageManager.ReclaimAbandonedAppends.
+	PrefixAppendIntent = "aw:"
+	// The keys below describe the database as a whole rather than any one
+	// object.  They are single, underscore-prefixed keys, they are written at
+	// open before any consumer touches a record, and none of them is ever
+	// evicted; the prefixes above never collide with them.
+
 	// KeySalt is the single DB key that stores the random salt used when
 	// hashing object/instance names.  The salt prevents an attacker with
 	// DB access from correlating hashes with known URLs.
 	KeySalt = "_salt"
+
+	// KeyStoreMode records whether this database belongs to a cache or to a
+	// pstore-backed origin.  The two share this key space, so opening one as
+	// the other would silently corrupt it; both check this marker on open.
+	KeyStoreMode = "_mode"
+
+	// KeySchemaVersion records the layout of the records in this database:
+	// which keys exist, how their values are encoded, and how the hashes that
+	// name them are derived.  The value is the decimal ASCII form of a
+	// SchemaVersion, so a dump of the database reads plainly.
+	//
+	// KeyStoreMode says *who* owns the database; this says *what layout* the
+	// owner wrote.  See CurrentSchemaVersion and CacheDB.ensureSchemaVersion.
+	KeySchemaVersion = "_schema"
+)
+
+// SchemaVersion identifies one revision of the on-disk layout of a block store
+// database (both the cache and the pstore origin backend share it, since they
+// share the key space).
+type SchemaVersion uint32
+
+const (
+	// CurrentSchemaVersion is the layout this binary reads and writes.
+	//
+	// Bump it whenever a change makes records written by an older binary
+	// unreadable — or, worse, silently misread — by a newer one: a new or
+	// renamed key prefix, a different value encoding, or a change to how
+	// object/instance hashes are derived — normalizeURL, which decides which
+	// spellings of a URL name one object, is exactly that sort of key
+	// derivation, and a change there has no other way to announce itself.
+	// Purely additive changes that older binaries can ignore do not need a
+	// bump.
+	//
+	// Whoever bumps it is responsible for teaching migrateSchema how to bring
+	// a database written under every still-supported older version forward.
+	CurrentSchemaVersion SchemaVersion = 1
+)
+
+// Prefixes reserved by the pstore origin backend (see docs/pstore-design.md).
+// A pstore shares this key space but never opens a cache database and vice
+// versa (enforced via KeyStoreMode), so the prefixes cannot collide at
+// runtime.  They are declared here so that future cache features do not claim
+// them.
+const (
+	// PrefixDirent stores pstore directory entries, keyed by parent path and
+	// name: pd:<parent path>\x00<name>
+	PrefixDirent = "pd:"
+	// PrefixGarbage stores pstore instances and subtrees awaiting reclamation
+	PrefixGarbage = "pg:"
+)
+
+// StoreMode identifies which subsystem owns a database.
+type StoreMode string
+
+const (
+	// StoreModeCache marks a database owned by the local cache.
+	StoreModeCache StoreMode = "cache"
+	// StoreModePStore marks a database owned by a pstore origin backend.
+	StoreModePStore StoreMode = "pstore"
 )
 
 // StorageID identifies a storage location.  0 means inline (data in BadgerDB),
@@ -128,7 +206,16 @@ type StorageDirConfig struct {
 //
 // Returns nil (not an error) when the key is unset or empty.
 func ParseStorageDirsConfig() ([]StorageDirConfig, error) {
-	raw := param.LocalCache_StorageDirs.GetRaw()
+	return ParseStorageDirsValue(param.LocalCache_StorageDirs.GetRaw(), param.LocalCache_StorageDirs.GetName())
+}
+
+// ParseStorageDirsValue parses an already-fetched StorageDirs setting.  It
+// exists so another subsystem configuring the same block store -- the pstore
+// origin backend, via Origin.PStoreStorageDirs -- accepts exactly the same two
+// formats without duplicating the parsing.
+//
+// name identifies the setting in error messages.
+func ParseStorageDirsValue(raw any, name string) ([]StorageDirConfig, error) {
 	if raw == nil {
 		return nil, nil
 	}
@@ -144,12 +231,12 @@ func ParseStorageDirsConfig() ([]StorageDirConfig, error) {
 			case string:
 				// Plain string path (backward-compat format)
 				if e == "" {
-					return nil, fmt.Errorf("LocalCache.StorageDirs[%d]: empty path", i)
+					return nil, fmt.Errorf("%s[%d]: empty path", name, i)
 				}
 				configs = append(configs, StorageDirConfig{Path: e})
 			case map[string]interface{}:
 				// Structured entry
-				cfg, err := parseStorageDirEntry(i, e)
+				cfg, err := parseStorageDirEntry(name, i, e)
 				if err != nil {
 					return nil, err
 				}
@@ -160,13 +247,13 @@ func ParseStorageDirsConfig() ([]StorageDirConfig, error) {
 				for k, val := range e {
 					converted[fmt.Sprint(k)] = val
 				}
-				cfg, err := parseStorageDirEntry(i, converted)
+				cfg, err := parseStorageDirEntry(name, i, converted)
 				if err != nil {
 					return nil, err
 				}
 				configs = append(configs, cfg)
 			default:
-				return nil, fmt.Errorf("LocalCache.StorageDirs[%d]: unsupported type %T", i, elem)
+				return nil, fmt.Errorf("%s[%d]: unsupported type %T", name, i, elem)
 			}
 		}
 		return configs, nil
@@ -178,18 +265,18 @@ func ParseStorageDirsConfig() ([]StorageDirConfig, error) {
 		configs := make([]StorageDirConfig, len(v))
 		for i, p := range v {
 			if p == "" {
-				return nil, fmt.Errorf("LocalCache.StorageDirs[%d]: empty path", i)
+				return nil, fmt.Errorf("%s[%d]: empty path", name, i)
 			}
 			configs[i] = StorageDirConfig{Path: p}
 		}
 		return configs, nil
 	default:
-		return nil, fmt.Errorf("LocalCache.StorageDirs: unsupported type %T; expected list of paths or objects", raw)
+		return nil, fmt.Errorf("%s: unsupported type %T; expected list of paths or objects", name, raw)
 	}
 }
 
 // parseStorageDirEntry converts a map entry into a StorageDirConfig.
-func parseStorageDirEntry(idx int, m map[string]interface{}) (StorageDirConfig, error) {
+func parseStorageDirEntry(name string, idx int, m map[string]interface{}) (StorageDirConfig, error) {
 	var cfg StorageDirConfig
 
 	// Path (required)
@@ -203,7 +290,7 @@ func parseStorageDirEntry(idx int, m map[string]interface{}) (StorageDirConfig, 
 		}
 	}
 	if cfg.Path == "" {
-		return cfg, fmt.Errorf("LocalCache.StorageDirs[%d]: missing or empty Path", idx)
+		return cfg, fmt.Errorf("%s[%d]: missing or empty Path", name, idx)
 	}
 
 	// MaxSize (optional, string like "500GB" or number of bytes)
@@ -218,7 +305,7 @@ func parseStorageDirEntry(idx int, m map[string]interface{}) (StorageDirConfig, 
 			if s != "" && s != "0" {
 				n, err := utils.ParseBytes(s)
 				if err != nil {
-					return cfg, fmt.Errorf("LocalCache.StorageDirs[%d].MaxSize: %w", idx, err)
+					return cfg, fmt.Errorf("%s[%d].MaxSize: %w", name, idx, err)
 				}
 				cfg.MaxSize = n
 			}
@@ -574,7 +661,7 @@ func (m *CacheMetadata) ResponseCacheControl() string {
 	// If the origin specified Cache-Control, build the response header.
 	if cc := m.GetCacheControlHeader(); cc != "" {
 		// When the origin sets max-age, also advertise s-maxage with the
-		// same value so that downstream shared caches honour the
+		// same value so that downstream shared caches honor the
 		// directive (RFC 7234 §5.2.2.9).  Skip if s-maxage is already
 		// present or the response should not be stored.
 		if m.CCMaxAge > 0 && m.CCFlags&ccNoStore == 0 {
@@ -667,7 +754,15 @@ func ComputeInstanceHash(salt []byte, etag string, objectHash ObjectHash) Instan
 	return InstanceHash(hex.EncodeToString(h.Sum(nil)))
 }
 
-// normalizeURL normalizes a pelican URL for consistent hashing
+// normalizeURL normalizes a pelican URL for consistent hashing.
+//
+// Only the scheme and host are folded.  Those are case-insensitive per
+// RFC 3986 §6.2.2.1, so folding them makes equivalent URLs hash alike.  The
+// path is left exactly as written: object paths are case-sensitive on every
+// backend Pelican serves (POSIX, S3, HTTPS), so /ns/Data.txt and /ns/data.txt
+// are different objects, and folding them together would give them one cache
+// entry from which whichever was fetched last is served for both — a
+// collision nothing on the read path detects.  See docs/pstore-design.md §12.
 func normalizeURL(pelicanURL string) string {
 	// Parse the URL
 	u, err := url.Parse(pelicanURL)
@@ -677,8 +772,57 @@ func normalizeURL(pelicanURL string) string {
 	}
 
 	// Rebuild with normalized components
-	normalized := u.Scheme + "://" + u.Host + path.Clean(u.Path)
-	return strings.ToLower(normalized)
+	return strings.ToLower(u.Scheme) + "://" + normalizeHost(u.Host) + path.Clean(u.Path)
+}
+
+// normalizeHost folds the authority of a URL so that every spelling of one
+// host hashes to one object.
+//
+// strings.ToLower is the right fold only for an ASCII host.  A domain name may
+// be internationalized, and an IDN has two equally valid spellings — the
+// Unicode form and its punycode A-label — that no amount of lowercasing brings
+// together, with a case fold of its own that IDNA defines and ASCII does not.
+// idna.Lookup.ToASCII collapses all of them, so BÜCHER.example,
+// bücher.example, and xn--bcher-kva.example name the same cached object.
+//
+// Three things are deliberately kept away from IDNA:
+//
+//   - The port is not part of the domain name.  It is split off, left exactly
+//     as written, and reattached.
+//   - IP literals are not domain names.  A bracketed IPv6 literal in
+//     particular is rejected outright by IDNA (both the brackets and the
+//     colons are disallowed runes), so literals are only lowercased.
+//   - A host IDNA rejects for any other reason — an underscore, say — is
+//     lowercased instead.  This function has no error to return and must
+//     answer deterministically; a name that cannot be an IDN has no
+//     alternative spelling to collapse in the first place.
+func normalizeHost(host string) string {
+	if host == "" {
+		return ""
+	}
+
+	hostname, port := host, ""
+	if h, p, err := net.SplitHostPort(host); err == nil {
+		hostname, port = h, ":"+p
+		// SplitHostPort strips the brackets from an IPv6 literal; the host
+		// is not spellable without them, so put them back.
+		if strings.ContainsRune(hostname, ':') {
+			return "[" + strings.ToLower(hostname) + "]" + port
+		}
+	} else if strings.HasPrefix(hostname, "[") {
+		// A bracketed IPv6 literal carrying no port.
+		return strings.ToLower(hostname)
+	}
+
+	if net.ParseIP(hostname) != nil {
+		return strings.ToLower(hostname) + port
+	}
+
+	ascii, err := idna.Lookup.ToASCII(hostname)
+	if err != nil {
+		return strings.ToLower(hostname) + port
+	}
+	return ascii + port
 }
 
 // GetInstanceStoragePath returns the 2-level directory path for storing a file
@@ -714,6 +858,19 @@ func ETagKey(objectHash ObjectHash) []byte {
 // NamespaceKey returns the BadgerDB key for a namespace prefix mapping
 func NamespaceKey(prefix string) []byte {
 	return []byte(PrefixNamespace + prefix)
+}
+
+// AppendIntentKey returns the BadgerDB key for an in-flight streaming append.
+func AppendIntentKey(instanceHash InstanceHash) []byte {
+	return []byte(PrefixAppendIntent + string(instanceHash))
+}
+
+// AppendIntent is the record written while an AppendWriter is building an
+// object.  StartedAt lets a reclamation pass leave very recent appends alone
+// even when it cannot consult the in-process registry of live writers.
+type AppendIntent struct {
+	StartedAt   time.Time   `msgpack:"started_at"`
+	NamespaceID NamespaceID `msgpack:"namespace_id"`
 }
 
 // LRUKey returns the BadgerDB key for LRU tracking

--- a/local_cache/schema_test.go
+++ b/local_cache/schema_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func TestParseStorageDirsConfig(t *testing.T) {
+	defer viper.Reset()
+
 	t.Run("Unset", func(t *testing.T) {
 		viper.Reset()
 		dirs, err := ParseStorageDirsConfig()
@@ -170,4 +172,132 @@ func TestParseStorageDirsConfig(t *testing.T) {
 		assert.Equal(t, "/yaml-style", dirs[0].Path)
 		assert.Equal(t, uint64(100*1024*1024*1024), dirs[0].MaxSize)
 	})
+}
+
+// TestNormalizeURLPreservesPathCase holds down a cache correctness property:
+// two objects whose paths differ only in case must not collapse onto one cache
+// entry.
+//
+// Object paths are case-sensitive on every backend Pelican serves, and the
+// read path (resolveObject) does not compare SourceURL before serving, so a
+// collision here silently returns whichever object was fetched most recently
+// for a request for the other one.
+func TestNormalizeURLPreservesPathCase(t *testing.T) {
+	upper := normalizeURL("pelican://example.org/ns/Data.txt")
+	lower := normalizeURL("pelican://example.org/ns/data.txt")
+
+	assert.Equal(t, "pelican://example.org/ns/Data.txt", upper, "path case is preserved verbatim")
+	assert.NotEqual(t, upper, lower, "paths differing only in case must not normalize alike")
+}
+
+// TestNormalizeURLFoldsSchemeAndHost covers the half of the URL that is
+// case-insensitive per RFC 3986 6.2.2.1 and therefore must fold.
+func TestNormalizeURLFoldsSchemeAndHost(t *testing.T) {
+	cases := []string{
+		"pelican://example.org/ns/Obj",
+		"PELICAN://example.org/ns/Obj",
+		"pelican://EXAMPLE.ORG/ns/Obj",
+		"PELICAN://Example.Org/ns/Obj",
+	}
+	want := "pelican://example.org/ns/Obj"
+	for _, in := range cases {
+		assert.Equal(t, want, normalizeURL(in), "normalizing %q", in)
+	}
+}
+
+func TestNormalizeURLCleansPath(t *testing.T) {
+	for in, want := range map[string]string{
+		"pelican://h/ns//a":     "pelican://h/ns/a",
+		"pelican://h/ns/./a":    "pelican://h/ns/a",
+		"pelican://h/ns/b/../a": "pelican://h/ns/a",
+		"pelican://h/ns/a/":     "pelican://h/ns/a",
+	} {
+		assert.Equal(t, want, normalizeURL(in), "normalizing %q", in)
+	}
+}
+
+// TestObjectHashDistinguishesCaseVariants checks the property that actually
+// matters: distinct objects get distinct cache keys, so one cannot be served
+// in place of the other.
+func TestObjectHashDistinguishesCaseVariants(t *testing.T) {
+	salt := []byte("test-salt-for-hashing-purposes--")
+
+	upper := ComputeObjectHash(salt, "pelican://example.org/ns/Data.txt")
+	lower := ComputeObjectHash(salt, "pelican://example.org/ns/data.txt")
+	assert.NotEqual(t, upper, lower, "case-variant paths must hash to different objects")
+
+	// Scheme and host case must still not change the identity of an object.
+	a := ComputeObjectHash(salt, "pelican://Example.ORG/ns/Data.txt")
+	b := ComputeObjectHash(salt, "pelican://example.org/ns/Data.txt")
+	assert.Equal(t, a, b, "scheme and host case must not change an object's identity")
+}
+
+// TestNormalizePelicanURLPreservesCase covers the exported wrapper the
+// introspection and API paths use.  It takes both full URLs and bare paths,
+// and must agree with normalizeURL on the case of the object path either way:
+// the same object spelled two ways has to normalize to one answer.
+func TestNormalizePelicanURLPreservesCase(t *testing.T) {
+	assert.Equal(t, "pelican://example.org/ns/Data.txt",
+		NormalizePelicanURL("pelican://example.org/ns/Data.txt"))
+	assert.Equal(t, "osdf:///ns/Data.txt", NormalizePelicanURL("osdf:///ns/Data.txt"))
+	assert.Equal(t, "/ns/Data.txt", NormalizePelicanURL("/ns/Data.txt"),
+		"a bare path keeps its case")
+}
+
+// TestNormalizeHost covers the folding of the authority: ASCII case, the two
+// spellings of an internationalized name, and the things that must be left
+// alone -- ports and IP literals.
+func TestNormalizeHost(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"Empty", "", ""},
+		{"ASCII", "example.org", "example.org"},
+		{"MixedCase", "Example.ORG", "example.org"},
+		{"UpperCase", "EXAMPLE.ORG", "example.org"},
+		{"TrailingDot", "Example.ORG.", "example.org."},
+		{"WithPort", "Example.ORG:8443", "example.org:8443"},
+		{"UnicodeIDN", "bücher.example", "xn--bcher-kva.example"},
+		{"UnicodeIDNUpper", "BÜCHER.example", "xn--bcher-kva.example"},
+		{"PunycodeIDN", "xn--bcher-kva.example", "xn--bcher-kva.example"},
+		{"UnicodeIDNWithPort", "BÜCHER.example:8443", "xn--bcher-kva.example:8443"},
+		{"IPv4", "192.168.1.1", "192.168.1.1"},
+		{"IPv4WithPort", "192.168.1.1:8443", "192.168.1.1:8443"},
+		{"IPv6Bracketed", "[2001:DB8::1]", "[2001:db8::1]"},
+		{"IPv6BracketedWithPort", "[2001:DB8::1]:8443", "[2001:db8::1]:8443"},
+		{"IPv6Loopback", "[::1]:8443", "[::1]:8443"},
+		// IDNA rejects an underscore under STD3 rules; normalizeHost has no
+		// error to return, so it must still answer, deterministically.
+		{"IDNARejected", "My_Host.Example", "my_host.example"},
+		{"IDNARejectedWithPort", "My_Host.Example:443", "my_host.example:443"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, normalizeHost(tc.in))
+		})
+	}
+}
+
+// TestObjectHashFoldsIDNSpellings is the property normalizeHost exists for: a
+// Unicode domain name and its punycode A-label are the same host, so a URL
+// spelled either way must reach the same cached object.
+func TestObjectHashFoldsIDNSpellings(t *testing.T) {
+	salt := []byte("test-salt-for-hashing-purposes--")
+
+	unicode := ComputeObjectHash(salt, "pelican://bücher.example/ns/Data.txt")
+	upper := ComputeObjectHash(salt, "pelican://BÜCHER.example/ns/Data.txt")
+	puny := ComputeObjectHash(salt, "pelican://xn--bcher-kva.example/ns/Data.txt")
+
+	assert.Equal(t, unicode, puny, "an IDN and its A-label name one object")
+	assert.Equal(t, unicode, upper, "IDNA case folding must not change identity")
+
+	// A different host is still a different object.
+	other := ComputeObjectHash(salt, "pelican://bucher.example/ns/Data.txt")
+	assert.NotEqual(t, unicode, other)
+
+	// The port is part of the authority, not of the domain name, and
+	// distinguishes hosts.
+	withPort := ComputeObjectHash(salt, "pelican://bücher.example:8443/ns/Data.txt")
+	assert.NotEqual(t, unicode, withPort)
 }

--- a/local_cache/schema_version_test.go
+++ b/local_cache/schema_version_test.go
@@ -1,0 +1,442 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package local_cache
+
+import (
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// openRawBadger opens the underlying BadgerDB directly, bypassing NewCacheDB
+// and therefore every check it performs.  Tests use it to inspect a database
+// that CacheDB refuses to open.
+func openRawBadger(t *testing.T, baseDir string) *badger.DB {
+	t.Helper()
+	encMgr, err := NewEncryptionManager(baseDir)
+	require.NoError(t, err)
+	dbKey, err := encMgr.DeriveDBKey()
+	require.NoError(t, err)
+
+	opts := badger.DefaultOptions(filepath.Join(baseDir, dbSubDir))
+	opts.Logger = newBadgerLogger()
+	opts.EncryptionKey = dbKey
+	opts.EncryptionKeyRotationDuration = 0
+	opts.IndexCacheSize = 64 << 20
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// openPlainBadger opens an unencrypted BadgerDB, optionally read-only, for
+// tests that need a real read-only handle to wrap in a CacheDB.  See
+// TestSchemaVersionReadOnlyPath for why encryption is left off.
+func openPlainBadger(t *testing.T, dir string, readOnly bool) *badger.DB {
+	t.Helper()
+	opts := badger.DefaultOptions(filepath.Join(dir, dbSubDir))
+	opts.Logger = newBadgerLogger()
+	opts.ReadOnly = readOnly
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// requireRawKeyAbsent asserts that a key is missing from a database opened
+// outside of CacheDB.
+func requireRawKeyAbsent(t *testing.T, db *badger.DB, key string) {
+	t.Helper()
+	require.NoError(t, db.View(func(txn *badger.Txn) error {
+		_, err := txn.Get([]byte(key))
+		assert.ErrorIs(t, err, badger.ErrKeyNotFound, "key %s should not be present", key)
+		return nil
+	}))
+}
+
+// readRawKey returns the raw value of a database key, and whether it exists.
+func readRawKey(t *testing.T, db *CacheDB, key string) ([]byte, bool) {
+	t.Helper()
+	var out []byte
+	var found bool
+	require.NoError(t, db.DB().View(func(txn *badger.Txn) error {
+		item, err := txn.Get([]byte(key))
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			return nil
+		} else if err != nil {
+			return err
+		}
+		found = true
+		return item.Value(func(val []byte) error {
+			out = append([]byte(nil), val...)
+			return nil
+		})
+	}))
+	return out, found
+}
+
+// setRawKey writes a raw value, standing in for a database written by some
+// other build of Pelican.
+func setRawKey(t *testing.T, db *CacheDB, key string, val []byte) {
+	t.Helper()
+	require.NoError(t, db.DB().Update(func(txn *badger.Txn) error {
+		return txn.Set([]byte(key), val)
+	}))
+}
+
+// deleteRawKey removes a raw key, standing in for a database written before
+// that key existed.
+func deleteRawKey(t *testing.T, db *CacheDB, key string) {
+	t.Helper()
+	require.NoError(t, db.DB().Update(func(txn *badger.Txn) error {
+		return txn.Delete([]byte(key))
+	}))
+}
+
+// requireSchemaVersion asserts the stamped schema version.
+func requireSchemaVersion(t *testing.T, db *CacheDB, want SchemaVersion) {
+	t.Helper()
+	val, found := readRawKey(t, db, KeySchemaVersion)
+	require.True(t, found, "database carries no schema version marker")
+	assert.Equal(t, strconv.FormatUint(uint64(want), 10), string(val))
+}
+
+// writeSampleObject stores one metadata record so that the database is not
+// merely a set of header keys, and returns its instance hash.
+func writeSampleObject(t *testing.T, db *CacheDB) InstanceHash {
+	t.Helper()
+	objHash := db.ObjectHash("pelican://example.com/ns/object.txt")
+	instHash := db.InstanceHash("etag-1", objHash)
+	require.NoError(t, db.SetMetadata(instHash, &CacheMetadata{
+		ETag:          "etag-1",
+		ContentLength: 42,
+		Completed:     time.Now(),
+	}))
+	return instHash
+}
+
+// TestSchemaVersionFreshDatabase verifies that a newly created database is
+// stamped with the version this binary writes.
+func TestSchemaVersionFreshDatabase(t *testing.T) {
+	InitIssuerKeyForTests(t)
+	ctx := t.Context()
+
+	db, err := NewCacheDB(ctx, t.TempDir())
+	require.NoError(t, err)
+	defer db.Close()
+
+	requireSchemaVersion(t, db, CurrentSchemaVersion)
+}
+
+// TestSchemaVersionAdoptsUnversionedDatabase covers the upgrade path taken by
+// every cache deployed before versioning existed: the database holds real
+// records but no version marker, so it is adopted as the current schema,
+// stamped, and continues to serve its contents.
+func TestSchemaVersionAdoptsUnversionedDatabase(t *testing.T) {
+	InitIssuerKeyForTests(t)
+	ctx := t.Context()
+	dir := t.TempDir()
+
+	db, err := NewCacheDB(ctx, dir)
+	require.NoError(t, err)
+	instHash := writeSampleObject(t, db)
+	// Strip the marker: this is what a pre-versioning database looks like.
+	deleteRawKey(t, db, KeySchemaVersion)
+	_, found := readRawKey(t, db, KeySchemaVersion)
+	require.False(t, found)
+	require.NoError(t, db.Close())
+
+	reopened, err := NewCacheDB(ctx, dir)
+	require.NoError(t, err, "an unversioned cache database must still open")
+	defer reopened.Close()
+
+	requireSchemaVersion(t, reopened, CurrentSchemaVersion)
+
+	// Adoption must not disturb the records that were already there.
+	meta, err := reopened.GetMetadata(instHash)
+	require.NoError(t, err)
+	require.NotNil(t, meta, "adoption lost the pre-existing metadata")
+	assert.Equal(t, int64(42), meta.ContentLength)
+
+	// And the store mode marker still governs ownership as before.
+	require.NoError(t, reopened.EnsureStoreMode(StoreModeCache))
+}
+
+// TestSchemaVersionRefusesNewer verifies that a database written under a later
+// layout is refused rather than misread, and that the error names both the
+// version found and the version supported.
+func TestSchemaVersionRefusesNewer(t *testing.T) {
+	InitIssuerKeyForTests(t)
+	ctx := t.Context()
+	dir := t.TempDir()
+
+	future := CurrentSchemaVersion + 1
+	db, err := NewCacheDB(ctx, dir)
+	require.NoError(t, err)
+	writeSampleObject(t, db)
+	setRawKey(t, db, KeySchemaVersion, []byte(strconv.FormatUint(uint64(future), 10)))
+	require.NoError(t, db.Close())
+
+	reopened, err := NewCacheDB(ctx, dir)
+	require.Error(t, err, "a database from a newer Pelican must not open")
+	if reopened != nil {
+		reopened.Close()
+	}
+	assert.Contains(t, err.Error(), "schema version "+strconv.FormatUint(uint64(future), 10),
+		"error should name the version found")
+	assert.Contains(t, err.Error(), "version "+strconv.FormatUint(uint64(CurrentSchemaVersion), 10),
+		"error should name the version supported")
+	assert.Contains(t, err.Error(), dir, "error should name the database")
+}
+
+// TestSchemaVersionRefusalLeavesDatabaseUntouched verifies that refusing a
+// newer database does not write anything into it -- an old binary must not
+// leave fingerprints on a database it could not read.
+func TestSchemaVersionRefusalLeavesDatabaseUntouched(t *testing.T) {
+	InitIssuerKeyForTests(t)
+	ctx := t.Context()
+	dir := t.TempDir()
+
+	future := CurrentSchemaVersion + 1
+	db, err := NewCacheDB(ctx, dir)
+	require.NoError(t, err)
+	writeSampleObject(t, db)
+	// Remove the markers a fresh open would otherwise write, so that a stray
+	// write during the refused open is visible.
+	deleteRawKey(t, db, KeySalt)
+	deleteRawKey(t, db, KeyStoreMode)
+	setRawKey(t, db, KeySchemaVersion, []byte(strconv.FormatUint(uint64(future), 10)))
+	require.NoError(t, db.Close())
+
+	refused, err := NewCacheDB(ctx, dir)
+	require.Error(t, err)
+	if refused != nil {
+		refused.Close()
+	}
+
+	// Inspect the database behind CacheDB's back: the refused open must have
+	// written neither a salt nor a store mode marker.
+	raw := openRawBadger(t, dir)
+	requireRawKeyAbsent(t, raw, KeySalt)
+	requireRawKeyAbsent(t, raw, KeyStoreMode)
+}
+
+// TestSchemaVersionReadOnlyPath exercises VerifySchemaVersion against a
+// genuinely read-only BadgerDB handle -- the strongest possible statement of
+// the claim the function makes, since badger rejects any Update on such a
+// handle and a stamping implementation would fail outright rather than merely
+// leaving a key behind.
+//
+// The handle is built by hand rather than through OpenCacheDBReadOnly, which
+// no longer uses BadgerDB's read-only mode at all (see the comment there: it
+// aborts the process on an encrypted database with SST data, and is
+// unsupported on Windows).  Wrapping a plain read-only handle in a CacheDB
+// exercises exactly the code under test: VerifySchemaVersion reads one key and
+// touches nothing else.
+//
+// The introspection path itself is covered end to end, on every platform, by
+// TestOpenCacheDBReadOnlyLeavesNoStamp and
+// TestOpenCacheDBReadOnlyRefusesNewerSchema in introspect_open_test.go.
+func TestSchemaVersionReadOnlyPath(t *testing.T) {
+	// BadgerDB refuses read-only mode on Windows outright ("Read-only mode is
+	// not supported on Windows"), so there is no read-only handle to wrap and
+	// nothing here to exercise.  This costs no coverage of the introspection
+	// path, which does not depend on that mode; it only means this particular
+	// way of proving VerifySchemaVersion never writes is unavailable there.
+	if runtime.GOOS == "windows" {
+		t.Skip("BadgerDB does not support read-only mode on Windows")
+	}
+
+	t.Run("UnversionedDatabaseAccepted", func(t *testing.T) {
+		dir := t.TempDir()
+		seed := openPlainBadger(t, dir, false)
+		require.NoError(t, seed.Update(func(txn *badger.Txn) error {
+			return txn.Set(MetaKey("instance"), []byte("record"))
+		}))
+		require.NoError(t, seed.Close())
+
+		ro := openPlainBadger(t, dir, true)
+		cdb := &CacheDB{db: ro, baseDir: dir}
+		require.NoError(t, cdb.VerifySchemaVersion(),
+			"introspecting a pre-versioning database must not fail")
+
+		// ...and nothing was stamped.
+		require.NoError(t, ro.View(func(txn *badger.Txn) error {
+			_, err := txn.Get([]byte(KeySchemaVersion))
+			assert.ErrorIs(t, err, badger.ErrKeyNotFound, "read-only path wrote a stamp")
+			return nil
+		}))
+	})
+
+	t.Run("CurrentVersionAccepted", func(t *testing.T) {
+		dir := t.TempDir()
+		seed := openPlainBadger(t, dir, false)
+		require.NoError(t, seed.Update(func(txn *badger.Txn) error {
+			return txn.Set([]byte(KeySchemaVersion),
+				[]byte(strconv.FormatUint(uint64(CurrentSchemaVersion), 10)))
+		}))
+		require.NoError(t, seed.Close())
+
+		cdb := &CacheDB{db: openPlainBadger(t, dir, true), baseDir: dir}
+		require.NoError(t, cdb.VerifySchemaVersion())
+	})
+
+	t.Run("NewerVersionRefused", func(t *testing.T) {
+		dir := t.TempDir()
+		future := CurrentSchemaVersion + 1
+		seed := openPlainBadger(t, dir, false)
+		require.NoError(t, seed.Update(func(txn *badger.Txn) error {
+			return txn.Set([]byte(KeySchemaVersion),
+				[]byte(strconv.FormatUint(uint64(future), 10)))
+		}))
+		require.NoError(t, seed.Close())
+
+		cdb := &CacheDB{db: openPlainBadger(t, dir, true), baseDir: dir}
+		err := cdb.VerifySchemaVersion()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "schema version "+strconv.FormatUint(uint64(future), 10),
+			"error should name the version found")
+		assert.Contains(t, err.Error(), "version "+strconv.FormatUint(uint64(CurrentSchemaVersion), 10),
+			"error should name the version supported")
+	})
+}
+
+// TestSchemaVersionOlderWithoutMigration pins the behavior of the migration
+// seam.  No Pelican has ever written a version below CurrentSchemaVersion, so
+// a marker claiming one cannot be honored: there is no migration to run and
+// interpreting the records under today's rules is the very thing versioning
+// exists to prevent.  The refusal names the version, so whoever adds schema
+// version 2 sees immediately where the migration belongs (migrateSchema).
+func TestSchemaVersionOlderWithoutMigration(t *testing.T) {
+	InitIssuerKeyForTests(t)
+	ctx := t.Context()
+	dir := t.TempDir()
+
+	db, err := NewCacheDB(ctx, dir)
+	require.NoError(t, err)
+	setRawKey(t, db, KeySchemaVersion, []byte("0"))
+	require.NoError(t, db.Close())
+
+	reopened, err := NewCacheDB(ctx, dir)
+	require.Error(t, err)
+	if reopened != nil {
+		reopened.Close()
+	}
+	assert.Contains(t, err.Error(), "no migration is available from schema version 0")
+}
+
+// TestSchemaVersionMalformedMarker verifies that a marker that is not a
+// version number is reported rather than silently treated as version zero.
+func TestSchemaVersionMalformedMarker(t *testing.T) {
+	InitIssuerKeyForTests(t)
+	ctx := t.Context()
+	dir := t.TempDir()
+
+	db, err := NewCacheDB(ctx, dir)
+	require.NoError(t, err)
+	setRawKey(t, db, KeySchemaVersion, []byte("not-a-version"))
+	require.NoError(t, db.Close())
+
+	reopened, err := NewCacheDB(ctx, dir)
+	require.Error(t, err)
+	if reopened != nil {
+		reopened.Close()
+	}
+	assert.Contains(t, err.Error(), "not a version number")
+}
+
+// TestSchemaVersionAndStoreModeCoexist verifies that the two header markers do
+// not interfere: the version stamp must not make an otherwise empty database
+// look "used" to store mode adoption, and a mode mismatch must still fail with
+// the mode error.
+func TestSchemaVersionAndStoreModeCoexist(t *testing.T) {
+	InitIssuerKeyForTests(t)
+	ctx := t.Context()
+
+	t.Run("EmptyDatabaseStillAdoptableAsPStore", func(t *testing.T) {
+		// A fresh database carries a salt and a schema version before any
+		// consumer claims it.  Neither says anything about who owns it, so a
+		// pstore -- which may only adopt an otherwise empty database -- must
+		// still be able to claim it.
+		db, err := NewCacheDB(ctx, t.TempDir())
+		require.NoError(t, err)
+		defer db.Close()
+
+		requireSchemaVersion(t, db, CurrentSchemaVersion)
+		require.NoError(t, db.EnsureStoreMode(StoreModePStore),
+			"the schema version stamp must not block pstore adoption")
+	})
+
+	t.Run("NonEmptyDatabaseStillRefusedForPStore", func(t *testing.T) {
+		db, err := NewCacheDB(ctx, t.TempDir())
+		require.NoError(t, err)
+		defer db.Close()
+
+		writeSampleObject(t, db)
+		err = db.EnsureStoreMode(StoreModePStore)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no store mode marker")
+	})
+
+	t.Run("ModeMismatchStillFails", func(t *testing.T) {
+		dir := t.TempDir()
+		db, err := NewCacheDB(ctx, dir)
+		require.NoError(t, err)
+		require.NoError(t, db.EnsureStoreMode(StoreModeCache))
+		requireSchemaVersion(t, db, CurrentSchemaVersion)
+		require.NoError(t, db.Close())
+
+		reopened, err := NewCacheDB(ctx, dir)
+		require.NoError(t, err, "the version check must not reject a well-formed database")
+		defer reopened.Close()
+
+		err = reopened.EnsureStoreMode(StoreModePStore)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "belongs to a \"cache\" store")
+	})
+
+	t.Run("VersionRefusalPrecedesModeCheck", func(t *testing.T) {
+		// A database owned by a pstore and written under a newer layout is
+		// refused for its version, not misreported as a mode problem: the mode
+		// marker is itself a record written under a layout we cannot read.
+		dir := t.TempDir()
+		db, err := NewCacheDB(ctx, dir)
+		require.NoError(t, err)
+		require.NoError(t, db.EnsureStoreMode(StoreModePStore))
+		setRawKey(t, db, KeySchemaVersion,
+			[]byte(strconv.FormatUint(uint64(CurrentSchemaVersion+1), 10)))
+		require.NoError(t, db.Close())
+
+		reopened, err := NewCacheDB(ctx, dir)
+		require.Error(t, err)
+		if reopened != nil {
+			reopened.Close()
+		}
+		assert.Contains(t, err.Error(), "schema version")
+		assert.NotContains(t, err.Error(), "belongs to a",
+			"the version refusal must not be reported as a store mode problem")
+	})
+}

--- a/local_cache/storage.go
+++ b/local_cache/storage.go
@@ -355,6 +355,17 @@ type StorageManager struct {
 	// Nil when disabled (MemoryCacheSize == 0).
 	ptCache *ristretto.Cache[uint64, []byte]
 
+	// pins tracks object versions with live readers, so a delete path that
+	// respects them does not pull data out from under one.  See pin.go.
+	pins *pinSet
+
+	// liveAppends holds the instance hashes of AppendWriters this process
+	// still owns, as a set (the value is always struct{}{}).  A persisted
+	// append-in-flight record whose hash is absent here belongs to a writer
+	// that did not survive, which is what makes it reclaimable.  Kept as a
+	// sync.Map so the zero value works in every StorageManager constructor.
+	liveAppends sync.Map
+
 	// chooseDir selects a storage directory for new chunk files.
 	// Defaults to simple round-robin.  In production, NewPersistentCache
 	// overwrites this with EvictionManager.ChooseDiskStorage (weighted
@@ -572,6 +583,7 @@ func NewStorageManager(db *CacheDB, dirs []string, inlineMax int, egrp *errgroup
 		fdCacheMaxSize: fdCacheSize,
 		ptCache:        ptCache,
 		chooseDir:      defaultChooseDir,
+		pins:           newPinSet(),
 		blockStates:    newBlockStateCache(db),
 		diskCrypto: ttlcache.New[InstanceHash, *diskCryptoEntry](
 			ttlcache.WithTTL[InstanceHash, *diskCryptoEntry](diskCryptoTTL),
@@ -602,12 +614,33 @@ func NewStorageManager(db *CacheDB, dirs []string, inlineMax int, egrp *errgroup
 	return sm, nil
 }
 
+// SetChooseDir replaces the storage-directory selection function.
+//
+// The default is plain round-robin, which ignores how full each directory is.
+// The cache substitutes a free-space-weighted chooser from its eviction
+// manager; a pstore, which has no eviction manager, substitutes one driven by
+// its own capacity limits.  Without this a store with directories of
+// different sizes round-robins straight into a full one.
+//
+// Must be called before any concurrent access begins.
+func (sm *StorageManager) SetChooseDir(fn func() StorageID) {
+	if fn != nil {
+		sm.chooseDir = fn
+	}
+}
+
 // GetDirs returns the configured storage directories (storageID → objects dir).
 func (sm *StorageManager) GetDirs() map[StorageID]string {
 	return sm.dirs
 }
 
 // Close stops TTL cache eviction goroutines and releases cached resources.
+//
+// Only the caches that were actually started are stopped.  ttlcache's Stop is
+// an unbuffered channel send that its Start loop receives, so stopping a cache
+// whose loop was never spawned blocks forever -- which is what happened to
+// every manager built by NewStorageManagerReadOnly, making the read-only
+// introspection paths hang on exit.
 func (sm *StorageManager) Close() {
 	// Stop() hands the eviction loop a value over an unbuffered channel and
 	// waits for it to be received, so it blocks forever if the loop is not
@@ -634,6 +667,12 @@ func (sm *StorageManager) Close() {
 // NewStorageManagerReadOnly creates a storage manager for read-only introspection.
 // This is a lightweight variant suitable for CLI tools that only need to read
 // metadata and block states, not perform downloads or writes.
+//
+// It carries no read-only flag of its own, and needs none: it never touches
+// the database except through db's typed methods, so a db from
+// OpenCacheDBReadOnly already refuses every write made through it.  Callers
+// that hand it a writable db (pstore's maintenance open, which needs `fsck
+// --repair` to work) are asserting their own preconditions instead.
 func NewStorageManagerReadOnly(baseDir string, db *CacheDB) (*StorageManager, error) {
 	// Load disk mappings to discover storage directories
 	mappings, err := db.LoadDiskMappings()
@@ -651,6 +690,7 @@ func NewStorageManagerReadOnly(baseDir string, db *CacheDB) (*StorageManager, er
 		db:             db,
 		dirs:           objDirs,
 		inlineMaxBytes: InlineThreshold,
+		pins:           newPinSet(),
 		blockStates:    newBlockStateCache(db),
 		diskCrypto: ttlcache.New[InstanceHash, *diskCryptoEntry](
 			ttlcache.WithTTL[InstanceHash, *diskCryptoEntry](diskCryptoTTL),
@@ -1887,14 +1927,30 @@ func (sm *StorageManager) deleteChunkFiles(instanceHash InstanceHash, contentLen
 // either limit means "no limit on that dimension".  The method is allowed
 // to go one object over the byte threshold to prevent starvation.
 //
+// Objects under a live reader are spared.  Deleting one does not merely slow
+// that reader down: refCountedFile keeps its descriptor open across the
+// unlink, but the reader also needs the object's metadata, data key, and
+// block state, and eviction removes all three -- so the transfer fails.  The
+// overlap is small by construction, since the head of the LRU index is the
+// least recently used object and a pinned object is being read right now, but
+// UpdateLRU debounces by ten minutes: a slow reader streaming a large object
+// through a fast-churning cache can drift toward the head, which is exactly
+// the case worth protecting.
+//
+// A spared object stays at the head of the index and is reconsidered on the
+// next pass, by which time its reader has usually finished.
+//
 // All DB mutations happen atomically; filesystem deletes follow afterward.
-// Returns the evicted objects, total bytes freed, and any error.
-func (sm *StorageManager) EvictByLRU(storageID StorageID, namespaceID NamespaceID, maxObjects int, maxBytes int64) ([]evictedObject, uint64, error) {
-	evicted, err := sm.db.EvictByLRU(storageID, namespaceID, maxObjects, maxBytes)
+// Returns the evicted objects, total bytes freed, and how many were spared.
+func (sm *StorageManager) EvictByLRU(storageID StorageID, namespaceID NamespaceID, maxObjects int, maxBytes int64) ([]evictedObject, uint64, int, error) {
+	// isPinned is called from inside the eviction transaction.  That is safe
+	// because pins.mu is a leaf: pinning never opens a Badger transaction, so
+	// the two locks cannot be acquired in opposing orders.
+	evicted, skipped, err := sm.db.EvictByLRU(storageID, namespaceID, maxObjects, maxBytes, sm.pins.isPinned)
 	if err != nil {
 		// Return the attempted (uncommitted) objects alongside the error
 		// so the caller can log which objects were involved in a conflict.
-		return evicted, 0, errors.Wrap(err, "failed to evict objects by LRU")
+		return evicted, 0, skipped, errors.Wrap(err, "failed to evict objects by LRU")
 	}
 
 	var totalFreed uint64
@@ -1921,7 +1977,7 @@ func (sm *StorageManager) EvictByLRU(storageID StorageID, namespaceID NamespaceI
 		}
 	}
 
-	return evicted, totalFreed, nil
+	return evicted, totalFreed, skipped, nil
 }
 
 // GetObjectSize returns the content length of a cached object
@@ -1973,6 +2029,7 @@ type ObjectReader struct {
 	inlineData   []byte
 	encryptor    *BlockEncryptor   // cached from getDiskCrypto; nil for inline
 	blockState   *ObjectBlockState // cached from GetSharedBlockState; nil for inline
+	unpin        func()            // releases this reader's pin; see pin.go
 }
 
 // NewObjectReader creates a reader for a cached object
@@ -1991,12 +2048,16 @@ func (sm *StorageManager) NewObjectReader(instanceHash InstanceHash) (*ObjectRea
 		meta:         meta,
 		position:     0,
 		length:       meta.ContentLength,
+		// Held until Close so a concurrent delete that respects pins cannot
+		// remove the metadata and block state this reader still needs.
+		unpin: sm.pins.pin(instanceHash),
 	}
 
 	if meta.IsInline() {
 		// Read all inline data upfront
 		data, err := sm.ReadInline(instanceHash)
 		if err != nil {
+			reader.unpin()
 			return nil, err
 		}
 		reader.inlineData = data
@@ -2004,6 +2065,7 @@ func (sm *StorageManager) NewObjectReader(instanceHash InstanceHash) (*ObjectRea
 		// Cache the encryptor so Read/ReadAt skip the getDiskCrypto TTL lookup.
 		dc, err := sm.getDiskCrypto(instanceHash)
 		if err != nil {
+			reader.unpin()
 			return nil, errors.Wrap(err, "failed to get disk crypto")
 		}
 		reader.encryptor = dc.encryptor
@@ -2011,6 +2073,7 @@ func (sm *StorageManager) NewObjectReader(instanceHash InstanceHash) (*ObjectRea
 		// Cache the block state so Read/ReadAt skip the GetSharedBlockState TTL lookup.
 		bs, err := sm.GetSharedBlockState(instanceHash)
 		if err != nil {
+			reader.unpin()
 			return nil, errors.Wrap(err, "failed to get block state")
 		}
 		reader.blockState = bs
@@ -2021,6 +2084,7 @@ func (sm *StorageManager) NewObjectReader(instanceHash InstanceHash) (*ObjectRea
 		// ReadBlocks callers.
 		rc, err := sm.getFile(instanceHash, meta.StorageID)
 		if err != nil {
+			reader.unpin()
 			return nil, errors.Wrap(err, "failed to open object file")
 		}
 		reader.file = rc
@@ -2160,6 +2224,9 @@ func (r *ObjectReader) Close() error {
 	if r.file != nil {
 		r.file.Release()
 		r.file = nil
+	}
+	if r.unpin != nil {
+		r.unpin()
 	}
 	return nil
 }

--- a/local_cache/storage_fadvise_linux.go
+++ b/local_cache/storage_fadvise_linux.go
@@ -28,7 +28,7 @@ import (
 
 // fadviseSequential hints to the kernel that the given file descriptor
 // will be accessed sequentially, enabling readahead and write-back
-// optimisations.
+// optimizations.
 func fadviseSequential(f *os.File) error {
 	return unix.Fadvise(int(f.Fd()), 0, 0, unix.FADV_SEQUENTIAL)
 }

--- a/metrics/pstore.go
+++ b/metrics/pstore.go
@@ -1,0 +1,362 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Metrics for the Pelican store (`pstore`), the origin backend that drives the
+// cache V2 block store directly.  See docs/pstore-design.md §11.7.
+//
+// These live here rather than in the pstore package for the reason the rest of
+// this package exists: one place to read the whole exported surface, and one
+// place a name collision is caught.  The collectors are package-level and
+// registered by promauto at init, which is what makes them safe when several
+// exports share one store -- they do -- and when a process runs both a cache
+// and an origin.
+//
+// Three rules shaped the set:
+//
+//   - Nothing here is fed by a syscall or by work done inside a lock on a
+//     serving path.  The capacity gauges are republished from figures the
+//     store already keeps in memory, by the janitor and at open; the write
+//     counters are a single atomic add per completed write.
+//   - Gauges describe state, so they must be right after a restart rather than
+//     after the first event.  The capacity gauges are published from what the
+//     capacity tracker recovers from the catalog at open, not left at zero
+//     until something is written.
+//   - There is deliberately no `store` label.  `Origin.PStoreLocation` is a
+//     single process-wide parameter, so a server process has exactly one
+//     store; the offline CLI opens its own, in its own process, where nothing
+//     is scraped.  Storage directories are owned exclusively by one store, so
+//     the `directory` label stays unambiguous regardless.
+//
+// # Relationship to the `pelican_cache_*` scan series
+//
+// pstore's scheduled data scan is `local_cache.ConsistencyChecker.RunDataScan`,
+// which is also the cache's, and which used to report an *origin's* integrity
+// scan under `pelican_cache_data_scan_*`.  That is resolved at the source: the
+// checker a pstore builds sets `ConsistencyConfig.SuppressCacheMetrics`, so the
+// cache-named series are not touched by an origin and the equivalent figures
+// are published here instead.  Nothing is counted twice, and a process running
+// both a cache and a pstore origin reports each under its own name.
+//
+// The one difference an operator will notice: the cache updates its scan
+// counters after every object, while `pelican_pstore_data_scan_*` is added to
+// once per completed pass.  A pass over a large store can take a day, so these
+// step rather than climb.  `pelican_pstore_scheduled_pass_last_success_timestamp_seconds`
+// is what says a pass is in progress or stuck.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Label values for the `pass` label on the scheduled-pass metrics below.
+// They name the three loops in pstore that run work on a schedule.
+const (
+	PStorePassIndexCheck     = "index_check"
+	PStorePassDataScan       = "data_scan"
+	PStorePassMetadataBackup = "metadata_backup"
+)
+
+// Label values for the `tier` label on PStoreWritesTotal.  They are the three
+// write tiers in docs/pstore-design.md §6.1.
+const (
+	PStoreTierInline   = "inline"
+	PStoreTierBuffered = "buffered"
+	PStoreTierStreamed = "streamed"
+)
+
+// Label values for the `reason` label on PStoreWriteFailuresTotal.
+const (
+	PStoreWriteFailureNoSpace  = "no_space"
+	PStoreWriteFailureConflict = "conflict"
+)
+
+// Label values for the `kind` label on PStoreReclamationPending.
+const (
+	PStoreReclaimKindInstance = "instance"
+	PStoreReclaimKindSubtree  = "subtree"
+)
+
+// Label values for the `kind` label on PStoreFsckFindings.
+const (
+	PStoreFsckDanglingEntries   = "dangling_entries"
+	PStoreFsckMissingData       = "missing_data"
+	PStoreFsckOrphanedInstances = "orphaned_instances"
+	PStoreFsckPendingInstances  = "pending_instances"
+	PStoreFsckCorruptObjects    = "corrupt_objects"
+	PStoreFsckUsageDrift        = "usage_drift_directories"
+)
+
+// PStoreDirectoryInline is the `directory` label value for the pseudo-directory
+// that holds objects stored inline in the catalog rather than in a storage
+// directory.  It is deliberately not a path: inline objects live wherever the
+// catalog does, which may be one of the real directories, and giving them that
+// path would merge two different quantities into one series.
+const PStoreDirectoryInline = "(inline)"
+
+// ---------------------------------------------------------------------------
+// Capacity
+// ---------------------------------------------------------------------------
+
+// A pstore never evicts.  When it fills, writes fail with ENOSPC and the origin
+// answers 507, and until then nothing else in the process says the store is
+// approaching that point -- the block files are encrypted and spread over
+// several directories, so `du` does not answer it either.  These are gauges
+// because they describe a level, and they are republished from the capacity
+// tracker's in-memory figures (which are themselves seeded from the catalog at
+// open) rather than measured, so nothing here costs a stat().
+var (
+	PStoreDirectoryUsedBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pelican_pstore_directory_used_bytes",
+		Help: "Bytes committed plus reserved in one pstore storage directory. " +
+			"Cardinality is the number of configured directories, plus one for " +
+			"\"" + PStoreDirectoryInline + "\", the objects held in the catalog itself.",
+	}, []string{"directory"})
+
+	PStoreDirectoryLimitBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pelican_pstore_directory_limit_bytes",
+		Help: "Configured ceiling for one pstore storage directory (its MaxSize). " +
+			"Zero means the directory is unbounded, which is also why the aggregate " +
+			"limit is not the sum of these.",
+	}, []string{"directory"})
+
+	// The aggregate is a separate series rather than a sum() over the
+	// per-directory ones because it cannot be derived from them: one unbounded
+	// directory makes the whole store unbounded, so summing the limits would
+	// invent a ceiling that does not exist.  It is also the figure that
+	// actually refuses a write.
+	PStoreUsedBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "pelican_pstore_used_bytes",
+		Help: "Bytes committed plus reserved across the whole pstore. This is the " +
+			"figure tested against the aggregate ceiling when a write is refused.",
+	})
+
+	PStoreLimitBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "pelican_pstore_limit_bytes",
+		Help: "Aggregate ceiling for the pstore: the sum of the configured " +
+			"per-directory limits, or zero when any directory is unbounded and " +
+			"therefore the store as a whole is.",
+	})
+
+	// Sourced from the scheduled index check rather than kept incrementally.
+	// There is no cheap count in the catalog, and maintaining one on the write
+	// and delete paths would be a second thing to keep correct for a number
+	// nobody alerts on -- so this is as of the last pass, and is absent until
+	// the first one completes.
+	PStoreObjects = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "pelican_pstore_objects",
+		Help: "Objects in the pstore as of the last completed consistency pass " +
+			"(Origin.PStoreIndexCheckInterval). Directories are excluded.",
+	})
+)
+
+// ---------------------------------------------------------------------------
+// Scheduled passes: index check, data scan, metadata backup
+// ---------------------------------------------------------------------------
+
+// The three background loops are the same shape -- run periodically, may fail,
+// take a measurable time, may overrun their interval -- so they share one
+// family with a `pass` label rather than three parallel sets of names.
+//
+// The metadata backup is the one that matters most and is invisible today.  An
+// origin whose catalog backups silently stopped still serves perfectly until
+// the catalog is lost, at which point the block files are unreadable bytes.
+// The alert is on age:
+//
+//	time() - pelican_pstore_scheduled_pass_last_success_timestamp_seconds{pass="metadata_backup"}
+//
+// which is why the timestamp is advanced only by a pass that actually
+// succeeded, and a failure moves the failure counter instead.
+var (
+	PStoreScheduledPassesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "pelican_pstore_scheduled_passes_total",
+		Help: "Attempts at a pstore scheduled maintenance pass, by pass: " +
+			"\"index_check\", \"data_scan\", or \"metadata_backup\".",
+	}, []string{"pass"})
+
+	PStoreScheduledPassFailuresTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "pelican_pstore_scheduled_pass_failures_total",
+		Help: "Attempts at a pstore scheduled maintenance pass that returned an error. " +
+			"A failed pass is logged and retried at the next interval; it never takes " +
+			"the origin down, which is exactly why it needs to be visible here.",
+	}, []string{"pass"})
+
+	PStoreScheduledPassLastSuccessTime = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pelican_pstore_scheduled_pass_last_success_timestamp_seconds",
+		Help: "Unix time at which a pstore scheduled maintenance pass last completed " +
+			"successfully. Zero (or absent) means no pass has ever succeeded in this " +
+			"process. Alert on the age of pass=\"metadata_backup\".",
+	}, []string{"pass"})
+
+	PStoreScheduledPassLastDurationSeconds = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pelican_pstore_scheduled_pass_last_duration_seconds",
+		Help: "How long the last pstore scheduled maintenance pass took. A gauge " +
+			"rather than a histogram: these run hours apart, so a distribution would " +
+			"be several near-empty series describing a handful of samples a day.",
+	}, []string{"pass"})
+
+	// Runs are spaced from the end of one to the start of the next, so an
+	// overrun does not compound -- but it does mean the store is too large for
+	// the configured interval, and the loops only log that at warn level.
+	PStoreScheduledPassOverrunsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "pelican_pstore_scheduled_pass_overruns_total",
+		Help: "Passes that took longer than their configured interval. The next run " +
+			"still waits a full interval, so nothing compounds; a rising count means " +
+			"the check cannot actually run as often as configured.",
+	}, []string{"pass"})
+
+	PStoreMetadataBackupLastSizeBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "pelican_pstore_metadata_backup_last_size_bytes",
+		Help: "Size of the last snapshot the pstore metadata backup published. A " +
+			"collapse in this against a store that is still growing is the shape of " +
+			"a backup that succeeds while capturing nothing.",
+	})
+)
+
+// ---------------------------------------------------------------------------
+// Integrity findings
+// ---------------------------------------------------------------------------
+
+var (
+	// Counted per pass rather than read from the checker's own totals, which
+	// accumulate across every scan the process has ever run and so stay above
+	// zero forever once a single mismatch has been seen.  runDataScanLoop
+	// already takes that difference for its log message; this adds the same
+	// difference here.
+	PStoreDataScanMismatchesTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "pelican_pstore_data_scan_mismatches_total",
+		Help: "Objects whose stored data no longer matched the checksums recorded at " +
+			"ingest, summed over completed data scans. An origin cannot re-fetch what " +
+			"it has lost, so any increase is a restore-or-re-ingest decision.",
+	})
+
+	PStoreDataScanObjectsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "pelican_pstore_data_scan_objects_total",
+		Help: "Objects read back and verified, summed over completed data scans. " +
+			"Updated once per pass, not per object.",
+	})
+
+	PStoreDataScanBytesTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "pelican_pstore_data_scan_bytes_total",
+		Help: "Bytes read back and verified, summed over completed data scans. " +
+			"Updated once per pass, not per object.",
+	})
+
+	// One gauge per finding class, set at the end of a pass.  Deliberately not
+	// one series per finding: the findings are paths, and a store with a
+	// hundred thousand dangling entries would otherwise put a hundred thousand
+	// series into the registry at exactly the moment it is least able to
+	// afford it.  The paths are in the fsck report and the log.
+	PStoreFsckFindings = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pelican_pstore_fsck_findings",
+		Help: "Findings from the last pstore consistency pass, by class. " +
+			"\"orphaned_instances\" and \"pending_instances\" are per examined slice " +
+			"of the instance-hash space, not store-wide totals: the scheduled index " +
+			"check covers one slice per pass to bound its memory. \"corrupt_objects\" " +
+			"is only set by a deep pass, which is an operator action rather than a " +
+			"scheduled one.",
+	}, []string{"kind"})
+)
+
+// ---------------------------------------------------------------------------
+// Reclamation
+// ---------------------------------------------------------------------------
+
+// Nothing in a pstore is evicted, so the janitor draining the `pg:` queue is
+// the only thing that gives space back.  A queue that grows monotonically is a
+// capacity leak that ends as a 507, and it is silent: each sweep is bounded
+// work and simply falls further behind.
+var (
+	// Measured by a keys-only scan of the queue, taken at most once per resting
+	// janitor interval so that a backlog -- the case where the scan is not free
+	// -- cannot make the sweep rate pay for the measurement.
+	PStoreReclamationPending = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pelican_pstore_reclamation_pending",
+		Help: "Work waiting in the pstore reclamation queue: \"instance\" for object " +
+			"versions whose blocks are still to be freed, \"subtree\" for detached " +
+			"directories still to be drained. Sampled at most once per janitor " +
+			"resting interval.",
+	}, []string{"kind"})
+
+	PStoreDetachedSubtrees = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "pelican_pstore_detached_subtrees",
+		Help: "Subtrees unlinked by a recursive delete that the janitor has not " +
+			"finished draining. Paths beneath them are refused with a retryable " +
+			"error, so a value that does not return to zero is user-visible.",
+	})
+
+	PStoreReclaimedObjectsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "pelican_pstore_reclaimed_objects_total",
+		Help: "Object versions whose blocks the janitor has released.",
+	})
+
+	PStoreReclaimedBytesTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "pelican_pstore_reclaimed_bytes_total",
+		Help: "Bytes the janitor has released, from the metadata of each version it " +
+			"freed. Compare against pelican_pstore_used_bytes to see reclamation " +
+			"keeping up with deletion.",
+	})
+
+	// Its own counter rather than a label on the one above, because it counts a
+	// different failure: a streaming upload that died before it reached the
+	// queue at all.  A cache reclaims those from its eviction manager, which a
+	// pstore never constructs, so this is the one path that used to leak
+	// without any record.
+	PStoreAbandonedWritesReclaimedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "pelican_pstore_abandoned_writes_reclaimed_total",
+		Help: "Streaming writes whose writer never finished and whose space the " +
+			"janitor has since released.",
+	})
+)
+
+// ---------------------------------------------------------------------------
+// Write path
+// ---------------------------------------------------------------------------
+
+var (
+	// The tier is chosen by how much data actually arrives, so this is the
+	// distribution of object sizes as the store experiences it, and it says
+	// whether the spill threshold suits the workload: a store whose writes are
+	// nearly all "streamed" is buffering nothing and paying whole-chunk
+	// reservations for objects that would fit in one file.
+	PStoreWritesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "pelican_pstore_writes_total",
+		Help: "Objects successfully written, by storage tier: \"inline\" (held in the " +
+			"catalog), \"buffered\" (written in one piece at a known length), or " +
+			"\"streamed\" (chunked through the append writer).",
+	}, []string{"tier"})
+
+	PStoreWriteFailuresTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "pelican_pstore_write_failures_total",
+		Help: "Writes refused, by reason: \"no_space\" when the store is at its " +
+			"ceiling (the origin answers 507), \"conflict\" when a write lost the race " +
+			"for its path too many times to retry (the origin answers 409).",
+	}, []string{"reason"})
+
+	// Retries are separate from failures because they are not errors: the store
+	// absorbing a concurrent PUT to the same path is the design working.  It is
+	// worth seeing because a sustained retry rate is what precedes the
+	// conflict failures above.
+	PStoreWriteConflictRetriesTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "pelican_pstore_write_conflict_retries_total",
+		Help: "Commit attempts aborted by a concurrent write to the same path and " +
+			"retried. Not an error: the retry is how the store absorbs concurrent " +
+			"PUTs rather than answering them with a transaction conflict.",
+	})
+)

--- a/origin/advertise.go
+++ b/origin/advertise.go
@@ -150,10 +150,14 @@ func (server *OriginServer) CreateAdvertisement(name, id, originUrlStr, originWe
 	// to the right endpoint. When the origin is standalone, older clients cannot handle
 	// non-empty resource paths, so we advertise the base URL.
 	// WebURL stays as the base server URL for web browser access.
+	//
+	// This tracks UsesXRootD rather than an explicit list of storage types: the
+	// condition is exactly "served by the pelican process rather than XRootD",
+	// and a hand-maintained list silently omits each new native backend --
+	// which is how pstore first advertised a data URL with no route behind it,
+	// leaving the director redirecting into a loop.
 	dataUrlToAdvertise := originUrlStr
-	if (ost == server_structs.OriginStoragePosixv2 || ost == server_structs.OriginStorageSSH ||
-		ost == server_structs.OriginStorageS3v2 || ost == server_structs.OriginStorageHTTPSv2 ||
-		ost == server_structs.OriginStorageGlobusv2) && config.IsServerEnabled(server_structs.DirectorType) {
+	if !ost.UsesXRootD() && config.IsServerEnabled(server_structs.DirectorType) {
 		if parsedUrl, err := url.Parse(originUrlStr); err == nil {
 			parsedUrl.Path = server_structs.OriginDataRoutePrefix
 			dataUrlToAdvertise = parsedUrl.String()

--- a/origin_serve/authz.go
+++ b/origin_serve/authz.go
@@ -109,7 +109,7 @@ func newAuthConfig(ctx context.Context, egrp *errgroup.Group) (ac *authConfig) {
 	// respectively) that must always be accepted.  In addition, the
 	// origin's own URL (Origin.TokenAudience, which defaults to
 	// Origin.Url) is accepted so that tokens scoped to this specific
-	// origin are honoured.
+	// origin are honored.
 	ac.audiences = []string{
 		"https://wlcg.cern.ch/jwt/v1/any", // WLCG wildcard
 		"ANY",                             // SciTokens wildcard
@@ -305,7 +305,7 @@ func (ac *authConfig) getResourceScopes(tokenStr string) (scopes []token_scopes.
 	// Validate the audience claim.  The WLCG Common JWT Profile and
 	// SciTokens specifications require that the resource server check
 	// the "aud" claim against its own identity (Origin.TokenAudience)
-	// or the recognised wildcard values.
+	// or the recognized wildcard values.
 	tokenAuds := tok.Audience()
 	if len(tokenAuds) > 0 && len(ac.audiences) > 0 {
 		audOK := false

--- a/origin_serve/authz_test.go
+++ b/origin_serve/authz_test.go
@@ -442,7 +442,7 @@ func TestAuthorizationWithDirtyPaths(t *testing.T) {
 		t.Run(dp.name, func(t *testing.T) {
 			_, authorized := ac.authorizeWithContext(ctx, token_scopes.Wlcg_Storage_Read, dp.resource, tok)
 			assert.True(t, authorized,
-				"dirty path %q should be authorized after path.Clean normalisation", dp.resource)
+				"dirty path %q should be authorized after path.Clean normalization", dp.resource)
 		})
 	}
 

--- a/origin_serve/backend_blob.go
+++ b/origin_serve/backend_blob.go
@@ -329,7 +329,7 @@ type blobFileSystem struct {
 	bucket *blob.Bucket
 }
 
-// blobKey normalises a webdav path ("/foo/bar") to a blob key ("foo/bar").
+// blobKey normalizes a webdav path ("/foo/bar") to a blob key ("foo/bar").
 // Also cleans path traversal sequences as defense-in-depth.
 func blobKey(name string) string {
 	return strings.TrimPrefix(path.Clean("/"+name), "/")
@@ -371,7 +371,7 @@ func (fs *blobFileSystem) OpenFile(ctx context.Context, name string, flag int, _
 	if _, peekErr := peekIter.Next(ctx); peekErr == nil {
 		// It is a directory — return a lazy dir handle (a fresh iterator
 		// will be created when Readdir is called). Carry the request context
-		// so the deferred listing honours cancellation/deadlines.
+		// so the deferred listing honors cancellation/deadlines.
 		return &blobDirFile{name: name, bucket: fs.bucket, prefix: dirPrefix, ctx: ctx}, nil
 	}
 

--- a/origin_serve/backend_pstore.go
+++ b/origin_serve/backend_pstore.go
@@ -1,0 +1,279 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// pstoreBackend — OriginBackend for the Pelican store.
+//
+// The store exposes an afero.Fs, so this is the same shape as the local POSIX
+// backend: wrap it in the shared aferoFileSystem adapter and hand the result
+// to the generic WebDAV handler.  See docs/pstore-design.md.
+
+package origin_serve
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/webdav"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/local_cache"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/pstore"
+	"github.com/pelicanplatform/pelican/server_utils"
+)
+
+// pstoreBackend serves an export from a pstore.Store.
+//
+// Several exports can share one store, each mapped onto a different subtree
+// through its StoragePrefix, so the backend does not own the store it uses.
+type pstoreBackend struct {
+	store         *pstore.Store
+	fs            webdav.FileSystem
+	storagePrefix string
+}
+
+// openStores holds the stores opened during handler initialization, keyed by
+// directory.
+//
+// A store takes an exclusive lock on its directory, so every export mapped
+// onto the same location must share one -- opening a second would simply fail.
+// InitializeHandlers runs single-threaded at startup, so a plain map suffices.
+var openStores = map[string]*pstore.Store{}
+
+// ResetPStoreState drops the shared stores between handler initializations.
+// Only tests re-initialize handlers within one process.
+func ResetPStoreState() {
+	openStores = map[string]*pstore.Store{}
+}
+
+// newPStoreBackend opens the store for an export and starts its janitor.
+//
+// The store is opened once per export.  Each export gets its own directory
+// tree, because a store assumes exclusive ownership of its directories.
+func newPStoreBackend(
+	ctx context.Context,
+	export server_utils.OriginExport,
+	logger func(*http.Request, error),
+) (*pstoreBackend, error) {
+	// The store spawns background workers (block-state flushing, the janitor)
+	// that must live as long as the server, so they join the process-wide
+	// error group the launcher stashes in the context.
+	egrp, ok := ctx.Value(config.EgrpKey).(*errgroup.Group)
+	if !ok {
+		return nil, errors.New("no error group in context; cannot start the pstore background workers")
+	}
+
+	dirs, err := local_cache.ParseStorageDirsValue(
+		param.Origin_PStoreStorageDirs.GetRaw(), param.Origin_PStoreStorageDirs.GetName())
+	if err != nil {
+		return nil, err
+	}
+
+	baseDir := param.Origin_PStoreLocation.GetString()
+	if baseDir == "" && len(dirs) > 0 {
+		// The catalog lives alongside the first data directory when no
+		// dedicated location is configured.
+		baseDir = dirs[0].Path
+	}
+	if baseDir == "" {
+		return nil, errors.Errorf("%s must be set when the origin storage type is 'pstore'",
+			param.Origin_PStoreLocation.GetName())
+	}
+
+	// Exports mapped onto the same directory share a store; the first one
+	// opens it and starts its background work.
+	store, opened := openStores[baseDir]
+	if !opened {
+		store, err = pstore.Open(ctx, egrp, pstore.Config{
+			BaseDir:        baseDir,
+			StorageDirs:    dirs,
+			InlineMaxBytes: param.Origin_PStoreInlineMaxBytes.GetInt(),
+			NamespaceLabel: baseDir,
+		})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to open the pstore at %s", baseDir)
+		}
+		openStores[baseDir] = store
+
+		// Reclamation runs for the life of the server; without it, superseded
+		// object versions and deleted subtrees would hold space indefinitely.
+		store.StartJanitor(ctx, egrp)
+
+		// Back up the metadata periodically.  Losing it is not recoverable
+		// the way a cache's database is: the block files are unreadable
+		// without it.
+		backupKeys, kErr := pstoreBackupKeys()
+		if kErr != nil {
+			return nil, kErr
+		}
+		store.StartBackups(ctx, egrp, pstore.BackupConfig{
+			Dir:      param.Origin_PStoreMetadataBackupLocation.GetString(),
+			Interval: param.Origin_PStoreMetadataBackupInterval.GetDuration(),
+			Keep:     param.Origin_PStoreMetadataBackupsToKeep.GetInt(),
+			Keys:     backupKeys,
+		})
+
+		// Check the store against itself on a schedule.  An origin needs this
+		// more than a cache does: a cache that finds a corrupt object
+		// re-fetches it, and an origin has nowhere to re-fetch from.
+		store.StartIntegrityChecks(ctx, egrp, pstore.IntegrityConfig{
+			IndexInterval:       param.Origin_PStoreIndexCheckInterval.GetDuration(),
+			DataInterval:        param.Origin_PStoreDataScanInterval.GetDuration(),
+			DataScanBytesPerSec: int64(param.Origin_PStoreDataScanRate.GetByteRate()),
+		})
+
+		// Close the store when the server context is cancelled.
+		//
+		// Nothing in the origin's shutdown path knows about backends, so
+		// without this the block store's TTL-cache workers -- which only stop
+		// on StorageManager.Close -- outlive the server and the process error
+		// group never drains, hanging shutdown indefinitely.
+		egrp.Go(func() error {
+			<-ctx.Done()
+			if cErr := store.Close(); cErr != nil {
+				log.Warnf("Failed to close the pstore at %s: %v", baseDir, cErr)
+			}
+			return nil
+		})
+	}
+
+	// The export's StoragePrefix is a logical subtree inside the store rather
+	// than a filesystem path, and the shared adapter already joins it onto
+	// every request path.
+	//
+	// pstore.FS creates missing parents itself rather than using the shared
+	// autoCreateDirFs wrapper: that wrapper derives the parent with filepath,
+	// and a pstore path is a namespace path that is always slash-separated,
+	// so on Windows it would ask for a directory named "\a\b\c".
+	fs := newAferoFileSystem(pstore.NewFS(store), export.StoragePrefix, logger)
+
+	return &pstoreBackend{store: store, fs: fs, storagePrefix: export.StoragePrefix}, nil
+}
+
+func (b *pstoreBackend) CheckAvailability() error      { return nil }
+func (b *pstoreBackend) FileSystem() webdav.FileSystem { return b.fs }
+
+// Checksummer serves Want-Digest from the checksums recorded at ingest.
+func (b *pstoreBackend) Checksummer() server_utils.OriginChecksummer {
+	return &pstoreChecksummer{store: b.store, storagePrefix: b.storagePrefix}
+}
+
+// pstoreChecksummer answers Want-Digest from stored metadata.
+//
+// Unlike the POSIX backend's xattr scheme this never reads the object: the
+// digests were computed while the bytes were being written, so the response
+// costs one metadata lookup no matter how large the object is.  The digests
+// also belong to the specific version, so an overwrite cannot leave a stale
+// value behind the way an mtime-validated xattr cache can.
+type pstoreChecksummer struct {
+	store         *pstore.Store
+	storagePrefix string
+}
+
+// GetDigests returns RFC 3230 digest strings for the algorithms the client
+// asked for, skipping any that were not recorded.
+func (c *pstoreChecksummer) GetDigests(relativePath string, wantDigest string) ([]string, error) {
+	if wantDigest == "" {
+		return nil, nil
+	}
+
+	// The store holds objects under the export's storage prefix, which the
+	// WebDAV layer strips before handing the path here.
+	//
+	// The join is re-confined rather than trusted: path.Join normalizes away
+	// any ".." in the relative path, so a HEAD for "/../two/secret.txt"
+	// resolved into a neighbouring export's subtree and this method answered
+	// with its real digests.  The handler now cleans the path before calling,
+	// but a checksum lookup that silently addresses another tenant's object is
+	// not something to leave depending on one caller doing the right thing.
+	full, err := confineToPrefix(c.storagePrefix, relativePath)
+	if err != nil {
+		log.Warnf("Refusing a digest lookup for %s: outside the export's storage prefix", relativePath)
+		return nil, err
+	}
+
+	stored, err := c.store.Digests(full)
+	if err != nil {
+		// A missing object or one written before checksums were recorded is
+		// not an error: the handler simply omits the Digest header.
+		log.Debugf("No stored digests for %s: %v", relativePath, err)
+		return nil, nil
+	}
+
+	byType := make(map[local_cache.ChecksumType]local_cache.Checksum, len(stored))
+	for _, c := range stored {
+		byType[c.Type] = c
+	}
+
+	var out []string
+	for _, alg := range strings.Split(wantDigest, ",") {
+		t, ok := local_cache.ParseChecksumAlgorithm(alg)
+		if !ok {
+			continue
+		}
+		if c, have := byType[t]; have {
+			// Naming and encoding come from local_cache so the origin cannot
+			// drift from the value the cache would report for the same bytes.
+			if entry := local_cache.FormatDigestEntry(c); entry != "" {
+				out = append(out, entry)
+			}
+		}
+	}
+	return out, nil
+}
+
+// Close releases the store this backend uses.
+//
+// Only safe when the backend is the sole user of that store, which is the
+// case in tests; in the server the store is shared between exports and closed
+// once, from the goroutine watching the server context.
+func (b *pstoreBackend) Close() error { return b.store.Close() }
+
+// HasCapacityFor implements server_utils.CapacityReporter so the origin can
+// refuse an oversized PUT with 507 before the client streams its body.
+func (b *pstoreBackend) HasCapacityFor(nBytes int64) error {
+	return b.store.HasCapacityFor(nBytes)
+}
+
+// pstoreBackupKeys resolves the keys metadata snapshots are sealed to.
+//
+// The store does not read configuration itself -- pstore deliberately does not
+// import config -- so the resolution happens here and the result is handed in.
+//
+// Every current issuer key is a recipient, which is what makes rotation free: a
+// snapshot written before a rotation still opens with either the key that has
+// since been retired or the one that was already present.  There is deliberately
+// no way to configure a different key: the scheme derives everything an operator
+// could need from the issuer keys, and the per-archive key an outside custodian
+// should be given is printed per file by `pelican-server origin pstore
+// metadata-backup-key <file>` rather than fixed for the whole series.
+func pstoreBackupKeys() (pstore.BackupKeys, error) {
+	issuerKeys := config.GetIssuerPrivateKeys()
+	if len(issuerKeys) == 0 && param.Origin_PStoreMetadataBackupLocation.GetString() != "" {
+		return pstore.BackupKeys{}, errors.Errorf(
+			"metadata backups are enabled (%s) but the origin has no issuer keys to "+
+				"derive a backup key from; a snapshot is a logical dump of the namespace "+
+				"and is never written unencrypted",
+			param.Origin_PStoreMetadataBackupLocation.GetName())
+	}
+	return pstore.BackupKeys{IssuerKeys: issuerKeys}, nil
+}

--- a/origin_serve/backend_pstore_test.go
+++ b/origin_serve/backend_pstore_test.go
@@ -1,0 +1,341 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package origin_serve
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/webdav"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/local_cache"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
+)
+
+// newPStoreTestBackend builds the backend the origin handler would build,
+// through the real configuration path.
+func newPStoreTestBackend(t *testing.T, storagePrefix string) *pstoreBackend {
+	t.Helper()
+	local_cache.InitIssuerKeyForTests(t)
+	ResetPStoreState()
+	t.Cleanup(ResetPStoreState)
+
+	require.NoError(t, param.Origin_PStoreLocation.Set(t.TempDir()))
+
+	baseCtx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	egrp, egrpCtx := errgroup.WithContext(baseCtx)
+	ctx := context.WithValue(egrpCtx, config.EgrpKey, egrp)
+
+	logger := func(*http.Request, error) {}
+	backend, err := newPStoreBackend(ctx, server_utils.OriginExport{
+		FederationPrefix: "/test",
+		StoragePrefix:    storagePrefix,
+	}, logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, backend.Close()) })
+	return backend
+}
+
+// TestPStoreBackendServesThroughWebDAV drives the store through the exact
+// webdav.FileSystem the origin handler is given, so the afero adapter, the
+// storage-prefix join, and the store all participate.
+func TestPStoreBackendServesThroughWebDAV(t *testing.T) {
+	backend := newPStoreTestBackend(t, "/")
+	fs := backend.FileSystem()
+	ctx := t.Context()
+
+	require.NoError(t, backend.CheckAvailability())
+
+	require.NoError(t, fs.Mkdir(ctx, "/data", 0755))
+
+	f, err := fs.OpenFile(ctx, "/data/object.txt", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	require.NoError(t, err)
+	_, err = f.Write([]byte("served from pstore"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	r, err := fs.OpenFile(ctx, "/data/object.txt", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	defer r.Close()
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Equal(t, "served from pstore", string(got))
+
+	fi, err := fs.Stat(ctx, "/data/object.txt")
+	require.NoError(t, err)
+	assert.Equal(t, int64(len("served from pstore")), fi.Size())
+
+	// The handler sets the ETag response header from this.
+	tagger, ok := fi.(webdav.ETager)
+	require.True(t, ok, "pstore FileInfo must implement webdav.ETager")
+	tag, err := tagger.ETag(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, tag)
+}
+
+// TestPStoreBackendPropfindListing covers the directory read the WebDAV
+// PROPFIND handler performs.
+func TestPStoreBackendPropfindListing(t *testing.T) {
+	backend := newPStoreTestBackend(t, "/")
+	fs := backend.FileSystem()
+	ctx := t.Context()
+
+	require.NoError(t, fs.Mkdir(ctx, "/dir", 0755))
+	for _, name := range []string{"c.txt", "a.txt", "b.txt"} {
+		f, err := fs.OpenFile(ctx, "/dir/"+name, os.O_WRONLY|os.O_CREATE, 0644)
+		require.NoError(t, err)
+		_, err = f.Write([]byte(name))
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+	}
+	require.NoError(t, fs.Mkdir(ctx, "/dir/sub", 0755))
+
+	d, err := fs.OpenFile(ctx, "/dir", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	defer d.Close()
+
+	infos, err := d.Readdir(-1)
+	require.NoError(t, err)
+	names := make([]string, len(infos))
+	for i, fi := range infos {
+		names[i] = fi.Name()
+	}
+	assert.Equal(t, []string{"a.txt", "b.txt", "c.txt", "sub"}, names,
+		"direct children only, in name order")
+}
+
+// TestPStoreBackendHonorsStoragePrefix checks that an export mapped onto a
+// subtree of the store sees only that subtree.
+func TestPStoreBackendHonorsStoragePrefix(t *testing.T) {
+	backend := newPStoreTestBackend(t, "/exports/one")
+	fs := backend.FileSystem()
+	ctx := t.Context()
+
+	// The adapter joins the prefix onto request paths, so the intermediate
+	// directories have to exist in the store first.
+	require.NoError(t, fs.Mkdir(ctx, "/", 0755))
+
+	f, err := fs.OpenFile(ctx, "/inside.txt", os.O_WRONLY|os.O_CREATE, 0644)
+	require.NoError(t, err)
+	_, err = f.Write([]byte("scoped"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// The object landed under the prefix in the underlying store, not at the
+	// store root.
+	d, err := backend.store.Stat("/exports/one/inside.txt")
+	require.NoError(t, err)
+	assert.Equal(t, int64(len("scoped")), d.Size)
+
+	_, err = backend.store.Stat("/inside.txt")
+	assert.Error(t, err, "nothing is written outside the export's prefix")
+}
+
+// TestPStoreBackendRemoveAndRename exercises DELETE and MOVE.
+func TestPStoreBackendRemoveAndRename(t *testing.T) {
+	backend := newPStoreTestBackend(t, "/")
+	fs := backend.FileSystem()
+	ctx := t.Context()
+
+	f, err := fs.OpenFile(ctx, "/a.txt", os.O_WRONLY|os.O_CREATE, 0644)
+	require.NoError(t, err)
+	_, err = f.Write([]byte("payload"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	require.NoError(t, fs.Rename(ctx, "/a.txt", "/b.txt"))
+	_, err = fs.Stat(ctx, "/a.txt")
+	assert.True(t, os.IsNotExist(err))
+
+	r, err := fs.OpenFile(ctx, "/b.txt", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	assert.Equal(t, "payload", string(got))
+
+	require.NoError(t, fs.RemoveAll(ctx, "/b.txt"))
+	_, err = fs.Stat(ctx, "/b.txt")
+	assert.True(t, os.IsNotExist(err))
+}
+
+// TestPStoreBackendRequiresEgrp documents why the context must carry the
+// process error group: the store starts background workers that outlive the
+// call.
+func TestPStoreBackendRequiresEgrp(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+	ResetPStoreState()
+	t.Cleanup(ResetPStoreState)
+	require.NoError(t, param.Origin_PStoreLocation.Set(t.TempDir()))
+
+	_, err := newPStoreBackend(t.Context(), server_utils.OriginExport{
+		FederationPrefix: "/test",
+		StoragePrefix:    "/",
+	}, func(*http.Request, error) {})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error group")
+}
+
+// TestPStoreBackendReportsCapacity checks the backend satisfies the optional
+// interface the PUT path uses to refuse an oversized upload up front.
+func TestPStoreBackendReportsCapacity(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+	ResetPStoreState()
+	t.Cleanup(ResetPStoreState)
+
+	dir := t.TempDir()
+	require.NoError(t, param.Origin_PStoreLocation.Set(dir))
+	// Shaped as viper delivers a YAML list of objects.
+	require.NoError(t, param.Origin_PStoreStorageDirs.Set([]any{
+		map[string]any{"Path": dir, "MaxSize": "256KB"},
+	}))
+	t.Cleanup(func() { _ = param.Origin_PStoreStorageDirs.Set(nil) })
+
+	baseCtx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	egrp, egrpCtx := errgroup.WithContext(baseCtx)
+	ctx := context.WithValue(egrpCtx, config.EgrpKey, egrp)
+
+	backend, err := newPStoreBackend(ctx, server_utils.OriginExport{
+		FederationPrefix: "/test",
+		StoragePrefix:    "/",
+	}, func(*http.Request, error) {})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, backend.Close()) })
+
+	reporter, ok := server_utils.OriginBackend(backend).(server_utils.CapacityReporter)
+	require.True(t, ok, "pstore must report capacity so PUT can pre-flight")
+
+	assert.NoError(t, reporter.HasCapacityFor(1024))
+
+	err = reporter.HasCapacityFor(10 << 20)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, syscall.ENOSPC,
+		"the refusal must be ENOSPC, which MapToHTTPStatus turns into 507")
+	assert.Equal(t, http.StatusInsufficientStorage, NewErrorHandler().MapToHTTPStatus(err))
+}
+
+// TestENOSPCMapsTo507 pins the error-to-status fix. ENOSPC was missing from
+// the syscall switch, so an out-of-space write fell through to the string
+// matcher and surfaced as a 500.
+func TestENOSPCMapsTo507(t *testing.T) {
+	eh := NewErrorHandler()
+
+	assert.Equal(t, http.StatusInsufficientStorage, eh.MapToHTTPStatus(syscall.ENOSPC))
+	assert.Equal(t, http.StatusInsufficientStorage, eh.MapToHTTPStatus(syscall.EDQUOT))
+	assert.Equal(t, http.StatusInsufficientStorage,
+		eh.MapToHTTPStatus(&os.PathError{Op: "write", Path: "/x", Err: syscall.ENOSPC}),
+		"the error arrives wrapped in a PathError from the filesystem layer")
+	assert.Equal(t, http.StatusInsufficientStorage,
+		eh.MapToHTTPStatus(errors.Wrap(syscall.ENOSPC, "the store is full")),
+		"and wrapped again with context by the store")
+}
+
+// TestPStoreBackendAutoCreatesParents covers the wrapper the POSIX backend
+// also relies on: clients PUT into prefixes that do not exist yet, without an
+// explicit MKCOL, and the write must create them rather than fail.
+func TestPStoreBackendAutoCreatesParents(t *testing.T) {
+	backend := newPStoreTestBackend(t, "/")
+	fs := backend.FileSystem()
+	ctx := t.Context()
+
+	f, err := fs.OpenFile(ctx, "/deep/nested/new/object.txt", os.O_WRONLY|os.O_CREATE, 0644)
+	require.NoError(t, err, "a PUT into a fresh prefix must create its parents")
+	_, err = f.Write([]byte("auto"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	got, err := backend.store.ReadAll("/deep/nested/new/object.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "auto", string(got))
+
+	di, err := fs.Stat(ctx, "/deep/nested")
+	require.NoError(t, err)
+	assert.True(t, di.IsDir())
+}
+
+// TestPStoreBackendsShareOneStore covers two exports mapped onto the same
+// store directory.
+//
+// A store takes an exclusive lock on its directory, so two independent opens
+// of one directory cannot both succeed. The exports therefore share a single
+// store, each scoped to its own subtree by StoragePrefix.
+func TestPStoreBackendsShareOneStore(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+	ResetPStoreState()
+	t.Cleanup(ResetPStoreState)
+	require.NoError(t, param.Origin_PStoreLocation.Set(t.TempDir()))
+
+	baseCtx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	egrp, egrpCtx := errgroup.WithContext(baseCtx)
+	ctx := context.WithValue(egrpCtx, config.EgrpKey, egrp)
+	logger := func(*http.Request, error) {}
+
+	first, err := newPStoreBackend(ctx, server_utils.OriginExport{
+		FederationPrefix: "/one", StoragePrefix: "/exports/one",
+	}, logger)
+	require.NoError(t, err)
+
+	second, err := newPStoreBackend(ctx, server_utils.OriginExport{
+		FederationPrefix: "/two", StoragePrefix: "/exports/two",
+	}, logger)
+	require.NoError(t, err, "a second export on the same store must not fail on the lock")
+	t.Cleanup(func() { assert.NoError(t, first.Close()) })
+
+	assert.Same(t, first.store, second.store, "both exports use one store")
+
+	// Each export writes into its own subtree and cannot see the other's.
+	writeThrough := func(b *pstoreBackend, name, body string) {
+		t.Helper()
+		f, wErr := b.FileSystem().OpenFile(ctx, name, os.O_WRONLY|os.O_CREATE, 0644)
+		require.NoError(t, wErr)
+		_, wErr = f.Write([]byte(body))
+		require.NoError(t, wErr)
+		require.NoError(t, f.Close())
+	}
+	writeThrough(first, "/data.txt", "from one")
+	writeThrough(second, "/data.txt", "from two")
+
+	oneBody, err := first.store.ReadAll("/exports/one/data.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "from one", string(oneBody))
+
+	twoBody, err := second.store.ReadAll("/exports/two/data.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "from two", string(twoBody))
+
+	// Neither export sees the other's object at its own path.
+	_, err = first.FileSystem().Stat(ctx, "/data.txt")
+	require.NoError(t, err)
+	fi, err := first.FileSystem().Stat(ctx, "/data.txt")
+	require.NoError(t, err)
+	assert.Equal(t, int64(len("from one")), fi.Size(), "each export is scoped to its prefix")
+}

--- a/origin_serve/error_handling.go
+++ b/origin_serve/error_handling.go
@@ -27,6 +27,8 @@ import (
 	"syscall"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/pelicanplatform/pelican/pstore"
 )
 
 // ErrorHandler manages consistent error handling and HTTP status code mapping
@@ -54,6 +56,7 @@ func NewErrorHandler() *ErrorHandler {
 
 			// Resource exhaustion
 			"disk quota exceeded":              http.StatusInsufficientStorage,
+			"no space left on device":          http.StatusInsufficientStorage,
 			"too many open files":              http.StatusServiceUnavailable,
 			"resource temporarily unavailable": http.StatusServiceUnavailable,
 
@@ -120,7 +123,10 @@ func (eh *ErrorHandler) MapToHTTPStatus(err error) int {
 			return http.StatusBadRequest
 		case syscall.EMFILE, syscall.ENFILE:
 			return http.StatusServiceUnavailable
-		case syscall.EDQUOT:
+		case syscall.EDQUOT, syscall.ENOSPC:
+			// ENOSPC is the canonical out-of-space error and was previously
+			// missing here, so it fell through to the string matcher and came
+			// out as a 500 rather than 507.
 			return http.StatusInsufficientStorage
 		case syscall.ECONNREFUSED:
 			return http.StatusServiceUnavailable
@@ -141,6 +147,48 @@ func (eh *ErrorHandler) MapToHTTPStatus(err error) int {
 
 	// Default to internal server error for unknown errors
 	return http.StatusInternalServerError
+}
+
+// statusForBackendError returns the HTTP status a backend error deserves, or
+// zero when the WebDAV handler's own status should stand.
+//
+// golang.org/x/net/webdav has a fixed, coarse mapping: every failed write is
+// 405 Method Not Allowed and every failed open is 404 or 409, whatever went
+// wrong underneath. That is actively misleading -- a full store, a subtree
+// still being reclaimed, and a failed compare-and-swap are all things a client
+// can act on, and "method not allowed" tells it to do the one thing that will
+// never help. Nothing in the request path used to consult MapToHTTPStatus at
+// all, so the ENOSPC-to-507 mapping below it existed only in tests.
+//
+// Only errors whose meaning is unambiguous are rewritten; anything else is
+// left to the WebDAV handler, so this cannot turn a correct status into a
+// worse one.
+//
+// conditional says the request carried If-Match or If-None-Match, which is
+// what distinguishes "the object already exists" as a failed precondition
+// (412) from an ordinary conflict (409).
+func statusForBackendError(err error, conditional bool) int {
+	if err == nil {
+		return 0
+	}
+	switch {
+	case errors.Is(err, syscall.ENOSPC), errors.Is(err, syscall.EDQUOT):
+		return http.StatusInsufficientStorage
+	case errors.Is(err, pstore.ErrPreconditionFailed):
+		return http.StatusPreconditionFailed
+	case errors.Is(err, pstore.ErrDraining), errors.Is(err, pstore.ErrConflict):
+		// Both mean "this will work if you try again shortly", which is what
+		// 409 tells a client -- and is a great deal more useful than the 500
+		// an opaque index-transaction error would otherwise produce.
+		return http.StatusConflict
+	case errors.Is(err, fs.ErrPermission):
+		// A path refused by the export's containment check, among others.
+		return http.StatusForbidden
+	case conditional && errors.Is(err, fs.ErrExist):
+		// "If-None-Match: *" lost the race to a concurrent create.
+		return http.StatusPreconditionFailed
+	}
+	return 0
 }
 
 // LogError logs an error with appropriate context

--- a/origin_serve/etag_test.go
+++ b/origin_serve/etag_test.go
@@ -161,8 +161,12 @@ func newTestGetServer(t *testing.T, storageDir string) *httptest.Server {
 		LockSystem: webdav.NewMemLS(),
 		Prefix:     "/test",
 	}
+	// The host-filesystem fast paths (ETag, conditional GET, browser
+	// directory listing) only run for a backend whose StoragePrefix really is
+	// a directory here, which is exactly what a POSIX backend is.
+	backend := newLocalBackend(wd.FileSystem, storageDir)
 	r.GET("/test/*path", func(c *gin.Context) {
-		handleGetWithETag(c, wd, c.Request, c.Param("path"), storageDir)
+		handleGetWithETag(c, wd, c.Request, c.Param("path"), backend, storageDir)
 	})
 	return httptest.NewServer(r)
 }

--- a/origin_serve/filesystem.go
+++ b/origin_serve/filesystem.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -37,10 +38,226 @@ import (
 	"github.com/pelicanplatform/pelican/metrics"
 )
 
+// SizeHintFs is optionally implemented by an afero.Fs whose write path can do
+// better when the object's final size is known up front.
+//
+// afero.Fs has no context and no size argument, so a backend that would
+// benefit -- pstore picks its storage tier from the size, and buffers to
+// discover it otherwise -- cannot see the Content-Length the handler already
+// has. This carries it across that gap.
+//
+// A size of -1 means unknown, which is what a chunked-encoding PUT gives.
+type SizeHintFs interface {
+	OpenFileSized(name string, flag int, perm os.FileMode, size int64) (afero.File, error)
+}
+
+// ConditionalWriteFs is optionally implemented by an afero.Fs that can enforce
+// an HTTP conditional-write precondition (RFC 9110 §13.1) atomically, at the
+// moment the new version is installed.
+//
+// checkPutPreconditions evaluates If-Match / If-None-Match before the write
+// begins, which is inherently a stat-then-write race: two concurrent
+// "If-None-Match: *" PUTs both observe an absent object and both commit. A
+// backend that can re-check the condition inside its commit transaction --
+// pstore does -- closes that race, so the handler hands the parsed condition
+// down here rather than keeping it to itself.
+//
+// The condition is expressed with plain scalars rather than a shared struct so
+// that a backend package does not have to import origin_serve to implement it.
+// requireAbsent is "If-None-Match: *"; requireETag is a single-tag "If-Match",
+// carrying the entity tag exactly as the client sent it (the backend, which
+// minted it, is the only layer that knows how to interpret it). size is the
+// Content-Length hint, or -1 when unknown, matching SizeHintFs.
+type ConditionalWriteFs interface {
+	OpenFileConditional(name string, flag int, perm os.FileMode, size int64,
+		requireAbsent bool, requireETag string) (afero.File, error)
+}
+
+// writeCondition is a parsed conditional-write precondition on its way from
+// the PUT handler to a ConditionalWriteFs.
+type writeCondition struct {
+	// requireAbsent demands the object not exist (If-None-Match: *).
+	requireAbsent bool
+	// requireETag demands the object still carry this entity tag (If-Match
+	// with exactly one tag; a list or "*" cannot be expressed).
+	requireETag string
+}
+
+// isSet reports whether anything needs to be enforced at commit.
+func (wc writeCondition) isSet() bool {
+	return wc.requireAbsent || wc.requireETag != ""
+}
+
+type writeConditionKey struct{}
+
+// contextWithWriteCondition carries a precondition down to the filesystem.
+//
+// afero.Fs has neither a context nor a place for this, so it travels the same
+// way the content-length hint does (see ContextWithContentLength): the WebDAV
+// handler passes the request context straight to FileSystem.OpenFile.
+func contextWithWriteCondition(ctx context.Context, cond writeCondition) context.Context {
+	return context.WithValue(ctx, writeConditionKey{}, cond)
+}
+
+// writeConditionFromCtx returns the precondition attached to ctx, if any.
+func writeConditionFromCtx(ctx context.Context) (writeCondition, bool) {
+	cond, ok := ctx.Value(writeConditionKey{}).(writeCondition)
+	return cond, ok && cond.isSet()
+}
+
+// writeAborter is implemented by a backend file whose Close would otherwise
+// commit whatever bytes happened to arrive.
+//
+// golang.org/x/net/webdav's handlePut calls f.Close() before it looks at the
+// error from io.Copy, so a client that disconnects halfway through an
+// overwrite has its truncated body committed over the previous version. A
+// backend that builds a new version and swaps it in at Close -- pstore -- can
+// discard it instead, but only if it is told the write failed before Close
+// runs.
+type writeAborter interface {
+	// AbortWrite records that the data written so far is incomplete, so that
+	// Close discards the pending version rather than installing it.
+	AbortWrite(err error)
+}
+
+// writeGuard connects a failed request-body read to the open backend file.
+//
+// The failure is observed by the handler (reading r.Body) and has to be acted
+// on by the filesystem (closing the file), and neither has a reference to the
+// other: webdav.handlePut opens the file itself, from a context the handler
+// supplied. The guard is that reference, planted in the context on the way
+// down and populated by aferoFileSystem.OpenFile on the way back.
+type writeGuard struct {
+	mu   sync.Mutex
+	file writeAborter
+	err  error
+}
+
+// register records the file a PUT is writing to. A failure that arrived before
+// the file was opened is applied immediately, so the two orderings agree.
+func (g *writeGuard) register(f afero.File) {
+	aborter, ok := f.(writeAborter)
+	if !ok {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.file = aborter
+	if g.err != nil {
+		aborter.AbortWrite(g.err)
+	}
+}
+
+// fail marks the write as incomplete.
+func (g *writeGuard) fail(err error) {
+	if err == nil {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.err == nil {
+		g.err = err
+	}
+	if g.file != nil {
+		g.file.AbortWrite(err)
+	}
+}
+
+// failed reports whether the body read failed.
+func (g *writeGuard) failed() error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.err
+}
+
+type writeGuardKey struct{}
+
+// contextWithWriteGuard attaches a guard so the filesystem can register the
+// file it opens for this request.
+func contextWithWriteGuard(ctx context.Context, g *writeGuard) context.Context {
+	return context.WithValue(ctx, writeGuardKey{}, g)
+}
+
+// writeGuardFromCtx returns the guard attached to ctx, if any.
+func writeGuardFromCtx(ctx context.Context) *writeGuard {
+	g, _ := ctx.Value(writeGuardKey{}).(*writeGuard)
+	return g
+}
+
+// guardedBody records a request-body read failure on the guard, so that the
+// file the body was being copied into is discarded rather than committed.
+type guardedBody struct {
+	io.ReadCloser
+	guard *writeGuard
+}
+
+func (b *guardedBody) Read(p []byte) (int, error) {
+	n, err := b.ReadCloser.Read(p)
+	if err != nil && err != io.EOF {
+		b.guard.fail(err)
+	}
+	return n, err
+}
+
 // autoCreateDirFs wraps an afero.Fs to automatically create parent directories
 // when opening a file for writing
 type autoCreateDirFs struct {
 	afero.Fs
+}
+
+// OpenFileSized forwards the size hint to the wrapped filesystem, creating
+// parent directories on the same terms as OpenFile.
+//
+// Without this the wrapper would silently swallow the hint for every backend
+// it wraps, since a type assertion against autoCreateDirFs would fail.
+func (fs *autoCreateDirFs) OpenFileSized(name string, flag int, perm os.FileMode, size int64) (afero.File, error) {
+	inner, ok := fs.Fs.(SizeHintFs)
+	if !ok {
+		return fs.OpenFile(name, flag, perm)
+	}
+
+	file, err := inner.OpenFileSized(name, flag, perm, size)
+	if err != nil && os.IsNotExist(err) && (flag&os.O_CREATE != 0 || flag&os.O_WRONLY != 0 || flag&os.O_RDWR != 0) {
+		dir := filepath.Dir(name)
+		if dir != "" && dir != "." && dir != "/" {
+			if mkdirErr := fs.Fs.MkdirAll(dir, 0755); mkdirErr == nil {
+				file, err = inner.OpenFileSized(name, flag, perm, size)
+			}
+		}
+	}
+	return file, err
+}
+
+// OpenFileConditional forwards a conditional write, creating parent
+// directories on the same terms as OpenFile.
+//
+// As with OpenFileSized, the wrapper has to forward explicitly: a type
+// assertion against autoCreateDirFs would fail and the condition would be
+// silently dropped, which is the one outcome a conditional write must never
+// have.
+func (fs *autoCreateDirFs) OpenFileConditional(name string, flag int, perm os.FileMode, size int64,
+	requireAbsent bool, requireETag string) (afero.File, error) {
+	inner, ok := fs.Fs.(ConditionalWriteFs)
+	if !ok {
+		if size >= 0 {
+			return fs.OpenFileSized(name, flag, perm, size)
+		}
+		return fs.OpenFile(name, flag, perm)
+	}
+
+	open := func() (afero.File, error) {
+		return inner.OpenFileConditional(name, flag, perm, size, requireAbsent, requireETag)
+	}
+	file, err := open()
+	if err != nil && os.IsNotExist(err) && (flag&os.O_CREATE != 0 || flag&os.O_WRONLY != 0 || flag&os.O_RDWR != 0) {
+		dir := filepath.Dir(name)
+		if dir != "" && dir != "." && dir != "/" {
+			if mkdirErr := fs.Fs.MkdirAll(dir, 0755); mkdirErr == nil {
+				file, err = open()
+			}
+		}
+	}
+	return file, err
 }
 
 // newAutoCreateDirFs creates a new filesystem that auto-creates parent directories
@@ -185,14 +402,20 @@ func (afs *aferoFileSystem) Mkdir(ctx context.Context, name string, perm os.File
 		slowHistogram: metrics.StorageSlowMkdirTime,
 	}, usernameFromContext(ctx))()
 
-	fullPath := afs.fullPath(name)
+	fullPath, err := afs.fullPath(name)
+	if err != nil {
+		return err
+	}
 	// Use webdav logger if available
 	return afs.fs.MkdirAll(fullPath, perm)
 }
 
 // OpenFile implements webdav.FileSystem
 func (afs *aferoFileSystem) OpenFile(ctx context.Context, name string, flag int, perm os.FileMode) (webdav.File, error) {
-	fullPath := afs.fullPath(name)
+	fullPath, pathErr := afs.fullPath(name)
+	if pathErr != nil {
+		return nil, pathErr
+	}
 	username := usernameFromContext(ctx)
 	if afs.logger != nil {
 		afs.logger(nil, nil) // Use the logger provided by webdav
@@ -235,7 +458,10 @@ func (afs *aferoFileSystem) OpenFile(ctx context.Context, name string, flag int,
 		}
 	}
 
-	file, err := afs.fs.OpenFile(fullPath, flag, perm)
+	// Hand the backend the expected size when the handler knows it and the
+	// filesystem can use it, and the conditional-write precondition when the
+	// handler parsed one.  Everything else behaves exactly as before.
+	file, err := afs.openBacking(ctx, fullPath, flag, perm)
 	if err != nil {
 		if flag&(os.O_WRONLY|os.O_RDWR|os.O_CREATE|os.O_TRUNC) != 0 {
 			metrics.StorageOpenErrorsTotal.WithLabelValues(metrics.BackendPOSIXv2, username).Inc()
@@ -254,6 +480,14 @@ func (afs *aferoFileSystem) OpenFile(ctx context.Context, name string, flag int,
 		if issuer, ok := ctx.Value(issuerContextKey{}).(string); ok && issuer != "" {
 			userID = fmt.Sprintf("%s@%s", userID, issuer)
 		}
+	}
+
+	// Let a failed request body reach this file, so a PUT that dies mid-stream
+	// is discarded instead of being committed by webdav's unconditional
+	// f.Close().  The raw backend file is registered rather than a wrapper:
+	// the wrappers below are this package's and know nothing about aborting.
+	if guard := writeGuardFromCtx(ctx); guard != nil {
+		guard.register(file)
 	}
 
 	// Wrap the file with metrics tracking
@@ -279,8 +513,34 @@ func (afs *aferoFileSystem) RemoveAll(ctx context.Context, name string) error {
 		slowHistogram: metrics.StorageSlowUnlinkTime,
 	}, usernameFromContext(ctx))()
 
-	fullPath := afs.fullPath(name)
+	fullPath, err := afs.fullPath(name)
+	if err != nil {
+		return err
+	}
 	return afs.fs.RemoveAll(fullPath)
+}
+
+// openBacking opens the underlying file, using the richest interface the
+// backend implements: a conditional write when the request carried a
+// precondition, a size-hinted write when the handler knows the length, and a
+// plain OpenFile otherwise.
+func (afs *aferoFileSystem) openBacking(ctx context.Context, fullPath string, flag int, perm os.FileMode) (afero.File, error) {
+	hint := contentLengthFromCtx(ctx)
+
+	if cond, ok := writeConditionFromCtx(ctx); ok {
+		if conditional, can := afs.fs.(ConditionalWriteFs); can {
+			return conditional.OpenFileConditional(fullPath, flag, perm, hint,
+				cond.requireAbsent, cond.requireETag)
+		}
+		// The backend cannot enforce the condition at commit; the handler's
+		// early check already rejected the common case, and there is nothing
+		// further this layer can do.
+	}
+
+	if sized, ok := afs.fs.(SizeHintFs); ok && hint >= 0 {
+		return sized.OpenFileSized(fullPath, flag, perm, hint)
+	}
+	return afs.fs.OpenFile(fullPath, flag, perm)
 }
 
 // Rename implements webdav.FileSystem
@@ -292,8 +552,14 @@ func (afs *aferoFileSystem) Rename(ctx context.Context, oldName, newName string)
 		slowHistogram: metrics.StorageSlowRenameTime,
 	}, usernameFromContext(ctx))()
 
-	oldPath := afs.fullPath(oldName)
-	newPath := afs.fullPath(newName)
+	oldPath, err := afs.fullPath(oldName)
+	if err != nil {
+		return err
+	}
+	newPath, err := afs.fullPath(newName)
+	if err != nil {
+		return err
+	}
 	return afs.fs.Rename(oldPath, newPath)
 }
 
@@ -306,16 +572,55 @@ func (afs *aferoFileSystem) Stat(ctx context.Context, name string) (os.FileInfo,
 		slowHistogram: metrics.StorageSlowStatTime,
 	}, usernameFromContext(ctx))()
 
-	fullPath := afs.fullPath(name)
+	fullPath, err := afs.fullPath(name)
+	if err != nil {
+		return nil, err
+	}
 	return afs.fs.Stat(fullPath)
 }
 
-// fullPath converts a webdav path to a full filesystem path
-func (afs *aferoFileSystem) fullPath(name string) string {
+// fullPath converts a WebDAV path to a full filesystem path, refusing any that
+// would leave the export's storage prefix.
+//
+// This is the containment boundary for every prefix-joined backend, and it has
+// to be, because there is nothing behind it: pstore's prefix is a logical
+// namespace path, so there is no os.Root to catch an escape the way the POSIX
+// backend has. golang.org/x/net/webdav cleans the request *path* but hands the
+// Destination header of a COPY or MOVE to Rename / RemoveAll / OpenFile after
+// no more than a strings.TrimPrefix, so "Destination: /<prefix>/../../other"
+// arrived here with its dot-segments intact and path.Join happily resolved it
+// into a neighbouring export -- with MOVE's RFC 4918 §9.9.3 "DELETE the
+// destination first" turning that into cross-tenant data loss.
+//
+// The check mirrors the one handleCopyTPC already applies to its own
+// destination (see tpc_handler.go): normalize, then require the result to
+// still lie under the prefix.
+func (afs *aferoFileSystem) fullPath(name string) (string, error) {
 	if afs.prefix == "" {
-		return name
+		// Nothing to escape: this filesystem is already rooted at the export
+		// (server_utils.NewOsRootFs, a BasePathFs, or a remote endpoint), and
+		// that root is what confines it.
+		return name, nil
 	}
-	return path.Join(afs.prefix, name)
+	return confineToPrefix(afs.prefix, name)
+}
+
+// confineToPrefix joins a request-relative path onto a storage prefix and
+// refuses any result that does not remain under it.
+//
+// It is shared by every place that maps an untrusted, request-supplied path
+// into a prefixed namespace -- the WebDAV filesystem above and the pstore
+// checksummer -- because "path.Join normalizes the dot-segments away and lands
+// somewhere else" is the same bug wherever it appears.
+func confineToPrefix(prefix, name string) (string, error) {
+	cleanPrefix := path.Clean("/" + strings.TrimPrefix(prefix, "/"))
+	joined := path.Join(cleanPrefix, name)
+	if !hasPathPrefix(joined, cleanPrefix) {
+		// os.ErrPermission rather than ErrNotExist: the path is refused, and
+		// saying "not found" for a path that may well exist invites probing.
+		return "", &os.PathError{Op: "open", Path: name, Err: os.ErrPermission}
+	}
+	return joined, nil
 }
 
 // aferoFile wraps an afero.File to implement webdav.File

--- a/origin_serve/handlers.go
+++ b/origin_serve/handlers.go
@@ -22,10 +22,12 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"html"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"sort"
@@ -149,7 +151,7 @@ func (mrr *metricsRequestReader) Close() error {
 // and Cache-Control headers are set before response headers are flushed.
 // The Cache-Control value is driven by the Origin.CacheControl configuration
 // parameter.  When empty (the default), no Cache-Control header is set,
-// matching the behaviour of a plain XRootD origin.
+// matching the behavior of a plain XRootD origin.
 type etagResponseWriter struct {
 	http.ResponseWriter
 	etag         string
@@ -657,6 +659,16 @@ func InitializeHandlers(ctx context.Context, exports []server_utils.OriginExport
 			}
 			backend = sshBackend
 
+		case server_structs.OriginStoragePStore:
+			// Pelican store: an encrypted block store on local disk, served
+			// through the same afero adapter as the POSIX backend.
+			psBackend, psErr := newPStoreBackend(ctx, export, logger)
+			if psErr != nil {
+				return fmt.Errorf("failed to create pstore backend for %s: %w", export.FederationPrefix, psErr)
+			}
+			backend = psBackend
+			log.Infof("Initialized pstore backend for %s", export.FederationPrefix)
+
 		case server_structs.OriginStorageS3v2:
 			// Native blob backend (S3, GCS, Azure) via gocloud.dev/blob
 			blobURL := param.Origin_ObjectProviderURL.GetString()
@@ -841,6 +853,134 @@ func InitializeHandlers(ctx context.Context, exports []server_utils.OriginExport
 	return nil
 }
 
+// exportRequestHandler builds the Gin handler that serves one export.
+//
+// It is a named function rather than a closure inside RegisterHandlers so that
+// the dispatch it performs -- path cleaning, the capacity and precondition
+// pre-flight, destination validation, and the choice of WebDAV entry point --
+// can be exercised on a test engine without standing up a federation.
+func exportRequestHandler(backend server_utils.OriginBackend, handler *webdav.Handler,
+	federationPrefix, routePrefix string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Ask the backend whether it can serve requests right now.
+		if err := backend.CheckAvailability(); err != nil {
+			statusCode := http.StatusServiceUnavailable
+			if sc, ok := err.(server_utils.HTTPStatusCoder); ok {
+				statusCode = sc.HTTPStatusCode()
+			}
+			c.AbortWithStatusJSON(statusCode, gin.H{"error": err.Error()})
+			return
+		}
+
+		// Get the path relative to the export (strip the federation prefix)
+		wildcardPath := c.Param("path")
+
+		// Clean the path to prevent traversal attacks via
+		// URL-encoded dot-dot sequences (%2e%2e). Without
+		// this, a request like /prefix/%2e%2e/secret reaches
+		// the backend with ".." intact, potentially escaping
+		// the storage root.
+		newPath := path.Clean(wildcardPath)
+		// path.Clean("") == "." and path.Clean("/") == "/"; collapse the
+		// degenerate "." back to "/" so the URL we hand the WebDAV
+		// handler stays well-formed.
+		if newPath == "." {
+			newPath = "/"
+		}
+
+		// path.Clean also strips a trailing separator, which the WebDAV
+		// handler does not care about but a directory URL does: the browser
+		// listing titles itself with this path and a client resolves relative
+		// links against it, so "/dir" and "/dir/" are not interchangeable.
+		// Restore the slash for the handlers that render it. Doing so cannot
+		// reintroduce traversal -- the dot-segments are already gone by here,
+		// and "/a/../b/" has become "/b/".
+		relPath := newPath
+		if newPath != "/" && strings.HasSuffix(wildcardPath, "/") {
+			relPath += "/"
+		}
+
+		// Create a shallow copy of the request and modify its URL.
+		// The WebDAV handler's stripPrefix relies on URL.Path still
+		// starting with handler.Prefix (= routePrefix), so put the
+		// route prefix back on. Keeping the prefix here also keeps
+		// PROPFIND href values aligned with the public URL.
+		modifiedReq := c.Request.Clone(c.Request.Context())
+		modifiedURL := *c.Request.URL
+		modifiedURL.Path = routePrefix + newPath
+		modifiedReq.URL = &modifiedURL
+
+		// Stash client tracing headers (X-Pelican-JobId,
+		// X-Pelican-Timeout) in the request context so backends
+		// that forward requests can propagate them.
+		modifiedReq = server_utils.StashPelicanHeaders(modifiedReq)
+
+		// For PUT requests, pass the Content-Length as a size hint
+		// so the blob backend can optimize upload part sizes.
+		if c.Request.Method == http.MethodPut && c.Request.ContentLength > 0 {
+			ctx := ContextWithContentLength(modifiedReq.Context(), c.Request.ContentLength)
+			modifiedReq = modifiedReq.WithContext(ctx)
+		}
+
+		// Every one of these is handed newPath, the cleaned path, rather
+		// than the raw wildcard: a request for "/%2e%2e/other" arrives
+		// with its dot-segments intact (Gin and net/http do not normalize
+		// them), and a backend that joins the path onto a storage prefix
+		// resolves them into a neighbouring export.
+		if isTPCRequest(c.Request) {
+			handleCopyTPC(c, backend, federationPrefix)
+		} else if c.Request.Method == http.MethodHead {
+			// For HEAD requests, pass the modified request to the WebDAV
+			// handler (it needs the full URL so its Prefix stripping works
+			// correctly). newPath is used only for checksum lookup.
+			handleHeadWithChecksum(c, handler, modifiedReq, relPath, backend)
+		} else if c.Request.Method == http.MethodGet {
+			// For GET requests, add ETag header based on file metadata
+			handleGetWithETag(c, handler, modifiedReq, relPath, backend, exportPrefixMap[federationPrefix])
+		} else if c.Request.Method == http.MethodPut {
+			// Refuse a PUT that cannot fit before the client streams a
+			// body the backend would only discard.  The WebDAV handler
+			// reports a mid-stream write failure as 405 Method Not
+			// Allowed, which tells the client nothing useful; catching it
+			// here yields a correct 507 with a reason.
+			if !checkBackendCapacity(c, backend) {
+				return
+			}
+			// Evaluate If-Match / If-None-Match, which the WebDAV
+			// handler does not implement. Ignoring them silently would
+			// leave a client believing it had compare-and-swap
+			// protection it never got.
+			cond, ok := checkPutPreconditions(c, backend, newPath)
+			if !ok {
+				return
+			}
+			if cond.isSet() {
+				// Carry the condition to the backend so it can re-check it
+				// at commit; the check above is only the fast path.
+				modifiedReq = modifiedReq.WithContext(
+					contextWithWriteCondition(modifiedReq.Context(), cond))
+			}
+			// For PUT requests, return ETag of the newly written file
+			handlePutWithETag(c, handler, modifiedReq, relPath, backend,
+				exportPrefixMap[federationPrefix], cond.isSet())
+		} else {
+			// COPY and MOVE name their target in a header the WebDAV
+			// handler neither cleans nor authorizes, so both have to
+			// happen here.
+			if c.Request.Method == "COPY" || c.Request.Method == "MOVE" {
+				if !checkCopyMoveDestination(c, routePrefix, federationPrefix) {
+					return
+				}
+			}
+			// For all other methods (including PROPFIND), pass the modified
+			// request to the WebDAV handler. The handler's Prefix field
+			// ensures it strips the route prefix for filesystem access
+			// while using it to construct correct href values in responses.
+			serveWebDAVMethod(c, handler, modifiedReq)
+		}
+	}
+}
+
 // RegisterHandlers registers the HTTP handlers with the Gin engine.
 // When the director is also running in the same server, handlers are registered
 // under /api/v1.0/origin/<prefix> so the director can distinguish between its routing
@@ -879,76 +1019,7 @@ func RegisterHandlers(engine *gin.Engine, directorEnabled bool) error {
 		group.Use(xrdMonitoringMiddleware())
 
 		// Create a handler function for all requests
-		handleRequest := func(c *gin.Context) {
-			// Ask the backend whether it can serve requests right now.
-			if err := backend.CheckAvailability(); err != nil {
-				statusCode := http.StatusServiceUnavailable
-				if sc, ok := err.(server_utils.HTTPStatusCoder); ok {
-					statusCode = sc.HTTPStatusCode()
-				}
-				c.AbortWithStatusJSON(statusCode, gin.H{"error": err.Error()})
-				return
-			}
-
-			// Get the path relative to the export (strip the federation prefix)
-			wildcardPath := c.Param("path")
-
-			// Clean the path to prevent traversal attacks via
-			// URL-encoded dot-dot sequences (%2e%2e). Without
-			// this, a request like /prefix/%2e%2e/secret reaches
-			// the backend with ".." intact, potentially escaping
-			// the storage root.
-			newPath := path.Clean(wildcardPath)
-			// path.Clean("") == "." and path.Clean("/") == "/"; collapse the
-			// degenerate "." back to "/" so the URL we hand the WebDAV
-			// handler stays well-formed.
-			if newPath == "." {
-				newPath = "/"
-			}
-
-			// Create a shallow copy of the request and modify its URL.
-			// The WebDAV handler's stripPrefix relies on URL.Path still
-			// starting with handler.Prefix (= routePrefix), so put the
-			// route prefix back on. Keeping the prefix here also keeps
-			// PROPFIND href values aligned with the public URL.
-			modifiedReq := c.Request.Clone(c.Request.Context())
-			modifiedURL := *c.Request.URL
-			modifiedURL.Path = routePrefix + newPath
-			modifiedReq.URL = &modifiedURL
-
-			// Stash client tracing headers (X-Pelican-JobId,
-			// X-Pelican-Timeout) in the request context so backends
-			// that forward requests can propagate them.
-			modifiedReq = server_utils.StashPelicanHeaders(modifiedReq)
-
-			// For PUT requests, pass the Content-Length as a size hint
-			// so the blob backend can optimize upload part sizes.
-			if c.Request.Method == http.MethodPut && c.Request.ContentLength > 0 {
-				ctx := ContextWithContentLength(modifiedReq.Context(), c.Request.ContentLength)
-				modifiedReq = modifiedReq.WithContext(ctx)
-			}
-
-			if isTPCRequest(c.Request) {
-				handleCopyTPC(c, backend, prefix)
-			} else if c.Request.Method == http.MethodHead {
-				// For HEAD requests, pass the original request to the WebDAV handler
-				// (it needs the full URL so its Prefix stripping works correctly).
-				// wildcardPath is used only for checksum lookup on the filesystem.
-				handleHeadWithChecksum(c, handler, modifiedReq, wildcardPath, backend)
-			} else if c.Request.Method == http.MethodGet {
-				// For GET requests, add ETag header based on file metadata
-				handleGetWithETag(c, handler, modifiedReq, wildcardPath, exportPrefixMap[prefix])
-			} else if c.Request.Method == http.MethodPut {
-				// For PUT requests, return ETag of the newly written file
-				handlePutWithETag(c, handler, modifiedReq, wildcardPath, exportPrefixMap[prefix])
-			} else {
-				// For all other methods (including PROPFIND), pass the original request
-				// to the WebDAV handler. The handler's Prefix field ensures it strips
-				// the route prefix for filesystem access while using it to construct
-				// correct href values in responses.
-				handler.ServeHTTP(c.Writer, modifiedReq)
-			}
-		}
+		handleRequest := exportRequestHandler(backend, handler, prefix, routePrefix)
 
 		// Register handler for standard HTTP methods
 		group.Any("/*path", handleRequest)
@@ -969,6 +1040,172 @@ func RegisterHandlers(engine *gin.Engine, directorEnabled bool) error {
 
 	handlersRegistered = true
 	return nil
+}
+
+// checkCopyMoveDestination validates and authorizes the Destination header of
+// a COPY or MOVE.  It returns true when the request should proceed and
+// otherwise writes the response itself.
+//
+// golang.org/x/net/webdav does neither. Its handleCopyMove takes the
+// destination's URL path, strips the handler's prefix with a bare
+// strings.TrimPrefix, and hands the remainder to Rename, OpenFile, and --
+// because RFC 4918 §9.9.3 requires MOVE to delete an existing destination
+// first -- RemoveAll. Nothing along that path cleans the dot-segments or asks
+// whether the caller may write where they point. A client holding
+// storage.modify on one export could therefore aim a MOVE at another export's
+// subtree and have it deleted, and COPY defaults to Overwrite: T so it needed
+// no header at all.
+//
+// aferoFileSystem.fullPath now refuses such a path outright, which is the
+// durable fix; this adds the two things only the handler knows. First, the
+// destination must lie inside this export's route, since the WebDAV handler is
+// bound to a single export's filesystem and a path outside it cannot be served
+// correctly under any interpretation. Second, the destination is authorized in
+// its own right: authMiddleware only ever authorized the request path, so a
+// token scoped to one subtree could write to another, including one whose
+// export is configured Writes: false.
+func checkCopyMoveDestination(c *gin.Context, routePrefix, federationPrefix string) bool {
+	hdr := c.GetHeader("Destination")
+	if hdr == "" {
+		// The WebDAV handler reports the missing header itself (400).
+		return true
+	}
+	u, err := url.Parse(hdr)
+	if err != nil || u.Path == "" {
+		// Likewise for an unparsable or empty destination (400 / 502).
+		return true
+	}
+	if u.Host != "" && u.Host != c.Request.Host {
+		// Likewise for a foreign host (502).
+		return true
+	}
+
+	dst := path.Clean(u.Path)
+	if !hasPathPrefix(dst, routePrefix) {
+		log.Warnf("Refusing %s to %q: destination is outside the export at %s",
+			c.Request.Method, hdr, routePrefix)
+		c.String(http.StatusForbidden, "Destination is outside the export")
+		return false
+	}
+
+	ac := GetAuthConfig()
+	if ac == nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+			"error":  "internal_error",
+			"detail": "auth config not initialized",
+		})
+		return false
+	}
+
+	// Token scopes are expressed against federation paths, so map the route
+	// path back before asking.
+	resource := path.Join(federationPrefix, strings.TrimPrefix(dst, routePrefix))
+	action := getActionFromMethod(c.Request.Method)
+	for _, tok := range extractTokens(c.Request) {
+		if ac.authorize(action, resource, tok) {
+			return true
+		}
+	}
+
+	log.Warnf("Refusing %s to %s: no token authorizes %s on the destination",
+		c.Request.Method, resource, action)
+	c.String(http.StatusForbidden, "Not authorized to write to the destination")
+	return false
+}
+
+// serveWebDAVMethod runs the WebDAV handler for a method other than GET, HEAD,
+// or PUT, correcting the status where the handler's own mapping is wrong.
+//
+// The correction is only applied to methods whose response body is small and
+// bounded. PROPFIND can enumerate an entire subtree and GET streams object
+// data, and neither can be buffered to hold the status open.
+func serveWebDAVMethod(c *gin.Context, handler *webdav.Handler, req *http.Request) {
+	switch req.Method {
+	case http.MethodDelete, "COPY", "MOVE", "MKCOL":
+		dw := &deferredHeaderWriter{ResponseWriter: c.Writer}
+		serveWebDAV(dw, handler, req, false)
+		dw.Flush()
+	default:
+		handler.ServeHTTP(c.Writer, req)
+	}
+}
+
+// serveWebDAV runs the WebDAV handler against a deferred writer and rewrites
+// the status when the underlying error carries a more specific one.
+//
+// webdav.Handler does not expose the error behind its status, but it does hand
+// it to Logger on the way out, which is enough: the handler is shallow-copied
+// per request so its Logger can capture the error without disturbing the
+// shared one. The status is then still open, because deferredHeaderWriter has
+// not flushed it.
+//
+// Without this, none of the origin's error mapping reached a client: ENOSPC
+// came out as 405 Method Not Allowed, ErrDraining as 404, and
+// ErrPreconditionFailed was unreachable.
+func serveWebDAV(dw *deferredHeaderWriter, handler *webdav.Handler, req *http.Request, conditional bool) {
+	var captured error
+	perRequest := *handler
+	perRequest.Logger = func(r *http.Request, err error) {
+		if err != nil {
+			captured = err
+		}
+		if handler.Logger != nil {
+			handler.Logger(r, err)
+		}
+	}
+
+	perRequest.ServeHTTP(dw, req)
+
+	if dw.code < 400 || captured == nil {
+		return
+	}
+	status := statusForBackendError(captured, conditional)
+	if status == 0 || status == dw.code {
+		return
+	}
+	log.Debugf("Reporting %d rather than the WebDAV handler's %d for %s %s: %v",
+		status, dw.code, req.Method, req.URL.Path, captured)
+	dw.code = status
+	// The handler wrote StatusText for the status it chose, which is now the
+	// wrong text for the wrong code.
+	dw.buf = []byte(http.StatusText(status))
+}
+
+// localRootProvider is implemented by a backend that can hand out an os.Root
+// for the export, because its storage really is a directory on this host.
+type localRootProvider interface {
+	LocalStorageRoot() (*os.Root, error)
+}
+
+// errNotHostFilesystem reports that an export's storage is not a directory on
+// this machine, so the host-filesystem fast paths do not apply to it.
+var errNotHostFilesystem = errors.New("the export's storage is not on the host filesystem")
+
+// openLocalStorageRoot opens the export's storage prefix as an os.Root, but
+// only when that prefix actually names a directory on this host.
+//
+// An export's StoragePrefix means whatever its backend says it means. For
+// POSIX it is a host path. For pstore it is a logical path inside the store's
+// namespace -- server_utils/origin_pstore.go says so explicitly -- and for the
+// S3, HTTPS, and Globus backends it names a remote subtree. Resolving those
+// against the local filesystem is not merely useless: "/" is the natural
+// StoragePrefix for a single-export pstore origin, and os.OpenRoot("/")
+// succeeds, which turned a browser GET into an HTML index of the origin host's
+// root directory and made ETag and Last-Modified an existence-and-mtime oracle
+// for host files. handlePutWithETag was worse still, running InvalidateChecksums
+// -- which opens O_RDWR and strips xattrs -- against unrelated local files.
+//
+// Backends opt in by implementing localRootProvider; the POSIX backend is
+// recognized directly, since its whole contract is that StoragePrefix is a
+// host path.
+func openLocalStorageRoot(backend server_utils.OriginBackend, storagePrefix string) (*os.Root, error) {
+	switch b := backend.(type) {
+	case localRootProvider:
+		return b.LocalStorageRoot()
+	case *localBackend:
+		return os.OpenRoot(storagePrefix)
+	}
+	return nil, errNotHostFilesystem
 }
 
 // handleHeadWithChecksum handles HEAD requests and adds checksum headers per RFC 3230
@@ -1041,21 +1278,67 @@ func computeETag(info os.FileInfo) string {
 	return fmt.Sprintf(`"%x"`, sum[:8])
 }
 
+// checkBackendCapacity refuses a PUT the backend has already said will not
+// fit, writing 507 Insufficient Storage.  It returns true when the request
+// should proceed.
+//
+// Only fixed-size backends implement server_utils.CapacityReporter, and the
+// check needs a declared Content-Length: a chunked-encoding PUT has no length
+// to test, so it proceeds and is enforced by the write path instead.
+//
+// The check is advisory. A concurrent write may take the headroom between here
+// and the reservation, so the store enforces its own limit regardless; this
+// only improves the common case.
+func checkBackendCapacity(c *gin.Context, backend server_utils.OriginBackend) bool {
+	reporter, ok := backend.(server_utils.CapacityReporter)
+	if !ok || c.Request.ContentLength <= 0 {
+		return true
+	}
+	if err := reporter.HasCapacityFor(c.Request.ContentLength); err != nil {
+		log.Warnf("Refusing PUT of %d bytes to %s: %v", c.Request.ContentLength, c.Request.URL.Path, err)
+		c.String(http.StatusInsufficientStorage, "Insufficient storage: %v", err)
+		return false
+	}
+	return true
+}
+
 // handlePutWithETag handles PUT requests and returns the ETag of the newly
-// written file in the response headers.  The ETag is computed from the file's
-// mtime and size after the WebDAV handler finishes writing, using the same
-// formula as handleGetWithETag so that GET after PUT returns the same ETag.
+// written file in the response headers.  For a host-filesystem backend the
+// ETag is computed from the file's mtime and size after the WebDAV handler
+// finishes writing, using the same formula as handleGetWithETag so that GET
+// after PUT returns the same ETag; other backends mint their own, which the
+// WebDAV handler has already set from webdav.ETager.
 //
 // Because PUT responses are typically header-only (201 Created or 204 No
 // Content), we wrap the response writer to defer the header flush until after
 // we have had a chance to stat the new file.
-func handlePutWithETag(c *gin.Context, handler *webdav.Handler, req *http.Request, relativePath string, storagePrefix string) {
+//
+// The request body is wrapped so that a read failure -- a client that
+// disconnects halfway through an overwrite, most often -- reaches the file
+// before it is closed.  webdav.handlePut closes the file before it examines
+// the error from io.Copy, so a backend that commits at Close (pstore) would
+// otherwise install the truncated body over a complete object.  See
+// writeGuard.
+func handlePutWithETag(c *gin.Context, handler *webdav.Handler, req *http.Request, relativePath string,
+	backend server_utils.OriginBackend, storagePrefix string, conditional bool) {
+	guard := &writeGuard{}
+	req = req.WithContext(contextWithWriteGuard(req.Context(), guard))
+	req.Body = &guardedBody{ReadCloser: req.Body, guard: guard}
+
 	dw := &deferredHeaderWriter{ResponseWriter: c.Writer}
-	handler.ServeHTTP(dw, req)
+	serveWebDAV(dw, handler, req, conditional)
+
+	// A body that failed mid-stream must never be reported as a success, even
+	// if the backend could not be told to discard it.
+	if failed := guard.failed(); failed != nil && dw.code >= 200 && dw.code < 300 {
+		log.Warnf("PUT of %s failed while reading the request body: %v", req.URL.Path, failed)
+		dw.code = http.StatusBadRequest
+		dw.buf = []byte("Request body ended prematurely")
+	}
 
 	// On success (2xx), stat the written file and compute ETag.
 	if dw.code >= 200 && dw.code < 300 {
-		root, err := os.OpenRoot(storagePrefix)
+		root, err := openLocalStorageRoot(backend, storagePrefix)
 		if err == nil {
 			defer root.Close()
 			normalizedPath := strings.TrimPrefix(relativePath, "/")
@@ -1119,11 +1402,18 @@ func (d *deferredHeaderWriter) Flush() {
 // - If-None-Match takes precedence over If-Modified-Since when both are present
 // - If-None-Match compares ETags (strong or weak comparison depending on method)
 // - If-Modified-Since compares modification times (only for GET/HEAD)
-func handleGetWithETag(c *gin.Context, handler *webdav.Handler, req *http.Request, relativePath string, storagePrefix string) {
+//
+// The ETag and directory-listing fast paths below read the host filesystem
+// directly, so they only apply to a backend whose storage really is on this
+// host.  Everything else -- pstore, S3, HTTPS, Globus -- falls through to the
+// WebDAV handler, whose findETag already asks the backend for its own entity
+// tag through webdav.ETager.
+func handleGetWithETag(c *gin.Context, handler *webdav.Handler, req *http.Request, relativePath string,
+	backend server_utils.OriginBackend, storagePrefix string) {
 	// Use os.Root to prevent symlink attacks
-	root, err := os.OpenRoot(storagePrefix)
+	root, err := openLocalStorageRoot(backend, storagePrefix)
 	if err != nil {
-		log.Debugf("Failed to open storage root for ETag: %v", err)
+		log.Debugf("Not serving %s from a host-filesystem root: %v", relativePath, err)
 		handler.ServeHTTP(c.Writer, req)
 		return
 	}

--- a/origin_serve/preconditions.go
+++ b/origin_serve/preconditions.go
@@ -1,0 +1,200 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Conditional-write preconditions (RFC 9110 §13.1).
+//
+// golang.org/x/net/webdav does not implement If-Match or If-None-Match --
+// there is an explicit TODO in its handlePut -- so a client asking for
+// compare-and-swap or create-only semantics is silently given
+// last-writer-wins instead.  Silently ignoring a precondition is the worst
+// possible behavior: the client believes it has protection it does not have.
+//
+// These checks run before the WebDAV handler, against whatever ETag the
+// backend reports, so every backend gets them rather than just pstore.
+//
+// The evaluation here is inherently racy against a concurrent writer, since
+// the stat and the write are not atomic: two "If-None-Match: *" PUTs can both
+// find the path absent. It is therefore only the fast path. The parsed
+// condition is returned to the caller and threaded down to the backend, and a
+// backend that can re-check it inside its commit transaction -- pstore, via
+// ConditionalWriteFs, which becomes RequireAbsent / RequireGeneration on the
+// write handle -- is what actually delivers the guarantee.
+//
+// Two forms cannot be expressed at commit and remain best-effort here:
+// "If-Match: *" (which asserts existence rather than a particular version) and
+// a multi-tag list (which asserts membership). Both are vanishingly rare from
+// real clients, and both fail closed on the early check.
+
+package origin_serve
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/net/webdav"
+
+	"github.com/pelicanplatform/pelican/server_utils"
+)
+
+// checkPutPreconditions evaluates If-Match and If-None-Match for a write.
+//
+// It returns the condition to enforce at commit and true when the request
+// should proceed; otherwise it writes the response itself.
+func checkPutPreconditions(c *gin.Context, backend server_utils.OriginBackend, relativePath string) (writeCondition, bool) {
+	var cond writeCondition
+
+	ifMatch := strings.TrimSpace(c.Request.Header.Get("If-Match"))
+	ifNoneMatch := strings.TrimSpace(c.Request.Header.Get("If-None-Match"))
+	if ifMatch == "" && ifNoneMatch == "" {
+		return cond, true
+	}
+
+	ctx := c.Request.Context()
+	currentETag, exists, err := currentEntityTag(ctx, backend, relativePath)
+	if err != nil {
+		// The target cannot be inspected, so the precondition cannot be
+		// evaluated. Failing closed is safer than silently ignoring it.
+		c.String(http.StatusInternalServerError, "Unable to evaluate precondition: %v", err)
+		return cond, false
+	}
+
+	// RFC 9110 §13.1.2: If-None-Match: * fails when the target exists; an
+	// entity-tag list fails when one of the tags matches. Comparison is weak.
+	if ifNoneMatch != "" {
+		// "*" must be the sole member of the list. A request that sends it
+		// alongside a tag is malformed, and the previous string comparison
+		// against "*" sent `*, "junk"` down the entity-tag branch -- where "*"
+		// is just a tag that never matches, so the create-only request was
+		// silently downgraded to an unconditional overwrite. Any "*" member is
+		// therefore treated as the wildcard form, which is the reading that
+		// fails closed.
+		if etagListHasWildcard(ifNoneMatch) {
+			if exists {
+				c.String(http.StatusPreconditionFailed, "Object already exists")
+				return cond, false
+			}
+			cond.requireAbsent = true
+		} else if exists && etagListMatches(ifNoneMatch, currentETag) {
+			c.String(http.StatusPreconditionFailed, "Object matches If-None-Match")
+			return cond, false
+		}
+	}
+
+	// RFC 9110 §13.1.1: If-Match: * fails when the target does not exist; an
+	// entity-tag list fails unless one of the tags matches.
+	if ifMatch != "" {
+		if !exists {
+			c.String(http.StatusPreconditionFailed, "Object does not exist")
+			return cond, false
+		}
+		if !etagListHasWildcard(ifMatch) {
+			if !etagListMatches(ifMatch, currentETag) {
+				c.String(http.StatusPreconditionFailed, "Object does not match If-Match")
+				return cond, false
+			}
+			// A single tag is a compare-and-swap the backend can re-check at
+			// commit; a list is a membership test it cannot, and stays with
+			// the early check above.
+			if tags := splitETagList(ifMatch); len(tags) == 1 {
+				cond.requireETag = tags[0]
+			}
+		}
+	}
+
+	return cond, true
+}
+
+// currentEntityTag returns the target's current ETag and whether it exists.
+//
+// It prefers the backend's own tag (webdav.ETager, which pstore implements to
+// expose an object's generation) and falls back to the same size-and-mtime
+// formula the WebDAV handler would use, so the value a client compares against
+// is the one it was given.
+func currentEntityTag(ctx context.Context, backend server_utils.OriginBackend, relativePath string) (string, bool, error) {
+	info, err := backend.FileSystem().Stat(ctx, relativePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+
+	if tagger, ok := info.(webdav.ETager); ok {
+		tag, tagErr := tagger.ETag(ctx)
+		if tagErr == nil && tag != "" {
+			return tag, true, nil
+		}
+		// ErrNotImplemented means "use the default", which is not a failure.
+	}
+	return computeETag(info), true, nil
+}
+
+// splitETagList splits a comma-separated entity-tag list, dropping empties.
+func splitETagList(list string) []string {
+	parts := strings.Split(list, ",")
+	tags := make([]string, 0, len(parts))
+	for _, entry := range parts {
+		if entry = strings.TrimSpace(entry); entry != "" {
+			tags = append(tags, entry)
+		}
+	}
+	return tags
+}
+
+// etagListHasWildcard reports whether "*" appears anywhere in an entity-tag
+// list.
+//
+// RFC 9110 §13.1.1 and §13.1.2 define "*" as the whole field value rather than
+// a list member, so a list that contains it is malformed. Honoring it as the
+// wildcard is the conservative reading: the alternative is comparing it as an
+// opaque tag, where it matches nothing and the precondition silently passes.
+func etagListHasWildcard(list string) bool {
+	for _, tag := range splitETagList(list) {
+		if tag == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+// etagListMatches reports whether candidate appears in a comma-separated
+// entity-tag list.
+//
+// Comparison is weak (RFC 9110 §8.8.3.2): a W/ prefix is ignored on both
+// sides, which is what If-None-Match requires and is the safer reading for
+// If-Match given that a backend may legitimately report a weak tag.
+func etagListMatches(list, candidate string) bool {
+	if candidate == "" {
+		return false
+	}
+	want := normalizeETag(candidate)
+	for _, entry := range strings.Split(list, ",") {
+		if normalizeETag(strings.TrimSpace(entry)) == want {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeETag strips a weak-comparison prefix so two tags can be compared.
+func normalizeETag(tag string) string {
+	return strings.TrimPrefix(strings.TrimSpace(tag), "W/")
+}

--- a/origin_serve/preconditions_test.go
+++ b/origin_serve/preconditions_test.go
@@ -1,0 +1,188 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package origin_serve
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/webdav"
+)
+
+func TestETagListMatches(t *testing.T) {
+	assert.True(t, etagListMatches(`"abc"`, `"abc"`))
+	assert.True(t, etagListMatches(`"abc", "def"`, `"def"`))
+	assert.True(t, etagListMatches(`W/"abc"`, `"abc"`), "comparison is weak")
+	assert.True(t, etagListMatches(`"abc"`, `W/"abc"`), "weak on either side")
+	assert.False(t, etagListMatches(`"abc"`, `"xyz"`))
+	assert.False(t, etagListMatches(`"abc"`, ""), "an absent tag never matches")
+	assert.False(t, etagListMatches("", `"abc"`))
+}
+
+// putPreconditionCase drives checkPutPreconditions against a real pstore
+// backend, which is the one that reports a generation-based ETag.
+func runPreconditionCase(t *testing.T, headers map[string]string, path string) (int, bool) {
+	t.Helper()
+	backend := newPStoreTestBackend(t, "/")
+
+	// Seed an object so there is something to match against.
+	fs := backend.FileSystem()
+	f, err := fs.OpenFile(t.Context(), "/exists.txt", os.O_WRONLY|os.O_CREATE, 0644)
+	require.NoError(t, err)
+	_, err = f.Write([]byte("seed"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPut, "http://origin"+path, nil)
+	for k, v := range headers {
+		c.Request.Header.Set(k, v)
+	}
+
+	_, proceed := checkPutPreconditions(c, backend, path)
+	return rec.Code, proceed
+}
+
+// currentETagOf returns the ETag a client would have been given for path.
+func currentETagOf(t *testing.T, backend *pstoreBackend, path string) string {
+	t.Helper()
+	info, err := backend.FileSystem().Stat(t.Context(), path)
+	require.NoError(t, err)
+	tag, err := info.(webdav.ETager).ETag(context.Background())
+	require.NoError(t, err)
+	return tag
+}
+
+func TestPutPreconditionsNoHeaders(t *testing.T) {
+	_, proceed := runPreconditionCase(t, nil, "/exists.txt")
+	assert.True(t, proceed, "an unconditional PUT is unaffected")
+}
+
+// TestPutPreconditionIfNoneMatchStar is the create-only case: a client using
+// it must not silently overwrite.
+func TestPutPreconditionIfNoneMatchStar(t *testing.T) {
+	code, proceed := runPreconditionCase(t,
+		map[string]string{"If-None-Match": "*"}, "/exists.txt")
+	assert.False(t, proceed)
+	assert.Equal(t, http.StatusPreconditionFailed, code)
+
+	_, proceedNew := runPreconditionCase(t,
+		map[string]string{"If-None-Match": "*"}, "/brand-new.txt")
+	assert.True(t, proceedNew, "create-only succeeds when nothing is there")
+}
+
+// TestPutPreconditionIfMatch covers compare-and-swap in both directions.
+func TestPutPreconditionIfMatch(t *testing.T) {
+	backend := newPStoreTestBackend(t, "/")
+	fs := backend.FileSystem()
+	f, err := fs.OpenFile(t.Context(), "/obj.txt", os.O_WRONLY|os.O_CREATE, 0644)
+	require.NoError(t, err)
+	_, err = f.Write([]byte("v1"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	current := currentETagOf(t, backend, "/obj.txt")
+
+	newReq := func(hdr, val string) (*gin.Context, *httptest.ResponseRecorder) {
+		gin.SetMode(gin.TestMode)
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodPut, "http://origin/obj.txt", nil)
+		c.Request.Header.Set(hdr, val)
+		return c, rec
+	}
+
+	t.Run("matching tag proceeds", func(t *testing.T) {
+		c, _ := newReq("If-Match", current)
+		cond, ok := checkPutPreconditions(c, backend, "/obj.txt")
+		assert.True(t, ok)
+		assert.Equal(t, current, cond.requireETag,
+			"a single-tag If-Match is carried down for the backend to re-check at commit")
+	})
+
+	t.Run("stale tag is refused", func(t *testing.T) {
+		c, rec := newReq("If-Match", `"0000000000000000"`)
+		_, ok := checkPutPreconditions(c, backend, "/obj.txt")
+		assert.False(t, ok)
+		assert.Equal(t, http.StatusPreconditionFailed, rec.Code)
+	})
+
+	t.Run("star requires existence", func(t *testing.T) {
+		c, _ := newReq("If-Match", "*")
+		cond, ok := checkPutPreconditions(c, backend, "/obj.txt")
+		assert.True(t, ok)
+		assert.False(t, cond.isSet(), "\"*\" asserts existence, which no backend can re-check at commit")
+
+		c2, rec2 := newReq("If-Match", "*")
+		_, ok = checkPutPreconditions(c2, backend, "/absent.txt")
+		assert.False(t, ok)
+		assert.Equal(t, http.StatusPreconditionFailed, rec2.Code)
+	})
+
+	t.Run("tag stops matching after an overwrite", func(t *testing.T) {
+		f2, wErr := fs.OpenFile(t.Context(), "/obj.txt", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+		require.NoError(t, wErr)
+		_, wErr = f2.Write([]byte("v2"))
+		require.NoError(t, wErr)
+		require.NoError(t, f2.Close())
+
+		c, rec := newReq("If-Match", current)
+		_, ok := checkPutPreconditions(c, backend, "/obj.txt")
+		assert.False(t, ok, "the old generation must no longer satisfy If-Match")
+		assert.Equal(t, http.StatusPreconditionFailed, rec.Code)
+	})
+}
+
+// TestPutPreconditionIfNoneMatchTag covers the entity-tag form, as opposed to
+// the "*" form.
+func TestPutPreconditionIfNoneMatchTag(t *testing.T) {
+	backend := newPStoreTestBackend(t, "/")
+	fs := backend.FileSystem()
+	f, err := fs.OpenFile(t.Context(), "/obj.txt", os.O_WRONLY|os.O_CREATE, 0644)
+	require.NoError(t, err)
+	_, err = f.Write([]byte("v1"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	current := currentETagOf(t, backend, "/obj.txt")
+
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPut, "http://origin/obj.txt", nil)
+	c.Request.Header.Set("If-None-Match", current)
+	_, ok := checkPutPreconditions(c, backend, "/obj.txt")
+	assert.False(t, ok)
+	assert.Equal(t, http.StatusPreconditionFailed, rec.Code)
+
+	rec2 := httptest.NewRecorder()
+	c2, _ := gin.CreateTestContext(rec2)
+	c2.Request = httptest.NewRequest(http.MethodPut, "http://origin/obj.txt", nil)
+	c2.Request.Header.Set("If-None-Match", `"some-other-tag"`)
+	_, ok = checkPutPreconditions(c2, backend, "/obj.txt")
+	assert.True(t, ok, "a non-matching tag does not block the write")
+}

--- a/origin_serve/pstore_serving_test.go
+++ b/origin_serve/pstore_serving_test.go
@@ -1,0 +1,898 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// End-to-end tests that drive real HTTP requests through the registered Gin
+// engine into a live pstore.
+//
+// Everything here goes through InitializeHandlers and RegisterHandlers -- the
+// same two calls the launcher makes -- so the middleware chain, the WebDAV
+// handler, the afero adapter, the storage-prefix join, and the store all
+// participate. The bugs these cover were all invisible to tests that called
+// the filesystem directly: they lived in the seam between the handler and the
+// backend.
+
+package origin_serve
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jellydator/ttlcache/v3"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/local_cache"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/pstore"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
+)
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+// servedOrigin is a running origin: real exports, a real store, and a Gin
+// engine with the routes RegisterHandlers produces.
+type servedOrigin struct {
+	engine *gin.Engine
+	// key signs the test tokens; the auth config is told to trust it for each
+	// issuer the exports name.
+	key jwk.Key
+}
+
+// backendFor returns the pstore backend serving a federation prefix.
+func (o *servedOrigin) backendFor(t *testing.T, federationPrefix string) *pstoreBackend {
+	t.Helper()
+	be, ok := backends[federationPrefix].(*pstoreBackend)
+	require.True(t, ok, "export %s is not served by a pstore backend", federationPrefix)
+	return be
+}
+
+// store returns the store the exports share.
+func (o *servedOrigin) store(t *testing.T, federationPrefix string) *pstore.Store {
+	return o.backendFor(t, federationPrefix).store
+}
+
+// token mints a bearer token for one of the exports' issuers.
+func (o *servedOrigin) token(t *testing.T, issuer, scopes string) string {
+	t.Helper()
+	return createTestToken(t, o.key, issuer, "tester", []string{"testers"}, scopes)
+}
+
+// newServedOrigin brings up an origin over a pstore, through the same calls
+// the launcher makes.
+//
+// storageDirs, when non-nil, is passed to Origin.PStoreStorageDirs so a test
+// can cap the store's capacity.
+func newServedOrigin(t *testing.T, exports []server_utils.OriginExport, storageDirs []any) *servedOrigin {
+	t.Helper()
+
+	local_cache.InitIssuerKeyForTests(t)
+	ResetPStoreState()
+	ResetHandlers()
+	t.Cleanup(func() {
+		ResetHandlers()
+		ResetPStoreState()
+	})
+
+	require.NoError(t, param.Origin_StorageType.Set(string(server_structs.OriginStoragePStore)))
+	t.Cleanup(func() { _ = param.Origin_StorageType.Set("posix") })
+
+	storeDir := t.TempDir()
+	require.NoError(t, param.Origin_PStoreLocation.Set(storeDir))
+	if storageDirs != nil {
+		require.NoError(t, param.Origin_PStoreStorageDirs.Set(storageDirs))
+		t.Cleanup(func() { _ = param.Origin_PStoreStorageDirs.Set(nil) })
+	}
+
+	baseCtx, cancel := context.WithCancel(context.Background())
+	egrp, egrpCtx := errgroup.WithContext(baseCtx)
+	ctx := context.WithValue(egrpCtx, config.EgrpKey, egrp)
+	// The store's background workers -- and the goroutine that closes it --
+	// only stop when this context is cancelled, so tear them down before the
+	// temp directory goes away.
+	t.Cleanup(func() {
+		cancel()
+		_ = egrp.Wait()
+	})
+
+	require.NoError(t, InitializeHandlers(ctx, exports))
+	require.NoError(t, InitAuthConfig(ctx, egrp, exports))
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	require.NoError(t, RegisterHandlers(engine, false))
+
+	o := &servedOrigin{engine: engine, key: generateTestKey(t)}
+
+	// Trust the signing key for every issuer the exports name, rather than
+	// standing up a JWKS endpoint per issuer. Everything downstream of the
+	// signature check -- issuer trust, audience, scope parsing, and the
+	// per-export capability filtering in getAcls -- still runs for real.
+	pub, err := o.key.PublicKey()
+	require.NoError(t, err)
+	require.NoError(t, pub.Set(jwk.KeyIDKey, "test-key"))
+	set := jwk.NewSet()
+	require.NoError(t, set.AddKey(pub))
+
+	ac := GetAuthConfig()
+	require.NotNil(t, ac)
+	for _, export := range exports {
+		for _, issuer := range export.IssuerUrls {
+			ac.issuerKeys.Set(issuer, authConfigItem{set: set}, ttlcache.DefaultTTL)
+		}
+	}
+
+	return o
+}
+
+// do runs a request against the engine.
+func (o *servedOrigin) do(req *http.Request) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	o.engine.ServeHTTP(rec, req)
+	return rec
+}
+
+// put issues an authenticated PUT with a known length.
+func (o *servedOrigin) put(t *testing.T, token, url, body string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, url, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	return o.do(req)
+}
+
+// writeObject seeds an object through the export's filesystem.
+func writeObject(t *testing.T, backend *pstoreBackend, name, body string) {
+	t.Helper()
+	f, err := backend.FileSystem().OpenFile(context.Background(), name,
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	require.NoError(t, err)
+	_, err = f.Write([]byte(body))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+}
+
+// unsizedBody hides a reader's type so httptest.NewRequest reports an unknown
+// Content-Length, which is what a chunked-encoding PUT gives the handler --
+// and the only way past the up-front capacity check into the write path.
+type unsizedBody struct{ io.Reader }
+
+// failingReader yields a prefix and then fails, standing in for a client that
+// disconnects partway through an upload.
+type failingReader struct {
+	prefix []byte
+	off    int
+}
+
+func (r *failingReader) Read(p []byte) (int, error) {
+	if r.off < len(r.prefix) {
+		n := copy(p, r.prefix[r.off:])
+		r.off += n
+		return n, nil
+	}
+	return 0, errors.New("simulated client disconnect")
+}
+
+// ---------------------------------------------------------------------------
+// Cross-export destruction via the Destination header
+// ---------------------------------------------------------------------------
+
+// twoTenantExports is the shape the cross-tenant attack needs: two exports on
+// one store, in separate storage subtrees, trusting separate issuers -- so a
+// token good for one grants nothing on the other.
+func twoTenantExports() []server_utils.OriginExport {
+	return []server_utils.OriginExport{
+		{
+			FederationPrefix: "/pubA",
+			StoragePrefix:    "/tenantA",
+			IssuerUrls:       []string{"https://issuer-a.example.com"},
+			Capabilities: server_structs.Capabilities{
+				Reads: true, Writes: true, Copies: true,
+			},
+		},
+		{
+			FederationPrefix: "/privB",
+			StoragePrefix:    "/tenantB",
+			IssuerUrls:       []string{"https://issuer-b.example.com"},
+			Capabilities: server_structs.Capabilities{
+				Reads: true, Writes: true,
+			},
+		},
+	}
+}
+
+// TestCrossExportMoveWithDotDotDestinationIsRefused is the most important test
+// in this change.
+//
+// golang.org/x/net/webdav cleans the request path but not the Destination
+// header: handleCopyMove strips its own prefix with a bare TrimPrefix and
+// hands what is left to Rename and -- because RFC 4918 §9.9.3 makes MOVE
+// delete an existing destination first -- RemoveAll. With pstore, whose
+// containment was nothing more than path.Join(storagePrefix, name), a client
+// holding storage.modify on one export could aim a MOVE at another export's
+// subtree and get back 204 No Content with the whole subtree deleted.
+func TestCrossExportMoveWithDotDotDestinationIsRefused(t *testing.T) {
+	o := newServedOrigin(t, twoTenantExports(), nil)
+
+	tenantA := o.backendFor(t, "/pubA")
+	tenantB := o.backendFor(t, "/privB")
+	writeObject(t, tenantA, "/mine.txt", "mine")
+	writeObject(t, tenantB, "/keep.txt", "tenant B data")
+	writeObject(t, tenantB, "/dir/deep.txt", "tenant B nested data")
+
+	// A token that authorizes everything the attacker's own export allows.
+	tok := o.token(t, "https://issuer-a.example.com",
+		"storage.read:/ storage.create:/ storage.modify:/")
+
+	req := httptest.NewRequest("MOVE", "/pubA/mine.txt", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	// path.Join("/tenantA", "/../../tenantB") == "/tenantB".
+	req.Header.Set("Destination", "/pubA/../../tenantB")
+	req.Header.Set("Overwrite", "T")
+	rec := o.do(req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code,
+		"a destination outside the export must be refused, got %d: %s", rec.Code, rec.Body.String())
+
+	// The point of the whole test: tenant B still has its data.
+	store := o.store(t, "/privB")
+	keep, err := store.ReadAll("/tenantB/keep.txt")
+	require.NoError(t, err, "tenant B's object must survive")
+	assert.Equal(t, "tenant B data", string(keep))
+	deep, err := store.ReadAll("/tenantB/dir/deep.txt")
+	require.NoError(t, err, "tenant B's subtree must survive")
+	assert.Equal(t, "tenant B nested data", string(deep))
+
+	// And the source is untouched, since the move never happened.
+	mine, err := store.ReadAll("/tenantA/mine.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "mine", string(mine))
+}
+
+// TestCrossExportCopyWithDotDotDestinationIsRefused covers the same header on
+// COPY, whose Overwrite defaults to true (`!= "F"`), so the destructive form
+// needs no header at all.
+func TestCrossExportCopyWithDotDotDestinationIsRefused(t *testing.T) {
+	o := newServedOrigin(t, twoTenantExports(), nil)
+
+	writeObject(t, o.backendFor(t, "/pubA"), "/mine.txt", "mine")
+	writeObject(t, o.backendFor(t, "/privB"), "/keep.txt", "tenant B data")
+
+	tok := o.token(t, "https://issuer-a.example.com",
+		"storage.read:/ storage.create:/ storage.modify:/")
+
+	req := httptest.NewRequest("COPY", "/pubA/mine.txt", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Destination", "/pubA/../../tenantB/keep.txt")
+	rec := o.do(req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code,
+		"got %d: %s", rec.Code, rec.Body.String())
+
+	keep, err := o.store(t, "/privB").ReadAll("/tenantB/keep.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "tenant B data", string(keep),
+		"tenant B's object must not have been overwritten")
+}
+
+// TestAferoFileSystemConfinesEveryOperation pins the sink itself, independent
+// of any handler: whatever reaches the WebDAV filesystem with a path that
+// leaves the export is refused, and refused as a permission error so the
+// status mapping reports 403 rather than 500.
+func TestAferoFileSystemConfinesEveryOperation(t *testing.T) {
+	backend := newPStoreTestBackend(t, "/tenantA")
+	fs := backend.FileSystem()
+	ctx := context.Background()
+
+	// Seed a neighbouring subtree directly in the store.
+	require.NoError(t, backend.store.MkdirAll("/tenantB"))
+	w, err := backend.store.Create("/tenantB/keep.txt")
+	require.NoError(t, err)
+	_, err = w.Write([]byte("tenant B data"))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	escapes := "/../../tenantB"
+
+	t.Run("RemoveAll", func(t *testing.T) {
+		err := fs.RemoveAll(ctx, escapes)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrPermission)
+		assert.Equal(t, http.StatusForbidden, statusForBackendError(err, false))
+	})
+	t.Run("Rename", func(t *testing.T) {
+		assert.ErrorIs(t, fs.Rename(ctx, "/a.txt", escapes), os.ErrPermission)
+		assert.ErrorIs(t, fs.Rename(ctx, escapes, "/a.txt"), os.ErrPermission)
+	})
+	t.Run("Stat", func(t *testing.T) {
+		_, err := fs.Stat(ctx, escapes+"/keep.txt")
+		assert.ErrorIs(t, err, os.ErrPermission)
+	})
+	t.Run("OpenFile", func(t *testing.T) {
+		_, err := fs.OpenFile(ctx, escapes+"/keep.txt", os.O_RDONLY, 0)
+		assert.ErrorIs(t, err, os.ErrPermission)
+	})
+	t.Run("Mkdir", func(t *testing.T) {
+		assert.ErrorIs(t, fs.Mkdir(ctx, escapes+"/new", 0755), os.ErrPermission)
+	})
+
+	// Nothing above touched the neighbour.
+	body, err := backend.store.ReadAll("/tenantB/keep.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "tenant B data", string(body))
+
+	// A path that stays inside is unaffected.
+	inside, err := confineToPrefix("/tenantA", "/sub/../ok.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "/tenantA/ok.txt", inside)
+}
+
+// ---------------------------------------------------------------------------
+// The destination is authorized in its own right
+// ---------------------------------------------------------------------------
+
+// TestReadOnlyExportIsNotWritableViaMoveDestination covers the authorization
+// half of the same bug: authMiddleware only ever checked the request path, so
+// the Writes capability of the export the data would land in was never
+// consulted.
+func TestReadOnlyExportIsNotWritableViaMoveDestination(t *testing.T) {
+	issuer := "https://issuer.example.com"
+	o := newServedOrigin(t, []server_utils.OriginExport{
+		{
+			FederationPrefix: "/rw",
+			StoragePrefix:    "/tenantRW",
+			IssuerUrls:       []string{issuer},
+			Capabilities:     server_structs.Capabilities{Reads: true, Writes: true},
+		},
+		{
+			// Same issuer, same token -- only the capability differs.
+			FederationPrefix: "/ro",
+			StoragePrefix:    "/tenantRO",
+			IssuerUrls:       []string{issuer},
+			Capabilities:     server_structs.Capabilities{Reads: true, Writes: false},
+		},
+	}, nil)
+
+	writeObject(t, o.backendFor(t, "/rw"), "/mine.txt", "mine")
+
+	tok := o.token(t, issuer, "storage.read:/ storage.create:/ storage.modify:/")
+
+	req := httptest.NewRequest("MOVE", "/rw/mine.txt", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Destination", "/ro/stolen.txt")
+	req.Header.Set("Overwrite", "T")
+	rec := o.do(req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code, "got %d: %s", rec.Code, rec.Body.String())
+
+	_, err := o.store(t, "/ro").Stat("/tenantRO/stolen.txt")
+	assert.Error(t, err, "nothing may be written into a read-only export")
+
+	// The source survives: a refused MOVE must not consume it.
+	body, err := o.store(t, "/rw").ReadAll("/tenantRW/mine.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "mine", string(body))
+}
+
+// TestMoveDestinationOutsideTokenScopeIsRefused checks the finer case: the
+// destination is inside the same export, so confinement alone would allow it,
+// but the token's scope does not reach it.
+func TestMoveDestinationOutsideTokenScopeIsRefused(t *testing.T) {
+	issuer := "https://issuer.example.com"
+	o := newServedOrigin(t, []server_utils.OriginExport{{
+		FederationPrefix: "/data",
+		StoragePrefix:    "/tenant",
+		IssuerUrls:       []string{issuer},
+		Capabilities:     server_structs.Capabilities{Reads: true, Writes: true},
+	}}, nil)
+
+	writeObject(t, o.backendFor(t, "/data"), "/sub/mine.txt", "mine")
+
+	// Authorized for /data/sub only.
+	tok := o.token(t, issuer, "storage.read:/sub storage.create:/sub storage.modify:/sub")
+
+	t.Run("outside the scope", func(t *testing.T) {
+		req := httptest.NewRequest("MOVE", "/data/sub/mine.txt", nil)
+		req.Header.Set("Authorization", "Bearer "+tok)
+		req.Header.Set("Destination", "/data/elsewhere.txt")
+		rec := o.do(req)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code, "got %d: %s", rec.Code, rec.Body.String())
+		_, err := o.store(t, "/data").Stat("/tenant/elsewhere.txt")
+		assert.Error(t, err)
+	})
+
+	t.Run("inside the scope", func(t *testing.T) {
+		req := httptest.NewRequest("MOVE", "/data/sub/mine.txt", nil)
+		req.Header.Set("Authorization", "Bearer "+tok)
+		req.Header.Set("Destination", "/data/sub/renamed.txt")
+		rec := o.do(req)
+
+		require.Less(t, rec.Code, 300, "an authorized move must still work: %s", rec.Body.String())
+		body, err := o.store(t, "/data").ReadAll("/tenant/sub/renamed.txt")
+		require.NoError(t, err)
+		assert.Equal(t, "mine", string(body))
+	})
+}
+
+// ---------------------------------------------------------------------------
+// A logical StoragePrefix is not a host path
+// ---------------------------------------------------------------------------
+
+// TestPStoreGetDoesNotListTheHostFilesystem covers the confusion between an
+// export's logical StoragePrefix and a path on this machine.
+//
+// handleGetWithETag used to call os.OpenRoot(storagePrefix) unconditionally.
+// For pstore that prefix is a namespace path inside the store; "/" is the
+// natural choice for a single-export origin, os.OpenRoot("/") succeeds, and a
+// browser GET was answered with an HTML index of the origin host's root
+// directory -- plus an ETag and Last-Modified derived from host files, which
+// honored If-None-Match and became an existence-and-mtime oracle.
+func TestPStoreGetDoesNotListTheHostFilesystem(t *testing.T) {
+	// A directory that exists on this host and also names the export's
+	// logical storage prefix, which is what makes the confusion observable.
+	hostDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(hostDir, "host-only-secret.txt"),
+		[]byte("this file is on the origin host, not in the store"), 0o600))
+
+	issuer := "https://issuer.example.com"
+	o := newServedOrigin(t, []server_utils.OriginExport{{
+		FederationPrefix: "/pub",
+		StoragePrefix:    hostDir,
+		IssuerUrls:       []string{issuer},
+		Capabilities:     server_structs.Capabilities{Reads: true, Writes: true, PublicReads: true},
+	}}, nil)
+
+	// Give the export a directory of its own inside the store, so the request
+	// resolves to something real in the namespace rather than 404ing for an
+	// unrelated reason.
+	require.NoError(t, o.store(t, "/pub").MkdirAll(hostDir))
+	writeObject(t, o.backendFor(t, "/pub"), "/in-the-store.txt", "store data")
+
+	req := httptest.NewRequest(http.MethodGet, "/pub/", nil)
+	req.Header.Set("Accept", "text/html,application/xhtml+xml")
+	rec := o.do(req)
+
+	body := rec.Body.String()
+	assert.NotContains(t, body, "host-only-secret.txt",
+		"the response must never enumerate the origin host's filesystem")
+	assert.NotContains(t, body, "Index of",
+		"the host-filesystem directory listing must not run for a pstore export")
+
+	// The same confusion made a GET for a host file answerable at all.
+	req = httptest.NewRequest(http.MethodGet, "/pub/host-only-secret.txt", nil)
+	rec = o.do(req)
+	assert.Equal(t, http.StatusNotFound, rec.Code,
+		"a file that exists only on the host must not be visible through the export")
+	assert.Empty(t, rec.Header().Get("ETag"),
+		"no host-derived validator may leak")
+}
+
+// ---------------------------------------------------------------------------
+// A failed PUT must not commit
+// ---------------------------------------------------------------------------
+
+// TestPutWithFailingBodyKeepsThePreviousObject is the silent-data-loss case.
+//
+// webdav.handlePut calls f.Close() before it looks at the error from io.Copy,
+// and a pstore Close installs whatever arrived. A client that died partway
+// through an overwrite therefore replaced a complete object with a fragment
+// and got a 405 -- by which time the original was gone.
+func TestPutWithFailingBodyKeepsThePreviousObject(t *testing.T) {
+	issuer := "https://issuer.example.com"
+	o := newServedOrigin(t, []server_utils.OriginExport{{
+		FederationPrefix: "/data",
+		StoragePrefix:    "/tenant",
+		IssuerUrls:       []string{issuer},
+		Capabilities:     server_structs.Capabilities{Reads: true, Writes: true},
+	}}, nil)
+
+	tok := o.token(t, issuer, "storage.read:/ storage.create:/ storage.modify:/")
+
+	const original = "THE COMPLETE ORIGINAL OBJECT"
+	rec := o.put(t, tok, "/data/obj.txt", original, nil)
+	require.Less(t, rec.Code, 300, "seeding PUT failed: %s", rec.Body.String())
+
+	// Now overwrite it with a body that dies after seven bytes.
+	req := httptest.NewRequest(http.MethodPut, "/data/obj.txt",
+		unsizedBody{&failingReader{prefix: []byte("PARTIAL")}})
+	req.Header.Set("Authorization", "Bearer "+tok)
+	rec = o.do(req)
+
+	assert.GreaterOrEqual(t, rec.Code, 400,
+		"a PUT whose body failed must not be reported as success")
+
+	body, err := o.store(t, "/data").ReadAll("/tenant/obj.txt")
+	require.NoError(t, err, "the object must still exist")
+	assert.Equal(t, original, string(body),
+		"a failed PUT must leave the previous version's bytes intact")
+}
+
+// TestPstoreFileAbortsRatherThanCommitting checks the backend half on its own,
+// so the guarantee does not depend on the handler wiring.
+func TestPstoreFileAbortsRatherThanCommitting(t *testing.T) {
+	backend := newPStoreTestBackend(t, "/")
+	fs := backend.FileSystem()
+	ctx := context.Background()
+
+	f, err := fs.OpenFile(ctx, "/obj.txt", os.O_WRONLY|os.O_CREATE, 0644)
+	require.NoError(t, err)
+	_, err = f.Write([]byte("v1 complete"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// A second write that is told, mid-flight, that its data is incomplete.
+	// The guard is what the PUT handler plants in the context, and what the
+	// filesystem registers the backend file with, so going through it
+	// exercises the real wiring rather than reaching for the raw handle.
+	guard := &writeGuard{}
+	f2, err := fs.OpenFile(contextWithWriteGuard(ctx, guard), "/obj.txt",
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	require.NoError(t, err)
+	_, err = f2.Write([]byte("PARTIAL"))
+	require.NoError(t, err)
+
+	guard.fail(errors.New("client went away"))
+	require.Error(t, guard.failed())
+
+	require.Error(t, f2.Close(), "Close must report the failure rather than pretend to commit")
+
+	body, err := backend.store.ReadAll("/obj.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "v1 complete", string(body))
+}
+
+// ---------------------------------------------------------------------------
+// Over-capacity PUT reports 507, not 405
+// ---------------------------------------------------------------------------
+
+// TestOverCapacityPutReturns507 pins the mapping to what a client actually
+// sees.
+//
+// The ENOSPC-to-507 entry in MapToHTTPStatus had no caller on any request
+// path, so every over-capacity write came out of golang.org/x/net/webdav as
+// 405 Method Not Allowed -- which tells a client the method is unsupported and
+// that retrying is pointless, the opposite of the truth.
+func TestOverCapacityPutReturns507(t *testing.T) {
+	issuer := "https://issuer.example.com"
+	capped := t.TempDir()
+	o := newServedOrigin(t, []server_utils.OriginExport{{
+		FederationPrefix: "/data",
+		StoragePrefix:    "/tenant",
+		IssuerUrls:       []string{issuer},
+		Capabilities:     server_structs.Capabilities{Reads: true, Writes: true},
+	}}, []any{
+		// Shaped as viper delivers a YAML list of objects.
+		map[string]any{"Path": capped, "MaxSize": "256KB"},
+	})
+
+	tok := o.token(t, issuer, "storage.read:/ storage.create:/ storage.modify:/")
+
+	// Ask for far more than the store can hold, rather than probing for the
+	// exact threshold: the placement granularity is an implementation detail.
+	oversized := strings.Repeat("x", 8<<20)
+
+	t.Run("declared length is refused up front", func(t *testing.T) {
+		rec := o.put(t, tok, "/data/big.bin", oversized, nil)
+		assert.Equal(t, http.StatusInsufficientStorage, rec.Code,
+			"got %d: %s", rec.Code, rec.Body.String())
+	})
+
+	t.Run("unknown length is refused by the write path", func(t *testing.T) {
+		// No Content-Length, so the up-front check cannot help and the error
+		// has to survive the WebDAV handler's own 405.
+		req := httptest.NewRequest(http.MethodPut, "/data/chunked.bin",
+			unsizedBody{strings.NewReader(oversized)})
+		req.Header.Set("Authorization", "Bearer "+tok)
+		require.EqualValues(t, -1, req.ContentLength, "the test needs an unknown length")
+
+		rec := o.do(req)
+		assert.Equal(t, http.StatusInsufficientStorage, rec.Code,
+			"an out-of-space write must report 507, not the WebDAV handler's 405; got %d: %s",
+			rec.Code, rec.Body.String())
+	})
+
+	t.Run("the object is not left behind", func(t *testing.T) {
+		_, err := o.store(t, "/data").Stat("/tenant/chunked.bin")
+		assert.Error(t, err)
+	})
+}
+
+// TestStatusForBackendError covers the mapping directly, including the cases
+// no client-visible path exercises today.
+func TestStatusForBackendError(t *testing.T) {
+	assert.Equal(t, http.StatusInsufficientStorage,
+		statusForBackendError(&os.PathError{Op: "write", Path: "/x", Err: pstore.ErrNoSpace}, false))
+	assert.Equal(t, http.StatusConflict,
+		statusForBackendError(errors.Wrap(pstore.ErrDraining, "close"), false))
+	assert.Equal(t, http.StatusPreconditionFailed,
+		statusForBackendError(&os.PathError{Op: "close", Path: "/x", Err: pstore.ErrPreconditionFailed}, false))
+	assert.Equal(t, http.StatusPreconditionFailed,
+		statusForBackendError(&os.PathError{Op: "close", Path: "/x", Err: pstore.ErrExist}, true),
+		"ErrExist is a failed precondition only when the request carried one")
+	assert.Equal(t, 0,
+		statusForBackendError(&os.PathError{Op: "close", Path: "/x", Err: pstore.ErrExist}, false),
+		"and an ordinary conflict is left to the WebDAV handler")
+	assert.Equal(t, http.StatusForbidden,
+		statusForBackendError(&os.PathError{Op: "open", Path: "/x", Err: os.ErrPermission}, false))
+	assert.Equal(t, 0, statusForBackendError(nil, false))
+	assert.Equal(t, 0, statusForBackendError(errors.New("something unrecognized"), false),
+		"an unrecognized error must not be given a made-up status")
+}
+
+// ---------------------------------------------------------------------------
+// 6 & 7. Conditional writes
+// ---------------------------------------------------------------------------
+
+// TestConcurrentCreateOnlyPutsElectOneWinner is the compare-and-swap
+// guarantee.
+//
+// checkPutPreconditions is a stat followed by a write, so on its own two
+// "If-None-Match: *" PUTs to the same path both observe an absent object and
+// both commit -- and the store's own RequireAbsent, which would have caught
+// it, had no caller anywhere in the repo. The condition is now carried into
+// the transaction that installs the new version.
+func TestConcurrentCreateOnlyPutsElectOneWinner(t *testing.T) {
+	issuer := "https://issuer.example.com"
+	o := newServedOrigin(t, []server_utils.OriginExport{{
+		FederationPrefix: "/data",
+		StoragePrefix:    "/tenant",
+		IssuerUrls:       []string{issuer},
+		Capabilities:     server_structs.Capabilities{Reads: true, Writes: true},
+	}}, nil)
+
+	tok := o.token(t, issuer, "storage.read:/ storage.create:/ storage.modify:/")
+
+	const racers = 4
+	start := make(chan struct{})
+	codes := make([]int, racers)
+	var wg sync.WaitGroup
+	for i := range racers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			rec := o.put(t, tok, "/data/create-only.txt",
+				fmt.Sprintf("written by racer %d", i),
+				map[string]string{"If-None-Match": "*"})
+			codes[i] = rec.Code
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	created := 0
+	for _, code := range codes {
+		switch {
+		case code >= 200 && code < 300:
+			created++
+		case code == http.StatusPreconditionFailed:
+			// Refused, either by the early check or by the commit.
+		case code == webdavStatusLocked:
+			// golang.org/x/net/webdav takes an exclusive lock for the
+			// duration of a PUT, so a request that overlaps the winner
+			// exactly is turned away before it ever reaches the
+			// precondition. That is still a refusal, and still leaves
+			// exactly one writer.
+		default:
+			t.Errorf("unexpected status %d from a create-only PUT (all: %v)", code, codes)
+		}
+	}
+	assert.Equal(t, 1, created, "exactly one create-only PUT may succeed: %v", codes)
+
+	// And one of them is what is actually stored.
+	body, err := o.store(t, "/data").ReadAll("/tenant/create-only.txt")
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "written by racer")
+}
+
+// webdavStatusLocked is golang.org/x/net/webdav's StatusLocked (RFC 4918
+// §11.3), which the package exports but net/http does not define.
+const webdavStatusLocked = 423
+
+// TestConcurrentConditionalWritesElectOneWinner is the same race one layer
+// down, where the WebDAV lock system is not there to serialize it -- so the
+// store's own commit-time check is the only thing standing between the two
+// writers.
+//
+// Before this change WriteHandle.RequireAbsent had no caller anywhere in the
+// repo, and webdav.handlePut opens with O_RDWR|O_CREATE|O_TRUNC (no O_EXCL),
+// so nothing reached it: both writers committed and the create-only guarantee
+// was simply not delivered.
+func TestConcurrentConditionalWritesElectOneWinner(t *testing.T) {
+	backend := newPStoreTestBackend(t, "/tenant")
+	fs := backend.FileSystem()
+	// The export's own subtree exists before the race, so the only thing the
+	// racers contend for is the object itself.
+	require.NoError(t, backend.store.MkdirAll("/tenant"))
+	condCtx := contextWithWriteCondition(context.Background(), writeCondition{requireAbsent: true})
+
+	const racers = 4
+	start := make(chan struct{})
+	errs := make([]error, racers)
+	var wg sync.WaitGroup
+	for i := range racers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			f, err := fs.OpenFile(condCtx, "/create-only.txt", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			if _, err := f.Write([]byte(fmt.Sprintf("racer %d", i))); err != nil {
+				errs[i] = err
+				_ = f.Close()
+				return
+			}
+			<-start
+			errs[i] = f.Close()
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	won := 0
+	for i, err := range errs {
+		if err == nil {
+			won++
+			continue
+		}
+		// A loser either finds the winner's entry (ErrExist) or is aborted by
+		// the index's serializable isolation before it can (ErrConflict).
+		// Either way it did not create the object, and either way the origin
+		// must give the client a status that says so rather than a 500.
+		assert.True(t,
+			errors.Is(err, pstore.ErrExist) || errors.Is(err, pstore.ErrConflict),
+			"racer %d lost with an unexpected error: %v", i, err)
+		status := statusForBackendError(err, true)
+		assert.Contains(t, []int{http.StatusPreconditionFailed, http.StatusConflict}, status,
+			"racer %d's failure must map to a 4xx a client can act on, got %d (%v)", i, status, err)
+	}
+	assert.Equal(t, 1, won, "exactly one conditional create may commit; errors: %v", errs)
+
+	// Whatever happened, exactly one version is installed and it is complete.
+	body, err := backend.store.ReadAll("/tenant/create-only.txt")
+	require.NoError(t, err)
+	assert.Regexp(t, `^racer \d$`, string(body))
+}
+
+// TestConditionalPutEnforcedAtCommit checks the enforcement point rather than
+// the race: the object is changed out from under the request after the early
+// check has already passed, which is exactly what the early check cannot see.
+func TestConditionalPutEnforcedAtCommit(t *testing.T) {
+	backend := newPStoreTestBackend(t, "/tenant")
+	ctx := context.Background()
+
+	writeObject(t, backend, "/obj.txt", "v1")
+	info, err := backend.FileSystem().Stat(ctx, "/obj.txt")
+	require.NoError(t, err)
+	staleTag, err := info.(interface {
+		ETag(context.Context) (string, error)
+	}).ETag(ctx)
+	require.NoError(t, err)
+
+	// Open a conditional write against the tag we just read...
+	condCtx := contextWithWriteCondition(ctx, writeCondition{requireETag: staleTag})
+	f, err := backend.FileSystem().OpenFile(condCtx, "/obj.txt",
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	require.NoError(t, err)
+	_, err = f.Write([]byte("v3 from the conditional writer"))
+	require.NoError(t, err)
+
+	// ...then let someone else win the race before it commits.
+	writeObject(t, backend, "/obj.txt", "v2 from the interloper")
+
+	err = f.Close()
+	require.Error(t, err, "the commit must notice the generation moved")
+	assert.ErrorIs(t, err, pstore.ErrPreconditionFailed)
+	assert.Equal(t, http.StatusPreconditionFailed, statusForBackendError(err, true))
+
+	body, err := backend.store.ReadAll("/tenant/obj.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "v2 from the interloper", string(body),
+		"the losing conditional write must not have installed anything")
+}
+
+// TestIfNoneMatchStarInAListDoesNotOverwrite guards against a fail-open
+// parse.
+//
+// `If-None-Match: *, "junk"` is not string-equal to "*". A parser that
+// compares the whole header value takes the entity-tag branch, where "*" is
+// just a tag matching nothing, and silently downgrades a create-only request
+// to an unconditional overwrite. RFC 9110 requires "*" to be the sole
+// member, so any "*" in the list is the wildcard form.
+func TestIfNoneMatchStarInAListDoesNotOverwrite(t *testing.T) {
+	issuer := "https://issuer.example.com"
+	o := newServedOrigin(t, []server_utils.OriginExport{{
+		FederationPrefix: "/data",
+		StoragePrefix:    "/tenant",
+		IssuerUrls:       []string{issuer},
+		Capabilities:     server_structs.Capabilities{Reads: true, Writes: true},
+	}}, nil)
+
+	tok := o.token(t, issuer, "storage.read:/ storage.create:/ storage.modify:/")
+
+	rec := o.put(t, tok, "/data/obj.txt", "original", nil)
+	require.Less(t, rec.Code, 300, "seeding PUT failed: %s", rec.Body.String())
+
+	for _, header := range []string{`*, "junk"`, `"junk", *`, `  *  `} {
+		t.Run(header, func(t *testing.T) {
+			rec := o.put(t, tok, "/data/obj.txt", "overwritten",
+				map[string]string{"If-None-Match": header})
+			assert.Equal(t, http.StatusPreconditionFailed, rec.Code,
+				"any list containing * is the create-only form; got %d: %s",
+				rec.Code, rec.Body.String())
+
+			body, err := o.store(t, "/data").ReadAll("/tenant/obj.txt")
+			require.NoError(t, err)
+			assert.Equal(t, "original", string(body))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Digest lookups are confined too
+// ---------------------------------------------------------------------------
+
+// TestGetDigestsRefusesTraversal covers the checksum path, which joined the
+// request-relative path onto the storage prefix without re-confining it: a
+// HEAD for "/../two/secret.txt" on one export returned real digests for
+// another export's object.
+func TestGetDigestsRefusesTraversal(t *testing.T) {
+	backend := newPStoreTestBackend(t, "/exports/one")
+
+	// A neighbour to reach for.
+	require.NoError(t, backend.store.MkdirAll("/exports/two"))
+	w, err := backend.store.Create("/exports/two/secret.txt")
+	require.NoError(t, err)
+	_, err = w.Write([]byte("another export's data"))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	cs := backend.Checksummer()
+	require.NotNil(t, cs)
+
+	digests, err := cs.GetDigests("/../two/secret.txt", "md5,crc32c")
+	assert.Error(t, err, "a digest lookup must not resolve outside the export")
+	assert.ErrorIs(t, err, os.ErrPermission)
+	assert.Empty(t, digests)
+
+	// The same lookup for the export's own object still works.
+	writeObject(t, backend, "/mine.txt", "my data")
+	digests, err = cs.GetDigests("/mine.txt", "md5")
+	require.NoError(t, err)
+	assert.NotEmpty(t, digests, "digests for the export's own objects are unaffected")
+}

--- a/origin_serve/storage_api.go
+++ b/origin_serve/storage_api.go
@@ -1,0 +1,285 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Storage-backend introspection API.
+//
+// This is an *administrative* interface to the storage backend, not part of
+// the origin's data or federation API.  It is mounted under
+// /api/v1.0/origin/storage precisely so that is obvious from the path: nothing
+// here serves objects, participates in discovery, or is reachable by a
+// federation client.  Every route requires an administrator.
+//
+// It exists because a pstore keeps its namespace in an encrypted database that
+// holds an exclusive lock while the origin runs, so the offline CLI cannot
+// look at a live store.  Answering "what is in there right now" needs the
+// running process to answer it.
+//
+// Only operations that are meaningful against a moving target are exposed.
+// Listing, stat, usage, and digests all describe a moment and are honest about
+// it.  A consistency check is not: scanning an index while it is being
+// rewritten produces findings that are indistinguishable from real ones, so
+// fsck stays offline where its answers mean something.  Repair is likewise
+// absent -- changing a store underneath a running origin is not something to
+// offer over HTTP.
+
+package origin_serve
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+
+	"github.com/pelicanplatform/pelican/local_cache"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/pstore"
+	"github.com/pelicanplatform/pelican/server_structs"
+)
+
+// storageBackendKind names the backend an introspection response came from,
+// so a client can tell whether the fields it wants are even applicable.
+type storageBackendKind string
+
+const storageBackendPStore storageBackendKind = "pstore"
+
+// storageEntryResponse describes one namespace entry.
+type storageEntryResponse struct {
+	Name     string    `json:"name"`
+	Path     string    `json:"path"`
+	IsDir    bool      `json:"isDir"`
+	Size     int64     `json:"size"`
+	Modified time.Time `json:"modified"`
+	ETag     string    `json:"etag,omitempty"`
+}
+
+// storageListResponse is a page of a directory listing.
+type storageListResponse struct {
+	Backend storageBackendKind     `json:"backend"`
+	Path    string                 `json:"path"`
+	Entries []storageEntryResponse `json:"entries"`
+	// More reports that the directory continues past this page; pass the last
+	// entry's name as "after" to continue.
+	More bool `json:"more"`
+}
+
+// storageUsageResponse reports what a store is holding.
+type storageUsageResponse struct {
+	Backend storageBackendKind `json:"backend"`
+	// UsedBytes counts committed plus reserved bytes across the store.
+	UsedBytes int64 `json:"usedBytes"`
+	// CapacityBytes is the configured ceiling; zero means unbounded.
+	CapacityBytes int64 `json:"capacityBytes"`
+}
+
+// storageDigestResponse reports the checksums recorded at ingest.
+type storageDigestResponse struct {
+	Backend storageBackendKind `json:"backend"`
+	Path    string             `json:"path"`
+	// Digest is the value the origin would send in an RFC 3230 Digest header.
+	Digest string `json:"digest"`
+}
+
+// RegisterStorageAPI mounts the administrative storage-backend routes.
+//
+// Registering nothing when the backend is not a pstore is deliberate: a 404
+// tells an operator plainly that this origin has no such interface, which is
+// better than a route that exists and always fails.
+//
+// The middleware is variadic because admin authorization takes two handlers,
+// not one: web_ui.AdminAuthHandler only inspects the "User" the authentication
+// handler put in the context, so on its own it rejects everyone with a 401 and
+// the authorization it implements never runs. Every other admin route in the
+// server registers the pair (see local_cache.RegisterPersistentCacheAPI,
+// web_ui.RegisterPprofRoutes, director's RegisterDirectorWebAPI).
+func RegisterStorageAPI(router *gin.RouterGroup, auth ...gin.HandlerFunc) {
+	store := singlePStore()
+	if store == nil {
+		return
+	}
+
+	// "storage" rather than something under the origin's own API surface:
+	// these routes describe the backend, not the origin's role in a
+	// federation, and nothing here is for federation clients.
+	group := router.Group("/origin/storage/pstore", auth...)
+	{
+		group.GET("/ls/*path", func(c *gin.Context) { handleStorageList(c, store) })
+		group.GET("/stat/*path", func(c *gin.Context) { handleStorageStat(c, store) })
+		group.GET("/digest/*path", func(c *gin.Context) { handleStorageDigest(c, store) })
+		group.GET("/usage", func(c *gin.Context) { handleStorageUsage(c, store) })
+	}
+}
+
+// singlePStore returns the store to introspect, when there is exactly one.
+//
+// Exports share a store, so in every supported configuration there is one.
+// Returning nil rather than picking arbitrarily keeps a future multi-store
+// setup from being silently misreported.
+func singlePStore() *pstore.Store {
+	if server_structs.OriginStorageType(param.Origin_StorageType.GetString()) !=
+		server_structs.OriginStoragePStore {
+		return nil
+	}
+	if len(openStores) != 1 {
+		return nil
+	}
+	for _, s := range openStores {
+		return s
+	}
+	return nil
+}
+
+// requestPath extracts the wildcard path, defaulting to the store root.
+func requestPath(c *gin.Context) string {
+	p := c.Param("path")
+	if p == "" {
+		return "/"
+	}
+	return p
+}
+
+// respondStorageError maps a store error onto a status the caller can act on.
+func respondStorageError(c *gin.Context, err error) {
+	c.JSON(storageErrorStatus(err), server_structs.SimpleApiResp{
+		Status: server_structs.RespFailed,
+		Msg:    err.Error(),
+	})
+}
+
+// storageErrorStatus chooses the status for a store error.
+func storageErrorStatus(err error) int {
+	// Specific before general.  ErrNotExist is the broadest of these
+	// sentinels, and platforms differ on which errnos they fold into it, so
+	// testing it first can swallow a more precise answer.
+	switch {
+	case errors.Is(err, pstore.ErrNotDir), errors.Is(err, pstore.ErrIsDir),
+		errors.Is(err, pstore.ErrInvalidPath):
+		return http.StatusBadRequest
+	case errors.Is(err, pstore.ErrNotExist):
+		return http.StatusNotFound
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+func handleStorageList(c *gin.Context, store *pstore.Store) {
+	limit := 1000
+	if raw := c.Query("limit"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 0 {
+			c.JSON(http.StatusBadRequest, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "limit must be a non-negative integer",
+			})
+			return
+		}
+		limit = parsed
+	}
+
+	path := requestPath(c)
+	entries, more, err := store.List(path, c.Query("after"), limit)
+	if err != nil {
+		respondStorageError(c, err)
+		return
+	}
+
+	resp := storageListResponse{
+		Backend: storageBackendPStore,
+		Path:    path,
+		Entries: make([]storageEntryResponse, 0, len(entries)),
+		More:    more,
+	}
+	for _, e := range entries {
+		resp.Entries = append(resp.Entries, entryResponse(path, e.Name, e.Dirent))
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+func handleStorageStat(c *gin.Context, store *pstore.Store) {
+	path := requestPath(c)
+	d, err := store.Stat(path)
+	if err != nil {
+		respondStorageError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, entryResponse("", path, d))
+}
+
+func handleStorageDigest(c *gin.Context, store *pstore.Store) {
+	path := requestPath(c)
+	digests, err := store.Digests(path)
+	if err != nil {
+		respondStorageError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, storageDigestResponse{
+		Backend: storageBackendPStore,
+		Path:    path,
+		Digest:  local_cache.FormatDigestHeader(digests),
+	})
+}
+
+func handleStorageUsage(c *gin.Context, store *pstore.Store) {
+	used, capacity := store.Usage()
+	c.JSON(http.StatusOK, storageUsageResponse{
+		Backend:       storageBackendPStore,
+		UsedBytes:     used,
+		CapacityBytes: capacity,
+	})
+}
+
+// entryResponse renders one entry.  When parent is empty, name is taken as a
+// full path.
+func entryResponse(parent, name string, d *pstore.Dirent) storageEntryResponse {
+	full := name
+	if parent != "" {
+		if parent == "/" {
+			full = "/" + name
+		} else {
+			full = parent + "/" + name
+		}
+	} else {
+		name = pathBase(name)
+	}
+
+	e := storageEntryResponse{
+		Name:     name,
+		Path:     full,
+		IsDir:    d.IsDir(),
+		Size:     d.Size,
+		Modified: time.Unix(0, d.MTimeNanos),
+	}
+	if !d.IsDir() && d.Generation != "" {
+		e.ETag = `"` + d.Generation + `"`
+	}
+	return e
+}
+
+// pathBase returns the final component of a namespace path.
+func pathBase(p string) string {
+	for i := len(p) - 1; i >= 0; i-- {
+		if p[i] == '/' {
+			if i == len(p)-1 && len(p) > 1 {
+				continue
+			}
+			return p[i+1:]
+		}
+	}
+	return p
+}

--- a/origin_serve/storage_api_authz_test.go
+++ b/origin_serve/storage_api_authz_test.go
@@ -1,0 +1,146 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Authorization for the administrative storage-introspection routes, wired
+// exactly as the launcher wires it.
+//
+// The other storage_api tests stub the middleware out so they can exercise the
+// handlers. These do the opposite: they run the real web_ui pair and never
+// reach a handler, because the bug being pinned was in the registration
+// itself. RegisterStorageAPI was mounted with AdminAuthHandler alone, which
+// reads the "User" that an authentication handler is supposed to have put in
+// the context and 401s when it is empty -- so every caller, administrator or
+// not, was rejected and the authorization it implements had never once run.
+
+package origin_serve
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/web_ui"
+)
+
+// newAuthenticatedStorageAPI mounts the storage routes behind the same
+// middleware pair the launcher uses.
+func newAuthenticatedStorageAPI(t *testing.T) *gin.Engine {
+	t.Helper()
+
+	require.NoError(t, param.Origin_StorageType.Set(string(server_structs.OriginStoragePStore)))
+	t.Cleanup(func() { _ = param.Origin_StorageType.Set("posix") })
+
+	// web_ui.AuthHandler refuses bearer tokens outright unless the server
+	// knows its own URL, since that is what it pins the issuer to.
+	require.NoError(t, param.Server_ExternalWebUrl.Set("https://origin.example.com"))
+	t.Cleanup(func() { _ = param.Server_ExternalWebUrl.Set("") })
+
+	// Brings up the store (and, via InitIssuerKeyForTests, the local issuer
+	// key that signs and verifies the tokens below).
+	_ = newPStoreTestBackend(t, "/")
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	RegisterStorageAPI(engine.Group("/api/v1.0"), web_ui.AuthHandler, web_ui.AdminAuthHandler)
+	return engine
+}
+
+// localBearerToken mints a token this server would accept as its own: signed
+// by the local issuer key, with the issuer pinned to GetLocalIssuerUrl().
+func localBearerToken(t *testing.T, subject string) string {
+	t.Helper()
+
+	key, err := config.GetIssuerPrivateJWK()
+	require.NoError(t, err)
+
+	tok, err := jwt.NewBuilder().
+		Issuer(config.GetLocalIssuerUrl()).
+		Subject(subject).
+		IssuedAt(time.Now()).
+		Expiration(time.Now().Add(time.Hour)).
+		Build()
+	require.NoError(t, err)
+
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256, key))
+	require.NoError(t, err)
+	return string(signed)
+}
+
+// TestStorageAPIRejectsUnauthenticated covers the fail-closed half.
+func TestStorageAPIRejectsUnauthenticated(t *testing.T) {
+	engine := newAuthenticatedStorageAPI(t)
+
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/api/v1.0/origin/storage/pstore/usage", nil))
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"an anonymous caller must be told to authenticate: %s", rec.Body.String())
+}
+
+// TestStorageAPIRejectsNonAdmin is the case that could never happen before:
+// with only AdminAuthHandler mounted, a perfectly valid non-admin token still
+// produced a 401, so the administrator check itself was dead code.
+func TestStorageAPIRejectsNonAdmin(t *testing.T) {
+	engine := newAuthenticatedStorageAPI(t)
+
+	for _, route := range []string{"usage", "ls/", "stat/x", "digest/x"} {
+		t.Run(route, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet,
+				"/api/v1.0/origin/storage/pstore/"+route, nil)
+			req.Header.Set("Authorization", "Bearer "+localBearerToken(t, "not-an-admin"))
+
+			rec := httptest.NewRecorder()
+			engine.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusForbidden, rec.Code,
+				"an authenticated non-administrator must get 403, not 401: %s", rec.Body.String())
+		})
+	}
+}
+
+// TestStorageAPIAdmitsAdmin closes the loop: with the pair mounted, an
+// administrator actually reaches the handler.  Without it, this route was
+// unreachable by anyone and `pelican-server origin introspect` could never succeed.
+func TestStorageAPIAdmitsAdmin(t *testing.T) {
+	engine := newAuthenticatedStorageAPI(t)
+
+	require.NoError(t, param.Server_UIAdminUsers.Set([]string{"the-admin"}))
+	t.Cleanup(func() { _ = param.Server_UIAdminUsers.Set(nil) })
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1.0/origin/storage/pstore/usage", nil)
+	req.Header.Set("Authorization", "Bearer "+localBearerToken(t, "the-admin"))
+
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code,
+		"an administrator must reach the handler: %s", rec.Body.String())
+	assert.Contains(t, rec.Body.String(), "usedBytes")
+}

--- a/origin_serve/storage_api_test.go
+++ b/origin_serve/storage_api_test.go
@@ -1,0 +1,201 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package origin_serve
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
+)
+
+// newStorageAPI stands up the administrative routes over a live store, with
+// authentication stubbed so the tests exercise the handlers rather than the
+// auth stack.
+func newStorageAPI(t *testing.T) (*gin.Engine, *pstoreBackend) {
+	t.Helper()
+	require.NoError(t, param.Origin_StorageType.Set(string(server_structs.OriginStoragePStore)))
+	t.Cleanup(func() { _ = param.Origin_StorageType.Set("posix") })
+
+	backend := newPStoreTestBackend(t, "/")
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	RegisterStorageAPI(engine.Group("/api/v1.0"), func(c *gin.Context) { c.Next() })
+	return engine, backend
+}
+
+func seedObject(t *testing.T, b *pstoreBackend, name, body string) {
+	t.Helper()
+	f, err := b.FileSystem().OpenFile(t.Context(), name, os.O_WRONLY|os.O_CREATE, 0644)
+	require.NoError(t, err)
+	_, err = f.Write([]byte(body))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+}
+
+func getJSON(t *testing.T, engine *gin.Engine, path string, out any) int {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+	if out != nil && rec.Code == http.StatusOK {
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), out))
+	}
+	// Surface the body on an unexpected status; a bare status code says
+	// nothing about which of several conditions produced it.
+	t.Logf("GET %s -> %d: %s", path, rec.Code, strings.TrimSpace(rec.Body.String()))
+	return rec.Code
+}
+
+// TestStorageAPIListsALiveStore is the point of the whole interface: the
+// offline CLI cannot open a store the origin holds locked, so the running
+// process has to answer.
+func TestStorageAPIListsALiveStore(t *testing.T) {
+	engine, backend := newStorageAPI(t)
+
+	require.NoError(t, backend.FileSystem().Mkdir(t.Context(), "/data", 0755))
+	seedObject(t, backend, "/data/a.txt", "alpha")
+	seedObject(t, backend, "/data/b.txt", "beta")
+
+	var result storageListResponse
+	require.Equal(t, http.StatusOK, getJSON(t, engine, "/api/v1.0/origin/storage/pstore/ls/data", &result))
+
+	assert.Equal(t, storageBackendPStore, result.Backend)
+	require.Len(t, result.Entries, 2)
+	assert.Equal(t, "a.txt", result.Entries[0].Name)
+	assert.Equal(t, "/data/a.txt", result.Entries[0].Path)
+	assert.Equal(t, int64(5), result.Entries[0].Size)
+	assert.NotEmpty(t, result.Entries[0].ETag)
+	assert.False(t, result.More)
+}
+
+func TestStorageAPIPaginates(t *testing.T) {
+	engine, backend := newStorageAPI(t)
+
+	require.NoError(t, backend.FileSystem().Mkdir(t.Context(), "/d", 0755))
+	for _, n := range []string{"a", "b", "c"} {
+		seedObject(t, backend, "/d/"+n, n)
+	}
+
+	var page storageListResponse
+	require.Equal(t, http.StatusOK,
+		getJSON(t, engine, "/api/v1.0/origin/storage/pstore/ls/d?limit=2", &page))
+	require.Len(t, page.Entries, 2)
+	assert.True(t, page.More, "a truncated page says so")
+
+	var rest storageListResponse
+	require.Equal(t, http.StatusOK,
+		getJSON(t, engine, "/api/v1.0/origin/storage/pstore/ls/d?limit=2&after=b", &rest))
+	require.Len(t, rest.Entries, 1)
+	assert.Equal(t, "c", rest.Entries[0].Name)
+	assert.False(t, rest.More)
+}
+
+func TestStorageAPIStatAndDigest(t *testing.T) {
+	engine, backend := newStorageAPI(t)
+	seedObject(t, backend, "/obj.txt", "contents")
+
+	var entry storageEntryResponse
+	require.Equal(t, http.StatusOK,
+		getJSON(t, engine, "/api/v1.0/origin/storage/pstore/stat/obj.txt", &entry))
+	assert.Equal(t, "obj.txt", entry.Name)
+	assert.Equal(t, int64(8), entry.Size)
+	assert.False(t, entry.IsDir)
+
+	var digest storageDigestResponse
+	require.Equal(t, http.StatusOK,
+		getJSON(t, engine, "/api/v1.0/origin/storage/pstore/digest/obj.txt", &digest))
+	assert.Contains(t, digest.Digest, "md5=", "digests are reported in RFC 3230 form")
+}
+
+func TestStorageAPIUsage(t *testing.T) {
+	engine, backend := newStorageAPI(t)
+	seedObject(t, backend, "/obj.txt", "contents")
+
+	var usage storageUsageResponse
+	require.Equal(t, http.StatusOK,
+		getJSON(t, engine, "/api/v1.0/origin/storage/pstore/usage", &usage))
+	assert.Equal(t, storageBackendPStore, usage.Backend)
+	assert.Greater(t, usage.UsedBytes, int64(0))
+}
+
+// TestStorageAPIErrorsAreActionable checks that a caller can tell the
+// difference between a missing object and a misuse.
+func TestStorageAPIErrorsAreActionable(t *testing.T) {
+	engine, backend := newStorageAPI(t)
+	seedObject(t, backend, "/file.txt", "x")
+
+	assert.Equal(t, http.StatusNotFound,
+		getJSON(t, engine, "/api/v1.0/origin/storage/pstore/stat/missing", nil))
+	assert.Equal(t, http.StatusBadRequest,
+		getJSON(t, engine, "/api/v1.0/origin/storage/pstore/ls/file.txt", nil),
+		"listing a file is a client error, not a server one")
+	assert.Equal(t, http.StatusBadRequest,
+		getJSON(t, engine, "/api/v1.0/origin/storage/pstore/ls/?limit=-1", nil))
+}
+
+// TestStorageAPIAbsentOnOtherBackends is why the CLI can say "this origin has
+// no such interface" rather than failing obscurely: the routes are never
+// registered unless the backend actually has one.
+func TestStorageAPIAbsentOnOtherBackends(t *testing.T) {
+	require.NoError(t, param.Origin_StorageType.Set("posix"))
+	t.Cleanup(func() { _ = param.Origin_StorageType.Set("posix") })
+	ResetPStoreState()
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	RegisterStorageAPI(engine.Group("/api/v1.0"), func(c *gin.Context) { c.Next() })
+
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/api/v1.0/origin/storage/pstore/usage", nil))
+	assert.Equal(t, http.StatusNotFound, rec.Code,
+		"a non-pstore origin registers no storage routes at all")
+}
+
+// TestStorageAPIRequiresAdmin confirms the middleware is actually applied;
+// these routes expose the whole namespace.
+func TestStorageAPIRequiresAdmin(t *testing.T) {
+	require.NoError(t, param.Origin_StorageType.Set(string(server_structs.OriginStoragePStore)))
+	t.Cleanup(func() { _ = param.Origin_StorageType.Set("posix") })
+	_ = newPStoreTestBackend(t, "/")
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	denied := false
+	RegisterStorageAPI(engine.Group("/api/v1.0"), func(c *gin.Context) {
+		denied = true
+		c.AbortWithStatus(http.StatusForbidden)
+	})
+
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/api/v1.0/origin/storage/pstore/usage", nil))
+	assert.True(t, denied, "the auth handler must run before the route")
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}

--- a/origin_serve/tpc_handler.go
+++ b/origin_serve/tpc_handler.go
@@ -116,7 +116,7 @@ func copyWithContext(dst io.Writer, src io.Reader) error {
 //
 // The client sends an HTTP COPY request to the destination origin with:
 //   - Source header: URL of the source object
-//   - Authorization header: bearer token authorising writes on this destination
+//   - Authorization header: bearer token authorizing writes on this destination
 //   - TransferHeader* headers: any header prefixed with "TransferHeader" is
 //     forwarded to the source GET with the prefix stripped (e.g.
 //     TransferHeaderAuthorization becomes Authorization).  Hop-by-hop and

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -394,6 +394,15 @@ var runtimeConfigurableMap = map[string]bool{
 	"Origin.MultiuserVarlinkSocketPath": false,
 	"Origin.NamespacePrefix": false,
 	"Origin.ObjectProviderURL": false,
+	"Origin.PStoreDataScanInterval": false,
+	"Origin.PStoreDataScanRate": false,
+	"Origin.PStoreIndexCheckInterval": false,
+	"Origin.PStoreInlineMaxBytes": false,
+	"Origin.PStoreLocation": false,
+	"Origin.PStoreMetadataBackupInterval": false,
+	"Origin.PStoreMetadataBackupLocation": false,
+	"Origin.PStoreMetadataBackupsToKeep": false,
+	"Origin.PStoreStorageDirs": false,
 	"Origin.Port": false,
 	"Origin.RunLocation": false,
 	"Origin.S3AccessKeyfile": false,
@@ -722,6 +731,8 @@ var stringAccessors = map[string]func(*Config) string{
 	"Origin.MultiuserVarlinkSocketPath": func(c *Config) string { return c.Origin.MultiuserVarlinkSocketPath },
 	"Origin.NamespacePrefix": func(c *Config) string { return c.Origin.NamespacePrefix },
 	"Origin.ObjectProviderURL": func(c *Config) string { return c.Origin.ObjectProviderURL },
+	"Origin.PStoreLocation": func(c *Config) string { return c.Origin.PStoreLocation },
+	"Origin.PStoreMetadataBackupLocation": func(c *Config) string { return c.Origin.PStoreMetadataBackupLocation },
 	"Origin.RunLocation": func(c *Config) string { return c.Origin.RunLocation },
 	"Origin.S3AccessKeyfile": func(c *Config) string { return c.Origin.S3AccessKeyfile },
 	"Origin.S3Bucket": func(c *Config) string { return c.Origin.S3Bucket },
@@ -941,6 +952,8 @@ var intAccessors = map[string]func(*Config) int{
 	"Origin.DiskUsageCalculationRateLimit": func(c *Config) int { return c.Origin.DiskUsageCalculationRateLimit },
 	"Origin.MultiuserMinID": func(c *Config) int { return c.Origin.MultiuserMinID },
 	"Origin.MultiuserUmask": func(c *Config) int { return c.Origin.MultiuserUmask },
+	"Origin.PStoreInlineMaxBytes": func(c *Config) int { return c.Origin.PStoreInlineMaxBytes },
+	"Origin.PStoreMetadataBackupsToKeep": func(c *Config) int { return c.Origin.PStoreMetadataBackupsToKeep },
 	"Origin.Port": func(c *Config) int { return c.Origin.Port },
 	"Origin.SSH.MaxRetries": func(c *Config) int { return c.Origin.SSH.MaxRetries },
 	"Origin.SSH.Port": func(c *Config) int { return c.Origin.SSH.Port },
@@ -990,6 +1003,7 @@ func (iP IntParam) Set(value int) error {
 }
 
 var byteRateAccessors = map[string]func(*Config) byte_rate.ByteRate{
+	"Origin.PStoreDataScanRate": func(c *Config) byte_rate.ByteRate { return c.Origin.PStoreDataScanRate },
 	"Origin.TransferRateLimit": func(c *Config) byte_rate.ByteRate { return c.Origin.TransferRateLimit },
 }
 
@@ -1202,6 +1216,9 @@ var durationAccessors = map[string]func(*Config) time.Duration{
 	"Origin.DiskUsageCalculationDelay": func(c *Config) time.Duration { return c.Origin.DiskUsageCalculationDelay },
 	"Origin.DiskUsageCalculationInterval": func(c *Config) time.Duration { return c.Origin.DiskUsageCalculationInterval },
 	"Origin.Globusv2TokenRefreshInterval": func(c *Config) time.Duration { return c.Origin.Globusv2TokenRefreshInterval },
+	"Origin.PStoreDataScanInterval": func(c *Config) time.Duration { return c.Origin.PStoreDataScanInterval },
+	"Origin.PStoreIndexCheckInterval": func(c *Config) time.Duration { return c.Origin.PStoreIndexCheckInterval },
+	"Origin.PStoreMetadataBackupInterval": func(c *Config) time.Duration { return c.Origin.PStoreMetadataBackupInterval },
 	"Origin.SSH.ChallengeTimeout": func(c *Config) time.Duration { return c.Origin.SSH.ChallengeTimeout },
 	"Origin.SSH.ConnectTimeout": func(c *Config) time.Duration { return c.Origin.SSH.ConnectTimeout },
 	"Origin.SSH.KeepaliveInterval": func(c *Config) time.Duration { return c.Origin.SSH.KeepaliveInterval },
@@ -1619,6 +1636,15 @@ var allParameterNames = []string{
 	"Origin.MultiuserVarlinkSocketPath",
 	"Origin.NamespacePrefix",
 	"Origin.ObjectProviderURL",
+	"Origin.PStoreDataScanInterval",
+	"Origin.PStoreDataScanRate",
+	"Origin.PStoreIndexCheckInterval",
+	"Origin.PStoreInlineMaxBytes",
+	"Origin.PStoreLocation",
+	"Origin.PStoreMetadataBackupInterval",
+	"Origin.PStoreMetadataBackupLocation",
+	"Origin.PStoreMetadataBackupsToKeep",
+	"Origin.PStoreStorageDirs",
 	"Origin.Port",
 	"Origin.RunLocation",
 	"Origin.S3AccessKeyfile",
@@ -1920,6 +1946,8 @@ var (
 	Origin_MultiuserVarlinkSocketPath = StringParam{"Origin.MultiuserVarlinkSocketPath"}
 	Origin_NamespacePrefix = StringParam{"Origin.NamespacePrefix"}
 	Origin_ObjectProviderURL = StringParam{"Origin.ObjectProviderURL"}
+	Origin_PStoreLocation = StringParam{"Origin.PStoreLocation"}
+	Origin_PStoreMetadataBackupLocation = StringParam{"Origin.PStoreMetadataBackupLocation"}
 	Origin_RunLocation = StringParam{"Origin.RunLocation"}
 	Origin_S3AccessKeyfile = StringParam{"Origin.S3AccessKeyfile"}
 	Origin_S3Bucket = StringParam{"Origin.S3Bucket"}
@@ -2083,6 +2111,8 @@ var (
 	Origin_DiskUsageCalculationRateLimit = IntParam{"Origin.DiskUsageCalculationRateLimit"}
 	Origin_MultiuserMinID = IntParam{"Origin.MultiuserMinID"}
 	Origin_MultiuserUmask = IntParam{"Origin.MultiuserUmask"}
+	Origin_PStoreInlineMaxBytes = IntParam{"Origin.PStoreInlineMaxBytes"}
+	Origin_PStoreMetadataBackupsToKeep = IntParam{"Origin.PStoreMetadataBackupsToKeep"}
 	Origin_Port = IntParam{"Origin.Port"}
 	Origin_SSH_MaxRetries = IntParam{"Origin.SSH.MaxRetries"}
 	Origin_SSH_Port = IntParam{"Origin.SSH.Port"}
@@ -2104,6 +2134,7 @@ var (
 )
 
 var (
+	Origin_PStoreDataScanRate = ByteRateParam{"Origin.PStoreDataScanRate"}
 	Origin_TransferRateLimit = ByteRateParam{"Origin.TransferRateLimit"}
 )
 
@@ -2251,6 +2282,9 @@ var (
 	Origin_DiskUsageCalculationDelay = DurationParam{"Origin.DiskUsageCalculationDelay"}
 	Origin_DiskUsageCalculationInterval = DurationParam{"Origin.DiskUsageCalculationInterval"}
 	Origin_Globusv2TokenRefreshInterval = DurationParam{"Origin.Globusv2TokenRefreshInterval"}
+	Origin_PStoreDataScanInterval = DurationParam{"Origin.PStoreDataScanInterval"}
+	Origin_PStoreIndexCheckInterval = DurationParam{"Origin.PStoreIndexCheckInterval"}
+	Origin_PStoreMetadataBackupInterval = DurationParam{"Origin.PStoreMetadataBackupInterval"}
 	Origin_SSH_ChallengeTimeout = DurationParam{"Origin.SSH.ChallengeTimeout"}
 	Origin_SSH_ConnectTimeout = DurationParam{"Origin.SSH.ConnectTimeout"}
 	Origin_SSH_KeepaliveInterval = DurationParam{"Origin.SSH.KeepaliveInterval"}
@@ -2290,6 +2324,7 @@ var (
 	LocalCache_StorageDirs = ObjectParam{"LocalCache.StorageDirs"}
 	Lotman_PolicyDefinitions = ObjectParam{"Lotman.PolicyDefinitions"}
 	Origin_Exports = ObjectParam{"Origin.Exports"}
+	Origin_PStoreStorageDirs = ObjectParam{"Origin.PStoreStorageDirs"}
 	Registry_CustomRegistrationFields = ObjectParam{"Registry.CustomRegistrationFields"}
 	Registry_Institutions = ObjectParam{"Registry.Institutions"}
 	Shoveler_IPMapping = ObjectParam{"Shoveler.IPMapping"}
@@ -2431,6 +2466,8 @@ func init() {
 		"Origin.MultiuserVarlinkSocketPath": Origin_MultiuserVarlinkSocketPath,
 		"Origin.NamespacePrefix": Origin_NamespacePrefix,
 		"Origin.ObjectProviderURL": Origin_ObjectProviderURL,
+		"Origin.PStoreLocation": Origin_PStoreLocation,
+		"Origin.PStoreMetadataBackupLocation": Origin_PStoreMetadataBackupLocation,
 		"Origin.RunLocation": Origin_RunLocation,
 		"Origin.S3AccessKeyfile": Origin_S3AccessKeyfile,
 		"Origin.S3Bucket": Origin_S3Bucket,
@@ -2588,6 +2625,8 @@ func init() {
 		"Origin.DiskUsageCalculationRateLimit": Origin_DiskUsageCalculationRateLimit,
 		"Origin.MultiuserMinID": Origin_MultiuserMinID,
 		"Origin.MultiuserUmask": Origin_MultiuserUmask,
+		"Origin.PStoreInlineMaxBytes": Origin_PStoreInlineMaxBytes,
+		"Origin.PStoreMetadataBackupsToKeep": Origin_PStoreMetadataBackupsToKeep,
 		"Origin.Port": Origin_Port,
 		"Origin.SSH.MaxRetries": Origin_SSH_MaxRetries,
 		"Origin.SSH.Port": Origin_SSH_Port,
@@ -2606,6 +2645,7 @@ func init() {
 		"Xrootd.MaxThreads": Xrootd_MaxThreads,
 		"Xrootd.Port": Xrootd_Port,
 		"Xrootd.SummaryMonitoringPort": Xrootd_SummaryMonitoringPort,
+		"Origin.PStoreDataScanRate": Origin_PStoreDataScanRate,
 		"Origin.TransferRateLimit": Origin_TransferRateLimit,
 		"Cache.DirectorTest": Cache_DirectorTest,
 		"Cache.DisableClientX509": Cache_DisableClientX509,
@@ -2747,6 +2787,9 @@ func init() {
 		"Origin.DiskUsageCalculationDelay": Origin_DiskUsageCalculationDelay,
 		"Origin.DiskUsageCalculationInterval": Origin_DiskUsageCalculationInterval,
 		"Origin.Globusv2TokenRefreshInterval": Origin_Globusv2TokenRefreshInterval,
+		"Origin.PStoreDataScanInterval": Origin_PStoreDataScanInterval,
+		"Origin.PStoreIndexCheckInterval": Origin_PStoreIndexCheckInterval,
+		"Origin.PStoreMetadataBackupInterval": Origin_PStoreMetadataBackupInterval,
 		"Origin.SSH.ChallengeTimeout": Origin_SSH_ChallengeTimeout,
 		"Origin.SSH.ConnectTimeout": Origin_SSH_ConnectTimeout,
 		"Origin.SSH.KeepaliveInterval": Origin_SSH_KeepaliveInterval,
@@ -2783,6 +2826,7 @@ func init() {
 		"LocalCache.StorageDirs": LocalCache_StorageDirs,
 		"Lotman.PolicyDefinitions": Lotman_PolicyDefinitions,
 		"Origin.Exports": Origin_Exports,
+		"Origin.PStoreStorageDirs": Origin_PStoreStorageDirs,
 		"Registry.CustomRegistrationFields": Registry_CustomRegistrationFields,
 		"Registry.Institutions": Registry_Institutions,
 		"Shoveler.IPMapping": Shoveler_IPMapping,

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -358,6 +358,15 @@ type Config struct {
 		MultiuserVarlinkSocketPath string `mapstructure:"multiuservarlinksocketpath" yaml:"MultiuserVarlinkSocketPath"`
 		NamespacePrefix string `mapstructure:"namespaceprefix" yaml:"NamespacePrefix"`
 		ObjectProviderURL string `mapstructure:"objectproviderurl" yaml:"ObjectProviderURL"`
+		PStoreDataScanInterval time.Duration `mapstructure:"pstoredatascaninterval" yaml:"PStoreDataScanInterval"`
+		PStoreDataScanRate byte_rate.ByteRate `mapstructure:"pstoredatascanrate" yaml:"PStoreDataScanRate"`
+		PStoreIndexCheckInterval time.Duration `mapstructure:"pstoreindexcheckinterval" yaml:"PStoreIndexCheckInterval"`
+		PStoreInlineMaxBytes int `mapstructure:"pstoreinlinemaxbytes" yaml:"PStoreInlineMaxBytes"`
+		PStoreLocation string `mapstructure:"pstorelocation" yaml:"PStoreLocation"`
+		PStoreMetadataBackupInterval time.Duration `mapstructure:"pstoremetadatabackupinterval" yaml:"PStoreMetadataBackupInterval"`
+		PStoreMetadataBackupLocation string `mapstructure:"pstoremetadatabackuplocation" yaml:"PStoreMetadataBackupLocation"`
+		PStoreMetadataBackupsToKeep int `mapstructure:"pstoremetadatabackupstokeep" yaml:"PStoreMetadataBackupsToKeep"`
+		PStoreStorageDirs any `mapstructure:"pstorestoragedirs" yaml:"PStoreStorageDirs"`
 		Port int `mapstructure:"port" yaml:"Port"`
 		RunLocation string `mapstructure:"runlocation" yaml:"RunLocation"`
 		S3AccessKeyfile string `mapstructure:"s3accesskeyfile" yaml:"S3AccessKeyfile"`
@@ -899,6 +908,15 @@ type configWithType struct {
 		MultiuserVarlinkSocketPath struct { Type string; Value string }
 		NamespacePrefix struct { Type string; Value string }
 		ObjectProviderURL struct { Type string; Value string }
+		PStoreDataScanInterval struct { Type string; Value time.Duration }
+		PStoreDataScanRate struct { Type string; Value byte_rate.ByteRate }
+		PStoreIndexCheckInterval struct { Type string; Value time.Duration }
+		PStoreInlineMaxBytes struct { Type string; Value int }
+		PStoreLocation struct { Type string; Value string }
+		PStoreMetadataBackupInterval struct { Type string; Value time.Duration }
+		PStoreMetadataBackupLocation struct { Type string; Value string }
+		PStoreMetadataBackupsToKeep struct { Type string; Value int }
+		PStoreStorageDirs struct { Type string; Value any }
 		Port struct { Type string; Value int }
 		RunLocation struct { Type string; Value string }
 		S3AccessKeyfile struct { Type string; Value string }

--- a/pstore/backup.go
+++ b/pstore/backup.go
@@ -1,0 +1,552 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Metadata backup and restore: the container and the policy.
+//
+// This file owns what a snapshot *is* -- when one is taken, what goes in it,
+// how it is published, pruned, and loaded back.  backup_crypto.go owns the
+// other half: the envelope that carries the key and the AES-256-GCM sealing of
+// the body under it.  The split is one of policy and mechanism, and the rule
+// that lives here is that there is exactly one container and it is sealed:
+// there is no unencrypted path out of this package, and nothing to dispatch on.
+//
+// For a cache, losing the database is an inconvenience: every object in it can
+// be fetched again from an origin.  For an origin it is data loss.  The block
+// files on disk are named by hash and encrypted, and everything needed to
+// interpret them -- the namespace, each object's data key, its size, its
+// checksums -- lives in the catalog.  A store whose catalog is gone is a
+// directory of unreadable bytes.
+//
+// So the catalog -- the metadata -- is backed up separately from the data,
+// and far more often than its size would suggest is necessary.  It is small (megabytes against
+// terabytes of objects) and BadgerDB can stream a consistent snapshot of it
+// while the origin is running, so a periodic snapshot costs almost nothing.
+//
+// A backup is only useful alongside two other things, and the CLI says so
+// rather than letting an operator discover it during a recovery:
+//
+//   - the block files, which ordinary filesystem backup tools handle; and
+//   - masterkey.json, which wraps the key everything is encrypted under.  It
+//     is itself encrypted under the origin's issuer keys, so those must
+//     survive too.
+//
+// # What a sealed snapshot contains, and what opens it
+//
+// An archive is not merely ciphertext: it carries the material needed to open
+// itself, to anyone who holds one of three keys.  Its header holds
+//
+//   - a 32-byte salt drawn for this snapshot alone, and
+//   - one envelope block per recipient, each carrying **the archive's backup
+//     key sealed to one of the origin's current issuer keys** (or, when
+//     BackupKeys.BackupKey is supplied, to that key instead).
+//
+// The body is encrypted under a per-file key = HKDF(backup key, salt), so the
+// three ways into an archive are:
+//
+//   - an **issuer key** -- derive its pstore key pair, open its envelope block,
+//     recover the backup key, derive the per-file key;
+//   - the **escrowed backup key** -- open its own envelope block, which yields
+//     the archive's backup key, and derive from there;
+//   - that **one archive's file key** -- decrypt directly, with no envelope and
+//     no issuer key present anywhere.
+//
+// The property this buys, and the reason the backup key is embedded rather than
+// left implicit: **losing the origin's issuer keys does not lose the archives,
+// provided the backup key was escrowed.**  An archive also survives a key
+// rotation, because it opens with any issuer key that was current when it was
+// written.  See backup_crypto.go for the derivation, the envelope layout, and
+// what is authenticated.
+//
+// These three keys open the *catalog*, and nothing else.  They are unrelated to
+// masterkey.json, which is what makes the block files readable and which is
+// sealed to the issuer keys directly -- so an escrowed backup key on its own
+// recovers the namespace but not one byte of object data.  recover.go states
+// the whole of what a recovery needs; it is the thing to read before deciding
+// what to escrow.
+//
+// # Why a backup is not just BadgerDB's stream
+//
+// BadgerDB's backup is a sequence of length-prefixed protobuf frames, and its
+// loader treats a clean EOF at any frame boundary as the end of a complete
+// backup.  Written straight to a file, a snapshot truncated at a frame
+// boundary -- a full disk, a killed process, a partial copy off the host --
+// restores with no error and fewer objects than it had, or none at all.  For a
+// primary store that is the worst possible failure: it is silent, and it is
+// discovered during a recovery.
+//
+// So a metadata backup is a container, and the container gets that property
+// from its AEAD construction: chunks are bound to their position and the last
+// one is marked, so truncation and splicing both fail to open rather than
+// restoring part of a catalog.  Every snapshot this package publishes uses it,
+// because a snapshot is a logical dump of the namespace and must never be
+// written in the clear.
+
+package pstore
+
+import (
+	"bufio"
+	"compress/gzip"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/metrics"
+)
+
+// BackupEncrypted writes a snapshot sealed to keys.
+//
+// This is the only way to write a snapshot.  Encryption is not optional and
+// there is no key to forget to configure: the archive's backup key is derived
+// from the origin's issuer keys unless one is supplied outright, and a caller
+// that can produce neither gets an error rather than a cleartext dump of the
+// namespace.
+//
+// **What ends up in the file** is the compressed catalog encrypted under a key
+// belonging to this snapshot alone, preceded by a header that carries the salt
+// that key was derived from *and the archive's backup key sealed once per
+// recipient* -- one recipient per issuer key in keys.IssuerKeys, or the single
+// supplied keys.BackupKey when there is one.  Embedding the sealed backup key
+// is what makes the file self-opening: any of those issuer keys reaches it, and
+// so does the escrowed backup key on a machine that has never held them.  An
+// operator who escrowed the backup key can restore this file after the issuer
+// keys are gone.  See backup_crypto.go for the derivation and the envelope.
+//
+// Truncation and tampering are detected by the AEAD construction itself, so
+// there is no second framing layer inside the sealed one.
+func (s *Store) BackupEncrypted(w io.Writer, keys BackupKeys) (uint64, error) {
+	// BadgerDB writes the snapshot rather than handing it back, so bridge the
+	// two with a pipe instead of buffering a whole catalog in memory.
+	pr, pw := io.Pipe()
+
+	var (
+		version uint64
+		bErr    error
+	)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// Compress on the way to the sealer: a catalog is mostly repeated
+		// path strings and near-identical metadata records, so it shrinks a
+		// great deal, and ciphertext would not compress at all afterwards.
+		zw := gzip.NewWriter(pw)
+		version, bErr = s.bdb.Backup(zw, 0)
+		if bErr == nil {
+			bErr = zw.Close()
+		}
+		pw.CloseWithError(bErr)
+	}()
+
+	if err := encryptBackup(w, pr, keys); err != nil {
+		pr.CloseWithError(err)
+		<-done
+		return 0, err
+	}
+	<-done
+	if bErr != nil {
+		return 0, errors.Wrap(bErr, "failed to back up the pstore metadata")
+	}
+	return version, nil
+}
+
+// restoreEncrypted loads a snapshot sealed by BackupEncrypted.
+func (s *Store) restoreEncrypted(r io.Reader, keys BackupKeys) error {
+	pr, pw := io.Pipe()
+
+	// The decryption error is kept rather than only propagated through the
+	// pipe, because it is the one an operator can act on.  A wrong key, an
+	// unreadable format version and a damaged header all surface here as "gzip:
+	// invalid header" on the reading side; reporting that instead would replace
+	// a sentence naming the key IDs the archive needs with one naming a
+	// compression library.
+	var decErr error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		decErr = decryptBackup(pw, r, keys)
+		pw.CloseWithError(decErr)
+	}()
+
+	zr, err := gzip.NewReader(pr)
+	if err != nil {
+		pr.CloseWithError(err)
+		<-done
+		if decErr != nil {
+			return decErr
+		}
+		return errors.Wrap(err, "the snapshot is not readable after decryption")
+	}
+	defer zr.Close()
+
+	if err := s.restoreStream(zr); err != nil {
+		pr.CloseWithError(err)
+		<-done
+		return err
+	}
+	<-done
+	return nil
+}
+
+// Restore loads a metadata backup into this store.
+//
+// There is one container and it is sealed, so the only question the file itself
+// answers is whether it is a pstore snapshot at all: a file without the magic is
+// refused as "not a backup", and one whose format version this build does not
+// read is refused by number rather than misparsed.  The two are separate
+// messages on purpose -- they send an operator to different places.
+//
+// **Any one of three keys opens an archive**, and keys may carry whichever the
+// operator still has:
+//
+//   - keys.IssuerKeys -- the origin's issuer keys, the ordinary case on the
+//     origin itself.  Any single key the archive was sealed to is enough, so a
+//     rotation does not strand the archives that overlapped it.
+//   - keys.BackupKey -- the escrowed backup key from DeriveBackupKey.  The
+//     archive carries its own backup key sealed to this one, so this restores
+//     on a machine that has never held the origin's issuer keys.  **Escrowing
+//     it is what makes the loss of the issuer keys survivable.**
+//   - keys.FileKey -- that one archive's own key from DeriveFileKey, which
+//     opens it and nothing else.
+//
+// The store must be empty: restoring over live records would interleave two
+// namespaces rather than replace one.
+//
+// **A failed restore is not a no-op.**  BadgerDB's loader writes as it reads,
+// so a snapshot that turns out to be truncated or damaged part-way through
+// leaves records in the directory and this handle unusable.  There is no way
+// to unwind that from here; the directory has to be discarded and the restore
+// started again into a fresh one.  This is why the container authenticates its
+// header before a byte of the body is opened and marks its terminating chunk:
+// most damage is caught before a single record is written, and what is caught
+// late says plainly what state it left behind.
+//
+// **The store must be reopened afterwards.**  A restore replaces the whole
+// database, including everything a store reads once at open and then caches:
+// the hash salt that every instance hash is derived from, and the mapping
+// from storage IDs to directories.  Continuing to use the handle would
+// compute hashes that match nothing and look for block files under empty
+// paths.  The salt is refreshed here so that a caller inspecting the
+// namespace immediately after a restore sees the right thing, but reading
+// object data requires a fresh open.
+func (s *Store) Restore(r io.Reader, keys BackupKeys) error {
+	// Cheapest precondition first: a store that cannot be written to will not
+	// become restorable further down, and reporting "this file is too short"
+	// for it would send an operator after the wrong problem.
+	if err := s.checkWritable(); err != nil {
+		return err
+	}
+
+	// Recognize the container before handing the file to the decryption
+	// pipeline, so that a file which is not a snapshot at all is named as such.
+	// Peek rather than read: the reader below wants its own magic back.
+	//
+	// This is the message an operator sees after pointing `metadata-restore` at
+	// the wrong path, or at a bare BadgerDB dump -- which is the dangerous one,
+	// because BadgerDB's loader would happily accept a truncated dump and
+	// restore a fraction of a namespace without complaint.
+	br := bufio.NewReader(r)
+	magic, err := br.Peek(len(backupMagicPrefix))
+	if err != nil && len(magic) < len(backupMagicPrefix) {
+		return errors.Wrap(err, "this file is too short to be a pstore metadata backup")
+	}
+	if !looksEncrypted(magic) {
+		return errors.New("this file is not a pstore metadata backup: it does not begin with " +
+			"the container magic. Every snapshot pstore writes carries one, so this is either " +
+			"not a snapshot -- a raw database dump, or another file entirely -- or a snapshot " +
+			"that has lost its opening bytes")
+	}
+	return s.restoreEncrypted(br, keys)
+}
+
+// restoreStream loads an already-unwrapped BadgerDB stream.
+//
+// r must fail rather than report EOF when its input was truncated, which the
+// sealed container's reader does: its terminating chunk is the only clean end
+// of stream.
+func (s *Store) restoreStream(r io.Reader) error {
+	if err := s.checkWritable(); err != nil {
+		return err
+	}
+	empty, err := s.isEmpty()
+	if err != nil {
+		return err
+	}
+	if !empty {
+		return errors.New("refusing to restore into a store that already holds objects; " +
+			"restore into an empty directory instead")
+	}
+	if err := s.bdb.Load(r, restoreMaxPendingWrites); err != nil {
+		// A load that stops part-way through leaves records behind *and*
+		// leaves BadgerDB's transaction watermark short of the timestamps it
+		// already wrote, so this handle will block on the next read and the
+		// directory holds a fragment of a namespace.  Nothing here can undo
+		// either; what it can do is say so, rather than let an operator retry
+		// into the same directory and build a chimera out of two catalogs.
+		return errors.Wrap(err,
+			"failed to restore the pstore metadata; this directory now holds a partial "+
+				"catalog and must be discarded -- restore into a fresh one")
+	}
+
+	// Load replaces the database wholesale, header keys included, so the
+	// schema version that was checked when this store opened is not the one
+	// now on disk.  A snapshot taken by a newer Pelican carries a newer
+	// layout, and nothing else would notice: the open-time check has already
+	// run.  Re-verify against what the restore actually wrote.
+	if err := s.db.VerifySchemaVersion(); err != nil {
+		return errors.Wrap(err,
+			"the restored catalog was written by a newer Pelican; this directory must be "+
+				"discarded and the restore repeated with a build that supports it")
+	}
+
+	// The restore replaced the database's contents, including the hash salt
+	// every instance hash in it was derived from.  The salt cached when this
+	// store opened is now the wrong one, and using it would compute hashes
+	// that match nothing -- a restored catalog whose objects all appear
+	// missing.
+	if err := s.db.ReloadSalt(); err != nil {
+		return err
+	}
+
+	// Detached-subtree state belongs to the restored catalog too.
+	s.detached = newDetachedSet()
+	return s.reloadDetached()
+}
+
+// restoreMaxPendingWrites bounds BadgerDB's write concurrency during a load.
+const restoreMaxPendingWrites = 256
+
+// isEmpty reports whether the namespace holds no entries.
+func (s *Store) isEmpty() (bool, error) {
+	entries, _, err := s.List("/", "", 1)
+	if err != nil {
+		return false, err
+	}
+	return len(entries) == 0, nil
+}
+
+// ---------------------------------------------------------------------------
+// The scheduled backup
+// ---------------------------------------------------------------------------
+
+// StartBackups snapshots the catalog to dir every interval, for as long as the
+// context lives.
+//
+// Each pass writes a new timestamped file and prunes the oldest beyond keep,
+// so a corrupted catalog can be rolled back to rather than only forward from.
+// A failed pass is logged and retried at the next interval: a backup problem
+// must not take the origin down.
+//
+// One snapshot is taken immediately.  Waiting for the first interval to elapse
+// means an unwritable backup directory -- the wrong owner, a full filesystem, a
+// typo in the configured path -- goes unreported for a whole interval, and a
+// store that dies inside its first hour has no metadata backup at all, which is
+// the case backups exist for.
+//
+// After that the interval is a gap, not a cadence: the next snapshot starts an
+// interval after the previous one *finished*.  A snapshot of a large catalog is
+// not instant, and the six-hour default is close enough to the time one can take
+// that a fixed cadence would have the origin snapshotting back to back.  See
+// runPeriodically in integrity.go.
+func (s *Store) StartBackups(ctx context.Context, egrp *errgroup.Group, cfg BackupConfig) {
+	if cfg.Dir == "" || cfg.Interval <= 0 {
+		return
+	}
+	if cfg.Keys.Empty() {
+		// Refusing outright is the point of the change that made encryption
+		// mandatory.  The alternative -- warning and writing cleartext -- put a
+		// dump of the whole namespace on disk for anyone who did not read the
+		// log, which is everyone.
+		log.Errorf("No keys are available to encrypt pstore metadata backups, so the "+
+			"origin's metadata is NOT being backed up to %s. A snapshot is a logical dump "+
+			"of the namespace and is never written unencrypted.", cfg.Dir)
+		return
+	}
+	// Fail the obvious way at startup rather than an interval later.
+	if err := os.MkdirAll(cfg.Dir, 0700); err != nil {
+		log.Errorf("pstore metadata backup directory %s is not usable, so the origin's "+
+			"metadata is NOT being backed up: %v", cfg.Dir, err)
+	}
+	egrp.Go(func() error {
+		s.runBackupLoop(ctx, cfg, realSchedule())
+		return nil
+	})
+	log.Infof("pstore metadata backups every %s to %s (keeping %d)",
+		cfg.Interval, cfg.Dir, cfg.Keep)
+}
+
+// runBackupLoop takes the startup snapshot and then one per interval.
+//
+// Split out of StartBackups so the schedule can be driven by a test; everything
+// above it is validation and logging that a test would only have to work
+// around.
+func (s *Store) runBackupLoop(ctx context.Context, cfg BackupConfig, sched schedule) {
+	// The startup snapshot is observed exactly like a scheduled one.  Leaving
+	// it out would mean a store whose very first backup fails looks like a
+	// store that has simply not been up long enough to snapshot yet -- and the
+	// startup snapshot exists precisely because that first hour is the window
+	// backups are most often silently broken in.
+	observedSnapshot := func() error {
+		pass := beginPass(metrics.PStorePassMetadataBackup, cfg.Interval, sched)
+		err := s.snapshotOnce(cfg)
+		pass.finish(err == nil)
+		return err
+	}
+
+	if err := observedSnapshot(); err != nil {
+		// Loud: at startup this is almost always a misconfiguration the
+		// operator can fix now, rather than discover during a recovery.
+		log.Errorf("Initial pstore metadata backup failed: %v", err)
+	}
+
+	runPeriodically(ctx, cfg.Interval, sched, "metadata backup", func() {
+		if err := observedSnapshot(); err != nil {
+			log.Warnf("pstore metadata backup failed: %v", err)
+		}
+	})
+}
+
+// BackupConfig describes the periodic metadata backup.
+type BackupConfig struct {
+	// Dir receives the snapshot files.  Empty disables backups.
+	Dir string
+	// Interval between snapshots.
+	Interval time.Duration
+	// Keep bounds how many snapshots are retained; zero keeps them all.
+	Keep int
+	// Keys seal each snapshot.  They are supplied by the caller rather than
+	// read from configuration here, so this package stays independent of
+	// config and a test can seal to keys of its own.  Backups do not start
+	// without them: a snapshot is a logical dump and is never written in the
+	// clear.
+	Keys BackupKeys
+}
+
+// metadataBackupPrefix names the metadata backups so pruning can recognize
+// its own output and leave anything else in the directory alone.
+const metadataBackupPrefix = "pstore-metadata-"
+
+// snapshotOnce writes one snapshot and prunes older ones.
+//
+// It writes to a temporary name, flushes it to stable storage, and only then
+// renames, so neither a crash nor a power cut can publish a truncated file
+// under a name that pruning will count towards retention.  The rename alone
+// is not enough: it orders nothing against the data, so a machine that loses
+// power just after the rename can come back with the directory entry present
+// and the file's contents partly unwritten.
+func (s *Store) snapshotOnce(cfg BackupConfig) error {
+	if err := os.MkdirAll(cfg.Dir, 0700); err != nil {
+		return errors.Wrapf(err, "failed to create the backup directory %s", cfg.Dir)
+	}
+
+	name := metadataBackupPrefix + time.Now().UTC().Format("20060102T150405Z") + ".pmb"
+	final := filepath.Join(cfg.Dir, name)
+	tmp := final + ".partial"
+
+	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create %s", tmp)
+	}
+	_, bErr := s.BackupEncrypted(f, cfg.Keys)
+	if bErr != nil {
+		f.Close()
+		_ = os.Remove(tmp)
+		return bErr
+	}
+	if sErr := f.Sync(); sErr != nil {
+		f.Close()
+		_ = os.Remove(tmp)
+		return errors.Wrapf(sErr, "failed to flush %s to disk", tmp)
+	}
+	// Read the size off the handle we already hold, before it is closed.  A
+	// snapshot that keeps succeeding while shrinking against a growing store
+	// is a real failure mode -- a backup that captures nothing -- and it has
+	// no other symptom until a recovery.
+	var size int64
+	if fi, stErr := f.Stat(); stErr == nil {
+		size = fi.Size()
+	}
+	if cErr := f.Close(); cErr != nil {
+		_ = os.Remove(tmp)
+		return errors.Wrapf(cErr, "failed to finish writing %s", tmp)
+	}
+	if rErr := os.Rename(tmp, final); rErr != nil {
+		_ = os.Remove(tmp)
+		return errors.Wrapf(rErr, "failed to publish %s", final)
+	}
+	// Only once the snapshot is published under its final name: a size for a
+	// file that was never renamed describes a backup that does not exist.
+	metrics.PStoreMetadataBackupLastSizeBytes.Set(float64(size))
+	// Durably record the rename too, so the published name cannot outlive a
+	// crash while pointing at a file the filesystem has forgotten.
+	syncDir(cfg.Dir)
+
+	log.Debugf("Wrote pstore metadata backup %s", final)
+	return s.pruneSnapshots(cfg)
+}
+
+// syncDir flushes a directory's own entries.
+//
+// Best effort: some platforms (notably Windows) do not allow opening a
+// directory for this, and there the rename's durability is the filesystem's
+// business rather than ours.
+func syncDir(dir string) {
+	d, err := os.Open(dir)
+	if err != nil {
+		return
+	}
+	defer d.Close()
+	_ = d.Sync()
+}
+
+// pruneSnapshots removes the oldest snapshots beyond the retention count.
+func (s *Store) pruneSnapshots(cfg BackupConfig) error {
+	if cfg.Keep <= 0 {
+		return nil
+	}
+	entries, err := os.ReadDir(cfg.Dir)
+	if err != nil {
+		return errors.Wrapf(err, "failed to read the backup directory %s", cfg.Dir)
+	}
+
+	var snapshots []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasPrefix(e.Name(), metadataBackupPrefix) &&
+			strings.HasSuffix(e.Name(), ".pmb") {
+			snapshots = append(snapshots, e.Name())
+		}
+	}
+	if len(snapshots) <= cfg.Keep {
+		return nil
+	}
+
+	// The timestamp is fixed-width, so lexical order is chronological.
+	sort.Strings(snapshots)
+	for _, name := range snapshots[:len(snapshots)-cfg.Keep] {
+		if rErr := os.Remove(filepath.Join(cfg.Dir, name)); rErr != nil {
+			log.Warnf("Failed to prune old pstore metadata backup %s: %v", name, rErr)
+		}
+	}
+	return nil
+}

--- a/pstore/backup_crypto.go
+++ b/pstore/backup_crypto.go
@@ -1,0 +1,807 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Backup encryption: the envelope and the cipher.
+//
+// backup.go owns the container and the policy -- what a snapshot is, when one is
+// taken, how it is published and pruned, and the rule that every one of them is
+// sealed.  This file owns what makes sealing possible: the envelope that carries
+// the key to each recipient, and the AEAD that protects the body under it.
+//
+// A store is encrypted at rest, but BadgerDB's backup is a *logical* dump:
+// values come back decrypted, so a raw snapshot is cleartext.  It contains
+// every object path, all the metadata, and the hash salt that makes on-disk
+// filenames unguessable.  Writing that to a backup directory would undo the
+// at-rest protection the store exists to provide.
+//
+// **There is therefore no way to write an unencrypted snapshot.**  Making
+// encryption conditional on an operator having generated and configured a key,
+// and warning in the log when they had not, would be the weakest control there
+// is for a file that leaks the whole namespace: nobody reads the warning, and
+// the failure is silent and permanent.  A backup either encrypts or fails.
+//
+// # The key hierarchy
+//
+// There are three levels, and possession of *any* one of them opens an archive.
+// That is the point of the arrangement: a recovery happens on whatever the
+// operator still has, and which of the three that is cannot be predicted in
+// advance.
+//
+//	 1. The **master keys** are the origin's issuer keys.  They are what the
+//	    origin cannot run without and already protects carefully, so nothing new
+//	    has to be created, configured, or remembered.
+//
+//	 2. The **backup key** is derived from an issuer key with
+//	    backup_keys.DeriveKeyPair(key, LabelPStore) -- HKDF-SHA256 over the
+//	    issuer key's PKCS8 encoding, read out as a Curve25519 private key.  It is
+//	    deterministic, so `pelican-server origin pstore metadata-backup-key` re-derives
+//	    and prints the same 32 bytes every time and an operator can escrow them.
+//	    The label domain-separates it from the server database's backup key, so
+//	    escrowing one does not hand over the other, and the derivation is one-way,
+//	    so a leaked backup key does not yield the issuer key behind it.
+//
+//	 3. The **per-file key** is HKDF-SHA256 over the backup key, salted with 32
+//	    random bytes drawn for that one snapshot and stored in its header, under
+//	    a different info label from the one that produced the backup key.  It is
+//	    what the body is actually encrypted under.  Every snapshot therefore has
+//	    a key of its own, and holding one snapshot's key reveals nothing about
+//	    any other snapshot -- so a single archive can be handed to someone
+//	    without handing them the whole series.
+//
+// The consequence worth stating outright: **losing the origin's issuer keys does
+// not lose the archives, provided the backup key was escrowed.**  Level 2 is
+// reachable without level 1, and level 3 is reachable from level 2.
+//
+// The backup key is **embedded in the archive, encrypted**: one envelope block
+// per recipient, each a NaCl box sealed to the key pair derived from one of the
+// origin's current issuer keys.  Each box is sealed to itself, so the private
+// half alone opens it and there is no separate sender key to keep.  That is what
+// makes rotation free -- an archive opens with any issuer key that was current
+// when it was written, so retiring a key does not strand the archives that
+// overlapped it -- and it is what lets an issuer key reach the per-file key at
+// all.
+//
+// The archive's backup key is the one derived from the first issuer key in
+// sorted order, and it is itself one of the recipients.  That last detail is
+// what makes the second and third recovery paths uniform: whichever escrowed
+// backup key an operator produces, it opens *its own* envelope block, which
+// yields the archive's backup key, which derives the per-file key.  When the key
+// produced happens to be the archive's own, that block hands it straight back.
+//
+// # The three ways in
+//
+//	an issuer key   -> derive its key pair -> open the envelope -> backup key
+//	                   -> HKDF with the salt in the header -> per-file key
+//	a backup key    -> open the envelope with it -> the archive's backup key
+//	                   -> HKDF with the salt in the header -> per-file key
+//	a per-file key  -> decrypt.  No derivation, no envelope, no issuer key.
+//
+// Object *contents* are not exposed by any of this -- each object's data key is
+// stored already wrapped by the master key, so the block files stay protected
+// even if a snapshot leaks.  The namespace is what needs covering here.
+//
+// Snapshots are compressed before they are sealed, which is the only order that
+// works: ciphertext is incompressible, so compressing afterwards would achieve
+// nothing.  A catalog compresses extremely well -- it is mostly repetitive path
+// strings and structurally similar metadata records -- and smaller snapshots
+// mean retention costs less, so more of them can be kept.
+//
+// Compressing before encrypting can leak information through ciphertext length
+// when an attacker chooses part of the plaintext and observes the result
+// repeatedly.  That is not this: a snapshot is written once, from data the
+// attacker does not control interactively, and there is no oracle to query.
+//
+// # The layout on disk
+//
+//	magic     "PELICAN-PSTORE-BACKUP\0" and a one-byte format version
+//	salt      32 random bytes, drawn for this snapshot
+//	envelope  a uint16 recipient count, then per recipient a length-prefixed key
+//	          ID and the length-prefixed backup key sealed to it
+//	body      sealed chunks, each behind its sealed length and an end marker
+//
+// # Nonces, and what is authenticated
+//
+// The per-file key is unique to one archive, because the salt it is derived from
+// is drawn fresh for every snapshot.  A GCM nonce therefore only has to be
+// unique *within* an archive, so it can be a pure chunk counter -- there is no
+// random nonce prefix to collide across archives, and so no birthday bound on
+// how many snapshots may be taken under the same key.
+//
+// The whole header -- magic, salt, and every envelope block -- is passed as
+// additional authenticated data on every chunk.  So the salt cannot be swapped
+// (which would silently change which key the file claims to want), the envelope
+// cannot be stripped, extended, or lifted from another archive, and no chunk can
+// be spliced from one archive into another.  The terminating chunk is marked in
+// both the framing and the nonce, so a truncated stream cannot be re-sealed as
+// if it had ended where it was cut.
+//
+// # Format versions
+//
+// The magic ends in a version byte and the reader dispatches on it, so changing
+// the format later has somewhere to go and old readers report the mismatch
+// instead of misparsing.  Exactly one version is understood at a time: a file
+// carrying any other is refused by number -- what it is, and what this build
+// reads -- rather than decoded on a guess.
+
+package pstore
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/hkdf"
+	"golang.org/x/crypto/nacl/box"
+
+	"github.com/pelicanplatform/pelican/backup_keys"
+)
+
+const (
+	// backupKeySize is the AES-256 key length, and also the length of a
+	// Curve25519 private key -- the two happen to coincide, which is why one
+	// key file format serves the backup keys and the per-file keys alike.
+	backupKeySize = 32
+
+	// backupMagicPrefix opens every snapshot, whatever its version.
+	//
+	// Matching the family rather than the exact version is what lets a snapshot
+	// this build cannot read be reported as a version mismatch -- "find the
+	// build that wrote this" -- instead of collapsing into "this is not a
+	// backup", which sends an operator looking for the wrong file.
+	backupMagicPrefix = "PELICAN-PSTORE-BACKUP\x00"
+
+	// backupFormatVersion is the container version this build writes, and the
+	// only one it reads.  It is the last byte of the magic.
+	backupFormatVersion = 1
+
+	// backupMagic opens every snapshot in the current format: a per-snapshot
+	// salt, the archive's backup key sealed to one or more recipients, and a
+	// body encrypted under a per-file key derived from the two.
+	//
+	// Its last byte must be backupFormatVersion; Go cannot express that as a
+	// constant, so TestAnUnsupportedFormatVersionIsRefused asserts it instead.
+	backupMagic = backupMagicPrefix + "\x01"
+
+	// backupChunkSize is the plaintext size of each sealed chunk.  Chunking
+	// keeps memory flat for a snapshot of any size.
+	backupChunkSize = 64 << 10
+
+	// backupSaltSize is the per-snapshot HKDF salt.
+	backupSaltSize = 32
+
+	// backupFileKeyInfo domain-separates the per-file key from the backup key
+	// it is derived from.
+	//
+	// It must differ from backup_keys.LabelPStore, which produced that backup
+	// key: sharing an info string across levels of a hierarchy is how a
+	// hierarchy stops being one.
+	backupFileKeyInfo = "pelican pstore metadata backup file key v1"
+
+	// backupNonceCounterOffset leaves the first four bytes of the nonce zero.
+	// The key is already unique per snapshot, so the nonce only has to be
+	// unique within one -- and 2^63 chunks of 64 KiB is more archive than any
+	// filesystem will hold.
+	backupNonceCounterOffset = 4
+
+	// backupMaxRecipients bounds the envelope so a corrupt header cannot make
+	// a reader allocate without limit.  An origin with more than this many
+	// live issuer keys has a different problem.
+	backupMaxRecipients = 64
+
+	// backupMaxKeyIDLen and backupMaxSealedLen bound the two variable-length
+	// fields in a recipient block for the same reason.
+	backupMaxKeyIDLen  = 256
+	backupMaxSealedLen = 1024
+)
+
+// ErrNoMatchingKey reports a snapshot that none of the supplied keys open.
+//
+// SealedKeyIDs names the keys it *was* sealed to, which is the only thing that
+// tells an operator holding the wrong keyring what to go and find.
+type ErrNoMatchingKey struct {
+	SealedKeyIDs []string
+}
+
+func (e *ErrNoMatchingKey) Error() string {
+	if len(e.SealedKeyIDs) == 0 {
+		return "the snapshot could not be decrypted: it names no keys at all, so it is damaged"
+	}
+	return fmt.Sprintf("the snapshot could not be decrypted: none of the available keys match; "+
+		"it was sealed to key(s): %s", strings.Join(e.SealedKeyIDs, ", "))
+}
+
+// BackupKeys names the keys a snapshot is sealed to, or opened with.
+//
+// The three fields are the three levels of the hierarchy, and on the reading
+// side any one of them is enough.  They are passed in rather than read from
+// configuration so that pstore stays free of the config package: the caller
+// resolves the origin's issuer keys and hands them over, and a test supplies
+// whatever keys it likes.
+type BackupKeys struct {
+	// IssuerKeys are the origin's current issuer keys, by key ID (level 1).
+	// The archive's backup key is sealed to the pstore-domain key pair derived
+	// from each, and any one of them opens it -- so a snapshot written before a
+	// rotation still opens afterwards, as long as one of the keys it was
+	// written under survives.
+	IssuerKeys map[string]jwk.Key
+
+	// BackupKey is a raw 32-byte Curve25519 private key from level 2: the
+	// escrowed key printed by `pelican-server origin pstore metadata-backup-key`, or
+	// an independent key for backups that must be restorable somewhere that
+	// will never hold this origin's issuer keys.
+	//
+	// When writing, it *replaces* the issuer-derived recipients rather than
+	// joining them.  When reading, it opens the envelope and yields the
+	// archive's own backup key, from which the per-file key is derived.
+	BackupKey []byte
+
+	// FileKey is one archive's own key (level 3), as printed by
+	// `metadata-backup-key <file>`.  It decrypts that archive's body directly:
+	// no derivation, no envelope, and no issuer key need be present.  It opens
+	// nothing else, which is the point of having it.
+	//
+	// It is read-only.  Sealing a new archive requires a backup key to embed,
+	// and a per-file key is downstream of one.
+	FileKey []byte
+}
+
+// Empty reports whether there is nothing here to *seal* to.
+//
+// FileKey is deliberately not consulted: it opens one existing archive and
+// cannot write a new one, so a caller holding only that has nothing to back up
+// with.
+func (k BackupKeys) Empty() bool {
+	return len(k.BackupKey) == 0 && len(k.IssuerKeys) == 0
+}
+
+// backupRecipient is one key an archive's backup key is sealed to.
+//
+// Both halves are derived from the same secret and the box is sealed to
+// itself, so holding the private key is all it takes to open -- there is no
+// separate sender key to keep.
+type backupRecipient struct {
+	keyID string
+	priv  *[32]byte
+	pub   *[32]byte
+}
+
+// recipients resolves the keys an archive is sealed to, refusing to produce an
+// empty list: a snapshot with no recipients would be a snapshot nobody can
+// read, and writing one is worse than failing.
+//
+// The first entry is the archive's backup key, so the order candidates() puts
+// them in is load-bearing rather than cosmetic.
+func (k BackupKeys) recipients() ([]backupRecipient, error) {
+	out, err := k.candidates()
+	if err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		if len(k.FileKey) > 0 {
+			return nil, errors.New("a per-file key opens the one snapshot it belongs to and " +
+				"cannot seal a new one; supply the origin's issuer keys or a backup key")
+		}
+		return nil, errors.New("no keys are available to encrypt the metadata snapshot; " +
+			"a snapshot is a logical dump of the namespace and is never written in the clear")
+	}
+	return out, nil
+}
+
+// candidates resolves the configured keys into key pairs, in a deterministic
+// order so two runs over the same keys produce headers that differ only in
+// their random parts.  An empty result is not an error here -- on the reading
+// side it simply means nothing can open the archive, which the caller reports
+// along with the keys it was sealed to.
+func (k BackupKeys) candidates() ([]backupRecipient, error) {
+	if len(k.BackupKey) > 0 {
+		priv, pub, err := backup_keys.KeyPairFromPrivate(k.BackupKey)
+		if err != nil {
+			return nil, err
+		}
+		return []backupRecipient{{keyID: suppliedKeyID(pub), priv: priv, pub: pub}}, nil
+	}
+
+	keyIDs := make([]string, 0, len(k.IssuerKeys))
+	for keyID := range k.IssuerKeys {
+		keyIDs = append(keyIDs, keyID)
+	}
+	sort.Strings(keyIDs)
+
+	out := make([]backupRecipient, 0, len(keyIDs))
+	for _, keyID := range keyIDs {
+		priv, pub, err := backup_keys.DeriveKeyPair(k.IssuerKeys[keyID], backup_keys.LabelPStore)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to derive the backup key for issuer key %s", keyID)
+		}
+		out = append(out, backupRecipient{keyID: keyID, priv: priv, pub: pub})
+	}
+	return out, nil
+}
+
+// suppliedKeyID labels an explicitly supplied backup key so that a snapshot
+// sealed to one says which, rather than only that it was not an issuer key.
+//
+// It is a fingerprint of the public half: it identifies the key without
+// revealing anything about it.
+func suppliedKeyID(pub *[32]byte) string {
+	sum := sha256.Sum256(pub[:])
+	return "backup-key:" + hex.EncodeToString(sum[:8])
+}
+
+// generateBackupKey returns a new random 32-byte key, base64-encoded.
+//
+// Only tests need this: the operator-facing key is derived rather than
+// generated.  An operator who wants an independent backup key can produce 32
+// random bytes with anything.
+func generateBackupKey() (string, error) {
+	key := make([]byte, backupKeySize)
+	if _, err := rand.Read(key); err != nil {
+		return "", errors.Wrap(err, "failed to generate a backup key")
+	}
+	return base64.StdEncoding.EncodeToString(key), nil
+}
+
+// ParseBackupKey decodes a base64 backup or per-file key and checks its length.
+func ParseBackupKey(encoded string) ([]byte, error) {
+	key, err := base64.StdEncoding.DecodeString(strings.TrimSpace(encoded))
+	if err != nil {
+		return nil, errors.Wrap(err, "the backup key is not valid base64")
+	}
+	if len(key) != backupKeySize {
+		return nil, errors.Errorf("the backup key must be %d bytes, got %d",
+			backupKeySize, len(key))
+	}
+	return key, nil
+}
+
+// FormatBackupKey renders a raw backup or per-file key the way a key file holds
+// it.
+func FormatBackupKey(key []byte) string {
+	return base64.StdEncoding.EncodeToString(key)
+}
+
+// DeriveBackupKey returns the level-2 pstore backup private key for one issuer
+// key, which is what `metadata-backup-key` prints for escrow.
+//
+// The same issuer key always yields the same backup key, so printing it twice
+// gives the same answer -- that is the property that makes escrowing it useful.
+// It opens every snapshot this origin writes; for the key that opens exactly
+// one of them, see DeriveFileKey.
+func DeriveBackupKey(issuerKey jwk.Key) ([]byte, error) {
+	priv, _, err := backup_keys.DeriveKeyPair(issuerKey, backup_keys.LabelPStore)
+	if err != nil {
+		return nil, err
+	}
+	return priv[:], nil
+}
+
+// DeriveFileKey returns the level-3 key that opens exactly the archive in r,
+// and nothing else.
+//
+// It reads only the header, so r may be a file opened purely for this.  keys
+// supplies whatever the caller has: the origin's issuer keys, or an escrowed
+// backup key -- either reaches the same answer, because the archive carries its
+// own backup key sealed to both.
+func DeriveFileKey(r io.Reader, keys BackupKeys) ([]byte, error) {
+	magic, err := readBackupMagic(r)
+	if err != nil {
+		return nil, err
+	}
+	fileKey, _, err := openBackupHeader(r, magic, keys)
+	return fileKey, err
+}
+
+// readBackupMagic consumes the container magic and checks that this build can
+// read what follows it.
+//
+// A file whose version byte is not the one supported is refused by number
+// rather than decoded: the layout behind the magic is version-specific, so
+// reading on would either fail with a cryptographic error that names nothing
+// useful or, worse, parse into the wrong shape.
+func readBackupMagic(r io.Reader) ([]byte, error) {
+	magic := make([]byte, len(backupMagic))
+	if _, err := io.ReadFull(r, magic); err != nil {
+		return nil, errors.Wrap(err, "failed to read the backup header")
+	}
+	if string(magic[:len(backupMagicPrefix)]) != backupMagicPrefix {
+		return nil, errors.New("this file is not an encrypted pstore snapshot")
+	}
+	if version := magic[len(backupMagicPrefix)]; version != backupFormatVersion {
+		return nil, errors.Errorf("this snapshot is in pstore backup format version %d, "+
+			"but this build reads only version %d", version, backupFormatVersion)
+	}
+	return magic, nil
+}
+
+// newBackupAEAD builds the cipher used for both directions.
+func newBackupAEAD(key []byte) (cipher.AEAD, error) {
+	if len(key) != backupKeySize {
+		return nil, errors.Errorf("a snapshot key must be %d bytes, got %d",
+			backupKeySize, len(key))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to initialize the backup cipher")
+	}
+	aead, err := cipher.NewGCM(block)
+	return aead, errors.Wrap(err, "failed to initialize the backup cipher")
+}
+
+// deriveFileKey produces one snapshot's own encryption key from the backup key
+// it is sealed under and the salt drawn for it.
+//
+// The salt is what makes the result unique per snapshot, and the info label is
+// what keeps this level distinct from the one that produced backupKey: derive
+// twice with the same inputs and the same 32 bytes come back, which is what
+// lets `metadata-backup-key <file>` reproduce a key that was never stored.
+func deriveFileKey(backupKey, salt []byte) ([]byte, error) {
+	if len(backupKey) != backupKeySize {
+		return nil, errors.Errorf("a backup key must be %d bytes, got %d",
+			backupKeySize, len(backupKey))
+	}
+	fileKey := make([]byte, backupKeySize)
+	reader := hkdf.New(sha256.New, backupKey, salt, []byte(backupFileKeyInfo))
+	if _, err := io.ReadFull(reader, fileKey); err != nil {
+		return nil, errors.Wrap(err, "failed to derive the snapshot's own key")
+	}
+	return fileKey, nil
+}
+
+// encryptBackup copies src to dst, sealing it to keys.
+//
+// The output is the magic, the salt, the envelope carrying the backup key, then
+// a sequence of sealed chunks each prefixed with its sealed length.  Every chunk
+// is bound to its position by a counter in the nonce and to this archive by the
+// whole header as additional data, and the final chunk is marked, so reordering,
+// dropping, truncating, or splicing chunks between archives is detected rather
+// than silently producing a short restore.
+func encryptBackup(dst io.Writer, src io.Reader, keys BackupKeys) error {
+	recipients, err := keys.recipients()
+	if err != nil {
+		return err
+	}
+
+	// The archive's backup key is the first recipient's, which candidates()
+	// fixes deterministically.  It is itself a recipient, so an operator
+	// holding any escrowed backup key reaches it the same way an issuer key
+	// does.
+	backupKey := recipients[0].priv[:]
+
+	// The salt is what makes this snapshot's key its own, and it is the reason
+	// the nonce can be a bare counter: two archives share a key only if the
+	// CSPRNG repeats.
+	salt := make([]byte, backupSaltSize)
+	if _, err := rand.Read(salt); err != nil {
+		return errors.Wrap(err, "failed to generate a snapshot salt")
+	}
+
+	fileKey, err := deriveFileKey(backupKey, salt)
+	if err != nil {
+		return err
+	}
+	aead, err := newBackupAEAD(fileKey)
+	if err != nil {
+		return err
+	}
+
+	header, err := buildBackupHeader(backupKey, salt, recipients)
+	if err != nil {
+		return err
+	}
+	if _, err := dst.Write(header); err != nil {
+		return errors.Wrap(err, "failed to write the backup header")
+	}
+
+	buf := make([]byte, backupChunkSize)
+	var counter uint64
+	for {
+		n, rErr := io.ReadFull(src, buf)
+		last := rErr == io.EOF || rErr == io.ErrUnexpectedEOF
+		if rErr != nil && !last {
+			return errors.Wrap(rErr, "failed to read the snapshot")
+		}
+
+		nonce := backupNonce(counter, last)
+		sealed := aead.Seal(nil, nonce, buf[:n], header)
+		var chunkHeader [5]byte
+		binary.BigEndian.PutUint32(chunkHeader[:4], uint32(len(sealed)))
+		if last {
+			chunkHeader[4] = 1
+		}
+		if _, wErr := dst.Write(chunkHeader[:]); wErr != nil {
+			return errors.Wrap(wErr, "failed to write the backup")
+		}
+		if _, wErr := dst.Write(sealed); wErr != nil {
+			return errors.Wrap(wErr, "failed to write the backup")
+		}
+		if last {
+			return nil
+		}
+		counter++
+	}
+}
+
+// buildBackupHeader lays out the magic, the salt, and one block per recipient.
+//
+// The whole thing is authenticated as additional data on every chunk, so the
+// salt cannot be swapped and a recipient cannot be removed, added, or lifted
+// from another archive without the body failing to open.
+func buildBackupHeader(backupKey, salt []byte, recipients []backupRecipient) ([]byte, error) {
+	header := make([]byte, 0, len(backupMagic)+len(salt)+2+len(recipients)*128)
+	header = append(header, backupMagic...)
+	header = append(header, salt...)
+	header = binary.BigEndian.AppendUint16(header, uint16(len(recipients)))
+
+	for _, r := range recipients {
+		var nonce [24]byte
+		if _, err := rand.Read(nonce[:]); err != nil {
+			return nil, errors.Wrap(err, "failed to generate a key nonce")
+		}
+		// Sealed to itself: the private key alone opens it, so an escrowed key
+		// needs no counterpart.
+		sealed := box.Seal(nonce[:], backupKey, &nonce, r.pub, r.priv)
+
+		if len(r.keyID) > backupMaxKeyIDLen {
+			return nil, errors.Errorf("the key ID %q is too long to record in a snapshot", r.keyID)
+		}
+		header = binary.BigEndian.AppendUint16(header, uint16(len(r.keyID)))
+		header = append(header, r.keyID...)
+		header = binary.BigEndian.AppendUint16(header, uint16(len(sealed)))
+		header = append(header, sealed...)
+	}
+	return header, nil
+}
+
+// sealedBlock is one recipient's envelope as it was read back off disk.
+type sealedBlock struct {
+	keyID string
+	data  []byte
+}
+
+// readEnvelope reads the recipient blocks, returning both the parsed blocks and
+// the raw bytes they occupied, because the reader has to reassemble the exact
+// header it authenticates against.
+func readEnvelope(src io.Reader) (blocks []sealedBlock, raw []byte, err error) {
+	var countBuf [2]byte
+	if _, err := io.ReadFull(src, countBuf[:]); err != nil {
+		return nil, nil, errors.Wrap(err, "failed to read the backup header")
+	}
+	raw = append(raw, countBuf[:]...)
+	count := int(binary.BigEndian.Uint16(countBuf[:]))
+	if count == 0 || count > backupMaxRecipients {
+		return nil, nil, errors.New("the backup is malformed: implausible number of keys")
+	}
+
+	blocks = make([]sealedBlock, 0, count)
+	for i := 0; i < count; i++ {
+		keyID, rawKeyID, rErr := readLengthPrefixed(src, backupMaxKeyIDLen)
+		if rErr != nil {
+			return nil, nil, rErr
+		}
+		raw = append(raw, rawKeyID...)
+		sealed, rawSealed, rErr := readLengthPrefixed(src, backupMaxSealedLen)
+		if rErr != nil {
+			return nil, nil, rErr
+		}
+		raw = append(raw, rawSealed...)
+		blocks = append(blocks, sealedBlock{keyID: string(keyID), data: sealed})
+	}
+	return blocks, raw, nil
+}
+
+// unsealEnvelope recovers the archive's backup key from the envelope, using any
+// key the caller holds.
+//
+// The key IDs are matched first, because that is the common case and it is the
+// cheap one; every block is then tried against every candidate, so an archive
+// sealed to a supplied backup key still opens when the operator hands over
+// those bytes without knowing the fingerprint they were recorded under.
+func unsealEnvelope(blocks []sealedBlock, keys BackupKeys) ([]byte, error) {
+	candidates, err := keys.candidates()
+	if err != nil {
+		return nil, err
+	}
+
+	open := func(b sealedBlock, r backupRecipient) ([]byte, bool) {
+		if len(b.data) <= 24 {
+			return nil, false
+		}
+		var nonce [24]byte
+		copy(nonce[:], b.data[:24])
+		key, ok := box.Open(nil, b.data[24:], &nonce, r.pub, r.priv)
+		if !ok || len(key) != backupKeySize {
+			return nil, false
+		}
+		return key, true
+	}
+
+	byID := make(map[string]backupRecipient, len(candidates))
+	for _, r := range candidates {
+		byID[r.keyID] = r
+	}
+	for _, b := range blocks {
+		if r, found := byID[b.keyID]; found {
+			if key, ok := open(b, r); ok {
+				return key, nil
+			}
+		}
+	}
+	for _, b := range blocks {
+		for _, r := range candidates {
+			if key, ok := open(b, r); ok {
+				return key, nil
+			}
+		}
+	}
+
+	sealedTo := make([]string, 0, len(blocks))
+	for _, b := range blocks {
+		sealedTo = append(sealedTo, b.keyID)
+	}
+	return nil, &ErrNoMatchingKey{SealedKeyIDs: sealedTo}
+}
+
+// openBackupHeader reads the salt and the envelope and produces the archive's
+// own key, along with the exact header bytes that authenticate its body.
+//
+// A caller holding the per-file key short-circuits the envelope entirely: the
+// header is still parsed, because the body is authenticated against it and the
+// body does not start until it ends, but nothing in it has to be opened.
+func openBackupHeader(src io.Reader, magic []byte, keys BackupKeys) (fileKey, header []byte, err error) {
+	header = append(header, magic...)
+
+	salt := make([]byte, backupSaltSize)
+	if _, err := io.ReadFull(src, salt); err != nil {
+		return nil, nil, errors.Wrap(err, "failed to read the backup header")
+	}
+	header = append(header, salt...)
+
+	blocks, raw, err := readEnvelope(src)
+	if err != nil {
+		return nil, nil, err
+	}
+	header = append(header, raw...)
+
+	if len(keys.FileKey) > 0 {
+		if len(keys.FileKey) != backupKeySize {
+			return nil, nil, errors.Errorf("a per-file key must be %d bytes, got %d",
+				backupKeySize, len(keys.FileKey))
+		}
+		return keys.FileKey, header, nil
+	}
+
+	backupKey, err := unsealEnvelope(blocks, keys)
+	if err != nil {
+		return nil, nil, err
+	}
+	fileKey, err = deriveFileKey(backupKey, salt)
+	if err != nil {
+		return nil, nil, err
+	}
+	return fileKey, header, nil
+}
+
+// readLengthPrefixed reads one uint16-prefixed field, returning both its
+// contents and the raw bytes it occupied so the caller can reassemble the
+// header it has to authenticate.
+func readLengthPrefixed(src io.Reader, max int) (value, raw []byte, err error) {
+	var lenBuf [2]byte
+	if _, err := io.ReadFull(src, lenBuf[:]); err != nil {
+		return nil, nil, errors.Wrap(err, "failed to read the backup header")
+	}
+	n := int(binary.BigEndian.Uint16(lenBuf[:]))
+	if n > max {
+		return nil, nil, errors.New("the backup is malformed: implausible header field length")
+	}
+	value = make([]byte, n)
+	if _, err := io.ReadFull(src, value); err != nil {
+		return nil, nil, errors.Wrap(err, "failed to read the backup header")
+	}
+	raw = append(append([]byte{}, lenBuf[:]...), value...)
+	return value, raw, nil
+}
+
+// decryptBackup copies src to dst, opening it with keys.
+//
+// The header is read first and in full, because it is both where the key comes
+// from and what every chunk is authenticated against.
+func decryptBackup(dst io.Writer, src io.Reader, keys BackupKeys) error {
+	magic, err := readBackupMagic(src)
+	if err != nil {
+		return err
+	}
+	fileKey, aad, err := openBackupHeader(src, magic, keys)
+	if err != nil {
+		return err
+	}
+	aead, err := newBackupAEAD(fileKey)
+	if err != nil {
+		return err
+	}
+
+	var counter uint64
+	for {
+		var chunkHeader [5]byte
+		if _, err := io.ReadFull(src, chunkHeader[:]); err != nil {
+			// Running out of input before the final chunk means the file was
+			// truncated; the marker is what tells us the stream ended
+			// legitimately.
+			return errors.Wrap(err, "the backup ended before its final chunk; it is truncated")
+		}
+		size := binary.BigEndian.Uint32(chunkHeader[:4])
+		last := chunkHeader[4] == 1
+		if size > backupChunkSize+uint32(aead.Overhead()) {
+			return errors.New("the backup is malformed: implausible chunk length")
+		}
+
+		sealed := make([]byte, size)
+		if _, err := io.ReadFull(src, sealed); err != nil {
+			return errors.Wrap(err, "the backup is truncated")
+		}
+		nonce := backupNonce(counter, last)
+		plain, err := aead.Open(nil, nonce, sealed, aad)
+		if err != nil {
+			return errors.New("the backup could not be decrypted: wrong key, " +
+				"or the file has been altered")
+		}
+		if _, err := dst.Write(plain); err != nil {
+			return errors.Wrap(err, "failed to write the decrypted snapshot")
+		}
+		if last {
+			return nil
+		}
+		counter++
+	}
+}
+
+// backupNonce derives a chunk's nonce from its position and whether it
+// terminates the stream.
+//
+// Binding the terminator into the nonce is what makes truncation detectable:
+// a stream cut short cannot be re-sealed as if it had ended there.
+func backupNonce(counter uint64, last bool) []byte {
+	nonce := make([]byte, 12)
+	binary.BigEndian.PutUint64(nonce[backupNonceCounterOffset:], counter)
+	if last {
+		// Flip the high bit of the counter space for the terminating chunk so
+		// it can never collide with a non-final chunk's nonce.
+		nonce[backupNonceCounterOffset] |= 0x80
+	}
+	return nonce
+}
+
+// looksEncrypted reports whether a file begins with the container magic, so
+// Restore can tell a snapshot from whatever else an operator may have named.
+//
+// It matches the family prefix rather than the exact version, so a snapshot
+// whose version this build does not read still reaches the reader that refuses
+// it by number, instead of being turned away as "not a backup".
+func looksEncrypted(header []byte) bool {
+	return len(header) >= len(backupMagicPrefix) &&
+		string(header[:len(backupMagicPrefix)]) == backupMagicPrefix
+}

--- a/pstore/backup_test.go
+++ b/pstore/backup_test.go
@@ -1,0 +1,1956 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package pstore
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/backup_keys"
+	"github.com/pelicanplatform/pelican/local_cache"
+)
+
+// testIssuerKeys builds a keyring standing in for the origin's issuer keys.
+//
+// Snapshots are sealed to keys derived from these, so a test can play out a
+// rotation simply by handing different subsets of the same keyring to the
+// writer and the reader.
+func testIssuerKeys(t *testing.T, keyIDs ...string) map[string]jwk.Key {
+	t.Helper()
+	keys := make(map[string]jwk.Key, len(keyIDs))
+	for _, keyID := range keyIDs {
+		raw, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		key, err := jwk.FromRaw(raw)
+		require.NoError(t, err)
+		require.NoError(t, key.Set(jwk.KeyIDKey, keyID))
+		keys[keyID] = key
+	}
+	return keys
+}
+
+// testBackupKeys is a keyring for tests that only need a snapshot to be
+// sealed to something, without caring what.
+func testBackupKeys(t *testing.T) BackupKeys {
+	t.Helper()
+	return BackupKeys{IssuerKeys: testIssuerKeys(t, "kid-a", "kid-b")}
+}
+
+// sealSnapshot takes a snapshot of s and returns it with the keys that open it.
+//
+// There is one container and it is sealed, so a test that just wants "a
+// snapshot of this store" needs a keyring; producing one here keeps that from
+// being restated a dozen times, and folds in the two assertions every snapshot
+// owes regardless of what the caller is really testing.
+func sealSnapshot(t *testing.T, s *Store) ([]byte, BackupKeys) {
+	t.Helper()
+	keys := testBackupKeys(t)
+
+	var snapshot bytes.Buffer
+	version, err := s.BackupEncrypted(&snapshot, keys)
+	require.NoError(t, err)
+	require.NotZero(t, version, "a snapshot reports the version it covers")
+	require.NotZero(t, snapshot.Len())
+	return snapshot.Bytes(), keys
+}
+
+// TestBackupRestoreRoundTrip is the recovery path an operator depends on: a
+// catalog snapshot taken from one store, loaded into an empty one, yields the
+// same namespace.
+func TestBackupRestoreRoundTrip(t *testing.T) {
+	source := newTestStore(t)
+
+	require.NoError(t, source.MkdirAll("/data/sub"))
+	writeObject(t, source, "/data/a.txt", []byte("alpha"))
+	writeObject(t, source, "/data/sub/b.txt", []byte("beta"))
+
+	snapshot, keys := sealSnapshot(t, source)
+
+	// Restore into a fresh store.
+	local_cache.InitIssuerKeyForTests(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	egrp, _ := errgroup.WithContext(ctx)
+
+	target, err := Open(ctx, egrp, Config{BaseDir: t.TempDir()})
+	require.NoError(t, err)
+	defer target.Close()
+
+	require.NoError(t, target.Restore(bytes.NewReader(snapshot), keys))
+
+	// The namespace came back.
+	entries, _, err := target.List("/data", "", 0)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a.txt", "sub"}, entryNames(entries))
+
+	d, err := target.Stat("/data/sub/b.txt")
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), d.Size)
+
+	// Generations survive, so ETags stay stable across a restore.
+	srcDirent, err := source.Stat("/data/a.txt")
+	require.NoError(t, err)
+	dstDirent, err := target.Stat("/data/a.txt")
+	require.NoError(t, err)
+	assert.Equal(t, srcDirent.Generation, dstDirent.Generation)
+}
+
+// TestBackupIsSafeOnALiveStore covers the property that makes periodic
+// backups viable at all: the snapshot streams at a fixed read timestamp, so it
+// is a coherent moment rather than a smear across the writes that happened
+// while it ran.
+//
+// "It did not return an error" is not that property.  The writer here appends
+// objects in a known order, so a coherent snapshot can only contain a *prefix*
+// of them -- a snapshot holding number 7 but not number 3 would mean the pass
+// read at two different timestamps.  That is what is asserted, along with
+// every restored entry being intact.
+func TestBackupIsSafeOnALiveStore(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.Mkdir("/live"))
+	writeObject(t, s, "/live/before.txt", []byte("before"))
+
+	const payload = "x"
+	var (
+		ready   = make(chan struct{})
+		stop    = make(chan struct{})
+		done    = make(chan struct{})
+		written int
+		// testing does not support require/assert from a non-test goroutine,
+		// so the writer reports back rather than failing in place.
+		writeErr error
+	)
+	go func() {
+		defer close(done)
+		for i := 0; ; i++ {
+			h, err := s.Create(fmt.Sprintf("/live/during-%04d.txt", i))
+			if err == nil {
+				_, err = h.Write([]byte(payload))
+			}
+			if err == nil {
+				err = h.Close()
+			}
+			if err != nil {
+				writeErr = err
+				return
+			}
+			written = i + 1
+			if i == 0 {
+				// The backup starts only once the store is demonstrably being
+				// written to, so the overlap is not left to timing.
+				close(ready)
+			}
+			select {
+			case <-stop:
+				return
+			default:
+			}
+		}
+	}()
+
+	<-ready
+	keys := testBackupKeys(t)
+	var snapshot bytes.Buffer
+	_, err := s.BackupEncrypted(&snapshot, keys)
+	close(stop)
+	<-done
+
+	require.NoError(t, err, "a snapshot must not fail because writes are in flight")
+	require.NoError(t, writeErr, "writes must not fail because a snapshot is running")
+	require.Greater(t, written, 0)
+
+	// Load the snapshot into a fresh store and inspect what it actually
+	// captured.
+	local_cache.InitIssuerKeyForTests(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	egrp, _ := errgroup.WithContext(ctx)
+	target, err := Open(ctx, egrp, Config{BaseDir: t.TempDir()})
+	require.NoError(t, err)
+	defer target.Close()
+	require.NoError(t, target.Restore(&snapshot, keys))
+
+	entries, _, err := target.List("/live", "", 0)
+	require.NoError(t, err)
+
+	captured := map[string]bool{}
+	for _, e := range entries {
+		captured[e.Name] = true
+		d, sErr := target.Stat("/live/" + e.Name)
+		require.NoError(t, sErr, "every entry in a snapshot is complete")
+		if e.Name != "before.txt" {
+			assert.Equal(t, int64(len(payload)), d.Size,
+				"%s was captured mid-write", e.Name)
+		}
+	}
+	assert.True(t, captured["before.txt"],
+		"an object written before the snapshot started must be in it")
+
+	// The writer appended in order, so the captured set must be a prefix.
+	seen := 0
+	for i := 0; i < written; i++ {
+		if captured[fmt.Sprintf("during-%04d.txt", i)] {
+			seen = i + 1
+		}
+	}
+	for i := 0; i < seen; i++ {
+		assert.True(t, captured[fmt.Sprintf("during-%04d.txt", i)],
+			"a coherent snapshot holds a prefix of the writes, but during-%04d.txt is missing "+
+				"while a later one is present", i)
+	}
+}
+
+func TestRestoreRefusesANonEmptyStore(t *testing.T) {
+	source := newTestStore(t)
+	writeObject(t, source, "/a.txt", []byte("alpha"))
+
+	snapshot, keys := sealSnapshot(t, source)
+
+	// Restoring into the store it came from would interleave namespaces.
+	err := source.Restore(bytes.NewReader(snapshot), keys)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already holds objects")
+}
+
+func TestRestoreRefusedOnAReadOnlyStore(t *testing.T) {
+	ro := buildStoreThenReopenReadOnly(t)
+	assert.ErrorIs(t, ro.Restore(bytes.NewReader(nil), BackupKeys{}), ErrNotSupported)
+}
+
+// TestSnapshotWritesAtomically checks that a pass publishes a name only when
+// there is a complete backup under it.
+//
+// The success path alone proves nothing -- an implementation that writes
+// straight to the final name passes it.  The failing pass is the test: a
+// backup that dies part-way through must leave the directory as it found it,
+// with no half-written file under a name that pruning would count towards
+// retention and a recovery would reach for.
+func TestSnapshotWritesAtomically(t *testing.T) {
+	t.Run("success publishes a complete, restorable file", func(t *testing.T) {
+		s := newTestStore(t)
+		writeObject(t, s, "/a.txt", []byte("alpha"))
+
+		keys := testBackupKeys(t)
+		dir := t.TempDir()
+		require.NoError(t, s.snapshotOnce(BackupConfig{Dir: dir, Interval: time.Hour, Keys: keys}))
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		assert.True(t, strings.HasPrefix(entries[0].Name(), metadataBackupPrefix))
+		assert.True(t, strings.HasSuffix(entries[0].Name(), ".pmb"),
+			"no .partial file survives a successful pass")
+
+		// Published means restorable, not merely present.
+		f, err := os.Open(filepath.Join(dir, entries[0].Name()))
+		require.NoError(t, err)
+		defer f.Close()
+		target := newTestStore(t)
+		require.NoError(t, target.Restore(f, keys))
+		d, err := target.Stat("/a.txt")
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), d.Size)
+	})
+
+	t.Run("failure publishes nothing", func(t *testing.T) {
+		if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+			t.Skip("directory permissions do not deny writes here")
+		}
+		s := newTestStore(t)
+		writeObject(t, s, "/a.txt", []byte("alpha"))
+
+		dir := t.TempDir()
+		require.NoError(t, os.Chmod(dir, 0500))
+		t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+
+		require.Error(t, s.snapshotOnce(BackupConfig{
+			Dir: dir, Interval: time.Hour, Keys: testBackupKeys(t),
+		}))
+
+		require.NoError(t, os.Chmod(dir, 0700))
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		assert.Empty(t, entries,
+			"a failed pass publishes nothing at all -- not the final name, and not a "+
+				"leftover .partial")
+	})
+
+	t.Run("a partial from a crashed pass is never taken for a backup", func(t *testing.T) {
+		// The temporary name is load-bearing, not cosmetic: whatever a crash
+		// leaves behind must not count towards retention (which would evict a
+		// real backup) and must not be reachable as one.
+		s := newTestStore(t)
+		writeObject(t, s, "/a.txt", []byte("alpha"))
+
+		dir := t.TempDir()
+		crashed := filepath.Join(dir,
+			metadataBackupPrefix+"20260101T000000Z.pmb.partial")
+		require.NoError(t, os.WriteFile(crashed, []byte("half a backup"), 0600))
+
+		keys := testBackupKeys(t)
+		require.NoError(t, s.snapshotOnce(BackupConfig{
+			Dir: dir, Interval: time.Hour, Keep: 1, Keys: keys,
+		}))
+
+		var published []string
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		for _, e := range entries {
+			if strings.HasSuffix(e.Name(), ".pmb") {
+				published = append(published, e.Name())
+			}
+		}
+		require.Len(t, published, 1, "the fragment is not a backup")
+
+		_, err = os.Stat(crashed)
+		assert.NoError(t, err, "pruning leaves what it does not recognize alone")
+
+		f, err := os.Open(filepath.Join(dir, published[0]))
+		require.NoError(t, err)
+		defer f.Close()
+		target := newTestStore(t)
+		assert.NoError(t, target.Restore(f, keys), "the one published file is complete")
+	})
+}
+
+// TestRestoreRefusesAFileThatIsNotASnapshot covers the front door of the one
+// container an operator can be holding.
+//
+// It matters because of what BadgerDB's own loader does with a file it should
+// refuse: it treats a clean EOF at any frame boundary as the end of a complete
+// backup, so a raw dump cut short restores with no error and fewer objects --
+// or none.  For a primary store that is the worst kind of failure, silent and
+// discovered during a recovery.  The magic on the front of every snapshot is
+// what makes such a file recognizable as not-a-snapshot, and the error has to
+// say that rather than anything about keys: "this is not a backup" and "this
+// backup will not open" send an operator to entirely different places.
+func TestRestoreRefusesAFileThatIsNotASnapshot(t *testing.T) {
+	source := newTestStore(t)
+	require.NoError(t, source.MkdirAll("/data"))
+	writeObject(t, source, "/data/a.txt", []byte("alpha"))
+
+	t.Run("a bare BadgerDB stream", func(t *testing.T) {
+		var raw bytes.Buffer
+		_, bErr := source.bdb.Backup(&raw, 0)
+		require.NoError(t, bErr)
+
+		target := newTestStore(t)
+		rErr := target.Restore(bytes.NewReader(raw.Bytes()), testBackupKeys(t))
+		require.Error(t, rErr, "BadgerDB's own output is not a pstore snapshot")
+		assert.Contains(t, rErr.Error(), "not a pstore metadata backup")
+
+		entries, _, lErr := target.List("/", "", 0)
+		require.NoError(t, lErr)
+		assert.Empty(t, entries, "it is refused before a single record is written")
+	})
+
+	t.Run("an empty file", func(t *testing.T) {
+		target := newTestStore(t)
+		rErr := target.Restore(bytes.NewReader(nil), testBackupKeys(t))
+		require.Error(t, rErr)
+		assert.Contains(t, rErr.Error(), "too short")
+	})
+
+	t.Run("a file with an unrelated magic", func(t *testing.T) {
+		target := newTestStore(t)
+		rErr := target.Restore(strings.NewReader("SQLite format 3\x00 and then some"),
+			testBackupKeys(t))
+		require.Error(t, rErr)
+		assert.Contains(t, rErr.Error(), "not a pstore metadata backup")
+	})
+}
+
+// TestATruncatedSnapshotIsRefused is the reason a snapshot is a sealed
+// container rather than a BadgerDB stream written straight out.
+//
+// Every cut point has to be refused, not merely the ones that happen to land
+// mid-record: the terminating chunk is bound into its own nonce, so a stream cut
+// short cannot be passed off as one that ended there.  A store cut at 200
+// objects exercises enough chunks for the cuts to fall in different places.
+func TestATruncatedSnapshotIsRefused(t *testing.T) {
+	source := newTestStore(t)
+	require.NoError(t, source.MkdirAll("/data"))
+	for i := range 200 {
+		writeObject(t, source, fmt.Sprintf("/data/obj-%03d", i), randomBytes(256, int64(i)))
+	}
+
+	full, keys := sealSnapshot(t, source)
+	require.Greater(t, len(full), 1024)
+
+	// The store is not inspected after each cut on purpose: BadgerDB's loader
+	// writes as it reads and leaves its transaction watermark short when it
+	// stops early, so a handle whose restore failed blocks on the next read.
+	// That is what the error tells the operator to do something about.
+	for _, cut := range []int{
+		len(backupMagic),     // the magic and nothing else
+		len(backupMagic) + 4, // part-way through the salt
+		len(full) / 2,
+		len(full) - 1, // one byte short of complete
+	} {
+		t.Run(fmt.Sprint("cut at ", cut), func(t *testing.T) {
+			target := newTestStore(t)
+			rErr := target.Restore(bytes.NewReader(full[:cut]), keys)
+			require.Error(t, rErr, "a truncated snapshot must not restore")
+		})
+	}
+
+	t.Run("nothing is written when truncation is caught before the load", func(t *testing.T) {
+		// The header is read and authenticated in full before a byte of the
+		// body is opened, so damage near the front is refused before a single
+		// record lands and the target directory is still usable.
+		target := newTestStore(t)
+		require.Error(t, target.Restore(bytes.NewReader(full[:len(backupMagic)+4]), keys))
+
+		entries, _, lErr := target.List("/", "", 0)
+		require.NoError(t, lErr)
+		assert.Empty(t, entries)
+	})
+
+	t.Run("altered content is refused", func(t *testing.T) {
+		altered := append([]byte(nil), full...)
+		// Flip a byte inside the sealed body, past the header.
+		_, _, bodyAt := backupHeaderLayout(t, altered)
+		altered[bodyAt+16] ^= 0xff
+		target := newTestStore(t)
+		rErr := target.Restore(bytes.NewReader(altered), keys)
+		require.Error(t, rErr, "a damaged snapshot must not restore")
+	})
+
+	t.Run("the intact snapshot restores completely", func(t *testing.T) {
+		target := newTestStore(t)
+		require.NoError(t, target.Restore(bytes.NewReader(full), keys))
+		entries, _, lErr := target.List("/data", "", 0)
+		require.NoError(t, lErr)
+		assert.Len(t, entries, 200, "every object comes back")
+	})
+}
+
+// TestASnapshotStandsOnItsOwn is the property that lets an operator reach for
+// whichever file in the backup directory they like.
+//
+// Every snapshot is complete, so restoring the newest one needs nothing that
+// came before it -- and layering an older one on top is refused, because
+// restoring over live records would interleave two namespaces rather than
+// replace one.
+func TestASnapshotStandsOnItsOwn(t *testing.T) {
+	s := newTestStore(t)
+	writeObject(t, s, "/a.txt", []byte("alpha"))
+	first, firstKeys := sealSnapshot(t, s)
+
+	writeObject(t, s, "/b.txt", []byte("beta"))
+	second, secondKeys := sealSnapshot(t, s)
+
+	target := newTestStore(t)
+	require.NoError(t, target.Restore(bytes.NewReader(second), secondKeys))
+	for _, name := range []string{"/a.txt", "/b.txt"} {
+		_, sErr := target.Stat(name)
+		assert.NoError(t, sErr, "%s is in the later snapshot without needing the earlier one", name)
+	}
+
+	err := target.Restore(bytes.NewReader(first), firstKeys)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already holds objects")
+}
+
+// TestSnapshotRetention checks that the oldest snapshots are pruned, which is
+// what lets an operator roll back to before a corruption rather than only
+// forward from the newest one.
+func TestSnapshotRetention(t *testing.T) {
+	s := newTestStore(t)
+	dir := t.TempDir()
+
+	// Stand in for six passes on six different days.
+	var names []string
+	for day := 1; day <= 6; day++ {
+		name := fmt.Sprintf("%s202601%02dT000000Z.pmb", metadataBackupPrefix, day)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("snapshot"), 0600))
+		names = append(names, name)
+	}
+	// Something else in the directory must be left alone.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "operator-notes.txt"), []byte("keep"), 0600))
+
+	require.NoError(t, s.pruneSnapshots(BackupConfig{Dir: dir, Keep: 3}))
+
+	remaining := map[string]bool{}
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		remaining[e.Name()] = true
+	}
+
+	assert.True(t, remaining["operator-notes.txt"], "unrelated files are untouched")
+	for _, n := range names[:3] {
+		assert.False(t, remaining[n], "%s is older than the retention window", n)
+	}
+	for _, n := range names[3:] {
+		assert.True(t, remaining[n], "%s is within the retention window", n)
+	}
+}
+
+func TestSnapshotRetentionKeepsEverythingWhenZero(t *testing.T) {
+	s := newTestStore(t)
+	dir := t.TempDir()
+	for day := 1; day <= 3; day++ {
+		name := fmt.Sprintf("%s202601%02dT000000Z.pmb", metadataBackupPrefix, day)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("s"), 0600))
+	}
+
+	require.NoError(t, s.pruneSnapshots(BackupConfig{Dir: dir, Keep: 0}))
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 3, "zero retention keeps every snapshot")
+}
+
+// TestRestoreIntoAFreshDirectoryViaMaintenance follows the path the CLI
+// actually takes.  The round-trip test above restores through Open, which
+// adopts an empty database; the CLI restores through OpenMaintenance, which
+// refuses an unmarked non-empty one.  A fresh directory is the only sensible
+// restore target, so OpenMaintenance has to apply the same adoption rule --
+// otherwise the CLI could not restore anywhere at all.
+func TestRestoreIntoAFreshDirectoryViaMaintenance(t *testing.T) {
+	source := newTestStore(t)
+	require.NoError(t, source.MkdirAll("/data"))
+	writeObject(t, source, "/data/a.txt", []byte("alpha"))
+
+	snapshot, keys := sealSnapshot(t, source)
+
+	// A brand-new directory, as an operator recovering onto clean disk would
+	// have.
+	fresh := t.TempDir()
+	target, err := OpenMaintenance(t.Context(), fresh, true)
+	require.NoError(t, err, "restore must be able to populate an empty directory")
+	require.NoError(t, target.Restore(bytes.NewReader(snapshot), keys))
+
+	entries, _, err := target.List("/data", "", 0)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a.txt"}, entryNames(entries))
+	require.NoError(t, target.Close())
+
+	// Reopening read-only now works, because the restore claimed the store.
+	reopened, err := OpenMaintenance(t.Context(), fresh, false)
+	require.NoError(t, err)
+	defer reopened.Close()
+	report, err := reopened.Fsck(t.Context(), false)
+	require.NoError(t, err)
+	assert.Equal(t, 2, report.EntriesScanned, "the restored namespace checks out")
+}
+
+// TestMaintenanceStillRefusesAnUnmarkedNonEmptyDatabase confirms the adoption
+// rule did not become permissive: a cache predating the marker must never be
+// claimed as a pstore, even when writes are allowed.
+func TestMaintenanceStillRefusesAnUnmarkedNonEmptyDatabase(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	dir := t.TempDir()
+
+	db, err := local_cache.NewCacheDB(ctx, dir)
+	require.NoError(t, err)
+	require.NoError(t, db.SetNamespaceMapping("/legacy", 1))
+	require.NoError(t, db.Close())
+
+	_, err = OpenMaintenance(ctx, dir, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pre-existing cache")
+}
+
+// TestBackupKeyRoundTrip covers the sealed-snapshot path, which is what any
+// snapshot leaving the machine should use.
+func TestBackupKeyRoundTrip(t *testing.T) {
+	source := newTestStore(t)
+	require.NoError(t, source.MkdirAll("/data"))
+	writeObject(t, source, "/data/a.txt", []byte("alpha"))
+
+	encoded, err := generateBackupKey()
+	require.NoError(t, err)
+	key, err := ParseBackupKey(encoded)
+	require.NoError(t, err)
+
+	var sealed bytes.Buffer
+	_, err = source.BackupEncrypted(&sealed, BackupKeys{BackupKey: key})
+	require.NoError(t, err)
+
+	// The namespace must not be readable in the file.  A snapshot is a logical
+	// dump: written in the clear it would carry every one of these paths.
+	assert.NotContains(t, sealed.String(), "a.txt",
+		"an encrypted snapshot must not leak object paths")
+
+	misdirected := newTestStore(t)
+	err = misdirected.Restore(bytes.NewReader(sealed.Bytes()), BackupKeys{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "none of the available keys match",
+		"restoring a sealed snapshot with nothing to open it must say so")
+
+	target := newTestStore(t)
+	require.NoError(t, target.Restore(bytes.NewReader(sealed.Bytes()), BackupKeys{BackupKey: key}))
+
+	// The namespace comes back...
+	d, err := target.Stat("/data/a.txt")
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), d.Size)
+
+	// ...but not the object content, because a snapshot covers the catalog
+	// only.  Reading needs the block files too, which is exactly why the CLI
+	// says so at backup time.
+	_, err = target.ReadAll("/data/a.txt")
+	assert.Error(t, err, "a catalog-only restore cannot serve data")
+}
+
+// TestFullRecoveryFromSnapshotAndData is the real recovery drill: a snapshot
+// restored alongside the block files and the master key gives back readable
+// objects.
+func TestFullRecoveryFromSnapshotAndData(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	egrp, _ := errgroup.WithContext(ctx)
+
+	// Build a store and snapshot it.
+	sourceDir := t.TempDir()
+	source, err := Open(ctx, egrp, Config{BaseDir: sourceDir})
+	require.NoError(t, err)
+	require.NoError(t, source.MkdirAll("/data/sub"))
+	writeObject(t, source, "/data/small.txt", []byte("inline payload"))
+	big := randomBytes(64<<10, 91)
+	writeObject(t, source, "/data/sub/big.bin", big)
+
+	encoded, err := generateBackupKey()
+	require.NoError(t, err)
+	key, err := ParseBackupKey(encoded)
+	require.NoError(t, err)
+
+	var sealed bytes.Buffer
+	_, err = source.BackupEncrypted(&sealed, BackupKeys{BackupKey: key})
+	require.NoError(t, err)
+	require.NoError(t, source.Close())
+
+	// Recover onto fresh disk: the block files and master key are restored by
+	// ordinary means, the catalog from the snapshot.
+	recoverDir := t.TempDir()
+	copyTree(t, filepath.Join(sourceDir, "objects"), filepath.Join(recoverDir, "objects"))
+	copyFile(t, filepath.Join(sourceDir, "masterkey.json"), filepath.Join(recoverDir, "masterkey.json"))
+
+	loader, err := OpenMaintenance(ctx, recoverDir, true)
+	require.NoError(t, err)
+	require.NoError(t, loader.Restore(bytes.NewReader(sealed.Bytes()), BackupKeys{BackupKey: key}))
+	// A restore replaces everything the store cached at open -- the hash salt
+	// and the storage-directory mapping -- so the handle must be reopened
+	// before the data is readable.
+	require.NoError(t, loader.Close())
+
+	recovered, err := OpenMaintenance(ctx, recoverDir, false)
+	require.NoError(t, err)
+	defer recovered.Close()
+
+	// Both objects read back intact.
+	small, err := recovered.ReadAll("/data/small.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "inline payload", string(small))
+
+	large, err := recovered.ReadAll("/data/sub/big.bin")
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(big, large))
+
+	// And a deep check confirms the recovered data matches its checksums.
+	report, err := recovered.FsckWith(ctx, FsckOptions{Deep: true})
+	require.NoError(t, err)
+	assert.True(t, report.Healthy(), "the recovered store verifies: %+v", report)
+	assert.Equal(t, 2, report.ObjectsVerified)
+}
+
+// TestExportRecoversToPlainFiles covers getting data out without Pelican at
+// all, which is what an operator wants when the origin will not start.
+func TestExportRecoversToPlainFiles(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.MkdirAll("/data/sub"))
+	writeObject(t, s, "/data/one.txt", []byte("first"))
+	writeObject(t, s, "/data/sub/two.txt", []byte("second"))
+
+	dest := t.TempDir()
+	report, err := s.Export(t.Context(), ExportOptions{Root: "/data", Dest: dest, Verify: true})
+	require.NoError(t, err)
+	assert.Equal(t, 2, report.FilesWritten)
+	assert.Empty(t, report.Failed)
+
+	one, err := os.ReadFile(filepath.Join(dest, "one.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "first", string(one))
+
+	two, err := os.ReadFile(filepath.Join(dest, "sub", "two.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "second", string(two))
+}
+
+// TestExportContinuesPastBadObjects is the property that matters on a damaged
+// store: recovering most of the data and being told exactly what was lost
+// beats stopping at the first bad block.
+func TestExportContinuesPastBadObjects(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.Mkdir("/data"))
+	writeObject(t, s, "/data/good.txt", []byte("readable"))
+	writeObject(t, s, "/data/bad.bin", randomBytes(64<<10, 92))
+
+	// Destroy one object's data behind the store's back.
+	d, err := s.Stat("/data/bad.bin")
+	require.NoError(t, err)
+	hash := instanceHashFor(s.db, d.Generation)
+	meta, err := s.db.GetMetadata(hash)
+	require.NoError(t, err)
+	dirs := s.storage.GetDirs()
+	require.NoError(t, os.Remove(filepath.Join(dirs[meta.StorageID],
+		local_cache.GetInstanceStoragePath(hash))))
+
+	dest := t.TempDir()
+	report, err := s.Export(t.Context(), ExportOptions{Root: "/data", Dest: dest})
+	require.NoError(t, err, "a damaged object must not abort the whole export")
+	assert.Equal(t, 1, report.FilesWritten)
+	assert.Contains(t, report.Failed, "/data/bad.bin")
+
+	good, err := os.ReadFile(filepath.Join(dest, "good.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "readable", string(good))
+}
+
+// TestExportRefusesEscapingPaths guards the destination against a damaged or
+// hand-edited catalog.
+//
+// The mapping function is checked directly *and* through Export, because a
+// correct destinationFor that Export forgets to call protects nothing.  The
+// escaping entry is written straight into the index, since the ordinary write
+// path validates paths and could not produce one.
+func TestExportRefusesEscapingPaths(t *testing.T) {
+	_, err := destinationFor("/data", "/data/../../etc/passwd", "/tmp/dest")
+	assert.Error(t, err)
+
+	ok, err := destinationFor("/data", "/data/sub/f.txt", "/tmp/dest")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/tmp/dest", "sub", "f.txt"), ok)
+
+	s := newTestStore(t)
+	require.NoError(t, s.Mkdir("/data"))
+	writeObject(t, s, "/data/good.txt", []byte("fine"))
+
+	// A child of /data whose name climbs out of the subtree, as operator
+	// surgery or a corrupt record could leave behind.  The ordinary write
+	// path validates names and could never produce this one.
+	require.NoError(t, s.bdb.Update(func(txn *badger.Txn) error {
+		return putDirent(txn, "/data/..", &Dirent{Type: EntryFile, Generation: "deadbeef"})
+	}))
+
+	dest := filepath.Join(t.TempDir(), "out")
+	report, err := s.Export(t.Context(), ExportOptions{Root: "/data", Dest: dest})
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.FilesWritten, "the legitimate object still comes out")
+	require.Contains(t, report.Failed, "/data/..")
+	assert.Contains(t, report.Failed["/data/.."], "outside the destination")
+
+	siblings, err := os.ReadDir(filepath.Dir(dest))
+	require.NoError(t, err)
+	require.Len(t, siblings, 1, "nothing was written beside the destination")
+	assert.Equal(t, filepath.Base(dest), siblings[0].Name())
+}
+
+// TestExportResumeSkipsWhatIsAlreadyThere covers re-running an interrupted
+// recovery.  Without --resume every file the first run wrote comes back as a
+// failure, which is indistinguishable from real corruption at exactly the
+// moment an operator needs to tell the difference.
+func TestExportResumeSkipsWhatIsAlreadyThere(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.MkdirAll("/data/sub"))
+	writeObject(t, s, "/data/one.txt", []byte("first"))
+	writeObject(t, s, "/data/sub/two.txt", []byte("second"))
+
+	dest := t.TempDir()
+	first, err := s.Export(t.Context(), ExportOptions{Root: "/data", Dest: dest})
+	require.NoError(t, err)
+	require.Equal(t, 2, first.FilesWritten)
+
+	// Re-running without --resume reports every file as a failure, which is
+	// the behavior --resume exists to fix.
+	plain, err := s.Export(t.Context(), ExportOptions{Root: "/data", Dest: dest})
+	require.NoError(t, err)
+	assert.Len(t, plain.Failed, 2)
+	assert.Zero(t, plain.AlreadyPresent)
+
+	resumed, err := s.Export(t.Context(), ExportOptions{Root: "/data", Dest: dest, Resume: true})
+	require.NoError(t, err)
+	assert.Empty(t, resumed.Failed, "already-written files are not failures")
+	assert.Equal(t, 2, resumed.AlreadyPresent)
+	assert.Zero(t, resumed.FilesWritten)
+
+	// A genuinely missing file is still exported by the resumed run, and the
+	// files already there are left untouched.
+	require.NoError(t, os.Remove(filepath.Join(dest, "one.txt")))
+	require.NoError(t, os.WriteFile(filepath.Join(dest, "sub", "two.txt"), []byte("edited"), 0600))
+
+	third, err := s.Export(t.Context(), ExportOptions{Root: "/data", Dest: dest, Resume: true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, third.FilesWritten)
+	assert.Equal(t, 1, third.AlreadyPresent)
+	assert.Empty(t, third.Failed)
+
+	got, err := os.ReadFile(filepath.Join(dest, "sub", "two.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "edited", string(got), "a resume never overwrites what is already there")
+}
+
+func copyTree(t *testing.T, src, dst string) {
+	t.Helper()
+	require.NoError(t, filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, rErr := filepath.Rel(src, p)
+		if rErr != nil {
+			return rErr
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0750)
+		}
+		data, rErr := os.ReadFile(p)
+		if rErr != nil {
+			return rErr
+		}
+		return os.WriteFile(target, data, info.Mode())
+	}))
+}
+
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	data, err := os.ReadFile(src)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(dst, data, 0600))
+}
+
+func TestBackupKeyErrors(t *testing.T) {
+	s := newTestStore(t)
+	writeObject(t, s, "/a.txt", []byte("alpha"))
+
+	encoded, err := generateBackupKey()
+	require.NoError(t, err)
+	key, err := ParseBackupKey(encoded)
+	require.NoError(t, err)
+
+	var sealed bytes.Buffer
+	_, err = s.BackupEncrypted(&sealed, BackupKeys{BackupKey: key})
+	require.NoError(t, err)
+
+	t.Run("wrong key", func(t *testing.T) {
+		otherEncoded, gErr := generateBackupKey()
+		require.NoError(t, gErr)
+		other, gErr := ParseBackupKey(otherEncoded)
+		require.NoError(t, gErr)
+
+		target := newTestStore(t)
+		rErr := target.Restore(bytes.NewReader(sealed.Bytes()), BackupKeys{BackupKey: other})
+		require.Error(t, rErr)
+		assert.Contains(t, rErr.Error(), "could not be decrypted")
+	})
+
+	t.Run("truncated", func(t *testing.T) {
+		cut := sealed.Bytes()[:sealed.Len()/2]
+		target := newTestStore(t)
+		rErr := target.Restore(bytes.NewReader(cut), BackupKeys{BackupKey: key})
+		require.Error(t, rErr, "a truncated snapshot must not restore silently")
+	})
+
+	t.Run("tampered", func(t *testing.T) {
+		altered := make([]byte, sealed.Len())
+		copy(altered, sealed.Bytes())
+		// Flip a byte inside the final sealed chunk.
+		altered[len(altered)-10] ^= 0xff
+		target := newTestStore(t)
+		rErr := target.Restore(bytes.NewReader(altered), BackupKeys{BackupKey: key})
+		require.Error(t, rErr)
+	})
+
+	t.Run("header tampered", func(t *testing.T) {
+		// The header -- the salt and the whole recipient list -- is bound in as
+		// additional data, so an archive whose envelope has been edited cannot
+		// be passed off as a different but valid one.  The byte flipped here is
+		// inside the recorded key ID, which leaves every length field intact:
+		// the envelope still opens, and the body is what refuses.
+		altered := make([]byte, sealed.Len())
+		copy(altered, sealed.Bytes())
+		_, envelopeAt, _ := backupHeaderLayout(t, altered)
+		altered[envelopeAt+4+15] ^= 0xff
+		target := newTestStore(t)
+		rErr := target.Restore(bytes.NewReader(altered), BackupKeys{BackupKey: key})
+		require.Error(t, rErr)
+	})
+
+	t.Run("bad key encoding", func(t *testing.T) {
+		_, pErr := ParseBackupKey("not base64!!")
+		assert.Error(t, pErr)
+		_, pErr = ParseBackupKey("c2hvcnQ=")
+		assert.ErrorContains(t, pErr, "must be 32 bytes")
+	})
+}
+
+// TestExportRecoversNestedSubset covers recovering part of a tree rather than
+// all of it, which is the common case: one project's prefix out of a store
+// holding many.
+func TestExportRecoversNestedSubset(t *testing.T) {
+	s := newTestStore(t)
+
+	require.NoError(t, s.MkdirAll("/projects/alpha/data/raw"))
+	require.NoError(t, s.MkdirAll("/projects/beta"))
+	writeObject(t, s, "/projects/alpha/readme.txt", []byte("alpha readme"))
+	writeObject(t, s, "/projects/alpha/data/set.csv", []byte("1,2,3"))
+	writeObject(t, s, "/projects/alpha/data/raw/deep.bin", randomBytes(8<<10, 55))
+	writeObject(t, s, "/projects/beta/other.txt", []byte("should not appear"))
+
+	dest := t.TempDir()
+	report, err := s.Export(t.Context(), ExportOptions{
+		Root: "/projects/alpha", Dest: dest, Verify: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, report.FilesWritten)
+	assert.Empty(t, report.Failed)
+
+	// The subtree is rebased on the destination, not reproduced from the root.
+	for rel, want := range map[string]string{
+		filepath.Join("readme.txt"):      "alpha readme",
+		filepath.Join("data", "set.csv"): "1,2,3",
+	} {
+		got, rErr := os.ReadFile(filepath.Join(dest, rel))
+		require.NoError(t, rErr, "%s should have been exported", rel)
+		assert.Equal(t, want, string(got))
+	}
+	_, err = os.Stat(filepath.Join(dest, "data", "raw", "deep.bin"))
+	assert.NoError(t, err, "nesting below the root is preserved")
+
+	// Nothing outside the requested subtree came along.
+	_, err = os.Stat(filepath.Join(dest, "other.txt"))
+	assert.True(t, os.IsNotExist(err))
+	entries, err := os.ReadDir(dest)
+	require.NoError(t, err)
+	assert.Len(t, entries, 2, "only the subtree's own children are at the top level")
+}
+
+// TestExportDryRunWritesNothing lets an operator see the scope of a recovery
+// before committing disk to it.
+func TestExportDryRunWritesNothing(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.MkdirAll("/tree/sub"))
+	writeObject(t, s, "/tree/a.txt", []byte("aaa"))
+	writeObject(t, s, "/tree/sub/b.txt", []byte("bbbb"))
+
+	dest := filepath.Join(t.TempDir(), "not-created-yet")
+	report, err := s.Export(t.Context(), ExportOptions{Root: "/tree", Dest: dest, DryRun: true})
+	require.NoError(t, err)
+	assert.Equal(t, 2, report.FilesWritten)
+	assert.Equal(t, int64(7), report.BytesWritten)
+
+	_, err = os.Stat(dest)
+	assert.True(t, os.IsNotExist(err), "a dry run creates nothing")
+}
+
+// TestAnUnsupportedFormatVersionIsRefused covers the version byte in the magic.
+//
+// The container is versioned so that changing the format later has somewhere to
+// go.  What that costs is a file this build cannot read, and the only safe
+// answer is to say so by number: the layout behind the magic is version-
+// specific, so decoding on a guess would either fail with a cryptographic error
+// naming nothing useful or parse into the wrong shape.
+//
+// The versions below stand for a byte below the supported one, one plausibly
+// from a later release, and a byte that is simply garbage.  A file with an
+// unrelated magic is checked alongside them, because "I do not read this
+// version" and "this is not a snapshot" send an operator to different places
+// and must not collapse into one message.
+func TestAnUnsupportedFormatVersionIsRefused(t *testing.T) {
+	source := newTestStore(t)
+	require.NoError(t, source.MkdirAll("/data"))
+	writeObject(t, source, "/data/a.txt", []byte("alpha"))
+
+	encoded, err := generateBackupKey()
+	require.NoError(t, err)
+	key, err := ParseBackupKey(encoded)
+	require.NoError(t, err)
+
+	var current bytes.Buffer
+	_, err = source.BackupEncrypted(&current, BackupKeys{BackupKey: key})
+	require.NoError(t, err)
+	require.Equal(t, backupMagic, string(current.Bytes()[:len(backupMagic)]),
+		"a snapshot is written in the current format")
+	require.Equal(t, byte(backupFormatVersion), backupMagic[len(backupMagicPrefix)],
+		"the magic's version byte and backupFormatVersion must not drift apart")
+
+	for _, version := range []byte{0x00, 0x05, 0xff} {
+		t.Run(fmt.Sprintf("version %#02x", version), func(t *testing.T) {
+			other := append([]byte(nil), current.Bytes()...)
+			other[len(backupMagic)-1] = version
+
+			target := newTestStore(t)
+			rErr := target.Restore(bytes.NewReader(other), BackupKeys{BackupKey: key})
+			require.Error(t, rErr, "a version this build does not read must not be decoded")
+			// The error has to name both numbers: the operator's next move is to
+			// find the build that wrote it, and "wrong key or altered file" would
+			// send them after the wrong problem entirely.
+			assert.Contains(t, rErr.Error(), fmt.Sprintf("version %d", version))
+			assert.Contains(t, rErr.Error(),
+				fmt.Sprintf("only version %d", backupFormatVersion))
+		})
+	}
+
+	t.Run("a file that is not a snapshot at all says so instead", func(t *testing.T) {
+		target := newTestStore(t)
+		rErr := target.Restore(strings.NewReader("PELICAN-SOMETHING-ELSE\x00\x01 and a body"),
+			BackupKeys{BackupKey: key})
+		require.Error(t, rErr)
+		assert.NotContains(t, rErr.Error(), "format version",
+			"an unrelated file is not a version mismatch")
+	})
+
+	t.Run("the untouched archive still restores", func(t *testing.T) {
+		target := newTestStore(t)
+		require.NoError(t,
+			target.Restore(bytes.NewReader(current.Bytes()), BackupKeys{BackupKey: key}))
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Issuer-derived backup keys
+// ---------------------------------------------------------------------------
+
+// TestSnapshotOpensWithAnyIssuerKey is the property the multi-recipient
+// envelope exists for.
+//
+// A snapshot is sealed to every issuer key that was current when it was
+// written, so an operator holding any one of them can restore it. Without that,
+// a snapshot would be tied to whichever key happened to be active at the
+// moment, and an origin that rotates keys would accumulate archives that only
+// one specific key opens.
+func TestSnapshotOpensWithAnyIssuerKey(t *testing.T) {
+	source := newTestStore(t)
+	require.NoError(t, source.MkdirAll("/data/sub"))
+	writeObject(t, source, "/data/a.txt", []byte("alpha"))
+	writeObject(t, source, "/data/sub/b.txt", []byte("beta"))
+
+	all := testIssuerKeys(t, "kid-a", "kid-b", "kid-c")
+
+	var sealed bytes.Buffer
+	_, err := source.BackupEncrypted(&sealed, BackupKeys{IssuerKeys: all})
+	require.NoError(t, err)
+
+	assert.NotContains(t, sealed.String(), "a.txt",
+		"an encrypted snapshot must not leak object paths")
+
+	for keyID := range all {
+		t.Run(keyID, func(t *testing.T) {
+			only := map[string]jwk.Key{keyID: all[keyID]}
+			target := newTestStore(t)
+			require.NoError(t,
+				target.Restore(bytes.NewReader(sealed.Bytes()), BackupKeys{IssuerKeys: only}),
+				"any one of the keys it was sealed to must open it")
+
+			entries, lErr := listNames(target, "/data")
+			require.NoError(t, lErr)
+			assert.Equal(t, []string{"a.txt", "sub"}, entries)
+		})
+	}
+}
+
+// TestSnapshotSurvivesAKeyRotation plays out the rotation an origin actually
+// performs: a new key is added, then the old one is retired.
+//
+// An archive written while both were live must still open afterwards with the
+// key that survived. An archive written before the new key existed opens only
+// with the retired one -- and when that is gone, the error has to name the key
+// IDs it was sealed to, because that is the only thing that tells an operator
+// what to go and find.
+func TestSnapshotSurvivesAKeyRotation(t *testing.T) {
+	source := newTestStore(t)
+	require.NoError(t, source.MkdirAll("/data"))
+	writeObject(t, source, "/data/a.txt", []byte("alpha"))
+
+	keys := testIssuerKeys(t, "old", "new")
+	oldOnly := map[string]jwk.Key{"old": keys["old"]}
+	newOnly := map[string]jwk.Key{"new": keys["new"]}
+
+	// Written while only the old key existed.
+	var beforeRotation bytes.Buffer
+	_, err := source.BackupEncrypted(&beforeRotation, BackupKeys{IssuerKeys: oldOnly})
+	require.NoError(t, err)
+
+	// Written during the overlap, when both keys were current.
+	var duringRotation bytes.Buffer
+	_, err = source.BackupEncrypted(&duringRotation, BackupKeys{IssuerKeys: keys})
+	require.NoError(t, err)
+
+	t.Run("an overlapping archive opens with the key that survived", func(t *testing.T) {
+		target := newTestStore(t)
+		require.NoError(t, target.Restore(bytes.NewReader(duringRotation.Bytes()),
+			BackupKeys{IssuerKeys: newOnly}))
+		entries, lErr := listNames(target, "/data")
+		require.NoError(t, lErr)
+		assert.Equal(t, []string{"a.txt"}, entries)
+	})
+
+	t.Run("an archive sealed only to the retired key names it", func(t *testing.T) {
+		target := newTestStore(t)
+		rErr := target.Restore(bytes.NewReader(beforeRotation.Bytes()),
+			BackupKeys{IssuerKeys: newOnly})
+		require.Error(t, rErr)
+
+		var noKey *ErrNoMatchingKey
+		require.ErrorAs(t, rErr, &noKey)
+		assert.Equal(t, []string{"old"}, noKey.SealedKeyIDs,
+			"the error must name the key the archive needs")
+		assert.Contains(t, rErr.Error(), "old")
+	})
+
+	t.Run("an archive sealed only to the retired key still opens with it", func(t *testing.T) {
+		target := newTestStore(t)
+		require.NoError(t, target.Restore(bytes.NewReader(beforeRotation.Bytes()),
+			BackupKeys{IssuerKeys: oldOnly}),
+			"retiring a key elsewhere does not invalidate the archives it sealed")
+	})
+}
+
+// TestSnapshotOpensWithTheEscrowedKeyAlone is the disaster path: the origin is
+// gone, its issuer keys with it, and all that is left is the key an operator
+// printed with "metadata-backup-key" and filed away.
+func TestSnapshotOpensWithTheEscrowedKeyAlone(t *testing.T) {
+	source := newTestStore(t)
+	require.NoError(t, source.MkdirAll("/data"))
+	writeObject(t, source, "/data/a.txt", []byte("alpha"))
+
+	issuerKeys := testIssuerKeys(t, "kid-a", "kid-b")
+
+	var sealed bytes.Buffer
+	_, err := source.BackupEncrypted(&sealed, BackupKeys{IssuerKeys: issuerKeys})
+	require.NoError(t, err)
+
+	// What the operator saved: the derived private key, round-tripped through
+	// the base64 form a key file holds.
+	escrowed, err := DeriveBackupKey(issuerKeys["kid-b"])
+	require.NoError(t, err)
+	fromFile, err := ParseBackupKey(FormatBackupKey(escrowed))
+	require.NoError(t, err)
+
+	target := newTestStore(t)
+	require.NoError(t,
+		target.Restore(bytes.NewReader(sealed.Bytes()), BackupKeys{BackupKey: fromFile}),
+		"the escrowed key alone must open the archive, with no issuer keys present")
+
+	entries, err := listNames(target, "/data")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a.txt"}, entries)
+
+	t.Run("an unrelated key does not", func(t *testing.T) {
+		stranger, dErr := DeriveBackupKey(testIssuerKeys(t, "elsewhere")["elsewhere"])
+		require.NoError(t, dErr)
+		other := newTestStore(t)
+		rErr := other.Restore(bytes.NewReader(sealed.Bytes()), BackupKeys{BackupKey: stranger})
+		require.Error(t, rErr)
+		var noKey *ErrNoMatchingKey
+		assert.ErrorAs(t, rErr, &noKey)
+	})
+}
+
+// TestBackupKeysAreDomainSeparated checks the pstore side of the property
+// backup_keys exists to provide: the key that opens a pstore snapshot is not
+// the key that opens a server database backup, so escrowing one does not hand
+// over the other.
+func TestBackupKeysAreDomainSeparated(t *testing.T) {
+	issuerKey := testIssuerKeys(t, "kid")["kid"]
+
+	pstoreKey, err := DeriveBackupKey(issuerKey)
+	require.NoError(t, err)
+	databaseKey, _, err := backup_keys.DeriveKeyPair(issuerKey, backup_keys.LabelDatabase)
+	require.NoError(t, err)
+	require.NotEqual(t, databaseKey[:], pstoreKey)
+
+	source := newTestStore(t)
+	require.NoError(t, source.MkdirAll("/data"))
+	writeObject(t, source, "/data/a.txt", []byte("alpha"))
+
+	var sealed bytes.Buffer
+	_, err = source.BackupEncrypted(&sealed, BackupKeys{BackupKey: pstoreKey})
+	require.NoError(t, err)
+
+	target := newTestStore(t)
+	rErr := target.Restore(bytes.NewReader(sealed.Bytes()),
+		BackupKeys{BackupKey: databaseKey[:]})
+	require.Error(t, rErr, "the database backup key must not open a pstore snapshot")
+	var noKey *ErrNoMatchingKey
+	assert.ErrorAs(t, rErr, &noKey)
+}
+
+// TestBackupKeyReplacesTheIssuerKeys pins the semantics of
+// `metadata-backup --key-file`: the key it names is an override, not an
+// addition.
+//
+// The distinction matters to the operator who passes it precisely because they
+// want a backup that does not depend on this host's keys. If the issuer keys
+// were also recipients, the archive would still be openable by whoever holds
+// them, which is the property they were trying to avoid.
+func TestBackupKeyReplacesTheIssuerKeys(t *testing.T) {
+	source := newTestStore(t)
+	require.NoError(t, source.MkdirAll("/data"))
+	writeObject(t, source, "/data/a.txt", []byte("alpha"))
+
+	issuerKeys := testIssuerKeys(t, "kid-a")
+	encoded, err := generateBackupKey()
+	require.NoError(t, err)
+	override, err := ParseBackupKey(encoded)
+	require.NoError(t, err)
+
+	var sealed bytes.Buffer
+	_, err = source.BackupEncrypted(&sealed, BackupKeys{
+		IssuerKeys: issuerKeys, BackupKey: override,
+	})
+	require.NoError(t, err)
+
+	target := newTestStore(t)
+	require.NoError(t,
+		target.Restore(bytes.NewReader(sealed.Bytes()), BackupKeys{BackupKey: override}))
+
+	other := newTestStore(t)
+	rErr := other.Restore(bytes.NewReader(sealed.Bytes()), BackupKeys{IssuerKeys: issuerKeys})
+	require.Error(t, rErr, "an override must exclude the issuer keys, not join them")
+	var noKey *ErrNoMatchingKey
+	require.ErrorAs(t, rErr, &noKey)
+	require.Len(t, noKey.SealedKeyIDs, 1)
+	assert.True(t, strings.HasPrefix(noKey.SealedKeyIDs[0], "backup-key:"),
+		"an explicitly supplied key is identified by fingerprint, not by an issuer key ID")
+}
+
+// TestSnapshotRefusesToWriteWithoutKeys is the whole point of the rule: there
+// is no configuration, and no combination of missing keys, that produces a
+// cleartext dump of the namespace. A backup either encrypts or fails.
+func TestSnapshotRefusesToWriteWithoutKeys(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.MkdirAll("/data"))
+	writeObject(t, s, "/data/a.txt", []byte("alpha"))
+
+	var out bytes.Buffer
+	_, err := s.BackupEncrypted(&out, BackupKeys{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no keys are available")
+	assert.NotContains(t, out.String(), "a.txt",
+		"a refused backup must not have leaked the namespace on its way out")
+
+	t.Run("the scheduled backup writes nothing either", func(t *testing.T) {
+		dir := t.TempDir()
+		require.Error(t, s.snapshotOnce(BackupConfig{Dir: dir, Interval: time.Hour}))
+
+		entries, rErr := os.ReadDir(dir)
+		require.NoError(t, rErr)
+		for _, e := range entries {
+			// The partial file is removed on failure; nothing may survive that
+			// pruning would later count as a backup.
+			assert.Fail(t, "a failed snapshot left a file behind", e.Name())
+		}
+	})
+}
+
+// TestEveryWrittenSnapshotIsSealed guards the absence of an unencrypted path.
+//
+// The scheduled backup is the one that runs unattended, so it is the one where
+// a cleartext dump would go unnoticed. Every file it publishes must carry an
+// encrypted magic and must not contain a path from the catalog.
+func TestEveryWrittenSnapshotIsSealed(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.MkdirAll("/data"))
+	writeObject(t, s, "/data/secret-name.txt", []byte("alpha"))
+
+	dir := t.TempDir()
+	require.NoError(t, s.snapshotOnce(BackupConfig{
+		Dir:      dir,
+		Interval: time.Hour,
+		Keys:     BackupKeys{IssuerKeys: testIssuerKeys(t, "kid-a")},
+	}))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	body, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	require.NoError(t, err)
+	assert.True(t, looksEncrypted(body), "a published snapshot must be sealed")
+	assert.NotContains(t, string(body), "secret-name.txt")
+}
+
+// ---------------------------------------------------------------------------
+// The three-level key hierarchy
+// ---------------------------------------------------------------------------
+
+// backupHeaderLayout locates the parts of a header inside a sealed archive, so
+// the tampering tests can edit one field without disturbing any other.
+//
+// It parses rather than assuming fixed offsets: the envelope is
+// variable-length, and a test that hard-codes where the body starts would
+// silently stop testing anything the first time a key ID changed length.
+func backupHeaderLayout(t *testing.T, archive []byte) (saltAt, envelopeAt, bodyAt int) {
+	t.Helper()
+	require.Greater(t, len(archive), len(backupMagic)+backupSaltSize+2)
+	require.Equal(t, backupMagic, string(archive[:len(backupMagic)]))
+
+	saltAt = len(backupMagic)
+	envelopeAt = saltAt + backupSaltSize
+	at := envelopeAt
+	count := int(binary.BigEndian.Uint16(archive[at : at+2]))
+	require.Positive(t, count)
+	at += 2
+	for range count {
+		for range 2 { // the key ID, then the sealed backup key
+			require.Less(t, at+2, len(archive))
+			n := int(binary.BigEndian.Uint16(archive[at : at+2]))
+			at += 2 + n
+		}
+	}
+	require.Less(t, at, len(archive))
+	return saltAt, envelopeAt, at
+}
+
+// sealOneObject writes a small store's catalog out under keys, which is all
+// most of the key-hierarchy tests need.
+func sealOneObject(t *testing.T, keys BackupKeys) []byte {
+	t.Helper()
+	source := newTestStore(t)
+	require.NoError(t, source.MkdirAll("/data"))
+	writeObject(t, source, "/data/a.txt", []byte("alpha"))
+
+	var sealed bytes.Buffer
+	_, err := source.BackupEncrypted(&sealed, keys)
+	require.NoError(t, err)
+	return sealed.Bytes()
+}
+
+// restoresCleanly reports whether an archive opens with keys and brings the
+// namespace back.
+func restoresCleanly(t *testing.T, archive []byte, keys BackupKeys) error {
+	t.Helper()
+	target := newTestStore(t)
+	if err := target.Restore(bytes.NewReader(archive), keys); err != nil {
+		return err
+	}
+	entries, err := listNames(target, "/data")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a.txt"}, entries)
+	return nil
+}
+
+// TestThreeWaysToOpenASnapshot is the whole point of the hierarchy: a recovery
+// happens on whatever the operator still has, and which of the three levels
+// that is cannot be predicted when the backup is written.
+//
+// Each path is exercised on its own, with nothing else supplied -- in
+// particular the per-file key opens the archive with no issuer key present
+// anywhere, which is what makes it safe to hand a single archive to someone.
+func TestThreeWaysToOpenASnapshot(t *testing.T) {
+	issuerKeys := testIssuerKeys(t, "kid-a", "kid-b")
+	archive := sealOneObject(t, BackupKeys{IssuerKeys: issuerKeys})
+
+	t.Run("level 1: an issuer key", func(t *testing.T) {
+		require.NoError(t, restoresCleanly(t, archive,
+			BackupKeys{IssuerKeys: map[string]jwk.Key{"kid-b": issuerKeys["kid-b"]}}))
+	})
+
+	t.Run("level 2: the backup key alone", func(t *testing.T) {
+		// Escrowed from an issuer key the reader no longer has, and
+		// round-tripped through the base64 form a key file holds.
+		escrowed, err := DeriveBackupKey(issuerKeys["kid-b"])
+		require.NoError(t, err)
+		fromFile, err := ParseBackupKey(FormatBackupKey(escrowed))
+		require.NoError(t, err)
+
+		require.NoError(t, restoresCleanly(t, archive, BackupKeys{BackupKey: fromFile}))
+	})
+
+	t.Run("level 3: this file's key alone", func(t *testing.T) {
+		fileKey, err := DeriveFileKey(bytes.NewReader(archive),
+			BackupKeys{IssuerKeys: issuerKeys})
+		require.NoError(t, err)
+		fromFile, err := ParseBackupKey(FormatBackupKey(fileKey))
+		require.NoError(t, err)
+
+		require.NoError(t, restoresCleanly(t, archive, BackupKeys{FileKey: fromFile}),
+			"a per-file key must open its archive with no issuer key and no backup key")
+	})
+
+	t.Run("the three keys are all different", func(t *testing.T) {
+		backupKey, err := DeriveBackupKey(issuerKeys["kid-a"])
+		require.NoError(t, err)
+		fileKey, err := DeriveFileKey(bytes.NewReader(archive),
+			BackupKeys{IssuerKeys: issuerKeys})
+		require.NoError(t, err)
+
+		assert.NotEqual(t, backupKey, fileKey,
+			"a per-file key that equalled the backup key would be no narrower than it")
+
+		assert.NotContains(t, string(archive), string(backupKey),
+			"the backup key travels sealed, never in the clear")
+		assert.NotContains(t, string(archive), string(fileKey),
+			"the per-file key is derived, never stored")
+	})
+}
+
+// TestEveryArchiveHasItsOwnKey is what makes handing out one archive's key
+// safe.
+//
+// Two snapshots taken back to back from the same store, under the same issuer
+// keys, must be encrypted under different keys -- and neither key may open the
+// other file. Without the per-archive salt both would derive the same key and
+// giving away one would give away the series.
+func TestEveryArchiveHasItsOwnKey(t *testing.T) {
+	issuerKeys := testIssuerKeys(t, "kid-a")
+
+	source := newTestStore(t)
+	require.NoError(t, source.MkdirAll("/data"))
+	writeObject(t, source, "/data/a.txt", []byte("alpha"))
+
+	var first, second bytes.Buffer
+	_, err := source.BackupEncrypted(&first, BackupKeys{IssuerKeys: issuerKeys})
+	require.NoError(t, err)
+	_, err = source.BackupEncrypted(&second, BackupKeys{IssuerKeys: issuerKeys})
+	require.NoError(t, err)
+
+	firstSalt, _, _ := backupHeaderLayout(t, first.Bytes())
+	assert.NotEqual(t,
+		first.Bytes()[firstSalt:firstSalt+backupSaltSize],
+		second.Bytes()[firstSalt:firstSalt+backupSaltSize],
+		"each snapshot draws its own salt")
+
+	firstKey, err := DeriveFileKey(bytes.NewReader(first.Bytes()),
+		BackupKeys{IssuerKeys: issuerKeys})
+	require.NoError(t, err)
+	secondKey, err := DeriveFileKey(bytes.NewReader(second.Bytes()),
+		BackupKeys{IssuerKeys: issuerKeys})
+	require.NoError(t, err)
+	require.NotEqual(t, firstKey, secondKey, "two snapshots must not share a key")
+
+	// The derivation is deterministic, so asking twice gives the same answer --
+	// which is what lets the key be re-derived rather than stored.
+	again, err := DeriveFileKey(bytes.NewReader(first.Bytes()),
+		BackupKeys{IssuerKeys: issuerKeys})
+	require.NoError(t, err)
+	assert.Equal(t, firstKey, again)
+
+	require.NoError(t, restoresCleanly(t, first.Bytes(), BackupKeys{FileKey: firstKey}))
+	require.NoError(t, restoresCleanly(t, second.Bytes(), BackupKeys{FileKey: secondKey}))
+
+	crossed := restoresCleanly(t, second.Bytes(), BackupKeys{FileKey: firstKey})
+	require.Error(t, crossed, "one archive's key must not open another")
+	assert.Contains(t, crossed.Error(), "could not be decrypted")
+}
+
+// TestEscrowedBackupKeyDerivesAFileKey covers the recovery that has to work
+// when nothing of the origin survives: an operator holding only the escrowed
+// level-2 key, on a machine that has never held this origin's issuer keys, can
+// still produce the key for one named archive and hand that on.
+func TestEscrowedBackupKeyDerivesAFileKey(t *testing.T) {
+	issuerKeys := testIssuerKeys(t, "kid-a", "kid-b")
+	archive := sealOneObject(t, BackupKeys{IssuerKeys: issuerKeys})
+
+	for _, keyID := range []string{"kid-a", "kid-b"} {
+		t.Run("escrowed from "+keyID, func(t *testing.T) {
+			// Any of the origin's backup keys works, not only the one the
+			// archive happened to derive its own key from: the archive carries
+			// that key sealed to every recipient.
+			escrowed, err := DeriveBackupKey(issuerKeys[keyID])
+			require.NoError(t, err)
+
+			fileKey, err := DeriveFileKey(bytes.NewReader(archive),
+				BackupKeys{BackupKey: escrowed})
+			require.NoError(t, err)
+
+			viaIssuer, err := DeriveFileKey(bytes.NewReader(archive),
+				BackupKeys{IssuerKeys: issuerKeys})
+			require.NoError(t, err)
+			assert.Equal(t, viaIssuer, fileKey,
+				"the escrowed key must reach the same per-file key the issuer keys do")
+
+			require.NoError(t, restoresCleanly(t, archive, BackupKeys{FileKey: fileKey}))
+		})
+	}
+
+	// The level-3 key really is HKDF over the level-2 key and the salt sitting
+	// in the file, and nothing else -- checked against the primitive rather
+	// than against the implementation that produced it, so a change to the
+	// envelope cannot quietly change what "derived from the intermediate key
+	// plus the salt in the backup" means.
+	t.Run("it is HKDF over the backup key and the salt in the file", func(t *testing.T) {
+		saltAt, _, _ := backupHeaderLayout(t, archive)
+		salt := archive[saltAt : saltAt+backupSaltSize]
+
+		// kid-a sorts first, so its backup key is the archive's own.
+		canonical, err := DeriveBackupKey(issuerKeys["kid-a"])
+		require.NoError(t, err)
+		want, err := deriveFileKey(canonical, salt)
+		require.NoError(t, err)
+
+		got, err := DeriveFileKey(bytes.NewReader(archive), BackupKeys{IssuerKeys: issuerKeys})
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("a stranger's backup key derives nothing", func(t *testing.T) {
+		stranger, err := DeriveBackupKey(testIssuerKeys(t, "elsewhere")["elsewhere"])
+		require.NoError(t, err)
+		_, err = DeriveFileKey(bytes.NewReader(archive), BackupKeys{BackupKey: stranger})
+		require.Error(t, err)
+		var noKey *ErrNoMatchingKey
+		assert.ErrorAs(t, err, &noKey)
+	})
+}
+
+// TestHeaderIsBoundToTheBody covers the AAD binding one field at a time.
+//
+// Every one of these edits leaves a structurally valid archive behind, so
+// nothing but the authentication catches them. The salt and the sealed backup
+// key are the two new fields, and both have to be covered or an attacker could
+// point an archive at a key of their choosing or graft one archive's envelope
+// onto another's body.
+func TestHeaderIsBoundToTheBody(t *testing.T) {
+	issuerKeys := testIssuerKeys(t, "kid-a")
+
+	// Both archives cover the same store under the same keys, so their headers
+	// are laid out identically -- same salt length, same recipients, same key
+	// IDs -- and every field below is byte-for-byte substitutable between them.
+	// Only the cryptography can tell them apart. (The bodies differ in length by
+	// a byte or two, because a catalog carries commit timestamps and compresses
+	// slightly differently each pass; the body splice therefore replaces the
+	// whole tail rather than an equal-length window.)
+	source := newTestStore(t)
+	require.NoError(t, source.MkdirAll("/data"))
+	writeObject(t, source, "/data/a.txt", []byte("alpha"))
+
+	var a, b bytes.Buffer
+	_, err := source.BackupEncrypted(&a, BackupKeys{IssuerKeys: issuerKeys})
+	require.NoError(t, err)
+	_, err = source.BackupEncrypted(&b, BackupKeys{IssuerKeys: issuerKeys})
+	require.NoError(t, err)
+
+	saltAt, envelopeAt, bodyAt := backupHeaderLayout(t, a.Bytes())
+	otherSaltAt, otherEnvelopeAt, otherBodyAt := backupHeaderLayout(t, b.Bytes())
+	require.Equal(t, []int{saltAt, envelopeAt, bodyAt},
+		[]int{otherSaltAt, otherEnvelopeAt, otherBodyAt},
+		"the two headers must be the same shape for the splices to mean anything")
+
+	for _, tc := range []struct {
+		name string
+		from int
+		// to is exclusive; -1 splices everything from `from` to the end, which
+		// is how the body is swapped despite the two differing in length.
+		to    int
+		about string
+	}{
+		{"the salt", saltAt, envelopeAt,
+			"swapping the salt would silently change which key the archive claims to want"},
+		{"the sealed backup key", envelopeAt, bodyAt,
+			"the envelope must not be liftable from another archive"},
+		{"the body", bodyAt, -1,
+			"chunks must not be spliceable between archives"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var spliced []byte
+			if tc.to < 0 {
+				spliced = append(append([]byte(nil), a.Bytes()[:tc.from]...),
+					b.Bytes()[tc.from:]...)
+			} else {
+				spliced = append([]byte(nil), a.Bytes()...)
+				copy(spliced[tc.from:tc.to], b.Bytes()[tc.from:tc.to])
+			}
+			require.NotEqual(t, a.Bytes(), spliced, "the splice changed nothing")
+
+			rErr := restoresCleanly(t, spliced, BackupKeys{IssuerKeys: issuerKeys})
+			require.Error(t, rErr, tc.about)
+		})
+	}
+
+	t.Run("the untouched archive still restores", func(t *testing.T) {
+		require.NoError(t, restoresCleanly(t, a.Bytes(), BackupKeys{IssuerKeys: issuerKeys}))
+	})
+}
+
+// TestAPerFileKeyCannotWriteASnapshot keeps the level-3 key one-directional.
+//
+// It is the key that gets handed out, so it must not be usable to produce a new
+// archive that would then look like one the origin wrote.
+func TestAPerFileKeyCannotWriteASnapshot(t *testing.T) {
+	issuerKeys := testIssuerKeys(t, "kid-a")
+	archive := sealOneObject(t, BackupKeys{IssuerKeys: issuerKeys})
+	fileKey, err := DeriveFileKey(bytes.NewReader(archive), BackupKeys{IssuerKeys: issuerKeys})
+	require.NoError(t, err)
+
+	s := newTestStore(t)
+	require.NoError(t, s.MkdirAll("/data"))
+	writeObject(t, s, "/data/secret-name.txt", []byte("alpha"))
+
+	var out bytes.Buffer
+	_, err = s.BackupEncrypted(&out, BackupKeys{FileKey: fileKey})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot seal a new one")
+	assert.NotContains(t, out.String(), "secret-name.txt",
+		"a refused backup must not have leaked the namespace on its way out")
+}
+
+// listNames returns the direct children of a directory, for the many
+// assertions that only care about what came back.
+func listNames(s *Store, dir string) ([]string, error) {
+	entries, _, err := s.List(dir, "", 0)
+	if err != nil {
+		return nil, err
+	}
+	return entryNames(entries), nil
+}
+
+// ---------------------------------------------------------------------------
+// Scheduling
+// ---------------------------------------------------------------------------
+
+// fakeTimer stands in for the timer a scheduled loop waits on, so a test
+// decides exactly when a run starts.
+//
+// Everything is unbuffered on purpose.  A real time.Timer's channel holds one
+// pending fire, which is precisely the behavior these tests exist to rule out;
+// a fake that buffered would reproduce the bug it is meant to detect.  With
+// unbuffered channels, a fire that nobody is waiting for blocks instead of
+// queueing, and the test says so by name rather than hanging silently.
+type fakeTimer struct {
+	// armed receives the duration passed to the constructor and to every
+	// Reset, so a test can see *when* the next wait was set up relative to the
+	// work finishing -- which is the whole property under test.
+	armed chan time.Duration
+	fires chan time.Time
+	// stopped is closed when the loop releases the timer, which is how a test
+	// tells a clean shutdown from a leak.
+	stopped chan struct{}
+}
+
+func newFakeTimer() *fakeTimer {
+	return &fakeTimer{
+		armed:   make(chan time.Duration, 8),
+		fires:   make(chan time.Time),
+		stopped: make(chan struct{}),
+	}
+}
+
+// new is the schedule's timer factory: the loop asks for one timer and keeps
+// resetting it.
+func (f *fakeTimer) new(d time.Duration) periodicTimer {
+	f.armed <- d
+	return f
+}
+
+func (f *fakeTimer) Chan() <-chan time.Time { return f.fires }
+func (f *fakeTimer) Reset(d time.Duration)  { f.armed <- d }
+func (f *fakeTimer) Stop()                  { close(f.stopped) }
+
+// fire releases one run and blocks until the loop takes it, so the test always
+// knows the loop was waiting rather than busy.
+func (f *fakeTimer) fire(t *testing.T) {
+	t.Helper()
+	select {
+	case f.fires <- time.Now():
+	case <-time.After(testScheduleTimeout):
+		t.Fatal("the loop was not waiting on its timer")
+	}
+}
+
+// armedFor returns the duration the next wait was set to, failing rather than
+// hanging if the loop never armed one.
+func (f *fakeTimer) armedFor(t *testing.T) time.Duration {
+	t.Helper()
+	select {
+	case d := <-f.armed:
+		return d
+	case <-time.After(testScheduleTimeout):
+		t.Fatal("the loop never armed its timer")
+		return 0
+	}
+}
+
+// testScheduleTimeout bounds the waits above.  It is a failure deadline, not a
+// synchronization delay: every assertion below completes as soon as the loop
+// reaches the point it is waiting for, and this is only how long a test is
+// willing to wait before declaring the loop stuck.
+const testScheduleTimeout = 30 * time.Second
+
+// TestScheduledRunsAreSpacedFromTheEndOfTheLastRun is the property a ticker did
+// not have.
+//
+// A ticker fires on a fixed cadence regardless of how long the body takes, so a
+// pass that overruns its interval finds a tick already waiting when it finishes
+// and starts again immediately.  With a 24-hour interval and a 24-hour data
+// scan, an origin scans continuously -- and nothing in the configuration says
+// so.  What is asserted here is the mechanism that fixes it: the next wait is
+// armed only *after* the work returns, so an overrun can never produce
+// back-to-back runs.
+func TestScheduledRunsAreSpacedFromTheEndOfTheLastRun(t *testing.T) {
+	timer := newFakeTimer()
+	started := make(chan struct{})
+	finish := make(chan struct{})
+	done := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go func() {
+		defer close(done)
+		runPeriodically(ctx, time.Hour, schedule{newTimer: timer.new, now: time.Now},
+			"test pass", func() {
+				started <- struct{}{}
+				<-finish
+			})
+	}()
+
+	// Nothing runs until the first wait elapses.
+	assert.Equal(t, time.Hour, timer.armedFor(t), "the loop waits before its first run")
+	select {
+	case <-started:
+		t.Fatal("a run began before the interval elapsed")
+	default:
+	}
+
+	// One fire starts one run, which then overruns: while it is in flight the
+	// timer has not been re-armed, so there is nowhere for a second fire to
+	// come from. A ticker would have had one waiting.
+	timer.fire(t)
+	<-started
+	select {
+	case d := <-timer.armed:
+		t.Fatalf("the next run was scheduled %s into the previous one, so an overrunning "+
+			"pass would be followed immediately by another", d)
+	default:
+	}
+
+	// Only once the run finishes is the next interval armed.
+	finish <- struct{}{}
+	assert.Equal(t, time.Hour, timer.armedFor(t),
+		"the gap is measured from the end of the run, not from its start")
+
+	// And that next interval really does gate the next run.
+	timer.fire(t)
+	<-started
+	finish <- struct{}{}
+	assert.Equal(t, time.Hour, timer.armedFor(t))
+
+	// Cancellation is prompt and releases the timer: the loop is waiting on the
+	// timer it just armed, and must leave through the context instead.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(testScheduleTimeout):
+		t.Fatal("the loop did not return when its context was cancelled")
+	}
+	select {
+	case <-timer.stopped:
+	default:
+		t.Fatal("the loop returned without releasing its timer")
+	}
+}
+
+// TestAnOverrunningRunIsReported covers the operator's only signal that the
+// configured interval is faster than the store's size allows.
+//
+// The run still completes and the next one is still scheduled -- the loop does
+// not intervene -- so a log line is the whole of the feedback, and it has to
+// say what the consequence is rather than only reporting two durations.
+func TestAnOverrunningRunIsReported(t *testing.T) {
+	hook := test.NewGlobal()
+	t.Cleanup(hook.Reset)
+
+	// A clock the test advances itself: the loop reads it once before the work
+	// and once after, so handing back two readings an hour apart makes a
+	// one-minute interval overrun without anything taking any time at all.
+	readings := []time.Time{
+		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC),
+	}
+	now := func() time.Time {
+		at := readings[0]
+		if len(readings) > 1 {
+			readings = readings[1:]
+		}
+		return at
+	}
+
+	timer := newFakeTimer()
+	ran := make(chan struct{})
+	done := make(chan struct{})
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go func() {
+		defer close(done)
+		runPeriodically(ctx, time.Minute, schedule{newTimer: timer.new, now: now},
+			"data scan", func() { ran <- struct{}{} })
+	}()
+
+	require.Equal(t, time.Minute, timer.armedFor(t))
+	timer.fire(t)
+	<-ran
+	require.Equal(t, time.Minute, timer.armedFor(t),
+		"an overrun does not stop the loop from scheduling the next run")
+
+	cancel()
+	<-done
+
+	var overrun *logrus.Entry
+	for _, entry := range hook.AllEntries() {
+		if strings.Contains(entry.Message, "took 1h0m0s") {
+			overrun = entry
+		}
+	}
+	require.NotNil(t, overrun, "an overrunning run must be reported")
+	assert.Equal(t, logrus.WarnLevel, overrun.Level)
+	assert.Contains(t, overrun.Message, "data scan", "the message names the pass that overran")
+	assert.Contains(t, overrun.Message, "longer than its configured interval of 1m0s")
+	assert.Contains(t, overrun.Message, "Lengthen the interval",
+		"the message has to say what to do about it, not only that it happened")
+}
+
+// TestARunThatFitsIsNotReported keeps the warning above meaningful: an origin
+// whose checks comfortably fit their interval must not be told anything.
+func TestARunThatFitsIsNotReported(t *testing.T) {
+	hook := test.NewGlobal()
+	t.Cleanup(hook.Reset)
+
+	timer := newFakeTimer()
+	ran := make(chan struct{})
+	done := make(chan struct{})
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go func() {
+		defer close(done)
+		runPeriodically(ctx, time.Hour, schedule{newTimer: timer.new, now: time.Now},
+			"index check", func() { ran <- struct{}{} })
+	}()
+
+	require.Equal(t, time.Hour, timer.armedFor(t))
+	timer.fire(t)
+	<-ran
+	require.Equal(t, time.Hour, timer.armedFor(t))
+
+	cancel()
+	<-done
+
+	for _, entry := range hook.AllEntries() {
+		assert.NotContains(t, entry.Message, "longer than its configured interval")
+	}
+}
+
+// TestScheduledBackupsSnapshotAtStartupThenOnTheInterval pins the two halves of
+// the backup loop's schedule together.
+//
+// The startup snapshot is what catches an unwritable backup directory now
+// rather than an interval from now, and what keeps a store that dies in its
+// first hour from having no metadata backup at all. The interval after it is a
+// gap, not a cadence: a snapshot of a large catalog is not instant, and the
+// default is six hours.
+func TestScheduledBackupsSnapshotAtStartupThenOnTheInterval(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.MkdirAll("/data"))
+	writeObject(t, s, "/data/a.txt", []byte("alpha"))
+
+	dir := t.TempDir()
+	cfg := BackupConfig{Dir: dir, Interval: 6 * time.Hour, Keys: testBackupKeys(t)}
+
+	timer := newFakeTimer()
+	done := make(chan struct{})
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go func() {
+		defer close(done)
+		s.runBackupLoop(ctx, cfg, schedule{newTimer: timer.new, now: time.Now})
+	}()
+
+	// The loop reaching its first wait means the startup snapshot has already
+	// been taken.
+	require.Equal(t, 6*time.Hour, timer.armedFor(t))
+	require.Len(t, publishedSnapshots(t, dir), 1,
+		"a snapshot is taken at startup, not an interval later")
+
+	// Each subsequent interval takes another, and the next wait is armed only
+	// once that one is on disk.
+	//
+	// The store gains an object first, so what proves the second pass ran is
+	// the published snapshot's contents rather than a file count: snapshot
+	// names carry a one-second timestamp, and two passes inside the same second
+	// -- which is what driving the schedule by hand produces -- land on the
+	// same name.
+	writeObject(t, s, "/data/b.txt", []byte("beta"))
+	timer.fire(t)
+	require.Equal(t, 6*time.Hour, timer.armedFor(t))
+
+	published := publishedSnapshots(t, dir)
+	require.NotEmpty(t, published)
+	f, err := os.Open(filepath.Join(dir, published[len(published)-1]))
+	require.NoError(t, err)
+	defer f.Close()
+
+	target := newTestStore(t)
+	require.NoError(t, target.Restore(f, cfg.Keys))
+	names, err := listNames(target, "/data")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a.txt", "b.txt"}, names,
+		"the snapshot published on the interval covers what the store held at that point")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(testScheduleTimeout):
+		t.Fatal("the backup loop did not return when its context was cancelled")
+	}
+}
+
+// publishedSnapshots lists the complete snapshots in a backup directory,
+// ignoring the .partial files a pass in flight may have left.
+func publishedSnapshots(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	var names []string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), metadataBackupPrefix) && strings.HasSuffix(e.Name(), ".pmb") {
+			names = append(names, e.Name())
+		}
+	}
+	return names
+}

--- a/pstore/capacity.go
+++ b/pstore/capacity.go
@@ -1,0 +1,522 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Capacity accounting.
+//
+// A pstore has a fixed size and never evicts: once full, writes fail with
+// ErrNoSpace (which the WebDAV layer maps to 507) until something is deleted.
+//
+// Enforcement is a reservation taken *before* bytes are written, because the
+// block store charges usage only once a file has been created and
+// pre-allocated — by which point it is too late to refuse.  Reservations live
+// in memory rather than the catalog: a store owns its directories exclusively
+// for its lifetime, so an in-process counter is exact, and it costs no writes
+// on the hot path.  Counters are seeded from the catalog's persisted usage at
+// startup, so a restart recovers the true figure.
+//
+// Note that this bounds total capacity only.  Path-based quotas are a separate
+// feature and are deliberately not implemented here; see
+// docs/pstore-design.md §7.2.
+
+package pstore
+
+import (
+	"math"
+	"path/filepath"
+	"sync"
+
+	"github.com/pkg/errors"
+
+	"github.com/pelicanplatform/pelican/local_cache"
+	"github.com/pelicanplatform/pelican/metrics"
+)
+
+// parentDir maps a storage manager's "objects" subdirectory back to the
+// directory that was configured.
+//
+// This is a filesystem path, so it uses filepath rather than the path package
+// the namespace index uses.  Getting that wrong is silent on Linux and broken
+// on Windows, where path.Dir on "C:\\store\\objects" finds no separator,
+// returns ".", and every configured size limit fails to match -- leaving the
+// store unbounded.
+func parentDir(p string) string {
+	return filepath.Dir(p)
+}
+
+// dirCapacity tracks one storage directory's committed and reserved bytes.
+type dirCapacity struct {
+	// maxBytes is the hard ceiling; zero means unbounded.
+	maxBytes int64
+	// used is bytes already charged in the catalog plus bytes reserved by
+	// writes currently in flight.
+	used int64
+}
+
+// capacityTracker enforces the store's size bound.
+//
+// Enforcement has two halves, and a write has to clear both.  The aggregate
+// must have room for the whole object.  And the largest single unit the block
+// store will place -- one chunk for a streamed object, the entire file for
+// anything smaller -- must fit in some individual directory, because a unit
+// lands whole or not at all.  A store spanning a nearly-full small disk and a
+// large one has aggregate headroom long after the small disk can take another
+// chunk, so checking only the total would accept writes that then fail on the
+// filesystem.
+//
+// Placement is not opaque to this tracker: Store.Open hands chooseDir to the
+// block store through SetChooseDir, and the middle write tier asks for a
+// directory directly, so the same headroom figures that refuse a write also
+// decide where its bytes go.
+//
+// Two details make the arithmetic honest.  A streamed object reserves its
+// chunk-rounded footprint rather than its content length, because AppendWriter
+// pre-allocates and charges whole chunks and the difference is refunded at
+// settle.  And reservations still in flight participate in the per-directory
+// test, since a directory's committed figure only catches up when a write
+// settles -- without that, concurrent writers each measure the same free space
+// and collectively overrun it.
+type capacityTracker struct {
+	mu   sync.Mutex
+	dirs map[local_cache.StorageID]*dirCapacity
+
+	// total is committed-plus-reserved bytes across every directory.
+	total int64
+	// maxTotal is the aggregate ceiling; zero means unbounded.  It is the sum
+	// of the configured per-directory limits, and is unbounded if any
+	// directory is unbounded.
+	maxTotal int64
+	// reserved is bytes claimed by writes in flight, included in total.
+	reserved int64
+}
+
+// newCapacityTracker seeds per-directory counters from persisted usage.
+func newCapacityTracker(
+	db *local_cache.CacheDB,
+	storage *local_cache.StorageManager,
+	cfgDirs []local_cache.StorageDirConfig,
+) (*capacityTracker, error) {
+	mounted := storage.GetDirs()
+
+	// Storage IDs are assigned by NewStorageManager in the order directories
+	// were configured, so match limits back by path.
+	//
+	// Both sides are cleaned before they meet.  GetDirs reports
+	// filepath.Join(configured, "objects"), which is already clean, so a
+	// configured path carrying a trailing separator ("/srv/pstore/") would
+	// never match the cleaned form parentDir yields -- and a limit that
+	// matches nothing silently leaves the directory unbounded, disabling
+	// every ENOSPC and 507 path the operator asked for.
+	limitByPath := make(map[string]uint64, len(cfgDirs))
+	for _, d := range cfgDirs {
+		limitByPath[filepath.Clean(d.Path)] = d.MaxSize
+	}
+
+	ct := &capacityTracker{dirs: make(map[local_cache.StorageID]*dirCapacity, len(mounted)+1)}
+
+	// Inline objects live in the catalog rather than a storage directory, but
+	// they still occupy disk and are charged to StorageIDInline.  Tracking
+	// that pseudo-directory is what keeps a store from being filled without
+	// limit by objects that are each below the inline threshold.  It carries
+	// no ceiling of its own; it contributes to the aggregate.
+	inlineUsed, err := usageForDir(db, local_cache.StorageIDInline)
+	if err != nil {
+		return nil, err
+	}
+	ct.dirs[local_cache.StorageIDInline] = &dirCapacity{used: inlineUsed}
+	ct.total += inlineUsed
+
+	anyUnbounded := false
+	for id, objDir := range mounted {
+		used, err := usageForDir(db, id)
+		if err != nil {
+			return nil, err
+		}
+		dc := &dirCapacity{used: used}
+		// GetDirs reports the "objects" subdirectory; the configured path is
+		// its parent.
+		if limit, ok := limitByPath[filepath.Clean(parentDir(objDir))]; ok && limit > 0 {
+			dc.maxBytes = int64(limit)
+		} else {
+			anyUnbounded = true
+		}
+		ct.dirs[id] = dc
+		ct.total += used
+		ct.maxTotal += dc.maxBytes
+	}
+	// A single unbounded directory means the store as a whole is unbounded;
+	// summing the rest would invent a ceiling that does not exist.
+	if anyUnbounded {
+		ct.maxTotal = 0
+	}
+	return ct, nil
+}
+
+// usageForDir sums the catalog's per-namespace usage counters for one
+// storage directory.
+func usageForDir(db *local_cache.CacheDB, id local_cache.StorageID) (int64, error) {
+	perNamespace, err := db.GetDirUsage(id)
+	if err != nil {
+		return 0, errors.Wrapf(err, "failed to read usage for storage directory %d", id)
+	}
+	var total int64
+	for _, v := range perNamespace {
+		total += v
+	}
+	return total, nil
+}
+
+// reserve claims nBytes of store capacity, returning ErrNoSpace when it will
+// not fit.  Every successful reservation must be matched by exactly one
+// releaseReservation or settle.
+//
+// Two conditions have to hold, and checking only the first is not enough.  The
+// aggregate must have room, obviously.  But the block store places each chunk
+// in a single directory, so some directory must also have room for the largest
+// unit that will be placed there -- otherwise a write can pass an aggregate
+// check with plenty of total headroom and then fail against a directory that
+// is individually full.  unit is that placement granularity: one chunk for a
+// streamed object, the whole footprint for anything smaller.
+//
+// held is what the caller has already reserved for this same write.  It is
+// excluded from the per-directory test because the aggregate test above
+// already counts it; leaving it in would make a growing streamed write
+// increasingly refuse to extend itself.  Every *other* writer's in-flight
+// reservation does count, which is what stops N concurrent writers from each
+// seeing the same free space and collectively overrunning the ceiling.
+func (ct *capacityTracker) reserve(nBytes, unit, held int64) error {
+	if nBytes <= 0 {
+		return nil
+	}
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+
+	if err := ct.roomForLocked(nBytes, unit, held); err != nil {
+		return err
+	}
+
+	ct.total += nBytes
+	ct.reserved += nBytes
+	return nil
+}
+
+// checkRoom reports whether a reservation of nBytes with the given placement
+// unit would currently be accepted, without claiming anything.
+func (ct *capacityTracker) checkRoom(nBytes, unit int64) error {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	return ct.roomForLocked(nBytes, unit, 0)
+}
+
+// roomForLocked is the shared ErrNoSpace test behind reserve and checkRoom.
+func (ct *capacityTracker) roomForLocked(nBytes, unit, held int64) error {
+	if ct.maxTotal > 0 && ct.total+nBytes > ct.maxTotal {
+		return errors.Wrapf(ErrNoSpace,
+			"the store is full (%d of %d bytes used, %d requested)",
+			ct.total, ct.maxTotal, nBytes)
+	}
+	if unit > 0 && !ct.anyDirHasRoomLocked(unit, held) {
+		return errors.Wrapf(ErrNoSpace,
+			"no storage directory has room for %d bytes, though the store as a "+
+				"whole is under its limit", unit)
+	}
+	return nil
+}
+
+// anyDirHasRoomLocked reports whether some bounded directory can still take
+// nBytes.  An unbounded directory always can.
+//
+// A directory's committed figure lags reality while writes are in flight: the
+// block store charges the catalog as it pre-allocates, but this tracker learns
+// the real placement only at settle.  Counting the other writers' outstanding
+// reservations against every candidate directory closes that gap -- it is
+// pessimistic when the store spans several directories, which is the correct
+// direction to be wrong in for a check whose job is to refuse writes that
+// would not fit.
+func (ct *capacityTracker) anyDirHasRoomLocked(nBytes, held int64) bool {
+	inFlight := clampNonNegative(ct.reserved - held)
+	for id, dc := range ct.dirs {
+		if id == local_cache.StorageIDInline {
+			continue
+		}
+		if dc.maxBytes <= 0 || dc.used+inFlight+nBytes <= dc.maxBytes {
+			return true
+		}
+	}
+	return false
+}
+
+// chooseDir picks the storage directory for the next chunk.
+//
+// It replaces the block store's default round-robin, which ignores how full
+// each directory is: with directories of different sizes that walks straight
+// into a full one. Preference goes to the directory with the most absolute
+// headroom, so a store spanning a small disk and a large one fills the large
+// one first rather than alternating until the small one overflows.
+//
+// Unbounded directories are treated as having unlimited headroom. When every
+// directory is over its limit the least-full one is returned: refusing here
+// would mean returning an invalid StorageID, and the reservation path has
+// already declined the write.
+func (ct *capacityTracker) chooseDir() local_cache.StorageID {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+
+	var (
+		best      local_cache.StorageID
+		bestRoom  int64
+		bestFound bool
+	)
+	for id, dc := range ct.dirs {
+		if id == local_cache.StorageIDInline {
+			continue
+		}
+		room := int64(math.MaxInt64)
+		if dc.maxBytes > 0 {
+			room = dc.maxBytes - dc.used
+		}
+		if !bestFound || room > bestRoom {
+			best, bestRoom, bestFound = id, room, true
+		}
+	}
+	return best
+}
+
+// releaseReservation returns capacity claimed by a write that never landed.
+func (ct *capacityTracker) releaseReservation(nBytes int64) {
+	if nBytes <= 0 {
+		return
+	}
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+
+	ct.reserved = clampNonNegative(ct.reserved - nBytes)
+	ct.total = clampNonNegative(ct.total - nBytes)
+}
+
+// settle converts a reservation into committed bytes once a write has landed
+// and its real footprint is known, attributing them to the directories the
+// block store actually chose.
+func (ct *capacityTracker) settle(reserved int64, actual map[local_cache.StorageID]int64) {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+
+	// Drop the estimate, then add what the object really occupies.
+	ct.reserved = clampNonNegative(ct.reserved - reserved)
+	ct.total = clampNonNegative(ct.total - reserved)
+
+	for id, n := range actual {
+		if dc, ok := ct.dirs[id]; ok {
+			dc.used += n
+		}
+		ct.total += n
+	}
+}
+
+// release accounts for bytes freed by a delete.
+func (ct *capacityTracker) release(id local_cache.StorageID, nBytes int64) {
+	if nBytes <= 0 {
+		return
+	}
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+
+	if dc, ok := ct.dirs[id]; ok {
+		dc.used = clampNonNegative(dc.used - nBytes)
+	}
+	ct.total = clampNonNegative(ct.total - nBytes)
+}
+
+// usageOf reports committed-plus-reserved bytes and the ceiling for one
+// directory.  A ceiling of zero means unbounded.
+func (ct *capacityTracker) usageOf(id local_cache.StorageID) (used, max int64) {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+
+	if dc, ok := ct.dirs[id]; ok {
+		return dc.used, dc.maxBytes
+	}
+	return 0, 0
+}
+
+// aggregateUsage reports store-wide committed-plus-reserved bytes and the
+// aggregate ceiling.  A ceiling of zero means unbounded.
+func (ct *capacityTracker) aggregateUsage() (used, max int64) {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	return ct.total, ct.maxTotal
+}
+
+func clampNonNegative(v int64) int64 {
+	if v < 0 {
+		return 0
+	}
+	return v
+}
+
+// resync replaces a directory's counter with the catalog's persisted figure.
+//
+// Reservations survive: the aggregate is adjusted by the delta rather than
+// recomputed, so only the committed half of the figure is replaced.  That is
+// what makes it safe to call while writes are in flight -- which the janitor
+// does after the block store reclaims an abandoned streaming write, since that
+// path refunds the catalog directly and does not say which directories it
+// touched.
+func (ct *capacityTracker) resync(db *local_cache.CacheDB, id local_cache.StorageID) error {
+	used, err := usageForDir(db, id)
+	if err != nil {
+		return err
+	}
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+
+	if dc, ok := ct.dirs[id]; ok {
+		ct.total = clampNonNegative(ct.total - dc.used + used)
+		dc.used = used
+	}
+	return nil
+}
+
+// storageIDs returns the tracked directories.
+func (ct *capacityTracker) storageIDs() []local_cache.StorageID {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+
+	ids := make([]local_cache.StorageID, 0, len(ct.dirs))
+	for id := range ct.dirs {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
+
+// dirUsage is one directory's line in a capacity snapshot.
+type dirUsage struct {
+	id   local_cache.StorageID
+	used int64
+	max  int64
+}
+
+// snapshot reads the whole tracker under one lock.
+//
+// Publishing the gauges by calling aggregateUsage and then usageOf per
+// directory would take and release the mutex once per series, and would report
+// figures from different instants as though they were one measurement -- the
+// aggregate not matching the sum of its parts is exactly the kind of thing an
+// operator loses an afternoon to.  One acquisition of a mutex that is otherwise
+// held for nanoseconds at a time is not a contention concern; this runs at
+// open and once per janitor sweep, never on a serving path.
+func (ct *capacityTracker) snapshot() (used, max int64, dirs []dirUsage) {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+
+	dirs = make([]dirUsage, 0, len(ct.dirs))
+	for id, dc := range ct.dirs {
+		dirs = append(dirs, dirUsage{id: id, used: dc.used, max: dc.maxBytes})
+	}
+	return ct.total, ct.maxTotal, dirs
+}
+
+// storageDirLabels maps each storage ID onto the label the capacity gauges
+// report it under: the directory as it was configured, which is what an
+// operator recognizes, rather than the "objects" subdirectory the block store
+// works in or an opaque numeric ID.
+//
+// The inline pseudo-directory gets a name that is deliberately not a path.
+// Inline objects live in the catalog, which sits in BaseDir and may therefore
+// be one of the real directories; labeling them with that path would add two
+// unrelated quantities together in one series.
+func storageDirLabels(storage *local_cache.StorageManager) map[local_cache.StorageID]string {
+	mounted := storage.GetDirs()
+	labels := make(map[local_cache.StorageID]string, len(mounted)+1)
+	for id, objDir := range mounted {
+		labels[id] = parentDir(objDir)
+	}
+	labels[local_cache.StorageIDInline] = metrics.PStoreDirectoryInline
+	return labels
+}
+
+// publishCapacityMetrics republishes the capacity gauges from the tracker's
+// in-memory figures.
+//
+// Those figures are seeded from the catalog when the store opens, so calling
+// this at open is what makes the gauges describe a restarted origin correctly
+// instead of reading zero until the first write.  Afterwards the janitor
+// refreshes them: the write path deliberately does not, because settling a
+// write already holds the capacity lock and a store under load would then be
+// updating four gauges per object to publish a level that is scraped once a
+// minute.
+func (s *Store) publishCapacityMetrics() {
+	used, max, dirs := s.capacity.snapshot()
+	metrics.PStoreUsedBytes.Set(float64(used))
+	metrics.PStoreLimitBytes.Set(float64(max))
+
+	for _, d := range dirs {
+		label, ok := s.dirLabels[d.id]
+		if !ok {
+			// A directory the tracker knows and the label map does not cannot
+			// happen -- both are built from the same storage manager at open
+			// -- but reporting it under a made-up name would be worse than
+			// omitting it.
+			continue
+		}
+		metrics.PStoreDirectoryUsedBytes.WithLabelValues(label).Set(float64(d.used))
+		metrics.PStoreDirectoryLimitBytes.WithLabelValues(label).Set(float64(d.max))
+	}
+}
+
+// HasCapacityFor reports whether a write of contentLen content bytes could
+// currently be accepted.
+//
+// It models exactly what the write path will reserve -- the per-block overhead,
+// the chunk rounding a streamed object pays, and the per-directory placement
+// unit -- via plannedFootprint.  Answering a different question here than the
+// write path asks would be worse than not checking at all: the origin would
+// accept a PUT it is about to fail with a 507 halfway through the body, or
+// refuse one that would have fit.
+//
+// It remains advisory in one respect: a concurrent write may consume the
+// headroom before this caller reserves it, so the write path enforces the
+// limit independently.  Its purpose is to let the origin refuse a PUT before
+// the client streams a body that cannot land.
+func (s *Store) HasCapacityFor(contentLen int64) error {
+	if contentLen <= 0 {
+		return nil
+	}
+	if _, max := s.capacity.aggregateUsage(); max <= 0 {
+		return nil
+	}
+	need, unit := s.plannedFootprint(contentLen)
+	err := s.capacity.checkRoom(need, unit)
+	if errors.Is(err, ErrNoSpace) {
+		// Counted here rather than inside the tracker so the increment stays
+		// outside the capacity lock.  There is no double count with the
+		// increment in ensureReserved: a request refused here never reaches
+		// the write path at all.
+		metrics.PStoreWriteFailuresTotal.WithLabelValues(metrics.PStoreWriteFailureNoSpace).Inc()
+	}
+	return err
+}
+
+// Usage reports the store's committed-plus-reserved bytes and its ceiling.
+// A ceiling of zero means the store is unbounded.
+func (s *Store) Usage() (used, max int64) {
+	return s.capacity.aggregateUsage()
+}

--- a/pstore/capacity_test.go
+++ b/pstore/capacity_test.go
@@ -1,0 +1,644 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package pstore
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/local_cache"
+)
+
+// newBoundedStore opens a store whose single directory has a hard ceiling.
+func newBoundedStore(t *testing.T, maxBytes uint64) *Store {
+	t.Helper()
+	local_cache.InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	egrp, _ := errgroup.WithContext(ctx)
+
+	dir := t.TempDir()
+	s, err := Open(ctx, egrp, Config{
+		BaseDir:     dir,
+		StorageDirs: []local_cache.StorageDirConfig{{Path: dir, MaxSize: maxBytes}},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, s.Close()) })
+	return s
+}
+
+func TestCapacityCeilingFromConfig(t *testing.T) {
+	const limit = 1 << 20
+	s := newBoundedStore(t, limit)
+
+	used, max := s.Usage()
+	assert.Equal(t, int64(limit), max, "the configured MaxSize becomes the ceiling")
+	assert.Zero(t, used, "a fresh store uses nothing")
+}
+
+// TestUnboundedWhenAnyDirIsUnbounded documents the deliberate choice: summing
+// the bounded directories would invent a ceiling the operator never set.
+func TestUnboundedWhenAnyDirIsUnbounded(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	egrp, _ := errgroup.WithContext(ctx)
+
+	bounded, unbounded := t.TempDir(), t.TempDir()
+	s, err := Open(ctx, egrp, Config{
+		BaseDir: t.TempDir(),
+		StorageDirs: []local_cache.StorageDirConfig{
+			{Path: bounded, MaxSize: 1 << 20},
+			{Path: unbounded},
+		},
+	})
+	require.NoError(t, err)
+	defer s.Close()
+
+	_, max := s.Usage()
+	assert.Zero(t, max, "one unbounded directory makes the store unbounded")
+}
+
+// TestWriteBeyondCapacityFailsWithENOSPC is the core enforcement test.  The
+// error must be ENOSPC specifically, because that is what the origin maps to
+// 507.
+func TestWriteBeyondCapacityFailsWithENOSPC(t *testing.T) {
+	const limit = 512 << 10
+	s := newBoundedStore(t, limit)
+
+	w, err := s.Create("/toobig")
+	require.NoError(t, err)
+
+	// Write past the ceiling in increments; the reservation should refuse
+	// before the bytes land.
+	var writeErr error
+	payload := randomBytes(64<<10, 3)
+	for range 20 {
+		if _, writeErr = w.Write(payload); writeErr != nil {
+			break
+		}
+	}
+	require.Error(t, writeErr, "a write past the ceiling must fail")
+	assert.ErrorIs(t, writeErr, ErrNoSpace)
+	assert.ErrorIs(t, writeErr, syscall.ENOSPC, "callers match on ENOSPC to produce a 507")
+
+	require.NoError(t, w.Abort())
+
+	_, err = s.Stat("/toobig")
+	assert.ErrorIs(t, err, ErrNotExist, "the refused object never appears")
+}
+
+// TestCapacityReleasedOnDelete confirms space comes back, so a full store
+// recovers once an operator deletes something -- the only way it can, since
+// there is no eviction.
+func TestCapacityReleasedOnDelete(t *testing.T) {
+	const limit = 1 << 20
+	s := newBoundedStore(t, limit)
+
+	content := randomBytes(256<<10, 4)
+	writeObject(t, s, "/first", content)
+
+	usedAfterWrite, _ := s.Usage()
+	assert.Greater(t, usedAfterWrite, int64(0), "a stored object consumes capacity")
+
+	require.NoError(t, s.Remove("/first"))
+	_, err := s.RunGC(t.Context())
+	require.NoError(t, err)
+
+	usedAfterDelete, _ := s.Usage()
+	assert.Less(t, usedAfterDelete, usedAfterWrite, "reclaiming the object frees capacity")
+}
+
+func TestHasCapacityFor(t *testing.T) {
+	const limit = 256 << 10
+	s := newBoundedStore(t, limit)
+
+	assert.NoError(t, s.HasCapacityFor(1024), "a small write fits")
+	assert.NoError(t, s.HasCapacityFor(0), "an empty write always fits")
+
+	err := s.HasCapacityFor(limit * 2)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoSpace)
+
+	// Accounts for the per-block overhead, so a write of exactly the ceiling
+	// does not fit.
+	assert.Error(t, s.HasCapacityFor(limit), "the on-disk footprint exceeds the content length")
+}
+
+func TestHasCapacityForUnboundedStore(t *testing.T) {
+	s := newTestStore(t)
+	assert.NoError(t, s.HasCapacityFor(1<<40), "an unbounded store accepts anything")
+}
+
+// TestCapacitySurvivesReopen checks the counters are rebuilt from the catalog
+// rather than starting at zero, which would let a restart overfill the store.
+func TestCapacitySurvivesReopen(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	egrp, _ := errgroup.WithContext(ctx)
+
+	dir := t.TempDir()
+	cfg := Config{
+		BaseDir:     dir,
+		StorageDirs: []local_cache.StorageDirConfig{{Path: dir, MaxSize: 1 << 20}},
+	}
+
+	s, err := Open(ctx, egrp, cfg)
+	require.NoError(t, err)
+	writeObject(t, s, "/persisted", randomBytes(128<<10, 8))
+	usedBefore, _ := s.Usage()
+	require.NoError(t, s.Close())
+	require.Greater(t, usedBefore, int64(0))
+
+	s2, err := Open(ctx, egrp, cfg)
+	require.NoError(t, err)
+	defer s2.Close()
+
+	usedAfter, max := s2.Usage()
+	assert.Equal(t, int64(1<<20), max)
+	assert.Equal(t, usedBefore, usedAfter, "usage is recovered from the catalog on reopen")
+}
+
+// TestInlineObjectsCountTowardCapacity guards a gap that would let a store be
+// filled without limit: objects at or below the inline threshold live in the
+// catalog rather than a storage directory, and if that pseudo-directory is not
+// tracked, millions of small objects never trigger ENOSPC.
+func TestInlineObjectsCountTowardCapacity(t *testing.T) {
+	s := newBoundedStore(t, 1<<20)
+
+	before, _ := s.Usage()
+	require.Zero(t, before)
+
+	// Comfortably below InlineThreshold, so this never touches a block file.
+	writeObject(t, s, "/tiny", []byte("small enough to live in the catalog"))
+
+	after, _ := s.Usage()
+	assert.Greater(t, after, before, "an inline object consumes tracked capacity")
+}
+
+// TestInlineUsageSurvivesReopen confirms the inline figure is seeded from the
+// catalog too, not just accumulated in memory.
+func TestInlineUsageSurvivesReopen(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	egrp, _ := errgroup.WithContext(ctx)
+
+	dir := t.TempDir()
+	cfg := Config{
+		BaseDir:     dir,
+		StorageDirs: []local_cache.StorageDirConfig{{Path: dir, MaxSize: 1 << 20}},
+	}
+
+	s, err := Open(ctx, egrp, cfg)
+	require.NoError(t, err)
+	writeObject(t, s, "/tiny", []byte("inline payload"))
+	usedBefore, _ := s.Usage()
+	require.NoError(t, s.Close())
+	require.Greater(t, usedBefore, int64(0))
+
+	s2, err := Open(ctx, egrp, cfg)
+	require.NoError(t, err)
+	defer s2.Close()
+
+	usedAfter, _ := s2.Usage()
+	assert.Equal(t, usedBefore, usedAfter, "inline usage is recovered on reopen")
+}
+
+// newMultiDirStore opens a store spanning two directories with independent
+// ceilings.
+func newMultiDirStore(t *testing.T, sizes ...uint64) *Store {
+	t.Helper()
+	local_cache.InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	egrp, _ := errgroup.WithContext(ctx)
+
+	dirs := make([]local_cache.StorageDirConfig, len(sizes))
+	for i, sz := range sizes {
+		dirs[i] = local_cache.StorageDirConfig{Path: t.TempDir(), MaxSize: sz}
+	}
+	s, err := Open(ctx, egrp, Config{BaseDir: t.TempDir(), StorageDirs: dirs})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, s.Close()) })
+	return s
+}
+
+// blockDirIDs returns the real storage directories, dropping the inline
+// pseudo-directory, which holds no block files and is never a placement
+// target.
+func blockDirIDs(s *Store) []local_cache.StorageID {
+	var ids []local_cache.StorageID
+	for _, id := range s.capacity.storageIDs() {
+		if id != local_cache.StorageIDInline {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// TestChooseDirPrefersTheDirectoryWithRoom is the placement half of the
+// multi-directory problem.  The block store's default chooser is round-robin,
+// which ignores how full each directory is; with a small directory and a large
+// one it alternates until the small one overflows.
+func TestChooseDirPrefersTheDirectoryWithRoom(t *testing.T) {
+	s := newMultiDirStore(t, 1<<20, 64<<20)
+
+	dirIDs := blockDirIDs(s)
+	require.Len(t, dirIDs, 2)
+
+	// Name the directories by the ceiling they were configured with rather
+	// than by assuming an ID ordering, so the assertions below are about
+	// headroom and nothing else.
+	var small, large local_cache.StorageID
+	for _, id := range dirIDs {
+		if _, max := s.capacity.usageOf(id); max == 1<<20 {
+			small = id
+		} else {
+			large = id
+		}
+	}
+	require.NotZero(t, small)
+	require.NotZero(t, large)
+
+	assert.Equal(t, large, s.capacity.chooseDir(),
+		"the directory with more headroom is chosen")
+
+	// Charge the large directory until the small one has more headroom; the
+	// preference must follow, which is exactly what round-robin does not do.
+	s.capacity.settle(0, map[local_cache.StorageID]int64{large: (64 << 20) - (512 << 10)})
+	assert.Equal(t, small, s.capacity.chooseDir(),
+		"a directory that is now the fuller one stops being preferred")
+
+	// And once the small one is fuller still, preference goes back.
+	s.capacity.settle(0, map[local_cache.StorageID]int64{small: (1 << 20) - (128 << 10)})
+	assert.Equal(t, large, s.capacity.chooseDir(),
+		"selection tracks headroom in both directions")
+}
+
+// BenchmarkChooseDir measures the per-call cost of the placement chooser,
+// which the block store consults once per chunk allocation.
+//
+// It exists to answer whether the linear scan should be replaced by a
+// probabilistic selection over periodically refreshed weights.  The tracker is
+// built directly rather than through Open: chooseDir touches nothing but its
+// own map -- no syscall, no statfs, no catalog read -- so a real store would
+// add setup cost without changing what is being measured.
+//
+// The realistic sizes are the first two.  A storage directory is a disk an
+// operator mounted and listed in the configuration; 2 to 8 is the shape of
+// every deployment.  The 64- and 256-directory cases are there to show the
+// slope, not because anyone runs them.
+func BenchmarkChooseDir(b *testing.B) {
+	for _, n := range []int{2, 8, 64, 256} {
+		b.Run(strconv.Itoa(n)+"dirs", func(b *testing.B) {
+			ct := &capacityTracker{dirs: make(map[local_cache.StorageID]*dirCapacity, n+1)}
+			ct.dirs[local_cache.StorageIDInline] = &dirCapacity{}
+			for i := range n {
+				id := local_cache.StorageIDFirstDisk + local_cache.StorageID(i)
+				// Staggered fill levels, so the winner is not the first
+				// candidate examined and the comparison actually runs.
+				ct.dirs[id] = &dirCapacity{
+					maxBytes: 1 << 40,
+					used:     int64(i) * (1 << 30),
+				}
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				sinkStorageID = ct.chooseDir()
+			}
+		})
+	}
+}
+
+// sinkStorageID keeps the benchmark's result live so the call is not elided.
+var sinkStorageID local_cache.StorageID
+
+// TestWritesRespectPerDirectoryCeilings is the same property observed through
+// the public API rather than by poking the chooser.  Every write tier has to
+// route through the capacity tracker: the streaming tier goes through the
+// block store's chooseDir hook, but the middle (buffered, exact-length) tier
+// allocates its file itself, so a hardcoded first directory there would fill
+// past its MaxSize while the other sat empty.
+func TestWritesRespectPerDirectoryCeilings(t *testing.T) {
+	const perDir = 8 << 20
+	s := newMultiDirStore(t, perDir, perDir)
+
+	// Inline: charged to the catalog's pseudo-directory.
+	for i := range 10 {
+		writeObject(t, s, "/inline"+strconv.Itoa(i), randomBytes(1<<10, int64(i)))
+	}
+	// Buffered exact-length: 24 x 400 KiB is 9.6 MiB, more than either
+	// directory can hold on its own.
+	for i := range 24 {
+		writeObject(t, s, "/mid"+strconv.Itoa(i), randomBytes(400<<10, int64(100+i)))
+	}
+	// Streamed: past the spill threshold, so the chunk allocator places it.
+	w, err := s.CreateSized("/streamed", 1536<<10)
+	require.NoError(t, err)
+	_, err = w.Write(randomBytes(1536<<10, 7))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	for _, id := range blockDirIDs(s) {
+		used, err := usageForDir(s.db, id)
+		require.NoError(t, err)
+		_, max := s.capacity.usageOf(id)
+		require.Equal(t, int64(perDir), max)
+		assert.LessOrEqual(t, used, max,
+			"storage directory %d exceeded its configured MaxSize", id)
+	}
+
+	// The data still reads back, so the spreading did not lose anything.
+	got, err := s.ReadAll("/mid0")
+	require.NoError(t, err)
+	assert.Equal(t, randomBytes(400<<10, 100), got)
+}
+
+// TestReserveRequiresADirectoryWithRoom covers the accounting half.  A write
+// can pass an aggregate check while no single directory can actually hold the
+// chunk it is about to place, which is how a store with total headroom still
+// fails a write.
+func TestReserveRequiresADirectoryWithRoom(t *testing.T) {
+	s := newMultiDirStore(t, 4<<20, 4<<20)
+
+	used, max := s.Usage()
+	require.Equal(t, int64(8<<20), max, "the aggregate is the sum of both")
+	require.Zero(t, used)
+
+	// Fill both directories to just under their individual ceilings, leaving
+	// the aggregate with room but neither directory able to take a big chunk.
+	for _, id := range s.capacity.storageIDs() {
+		if id == local_cache.StorageIDInline {
+			continue
+		}
+		_, dirMax := s.capacity.usageOf(id)
+		s.capacity.settle(0, map[local_cache.StorageID]int64{id: dirMax - (256 << 10)})
+	}
+
+	usedNow, maxNow := s.Usage()
+	require.Less(t, usedNow, maxNow, "the store still has aggregate headroom")
+
+	// A unit larger than any single directory's remaining room must be
+	// refused even though the aggregate would accept it.
+	err := s.capacity.reserve(512<<10, 512<<10, 0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoSpace)
+
+	// A unit that fits in a directory is still accepted.
+	assert.NoError(t, s.capacity.reserve(64<<10, 64<<10, 0))
+}
+
+// TestReserveIgnoresPerDirLimitsWhenUnbounded confirms an unbounded directory
+// keeps the store usable regardless of the others.
+func TestReserveIgnoresPerDirLimitsWhenUnbounded(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	egrp, _ := errgroup.WithContext(ctx)
+
+	s, err := Open(ctx, egrp, Config{
+		BaseDir: t.TempDir(),
+		StorageDirs: []local_cache.StorageDirConfig{
+			{Path: t.TempDir(), MaxSize: 1 << 10},
+			{Path: t.TempDir()},
+		},
+	})
+	require.NoError(t, err)
+	defer s.Close()
+
+	assert.NoError(t, s.capacity.reserve(1<<30, 1<<30, 0),
+		"an unbounded directory can absorb any single unit")
+}
+
+// TestParentDirUsesFilesystemSemantics guards a bug that is invisible on Linux
+// and breaks the store on Windows.
+//
+// parentDir maps a storage manager's "objects" subdirectory back to the
+// configured directory so its size limit can be found. That is a filesystem
+// path, not a namespace path: using the slash-only path package would find no
+// separator in "C:\store\objects", return ".", match no configured limit, and
+// leave every directory silently unbounded.
+func TestParentDirUsesFilesystemSemantics(t *testing.T) {
+	// The separator this platform actually uses must round-trip.
+	joined := filepath.Join("store", "objects")
+	assert.Equal(t, "store", parentDir(joined))
+
+	// And an absolute path keeps its root.
+	abs := filepath.Join(string(filepath.Separator)+"srv", "pstore", "objects")
+	assert.Equal(t, filepath.Join(string(filepath.Separator)+"srv", "pstore"), parentDir(abs))
+}
+
+// assertWithinCeilings checks the catalog's own usage counters -- not the
+// in-memory estimate -- against every configured ceiling.  The counters are
+// what the block store charges as it pre-allocates, so they are the figure a
+// full disk would actually correspond to.
+func assertWithinCeilings(t *testing.T, s *Store) {
+	t.Helper()
+
+	total, err := usageForDir(s.db, local_cache.StorageIDInline)
+	require.NoError(t, err)
+	for _, id := range blockDirIDs(s) {
+		used, uErr := usageForDir(s.db, id)
+		require.NoError(t, uErr)
+		total += used
+
+		if _, max := s.capacity.usageOf(id); max > 0 {
+			assert.LessOrEqual(t, used, max,
+				"storage directory %d holds %d bytes, past its %d-byte ceiling", id, used, max)
+		}
+	}
+	if _, max := s.Usage(); max > 0 {
+		assert.LessOrEqual(t, total, max,
+			"the store holds %d bytes, past its %d-byte ceiling", total, max)
+	}
+}
+
+// TestConcurrentWritesStayWithinTheCeiling is the case a single-writer test
+// cannot see.
+//
+// A streamed write pre-allocates and is charged a whole chunk the moment it
+// touches one, so the reservation has to be the chunk-rounded footprint rather
+// than the content length -- and the per-directory room test has to count the
+// reservations other writers already hold.  With neither in place every
+// concurrent writer passed the same check against the same apparently-free
+// space, and N writers charged N times what the ceiling allowed.  That is a
+// real out-of-space condition, not an accounting slip.
+func TestConcurrentWritesStayWithinTheCeiling(t *testing.T) {
+	const (
+		writers   = 16
+		objectLen = 2 << 20
+		limit     = 256 << 20
+	)
+	s := newBoundedStore(t, limit)
+
+	payload := randomBytes(objectLen, 77)
+
+	var (
+		ready    sync.WaitGroup
+		mu       sync.Mutex
+		refusals []error
+		grp      errgroup.Group
+	)
+	release := make(chan struct{})
+	ready.Add(writers)
+
+	for i := range writers {
+		grp.Go(func() error {
+			w, err := s.Create("/concurrent" + strconv.Itoa(i))
+			if err != nil {
+				ready.Done()
+				return err
+			}
+			_, wErr := w.Write(payload)
+			// Every writer reports in whether or not its bytes went down, so
+			// the sampling below happens with all of them genuinely in flight
+			// and none of them committed.  No timing involved.
+			ready.Done()
+			<-release
+
+			if wErr != nil {
+				mu.Lock()
+				refusals = append(refusals, wErr)
+				mu.Unlock()
+				return w.Abort()
+			}
+			return w.Close()
+		})
+	}
+
+	ready.Wait()
+	assertWithinCeilings(t, s)
+
+	close(release)
+	require.NoError(t, grp.Wait())
+	assertWithinCeilings(t, s)
+
+	for _, err := range refusals {
+		assert.ErrorIs(t, err, ErrNoSpace,
+			"the only failure a writer may see is an explicit refusal")
+	}
+	assert.Empty(t, refusals, "this store is comfortably large enough for every writer")
+
+	// And the objects are all really there.
+	for i := range writers {
+		d, err := s.Stat("/concurrent" + strconv.Itoa(i))
+		require.NoError(t, err)
+		assert.Equal(t, int64(objectLen), d.Size)
+	}
+}
+
+// TestSpilledObjectFitsInASmallBoundedStore guards the interaction between the
+// two write-path constants.  A streaming chunk fixed at 64 MiB while buffering
+// stopped at 1 MiB would make every object over a megabyte demand 64 MiB of
+// free space in a single directory: a bounded store smaller than that could
+// never accept one, and any store whose directories dropped below 64 MiB free
+// would refuse writes with tens of megabytes still available.
+func TestSpilledObjectFitsInASmallBoundedStore(t *testing.T) {
+	const limit = 16 << 20
+	s := newBoundedStore(t, limit)
+
+	content := randomBytes(2<<20, 21)
+	require.Greater(t, len(content), spillThreshold, "this object must reach the streaming tier")
+
+	// With a declared length the pre-flight check and the write have to agree;
+	// the origin turns a disagreement into either a spurious 507 or a PUT that
+	// fails halfway through the body.
+	require.NoError(t, s.HasCapacityFor(int64(len(content))))
+
+	w, err := s.CreateSized("/sized", int64(len(content)))
+	require.NoError(t, err)
+	_, err = w.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	got, err := s.ReadAll("/sized")
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+
+	// And without a declared length, which is what a chunked-encoding PUT
+	// looks like.
+	writeObject(t, s, "/unsized", content)
+	got, err = s.ReadAll("/unsized")
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+
+	assertWithinCeilings(t, s)
+}
+
+// TestTrailingSeparatorStillBoundsTheStore covers a configuration typo that
+// silently disabled every capacity limit.
+//
+// Per-directory ceilings are matched back to the block store's directories by
+// path.  The configured value was used raw while the block store reports the
+// cleaned form, so "Path: /srv/pstore/" matched nothing, the directory came up
+// unbounded, and one unbounded directory makes the whole store unbounded --
+// disabling ENOSPC, the 507 mapping, and everything downstream of them.
+func TestTrailingSeparatorStillBoundsTheStore(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	egrp, _ := errgroup.WithContext(ctx)
+
+	dir := t.TempDir()
+	s, err := Open(ctx, egrp, Config{
+		BaseDir: dir,
+		StorageDirs: []local_cache.StorageDirConfig{
+			{Path: dir + string(filepath.Separator), MaxSize: 1 << 20},
+		},
+	})
+	require.NoError(t, err)
+	defer s.Close()
+
+	_, max := s.Usage()
+	require.Equal(t, int64(1<<20), max,
+		"a trailing separator must not turn a bounded store into an unbounded one")
+
+	// The ceiling is not just reported, it is enforced.
+	w, err := s.Create("/toobig")
+	require.NoError(t, err)
+	var writeErr error
+	payload := randomBytes(64<<10, 3)
+	for range 40 {
+		if _, writeErr = w.Write(payload); writeErr != nil {
+			break
+		}
+	}
+	require.Error(t, writeErr, "the configured ceiling must actually refuse a write")
+	assert.ErrorIs(t, writeErr, ErrNoSpace)
+	require.NoError(t, w.Abort())
+}

--- a/pstore/checksum.go
+++ b/pstore/checksum.go
@@ -1,0 +1,133 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Checksums computed at ingest.
+//
+// A POSIX origin answers Want-Digest from checksums cached in xattrs, which
+// depends on filesystem xattr support and on something having computed them
+// earlier -- otherwise the whole object is re-read.
+//
+// pstore hashes the stream as it is written, which costs no extra I/O because
+// the bytes are already in hand, and stores the result on the object version's
+// metadata.  A Want-Digest HEAD is then a metadata read regardless of object
+// size.  Because the digests belong to the version rather than the path, an
+// overwrite cannot leave a stale checksum behind the way an mtime-validated
+// xattr cache can.
+//
+// Algorithm naming, value encoding, and hasher construction all come from
+// local_cache, which the cache's own Digest header and consistency checker
+// use as well.
+
+package pstore
+
+import (
+	"hash"
+
+	"github.com/pkg/errors"
+
+	"github.com/pelicanplatform/pelican/local_cache"
+)
+
+// ingestAlgorithms are the digests recorded for every object.
+//
+// The set is fixed rather than configurable: hashing is cheap next to the I/O
+// already happening, and computing one later would mean re-reading the object,
+// which is the cost this exists to avoid.
+var ingestAlgorithms = []local_cache.ChecksumType{
+	local_cache.ChecksumMD5,
+	local_cache.ChecksumSHA1,
+	local_cache.ChecksumCRC32C,
+}
+
+// ingestDigests hashes an object as it is written.
+type ingestDigests struct {
+	types  []local_cache.ChecksumType
+	hashes []hash.Hash
+}
+
+func newIngestDigests() (*ingestDigests, error) {
+	d := &ingestDigests{
+		types:  ingestAlgorithms,
+		hashes: make([]hash.Hash, 0, len(ingestAlgorithms)),
+	}
+	for _, t := range ingestAlgorithms {
+		h, err := local_cache.NewChecksumHasher(t)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to build an ingest hasher")
+		}
+		d.hashes = append(d.hashes, h)
+	}
+	return d, nil
+}
+
+// Write feeds bytes to every digest.  hash.Hash writes never fail.
+func (d *ingestDigests) Write(p []byte) {
+	if d == nil || len(p) == 0 {
+		return
+	}
+	for _, h := range d.hashes {
+		_, _ = h.Write(p)
+	}
+}
+
+// checksums renders the digests in the catalog's representation.
+//
+// They are marked OriginVerified because this origin computed them over the
+// bytes it stored, which is the strongest provenance available.
+func (d *ingestDigests) checksums() []local_cache.Checksum {
+	if d == nil {
+		return nil
+	}
+	out := make([]local_cache.Checksum, 0, len(d.hashes))
+	for i, h := range d.hashes {
+		out = append(out, local_cache.Checksum{
+			Type:           d.types[i],
+			Value:          h.Sum(nil),
+			OriginVerified: true,
+		})
+	}
+	return out
+}
+
+// Digests returns the checksums recorded for an object when it was written.
+//
+// An object written before checksums were recorded yields an empty slice
+// rather than an error, so callers can fall back rather than fail.
+func (s *Store) Digests(name string) ([]local_cache.Checksum, error) {
+	cleanPath, err := cleanRelative(name)
+	if err != nil {
+		return nil, err
+	}
+
+	d, err := s.Stat(cleanPath)
+	if err != nil {
+		return nil, err
+	}
+	if d.IsDir() {
+		return nil, ErrIsDir
+	}
+
+	meta, err := s.db.GetMetadata(instanceHashFor(s.db, d.Generation))
+	if err != nil {
+		return nil, err
+	}
+	if meta == nil {
+		return nil, ErrNotExist
+	}
+	return meta.Checksums, nil
+}

--- a/pstore/checksum_fsck_test.go
+++ b/pstore/checksum_fsck_test.go
@@ -1,0 +1,937 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package pstore
+
+import (
+	"context"
+	"crypto/md5"
+	"crypto/sha1"
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/local_cache"
+)
+
+// TestIngestChecksums verifies the digests recorded while writing match the
+// content, across all three write tiers.
+func TestIngestChecksums(t *testing.T) {
+	s := newTestStore(t)
+
+	cases := map[string]int{
+		"inline":   100,
+		"buffered": 1 << 20,
+		"streamed": spillThreshold + (1 << 20),
+	}
+	for name, size := range cases {
+		t.Run(name, func(t *testing.T) {
+			content := randomBytes(size, int64(size))
+			path := "/sum-" + name
+			writeObject(t, s, path, content)
+
+			got, err := s.Digests(path)
+			require.NoError(t, err)
+			byType := digestsByType(got)
+
+			wantMD5 := md5.Sum(content)
+			wantSHA1 := sha1.Sum(content)
+			wantCRC := crc32.Checksum(content, crc32.MakeTable(crc32.Castagnoli))
+
+			assert.Equal(t, wantMD5[:], byType[local_cache.ChecksumMD5].Value)
+			assert.Equal(t, wantSHA1[:], byType[local_cache.ChecksumSHA1].Value)
+			assert.Equal(t, wantCRC, binary.BigEndian.Uint32(byType[local_cache.ChecksumCRC32C].Value))
+		})
+	}
+}
+
+// TestChecksumsAreVersionScoped is the advantage over an mtime-validated xattr
+// cache: digests belong to the version, so an overwrite cannot leave a stale
+// value behind even within the same clock tick.
+func TestChecksumsAreVersionScoped(t *testing.T) {
+	s := newTestStore(t)
+
+	writeObject(t, s, "/obj", []byte("first"))
+	first, err := s.Digests("/obj")
+	require.NoError(t, err)
+
+	writeObject(t, s, "/obj", []byte("second"))
+	second, err := s.Digests("/obj")
+	require.NoError(t, err)
+
+	firstMD5 := digestsByType(first)[local_cache.ChecksumMD5].Value
+	secondMD5 := digestsByType(second)[local_cache.ChecksumMD5].Value
+	assert.NotEqual(t, firstMD5, secondMD5)
+
+	wantMD5 := md5.Sum([]byte("second"))
+	assert.Equal(t, wantMD5[:], secondMD5)
+}
+
+func TestDigestsErrors(t *testing.T) {
+	s := newTestStore(t)
+
+	_, err := s.Digests("/missing")
+	assert.ErrorIs(t, err, ErrNotExist)
+
+	require.NoError(t, s.Mkdir("/d"))
+	_, err = s.Digests("/d")
+	assert.ErrorIs(t, err, ErrIsDir)
+}
+
+func TestParseChecksumAlgorithm(t *testing.T) {
+	for in, want := range map[string]local_cache.ChecksumType{
+		"md5": local_cache.ChecksumMD5, "MD5": local_cache.ChecksumMD5,
+		"sha": local_cache.ChecksumSHA1, "sha-1": local_cache.ChecksumSHA1,
+		"SHA1":   local_cache.ChecksumSHA1,
+		"crc32c": local_cache.ChecksumCRC32C, " crc32c ": local_cache.ChecksumCRC32C,
+		"sha-256": local_cache.ChecksumSHA256,
+	} {
+		got, ok := local_cache.ParseChecksumAlgorithm(in)
+		assert.True(t, ok, "parsing %q", in)
+		assert.Equal(t, want, got, "parsing %q", in)
+	}
+	_, ok := local_cache.ParseChecksumAlgorithm("nonsense")
+	assert.False(t, ok)
+}
+
+// digestsByType indexes a checksum slice for assertions.
+func digestsByType(cs []local_cache.Checksum) map[local_cache.ChecksumType]local_cache.Checksum {
+	out := make(map[local_cache.ChecksumType]local_cache.Checksum, len(cs))
+	for _, c := range cs {
+		out[c.Type] = c
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// fsck
+// ---------------------------------------------------------------------------
+
+func TestFsckHealthyStore(t *testing.T) {
+	s := newTestStore(t)
+
+	require.NoError(t, s.MkdirAll("/a/b"))
+	writeObject(t, s, "/a/f1", []byte("one"))
+	writeObject(t, s, "/a/b/f2", randomBytes(64<<10, 2))
+
+	report, err := s.Fsck(t.Context(), false)
+	require.NoError(t, err)
+	assert.True(t, report.Healthy(), "a store built through the normal path is clean: %+v", report)
+	assert.Equal(t, 4, report.EntriesScanned, "two directories and two files")
+	assert.Equal(t, 2, report.DirectoriesScanned)
+}
+
+// TestFsckDetectsDanglingEntry simulates metadata lost underneath a live
+// entry, which would otherwise surface as an error mid-read.
+func TestFsckDetectsDanglingEntry(t *testing.T) {
+	s := newTestStore(t)
+
+	writeObject(t, s, "/orphan-entry", []byte("data"))
+	d, err := s.Stat("/orphan-entry")
+	require.NoError(t, err)
+
+	// Delete the metadata behind the entry's back.
+	require.NoError(t, s.db.DeleteMetadata(instanceHashFor(s.db, d.Generation)))
+
+	report, err := s.Fsck(t.Context(), false)
+	require.NoError(t, err)
+	assert.False(t, report.Healthy())
+	assert.Equal(t, []string{"/orphan-entry"}, report.DanglingEntries)
+
+	// A dry run changes nothing.
+	_, err = s.Stat("/orphan-entry")
+	assert.NoError(t, err, "the entry survives a read-only pass")
+
+	report, err = s.Fsck(t.Context(), true)
+	require.NoError(t, err)
+	// `Repaired` is set from the flag that was passed in, so asserting it is
+	// asserting that true is true.  What matters is what repair claims to
+	// have acted on, and whether it actually did.
+	assert.Contains(t, report.Resolved(), "Entries whose object data is missing (removed)")
+	assert.Empty(t, report.Unresolved(), "nothing was left for an operator to decide")
+
+	_, err = s.Stat("/orphan-entry")
+	assert.ErrorIs(t, err, ErrNotExist, "repair removes the unservable entry")
+
+	// And a second pass finds the store clean, which a repair that only
+	// reported would not achieve.
+	report, err = s.Fsck(t.Context(), false)
+	require.NoError(t, err)
+	assert.True(t, report.Healthy(), "%+v", report)
+}
+
+// TestFsckDetectsOrphanedInstance covers the opposite direction: a version
+// no entry refers to, which would hold space indefinitely.
+func TestFsckDetectsOrphanedInstance(t *testing.T) {
+	s := newTestStore(t)
+
+	writeObject(t, s, "/obj", randomBytes(32<<10, 3))
+	d, err := s.Stat("/obj")
+	require.NoError(t, err)
+	hash := instanceHashFor(s.db, d.Generation)
+
+	// Drop the entry without queueing the version, as a partial failure
+	// outside the normal transaction would.
+	require.NoError(t, s.bdb.Update(func(txn *badger.Txn) error {
+		return deleteDirent(txn, "/obj")
+	}))
+
+	// The version was written moments ago, so the grace period that protects
+	// writes in flight covers it; a pass that respects the default reports it
+	// as pending rather than as garbage.  Nothing is writing here, so the
+	// test waives it explicitly.
+	graced, err := s.Fsck(t.Context(), false)
+	require.NoError(t, err)
+	assert.NotContains(t, graced.OrphanedInstances, string(hash),
+		"a version this young could still be a write in flight")
+	assert.Contains(t, graced.PendingInstances, string(hash))
+
+	report, err := s.FsckWith(t.Context(), FsckOptions{MinAge: FsckNoGracePeriod})
+	require.NoError(t, err)
+	assert.Contains(t, report.OrphanedInstances, string(hash))
+
+	report, err = s.FsckWith(t.Context(), FsckOptions{Repair: true, MinAge: FsckNoGracePeriod})
+	require.NoError(t, err)
+	require.Contains(t, report.OrphanedInstances, string(hash))
+
+	// Repair queues it rather than deleting inline, so reclamation still
+	// respects reader pins.
+	stats, err := s.RunGC(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.InstancesFreed)
+
+	meta, err := s.db.GetMetadata(hash)
+	require.NoError(t, err)
+	assert.Nil(t, meta)
+}
+
+// TestFsckIgnoresQueuedInstances checks that a version already awaiting the
+// janitor is not double-reported as an orphan.
+func TestFsckIgnoresQueuedInstances(t *testing.T) {
+	s := newTestStore(t)
+
+	writeObject(t, s, "/obj", []byte("v1"))
+	writeObject(t, s, "/obj", []byte("v2")) // supersedes v1, queueing it
+
+	report, err := s.Fsck(t.Context(), false)
+	require.NoError(t, err)
+	assert.Empty(t, report.OrphanedInstances,
+		"a version already queued for reclamation is not an orphan")
+}
+
+// synthHash renders n as an instance hash: fixed-width lowercase hex, so
+// ascending n gives ascending BadgerDB key order, which is what the queue
+// cursor's merge depends on.
+func synthHash(n int) local_cache.InstanceHash {
+	return local_cache.InstanceHash(fmt.Sprintf("%064x", n))
+}
+
+// enqueueSynthetic puts hashes on the reclamation queue directly, without the
+// metadata that would normally accompany them.
+func enqueueSynthetic(t *testing.T, s *Store, hashes []local_cache.InstanceHash) {
+	t.Helper()
+	require.NoError(t, s.bdb.Update(func(txn *badger.Txn) error {
+		for _, h := range hashes {
+			if err := enqueueInstance(txn, h); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+}
+
+// TestQueuedCursorMergesAcrossBatches exercises the queue side of the orphan
+// comparison, which is a merge of two hash-ordered scans rather than a set
+// held in memory.
+//
+// The queue is seeded well past one batch so the cursor has to refill and
+// resume, and the probes interleave present and absent hashes so both the
+// "advance past" and the "stop short" branches run.  A cursor that lost its
+// place across a refill would report a queued version as unqueued, and fsck
+// --repair would then queue a version the janitor is already holding -- or,
+// worse, one that a live write has tombstoned for itself.
+func TestQueuedCursorMergesAcrossBatches(t *testing.T) {
+	s := newTestStore(t)
+
+	// Two and a half batches' worth, at every other hash.
+	const span = fsckBatchSize*5 + 7
+	var queued []local_cache.InstanceHash
+	for i := 0; i < span; i += 2 {
+		queued = append(queued, synthHash(i))
+	}
+	enqueueSynthetic(t, s, queued)
+
+	c := s.newQueuedCursor(t.Context(), "")
+	for i := range span {
+		got, err := c.contains(synthHash(i))
+		require.NoError(t, err, "probe %d", i)
+		require.Equal(t, i%2 == 0, got, "probe %d", i)
+	}
+
+	// Past the end of the queue the cursor keeps answering, rather than
+	// running off the end of its buffer.
+	got, err := c.contains(synthHash(span + 1000))
+	require.NoError(t, err)
+	assert.False(t, got)
+}
+
+// TestQueuedCursorHonorsShard checks the cursor stays inside the slice of the
+// instance-hash space it was opened over, since a sharded pass compares only
+// that slice's metadata.
+func TestQueuedCursorHonorsShard(t *testing.T) {
+	s := newTestStore(t)
+
+	inShard := local_cache.InstanceHash("a" + fmt.Sprintf("%063x", 1))
+	outOfShard := local_cache.InstanceHash("b" + fmt.Sprintf("%063x", 1))
+	enqueueSynthetic(t, s, []local_cache.InstanceHash{inShard, outOfShard})
+
+	c := s.newQueuedCursor(t.Context(), "a")
+	got, err := c.contains(inShard)
+	require.NoError(t, err)
+	assert.True(t, got, "a queued version inside the slice is found")
+
+	c = s.newQueuedCursor(t.Context(), "a")
+	got, err = c.contains(outOfShard)
+	require.NoError(t, err)
+	assert.False(t, got, "a queued version outside the slice is not this pass's business")
+}
+
+// TestFsckIgnoresQueuedInstancesWithALargeQueue is the property of
+// TestFsckIgnoresQueuedInstances again, with a queue several batches deep.
+//
+// A backlog is exactly when fsck matters: draining a detached subtree enqueues
+// one key per version it unlinks, so a recursive delete leaves the queue far
+// larger than the number of objects left in the store.  The real superseded
+// entries are spread across the hash space so the real one is reached
+// mid-stream rather than in the first batch.
+func TestFsckIgnoresQueuedInstancesWithALargeQueue(t *testing.T) {
+	s := newTestStore(t)
+
+	writeObject(t, s, "/obj", []byte("v1"))
+	writeObject(t, s, "/obj", []byte("v2")) // supersedes v1, queueing it
+
+	// Synthetic entries have no metadata, so they also cover the case of a
+	// queued version the janitor has already reclaimed.  They are placed at
+	// both ends of the hash space so the cursor has to skip forward over
+	// several batches before and after the real one.
+	var filler []local_cache.InstanceHash
+	for i := range fsckBatchSize * 3 {
+		filler = append(filler, synthHash(i))
+		filler = append(filler,
+			local_cache.InstanceHash("f"+fmt.Sprintf("%063x", i)))
+	}
+	enqueueSynthetic(t, s, filler)
+
+	report, err := s.FsckWith(t.Context(), FsckOptions{MinAge: FsckNoGracePeriod})
+	require.NoError(t, err)
+	assert.Empty(t, report.OrphanedInstances,
+		"a version already queued for reclamation is not an orphan, however deep the queue")
+	assert.Empty(t, report.DanglingEntries)
+}
+
+// TestFsckDetectsIncompleteWrite covers a version whose metadata exists but
+// whose write never finished.
+func TestFsckDetectsIncompleteWrite(t *testing.T) {
+	s := newTestStore(t)
+
+	writeObject(t, s, "/partial", []byte("data"))
+	d, err := s.Stat("/partial")
+	require.NoError(t, err)
+	hash := instanceHashFor(s.db, d.Generation)
+
+	meta, err := s.db.GetMetadata(hash)
+	require.NoError(t, err)
+	meta.Completed = time.Time{}
+	require.NoError(t, s.db.SetMetadata(hash, meta))
+
+	report, err := s.Fsck(t.Context(), false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/partial"}, report.MissingData)
+}
+
+// TestDeepFsckVerifiesData covers the only check that can see at-rest
+// corruption.  Everything else in fsck reads the catalog; a flipped bit in a
+// block file is invisible until the data is read back and compared against the
+// checksums recorded at ingest.
+func TestDeepFsckVerifiesData(t *testing.T) {
+	s := newTestStore(t)
+
+	// Large enough to land in a block file rather than inline, so there is
+	// something on disk to corrupt.
+	content := randomBytes(64<<10, 77)
+	writeObject(t, s, "/obj.bin", content)
+
+	report, err := s.FsckWith(t.Context(), FsckOptions{Deep: true})
+	require.NoError(t, err)
+	assert.True(t, report.Healthy(), "an untouched object verifies: %+v", report)
+	assert.Equal(t, 1, report.ObjectsVerified)
+
+	ok, err := s.VerifyObject("/obj.bin")
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+// TestDeepFsckDetectsCorruptedData flips bytes underneath the store and
+// confirms the deep pass notices, where a shallow pass cannot.
+func TestDeepFsckDetectsCorruptedData(t *testing.T) {
+	s := newTestStore(t)
+
+	writeObject(t, s, "/obj.bin", randomBytes(64<<10, 78))
+	d, err := s.Stat("/obj.bin")
+	require.NoError(t, err)
+
+	// Corrupt the block file directly, behind the store's back.
+	hash := instanceHashFor(s.db, d.Generation)
+	meta, err := s.db.GetMetadata(hash)
+	require.NoError(t, err)
+	require.False(t, meta.IsInline(), "the fixture must be on disk to be corruptible")
+
+	dirs := s.storage.GetDirs()
+	objPath := filepath.Join(dirs[meta.StorageID], local_cache.GetInstanceStoragePath(hash))
+	f, err := os.OpenFile(objPath, os.O_WRONLY, 0)
+	require.NoError(t, err, "the block file should exist at %s", objPath)
+	_, err = f.WriteAt([]byte{0xde, 0xad, 0xbe, 0xef}, 1024)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// A shallow pass reads only the catalog and sees nothing wrong.
+	shallow, err := s.Fsck(t.Context(), false)
+	require.NoError(t, err)
+	assert.True(t, shallow.Healthy(), "the catalog is still consistent: %+v", shallow)
+
+	// The deep pass reads the data and catches it.
+	deep, err := s.FsckWith(t.Context(), FsckOptions{Deep: true})
+	require.NoError(t, err)
+	assert.False(t, deep.Healthy())
+	assert.Equal(t, []string{"/obj.bin"}, deep.CorruptObjects)
+
+	ok, _ := s.VerifyObject("/obj.bin")
+	assert.False(t, ok, "the object no longer matches its recorded checksums")
+}
+
+// ---------------------------------------------------------------------------
+// The scheduled scans
+// ---------------------------------------------------------------------------
+
+// TestScheduledDataScanPreservesCorruptObjects is the difference between a
+// cache and a primary store, and it is a data-loss bug when it is missing.
+//
+// The data scan is the cache's, and the cache deletes an object whose data no
+// longer matches its checksums -- correctly, because the next request refetches
+// it from the origin. An origin has no upstream. Running the cache's policy
+// against a pstore destroys the only copy, and with it the only record of the
+// object's path, size and checksums, after which `fsck --repair` classifies
+// the surviving entry as dangling and removes that too.
+func TestScheduledDataScanPreservesCorruptObjects(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content []byte
+	}{
+		{"inline", []byte("small enough to live in the catalog")},
+		{"on disk", randomBytes(64<<10, 101)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(t)
+			writeObject(t, s, "/obj", tc.content)
+
+			d, err := s.Stat("/obj")
+			require.NoError(t, err)
+			hash := instanceHashFor(s.db, d.Generation)
+
+			// Corrupt the *recorded* checksum rather than the data, so the
+			// mismatch is real and the bytes are still the ones we can assert
+			// on afterwards.
+			meta, err := s.db.GetMetadata(hash)
+			require.NoError(t, err)
+			require.NotEmpty(t, meta.Checksums)
+			for i := range meta.Checksums {
+				meta.Checksums[i].Value = append([]byte(nil), meta.Checksums[i].Value...)
+				meta.Checksums[i].Value[0] ^= 0xff
+			}
+			require.NoError(t, s.db.SetMetadata(hash, meta))
+
+			// Exactly what the scheduled scan runs.
+			checker := local_cache.NewConsistencyChecker(s.db, s.storage, newPStoreScanConfig(0))
+			require.NoError(t, checker.RunDataScan(t.Context(), nil))
+			require.Equal(t, int64(1), checker.GetStats().ChecksumMismatches,
+				"the scan must still detect the corruption")
+
+			// The object survives, in full.
+			survived, err := s.db.GetMetadata(hash)
+			require.NoError(t, err)
+			require.NotNil(t, survived, "the only copy's metadata must not be deleted")
+			assert.Equal(t, int64(len(tc.content)), survived.ContentLength)
+
+			got, err := s.ReadAll("/obj")
+			require.NoError(t, err, "an origin cannot re-fetch what it has lost")
+			assert.Equal(t, tc.content, got)
+
+			// And fsck does not then mistake the entry for a dangling one and
+			// finish the job.
+			report, err := s.FsckWith(t.Context(), FsckOptions{Repair: true, MinAge: FsckNoGracePeriod})
+			require.NoError(t, err)
+			assert.Empty(t, report.DanglingEntries)
+			_, err = s.Stat("/obj")
+			assert.NoError(t, err, "the entry, and with it the object's path and size, survives")
+		})
+	}
+}
+
+// TestCacheDataScanStillDeletesCorruptObjects is the other half: the fix above
+// must not change what a cache does. A cache SHOULD delete and re-fetch, and
+// suppressing that would turn every corrupt cache object into a permanent
+// error instead of a self-healing miss.
+func TestCacheDataScanStillDeletesCorruptObjects(t *testing.T) {
+	s := newTestStore(t)
+	writeObject(t, s, "/obj.bin", randomBytes(64<<10, 102))
+
+	d, err := s.Stat("/obj.bin")
+	require.NoError(t, err)
+	hash := instanceHashFor(s.db, d.Generation)
+
+	meta, err := s.db.GetMetadata(hash)
+	require.NoError(t, err)
+	require.False(t, meta.IsInline())
+	for i := range meta.Checksums {
+		meta.Checksums[i].Value = append([]byte(nil), meta.Checksums[i].Value...)
+		meta.Checksums[i].Value[0] ^= 0xff
+	}
+	require.NoError(t, s.db.SetMetadata(hash, meta))
+
+	// A cache's configuration: no PreserveCorruptObjects.
+	checker := local_cache.NewConsistencyChecker(s.db, s.storage, local_cache.ConsistencyConfig{
+		ChecksumTypes: ingestAlgorithms,
+	})
+	require.NoError(t, checker.RunDataScan(t.Context(), nil))
+	require.Equal(t, int64(1), checker.GetStats().ChecksumMismatches)
+
+	gone, err := s.db.GetMetadata(hash)
+	require.NoError(t, err)
+	assert.Nil(t, gone, "a cache still discards a corrupt object so the next request refetches it")
+}
+
+// TestScheduledDataScanDoesNotBackfillChecksums covers the second way the
+// scan was not the read-only pass its callers believed. Backfilling checksums
+// for an object that has none is a metadata write, and against a primary store
+// it can bless data that is already corrupt.
+func TestScheduledDataScanDoesNotBackfillChecksums(t *testing.T) {
+	s := newTestStore(t)
+	writeObject(t, s, "/obj.bin", randomBytes(64<<10, 103))
+
+	d, err := s.Stat("/obj.bin")
+	require.NoError(t, err)
+	hash := instanceHashFor(s.db, d.Generation)
+
+	meta, err := s.db.GetMetadata(hash)
+	require.NoError(t, err)
+	meta.Checksums = nil
+	require.NoError(t, s.db.SetMetadata(hash, meta))
+
+	checker := local_cache.NewConsistencyChecker(s.db, s.storage, newPStoreScanConfig(0))
+	require.NoError(t, checker.RunDataScan(t.Context(), nil))
+
+	after, err := s.db.GetMetadata(hash)
+	require.NoError(t, err)
+	assert.Empty(t, after.Checksums, "the scheduled scan writes nothing")
+}
+
+// TestDataScanStatisticsAreReportedPerPass pins the accumulation bug: the
+// checker totals its statistics across every scan it has ever run, so once a
+// single mismatch has been seen the absolute count stays above zero and every
+// later pass logs an error about a problem that is no longer there.
+func TestDataScanStatisticsAreReportedPerPass(t *testing.T) {
+	s := newTestStore(t)
+	writeObject(t, s, "/bad.bin", randomBytes(64<<10, 104))
+
+	d, err := s.Stat("/bad.bin")
+	require.NoError(t, err)
+	hash := instanceHashFor(s.db, d.Generation)
+	meta, err := s.db.GetMetadata(hash)
+	require.NoError(t, err)
+	for i := range meta.Checksums {
+		meta.Checksums[i].Value = append([]byte(nil), meta.Checksums[i].Value...)
+		meta.Checksums[i].Value[0] ^= 0xff
+	}
+	require.NoError(t, s.db.SetMetadata(hash, meta))
+
+	checker := local_cache.NewConsistencyChecker(s.db, s.storage, newPStoreScanConfig(0))
+
+	before := checker.GetStats().ChecksumMismatches
+	require.NoError(t, checker.RunDataScan(t.Context(), nil))
+	firstPass := checker.GetStats().ChecksumMismatches - before
+	assert.Equal(t, int64(1), firstPass)
+
+	// Put the object right again, exactly as an operator restoring from
+	// backup would.
+	restored, err := s.db.GetMetadata(hash)
+	require.NoError(t, err)
+	for i := range restored.Checksums {
+		restored.Checksums[i].Value[0] ^= 0xff
+	}
+	require.NoError(t, s.db.SetMetadata(hash, restored))
+
+	before = checker.GetStats().ChecksumMismatches
+	require.NoError(t, checker.RunDataScan(t.Context(), nil))
+	secondPass := checker.GetStats().ChecksumMismatches - before
+	assert.Zero(t, secondPass, "the next pass reports what it found, not the running total")
+	assert.Positive(t, checker.GetStats().ChecksumMismatches,
+		"the running total is what made the absolute count useless")
+}
+
+// TestStartIntegrityChecksRunsAndPreservesData covers the scheduled loop
+// itself rather than the pass it drives. An unattended job is exactly where a
+// scan that deleted the only copy of an object would go unnoticed, so the loop
+// has to be exercised end to end and not merely the function it calls.
+func TestStartIntegrityChecksRunsAndPreservesData(t *testing.T) {
+	s := newTestStore(t)
+
+	content := randomBytes(64<<10, 105)
+	writeObject(t, s, "/obj.bin", content)
+
+	d, err := s.Stat("/obj.bin")
+	require.NoError(t, err)
+	hash := instanceHashFor(s.db, d.Generation)
+	meta, err := s.db.GetMetadata(hash)
+	require.NoError(t, err)
+	for i := range meta.Checksums {
+		meta.Checksums[i].Value = append([]byte(nil), meta.Checksums[i].Value...)
+		meta.Checksums[i].Value[0] ^= 0xff
+	}
+	require.NoError(t, s.db.SetMetadata(hash, meta))
+
+	baseline := dataScanInconsistentTotal(t)
+
+	// A group of its own, so the wait below covers exactly these two loops.
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	egrp, _ := errgroup.WithContext(ctx)
+
+	// Intervals short enough that both loops tick many times over the
+	// window below; nothing here sleeps to synchronize.
+	s.StartIntegrityChecks(ctx, egrp, IntegrityConfig{
+		IndexInterval: time.Millisecond,
+		DataInterval:  time.Millisecond,
+	})
+
+	// Wait for the data scan to have actually run over the corrupt object, so
+	// what follows is about a scan that happened rather than one that has not
+	// started yet.  The metric the scan bumps on a mismatch is the signal;
+	// nothing here sleeps for a fixed period and hopes.
+	require.Eventually(t, func() bool {
+		return dataScanInconsistentTotal(t) > baseline
+	}, 20*time.Second, 5*time.Millisecond,
+		"the scheduled data scan must run and report the mismatch")
+
+	cancel()
+	require.NoError(t, egrp.Wait())
+
+	survived, err := s.db.GetMetadata(hash)
+	require.NoError(t, err)
+	require.NotNil(t, survived, "the background scan must never delete the only copy")
+
+	got, err := s.ReadAll("/obj.bin")
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+
+	cancel()
+	assert.NoError(t, egrp.Wait())
+}
+
+// ---------------------------------------------------------------------------
+// Usage drift
+// ---------------------------------------------------------------------------
+
+// TestFsckRepairPersistsUsageResync is the difference between a repair and a
+// no-op. The counters are seeded from the catalog at every open, so resyncing
+// only the in-memory copy leaves the drift on disk to be read back on the next
+// start -- and an over-counted directory makes the store answer 507 forever
+// with no operator remedy.
+func TestFsckRepairPersistsUsageResync(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	egrp, _ := errgroup.WithContext(ctx)
+	dir := t.TempDir()
+
+	s, err := Open(ctx, egrp, Config{BaseDir: dir})
+	require.NoError(t, err)
+	writeObject(t, s, "/obj.bin", randomBytes(64<<10, 106))
+
+	d, err := s.Stat("/obj.bin")
+	require.NoError(t, err)
+	meta, err := s.db.GetMetadata(instanceHashFor(s.db, d.Generation))
+	require.NoError(t, err)
+	require.False(t, meta.IsInline(), "the fixture must be charged to a storage directory")
+
+	// Inject drift the way a partial failure would: the counter says more is
+	// used than the objects actually occupy.
+	const drift = 4096
+	require.NoError(t, s.db.AddUsage(meta.StorageID, meta.NamespaceID, drift))
+	require.NoError(t, s.Close())
+
+	reopened, err := OpenMaintenance(ctx, dir, true)
+	require.NoError(t, err)
+	before, err := reopened.FsckWith(ctx, FsckOptions{MinAge: FsckNoGracePeriod})
+	require.NoError(t, err)
+	require.Equal(t, int64(-drift), before.UsageDrift[meta.StorageID],
+		"the counter over-reports by exactly what was injected")
+
+	repaired, err := reopened.FsckWith(ctx, FsckOptions{Repair: true, MinAge: FsckNoGracePeriod})
+	require.NoError(t, err)
+	assert.True(t, repaired.UsageResynced)
+	assert.Contains(t, repaired.Resolved(), "Usage counter drift (rewritten from the catalog)")
+	require.NoError(t, reopened.Close())
+
+	// The fix has to survive a reopen, because that is where the counter is
+	// read from.
+	after, err := OpenMaintenance(ctx, dir, false)
+	require.NoError(t, err)
+	defer after.Close()
+
+	report, err := after.FsckWith(ctx, FsckOptions{MinAge: FsckNoGracePeriod})
+	require.NoError(t, err)
+	assert.Empty(t, report.UsageDrift, "the drift is gone, not merely recomputed in memory")
+	assert.True(t, report.Healthy(), "%+v", report)
+}
+
+// TestFsckRepairReportsWhatItCannotFix separates the two lists. Printing
+// unrepairable findings under "Repaired the following:" and exiting zero is
+// how a monitoring script reads success off a store full of corrupt objects.
+func TestFsckRepairReportsWhatItCannotFix(t *testing.T) {
+	s := newTestStore(t)
+
+	// Something repair can fix...
+	writeObject(t, s, "/dangling", []byte("data"))
+	d, err := s.Stat("/dangling")
+	require.NoError(t, err)
+	require.NoError(t, s.db.DeleteMetadata(instanceHashFor(s.db, d.Generation)))
+
+	// ...and something it cannot.
+	writeObject(t, s, "/incomplete", []byte("data"))
+	d2, err := s.Stat("/incomplete")
+	require.NoError(t, err)
+	hash := instanceHashFor(s.db, d2.Generation)
+	meta, err := s.db.GetMetadata(hash)
+	require.NoError(t, err)
+	meta.Completed = time.Time{}
+	require.NoError(t, s.db.SetMetadata(hash, meta))
+
+	report, err := s.FsckWith(t.Context(), FsckOptions{Repair: true, MinAge: FsckNoGracePeriod})
+	require.NoError(t, err)
+
+	assert.Contains(t, report.Resolved(), "Entries whose object data is missing (removed)")
+	assert.Contains(t, report.Unresolved(), "Writes that never completed")
+	assert.NotContains(t, report.Resolved(), "Writes that never completed",
+		"repair must not claim a finding it did not act on")
+	assert.NotEmpty(t, report.Unresolved(),
+		"a caller must have something to exit non-zero on")
+}
+
+// TestFsckDeepRepairDoesNotClaimCorruptObjects is the same property under
+// --repair --deep, where it is easiest to get wrong: a repair pass over
+// checksum-mismatched objects must not report them as repaired and return
+// success, because nothing in the store can reconstruct the lost bytes.
+func TestFsckDeepRepairDoesNotClaimCorruptObjects(t *testing.T) {
+	s := newTestStore(t)
+	writeObject(t, s, "/obj.bin", randomBytes(64<<10, 107))
+
+	d, err := s.Stat("/obj.bin")
+	require.NoError(t, err)
+	hash := instanceHashFor(s.db, d.Generation)
+	meta, err := s.db.GetMetadata(hash)
+	require.NoError(t, err)
+	dirs := s.storage.GetDirs()
+	f, err := os.OpenFile(filepath.Join(dirs[meta.StorageID],
+		local_cache.GetInstanceStoragePath(hash)), os.O_WRONLY, 0)
+	require.NoError(t, err)
+	_, err = f.WriteAt([]byte{0xde, 0xad, 0xbe, 0xef}, 2048)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	report, err := s.FsckWith(t.Context(), FsckOptions{
+		Repair: true, Deep: true, MinAge: FsckNoGracePeriod,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"/obj.bin"}, report.CorruptObjects)
+	assert.Contains(t, report.Unresolved(),
+		"Objects whose data no longer matches its checksums")
+	assert.Empty(t, report.Resolved(), "repair acted on nothing here")
+	assert.False(t, report.Healthy())
+
+	// The corrupt object is still present: fsck reports, it does not decide.
+	_, err = s.Stat("/obj.bin")
+	assert.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// In-flight writes
+// ---------------------------------------------------------------------------
+
+// TestFsckDoesNotReclaimAnInFlightWrite is the hazard the grace period exists
+// for. A streaming upload writes its metadata before any directory entry
+// exists, so from the catalog it is byte-for-byte a crash-window orphan.
+// Repairing one destroys a live upload.
+func TestFsckDoesNotReclaimAnInFlightWrite(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.Mkdir("/data"))
+
+	// Open a write and stream enough through it to materialize storage,
+	// without committing.  This is a real in-flight upload, not a simulation
+	// of one.
+	h, err := s.Create("/data/uploading.bin")
+	require.NoError(t, err)
+	payload := randomBytes(spillThreshold+(1<<20), 108)
+	_, err = h.Write(payload)
+	require.NoError(t, err)
+
+	report, err := s.Fsck(t.Context(), true)
+	require.NoError(t, err)
+	assert.Empty(t, report.OrphanedInstances,
+		"a write in flight must never be classified as garbage")
+
+	// The upload completes and reads back whole.
+	require.NoError(t, h.Close())
+	got, err := s.ReadAll("/data/uploading.bin")
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+
+	// And once it is committed, the store is clean.
+	after, err := s.Fsck(t.Context(), false)
+	require.NoError(t, err)
+	assert.True(t, after.Healthy(), "%+v", after)
+}
+
+// TestFsckRepairRefusesAReadOnlyStore checks the guard is fsck's own rather
+// than a side effect of BadgerDB's directory lock. Relying on the lock means
+// any future live-repair path silently becomes a data-loss path.
+func TestFsckRepairRefusesAReadOnlyStore(t *testing.T) {
+	ro := buildStoreThenReopenReadOnly(t)
+
+	_, err := ro.Fsck(t.Context(), true)
+	assert.ErrorIs(t, err, ErrNotSupported,
+		"a repair pass must refuse a read-only store up front")
+
+	// Reporting still works.
+	report, err := ro.Fsck(t.Context(), false)
+	require.NoError(t, err)
+	assert.True(t, report.Healthy(), "%+v", report)
+}
+
+// TestFsckShardedOrphanScanCoversEverything checks the partitioning that keeps
+// the hourly check's memory bounded: each pass examines one slice of the
+// instance-hash space, and rotating through them finds every orphan exactly
+// once.
+func TestFsckShardedOrphanScanCoversEverything(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.Mkdir("/data"))
+
+	want := map[string]bool{}
+	for i := range 40 {
+		name := fmt.Sprintf("/data/obj-%02d", i)
+		writeObject(t, s, name, randomBytes(64, int64(i)))
+		d, err := s.Stat(name)
+		require.NoError(t, err)
+		want[string(instanceHashFor(s.db, d.Generation))] = true
+		require.NoError(t, s.bdb.Update(func(txn *badger.Txn) error {
+			return deleteDirent(txn, name)
+		}))
+	}
+
+	full, err := s.FsckWith(t.Context(), FsckOptions{MinAge: FsckNoGracePeriod})
+	require.NoError(t, err)
+	require.Len(t, full.OrphanedInstances, len(want))
+	assert.False(t, full.OrphanScanPartial)
+
+	// The same set, gathered one slice at a time.
+	const shards = 16
+	got := map[string]int{}
+	for shard := range shards {
+		partial, pErr := s.FsckWith(t.Context(), FsckOptions{
+			OrphanShardOf: shards, OrphanShard: shard, MinAge: FsckNoGracePeriod,
+		})
+		require.NoError(t, pErr)
+		assert.True(t, partial.OrphanScanPartial)
+		assert.Equal(t, full.EntriesScanned, partial.EntriesScanned,
+			"the per-entry checks still cover the whole index")
+		for _, h := range partial.OrphanedInstances {
+			got[h]++
+		}
+	}
+
+	assert.Len(t, got, len(want), "every orphan is found across a full rotation")
+	for h, n := range got {
+		assert.True(t, want[h], "%s is not one of the orphans", h)
+		assert.Equal(t, 1, n, "%s was reported by more than one slice", h)
+	}
+}
+
+// dataScanInconsistentTotal reads the counter of objects a pstore data scan
+// found not to match their checksums.
+//
+// The scheduled loop exposes nothing else a test can wait on, and waiting on
+// the clock instead would be a race dressed up as a delay.
+//
+// It reads the pstore-named counter rather than the block store's
+// pelican_cache_data_scan_* one, which a pstore no longer touches: an origin
+// reporting its integrity scan as cache activity was the thing that had to
+// stop.  See newPStoreScanConfig.
+func dataScanInconsistentTotal(t *testing.T) float64 {
+	t.Helper()
+	return labeledCounterValue(t, "pelican_pstore_data_scan_mismatches_total", nil)
+}
+
+// TestTruncateHashIsDeterministicAndDistinct covers the property the reachable
+// set depends on: a live version can never be absent from it.
+//
+// Truncation is only safe because it is deterministic. The same hash always
+// yields the same key, so every reachable version puts its own prefix in the
+// set and is found again when the metadata scan asks. The reverse -- two
+// distinct hashes sharing a key -- is possible in principle and merely means a
+// missed orphan, never a reclaimed live object.
+func TestTruncateHashIsDeterministicAndDistinct(t *testing.T) {
+	t.Parallel()
+
+	a := local_cache.InstanceHash(strings.Repeat("a1b2c3d4", 8))
+	b := local_cache.InstanceHash(strings.Repeat("f9e8d7c6", 8))
+
+	require.Equal(t, truncateHash(a), truncateHash(a),
+		"the same hash must always produce the same key, or a live version could go missing")
+	require.NotEqual(t, truncateHash(a), truncateHash(b))
+
+	// Two hashes agreeing on the first 128 bits and differing afterwards do
+	// collide. That is the accepted failure mode, and it is one-directional:
+	// it can only hide an orphan.
+	shared := strings.Repeat("ab", 16)
+	c := local_cache.InstanceHash(shared + strings.Repeat("00", 16))
+	d := local_cache.InstanceHash(shared + strings.Repeat("ff", 16))
+	require.Equal(t, truncateHash(c), truncateHash(d),
+		"a 128-bit prefix collision is expected; the safety argument is the direction, not the odds")
+
+	// A malformed hash must not silently alias onto a well-formed one.
+	require.NotEqual(t, truncateHash(a), truncateHash(local_cache.InstanceHash("not-hex")))
+}

--- a/pstore/detached.go
+++ b/pstore/detached.go
@@ -1,0 +1,136 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Detached subtrees.
+//
+// RemoveAll on a large directory cannot delete every descendant in one
+// transaction, so it unlinks the directory from its parent and hands the root
+// to the janitor.  With an inode-style index that would be enough: the
+// descendants would be unreachable the moment the parent's entry went away.
+//
+// Keys here are path-derived, though, and a lookup is a single point get that
+// never consults ancestors — that is exactly why listing a directory is cheap.
+// The consequence is that a descendant of a detached directory stays directly
+// addressable until the janitor reaches it.
+//
+// Rather than pay O(depth) ancestor checks on every lookup, the store keeps
+// the set of detached roots in memory and tests a path against it.  The set is
+// empty except while a drain is in progress, and holds one entry per RemoveAll
+// still draining, so the check costs a handful of string comparisons on paths
+// nobody should be reading anyway.  It is rebuilt from the pg: queue at open,
+// so a crash mid-drain does not resurrect a deleted tree.
+
+package pstore
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/dgraph-io/badger/v4"
+)
+
+// badgerTxn aliases the transaction type so the resolver signature stays
+// readable alongside the index helpers.
+type badgerTxn = badger.Txn
+
+// detachedSet tracks subtree roots that have been unlinked but not yet
+// drained.
+//
+// contains is called on every path resolution, and the set is empty in all but
+// the moments after a RemoveAll, so the empty case must cost as little as
+// possible.  An atomic population count is consulted first and the lock is
+// taken only when there is actually something to compare against; the count is
+// advisory, and the authoritative check happens under the read lock.
+type detachedSet struct {
+	// nonEmpty mirrors len(roots) for the lock-free fast path.  It may lag by
+	// the width of a single add or remove, which is harmless: a stale false
+	// can only occur before the transaction that detaches a subtree has been
+	// observed, and a stale true costs one wasted lock acquisition.
+	nonEmpty atomic.Bool
+
+	mu    sync.RWMutex
+	roots map[string]struct{}
+}
+
+func newDetachedSet() *detachedSet {
+	return &detachedSet{roots: make(map[string]struct{})}
+}
+
+// add marks a subtree as detached.
+func (d *detachedSet) add(root string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.roots[root] = struct{}{}
+	d.nonEmpty.Store(true)
+}
+
+// remove clears a subtree once it has been fully drained.
+func (d *detachedSet) remove(root string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.roots, root)
+	d.nonEmpty.Store(len(d.roots) > 0)
+}
+
+// contains reports whether cleanPath is a detached root or lies beneath one,
+// in which case it must be treated as already gone.
+func (d *detachedSet) contains(cleanPath string) bool {
+	// The overwhelmingly common case: nothing is draining, so no lock.
+	if !d.nonEmpty.Load() {
+		return false
+	}
+
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	for root := range d.roots {
+		if cleanPath == root || strings.HasPrefix(cleanPath, root+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// len reports how many subtrees are awaiting drain.
+func (d *detachedSet) len() int {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return len(d.roots)
+}
+
+// reloadDetached rebuilds the detached-subtree set from the garbage queue,
+// so a store that crashed mid-drain does not expose a half-deleted tree.
+func (s *Store) reloadDetached() error {
+	subtrees, err := s.collectAllSubtrees()
+	if err != nil {
+		return err
+	}
+	for _, root := range subtrees {
+		s.detached.add(root)
+	}
+	return nil
+}
+
+// resolve reads the entry at cleanPath, reporting ErrNotExist for anything
+// inside a subtree that has been unlinked but not yet drained.
+func (s *Store) resolve(txn *badgerTxn, cleanPath string) (*Dirent, error) {
+	if s.detached.contains(cleanPath) {
+		return nil, ErrNotExist
+	}
+	return getDirent(txn, cleanPath)
+}

--- a/pstore/errors.go
+++ b/pstore/errors.go
@@ -1,0 +1,84 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package pstore
+
+import (
+	"io/fs"
+	"syscall"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/pkg/errors"
+)
+
+// Sentinel errors.  These alias the syscall/fs values the afero and WebDAV
+// layers already understand, so that errors.Is(err, fs.ErrNotExist),
+// os.IsNotExist, and the handler's status mapping all work without
+// translation.
+var (
+	// ErrNotExist is returned when a path has no entry.
+	ErrNotExist = fs.ErrNotExist
+	// ErrExist is returned when a path already has an entry and the caller
+	// required that it not.
+	ErrExist = fs.ErrExist
+	// ErrNotDir is returned when a path component is not a directory.
+	ErrNotDir = syscall.ENOTDIR
+	// ErrIsDir is returned when a directory is used where a file is required.
+	ErrIsDir = syscall.EISDIR
+	// ErrNotEmpty is returned when a non-recursive removal targets a
+	// directory that still has entries.
+	ErrNotEmpty = syscall.ENOTEMPTY
+	// ErrNoSpace is returned when a write would exceed the store's capacity.
+	//
+	// golang.org/x/net/webdav reports any failed write as 405 Method Not
+	// Allowed, so the origin rewrites the status itself: see
+	// origin_serve.statusForBackendError, which turns this into 507
+	// Insufficient Storage.
+	ErrNoSpace = syscall.ENOSPC
+	// ErrInvalidPath is returned for paths the index cannot represent.
+	ErrInvalidPath = fs.ErrInvalid
+	// ErrNotSupported is returned for operations pstore deliberately does not
+	// implement, such as writing at an arbitrary offset.
+	ErrNotSupported = errors.New("operation not supported by pstore")
+	// ErrDraining is returned when a path is inside a subtree that a
+	// recursive delete has removed but the janitor has not finished
+	// reclaiming.  Retrying shortly succeeds; the janitor speeds up while a
+	// backlog exists.  origin_serve.statusForBackendError reports it as 409
+	// Conflict, which is what tells a client the retry is worth making.
+	ErrDraining = errors.New("path is still being reclaimed")
+	// ErrPreconditionFailed is returned when a conditional write's
+	// precondition does not hold -- that is, when Close finds the object no
+	// longer carries the generation the caller required.
+	// origin_serve.statusForBackendError reports it as 412 Precondition
+	// Failed.
+	ErrPreconditionFailed = errors.New("precondition failed")
+	// ErrConflict is returned when two writers raced to install the same path
+	// and this one's index transaction lost.
+	//
+	// The store's index is serializable, so a commit that reads an entry
+	// another commit is replacing is aborted rather than serialized behind it.
+	// Nothing is lost -- the winner's version is installed and the loser's is
+	// discarded -- and retrying succeeds.  The WebDAV lock system serializes
+	// same-path PUTs before they reach here, so a client normally sees 423
+	// Locked instead; this is what a caller using the store directly gets.
+	// origin_serve.statusForBackendError reports it as 409 Conflict rather
+	// than letting an opaque database error surface as a 500.
+	ErrConflict = badger.ErrConflict
+	// ErrClosed is returned when a handle is used after Close.
+	ErrClosed = fs.ErrClosed
+)

--- a/pstore/fs.go
+++ b/pstore/fs.go
@@ -1,0 +1,653 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// The afero.Fs face of a store.
+//
+// origin_serve already adapts any afero.Fs into a webdav.FileSystem and layers
+// on Prometheus metrics, HTB rate limiting, multiuser wrapping, and directory
+// pagination (origin_serve/filesystem.go).  Implementing afero.Fs is therefore
+// all pstore needs to be servable, and this file is deliberately a thin
+// translation over Store rather than a second implementation of anything.
+//
+// Where POSIX semantics and object-store semantics disagree, pstore follows
+// what WebDAV and the Pelican client actually exercise: no chmod, no chown, no
+// symlinks, no truncate of an existing object, and no writing at an offset.
+
+package pstore
+
+import (
+	"context"
+	"io"
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+	"golang.org/x/net/webdav"
+)
+
+// FS adapts a Store to afero.Fs.
+type FS struct {
+	store *Store
+}
+
+// Ensure the adapter really satisfies the interfaces the origin needs.
+var (
+	_ afero.Fs   = (*FS)(nil)
+	_ afero.File = (*file)(nil)
+)
+
+// NewFS returns an afero.Fs backed by the store.
+func NewFS(s *Store) *FS { return &FS{store: s} }
+
+// Name identifies the filesystem in afero diagnostics.
+func (fs *FS) Name() string { return "pstore" }
+
+// Create makes (or replaces) an object and returns it open for writing,
+// creating any missing parent directories.
+//
+// Auto-creating parents is what lets a client PUT into a prefix that does not
+// exist yet, which is how uploads normally arrive -- no explicit MKCOL. The
+// origin has a shared afero wrapper that does this, but it derives the parent
+// with filepath, and a pstore path is a namespace path that is always
+// slash-separated: on Windows the wrapper would ask for a directory literally
+// named "\a\b\c". Doing it here keeps the separator right on every platform.
+func (fs *FS) Create(name string) (afero.File, error) {
+	w, err := fs.createWithParents(name)
+	if err != nil {
+		return nil, pathError("create", name, err)
+	}
+	return &file{fs: fs, name: name, w: w}, nil
+}
+
+// createWithParents opens a write handle, creating missing parents on the
+// first attempt that reports the parent absent.
+func (fs *FS) createWithParents(name string) (*WriteHandle, error) {
+	return fs.createSizedWithParents(name, -1)
+}
+
+// createSizedWithParents is createWithParents with an optional size hint.
+func (fs *FS) createSizedWithParents(name string, size int64) (*WriteHandle, error) {
+	open := func() (*WriteHandle, error) {
+		if size >= 0 {
+			return fs.store.CreateSized(name, size)
+		}
+		return fs.store.Create(name)
+	}
+
+	w, err := open()
+	if err == nil || !errors.Is(err, ErrNotExist) {
+		return w, err
+	}
+
+	parent := path.Dir(name)
+	if parent == "." || parent == "/" || parent == "" {
+		return nil, err
+	}
+	if mkErr := fs.store.MkdirAll(parent); mkErr != nil {
+		// Report why the create failed, not why the recovery did, unless the
+		// recovery hit something meaningfully different.
+		if errors.Is(mkErr, ErrDraining) || errors.Is(mkErr, ErrNotDir) {
+			return nil, mkErr
+		}
+		return nil, err
+	}
+	return open()
+}
+
+// Mkdir creates a directory.  perm is ignored: pstore has no per-entry
+// permissions, since access control is the origin's authorization layer.
+func (fs *FS) Mkdir(name string, _ os.FileMode) error {
+	return pathError("mkdir", name, fs.store.Mkdir(name))
+}
+
+// MkdirAll creates a directory and any missing ancestors.
+func (fs *FS) MkdirAll(path string, _ os.FileMode) error {
+	return pathError("mkdir", path, fs.store.MkdirAll(path))
+}
+
+// Open opens an object or directory for reading.
+func (fs *FS) Open(name string) (afero.File, error) {
+	return fs.OpenFile(name, os.O_RDONLY, 0)
+}
+
+// OpenFile opens a path with the given flags.
+//
+// Objects are immutable, so the write flags all mean the same thing: build a
+// new version and swap it in at Close.  O_APPEND is refused rather than
+// silently truncating, since there is no way to honor it.
+func (fs *FS) OpenFile(name string, flag int, _ os.FileMode) (afero.File, error) {
+	writing := flag&(os.O_WRONLY|os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_APPEND) != 0
+
+	if !writing {
+		// Try the object first.  Opening a file is the common case by a wide
+		// margin, and OpenRead already resolves the entry, so leading with
+		// Stat would cost every read an extra lookup to answer a question
+		// OpenRead has to answer anyway.  A directory reports ErrIsDir, which
+		// is the one case that needs the second lookup.
+		r, err := fs.store.OpenRead(name)
+		if err == nil {
+			return &file{fs: fs, name: name, r: r}, nil
+		}
+		if !errors.Is(err, ErrIsDir) {
+			return nil, pathError("open", name, err)
+		}
+		d, sErr := fs.store.Stat(name)
+		if sErr != nil {
+			return nil, pathError("open", name, sErr)
+		}
+		return &file{fs: fs, name: name, dir: d}, nil
+	}
+
+	if flag&os.O_APPEND != 0 {
+		// Appending would require reading the existing object back and
+		// rewriting it, which is not what any Pelican caller wants.
+		return nil, pathError("open", name, ErrNotSupported)
+	}
+	if flag&os.O_EXCL != 0 && flag&os.O_CREATE != 0 {
+		w, err := fs.createWithParents(name)
+		if err != nil {
+			return nil, pathError("open", name, err)
+		}
+		w.RequireAbsent()
+		return &file{fs: fs, name: name, w: w}, nil
+	}
+	return fs.Create(name)
+}
+
+// OpenFileSized is OpenFile with the object's expected length, which lets the
+// write path pick its storage tier immediately instead of buffering to
+// discover it.  It implements origin_serve's size-hint interface.
+//
+// The size is advisory: the object is stored at whatever length actually
+// arrives, so a wrong or absent hint costs nothing but the buffering it would
+// have avoided.
+func (fs *FS) OpenFileSized(name string, flag int, perm os.FileMode, size int64) (afero.File, error) {
+	writing := flag&(os.O_WRONLY|os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_APPEND) != 0
+	if !writing || size < 0 {
+		return fs.OpenFile(name, flag, perm)
+	}
+	if flag&os.O_APPEND != 0 {
+		return nil, pathError("open", name, ErrNotSupported)
+	}
+
+	w, err := fs.createSizedWithParents(name, size)
+	if err != nil {
+		return nil, pathError("open", name, err)
+	}
+	if flag&os.O_EXCL != 0 && flag&os.O_CREATE != 0 {
+		w.RequireAbsent()
+	}
+	return &file{fs: fs, name: name, w: w}, nil
+}
+
+// OpenFileConditional is OpenFileSized with an HTTP conditional-write
+// precondition attached, implementing origin_serve's ConditionalWriteFs.
+//
+// The precondition is enforced by Close, inside the single transaction that
+// resolves the existing entry and installs the new one, which is the only
+// place it can be enforced without a race.  Checking it here, at open time,
+// would be exactly the stat-then-write the caller is trying to avoid: two
+// concurrent "If-None-Match: *" PUTs would both find the path absent and both
+// commit.
+//
+// requireETag carries the client's entity tag verbatim; an object's tag is its
+// generation, so the tag is unwrapped rather than compared as a string.
+func (fs *FS) OpenFileConditional(name string, flag int, perm os.FileMode, size int64,
+	requireAbsent bool, requireETag string) (afero.File, error) {
+	f, err := fs.OpenFileSized(name, flag, perm, size)
+	if err != nil {
+		return nil, err
+	}
+	pf, ok := f.(*file)
+	if !ok || pf.w == nil {
+		// Not a write; there is nothing to make conditional.
+		return f, nil
+	}
+	if requireAbsent {
+		pf.w.RequireAbsent()
+	}
+	if gen := generationFromETag(requireETag); gen != "" {
+		pf.w.RequireGeneration(gen)
+	}
+	return f, nil
+}
+
+// generationFromETag recovers the generation an entity tag was minted from, so
+// that a client's If-Match can be enforced against the index.  It is the
+// inverse of etagFor, tolerant of the weak-comparison prefix a proxy may add.
+func generationFromETag(tag string) string {
+	tag = strings.TrimSpace(tag)
+	tag = strings.TrimPrefix(tag, "W/")
+	return strings.Trim(tag, `"`)
+}
+
+// Remove deletes an object, or an empty directory.
+func (fs *FS) Remove(name string) error {
+	return pathError("remove", name, fs.store.Remove(name))
+}
+
+// RemoveAll deletes a path and everything beneath it.
+func (fs *FS) RemoveAll(path string) error {
+	return pathError("removeall", path, fs.store.RemoveAll(path))
+}
+
+// Rename moves an entry.
+func (fs *FS) Rename(oldname, newname string) error {
+	if err := fs.store.Rename(oldname, newname); err != nil {
+		return &os.LinkError{Op: "rename", Old: oldname, New: newname, Err: err}
+	}
+	return nil
+}
+
+// Stat returns file information for a path.
+func (fs *FS) Stat(name string) (os.FileInfo, error) {
+	d, err := fs.store.Stat(name)
+	if err != nil {
+		return nil, pathError("stat", name, err)
+	}
+	return newFileInfo(baseName(name), d), nil
+}
+
+// Chmod is not supported: pstore stores no per-entry permissions.
+func (fs *FS) Chmod(name string, _ os.FileMode) error {
+	return pathError("chmod", name, ErrNotSupported)
+}
+
+// Chown is not supported: pstore stores no per-entry ownership.
+func (fs *FS) Chown(name string, _, _ int) error {
+	return pathError("chown", name, ErrNotSupported)
+}
+
+// Chtimes is not supported: an object's mtime is set when its version is
+// committed.
+func (fs *FS) Chtimes(name string, _, _ time.Time) error {
+	return pathError("chtimes", name, ErrNotSupported)
+}
+
+// ---------------------------------------------------------------------------
+// File handles
+// ---------------------------------------------------------------------------
+
+// file is an open object or directory.  Exactly one of r, w, or dir is set.
+type file struct {
+	fs   *FS
+	name string
+
+	r   *ReadHandle
+	w   *WriteHandle
+	dir *Dirent
+
+	// dirCursor is the last name handed to the caller, so the next Readdir
+	// page resumes from the index rather than from a buffered slice.
+	dirCursor string
+	// dirDone records that the index is exhausted, so further calls report
+	// EOF without rescanning.
+	dirDone bool
+
+	// writeErr is sticky: once the data destined for this object is known to
+	// be incomplete, Close must discard the pending version rather than
+	// install it.  See AbortWrite.
+	writeErr error
+	// writeMu guards writeErr, which is set from the goroutine reading the
+	// request body as well as from Write.
+	writeMu sync.Mutex
+
+	closed bool
+}
+
+// Name returns the path the handle was opened with.
+func (f *file) Name() string { return f.name }
+
+// AbortWrite records that the bytes written so far do not make up the whole
+// object, so that Close discards the pending version instead of installing it.
+//
+// It exists because the caller that discovers the failure is not the caller
+// that closes the handle.  golang.org/x/net/webdav's handlePut does
+//
+//	_, copyErr := io.Copy(f, r.Body)
+//	fi, statErr := f.Stat()
+//	closeErr := f.Close()
+//	if copyErr != nil { return http.StatusMethodNotAllowed, copyErr }
+//
+// -- Close runs before copyErr is ever looked at.  Since a pstore write builds
+// a complete new version and swaps it in at Close, a client that disconnects
+// partway through an overwrite would otherwise have its truncated body
+// committed over a good object, on a store that is very likely the only copy
+// of the data.  The origin wraps the request body so a read failure lands here
+// first (see origin_serve's writeGuard).
+func (f *file) AbortWrite(err error) {
+	if f.w == nil {
+		return
+	}
+	if err == nil {
+		err = errors.New("the write was aborted before it completed")
+	}
+	f.writeMu.Lock()
+	defer f.writeMu.Unlock()
+	if f.writeErr == nil {
+		f.writeErr = err
+	}
+}
+
+// failedWrite returns the sticky write error, if any.
+func (f *file) failedWrite() error {
+	f.writeMu.Lock()
+	defer f.writeMu.Unlock()
+	return f.writeErr
+}
+
+// Close releases the handle.  For a write handle this is where the new
+// version is committed -- unless the data is known to be incomplete, in which
+// case the pending version is discarded and the previous one survives
+// untouched.
+func (f *file) Close() error {
+	if f.closed {
+		return pathError("close", f.name, ErrClosed)
+	}
+	f.closed = true
+
+	switch {
+	case f.w != nil:
+		if failed := f.failedWrite(); failed != nil {
+			// Abort, not Close: installing a truncated version is silent data
+			// loss, and the object's previous version is still correct.
+			_ = f.w.Abort()
+			return pathError("close", f.name, failed)
+		}
+		return pathError("close", f.name, f.w.Close())
+	case f.r != nil:
+		return pathError("close", f.name, f.r.Close())
+	default:
+		return nil
+	}
+}
+
+func (f *file) Read(p []byte) (int, error) {
+	if f.r == nil {
+		return 0, pathError("read", f.name, badMode(f))
+	}
+	return f.r.Read(p)
+}
+
+func (f *file) ReadAt(p []byte, off int64) (int, error) {
+	if f.r == nil {
+		return 0, pathError("read", f.name, badMode(f))
+	}
+	return f.r.ReadAt(p, off)
+}
+
+func (f *file) Seek(offset int64, whence int) (int64, error) {
+	if f.r == nil {
+		// Seeking a write handle would imply a partial update.
+		return 0, pathError("seek", f.name, ErrNotSupported)
+	}
+	return f.r.Seek(offset, whence)
+}
+
+func (f *file) Write(p []byte) (int, error) {
+	if f.w == nil {
+		return 0, pathError("write", f.name, badMode(f))
+	}
+	n, err := f.w.Write(p)
+	if err != nil {
+		// A refused write (the store is full, the block layer failed) leaves
+		// the object short.  Remember it so Close cannot install the fragment
+		// over a complete previous version.
+		f.AbortWrite(err)
+	}
+	return n, err
+}
+
+// WriteAt is refused: objects are immutable and written sequentially.
+//
+// The refusal is recorded, because a caller that meant to write at an offset
+// and was told no has not produced the object it intended; committing the
+// sequential prefix it happened to write first would be worse than failing.
+func (f *file) WriteAt([]byte, int64) (int, error) {
+	err := pathError("write", f.name, ErrNotSupported)
+	f.AbortWrite(err)
+	return 0, err
+}
+
+func (f *file) WriteString(s string) (int, error) { return f.Write([]byte(s)) }
+
+// Truncate supports exactly one case: truncating a freshly created,
+// not-yet-written object to zero.
+//
+// That is how a zero-length file gets created through several ordinary code
+// paths (afero.WriteFile with empty content, `: > file` semantics), and it
+// costs nothing because a pending write is already empty.  Any other target
+// length, or truncating after bytes have been written, would be a partial
+// update, which objects here do not support.
+func (f *file) Truncate(size int64) error {
+	if f.w == nil {
+		return pathError("truncate", f.name, badMode(f))
+	}
+	if size != 0 || f.w.Size() != 0 {
+		return pathError("truncate", f.name, ErrNotSupported)
+	}
+	return nil
+}
+
+// Sync is a no-op: a version is durable once Close commits it.
+func (f *file) Sync() error { return nil }
+
+// Stat returns information about the open handle.
+//
+// For a write handle this reports the *pending* version rather than looking
+// the path up, which matters more than it sounds: objects are immutable and
+// the new version is only installed at Close, so the path may not exist yet or
+// may still hold the previous version. webdav.handlePut stats the file before
+// closing it and turns any error into 405 Method Not Allowed, so consulting
+// the namespace here makes every create fail with a status that says the
+// method is unsupported. An os.File would stat the open file, not the path;
+// so does this.
+func (f *file) Stat() (os.FileInfo, error) {
+	switch {
+	case f.dir != nil:
+		return newFileInfo(baseName(f.name), f.dir), nil
+	case f.r != nil:
+		return newFileInfo(baseName(f.name), f.r.Dirent()), nil
+	case f.w != nil:
+		return newFileInfo(baseName(f.name), &Dirent{
+			Type:       EntryFile,
+			Generation: f.w.Generation(),
+			Size:       f.w.Size(),
+			MTimeNanos: time.Now().UnixNano(),
+			Mode:       uint32(defaultFileMode),
+		}), nil
+	default:
+		return f.fs.Stat(f.name)
+	}
+}
+
+// Readdir returns directory entries, in name order.
+//
+// It follows the os.File contract: a positive count returns at most that many
+// entries and io.EOF once exhausted, while count <= 0 returns everything
+// remaining.
+//
+// A positive count is served straight from the index, one page per call,
+// resuming from the last name returned.  Nothing is buffered, so a directory
+// with a hundred thousand entries costs the caller only what it actually
+// reads.  count <= 0 is materialized because the contract demands the whole
+// remainder in one slice; callers that cannot afford that should paginate.
+//
+// The listing is not a snapshot: a concurrent write between pages will be
+// seen if it sorts after the resume point, and missed if before.  That
+// matches what a POSIX directory read gives and is what the WebDAV layer
+// already assumes.
+func (f *file) Readdir(count int) ([]os.FileInfo, error) {
+	if f.dir == nil {
+		return nil, pathError("readdir", f.name, ErrNotDir)
+	}
+
+	if count <= 0 {
+		// os.File returns the remainder and a nil error, never io.EOF, for a
+		// non-positive count -- including when the remainder is empty because
+		// paginated calls already drained the handle.
+		if f.dirDone {
+			return []os.FileInfo{}, nil
+		}
+		entries, _, err := f.fs.store.List(f.name, f.dirCursor, 0)
+		if err != nil {
+			return nil, pathError("readdir", f.name, err)
+		}
+		f.dirDone = true
+		if len(entries) > 0 {
+			f.dirCursor = entries[len(entries)-1].Name
+		}
+		return toFileInfos(entries), nil
+	}
+
+	if f.dirDone {
+		return nil, io.EOF
+	}
+	entries, more, err := f.fs.store.List(f.name, f.dirCursor, count)
+	if err != nil {
+		return nil, pathError("readdir", f.name, err)
+	}
+	if len(entries) == 0 {
+		f.dirDone = true
+		return nil, io.EOF
+	}
+	f.dirCursor = entries[len(entries)-1].Name
+	if !more {
+		// Remember that the index is exhausted so the next call reports EOF
+		// without another scan.
+		f.dirDone = true
+	}
+	return toFileInfos(entries), nil
+}
+
+// toFileInfos adapts a page of index entries for the caller.
+func toFileInfos(entries []ListEntry) []os.FileInfo {
+	infos := make([]os.FileInfo, 0, len(entries))
+	for _, e := range entries {
+		infos = append(infos, newFileInfo(e.Name, e.Dirent))
+	}
+	return infos
+}
+
+// Readdirnames returns the names of directory entries.
+func (f *file) Readdirnames(n int) ([]string, error) {
+	infos, err := f.Readdir(n)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, len(infos))
+	for i, fi := range infos {
+		names[i] = fi.Name()
+	}
+	return names, nil
+}
+
+// badMode reports the error for using a handle in the wrong direction.
+func badMode(f *file) error {
+	if f.dir != nil {
+		return ErrIsDir
+	}
+	return ErrNotSupported
+}
+
+// ---------------------------------------------------------------------------
+// FileInfo
+// ---------------------------------------------------------------------------
+
+// fileInfo adapts a dirent to os.FileInfo.
+//
+// What it carries is exactly what the directory entry carries: size, mode,
+// modification time, and -- through ETag below and Sys() -- the object's
+// generation.  That is deliberate, because a listing must not cost one
+// metadata read per entry.
+//
+// Two things are therefore absent.  Access time lives on the object's
+// metadata and is available via Store.AccessTime.  There is no separate
+// creation time: objects are immutable, so a version's modification time is
+// when that version was created.
+type fileInfo struct {
+	name   string
+	dirent *Dirent
+}
+
+func newFileInfo(name string, d *Dirent) os.FileInfo {
+	return &fileInfo{name: name, dirent: d}
+}
+
+func (fi *fileInfo) Name() string { return fi.name }
+
+func (fi *fileInfo) Size() int64 {
+	if fi.dirent.IsDir() {
+		return 0
+	}
+	return fi.dirent.Size
+}
+
+func (fi *fileInfo) Mode() os.FileMode {
+	if fi.dirent.IsDir() {
+		return os.ModeDir | os.FileMode(fi.dirent.Mode).Perm()
+	}
+	return os.FileMode(fi.dirent.Mode).Perm()
+}
+
+func (fi *fileInfo) ModTime() time.Time { return time.Unix(0, fi.dirent.MTimeNanos) }
+func (fi *fileInfo) IsDir() bool        { return fi.dirent.IsDir() }
+func (fi *fileInfo) Sys() any           { return fi.dirent }
+
+// ETag implements webdav.ETager so the handler advertises the object's
+// generation rather than its default size-and-mtime approximation.  The
+// generation is a strong validator minted per write, which is exactly what an
+// entity tag should be.
+//
+// Directories have no generation, so they fall back to the handler's default.
+func (fi *fileInfo) ETag(_ context.Context) (string, error) {
+	if fi.dirent.IsDir() || fi.dirent.Generation == "" {
+		return "", webdav.ErrNotImplemented
+	}
+	return etagFor(fi.dirent.Generation), nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// pathError wraps err in *os.PathError so callers can use errors.Is against
+// the fs sentinels, which is what afero and the WebDAV handler expect.
+func pathError(op, name string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &os.PathError{Op: op, Path: name, Err: errors.Cause(err)}
+}
+
+// baseName returns the final component of a path, for FileInfo.Name.
+func baseName(name string) string {
+	cleaned, err := cleanRelative(name)
+	if err != nil {
+		return name
+	}
+	if isRootPath(cleaned) {
+		return "/"
+	}
+	_, base := splitPath(cleaned)
+	return base
+}

--- a/pstore/fs_test.go
+++ b/pstore/fs_test.go
@@ -1,0 +1,754 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package pstore
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/webdav"
+)
+
+func newTestFS(t *testing.T) *FS {
+	t.Helper()
+	return NewFS(newTestStore(t))
+}
+
+func TestFSWriteReadThroughAfero(t *testing.T) {
+	fsys := newTestFS(t)
+
+	content := []byte("hello pstore")
+	require.NoError(t, afero.WriteFile(fsys, "/greeting", content, 0644))
+
+	got, err := afero.ReadFile(fsys, "/greeting")
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+
+	exists, err := afero.Exists(fsys, "/greeting")
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+// TestFSLargeFileThroughAfero pushes past the spill threshold so the streaming
+// tier is exercised through the adapter rather than the store API directly.
+func TestFSLargeFileThroughAfero(t *testing.T) {
+	fsys := newTestFS(t)
+
+	content := randomBytes(spillThreshold+(1<<20), 42)
+	require.NoError(t, afero.WriteFile(fsys, "/big.bin", content, 0644))
+
+	got, err := afero.ReadFile(fsys, "/big.bin")
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(content, got))
+}
+
+func TestFSStat(t *testing.T) {
+	fsys := newTestFS(t)
+
+	require.NoError(t, fsys.MkdirAll("/d", 0755))
+	require.NoError(t, afero.WriteFile(fsys, "/d/f", []byte("12345"), 0644))
+
+	fi, err := fsys.Stat("/d/f")
+	require.NoError(t, err)
+	assert.Equal(t, "f", fi.Name(), "Name is the final component, not the full path")
+	assert.Equal(t, int64(5), fi.Size())
+	assert.False(t, fi.IsDir())
+	assert.False(t, fi.ModTime().IsZero())
+
+	di, err := fsys.Stat("/d")
+	require.NoError(t, err)
+	assert.True(t, di.IsDir())
+	assert.True(t, di.Mode().IsDir())
+}
+
+// TestFSStatErrorsAreRecognizable matters because the WebDAV handler and afero
+// both branch on os.IsNotExist and errors.Is against the fs sentinels.
+func TestFSStatErrorsAreRecognizable(t *testing.T) {
+	fsys := newTestFS(t)
+
+	_, err := fsys.Stat("/nope")
+	require.Error(t, err)
+	assert.True(t, os.IsNotExist(err), "os.IsNotExist must recognize the error")
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+
+	var pathErr *os.PathError
+	assert.ErrorAs(t, err, &pathErr, "errors are wrapped as *os.PathError")
+	assert.Equal(t, "stat", pathErr.Op)
+	assert.Equal(t, "/nope", pathErr.Path)
+}
+
+// TestFSETag checks the webdav.ETager contract: objects advertise their
+// generation, directories defer to the handler's default.
+func TestFSETag(t *testing.T) {
+	fsys := newTestFS(t)
+
+	require.NoError(t, afero.WriteFile(fsys, "/obj", []byte("x"), 0644))
+	fi, err := fsys.Stat("/obj")
+	require.NoError(t, err)
+
+	tagger, ok := fi.(webdav.ETager)
+	require.True(t, ok, "FileInfo must implement webdav.ETager")
+
+	tag, err := tagger.ETag(t.Context())
+	require.NoError(t, err)
+	assert.NotEmpty(t, tag)
+	assert.True(t, bytes.HasPrefix([]byte(tag), []byte(`"`)), "a strong ETag is quoted")
+
+	// A new version must produce a new tag.
+	require.NoError(t, afero.WriteFile(fsys, "/obj", []byte("y"), 0644))
+	fi2, err := fsys.Stat("/obj")
+	require.NoError(t, err)
+	tag2, err := fi2.(webdav.ETager).ETag(t.Context())
+	require.NoError(t, err)
+	assert.NotEqual(t, tag, tag2)
+
+	require.NoError(t, fsys.Mkdir("/dir", 0755))
+	di, err := fsys.Stat("/dir")
+	require.NoError(t, err)
+	_, err = di.(webdav.ETager).ETag(t.Context())
+	assert.ErrorIs(t, err, webdav.ErrNotImplemented,
+		"a directory falls back to the handler's default tag")
+}
+
+// TestFSReaddirContract pins the os.File semantics the WebDAV layer relies on:
+// a positive count paginates and ends in io.EOF, count <= 0 drains.
+func TestFSReaddirContract(t *testing.T) {
+	fsys := newTestFS(t)
+
+	require.NoError(t, fsys.MkdirAll("/d/sub", 0755))
+	for _, n := range []string{"a", "b", "c"} {
+		require.NoError(t, afero.WriteFile(fsys, "/d/"+n, []byte(n), 0644))
+	}
+
+	t.Run("paginated", func(t *testing.T) {
+		f, err := fsys.Open("/d")
+		require.NoError(t, err)
+		defer f.Close()
+
+		var names []string
+		for {
+			batch, rErr := f.Readdir(2)
+			if rErr == io.EOF {
+				break
+			}
+			require.NoError(t, rErr)
+			for _, fi := range batch {
+				names = append(names, fi.Name())
+			}
+		}
+		assert.Equal(t, []string{"a", "b", "c", "sub"}, names, "sorted, all entries, once each")
+	})
+
+	t.Run("drain", func(t *testing.T) {
+		f, err := fsys.Open("/d")
+		require.NoError(t, err)
+		defer f.Close()
+
+		all, err := f.Readdir(-1)
+		require.NoError(t, err)
+		require.Len(t, all, 4)
+		assert.Equal(t, "sub", all[3].Name())
+		assert.True(t, all[3].IsDir())
+	})
+}
+
+// TestFSReadDirViaAfero exercises the helper the origin's adapter actually
+// calls (origin_serve/filesystem.go uses afero.ReadDir).
+func TestFSReadDirViaAfero(t *testing.T) {
+	fsys := newTestFS(t)
+
+	require.NoError(t, fsys.Mkdir("/d", 0755))
+	for _, n := range []string{"z", "a", "m"} {
+		require.NoError(t, afero.WriteFile(fsys, "/d/"+n, []byte(n), 0644))
+	}
+
+	infos, err := afero.ReadDir(fsys, "/d")
+	require.NoError(t, err)
+	names := make([]string, len(infos))
+	for i, fi := range infos {
+		names[i] = fi.Name()
+	}
+	assert.Equal(t, []string{"a", "m", "z"}, names)
+}
+
+func TestFSReaddirOnFileFails(t *testing.T) {
+	fsys := newTestFS(t)
+
+	require.NoError(t, afero.WriteFile(fsys, "/f", []byte("x"), 0644))
+	f, err := fsys.Open("/f")
+	require.NoError(t, err)
+	defer f.Close()
+
+	_, err = f.Readdir(-1)
+	assert.Error(t, err)
+}
+
+func TestFSWalk(t *testing.T) {
+	fsys := newTestFS(t)
+
+	require.NoError(t, fsys.MkdirAll("/tree/a/b", 0755))
+	require.NoError(t, afero.WriteFile(fsys, "/tree/f1", []byte("1"), 0644))
+	require.NoError(t, afero.WriteFile(fsys, "/tree/a/b/f2", []byte("2"), 0644))
+
+	// Walked here rather than with afero.Walk, which builds child paths with
+	// filepath.Join and so hands a backslash-separated path to a namespace
+	// that only knows "/".  The origin's adapter joins with path.Join, so
+	// production never takes that route.
+	var seen []string
+	var walk func(string)
+	walk = func(dir string) {
+		seen = append(seen, dir)
+		entries, err := afero.ReadDir(fsys, dir)
+		require.NoError(t, err)
+		for _, e := range entries {
+			child := dir + "/" + e.Name()
+			if dir == "/" {
+				child = "/" + e.Name()
+			}
+			if e.IsDir() {
+				walk(child)
+				continue
+			}
+			seen = append(seen, child)
+		}
+	}
+	walk("/tree")
+
+	assert.Equal(t, []string{"/tree", "/tree/a", "/tree/a/b", "/tree/a/b/f2", "/tree/f1"}, seen)
+}
+
+func TestFSSeekAndReadAt(t *testing.T) {
+	fsys := newTestFS(t)
+
+	content := []byte("0123456789")
+	require.NoError(t, afero.WriteFile(fsys, "/f", content, 0644))
+
+	f, err := fsys.Open("/f")
+	require.NoError(t, err)
+	defer f.Close()
+
+	off, err := f.Seek(4, io.SeekStart)
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), off)
+
+	rest, err := io.ReadAll(f)
+	require.NoError(t, err)
+	assert.Equal(t, "456789", string(rest))
+
+	buf := make([]byte, 3)
+	n, err := f.ReadAt(buf, 2)
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+	assert.Equal(t, "234", string(buf))
+}
+
+// TestFSOpenFileExclusive covers O_CREATE|O_EXCL, which maps onto the store's
+// create-only precondition.
+func TestFSOpenFileExclusive(t *testing.T) {
+	fsys := newTestFS(t)
+
+	f, err := fsys.OpenFile("/excl", os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	require.NoError(t, err)
+	_, err = f.Write([]byte("first"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	f2, err := fsys.OpenFile("/excl", os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	require.NoError(t, err, "the conflict surfaces at Close, when the swap is attempted")
+	_, err = f2.Write([]byte("second"))
+	require.NoError(t, err)
+	assert.ErrorIs(t, f2.Close(), fs.ErrExist)
+
+	got, err := afero.ReadFile(fsys, "/excl")
+	require.NoError(t, err)
+	assert.Equal(t, "first", string(got))
+}
+
+// TestFSUnsupportedOperations documents the POSIX surface pstore declines,
+// rather than pretending to implement it.
+func TestFSUnsupportedOperations(t *testing.T) {
+	fsys := newTestFS(t)
+
+	require.NoError(t, afero.WriteFile(fsys, "/f", []byte("x"), 0644))
+
+	assert.Error(t, fsys.Chmod("/f", 0600))
+	assert.Error(t, fsys.Chown("/f", 0, 0))
+
+	_, err := fsys.OpenFile("/f", os.O_WRONLY|os.O_APPEND, 0644)
+	assert.Error(t, err, "appending would require rewriting the object")
+
+	f, err := fsys.Create("/g")
+	require.NoError(t, err)
+	defer f.Close()
+	_, err = f.WriteAt([]byte("x"), 5)
+	assert.Error(t, err, "objects are written sequentially")
+	_, err = f.Seek(0, io.SeekStart)
+	assert.Error(t, err, "seeking a write handle would imply a partial update")
+	assert.Error(t, f.Truncate(10), "truncating to a nonzero length is a partial update")
+}
+
+func TestFSRemoveAndRename(t *testing.T) {
+	fsys := newTestFS(t)
+
+	require.NoError(t, fsys.MkdirAll("/a/b", 0755))
+	require.NoError(t, afero.WriteFile(fsys, "/a/b/f", []byte("data"), 0644))
+
+	require.NoError(t, fsys.Rename("/a/b/f", "/a/moved"))
+	got, err := afero.ReadFile(fsys, "/a/moved")
+	require.NoError(t, err)
+	assert.Equal(t, "data", string(got))
+
+	require.NoError(t, fsys.Remove("/a/moved"))
+	exists, err := afero.Exists(fsys, "/a/moved")
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	require.NoError(t, fsys.RemoveAll("/a"))
+	exists, err = afero.Exists(fsys, "/a")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestFSRenameErrorIsLinkError(t *testing.T) {
+	fsys := newTestFS(t)
+
+	err := fsys.Rename("/missing", "/dest")
+	require.Error(t, err)
+	var linkErr *os.LinkError
+	assert.ErrorAs(t, err, &linkErr)
+	assert.Equal(t, "rename", linkErr.Op)
+}
+
+// TestFSDirectoryWriteConflict covers the case the origin's adapter has a
+// specific workaround for: a PUT aimed at an existing collection.
+func TestFSDirectoryWriteConflict(t *testing.T) {
+	fsys := newTestFS(t)
+
+	require.NoError(t, fsys.Mkdir("/d", 0755))
+	_, err := fsys.Create("/d")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrIsDir)
+}
+
+// TestFSStatOnOpenWriteHandle pins the behavior that webdav.handlePut
+// depends on: it calls Stat between the last Write and Close.
+//
+// Under commit-at-close the object is not at its path yet, so consulting the
+// namespace here fails -- and the handler turns any stat error into 405
+// Method Not Allowed, which makes every create look like an unsupported
+// method. An os.File stats the open file rather than the path; so must this.
+func TestFSStatOnOpenWriteHandle(t *testing.T) {
+	fsys := newTestFS(t)
+
+	f, err := fsys.Create("/pending.txt")
+	require.NoError(t, err)
+
+	_, err = f.Write([]byte("twelve bytes"))
+	require.NoError(t, err)
+
+	// The path does not resolve yet...
+	_, err = fsys.Stat("/pending.txt")
+	assert.True(t, os.IsNotExist(err), "the object is not installed until Close")
+
+	// ...but the handle still describes what is being written.
+	fi, err := f.Stat()
+	require.NoError(t, err, "stat on an open write handle must not consult the namespace")
+	assert.Equal(t, int64(12), fi.Size())
+	assert.False(t, fi.IsDir())
+	assert.Equal(t, "pending.txt", fi.Name())
+
+	require.NoError(t, f.Close())
+
+	after, err := fsys.Stat("/pending.txt")
+	require.NoError(t, err)
+	assert.Equal(t, int64(12), after.Size())
+}
+
+// TestFSStatOnOverwriteHandleShowsPendingVersion is the same hazard for an
+// overwrite: the path resolves, but to the *old* version, so reporting it
+// would tell the handler the wrong size for the object it just wrote.
+func TestFSStatOnOverwriteHandleShowsPendingVersion(t *testing.T) {
+	fsys := newTestFS(t)
+
+	require.NoError(t, afero.WriteFile(fsys, "/obj.txt", []byte("original-content"), 0644))
+
+	f, err := fsys.Create("/obj.txt")
+	require.NoError(t, err)
+	_, err = f.Write([]byte("new"))
+	require.NoError(t, err)
+
+	fi, err := f.Stat()
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), fi.Size(), "the handle reports the pending version, not the old one")
+
+	require.NoError(t, f.Close())
+}
+
+// TestFSTruncateCreatesEmptyFile covers the one truncate that is meaningful
+// here.  Several ordinary paths create a zero-length file by truncating a
+// freshly opened handle, and a pending write is already empty, so this costs
+// nothing and avoids failing writes that should obviously work.
+func TestFSTruncateCreatesEmptyFile(t *testing.T) {
+	fsys := newTestFS(t)
+
+	f, err := fsys.Create("/empty.txt")
+	require.NoError(t, err)
+	require.NoError(t, f.Truncate(0), "truncating an unwritten handle to zero is allowed")
+	require.NoError(t, f.Close())
+
+	fi, err := fsys.Stat("/empty.txt")
+	require.NoError(t, err)
+	assert.Zero(t, fi.Size())
+
+	// afero.WriteFile with empty content goes through this path.
+	require.NoError(t, afero.WriteFile(fsys, "/empty2.txt", nil, 0644))
+	fi2, err := fsys.Stat("/empty2.txt")
+	require.NoError(t, err)
+	assert.Zero(t, fi2.Size())
+}
+
+func TestFSTruncateAfterWriteIsRefused(t *testing.T) {
+	fsys := newTestFS(t)
+
+	f, err := fsys.Create("/written.txt")
+	require.NoError(t, err)
+	defer f.Close()
+	_, err = f.Write([]byte("content"))
+	require.NoError(t, err)
+
+	assert.Error(t, f.Truncate(0),
+		"discarding bytes already written would be a partial update")
+}
+
+// TestFSReaddirPaginatesWithoutBuffering is the property that matters for
+// large directories: each page is served from the index, so a caller reading
+// the first page of a 100k-entry directory does not pay for the other 99k.
+func TestFSReaddirPaginatesWithoutBuffering(t *testing.T) {
+	fsys := newTestFS(t)
+
+	require.NoError(t, fsys.Mkdir("/big", 0755))
+	const total = 250
+	for i := range total {
+		name := fmt.Sprintf("/big/f%04d", i)
+		require.NoError(t, afero.WriteFile(fsys, name, []byte("x"), 0644))
+	}
+
+	f, err := fsys.Open("/big")
+	require.NoError(t, err)
+	defer f.Close()
+
+	var names []string
+	pages := 0
+	for {
+		batch, rErr := f.Readdir(40)
+		if rErr == io.EOF {
+			break
+		}
+		require.NoError(t, rErr)
+		require.NotEmpty(t, batch, "a non-EOF page must not be empty")
+		pages++
+		for _, fi := range batch {
+			names = append(names, fi.Name())
+		}
+	}
+
+	require.Len(t, names, total, "every entry is returned exactly once")
+	assert.Greater(t, pages, 1, "a directory this size takes several pages")
+	assert.True(t, sort.StringsAreSorted(names), "pages continue in name order")
+	assert.Equal(t, "f0000", names[0])
+	assert.Equal(t, "f0249", names[total-1])
+}
+
+// TestFSReaddirDrainAfterPartialPage checks that count <= 0 resumes from the
+// cursor rather than restarting, which is what os.File does.
+func TestFSReaddirDrainAfterPartialPage(t *testing.T) {
+	fsys := newTestFS(t)
+
+	require.NoError(t, fsys.Mkdir("/d", 0755))
+	for _, n := range []string{"a", "b", "c", "d", "e"} {
+		require.NoError(t, afero.WriteFile(fsys, "/d/"+n, []byte(n), 0644))
+	}
+
+	f, err := fsys.Open("/d")
+	require.NoError(t, err)
+	defer f.Close()
+
+	first, err := f.Readdir(2)
+	require.NoError(t, err)
+	require.Len(t, first, 2)
+
+	rest, err := f.Readdir(-1)
+	require.NoError(t, err)
+	assert.Len(t, rest, 3, "the drain returns only what is left")
+	assert.Equal(t, "c", rest[0].Name())
+
+	_, err = f.Readdir(1)
+	assert.ErrorIs(t, err, io.EOF, "the handle is exhausted")
+}
+
+// TestFSReaddirEmptyDirectory pins the EOF behavior for a directory with no
+// entries, which the paginated path has to get right on the first call.
+func TestFSReaddirEmptyDirectory(t *testing.T) {
+	fsys := newTestFS(t)
+	require.NoError(t, fsys.Mkdir("/empty", 0755))
+
+	f, err := fsys.Open("/empty")
+	require.NoError(t, err)
+	defer f.Close()
+
+	all, err := f.Readdir(-1)
+	require.NoError(t, err)
+	assert.Empty(t, all)
+
+	f2, err := fsys.Open("/empty")
+	require.NoError(t, err)
+	defer f2.Close()
+	_, err = f2.Readdir(10)
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+// TestFSCreateParentsUsesNamespaceSeparator guards the other half of the same
+// class of bug.  A pstore path is a namespace path and is always
+// slash-separated, whatever the host filesystem uses, so deriving a parent
+// with filepath would ask for a directory named "\a\b\c" on Windows and
+// quietly fail every upload into a fresh prefix.
+func TestFSCreateParentsUsesNamespaceSeparator(t *testing.T) {
+	fsys := newTestFS(t)
+
+	require.NoError(t, afero.WriteFile(fsys, "/a/b/c/deep.txt", []byte("deep"), 0644))
+
+	// Each level exists as a real directory, not one literally named "a/b/c".
+	for _, dir := range []string{"/a", "/a/b", "/a/b/c"} {
+		fi, err := fsys.Stat(dir)
+		require.NoError(t, err, "%s should have been created", dir)
+		assert.True(t, fi.IsDir())
+	}
+
+	entries, err := afero.ReadDir(fsys, "/")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "a", entries[0].Name(),
+		"the root holds one directory, not a single oddly-named entry")
+
+	got, err := afero.ReadFile(fsys, "/a/b/c/deep.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "deep", string(got))
+}
+
+// TestFSReaddirDrainAfterExhaustion pins the os.File contract for a
+// non-positive count.
+//
+// The dirDone short-circuit has to sit below the count<=0 branch. Above it, a
+// handle that paginated calls had already drained would answer a "give me the
+// rest" call with io.EOF, and os.File never does that: n <= 0 returns whatever
+// remains -- possibly nothing -- and a nil error. Callers that treat io.EOF as
+// a failure (afero.Walk among them) would see a spurious error at the end of
+// every directory they happened to read that way.
+func TestFSReaddirDrainAfterExhaustion(t *testing.T) {
+	fsys := newTestFS(t)
+
+	require.NoError(t, fsys.Mkdir("/d", 0755))
+	for _, n := range []string{"a", "b"} {
+		require.NoError(t, afero.WriteFile(fsys, "/d/"+n, []byte(n), 0644))
+	}
+
+	f, err := fsys.Open("/d")
+	require.NoError(t, err)
+	defer f.Close()
+
+	page, err := f.Readdir(2)
+	require.NoError(t, err)
+	require.Len(t, page, 2, "the paginated call drains the directory")
+
+	rest, err := f.Readdir(-1)
+	assert.NoError(t, err, "a non-positive count returns the remainder, never io.EOF")
+	assert.Empty(t, rest)
+
+	// A second drain is just as harmless, and a positive count still reports
+	// exhaustion the way os.File does.
+	rest, err = f.Readdir(0)
+	assert.NoError(t, err)
+	assert.Empty(t, rest)
+	_, err = f.Readdir(1)
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+// TestFSAbortedWriteLeavesPreviousVersionIntact is the data-loss guarantee.
+//
+// golang.org/x/net/webdav's handlePut closes the file before it examines the
+// error from io.Copy, and a pstore Close installs whatever bytes arrived. A
+// client that disconnected halfway through an overwrite therefore replaced a
+// complete object with a fragment. AbortWrite is how the layer that sees the
+// failure tells the handle not to commit.
+func TestFSAbortedWriteLeavesPreviousVersionIntact(t *testing.T) {
+	fsys := newTestFS(t)
+
+	const original = "THE COMPLETE ORIGINAL OBJECT"
+	require.NoError(t, afero.WriteFile(fsys, "/obj", []byte(original), 0644))
+	before, err := fsys.Stat("/obj")
+	require.NoError(t, err)
+
+	f, err := fsys.OpenFile("/obj", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	require.NoError(t, err)
+	_, err = f.Write([]byte("PARTIAL"))
+	require.NoError(t, err)
+
+	aborter, ok := f.(interface{ AbortWrite(error) })
+	require.True(t, ok, "a pstore write handle must be abortable")
+	aborter.AbortWrite(errors.New("the client went away"))
+
+	err = f.Close()
+	require.Error(t, err, "Close must report the failure rather than commit a fragment")
+	assert.Contains(t, err.Error(), "the client went away")
+
+	got, err := afero.ReadFile(fsys, "/obj")
+	require.NoError(t, err)
+	assert.Equal(t, original, string(got), "the previous version's bytes must survive")
+
+	after, err := fsys.Stat("/obj")
+	require.NoError(t, err)
+	assert.Equal(t, before.Sys().(*Dirent).Generation, after.Sys().(*Dirent).Generation,
+		"and its generation, so a client's ETag is still valid")
+}
+
+// TestFSAbortedCreateLeavesNothingBehind covers the same path for a create
+// rather than an overwrite: the object must not appear at all.
+func TestFSAbortedCreateLeavesNothingBehind(t *testing.T) {
+	fsys := newTestFS(t)
+
+	f, err := fsys.Create("/fresh")
+	require.NoError(t, err)
+	_, err = f.Write([]byte("PARTIAL"))
+	require.NoError(t, err)
+	f.(interface{ AbortWrite(error) }).AbortWrite(errors.New("truncated upload"))
+	require.Error(t, f.Close())
+
+	_, err = fsys.Stat("/fresh")
+	assert.True(t, os.IsNotExist(err), "an aborted create must not become visible")
+}
+
+// TestFSFailedWriteIsSticky covers the case AbortWrite cannot see: the write
+// itself was refused, and Close runs anyway because webdav calls it before it
+// looks at the copy error.
+func TestFSFailedWriteIsSticky(t *testing.T) {
+	fsys := newTestFS(t)
+
+	const original = "v1 complete"
+	require.NoError(t, afero.WriteFile(fsys, "/obj", []byte(original), 0644))
+
+	f, err := fsys.OpenFile("/obj", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	require.NoError(t, err)
+	_, err = f.Write([]byte("some bytes"))
+	require.NoError(t, err)
+
+	// WriteAt is always refused, which stands in for any mid-stream write
+	// failure (an out-of-space store, a block-layer error).
+	_, err = f.WriteAt([]byte("at an offset"), 4)
+	require.Error(t, err)
+
+	require.Error(t, f.Close(), "a handle whose write failed must not commit")
+
+	got, err := afero.ReadFile(fsys, "/obj")
+	require.NoError(t, err)
+	assert.Equal(t, original, string(got))
+}
+
+// TestFSOpenFileConditional covers the store-side of a conditional write,
+// which the origin reaches through origin_serve's ConditionalWriteFs.
+func TestFSOpenFileConditional(t *testing.T) {
+	fsys := newTestFS(t)
+
+	t.Run("require absent", func(t *testing.T) {
+		f, err := fsys.OpenFileConditional("/create-only", os.O_WRONLY|os.O_CREATE, 0644, -1, true, "")
+		require.NoError(t, err)
+		_, err = f.Write([]byte("first"))
+		require.NoError(t, err)
+		require.NoError(t, f.Close(), "the first create-only write wins")
+
+		f2, err := fsys.OpenFileConditional("/create-only", os.O_WRONLY|os.O_CREATE, 0644, -1, true, "")
+		require.NoError(t, err, "the condition is evaluated at commit, not at open")
+		_, err = f2.Write([]byte("second"))
+		require.NoError(t, err)
+		assert.ErrorIs(t, f2.Close(), ErrExist)
+
+		got, err := afero.ReadFile(fsys, "/create-only")
+		require.NoError(t, err)
+		assert.Equal(t, "first", string(got))
+	})
+
+	t.Run("require generation", func(t *testing.T) {
+		require.NoError(t, afero.WriteFile(fsys, "/cas", []byte("v1"), 0644))
+		info, err := fsys.Stat("/cas")
+		require.NoError(t, err)
+		tag, err := info.(webdav.ETager).ETag(context.Background())
+		require.NoError(t, err)
+
+		// Open against the tag we just read, then let someone else win.
+		f, err := fsys.OpenFileConditional("/cas", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644, -1, false, tag)
+		require.NoError(t, err)
+		_, err = f.Write([]byte("v3"))
+		require.NoError(t, err)
+		require.NoError(t, afero.WriteFile(fsys, "/cas", []byte("v2"), 0644))
+
+		assert.ErrorIs(t, f.Close(), ErrPreconditionFailed)
+
+		got, err := afero.ReadFile(fsys, "/cas")
+		require.NoError(t, err)
+		assert.Equal(t, "v2", string(got), "the losing write installs nothing")
+	})
+
+	t.Run("matching generation commits", func(t *testing.T) {
+		require.NoError(t, afero.WriteFile(fsys, "/cas2", []byte("v1"), 0644))
+		info, err := fsys.Stat("/cas2")
+		require.NoError(t, err)
+		tag, err := info.(webdav.ETager).ETag(context.Background())
+		require.NoError(t, err)
+
+		f, err := fsys.OpenFileConditional("/cas2", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644, -1, false, tag)
+		require.NoError(t, err)
+		_, err = f.Write([]byte("v2"))
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		got, err := afero.ReadFile(fsys, "/cas2")
+		require.NoError(t, err)
+		assert.Equal(t, "v2", string(got))
+	})
+}
+
+// TestGenerationFromETag pins the tag-to-generation unwrapping, including the
+// weak prefix a proxy may add.
+func TestGenerationFromETag(t *testing.T) {
+	assert.Equal(t, "abc123", generationFromETag(`"abc123"`))
+	assert.Equal(t, "abc123", generationFromETag(`W/"abc123"`))
+	assert.Equal(t, "abc123", generationFromETag(`  "abc123" `))
+	assert.Equal(t, "abc123", generationFromETag(`abc123`))
+	assert.Empty(t, generationFromETag(""))
+	assert.Equal(t, "gen", generationFromETag(etagFor("gen")))
+}

--- a/pstore/fsck.go
+++ b/pstore/fsck.go
@@ -1,0 +1,1121 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Consistency checking.
+//
+// fsck is a backstop, not a load-bearing part of correctness.  Every mutation
+// that makes data unreachable also queues it for reclamation in the same
+// transaction, so space cannot leak unless the janitor never runs.  What fsck
+// catches is the residue of bugs, interrupted upgrades, and operator surgery:
+// entries pointing at metadata that is gone, metadata no longer reachable from
+// any entry, and usage counters that have drifted.
+//
+// It walks the index rather than the storage directories, so it is bounded by
+// the number of objects rather than by their size, and it reports before it
+// repairs.
+//
+// Two properties matter more than they look, because this runs on a schedule
+// against stores holding millions of objects:
+//
+//   - No pass holds a read transaction open across the whole catalog.  Every
+//     scan here is batched and resumable, so BadgerDB's read watermark
+//     advances and value-log GC is never blocked for the length of a check.
+//   - The one comparison that needs a set in memory -- object versions no
+//     entry refers to -- is partitioned over the instance-hash space, so peak
+//     memory is bounded by a budget rather than by the object count.  It needs
+//     a set because the two sides are ordered differently: the versions in
+//     question are discovered by walking the index, which is ordered by path,
+//     while the metadata they are compared against is ordered by instance
+//     hash, an HMAC with no relation to the path.  Where two sides *are*
+//     ordered alike -- the reclamation queue and the metadata scan, both keyed
+//     by instance hash -- they are merged instead, and cost no memory at all.
+//     See queuedCursor.
+//
+// And one rule that matters more than either: nothing here treats a write
+// that is still in flight as garbage.  An object that has been written but
+// whose directory entry has not landed yet is indistinguishable, in the
+// catalog, from the residue of a crash.  Reclaiming it would destroy a live
+// upload, so instances are only reported as orphans once they have been
+// complete for longer than a grace period and carry no in-flight marker.
+
+package pstore
+
+import (
+	"context"
+	"encoding/hex"
+	"strings"
+	"time"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/pkg/errors"
+
+	"github.com/pelicanplatform/pelican/local_cache"
+	"github.com/pelicanplatform/pelican/metrics"
+)
+
+// reachableKey is the map key for the reachable-version set: the first 16
+// bytes of an instance hash, decoded from its hex spelling.
+//
+// The set is large -- one entry per live version in the shard -- and the hash
+// is a 64-character hex string, so the string key costs about 117 bytes per
+// entry against 36 for a fixed-size array. At the budget below that is the
+// difference between roughly 235 MiB and 72 MiB of resident memory for a
+// scheduled backstop.
+//
+// Truncating to 128 bits is safe *in this direction specifically*, which is
+// worth stating because the tool deletes data. The set is consulted as "in the
+// set means leave it alone": a hash found here is skipped and never becomes a
+// reclamation candidate. So a collision can only make an orphan look reachable
+// and be passed over -- space that is not reclaimed until the next run with a
+// different shard boundary. It can never do the reverse, because truncation is
+// deterministic: every genuinely reachable hash puts its own prefix in the set,
+// so a live version can never be missing from it and can never be reclaimed.
+// The probability is negligible regardless -- about 2^-87 across the whole
+// budget -- but the asymmetry is what makes it acceptable rather than the odds.
+type reachableKey [16]byte
+
+// truncateHash builds the map key. A hash that is not the expected hex
+// spelling cannot be truncated meaningfully, so it falls back to copying the
+// raw bytes: a malformed hash is fsck's business to report, not to silently
+// alias onto another entry.
+func truncateHash(hash local_cache.InstanceHash) reachableKey {
+	var k reachableKey
+	if n, err := hex.Decode(k[:], []byte(hash)[:min(len(hash), 2*len(k))]); err == nil && n == len(k) {
+		return k
+	}
+	copy(k[:], hash)
+	return k
+}
+
+const (
+	// fsckBatchSize bounds how many keys a single read transaction covers.
+	// Every scan below reopens a transaction per batch and resumes from the
+	// last key, so no pass pins BadgerDB's read watermark for its duration.
+	fsckBatchSize = 4096
+
+	// fsckReachableBudget bounds how many instance hashes one pass keeps in
+	// memory while looking for orphans.  Above it the comparison is split
+	// across slices of the instance-hash space, trading repeated index walks
+	// for a memory ceiling -- the walk is over the catalog, which is small
+	// against the data, while an unbounded map is not.
+	fsckReachableBudget = 2 << 20
+
+	// fsckMaxShardWidth caps the partitioning at 256 slices (two hex digits),
+	// so an enormous store degrades in scan time rather than in memory.
+	fsckMaxShardWidth = 2
+
+	// fsckDefaultMinAge is how long an unreferenced object version must have
+	// been complete before it is called an orphan.
+	//
+	// The window is real: Create writes the object's metadata and blocks and
+	// only then commits the directory entry, so between those two an entirely
+	// healthy upload has metadata that no entry points at.  Without a grace
+	// period `fsck --repair` would queue a live write for reclamation.  The
+	// cache's own checker takes the same precaution for the same reason.
+	fsckDefaultMinAge = 5 * time.Minute
+)
+
+// errFsckBatchFull unwinds a batched scan once its batch is full.
+var errFsckBatchFull = errors.New("fsck batch full")
+
+// FsckReport summarizes a consistency pass.
+type FsckReport struct {
+	// EntriesScanned is how many index entries were examined.
+	EntriesScanned int
+	// DirectoriesScanned is how many of those were directories.
+	DirectoriesScanned int
+
+	// DanglingEntries are files whose object version has no metadata.  The
+	// entry is unreadable, so it is reported and, when repairing, removed.
+	DanglingEntries []string
+	// MissingData are objects whose metadata exists but whose blocks are
+	// incomplete, meaning a write was interrupted before it committed.
+	MissingData []string
+	// OrphanedInstances are object versions no entry refers to, which have
+	// been complete for longer than the grace period.  They hold space and
+	// are queued for reclamation when repairing.
+	OrphanedInstances []string
+	// PendingInstances are object versions no entry refers to *yet*: a write
+	// that has not completed, or one that completed within the grace period.
+	//
+	// These are reported for visibility and never repaired.  A live upload
+	// looks exactly like a crash-window orphan from the catalog's point of
+	// view, and reclaiming one would delete an object out from under the
+	// client still writing it.  Reclamation of writes that really were
+	// abandoned belongs to the append-intent sweep, which can tell the
+	// difference.
+	PendingInstances []string
+	// CorruptObjects are objects whose stored data no longer matches the
+	// checksums recorded when they were written.  Only populated by a deep
+	// pass.
+	CorruptObjects []string
+	// ObjectsVerified counts the objects a deep pass read back.
+	ObjectsVerified int
+
+	// UsageDrift is the difference, per storage directory, between the
+	// catalog's recorded usage and what the objects actually occupy.
+	UsageDrift map[local_cache.StorageID]int64
+
+	// OrphanScanPartial reports that the orphan comparison covered only a
+	// slice of the instance-hash space, so its findings are not exhaustive.
+	OrphanScanPartial bool
+	// OrphanScanShards is how many slices the space was divided into, which
+	// is the number of passes a caller must rotate through for full coverage.
+	//
+	// It can exceed what the caller asked for: the slices are hex prefixes of
+	// the instance hash, so a request is rounded up to a power of sixteen.  A
+	// caller that rotates over its own number instead of this one would leave
+	// most of the store permanently unexamined.
+	OrphanScanShards int
+
+	// Repaired reports whether a repair pass ran.  It says nothing about
+	// whether every finding was resolved -- see Resolved and Unresolved.
+	Repaired bool
+	// UsageResynced reports that the drift above was written back to the
+	// catalog, not merely recomputed in memory.
+	UsageResynced bool
+}
+
+// Healthy reports whether the pass found nothing wrong.
+//
+// Pending instances are deliberately excluded: a write in flight is what a
+// busy origin looks like, not a fault.
+func (r *FsckReport) Healthy() bool {
+	return len(r.DanglingEntries) == 0 &&
+		len(r.MissingData) == 0 &&
+		len(r.OrphanedInstances) == 0 &&
+		len(r.CorruptObjects) == 0 &&
+		len(r.UsageDrift) == 0
+}
+
+// Resolved lists what a repair pass actually acted on.
+//
+// This exists because the two lists are not the same and reporting them as
+// though they were is how an operator comes to believe a store was fixed.
+// Repair can unlink an unreadable entry, queue an unreferenced version, and
+// rewrite a drifted counter.  It cannot manufacture data that is gone, and it
+// cannot un-corrupt a block.
+func (r *FsckReport) Resolved() []string {
+	if !r.Repaired {
+		return nil
+	}
+	var out []string
+	if len(r.DanglingEntries) > 0 {
+		out = append(out, "Entries whose object data is missing (removed)")
+	}
+	if len(r.OrphanedInstances) > 0 {
+		out = append(out, "Object versions no entry refers to (queued for reclamation)")
+	}
+	if r.UsageResynced && len(r.UsageDrift) > 0 {
+		out = append(out, "Usage counter drift (rewritten from the catalog)")
+	}
+	return out
+}
+
+// Unresolved lists findings that survive a repair pass, so a caller can exit
+// non-zero rather than reporting success.
+func (r *FsckReport) Unresolved() []string {
+	var out []string
+	add := func(cond bool, label string) {
+		if cond {
+			out = append(out, label)
+		}
+	}
+	if r.Repaired {
+		// Repair unlinks dangling entries and queues orphans, so those are
+		// gone.  These two it cannot touch: data that was never written
+		// cannot be conjured, and a block that no longer matches its checksum
+		// needs a decision -- restore, re-ingest, or accept the loss -- that
+		// belongs to an operator.
+		add(!r.UsageResynced && len(r.UsageDrift) > 0, "Usage counter drift")
+	} else {
+		add(len(r.DanglingEntries) > 0, "Entries whose object data is missing")
+		add(len(r.OrphanedInstances) > 0, "Object versions no entry refers to")
+		add(len(r.UsageDrift) > 0, "Usage counter drift")
+	}
+	add(len(r.MissingData) > 0, "Writes that never completed")
+	add(len(r.CorruptObjects) > 0, "Objects whose data no longer matches its checksums")
+	return out
+}
+
+// Fsck checks the store's internal consistency.
+//
+// When repair is false nothing is modified, which is the mode an operator
+// should reach for first.  When true, dangling entries are removed, orphaned
+// versions are queued for reclamation, and usage counters are resynced from
+// the catalog.
+func (s *Store) Fsck(ctx context.Context, repair bool) (*FsckReport, error) {
+	return s.FsckWith(ctx, FsckOptions{Repair: repair})
+}
+
+// FsckOptions selects what a consistency pass checks.
+type FsckOptions struct {
+	// Repair acts on what the pass finds rather than only reporting it.
+	Repair bool
+	// Deep additionally reads every object back and verifies it against the
+	// checksums recorded at ingest.
+	//
+	// This is the only check that detects at-rest corruption -- a flipped bit
+	// in a block file, or a truncated chunk -- because everything else reads
+	// only the catalog.  It costs a full pass over the data, so it is off by
+	// default and belongs on a schedule rather than in a routine check.
+	Deep bool
+
+	// SkipOrphanScan omits the search for object versions no entry refers to.
+	//
+	// That search is the only part of a pass whose cost is not streaming: it
+	// must hold the set of referenced versions while it scans the catalog.
+	// Everything else -- unreadable entries, interrupted writes, counter
+	// drift -- is a streaming check.  A frequent background pass therefore
+	// skips it, or covers one slice at a time; an operator running fsck by
+	// hand wants the whole answer and gets it.
+	SkipOrphanScan bool
+
+	// OrphanShardOf, when greater than one, splits the orphan comparison into
+	// that many slices of the instance-hash space and examines only
+	// OrphanShard.  Rotating the slice across successive passes gives full
+	// coverage over time at a fraction of the memory.
+	//
+	// It is rounded up to a power of sixteen, because the slices are hex
+	// prefixes of the instance hash.  Rotate over FsckReport.OrphanScanShards
+	// rather than over this value: they differ whenever it is not already a
+	// power of sixteen, and rotating over the smaller one would leave most of
+	// the store permanently unexamined.
+	OrphanShardOf int
+	// OrphanShard selects the slice, modulo the effective slice count.
+	OrphanShard int
+
+	// MinAge is how long an unreferenced version must have been complete
+	// before it counts as an orphan rather than a write still in flight.
+	//
+	// Zero selects fsckDefaultMinAge.  The zero value is the safe one on
+	// purpose: a caller that forgets this field gets the grace period, not
+	// the hazard it exists to prevent.  Pass FsckNoGracePeriod to switch it
+	// off, which only a test with no concurrent writers should do.
+	MinAge time.Duration
+}
+
+// FsckNoGracePeriod disables the in-flight-write grace period.
+//
+// Only safe when nothing can be writing to the store -- a test, or an offline
+// pass an operator has taken responsibility for.
+const FsckNoGracePeriod = time.Duration(-1)
+
+// FsckWith checks the store's internal consistency with explicit options.
+func (s *Store) FsckWith(ctx context.Context, opts FsckOptions) (*FsckReport, error) {
+	report := &FsckReport{
+		UsageDrift: make(map[local_cache.StorageID]int64),
+		Repaired:   opts.Repair,
+	}
+	if opts.Repair {
+		// Fail before doing any work rather than after, and do not rely on
+		// BadgerDB's directory lock to be the thing that stops a repair pass
+		// from running against a store someone else is writing.
+		if err := s.checkWritable(); err != nil {
+			return nil, err
+		}
+	}
+
+	minAge := opts.MinAge
+	switch {
+	case minAge == 0:
+		minAge = fsckDefaultMinAge
+	case minAge < 0:
+		minAge = 0
+	}
+
+	// Counter drift first: it is a streaming scan, and its object count is
+	// what sizes the orphan comparison below.
+	actual, objectCount, err := s.footprintByUsageKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+	drift, err := s.usageDrift(actual)
+	if err != nil {
+		return nil, err
+	}
+	for key, d := range drift {
+		if d != 0 {
+			report.UsageDrift[key.StorageID] += d
+		}
+	}
+	for id, d := range report.UsageDrift {
+		if d == 0 {
+			delete(report.UsageDrift, id)
+		}
+	}
+
+	shards := []string{""}
+	if !opts.SkipOrphanScan {
+		shards = fsckShards(objectCount, opts.OrphanShardOf, opts.OrphanShard)
+		if opts.OrphanShardOf > 1 {
+			report.OrphanScanPartial = true
+			report.OrphanScanShards = len(hexPrefixes(hexShardWidth(opts.OrphanShardOf)))
+		} else {
+			report.OrphanScanShards = 1
+		}
+	}
+
+	// Built once: the checker carries rate limiters and metric handles, and a
+	// deep pass would otherwise construct one per object.
+	var checker *local_cache.ConsistencyChecker
+	if opts.Deep {
+		checker = s.consistencyChecker()
+	}
+
+	for i, shard := range shards {
+		// The per-entry checks cover the whole index and do not depend on the
+		// slice, so they run once no matter how many slices the orphan
+		// comparison is split into.
+		entryChecks := i == 0
+
+		reachable := make(map[reachableKey]struct{})
+		if err := s.scanIndexBatched(ctx, func(entryPath string, d *Dirent) error {
+			if entryChecks {
+				report.EntriesScanned++
+				if d.IsDir() {
+					report.DirectoriesScanned++
+					return nil
+				}
+			} else if d.IsDir() {
+				return nil
+			}
+			if d.Generation == "" {
+				if entryChecks {
+					report.DanglingEntries = append(report.DanglingEntries, entryPath)
+				}
+				return nil
+			}
+
+			hash := instanceHashFor(s.db, d.Generation)
+			if !opts.SkipOrphanScan && strings.HasPrefix(string(hash), shard) {
+				reachable[truncateHash(hash)] = struct{}{}
+			}
+			if !entryChecks {
+				return nil
+			}
+
+			meta, mErr := s.db.GetMetadata(hash)
+			if mErr != nil {
+				return errors.Wrapf(mErr, "failed to read metadata for %s", entryPath)
+			}
+			if meta == nil {
+				report.DanglingEntries = append(report.DanglingEntries, entryPath)
+				return nil
+			}
+			// A version whose write never completed is not servable.
+			if meta.Completed.IsZero() {
+				report.MissingData = append(report.MissingData, entryPath)
+				return nil
+			}
+			if opts.Deep {
+				// Verified here rather than collected for later, so a deep
+				// pass over ten million objects does not also build a
+				// ten-million-entry slice of things to do.
+				ok, vErr := checker.VerifyObject(hash)
+				if vErr != nil {
+					// A verification that cannot run is itself a finding: the
+					// object is not readable.
+					report.CorruptObjects = append(report.CorruptObjects, entryPath)
+					return nil
+				}
+				report.ObjectsVerified++
+				if !ok {
+					report.CorruptObjects = append(report.CorruptObjects, entryPath)
+				}
+			}
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+
+		if opts.SkipOrphanScan {
+			continue
+		}
+		if err := s.collectOrphans(ctx, shard, reachable, minAge, report); err != nil {
+			return nil, err
+		}
+	}
+
+	if !opts.Repair {
+		observeFsck(report, opts, false)
+		return report, nil
+	}
+	if err := s.repair(ctx, report, drift); err != nil {
+		// A repair that stopped part-way leaves a mixture nothing here can
+		// describe, so report the findings as the pass saw them: the operator
+		// is being sent to look either way.
+		observeFsck(report, opts, false)
+		return report, err
+	}
+	observeFsck(report, opts, true)
+	// Repair rewrote the drifted usage counters and reseeded the tracker from
+	// them, so the capacity gauges are stale by exactly the amount that was
+	// wrong.
+	s.publishCapacityMetrics()
+
+	return report, nil
+}
+
+// observeFsck publishes a completed pass's findings.
+//
+// A gauge per class, set at the end of a pass, rather than a series per
+// finding: the findings are paths, and a store with a hundred thousand
+// dangling entries would otherwise put a hundred thousand series into the
+// registry at exactly the moment it can least afford it.  The paths are in the
+// report and in the log; the gauges answer "is anything wrong, and is it
+// getting worse".
+//
+// Two classes are conditional, because setting them from a pass that did not
+// look would be worse than not setting them at all:
+//
+//   - corrupt objects are only visible to a deep pass, so a shallow pass
+//     writing zero would erase what a deep one found;
+//   - the object count comes from the index walk, which every pass does in
+//     full -- so unlike the orphan comparison it is always store-wide.
+//
+// The orphan and pending counts *are* published from a sharded pass, and are
+// then per-slice rather than store-wide.  That is stated in the metric's help
+// text.  The alternative -- publishing them only from an exhaustive pass --
+// would leave them frozen forever in a server process, since the scheduled
+// index check always shards.
+//
+// resolved says a repair pass completed, in which case the classes repair
+// actually acts on are published as zero.  The report keeps its lists either
+// way -- they are what was found -- but a gauge answers "is anything wrong
+// now", and leaving it high after the entries have been unlinked and the
+// orphans queued would report a repaired store as broken until the next
+// scheduled pass.  The split is the same one FsckReport.Resolved and
+// FsckReport.Unresolved make, and for the same reason: repair cannot
+// manufacture data that is gone or un-corrupt a block.
+func observeFsck(report *FsckReport, opts FsckOptions, resolved bool) {
+	set := func(kind string, n int) {
+		metrics.PStoreFsckFindings.WithLabelValues(kind).Set(float64(n))
+	}
+	cleared := func(n int) int {
+		if resolved {
+			return 0
+		}
+		return n
+	}
+	set(metrics.PStoreFsckDanglingEntries, cleared(len(report.DanglingEntries)))
+	set(metrics.PStoreFsckOrphanedInstances, cleared(len(report.OrphanedInstances)))
+	if resolved && report.UsageResynced {
+		set(metrics.PStoreFsckUsageDrift, 0)
+	} else {
+		set(metrics.PStoreFsckUsageDrift, len(report.UsageDrift))
+	}
+
+	// Repair cannot touch these two, so they stand whatever it did.
+	set(metrics.PStoreFsckMissingData, len(report.MissingData))
+	set(metrics.PStoreFsckPendingInstances, len(report.PendingInstances))
+	if opts.Deep {
+		set(metrics.PStoreFsckCorruptObjects, len(report.CorruptObjects))
+	}
+
+	// The only count of the store's objects that does not cost a scan of its
+	// own; the index walk has just done it.
+	metrics.PStoreObjects.Set(float64(report.EntriesScanned - report.DirectoriesScanned))
+}
+
+// collectOrphans classifies the versions in one slice of the instance-hash
+// space that no entry refers to.
+func (s *Store) collectOrphans(
+	ctx context.Context,
+	shard string,
+	reachable map[reachableKey]struct{},
+	minAge time.Duration,
+	report *FsckReport,
+) error {
+	// The reclamation queue is not only a list of dead versions.  A write in
+	// progress tombstones its own instance before materializing it and clears
+	// the entry in the transaction that installs it, so a `pg:i:` key can
+	// belong to a live upload.  Skipping everything on the queue is therefore
+	// doubly right: those versions are the janitor's business either way, and
+	// the ones that are not garbage must not be touched at all.
+	//
+	// The queue is consulted with a cursor rather than loaded into a set,
+	// because `pg:i:<hash>` and `m:<hash>` are ordered by the same hash, so the
+	// two scans merge.  See queuedCursor.
+	queued := s.newQueuedCursor(ctx, shard)
+
+	// Keys only: deciding reachability needs the hash, not the record.  The
+	// few candidates that survive are read individually below, which is far
+	// cheaper than decoding every metadata value in the store.
+	var candidates []local_cache.InstanceHash
+	if err := s.scanMetadataHashes(ctx, shard, func(hash local_cache.InstanceHash) error {
+		// Reachability first: in a healthy store nearly every version is
+		// referenced, so this settles most hashes without touching the queue.
+		// Consulting the cursor on only the survivors is still an ascending
+		// sequence, which is all the merge requires.
+		if _, ok := reachable[truncateHash(hash)]; ok {
+			return nil
+		}
+		isQueued, err := queued.contains(hash)
+		if err != nil {
+			return err
+		}
+		if isQueued {
+			return nil
+		}
+		candidates = append(candidates, hash)
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "failed to scan object metadata")
+	}
+
+	cutoff := time.Now().Add(-minAge)
+	for _, hash := range candidates {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		// A streaming upload records an append intent before it has any
+		// directory entry.  That marker is the reclamation handle for writes
+		// that really were abandoned, and it belongs to the append sweep --
+		// fsck must not race it.
+		inFlight, err := s.hasAppendIntent(hash)
+		if err != nil {
+			return err
+		}
+		if inFlight {
+			report.PendingInstances = append(report.PendingInstances, string(hash))
+			continue
+		}
+
+		meta, err := s.db.GetMetadata(hash)
+		if err != nil {
+			return errors.Wrapf(err, "failed to read metadata for %s", hash)
+		}
+		if meta == nil {
+			// It went away between the two scans, which is the janitor doing
+			// its job.
+			continue
+		}
+		if meta.Completed.IsZero() || meta.Completed.After(cutoff) {
+			report.PendingInstances = append(report.PendingInstances, string(hash))
+			continue
+		}
+		report.OrphanedInstances = append(report.OrphanedInstances, string(hash))
+	}
+	return nil
+}
+
+// repair acts on what Fsck found.
+func (s *Store) repair(ctx context.Context, report *FsckReport, drift map[local_cache.StorageUsageKey]int64) error {
+	if err := s.checkWritable(); err != nil {
+		return err
+	}
+
+	// Unlink entries that cannot be served, so a client gets a clean 404
+	// rather than an error mid-read.
+	for _, entryPath := range report.DanglingEntries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := s.bdb.Update(func(txn *badger.Txn) error {
+			return deleteDirent(txn, entryPath)
+		}); err != nil {
+			return errors.Wrapf(err, "failed to remove dangling entry %s", entryPath)
+		}
+	}
+
+	// Hand orphans to the janitor rather than deleting inline, so reclamation
+	// goes through the one path that also respects reader pins.
+	for _, hash := range report.OrphanedInstances {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		h := local_cache.InstanceHash(hash)
+		if err := s.bdb.Update(func(txn *badger.Txn) error {
+			return enqueueInstance(txn, h)
+		}); err != nil {
+			return errors.Wrapf(err, "failed to queue orphan %s", hash)
+		}
+	}
+
+	// Write the corrected totals back to the catalog.
+	//
+	// Reseeding the in-memory counters alone was the whole of this step once,
+	// and it repaired nothing: the counters are seeded *from* the catalog at
+	// every open, so a drifted `u:` survived the repair and was read back on
+	// the next start.  An over-counted directory therefore made the store
+	// answer 507 forever with no operator remedy.  SetUsage overwrites the
+	// key with a discard marker, so the old value cannot be summed back in.
+	for key, d := range drift {
+		if d == 0 {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		recorded, err := s.db.GetUsage(key.StorageID, key.NamespaceID)
+		if err != nil {
+			return errors.Wrapf(err, "failed to read usage for storage %d", key.StorageID)
+		}
+		if err := s.db.SetUsage(key.StorageID, key.NamespaceID, recorded+d); err != nil {
+			return errors.Wrapf(err, "failed to rewrite usage for storage %d", key.StorageID)
+		}
+	}
+	report.UsageResynced = true
+
+	// Reseed the in-memory counters from the catalog we just corrected.
+	for _, id := range s.capacity.storageIDs() {
+		if err := s.capacity.resync(s.db, id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Bounded scans
+// ---------------------------------------------------------------------------
+
+// scanIndexBatched visits every index entry, reopening a read transaction
+// every fsckBatchSize keys and resuming from the last one.
+//
+// The callback runs outside the transaction, so a per-entry metadata lookup
+// does not nest a second transaction inside a long-lived one, and BadgerDB's
+// read watermark advances while the pass is running.
+func (s *Store) scanIndexBatched(ctx context.Context, fn func(entryPath string, d *Dirent) error) error {
+	type indexEntry struct {
+		path string
+		d    *Dirent
+	}
+
+	prefix := []byte(local_cache.PrefixDirent)
+	seek := append([]byte(nil), prefix...)
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		batch := make([]indexEntry, 0, fsckBatchSize)
+		var lastKey []byte
+		exhausted := true
+
+		if err := s.bdb.View(func(txn *badger.Txn) error {
+			opts := badger.DefaultIteratorOptions
+			opts.Prefix = prefix
+			it := txn.NewIterator(opts)
+			defer it.Close()
+
+			for it.Seek(seek); it.ValidForPrefix(prefix); it.Next() {
+				item := it.Item()
+				lastKey = item.KeyCopy(lastKey[:0])
+
+				entryPath, ok := pathFromKey(item.Key())
+				if ok {
+					var d *Dirent
+					if err := item.Value(func(val []byte) error {
+						var dErr error
+						d, dErr = decodeDirent(val)
+						return dErr
+					}); err != nil {
+						return errors.Wrapf(err, "failed to read entry %s", entryPath)
+					}
+					batch = append(batch, indexEntry{path: entryPath, d: d})
+				}
+				// A key that does not decode is not ours to interpret; it is
+				// skipped rather than guessed at, but it still advances the
+				// resume point.
+				if len(batch) >= fsckBatchSize {
+					exhausted = false
+					return nil
+				}
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		for _, e := range batch {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if err := fn(e.path, e.d); err != nil {
+				return err
+			}
+		}
+		if exhausted {
+			return nil
+		}
+		seek = nextKeyAfter(lastKey)
+	}
+}
+
+// scanMetadataHashes visits the instance hashes whose metadata key falls in
+// one slice of the hash space, in bounded batches and without reading values.
+func (s *Store) scanMetadataHashes(ctx context.Context, shard string, fn func(local_cache.InstanceHash) error) error {
+	prefix := []byte(local_cache.PrefixMeta + shard)
+	seek := append([]byte(nil), prefix...)
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		batch := make([]local_cache.InstanceHash, 0, fsckBatchSize)
+		var lastKey []byte
+		exhausted := true
+
+		if err := s.bdb.View(func(txn *badger.Txn) error {
+			opts := badger.DefaultIteratorOptions
+			opts.Prefix = prefix
+			opts.PrefetchValues = false
+			it := txn.NewIterator(opts)
+			defer it.Close()
+
+			for it.Seek(seek); it.ValidForPrefix(prefix); it.Next() {
+				key := it.Item().Key()
+				lastKey = it.Item().KeyCopy(lastKey[:0])
+				batch = append(batch, local_cache.InstanceHash(key[len(local_cache.PrefixMeta):]))
+				if len(batch) >= fsckBatchSize {
+					exhausted = false
+					return nil
+				}
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		for _, h := range batch {
+			if err := fn(h); err != nil {
+				return err
+			}
+		}
+		if exhausted {
+			return nil
+		}
+		seek = nextKeyAfter(lastKey)
+	}
+}
+
+// footprintByUsageKey totals what the objects really occupy, per usage
+// counter, and counts them.
+//
+// This deliberately does not use CacheDB.ComputeActualUsage: that sums raw
+// ContentLength, whereas the counters are charged CalculateFileSize -- the
+// on-disk size including each block's authentication tag. Comparing the two
+// reports phantom drift of exactly the MAC overhead on every healthy store.
+// PerDirectoryBytes yields the same quantity the counters hold, and is what
+// the write and reclaim paths already use.
+func (s *Store) footprintByUsageKey(ctx context.Context) (map[local_cache.StorageUsageKey]int64, int, error) {
+	out := make(map[local_cache.StorageUsageKey]int64)
+	count := 0
+
+	start := local_cache.InstanceHash("")
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, 0, err
+		}
+		n := 0
+		var last local_cache.InstanceHash
+		err := s.db.ScanMetadataFrom(start, func(hash local_cache.InstanceHash, meta *local_cache.CacheMetadata) error {
+			for id, bytes := range meta.PerDirectoryBytes() {
+				out[local_cache.StorageUsageKey{StorageID: id, NamespaceID: meta.NamespaceID}] += bytes
+			}
+			count++
+			n++
+			last = hash
+			if n >= fsckBatchSize {
+				return errFsckBatchFull
+			}
+			return nil
+		})
+		if err != nil && !errors.Is(err, errFsckBatchFull) {
+			return nil, 0, errors.Wrap(err, "failed to total object footprints")
+		}
+		if err == nil {
+			return out, count, nil
+		}
+		start = last
+	}
+}
+
+// usageDrift reports actual-minus-recorded per usage counter.
+func (s *Store) usageDrift(actual map[local_cache.StorageUsageKey]int64) (map[local_cache.StorageUsageKey]int64, error) {
+	recorded, err := s.db.GetAllUsage()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read recorded usage")
+	}
+
+	drift := make(map[local_cache.StorageUsageKey]int64)
+	for key, v := range actual {
+		// StorageIDInline is the catalog itself, not a storage directory, so
+		// it is excluded from both sides of the comparison.
+		if key.StorageID == local_cache.StorageIDInline {
+			continue
+		}
+		drift[key] += v
+	}
+	for key, v := range recorded {
+		if key.StorageID == local_cache.StorageIDInline {
+			continue
+		}
+		drift[key] -= v
+	}
+	for key, d := range drift {
+		if d == 0 {
+			delete(drift, key)
+		}
+	}
+	return drift, nil
+}
+
+// queuedCursor answers "is this version on the reclamation queue?" by merging
+// the queue with the metadata scan instead of loading it into a set.
+//
+// "Queued" rather than "awaiting reclamation": the same key is the crash-window
+// tombstone a write in flight sets on itself, so membership means only that
+// fsck must leave the version alone.  That ambiguity is what queuedInstance
+// encodes, and the cursor deals in that type throughout -- it reports a bool and
+// never yields a hash, so skipping everything queued stays the only thing fsck
+// can do with the queue.
+//
+// The merge is possible because `pg:i:<hash>` and `m:<hash>` are both keyed by
+// the instance hash, in the same fixed-width hex encoding behind a fixed-length
+// prefix -- so BadgerDB's byte order over the two prefixes is the same order,
+// and two cursors walking forward together answer every membership question in
+// one pass with no set at all.  (The *reachable* set above cannot be merged
+// this way: it is discovered by walking `pd:`, which is ordered by path, and
+// the instance hash is an HMAC that deliberately bears no relation to the path.
+// That mismatch is the whole reason that comparison needs a set, and why the
+// set is partitioned over a memory budget.)
+//
+// The gain is not speed -- the old set was one bounded scan too -- it is that
+// the queue is no longer held in memory.  It had no budget, and it is the one
+// structure here that can be arbitrarily large at exactly the moment fsck is
+// most likely to run: draining a detached subtree enqueues one `pg:i:` key per
+// version it unlinks, so a recursive delete of a million objects puts a million
+// keys on the queue until the janitor works through it.
+//
+// Callers must present hashes in ascending order.  The cursor only ever moves
+// forward, so a caller that goes backwards would silently get false.
+type queuedCursor struct {
+	ctx    context.Context
+	s      *Store
+	prefix []byte
+	trim   int
+
+	// seek is where the next batch resumes; buf holds the current one.  Like
+	// every other scan here it is batched, so no read transaction stays open
+	// across the pass.
+	//
+	// The batch is []queuedInstance rather than []local_cache.InstanceHash for
+	// the reason the type exists: a raw scan of `pg:i:` is exactly the thing a
+	// future change must not be able to feed to a delete, and membership is all
+	// this cursor ever needs to answer.  The two are the same size, so the merge
+	// costs what it always did.
+	seek []byte
+	buf  []queuedInstance
+	pos  int
+	done bool
+}
+
+// newQueuedCursor opens a cursor over the reclamation queue within one slice
+// of the instance-hash space.
+func (s *Store) newQueuedCursor(ctx context.Context, shard string) *queuedCursor {
+	prefix := []byte(local_cache.PrefixGarbage + garbageKindInstance + shard)
+	return &queuedCursor{
+		ctx:    ctx,
+		s:      s,
+		prefix: prefix,
+		trim:   len(local_cache.PrefixGarbage + garbageKindInstance),
+		seek:   append([]byte(nil), prefix...),
+	}
+}
+
+// contains reports whether hash is on the queue, advancing past every queued
+// version that sorts before it.
+func (c *queuedCursor) contains(hash local_cache.InstanceHash) (bool, error) {
+	for {
+		if c.pos >= len(c.buf) {
+			if c.done {
+				return false, nil
+			}
+			if err := c.fill(); err != nil {
+				return false, err
+			}
+			continue
+		}
+		switch cmp := c.buf[c.pos].compare(hash); {
+		case cmp < 0:
+			// Queued but with no metadata: already reclaimed, or queued by a
+			// path that never wrote any.  Nothing to report either way.
+			c.pos++
+		case cmp == 0:
+			return true, nil
+		default:
+			return false, nil
+		}
+	}
+}
+
+// fill loads the next batch.  It always makes progress: either buf gains
+// entries or done is set, so contains cannot spin.
+func (c *queuedCursor) fill() error {
+	if err := c.ctx.Err(); err != nil {
+		return err
+	}
+
+	c.buf = c.buf[:0]
+	c.pos = 0
+	var lastKey []byte
+
+	if err := c.s.bdb.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.Prefix = c.prefix
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		for it.Seek(c.seek); it.ValidForPrefix(c.prefix); it.Next() {
+			item := it.Item()
+			lastKey = item.KeyCopy(lastKey[:0])
+			// A []byte-to-string conversion copies, so this does not retain
+			// the iterator's buffer past Next.
+			c.buf = append(c.buf, newQueuedInstance(string(item.Key()[c.trim:])))
+			if len(c.buf) >= fsckBatchSize {
+				return nil
+			}
+		}
+		c.done = true
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "failed to read the reclamation queue")
+	}
+
+	if len(c.buf) == 0 {
+		c.done = true
+		return nil
+	}
+	c.seek = nextKeyAfter(lastKey)
+	return nil
+}
+
+// hasAppendIntent reports whether a streaming write is part-way through
+// building this version.
+func (s *Store) hasAppendIntent(hash local_cache.InstanceHash) (bool, error) {
+	found := false
+	err := s.bdb.View(func(txn *badger.Txn) error {
+		_, gErr := txn.Get(local_cache.AppendIntentKey(hash))
+		if errors.Is(gErr, badger.ErrKeyNotFound) {
+			return nil
+		}
+		if gErr != nil {
+			return gErr
+		}
+		found = true
+		return nil
+	})
+	return found, errors.Wrapf(err, "failed to check for an in-flight write of %s", hash)
+}
+
+// nextKeyAfter returns the smallest key strictly greater than key, so a
+// batched scan resumes without re-delivering the last entry.
+func nextKeyAfter(key []byte) []byte {
+	next := make([]byte, len(key)+1)
+	copy(next, key)
+	return next
+}
+
+// fsckShards picks the slices of the instance-hash space the orphan
+// comparison runs over.
+//
+// With no explicit request the whole space is covered, split into as many
+// slices as it takes to keep the referenced-version set under the budget.
+// With one, a single slice is examined and the caller rotates.
+func fsckShards(objectCount, shardOf, shard int) []string {
+	if shardOf > 1 {
+		width := hexShardWidth(shardOf)
+		prefixes := hexPrefixes(width)
+		if shard < 0 {
+			shard = -shard
+		}
+		return []string{prefixes[shard%len(prefixes)]}
+	}
+
+	width := 0
+	for objectCount > fsckReachableBudget && width < fsckMaxShardWidth {
+		objectCount /= 16
+		width++
+	}
+	return hexPrefixes(width)
+}
+
+// hexShardWidth is how many hex digits it takes to name n slices.
+func hexShardWidth(n int) int {
+	width := 0
+	for total := 1; total < n && width < fsckMaxShardWidth; total *= 16 {
+		width++
+	}
+	return width
+}
+
+// hexPrefixes enumerates every hex string of the given length.
+func hexPrefixes(width int) []string {
+	out := []string{""}
+	for i := 0; i < width; i++ {
+		next := make([]string, 0, len(out)*16)
+		for _, p := range out {
+			for _, c := range "0123456789abcdef" {
+				next = append(next, p+string(c))
+			}
+		}
+		out = next
+	}
+	return out
+}
+
+// consistencyChecker builds the cache's integrity checker over this store.
+//
+// The block store, its metadata, and its checksums are the cache's, so the
+// machinery that verifies them is too -- reimplementing block-level
+// verification here would be a second thing to keep correct.  What is *not*
+// shared is policy: the cache's scan deletes an object whose data no longer
+// matches its checksums, because for a cache that is the repair.  For a store
+// holding the only copy it is the loss, so the checker is built with
+// PreserveCorruptObjects and the backfill suppressed.  Only the verification
+// entry points are used here in any case; pstore's index consistency is
+// checked by Fsck above.
+func (s *Store) consistencyChecker() *local_cache.ConsistencyChecker {
+	return local_cache.NewConsistencyChecker(s.db, s.storage, newPStoreScanConfig(0))
+}
+
+// VerifyObject reads one object back and checks it against the checksums
+// recorded when it was written.
+//
+// Returns false when the data no longer matches, which means at-rest
+// corruption: every other check reads only the catalog and cannot see it.
+func (s *Store) VerifyObject(name string) (bool, error) {
+	cleanPath, err := cleanRelative(name)
+	if err != nil {
+		return false, err
+	}
+	d, err := s.Stat(cleanPath)
+	if err != nil {
+		return false, err
+	}
+	if d.IsDir() {
+		return false, ErrIsDir
+	}
+	return s.consistencyChecker().VerifyObject(instanceHashFor(s.db, d.Generation))
+}

--- a/pstore/gc.go
+++ b/pstore/gc.go
@@ -1,0 +1,815 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Garbage collection.
+//
+// Three things produce garbage: overwriting an object (the superseded
+// version), aborting a write, and deleting.  In every case the entry becomes
+// unreachable from the index and the bytes must be reclaimed afterwards.
+//
+// The queue entry is always written in the *same transaction* that makes the
+// data unreachable.  That is what makes reclamation crash-safe: there is no
+// window in which an orphan is both invisible to the index and absent from the
+// queue, so space can only leak if the janitor never runs.  fsck is a backstop
+// rather than a requirement.
+//
+// Two kinds of work are queued:
+//
+//	pg:i:<instanceHash>  an object version whose blocks should be freed
+//	pg:t:<path>          a detached subtree whose entries should be removed
+//
+// The instance queue carries two meanings under the one key: a version that is
+// dead, and a version a write is still building.  Telling them apart is what
+// queuedInstance and its claim method exist for; nothing else in the package can
+// turn a queue entry into something deletable.
+//
+// A subtree is queued rather than deleted inline because a large one cannot
+// fit in a single transaction.  Unlinking its entry from the parent makes it
+// unreachable immediately, and deletion need not be atomic — a partially
+// drained subtree is invisible either way.
+
+package pstore
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/local_cache"
+	"github.com/pelicanplatform/pelican/metrics"
+)
+
+const (
+	// garbageKindInstance queues one object version for block reclamation.
+	garbageKindInstance = "i:"
+	// garbageKindSubtree queues a detached directory for removal.
+	garbageKindSubtree = "t:"
+
+	// janitorInterval is the resting period between sweeps.
+	janitorInterval = 30 * time.Second
+
+	// janitorMinInterval is how fast the sweep may run while it is behind.
+	// A sweep is bounded work, so backing off to this under a backlog drains
+	// it in bounded time instead of leaving space reclaimed only as fast as
+	// one batch per resting period.
+	janitorMinInterval = 250 * time.Millisecond
+
+	// janitorBatchSize bounds how many queue entries one sweep handles, so a
+	// large backlog is drained over several passes instead of one long
+	// transaction.
+	janitorBatchSize = 512
+
+	// subtreeBatchSize bounds how many entries are removed from a detached
+	// subtree per transaction.
+	subtreeBatchSize = 256
+
+	// queueDepthInterval bounds how often the janitor measures the reclamation
+	// backlog for pelican_pstore_reclamation_pending.
+	//
+	// The measurement is a keys-only scan of the pg: prefix, which is free
+	// when the queue is short and proportional to the backlog when it is not
+	// -- that is, it costs the most in exactly the situation that makes the
+	// janitor sweep at janitorMinInterval.  Tying it to the resting period
+	// rather than to the sweep keeps the cost flat no matter how far behind
+	// the queue gets, at the price of a gauge that is at most this stale.  A
+	// backlog worth alerting on persists for far longer than thirty seconds.
+	queueDepthInterval = janitorInterval
+
+	// appendReclaimGrace is how long a streaming write's append-in-flight
+	// record must have been sitting before the janitor treats it as
+	// abandoned.
+	//
+	// Two things protect an upload that is merely slow, and they cover
+	// different failures.  The block store's live-writer registry covers this
+	// process: an AppendWriter that exists is never reclaimed no matter how
+	// long it takes.  The grace covers a restart, where that registry starts
+	// empty and every record in the catalog looks abandoned -- so it has to be
+	// long enough that a store coming back up cannot delete a write that
+	// something else is still finishing.
+	//
+	// Ten minutes matches the value the cache's janitor uses, so an operator
+	// reading either subsystem sees the same window, and it is deliberately
+	// longer than fsck's five-minute orphan threshold: fsck reports before it
+	// repairs and only deletes when asked, whereas this runs unattended.
+	appendReclaimGrace = 10 * time.Minute
+)
+
+// garbageInstanceKey returns the queue key for an object version.
+func garbageInstanceKey(h local_cache.InstanceHash) []byte {
+	return []byte(local_cache.PrefixGarbage + garbageKindInstance + string(h))
+}
+
+// garbageSubtreeKey returns the queue key for a detached subtree.
+func garbageSubtreeKey(cleanPath string) []byte {
+	return []byte(local_cache.PrefixGarbage + garbageKindSubtree + cleanPath)
+}
+
+// enqueueInstance queues an object version for reclamation.  It must be called
+// inside the transaction that makes the version unreachable.
+func enqueueInstance(txn *badger.Txn, h local_cache.InstanceHash) error {
+	if h == "" {
+		return nil
+	}
+	return errors.Wrapf(txn.Set(garbageInstanceKey(h), nil),
+		"failed to queue object version %s for reclamation", h)
+}
+
+// dequeueInstance removes an object version from the queue.  It must be called
+// inside the transaction that makes the version reachable, so that a version is
+// never simultaneously reachable and scheduled for reclamation.
+func dequeueInstance(txn *badger.Txn, h local_cache.InstanceHash) error {
+	if h == "" {
+		return nil
+	}
+	return errors.Wrapf(txn.Delete(garbageInstanceKey(h)),
+		"failed to clear the reclamation entry for object version %s", h)
+}
+
+// enqueueSubtree queues a detached directory for removal.  It must be called
+// inside the transaction that unlinks the directory from its parent.
+func enqueueSubtree(txn *badger.Txn, cleanPath string) error {
+	return errors.Wrapf(txn.Set(garbageSubtreeKey(cleanPath), nil),
+		"failed to queue subtree %s for removal", cleanPath)
+}
+
+// StartJanitor runs the reclamation sweep until the context is cancelled.
+//
+// The interval adapts to the backlog.  Each sweep handles a bounded batch, so
+// a fixed period puts a ceiling on how fast space can come back: deleting a
+// tree of a million objects at one batch per resting period would take days,
+// during which the store stays full and refuses writes.  A sweep that fills
+// its batch halves the wait, down to janitorMinInterval; a sweep that does not
+// steps back toward the resting period.  Reclamation therefore accelerates
+// exactly when there is something to reclaim and idles otherwise.
+func (s *Store) StartJanitor(ctx context.Context, egrp *errgroup.Group) {
+	egrp.Go(func() error {
+		wait := janitorInterval
+		timer := time.NewTimer(wait)
+		defer timer.Stop()
+
+		// The store publishes a backlog figure at open, so the first
+		// measurement here is due a full interval later.
+		lastDepth := time.Now()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-timer.C:
+			}
+
+			stats, err := s.RunGC(ctx)
+			if err != nil {
+				log.Warnf("pstore garbage collection pass failed: %v", err)
+			}
+
+			if time.Since(lastDepth) >= queueDepthInterval {
+				s.publishReclamationMetrics()
+				lastDepth = time.Now()
+			}
+
+			if stats.HitBatchLimit {
+				wait /= 2
+				if wait < janitorMinInterval {
+					wait = janitorMinInterval
+				}
+			} else if wait < janitorInterval {
+				// Ease back rather than snapping to the resting period, so a
+				// bursty deleter does not oscillate between the two rates.
+				wait *= 2
+				if wait > janitorInterval {
+					wait = janitorInterval
+				}
+			}
+			timer.Reset(wait)
+		}
+	})
+}
+
+// GCStats reports what one sweep accomplished.
+type GCStats struct {
+	// InstancesFreed is the number of object versions whose blocks were
+	// released.
+	InstancesFreed int
+	// InstancesPinned is the number skipped because a reader still holds
+	// them; they are retried on a later pass.
+	InstancesPinned int
+	// SubtreeEntriesRemoved is the number of directory entries removed from
+	// detached subtrees.
+	SubtreeEntriesRemoved int
+	// SubtreesCompleted is the number of detached subtrees fully drained.
+	SubtreesCompleted int
+	// AbandonedAppendsReclaimed is the number of streaming writes whose
+	// writer never finished and whose space has now been released.
+	AbandonedAppendsReclaimed int
+	// BytesFreed is how much space the released object versions occupied,
+	// summed from each version's metadata before it was deleted.  It excludes
+	// abandoned streaming writes, whose footprint the block store refunds
+	// directly without reporting it.
+	BytesFreed int64
+
+	// HitBatchLimit reports that the queue had more work than one sweep
+	// handles, so another should follow sooner than the resting period.
+	HitBatchLimit bool
+}
+
+// RunGC performs one reclamation pass and reports what it did.
+//
+// Safe to call directly; the janitor simply calls it on a timer.
+func (s *Store) RunGC(ctx context.Context) (GCStats, error) {
+	var stats GCStats
+
+	instances, subtrees, saturated, err := s.collectGarbage()
+	if err != nil {
+		return stats, err
+	}
+	stats.HitBatchLimit = saturated
+
+	for _, q := range instances {
+		if err := ctx.Err(); err != nil {
+			return stats, nil
+		}
+		// Every decision about whether this entry may be acted on lives in
+		// reclaimInstance, which is the only thing a queuedInstance can be
+		// passed to.  The sweep counts outcomes; it does not get a vote.
+		outcome, freed, err := s.reclaimInstance(q)
+		if err != nil {
+			// The hash is already in the error: every failure path below
+			// names the version it was working on.
+			log.Warnf("Failed to reclaim a queued object version: %v", err)
+			continue
+		}
+		switch outcome {
+		case reclaimFreed:
+			stats.InstancesFreed++
+			stats.BytesFreed += freed
+		case reclaimPinned:
+			// Either a reader holds the version or a write is still building
+			// it.  Both are retried on a later pass.
+			stats.InstancesPinned++
+		case reclaimWithdrawn:
+			// Never was garbage; nothing to report.
+		}
+	}
+
+	for _, root := range subtrees {
+		if err := ctx.Err(); err != nil {
+			return stats, nil
+		}
+		removed, done, err := s.drainSubtree(root)
+		stats.SubtreeEntriesRemoved += removed
+		if err != nil {
+			log.Warnf("Failed to drain detached subtree %s: %v", root, err)
+			continue
+		}
+		if done {
+			// Nothing under this root remains in the index, so lookups no
+			// longer need masking.
+			s.detached.remove(root)
+			stats.SubtreesCompleted++
+		} else {
+			// The subtree outran one batch, so there is more to do.
+			stats.HitBatchLimit = true
+		}
+	}
+
+	// A streaming write that died before Close never reached the reclamation
+	// queue at all, so the pg: entries above cannot see it; the block store
+	// tracks it separately.  Folding the sweep in here rather than giving it
+	// its own ticker means it inherits the janitor's adaptive backoff and
+	// there is still exactly one place that reclaims space.
+	reclaimed, err := s.ReclaimAbandonedAppends(appendReclaimGrace)
+	if err != nil {
+		log.Warnf("Failed to reclaim abandoned streaming writes: %v", err)
+	}
+	stats.AbandonedAppendsReclaimed = reclaimed
+
+	s.observeGC(stats)
+	return stats, nil
+}
+
+// observeGC publishes what one sweep accomplished.
+//
+// The capacity gauges are refreshed here rather than from the write path
+// because this is the one loop that runs whether or not anything is happening,
+// so the levels stay current on an idle store and no serving path pays for
+// them.  A sweep that freed nothing still republishes: usage moves on writes
+// too, and this is what carries that.
+func (s *Store) observeGC(stats GCStats) {
+	if stats.InstancesFreed > 0 {
+		metrics.PStoreReclaimedObjectsTotal.Add(float64(stats.InstancesFreed))
+	}
+	if stats.BytesFreed > 0 {
+		metrics.PStoreReclaimedBytesTotal.Add(float64(stats.BytesFreed))
+	}
+	if stats.AbandonedAppendsReclaimed > 0 {
+		metrics.PStoreAbandonedWritesReclaimedTotal.Add(float64(stats.AbandonedAppendsReclaimed))
+	}
+	metrics.PStoreDetachedSubtrees.Set(float64(s.detached.len()))
+	s.publishCapacityMetrics()
+}
+
+// publishReclamationMetrics measures the reclamation backlog and publishes it.
+//
+// This is the only measurement in the whole set that is not already in memory:
+// the pg: queue lives in the catalog, and its length is a keys-only prefix
+// scan.  The scan is bounded by the backlog rather than by the store, which is
+// the right shape -- a healthy store's queue is empty and the scan is a single
+// seek -- but it is why the janitor rate-limits the call rather than making it
+// once per sweep.  See queueDepthInterval.
+func (s *Store) publishReclamationMetrics() {
+	instances, subtrees, err := s.queueDepth()
+	if err != nil {
+		// A failure to observe is not a failure to serve.  The gauge keeps
+		// its previous value, which is preferable to publishing a zero that
+		// would read as "the backlog cleared".
+		log.Debugf("Failed to measure the pstore reclamation backlog: %v", err)
+		return
+	}
+	metrics.PStoreReclamationPending.
+		WithLabelValues(metrics.PStoreReclaimKindInstance).Set(float64(instances))
+	metrics.PStoreReclamationPending.
+		WithLabelValues(metrics.PStoreReclaimKindSubtree).Set(float64(subtrees))
+	metrics.PStoreDetachedSubtrees.Set(float64(s.detached.len()))
+}
+
+// queueDepth counts what is waiting in the reclamation queue.
+//
+// Separate from collectGarbage, which stops at janitorBatchSize because it has
+// to hold what it collects: counting holds nothing, so it can afford to run to
+// the end of the prefix and report a real number rather than one saturated at
+// the batch size.  A gauge pinned at 512 would say "at least 512" while looking
+// exactly like a queue that is genuinely 512 long and stable, which is the
+// opposite of what this is for.
+func (s *Store) queueDepth() (instances, subtrees int, err error) {
+	prefix := []byte(local_cache.PrefixGarbage)
+
+	err = s.bdb.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.Prefix = prefix
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			rest := string(it.Item().Key()[len(prefix):])
+			switch {
+			case strings.HasPrefix(rest, garbageKindInstance):
+				instances++
+			case strings.HasPrefix(rest, garbageKindSubtree):
+				subtrees++
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, 0, errors.Wrap(err, "failed to read the pstore garbage queue")
+	}
+	return instances, subtrees, nil
+}
+
+// ReclaimAbandonedAppends releases capacity held by streaming writes whose
+// writer never finished, and returns how many objects it freed.
+//
+// This closes the one gap the pg: queue cannot cover.  A write is queued for
+// reclamation at the start of materialization (WriteHandle.beginMaterialize),
+// which protects everything from there to the commit.  Before that point the
+// object exists only as a partly written stream, and the block store records
+// it under its own append-in-flight marker; a process that dies mid-upload
+// leaves chunk files allocated and charged with nothing in the pg: queue
+// pointing at them.  The cache reclaims those from its eviction manager, which
+// a pstore deliberately never constructs -- so without this the store that
+// makes the heaviest use of streaming writes was the one never cleaning up
+// after them.
+//
+// The two mechanisms compose rather than double-count.  Deleting an object
+// clears its append marker in the same transaction, so a version the pg: queue
+// already reclaimed is found here with no metadata and only its stale marker
+// is dropped; conversely an object reclaimed here is gone before any pg: entry
+// could refer to it.
+//
+// minAge is the grace period; see appendReclaimGrace.  Passing zero reclaims
+// every record with no live writer, which is for tooling and tests rather than
+// the janitor.
+func (s *Store) ReclaimAbandonedAppends(minAge time.Duration) (int, error) {
+	if s.readOnly {
+		return 0, nil
+	}
+	n, err := s.storage.ReclaimAbandonedAppends(minAge)
+	if n > 0 {
+		// The block store refunded the catalog's usage counters directly, so
+		// the in-memory figures have to be re-read rather than adjusted: it
+		// reports how many objects it freed, not which directories held them.
+		for _, id := range s.capacity.storageIDs() {
+			if rErr := s.capacity.resync(s.db, id); rErr != nil {
+				log.Warnf("Failed to resync usage for storage directory %d: %v", id, rErr)
+			}
+		}
+		log.Infof("Reclaimed %d object(s) left behind by interrupted streaming writes", n)
+	}
+	return n, errors.Wrap(err, "failed to reclaim abandoned streaming writes")
+}
+
+// queuedInstance is one `pg:i:` entry, exactly as it came off the reclamation
+// queue: a hash that may or may not be garbage.
+//
+// The queue carries two meanings under the same key.  Originally an entry meant
+// "this version is superseded or deleted; its bytes may be reclaimed".  A write
+// in flight now writes that same key as a tombstone before it materializes
+// anything (WriteHandle.beginMaterialize), so an entry can equally mean "a write
+// is in progress and may or may not land".  Reclaiming the second kind deletes a
+// live upload, which is the worst thing this package can do.
+//
+// Separating the two takes a specific check in a specific order -- see claim --
+// and for a while nothing but a comment said so.  Hence a type that is *not* an
+// instance hash.  What comes off the queue cannot be handed to
+// StorageManager.DeleteIfUnpinned, to CacheDB.GetMetadata, or to any index
+// mutation, because none of them accept it; the only way to obtain something
+// they do accept is to call claim, which is the check.  A future caller that
+// reads the queue therefore cannot skip the interlock without visibly rewriting
+// this type.
+//
+// It is a struct rather than a defined string type on purpose: a defined type
+// would convert to local_cache.InstanceHash in a single token.  The cost is
+// nothing -- the struct is one string header, so a batch of queuedInstance
+// allocates exactly what a batch of hashes did, which matters because the
+// janitor walks this batch over potentially millions of entries.
+type queuedInstance struct {
+	// unsafeHash is the hash portion of the key, deliberately typed as a plain
+	// string rather than as local_cache.InstanceHash: nothing that deletes data
+	// accepts a string, so even inside this package a bypass has to be spelled
+	// out as an explicit conversion rather than happening by accident.
+	//
+	// TestReclamationQueueEntriesCannotBypassTheInterlock fails if this field
+	// is read outside a method of queuedInstance, if any method other than
+	// claim yields a hash, or if the type is constructed anywhere but
+	// newQueuedInstance.
+	unsafeHash string
+}
+
+// newQueuedInstance wraps the hash portion of a `pg:i:` key.
+func newQueuedInstance(hash string) queuedInstance {
+	return queuedInstance{unsafeHash: hash}
+}
+
+// compare orders a queued entry against a metadata hash, reporting the usual
+// negative, zero, or positive.
+//
+// Ordering is all fsck's merge needs, and ordering is all this gives it: a
+// caller can learn that a version is on the queue without ever holding
+// something it could delete.  See queuedCursor.
+func (q queuedInstance) compare(h local_cache.InstanceHash) int {
+	return strings.Compare(q.unsafeHash, string(h))
+}
+
+// claim runs the interlock that separates the queue's two meanings, and yields
+// the hash only when the entry really is garbage.
+//
+// The batch an entry came from is a snapshot, and an entry can be *withdrawn*
+// after it is taken: a write in progress queues its own version before
+// materializing it and clears that entry in the transaction that installs it
+// (see WriteHandle.beginMaterialize).  Acting on a stale snapshot would delete a
+// live object out from under its own commit.
+//
+// Two observations in this order settle it.  The pin comes first.  The writer
+// holds one from before its entry is visible until after the entry is cleared,
+// and a reader holding the version would equally break if its metadata and block
+// state vanished underneath it -- so a pinned version is left for a later pass
+// either way, and the storage manager is asked because it is what hands out
+// readers.  The re-read comes second.  Read the three facts in order: the caller
+// saw the entry, then found it unpinned, and now the entry is still present.
+// For that to describe a write in flight the writer would have had to release
+// its pin before clearing the entry, which it never does -- so the version
+// really is garbage.
+//
+// Both halves live here, rather than being split between here and the sweep, so
+// that there is one place to read and one place a future caller has to go
+// through.  The cost is unchanged: a pinned entry returns before any database
+// read, and every other entry costs the single re-read it always did.
+func (q queuedInstance) claim(s *Store) (local_cache.InstanceHash, reclaimOutcome, error) {
+	h := local_cache.InstanceHash(q.unsafeHash)
+
+	if s.storage.IsObjectPinned(h) {
+		return "", reclaimPinned, nil
+	}
+
+	stillQueued, err := s.instanceQueued(h)
+	if err != nil {
+		return "", reclaimWithdrawn, err
+	}
+	if !stillQueued {
+		return "", reclaimWithdrawn, nil
+	}
+	return h, reclaimEligible, nil
+}
+
+// collectGarbage reads a bounded batch of pending work from the queue.
+//
+// Object versions come back as queuedInstance rather than as instance hashes,
+// which is what keeps this from being a source of deletable hashes: see
+// queuedInstance.
+func (s *Store) collectGarbage() ([]queuedInstance, []string, bool, error) {
+	var (
+		instances []queuedInstance
+		subtrees  []string
+		saturated bool
+	)
+	prefix := []byte(local_cache.PrefixGarbage)
+
+	err := s.bdb.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.Prefix = prefix
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			if len(instances)+len(subtrees) >= janitorBatchSize {
+				saturated = true
+				break
+			}
+			rest := string(it.Item().Key()[len(prefix):])
+			switch {
+			case strings.HasPrefix(rest, garbageKindInstance):
+				instances = append(instances,
+					newQueuedInstance(strings.TrimPrefix(rest, garbageKindInstance)))
+			case strings.HasPrefix(rest, garbageKindSubtree):
+				subtrees = append(subtrees, strings.TrimPrefix(rest, garbageKindSubtree))
+			default:
+				log.Warnf("Ignoring unrecognized pstore garbage queue entry %q", rest)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, false, errors.Wrap(err, "failed to read the pstore garbage queue")
+	}
+	return instances, subtrees, saturated, nil
+}
+
+// reclaimOutcome says what happened to one queued object version.
+type reclaimOutcome int
+
+const (
+	// reclaimFreed means the version's blocks were released.
+	reclaimFreed reclaimOutcome = iota
+	// reclaimPinned means a reader holds it, or a write is still building it;
+	// it stays queued for a later pass.
+	reclaimPinned
+	// reclaimWithdrawn means the queue entry is gone: the version was never
+	// garbage after all.
+	reclaimWithdrawn
+	// reclaimEligible is not the outcome of a sweep but the verdict of the
+	// interlock: the entry really is garbage and may be deleted.  It is what
+	// queuedInstance.claim returns alongside the hash, and reclaimInstance
+	// never reports it.
+	reclaimEligible
+)
+
+// reclaimInstance frees a queued object version's blocks and dequeues it.
+//
+// This is the only consumer of a queuedInstance in the package, and it opens by
+// asking claim whether the entry may be acted on at all; a caller holding a
+// queue entry has no other way to reach a delete.  Everything below the claim is
+// what happens once the interlock has said yes.
+//
+// It also reports how many bytes the version occupied, which is the same
+// figure it credits back to the capacity counters -- so the reclaimed-bytes
+// metric costs nothing beyond the addition, and cannot disagree with the
+// accounting it is meant to describe.
+func (s *Store) reclaimInstance(q queuedInstance) (reclaimOutcome, int64, error) {
+	h, outcome, err := q.claim(s)
+	if err != nil {
+		return outcome, 0, err
+	}
+	if outcome != reclaimEligible {
+		return outcome, 0, nil
+	}
+
+	// Record the space before deleting, so the in-memory capacity counters
+	// can be credited: StorageManager.Delete updates the catalog's usage
+	// counters but knows nothing about our reservations.
+	meta, err := s.db.GetMetadata(h)
+	if err != nil {
+		return reclaimWithdrawn, 0, errors.Wrapf(err, "failed to read metadata for %s", h)
+	}
+
+	var freed int64
+	if meta != nil {
+		deleted, dErr := s.storage.DeleteIfUnpinned(h)
+		if dErr != nil {
+			return reclaimWithdrawn, 0, errors.Wrapf(dErr, "failed to delete object version %s", h)
+		}
+		if !deleted {
+			return reclaimPinned, 0, nil
+		}
+		for storageID, bytes := range meta.PerDirectoryBytes() {
+			s.capacity.release(storageID, bytes)
+			freed += bytes
+		}
+	}
+
+	// Wrapped with the hash because the sweep no longer holds one to name in
+	// its log line: a queuedInstance is not a hash, on purpose.
+	return reclaimFreed, freed, errors.Wrapf(s.bdb.Update(func(txn *badger.Txn) error {
+		return txn.Delete(garbageInstanceKey(h))
+	}), "failed to clear the reclamation entry for object version %s", h)
+}
+
+// instanceQueued reports whether an object version is still listed for
+// reclamation.
+func (s *Store) instanceQueued(h local_cache.InstanceHash) (bool, error) {
+	found := false
+	err := s.bdb.View(func(txn *badger.Txn) error {
+		_, gErr := txn.Get(garbageInstanceKey(h))
+		if errors.Is(gErr, badger.ErrKeyNotFound) {
+			return nil
+		}
+		if gErr != nil {
+			return gErr
+		}
+		found = true
+		return nil
+	})
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to re-read the reclamation entry for %s", h)
+	}
+	return found, nil
+}
+
+// drainSubtree removes up to subtreeBatchSize entries from a detached
+// subtree, queueing each file's object version for reclamation as it goes.
+//
+// It reports how many entries it removed and whether the subtree is now
+// empty; when it is, the queue entry is dropped.  A subtree larger than one
+// batch is finished by later passes.
+func (s *Store) drainSubtree(root string) (int, bool, error) {
+	removed := 0
+	done := false
+
+	err := s.bdb.Update(func(txn *badger.Txn) error {
+		var batch []string
+		var instances []local_cache.InstanceHash
+
+		if wErr := walkSubtree(txn, root, func(entryPath string, d *Dirent) error {
+			if len(batch) >= subtreeBatchSize {
+				return errStopWalk
+			}
+			batch = append(batch, entryPath)
+			if !d.IsDir() && d.Generation != "" {
+				instances = append(instances, instanceHashFor(s.db, d.Generation))
+			}
+			return nil
+		}); wErr != nil && !errors.Is(wErr, errStopWalk) {
+			return wErr
+		}
+
+		for _, p := range batch {
+			if dErr := deleteDirent(txn, p); dErr != nil {
+				return dErr
+			}
+		}
+		for _, h := range instances {
+			if eErr := enqueueInstance(txn, h); eErr != nil {
+				return eErr
+			}
+		}
+		removed = len(batch)
+
+		// Nothing left to walk means the subtree is fully drained, so the
+		// work item itself can go.
+		if len(batch) < subtreeBatchSize {
+			done = true
+			return txn.Delete(garbageSubtreeKey(root))
+		}
+		return nil
+	})
+	if err != nil {
+		return removed, false, err
+	}
+	return removed, done, nil
+}
+
+// errStopWalk halts a subtree walk once a batch is full.  It never escapes
+// drainSubtree.
+var errStopWalk = errors.New("stop walk")
+
+// collectAllSubtrees returns every queued subtree root, unbounded, for
+// rebuilding the detached set at open.
+func (s *Store) collectAllSubtrees() ([]string, error) {
+	var subtrees []string
+	prefix := []byte(local_cache.PrefixGarbage + garbageKindSubtree)
+
+	err := s.bdb.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.Prefix = prefix
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			subtrees = append(subtrees, string(it.Item().Key()[len(prefix):]))
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read queued subtrees")
+	}
+	return subtrees, nil
+}
+
+// requireDirResolved verifies dir exists and is a directory, honoring
+// detached subtrees.
+func (s *Store) requireDirResolved(txn *badger.Txn, dir string) error {
+	if isRootPath(dir) {
+		return nil
+	}
+	d, err := s.resolve(txn, dir)
+	if err != nil {
+		return err
+	}
+	if !d.IsDir() {
+		return ErrNotDir
+	}
+	return nil
+}
+
+// deleteSubtreeInline removes an entire subtree within the caller's
+// transaction, queueing each object version for reclamation.
+//
+// It reports false without modifying anything when the subtree is larger than
+// one transaction should carry, leaving the caller to detach and defer.  The
+// bound is deliberately the same batch size the janitor uses: a removal that
+// the janitor would handle in a single pass may as well complete immediately,
+// which keeps the paths free for reuse.
+func deleteSubtreeInline(txn *badger.Txn, db *local_cache.CacheDB, root string) (bool, error) {
+	var (
+		paths     []string
+		instances []local_cache.InstanceHash
+		tooBig    bool
+	)
+
+	if err := walkSubtree(txn, root, func(entryPath string, d *Dirent) error {
+		if len(paths) >= subtreeBatchSize {
+			tooBig = true
+			return errStopWalk
+		}
+		paths = append(paths, entryPath)
+		if !d.IsDir() && d.Generation != "" {
+			instances = append(instances, instanceHashFor(db, d.Generation))
+		}
+		return nil
+	}); err != nil && !errors.Is(err, errStopWalk) {
+		return false, err
+	}
+	if tooBig {
+		return false, nil
+	}
+
+	for _, p := range paths {
+		if err := deleteDirent(txn, p); err != nil {
+			return false, err
+		}
+	}
+	for _, h := range instances {
+		if err := enqueueInstance(txn, h); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+// checkNotDraining refuses to create an entry inside a subtree that has been
+// removed but not yet drained.
+//
+// Those descendants still occupy the keys the new entries would use, and the
+// drain will delete whatever it finds there, so allowing the write would lose
+// it. Only subtrees too large to remove inline are ever in this state, and the
+// janitor accelerates while a backlog exists, so the wait is bounded.
+func (s *Store) checkNotDraining(cleanPath string) error {
+	if !s.detached.contains(cleanPath) {
+		return nil
+	}
+	return errors.Wrapf(ErrDraining,
+		"%s is still being reclaimed after a recursive delete; retry shortly", cleanPath)
+}

--- a/pstore/gc_test.go
+++ b/pstore/gc_test.go
@@ -1,0 +1,325 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package pstore
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/local_cache"
+)
+
+// The shape of the reclamation queue's boundary, pinned at compile time.
+//
+// A `pg:i:` entry means either "this version is garbage" or "a write is in
+// flight"; deleting the second kind destroys a live upload.  What keeps the two
+// apart is that reading the queue yields a queuedInstance, which no delete and
+// no index mutation accepts, and that the sole route from one back to an
+// instance hash is claim, which runs the interlock.
+//
+// These assertions fail to *compile* if that boundary is dismantled: if
+// collectGarbage goes back to handing out bare hashes, if reclaimInstance starts
+// accepting one, or if claim's signature changes so that the check can be
+// skipped.  A reviewer who has to delete a line here is being told exactly what
+// they are giving up.
+var (
+	_ func(*Store) ([]queuedInstance, []string, bool, error)                         = (*Store).collectGarbage
+	_ func(*Store, queuedInstance) (reclaimOutcome, int64, error)                    = (*Store).reclaimInstance
+	_ func(queuedInstance, *Store) (local_cache.InstanceHash, reclaimOutcome, error) = queuedInstance.claim
+	_ func(queuedInstance, local_cache.InstanceHash) int                             = queuedInstance.compare
+	_ func(string) queuedInstance                                                    = newQueuedInstance
+)
+
+// TestReclamationQueueEntriesCannotBypassTheInterlock enforces what the type
+// system alone cannot, because everything here is one package.
+//
+// Within a package an unexported field is still reachable, so queuedInstance
+// stops an *accident* -- its hash is a plain string, which no delete accepts --
+// but not a determined bypass.  This closes that by reading the package's own
+// source and insisting on three properties:
+//
+//  1. only a method of queuedInstance may touch the raw hash;
+//  2. only claim, which performs the pin check and the re-read, may hand one
+//     back out;
+//  3. only newQueuedInstance may build the type, so there is one place a hash
+//     enters it.
+//
+// Together those mean the single path from the reclamation queue to a deletable
+// hash runs through claim.  A change that opens a second path fails here with
+// the reason rather than silently shipping.
+func TestReclamationQueueEntriesCannotBypassTheInterlock(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		// Tests may reach for the field freely; it is the shipping code that
+		// has to be kept honest.
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	require.NoError(t, err)
+	pkg := pkgs["pstore"]
+	require.NotNil(t, pkg, "the pstore package must parse")
+
+	// Sanity: the rules below are vacuous if the field ever gets renamed, so
+	// prove the scan actually found the accessor it is meant to be policing.
+	sawClaim := false
+
+	for _, file := range pkg.Files {
+		for _, decl := range file.Decls {
+			fn, isFunc := decl.(*ast.FuncDecl)
+			owner, onQueuedInstance := "", false
+			if isFunc {
+				owner = fn.Name.Name
+				onQueuedInstance = receiverTypeName(fn) == "queuedInstance"
+			}
+
+			if onQueuedInstance && owner == "claim" {
+				sawClaim = true
+			}
+
+			// (2) A method of queuedInstance other than claim may not return
+			// anything the hash can be recovered from.  A String() method would
+			// be exactly as dangerous as an exported field.
+			if onQueuedInstance && owner != "claim" && fn.Type.Results != nil {
+				for _, res := range fn.Type.Results.List {
+					name := typeExprName(res.Type)
+					assert.NotContains(t, []string{"string", "local_cache.InstanceHash"}, name,
+						"queuedInstance.%s returns %s: only claim, which runs the pin check "+
+							"and the queue re-read, may yield the hash of a queued entry",
+						owner, name)
+				}
+			}
+
+			ast.Inspect(decl, func(n ast.Node) bool {
+				switch node := n.(type) {
+				case *ast.SelectorExpr:
+					// (1) Reading the raw hash is the dangerous act; confine it
+					// to the type's own methods, where the reasoning lives.
+					if node.Sel.Name == "unsafeHash" {
+						assert.True(t, onQueuedInstance,
+							"%s reads queuedInstance.unsafeHash: a queue entry may only be "+
+								"turned into an instance hash by queuedInstance.claim, which "+
+								"performs the pin check and the queue re-read that tell a dead "+
+								"version from a write in flight",
+							describeDecl(owner, isFunc))
+					}
+				case *ast.CompositeLit:
+					// (3) One constructor, so there is one place a hash becomes
+					// a queued entry.
+					if typeExprName(node.Type) == "queuedInstance" {
+						assert.Equal(t, "newQueuedInstance", owner,
+							"%s builds a queuedInstance literal: construct it through "+
+								"newQueuedInstance so the queue has a single entry point",
+							describeDecl(owner, isFunc))
+					}
+				}
+				return true
+			})
+		}
+	}
+
+	assert.True(t, sawClaim,
+		"queuedInstance.claim was not found; the rules above police a name that no longer exists")
+}
+
+// receiverTypeName reports the type a method is declared on, or "" for a
+// plain function.
+func receiverTypeName(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return ""
+	}
+	return typeExprName(fn.Recv.List[0].Type)
+}
+
+// typeExprName renders the identifier, qualified identifier, or pointer target
+// a type expression names.  Anything else reports "", which no rule matches.
+func typeExprName(e ast.Expr) string {
+	switch t := e.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		return typeExprName(t.X)
+	case *ast.SelectorExpr:
+		return typeExprName(t.X) + "." + t.Sel.Name
+	}
+	return ""
+}
+
+// describeDecl names a declaration for a failure message.
+func describeDecl(owner string, isFunc bool) string {
+	if !isFunc {
+		return "a package-level declaration"
+	}
+	return owner
+}
+
+// TestJanitorNeverReclaimsAWriteInFlight is the runtime half: a full sweep run
+// at the worst possible moment must leave a live upload alone.
+//
+// A write tombstones its own version on the reclamation queue before it
+// materializes anything, so between beginMaterialize and the commit the entry is
+// byte-for-byte what a superseded version looks like.  The pin the writer holds
+// is what distinguishes them, and this steps through Close by hand so the sweep
+// lands exactly inside that window.
+func TestJanitorNeverReclaimsAWriteInFlight(t *testing.T) {
+	s := newTestStore(t)
+
+	content := randomBytes(8<<10, 17)
+	w, err := s.Create("/in-flight")
+	require.NoError(t, err)
+	_, err = w.Write(content)
+	require.NoError(t, err)
+
+	require.NoError(t, w.beginMaterialize())
+	meta, err := w.materialize()
+	require.NoError(t, err)
+
+	// The tombstone is indistinguishable from a work item, which is the whole
+	// difficulty.
+	queued, _, _, err := s.collectGarbage()
+	require.NoError(t, err)
+	require.Equal(t, []queuedInstance{newQueuedInstance(string(w.instanceHash))}, queued,
+		"a write in flight sits on the queue looking exactly like garbage")
+
+	stats, err := s.RunGC(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, stats.InstancesFreed, "a sweep must never reclaim a write in flight")
+	assert.Zero(t, stats.BytesFreed)
+	assert.Equal(t, 1, stats.InstancesPinned, "it is deferred, not dropped")
+
+	stored, err := s.db.GetMetadata(w.instanceHash)
+	require.NoError(t, err)
+	require.NotNil(t, stored, "the half-built version survived the sweep intact")
+
+	// Repeated passes must not wear it down either: the entry stays queued, so
+	// there is no count of attempts after which it is reclaimed anyway.
+	for range 3 {
+		_, err = s.RunGC(t.Context())
+		require.NoError(t, err)
+	}
+	stillQueued, err := s.instanceQueued(w.instanceHash)
+	require.NoError(t, err)
+	assert.True(t, stillQueued, "the tombstone is the writer's to clear, not the janitor's")
+
+	finishInterruptedWrite(t, w, meta)
+
+	// The commit withdrew the entry, so the queue is empty and the object reads
+	// back exactly as written.
+	drainQueue(t, s)
+	assertQueueEmpty(t, s)
+	got, err := s.ReadAll("/in-flight")
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+}
+
+// TestReclaimRefusesAWithdrawnQueueEntry covers the second half of the
+// interlock, the one a pin check alone would miss.
+//
+// The janitor works from a snapshot.  A write that commits after the batch is
+// taken has both cleared its queue entry and released its pin, so an entry read
+// a moment earlier now looks like unpinned garbage.  Re-reading the entry is
+// what catches it.
+func TestReclaimRefusesAWithdrawnQueueEntry(t *testing.T) {
+	s := newTestStore(t)
+
+	content := randomBytes(8<<10, 19)
+	w, err := s.Create("/withdrawn")
+	require.NoError(t, err)
+	_, err = w.Write(content)
+	require.NoError(t, err)
+
+	require.NoError(t, w.beginMaterialize())
+	meta, err := w.materialize()
+	require.NoError(t, err)
+
+	// The batch is taken while the write is still in flight...
+	batch, _, _, err := s.collectGarbage()
+	require.NoError(t, err)
+	require.Len(t, batch, 1)
+
+	// ...and the write commits before the janitor gets to it.
+	finishInterruptedWrite(t, w, meta)
+
+	outcome, freed, err := s.reclaimInstance(batch[0])
+	require.NoError(t, err)
+	assert.Equal(t, reclaimWithdrawn, outcome,
+		"an entry cleared by its own commit is not garbage, pin or no pin")
+	assert.Zero(t, freed)
+
+	got, err := s.ReadAll("/withdrawn")
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+}
+
+// TestReclaimFreesASupersededVersion is the positive control: the interlock
+// refuses live writes without also refusing the work it exists to do.
+func TestReclaimFreesASupersededVersion(t *testing.T) {
+	s := newTestStore(t)
+
+	writeObject(t, s, "/obj", randomBytes(8<<10, 23))
+	first, err := s.Stat("/obj")
+	require.NoError(t, err)
+	superseded := instanceHashFor(s.db, first.Generation)
+
+	writeObject(t, s, "/obj", randomBytes(8<<10, 29))
+
+	batch, _, _, err := s.collectGarbage()
+	require.NoError(t, err)
+	require.Equal(t, []queuedInstance{newQueuedInstance(string(superseded))}, batch)
+
+	outcome, freed, err := s.reclaimInstance(batch[0])
+	require.NoError(t, err)
+	assert.Equal(t, reclaimFreed, outcome)
+	assert.Positive(t, freed, "the freed bytes are the ones credited back to capacity")
+
+	stored, err := s.db.GetMetadata(superseded)
+	require.NoError(t, err)
+	assert.Nil(t, stored, "the superseded version is gone")
+	assertQueueEmpty(t, s)
+}
+
+// finishInterruptedWrite completes a write that was stepped through
+// beginMaterialize and materialize by hand, performing the rest of what Close
+// would have done.
+func finishInterruptedWrite(t *testing.T, w *WriteHandle, meta *local_cache.CacheMetadata) {
+	t.Helper()
+
+	require.NoError(t, w.install(&Dirent{
+		Type:       EntryFile,
+		Generation: w.generation,
+		Size:       w.written.Load(),
+		MTimeNanos: time.Now().UnixNano(),
+		Mode:       uint32(defaultFileMode),
+	}))
+	w.endMaterialize()
+
+	if meta != nil {
+		w.store.capacity.settle(w.reserved, meta.PerDirectoryBytes())
+	} else {
+		w.store.capacity.settle(w.reserved, nil)
+	}
+	w.reserved = 0
+	w.done = true
+}

--- a/pstore/index.go
+++ b/pstore/index.go
@@ -1,0 +1,407 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// The pstore directory index.
+//
+// Entries are keyed by parent path and name:
+//
+//	pd:<parent path>\x00<name>
+//
+// so that a directory's direct children form one contiguous, name-ordered key
+// range.  Listing a single directory — the dominant operation — is a
+// sequential scan with no seeks and no filtering.  Both files and directories
+// are entries under their parent, so a directory needs no marker record and an
+// empty directory is as real as any other entry.
+//
+// A subtree spans two contiguous ranges: the direct children under
+// pd:<path>\x00, and everything deeper under the prefix pd:<path>/, because
+// every node below the direct children has a parent path beginning with
+// "<path>/".  Both are sequential; see docs/pstore-design.md §4.
+//
+// NUL is the separator precisely because it cannot appear in a path component
+// (validatePath rejects it), which is what makes the encoding unambiguous.
+
+package pstore
+
+import (
+	"bytes"
+	"path"
+	"strings"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/pkg/errors"
+	"github.com/vmihailenco/msgpack/v5"
+
+	"github.com/pelicanplatform/pelican/local_cache"
+)
+
+// EntryType distinguishes files from directories in a dirent.
+type EntryType uint8
+
+const (
+	// EntryFile is a regular object.
+	EntryFile EntryType = 0
+	// EntryDir is a directory.
+	EntryDir EntryType = 1
+)
+
+// direntSeparator separates a parent path from a child name in an index key.
+// It is NUL because path components may not contain it (see validatePath).
+const direntSeparator = 0x00
+
+// Dirent is one entry in a directory.
+//
+// Size, MTimeNanos, and Generation are denormalized from the object's
+// CacheMetadata so that a listing is a single scan: without them, a PROPFIND
+// over a large directory would need one additional point lookup per child.
+// They are rewritten only at commit, in a transaction the write path performs
+// anyway.
+type Dirent struct {
+	Type       EntryType `msgpack:"t"`
+	Generation string    `msgpack:"g,omitempty"` // files only; also the ETag
+	Size       int64     `msgpack:"s,omitempty"`
+	MTimeNanos int64     `msgpack:"m"`
+	Mode       uint32    `msgpack:"o"`
+}
+
+// IsDir reports whether the entry is a directory.
+func (d *Dirent) IsDir() bool { return d.Type == EntryDir }
+
+// direntKey returns the index key for the entry at the given absolute path.
+//
+// The path must already be validated and cleaned.  The root has no parent and
+// therefore no dirent; callers must not pass it.
+func direntKey(cleanPath string) []byte {
+	parent, name := splitPath(cleanPath)
+	return childKey(parent, name)
+}
+
+// childKey returns the index key for name within parent.
+func childKey(parent, name string) []byte {
+	var b bytes.Buffer
+	b.Grow(len(local_cache.PrefixDirent) + len(parent) + 1 + len(name))
+	b.WriteString(local_cache.PrefixDirent)
+	b.WriteString(parent)
+	b.WriteByte(direntSeparator)
+	b.WriteString(name)
+	return b.Bytes()
+}
+
+// childrenPrefix returns the key prefix covering exactly the direct children
+// of the directory at parent.
+func childrenPrefix(parent string) []byte {
+	var b bytes.Buffer
+	b.Grow(len(local_cache.PrefixDirent) + len(parent) + 1)
+	b.WriteString(local_cache.PrefixDirent)
+	b.WriteString(parent)
+	b.WriteByte(direntSeparator)
+	return b.Bytes()
+}
+
+// descendantsPrefix returns the key prefix covering every node strictly below
+// the direct children of dir — that is, all entries whose parent path begins
+// with "<dir>/".
+//
+// For the root this is the whole index, since every parent path begins with
+// "/". Callers that need the root's full subtree should use the index prefix
+// directly; isRootPath reports that case.
+func descendantsPrefix(dir string) []byte {
+	if isRootPath(dir) {
+		return []byte(local_cache.PrefixDirent)
+	}
+	return []byte(local_cache.PrefixDirent + dir + "/")
+}
+
+// splitPath divides an absolute, cleaned path into its parent directory and
+// final component.
+//
+// This is path.Split with the two adjustments the index needs: the trailing
+// separator is dropped from the parent, since keys are built from an exact
+// parent path, and a top-level entry reports "/" rather than the empty string.
+func splitPath(cleanPath string) (parent, name string) {
+	dir, name := path.Split(cleanPath)
+	if dir == "/" || dir == "" {
+		return "/", name
+	}
+	return strings.TrimSuffix(dir, "/"), name
+}
+
+// joinPath appends a child name to a parent directory path.
+//
+// path.Join would also Clean the result, which is wasted work here: both
+// halves are already clean, and name is a single validated component.
+func joinPath(parent, name string) string {
+	if isRootPath(parent) {
+		return "/" + name
+	}
+	return parent + "/" + name
+}
+
+// isRootPath reports whether p denotes the store root.
+func isRootPath(p string) bool { return p == "/" }
+
+// encodeDirent serializes a dirent for storage.
+func encodeDirent(d *Dirent) ([]byte, error) {
+	b, err := msgpack.Marshal(d)
+	return b, errors.Wrap(err, "failed to encode directory entry")
+}
+
+// decodeDirent deserializes a stored dirent.
+func decodeDirent(b []byte) (*Dirent, error) {
+	var d Dirent
+	if err := msgpack.Unmarshal(b, &d); err != nil {
+		return nil, errors.Wrap(err, "failed to decode directory entry")
+	}
+	return &d, nil
+}
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+// getDirent reads the entry at cleanPath within the given transaction.
+// It returns ErrNotExist when no entry is present.
+func getDirent(txn *badger.Txn, cleanPath string) (*Dirent, error) {
+	if isRootPath(cleanPath) {
+		return rootDirent(), nil
+	}
+	item, err := txn.Get(direntKey(cleanPath))
+	if err != nil {
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			return nil, ErrNotExist
+		}
+		return nil, errors.Wrapf(err, "failed to look up %s", cleanPath)
+	}
+	var d *Dirent
+	err = item.Value(func(val []byte) error {
+		var dErr error
+		d, dErr = decodeDirent(val)
+		return dErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// rootDirent synthesizes the entry for the store root, which has no parent and
+// therefore no stored record.
+func rootDirent() *Dirent {
+	return &Dirent{Type: EntryDir, Mode: uint32(defaultDirMode)}
+}
+
+// ListEntry pairs a child name with its dirent during a listing.
+type ListEntry struct {
+	Name   string
+	Dirent *Dirent
+}
+
+// listDir returns the direct children of dir in name order.
+//
+// This is a single sequential scan over one contiguous key range: every key
+// under the prefix is a direct child, so there is nothing to filter and no
+// subtree to seek past.
+//
+// When limit is positive at most that many entries are returned, starting at
+// the first name strictly greater than after (empty means start at the
+// beginning).  The returned bool reports whether more entries remain.
+func listDir(txn *badger.Txn, dir string, after string, limit int) ([]ListEntry, bool, error) {
+	prefix := childrenPrefix(dir)
+
+	opts := badger.DefaultIteratorOptions
+	opts.Prefix = prefix
+	it := txn.NewIterator(opts)
+	defer it.Close()
+
+	start := prefix
+	if after != "" {
+		// Seek past the last name already returned.  Appending a zero byte
+		// yields the smallest key strictly greater than the "after" key,
+		// because no name may contain NUL.
+		start = append(childKey(dir, after), 0x00)
+	}
+
+	entries := make([]ListEntry, 0, 16)
+	more := false
+	for it.Seek(start); it.ValidForPrefix(prefix); it.Next() {
+		if limit > 0 && len(entries) == limit {
+			more = true
+			break
+		}
+		item := it.Item()
+		name := string(item.Key()[len(prefix):])
+		var d *Dirent
+		if err := item.Value(func(val []byte) error {
+			var dErr error
+			d, dErr = decodeDirent(val)
+			return dErr
+		}); err != nil {
+			return nil, false, errors.Wrapf(err, "failed to read entry %q in %s", name, dir)
+		}
+		entries = append(entries, ListEntry{Name: name, Dirent: d})
+	}
+	return entries, more, nil
+}
+
+// dirHasChildren reports whether dir contains at least one entry.
+func dirHasChildren(txn *badger.Txn, dir string) (bool, error) {
+	prefix := childrenPrefix(dir)
+
+	opts := badger.DefaultIteratorOptions
+	opts.Prefix = prefix
+	opts.PrefetchValues = false
+	it := txn.NewIterator(opts)
+	defer it.Close()
+
+	it.Seek(prefix)
+	return it.ValidForPrefix(prefix), nil
+}
+
+// walkSubtree invokes fn for every entry at or below dir, excluding dir
+// itself.  It covers both of the subtree's contiguous ranges: the direct
+// children, then everything deeper.
+//
+// Entries are not delivered in path order.  Every consumer — capacity
+// accounting, recursive delete, rename, fsck — is order-independent.
+func walkSubtree(txn *badger.Txn, dir string, fn func(entryPath string, d *Dirent) error) error {
+	visit := func(prefix []byte) error {
+		opts := badger.DefaultIteratorOptions
+		opts.Prefix = prefix
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			item := it.Item()
+			entryPath, ok := pathFromKey(item.Key())
+			if !ok {
+				// A key that does not decode is not ours to interpret; fsck
+				// reports it rather than the hot path guessing.
+				continue
+			}
+			var d *Dirent
+			if err := item.Value(func(val []byte) error {
+				var dErr error
+				d, dErr = decodeDirent(val)
+				return dErr
+			}); err != nil {
+				return errors.Wrapf(err, "failed to read entry %s", entryPath)
+			}
+			if err := fn(entryPath, d); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if isRootPath(dir) {
+		// Every parent path begins with "/", so the root's subtree is the
+		// whole index and the two ranges collapse into one.
+		return visit([]byte(local_cache.PrefixDirent))
+	}
+	if err := visit(childrenPrefix(dir)); err != nil {
+		return err
+	}
+	return visit(descendantsPrefix(dir))
+}
+
+// pathFromKey recovers the absolute path an index key refers to.
+func pathFromKey(key []byte) (string, bool) {
+	if !bytes.HasPrefix(key, []byte(local_cache.PrefixDirent)) {
+		return "", false
+	}
+	rest := key[len(local_cache.PrefixDirent):]
+	sep := bytes.IndexByte(rest, direntSeparator)
+	if sep < 0 {
+		return "", false
+	}
+	parent := string(rest[:sep])
+	name := string(rest[sep+1:])
+	if parent == "" || name == "" {
+		return "", false
+	}
+	return joinPath(parent, name), true
+}
+
+// ---------------------------------------------------------------------------
+// Writes
+// ---------------------------------------------------------------------------
+
+// putDirent writes an entry within the given transaction.
+func putDirent(txn *badger.Txn, cleanPath string, d *Dirent) error {
+	if isRootPath(cleanPath) {
+		return errors.New("the store root has no directory entry")
+	}
+	val, err := encodeDirent(d)
+	if err != nil {
+		return err
+	}
+	return errors.Wrapf(txn.Set(direntKey(cleanPath), val), "failed to write entry %s", cleanPath)
+}
+
+// deleteDirent removes an entry within the given transaction.
+func deleteDirent(txn *badger.Txn, cleanPath string) error {
+	if isRootPath(cleanPath) {
+		return errors.New("the store root has no directory entry")
+	}
+	return errors.Wrapf(txn.Delete(direntKey(cleanPath)), "failed to delete entry %s", cleanPath)
+}
+
+// cleanRelative normalizes a caller-supplied path into the store's absolute,
+// cleaned form and validates it.
+func cleanRelative(p string) (string, error) {
+	if p == "" {
+		return "", errors.Wrap(ErrInvalidPath, "empty path")
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	cleaned := path.Clean(p)
+	if err := validatePath(cleaned); err != nil {
+		return "", err
+	}
+	return cleaned, nil
+}
+
+// validatePath rejects paths the index cannot represent unambiguously.
+//
+// The NUL check is load-bearing rather than defensive: the index key encoding
+// uses NUL to separate a parent path from a name, so a name containing NUL
+// would make pd:/a\x00b ambiguous between the file /a/b and a file literally
+// named "a\x00b" at the root.
+func validatePath(cleanPath string) error {
+	if !strings.HasPrefix(cleanPath, "/") {
+		return errors.Wrapf(ErrInvalidPath, "path %q is not absolute", cleanPath)
+	}
+	if strings.ContainsRune(cleanPath, direntSeparator) {
+		return errors.Wrap(ErrInvalidPath, "path contains a NUL byte")
+	}
+	if isRootPath(cleanPath) {
+		return nil
+	}
+	for _, component := range strings.Split(strings.TrimPrefix(cleanPath, "/"), "/") {
+		switch component {
+		case "":
+			return errors.Wrapf(ErrInvalidPath, "path %q has an empty component", cleanPath)
+		case ".", "..":
+			// path.Clean resolves these, so reaching here means the path
+			// tried to escape the root.
+			return errors.Wrapf(ErrInvalidPath, "path %q escapes the store root", cleanPath)
+		}
+	}
+	return nil
+}

--- a/pstore/index_test.go
+++ b/pstore/index_test.go
@@ -1,0 +1,174 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package pstore
+
+import (
+	"bytes"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitAndJoinPath(t *testing.T) {
+	cases := []struct {
+		in     string
+		parent string
+		name   string
+	}{
+		{"/a", "/", "a"},
+		{"/a/b", "/a", "b"},
+		{"/a/b/c", "/a/b", "c"},
+		{"/deeply/nested/path/object.dat", "/deeply/nested/path", "object.dat"},
+	}
+	for _, tc := range cases {
+		parent, name := splitPath(tc.in)
+		assert.Equal(t, tc.parent, parent, "parent of %s", tc.in)
+		assert.Equal(t, tc.name, name, "name of %s", tc.in)
+		assert.Equal(t, tc.in, joinPath(parent, name), "round trip of %s", tc.in)
+	}
+}
+
+func TestPathFromKeyRoundTrip(t *testing.T) {
+	for _, p := range []string{"/a", "/a/b", "/a/b/c.dat", "/x-y/z.0"} {
+		got, ok := pathFromKey(direntKey(p))
+		require.True(t, ok, "key for %s should decode", p)
+		assert.Equal(t, p, got)
+	}
+}
+
+// TestDirentKeyOrdering pins the ordering property the whole index rests on:
+// because every key ends in the bare name, a directory's children sort by
+// name with no terminator games.  The sibling set /a (a directory), /a.b, and
+// /a0b is the case that breaks a full-path key layout, where /a's marker would
+// sort between the two files.
+func TestDirentKeyOrdering(t *testing.T) {
+	keys := [][]byte{
+		direntKey("/a0b"),
+		direntKey("/a.b"),
+		direntKey("/a"),
+	}
+	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i], keys[j]) < 0 })
+
+	names := make([]string, len(keys))
+	for i, k := range keys {
+		p, ok := pathFromKey(k)
+		require.True(t, ok)
+		names[i] = p
+	}
+	assert.Equal(t, []string{"/a", "/a.b", "/a0b"}, names,
+		"entries must sort by name regardless of the bytes that follow")
+}
+
+// TestSiblingPrefixIsolation checks that a subtree's descendant range cannot
+// swallow a sibling whose name merely shares a prefix.  /a's descendants live
+// under "pd:/a/" while /a-b's children live under "pd:/a-b\x00", and the two
+// diverge at '-' (0x2D) versus '/' (0x2F).
+func TestSiblingPrefixIsolation(t *testing.T) {
+	descPrefix := descendantsPrefix("/a")
+
+	assert.True(t, bytes.HasPrefix(direntKey("/a/q/r"), descPrefix),
+		"a grandchild of /a must fall inside /a's descendant range")
+	assert.False(t, bytes.HasPrefix(direntKey("/a-b/x"), descPrefix),
+		"a child of sibling /a-b must fall outside /a's descendant range")
+	assert.False(t, bytes.HasPrefix(direntKey("/a0b"), descPrefix),
+		"sibling file /a0b must fall outside /a's descendant range")
+
+	childPrefix := childrenPrefix("/a")
+	assert.True(t, bytes.HasPrefix(direntKey("/a/b"), childPrefix))
+	assert.False(t, bytes.HasPrefix(direntKey("/a/b/c"), childPrefix),
+		"a grandchild must not appear in the direct-children range")
+	assert.False(t, bytes.HasPrefix(direntKey("/a-b"), childPrefix))
+}
+
+// TestRootDescendantsCoverEverything documents the root special case: every
+// parent path begins with "/", so the root's subtree is the whole index.
+func TestRootDescendantsCoverEverything(t *testing.T) {
+	prefix := descendantsPrefix("/")
+	for _, p := range []string{"/a", "/a/b", "/z/y/x"} {
+		assert.True(t, bytes.HasPrefix(direntKey(p), prefix), "%s should be under the root", p)
+	}
+}
+
+func TestValidatePath(t *testing.T) {
+	valid := []string{"/", "/a", "/a/b", "/a b/c", "/a-b/c.d", "/Case/Sensitive"}
+	for _, p := range valid {
+		assert.NoError(t, validatePath(p), "%q should be valid", p)
+	}
+
+	// NUL is rejected because the key encoding uses it as the separator; a
+	// name containing one would make pd:/a\x00b ambiguous between the file
+	// /a/b and a file literally named "a\x00b" at the root.
+	assert.ErrorIs(t, validatePath("/a\x00b"), ErrInvalidPath)
+	assert.ErrorIs(t, validatePath("a/b"), ErrInvalidPath, "relative paths are rejected")
+}
+
+func TestCleanRelative(t *testing.T) {
+	cases := map[string]string{
+		"/a/b":      "/a/b",
+		"a/b":       "/a/b",
+		"/a//b":     "/a/b",
+		"/a/./b":    "/a/b",
+		"/a/c/../b": "/a/b",
+		"/a/b/":     "/a/b",
+		"/":         "/",
+		"/Data.txt": "/Data.txt",
+	}
+	for in, want := range cases {
+		got, err := cleanRelative(in)
+		require.NoError(t, err, "cleaning %q", in)
+		assert.Equal(t, want, got, "cleaning %q", in)
+	}
+
+	// Escaping the root resolves to "/" via path.Clean rather than reaching
+	// outside it, which is the behavior the origin's traversal tests expect.
+	got, err := cleanRelative("/../../etc/passwd")
+	require.NoError(t, err)
+	assert.Equal(t, "/etc/passwd", got, "traversal must be clamped to the root")
+
+	_, err = cleanRelative("")
+	assert.ErrorIs(t, err, ErrInvalidPath)
+
+	_, err = cleanRelative("/bad\x00name")
+	assert.ErrorIs(t, err, ErrInvalidPath)
+}
+
+// TestCaseSensitivity guards against the case-folding bug that affects the
+// cache's URL hashing (see docs/pstore-design.md §12): pstore paths must be
+// case-sensitive, since POSIX and S3 origins are.
+func TestCaseSensitivity(t *testing.T) {
+	assert.NotEqual(t, direntKey("/ns/Data.txt"), direntKey("/ns/data.txt"),
+		"paths differing only in case must be distinct entries")
+}
+
+func TestDirentEncodeRoundTrip(t *testing.T) {
+	in := &Dirent{
+		Type:       EntryFile,
+		Generation: "deadbeef",
+		Size:       4096,
+		MTimeNanos: 1234567890,
+		Mode:       0644,
+	}
+	b, err := encodeDirent(in)
+	require.NoError(t, err)
+	out, err := decodeDirent(b)
+	require.NoError(t, err)
+	assert.Equal(t, in, out)
+}

--- a/pstore/integrity.go
+++ b/pstore/integrity.go
@@ -1,0 +1,389 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Scheduled integrity checking.
+//
+// The cache scans itself continuously, and an origin needs it more, not less:
+// a cache that discovers a corrupt object re-fetches it, while an origin has
+// nowhere to re-fetch from.  Corruption that is only discovered when a client
+// asks for the object has already been undetected for however long it sat
+// there -- possibly long enough to have propagated into every backup that
+// covers it.
+//
+// Two passes run on their own schedules, because they cost very different
+// amounts:
+//
+//   - the index check reads only the catalog, so it is cheap and frequent;
+//   - the data scan reads every block back and verifies it against the
+//     checksums recorded at ingest, so it is rate-limited and infrequent.
+//
+// Both are scheduled from the *end* of the previous run rather than on a fixed
+// cadence -- see runPeriodically, which the metadata backup loop in backup.go
+// shares for the same reason.
+//
+// Neither modifies anything.  Repair stays a deliberate operator action
+// through `pstore fsck --repair`, because the right response to a corrupt
+// object is a judgment call -- restore it, re-ingest it, or accept the loss
+// -- and not one a background task should be making at three in the morning.
+//
+// That is worth stating precisely, because the scan is the cache's and the
+// cache's policy is the opposite one.  The cache deletes an object whose data
+// no longer matches its checksums, which is exactly right for a cache: the
+// next request re-fetches it from the origin and the object is repaired.  An
+// origin has no upstream, so the same delete destroys the only copy -- and
+// with it the only record of the object's path, size, and checksums, after
+// which `fsck --repair` reclassifies the surviving entry as dangling and
+// removes that too.  The scan is therefore configured with
+// PreserveCorruptObjects, and with SkipChecksumBackfill so that the one other
+// write it would make -- recording checksums for an object that has none --
+// does not happen either.
+
+package pstore
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/local_cache"
+	"github.com/pelicanplatform/pelican/metrics"
+)
+
+// IntegrityConfig schedules the background checks.
+type IntegrityConfig struct {
+	// IndexInterval is how often the catalog-only check runs.  Zero disables
+	// it.
+	IndexInterval time.Duration
+	// DataInterval is how often every object is read back and verified.
+	// Zero disables it.
+	DataInterval time.Duration
+	// DataScanBytesPerSec caps the verification read rate so the scan does
+	// not compete with serving.  Zero selects the block store's default.
+	DataScanBytesPerSec int64
+}
+
+// StartIntegrityChecks runs the scheduled checks until the context is
+// cancelled.
+func (s *Store) StartIntegrityChecks(ctx context.Context, egrp *errgroup.Group, cfg IntegrityConfig) {
+	if cfg.IndexInterval > 0 {
+		egrp.Go(func() error {
+			s.runIndexCheckLoop(ctx, cfg.IndexInterval, realSchedule())
+			return nil
+		})
+	}
+	if cfg.DataInterval > 0 {
+		egrp.Go(func() error {
+			s.runDataScanLoop(ctx, cfg, realSchedule())
+			return nil
+		})
+	}
+	if cfg.IndexInterval > 0 || cfg.DataInterval > 0 {
+		log.Infof("pstore integrity checks: index every %s, data every %s",
+			cfg.IndexInterval, cfg.DataInterval)
+	}
+}
+
+// indexCheckOrphanShards is how many slices of the instance-hash space the
+// background index check spreads its orphan search over.
+//
+// Everything else the check does streams; the orphan search is the one part
+// that must hold a set of referenced versions in memory, and at the millions
+// of objects this design targets that set is the whole cost of the pass.
+// Covering one sixteenth of the space per run bounds it to a sixteenth of the
+// store while still sweeping everything within a day at the default hourly
+// interval -- and orphans are residue, not a failure mode that needs
+// detecting inside the hour.
+const indexCheckOrphanShards = 16
+
+// runIndexCheckLoop periodically checks the catalog against itself.
+func (s *Store) runIndexCheckLoop(ctx context.Context, interval time.Duration, sched schedule) {
+	shard := 0
+	runPeriodically(ctx, interval, sched, "index check", func() {
+		pass := beginPass(metrics.PStorePassIndexCheck, interval, sched)
+
+		report, err := s.FsckWith(ctx, FsckOptions{
+			OrphanShardOf: indexCheckOrphanShards,
+			OrphanShard:   shard,
+		})
+		shard = (shard + 1) % indexCheckOrphanShards
+		pass.finish(err == nil)
+		if err != nil {
+			log.Warnf("pstore index check failed: %v", err)
+			return
+		}
+		if report.Healthy() {
+			log.Debugf("pstore index check: %d entries, no problems", report.EntriesScanned)
+			return
+		}
+		// Loud, because an inconsistent index means some object is either
+		// unreachable or holding space nothing accounts for.
+		log.Errorf("pstore index check found problems: %d dangling entries, "+
+			"%d incomplete writes, %d orphaned versions, drift in %d directories. "+
+			"Run `pelican-server origin pstore fsck` for detail.",
+			len(report.DanglingEntries), len(report.MissingData),
+			len(report.OrphanedInstances), len(report.UsageDrift))
+	})
+}
+
+// runDataScanLoop periodically reads every object back and verifies it.
+func (s *Store) runDataScanLoop(ctx context.Context, cfg IntegrityConfig, sched schedule) {
+	checker := local_cache.NewConsistencyChecker(s.db, s.storage, newPStoreScanConfig(cfg.DataScanBytesPerSec))
+
+	runPeriodically(ctx, cfg.DataInterval, sched, "data scan", func() {
+		pass := beginPass(metrics.PStorePassDataScan, cfg.DataInterval, sched)
+
+		// The checker accumulates its statistics across every scan it has ever
+		// run, so the absolute count stays above zero forever once a single
+		// mismatch has been seen.  Compare against the count going in, so what
+		// is reported is what *this* pass found.
+		before := checker.GetStats()
+
+		// The block store's own scan does the reading and rate limiting;
+		// reimplementing that here would be a second thing to keep correct.
+		if err := checker.RunDataScan(ctx, nil); err != nil {
+			pass.finish(false)
+			if ctx.Err() == nil {
+				log.Warnf("pstore data scan failed: %v", err)
+			}
+			return
+		}
+		pass.finish(true)
+
+		// The same differencing carries the pstore-named counters.  The
+		// checker's own pelican_cache_data_scan_* series are suppressed for a
+		// pstore (see newPStoreScanConfig), so this is the only place an
+		// origin's scan is reported and nothing is counted twice.
+		after := checker.GetStats()
+		observeDataScan(before, after)
+
+		if found := after.ChecksumMismatches - before.ChecksumMismatches; found > 0 {
+			log.Errorf("pstore data scan found %d object(s) whose data no longer "+
+				"matches their checksums. Run `pelican-server origin pstore fsck --deep` "+
+				"to identify them; an origin cannot re-fetch what it has lost. "+
+				"The objects have been left in place -- restore them from backup "+
+				"or re-ingest them.", found)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Observing a scheduled pass
+// ---------------------------------------------------------------------------
+
+// passObserver reports one run of a scheduled maintenance loop.
+//
+// The three loops -- index check, data scan, metadata backup -- differ in what
+// they do and hardly at all in what an operator needs to know about them: did
+// it run, did it work, how long did it take, and is it still finishing inside
+// its interval.  So they share one set of series distinguished by a `pass`
+// label, and this is the only place that writes them.
+//
+// It deliberately does not live inside runPeriodically.  That helper is driven
+// directly by tests, and threading a metric label through it would put an
+// argument on every one of those call sites for the benefit of none of them --
+// while the backup loop's startup snapshot, which runs *before* the first
+// scheduled pass, would still need its own path.  Wrapping the work instead
+// covers both with one mechanism.
+type passObserver struct {
+	pass     string
+	interval time.Duration
+	sched    schedule
+	started  time.Time
+}
+
+// beginPass records an attempt and starts the clock.
+func beginPass(pass string, interval time.Duration, sched schedule) passObserver {
+	metrics.PStoreScheduledPassesTotal.WithLabelValues(pass).Inc()
+	return passObserver{pass: pass, interval: interval, sched: sched, started: sched.now()}
+}
+
+// finish records how the run ended.
+//
+// Only a successful run advances the last-success timestamp, which is the
+// entire value of that gauge: an alert on its age has to keep firing while a
+// loop fails every interval, rather than being reset by the attempt.  A
+// metadata backup that has been failing for a week is invisible under any
+// other arrangement.
+func (p passObserver) finish(ok bool) {
+	elapsed := p.sched.now().Sub(p.started)
+	metrics.PStoreScheduledPassLastDurationSeconds.
+		WithLabelValues(p.pass).Set(elapsed.Seconds())
+
+	// Counted for a failed run too: a pass that overruns and then errors is
+	// still a pass the configured interval cannot accommodate, and it is
+	// usually the more interesting of the two facts.
+	if p.interval > 0 && elapsed > p.interval {
+		metrics.PStoreScheduledPassOverrunsTotal.WithLabelValues(p.pass).Inc()
+	}
+
+	if !ok {
+		metrics.PStoreScheduledPassFailuresTotal.WithLabelValues(p.pass).Inc()
+		return
+	}
+	metrics.PStoreScheduledPassLastSuccessTime.
+		WithLabelValues(p.pass).Set(float64(p.sched.now().Unix()))
+}
+
+// observeDataScan publishes what one completed data scan covered.
+//
+// The checker's statistics are cumulative over the life of the process, so
+// every figure here is a difference across the pass -- the same treatment the
+// mismatch count already needed for its log message, applied to the rest.
+// Publishing the absolute values instead would produce counters that jump to
+// the running total on the first scrape after a restart.
+func observeDataScan(before, after local_cache.ConsistencyStats) {
+	add := func(c prometheus.Counter, delta int64) {
+		if delta > 0 {
+			c.Add(float64(delta))
+		}
+	}
+	add(metrics.PStoreDataScanMismatchesTotal, after.ChecksumMismatches-before.ChecksumMismatches)
+	add(metrics.PStoreDataScanObjectsTotal, after.ObjectsVerified-before.ObjectsVerified)
+	add(metrics.PStoreDataScanBytesTotal, after.BytesVerified-before.BytesVerified)
+}
+
+// ---------------------------------------------------------------------------
+// Scheduling
+// ---------------------------------------------------------------------------
+
+// periodicTimer is the part of time.Timer a scheduled loop needs.
+//
+// It is an interface so a test can supply its own.  What these loops have to
+// get right is *when* the next wait is armed relative to the work finishing,
+// and that ordering cannot be observed by sleeping and watching -- a test that
+// tried would be both slow and flaky, and this repository does not allow
+// sleep-based synchronization in the first place.
+type periodicTimer interface {
+	// Chan is the channel that fires when the wait is over.
+	Chan() <-chan time.Time
+	// Reset arms the timer to fire d from now.  It is only ever called on a
+	// timer that has already fired and been drained, so the usual
+	// Stop-then-drain dance around time.Timer.Reset does not apply.
+	Reset(d time.Duration)
+	// Stop releases the timer.
+	Stop()
+}
+
+// realTimer is the production periodicTimer.
+type realTimer struct{ t *time.Timer }
+
+func (r realTimer) Chan() <-chan time.Time { return r.t.C }
+func (r realTimer) Reset(d time.Duration)  { r.t.Reset(d) }
+func (r realTimer) Stop()                  { r.t.Stop() }
+
+// schedule supplies a periodic loop with its sense of time.
+type schedule struct {
+	// newTimer creates the timer the loop waits on, armed for the first run.
+	newTimer func(time.Duration) periodicTimer
+	// now reads the clock, which the loop uses only to measure how long a run
+	// took.
+	now func() time.Time
+}
+
+// realSchedule is the wall clock, which is what every caller outside a test
+// wants.
+func realSchedule() schedule {
+	return schedule{
+		newTimer: func(d time.Duration) periodicTimer { return realTimer{t: time.NewTimer(d)} },
+		now:      time.Now,
+	}
+}
+
+// runPeriodically calls work forever, leaving at least interval between the
+// *end* of one run and the *start* of the next, and returns when ctx is done.
+//
+// The gap, rather than the cadence, is the whole point.  A time.Ticker -- which
+// all three of these loops used to use -- fires on a fixed period no matter how
+// long the body takes.  Go drops ticks that pile up, so it does not queue an
+// unbounded backlog, but it does leave one tick pending: a data scan configured
+// to run every 24 hours that takes 24 hours to finish finds a tick already
+// waiting the moment it returns and starts again immediately.  The origin then
+// scans continuously, competing with what it is meant to be protecting, and
+// nothing in the configuration says that is what will happen.  Arming the timer
+// after the work completes makes the interval mean what an operator reads it to
+// mean.
+//
+// An overrun is logged, because it is the operator's only signal that the
+// interval is set faster than the store's size allows.  Nothing else changes:
+// the run is not cancelled and the next one is not skipped.  The message says
+// what the consequence is, since "took longer than the interval" on its own does
+// not tell anyone whether that is a problem.
+//
+// work is expected to honor ctx itself; the loop bounds when it starts, not how
+// long it runs.
+func runPeriodically(ctx context.Context, interval time.Duration, sched schedule, what string, work func()) {
+	timer := sched.newTimer(interval)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.Chan():
+		}
+
+		started := sched.now()
+		work()
+		elapsed := sched.now().Sub(started)
+
+		// Checked before the reset so the operator is told about the overrun
+		// even on the pass that is about to be cancelled.
+		if elapsed > interval {
+			log.Warnf("The pstore %s took %s, which is longer than its configured interval "+
+				"of %s. Runs are spaced from the end of one to the start of the next, so the "+
+				"next %s begins %s from now rather than immediately -- but this store is large "+
+				"enough that the check cannot actually run as often as configured. Lengthen "+
+				"the interval to match reality, or raise the scan rate limit.",
+				what, elapsed.Round(time.Second), interval, what, interval)
+		}
+
+		// Reset here, after the work, rather than letting a ticker run
+		// underneath it: this is the line that makes the interval a gap.
+		timer.Reset(interval)
+	}
+}
+
+// newPStoreScanConfig builds the checker configuration a pstore must use.
+//
+// It is a function rather than a literal at each call site so that the two
+// non-negotiable flags cannot be forgotten by a future caller: without them
+// the cache's scan deletes an object on a checksum mismatch, which for a
+// primary store is the data loss rather than the repair.
+func newPStoreScanConfig(bytesPerSec int64) local_cache.ConsistencyConfig {
+	return local_cache.ConsistencyConfig{
+		// Match what is recorded at ingest, so verification compares against
+		// checksums that actually exist.
+		ChecksumTypes:       ingestAlgorithms,
+		DataScanBytesPerSec: bytesPerSec,
+		// An origin cannot re-fetch what it has lost.
+		PreserveCorruptObjects: true,
+		// Keep the pass genuinely read-only.
+		SkipChecksumBackfill: true,
+		// The checker is the cache's, and its metrics are named for a cache.
+		// Left on, an origin's integrity scan would report itself as
+		// pelican_cache_data_scan_* -- so a process serving only an origin
+		// publishes cache series, and one serving both adds the origin's scan
+		// to the cache's on the same graph.  The equivalent figures are
+		// published under pelican_pstore_data_scan_* instead; see
+		// observeDataScan.
+		SuppressCacheMetrics: true,
+	}
+}

--- a/pstore/maintenance.go
+++ b/pstore/maintenance.go
@@ -1,0 +1,154 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Offline maintenance access, for the CLI.
+//
+// A pstore keeps its namespace in an encrypted database and its objects in
+// encrypted block files, so an operator cannot inspect it with ls or du.
+// OpenMaintenance is how the CLI gets in.
+//
+// The origin must be stopped either way: BadgerDB takes a directory lock on
+// open, and a consistency check racing a live origin's writes would not mean
+// anything.
+//
+// This deliberately does not use BadgerDB's ReadOnly mode. That mode takes a
+// shared flock rather than an exclusive one, but a running origin holds the
+// exclusive lock regardless, so read-only buys no concurrency -- and it fails
+// outright on some platforms. Instead the database is opened normally and
+// writes are refused in Go, which additionally lets `fsck --repair` work.
+//
+// The directory lock is a consequence of how the store is opened, not a
+// safety property anything is allowed to lean on. Destructive passes assert
+// their own preconditions -- `Store.repair` calls checkWritable before it
+// touches anything -- because a future path that repairs a live store would
+// otherwise turn "the lock happened to stop us" into silent data loss. fsck
+// carries the same defense at the level below: an unreferenced object version
+// is only reclaimable once it has been complete for longer than a grace
+// period and is not tombstoned as a write in flight.
+
+package pstore
+
+import (
+	"context"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/local_cache"
+)
+
+// OpenMaintenance opens a stopped store for inspection or repair.
+//
+// When allowWrites is false every mutating entry point refuses, so an
+// inspection command cannot modify the store even by mistake.
+//
+// Requires issuer keys, since the catalog is encrypted under a key derived
+// from them.  The caller must Close the result.
+func OpenMaintenance(ctx context.Context, baseDir string, allowWrites bool) (*Store, error) {
+	if baseDir == "" {
+		return nil, errors.New("pstore requires a base directory")
+	}
+
+	// Background workers still start, so give them a group to live in and
+	// stop them on Close.
+	egrp, egrpCtx := errgroup.WithContext(ctx)
+
+	db, err := local_cache.NewCacheDB(egrpCtx, baseDir)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open the pstore catalog at %s", baseDir)
+	}
+
+	// Confirm this is a pstore before interpreting any key as a pstore
+	// record.
+	//
+	// When writes are allowed the ordinary adoption rule applies, because
+	// `restore` has to be able to populate a fresh directory: an empty
+	// database is claimed, a non-empty unmarked one is refused since it can
+	// only be a cache predating the marker.  Inspection commands take the
+	// read-only check, which never writes and so never adopts -- a CLI
+	// pointed at the wrong directory should say so rather than claim it.
+	if allowWrites {
+		if err := db.EnsureStoreMode(local_cache.StoreModePStore); err != nil {
+			db.Close()
+			return nil, err
+		}
+	} else if err := verifyStoreMode(db); err != nil {
+		db.Close()
+		return nil, err
+	}
+
+	storage, err := local_cache.NewStorageManagerReadOnly(baseDir, db)
+	if err != nil {
+		db.Close()
+		return nil, errors.Wrap(err, "failed to open pstore block storage")
+	}
+
+	capacity, err := newCapacityTracker(db, storage, nil)
+	if err != nil {
+		storage.Close()
+		db.Close()
+		return nil, err
+	}
+
+	store := &Store{
+		db:        db,
+		storage:   storage,
+		bdb:       db.DB(),
+		capacity:  capacity,
+		dirLabels: storageDirLabels(storage),
+		detached:  newDetachedSet(),
+		readOnly:  !allowWrites,
+		egrp:      egrp,
+	}
+	if err := store.reloadDetached(); err != nil {
+		storage.Close()
+		db.Close()
+		return nil, err
+	}
+	return store, nil
+}
+
+// ReadOnly reports whether the store refuses mutations.
+func (s *Store) ReadOnly() bool { return s.readOnly }
+
+// verifyStoreMode checks the mode marker without writing one.
+func verifyStoreMode(db *local_cache.CacheDB) error {
+	var found local_cache.StoreMode
+	err := db.DB().View(func(txn *badger.Txn) error {
+		item, gErr := txn.Get([]byte(local_cache.KeyStoreMode))
+		if gErr != nil {
+			return gErr
+		}
+		return item.Value(func(val []byte) error {
+			found = local_cache.StoreMode(val)
+			return nil
+		})
+	})
+	if errors.Is(err, badger.ErrKeyNotFound) {
+		return errors.New("this database has no store mode marker, so it is not a pstore " +
+			"(a cache predating the marker has none; use the cache introspection commands)")
+	}
+	if err != nil {
+		return errors.Wrap(err, "failed to read the store mode marker")
+	}
+	if found != local_cache.StoreModePStore {
+		return errors.Errorf("this database belongs to a %q store, not a pstore", string(found))
+	}
+	return nil
+}

--- a/pstore/maintenance_test.go
+++ b/pstore/maintenance_test.go
@@ -1,0 +1,174 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package pstore
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/local_cache"
+)
+
+// buildStoreThenReopenReadOnly populates a store, closes it, and reopens it
+// the way the CLI does.
+func buildStoreThenReopenReadOnly(t *testing.T) *Store {
+	t.Helper()
+	local_cache.InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	egrp, _ := errgroup.WithContext(ctx)
+	dir := t.TempDir()
+
+	s, err := Open(ctx, egrp, Config{BaseDir: dir})
+	require.NoError(t, err)
+	require.NoError(t, s.MkdirAll("/data/sub"))
+	writeObject(t, s, "/data/a.txt", []byte("alpha"))
+	writeObject(t, s, "/data/sub/b.bin", randomBytes(4096, 21))
+	require.NoError(t, s.Close())
+
+	ro, err := OpenMaintenance(t.Context(), dir, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, ro.Close()) })
+	return ro
+}
+
+func TestOpenMaintenanceReads(t *testing.T) {
+	ro := buildStoreThenReopenReadOnly(t)
+	assert.True(t, ro.ReadOnly())
+
+	entries, _, err := ro.List("/data", "", 0)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a.txt", "sub"}, entryNames(entries))
+
+	d, err := ro.Stat("/data/a.txt")
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), d.Size)
+
+	got, err := ro.ReadAll("/data/a.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "alpha", string(got))
+
+	digests, err := ro.Digests("/data/a.txt")
+	require.NoError(t, err)
+	assert.NotEmpty(t, digests, "checksums recorded at ingest survive a reopen")
+}
+
+// TestOpenMaintenanceRefusesWrites checks the guard on every mutating entry
+// point, so a CLI mistake fails clearly rather than deep inside BadgerDB.
+func TestOpenMaintenanceRefusesWrites(t *testing.T) {
+	ro := buildStoreThenReopenReadOnly(t)
+
+	assert.ErrorIs(t, ro.Mkdir("/nope"), ErrNotSupported)
+	assert.ErrorIs(t, ro.MkdirAll("/nope/deep"), ErrNotSupported)
+	assert.ErrorIs(t, ro.Remove("/data/a.txt"), ErrNotSupported)
+	assert.ErrorIs(t, ro.RemoveAll("/data"), ErrNotSupported)
+	assert.ErrorIs(t, ro.Rename("/data/a.txt", "/data/c.txt"), ErrNotSupported)
+
+	_, err := ro.Create("/data/new.txt")
+	assert.ErrorIs(t, err, ErrNotSupported)
+
+	// The store is untouched.
+	_, err = ro.Stat("/data/a.txt")
+	assert.NoError(t, err)
+}
+
+// TestOpenMaintenanceFsckIsUsable is the CLI's main job: report on a stopped
+// store without changing it.
+func TestOpenMaintenanceFsckIsUsable(t *testing.T) {
+	ro := buildStoreThenReopenReadOnly(t)
+
+	report, err := ro.Fsck(t.Context(), false)
+	require.NoError(t, err)
+	assert.True(t, report.Healthy(), "a normally-built store checks out clean: %+v", report)
+	assert.Equal(t, 4, report.EntriesScanned)
+}
+
+// TestOpenMaintenanceRejectsACacheDatabase keeps the CLI from interpreting a
+// cache's records as pstore ones.  Read-only mode cannot write a marker, so a
+// database without one is refused rather than adopted.
+func TestOpenMaintenanceRejectsACacheDatabase(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	dir := t.TempDir()
+
+	db, err := local_cache.NewCacheDB(ctx, dir)
+	require.NoError(t, err)
+	require.NoError(t, db.EnsureStoreMode(local_cache.StoreModeCache))
+	require.NoError(t, db.Close())
+
+	_, err = OpenMaintenance(t.Context(), dir, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cache")
+}
+
+// TestOpenMaintenanceRefusesRepairWithoutWrites is the guard that must not be
+// the directory lock.
+//
+// A repair pass unlinks entries and queues object versions for reclamation.
+// Today the only thing stopping it from running against a live store is
+// BadgerDB refusing to open the directory twice -- which is a property of how
+// the CLI happens to get in, not of fsck. Asserting the refusal here pins it
+// to fsck itself, so that a future live-repair path has to make a deliberate
+// decision rather than inheriting one.
+func TestOpenMaintenanceRefusesRepairWithoutWrites(t *testing.T) {
+	ro := buildStoreThenReopenReadOnly(t)
+
+	_, err := ro.Fsck(t.Context(), true)
+	require.ErrorIs(t, err, ErrNotSupported)
+
+	// The store is untouched and still reportable.
+	report, err := ro.Fsck(t.Context(), false)
+	require.NoError(t, err)
+	assert.True(t, report.Healthy(), "%+v", report)
+	assert.Equal(t, 4, report.EntriesScanned)
+}
+
+// TestOpenMaintenanceFsckScansInBoundedBatches checks the pass still sees
+// every entry once its scans are split across transactions.
+//
+// The batching exists so that an hourly check over millions of objects does
+// not pin BadgerDB's read watermark for its whole duration; an off-by-one in
+// the resume key would either skip entries or deliver them twice, and both
+// are silent.
+func TestOpenMaintenanceFsckScansInBoundedBatches(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.Mkdir("/many"))
+
+	// More entries than one batch, so the resume path is exercised rather
+	// than just the first pass.
+	const count = fsckBatchSize + 37
+	for i := range count {
+		writeObject(t, s, fmt.Sprintf("/many/obj-%05d", i), []byte("x"))
+	}
+
+	report, err := s.FsckWith(t.Context(), FsckOptions{MinAge: FsckNoGracePeriod})
+	require.NoError(t, err)
+	assert.Equal(t, count+1, report.EntriesScanned,
+		"every entry is delivered exactly once across batch boundaries")
+	assert.Equal(t, 1, report.DirectoriesScanned)
+	assert.True(t, report.Healthy(), "%+v", report)
+}

--- a/pstore/metrics_test.go
+++ b/pstore/metrics_test.go
@@ -1,0 +1,414 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package pstore
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/local_cache"
+	"github.com/pelicanplatform/pelican/metrics"
+)
+
+// The collectors are process-global, so these tests read them by gathering the
+// default registry rather than by holding references.  That is deliberate: it
+// checks the series an operator would actually scrape, including its name,
+// which a direct read of the collector variable would not.
+
+// seriesValue reads one series out of a metric family, matching every label
+// given.  The bool reports whether the series exists at all, which is the
+// difference between "published as zero" and "never published".
+//
+// Gauges and counters share one reader.  A family carries one or the other, so
+// the unset accessor returns a nil message whose value is zero -- which makes
+// the sum unambiguous, and saves a second copy of the label matching that is
+// the only interesting part of this.
+func seriesValue(t *testing.T, name string, labels map[string]string) (float64, bool) {
+	t.Helper()
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			matched := true
+			for wantName, wantValue := range labels {
+				found := false
+				for _, l := range m.GetLabel() {
+					if l.GetName() == wantName && l.GetValue() == wantValue {
+						found = true
+						break
+					}
+				}
+				if !found {
+					matched = false
+					break
+				}
+			}
+			if matched {
+				return m.GetGauge().GetValue() + m.GetCounter().GetValue(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+// gaugeValue is seriesValue where the caller cares whether the gauge was ever
+// published.
+func gaugeValue(t *testing.T, name string, labels map[string]string) (float64, bool) {
+	t.Helper()
+	return seriesValue(t, name, labels)
+}
+
+// labeledCounterValue is seriesValue where an untouched counter and a counter
+// at zero mean the same thing.
+func labeledCounterValue(t *testing.T, name string, labels map[string]string) float64 {
+	t.Helper()
+	v, _ := seriesValue(t, name, labels)
+	return v
+}
+
+// TestCapacityGaugesPublishedFromRecoveredUsageAtOpen is the restart case.
+//
+// The capacity gauges describe a level, not an event, so a store that comes
+// back up holding data must say so before anything is written to it.  Left to
+// the write path they would read zero for however long it took the next PUT to
+// arrive -- which is exactly the window in which an operator restarting a full
+// origin looks at the dashboard.
+func TestCapacityGaugesPublishedFromRecoveredUsageAtOpen(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+
+	const limit = 8 << 20
+	dir := t.TempDir()
+	cfg := Config{
+		BaseDir:     dir,
+		StorageDirs: []local_cache.StorageDirConfig{{Path: dir, MaxSize: limit}},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	egrp, _ := errgroup.WithContext(ctx)
+
+	first, err := Open(ctx, egrp, cfg)
+	require.NoError(t, err)
+
+	// Large enough to land in a storage directory rather than in the catalog,
+	// so the per-directory gauge has something to report.
+	writeObject(t, first, "/obj.bin", randomBytes(256<<10, 7))
+	wantUsed, wantMax := first.Usage()
+	require.Positive(t, wantUsed)
+	require.NoError(t, first.Close())
+
+	// Poison the gauges so that anything read below can only have come from
+	// the reopen.  Without this the test would pass on the values the first
+	// store left behind.
+	const poison = -12345
+	metrics.PStoreUsedBytes.Set(poison)
+	metrics.PStoreLimitBytes.Set(poison)
+	metrics.PStoreDirectoryUsedBytes.Reset()
+	metrics.PStoreDirectoryLimitBytes.Reset()
+
+	second, err := Open(ctx, egrp, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, second.Close()) })
+
+	gotUsed, ok := gaugeValue(t, "pelican_pstore_used_bytes", nil)
+	require.True(t, ok, "the aggregate usage gauge must be published at open")
+	assert.Equal(t, float64(wantUsed), gotUsed,
+		"the gauge must carry the usage the tracker recovered from the catalog, "+
+			"not zero until the first write")
+
+	gotMax, ok := gaugeValue(t, "pelican_pstore_limit_bytes", nil)
+	require.True(t, ok)
+	assert.Equal(t, float64(wantMax), gotMax)
+	assert.Equal(t, float64(limit), gotMax, "the configured ceiling is the aggregate one")
+
+	// The same for the directory the bytes actually landed in.  The label is
+	// the configured path, not the block store's "objects" subdirectory.
+	label, ok := second.dirLabels[storageIDForPath(t, second, dir)]
+	require.True(t, ok)
+	assert.Equal(t, dir, label, "the gauge is labeled with the directory as configured")
+
+	dirUsed, ok := gaugeValue(t, "pelican_pstore_directory_used_bytes",
+		map[string]string{"directory": label})
+	require.True(t, ok, "the per-directory usage gauge must be published at open")
+	assert.Positive(t, dirUsed)
+
+	dirLimit, ok := gaugeValue(t, "pelican_pstore_directory_limit_bytes",
+		map[string]string{"directory": label})
+	require.True(t, ok)
+	assert.Equal(t, float64(limit), dirLimit)
+
+	// The inline pseudo-directory is reported too, under a name that is
+	// deliberately not a path so it cannot be confused with a real one.
+	_, ok = gaugeValue(t, "pelican_pstore_directory_used_bytes",
+		map[string]string{"directory": metrics.PStoreDirectoryInline})
+	assert.True(t, ok, "objects held in the catalog are accounted for as well")
+}
+
+// storageIDForPath finds the storage ID the block store assigned to a
+// configured directory.
+func storageIDForPath(t *testing.T, s *Store, path string) local_cache.StorageID {
+	t.Helper()
+	for id, label := range s.dirLabels {
+		if label == path {
+			return id
+		}
+	}
+	t.Fatalf("no storage directory is labeled %s", path)
+	return 0
+}
+
+// TestFailedBackupDoesNotAdvanceLastSuccess covers the one property the whole
+// backup-freshness alert rests on.
+//
+// "Seconds since the last successful snapshot" is only a useful alert if a
+// failing pass leaves the timestamp alone.  A pass that advanced it on every
+// attempt would make an origin whose backups have been failing for a week look
+// like one that backed up minutes ago -- which is precisely the failure the
+// metric exists to catch, reported as health.
+func TestFailedBackupDoesNotAdvanceLastSuccess(t *testing.T) {
+	s := newTestStore(t)
+
+	passLabels := map[string]string{"pass": metrics.PStorePassMetadataBackup}
+	const (
+		attemptsMetric = "pelican_pstore_scheduled_passes_total"
+		failuresMetric = "pelican_pstore_scheduled_pass_failures_total"
+		successMetric  = "pelican_pstore_scheduled_pass_last_success_timestamp_seconds"
+	)
+
+	attemptsBefore := labeledCounterValue(t, attemptsMetric, passLabels)
+	failuresBefore := labeledCounterValue(t, failuresMetric, passLabels)
+	successBefore, _ := gaugeValue(t, successMetric, passLabels)
+
+	// A backup directory whose parent is a regular file cannot be created, so
+	// the snapshot fails the way a wrong path or a bad owner would.
+	blocker := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0600))
+
+	badCfg := BackupConfig{
+		Dir:      filepath.Join(blocker, "backups"),
+		Interval: time.Hour,
+		Keep:     2,
+		Keys:     testBackupKeys(t),
+	}
+	runOneBackup(t, s, badCfg)
+
+	assert.Equal(t, attemptsBefore+1, labeledCounterValue(t, attemptsMetric, passLabels),
+		"a failed pass is still an attempt")
+	assert.Equal(t, failuresBefore+1, labeledCounterValue(t, failuresMetric, passLabels),
+		"a failed backup increments the failure counter")
+
+	successAfterFailure, _ := gaugeValue(t, successMetric, passLabels)
+	assert.Equal(t, successBefore, successAfterFailure,
+		"a failed backup must not advance the last-success timestamp")
+
+	// And the counterpart: a snapshot that lands does advance it, and records
+	// what it published.
+	goodCfg := badCfg
+	goodCfg.Dir = t.TempDir()
+	runOneBackup(t, s, goodCfg)
+
+	assert.Equal(t, failuresBefore+1, labeledCounterValue(t, failuresMetric, passLabels),
+		"a successful backup does not increment failures")
+
+	successAfterSuccess, ok := gaugeValue(t, successMetric, passLabels)
+	require.True(t, ok)
+	assert.Greater(t, successAfterSuccess, successAfterFailure,
+		"a successful backup advances the last-success timestamp")
+
+	size, ok := gaugeValue(t, "pelican_pstore_metadata_backup_last_size_bytes", nil)
+	require.True(t, ok)
+	assert.Positive(t, size, "the published snapshot's size is recorded")
+}
+
+// runOneBackup drives the real backup loop through exactly its startup
+// snapshot.
+//
+// The context is already cancelled, so runPeriodically returns without arming
+// anything: the loop runs once, synchronously, and nothing here waits on a
+// clock.  Going through runBackupLoop rather than calling snapshotOnce is the
+// point -- the instrumentation lives in the loop, and a test that bypassed it
+// would pass with the loop unwired.
+func runOneBackup(t *testing.T, s *Store, cfg BackupConfig) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	s.runBackupLoop(ctx, cfg, realSchedule())
+}
+
+// TestWriteTierCounterAttributesEachTier checks that a write is counted under
+// the tier that actually stored it.
+//
+// The tier is not a property of the request: it is chosen by how much data
+// arrives, and a declared length only pre-selects it.  Getting the attribution
+// wrong would make the distribution -- the whole reason an operator looks at
+// this -- describe something other than where their objects went.
+func TestWriteTierCounterAttributesEachTier(t *testing.T) {
+	s := newTestStore(t)
+
+	inlineMax := int64(s.storage.InlineMaxBytes())
+	require.Positive(t, inlineMax)
+	require.Less(t, inlineMax, int64(spillThreshold),
+		"the buffered tier only exists between these two thresholds")
+
+	const metric = "pelican_pstore_writes_total"
+	tierLabels := func(tier string) map[string]string { return map[string]string{"tier": tier} }
+
+	before := map[string]float64{}
+	for _, tier := range []string{
+		metrics.PStoreTierInline, metrics.PStoreTierBuffered, metrics.PStoreTierStreamed,
+	} {
+		before[tier] = labeledCounterValue(t, metric, tierLabels(tier))
+	}
+
+	// One object per tier, sized by the same thresholds the write path uses.
+	writeObject(t, s, "/inline.bin", randomBytes(int(inlineMax), 1))
+	writeObject(t, s, "/buffered.bin", randomBytes(int(inlineMax)+1024, 2))
+	writeObject(t, s, "/streamed.bin", randomBytes(spillThreshold+4096, 3))
+
+	for _, tier := range []string{
+		metrics.PStoreTierInline, metrics.PStoreTierBuffered, metrics.PStoreTierStreamed,
+	} {
+		assert.Equal(t, before[tier]+1, labeledCounterValue(t, metric, tierLabels(tier)),
+			"exactly one write should have been attributed to the %q tier", tier)
+	}
+
+	// A write that never lands is not counted at all: the counter describes
+	// what the store holds, not what was attempted.
+	w, err := s.Create("/aborted.bin")
+	require.NoError(t, err)
+	_, err = w.Write(randomBytes(4096, 4))
+	require.NoError(t, err)
+	require.NoError(t, w.Abort())
+
+	total := 0.0
+	for _, tier := range []string{
+		metrics.PStoreTierInline, metrics.PStoreTierBuffered, metrics.PStoreTierStreamed,
+	} {
+		total += labeledCounterValue(t, metric, tierLabels(tier)) - before[tier]
+	}
+	assert.Equal(t, 3.0, total, "an aborted write is not counted under any tier")
+}
+
+// TestReclamationBacklogIsCountedToTheEndOfTheQueue covers the measurement the
+// backlog gauge depends on.
+//
+// collectGarbage stops at the batch size because it has to hold what it
+// collects; queueDepth holds nothing and must therefore report the real
+// number.  A count that saturated at the batch size would make a queue of half
+// a million look identical to one of five hundred that is perfectly stable --
+// the two cases the gauge exists to tell apart.
+func TestReclamationBacklogIsCountedToTheEndOfTheQueue(t *testing.T) {
+	s := newTestStore(t)
+
+	instances, subtrees, err := s.queueDepth()
+	require.NoError(t, err)
+	assert.Zero(t, instances, "a fresh store has nothing queued")
+	assert.Zero(t, subtrees)
+
+	const objects = 5
+	for i := range objects {
+		name := "/obj" + string(rune('a'+i)) + ".bin"
+		writeObject(t, s, name, randomBytes(2048, int64(i)))
+		require.NoError(t, s.Remove(name))
+	}
+	// A detached subtree is queued under a different kind, and the two must
+	// not be conflated: one is bytes waiting to be freed, the other is paths
+	// that are refusing writes until the drain finishes.
+	require.NoError(t, s.bdb.Update(func(txn *badger.Txn) error {
+		return enqueueSubtree(txn, "/detached")
+	}))
+
+	instances, subtrees, err = s.queueDepth()
+	require.NoError(t, err)
+	assert.Equal(t, objects, instances, "every deleted version is waiting on the queue")
+	assert.Equal(t, 1, subtrees)
+
+	// The gauge follows, and the sweep drains what it counted.
+	s.publishReclamationMetrics()
+	pending, ok := gaugeValue(t, "pelican_pstore_reclamation_pending",
+		map[string]string{"kind": metrics.PStoreReclaimKindInstance})
+	require.True(t, ok)
+	assert.Equal(t, float64(objects), pending)
+
+	stats, err := s.RunGC(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, objects, stats.InstancesFreed)
+	assert.Positive(t, stats.BytesFreed, "reclaimed bytes are reported alongside the count")
+
+	instances, _, err = s.queueDepth()
+	require.NoError(t, err)
+	assert.Zero(t, instances, "the sweep drained what the gauge reported")
+}
+
+// TestFsckFindingsGaugeReflectsRepair covers the one piece of judgment in the
+// fsck gauges: a repaired store must stop reporting the findings repair
+// resolved.
+//
+// The report keeps its lists either way -- they are what the pass found -- but
+// a gauge answers "is anything wrong now".  Left high after the unservable
+// entries were unlinked, it would send an operator after a problem that no
+// longer exists, every time they ran the fix.
+func TestFsckFindingsGaugeReflectsRepair(t *testing.T) {
+	s := newTestStore(t)
+
+	writeObject(t, s, "/a.bin", []byte("one"))
+	writeObject(t, s, "/b.bin", []byte("two"))
+
+	// Delete one object's metadata behind the index's back, which is what a
+	// dangling entry is.
+	d, err := s.Stat("/a.bin")
+	require.NoError(t, err)
+	require.NoError(t, s.db.DeleteMetadata(instanceHashFor(s.db, d.Generation)))
+
+	danglingLabels := map[string]string{"kind": metrics.PStoreFsckDanglingEntries}
+
+	report, err := s.Fsck(t.Context(), false)
+	require.NoError(t, err)
+	require.Len(t, report.DanglingEntries, 1)
+
+	dangling, ok := gaugeValue(t, "pelican_pstore_fsck_findings", danglingLabels)
+	require.True(t, ok, "a completed pass publishes its findings")
+	assert.Equal(t, 1.0, dangling)
+
+	// The object count comes from the same index walk, so it costs no extra
+	// scan and is available as soon as the first pass finishes.
+	objects, ok := gaugeValue(t, "pelican_pstore_objects", nil)
+	require.True(t, ok)
+	assert.Equal(t, 2.0, objects, "two files, the root directory excluded")
+
+	_, err = s.Fsck(t.Context(), true)
+	require.NoError(t, err)
+
+	dangling, ok = gaugeValue(t, "pelican_pstore_fsck_findings", danglingLabels)
+	require.True(t, ok)
+	assert.Zero(t, dangling, "repair unlinked the entry, so nothing is left to report")
+}

--- a/pstore/object.go
+++ b/pstore/object.go
@@ -1,0 +1,76 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Object identity.
+//
+// Every write mints a generation: 128 random bits that serve as the version's
+// identity, its HTTP ETag, and the input to its storage key.
+//
+//	instanceHash = HMAC(salt, "gen:" + generation)
+//
+// The derivation deliberately does not involve the path.  That keeps the
+// object's metadata, block state, and on-disk data files path-independent, so
+// renaming an entry rewrites index keys and moves no bytes.  It also means two
+// paths can never collide on a storage key the way the cache's URL-derived
+// hashes can (see docs/pstore-design.md §12).
+//
+// Data files stay hash-named on disk, so an attacker holding the disks but not
+// the master key still cannot tell which objects a store contains.
+
+package pstore
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/pkg/errors"
+
+	"github.com/pelicanplatform/pelican/local_cache"
+)
+
+// generationBytes is the size of a generation token.  128 bits is enough that
+// a collision is not worth reasoning about, and it doubles as a strong opaque
+// ETag.
+const generationBytes = 16
+
+// newGeneration mints a fresh version token.
+func newGeneration() (string, error) {
+	buf := make([]byte, generationBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", errors.Wrap(err, "failed to generate an object version token")
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// instanceHashFor derives the storage key for a generation.
+func instanceHashFor(db *local_cache.CacheDB, generation string) local_cache.InstanceHash {
+	h := hmac.New(sha256.New, db.Salt())
+	h.Write([]byte("gen:"))
+	h.Write([]byte(generation))
+	return local_cache.InstanceHash(hex.EncodeToString(h.Sum(nil)))
+}
+
+// etagFor renders a generation as a strong HTTP entity tag.
+func etagFor(generation string) string {
+	if generation == "" {
+		return ""
+	}
+	return `"` + generation + `"`
+}

--- a/pstore/object_io.go
+++ b/pstore/object_io.go
@@ -1,0 +1,904 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Reading and writing object content.
+//
+// Objects are immutable.  A write always builds a complete new version and
+// swaps it in at Close; there is no partial update, and a seek-then-write is
+// refused rather than emulated.
+//
+// The write path has three tiers, chosen by how much data actually arrives:
+//
+//	<= InlineThreshold   stored directly in the catalog
+//	<= spillThreshold    buffered, then written with the exact length known
+//	>  spillThreshold    streamed through AppendWriter, length discovered at
+//	                     the end
+//
+// The middle tier matters for capacity.  AppendWriter allocates whole chunks
+// while streaming, so routing a 100 KB object through it would reserve a full
+// chunk and hold it until Finalize refunds the difference — enough to
+// spuriously fail a write on a near-full store.  Buffering to the spill
+// threshold means only genuinely large objects take that path, where the
+// overshoot is proportionally small.
+//
+// The chunk size is therefore not a constant: it is derived from the declared
+// length when there is one, and bounded by minStreamChunkSize either way, so
+// that the gap between "we stopped buffering" and "we reserve a whole chunk"
+// stays a small factor rather than the 64× it would be at the block store's
+// largest chunk size.  See streamChunkSizeCodeFor.
+
+package pstore
+
+import (
+	"context"
+	"io"
+	"runtime"
+	"sync/atomic"
+	"time"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/pelicanplatform/pelican/local_cache"
+	"github.com/pelicanplatform/pelican/metrics"
+)
+
+const (
+	// spillThreshold is how much of an object is buffered before switching to
+	// streaming.  Below it the exact length is known at Close, so storage is
+	// allocated once at the right size.
+	//
+	// The buffer is per in-flight write and cannot be evicted, so this trades
+	// directly against concurrency: at 8 MiB a hundred concurrent uploads
+	// could pin most of a gigabyte. 1 MiB keeps the common small-object case
+	// on the exact-length path while bounding what a burst of writers holds.
+	spillThreshold = 1 << 20
+
+	// minStreamChunkSize is the smallest chunk the block store can encode
+	// (ChunkSizeCode 1 is 2 MiB), and therefore the floor for anything
+	// streamed.  Keeping it within a small factor of spillThreshold is what
+	// makes a bounded store usable: AppendWriter pre-allocates and charges a
+	// whole chunk the moment a stream touches it, so the chunk size is the
+	// real minimum free space an object above the spill threshold demands.
+	minStreamChunkSize = 2 << 20
+
+	// maxStreamChunkSize caps the chunk size for a stream whose length is
+	// declared.  A genuinely large upload wants large chunks -- a terabyte at
+	// the minimum chunk size would be half a million files -- and it needs the
+	// space anyway, so the over-reservation is proportionally nothing.
+	maxStreamChunkSize = 64 << 20
+
+	// defaultStreamChunkSize is used when the length is not declared at all,
+	// which is what a chunked transfer-encoding PUT looks like.  There is no
+	// way to size the chunk from the object, so this is a deliberate
+	// compromise: eight times the spill threshold, so a store only needs
+	// ~8 MiB of headroom in some directory to accept an unknown-length
+	// object, at the cost of eight times as many chunk files as
+	// maxStreamChunkSize would produce for a very large one.  A caller that
+	// knows the length gets a chunk sized to it instead; see CreateSized.
+	defaultStreamChunkSize = 8 << 20
+)
+
+// streamChunkSizeCodeFor picks the chunk size a streamed write should use.
+//
+// A declared length is honored up to maxStreamChunkSize so that an object
+// just past the spill threshold reserves megabytes rather than the fixed
+// 64 MiB the block store's largest chunk would cost -- the difference between
+// a bounded store accepting a 2 MiB object and refusing every object over
+// 1 MiB unless some directory happens to have 64 MiB free.
+func streamChunkSizeCodeFor(declaredLen int64) local_cache.ChunkSizeCode {
+	want := declaredLen
+	if want <= 0 {
+		want = defaultStreamChunkSize
+	}
+	if want < minStreamChunkSize {
+		want = minStreamChunkSize
+	}
+	if want > maxStreamChunkSize {
+		want = maxStreamChunkSize
+	}
+
+	// The encoded size is rounded down to a block boundary, so the chosen code
+	// can land a few kilobytes under the request and an object sized exactly
+	// at a chunk boundary spills into a second chunk.  That is deliberately
+	// left alone: two chunks of N cost the same reservation as one chunk of
+	// 2N, and stepping the code up would silently double the chunk size for
+	// the undeclared case -- 8 MiB becoming 16 MiB -- which is the very
+	// over-reservation this function exists to avoid.
+	return local_cache.BytesToChunkSizeCode(uint64(want))
+}
+
+// chunkedFootprint is the on-disk size a streamed object of contentLen bytes
+// occupies while it is being written: whole chunks, because AppendWriter keeps
+// the provisional length chunk-aligned and every allocated chunk is
+// pre-allocated and charged at full size.  Finalize trims the tail afterwards.
+func chunkedFootprint(contentLen, chunkSize int64) int64 {
+	chunks := (contentLen + chunkSize - 1) / chunkSize
+	if chunks < 1 {
+		chunks = 1
+	}
+	return chunks * local_cache.CalculateFileSize(chunkSize)
+}
+
+// plannedFootprint reports the bytes a write of contentLen will occupy and the
+// largest single unit the block store has to fit into one directory.
+//
+// It is the one place that knows how a length maps onto a storage tier, so
+// that the pre-flight check (HasCapacityFor) and the reservation the write
+// actually takes cannot drift apart.
+func (s *Store) plannedFootprint(contentLen int64) (need, unit int64) {
+	if contentLen <= int64(s.storage.InlineMaxBytes()) {
+		// Inline objects live in the catalog, are charged their content
+		// length, and never occupy a storage directory -- so they count
+		// against the aggregate but impose no per-directory requirement.
+		return contentLen, 0
+	}
+	if contentLen < spillThreshold {
+		need = local_cache.CalculateFileSize(contentLen)
+		return need, need
+	}
+	chunkSize := int64(local_cache.ChunkSizeCodeToBytes(streamChunkSizeCodeFor(contentLen)))
+	return chunkedFootprint(contentLen, chunkSize), local_cache.CalculateFileSize(chunkSize)
+}
+
+// ---------------------------------------------------------------------------
+// Writing
+// ---------------------------------------------------------------------------
+
+// WriteHandle accumulates a new version of an object and installs it at Close.
+//
+// Not safe for concurrent use.  Nothing the handle writes is visible to
+// readers until Close returns successfully.
+type WriteHandle struct {
+	store *Store
+	path  string
+
+	generation   string
+	instanceHash local_cache.InstanceHash
+
+	buf     []byte
+	spilled bool
+	aw      *local_cache.AppendWriter
+
+	// declaredSize is the length the caller promised, or -1 when unknown.  It
+	// only sizes the storage tier and the streaming chunk; the object is
+	// stored at whatever length actually arrives.
+	declaredSize int64
+
+	// chunkSize is the streaming chunk size, fixed at spill.  Zero until then.
+	chunkSize int64
+
+	// unpin releases the pin taken for the duration of materialization, which
+	// is what keeps the janitor from reclaiming the half-built instance the
+	// commit is about to make reachable.  Nil outside that window.
+	unpin func()
+
+	// written is atomic because Stat reads it while Write advances it.  The
+	// handle is single-writer by contract, but webdav.handlePut stats the
+	// file between writing and closing, and a caller is free to stat from
+	// another goroutine; a torn read of an int64 is not worth the risk.
+	written atomic.Int64
+
+	// reserved is the capacity claimed so far; released or settled at the end.
+	reserved int64
+
+	// tier records which of the three storage tiers materialize actually
+	// used, for pelican_pstore_writes_total.  It is set there rather than
+	// recomputed from the handle's state at Close so that the counter cannot
+	// drift from the decision it is reporting on -- the two conditions are
+	// subtle enough (a spilled handle is streamed even if the content turned
+	// out to be tiny) that a second copy of them would eventually disagree.
+	tier string
+
+	// digests hash the stream as it is written, so a later Want-Digest is a
+	// metadata read rather than a re-read of the object.
+	digests *ingestDigests
+
+	// requireAbsent and requireGeneration carry conditional-write
+	// preconditions evaluated in the commit transaction.
+	requireAbsent     bool
+	requireGeneration string
+
+	done bool
+}
+
+// Create begins a new version of the object at name.  The parent directory
+// must exist.  Nothing changes on disk until Close.
+func (s *Store) Create(name string) (*WriteHandle, error) {
+	if err := s.checkWritable(); err != nil {
+		return nil, err
+	}
+	cleanPath, err := cleanRelative(name)
+	if err != nil {
+		return nil, err
+	}
+	if isRootPath(cleanPath) {
+		return nil, ErrIsDir
+	}
+
+	if err := s.checkNotDraining(cleanPath); err != nil {
+		return nil, err
+	}
+
+	parent, _ := splitPath(cleanPath)
+	err = s.bdb.View(func(txn *badger.Txn) error {
+		if pErr := s.requireDirResolved(txn, parent); pErr != nil {
+			return pErr
+		}
+		// Refuse up front when the target is a directory; the commit checks
+		// again, since another writer could intervene.
+		d, gErr := s.resolve(txn, cleanPath)
+		if gErr == nil && d.IsDir() {
+			return ErrIsDir
+		}
+		if gErr != nil && !errors.Is(gErr, ErrNotExist) {
+			return gErr
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	generation, err := newGeneration()
+	if err != nil {
+		return nil, err
+	}
+	digests, err := newIngestDigests()
+	if err != nil {
+		return nil, err
+	}
+
+	return &WriteHandle{
+		store:        s,
+		path:         cleanPath,
+		generation:   generation,
+		instanceHash: instanceHashFor(s.db, generation),
+		buf:          make([]byte, 0, 64<<10),
+		digests:      digests,
+		declaredSize: -1,
+	}, nil
+}
+
+// CreateSized is Create for a caller that already knows the object's length.
+//
+// The size only selects the storage tier up front; it is a hint, not a
+// promise, and the object is stored at whatever length actually arrives.  A
+// declared size at or above the spill threshold goes straight to the streaming
+// writer, so a large upload never buffers a megabyte first.
+//
+// A negative size means unknown and behaves exactly like Create.
+//
+// Declaring the size also sizes the streaming chunk, which is what lets a
+// bounded store accept an object a little over the spill threshold: an
+// undeclared write has to assume defaultStreamChunkSize.
+func (s *Store) CreateSized(name string, size int64) (*WriteHandle, error) {
+	w, err := s.Create(name)
+	if err != nil {
+		return nil, err
+	}
+	w.declaredSize = size
+	if size >= spillThreshold {
+		if sErr := w.spill(); sErr != nil {
+			_ = w.Abort()
+			return nil, sErr
+		}
+	}
+	return w, nil
+}
+
+// RequireAbsent makes Close fail with ErrExist if the object already exists,
+// implementing "If-None-Match: *".
+func (w *WriteHandle) RequireAbsent() { w.requireAbsent = true }
+
+// RequireGeneration makes Close fail with ErrPreconditionFailed unless the
+// object still carries the given generation, implementing "If-Match".
+func (w *WriteHandle) RequireGeneration(generation string) {
+	w.requireGeneration = generation
+}
+
+// Generation returns the version token this write will install, which is also
+// the object's ETag.
+func (w *WriteHandle) Generation() string { return w.generation }
+
+// Size returns how many bytes have been accepted so far.  The object is not
+// visible at its path until Close, so this is the only way to observe the
+// pending version's length.
+func (w *WriteHandle) Size() int64 { return w.written.Load() }
+
+// Path returns the object path this write will install to.
+func (w *WriteHandle) Path() string { return w.path }
+
+// Write appends to the new version.
+func (w *WriteHandle) Write(p []byte) (int, error) {
+	if w.done {
+		return 0, ErrClosed
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	if !w.spilled {
+		if len(w.buf)+len(p) <= spillThreshold {
+			if err := w.ensureReserved(int64(len(w.buf) + len(p))); err != nil {
+				return 0, err
+			}
+			w.buf = append(w.buf, p...)
+			w.written.Add(int64(len(p)))
+			w.digests.Write(p)
+			return len(p), nil
+		}
+		// Crossed the threshold: switch to streaming and hand over the
+		// buffered prefix.
+		if err := w.spill(); err != nil {
+			return 0, err
+		}
+	}
+
+	if err := w.ensureReserved(w.written.Load() + int64(len(p))); err != nil {
+		return 0, err
+	}
+	n, err := w.aw.Write(p)
+	if err != nil {
+		return n, err
+	}
+	w.written.Add(int64(n))
+	w.digests.Write(p[:n])
+	return n, nil
+}
+
+// spill switches from buffering to the streaming writer.
+//
+// The reservation is taken up to the streamed footprint *before* the buffered
+// prefix is handed over, because that first write allocates and charges a
+// whole chunk; reserving afterwards would let the charge land on a store that
+// had no room for it.
+func (w *WriteHandle) spill() error {
+	sizeCode := streamChunkSizeCodeFor(w.declaredSize)
+	w.chunkSize = int64(local_cache.ChunkSizeCodeToBytes(sizeCode))
+	if w.chunkSize <= 0 {
+		return errors.Errorf("invalid streaming chunk size code %d", sizeCode)
+	}
+	// From here the footprint is counted in whole chunks even if the writer
+	// below fails to come up; discard releases whatever was claimed.
+	w.spilled = true
+	buffered := w.buf
+	if err := w.ensureReserved(int64(len(buffered))); err != nil {
+		return err
+	}
+
+	aw, err := w.store.storage.NewAppendWriter(
+		context.Background(),
+		w.instanceHash,
+		w.store.namespaceID,
+		sizeCode,
+	)
+	if err != nil {
+		return err
+	}
+	if len(buffered) > 0 {
+		if _, wErr := aw.Write(buffered); wErr != nil {
+			_ = aw.Abort()
+			return wErr
+		}
+	}
+	w.aw = aw
+	w.buf = nil
+	return nil
+}
+
+// ensureReserved keeps the capacity reservation at least as large as the
+// object's on-disk footprint will be, so a write that would overflow the
+// store is refused before its bytes are committed.
+//
+// For a streamed object the footprint is whole chunks, not the content length:
+// AppendWriter keeps its provisional length chunk-aligned, so every chunk the
+// stream touches is pre-allocated and charged in full.  Reserving only the
+// content length is how concurrent writers sail past the ceiling -- each ends
+// up charged a fraction of what it actually holds.  Finalize trims the tail and
+// settle refunds the difference once the real footprint is known.
+//
+// The unit passed alongside is the placement granularity: a streamed object is
+// laid down one chunk at a time, each landing whole in a single directory, so
+// some directory must have room for a chunk.  A buffered object is written in
+// one piece and needs room for the whole thing.
+func (w *WriteHandle) ensureReserved(contentLen int64) error {
+	need := w.footprintFor(contentLen)
+	if need <= w.reserved {
+		return nil
+	}
+	unit := need
+	if w.spilled {
+		unit = local_cache.CalculateFileSize(w.chunkSize)
+	}
+	delta := need - w.reserved
+	if err := w.store.capacity.reserve(delta, unit, w.reserved); err != nil {
+		// Only the failure path is instrumented; the success path is the hot
+		// one and stays a bare reservation.  This is the mid-write refusal --
+		// the pre-flight one is counted in HasCapacityFor, and a request
+		// cannot take both, because a pre-flight refusal never opens a handle.
+		if errors.Is(err, ErrNoSpace) {
+			metrics.PStoreWriteFailuresTotal.
+				WithLabelValues(metrics.PStoreWriteFailureNoSpace).Inc()
+		}
+		return err
+	}
+	w.reserved += delta
+	return nil
+}
+
+// footprintFor is the on-disk size contentLen bytes will occupy in the tier
+// this handle is writing through.
+func (w *WriteHandle) footprintFor(contentLen int64) int64 {
+	if w.spilled {
+		return chunkedFootprint(contentLen, w.chunkSize)
+	}
+	return local_cache.CalculateFileSize(contentLen)
+}
+
+// Close finalizes the object's data and installs it at its path.
+//
+// The install is one transaction: it re-checks preconditions, writes the new
+// dirent, and queues the superseded version for reclamation.  Committing the
+// swap and the queue entry together is what makes overwrite crash-safe.  A
+// concurrent writer to the same path can abort that transaction, in which case
+// it is retried against fresh state; see install.
+func (w *WriteHandle) Close() error {
+	if w.done {
+		return ErrClosed
+	}
+	w.done = true
+
+	if err := w.beginMaterialize(); err != nil {
+		w.discard()
+		return err
+	}
+
+	meta, err := w.materialize()
+	if err != nil {
+		w.discard()
+		return err
+	}
+
+	now := time.Now()
+	entry := &Dirent{
+		Type:       EntryFile,
+		Generation: w.generation,
+		Size:       w.written.Load(),
+		MTimeNanos: now.UnixNano(),
+		Mode:       uint32(defaultFileMode),
+	}
+
+	if err := w.install(entry); err != nil {
+		w.discard()
+		return err
+	}
+	w.endMaterialize()
+
+	// The write landed; convert the estimate into real per-directory usage.
+	if meta != nil {
+		w.store.capacity.settle(w.reserved, meta.PerDirectoryBytes())
+	} else {
+		w.store.capacity.settle(w.reserved, nil)
+	}
+	w.reserved = 0
+
+	// Counted only once the object is installed, so the tier distribution
+	// describes what the store holds rather than what was attempted.  One
+	// atomic add per object; the capacity gauges are deliberately *not*
+	// republished here, since that would put four gauge writes on every write
+	// to publish a level nobody samples more than once a minute.
+	if w.tier != "" {
+		metrics.PStoreWritesTotal.WithLabelValues(w.tier).Inc()
+	}
+	return nil
+}
+
+// maxInstallAttempts bounds how many times Close retries the transaction that
+// swaps the new version into the namespace.
+//
+// The index is serializable, so two commits touching the same entry cannot
+// both succeed: BadgerDB aborts the second rather than serializing it.  That
+// is the right database behavior and the wrong client behavior -- a
+// concurrent PUT to the same path is an ordinary thing for an origin to
+// receive, and answering it with a transaction-conflict error is asking the
+// client to do work the store can do itself.
+const maxInstallAttempts = 8
+
+// install swaps the new version into the namespace, retrying a lost race.
+//
+// Every attempt is a fresh transaction that re-reads the current entry, so the
+// conditional-write preconditions are evaluated against the state at the
+// moment of the commit that actually lands -- never against a snapshot taken
+// before an earlier attempt.  That distinction is the whole point: reusing the
+// first attempt's read would let a RequireAbsent writer overwrite an object
+// another writer installed in between, turning a refused write into a silent
+// lost update.  A retry is therefore free to conclude ErrExist or
+// ErrPreconditionFailed where the first attempt would have succeeded, and that
+// is the correct answer.
+//
+// Nothing is committed by a losing attempt, so the pg: bookkeeping stays
+// consistent across retries: the entry beginMaterialize wrote is only cleared
+// by the transaction that also makes the version reachable.
+func (w *WriteHandle) install(entry *Dirent) error {
+	var lastErr error
+	for attempt := range maxInstallAttempts {
+		if attempt > 0 {
+			// Counted here rather than where the conflict is detected so that
+			// it measures retries taken, not conflicts observed: the final
+			// attempt's conflict does not lead to a retry and is reported as a
+			// failure below instead.
+			metrics.PStoreWriteConflictRetriesTotal.Inc()
+
+			// Yield rather than sleep.  The writer that won the previous round
+			// has already committed -- that is why this one was aborted -- so
+			// there is nothing to wait for beyond letting it get on with the
+			// rest of its Close.
+			runtime.Gosched()
+		}
+
+		err := w.store.bdb.Update(func(txn *badger.Txn) error {
+			var superseded local_cache.InstanceHash
+
+			parent, _ := splitPath(w.path)
+			if pErr := w.store.requireDirResolved(txn, parent); pErr != nil {
+				return pErr
+			}
+
+			existing, gErr := w.store.resolve(txn, w.path)
+			switch {
+			case gErr == nil:
+				if existing.IsDir() {
+					return ErrIsDir
+				}
+				if w.requireAbsent {
+					return ErrExist
+				}
+				if w.requireGeneration != "" && existing.Generation != w.requireGeneration {
+					return ErrPreconditionFailed
+				}
+				if existing.Generation != "" {
+					superseded = instanceHashFor(w.store.db, existing.Generation)
+				}
+			case errors.Is(gErr, ErrNotExist):
+				if w.requireGeneration != "" {
+					return ErrPreconditionFailed
+				}
+			default:
+				return gErr
+			}
+
+			if pErr := putDirent(txn, w.path, entry); pErr != nil {
+				return pErr
+			}
+			// The version stops being an orphan and starts being reachable in
+			// the same transaction, so the crash window beginMaterialize
+			// opened closes exactly when it is no longer needed.
+			if dErr := dequeueInstance(txn, w.instanceHash); dErr != nil {
+				return dErr
+			}
+			// Same transaction as the swap: the old version must never be
+			// unreachable and unqueued at the same time.
+			return enqueueInstance(txn, superseded)
+		})
+		if err == nil {
+			return nil
+		}
+		// Match on what BadgerDB actually returns rather than on the package
+		// sentinel, so this keeps working if ErrConflict stops aliasing it.
+		if !errors.Is(err, badger.ErrConflict) {
+			return err
+		}
+		lastErr = err
+	}
+	// Losing this many rounds in a row means the path is under sustained
+	// contention rather than a momentary overlap.  ErrConflict is retryable and
+	// says so; origin_serve reports it as 409 rather than an opaque 500.
+	metrics.PStoreWriteFailuresTotal.WithLabelValues(metrics.PStoreWriteFailureConflict).Inc()
+	return errors.Wrapf(ErrConflict,
+		"failed to install %s after %d attempts (%v)", w.path, maxInstallAttempts, lastErr)
+}
+
+// beginMaterialize opens the window in which a half-built object version
+// exists on disk but is not yet reachable from the index.
+//
+// materialize writes the metadata record, the block state, the data files, and
+// the usage charge before the commit transaction runs.  Process death anywhere
+// in there would otherwise leave exactly the orphan the design promises cannot
+// happen: bytes charged to the usage counters, no dirent pointing at them, and
+// nothing in the reclamation queue -- recoverable only by an offline fsck.
+//
+// Queueing the version for reclamation *first* inverts that.  A crash leaves a
+// queue entry the janitor picks up on its own, and a successful commit removes
+// the entry in the very transaction that makes the version reachable.
+//
+// The price is that a `pg:i:` entry no longer means only "this is garbage": it
+// now also means "a write is in flight", and the janitor must not confuse the
+// two.  The pin taken here is the first half of what distinguishes them, held
+// from before the entry is visible until after it is cleared.  The second half
+// is a re-read on the janitor's side; both live in queuedInstance.claim, which
+// is the only thing that can turn a queue entry back into a deletable hash.
+func (w *WriteHandle) beginMaterialize() error {
+	if err := w.store.checkWritable(); err != nil {
+		return err
+	}
+	// Pin before the queue entry is visible, so a janitor that sees the entry
+	// necessarily sees the pin too.
+	w.unpin = w.store.storage.PinObject(w.instanceHash)
+	if err := w.store.bdb.Update(func(txn *badger.Txn) error {
+		return enqueueInstance(txn, w.instanceHash)
+	}); err != nil {
+		w.endMaterialize()
+		return errors.Wrapf(err, "failed to record the pending write for %s", w.path)
+	}
+	return nil
+}
+
+// endMaterialize closes the window beginMaterialize opened.
+func (w *WriteHandle) endMaterialize() {
+	if w.unpin != nil {
+		w.unpin()
+		w.unpin = nil
+	}
+}
+
+// materialize writes the buffered or streamed content into block storage and
+// returns the finished metadata.  Inline objects have no per-directory
+// footprint and return nil.
+func (w *WriteHandle) materialize() (*local_cache.CacheMetadata, error) {
+	ctx := context.Background()
+
+	if w.spilled {
+		w.tier = metrics.PStoreTierStreamed
+		meta, err := w.aw.Finalize()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to finalize the streamed object")
+		}
+		if err := w.recordDigests(meta); err != nil {
+			return nil, err
+		}
+		return meta, nil
+	}
+
+	inlineMax := int64(w.store.storage.InlineMaxBytes())
+	written := w.written.Load()
+	if written <= inlineMax {
+		w.tier = metrics.PStoreTierInline
+		meta := &local_cache.CacheMetadata{
+			ContentLength: written,
+			NamespaceID:   w.store.namespaceID,
+			Completed:     time.Now(),
+			Checksums:     w.digests.checksums(),
+		}
+		if err := w.store.storage.StoreInline(ctx, w.instanceHash, meta, w.buf); err != nil {
+			return nil, errors.Wrap(err, "failed to store the object inline")
+		}
+		// Returned so the caller settles capacity: an inline object still
+		// occupies disk (in the catalog) and StoreInline charges it to
+		// StorageIDInline, which PerDirectoryBytes attributes correctly.
+		// Dropping it here would let small objects fill a store without ever
+		// counting against its ceiling.
+		return meta, nil
+	}
+
+	// The exact length is known, so allocate once at the right size instead
+	// of growing and trimming.
+	//
+	// This tier picks its own directory rather than going through the block
+	// store's chooseDir hook, which only fires for chunk allocation.  It must
+	// still ask the capacity tracker: DirIDs() is sorted, so taking the first
+	// entry would pour every 4 KiB–1 MiB object into one directory until it
+	// blew past its MaxSize while the others sat empty.
+	w.tier = metrics.PStoreTierBuffered
+	meta, err := w.store.storage.InitDiskStorage(
+		ctx, w.instanceHash, written, w.store.capacity.chooseDir(), w.store.namespaceID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to allocate object storage")
+	}
+	if err := w.store.storage.WriteBlocks(w.instanceHash, 0, w.buf); err != nil {
+		return nil, errors.Wrap(err, "failed to write object data")
+	}
+	meta.Completed = time.Now()
+	meta.Checksums = w.digests.checksums()
+	if err := w.store.db.SetMetadata(w.instanceHash, meta); err != nil {
+		return nil, errors.Wrap(err, "failed to record object metadata")
+	}
+	return meta, nil
+}
+
+// recordDigests attaches the ingest checksums to an object whose metadata was
+// written by AppendWriter.Finalize.
+func (w *WriteHandle) recordDigests(meta *local_cache.CacheMetadata) error {
+	meta.Checksums = w.digests.checksums()
+	if err := w.store.db.SetMetadata(w.instanceHash, meta); err != nil {
+		return errors.Wrap(err, "failed to record object checksums")
+	}
+	return nil
+}
+
+// Abort discards the pending version without touching the namespace.
+func (w *WriteHandle) Abort() error {
+	if w.done {
+		return nil
+	}
+	w.done = true
+	w.discard()
+	return nil
+}
+
+// discard releases everything a failed or abandoned write claimed.
+//
+// Storage is always cleaned up, never only when bytes were written: a
+// zero-length object still gets an inline metadata record from materialize, so
+// a refused commit on an empty write would otherwise leave an m: record behind
+// with nothing referencing it.  Deleting an instance that was never created is
+// already tolerated, so there is nothing to gain from guessing.
+func (w *WriteHandle) discard() {
+	if w.aw != nil {
+		if err := w.aw.Abort(); err != nil {
+			log.Warnf("Failed to discard partial object %s: %v", w.path, err)
+		}
+	} else if err := w.store.storage.Delete(w.instanceHash); err != nil {
+		log.Debugf("Nothing to discard for %s: %v", w.path, err)
+	}
+	// The pg: entry beginMaterialize wrote is deliberately left in place: it
+	// costs one janitor visit against an instance that is already gone, and
+	// keeping it is what covers a crash between here and now.
+	w.endMaterialize()
+	if w.reserved > 0 {
+		w.store.capacity.releaseReservation(w.reserved)
+		w.reserved = 0
+	}
+	w.buf = nil
+}
+
+// ---------------------------------------------------------------------------
+// Reading
+// ---------------------------------------------------------------------------
+
+// ReadHandle streams an object version.
+//
+// The underlying ObjectReader pins the version for its own lifetime, so the
+// janitor cannot reclaim it mid-read; nothing extra is needed here.
+type ReadHandle struct {
+	*local_cache.ObjectReader
+	dirent *Dirent
+}
+
+// Dirent returns the entry the handle was opened from.
+func (r *ReadHandle) Dirent() *Dirent { return r.dirent }
+
+// Close releases the reader, and with it the pin it holds.
+func (r *ReadHandle) Close() error {
+	return r.ObjectReader.Close()
+}
+
+// openRaceRetries bounds how many times OpenRead re-resolves an object whose
+// version vanished between the lookup and the open.  Losing the race twice in
+// a row against the same generation means the version is genuinely missing,
+// not being overwritten.
+const openRaceRetries = 3
+
+// OpenRead opens the current version of an object for reading.
+//
+// Resolving the path and opening the version are two steps, and an overwrite
+// can land between them: the swap commits, the superseded version is queued,
+// the janitor finds it unpinned, and the open then fails on a generation that
+// was current a microsecond earlier.  That surfaces as a 500 on an object that
+// existed the whole time.
+//
+// Two things close that.  The pin is taken inside the resolving transaction,
+// so a janitor that can see the version is superseded can also see that
+// somebody holds it — queuedInstance.claim refuses pinned versions.  And the
+// open is retried against a freshly resolved generation, which covers the
+// residual window between the read snapshot and the pin actually landing.
+// Retrying is safe because it is idempotent and bounded, and it terminates:
+// either the path resolves to a version that opens, or it stops changing.
+func (s *Store) OpenRead(name string) (*ReadHandle, error) {
+	cleanPath, err := cleanRelative(name)
+	if err != nil {
+		return nil, err
+	}
+
+	var lastGeneration string
+	for attempt := 0; ; attempt++ {
+		var (
+			entry *Dirent
+			hash  local_cache.InstanceHash
+			unpin func()
+		)
+		if vErr := s.bdb.View(func(txn *badger.Txn) error {
+			d, gErr := s.resolve(txn, cleanPath)
+			if gErr != nil {
+				return gErr
+			}
+			if d.IsDir() {
+				return ErrIsDir
+			}
+			entry = d
+			hash = instanceHashFor(s.db, d.Generation)
+			unpin = s.storage.PinObject(hash)
+			return nil
+		}); vErr != nil {
+			return nil, vErr
+		}
+
+		reader, oErr := s.storage.NewObjectReader(hash)
+		// NewObjectReader took a pin of its own for the reader's lifetime, so
+		// this one has done its job either way.
+		unpin()
+		if oErr != nil {
+			if attempt < openRaceRetries && entry.Generation != lastGeneration {
+				lastGeneration = entry.Generation
+				continue
+			}
+			return nil, errors.Wrapf(oErr, "failed to open %s", cleanPath)
+		}
+
+		// Refresh the access time.  UpdateLRU debounces internally, so a hot
+		// object pays a single metadata read rather than an index write.
+		if lErr := s.db.UpdateLRU(hash, atimeDebounce); lErr != nil {
+			log.Debugf("Failed to record access time for %s: %v", cleanPath, lErr)
+		}
+
+		return &ReadHandle{ObjectReader: reader, dirent: entry}, nil
+	}
+}
+
+// AccessTime returns when an object was last read, as maintained by the LRU
+// index (§8).
+//
+// This is deliberately not surfaced through FileInfo: it lives on the object's
+// metadata rather than its directory entry, so reporting it from Stat would
+// add a metadata read to every lookup to answer a question almost no caller
+// asks.  Operators get it from `pelican-server origin pstore stat`.
+//
+// A zero time means the object has not been read since it was written, or was
+// read within the debounce window before any access was recorded.
+func (s *Store) AccessTime(name string) (time.Time, error) {
+	cleanPath, err := cleanRelative(name)
+	if err != nil {
+		return time.Time{}, err
+	}
+	d, err := s.Stat(cleanPath)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if d.IsDir() {
+		return time.Time{}, ErrIsDir
+	}
+	meta, err := s.db.GetMetadata(instanceHashFor(s.db, d.Generation))
+	if err != nil {
+		return time.Time{}, err
+	}
+	if meta == nil {
+		return time.Time{}, ErrNotExist
+	}
+	return meta.LastAccessTime, nil
+}
+
+// ReadAll is a convenience wrapper that returns an object's whole content.
+func (s *Store) ReadAll(name string) ([]byte, error) {
+	r, err := s.OpenRead(name)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	return io.ReadAll(r)
+}

--- a/pstore/object_io_test.go
+++ b/pstore/object_io_test.go
@@ -1,0 +1,1301 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package pstore
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"math/rand"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/local_cache"
+)
+
+// writeObject stores content at name through the normal write path.
+func writeObject(t *testing.T, s *Store, name string, content []byte) {
+	t.Helper()
+	w, err := s.Create(name)
+	require.NoError(t, err)
+	n, err := w.Write(content)
+	require.NoError(t, err)
+	require.Equal(t, len(content), n)
+	require.NoError(t, w.Close())
+}
+
+func randomBytes(n int, seed int64) []byte {
+	b := make([]byte, n)
+	rng := rand.New(rand.NewSource(seed))
+	_, _ = rng.Read(b)
+	return b
+}
+
+// TestWriteReadRoundTrip covers all three write tiers: inline, buffered with
+// an exact length, and streamed past the spill threshold.
+func TestWriteReadRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+
+	cases := []struct {
+		name string
+		size int
+	}{
+		{"empty", 0},
+		{"tiny inline", 10},
+		{"just under inline threshold", 4095},
+		{"just over inline threshold", 4097},
+		{"buffered", 1 << 20},
+		{"just under spill threshold", spillThreshold - 1},
+		{"streamed past spill", spillThreshold + (1 << 20)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			content := randomBytes(tc.size, int64(tc.size)+1)
+			path := "/obj-" + strconv.Itoa(tc.size)
+
+			writeObject(t, s, path, content)
+
+			d, err := s.Stat(path)
+			require.NoError(t, err)
+			assert.False(t, d.IsDir())
+			assert.Equal(t, int64(tc.size), d.Size, "dirent records the object size")
+			assert.NotEmpty(t, d.Generation, "every version carries a generation")
+
+			got, err := s.ReadAll(path)
+			require.NoError(t, err)
+			assert.True(t, bytes.Equal(content, got), "content round-trips")
+		})
+	}
+}
+
+// TestWriteInIncrements checks that a caller streaming in small pieces gets
+// the same result as one big write, including across the spill boundary.
+func TestWriteInIncrements(t *testing.T) {
+	s := newTestStore(t)
+
+	content := randomBytes(spillThreshold+(2<<20), 99)
+	w, err := s.Create("/streamed")
+	require.NoError(t, err)
+	for off := 0; off < len(content); off += 7919 {
+		end := off + 7919
+		if end > len(content) {
+			end = len(content)
+		}
+		_, wErr := w.Write(content[off:end])
+		require.NoError(t, wErr)
+	}
+	require.NoError(t, w.Close())
+
+	got, err := s.ReadAll("/streamed")
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(content, got))
+}
+
+// TestWriteIsInvisibleUntilClose is the atomicity property: a reader sees
+// either the old version or the new one, never a partial write.
+func TestWriteIsInvisibleUntilClose(t *testing.T) {
+	s := newTestStore(t)
+
+	writeObject(t, s, "/obj", []byte("original"))
+
+	w, err := s.Create("/obj")
+	require.NoError(t, err)
+	_, err = w.Write([]byte("replacement"))
+	require.NoError(t, err)
+
+	got, err := s.ReadAll("/obj")
+	require.NoError(t, err)
+	assert.Equal(t, "original", string(got), "the pending write is not visible")
+
+	require.NoError(t, w.Close())
+	got, err = s.ReadAll("/obj")
+	require.NoError(t, err)
+	assert.Equal(t, "replacement", string(got), "close swaps the version in")
+}
+
+// TestOverwriteChangesGeneration confirms each version gets a fresh token,
+// which is what the ETag and the storage key are derived from.
+func TestOverwriteChangesGeneration(t *testing.T) {
+	s := newTestStore(t)
+
+	writeObject(t, s, "/obj", []byte("v1"))
+	first, err := s.Stat("/obj")
+	require.NoError(t, err)
+
+	writeObject(t, s, "/obj", []byte("v2"))
+	second, err := s.Stat("/obj")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, first.Generation, second.Generation)
+	// etagFor is injective, so comparing two ETags adds nothing over comparing
+	// the generations.  What is worth pinning is the rendering itself: the
+	// origin emits this verbatim, and a strong entity tag must be quoted.
+	assert.Equal(t, `"`+second.Generation+`"`, etagFor(second.Generation))
+	assert.Empty(t, etagFor(""), "a directory has no entity tag")
+}
+
+// TestReaderSurvivesOverwrite is the reason reader pinning exists: a reader
+// holding the old version must keep working after it is superseded and the
+// janitor has run.
+func TestReaderSurvivesOverwrite(t *testing.T) {
+	s := newTestStore(t)
+
+	original := randomBytes(256<<10, 5)
+	writeObject(t, s, "/obj", original)
+
+	r, err := s.OpenRead("/obj")
+	require.NoError(t, err)
+	defer r.Close()
+
+	// Read a little, so the handle is genuinely mid-stream.
+	head := make([]byte, 1024)
+	_, err = io.ReadFull(r, head)
+	require.NoError(t, err)
+
+	writeObject(t, s, "/obj", []byte("replacement"))
+
+	stats, err := s.RunGC(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.InstancesPinned, "the pinned version must be skipped")
+	assert.Equal(t, 0, stats.InstancesFreed)
+
+	rest, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(original, append(head, rest...)),
+		"the open reader still sees the version it opened")
+}
+
+// TestGCReclaimsSupersededVersionOnceUnpinned completes the previous test:
+// after the reader closes, the next pass frees the old version.
+func TestGCReclaimsSupersededVersionOnceUnpinned(t *testing.T) {
+	s := newTestStore(t)
+
+	writeObject(t, s, "/obj", randomBytes(64<<10, 6))
+	r, err := s.OpenRead("/obj")
+	require.NoError(t, err)
+	oldHash := instanceHashFor(s.db, r.Dirent().Generation)
+
+	writeObject(t, s, "/obj", []byte("replacement"))
+
+	stats, err := s.RunGC(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.InstancesPinned)
+
+	require.NoError(t, r.Close())
+
+	stats, err = s.RunGC(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.InstancesFreed)
+	assert.Equal(t, 0, stats.InstancesPinned)
+
+	meta, err := s.db.GetMetadata(oldHash)
+	require.NoError(t, err)
+	assert.Nil(t, meta, "the superseded version is gone")
+}
+
+func TestRemoveFile(t *testing.T) {
+	s := newTestStore(t)
+
+	writeObject(t, s, "/obj", []byte("bye"))
+	require.NoError(t, s.Remove("/obj"))
+
+	_, err := s.Stat("/obj")
+	assert.ErrorIs(t, err, ErrNotExist)
+
+	stats, err := s.RunGC(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.InstancesFreed, "the deleted object's bytes are reclaimed")
+}
+
+func TestRemoveDirectory(t *testing.T) {
+	s := newTestStore(t)
+
+	require.NoError(t, s.Mkdir("/d"))
+	require.NoError(t, s.Remove("/d"), "an empty directory can be removed")
+
+	require.NoError(t, s.Mkdir("/d2"))
+	writeObject(t, s, "/d2/f", []byte("x"))
+	assert.ErrorIs(t, s.Remove("/d2"), ErrNotEmpty, "a populated directory cannot")
+}
+
+// TestRemoveAllDrainsSubtree covers the detach-then-drain path: the subtree
+// disappears at once and the janitor reclaims it afterwards.
+//
+// The subtree is deliberately larger than one removal transaction.  A small
+// one is removed inline and never reaches the janitor at all, so a masking
+// bug that never actually reclaimed anything would pass unnoticed.
+func TestRemoveAllDrainsSubtree(t *testing.T) {
+	s := newTestStore(t)
+
+	makeDeferredSubtree(t, s, "/tree")
+	writeObject(t, s, "/tree/a/b/marker", []byte("gone"))
+	marker, err := s.Stat("/tree/a/b/marker")
+	require.NoError(t, err)
+	markerHash := instanceHashFor(s.db, marker.Generation)
+	writeObject(t, s, "/outside", []byte("keep"))
+
+	require.NoError(t, s.RemoveAll("/tree"))
+	require.Equal(t, 1, s.detached.len(), "a deferred removal is masked while it drains")
+
+	_, err = s.Stat("/tree")
+	assert.ErrorIs(t, err, ErrNotExist, "the subtree is unreachable immediately")
+	_, err = s.Stat("/tree/a/b/marker")
+	assert.ErrorIs(t, err, ErrNotExist)
+
+	// Drain until the queue is genuinely empty, and insist that it empties:
+	// masking without reclaiming would leave every one of these bytes on disk.
+	// A pass that finishes the subtree only *enqueues* its objects, so the
+	// loop has to run until a pass does nothing at all.
+	drained := false
+	for range 20 {
+		stats, gErr := s.RunGC(t.Context())
+		require.NoError(t, gErr)
+		idle := stats.InstancesFreed == 0 && stats.SubtreeEntriesRemoved == 0 &&
+			stats.InstancesPinned == 0 && !stats.HitBatchLimit
+		if idle && s.detached.len() == 0 {
+			drained = true
+			break
+		}
+	}
+	require.True(t, drained, "the janitor must finish draining the detached subtree")
+	assert.Zero(t, s.detached.len(), "the mask lifts once nothing is left in the index")
+
+	// Nothing of the subtree survives in either the index or block storage.
+	require.NoError(t, s.bdb.View(func(txn *badger.Txn) error {
+		return walkSubtree(txn, "/tree", func(entryPath string, _ *Dirent) error {
+			return assertNoEntry(entryPath)
+		})
+	}))
+	meta, err := s.db.GetMetadata(markerHash)
+	require.NoError(t, err)
+	assert.Nil(t, meta, "the removed objects' bytes are reclaimed, not merely hidden")
+
+	got, err := s.ReadAll("/outside")
+	require.NoError(t, err)
+	assert.Equal(t, "keep", string(got), "an unrelated object is untouched")
+}
+
+// assertNoEntry turns a surviving index key into an error the walk reports.
+func assertNoEntry(entryPath string) error {
+	return errors.Errorf("%s still has an index entry after the drain", entryPath)
+}
+
+func TestRemoveAllMissingIsNotAnError(t *testing.T) {
+	s := newTestStore(t)
+	assert.NoError(t, s.RemoveAll("/never-existed"))
+}
+
+// TestRenameFileMovesNoData checks the central rename property: the entry
+// moves, the object's identity does not, so the content is unchanged and no
+// data file is touched.
+func TestRenameFileMovesNoData(t *testing.T) {
+	s := newTestStore(t)
+
+	content := randomBytes(128<<10, 11)
+	writeObject(t, s, "/a", content)
+	before, err := s.Stat("/a")
+	require.NoError(t, err)
+
+	require.NoError(t, s.Mkdir("/dst"))
+	require.NoError(t, s.Rename("/a", "/dst/b"))
+
+	_, err = s.Stat("/a")
+	assert.ErrorIs(t, err, ErrNotExist)
+
+	after, err := s.Stat("/dst/b")
+	require.NoError(t, err)
+	assert.Equal(t, before.Generation, after.Generation,
+		"identity comes from the generation, not the path")
+
+	got, err := s.ReadAll("/dst/b")
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(content, got))
+}
+
+func TestRenameDirectoryRebasesDescendants(t *testing.T) {
+	s := newTestStore(t)
+
+	require.NoError(t, s.MkdirAll("/old/sub"))
+	writeObject(t, s, "/old/f1", []byte("one"))
+	writeObject(t, s, "/old/sub/f2", []byte("two"))
+	// A sibling sharing a prefix must not be dragged along.
+	require.NoError(t, s.Mkdir("/old-sibling"))
+	writeObject(t, s, "/old-sibling/f3", []byte("three"))
+
+	require.NoError(t, s.Rename("/old", "/new"))
+
+	for path, want := range map[string]string{
+		"/new/f1":         "one",
+		"/new/sub/f2":     "two",
+		"/old-sibling/f3": "three",
+	} {
+		got, err := s.ReadAll(path)
+		require.NoError(t, err, "%s should be readable", path)
+		assert.Equal(t, want, string(got))
+	}
+
+	_, err := s.Stat("/old")
+	assert.ErrorIs(t, err, ErrNotExist)
+	_, err = s.Stat("/old/sub/f2")
+	assert.ErrorIs(t, err, ErrNotExist)
+}
+
+func TestRenameRejectsMoveBeneathItself(t *testing.T) {
+	s := newTestStore(t)
+
+	require.NoError(t, s.MkdirAll("/d/sub"))
+	err := s.Rename("/d", "/d/sub/d")
+	assert.ErrorIs(t, err, ErrInvalidPath)
+}
+
+func TestRenameReplacesDestinationFile(t *testing.T) {
+	s := newTestStore(t)
+
+	writeObject(t, s, "/src", []byte("source"))
+	writeObject(t, s, "/dst", []byte("destination"))
+
+	require.NoError(t, s.Rename("/src", "/dst"))
+	got, err := s.ReadAll("/dst")
+	require.NoError(t, err)
+	assert.Equal(t, "source", string(got))
+
+	stats, err := s.RunGC(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.InstancesFreed, "the replaced version is reclaimed")
+}
+
+func TestConditionalWrites(t *testing.T) {
+	s := newTestStore(t)
+
+	t.Run("require absent on a new object", func(t *testing.T) {
+		w, err := s.Create("/fresh")
+		require.NoError(t, err)
+		w.RequireAbsent()
+		_, err = w.Write([]byte("x"))
+		require.NoError(t, err)
+		assert.NoError(t, w.Close())
+	})
+
+	t.Run("require absent on an existing object", func(t *testing.T) {
+		w, err := s.Create("/fresh")
+		require.NoError(t, err)
+		w.RequireAbsent()
+		_, err = w.Write([]byte("y"))
+		require.NoError(t, err)
+		assert.ErrorIs(t, w.Close(), ErrExist)
+
+		got, rErr := s.ReadAll("/fresh")
+		require.NoError(t, rErr)
+		assert.Equal(t, "x", string(got), "the refused write left the object alone")
+	})
+
+	t.Run("require matching generation", func(t *testing.T) {
+		current, err := s.Stat("/fresh")
+		require.NoError(t, err)
+
+		w, err := s.Create("/fresh")
+		require.NoError(t, err)
+		w.RequireGeneration(current.Generation)
+		_, err = w.Write([]byte("updated"))
+		require.NoError(t, err)
+		assert.NoError(t, w.Close())
+	})
+
+	t.Run("require stale generation", func(t *testing.T) {
+		w, err := s.Create("/fresh")
+		require.NoError(t, err)
+		w.RequireGeneration("0000000000000000")
+		_, err = w.Write([]byte("nope"))
+		require.NoError(t, err)
+		assert.ErrorIs(t, w.Close(), ErrPreconditionFailed)
+
+		got, rErr := s.ReadAll("/fresh")
+		require.NoError(t, rErr)
+		assert.Equal(t, "updated", string(got))
+	})
+}
+
+func TestWriteErrors(t *testing.T) {
+	s := newTestStore(t)
+
+	_, err := s.Create("/missing/f")
+	assert.ErrorIs(t, err, ErrNotExist, "the parent must exist")
+
+	require.NoError(t, s.Mkdir("/d"))
+	_, err = s.Create("/d")
+	assert.ErrorIs(t, err, ErrIsDir, "a directory cannot be overwritten by a file")
+
+	_, err = s.OpenRead("/d")
+	assert.ErrorIs(t, err, ErrIsDir)
+
+	_, err = s.OpenRead("/nothing")
+	assert.ErrorIs(t, err, ErrNotExist)
+}
+
+// TestAbortLeavesNothingBehind confirms a torn-off upload neither appears in
+// the namespace nor holds capacity.
+func TestAbortLeavesNothingBehind(t *testing.T) {
+	s := newTestStore(t)
+
+	usedBefore, _ := s.capacity.aggregateUsage()
+
+	w, err := s.Create("/aborted")
+	require.NoError(t, err)
+	_, err = w.Write(randomBytes(spillThreshold+1024, 12))
+	require.NoError(t, err)
+	require.NoError(t, w.Abort())
+
+	_, err = s.Stat("/aborted")
+	assert.ErrorIs(t, err, ErrNotExist)
+
+	usedAfter, _ := s.capacity.aggregateUsage()
+	assert.Equal(t, usedBefore, usedAfter, "an aborted write releases its reservation")
+}
+
+// TestDetachedSubtreeDescendantsAreInvisible guards a consequence of
+// path-derived keys that is easy to reintroduce.
+//
+// RemoveAll on a subtree too large for one transaction unlinks the directory
+// and leaves the janitor to drain its descendants, but a lookup here is a
+// single point get that never consults ancestors -- that is precisely why
+// listing a directory is cheap. So a descendant's key outlives its parent, and
+// without explicit masking a deep path would still resolve after its tree was
+// deleted.
+func TestDetachedSubtreeDescendantsAreInvisible(t *testing.T) {
+	s := newTestStore(t)
+
+	makeDeferredSubtree(t, s, "/tree")
+	require.NoError(t, s.RemoveAll("/tree"))
+	require.Equal(t, 1, s.detached.len(), "a large subtree is masked while it drains")
+
+	for _, p := range []string{"/tree", "/tree/a", "/tree/a/b", "/tree/a/b/f0"} {
+		_, err := s.Stat(p)
+		assert.ErrorIs(t, err, ErrNotExist, "%s must not resolve after its tree is removed", p)
+	}
+
+	_, err := s.OpenRead("/tree/a/b/f0")
+	assert.ErrorIs(t, err, ErrNotExist, "a detached object cannot be opened")
+
+	_, _, err = s.List("/tree/a", "", 0)
+	assert.ErrorIs(t, err, ErrNotExist, "a detached directory cannot be listed")
+
+	// Writing into a tree that is still draining is refused outright rather
+	// than placed where the drain will delete it.
+	_, err = s.Create("/tree/a/new")
+	assert.ErrorIs(t, err, ErrDraining)
+}
+
+// TestDetachedMaskClearsAfterDrain confirms the mask is not permanent: once
+// the janitor has drained the tree the path is reusable.
+func TestDetachedMaskClearsAfterDrain(t *testing.T) {
+	s := newTestStore(t)
+
+	require.NoError(t, s.MkdirAll("/tree/a"))
+	writeObject(t, s, "/tree/a/f", []byte("data"))
+	require.NoError(t, s.RemoveAll("/tree"))
+
+	for range 5 {
+		if _, err := s.RunGC(t.Context()); err != nil {
+			t.Fatalf("gc pass failed: %v", err)
+		}
+		if s.detached.len() == 0 {
+			break
+		}
+	}
+	require.Equal(t, 0, s.detached.len(), "the mask lifts once the tree is drained")
+
+	// The path is free again.
+	require.NoError(t, s.MkdirAll("/tree/a"))
+	writeObject(t, s, "/tree/a/f", []byte("fresh"))
+	got, err := s.ReadAll("/tree/a/f")
+	require.NoError(t, err)
+	assert.Equal(t, "fresh", string(got))
+}
+
+// TestDetachedMaskSurvivesReopen covers the crash case: a store that stopped
+// mid-drain must not expose the half-deleted tree when it comes back.
+func TestDetachedMaskSurvivesReopen(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	dir := t.TempDir()
+	egrp, _ := errgroup.WithContext(ctx)
+
+	s, err := Open(ctx, egrp, Config{BaseDir: dir})
+	require.NoError(t, err)
+	makeDeferredSubtree(t, s, "/tree")
+	require.NoError(t, s.RemoveAll("/tree"))
+	require.Equal(t, 1, s.detached.len())
+	// Close without draining, standing in for a crash.
+	require.NoError(t, s.Close())
+
+	s2, err := Open(ctx, egrp, Config{BaseDir: dir})
+	require.NoError(t, err)
+	defer s2.Close()
+
+	assert.Equal(t, 1, s2.detached.len(), "the pending drain is recovered from the queue")
+	_, err = s2.Stat("/tree/a/b/f0")
+	assert.ErrorIs(t, err, ErrNotExist, "a half-deleted tree stays invisible across a restart")
+}
+
+// TestRemoveAllLargeSubtreeDrainsAcrossPasses exercises the batching: a
+// subtree bigger than one transaction is drained over several passes and is
+// invisible throughout.
+func TestRemoveAllLargeSubtreeDrainsAcrossPasses(t *testing.T) {
+	s := newTestStore(t)
+
+	require.NoError(t, s.Mkdir("/big"))
+	const count = subtreeBatchSize + 50
+	for i := range count {
+		writeObject(t, s, "/big/f"+strconv.Itoa(i), []byte("x"))
+	}
+
+	require.NoError(t, s.RemoveAll("/big"))
+	_, err := s.Stat("/big/f0")
+	assert.ErrorIs(t, err, ErrNotExist)
+
+	passes := 0
+	for s.detached.len() > 0 && passes < 20 {
+		_, gErr := s.RunGC(t.Context())
+		require.NoError(t, gErr)
+		passes++
+	}
+	assert.Zero(t, s.detached.len(), "the subtree drains across passes")
+	assert.Greater(t, passes, 1, "a subtree this size needs more than one pass")
+}
+
+// TestSubtreeRecreatedImmediately is the case where masking and draining
+// could collide: a tree is removed and the same paths recreated at once.
+//
+// Because a subtree that fits in one transaction is removed inline, there is
+// no window at all -- the paths are free the moment RemoveAll returns. That is
+// the whole reason removal is not deferred by default.
+func TestSubtreeRecreatedImmediately(t *testing.T) {
+	s := newTestStore(t)
+
+	require.NoError(t, s.MkdirAll("/tree/a"))
+	writeObject(t, s, "/tree/a/f", []byte("original"))
+	original, err := s.Stat("/tree/a/f")
+	require.NoError(t, err)
+
+	require.NoError(t, s.RemoveAll("/tree"))
+	assert.Zero(t, s.detached.len(), "a small subtree needs no mask; it is already gone")
+
+	// Recreate the very same paths straight away.
+	require.NoError(t, s.MkdirAll("/tree/a"))
+	writeObject(t, s, "/tree/a/f", []byte("recreated"))
+
+	got, err := s.ReadAll("/tree/a/f")
+	require.NoError(t, err)
+	assert.Equal(t, "recreated", string(got))
+
+	recreated, err := s.Stat("/tree/a/f")
+	require.NoError(t, err)
+	assert.NotEqual(t, original.Generation, recreated.Generation,
+		"the recreated object is a new version, not the old one resurfacing")
+
+	// A GC pass must not disturb the recreated tree.
+	for range 5 {
+		_, gErr := s.RunGC(t.Context())
+		require.NoError(t, gErr)
+	}
+	after, err := s.ReadAll("/tree/a/f")
+	require.NoError(t, err, "reclamation must not touch the recreated object")
+	assert.Equal(t, "recreated", string(after))
+
+	oldMeta, err := s.db.GetMetadata(instanceHashFor(s.db, original.Generation))
+	require.NoError(t, err)
+	assert.Nil(t, oldMeta, "the removed version was reclaimed")
+}
+
+// TestLargeSubtreeRecreatedWhileDraining covers the case that cannot be made
+// instantaneous.  A subtree too large to remove in one transaction is drained
+// in the background, and its descendants still occupy the keys a recreated
+// tree would use -- so recreation is refused until the drain finishes, rather
+// than writing data the drain would then delete.
+func TestLargeSubtreeRecreatedWhileDraining(t *testing.T) {
+	s := newTestStore(t)
+
+	makeDeferredSubtree(t, s, "/tree")
+	require.NoError(t, s.RemoveAll("/tree"))
+	require.Equal(t, 1, s.detached.len())
+
+	err := s.MkdirAll("/tree/a")
+	assert.ErrorIs(t, err, ErrDraining, "recreating a draining tree is refused, not silently lost")
+
+	// Once drained, the paths are free again.
+	for range 20 {
+		if _, gErr := s.RunGC(t.Context()); gErr != nil {
+			t.Fatalf("gc pass failed: %v", gErr)
+		}
+		if s.detached.len() == 0 {
+			break
+		}
+	}
+	require.Zero(t, s.detached.len())
+
+	require.NoError(t, s.MkdirAll("/tree/a/b"))
+	writeObject(t, s, "/tree/a/b/f0", []byte("recreated"))
+	got, err := s.ReadAll("/tree/a/b/f0")
+	require.NoError(t, err)
+	assert.Equal(t, "recreated", string(got))
+}
+
+// makeDeferredSubtree builds a subtree larger than one removal transaction, so
+// RemoveAll must detach it and leave the janitor to drain.
+func makeDeferredSubtree(t *testing.T, s *Store, root string) {
+	t.Helper()
+	require.NoError(t, s.MkdirAll(root+"/a/b"))
+	for i := range subtreeBatchSize + 50 {
+		writeObject(t, s, root+"/a/b/f"+strconv.Itoa(i), []byte("x"))
+	}
+}
+
+// TestGCReportsBacklog drives the signal the janitor uses to speed up: a sweep
+// that fills its batch says so, and one that clears the queue does not.
+func TestGCReportsBacklog(t *testing.T) {
+	s := newTestStore(t)
+
+	require.NoError(t, s.Mkdir("/many"))
+	// Enough objects that deleting them all outruns a single sweep.
+	for i := range janitorBatchSize + 100 {
+		writeObject(t, s, "/many/f"+strconv.Itoa(i), []byte("x"))
+		require.NoError(t, s.Remove("/many/f"+strconv.Itoa(i)))
+	}
+
+	stats, err := s.RunGC(t.Context())
+	require.NoError(t, err)
+	assert.True(t, stats.HitBatchLimit,
+		"a queue larger than one batch must ask for another sweep sooner")
+	assert.Equal(t, janitorBatchSize, stats.InstancesFreed)
+
+	// Drain the rest.
+	for range 10 {
+		stats, err = s.RunGC(t.Context())
+		require.NoError(t, err)
+		if !stats.HitBatchLimit {
+			break
+		}
+	}
+	assert.False(t, stats.HitBatchLimit, "an emptied queue stops asking")
+}
+
+// ---------------------------------------------------------------------------
+// Draining subtrees and rename
+// ---------------------------------------------------------------------------
+
+// TestRenameOntoADrainingSubtreeIsRefused guards the worst failure the store
+// had: a rename whose destination was a subtree still being reclaimed.
+//
+// Create, Mkdir and MkdirAll all consult the drain queue; Rename did not, and
+// its resolves go through the masking resolver, which reports a detached path
+// as ErrNotExist.  The destination therefore looked free, the rename
+// "succeeded", the source was rebased onto keys the janitor was about to walk,
+// and the drain then deleted both trees -- with no error reported anywhere.
+func TestRenameOntoADrainingSubtreeIsRefused(t *testing.T) {
+	s := newTestStore(t)
+
+	makeDeferredSubtree(t, s, "/tree")
+	require.NoError(t, s.MkdirAll("/src/inner"))
+	writeObject(t, s, "/src/inner/precious", []byte("precious"))
+
+	require.NoError(t, s.RemoveAll("/tree"))
+	require.Equal(t, 1, s.detached.len(), "the subtree is too large to remove inline")
+
+	err := s.Rename("/src", "/tree")
+	require.Error(t, err, "renaming onto a draining subtree must not appear to succeed")
+	assert.ErrorIs(t, err, ErrDraining)
+
+	// The source survived, entry and content both.
+	d, err := s.Stat("/src/inner/precious")
+	require.NoError(t, err)
+	assert.False(t, d.IsDir())
+	got, err := s.ReadAll("/src/inner/precious")
+	require.NoError(t, err)
+	assert.Equal(t, "precious", string(got))
+
+	// A descendant of the draining root is no better a destination...
+	assert.ErrorIs(t, s.Rename("/src", "/tree/a"), ErrDraining)
+	// ...and renaming out of one is refused rather than resurrecting it.
+	assert.ErrorIs(t, s.Rename("/tree/a", "/moved"), ErrDraining)
+	_, err = s.Stat("/moved")
+	assert.ErrorIs(t, err, ErrNotExist)
+
+	// Once the drain completes the source is still intact and the path frees up.
+	for range 20 {
+		_, gErr := s.RunGC(t.Context())
+		require.NoError(t, gErr)
+		if s.detached.len() == 0 {
+			break
+		}
+	}
+	require.Zero(t, s.detached.len())
+
+	got, err = s.ReadAll("/src/inner/precious")
+	require.NoError(t, err)
+	assert.Equal(t, "precious", string(got), "the drain must not have touched the source")
+
+	require.NoError(t, s.Rename("/src", "/tree"))
+	got, err = s.ReadAll("/tree/inner/precious")
+	require.NoError(t, err)
+	assert.Equal(t, "precious", string(got))
+}
+
+// TestRenameOfAnEnormousDirectoryIsRefusedClearly covers the other rename
+// limit.  A directory rename rewrites every descendant key in one transaction,
+// and BadgerDB caps how much that transaction may hold; past the cap the
+// commit failed with "Txn is too big to fit into one request", which is not
+// something a client can act on.  The refusal must be typed and the tree
+// untouched.
+func TestRenameOfAnEnormousDirectoryIsRefusedClearly(t *testing.T) {
+	s := newTestStore(t)
+
+	require.NoError(t, s.Mkdir("/huge"))
+	require.NoError(t, s.bdb.Update(func(txn *badger.Txn) error {
+		for i := range renameSubtreeLimit + 1 {
+			if err := putDirent(txn, "/huge/f"+strconv.Itoa(i), &Dirent{
+				Type: EntryFile,
+				Mode: uint32(defaultFileMode),
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+
+	err := s.Rename("/huge", "/renamed")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotSupported)
+	assert.Contains(t, err.Error(), "smaller groups", "the message has to be actionable")
+
+	// Nothing moved.
+	_, err = s.Stat("/renamed")
+	assert.ErrorIs(t, err, ErrNotExist)
+	_, err = s.Stat("/huge/f0")
+	assert.NoError(t, err, "a refused rename leaves the source exactly as it was")
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency
+// ---------------------------------------------------------------------------
+
+// TestConcurrentOverwriteAndOpenNeverFailsSpuriously drives the race between
+// resolving a path and opening the version it names.
+//
+// An overwrite commits between those two steps, the superseded version is
+// queued, and the janitor -- finding it unpinned -- reclaims it, so the open
+// fails on a version that was current a moment earlier.  The error is not
+// ErrNotExist, so it reaches the client as a 500 for an object that existed
+// throughout.  Not one open here is allowed to fail.
+func TestConcurrentOverwriteAndOpenNeverFailsSpuriously(t *testing.T) {
+	s := newTestStore(t)
+
+	content := randomBytes(32<<10, 51)
+	writeObject(t, s, "/hot", content)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	var grp errgroup.Group
+
+	// A steady stream of overwrites, each superseding a version a reader may
+	// have just resolved.
+	grp.Go(func() error {
+		for ctx.Err() == nil {
+			w, err := s.Create("/hot")
+			if err != nil {
+				return errors.Wrap(err, "overwriter failed to create")
+			}
+			if _, wErr := w.Write(content); wErr != nil {
+				_ = w.Abort()
+				return errors.Wrap(wErr, "overwriter failed to write")
+			}
+			if cErr := w.Close(); cErr != nil {
+				return errors.Wrap(cErr, "overwriter failed to close")
+			}
+		}
+		return nil
+	})
+
+	// ...and a janitor racing to reclaim what the overwrites supersede.
+	grp.Go(func() error {
+		for ctx.Err() == nil {
+			if _, err := s.RunGC(ctx); err != nil {
+				return errors.Wrap(err, "gc pass failed")
+			}
+		}
+		return nil
+	})
+
+	grp.Go(func() error {
+		// Stopping the other two is this goroutine's job, so the group drains
+		// as soon as the sampling is done.
+		defer cancel()
+		for i := range 2000 {
+			r, err := s.OpenRead("/hot")
+			if err != nil {
+				return errors.Wrapf(err, "open %d of an object that exists throughout failed", i)
+			}
+			if cErr := r.Close(); cErr != nil {
+				return errors.Wrap(cErr, "closing a reader failed")
+			}
+		}
+		return nil
+	})
+
+	require.NoError(t, grp.Wait())
+}
+
+// ---------------------------------------------------------------------------
+// Crash safety
+// ---------------------------------------------------------------------------
+
+// TestCrashBetweenMaterializeAndCommitLeavesNoUnqueuedOrphan covers the window
+// the design claims does not exist.
+//
+// materialize writes the metadata record, the block state, the data files and
+// the usage charge before the commit transaction runs.  Process death in there
+// would otherwise leave bytes charged to the usage counters with no dirent
+// pointing at them and nothing in the reclamation queue -- recoverable only by
+// an offline fsck --repair.  Queueing the version before materialization
+// starts, and clearing that entry in the transaction that makes it reachable,
+// turns the crash into ordinary janitor work.
+func TestCrashBetweenMaterializeAndCommitLeavesNoUnqueuedOrphan(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	egrp, _ := errgroup.WithContext(ctx)
+
+	dir := t.TempDir()
+	cfg := Config{
+		BaseDir:     dir,
+		StorageDirs: []local_cache.StorageDirConfig{{Path: dir, MaxSize: 64 << 20}},
+	}
+
+	s, err := Open(ctx, egrp, cfg)
+	require.NoError(t, err)
+	baseline, _ := s.Usage()
+
+	w, err := s.CreateSized("/crashed", 2<<20)
+	require.NoError(t, err)
+	_, err = w.Write(randomBytes(2<<20, 31))
+	require.NoError(t, err)
+
+	// Stand in for process death between materialization and the commit that
+	// would install the object: everything is on disk and charged, nothing
+	// points at it, and Close is never reached.
+	require.NoError(t, w.beginMaterialize())
+	_, err = w.materialize()
+	require.NoError(t, err)
+	hash := w.instanceHash
+	require.NoError(t, s.Close())
+
+	s2, err := Open(ctx, egrp, cfg)
+	require.NoError(t, err)
+	defer s2.Close()
+
+	_, err = s2.Stat("/crashed")
+	assert.ErrorIs(t, err, ErrNotExist, "the half-written version is not reachable")
+
+	meta, err := s2.db.GetMetadata(hash)
+	require.NoError(t, err)
+	require.NotNil(t, meta, "its bytes really are on disk")
+	orphaned, _ := s2.Usage()
+	require.Greater(t, orphaned, baseline, "and really are charged against the store")
+
+	// The janitor reclaims it unaided; no offline fsck required.
+	stats, err := s2.RunGC(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.InstancesFreed, "the orphan was queued, not stranded")
+
+	meta, err = s2.db.GetMetadata(hash)
+	require.NoError(t, err)
+	assert.Nil(t, meta)
+	recovered, _ := s2.Usage()
+	assert.Equal(t, baseline, recovered, "and the capacity it held comes back")
+}
+
+// TestSuccessfulWriteLeavesNothingQueued is the other half: the crash-window
+// marker must not survive a write that lands, or every object would arrive
+// with a reclamation entry against it.
+func TestSuccessfulWriteLeavesNothingQueued(t *testing.T) {
+	s := newTestStore(t)
+
+	writeObject(t, s, "/clean", randomBytes(spillThreshold+(1<<20), 61))
+
+	stats, err := s.RunGC(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, stats.InstancesFreed, "a committed object is not garbage")
+	assert.Zero(t, stats.InstancesPinned)
+
+	got, err := s.ReadAll("/clean")
+	require.NoError(t, err)
+	assert.Len(t, got, spillThreshold+(1<<20))
+}
+
+// TestRefusedZeroLengthWriteLeavesNoMetadata covers the catalog leak the abort
+// path has to avoid: materialize stores an inline record even for a zero-byte
+// object, so a discard that skipped cleanup unless bytes had been written would
+// leave a refused conditional write's m: record behind with nothing referencing
+// it.
+func TestRefusedZeroLengthWriteLeavesNoMetadata(t *testing.T) {
+	s := newTestStore(t)
+
+	writeObject(t, s, "/f", []byte("existing"))
+
+	w, err := s.Create("/f")
+	require.NoError(t, err)
+	w.RequireAbsent()
+	// Not one byte is written, so the object materializes as an empty inline
+	// record before the commit refuses it.
+	assert.ErrorIs(t, w.Close(), ErrExist)
+
+	meta, err := s.db.GetMetadata(instanceHashFor(s.db, w.Generation()))
+	require.NoError(t, err)
+	assert.Nil(t, meta, "the refused write leaves no metadata record behind")
+
+	got, err := s.ReadAll("/f")
+	require.NoError(t, err)
+	assert.Equal(t, "existing", string(got), "and the existing object is untouched")
+}
+
+// TestZeroLengthObjectRoundTrips is the companion property: an empty object is
+// a real object, and refusing one write must not have broken writing one.
+func TestZeroLengthObjectRoundTrips(t *testing.T) {
+	s := newTestStore(t)
+
+	w, err := s.Create("/empty")
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	d, err := s.Stat("/empty")
+	require.NoError(t, err)
+	assert.Zero(t, d.Size)
+
+	got, err := s.ReadAll("/empty")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// TestConcurrentWritesToOnePathElectOneWinner covers the commit race between
+// two writers to the same path.
+//
+// The index is serializable, so BadgerDB aborts the second of two commits that
+// touch the same entry rather than serializing it.  Surfaced as-is that is a
+// bare "Transaction Conflict. Please retry", which the origin would turn into a
+// 500 -- for something that is an ordinary concurrent PUT and entirely
+// retryable.  Close retries it internally instead.
+func TestConcurrentWritesToOnePathElectOneWinner(t *testing.T) {
+	const writers = 8
+
+	t.Run("unconditional writes all land", func(t *testing.T) {
+		s := newTestStore(t)
+
+		var (
+			start = make(chan struct{})
+			grp   errgroup.Group
+			mu    sync.Mutex
+			seen  []string
+		)
+		for i := range writers {
+			grp.Go(func() error {
+				w, err := s.Create("/contended")
+				if err != nil {
+					return err
+				}
+				if _, wErr := w.Write([]byte("payload-" + strconv.Itoa(i))); wErr != nil {
+					_ = w.Abort()
+					return wErr
+				}
+				mu.Lock()
+				seen = append(seen, w.Generation())
+				mu.Unlock()
+
+				// Commit all of them at once, which is what makes the
+				// transactions overlap.
+				<-start
+				return w.Close()
+			})
+		}
+		close(start)
+		require.NoError(t, grp.Wait(),
+			"a concurrent commit must be retried, not reported as a conflict")
+
+		// Exactly one version is installed, and it is one of the writers'.
+		d, err := s.Stat("/contended")
+		require.NoError(t, err)
+		assert.Contains(t, seen, d.Generation)
+
+		got, err := s.ReadAll("/contended")
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(string(got), "payload-"))
+
+		// The seven superseded versions are queued and reclaimed, and nothing
+		// is stranded: the queue empties and only the winner's bytes remain.
+		drainQueue(t, s)
+		assertQueueEmpty(t, s)
+		assertOnlyInstancesRemain(t, s, instanceHashFor(s.db, d.Generation))
+	})
+
+	t.Run("require-absent elects exactly one", func(t *testing.T) {
+		s := newTestStore(t)
+
+		var (
+			start   = make(chan struct{})
+			grp     errgroup.Group
+			mu      sync.Mutex
+			winners []string
+			losers  []error
+		)
+		for i := range writers {
+			grp.Go(func() error {
+				w, err := s.Create("/exclusive")
+				if err != nil {
+					return err
+				}
+				w.RequireAbsent()
+				if _, wErr := w.Write([]byte("payload-" + strconv.Itoa(i))); wErr != nil {
+					_ = w.Abort()
+					return wErr
+				}
+
+				<-start
+				cErr := w.Close()
+				mu.Lock()
+				defer mu.Unlock()
+				if cErr == nil {
+					winners = append(winners, w.Generation())
+				} else {
+					losers = append(losers, cErr)
+				}
+				return nil
+			})
+		}
+		close(start)
+		require.NoError(t, grp.Wait())
+
+		// This is the property a naive retry breaks: re-running the commit
+		// against the state read before the first attempt would let a second
+		// writer's RequireAbsent pass after the first had already installed.
+		require.Len(t, winners, 1, "If-None-Match: * must admit exactly one writer")
+		assert.Len(t, losers, writers-1)
+		for _, err := range losers {
+			assert.ErrorIs(t, err, ErrExist,
+				"a loser is refused on the precondition, not on a database conflict")
+			assert.NotErrorIs(t, err, ErrConflict)
+		}
+
+		d, err := s.Stat("/exclusive")
+		require.NoError(t, err)
+		assert.Equal(t, winners[0], d.Generation)
+
+		// The refused writers' instances are queued by their own crash-window
+		// marker and reclaimed; none is left charged against the store.
+		drainQueue(t, s)
+		assertQueueEmpty(t, s)
+		assertOnlyInstancesRemain(t, s, instanceHashFor(s.db, d.Generation))
+	})
+}
+
+// drainQueue runs reclamation passes until one does nothing.
+func drainQueue(t *testing.T, s *Store) {
+	t.Helper()
+	for range 20 {
+		stats, err := s.RunGC(t.Context())
+		require.NoError(t, err)
+		if stats.InstancesFreed == 0 && stats.InstancesPinned == 0 &&
+			stats.SubtreeEntriesRemoved == 0 && !stats.HitBatchLimit {
+			return
+		}
+	}
+	t.Fatal("the reclamation queue never emptied")
+}
+
+// assertQueueEmpty checks that nothing is left waiting for the janitor.
+func assertQueueEmpty(t *testing.T, s *Store) {
+	t.Helper()
+	instances, subtrees, _, err := s.collectGarbage()
+	require.NoError(t, err)
+	assert.Empty(t, instances, "no object version may be left queued")
+	assert.Empty(t, subtrees, "no subtree may be left queued")
+}
+
+// assertOnlyInstancesRemain checks that the catalog holds metadata for exactly
+// the given versions -- nothing orphaned, nothing over-reclaimed.
+func assertOnlyInstancesRemain(t *testing.T, s *Store, want ...local_cache.InstanceHash) {
+	t.Helper()
+
+	wanted := make(map[local_cache.InstanceHash]bool, len(want))
+	for _, h := range want {
+		wanted[h] = true
+		meta, err := s.db.GetMetadata(h)
+		require.NoError(t, err)
+		assert.NotNil(t, meta, "the installed version %s must still be present", h)
+	}
+
+	var surplus []string
+	require.NoError(t, s.bdb.View(func(txn *badger.Txn) error {
+		prefix := []byte(local_cache.PrefixMeta)
+		opts := badger.DefaultIteratorOptions
+		opts.Prefix = prefix
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			h := local_cache.InstanceHash(it.Item().Key()[len(prefix):])
+			if !wanted[h] {
+				surplus = append(surplus, string(h))
+			}
+		}
+		return nil
+	}))
+	assert.Empty(t, surplus, "no object version may be left orphaned in the catalog")
+}
+
+// TestJanitorReclaimsAbandonedStreamingWrites covers the one leak the pg:
+// queue structurally cannot see.
+//
+// A write is queued for reclamation at the start of materialization, which
+// covers everything from there to the commit.  Before that the object is a
+// partly written stream: chunk files allocated and charged, tracked only by
+// the block store's own append-in-flight marker, with nothing in the pg: queue
+// referring to it.  The block store reclaims those from a sweep the cache
+// drives out of its eviction manager -- which a pstore never constructs, so on
+// an origin the sweep simply never ran.
+func TestJanitorReclaimsAbandonedStreamingWrites(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	egrp, _ := errgroup.WithContext(ctx)
+
+	dir := t.TempDir()
+	cfg := Config{
+		BaseDir:     dir,
+		StorageDirs: []local_cache.StorageDirConfig{{Path: dir, MaxSize: 64 << 20}},
+	}
+
+	s, err := Open(ctx, egrp, cfg)
+	require.NoError(t, err)
+	baseline, _ := s.Usage()
+
+	w, err := s.CreateSized("/abandoned", 4<<20)
+	require.NoError(t, err)
+	_, err = w.Write(randomBytes(4<<20, 41))
+	require.NoError(t, err)
+	hash := w.instanceHash
+
+	// Never finalized, never aborted: the handle simply goes away with the
+	// process.  Reopening also clears the block store's live-writer registry,
+	// which is what makes the leftover indistinguishable from a crash.
+	require.NoError(t, s.Close())
+
+	s2, err := Open(ctx, egrp, cfg)
+	require.NoError(t, err)
+	defer s2.Close()
+
+	meta, err := s2.db.GetMetadata(hash)
+	require.NoError(t, err)
+	require.NotNil(t, meta, "the interrupted stream's chunks are on disk")
+	require.True(t, meta.Completed.IsZero(), "and it was never finalized")
+
+	leaked, _ := s2.Usage()
+	require.Greater(t, leaked, baseline, "and its chunks are charged against the store")
+
+	// Nothing in the reclamation queue refers to it, which is precisely why
+	// the append sweep has to exist.
+	instances, _, _, err := s2.collectGarbage()
+	require.NoError(t, err)
+	require.NotContains(t, instances, newQueuedInstance(string(hash)))
+
+	// A pass at the real grace period leaves it alone: an upload that is
+	// merely slow must never be deleted out from under its client.
+	stats, err := s2.RunGC(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, stats.AbandonedAppendsReclaimed,
+		"a freshly abandoned write is still within the grace period")
+	meta, err = s2.db.GetMetadata(hash)
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+
+	// Backdate the record past the grace period, standing in for the passage
+	// of time, and the janitor reclaims it -- no separate ticker, no eviction
+	// manager, just the ordinary sweep.
+	require.NoError(t, s2.db.SetAppendIntent(hash, local_cache.AppendIntent{
+		StartedAt: time.Now().Add(-2 * appendReclaimGrace),
+	}))
+
+	stats, err = s2.RunGC(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.AbandonedAppendsReclaimed)
+
+	meta, err = s2.db.GetMetadata(hash)
+	require.NoError(t, err)
+	assert.Nil(t, meta, "the abandoned stream is gone")
+
+	recovered, _ := s2.Usage()
+	assert.Equal(t, baseline, recovered, "and the capacity it held comes back")
+}
+
+// TestAppendSweepLeavesLiveWritersAlone is the safety half: an upload in
+// progress in this process must survive the sweep however long it takes, since
+// the grace period cannot distinguish slow from dead.
+func TestAppendSweepLeavesLiveWritersAlone(t *testing.T) {
+	s := newTestStore(t)
+
+	w, err := s.CreateSized("/slow", 4<<20)
+	require.NoError(t, err)
+	_, err = w.Write(randomBytes(2<<20, 43))
+	require.NoError(t, err)
+
+	// Zero grace: only the live-writer registry can save it.
+	n, err := s.ReclaimAbandonedAppends(0)
+	require.NoError(t, err)
+	assert.Zero(t, n, "a writer this process still holds is not abandoned")
+
+	// And the write completes normally afterwards.
+	_, err = w.Write(randomBytes(2<<20, 44))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	got, err := s.ReadAll("/slow")
+	require.NoError(t, err)
+	assert.Len(t, got, 4<<20)
+
+	// A finished write leaves no marker for a later sweep to trip over.
+	n, err = s.ReclaimAbandonedAppends(0)
+	require.NoError(t, err)
+	assert.Zero(t, n)
+	d, err := s.Stat("/slow")
+	require.NoError(t, err)
+	assert.Equal(t, int64(4<<20), d.Size)
+}

--- a/pstore/recover.go
+++ b/pstore/recover.go
@@ -1,0 +1,293 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Getting data back out.
+//
+// A store is not something an operator can read with ordinary tools, so the
+// recovery path has to be part of the product rather than an exercise left to
+// whoever is having the bad day.  Export writes objects out as plain files in
+// a normal directory tree: no Pelican, no origin, no client -- just the data.
+//
+// # What a recovery needs
+//
+// Three things, and they are separate on purpose so they can be stored
+// separately -- and so that losing one does not mean losing the store:
+//
+//   - the catalog, from a metadata snapshot or from the store itself;
+//   - the block files, whatever ordinary tool backed them up; and
+//   - masterkey.json, which wraps the key the block files are encrypted under.
+//
+// Export runs against a store opened for maintenance, so the usual route is to
+// restore a snapshot into a directory holding the block files and
+// masterkey.json, then export from that.
+//
+// # Two key hierarchies, and why that is not a contradiction
+//
+// It is easy to read backup.go and conclude that the backup keys are all an
+// operator needs to escrow.  They are not, and the difference is worth being
+// precise about because a recovery is a bad time to discover it.  There are two
+// unrelated mechanisms:
+//
+//   - The **metadata-backup keys** (backup.go, backup_crypto.go) open a
+//     *snapshot file*.  Any one of an issuer key, the escrowed backup key, or
+//     that archive's own file key decrypts the container and yields the catalog:
+//     paths, sizes, checksums, generations, and each object's data key.
+//   - **masterkey.json** holds the store's *data* master key, which every block
+//     file is encrypted under.  It lives in the store's base directory and is
+//     itself sealed to the origin's issuer keys, one wrapped copy per key ID, so
+//     opening it requires one of those issuer keys.  It has nothing to do with
+//     the backup key hierarchy and is not derived from it.
+//
+// The consequence an operator has to plan around: **escrowing the backup key
+// buys the catalog, not the data.**  With it and a snapshot you can read the
+// namespace -- every path, size and checksum -- and nothing else.  Turning that
+// back into objects also needs the block files *and* masterkey.json, and
+// masterkey.json is useless without one of the issuer keys it was sealed to.
+// So an issuer key has to survive, or be escrowed alongside the backup key; the
+// backup key alone is not a complete recovery plan.
+
+package pstore
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// ExportOptions controls a recovery export.
+type ExportOptions struct {
+	// Root is the subtree to export; empty means the whole store.
+	Root string
+	// Dest is the directory to write into.  It is created if missing.
+	Dest string
+	// Verify checks each object against its recorded checksums as it is
+	// written, so a recovery does not quietly reproduce corrupt data.
+	Verify bool
+	// DryRun reports what would be written without writing it.
+	DryRun bool
+	// Resume skips objects already present in the destination instead of
+	// reporting them.
+	//
+	// An export of a large store is interrupted sooner or later -- a full
+	// disk, a lost session, an operator's Ctrl-C -- and the natural response
+	// is to run it again.  Without this the second run reports every file the
+	// first one wrote as a failure, which is indistinguishable from real
+	// corruption at exactly the moment an operator most needs to tell the
+	// difference.
+	Resume bool
+}
+
+// ExportReport summarizes a recovery export.
+type ExportReport struct {
+	// FilesWritten is how many objects were exported.
+	FilesWritten int
+	// DirsCreated is how many directories were created.
+	DirsCreated int
+	// BytesWritten totals the object content exported.
+	BytesWritten int64
+	// Failed lists objects that could not be exported, with the reason.
+	// A recovery continues past a bad object rather than abandoning the rest.
+	Failed map[string]string
+	// AlreadyPresent counts objects skipped because the destination already
+	// held a file of that name.
+	//
+	// Kept apart from Failed on purpose.  "The previous run already wrote
+	// this" and "this object cannot be read" call for opposite responses, and
+	// a report that conflates them turns a resumed export into a false
+	// corruption report.
+	AlreadyPresent int
+}
+
+// Export writes a subtree out as ordinary files.
+//
+// It continues past objects it cannot read, collecting them in the report: on
+// a damaged store, recovering most of the data and being told exactly what was
+// lost is far more useful than stopping at the first bad block.
+func (s *Store) Export(ctx context.Context, opts ExportOptions) (*ExportReport, error) {
+	if opts.Dest == "" {
+		return nil, errors.New("a destination directory is required")
+	}
+	root := opts.Root
+	if root == "" {
+		root = "/"
+	}
+	cleanRoot, err := cleanRelative(root)
+	if err != nil {
+		return nil, err
+	}
+
+	report := &ExportReport{Failed: map[string]string{}}
+	if !opts.DryRun {
+		if err := os.MkdirAll(opts.Dest, 0750); err != nil {
+			return nil, errors.Wrapf(err, "cannot create %s", opts.Dest)
+		}
+	}
+	return report, s.exportDir(ctx, cleanRoot, cleanRoot, opts, report)
+}
+
+// exportDir walks one directory, recursing into children.
+//
+// It pages through the listing rather than materializing it, so exporting a
+// directory with a very large number of entries does not need them all in
+// memory at once.
+func (s *Store) exportDir(ctx context.Context, dir, root string, opts ExportOptions, report *ExportReport) error {
+	after := ""
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		entries, more, err := s.List(dir, after, 512)
+		if err != nil {
+			return errors.Wrapf(err, "cannot list %s", dir)
+		}
+		if len(entries) == 0 {
+			return nil
+		}
+
+		for _, e := range entries {
+			childPath := joinPath(dir, e.Name)
+			localPath, lErr := destinationFor(root, childPath, opts.Dest)
+			if lErr != nil {
+				report.Failed[childPath] = lErr.Error()
+				continue
+			}
+
+			if e.Dirent.IsDir() {
+				if !opts.DryRun {
+					if mErr := os.MkdirAll(localPath, 0750); mErr != nil {
+						report.Failed[childPath] = mErr.Error()
+						continue
+					}
+				}
+				report.DirsCreated++
+				if rErr := s.exportDir(ctx, childPath, root, opts, report); rErr != nil {
+					return rErr
+				}
+				continue
+			}
+
+			n, fErr := s.exportFile(childPath, localPath, opts)
+			if errors.Is(fErr, errAlreadyExported) {
+				report.AlreadyPresent++
+				continue
+			}
+			if fErr != nil {
+				report.Failed[childPath] = fErr.Error()
+				log.Warnf("Could not export %s: %v", childPath, fErr)
+				continue
+			}
+			report.FilesWritten++
+			report.BytesWritten += n
+		}
+
+		if !more {
+			return nil
+		}
+		after = entries[len(entries)-1].Name
+	}
+}
+
+// errAlreadyExported marks an object a resumed run found already in place.
+var errAlreadyExported = errors.New("already exported")
+
+// exportFile writes one object out.
+func (s *Store) exportFile(objectPath, localPath string, opts ExportOptions) (int64, error) {
+	if opts.Resume && !opts.DryRun {
+		// Checked before the (expensive) verification so that resuming a
+		// --verify export does not re-read every object it already wrote.
+		if _, err := os.Stat(localPath); err == nil {
+			return 0, errAlreadyExported
+		}
+	}
+	if opts.Verify {
+		ok, err := s.VerifyObject(objectPath)
+		if err != nil {
+			return 0, errors.Wrap(err, "could not verify")
+		}
+		if !ok {
+			return 0, errors.New("data does not match its recorded checksums")
+		}
+	}
+	if opts.DryRun {
+		d, err := s.Stat(objectPath)
+		if err != nil {
+			return 0, err
+		}
+		return d.Size, nil
+	}
+
+	r, err := s.OpenRead(objectPath)
+	if err != nil {
+		return 0, err
+	}
+	defer r.Close()
+
+	if err := os.MkdirAll(filepath.Dir(localPath), 0750); err != nil {
+		return 0, err
+	}
+	// Exclusive create: a recovery must never silently overwrite whatever is
+	// already in the destination.  Losing the race with a concurrent writer
+	// reads the same as finding the file already there, which is what --resume
+	// is for.
+	f, err := os.OpenFile(localPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0640)
+	if err != nil {
+		if opts.Resume && os.IsExist(err) {
+			return 0, errAlreadyExported
+		}
+		return 0, err
+	}
+	defer f.Close()
+
+	n, err := io.Copy(f, r)
+	if err != nil {
+		return n, err
+	}
+	return n, f.Sync()
+}
+
+// destinationFor maps an object path to its place under the destination
+// directory, refusing anything that would escape it.
+func destinationFor(root, objectPath, dest string) (string, error) {
+	rel := strings.TrimPrefix(objectPath, root)
+	rel = strings.TrimPrefix(rel, "/")
+	if rel == "" {
+		return "", errors.Errorf("%s is the export root", objectPath)
+	}
+
+	// Object paths are validated on the way in, but a recovery may be run
+	// against a damaged or hand-edited catalog, so the destination is checked
+	// rather than trusted.
+	local := filepath.Join(dest, filepath.FromSlash(rel))
+	absDest, err := filepath.Abs(dest)
+	if err != nil {
+		return "", err
+	}
+	absLocal, err := filepath.Abs(local)
+	if err != nil {
+		return "", err
+	}
+	if absLocal != absDest && !strings.HasPrefix(absLocal, absDest+string(os.PathSeparator)) {
+		return "", errors.Errorf("%s would be written outside the destination", objectPath)
+	}
+	return local, nil
+}

--- a/pstore/store.go
+++ b/pstore/store.go
@@ -1,0 +1,682 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Package pstore ("pelican store") uses the cache V2 block store as an
+// origin's primary data store rather than as a cache.
+//
+// The block store underneath local_cache — encrypted 4080-byte blocks,
+// multi-directory spreading, chunking for large objects, and a BadgerDB
+// catalog that is itself encrypted at rest — is a general-purpose object store
+// that happens to be used by a cache.  pstore drives it directly, adds the one
+// thing a cache never needed (a directory index), and exposes the result as an
+// afero.Fs so it drops into the origin's existing serving stack.
+//
+// Objects are immutable: Pelican has no mid-file edits, so a write always
+// creates a complete new version and atomically swaps it in.  There is no
+// eviction; when the store fills, writes fail with ErrNoSpace until something
+// is deleted.
+//
+// See docs/pstore-design.md for the full design.
+package pstore
+
+import (
+	"context"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/local_cache"
+)
+
+const (
+	// defaultDirMode is the mode reported for directories.  pstore does not
+	// implement per-entry ownership or permissions; access control is the
+	// origin's authorization layer, not the store's.
+	defaultDirMode os.FileMode = os.ModeDir | 0755
+	// defaultFileMode is the mode reported for objects.
+	defaultFileMode os.FileMode = 0644
+
+	// atimeDebounce bounds how often a read refreshes an object's access
+	// time.  Below this interval a read is a single metadata get and skips
+	// the index update entirely.
+	atimeDebounce = 15 * time.Minute
+)
+
+// Config describes a store to open.
+type Config struct {
+	// BaseDir holds the BadgerDB catalog.  It is also the first storage
+	// directory when StorageDirs is empty.
+	BaseDir string
+
+	// StorageDirs are the directories object data is spread across.  When
+	// empty, BaseDir is used as the sole storage directory.
+	StorageDirs []local_cache.StorageDirConfig
+
+	// InlineMaxBytes is the largest object stored directly in the catalog
+	// rather than on disk.  Zero selects local_cache.InlineThreshold.
+	InlineMaxBytes int
+
+	// NamespaceLabel names the store in the catalog's usage counters.
+	//
+	// A store is one accounting unit spanning however many exports are mapped
+	// onto subtrees of it, because capacity is enforced store-wide (§7).
+	// Per-export accounting arrives with path-based quotas, where the lot
+	// tree is the natural place for it.  Empty selects the store root.
+	NamespaceLabel string
+}
+
+// Store is the object store backing a pstore origin.
+//
+// It owns the catalog and the block store, and is safe for concurrent use.  A
+// store has exclusive ownership of its directories for its lifetime, exactly
+// as the cache does.
+type Store struct {
+	db      *local_cache.CacheDB
+	storage *local_cache.StorageManager
+	bdb     *badger.DB
+
+	capacity *capacityTracker
+
+	// dirLabels names each storage directory for the capacity gauges.  Built
+	// once at open, because resolving a storage ID to its configured path
+	// means walking the block store's directory map and every publish would
+	// otherwise redo it.
+	dirLabels map[local_cache.StorageID]string
+
+	// namespaceID scopes this store's usage counters.  A store backs one
+	// export, so a single ID covers everything in it.
+	namespaceID local_cache.NamespaceID
+
+	// detached holds subtree roots that RemoveAll has unlinked but the
+	// janitor has not finished draining.  Their descendants remain in the
+	// index, so lookups must treat them as already gone.
+	detached *detachedSet
+
+	// readOnly marks a store opened for offline inspection; every mutating
+	// entry point refuses rather than failing deeper down in BadgerDB.
+	readOnly bool
+
+	// egrp is set only for maintenance opens, which own the group their
+	// background workers run in and must drain it on Close.
+	egrp *errgroup.Group
+
+	closeOnce sync.Once
+}
+
+// checkWritable reports an error when the store was opened read-only.
+func (s *Store) checkWritable() error {
+	if s.readOnly {
+		return errors.Wrap(ErrNotSupported, "the store is open read-only")
+	}
+	return nil
+}
+
+// Open initializes a store, creating it if the directory is empty.
+//
+// Requires issuer keys to be available (config.GetIssuerPublicJWKS or the test
+// helper), because the catalog and every object's data key are encrypted under
+// a master key derived from them.
+func Open(ctx context.Context, egrp *errgroup.Group, cfg Config) (*Store, error) {
+	if cfg.BaseDir == "" {
+		return nil, errors.New("pstore requires a base directory")
+	}
+
+	dirs := cfg.StorageDirs
+	if len(dirs) == 0 {
+		dirs = []local_cache.StorageDirConfig{{Path: cfg.BaseDir}}
+	}
+	dirPaths := make([]string, len(dirs))
+	for i, d := range dirs {
+		if d.Path == "" {
+			return nil, errors.Errorf("pstore storage directory %d has an empty path", i)
+		}
+		dirPaths[i] = d.Path
+	}
+
+	db, err := local_cache.NewCacheDB(ctx, cfg.BaseDir)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to open the pstore catalog")
+	}
+
+	// Claim the database before touching it: a cache and a pstore share this
+	// key space, so opening one as the other would silently corrupt it.
+	if err := db.EnsureStoreMode(local_cache.StoreModePStore); err != nil {
+		db.Close()
+		return nil, err
+	}
+
+	storage, err := local_cache.NewStorageManager(db, dirPaths, cfg.InlineMaxBytes, egrp)
+	if err != nil {
+		db.Close()
+		return nil, errors.Wrap(err, "failed to open pstore block storage")
+	}
+
+	capacity, err := newCapacityTracker(db, storage, dirs)
+	if err != nil {
+		storage.Close()
+		db.Close()
+		return nil, err
+	}
+
+	namespaceID, err := resolveNamespaceID(db, cfg.NamespaceLabel)
+	if err != nil {
+		storage.Close()
+		db.Close()
+		return nil, err
+	}
+
+	store := &Store{
+		db:          db,
+		storage:     storage,
+		bdb:         db.DB(),
+		capacity:    capacity,
+		dirLabels:   storageDirLabels(storage),
+		namespaceID: namespaceID,
+		detached:    newDetachedSet(),
+	}
+
+	// The block store's default chooser is round-robin, which ignores how
+	// full each directory is; hand it one driven by the capacity limits.
+	storage.SetChooseDir(capacity.chooseDir)
+
+	// A crash mid-drain leaves queue entries behind; reload them so the
+	// half-deleted trees stay invisible.
+	if err := store.reloadDetached(); err != nil {
+		storage.Close()
+		db.Close()
+		return nil, err
+	}
+
+	// Publish capacity before serving starts.  The tracker has just recovered
+	// the store's real usage from the catalog, and a gauge that only becomes
+	// correct after the first write would tell an operator that a restarted
+	// origin holding terabytes was empty -- for however long it took the next
+	// PUT to arrive.
+	store.publishCapacityMetrics()
+	store.publishReclamationMetrics()
+
+	return store, nil
+}
+
+// resolveNamespaceID assigns a stable usage-accounting ID to the store's
+// export, reusing the catalog's existing namespace index.
+func resolveNamespaceID(db *local_cache.CacheDB, prefix string) (local_cache.NamespaceID, error) {
+	if prefix == "" {
+		prefix = "/"
+	}
+	existing, next, err := db.LoadNamespaceMappings()
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to load namespace mappings")
+	}
+	if id, ok := existing[prefix]; ok {
+		return id, nil
+	}
+	if next == 0 {
+		next = 1
+	}
+	if err := db.SetNamespaceMapping(prefix, next); err != nil {
+		return 0, errors.Wrapf(err, "failed to register namespace %s", prefix)
+	}
+	return next, nil
+}
+
+// Close releases the store's resources.
+//
+// Safe to call more than once: the origin closes a store both explicitly and
+// from the shutdown goroutine watching the server context, and the block
+// store's TTL caches do not tolerate being stopped twice.
+func (s *Store) Close() error {
+	var err error
+	s.closeOnce.Do(func() {
+		s.storage.Close()
+		err = s.db.Close()
+		// A maintenance open owns its error group; wait for the block
+		// store's workers so the process can exit.
+		if s.egrp != nil {
+			if wErr := s.egrp.Wait(); wErr != nil && err == nil {
+				err = wErr
+			}
+		}
+	})
+	return err
+}
+
+// DB exposes the catalog, for introspection and tests.
+func (s *Store) DB() *local_cache.CacheDB { return s.db }
+
+// Storage exposes the block store, for introspection and tests.
+func (s *Store) Storage() *local_cache.StorageManager { return s.storage }
+
+// ---------------------------------------------------------------------------
+// Namespace operations
+// ---------------------------------------------------------------------------
+
+// Stat returns the entry at the given path.
+func (s *Store) Stat(name string) (*Dirent, error) {
+	cleanPath, err := cleanRelative(name)
+	if err != nil {
+		return nil, err
+	}
+	var d *Dirent
+	err = s.bdb.View(func(txn *badger.Txn) error {
+		var gErr error
+		d, gErr = s.resolve(txn, cleanPath)
+		return gErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// List returns the direct children of a directory in name order.
+//
+// after resumes a previous listing at the first name strictly greater than it;
+// limit bounds the result (0 means unbounded).  The bool reports whether more
+// entries remain.
+func (s *Store) List(name string, after string, limit int) ([]ListEntry, bool, error) {
+	cleanPath, err := cleanRelative(name)
+	if err != nil {
+		return nil, false, err
+	}
+	var (
+		entries []ListEntry
+		more    bool
+	)
+	err = s.bdb.View(func(txn *badger.Txn) error {
+		if dErr := s.requireDirResolved(txn, cleanPath); dErr != nil {
+			return dErr
+		}
+		var lErr error
+		entries, more, lErr = listDir(txn, cleanPath, after, limit)
+		return lErr
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	return entries, more, nil
+}
+
+// Mkdir creates a single directory.  The parent must already exist.
+func (s *Store) Mkdir(name string) error {
+	if err := s.checkWritable(); err != nil {
+		return err
+	}
+	cleanPath, err := cleanRelative(name)
+	if err != nil {
+		return err
+	}
+	if isRootPath(cleanPath) {
+		return ErrExist
+	}
+	parent, _ := splitPath(cleanPath)
+
+	if err := s.checkNotDraining(cleanPath); err != nil {
+		return err
+	}
+
+	return s.bdb.Update(func(txn *badger.Txn) error {
+		if pErr := s.requireDirResolved(txn, parent); pErr != nil {
+			if errors.Is(pErr, ErrNotExist) {
+				return errors.Wrapf(ErrNotExist, "parent directory %s does not exist", parent)
+			}
+			return pErr
+		}
+		if _, gErr := s.resolve(txn, cleanPath); gErr == nil {
+			return ErrExist
+		} else if !errors.Is(gErr, ErrNotExist) {
+			return gErr
+		}
+		return putDirent(txn, cleanPath, &Dirent{
+			Type:       EntryDir,
+			MTimeNanos: time.Now().UnixNano(),
+			Mode:       uint32(defaultDirMode.Perm()),
+		})
+	})
+}
+
+// MkdirAll creates a directory and any missing ancestors.  It succeeds when
+// the directory already exists.
+func (s *Store) MkdirAll(name string) error {
+	if err := s.checkWritable(); err != nil {
+		return err
+	}
+	cleanPath, err := cleanRelative(name)
+	if err != nil {
+		return err
+	}
+	if isRootPath(cleanPath) {
+		return nil
+	}
+
+	if err := s.checkNotDraining(cleanPath); err != nil {
+		return err
+	}
+
+	// Collect the chain root-ward so ancestors are created outermost first.
+	var missing []string
+	for cur := cleanPath; !isRootPath(cur); {
+		missing = append(missing, cur)
+		cur, _ = splitPath(cur)
+	}
+
+	return s.bdb.Update(func(txn *badger.Txn) error {
+		now := time.Now().UnixNano()
+		for i := len(missing) - 1; i >= 0; i-- {
+			p := missing[i]
+			d, gErr := s.resolve(txn, p)
+			if gErr == nil {
+				if !d.IsDir() {
+					return errors.Wrapf(ErrNotDir, "%s exists and is not a directory", p)
+				}
+				continue
+			}
+			if !errors.Is(gErr, ErrNotExist) {
+				return gErr
+			}
+			if pErr := putDirent(txn, p, &Dirent{
+				Type:       EntryDir,
+				MTimeNanos: now,
+				Mode:       uint32(defaultDirMode.Perm()),
+			}); pErr != nil {
+				return pErr
+			}
+		}
+		return nil
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Removal and rename
+// ---------------------------------------------------------------------------
+
+// Remove deletes a file, or an empty directory.
+//
+// The entry and its reclamation record are written together, so the object's
+// bytes can never become unreachable without also being queued for the
+// janitor.
+func (s *Store) Remove(name string) error {
+	if err := s.checkWritable(); err != nil {
+		return err
+	}
+	cleanPath, err := cleanRelative(name)
+	if err != nil {
+		return err
+	}
+	if isRootPath(cleanPath) {
+		return errors.Wrap(ErrInvalidPath, "cannot remove the store root")
+	}
+
+	return s.bdb.Update(func(txn *badger.Txn) error {
+		d, gErr := s.resolve(txn, cleanPath)
+		if gErr != nil {
+			return gErr
+		}
+		if d.IsDir() {
+			hasChildren, cErr := dirHasChildren(txn, cleanPath)
+			if cErr != nil {
+				return cErr
+			}
+			if hasChildren {
+				return ErrNotEmpty
+			}
+			return deleteDirent(txn, cleanPath)
+		}
+		if dErr := deleteDirent(txn, cleanPath); dErr != nil {
+			return dErr
+		}
+		if d.Generation == "" {
+			return nil
+		}
+		return enqueueInstance(txn, instanceHashFor(s.db, d.Generation))
+	})
+}
+
+// RemoveAll deletes a path and everything beneath it.
+//
+// A large subtree cannot be removed in one transaction, so the entry is
+// unlinked from its parent — making the subtree unreachable at once — and its
+// root handed to the janitor to drain.  Deletion need not be atomic: a
+// partially drained subtree is invisible either way.
+func (s *Store) RemoveAll(name string) error {
+	if err := s.checkWritable(); err != nil {
+		return err
+	}
+	cleanPath, err := cleanRelative(name)
+	if err != nil {
+		return err
+	}
+	if isRootPath(cleanPath) {
+		return errors.Wrap(ErrInvalidPath, "cannot remove the store root")
+	}
+
+	// The transaction is driven by hand rather than through bdb.Update so the
+	// detached mark can be raised between the last write and the commit.
+	// Raising it afterwards leaves a window in which the subtree is already
+	// unlinked but still resolves: Stat, OpenRead and List on a descendant
+	// succeed on data that is gone, and a Create that slips past
+	// checkNotDraining materializes an instance whose commit then fails.
+	txn := s.bdb.NewTransaction(true)
+	defer txn.Discard()
+
+	detached := false
+	err = func() error {
+		d, gErr := s.resolve(txn, cleanPath)
+		if gErr != nil {
+			return gErr
+		}
+		if dErr := deleteDirent(txn, cleanPath); dErr != nil {
+			return dErr
+		}
+		if !d.IsDir() {
+			if d.Generation == "" {
+				return nil
+			}
+			return enqueueInstance(txn, instanceHashFor(s.db, d.Generation))
+		}
+
+		// Remove the whole subtree now when it is small enough to fit in this
+		// transaction, which covers nearly every real removal.
+		//
+		// This matters for more than latency.  A detached subtree leaves its
+		// descendants in the index under keys the same paths would reuse, so
+		// recreating the tree before the janitor drains it would put new
+		// entries where the drain is about to delete.  Finishing inline
+		// removes that window entirely; only a subtree too large for one
+		// transaction is deferred, and re-creating one of those is refused
+		// until the drain completes rather than silently losing data.
+		done, dErr := deleteSubtreeInline(txn, s.db, cleanPath)
+		if dErr != nil {
+			return dErr
+		}
+		if done {
+			return nil
+		}
+		detached = true
+		return enqueueSubtree(txn, cleanPath)
+	}()
+	// Matching os.RemoveAll, removing something that is not there is not an
+	// error.
+	if errors.Is(err, ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if detached {
+		// Descendants keep their index keys until the janitor drains them,
+		// and a path-derived lookup does not consult ancestors, so they must
+		// be masked explicitly until then.  See detached.go.
+		s.detached.add(cleanPath)
+	}
+	if cErr := txn.Commit(); cErr != nil {
+		if detached {
+			// Nothing was unlinked after all, so the mask must come back down
+			// or the subtree stays invisible for the life of the process.
+			s.detached.remove(cleanPath)
+		}
+		return errors.Wrapf(cErr, "failed to remove %s", cleanPath)
+	}
+	return nil
+}
+
+// Rename moves an entry, replacing any existing file at the destination.
+//
+// Renaming a file rewrites one key.  Renaming a directory rewrites every
+// descendant's key, which is why it is O(descendants) — but object identity
+// does not depend on the path, so no data file is touched and no bytes move.
+func (s *Store) Rename(oldName, newName string) error {
+	if err := s.checkWritable(); err != nil {
+		return err
+	}
+	oldPath, err := cleanRelative(oldName)
+	if err != nil {
+		return err
+	}
+	newPath, err := cleanRelative(newName)
+	if err != nil {
+		return err
+	}
+	if isRootPath(oldPath) || isRootPath(newPath) {
+		return errors.Wrap(ErrInvalidPath, "cannot rename the store root")
+	}
+	if oldPath == newPath {
+		return nil
+	}
+	// Moving a directory into itself would detach the subtree from the tree.
+	if strings.HasPrefix(newPath, oldPath+"/") {
+		return errors.Wrapf(ErrInvalidPath, "cannot move %s beneath itself", oldPath)
+	}
+
+	// Both ends have to be checked against the drain queue, and neither check
+	// can be left to the resolves below: resolve *masks* a detached path as
+	// ErrNotExist, so a destination that is a subtree still being reclaimed
+	// looks like free space.  The rename would then succeed, rebase the source
+	// onto keys the drain is about to walk, and the janitor would delete both
+	// subtrees without anything reporting an error.
+	if err := s.checkNotDraining(oldPath); err != nil {
+		return err
+	}
+	if err := s.checkNotDraining(newPath); err != nil {
+		return err
+	}
+
+	return s.bdb.Update(func(txn *badger.Txn) error {
+		src, gErr := s.resolve(txn, oldPath)
+		if gErr != nil {
+			return gErr
+		}
+		newParent, _ := splitPath(newPath)
+		if pErr := s.requireDirResolved(txn, newParent); pErr != nil {
+			return pErr
+		}
+
+		// A destination file is replaced; its version still needs reclaiming.
+		if dst, dErr := s.resolve(txn, newPath); dErr == nil {
+			switch {
+			case dst.IsDir():
+				return ErrIsDir
+			case src.IsDir():
+				return ErrNotDir
+			}
+			if dst.Generation != "" {
+				if eErr := enqueueInstance(txn, instanceHashFor(s.db, dst.Generation)); eErr != nil {
+					return eErr
+				}
+			}
+		} else if !errors.Is(dErr, ErrNotExist) {
+			return dErr
+		}
+
+		if src.IsDir() {
+			if mErr := moveSubtree(txn, oldPath, newPath); mErr != nil {
+				return mErr
+			}
+		}
+		if dErr := deleteDirent(txn, oldPath); dErr != nil {
+			return dErr
+		}
+		return putDirent(txn, newPath, src)
+	})
+}
+
+// renameSubtreeLimit bounds how many descendants a single directory rename may
+// rewrite.
+//
+// A rename is atomic by construction — every key moves in one transaction, or
+// none does — and BadgerDB caps how much one transaction may hold.  Past that
+// cap the commit fails with "Txn is too big to fit into one request", which is
+// not something a WebDAV client can act on.  Batching the rewrite across
+// several transactions would lift the ceiling but would also mean a crash
+// mid-rename could leave a tree half under each name, which is a far worse
+// failure than a refusal: rename is the one namespace operation callers rely
+// on being all-or-nothing.  So the limit is enforced explicitly, before
+// anything is written, and reported as ErrNotSupported with an actionable
+// message.
+//
+// The value is well under the point where BadgerDB actually refuses (~150k
+// entries with dirents this size), so the typed error always wins the race
+// against the raw one.
+const renameSubtreeLimit = 50_000
+
+// moveSubtree rewrites every descendant key so it hangs off newRoot.
+//
+// Only index keys change: an object's identity comes from its generation, not
+// its path, so metadata, block state, and data files all stay put.
+func moveSubtree(txn *badger.Txn, oldRoot, newRoot string) error {
+	type move struct {
+		path   string
+		dirent *Dirent
+	}
+	var moves []move
+	oversize := false
+
+	if err := walkSubtree(txn, oldRoot, func(entryPath string, d *Dirent) error {
+		if len(moves) >= renameSubtreeLimit {
+			oversize = true
+			return errStopWalk
+		}
+		moves = append(moves, move{path: entryPath, dirent: d})
+		return nil
+	}); err != nil && !errors.Is(err, errStopWalk) {
+		return err
+	}
+	if oversize {
+		return errors.Wrapf(ErrNotSupported,
+			"cannot rename %s: it holds more than %d entries, which does not fit in "+
+				"one atomic transaction; move its children in smaller groups",
+			oldRoot, renameSubtreeLimit)
+	}
+
+	for _, m := range moves {
+		if err := deleteDirent(txn, m.path); err != nil {
+			return err
+		}
+		rebased := newRoot + strings.TrimPrefix(m.path, oldRoot)
+		if err := putDirent(txn, rebased, m.dirent); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pstore/store_test.go
+++ b/pstore/store_test.go
@@ -1,0 +1,272 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package pstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/local_cache"
+)
+
+// newTestStore opens a store in a temporary directory and closes it on
+// cleanup.
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	local_cache.InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	egrp, _ := errgroup.WithContext(ctx)
+
+	s, err := Open(ctx, egrp, Config{BaseDir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, s.Close()) })
+	return s
+}
+
+func TestOpenAndClose(t *testing.T) {
+	s := newTestStore(t)
+
+	root, err := s.Stat("/")
+	require.NoError(t, err)
+	assert.True(t, root.IsDir(), "the root is always a directory")
+}
+
+// TestStoreModeRejectsCacheDatabase covers the guard that keeps a pstore and a
+// cache from operating on the same key space.  A database already claimed by
+// the cache must be refused rather than silently corrupted.
+func TestStoreModeRejectsCacheDatabase(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	dir := t.TempDir()
+
+	db, err := local_cache.NewCacheDB(ctx, dir)
+	require.NoError(t, err)
+	require.NoError(t, db.EnsureStoreMode(local_cache.StoreModeCache))
+	require.NoError(t, db.Close())
+
+	egrp, _ := errgroup.WithContext(ctx)
+	_, err = Open(ctx, egrp, Config{BaseDir: dir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cache")
+}
+
+// TestStoreModeRejectsUnmarkedNonEmptyDatabase covers the legacy case: a cache
+// database predating the marker holds data but claims nothing.  pstore always
+// writes a marker, so such a database can only be a cache and must not be
+// adopted.
+func TestStoreModeRejectsUnmarkedNonEmptyDatabase(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	dir := t.TempDir()
+
+	db, err := local_cache.NewCacheDB(ctx, dir)
+	require.NoError(t, err)
+	// Write a record without claiming a mode, as a pre-marker cache would.
+	require.NoError(t, db.SetNamespaceMapping("/legacy", 1))
+	require.NoError(t, db.Close())
+
+	egrp, _ := errgroup.WithContext(ctx)
+	_, err = Open(ctx, egrp, Config{BaseDir: dir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pre-existing cache")
+}
+
+// TestStoreModePersistsAcrossReopen confirms a pstore reopens its own database
+// and that the cache is then locked out of it.
+func TestStoreModePersistsAcrossReopen(t *testing.T) {
+	local_cache.InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	dir := t.TempDir()
+	egrp, _ := errgroup.WithContext(ctx)
+
+	s, err := Open(ctx, egrp, Config{BaseDir: dir})
+	require.NoError(t, err)
+	require.NoError(t, s.Mkdir("/persisted"))
+	require.NoError(t, s.Close())
+
+	s2, err := Open(ctx, egrp, Config{BaseDir: dir})
+	require.NoError(t, err)
+	d, err := s2.Stat("/persisted")
+	require.NoError(t, err)
+	assert.True(t, d.IsDir())
+	require.NoError(t, s2.Close())
+
+	db, err := local_cache.NewCacheDB(ctx, dir)
+	require.NoError(t, err)
+	defer db.Close()
+	err = db.EnsureStoreMode(local_cache.StoreModeCache)
+	require.Error(t, err, "a cache must not open a pstore database")
+	assert.Contains(t, err.Error(), "pstore")
+}
+
+func TestMkdirAndStat(t *testing.T) {
+	s := newTestStore(t)
+
+	require.NoError(t, s.Mkdir("/proj"))
+	d, err := s.Stat("/proj")
+	require.NoError(t, err)
+	assert.True(t, d.IsDir())
+
+	assert.ErrorIs(t, s.Mkdir("/proj"), ErrExist, "re-creating a directory fails")
+	assert.ErrorIs(t, s.Mkdir("/missing/deep"), ErrNotExist, "the parent must exist")
+
+	_, err = s.Stat("/nope")
+	assert.ErrorIs(t, err, ErrNotExist)
+}
+
+func TestMkdirAll(t *testing.T) {
+	s := newTestStore(t)
+
+	require.NoError(t, s.MkdirAll("/a/b/c"))
+	for _, p := range []string{"/a", "/a/b", "/a/b/c"} {
+		d, err := s.Stat(p)
+		require.NoError(t, err, "%s should exist", p)
+		assert.True(t, d.IsDir(), "%s should be a directory", p)
+	}
+
+	assert.NoError(t, s.MkdirAll("/a/b/c"), "MkdirAll is idempotent")
+	assert.NoError(t, s.MkdirAll("/"), "MkdirAll on the root is a no-op")
+}
+
+// TestListReturnsOnlyDirectChildren is the central property of the index: a
+// listing is one contiguous range holding exactly the direct children, with
+// no descendants to filter out and no subtrees to seek past.
+func TestListReturnsOnlyDirectChildren(t *testing.T) {
+	s := newTestStore(t)
+
+	require.NoError(t, s.MkdirAll("/d/sub/deeper"))
+	require.NoError(t, s.Mkdir("/d/other"))
+	require.NoError(t, s.Mkdir("/elsewhere"))
+
+	entries, more, err := s.List("/d", "", 0)
+	require.NoError(t, err)
+	assert.False(t, more)
+
+	names := entryNames(entries)
+	assert.Equal(t, []string{"other", "sub"}, names,
+		"only direct children, in name order")
+}
+
+// TestListOrderingWithAwkwardSiblings is the runtime counterpart to
+// TestDirentKeyOrdering: the siblings that would break a full-path key layout
+// must come back in plain name order.
+func TestListOrderingWithAwkwardSiblings(t *testing.T) {
+	s := newTestStore(t)
+
+	require.NoError(t, s.Mkdir("/a"))
+	require.NoError(t, s.Mkdir("/a.b"))
+	require.NoError(t, s.Mkdir("/a0b"))
+	require.NoError(t, s.Mkdir("/a-b"))
+	// Give /a descendants, which a full-path layout would interleave with
+	// its siblings.
+	require.NoError(t, s.MkdirAll("/a/x/y"))
+	require.NoError(t, s.Mkdir("/a-b/child"))
+
+	entries, _, err := s.List("/", "", 0)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "a-b", "a.b", "a0b"}, entryNames(entries))
+}
+
+func TestListPagination(t *testing.T) {
+	s := newTestStore(t)
+
+	require.NoError(t, s.Mkdir("/d"))
+	for _, n := range []string{"a", "b", "c", "d", "e"} {
+		require.NoError(t, s.Mkdir("/d/"+n))
+	}
+
+	first, more, err := s.List("/d", "", 2)
+	require.NoError(t, err)
+	assert.True(t, more)
+	assert.Equal(t, []string{"a", "b"}, entryNames(first))
+
+	second, more, err := s.List("/d", "b", 2)
+	require.NoError(t, err)
+	assert.True(t, more)
+	assert.Equal(t, []string{"c", "d"}, entryNames(second))
+
+	third, more, err := s.List("/d", "d", 2)
+	require.NoError(t, err)
+	assert.False(t, more, "the final page reports no remainder")
+	assert.Equal(t, []string{"e"}, entryNames(third))
+}
+
+func TestListErrors(t *testing.T) {
+	s := newTestStore(t)
+
+	_, _, err := s.List("/missing", "", 0)
+	assert.ErrorIs(t, err, ErrNotExist)
+
+	// A file is not listable.
+	require.NoError(t, s.Mkdir("/d"))
+	require.NoError(t, putFileForTest(s, "/d/f", 10))
+	_, _, err = s.List("/d/f", "", 0)
+	assert.ErrorIs(t, err, ErrNotDir)
+}
+
+func TestListEmptyDirectory(t *testing.T) {
+	s := newTestStore(t)
+
+	require.NoError(t, s.Mkdir("/empty"))
+	entries, more, err := s.List("/empty", "", 0)
+	require.NoError(t, err)
+	assert.False(t, more)
+	assert.Empty(t, entries, "an empty directory is a real, listable entry")
+}
+
+// putFileForTest writes a file dirent directly, without object data.  The
+// write path arrives in a later phase; index-level tests only need an entry of
+// the right type to exist.
+func putFileForTest(s *Store, name string, size int64) error {
+	cleanPath, err := cleanRelative(name)
+	if err != nil {
+		return err
+	}
+	return s.bdb.Update(func(txn *badger.Txn) error {
+		return putDirent(txn, cleanPath, &Dirent{
+			Type:       EntryFile,
+			Generation: "testgen",
+			Size:       size,
+			MTimeNanos: time.Now().UnixNano(),
+			Mode:       uint32(defaultFileMode),
+		})
+	})
+}
+
+func entryNames(entries []ListEntry) []string {
+	names := make([]string, len(entries))
+	for i, e := range entries {
+		names[i] = e.Name
+	}
+	return names
+}

--- a/server_structs/origin.go
+++ b/server_structs/origin.go
@@ -52,6 +52,7 @@ const (
 	OriginStorageS3v2     OriginStorageType = "s3v2"     // Native S3 backend (no XRootD)
 	OriginStorageHTTPSv2  OriginStorageType = "httpsv2"  // Native HTTPS/WebDAV backend (no XRootD)
 	OriginStorageGlobusv2 OriginStorageType = "globusv2" // Native Globus backend (no XRootD)
+	OriginStoragePStore   OriginStorageType = "pstore"   // Pelican store: encrypted block store on local disk (no XRootD)
 	OriginStorageXRoot    OriginStorageType = "xroot"    // Not meant to be extensible, but facilitates legacy OSDF --> Pelican transition
 )
 
@@ -59,14 +60,33 @@ var (
 	ErrUnknownOriginStorageType = errors.New("unknown origin storage type")
 )
 
-// IsPosixLike reports whether the storage type is a "POSIX-like" backend whose
-// data lives on a locally-mounted filesystem (as opposed to a remote-protocol
-// backend such as S3, HTTPS, Globus, SSH, or XRoot). POSIX-like backends share
-// behavior in several places: the origin can run its own self-test and the
-// director can probe it; atomic uploads (POSC) work because rename(2) is
-// available; checksum xattrs can be stored on local files; etc. New POSIX-like
-// backends should be added here rather than growing the list of `==` checks
-// scattered across the codebase.
+// SupportsSelfTest reports whether the origin can accept the write-read probe
+// that the origin self-test and the director test rely on.
+//
+// The probe writes a small object and reads it back, so it needs a backend the
+// origin can write to directly and cheaply. That rules out the
+// remote-protocol backends (S3, HTTPS, Globus, SSH, XRoot), where the probe
+// would mean egress and credentials for every health check.
+//
+// Note that this is a different question from IsPosixLike: pstore is not a
+// POSIX filesystem and its StoragePrefix is not a host path, but it is local
+// and writable, so it can self-test.
+func (t OriginStorageType) SupportsSelfTest() bool {
+	switch t {
+	case OriginStoragePosix, OriginStoragePosixv2, OriginStoragePStore:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsPosixLike reports whether an export's StoragePrefix names a directory on
+// this host, so it can be walked, stat'd, or opened as an os.Root.
+//
+// pstore is deliberately excluded. Its StoragePrefix is a path inside the
+// store's own namespace, not on the filesystem -- "/" is a perfectly ordinary
+// value for it -- so resolving one against the local filesystem reads
+// something else entirely, or the host's root directory.
 func (t OriginStorageType) IsPosixLike() bool {
 	switch t {
 	case OriginStoragePosix, OriginStoragePosixv2:
@@ -82,7 +102,7 @@ func (t OriginStorageType) IsPosixLike() bool {
 // added here rather than duplicating the list of storage-type comparisons.
 func (t OriginStorageType) UsesXRootD() bool {
 	switch t {
-	case OriginStoragePosixv2, OriginStorageSSH, OriginStorageS3v2, OriginStorageHTTPSv2, OriginStorageGlobusv2:
+	case OriginStoragePosixv2, OriginStorageSSH, OriginStorageS3v2, OriginStorageHTTPSv2, OriginStorageGlobusv2, OriginStoragePStore:
 		return false
 	default:
 		return true
@@ -112,8 +132,10 @@ func ParseOriginStorageType(storageType string) (ost OriginStorageType, err erro
 		ost = OriginStorageHTTPSv2
 	case string(OriginStorageGlobusv2):
 		ost = OriginStorageGlobusv2
+	case string(OriginStoragePStore):
+		ost = OriginStoragePStore
 	default:
-		err = errors.Wrapf(ErrUnknownOriginStorageType, "storage type %s (known types are posix, posixv2, ssh, s3, s3v2, https, httpsv2, globus, globusv2, and xroot)", storageType)
+		err = errors.Wrapf(ErrUnknownOriginStorageType, "storage type %s (known types are posix, posixv2, ssh, s3, s3v2, https, httpsv2, globus, globusv2, pstore, and xroot)", storageType)
 	}
 	return
 }

--- a/server_structs/origin_test.go
+++ b/server_structs/origin_test.go
@@ -25,31 +25,36 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestOriginStorageType_IsPosixLike pins down which backends count as
-// "POSIX-like" so a future contributor can't silently flip an entry and have
-// every downstream call site (self-test, director-test, etc.) start treating
-// a remote-protocol backend as local.
-func TestOriginStorageType_IsPosixLike(t *testing.T) {
+// TestOriginStorageType_SupportsSelfTest pins down which backends accept the
+// write-read probe, so a future contributor can't silently flip an entry and
+// have the origin self-test and director test start probing a remote-protocol
+// backend -- which would mean egress and credentials on every health check.
+func TestOriginStorageType_SupportsSelfTest(t *testing.T) {
 	cases := []struct {
 		in       OriginStorageType
 		expected bool
 	}{
 		{OriginStoragePosix, true},
 		{OriginStoragePosixv2, true},
+		// pstore is not a POSIX filesystem, but it is local and writable.
+		{OriginStoragePStore, true},
 
 		{OriginStorageSSH, false},
 		{OriginStorageS3, false},
+		{OriginStorageS3v2, false},
 		{OriginStorageHTTPS, false},
+		{OriginStorageHTTPSv2, false},
 		{OriginStorageGlobus, false},
+		{OriginStorageGlobusv2, false},
 		{OriginStorageXRoot, false},
 
-		// Unknown / unset values must not be treated as POSIX-like.
+		// Unknown / unset values must not be probed.
 		{OriginStorageType(""), false},
 		{OriginStorageType("does-not-exist"), false},
 	}
 	for _, tc := range cases {
 		t.Run(string(tc.in), func(t *testing.T) {
-			assert.Equal(t, tc.expected, tc.in.IsPosixLike())
+			assert.Equal(t, tc.expected, tc.in.SupportsSelfTest())
 		})
 	}
 }
@@ -90,4 +95,55 @@ func TestParseExportVolume(t *testing.T) {
 				"a federation prefix must never pick up the platform separator")
 		})
 	}
+}
+
+// TestOriginStorageType_IsPosixLike pins the distinction that matters most
+// here: pstore can self-test, but its StoragePrefix is not a host path.
+// Conflating the two would send a directory walk, a stat, or an os.Root at a
+// path inside the store's namespace -- "/" being an ordinary value for it.
+func TestOriginStorageType_IsPosixLike(t *testing.T) {
+	for _, hostPath := range []OriginStorageType{
+		OriginStoragePosix, OriginStoragePosixv2,
+	} {
+		assert.True(t, hostPath.IsPosixLike(), "%s stores data at a host path", hostPath)
+	}
+	for _, notHostPath := range []OriginStorageType{
+		OriginStoragePStore, OriginStorageSSH, OriginStorageS3, OriginStorageS3v2,
+		OriginStorageHTTPS, OriginStorageHTTPSv2, OriginStorageGlobus,
+		OriginStorageGlobusv2, OriginStorageXRoot,
+	} {
+		assert.False(t, notHostPath.IsPosixLike(),
+			"%s does not store data at a host path", notHostPath)
+	}
+
+	// The two predicates disagree on pstore, and that disagreement is the point.
+	assert.True(t, OriginStoragePStore.SupportsSelfTest())
+	assert.False(t, OriginStoragePStore.IsPosixLike())
+}
+
+// TestOriginStorageType_UsesXRootD pins the other half: pstore is served
+// directly by the pelican process and must never launch XRootD.
+func TestOriginStorageType_UsesXRootD(t *testing.T) {
+	for _, native := range []OriginStorageType{
+		OriginStoragePosixv2, OriginStorageSSH, OriginStorageS3v2,
+		OriginStorageHTTPSv2, OriginStorageGlobusv2, OriginStoragePStore,
+	} {
+		assert.False(t, native.UsesXRootD(), "%s is served natively", native)
+	}
+	for _, xrootd := range []OriginStorageType{
+		OriginStoragePosix, OriginStorageS3, OriginStorageHTTPS,
+		OriginStorageGlobus, OriginStorageXRoot,
+	} {
+		assert.True(t, xrootd.UsesXRootD(), "%s is fronted by XRootD", xrootd)
+	}
+}
+
+// TestParseOriginStorageType covers the pstore spelling reaching the parser.
+func TestParseOriginStorageType(t *testing.T) {
+	got, err := ParseOriginStorageType("pstore")
+	assert.NoError(t, err)
+	assert.Equal(t, OriginStoragePStore, got)
+
+	_, err = ParseOriginStorageType("nonsense")
+	assert.ErrorIs(t, err, ErrUnknownOriginStorageType)
 }

--- a/server_utils/origin.go
+++ b/server_utils/origin.go
@@ -649,6 +649,8 @@ func GetOriginExports() ([]OriginExport, error) {
 		origin = &HTTPSv2Origin{}
 	case server_structs.OriginStorageGlobusv2:
 		origin = &Globusv2Origin{}
+	case server_structs.OriginStoragePStore:
+		origin = &PStoreOrigin{}
 	case server_structs.OriginStorageXRoot:
 		origin = &XRootOrigin{}
 	default:

--- a/server_utils/origin_backend.go
+++ b/server_utils/origin_backend.go
@@ -58,6 +58,21 @@ type OriginChecksummer interface {
 	GetDigests(relativePath string, wantDigest string) ([]string, error)
 }
 
+// CapacityReporter is optionally implemented by backends that enforce a fixed
+// size and can say up front whether a write will fit.
+//
+// A backend that cannot accept more data is better off refusing a PUT before
+// the client streams a body it will have to discard, and better off returning
+// 507 than whatever status the WebDAV handler infers from a mid-stream write
+// failure.  Backends that grow on demand simply do not implement this.
+type CapacityReporter interface {
+	// HasCapacityFor reports nil when a write of nBytes can currently be
+	// accepted, or an error (typically wrapping syscall.ENOSPC) when it
+	// cannot.  It is advisory: capacity may still be exhausted by a
+	// concurrent write, so the write path must enforce the limit too.
+	HasCapacityFor(nBytes int64) error
+}
+
 // HTTPStatusCoder is optionally implemented by errors returned from
 // CheckAvailability to control the HTTP status code sent to clients.
 type HTTPStatusCoder interface {

--- a/server_utils/origin_pstore.go
+++ b/server_utils/origin_pstore.go
@@ -1,0 +1,57 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package server_utils
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
+)
+
+// PStoreOrigin is the Pelican store backend: an encrypted block store on
+// local disk, served directly by the pelican process.  See
+// docs/pstore-design.md.
+type PStoreOrigin struct {
+	BaseOrigin
+}
+
+func (o *PStoreOrigin) Type(_ Origin) server_structs.OriginStorageType {
+	return server_structs.OriginStoragePStore
+}
+
+// validateStoragePrefix checks the export's storage prefix as a logical path
+// inside the store.
+//
+// Unlike a POSIX origin's, this prefix is not a filesystem path and must not
+// be resolved against the local filesystem: the store's namespace lives in the
+// catalog, and the prefix names a subtree within it that need not exist yet.
+func (o *PStoreOrigin) validateStoragePrefix(prefix string) error {
+	return validatePathLikePrefix(prefix)
+}
+
+// validateExtra requires the store location to be configured, since unlike a
+// POSIX origin there is no directory to fall back on.
+func (o *PStoreOrigin) validateExtra(_ *OriginExport, _ int) error {
+	if param.Origin_PStoreLocation.GetString() == "" && param.Origin_PStoreStorageDirs.GetRaw() == nil {
+		return errors.Errorf("either %s or %s must be set when the origin storage type is 'pstore'",
+			param.Origin_PStoreLocation.GetName(), param.Origin_PStoreStorageDirs.GetName())
+	}
+	return nil
+}

--- a/ssh_posixv2/helper_broker_test.go
+++ b/ssh_posixv2/helper_broker_test.go
@@ -511,14 +511,51 @@ func TestSSHFileSystemInterface(t *testing.T) {
 	var _ server_utils.OriginBackend = fs
 
 	// Test URL construction
-	url := fs.makeHelperURL("/subdir/file.txt")
+	url, err := fs.makeHelperURL("/subdir/file.txt")
+	require.NoError(t, err)
 	assert.Equal(t, "http://helper/test/subdir/file.txt", url)
 
-	url = fs.makeHelperURL("")
+	url, err = fs.makeHelperURL("")
+	require.NoError(t, err)
 	assert.Equal(t, "http://helper/test", url)
 
-	url = fs.makeHelperURL("/")
+	url, err = fs.makeHelperURL("/")
+	require.NoError(t, err)
 	assert.Equal(t, "http://helper/test/", url)
+}
+
+// TestMakeHelperURLRefusesEscapingPaths pins the containment on makeHelperURL
+// itself.  The handler cleans the request path before it gets here, but the
+// Destination header of a MOVE or COPY is not cleaned by x/net/webdav, so a
+// name carrying "../" reaches this function intact and would otherwise
+// resolve onto another export's route on the helper.
+func TestMakeHelperURLRefusesEscapingPaths(t *testing.T) {
+	fs := NewSSHFileSystem(nil, "/exports/one", "/srv/one")
+
+	for _, name := range []string{
+		"/../two/secret.txt",
+		"/../../etc/passwd",
+		"/subdir/../../two",
+		"/..",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := fs.makeHelperURL(name)
+			require.Error(t, err, "a path resolving outside the federation prefix must be refused")
+			assert.Contains(t, err.Error(), "outside the export's federation prefix")
+		})
+	}
+
+	// A sibling prefix that merely shares a string prefix is not "under" it.
+	_, err := fs.makeHelperURL("/../one-secret/x")
+	require.Error(t, err)
+
+	// Dot-segments that stay inside the prefix remain legal.
+	url, err := fs.makeHelperURL("/subdir/../file.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "http://helper/exports/one/file.txt", url)
+
+	// Rename carries the destination through the same guard.
+	require.Error(t, fs.Rename(context.Background(), "/a.txt", "/../two/b.txt"))
 }
 
 // TestSSHFileInfo tests the sshFileInfo implementation

--- a/ssh_posixv2/helper_cmd.go
+++ b/ssh_posixv2/helper_cmd.go
@@ -130,7 +130,7 @@ func RunHelper(ctx context.Context) error {
 			log.SetLevel(lvl)
 			sshLog.Debugf("Log level set to %s (from origin)", lvl)
 		} else {
-			sshLog.Warnf("Ignoring unrecognised log level %q from origin: %v", config.LogLevel, err)
+			sshLog.Warnf("Ignoring unrecognized log level %q from origin: %v", config.LogLevel, err)
 		}
 	}
 

--- a/ssh_posixv2/origin_filesystem.go
+++ b/ssh_posixv2/origin_filesystem.go
@@ -124,21 +124,48 @@ func NewSSHFileSystem(transport http.RoundTripper, federationPrefix, storagePref
 
 // makeHelperURL constructs the URL for a request to the helper
 // The helper serves WebDAV at /<federationPrefix>/<path>
-func (fs *SSHFileSystem) makeHelperURL(name string) string {
+//
+// name arrives from the WebDAV layer and is not trusted.  path.Join
+// normalizes dot-segments away, so a name containing "../" would resolve
+// *out* of the federation prefix and address a different export's route on
+// the helper -- the same join-then-clean mistake that aferoFileSystem's
+// confineToPrefix exists to prevent.  The request path is cleaned before it
+// reaches here, but a MOVE or COPY Destination header is not cleaned by
+// golang.org/x/net/webdav, so the guard belongs here as well: SSHFileSystem
+// is a webdav.FileSystem in its own right and must not depend on a caller
+// two layers up having sanitised its input.
+func (fs *SSHFileSystem) makeHelperURL(name string) (string, error) {
 	// The helper uses the federation prefix as its route.
 	// Preserve trailing slashes so that directory requests match the
 	// http.ServeMux pattern registered with a trailing slash.
 	trailingSlash := strings.HasSuffix(name, "/")
-	cleanPath := path.Clean(path.Join(fs.federationPrefix, name))
+	prefix := path.Clean("/" + strings.TrimPrefix(fs.federationPrefix, "/"))
+	cleanPath := path.Clean(path.Join(prefix, name))
+	if !withinPrefix(cleanPath, prefix) {
+		return "", errors.Errorf("path %q resolves outside the export's federation prefix %q", name, fs.federationPrefix)
+	}
 	if trailingSlash && !strings.HasSuffix(cleanPath, "/") {
 		cleanPath += "/"
 	}
-	return "http://helper" + cleanPath
+	return "http://helper" + cleanPath, nil
+}
+
+// withinPrefix reports whether an already-cleaned absolute path is the
+// prefix itself or sits beneath it.  The trailing separator matters: without
+// it "/exports/one-secret" would count as being under "/exports/one".
+func withinPrefix(cleaned, prefix string) bool {
+	if prefix == "/" || cleaned == prefix {
+		return true
+	}
+	return strings.HasPrefix(cleaned, strings.TrimSuffix(prefix, "/")+"/")
 }
 
 // Mkdir creates a directory on the remote filesystem via WebDAV MKCOL
 func (fs *SSHFileSystem) Mkdir(ctx context.Context, name string, perm os.FileMode) error {
-	url := fs.makeHelperURL(name)
+	url, err := fs.makeHelperURL(name)
+	if err != nil {
+		return err
+	}
 	req, err := http.NewRequestWithContext(ctx, "MKCOL", url, nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to create MKCOL request")
@@ -179,7 +206,10 @@ func (fs *SSHFileSystem) OpenFile(ctx context.Context, name string, flag int, pe
 
 // RemoveAll removes a file or directory
 func (fs *SSHFileSystem) RemoveAll(ctx context.Context, name string) error {
-	url := fs.makeHelperURL(name)
+	url, err := fs.makeHelperURL(name)
+	if err != nil {
+		return err
+	}
 	req, err := http.NewRequestWithContext(ctx, "DELETE", url, nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to create DELETE request")
@@ -201,14 +231,20 @@ func (fs *SSHFileSystem) RemoveAll(ctx context.Context, name string) error {
 
 // Rename renames a file or directory via WebDAV MOVE
 func (fs *SSHFileSystem) Rename(ctx context.Context, oldName, newName string) error {
-	url := fs.makeHelperURL(oldName)
+	url, err := fs.makeHelperURL(oldName)
+	if err != nil {
+		return err
+	}
 	req, err := http.NewRequestWithContext(ctx, "MOVE", url, nil)
 	if err != nil {
 		return errors.Wrap(err, "failed to create MOVE request")
 	}
 
 	// Set the Destination header for the new location
-	destURL := fs.makeHelperURL(newName)
+	destURL, err := fs.makeHelperURL(newName)
+	if err != nil {
+		return err
+	}
 	req.Header.Set("Destination", destURL)
 	req.Header.Set("Overwrite", "T")
 	setPelicanHeaders(ctx, req)
@@ -228,7 +264,10 @@ func (fs *SSHFileSystem) Rename(ctx context.Context, oldName, newName string) er
 
 // Stat returns file info via WebDAV PROPFIND
 func (fs *SSHFileSystem) Stat(ctx context.Context, name string) (os.FileInfo, error) {
-	url := fs.makeHelperURL(name)
+	url, err := fs.makeHelperURL(name)
+	if err != nil {
+		return nil, err
+	}
 	req, err := http.NewRequestWithContext(ctx, "PROPFIND", url, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create PROPFIND request")
@@ -414,7 +453,10 @@ func (f *sshFile) Close() error {
 func (f *sshFile) Read(p []byte) (n int, err error) {
 	// If we don't have a reader yet, create one
 	if f.reader == nil {
-		url := f.fs.makeHelperURL(f.name)
+		url, err := f.fs.makeHelperURL(f.name)
+		if err != nil {
+			return 0, err
+		}
 		req, err := http.NewRequestWithContext(f.ctx, "GET", url, nil)
 		if err != nil {
 			return 0, errors.Wrap(err, "failed to create GET request")
@@ -496,7 +538,12 @@ func (f *sshFile) Write(p []byte) (n int, err error) {
 		go func() {
 			defer close(f.writeDone)
 
-			helperURL := f.fs.makeHelperURL(f.name)
+			helperURL, err := f.fs.makeHelperURL(f.name)
+			if err != nil {
+				f.writeErr = err
+				_ = pr.CloseWithError(err)
+				return
+			}
 			req, err := http.NewRequestWithContext(f.ctx, "PUT", helperURL, pr)
 			if err != nil {
 				f.writeErr = errors.Wrap(err, "failed to create PUT request")
@@ -535,7 +582,10 @@ func (f *sshFile) Readdir(count int) ([]os.FileInfo, error) {
 	if !strings.HasSuffix(dirName, "/") {
 		dirName += "/"
 	}
-	url := f.fs.makeHelperURL(dirName)
+	url, err := f.fs.makeHelperURL(dirName)
+	if err != nil {
+		return nil, err
+	}
 	req, err := http.NewRequestWithContext(f.ctx, "PROPFIND", url, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create PROPFIND request")

--- a/web_ui/frontend/components/configuration/Fields/Field.tsx
+++ b/web_ui/frontend/components/configuration/Fields/Field.tsx
@@ -211,6 +211,9 @@ const Field = ({
               keyGetter={(v) => v.policyname}
             />
           );
+        // Origin.PStoreStorageDirs takes the same shape as
+        // LocalCache.StorageDirs, so it reuses the same form.
+        case 'PStoreStorageDirs':
         case 'StorageDirs':
           return (
             <ObjectField


### PR DESCRIPTION
Adds **pstore** ("pelican store"): an origin storage backend that uses the cache V2 block store as an origin's *primary* data store rather than as a cache.

The block store under `local_cache` — encrypted 4080-byte blocks, multi-directory spreading, chunking, and a BadgerDB catalog that is itself encrypted at rest — is a general-purpose object store that happens to be used by a cache. pstore drives it directly, adds the one thing a cache never needed (a directory index), and exposes the result as an `afero.Fs`, so it reuses the origin's existing WebDAV serving stack rather than adding a parallel one.

Full design, including the reasoning behind each decision, is in `docs/pstore-design.md`.

## What an operator gets

Relative to a POSIX origin: encryption at rest for data and metadata keyed off the origin's issuer keys; atomic overwrite with no `Origin.EnableAtomicUploads`, temp-upload directory, or same-filesystem rename constraint; O(1) `Want-Digest` responses from checksums computed at ingest; multi-disk spreading without LVM or RAID; and millions of small objects without the per-directory scaling behaviour of the underlying filesystem.

It deliberately does not evict — the store has a configured size and returns 507 when full — and objects are immutable, matching Pelican's lack of mid-file edits.

## The index

Entries are keyed `pd:<parent path>\x00<name>`, so a directory's direct children are one contiguous, name-ordered range. Listing a single directory is the dominant operation and becomes a sequential scan with no seeks; a subtree stays reachable as two contiguous ranges for capacity accounting and fsck. Object identity comes from a per-write generation (which is also the ETag) rather than the path, so renaming rewrites index keys and moves zero bytes — and a directory rename runs entirely inside one BadgerDB transaction, so it is atomic.

Two consequences that are easy to miss and are covered by tests:

- **Detached subtrees need explicit masking.** `RemoveAll` removes a subtree inline when it fits in one transaction, which covers nearly every real removal. A subtree too large for that is unlinked and handed to a janitor — but lookups here are path-derived point gets that never consult ancestors, which is exactly why listing is cheap, so a descendant's key outlives its parent. Rather than pay O(depth) ancestor checks on every lookup, detached roots are masked in memory and rebuilt from the queue at open. Reads inside a draining subtree see "not found"; a create returns a distinct retryable error rather than being silently lost to the drain.
- **Reader pinning is mandatory for plain overwrite**, not just for versioning: `refCountedFile` survives unlink, but deleting a live reader's metadata does not. The pin set lives in `local_cache` next to `NewObjectReader` and `Delete`, and the cache's LRU eviction now respects it too.

## Operator-facing subsystems

An origin cannot re-fetch what it loses, and everything here follows from that one asymmetry with the cache.

- **Metadata backup and restore** (`pstore/backup.go`, `pstore/backup_crypto.go`). The block files are named by hash and encrypted, and everything needed to interpret them lives in the catalog, so a store whose catalog is gone is a directory of unreadable bytes. BadgerDB can stream a consistent snapshot of it while the origin runs, so it is backed up on a timer (`Origin.PStoreMetadataBackupLocation`, `…Interval` default 6h, `…ToKeep`), written to a `.partial` name and renamed on success.

  **Keys form a three-level hierarchy, and any level opens an archive.** The origin's issuer keys derive a *backup key*, which is deterministic and therefore escrowable. Each archive draws a random salt, stores it in its own header, and derives its own *file key* from the backup key and that salt. The body is sealed under the file key; the backup key is embedded sealed to every current issuer key. So an archive opens with an issuer key, with the escrowed backup key, or with that one archive's own file key — and the last reveals nothing about any other archive, which is what makes it safe to hand out. The salt, the sealed backup key and every chunk are bound together as additional authenticated data, so nothing can be spliced between archives. `metadata-backup-key` given an archive prints that archive's key; with no argument it prints the escrowable one. Losing the issuer keys does not lose the archives, provided the backup key was escrowed.

  There is one container version and no unencrypted path: encryption is unconditional, and a file whose version this build does not read is refused by number rather than decoded. Every backup is complete — an incremental chain could not be restored, since `Restore` refuses a non-empty store, so the mode does not exist.
- **Scheduled integrity checks** (`pstore/integrity.go`). A cheap catalog-only index check (`Origin.PStoreIndexCheckInterval`, default 1h) and a rate-limited read-back verification of every object against its ingest checksums (`Origin.PStoreDataScanInterval`, default 24h; `Origin.PStoreDataScanRate`). Both intervals are a **minimum gap from the end of one pass to the start of the next**, not a fixed cadence — a scan of a large store can outlast its own interval, and a ticker would then verify continuously. A pass that overruns is logged at warn level. Both are non-destructive, enforced in code rather than by convention: the cache's checker *deletes* an object whose data no longer matches and re-fetches it, which is right for a cache and is the data loss for an origin.
- **Prometheus metrics** (`metrics/pstore.go`). Capacity (aggregate and per directory — the aggregate cannot be derived, since one unbounded directory makes the whole store unbounded), the timestamp of the last *successful* scheduled pass of each kind, reclamation backlog, write tier distribution, and fsck findings. The pstore data scan no longer reports under the cache's `pelican_cache_data_scan_*` series.
- **Recovery export** (`pstore/recover.go`, `pelican-server origin pstore export`). Writes a subtree out as plain files with no Pelican in the loop, continuing past objects it cannot read and reporting exactly what was lost. Note this needs more than the backup keys: those open the *catalog*, while reading the *data* also needs the block files and `masterkey.json`, which is sealed to the issuer keys directly.
- **Live introspection API** (`origin_serve/storage_api.go`, `cmd/origin_introspect.go`). The database holds an exclusive lock while the origin runs, so the offline CLI cannot look at a live store. Four admin-gated routes under `/api/v1.0/origin/storage/pstore` answer "what is in there right now"; the token is minted from the local issuer key, so no token file is normally needed.
- **Offline CLI** (`cmd/origin_pstore.go`): `ls`, `stat`, `du`, `fsck [--repair] [--deep]`, `digest`, `metadata-backup`, `metadata-restore`, `metadata-backup-key`, `export`.

## New backend interfaces and the status-mapping point

Small seams in `origin_serve` that any origin backend can adopt:

- **`SizeHintFs` / `OpenFileSized`** — `afero.Fs` has no context and no size argument, so a backend cannot see the `Content-Length` the handler already has. pstore picks its storage tier *and its streaming chunk size* from the declared size instead of buffering to discover it; the hint is advisory and `-1` (chunked encoding) simply falls back to a default chunk size, which reserves more.
- **`ConditionalWriteFs` / `OpenFileConditional`** — evaluating `If-Match` / `If-None-Match` before the write begins is a stat-then-write race. A backend that can re-check the condition inside its commit transaction closes it; pstore does, in the same transaction that installs the dirent.
- **`localRootProvider` / `LocalStorageRoot`** — backends now **opt in** to having their `StoragePrefix` resolved against the host filesystem. See the disclosure bug below; previously every backend was assumed to be POSIX-shaped.
- **`statusForBackendError`** — the single place a backend sentinel becomes a status: `ENOSPC`/`EDQUOT` → 507, `ErrPreconditionFailed` → 412, `ErrDraining`/`ErrConflict` → 409, `ErrPermission` → 403. The two 409s share a meaning — *retry shortly* — which beats the 500 an opaque index-transaction error used to produce.

## Bugs found in existing code

Several of these are independent of pstore and worth reviewing on their own:

- **`local_cache.normalizeURL` case-folded object paths.** `/ns/Data.txt` and `/ns/data.txt` collapsed onto one cache entry, and the read path does not compare `SourceURL` before serving, so a request for one silently returned the other's bytes with a 200. Where two case-variant paths fall under different authorization rules, that is a bypass as well as wrong data. Now only scheme and host are folded, per RFC 3986.
- **`StorageManager.Close` hung on a read-only manager.** `ttlcache.Stop()` is an unbuffered send its `Start` loop receives, and `NewStorageManagerReadOnly` never spawns those loops, so `pelican cache introspect` hung on exit. This branch carried its own fix, but `main` has since fixed the same bug more thoroughly (an atomic CAS that also makes `Close` repeatable); the rebase drops this branch's version in favour of `main`'s, and the redundant flag with it.
- **`ENOSPC` was not mapped to 507.** `MapToHTTPStatus` handled `EDQUOT` but not `ENOSPC`, so the canonical out-of-space error surfaced as a 500 for every backend.
- **`If-Match` / `If-None-Match` were silently ignored on PUT.** `golang.org/x/net/webdav` does not implement them (there is a TODO in its `handlePut`), so a client asking for compare-and-swap got last-writer-wins while believing it was protected. Now honoured for all backends.
- **The native-origin data URL used a hand-maintained storage-type list.** pstore advertised a `DataURL` with no route behind it, and the director redirected into a 307 loop. Replaced with `!UsesXRootD()`, the condition it was spelling out.
- **`IsPosixLike()` replaced by `SupportsSelfTest()`.** Both its call sites were the same check — can this backend accept the write-read probe. Its doc comment also claimed to cover atomic uploads and xattr checksums; neither had a call site.
- **LRU eviction could delete an object out from under a live reader.** Now spared and reported as `skippedInUse`, and a pass that frees nothing stops instead of looping until its timeout.
- **Host-filesystem fast paths resolved every backend's `StoragePrefix` with `os.OpenRoot`.** An export's `StoragePrefix` means whatever its backend says it means — a host path for POSIX, a logical namespace path for pstore, a remote subtree for S3/HTTPS/Globus. For a single-export pstore origin the natural prefix is `/`, and `os.OpenRoot("/")` succeeds: a browser GET returned an HTML index of the **origin host's root directory**, and ETag/Last-Modified became an existence-and-mtime oracle for host files. The PUT path was worse, running checksum invalidation — which opens `O_RDWR` and strips xattrs — against unrelated local files. Backends now opt in via `localRootProvider`.

- **Offline cache introspection could not work anywhere.** `OpenCacheDBReadOnly` used BadgerDB's read-only mode, which aborts the *process* — `log.Fatal`, not an error return — when the database is encrypted and holds any SST file, which is every cache that has been used; and read-only mode is unsupported on Windows outright. The path had no test at all. It now opens normally and refuses mutation in Go, the trade `pstore.OpenMaintenance` already makes, so the guarantee that inspecting a database does not change it is enforced by Pelican rather than by BadgerDB.
- **Auto-minted admin tokens were rejected on some hosts.** `fetchOrGenerateWebAPIAdminToken` minted with `GetServerIssuerURL()` while every verifier pins `GetLocalIssuerUrl()`. The two disagree when `Server.IssuerUrl` is set at all, and again when the origin and director are co-located. Affected six commands. The CLI now reproduces the verifier's rule; the one case it cannot resolve from configuration is reported with both issuers named rather than as a bare 401.

## `local_cache` upgrade notes

Most of the `local_cache` change is additive (`AppendWriter`, the pin set, `CacheDB.DB()`, `EnsureStoreMode`, `ReloadSalt`, `SetChooseDir`, `ParseStorageDirsValue`, `checksum_format.go`, and a `_schema` version marker), but a few things are not:

- **Object hashing changed.** `normalizeURL` no longer case-folds the path, so `/ns/Data.txt` and `/ns/data.txt` stop collapsing onto one entry; and the host is now folded with IDNA rather than `strings.ToLower`, so the Unicode and punycode spellings of an internationalized name reach the same hash. The cache V2 block store has never shipped, so there is nothing deployed holding objects under the old derivation.
- **The block store now records a schema version.** `_mode` says who owns a database; `_schema` says what layout it uses. It is stamped at creation and checked at open, and a database written by a newer build is refused with both versions named. An unmarked database predates versioning and is adopted, so a deployed cache keeps starting.
- **`StorageManager.EvictByLRU` gained a skip predicate and a fourth return value**, and `EvictionManager.evictFromNamespace` changed signature to carry the spared count. Behaviorally the cache now declines to evict an object under a live reader; there is nothing for an operator to do.
- **Eviction stopped repeating a metadata read.** The purge-first drain and the cross-directory chunk scan each decoded an object's metadata and then called a delete that decoded the same record again in the same transaction. Also, the `e:` cleanup compared a raw stored value against a timestamp-prefixed encoding and so never matched, leaving an ETag pointer behind for every object the cache ever evicted.

## Testing

pstore has ~150 unit tests, clean under `-race` and `-count=2`, plus an end-to-end federation test driving upload, download, a 10 MB object past the spill threshold, overwrite, stat, list, and delete through the Pelican client. That fed test earned its keep: it found four bugs the unit tests structurally could not, each living in a seam between components (the DataURL loop above, `Stat` on an open write handle being turned into a 405 by the WebDAV handler, hex-encoded digests failing the client's base64 comparison, and nothing ever closing the store — which hung origin shutdown).

Concurrency is covered directly rather than by inspection: sixteen in-flight writers against a bounded store checking the reservation accounting never crosses the ceiling and never leaks (`TestConcurrentWritesStayWithinTheCeiling`), two thousand opens against a live overwriter with the janitor running — the pin/GC race (`TestConcurrentOverwriteAndOpenNeverFailsSpuriously`), eight writers racing for one path with exactly one winner (`TestConcurrentWritesToOnePathElectOneWinner`), and the same election through the WebDAV handler (`TestConcurrentConditionalWritesElectOneWinner`, `TestConcurrentCreateOnlyPutsElectOneWinner`).

`local_cache` gains coverage for the streaming append writer, reader pinning and the eviction skip, and the case-sensitivity fix. `origin_serve` gains `pstore_serving_test.go` and `storage_api_authz_test.go`, driving pstore through the real serving and authorization stack, plus conditional-write parsing.

The CLI was verified against a real store rather than only compiled; reported md5 and sha1 match the system tools.

## Known limitations

Worth knowing before a recovery rather than during one:

- **A failed metadata restore cannot be unwound.** BadgerDB's loader writes as it reads, so a snapshot that turns out to be damaged part-way through leaves records behind *and* leaves the transaction watermark short of the timestamps already written — the handle blocks on the next read and the directory holds a fragment of a namespace. Nothing in pstore can undo either. The error says so explicitly: the directory must be **discarded** and the restore started again into a fresh one, never retried into the same one. Both container formats verify eagerly precisely so that most damage is caught before a single record is written.
- **`If-Match: *` and multi-tag entity-tag lists are best-effort.** They assert existence and membership respectively, neither of which a compare-and-swap on a single dirent can express, so they are enforced only by the pre-write check and are not atomic against a concurrent writer. Single-tag `If-Match` and `If-None-Match: *` — the two forms real clients send — are fully atomic at commit.
- **A chunked-encoding PUT that runs out of space still surfaces as 405**, and reserves more than a same-sized declared-length write, because the chunk size cannot be derived from an unknown length. Sending `Content-Length` avoids both.
- **A directory rename above 50,000 descendants is refused** (typed `ErrNotSupported`, checked before anything is written) rather than being split into non-atomic pieces. The Pelican client never issues `MOVE`.

## Deferred, and recorded in the design

- **Path-based quotas** (§7.2) — depends on the LotMan-into-`local_cache` work plus a lot-bootstrapping design that does not exist yet. Write-time enforcement is the recorded intent; the index already supports it.
- **Chunked-encoding PUT still surfaces as 405 when out of space** (§7.1) — the pre-flight capacity check needs a declared `Content-Length`. Fixing it generally means changing write-error reporting for every backend.
- **A `local_cache` schema version** (§15) — see the upgrade notes above.
- **Running the origin's `directory_listing_test.go` and `path_traversal_test.go` suites against pstore** (§14) — pstore has its own path-constraint tests and now has dedicated `origin_serve` serving and authz suites, so this is redundancy not yet taken rather than a coverage gap.
- **Verifying `SourceURL` on the cache's hot read path** — what would have made the case-folding bug visible rather than silent, but it needs a normalize-and-compare per hit and risks spurious misses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

