### PR TITLE
Move cookie to same-site lax

### DIFF
--- a/web_ui/authentication.go
+++ b/web_ui/authentication.go
@@ -473,12 +473,28 @@ func setLoginCookie(ctx *gin.Context, userRecord *database.User, groups []string
 	}
 
 	// One cookie should be used for all path.
-	// SetSameSite must be called BEFORE SetCookie: gin reads the
-	// configured SameSite mode at SetCookie time, so setting it
-	// afterwards would emit the login cookie with no SameSite attribute
-	// (falling back to the browser default) instead of the intended
-	// Strict.
-	ctx.SetSameSite(http.SameSiteStrictMode)
+	//
+	// SetSameSite must be called BEFORE SetCookie: gin reads the mode at
+	// SetCookie time, so setting it afterwards emits no SameSite
+	// attribute at all and the browser default applies.
+	//
+	// Lax, NOT Strict — load-bearing for OIDC. This cookie is issued by
+	// the OAuth callback, reached via a redirect chain starting at the
+	// identity provider. Browsers compute SameSite context across the
+	// whole chain, so a cross-site hop withholds Strict cookies on every
+	// later hop (a server-side redirect can't launder it): the cookie is
+	// set but not sent on the navigation into the post-login page, which
+	// then bounces to /view/login/ in a loop. Lax is sent on top-level
+	// navigations, which is what the OIDC return needs.
+	//
+	// Lax's main CSRF cost over Strict is that the cookie may ride a
+	// cross-site top-level GET, exploitable only via a
+	// cookie-authenticated GET that mutates state — there are none, and
+	// cross-origin responses aren't readable by the initiator. Non-safe
+	// methods are equally protected either way, with isSameOriginRequest
+	// below as an independent Origin/Referer check. If you add a mutating
+	// GET, guard it explicitly rather than reaching for Strict here.
+	ctx.SetSameSite(http.SameSiteLaxMode)
 	ctx.SetCookie("login", tok, int(loginLifetime.Seconds()), "/", ctx.Request.URL.Host, true, true)
 
 	// Track last login time
@@ -506,17 +522,20 @@ func setLoginCookie(ctx *gin.Context, userRecord *database.User, groups []string
 //     letting the real UI through — with no token plumbing on the
 //     client.
 //
-// This is defense-in-depth on top of the login cookie's SameSite=Strict
-// (which already stops modern browsers from attaching the cookie
-// cross-site); it also covers the SameSite gaps (very old browsers,
-// certain same-site sub-origin scenarios).
+// This is defense-in-depth on top of the login cookie's SameSite=Lax,
+// which already stops modern browsers from attaching the cookie to
+// cross-site non-safe-method requests and to cross-site subresource/XHR
+// requests of any method. It also covers the SameSite gaps (very old
+// browsers, some same-site sub-origin cases, Chrome's brief "Lax+POST"
+// allowance for a freshly-set cookie).
 //
 // Returns true (allow) for safe methods, Bearer-authenticated requests,
-// same-origin requests, and requests with no Origin/Referer at all (not
-// a browser-driven cross-site POST — SameSite=Strict is the backstop and
-// this keeps non-browser cookie clients and tests working). Returns
-// false ONLY when a cookie-authenticated, state-changing request carries
-// an Origin/Referer that does not match this server.
+// same-origin requests, and requests with no Origin/Referer at all —
+// that last case keeps non-browser cookie clients and tests working, and
+// isn't a browser-driven cross-site mutation, since browsers always send
+// Origin on those and Lax withholds the cookie anyway. Returns false
+// ONLY when a cookie-authenticated, state-changing request carries an
+// Origin/Referer that does not match this server.
 func isSameOriginRequest(ctx *gin.Context) bool {
 	switch ctx.Request.Method {
 	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace:
@@ -1180,8 +1199,6 @@ func resetLoginHandler(ctx *gin.Context) {
 }
 
 func logoutHandler(ctx *gin.Context) {
-	// SetSameSite before SetCookie (see setLoginCookie for why).
-	ctx.SetSameSite(http.SameSiteStrictMode)
 	ctx.SetCookie("login", "", -1, "/", ctx.Request.URL.Host, true, true)
 	ctx.Set("User", "")
 	ctx.JSON(http.StatusOK,

--- a/web_ui/authentication_test.go
+++ b/web_ui/authentication_test.go
@@ -454,6 +454,59 @@ func TestPasswordBasedLoginAPI(t *testing.T) {
 	})
 }
 
+// TestLoginCookieSameSite pins the login cookie to SameSite=Lax.
+//
+// Lax is required for OIDC. The OAuth callback issues this cookie at the
+// end of a redirect chain that starts at the identity provider, and
+// browsers compute SameSite context across the whole chain — so a chain
+// containing a cross-site hop withholds Strict cookies on every later
+// hop. A Strict cookie is set correctly but never SENT on the navigation
+// into the post-login page, so the server sees an anonymous request and
+// bounces the user back to /view/login/ in a loop.
+//
+// Asserting on the parsed SameSite field catches both regressions this
+// has hit before: the mode changed to Strict, and the attribute missing
+// entirely (SetSameSite called AFTER SetCookie, which gin ignores) — an
+// absent attribute parses as SameSiteDefaultMode, not Lax.
+func TestLoginCookieSameSite(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	setupWebUIEnv(t)
+
+	mockDB, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err, "Error setting up mock DB")
+	database.ServerDatabase = mockDB
+	migrateTestDB(t)
+
+	_, err = tempPasswdFile.WriteString("admin:password\n")
+	require.NoError(t, err, "Error writing to temp password file")
+	require.NoError(t, configureAuthDB())
+	require.NoError(t, WritePasswordEntry("user", "password"), "error writing a user")
+
+	req, err := http.NewRequest("POST", "/api/v1.0/auth/login",
+		strings.NewReader(`{"user": "user", "password": "password"}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	require.Equal(t, http.StatusOK, recorder.Code,
+		fmt.Sprintf("login failed, body: %s", recorder.Body.String()))
+
+	var loginCookie *http.Cookie
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == "login" {
+			loginCookie = cookie
+		}
+	}
+	require.NotNil(t, loginCookie, "no login cookie was issued")
+
+	assert.Equal(t, http.SameSiteLaxMode, loginCookie.SameSite,
+		"login cookie must be SameSite=Lax or OIDC login loops back to /view/login/; see setLoginCookie")
+	assert.True(t, loginCookie.HttpOnly, "login cookie must be HttpOnly")
+	assert.True(t, loginCookie.Secure, "login cookie must be Secure")
+}
+
 func TestWhoamiAPI(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	server_utils.ResetTestState()

--- a/web_ui/frontend/Makefile
+++ b/web_ui/frontend/Makefile
@@ -2,4 +2,4 @@ run:
 	docker compose up pelican-server-central pelican-server-origin pelican-api-proxy
 
 build:
-	docker compose run pelican-builder
+	docker compose run --rm pelican-builder


### PR DESCRIPTION
Fixes the authentication and maintains secure practices.

Needed to be fixed because a AI drive-by determined that we should have samesite strict which broke the authentication. We do not need samesite strict.

Does increase the possibility of security issues should someone add a mutating GET. It is standard practice to not make GETs change state though so I think we are fine.