### PR TITLE
Cache: S3 storage targets with presigned-URL redirects

### DIFF
--- a/.github/scripts/validate-parameters/main.py
+++ b/.github/scripts/validate-parameters/main.py
@@ -36,6 +36,7 @@ ENUMERATIONS = {
 # configurable via Pelican's web UI. The ones in this list are known to have
 # beeh handled appropriately.
 VERIFIED_OBJECT_STRUCTURES = [
+    "Cache.S3StorageTargets",
     "GeoIPOverrides",
     "Issuer.AuthorizationTemplates",
     "Issuer.OIDCAuthenticationRequirements",

--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -111,6 +111,14 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 		val = strings.ReplaceAll(val, "${Cache.RunLocation}", v.GetString(param.Cache_RunLocation.GetName()))
 		v.SetDefault(param.Cache_ClientStatisticsLocation.GetName(), val)
 	}
+	// Cache.S3DisableRedirect
+	v.SetDefault(param.Cache_S3DisableRedirect.GetName(), false)
+	// Cache.S3PresignEvictionHold
+	v.SetDefault(param.Cache_S3PresignEvictionHold.GetName(), "5m")
+	// Cache.S3PresignExpiry
+	v.SetDefault(param.Cache_S3PresignExpiry.GetName(), "5m")
+	// Cache.S3UploadThreshold
+	v.SetDefault(param.Cache_S3UploadThreshold.GetName(), "4MB")
 	// Cache.SelfTest
 	v.SetDefault(param.Cache_SelfTest.GetName(), true)
 	// Cache.SelfTestInterval

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -3236,6 +3236,83 @@ default: false
 components: ["cache"]
 hidden: true
 ---
+name: Cache.S3StorageTargets
+description: |+
+  A list of S3 storage targets the V2 (persistent) cache uses as additional object storage.
+  Once an object is fully downloaded to a local storage directory, the cache uploads it
+  (unencrypted) to a configured S3 bucket when the object size meets or exceeds
+  ${Cache.S3UploadThreshold}; the local copy is then removed and the object is served from S3.
+
+  Each entry is an object with the following keys:
+
+  - **ServiceUrl** (string, required): S3 endpoint URL (e.g. `https://s3.us-east-1.amazonaws.com`).
+  - **Region** (string, optional): the S3 region; defaults to `us-east-1`.
+  - **Bucket** (string, required): the bucket that holds cached objects.
+  - **Prefix** (string, optional): a key prefix under which objects are stored.
+  - **UrlStyle** (string, optional): `path` (default) or `virtual` bucket addressing.
+  - **AccessKeyfile** (string, optional): file containing the S3 access key ID.
+  - **SecretKeyfile** (string, optional): file containing the S3 secret key.
+    Both keyfiles must be provided together; when omitted, the ambient AWS credential
+    chain is used.
+  - **MaxSize** (string, required): maximum bytes of cache data stored in the bucket
+    (e.g. "5TB").  Unlike directory targets it cannot be auto-detected.
+  - **HighWaterMarkPercentage** / **LowWaterMarkPercentage** (int, optional): eviction
+    watermarks as a percentage of MaxSize; defaults follow ${Cache.HighWaterMark} and
+    ${Cache.LowWaterMark}.
+
+  Example YAML:
+  ```yaml
+  Cache:
+    S3StorageTargets:
+      - ServiceUrl: https://s3.example.com
+        Region: us-east-1
+        Bucket: pelican-cache
+        Prefix: objects
+        MaxSize: 10TB
+        AccessKeyfile: /etc/pelican/s3-access
+        SecretKeyfile: /etc/pelican/s3-secret
+  ```
+
+  This setting only has effect when `${Cache.EnableV2}` is true.
+type: object
+default: none
+components: ["cache"]
+---
+name: Cache.S3UploadThreshold
+description: |+
+  The minimum object size for the V2 cache to tier a completed object to an S3 storage
+  target configured via ${Cache.S3StorageTargets}.  Objects smaller than this threshold
+  stay on local storage.  Accepts byte units (e.g. "4MB", "16MiB").
+type: string
+default: 4MB
+components: ["cache"]
+---
+name: Cache.S3DisableRedirect
+description: |+
+  When objects are stored on an S3 storage target (${Cache.S3StorageTargets}), the V2 cache
+  by default redirects GET requests to a pre-signed S3 URL so clients download directly from
+  the bucket.  Set this to true to instead proxy the object bytes through the cache.
+type: bool
+default: false
+components: ["cache"]
+---
+name: Cache.S3PresignExpiry
+description: |+
+  The lifetime of pre-signed S3 URLs handed to clients when serving objects from an S3
+  storage target via redirect (see ${Cache.S3DisableRedirect}).
+type: duration
+default: 5m
+components: ["cache"]
+---
+name: Cache.S3PresignEvictionHold
+description: |+
+  How long after handing out a pre-signed S3 URL the referenced object is protected from
+  cache eviction.  This prevents deleting an object out from under a client that is still
+  downloading it via a pre-signed URL.  Should be at least ${Cache.S3PresignExpiry}.
+type: duration
+default: 5m
+components: ["cache"]
+---
 name: Cache.WorkerCount
 description: |+
   The number of concurrent transfer workers the V2 (persistent) cache uses to fetch objects from upstream

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -3257,8 +3257,10 @@ description: |+
   - **MaxSize** (string, required): maximum bytes of cache data stored in the bucket
     (e.g. "5TB").  Unlike directory targets it cannot be auto-detected.
   - **HighWaterMarkPercentage** / **LowWaterMarkPercentage** (int, optional): eviction
-    watermarks as a percentage of MaxSize; defaults follow ${Cache.HighWaterMark} and
-    ${Cache.LowWaterMark}.
+    watermarks as a percentage of MaxSize.  When omitted they follow
+    ${Cache.HighWaterMark} and ${Cache.LowWaterMark} if those are expressed as
+    percentages; absolute-byte watermarks are not applied to buckets, which fall back
+    to the built-in 90%/80% defaults instead.
 
   Example YAML:
   ```yaml
@@ -3273,7 +3275,33 @@ description: |+
         SecretKeyfile: /etc/pelican/s3-secret
   ```
 
-  This setting only has effect when `${Cache.EnableV2}` is true.
+  **The cache assumes exclusive ownership of the bucket (or of the configured
+  Prefix within it).**  Its consistency sweep deletes any object under the prefix
+  it does not recognize, and crash recovery aborts all in-progress multipart
+  uploads there — do not share the prefix with other applications or with a
+  second cache instance.
+
+  **Objects on an S3 target are protected differently from objects on local disk.**
+  On disk the cache encrypts every block and authenticates it on read, so tampering
+  and disclosure both require breaking the encryption.  A tiered object is stored as
+  plaintext, and the cache verifies only its size:
+
+  - Anyone who can *read* the bucket can read every object tiered to it, including
+    objects from namespaces that require a token through Pelican.
+  - Anyone who can *write* the bucket can replace an object's bytes with content of
+    the same length, and the cache will serve it — with the origin's ETag and
+    checksums attached — without detecting the substitution.  The periodic data-
+    integrity scan does not checksum tiered objects.
+
+  Treat the bucket as part of the cache's trust boundary: give the cache a
+  dedicated least-privilege credential, keep the bucket private (no anonymous or
+  cross-account access), prefer an `https` endpoint, and consider server-side
+  encryption plus versioning or object lock.  Operators who need the on-disk
+  guarantees for a given namespace should not tier it — raise
+  ${Cache.S3UploadThreshold} above the object sizes involved.
+
+  This setting only has effect when `${Cache.EnableV2}` is true; the cache logs a
+  warning and ignores S3 targets otherwise.
 type: object
 default: none
 components: ["cache"]
@@ -3282,7 +3310,8 @@ name: Cache.S3UploadThreshold
 description: |+
   The minimum object size for the V2 cache to tier a completed object to an S3 storage
   target configured via ${Cache.S3StorageTargets}.  Objects smaller than this threshold
-  stay on local storage.  Accepts byte units (e.g. "4MB", "16MiB").
+  stay on local storage.  Accepts byte units (e.g. "4MB", "512MB", "1TB"); the
+  suffixes are binary multiples.
 type: string
 default: 4MB
 components: ["cache"]
@@ -3292,6 +3321,21 @@ description: |+
   When objects are stored on an S3 storage target (${Cache.S3StorageTargets}), the V2 cache
   by default redirects GET requests to a pre-signed S3 URL so clients download directly from
   the bucket.  Set this to true to instead proxy the object bytes through the cache.
+
+  The pre-signed URL is self-authenticating and never carries the client's Pelican bearer
+  token.  Spec-compliant HTTP clients (including Pelican's own client) drop the Authorization
+  header when following a redirect, unless the destination is the host they connected to or a
+  subdomain of it — so when a request carries such a header and the bucket endpoint falls
+  inside the cache's own DNS domain, the cache proxies that request instead of redirecting it,
+  rather than relying on the operator to notice.
+
+  Enable this option (proxy instead of redirect) if you serve private namespaces to clients
+  that forward Authorization even across unrelated hosts, contrary to the specification
+  (e.g. `curl --location-trusted`).
+
+  Note that bytes served by redirect do not pass through the cache, so they are not counted
+  in the cache's transfer monitoring.  Proxying restores that accounting at the cost of
+  moving the data through the cache.
 type: bool
 default: false
 components: ["cache"]

--- a/e2e_fed_tests/cache_s3_storage_test.go
+++ b/e2e_fed_tests/cache_s3_storage_test.go
@@ -1,0 +1,236 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// End-to-end tests for the persistent cache's S3 storage targets: a full
+// federation (director, registry, origin, V2 cache) plus a live minio
+// bucket.  Objects fetched through the cache are tiered to the bucket once
+// complete, after which GETs are answered with a 307 to a pre-signed S3
+// URL (or proxied through the cache when redirect is disabled).
+
+package fed_tests
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/fed_test_utils"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/test_utils"
+)
+
+// noRedirectHTTPClient returns a client that trusts the federation's TLS
+// certificates and does not follow redirects, so tests can observe the
+// cache's 307 responses directly.
+func noRedirectHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: config.GetTransport(),
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+// getWithToken issues a GET (optionally with a Range header) and returns
+// the response; callers own the body.
+func getWithToken(t *testing.T, httpClient *http.Client, url, token, rangeHeader string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	if rangeHeader != "" {
+		req.Header.Set("Range", rangeHeader)
+	}
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// TestCacheS3StorageFederationE2E spins up a complete federation with an
+// S3 storage target on the V2 cache and verifies the whole tiering +
+// serving lifecycle against a live minio server.
+func TestCacheS3StorageFederationE2E(t *testing.T) {
+	test_utils.SkipIfNoMinio(t)
+	endpoint, accessKey, secretKey := test_utils.StartMinio(t, "pelican-cache-fed-e2e")
+
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+
+	keyDir := t.TempDir()
+	accessKeyfile := filepath.Join(keyDir, "access")
+	secretKeyfile := filepath.Join(keyDir, "secret")
+	require.NoError(t, os.WriteFile(accessKeyfile, []byte(accessKey), 0600))
+	require.NoError(t, os.WriteFile(secretKeyfile, []byte(secretKey), 0600))
+
+	require.NoError(t, param.Cache_EnableV2.Set(true))
+	require.NoError(t, param.Cache_S3UploadThreshold.Set("4KB"))
+	require.NoError(t, param.Cache_S3StorageTargets.Set([]interface{}{
+		map[string]interface{}{
+			"ServiceUrl":    endpoint,
+			"Bucket":        "pelican-cache-fed-e2e",
+			"Prefix":        "cache",
+			"MaxSize":       "1GB",
+			"AccessKeyfile": accessKeyfile,
+			"SecretKeyfile": secretKeyfile,
+		},
+	}))
+
+	ft := fed_test_utils.NewFedTest(t, persistentCacheConfig)
+	token := getTempTokenForTest(t)
+
+	// A large object (above the threshold) that should be tiered, and a
+	// small one that must stay on local storage.
+	bigContent := writeOriginFile(t, ft, "s3_tier_big.bin", 64*1024)
+	smallContent := writeOriginFile(t, ft, "s3_tier_small.bin", 512)
+
+	bigCacheURL := waitForCacheRedirectURL(t, ft, "/test/s3_tier_big.bin", token)
+	httpClient := noRedirectHTTPClient()
+
+	// First GET is a cache miss served from local storage: a plain 200
+	// with the full body (tiering happens only after completion).
+	resp := getWithToken(t, httpClient, bigCacheURL, token, "")
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "cache-miss GET failed: %s", string(body))
+	require.Equal(t, bigContent, body)
+
+	// The completion hook enqueues the object for tiering; once the upload
+	// commits, the cache answers with a 307 to a pre-signed bucket URL.
+	var location string
+	require.Eventually(t, func() bool {
+		resp := getWithToken(t, httpClient, bigCacheURL, token, "")
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusTemporaryRedirect {
+			return false
+		}
+		location = resp.Header.Get("Location")
+		return location != ""
+	}, 30*time.Second, 250*time.Millisecond, "cache never redirected to the S3 bucket")
+
+	assert.Contains(t, location, "pelican-cache-fed-e2e", "redirect should point at the bucket")
+	assert.Contains(t, location, "X-Amz-Signature", "redirect should be pre-signed")
+
+	// The pre-signed URL is self-authenticating: a bare client with no
+	// token downloads the object bytes directly from the bucket.
+	presignResp, err := http.Get(location)
+	require.NoError(t, err)
+	body, err = io.ReadAll(presignResp.Body)
+	presignResp.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, presignResp.StatusCode)
+	assert.Equal(t, bigContent, body)
+
+	// A redirect-following client gets the object transparently through
+	// the cache endpoint.
+	followClient := &http.Client{Transport: config.GetTransport()}
+	resp = getWithToken(t, followClient, bigCacheURL, token, "")
+	body, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, bigContent, body)
+
+	// Range requests survive the redirect: the client re-applies the Range
+	// header to the pre-signed URL and S3 honors it.
+	resp = getWithToken(t, followClient, bigCacheURL, token, "bytes=1000-1999")
+	body, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusPartialContent, resp.StatusCode)
+	assert.Equal(t, bigContent[1000:2000], body)
+
+	// The full Pelican transfer client works end-to-end through the
+	// director -> cache -> pre-signed-URL chain.
+	downloadDir := t.TempDir()
+	downloadFile := filepath.Join(downloadDir, "via_client.bin")
+	fedURL := fmt.Sprintf("pelican://%s:%d/test/s3_tier_big.bin",
+		param.Server_Hostname.GetString(), param.Server_WebPort.GetInt())
+	_, err = client.DoGet(ft.Ctx, fedURL, downloadFile, false, client.WithToken(token))
+	require.NoError(t, err)
+	downloaded, err := os.ReadFile(downloadFile)
+	require.NoError(t, err)
+	assert.Equal(t, bigContent, downloaded)
+
+	// The small object stays on local storage: served directly with a 200
+	// even though the big object has already been tiered (which proves the
+	// upload workers have drained past it).
+	smallCacheURL := waitForCacheRedirectURL(t, ft, "/test/s3_tier_small.bin", token)
+	resp = getWithToken(t, httpClient, smallCacheURL, token, "")
+	body, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+	// A 200 here is itself the assertion that the object was not tiered: a
+	// tiered object would have answered the same request with a 307.
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"below-threshold object must be served from local storage, not redirected")
+	assert.Equal(t, smallContent, body)
+
+	// With redirect disabled, the same tiered object is proxied through
+	// the cache: plain 200 with the bytes streamed from the bucket.
+	require.NoError(t, param.Cache_S3DisableRedirect.Set(true))
+	t.Cleanup(func() { _ = param.Cache_S3DisableRedirect.Set(false) })
+	resp = getWithToken(t, httpClient, bigCacheURL, token, "")
+	body, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "proxy-mode GET failed: %s", string(body))
+	assert.Equal(t, bigContent, body)
+
+	// Proxy-mode range request is served by the cache itself.
+	resp = getWithToken(t, httpClient, bigCacheURL, token, "bytes=4000-4999")
+	body, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusPartialContent, resp.StatusCode)
+	assert.Equal(t, bigContent[4000:5000], body)
+
+	// Sanity: the local copy of the tiered object is gone — the objects
+	// directory holds only the small object's file.
+	cacheStorageLocation := param.Cache_StorageLocation.GetString()
+	require.NotEmpty(t, cacheStorageLocation)
+	objectsDir := filepath.Join(cacheStorageLocation, "persistent-cache", "objects")
+	bigOnDiskSize := int64(0)
+	_ = filepath.Walk(objectsDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || strings.HasSuffix(path, ".pelican-cache-id") {
+			return nil
+		}
+		if info.Size() > bigOnDiskSize {
+			bigOnDiskSize = info.Size()
+		}
+		return nil
+	})
+	assert.Less(t, bigOnDiskSize, int64(32*1024),
+		"the 64KB object should no longer have a local file after tiering")
+}

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,12 @@ require (
 	github.com/PelicanPlatform/classad v0.0.5
 	github.com/RoaringBitmap/roaring v1.9.4
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
+	github.com/aws/aws-sdk-go-v2 v1.41.3
 	github.com/aws/aws-sdk-go-v2/config v1.32.2
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.11
+	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.20.12
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.4
+	github.com/aws/smithy-go v1.24.2
 	github.com/bbockelm/gosssd v0.0.1
 	github.com/charmbracelet/glamour v0.8.0
 	github.com/cyphar/filepath-securejoin v0.4.1
@@ -91,10 +94,8 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 // indirect
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.41.3 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.6 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.19 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.20.12 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.19 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.19 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
@@ -107,7 +108,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.8 // indirect
-	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/bits-and-blooms/bitset v1.12.0 // indirect

--- a/launchers/cache_serve.go
+++ b/launchers/cache_serve.go
@@ -81,6 +81,14 @@ func CacheServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, m
 		return cacheServeWithPersistentCache(ctx, engine, egrp, modules)
 	}
 
+	// S3 storage targets are implemented only by the V2 cache.  Silently
+	// ignoring them would leave an operator believing their objects are being
+	// tiered to a bucket that is never written to.
+	if param.Cache_S3StorageTargets.IsSet() {
+		log.Warningln("Cache.S3StorageTargets is configured but Cache.EnableV2 is false; " +
+			"S3 storage targets are only supported by the V2 cache and will be ignored")
+	}
+
 	return cacheServeWithXRootD(ctx, engine, egrp, modules)
 }
 

--- a/local_cache/consistency.go
+++ b/local_cache/consistency.go
@@ -309,6 +309,13 @@ func (cc *ConsistencyChecker) Start(ctx context.Context, egrp *errgroup.Group) {
 	egrp.Go(func() error {
 		return cc.dataScanLoop(ctx)
 	})
+
+	// S3 bucket reconciliation - runs hourly when S3 targets exist
+	if len(cc.storage.s3Targets) > 0 {
+		egrp.Go(func() error {
+			return cc.s3ScanLoop(ctx)
+		})
+	}
 }
 
 // Stop stops the consistency checker
@@ -758,8 +765,10 @@ func (cc *ConsistencyChecker) RunMetadataScan(ctx context.Context, progressCh ch
 
 			// For completed disk objects, verify all required chunk files exist.
 			// In-progress objects may have partial chunks (from byte-range downloads),
-			// so we only check completed objects.
-			if meta.IsDisk() && !meta.Completed.IsZero() {
+			// so we only check completed objects.  Objects resident on an S3
+			// storage target have no local files at all — they are verified
+			// against the bucket listing by the S3 sweep instead.
+			if meta.IsDisk() && !meta.Completed.IsZero() && !cc.storage.IsS3Backed(meta.StorageID) {
 				if !cc.allChunkFilesExist(meta, instanceHash) {
 					// Some chunk files are missing - queue DB entry for deletion
 					if len(deletions) < maxDeletionsPerTx {
@@ -1385,6 +1394,13 @@ func (cc *ConsistencyChecker) verifyObjectChecksum(
 	bytesLimiter *rate.Limiter,
 	checksumMismatches, inconsistentBytes, bytesVerified, objectsVerified *int64,
 ) error {
+	// Objects resident on an S3 target have no local data to read back.
+	// The bucket provides its own at-rest durability; the S3 sweep
+	// cross-checks existence and size against metadata instead.
+	if cc.storage.IsS3Backed(meta.StorageID) {
+		return errChecksumSkipped
+	}
+
 	// For disk storage, check if complete before attempting any checksumming
 	if meta.IsDisk() {
 		complete, err := cc.storage.IsComplete(instanceHash)
@@ -1616,6 +1632,19 @@ func (cc *ConsistencyChecker) VerifyObject(instanceHash InstanceHash) (bool, err
 	}
 	if meta == nil {
 		return false, errors.New("object not found")
+	}
+
+	// S3-resident objects have no local data; verify existence and size
+	// against the bucket instead.  Bound the probe so a hung S3 endpoint
+	// cannot block VerifyObject indefinitely.
+	if target := cc.storage.getS3Target(meta.StorageID); target != nil {
+		probeCtx, cancel := context.WithTimeout(context.Background(), s3SweepOpTimeout)
+		defer cancel()
+		size, exists, err := target.objectSize(probeCtx, instanceHash)
+		if err != nil {
+			return false, err
+		}
+		return exists && size == meta.ContentLength, nil
 	}
 
 	// For disk storage, check that all ALLOCATED chunk files exist and object is complete

--- a/local_cache/database.go
+++ b/local_cache/database.go
@@ -88,6 +88,11 @@ type CacheDB struct {
 	// so this flag is what actually keeps an inspection tool from modifying
 	// the database: every mutating entry point checks it first.
 	readOnly bool
+
+	// presignHold is how long after a pre-signed URL was handed out an
+	// object is protected from eviction (0 = no protection).  Set during
+	// single-threaded init via setPresignHold; read-only afterwards.
+	presignHold time.Duration
 }
 
 // ErrReadOnly is returned by every mutating CacheDB method when the handle was
@@ -104,6 +109,14 @@ func (cdb *CacheDB) checkWritable() error {
 
 // ReadOnly reports whether this handle refuses mutations.
 func (cdb *CacheDB) ReadOnly() bool { return cdb.readOnly }
+
+// setPresignHold configures the eviction protection window for objects with
+// a recently issued pre-signed URL.  Must be called during single-threaded
+// initialization.  It only sets an in-memory field (it is not a database
+// write), so it is unexported and needs no read-only guard.
+func (cdb *CacheDB) setPresignHold(d time.Duration) {
+	cdb.presignHold = d
+}
 
 // cacheDBOptions builds the BadgerDB options shared by every way of opening a
 // cache database.  Both the writable open and the introspection open must use
@@ -686,6 +699,15 @@ func formatSchemaVersion(v SchemaVersion) []byte {
 // from ensureSchemaVersion before the stamping transaction, and leave this
 // function for the cheap in-place cases.
 func migrateSchema(txn *badger.Txn, from SchemaVersion) error {
+	if from == 1 {
+		// 1 -> 2 rewrites nothing: the S3 layout only adds key prefixes (up:,
+		// ps:) that a version-1 database simply has none of, and the new
+		// DiskMapping.Backend field decodes as BackendPosix when absent, which
+		// is what every mapping written under version 1 is.  Stamping the new
+		// version is the whole migration; see CurrentSchemaVersion for why the
+		// stamp matters even so.
+		return nil
+	}
 	return errors.Errorf("no migration is available from schema version %d", from)
 }
 
@@ -1937,6 +1959,223 @@ func (cdb *CacheDB) ComputeActualUsage() (map[StorageUsageKey]int64, error) {
 	return actual, err
 }
 
+// --- S3 Tiering Operations ---
+
+// SetS3UploadIntent records an in-progress upload to an S3 target.  Written
+// before the first byte reaches the bucket so that a crash never leaves an
+// untracked object in S3.
+//
+// This and DeleteS3UploadIntent perform a single blind Set/Delete with no
+// prior read, so their transaction read-set is empty and BadgerDB's
+// serializable-snapshot conflict detection can never flag them — no retry
+// loop is required (unlike RecordPresignIssued or RelocateObject, which read
+// before writing).
+func (cdb *CacheDB) SetS3UploadIntent(instanceHash InstanceHash, intent *S3UploadIntent) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
+	data, err := msgpack.Marshal(intent)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal upload intent")
+	}
+	return cdb.db.Update(func(txn *badger.Txn) error {
+		return txn.Set(S3UploadIntentKey(instanceHash), data)
+	})
+}
+
+// DeleteS3UploadIntent removes an upload intent record.
+func (cdb *CacheDB) DeleteS3UploadIntent(instanceHash InstanceHash) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
+	return cdb.db.Update(func(txn *badger.Txn) error {
+		err := txn.Delete(S3UploadIntentKey(instanceHash))
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			return nil
+		}
+		return err
+	})
+}
+
+// ListS3UploadIntents returns all recorded upload intents, used by crash
+// recovery to reconcile the bucket with the metadata store.
+func (cdb *CacheDB) ListS3UploadIntents() (map[InstanceHash]*S3UploadIntent, error) {
+	intents := make(map[InstanceHash]*S3UploadIntent)
+	err := cdb.db.View(func(txn *badger.Txn) error {
+		prefix := []byte(PrefixS3Upload)
+		opts := badger.DefaultIteratorOptions
+		opts.Prefix = prefix
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			item := it.Item()
+			hash := InstanceHash(item.Key()[len(PrefixS3Upload):])
+			var intent S3UploadIntent
+			err := item.Value(func(val []byte) error {
+				return msgpack.Unmarshal(val, &intent)
+			})
+			if err != nil {
+				log.Warnf("Failed to unmarshal S3 upload intent for %s: %v", hash, err)
+				continue
+			}
+			intents[hash] = &intent
+		}
+		return nil
+	})
+	return intents, err
+}
+
+// presignRecordRetries bounds retries of RecordPresignIssued on BadgerDB
+// write conflicts (the debounce read makes it a read-modify-write, so two
+// presigns racing on the same object can conflict).
+const presignRecordRetries = 5
+
+// RecordPresignIssued stamps the current time on an object's presign key.
+// Objects with a stamp newer than the configured presign hold window are
+// skipped by eviction, so a client holding a fresh pre-signed URL never has
+// the object deleted out from under it.
+//
+// The write is debounced so that a hot object being redirected repeatedly does
+// not stamp the same key on every request.  The debounce window is bounded by
+// how much slack the hold has over a URL's lifetime: skipping a write leaves
+// the stamp up to one window old, so the protection a caller can still count
+// on is hold-minus-window, which must remain at least as long as the URL it
+// just handed out.  presignHoldHeadroom is the slack the cache guarantees when
+// it resolves the hold, and a quarter of the hold is the cheaper bound, so the
+// debounce is the smaller of the two.
+func (cdb *CacheDB) RecordPresignIssued(instanceHash InstanceHash) error {
+	if err := cdb.checkWritable(); err != nil {
+		return err
+	}
+	now := time.Now()
+	debounce := cdb.presignHold / 4
+	if slack := cdb.presignHold - s3PresignExpiry(); slack < debounce {
+		debounce = slack
+	}
+	val := make([]byte, 8)
+	binary.BigEndian.PutUint64(val, uint64(now.UnixNano()))
+
+	for attempt := 0; ; attempt++ {
+		err := cdb.db.Update(func(txn *badger.Txn) error {
+			if debounce > 0 {
+				if item, gErr := txn.Get(PresignKey(instanceHash)); gErr == nil {
+					var prev int64
+					_ = item.Value(func(v []byte) error {
+						if len(v) >= 8 {
+							prev = int64(binary.BigEndian.Uint64(v))
+						}
+						return nil
+					})
+					if prev > 0 && now.Sub(time.Unix(0, prev)) < debounce {
+						return nil // recent enough; skip the write
+					}
+				}
+			}
+			return txn.Set(PresignKey(instanceHash), val)
+		})
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, badger.ErrConflict) && attempt < presignRecordRetries {
+			continue
+		}
+		return err
+	}
+}
+
+// presignHeldInTxn reports whether the object's presign stamp is within the
+// eviction protection window.
+func (cdb *CacheDB) presignHeldInTxn(txn *badger.Txn, instanceHash InstanceHash) bool {
+	if cdb.presignHold <= 0 {
+		return false
+	}
+	item, err := txn.Get(PresignKey(instanceHash))
+	if err != nil {
+		return false
+	}
+	var issuedAt int64
+	_ = item.Value(func(val []byte) error {
+		if len(val) >= 8 {
+			issuedAt = int64(binary.BigEndian.Uint64(val))
+		}
+		return nil
+	})
+	return issuedAt > 0 && time.Since(time.Unix(0, issuedAt)) < cdb.presignHold
+}
+
+// RelocateObject atomically moves a completed object's metadata onto the
+// given S3 storage target.  The StorageID is rewritten (bypassing the
+// set-once merge rule — this is the one sanctioned transition) and the LRU
+// index entry is moved from the object's base storage ID to the new one.
+//
+// Chunked objects are supported: because an S3 target holds the object as a
+// single contiguous blob, relocation flattens the chunk layout
+// (ChunkSizeCode / ChunkLocations are cleared).  The returned pre-relocation
+// metadata still carries the original chunk layout so the caller can delete
+// every local chunk file and refund each contributing directory's usage.
+//
+// The caller is responsible for moving the object *data* and for adjusting
+// usage counters after the transaction commits (AddUsage cannot run inside
+// a transaction).  Returns the pre-relocation metadata.
+func (cdb *CacheDB) RelocateObject(instanceHash InstanceHash, newStorageID StorageID) (*CacheMetadata, error) {
+	if err := cdb.checkWritable(); err != nil {
+		return nil, err
+	}
+	var prev CacheMetadata
+	err := cdb.db.Update(func(txn *badger.Txn) error {
+		item, err := txn.Get(MetaKey(instanceHash))
+		if err != nil {
+			return errors.Wrap(err, "object metadata not found")
+		}
+		if err := item.Value(func(val []byte) error {
+			return msgpack.Unmarshal(val, &prev)
+		}); err != nil {
+			return errors.Wrap(err, "failed to unmarshal metadata")
+		}
+
+		if prev.Completed.IsZero() {
+			return errors.New("cannot relocate an incomplete object")
+		}
+		if prev.StorageID == StorageIDInline && !prev.IsChunked() {
+			return errors.New("cannot relocate an inline object")
+		}
+		if prev.StorageID == newStorageID {
+			return errors.New("object already resides on the target storage")
+		}
+
+		// Move the LRU index entry, preserving the access timestamp.  The
+		// LRU is keyed by the object's base StorageID (chunk 0's directory
+		// for chunked objects), which is what deleteObjectInTxn also uses.
+		if !prev.LastAccessTime.IsZero() {
+			oldKey := LRUKey(prev.StorageID, prev.NamespaceID, prev.LastAccessTime, instanceHash)
+			if err := txn.Delete(oldKey); err != nil && !errors.Is(err, badger.ErrKeyNotFound) {
+				return errors.Wrap(err, "failed to delete old LRU key")
+			}
+			newKey := LRUKey(newStorageID, prev.NamespaceID, prev.LastAccessTime, instanceHash)
+			if err := txn.Set(newKey, nil); err != nil {
+				return errors.Wrap(err, "failed to set new LRU key")
+			}
+		}
+
+		updated := prev
+		updated.StorageID = newStorageID
+		// The bucket holds one contiguous blob; drop the chunk layout so the
+		// object is a plain single-storage object on the S3 target.
+		updated.ChunkSizeCode = ChunkingDisabled
+		updated.ChunkLocations = nil
+		data, err := msgpack.Marshal(&updated)
+		if err != nil {
+			return errors.Wrap(err, "failed to marshal relocated metadata")
+		}
+		return txn.Set(MetaKey(instanceHash), data)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &prev, nil
+}
+
 // --- Bulk Operations ---
 
 // deleteObjectInTxn removes all DB keys for a cached object within an
@@ -2050,8 +2289,20 @@ func deleteObjectWithMetaInTxn(txn *badger.Txn, salt []byte, instanceHash Instan
 		}
 	}
 
-	// Delete purge-first marker if present (best-effort, ignore not-found)
+	// Delete purge-first marker, presign stamp, and any S3 upload intent if
+	// present (best-effort, ignore not-found).
+	//
+	// Dropping the intent here is safe and necessary: an intent outliving its
+	// object would make the S3 consistency sweep skip that hash in both
+	// directions forever, on the assumption that the uploader owns it.  Any
+	// bucket bytes are handled by the same deletion -- StorageManager.Delete
+	// and EvictByLRU remove the bucket object for an S3-resident version --
+	// and an intent for an upload still in flight belongs to an object whose
+	// metadata is being deleted underneath it, which the uploader detects when
+	// its relocation fails and cleans up the bucket copy itself.
 	_ = txn.Delete(PurgeFirstKey(instanceHash))
+	_ = txn.Delete(PresignKey(instanceHash))
+	_ = txn.Delete(S3UploadIntentKey(instanceHash))
 
 	// Likewise the append-in-flight marker: whatever removed the object also
 	// removed the thing the marker exists to let us reclaim.
@@ -2184,6 +2435,15 @@ func (cdb *CacheDB) EvictByLRU(storageID StorageID, namespaceID NamespaceID, max
 			// Checked before the metadata read: a protected object is not
 			// going anywhere this pass, so there is nothing to learn about it.
 			if skip != nil && skip(hash) {
+				*skipCounter++
+				return
+			}
+			// Objects with a recently issued pre-signed URL are protected the
+			// same way: a client may still be downloading directly from the
+			// bucket.  Counts against the skip budget so a namespace full of
+			// held objects cannot spin the LRU walk.
+			if cdb.presignHeldInTxn(txn, hash) {
+				log.Debugf("Skipping eviction of %s: pre-signed URL issued within hold window", hash)
 				*skipCounter++
 				return
 			}
@@ -2576,6 +2836,11 @@ func (cdb *CacheDB) FindRecyclableStorageID(mountedDirs map[StorageID]string) (S
 	for _, dm := range mappings {
 		if _, mounted := mountedDirs[dm.ID]; mounted {
 			continue // still in use
+		}
+		if dm.Backend != BackendPosix {
+			// S3 targets are never in mountedDirs; they must not be
+			// recycled out from under a configured bucket.
+			continue
 		}
 
 		// Sum usage across all namespaces for this storageID.

--- a/local_cache/eviction.go
+++ b/local_cache/eviction.go
@@ -58,6 +58,11 @@ type EvictionManager struct {
 	// Sorted list of directory IDs.  Read-only after construction.
 	dirIDs []StorageID
 
+	// Sorted list of directory IDs eligible for new-object placement
+	// (excludes NoPlacement targets such as S3 buckets).  Read-only
+	// after construction.
+	placementIDs []StorageID
+
 	// Pre-computed shuffled lookup table for ChooseDiskStorage.
 	// The table has rrTableSize entries, each containing a storageID.
 	// Entries are assigned proportional to free space and then
@@ -81,6 +86,24 @@ type dirEvictionLimits struct {
 	lowWater  uint64
 }
 
+// clampToInt64 converts a byte count to the signed arithmetic the eviction
+// bookkeeping uses, saturating rather than wrapping.
+//
+// These limits are already clamped where they are built, but that is several
+// functions away from where they are used: the checks live in
+// NewEvictionManager and the conversions happen wherever a limit meets a usage
+// figure.  Keeping a bound at each conversion means the guarantee is visible
+// at the point it matters -- to a reader, to a future edit that introduces
+// another limit, and to static analysis, which cannot carry the invariant
+// across a struct field and reports every one of these as an unchecked
+// narrowing conversion.
+func clampToInt64(v uint64) int64 {
+	if v > uint64(math.MaxInt64) {
+		return math.MaxInt64
+	}
+	return int64(v)
+}
+
 // EvictionConfig holds configuration for the eviction manager
 type EvictionConfig struct {
 	// DirConfigs maps storageID to its eviction limits.
@@ -95,6 +118,11 @@ type EvictionDirConfig struct {
 	LowWaterPercentage  int    // Percentage at which eviction stops  (0 = default 80)
 	HighWaterBytes      uint64 // Absolute byte threshold (overrides percentage when > 0)
 	LowWaterBytes       uint64 // Absolute byte threshold (overrides percentage when > 0)
+	// NoPlacement excludes this storage target from new-object placement
+	// (ChooseDiskStorage).  Used for S3 targets, which only receive
+	// completed objects tiered by the uploader; they still participate in
+	// usage accounting and eviction.
+	NoPlacement bool
 }
 
 // NewEvictionManager creates a new eviction manager
@@ -125,12 +153,18 @@ func NewEvictionManager(db *CacheDB, storage *StorageManager, config EvictionCon
 		}
 
 		// Sanity: clamp watermarks to MaxSize, ensure high >= low,
-		// and cap at MaxInt64 so uint64→int64 conversions are safe.
-		if highWater > dcfg.MaxSize {
-			highWater = dcfg.MaxSize
+		// and cap everything at MaxInt64 so the uint64→int64 conversions
+		// used throughout eviction (e.g. DirFree) cannot produce a negative
+		// value from an absurdly large configured size.
+		maxSize := dcfg.MaxSize
+		if highWater > maxSize {
+			highWater = maxSize
 		}
 		if lowWater > highWater {
 			lowWater = highWater
+		}
+		if maxSize > uint64(math.MaxInt64) {
+			maxSize = uint64(math.MaxInt64)
 		}
 		if highWater > uint64(math.MaxInt64) {
 			highWater = uint64(math.MaxInt64)
@@ -140,7 +174,7 @@ func NewEvictionManager(db *CacheDB, storage *StorageManager, config EvictionCon
 		}
 
 		dirLimits[id] = &dirEvictionLimits{
-			maxSize:   dcfg.MaxSize,
+			maxSize:   maxSize,
 			highWater: highWater,
 			lowWater:  lowWater,
 		}
@@ -148,19 +182,29 @@ func NewEvictionManager(db *CacheDB, storage *StorageManager, config EvictionCon
 
 	dirUsage := make(map[StorageID]*atomic.Int64, len(config.DirConfigs))
 	dirIDs := make([]StorageID, 0, len(config.DirConfigs))
-	for id := range config.DirConfigs {
+	placementIDs := make([]StorageID, 0, len(config.DirConfigs))
+	for id, dcfg := range config.DirConfigs {
 		dirUsage[id] = &atomic.Int64{}
 		dirIDs = append(dirIDs, id)
+		if !dcfg.NoPlacement {
+			placementIDs = append(placementIDs, id)
+		}
 	}
 	sort.Slice(dirIDs, func(i, j int) bool { return dirIDs[i] < dirIDs[j] })
+	sort.Slice(placementIDs, func(i, j int) bool { return placementIDs[i] < placementIDs[j] })
+	if len(placementIDs) == 0 {
+		// Safety: never leave placement with an empty candidate set.
+		placementIDs = dirIDs
+	}
 
 	em := &EvictionManager{
-		db:        db,
-		storage:   storage,
-		dirLimits: dirLimits,
-		dirUsage:  dirUsage,
-		dirIDs:    dirIDs,
-		evictChan: make(chan struct{}, 1),
+		db:           db,
+		storage:      storage,
+		dirLimits:    dirLimits,
+		dirUsage:     dirUsage,
+		dirIDs:       dirIDs,
+		placementIDs: placementIDs,
+		evictChan:    make(chan struct{}, 1),
 	}
 	em.rebuildRRTable()
 	return em
@@ -258,7 +302,7 @@ func (em *EvictionManager) NoteUsageIncrease(storageID StorageID, bytes int64) {
 
 	// Fast path: check the atomic estimate against the watermark.
 	limits, lok := em.dirLimits[storageID]
-	if !lok || newVal <= int64(limits.highWater) {
+	if !lok || newVal <= clampToInt64(limits.highWater) {
 		return
 	}
 
@@ -267,9 +311,37 @@ func (em *EvictionManager) NoteUsageIncrease(storageID StorageID, bytes int64) {
 	dbUsage := em.getDirUsage(storageID)
 	counter.Store(dbUsage)
 
-	if dbUsage > int64(limits.highWater) {
+	if dbUsage > clampToInt64(limits.highWater) {
 		em.TriggerEviction()
 	}
+}
+
+// NoteUsageDecrease adjusts the in-memory estimate downward after bytes
+// were released from a storage target (e.g. the local copy removed after
+// tiering to S3, or a failed upload refunded).  The DB-level counters must
+// already have been updated by the caller.
+func (em *EvictionManager) NoteUsageDecrease(storageID StorageID, bytes int64) {
+	if counter, ok := em.dirUsage[storageID]; ok {
+		counter.Add(-bytes)
+	}
+}
+
+// DirFree returns the estimated free bytes on a storage target based on
+// the in-memory usage estimate (no DB query).  Returns 0 for unknown IDs.
+func (em *EvictionManager) DirFree(storageID StorageID) int64 {
+	limits, ok := em.dirLimits[storageID]
+	if !ok {
+		return 0
+	}
+	used := em.dirUsage[storageID].Load()
+	if used < 0 {
+		used = 0
+	}
+	free := clampToInt64(limits.maxSize) - used
+	if free < 0 {
+		free = 0
+	}
+	return free
 }
 
 // GetTotalUsage returns the current total cache usage (sum of per-dir atomics).
@@ -379,9 +451,13 @@ func (em *EvictionManager) checkAndEvict() {
 				"highWater": limits.highWater,
 			}).Info("Starting eviction")
 
+			// Namespaces that made no eviction progress this pass (e.g.
+			// every candidate protected by a presign hold) are excluded
+			// so the loop moves on instead of spinning on them.
+			excluded := make(map[NamespaceID]bool)
 			for dirUsage = em.getDirUsage(sid); dirUsage > 0 && uint64(dirUsage) > limits.lowWater; dirUsage = em.getDirUsage(sid) {
 				// Find the greediest namespace in this directory
-				targetKey, targetUsage, err := em.findGreediestNamespaceInDir(sid)
+				targetKey, targetUsage, err := em.findGreediestNamespaceInDir(sid, excluded)
 				if err != nil {
 					rl.WithFields(log.Fields{"storageID": sid}).Warn("Failed to find greediest namespace")
 					break
@@ -392,7 +468,7 @@ func (em *EvictionManager) checkAndEvict() {
 					break
 				}
 
-				overhead := dirUsage - int64(limits.lowWater)
+				overhead := dirUsage - clampToInt64(limits.lowWater)
 				rl.WithFields(log.Fields{
 					"storageID":   targetKey.StorageID,
 					"namespaceID": targetKey.NamespaceID,
@@ -414,19 +490,24 @@ func (em *EvictionManager) checkAndEvict() {
 				totalEvictedObjects.Add(int64(count))
 				totalSkipped.Add(int64(skipped))
 
-				// A pass that freed nothing will pick the same namespace and
-				// do the same thing again, so looping only burns CPU until the
-				// timeout below.  Stop and let the next cycle try, by which
-				// time whatever blocked this one has usually cleared.
+				// A pass that freed nothing would pick the same namespace and
+				// do the same thing again, so retrying it only burns CPU until
+				// the timeout below.  Exclude the namespace and move on to the
+				// next-greediest one: a namespace whose LRU head is entirely
+				// in use (open readers, or objects under a presign hold) must
+				// not stop the whole storage target from draining, or a bucket
+				// sitting above its high-water mark never recovers and tiering
+				// stalls once no target has room.  When every namespace is
+				// excluded, findGreediestNamespaceInDir reports no usage and
+				// the loop exits above.
 				if count == 0 {
-					if skipped > 0 {
-						rl.WithFields(log.Fields{
-							"storageID":   targetKey.StorageID,
-							"namespaceID": targetKey.NamespaceID,
-							"skipped":     skipped,
-						}).Debug("Eviction made no progress; every candidate was in use")
-					}
-					break
+					rl.WithFields(log.Fields{
+						"storageID":   targetKey.StorageID,
+						"namespaceID": targetKey.NamespaceID,
+						"skipped":     skipped,
+					}).Debug("Eviction made no progress in namespace; excluding it for this pass")
+					excluded[targetKey.NamespaceID] = true
+					continue
 				}
 
 				// Safety: don't run for too long
@@ -454,8 +535,10 @@ func (em *EvictionManager) checkAndEvict() {
 }
 
 // findGreediestNamespaceInDir finds the namespace with highest usage
-// within a specific storage directory.
-func (em *EvictionManager) findGreediestNamespaceInDir(storageID StorageID) (StorageUsageKey, int64, error) {
+// within a specific storage directory.  Namespaces in the excluded set
+// (nil = none) are skipped; callers use this to move past namespaces whose
+// candidates are all protected from eviction.
+func (em *EvictionManager) findGreediestNamespaceInDir(storageID StorageID, excluded map[NamespaceID]bool) (StorageUsageKey, int64, error) {
 	nsUsage, err := em.db.GetDirUsage(storageID)
 	if err != nil {
 		return StorageUsageKey{}, 0, errors.Wrap(err, "failed to get namespace usage")
@@ -464,6 +547,9 @@ func (em *EvictionManager) findGreediestNamespaceInDir(storageID StorageID) (Sto
 	var bestNS NamespaceID
 	var bestUsage int64
 	for ns, usage := range nsUsage {
+		if excluded[ns] {
+			continue
+		}
 		if usage > bestUsage {
 			bestUsage = usage
 			bestNS = ns
@@ -638,10 +724,10 @@ func (em *EvictionManager) HasSpace(needed uint64) bool {
 func (em *EvictionManager) rebuildRRTable() {
 	var table [rrTableSize]StorageID
 
-	if len(em.dirIDs) == 1 {
+	if len(em.placementIDs) == 1 {
 		// Single-directory fast path: fill the entire table.
 		for i := range table {
-			table[i] = em.dirIDs[0]
+			table[i] = em.placementIDs[0]
 		}
 		em.rrTable.Store(&table)
 		em.rrLastUpdate.Store(time.Now().UnixMilli())
@@ -653,14 +739,14 @@ func (em *EvictionManager) rebuildRRTable() {
 		id   StorageID
 		free int64
 	}
-	raw := make([]dirWeight, 0, len(em.dirIDs))
+	raw := make([]dirWeight, 0, len(em.placementIDs))
 	var rawTotal int64
-	for _, sid := range em.dirIDs {
+	for _, sid := range em.placementIDs {
 		used := em.dirUsage[sid].Load()
 		if used < 0 {
 			used = 0
 		}
-		free := int64(em.dirLimits[sid].maxSize) - used
+		free := clampToInt64(em.dirLimits[sid].maxSize) - used
 		if free < 1 {
 			free = 1
 		}
@@ -756,7 +842,7 @@ func (em *EvictionManager) ChooseDiskStorage() StorageID {
 func (em *EvictionManager) ForcePurge() error {
 	targets := make(map[StorageID]int64, len(em.dirLimits))
 	for sid, limits := range em.dirLimits {
-		targets[sid] = int64(limits.lowWater)
+		targets[sid] = clampToInt64(limits.lowWater)
 	}
 	_, _, err := em.forcePurgeToTargets("Force purge", targets)
 	return err
@@ -782,7 +868,7 @@ func (em *EvictionManager) ForcePurgeToBytes(targetBytes uint64) (uint64, int64,
 
 	targets := make(map[StorageID]int64, len(em.dirLimits))
 	for sid, limits := range em.dirLimits {
-		targets[sid] = int64((targetBytes * limits.maxSize) / totalMax)
+		targets[sid] = clampToInt64((targetBytes * limits.maxSize) / totalMax)
 	}
 	return em.forcePurgeToTargets("Purge-to-target", targets)
 }
@@ -827,8 +913,9 @@ func (em *EvictionManager) forcePurgeToTargets(label string, targets map[Storage
 				return
 			}
 
+			excluded := make(map[NamespaceID]bool)
 			for dirUsage > dirTarget {
-				targetKey, targetUsage, err := em.findGreediestNamespaceInDir(sid)
+				targetKey, targetUsage, err := em.findGreediestNamespaceInDir(sid, excluded)
 				if err != nil || targetUsage <= 0 {
 					break
 				}
@@ -846,16 +933,21 @@ func (em *EvictionManager) forcePurgeToTargets(label string, targets map[Storage
 				evictedBytes.Add(bytes)
 				evictedObjects.Add(int64(count))
 
-				// As in checkAndEvict: no progress means the next iteration
-				// would repeat this one exactly.
+				// As in checkAndEvict: a namespace that freed nothing would be
+				// chosen again on the next iteration, so exclude it and try the
+				// next-greediest one.  Once every namespace is excluded the
+				// loop exits via the targetUsage check above, at which point
+				// the purge really could not reach its target.
 				if count == 0 {
 					if skipped > 0 {
 						rl.WithFields(log.Fields{
-							"storageID": sid,
-							"skipped":   skipped,
-						}).Warnf("%s could not reach its target; every candidate was in use", label)
+							"storageID":   sid,
+							"namespaceID": targetKey.NamespaceID,
+							"skipped":     skipped,
+						}).Debugf("%s made no progress in namespace; excluding it", label)
 					}
-					break
+					excluded[targetKey.NamespaceID] = true
+					continue
 				}
 
 				if time.Since(startTime) > 60*time.Second {

--- a/local_cache/introspect_open_test.go
+++ b/local_cache/introspect_open_test.go
@@ -245,6 +245,12 @@ func TestOpenCacheDBReadOnlyRefusesWrites(t *testing.T) {
 			_, _, err := db.EvictByLRU(StorageIDInline, 1, 1, 0, nil)
 			return err
 		},
+		"SetS3UploadIntent": func() error {
+			return db.SetS3UploadIntent(instHash, &S3UploadIntent{})
+		},
+		"DeleteS3UploadIntent": func() error {
+			return db.DeleteS3UploadIntent(instHash)
+		},
 		// A batch holds an open BadgerDB write transaction, so each of these
 		// cancels the one it took -- the refusal is the assertion, not a reason
 		// to leak the transaction until Close.

--- a/local_cache/persistent_cache.go
+++ b/local_cache/persistent_cache.go
@@ -226,6 +226,10 @@ type PersistentCache struct {
 
 	// Prestage worker pool manager (created lazily on first API call).
 	prestageManager *PrestageManager
+
+	// s3Uploader tiers completed objects to S3 storage targets.
+	// Nil when no S3 targets are configured.
+	s3Uploader *s3Uploader
 }
 
 // persistentDownload tracks an active download operation
@@ -561,6 +565,19 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 		return nil, err
 	}
 
+	// Register any configured S3 storage targets.  They receive their own
+	// storage IDs (persisted via an identity object in the bucket) but are
+	// excluded from new-object placement — objects arrive there only by
+	// tiering after completion.
+	s3TargetConfigs, err := ParseS3TargetsConfig()
+	if err != nil {
+		return failInit(err)
+	}
+	s3TargetIDs, err := storage.RegisterS3Targets(ctx, s3TargetConfigs)
+	if err != nil {
+		return failInit(errors.Wrap(err, "failed to register S3 storage targets"))
+	}
+
 	// Build eviction dir configs now that we know storageID → path mapping.
 	// GetDirs() returns paths with /objects appended; strip the suffix to
 	// match against the original config paths.
@@ -602,6 +619,48 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 			HighWaterBytes:      defaultHWBytes,
 			LowWaterBytes:       defaultLWBytes,
 		}
+	}
+
+	// S3 targets get their own eviction limits (MaxSize is required in the
+	// config since bucket capacity cannot be auto-detected).  Absolute
+	// default watermarks are not applied — they are tuned for local
+	// directories; buckets use the percentage watermarks.
+	for id, s3cfg := range s3TargetIDs {
+		hwp := s3cfg.HighWaterMarkPercentage
+		if hwp <= 0 {
+			hwp = defaultHWP
+		}
+		lwp := s3cfg.LowWaterMarkPercentage
+		if lwp <= 0 {
+			lwp = defaultLWP
+		}
+		evictionDirCfgs[id] = EvictionDirConfig{
+			MaxSize:             s3cfg.MaxSize,
+			HighWaterPercentage: hwp,
+			LowWaterPercentage:  lwp,
+			NoPlacement:         true,
+		}
+	}
+
+	// Objects with a recently issued pre-signed URL must not be evicted —
+	// a client may still be mid-download directly from the bucket.
+	//
+	// The hold has to outlast the URL, not merely match it: a URL minted at t
+	// is usable until t+expiry, so a hold of the same length leaves the last
+	// moments of its life unprotected.  Stretch a too-short hold rather than
+	// refusing to start, and say so, since the safe value is derivable.
+	if len(s3TargetIDs) > 0 {
+		hold := param.Cache_S3PresignEvictionHold.GetDuration()
+		if hold <= 0 {
+			hold = 5 * time.Minute
+		}
+		if minimum := s3PresignExpiry() + presignHoldHeadroom; hold < minimum {
+			log.Warnf("Cache.S3PresignEvictionHold (%s) does not outlast Cache.S3PresignExpiry (%s); "+
+				"using %s so an object cannot be evicted while a pre-signed URL for it is still valid",
+				hold, s3PresignExpiry(), minimum)
+			hold = minimum
+		}
+		db.setPresignHold(hold)
 	}
 
 	// Initialize eviction manager
@@ -709,10 +768,42 @@ func NewPersistentCache(ctx context.Context, egrp *errgroup.Group, cfg Persisten
 		log.Infof("Restored %d namespace mappings (max ID %d)", len(nsMap), maxID)
 	}
 
+	// Build the S3 tiering uploader and wire completion notifications now,
+	// while initialization is still single-threaded: onObjectComplete is read
+	// by every download that finishes, so it must be in place before anything
+	// below can start one.
+	if len(s3TargetIDs) > 0 {
+		threshold := int64(4 * 1024 * 1024)
+		if thresholdStr := param.Cache_S3UploadThreshold.GetString(); thresholdStr != "" {
+			parsed, err := utils.ParseBytes(thresholdStr)
+			if err != nil {
+				pc.Close()
+				return nil, errors.Wrap(err, "failed to parse Cache.S3UploadThreshold")
+			}
+			threshold = int64(parsed)
+		}
+		uploader := newS3Uploader(db, storage, eviction, threshold)
+		storage.onObjectComplete = uploader.MaybeEnqueue
+		pc.s3Uploader = uploader
+	}
+
 	// Start background tasks
 	db.StartGC(ctx, egrp)
 	eviction.Start(ctx, egrp)
 	consistency.Start(ctx, egrp)
+
+	// Start the S3 tiering uploader.  Its crash recovery runs synchronously
+	// here, before the cache serves anything: it reconciles the buckets
+	// against the metadata store, and a bucket left inconsistent by a previous
+	// process must not have new uploads layered on top of it.  A failure is
+	// fatal rather than logged -- silently continuing would leave tiering off
+	// for the process lifetime with objects still accumulating locally.
+	if pc.s3Uploader != nil {
+		if err := pc.s3Uploader.Start(ctx, egrp); err != nil {
+			pc.Close()
+			return nil, errors.Wrap(err, "failed to start the S3 tiering uploader")
+		}
+	}
 
 	// Ensure all resources are released when the context is cancelled.
 	// Without this, the TransferEngine and BadgerDB leak across tests
@@ -1021,6 +1112,16 @@ func (pc *PersistentCache) resolveObject(
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to check cache")
 		}
+		// An object whose storage no longer exists -- most plausibly one left
+		// behind by a bucket that has since been removed from the
+		// configuration -- is a miss, not something to look for on disk.  Its
+		// storage ID resolves to no directory, and treating it as a hit would
+		// send the read to an arbitrary one.
+		if meta != nil && !pc.storage.storageIsResolvable(meta.StorageID) {
+			log.Warnf("Cached object %s names storage %d, which is not configured; treating as a miss",
+				instanceHash, meta.StorageID)
+			meta = nil
+		}
 	}
 
 	var dl *persistentDownload
@@ -1301,6 +1402,12 @@ func (pc *PersistentCache) GetSeekableReader(ctx context.Context, objectPath, be
 			}}, res.meta, nil
 		}
 
+		// Objects tiered to an S3 storage target are proxied through a
+		// seekable remote stream (no local blocks exist for them).
+		if target := pc.storage.getS3Target(res.meta.StorageID); target != nil {
+			return pc.newS3SeekableReader(ctx, target, res), res.meta, nil
+		}
+
 		rr, err := pc.newFetchingRangeReader(res, 0, res.meta.ContentLength-1)
 		if err != nil {
 			if attempt < maxAttempts-1 && isEvictedError(err) {
@@ -1330,6 +1437,29 @@ func (pc *PersistentCache) GetRange(ctx context.Context, objectPath, token, rang
 		// Handle no-store streaming response
 		if res.noStoreRC != nil {
 			return res.noStoreRC, nil
+		}
+
+		// Objects tiered to an S3 storage target stream directly from the
+		// bucket (optionally limited to the requested range).
+		if target := pc.storage.getS3Target(res.meta.StorageID); target != nil {
+			stream := newS3ObjectStream(ctx, target, res.instanceHash, res.meta.ContentLength)
+			// Pinned for the life of the stream; see newS3SeekableReader.
+			stream.onClose = pc.storage.PinObject(res.instanceHash)
+			if rangeHeader != "" {
+				ranges, err := ParseRangeHeader(rangeHeader, res.meta.ContentLength)
+				if err != nil {
+					stream.Close()
+					return nil, errors.Wrap(err, "invalid range header")
+				}
+				if len(ranges) > 0 {
+					if _, err := stream.Seek(ranges[0].Start, io.SeekStart); err != nil {
+						stream.Close()
+						return nil, err
+					}
+					return &limitedReadCloser{stream: stream, remain: ranges[0].End - ranges[0].Start + 1}, nil
+				}
+			}
+			return stream, nil
 		}
 
 		// Handle range request

--- a/local_cache/persistent_cache_api.go
+++ b/local_cache/persistent_cache_api.go
@@ -552,6 +552,14 @@ func (pc *PersistentCache) serveObject(w http.ResponseWriter, r *http.Request) {
 		_ = size
 	}
 
+	// Objects tiered to an S3 storage target are served by redirecting the
+	// client to a pre-signed bucket URL (unless disabled).  Presigned URLs
+	// are self-authenticating; the client's bearer token is dropped on the
+	// cross-host hop, which is exactly what we want.
+	if pc.tryS3Redirect(w, r, objectPath, bearerToken, reqLog, startTime) {
+		return
+	}
+
 	// Get seekable reader for the object (handles on-demand fetching).
 	// When the client sent a Range header, tell the cache so that on a
 	// miss it can use a lightweight HEAD + on-demand block fetch instead

--- a/local_cache/range_reader.go
+++ b/local_cache/range_reader.go
@@ -164,6 +164,12 @@ type RangeReader struct {
 	// because a pipe is forward-only.
 	noStoreReader io.ReadCloser
 
+	// remoteStream serves objects that reside on an S3 storage target when
+	// redirect is disabled (proxy mode).  Unlike noStoreReader it is
+	// seekable, so http.ServeContent works normally.  When set, Read/Seek
+	// delegate here and the block-storage path is bypassed.
+	remoteStream *s3ObjectStream
+
 	// size is the content length of a no-store response.  It is only valid
 	// when noStoreReader is set.
 	size int64
@@ -279,6 +285,11 @@ func (rr *RangeReader) ReadContext(ctx context.Context, p []byte) (n int, err er
 	// Streaming no-store mode: forward-only pipe from origin
 	if rr.noStoreReader != nil {
 		return rr.noStoreReader.Read(p)
+	}
+
+	// S3 proxy mode: delegate to the remote stream
+	if rr.remoteStream != nil {
+		return rr.remoteStream.Read(p)
 	}
 
 	if rr.position > rr.end {
@@ -590,6 +601,9 @@ func (rr *RangeReader) Close() error {
 	if rr.noStoreReader != nil {
 		err = rr.noStoreReader.Close()
 	}
+	if rr.remoteStream != nil {
+		err = rr.remoteStream.Close()
+	}
 	if rr.onClose != nil {
 		rr.onClose()
 	}
@@ -659,6 +673,11 @@ func (rr *RangeReader) Seek(offset int64, whence int) (int64, error) {
 	// Streaming no-store mode: cannot seek a pipe
 	if rr.noStoreReader != nil {
 		return 0, errors.New("seek not supported on streaming no-store response")
+	}
+
+	// S3 proxy mode: the remote stream is seekable
+	if rr.remoteStream != nil {
+		return rr.remoteStream.Seek(offset, whence)
 	}
 
 	var newPos int64

--- a/local_cache/s3_consistency.go
+++ b/local_cache/s3_consistency.go
@@ -1,0 +1,340 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package local_cache
+
+import (
+	"context"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// s3ScanLoop runs the periodic S3 consistency sweep.  Started only when at
+// least one S3 storage target is configured.
+func (cc *ConsistencyChecker) s3ScanLoop(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return nil
+	case <-cc.stopCh:
+		return nil
+	case <-time.After(10 * time.Minute):
+	}
+
+	const scanInterval = 1 * time.Hour
+
+	for {
+		if err := cc.RunS3Scan(ctx); err != nil {
+			log.Warnf("S3 consistency scan error: %v", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-cc.stopCh:
+			return nil
+		case <-time.After(scanInterval):
+		}
+	}
+}
+
+// RunS3Scan reconciles each S3 storage target's bucket contents against the
+// metadata store:
+//
+//   - objects in the bucket with no S3-resident metadata (and no in-flight
+//     upload intent) are orphans and deleted from the bucket;
+//   - S3-resident metadata whose bucket object is missing (or whose size
+//     disagrees) is removed so the object is re-fetched from the origin on
+//     the next request.
+//
+// Byte-level usage for S3 storage IDs is reconciled by the regular metadata
+// scan (usageDuringScan covers every metadata entry regardless of backend).
+func (cc *ConsistencyChecker) RunS3Scan(ctx context.Context) error {
+	for sid, target := range cc.storage.s3Targets {
+		if err := cc.scanS3Target(ctx, sid, target); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// s3BucketEntry is one object observed while listing a bucket.
+type s3BucketEntry struct {
+	hash     InstanceHash
+	size     int64
+	modified time.Time
+}
+
+// s3MaxOrphansPerScan bounds how many orphan candidates (in either
+// direction) a single sweep collects before it stops accumulating and
+// defers the rest to the next sweep.  This caps the sweep's memory
+// regardless of how large or divergent the bucket is.
+const s3MaxOrphansPerScan = 4096
+
+// s3SweepOpTimeout bounds each individual S3 HeadObject / DeleteObject the
+// sweep issues while reconciling, so one hung request cannot stall the pass.
+const s3SweepOpTimeout = 2 * time.Minute
+
+func (cc *ConsistencyChecker) scanS3Target(ctx context.Context, sid StorageID, target *s3Target) error {
+	scanStart := time.Now()
+
+	// Snapshot the in-flight upload intents; objects covered by an intent
+	// are owned by the uploader and skipped entirely.
+	intents, err := cc.db.ListS3UploadIntents()
+	if err != nil {
+		return err
+	}
+
+	// Stream the bucket listing (lexicographic key order == instance-hash
+	// order thanks to the shared aa/bb/rest layout).  The producer goroutine
+	// is bounded to this function: listCtx is cancelled on every return path
+	// (defer), which unblocks the goroutine if it is parked on a channel
+	// send, and listDone is buffered so its final send never blocks.  We
+	// also join on listDone before returning (see below), so the goroutine
+	// can never outlive scanS3Target — no errgroup needed.
+	listChan := make(chan s3BucketEntry, 256)
+	listDone := make(chan error, 1)
+	listCtx, cancelList := context.WithCancel(ctx)
+	go func() {
+		defer close(listChan)
+		listDone <- target.listObjects(listCtx, func(hash InstanceHash, size int64, modified time.Time) error {
+			select {
+			case listChan <- s3BucketEntry{hash: hash, size: size, modified: modified}:
+				return nil
+			case <-listCtx.Done():
+				return listCtx.Err()
+			}
+		})
+	}()
+
+	// listErr is populated by the deferred join.  Guaranteeing the join on
+	// every return path is what makes the goroutine unable to escape.  The
+	// merge join below always consumes the listing to completion (it stops
+	// appending once the orphan cap is hit, but keeps draining), so under
+	// normal operation the producer finishes on its own and listErr carries
+	// its real result; cancelList()/the drain only matter on an early error
+	// return.
+	var listErr error
+	joined := false
+	joinList := func() {
+		if joined {
+			return
+		}
+		joined = true
+		cancelList()
+		// Drain any buffered entries so the producer is never blocked on a
+		// send while we wait for it to finish.
+		for range listChan {
+		}
+		listErr = <-listDone
+	}
+	defer joinList()
+
+	var orphanBucket []s3BucketEntry // in bucket, not in DB
+	var orphanDB []InstanceHash      // in DB, not in bucket (or size mismatch)
+	capped := false                  // hit s3MaxOrphansPerScan; more remains
+
+	// considerBucketOrphan applies the grace period and intent check
+	// before queuing a bucket object for deletion.
+	considerBucketOrphan := func(e s3BucketEntry) {
+		if _, uploading := intents[e.hash]; uploading {
+			return
+		}
+		if cc.minAgeForCleanup > 0 && time.Since(e.modified) < cc.minAgeForCleanup {
+			return
+		}
+		if len(orphanBucket) >= s3MaxOrphansPerScan {
+			capped = true
+			return
+		}
+		orphanBucket = append(orphanBucket, e)
+	}
+
+	// Merge join: DB metadata (restricted to this storage ID) vs listing.
+	// The join always runs to completion so the listing producer finishes
+	// on its own; once an orphan list reaches the cap it simply stops
+	// appending (recording capped) rather than stopping the walk.
+	current, listOk := <-listChan
+	scanErr := cc.db.ScanMetadata(func(instanceHash InstanceHash, meta *CacheMetadata) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		if meta.StorageID != sid {
+			return nil
+		}
+
+		// Bucket keys sorting before this DB entry have no metadata.
+		for listOk && current.hash < instanceHash {
+			considerBucketOrphan(current)
+			current, listOk = <-listChan
+		}
+
+		if listOk && current.hash == instanceHash {
+			// Present in both — objects are stored plaintext, so the
+			// bucket size must equal ContentLength exactly.
+			if !meta.Completed.IsZero() && meta.ContentLength != current.size {
+				log.Warnf("S3 object %s size mismatch (bucket %d, metadata %d); removing",
+					instanceHash, current.size, meta.ContentLength)
+				if len(orphanDB) >= s3MaxOrphansPerScan {
+					capped = true
+				} else {
+					orphanDB = append(orphanDB, instanceHash)
+				}
+			}
+			current, listOk = <-listChan
+			return nil
+		}
+
+		// DB entry with no bucket object.  Grace period guards against
+		// races with a relocation committing mid-listing.
+		if _, uploading := intents[instanceHash]; uploading {
+			return nil
+		}
+		if cc.minAgeForCleanup > 0 && !meta.Completed.IsZero() && time.Since(meta.Completed) < cc.minAgeForCleanup {
+			return nil
+		}
+		if len(orphanDB) >= s3MaxOrphansPerScan {
+			capped = true
+			return nil
+		}
+		orphanDB = append(orphanDB, instanceHash)
+		return nil
+	})
+
+	// Any remaining listing entries have no metadata at all.  Drain them all
+	// (considerBucketOrphan stops appending once the cap is hit) so the
+	// producer goroutine finishes on its own.
+	for listOk {
+		considerBucketOrphan(current)
+		current, listOk = <-listChan
+	}
+	joinList()
+
+	if scanErr != nil {
+		return scanErr
+	}
+	if listErr != nil {
+		// An incomplete listing would make every unseen DB entry look
+		// orphaned — mirror the metadata scan's walk-error policy and
+		// skip all deletions this pass.
+		log.Warnf("S3 listing of %s failed; skipping deletions this pass: %v", target.cfg.DisplayURL(), listErr)
+		return nil
+	}
+
+	deletedBucket, deletedDB := 0, 0
+
+	// One fresh snapshot of the in-flight uploads for the whole deletion pass:
+	// an upload that started since the listing began owns its bucket object,
+	// and taking the snapshot here rather than inside the loop keeps this to a
+	// single prefix scan instead of one per orphan.
+	currentIntents, err := cc.db.ListS3UploadIntents()
+	if err != nil {
+		log.Warnf("Failed to re-read S3 upload intents; skipping deletions this pass: %v", err)
+		return nil
+	}
+
+	// Delete bucket orphans, re-verifying against current metadata so a
+	// relocation that landed during the scan is not clobbered.  Each S3
+	// operation is given a finite timeout so a single hung request cannot
+	// stall the sweep.
+	for _, e := range orphanBucket {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		meta, err := cc.db.GetMetadata(e.hash)
+		if err == nil && meta != nil && meta.StorageID == sid {
+			continue // relocated here since the scan; no longer an orphan
+		}
+		if _, uploading := currentIntents[e.hash]; uploading {
+			continue
+		}
+		opCtx, cancel := context.WithTimeout(ctx, s3SweepOpTimeout)
+		err = target.deleteObject(opCtx, e.hash)
+		cancel()
+		if err != nil {
+			log.Warnf("Failed to delete orphaned S3 object %s: %v", e.hash, err)
+			continue
+		}
+		deletedBucket++
+	}
+
+	// Delete DB entries whose bucket object is gone, re-probing the bucket
+	// first so an eventually-consistent listing doesn't nuke a live entry.
+	for _, hash := range orphanDB {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		meta, err := cc.db.GetMetadata(hash)
+		if err != nil || meta == nil || meta.StorageID != sid {
+			continue
+		}
+		opCtx, cancel := context.WithTimeout(ctx, s3SweepOpTimeout)
+		exists, err := target.objectExists(opCtx, hash)
+		if err != nil {
+			cancel()
+			log.Warnf("Failed to verify S3 object %s before cleanup: %v", hash, err)
+			continue
+		}
+		if exists && meta.ContentLength == 0 {
+			cancel()
+			continue
+		}
+		if exists {
+			// Present after all — only remove when the size disagrees.
+			mismatch := cc.s3SizeMismatch(opCtx, target, hash, meta)
+			cancel()
+			if !mismatch {
+				continue
+			}
+		} else {
+			cancel()
+		}
+		if err := cc.storage.Delete(hash); err != nil {
+			log.Warnf("Failed to delete S3-orphaned DB entry %s: %v", hash, err)
+			continue
+		}
+		deletedDB++
+	}
+
+	if deletedBucket > 0 || deletedDB > 0 {
+		log.Infof("S3 consistency sweep of %s: removed %d orphaned bucket object(s), %d orphaned DB entr(ies) in %s",
+			target.cfg.DisplayURL(), deletedBucket, deletedDB, time.Since(scanStart).Round(time.Millisecond))
+	}
+	if capped {
+		log.Infof("S3 consistency sweep of %s hit the %d-orphan cap; remaining divergence will be handled on the next sweep",
+			target.cfg.DisplayURL(), s3MaxOrphansPerScan)
+	}
+
+	cc.statsMu.Lock()
+	cc.stats.OrphanedFiles += int64(deletedBucket)
+	cc.stats.OrphanedDBEntries += int64(deletedDB)
+	cc.statsMu.Unlock()
+	return nil
+}
+
+// s3SizeMismatch re-checks an apparent size mismatch with a HeadObject
+// probe (the listing snapshot may be stale).
+func (cc *ConsistencyChecker) s3SizeMismatch(ctx context.Context, target *s3Target, hash InstanceHash, meta *CacheMetadata) bool {
+	size, exists, err := target.objectSize(ctx, hash)
+	if err != nil || !exists {
+		return false
+	}
+	return size != meta.ContentLength
+}

--- a/local_cache/s3_serve.go
+++ b/local_cache/s3_serve.go
@@ -1,0 +1,286 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package local_cache
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/token_scopes"
+)
+
+// newS3SeekableReader builds a SeekableReader that proxies an S3-resident
+// object through the cache (used when redirect is disabled, or by internal
+// callers such as the data-integrity scan).
+//
+// The object is pinned for the life of the stream.  A proxied object gets no
+// presign stamp -- no URL was handed out -- so the pin is its only protection:
+// without it, eviction could delete the bucket object between two of this
+// reader's ranged GETs, which is exactly the configuration operators are
+// pointed at for private namespaces.
+func (pc *PersistentCache) newS3SeekableReader(ctx context.Context, target *s3Target, res *objectResolution) *SeekableReader {
+	stream := newS3ObjectStream(ctx, target, res.instanceHash, res.meta.ContentLength)
+	stream.onClose = pc.storage.PinObject(res.instanceHash)
+	return &SeekableReader{RangeReader: &RangeReader{
+		storage:      pc.storage,
+		instanceHash: res.instanceHash,
+		meta:         res.meta,
+		start:        0,
+		end:          res.meta.ContentLength - 1,
+		remoteStream: stream,
+	}}
+}
+
+// presignHoldHeadroom is how much longer than a pre-signed URL's lifetime the
+// eviction hold must last, covering the gap between minting a URL and the
+// client actually finishing with it.
+const presignHoldHeadroom = 5 * time.Minute
+
+// s3PresignExpiry returns the configured presigned-URL lifetime.
+func s3PresignExpiry() time.Duration {
+	if d := param.Cache_S3PresignExpiry.GetDuration(); d > 0 {
+		return d
+	}
+	return 5 * time.Minute
+}
+
+// redirectRetainsAuthorization reports whether a spec-compliant HTTP client
+// following a redirect from this cache to the given host would carry the
+// client's Authorization header along with it.
+//
+// This mirrors net/http's own rule (shouldCopyHeaderOnRedirect ->
+// isDomainOrSubdomain): the header survives when the destination is the same
+// host as the origin *or any subdomain of it* -- "foo.com" to "sub.foo.com" is
+// deliberately permitted.  Matching by equality alone would miss the subdomain
+// case, which is not exotic for object storage: a cache on cache.example.org
+// beside a MinIO or Ceph RGW on s3.cache.example.org hits it, and virtual-host
+// bucket addressing adds another label on top.
+//
+// Ports are irrelevant (net/http compares hostnames only), and an IP literal
+// can never be a subdomain, matching net/http's ':'/'%' bail-out.
+func redirectRetainsAuthorization(destHost, cacheHost string) bool {
+	dest, cache := hostOnly(destHost), hostOnly(cacheHost)
+	if dest == "" || cache == "" {
+		// Nothing to compare; assume the worst so the caller proxies.
+		return true
+	}
+	if dest == cache {
+		return true
+	}
+	if strings.ContainsAny(dest, ":%") {
+		return false // IP literal or zone-scoped address
+	}
+	if !strings.HasSuffix(dest, cache) {
+		return false
+	}
+	return dest[len(dest)-len(cache)-1] == '.'
+}
+
+// hostOnly folds a host[:port] (or a bare URL) down to the ASCII hostname
+// net/http would compare, reusing the cache's own IDNA folding.
+func hostOnly(host string) string {
+	if host == "" {
+		return ""
+	}
+	if u, err := url.Parse(host); err == nil && u.Host != "" {
+		host = u.Host
+	}
+	normalized := normalizeHost(host)
+	if h, _, err := net.SplitHostPort(normalized); err == nil {
+		normalized = h
+	}
+	return strings.Trim(normalized, "[]")
+}
+
+// cacheExternalHost returns the host clients use to reach this cache, which is
+// the origin host of the redirect for Authorization-forwarding purposes.
+func cacheExternalHost() string {
+	if u := param.Server_ExternalWebUrl.GetString(); u != "" {
+		return hostOnly(u)
+	}
+	return hostOnly(param.Server_Hostname.GetString())
+}
+
+// tryS3Redirect serves a GET by redirecting the client to a pre-signed S3
+// URL when possible.  Returns true when the response has been written
+// (redirect issued); false means the caller should proceed with the normal
+// serving path (object not on S3, redirect disabled, object stale, etc.).
+//
+// The redirect is only issued for objects that are fully resident on an S3
+// target and still fresh — stale objects fall through so the normal path
+// revalidates against the origin.  Issuing the URL stamps the presign key,
+// which protects the object from eviction for Cache.S3PresignEvictionHold.
+//
+// Token safety: the presigned URL points at the S3 provider, which is outside
+// the federation trust boundary, so the client's bearer token must not reach
+// it.  Two of the three ways it could are closed by construction:
+//   - The presigned URL (the redirect Location) is self-authenticating and
+//     carries only AWS SigV4 material; the Pelican token is never embedded.
+//   - A token delivered as ?authz= (how the director hands one to a client)
+//     is not carried onto the Location: http.Redirect only rewrites the query
+//     for relative targets, and a presigned URL is absolute.
+//
+// The third is the Authorization header, which a compliant client drops only
+// when the destination is neither the host it connected to nor a subdomain of
+// it (see redirectRetainsAuthorization).  When a request carries such a header
+// and the bucket endpoint falls inside that domain, this function declines and
+// the object is proxied instead, so an S3 endpoint co-located with the cache
+// cannot be handed federation tokens.
+//
+// Residual risk: a client that re-sends Authorization across unrelated hosts,
+// contrary to the spec (e.g. curl --location-trusted), still discloses it.
+// Operators serving private namespaces to such clients should set
+// Cache.S3DisableRedirect.  See TestS3RedirectDropsAuthorizationCrossHost.
+func (pc *PersistentCache) tryS3Redirect(w http.ResponseWriter, r *http.Request, objectPath, token string, reqLog *log.Entry, startTime time.Time) bool {
+	if len(pc.storage.s3Targets) == 0 || param.Cache_S3DisableRedirect.GetBool() {
+		return false
+	}
+
+	if ok, _ := pc.ac.authorize(token_scopes.Wlcg_Storage_Read, objectPath, token); !ok {
+		// Let the normal path produce the proper 403 response.
+		return false
+	}
+
+	pelicanURL := pc.normalizePath(objectPath)
+	objectHash := pc.db.ObjectHash(pelicanURL)
+	etag, found, err := pc.db.GetLatestETag(objectHash)
+	if err != nil || !found {
+		return false
+	}
+	instanceHash := pc.db.InstanceHash(etag, objectHash)
+	meta, err := pc.storage.GetMetadata(instanceHash)
+	if err != nil || meta == nil || meta.Completed.IsZero() {
+		return false
+	}
+	target := pc.storage.getS3Target(meta.StorageID)
+	if target == nil {
+		return false
+	}
+	// Would redirecting hand this client's Authorization header to the bucket?
+	// Only a request that carries one has anything to leak -- a public read,
+	// or the director's ?authz= flow, does not -- and the host to compare
+	// against is the one the client actually connected to, since that is what
+	// its redirect policy compares.  See the doc comment.
+	if r.Header.Get("Authorization") != "" && redirectRetainsAuthorization(target.cfg.ServiceUrl, r.Host) {
+		reqLog.Debug("Proxying instead of redirecting: the bucket endpoint shares this cache's DNS domain, " +
+			"so the client would forward its credentials to it")
+		return false
+	}
+
+	// Freshness: no-store/no-cache objects and anything past its expiry
+	// must go through the normal path so revalidation happens.
+	if meta.CCFlags&(ccNoStore|ccNoCache) != 0 {
+		return false
+	}
+	if expires := meta.ComputeExpires(); expires.IsZero() || !expires.After(time.Now()) {
+		return false
+	}
+
+	// A client revalidating with the ETag it already holds is answered here
+	// rather than redirected.  Sending it to the bucket instead would make it
+	// re-download the whole object for nothing: the far end cannot complete the
+	// revalidation, because S3 answers with its own ETag (an MD5 of the stored
+	// bytes) which never matches the origin's.
+	if meta.ETag != "" {
+		for _, match := range strings.Split(r.Header.Get("If-None-Match"), ",") {
+			if match = strings.TrimSpace(match); match == "*" || (match != "" && match == meta.ETag) {
+				w.Header().Set("ETag", meta.ETag)
+				w.Header().Set("Cache-Control", meta.ResponseCacheControl())
+				w.WriteHeader(http.StatusNotModified)
+				reqLog.WithFields(log.Fields{
+					"status":   http.StatusNotModified,
+					"cache":    "hit-redirect",
+					"duration": time.Since(startTime).Round(time.Millisecond).String(),
+				}).Info("Request complete")
+				return true
+			}
+		}
+	}
+
+	presignedURL, err := target.presignGet(r.Context(), instanceHash, s3PresignExpiry())
+	if err != nil {
+		reqLog.WithError(err).Warn("Failed to presign S3 URL; falling back to proxying")
+		return false
+	}
+
+	// Stamp the presign key *before* handing out the URL so the eviction
+	// hold is in place by the time the client can use it.
+	if err := pc.db.RecordPresignIssued(instanceHash); err != nil {
+		reqLog.WithError(err).Warn("Failed to record presign stamp; falling back to proxying")
+		return false
+	}
+	if err := pc.eviction.RecordAccess(instanceHash); err != nil {
+		log.Debugf("Failed to record access for %s during S3 redirect: %v", instanceHash, err)
+	}
+
+	// Carry the same validators and freshness metadata the proxied path sets,
+	// so a redirected client is not told less about the object than a proxied
+	// one.  The client verifies the checksums against what it receives from the
+	// bucket; the cache never sees those bytes.
+	if meta.ETag != "" {
+		w.Header().Set("ETag", meta.ETag)
+	}
+	if digest := formatDigestHeader(meta.Checksums); digest != "" {
+		w.Header().Set("Digest", digest)
+	}
+	if !meta.Completed.IsZero() {
+		if age := int(time.Since(meta.Completed).Seconds()); age >= 0 {
+			w.Header().Set("Age", strconv.Itoa(age))
+		}
+	}
+	w.Header().Set("Cache-Control", meta.ResponseCacheControl())
+	http.Redirect(w, r, presignedURL, http.StatusTemporaryRedirect)
+	reqLog.WithFields(log.Fields{
+		"status":   http.StatusTemporaryRedirect,
+		"cache":    "hit-redirect",
+		"duration": time.Since(startTime).Round(time.Millisecond).String(),
+	}).Info("Request complete")
+	return true
+}
+
+// limitedReadCloser bounds a stream to n bytes while preserving Close.
+type limitedReadCloser struct {
+	stream *s3ObjectStream
+	remain int64
+}
+
+func (l *limitedReadCloser) Read(p []byte) (int, error) {
+	if l.remain <= 0 {
+		return 0, io.EOF
+	}
+	if int64(len(p)) > l.remain {
+		p = p[:l.remain]
+	}
+	n, err := l.stream.Read(p)
+	l.remain -= int64(n)
+	return n, err
+}
+
+func (l *limitedReadCloser) Close() error {
+	return l.stream.Close()
+}

--- a/local_cache/s3_target.go
+++ b/local_cache/s3_target.go
@@ -1,0 +1,504 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package local_cache
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// s3IdentityKey is the object key (under the configured prefix) that holds
+// the target's identity UUID, mirroring the .pelican-cache-id file dropped
+// in POSIX storage directories.  The UUID lets a bucket be re-associated
+// with its storage ID when the endpoint URL or credentials change.
+const s3IdentityKey = ".pelican-cache-id"
+
+// s3Target wraps the AWS SDK clients for one S3 bucket used as a cache
+// storage target.  Objects are stored unencrypted under
+// <prefix>/<aa>/<bb>/<rest-of-instance-hash> — the same fan-out layout as
+// POSIX directories, which keeps bucket listings in instance-hash order for
+// the consistency sweep's merge join.
+type s3Target struct {
+	id      StorageID
+	cfg     S3TargetConfig
+	client  *s3.Client
+	presign *s3.PresignClient
+	upload  *manager.Uploader
+}
+
+// newS3Target constructs the SDK clients for a target.  No network I/O is
+// performed here; identity resolution happens in (*s3Target).resolveIdentity.
+func newS3Target(ctx context.Context, cfg S3TargetConfig) (*s3Target, error) {
+	cfgOpts := []func(*awsconfig.LoadOptions) error{
+		awsconfig.WithRegion(cfg.Region),
+	}
+	if cfg.AccessKeyfile != "" {
+		accessKey, secretKey, err := readS3Keyfiles(cfg.AccessKeyfile, cfg.SecretKeyfile)
+		if err != nil {
+			return nil, err
+		}
+		cfgOpts = append(cfgOpts, awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(accessKey, secretKey, ""),
+		))
+	}
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, cfgOpts...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to load AWS config for cache S3 target %s", cfg.Bucket)
+	}
+
+	var s3Opts []func(*s3.Options)
+	if strings.ToLower(cfg.UrlStyle) != "virtual" {
+		s3Opts = append(s3Opts, func(o *s3.Options) { o.UsePathStyle = true })
+	}
+	endpoint := cfg.ServiceUrl
+	s3Opts = append(s3Opts, func(o *s3.Options) { o.BaseEndpoint = &endpoint })
+
+	client := s3.NewFromConfig(awsCfg, s3Opts...)
+	return &s3Target{
+		cfg:     cfg,
+		client:  client,
+		presign: s3.NewPresignClient(client),
+		upload:  manager.NewUploader(client),
+	}, nil
+}
+
+// readS3Keyfiles loads static credentials from the configured key files,
+// mirroring the origin's S3 credential handling (whole file, trimmed).
+func readS3Keyfiles(accessKeyFile, secretKeyFile string) (accessKey, secretKey string, err error) {
+	akBytes, err := os.ReadFile(accessKeyFile)
+	if err != nil {
+		return "", "", errors.Wrap(err, "failed to read S3 access keyfile")
+	}
+	skBytes, err := os.ReadFile(secretKeyFile)
+	if err != nil {
+		return "", "", errors.Wrap(err, "failed to read S3 secret keyfile")
+	}
+	return strings.TrimSpace(string(akBytes)), strings.TrimSpace(string(skBytes)), nil
+}
+
+// objectKey returns the bucket key for an instance hash.
+func (t *s3Target) objectKey(instanceHash InstanceHash) string {
+	return t.keyForStoragePath(GetInstanceStoragePath(instanceHash))
+}
+
+// keyForStoragePath prepends the configured prefix to a storage-relative path.
+func (t *s3Target) keyForStoragePath(rel string) string {
+	if t.cfg.Prefix == "" {
+		return rel
+	}
+	return path.Join(t.cfg.Prefix, rel)
+}
+
+// hashFromKey converts a bucket key back to an instance hash, undoing the
+// prefix and the aa/bb/rest fan-out.  Returns "" when the key does not look
+// like a cache object (e.g. the identity object).
+func (t *s3Target) hashFromKey(key string) InstanceHash {
+	rel := key
+	if t.cfg.Prefix != "" {
+		var ok bool
+		rel, ok = strings.CutPrefix(key, t.cfg.Prefix+"/")
+		if !ok {
+			return ""
+		}
+	}
+	parts := strings.SplitN(rel, "/", 3)
+	if len(parts) != 3 || len(parts[0]) != 2 || len(parts[1]) != 2 {
+		return ""
+	}
+	hash := parts[0] + parts[1] + parts[2]
+	if len(hash) != 64 {
+		return ""
+	}
+	for _, c := range hash {
+		if !(c >= '0' && c <= '9' || c >= 'a' && c <= 'f') {
+			return ""
+		}
+	}
+	return InstanceHash(hash)
+}
+
+// resolveIdentity reads the identity UUID object from the bucket, creating
+// it when missing.  Returns the UUID string.
+func (t *s3Target) resolveIdentity(ctx context.Context) (string, error) {
+	key := t.keyForStoragePath(s3IdentityKey)
+	out, err := t.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: &t.cfg.Bucket,
+		Key:    &key,
+	})
+	if err == nil {
+		defer out.Body.Close()
+		data, readErr := io.ReadAll(io.LimitReader(out.Body, 128))
+		if readErr == nil {
+			id := strings.TrimSpace(string(data))
+			if _, parseErr := uuid.Parse(id); parseErr == nil {
+				return id, nil
+			}
+		}
+		log.Warnf("Cache S3 target %s has an invalid identity object; rewriting", t.cfg.DisplayURL())
+	} else if !isS3NotFound(err) {
+		return "", errors.Wrapf(err, "failed to read identity object from cache S3 target %s", t.cfg.DisplayURL())
+	}
+
+	newID := uuid.New().String()
+	body := strings.NewReader(newID)
+	if _, err := t.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: &t.cfg.Bucket,
+		Key:    &key,
+		Body:   body,
+	}); err != nil {
+		return "", errors.Wrapf(err, "failed to write identity object to cache S3 target %s", t.cfg.DisplayURL())
+	}
+	return newID, nil
+}
+
+// isS3NotFound reports whether an S3 error indicates a missing object.
+//
+// The typed errors cover the documented cases, but a HeadObject against a
+// missing key, and several S3-compatible implementations in general, answer
+// with a bare 404 that the SDK surfaces as a generic API error.  Those are
+// recognised by inspecting the HTTP status the response carries rather than by
+// matching error text, so a provider that phrases its errors differently
+// cannot turn "absent" into a hard failure -- which would make deletes
+// non-idempotent and leave the consistency sweep unable to ever reconcile the
+// entry it was checking.
+func isS3NotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var noKey *s3types.NoSuchKey
+	var notFound *s3types.NotFound
+	if errors.As(err, &noKey) || errors.As(err, &notFound) {
+		return true
+	}
+	var respErr *awshttp.ResponseError
+	if errors.As(err, &respErr) {
+		return respErr.HTTPStatusCode() == http.StatusNotFound
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "NoSuchKey", "NotFound", "404":
+			return true
+		}
+	}
+	return false
+}
+
+// uploadObject streams plaintext object bytes to the bucket.  Multipart is
+// handled by the SDK's upload manager; on error, incomplete parts are
+// aborted automatically (LeavePartsOnError defaults to false).
+func (t *s3Target) uploadObject(ctx context.Context, instanceHash InstanceHash, contentType string, size int64, body io.Reader) error {
+	key := t.objectKey(instanceHash)
+	input := &s3.PutObjectInput{
+		Bucket:        &t.cfg.Bucket,
+		Key:           &key,
+		Body:          body,
+		ContentLength: &size,
+	}
+	if contentType != "" {
+		input.ContentType = &contentType
+	}
+	_, err := t.upload.Upload(ctx, input)
+	return errors.Wrapf(err, "failed to upload %s to cache S3 target %s", instanceHash, t.cfg.DisplayURL())
+}
+
+// deleteObject removes an object from the bucket.  Missing objects are not
+// an error (deletion is idempotent).
+func (t *s3Target) deleteObject(ctx context.Context, instanceHash InstanceHash) error {
+	key := t.objectKey(instanceHash)
+	_, err := t.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: &t.cfg.Bucket,
+		Key:    &key,
+	})
+	if err != nil && !isS3NotFound(err) {
+		return errors.Wrapf(err, "failed to delete %s from cache S3 target %s", instanceHash, t.cfg.DisplayURL())
+	}
+	return nil
+}
+
+// objectExists probes the bucket for an object via HeadObject.
+func (t *s3Target) objectExists(ctx context.Context, instanceHash InstanceHash) (bool, error) {
+	_, exists, err := t.objectSize(ctx, instanceHash)
+	return exists, err
+}
+
+// objectSize probes the bucket for an object's size via HeadObject.
+func (t *s3Target) objectSize(ctx context.Context, instanceHash InstanceHash) (size int64, exists bool, err error) {
+	key := t.objectKey(instanceHash)
+	out, err := t.client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: &t.cfg.Bucket,
+		Key:    &key,
+	})
+	if err == nil {
+		if out.ContentLength != nil {
+			size = *out.ContentLength
+		}
+		return size, true, nil
+	}
+	if isS3NotFound(err) {
+		return 0, false, nil
+	}
+	return 0, false, errors.Wrapf(err, "failed to stat %s on cache S3 target %s", instanceHash, t.cfg.DisplayURL())
+}
+
+// presignGet returns a pre-signed GET URL for the object.
+func (t *s3Target) presignGet(ctx context.Context, instanceHash InstanceHash, expiry time.Duration) (string, error) {
+	key := t.objectKey(instanceHash)
+	req, err := t.presign.PresignGetObject(ctx, &s3.GetObjectInput{
+		Bucket: &t.cfg.Bucket,
+		Key:    &key,
+	}, s3.WithPresignExpires(expiry))
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to presign GET for %s on cache S3 target %s", instanceHash, t.cfg.DisplayURL())
+	}
+	return req.URL, nil
+}
+
+// openStream starts a GET at the given byte offset and returns the body.
+// Used by the proxying read path; a Seek discards the stream and opens a
+// new one at the target offset.
+func (t *s3Target) openStream(ctx context.Context, instanceHash InstanceHash, offset int64) (io.ReadCloser, error) {
+	key := t.objectKey(instanceHash)
+	input := &s3.GetObjectInput{
+		Bucket: &t.cfg.Bucket,
+		Key:    &key,
+	}
+	if offset > 0 {
+		rng := fmt.Sprintf("bytes=%d-", offset)
+		input.Range = &rng
+	}
+	out, err := t.client.GetObject(ctx, input)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open %s on cache S3 target %s", instanceHash, t.cfg.DisplayURL())
+	}
+	return out.Body, nil
+}
+
+// listObjects walks the bucket under the configured prefix in lexicographic
+// key order, invoking fn for each cache object (identity and non-cache keys
+// are skipped).  Because the key layout mirrors GetInstanceStoragePath, the
+// callback observes instance hashes in sorted order.
+func (t *s3Target) listObjects(ctx context.Context, fn func(hash InstanceHash, size int64, modified time.Time) error) error {
+	input := &s3.ListObjectsV2Input{
+		Bucket: &t.cfg.Bucket,
+	}
+	if t.cfg.Prefix != "" {
+		prefix := t.cfg.Prefix + "/"
+		input.Prefix = &prefix
+	}
+	paginator := s3.NewListObjectsV2Paginator(t.client, input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return errors.Wrapf(err, "failed to list cache S3 target %s", t.cfg.DisplayURL())
+		}
+		for _, obj := range page.Contents {
+			if obj.Key == nil {
+				continue
+			}
+			hash := t.hashFromKey(*obj.Key)
+			if hash == "" {
+				continue
+			}
+			var size int64
+			if obj.Size != nil {
+				size = *obj.Size
+			}
+			var modified time.Time
+			if obj.LastModified != nil {
+				modified = *obj.LastModified
+			}
+			if err := fn(hash, size, modified); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// abortStaleMultipartUploads aborts multipart uploads under the prefix that
+// started more than maxAge ago.  Incomplete multipart parts are invisible to
+// listings but still consume bucket space; this reclaims them after crashes.
+func (t *s3Target) abortStaleMultipartUploads(ctx context.Context, maxAge time.Duration) (aborted int, err error) {
+	input := &s3.ListMultipartUploadsInput{
+		Bucket: &t.cfg.Bucket,
+	}
+	if t.cfg.Prefix != "" {
+		prefix := t.cfg.Prefix + "/"
+		input.Prefix = &prefix
+	}
+	cutoff := time.Now().Add(-maxAge)
+	for {
+		out, listErr := t.client.ListMultipartUploads(ctx, input)
+		if listErr != nil {
+			return aborted, errors.Wrapf(listErr, "failed to list multipart uploads on cache S3 target %s", t.cfg.DisplayURL())
+		}
+		for _, up := range out.Uploads {
+			if up.Key == nil || up.UploadId == nil {
+				continue
+			}
+			if up.Initiated != nil && up.Initiated.After(cutoff) {
+				continue
+			}
+			_, abortErr := t.client.AbortMultipartUpload(ctx, &s3.AbortMultipartUploadInput{
+				Bucket:   &t.cfg.Bucket,
+				Key:      up.Key,
+				UploadId: up.UploadId,
+			})
+			if abortErr != nil {
+				log.Warnf("Failed to abort stale multipart upload %s on cache S3 target %s: %v",
+					*up.Key, t.cfg.DisplayURL(), abortErr)
+				continue
+			}
+			aborted++
+		}
+		if out.IsTruncated == nil || !*out.IsTruncated {
+			return aborted, nil
+		}
+		input.KeyMarker = out.NextKeyMarker
+		input.UploadIdMarker = out.NextUploadIdMarker
+	}
+}
+
+// s3ObjectStream adapts a lazily-opened S3 GET stream into an
+// io.ReadSeekCloser suitable for http.ServeContent.  ServeContent's access
+// pattern is a couple of Seeks (to learn the size / position) followed by a
+// sequential read of one range, so the implementation opens at most one GET
+// per served range: Seek is a pure position update and the GET starts on the
+// first Read after a position change.
+type s3ObjectStream struct {
+	ctx      context.Context
+	target   *s3Target
+	hash     InstanceHash
+	size     int64
+	position int64
+
+	body       io.ReadCloser
+	bodyOffset int64 // position the current body corresponds to
+
+	// onClose releases resources held for the lifetime of the stream -- for a
+	// stream serving a client, the reader pin that keeps eviction from
+	// deleting the bucket object mid-transfer.  Called once, by Close.
+	onClose func()
+}
+
+func newS3ObjectStream(ctx context.Context, target *s3Target, hash InstanceHash, size int64) *s3ObjectStream {
+	return &s3ObjectStream{ctx: ctx, target: target, hash: hash, size: size}
+}
+
+func (s *s3ObjectStream) Read(p []byte) (int, error) {
+	if s.position >= s.size {
+		return 0, io.EOF
+	}
+	if s.body == nil || s.bodyOffset != s.position {
+		if s.body != nil {
+			s.body.Close()
+			s.body = nil
+		}
+		body, err := s.target.openStream(s.ctx, s.hash, s.position)
+		if err != nil {
+			// Read errors can surface to clients via the response body or
+			// the X-Transfer-Status trailer; log the detail (which names
+			// the endpoint/bucket) and return a generic error so proxy
+			// mode does not disclose the backing store.
+			log.Warnf("Failed to open S3 stream for %s: %v", s.hash, err)
+			return 0, errors.Errorf("failed to read object %s from backing storage", s.hash)
+		}
+		s.body = body
+		s.bodyOffset = s.position
+	}
+	n, err := s.body.Read(p)
+	s.position += int64(n)
+	s.bodyOffset = s.position
+	if err != nil && err != io.EOF {
+		// The body is no longer usable.  Drop it and leave bodyOffset where it
+		// is so the next Read reopens at the current position rather than
+		// reading on through a broken stream: a mid-transfer network blip
+		// should cost one re-issued GET, not the whole proxied transfer.
+		log.Warnf("S3 stream for %s failed at offset %d; will reopen: %v", s.hash, s.position, err)
+		s.body.Close()
+		s.body = nil
+		if n > 0 {
+			return n, nil
+		}
+		body, reopenErr := s.target.openStream(s.ctx, s.hash, s.position)
+		if reopenErr != nil {
+			log.Warnf("Failed to reopen S3 stream for %s: %v", s.hash, reopenErr)
+			return 0, errors.Errorf("failed to read object %s from backing storage", s.hash)
+		}
+		s.body = body
+		s.bodyOffset = s.position
+		return 0, nil
+	}
+	if err == io.EOF && s.position < s.size {
+		// Short object relative to metadata — surface as an error rather
+		// than silently truncating the response.
+		return n, errors.Errorf("S3 object %s ended at %d bytes; expected %d", s.hash, s.position, s.size)
+	}
+	return n, err
+}
+
+func (s *s3ObjectStream) Seek(offset int64, whence int) (int64, error) {
+	var newPos int64
+	switch whence {
+	case io.SeekStart:
+		newPos = offset
+	case io.SeekCurrent:
+		newPos = s.position + offset
+	case io.SeekEnd:
+		newPos = s.size + offset
+	default:
+		return 0, errors.New("invalid whence")
+	}
+	if newPos < 0 {
+		return 0, errors.New("negative seek position")
+	}
+	s.position = newPos
+	return newPos, nil
+}
+
+func (s *s3ObjectStream) Close() error {
+	if s.onClose != nil {
+		s.onClose()
+		s.onClose = nil
+	}
+	if s.body != nil {
+		err := s.body.Close()
+		s.body = nil
+		return err
+	}
+	return nil
+}

--- a/local_cache/s3_tiering_test.go
+++ b/local_cache/s3_tiering_test.go
@@ -1,0 +1,1230 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package local_cache
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	badger "github.com/dgraph-io/badger/v4"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/pelican_url"
+	"github.com/pelicanplatform/pelican/server_structs"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/test_utils"
+)
+
+// setS3Targets configures the Cache.S3StorageTargets parameter through the
+// param API (rather than touching viper directly) for tests.
+func setS3Targets(t *testing.T, targets []interface{}) {
+	t.Helper()
+	require.NoError(t, param.Cache_S3StorageTargets.Set(targets))
+}
+
+func TestParseS3TargetsConfig(t *testing.T) {
+	t.Run("Unset", func(t *testing.T) {
+		server_utils.ResetTestState()
+		targets, err := ParseS3TargetsConfig()
+		require.NoError(t, err)
+		assert.Nil(t, targets)
+	})
+
+	t.Run("Valid", func(t *testing.T) {
+		server_utils.ResetTestState()
+		setS3Targets(t, []interface{}{
+			map[string]interface{}{
+				"ServiceUrl": "https://s3.example.com",
+				"Bucket":     "pelican-cache",
+				"Prefix":     "/objects/",
+				"MaxSize":    "10GB",
+			},
+		})
+		targets, err := ParseS3TargetsConfig()
+		require.NoError(t, err)
+		require.Len(t, targets, 1)
+		assert.Equal(t, "https://s3.example.com", targets[0].ServiceUrl)
+		assert.Equal(t, "pelican-cache", targets[0].Bucket)
+		assert.Equal(t, "objects", targets[0].Prefix, "prefix should be slash-trimmed")
+		assert.Equal(t, "us-east-1", targets[0].Region, "region should default")
+		assert.Equal(t, "path", targets[0].UrlStyle, "url style should default")
+		assert.Equal(t, uint64(10*1024*1024*1024), targets[0].MaxSize)
+		assert.Equal(t, "s3://s3.example.com/pelican-cache/objects", targets[0].DisplayURL())
+	})
+
+	t.Run("MissingBucket", func(t *testing.T) {
+		server_utils.ResetTestState()
+		setS3Targets(t, []interface{}{
+			map[string]interface{}{
+				"ServiceUrl": "https://s3.example.com",
+				"MaxSize":    "10GB",
+			},
+		})
+		_, err := ParseS3TargetsConfig()
+		require.ErrorContains(t, err, "Bucket")
+	})
+
+	t.Run("MissingMaxSize", func(t *testing.T) {
+		server_utils.ResetTestState()
+		setS3Targets(t, []interface{}{
+			map[string]interface{}{
+				"ServiceUrl": "https://s3.example.com",
+				"Bucket":     "b",
+			},
+		})
+		_, err := ParseS3TargetsConfig()
+		require.ErrorContains(t, err, "MaxSize")
+	})
+
+	t.Run("KeyfilesMustBePaired", func(t *testing.T) {
+		server_utils.ResetTestState()
+		setS3Targets(t, []interface{}{
+			map[string]interface{}{
+				"ServiceUrl":    "https://s3.example.com",
+				"Bucket":        "b",
+				"MaxSize":       "1GB",
+				"AccessKeyfile": "/etc/access",
+			},
+		})
+		_, err := ParseS3TargetsConfig()
+		require.ErrorContains(t, err, "must be set together")
+	})
+}
+
+func TestS3KeyLayout(t *testing.T) {
+	hash := InstanceHash("42561abfe18be8fca1dcd5b6ac0f6b6d42561abfe18be8fca1dcd5b6ac0f6b6d")
+
+	t.Run("WithPrefix", func(t *testing.T) {
+		target := &s3Target{cfg: S3TargetConfig{Bucket: "b", Prefix: "objects"}}
+		key := target.objectKey(hash)
+		assert.Equal(t, "objects/42/56/1abfe18be8fca1dcd5b6ac0f6b6d42561abfe18be8fca1dcd5b6ac0f6b6d", key)
+		assert.Equal(t, hash, target.hashFromKey(key))
+		assert.Equal(t, InstanceHash(""), target.hashFromKey("other/42/56/rest"))
+		assert.Equal(t, InstanceHash(""), target.hashFromKey(target.keyForStoragePath(s3IdentityKey)))
+	})
+
+	t.Run("NoPrefix", func(t *testing.T) {
+		target := &s3Target{cfg: S3TargetConfig{Bucket: "b"}}
+		key := target.objectKey(hash)
+		assert.Equal(t, "42/56/1abfe18be8fca1dcd5b6ac0f6b6d42561abfe18be8fca1dcd5b6ac0f6b6d", key)
+		assert.Equal(t, hash, target.hashFromKey(key))
+		assert.Equal(t, InstanceHash(""), target.hashFromKey(".pelican-cache-id"))
+		assert.Equal(t, InstanceHash(""), target.hashFromKey("42/56/not-hex-suffix"))
+	})
+}
+
+// s3TestEnv bundles the pieces needed to exercise tiering against minio.
+type s3TestEnv struct {
+	db       *CacheDB
+	storage  *StorageManager
+	eviction *EvictionManager
+	uploader *s3Uploader
+	target   *s3Target
+	s3ID     StorageID
+	diskID   StorageID
+}
+
+// setupS3TestEnv starts minio, registers one S3 target alongside one local
+// directory, and wires an eviction manager + uploader (no background
+// goroutines are started; tests drive the pieces synchronously).
+func setupS3TestEnv(t *testing.T, ctx context.Context) *s3TestEnv {
+	test_utils.SkipIfNoMinio(t)
+	endpoint, accessKey, secretKey := test_utils.StartMinio(t, "pelican-cache-test")
+
+	InitIssuerKeyForTests(t)
+	tmpDir := t.TempDir()
+
+	keyDir := t.TempDir()
+	accessKeyfile := filepath.Join(keyDir, "access")
+	secretKeyfile := filepath.Join(keyDir, "secret")
+	require.NoError(t, os.WriteFile(accessKeyfile, []byte(accessKey+"\n"), 0600))
+	require.NoError(t, os.WriteFile(secretKeyfile, []byte(secretKey+"\n"), 0600))
+
+	db, err := NewCacheDB(ctx, tmpDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	egrp, _ := errgroup.WithContext(ctx)
+	storage, err := NewStorageManager(db, []string{tmpDir}, 0, egrp)
+	require.NoError(t, err)
+	t.Cleanup(func() { storage.Close() })
+
+	targetCfg := S3TargetConfig{
+		ServiceUrl:    endpoint,
+		Region:        "us-east-1",
+		Bucket:        "pelican-cache-test",
+		Prefix:        "cache",
+		UrlStyle:      "path",
+		AccessKeyfile: accessKeyfile,
+		SecretKeyfile: secretKeyfile,
+		MaxSize:       1 << 30,
+	}
+	registered, err := storage.RegisterS3Targets(ctx, []S3TargetConfig{targetCfg})
+	require.NoError(t, err)
+	require.Len(t, registered, 1)
+
+	env := &s3TestEnv{db: db, storage: storage}
+	for id := range registered {
+		env.s3ID = id
+	}
+	env.target = storage.getS3Target(env.s3ID)
+	require.NotNil(t, env.target)
+	for id := range storage.GetDirs() {
+		env.diskID = id
+	}
+	require.NotEqual(t, env.diskID, env.s3ID)
+
+	env.eviction = NewEvictionManager(db, storage, EvictionConfig{
+		DirConfigs: map[StorageID]EvictionDirConfig{
+			env.diskID: {MaxSize: 1 << 30},
+			env.s3ID:   {MaxSize: targetCfg.MaxSize, NoPlacement: true},
+		},
+	})
+	env.uploader = newS3Uploader(db, storage, env.eviction, 1024)
+	return env
+}
+
+func TestS3TieringLifecycle(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	env := setupS3TestEnv(t, ctx)
+
+	data := make([]byte, 3*BlockDataSize+123) // multi-block, above the 1KB threshold
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	hash := InstanceHash(fmt.Sprintf("%064d", 1))
+	nsID := NamespaceID(1)
+	storeTestObject(t, ctx, env.storage, hash, data, env.diskID, nsID)
+	fileSize := CalculateFileSize(int64(len(data)))
+
+	// Tier the object to S3.
+	require.NoError(t, env.uploader.processObject(ctx, hash))
+
+	// Metadata now points at the S3 target and the intent is gone.
+	meta, err := env.storage.GetMetadata(hash)
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+	assert.Equal(t, env.s3ID, meta.StorageID)
+	intents, err := env.db.ListS3UploadIntents()
+	require.NoError(t, err)
+	assert.Empty(t, intents)
+
+	// The local file is gone; usage moved from the directory to the bucket.
+	localPath := env.storage.getObjectPathForDir(env.diskID, hash)
+	_, statErr := os.Stat(localPath)
+	assert.True(t, os.IsNotExist(statErr), "local file should be deleted after tiering")
+	diskUsage, err := env.db.GetUsage(env.diskID, nsID)
+	require.NoError(t, err)
+	assert.Zero(t, diskUsage)
+	s3Usage, err := env.db.GetUsage(env.s3ID, nsID)
+	require.NoError(t, err)
+	assert.Equal(t, fileSize, s3Usage)
+
+	// The bucket object is the plaintext content.
+	stream, err := env.target.openStream(ctx, hash, 0)
+	require.NoError(t, err)
+	fetched, err := io.ReadAll(stream)
+	stream.Close()
+	require.NoError(t, err)
+	assert.Equal(t, data, fetched)
+
+	// Ranged reads through the proxy-mode stream work.
+	objStream := newS3ObjectStream(ctx, env.target, hash, int64(len(data)))
+	defer objStream.Close()
+	_, err = objStream.Seek(int64(BlockDataSize), io.SeekStart)
+	require.NoError(t, err)
+	buf := make([]byte, 100)
+	_, err = io.ReadFull(objStream, buf)
+	require.NoError(t, err)
+	assert.Equal(t, data[BlockDataSize:BlockDataSize+100], buf)
+
+	// A pre-signed URL serves the object without credentials.
+	presigned, err := env.target.presignGet(ctx, hash, 5*time.Minute)
+	require.NoError(t, err)
+	resp, err := http.Get(presigned)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, data, body)
+
+	// A fresh presign stamp protects the object from eviction...
+	require.NoError(t, env.db.UpdateLRU(hash, 0)) // create the LRU entry under the S3 storage ID
+	env.db.setPresignHold(time.Hour)
+	require.NoError(t, env.db.RecordPresignIssued(hash))
+	evicted, _, _, err := env.storage.EvictByLRU(env.s3ID, nsID, 0, 0)
+	require.NoError(t, err)
+	assert.Empty(t, evicted, "presign hold should block eviction")
+
+	// ...and once the hold lapses, eviction removes DB entry and bucket object.
+	env.db.setPresignHold(time.Nanosecond)
+	evicted, _, _, err = env.storage.EvictByLRU(env.s3ID, nsID, 0, 0)
+	require.NoError(t, err)
+	require.Len(t, evicted, 1)
+	exists, err := env.target.objectExists(ctx, hash)
+	require.NoError(t, err)
+	assert.False(t, exists, "bucket object should be deleted on eviction")
+	meta, err = env.storage.GetMetadata(hash)
+	require.NoError(t, err)
+	assert.Nil(t, meta)
+}
+
+// TestS3TieringChunkedObject verifies that a large chunked object — whose
+// data is spread across multiple local directories in multiple chunk files —
+// migrates to S3 as a single flattened blob, with every local chunk file
+// removed and each contributing directory's usage released.  Large objects
+// are exactly the ones chunking splits up, so this is the primary tiering
+// case once chunking is enabled.
+func TestS3TieringChunkedObject(t *testing.T) {
+	test_utils.SkipIfNoMinio(t)
+	endpoint, accessKey, secretKey := test_utils.StartMinio(t, "pelican-cache-chunked")
+	InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dir1, dir2, dbDir := t.TempDir(), t.TempDir(), t.TempDir()
+	keyDir := t.TempDir()
+	accessKeyfile := filepath.Join(keyDir, "access")
+	secretKeyfile := filepath.Join(keyDir, "secret")
+	require.NoError(t, os.WriteFile(accessKeyfile, []byte(accessKey), 0600))
+	require.NoError(t, os.WriteFile(secretKeyfile, []byte(secretKey), 0600))
+
+	db, err := NewCacheDB(ctx, dbDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	egrp, _ := errgroup.WithContext(ctx)
+	storage, err := NewStorageManager(db, []string{dir1, dir2}, 0, egrp)
+	require.NoError(t, err)
+	t.Cleanup(func() { storage.Close() })
+
+	registered, err := storage.RegisterS3Targets(ctx, []S3TargetConfig{{
+		ServiceUrl:    endpoint,
+		Region:        "us-east-1",
+		Bucket:        "pelican-cache-chunked",
+		Prefix:        "cache",
+		UrlStyle:      "path",
+		AccessKeyfile: accessKeyfile,
+		SecretKeyfile: secretKeyfile,
+		MaxSize:       1 << 30,
+	}})
+	require.NoError(t, err)
+	require.Len(t, registered, 1)
+	var s3ID StorageID
+	for id := range registered {
+		s3ID = id
+	}
+	target := storage.getS3Target(s3ID)
+	require.NotNil(t, target)
+
+	dirCfgs := map[StorageID]EvictionDirConfig{s3ID: {MaxSize: 1 << 30, NoPlacement: true}}
+	for id := range storage.GetDirs() {
+		dirCfgs[id] = EvictionDirConfig{MaxSize: 1 << 30}
+	}
+	eviction := NewEvictionManager(db, storage, EvictionConfig{DirConfigs: dirCfgs})
+	uploader := newS3Uploader(db, storage, eviction, 1024)
+
+	// A two-chunk object; the chunks round-robin across dir1 and dir2.
+	chunkSizeCode := BytesToChunkSizeCode(2 * 1024 * 1024)
+	chunkSize := int64(ChunkSizeCodeToBytes(chunkSizeCode))
+	objectSize := chunkSize*2 - 37 // just under two full chunks
+	data := make([]byte, objectSize)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	nsID := NamespaceID(7)
+	hash := InstanceHash(fmt.Sprintf("%064x", 0xC0FFEE))
+
+	meta, err := storage.InitLazyChunkedStorage(ctx, hash, objectSize, chunkSizeCode)
+	require.NoError(t, err)
+	chunkCount := CalculateChunkCount(objectSize, chunkSizeCode)
+	require.GreaterOrEqual(t, chunkCount, 2, "test needs a multi-chunk object")
+	for i := 0; i < chunkCount; i++ {
+		meta, err = storage.AllocateChunk(ctx, hash, meta, i)
+		require.NoError(t, err)
+	}
+	require.NoError(t, storage.WriteBlocks(hash, 0, data))
+	meta.Completed = time.Now().Add(-10 * time.Minute)
+	meta.NamespaceID = nsID
+	require.NoError(t, storage.SetMetadata(hash, meta))
+	require.True(t, meta.IsChunked())
+
+	// Record chunk file paths so we can confirm every one is removed.
+	var chunkPaths []string
+	for i := 0; i < chunkCount; i++ {
+		sid := meta.GetChunkStorageID(i)
+		chunkPaths = append(chunkPaths, storage.getChunkPath(sid, hash, i))
+	}
+
+	// Tier the chunked object.
+	require.NoError(t, uploader.processObject(ctx, hash))
+
+	// Metadata is now a single flattened S3 object.
+	got, err := storage.GetMetadata(hash)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, s3ID, got.StorageID)
+	assert.False(t, got.IsChunked(), "relocation must flatten the chunk layout")
+	assert.Equal(t, objectSize, got.ContentLength)
+
+	// Every local chunk file is gone and each directory's usage is released.
+	for _, p := range chunkPaths {
+		_, statErr := os.Stat(p)
+		assert.Truef(t, os.IsNotExist(statErr), "chunk file should be deleted: %s", p)
+	}
+	for id := range storage.GetDirs() {
+		usage, err := db.GetUsage(id, nsID)
+		require.NoError(t, err)
+		assert.Zerof(t, usage, "disk usage should be released for storage %d", id)
+	}
+	s3Usage, err := db.GetUsage(s3ID, nsID)
+	require.NoError(t, err)
+	assert.Equal(t, CalculateFileSize(objectSize), s3Usage)
+
+	// The bucket holds the full contiguous plaintext object.
+	stream, err := target.openStream(ctx, hash, 0)
+	require.NoError(t, err)
+	fetched, err := io.ReadAll(stream)
+	stream.Close()
+	require.NoError(t, err)
+	assert.Equal(t, data, fetched)
+
+	// No upload intent left behind.
+	intents, err := db.ListS3UploadIntents()
+	require.NoError(t, err)
+	assert.Empty(t, intents)
+}
+
+func TestS3TieringSkipsSmallAndInlineObjects(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	env := setupS3TestEnv(t, ctx)
+
+	t.Run("BelowThreshold", func(t *testing.T) {
+		data := []byte("small object below the threshold")
+		hash := InstanceHash(fmt.Sprintf("%064d", 2))
+		storeTestObject(t, ctx, env.storage, hash, data, env.diskID, 1)
+
+		require.NoError(t, env.uploader.processObject(ctx, hash))
+
+		meta, err := env.storage.GetMetadata(hash)
+		require.NoError(t, err)
+		require.NotNil(t, meta)
+		assert.Equal(t, env.diskID, meta.StorageID, "small object must stay local")
+	})
+
+	t.Run("Inline", func(t *testing.T) {
+		// An inline object lives in BadgerDB, not on a storage directory, so
+		// there is nothing to upload even if it were large enough.  Give it a
+		// content length above the threshold to prove the inline check, not
+		// the size check, is what excludes it.
+		data := []byte("inline object")
+		hash := InstanceHash(fmt.Sprintf("%064d", 3))
+		meta := &CacheMetadata{
+			ETag:          "inline-etag",
+			ContentLength: int64(len(data)),
+			NamespaceID:   1,
+			Completed:     time.Now().Add(-10 * time.Minute),
+			LastValidated: time.Now(),
+		}
+		require.NoError(t, env.storage.StoreInline(ctx, hash, meta, data))
+
+		stored, err := env.storage.GetMetadata(hash)
+		require.NoError(t, err)
+		require.NotNil(t, stored)
+		require.True(t, stored.IsInline(), "object should be stored inline")
+		assert.False(t, env.uploader.eligible(stored), "an inline object is never a tiering candidate")
+
+		require.NoError(t, env.uploader.processObject(ctx, hash))
+		stored, err = env.storage.GetMetadata(hash)
+		require.NoError(t, err)
+		require.NotNil(t, stored)
+		assert.Equal(t, StorageIDInline, stored.StorageID, "inline object must stay inline")
+	})
+}
+
+// TestS3RelocationMovesLRUEntry pins the LRU bookkeeping that relocation
+// depends on: the index entry has to move from the local storage ID to the
+// bucket's, keeping its access timestamp, or the object becomes invisible to
+// eviction on its new target (and leaves a phantom entry behind on the old
+// one).  The rest of the suite stores objects without ever recording an
+// access, which leaves LastAccessTime zero and skips this path entirely.
+func TestS3RelocationMovesLRUEntry(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	env := setupS3TestEnv(t, ctx)
+
+	data := make([]byte, 2*BlockDataSize)
+	hash := InstanceHash(fmt.Sprintf("%064d", 11))
+	nsID := NamespaceID(3)
+	storeTestObject(t, ctx, env.storage, hash, data, env.diskID, nsID)
+
+	// Record an access so the object has an LRU entry to move.
+	require.NoError(t, env.db.UpdateLRU(hash, 0))
+	before, err := env.storage.GetMetadata(hash)
+	require.NoError(t, err)
+	require.False(t, before.LastAccessTime.IsZero(), "access time should be recorded")
+	require.True(t, lruKeyExists(t, env.db, env.diskID, nsID, before.LastAccessTime, hash),
+		"the object should start in the local LRU index")
+
+	require.NoError(t, env.uploader.processObject(ctx, hash))
+
+	after, err := env.storage.GetMetadata(hash)
+	require.NoError(t, err)
+	require.Equal(t, env.s3ID, after.StorageID)
+	assert.Equal(t, before.LastAccessTime.UnixNano(), after.LastAccessTime.UnixNano(),
+		"relocation must preserve the access time, not reset the object's LRU position")
+	assert.False(t, lruKeyExists(t, env.db, env.diskID, nsID, before.LastAccessTime, hash),
+		"the local LRU entry must be gone")
+	assert.True(t, lruKeyExists(t, env.db, env.s3ID, nsID, before.LastAccessTime, hash),
+		"the object must appear in the S3 target's LRU index")
+}
+
+// TestS3TieringDefersReleaseWhileReaderOpen covers the window between an
+// object completing and a client finishing with it: tiering must not delete
+// the local copy a reader is working from.  A chunked object is used because
+// its reads reopen chunk files by path, so an early unlink breaks the transfer
+// outright rather than surviving on an already-open descriptor.
+func TestS3TieringDefersReleaseWhileReaderOpen(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	env := setupS3TestEnv(t, ctx)
+
+	data := make([]byte, 3*BlockDataSize+7)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	hash := InstanceHash(fmt.Sprintf("%064d", 12))
+	nsID := NamespaceID(4)
+	storeTestObject(t, ctx, env.storage, hash, data, env.diskID, nsID)
+	localPath := env.storage.getObjectPathForDir(env.diskID, hash)
+
+	// A client is part-way through the object.
+	reader, err := env.storage.NewObjectReader(hash)
+	require.NoError(t, err)
+	head := make([]byte, BlockDataSize)
+	_, err = io.ReadFull(reader, head)
+	require.NoError(t, err)
+
+	require.NoError(t, env.uploader.processObject(ctx, hash))
+
+	// The bucket copy is authoritative, but the local file survives while the
+	// reader holds it -- and the reader can still finish.
+	meta, err := env.storage.GetMetadata(hash)
+	require.NoError(t, err)
+	require.Equal(t, env.s3ID, meta.StorageID, "relocation should still commit")
+	_, statErr := os.Stat(localPath)
+	require.NoError(t, statErr, "local file must survive while a reader holds the object")
+
+	rest, err := io.ReadAll(reader)
+	require.NoError(t, err, "the in-flight read must not be broken by tiering")
+	assert.Equal(t, data[BlockDataSize:], rest)
+	require.NoError(t, reader.Close())
+
+	// The intent is kept so the cleanup can be retried, and the retry pass
+	// finishes it once the reader is gone.
+	intents, err := env.db.ListS3UploadIntents()
+	require.NoError(t, err)
+	require.Contains(t, intents, hash, "the deferred cleanup must stay recorded")
+
+	env.uploader.finishDeferredReleases(ctx)
+
+	_, statErr = os.Stat(localPath)
+	assert.True(t, os.IsNotExist(statErr), "local file should be removed once unpinned")
+	intents, err = env.db.ListS3UploadIntents()
+	require.NoError(t, err)
+	assert.Empty(t, intents, "the intent should be cleared after cleanup completes")
+	diskUsage, err := env.db.GetUsage(env.diskID, nsID)
+	require.NoError(t, err)
+	assert.Zero(t, diskUsage, "the deferred release must still refund the local capacity")
+}
+
+// TestS3UploaderRecoveryAccounting covers the two recovery branches that run
+// after a relocation has committed.  Both are pure accounting: getting them
+// wrong silently drives a usage counter away from reality, which shows up much
+// later as a bucket that will not fill or one that never drains.
+func TestS3UploaderRecoveryAccounting(t *testing.T) {
+	t.Run("ObjectDeletedAfterRelocation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		env := setupS3TestEnv(t, ctx)
+
+		nsID := NamespaceID(5)
+		hash := InstanceHash(fmt.Sprintf("%064d", 13))
+		size := int64(4 * BlockDataSize)
+
+		// The state a crash leaves behind when the object was deleted after
+		// its relocation committed: the deletion already refunded the bucket
+		// charge, so recovery must not refund it a second time.
+		require.NoError(t, env.db.SetS3UploadIntent(hash, &S3UploadIntent{
+			TargetStorageID:   env.s3ID,
+			OriginalStorageID: env.diskID,
+			Key:               env.target.objectKey(hash),
+			Size:              size,
+			NamespaceID:       nsID,
+			StartedAt:         time.Now().Add(-time.Minute),
+			RelocatedAt:       time.Now().Add(-30 * time.Second),
+		}))
+
+		require.NoError(t, env.uploader.recover(ctx))
+
+		s3Usage, err := env.db.GetUsage(env.s3ID, nsID)
+		require.NoError(t, err)
+		assert.Zero(t, s3Usage, "recovery must not refund a charge the deletion already returned")
+		intents, err := env.db.ListS3UploadIntents()
+		require.NoError(t, err)
+		assert.Empty(t, intents)
+	})
+
+	t.Run("LocalCleanupUnfinished", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		env := setupS3TestEnv(t, ctx)
+
+		data := make([]byte, 2*BlockDataSize)
+		hash := InstanceHash(fmt.Sprintf("%064d", 14))
+		nsID := NamespaceID(6)
+		storeTestObject(t, ctx, env.storage, hash, data, env.diskID, nsID)
+		localPath := env.storage.getObjectPathForDir(env.diskID, hash)
+		fileSize := CalculateFileSize(int64(len(data)))
+
+		// Relocation committed, local cleanup did not: the object is on the
+		// bucket, the local file and its charge are still there.
+		require.NoError(t, env.db.AddUsage(env.s3ID, nsID, fileSize))
+		require.NoError(t, env.db.SetS3UploadIntent(hash, &S3UploadIntent{
+			TargetStorageID:   env.s3ID,
+			OriginalStorageID: env.diskID,
+			Key:               env.target.objectKey(hash),
+			Size:              int64(len(data)),
+			NamespaceID:       nsID,
+			StartedAt:         time.Now().Add(-time.Minute),
+			RelocatedAt:       time.Now().Add(-30 * time.Second),
+		}))
+		_, err := env.db.RelocateObject(hash, env.s3ID)
+		require.NoError(t, err)
+
+		require.NoError(t, env.uploader.recover(ctx))
+
+		_, statErr := os.Stat(localPath)
+		assert.True(t, os.IsNotExist(statErr), "the leftover local file should be removed")
+		diskUsage, err := env.db.GetUsage(env.diskID, nsID)
+		require.NoError(t, err)
+		assert.Zero(t, diskUsage, "the local charge must be refunded, not leaked")
+		s3Usage, err := env.db.GetUsage(env.s3ID, nsID)
+		require.NoError(t, err)
+		assert.Equal(t, fileSize, s3Usage, "the bucket charge belongs to the object and must remain")
+	})
+}
+
+// TestS3TieringConcurrentWorkers runs several workers at one object, the way
+// repeated completion notifications can.  Exactly one may tier it, and the
+// bucket copy must survive: an earlier version of the in-flight guard let the
+// losing worker delete the winner's object.
+func TestS3TieringConcurrentWorkers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	env := setupS3TestEnv(t, ctx)
+
+	data := make([]byte, 2*BlockDataSize)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	hash := InstanceHash(fmt.Sprintf("%064d", 15))
+	nsID := NamespaceID(7)
+	storeTestObject(t, ctx, env.storage, hash, data, env.diskID, nsID)
+
+	var wg sync.WaitGroup
+	errs := make([]error, 4)
+	for i := range errs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = env.uploader.processObject(ctx, hash)
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		assert.NoError(t, err, "worker %d", i)
+	}
+
+	meta, err := env.storage.GetMetadata(hash)
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+	assert.Equal(t, env.s3ID, meta.StorageID)
+
+	// The object is in the bucket exactly once, with the right bytes, and the
+	// bucket is charged for exactly one copy.
+	stream, err := env.target.openStream(ctx, hash, 0)
+	require.NoError(t, err)
+	fetched, err := io.ReadAll(stream)
+	stream.Close()
+	require.NoError(t, err)
+	assert.Equal(t, data, fetched, "the surviving bucket object must hold the real bytes")
+
+	s3Usage, err := env.db.GetUsage(env.s3ID, nsID)
+	require.NoError(t, err)
+	assert.Equal(t, CalculateFileSize(int64(len(data))), s3Usage,
+		"only one worker's charge may stick")
+	intents, err := env.db.ListS3UploadIntents()
+	require.NoError(t, err)
+	assert.Empty(t, intents)
+}
+
+// TestEvictionDrainsPastHeldNamespace covers the interaction between presign
+// holds and the eviction driver.  A namespace whose LRU head is entirely held
+// must not stop the storage target from draining: if it did, a bucket over its
+// high-water mark would never recover, and tiering would stop as soon as no
+// target had room.  Driving checkAndEvict (rather than EvictByLRU directly) is
+// the point -- the namespace-selection loop is where the starvation lives.
+func TestEvictionDrainsPastHeldNamespace(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	env := setupS3TestEnv(t, ctx)
+
+	data := make([]byte, 2*BlockDataSize)
+	fileSize := CalculateFileSize(int64(len(data)))
+
+	// Two namespaces on the bucket.  The greedier one is entirely protected by
+	// presign holds; the other is evictable.
+	heldNS, freeNS := NamespaceID(21), NamespaceID(22)
+	var heldHashes []InstanceHash
+	for i := 0; i < 3; i++ {
+		h := InstanceHash(fmt.Sprintf("%064d", 30+i))
+		storeTestObject(t, ctx, env.storage, h, data, env.diskID, heldNS)
+		require.NoError(t, env.uploader.processObject(ctx, h))
+		require.NoError(t, env.db.UpdateLRU(h, 0))
+		heldHashes = append(heldHashes, h)
+	}
+	freeHash := InstanceHash(fmt.Sprintf("%064d", 40))
+	storeTestObject(t, ctx, env.storage, freeHash, data, env.diskID, freeNS)
+	require.NoError(t, env.uploader.processObject(ctx, freeHash))
+	require.NoError(t, env.db.UpdateLRU(freeHash, 0))
+
+	env.db.setPresignHold(time.Hour)
+	for _, h := range heldHashes {
+		require.NoError(t, env.db.RecordPresignIssued(h))
+	}
+
+	// Rebuild the eviction manager with a limit that forces it to evict: the
+	// bucket now holds four objects and may keep one.
+	eviction := NewEvictionManager(env.db, env.storage, EvictionConfig{
+		DirConfigs: map[StorageID]EvictionDirConfig{
+			env.diskID: {MaxSize: 1 << 30},
+			env.s3ID:   {MaxSize: uint64(fileSize) * 4, HighWaterPercentage: 30, LowWaterPercentage: 20, NoPlacement: true},
+		},
+	})
+	eviction.recalculateDirUsage()
+	eviction.checkAndEvict()
+
+	// The held namespace is untouched, and the evictable one was drained
+	// rather than skipped along with it.
+	for _, h := range heldHashes {
+		meta, err := env.storage.GetMetadata(h)
+		require.NoError(t, err)
+		assert.NotNil(t, meta, "an object under a presign hold must survive eviction")
+	}
+	meta, err := env.storage.GetMetadata(freeHash)
+	require.NoError(t, err)
+	assert.Nil(t, meta, "eviction must move past the held namespace and drain the evictable one")
+}
+
+// TestContainedObjectPath pins the containment rule every object path goes
+// through.  Instance hashes are HMAC hex today and so cannot traverse, but the
+// path is derived from a client-supplied URL and the check is what makes that
+// safe regardless of who supplies the hash later.
+func TestContainedObjectPath(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "srv", "cache", "objects")
+
+	t.Run("NormalHashLayout", func(t *testing.T) {
+		hash := InstanceHash("42561abfe18be8fca1dcd5b6ac0f6b6d42561abfe18be8fca1dcd5b6ac0f6b6d")
+		got := containedObjectPath(root, GetInstanceStoragePath(hash))
+		assert.Equal(t, filepath.Join(root, "42", "56", "1abfe18be8fca1dcd5b6ac0f6b6d42561abfe18be8fca1dcd5b6ac0f6b6d"), got)
+	})
+
+	t.Run("ShortSyntheticHash", func(t *testing.T) {
+		// The DB-level tests use readable hashes; those stay inside the
+		// directory and must keep working.
+		got := containedObjectPath(root, GetInstanceStoragePath(InstanceHash("abc")))
+		assert.Equal(t, filepath.Join(root, "abc"), got)
+	})
+
+	t.Run("TraversalIsRefused", func(t *testing.T) {
+		for _, relative := range []string{
+			"../../../etc/passwd",
+			"aa/bb/../../../../etc/passwd",
+			filepath.Join("..", "sibling-dir", "object"),
+		} {
+			assert.Empty(t, containedObjectPath(root, relative),
+				"a path escaping the storage directory must be refused: %q", relative)
+		}
+	})
+
+	t.Run("EmptyDirectoryIsRefused", func(t *testing.T) {
+		assert.Empty(t, containedObjectPath("", "aa/bb/cc"))
+	})
+}
+
+// lruKeyExists reports whether the LRU index holds the exact entry for an
+// object on a storage target.
+func lruKeyExists(t *testing.T, db *CacheDB, sid StorageID, nsID NamespaceID, ts time.Time, hash InstanceHash) bool {
+	t.Helper()
+	var found bool
+	require.NoError(t, db.db.View(func(txn *badger.Txn) error {
+		_, err := txn.Get(LRUKey(sid, nsID, ts, hash))
+		if err == nil {
+			found = true
+			return nil
+		}
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			return nil
+		}
+		return err
+	}))
+	return found
+}
+
+func TestS3TargetIdentityStable(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	env := setupS3TestEnv(t, ctx)
+
+	// Re-register against the same database and bucket: the storage ID
+	// must be re-associated via the bucket identity object, not reassigned.
+	cfg := env.target.cfg
+	registered, err := env.storage.RegisterS3Targets(ctx, []S3TargetConfig{cfg})
+	require.NoError(t, err)
+	require.Len(t, registered, 1)
+	for id := range registered {
+		assert.Equal(t, env.s3ID, id)
+	}
+}
+
+func TestS3UploaderRecovery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	env := setupS3TestEnv(t, ctx)
+
+	data := make([]byte, 8192)
+	hash := InstanceHash(fmt.Sprintf("%064d", 3))
+	nsID := NamespaceID(1)
+	storeTestObject(t, ctx, env.storage, hash, data, env.diskID, nsID)
+	fileSize := CalculateFileSize(int64(len(data)))
+
+	// Simulate a crash mid-upload: usage charged, intent recorded, object
+	// bytes (fully) uploaded — but the relocation never committed.
+	require.NoError(t, env.db.AddUsage(env.s3ID, nsID, fileSize))
+	require.NoError(t, env.db.SetS3UploadIntent(hash, &S3UploadIntent{
+		TargetStorageID:   env.s3ID,
+		OriginalStorageID: env.diskID,
+		Key:               env.target.objectKey(hash),
+		Size:              int64(len(data)),
+		NamespaceID:       nsID,
+		StartedAt:         time.Now(),
+	}))
+	require.NoError(t, env.target.uploadObject(ctx, hash, "", int64(len(data)), newZeroReader(len(data))))
+
+	require.NoError(t, env.uploader.recover(ctx))
+
+	// The uncommitted bucket object is removed, the charge refunded, the
+	// intent dropped, and the object re-queued for upload.
+	exists, err := env.target.objectExists(ctx, hash)
+	require.NoError(t, err)
+	assert.False(t, exists, "uncommitted upload should be deleted during recovery")
+	s3Usage, err := env.db.GetUsage(env.s3ID, nsID)
+	require.NoError(t, err)
+	assert.Zero(t, s3Usage)
+	intents, err := env.db.ListS3UploadIntents()
+	require.NoError(t, err)
+	assert.Empty(t, intents)
+	select {
+	case queued := <-env.uploader.queue:
+		assert.Equal(t, hash, queued)
+	default:
+		t.Fatal("expected the recovered object to be re-queued for tiering")
+	}
+}
+
+// TestS3RedirectDropsAuthorizationCrossHost pins the safety property that
+// makes the S3 presigned-URL redirect safe by default: a spec-compliant
+// HTTP client — specifically the one Pelican itself uses (config.GetClient,
+// which sets no CheckRedirect) — does NOT forward the Authorization header
+// to the redirect target when that target is a different hostname, as a
+// real S3 provider always is.  The cross-host redirect is exactly what the
+// cache issues in tryS3Redirect, so this guarantees a client's bearer token
+// is never disclosed to the S3 endpoint.
+//
+// The same-hostname case (different port) shows the converse, and is why the
+// cache cannot simply redirect everything: net/http compares hostnames and
+// ignores ports, so an endpoint co-located with the cache does receive the
+// header.  redirectRetainsAuthorization is what detects that arrangement --
+// including the subdomain form, which this loopback-only test cannot stage --
+// and tryS3Redirect proxies those targets instead.  See
+// TestRedirectRetainsAuthorization.
+func TestS3RedirectDropsAuthorizationCrossHost(t *testing.T) {
+	// s3Backend stands in for the S3 provider (the redirect target); it
+	// records whether the Authorization header survived the hop.
+	var sawAuth string
+	s3Backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer s3Backend.Close()
+	backendURL, err := url.Parse(s3Backend.URL)
+	require.NoError(t, err)
+
+	// cache stands in for the cache endpoint; it 307s to the "S3 provider"
+	// on a chosen hostname, mirroring http.Redirect in tryS3Redirect.
+	var redirectHost string // set per subtest
+	cache := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		target := *backendURL
+		target.Host = redirectHost + ":" + backendURL.Port()
+		http.Redirect(w, r, target.String(), http.StatusTemporaryRedirect)
+	}))
+	defer cache.Close()
+
+	// The Pelican client's redirect policy: config.GetClient sets no
+	// CheckRedirect, so this mirrors exactly how a real transfer follows the
+	// cache's redirect.  (Use a bare client with the same policy to avoid
+	// pulling in TLS/federation setup.)
+	client := &http.Client{}
+
+	tests := []struct {
+		name         string
+		redirectHost string
+		wantStripped bool
+	}{
+		// A real S3 provider is always a different hostname than the cache.
+		{"cross-host (real S3)", "localhost", true},
+		// Documents the residual same-hostname exposure.
+		{"same-host different-port", "127.0.0.1", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sawAuth = ""
+			redirectHost = tt.redirectHost
+			req, err := http.NewRequest(http.MethodGet, cache.URL, nil)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", "Bearer super-secret-token")
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+
+			if tt.wantStripped {
+				assert.Empty(t, sawAuth,
+					"Authorization must be stripped on the cross-host redirect to S3")
+			} else {
+				assert.Equal(t, "Bearer super-secret-token", sawAuth,
+					"a same-hostname redirect preserves Authorization, which is what the guard is for")
+			}
+		})
+	}
+}
+
+// TestRedirectRetainsAuthorization pins the guard that decides whether an S3
+// target may be served by redirect at all.  It has to match net/http's rule
+// (isDomainOrSubdomain), and the subdomain cases are the ones worth pinning:
+// an endpoint like s3.cache.example.org beside a cache on cache.example.org
+// keeps the client's Authorization header, and getting this wrong hands
+// federation tokens to the object store.
+func TestRedirectRetainsAuthorization(t *testing.T) {
+	tests := []struct {
+		name       string
+		dest       string
+		cache      string
+		wantRetain bool
+	}{
+		{"unrelated host", "https://s3.amazonaws.com", "cache.example.org", false},
+		{"same host", "https://cache.example.org", "cache.example.org", true},
+		{"same host, different port", "https://cache.example.org:9000", "cache.example.org", true},
+		{"endpoint is a subdomain of the cache", "https://s3.cache.example.org", "cache.example.org", true},
+		{"virtual-host bucket under a subdomain", "https://bucket.s3.cache.example.org", "cache.example.org", true},
+		{"cache is a subdomain of the endpoint", "https://example.org", "cache.example.org", false},
+		{"shared suffix but not a subdomain", "https://s3-cache.example.org", "cache.example.org", false},
+		{"sibling subdomains", "https://s3.example.org", "cache.example.org", false},
+		{"IP literal endpoint", "https://192.0.2.10:9000", "cache.example.org", false},
+		{"case and trailing dot folded", "https://S3.CACHE.example.org", "cache.example.org", true},
+		{"unknown cache host is treated as unsafe", "https://s3.amazonaws.com", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantRetain, redirectRetainsAuthorization(tt.dest, tt.cache))
+		})
+	}
+}
+
+// TestS3RedirectServing is a handler-level end-to-end test: it stands up a
+// real persistent cache with an S3 target (minio), lets the tiering
+// pipeline move a completed object into the bucket, and asserts that a GET
+// through serveObject is answered with a 307 to a working pre-signed URL —
+// and with the proxied bytes when redirect is disabled.
+func TestS3RedirectServing(t *testing.T) {
+	test_utils.SkipIfNoMinio(t)
+	endpoint, accessKey, secretKey := test_utils.StartMinio(t, "pelican-redirect-test")
+
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+	InitIssuerKeyForTests(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	egrp, _ := errgroup.WithContext(ctx)
+	t.Cleanup(func() {
+		cancel()
+		_ = egrp.Wait()
+	})
+
+	// Stub federation so NewPersistentCache resolves offline.
+	config.SetFederation(pelican_url.FederationDiscovery{
+		DiscoveryEndpoint: "https://cache.example:8443",
+		DirectorEndpoint:  "https://cache.example:8443",
+	})
+
+	keyDir := t.TempDir()
+	accessKeyfile := filepath.Join(keyDir, "access")
+	secretKeyfile := filepath.Join(keyDir, "secret")
+	require.NoError(t, os.WriteFile(accessKeyfile, []byte(accessKey), 0600))
+	require.NoError(t, os.WriteFile(secretKeyfile, []byte(secretKey), 0600))
+
+	setS3Targets(t, []interface{}{
+		map[string]interface{}{
+			"ServiceUrl":    endpoint,
+			"Bucket":        "pelican-redirect-test",
+			"Prefix":        "cache",
+			"MaxSize":       "1GB",
+			"AccessKeyfile": accessKeyfile,
+			"SecretKeyfile": secretKeyfile,
+		},
+	})
+	require.NoError(t, param.Cache_S3UploadThreshold.Set("1KB"))
+
+	tmpDir := t.TempDir()
+	pc, err := NewPersistentCache(ctx, egrp, PersistentCacheConfig{
+		Mode:        CacheModeServer,
+		BaseDir:     tmpDir,
+		StorageDirs: []StorageDirConfig{{Path: tmpDir}},
+		DeferConfig: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pc.Close() })
+	require.NotNil(t, pc.s3Uploader, "uploader should be wired when S3 targets are configured")
+
+	var s3ID StorageID
+	for id := range pc.storage.s3Targets {
+		s3ID = id
+	}
+
+	// Inject a public namespace so the tokenless GET authorizes.
+	require.NoError(t, pc.ac.updateConfig([]server_structs.NamespaceAd{{
+		Path: "/test",
+		Caps: server_structs.Capabilities{PublicReads: true, Reads: true},
+	}}))
+
+	// Store an object; the completion hook enqueues it for tiering and a
+	// background worker moves it into the bucket.
+	const objectPath = "/test/redirected_object.bin"
+	const etag = "redirect-test-etag"
+	normalized := pc.normalizePath(objectPath)
+	objectHash := pc.db.ObjectHash(normalized)
+	instanceHash := pc.db.InstanceHash(etag, objectHash)
+	var diskID StorageID
+	for id := range pc.storage.GetDirs() {
+		diskID = id
+	}
+	data := bytes.Repeat([]byte("s3-redirect-test-data\n"), 700) // ~15 KiB
+	storeTestObject(t, ctx, pc.storage, instanceHash, data, diskID, NamespaceID(1))
+	require.NoError(t, pc.db.SetLatestETag(objectHash, etag, time.Now()))
+
+	// Nudge the queue directly (storeTestObject bypasses some completion
+	// paths) and wait for the relocation to land.
+	pc.s3Uploader.MaybeEnqueue(instanceHash)
+	require.Eventually(t, func() bool {
+		meta, err := pc.storage.GetMetadata(instanceHash)
+		return err == nil && meta != nil && meta.StorageID == s3ID
+	}, 15*time.Second, 50*time.Millisecond, "object should be tiered to the S3 target")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pc.serveObject(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	// Default mode: the GET is answered with a 307 to a pre-signed URL.
+	noRedirectClient := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	resp, err := noRedirectClient.Get(srv.URL + objectPath)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+	location := resp.Header.Get("Location")
+	require.NotEmpty(t, location)
+	assert.Contains(t, location, "pelican-redirect-test", "redirect should point at the bucket")
+	assert.Contains(t, location, "X-Amz-Signature", "redirect should be pre-signed")
+
+	// The pre-signed URL serves the object bytes without credentials.
+	resp, err = http.Get(location)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, data, body)
+
+	// A default http.Client follows the redirect transparently.
+	resp, err = http.Get(srv.URL + objectPath)
+	require.NoError(t, err)
+	body, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, data, body)
+
+	// Range requests survive the redirect (the client re-applies Range to
+	// the pre-signed URL and S3 honors it).
+	req, err := http.NewRequest(http.MethodGet, srv.URL+objectPath, nil)
+	require.NoError(t, err)
+	req.Header.Set("Range", "bytes=100-199")
+	resp, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	body, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusPartialContent, resp.StatusCode)
+	assert.Equal(t, data[100:200], body)
+
+	// With redirect disabled, the same GET proxies the bytes through the
+	// cache (S3 stream mode) with a plain 200.
+	require.NoError(t, param.Cache_S3DisableRedirect.Set(true))
+	t.Cleanup(func() { _ = param.Cache_S3DisableRedirect.Set(false) })
+	resp, err = noRedirectClient.Get(srv.URL + objectPath)
+	require.NoError(t, err)
+	body, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "proxy-mode GET failed: %s", string(body))
+	assert.Equal(t, data, body)
+
+	// Proxy-mode range request is served by the cache itself.
+	req, err = http.NewRequest(http.MethodGet, srv.URL+objectPath, nil)
+	require.NoError(t, err)
+	req.Header.Set("Range", "bytes=4000-4999")
+	resp, err = noRedirectClient.Do(req)
+	require.NoError(t, err)
+	body, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusPartialContent, resp.StatusCode)
+	assert.Equal(t, data[4000:5000], body)
+
+	// The redirect stamped a presign hold: eviction must skip the object.
+	evicted, _, _, err := pc.storage.EvictByLRU(s3ID, NamespaceID(1), 0, 0)
+	require.NoError(t, err)
+	assert.Empty(t, evicted, "presign hold should protect the object from eviction")
+}
+
+// newZeroReader returns a reader yielding n zero bytes.
+func newZeroReader(n int) io.Reader {
+	return io.LimitReader(zeroReader{}, int64(n))
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+func TestS3ConsistencySweep(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	env := setupS3TestEnv(t, ctx)
+	nsID := NamespaceID(1)
+
+	checker := NewConsistencyChecker(env.db, env.storage, ConsistencyConfig{
+		MinAgeForCleanup: 0, // disable the grace period for the test
+	})
+
+	// A valid tiered object that must survive both sweeps.
+	keepData := make([]byte, 4096)
+	keepHash := InstanceHash(fmt.Sprintf("%064d", 4))
+	storeTestObject(t, ctx, env.storage, keepHash, keepData, env.diskID, nsID)
+	require.NoError(t, env.uploader.processObject(ctx, keepHash))
+
+	// A stray bucket object with no metadata.
+	strayHash := InstanceHash(fmt.Sprintf("%064d", 5))
+	require.NoError(t, env.target.uploadObject(ctx, strayHash, "", 128, newZeroReader(128)))
+
+	// An S3-resident DB entry whose bucket object is missing.
+	ghostHash := InstanceHash(fmt.Sprintf("%064d", 6))
+	require.NoError(t, env.db.SetMetadata(ghostHash, &CacheMetadata{
+		ContentLength: 2048,
+		SourceURL:     "pelican://example.com/ghost",
+		StorageID:     env.s3ID,
+		NamespaceID:   nsID,
+		Completed:     time.Now().Add(-time.Hour),
+	}))
+
+	// The regular metadata scan must NOT treat S3-resident entries as
+	// orphaned DB entries (they have no local chunk files by design).
+	require.NoError(t, checker.RunMetadataScan(ctx, nil))
+	meta, err := env.storage.GetMetadata(keepHash)
+	require.NoError(t, err)
+	require.NotNil(t, meta, "metadata scan must not delete S3-resident entries")
+	assert.Equal(t, env.s3ID, meta.StorageID)
+
+	// The S3 sweep removes the stray bucket object and the ghost DB entry
+	// while leaving the valid object alone.
+	require.NoError(t, checker.RunS3Scan(ctx))
+
+	exists, err := env.target.objectExists(ctx, strayHash)
+	require.NoError(t, err)
+	assert.False(t, exists, "stray bucket object should be removed")
+
+	ghostMeta, err := env.storage.GetMetadata(ghostHash)
+	require.NoError(t, err)
+	assert.Nil(t, ghostMeta, "DB entry without a bucket object should be removed")
+
+	exists, err = env.target.objectExists(ctx, keepHash)
+	require.NoError(t, err)
+	assert.True(t, exists, "valid tiered object should survive the sweep")
+	meta, err = env.storage.GetMetadata(keepHash)
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+}

--- a/local_cache/s3_uploader.go
+++ b/local_cache/s3_uploader.go
@@ -1,0 +1,589 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package local_cache
+
+import (
+	"context"
+	rand "math/rand/v2"
+	"sync"
+	"time"
+
+	badger "github.com/dgraph-io/badger/v4"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	// s3UploadWorkers is the number of concurrent tiering uploads.
+	s3UploadWorkers = 4
+	// s3UploadQueueDepth bounds the pending-upload queue.  When full,
+	// candidates are dropped; the periodic S3 sweep re-enqueues eligible
+	// objects, so a drop only delays tiering.
+	s3UploadQueueDepth = 1024
+	// s3RelocateRetries bounds retries of the relocation transaction on
+	// BadgerDB write conflicts (e.g. racing an LRU update).
+	s3RelocateRetries = 5
+	// s3RescanBaseInterval is the steady-state gap between backfill rescans.
+	s3RescanBaseInterval = 1 * time.Hour
+	// s3RescanMinInterval is the floor the adaptive rescan sleep halves
+	// toward while there is still deferred work to enqueue.
+	s3RescanMinInterval = 1 * time.Minute
+	// s3CleanupTimeout bounds the bucket delete issued when an upload is
+	// abandoned.  It runs on a context detached from the request/shutdown
+	// context, so it needs its own deadline.
+	s3CleanupTimeout = 2 * time.Minute
+)
+
+// s3Uploader tiers completed objects from local storage directories to S3
+// storage targets.  Objects become candidates when they complete (via the
+// StorageManager's onObjectComplete hook), at startup (backfill scan), and
+// during the periodic S3 consistency sweep.
+type s3Uploader struct {
+	db        *CacheDB
+	storage   *StorageManager
+	eviction  *EvictionManager
+	threshold int64
+
+	queue chan InstanceHash
+	ctx   context.Context
+
+	// inflight guards against two workers tiering the same object at once
+	// (completion notifications can fire more than once per object).
+	inflightMu sync.Mutex
+	inflight   map[InstanceHash]bool
+}
+
+// newS3Uploader creates the uploader.  threshold is the minimum object
+// ContentLength for tiering.
+func newS3Uploader(db *CacheDB, storage *StorageManager, eviction *EvictionManager, threshold int64) *s3Uploader {
+	return &s3Uploader{
+		db:        db,
+		storage:   storage,
+		eviction:  eviction,
+		threshold: threshold,
+		queue:     make(chan InstanceHash, s3UploadQueueDepth),
+		inflight:  make(map[InstanceHash]bool),
+	}
+}
+
+// Start runs crash recovery synchronously, then launches the upload
+// workers and a background backfill scan.
+func (u *s3Uploader) Start(ctx context.Context, egrp *errgroup.Group) error {
+	u.ctx = ctx
+	if err := u.recover(ctx); err != nil {
+		return err
+	}
+	for i := 0; i < s3UploadWorkers; i++ {
+		egrp.Go(func() error {
+			u.workerLoop(ctx)
+			return nil
+		})
+	}
+	egrp.Go(func() error {
+		u.backfillScan(ctx)
+		return nil
+	})
+	egrp.Go(func() error {
+		u.rescanLoop(ctx)
+		return nil
+	})
+	return nil
+}
+
+// rescanLoop periodically re-enqueues eligible objects that were deferred
+// (queue full, no room on any target) and aborts multipart uploads that
+// outlived any plausible in-flight transfer.
+//
+// The sleep is adaptive: when a backfill pass leaves work behind (the queue
+// filled before every eligible object was enqueued), the next pass runs
+// sooner — the interval halves toward s3RescanMinInterval — so a large
+// backlog drains in minutes rather than hours.  Once a pass enqueues
+// everything eligible, the interval resets to the steady-state base.
+func (u *s3Uploader) rescanLoop(ctx context.Context) {
+	sleep := s3RescanBaseInterval
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(sleep):
+		}
+
+		_, deferred := u.backfillScan(ctx)
+
+		// Finish local cleanup for objects that were still under a reader when
+		// their relocation committed.
+		u.finishDeferredReleases(ctx)
+
+		// Only reconcile stale multipart uploads on full-interval passes so
+		// catch-up cycles don't hammer the bucket's ListMultipartUploads.
+		if sleep >= s3RescanBaseInterval {
+			for _, target := range u.storage.s3Targets {
+				if aborted, err := target.abortStaleMultipartUploads(ctx, 6*time.Hour); err != nil {
+					log.Warnf("Failed to abort stale multipart uploads on %s: %v", target.cfg.DisplayURL(), err)
+				} else if aborted > 0 {
+					log.Infof("Aborted %d stale multipart upload(s) on %s", aborted, target.cfg.DisplayURL())
+				}
+			}
+		}
+
+		if deferred {
+			sleep /= 2
+			if sleep < s3RescanMinInterval {
+				sleep = s3RescanMinInterval
+			}
+		} else {
+			sleep = s3RescanBaseInterval
+		}
+	}
+}
+
+// MaybeEnqueue submits an object for tiering consideration.  Non-blocking;
+// eligibility is checked by the worker.  Safe to call from completion
+// callbacks.
+func (u *s3Uploader) MaybeEnqueue(instanceHash InstanceHash) {
+	select {
+	case u.queue <- instanceHash:
+	default:
+		// Queue full — the periodic sweep will pick the object up later.
+	}
+}
+
+func (u *s3Uploader) workerLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case hash := <-u.queue:
+			if err := u.processObject(ctx, hash); err != nil {
+				log.Warnf("Failed to tier object %s to S3: %v", hash, err)
+			}
+		}
+	}
+}
+
+// eligible checks whether an object should be tiered right now.  Chunked
+// objects are eligible: large objects (the prime tiering candidates) are
+// exactly the ones chunking splits across directories, and relocation
+// flattens them into a single bucket blob.
+func (u *s3Uploader) eligible(meta *CacheMetadata) bool {
+	return meta != nil &&
+		!meta.Completed.IsZero() &&
+		meta.StorageID != StorageIDInline &&
+		!u.storage.IsS3Backed(meta.StorageID) &&
+		meta.ContentLength >= u.threshold
+}
+
+// chooseTarget randomly selects an S3 target that can currently hold the
+// object, weighted by each target's estimated free space, so concurrent
+// uploads spread across targets instead of all piling onto the single
+// emptiest one.  Returns nil when no target fits.
+//
+// Concurrency: s3Targets is read-only after initialization and DirFree reads
+// lock-free atomic counters, so this is safe to call from every worker
+// without a lock.  The free-space figures are estimates that may be briefly
+// stale relative to concurrent charges, but the authoritative capacity guard
+// is the up-front usage charge in processObject (plus watermark eviction), so
+// a stale estimate can at worst cause a transient overshoot that eviction
+// corrects — never a lost or corrupted object.
+func (u *s3Uploader) chooseTarget(size int64) *s3Target {
+	type candidate struct {
+		target *s3Target
+		free   int64
+	}
+	var candidates []candidate
+	var totalFree int64
+	for id, target := range u.storage.s3Targets {
+		if free := u.eviction.DirFree(id); free >= size {
+			candidates = append(candidates, candidate{target: target, free: free})
+			totalFree += free
+		}
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	if len(candidates) == 1 || totalFree <= 0 {
+		return candidates[0].target
+	}
+	// Weighted pick: land in the slice proportional to each target's free.
+	r := rand.Int64N(totalFree)
+	for _, c := range candidates {
+		if r < c.free {
+			return c.target
+		}
+		r -= c.free
+	}
+	return candidates[len(candidates)-1].target
+}
+
+// processObject performs one tiering operation:
+//
+//  1. re-check eligibility from current metadata
+//  2. charge usage on the S3 target up front (the cache's usual model),
+//     triggering eviction if the bucket crosses its high-water mark
+//  3. record the upload intent in BadgerDB (crash safety: any bytes that
+//     may exist in the bucket are always covered by an intent or by
+//     relocated metadata)
+//  4. stream the decrypted object to the bucket
+//  5. relocate metadata (StorageID + LRU index) to the S3 target
+//  6. release the local copy: usage refund, file deletion, cache invalidation
+//  7. drop the intent
+func (u *s3Uploader) processObject(ctx context.Context, instanceHash InstanceHash) error {
+	u.inflightMu.Lock()
+	if u.inflight[instanceHash] {
+		u.inflightMu.Unlock()
+		return nil // another worker is already tiering this object
+	}
+	u.inflight[instanceHash] = true
+	u.inflightMu.Unlock()
+	defer func() {
+		u.inflightMu.Lock()
+		delete(u.inflight, instanceHash)
+		u.inflightMu.Unlock()
+	}()
+
+	meta, err := u.storage.GetMetadata(instanceHash)
+	if err != nil {
+		return errors.Wrap(err, "failed to load metadata")
+	}
+	if !u.eligible(meta) {
+		return nil
+	}
+	localID := meta.StorageID
+	fileSize := CalculateFileSize(meta.ContentLength)
+
+	target := u.chooseTarget(fileSize)
+	if target == nil {
+		// No target currently fits; nudge eviction so space opens up and
+		// let the periodic sweep retry.
+		u.eviction.TriggerEviction()
+		log.Debugf("No S3 target has room for %s (%d bytes); deferring", instanceHash, fileSize)
+		return nil
+	}
+
+	// Charge the S3 target up front so concurrent uploads cannot
+	// collectively overrun the bucket; refunded on failure.
+	if err := u.db.AddUsage(target.id, meta.NamespaceID, fileSize); err != nil {
+		return errors.Wrap(err, "failed to charge S3 usage")
+	}
+	u.eviction.NoteUsageIncrease(target.id, fileSize)
+	refund := func() {
+		if err := u.db.AddUsage(target.id, meta.NamespaceID, -fileSize); err != nil {
+			log.Warnf("Failed to refund S3 usage for %s: %v", instanceHash, err)
+		}
+		u.eviction.NoteUsageDecrease(target.id, fileSize)
+	}
+
+	intent := &S3UploadIntent{
+		TargetStorageID:        target.id,
+		OriginalStorageID:      localID,
+		OriginalChunkSizeCode:  meta.ChunkSizeCode,
+		OriginalChunkLocations: meta.ChunkLocations,
+		Key:                    target.objectKey(instanceHash),
+		Size:                   meta.ContentLength,
+		NamespaceID:            meta.NamespaceID,
+		StartedAt:              time.Now(),
+	}
+	if err := u.db.SetS3UploadIntent(instanceHash, intent); err != nil {
+		refund()
+		return errors.Wrap(err, "failed to record upload intent")
+	}
+
+	// abandon cleans up bucket + intent + usage after a failure.
+	//
+	// The delete runs on a context detached from ctx: the common reason to
+	// abandon an upload is that ctx was cancelled by shutdown, and reusing it
+	// would fail the delete and strand bytes in the bucket.  If the delete
+	// fails anyway the intent is kept, not dropped -- an intent is the only
+	// record that those bytes exist, so removing it while they remain would
+	// break the invariant that every object in the bucket is covered by an
+	// intent or by relocated metadata.  Recovery retries it.
+	abandon := func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s3CleanupTimeout)
+		defer cancel()
+		if delErr := target.deleteObject(cleanupCtx, instanceHash); delErr != nil {
+			log.Warnf("Failed to clean up S3 object for %s after aborted tiering (keeping the intent so recovery retries): %v",
+				instanceHash, delErr)
+			return
+		}
+		refund()
+		if delErr := u.db.DeleteS3UploadIntent(instanceHash); delErr != nil {
+			log.Warnf("Failed to delete upload intent for %s: %v", instanceHash, delErr)
+		}
+	}
+
+	reader, err := u.storage.NewObjectReader(instanceHash)
+	if err != nil {
+		abandon()
+		return errors.Wrap(err, "failed to open object for upload")
+	}
+	uploadErr := target.uploadObject(ctx, instanceHash, meta.ContentType, meta.ContentLength, reader)
+	reader.Close()
+	if uploadErr != nil {
+		abandon()
+		return uploadErr
+	}
+
+	// Relocate metadata; retry on OCC conflicts with concurrent metadata
+	// writers (LRU updates, checksum merges).
+	var prev *CacheMetadata
+	for attempt := 0; ; attempt++ {
+		prev, err = u.db.RelocateObject(instanceHash, target.id)
+		if err == nil {
+			break
+		}
+		if errors.Is(err, badger.ErrConflict) && attempt < s3RelocateRetries {
+			time.Sleep(time.Duration(attempt+1) * 5 * time.Millisecond)
+			continue
+		}
+		// If a concurrent tiering pass already relocated the object here,
+		// the bucket copy is live — refund only this pass's charge and
+		// leave the object alone.
+		if cur, curErr := u.storage.GetMetadata(instanceHash); curErr == nil && cur != nil && cur.StorageID == target.id {
+			refund()
+			if delErr := u.db.DeleteS3UploadIntent(instanceHash); delErr != nil {
+				log.Warnf("Failed to delete upload intent for %s: %v", instanceHash, delErr)
+			}
+			return nil
+		}
+		// Relocation failed (e.g. object evicted mid-upload) — remove the
+		// bucket copy so nothing is leaked.
+		abandon()
+		return errors.Wrap(err, "failed to relocate object metadata to S3 target")
+	}
+
+	// Record that the bucket copy is now authoritative before touching the
+	// local one.  If the process dies anywhere below, recovery needs to know
+	// that the bucket bytes belong to the object rather than to this intent.
+	intent.RelocatedAt = time.Now()
+	if err := u.db.SetS3UploadIntent(instanceHash, intent); err != nil {
+		// Not fatal: recovery also treats "metadata already points at the
+		// target" as proof the relocation committed.  Only the object-deleted
+		// case needs the marker, so log and continue.
+		log.Warnf("Failed to mark upload intent for %s as relocated: %v", instanceHash, err)
+	}
+
+	// Release the local copy, unless a reader is still working from it.
+	if !u.releaseLocalCopy(instanceHash, prev) {
+		// A reader holds this version.  Its RangeReader captured the
+		// pre-relocation metadata, so it is still reading the local chunk
+		// files; deleting them now would break the transfer.  Leave the
+		// intent in place -- finishDeferredReleases retries once the reader
+		// is gone, and crash recovery finishes the job after a restart.
+		log.Debugf("Deferring local cleanup of tiered object %s: a reader still holds it", instanceHash)
+		return nil
+	}
+
+	if err := u.db.DeleteS3UploadIntent(instanceHash); err != nil {
+		log.Warnf("Failed to delete upload intent for %s: %v", instanceHash, err)
+	}
+	log.Debugf("Tiered object %s (%d bytes) to S3 target %d", instanceHash, meta.ContentLength, target.id)
+	return nil
+}
+
+// releaseLocalCopy removes a tiered object's local files and returns their
+// capacity to the directories that held them.  prev must be the object's
+// pre-relocation metadata, which still carries the chunk layout, so that a
+// chunked object's bytes are refunded to every directory that held a chunk.
+//
+// Returns false without touching anything when a reader is pinned on the
+// version, leaving the caller to retry later.
+func (u *s3Uploader) releaseLocalCopy(instanceHash InstanceHash, prev *CacheMetadata) bool {
+	if u.storage.IsObjectPinned(instanceHash) {
+		return false
+	}
+	// A reader could still arrive between the check and the deletes.  It would
+	// have to read the relocated metadata to do so, which points at the
+	// bucket, so it never reaches the local files -- unlike the reader this
+	// check protects, which captured the layout before relocation.
+	for sid, bytes := range prev.PerDirectoryBytes() {
+		if err := u.db.AddUsage(sid, prev.NamespaceID, -bytes); err != nil {
+			log.Warnf("Failed to release local usage for tiered object %s on storage %d: %v", instanceHash, sid, err)
+		}
+		u.eviction.NoteUsageDecrease(sid, bytes)
+	}
+	u.storage.invalidateObjectCaches(instanceHash, prev.ChunkCount())
+	u.storage.deleteChunkFiles(instanceHash, prev.ContentLength, prev.StorageID, prev.ChunkSizeCode, prev.ChunkLocations)
+	return true
+}
+
+// localCopyFromIntent reconstructs the pre-relocation metadata an intent
+// recorded, for use with releaseLocalCopy.
+func localCopyFromIntent(intent *S3UploadIntent) *CacheMetadata {
+	return &CacheMetadata{
+		StorageID:      intent.OriginalStorageID,
+		ContentLength:  intent.Size,
+		ChunkSizeCode:  intent.OriginalChunkSizeCode,
+		ChunkLocations: intent.OriginalChunkLocations,
+		NamespaceID:    intent.NamespaceID,
+	}
+}
+
+// finishDeferredReleases completes the local cleanup for objects whose
+// relocation committed but whose local copy was still under a reader at the
+// time.  Only that state is retried here: it is unambiguous (an in-flight
+// upload has not relocated yet, so its metadata still names local storage),
+// which makes the pass safe to run at any point, unlike the broader
+// reconciliation in recover().
+func (u *s3Uploader) finishDeferredReleases(ctx context.Context) {
+	intents, err := u.db.ListS3UploadIntents()
+	if err != nil {
+		log.Warnf("Failed to list S3 upload intents for deferred cleanup: %v", err)
+		return
+	}
+	for hash, intent := range intents {
+		if ctx.Err() != nil {
+			return
+		}
+		meta, err := u.storage.GetMetadata(hash)
+		if err != nil || meta == nil || meta.StorageID != intent.TargetStorageID {
+			continue
+		}
+		if !u.releaseLocalCopy(hash, localCopyFromIntent(intent)) {
+			continue // still pinned; try again next pass
+		}
+		if err := u.db.DeleteS3UploadIntent(hash); err != nil {
+			log.Warnf("Failed to delete upload intent for %s: %v", hash, err)
+			continue
+		}
+		log.Debugf("Completed deferred local cleanup of tiered object %s", hash)
+	}
+}
+
+// recover reconciles upload intents left behind by a crash.  Invariant:
+// any object bytes in a bucket are referenced either by relocated metadata
+// or by an intent — so walking the intents finds every possible leak.
+func (u *s3Uploader) recover(ctx context.Context) error {
+	intents, err := u.db.ListS3UploadIntents()
+	if err != nil {
+		return errors.Wrap(err, "failed to list S3 upload intents")
+	}
+	for hash, intent := range intents {
+		target := u.storage.getS3Target(intent.TargetStorageID)
+		if target == nil {
+			// Target no longer configured; drop the intent — the object
+			// (if any) will be found if the bucket is ever re-attached.
+			log.Warnf("Upload intent for %s references unknown S3 target %d; dropping", hash, intent.TargetStorageID)
+			if err := u.db.DeleteS3UploadIntent(hash); err != nil {
+				log.Warnf("Failed to delete stale upload intent for %s: %v", hash, err)
+			}
+			continue
+		}
+
+		meta, err := u.storage.GetMetadata(hash)
+		if err != nil {
+			return errors.Wrapf(err, "failed to load metadata for pending upload %s", hash)
+		}
+		switch {
+		case meta == nil && !intent.RelocatedAt.IsZero():
+			// The object was deleted after its relocation committed, so the
+			// bucket bytes and their charge belonged to the object: whatever
+			// deleted it already removed the bucket copy and refunded the
+			// target.  Refunding again here would drive the counter negative.
+			// What can remain is a local copy whose release was deferred
+			// (reader pinned) and whose charge the deletion did not see,
+			// because by then the metadata named only the bucket.
+			u.releaseLocalCopy(hash, localCopyFromIntent(intent))
+			// Belt and braces: the bucket object should already be gone.
+			if err := target.deleteObject(ctx, hash); err != nil {
+				log.Warnf("Failed to confirm removal of S3 object %s during recovery: %v", hash, err)
+			}
+		case meta == nil:
+			// The object was deleted while the upload was still in flight, so
+			// the bucket bytes are this intent's to reclaim, as is the charge
+			// taken for them.  The deletion refunded only the local storage.
+			if err := target.deleteObject(ctx, hash); err != nil {
+				log.Warnf("Failed to delete orphaned S3 object %s during recovery: %v", hash, err)
+				continue // keep the intent so a later pass retries
+			}
+			if err := u.db.AddUsage(intent.TargetStorageID, intent.NamespaceID, -CalculateFileSize(intent.Size)); err != nil {
+				log.Warnf("Failed to refund S3 usage for %s during recovery: %v", hash, err)
+			}
+			u.eviction.NoteUsageDecrease(intent.TargetStorageID, CalculateFileSize(intent.Size))
+		case meta.StorageID == intent.TargetStorageID:
+			// Relocation committed but local cleanup didn't finish — remove
+			// the leftover local file(s) and refund the capacity they still
+			// hold.  The intent carries the original chunk layout, so every
+			// chunk file is removed and every directory that held one is
+			// credited, not just chunk 0's.
+			if !u.releaseLocalCopy(hash, localCopyFromIntent(intent)) {
+				continue // pinned; finishDeferredReleases will retry
+			}
+		default:
+			// Upload did not commit.  Remove any partial/complete bucket
+			// copy, refund the up-front charge, and re-queue the object.
+			if err := target.deleteObject(ctx, hash); err != nil {
+				log.Warnf("Failed to delete uncommitted S3 object %s during recovery: %v", hash, err)
+				continue // keep the intent so a later pass retries
+			}
+			if err := u.db.AddUsage(intent.TargetStorageID, intent.NamespaceID, -CalculateFileSize(intent.Size)); err != nil {
+				log.Warnf("Failed to refund S3 usage for %s during recovery: %v", hash, err)
+			}
+			u.eviction.NoteUsageDecrease(intent.TargetStorageID, CalculateFileSize(intent.Size))
+			u.MaybeEnqueue(hash)
+		}
+		if err := u.db.DeleteS3UploadIntent(hash); err != nil {
+			log.Warnf("Failed to delete upload intent for %s during recovery: %v", hash, err)
+		}
+	}
+
+	// Abort any multipart uploads left over from a previous process.  The
+	// identity object marks the bucket as owned by this cache, so nothing
+	// else can have live multipart uploads under our prefix.
+	for _, target := range u.storage.s3Targets {
+		if aborted, err := target.abortStaleMultipartUploads(ctx, 0); err != nil {
+			log.Warnf("Failed to abort stale multipart uploads on %s: %v", target.cfg.DisplayURL(), err)
+		} else if aborted > 0 {
+			log.Infof("Aborted %d stale multipart upload(s) on %s", aborted, target.cfg.DisplayURL())
+		}
+	}
+	return nil
+}
+
+// backfillScan walks existing metadata once and enqueues completed local
+// objects that meet the tiering threshold (e.g. objects cached before an S3
+// target was configured, or deferred when the queue was previously full).
+//
+// It returns the number of objects queued and whether any eligible object
+// could not be enqueued because the queue was full (deferred == true),
+// signalling to the caller that more work remains.
+func (u *s3Uploader) backfillScan(ctx context.Context) (queued int, deferred bool) {
+	err := u.db.ScanMetadata(func(instanceHash InstanceHash, meta *CacheMetadata) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if !u.eligible(meta) {
+			return nil
+		}
+		select {
+		case u.queue <- instanceHash:
+			queued++
+		default:
+			deferred = true // queue full; a later rescan will pick it up
+		}
+		return nil
+	})
+	if err != nil && ctx.Err() == nil {
+		log.Warnf("S3 tiering backfill scan failed: %v", err)
+	}
+	if queued > 0 {
+		log.Infof("S3 tiering backfill: queued %d candidate object(s)", queued)
+	}
+	return queued, deferred
+}

--- a/local_cache/schema.go
+++ b/local_cache/schema.go
@@ -45,7 +45,13 @@ type ObjectHash string
 // accidental confusion with ObjectHash or arbitrary strings.
 type InstanceHash string
 
-// Key prefixes for BadgerDB
+// Key prefixes for BadgerDB.
+//
+// This block is the authoritative registry of every key namespace used in
+// the cache database; when adding a new namespace, document it here (and add
+// a key constructor next to the others below).  Per-object keys must also be
+// removed in deleteObjectInTxn and PurgeStorageID or they will leak on
+// eviction / storage recycling.
 const (
 	// PrefixMeta stores CacheMetadata (headers, validation info, storage mode)
 	PrefixMeta = "m:"
@@ -76,6 +82,16 @@ const (
 	// remove it, and anything left over belongs to a writer that did not
 	// survive.  See StorageManager.ReclaimAbandonedAppends.
 	PrefixAppendIntent = "aw:"
+	// PrefixS3Upload tracks in-progress uploads to S3 storage targets:
+	// up:<instance_hash> -> msgpack(S3UploadIntent).  An intent is written
+	// before the first byte reaches S3 and removed only after the object
+	// has been relocated (or the partial upload aborted), so a crash never
+	// leaves untracked objects in the bucket.
+	PrefixS3Upload = "up:"
+	// PrefixPresign records when a pre-signed URL was last handed out for
+	// an object: ps:<instance_hash> -> 8-byte big-endian UnixNano.
+	// Eviction skips objects with a recent presign timestamp.
+	PrefixPresign = "ps:"
 	// The keys below describe the database as a whole rather than any one
 	// object.  They are single, underscore-prefixed keys, they are written at
 	// open before any consumer touches a record, and none of them is ever
@@ -120,7 +136,18 @@ const (
 	//
 	// Whoever bumps it is responsible for teaching migrateSchema how to bring
 	// a database written under every still-supported older version forward.
-	CurrentSchemaVersion SchemaVersion = 1
+	//
+	// Version 2 added the S3 storage-target layout: the up: and ps: prefixes
+	// and DiskMapping.Backend.  Nothing needs rewriting to read it -- both
+	// prefixes are additive and an absent Backend means BackendPosix -- but
+	// the bump is not cosmetic.  It is what stops a version-1 binary from
+	// opening the database: that binary's FindRecyclableStorageID predates
+	// the "never recycle a non-POSIX mapping" rule, so it would hand an S3
+	// target's storage ID to a local directory and PurgeStorageID would take
+	// every tiered object's metadata with it.  Refusing the database is the
+	// mechanism that turns a silent, unrecoverable data loss into a
+	// startup error telling the operator to upgrade again.
+	CurrentSchemaVersion SchemaVersion = 2
 )
 
 // Prefixes reserved by the pstore origin backend (see docs/pstore-design.md).
@@ -709,13 +736,62 @@ func (m *CacheMetadata) EnsureExpires() {
 	}
 }
 
+// Backend types for DiskMapping.  The zero value ("") means a local POSIX
+// directory for backward compatibility with existing databases.
+const (
+	// BackendPosix is a local directory-backed storage target.
+	BackendPosix = ""
+	// BackendS3 is an S3 bucket-backed storage target.
+	BackendS3 = "s3"
+)
+
 // DiskMapping stores the mapping of a storage ID to its directory path
 // and UUID.  The UUID file is dropped in the directory root so that
 // directories can be remounted at different paths and re-associated.
+//
+// For S3 targets (Backend == BackendS3), Directory holds a display URL
+// (s3://<endpoint-host>/<bucket>/<prefix>) and the UUID is stored in an
+// identity object inside the bucket, so the same re-association logic
+// applies when a bucket is reconfigured under a different endpoint.
 type DiskMapping struct {
 	ID        StorageID `msgpack:"id"`
 	UUID      string    `msgpack:"uuid"`
 	Directory string    `msgpack:"dir"`
+	Backend   string    `msgpack:"be,omitempty"`
+}
+
+// S3UploadIntent records an in-progress upload of a completed object to an
+// S3 storage target.  Serialized with msgpack under up:<instance_hash>.
+type S3UploadIntent struct {
+	// TargetStorageID is the S3 storage target being uploaded to.
+	TargetStorageID StorageID `msgpack:"tid"`
+	// OriginalStorageID is the local (POSIX) storage the object's base
+	// (chunk 0) lives on; used by crash recovery to clean up the local
+	// file(s) when the upload committed but local deletion did not happen.
+	OriginalStorageID StorageID `msgpack:"oid"`
+	// OriginalChunkSizeCode and OriginalChunkLocations capture the object's
+	// pre-relocation chunk layout so crash recovery can delete every local
+	// chunk file after relocation flattened the metadata to a single S3
+	// object.  Both are zero/empty for non-chunked objects.
+	OriginalChunkSizeCode  ChunkSizeCode   `msgpack:"ocsc,omitempty"`
+	OriginalChunkLocations []ChunkLocation `msgpack:"ocl,omitempty"`
+	// Key is the full object key inside the bucket (including prefix).
+	Key string `msgpack:"key"`
+	// Size is the object ContentLength at upload time.
+	Size int64 `msgpack:"sz"`
+	// NamespaceID for usage accounting.
+	NamespaceID NamespaceID `msgpack:"ns"`
+	// StartedAt is when the upload began.
+	StartedAt time.Time `msgpack:"st"`
+	// RelocatedAt is set once the relocation transaction has committed, i.e.
+	// once the bucket copy -- not the local one -- is the object's
+	// authoritative storage.  It is what lets crash recovery tell the two
+	// halves of the lifecycle apart when the metadata record is gone: before
+	// relocation the bucket bytes and their capacity charge belong to this
+	// intent and must be reclaimed, while afterwards they belong to the
+	// object, so whatever deleted it has already accounted for them and only
+	// the leftover local copy needs cleaning up.  Zero means "not yet".
+	RelocatedAt time.Time `msgpack:"rat,omitempty"`
 }
 
 // MasterKeyFile represents the encrypted master key file format
@@ -987,4 +1063,191 @@ func ContentOffsetWithinBlock(contentOffset int64) int {
 // PurgeFirstKey returns the BadgerDB key for purge first tracking
 func PurgeFirstKey(instanceHash InstanceHash) []byte {
 	return []byte(PrefixPurgeFirst + string(instanceHash))
+}
+
+// S3UploadIntentKey returns the BadgerDB key tracking an in-progress upload
+// of an object to an S3 storage target.
+func S3UploadIntentKey(instanceHash InstanceHash) []byte {
+	return []byte(PrefixS3Upload + string(instanceHash))
+}
+
+// PresignKey returns the BadgerDB key recording the last time a pre-signed
+// URL was handed out for an object.
+func PresignKey(instanceHash InstanceHash) []byte {
+	return []byte(PrefixPresign + string(instanceHash))
+}
+
+// S3TargetConfig describes one S3 bucket used as a cache storage target.
+type S3TargetConfig struct {
+	// ServiceUrl is the S3 endpoint (e.g. https://s3.us-east-1.amazonaws.com).
+	ServiceUrl string
+	// Region is the S3 region; defaults to us-east-1 when empty.
+	Region string
+	// Bucket is the bucket name.
+	Bucket string
+	// Prefix is an optional key prefix under which cache objects live.
+	Prefix string
+	// UrlStyle is "path" (default) or "virtual".
+	UrlStyle string
+	// AccessKeyfile / SecretKeyfile point at files holding static
+	// credentials.  Both must be set together; when empty the ambient AWS
+	// credential chain is used.
+	AccessKeyfile string
+	SecretKeyfile string
+	// MaxSize is the maximum bytes of cache data stored in the bucket.
+	// Required — bucket capacity cannot be auto-detected.
+	MaxSize uint64
+	// Watermark overrides (percent of MaxSize); 0 means use the global default.
+	HighWaterMarkPercentage int
+	LowWaterMarkPercentage  int
+}
+
+// ServiceUrlScheme returns the URL scheme of the configured endpoint,
+// defaulting to https when the endpoint carries none.
+func (c *S3TargetConfig) ServiceUrlScheme() string {
+	if u, err := url.Parse(c.ServiceUrl); err == nil && u.Scheme != "" {
+		return strings.ToLower(u.Scheme)
+	}
+	return "https"
+}
+
+// DisplayURL returns a human-readable identity string for the target,
+// stored in the DiskMapping.Directory field.
+func (c *S3TargetConfig) DisplayURL() string {
+	host := c.ServiceUrl
+	if u, err := url.Parse(c.ServiceUrl); err == nil && u.Host != "" {
+		host = u.Host
+	}
+	s := "s3://" + host + "/" + c.Bucket
+	if c.Prefix != "" {
+		s += "/" + strings.Trim(c.Prefix, "/")
+	}
+	return s
+}
+
+// ParseS3TargetsConfig reads the Cache.S3StorageTargets setting and returns
+// the parsed target configurations.  Returns nil (not an error) when the key
+// is unset or empty.
+func ParseS3TargetsConfig() ([]S3TargetConfig, error) {
+	raw := param.Cache_S3StorageTargets.GetRaw()
+	if raw == nil {
+		return nil, nil
+	}
+
+	list, ok := raw.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Cache.S3StorageTargets: unsupported type %T; expected a list of objects", raw)
+	}
+	configs := make([]S3TargetConfig, 0, len(list))
+	for i, elem := range list {
+		var m map[string]interface{}
+		switch e := elem.(type) {
+		case map[string]interface{}:
+			m = e
+		case map[interface{}]interface{}:
+			m = make(map[string]interface{}, len(e))
+			for k, val := range e {
+				m[fmt.Sprint(k)] = val
+			}
+		default:
+			return nil, fmt.Errorf("Cache.S3StorageTargets[%d]: unsupported type %T; expected an object", i, elem)
+		}
+		cfg, err := parseS3TargetEntry(i, m)
+		if err != nil {
+			return nil, err
+		}
+		configs = append(configs, cfg)
+	}
+	return configs, nil
+}
+
+// s3EntryString fetches a string-valued key from an S3 target entry,
+// falling back to the all-lowercase key name (viper lowercases keys in
+// some code paths).
+func s3EntryString(m map[string]interface{}, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	if v, ok := m[strings.ToLower(key)].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// s3EntryInt fetches an integer-valued key with lowercase fallback.
+func s3EntryInt(m map[string]interface{}, key string) int {
+	v, ok := m[key]
+	if !ok {
+		v, ok = m[strings.ToLower(key)]
+	}
+	if !ok || v == nil {
+		return 0
+	}
+	switch n := v.(type) {
+	case int:
+		return n
+	case int64:
+		return int(n)
+	case float64:
+		return int(n)
+	}
+	return 0
+}
+
+// parseS3TargetEntry converts a map entry into an S3TargetConfig.
+func parseS3TargetEntry(idx int, m map[string]interface{}) (S3TargetConfig, error) {
+	cfg := S3TargetConfig{
+		ServiceUrl:              s3EntryString(m, "ServiceUrl"),
+		Region:                  s3EntryString(m, "Region"),
+		Bucket:                  s3EntryString(m, "Bucket"),
+		Prefix:                  strings.Trim(s3EntryString(m, "Prefix"), "/"),
+		UrlStyle:                s3EntryString(m, "UrlStyle"),
+		AccessKeyfile:           s3EntryString(m, "AccessKeyfile"),
+		SecretKeyfile:           s3EntryString(m, "SecretKeyfile"),
+		HighWaterMarkPercentage: s3EntryInt(m, "HighWaterMarkPercentage"),
+		LowWaterMarkPercentage:  s3EntryInt(m, "LowWaterMarkPercentage"),
+	}
+	if cfg.ServiceUrl == "" {
+		return cfg, fmt.Errorf("Cache.S3StorageTargets[%d]: missing required ServiceUrl", idx)
+	}
+	if cfg.Bucket == "" {
+		return cfg, fmt.Errorf("Cache.S3StorageTargets[%d]: missing required Bucket", idx)
+	}
+	if cfg.Region == "" {
+		cfg.Region = "us-east-1"
+	}
+	if cfg.UrlStyle == "" {
+		cfg.UrlStyle = "path"
+	}
+	if (cfg.AccessKeyfile == "") != (cfg.SecretKeyfile == "") {
+		return cfg, fmt.Errorf("Cache.S3StorageTargets[%d]: AccessKeyfile and SecretKeyfile must be set together", idx)
+	}
+
+	// MaxSize (required, string like "5TB" or a byte count)
+	var rawSize interface{}
+	if v, ok := m["MaxSize"]; ok {
+		rawSize = v
+	} else if v, ok := m["maxsize"]; ok {
+		rawSize = v
+	}
+	switch s := rawSize.(type) {
+	case string:
+		if s != "" && s != "0" {
+			n, err := utils.ParseBytes(s)
+			if err != nil {
+				return cfg, fmt.Errorf("Cache.S3StorageTargets[%d].MaxSize: %w", idx, err)
+			}
+			cfg.MaxSize = n
+		}
+	case int:
+		cfg.MaxSize = uint64(s)
+	case int64:
+		cfg.MaxSize = uint64(s)
+	case float64:
+		cfg.MaxSize = uint64(s)
+	}
+	if cfg.MaxSize == 0 {
+		return cfg, fmt.Errorf("Cache.S3StorageTargets[%d]: MaxSize is required for S3 targets (bucket capacity cannot be auto-detected)", idx)
+	}
+	return cfg, nil
 }

--- a/local_cache/storage.go
+++ b/local_cache/storage.go
@@ -22,10 +22,12 @@ import (
 	"context"
 	"encoding/binary"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -371,6 +373,18 @@ type StorageManager struct {
 	// overwrites this with EvictionManager.ChooseDiskStorage (weighted
 	// by free space) before any concurrent access begins.
 	chooseDir func() StorageID
+
+	// s3Targets maps storageID → S3 bucket target.  New objects are never
+	// placed here directly; completed objects are tiered to S3 by the
+	// uploader.  Populated by RegisterS3Targets during single-threaded
+	// init; read-only afterwards.
+	s3Targets map[StorageID]*s3Target
+
+	// onObjectComplete, when non-nil, is invoked (on the completing
+	// goroutine) each time an object transitions to Completed.  Set during
+	// single-threaded init by the S3 uploader to observe candidates for
+	// tiering.
+	onObjectComplete func(InstanceHash)
 }
 
 // StorageDirInfo describes a configured storage directory at runtime.
@@ -546,6 +560,12 @@ func NewStorageManager(db *CacheDB, dirs []string, inlineMax int, egrp *errgroup
 		}
 	}
 	if ptCacheSize > 0 {
+		// Clamp to MaxInt64 before the int64 conversions below: ristretto's
+		// cost API is int64, and a configured size above MaxInt64 would wrap
+		// to a negative cost.  No real memory cache approaches this bound.
+		if ptCacheSize > uint64(math.MaxInt64) {
+			ptCacheSize = uint64(math.MaxInt64)
+		}
 		// NumCounters should be ~10× the expected max number of entries.
 		numEntries := int64(ptCacheSize) / BlockDataSize
 		numCounters := numEntries * 10
@@ -634,6 +654,112 @@ func (sm *StorageManager) GetDirs() map[StorageID]string {
 	return sm.dirs
 }
 
+// RegisterS3Targets resolves identities for the configured S3 storage
+// targets and assigns each a storage ID, mirroring the UUID-based directory
+// association performed by NewStorageManager.  Must be called during
+// single-threaded initialization, before any concurrent access.
+//
+// Returns the storageID → config mapping for the registered targets.
+func (sm *StorageManager) RegisterS3Targets(ctx context.Context, configs []S3TargetConfig) (map[StorageID]S3TargetConfig, error) {
+	if len(configs) == 0 {
+		return nil, nil
+	}
+	persisted, err := sm.db.LoadDiskMappings()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to load disk mappings for S3 target registration")
+	}
+	byUUID := make(map[string]DiskMapping, len(persisted))
+	usedIDs := make(map[StorageID]bool, len(persisted))
+	for _, dm := range persisted {
+		byUUID[dm.UUID] = dm
+		usedIDs[dm.ID] = true
+	}
+	for id := range sm.dirs {
+		usedIDs[id] = true
+	}
+	if len(sm.dirs)+len(configs) > 255 {
+		return nil, errors.New("at most 255 storage targets (directories + S3 buckets) are supported")
+	}
+
+	sm.s3Targets = make(map[StorageID]*s3Target, len(configs))
+	result := make(map[StorageID]S3TargetConfig, len(configs))
+	cacheHost := cacheExternalHost()
+	claimedUUIDs := make(map[string]string, len(configs))
+	for i := range configs {
+		cfg := configs[i]
+		if !strings.EqualFold(cfg.ServiceUrlScheme(), "https") {
+			log.Warnf("Cache S3 target %s is configured over %s: object data and pre-signed URLs "+
+				"will cross the network in cleartext", cfg.DisplayURL(), cfg.ServiceUrlScheme())
+		}
+		target, err := newS3Target(ctx, cfg)
+		if err != nil {
+			return nil, err
+		}
+		uid, err := target.resolveIdentity(ctx)
+		if err != nil {
+			return nil, err
+		}
+		// Two entries that resolve to the same bucket and prefix share an
+		// identity object, so they would be assigned one storage ID and the
+		// second would silently replace the first -- leaving one entry's
+		// MaxSize governing both buckets' worth of data.
+		if prev, dup := claimedUUIDs[uid]; dup {
+			return nil, errors.Errorf("cache S3 targets %s and %s resolve to the same bucket and prefix; "+
+				"configure each bucket (or prefix) once", prev, cfg.DisplayURL())
+		}
+		claimedUUIDs[uid] = cfg.DisplayURL()
+
+		// Advisory: warn once at startup about an arrangement that will make
+		// the cache proxy token-bearing requests instead of redirecting them.
+		// The decision itself is per-request, against the host the client
+		// actually connected to -- see (*PersistentCache).tryS3Redirect.
+		if cacheHost != "" && redirectRetainsAuthorization(cfg.ServiceUrl, cacheHost) {
+			log.Warnf("Cache S3 target %s shares the cache's DNS domain (%s); authenticated requests for "+
+				"objects on it will be proxied rather than served by pre-signed redirect, so that client "+
+				"credentials are not forwarded to the bucket endpoint", cfg.DisplayURL(), cacheHost)
+		}
+
+		var id StorageID
+		if dm, known := byUUID[uid]; known {
+			if dm.Backend != BackendS3 {
+				return nil, errors.Errorf("cache S3 target %s has the identity of storage %d, which is not an S3 target", cfg.DisplayURL(), dm.ID)
+			}
+			id = dm.ID
+			if dm.Directory != cfg.DisplayURL() {
+				log.Infof("Cache S3 target %d (UUID %s) moved: %s → %s", dm.ID, uid, dm.Directory, cfg.DisplayURL())
+			}
+		} else {
+			id = StorageIDFirstDisk
+			for usedIDs[id] {
+				id++
+				if id == 0 {
+					return nil, errors.New("exhausted storage IDs while registering S3 targets")
+				}
+			}
+			log.Infof("Assigned storage ID %d (UUID %s) to cache S3 target %s", id, uid, cfg.DisplayURL())
+		}
+		if err := sm.db.SaveDiskMapping(DiskMapping{ID: id, UUID: uid, Directory: cfg.DisplayURL(), Backend: BackendS3}); err != nil {
+			return nil, errors.Wrapf(err, "failed to save mapping for cache S3 target %s", cfg.DisplayURL())
+		}
+		usedIDs[id] = true
+		target.id = id
+		sm.s3Targets[id] = target
+		result[id] = cfg
+	}
+	return result, nil
+}
+
+// IsS3Backed reports whether the given storage ID is an S3 bucket target.
+func (sm *StorageManager) IsS3Backed(id StorageID) bool {
+	_, ok := sm.s3Targets[id]
+	return ok
+}
+
+// getS3Target returns the S3 target for a storage ID, or nil.
+func (sm *StorageManager) getS3Target(id StorageID) *s3Target {
+	return sm.s3Targets[id]
+}
+
 // Close stops TTL cache eviction goroutines and releases cached resources.
 //
 // Only the caches that were actually started are stopped.  ttlcache's Stop is
@@ -682,6 +808,9 @@ func NewStorageManagerReadOnly(baseDir string, db *CacheDB) (*StorageManager, er
 
 	objDirs := make(map[StorageID]string, len(mappings))
 	for _, dm := range mappings {
+		if dm.Backend != BackendPosix {
+			continue // S3 targets have no local directory
+		}
 		objDirs[dm.ID] = filepath.Join(dm.Directory, objectsSubDir)
 	}
 
@@ -808,7 +937,58 @@ func (sm *StorageManager) getObjectPathForDir(storageID StorageID, instanceHash 
 			break
 		}
 	}
-	return filepath.Join(dir, GetInstanceStoragePath(instanceHash))
+	return containedObjectPath(dir, GetInstanceStoragePath(instanceHash))
+}
+
+// containedObjectPath joins a storage-relative object path onto a storage
+// directory and returns it only if the result stays inside that directory.
+//
+// An instance hash is the hex of an HMAC, so in practice it cannot contain a
+// separator or a "..", and every hash reaching here was produced by
+// ComputeInstanceHash rather than taken from a request.  That is an argument
+// about the callers, though, and it is the sort of argument that quietly stops
+// being true: the hash is derived from a client-supplied URL, it names a path,
+// and a future caller could reasonably pass one from somewhere else -- a
+// bucket listing, a repair tool, a database whose contents are older than the
+// code reading them.  Checking containment here costs one comparison on a path
+// that is about to be opened anyway, and it is the difference between "this
+// cannot escape the cache directory" and "this cannot escape as long as
+// nobody changes how hashes are made".
+//
+// Returns "" when the path would escape, which every os.* call rejects; the
+// caller reports it the same way it reports any other unopenable object.
+func containedObjectPath(dir, relative string) string {
+	if dir == "" {
+		return ""
+	}
+	root := filepath.Clean(dir)
+	full := filepath.Join(root, relative)
+	if full != root && !strings.HasPrefix(full, root+string(os.PathSeparator)) {
+		log.Errorf("Refusing an object path that escapes its storage directory: %q under %q", relative, root)
+		return ""
+	}
+	return full
+}
+
+// storageIsResolvable reports whether a storage ID names something this manager
+// can actually reach: a configured directory, inline storage, or a registered
+// S3 target.
+//
+// An object whose storage ID resolves to none of those must be treated as a
+// miss rather than looked up on disk.  A bucket that has been removed from the
+// configuration leaves its objects' metadata behind pointing at an ID with no
+// directory, and getObjectPathForDir answers for any unknown ID by falling back
+// to an arbitrary directory -- so a read would silently look for the object in
+// the wrong place, and auto-repair could write it there.
+func (sm *StorageManager) storageIsResolvable(storageID StorageID) bool {
+	if storageID == StorageIDInline {
+		return true
+	}
+	if _, ok := sm.dirs[storageID]; ok {
+		return true
+	}
+	_, ok := sm.s3Targets[storageID]
+	return ok
 }
 
 // getObjectPath returns the full filesystem path for an object.
@@ -823,6 +1003,11 @@ func (sm *StorageManager) getObjectPath(instanceHash InstanceHash) string {
 // For chunks 1+, a suffix like "-2", "-3" is appended.
 func (sm *StorageManager) getChunkPath(storageID StorageID, instanceHash InstanceHash, chunkIndex int) string {
 	basePath := sm.getObjectPathForDir(storageID, instanceHash)
+	if basePath == "" {
+		// Rejected by containment; suffixing it would turn an unusable path
+		// back into a usable one.
+		return ""
+	}
 	return GetChunkPath(basePath, chunkIndex)
 }
 
@@ -1428,6 +1613,9 @@ func (sm *StorageManager) checkAndMarkComplete(instanceHash InstanceHash, meta *
 		if err := sm.db.MergeMetadata(instanceHash, completionMeta); err != nil {
 			log.Warnf("Failed to update completion time: %v", err)
 		}
+		if sm.onObjectComplete != nil {
+			sm.onObjectComplete(instanceHash)
+		}
 	}
 }
 
@@ -1888,9 +2076,19 @@ func (sm *StorageManager) Delete(instanceHash InstanceHash) error {
 	}
 	sm.invalidateObjectCaches(instanceHash, chunkCount)
 
-	// If stored on disk, delete all chunk files
-	if meta != nil && meta.IsDisk() {
-		sm.deleteChunkFiles(instanceHash, meta.ContentLength, meta.StorageID, meta.ChunkSizeCode, meta.ChunkLocations)
+	// If stored on an S3 target, delete the bucket object; otherwise
+	// delete all chunk files on disk.
+	if meta != nil {
+		if target := sm.getS3Target(meta.StorageID); target != nil {
+			delCtx, delCancel := context.WithTimeout(context.Background(), s3SweepOpTimeout)
+			err := target.deleteObject(delCtx, instanceHash)
+			delCancel()
+			if err != nil {
+				log.Warnf("Failed to delete %s from S3 target %d (consistency sweep will retry): %v", instanceHash, meta.StorageID, err)
+			}
+		} else if meta.IsDisk() {
+			sm.deleteChunkFiles(instanceHash, meta.ContentLength, meta.StorageID, meta.ChunkSizeCode, meta.ChunkLocations)
+		}
 	}
 
 	return nil
@@ -1971,8 +2169,17 @@ func (sm *StorageManager) EvictByLRU(storageID StorageID, namespaceID NamespaceI
 		// Remove all in-memory cached state for this object.
 		sm.invalidateObjectCaches(obj.instanceHash, CalculateChunkCount(obj.contentLen, obj.chunkSizeCode))
 
-		// Delete all chunk files from disk
-		if obj.storageID != StorageIDInline {
+		// Delete the backing data: bucket object for S3-resident objects,
+		// chunk files on disk otherwise.
+		if target := sm.getS3Target(obj.storageID); target != nil {
+			delCtx, delCancel := context.WithTimeout(context.Background(), s3SweepOpTimeout)
+			err := target.deleteObject(delCtx, obj.instanceHash)
+			delCancel()
+			if err != nil {
+				log.Warnf("Failed to delete evicted object %s from S3 target %d (consistency sweep will retry): %v",
+					obj.instanceHash, obj.storageID, err)
+			}
+		} else if obj.storageID != StorageIDInline {
 			sm.deleteChunkFiles(obj.instanceHash, obj.contentLen, obj.storageID, obj.chunkSizeCode, obj.chunkLocations)
 		}
 	}
@@ -2651,6 +2858,12 @@ func (bw *BlockWriter) Close() error {
 
 		if bw.onComplete != nil {
 			bw.onComplete()
+		}
+
+		// Notify the completion observer (e.g. the S3 uploader) so the
+		// object can be considered for tiering.
+		if bw.sm.onObjectComplete != nil {
+			bw.sm.onObjectComplete(bw.instanceHash)
 		}
 	}
 

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -138,6 +138,11 @@ var runtimeConfigurableMap = map[string]bool{
 	"Cache.PermittedNamespaces": false,
 	"Cache.Port": false,
 	"Cache.RunLocation": false,
+	"Cache.S3DisableRedirect": false,
+	"Cache.S3PresignEvictionHold": false,
+	"Cache.S3PresignExpiry": false,
+	"Cache.S3StorageTargets": false,
+	"Cache.S3UploadThreshold": false,
 	"Cache.SelfTest": false,
 	"Cache.SelfTestInterval": false,
 	"Cache.SelfTestMaxAge": false,
@@ -662,6 +667,7 @@ var stringAccessors = map[string]func(*Config) string{
 	"Cache.NamespaceLocation": func(c *Config) string { return c.Cache.NamespaceLocation },
 	"Cache.PSSOrigin": func(c *Config) string { return c.Cache.PSSOrigin },
 	"Cache.RunLocation": func(c *Config) string { return c.Cache.RunLocation },
+	"Cache.S3UploadThreshold": func(c *Config) string { return c.Cache.S3UploadThreshold },
 	"Cache.SentinelLocation": func(c *Config) string { return c.Cache.SentinelLocation },
 	"Cache.StorageLocation": func(c *Config) string { return c.Cache.StorageLocation },
 	"Cache.Url": func(c *Config) string { return c.Cache.Url },
@@ -1104,6 +1110,7 @@ var boolAccessors = map[string]func(*Config) bool{
 	"Cache.EnableTLSClientAuth": func(c *Config) bool { return c.Cache.EnableTLSClientAuth },
 	"Cache.EnableV2": func(c *Config) bool { return c.Cache.EnableV2 },
 	"Cache.EnableVoms": func(c *Config) bool { return c.Cache.EnableVoms },
+	"Cache.S3DisableRedirect": func(c *Config) bool { return c.Cache.S3DisableRedirect },
 	"Cache.SelfTest": func(c *Config) bool { return c.Cache.SelfTest },
 	"Client.AssumeDirectorServerHeader": func(c *Config) bool { return c.Client.AssumeDirectorServerHeader },
 	"Client.DisableHttpProxy": func(c *Config) bool { return c.Client.DisableHttpProxy },
@@ -1224,6 +1231,8 @@ var durationAccessors = map[string]func(*Config) time.Duration{
 	"Cache.DefaultCacheTimeout": func(c *Config) time.Duration { return c.Cache.DefaultCacheTimeout },
 	"Cache.EvictionMonitoringInterval": func(c *Config) time.Duration { return c.Cache.EvictionMonitoringInterval },
 	"Cache.MinDirectorRefreshInterval": func(c *Config) time.Duration { return c.Cache.MinDirectorRefreshInterval },
+	"Cache.S3PresignEvictionHold": func(c *Config) time.Duration { return c.Cache.S3PresignEvictionHold },
+	"Cache.S3PresignExpiry": func(c *Config) time.Duration { return c.Cache.S3PresignExpiry },
 	"Cache.SelfTestInterval": func(c *Config) time.Duration { return c.Cache.SelfTestInterval },
 	"Cache.SelfTestMaxAge": func(c *Config) time.Duration { return c.Cache.SelfTestMaxAge },
 	"Cache.Throttle.EMAWindow": func(c *Config) time.Duration { return c.Cache.Throttle.EMAWindow },
@@ -1446,6 +1455,11 @@ var allParameterNames = []string{
 	"Cache.PermittedNamespaces",
 	"Cache.Port",
 	"Cache.RunLocation",
+	"Cache.S3DisableRedirect",
+	"Cache.S3PresignEvictionHold",
+	"Cache.S3PresignExpiry",
+	"Cache.S3StorageTargets",
+	"Cache.S3UploadThreshold",
 	"Cache.SelfTest",
 	"Cache.SelfTestInterval",
 	"Cache.SelfTestMaxAge",
@@ -1943,6 +1957,7 @@ var (
 	Cache_NamespaceLocation = StringParam{"Cache.NamespaceLocation"}
 	Cache_PSSOrigin = StringParam{"Cache.PSSOrigin"}
 	Cache_RunLocation = StringParam{"Cache.RunLocation"}
+	Cache_S3UploadThreshold = StringParam{"Cache.S3UploadThreshold"}
 	Cache_SentinelLocation = StringParam{"Cache.SentinelLocation"}
 	Cache_StorageLocation = StringParam{"Cache.StorageLocation"}
 	Cache_Url = StringParam{"Cache.Url"}
@@ -2264,6 +2279,7 @@ var (
 	Cache_EnableTLSClientAuth = BoolParam{"Cache.EnableTLSClientAuth"}
 	Cache_EnableV2 = BoolParam{"Cache.EnableV2"}
 	Cache_EnableVoms = BoolParam{"Cache.EnableVoms"}
+	Cache_S3DisableRedirect = BoolParam{"Cache.S3DisableRedirect"}
 	Cache_SelfTest = BoolParam{"Cache.SelfTest"}
 	Client_AssumeDirectorServerHeader = BoolParam{"Client.AssumeDirectorServerHeader"}
 	Client_DisableHttpProxy = BoolParam{"Client.DisableHttpProxy"}
@@ -2356,6 +2372,8 @@ var (
 	Cache_DefaultCacheTimeout = DurationParam{"Cache.DefaultCacheTimeout"}
 	Cache_EvictionMonitoringInterval = DurationParam{"Cache.EvictionMonitoringInterval"}
 	Cache_MinDirectorRefreshInterval = DurationParam{"Cache.MinDirectorRefreshInterval"}
+	Cache_S3PresignEvictionHold = DurationParam{"Cache.S3PresignEvictionHold"}
+	Cache_S3PresignExpiry = DurationParam{"Cache.S3PresignExpiry"}
 	Cache_SelfTestInterval = DurationParam{"Cache.SelfTestInterval"}
 	Cache_SelfTestMaxAge = DurationParam{"Cache.SelfTestMaxAge"}
 	Cache_Throttle_EMAWindow = DurationParam{"Cache.Throttle.EMAWindow"}
@@ -2450,6 +2468,7 @@ var (
 )
 
 var (
+	Cache_S3StorageTargets = ObjectParam{"Cache.S3StorageTargets"}
 	GeoIPOverrides = ObjectParam{"GeoIPOverrides"}
 	Issuer_AuthorizationTemplates = ObjectParam{"Issuer.AuthorizationTemplates"}
 	Issuer_OIDCAuthenticationRequirements = ObjectParam{"Issuer.OIDCAuthenticationRequirements"}
@@ -2496,6 +2515,7 @@ func init() {
 		"Cache.NamespaceLocation": Cache_NamespaceLocation,
 		"Cache.PSSOrigin": Cache_PSSOrigin,
 		"Cache.RunLocation": Cache_RunLocation,
+		"Cache.S3UploadThreshold": Cache_S3UploadThreshold,
 		"Cache.SentinelLocation": Cache_SentinelLocation,
 		"Cache.StorageLocation": Cache_StorageLocation,
 		"Cache.Url": Cache_Url,
@@ -2805,6 +2825,7 @@ func init() {
 		"Cache.EnableTLSClientAuth": Cache_EnableTLSClientAuth,
 		"Cache.EnableV2": Cache_EnableV2,
 		"Cache.EnableVoms": Cache_EnableVoms,
+		"Cache.S3DisableRedirect": Cache_S3DisableRedirect,
 		"Cache.SelfTest": Cache_SelfTest,
 		"Client.AssumeDirectorServerHeader": Client_AssumeDirectorServerHeader,
 		"Client.DisableHttpProxy": Client_DisableHttpProxy,
@@ -2894,6 +2915,8 @@ func init() {
 		"Cache.DefaultCacheTimeout": Cache_DefaultCacheTimeout,
 		"Cache.EvictionMonitoringInterval": Cache_EvictionMonitoringInterval,
 		"Cache.MinDirectorRefreshInterval": Cache_MinDirectorRefreshInterval,
+		"Cache.S3PresignEvictionHold": Cache_S3PresignEvictionHold,
+		"Cache.S3PresignExpiry": Cache_S3PresignExpiry,
 		"Cache.SelfTestInterval": Cache_SelfTestInterval,
 		"Cache.SelfTestMaxAge": Cache_SelfTestMaxAge,
 		"Cache.Throttle.EMAWindow": Cache_Throttle_EMAWindow,
@@ -2985,6 +3008,7 @@ func init() {
 		"Xrootd.HttpMaxDelay": Xrootd_HttpMaxDelay,
 		"Xrootd.MaxStartupWait": Xrootd_MaxStartupWait,
 		"Xrootd.ShutdownTimeout": Xrootd_ShutdownTimeout,
+		"Cache.S3StorageTargets": Cache_S3StorageTargets,
 		"GeoIPOverrides": GeoIPOverrides,
 		"Issuer.AuthorizationTemplates": Issuer_AuthorizationTemplates,
 		"Issuer.OIDCAuthenticationRequirements": Issuer_OIDCAuthenticationRequirements,

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -68,6 +68,11 @@ type Config struct {
 		PermittedNamespaces []string `mapstructure:"permittednamespaces" yaml:"PermittedNamespaces"`
 		Port int `mapstructure:"port" yaml:"Port"`
 		RunLocation string `mapstructure:"runlocation" yaml:"RunLocation"`
+		S3DisableRedirect bool `mapstructure:"s3disableredirect" yaml:"S3DisableRedirect"`
+		S3PresignEvictionHold time.Duration `mapstructure:"s3presignevictionhold" yaml:"S3PresignEvictionHold"`
+		S3PresignExpiry time.Duration `mapstructure:"s3presignexpiry" yaml:"S3PresignExpiry"`
+		S3StorageTargets any `mapstructure:"s3storagetargets" yaml:"S3StorageTargets"`
+		S3UploadThreshold string `mapstructure:"s3uploadthreshold" yaml:"S3UploadThreshold"`
 		SelfTest bool `mapstructure:"selftest" yaml:"SelfTest"`
 		SelfTestInterval time.Duration `mapstructure:"selftestinterval" yaml:"SelfTestInterval"`
 		SelfTestMaxAge time.Duration `mapstructure:"selftestmaxage" yaml:"SelfTestMaxAge"`
@@ -657,6 +662,11 @@ type configWithType struct {
 		PermittedNamespaces struct { Type string; Value []string }
 		Port struct { Type string; Value int }
 		RunLocation struct { Type string; Value string }
+		S3DisableRedirect struct { Type string; Value bool }
+		S3PresignEvictionHold struct { Type string; Value time.Duration }
+		S3PresignExpiry struct { Type string; Value time.Duration }
+		S3StorageTargets struct { Type string; Value any }
+		S3UploadThreshold struct { Type string; Value string }
 		SelfTest struct { Type string; Value bool }
 		SelfTestInterval struct { Type string; Value time.Duration }
 		SelfTestMaxAge struct { Type string; Value time.Duration }

--- a/web_ui/frontend/components/configuration/Fields/Field.tsx
+++ b/web_ui/frontend/components/configuration/Fields/Field.tsx
@@ -23,6 +23,8 @@ import {
   ParameterInputProps,
   PolicyDefinition,
   PolicyDefinitionForm,
+  S3StorageTarget,
+  S3StorageTargetForm,
   StorageDir,
   StorageDirForm,
   StringField,
@@ -223,6 +225,17 @@ const Field = ({
               value={value as StorageDir[]}
               Form={StorageDirForm}
               keyGetter={(v) => v.path}
+            />
+          );
+        case 'S3StorageTargets':
+          return (
+            <ObjectField
+              focused={focused}
+              onChange={handleChange<S3StorageTarget[]>}
+              name={name}
+              value={value as S3StorageTarget[]}
+              Form={S3StorageTargetForm}
+              keyGetter={(v) => v.serviceurl + '/' + v.bucket}
             />
           );
         default:

--- a/web_ui/frontend/components/configuration/Fields/ObjectField/S3StorageTargetForm.tsx
+++ b/web_ui/frontend/components/configuration/Fields/ObjectField/S3StorageTargetForm.tsx
@@ -1,0 +1,123 @@
+import {
+  FormProps,
+  IntegerField,
+  S3StorageTarget,
+  StringField,
+} from '@/components/configuration';
+import React, { useCallback } from 'react';
+import { Box, Button } from '@mui/material';
+
+const verifyForm = (x: S3StorageTarget) => {
+  return x.serviceurl != '' && x.bucket != '' && x.maxsize != '';
+};
+
+const createDefaultS3StorageTarget = (): S3StorageTarget => {
+  return {
+    serviceurl: '',
+    region: '',
+    bucket: '',
+    prefix: '',
+    urlstyle: '',
+    accesskeyfile: '',
+    secretkeyfile: '',
+    maxsize: '',
+    highwatermarkpercentage: 0,
+    lowwatermarkpercentage: 0,
+  };
+};
+
+const S3StorageTargetForm = ({
+  onSubmit,
+  value,
+}: FormProps<S3StorageTarget>) => {
+  const [target, setTarget] = React.useState<S3StorageTarget>(
+    value || createDefaultS3StorageTarget()
+  );
+
+  const submitHandler = useCallback(() => {
+    if (!verifyForm(target)) {
+      return;
+    }
+    onSubmit(target);
+  }, [target, onSubmit]);
+
+  return (
+    <>
+      <Box my={2}>
+        <StringField
+          name={'ServiceUrl'}
+          onChange={(e) => setTarget({ ...target, serviceurl: e })}
+          value={target.serviceurl}
+        />
+      </Box>
+      <Box mb={2}>
+        <StringField
+          name={'Region'}
+          onChange={(e) => setTarget({ ...target, region: e })}
+          value={target.region}
+        />
+      </Box>
+      <Box mb={2}>
+        <StringField
+          name={'Bucket'}
+          onChange={(e) => setTarget({ ...target, bucket: e })}
+          value={target.bucket}
+        />
+      </Box>
+      <Box mb={2}>
+        <StringField
+          name={'Prefix'}
+          onChange={(e) => setTarget({ ...target, prefix: e })}
+          value={target.prefix}
+        />
+      </Box>
+      <Box mb={2}>
+        <StringField
+          name={'UrlStyle'}
+          onChange={(e) => setTarget({ ...target, urlstyle: e })}
+          value={target.urlstyle}
+        />
+      </Box>
+      <Box mb={2}>
+        <StringField
+          name={'AccessKeyfile'}
+          onChange={(e) => setTarget({ ...target, accesskeyfile: e })}
+          value={target.accesskeyfile}
+        />
+      </Box>
+      <Box mb={2}>
+        <StringField
+          name={'SecretKeyfile'}
+          onChange={(e) => setTarget({ ...target, secretkeyfile: e })}
+          value={target.secretkeyfile}
+        />
+      </Box>
+      <Box mb={2}>
+        <StringField
+          name={'MaxSize'}
+          onChange={(e) => setTarget({ ...target, maxsize: e })}
+          value={target.maxsize}
+        />
+      </Box>
+      <Box mb={2}>
+        <IntegerField
+          name={'HighWaterMarkPercentage'}
+          onChange={(e) => setTarget({ ...target, highwatermarkpercentage: e })}
+          value={target.highwatermarkpercentage}
+        />
+      </Box>
+      <Box mb={2}>
+        <IntegerField
+          name={'LowWaterMarkPercentage'}
+          onChange={(e) => setTarget({ ...target, lowwatermarkpercentage: e })}
+          value={target.lowwatermarkpercentage}
+        />
+      </Box>
+      <Button type={'submit'} onClick={submitHandler}>
+        Submit
+      </Button>
+    </>
+  );
+};
+
+export default S3StorageTargetForm;

--- a/web_ui/frontend/components/configuration/Fields/ObjectField/index.tsx
+++ b/web_ui/frontend/components/configuration/Fields/ObjectField/index.tsx
@@ -11,6 +11,7 @@ import PathForm from './PathForm';
 import AuthorizationTemplateForm from './AuthorizationTemplateForm';
 import PolicyDefinitionForm from './PolicyDefinitionForm';
 import StorageDirForm from './StorageDirForm';
+import S3StorageTargetForm from './S3StorageTargetForm';
 
 export {
   AuthorizationTemplateForm,
@@ -25,4 +26,5 @@ export {
   PathForm,
   PolicyDefinitionForm,
   StorageDirForm,
+  S3StorageTargetForm,
 };

--- a/web_ui/frontend/components/configuration/Fields/index.ts
+++ b/web_ui/frontend/components/configuration/Fields/index.ts
@@ -54,7 +54,8 @@ export type ParameterValue =
   | GeoIPOverride[]
   | Export[]
   | PolicyDefinition[]
-  | StorageDir[];
+  | StorageDir[]
+  | S3StorageTarget[];
 
 export type ParameterValueRecord = { [key: string]: ParameterValue };
 
@@ -149,6 +150,19 @@ export interface Export {
 
 export interface StorageDir {
   path: string;
+  maxsize: string;
+  highwatermarkpercentage: number;
+  lowwatermarkpercentage: number;
+}
+
+export interface S3StorageTarget {
+  serviceurl: string;
+  region: string;
+  bucket: string;
+  prefix: string;
+  urlstyle: string;
+  accesskeyfile: string;
+  secretkeyfile: string;
   maxsize: string;
   highwatermarkpercentage: number;
   lowwatermarkpercentage: number;


### PR DESCRIPTION
## Summary

Adds a new kind of storage target to the V2 (persistent) cache: an **S3 bucket**. Completed objects at or above a size threshold are tiered from local disk to the bucket, after which the cache serves them by redirecting clients to a pre-signed S3 URL (or proxying, when that would be unsafe or is disabled). This lets a cache spill its working set to cheap object storage while keeping in-progress downloads on fast local disk.

## Design

- **S3 buckets as storage IDs** — each bucket is registered as a `StorageID` with identity persisted via an object in the bucket (the S3 analogue of the `.pelican-cache-id` UUID files). Buckets participate in usage accounting, LRU tracking, watermark-driven eviction, and the consistency machinery, but are excluded from new-object placement.
- **Tiering on completion** — once an object is complete and ≥ `Cache.S3UploadThreshold` (default 4MB), upload workers (default 4) stream it decrypted to the bucket, choosing a target weighted by free space. An `up:<hash>` BadgerDB intent covers the bucket bytes until they are accounted for elsewhere; it also records when the relocation committed, which is what lets crash recovery distinguish "the upload never finished, reclaim it" from "the object was deleted after it landed, leave the bucket accounting alone". Relocation flattens chunked objects onto the single bucket blob and moves the LRU entry; the local copy is then released and every directory that held a chunk is refunded — **unless a reader is still working from it**, in which case the release is deferred rather than pulling files out from under an in-flight transfer.
- **Serving** — redirect by default; proxy through a seekable ranged-GetObject stream when `Cache.S3DisableRedirect` is set, when the object is stale, or when the request carries credentials a redirect would disclose (see below). Either way the object is protected while it is served: redirects stamp a debounced `ps:<hash>` eviction hold guaranteed to outlast the URL, and proxied reads hold a reader pin. A client revalidating with an ETag gets a 304 instead of being sent to re-download from the bucket.
- **Eviction** — a namespace whose LRU head is entirely in use (open readers, or objects under a presign hold) is skipped and the next-greediest namespace is tried, so a held namespace cannot stop a bucket from draining.
- **Consistency** — an hourly sweep merge-joins the hash-ordered bucket listing against metadata, deleting orphans in both directions (bounded per pass, each S3 request time-limited); the metadata/data scans skip S3-resident entries they'd otherwise misclassify.

## Security properties

The pre-signed URL is self-authenticating and never carries the Pelican bearer token, and a `?authz=`-delivered token is not propagated into the `Location` (`http.Redirect` only rewrites the query for relative targets). The remaining vector is the `Authorization` header, which a compliant client drops only when the destination is outside the domain it connected to — note this is Go's *domain-or-subdomain* rule, so an S3 endpoint like `s3.cache.example.org` beside a cache on `cache.example.org` **would** keep the header. The cache detects that per request and proxies instead of redirecting, and warns at startup. `Cache.S3DisableRedirect` remains for clients that forward `Authorization` even across unrelated hosts, contrary to spec.

Tiered objects are stored **plaintext** and verified **by size only**, unlike local blocks which are AES-GCM sealed and authenticated on read. The parameter documentation now states this explicitly: bucket read access discloses every tiered object (including from token-protected namespaces), bucket write access permits undetected same-length substitution, and the data-integrity scan does not checksum tiered objects. Operators are pointed at least-privilege credentials, a private bucket, an `https` endpoint, SSE, and versioning/object-lock.

Bytes served by redirect do not pass through the cache and are therefore **not counted in transfer monitoring** — an accepted trade-off, documented on `Cache.S3DisableRedirect`.

## Schema version

Bumped to 2. Nothing needs rewriting to read a version-1 database, but a version-1 binary must not open a version-2 one: it predates the rule that a non-POSIX storage mapping is never recycled, so it would hand an S3 target's storage ID to a local directory and take every tiered object's metadata with it. The bump turns that silent data loss into a startup error.

## New configuration

`Cache.S3StorageTargets` (object list; configurable via the web UI), `Cache.S3UploadThreshold`, `Cache.S3DisableRedirect`, `Cache.S3PresignExpiry`, `Cache.S3PresignEvictionHold`.

## Testing

minio-backed `local_cache` tests cover the tiering lifecycle, multi-directory chunked-object migration, the LRU-entry move, deferring release while a reader is open, both post-relocation recovery branches (the accounting cases), concurrent workers racing one object, presign-hold eviction protection including draining past a held namespace, the redirect/proxy handler paths, and the Authorization-retention rule as a table (subdomain and virtual-host-bucket forms included). `TestCacheS3StorageFederationE2E` exercises a full federation spin-up (director, registry, origin, V2 cache) against live minio, end to end through director → cache → pre-signed URL, plus proxy mode and range requests.

Uses aws-sdk-go-v2 (already a dependency via the s3v2 origin backend); the presign client and upload manager add no new modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
