### PR TITLE
Make Claude Code for VS Code's transcript persistent

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,7 +37,7 @@
 			]
 		}
 	},
-	"postCreateCommand": "go install github.com/go-delve/delve/cmd/dlv@latest",
+	"postCreateCommand": "sudo chown -R $(id -u):$(id -g) $HOME/.claude && go install github.com/go-delve/delve/cmd/dlv@latest",
 	"remoteEnv": {
 		"GOPATH": "/home/vscode/go",
 		"PATH": "/usr/local/go/bin:/home/vscode/go/bin:${containerEnv:PATH}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -55,5 +55,6 @@
 		"ghcr.io/devcontainers/features/git:1": {
 			"version": "latest"
 		}
-	}
+	},
+	"mounts": [ "source=claude-code-config,target=/home/vscode/.claude,type=volume" ]
 }


### PR DESCRIPTION
Currently, if we rebuild the container image and start a new container, we will lose all Claude Code's transcript and login credentials, because they are stored in `/home/vscode/.claude`, which will be wiped out across image rebuild. We make `.claude` become a named volume managed by the docker. In this way, everything under `.claude` folder become persistent and can be shared among multiple containers.

Note: Transcripts are saved locally and not synced with the remote.