### PR TITLE
oauth2: request the full storage scope set in interactive device flows (parked)

### DIFF
--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -110,14 +110,31 @@ func AcquireToken(issuerUrl string, entry *config.PrefixEntry, dirResp server_st
 	}
 
 	storageScopes := []string{}
-	if opts.Operation.IsEnabled(config.TokenWrite) || opts.Operation.IsEnabled(config.TokenSharedWrite) {
-		storageScopes = append(storageScopes, "storage.create:"+pathCleaned)
-	}
-	if opts.Operation.IsEnabled(config.TokenDelete) {
-		storageScopes = append(storageScopes, "storage.modify:"+pathCleaned)
-	}
-	if opts.Operation.IsEnabled(config.TokenRead) || opts.Operation.IsEnabled(config.TokenSharedRead) || opts.Operation.IsEnabled(config.TokenList) {
-		storageScopes = append(storageScopes, "storage.read:"+pathCleaned)
+	if opts.Operation.IsEnabled(config.TokenSharedWrite) || opts.Operation.IsEnabled(config.TokenSharedRead) {
+		// Shared tokens are handed to third parties: request exactly the
+		// scopes asked for and nothing more.
+		if opts.Operation.IsEnabled(config.TokenWrite) || opts.Operation.IsEnabled(config.TokenSharedWrite) {
+			storageScopes = append(storageScopes, "storage.create:"+pathCleaned)
+		}
+		if opts.Operation.IsEnabled(config.TokenDelete) {
+			storageScopes = append(storageScopes, "storage.modify:"+pathCleaned)
+		}
+		if opts.Operation.IsEnabled(config.TokenRead) || opts.Operation.IsEnabled(config.TokenSharedRead) || opts.Operation.IsEnabled(config.TokenList) {
+			storageScopes = append(storageScopes, "storage.read:"+pathCleaned)
+		}
+	} else {
+		// This is the interactive device-code flow -- the expensive step,
+		// with a human in a browser -- reached only after wallet reuse and
+		// refresh have both failed. Request the full set of storage scopes
+		// the client registration already permits, so a single approval
+		// covers the whole session; otherwise every operation needing a
+		// scope the stored token lacks (read, then create, then modify)
+		// launches yet another device flow. The user still sees and
+		// approves the full scope list at the issuer.
+		storageScopes = append(storageScopes,
+			"storage.read:"+pathCleaned,
+			"storage.create:"+pathCleaned,
+			"storage.modify:"+pathCleaned)
 	}
 	storageScope := strings.Join(storageScopes, " ")
 	log.Debugln("Requesting a credential with the following scope:", storageScope)


### PR DESCRIPTION
**Parked — not proposed for merge as-is.** Kept open to record the problem and the discussion; see the alternative at the bottom, which needs no change here at all.

Everything else that was in this PR has landed or moved to its own PR:

- #3654 — checksums (merged, also fixed #3614)
- #3655 — director response reuse (merged)
- #3656 — director advertisements
- #3659 — the XRootD binary startup gate (merged)
- #3668 — upload `storage.modify` scopes, plus the two `PelicanFS` fixes

### What remains here

The device-code flow is reached only after wallet reuse and refresh have both failed, and it costs a human interaction in a browser. Requesting only the current operation's scope means a session that reads, then creates, then overwrites launches a separate device flow for each scope the stored token lacks. This commit requests `storage.read` + `storage.create` + `storage.modify` — which the client registration already permits — so one approval covers the whole session. Shared tokens, which get handed to third parties, keep requesting exactly what was asked for.

### Why it shouldn't merge in this form

It changes what *every* interactive Pelican user is asked to approve, to suit a caller that happens to know it will need all three. A `pelican object get` should not ask a user to approve write and modify on their behalf, and "the issuer shows them the list" isn't much of a defence when the list is broader than the operation they requested.

That was fine in pelfs, where we know up front the filesystem needs all three. It is not a good default.

### The alternative: no client change needed

A caller that knows its own needs can request them itself, using the existing scope mapping — `TokenWrite` → `storage.create`, `TokenDelete` → `storage.modify`, `TokenRead` → `storage.read`. Set all three bits and one device flow returns all three scopes:

```go
pUrl, err := client.ParseRemoteAsPUrl(ctx, "pelican://example.org/prefix/object")
dirResp, err := client.GetDirectorInfoForPath(ctx, pUrl, http.MethodGet, "")

opts := config.TokenGenerationOpts{
    Operation: config.TokenRead | config.TokenWrite | config.TokenDelete,
}
_, err = client.AcquireToken(pUrl.GetRawUrl(), dirResp, opts)
```

Every function there is already exported. The acquired token lands in the wallet, and `hasAcceptableScope` builds its requirements from the operation each *later* call requests — so a token carrying all three scopes satisfies every narrower request that follows, and no further device flow is triggered.

That gets pelfs exactly what this commit was for, opt-in, without changing what a plain CLI user is asked to approve. Unless there's a reason it won't work, the right resolution is to do that in pelfs and close this.
