### PR TITLE
client: fix segfault in NewTransferJob (nil named-return read from a detached director loader)

### DIFF
--- a/client/dir_resp_cache_test.go
+++ b/client/dir_resp_cache_test.go
@@ -659,3 +659,59 @@ func TestDirRespCacheCredentialScoping(t *testing.T) {
 		assert.Empty(t, base.WithCredential("").Credential, "no token means no credential scoping")
 	})
 }
+
+// TestLookupOrLoadLoaderOutlivesCancelledCaller pins the property that makes
+// what a loader closes over matter.
+//
+// LookupOrLoad runs its loader on a goroutine with cancellation detached, so a
+// caller that gives up does not waste a query other waiters want. The
+// consequence is that the loader can still be running after the call that
+// created it has returned -- so anything it reads must be a value snapshotted
+// beforehand, never a field of a variable the caller may since have
+// reassigned. NewTransferJob's `tj` is a named return, and a nil-returning
+// error path there once turned exactly this into a segfault.
+//
+// If someone later makes the loader inherit the caller's cancellation, this
+// test fails and the hazard is gone; if they keep the detachment, it stays
+// documented.
+func TestLookupOrLoadLoaderOutlivesCancelledCaller(t *testing.T) {
+	cache := NewDirRespCache(5 * time.Minute)
+
+	loaderStarted := make(chan struct{})
+	release := make(chan struct{})
+	loaderFinished := make(chan struct{})
+	var loaderCtxErr error
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		_, _ = cache.LookupOrLoad(ctx, testFederation, testFlavor, "/outlive/file.txt",
+			func(loaderCtx context.Context) (server_structs.DirectorResponse, string, error) {
+				close(loaderStarted)
+				<-release
+				// Recorded rather than asserted here: this runs on a
+				// different goroutine than the test body.
+				loaderCtxErr = loaderCtx.Err()
+				close(loaderFinished)
+				return makeDirResp("/outlive"), "/outlive", nil
+			})
+	}()
+
+	<-loaderStarted
+	// The originating caller gives up while the loader is mid-flight.
+	cancel()
+	close(release)
+
+	select {
+	case <-loaderFinished:
+	case <-time.After(10 * time.Second):
+		t.Fatal("loader did not run to completion after its caller was cancelled")
+	}
+
+	assert.NoError(t, loaderCtxErr,
+		"the loader's context must not be cancelled along with its caller's")
+
+	// And the work it did is still usable by everyone else.
+	resp, ok := cache.Lookup(testFederation, testFlavor, "/outlive/file.txt")
+	assert.True(t, ok, "the completed load should have been stored")
+	assert.NotNil(t, resp)
+}

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2163,7 +2163,17 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 	// rejection carrying token hints has something to acquire onto.
 	directorless := copyUrl.FedInfo.DirectorEndpoint == "" && copyUrl.FedInfo.DiscoveryEndpoint != ""
 	copyUrlRef := &copyUrl
-	dirFlavor := NewDirRespFlavor(httpMethod, tj.cacheMode, copyUrl.RawQuery)
+	// Snapshot the routing mode for the director loaders below rather than
+	// reading it off tj inside them. Those loaders run on a goroutine that
+	// DirRespCache.LookupOrLoad deliberately lets outlive this call -- it
+	// detaches cancellation so a caller that goes away does not waste the
+	// query other waiters are relying on -- while tj is this function's
+	// *named return*. Every `return nil, err` below therefore assigns nil to
+	// the very variable such a goroutine would be dereferencing, and
+	// tj.cacheMode on a nil tj is a segfault at offset 0x318 rather than a
+	// read of `false`.
+	cacheMode := tj.cacheMode
+	dirFlavor := NewDirRespFlavor(httpMethod, cacheMode, copyUrl.RawQuery)
 	// A download against a directorless federation resolves locally and pays no
 	// round trip: it addresses the object to the host the user named and lets
 	// the origin's own rejection say what credential the namespace wants.  An
@@ -2173,7 +2183,7 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 		dirResp, err = resolveForRequest(tj.ctx, &copyUrl, httpMethod, "", tj.cacheMode)
 	} else if tc.engine != nil && tc.engine.dirRespCache != nil {
 		dirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, copyUrl.FedInfo.DiscoveryEndpoint, dirFlavor, copyUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
-			resp, qErr := getDirectorInfoForPath(ctx, copyUrlRef, httpMethod, "", tj.cacheMode)
+			resp, qErr := getDirectorInfoForPath(ctx, copyUrlRef, httpMethod, "", cacheMode)
 			return resp, resp.XPelNsHdr.Namespace, qErr
 		})
 	} else {
@@ -2239,7 +2249,7 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 			authFlavor := dirFlavor.WithCredential(contents)
 			if tc.engine != nil && tc.engine.dirRespCache != nil {
 				dirResp, err = tc.engine.dirRespCache.LookupOrLoad(tj.ctx, copyUrl.FedInfo.DiscoveryEndpoint, authFlavor, copyUrl.Path, func(ctx context.Context) (server_structs.DirectorResponse, string, error) {
-					resp, qErr := getDirectorInfoForPath(ctx, copyUrlRef, httpMethod, contents, tj.cacheMode)
+					resp, qErr := getDirectorInfoForPath(ctx, copyUrlRef, httpMethod, contents, cacheMode)
 					return resp, resp.XPelNsHdr.Namespace, qErr
 				})
 			} else {


### PR DESCRIPTION
**`main` is currently segfaulting in the client, and it's my fault — this is a regression I introduced in #3655.** Sorry.

### What happens

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x318]

goroutine 1636 [running]:
client.(*TransferClient).NewTransferJob.func2(...)
    client/handle_http.go:2242
client.(*DirRespCache).LookupOrLoad.func1()
    client/dir_resp_cache.go:371
created by client.(*DirRespCache).LookupOrLoad in goroutine 1619
    client/dir_resp_cache.go:369
```

Three things have to line up, and after #3655 they do:

1. `NewTransferJob` declares its result as a **named return** — `(tj *TransferJob, err error)` — so every `return nil, err` in it *assigns nil to `tj`*.
2. `DirRespCache.LookupOrLoad` runs its loader on a goroutine with cancellation detached (`context.WithoutCancel`), deliberately, so a caller that gives up doesn't waste a query other waiters are blocked on. The loader can therefore still be running after `NewTransferJob` has returned.
3. Two of those loaders read `tj.cacheMode` — a field of the variable step 1 may have just set to nil.

Reading `tj.cacheMode` off a nil `tj` isn't a read of `false`, it's a segfault. `unsafe.Offsetof(TransferJob.cacheMode)` is **`0x318`**, which is exactly the faulting address in every instance, so there's no ambiguity about which dereference it was.

It surfaces as `client_agent/apiclient TestAPIClientJobStatus` and `TestAPIClientCreateJob` dying during teardown — where a cancelled caller and an in-flight loader most easily overlap. Both are failing on `main` now (runs 32584310059 and 32584615683, after #3655 merged at 16:18Z), and neither failed before it.

### The fix

Snapshot the value into a local before the loaders, which is what this code did until I replaced the local with a field read in 1e2dccaa. The loaders now close over a value no error path can reassign.

That commit's diff shows the regression plainly — it deleted the `cacheMode := tj.cacheMode` line and swapped `cacheMode` for `tj.cacheMode` *inside* the closure. The pre-existing code was right and I made it worse while moving the flavor construction around.

Only these two loaders were affected; the others in `NewPrestageJob` and `NewCopyJob` pass literals or already-snapshotted values, not `tj` fields.

### Testing

`TestLookupOrLoadLoaderOutlivesCancelledCaller` pins the precondition rather than the symptom: it starts a loader, cancels the originating caller mid-flight, and asserts the loader still runs to completion, that its own context is *not* cancelled with the caller's, and that its result is still stored for everyone else. That's the property that makes snapshotting mandatory, so the reason won't have to be rediscovered — and if someone later makes loaders inherit caller cancellation, the test fails and says the hazard is gone.

The existing `DirRespCache` suite passes.

**I could not reproduce the panic locally**, and I want to be clear about that rather than imply otherwise: it needs a loader in flight at the moment an error path fires, and the `client_agent` fed tests fail on this machine for unrelated environment reasons (~30s timeouts, no XRootD plugin env). The diagnosis rests on the stack trace, the named-return/`WithoutCancel` interaction, and the offset matching the faulting address exactly — not on a local repro. CI is the check.
