### PR TITLE
origin: answer OPTIONS on the server root

### DIFF
--- a/origin_serve/handlers.go
+++ b/origin_serve/handlers.go
@@ -981,6 +981,40 @@ func exportRequestHandler(backend server_utils.OriginBackend, handler *webdav.Ha
 	}
 }
 
+// registerRootOptions answers OPTIONS on the server root with the WebDAV verbs
+// this origin supports.
+//
+// Clients probe an endpoint's capabilities once per host and cache the answer
+// for every path on it -- xrdcl-curl keys its verbs cache by scheme, host and
+// port, and probes exactly scheme://host:port. Serving 405 there told such a
+// client "this origin does not do PROPFIND", even though every namespace route
+// advertises it, because the root carries no export and so matched no route.
+//
+// The reply is deliberately unauthenticated: OPTIONS asks what the server can
+// do, not what the caller may do, and a 401 is as useless to a capability
+// probe as a 405. Per-path authorization is unaffected.
+func registerRootOptions(engine *gin.Engine) {
+	verbs := []string{
+		"OPTIONS", "GET", "HEAD", "PUT", "DELETE",
+		"PROPFIND", "PROPPATCH", "MKCOL", "MOVE", "LOCK", "UNLOCK",
+	}
+	// COPY is per-export, so advertise it only when some export allows it.
+	for _, enabled := range copyEnabledPrefixes {
+		if enabled {
+			verbs = append(verbs, "COPY")
+			break
+		}
+	}
+	sort.Strings(verbs)
+
+	allow := strings.Join(verbs, ", ")
+	engine.Handle(http.MethodOptions, "/", func(c *gin.Context) {
+		c.Header("Allow", allow)
+		c.Header("DAV", "1, 2")
+		c.Status(http.StatusOK)
+	})
+}
+
 // RegisterHandlers registers the HTTP handlers with the Gin engine.
 // When the director is also running in the same server, handlers are registered
 // under /api/v1.0/origin/<prefix> so the director can distinguish between its routing
@@ -1037,6 +1071,8 @@ func RegisterHandlers(engine *gin.Engine, directorEnabled bool) error {
 
 		log.Infof("Registered HTTP handlers for prefix: %s (route: %s)", prefix, routePrefix)
 	}
+
+	registerRootOptions(engine)
 
 	handlersRegistered = true
 	return nil

--- a/origin_serve/root_options_test.go
+++ b/origin_serve/root_options_test.go
@@ -1,0 +1,97 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package origin_serve
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A client that probes an origin's capabilities asks for them once per host
+// and applies the answer to every path there -- xrdcl-curl keys its verbs
+// cache by scheme, host and port and probes exactly scheme://host:port. The
+// root used to carry no route at all, so that probe got a 405 with no Allow
+// header and the client concluded the origin could not do PROPFIND, which is
+// the opposite of what every namespace route on it advertises.
+func TestRootOptionsAdvertisesWebDAVVerbs(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	copyEnabledPrefixes = map[string]bool{}
+	t.Cleanup(func() { copyEnabledPrefixes = nil })
+	registerRootOptions(engine)
+
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "OPTIONS on the root must not 405")
+
+	allow := rec.Header().Get("Allow")
+	require.NotEmpty(t, allow, "a capability probe is useless without an Allow header")
+	for _, verb := range []string{"OPTIONS", "GET", "HEAD", "PUT", "PROPFIND"} {
+		assert.Contains(t, allow, verb, "Allow should advertise %s", verb)
+	}
+	assert.Equal(t, "1, 2", rec.Header().Get("DAV"))
+}
+
+// The probe must work without credentials: OPTIONS asks what the server can
+// do, not what the caller may do, and a 401 is as unhelpful to it as a 405.
+func TestRootOptionsNeedsNoCredentials(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	copyEnabledPrefixes = map[string]bool{}
+	t.Cleanup(func() { copyEnabledPrefixes = nil })
+	registerRootOptions(engine)
+
+	req := httptest.NewRequest(http.MethodOptions, "/", nil) // no Authorization
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Header().Get("Allow"), "PROPFIND")
+}
+
+// COPY is enabled per export, so it is advertised only when some export has it.
+func TestRootOptionsAdvertisesCopyOnlyWhenEnabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	probe := func() string {
+		engine := gin.New()
+		registerRootOptions(engine)
+		req := httptest.NewRequest(http.MethodOptions, "/", nil)
+		rec := httptest.NewRecorder()
+		engine.ServeHTTP(rec, req)
+		return rec.Header().Get("Allow")
+	}
+
+	copyEnabledPrefixes = map[string]bool{}
+	t.Cleanup(func() { copyEnabledPrefixes = nil })
+	assert.False(t, strings.Contains(probe(), "COPY"),
+		"COPY must not be advertised when no export enables it")
+
+	copyEnabledPrefixes = map[string]bool{"/test": true}
+	assert.True(t, strings.Contains(probe(), "COPY"),
+		"COPY should be advertised once an export enables it")
+}


### PR DESCRIPTION
A POSIX v2 origin answered `OPTIONS /` with a 405 and no `Allow` header. That matters more than it looks, because a client probes an endpoint's capabilities **once per host** and applies the answer to every path there.

`xrdcl-curl` — how an XRootD cache reaches an origin over `pelican://` — keys its verbs cache by scheme, host and port, and probes exactly `scheme://host:port`. Nothing was registered at the root, so the probe got a 405, and the client recorded that the origin does not support PROPFIND: the opposite of what every namespace route on it advertises, and for the entire host.

Measured against the live federation, the origin was fine everywhere except the one place the probe looks:

| `OPTIONS` path | result |
|---|---|
| `/` | **405**, no `Allow` |
| `/osdf-tutorial` | 307 |
| `/osdf-tutorial/` | 401 |
| object path, with token | 200, `Allow: … PROPFIND …` |

Of the 77 origins currently advertised in the OSDF, this was the only reachable one that failed a root capability probe. The XRootD origins all return a full `Allow` there, as does the director.

### Why it wasn't harmless

A cache stat that had already selected PROPFIND for an earlier leg (the director advertises it) fell back to HEAD on the strength of the recorded answer. A libcurl handle bug — `CURLOPT_CUSTOMREQUEST` persists, and the fallback didn't clear it — then left the request going out as a PROPFIND while the stat believed it had sent a HEAD, so it read the object's size from the `Content-Length` of the 207 reply. Objects ended up cached truncated to the length of their own PROPFIND document: one 66,939,740 byte object was served by the cache as exactly 755 bytes, its multistatus document's length, with the real leading bytes of the file.

That half is fixed separately in PelicanPlatform/xrdcl-pelican#123. Either fix alone stops the truncation; this one also stops the wrong verbs-cache entry that started it, and helps any deployed cache that won't pick up a client update soon.

### The change

Register an `OPTIONS /` handler advertising the verbs this origin supports, with `DAV: 1, 2`. COPY is advertised only when some export enables it, since that is a per-export capability.

The reply is deliberately unauthenticated. OPTIONS asks what the *server* can do, not what the caller may do, and a 401 is as useless to a capability probe as a 405 was — note the 401s in the table above, which is what the probe would hit if it were moved under the auth middleware. Per-path authorization is untouched.

### Testing

`origin_serve/root_options_test.go` covers the advertised verb list and `DAV` header, that the probe works with no credentials, and that COPY appears only when an export enables it.

For reviewers: `origin_serve` has three pre-existing failures on my macOS box (`TestTPCWithPOSIXv2`, `TestTPCCrossOrigin`, `TestTPCWithXRootD`, each ~30s). I confirmed they fail identically on a clean `origin/main` checkout, so they are environmental here rather than caused by this change.
