### PR TITLE
Cache: log director-test cleanup successes at debug level

### DIFF
--- a/cache/cache_api.go
+++ b/cache/cache_api.go
@@ -216,12 +216,16 @@ func cleanupDirectorTestFiles(ctx context.Context, dirTestPath string) error {
 
 	// Clean up legacy flat files
 	if len(legacyFiles) > 0 {
+		cleanedCount := 0
 		for i := 0; i < len(legacyFiles); i++ {
 			filePath := filepath.Join(dirTestPath, legacyFiles[i].Name())
 			if err := removeTestFile(ctx, filePath); err != nil {
 				log.WithError(err).Warnf("Failed to remove legacy director test file: %s", filePath)
+			} else {
+				cleanedCount++
 			}
 		}
+		log.Debugf("Cleaned up %d of %d legacy director test files scanned in %s", cleanedCount, len(legacyFiles), dirTestPath)
 	}
 
 	return nil
@@ -245,6 +249,8 @@ func cleanupDirectorIDSubtree(ctx context.Context, idDirPath, todayStr string) e
 		if entry.Name() < todayStr {
 			if err := cleanTestDir(ctx, dateDir); err != nil {
 				log.WithError(err).Warnf("Failed to remove old director test directory: %s", dateDir)
+			} else {
+				log.Debugf("Cleaned up old director test directory: %s", dateDir)
 			}
 		} else if entry.Name() == todayStr {
 			if err := cleanupOldFilesInDir(ctx, dateDir, 1); err != nil {
@@ -290,14 +296,20 @@ func cleanupOldFilesInDir(ctx context.Context, dirPath string, keepObjects int) 
 	}
 	sort.Strings(keys)
 
+	cleanedCount := 0
+	totalCount := 0
 	for i := 0; i < len(keys)-keepObjects; i++ {
 		for _, name := range objects[keys[i]] {
+			totalCount++
 			filePath := filepath.Join(dirPath, name)
 			if err := removeTestFile(ctx, filePath); err != nil {
 				log.WithError(err).Warnf("Failed to remove old test file: %s", filePath)
+			} else {
+				cleanedCount++
 			}
 		}
 	}
+	log.Debugf("Cleaned up %d of %d director test files scanned in %s", cleanedCount, totalCount, dirPath)
 	return nil
 }
 
@@ -351,6 +363,8 @@ func HandleDirectorEvictRequest(ctx *gin.Context) {
 		return
 	}
 
+	log.Debugf("Received authorized eviction request from director for test file %s", reqBody.Path)
+
 	if err := evictViaLocalPlugin(ctx.Request.Context(), reqBody.Path); err != nil {
 		log.Warningf("Failed to submit evict request for director test file %s: %v", reqBody.Path, err)
 		ctx.JSON(http.StatusInternalServerError, server_structs.SimpleApiResp{
@@ -363,7 +377,7 @@ func HandleDirectorEvictRequest(ctx *gin.Context) {
 	// Note: the file is now a PFC purge candidate, not necessarily removed from disk.
 	// Physical removal is deferred to PFC's threshold-gated purge cycle (see the doc
 	// comment on evictViaLocalPlugin).
-	log.Debugf("Marked director test file as PFC purge candidate via local plugin: %s", reqBody.Path)
+	log.Debugf("Successfully marked director test file %q as a PFC purge candidate via Evict API", reqBody.Path)
 	ctx.JSON(http.StatusOK, server_structs.SimpleApiResp{
 		Status: server_structs.RespOK,
 		Msg:    "Eviction request accepted; file marked as a purge candidate (physical removal deferred to PFC purge cycle)",
@@ -468,6 +482,8 @@ func LaunchDirectorTestFileCleanup(ctx context.Context, egrp *errgroup.Group) {
 			// Run immediately on startup, then once every 24h.
 			if err := cleanupDirectorTestFiles(ctx, dirTestPath); err != nil {
 				log.Warningf("Failure during director test file backup cleanup: %v", err)
+			} else {
+				log.Debugf("Director test file backup cleanup pass completed for %s", dirTestPath)
 			}
 			select {
 			case <-ctx.Done():

--- a/docs/user-group-design.md
+++ b/docs/user-group-design.md
@@ -56,6 +56,7 @@ A group has the following properties:
 
 - For most web UI actions, authorization to perform an action should be based on the calculated scopes from the user and associated group records.
 - Deleted users have no authorizations.
-- Users may generate an API key with a subset of their authorizations.
+- API keys are intended for the long-lived credential use case (no renewal but revocation), not as the primary access path. For accessing objects and collections, users should rely on OAuth2-issued tokens from a normal web login, which already carry their permitted scopes.
+  - API key creation is admin-only: the web UI’s API-key endpoints require the server-admin privilege.
   - Actions from API keys must be distinguishable (for creators / deleters, etc) from those done by the web UI. At least the key ID must be recorded if a key was used.
   - Users can lose authorizations after the API key was used. Thus, when an API key is used, its scopes must be intersected with the current scopes for the user.


### PR DESCRIPTION
This PR address two feedbacks in 7.27 testing:

1. a one-line docs clarification that API key creation is currently admin-only.

2. Per @williamnswanson's feedback in OPS-528, the cache's director-test eviction and cleanup paths logged only failures, making it hard to confirm the machinery was working. This adds debug-level success logging:

- `HandleDirectorEvictRequest`: log when an authorized evict request arrives from the director (the cache-side signal that the director's health test succeeded), and when the file is successfully marked as a PFC purge candidate.
- Daily backup cleanup sweep: per-pass completion log, "cleaned up X of Y" summaries for legacy flat files and for aged-out test files, and a log per removed day-directory.

Closes #3630
