### PR TITLE
Allow callback-based overrides of the device code handler

### DIFF
--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -46,11 +46,17 @@ import (
 // otherwise it is verification_uri and userCode is the code to enter there.
 // The handler is called only when the issuer named a URL at all.
 //
-// It runs on the goroutine driving the flow, after the URL has been written
-// to stderr and before polling begins, so a handler that blocks delays the
-// user's own approval.  It must not be treated as the only way the user is
-// told: AcquireToken prints the URL whether or not a handler is installed,
-// and a handler that fails silently leaves that output as the fallback.
+// It runs on the goroutine driving the flow, before polling begins, so a
+// handler that blocks delays the user's own approval.
+//
+// An installed handler REPLACES Pelican's own announcement rather than adding
+// to it: while one is installed the URL is not written to stderr.  An embedder
+// installs a handler precisely because the terminal is not where its user is
+// looking -- a page, a desktop notification, a GUI -- and printing there
+// anyway is at best noise in a log the user never reads.  The consequence is
+// that the handler is the ONLY way the user learns where to approve, so one
+// that drops the URL silently leaves the flow with nothing to show, and it
+// polls until it expires.
 type VerificationURLHandler func(verificationURL, userCode string)
 
 var verificationURLHandler atomic.Pointer[VerificationURLHandler]
@@ -113,39 +119,46 @@ func trimPath(pathName string, maxDepth int) string {
 }
 
 // announceVerification tells the user where to approve the pending device-flow
-// authorization request, writing the instructions to w and then handing the
-// same URL to the installed VerificationURLHandler, if there is one.
+// authorization request: through the installed VerificationURLHandler if there
+// is one, and otherwise by writing the instructions to w.
 //
 // Which URL the user needs depends on the issuer.  A verification_uri_complete
 // already carries the user code, so it suffices on its own; a plain
 // verification_uri has to be paired with the code the user then types there.
 //
-// The write to w happens unconditionally and first, so a handler can only add
-// a way for the user to reach the URL, never take one away.
+// Exactly one of the two announcements happens, so an embedder that has
+// somewhere better to put the URL does not also spray it across a terminal
+// nobody is watching.  A response naming no URL at all is the exception: there
+// is nothing to hand a handler, so the printed output remains as the only
+// record that a flow was attempted.
 func announceVerification(w io.Writer, deviceAuth *DeviceAuth) {
+	// A verification_uri_complete carries the code already; a plain
+	// verification_uri needs it alongside.
 	verificationURL, userCode := deviceAuth.VerificationURIComplete, ""
-	if len(verificationURL) > 0 {
+	complete := verificationURL != ""
+	if !complete {
+		verificationURL, userCode = deviceAuth.VerificationURI, deviceAuth.UserCode
+	}
+
+	if verificationURL != "" {
+		if handler := verificationURLHandler.Load(); handler != nil {
+			(*handler)(verificationURL, userCode)
+			return
+		}
+	}
+
+	if complete {
 		fmt.Fprintln(w, "To approve credentials for this operation, please navigate to the following URL and approve the request:")
 		fmt.Fprintln(w, "")
 		fmt.Fprintln(w, verificationURL)
-	} else {
-		verificationURL, userCode = deviceAuth.VerificationURI, deviceAuth.UserCode
-		fmt.Fprintln(w, "To approve credentials for this operation, please navigate to the following URL:")
-		fmt.Fprintln(w, "")
-		fmt.Fprintln(w, verificationURL)
-		fmt.Fprintln(w, "\nand enter the following code")
-		fmt.Fprintln(w, "")
-		fmt.Fprintln(w, userCode)
-	}
-
-	// A malformed response naming no URL at all leaves nothing worth handing
-	// over; the printed output above is still the user's record of it.
-	if verificationURL == "" {
 		return
 	}
-	if handler := verificationURLHandler.Load(); handler != nil {
-		(*handler)(verificationURL, userCode)
-	}
+	fmt.Fprintln(w, "To approve credentials for this operation, please navigate to the following URL:")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, verificationURL)
+	fmt.Fprintln(w, "\nand enter the following code")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, userCode)
 }
 
 func AcquireToken(issuerUrl string, entry *config.PrefixEntry, dirResp server_structs.DirectorResponse, osdfPath string, opts config.TokenGenerationOpts) (*config.TokenEntry, error) {

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"sync/atomic"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -35,6 +36,48 @@ import (
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/server_structs"
 )
+
+// VerificationURLHandler is called with the address a user must visit to
+// approve a device-flow authorization request, and the code they must enter
+// once there.
+//
+// verificationURL is the issuer's verification_uri_complete when it supplied
+// one, in which case the URL already carries the code and userCode is empty;
+// otherwise it is verification_uri and userCode is the code to enter there.
+// The handler is called only when the issuer named a URL at all.
+//
+// It runs on the goroutine driving the flow, after the URL has been written
+// to stderr and before polling begins, so a handler that blocks delays the
+// user's own approval.  It must not be treated as the only way the user is
+// told: AcquireToken prints the URL whether or not a handler is installed,
+// and a handler that fails silently leaves that output as the fallback.
+type VerificationURLHandler func(verificationURL, userCode string)
+
+var verificationURLHandler atomic.Pointer[VerificationURLHandler]
+
+// SetVerificationURLHandler installs handler as the process-wide destination
+// for device-flow verification URLs, replacing any previous one.  A nil
+// handler removes the current one.
+//
+// This exists so that a program embedding Pelican can bring the URL to its
+// user by whatever means suits it -- opening a browser, raising a desktop
+// notification, showing it in a GUI -- without reimplementing the flow.  Every
+// step AcquireToken performs around the announcement is unexported: deciding
+// whether a cached token would have done (client.tokenIsAcceptable), dynamic
+// client registration (client.registerClient), scope construction (trimPath),
+// refresh (client.refreshTokenEntry), and local minting (client.generateToken).
+// An embedder that copied them to reach the URL would drift from them, and the
+// first consequence is that Pelican judges the token the copy obtained
+// unacceptable and opens a second device flow -- so the user approves twice.
+//
+// It is safe to call at any time, including while a flow is in progress.
+func SetVerificationURLHandler(handler VerificationURLHandler) {
+	if handler == nil {
+		verificationURLHandler.Store(nil)
+		return
+	}
+	verificationURLHandler.Store(&handler)
+}
 
 func deviceCodeSupported(grantTypes *[]string) bool {
 	for _, grant := range *grantTypes {
@@ -70,23 +113,38 @@ func trimPath(pathName string, maxDepth int) string {
 }
 
 // announceVerification tells the user where to approve the pending device-flow
-// authorization request, writing the instructions to w.
+// authorization request, writing the instructions to w and then handing the
+// same URL to the installed VerificationURLHandler, if there is one.
 //
 // Which URL the user needs depends on the issuer.  A verification_uri_complete
 // already carries the user code, so it suffices on its own; a plain
 // verification_uri has to be paired with the code the user then types there.
+//
+// The write to w happens unconditionally and first, so a handler can only add
+// a way for the user to reach the URL, never take one away.
 func announceVerification(w io.Writer, deviceAuth *DeviceAuth) {
-	if len(deviceAuth.VerificationURIComplete) > 0 {
+	verificationURL, userCode := deviceAuth.VerificationURIComplete, ""
+	if len(verificationURL) > 0 {
 		fmt.Fprintln(w, "To approve credentials for this operation, please navigate to the following URL and approve the request:")
 		fmt.Fprintln(w, "")
-		fmt.Fprintln(w, deviceAuth.VerificationURIComplete)
+		fmt.Fprintln(w, verificationURL)
 	} else {
+		verificationURL, userCode = deviceAuth.VerificationURI, deviceAuth.UserCode
 		fmt.Fprintln(w, "To approve credentials for this operation, please navigate to the following URL:")
 		fmt.Fprintln(w, "")
-		fmt.Fprintln(w, deviceAuth.VerificationURI)
+		fmt.Fprintln(w, verificationURL)
 		fmt.Fprintln(w, "\nand enter the following code")
 		fmt.Fprintln(w, "")
-		fmt.Fprintln(w, deviceAuth.UserCode)
+		fmt.Fprintln(w, userCode)
+	}
+
+	// A malformed response naming no URL at all leaves nothing worth handing
+	// over; the printed output above is still the user's record of it.
+	if verificationURL == "" {
+		return
+	}
+	if handler := verificationURLHandler.Load(); handler != nil {
+		(*handler)(verificationURL, userCode)
 	}
 }
 

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -69,6 +69,27 @@ func trimPath(pathName string, maxDepth int) string {
 	return "/" + path.Join(pathComponents[0:maxLength]...)
 }
 
+// announceVerification tells the user where to approve the pending device-flow
+// authorization request, writing the instructions to w.
+//
+// Which URL the user needs depends on the issuer.  A verification_uri_complete
+// already carries the user code, so it suffices on its own; a plain
+// verification_uri has to be paired with the code the user then types there.
+func announceVerification(w io.Writer, deviceAuth *DeviceAuth) {
+	if len(deviceAuth.VerificationURIComplete) > 0 {
+		fmt.Fprintln(w, "To approve credentials for this operation, please navigate to the following URL and approve the request:")
+		fmt.Fprintln(w, "")
+		fmt.Fprintln(w, deviceAuth.VerificationURIComplete)
+	} else {
+		fmt.Fprintln(w, "To approve credentials for this operation, please navigate to the following URL:")
+		fmt.Fprintln(w, "")
+		fmt.Fprintln(w, deviceAuth.VerificationURI)
+		fmt.Fprintln(w, "\nand enter the following code")
+		fmt.Fprintln(w, "")
+		fmt.Fprintln(w, deviceAuth.UserCode)
+	}
+}
+
 func AcquireToken(issuerUrl string, entry *config.PrefixEntry, dirResp server_structs.DirectorResponse, osdfPath string, opts config.TokenGenerationOpts) (*config.TokenEntry, error) {
 	if fileInfo, _ := os.Stdout.Stat(); (len(os.Getenv(config.GetPreferredPrefix().String()+"_SKIP_TERMINAL_CHECK")) == 0) && ((fileInfo.Mode() & os.ModeCharDevice) == 0) {
 		return nil, errors.New("This program must be run in a terminal to acquire a new token")
@@ -140,18 +161,7 @@ func AcquireToken(issuerUrl string, entry *config.PrefixEntry, dirResp server_st
 		return nil, errors.Wrapf(err, "Failed to perform device code flow with URL %s", issuerInfo.DeviceAuthURL)
 	}
 
-	if len(deviceAuth.VerificationURIComplete) > 0 {
-		fmt.Fprintln(os.Stderr, "To approve credentials for this operation, please navigate to the following URL and approve the request:")
-		fmt.Fprintln(os.Stderr, "")
-		fmt.Fprintln(os.Stderr, deviceAuth.VerificationURIComplete)
-	} else {
-		fmt.Fprintln(os.Stderr, "To approve credentials for this operation, please navigate to the following URL:")
-		fmt.Fprintln(os.Stderr, "")
-		fmt.Fprintln(os.Stderr, deviceAuth.VerificationURIComplete)
-		fmt.Fprintln(os.Stderr, "\nand enter the following code")
-		fmt.Fprintln(os.Stderr, "")
-		fmt.Fprintln(os.Stderr, deviceAuth.UserCode)
-	}
+	announceVerification(os.Stderr, deviceAuth)
 
 	upstream_token, err := oauth2Config.Poll(ctx, deviceAuth)
 	if err != nil {

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -76,6 +76,12 @@ var verificationURLHandler atomic.Pointer[VerificationURLHandler]
 // first consequence is that Pelican judges the token the copy obtained
 // unacceptable and opens a second device flow -- so the user approves twice.
 //
+// Installing a handler also lifts AcquireToken's terminal requirement, which
+// exists so that a flow is never started with no way to tell the user where to
+// approve it.  A handler is another such way, so an embedder with no terminal
+// -- a program under a service manager, or one whose output is redirected --
+// can acquire a token where it previously could not.
+//
 // It is safe to call at any time, including while a flow is in progress.
 func SetVerificationURLHandler(handler VerificationURLHandler) {
 	if handler == nil {
@@ -161,8 +167,37 @@ func announceVerification(w io.Writer, deviceAuth *DeviceAuth) {
 	fmt.Fprintln(w, userCode)
 }
 
+// verificationTargetAvailable reports whether there is anywhere to send the
+// verification URL a device flow is about to produce.
+//
+// A device flow is worthless if nobody ever sees that URL, which is what the
+// terminal requirement has always been about: a program with no terminal had
+// no way to tell its user where to approve, so failing early beat polling for
+// an approval that could never come.
+//
+// An installed VerificationURLHandler is an embedder saying it has somewhere
+// else to put the URL -- a page, a desktop notification, a GUI -- so it meets
+// that requirement without a terminal, and it is exactly the case the handler
+// exists for. A program that opens a browser for its user is often started
+// from a terminal nobody is watching, and under a service manager it may have
+// no terminal at all; refusing there would make the handler unusable in the
+// situation it was added to serve.
+func verificationTargetAvailable() bool {
+	if verificationURLHandler.Load() != nil {
+		return true
+	}
+	if len(os.Getenv(config.GetPreferredPrefix().String()+"_SKIP_TERMINAL_CHECK")) > 0 {
+		return true
+	}
+	// Stat fails on a closed or exotic descriptor, which is not a terminal
+	// either; the previous form dereferenced the nil FileInfo that comes back
+	// with the error.
+	fileInfo, err := os.Stdout.Stat()
+	return err == nil && (fileInfo.Mode()&os.ModeCharDevice) != 0
+}
+
 func AcquireToken(issuerUrl string, entry *config.PrefixEntry, dirResp server_structs.DirectorResponse, osdfPath string, opts config.TokenGenerationOpts) (*config.TokenEntry, error) {
-	if fileInfo, _ := os.Stdout.Stat(); (len(os.Getenv(config.GetPreferredPrefix().String()+"_SKIP_TERMINAL_CHECK")) == 0) && ((fileInfo.Mode() & os.ModeCharDevice) == 0) {
+	if !verificationTargetAvailable() {
 		return nil, errors.New("This program must be run in a terminal to acquire a new token")
 	}
 

--- a/oauth2/oauth2_test.go
+++ b/oauth2/oauth2_test.go
@@ -1,0 +1,54 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package oauth2
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnnounceVerification(t *testing.T) {
+	t.Run("complete-uri-is-printed-alone", func(t *testing.T) {
+		out := &strings.Builder{}
+		announceVerification(out, &DeviceAuth{
+			UserCode:                "ABCD-EFGH",
+			VerificationURI:         "https://issuer.example.com/device",
+			VerificationURIComplete: "https://issuer.example.com/device?user_code=ABCD-EFGH",
+		})
+		assert.Contains(t, out.String(), "https://issuer.example.com/device?user_code=ABCD-EFGH")
+		// The complete URI carries the code, so the user is not asked to type it.
+		assert.NotContains(t, out.String(), "enter the following code")
+	})
+
+	t.Run("uri-and-code-are-printed-when-no-complete-uri", func(t *testing.T) {
+		out := &strings.Builder{}
+		announceVerification(out, &DeviceAuth{
+			UserCode:        "ABCD-EFGH",
+			VerificationURI: "https://issuer.example.com/device",
+		})
+		// Regression: this branch used to print VerificationURIComplete, which
+		// is by definition empty here, so the user was told to navigate to a
+		// blank line and then handed a code with nowhere to type it.
+		assert.Contains(t, out.String(), "https://issuer.example.com/device")
+		assert.Contains(t, out.String(), "enter the following code")
+		assert.Contains(t, out.String(), "ABCD-EFGH")
+	})
+}

--- a/oauth2/oauth2_test.go
+++ b/oauth2/oauth2_test.go
@@ -19,11 +19,14 @@
 package oauth2
 
 import (
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/config"
 )
 
 // verificationCall records one invocation of a VerificationURLHandler.
@@ -154,5 +157,41 @@ func TestVerificationURLHandler(t *testing.T) {
 		// stays as the only record that a flow was attempted -- the one case
 		// where an installed handler does not suppress it.
 		assert.Contains(t, out.String(), "To approve credentials")
+	})
+}
+
+func TestVerificationTargetAvailable(t *testing.T) {
+	skipVar := config.GetPreferredPrefix().String() + "_SKIP_TERMINAL_CHECK"
+
+	stdoutIsTerminal := func(t *testing.T) bool {
+		t.Helper()
+		fileInfo, err := os.Stdout.Stat()
+		return err == nil && (fileInfo.Mode()&os.ModeCharDevice) != 0
+	}
+
+	t.Run("no-terminal-no-handler-no-escape-is-refused", func(t *testing.T) {
+		if stdoutIsTerminal(t) {
+			t.Skip("stdout is a terminal here, so the case under test cannot arise")
+		}
+		t.Setenv(skipVar, "")
+		SetVerificationURLHandler(nil)
+		assert.False(t, verificationTargetAvailable())
+	})
+
+	t.Run("a-handler-is-a-target-without-a-terminal", func(t *testing.T) {
+		if stdoutIsTerminal(t) {
+			t.Skip("stdout is a terminal here, so this proves nothing about the handler")
+		}
+		t.Setenv(skipVar, "")
+		captureVerificationURLs(t)
+		// This is the whole point of the change: an embedder showing the URL
+		// on a page has somewhere to put it, and no terminal.
+		assert.True(t, verificationTargetAvailable())
+	})
+
+	t.Run("the-escape-hatch-still-works", func(t *testing.T) {
+		t.Setenv(skipVar, "1")
+		SetVerificationURLHandler(nil)
+		assert.True(t, verificationTargetAvailable())
 	})
 }

--- a/oauth2/oauth2_test.go
+++ b/oauth2/oauth2_test.go
@@ -110,8 +110,10 @@ func TestVerificationURLHandler(t *testing.T) {
 		// the embedder to show alongside it.
 		assert.Equal(t, "https://issuer.example.com/device?user_code=ABCD-EFGH", recorder.calls[0].verificationURL)
 		assert.Empty(t, recorder.calls[0].userCode)
-		// Pelican's own announcement is unchanged by the handler being there.
-		assert.Contains(t, out.String(), "https://issuer.example.com/device?user_code=ABCD-EFGH")
+		// The handler REPLACES the terminal announcement: an embedder that
+		// has somewhere better to put the URL does not also get it sprayed
+		// across a terminal nobody is watching.
+		assert.Empty(t, out.String(), "nothing should be printed while a handler is installed")
 	})
 
 	t.Run("handler-gets-the-uri-and-the-code", func(t *testing.T) {
@@ -124,7 +126,7 @@ func TestVerificationURLHandler(t *testing.T) {
 		require.Len(t, recorder.calls, 1)
 		assert.Equal(t, "https://issuer.example.com/device", recorder.calls[0].verificationURL)
 		assert.Equal(t, "ABCD-EFGH", recorder.calls[0].userCode)
-		assert.Contains(t, out.String(), "https://issuer.example.com/device")
+		assert.Empty(t, out.String(), "nothing should be printed while a handler is installed")
 	})
 
 	t.Run("handler-can-be-replaced-and-removed", func(t *testing.T) {
@@ -145,7 +147,12 @@ func TestVerificationURLHandler(t *testing.T) {
 		recorder := captureVerificationURLs(t)
 		// An issuer response naming neither URI is malformed, but it should
 		// not send an embedder off to open the empty string.
-		announceVerification(&strings.Builder{}, &DeviceAuth{UserCode: "ABCD-EFGH"})
+		out := &strings.Builder{}
+		announceVerification(out, &DeviceAuth{UserCode: "ABCD-EFGH"})
 		assert.Empty(t, recorder.calls)
+		// With no URL there is nothing to hand over, so the printed output
+		// stays as the only record that a flow was attempted -- the one case
+		// where an installed handler does not suppress it.
+		assert.Contains(t, out.String(), "To approve credentials")
 	})
 }

--- a/oauth2/oauth2_test.go
+++ b/oauth2/oauth2_test.go
@@ -23,7 +23,37 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// verificationCall records one invocation of a VerificationURLHandler.
+type verificationCall struct {
+	verificationURL string
+	userCode        string
+}
+
+// verificationRecorder is a VerificationURLHandler that remembers what it was
+// given.
+type verificationRecorder struct {
+	calls []verificationCall
+}
+
+func (recorder *verificationRecorder) handle(verificationURL, userCode string) {
+	recorder.calls = append(recorder.calls, verificationCall{verificationURL, userCode})
+}
+
+// captureVerificationURLs installs a recorder as the handler and removes it
+// again when the test ends, so that the process-wide handler does not leak into
+// the next test.
+func captureVerificationURLs(t *testing.T) *verificationRecorder {
+	t.Helper()
+	recorder := &verificationRecorder{}
+	SetVerificationURLHandler(recorder.handle)
+	t.Cleanup(func() {
+		SetVerificationURLHandler(nil)
+	})
+	return recorder
+}
 
 func TestAnnounceVerification(t *testing.T) {
 	t.Run("complete-uri-is-printed-alone", func(t *testing.T) {
@@ -50,5 +80,72 @@ func TestAnnounceVerification(t *testing.T) {
 		assert.Contains(t, out.String(), "https://issuer.example.com/device")
 		assert.Contains(t, out.String(), "enter the following code")
 		assert.Contains(t, out.String(), "ABCD-EFGH")
+	})
+}
+
+func TestVerificationURLHandler(t *testing.T) {
+	t.Run("no-handler-installed-is-a-no-op", func(t *testing.T) {
+		SetVerificationURLHandler(nil)
+		out := &strings.Builder{}
+		// The point is that this neither panics nor suppresses the output a
+		// user with no embedder relies on.
+		announceVerification(out, &DeviceAuth{
+			UserCode:                "ABCD-EFGH",
+			VerificationURI:         "https://issuer.example.com/device",
+			VerificationURIComplete: "https://issuer.example.com/device?user_code=ABCD-EFGH",
+		})
+		assert.Contains(t, out.String(), "https://issuer.example.com/device?user_code=ABCD-EFGH")
+	})
+
+	t.Run("handler-gets-the-complete-uri-and-no-code", func(t *testing.T) {
+		recorder := captureVerificationURLs(t)
+		out := &strings.Builder{}
+		announceVerification(out, &DeviceAuth{
+			UserCode:                "ABCD-EFGH",
+			VerificationURI:         "https://issuer.example.com/device",
+			VerificationURIComplete: "https://issuer.example.com/device?user_code=ABCD-EFGH",
+		})
+		require.Len(t, recorder.calls, 1)
+		// The complete URI already carries the code, so there is nothing for
+		// the embedder to show alongside it.
+		assert.Equal(t, "https://issuer.example.com/device?user_code=ABCD-EFGH", recorder.calls[0].verificationURL)
+		assert.Empty(t, recorder.calls[0].userCode)
+		// Pelican's own announcement is unchanged by the handler being there.
+		assert.Contains(t, out.String(), "https://issuer.example.com/device?user_code=ABCD-EFGH")
+	})
+
+	t.Run("handler-gets-the-uri-and-the-code", func(t *testing.T) {
+		recorder := captureVerificationURLs(t)
+		out := &strings.Builder{}
+		announceVerification(out, &DeviceAuth{
+			UserCode:        "ABCD-EFGH",
+			VerificationURI: "https://issuer.example.com/device",
+		})
+		require.Len(t, recorder.calls, 1)
+		assert.Equal(t, "https://issuer.example.com/device", recorder.calls[0].verificationURL)
+		assert.Equal(t, "ABCD-EFGH", recorder.calls[0].userCode)
+		assert.Contains(t, out.String(), "https://issuer.example.com/device")
+	})
+
+	t.Run("handler-can-be-replaced-and-removed", func(t *testing.T) {
+		first := captureVerificationURLs(t)
+
+		second := &verificationRecorder{}
+		SetVerificationURLHandler(second.handle)
+		announceVerification(&strings.Builder{}, &DeviceAuth{VerificationURIComplete: "https://issuer.example.com/one"})
+		assert.Empty(t, first.calls, "the replaced handler should no longer be called")
+		require.Len(t, second.calls, 1)
+
+		SetVerificationURLHandler(nil)
+		announceVerification(&strings.Builder{}, &DeviceAuth{VerificationURIComplete: "https://issuer.example.com/two"})
+		assert.Len(t, second.calls, 1, "a removed handler should no longer be called")
+	})
+
+	t.Run("handler-is-not-called-without-a-url", func(t *testing.T) {
+		recorder := captureVerificationURLs(t)
+		// An issuer response naming neither URI is malformed, but it should
+		// not send an embedder off to open the empty string.
+		announceVerification(&strings.Builder{}, &DeviceAuth{UserCode: "ABCD-EFGH"})
+		assert.Empty(t, recorder.calls)
 	})
 }


### PR DESCRIPTION
The device code handler currently prints out all the information the user needs to know for authenticating to stderr.

While that works well for terminal-based workflows, it's an awkward intercept for embedding the Pelican client into other applications.

This PR adds a public API to allow hijacking the device code URL.  It also fixes a small bug where the verification URL was never printed to stderr if the remote issuer didn't support `verification_uri_complete` (which all our test issuers apparently do...).

Fixes #3671 