### PR TITLE
plugin: Fix TransferProtocol and TransferFileName in recursive ClassAds

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -986,6 +986,8 @@ func workerFailureResult(file *clientTransferFile, err error) TransferResults {
 	}
 	res := newTransferResults(file.file.job)
 	res.JobId = file.jobId
+	res.Scheme = file.file.remoteURL.Scheme
+	res.Source = file.file.remoteURL.String()
 	res.Error = err
 	return res
 }
@@ -3007,10 +3009,12 @@ func runTransferWorkerFile(ctx context.Context, file *clientTransferFile, result
 	}
 	transferResults.JobId = file.jobId
 	transferResults.Scheme = file.file.remoteURL.Scheme
+	transferResults.Source = file.file.remoteURL.String()
 	if err != nil {
 		log.Errorf("Error when attempting to transfer object %s for client %s: %v", file.file.remoteURL, file.uuid.String(), err)
 		transferResults = newTransferResults(file.file.job)
 		transferResults.Scheme = file.file.remoteURL.Scheme
+		transferResults.Source = file.file.remoteURL.String()
 		transferResults.Error = err
 	}
 	if file.file.job != nil && file.file.job.dirResp.RedirectInfo != nil {
@@ -5512,7 +5516,7 @@ func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfer
 							callback:           job.job.callback,
 							job:                job.job,
 							engine:             te,
-							remoteURL:          &url.URL{Path: remotePath},
+							remoteURL:          &url.URL{Scheme: job.job.remoteURL.Scheme, Path: remotePath},
 							requestedChecksums: job.job.requestedChecksums,
 							requireChecksum:    job.job.requireChecksum,
 							packOption:         transfers[0].PackOption,
@@ -5600,7 +5604,7 @@ func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfer
 					callback:           job.job.callback,
 					job:                job.job,
 					engine:             te,
-					remoteURL:          &url.URL{Path: newPath},
+					remoteURL:          &url.URL{Scheme: job.job.remoteURL.Scheme, Path: newPath},
 					requestedChecksums: job.job.requestedChecksums,
 					requireChecksum:    job.job.requireChecksum,
 					packOption:         transfers[0].PackOption,

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -568,7 +568,10 @@ func runPluginWorker(ctx context.Context, upload bool, workChan <-chan PluginTra
 				if err != nil {
 					log.Errorf("Failed to set TransferType: %s", err)
 				}
-				err = resultAd.Set("TransferFileName", path.Base(transfer.url.String()))
+				// Use the per-file Source URL (set by processTransfer) so that
+				// recursive child files report their own name rather than the
+				// parent collection name with ?recursive appended.
+				err = resultAd.Set("TransferFileName", path.Base(result.Source))
 				if err != nil {
 					log.Errorf("Failed to set TransferFileName: %s", err)
 				}

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -1462,7 +1462,22 @@ func TestPluginRecursiveDownload(t *testing.T) {
 			}
 		}
 		// Check we get 2 result ads back (each file has been downloaded)
-		assert.Equal(t, 2, len(resultAds))
+		require.Equal(t, 2, len(resultAds))
+
+		// Verify that each child file reports the correct TransferProtocol
+		// and TransferFileName (not the parent collection URL with ?recursive).
+		fileNames := make([]string, 0, 2)
+		for _, ad := range resultAds {
+			proto, ok := classad.GetAs[string](ad, "TransferProtocol")
+			require.True(t, ok, "TransferProtocol must be present")
+			assert.Equal(t, "pelican", proto, "TransferProtocol should be the original scheme, not empty")
+
+			fileName, ok := classad.GetAs[string](ad, "TransferFileName")
+			require.True(t, ok, "TransferFileName must be present")
+			assert.NotContains(t, fileName, "recursive", "TransferFileName should not contain the ?recursive query")
+			fileNames = append(fileNames, fileName)
+		}
+		assert.ElementsMatch(t, []string{"test.txt", "test2.txt"}, fileNames)
 	})
 
 	t.Run("TestRecursiveFailureDirNotFound", func(t *testing.T) {


### PR DESCRIPTION
When the plugin handles a `?recursive` download, child `transferFile` objects were created with `remoteURL` missing the `Scheme` field, causing `TransferProtocol` to be empty in the output ClassAd. This prevented HTCondor from prefixing [transfer stats attributes](https://github.com/htcondor/htcondor/blob/main/src/condor_utils/file_transfer.cpp#L7454-L7459) (e.g. `PELICANSizeBytesLastRun`).

Additionally, `TransferFileName` reported the parent collection name with the query string appended (e.g. `data?recursive`) instead of individual child filenames, because all child results mapped back to the parent job URL in the plugin's `jobMap`.

Fix both by propagating the parent job's `Scheme` to child file URLs and overriding `Source` on each `TransferResults` with the per-file URL so the plugin can derive accurate filenames.

Resolves #3622

(Maintainers, please feel free to update the target branch if needed for backporting or whatever!)