### PR TITLE
Don't digest a collection; don't refuse a cache ad you could wait for or retry

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -265,6 +265,7 @@ type (
 		project            string
 		requireChecksum    bool
 		requestedChecksums []ChecksumType
+		skipChecksums      bool
 		err                error
 		writer             io.WriteCloser          // Optional writer for downloads
 		reader             io.ReadCloser           // Optional reader for uploads
@@ -317,6 +318,7 @@ type (
 		xferType           transferType
 		requestedChecksums []ChecksumType
 		requireChecksum    bool
+		skipChecksums      bool
 		recursive          bool
 		rejectCollections  bool // If true, error when the remote path is a collection
 		skipAcquire        bool
@@ -437,6 +439,7 @@ type (
 	identTransferOptionCollectionsUrl           struct{}
 	identTransferOptionChecksums                struct{}
 	identTransferOptionRequireChecksum          struct{}
+	identTransferOptionSkipChecksums            struct{}
 	identTransferOptionRecursive                struct{}
 	identTransferOptionDepth                    struct{}
 	identTransferOptionWriter                   struct{}
@@ -1307,6 +1310,20 @@ func WithObjectMetadataContentType(contentType string) TransferOption {
 	return option.New(identTransferOptionObjectMetadataBlobType{}, contentType)
 }
 
+// WithSkipChecksums suppresses the digest request a download otherwise makes
+// once the bytes are in hand.
+//
+// That request is a HEAD carrying Want-Digest, and it is worth making for an
+// object: it is what verifies the transfer. It is not worth making for a
+// response the caller has already decided it will neither store nor verify --
+// a cache streaming a collection's directory index, say. Servers are free to
+// ignore Want-Digest, and an XRootD origin asked to digest a collection
+// answers nothing at all, so the request sits until the transport's response
+// header timeout expires. The caller waiting on the download waits with it.
+func WithSkipChecksums() TransferOption {
+	return option.New(identTransferOptionSkipChecksums{}, true)
+}
+
 // Create an option to specify the token acquisition logic
 //
 // Token acquisition (e.g., using OAuth2 to get a token when one
@@ -1458,6 +1475,8 @@ func applyJobOptions(tj *TransferJob, options []TransferOption) {
 			tj.requestedChecksums = opt.Value().([]ChecksumType)
 		case identTransferOptionRequireChecksum{}:
 			tj.requireChecksum = opt.Value().(bool)
+		case identTransferOptionSkipChecksums{}:
+			tj.skipChecksums = opt.Value().(bool)
 		case identTransferOptionDryRun{}:
 			tj.dryRun = opt.Value().(bool)
 		case identTransferOptionMetadataChannel{}:
@@ -3120,6 +3139,7 @@ func (te *TransferEngine) createTransferFiles(job *clientTransferJob) (err error
 			srcToken:           job.job.srcToken,
 			requestedChecksums: job.job.requestedChecksums,
 			requireChecksum:    job.job.requireChecksum,
+			skipChecksums:      job.job.skipChecksums,
 			packOption:         packOption,
 			localPath:          job.job.localPath,
 			xferType:           job.job.xferType,
@@ -3931,6 +3951,16 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 				"url": transfer.remoteURL.String(),
 				"job": transfer.job.ID(),
 			}).Debugln("Skipping checksum verification for byte-range download")
+		} else if transfer.skipChecksums {
+			// The caller has said it will not verify this response and will
+			// not keep it, so the digest has no consumer. Asking anyway costs
+			// a round trip the caller waits on -- and against a server that
+			// declines to answer Want-Digest for this path, it costs the
+			// transport's full response header timeout.
+			log.WithFields(log.Fields{
+				"url": transfer.remoteURL.String(),
+				"job": transfer.job.ID(),
+			}).Debugln("Skipping checksum fetch at the caller's request")
 		} else {
 			// Fetch checksum of the downloaded file, compare it to the calculated.
 			// Use downloadAttemptCount (the number of download-loop iterations)
@@ -5797,6 +5827,7 @@ func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfer
 							remoteURL:          &url.URL{Path: remotePath},
 							requestedChecksums: job.job.requestedChecksums,
 							requireChecksum:    job.job.requireChecksum,
+							skipChecksums:      job.job.skipChecksums,
 							packOption:         transfers[0].PackOption,
 							localPath:          job.job.localPath,
 							xferType:           job.job.xferType,
@@ -5885,6 +5916,7 @@ func (te *TransferEngine) walkDirDownloadHelper(job *clientTransferJob, transfer
 					remoteURL:          &url.URL{Path: newPath},
 					requestedChecksums: job.job.requestedChecksums,
 					requireChecksum:    job.job.requireChecksum,
+					skipChecksums:      job.job.skipChecksums,
 					packOption:         transfers[0].PackOption,
 					localPath:          targetPath,
 					xferType:           job.job.xferType,

--- a/client/skip_checksums_test.go
+++ b/client/skip_checksums_test.go
@@ -1,0 +1,118 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package client
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/pelican_url"
+	"github.com/pelicanplatform/pelican/test_utils"
+)
+
+// TestSkipChecksumsSuppressesDigestRequest covers WithSkipChecksums.
+//
+// A download normally follows the body with a HEAD carrying Want-Digest, and
+// that request is what verifies the transfer -- so the default must keep
+// making it. A caller that will neither verify nor keep the response (a cache
+// passing a collection's index through) can opt out, and then no digest
+// request may be sent at all: against a server that declines to answer
+// Want-Digest for the path, that request sits until the transport's response
+// header timeout, and everyone waiting on the download waits with it.
+func TestSkipChecksumsSuppressesDigestRequest(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	test_utils.InitClient(t, map[param.Param]any{
+		param.Logging_Level: "debug",
+	})
+
+	body := []byte("collection index stand-in")
+	sum := md5.Sum(body)
+	md5Base64 := base64.StdEncoding.EncodeToString(sum[:])
+	contentLen := strconv.Itoa(len(body))
+
+	var digestRequests atomic.Int32
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			if r.Header.Get("Want-Digest") != "" {
+				digestRequests.Add(1)
+				w.Header().Set("Digest", "md5="+md5Base64)
+			}
+			w.Header().Set("Content-Length", contentLen)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.Header().Set("Content-Length", contentLen)
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write(body)
+		assert.NoError(t, err)
+	}))
+	defer svr.Close()
+
+	svrURL, err := url.Parse(svr.URL)
+	require.NoError(t, err)
+
+	newTransfer := func(skip bool) *transferFile {
+		return &transferFile{
+			xferType: transferTypeDownload,
+			ctx:      context.Background(),
+			job: &TransferJob{
+				remoteURL: &pelican_url.PelicanURL{
+					Scheme: "pelican://",
+					Host:   svrURL.Host,
+					Path:   svrURL.Path + "/object",
+				},
+			},
+			localPath:     os.DevNull,
+			remoteURL:     svrURL,
+			attempts:      []transferAttemptDetails{{Url: svrURL}},
+			skipChecksums: skip,
+		}
+	}
+
+	t.Run("default asks for a digest", func(t *testing.T) {
+		digestRequests.Store(0)
+		results, err := downloadObject(newTransfer(false))
+		require.NoError(t, err)
+		require.NoError(t, results.Error)
+		assert.Positive(t, digestRequests.Load(),
+			"a normal download must still fetch the digest that verifies it")
+	})
+
+	t.Run("skip sends none", func(t *testing.T) {
+		digestRequests.Store(0)
+		results, err := downloadObject(newTransfer(true))
+		require.NoError(t, err)
+		require.NoError(t, results.Error,
+			"skipping the digest must not fail the transfer")
+		assert.Zero(t, digestRequests.Load(),
+			"no Want-Digest request may be sent once the caller has opted out")
+	})
+}

--- a/director/allowed_prefixes_wait_test.go
+++ b/director/allowed_prefixes_wait_test.go
@@ -1,0 +1,85 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package director
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestWaitForAllowedPrefixesForCaches covers the wait that decides whether a
+// cache advertisement is held or refused.
+//
+// Holding matters because a refused cache does not advertise again until its
+// next cycle (Server.AdvertisementInterval, a minute by default) -- so the
+// wait has to outlast a registry that is merely slow to come up, while still
+// ending the moment the data arrives and the moment the caller gives up.
+func TestWaitForAllowedPrefixesForCaches(t *testing.T) {
+	// This timestamp is package-global and shared with the rest of the
+	// director tests; put back whatever was there.
+	original := allowedPrefixesForCachesLastSetTimestamp.Load()
+	t.Cleanup(func() { allowedPrefixesForCachesLastSetTimestamp.Store(original) })
+
+	t.Run("returns at once when already initialized", func(t *testing.T) {
+		allowedPrefixesForCachesLastSetTimestamp.Store(time.Now().Unix())
+
+		start := time.Now()
+		assert.True(t, waitForAllowedPrefixesForCaches(context.Background()))
+		assert.Less(t, time.Since(start), 100*time.Millisecond,
+			"an initialized director must not delay the ad at all")
+	})
+
+	t.Run("returns once the data arrives", func(t *testing.T) {
+		allowedPrefixesForCachesLastSetTimestamp.Store(0)
+
+		// Stand in for the registry becoming reachable partway through the
+		// wait, which is the case the hold exists for.
+		go func() {
+			time.Sleep(250 * time.Millisecond)
+			allowedPrefixesForCachesLastSetTimestamp.Store(time.Now().Unix())
+		}()
+
+		start := time.Now()
+		assert.True(t, waitForAllowedPrefixesForCaches(context.Background()),
+			"the ad should be held until the prefixes land, then accepted")
+		elapsed := time.Since(start)
+		assert.GreaterOrEqual(t, elapsed, 200*time.Millisecond, "it must actually have waited")
+		assert.Less(t, elapsed, allowedPrefixesInitWait,
+			"and returned when the data arrived rather than running out the bound")
+	})
+
+	t.Run("gives up when the caller does", func(t *testing.T) {
+		allowedPrefixesForCachesLastSetTimestamp.Store(0)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			cancel()
+		}()
+
+		start := time.Now()
+		assert.False(t, waitForAllowedPrefixesForCaches(ctx),
+			"a caller that has hung up must not hold a director goroutine")
+		assert.Less(t, time.Since(start), allowedPrefixesInitWait,
+			"cancellation must end the wait early, not run out the bound")
+	})
+}

--- a/director/director.go
+++ b/director/director.go
@@ -1179,10 +1179,15 @@ func registerServerAd(engineCtx context.Context, ctx *gin.Context, sType server_
 		// federation a minute without this cache to settle a condition that
 		// usually clears in seconds.
 		if !waitForAllowedPrefixesForCaches(ctx.Request.Context()) {
-			log.Error("Allowed prefixes for caches data was not initialized in time; asking this cache to advertise again shortly")
+			log.Error("Allowed prefixes for caches data was not initialized before this cache advertisement had to be answered")
 			// Distinct from the stale case below: nothing is known to be
 			// wrong, the director is simply not ready, so say so with a
 			// retryable status rather than a 500.
+			//
+			// Note that Pelican's own advertiser does not read this hint --
+			// doAdvertise treats any failure alike and waits for its next
+			// cycle -- so this is correct HTTP for other clients rather than
+			// something that shortens the retry today.
 			ctx.Header("Retry-After", "1")
 			ctx.JSON(http.StatusServiceUnavailable, server_structs.SimpleApiResp{
 				Status: server_structs.RespFailed,

--- a/director/director.go
+++ b/director/director.go
@@ -1170,19 +1170,25 @@ func registerServerAd(engineCtx context.Context, ctx *gin.Context, sType server_
 	// Check if the allowed prefixes for caches data from the registry
 	// has been initialized in the director
 	if sType == server_structs.CacheType {
-		// If the allowed prefix for caches data is not initialized,
-		// wait for it to be initialized for 3 seconds.
-		if allowedPrefixesForCachesLastSetTimestamp.Load() == 0 {
-			log.Warning("Allowed prefixes for caches data is not initialized. Waiting for initialization before continuing with processing cache server advertisement.")
-			start := time.Now()
-			// Wait until last set timestamp is updated
-			for allowedPrefixesForCachesLastSetTimestamp.Load() == 0 {
-				if time.Since(start) >= 3*time.Second {
-					log.Error("Allowed prefix for caches data was not initialized within the 3-second timeout")
-					break
-				}
-				time.Sleep(100 * time.Millisecond)
-			}
+		// A cache ad that arrives before the director has its allowed prefixes
+		// cannot be judged yet, so hold it rather than turning it away. The
+		// registry fetch behind this retries every second until it succeeds,
+		// but a cache whose ad is refused does not offer itself again until
+		// its next advertisement -- Server.AdvertisementInterval, a minute by
+		// default, with no retry in between. Refusing therefore costs the
+		// federation a minute without this cache to settle a condition that
+		// usually clears in seconds.
+		if !waitForAllowedPrefixesForCaches(ctx.Request.Context()) {
+			log.Error("Allowed prefixes for caches data was not initialized in time; asking this cache to advertise again shortly")
+			// Distinct from the stale case below: nothing is known to be
+			// wrong, the director is simply not ready, so say so with a
+			// retryable status rather than a 500.
+			ctx.Header("Retry-After", "1")
+			ctx.JSON(http.StatusServiceUnavailable, server_structs.SimpleApiResp{
+				Status: server_structs.RespFailed,
+				Msg:    "The Director has not yet fetched this cache's allowed prefixes from the Registry; please retry shortly.",
+			})
+			return
 		}
 
 		// If the allowed prefix for caches data is stale (older than 15 minutes),

--- a/director/registry_periodic_query.go
+++ b/director/registry_periodic_query.go
@@ -49,6 +49,46 @@ func init() {
 	allowedPrefixesForCachesLastSetTimestamp.Store(0)
 }
 
+// allowedPrefixesInitWait bounds how long a cache advertisement will be held
+// waiting for the director's allowed-prefixes data to arrive.
+//
+// The bound only has to cover the registry becoming reachable, because
+// LaunchRegistryPeriodicQuery retries every second until it is. It is set well
+// above that so an ordinarily slow federation startup does not turn a cache
+// away, and the wait ends as soon as the data lands. In practice the caller's
+// own timeout is the tighter bound: waitForAllowedPrefixesForCaches also
+// returns when the request context is cancelled.
+const allowedPrefixesInitWait = 30 * time.Second
+
+// waitForAllowedPrefixesForCaches blocks until the director has fetched the
+// allowed prefixes for caches at least once, reporting whether it did.
+//
+// It returns immediately once the data is present, and gives up when the
+// caller's context is cancelled or allowedPrefixesInitWait elapses.
+func waitForAllowedPrefixesForCaches(ctx context.Context) bool {
+	if allowedPrefixesForCachesLastSetTimestamp.Load() != 0 {
+		return true
+	}
+
+	deadline := time.NewTimer(allowedPrefixesInitWait)
+	defer deadline.Stop()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if allowedPrefixesForCachesLastSetTimestamp.Load() != 0 {
+				return true
+			}
+		case <-deadline.C:
+			return false
+		case <-ctx.Done():
+			return false
+		}
+	}
+}
+
 // convertListToSet converts a map of string to list of strings into a map of string to set of strings.
 func convertMapOfListToMapOfSet(input map[string][]string) map[string]map[string]struct{} {
 	result := make(map[string]map[string]struct{})

--- a/director/registry_periodic_query.go
+++ b/director/registry_periodic_query.go
@@ -52,13 +52,21 @@ func init() {
 // allowedPrefixesInitWait bounds how long a cache advertisement will be held
 // waiting for the director's allowed-prefixes data to arrive.
 //
-// The bound only has to cover the registry becoming reachable, because
-// LaunchRegistryPeriodicQuery retries every second until it is. It is set well
-// above that so an ordinarily slow federation startup does not turn a cache
-// away, and the wait ends as soon as the data lands. In practice the caller's
-// own timeout is the tighter bound: waitForAllowedPrefixesForCaches also
-// returns when the request context is cancelled.
-const allowedPrefixesInitWait = 30 * time.Second
+// This is not the bound that usually governs. A Pelican cache advertises with
+// a client that sets no timeout of its own, so its transport does:
+// Transport.ResponseHeaderTimeout, 10s by default. That client gives up first,
+// the request context is cancelled, and the wait ends there -- so what
+// actually decides whether an ad survives is the advertiser's timeout, not
+// this constant. It sits just above that default to bound a caller willing to
+// wait longer, and to keep a goroutine from being parked indefinitely by one
+// that never hangs up.
+//
+// Widening the window is worthwhile even so: the registry fetch behind this
+// retries every second, so most of what used to be refused inside 3s is now
+// accepted. A registry that takes longer than the advertiser's timeout to come
+// up will still cost that cache an advertisement cycle, because nothing on the
+// advertising side retries -- see doAdvertise in launcher_utils/advertise.go.
+const allowedPrefixesInitWait = 15 * time.Second
 
 // waitForAllowedPrefixesForCaches blocks until the director has fetched the
 // allowed prefixes for caches at least once, reporting whether it did.

--- a/launcher_utils/advertise.go
+++ b/launcher_utils/advertise.go
@@ -30,6 +30,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -52,10 +53,101 @@ type directorResponse struct {
 	ApprovalError bool   `json:"approval_error"`
 }
 
+// retryableAdError is a director response that says "not now" rather than
+// "no": the ad was not accepted, but nothing about it was judged wrong.
+//
+// It exists because the cost of treating the two alike is asymmetric. A
+// permanent rejection is worth reporting and waiting on; a director that is
+// merely not ready yet -- one that has not finished fetching the allowed
+// prefixes for caches, say -- clears in seconds, while waiting for the next
+// advertisement cycle leaves the federation without this server for
+// Server.AdvertisementInterval, a minute by default.
+type retryableAdError struct {
+	status     int
+	retryAfter time.Duration
+	msg        string
+}
+
+func (e *retryableAdError) Error() string {
+	return fmt.Sprintf("director is not ready to accept this advertisement (HTTP %d): %s", e.status, e.msg)
+}
+
+// isRetryableAdStatus reports whether a status means "ask again shortly".
+//
+// Deliberately narrow: 503 is the director saying it is not ready, and 429 is
+// it saying not so fast. Everything else -- including 500 -- is treated as a
+// real failure, because retrying a genuinely broken director every couple of
+// seconds only adds load to something already in trouble.
+func isRetryableAdStatus(status int) bool {
+	return status == http.StatusServiceUnavailable || status == http.StatusTooManyRequests
+}
+
+// parseAdRetryAfter reads a Retry-After header expressed in whole seconds,
+// which is the only form Pelican's own services send. An HTTP-date is valid
+// per RFC 9110 but is not produced here, and an unparsable or absent value
+// simply means "no hint" -- the caller supplies its own delay.
+//
+// The result is clamped so a hint cannot stall advertisement: a server that
+// asks for an hour still gets asked again on the caller's schedule.
+func parseAdRetryAfter(value string) time.Duration {
+	if value == "" {
+		return 0
+	}
+	seconds, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || seconds < 0 {
+		return 0
+	}
+	hint := time.Duration(seconds) * time.Second
+	if hint > maxAdRetryDelay {
+		return maxAdRetryDelay
+	}
+	return hint
+}
+
+const (
+	// adRetryAttempts is how many extra attempts a retryable rejection buys.
+	// Small on purpose: this is here to ride out a director still starting up,
+	// not to paper over one that is down. Once these are spent the ordinary
+	// advertisement cycle takes over, which is the behavior that existed
+	// before.
+	adRetryAttempts = 3
+	// defaultAdRetryDelay is used when the director sends no Retry-After.
+	defaultAdRetryDelay = 2 * time.Second
+	// maxAdRetryDelay caps both the hint and the default, keeping the whole
+	// retry sequence far short of an advertisement interval.
+	maxAdRetryDelay = 5 * time.Second
+)
+
 func doAdvertise(ctx context.Context, servers []server_structs.XRootDServer) {
 	log.Debugf("About to advertise %d XRootD servers", len(servers))
 	start := time.Now()
+
 	err := Advertise(ctx, servers)
+	// A director that answered "not yet" is worth asking again right away.
+	// Without this the next attempt is a whole advertisement cycle out, so a
+	// director that was starting up for a few seconds costs this server a
+	// minute of not being matchmade -- the ad is simply missing from the
+	// federation for that long.
+	for attempt := 1; attempt <= adRetryAttempts; attempt++ {
+		var retryable *retryableAdError
+		if !errors.As(err, &retryable) {
+			break
+		}
+		delay := retryable.retryAfter
+		if delay <= 0 {
+			delay = defaultAdRetryDelay
+		}
+		log.Infof("Director is not ready to accept the advertisement (%v); retrying in %v (attempt %d of %d)",
+			retryable.msg, delay, attempt, adRetryAttempts)
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			log.Debugln("Advertisement retry abandoned: context cancelled")
+			return
+		}
+		err = Advertise(ctx, servers)
+	}
+
 	duration := time.Since(start)
 	if err != nil {
 		log.Warningf("XRootD server advertise failed (duration %s): %v", duration.String(), err)
@@ -215,6 +307,15 @@ func advertiseInternal(ctx context.Context, server server_structs.XRootDServer) 
 					return errors.Wrapf(unmarshalErr, "could not decode the director's response, which responded %v from director advertisement: %s", resp.StatusCode, string(respbody))
 				}
 				log.Warningln("Error response from", directorUrl.String(), "status:", resp.StatusCode, "message:", respSimpleError.Msg)
+				if isRetryableAdStatus(resp.StatusCode) {
+					// Keep the status and any hint, so the caller can tell
+					// "not yet" from "no" instead of waiting a full cycle.
+					return &retryableAdError{
+						status:     resp.StatusCode,
+						retryAfter: parseAdRetryAfter(resp.Header.Get("Retry-After")),
+						msg:        respSimpleError.Msg,
+					}
+				}
 				return errors.Errorf("error during director advertisement: %v", respSimpleError.Msg)
 			}
 			successCount.Add(1)

--- a/launcher_utils/advertise_retry_test.go
+++ b/launcher_utils/advertise_retry_test.go
@@ -1,0 +1,103 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package launcher_utils
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsRetryableAdStatus pins down which director answers buy a quick retry.
+// The set is deliberately narrow: retrying a director that is actually broken
+// just adds load to something already in trouble.
+func TestIsRetryableAdStatus(t *testing.T) {
+	for _, status := range []int{http.StatusServiceUnavailable, http.StatusTooManyRequests} {
+		assert.True(t, isRetryableAdStatus(status), "HTTP %d means 'ask again shortly'", status)
+	}
+	for _, status := range []int{
+		http.StatusInternalServerError, // something is wrong, not merely unready
+		http.StatusForbidden,
+		http.StatusBadRequest,
+		http.StatusNotFound,
+		http.StatusOK,
+	} {
+		assert.False(t, isRetryableAdStatus(status), "HTTP %d must not be retried", status)
+	}
+}
+
+func TestParseAdRetryAfter(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   time.Duration
+	}{
+		{"absent means no hint", "", 0},
+		{"whole seconds", "1", time.Second},
+		{"surrounding space is tolerated", "  3 ", 3 * time.Second},
+		{"zero means no hint", "0", 0},
+		{"an HTTP-date is not a hint we understand", "Wed, 21 Oct 2026 07:28:00 GMT", 0},
+		{"garbage means no hint", "soon", 0},
+		{"negative means no hint", "-5", 0},
+		{"an absurd hint is clamped, never honored as-is", "3600", maxAdRetryDelay},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parseAdRetryAfter(tc.header))
+		})
+	}
+
+	assert.LessOrEqual(t, defaultAdRetryDelay, maxAdRetryDelay,
+		"the fallback delay must respect the same cap as a hint")
+}
+
+// TestRetryableAdErrorSurvivesWrapping guards the mechanism the retry hangs
+// on. doAdvertise decides whether to retry with errors.As, so if any layer
+// between the response handler and it were to flatten the error into a plain
+// string, the retry would silently never fire and the regression would be
+// invisible -- advertisement would simply go back to costing a full cycle.
+func TestRetryableAdErrorSurvivesWrapping(t *testing.T) {
+	base := &retryableAdError{
+		status:     http.StatusServiceUnavailable,
+		retryAfter: time.Second,
+		msg:        "not ready",
+	}
+
+	var found *retryableAdError
+	require.True(t, errors.As(error(base), &found), "the error must be recognizable as itself")
+	assert.Equal(t, http.StatusServiceUnavailable, found.status)
+	assert.Equal(t, time.Second, found.retryAfter)
+
+	// pkg/errors is what this package wraps with; make sure a wrap on the way
+	// up does not hide the status.
+	found = nil
+	wrapped := errors.Wrap(error(base), "failed to advertise")
+	require.True(t, errors.As(wrapped, &found), "wrapping must not hide a retryable rejection")
+	assert.Equal(t, http.StatusServiceUnavailable, found.status)
+
+	// And a plain failure must not be mistaken for a retryable one.
+	found = nil
+	assert.False(t, errors.As(errors.New("the director rejected the server advertisement"), &found))
+
+	assert.Contains(t, base.Error(), "503", "the message should name the status a reader will see in logs")
+}

--- a/local_cache/persistent_cache.go
+++ b/local_cache/persistent_cache.go
@@ -1997,6 +1997,15 @@ func (pc *PersistentCache) performDownload(ctx context.Context, dl *persistentDo
 		client.WithWriter(dw),
 		client.WithMetadataChannel(metadataChan),
 	}
+	if dl.forceNoStore {
+		// The source is a collection, so this response is passed through and
+		// never stored -- nothing will ever compare a digest against it. The
+		// origin may also refuse to produce one: XRootD does not answer
+		// Want-Digest for a collection, leaving the request to sit until the
+		// response header timeout, with the client that asked for the listing
+		// waiting the whole time.
+		transferOpts = append(transferOpts, client.WithSkipChecksums())
+	}
 	if fedTP != nil {
 		transferOpts = append(transferOpts, client.WithFedToken(fedTP))
 	}


### PR DESCRIPTION
`TestCacheXrootdCollectionNotStoredAsObject` has been failing in CI at roughly a 50% rate. It turned out to be two independent races, one of them a real cache bug rather than a test problem. Both are fixed here.

### 1. The cache asks the origin to digest a collection, and waits 10s for an answer that never comes

This is the failure CI actually hits. From run 32532472732, `Test latest-itb / Linux (pelican-server)`:

```
Error: Received unexpected error:
  Get "https://…/api/v1.0/cache/data/…/test/xrootd-collection?authz=***":
  net/http: timeout awaiting response headers
Test: TestCacheXrootdCollectionNotStoredAsObject
```

The cache's own log says where the time went:

```
22:53:40.167  HTTP Transfer was successful … Downloaded bytes: 1067
22:53:40.167  Fetching checksum for …/test/xrootd-collection for types md5, crc32c, crc32, sha
22:53:50.156  Server did not provide any checksum values to compare      ← 9.99s later
```

Every download ends with a HEAD carrying `Want-Digest`, and that request is what verifies the transfer — worth making for an object. It is not worth making for a **collection's directory index**, which the cache serves so a user can see it but deliberately never stores. Nothing will ever compare a digest against it.

XRootD doesn't answer `Want-Digest` for a collection at all, so the request sits until `Transport.ResponseHeaderTimeout` (default 10s) expires. The cache buffers this response before answering, so that 10s lands on the client waiting for the listing — which is subject to the very same 10s timeout. Two 10s timers started moments apart is a coin flip, which is exactly the observed ~50%.

The cache already determines whether the source is a collection *before* it starts the download — that's what decides the response may not be written to disk. Where that says yes, it now passes a new `client.WithSkipChecksums()` and the digest is never requested. Everything else keeps fetching it, including the cache's own storable downloads, so nothing that gets kept goes unverified. The no-store path takes the streaming branch in `performDownload` and never reaches the inline-store path where checksums are persisted, so stored-object metadata is unaffected.

This is a user-facing fix as well as a test fix: on any deployment where the origin declines to digest a collection, *every* listing fetched through a V2 cache currently pays a 10s stall.

### 2. The director refuses a cache ad it could have waited for

The second race showed up locally (1 run in 10) rather than in the CI logs I read, and it's a genuinely different failure — `Director never redirected to cache`, from `waitForCacheRedirectURL`.

A cache advertisement that arrives before the director has fetched the allowed prefixes for caches can't be judged yet. The handler already waited for that data — but only 3 seconds, and then fell through. With the timestamp still `0`, `time.Unix(0, 0)` is 1970, so the staleness check below it treats a director that has *never* initialized as one whose data is *outdated*, and answers 500:

```
director.go:1176: warning Allowed prefixes for caches data is not initialized.
                  Waiting for initialization before continuing with processing
                  cache server advertisement.
```

What makes that 500 expensive is an asymmetry between the two retry paths. The registry fetch behind it retries **every second** until it succeeds (`LaunchRegistryPeriodicQuery`), so the condition normally clears in seconds. But `doAdvertise` has **no retry at all** — it logs the failure, sets a health status, and waits for the next tick of `Server.AdvertisementInterval`, a minute by default. Three seconds of impatience on the director's side therefore costs the federation a minute without that cache.

So hold the ad instead of refusing it. `waitForAllowedPrefixesForCaches` returns the instant the data lands, and gives up when the caller's request context is cancelled or `allowedPrefixesInitWait` elapses. If it does run out, the answer is now **503 with `Retry-After`** rather than 500: nothing is known to be broken, the director simply isn't ready, and those two cases deserve different messages.

The readiness condition stays derived from the existing timestamp rather than a new channel, because several director tests set that timestamp directly without running the periodic query and would deadlock waiting on a channel nothing closes.

Worth being precise about what that hold can promise, because on its own it is **not** a complete fix. A Pelican cache advertises with `http.Client{Transport: tr}` — no `Timeout` of its own — so `Transport.ResponseHeaderTimeout` governs, 10s by default. The advertiser hangs up first, the request context is cancelled, and the wait ends there. The hold therefore widens the window from 3s to the advertiser's timeout, which covers most of it, but a registry slower than that would still leave the cache absent for a full cycle.

### 3. Advertising treated "not yet" the same as "no"

That remaining hole is on the advertising side, and it is the more general problem: `doAdvertise` had one response to every failure — log it and wait for the next tick. With `Server.AdvertisementInterval` at a minute, *any* transient rejection cost a server a minute of not being matchmade, its ad simply absent from the federation.

So the two answers are now distinguished. A 503 or 429 comes back as a `retryableAdError` carrying the status and any `Retry-After` hint, and `doAdvertise` retries up to three times — on the hint when given, otherwise 2s, clamped to 5s so the whole sequence stays far short of an advertisement interval. Everything else, **500 included**, remains a single failure: retrying a director that is genuinely broken only adds load to something already in trouble.

This is also what finally makes the `Retry-After` above mean something. Before this commit nothing on Pelican's advertising path read that header.

### Testing

Two unit tests, both deterministic:

- `TestSkipChecksumsSuppressesDigestRequest` contrasts the cases that must stay distinct — a normal download still sends the `Want-Digest` HEAD that verifies it, a download that opted out sends none. It counts digest requests server-side rather than asserting on logs.
- `TestWaitForAllowedPrefixesForCaches` covers the hold: no delay at all when the director is already initialized, returns when the prefixes arrive mid-wait (rather than by running out the bound), and gives up early when the caller cancels.
- `TestIsRetryableAdStatus` and `TestParseAdRetryAfter` pin the retry's decision points, including that 500 is *not* retried and that an absurd `Retry-After` is clamped rather than honored.
- `TestRetryableAdErrorSurvivesWrapping` guards the mechanism itself: `doAdvertise` decides with `errors.As`, so if any layer flattened the error into a string the retry would silently never fire and nothing would look wrong.

E2E, locally, with the XRootD plugin environment:

- **Before**, `TestCacheXrootdCollectionNotStoredAsObject` ×10: 9 passed, 1 failed with `Director never redirected to cache` (race 2).
- **After** (rebased, both fixes), both XRootD collection tests ×8 (16 test runs): all passed, every run issuing **zero** `Want-Digest` requests for the collection.
- Because `waitForCacheRedirectURL` is shared, I also ran all 31 tests that call it — `cache_collection`, `cache_control`, `cache_corruption`, `cache_streaming`, `fed_token`, `transfer_status` — as one package run: `ok e2e_fed_tests 1009.977s`, no failures.

Being straight about what those local runs do and don't establish, since neither race reproduces reliably here:

- **Race 1 does not reproduce on this machine at all** — the local XRootD answers the digest in ~5ms instead of hanging, which is why the CI logs were needed to find it. Local green runs aren't evidence it's fixed. The evidence is that the request is no longer made: the operation that raced the client's timeout is gone, not merely likelier to win.
- **Race 2 didn't occur in the 8 post-fix runs either** — the director's allowed-prefixes wait was never entered, so those runs never exercised the new code path. It was a 1-in-10 condition before, so 8 clean runs is a weak signal. The unit tests are what actually cover the director hold and the advertise retry; no local e2e run here has exercised either.

CI is the arbiter for both.

One note: this touches `client/handle_http.go` in the same function as #3654, so whichever merges second will need a small rebase.
