### PR TITLE
Director Streamling - Rework Logging to reduce blocking states

### DIFF
--- a/config/log_buffer.go
+++ b/config/log_buffer.go
@@ -233,6 +233,11 @@ func StartLogRingBuffer(ctx context.Context) {
 	// install cannot be dropped by a rebuild running alongside it.
 	globalTransformMu.Lock()
 	log.AddHook(&logRingBufferHook{buf: buf})
+	// The ring documents an info-and-above capture floor (see shouldBuffer),
+	// so logrus's level gate must admit info entries while the ring is
+	// installed even when the operator configured a quieter level. The
+	// buffer was stored above, so the re-derivation sees it.
+	syncLogrusLevelLocked()
 	globalTransformMu.Unlock()
 }
 
@@ -249,6 +254,12 @@ func StopLogRingBuffer() {
 	// new entries are delivered.
 	buf.closed.Store(true)
 	removeLogRingBufferHook()
+	// With the buffer gone (swapped to nil above), drop logrus's level back
+	// to whatever the remaining consumers need -- the info floor the ring
+	// imposed no longer applies.
+	globalTransformMu.Lock()
+	syncLogrusLevelLocked()
+	globalTransformMu.Unlock()
 	// Stop the compression worker. Cancelling the worker context is sufficient
 	// on its own: compressLoop selects on workerCtx.Done(). We deliberately do
 	// NOT close compressQueue -- Fire performs a non-blocking send on it under
@@ -329,8 +340,14 @@ func (h *logRingBufferHook) Fire(entry *log.Entry) error {
 //
 // The effective level comes from GetEffectiveLogLevel (which knows about
 // the hook-based filtering initFilterLogging installs); logrus's own
-// GetLevel is often pinned to TraceLevel so hooks see everything even when
-// the operator asked for info-only output.
+// GetLevel can sit above the operator's configured level while a registered
+// RegexpFilter needs to observe more verbose entries (see logrusLevelFor),
+// so it is not a reliable statement of what the operator asked for.
+//
+// The "always buffered" tier is only deliverable because logrusLevelFor
+// floors logrus's level gate at info while the ring is installed -- info
+// entries on a warn/error-configured server would otherwise be rejected
+// before any hook fires. If you change that floor, change this contract.
 func shouldBuffer(level log.Level) bool {
 	if level <= log.InfoLevel {
 		return true

--- a/config/log_buffer.go
+++ b/config/log_buffer.go
@@ -234,9 +234,11 @@ func StartLogRingBuffer(ctx context.Context) {
 	globalTransformMu.Lock()
 	log.AddHook(&logRingBufferHook{buf: buf})
 	// The ring documents an info-and-above capture floor (see shouldBuffer),
-	// so logrus's level gate must admit info entries while the ring is
-	// installed even when the operator configured a quieter level. The
-	// buffer was stored above, so the re-derivation sees it.
+	// so register an Info demand: logrus's level gate must admit info entries
+	// while the ring is installed even when the operator configured a quieter
+	// level. It is a floor (not hookOnly), so it holds during the InitServer
+	// window before hook-based filtering is active.
+	registerLevelDemandLocked("log-ring-buffer", log.InfoLevel, false)
 	syncLogrusLevelLocked()
 	globalTransformMu.Unlock()
 }
@@ -254,10 +256,10 @@ func StopLogRingBuffer() {
 	// new entries are delivered.
 	buf.closed.Store(true)
 	removeLogRingBufferHook()
-	// With the buffer gone (swapped to nil above), drop logrus's level back
-	// to whatever the remaining consumers need -- the info floor the ring
-	// imposed no longer applies.
+	// Withdraw the info floor and re-derive: logrus drops back to whatever the
+	// remaining consumers need.
 	globalTransformMu.Lock()
+	releaseLevelDemandLocked("log-ring-buffer")
 	syncLogrusLevelLocked()
 	globalTransformMu.Unlock()
 	// Stop the compression worker. Cancelling the worker context is sufficient
@@ -341,11 +343,12 @@ func (h *logRingBufferHook) Fire(entry *log.Entry) error {
 // The effective level comes from GetEffectiveLogLevel (which knows about
 // the hook-based filtering initFilterLogging installs); logrus's own
 // GetLevel can sit above the operator's configured level while a registered
-// RegexpFilter needs to observe more verbose entries (see logrusLevelFor),
+// RegexpFilter needs to observe more verbose entries (see deriveLevelLocked),
 // so it is not a reliable statement of what the operator asked for.
 //
-// The "always buffered" tier is only deliverable because logrusLevelFor
-// floors logrus's level gate at info while the ring is installed -- info
+// The "always buffered" tier is only deliverable because StartLogRingBuffer
+// registers an info-level demand (see RegisterLevelDemand / deriveLevelLocked)
+// that floors logrus's level gate at info while the ring is installed -- info
 // entries on a warn/error-configured server would otherwise be rejected
 // before any hook fires. If you change that floor, change this contract.
 func shouldBuffer(level log.Level) bool {

--- a/config/logging.go
+++ b/config/logging.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -43,6 +44,13 @@ type (
 	RegexpFilter struct {
 		Regexp *regexp.Regexp
 		Name   string
+		// Levels declares which log levels this filter observes; Fire is only
+		// invoked for entries at these levels. The declaration also feeds
+		// logrusLevelFor, which raises logrus's internal level just far enough
+		// for the filter to see what it asked for. Leaving Levels empty means
+		// "observe everything" -- at the cost of pinning logrus to TraceLevel
+		// (full entry construction for every suppressed log call in the
+		// process) for as long as the filter is registered.
 		Levels []log.Level
 		Fire   func(*log.Entry) error
 	}
@@ -84,12 +92,20 @@ var (
 	// shouldBuffer reads it on every incoming log line, so answering the
 	// query must stay a single atomic load: it cannot take
 	// globalTransformMu or walk the transform hook's LogLevels slice, which
-	// is what the level would otherwise have to be derived from. Keeping
-	// that true is the job of every level-changing site -- SetLogging
-	// (called by the param-callback registered via RegisterLoggingCallback),
-	// initFilterLogging, and ResetGlobalLoggingHooks -- each of which writes
-	// the new level here.
+	// is what the level would otherwise have to be derived from. It is the
+	// authoritative record of the operator-configured level: seeded at
+	// package init and written ONLY by SetLogging (called by the
+	// param-callback registered via RegisterLoggingCallback). Every other
+	// level-changing site derives from it; none may write it.
 	effectiveLogLevel atomic.Uint32
+
+	// testLogFloor is a level floor declared by a test harness whose log hook
+	// forwards entries to t.Log for failure diagnostics (see
+	// test_utils.SetupTestLogging). Zero means "no floor". It participates in
+	// logrusLevelFor the same way the ring buffer and registered filters do,
+	// which is what lets the harness's verbosity survive a mid-test
+	// InitClient/InitServer re-deriving the level from the configured value.
+	testLogFloor atomic.Uint32
 )
 
 func (sw *syncWriter) Write(p []byte) (n int, err error) {
@@ -161,6 +177,12 @@ func (rt *regexpTransformHook) Levels() []log.Level {
 func (fh *RegexpFilterHook) Fire(entry *log.Entry) (err error) {
 	filters := fh.filters.Load()
 	for _, filter := range *filters {
+		// A filter only observes the levels it declared (empty means all).
+		// logrusLevelFor uses the same declaration to decide how far logrus's
+		// level gate must open, so declaration and delivery stay in agreement.
+		if len(filter.Levels) > 0 && !slices.Contains(filter.Levels, entry.Level) {
+			continue
+		}
 		if filter.Regexp.MatchString(entry.Message) {
 			curErr := filter.Fire(entry)
 			if curErr != nil && err == nil {
@@ -257,24 +279,135 @@ func redactEntryCopy(entry *log.Entry) *log.Entry {
 	return &dup
 }
 
-func initFilterLogging() {
-	// Our filters may want to see every log message, even those that
-	// are not otherwise printed.  Have the log levels printed via a hook
-	// (instead of the typical output mechanism) so we can crank up the
-	// global log.
-	filters := make([]*RegexpFilter, 0)
-	globalFilters.filters.Store(&filters)
+// logrusLevelFor returns the level logrus itself should run at: the
+// operator's configured level, raised only as far as the registered
+// consumers of sub-level entries need to observe. Today those consumers are
+// registered RegexpFilters (each declaring its Levels) and the log ring
+// buffer (a standing info-and-above floor while installed). logrus's level gate sits in front of all
+// entry construction (formatting, hook dispatch, and three acquisitions of
+// the logger's global mutex), so keeping the level as low as possible is
+// what spares suppressed Tracef/Debugf calls on hot request paths the
+// formatting, hook dispatch, and global-mutex traffic of entry construction
+// (argument boxing may still allocate at call sites with parameters).
+//
+// A filter that does not declare Levels is assumed to need everything,
+// which restores the historical pin to TraceLevel while it is registered.
+//
+// If another filter needs to be added in lets move to a new method of level
+// registration to enable rather than continuously piling on.
+func logrusLevelFor(configured log.Level) log.Level {
+	needed := floorLevelFor(configured)
+	if filters := globalFilters.filters.Load(); filters != nil {
+		for _, filter := range *filters {
+			if len(filter.Levels) == 0 {
+				return log.TraceLevel
+			}
+			for _, lvl := range filter.Levels {
+				if lvl > needed {
+					needed = lvl
+				}
+			}
+		}
+	}
+	return needed
+}
 
-	// On the FIRST init pass, log.GetLevel() reflects the operator's
-	// configured level. On subsequent passes (unit-test reinit, config
-	// reload paths that re-enter this function) it reflects the pinned
-	// TraceLevel we set below -- reading it then would clobber the
-	// effective-level cache with Trace and cause the log buffer to
-	// silently capture trace lines the operator never asked for.
-	// Guard the cache update behind the same first-time-only gate that
-	// installs the hooks.
-	configLevel := log.GetLevel()
-	log.SetLevel(log.TraceLevel)
+// floorLevelFor applies the standing level floors -- the consumers that must
+// observe sub-configured entries in every logging mode, hook-based or not:
+//
+//   - The log ring buffer (served by the pelican.log_read triage endpoints)
+//     documents that info and above are always captured, so a server running
+//     a quiet Logging.Level still has recent context available for remote
+//     triage. That contract must hold from the moment StartLogRingBuffer
+//     runs -- which on a server is early in InitServer, well before
+//     initFilterLogging installs hook-based output gating.
+//   - A test harness forwarding entries to t.Log declares a floor so failing
+//     tests keep their diagnostic output across in-test re-initialization.
+//
+// Unlike filter needs (see logrusLevelFor), floors deliberately apply even
+// when hook-based filtering is inactive. In that mode logrus's Out is the
+// real writer, so floor-admitted entries also reach the output -- e.g. a
+// warn-configured server writes info lines during the InitServer window.
+// That is the accepted price of the ring's "always captured" tier; once
+// initFilterLogging installs the hook-gated writer, output returns to the
+// configured level while the floors keep feeding the hooks.
+func floorLevelFor(configured log.Level) log.Level {
+	needed := configured
+	if globalLogBuffer.Load() != nil && log.InfoLevel > needed {
+		needed = log.InfoLevel
+	}
+	// testLogFloor == 0 means "no floor declared"; no explicit check is
+	// needed because 0 is PanicLevel, the least verbose level, which can
+	// never exceed `needed` -- the sentinel is inert by construction.
+	if floor := log.Level(testLogFloor.Load()); floor > needed {
+		needed = floor
+	}
+	return needed
+}
+
+// syncLogrusLevelLocked re-derives logrus's internal level after a change to
+// the registered floors or filter set. Callers must hold globalTransformMu:
+// SetLogging updates the level under the same mutex, so a derive-then-set
+// outside it could interleave with a concurrent SetLogging and leave logrus
+// below what a just-registered consumer needs (a lost update, and a consumer
+// that never fires).
+//
+// Both branches derive from the effective-level cache -- the authoritative
+// record of the operator's configured level (seeded at package init, stored
+// unconditionally by SetLogging) -- never from log.GetLevel(), which may
+// already be floor-raised; deriving from it would make the sync a one-way
+// ratchet that can never lower the level after a floor is lifted. Filter
+// needs apply only when hook-based filtering is active; otherwise raising
+// the level for a filter would leak filter-only lines straight to the
+// output. Floors (ring buffer, test harness) apply in both modes -- see
+// floorLevelFor.
+func syncLogrusLevelLocked() {
+	if addedGlobalFilters {
+		log.SetLevel(logrusLevelFor(GetEffectiveLogLevel()))
+	} else {
+		log.SetLevel(floorLevelFor(GetEffectiveLogLevel()))
+	}
+}
+
+func initFilterLogging() {
+
+	// The mutex serializes the read-modify-write on the filter list against
+	// concurrent Add/Remove calls, and the level update against SetLogging.
+	globalTransformMu.Lock()
+	defer globalTransformMu.Unlock()
+
+	// Our filters may want to see log messages that are not otherwise
+	// printed. Printing happens via a hook (instead of the typical output
+	// mechanism), so logrus's own level only controls which entries the
+	// hooks get to see -- raise it no further than the filters require.
+	//
+	// Only initialize the filter list on first use: re-entry happens at
+	// runtime (config.InitClient is reachable inside a server process, e.g.
+	// from the local-cache module) and must not unregister live filters
+	// such as the xrootd startup watchers.
+	if globalFilters.filters.Load() == nil {
+		filters := make([]*RegexpFilter, 0)
+		globalFilters.filters.Store(&filters)
+	}
+
+	// The effective-level cache is the authoritative record of what the
+	// operator configured: SetLogging stores it unconditionally before any
+	// init path reaches this function, and the package-init seed covers the
+	// window before that. logrus's own log.GetLevel() is NOT a valid source
+	// here on either pass -- it may already be raised above the configured
+	// level by a standing floor (ring buffer, test harness) or a registered
+	// filter, and caching a raised value would poison GetEffectiveLogLevel
+	// for every consumer that gates behavior on it (debug headers, the ring
+	// buffer's debug/trace tier, config printing).
+	//
+	// Historically the level was pinned to TraceLevel here so the filter
+	// hooks could see every message. That forced every suppressed
+	// Tracef/Debugf in the codebase to pay full logrus entry construction
+	// (three global-mutex acquisitions and a formatting pass) on hot
+	// request paths; now the level is raised only as far as registered
+	// consumers actually need (see logrusLevelFor).
+	configLevel := GetEffectiveLogLevel()
+	log.SetLevel(logrusLevelFor(configLevel))
 	hookLevel := make([]log.Level, 0)
 	for _, lvl := range log.AllLevels {
 		if lvl <= configLevel {
@@ -284,11 +417,8 @@ func initFilterLogging() {
 
 	// Unit tests may initialize the server multiple times; avoid configuring
 	// the global logging multiple times
-	globalTransformMu.Lock()
 	if !addedGlobalFilters {
 		addedGlobalFilters = true
-		effectiveLogLevel.Store(uint32(configLevel))
-		globalTransformMu.Unlock()
 		// Set the writer to what logrus has
 		newHook := &writer.Hook{
 			Writer:    ensureThreadSafeWriter(log.StandardLogger().Out),
@@ -304,8 +434,37 @@ func initFilterLogging() {
 		// prior unit tests affect this one.
 		newRegex := regexp.MustCompile(bearerTokenRegexStr)
 		globalTransform.regex.Store(newRegex)
+	}
+}
+
+// SetTestLogFloor declares that a test harness needs logrus to admit entries
+// at lvl and below-severity regardless of the configured level, so its log
+// hook (which forwards entries to t.Log) keeps receiving diagnostics when a
+// test re-initializes logging via InitClient/InitServer. Cleared with
+// ClearTestLogFloor; intended only for test harnesses.
+// The returned restore function reinstates the floor that was in effect
+// before this call, so nested harnesses (a package-level
+// SetupGlobalTestLogging plus per-test SetupTestLogging, or parent tests
+// with subtests) do not wipe each other's declarations.
+func SetTestLogFloor(lvl log.Level) (restore func()) {
+	prev := testLogFloor.Swap(uint32(lvl))
+	globalTransformMu.Lock()
+	syncLogrusLevelLocked()
+	globalTransformMu.Unlock()
+	return func() {
+		testLogFloor.Store(prev)
+		globalTransformMu.Lock()
+		syncLogrusLevelLocked()
 		globalTransformMu.Unlock()
 	}
+}
+
+// ClearTestLogFloor removes the floor installed by SetTestLogFloor.
+func ClearTestLogFloor() {
+	testLogFloor.Store(0)
+	globalTransformMu.Lock()
+	defer globalTransformMu.Unlock()
+	syncLogrusLevelLocked()
 }
 
 // ResetGlobalLoggingHooks resets the global logging hooks and flags for testing.
@@ -321,34 +480,51 @@ func ResetGlobalLoggingHooks() {
 		}
 		globalTransform.hook.Store(newHook)
 	}
-	// The hook was just widened back to AllLevels, so anything through
-	// TraceLevel is now nominally "effective". Match that in the cache
-	// so GetEffectiveLogLevel doesn't return a stale narrower level from
-	// the previous test.
-	effectiveLogLevel.Store(uint32(log.TraceLevel))
+	// Deliberately leave effectiveLogLevel alone: it is the authoritative
+	// record of what the operator configured (seeded at package init, then
+	// stored by every SetLogging call), and writing a sentinel here would be
+	// read back by the next initFilterLogging as "what the operator asked
+	// for". A test that needs a specific level must establish it via
+	// SetLogging; a harness that needs verbosity declares a floor via
+	// SetTestLogFloor.
 }
 
 func AddFilter(newFilter *RegexpFilter) {
-	filters := globalFilters.filters.Load()
-	var newFilters []*RegexpFilter
-	if filters == nil {
-		newFilters = make([]*RegexpFilter, 0)
-	} else {
-		newFilters = *filters
+	// The mutex serializes the read-modify-write on the filter list against
+	// concurrent Add/Remove calls, and the level update against SetLogging.
+	globalTransformMu.Lock()
+	defer globalTransformMu.Unlock()
+	var existing []*RegexpFilter
+	if filters := globalFilters.filters.Load(); filters != nil {
+		existing = *filters
 	}
+	// Copy rather than append in place: Fire iterates the published slice
+	// lock-free, so a published slice must never be mutated afterward.
+	newFilters := make([]*RegexpFilter, 0, len(existing)+1)
+	newFilters = append(newFilters, existing...)
 	newFilters = append(newFilters, newFilter)
 	globalFilters.filters.Store(&newFilters)
+	// The new filter may need to observe levels below the configured one;
+	// raise logrus's level accordingly for as long as it is registered.
+	syncLogrusLevelLocked()
 }
 
 func RemoveFilter(name string) {
-	filters := *globalFilters.filters.Load()
-	result := make([]*RegexpFilter, 0)
-	for _, filter := range filters {
+	globalTransformMu.Lock()
+	defer globalTransformMu.Unlock()
+	var existing []*RegexpFilter
+	if filters := globalFilters.filters.Load(); filters != nil {
+		existing = *filters
+	}
+	result := make([]*RegexpFilter, 0, len(existing))
+	for _, filter := range existing {
 		if filter.Name != name {
 			result = append(result, filter)
 		}
 	}
 	globalFilters.filters.Store(&result)
+	// Drop logrus's level back down if this filter was what held it up.
+	syncLogrusLevelLocked()
 }
 
 func SetLogging(logLevel log.Level) {
@@ -370,18 +546,24 @@ func SetLogging(logLevel log.Level) {
 	})
 
 	// When global filters are active, we use hook-based filtering instead of logrus's
-	// internal level filtering. We set logrus to TraceLevel (the most permissive) so
-	// that ALL log messages pass through to our hooks; the hooks then filter based on
-	// the user's configured level via hookLevel. This approach allows our RegexpFilterHook
-	// to see all messages regardless of the configured output level.
+	// internal level filtering: the hooks decide what is written via hookLevel. logrus's
+	// own level then only controls which entries reach the hooks, so run it at the
+	// configured level, raised just far enough for any registered RegexpFilter to see
+	// the messages it declared interest in (see logrusLevelFor).
 	globalTransformMu.Lock()
 	if addedGlobalFilters {
-		log.SetLevel(log.TraceLevel)
+		log.SetLevel(logrusLevelFor(logLevel))
 		hookLevel := make([]log.Level, 0, len(log.AllLevels))
 
 		// Atomically get current hooks
 		emptyHooks := log.LevelHooks{}
 		currentHooks := log.StandardLogger().ReplaceHooks(emptyHooks)
+		// Reinstall a copy at once so the logger is never hookless while we
+		// rebuild: with Out at io.Discard, entries emitted in that window
+		// would be lost entirely. The copy matters because currentHooks is
+		// read below while logrus writes to the reinstalled set. Same
+		// pattern as removeLogRingBufferHook.
+		log.StandardLogger().ReplaceHooks(copyLevelHooks(currentHooks))
 
 		// Build new hooks map, removing our global hooks
 		newHooks := log.LevelHooks{}
@@ -415,24 +597,30 @@ func SetLogging(logLevel log.Level) {
 		for _, lvl := range hookLevel {
 			newHooks[lvl] = append(newHooks[lvl], globalTransform)
 		}
-		globalTransformMu.Unlock()
-
-		// Atomically replace all hooks
+		// Install the rebuilt set before releasing the mutex: Start/Stop of
+		// the ring buffer mutate the same hook set under this mutex, so
+		// swapping after unlock could overwrite a concurrent install with
+		// our stale snapshot (an installed-but-starved ring buffer).
 		log.StandardLogger().ReplaceHooks(newHooks)
-	} else {
 		globalTransformMu.Unlock()
-		log.SetLevel(logLevel)
+	} else {
+		// No hook-based gating yet: logrus's own level is the output gate.
+		// Still honor the standing floors (ring buffer, test harness) so
+		// their capture contracts hold before initFilterLogging runs; see
+		// floorLevelFor for the output-leak trade this accepts.
+		log.SetLevel(floorLevelFor(logLevel))
+		globalTransformMu.Unlock()
 	}
 }
 
 // GetEffectiveLogLevel returns the effective log level -- the level the
-// operator asked for, as opposed to logrus's internal log.GetLevel()
-// which is pinned to TraceLevel whenever the hook-based filter tree is
-// active (so hooks see every entry). The value is served from an atomic
-// cache updated by SetLogging, initFilterLogging, and
-// ResetGlobalLoggingHooks; the hot path (LogRingBuffer.shouldBuffer,
-// invoked on every entry) is therefore a single atomic load with no
-// mutex contention or slice walk.
+// operator asked for, as opposed to logrus's internal log.GetLevel(),
+// which may sit temporarily above it while a registered RegexpFilter needs
+// to observe more verbose entries (see logrusLevelFor). The value is
+// served from an atomic cache seeded at package init and updated only by
+// SetLogging; the hot path (LogRingBuffer.shouldBuffer, invoked on every
+// entry) is therefore a single atomic load with no mutex contention or
+// slice walk.
 func GetEffectiveLogLevel() log.Level {
 	return log.Level(effectiveLogLevel.Load())
 }

--- a/config/logging.go
+++ b/config/logging.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"regexp"
 	"slices"
+	"strconv"
 	"sync"
 	"sync/atomic"
 
@@ -45,12 +46,13 @@ type (
 		Regexp *regexp.Regexp
 		Name   string
 		// Levels declares which log levels this filter observes; Fire is only
-		// invoked for entries at these levels. The declaration also feeds
-		// logrusLevelFor, which raises logrus's internal level just far enough
-		// for the filter to see what it asked for. Leaving Levels empty means
-		// "observe everything" -- at the cost of pinning logrus to TraceLevel
-		// (full entry construction for every suppressed log call in the
-		// process) for as long as the filter is registered.
+		// invoked for entries at these levels. The declaration also feeds the
+		// level-demand registry (see syncFilterDemandLocked), which raises logrus's
+		// internal level just far enough for the filter to see what it asked
+		// for. Leaving Levels empty means "observe everything" -- at the cost
+		// of raising logrus to TraceLevel (full entry construction for every
+		// suppressed log call in the process) for as long as the filter is
+		// registered.
 		Levels []log.Level
 		Fire   func(*log.Entry) error
 	}
@@ -99,14 +101,29 @@ var (
 	// level-changing site derives from it; none may write it.
 	effectiveLogLevel atomic.Uint32
 
-	// testLogFloor is a level floor declared by a test harness whose log hook
-	// forwards entries to t.Log for failure diagnostics (see
-	// test_utils.SetupTestLogging). Zero means "no floor". It participates in
-	// logrusLevelFor the same way the ring buffer and registered filters do,
-	// which is what lets the harness's verbosity survive a mid-test
-	// InitClient/InitServer re-deriving the level from the configured value.
-	testLogFloor atomic.Uint32
+	// levelDemands holds every consumer that needs logrus to admit entries
+	// below the operator-configured level -- the log ring buffer, registered
+	// RegexpFilters, and test harnesses -- keyed by a stable string. It is
+	// guarded by globalTransformMu and read by deriveLevelLocked.
+	levelDemands = map[string]levelDemand{}
+
+	// demandSeq stamps each RegisterLevelDemand registration with a unique
+	// sequence number (so a superseded registration's release is a no-op) and
+	// hands each SetTestLogFloor call a unique demand key.
+	demandSeq atomic.Uint64
 )
+
+// levelDemand is one consumer's declared need for logrus to admit entries at
+// `level` or more verbose. A hookOnly demand counts only while hook-based
+// filtering is active (see deriveLevelLocked). seq identifies the registration
+// that installed it, so a release from a superseded RegisterLevelDemand call
+// does not remove a newer demand under the same key (zero for demands set
+// through the internal locked helpers, which release unconditionally by key).
+type levelDemand struct {
+	level    log.Level
+	hookOnly bool
+	seq      uint64
+}
 
 func (sw *syncWriter) Write(p []byte) (n int, err error) {
 	sw.mu.Lock()
@@ -178,7 +195,7 @@ func (fh *RegexpFilterHook) Fire(entry *log.Entry) (err error) {
 	filters := fh.filters.Load()
 	for _, filter := range *filters {
 		// A filter only observes the levels it declared (empty means all).
-		// logrusLevelFor uses the same declaration to decide how far logrus's
+		// syncFilterDemandLocked uses the same declaration to decide how far logrus's
 		// level gate must open, so declaration and delivery stay in agreement.
 		if len(filter.Levels) > 0 && !slices.Contains(filter.Levels, entry.Level) {
 			continue
@@ -279,94 +296,121 @@ func redactEntryCopy(entry *log.Entry) *log.Entry {
 	return &dup
 }
 
-// logrusLevelFor returns the level logrus itself should run at: the
-// operator's configured level, raised only as far as the registered
-// consumers of sub-level entries need to observe. Today those consumers are
-// registered RegexpFilters (each declaring its Levels) and the log ring
-// buffer (a standing info-and-above floor while installed). logrus's level gate sits in front of all
-// entry construction (formatting, hook dispatch, and three acquisitions of
-// the logger's global mutex), so keeping the level as low as possible is
-// what spares suppressed Tracef/Debugf calls on hot request paths the
-// formatting, hook dispatch, and global-mutex traffic of entry construction
-// (argument boxing may still allocate at call sites with parameters).
+// deriveLevelLocked returns the level logrus must run at: the operator's
+// configured level, raised to satisfy every registered demand that applies in
+// the current gating mode.
 //
-// A filter that does not declare Levels is assumed to need everything,
-// which restores the historical pin to TraceLevel while it is registered.
+// The configured level comes from the effective-level cache (the authoritative
+// record, seeded at package init and stored only by SetLogging), never from
+// log.GetLevel(). log.GetLevel() may already be raised by a standing demand,
+// so deriving from it would make the derivation a one-way ratchet that could
+// never lower the level again once a demand is released.
 //
-// If another filter needs to be added in lets move to a new method of level
-// registration to enable rather than continuously piling on.
-func logrusLevelFor(configured log.Level) log.Level {
-	needed := floorLevelFor(configured)
-	if filters := globalFilters.filters.Load(); filters != nil {
-		for _, filter := range *filters {
-			if len(filter.Levels) == 0 {
-				return log.TraceLevel
+// A hookOnly demand -- a RegexpFilter -- counts only while hook-based
+// filtering is active: in that mode logrus's level merely decides which
+// entries reach the hooks, so opening the gate for a filter costs nothing on
+// the output. Before hook-based filtering is installed logrus's Out is the
+// real writer, so raising the gate for a filter would leak filter-only lines
+// to the output; those demands are skipped until then. Floors (ring buffer,
+// test harness) are not hookOnly and apply in both modes -- the ring buffer's
+// "info and above always captured" tier must hold from the moment it is
+// installed, which on a server is well before initFilterLogging runs. The
+// accepted price is that a quiet-configured server writes those floor-admitted
+// lines to its output during that startup window.
+//
+// Callers must hold globalTransformMu.
+func deriveLevelLocked() log.Level {
+	needed := GetEffectiveLogLevel()
+	for _, d := range levelDemands {
+		if d.hookOnly && !addedGlobalFilters {
+			continue
+		}
+		needed = max(needed, d.level)
+	}
+	return needed
+}
+
+// syncLogrusLevelLocked re-derives and applies logrus's internal level after a
+// change to the registered demands, the filter set, or the configured level.
+// Callers must hold globalTransformMu: SetLogging updates the level under the
+// same mutex, so a derive-then-set outside it could interleave with a
+// concurrent SetLogging and leave logrus below what a just-registered consumer
+// needs (a lost update, and a consumer that never fires).
+func syncLogrusLevelLocked() {
+	log.SetLevel(deriveLevelLocked())
+}
+
+// registerLevelDemandLocked records a demand and releaseLevelDemandLocked
+// removes it. Both only mutate the map; the caller re-derives the level (it
+// already holds the mutex and usually batches the demand change with other
+// work). Callers must hold globalTransformMu.
+func registerLevelDemandLocked(key string, level log.Level, hookOnly bool) {
+	levelDemands[key] = levelDemand{level: level, hookOnly: hookOnly}
+}
+
+func releaseLevelDemandLocked(key string) {
+	delete(levelDemands, key)
+}
+
+// RegisterLevelDemand declares that the consumer identified by `key` needs
+// logrus to admit entries at `level` or more verbose, regardless of the
+// operator-configured level, and returns a function that withdraws the demand.
+// The gate is raised immediately and re-derived when the demand is withdrawn.
+// Re-registering the same key replaces its level; the release returned by the
+// superseded call then becomes a no-op, so independent owners sharing a key
+// never withdraw one another's live demand.
+//
+// This is the general mechanism behind the ring-buffer floor, filter needs,
+// and the test-harness floor (SetTestLogFloor): a new consumer that must
+// observe sub-configured entries should register here rather than growing
+// another special case. Demands registered through this exported entry point
+// are floors -- they hold in every logging mode. (Filter needs, which apply
+// only while hook-based filtering is active, are registered internally.)
+func RegisterLevelDemand(key string, level log.Level) (release func()) {
+	seq := demandSeq.Add(1)
+	globalTransformMu.Lock()
+	levelDemands[key] = levelDemand{level: level, hookOnly: false, seq: seq}
+	syncLogrusLevelLocked()
+	globalTransformMu.Unlock()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			globalTransformMu.Lock()
+			// Only remove the demand if this registration still owns the key:
+			// a later RegisterLevelDemand(key, ...) supersedes us, and its demand
+			// must survive our release.
+			if d, ok := levelDemands[key]; ok && d.seq == seq {
+				releaseLevelDemandLocked(key)
+				syncLogrusLevelLocked()
 			}
-			for _, lvl := range filter.Levels {
-				if lvl > needed {
-					needed = lvl
-				}
-			}
+			globalTransformMu.Unlock()
+		})
+	}
+}
+
+// syncFilterDemandLocked recomputes the single "filters" demand from the live
+// filter list: the max level any registered filter declared, or TraceLevel if
+// any filter declares no Levels (it observes everything). Keying all filters
+// under one demand -- rather than one demand per filter name -- matches the
+// old whole-list scan and avoids a same-name registration clobbering another
+// filter's need. Caller must hold globalTransformMu.
+func syncFilterDemandLocked() {
+	filters := globalFilters.filters.Load()
+	if filters == nil || len(*filters) == 0 {
+		releaseLevelDemandLocked("filters")
+		return
+	}
+	needed := log.PanicLevel
+	for _, f := range *filters {
+		if len(f.Levels) == 0 {
+			needed = log.TraceLevel
+			break
+		}
+		for _, lvl := range f.Levels {
+			needed = max(needed, lvl)
 		}
 	}
-	return needed
-}
-
-// floorLevelFor applies the standing level floors -- the consumers that must
-// observe sub-configured entries in every logging mode, hook-based or not:
-//
-//   - The log ring buffer (served by the pelican.log_read triage endpoints)
-//     documents that info and above are always captured, so a server running
-//     a quiet Logging.Level still has recent context available for remote
-//     triage. That contract must hold from the moment StartLogRingBuffer
-//     runs -- which on a server is early in InitServer, well before
-//     initFilterLogging installs hook-based output gating.
-//   - A test harness forwarding entries to t.Log declares a floor so failing
-//     tests keep their diagnostic output across in-test re-initialization.
-//
-// Unlike filter needs (see logrusLevelFor), floors deliberately apply even
-// when hook-based filtering is inactive. In that mode logrus's Out is the
-// real writer, so floor-admitted entries also reach the output -- e.g. a
-// warn-configured server writes info lines during the InitServer window.
-// That is the accepted price of the ring's "always captured" tier; once
-// initFilterLogging installs the hook-gated writer, output returns to the
-// configured level while the floors keep feeding the hooks.
-func floorLevelFor(configured log.Level) log.Level {
-	needed := configured
-	if globalLogBuffer.Load() != nil && log.InfoLevel > needed {
-		needed = log.InfoLevel
-	}
-	// testLogFloor == 0 means "no floor declared"; no explicit check is
-	// needed because 0 is PanicLevel, the least verbose level, which can
-	// never exceed `needed` -- the sentinel is inert by construction.
-	if floor := log.Level(testLogFloor.Load()); floor > needed {
-		needed = floor
-	}
-	return needed
-}
-
-// syncLogrusLevelLocked re-derives logrus's internal level after a change to
-// the registered floors or filter set. Callers must hold globalTransformMu:
-// SetLogging updates the level under the same mutex, so a derive-then-set
-// outside it could interleave with a concurrent SetLogging and leave logrus
-// below what a just-registered consumer needs (a lost update, and a consumer
-// that never fires).
-//
-// Both branches derive from the effective-level cache -- the authoritative
-// record of the operator's configured level (seeded at package init, stored
-// unconditionally by SetLogging) -- never from log.GetLevel(), which may
-// already be floor-raised; deriving from it would make the sync a one-way
-// ratchet that can never lower the level after a floor is lifted. Filter
-// needs apply only when hook-based filtering is active; otherwise raising
-// the level for a filter would leak filter-only lines straight to the
-// output. Floors (ring buffer, test harness) apply in both modes -- see
-// floorLevelFor.
-func syncLogrusLevelLocked() {
-	if addedGlobalFilters {
-		log.SetLevel(logrusLevelFor(GetEffectiveLogLevel()))
-	} else {
-		log.SetLevel(floorLevelFor(GetEffectiveLogLevel()))
-	}
+	registerLevelDemandLocked("filters", needed, true)
 }
 
 func initFilterLogging() {
@@ -405,9 +449,8 @@ func initFilterLogging() {
 	// Tracef/Debugf in the codebase to pay full logrus entry construction
 	// (three global-mutex acquisitions and a formatting pass) on hot
 	// request paths; now the level is raised only as far as registered
-	// consumers actually need (see logrusLevelFor).
+	// consumers actually need (see deriveLevelLocked).
 	configLevel := GetEffectiveLogLevel()
-	log.SetLevel(logrusLevelFor(configLevel))
 	hookLevel := make([]log.Level, 0)
 	for _, lvl := range log.AllLevels {
 		if lvl <= configLevel {
@@ -435,36 +478,23 @@ func initFilterLogging() {
 		newRegex := regexp.MustCompile(bearerTokenRegexStr)
 		globalTransform.regex.Store(newRegex)
 	}
+
+	// Re-derive now that addedGlobalFilters is set: the hookOnly filter demands
+	// apply from here on, so the gate opens to what the filters need.
+	syncLogrusLevelLocked()
 }
 
 // SetTestLogFloor declares that a test harness needs logrus to admit entries
-// at lvl and below-severity regardless of the configured level, so its log
-// hook (which forwards entries to t.Log) keeps receiving diagnostics when a
-// test re-initializes logging via InitClient/InitServer. Cleared with
-// ClearTestLogFloor; intended only for test harnesses.
-// The returned restore function reinstates the floor that was in effect
-// before this call, so nested harnesses (a package-level
-// SetupGlobalTestLogging plus per-test SetupTestLogging, or parent tests
-// with subtests) do not wipe each other's declarations.
+// at lvl or more verbose regardless of the configured level, so its log hook
+// (which forwards entries to t.Log) keeps receiving diagnostics when a test
+// re-initializes logging via InitClient/InitServer. It returns a restore
+// function that withdraws just this declaration. Each call takes a unique
+// demand key, so concurrent or nested harnesses never wipe one another's floor
+// and restores may run in any order. Intended only for test harnesses; it is a
+// thin wrapper over RegisterLevelDemand.
 func SetTestLogFloor(lvl log.Level) (restore func()) {
-	prev := testLogFloor.Swap(uint32(lvl))
-	globalTransformMu.Lock()
-	syncLogrusLevelLocked()
-	globalTransformMu.Unlock()
-	return func() {
-		testLogFloor.Store(prev)
-		globalTransformMu.Lock()
-		syncLogrusLevelLocked()
-		globalTransformMu.Unlock()
-	}
-}
-
-// ClearTestLogFloor removes the floor installed by SetTestLogFloor.
-func ClearTestLogFloor() {
-	testLogFloor.Store(0)
-	globalTransformMu.Lock()
-	defer globalTransformMu.Unlock()
-	syncLogrusLevelLocked()
+	key := "test-harness:" + strconv.FormatUint(demandSeq.Add(1), 10)
+	return RegisterLevelDemand(key, lvl)
 }
 
 // ResetGlobalLoggingHooks resets the global logging hooks and flags for testing.
@@ -505,7 +535,10 @@ func AddFilter(newFilter *RegexpFilter) {
 	newFilters = append(newFilters, newFilter)
 	globalFilters.filters.Store(&newFilters)
 	// The new filter may need to observe levels below the configured one;
-	// raise logrus's level accordingly for as long as it is registered.
+	// recompute the filters' collective demand so logrus's level is raised for
+	// as long as it is registered (a hookOnly demand: it applies only in hook
+	// mode).
+	syncFilterDemandLocked()
 	syncLogrusLevelLocked()
 }
 
@@ -524,6 +557,7 @@ func RemoveFilter(name string) {
 	}
 	globalFilters.filters.Store(&result)
 	// Drop logrus's level back down if this filter was what held it up.
+	syncFilterDemandLocked()
 	syncLogrusLevelLocked()
 }
 
@@ -549,10 +583,10 @@ func SetLogging(logLevel log.Level) {
 	// internal level filtering: the hooks decide what is written via hookLevel. logrus's
 	// own level then only controls which entries reach the hooks, so run it at the
 	// configured level, raised just far enough for any registered RegexpFilter to see
-	// the messages it declared interest in (see logrusLevelFor).
+	// the messages it declared interest in (see deriveLevelLocked).
 	globalTransformMu.Lock()
 	if addedGlobalFilters {
-		log.SetLevel(logrusLevelFor(logLevel))
+		syncLogrusLevelLocked()
 		hookLevel := make([]log.Level, 0, len(log.AllLevels))
 
 		// Atomically get current hooks
@@ -607,8 +641,8 @@ func SetLogging(logLevel log.Level) {
 		// No hook-based gating yet: logrus's own level is the output gate.
 		// Still honor the standing floors (ring buffer, test harness) so
 		// their capture contracts hold before initFilterLogging runs; see
-		// floorLevelFor for the output-leak trade this accepts.
-		log.SetLevel(floorLevelFor(logLevel))
+		// deriveLevelLocked for the output-leak trade this accepts.
+		syncLogrusLevelLocked()
 		globalTransformMu.Unlock()
 	}
 }
@@ -616,7 +650,7 @@ func SetLogging(logLevel log.Level) {
 // GetEffectiveLogLevel returns the effective log level -- the level the
 // operator asked for, as opposed to logrus's internal log.GetLevel(),
 // which may sit temporarily above it while a registered RegexpFilter needs
-// to observe more verbose entries (see logrusLevelFor). The value is
+// to observe more verbose entries (see deriveLevelLocked). The value is
 // served from an atomic cache seeded at package init and updated only by
 // SetLogging; the hot path (LogRingBuffer.shouldBuffer, invoked on every
 // entry) is therefore a single atomic load with no mutex contention or

--- a/config/logging_unpin_test.go
+++ b/config/logging_unpin_test.go
@@ -241,8 +241,11 @@ func TestHarnessLogFloorSurvivesReinit(t *testing.T) {
 	prevEffective := GetEffectiveLogLevel()
 	prevOut := log.StandardLogger().Out
 	prevHooks := log.StandardLogger().ReplaceHooks(log.LevelHooks{})
+	var restore func()
 	t.Cleanup(func() {
-		ClearTestLogFloor()
+		if restore != nil {
+			restore()
+		}
 		log.StandardLogger().ReplaceHooks(prevHooks)
 		log.SetOutput(prevOut)
 		SetLogging(prevEffective)
@@ -252,7 +255,7 @@ func TestHarnessLogFloorSurvivesReinit(t *testing.T) {
 
 	ResetGlobalLoggingHooks()
 	log.SetOutput(io.Discard)
-	SetTestLogFloor(log.TraceLevel)
+	restore = SetTestLogFloor(log.TraceLevel)
 
 	// Simulate a mid-test InitClient/InitServer: init runs with a quiet
 	// configured level, but the harness floor must keep the gate open.
@@ -265,34 +268,48 @@ func TestHarnessLogFloorSurvivesReinit(t *testing.T) {
 	assert.Equal(t, log.TraceLevel, log.GetLevel(),
 		"the harness floor must survive SetLogging")
 
-	ClearTestLogFloor()
+	restore()
 	assert.Equal(t, log.WarnLevel, log.GetLevel(),
-		"clearing the floor must restore the configured level")
+		"withdrawing the floor must restore the configured level")
 }
 
-// The test-harness floor is a single global slot shared by nested harnesses
-// (a package-level SetupGlobalTestLogging plus per-test SetupTestLogging, or
-// parent tests with subtests), so restoring must reinstate the previous
-// floor rather than wiping it.
+// Test-harness floors are independent keyed demands, so nested or concurrent
+// harnesses (a package-level SetupGlobalTestLogging plus per-test
+// SetupTestLogging, or parallel tests) never wipe one another and their
+// restores may run in any order -- the gate always reflects the most verbose
+// demand still outstanding.
 func TestTestLogFloorNesting(t *testing.T) {
-	t.Cleanup(ClearTestLogFloor)
-	ClearTestLogFloor()
+	prevLevel := log.GetLevel()
+	prevEffective := GetEffectiveLogLevel()
+	prevOut := log.StandardLogger().Out
+	t.Cleanup(func() {
+		log.SetOutput(prevOut)
+		SetLogging(prevEffective)
+		log.SetLevel(prevLevel)
+		ResetGlobalLoggingHooks()
+	})
 
-	outerRestore := SetTestLogFloor(log.TraceLevel)
-	innerRestore := SetTestLogFloor(log.DebugLevel)
-	assert.Equal(t, log.DebugLevel, log.Level(testLogFloor.Load()))
+	ResetGlobalLoggingHooks()
+	log.SetOutput(io.Discard)
+	SetLogging(log.WarnLevel)
+
+	outerRestore := SetTestLogFloor(log.InfoLevel)
+	innerRestore := SetTestLogFloor(log.TraceLevel)
+	assert.Equal(t, log.TraceLevel, log.GetLevel(),
+		"the most verbose outstanding floor wins")
+
+	// Restore out of nesting order -- the outer (less verbose) first.
+	outerRestore()
+	assert.Equal(t, log.TraceLevel, log.GetLevel(),
+		"withdrawing a less-verbose floor leaves the more-verbose one intact")
 
 	innerRestore()
-	assert.Equal(t, log.TraceLevel, log.Level(testLogFloor.Load()),
-		"an inner harness's restore must reinstate the outer floor, not wipe it")
-
-	outerRestore()
-	assert.Equal(t, log.Level(0), log.Level(testLogFloor.Load()),
-		"the outermost restore returns to no-floor")
+	assert.Equal(t, log.WarnLevel, log.GetLevel(),
+		"with no floors outstanding the gate returns to the configured level")
 }
 
 // A filter's Levels declaration must control which entries its Fire callback
-// observes, so declaration and delivery agree (logrusLevelFor uses the same
+// observes, so declaration and delivery agree (syncFilterDemandLocked uses the same
 // declaration to decide how far the level gate opens).
 func TestRegexpFilterLevelEnforcement(t *testing.T) {
 	var declaredFired, undeclaredFired atomic.Int64

--- a/config/logging_unpin_test.go
+++ b/config/logging_unpin_test.go
@@ -1,0 +1,322 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ ***************************************************************/
+
+package config
+
+import (
+	"context"
+	"io"
+	"regexp"
+	"sync/atomic"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+// countingFormatter counts how many entries reach logrus's formatting stage.
+// A suppressed log line must never get this far.
+type countingFormatter struct{ count atomic.Int64 }
+
+func (c *countingFormatter) Format(e *log.Entry) ([]byte, error) {
+	c.count.Add(1)
+	return []byte{}, nil
+}
+
+// The hook-based filter pipeline must not pin logrus's internal level to
+// Trace: a Tracef/Debugf below the configured level has to be rejected by
+// the level gate before any entry is constructed, or hot request paths pay
+// formatting plus three global-mutex acquisitions per suppressed line.
+func TestLogrusLevelNotPinnedByFilterInit(t *testing.T) {
+	prevLevel := log.GetLevel()
+	// SetLogging writes the package-global effective-level cache, which
+	// nothing else resets -- restore it so this test's levels don't leak
+	// into whichever test runs next.
+	prevEffective := GetEffectiveLogLevel()
+	prevOut := log.StandardLogger().Out
+	prevFormatter := log.StandardLogger().Formatter
+	prevHooks := log.StandardLogger().ReplaceHooks(log.LevelHooks{})
+	t.Cleanup(func() {
+		log.StandardLogger().ReplaceHooks(prevHooks)
+		log.SetFormatter(prevFormatter)
+		log.SetOutput(prevOut)
+		SetLogging(prevEffective)
+		log.SetLevel(prevLevel)
+		ResetGlobalLoggingHooks()
+	})
+
+	ResetGlobalLoggingHooks()
+	log.SetOutput(io.Discard)
+	SetLogging(log.InfoLevel)
+	initFilterLogging()
+
+	assert.Equal(t, log.InfoLevel, log.GetLevel(),
+		"initFilterLogging must not raise logrus above the configured level when no filters are registered")
+
+	cf := &countingFormatter{}
+	log.SetFormatter(cf)
+	log.Tracef("suppressed %d", 42)
+	log.Debugf("suppressed %d", 43)
+	assert.Zero(t, cf.count.Load(),
+		"suppressed lines must not construct entries or run the formatter")
+	log.Infof("emitted %d", 44)
+	assert.Positive(t, cf.count.Load(), "lines at the configured level must still be emitted")
+
+	// A filter declaring interest in Debug raises the level while registered...
+	noop := func(*log.Entry) error { return nil }
+	AddFilter(&RegexpFilter{Name: "test_debug", Regexp: regexp.MustCompile("x"),
+		Levels: []log.Level{log.DebugLevel}, Fire: noop})
+	assert.Equal(t, log.DebugLevel, log.GetLevel(),
+		"a registered filter must raise logrus's level to what it needs to observe")
+
+	// ...and the level drops back once it is gone.
+	RemoveFilter("test_debug")
+	assert.Equal(t, log.InfoLevel, log.GetLevel(),
+		"removing the filter must restore the configured level")
+
+	// A filter that declares no levels is assumed to need everything.
+	AddFilter(&RegexpFilter{Name: "test_all", Regexp: regexp.MustCompile("x"), Fire: noop})
+	assert.Equal(t, log.TraceLevel, log.GetLevel())
+	RemoveFilter("test_all")
+	assert.Equal(t, log.InfoLevel, log.GetLevel())
+
+	// The operator-facing case that matters in production: Logging.Level set
+	// quieter than Info while the xrootd startup filters (Levels: [Info]) are
+	// registered. The gate must open to Info or startup detection hangs.
+	SetLogging(log.WarnLevel)
+	assert.Equal(t, log.WarnLevel, log.GetLevel())
+	AddFilter(&RegexpFilter{Name: "test_startup", Regexp: regexp.MustCompile("x"),
+		Levels: []log.Level{log.InfoLevel}, Fire: noop})
+	assert.Equal(t, log.InfoLevel, log.GetLevel(),
+		"an Info-needing filter must raise logrus above a Warn-configured level")
+	RemoveFilter("test_startup")
+	assert.Equal(t, log.WarnLevel, log.GetLevel())
+
+	// SetLogging keeps the derived level in sync with the configured one.
+	SetLogging(log.ErrorLevel)
+	assert.Equal(t, log.ErrorLevel, log.GetLevel())
+}
+
+// Without hook-based filtering active, filter registration must not touch
+// logrus's level: in that mode logrus's own level IS the output gate, and
+// raising it would leak filter-only lines straight to the output.
+func TestFilterRegistrationNoopWithoutHooks(t *testing.T) {
+	prevLevel := log.GetLevel()
+	prevEffective := GetEffectiveLogLevel()
+	t.Cleanup(func() {
+		SetLogging(prevEffective)
+		log.SetLevel(prevLevel)
+		ResetGlobalLoggingHooks()
+	})
+
+	ResetGlobalLoggingHooks() // addedGlobalFilters = false
+	SetLogging(log.WarnLevel)
+
+	AddFilter(&RegexpFilter{Name: "test_noop", Regexp: regexp.MustCompile("x"),
+		Levels: []log.Level{log.TraceLevel}, Fire: func(*log.Entry) error { return nil }})
+	defer RemoveFilter("test_noop")
+
+	assert.Equal(t, log.WarnLevel, log.GetLevel(),
+		"filter registration must not raise logrus's level when hook-based filtering is inactive")
+}
+
+// The log ring buffer documents an info-and-above capture floor for the
+// remote triage endpoints, so while it is installed the level gate must
+// admit info entries even under a quieter configured level.
+func TestLogRingBufferImposesInfoFloor(t *testing.T) {
+	prevLevel := log.GetLevel()
+	prevEffective := GetEffectiveLogLevel()
+	prevOut := log.StandardLogger().Out
+	prevHooks := log.StandardLogger().ReplaceHooks(log.LevelHooks{})
+	t.Cleanup(func() {
+		StopLogRingBuffer()
+		log.StandardLogger().ReplaceHooks(prevHooks)
+		log.SetOutput(prevOut)
+		SetLogging(prevEffective)
+		log.SetLevel(prevLevel)
+		ResetGlobalLoggingHooks()
+	})
+
+	ResetGlobalLoggingHooks()
+	StopLogRingBuffer() // ensure a clean slate if a prior test left one running
+	log.SetOutput(io.Discard)
+	SetLogging(log.WarnLevel)
+	assert.Equal(t, log.WarnLevel, log.GetLevel(),
+		"without the ring buffer, a warn-configured server runs logrus at warn")
+
+	// Production order: on a server, StartLogRingBuffer runs early in
+	// InitServer, well BEFORE initFilterLogging installs hook-based gating
+	// (config.go wires them in that order). The info floor must hold from
+	// the moment the ring is installed, or the startup window -- the most
+	// diagnostically valuable stretch -- is never captured.
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	StartLogRingBuffer(ctx)
+	assert.Equal(t, log.InfoLevel, log.GetLevel(),
+		"installing the ring buffer must floor the gate even before hook-based filtering is active")
+
+	initFilterLogging()
+	SetLogging(log.WarnLevel)
+	assert.Equal(t, log.InfoLevel, log.GetLevel(),
+		"the floor must hold once hook-based filtering activates")
+
+	// Re-deriving the level for any reason keeps the floor...
+	SetLogging(log.ErrorLevel)
+	assert.Equal(t, log.InfoLevel, log.GetLevel(),
+		"the floor must survive SetLogging to a quieter level")
+
+	// ...but never caps a more verbose configuration.
+	SetLogging(log.DebugLevel)
+	assert.Equal(t, log.DebugLevel, log.GetLevel())
+
+	// The floor lifts when the ring buffer is stopped.
+	SetLogging(log.ErrorLevel)
+	StopLogRingBuffer()
+	assert.Equal(t, log.ErrorLevel, log.GetLevel(),
+		"stopping the ring buffer must drop the level back to the configured one")
+}
+
+// Lifting a floor must lower logrus back to the configured level even before
+// hook-based filtering is active (the InitServer startup window, and test
+// binaries after a harness reset). Regression test for the raise-only
+// derivation bug: the non-hook sync used to derive from log.GetLevel() --
+// the already-raised value -- so no floor could ever be withdrawn.
+func TestFloorLiftsInNonHookMode(t *testing.T) {
+	prevLevel := log.GetLevel()
+	prevEffective := GetEffectiveLogLevel()
+	prevOut := log.StandardLogger().Out
+	prevHooks := log.StandardLogger().ReplaceHooks(log.LevelHooks{})
+	t.Cleanup(func() {
+		StopLogRingBuffer()
+		log.StandardLogger().ReplaceHooks(prevHooks)
+		log.SetOutput(prevOut)
+		SetLogging(prevEffective)
+		log.SetLevel(prevLevel)
+		ResetGlobalLoggingHooks()
+	})
+
+	ResetGlobalLoggingHooks() // addedGlobalFilters = false for the whole test
+	StopLogRingBuffer()
+	log.SetOutput(io.Discard)
+	SetLogging(log.WarnLevel)
+
+	// Ring-buffer floor: raised on install, lowered on stop.
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	StartLogRingBuffer(ctx)
+	assert.Equal(t, log.InfoLevel, log.GetLevel())
+	StopLogRingBuffer()
+	assert.Equal(t, log.WarnLevel, log.GetLevel(),
+		"stopping the ring buffer must lower logrus back to the configured level in non-hook mode")
+
+	// Test-harness floor: raised on declare, lowered on restore.
+	restore := SetTestLogFloor(log.TraceLevel)
+	assert.Equal(t, log.TraceLevel, log.GetLevel())
+	restore()
+	assert.Equal(t, log.WarnLevel, log.GetLevel(),
+		"restoring the test floor must lower logrus back to the configured level in non-hook mode")
+}
+
+// A test harness that forwards entries to t.Log declares a floor so that a
+// test calling InitClient/InitServer mid-test (which re-derives the level
+// from the configured value) does not silently starve its own failure
+// diagnostics.
+func TestHarnessLogFloorSurvivesReinit(t *testing.T) {
+	prevLevel := log.GetLevel()
+	prevEffective := GetEffectiveLogLevel()
+	prevOut := log.StandardLogger().Out
+	prevHooks := log.StandardLogger().ReplaceHooks(log.LevelHooks{})
+	t.Cleanup(func() {
+		ClearTestLogFloor()
+		log.StandardLogger().ReplaceHooks(prevHooks)
+		log.SetOutput(prevOut)
+		SetLogging(prevEffective)
+		log.SetLevel(prevLevel)
+		ResetGlobalLoggingHooks()
+	})
+
+	ResetGlobalLoggingHooks()
+	log.SetOutput(io.Discard)
+	SetTestLogFloor(log.TraceLevel)
+
+	// Simulate a mid-test InitClient/InitServer: init runs with a quiet
+	// configured level, but the harness floor must keep the gate open.
+	SetLogging(log.ErrorLevel)
+	initFilterLogging()
+	assert.Equal(t, log.TraceLevel, log.GetLevel(),
+		"the harness floor must survive initFilterLogging")
+
+	SetLogging(log.WarnLevel)
+	assert.Equal(t, log.TraceLevel, log.GetLevel(),
+		"the harness floor must survive SetLogging")
+
+	ClearTestLogFloor()
+	assert.Equal(t, log.WarnLevel, log.GetLevel(),
+		"clearing the floor must restore the configured level")
+}
+
+// The test-harness floor is a single global slot shared by nested harnesses
+// (a package-level SetupGlobalTestLogging plus per-test SetupTestLogging, or
+// parent tests with subtests), so restoring must reinstate the previous
+// floor rather than wiping it.
+func TestTestLogFloorNesting(t *testing.T) {
+	t.Cleanup(ClearTestLogFloor)
+	ClearTestLogFloor()
+
+	outerRestore := SetTestLogFloor(log.TraceLevel)
+	innerRestore := SetTestLogFloor(log.DebugLevel)
+	assert.Equal(t, log.DebugLevel, log.Level(testLogFloor.Load()))
+
+	innerRestore()
+	assert.Equal(t, log.TraceLevel, log.Level(testLogFloor.Load()),
+		"an inner harness's restore must reinstate the outer floor, not wipe it")
+
+	outerRestore()
+	assert.Equal(t, log.Level(0), log.Level(testLogFloor.Load()),
+		"the outermost restore returns to no-floor")
+}
+
+// A filter's Levels declaration must control which entries its Fire callback
+// observes, so declaration and delivery agree (logrusLevelFor uses the same
+// declaration to decide how far the level gate opens).
+func TestRegexpFilterLevelEnforcement(t *testing.T) {
+	var declaredFired, undeclaredFired atomic.Int64
+
+	hook := RegexpFilterHook{}
+	filters := []*RegexpFilter{
+		{Name: "declared", Regexp: regexp.MustCompile("match-me"),
+			Levels: []log.Level{log.InfoLevel},
+			Fire:   func(*log.Entry) error { declaredFired.Add(1); return nil }},
+		{Name: "undeclared", Regexp: regexp.MustCompile("match-me"),
+			Fire: func(*log.Entry) error { undeclaredFired.Add(1); return nil }},
+	}
+	hook.filters.Store(&filters)
+
+	fire := func(lvl log.Level) {
+		entry := &log.Entry{Logger: log.StandardLogger(), Level: lvl, Message: "match-me"}
+		assert.NoError(t, hook.Fire(entry))
+	}
+
+	fire(log.InfoLevel)
+	assert.Equal(t, int64(1), declaredFired.Load(), "declared level must be delivered")
+	assert.Equal(t, int64(1), undeclaredFired.Load(), "empty Levels must observe everything")
+
+	fire(log.DebugLevel)
+	assert.Equal(t, int64(1), declaredFired.Load(), "undeclared level must not be delivered")
+	assert.Equal(t, int64(2), undeclaredFired.Load(), "empty Levels must observe everything")
+}

--- a/logging/level_manager.go
+++ b/logging/level_manager.go
@@ -50,6 +50,14 @@ type (
 		cancel        context.CancelFunc
 		egrp          *errgroup.Group
 		updateCh      chan struct{}
+		// getLevel returns the operator-configured log level for Logging.Level.
+		// Injected by InitLogLevelManager (config.GetEffectiveLogLevel) so the
+		// manager compares against the configured level rather than logrus's
+		// raw level, which can sit above the configured level while a ring
+		// buffer or test-harness floor is active. Nil on the un-injected
+		// GetLogLevelManager path, where getCurrentLevel falls back to
+		// log.GetLevel().
+		getLevel func() log.Level
 	}
 )
 
@@ -88,6 +96,7 @@ func InitLogLevelManager(ctx context.Context, egrp *errgroup.Group, setFunc func
 			cancel:        cancel,
 			egrp:          egrp,
 			updateCh:      make(chan struct{}, 1),
+			getLevel:      getFunc,
 		}
 
 		globalManager.applyChanges()
@@ -374,8 +383,16 @@ func (m *LogLevelManager) getCurrentLevel(paramName string) log.Level {
 		}
 	}
 
-	// For Logging.Level, fall back to logrus current level
+	// For Logging.Level, fall back to the configured level. Prefer the
+	// injected effective-level accessor: logrus's own level can sit above the
+	// configured level while a ring-buffer or test-harness floor is active, and
+	// reading it here would make applyChanges issue a spurious param write on
+	// every base-level capture (and record the floor as the base level, which
+	// then gets written back when a temporary change expires).
 	if paramName == param.Logging_Level.GetName() {
+		if m.getLevel != nil {
+			return m.getLevel()
+		}
 		return log.GetLevel()
 	}
 

--- a/logging/level_manager_test.go
+++ b/logging/level_manager_test.go
@@ -43,6 +43,9 @@ func TestLogLevelManager_AddChange(t *testing.T) {
 	origLevel := config.GetEffectiveLogLevel()
 	defer config.SetLogging(origLevel)
 
+	// Wire the manager the way config.InitConfig does, so it reads the
+	// configured level via GetEffectiveLogLevel rather than logrus's raw level.
+	logging.InitLogLevelManager(nil, nil, config.SetLogging, config.GetEffectiveLogLevel)
 	manager := logging.GetLogLevelManager()
 	defer func() {
 		manager.Shutdown()
@@ -87,6 +90,9 @@ func TestLogLevelManager_RemoveChange(t *testing.T) {
 	origLevel := config.GetEffectiveLogLevel()
 	defer config.SetLogging(origLevel)
 
+	// Wire the manager the way config.InitConfig does, so it reads the
+	// configured level via GetEffectiveLogLevel rather than logrus's raw level.
+	logging.InitLogLevelManager(nil, nil, config.SetLogging, config.GetEffectiveLogLevel)
 	manager := logging.GetLogLevelManager()
 	defer func() {
 		manager.Shutdown()
@@ -140,6 +146,9 @@ func TestLogLevelManager_MultipleChanges(t *testing.T) {
 	origLevel := config.GetEffectiveLogLevel()
 	defer config.SetLogging(origLevel)
 
+	// Wire the manager the way config.InitConfig does, so it reads the
+	// configured level via GetEffectiveLogLevel rather than logrus's raw level.
+	logging.InitLogLevelManager(nil, nil, config.SetLogging, config.GetEffectiveLogLevel)
 	manager := logging.GetLogLevelManager()
 	defer func() {
 		manager.Shutdown()
@@ -221,6 +230,9 @@ func TestLogLevelManager_ExpiredChanges(t *testing.T) {
 	origLevel := config.GetEffectiveLogLevel()
 	defer config.SetLogging(origLevel)
 
+	// Wire the manager the way config.InitConfig does, so it reads the
+	// configured level via GetEffectiveLogLevel rather than logrus's raw level.
+	logging.InitLogLevelManager(nil, nil, config.SetLogging, config.GetEffectiveLogLevel)
 	manager := logging.GetLogLevelManager()
 	defer func() {
 		manager.Shutdown()
@@ -272,6 +284,9 @@ func TestLogLevelManager_SetBaseLevel(t *testing.T) {
 	origLevel := config.GetEffectiveLogLevel()
 	defer config.SetLogging(origLevel)
 
+	// Wire the manager the way config.InitConfig does, so it reads the
+	// configured level via GetEffectiveLogLevel rather than logrus's raw level.
+	logging.InitLogLevelManager(nil, nil, config.SetLogging, config.GetEffectiveLogLevel)
 	manager := logging.GetLogLevelManager()
 	defer func() {
 		manager.Shutdown()
@@ -326,6 +341,9 @@ func TestLogLevelManager_BackgroundExpiry(t *testing.T) {
 	origLevel := config.GetEffectiveLogLevel()
 	defer config.SetLogging(origLevel)
 
+	// Wire the manager the way config.InitConfig does, so it reads the
+	// configured level via GetEffectiveLogLevel rather than logrus's raw level.
+	logging.InitLogLevelManager(nil, nil, config.SetLogging, config.GetEffectiveLogLevel)
 	manager := logging.GetLogLevelManager()
 	defer func() {
 		manager.Shutdown()

--- a/ssh_posixv2/backend.go
+++ b/ssh_posixv2/backend.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pelicanplatform/pelican/config"
@@ -452,7 +451,7 @@ func runConnection(ctx context.Context, sessionEstablishTimeout time.Duration, c
 			AuthCookie:       authCookie,
 			Exports:          exports,
 			DirectListenMode: true,
-			LogLevel:         log.GetLevel().String(),
+			LogLevel:         config.GetEffectiveLogLevel().String(),
 		}
 		sshLog.Info("Tunnel mode: helper will listen on local port (origin dials via SSH)")
 	} else {
@@ -469,7 +468,7 @@ func runConnection(ctx context.Context, sessionEstablishTimeout time.Duration, c
 		if err != nil {
 			return errors.Wrap(err, "failed to create helper config")
 		}
-		helperConfig.LogLevel = log.GetLevel().String()
+		helperConfig.LogLevel = config.GetEffectiveLogLevel().String()
 	}
 
 	// Start the helper process.

--- a/ssh_posixv2/helper_cmd.go
+++ b/ssh_posixv2/helper_cmd.go
@@ -43,6 +43,7 @@ import (
 	"golang.org/x/net/webdav"
 	"golang.org/x/sync/errgroup"
 
+	pelican_config "github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_utils"
 )
 
@@ -120,19 +121,27 @@ func RunHelper(ctx context.Context) error {
 		return errors.Wrap(err, "failed to read helper config from stdin")
 	}
 
-	// Use JSON formatter so the origin can reliably parse our log output
-	// from stderr and relay it with structured fields (daemon=ssh-helper).
-	log.SetFormatter(&log.JSONFormatter{})
-
-	// Apply the log level from the origin, if provided
+	// Apply the log level from the origin, if provided. Route it through
+	// pelican_config.SetLogging rather than logrus's SetLevel so the
+	// effective-level cache agrees with logrus's gate in this process:
+	// the helper never runs InitClient/InitServer, so nothing else writes
+	// that cache, and consumers like the GORM logger (database/utils) pick
+	// their verbosity from it.
 	if config.LogLevel != "" {
 		if lvl, err := log.ParseLevel(config.LogLevel); err == nil {
-			log.SetLevel(lvl)
+			pelican_config.SetLogging(lvl)
 			sshLog.Debugf("Log level set to %s (from origin)", lvl)
 		} else {
 			sshLog.Warnf("Ignoring unrecognized log level %q from origin: %v", config.LogLevel, err)
 		}
 	}
+
+	// Use JSON formatter so the origin can reliably parse our log output
+	// from stderr and relay it with structured fields (daemon=ssh-helper).
+	// Must be set AFTER SetLogging above: SetLogging installs the default
+	// text formatter on its first use in a process, which would otherwise
+	// override the JSON formatter.
+	log.SetFormatter(&log.JSONFormatter{})
 
 	sshLog.Infof("Helper configured with %d exports", len(config.Exports))
 

--- a/test_utils/utils.go
+++ b/test_utils/utils.go
@@ -517,6 +517,12 @@ func SetupGlobalTestLogging() func() {
 	originalFormatter := logrus.StandardLogger().Formatter
 	originalReportCaller := logrus.StandardLogger().ReportCaller
 	globalHookEnabled.Store(true)
+	// Package-level capture wants full verbosity too, and must survive any
+	// InitClient/InitServer a TestMain performs before tests run. Declaring
+	// the floor also raises logrus's level to it, and the returned restore
+	// re-derives the level (configured value plus any remaining floors) when
+	// the cleanup runs -- no manual save/restore of the raw level.
+	restoreFloor := config.SetTestLogFloor(logrus.TraceLevel)
 
 	globalLogMu.Lock()
 	globalLogBuffer.Reset()
@@ -532,6 +538,7 @@ func SetupGlobalTestLogging() func() {
 		logrus.StandardLogger().ReplaceHooks(originalHooks)
 		logrus.SetFormatter(originalFormatter)
 		logrus.SetReportCaller(originalReportCaller)
+		restoreFloor()
 	}
 }
 
@@ -562,6 +569,19 @@ func SetupTestLogging(t testing.TB) func() {
 	logrus.SetOutput(io.Discard)
 	logrus.StandardLogger().ReplaceHooks(make(logrus.LevelHooks))
 	logrus.SetReportCaller(true)
+	// The test hook wants to observe every entry regardless of the configured
+	// level: tests assert on debug/trace lines, and TestLogHook forwards
+	// entries to t.Log so failing tests carry their diagnostics. Production
+	// code no longer pins logrus to TraceLevel (see config.initFilterLogging),
+	// so the harness must request the verbosity itself -- and must declare it
+	// as a floor, or a test that calls InitClient/InitServer would re-derive
+	// the level from the configured value and silently starve the hook for
+	// the rest of the test. Declaring the floor raises logrus's level; the
+	// returned restore re-derives it (configured value plus any remaining
+	// floors) on cleanup. Keep the restore rather than clearing: a
+	// package-level SetupGlobalTestLogging (or a parent test) may own an
+	// outer floor that this per-test harness must reinstate, not wipe.
+	restoreFloor := config.SetTestLogFloor(logrus.TraceLevel)
 	hook := NewTestLogHook(t)
 	logrus.AddHook(hook)
 
@@ -583,6 +603,7 @@ func SetupTestLogging(t testing.TB) func() {
 		logrus.StandardLogger().ReplaceHooks(originalHooks)
 		logrus.SetFormatter(originalFormatter)
 		logrus.SetReportCaller(originalReportCaller)
+		restoreFloor()
 		globalHookEnabled.Store(previousGlobalHookState)
 	}
 }

--- a/web_ui/logging_api_test.go
+++ b/web_ui/logging_api_test.go
@@ -84,6 +84,10 @@ func TestHandleSetLogLevel(t *testing.T) {
 	})
 
 	router := setupLoggingRouter()
+	// Wire the manager the way config.InitConfig does, so getCurrentLevel reads
+	// the configured level via GetEffectiveLogLevel rather than logrus's raw
+	// (floor-raised) level.
+	logging.InitLogLevelManager(nil, nil, config.SetLogging, config.GetEffectiveLogLevel)
 	manager := logging.GetLogLevelManager()
 	defer manager.Shutdown()
 
@@ -197,6 +201,10 @@ func TestHandleGetLogLevel(t *testing.T) {
 	})
 
 	router := setupLoggingRouter()
+	// Wire the manager the way config.InitConfig does, so getCurrentLevel reads
+	// the configured level via GetEffectiveLogLevel rather than logrus's raw
+	// (floor-raised) level.
+	logging.InitLogLevelManager(nil, nil, config.SetLogging, config.GetEffectiveLogLevel)
 	manager := logging.GetLogLevelManager()
 	defer manager.Shutdown()
 
@@ -273,6 +281,10 @@ func TestHandleDeleteLogLevel(t *testing.T) {
 	})
 
 	router := setupLoggingRouter()
+	// Wire the manager the way config.InitConfig does, so getCurrentLevel reads
+	// the configured level via GetEffectiveLogLevel rather than logrus's raw
+	// (floor-raised) level.
+	logging.InitLogLevelManager(nil, nil, config.SetLogging, config.GetEffectiveLogLevel)
 	manager := logging.GetLogLevelManager()
 	defer manager.Shutdown()
 
@@ -341,6 +353,10 @@ func TestLogLevelIntegration(t *testing.T) {
 	})
 
 	router := setupLoggingRouter()
+	// Wire the manager the way config.InitConfig does, so getCurrentLevel reads
+	// the configured level via GetEffectiveLogLevel rather than logrus's raw
+	// (floor-raised) level.
+	logging.InitLogLevelManager(nil, nil, config.SetLogging, config.GetEffectiveLogLevel)
 	manager := logging.GetLogLevelManager()
 	defer manager.Shutdown()
 

--- a/web_ui/ui_unix_test.go
+++ b/web_ui/ui_unix_test.go
@@ -51,6 +51,13 @@ func TestDoReload(t *testing.T) {
 	require.NoError(t, param.Server_UIPasswordFile.Set(passwordFile))
 	hook := test.NewGlobal()
 
+	// This test asserts on Debug-level entries; logrus no longer runs above
+	// the configured level (see config.initFilterLogging), so request the
+	// verbosity explicitly.
+	prevLevel := logrus.GetLevel()
+	logrus.SetLevel(logrus.DebugLevel)
+	t.Cleanup(func() { logrus.SetLevel(prevLevel) })
+
 	// Without a authdb set up, it should return nil with log message
 	err := doReload()
 	require.NoError(t, err)


### PR DESCRIPTION
On a local director with simulated prod ads it appears the two biggest areas of improvement to speeding up the director is:

**Bug**: We paid to generate and format all logs, even if we threw them away.

The initial logging gate was hardcoded to the lowest level so that the consumers could see all the logs and do their own gating. This resulted in expensive locks on the global mutex for logs that were never consumed by consumers that had their own gates set to higher log levels.

The fix acknowledges that we know the log levels that are set for the consumers at the beginning so we can set the initial gate to the lowest log level of the consumers preventing unneeded locks for logs that are lower.

Current logs in Director redirect hot path that we paid for but didn't use:


Suppressed log call | Location | Count / redirect | Mutex acquisitions | ~Cost each
-- | -- | -- | -- | --
"Skipping '%s' server — filtered/downtime" | sort.go:166 (now ad_index.go:136) | K (per filtered server; 5–10 typical) | 3K | ~4µs
"Request %s requires features %v" | sort.go:377 | 1 | 3 | ~4µs
"will skip origin stats" | stat.go:642 | 2 (fn runs twice) | 6 | ~4µs
"will skip cache stats" | stat.go:647 | 2 (fn runs twice) | 6 | ~4µs
"Sorting caches for request %s" | sort.go:503 | 1 | 3 | ~4µs
"Grabbing coordinate from rand-assignment cache" / "Overriding Geolocation" | sort_utilities.go:506 / 478 | 0–1 | 0–3 | ~4µs
Total wasted |   | ~7 + K ≈ 12–17 | ~36–51 | ~50–70µs
