### PR TITLE
Make usernames a truly global authorization handle

### DIFF
--- a/database/collection.go
+++ b/database/collection.go
@@ -329,9 +329,9 @@ const (
 // for the correct first-login / return-visit flow.
 type User struct {
 	ID          string     `gorm:"primaryKey" json:"id"`
-	Username    string     `gorm:"not null;uniqueIndex:idx_user_issuer" json:"username"`
+	Username    string     `gorm:"not null;uniqueIndex:idx_user_username_live" json:"username"`
 	Sub         string     `gorm:"not null;uniqueIndex:idx_user_sub_issuer" json:"sub"`
-	Issuer      string     `gorm:"not null;uniqueIndex:idx_user_issuer;uniqueIndex:idx_user_sub_issuer" json:"issuer"`
+	Issuer      string     `gorm:"not null;uniqueIndex:idx_user_sub_issuer" json:"issuer"`
 	Status      UserStatus `gorm:"not null;default:active" json:"status"`
 	LastLoginAt *time.Time `json:"lastLoginAt"`
 	DisplayName string     `gorm:"not null;default:''" json:"displayName"`

--- a/database/collection.go
+++ b/database/collection.go
@@ -268,6 +268,14 @@ const (
 	UserStatusInactive UserStatus = "inactive"
 )
 
+// BuiltinAdminUsername is the reserved username of the built-in
+// administrator that the htpasswd / init-code bootstrap creates and
+// that CheckAdmin in the web layer keys its bypass off of. It is the
+// ONLY account eligible for issuer-blind adoption (see
+// adoptBuiltinAdminByUsername); every other username is strictly keyed
+// on (sub, issuer).
+const BuiltinAdminUsername = "admin"
+
 // User is the canonical user record. Four concepts live on this row and
 // they are intentionally distinct — code that conflates them is a bug.
 //
@@ -1688,12 +1696,30 @@ func GetOrCreateUser(db *gorm.DB, username string, sub string, issuer string, cr
 		return nil, err
 	}
 
+	// No (sub, issuer) linkage yet. For the built-in admin ONLY, the
+	// username may already have a live row that a sibling service
+	// created: several services sharing one server DB (the dev-container
+	// / e2e layout) each call this with their own ExternalWebUrl as
+	// issuer, and usernames are globally unique among live rows, so a
+	// second service must adopt the first's "admin" row instead of
+	// minting a per-issuer duplicate the unique index now forbids.
+	// Adoption is deliberately limited to "admin": for any other
+	// username we do NOT infer that two local-shaped rows are the same
+	// person, and the create below simply fails the collision (see
+	// adoptBuiltinAdminByUsername).
+	if adopted, ok, adoptErr := adoptBuiltinAdminByUsername(db, username, sub); adoptErr != nil {
+		return nil, adoptErr
+	} else if ok {
+		return adopted, nil
+	}
+
 	// User not found, create one.
 	created, createErr := CreateUser(db, username, sub, issuer, creator)
 	if createErr == nil {
 		return created, nil
 	}
-	// A concurrent request may have created the same (sub, issuer) user between
+	// A concurrent request may have created the same (sub, issuer) user
+	// (or, the built-in "admin" user under a sibling service's issuer) between
 	// our SELECT above and this INSERT, tripping a UNIQUE constraint. For a
 	// get-or-create that is not a failure: if the row now exists, return it so
 	// concurrent first-time authentications don't spuriously fail (a 500 on the
@@ -1702,7 +1728,50 @@ func GetOrCreateUser(db *gorm.DB, username string, sub string, issuer string, cr
 	if getErr := db.Where("sub = ? AND issuer = ?", sub, issuer).First(user).Error; getErr == nil {
 		return user, nil
 	}
+	if adopted, ok, adoptErr := adoptBuiltinAdminByUsername(db, username, sub); adoptErr == nil && ok {
+		return adopted, nil
+	}
 	return nil, createErr
+}
+
+// adoptBuiltinAdminByUsername implements GetOrCreateUser's cross-issuer
+// adoption rule, restricted to the single built-in admin account. It
+// returns the live user row holding `username` iff ALL of:
+//
+//   - the username is the reserved BuiltinAdminUsername,
+//   - the requested account is local-shaped (sub == username, i.e. the
+//     htpasswd / init-code bootstrap shape, no IdP linkage), and
+//   - the existing live row is likewise local-shaped.
+//
+// ok is false otherwise, so the caller falls through to CreateUser and
+// a genuine collision surfaces the username-uniqueness error. The two
+// local-shape guards mean a password login can never take over an
+// OIDC-linked account that merely shares the name "admin"; that case is
+// treated exactly like CreateLocalUser and fails.
+//
+// Only "admin" is adoptable because it is the one account Pelican itself
+// bootstraps under a per-service issuer and verifies against a single
+// shared htpasswd credential; for every other username we make no such
+// same-person inference across issuers.
+func adoptBuiltinAdminByUsername(db *gorm.DB, username, sub string) (*User, bool, error) {
+	if username != BuiltinAdminUsername {
+		return nil, false, nil
+	}
+	if sub != username {
+		return nil, false, nil
+	}
+	user := &User{}
+	err := db.Where("username = ?", username).First(user).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	if user.Sub != user.Username {
+		return nil, false, nil
+	}
+	return user, true, nil
 }
 
 func GetUserByID(db *gorm.DB, id string) (*User, error) {
@@ -1842,13 +1911,21 @@ func BootstrapAdminAndBackfillOwners(db *gorm.DB) error {
 		return nil
 	}
 
-	// 1. Ensure an admin user row exists. The admin "username" is
-	//    the literal string "admin"; CheckAdmin in the web layer keys
+	// 1. Ensure an admin user row exists. The admin "username" is the
+	//    reserved BuiltinAdminUsername; CheckAdmin in the web layer keys
 	//    its bypass off that username, and the htpasswd login path has
 	//    historically created the row with sub == username == "admin"
-	//    and issuer == externalURL — so we follow the same shape.
+	//    and issuer == externalURL, so we follow the same shape when
+	//    creating. The LOOKUP, however, is issuer-blind: username is
+	//    globally unique among live rows, and several services sharing
+	//    one server DB (the dev-container / e2e layout) each have their
+	//    own ExternalWebUrl, so a live "admin" bootstrapped by a sibling
+	//    service is the same built-in admin, and re-creating it
+	//    per-issuer would just trip the global unique index (surfaced as
+	//    "Post-migration bootstrap incomplete" at startup of every
+	//    service but the first).
 	var admin User
-	err := db.Where("username = ? AND issuer = ?", "admin", externalURL).First(&admin).Error
+	err := db.Where("username = ?", BuiltinAdminUsername).First(&admin).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		slug, slugErr := generateSlug()
 		if slugErr != nil {
@@ -1856,23 +1933,34 @@ func BootstrapAdminAndBackfillOwners(db *gorm.DB) error {
 		}
 		admin = User{
 			ID:        slug,
-			Username:  "admin",
-			Sub:       "admin",
+			Username:  BuiltinAdminUsername,
+			Sub:       BuiltinAdminUsername,
 			Issuer:    externalURL,
 			CreatedBy: CreatorSelfEnrolled,
 		}
 		if createErr := db.Create(&admin).Error; createErr != nil {
 			// A unique-constraint conflict here means another goroutine
-			// got there first; re-query and fall through.
+			// (or sibling service) got there first; re-query and fall
+			// through.
 			if !strings.Contains(createErr.Error(), "UNIQUE constraint failed") {
 				return createErr
 			}
-			if reErr := db.Where("username = ? AND issuer = ?", "admin", externalURL).First(&admin).Error; reErr != nil {
+			if reErr := db.Where("username = ?", BuiltinAdminUsername).First(&admin).Error; reErr != nil {
 				return reErr
 			}
 		}
 	} else if err != nil {
 		return err
+	} else if admin.Sub != admin.Username {
+		// A live "admin" row exists but is OIDC-linked (sub != username),
+		// not the local-shaped built-in admin. That can only happen if
+		// the built-in row was deleted and an IdP user later claimed the
+		// name. Do NOT backfill group ownership onto an IdP-backed
+		// account; surface the anomaly for the operator instead of
+		// silently treating it as the built-in admin.
+		return fmt.Errorf("username %q is held by an OIDC-linked account (sub=%q); "+
+			"the built-in admin row is absent, refusing to backfill ownership onto it",
+			BuiltinAdminUsername, admin.Sub)
 	}
 
 	// 2. Backfill ownerless groups onto the admin. Without this, the

--- a/database/collection.go
+++ b/database/collection.go
@@ -268,14 +268,6 @@ const (
 	UserStatusInactive UserStatus = "inactive"
 )
 
-// BuiltinAdminUsername is the reserved username of the built-in
-// administrator that the htpasswd / init-code bootstrap creates and
-// that CheckAdmin in the web layer keys its bypass off of. It is the
-// ONLY account eligible for issuer-blind adoption (see
-// adoptBuiltinAdminByUsername); every other username is strictly keyed
-// on (sub, issuer).
-const BuiltinAdminUsername = "admin"
-
 // User is the canonical user record. Four concepts live on this row and
 // they are intentionally distinct — code that conflates them is a bug.
 //
@@ -1696,30 +1688,12 @@ func GetOrCreateUser(db *gorm.DB, username string, sub string, issuer string, cr
 		return nil, err
 	}
 
-	// No (sub, issuer) linkage yet. For the built-in admin ONLY, the
-	// username may already have a live row that a sibling service
-	// created: several services sharing one server DB (the dev-container
-	// / e2e layout) each call this with their own ExternalWebUrl as
-	// issuer, and usernames are globally unique among live rows, so a
-	// second service must adopt the first's "admin" row instead of
-	// minting a per-issuer duplicate the unique index now forbids.
-	// Adoption is deliberately limited to "admin": for any other
-	// username we do NOT infer that two local-shaped rows are the same
-	// person, and the create below simply fails the collision (see
-	// adoptBuiltinAdminByUsername).
-	if adopted, ok, adoptErr := adoptBuiltinAdminByUsername(db, username, sub); adoptErr != nil {
-		return nil, adoptErr
-	} else if ok {
-		return adopted, nil
-	}
-
 	// User not found, create one.
 	created, createErr := CreateUser(db, username, sub, issuer, creator)
 	if createErr == nil {
 		return created, nil
 	}
-	// A concurrent request may have created the same (sub, issuer) user
-	// (or, the built-in "admin" user under a sibling service's issuer) between
+	// A concurrent request may have created the same (sub, issuer) user between
 	// our SELECT above and this INSERT, tripping a UNIQUE constraint. For a
 	// get-or-create that is not a failure: if the row now exists, return it so
 	// concurrent first-time authentications don't spuriously fail (a 500 on the
@@ -1728,50 +1702,7 @@ func GetOrCreateUser(db *gorm.DB, username string, sub string, issuer string, cr
 	if getErr := db.Where("sub = ? AND issuer = ?", sub, issuer).First(user).Error; getErr == nil {
 		return user, nil
 	}
-	if adopted, ok, adoptErr := adoptBuiltinAdminByUsername(db, username, sub); adoptErr == nil && ok {
-		return adopted, nil
-	}
 	return nil, createErr
-}
-
-// adoptBuiltinAdminByUsername implements GetOrCreateUser's cross-issuer
-// adoption rule, restricted to the single built-in admin account. It
-// returns the live user row holding `username` iff ALL of:
-//
-//   - the username is the reserved BuiltinAdminUsername,
-//   - the requested account is local-shaped (sub == username, i.e. the
-//     htpasswd / init-code bootstrap shape, no IdP linkage), and
-//   - the existing live row is likewise local-shaped.
-//
-// ok is false otherwise, so the caller falls through to CreateUser and
-// a genuine collision surfaces the username-uniqueness error. The two
-// local-shape guards mean a password login can never take over an
-// OIDC-linked account that merely shares the name "admin"; that case is
-// treated exactly like CreateLocalUser and fails.
-//
-// Only "admin" is adoptable because it is the one account Pelican itself
-// bootstraps under a per-service issuer and verifies against a single
-// shared htpasswd credential; for every other username we make no such
-// same-person inference across issuers.
-func adoptBuiltinAdminByUsername(db *gorm.DB, username, sub string) (*User, bool, error) {
-	if username != BuiltinAdminUsername {
-		return nil, false, nil
-	}
-	if sub != username {
-		return nil, false, nil
-	}
-	user := &User{}
-	err := db.Where("username = ?", username).First(user).Error
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, false, nil
-	}
-	if err != nil {
-		return nil, false, err
-	}
-	if user.Sub != user.Username {
-		return nil, false, nil
-	}
-	return user, true, nil
 }
 
 func GetUserByID(db *gorm.DB, id string) (*User, error) {
@@ -1911,21 +1842,13 @@ func BootstrapAdminAndBackfillOwners(db *gorm.DB) error {
 		return nil
 	}
 
-	// 1. Ensure an admin user row exists. The admin "username" is the
-	//    reserved BuiltinAdminUsername; CheckAdmin in the web layer keys
+	// 1. Ensure an admin user row exists. The admin "username" is
+	//    the literal string "admin"; CheckAdmin in the web layer keys
 	//    its bypass off that username, and the htpasswd login path has
 	//    historically created the row with sub == username == "admin"
-	//    and issuer == externalURL, so we follow the same shape when
-	//    creating. The LOOKUP, however, is issuer-blind: username is
-	//    globally unique among live rows, and several services sharing
-	//    one server DB (the dev-container / e2e layout) each have their
-	//    own ExternalWebUrl, so a live "admin" bootstrapped by a sibling
-	//    service is the same built-in admin, and re-creating it
-	//    per-issuer would just trip the global unique index (surfaced as
-	//    "Post-migration bootstrap incomplete" at startup of every
-	//    service but the first).
+	//    and issuer == externalURL — so we follow the same shape.
 	var admin User
-	err := db.Where("username = ?", BuiltinAdminUsername).First(&admin).Error
+	err := db.Where("username = ? AND issuer = ?", "admin", externalURL).First(&admin).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		slug, slugErr := generateSlug()
 		if slugErr != nil {
@@ -1933,34 +1856,23 @@ func BootstrapAdminAndBackfillOwners(db *gorm.DB) error {
 		}
 		admin = User{
 			ID:        slug,
-			Username:  BuiltinAdminUsername,
-			Sub:       BuiltinAdminUsername,
+			Username:  "admin",
+			Sub:       "admin",
 			Issuer:    externalURL,
 			CreatedBy: CreatorSelfEnrolled,
 		}
 		if createErr := db.Create(&admin).Error; createErr != nil {
 			// A unique-constraint conflict here means another goroutine
-			// (or sibling service) got there first; re-query and fall
-			// through.
+			// got there first; re-query and fall through.
 			if !strings.Contains(createErr.Error(), "UNIQUE constraint failed") {
 				return createErr
 			}
-			if reErr := db.Where("username = ?", BuiltinAdminUsername).First(&admin).Error; reErr != nil {
+			if reErr := db.Where("username = ? AND issuer = ?", "admin", externalURL).First(&admin).Error; reErr != nil {
 				return reErr
 			}
 		}
 	} else if err != nil {
 		return err
-	} else if admin.Sub != admin.Username {
-		// A live "admin" row exists but is OIDC-linked (sub != username),
-		// not the local-shaped built-in admin. That can only happen if
-		// the built-in row was deleted and an IdP user later claimed the
-		// name. Do NOT backfill group ownership onto an IdP-backed
-		// account; surface the anomaly for the operator instead of
-		// silently treating it as the built-in admin.
-		return fmt.Errorf("username %q is held by an OIDC-linked account (sub=%q); "+
-			"the built-in admin row is absent, refusing to backfill ownership onto it",
-			BuiltinAdminUsername, admin.Sub)
 	}
 
 	// 2. Backfill ownerless groups onto the admin. Without this, the

--- a/database/universal_migrations/20260812000000_global_unique_username.sql
+++ b/database/universal_migrations/20260812000000_global_unique_username.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Make username GLOBALLY unique among live rows, replacing the per-issuer
+-- UNIQUE(username, issuer).
+DROP INDEX IF EXISTS idx_user_issuer;
+CREATE UNIQUE INDEX idx_user_username_live
+    ON users (username)
+    WHERE deleted_at IS NULL;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- Restore the per-issuer partial unique index (state after 20260503120000).
+DROP INDEX IF EXISTS idx_user_username_live;
+CREATE UNIQUE INDEX idx_user_issuer
+    ON users (username, issuer)
+    WHERE deleted_at IS NULL;
+
+-- +goose StatementEnd

--- a/database/users_test.go
+++ b/database/users_test.go
@@ -104,6 +104,38 @@ func TestCreateLocalUserRejectsDuplicateUsername(t *testing.T) {
 	assert.Error(t, err, "second create with the same (username, issuer) must fail")
 }
 
+// Usernames are a GLOBAL authorization handle, not per-issuer: because
+// admin matching is issuer-blind (web_ui/scopes.go), a name must back at
+// most one live account across the whole server. Enforced by the partial
+// unique index idx_user_username_live (migration 20260812000000).
+func TestUsernameIsGloballyUniqueAcrossIssuers(t *testing.T) {
+	db := setupCollectionTestDB(t)
+
+	// An OIDC account claims "alice" under CILogon.
+	oidc, err := CreateUser(db, "alice", "cilogon-sub-123", "https://cilogon.org", adminCreator())
+	require.NoError(t, err)
+	require.Equal(t, "alice", oidc.Username)
+
+	// A local password account for "alice" (different issuer, different
+	// sub) must be refused — otherwise both collapse into one issuer-blind
+	// authz identity.
+	_, err = CreateLocalUser(db, "alice", "Alice Local", localIssuerForTests, adminCreator())
+	assert.Error(t, err, "local 'alice' must not coexist with OIDC 'alice'")
+
+	// An admin-created OIDC account under yet another issuer must also be
+	// refused.
+	_, err = CreateUser(db, "alice", "gh-sub-1", "https://github.com", adminCreator())
+	assert.Error(t, err, "cross-issuer duplicate username must be rejected")
+
+	// First-login bootstrap under a *different* issuer whose derived
+	// username also resolves to "alice" must disambiguate rather than
+	// create a second live "alice" (pre-fix this produced a duplicate).
+	u, err := LookupOrBootstrapUser(db, "gh-sub-2", "https://github.com", "Alice GH", []string{"alice"})
+	require.NoError(t, err)
+	assert.NotEqual(t, "alice", u.Username)
+	assert.True(t, strings.HasPrefix(u.Username, "alice-"), "expected disambiguated name, got %q", u.Username)
+}
+
 func TestCreateUserRejectsInvalidIdentifier(t *testing.T) {
 	db := setupCollectionTestDB(t)
 	for _, bad := range []string{"", "alice/admin", "alice..bob"} {

--- a/database/users_test.go
+++ b/database/users_test.go
@@ -29,9 +29,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
-
-	"github.com/pelicanplatform/pelican/config"
-	"github.com/pelicanplatform/pelican/param"
 )
 
 // The tests in this file cover the user/credential surface area:
@@ -137,81 +134,6 @@ func TestUsernameIsGloballyUniqueAcrossIssuers(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, "alice", u.Username)
 	assert.True(t, strings.HasPrefix(u.Username, "alice-"), "expected disambiguated name, got %q", u.Username)
-}
-
-// Several services sharing one server DB (the dev-container / e2e
-// layout) each bootstrap the built-in "admin" under their own
-// Server.ExternalWebUrl. Since usernames are globally unique, the
-// SECOND service must adopt the live local-shaped "admin" row (sub ==
-// username) a sibling created rather than mint a per-issuer duplicate.
-// Adoption is restricted to "admin": any other username collision
-// across issuers fails, and an OIDC-linked row is never adopted.
-func TestGetOrCreateUserAdoptsBuiltinAdminAcrossIssuers(t *testing.T) {
-	db := setupCollectionTestDB(t)
-
-	// The built-in admin is adopted across issuers (the shared-DB case).
-	first, err := GetOrCreateUser(db, "admin", "admin", "https://svc-a:8445", CreatorSelf())
-	require.NoError(t, err)
-	require.Equal(t, "admin", first.Username)
-
-	second, err := GetOrCreateUser(db, "admin", "admin", "https://svc-b:8446", CreatorSelf())
-	require.NoError(t, err)
-	assert.Equal(t, first.ID, second.ID, "sibling service must adopt the existing admin, not create a duplicate")
-	assert.Equal(t, "admin", second.Username)
-
-	// A NON-admin local account is NOT adopted across issuers: the second
-	// service's login must fail on the global unique index rather than
-	// silently link to the first service's row. We do not infer that two
-	// same-named local accounts are the same person.
-	_, err = GetOrCreateUser(db, "bob", "bob", "https://svc-a:8445", CreatorSelf())
-	require.NoError(t, err)
-	_, err = GetOrCreateUser(db, "bob", "bob", "https://svc-b:8446", CreatorSelf())
-	assert.Error(t, err, "non-admin local 'bob' must not be adopted across issuers")
-
-	// An OIDC-linked "admin" (sub != username) is never adopted by a
-	// password/init-code login that merely shares the name.
-	db2 := setupCollectionTestDB(t)
-	_, err = CreateUser(db2, "admin", "cilogon-sub-9", "https://cilogon.org", adminCreator())
-	require.NoError(t, err)
-	_, err = GetOrCreateUser(db2, "admin", "admin", "https://svc-b:8446", CreatorSelf())
-	assert.Error(t, err, "htpasswd 'admin' must not hijack an OIDC-linked 'admin'")
-}
-
-// The startup bootstrap must likewise be issuer-blind for the built-in
-// admin: a live "admin" created by a sibling service (different
-// ExternalWebUrl, same DB) IS the built-in admin, and re-creating it
-// per-issuer would trip the global unique username index (seen as
-// "Post-migration bootstrap incomplete" at startup of every service but
-// the first).
-func TestBootstrapAdminAdoptsAcrossIssuers(t *testing.T) {
-	db := setupCollectionTestDB(t)
-
-	existing, err := GetOrCreateUser(db, "admin", "admin", "https://svc-a:8445", CreatorSelf())
-	require.NoError(t, err)
-
-	require.NoError(t, param.Server_ExternalWebUrl.Set("https://svc-b:8446"))
-	t.Cleanup(config.ResetConfig)
-	require.NoError(t, BootstrapAdminAndBackfillOwners(db))
-
-	var admins []User
-	require.NoError(t, db.Where("username = ?", "admin").Find(&admins).Error)
-	require.Len(t, admins, 1, "bootstrap must adopt the sibling's admin row, not add another")
-	assert.Equal(t, existing.ID, admins[0].ID)
-}
-
-// If the only live "admin" is an OIDC-linked account (the built-in row
-// was deleted and an IdP user later claimed the name), bootstrap must
-// refuse rather than backfill group ownership onto that IdP-backed row.
-func TestBootstrapAdminRefusesOIDCLinkedAdmin(t *testing.T) {
-	db := setupCollectionTestDB(t)
-
-	_, err := CreateUser(db, "admin", "cilogon-sub-9", "https://cilogon.org", adminCreator())
-	require.NoError(t, err)
-
-	require.NoError(t, param.Server_ExternalWebUrl.Set("https://svc-b:8446"))
-	t.Cleanup(config.ResetConfig)
-	err = BootstrapAdminAndBackfillOwners(db)
-	assert.Error(t, err, "bootstrap must refuse an OIDC-linked 'admin' instead of adopting it")
 }
 
 func TestCreateUserRejectsInvalidIdentifier(t *testing.T) {

--- a/database/users_test.go
+++ b/database/users_test.go
@@ -29,6 +29,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
 )
 
 // The tests in this file cover the user/credential surface area:
@@ -134,6 +137,81 @@ func TestUsernameIsGloballyUniqueAcrossIssuers(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, "alice", u.Username)
 	assert.True(t, strings.HasPrefix(u.Username, "alice-"), "expected disambiguated name, got %q", u.Username)
+}
+
+// Several services sharing one server DB (the dev-container / e2e
+// layout) each bootstrap the built-in "admin" under their own
+// Server.ExternalWebUrl. Since usernames are globally unique, the
+// SECOND service must adopt the live local-shaped "admin" row (sub ==
+// username) a sibling created rather than mint a per-issuer duplicate.
+// Adoption is restricted to "admin": any other username collision
+// across issuers fails, and an OIDC-linked row is never adopted.
+func TestGetOrCreateUserAdoptsBuiltinAdminAcrossIssuers(t *testing.T) {
+	db := setupCollectionTestDB(t)
+
+	// The built-in admin is adopted across issuers (the shared-DB case).
+	first, err := GetOrCreateUser(db, "admin", "admin", "https://svc-a:8445", CreatorSelf())
+	require.NoError(t, err)
+	require.Equal(t, "admin", first.Username)
+
+	second, err := GetOrCreateUser(db, "admin", "admin", "https://svc-b:8446", CreatorSelf())
+	require.NoError(t, err)
+	assert.Equal(t, first.ID, second.ID, "sibling service must adopt the existing admin, not create a duplicate")
+	assert.Equal(t, "admin", second.Username)
+
+	// A NON-admin local account is NOT adopted across issuers: the second
+	// service's login must fail on the global unique index rather than
+	// silently link to the first service's row. We do not infer that two
+	// same-named local accounts are the same person.
+	_, err = GetOrCreateUser(db, "bob", "bob", "https://svc-a:8445", CreatorSelf())
+	require.NoError(t, err)
+	_, err = GetOrCreateUser(db, "bob", "bob", "https://svc-b:8446", CreatorSelf())
+	assert.Error(t, err, "non-admin local 'bob' must not be adopted across issuers")
+
+	// An OIDC-linked "admin" (sub != username) is never adopted by a
+	// password/init-code login that merely shares the name.
+	db2 := setupCollectionTestDB(t)
+	_, err = CreateUser(db2, "admin", "cilogon-sub-9", "https://cilogon.org", adminCreator())
+	require.NoError(t, err)
+	_, err = GetOrCreateUser(db2, "admin", "admin", "https://svc-b:8446", CreatorSelf())
+	assert.Error(t, err, "htpasswd 'admin' must not hijack an OIDC-linked 'admin'")
+}
+
+// The startup bootstrap must likewise be issuer-blind for the built-in
+// admin: a live "admin" created by a sibling service (different
+// ExternalWebUrl, same DB) IS the built-in admin, and re-creating it
+// per-issuer would trip the global unique username index (seen as
+// "Post-migration bootstrap incomplete" at startup of every service but
+// the first).
+func TestBootstrapAdminAdoptsAcrossIssuers(t *testing.T) {
+	db := setupCollectionTestDB(t)
+
+	existing, err := GetOrCreateUser(db, "admin", "admin", "https://svc-a:8445", CreatorSelf())
+	require.NoError(t, err)
+
+	require.NoError(t, param.Server_ExternalWebUrl.Set("https://svc-b:8446"))
+	t.Cleanup(config.ResetConfig)
+	require.NoError(t, BootstrapAdminAndBackfillOwners(db))
+
+	var admins []User
+	require.NoError(t, db.Where("username = ?", "admin").Find(&admins).Error)
+	require.Len(t, admins, 1, "bootstrap must adopt the sibling's admin row, not add another")
+	assert.Equal(t, existing.ID, admins[0].ID)
+}
+
+// If the only live "admin" is an OIDC-linked account (the built-in row
+// was deleted and an IdP user later claimed the name), bootstrap must
+// refuse rather than backfill group ownership onto that IdP-backed row.
+func TestBootstrapAdminRefusesOIDCLinkedAdmin(t *testing.T) {
+	db := setupCollectionTestDB(t)
+
+	_, err := CreateUser(db, "admin", "cilogon-sub-9", "https://cilogon.org", adminCreator())
+	require.NoError(t, err)
+
+	require.NoError(t, param.Server_ExternalWebUrl.Set("https://svc-b:8446"))
+	t.Cleanup(config.ResetConfig)
+	err = BootstrapAdminAndBackfillOwners(db)
+	assert.Error(t, err, "bootstrap must refuse an OIDC-linked 'admin' instead of adopting it")
 }
 
 func TestCreateUserRejectsInvalidIdentifier(t *testing.T) {

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -4383,10 +4383,17 @@ components: ["cache", "director", "origin", "registry"]
 ---
 name: Server.UIAdminUsers
 description: |+
-  A string slice of "subject" claim of users to give admin permission for the server admin website,
-  who are authenticated through OAuth/OIDC.
+  A list of Pelican usernames to give admin permission for the server Web UI.
 
-  The "subject" claim should be the "CILogon User Identifier" from CILogon user page: https://cilogon.org/
+  Each entry is matched against the server-managed username only. Confirm the exact value
+  from the user's profile page in the Web UI after they have logged in once.
+
+  **Breaking change (v7.27):** entries were previously also matched against the user's
+  OIDC "subject" claim (e.g. a CILogon User Identifier such as
+  `http://cilogon.org/serverA/users/12345`) and the internal user ID. As of v7.27 those
+  values no longer grant admin permission; Pelican logs a startup error naming any such
+  entry. Replace each one with the user's Pelican username, or (recommended) grant admin
+  access via ${Server.AdminGroups} instead.
 type: stringSlice
 default: []
 components: ["cache", "director", "origin", "registry"]
@@ -4411,7 +4418,7 @@ components: ["cache", "director", "origin", "registry"]
 ---
 name: Server.UserAdminUsers
 description: |+
-  A list of user identifiers (username, OIDC subject, or user ID) that are granted user administrator privileges.
+  A list of Pelican usernames that are granted user administrator privileges.
   User administrators can create, modify, and delete non-admin users and unprivileged groups.
   They cannot modify the system admin user or system admin groups.
 type: stringSlice
@@ -4428,7 +4435,7 @@ components: ["origin", "registry"]
 ---
 name: Server.CollectionAdminUsers
 description: |+
-  A list of user identifiers (username, OIDC subject, or user ID) that are granted collection administrator privileges.
+  A list of Pelican usernames that are granted collection administrator privileges.
   Collection administrators can create, modify, and delete collections and manage collection ACLs.
 type: stringSlice
 default: []

--- a/fed_test_utils/fed.go
+++ b/fed_test_utils/fed.go
@@ -43,6 +43,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/database"
 	"github.com/pelicanplatform/pelican/director"
 	"github.com/pelicanplatform/pelican/launchers"
 	"github.com/pelicanplatform/pelican/param"
@@ -427,6 +428,16 @@ func NewFedTest(t testing.TB, originConfig string, originSetup ...func(storageDi
 	for _, server := range servers {
 		ft.Pids = append(ft.Pids, server.GetPids()...)
 	}
+
+	// config.InitServer above ran BootstrapAdminAndBackfillOwners while
+	// Server.WebPort was still 0, so the "admin" user row's issuer is set to
+	// Server.ExternalWebUrl at the unbound default port. LaunchModules has
+	// now bound the real ephemeral port (UpdateConfigFromListener), so any
+	// login flow from here on computes a different issuer for "admin" and
+	// won't find that row. Here we realign it via UPDATE.
+	require.NoError(t, database.ServerDatabase.Model(&database.User{}).
+		Where("username = ?", "admin").
+		Update("issuer", param.Server_ExternalWebUrl.GetString()).Error)
 
 	desiredURL := param.Server_ExternalWebUrl.GetString() + "/api/v1.0/health"
 	err = server_utils.WaitUntilWorking(ctx, "GET", desiredURL, "director", 200, false)

--- a/transfer/transfer_tpc_e2e_test.go
+++ b/transfer/transfer_tpc_e2e_test.go
@@ -47,6 +47,7 @@ import (
 
 	"github.com/pelicanplatform/pelican/client"
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/database"
 	"github.com/pelicanplatform/pelican/fed_test_utils"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_utils"
@@ -264,6 +265,19 @@ func setupFedForTransferTPC(t testing.TB, storageType string) (ft *fed_test_util
 	originConfig = strings.Replace(originConfig, "StorageType: posixv2", "StorageType: "+storageType, 1)
 	ft = fed_test_utils.NewFedTest(t, originConfig)
 	require.NotNil(t, ft)
+
+	// The device-code login creates testuser under the web-login issuer, but
+	// the transfer tokens it mints carry the origin issuer. When the transfer
+	// middleware first saw such a token it tried to enroll a second "testuser"
+	// row and 500ed on the unique-username index. Pre-register that bearer
+	// identity (sub=testuser, origin issuer) under its own username in the
+	// shared test setup so the middleware's (sub, issuer) lookup hits instead.
+	// Once the server handles the collision, this workaround can be removed.
+	issuerURL, err := config.GetServerIssuerURL()
+	require.NoError(t, err)
+	_, err = database.CreateUser(database.ServerDatabase,
+		"testuser-transfer", "testuser", issuerURL, database.CreatorSelf())
+	require.NoError(t, err)
 	return
 }
 

--- a/web_ui/scopes.go
+++ b/web_ui/scopes.go
@@ -53,6 +53,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	pkgerrors "github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 
 	"github.com/pelicanplatform/pelican/api_token"
@@ -248,6 +249,48 @@ func hasScope(identity UserIdentity, scope token_scopes.TokenScope) bool {
 		}
 	}
 	return false
+}
+
+// warnNonUsernameAdminEntries scans the username-matched admin lists
+// (Server.UIAdminUsers, Server.UserAdminUsers,
+// Server.CollectionAdminUsers) for entries that can never match a
+// Pelican username and logs a startup error naming each one.
+//
+// As of v7.27 these lists are matched against the server-managed
+// username only — never the OIDC subject and never the internal user
+// ID (see addByUsernameMatch above and the design rationale on
+// CheckAdmin). Before v7.27, Server.UIAdminUsers also matched the
+// OIDC subject, so operators commonly listed CILogon User Identifiers
+// like "http://cilogon.org/serverA/users/12345". Such entries now
+// silently grant nothing — an admin lockout the operator should hear
+// about at startup, not discover as a login denial.
+//
+// database.ValidateIdentifier is the same validator applied wherever
+// usernames enter the system, so any entry it rejects (URL- or
+// oidc_sub-shaped values, anything with '/' or ':') cannot equal a
+// stored username. Opaque non-URL subjects are indistinguishable from
+// usernames and pass through unflagged; this is a heuristic for the
+// common CILogon case, not a completeness guarantee.
+func warnNonUsernameAdminEntries() {
+	for _, p := range []param.StringSliceParam{
+		param.Server_UIAdminUsers,
+		param.Server_UserAdminUsers,
+		param.Server_CollectionAdminUsers,
+	} {
+		invalid := []string{}
+		for _, entry := range p.GetStringSlice() {
+			if database.ValidateIdentifier(entry) != nil {
+				invalid = append(invalid, entry)
+			}
+		}
+		if len(invalid) > 0 {
+			log.Errorf("%s contains entries that are not valid Pelican usernames and will never grant admin permission: %q. "+
+				"As of Pelican v7.27, entries are matched against the server-managed username only "+
+				"(see user's profile page after they login) — OIDC subjects such as CILogon User "+
+				"Identifiers no longer grant admin. Replace the listed entries, or grant admin access via %s instead.",
+				p.GetName(), invalid, param.Server_AdminGroups.GetName())
+		}
+	}
 }
 
 // =============================================================================

--- a/web_ui/scopes_test.go
+++ b/web_ui/scopes_test.go
@@ -19,9 +19,12 @@
 package web_ui
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/glebarez/sqlite"
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
@@ -337,4 +340,78 @@ func TestCheckHelpersHonorAdminGroupsConfig(t *testing.T) {
 func mustCheckCollectionAdmin(identity UserIdentity) bool {
 	ok, _ := CheckCollectionAdmin(identity)
 	return ok
+}
+
+// TestWarnNonUsernameAdminEntries covers the startup check that flags
+// admin-list entries which can never match a server-managed username —
+// principally pre-7.27 CILogon OIDC subjects left in
+// Server.UIAdminUsers (see OPS-525).
+func TestWarnNonUsernameAdminEntries(t *testing.T) {
+	setup := func(t *testing.T) *logrustest.Hook {
+		server_utils.ResetTestState()
+		t.Cleanup(server_utils.ResetTestState)
+		hook := logrustest.NewGlobal()
+		t.Cleanup(hook.Reset)
+		return hook
+	}
+
+	errorEntries := func(hook *logrustest.Hook) []string {
+		msgs := []string{}
+		for _, e := range hook.AllEntries() {
+			if e.Level == logrus.ErrorLevel {
+				msgs = append(msgs, e.Message)
+			}
+		}
+		return msgs
+	}
+
+	t.Run("no lists set logs nothing", func(t *testing.T) {
+		hook := setup(t)
+		warnNonUsernameAdminEntries()
+		assert.Empty(t, errorEntries(hook))
+	})
+
+	t.Run("valid usernames log nothing", func(t *testing.T) {
+		hook := setup(t)
+		require.NoError(t, param.Server_UIAdminUsers.Set([]string{"alice", "bob@wisc.edu", "carol.d-e_f@example.org"}))
+		warnNonUsernameAdminEntries()
+		assert.Empty(t, errorEntries(hook))
+	})
+
+	t.Run("CILogon oidc_sub entry is named in an error", func(t *testing.T) {
+		hook := setup(t)
+		require.NoError(t, param.Server_UIAdminUsers.Set([]string{"http://cilogon.org/serverA/users/12345"}))
+		warnNonUsernameAdminEntries()
+		msgs := errorEntries(hook)
+		require.Len(t, msgs, 1)
+		assert.Contains(t, msgs[0], param.Server_UIAdminUsers.GetName())
+		assert.Contains(t, msgs[0], "http://cilogon.org/serverA/users/12345")
+		assert.Contains(t, msgs[0], param.Server_AdminGroups.GetName())
+	})
+
+	t.Run("mixed list names only the invalid entries", func(t *testing.T) {
+		hook := setup(t)
+		require.NoError(t, param.Server_UIAdminUsers.Set([]string{
+			"valid.user@example.edu",
+			"https://cilogon.org/serverB/users/999",
+		}))
+		warnNonUsernameAdminEntries()
+		msgs := errorEntries(hook)
+		require.Len(t, msgs, 1)
+		assert.Contains(t, msgs[0], "https://cilogon.org/serverB/users/999")
+		assert.NotContains(t, msgs[0], "valid.user@example.edu",
+			"valid username must not be listed as an offending entry")
+	})
+
+	t.Run("other username-matched admin lists are checked too", func(t *testing.T) {
+		hook := setup(t)
+		require.NoError(t, param.Server_UserAdminUsers.Set([]string{"http://cilogon.org/serverA/users/1"}))
+		require.NoError(t, param.Server_CollectionAdminUsers.Set([]string{"http://cilogon.org/serverA/users/2"}))
+		warnNonUsernameAdminEntries()
+		msgs := errorEntries(hook)
+		require.Len(t, msgs, 2)
+		joined := strings.Join(msgs, "\n")
+		assert.Contains(t, joined, param.Server_UserAdminUsers.GetName())
+		assert.Contains(t, joined, param.Server_CollectionAdminUsers.GetName())
+	})
 }

--- a/web_ui/ui.go
+++ b/web_ui/ui.go
@@ -1062,6 +1062,10 @@ func waitUntilLogin(ctx context.Context) error {
 //
 // You need to mount the static resources for UI in a separate function
 func ConfigureServerWebAPI(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group) error {
+	// Call out admin-list entries that can never match a username (e.g. CILogon
+	// OIDC subjects in Server.UIAdminUsers carried over from pre-v7.27 configs).
+	warnNonUsernameAdminEntries()
+
 	// start the cache for verified API keys
 	egrp.Go(func() error {
 		api_token.VerifiedKeysCache.Start()

--- a/web_ui/ui_test.go
+++ b/web_ui/ui_test.go
@@ -1021,12 +1021,11 @@ func TestGroupManagementAPI(t *testing.T) {
 	migrateTestDB(t)
 	// AuthHandler revalidates the user record on every cookie read;
 	// the tests below mint cookies for the owner-user / other-user /
-	// admin-user / new-member subjects, so the matching User rows
-	// have to exist before AuthHandler runs.
+	// admin-user subjects, so the matching User rows have to exist
+	// before AuthHandler runs.
 	ensureTestUserRow(t, "admin-user")
 	ensureTestUserRow(t, "owner-user")
 	ensureTestUserRow(t, "other-user")
-	ensureTestUserRow(t, "new-member")
 
 	t.Run("test-group-lifecycle", func(t *testing.T) {
 		// 1. Create a group as 'owner-user'


### PR DESCRIPTION
Fixes #3620. Related: #3608.

This PR address the issues in 7.27 testing, see Jira ticket OPS-525.

Admin matching (`Server.UIAdminUsers` / `Server.AdminGroups` / the built-in
"admin" grant) compares on username alone and ignores the issuer, and the
design doc calls the username "the unique machine-readable name". The schema
only enforced uniqueness per issuer, so one username could exist under two
issuers (e.g. a local password account and an OIDC account) and both would
satisfy a single admin entry. This PR closes that gap in 2 steps:

- **958ddebf9** warns loudly at startup when `Server.UIAdminUsers`,
  `Server.UserAdminUsers`, or `Server.CollectionAdminUsers` contain entries
  that can never be a valid Pelican username (pre-7.27 OIDC subjects such as
  CILogon User Identifiers), since those entries silently grant nothing.
- **04e224073** replaces the per-issuer `UNIQUE(username, issuer)` index with a
  global partial unique index on `username` (live rows only, so soft-deleted
  accounts don't reserve names). `UNIQUE(sub, issuer)` is unchanged.
 - ~~**464efb744** makes the built-in `admin` a single global identity, which fixes
  the startup/login failure described at the bottom (when multiple Pelican services
  shared the same `Server.DbLocation`, e.g. fed-in-a-box, dev container). The
  startup bootstrap and the htpasswd/init-code login paths adopt the live
  local-shaped `admin` row (`sub == username`) a sibling service created,
  instead of minting a per-issuer duplicate the new index rejects. Adoption is
  restricted to the literal `admin` account: every other username stays keyed on
  `(sub, issuer)`, so a cross-issuer collision fails rather than silently linking
  two same-named accounts. OIDC-linked rows (`sub != username`) are never
  adopted, and the bootstrap refuses to backfill group ownership onto an
  OIDC-linked `admin`.~~

### Note to admin

- If your existing database holds live cross-issuer duplicate usernames
  (legal under the old constraint), the migration fails at startup with
  `UNIQUE constraint failed: users.username`. Rename or remove the duplicate
  accounts, then restart; the migration does not pick a winner for you.
- After upgrade, check startup logs for the new error about
  `Server.UIAdminUsers` entries that are not valid usernames, and replace
  them with the server-managed username (visible on the user's profile page)
  or grant access via `Server.AdminGroups`.
- ~~In deployments where several services share one `Server.DbLocation` (dev
  container / e2e), the built-in `admin` is now a single global account: the
  first service to start creates the row, the rest adopt it, and logging in as
  admin on any of them resolves to the same user. Only `admin` is shared this
  way; non-admin local (htpasswd) accounts stay keyed per issuer, so do not rely
  on shared non-admin htpasswd identities across services (use OIDC or
  `Server.AdminGroups`, or give the services separate databases).~~

~~Background on the startup/login failure the third commit fixes:~~

> ~~Each service records the admin account in the shared database tagged with its own web address (ExternalWebURL). So when you log in on service B, the password checks out, but B looks for an "admin" row tagged with B's address, doesn't find one (service A already created the row tagged with A's address), and tries to create its own. The new rule that a username can only exist once in the database rejects that duplicate, the login handler hits that unexpected error, and the user sees a 500.~~

