### PR TITLE
client: make PelicanFS honor transfer options, and quiet the checksum fallback path

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -622,6 +622,11 @@ func createAllChecksumHashes() (writers []io.Writer, types []ChecksumType) {
 	return
 }
 
+// checksumFallbacksSeen tracks which fallback checksum algorithms have
+// already produced a warning this process, so repeated fallbacks (one per
+// transfer in bulk workloads) log at debug level instead.
+var checksumFallbacksSeen sync.Map
+
 // verifyTransferChecksums compares server-provided checksums against locally-computed ones.
 //
 // It tries to match any server-provided checksum against the computed values. If the match
@@ -666,9 +671,20 @@ func verifyTransferChecksums(
 			return false, error_codes.NewTransfer_ChecksumMismatchError(mismatchErr)
 		}
 		if !requestedSet[serverCk.Algorithm] {
-			log.WithFields(fields).Warnf(
-				"Requested checksum type(s) not provided by server; verified transfer using %s instead",
-				HttpDigestFromChecksum(serverCk.Algorithm))
+			// This fires for every transfer against a server that lacks the
+			// requested digest (e.g. an origin that only computes MD5 when
+			// CRC32C was requested) -- warn once per process per algorithm,
+			// then drop to debug so bulk workloads aren't flooded.
+			if _, seen := checksumFallbacksSeen.LoadOrStore(serverCk.Algorithm, struct{}{}); !seen {
+				log.WithFields(fields).Warnf(
+					"Requested checksum type(s) not provided by server; verified transfer using %s instead"+
+						" (subsequent fallbacks will be logged at debug level)",
+					HttpDigestFromChecksum(serverCk.Algorithm))
+			} else {
+				log.WithFields(fields).Debugf(
+					"Requested checksum type(s) not provided by server; verified transfer using %s instead",
+					HttpDigestFromChecksum(serverCk.Algorithm))
+			}
 		} else {
 			log.WithFields(fields).Debugf("Checksum %s matches: %s",
 				HttpDigestFromChecksum(serverCk.Algorithm),

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -627,15 +627,52 @@ func createAllChecksumHashes() (writers []io.Writer, types []ChecksumType) {
 // transfer in bulk workloads) log at debug level instead.
 var checksumFallbacksSeen sync.Map
 
+// serviceDigests remembers, per object-server host, which digest algorithms
+// the service most recently reported. When the caller requests no specific
+// checksum types, verification defaults to what this service is known to
+// provide; first contact still asks for the platform default (crc32c).
+var serviceDigests sync.Map // string (host) -> []ChecksumType
+
+// rememberServiceDigests records the digest algorithms a service reported so
+// later transfers to it can default their verification accordingly.
+func rememberServiceDigests(host string, infos []ChecksumInfo) {
+	if host == "" || len(infos) == 0 {
+		return
+	}
+	types := make([]ChecksumType, 0, len(infos))
+	for _, info := range infos {
+		types = append(types, info.Algorithm)
+	}
+	serviceDigests.Store(host, types)
+}
+
+// defaultChecksumTypesForService returns the checksum types to verify against
+// when the caller requested none: the set this service last reported, falling
+// back to the global default for services we have not heard from yet.
+func defaultChecksumTypesForService(host string) []ChecksumType {
+	if v, ok := serviceDigests.Load(host); ok {
+		if types, ok := v.([]ChecksumType); ok && len(types) > 0 {
+			return types
+		}
+	}
+	return []ChecksumType{AlgDefault}
+}
+
 // verifyTransferChecksums compares server-provided checksums against locally-computed ones.
 //
 // It tries to match any server-provided checksum against the computed values. If the match
 // is for a type the client didn't explicitly request (e.g., the server returned MD5 when
 // CRC32C was requested), a warning is logged about the fallback. Returns whether verification
 // succeeded and any error (e.g., checksum mismatch or missing required checksum).
+// quietFallbacks names algorithms whose use in place of the requested ones
+// should not be reported as a surprise: the caller expressed no preference
+// and this service is already known to provide these digests. It affects
+// logging only -- verification itself is unchanged, as is the set of
+// algorithms reported back to the caller in ClientChecksums.
 func verifyTransferChecksums(
 	allComputed map[ChecksumType][]byte,
 	requestedTypes []ChecksumType,
+	quietFallbacks []ChecksumType,
 	serverChecksums []ChecksumInfo,
 	requireChecksum bool,
 	fields log.Fields,
@@ -654,6 +691,10 @@ func verifyTransferChecksums(
 	for _, t := range requestedTypes {
 		requestedSet[t] = true
 	}
+	quietSet := make(map[ChecksumType]bool, len(quietFallbacks))
+	for _, t := range quietFallbacks {
+		quietSet[t] = true
+	}
 
 	for _, serverCk := range serverChecksums {
 		clientVal, ok := allComputed[serverCk.Algorithm]
@@ -671,6 +712,14 @@ func verifyTransferChecksums(
 			return false, error_codes.NewTransfer_ChecksumMismatchError(mismatchErr)
 		}
 		if !requestedSet[serverCk.Algorithm] {
+			if quietSet[serverCk.Algorithm] {
+				// Not what we asked for, but what this service is known to
+				// provide, and the caller expressed no preference.
+				log.WithFields(fields).Debugf("Checksum %s matches: %s",
+					HttpDigestFromChecksum(serverCk.Algorithm),
+					checksumValueToHttpDigest(serverCk.Algorithm, serverCk.Value))
+				return true, nil
+			}
 			// This fires for every transfer against a server that lacks the
 			// requested digest (e.g. an origin that only computes MD5 when
 			// CRC32C was requested) -- warn once per process per algorithm,
@@ -3728,6 +3777,7 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 			// entries from a failed prestage API call, or len(transferUrls),
 			// which is pre-allocated and may contain nil entries for unattempted URLs.
 			gotChecksum := false
+			checksumHost := ""
 			// Iterate through the various sources to fetch the checksums, starting with the successful one.
 			for idx := 0; idx < downloadAttemptCount; idx++ {
 				url := transferUrls[downloadAttemptCount-idx-1]
@@ -3743,6 +3793,8 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 				if checksums, err := fetchChecksum(ctx, KnownChecksumTypes(), url, tokenContents, transfer.project); err == nil {
 					transferResults.ServerChecksums = checksums
 					gotChecksum = true
+					checksumHost = url.Host
+					rememberServiceDigests(url.Host, checksums)
 				}
 			}
 			if !gotChecksum && transfer.requireChecksum {
@@ -3757,8 +3809,13 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 
 			// Populate ClientChecksums with the originally-requested types for backward compatibility
 			requestedTypes := transfer.requestedChecksums
+			var quietFallbacks []ChecksumType
 			if len(requestedTypes) == 0 {
 				requestedTypes = []ChecksumType{AlgDefault}
+				// The caller asked for nothing in particular, so a digest
+				// this service is known to provide is not a surprise worth
+				// warning about.
+				quietFallbacks = defaultChecksumTypesForService(checksumHost)
 			}
 			transferResults.ClientChecksums = make([]ChecksumInfo, 0, len(requestedTypes))
 			for _, t := range requestedTypes {
@@ -3777,7 +3834,7 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 				"job": transfer.job.ID(),
 			}
 			if _, verifyErr := verifyTransferChecksums(
-				allComputed, requestedTypes, transferResults.ServerChecksums,
+				allComputed, requestedTypes, quietFallbacks, transferResults.ServerChecksums,
 				transfer.requireChecksum, fields,
 			); verifyErr != nil {
 				transferResults.Error = verifyErr
@@ -5263,6 +5320,7 @@ Loop:
 			}
 		} else {
 			transferResult.ServerChecksums = result
+			rememberServiceDigests(dest.Host, result)
 		}
 
 		// Build map of all computed checksums for verification
@@ -5273,8 +5331,13 @@ Loop:
 
 		// Populate ClientChecksums with the originally-requested types for backward compatibility
 		requestedTypes := transfer.requestedChecksums
+		var quietFallbacks []ChecksumType
 		if len(requestedTypes) == 0 {
 			requestedTypes = []ChecksumType{AlgDefault}
+			// The caller asked for nothing in particular, so a digest this
+			// service is known to provide is not a surprise worth warning
+			// about.
+			quietFallbacks = defaultChecksumTypesForService(dest.Host)
 		}
 		transferResult.ClientChecksums = make([]ChecksumInfo, 0, len(requestedTypes))
 		for _, t := range requestedTypes {
@@ -5292,7 +5355,7 @@ Loop:
 			"job": transfer.job.ID(),
 		}
 		if _, verifyErr := verifyTransferChecksums(
-			allComputed, requestedTypes, transferResult.ServerChecksums,
+			allComputed, requestedTypes, quietFallbacks, transferResult.ServerChecksums,
 			transfer.requireChecksum, fields,
 		); verifyErr != nil {
 			transferResult.Error = verifyErr

--- a/client/pelican_fs.go
+++ b/client/pelican_fs.go
@@ -312,8 +312,11 @@ func (pf *PelicanFile) startTransferRead(p []byte) (int, error) {
 	pf.transferStarted = true
 	pf.transferOffset = 0
 
-	// Create a transfer job with the pipe writer
-	tj, err := pf.transferClient.NewTransferJob(pf.ctx, pf.pUrl.GetRawUrl(), "", false, false, WithWriter(pw))
+	// Create a transfer job with the pipe writer, forwarding the
+	// filesystem-level transfer options (checksum preferences, etc.).
+	opts := append([]TransferOption{}, pf.options...)
+	opts = append(opts, WithWriter(pw))
+	tj, err := pf.transferClient.NewTransferJob(pf.ctx, pf.pUrl.GetRawUrl(), "", false, false, opts...)
 	if err != nil {
 		pw.Close()
 		return 0, err
@@ -556,8 +559,11 @@ func (pf *PelicanFile) startTransferWrite() error {
 	pf.transferStarted = true
 	pf.writePosition = 0
 
-	// Create a transfer job with the pipe reader
-	tj, err := pf.transferClient.NewTransferJob(pf.ctx, pf.pUrl.GetRawUrl(), "", true, false, WithReader(pr))
+	// Create a transfer job with the pipe reader, forwarding the
+	// filesystem-level transfer options (checksum preferences, etc.).
+	opts := append([]TransferOption{}, pf.options...)
+	opts = append(opts, WithReader(pr))
+	tj, err := pf.transferClient.NewTransferJob(pf.ctx, pf.pUrl.GetRawUrl(), "", true, false, opts...)
 	if err != nil {
 		pr.Close()
 		pw.Close()

--- a/client/service_digests_test.go
+++ b/client/service_digests_test.go
@@ -1,0 +1,53 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestServiceDigestDefaults verifies that per-service digest memory drives
+// the default verification set: unknown services get the platform default
+// (CRC32C), while services that previously reported digests get those.
+func TestServiceDigestDefaults(t *testing.T) {
+	// Unknown service: platform default.
+	assert.Equal(t, []ChecksumType{AlgDefault}, defaultChecksumTypesForService("origin-a.example.com:8443"))
+
+	// A service that reported MD5 becomes the default for that service only.
+	rememberServiceDigests("origin-a.example.com:8443", []ChecksumInfo{
+		{Algorithm: AlgMD5, Value: []byte{0x01}},
+	})
+	assert.Equal(t, []ChecksumType{AlgMD5}, defaultChecksumTypesForService("origin-a.example.com:8443"))
+	assert.Equal(t, []ChecksumType{AlgDefault}, defaultChecksumTypesForService("origin-b.example.com:8443"))
+
+	// A later report (e.g. after a server upgrade) replaces the remembered set.
+	rememberServiceDigests("origin-a.example.com:8443", []ChecksumInfo{
+		{Algorithm: AlgCRC32C, Value: []byte{0x02}},
+		{Algorithm: AlgMD5, Value: []byte{0x03}},
+	})
+	assert.Equal(t, []ChecksumType{AlgCRC32C, AlgMD5}, defaultChecksumTypesForService("origin-a.example.com:8443"))
+
+	// Empty reports and empty hosts must not poison the cache.
+	rememberServiceDigests("origin-a.example.com:8443", nil)
+	assert.Equal(t, []ChecksumType{AlgCRC32C, AlgMD5}, defaultChecksumTypesForService("origin-a.example.com:8443"))
+	rememberServiceDigests("", []ChecksumInfo{{Algorithm: AlgSHA1}})
+	assert.Equal(t, []ChecksumType{AlgDefault}, defaultChecksumTypesForService(""))
+}

--- a/client/service_digests_test.go
+++ b/client/service_digests_test.go
@@ -19,9 +19,22 @@
 package client
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/pelican_url"
+	"github.com/pelicanplatform/pelican/test_utils"
 )
 
 // TestServiceDigestDefaults verifies that per-service digest memory drives
@@ -50,4 +63,110 @@ func TestServiceDigestDefaults(t *testing.T) {
 	assert.Equal(t, []ChecksumType{AlgCRC32C, AlgMD5}, defaultChecksumTypesForService("origin-a.example.com:8443"))
 	rememberServiceDigests("", []ChecksumInfo{{Algorithm: AlgSHA1}})
 	assert.Equal(t, []ChecksumType{AlgDefault}, defaultChecksumTypesForService(""))
+}
+
+// TestChecksumFallbackWarningQuietUnrequested covers the symptom reported in
+// issue #3614: a plain `pelican object get` against a server that computes
+// only MD5 warned "Requested checksum type(s) not provided by server" on
+// every transfer, even though the caller never asked for a particular digest
+// and could do nothing about the answer.
+//
+// The two cases are deliberately contrasted. A caller who asked for nothing
+// gets no warning at all -- including on first contact, since the service's
+// digests are remembered before the verification decision is made. A caller
+// who explicitly asked for CRC32C still learns it did not get it, but only
+// once per process rather than once per object.
+func TestChecksumFallbackWarningQuietUnrequested(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	test_utils.InitClient(t, map[param.Param]any{
+		param.Logging_Level: "debug",
+	})
+
+	// MD5 of "test file content", base64-encoded per RFC 3230.
+	const correctMD5Base64 = "x4UGDIZnlswqFwjJlxVMjg=="
+	const body = "test file content"
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", "17")
+			// This server computes only MD5, whatever was asked for.
+			w.Header().Set("Digest", "md5="+correctMD5Base64)
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			w.Header().Set("Content-Length", "17")
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(body))
+			assert.NoError(t, err)
+		default:
+			t.Fatal("Unexpected method:", r.Method)
+		}
+	}))
+	defer svr.Close()
+	svrURL, err := url.Parse(svr.URL)
+	require.NoError(t, err)
+
+	newTransfer := func(requested []ChecksumType) *transferFile {
+		return &transferFile{
+			xferType: transferTypeDownload,
+			ctx:      context.Background(),
+			job: &TransferJob{
+				remoteURL: &pelican_url.PelicanURL{
+					Scheme: "pelican://",
+					Host:   svrURL.Host,
+					Path:   svrURL.Path + "/test.txt",
+				},
+			},
+			localPath:          os.DevNull,
+			remoteURL:          svrURL,
+			attempts:           []transferAttemptDetails{{Url: svrURL}},
+			requestedChecksums: requested,
+		}
+	}
+
+	fallbackWarnings := func(entries []*logrus.Entry) (n int) {
+		for _, entry := range entries {
+			if entry.Level == logrus.WarnLevel &&
+				strings.Contains(entry.Message, "not provided by server") {
+				n++
+			}
+		}
+		return
+	}
+
+	// Both the per-service digest memory and the warn-once memory are
+	// process-wide, so clear this server's entries before each case: neither
+	// assertion may pass merely because an earlier test primed them.
+	reset := func() {
+		checksumFallbacksSeen.Delete(AlgMD5)
+		serviceDigests.Delete(svrURL.Host)
+	}
+
+	t.Run("unrequested is silent", func(t *testing.T) {
+		reset()
+		hook := logrustest.NewGlobal()
+		defer hook.Reset()
+
+		results, err := downloadObject(newTransfer(nil))
+		require.NoError(t, err)
+		require.NoError(t, results.Error, "MD5 should still verify the transfer")
+
+		assert.Zero(t, fallbackWarnings(hook.AllEntries()),
+			"a caller that requested no checksum type must not be warned about the one it got")
+	})
+
+	t.Run("explicit request warns once", func(t *testing.T) {
+		reset()
+		hook := logrustest.NewGlobal()
+		defer hook.Reset()
+
+		for range 2 {
+			results, err := downloadObject(newTransfer([]ChecksumType{AlgCRC32C}))
+			require.NoError(t, err)
+			require.NoError(t, results.Error, "MD5 should still verify the transfer")
+		}
+
+		assert.Equal(t, 1, fallbackWarnings(hook.AllEntries()),
+			"a caller that asked for CRC32C should be told once, not once per object")
+	})
 }

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -53,7 +53,9 @@ acc.authdb {{.Cache.RunLocation}}/authfile-cache-generated
 acc.authrefresh {{.Xrootd.AuthRefreshInterval}}
 ofs.authlib ++ libXrdAccSciTokens.so config={{.Cache.RunLocation}}/scitokens-cache-generated.cfg
 all.export {{.Cache.ExportLocation}}
-xrootd.chksum max 2 md5 adler32 crc32 crc32c
+# crc32c first: XRootD treats the leading algorithm as its default digest,
+# and crc32c is the platform preference (matching the Go origin and client).
+xrootd.chksum max 2 crc32c md5 adler32 crc32
 xrd.sched maxt {{.Xrootd.MaxThreads}}
 xrootd.trace emsg login stall redirect
 xrootd.tls all

--- a/xrootd/resources/xrootd-origin.cfg
+++ b/xrootd/resources/xrootd-origin.cfg
@@ -171,8 +171,11 @@ xrootd.export /.well-known
 http.exthandler xrdpelican libXrdHttpPelican.so
 xrootd.fslib ++ throttle  # throttle plugin is needed to calculate server IO load
 {{- if not .Origin.Multiuser}}
-xrootd.chksum max 10 md5 adler32 crc32 crc32c
+# crc32c first: XRootD treats the leading algorithm as its default digest,
+# and crc32c is the platform preference (matching the Go origin and client).
+xrootd.chksum max 10 crc32c md5 adler32 crc32
 {{- else}}
+# The multiuser checksum path does not support crc32c; md5 stays the default.
 xrootd.chksum max 10 md5 adler32 crc32
 {{- end}}
 xrd.sched maxt {{.Xrootd.MaxThreads}}


### PR DESCRIPTION
Fixes #3614.

Split out of #3625, which collected a batch of client and director fixes found while running a FUSE filesystem on top of the client library. This PR is the checksum subset, rebased onto `main` and independent of the rest.

### The load-bearing bug

`PelicanFS` never forwarded its transfer options to the transfer jobs its read and write paths create. Options passed to `NewPelicanFS` were stored on the file handle and then ignored, so *any* job-level option silently did nothing for a `PelicanFS` transfer. Checksums are just how I noticed — `WithRequestChecksums` had no effect.

### Two logging fixes — these are #3614

The reporter's complaint was precise: *"I didn't actually request any sort of checksum, and there isn't anything I can do about what the server provides, so this message is just an annoyance."* Both halves of that are addressed.

The "requested checksum type not provided by server" warning fired on every transfer against a server computing a different digest — one line per object moved, which for a bulk workload is a flood. It's now warned once per algorithm per process, then debug.

And when the caller requests no particular digest, the client now remembers what each object server actually reported and stops treating that as a surprise on subsequent transfers to the same service; first contact still asks for CRC32C. That only changes the logging decision — verification and `TransferResults.ClientChecksums` are untouched, and `ClientChecksums` still reports the algorithm the caller asked for even when the server answers with another.

Note the ordering that makes this quiet on the *first* transfer too, not just repeats: a service's reported digests are remembered before the verification decision reads them, so the reporter's very first `pelican object get` is silent. A caller who *does* explicitly ask for CRC32C is still told it didn't get CRC32C — once per process rather than once per object.

### A config change

XRootD treats the first algorithm in `xrootd.chksum` as its default — the one reported when a client expresses no preference — and ours was `md5`, even though CRC32C is what the Go origin defaults to (`Origin.DefaultChecksumTypes`) and what the client asks for first. Moved `crc32c` to the front for non-multiuser origins and for caches. The multiuser checksum path doesn't support crc32c, so that line is unchanged, and anything explicitly asking for adler32 or md5 still negotiates it via `Want-Digest`.

Worth flagging for deployment: existing objects on upgraded origins won't have crc32c precomputed, so the first query on a large pre-existing file pays a full read — the same cost md5 pays today on first query.

Note also which of the two commits actually closes #3614 for a CLI user: the per-service default does. `pelican object get` takes no checksum flag at all — `requestedChecksums` is always empty there, which is exactly why the reporter could say "I didn't actually request any sort of checksum" — and each invocation is a fresh process, so warn-once-per-process on its own would still print on every `get`. Warn-once matters for the long-lived cases (plugin mode, a filesystem), not for the reported one.

### Verified against a built client

Beyond the unit tests, I built the client from this branch and from `origin/main` and ran both against the same stand-in for the reporter's setup: a directorless federation whose origin computes only MD5, serving one object.

```
$ pelican object get pelican://$HOST/test/hello.txt ./out.txt     # x3, separate processes

origin/main            run 1: warnings=1  content=ok
                       run 2: warnings=1  content=ok
                       run 3: warnings=1  content=ok
                       => 3 warnings across 3 invocations

this branch            run 1: warnings=0  content=ok
                       run 2: warnings=0  content=ok
                       run 3: warnings=0  content=ok
                       => 0 warnings across 3 invocations
```

On `origin/main` each run emits the reported line verbatim:

> `level=warning msg="Requested checksum type(s) not provided by server; verified transfer using md5 instead"`

On this branch that line is gone and the verification still happens, at debug:

> `level=debug msg="Checksum md5 matches: k5jwCMw/p0NebBet84YohA=="`

Both binaries download identical, correct content.

### Testing

`TestServiceDigestDefaults` covers the per-service digest defaults. `TestChecksumFallbackWarningQuietUnrequested` covers #3614 end to end through `downloadObject`, contrasting the two cases that must stay distinct (requested-nothing is silent; explicitly-requested still warns, exactly once). I checked it isn't vacuous by disabling the quiet path and confirming that exactly the unrequested subtest fails while the warn-once subtest stays green. The existing checksum suite passes.

One note for reviewers: on my macOS box the federation-backed `xrootd` tests fail against a clean `origin/main` checkout too (I verified against a pristine baseline in the same worktree — same failure, same place), so they're environmental here rather than anything this branch did. CI is the arbiter.
