### PR TITLE
fix: correct path typo in docs/parameters.yaml (/projects_dept_a -> /projects/dept_a)

### DIFF
--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -4969,7 +4969,7 @@ description: |+
   - read /home/bbockelm
   - modify /home/bbockelm
   - read /projects/dept_a
-  - create /projects_dept_a
+  - create /projects/dept_a
   - read /data/dept_a
   - read /data/dept_b
 type: object


### PR DESCRIPTION
## Summary
Fix typo in docs/parameters.yaml: line 4965 path should be `/projects/dept_a` not `/projects_dept_a` (missing slash separator).

## Changes
- docs/parameters.yaml: `create /projects_dept_a` → `create /projects/dept_a`

## Testing
- Confirmed typo by comparing with the adjacent `read /projects/dept_a` entry (line 4964), which uses the correct path format.

## Related
Fixes #3652
