### PR TITLE
director: retire a shutting-down server's ad (relocation eviction dropped)

### DIFF
--- a/director/advertise.go
+++ b/director/advertise.go
@@ -358,11 +358,13 @@ func AdvertiseOSDF(ctx context.Context) error {
 	}
 
 	for _, ad := range originAdMap {
-		recordAd(ctx, ad.ServerAd, &ad.NamespaceAds)
+		// Topology ads carry no registry prefix to verify a name against.
+		recordAd(ctx, ad.ServerAd, &ad.NamespaceAds, false)
 	}
 
 	for _, ad := range cacheAdMap {
-		recordAd(ctx, ad.ServerAd, &ad.NamespaceAds)
+		// Topology ads carry no registry prefix to verify a name against.
+		recordAd(ctx, ad.ServerAd, &ad.NamespaceAds, false)
 	}
 
 	return nil

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -300,6 +300,54 @@ func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]
 		populateEWMAStatusWeight(&sAd, nil)
 	}
 
+	// A shutting-down server's final ad removes its cache entry outright.
+	// The name-keyed downtime filter alone is not enough: when a replacement
+	// server shares the name (the normal rollout case), the replacement's
+	// next healthy ad clears that filter — which used to resurrect the old
+	// server's still-cached ad for the remainder of its TTL.
+	if metrics.ParseHealthStatus(sAd.Status) == metrics.StatusShuttingDown {
+		log.Infof("Server %s (%s) advertised it is shutting down; removing it from matchmaking", sAd.Name, sAd.URL.String())
+		serverAds.Delete(rawURL)
+		serverAds.Delete(httpURL)
+		serverAds.Delete(httpsURL)
+		return
+	}
+
+	// Recognize replacements: a registration name identifies one logical
+	// server, so when an ad arrives for a name that is already cached at a
+	// DIFFERENT endpoint (an operator moved the origin — new host, port, or
+	// scheme), the two ads must not compete as if they were independent
+	// servers. StartTime orders the instances; without it on both sides
+	// (older Pelican versions) we cannot tell a replacement from an
+	// intentional multi-instance setup and leave both ads alone.
+	if !sAd.FromTopology && sAd.GetStartTime() > 0 {
+		for key, item := range serverAds.Items() {
+			if key == rawURL || key == httpURL || key == httpsURL {
+				continue
+			}
+			sib := item.Value()
+			if sib == nil || sib.FromTopology || sib.Name != sAd.Name || sib.Type != sAd.Type {
+				continue
+			}
+			if sib.GetStartTime() <= 0 {
+				continue
+			}
+			if sAd.GetStartTime() > sib.GetStartTime() {
+				log.Infof("Server %s moved from %s to %s; evicting the ad for the old endpoint", sAd.Name, key, sAd.URL.String())
+				serverAds.Delete(key)
+			} else if sAd.GetStartTime() < sib.GetStartTime() {
+				// A straggler heartbeat from the instance that was replaced
+				// (e.g. the old origin is still running during a rollout).
+				// Refusing it keeps the stale endpoint from re-inserting
+				// itself between the replacement's heartbeats. If this is a
+				// deliberate rollback, the rejection self-heals once the
+				// newer ad expires.
+				log.Infof("Ignoring ad for server %s at %s: a newer instance of this server is registered at %s", sAd.Name, sAd.URL.String(), sib.URL.String())
+				return
+			}
+		}
+	}
+
 	ad := server_structs.Advertisement{ServerAd: sAd, NamespaceAds: *namespaceAds}
 
 	adTTL := time.Until(sAd.Expiration)

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -246,7 +246,15 @@ func populateEWMAStatusWeight(newSAd, oldSAd *server_structs.ServerAd) {
 //  3. Set up the server `stat` call utilities
 //  4. Set up utilities for collecting origin/health server file transfer test status
 //  5. Return the updated ServerAd. The ServerAd passed in will not be modified
-func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]server_structs.NamespaceAd) (updatedAd server_structs.ServerAd) {
+//
+// nameAuthorized reports whether the caller confirmed that the advertised
+// server name is the one registered under the ad's registry prefix. The
+// advertise token authenticates the prefix, not the name, so anything keyed
+// by name -- retiring a shutting-down server, or evicting the ad of a server
+// that appears to have moved -- must not act on an unverified claim. Callers
+// that have not checked (topology ads, which carry no registration to check
+// against) pass false and get storage without those side effects.
+func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]server_structs.NamespaceAd, nameAuthorized bool) (updatedAd server_structs.ServerAd) {
 	if sAd.URL.String() == "" {
 		log.Errorf("The URL of the serverAd %#v is empty. Cannot set the TTL cache.", sAd)
 		return
@@ -305,7 +313,7 @@ func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]
 	// server shares the name (the normal rollout case), the replacement's
 	// next healthy ad clears that filter — which used to resurrect the old
 	// server's still-cached ad for the remainder of its TTL.
-	if metrics.ParseHealthStatus(sAd.Status) == metrics.StatusShuttingDown {
+	if nameAuthorized && metrics.ParseHealthStatus(sAd.Status) == metrics.StatusShuttingDown {
 		log.Infof("Server %s (%s) advertised it is shutting down; removing it from matchmaking", sAd.Name, sAd.URL.String())
 		serverAds.Delete(rawURL)
 		serverAds.Delete(httpURL)
@@ -320,7 +328,7 @@ func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]
 	// servers. StartTime orders the instances; without it on both sides
 	// (older Pelican versions) we cannot tell a replacement from an
 	// intentional multi-instance setup and leave both ads alone.
-	if !sAd.FromTopology && sAd.GetStartTime() > 0 {
+	if nameAuthorized && !sAd.FromTopology && sAd.GetStartTime() > 0 {
 		for key, item := range serverAds.Items() {
 			if key == rawURL || key == httpURL || key == httpsURL {
 				continue

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -337,6 +337,19 @@ func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]
 			if sib == nil || sib.FromTopology || sib.Name != sAd.Name || sib.Type != sAd.Type {
 				continue
 			}
+			// A shared name is not enough to conclude these are the same
+			// server. Name falls back to the hostname when Xrootd.Sitename
+			// is unset, so two origins on one host -- different ports,
+			// different exports, both perfectly legitimate -- advertise
+			// under the same name and would otherwise evict each other.
+			// The registry prefix is what actually identifies the
+			// registration: a server that moves endpoints keeps it, and two
+			// co-hosted servers do not share one. Without it on both sides
+			// there is nothing to distinguish the two cases, so leave them
+			// alone.
+			if sib.RegistryPrefix == "" || sAd.RegistryPrefix == "" || sib.RegistryPrefix != sAd.RegistryPrefix {
+				continue
+			}
 			if sib.GetStartTime() <= 0 {
 				continue
 			}

--- a/director/cache_ads.go
+++ b/director/cache_ads.go
@@ -321,54 +321,6 @@ func recordAd(ctx context.Context, sAd server_structs.ServerAd, namespaceAds *[]
 		return
 	}
 
-	// Recognize replacements: a registration name identifies one logical
-	// server, so when an ad arrives for a name that is already cached at a
-	// DIFFERENT endpoint (an operator moved the origin — new host, port, or
-	// scheme), the two ads must not compete as if they were independent
-	// servers. StartTime orders the instances; without it on both sides
-	// (older Pelican versions) we cannot tell a replacement from an
-	// intentional multi-instance setup and leave both ads alone.
-	if nameAuthorized && !sAd.FromTopology && sAd.GetStartTime() > 0 {
-		for key, item := range serverAds.Items() {
-			if key == rawURL || key == httpURL || key == httpsURL {
-				continue
-			}
-			sib := item.Value()
-			if sib == nil || sib.FromTopology || sib.Name != sAd.Name || sib.Type != sAd.Type {
-				continue
-			}
-			// A shared name is not enough to conclude these are the same
-			// server. Name falls back to the hostname when Xrootd.Sitename
-			// is unset, so two origins on one host -- different ports,
-			// different exports, both perfectly legitimate -- advertise
-			// under the same name and would otherwise evict each other.
-			// The registry prefix is what actually identifies the
-			// registration: a server that moves endpoints keeps it, and two
-			// co-hosted servers do not share one. Without it on both sides
-			// there is nothing to distinguish the two cases, so leave them
-			// alone.
-			if sib.RegistryPrefix == "" || sAd.RegistryPrefix == "" || sib.RegistryPrefix != sAd.RegistryPrefix {
-				continue
-			}
-			if sib.GetStartTime() <= 0 {
-				continue
-			}
-			if sAd.GetStartTime() > sib.GetStartTime() {
-				log.Infof("Server %s moved from %s to %s; evicting the ad for the old endpoint", sAd.Name, key, sAd.URL.String())
-				serverAds.Delete(key)
-			} else if sAd.GetStartTime() < sib.GetStartTime() {
-				// A straggler heartbeat from the instance that was replaced
-				// (e.g. the old origin is still running during a rollout).
-				// Refusing it keeps the stale endpoint from re-inserting
-				// itself between the replacement's heartbeats. If this is a
-				// deliberate rollback, the rejection self-heals once the
-				// newer ad expires.
-				log.Infof("Ignoring ad for server %s at %s: a newer instance of this server is registered at %s", sAd.Name, sAd.URL.String(), sib.URL.String())
-				return
-			}
-		}
-	}
-
 	ad := server_structs.Advertisement{ServerAd: sAd, NamespaceAds: *namespaceAds}
 
 	adTTL := time.Until(sAd.Expiration)

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -648,3 +648,109 @@ func TestGetCachedDowntimesDedup(t *testing.T) {
 
 	assert.ElementsMatch(t, []string{"dup-id", "registry-id"}, []string{downtimes[0].UUID, downtimes[1].UUID})
 }
+
+// TestRecordAdServerRelocation covers what happens when an operator moves a
+// server to a new endpoint (new host, port, or scheme) without changing its
+// registration name. The director keys advertisements by URL but keys
+// downtime/filtering by name, so without explicit handling the old and new
+// ads compete as if they were two independent servers -- and each request
+// can be matchmade to either, serving whichever namespace metadata (issuer,
+// collections URL) that instance advertised.
+func TestRecordAdServerRelocation(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	t.Cleanup(func() {
+		shutdownHealthTests()
+		shutdownStatUtils()
+	})
+	resetHealthTests()
+	shutdownStatUtils()
+
+	serverAds.DeleteAll()
+	go serverAds.Start()
+	t.Cleanup(func() {
+		serverAds.DeleteAll()
+		serverAds.Stop()
+	})
+
+	const name = "OSDF-TUTORIAL-ORIGIN"
+	oldURL := url.URL{Scheme: "https", Host: "tutorial-origin.example.org:8443"}
+	newURL := url.URL{Scheme: "https", Host: "tutorial-origin.example.org"}
+
+	mkAd := func(u url.URL, srvName string, startTime int64, status string) server_structs.ServerAd {
+		ad := server_structs.ServerAd{
+			URL:    u,
+			Type:   server_structs.OriginType.String(),
+			Status: status,
+		}
+		ad.Name = srvName
+		ad.StartTime = startTime
+		return ad
+	}
+	nsAds := []server_structs.NamespaceAd{}
+
+	t.Run("replacement-evicts-old-endpoint", func(t *testing.T) {
+		defer serverAds.DeleteAll()
+		recordAd(context.Background(), mkAd(oldURL, name, 1000, ""), &nsAds)
+		require.True(t, serverAds.Has(oldURL.String()))
+
+		recordAd(context.Background(), mkAd(newURL, name, 2000, ""), &nsAds)
+		assert.True(t, serverAds.Has(newURL.String()), "replacement must be recorded")
+		assert.False(t, serverAds.Has(oldURL.String()), "old endpoint must not linger and compete for matchmaking")
+	})
+
+	t.Run("straggler-ad-from-replaced-instance-is-ignored", func(t *testing.T) {
+		defer serverAds.DeleteAll()
+		recordAd(context.Background(), mkAd(newURL, name, 2000, ""), &nsAds)
+		// The old origin is still running and heartbeating during the rollout.
+		recordAd(context.Background(), mkAd(oldURL, name, 1000, ""), &nsAds)
+		assert.True(t, serverAds.Has(newURL.String()))
+		assert.False(t, serverAds.Has(oldURL.String()), "an older instance must not re-insert itself")
+	})
+
+	t.Run("shutdown-ad-removes-entry-and-replacement-does-not-resurrect-it", func(t *testing.T) {
+		defer serverAds.DeleteAll()
+		recordAd(context.Background(), mkAd(oldURL, name, 1000, ""), &nsAds)
+		require.True(t, serverAds.Has(oldURL.String()))
+
+		// Graceful shutdown: the final ad carries the shutdown status.
+		recordAd(context.Background(), mkAd(oldURL, name, 1000, "shutting down"), &nsAds)
+		assert.False(t, serverAds.Has(oldURL.String()), "a shutting-down server must leave matchmaking immediately")
+
+		// The replacement's healthy ad clears the name-keyed downtime filter;
+		// that must not bring the old endpoint's ad back.
+		recordAd(context.Background(), mkAd(newURL, name, 2000, ""), &nsAds)
+		assert.True(t, serverAds.Has(newURL.String()))
+		assert.False(t, serverAds.Has(oldURL.String()))
+	})
+
+	t.Run("distinct-servers-coexist", func(t *testing.T) {
+		defer serverAds.DeleteAll()
+		other := url.URL{Scheme: "https", Host: "other-origin.example.org"}
+		recordAd(context.Background(), mkAd(oldURL, name, 1000, ""), &nsAds)
+		recordAd(context.Background(), mkAd(other, "SOME-OTHER-ORIGIN", 2000, ""), &nsAds)
+		assert.True(t, serverAds.Has(oldURL.String()), "different names are different servers")
+		assert.True(t, serverAds.Has(other.String()))
+	})
+
+	t.Run("same-name-different-server-type-coexists", func(t *testing.T) {
+		defer serverAds.DeleteAll()
+		cacheURL := url.URL{Scheme: "https", Host: "tutorial-cache.example.org"}
+		cacheAd := mkAd(cacheURL, name, 2000, "")
+		cacheAd.Type = server_structs.CacheType.String()
+		recordAd(context.Background(), mkAd(oldURL, name, 1000, ""), &nsAds)
+		recordAd(context.Background(), cacheAd, &nsAds)
+		assert.True(t, serverAds.Has(oldURL.String()), "an origin and a cache sharing a name are distinct servers")
+		assert.True(t, serverAds.Has(cacheURL.String()))
+	})
+
+	t.Run("without-start-times-both-ads-are-kept", func(t *testing.T) {
+		defer serverAds.DeleteAll()
+		// Older Pelican versions do not report StartTime; we cannot tell a
+		// replacement from a deliberate multi-instance deployment, so leave
+		// the existing behavior (both ads live out their TTLs) alone.
+		recordAd(context.Background(), mkAd(oldURL, name, 0, ""), &nsAds)
+		recordAd(context.Background(), mkAd(newURL, name, 0, ""), &nsAds)
+		assert.True(t, serverAds.Has(oldURL.String()))
+		assert.True(t, serverAds.Has(newURL.String()))
+	})
+}

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -656,7 +656,7 @@ func TestGetCachedDowntimesDedup(t *testing.T) {
 // ads compete as if they were two independent servers -- and each request
 // can be matchmade to either, serving whichever namespace metadata (issuer,
 // collections URL) that instance advertised.
-func TestRecordAdServerRelocation(t *testing.T) {
+func TestRecordAdShutdownAndCoexistence(t *testing.T) {
 	t.Cleanup(test_utils.SetupTestLogging(t))
 	t.Cleanup(func() {
 		shutdownHealthTests()
@@ -693,25 +693,6 @@ func TestRecordAdServerRelocation(t *testing.T) {
 		return mkAdIn(registryPrefix, u, srvName, startTime, status)
 	}
 	nsAds := []server_structs.NamespaceAd{}
-
-	t.Run("replacement-evicts-old-endpoint", func(t *testing.T) {
-		defer serverAds.DeleteAll()
-		recordAd(context.Background(), mkAd(oldURL, name, 1000, ""), &nsAds, true)
-		require.True(t, serverAds.Has(oldURL.String()))
-
-		recordAd(context.Background(), mkAd(newURL, name, 2000, ""), &nsAds, true)
-		assert.True(t, serverAds.Has(newURL.String()), "replacement must be recorded")
-		assert.False(t, serverAds.Has(oldURL.String()), "old endpoint must not linger and compete for matchmaking")
-	})
-
-	t.Run("straggler-ad-from-replaced-instance-is-ignored", func(t *testing.T) {
-		defer serverAds.DeleteAll()
-		recordAd(context.Background(), mkAd(newURL, name, 2000, ""), &nsAds, true)
-		// The old origin is still running and heartbeating during the rollout.
-		recordAd(context.Background(), mkAd(oldURL, name, 1000, ""), &nsAds, true)
-		assert.True(t, serverAds.Has(newURL.String()))
-		assert.False(t, serverAds.Has(oldURL.String()), "an older instance must not re-insert itself")
-	})
 
 	t.Run("shutdown-ad-removes-entry-and-replacement-does-not-resurrect-it", func(t *testing.T) {
 		defer serverAds.DeleteAll()
@@ -755,21 +736,6 @@ func TestRecordAdServerRelocation(t *testing.T) {
 		assert.True(t, serverAds.Has(first.String()),
 			"a co-hosted origin must not be evicted as though the other had moved")
 		assert.True(t, serverAds.Has(second.String()), "the second origin must be recorded")
-	})
-
-	t.Run("relocation still applies within one registration", func(t *testing.T) {
-		// The guard above keys on the registry prefix, so a genuine move --
-		// same registration, new endpoint -- must still collapse to one ad.
-		defer serverAds.DeleteAll()
-		const sharedName = "co-hosted.example.org"
-		before := url.URL{Scheme: "https", Host: "co-hosted.example.org:34233"}
-		after := url.URL{Scheme: "https", Host: "co-hosted.example.org:43335"}
-
-		recordAd(context.Background(), mkAdIn("/origins/same", before, sharedName, 1000, ""), &nsAds, true)
-		recordAd(context.Background(), mkAdIn("/origins/same", after, sharedName, 2000, ""), &nsAds, true)
-
-		assert.True(t, serverAds.Has(after.String()), "the new endpoint must be recorded")
-		assert.False(t, serverAds.Has(before.String()), "the endpoint it moved off must not linger")
 	})
 
 	t.Run("same-name-different-server-type-coexists", func(t *testing.T) {

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -221,22 +221,22 @@ func TestRecordAd(t *testing.T) {
 
 	t.Run("topology-server-added-if-no-duplicate", func(t *testing.T) {
 		defer serverAds.DeleteAll()
-		recordAd(context.Background(), mockTopology.ServerAd, &mockTopology.NamespaceAds)
+		recordAd(context.Background(), mockTopology.ServerAd, &mockTopology.NamespaceAds, true)
 		assert.Len(t, serverAds.Items(), 1)
 		assert.True(t, serverAds.Has(topologyServerUrl.String()))
 	})
 
 	t.Run("pelican-server-added-if-no-duplicate", func(t *testing.T) {
 		defer serverAds.DeleteAll()
-		recordAd(context.Background(), mockPelican.ServerAd, &mockPelican.NamespaceAds)
+		recordAd(context.Background(), mockPelican.ServerAd, &mockPelican.NamespaceAds, true)
 		assert.Len(t, serverAds.Items(), 1)
 		assert.True(t, serverAds.Has(pelicanServerUrl.String()))
 	})
 
 	t.Run("pelican-server-overwrites-topology", func(t *testing.T) {
 		defer serverAds.DeleteAll()
-		recordAd(context.Background(), mockTopology.ServerAd, &mockTopology.NamespaceAds)
-		recordAd(context.Background(), mockPelican.ServerAd, &mockPelican.NamespaceAds)
+		recordAd(context.Background(), mockTopology.ServerAd, &mockTopology.NamespaceAds, true)
+		recordAd(context.Background(), mockPelican.ServerAd, &mockPelican.NamespaceAds, true)
 
 		assert.Len(t, serverAds.Items(), 1)
 		assert.True(t, serverAds.Has(pelicanServerUrl.String()))
@@ -247,8 +247,8 @@ func TestRecordAd(t *testing.T) {
 
 	t.Run("topology-server-is-ignored-with-dup-pelican-server", func(t *testing.T) {
 		defer serverAds.DeleteAll()
-		recordAd(context.Background(), mockPelican.ServerAd, &mockPelican.NamespaceAds)
-		recordAd(context.Background(), mockTopology.ServerAd, &mockTopology.NamespaceAds)
+		recordAd(context.Background(), mockPelican.ServerAd, &mockPelican.NamespaceAds, true)
+		recordAd(context.Background(), mockTopology.ServerAd, &mockTopology.NamespaceAds, true)
 
 		assert.Len(t, serverAds.Items(), 1)
 		assert.True(t, serverAds.Has(pelicanServerUrl.String()))
@@ -279,7 +279,7 @@ func TestRecordAd(t *testing.T) {
 		mockUrl := url.URL{Scheme: "https", Host: "192.168.100.100"}
 		serverAd := server_structs.ServerAd{URL: mockUrl, WebURL: mockUrl, FromTopology: false}
 		serverAd.Initialize("TEST_ORIGIN")
-		updatedAd := recordAd(context.Background(), serverAd, &mockPelican.NamespaceAds)
+		updatedAd := recordAd(context.Background(), serverAd, &mockPelican.NamespaceAds, true)
 		assert.NotEmpty(t, updatedAd.Longitude)
 		assert.NotEmpty(t, updatedAd.Latitude)
 		_, ok := healthTestUtils[mockUrl.String()]
@@ -690,35 +690,35 @@ func TestRecordAdServerRelocation(t *testing.T) {
 
 	t.Run("replacement-evicts-old-endpoint", func(t *testing.T) {
 		defer serverAds.DeleteAll()
-		recordAd(context.Background(), mkAd(oldURL, name, 1000, ""), &nsAds)
+		recordAd(context.Background(), mkAd(oldURL, name, 1000, ""), &nsAds, true)
 		require.True(t, serverAds.Has(oldURL.String()))
 
-		recordAd(context.Background(), mkAd(newURL, name, 2000, ""), &nsAds)
+		recordAd(context.Background(), mkAd(newURL, name, 2000, ""), &nsAds, true)
 		assert.True(t, serverAds.Has(newURL.String()), "replacement must be recorded")
 		assert.False(t, serverAds.Has(oldURL.String()), "old endpoint must not linger and compete for matchmaking")
 	})
 
 	t.Run("straggler-ad-from-replaced-instance-is-ignored", func(t *testing.T) {
 		defer serverAds.DeleteAll()
-		recordAd(context.Background(), mkAd(newURL, name, 2000, ""), &nsAds)
+		recordAd(context.Background(), mkAd(newURL, name, 2000, ""), &nsAds, true)
 		// The old origin is still running and heartbeating during the rollout.
-		recordAd(context.Background(), mkAd(oldURL, name, 1000, ""), &nsAds)
+		recordAd(context.Background(), mkAd(oldURL, name, 1000, ""), &nsAds, true)
 		assert.True(t, serverAds.Has(newURL.String()))
 		assert.False(t, serverAds.Has(oldURL.String()), "an older instance must not re-insert itself")
 	})
 
 	t.Run("shutdown-ad-removes-entry-and-replacement-does-not-resurrect-it", func(t *testing.T) {
 		defer serverAds.DeleteAll()
-		recordAd(context.Background(), mkAd(oldURL, name, 1000, ""), &nsAds)
+		recordAd(context.Background(), mkAd(oldURL, name, 1000, ""), &nsAds, true)
 		require.True(t, serverAds.Has(oldURL.String()))
 
 		// Graceful shutdown: the final ad carries the shutdown status.
-		recordAd(context.Background(), mkAd(oldURL, name, 1000, "shutting down"), &nsAds)
+		recordAd(context.Background(), mkAd(oldURL, name, 1000, "shutting down"), &nsAds, true)
 		assert.False(t, serverAds.Has(oldURL.String()), "a shutting-down server must leave matchmaking immediately")
 
 		// The replacement's healthy ad clears the name-keyed downtime filter;
 		// that must not bring the old endpoint's ad back.
-		recordAd(context.Background(), mkAd(newURL, name, 2000, ""), &nsAds)
+		recordAd(context.Background(), mkAd(newURL, name, 2000, ""), &nsAds, true)
 		assert.True(t, serverAds.Has(newURL.String()))
 		assert.False(t, serverAds.Has(oldURL.String()))
 	})
@@ -726,8 +726,8 @@ func TestRecordAdServerRelocation(t *testing.T) {
 	t.Run("distinct-servers-coexist", func(t *testing.T) {
 		defer serverAds.DeleteAll()
 		other := url.URL{Scheme: "https", Host: "other-origin.example.org"}
-		recordAd(context.Background(), mkAd(oldURL, name, 1000, ""), &nsAds)
-		recordAd(context.Background(), mkAd(other, "SOME-OTHER-ORIGIN", 2000, ""), &nsAds)
+		recordAd(context.Background(), mkAd(oldURL, name, 1000, ""), &nsAds, true)
+		recordAd(context.Background(), mkAd(other, "SOME-OTHER-ORIGIN", 2000, ""), &nsAds, true)
 		assert.True(t, serverAds.Has(oldURL.String()), "different names are different servers")
 		assert.True(t, serverAds.Has(other.String()))
 	})
@@ -737,8 +737,8 @@ func TestRecordAdServerRelocation(t *testing.T) {
 		cacheURL := url.URL{Scheme: "https", Host: "tutorial-cache.example.org"}
 		cacheAd := mkAd(cacheURL, name, 2000, "")
 		cacheAd.Type = server_structs.CacheType.String()
-		recordAd(context.Background(), mkAd(oldURL, name, 1000, ""), &nsAds)
-		recordAd(context.Background(), cacheAd, &nsAds)
+		recordAd(context.Background(), mkAd(oldURL, name, 1000, ""), &nsAds, true)
+		recordAd(context.Background(), cacheAd, &nsAds, true)
 		assert.True(t, serverAds.Has(oldURL.String()), "an origin and a cache sharing a name are distinct servers")
 		assert.True(t, serverAds.Has(cacheURL.String()))
 	})
@@ -748,8 +748,8 @@ func TestRecordAdServerRelocation(t *testing.T) {
 		// Older Pelican versions do not report StartTime; we cannot tell a
 		// replacement from a deliberate multi-instance deployment, so leave
 		// the existing behavior (both ads live out their TTLs) alone.
-		recordAd(context.Background(), mkAd(oldURL, name, 0, ""), &nsAds)
-		recordAd(context.Background(), mkAd(newURL, name, 0, ""), &nsAds)
+		recordAd(context.Background(), mkAd(oldURL, name, 0, ""), &nsAds, true)
+		recordAd(context.Background(), mkAd(newURL, name, 0, ""), &nsAds, true)
 		assert.True(t, serverAds.Has(oldURL.String()))
 		assert.True(t, serverAds.Has(newURL.String()))
 	})

--- a/director/cache_ads_test.go
+++ b/director/cache_ads_test.go
@@ -676,15 +676,21 @@ func TestRecordAdServerRelocation(t *testing.T) {
 	oldURL := url.URL{Scheme: "https", Host: "tutorial-origin.example.org:8443"}
 	newURL := url.URL{Scheme: "https", Host: "tutorial-origin.example.org"}
 
-	mkAd := func(u url.URL, srvName string, startTime int64, status string) server_structs.ServerAd {
+	const registryPrefix = "/origins/tutorial-origin.example.org"
+
+	mkAdIn := func(prefix string, u url.URL, srvName string, startTime int64, status string) server_structs.ServerAd {
 		ad := server_structs.ServerAd{
-			URL:    u,
-			Type:   server_structs.OriginType.String(),
-			Status: status,
+			URL:            u,
+			Type:           server_structs.OriginType.String(),
+			Status:         status,
+			RegistryPrefix: prefix,
 		}
 		ad.Name = srvName
 		ad.StartTime = startTime
 		return ad
+	}
+	mkAd := func(u url.URL, srvName string, startTime int64, status string) server_structs.ServerAd {
+		return mkAdIn(registryPrefix, u, srvName, startTime, status)
 	}
 	nsAds := []server_structs.NamespaceAd{}
 
@@ -730,6 +736,40 @@ func TestRecordAdServerRelocation(t *testing.T) {
 		recordAd(context.Background(), mkAd(other, "SOME-OTHER-ORIGIN", 2000, ""), &nsAds, true)
 		assert.True(t, serverAds.Has(oldURL.String()), "different names are different servers")
 		assert.True(t, serverAds.Has(other.String()))
+	})
+
+	t.Run("co-hosted servers sharing a hostname-derived name coexist", func(t *testing.T) {
+		// Name falls back to the hostname when Xrootd.Sitename is unset, so
+		// two origins on one host advertise under the same name at different
+		// ports. They are separate registrations and both must stay: this is
+		// how the cross-origin TPC tests are built, and treating one as a
+		// relocation of the other silently removed an origin mid-test.
+		defer serverAds.DeleteAll()
+		const sharedName = "co-hosted.example.org"
+		first := url.URL{Scheme: "https", Host: "co-hosted.example.org:34233"}
+		second := url.URL{Scheme: "https", Host: "co-hosted.example.org:43335"}
+
+		recordAd(context.Background(), mkAdIn("/origins/first", first, sharedName, 1000, ""), &nsAds, true)
+		recordAd(context.Background(), mkAdIn("/origins/second", second, sharedName, 2000, ""), &nsAds, true)
+
+		assert.True(t, serverAds.Has(first.String()),
+			"a co-hosted origin must not be evicted as though the other had moved")
+		assert.True(t, serverAds.Has(second.String()), "the second origin must be recorded")
+	})
+
+	t.Run("relocation still applies within one registration", func(t *testing.T) {
+		// The guard above keys on the registry prefix, so a genuine move --
+		// same registration, new endpoint -- must still collapse to one ad.
+		defer serverAds.DeleteAll()
+		const sharedName = "co-hosted.example.org"
+		before := url.URL{Scheme: "https", Host: "co-hosted.example.org:34233"}
+		after := url.URL{Scheme: "https", Host: "co-hosted.example.org:43335"}
+
+		recordAd(context.Background(), mkAdIn("/origins/same", before, sharedName, 1000, ""), &nsAds, true)
+		recordAd(context.Background(), mkAdIn("/origins/same", after, sharedName, 2000, ""), &nsAds, true)
+
+		assert.True(t, serverAds.Has(after.String()), "the new endpoint must be recorded")
+		assert.False(t, serverAds.Has(before.String()), "the endpoint it moved off must not linger")
 	})
 
 	t.Run("same-name-different-server-type-coexists", func(t *testing.T) {

--- a/director/director.go
+++ b/director/director.go
@@ -1431,7 +1431,12 @@ func registerServerAd(engineCtx context.Context, ctx *gin.Context, sType server_
 	// registration) but skip all filter mutation, so a server can neither suppress
 	// nor resurrect routing for a name it doesn't own.
 	sn := ad.Name
-	if downtimeNameAuthorized(engineCtx, sn, registryPrefix) {
+	// Computed once: it also decides whether recordAd may act on this ad's
+	// name below (retiring a shutting-down server, or evicting the ad of one
+	// that appears to have moved), which is name-keyed for the same reason
+	// and unsafe on an unverified claim for the same reason.
+	nameAuthorized := downtimeNameAuthorized(engineCtx, sn, registryPrefix)
+	if nameAuthorized {
 		// Process received server(origin/cache) downtimes and toggle the director's in-memory downtime tracker
 		applyServerDowntimes(sn, ad.Downtimes)
 
@@ -1484,11 +1489,13 @@ func registerServerAd(engineCtx context.Context, ctx *gin.Context, sType server_
 	}
 	ad.Now = time.Time{}
 
-	finishRegisterServeAd(engineCtx, ctx, &ad, sType)
+	finishRegisterServeAd(engineCtx, ctx, &ad, sType, nameAuthorized)
 }
 
 // Finish registering the provided service ad (cache or origin) after authorization was completed.
-func finishRegisterServeAd(engineCtx context.Context, ctx *gin.Context, ad *server_structs.OriginAdvertise, sType server_structs.ServerType) {
+// nameAuthorized is passed through to recordAd: see its doc comment for why
+// anything keyed by the advertised name may not act on an unverified claim.
+func finishRegisterServeAd(engineCtx context.Context, ctx *gin.Context, ad *server_structs.OriginAdvertise, sType server_structs.ServerType, nameAuthorized bool) {
 	log.Debugf("finishRegisterServeAd received %+v", ad)
 	st := ad.StorageType
 	// Defaults to POSIX
@@ -1553,7 +1560,7 @@ func finishRegisterServeAd(engineCtx context.Context, ctx *gin.Context, ad *serv
 	}
 	sAd.CopyFrom(ad)
 
-	recordAd(engineCtx, sAd, &ad.Namespaces)
+	recordAd(engineCtx, sAd, &ad.Namespaces, nameAuthorized)
 
 	ctx.JSON(http.StatusOK, server_structs.SimpleApiResp{Status: server_structs.RespOK, Msg: "Successful registration"})
 }

--- a/director/director_advertise.go
+++ b/director/director_advertise.go
@@ -217,7 +217,10 @@ func registerDirectorAd(appCtx context.Context, egrp *errgroup.Group, ctx *gin.C
 		if fAd.AdType == server_structs.OriginType.String() {
 			sType = server_structs.OriginType
 		}
-		finishRegisterServeAd(appCtx, ctx, fAd.ServiceAd, sType)
+		// Forwarded by a peer director, which resolved the advertised name
+		// against the registry before forwarding; this endpoint is
+		// director-authenticated and already trusted to insert ads at all.
+		finishRegisterServeAd(appCtx, ctx, fAd.ServiceAd, sType, true)
 		if ctx.IsAborted() {
 			return
 		}

--- a/director/director_test.go
+++ b/director/director_test.go
@@ -2086,7 +2086,7 @@ func TestRedirects(t *testing.T) {
 		}
 
 		cSlice := []server_structs.NamespaceAd{nsAd}
-		recordAd(context.Background(), pelCacheAd, &cSlice)
+		recordAd(context.Background(), pelCacheAd, &cSlice, true)
 
 		recorder := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(recorder)

--- a/director/sort_test.go
+++ b/director/sort_test.go
@@ -185,12 +185,12 @@ func TestGetAdsForPath(t *testing.T) {
 	o2Slice := []server_structs.NamespaceAd{nsAd2, nsAd3}
 	c1Slice := []server_structs.NamespaceAd{nsAd1, nsAd2, nsAdTopoOnly}
 	topoSlice := []server_structs.NamespaceAd{nsAdTopo1, nsAdTopoOnly}
-	recordAd(context.Background(), originAd2, &o2Slice)
-	recordAd(context.Background(), originAd1, &o1Slice)
+	recordAd(context.Background(), originAd2, &o2Slice, true)
+	recordAd(context.Background(), originAd1, &o1Slice, true)
 	// Add a server from Topology that serves /chtc namespace
-	recordAd(context.Background(), originAdTopo1, &topoSlice)
-	recordAd(context.Background(), cacheAd1, &c1Slice)
-	recordAd(context.Background(), cacheAd2, &o1Slice)
+	recordAd(context.Background(), originAdTopo1, &topoSlice, true)
+	recordAd(context.Background(), cacheAd1, &c1Slice, true)
+	recordAd(context.Background(), cacheAd2, &o1Slice, true)
 
 	testCases := []struct {
 		name            string


### PR DESCRIPTION
Fixes #3661.

**Scope reduced.** This started as two changes — retire a shutting-down server's ad, and evict the ad of a server that appears to have moved endpoints. The second one is gone; the history below explains why, because the reasoning matters more than the diff.

### What this does now

The director keys advertisements by URL but keys downtime and filtering by registration name, and nothing joins the two. A graceful shutdown set a *name*-keyed downtime filter and left the *URL*-keyed cache entry alone — and the replacement's next healthy ad, sharing that name, cleared the filter and brought the dead endpoint's ad back for the rest of its 15-minute TTL.

A shutting-down ad now deletes its own cache entry, so eligibility dies with the ad rather than with the name.

That inference is safe because it involves no guess about identity: the ad is reporting on *itself*. It is gated on `downtimeNameAuthorized`, the same check the director already applies to every other name-keyed mutation — the advertise token authenticates the registry prefix, not the name, so without the gate anyone able to advertise could retire another server's ad by claiming its name.

### Why the relocation half was removed

The premise was that an ad arriving for a name already cached at a different endpoint means that server moved. Three attempts, three legitimate deployments broken:

1. **No authorization.** Acting on `Status: shutting down` bypassed `downtimeNameAuthorized`, so a spoofed name could retire someone else's ad. Caught by `TestDirectorRegistration/name-mismatch-records-ad-but-cannot-mutate-filter`.
2. **Name is not identity.** `Name` falls back to the hostname when `Xrootd.Sitename` is unset, so two origins on one host share it. The cross-origin TPC tests build exactly that, and an origin was deleted mid-test:
   ```
   moved from https://…:34233 to https://…:43335; evicting the ad for the old endpoint
   ```
3. **Registry prefix is not identity either.** Requiring it to match as well still failed: co-located caches share `/caches/<hostname>`. `github_scripts/cache_availability_test.sh` starts three caches on one host with auto-assigned ports and no `Sitename` — the project's own test is the counterexample. Of the three ads, one survived.

The deeper problem is that a moved server and a co-located set are **indistinguishable at the moment an ad arrives**: same name, same prefix, same host, differing only in port and start time, whether an operator moved an origin or started a second cache. What separates them is what happens *next* — the moved endpoint stops heartbeating and its ad expires; co-located servers keep heartbeating. No inspection of a single ad recovers that.

So an ungraceful move is left to ad expiry, which is what handled it before this PR. The graceful case — the one originally hit on `/osdf-tutorial` — is covered by the shutdown retirement above.

**If relocation is worth revisiting**, staleness is the signal to build on: a sibling ad not refreshed in an advertisement interval or two is a departed endpoint, and a live co-located server is not. That rests on an observed fact rather than an assumption, and belongs in its own change.

### Testing

`TestRecordAdShutdownAndCoexistence` covers the retirement and, deliberately, the coexistence cases that the removed logic kept breaking: a shutdown ad removes the entry and a replacement does not resurrect it; distinct servers coexist; **co-hosted servers sharing a hostname-derived name coexist**; the same name under a different server type coexists; and ads without `StartTime` are both kept.

The `director` package passes apart from `TestDirectorShutdown` / `TestExpirationDirector` / `TestForwardDirector`, which fail identically on a clean `origin/main` checkout on this machine (~30s timeouts, environmental).
