### PR TITLE
client: key the director-response cache by the question asked, and reuse it everywhere

### DIFF
--- a/client/dir_resp_cache.go
+++ b/client/dir_resp_cache.go
@@ -21,6 +21,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"path"
 	"strings"
@@ -31,6 +32,64 @@ import (
 
 	"github.com/pelicanplatform/pelican/server_structs"
 )
+
+// DirRespFlavor identifies which question was put to the director.  A
+// response answers exactly one of them and must never be handed to a caller
+// who asked another: the object servers for a read are caches, for a write
+// the origins that accept it, and for a ?directread read the origins again.
+// Answering a writer with a read's response would both address the write to
+// caches that reject it and disclose the write credential to every one of
+// them -- the thing the rest of the client is careful not to do.
+type DirRespFlavor struct {
+	// Verb is the HTTP method the director was asked about: GET for a
+	// read, PUT for a write, COPY for a third-party copy destination.
+	Verb string
+	// CacheMode routes the query through the director's origin endpoint,
+	// which answers with origins instead of caches.  Set by callers that
+	// are themselves a cache.
+	CacheMode bool
+	// Query is the normalized query string of the object URL.  Parameters
+	// including directread and prefercached steer matchmaking, so a
+	// response obtained under one set does not answer for another.
+	Query string
+}
+
+// NewDirRespFlavor builds a flavor from the verb, the cache-embedded-client
+// mode, and the object URL's raw query.  The query is normalized so that
+// orderings of the same parameters share one entry.
+func NewDirRespFlavor(verb string, cacheMode bool, rawQuery string) DirRespFlavor {
+	if verb == "" {
+		verb = http.MethodGet
+	}
+	return DirRespFlavor{Verb: verb, CacheMode: cacheMode, Query: normalizeQuery(rawQuery)}
+}
+
+// normalizeQuery sorts a raw query string so equivalent orderings agree.
+// An unparsable query is kept verbatim: it then keys only itself, which
+// is the safe direction.
+func normalizeQuery(rawQuery string) string {
+	if rawQuery == "" {
+		return ""
+	}
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return rawQuery
+	}
+	return values.Encode()
+}
+
+// String renders the flavor for use inside a cache key.
+func (f DirRespFlavor) String() string {
+	routing := "via-caches"
+	if f.CacheMode {
+		routing = "via-origins"
+	}
+	verb := f.Verb
+	if verb == "" {
+		verb = http.MethodGet
+	}
+	return verb + " " + routing + " " + f.Query
+}
 
 // dirRespCacheEntry is a single cached director response with an expiry.
 type dirRespCacheEntry struct {
@@ -139,10 +198,12 @@ func reconstitutePaths(resp server_structs.DirectorResponse, objectPath string) 
 }
 
 // cacheKey qualifies a namespace prefix with the federation it was learned
-// from.  Neither a discovery endpoint nor a path can contain a newline, so one
-// federation's entries cannot be made to answer for another's.
-func cacheKey(federation, prefix string) string {
-	return federation + "\n" + prefix
+// from and the flavor of question that produced it.  None of a discovery
+// endpoint, a rendered flavor, or a path can contain a newline, so one
+// federation's entries cannot be made to answer for another's, nor one
+// flavor's for another's.
+func cacheKey(federation string, flavor DirRespFlavor, prefix string) string {
+	return federation + "\n" + flavor.String() + "\n" + prefix
 }
 
 // Store saves a DirectorResponse under the given prefix within federation.  Any
@@ -159,7 +220,7 @@ func cacheKey(federation, prefix string) string {
 // that was used to obtain this response from the director.  It is
 // stripped from each ObjectServer URL so the cached entry contains
 // only the server-side base path.  Pass "" if no stripping is needed.
-func (c *DirRespCache) Store(federation string, prefix string, objectPath string, resp server_structs.DirectorResponse) {
+func (c *DirRespCache) Store(federation string, flavor DirRespFlavor, prefix string, objectPath string, resp server_structs.DirectorResponse) {
 	prefix = path.Clean(prefix)
 	if !strings.HasPrefix(prefix, "/") {
 		log.Debugf("DirRespCache: skipping non-absolute prefix %q", prefix)
@@ -173,11 +234,11 @@ func (c *DirRespCache) Store(federation string, prefix string, objectPath string
 	resp = stripFederationPaths(resp, objectPath)
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.entries[cacheKey(federation, prefix)] = dirRespCacheEntry{
+	c.entries[cacheKey(federation, flavor, prefix)] = dirRespCacheEntry{
 		resp:   resp,
 		expiry: time.Now().Add(c.ttl),
 	}
-	log.Debugf("DirRespCache: stored entry for prefix %q in federation %q (TTL %s)", prefix, federation, c.ttl)
+	log.Debugf("DirRespCache: stored entry for prefix %q in federation %q, flavor %q (TTL %s)", prefix, federation, flavor, c.ttl)
 }
 
 // Lookup finds the longest cached prefix within federation that matches
@@ -189,7 +250,7 @@ func (c *DirRespCache) Store(federation string, prefix string, objectPath string
 //
 // Returns the cached DirectorResponse and true if a valid (non-expired)
 // entry was found, or the zero value and false otherwise.
-func (c *DirRespCache) Lookup(federation string, objectPath string) (server_structs.DirectorResponse, bool) {
+func (c *DirRespCache) Lookup(federation string, flavor DirRespFlavor, objectPath string) (server_structs.DirectorResponse, bool) {
 	objectPath = path.Clean(objectPath)
 	if federation == "" {
 		return server_structs.DirectorResponse{}, false
@@ -203,9 +264,9 @@ func (c *DirRespCache) Lookup(federation string, objectPath string) (server_stru
 	// for the longest matching prefix within this federation.
 	candidate := objectPath
 	for {
-		if entry, ok := c.entries[cacheKey(federation, candidate)]; ok {
+		if entry, ok := c.entries[cacheKey(federation, flavor, candidate)]; ok {
 			if now.Before(entry.expiry) {
-				log.Debugf("DirRespCache: hit for path %q → prefix %q", objectPath, candidate)
+				log.Debugf("DirRespCache: hit for path %q (flavor %q) → prefix %q", objectPath, flavor, candidate)
 				return reconstitutePaths(entry.resp, objectPath), true
 			}
 			// Entry expired — don't return it, but continue looking
@@ -221,7 +282,7 @@ func (c *DirRespCache) Lookup(federation string, objectPath string) (server_stru
 		candidate = parent
 	}
 
-	log.Debugf("DirRespCache: miss for path %q", objectPath)
+	log.Debugf("DirRespCache: miss for path %q (flavor %q)", objectPath, flavor)
 	return server_structs.DirectorResponse{}, false
 }
 
@@ -241,16 +302,17 @@ type DirRespLoader func(ctx context.Context) (resp server_structs.DirectorRespon
 //
 // On success the response is automatically stored in the cache under
 // the prefix returned by the loader.
-func (c *DirRespCache) LookupOrLoad(ctx context.Context, federation string, objectPath string, loader DirRespLoader) (server_structs.DirectorResponse, error) {
+func (c *DirRespCache) LookupOrLoad(ctx context.Context, federation string, flavor DirRespFlavor, objectPath string, loader DirRespLoader) (server_structs.DirectorResponse, error) {
 	// Fast path: cache hit.
-	if resp, ok := c.Lookup(federation, objectPath); ok {
+	if resp, ok := c.Lookup(federation, flavor, objectPath); ok {
 		return resp, nil
 	}
 
 	objectPath = path.Clean(objectPath)
-	// Coalescing is per federation too: two federations asking about the same
-	// path are asking different questions.
-	inflightKey := cacheKey(federation, objectPath)
+	// Coalescing is per federation and per flavor too: two federations -- or
+	// a reader and a writer -- asking about the same path are asking
+	// different questions and must not receive one another's answer.
+	inflightKey := cacheKey(federation, flavor, objectPath)
 
 	// Check for an in-flight request for this path.
 	c.sfMu.Lock()
@@ -281,7 +343,7 @@ func (c *DirRespCache) LookupOrLoad(ctx context.Context, federation string, obje
 		// On success, store in cache (stripping the federation
 		// object path from ObjectServer URLs).
 		if err == nil && prefix != "" {
-			c.Store(federation, prefix, objectPath, resp)
+			c.Store(federation, flavor, prefix, objectPath, resp)
 		}
 
 		// Store the stripped version; waitForCall callers will
@@ -327,11 +389,11 @@ func (c *DirRespCache) waitForCall(ctx context.Context, cl *call) (server_struct
 }
 
 // Invalidate removes the entry for the given prefix within federation.
-func (c *DirRespCache) Invalidate(federation string, prefix string) {
+func (c *DirRespCache) Invalidate(federation string, flavor DirRespFlavor, prefix string) {
 	prefix = path.Clean(prefix)
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	delete(c.entries, cacheKey(federation, prefix))
+	delete(c.entries, cacheKey(federation, flavor, prefix))
 }
 
 // InvalidateAll removes all cached entries.

--- a/client/dir_resp_cache.go
+++ b/client/dir_resp_cache.go
@@ -20,6 +20,8 @@ package client
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -52,6 +54,30 @@ type DirRespFlavor struct {
 	// including directread and prefercached steer matchmaking, so a
 	// response obtained under one set does not answer for another.
 	Query string
+	// Credential fingerprints the bearer token the response was obtained
+	// with, empty for an unauthenticated query.  A director may answer a
+	// credentialed request differently -- that is the whole reason the
+	// transfer paths re-ask once they hold a token -- so such a response
+	// must not be handed to a caller bearing a different credential, or to
+	// one bearing none.  It is a digest, never the token: cache keys reach
+	// debug logs.
+	Credential string
+}
+
+// WithCredential returns a copy of the flavor scoped to one bearer token.
+func (f DirRespFlavor) WithCredential(token string) DirRespFlavor {
+	f.Credential = tokenFingerprint(token)
+	return f
+}
+
+// tokenFingerprint reduces a bearer token to a short tag that identifies it
+// without disclosing it.
+func tokenFingerprint(token string) string {
+	if token == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:8])
 }
 
 // NewDirRespFlavor builds a flavor from the verb, the cache-embedded-client
@@ -88,7 +114,11 @@ func (f DirRespFlavor) String() string {
 	if verb == "" {
 		verb = http.MethodGet
 	}
-	return verb + " " + routing + " " + f.Query
+	rendered := verb + " " + routing + " " + f.Query
+	if f.Credential != "" {
+		rendered += " cred:" + f.Credential
+	}
+	return rendered
 }
 
 // dirRespCacheEntry is a single cached director response with an expiry.

--- a/client/dir_resp_cache_test.go
+++ b/client/dir_resp_cache_test.go
@@ -22,6 +22,7 @@ package client
 
 import (
 	"context"
+	"net/http"
 	"net/url"
 	"sync"
 	"sync/atomic"
@@ -47,76 +48,80 @@ func makeDirResp(namespace string) server_structs.DirectorResponse {
 // tests was learned from; cross-federation behavior is covered separately.
 const testFederation = "https://fed.example.com"
 
+// testFlavor is the ordinary read flavor: a plain GET, routed to caches,
+// with no query.  Tests that care about flavor isolation build their own.
+var testFlavor = NewDirRespFlavor(http.MethodGet, false, "")
+
 func TestDirRespCacheLookup(t *testing.T) {
 	cache := NewDirRespCache(5 * time.Minute)
 
 	t.Run("Miss", func(t *testing.T) {
-		_, ok := cache.Lookup(testFederation, "/no/such/path")
+		_, ok := cache.Lookup(testFederation, testFlavor, "/no/such/path")
 		assert.False(t, ok)
 	})
 
 	t.Run("ExactMatch", func(t *testing.T) {
 		resp := makeDirResp("/test")
-		cache.Store(testFederation, "/test", "", resp)
+		cache.Store(testFederation, testFlavor, "/test", "", resp)
 
-		got, ok := cache.Lookup(testFederation, "/test")
+		got, ok := cache.Lookup(testFederation, testFlavor, "/test")
 		require.True(t, ok)
 		assert.Equal(t, "/test", got.XPelNsHdr.Namespace)
 	})
 
 	t.Run("PrefixMatch", func(t *testing.T) {
 		resp := makeDirResp("/data/project")
-		cache.Store(testFederation, "/data/project", "", resp)
+		cache.Store(testFederation, testFlavor, "/data/project", "", resp)
 
-		got, ok := cache.Lookup(testFederation, "/data/project/subdir/file.txt")
+		got, ok := cache.Lookup(testFederation, testFlavor, "/data/project/subdir/file.txt")
 		require.True(t, ok)
 		assert.Equal(t, "/data/project", got.XPelNsHdr.Namespace)
 	})
 
 	t.Run("LongestPrefixWins", func(t *testing.T) {
-		cache.Store(testFederation, "/a", "", makeDirResp("/a"))
-		cache.Store(testFederation, "/a/b", "", makeDirResp("/a/b"))
-		cache.Store(testFederation, "/a/b/c", "", makeDirResp("/a/b/c"))
+		cache.Store(testFederation, testFlavor, "/a", "", makeDirResp("/a"))
+		cache.Store(testFederation, testFlavor, "/a/b", "", makeDirResp("/a/b"))
+		cache.Store(testFederation, testFlavor, "/a/b/c", "", makeDirResp("/a/b/c"))
 
-		got, ok := cache.Lookup(testFederation, "/a/b/c/d/e.txt")
+		got, ok := cache.Lookup(testFederation, testFlavor, "/a/b/c/d/e.txt")
 		require.True(t, ok)
 		assert.Equal(t, "/a/b/c", got.XPelNsHdr.Namespace,
 			"should match the longest prefix")
 
-		got, ok = cache.Lookup(testFederation, "/a/b/x.txt")
+		got, ok = cache.Lookup(testFederation, testFlavor, "/a/b/x.txt")
 		require.True(t, ok)
 		assert.Equal(t, "/a/b", got.XPelNsHdr.Namespace)
 
-		got, ok = cache.Lookup(testFederation, "/a/x.txt")
+		got, ok = cache.Lookup(testFederation, testFlavor, "/a/x.txt")
 		require.True(t, ok)
 		assert.Equal(t, "/a", got.XPelNsHdr.Namespace)
 	})
 
 	t.Run("NoPartialSegmentMatch", func(t *testing.T) {
 		cache2 := NewDirRespCache(5 * time.Minute)
-		cache2.Store(testFederation, "/abc", "", makeDirResp("/abc"))
+		cache2.Store(testFederation, testFlavor, "/abc", "", makeDirResp("/abc"))
 
 		// "/abcdef" should NOT match "/abc" because "abc" is not a path prefix of "abcdef"
 		// (there's no "/" separator).  The lookup walks up path.Dir so:
 		// /abcdef → / (no /abc match for /abcdef since path.Dir(/abcdef)=/ directly)
-		_, ok := cache2.Lookup(testFederation, "/abcdef")
+		_, ok := cache2.Lookup(testFederation, testFlavor, "/abcdef")
 		assert.False(t, ok, "should not match partial segment")
 	})
 
 	t.Run("FoobarNotCoveredByFoo", func(t *testing.T) {
 		cache2 := NewDirRespCache(5 * time.Minute)
-		cache2.Store(testFederation, "/foo", "", makeDirResp("/foo"))
+		cache2.Store(testFederation, testFlavor, "/foo", "", makeDirResp("/foo"))
 
 		// "/foobar" is a different path segment — it must NOT match "/foo".
-		_, ok := cache2.Lookup(testFederation, "/foobar")
+		_, ok := cache2.Lookup(testFederation, testFlavor, "/foobar")
 		assert.False(t, ok, "/foobar should not be covered by /foo")
 
 		// "/foobar/baz" should also not match.
-		_, ok = cache2.Lookup(testFederation, "/foobar/baz")
+		_, ok = cache2.Lookup(testFederation, testFlavor, "/foobar/baz")
 		assert.False(t, ok, "/foobar/baz should not be covered by /foo")
 
 		// But "/foo/bar" SHOULD match (different segment under /foo).
-		got, ok := cache2.Lookup(testFederation, "/foo/bar")
+		got, ok := cache2.Lookup(testFederation, testFlavor, "/foo/bar")
 		assert.True(t, ok, "/foo/bar should be covered by /foo")
 		assert.Equal(t, "/foo", got.XPelNsHdr.Namespace)
 	})
@@ -124,59 +129,59 @@ func TestDirRespCacheLookup(t *testing.T) {
 
 func TestDirRespCacheExpiry(t *testing.T) {
 	cache := NewDirRespCache(50 * time.Millisecond)
-	cache.Store(testFederation, "/test", "", makeDirResp("/test"))
+	cache.Store(testFederation, testFlavor, "/test", "", makeDirResp("/test"))
 
 	// Should be present immediately
-	_, ok := cache.Lookup(testFederation, "/test/file.txt")
+	_, ok := cache.Lookup(testFederation, testFlavor, "/test/file.txt")
 	require.True(t, ok)
 
 	// Wait for expiry
 	time.Sleep(60 * time.Millisecond)
 
-	_, ok = cache.Lookup(testFederation, "/test/file.txt")
+	_, ok = cache.Lookup(testFederation, testFlavor, "/test/file.txt")
 	assert.False(t, ok, "entry should have expired")
 }
 
 func TestDirRespCacheInvalidate(t *testing.T) {
 	cache := NewDirRespCache(5 * time.Minute)
-	cache.Store(testFederation, "/test", "", makeDirResp("/test"))
+	cache.Store(testFederation, testFlavor, "/test", "", makeDirResp("/test"))
 
-	_, ok := cache.Lookup(testFederation, "/test/file.txt")
+	_, ok := cache.Lookup(testFederation, testFlavor, "/test/file.txt")
 	require.True(t, ok)
 
-	cache.Invalidate(testFederation, "/test")
+	cache.Invalidate(testFederation, testFlavor, "/test")
 
-	_, ok = cache.Lookup(testFederation, "/test/file.txt")
+	_, ok = cache.Lookup(testFederation, testFlavor, "/test/file.txt")
 	assert.False(t, ok)
 }
 
 func TestDirRespCacheInvalidateAll(t *testing.T) {
 	cache := NewDirRespCache(5 * time.Minute)
-	cache.Store(testFederation, "/a", "", makeDirResp("/a"))
-	cache.Store(testFederation, "/b", "", makeDirResp("/b"))
+	cache.Store(testFederation, testFlavor, "/a", "", makeDirResp("/a"))
+	cache.Store(testFederation, testFlavor, "/b", "", makeDirResp("/b"))
 
 	assert.Equal(t, 2, cache.Len())
 
 	cache.InvalidateAll()
 
 	assert.Equal(t, 0, cache.Len())
-	_, ok := cache.Lookup(testFederation, "/a/file")
+	_, ok := cache.Lookup(testFederation, testFlavor, "/a/file")
 	assert.False(t, ok)
 }
 
 func TestDirRespCacheCleanExpired(t *testing.T) {
 	cache := NewDirRespCache(50 * time.Millisecond)
-	cache.Store(testFederation, "/expired", "", makeDirResp("/expired"))
+	cache.Store(testFederation, testFlavor, "/expired", "", makeDirResp("/expired"))
 
 	time.Sleep(60 * time.Millisecond)
 
-	cache.Store(testFederation, "/fresh", "", makeDirResp("/fresh"))
+	cache.Store(testFederation, testFlavor, "/fresh", "", makeDirResp("/fresh"))
 	assert.Equal(t, 2, cache.Len())
 
 	cache.cleanExpired()
 	assert.Equal(t, 1, cache.Len())
 
-	_, ok := cache.Lookup(testFederation, "/fresh/file")
+	_, ok := cache.Lookup(testFederation, testFlavor, "/fresh/file")
 	assert.True(t, ok)
 }
 
@@ -187,10 +192,10 @@ func TestDirRespCacheOverwrite(t *testing.T) {
 	resp2 := makeDirResp("/test-updated")
 	resp2.XPelNsHdr.Namespace = "/test" // same namespace
 
-	cache.Store(testFederation, "/test", "", resp1)
-	cache.Store(testFederation, "/test", "", resp2)
+	cache.Store(testFederation, testFlavor, "/test", "", resp1)
+	cache.Store(testFederation, testFlavor, "/test", "", resp2)
 
-	got, ok := cache.Lookup(testFederation, "/test/file")
+	got, ok := cache.Lookup(testFederation, testFlavor, "/test/file")
 	require.True(t, ok)
 	assert.Equal(t, resp2.ObjectServers[0].Host, got.ObjectServers[0].Host,
 		"later store should overwrite earlier")
@@ -223,10 +228,10 @@ func TestMatchesPrefix(t *testing.T) {
 func TestLookupOrLoadCacheHit(t *testing.T) {
 	cache := NewDirRespCache(5 * time.Minute)
 	resp := makeDirResp("/data")
-	cache.Store(testFederation, "/data", "", resp)
+	cache.Store(testFederation, testFlavor, "/data", "", resp)
 
 	var loaderCalled atomic.Int32
-	got, err := cache.LookupOrLoad(context.Background(), testFederation, "/data/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+	got, err := cache.LookupOrLoad(context.Background(), testFederation, testFlavor, "/data/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 		loaderCalled.Add(1)
 		return server_structs.DirectorResponse{}, "", nil
 	})
@@ -239,14 +244,14 @@ func TestLookupOrLoadCacheMiss(t *testing.T) {
 	cache := NewDirRespCache(5 * time.Minute)
 	resp := makeDirResp("/data")
 
-	got, err := cache.LookupOrLoad(context.Background(), testFederation, "/data/subdir/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+	got, err := cache.LookupOrLoad(context.Background(), testFederation, testFlavor, "/data/subdir/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 		return resp, "/data", nil
 	})
 	require.NoError(t, err)
 	assert.Equal(t, resp.ObjectServers[0].Host, got.ObjectServers[0].Host)
 
 	// The result should now be cached.
-	cached, ok := cache.Lookup(testFederation, "/data/other.txt")
+	cached, ok := cache.Lookup(testFederation, testFlavor, "/data/other.txt")
 	require.True(t, ok)
 	assert.Equal(t, resp.ObjectServers[0].Host, cached.ObjectServers[0].Host)
 }
@@ -269,7 +274,7 @@ func TestLookupOrLoadCoalesces(t *testing.T) {
 	for i := 0; i < numWaiters; i++ {
 		go func(idx int) {
 			defer wg.Done()
-			results[idx], errs[idx] = cache.LookupOrLoad(context.Background(), testFederation, "/ns/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+			results[idx], errs[idx] = cache.LookupOrLoad(context.Background(), testFederation, testFlavor, "/ns/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 				loaderCalls.Add(1)
 				<-gate // wait for the gate to open
 				return resp, "/ns", nil
@@ -297,7 +302,7 @@ func TestLookupOrLoadContextCancel(t *testing.T) {
 
 	go func() {
 		// Start a load that blocks for a long time.
-		_, _ = cache.LookupOrLoad(context.Background(), testFederation, "/slow/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+		_, _ = cache.LookupOrLoad(context.Background(), testFederation, testFlavor, "/slow/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 			close(loaderStarted)
 			time.Sleep(5 * time.Second)
 			return makeDirResp("/slow"), "/slow", nil
@@ -307,7 +312,7 @@ func TestLookupOrLoadContextCancel(t *testing.T) {
 	// Wait for the loader to start, then try a second caller with a cancelled context.
 	<-loaderStarted
 	cancel()
-	_, err := cache.LookupOrLoad(ctx, testFederation, "/slow/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+	_, err := cache.LookupOrLoad(ctx, testFederation, testFlavor, "/slow/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 		t.Fatal("loader should not be called for second waiter")
 		return server_structs.DirectorResponse{}, "", nil
 	})
@@ -317,13 +322,13 @@ func TestLookupOrLoadContextCancel(t *testing.T) {
 
 func TestLookupOrLoadNoPartialSegment(t *testing.T) {
 	cache := NewDirRespCache(5 * time.Minute)
-	cache.Store(testFederation, "/foo", "", makeDirResp("/foo"))
+	cache.Store(testFederation, testFlavor, "/foo", "", makeDirResp("/foo"))
 
 	var loaderCalled atomic.Int32
 	resp := makeDirResp("/foobar")
 
 	// LookupOrLoad for /foobar/file.txt should NOT match /foo and must invoke the loader.
-	got, err := cache.LookupOrLoad(context.Background(), testFederation, "/foobar/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+	got, err := cache.LookupOrLoad(context.Background(), testFederation, testFlavor, "/foobar/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 		loaderCalled.Add(1)
 		return resp, "/foobar", nil
 	})
@@ -333,7 +338,7 @@ func TestLookupOrLoadNoPartialSegment(t *testing.T) {
 
 	// Verify /foo/bar/file.txt still hits the /foo cache entry without calling the loader.
 	var loaderCalled2 atomic.Int32
-	got2, err := cache.LookupOrLoad(context.Background(), testFederation, "/foo/bar/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+	got2, err := cache.LookupOrLoad(context.Background(), testFederation, testFlavor, "/foo/bar/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 		loaderCalled2.Add(1)
 		return server_structs.DirectorResponse{}, "", nil
 	})
@@ -346,13 +351,13 @@ func TestLookupOrLoadLoaderError(t *testing.T) {
 	cache := NewDirRespCache(5 * time.Minute)
 	expectedErr := assert.AnError
 
-	_, err := cache.LookupOrLoad(context.Background(), testFederation, "/fail/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+	_, err := cache.LookupOrLoad(context.Background(), testFederation, testFlavor, "/fail/file.txt", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 		return server_structs.DirectorResponse{}, "", expectedErr
 	})
 	require.ErrorIs(t, err, expectedErr)
 
 	// Nothing should be cached on error.
-	_, ok := cache.Lookup(testFederation, "/fail/file.txt")
+	_, ok := cache.Lookup(testFederation, testFlavor, "/fail/file.txt")
 	assert.False(t, ok)
 	assert.Equal(t, 0, cache.Len())
 }
@@ -371,17 +376,17 @@ func TestDirRespCacheStripsFederationPath(t *testing.T) {
 			},
 		}
 
-		cache.Store(testFederation, "/test", "/test/file1.bin", resp)
+		cache.Store(testFederation, testFlavor, "/test", "/test/file1.bin", resp)
 
 		// Looking up with the SAME file should return original full paths.
-		got, ok := cache.Lookup(testFederation, "/test/file1.bin")
+		got, ok := cache.Lookup(testFederation, testFlavor, "/test/file1.bin")
 		require.True(t, ok)
 		assert.Equal(t, "/api/v1.0/origin/data/test/file1.bin", got.ObjectServers[0].Path)
 		assert.Equal(t, "/test/file1.bin", got.ObjectServers[1].Path)
 
 		// Looking up with a DIFFERENT file should return reconstituted paths
 		// with the new file's federation path.
-		got2, ok := cache.Lookup(testFederation, "/test/file2.bin")
+		got2, ok := cache.Lookup(testFederation, testFlavor, "/test/file2.bin")
 		require.True(t, ok)
 		assert.Equal(t, "/api/v1.0/origin/data/test/file2.bin", got2.ObjectServers[0].Path)
 		assert.Equal(t, "/test/file2.bin", got2.ObjectServers[1].Path)
@@ -400,7 +405,7 @@ func TestDirRespCacheStripsFederationPath(t *testing.T) {
 			},
 		}
 
-		got, err := cache.LookupOrLoad(context.Background(), testFederation, "/ns/obj1.bin", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+		got, err := cache.LookupOrLoad(context.Background(), testFederation, testFlavor, "/ns/obj1.bin", func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 			return resp, "/ns", nil
 		})
 		require.NoError(t, err)
@@ -411,7 +416,7 @@ func TestDirRespCacheStripsFederationPath(t *testing.T) {
 
 		// Subsequent lookup for a different file should return reconstituted
 		// paths with the new file's federation path.
-		cached, ok := cache.Lookup(testFederation, "/ns/obj2.bin")
+		cached, ok := cache.Lookup(testFederation, testFlavor, "/ns/obj2.bin")
 		require.True(t, ok)
 		assert.Equal(t, "/prefix/ns/obj2.bin", cached.ObjectServers[0].Path)
 	})
@@ -425,8 +430,8 @@ func TestDirRespCacheStripsFederationPath(t *testing.T) {
 			},
 		}
 
-		cache.Store(testFederation, "/test", "", resp)
-		got, ok := cache.Lookup(testFederation, "/test/file.txt")
+		cache.Store(testFederation, testFlavor, "/test", "", resp)
+		got, ok := cache.Lookup(testFederation, testFlavor, "/test/file.txt")
 		require.True(t, ok)
 		// With empty objectPath, nothing was stripped, so reconstitution
 		// appends the lookup path to the stored path.
@@ -445,12 +450,12 @@ func TestDirRespCacheIsolatesFederations(t *testing.T) {
 
 	t.Run("LookupDoesNotCrossFederations", func(t *testing.T) {
 		cache := NewDirRespCache(5 * time.Minute)
-		cache.Store(testFederation, "/shared", "", makeDirResp("/shared"))
+		cache.Store(testFederation, testFlavor, "/shared", "", makeDirResp("/shared"))
 
-		_, ok := cache.Lookup(otherFederation, "/shared/object.txt")
+		_, ok := cache.Lookup(otherFederation, testFlavor, "/shared/object.txt")
 		assert.False(t, ok, "an entry learned from one federation must not answer for another")
 
-		got, ok := cache.Lookup(testFederation, "/shared/object.txt")
+		got, ok := cache.Lookup(testFederation, testFlavor, "/shared/object.txt")
 		require.True(t, ok, "the federation that stored the entry still gets it")
 		assert.Equal(t, "/shared", got.XPelNsHdr.Namespace)
 	})
@@ -461,16 +466,16 @@ func TestDirRespCacheIsolatesFederations(t *testing.T) {
 		theirs := makeDirResp("/shared")
 		theirs.ObjectServers = []*url.URL{{Host: "cache.other-fed.example.com"}}
 
-		cache.Store(testFederation, "/shared", "", mine)
-		cache.Store(otherFederation, "/shared", "", theirs)
+		cache.Store(testFederation, testFlavor, "/shared", "", mine)
+		cache.Store(otherFederation, testFlavor, "/shared", "", theirs)
 
-		got, ok := cache.Lookup(testFederation, "/shared/object.txt")
+		got, ok := cache.Lookup(testFederation, testFlavor, "/shared/object.txt")
 		require.True(t, ok)
 		require.Len(t, got.ObjectServers, 1)
 		assert.Equal(t, "/shared.example.com", got.ObjectServers[0].Host,
 			"storing another federation's entry must not overwrite this one")
 
-		got, ok = cache.Lookup(otherFederation, "/shared/object.txt")
+		got, ok = cache.Lookup(otherFederation, testFlavor, "/shared/object.txt")
 		require.True(t, ok)
 		require.Len(t, got.ObjectServers, 1)
 		assert.Equal(t, "cache.other-fed.example.com", got.ObjectServers[0].Host)
@@ -486,9 +491,9 @@ func TestDirRespCacheIsolatesFederations(t *testing.T) {
 			}
 		}
 
-		_, err := cache.LookupOrLoad(context.Background(), testFederation, "/shared/object.txt", loader("/shared"))
+		_, err := cache.LookupOrLoad(context.Background(), testFederation, testFlavor, "/shared/object.txt", loader("/shared"))
 		require.NoError(t, err)
-		_, err = cache.LookupOrLoad(context.Background(), otherFederation, "/shared/object.txt", loader("/shared"))
+		_, err = cache.LookupOrLoad(context.Background(), otherFederation, testFlavor, "/shared/object.txt", loader("/shared"))
 		require.NoError(t, err)
 
 		assert.Equal(t, int32(2), atomic.LoadInt32(&calls),
@@ -497,10 +502,118 @@ func TestDirRespCacheIsolatesFederations(t *testing.T) {
 
 	t.Run("UnattributableEntriesAreNotCached", func(t *testing.T) {
 		cache := NewDirRespCache(5 * time.Minute)
-		cache.Store("", "/shared", "", makeDirResp("/shared"))
+		cache.Store("", testFlavor, "/shared", "", makeDirResp("/shared"))
 		assert.Equal(t, 0, cache.Len(), "an entry with no federation could answer for any of them")
 
-		_, ok := cache.Lookup("", "/shared/object.txt")
+		_, ok := cache.Lookup("", testFlavor, "/shared/object.txt")
 		assert.False(t, ok)
 	})
+}
+
+// A director response answers exactly one question.  These tests pin the
+// separations that keep one flavor's answer from being served to another:
+// a writer must never be handed the caches a read was told to use (that
+// both addresses the write to servers that reject it and discloses the
+// write credential to every one of them), and a ?directread read must not
+// be served the cache-routed answer it was explicitly avoiding.
+func TestDirRespCacheFlavorIsolation(t *testing.T) {
+	readFlavor := NewDirRespFlavor(http.MethodGet, false, "")
+	writeFlavor := NewDirRespFlavor(http.MethodPut, false, "")
+	directReadFlavor := NewDirRespFlavor(http.MethodGet, false, "directread")
+	cacheModeFlavor := NewDirRespFlavor(http.MethodGet, true, "")
+
+	t.Run("WriteDoesNotSeeReadEntry", func(t *testing.T) {
+		cache := NewDirRespCache(5 * time.Minute)
+		cache.Store(testFederation, readFlavor, "/ns", "", makeDirResp("/ns"))
+
+		_, ok := cache.Lookup(testFederation, writeFlavor, "/ns/file.txt")
+		assert.False(t, ok, "an upload must not be answered with a download's object servers")
+
+		_, ok = cache.Lookup(testFederation, readFlavor, "/ns/file.txt")
+		assert.True(t, ok, "the read entry itself still answers reads")
+	})
+
+	t.Run("ReadDoesNotSeeWriteEntry", func(t *testing.T) {
+		cache := NewDirRespCache(5 * time.Minute)
+		cache.Store(testFederation, writeFlavor, "/ns", "", makeDirResp("/ns"))
+
+		_, ok := cache.Lookup(testFederation, readFlavor, "/ns/file.txt")
+		assert.False(t, ok, "a download must not be answered with an upload's origins")
+	})
+
+	t.Run("DirectReadIsItsOwnFlavor", func(t *testing.T) {
+		cache := NewDirRespCache(5 * time.Minute)
+		cache.Store(testFederation, readFlavor, "/ns", "", makeDirResp("/ns"))
+
+		_, ok := cache.Lookup(testFederation, directReadFlavor, "/ns/lease.json")
+		assert.False(t, ok, "?directread asks for origins and must not get the cache-routed answer")
+	})
+
+	t.Run("CacheModeIsItsOwnFlavor", func(t *testing.T) {
+		cache := NewDirRespCache(5 * time.Minute)
+		cache.Store(testFederation, readFlavor, "/ns", "", makeDirResp("/ns"))
+
+		_, ok := cache.Lookup(testFederation, cacheModeFlavor, "/ns/file.txt")
+		assert.False(t, ok, "cache-mode routing queries a different director endpoint")
+	})
+
+	t.Run("QueryOrderDoesNotSplitEntries", func(t *testing.T) {
+		cache := NewDirRespCache(5 * time.Minute)
+		stored := NewDirRespFlavor(http.MethodGet, false, "directread&pack=auto")
+		cache.Store(testFederation, stored, "/ns", "", makeDirResp("/ns"))
+
+		reordered := NewDirRespFlavor(http.MethodGet, false, "pack=auto&directread")
+		_, ok := cache.Lookup(testFederation, reordered, "/ns/file.txt")
+		assert.True(t, ok, "the same parameters in another order are the same question")
+	})
+}
+
+// Concurrent misses are coalesced per flavor: a reader and a writer racing
+// on one path must each get their own director query, not share one answer.
+func TestDirRespCacheSingleflightIsPerFlavor(t *testing.T) {
+	cache := NewDirRespCache(5 * time.Minute)
+	readFlavor := NewDirRespFlavor(http.MethodGet, false, "")
+	writeFlavor := NewDirRespFlavor(http.MethodPut, false, "")
+
+	release := make(chan struct{})
+	var readCalls, writeCalls atomic.Int32
+
+	loader := func(counter *atomic.Int32, host string) DirRespLoader {
+		return func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+			counter.Add(1)
+			<-release // hold both in flight at once
+			return server_structs.DirectorResponse{
+				XPelNsHdr:     server_structs.XPelNs{Namespace: "/ns"},
+				ObjectServers: []*url.URL{{Host: host}},
+			}, "/ns", nil
+		}
+	}
+
+	var wg sync.WaitGroup
+	var readResp, writeResp server_structs.DirectorResponse
+	var readErr, writeErr error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		readResp, readErr = cache.LookupOrLoad(context.Background(), testFederation, readFlavor, "/ns/file.txt", loader(&readCalls, "cache.example.com"))
+	}()
+	go func() {
+		defer wg.Done()
+		writeResp, writeErr = cache.LookupOrLoad(context.Background(), testFederation, writeFlavor, "/ns/file.txt", loader(&writeCalls, "origin.example.com"))
+	}()
+
+	// Both loaders must be running: if the flavors shared a singleflight
+	// key, only one would have started and this would deadlock on release.
+	require.Eventually(t, func() bool {
+		return readCalls.Load() == 1 && writeCalls.Load() == 1
+	}, 5*time.Second, 10*time.Millisecond, "each flavor should issue its own director query")
+	close(release)
+	wg.Wait()
+
+	require.NoError(t, readErr)
+	require.NoError(t, writeErr)
+	require.Len(t, readResp.ObjectServers, 1)
+	require.Len(t, writeResp.ObjectServers, 1)
+	assert.Equal(t, "cache.example.com", readResp.ObjectServers[0].Host)
+	assert.Equal(t, "origin.example.com", writeResp.ObjectServers[0].Host, "the writer must keep its own answer")
 }

--- a/client/dir_resp_cache_test.go
+++ b/client/dir_resp_cache_test.go
@@ -617,3 +617,45 @@ func TestDirRespCacheSingleflightIsPerFlavor(t *testing.T) {
 	assert.Equal(t, "cache.example.com", readResp.ObjectServers[0].Host)
 	assert.Equal(t, "origin.example.com", writeResp.ObjectServers[0].Host, "the writer must keep its own answer")
 }
+
+// A director may answer differently once it sees a credential, so a
+// response obtained with one token must not be handed to a caller bearing a
+// different token -- or none.  The credential is carried as a digest so that
+// cache keys, which reach debug logs, never contain the token itself.
+func TestDirRespCacheCredentialScoping(t *testing.T) {
+	base := NewDirRespFlavor(http.MethodGet, false, "")
+	alice := base.WithCredential("alice-token")
+	bob := base.WithCredential("bob-token")
+
+	t.Run("AnotherTokenDoesNotSeeIt", func(t *testing.T) {
+		cache := NewDirRespCache(5 * time.Minute)
+		cache.Store(testFederation, alice, "/ns", "", makeDirResp("/ns"))
+
+		_, ok := cache.Lookup(testFederation, bob, "/ns/file.txt")
+		assert.False(t, ok, "one caller's authenticated answer must not serve another's token")
+
+		_, ok = cache.Lookup(testFederation, base, "/ns/file.txt")
+		assert.False(t, ok, "an authenticated answer must not serve an anonymous lookup")
+
+		_, ok = cache.Lookup(testFederation, alice, "/ns/file.txt")
+		assert.True(t, ok, "the same credential reuses its own answer")
+	})
+
+	t.Run("SameTokenSharesAcrossObjects", func(t *testing.T) {
+		cache := NewDirRespCache(5 * time.Minute)
+		cache.Store(testFederation, alice, "/ns", "/ns/first.txt", makeDirResp("/ns"))
+
+		// This is the property that keeps a token-protected namespace from
+		// spending a director round trip on every object.
+		_, ok := cache.Lookup(testFederation, alice, "/ns/second.txt")
+		assert.True(t, ok)
+	})
+
+	t.Run("KeyDoesNotContainTheToken", func(t *testing.T) {
+		const secret = "super-secret-bearer-token"
+		rendered := base.WithCredential(secret).String()
+		assert.NotContains(t, rendered, secret, "the token must not appear in a cache key")
+		assert.NotEmpty(t, base.WithCredential(secret).Credential)
+		assert.Empty(t, base.WithCredential("").Credential, "no token means no credential scoping")
+	})
+}

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1976,7 +1976,8 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 	} else if tc.engine != nil && tc.engine.dirRespCache != nil {
 		copyUrlRef := &copyUrl
 		cacheMode := tj.cacheMode
-		dirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, copyUrl.FedInfo.DiscoveryEndpoint, copyUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+		flavor := NewDirRespFlavor(httpMethod, cacheMode, copyUrl.RawQuery)
+		dirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, copyUrl.FedInfo.DiscoveryEndpoint, flavor, copyUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 			resp, qErr := getDirectorInfoForPath(ctx, copyUrlRef, httpMethod, "", cacheMode)
 			return resp, resp.XPelNsHdr.Namespace, qErr
 		})
@@ -2047,7 +2048,7 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 			tj.token.SetDirectorResponse(&dirResp)
 			// Update the cache with the token-authenticated response.
 			if tc.engine != nil && tc.engine.dirRespCache != nil && dirResp.XPelNsHdr.Namespace != "" {
-				tc.engine.dirRespCache.Store(copyUrl.FedInfo.DiscoveryEndpoint, dirResp.XPelNsHdr.Namespace, copyUrl.Path, dirResp)
+				tc.engine.dirRespCache.Store(copyUrl.FedInfo.DiscoveryEndpoint, NewDirRespFlavor(httpMethod, tj.cacheMode, copyUrl.RawQuery), dirResp.XPelNsHdr.Namespace, copyUrl.Path, dirResp)
 			}
 		}
 	} else {
@@ -2124,7 +2125,7 @@ func (tc *TransferClient) NewPrestageJob(ctx context.Context, remoteUrl *url.URL
 
 	var dirResp server_structs.DirectorResponse
 	if tc.engine != nil && tc.engine.dirRespCache != nil {
-		dirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, pelicanURL.FedInfo.DiscoveryEndpoint, pelicanURL.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+		dirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, pelicanURL.FedInfo.DiscoveryEndpoint, NewDirRespFlavor(http.MethodGet, false, pelicanURL.RawQuery), pelicanURL.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 			resp, qErr := getDirectorInfoForPath(ctx, pelicanURL, http.MethodGet, "", false)
 			return resp, resp.XPelNsHdr.Namespace, qErr
 		})
@@ -2157,7 +2158,7 @@ func (tc *TransferClient) NewPrestageJob(ctx context.Context, remoteUrl *url.URL
 			tj.dirResp = dirResp
 			tj.token.SetDirectorResponse(&dirResp)
 			if tc.engine != nil && tc.engine.dirRespCache != nil && dirResp.XPelNsHdr.Namespace != "" {
-				tc.engine.dirRespCache.Store(pelicanURL.FedInfo.DiscoveryEndpoint, dirResp.XPelNsHdr.Namespace, pelicanURL.Path, dirResp)
+				tc.engine.dirRespCache.Store(pelicanURL.FedInfo.DiscoveryEndpoint, NewDirRespFlavor(http.MethodGet, false, pelicanURL.RawQuery), dirResp.XPelNsHdr.Namespace, pelicanURL.Path, dirResp)
 			}
 		}
 	} else {
@@ -2246,9 +2247,15 @@ func (tc *TransferClient) NewCopyJob(ctx context.Context, src *url.URL, dest *ur
 	tj.directorUrl = copyDestUrl.FedInfo.DirectorEndpoint
 	var dirResp server_structs.DirectorResponse
 	destVerb := "COPY"
+	// The TPC destination flavor, pinned to COPY even when the query below
+	// falls back to PUT: the fallback is part of answering "where may this
+	// third-party copy write?", and only this resolution asks that question.
+	// Pinning it keeps lookup and store on one key, and keeps the entry from
+	// ever answering a plain PUT -- which would be a different question.
+	destFlavor := NewDirRespFlavor(destVerb, false, copyDestUrl.RawQuery)
 	if tc.engine != nil && tc.engine.dirRespCache != nil {
 		copyDestUrlRef := &copyDestUrl
-		dirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, copyDestUrl.FedInfo.DiscoveryEndpoint, copyDestUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+		dirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, copyDestUrl.FedInfo.DiscoveryEndpoint, destFlavor, copyDestUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 			resp, qErr := getDirectorInfoForPath(ctx, copyDestUrlRef, destVerb, "", false)
 			if qErr != nil {
 				// Fall back to PUT if COPY is not supported by the director
@@ -2290,7 +2297,7 @@ func (tc *TransferClient) NewCopyJob(ctx context.Context, src *url.URL, dest *ur
 			tj.destDirResp = dirResp
 			tj.token.SetDirectorResponse(&dirResp)
 			if tc.engine != nil && tc.engine.dirRespCache != nil && dirResp.XPelNsHdr.Namespace != "" {
-				tc.engine.dirRespCache.Store(copyDestUrl.FedInfo.DiscoveryEndpoint, dirResp.XPelNsHdr.Namespace, copyDestUrl.Path, dirResp)
+				tc.engine.dirRespCache.Store(copyDestUrl.FedInfo.DiscoveryEndpoint, destFlavor, dirResp.XPelNsHdr.Namespace, copyDestUrl.Path, dirResp)
 			}
 		}
 	}
@@ -2299,7 +2306,8 @@ func (tc *TransferClient) NewCopyJob(ctx context.Context, src *url.URL, dest *ur
 	var srcDirResp server_structs.DirectorResponse
 	if tc.engine != nil && tc.engine.dirRespCache != nil {
 		copySrcUrlRef := &copySrcUrl
-		srcDirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, copySrcUrl.FedInfo.DiscoveryEndpoint, copySrcUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+		srcFlavor := NewDirRespFlavor(http.MethodGet, false, copySrcUrl.RawQuery)
+		srcDirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, copySrcUrl.FedInfo.DiscoveryEndpoint, srcFlavor, copySrcUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 			resp, qErr := getDirectorInfoForPath(ctx, copySrcUrlRef, http.MethodGet, "", false)
 			return resp, resp.XPelNsHdr.Namespace, qErr
 		})
@@ -2330,7 +2338,7 @@ func (tc *TransferClient) NewCopyJob(ctx context.Context, src *url.URL, dest *ur
 			tj.srcDirResp = srcDirResp
 			tj.srcToken.SetDirectorResponse(&srcDirResp)
 			if tc.engine != nil && tc.engine.dirRespCache != nil && srcDirResp.XPelNsHdr.Namespace != "" {
-				tc.engine.dirRespCache.Store(copySrcUrl.FedInfo.DiscoveryEndpoint, srcDirResp.XPelNsHdr.Namespace, copySrcUrl.Path, srcDirResp)
+				tc.engine.dirRespCache.Store(copySrcUrl.FedInfo.DiscoveryEndpoint, NewDirRespFlavor(http.MethodGet, false, copySrcUrl.RawQuery), srcDirResp.XPelNsHdr.Namespace, copySrcUrl.Path, srcDirResp)
 			}
 		}
 	} else {
@@ -2408,7 +2416,7 @@ func (tc *TransferClient) CacheInfo(ctx context.Context, remoteUrl *url.URL, opt
 	if directorless {
 		dirResp, err = resolveForRequest(ctx, pelicanURL, http.MethodGet, "", false)
 	} else if tc.engine != nil && tc.engine.dirRespCache != nil {
-		dirResp, err = tc.engine.dirRespCache.LookupOrLoad(ctx, pelicanURL.FedInfo.DiscoveryEndpoint, pelicanURL.Path, func(lCtx context.Context) (server_structs.DirectorResponse, string, error) {
+		dirResp, err = tc.engine.dirRespCache.LookupOrLoad(ctx, pelicanURL.FedInfo.DiscoveryEndpoint, NewDirRespFlavor(http.MethodGet, false, pelicanURL.RawQuery), pelicanURL.Path, func(lCtx context.Context) (server_structs.DirectorResponse, string, error) {
 			resp, qErr := getDirectorInfoForPath(lCtx, pelicanURL, http.MethodGet, "", false)
 			return resp, resp.XPelNsHdr.Namespace, qErr
 		})
@@ -2440,7 +2448,7 @@ func (tc *TransferClient) CacheInfo(ctx context.Context, remoteUrl *url.URL, opt
 			}
 			token.SetDirectorResponse(&dirResp)
 			if tc.engine != nil && tc.engine.dirRespCache != nil && dirResp.XPelNsHdr.Namespace != "" {
-				tc.engine.dirRespCache.Store(pelicanURL.FedInfo.DiscoveryEndpoint, dirResp.XPelNsHdr.Namespace, pelicanURL.Path, dirResp)
+				tc.engine.dirRespCache.Store(pelicanURL.FedInfo.DiscoveryEndpoint, NewDirRespFlavor(http.MethodGet, false, pelicanURL.RawQuery), dirResp.XPelNsHdr.Namespace, pelicanURL.Path, dirResp)
 			}
 		}
 	} else if !directorless {

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1966,6 +1966,8 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 	// transfer therefore keeps its token generator either way, so that a
 	// rejection carrying token hints has something to acquire onto.
 	directorless := copyUrl.FedInfo.DirectorEndpoint == "" && copyUrl.FedInfo.DiscoveryEndpoint != ""
+	copyUrlRef := &copyUrl
+	dirFlavor := NewDirRespFlavor(httpMethod, tj.cacheMode, copyUrl.RawQuery)
 	// A download against a directorless federation resolves locally and pays no
 	// round trip: it addresses the object to the host the user named and lets
 	// the origin's own rejection say what credential the namespace wants.  An
@@ -1974,11 +1976,8 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 	if directorless && !upload {
 		dirResp, err = resolveForRequest(tj.ctx, &copyUrl, httpMethod, "", tj.cacheMode)
 	} else if tc.engine != nil && tc.engine.dirRespCache != nil {
-		copyUrlRef := &copyUrl
-		cacheMode := tj.cacheMode
-		flavor := NewDirRespFlavor(httpMethod, cacheMode, copyUrl.RawQuery)
-		dirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, copyUrl.FedInfo.DiscoveryEndpoint, flavor, copyUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
-			resp, qErr := getDirectorInfoForPath(ctx, copyUrlRef, httpMethod, "", cacheMode)
+		dirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, copyUrl.FedInfo.DiscoveryEndpoint, dirFlavor, copyUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+			resp, qErr := getDirectorInfoForPath(ctx, copyUrlRef, httpMethod, "", tj.cacheMode)
 			return resp, resp.XPelNsHdr.Namespace, qErr
 		})
 	} else {
@@ -2034,7 +2033,22 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 		// Skip re-query if the director already failed, or if there is no
 		// director to re-query.
 		if contents != "" && !directorFailed && !directorless {
-			dirResp, err = getDirectorInfoForPath(tj.ctx, &copyUrl, httpMethod, contents, tj.cacheMode)
+			// A director may answer differently once it sees a credential,
+			// so this asks again -- but the answer holds for every object
+			// in the namespace that this same credential reaches, and a
+			// token-protected namespace would otherwise spend a director
+			// round trip on every single transfer.  Cache it under a
+			// credential-scoped flavor: another token (or none) keys
+			// elsewhere and never receives this answer.
+			authFlavor := dirFlavor.WithCredential(contents)
+			if tc.engine != nil && tc.engine.dirRespCache != nil {
+				dirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, copyUrl.FedInfo.DiscoveryEndpoint, authFlavor, copyUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+					resp, qErr := getDirectorInfoForPath(ctx, copyUrlRef, httpMethod, contents, tj.cacheMode)
+					return resp, resp.XPelNsHdr.Namespace, qErr
+				})
+			} else {
+				dirResp, err = getDirectorInfoForPath(tj.ctx, &copyUrl, httpMethod, contents, tj.cacheMode)
+			}
 			if err != nil {
 				var sce *StatusCodeError
 				if errors.As(err, &sce) {
@@ -2046,10 +2060,6 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 			}
 			tj.dirResp = dirResp
 			tj.token.SetDirectorResponse(&dirResp)
-			// Update the cache with the token-authenticated response.
-			if tc.engine != nil && tc.engine.dirRespCache != nil && dirResp.XPelNsHdr.Namespace != "" {
-				tc.engine.dirRespCache.Store(copyUrl.FedInfo.DiscoveryEndpoint, NewDirRespFlavor(httpMethod, tj.cacheMode, copyUrl.RawQuery), dirResp.XPelNsHdr.Namespace, copyUrl.Path, dirResp)
-			}
 		}
 	} else {
 		tj.token = nil
@@ -2158,7 +2168,7 @@ func (tc *TransferClient) NewPrestageJob(ctx context.Context, remoteUrl *url.URL
 			tj.dirResp = dirResp
 			tj.token.SetDirectorResponse(&dirResp)
 			if tc.engine != nil && tc.engine.dirRespCache != nil && dirResp.XPelNsHdr.Namespace != "" {
-				tc.engine.dirRespCache.Store(pelicanURL.FedInfo.DiscoveryEndpoint, NewDirRespFlavor(http.MethodGet, false, pelicanURL.RawQuery), dirResp.XPelNsHdr.Namespace, pelicanURL.Path, dirResp)
+				tc.engine.dirRespCache.Store(pelicanURL.FedInfo.DiscoveryEndpoint, NewDirRespFlavor(http.MethodGet, false, pelicanURL.RawQuery).WithCredential(contents), dirResp.XPelNsHdr.Namespace, pelicanURL.Path, dirResp)
 			}
 		}
 	} else {
@@ -2297,7 +2307,7 @@ func (tc *TransferClient) NewCopyJob(ctx context.Context, src *url.URL, dest *ur
 			tj.destDirResp = dirResp
 			tj.token.SetDirectorResponse(&dirResp)
 			if tc.engine != nil && tc.engine.dirRespCache != nil && dirResp.XPelNsHdr.Namespace != "" {
-				tc.engine.dirRespCache.Store(copyDestUrl.FedInfo.DiscoveryEndpoint, destFlavor, dirResp.XPelNsHdr.Namespace, copyDestUrl.Path, dirResp)
+				tc.engine.dirRespCache.Store(copyDestUrl.FedInfo.DiscoveryEndpoint, destFlavor.WithCredential(contents), dirResp.XPelNsHdr.Namespace, copyDestUrl.Path, dirResp)
 			}
 		}
 	}
@@ -2338,7 +2348,7 @@ func (tc *TransferClient) NewCopyJob(ctx context.Context, src *url.URL, dest *ur
 			tj.srcDirResp = srcDirResp
 			tj.srcToken.SetDirectorResponse(&srcDirResp)
 			if tc.engine != nil && tc.engine.dirRespCache != nil && srcDirResp.XPelNsHdr.Namespace != "" {
-				tc.engine.dirRespCache.Store(copySrcUrl.FedInfo.DiscoveryEndpoint, NewDirRespFlavor(http.MethodGet, false, copySrcUrl.RawQuery), srcDirResp.XPelNsHdr.Namespace, copySrcUrl.Path, srcDirResp)
+				tc.engine.dirRespCache.Store(copySrcUrl.FedInfo.DiscoveryEndpoint, NewDirRespFlavor(http.MethodGet, false, copySrcUrl.RawQuery).WithCredential(contents), srcDirResp.XPelNsHdr.Namespace, copySrcUrl.Path, srcDirResp)
 			}
 		}
 	} else {
@@ -2448,7 +2458,7 @@ func (tc *TransferClient) CacheInfo(ctx context.Context, remoteUrl *url.URL, opt
 			}
 			token.SetDirectorResponse(&dirResp)
 			if tc.engine != nil && tc.engine.dirRespCache != nil && dirResp.XPelNsHdr.Namespace != "" {
-				tc.engine.dirRespCache.Store(pelicanURL.FedInfo.DiscoveryEndpoint, NewDirRespFlavor(http.MethodGet, false, pelicanURL.RawQuery), dirResp.XPelNsHdr.Namespace, pelicanURL.Path, dirResp)
+				tc.engine.dirRespCache.Store(pelicanURL.FedInfo.DiscoveryEndpoint, NewDirRespFlavor(http.MethodGet, false, pelicanURL.RawQuery).WithCredential(contents), dirResp.XPelNsHdr.Namespace, pelicanURL.Path, dirResp)
 			}
 		}
 	} else if !directorless {

--- a/client/main.go
+++ b/client/main.go
@@ -234,9 +234,10 @@ func stat(ctx context.Context, te *TransferEngine, destination string, options .
 
 	// Reuse the engine's director responses the way job creation does, when
 	// there is an engine. A cache stats before it downloads, so otherwise every
-	// miss spends two director queries on the same namespace. Only the read
-	// flavor is cached: an upload destination asks a different question and
-	// gets a different answer, and the cache is keyed only by prefix.
+	// miss spends two director queries on the same namespace. Cache entries
+	// are keyed by flavor -- verb, cache-mode routing, and the URL query --
+	// so an upload destination is cached too and can never be answered with a
+	// read's caches.
 	var dirResp server_structs.DirectorResponse
 	// A stat against a directorless federation is its own metadata query: the
 	// PROPFIND carries back whatever a preceding one would have said, so asking
@@ -245,8 +246,9 @@ func stat(ctx context.Context, te *TransferEngine, destination string, options .
 	directorless := pUrl.FedInfo.DirectorEndpoint == "" && pUrl.FedInfo.DiscoveryEndpoint != ""
 	if directorless && !uploadDestination {
 		dirResp, err = resolveForRequest(ctx, pUrl, directorMethod, "", cacheMode)
-	} else if te != nil && te.dirRespCache != nil && !uploadDestination {
-		dirResp, err = te.dirRespCache.LookupOrLoad(ctx, pUrl.FedInfo.DiscoveryEndpoint, pUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+	} else if te != nil && te.dirRespCache != nil {
+		flavor := NewDirRespFlavor(directorMethod, cacheMode, pUrl.RawQuery)
+		dirResp, err = te.dirRespCache.LookupOrLoad(ctx, pUrl.FedInfo.DiscoveryEndpoint, flavor, pUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 			resp, qErr := getDirectorInfoForPath(ctx, pUrl, directorMethod, "", cacheMode)
 			return resp, resp.XPelNsHdr.Namespace, qErr
 		})

--- a/client/main.go
+++ b/client/main.go
@@ -574,12 +574,50 @@ func Walk(ctx context.Context, remoteObject string, fn WalkFunc, options ...Tran
 	return walkOn(ctx, te, remoteObject, fn, options...)
 }
 
+// Walk is the package-level Walk for a caller that already holds an engine.
+// It skips the per-call engine setup and teardown, and the listing reuses
+// the engine's director responses instead of asking again.
+func (te *TransferEngine) Walk(ctx context.Context, remoteObject string, fn WalkFunc, options ...TransferOption) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Debugln("Panic captured while attempting to perform Walk:", r)
+			log.Debugln("Panic caused by the following", string(debug.Stack()))
+			err = errors.Errorf("Unrecoverable error (panic) captured in Walk: %v", r)
+		}
+	}()
+	return walkOn(ctx, te, remoteObject, fn, options...)
+}
+
+// List is DoList for a caller that already holds an engine.
+func (te *TransferEngine) List(ctx context.Context, remoteObject string, options ...TransferOption) ([]FileInfo, error) {
+	return collectList(func(fn WalkFunc) error {
+		return te.Walk(ctx, remoteObject, fn, options...)
+	})
+}
+
+// collectList buffers a walk into a slice, aborting on the first error --
+// the historical DoList shape, shared by both entry points.
+func collectList(walk func(WalkFunc) error) ([]FileInfo, error) {
+	var fileInfos []FileInfo
+	err := walk(func(info FileInfo, emitErr error) error {
+		if emitErr != nil {
+			return emitErr
+		}
+		fileInfos = append(fileInfos, info)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return fileInfos, nil
+}
+
 // walkOn is Walk without the transfer-engine dance; the caller owns the
 // TransferEngine (te is currently unused at the listing layer, but WalkMany
 // forwards a shared one anyway so the resource story matches what callers
 // expect). Panic recovery, options parsing, and SkipAll unwrapping happen
 // here, since they must apply to every Walk-shaped listing.
-func walkOn(ctx context.Context, _ *TransferEngine, remoteObject string, fn WalkFunc, options ...TransferOption) error {
+func walkOn(ctx context.Context, te *TransferEngine, remoteObject string, fn WalkFunc, options ...TransferOption) error {
 	pUrl, err := ParseRemoteAsPUrl(ctx, remoteObject)
 	if err != nil {
 		return errors.Wrapf(err, "failed to parse remote path: %s", remoteObject)
@@ -587,7 +625,21 @@ func walkOn(ctx context.Context, _ *TransferEngine, remoteObject string, fn Walk
 
 	// A listing carries back what a metadata query would have said, so a
 	// directorless federation is not asked twice.
-	dirResp, err := resolveForRequest(ctx, pUrl, http.MethodGet, "", false)
+	//
+	// When the caller owns an engine, take the director response from its
+	// cache: walking many collections under one namespace -- listing a
+	// directory of directories, say -- otherwise asks the director once per
+	// collection for an answer that is the same every time.
+	var dirResp server_structs.DirectorResponse
+	if te != nil && te.dirRespCache != nil {
+		flavor := NewDirRespFlavor(http.MethodGet, false, pUrl.RawQuery)
+		dirResp, err = te.dirRespCache.LookupOrLoad(ctx, pUrl.FedInfo.DiscoveryEndpoint, flavor, pUrl.Path, func(lCtx context.Context) (server_structs.DirectorResponse, string, error) {
+			resp, qErr := resolveForRequest(lCtx, pUrl, http.MethodGet, "", false)
+			return resp, resp.XPelNsHdr.Namespace, qErr
+		})
+	} else {
+		dirResp, err = resolveForRequest(ctx, pUrl, http.MethodGet, "", false)
+	}
 	if err != nil {
 		return err
 	}
@@ -753,17 +805,9 @@ func fanOutWalk(ctx context.Context, roots []string, parallelism int, fn WalkMan
 // partial results are discarded. Prefer Walk or WalkSeq when you want to
 // keep going past per-subtree failures.
 func DoList(ctx context.Context, remoteObject string, options ...TransferOption) (fileInfos []FileInfo, err error) {
-	err = Walk(ctx, remoteObject, func(info FileInfo, emitErr error) error {
-		if emitErr != nil {
-			return emitErr
-		}
-		fileInfos = append(fileInfos, info)
-		return nil
-	}, options...)
-	if err != nil {
-		return nil, err
-	}
-	return fileInfos, nil
+	return collectList(func(fn WalkFunc) error {
+		return Walk(ctx, remoteObject, fn, options...)
+	})
 }
 
 // errStopIter is returned from the callback inside walkAsSeq to unwind the
@@ -822,6 +866,20 @@ func WalkSeq(ctx context.Context, remoteObject string, options ...TransferOption
 
 // DoDelete queries the director using the DELETE HTTP method, retrieves the token, and initializes the delete operation.
 func DoDelete(ctx context.Context, remoteDestination string, recursive bool, options ...TransferOption) (err error) {
+	return deleteObj(ctx, nil, remoteDestination, recursive, options...)
+}
+
+// Delete is DoDelete for a caller that already holds an engine; the director
+// response is taken from the engine's cache rather than re-queried. Removing
+// many objects from one namespace otherwise spends a director round trip on
+// each.
+func (te *TransferEngine) Delete(ctx context.Context, remoteDestination string, recursive bool, options ...TransferOption) (err error) {
+	return deleteObj(ctx, te, remoteDestination, recursive, options...)
+}
+
+// deleteObj is the body of both. te may be nil, in which case the Director is
+// queried directly.
+func deleteObj(ctx context.Context, te *TransferEngine, remoteDestination string, recursive bool, options ...TransferOption) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Debugln("Panic occurred while attempting to perform delete operation (DoDelete):", r)
@@ -840,7 +898,16 @@ func DoDelete(ctx context.Context, remoteDestination string, recursive bool, opt
 		recursive = true
 	}
 
-	dirResp, err := getDirectorInfoForPath(ctx, pUrl, http.MethodDelete, "", false)
+	var dirResp server_structs.DirectorResponse
+	if te != nil && te.dirRespCache != nil {
+		flavor := NewDirRespFlavor(http.MethodDelete, false, pUrl.RawQuery)
+		dirResp, err = te.dirRespCache.LookupOrLoad(ctx, pUrl.FedInfo.DiscoveryEndpoint, flavor, pUrl.Path, func(lCtx context.Context) (server_structs.DirectorResponse, string, error) {
+			resp, qErr := getDirectorInfoForPath(lCtx, pUrl, http.MethodDelete, "", false)
+			return resp, resp.XPelNsHdr.Namespace, qErr
+		})
+	} else {
+		dirResp, err = getDirectorInfoForPath(ctx, pUrl, http.MethodDelete, "", false)
+	}
 	if err != nil {
 		return err
 	}

--- a/client/pelican_fs.go
+++ b/client/pelican_fs.go
@@ -119,9 +119,25 @@ func (pfs *PelicanFS) OpenFile(name string, flag int) (fs.File, error) {
 		operation = config.TokenWrite
 	}
 
-	dirResp, err := getDirectorInfoForPath(pfs.ctx, pUrl, httpMethod, "", false)
-	if err != nil {
-		return nil, &fs.PathError{Op: "open", Path: name, Err: err}
+	// Reads reuse the engine's cached director response (5 min TTL):
+	// block/filesystem-oriented callers open many objects under one
+	// namespace in quick succession and should neither pay a director
+	// round trip per open nor couple every read to the director's
+	// availability. Writes keep asking directly -- an upload destination
+	// asks the director a different question, and only the read flavor is
+	// cached.
+	var dirResp server_structs.DirectorResponse
+	var err2 error
+	if !writeMode && pfs.transferEngine != nil && pfs.transferEngine.dirRespCache != nil {
+		dirResp, err2 = pfs.transferEngine.dirRespCache.LookupOrLoad(pfs.ctx, pUrl.FedInfo.DiscoveryEndpoint, pUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+			resp, qErr := getDirectorInfoForPath(ctx, pUrl, httpMethod, "", false)
+			return resp, resp.XPelNsHdr.Namespace, qErr
+		})
+	} else {
+		dirResp, err2 = getDirectorInfoForPath(pfs.ctx, pUrl, httpMethod, "", false)
+	}
+	if err2 != nil {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: err2}
 	}
 
 	token := newTokenGenerator(pUrl, &dirResp, operation, true)

--- a/client/pelican_fs.go
+++ b/client/pelican_fs.go
@@ -72,6 +72,16 @@ func NewPelicanFSWithPrefix(ctx context.Context, urlPrefix string, options ...Tr
 	}
 }
 
+// Engine returns the transfer engine backing this filesystem.  Callers that
+// also make one-off client calls (Stat, List) can pass it to the engine-aware
+// variants so those share this filesystem's director-response cache instead
+// of querying the director again.
+func (pfs *PelicanFS) Engine() *TransferEngine {
+	pfs.mu.Lock()
+	defer pfs.mu.Unlock()
+	return pfs.transferEngine
+}
+
 // Open opens the named file for reading and returns a fs.File that also
 // implements io.ReaderAt, io.Seeker, io.Writer (for write mode), and
 // fs.ReadDirFile (for directories).
@@ -119,17 +129,18 @@ func (pfs *PelicanFS) OpenFile(name string, flag int) (fs.File, error) {
 		operation = config.TokenWrite
 	}
 
-	// Reads reuse the engine's cached director response (5 min TTL):
-	// block/filesystem-oriented callers open many objects under one
-	// namespace in quick succession and should neither pay a director
-	// round trip per open nor couple every read to the director's
-	// availability. Writes keep asking directly -- an upload destination
-	// asks the director a different question, and only the read flavor is
-	// cached.
+	// Opens reuse the engine's cached director response (5 min TTL):
+	// filesystem-oriented callers open many objects under one namespace in
+	// quick succession and should neither pay a director round trip per
+	// open nor couple every operation to the director's availability.
+	// Reads and writes cache separately -- the flavor carries the verb, so
+	// a writer is never handed the caches a read was told to use -- as does
+	// each distinct query (?directread and friends steer matchmaking).
 	var dirResp server_structs.DirectorResponse
 	var err2 error
-	if !writeMode && pfs.transferEngine != nil && pfs.transferEngine.dirRespCache != nil {
-		dirResp, err2 = pfs.transferEngine.dirRespCache.LookupOrLoad(pfs.ctx, pUrl.FedInfo.DiscoveryEndpoint, pUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
+	if pfs.transferEngine != nil && pfs.transferEngine.dirRespCache != nil {
+		flavor := NewDirRespFlavor(httpMethod, false, pUrl.RawQuery)
+		dirResp, err2 = pfs.transferEngine.dirRespCache.LookupOrLoad(pfs.ctx, pUrl.FedInfo.DiscoveryEndpoint, flavor, pUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
 			resp, qErr := getDirectorInfoForPath(ctx, pUrl, httpMethod, "", false)
 			return resp, resp.XPelNsHdr.Namespace, qErr
 		})

--- a/pelican_url/discovery.go
+++ b/pelican_url/discovery.go
@@ -509,6 +509,15 @@ func (p *PelicanURL) PopulateFedInfo(opts ...DiscoveryOption) error {
 			}
 
 			p.FedInfo = item.Value().fedInfo
+			// The cached federation info carries no discovery endpoint --
+			// the uncached path below stamps it after discovery, and the
+			// TTL cache stores what discovery returned.  Stamp it here too:
+			// callers key on this to attribute a namespace to the
+			// federation it was learned from, and one that arrives empty
+			// silently disables that keying (the director-response cache
+			// refuses to store or match an entry with no federation, so
+			// every object pays a fresh director query).
+			p.FedInfo.DiscoveryEndpoint = discoveryUrl.String()
 			log.Debugln("Using cached federation info for", discoveryUrl.String())
 			return nil
 		}


### PR DESCRIPTION
Split out of #3625, which collected a batch of client and director fixes found while running a FUSE filesystem on top of the client library. This PR is the director-response-reuse subset, rebased onto `main` and independent of the rest.

The shape of the workload that surfaced these: one long-lived process, thousands of small transfers under a single namespace, with stat and list in the hot path. Each fix reproduces outside that use case; the filesystem just hit them first.

### Correctness first: the cache was keyed by the wrong thing

`DirRespCache` was keyed by federation and namespace prefix alone, but a director response answers one *specific* question. The object servers for a read are caches; for a write they're the origins that accept it; for a `?directread` read the origins again; and cache-mode routing asks a different endpoint entirely. Sharing one entry across those is wrong in both directions:

- an upload handed a read's entry addresses the write to caches that reject it, and discloses the write credential to every one of them;
- a `?directread` read handed a cache-routed entry is served exactly the stale copy it was explicitly avoiding.

Entries (and the singleflight coalescing key) now carry a `DirRespFlavor`: verb, cache-mode routing, and the normalized URL query. Making the flavor a required argument put every call site in front of the compiler, so each now states which question it asked. The TPC destination pins the COPY flavor across its PUT fallback, so lookup and store agree on one key and that entry never answers a plain PUT.

### Then the reuse the keying makes safe

Since the flavors can no longer collide, the paths that previously opted out can opt in:

**Uploads and upload-destination stats** are cached like everything else, so a writer no longer pays a director round trip per object.

**`PelicanFS` opens.** `OpenFile` queried the director on every open, so a caller reading 4MiB blocks paid a round trip per block *and* — worse — had read availability pinned to director availability: a transient director outage stalled I/O the object servers could have kept serving. Opens now go through the engine's existing `DirRespCache` (5 min TTL). `PelicanFS.Engine()` is exposed so a caller doing filesystem opens plus one-off `Stat`/`List` shares the same cache.

**The token-authenticated re-query.** Once a transfer holds a token it asks the director again, because the answer can depend on the credential presented. That re-query ran for every object and ignored the cache entirely — the pattern in a debug log was hit, hit, query, object after object. The answer is reusable, but only by the same credential: handing it to a caller bearing a different token (or none) would disclose what that token was shown. So the flavor gains a credential *fingerprint* — a digest, never the token, because cache keys are rendered into debug logs — and the re-query goes through the cache under it. The other paths that re-ask with a token were storing their authenticated response under the anonymous key, where a later unauthenticated lookup would have picked it up; they now store it credential-scoped too.

Measured against a token-protected federation-in-a-box, 12 uploads plus 12 downloads plus 12 stats over one namespace: **14 director queries before, 3 after.**

**Listings and deletes.** A listing built an entire `TransferEngine` per call — worker pool, goroutines, setup and teardown — and then resolved the director through a path that consults no cache at all, because `walkOn` ignored the engine it was handed. Deletes queried per object for the same reason. `TransferEngine` gains `Walk`, `List`, and `Delete` mirroring the existing `Stat`; the package-level entry points keep their previous behavior for callers that hold no engine. Measured against a federation-in-a-box, seeding six session directories then restoring and pruning across them: 5 director queries and zero engine teardowns, in place of one of each per listing.

### Testing

New cache-keying tests: `TestDirRespCacheFlavorIsolation`, `TestDirRespCacheSingleflightIsPerFlavor`, `TestDirRespCacheCredentialScoping`. The existing `DirRespCache` suite passes.

One note for reviewers: on my macOS box the federation-backed client tests fail against a clean `origin/main` checkout too, so they're environmental here rather than anything this branch did. CI is the arbiter.
