### PR TITLE
xrootd: require the binary only for servers that launch it

### DIFF
--- a/xrootd/version_gate_test.go
+++ b/xrootd/version_gate_test.go
@@ -1,0 +1,65 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ ***************************************************************/
+
+package xrootd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/cache"
+	"github.com/pelicanplatform/pelican/origin"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
+)
+
+// The XRootD binary is a startup requirement only for servers that
+// actually launch one. Native origin backends and the v2 cache run
+// in-process, so demanding the binary would make it a hard dependency of
+// deployments that never use it.
+func TestServerLaunchesXrootd(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		storageType string
+		cacheV2     bool
+		server      server_structs.XRootDServer
+		want        bool
+	}{
+		{name: "posix origin launches xrootd", storageType: "posix", server: &origin.OriginServer{}, want: true},
+		{name: "s3 origin launches xrootd", storageType: "s3", server: &origin.OriginServer{}, want: true},
+		{name: "posixv2 origin is native", storageType: "posixv2", server: &origin.OriginServer{}, want: false},
+		{name: "pstore origin is native", storageType: "pstore", server: &origin.OriginServer{}, want: false},
+		{name: "s3v2 origin is native", storageType: "s3v2", server: &origin.OriginServer{}, want: false},
+		{name: "globusv2 origin is native", storageType: "globusv2", server: &origin.OriginServer{}, want: false},
+		{name: "v1 cache launches xrootd", cacheV2: false, server: &cache.CacheServer{}, want: true},
+		{name: "v2 cache is native", cacheV2: true, server: &cache.CacheServer{}, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, param.Reset())
+			defer func() { require.NoError(t, param.Reset()) }()
+			settings := map[string]any{"Cache.EnableV2": tc.cacheV2}
+			if tc.storageType != "" {
+				settings["Origin.StorageType"] = tc.storageType
+			}
+			require.NoError(t, param.MultiSet(settings))
+			assert.Equal(t, tc.want, serverLaunchesXrootd(tc.server))
+		})
+	}
+}

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -543,10 +543,33 @@ func enableSqliteWAL(dbPath string) error {
 	return nil
 }
 
+// serverLaunchesXrootd reports whether this server will actually start an
+// XRootD process. The native backends (posixv2, pstore, s3v2, httpsv2,
+// globusv2, ssh) and the v2 cache are served in-process by pelican and
+// never spawn the daemon.
+func serverLaunchesXrootd(server server_structs.XRootDServer) bool {
+	switch st := server.GetServerType(); {
+	case st.IsEnabled(server_structs.CacheType):
+		return !param.Cache_EnableV2.GetBool()
+	case st.IsEnabled(server_structs.OriginType):
+		return server_structs.OriginStorageType(param.Origin_StorageType.GetString()).UsesXRootD()
+	default:
+		// Unrecognized server kind: keep the conservative behavior and
+		// require the binary.
+		return true
+	}
+}
+
 func CheckXrootdEnv(server server_structs.XRootDServer) error {
-	// Check XRootD version before proceeding with environment setup
-	if err := CheckXrootdVersion(); err != nil {
-		return err
+	// Only require the XRootD binary when this server will run one.
+	// CheckDefaults calls this for every server, so an unconditional
+	// version probe made XRootD a hard startup dependency of deployments
+	// that never launch it — a native-backend origin or a v2 cache would
+	// refuse to start on a host without it.
+	if serverLaunchesXrootd(server) {
+		if err := CheckXrootdVersion(); err != nil {
+			return err
+		}
 	}
 
 	uid, err := config.GetDaemonUID()


### PR DESCRIPTION
`CheckDefaults` calls `CheckXrootdEnv` for every server, and its first statement probed the XRootD binary unconditionally. That made XRootD a hard startup dependency of deployments that never spawn it: a native-backend origin (posixv2, pstore, s3v2, httpsv2, globusv2, ssh) or a v2 cache would refuse to start on a host without the binary, dying with `XRootD binary not found in PATH` before serving anything.

The predicate already existed — `OriginStorageType.UsesXRootD`, which `originUsesXRootD` consults to decide whether to set up monitoring — it just wasn't consulted here. The version probe is now gated on whether this server actually launches a daemon (cache: `!Cache.EnableV2`; origin: `StorageType.UsesXRootD`), with unrecognized server kinds keeping the old conservative behavior. Everything else `CheckXrootdEnv` does is unchanged.

`CheckXrootdVersion` has exactly one non-test caller, so this is the only place that needed gating. The other binary lookup — `getXRootDRPaths` in `plugin_check.go` — already degrades gracefully, returning no paths when `exec.LookPath` fails.

### Verified against a built server

Built `pelican` (server tags) from this branch and from `origin/main`, and ran each with XRootD removed from `PATH`:

| server | binary | result |
|---|---|---|
| posixv2 origin | `origin/main` | **`Error: XRootD binary not found in PATH`** |
| posixv2 origin | this branch | no such error; proceeds to `Starting web engine...` |
| v2 cache | `origin/main` | **`Error: XRootD binary not found in PATH`** |
| v2 cache | this branch | no such error; cache registers and advertises |
| posix (v1) origin | this branch | **still** `Error: XRootD binary not found in PATH` — gate correctly not over-applied |

The patched posixv2 origin stops later, on `No namespace registry specified`, which is just my minimal test config lacking a federation — well past the check this PR is about.

Reaching the probe on the cache side needs a live director, since both cache paths in `launchers/cache_serve.go` call `CheckDefaults` *after* `GetNamespaceAdsFromDirector()`. Running `pelican serve --module director,registry,cache` with `Cache.EnableV2` supplies one in-process. No origin module was enabled, so the binary complaint on `origin/main` can only have come from the cache. On this branch the same invocation gets the cache all the way up:

```
Persistent cache HTTP handlers registered at /api/v1.0/cache/data/:discovery/*path
Cache introspection API registered at /api/v1.0/cache/introspect/
Namespace /caches/localhost not registered; new registration will proceed
Cache is registered
```

followed by ordinary advertise/evict traffic with the director, and no fatal error.

### Testing

`TestServerLaunchesXrootd` covers the predicate across origin storage types (posix and s3 launch XRootD; posixv2, pstore, s3v2, globusv2 are native) and both cache versions.

Found while making a downstream project's integration test run on a CI runner with no XRootD installed.
