### PR TITLE
Let a cache tell a client what token it needs

### DIFF
--- a/client/acquire_token.go
+++ b/client/acquire_token.go
@@ -86,7 +86,13 @@ type (
 		// (WithToken, or a token option on the transfer).  A caller who picked a
 		// credential does not want it silently replaced by one acquired from an
 		// issuer some object server named.
-		tokenIsExplicit         bool
+		tokenIsExplicit bool
+		// namedObjServers are the object servers the user picked for this
+		// transfer (Client.PreferredCaches, -c, or WithCaches).  They are hosts
+		// the user named, so they may advise on credentials; see
+		// canApplyTokenHint.  Written once while the job is being built, read by
+		// the workers that run it.
+		namedObjServers         []*url.URL
 		Destination             *pelican_url.PelicanURL
 		TokenLocation           string
 		TokenName               string
@@ -224,11 +230,12 @@ func (tg *tokenGenerator) SetDirectorResponse(dirResp *server_structs.DirectorRe
 // director selected, or an HTTP redirect target, holds only trust delegated by
 // someone else, and its hints are refused however plausible they look.
 //
-// Note the distinction is who chose the host, not whether a director exists: a
-// cache the user selected themselves (Client.PreferredCaches, -c) is named as
-// squarely as the URL's host and belongs here too.  Admitting it is left to the
-// change that gives explicitly-chosen caches their own standing, since nothing
-// in standalone mode needs it.
+// The distinction is who chose the host, not whether a director exists.  A cache
+// the user selected themselves -- Client.PreferredCaches, -c, or the caches a
+// caller handed this transfer -- is named as squarely as the URL's host: the
+// user sent their request there on purpose, and having done so, they are asking
+// what that cache says about what it will accept.  A cache a director picked out
+// of the same list is not, and stays refused.
 func (tg *tokenGenerator) canApplyTokenHint(objectServer *url.URL) bool {
 	if tg == nil || objectServer == nil || tg.Destination == nil {
 		return false
@@ -242,15 +249,59 @@ func (tg *tokenGenerator) canApplyTokenHint(objectServer *url.URL) bool {
 	// pelican_url, which overwrites whatever a discovery document claims with
 	// the host actually contacted, so a document cannot nominate a third party
 	// as the trust anchor.
-	discovery, err := url.Parse(tg.Destination.FedInfo.DiscoveryEndpoint)
-	if err != nil || discovery.Host == "" {
-		return false
-	}
+	//
 	// Scheme is compared along with host: the assumption is about a host
 	// reached the way the user asked to reach it, and a plaintext endpoint is
 	// not that for an https discovery host.
-	return strings.EqualFold(discovery.Host, objectServer.Host) &&
-		strings.EqualFold(discovery.Scheme, objectServer.Scheme)
+	if discovery, err := url.Parse(tg.Destination.FedInfo.DiscoveryEndpoint); err == nil &&
+		discovery.Host != "" &&
+		strings.EqualFold(discovery.Host, objectServer.Host) &&
+		strings.EqualFold(discovery.Scheme, objectServer.Scheme) {
+		return true
+	}
+	for _, named := range tg.namedObjServers {
+		if namesEndpoint(named, objectServer) {
+			return true
+		}
+	}
+	return false
+}
+
+// namesEndpoint reports whether named -- an object server the user picked --
+// refers to the endpoint that just answered.
+//
+// Host must match exactly (port included): a cache on another port is another
+// service.  A user who wrote a scheme gets that scheme, so advice arriving in
+// the clear from a host they named as https is not from the host they named.  A
+// bare hostname commits to nothing and takes whatever scheme the transfer
+// settled on -- https whenever the namespace wants a token, which is the only
+// case a hint is acted on.
+func namesEndpoint(named, endpoint *url.URL) bool {
+	if named == nil || endpoint == nil || endpoint.Host == "" {
+		return false
+	}
+	host, scheme := named.Host, named.Scheme
+	if host == "" {
+		// A preferred cache may be written as a bare hostname, with or without
+		// a port, which url.Parse leaves anywhere but Host.  That is the form
+		// generateTransferDetails resolves into a host, so read it the same way
+		// rather than refusing the entry the transfer went on to use.
+		host, scheme = named.String(), ""
+	}
+	if !strings.EqualFold(host, endpoint.Host) {
+		return false
+	}
+	return scheme == "" || strings.EqualFold(scheme, endpoint.Scheme)
+}
+
+// setNamedObjServers records the object servers the user picked for this
+// transfer, whose token hints it may then act on.  Called while the job is
+// being built, before any worker reads them.
+func (tg *tokenGenerator) setNamedObjServers(servers []*url.URL) {
+	if tg == nil {
+		return
+	}
+	tg.namedObjServers = servers
 }
 
 // withTokenHint returns a generator that acquires a credential according to the

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -1466,6 +1466,12 @@ func applyJobOptions(tj *TransferJob, options []TransferOption) {
 			tj.cacheMode = opt.Value().(bool)
 		}
 	}
+	// The object servers the user picked are the ones whose token hints this
+	// job may act on (see canApplyTokenHint).  Recorded after the loop, so a
+	// per-job WithCaches has already replaced whatever the client was created
+	// with.
+	tj.token.setNamedObjServers(tj.prefObjServers)
+	tj.srcToken.setNamedObjServers(tj.prefObjServers)
 }
 
 // Create an option to specify the object synchronization level
@@ -2621,6 +2627,9 @@ func (tc *TransferClient) CacheInfo(ctx context.Context, remoteUrl *url.URL, opt
 			token.SetToken(option.Value().(string))
 		}
 	}
+	// The probe below runs against the first of these when the caller named
+	// any, so they are hosts whose token hints it may act on.
+	token.setNamedObjServers(prefObjServers)
 
 	ctx, cancel := mergeCancel(tc.ctx, ctx)
 	defer cancel()

--- a/client/token_hint_test.go
+++ b/client/token_hint_test.go
@@ -323,6 +323,57 @@ func TestTokenHintIgnoredFromHostTheUserDidNotName(t *testing.T) {
 	assert.Equal(t, int32(0), atomic.LoadInt32(&stats.served))
 }
 
+// TestTokenHintHonoredFromCacheTheUserNamed is the other half of the boundary
+// above.  The endpoint is again not the host in the pelican:// URL -- but here
+// the user picked it themselves with -c, and having sent their request to that
+// cache on purpose, they are asking what it says about what it will accept.
+//
+// The fixture is TestTokenHintIgnoredFromHostTheUserDidNotName with one
+// difference: the same server is now among the caches the caller named.  The
+// opposite outcome is what shows that naming it is what decides this.
+func TestTokenHintHonoredFromCacheTheUserNamed(t *testing.T) {
+	stageTwoCredentials(t)
+
+	body := "hello cache"
+	var stats hintServerStats
+	svr := httptest.NewServer(countingTokenHintHandler(body, &stats))
+	t.Cleanup(svr.Close)
+
+	transfer, tok := newHintTransfer(t, svr.URL, hintTransferOpts{
+		discoveryEndpoint: "https://the-host-the-user-named.example.com",
+		directorEndpoint:  "https://director.example.com",
+	})
+	named, err := url.Parse(svr.URL)
+	require.NoError(t, err)
+	tok.setNamedObjServers([]*url.URL{named})
+
+	res, err := downloadObject(transfer)
+	require.NoError(t, err)
+	require.NoError(t, res.Error, "a cache the user named may say what token it wants")
+	assert.Equal(t, int64(len(body)), res.TransferredBytes)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&stats.rejected))
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&stats.served), int32(1))
+}
+
+// TestNamedCachesReachTheTokenGenerator pins the wiring between the two: the
+// caches a caller names on a job are the ones the job's generator will take
+// advice from.  Every job type shares this path, and a copy's source side reads
+// from them too.
+func TestNamedCachesReachTheTokenGenerator(t *testing.T) {
+	cache, err := url.Parse("https://cache.example.com:8443")
+	require.NoError(t, err)
+
+	tj := &TransferJob{
+		token:    NewTokenGenerator(nil, nil, config.TokenRead, false),
+		srcToken: NewTokenGenerator(nil, nil, config.TokenSharedRead, false),
+	}
+	applyJobOptions(tj, []TransferOption{WithCaches(cache)})
+
+	assert.Equal(t, []*url.URL{cache}, tj.token.namedObjServers)
+	assert.Equal(t, []*url.URL{cache}, tj.srcToken.namedObjServers,
+		"a copy reads from the caches the caller named as well")
+}
+
 // TestTokenHintDoesNotDisplaceExplicitToken pins that a caller who named a
 // credential keeps it.  Acting on a hint here would swap a credential the user
 // chose for one acquired from an issuer the server named.
@@ -401,6 +452,55 @@ func TestCanApplyTokenHint(t *testing.T) {
 	t.Run("no-discovery-endpoint", func(t *testing.T) {
 		tg := NewTokenGenerator(&pelican_url.PelicanURL{Path: "/protected/obj"}, nil, config.TokenRead, false)
 		assert.False(t, tg.canApplyTokenHint(objectServer))
+	})
+
+	// A cache the user picked is named as squarely as the URL's host, so the
+	// cases below are about which endpoint their choice actually refers to.
+	namedCache := func(t *testing.T, named string) *tokenGenerator {
+		t.Helper()
+		u, err := url.Parse(named)
+		require.NoError(t, err)
+		tg := newGen()
+		tg.Destination.FedInfo.DiscoveryEndpoint = "https://the-host-the-user-named.example.com"
+		tg.setNamedObjServers([]*url.URL{u})
+		return tg
+	}
+
+	t.Run("cache-the-user-named", func(t *testing.T) {
+		assert.True(t, namedCache(t, "https://origin.example.com:8444").canApplyTokenHint(objectServer))
+	})
+
+	t.Run("cache-the-user-named-as-a-bare-hostname", func(t *testing.T) {
+		// What url.Parse makes of "origin.example.com:8444" is a scheme and an
+		// opaque part, not a host; the transfer resolves it into a host anyway,
+		// so the gate has to read it the same way.
+		assert.True(t, namedCache(t, "origin.example.com:8444").canApplyTokenHint(objectServer),
+			"a preferred cache written without a scheme still names this endpoint")
+		assert.True(t, namedCache(t, "//origin.example.com:8444").canApplyTokenHint(objectServer))
+	})
+
+	t.Run("cache-the-user-named-on-another-port", func(t *testing.T) {
+		assert.False(t, namedCache(t, "https://origin.example.com:9999").canApplyTokenHint(objectServer),
+			"a cache on another port is another service")
+	})
+
+	t.Run("cache-the-user-named-answering-in-the-clear", func(t *testing.T) {
+		plaintext, err := url.Parse("http://origin.example.com:8444")
+		require.NoError(t, err)
+		assert.False(t, namedCache(t, "https://origin.example.com:8444").canApplyTokenHint(plaintext),
+			"advice in the clear is not from the host the user named as https")
+	})
+
+	t.Run("plus-sentinel-names-nothing", func(t *testing.T) {
+		assert.False(t, namedCache(t, "+").canApplyTokenHint(objectServer),
+			"the '+' that appends the director's own list is not a host")
+	})
+
+	t.Run("cache-the-user-named-does-not-admit-the-others", func(t *testing.T) {
+		other, err := url.Parse("https://some-other-cache.example.com:8443")
+		require.NoError(t, err)
+		assert.False(t, namedCache(t, "https://origin.example.com:8444").canApplyTokenHint(other),
+			"naming one cache says nothing about the rest of the director's list")
 	})
 
 	t.Run("nil-destination", func(t *testing.T) {

--- a/local_cache/cache_authz.go
+++ b/local_cache/cache_authz.go
@@ -34,6 +34,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
@@ -151,6 +152,52 @@ func (ac *authConfig) updateConfig(nsAds []server_structs.NamespaceAd) error {
 		ac.tokenAuthz.DeleteAll()
 	}
 	return nil
+}
+
+// SetTokenHintHeaders writes the director's X-Pelican-{Namespace,Authorization,
+// Token-Generation} headers describing how a caller could obtain a token for
+// resource, or does nothing if no namespace the cache knows about covers it.
+//
+// A client that a director sent here has already been told this.  A client that
+// came on its own has not: it named this cache itself (Client.PreferredCaches,
+// -c), or the director it would have asked was unreachable, and a bare refusal
+// would leave it with nowhere to go.  Emitting what the director would have said
+// lets it acquire the right credential and try again (see the token-hint retry
+// in client/handle_http.go), and lets a human with curl see where to
+// authenticate.  Whether such a hint may be acted on is the client's decision --
+// canApplyTokenHint -- not ours.
+//
+// The hint names the credential this cache recommends for the most specific
+// namespace covering resource; it is not a statement of what will be refused.
+// Authorization itself is unchanged: it still admits any token whose scopes
+// reach the path.
+func (ac *authConfig) SetTokenHintHeaders(hdr http.Header, resource string) {
+	// A cache that never finished configuring has no namespaces to describe;
+	// saying nothing is the same answer as having no match for the path.
+	if ac == nil {
+		return
+	}
+	namespaces := ac.ns.Load()
+	if namespaces == nil {
+		return
+	}
+	nsAd := server_structs.LongestNSMatch(resource, *namespaces)
+	if nsAd == nil {
+		return
+	}
+	// The V2 cache proxies PROPFIND to the origin on the same endpoint it serves
+	// objects from, so it is its own collections URL: a listing can flow through
+	// the cache the client is already talking to instead of sending it back to
+	// the origin.  Cache.Url is that endpoint (launchers/cache_serve.go sets it,
+	// including the federation prefix when a director is in play); the external
+	// web URL is what a cache configured before that assignment has.
+	collUrl := param.Cache_Url.GetString()
+	if collUrl == "" {
+		collUrl = param.Server_ExternalWebUrl.GetString()
+	}
+	server_structs.SetXNamespaceHeaderWithCollections(hdr, collUrl, *nsAd)
+	server_structs.SetXAuthHeader(hdr, *nsAd)
+	server_structs.SetXTokenGenHeader(hdr, *nsAd)
 }
 
 // nsAdsAuthzEqual reports whether two namespace-ad slices are semantically

--- a/local_cache/persistent_cache_api.go
+++ b/local_cache/persistent_cache_api.go
@@ -263,7 +263,10 @@ func validShedReason(reason string) string {
 // handleError writes a structured JSON error response based on the error type.
 // The reqLog entry carries request-scoped fields (method, path, reqId) so that
 // every log line emitted here is correlated with the original request.
-func handleError(w http.ResponseWriter, getErr error, sendTrailer bool, reqLog *log.Entry) {
+//
+// objectPath names what was asked for, so that a refusal can carry the token
+// hints for its namespace (see authConfig.SetTokenHintHeaders).
+func (pc *PersistentCache) handleError(w http.ResponseWriter, getErr error, objectPath string, sendTrailer bool, reqLog *log.Entry) {
 	// writeJSON is a small helper that sends a JSON object with "error" and
 	// "detail" keys.  It sets Content-Type before WriteHeader so Go does
 	// not fall back to content-sniffing.
@@ -282,11 +285,13 @@ func handleError(w http.ResponseWriter, getErr error, sendTrailer bool, reqLog *
 	var authErr *AuthorizationError
 	if errors.As(getErr, &authErr) {
 		reqLog.WithField("reason", authErr.Reason).Warn("Authorization denied")
+		pc.ac.SetTokenHintHeaders(w.Header(), objectPath)
 		writeJSON(http.StatusForbidden, "authorization_denied", authErr.Reason)
 		return
 	} else if errors.Is(getErr, authorizationDenied) {
 		// Fallback for the plain sentinel (shouldn't happen with new code paths).
 		reqLog.Warn("Authorization denied (no detail available)")
+		pc.ac.SetTokenHintHeaders(w.Header(), objectPath)
 		writeJSON(http.StatusForbidden, "authorization_denied", "authorization denied")
 		return
 	} else if errors.Is(getErr, context.DeadlineExceeded) {
@@ -493,7 +498,7 @@ func (pc *PersistentCache) serveObject(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusGatewayTimeout)
 				return
 			} else if statErr != nil {
-				handleError(w, statErr, sendTrailer, reqLog)
+				pc.handleError(w, statErr, objectPath, sendTrailer, reqLog)
 				return
 			}
 			w.Header().Set("Content-Length", strconv.FormatUint(size, 10))
@@ -505,7 +510,7 @@ func (pc *PersistentCache) serveObject(w http.ResponseWriter, r *http.Request) {
 		// Plain HEAD — stat only, no download.
 		result, headErr := pc.HeadObject(objectPath, bearerToken)
 		if headErr != nil {
-			handleError(w, headErr, sendTrailer, reqLog)
+			pc.handleError(w, headErr, objectPath, sendTrailer, reqLog)
 			return
 		}
 		w.Header().Set("Content-Length", strconv.FormatInt(result.ContentLength, 10))
@@ -544,7 +549,7 @@ func (pc *PersistentCache) serveObject(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusGatewayTimeout)
 			return
 		} else if statErr != nil {
-			handleError(w, statErr, sendTrailer, reqLog)
+			pc.handleError(w, statErr, objectPath, sendTrailer, reqLog)
 			return
 		}
 		// Object is cached — fall through to the normal GET path which will
@@ -607,7 +612,7 @@ func (pc *PersistentCache) serveObject(w http.ResponseWriter, r *http.Request) {
 		reader, meta, getErr = res.reader, res.meta, res.err
 	}
 	if getErr != nil {
-		handleError(w, getErr, sendTrailer, reqLog)
+		pc.handleError(w, getErr, objectPath, sendTrailer, reqLog)
 		return
 	}
 	defer reader.Close()
@@ -913,6 +918,7 @@ func (pc *PersistentCache) proxyPropfind(w http.ResponseWriter, r *http.Request,
 	if ok, reason := pc.ac.authorize(token_scopes.Wlcg_Storage_Read, objectPath, bearerToken); !ok {
 		reqLog.WithField("reason", reason).Warn("PROPFIND authorization denied")
 		w.Header().Set("Content-Type", "application/json")
+		pc.ac.SetTokenHintHeaders(w.Header(), objectPath)
 		w.WriteHeader(http.StatusForbidden)
 		resp, _ := json.Marshal(map[string]string{"error": "authorization_denied", "reason": reason})
 		if _, err := w.Write(resp); err != nil {
@@ -1044,6 +1050,7 @@ func (pc *PersistentCache) proxyWrite(w http.ResponseWriter, r *http.Request, ob
 	if ok, reason := pc.ac.authorize(requiredScope, objectPath, bearerToken); !ok {
 		reqLog.WithField("reason", reason).Warn("Write authorization denied")
 		w.Header().Set("Content-Type", "application/json")
+		pc.ac.SetTokenHintHeaders(w.Header(), objectPath)
 		w.WriteHeader(http.StatusForbidden)
 		resp, _ := json.Marshal(map[string]string{"error": "authorization_denied", "reason": reason})
 		if _, err := w.Write(resp); err != nil {

--- a/local_cache/persistent_cache_api_test.go
+++ b/local_cache/persistent_cache_api_test.go
@@ -86,7 +86,7 @@ func TestHandleErrorTooManyRequests(t *testing.T) {
 
 	t.Run("BareSentinel", func(t *testing.T) {
 		rec := httptest.NewRecorder()
-		handleError(rec, client.ErrTooManyRequests, false, reqLog)
+		(&PersistentCache{}).handleError(rec, client.ErrTooManyRequests, "/test/object", false, reqLog)
 		require.Equal(t, 429, rec.Code)
 		require.Equal(t, "60", rec.Header().Get("Retry-After"),
 			"Retry-After should tell the client to back off for 60 seconds")
@@ -104,7 +104,7 @@ func TestHandleErrorTooManyRequests(t *testing.T) {
 		// via errors.Is.
 		rec := httptest.NewRecorder()
 		wrapped := errors.Wrapf(client.ErrTooManyRequests, "origin %q pending queue is full", "originA")
-		handleError(rec, wrapped, false, reqLog)
+		(&PersistentCache{}).handleError(rec, wrapped, "/test/object", false, reqLog)
 		require.Equal(t, 429, rec.Code)
 		require.Equal(t, "60", rec.Header().Get("Retry-After"))
 	})
@@ -120,7 +120,7 @@ func TestHandleErrorTooManyRequests(t *testing.T) {
 		} {
 			rec := httptest.NewRecorder()
 			rej := &client.SchedulerRejection{Reason: reason, Tag: "originA"}
-			handleError(rec, rej, false, reqLog)
+			(&PersistentCache{}).handleError(rec, rej, "/test/object", false, reqLog)
 			require.Equal(t, 429, rec.Code)
 			require.Equal(t, "60", rec.Header().Get("Retry-After"))
 			var body map[string]string
@@ -136,7 +136,7 @@ func TestHandleErrorTooManyRequests(t *testing.T) {
 		// 429 with the upstream's reason — not as a misleading 500.
 		rec := httptest.NewRecorder()
 		throttled := &client.CacheThrottleError{Reason: string(client.ShedOriginSlow)}
-		handleError(rec, throttled, false, reqLog)
+		(&PersistentCache{}).handleError(rec, throttled, "/test/object", false, reqLog)
 		require.Equal(t, 429, rec.Code)
 		require.Equal(t, "60", rec.Header().Get("Retry-After"))
 		var body map[string]string
@@ -149,7 +149,7 @@ func TestHandleErrorTooManyRequests(t *testing.T) {
 		// existing internal_error / not_found / etc. paths, not fall
 		// through the new 429 branch.
 		rec := httptest.NewRecorder()
-		handleError(rec, errors.New("some other error"), false, reqLog)
+		(&PersistentCache{}).handleError(rec, errors.New("some other error"), "/test/object", false, reqLog)
 		assert.NotEqual(t, 429, rec.Code, "non-scheduler errors must not accidentally map to 429")
 		assert.Empty(t, rec.Header().Get("Retry-After"))
 	})
@@ -274,7 +274,7 @@ func TestHandleErrorThrottlePrecedence(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rec := httptest.NewRecorder()
-			handleError(rec, tt.err, false, reqLog)
+			(&PersistentCache{}).handleError(rec, tt.err, "/test/object", false, reqLog)
 			if tt.wantStatus == 0 {
 				assert.NotEqual(t, http.StatusTooManyRequests, rec.Code,
 					"a throttled attempt must not mask a more specific failure")
@@ -333,7 +333,7 @@ func TestRetryAfterValue(t *testing.T) {
 
 			// The same value is what a shed request actually advertises.
 			rec := httptest.NewRecorder()
-			handleError(rec, client.ErrTooManyRequests, false, log.NewEntry(log.New()))
+			(&PersistentCache{}).handleError(rec, client.ErrTooManyRequests, "/test/object", false, log.NewEntry(log.New()))
 			require.Equal(t, http.StatusTooManyRequests, rec.Code)
 			assert.Equal(t, tt.want, rec.Header().Get("Retry-After"))
 		})
@@ -363,10 +363,10 @@ func TestHandleErrorShedReasonIsValidated(t *testing.T) {
 	for _, reason := range known {
 		t.Run("known/"+reason, func(t *testing.T) {
 			rec := httptest.NewRecorder()
-			handleError(rec, &client.CacheThrottleError{
+			(&PersistentCache{}).handleError(rec, &client.CacheThrottleError{
 				Reason: reason,
 				Err:    client.ErrTooManyRequests,
-			}, false, reqLog)
+			}, "/test/object", false, reqLog)
 			require.Equal(t, http.StatusTooManyRequests, rec.Code)
 
 			var body map[string]string
@@ -387,10 +387,10 @@ func TestHandleErrorShedReasonIsValidated(t *testing.T) {
 	for _, tt := range hostile {
 		t.Run("rejected/"+tt.name, func(t *testing.T) {
 			rec := httptest.NewRecorder()
-			handleError(rec, &client.CacheThrottleError{
+			(&PersistentCache{}).handleError(rec, &client.CacheThrottleError{
 				Reason: tt.reason,
 				Err:    client.ErrTooManyRequests,
-			}, false, reqLog)
+			}, "/test/object", false, reqLog)
 			require.Equal(t, http.StatusTooManyRequests, rec.Code,
 				"the response is still a throttle; only the reason is discarded")
 
@@ -485,7 +485,7 @@ func TestHandleErrorNotFoundDoesNotMaskSpecificFailures(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rec := httptest.NewRecorder()
-			handleError(rec, tt.err, false, reqLog)
+			(&PersistentCache{}).handleError(rec, tt.err, "/test/object", false, reqLog)
 			assert.Equal(t, tt.wantStatus, rec.Code)
 		})
 	}

--- a/local_cache/token_hint_test.go
+++ b/local_cache/token_hint_test.go
@@ -1,0 +1,220 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package local_cache
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_structs"
+)
+
+// TestSetTokenHintHeaders pins the headers a cache attaches when it refuses a
+// request for a namespace that wants a credential: the same three the director
+// would have sent, and in the same form its parser reads back.
+func TestSetTokenHintHeaders(t *testing.T) {
+	ac := &authConfig{}
+	issuerURL, err := url.Parse("https://issuer.example.com")
+	require.NoError(t, err)
+	require.NoError(t, ac.updateConfig([]server_structs.NamespaceAd{
+		{
+			Path: "/protected",
+			Caps: server_structs.Capabilities{Reads: true}, // PublicReads false -> require-token
+			Issuer: []server_structs.TokenIssuer{
+				{IssuerUrl: *issuerURL, BasePaths: []string{"/protected"}},
+			},
+			Generation: []server_structs.TokenGen{
+				{
+					Strategy:         server_structs.OAuthStrategy,
+					MaxScopeDepth:    3,
+					CredentialIssuer: *issuerURL,
+				},
+			},
+		},
+	}))
+
+	hdr := http.Header{}
+	ac.SetTokenHintHeaders(hdr, "/protected/secret.txt")
+
+	assert.Equal(t, "namespace=/protected, require-token=true", hdr.Get("X-Pelican-Namespace"))
+	assert.Equal(t, "issuer=https://issuer.example.com", hdr.Get("X-Pelican-Authorization"))
+	assert.Contains(t, hdr.Get("X-Pelican-Token-Generation"), "strategy=OAuth2")
+
+	// The client reads these with the director-response parser, so the round
+	// trip is what makes the hint usable at all.
+	var ns server_structs.XPelNs
+	require.NoError(t, (&ns).ParseRawHeader(&hdr))
+	assert.Equal(t, "/protected", ns.Namespace)
+	assert.True(t, ns.RequireToken)
+}
+
+// TestHandleErrorAttachesTokenHints pins the wiring rather than the header
+// text: the refusal the client actually receives is the one that has to carry
+// the hint, and only a refusal a credential could fix.
+func TestHandleErrorAttachesTokenHints(t *testing.T) {
+	issuerURL, err := url.Parse("https://issuer.example.com")
+	require.NoError(t, err)
+	ac := &authConfig{}
+	require.NoError(t, ac.updateConfig([]server_structs.NamespaceAd{
+		{
+			Path:   "/protected",
+			Caps:   server_structs.Capabilities{Reads: true},
+			Issuer: []server_structs.TokenIssuer{{IssuerUrl: *issuerURL, BasePaths: []string{"/protected"}}},
+		},
+	}))
+	pc := &PersistentCache{ac: ac}
+	reqLog := log.NewEntry(log.New())
+
+	rec := httptest.NewRecorder()
+	pc.handleError(rec, newAuthorizationDenied("no token provided"), "/protected/secret.txt", false, reqLog)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, "namespace=/protected, require-token=true", rec.Header().Get("X-Pelican-Namespace"))
+	assert.Equal(t, "issuer=https://issuer.example.com", rec.Header().Get("X-Pelican-Authorization"))
+
+	// An upstream failure is not an invitation to go get a credential.
+	rec = httptest.NewRecorder()
+	pc.handleError(rec, errors.New("origin went away"), "/protected/secret.txt", false, reqLog)
+	assert.Empty(t, rec.Header().Get("X-Pelican-Namespace"))
+}
+
+// TestSetTokenHintHeadersMostSpecificNamespace pins that the hint describes the
+// namespace that actually covers the object, not merely one that shares a
+// prefix with it: nested namespaces can name different issuers.
+func TestSetTokenHintHeadersMostSpecificNamespace(t *testing.T) {
+	outer, err := url.Parse("https://outer.example.com")
+	require.NoError(t, err)
+	inner, err := url.Parse("https://inner.example.com")
+	require.NoError(t, err)
+
+	ac := &authConfig{}
+	require.NoError(t, ac.updateConfig([]server_structs.NamespaceAd{
+		{
+			Path:   "/foo",
+			Caps:   server_structs.Capabilities{Reads: true},
+			Issuer: []server_structs.TokenIssuer{{IssuerUrl: *outer, BasePaths: []string{"/foo"}}},
+		},
+		{
+			Path:   "/foo/bar",
+			Caps:   server_structs.Capabilities{Reads: true},
+			Issuer: []server_structs.TokenIssuer{{IssuerUrl: *inner, BasePaths: []string{"/foo/bar"}}},
+		},
+	}))
+
+	hdr := http.Header{}
+	ac.SetTokenHintHeaders(hdr, "/foo/bar/baz.txt")
+	assert.Equal(t, "namespace=/foo/bar, require-token=true", hdr.Get("X-Pelican-Namespace"))
+	assert.Equal(t, "issuer=https://inner.example.com", hdr.Get("X-Pelican-Authorization"))
+
+	hdr = http.Header{}
+	ac.SetTokenHintHeaders(hdr, "/foo/other.txt")
+	assert.Equal(t, "namespace=/foo, require-token=true", hdr.Get("X-Pelican-Namespace"))
+	assert.Equal(t, "issuer=https://outer.example.com", hdr.Get("X-Pelican-Authorization"))
+}
+
+// TestSetTokenHintHeadersCollectionsUrl pins that a listing-capable namespace is
+// advertised with this cache as its collections URL: the cache proxies PROPFIND
+// to the origin, so a client that reached the cache can list through it rather
+// than being sent elsewhere.
+func TestSetTokenHintHeadersCollectionsUrl(t *testing.T) {
+	const cacheDataUrl = "https://cache.example.com/api/v1.0/cache/data/fed.example.com"
+	require.NoError(t, param.Cache_Url.Set(cacheDataUrl))
+	t.Cleanup(func() { require.NoError(t, param.Cache_Url.Set("")) })
+
+	issuerURL, err := url.Parse("https://issuer.example.com")
+	require.NoError(t, err)
+	ac := &authConfig{}
+	require.NoError(t, ac.updateConfig([]server_structs.NamespaceAd{
+		{
+			Path:   "/protected",
+			Caps:   server_structs.Capabilities{Reads: true, Listings: true},
+			Issuer: []server_structs.TokenIssuer{{IssuerUrl: *issuerURL, BasePaths: []string{"/protected"}}},
+		},
+	}))
+
+	hdr := http.Header{}
+	ac.SetTokenHintHeaders(hdr, "/protected/dir/")
+	assert.Equal(t,
+		"namespace=/protected, require-token=true, collections-url="+cacheDataUrl,
+		hdr.Get("X-Pelican-Namespace"))
+
+	var ns server_structs.XPelNs
+	require.NoError(t, (&ns).ParseRawHeader(&hdr))
+	require.NotNil(t, ns.CollectionsUrl)
+	assert.Equal(t, cacheDataUrl, ns.CollectionsUrl.String())
+}
+
+// TestSetTokenHintHeadersNoCollectionsWhenListingsDisabled pins that the cache
+// does not offer to list a namespace whose origin does not allow it, however
+// willing the cache itself is to proxy the request.
+func TestSetTokenHintHeadersNoCollectionsWhenListingsDisabled(t *testing.T) {
+	require.NoError(t, param.Cache_Url.Set("https://cache.example.com/api/v1.0/cache/data/fed.example.com"))
+	t.Cleanup(func() { require.NoError(t, param.Cache_Url.Set("")) })
+
+	ac := &authConfig{}
+	require.NoError(t, ac.updateConfig([]server_structs.NamespaceAd{
+		{Path: "/protected", Caps: server_structs.Capabilities{Reads: true}}, // Listings false
+	}))
+
+	hdr := http.Header{}
+	ac.SetTokenHintHeaders(hdr, "/protected/x.txt")
+	assert.Equal(t, "namespace=/protected, require-token=true", hdr.Get("X-Pelican-Namespace"))
+}
+
+// TestSetTokenHintHeadersPublicNamespace pins that a public namespace is
+// reported as needing no token.  A client acts on a hint only when it says a
+// credential is required, so this is what stops one from being acquired for a
+// refusal that a credential would not have fixed.
+func TestSetTokenHintHeadersPublicNamespace(t *testing.T) {
+	ac := &authConfig{}
+	require.NoError(t, ac.updateConfig([]server_structs.NamespaceAd{
+		{Path: "/public", Caps: server_structs.Capabilities{Reads: true, PublicReads: true}},
+	}))
+
+	hdr := http.Header{}
+	ac.SetTokenHintHeaders(hdr, "/public/x.txt")
+	assert.Equal(t, "namespace=/public, require-token=false", hdr.Get("X-Pelican-Namespace"))
+}
+
+// TestSetTokenHintHeadersNoMatch pins that a path no namespace covers gets no
+// hint at all: the cache has nothing to say about it, and an empty
+// X-Pelican-Namespace would be read as a claim it does.
+func TestSetTokenHintHeadersNoMatch(t *testing.T) {
+	ac := &authConfig{}
+	require.NoError(t, ac.updateConfig([]server_structs.NamespaceAd{{Path: "/foo"}}))
+
+	hdr := http.Header{}
+	ac.SetTokenHintHeaders(hdr, "/bar/x.txt")
+	assert.Empty(t, hdr.Get("X-Pelican-Namespace"))
+	assert.Empty(t, hdr.Get("X-Pelican-Authorization"))
+	assert.Empty(t, hdr.Get("X-Pelican-Token-Generation"))
+
+	// A cache that has not yet heard from its director knows no namespaces at
+	// all; it must not panic on the way to saying nothing.
+	hdr = http.Header{}
+	(&authConfig{}).SetTokenHintHeaders(hdr, "/foo/x.txt")
+	assert.Empty(t, hdr.Get("X-Pelican-Namespace"))
+}


### PR DESCRIPTION
A cache refuses an unauthorized request with a bare 403. That is enough for a client a director sent there — it was told which issuer to use before it was redirected — but not for a client that arrived on its own: it named the cache itself (`Client.PreferredCaches`, `-c`), or the director it would have asked was unreachable. Such a client gets a refusal and has nowhere to go.

This is the standalone-cache half of #3510, split out so the anycast/BGP work can be reviewed separately. It stands on its own: it is what makes a forced-cache transfer work during a director outage, and what lets `-c` reach a cache for an authenticated namespace without a director round trip.

### The cache answers the question the director would have

A refusal the cache produces itself now carries the same `X-Pelican-{Namespace,Authorization,Token-Generation}` headers a director would send for that namespace, built from the namespace ads the director already gives the cache for authorization. The three refusals a cache issues on its own behalf — an object read, a PROPFIND, and a write — carry them. Failures a credential would not fix (an origin timeout, a throttle) do not, since a hint there would only send the client to acquire a token that changes nothing. A path no namespace covers gets no headers at all.

Authorization itself is unchanged. The hint names the credential the cache recommends for the most specific namespace covering the object; it is not a statement of what will be refused, and any token whose scopes reach the path is still accepted.

The namespace is advertised with this cache as its collections URL when it allows listings, since the V2 cache proxies PROPFIND to the origin on the endpoint it already serves objects from — so a client that reached the cache can list through it rather than being sent back across the federation.

This mirrors what a standalone origin already does (`origin_serve.authConfig.SetTokenHintHeaders`).

### The client may act on a hint from a cache it chose

The client already acts on token hints, but only from a host its user named — so far just the host in the `pelican://` URL. That distinction was never about the discovery host in particular; it is about who chose the endpoint. A cache the user picked themselves is named just as squarely, and having deliberately sent the request there, they are asking what that cache says it will accept. `canApplyTokenHint` says as much on `main` today, leaving this to "the change that gives explicitly-chosen caches their own standing" — this is that change.

A cache the *director* picked out of its own list is still refused, however identical the two look on the wire.

Which endpoint a named cache refers to is read the way the transfer reads it: host must match exactly, port included; a scheme the user wrote must match, so advice arriving in the clear is not accepted for a cache named as `https`; an entry written as a bare hostname commits to no scheme and is resolved the way the attempt list resolves it; and the `+` that appends the director's servers names no host at all.

### Tests

Cache side: the headers emitted for a token-required namespace and their round trip through the client's parser, the most-specific-namespace choice among nested namespaces with different issuers, the collections-url (and its absence when listings are off), a public namespace reporting `require-token=false`, no headers for an unmatched path, and the wiring — an authorization denial carries the hint, an upstream failure does not.

Client side: a hint from a cache the user named is honored end to end — the same fixture that pins a hint from an unnamed host being refused, with the opposite outcome — plus the named caches reaching the job's token generators (including a copy's source side) and the gate's decision table for ports, schemes, bare hostnames and the `+` sentinel.

---

#3510 is stacked on top of this and now contains only the BGP/anycast work. Because both heads are fork branches, its diff shows these two commits until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
