### PR TITLE
Harden CI: least-privilege GITHUB_TOKEN and SHA-pinned actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+---
+# Keep the SHA-pinned actions in .github/workflows/ from going stale.
+# Dependabot rewrites both the SHA and its trailing version comment.
+
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      # Withhold a version update until the release has been on the
+      # registry for this many days, which buys time for a malicious
+      # release to be noticed. Security updates are exempt.
+      default-days: 7

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -76,6 +76,12 @@ jobs:
     steps:
       - name: Determine how to build and push container images
         id: params
+        env:
+          # This step needs to know only whether the credentials exist.
+          # Pass them through the environment rather than interpolating
+          # them into the script.
+          HARBOR_ROBOT_USER: ${{ secrets.PELICAN_HARBOR_ROBOT_USER }}
+          HARBOR_ROBOT_PASSWORD: ${{ secrets.PELICAN_HARBOR_ROBOT_PASSWORD }}
         run: |
           set -eu
 
@@ -104,8 +110,8 @@ jobs:
           PUSH_DEVTEST=false
           PUSH_RELEASE=false
 
-          if [ -n '${{ secrets.PELICAN_HARBOR_ROBOT_USER }}' ] \
-             && [ -n '${{ secrets.PELICAN_HARBOR_ROBOT_PASSWORD }}' ]
+          if [ -n "${HARBOR_ROBOT_USER:-}" ] \
+             && [ -n "${HARBOR_ROBOT_PASSWORD:-}" ]
           then
             if ${IS_PRIMARY_GITHUB_REPO}; then
               # For the PelicanPlatform/pelican repo, we push test and

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,6 +36,9 @@ defaults:
     # bash-isms have a way of sneaking in unnoticed.
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
 
   # This first job determines the work to be done:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -172,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Set timestamp
         id: timestamp
@@ -258,7 +258,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Set up metadata
         id: meta
@@ -293,13 +293,13 @@ jobs:
       # The new attempt will automatically use its own, fresh caches.
 
       - name: Create a cache for Docker Buildx
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
         with:
           path: ${{ runner.temp }}/.base-buildx-cache
           key: base-buildx-${{ matrix.id }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Create a cache for the GitHub workspace
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
         with:
           path: ${{ github.workspace }}
           key: github-workspace-${{ matrix.id }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -382,14 +382,14 @@ jobs:
             type=raw,enable=${{ needs.tags.outputs.IS_LATEST }},latest-${{ matrix.arch }}
 
       - name: Restore the cache for Docker Buildx
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
         with:
           path: ${{ runner.temp }}/.base-buildx-cache
           key: base-buildx-${{ matrix.id }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           fail-on-cache-miss: true  # don't let cache-image-layers be for naught
 
       - name: Restore the cache for the GitHub workspace
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
         with:
           path: ${{ github.workspace }}
           key: github-workspace-${{ matrix.id }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -434,7 +434,7 @@ jobs:
 
       - name: Upload digest
         if: ${{ contains(fromJson(needs.params.outputs.images-to-push), matrix.image) }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: digests-${{ matrix.image }}-${{ matrix.id }}
           path: ${{ runner.temp }}/digests/*
@@ -473,7 +473,7 @@ jobs:
           password: ${{ secrets.PELICAN_HARBOR_ROBOT_PASSWORD }}
 
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: digests-${{ matrix.image }}-*
           merge-multiple: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -262,7 +262,7 @@ jobs:
 
       - name: Set up metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
@@ -305,13 +305,13 @@ jobs:
           key: github-workspace-${{ matrix.id }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
         with:
           buildkitd-flags: --debug
 
       - name: Log in to OSG Harbor
         if: ${{ contains(fromJson(needs.params.outputs.images-to-push), 'origin') }}
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         with:
           registry: hub.opensciencegrid.org
           username: ${{ secrets.PELICAN_HARBOR_ROBOT_USER }}
@@ -326,7 +326,7 @@ jobs:
       # these layers multiple times over.
 
       - name: Build and push origin
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           file: ./images/Dockerfile
           target: origin
@@ -372,7 +372,7 @@ jobs:
     steps:
       - name: Set up metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
@@ -396,13 +396,13 @@ jobs:
           fail-on-cache-miss: true  # don't let cache-image-layers be for naught
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
         with:
           buildkitd-flags: --debug
 
       - name: Log in to OSG Harbor
         if: ${{ contains(fromJson(needs.params.outputs.images-to-push), matrix.image) }}
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         with:
           registry: hub.opensciencegrid.org
           username: ${{ secrets.PELICAN_HARBOR_ROBOT_USER }}
@@ -410,7 +410,7 @@ jobs:
 
       - name: Build and push image
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           file: ./images/Dockerfile
           target: ${{ matrix.image }}
@@ -456,7 +456,7 @@ jobs:
     steps:
       - name: Set up metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
@@ -466,7 +466,7 @@ jobs:
             type=raw,enable=${{ needs.tags.outputs.IS_LATEST }},latest
 
       - name: Log in to OSG Harbor
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         with:
           registry: hub.opensciencegrid.org
           username: ${{ secrets.PELICAN_HARBOR_ROBOT_USER }}

--- a/.github/workflows/check-go-generate.yml
+++ b/.github/workflows/check-go-generate.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-go-generate:
     name: Check Go Generate

--- a/.github/workflows/check-go-generate.yml
+++ b/.github/workflows/check-go-generate.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Set Go version
         # Determine the string to use in setup-go's "go-version" input.
@@ -28,7 +28,7 @@ jobs:
           echo "version=${version}.x" >> $GITHUB_OUTPUT
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version: "${{ steps.go-version.outputs.version }}"
           check-latest: true

--- a/.github/workflows/check-large-objects.yml
+++ b/.github/workflows/check-large-objects.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/check-large-objects.yml
+++ b/.github/workflows/check-large-objects.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   check-large-objects:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-rebase-on-main.yml
+++ b/.github/workflows/check-rebase-on-main.yml
@@ -8,6 +8,9 @@ on:
     branches-ignore:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check-rebase:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-rebase-on-main.yml
+++ b/.github/workflows/check-rebase-on-main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
         with:
           fetch-depth: 0  # Fetch all history to check ancestry
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,18 +40,18 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
       with:
         languages: ${{ matrix.language }}
 
     # Autobuild attempts to build any compiled languages.
     # If this step fails, then you should remove it and run the build manually (see below).
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -65,4 +65,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,9 @@ on:
   schedule:
     - cron: "36 11 * * 6"  # 11:36 on Saturday
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/coverage-scheduled.yml
+++ b/.github/workflows/coverage-scheduled.yml
@@ -36,7 +36,7 @@ jobs:
             tags: server
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       # actions/setup-node downloads its own Node.js binary, which (as of
       # Node 24) dynamically links libatomic.so.1. The AlmaLinux-based container
@@ -46,7 +46,7 @@ jobs:
         run: dnf install -y libatomic
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
         with:
           node-version-file: "web_ui/frontend/package.json"
           cache: "npm"
@@ -60,7 +60,7 @@ jobs:
           echo "version=${version}.x" >> $GITHUB_OUTPUT
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version: "${{ steps.go-version.outputs.version }}"
           check-latest: true
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload coverage function report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-func-${{ matrix.binary_name }}
           path: coverage-func-${{ matrix.binary_name }}.txt
@@ -114,7 +114,7 @@ jobs:
       actions: read  # "gh run download" reads the Actions API
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Download coverage reports
         env:
@@ -132,7 +132,7 @@ jobs:
             coverage.json
 
       - name: Upload coverage JSON
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: code-coverage-json
           path: coverage.json

--- a/.github/workflows/coverage-scheduled.yml
+++ b/.github/workflows/coverage-scheduled.yml
@@ -15,6 +15,9 @@ on:
     - cron: "0 6 * * *"  # at 06:00 every day
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   collect:
     name: Collect coverage (${{ matrix.binary_name }})
@@ -106,6 +109,9 @@ jobs:
     if: ${{ !cancelled() }}
     needs: [collect]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read  # "gh run download" reads the Actions API
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/enforce-PR-labelling.yml
+++ b/.github/workflows/enforce-PR-labelling.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read  # the job queries closingIssuesReferences
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Validate PR has labels
         id: check_labels

--- a/.github/workflows/enforce-PR-labelling.yml
+++ b/.github/workflows/enforce-PR-labelling.yml
@@ -6,9 +6,15 @@ on:
     types: [opened, edited, labeled, unlabeled, synchronize]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate-pr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read  # the job queries closingIssuesReferences
     steps:
       - name: Check out the repository
         uses: actions/checkout@v6

--- a/.github/workflows/enforce-issue-labelling.yml
+++ b/.github/workflows/enforce-issue-labelling.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Validate that the closed issue still has at least one label
         id: check_labels

--- a/.github/workflows/enforce-issue-labelling.yml
+++ b/.github/workflows/enforce-issue-labelling.yml
@@ -4,8 +4,15 @@ on:
   issues:
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   validate-issue:
+    permissions:
+      contents: read
+      issues: write  # the job reopens an unlabelled issue
+
     # 1. Don’t even start the job when the stale-bot did the closing **or**
     #    when the issue already bears the `stale` label.
     if: |

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -7,6 +7,8 @@ on:
     types: [published]
   workflow_call:
 
+permissions: {}
+
 jobs:
   update-website:
     name: Update pelicanplatform.org

--- a/.github/workflows/pre-commit-linter.yml
+++ b/.github/workflows/pre-commit-linter.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Set Go version
         # Determine the string to use in setup-go's "go-version" input.
@@ -28,14 +28,14 @@ jobs:
           echo "version=${version}.x" >> $GITHUB_OUTPUT
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version: "${{ steps.go-version.outputs.version }}"
           check-latest: true
           cache: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.14"
 
@@ -56,10 +56,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
         with:
           node-version-file: "web_ui/frontend/package.json"
           cache: "npm"

--- a/.github/workflows/pre-commit-linter.yml
+++ b/.github/workflows/pre-commit-linter.yml
@@ -43,13 +43,13 @@ jobs:
       # because pre-commit (below) isn't configured to run them within the
       # CI actions.
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a  # v9.3.0
         with:
           version: v2.9.0
           args: --config=.golangci.yaml
 
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
 
   web-linter:
     name: Web

--- a/.github/workflows/pre-commit-linter.yml
+++ b/.github/workflows/pre-commit-linter.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   go-linter:
     name: Go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
         with:
           fetch-depth: 0  # GoReleaser needs history to look up the previous tag, and so on
           ref: ${{ github.ref_name }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
         with:
           node-version-file: "web_ui/frontend/package.json"
           cache: "npm"
@@ -46,7 +46,7 @@ jobs:
           echo "version=${version}.x" >> $GITHUB_OUTPUT
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version: "${{ steps.go-version.outputs.version }}"
           check-latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,20 +14,19 @@ permissions:
   contents: read
 
 jobs:
-  goreleaser:
-    name: GoReleaser
+  web-build:
+    name: Build Web UI
     if: ${{ github.repository == 'PelicanPlatform/pelican' }}
     runs-on: ubuntu-latest
-    # Confined to this job: GoReleaser publishes the release artifacts.
-    # Notably, its "before" hook runs "make web-build" (npm ci) on the
-    # runner, so keep the write scope off every other job.
+    # This job exists so that "npm ci" never runs on a runner that holds a
+    # write-scoped token. It is GoReleaser's "before" hook, hoisted out of
+    # the release job, which consumes the result as an artifact.
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
         with:
-          fetch-depth: 0  # GoReleaser needs history to look up the previous tag, and so on
           ref: ${{ github.ref_name }}
 
       - name: Set up Node.js
@@ -37,6 +36,19 @@ jobs:
           cache: "npm"
           cache-dependency-path: "web_ui/frontend/package-lock.json"
           check-latest: true
+
+      - name: Cache Next.js
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
+        with:
+          # Reference: https://nextjs.org/docs/pages/guides/ci-build-caching#github-actions
+          path: |
+            ~/.npm
+            ${{ github.workspace }}/web_ui/frontend/.next/cache
+          # Generate a new cache whenever packages or source files change.
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('web_ui/frontend/package-lock.json') }}-${{ hashFiles('web_ui/frontend/**/*.js', 'web_ui/frontend/**/*.jsx', 'web_ui/frontend/**/*.ts', 'web_ui/frontend/**/*.tsx', '!web_ui/frontend/**/node_modules/**') }}
+          # If source files changed but packages didn't, rebuild from a prior cache.
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('web_ui/frontend/package-lock.json') }}-
 
       - name: Set Go version
         # Determine the string to use in setup-go's "go-version" input.
@@ -51,6 +63,57 @@ jobs:
           go-version: "${{ steps.go-version.outputs.version }}"
           check-latest: true
 
+      - name: Build the web UI
+        run: |
+          make web-build
+
+      - name: Upload the web UI assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: web-ui
+          path: web_ui/frontend/out
+          include-hidden-files: true
+          overwrite: true  # allow the workflow to be re-run
+          retention-days: 1
+          if-no-files-found: error
+
+  goreleaser:
+    name: GoReleaser
+    needs: web-build
+    if: ${{ github.repository == 'PelicanPlatform/pelican' }}
+    runs-on: ubuntu-latest
+    # Nothing here runs npm, and "--skip=before" keeps GoReleaser from
+    # running the hooks that would.
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
+        with:
+          fetch-depth: 0  # GoReleaser needs history to look up the previous tag, and so on
+          ref: ${{ github.ref_name }}
+          # Do not leave the write-scoped token in .git/config.
+          persist-credentials: false
+
+      - name: Set Go version
+        # Determine the string to use in setup-go's "go-version" input.
+        id: go-version
+        run: |
+          version=$(grep -E '^go[[:space:]]*[0-9]+\.[0-9]+' go.mod | grep -oE '[0-9]+\.[0-9]+')
+          echo "version=${version}.x" >> $GITHUB_OUTPUT
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+        with:
+          go-version: "${{ steps.go-version.outputs.version }}"
+          check-latest: true
+
+      - name: Download the web UI assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: web-ui
+          path: web_ui/frontend/out
+
       - name: Generate GoReleaser config
         run: |
           make goreleaser-config
@@ -60,7 +123,9 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean --config .goreleaser.generated.yml
+          # The web-build job either ran the "before" hook or else their
+          # outputs are already committed.
+          args: release --clean --skip=before --config .goreleaser.generated.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           make goreleaser-config
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7.2.3
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,18 @@ on:
       - "v[1-9][0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   goreleaser:
     name: GoReleaser
     if: ${{ github.repository == 'PelicanPlatform/pelican' }}
     runs-on: ubuntu-latest
+    # Confined to this job: GoReleaser publishes the release artifacts.
+    # Notably, its "before" hook runs "make web-build" (npm ci) on the
+    # runner, so keep the write scope off every other job.
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9.1.0
         with:
           days-before-issue-stale: 60
           days-before-issue-close: 30

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: "00 00 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-linux-pr.yml
+++ b/.github/workflows/test-linux-pr.yml
@@ -13,6 +13,9 @@ on:
       - dispatch-build
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     name: Test

--- a/.github/workflows/test-linux-scheduled.yml
+++ b/.github/workflows/test-linux-scheduled.yml
@@ -33,7 +33,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Download artifacts
         env:

--- a/.github/workflows/test-linux-scheduled.yml
+++ b/.github/workflows/test-linux-scheduled.yml
@@ -10,6 +10,9 @@ on:
     - cron: "0 7 * * *"  # at 07:00 every day
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     name: Test
@@ -23,6 +26,11 @@ jobs:
     if: ${{ !cancelled() }}
     needs: [run-tests]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # download_junit_artifacts.sh runs "gh run list" and "gh run download"
+      # over the previous runs of this workflow.
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -42,7 +42,7 @@ jobs:
             tags: server
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
         with:
           fetch-depth: 0  # GoReleaser needs history to look up the previous tag, and so on
 
@@ -54,7 +54,7 @@ jobs:
         run: dnf install -y libatomic
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
         with:
           node-version-file: "web_ui/frontend/package.json"
           cache: "npm"
@@ -62,7 +62,7 @@ jobs:
           check-latest: true
 
       - name: Cache Next.js
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
         with:
           # Reference: https://nextjs.org/docs/pages/guides/ci-build-caching#github-actions
           path: |
@@ -82,7 +82,7 @@ jobs:
           echo "version=${version}.x" >> $GITHUB_OUTPUT
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version: "${{ steps.go-version.outputs.version }}"
           check-latest: true
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload JUnit report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: junit-${{ matrix.binary_name }}-${{ runner.os }}
           path: junit-${{ matrix.binary_name }}.xml

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Publish JUnit summary
         if: always()
-        uses: test-summary/action@v2
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:
           paths: junit-${{ matrix.binary_name }}.xml
 
@@ -156,7 +156,7 @@ jobs:
           make goreleaser-config
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7.2.3
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -21,6 +21,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     name: Linux (${{ matrix.binary_name }})

--- a/.github/workflows/test-macos-scheduled.yml
+++ b/.github/workflows/test-macos-scheduled.yml
@@ -6,6 +6,9 @@ on:
     - cron: "0 7 * * *"  # at 07:00 every day
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     name: Test
@@ -18,6 +21,11 @@ jobs:
     if: ${{ !cancelled() }}
     needs: [run-tests]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # download_junit_artifacts.sh runs "gh run list" and "gh run download"
+      # over the previous runs of this workflow.
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/test-macos-scheduled.yml
+++ b/.github/workflows/test-macos-scheduled.yml
@@ -28,7 +28,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Download artifacts
         env:

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Publish JUnit summary
         if: always()
-        uses: test-summary/action@v2
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:
           paths: junit-${{ matrix.binary_name }}.xml
 
@@ -131,7 +131,7 @@ jobs:
           make goreleaser-config
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7.2.3
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -23,6 +23,9 @@ on:
         default: false
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     name: macOS (${{ matrix.binary_name }})

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -42,12 +42,12 @@ jobs:
             tags: server
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
         with:
           fetch-depth: 0  # GoReleaser needs history to look up the previous tag, and so on
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
         with:
           node-version-file: "web_ui/frontend/package.json"
           cache: "npm"
@@ -55,7 +55,7 @@ jobs:
           check-latest: true
 
       - name: Cache Next.js
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
         with:
           # Reference: https://nextjs.org/docs/pages/guides/ci-build-caching#github-actions
           path: |
@@ -75,7 +75,7 @@ jobs:
           echo "version=${version}.x" >> $GITHUB_OUTPUT
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version: "${{ steps.go-version.outputs.version }}"
           check-latest: true
@@ -114,7 +114,7 @@ jobs:
 
       - name: Upload JUnit report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: junit-${{ matrix.binary_name }}-${{ runner.os }}
           path: junit-${{ matrix.binary_name }}.xml

--- a/.github/workflows/test-webui-e2e.yml
+++ b/.github/workflows/test-webui-e2e.yml
@@ -16,6 +16,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
 
   # ── Build ────────────────────────────────────────────────────────────────────

--- a/.github/workflows/test-webui-e2e.yml
+++ b/.github/workflows/test-webui-e2e.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
         with:
           fetch-depth: 0  # GoReleaser needs tag history
 
@@ -43,14 +43,14 @@ jobs:
         run: dnf install -y libatomic
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
         with:
           node-version-file: "web_ui/frontend/package.json"
           cache: "npm"
           cache-dependency-path: "web_ui/frontend/package-lock.json"
 
       - name: Cache Next.js build output
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
         with:
           # Reference: https://nextjs.org/docs/pages/guides/ci-build-caching#github-actions
           path: |
@@ -77,7 +77,7 @@ jobs:
           cp dist/pelican_linux_amd64_v1/pelican /tmp/pelican-binaries/pelican
           cp dist/pelican-server_linux_amd64_v1/pelican-server /tmp/pelican-binaries/pelican-server
       - name: Upload Pelican binaries
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: pelican-binaries
           path: /tmp/pelican-binaries/
@@ -119,7 +119,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       # actions/setup-node downloads its own Node.js binary, which (as of
       # Node 24) dynamically links libatomic.so.1. The pelican-dev image may
@@ -129,14 +129,14 @@ jobs:
         run: dnf install -y libatomic
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
         with:
           node-version-file: "web_ui/frontend/package.json"
           cache: "npm"
           cache-dependency-path: "web_ui/frontend/package-lock.json"
 
       - name: Download Pelican binaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: pelican-binaries
           path: /tmp/pelican-binaries
@@ -306,7 +306,7 @@ jobs:
           npx playwright test --project=${{ matrix.service }}
       - name: Upload Playwright HTML report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: playwright-report-${{ matrix.service }}
           path: web_ui/frontend/playwright-report/
@@ -314,7 +314,7 @@ jobs:
 
       - name: Upload Playwright raw artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: playwright-test-results-${{ matrix.service }}
           path: web_ui/frontend/test-results/
@@ -322,7 +322,7 @@ jobs:
 
       - name: Upload Pelican server logs on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: pelican-server-state-${{ matrix.service }}
           path: |

--- a/.github/workflows/test-windows-scheduled.yml
+++ b/.github/workflows/test-windows-scheduled.yml
@@ -6,6 +6,9 @@ on:
     - cron: "0 7 * * *"  # at 07:00 every day
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     name: Test
@@ -18,6 +21,11 @@ jobs:
     if: ${{ !cancelled() }}
     needs: [run-tests]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # download_junit_artifacts.sh runs "gh run list" and "gh run download"
+      # over the previous runs of this workflow.
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/test-windows-scheduled.yml
+++ b/.github/workflows/test-windows-scheduled.yml
@@ -28,7 +28,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Download artifacts
         env:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -23,6 +23,9 @@ on:
         default: false
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     name: Windows (${{ matrix.binary_name }})

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -39,7 +39,7 @@ jobs:
             tags: client
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
         with:
           fetch-depth: 0  # GoReleaser needs history to look up the previous tag, and so on
 
@@ -56,7 +56,7 @@ jobs:
           echo "version=${version}.x" >> $GITHUB_OUTPUT
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version: "${{ steps.go-version.outputs.version }}"
           check-latest: true
@@ -96,7 +96,7 @@ jobs:
 
       - name: Upload JUnit report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: junit-${{ matrix.binary_name }}-${{ runner.os }}
           path: junit-${{ matrix.binary_name }}.xml

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Publish JUnit summary
         if: always()
-        uses: test-summary/action@v2
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:
           paths: junit-${{ matrix.binary_name }}.xml
 
@@ -116,7 +116,7 @@ jobs:
         run: ./scripts/generate_goreleaser.sh .goreleaser.in.yml .goreleaser.generated.yml
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7.2.3
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/validate-parameters.yml
+++ b/.github/workflows/validate-parameters.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate

--- a/.github/workflows/validate-parameters.yml
+++ b/.github/workflows/validate-parameters.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6.1.0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.14"
           cache: "pip"


### PR DESCRIPTION
Closes #3601.

## Summary

Implements pretty much what the linked issue asks for.

## Out of scope

Tightening up how we pin the versions of anything outside of the GitHub Actions, and substantively revising how container image repository credentials are handled.