### PR TITLE
client: storage.modify for overwriting uploads, plus two PelicanFS fixes

### DIFF
--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -456,6 +456,7 @@ type (
 	identTransferOptionSourceTokenProvider      struct{}
 	identTransferOptionNonInteractive           struct{}
 	identTransferOptionStatUploadDestination    struct{}
+	identTransferOptionLazyStat                 struct{}
 	identTransferOptionRejectCollections        struct{}
 	identTransferOptionObjectMetadata           struct{}
 	identTransferOptionObjectMetadataFile       struct{}
@@ -1208,6 +1209,21 @@ func WithDestinationToken(token string) TransferOption {
 // no-op; for put operations it behaves identically to WithTokenLocation.
 func WithDestinationTokenLocation(location string) TransferOption {
 	return option.New(identTransferOptionDestinationTokenLocation{}, location)
+}
+
+// WithLazyStat defers the metadata lookup a read-mode OpenFile would
+// otherwise perform before returning the handle. A reader that only asks for
+// byte ranges never needs the object's size: end-of-file arrives as the
+// server's own 416, and the operations that do need a size (Stat, Seek from
+// the end, ReadDir) fetch one on demand.
+//
+// This trades a fail-fast open for a round trip per open. A caller reading
+// many objects it already knows exist -- a filesystem walking its own block
+// store, say -- wants that trade; one that opens a path a user typed
+// probably does not. PelicanFS.Open ignores this option and always stats,
+// because io/fs requires opening a missing file to fail.
+func WithLazyStat(enable bool) TransferOption {
+	return option.New(identTransferOptionLazyStat{}, enable)
 }
 
 // WithStatUploadDestination tells DoStat that the path being stat'ed is the

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2038,6 +2038,19 @@ func (te *TransferEngine) runJobHandler() error {
 	}
 }
 
+// uploadTokenOperation returns the token operation used when acquiring a
+// credential for an upload. By default only object creation is needed
+// (storage.create); when Client.EnableOverwrites is set, an upload may
+// replace an existing object — an action that causes data loss and therefore
+// requires storage.modify, requested via the delete operation bit.
+func uploadTokenOperation() config.TokenOperation {
+	operation := config.TokenWrite
+	if param.Client_EnableOverwrites.GetBool() {
+		operation.Set(config.TokenDelete)
+	}
+	return operation
+}
+
 // Create a new transfer job for the client
 //
 // The returned object can be further customized as desired.
@@ -2062,7 +2075,7 @@ func (tc *TransferClient) NewTransferJob(ctx context.Context, remoteUrl *url.URL
 	}
 	operation := config.TokenRead
 	if upload {
-		operation = config.TokenWrite
+		operation = uploadTokenOperation()
 	}
 	tj = &TransferJob{
 		prefObjServers: tc.prefObjServers,

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -3788,9 +3788,23 @@ func downloadObject(transfer *transferFile) (transferResults TransferResults, er
 		fileWriter = io.Discard
 	}
 
-	// Close the custom writer at the end if provided
+	// Close the custom writer at the end if provided. A pipe-backed writer
+	// (WithWriter — the io/fs read path) must learn about a failed transfer
+	// at Read time: a plain Close hands the reader a clean EOF, and a
+	// failed download becomes indistinguishable from an empty object (the
+	// error only surfaces through the results channel, which the reader may
+	// race). CloseWithError propagates the failure into the reader's Read;
+	// with a nil error it behaves exactly like Close.
 	if fileCloser != nil {
 		defer func() {
+			xferErr := err
+			if xferErr == nil && transferResults.Error != nil {
+				xferErr = transferResults.Error
+			}
+			if cwe, ok := fileCloser.(interface{ CloseWithError(error) error }); ok {
+				_ = cwe.CloseWithError(xferErr)
+				return
+			}
 			if closeErr := fileCloser.Close(); closeErr != nil && err == nil {
 				err = closeErr
 			}

--- a/client/main.go
+++ b/client/main.go
@@ -229,7 +229,9 @@ func stat(ctx context.Context, te *TransferEngine, destination string, options .
 	// the caller's write credential to every cache in the response.
 	directorMethod, tokenOperation := http.MethodGet, config.TokenRead
 	if uploadDestination {
-		directorMethod, tokenOperation = http.MethodPut, config.TokenWrite
+		// Use the upload operation so the credential acquired (and cached)
+		// here carries the same scopes the subsequent PUT will need.
+		directorMethod, tokenOperation = http.MethodPut, uploadTokenOperation()
 	}
 
 	// Reuse the engine's director responses the way job creation does, when

--- a/client/pelican_fs.go
+++ b/client/pelican_fs.go
@@ -82,16 +82,51 @@ func (pfs *PelicanFS) Engine() *TransferEngine {
 	return pfs.transferEngine
 }
 
+// ensureFileInfo fetches and memoizes the object's metadata for the
+// operations that cannot answer without it -- Stat, Seek from the end, and
+// ReadDir. With an eager stat this has already happened at open time; with
+// WithLazyStat it happens here, on the first operation that actually needs a
+// size, and not at all for a reader that only asks for byte ranges.
+func (pf *PelicanFile) ensureFileInfoLocked() (*FileInfo, error) {
+	if pf.fileInfo != nil {
+		return pf.fileInfo, nil
+	}
+	if pf.statErr != nil {
+		return nil, pf.statErr
+	}
+	fi, err := statHttp(pf.ctx, pf.pUrl, pf.dirResp, pf.token, nil)
+	if err != nil {
+		pf.statErr = err
+		return nil, err
+	}
+	pf.fileInfo = &fi
+	return pf.fileInfo, nil
+}
+
 // Open opens the named file for reading and returns a fs.File that also
 // implements io.ReaderAt, io.Seeker, io.Writer (for write mode), and
 // fs.ReadDirFile (for directories).
 func (pfs *PelicanFS) Open(name string) (fs.File, error) {
-	return pfs.OpenFile(name, os.O_RDONLY)
+	// io/fs requires that opening a nonexistent file returns an error, so
+	// this entry point always stats even when the filesystem was built with
+	// WithLazyStat. Callers that want the deferred behavior ask for it by
+	// name, through OpenFile.
+	return pfs.openFile(name, os.O_RDONLY, false)
 }
 
 // OpenFile opens the named file with specified flags.
 // Supported flags: os.O_RDONLY, os.O_WRONLY, os.O_RDWR, os.O_CREATE
 func (pfs *PelicanFS) OpenFile(name string, flag int) (fs.File, error) {
+	lazy := false
+	for _, o := range pfs.options {
+		if o.Ident() == (identTransferOptionLazyStat{}) {
+			lazy = o.Value().(bool)
+		}
+	}
+	return pfs.openFile(name, flag, lazy)
+}
+
+func (pfs *PelicanFS) openFile(name string, flag int, lazyStat bool) (fs.File, error) {
 	// Strip leading slash if present (fs.ValidPath requires unrooted paths)
 	cleanName := name
 	if len(name) > 0 && name[0] == '/' {
@@ -173,8 +208,14 @@ func (pfs *PelicanFS) OpenFile(name string, flag int) (fs.File, error) {
 
 	// Stat the file for reads (writes may create new file)
 	// For O_RDWR, try to stat first. If file doesn't exist, switch to write-only mode.
+	//
+	// A deferred stat is only offered for a plain read: O_RDWR decides
+	// between reading and creating on the strength of this answer, so it
+	// still asks. The handle a deferred open returns has asked nobody
+	// anything -- whether the object is there is settled by the first read.
+	lazyStat = lazyStat && !rdwrMode
 	var fileInfo *FileInfo
-	if readMode {
+	if readMode && !lazyStat {
 		fi, err := statHttp(pfs.ctx, pUrl, dirResp, token, nil)
 		if err != nil {
 			if rdwrMode {
@@ -241,6 +282,7 @@ func (pfs *PelicanFS) OpenFile(name string, flag int) (fs.File, error) {
 		writeMode:      writeMode,
 		rdwrMutex:      flag&os.O_RDWR != 0,
 		shouldShutdown: true,
+		lazyStat:       lazyStat,
 	}
 
 	return pf, nil
@@ -254,10 +296,15 @@ func (pfs *PelicanFS) OpenFile(name string, flag int) (fs.File, error) {
 // Functions with "Locked" suffix must be called with mu held.
 type PelicanFile struct {
 	// Immutable fields (safe to access without lock after construction)
-	ctx             context.Context
-	name            string
-	pUrl            *pelican_url.PelicanURL
-	fileInfo        *FileInfo
+	ctx      context.Context
+	name     string
+	pUrl     *pelican_url.PelicanURL
+	fileInfo *FileInfo
+	// statErr remembers a failed deferred stat so the operations that need
+	// one do not re-ask on every call.
+	statErr error
+	// lazyStat defers the metadata fetch until an operation needs it.
+	lazyStat        bool
 	options         []TransferOption
 	transferClient  *TransferClient
 	dirResp         server_structs.DirectorResponse
@@ -476,6 +523,28 @@ func (pf *PelicanFile) doRangeRead(p []byte, offset int64) (int, error) {
 
 		// Check status code
 		if resp.StatusCode != http.StatusPartialContent && resp.StatusCode != http.StatusOK {
+			if resp.StatusCode == http.StatusNotFound {
+				// Absence is a fact about the object, not a failure of this
+				// endpoint, but another server may still hold it -- so note
+				// it and keep trying. If every server agrees, the wrapped
+				// error below still satisfies errors.Is(err, fs.ErrNotExist),
+				// which is what tells a caller (a filesystem checking its
+				// own block store, say) that the object is gone rather than
+				// momentarily unreachable. With an eager stat this arrived
+				// at open time; a deferred open learns it here.
+				resp.Body.Close()
+				lastErr = errors.Wrapf(fs.ErrNotExist, "object not found at %s", objServer.String())
+				continue
+			}
+			if resp.StatusCode == http.StatusRequestedRangeNotSatisfiable {
+				// The range starts at or past the end of the object. That is
+				// end-of-file, not a failure, and it is how a reader learns
+				// where the end is when no stat established the size up
+				// front. Trying the remaining servers would only collect the
+				// same answer.
+				resp.Body.Close()
+				return 0, io.EOF
+			}
 			lastErr = errors.Errorf("unexpected status code: %d", resp.StatusCode)
 			continue
 		}
@@ -624,10 +693,11 @@ func (pf *PelicanFile) Seek(offset int64, whence int) (int64, error) {
 	case io.SeekCurrent:
 		newPos = pf.position + offset
 	case io.SeekEnd:
-		if pf.fileInfo == nil {
-			return 0, &fs.PathError{Op: "seek", Path: pf.name, Err: errors.New("cannot seek from end without file size")}
+		fi, err := pf.ensureFileInfoLocked()
+		if err != nil {
+			return 0, &fs.PathError{Op: "seek", Path: pf.name, Err: errors.Wrap(err, "cannot seek from end without file size")}
 		}
-		newPos = pf.fileInfo.Size + offset
+		newPos = fi.Size + offset
 	default:
 		return 0, &fs.PathError{Op: "seek", Path: pf.name, Err: errors.New("invalid whence")}
 	}
@@ -652,6 +722,13 @@ func (pf *PelicanFile) ReadDir(n int) ([]fs.DirEntry, error) {
 		return nil, fs.ErrClosed
 	}
 
+	if pf.fileInfo == nil && pf.lazyStat && pf.readMode {
+		// Nothing has established what this path is yet; a listing needs to
+		// know, so ask now.
+		if _, err := pf.ensureFileInfoLocked(); err != nil {
+			return nil, &fs.PathError{Op: "readdir", Path: pf.name, Err: err}
+		}
+	}
 	if pf.fileInfo == nil || !pf.fileInfo.IsCollection {
 		return nil, &fs.PathError{Op: "readdir", Path: pf.name, Err: errors.New("not a directory")}
 	}
@@ -714,6 +791,13 @@ func (pf *PelicanFile) Stat() (fs.FileInfo, error) {
 		return nil, fs.ErrClosed
 	}
 
+	if pf.fileInfo == nil && pf.lazyStat && pf.readMode {
+		// A deferred open has not looked the object up yet; Stat is exactly
+		// the question that requires it.
+		if _, err := pf.ensureFileInfoLocked(); err != nil {
+			return nil, &fs.PathError{Op: "stat", Path: pf.name, Err: err}
+		}
+	}
 	if pf.fileInfo == nil {
 		// For write-only files, we may not have stat info
 		return &pelicanFileInfo{

--- a/client/pelican_fs.go
+++ b/client/pelican_fs.go
@@ -126,7 +126,7 @@ func (pfs *PelicanFS) OpenFile(name string, flag int) (fs.File, error) {
 	operation := config.TokenRead
 	if writeMode && !rdwrMode {
 		httpMethod = http.MethodPut
-		operation = config.TokenWrite
+		operation = uploadTokenOperation()
 	}
 
 	// Opens reuse the engine's cached director response (5 min TTL):
@@ -186,7 +186,7 @@ func (pfs *PelicanFS) OpenFile(name string, flag int) (fs.File, error) {
 				if err != nil {
 					return nil, &fs.PathError{Op: "open", Path: name, Err: err}
 				}
-				token = NewTokenGenerator(pUrl, &dirResp, config.TokenWrite, true)
+				token = NewTokenGenerator(pUrl, &dirResp, uploadTokenOperation(), true)
 				for _, option := range pfs.options {
 					switch option.Ident() {
 					case identTransferOptionTokenLocation{}:

--- a/client/pelican_fs_range_test.go
+++ b/client/pelican_fs_range_test.go
@@ -1,0 +1,128 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/pelican_url"
+	"github.com/pelicanplatform/pelican/server_structs"
+)
+
+// rangeFile builds a PelicanFile that reads `body` from a test server, with
+// no file info -- the state a deferred (WithLazyStat) open leaves behind.
+func rangeFile(t *testing.T, body []byte) *PelicanFile {
+	t.Helper()
+	require.NoError(t, config.InitClient())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeContent(w, r, "obj", time.Time{}, bytes.NewReader(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	base, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	return &PelicanFile{
+		ctx:      context.Background(),
+		name:     "/obj",
+		pUrl:     &pelican_url.PelicanURL{Path: "/obj"},
+		readMode: true,
+		lazyStat: true,
+		dirResp: server_structs.DirectorResponse{
+			ObjectServers: []*url.URL{base},
+		},
+	}
+}
+
+// A reader past the end of the object is at EOF. Without an eager stat there
+// is no size to compare against, so the server's 416 has to carry that
+// meaning; anything else and a caller reading to the end loops or fails.
+func TestRangeReadPastEndIsEOF(t *testing.T) {
+	body := []byte("0123456789")
+	pf := rangeFile(t, body)
+
+	buf := make([]byte, 4)
+
+	n, err := pf.doRangeRead(buf, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 4, n)
+	assert.Equal(t, "0123", string(buf[:n]))
+
+	// Exactly at the end.
+	_, err = pf.doRangeRead(buf, int64(len(body)))
+	assert.ErrorIs(t, err, io.EOF, "a range starting at the end is EOF")
+
+	// Beyond the end.
+	_, err = pf.doRangeRead(buf, int64(len(body))+100)
+	assert.ErrorIs(t, err, io.EOF, "a range starting past the end is EOF")
+}
+
+// A read that straddles the end returns the bytes that exist rather than
+// failing: the server answers 206 with a truncated range.
+func TestRangeReadStraddlingEnd(t *testing.T) {
+	body := []byte("0123456789")
+	pf := rangeFile(t, body)
+
+	buf := make([]byte, 8)
+	n, err := pf.doRangeRead(buf, 6)
+	require.NoError(t, err)
+	assert.Equal(t, 4, n, "only the bytes that exist are returned")
+	assert.Equal(t, "6789", string(buf[:n]))
+}
+
+// A deferred open cannot report a missing object until something reads it,
+// so the read has to say so in a way callers can test for.
+func TestRangeReadMissingObjectIsNotExist(t *testing.T) {
+	require.NoError(t, config.InitClient())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	base, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	pf := &PelicanFile{
+		ctx:      context.Background(),
+		name:     "/gone",
+		pUrl:     &pelican_url.PelicanURL{Path: "/gone"},
+		readMode: true,
+		lazyStat: true,
+		dirResp: server_structs.DirectorResponse{
+			ObjectServers: []*url.URL{base},
+		},
+	}
+
+	_, err = pf.doRangeRead(make([]byte, 8), 0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, fs.ErrNotExist, "a read of a missing object must be distinguishable from an unreachable one")
+}


### PR DESCRIPTION
Split out of #3625: the three commits there that stand on their own, rebased onto `main`. The interactive device-flow scope change stays behind in #3625 and is not part of this PR.

### Upload token scopes

Uploads acquire credentials with only `storage.create`, but an overwriting PUT replaces existing data — something `storage.create` doesn't permit. When `Client.EnableOverwrites` is set, uploads now include the delete operation bit so the acquired credential carries `storage.modify`, at all four sites that pick the upload token operation: transfer jobs, `PelicanFS.OpenFile`'s write and rdwr-fallback paths, and the upload-destination stat, whose cached credential the subsequent PUT reuses.

Nothing changes when `Client.EnableOverwrites` is off, which is the default.

### `PelicanFS` reader can skip the stat it doesn't need

A read-mode `OpenFile` stats the object before returning the handle — a PROPFIND aimed at the director's object servers, once per open, which for a caller reading a block store is the most common operation it performs.

That stat buys three things, and a reader working from an index it already trusts needs none of them: a fail-fast open, an EOF short-circuit, and a range clamp. `WithLazyStat` defers it; `Stat`, `Seek` from the end, and `ReadDir` fetch one on demand. `Open` still stats unconditionally, because `io/fs` requires that opening a missing file fail, and `O_RDWR` still stats, because it decides between reading and creating on that answer.

Deferring it means the server's own status codes have to carry what the stat used to say, so two of them now do. **416** is end-of-file rather than a transport failure — the honest answer even with an eager stat, since an object that shrank would otherwise surface as an unexpected status code. **404** is `fs.ErrNotExist` rather than an opaque error, and only after every object server agrees, so a caller that distinguishes a missing object from an unreachable one keeps working when the news arrives at read time instead of open time.

### `CloseWithError` on `WithWriter` pipes

A failed download whose destination is a custom writer closed the pipe with a plain `Close`, handing the reader a clean EOF: the 404/403 stayed in the transfer results while the reader saw an empty, "successful" stream. The EOF-recovery path can race that close and come up empty, so callers observed zero-byte reads with nil errors — in the field, a pelfs pack bootstrap reported `bad pack magic … tail read 0 bytes … full-object retry: <nil>` for a perfectly intact 64MB object.

Closing the writer with the transfer's error delivers the failure synchronously as the reader's `Read` error, with no results plumbing involved. `CloseWithError(nil)` behaves exactly like `Close`, so the success path is unchanged.

### Testing

`TestRangeReadPastEndIsEOF`, `TestRangeReadStraddlingEnd`, and `TestRangeReadMissingObjectIsNotExist` cover the deferred-stat status-code translation, including a read that straddles the end and returns the bytes that exist — which also shows the range clamp was never load bearing.

The `client` collection-probe and checksum suites pass. The federation-backed tests fail on my macOS box against a clean `origin/main` checkout too, so they're environmental here; CI is the arbiter.
