### PR TITLE
origin: local storage cache for remote backends

### DIFF
--- a/cache_control/cache_control.go
+++ b/cache_control/cache_control.go
@@ -1,0 +1,262 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Package cache_control parses HTTP Cache-Control directives and applies
+// freshness policy to them.
+//
+// It is deliberately a leaf package: it depends only on the standard library,
+// with no reference to Pelican's configuration.  Callers supply their own
+// policy through Policy, so components with unrelated configuration knobs (the
+// local cache's LocalCache.* settings, the origin's Origin.StorageCache*
+// settings) can share one implementation of the caching rules without sharing
+// a dependency graph.
+package cache_control
+
+import (
+	"hash/fnv"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Bit flags for Directives.flags.  These values are persisted directly in the
+// local cache's on-disk metadata (CacheMetadata.CCFlags), so they must not be
+// renumbered.
+const (
+	FlagNoStore        uint8 = 0x01 // no-store
+	FlagNoCache        uint8 = 0x02 // no-cache
+	FlagPrivate        uint8 = 0x04 // private
+	FlagMustRevalidate uint8 = 0x08 // must-revalidate
+	FlagMaxAgeSet      uint8 = 0x10 // max-age or s-maxage was present
+)
+
+// NoCacheGracePeriod is the minimum interval between revalidation attempts
+// when the response carries Cache-Control: no-cache.  Strictly speaking,
+// no-cache means "revalidate before each use", but revalidation costs a
+// round trip; a short grace period collapses a burst of concurrent requests
+// for the same object into a single revalidation.
+const NoCacheGracePeriod = 5 * time.Second
+
+// Directives holds the parsed Cache-Control values relevant to caching.
+//
+// Boolean directives are packed into a bitfield; use the accessors rather
+// than reading the field directly.
+//
+// max-age and s-maxage are merged into a single freshness lifetime: when both
+// are present the larger is kept, because neither Pelican cache distinguishes
+// shared from private storage.
+type Directives struct {
+	flags  uint8
+	maxAge time.Duration // valid only when FlagMaxAgeSet is set
+}
+
+// Policy is the caller's freshness configuration, applied when the response's
+// own directives do not fully determine staleness.
+type Policy struct {
+	// DefaultMaxAge is the freshness lifetime for responses that carry no
+	// freshness directive.  A value <= 0 means "no default freshness": such
+	// responses are always stale and must be revalidated on every use.
+	DefaultMaxAge time.Duration
+
+	// JitterPercent (clamped to 0-100) is the deterministic per-object jitter
+	// applied to DefaultMaxAge, so that objects cached together do not all
+	// expire at the same instant.
+	JitterPercent int
+
+	// MaxFreshness caps the freshness a response may claim for itself via
+	// max-age / s-maxage.  Zero means no cap.  Capping matters when the
+	// backend's metadata is not fully trusted: without it, whoever can set an
+	// object's Cache-Control can pin content in the cache indefinitely.
+	MaxFreshness time.Duration
+}
+
+// --- flag accessors --------------------------------------------------------
+
+func (d Directives) NoStore() bool         { return d.flags&FlagNoStore != 0 }
+func (d Directives) NoCache() bool         { return d.flags&FlagNoCache != 0 }
+func (d Directives) Private() bool         { return d.flags&FlagPrivate != 0 }
+func (d Directives) MustRevalidate() bool  { return d.flags&FlagMustRevalidate != 0 }
+func (d Directives) MaxAgeSet() bool       { return d.flags&FlagMaxAgeSet != 0 }
+func (d Directives) MaxAge() time.Duration { return d.maxAge }
+
+// Flags returns the raw packed bitfield, for efficient serialization.
+// Prefer the named accessors when reading individual directives.
+func (d Directives) Flags() uint8 { return d.flags }
+
+// --- derived helpers -------------------------------------------------------
+
+// ShouldStore reports whether the response may be written to a shared cache.
+func (d Directives) ShouldStore() bool {
+	return d.flags&(FlagNoStore|FlagPrivate) == 0
+}
+
+// HasFreshness reports whether the response supplied explicit freshness
+// information (max-age or s-maxage).
+func (d Directives) HasFreshness() bool { return d.flags&FlagMaxAgeSet != 0 }
+
+// Freshness returns the merged freshness lifetime and whether it was set.
+func (d Directives) Freshness() (time.Duration, bool) {
+	if d.flags&FlagMaxAgeSet != 0 {
+		return d.maxAge, true
+	}
+	return 0, false
+}
+
+// HasDirectives reports whether any directive was parsed.
+func (d Directives) HasDirectives() bool { return d.flags != 0 || d.maxAge != 0 }
+
+// FromFlags rebuilds Directives from a persisted bitfield and max-age.  A
+// positive maxAge implies FlagMaxAgeSet regardless of whether the caller
+// included it in flags, since the two are stored separately on disk.
+func FromFlags(flags uint8, maxAge time.Duration) Directives {
+	d := Directives{flags: flags}
+	if maxAge > 0 {
+		d.maxAge = maxAge
+		d.flags |= FlagMaxAgeSet
+	}
+	return d
+}
+
+// IsStaleFor reports whether a response last validated at lastValidated must
+// be revalidated before it may be served again.
+//
+// key identifies the object, and seeds the jitter applied to
+// policy.DefaultMaxAge so that each object gets its own expiry instant; pass
+// the object's path (or any stable per-object string).  An empty key seeds the
+// jitter from lastValidated alone, which spreads objects validated at
+// different times but not objects validated together.
+func (d Directives) IsStaleFor(lastValidated time.Time, policy Policy, key string) bool {
+	age := time.Since(lastValidated)
+	if d.NoCache() {
+		return age > NoCacheGracePeriod
+	}
+	if freshness, ok := d.Freshness(); ok {
+		if policy.MaxFreshness > 0 && freshness > policy.MaxFreshness {
+			freshness = policy.MaxFreshness
+		}
+		return age > freshness
+	}
+	if policy.DefaultMaxAge <= 0 {
+		return true
+	}
+	return age > FreshnessFor(lastValidated, policy.DefaultMaxAge, policy.JitterPercent, key)
+}
+
+// FreshnessFor computes the jittered freshness lifetime for a response with no
+// freshness directive of its own.
+//
+// The result is deterministic in (lastValidated, key), so repeated calls for
+// the same object agree, and lies in [defaultMaxAge*(1-jitter), defaultMaxAge]
+// — jitter only ever shortens the window.
+func FreshnessFor(lastValidated time.Time, defaultMaxAge time.Duration, jitterPercent int, key string) time.Duration {
+	if jitterPercent < 0 {
+		jitterPercent = 0
+	} else if jitterPercent > 100 {
+		jitterPercent = 100
+	}
+
+	jitterFactor := 1.0 - (float64(jitterPercent) / 100.0)
+	minFreshness := time.Duration(float64(defaultMaxAge) * jitterFactor)
+
+	// Mix the object key into the seed.  Seeding from lastValidated alone
+	// would give every object validated in the same second an identical
+	// jitter, which defeats the purpose: a burst of objects fetched together
+	// would still expire together.
+	seed := uint64(lastValidated.Unix())
+	if key != "" {
+		h := fnv.New64a()
+		_, _ = h.Write([]byte(key))
+		seed ^= h.Sum64()
+	}
+	seed ^= seed >> 33
+	seed *= 0xff51afd7ed558ccd
+	seed ^= seed >> 33
+	jitterRand := float64(seed%10000) / 10000.0 // 0.0 to 1.0
+
+	return minFreshness + time.Duration(float64(defaultMaxAge-minFreshness)*jitterRand)
+}
+
+// Parse converts a Cache-Control header value into structured directives.
+// Directive names are matched case-insensitively, as RFC 7234 requires.
+func Parse(header string) Directives {
+	var d Directives
+	if header == "" {
+		return d
+	}
+
+	var (
+		maxAge    time.Duration
+		maxAgeOk  bool
+		sMaxAge   time.Duration
+		sMaxAgeOk bool
+	)
+
+	for _, part := range strings.Split(header, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		directive := part
+		value := ""
+		if eqIdx := strings.IndexByte(part, '='); eqIdx >= 0 {
+			directive = strings.TrimSpace(part[:eqIdx])
+			value = strings.TrimSpace(part[eqIdx+1:])
+			value = strings.Trim(value, "\"")
+		}
+
+		switch strings.ToLower(directive) {
+		case "no-store":
+			d.flags |= FlagNoStore
+		case "no-cache":
+			d.flags |= FlagNoCache
+		case "private":
+			d.flags |= FlagPrivate
+		case "must-revalidate":
+			d.flags |= FlagMustRevalidate
+		case "max-age":
+			if seconds, err := strconv.ParseInt(value, 10, 64); err == nil && seconds >= 0 {
+				maxAge = time.Duration(seconds) * time.Second
+				maxAgeOk = true
+			}
+		case "s-maxage":
+			if seconds, err := strconv.ParseInt(value, 10, 64); err == nil && seconds >= 0 {
+				sMaxAge = time.Duration(seconds) * time.Second
+				sMaxAgeOk = true
+			}
+		}
+	}
+
+	// Merge max-age and s-maxage: keep the larger of the two.
+	switch {
+	case maxAgeOk && sMaxAgeOk:
+		d.maxAge = maxAge
+		if sMaxAge > maxAge {
+			d.maxAge = sMaxAge
+		}
+		d.flags |= FlagMaxAgeSet
+	case sMaxAgeOk:
+		d.maxAge = sMaxAge
+		d.flags |= FlagMaxAgeSet
+	case maxAgeOk:
+		d.maxAge = maxAge
+		d.flags |= FlagMaxAgeSet
+	}
+
+	return d
+}

--- a/cache_control/cache_control_test.go
+++ b/cache_control/cache_control_test.go
@@ -1,0 +1,320 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package cache_control
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Parse must recognize every directive the caches act on, in the forms real
+// servers emit them: any case, arbitrary surrounding whitespace, optionally
+// quoted values.  Values it cannot make sense of are ignored rather than
+// guessed at, because a misparsed max-age silently changes how long content is
+// served without checking the origin.
+func TestParseDirectives(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		header         string
+		wantNoStore    bool
+		wantNoCache    bool
+		wantPrivate    bool
+		wantMustReval  bool
+		wantMaxAgeSet  bool
+		wantMaxAge     time.Duration
+		wantDirectives bool
+	}{
+		{name: "empty header"},
+		{name: "no-store", header: "no-store", wantNoStore: true, wantDirectives: true},
+		{name: "no-cache", header: "no-cache", wantNoCache: true, wantDirectives: true},
+		{name: "private", header: "private", wantPrivate: true, wantDirectives: true},
+		{name: "must-revalidate", header: "must-revalidate", wantMustReval: true, wantDirectives: true},
+		{
+			name: "max-age", header: "max-age=60",
+			wantMaxAgeSet: true, wantMaxAge: time.Minute, wantDirectives: true,
+		},
+		{
+			name: "zero max-age is still explicit", header: "max-age=0",
+			wantMaxAgeSet: true, wantMaxAge: 0, wantDirectives: true,
+		},
+		{
+			// Neither cache distinguishes shared from private storage, so the
+			// two lifetimes merge to the larger.
+			name: "s-maxage larger than max-age wins", header: "max-age=60, s-maxage=120",
+			wantMaxAgeSet: true, wantMaxAge: 2 * time.Minute, wantDirectives: true,
+		},
+		{
+			name: "max-age larger than s-maxage wins", header: "s-maxage=60, max-age=600",
+			wantMaxAgeSet: true, wantMaxAge: 10 * time.Minute, wantDirectives: true,
+		},
+		{
+			name: "s-maxage alone", header: "s-maxage=90",
+			wantMaxAgeSet: true, wantMaxAge: 90 * time.Second, wantDirectives: true,
+		},
+		{
+			name: "quoted value", header: `max-age="60"`,
+			wantMaxAgeSet: true, wantMaxAge: time.Minute, wantDirectives: true,
+		},
+		{
+			name: "case insensitive", header: "MAX-AGE=60, No-Store, NO-CACHE, Private, Must-Revalidate",
+			wantNoStore: true, wantNoCache: true, wantPrivate: true, wantMustReval: true,
+			wantMaxAgeSet: true, wantMaxAge: time.Minute, wantDirectives: true,
+		},
+		{
+			name: "surrounding whitespace and empty elements", header: "  ,  max-age = 60 ,, no-store  ,",
+			wantNoStore: true, wantMaxAgeSet: true, wantMaxAge: time.Minute, wantDirectives: true,
+		},
+		{name: "non-numeric max-age is ignored", header: "max-age=abc"},
+		{name: "negative max-age is ignored", header: "max-age=-5"},
+		{name: "empty max-age is ignored", header: "max-age="},
+		{name: "overflowing max-age is ignored", header: "max-age=99999999999999999999"},
+		{name: "unknown directives are ignored", header: "immutable, stale-while-revalidate=30, foo=bar"},
+		{
+			name: "junk alongside a good directive", header: "max-age=nope, no-store",
+			wantNoStore: true, wantDirectives: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := Parse(tc.header)
+			assert.Equal(t, tc.wantNoStore, d.NoStore(), "no-store")
+			assert.Equal(t, tc.wantNoCache, d.NoCache(), "no-cache")
+			assert.Equal(t, tc.wantPrivate, d.Private(), "private")
+			assert.Equal(t, tc.wantMustReval, d.MustRevalidate(), "must-revalidate")
+			assert.Equal(t, tc.wantMaxAgeSet, d.MaxAgeSet(), "max-age set")
+			assert.Equal(t, tc.wantMaxAgeSet, d.HasFreshness(), "HasFreshness must track MaxAgeSet")
+			assert.Equal(t, tc.wantMaxAge, d.MaxAge(), "max-age value")
+			freshness, ok := d.Freshness()
+			assert.Equal(t, tc.wantMaxAgeSet, ok, "Freshness ok")
+			if ok {
+				assert.Equal(t, tc.wantMaxAge, freshness, "Freshness value")
+			}
+			assert.Equal(t, tc.wantDirectives, d.HasDirectives(), "HasDirectives")
+		})
+	}
+}
+
+// The flag values are persisted in the local cache's on-disk metadata, so a
+// round trip through the serialized form must reproduce the parsed directives
+// exactly — including "max-age=0", whose max-age is indistinguishable from
+// "unset" unless the flag is carried across.
+func TestFromFlagsRoundTrip(t *testing.T) {
+	for _, header := range []string{
+		"",
+		"no-store",
+		"no-cache",
+		"private, must-revalidate",
+		"max-age=60",
+		"max-age=0",
+		"no-cache, max-age=300",
+		"no-store, no-cache, private, must-revalidate, max-age=1, s-maxage=2",
+	} {
+		t.Run(fmt.Sprintf("header %q", header), func(t *testing.T) {
+			original := Parse(header)
+			restored := FromFlags(original.Flags(), original.MaxAge())
+			assert.Equal(t, original, restored)
+		})
+	}
+
+	// A positive max-age implies the flag even when the caller omits it: the
+	// two halves are stored in separate on-disk fields.
+	d := FromFlags(0, 30*time.Second)
+	assert.True(t, d.MaxAgeSet())
+	assert.Equal(t, 30*time.Second, d.MaxAge())
+
+	// A non-positive max-age never sets the flag on its own.
+	d = FromFlags(FlagNoStore, 0)
+	assert.False(t, d.MaxAgeSet())
+	assert.True(t, d.NoStore())
+}
+
+// ShouldStore gates whether a response may be written to a shared cache at
+// all: no-store and private must never reach disk, while no-cache responses
+// are stored (they are merely revalidated before nearly every use).
+func TestShouldStore(t *testing.T) {
+	for _, tc := range []struct {
+		header string
+		want   bool
+	}{
+		{"", true},
+		{"max-age=600", true},
+		{"no-cache", true},
+		{"must-revalidate", true},
+		{"no-store", false},
+		{"private", false},
+		{"private, max-age=600", false},
+		{"no-store, max-age=600", false},
+		{"public, no-store", false},
+	} {
+		t.Run(fmt.Sprintf("header %q", tc.header), func(t *testing.T) {
+			assert.Equal(t, tc.want, Parse(tc.header).ShouldStore())
+		})
+	}
+}
+
+// IsStaleFor decides whether a copy may be served without contacting the
+// origin.  The rules it must hold to: no-cache revalidates outside a short
+// coalescing grace period; an explicit max-age wins over the caller's default
+// but is capped by MaxFreshness, so a backend cannot pin content in the cache;
+// and a non-positive DefaultMaxAge means "revalidate every time".
+func TestIsStaleFor(t *testing.T) {
+	now := time.Now()
+
+	t.Run("no-cache revalidates outside the grace period", func(t *testing.T) {
+		d := Parse("no-cache")
+		policy := Policy{DefaultMaxAge: 24 * time.Hour}
+		assert.False(t, d.IsStaleFor(now, policy, "/obj"), "within grace")
+		assert.True(t, d.IsStaleFor(now.Add(-2*NoCacheGracePeriod), policy, "/obj"), "past grace")
+	})
+
+	t.Run("no-cache ignores a long max-age", func(t *testing.T) {
+		d := Parse("no-cache, max-age=86400")
+		policy := Policy{DefaultMaxAge: 24 * time.Hour}
+		assert.True(t, d.IsStaleFor(now.Add(-2*NoCacheGracePeriod), policy, "/obj"))
+	})
+
+	t.Run("explicit freshness overrides the default", func(t *testing.T) {
+		d := Parse("max-age=60")
+		// DefaultMaxAge of zero would make a directive-free response always
+		// stale; an explicit max-age still governs.
+		policy := Policy{DefaultMaxAge: 0}
+		assert.False(t, d.IsStaleFor(now.Add(-30*time.Second), policy, "/obj"))
+		assert.True(t, d.IsStaleFor(now.Add(-90*time.Second), policy, "/obj"))
+	})
+
+	t.Run("MaxFreshness caps a backend's claim", func(t *testing.T) {
+		d := Parse("max-age=3600")
+		uncapped := Policy{DefaultMaxAge: time.Hour}
+		capped := Policy{DefaultMaxAge: time.Hour, MaxFreshness: time.Minute}
+		assert.False(t, d.IsStaleFor(now.Add(-2*time.Minute), uncapped, "/obj"), "uncapped policy honours the backend")
+		assert.True(t, d.IsStaleFor(now.Add(-2*time.Minute), capped, "/obj"), "cap must bound the backend's max-age")
+		assert.False(t, d.IsStaleFor(now.Add(-30*time.Second), capped, "/obj"), "within the cap it is still fresh")
+	})
+
+	t.Run("MaxFreshness does not extend a short max-age", func(t *testing.T) {
+		d := Parse("max-age=10")
+		policy := Policy{DefaultMaxAge: time.Hour, MaxFreshness: time.Hour}
+		assert.True(t, d.IsStaleFor(now.Add(-time.Minute), policy, "/obj"))
+	})
+
+	t.Run("no default freshness means always stale", func(t *testing.T) {
+		d := Parse("")
+		assert.True(t, d.IsStaleFor(now, Policy{DefaultMaxAge: 0}, "/obj"))
+		assert.True(t, d.IsStaleFor(now, Policy{DefaultMaxAge: -time.Hour}, "/obj"))
+		assert.True(t, Parse("must-revalidate").IsStaleFor(now, Policy{}, "/obj"))
+	})
+
+	t.Run("default freshness applies when the response says nothing", func(t *testing.T) {
+		d := Parse("")
+		policy := Policy{DefaultMaxAge: time.Hour}
+		assert.False(t, d.IsStaleFor(now, policy, "/obj"))
+		assert.True(t, d.IsStaleFor(now.Add(-2*time.Hour), policy, "/obj"))
+	})
+
+	t.Run("jitter only shortens the default window", func(t *testing.T) {
+		d := Parse("")
+		policy := Policy{DefaultMaxAge: time.Hour, JitterPercent: 50}
+		// Half the window is inside the jitter floor for every key.
+		assert.False(t, d.IsStaleFor(now.Add(-29*time.Minute), policy, "/obj"))
+		assert.True(t, d.IsStaleFor(now.Add(-61*time.Minute), policy, "/obj"))
+	})
+}
+
+// FreshnessFor spreads expiry across objects without ever extending the
+// operator's window: it is deterministic per (time, key), never exceeds
+// defaultMaxAge, never drops below the jitter floor, differs between objects
+// validated at the same instant, and clamps nonsensical jitter percentages
+// instead of producing negative or over-long lifetimes.
+func TestFreshnessFor(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	const maxAge = time.Hour
+
+	t.Run("deterministic", func(t *testing.T) {
+		first := FreshnessFor(base, maxAge, 50, "/some/object")
+		for i := 0; i < 5; i++ {
+			assert.Equal(t, first, FreshnessFor(base, maxAge, 50, "/some/object"))
+		}
+	})
+
+	t.Run("no jitter yields the full window", func(t *testing.T) {
+		assert.Equal(t, maxAge, FreshnessFor(base, maxAge, 0, "/some/object"))
+		assert.Equal(t, maxAge, FreshnessFor(base, maxAge, 0, ""))
+	})
+
+	t.Run("bounded by the jitter floor and the full window", func(t *testing.T) {
+		const jitter = 50
+		floor := maxAge / 2
+		for i := 0; i < 200; i++ {
+			key := fmt.Sprintf("/obj-%d", i)
+			got := FreshnessFor(base, maxAge, jitter, key)
+			assert.GreaterOrEqual(t, got, floor, "key %s below the jitter floor", key)
+			assert.LessOrEqual(t, got, maxAge, "key %s exceeds the configured window", key)
+		}
+	})
+
+	t.Run("varies per object", func(t *testing.T) {
+		// Objects fetched together must not all expire together, so the same
+		// instant with different keys must not collapse to one lifetime.
+		assert.NotEqual(t, FreshnessFor(base, maxAge, 50, "/obj-a"), FreshnessFor(base, maxAge, 50, "/obj-b"))
+
+		distinct := make(map[time.Duration]bool)
+		for i := 0; i < 50; i++ {
+			distinct[FreshnessFor(base, maxAge, 50, fmt.Sprintf("/obj-%d", i))] = true
+		}
+		assert.Greater(t, len(distinct), 25, "jitter should spread objects across the window")
+	})
+
+	t.Run("empty key still varies with the validation time", func(t *testing.T) {
+		a := FreshnessFor(base, maxAge, 50, "")
+		b := FreshnessFor(base.Add(time.Second), maxAge, 50, "")
+		assert.Equal(t, a, FreshnessFor(base, maxAge, 50, ""), "must stay deterministic")
+		assert.NotEqual(t, a, b, "different validation instants should not share a lifetime")
+	})
+
+	t.Run("jitter percent is clamped", func(t *testing.T) {
+		key := "/clamped"
+		assert.Equal(t, FreshnessFor(base, maxAge, 0, key), FreshnessFor(base, maxAge, -25, key),
+			"negative jitter must behave like none")
+		assert.Equal(t, FreshnessFor(base, maxAge, 100, key), FreshnessFor(base, maxAge, 250, key),
+			"jitter above 100 must behave like 100")
+		full := FreshnessFor(base, maxAge, 250, key)
+		assert.GreaterOrEqual(t, full, time.Duration(0))
+		assert.LessOrEqual(t, full, maxAge)
+	})
+
+	t.Run("zero window stays zero", func(t *testing.T) {
+		assert.Equal(t, time.Duration(0), FreshnessFor(base, 0, 50, "/obj"))
+	})
+}
+
+// The persisted flag values are part of the local cache's on-disk format;
+// renumbering them would silently reinterpret every stored entry.
+func TestFlagValuesAreStable(t *testing.T) {
+	require.Equal(t, uint8(0x01), FlagNoStore)
+	require.Equal(t, uint8(0x02), FlagNoCache)
+	require.Equal(t, uint8(0x04), FlagPrivate)
+	require.Equal(t, uint8(0x08), FlagMustRevalidate)
+	require.Equal(t, uint8(0x10), FlagMaxAgeSet)
+
+	d := Parse("no-store, no-cache, private, must-revalidate, max-age=1")
+	assert.Equal(t, FlagNoStore|FlagNoCache|FlagPrivate|FlagMustRevalidate|FlagMaxAgeSet, d.Flags())
+}

--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -736,6 +736,8 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 	v.SetDefault(param.Origin_SelfTestMaxAge.GetName(), "1h")
 	// Origin.StorageCacheDefaultMaxAge
 	v.SetDefault(param.Origin_StorageCacheDefaultMaxAge.GetName(), "24h")
+	// Origin.StorageCacheMaxConcurrentFetches
+	v.SetDefault(param.Origin_StorageCacheMaxConcurrentFetches.GetName(), 32)
 	// Origin.StorageCacheRevalidationJitter
 	v.SetDefault(param.Origin_StorageCacheRevalidationJitter.GetName(), 10)
 	// Origin.StorageCacheSize

--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -734,6 +734,12 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 	v.SetDefault(param.Origin_SelfTestInterval.GetName(), "15s")
 	// Origin.SelfTestMaxAge
 	v.SetDefault(param.Origin_SelfTestMaxAge.GetName(), "1h")
+	// Origin.StorageCacheDefaultMaxAge
+	v.SetDefault(param.Origin_StorageCacheDefaultMaxAge.GetName(), "24h")
+	// Origin.StorageCacheRevalidationJitter
+	v.SetDefault(param.Origin_StorageCacheRevalidationJitter.GetName(), 10)
+	// Origin.StorageCacheSize
+	v.SetDefault(param.Origin_StorageCacheSize.GetName(), 0)
 	// Origin.StorageType
 	v.SetDefault(param.Origin_StorageType.GetName(), "posix")
 	// Origin.TransferRateLimit

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1962,6 +1962,63 @@ type: string
 default: none
 components: ["origin"]
 ---
+name: Origin.StorageCacheLocation
+description: |+
+  A directory on local disk where the origin caches objects fetched from a remote storage backend
+  (storage types `s3v2`, `https`, and `globusv2`), avoiding repeated egress from the remote provider.
+
+  Cache validity follows standard HTTP caching rules driven by the backend's Cache-Control
+  information (an S3 object's Cache-Control metadata, or the Cache-Control response header from an
+  HTTPS backend).  While a copy is fresh it is served with no backend interaction at all; once
+  stale, the origin revalidates with a single metadata request (ETag comparison) and only refetches
+  when the object actually changed.  Backends that supply no Cache-Control fall under the
+  Origin.StorageCacheDefaultMaxAge policy; `no-store`/`private` objects are never cached.
+
+  Object fetches triggered by a client read continue at full speed into the cache even when the
+  requesting client is slower, and complete even if the client disconnects.
+
+  The directory must be writable by the origin and should live on a filesystem large enough to hold
+  the working set; use Origin.StorageCacheSize to bound total usage.  Leaving this unset disables
+  the storage cache.  The setting has no effect for local (posix) storage types.
+type: string
+default: none
+components: ["origin"]
+---
+name: Origin.StorageCacheDefaultMaxAge
+description: |+
+  The default freshness lifetime for objects in the origin's storage cache (see
+  Origin.StorageCacheLocation) when the storage backend does not provide explicit Cache-Control
+  information.  While fresh, cached objects are served without contacting the backend; after this
+  lifetime, the origin revalidates the object's ETag with the backend before serving it again.
+
+  This mirrors LocalCache.DefaultMaxAge.  Setting this to 0 disables default freshness: every read
+  revalidates with the backend (a metadata-only request; no data egress) unless the backend's own
+  Cache-Control directives say otherwise.
+type: duration
+default: 24h
+components: ["origin"]
+---
+name: Origin.StorageCacheRevalidationJitter
+description: |+
+  A percentage (0-100) of deterministic per-object jitter applied to Origin.StorageCacheDefaultMaxAge,
+  preventing many objects cached at the same time from all revalidating simultaneously.  Mirrors
+  LocalCache.RevalidationJitter.
+type: int
+default: 10
+components: ["origin"]
+---
+name: Origin.StorageCacheSize
+description: |+
+  The maximum total size of the origin's local storage cache (see Origin.StorageCacheLocation).
+  This parameter can be provided with units (e.g., 20GB, 150MB); if no unit is provided, then
+  it is assumed to be in bytes.
+
+  When usage exceeds the limit, the least-recently-accessed objects are evicted until usage falls
+  below 90% of the limit.  If not set (or 0), the cache size is unbounded.
+type: string
+default: 0
+components: ["origin"]
+---
 name: Origin.HttpServiceUrl
 description: |+
   If Origin.StorageType is set to `https`, the service URL is used as the base for requests to the backend.  To generate the

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -1965,22 +1965,33 @@ components: ["origin"]
 name: Origin.StorageCacheLocation
 description: |+
   A directory on local disk where the origin caches objects fetched from a remote storage backend
-  (storage types `s3v2`, `https`, and `globusv2`), avoiding repeated egress from the remote provider.
+  (storage types `s3v2`, `httpsv2`, and `globusv2`), avoiding repeated egress from the remote
+  provider.
 
   Cache validity follows standard HTTP caching rules driven by the backend's Cache-Control
   information (an S3 object's Cache-Control metadata, or the Cache-Control response header from an
-  HTTPS backend).  While a copy is fresh it is served with no backend interaction at all; once
-  stale, the origin revalidates with a single metadata request (ETag comparison) and only refetches
-  when the object actually changed.  Backends that supply no Cache-Control fall under the
-  Origin.StorageCacheDefaultMaxAge policy; `no-store`/`private` objects are never cached.
+  HTTPS backend in plain-HTTP mode; WebDAV PROPFIND responses carry none).  While a copy is fresh
+  it is served with no backend interaction at all; once stale, the origin revalidates with a single
+  metadata request (ETag comparison) and only refetches when the object actually changed.  Backends
+  that supply no Cache-Control fall under the Origin.StorageCacheDefaultMaxAge policy.  Objects the
+  backend reports as `no-store` or `private` are not cached, and any copy already held is dropped
+  the next time the origin revalidates them.
 
   Object fetches triggered by a client read continue at full speed into the cache even when the
-  requesting client is slower, and complete even if the client disconnects.
+  requesting client is slower, and complete even if the client disconnects.  Two access patterns
+  deliberately read straight from the backend instead: content-type sniffing (so a HEAD request
+  costs no object egress) and byte-range requests that start beyond what has been fetched so far
+  (so a small ranged read never waits for a whole-object transfer).
 
-  The directory must be writable by the origin and should live on a filesystem large enough to hold
-  the working set; use Origin.StorageCacheSize to bound total usage.  Leaving this unset disables
-  the storage cache.  The setting has no effect for local (posix) storage types.
-type: string
+  The directory must be writable by the origin, must not be writable by other local users, and
+  should live on a filesystem large enough to hold the working set; use Origin.StorageCacheSize to
+  bound total usage.  Leaving this unset disables the storage cache.  The setting has no effect for
+  storage types that are not listed above.
+
+  This setting is incompatible with Origin.HttpAuthTokenPassthrough: passthrough makes the upstream
+  authorize each client's own token, whereas the cache is shared by all clients.  The origin refuses
+  to start if both are configured.
+type: filename
 default: none
 components: ["origin"]
 ---
@@ -1991,9 +2002,13 @@ description: |+
   information.  While fresh, cached objects are served without contacting the backend; after this
   lifetime, the origin revalidates the object's ETag with the backend before serving it again.
 
-  This mirrors LocalCache.DefaultMaxAge.  Setting this to 0 disables default freshness: every read
-  revalidates with the backend (a metadata-only request; no data egress) unless the backend's own
-  Cache-Control directives say otherwise.
+  This value also caps the freshness a backend may claim for itself: an object whose Cache-Control
+  requests a longer max-age is still revalidated after this lifetime, so whoever can write an
+  object's metadata cannot pin it in the cache indefinitely.
+
+  This mirrors LocalCache.DefaultMaxAge.  Setting this to 0 disables caching of read results
+  entirely: every read revalidates with the backend (a metadata-only request; no data egress)
+  regardless of what the backend's own Cache-Control directives say.
 type: duration
 default: 24h
 components: ["origin"]
@@ -2005,6 +2020,20 @@ description: |+
   LocalCache.RevalidationJitter.
 type: int
 default: 10
+hidden: true
+components: ["origin"]
+---
+name: Origin.StorageCacheMaxConcurrentFetches
+description: |+
+  The maximum number of objects the origin's storage cache (see Origin.StorageCacheLocation) will
+  copy from the backend at the same time.  Each in-flight copy holds a backend connection and a
+  1 MB buffer, so this bounds both the memory and the provider egress a burst of requests can
+  trigger.
+
+  Requests that arrive while every slot is busy are served directly from the backend and are not
+  cached, so the limit costs cache hit rate under load rather than availability.
+type: int
+default: 32
 components: ["origin"]
 ---
 name: Origin.StorageCacheSize
@@ -2014,7 +2043,9 @@ description: |+
   it is assumed to be in bytes.
 
   When usage exceeds the limit, the least-recently-accessed objects are evicted until usage falls
-  below 90% of the limit.  If not set (or 0), the cache size is unbounded.
+  below 90% of the limit.  If not set (or 0), the cache size is unbounded.  Note that eviction runs
+  periodically rather than admitting against the limit, so usage may briefly exceed it while many
+  objects are being fetched at once.
 type: string
 default: 0
 components: ["origin"]

--- a/e2e_fed_tests/posixv2_advanced_test.go
+++ b/e2e_fed_tests/posixv2_advanced_test.go
@@ -169,7 +169,7 @@ func TestPosixv2OriginListingHTTP(t *testing.T) {
 		},
 	}
 
-	err := origin_serve.InitializeHandlers(t.Context(), exports)
+	err := origin_serve.InitializeHandlers(t.Context(), nil, exports)
 	require.NoError(t, err)
 
 	// Initialize auth config (required by auth middleware)

--- a/launchers/origin_serve.go
+++ b/launchers/origin_serve.go
@@ -317,7 +317,7 @@ func OriginServeFinish(ctx context.Context, egrp *errgroup.Group, engine *gin.En
 			return errors.Wrap(err, "failed to initialize origin_serve auth config")
 		}
 
-		if err := origin_serve.InitializeHandlers(ctx, originExports); err != nil {
+		if err := origin_serve.InitializeHandlers(ctx, egrp, originExports); err != nil {
 			return errors.Wrap(err, "failed to initialize origin_serve handlers")
 		}
 

--- a/local_cache/cache_control.go
+++ b/local_cache/cache_control.go
@@ -125,6 +125,26 @@ func (cd *CacheDirectives) IsStaleWithDefaults(lastValidated time.Time) bool {
 	return time.Since(lastValidated) > DefaultFreshness(lastValidated)
 }
 
+// IsStaleFor is the policy-parameterized variant of IsStale, for callers
+// outside the local cache (e.g. the origin's storage cache) that apply their
+// own default freshness configuration.  Directives take precedence exactly as
+// in IsStale; when the response carries no freshness information, the given
+// defaultMaxAge (with deterministic jitter) applies.  A defaultMaxAge <= 0
+// means "no default freshness": such responses are always considered stale
+// and must be revalidated on every use.
+func (cd *CacheDirectives) IsStaleFor(lastValidated time.Time, defaultMaxAge time.Duration, jitterPercent int) bool {
+	if cd.NoCache() {
+		return time.Since(lastValidated) > NoCacheGracePeriod
+	}
+	if freshness, ok := cd.Freshness(); ok {
+		return time.Since(lastValidated) > freshness
+	}
+	if defaultMaxAge <= 0 {
+		return true
+	}
+	return time.Since(lastValidated) > DefaultFreshnessFor(lastValidated, defaultMaxAge, jitterPercent)
+}
+
 // DefaultFreshness returns the jittered freshness lifetime used when the origin
 // doesn't provide explicit Cache-Control headers.  The jitter is deterministic
 // per object (seeded from lastValidated) so that repeated calls for the same
@@ -134,8 +154,13 @@ func DefaultFreshness(lastValidated time.Time) time.Duration {
 	if defaultMaxAge <= 0 {
 		defaultMaxAge = 24 * time.Hour // Fallback default
 	}
+	return DefaultFreshnessFor(lastValidated, defaultMaxAge, param.LocalCache_RevalidationJitter.GetInt())
+}
 
-	jitterPercent := param.LocalCache_RevalidationJitter.GetInt()
+// DefaultFreshnessFor computes the jittered freshness lifetime for an
+// explicit default-max-age / jitter policy rather than the LocalCache
+// configuration.  See DefaultFreshness for the jitter semantics.
+func DefaultFreshnessFor(lastValidated time.Time, defaultMaxAge time.Duration, jitterPercent int) time.Duration {
 	if jitterPercent < 0 {
 		jitterPercent = 0
 	} else if jitterPercent > 100 {

--- a/local_cache/cache_control.go
+++ b/local_cache/cache_control.go
@@ -19,173 +19,80 @@
 package local_cache
 
 import (
-	"strconv"
-	"strings"
 	"time"
 
+	"github.com/pelicanplatform/pelican/cache_control"
 	"github.com/pelicanplatform/pelican/param"
 )
 
-// Bit flags for CacheDirectives.flags.
-// These are the same values used in CacheMetadata.CCFlags so that
-// round-tripping through storage is a direct copy.
+// Bit flags for the parsed directives.  These are the same values used in
+// CacheMetadata.CCFlags so that round-tripping through storage is a direct
+// copy; they live in the cache_control package, which owns the bit layout.
 const (
-	ccNoStore        uint8 = 0x01 // no-store
-	ccNoCache        uint8 = 0x02 // no-cache
-	ccPrivate        uint8 = 0x04 // private
-	ccMustRevalidate uint8 = 0x08 // must-revalidate
-	ccMaxAgeSet      uint8 = 0x10 // max-age or s-maxage was present
+	ccNoStore        = cache_control.FlagNoStore
+	ccNoCache        = cache_control.FlagNoCache
+	ccPrivate        = cache_control.FlagPrivate
+	ccMustRevalidate = cache_control.FlagMustRevalidate
+	ccMaxAgeSet      = cache_control.FlagMaxAgeSet
 )
 
-// CacheDirectives holds parsed Cache-Control header values that are
-// relevant to the persistent cache.
-//
-// Boolean directives are packed into a bitfield; use the accessor methods
-// (NoStore, NoCache, etc.) instead of reading fields directly.
-//
-// max-age and s-maxage are merged into a single freshness lifetime:
-// when both are present the maximum of the two is kept, because the
-// Pelican local cache does not distinguish shared from private.
-type CacheDirectives struct {
-	flags  uint8
-	maxAge time.Duration // merged freshness lifetime (valid only when ccMaxAgeSet is set)
-}
-
-// --- flag accessors --------------------------------------------------------
-
-func (cd *CacheDirectives) NoStore() bool         { return cd.flags&ccNoStore != 0 }
-func (cd *CacheDirectives) NoCache() bool         { return cd.flags&ccNoCache != 0 }
-func (cd *CacheDirectives) Private() bool         { return cd.flags&ccPrivate != 0 }
-func (cd *CacheDirectives) MustRevalidate() bool  { return cd.flags&ccMustRevalidate != 0 }
-func (cd *CacheDirectives) MaxAgeSet() bool       { return cd.flags&ccMaxAgeSet != 0 }
-func (cd *CacheDirectives) MaxAge() time.Duration { return cd.maxAge }
-
-// Flags returns the raw packed bitfield.
-// Callers should prefer the named accessors; this is provided for
-// efficient serialization into CacheMetadata.CCFlags.
-func (cd *CacheDirectives) Flags() uint8 { return cd.flags }
-
-// --- derived helpers -------------------------------------------------------
-
-// ShouldStore returns true if the response is allowed to be stored in the cache.
-func (cd *CacheDirectives) ShouldStore() bool {
-	return cd.flags&(ccNoStore|ccPrivate) == 0
-}
-
-// HasFreshness returns true if the origin provided explicit freshness
-// information (max-age or s-maxage).
-func (cd *CacheDirectives) HasFreshness() bool {
-	return cd.flags&ccMaxAgeSet != 0
-}
-
-// Freshness returns the merged freshness lifetime and whether it was set.
-func (cd *CacheDirectives) Freshness() (time.Duration, bool) {
-	if cd.flags&ccMaxAgeSet != 0 {
-		return cd.maxAge, true
-	}
-	return 0, false
-}
-
-// HasDirectives returns true if any Cache-Control directive was parsed.
-func (cd *CacheDirectives) HasDirectives() bool {
-	return cd.flags != 0 || cd.maxAge != 0
-}
-
 // NoCacheGracePeriod is the minimum interval between revalidation attempts
-// when the origin sends Cache-Control: no-cache.  Strictly speaking, no-cache
-// means "must revalidate before each use," but revalidation in Pelican
-// requires a full GET (no conditional-request support yet), which is
-// expensive.  A short grace period prevents a thundering-herd of redundant
-// downloads when many clients hit the same object concurrently.
-const NoCacheGracePeriod = 5 * time.Second
+// for an object whose origin sent Cache-Control: no-cache.
+const NoCacheGracePeriod = cache_control.NoCacheGracePeriod
 
-// IsStale checks whether a cached response is stale given when it was last
-// validated (or originally stored).
-// If no freshness information is available (no max-age / s-maxage / no-cache),
-// applies the default cache policy from params with jitter.
-func (cd *CacheDirectives) IsStale(lastValidated time.Time) bool {
-	if cd.NoCache() {
-		// no-cache requires revalidation, but we allow a short grace
-		// period to avoid thundering-herd when many concurrent requests
-		// arrive for the same object.
-		return time.Since(lastValidated) > NoCacheGracePeriod
-	}
-	freshness, ok := cd.Freshness()
-	if !ok {
-		// No explicit freshness info — apply default policy from configuration.
-		// This provides a sensible default for origins that don't set Cache-Control.
-		return cd.IsStaleWithDefaults(lastValidated)
-	}
-	return time.Since(lastValidated) > freshness
+// CacheDirectives holds parsed Cache-Control header values that are relevant
+// to the persistent cache.  The parsing and the freshness rules live in the
+// cache_control package; this type adds the local cache's own configuration
+// (LocalCache.DefaultMaxAge and LocalCache.RevalidationJitter) on top.
+type CacheDirectives struct {
+	cache_control.Directives
 }
 
-// IsStaleWithDefaults checks staleness using configured default values and jitter.
-// This is used when the origin doesn't provide explicit Cache-Control headers.
-func (cd *CacheDirectives) IsStaleWithDefaults(lastValidated time.Time) bool {
-	return time.Since(lastValidated) > DefaultFreshness(lastValidated)
+// ParseCacheControl parses a Cache-Control header value into structured
+// directives.  Directive names are matched case-insensitively; when both
+// max-age and s-maxage are present the larger is kept.
+func ParseCacheControl(header string) CacheDirectives {
+	return CacheDirectives{cache_control.Parse(header)}
 }
 
-// IsStaleFor is the policy-parameterized variant of IsStale, for callers
-// outside the local cache (e.g. the origin's storage cache) that apply their
-// own default freshness configuration.  Directives take precedence exactly as
-// in IsStale; when the response carries no freshness information, the given
-// defaultMaxAge (with deterministic jitter) applies.  A defaultMaxAge <= 0
-// means "no default freshness": such responses are always considered stale
-// and must be revalidated on every use.
-func (cd *CacheDirectives) IsStaleFor(lastValidated time.Time, defaultMaxAge time.Duration, jitterPercent int) bool {
-	if cd.NoCache() {
-		return time.Since(lastValidated) > NoCacheGracePeriod
-	}
-	if freshness, ok := cd.Freshness(); ok {
-		return time.Since(lastValidated) > freshness
-	}
-	if defaultMaxAge <= 0 {
-		return true
-	}
-	return time.Since(lastValidated) > DefaultFreshnessFor(lastValidated, defaultMaxAge, jitterPercent)
-}
-
-// DefaultFreshness returns the jittered freshness lifetime used when the origin
-// doesn't provide explicit Cache-Control headers.  The jitter is deterministic
-// per object (seeded from lastValidated) so that repeated calls for the same
-// object return the same duration.
-func DefaultFreshness(lastValidated time.Time) time.Duration {
+// localCachePolicy returns the freshness policy from the LocalCache
+// configuration.  The local cache trusts its origins' Cache-Control values, so
+// no MaxFreshness cap is applied.
+func localCachePolicy() cache_control.Policy {
 	defaultMaxAge := param.LocalCache_DefaultMaxAge.GetDuration()
 	if defaultMaxAge <= 0 {
 		defaultMaxAge = 24 * time.Hour // Fallback default
 	}
-	return DefaultFreshnessFor(lastValidated, defaultMaxAge, param.LocalCache_RevalidationJitter.GetInt())
+	return cache_control.Policy{
+		DefaultMaxAge: defaultMaxAge,
+		JitterPercent: param.LocalCache_RevalidationJitter.GetInt(),
+	}
 }
 
-// DefaultFreshnessFor computes the jittered freshness lifetime for an
-// explicit default-max-age / jitter policy rather than the LocalCache
-// configuration.  See DefaultFreshness for the jitter semantics.
-func DefaultFreshnessFor(lastValidated time.Time, defaultMaxAge time.Duration, jitterPercent int) time.Duration {
-	if jitterPercent < 0 {
-		jitterPercent = 0
-	} else if jitterPercent > 100 {
-		jitterPercent = 100
-	}
+// IsStale checks whether a cached response is stale given when it was last
+// validated (or originally stored).  If the origin supplied no freshness
+// information, the configured LocalCache default policy applies, with jitter.
+func (cd *CacheDirectives) IsStale(lastValidated time.Time) bool {
+	return cd.IsStaleFor(lastValidated, localCachePolicy(), "")
+}
 
-	// Apply jitter: reduce max age by up to jitterPercent, picking a value
-	// uniformly in [minFreshness, defaultMaxAge]. For example, with 10% jitter
-	// and a defaultMaxAge of 24h, minFreshness is 21.6h and the actual freshness
-	// is chosen deterministically per object between 21.6h and 24h.
-	jitterFactor := 1.0 - (float64(jitterPercent) / 100.0)
-	minFreshness := time.Duration(float64(defaultMaxAge) * jitterFactor)
+// IsStaleWithDefaults checks staleness using the configured default values and
+// jitter, ignoring any freshness directive the origin supplied.
+func (cd *CacheDirectives) IsStaleWithDefaults(lastValidated time.Time) bool {
+	return time.Since(lastValidated) > DefaultFreshness(lastValidated)
+}
 
-	// Use a simple hash of the validation time to get deterministic randomness.
-	// This ensures the same object gets the same jitter value across requests.
-	seed := uint64(lastValidated.Unix())
-	seed = seed ^ (seed >> 33)
-	seed *= 0xff51afd7ed558ccd
-	seed = seed ^ (seed >> 33)
-	jitterRand := float64(seed%10000) / 10000.0 // 0.0 to 1.0
-
-	// Choose a jittered freshness in [minFreshness, defaultMaxAge] so that
-	// jitter only reduces freshness and never exceeds defaultMaxAge.
-	rangeDur := defaultMaxAge - minFreshness
-	return minFreshness + time.Duration(float64(rangeDur)*jitterRand)
+// DefaultFreshness returns the jittered freshness lifetime used when the origin
+// doesn't provide explicit Cache-Control headers.
+//
+// The jitter is deterministic in lastValidated, so repeated calls for the same
+// object return the same duration.  Note that the local cache does not key the
+// jitter by object: objects validated within the same second share a jitter
+// value.  (Callers that need per-object spreading, such as the origin's
+// storage cache, call cache_control.FreshnessFor with an object key.)
+func DefaultFreshness(lastValidated time.Time) time.Duration {
+	p := localCachePolicy()
+	return cache_control.FreshnessFor(lastValidated, p.DefaultMaxAge, p.JitterPercent, "")
 }
 
 // RemainingFreshness returns how much freshness lifetime is left for an object
@@ -196,79 +103,4 @@ func RemainingFreshness(lastValidated time.Time) time.Duration {
 		return 0
 	}
 	return remaining
-}
-
-// ParseCacheControl parses a Cache-Control header value into structured
-// directives.
-// The parsing is case-insensitive for directive names, as required by RFC 7234.
-// When both max-age and s-maxage are present, the maximum of the two durations
-// is kept (the Pelican local cache does not distinguish shared from private).
-func ParseCacheControl(header string) CacheDirectives {
-	var cd CacheDirectives
-	if header == "" {
-		return cd
-	}
-
-	var (
-		maxAge    time.Duration
-		maxAgeOk  bool
-		sMaxAge   time.Duration
-		sMaxAgeOk bool
-	)
-
-	for _, part := range strings.Split(header, ",") {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-
-		// Split on '=' for directives with values
-		directive := part
-		value := ""
-		if eqIdx := strings.IndexByte(part, '='); eqIdx >= 0 {
-			directive = strings.TrimSpace(part[:eqIdx])
-			value = strings.TrimSpace(part[eqIdx+1:])
-			// Strip surrounding quotes from value
-			value = strings.Trim(value, "\"")
-		}
-
-		switch strings.ToLower(directive) {
-		case "no-store":
-			cd.flags |= ccNoStore
-		case "no-cache":
-			cd.flags |= ccNoCache
-		case "private":
-			cd.flags |= ccPrivate
-		case "must-revalidate":
-			cd.flags |= ccMustRevalidate
-		case "max-age":
-			if seconds, err := strconv.ParseInt(value, 10, 64); err == nil && seconds >= 0 {
-				maxAge = time.Duration(seconds) * time.Second
-				maxAgeOk = true
-			}
-		case "s-maxage":
-			if seconds, err := strconv.ParseInt(value, 10, 64); err == nil && seconds >= 0 {
-				sMaxAge = time.Duration(seconds) * time.Second
-				sMaxAgeOk = true
-			}
-		}
-	}
-
-	// Merge max-age and s-maxage: take the maximum of the two.
-	switch {
-	case maxAgeOk && sMaxAgeOk:
-		cd.maxAge = maxAge
-		if sMaxAge > maxAge {
-			cd.maxAge = sMaxAge
-		}
-		cd.flags |= ccMaxAgeSet
-	case sMaxAgeOk:
-		cd.maxAge = sMaxAge
-		cd.flags |= ccMaxAgeSet
-	case maxAgeOk:
-		cd.maxAge = maxAge
-		cd.flags |= ccMaxAgeSet
-	}
-
-	return cd
 }

--- a/local_cache/schema.go
+++ b/local_cache/schema.go
@@ -31,6 +31,7 @@ import (
 
 	"golang.org/x/net/idna"
 
+	"github.com/pelicanplatform/pelican/cache_control"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/utils"
 )
@@ -613,14 +614,11 @@ func (m *CacheMetadata) SetCacheControl(header string) {
 
 // GetCacheDirectives returns the parsed cache directives
 func (m *CacheMetadata) GetCacheDirectives() CacheDirectives {
-	cd := CacheDirectives{
-		flags: m.CCFlags & 0x0F, // restore boolean flags
+	// Restore the boolean flags; a positive CCMaxAge implies ccMaxAgeSet,
+	// which is why that bit is not persisted separately.
+	return CacheDirectives{
+		cache_control.FromFlags(m.CCFlags&0x0F, time.Duration(m.CCMaxAge)*time.Second),
 	}
-	if m.CCMaxAge > 0 {
-		cd.maxAge = time.Duration(m.CCMaxAge) * time.Second
-		cd.flags |= ccMaxAgeSet
-	}
-	return cd
 }
 
 // GetCacheControlHeader reconstructs the Cache-Control header string for HTTP responses.

--- a/origin_serve/backend_blob.go
+++ b/origin_serve/backend_blob.go
@@ -512,10 +512,11 @@ func (fs *blobFileSystem) Stat(ctx context.Context, name string) (os.FileInfo, e
 	attrs, err := fs.bucket.Attributes(ctx, key)
 	if err == nil {
 		return &blobFileInfo{
-			name: path.Base(name),
-			size: attrs.Size,
-			mod:  attrs.ModTime,
-			etag: attrs.ETag,
+			name:         path.Base(name),
+			size:         attrs.Size,
+			mod:          attrs.ModTime,
+			etag:         attrs.ETag,
+			cacheControl: attrs.CacheControl,
 		}, nil
 	}
 
@@ -549,16 +550,20 @@ func isNotFound(err error) bool {
 // ---------------------------------------------------------------------------
 
 type blobFileInfo struct {
-	name  string
-	size  int64
-	mod   time.Time
-	isDir bool
-	etag  string
+	name         string
+	size         int64
+	mod          time.Time
+	isDir        bool
+	etag         string
+	cacheControl string
 }
 
 // BlobFileSysInfo is returned by blobFileInfo.Sys() when metadata is available.
 type BlobFileSysInfo struct {
 	ETag string
+	// CacheControl is the object's Cache-Control metadata as reported by the
+	// provider (e.g. the S3 object's Cache-Control attribute), if any.
+	CacheControl string
 }
 
 func (fi *blobFileInfo) Name() string      { return fi.name }
@@ -572,8 +577,8 @@ func (fi *blobFileInfo) ModTime() time.Time {
 }
 func (fi *blobFileInfo) IsDir() bool { return fi.isDir }
 func (fi *blobFileInfo) Sys() interface{} {
-	if fi.etag != "" {
-		return &BlobFileSysInfo{ETag: fi.etag}
+	if fi.etag != "" || fi.cacheControl != "" {
+		return &BlobFileSysInfo{ETag: fi.etag, CacheControl: fi.cacheControl}
 	}
 	return nil
 }

--- a/origin_serve/backend_https.go
+++ b/origin_serve/backend_https.go
@@ -530,11 +530,12 @@ func (fs *httpsFileSystem) Stat(ctx context.Context, name string) (os.FileInfo, 
 	}
 
 	return &httpsFileInfo{
-		name:    path.Base(name),
-		size:    resp.ContentLength,
-		modTime: parseHTTPDate(resp.Header.Get("Last-Modified")),
-		isDir:   false,
-		etag:    resp.Header.Get("ETag"),
+		name:         path.Base(name),
+		size:         resp.ContentLength,
+		modTime:      parseHTTPDate(resp.Header.Get("Last-Modified")),
+		isDir:        false,
+		etag:         resp.Header.Get("ETag"),
+		cacheControl: resp.Header.Get("Cache-Control"),
 	}, nil
 }
 
@@ -603,14 +604,18 @@ func (auth *simpleBearerAuthenticator) Clone() gowebdav.Authenticator {
 // HTTPS/WebDAV server.  Returned by httpsFileInfo.Sys() when populated.
 type HTTPSFileSysInfo struct {
 	ETag string
+	// CacheControl is the upstream response's Cache-Control header, if any
+	// (only available in HTTP-only mode; WebDAV PROPFIND does not carry it).
+	CacheControl string
 }
 
 type httpsFileInfo struct {
-	name    string
-	size    int64
-	modTime time.Time
-	isDir   bool
-	etag    string
+	name         string
+	size         int64
+	modTime      time.Time
+	isDir        bool
+	etag         string
+	cacheControl string
 }
 
 func (fi *httpsFileInfo) Name() string      { return fi.name }
@@ -624,8 +629,8 @@ func (fi *httpsFileInfo) ModTime() time.Time {
 }
 func (fi *httpsFileInfo) IsDir() bool { return fi.isDir }
 func (fi *httpsFileInfo) Sys() interface{} {
-	if fi.etag != "" {
-		return &HTTPSFileSysInfo{ETag: fi.etag}
+	if fi.etag != "" || fi.cacheControl != "" {
+		return &HTTPSFileSysInfo{ETag: fi.etag, CacheControl: fi.cacheControl}
 	}
 	return nil
 }

--- a/origin_serve/handlers.go
+++ b/origin_serve/handlers.go
@@ -41,6 +41,7 @@ import (
 	"github.com/spf13/afero"
 	"golang.org/x/net/webdav"
 	"golang.org/x/oauth2"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/database"
@@ -693,8 +694,11 @@ func xrdMonitoringMiddleware() gin.HandlerFunc {
 	}
 }
 
-// InitializeHandlers initializes the WebDAV handlers for each export
-func InitializeHandlers(ctx context.Context, exports []server_utils.OriginExport) error {
+// InitializeHandlers initializes the WebDAV handlers for each export.  egrp
+// owns any background task the handlers start (currently the storage cache's
+// janitor) so it is awaited at shutdown; it may be nil in tests that do not
+// exercise those tasks.
+func InitializeHandlers(ctx context.Context, egrp *errgroup.Group, exports []server_utils.OriginExport) error {
 	// Validate that if DisableDirectClients is enabled, no exports have DirectReads
 	if param.Origin_DisableDirectClients.GetBool() {
 		for _, export := range exports {
@@ -828,24 +832,55 @@ func InitializeHandlers(ctx context.Context, exports []server_utils.OriginExport
 	if loc := param.Origin_StorageCacheLocation.GetString(); loc != "" {
 		switch storageType {
 		case server_structs.OriginStorageS3v2, server_structs.OriginStorageHTTPSv2, server_structs.OriginStorageGlobusv2:
+			// With token passthrough the upstream, not Pelican, decides what
+			// each client may read, and it decides per credential.  A shared
+			// cache has no credential dimension: one user's copy would be
+			// served to every other user who clears the origin's own
+			// namespace check.  Refuse the combination rather than silently
+			// widening access.
+			if param.Origin_HttpAuthTokenPassthrough.GetBool() {
+				return fmt.Errorf("Origin.StorageCacheLocation cannot be used with Origin.HttpAuthTokenPassthrough: " +
+					"the cache is shared across clients, but passthrough makes the upstream authorize each client's " +
+					"token individually; unset one of the two")
+			}
 			var cacheSize int64
 			if sizeStr := param.Origin_StorageCacheSize.GetString(); sizeStr != "" && sizeStr != "0" {
 				parsed, err := units.ParseStrictBytes(sizeStr)
 				if err != nil {
 					return fmt.Errorf("failed to parse Origin.StorageCacheSize %q: %w", sizeStr, err)
 				}
+				if parsed < 0 {
+					return fmt.Errorf("Origin.StorageCacheSize %q is negative; use 0 for an unbounded cache", sizeStr)
+				}
 				cacheSize = parsed
 			}
+			jitter := param.Origin_StorageCacheRevalidationJitter.GetInt()
+			if jitter < 0 || jitter > 100 {
+				return fmt.Errorf("Origin.StorageCacheRevalidationJitter must be a percentage between 0 and 100, got %d", jitter)
+			}
+			maxAge := param.Origin_StorageCacheDefaultMaxAge.GetDuration()
+			if maxAge < 0 {
+				return fmt.Errorf("Origin.StorageCacheDefaultMaxAge must not be negative, got %s", maxAge)
+			}
+			concurrency := param.Origin_StorageCacheMaxConcurrentFetches.GetInt()
+			if concurrency <= 0 {
+				return fmt.Errorf("Origin.StorageCacheMaxConcurrentFetches must be positive, got %d", concurrency)
+			}
 			var err error
-			storageCacheMgr, err = newStorageCache(ctx, loc, cacheSize,
-				param.Origin_StorageCacheDefaultMaxAge.GetDuration(),
-				param.Origin_StorageCacheRevalidationJitter.GetInt())
+			storageCacheMgr, err = newStorageCache(ctx, loc, cacheSize, maxAge, jitter, concurrency)
 			if err != nil {
 				return err
 			}
-			log.Infof("Origin storage cache enabled at %s (max size: %d bytes; 0 means unbounded)", loc, cacheSize)
+			if egrp != nil {
+				egrp.Go(func() error {
+					storageCacheMgr.runJanitor()
+					return nil
+				})
+			}
+			log.Infof("Origin storage cache enabled at %s (max size: %d bytes, 0 means unbounded; up to %d concurrent fetches)",
+				loc, cacheSize, concurrency)
 		default:
-			log.Warningf("Origin.StorageCacheLocation is set but storage type %q reads local storage directly; ignoring the storage cache", storageType)
+			log.Warningf("Origin.StorageCacheLocation is set but storage type %q does not support the origin storage cache; ignoring it", storageType)
 		}
 	}
 
@@ -1132,8 +1167,15 @@ func InitializeHandlers(ctx context.Context, exports []server_utils.OriginExport
 		}
 
 		// Interpose the storage cache between the handler and the backend.
+		// The backend identity folded into the cache scope covers everything
+		// that changes which bytes a given object path resolves to, so
+		// repointing an export at other storage cannot serve entries cached
+		// from the previous one.
 		if storageCacheMgr != nil {
-			backend = newCachedBackend(backend, storageCacheMgr.newLayer(export.FederationPrefix, backend.FileSystem()))
+			backendID := fmt.Sprintf("%s\x00%s\x00%s\x00%s", storageType, export.StoragePrefix,
+				param.Origin_S3ServiceUrl.GetString()+param.Origin_HttpServiceUrl.GetString(),
+				export.S3Bucket+export.GlobusCollectionID)
+			backend = newCachedBackend(backend, storageCacheMgr.newLayer(export.FederationPrefix, backendID, backend.FileSystem()))
 			log.Infof("Storage cache layered over backend for %s", export.FederationPrefix)
 		}
 

--- a/origin_serve/handlers.go
+++ b/origin_serve/handlers.go
@@ -35,6 +35,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/alecthomas/units"
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -820,6 +821,34 @@ func InitializeHandlers(ctx context.Context, exports []server_utils.OriginExport
 	// Determine storage type for filesystem creation
 	storageType := server_structs.OriginStorageType(param.Origin_StorageType.GetString())
 
+	// The storage cache keeps local copies of objects fetched from remote
+	// backends (avoiding repeated provider egress).  It is shared across
+	// exports so the configured size bound applies to the whole tree.
+	var storageCacheMgr *storageCache
+	if loc := param.Origin_StorageCacheLocation.GetString(); loc != "" {
+		switch storageType {
+		case server_structs.OriginStorageS3v2, server_structs.OriginStorageHTTPSv2, server_structs.OriginStorageGlobusv2:
+			var cacheSize int64
+			if sizeStr := param.Origin_StorageCacheSize.GetString(); sizeStr != "" && sizeStr != "0" {
+				parsed, err := units.ParseStrictBytes(sizeStr)
+				if err != nil {
+					return fmt.Errorf("failed to parse Origin.StorageCacheSize %q: %w", sizeStr, err)
+				}
+				cacheSize = parsed
+			}
+			var err error
+			storageCacheMgr, err = newStorageCache(ctx, loc, cacheSize,
+				param.Origin_StorageCacheDefaultMaxAge.GetDuration(),
+				param.Origin_StorageCacheRevalidationJitter.GetInt())
+			if err != nil {
+				return err
+			}
+			log.Infof("Origin storage cache enabled at %s (max size: %d bytes; 0 means unbounded)", loc, cacheSize)
+		default:
+			log.Warningf("Origin.StorageCacheLocation is set but storage type %q reads local storage directly; ignoring the storage cache", storageType)
+		}
+	}
+
 	for _, export := range exports {
 		var backend server_utils.OriginBackend
 
@@ -1100,6 +1129,12 @@ func InitializeHandlers(ctx context.Context, exports []server_utils.OriginExport
 			}
 
 			backend = newLocalBackend(fs, export.StoragePrefix)
+		}
+
+		// Interpose the storage cache between the handler and the backend.
+		if storageCacheMgr != nil {
+			backend = newCachedBackend(backend, storageCacheMgr.newLayer(export.FederationPrefix, backend.FileSystem()))
+			log.Infof("Storage cache layered over backend for %s", export.FederationPrefix)
 		}
 
 		// Create a WebDAV handler

--- a/origin_serve/metadata_handlers_e2e_test.go
+++ b/origin_serve/metadata_handlers_e2e_test.go
@@ -50,7 +50,7 @@ import (
 
 // TestE2E_InitializeHandlers_EventualPublish is the "true standalone origin"
 // test: rather than hand-assembling the POSC + controller + webdav stack, it
-// boots the real handler wiring via InitializeHandlers(ctx, exports) — the
+// boots the real handler wiring via InitializeHandlers(ctx, egrp, exports) — the
 // exact handlers.go path where the eventual-mode bug lived — with POSC on, a
 // non-root export, eventual mode, a real SQLite ServerDatabase (migrations +
 // batcher), and real token auth. An authenticated PUT flows through the
@@ -106,7 +106,7 @@ func TestE2E_InitializeHandlers_EventualPublish(t *testing.T) {
 	t.Cleanup(ResetHandlers)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	if err := InitializeHandlers(ctx, exports); err != nil {
+	if err := InitializeHandlers(ctx, nil, exports); err != nil {
 		t.Fatalf("InitializeHandlers: %v", err)
 	}
 
@@ -208,7 +208,7 @@ func TestE2E_InitializeHandlers_LifecycleEvents(t *testing.T) {
 	t.Cleanup(ResetHandlers)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	if err := InitializeHandlers(ctx, exports); err != nil {
+	if err := InitializeHandlers(ctx, nil, exports); err != nil {
 		t.Fatalf("InitializeHandlers: %v", err)
 	}
 	egrp := &errgroup.Group{}

--- a/origin_serve/metrics_e2e_test.go
+++ b/origin_serve/metrics_e2e_test.go
@@ -118,7 +118,7 @@ func setupE2ETestServer(t *testing.T) (*httptest.Server, string, func()) {
 	}
 
 	// Initialize handlers
-	err = InitializeHandlers(t.Context(), exports)
+	err = InitializeHandlers(t.Context(), nil, exports)
 	require.NoError(t, err)
 
 	// Initialize auth config for the test (required even for public reads)
@@ -283,7 +283,7 @@ func TestMetricsRecordedForAuthRejection(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, InitializeHandlers(context.Background(), exports))
+	require.NoError(t, InitializeHandlers(context.Background(), nil, exports))
 
 	ac := &authConfig{}
 	ac.exports.Store(&exports)

--- a/origin_serve/pstore_serving_test.go
+++ b/origin_serve/pstore_serving_test.go
@@ -125,7 +125,7 @@ func newServedOrigin(t *testing.T, exports []server_utils.OriginExport, storageD
 		_ = egrp.Wait()
 	})
 
-	require.NoError(t, InitializeHandlers(ctx, exports))
+	require.NoError(t, InitializeHandlers(ctx, nil, exports))
 	require.NoError(t, InitAuthConfig(ctx, egrp, exports))
 
 	gin.SetMode(gin.TestMode)

--- a/origin_serve/storage_cache_fed_test.go
+++ b/origin_serve/storage_cache_fed_test.go
@@ -1,0 +1,217 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package origin_serve_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/fed_test_utils"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/test_utils"
+)
+
+// ---------------------------------------------------------------------------
+// e2eBackend — an instrumented HTTP object store standing in for the remote
+// provider (the thing whose egress the storage cache exists to avoid).
+// Serves OPTIONS/HEAD/GET so the origin's httpsv2 backend detects plain-HTTP
+// mode; counts data (GET) and metadata (HEAD) requests separately.
+// ---------------------------------------------------------------------------
+
+type e2eBackendObject struct {
+	content []byte
+	etag    string
+	mod     time.Time
+}
+
+type e2eBackend struct {
+	mu      sync.Mutex
+	objects map[string]e2eBackendObject
+	gets    int
+	heads   int
+	srv     *httptest.Server
+}
+
+func newE2EBackend(t *testing.T) *e2eBackend {
+	b := &e2eBackend{objects: make(map[string]e2eBackendObject)}
+	b.srv = httptest.NewServer(http.HandlerFunc(b.handle))
+	t.Cleanup(b.srv.Close)
+	return b
+}
+
+func (b *e2eBackend) put(p, content, etag string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.objects[path.Clean("/"+p)] = e2eBackendObject{content: []byte(content), etag: etag, mod: time.Now()}
+}
+
+func (b *e2eBackend) counts() (gets, heads int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.gets, b.heads
+}
+
+func (b *e2eBackend) handle(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodOptions:
+		// No DAV/PROPFIND advertised: the origin treats us as plain HTTP.
+		w.Header().Set("Allow", "OPTIONS, GET, HEAD")
+		w.WriteHeader(http.StatusOK)
+		return
+	case http.MethodGet, http.MethodHead:
+		b.mu.Lock()
+		obj, ok := b.objects[path.Clean(r.URL.Path)]
+		if ok {
+			if r.Method == http.MethodGet {
+				b.gets++
+			} else {
+				b.heads++
+			}
+		}
+		b.mu.Unlock()
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("ETag", obj.etag)
+		http.ServeContent(w, r, path.Base(r.URL.Path), obj.mod, bytes.NewReader(obj.content))
+		return
+	}
+	w.WriteHeader(http.StatusMethodNotAllowed)
+}
+
+// countCacheFiles tallies the .data and .meta files under the storage cache
+// directory on real disk.
+func countCacheFiles(t *testing.T, cacheDir string) (dataFiles, metaFiles int) {
+	t.Helper()
+	err := filepath.WalkDir(cacheDir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		switch {
+		case strings.HasSuffix(p, ".data"):
+			dataFiles++
+		case strings.HasSuffix(p, ".meta"):
+			metaFiles++
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	return
+}
+
+// TestStorageCacheFedE2E spins up a complete federation (director, registry,
+// origin, caches) with an httpsv2 origin whose remote backend is an
+// instrumented HTTP server, and the origin storage cache enabled.  It then
+// performs real client downloads through federation discovery and direct
+// reads, asserting:
+//
+//  1. the cold read pulls the object from the backend into the cache;
+//  2. a warm read serves the same bytes with ZERO additional backend
+//     traffic (no GET, no HEAD — the freshness window elides even
+//     revalidation);
+//  3. mutating the backend object does not change what a fresh cache serves
+//     (standard HTTP freshness semantics), proving the bytes come from the
+//     origin's local disk rather than the provider.
+func TestStorageCacheFedE2E(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+
+	backend := newE2EBackend(t)
+	cacheDir := t.TempDir()
+
+	cfg := fmt.Sprintf(`
+Origin:
+  StorageType: httpsv2
+  HttpServiceUrl: %q
+  StorageCacheLocation: %q
+  Exports:
+    - StoragePrefix: /<SHOULD BE OVERRIDDEN>
+      FederationPrefix: /test
+      Capabilities: ["PublicReads", "Reads", "DirectReads"]
+`, backend.srv.URL, cacheDir)
+
+	// The fed harness rewrites StoragePrefix to a fresh temp directory; for
+	// an httpsv2 origin that prefix is simply the path prepended on the
+	// backend, so register the object under it via the setup hook.
+	const objContent = "storage cache e2e payload -- hello from the provider"
+	var exportPrefix string
+	ft := fed_test_utils.NewFedTest(t, cfg, func(storageDir string) {
+		exportPrefix = storageDir
+		backend.put(path.Join(storageDir, "cached.txt"), objContent, `"sc-e2e-v1"`)
+	})
+
+	fedUrl := fmt.Sprintf("pelican://%s:%s/test/cached.txt?directread",
+		param.Server_Hostname.GetString(), strconv.Itoa(param.Server_WebPort.GetInt()))
+
+	download := func(name string) string {
+		dest := filepath.Join(t.TempDir(), name)
+		tr, err := client.DoGet(ft.Ctx, fedUrl, dest, false)
+		require.NoError(t, err)
+		require.Len(t, tr, 1)
+		require.NoError(t, tr[0].Error)
+		data, err := os.ReadFile(dest)
+		require.NoError(t, err)
+		return string(data)
+	}
+
+	// 1. Cold read: the origin fetches from the backend and installs the
+	// object in its storage cache.
+	require.Equal(t, objContent, download("cold.txt"))
+	coldGets, coldHeads := backend.counts()
+	require.GreaterOrEqual(t, coldGets, 1, "cold read must fetch data from the backend")
+
+	dataFiles, metaFiles := countCacheFiles(t, cacheDir)
+	require.Equal(t, 1, dataFiles, "cold read should leave one cached object")
+	require.Equal(t, 1, metaFiles, "cold read should leave one sidecar")
+
+	// 2. Warm read: identical bytes, and the backend sees no traffic at all —
+	// the entry is fresh, so even the revalidation HEAD is skipped.
+	require.Equal(t, objContent, download("warm.txt"))
+	warmGets, warmHeads := backend.counts()
+	assert.Equal(t, coldGets, warmGets, "warm read must not fetch data from the backend")
+	assert.Equal(t, coldHeads, warmHeads, "warm read must not even stat the backend")
+
+	// 3. Mutate the object at the provider.  The origin's copy is still
+	// fresh, so it keeps serving the validated bytes without contacting the
+	// backend — proof the response comes from local disk.
+	backend.put(path.Join(exportPrefix, "cached.txt"), "mutated at the provider", `"sc-e2e-v2"`)
+	require.Equal(t, objContent, download("fresh.txt"))
+	finalGets, finalHeads := backend.counts()
+	assert.Equal(t, coldGets, finalGets)
+	assert.Equal(t, coldHeads, finalHeads)
+}

--- a/origin_serve/storage_cache_fed_test.go
+++ b/origin_serve/storage_cache_fed_test.go
@@ -195,9 +195,17 @@ Origin:
 	coldGets, coldHeads := backend.counts()
 	require.GreaterOrEqual(t, coldGets, 1, "cold read must fetch data from the backend")
 
-	dataFiles, metaFiles := countCacheFiles(t, cacheDir)
-	require.Equal(t, 1, dataFiles, "cold read should leave one cached object")
-	require.Equal(t, 1, metaFiles, "cold read should leave one sidecar")
+	// The copy is deliberately detached from the client: ServeContent writes
+	// exactly Content-Length bytes, so the download completes as soon as the
+	// last byte is readable, which is strictly before the fetch goroutine
+	// installs the sidecar that marks the entry complete.  Wait for the entry
+	// to land rather than assuming the client's completion implies it -- from
+	// outside the process there is no other signal, and asserting immediately
+	// is a race the client wins on a loaded machine.
+	require.Eventually(t, func() bool {
+		dataFiles, metaFiles := countCacheFiles(t, cacheDir)
+		return dataFiles == 1 && metaFiles == 1
+	}, 30*time.Second, 20*time.Millisecond, "cold read should leave one cached object and one sidecar")
 
 	// 2. Warm read: identical bytes, and the backend sees no traffic at all —
 	// the entry is fresh, so even the revalidation HEAD is skipped.

--- a/origin_serve/storage_cache_fs.go
+++ b/origin_serve/storage_cache_fs.go
@@ -1,0 +1,1150 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Storage cache: a webdav.FileSystem layer that keeps a local-disk copy of
+// objects fetched from a remote origin backend (S3/blob, HTTPS, Globus).
+//
+// The cache exists to avoid repeated egress from the remote provider: an
+// origin physically located outside the provider (e.g. outside AWS) pays for
+// every byte read from the backend, so a large local disk can absorb repeat
+// reads.  Consistency follows the standard ETag revalidation rules: every
+// read stats the upstream backend (a metadata-only operation with no data
+// egress) and serves the local copy only when the upstream validator — the
+// provider's ETag when available, otherwise a size/mtime-derived tag — still
+// matches the one recorded when the copy was fetched.
+//
+// Freshness follows the same Cache-Control infrastructure the Pelican local
+// cache uses (local_cache.CacheDirectives): the backend's Cache-Control —
+// S3 object metadata or the upstream HTTPS response header — governs how
+// long a copy may be served with no upstream interaction at all.  When the
+// backend supplies no directives, a configurable default freshness lifetime
+// applies (Origin.StorageCacheDefaultMaxAge, jittered per object like
+// LocalCache.DefaultMaxAge).  Only once a copy goes stale does the layer
+// revalidate: one upstream stat compares validators, and a match simply
+// renews the freshness window without refetching.  no-store / private
+// responses bypass the cache entirely; no-cache responses are cached but
+// revalidated on (almost) every use.
+//
+// Fetches are decoupled from the requesting client: the upstream-to-disk
+// copy runs in its own goroutine at full speed, while the client reads from
+// the growing local file at its own pace.  A slow or disconnected client
+// never stalls (or cancels) the fetch, so the cache always ends up with a
+// complete copy that later readers can reuse.  Concurrent readers of the
+// same object share a single upstream fetch.
+package origin_serve
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"golang.org/x/net/webdav"
+
+	"github.com/pelicanplatform/pelican/local_cache"
+	"github.com/pelicanplatform/pelican/server_utils"
+)
+
+const (
+	// storageCacheEvictTarget is the fraction of the configured maximum size
+	// eviction drives usage down to once the maximum is exceeded.
+	storageCacheEvictTargetNum = 9
+	storageCacheEvictTargetDen = 10
+
+	// storageCacheJanitorInterval is how often the eviction pass runs.
+	storageCacheJanitorInterval = time.Minute
+
+	// storageCacheCopyBufSize is the buffer used for the upstream-to-disk copy.
+	storageCacheCopyBufSize = 1 << 20
+)
+
+// cacheEntryMeta is the JSON sidecar recorded next to each cached data file.
+// Its presence marks the data file as complete; it is written only after the
+// full object has been copied from the upstream backend.  The sidecar's file
+// mtime doubles as the entry's last-access time for LRU eviction.
+type cacheEntryMeta struct {
+	// Path is the object path within the export (for operator debugging).
+	Path string `json:"path"`
+	// Validator is the value compared against the upstream's current
+	// validator to decide whether the copy is still current.
+	Validator string `json:"validator"`
+	// ETag is the client-visible upstream ETag, empty when the upstream did
+	// not supply one (in which case the webdav default, derived from the
+	// preserved size and mtime, applies).
+	ETag string `json:"etag,omitempty"`
+	// CacheControl is the backend's raw Cache-Control value for the object,
+	// captured at fetch/revalidation time; it governs how long the copy is
+	// fresh (empty means the configured default policy applies).
+	CacheControl string `json:"cacheControl,omitempty"`
+	// LastValidatedUnixNano records when the copy was last confirmed current
+	// (at fetch completion or by a successful revalidation).  Freshness is
+	// measured from this instant.
+	LastValidatedUnixNano int64 `json:"lastValidatedUnixNano"`
+	// Size and ModTimeUnixNano preserve the upstream object metadata so
+	// responses served from the cache are indistinguishable from responses
+	// served from the backend.
+	Size            int64  `json:"size"`
+	ModTimeUnixNano int64  `json:"modTimeUnixNano"`
+	DataFile        string `json:"dataFile"`
+}
+
+func (m *cacheEntryMeta) fileInfo(name string) *cachedFileInfo {
+	return &cachedFileInfo{
+		name:    path.Base(name),
+		size:    m.Size,
+		modTime: time.Unix(0, m.ModTimeUnixNano),
+		etag:    m.ETag,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// storageCache — shared manager for the on-disk cache
+// ---------------------------------------------------------------------------
+
+// storageCache owns the cache directory tree, the in-flight fetch registry,
+// and the eviction janitor.  A single instance is shared by every export's
+// caching layer so the configured size bound applies to the tree as a whole.
+type storageCache struct {
+	fs      afero.Fs
+	ctx     context.Context // server-lifetime context bounding detached fetches
+	maxSize int64           // 0 or negative means unbounded
+
+	// defaultMaxAge is the freshness lifetime applied when the backend
+	// supplies no Cache-Control freshness information; <= 0 means no default
+	// freshness (every read revalidates).  revalidationJitter is the percent
+	// of deterministic per-object jitter applied to defaultMaxAge, matching
+	// the LocalCache.RevalidationJitter semantics.
+	defaultMaxAge      time.Duration
+	revalidationJitter int
+
+	mu      sync.Mutex
+	fetches map[string]*cacheFetch // keyed by the entry's meta-file path
+}
+
+// newStorageCache creates the cache root directory (if needed), opens a
+// symlink-safe afero filesystem rooted there, and starts the eviction
+// janitor.  The janitor and any in-flight fetches stop when ctx is done.
+func newStorageCache(ctx context.Context, location string, maxSize int64, defaultMaxAge time.Duration, revalidationJitter int) (*storageCache, error) {
+	if err := os.MkdirAll(location, 0700); err != nil {
+		return nil, fmt.Errorf("failed to create storage cache directory %s: %w", location, err)
+	}
+	rootFs, err := server_utils.NewOsRootFs(location)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open storage cache directory %s: %w", location, err)
+	}
+	c := &storageCache{
+		fs:                 rootFs,
+		ctx:                ctx,
+		maxSize:            maxSize,
+		defaultMaxAge:      defaultMaxAge,
+		revalidationJitter: revalidationJitter,
+		fetches:            make(map[string]*cacheFetch),
+	}
+	go c.runJanitor()
+	return c, nil
+}
+
+// newStorageCacheWithFs is the constructor used by tests: it accepts an
+// arbitrary afero filesystem and does not start the janitor.
+func newStorageCacheWithFs(ctx context.Context, fs afero.Fs, maxSize int64, defaultMaxAge time.Duration, revalidationJitter int) *storageCache {
+	return &storageCache{
+		fs:                 fs,
+		ctx:                ctx,
+		maxSize:            maxSize,
+		defaultMaxAge:      defaultMaxAge,
+		revalidationJitter: revalidationJitter,
+		fetches:            make(map[string]*cacheFetch),
+	}
+}
+
+// isFresh reports whether a completed cache entry may be served without any
+// upstream interaction, per its recorded Cache-Control directives (or the
+// configured default policy when the backend supplied none).
+func (c *storageCache) isFresh(meta *cacheEntryMeta) bool {
+	lastValidated := time.Unix(0, meta.LastValidatedUnixNano)
+	cd := local_cache.ParseCacheControl(meta.CacheControl)
+	return !cd.IsStaleFor(lastValidated, c.defaultMaxAge, c.revalidationJitter)
+}
+
+// newLayer returns the caching webdav.FileSystem for one export, scoped to
+// its own subdirectory so objects from different exports never collide.
+func (c *storageCache) newLayer(federationPrefix string, upstream webdav.FileSystem) *storageCacheFS {
+	sum := sha256.Sum256([]byte(federationPrefix))
+	sanitized := strings.ReplaceAll(strings.Trim(federationPrefix, "/"), "/", "_")
+	if sanitized == "" {
+		sanitized = "root"
+	}
+	return &storageCacheFS{
+		cache:    c,
+		upstream: upstream,
+		scope:    fmt.Sprintf("%s.%s", sanitized, hex.EncodeToString(sum[:4])),
+	}
+}
+
+func (c *storageCache) lookupFetch(metaRel string) *cacheFetch {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.fetches[metaRel]
+}
+
+// getOrStartFetch returns the in-flight fetch for the entry, registering the
+// provided one when none exists.  The winning fetch is returned; a losing
+// (raced) fetch is discarded without side effects since fetches start lazily.
+// Registering a fetch also creates its (empty) data file, so every attached
+// reader can open a handle immediately — bytes already copied stay readable
+// even if the fetch later aborts and unlinks the file.
+func (c *storageCache) getOrStartFetch(f *cacheFetch) (*cacheFetch, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if existing := c.fetches[f.metaRel]; existing != nil {
+		return existing, nil
+	}
+	if err := c.fs.MkdirAll(path.Dir(f.dataRel), 0700); err != nil {
+		return nil, fmt.Errorf("storage cache: failed to create cache directory: %w", err)
+	}
+	file, err := c.fs.OpenFile(f.dataRel, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("storage cache: failed to create cache file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return nil, fmt.Errorf("storage cache: failed to create cache file: %w", err)
+	}
+	c.fetches[f.metaRel] = f
+	return f, nil
+}
+
+// releaseUnstarted is called when the last reader of a never-started fetch
+// closes: the registration and the empty data file are discarded so
+// metadata-only opens (HEAD requests) leave nothing behind.
+func (c *storageCache) releaseUnstarted(f *cacheFetch) {
+	c.mu.Lock()
+	if c.fetches[f.metaRel] == f {
+		delete(c.fetches, f.metaRel)
+	}
+	c.mu.Unlock()
+	if err := c.fs.Remove(f.dataRel); err != nil && !os.IsNotExist(err) {
+		log.Debugf("Storage cache: failed to remove unused cache file %s: %v", f.dataRel, err)
+	}
+}
+
+func (c *storageCache) unregisterFetch(metaRel string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.fetches, metaRel)
+}
+
+// writeMeta serializes the sidecar; the fresh mtime doubles as an LRU touch.
+func (c *storageCache) writeMeta(metaRel string, meta *cacheEntryMeta) error {
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	return afero.WriteFile(c.fs, metaRel, data, 0600)
+}
+
+func (c *storageCache) readMeta(metaRel string) *cacheEntryMeta {
+	data, err := afero.ReadFile(c.fs, metaRel)
+	if err != nil {
+		return nil
+	}
+	var meta cacheEntryMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		// A torn write (e.g. crash mid-update) reads as a miss; the entry
+		// will be refetched and the sidecar rewritten.
+		return nil
+	}
+	return &meta
+}
+
+// touch bumps the entry's last-access marker (the meta file's mtime).
+func (c *storageCache) touch(metaRel string) {
+	now := time.Now()
+	if err := c.fs.Chtimes(metaRel, now, now); err != nil {
+		log.Debugf("Storage cache: failed to update access time for %s: %v", metaRel, err)
+	}
+}
+
+// invalidate drops the completed entry (sidecar first so a concurrent reader
+// never sees a sidecar pointing at a deleted data file's replacement).
+func (c *storageCache) invalidate(metaRel string) {
+	meta := c.readMeta(metaRel)
+	if err := c.fs.Remove(metaRel); err != nil && !os.IsNotExist(err) {
+		log.Debugf("Storage cache: failed to remove meta %s: %v", metaRel, err)
+	}
+	if meta != nil && meta.DataFile != "" {
+		dataRel := path.Join(path.Dir(metaRel), meta.DataFile)
+		if err := c.fs.Remove(dataRel); err != nil && !os.IsNotExist(err) {
+			log.Debugf("Storage cache: failed to remove data file %s: %v", dataRel, err)
+		}
+	}
+}
+
+// supersedeFetch marks any in-flight fetch for the entry as superseded so it
+// won't install its (pre-mutation) result as a completed entry.  Must be
+// called BEFORE invalidate: the ordering guarantees that a fetch either sees
+// the flag (and skips installing) or installed its sidecar beforehand, in
+// which case the subsequent invalidate removes it.
+func (c *storageCache) supersedeFetch(metaRel string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if f := c.fetches[metaRel]; f != nil {
+		f.superseded = true
+	}
+}
+
+// invalidateEntry is the notification hook for a single-object mutation
+// through the origin (PUT, DELETE, rename endpoint): it supersedes any
+// in-flight fetch and removes the completed entry.
+func (c *storageCache) invalidateEntry(metaRel string) {
+	c.supersedeFetch(metaRel)
+	c.invalidate(metaRel)
+}
+
+func (c *storageCache) runJanitor() {
+	ticker := time.NewTicker(storageCacheJanitorInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-ticker.C:
+			c.evictOnce()
+		}
+	}
+}
+
+// evictOnce scans the cache tree and, when total data-file usage exceeds the
+// configured maximum, removes least-recently-accessed entries until usage
+// falls below the eviction target.  Entries with an in-flight fetch are
+// never evicted; data files with no sidecar and no in-flight fetch are
+// orphans (crash leftovers) and are evicted first.
+func (c *storageCache) evictOnce() {
+	if c.maxSize <= 0 {
+		return
+	}
+
+	type entry struct {
+		dataRel string
+		metaRel string
+		size    int64
+		access  time.Time
+	}
+
+	metaTimes := make(map[string]time.Time)
+	var entries []entry
+	var total int64
+	err := afero.Walk(c.fs, ".", func(p string, info os.FileInfo, err error) error {
+		if err != nil || info == nil || info.IsDir() {
+			return nil
+		}
+		switch {
+		case strings.HasSuffix(p, ".meta"):
+			metaTimes[p] = info.ModTime()
+		case strings.HasSuffix(p, ".data"):
+			total += info.Size()
+			entries = append(entries, entry{dataRel: p, size: info.Size()})
+		}
+		return nil
+	})
+	if err != nil {
+		log.Warningf("Storage cache: eviction scan failed: %v", err)
+		return
+	}
+	if total <= c.maxSize {
+		return
+	}
+
+	c.mu.Lock()
+	inFlight := make(map[string]bool, len(c.fetches))
+	for metaRel := range c.fetches {
+		inFlight[metaRel] = true
+	}
+	c.mu.Unlock()
+
+	target := c.maxSize / storageCacheEvictTargetDen * storageCacheEvictTargetNum
+	victims := entries[:0]
+	for _, e := range entries {
+		// Data files are named "<hash>-<generation>.data"; the sidecar is
+		// "<hash>.meta" in the same directory.
+		base := path.Base(e.dataRel)
+		if idx := strings.IndexByte(base, '-'); idx > 0 {
+			e.metaRel = path.Join(path.Dir(e.dataRel), base[:idx]+".meta")
+		}
+		if inFlight[e.metaRel] {
+			continue
+		}
+		e.access = metaTimes[e.metaRel] // zero time for orphans: evicted first
+		victims = append(victims, e)
+	}
+	sort.Slice(victims, func(i, j int) bool { return victims[i].access.Before(victims[j].access) })
+
+	for _, v := range victims {
+		if total <= target {
+			break
+		}
+		if v.metaRel != "" {
+			if err := c.fs.Remove(v.metaRel); err != nil && !os.IsNotExist(err) {
+				log.Debugf("Storage cache: eviction failed to remove %s: %v", v.metaRel, err)
+			}
+		}
+		if err := c.fs.Remove(v.dataRel); err != nil && !os.IsNotExist(err) {
+			log.Debugf("Storage cache: eviction failed to remove %s: %v", v.dataRel, err)
+			continue
+		}
+		total -= v.size
+		log.Debugf("Storage cache: evicted %s (%d bytes)", v.dataRel, v.size)
+	}
+	log.Debugf("Storage cache: eviction pass complete; usage now %d bytes (max %d)", total, c.maxSize)
+}
+
+// ---------------------------------------------------------------------------
+// storageCacheFS — the per-export webdav.FileSystem layer
+// ---------------------------------------------------------------------------
+
+type storageCacheFS struct {
+	cache    *storageCache
+	upstream webdav.FileSystem
+	scope    string
+}
+
+// entryPaths maps an object path to its cache-relative sidecar path and
+// containing directory.  Entries are content-addressed by the SHA-256 of the
+// object path so arbitrary object names never produce hostile disk paths.
+func (l *storageCacheFS) entryPaths(name string) (metaRel, hashDir, hash string) {
+	sum := sha256.Sum256([]byte(path.Clean("/" + name)))
+	hash = hex.EncodeToString(sum[:])
+	hashDir = path.Join(l.scope, "objects", hash[:2])
+	metaRel = path.Join(hashDir, hash+".meta")
+	return
+}
+
+func (l *storageCacheFS) Mkdir(ctx context.Context, name string, perm os.FileMode) error {
+	return l.upstream.Mkdir(ctx, name, perm)
+}
+
+func (l *storageCacheFS) RemoveAll(ctx context.Context, name string) error {
+	// Enumerate the subtree before the upstream deletes it (afterwards it can
+	// no longer be listed); invalidate after the operation, and regardless of
+	// its result: a partial failure may still have removed some descendants.
+	targets, enumerated := l.enumerateSubtree(ctx, name)
+	err := l.upstream.RemoveAll(ctx, name)
+	l.invalidateSubtreeEntries(name, targets, enumerated)
+	return err
+}
+
+func (l *storageCacheFS) Rename(ctx context.Context, oldName, newName string) error {
+	// Both prefixes need invalidation: the source moves away, and the
+	// destination may have held objects that are now overwritten.
+	oldTargets, oldEnumerated := l.enumerateSubtree(ctx, oldName)
+	newTargets, newEnumerated := l.enumerateSubtree(ctx, newName)
+	err := l.upstream.Rename(ctx, oldName, newName)
+	l.invalidateSubtreeEntries(oldName, oldTargets, oldEnumerated)
+	l.invalidateSubtreeEntries(newName, newTargets, newEnumerated)
+	return err
+}
+
+// storageCacheEnumerationCap bounds the object list a directory mutation
+// buffers while unrolling a subtree invalidation.  Beyond this, invalidation
+// falls back to the sidecar scan: at that scale the mutation itself dwarfs a
+// pass over the cache, and the scan needs no per-path memory.
+const storageCacheEnumerationCap = 65536
+
+// enumerateSubtree lists the object paths currently under name in the
+// backend, so a directory mutation can be unrolled into exact per-object
+// invalidations — O(subtree) instead of a scan of every cached sidecar.
+// The listing is metadata-only (no data egress) and mirrors the one a blob
+// backend's RemoveAll performs internally, so it covers exactly the objects
+// the mutation affects.  Cached entries for objects that already vanished
+// from the backend out-of-band are not the mutation's responsibility; the
+// normal freshness/revalidation cycle retires them.
+//
+// Returns (paths, true) on success.  Returns (nil, false) when the backend
+// cannot enumerate (e.g. a plain-HTTP upstream with no listing support) or
+// the subtree exceeds storageCacheEnumerationCap; callers then fall back to
+// the sidecar scan, which is authoritative over the cache's own contents.
+func (l *storageCacheFS) enumerateSubtree(ctx context.Context, name string) ([]string, bool) {
+	clean := path.Clean("/" + name)
+	info, err := l.upstream.Stat(ctx, clean)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Nothing (visible) upstream: only the exact entry could need
+			// dropping.
+			return []string{clean}, true
+		}
+		return nil, false
+	}
+	if !info.IsDir() {
+		return []string{clean}, true
+	}
+
+	errCapExceeded := errors.New("enumeration cap exceeded")
+	paths := []string{clean}
+	var walk func(dir string) error
+	walk = func(dir string) error {
+		f, err := l.upstream.OpenFile(ctx, dir, os.O_RDONLY, 0)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		for {
+			ents, rdErr := f.Readdir(1024)
+			for _, e := range ents {
+				child := path.Join(dir, e.Name())
+				if e.IsDir() {
+					if err := walk(child); err != nil {
+						return err
+					}
+					continue
+				}
+				if len(paths) >= storageCacheEnumerationCap {
+					return errCapExceeded
+				}
+				paths = append(paths, child)
+			}
+			if rdErr == io.EOF || (rdErr == nil && len(ents) == 0) {
+				return nil
+			}
+			if rdErr != nil {
+				return rdErr
+			}
+		}
+	}
+	if err := walk(clean); err != nil {
+		log.Debugf("Storage cache: subtree enumeration of %s failed (%v); falling back to sidecar scan", clean, err)
+		return nil, false
+	}
+	return paths, true
+}
+
+// invalidateSubtreeEntries is the notification hook for mutations whose
+// target may be a directory.  In-flight fetches under the subtree are always
+// superseded first (an in-memory registry sweep) so none installs
+// pre-mutation content afterwards.  Completed entries are then dropped: per
+// enumerated path when the subtree could be listed, otherwise by scanning
+// the export's sidecars (each records its object path).
+func (l *storageCacheFS) invalidateSubtreeEntries(name string, targets []string, enumerated bool) {
+	clean := path.Clean("/" + name)
+	childPrefix := clean
+	if childPrefix != "/" {
+		childPrefix += "/"
+	}
+	matches := func(objPath string) bool {
+		return objPath == clean || strings.HasPrefix(objPath, childPrefix)
+	}
+
+	// Supersede in-flight fetches first (see supersedeFetch for ordering).
+	c := l.cache
+	scopePrefix := l.scope + "/"
+	c.mu.Lock()
+	for metaRel, f := range c.fetches {
+		if strings.HasPrefix(metaRel, scopePrefix) && matches(f.meta.Path) {
+			f.superseded = true
+		}
+	}
+	c.mu.Unlock()
+
+	if enumerated {
+		for _, p := range targets {
+			metaRel, _, _ := l.entryPaths(p)
+			c.invalidate(metaRel)
+		}
+		return
+	}
+
+	// Fallback: drop every completed entry whose recorded path is in the
+	// subtree.  O(total cached entries), used only when the backend can't
+	// tell us what lives under the prefix.
+	objectsDir := path.Join(l.scope, "objects")
+	walkErr := afero.Walk(c.fs, objectsDir, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info == nil || info.IsDir() || !strings.HasSuffix(p, ".meta") {
+			return nil
+		}
+		if meta := c.readMeta(p); meta != nil && matches(meta.Path) {
+			c.invalidate(p)
+		}
+		return nil
+	})
+	if walkErr != nil && !os.IsNotExist(walkErr) {
+		log.Debugf("Storage cache: subtree invalidation scan for %s failed: %v", clean, walkErr)
+	}
+}
+
+// Stat serves the preserved upstream metadata for fresh cache entries so
+// HEAD-style probes cost no upstream round-trip; anything else (stale
+// entries, misses, directories) is delegated to the backend.
+func (l *storageCacheFS) Stat(ctx context.Context, name string) (os.FileInfo, error) {
+	metaRel, _, _ := l.entryPaths(name)
+	if meta := l.cache.readMeta(metaRel); meta != nil && l.cache.isFresh(meta) {
+		return meta.fileInfo(name), nil
+	}
+	return l.upstream.Stat(ctx, name)
+}
+
+func (l *storageCacheFS) OpenFile(ctx context.Context, name string, flag int, perm os.FileMode) (webdav.File, error) {
+	// Writes pass straight through to the backend.  Blob uploads only commit
+	// on Close, so the returned handle is wrapped to invalidate the cached
+	// copy (and supersede any in-flight fetch) at that point: the old copy
+	// keeps serving during the upload, and the first read after the commit
+	// revalidates against the backend's new state.
+	if flag&(os.O_WRONLY|os.O_RDWR|os.O_CREATE|os.O_TRUNC) != 0 {
+		wf, err := l.upstream.OpenFile(ctx, name, flag, perm)
+		if err != nil {
+			return nil, err
+		}
+		metaRel, _, _ := l.entryPaths(name)
+		return &writeThroughFile{File: wf, cache: l.cache, metaRel: metaRel}, nil
+	}
+
+	metaRel, hashDir, hash := l.entryPaths(name)
+
+	// An in-flight fetch for this object serves everyone; attach to it.  If
+	// the attach races with the fetch being discarded (its last reader closed
+	// before it started), fall through and register a fresh fetch.
+	if f := l.cache.lookupFetch(metaRel); f != nil {
+		if reader, attachErr := newFetchReader(ctx, f); attachErr == nil {
+			return reader, nil
+		}
+	}
+
+	// A fresh completed entry is served with no upstream interaction at all —
+	// this is the common repeat-read path that avoids both egress and
+	// metadata round-trips.
+	meta := l.cache.readMeta(metaRel)
+	if meta != nil && l.cache.isFresh(meta) {
+		if file, openErr := l.cache.fs.Open(path.Join(hashDir, meta.DataFile)); openErr == nil {
+			l.cache.touch(metaRel)
+			return &cacheHitFile{File: file, info: meta.fileInfo(name)}, nil
+		}
+		// Sidecar present but data unreadable (e.g. eviction race): fall
+		// through and treat as a miss.
+	}
+
+	// Stale or missing: revalidate with a single upstream stat.  The stat is
+	// metadata-only, so this costs no data egress.
+	info, err := l.upstream.Stat(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		return l.upstream.OpenFile(ctx, name, flag, perm)
+	}
+
+	validator, explicitETag := upstreamValidator(ctx, info)
+	cacheControl := upstreamCacheControl(info)
+
+	// no-store / private responses must not be persisted: drop any existing
+	// copy (superseding a concurrently registered fetch, if any) and stream
+	// straight from the backend.
+	if cd := local_cache.ParseCacheControl(cacheControl); !cd.ShouldStore() {
+		if meta != nil {
+			l.cache.invalidateEntry(metaRel)
+		}
+		return l.upstream.OpenFile(ctx, name, flag, perm)
+	}
+
+	// Revalidated: the validator still matches, so renew the freshness
+	// window (and pick up any Cache-Control change) and serve locally.
+	oldDataFile := ""
+	if meta != nil {
+		if meta.Validator == validator {
+			meta.CacheControl = cacheControl
+			meta.LastValidatedUnixNano = time.Now().UnixNano()
+			if wErr := l.cache.writeMeta(metaRel, meta); wErr != nil {
+				log.Debugf("Storage cache: failed to renew metadata for %s: %v", metaRel, wErr)
+			}
+			if file, openErr := l.cache.fs.Open(path.Join(hashDir, meta.DataFile)); openErr == nil {
+				return &cacheHitFile{File: file, info: meta.fileInfo(name)}, nil
+			}
+			// Data unreadable despite matching validator: refetch.
+		}
+		oldDataFile = meta.DataFile
+	}
+
+	// Miss (or stale): fetch from the backend into the cache.  The fetch
+	// starts lazily on the first Read so metadata-only opens (HEAD requests,
+	// size probes) never trigger data egress.
+	gen := make([]byte, 8)
+	if _, err := rand.Read(gen); err != nil {
+		return nil, fmt.Errorf("failed to generate cache file name: %w", err)
+	}
+	etag := ""
+	if explicitETag {
+		etag = validator
+	}
+	f := &cacheFetch{
+		cache:   l.cache,
+		name:    name,
+		metaRel: metaRel,
+		dataRel: path.Join(hashDir, fmt.Sprintf("%s-%s.data", hash, hex.EncodeToString(gen))),
+		meta: cacheEntryMeta{
+			Path:                  path.Clean("/" + name),
+			Validator:             validator,
+			ETag:                  etag,
+			CacheControl:          cacheControl,
+			LastValidatedUnixNano: time.Now().UnixNano(),
+			Size:                  info.Size(),
+			ModTimeUnixNano:       info.ModTime().UnixNano(),
+			DataFile:              fmt.Sprintf("%s-%s.data", hash, hex.EncodeToString(gen)),
+		},
+		oldDataRel: "",
+		open: func(fetchCtx context.Context) (webdav.File, error) {
+			return l.upstream.OpenFile(fetchCtx, name, os.O_RDONLY, 0)
+		},
+	}
+	if oldDataFile != "" {
+		f.oldDataRel = path.Join(hashDir, oldDataFile)
+	}
+	f.cond = sync.NewCond(&f.mu)
+	f, err = l.cache.getOrStartFetch(f)
+	if err != nil {
+		return nil, err
+	}
+	return newFetchReader(ctx, f)
+}
+
+// upstreamValidator extracts the consistency validator for an upstream
+// FileInfo: the backend's own ETag when it exposes one (webdav.ETager or the
+// backend-specific Sys() payloads), otherwise the same size/mtime-derived
+// tag the origin uses for local files.  The boolean reports whether the
+// validator is a genuine upstream ETag (and therefore client-visible).
+func upstreamValidator(ctx context.Context, info os.FileInfo) (string, bool) {
+	if et, ok := info.(webdav.ETager); ok {
+		if v, err := et.ETag(ctx); err == nil && v != "" {
+			return v, true
+		}
+	}
+	switch sys := info.Sys().(type) {
+	case *BlobFileSysInfo:
+		if sys.ETag != "" {
+			return sys.ETag, true
+		}
+	case *HTTPSFileSysInfo:
+		if sys.ETag != "" {
+			return sys.ETag, true
+		}
+	}
+	return computeETag(info), false
+}
+
+// upstreamCacheControl extracts the backend's Cache-Control value for the
+// object, when the backend surfaces one (S3 object metadata, HTTPS response
+// header).  Empty means the configured default freshness policy applies.
+func upstreamCacheControl(info os.FileInfo) string {
+	switch sys := info.Sys().(type) {
+	case *BlobFileSysInfo:
+		return sys.CacheControl
+	case *HTTPSFileSysInfo:
+		return sys.CacheControl
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// cacheFetch — a single upstream-to-disk copy, shared by all readers
+// ---------------------------------------------------------------------------
+
+type cacheFetch struct {
+	cache      *storageCache
+	name       string
+	metaRel    string
+	dataRel    string
+	oldDataRel string // superseded data file removed once the new copy lands
+	meta       cacheEntryMeta
+	open       func(ctx context.Context) (webdav.File, error)
+
+	mu      sync.Mutex
+	cond    *sync.Cond
+	started bool
+	readers int
+	written int64
+	done    bool
+	err     error
+
+	// superseded is set (under storageCache.mu, NOT this mutex) when the
+	// object is mutated through the origin while this fetch is in flight.
+	// A superseded fetch still streams to its attached readers, but must not
+	// install its result as a completed cache entry: the bytes it is copying
+	// predate the mutation, yet its validation timestamp would look fresh.
+	superseded bool
+}
+
+// ensureStarted launches the copy goroutine exactly once.  The copy runs
+// under the cache's server-lifetime context, not any request context, so a
+// slow or disconnected client never cancels it.
+func (f *cacheFetch) ensureStarted() {
+	f.mu.Lock()
+	if f.started {
+		f.mu.Unlock()
+		return
+	}
+	f.started = true
+	f.mu.Unlock()
+	go f.run()
+}
+
+func (f *cacheFetch) run() {
+	src, err := f.open(f.cache.ctx)
+	if err != nil {
+		f.finish(fmt.Errorf("storage cache: upstream open of %s failed: %w", f.name, err))
+		return
+	}
+	defer src.Close()
+
+	// The (empty) data file was created when the fetch was registered.
+	dst, err := f.cache.fs.OpenFile(f.dataRel, os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		f.finish(fmt.Errorf("storage cache: failed to create cache file: %w", err))
+		return
+	}
+
+	buf := make([]byte, storageCacheCopyBufSize)
+	for {
+		n, readErr := src.Read(buf)
+		if n > 0 {
+			if _, writeErr := dst.Write(buf[:n]); writeErr != nil {
+				dst.Close()
+				f.abort(fmt.Errorf("storage cache: write to cache file failed: %w", writeErr))
+				return
+			}
+			f.mu.Lock()
+			f.written += int64(n)
+			f.cond.Broadcast()
+			f.mu.Unlock()
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			dst.Close()
+			f.abort(fmt.Errorf("storage cache: upstream read of %s failed: %w", f.name, readErr))
+			return
+		}
+	}
+	if err := dst.Close(); err != nil {
+		f.abort(fmt.Errorf("storage cache: failed to finalize cache file: %w", err))
+		return
+	}
+
+	// The size was captured at revalidation time; a mismatch means the
+	// object changed (or was truncated) mid-fetch, so the copy cannot be
+	// trusted and readers must see an error rather than a silent short read.
+	f.mu.Lock()
+	written := f.written
+	f.mu.Unlock()
+	if written != f.meta.Size {
+		f.abort(fmt.Errorf("storage cache: fetched %d bytes for %s but upstream reported %d", written, f.name, f.meta.Size))
+		return
+	}
+
+	// Install the completed entry.  The superseded check and the sidecar
+	// write happen under the registry lock so they are atomic with respect
+	// to supersedeFetch: either the flag is seen here (no install), or the
+	// sidecar lands before the mutation's invalidation sweep and is removed
+	// by it.
+	f.cache.mu.Lock()
+	superseded := f.superseded
+	var installErr error
+	if !superseded {
+		installErr = f.cache.writeMeta(f.metaRel, &f.meta)
+	}
+	f.cache.mu.Unlock()
+	if superseded {
+		log.Debugf("Storage cache: fetch of %s was superseded by a write; discarding", f.name)
+		if err := f.cache.fs.Remove(f.dataRel); err != nil && !os.IsNotExist(err) {
+			log.Debugf("Storage cache: failed to remove superseded fetch file %s: %v", f.dataRel, err)
+		}
+		// Attached readers already hold open handles and drain normally.
+		f.finish(nil)
+		return
+	}
+	if installErr != nil {
+		f.abort(fmt.Errorf("storage cache: failed to write metadata: %w", installErr))
+		return
+	}
+	if f.oldDataRel != "" {
+		if err := f.cache.fs.Remove(f.oldDataRel); err != nil && !os.IsNotExist(err) {
+			log.Debugf("Storage cache: failed to remove superseded data file %s: %v", f.oldDataRel, err)
+		}
+	}
+	f.finish(nil)
+}
+
+// abort discards the partial cache file and reports err to readers.
+func (f *cacheFetch) abort(err error) {
+	if rmErr := f.cache.fs.Remove(f.dataRel); rmErr != nil && !os.IsNotExist(rmErr) {
+		log.Debugf("Storage cache: failed to remove partial cache file %s: %v", f.dataRel, rmErr)
+	}
+	f.finish(err)
+}
+
+func (f *cacheFetch) finish(err error) {
+	if err != nil {
+		log.Warningf("%v", err)
+	}
+	f.mu.Lock()
+	f.done = true
+	f.err = err
+	f.cond.Broadcast()
+	f.mu.Unlock()
+	f.cache.unregisterFetch(f.metaRel)
+}
+
+// ---------------------------------------------------------------------------
+// fetchReader — a client's view of an in-flight (or lazily started) fetch
+// ---------------------------------------------------------------------------
+
+type fetchReader struct {
+	fetch  *cacheFetch
+	reqCtx context.Context
+
+	mu     sync.Mutex
+	file   afero.File
+	closed bool
+	offset int64
+}
+
+// newFetchReader attaches a reader to the fetch, opening its own handle on
+// the shared data file up front.  Holding the handle from the start
+// guarantees the reader can deliver every byte the fetch reports as written,
+// even if the fetch aborts (and unlinks the file) mid-stream.
+func newFetchReader(reqCtx context.Context, f *cacheFetch) (*fetchReader, error) {
+	file, err := f.cache.fs.Open(f.dataRel)
+	if err != nil {
+		return nil, fmt.Errorf("storage cache: failed to open cache file for read: %w", err)
+	}
+	f.mu.Lock()
+	f.readers++
+	f.mu.Unlock()
+	return &fetchReader{fetch: f, reqCtx: reqCtx, file: file}, nil
+}
+
+// Read serves bytes from the cache file, waiting for the fetch goroutine to
+// make progress when the reader has caught up.  The wait is interruptible by
+// the request context so a departed client releases its handler goroutine,
+// while the fetch itself keeps running.
+func (r *fetchReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return 0, os.ErrClosed
+	}
+
+	f := r.fetch
+	f.ensureStarted()
+
+	stop := context.AfterFunc(r.reqCtx, func() {
+		f.mu.Lock()
+		f.cond.Broadcast()
+		f.mu.Unlock()
+	})
+	defer stop()
+
+	f.mu.Lock()
+	for !f.done && f.written <= r.offset && r.reqCtx.Err() == nil {
+		f.cond.Wait()
+	}
+	written, ferr := f.written, f.err
+	f.mu.Unlock()
+
+	if err := r.reqCtx.Err(); err != nil {
+		return 0, err
+	}
+	if r.offset >= written {
+		if ferr != nil {
+			return 0, ferr
+		}
+		return 0, io.EOF
+	}
+
+	n := written - r.offset
+	if n > int64(len(p)) {
+		n = int64(len(p))
+	}
+	read, err := r.file.ReadAt(p[:n], r.offset)
+	r.offset += int64(read)
+	if err == io.EOF && read > 0 {
+		err = nil
+	}
+	return read, err
+}
+
+// Seek repositions the reader without blocking; the object size is already
+// known from the revalidation stat, so size probes (Seek to end) return
+// immediately even before any bytes have been fetched.
+func (r *fetchReader) Seek(offset int64, whence int) (int64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var next int64
+	switch whence {
+	case io.SeekStart:
+		next = offset
+	case io.SeekCurrent:
+		next = r.offset + offset
+	case io.SeekEnd:
+		next = r.fetch.meta.Size + offset
+	default:
+		return 0, fmt.Errorf("invalid seek whence %d", whence)
+	}
+	if next < 0 {
+		return 0, fmt.Errorf("negative seek offset")
+	}
+	r.offset = next
+	return next, nil
+}
+
+func (r *fetchReader) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+	err := r.file.Close()
+	r.file = nil
+
+	// If no reader ever triggered the fetch and this was the last handle
+	// (typical for HEAD requests), discard the pending fetch so the registry
+	// and disk don't accumulate never-used entries.
+	f := r.fetch
+	f.mu.Lock()
+	f.readers--
+	discard := f.readers == 0 && !f.started
+	f.mu.Unlock()
+	if discard {
+		f.cache.releaseUnstarted(f)
+	}
+	return err
+}
+
+func (r *fetchReader) Stat() (os.FileInfo, error) {
+	return r.fetch.meta.fileInfo(r.fetch.name), nil
+}
+
+func (r *fetchReader) Write(_ []byte) (int, error) {
+	return 0, fmt.Errorf("write not supported on cached read file")
+}
+
+func (r *fetchReader) Readdir(_ int) ([]os.FileInfo, error) {
+	return nil, fmt.Errorf("readdir not supported on file")
+}
+
+// ---------------------------------------------------------------------------
+// writeThroughFile — invalidation hook for origin-side writes
+// ---------------------------------------------------------------------------
+
+// writeThroughFile wraps an upstream write handle so the cached copy is
+// dropped when the upload commits (blob backends finalize on Close).  The
+// invalidation runs on success and failure alike — a failed streaming upload
+// may still have altered the backend object — and supersedes any in-flight
+// fetch so pre-write content can't be installed with a fresh timestamp.
+type writeThroughFile struct {
+	webdav.File
+	cache   *storageCache
+	metaRel string
+	once    sync.Once
+}
+
+func (w *writeThroughFile) Close() error {
+	err := w.File.Close()
+	w.once.Do(func() { w.cache.invalidateEntry(w.metaRel) })
+	return err
+}
+
+// ---------------------------------------------------------------------------
+// cacheHitFile — serves a completed cache entry directly from disk
+// ---------------------------------------------------------------------------
+
+type cacheHitFile struct {
+	afero.File
+	info os.FileInfo
+}
+
+// Stat reports the preserved upstream metadata, not the local file's, so
+// ETags and Last-Modified are identical whether the response is served from
+// the cache or the backend.
+func (f *cacheHitFile) Stat() (os.FileInfo, error) { return f.info, nil }
+
+func (f *cacheHitFile) Write(_ []byte) (int, error) {
+	return 0, fmt.Errorf("write not supported on cached read file")
+}
+
+func (f *cacheHitFile) Readdir(_ int) ([]os.FileInfo, error) {
+	return nil, fmt.Errorf("readdir not supported on file")
+}
+
+// ---------------------------------------------------------------------------
+// cachedFileInfo — upstream metadata preserved across the cache
+// ---------------------------------------------------------------------------
+
+type cachedFileInfo struct {
+	name    string
+	size    int64
+	modTime time.Time
+	etag    string
+}
+
+func (fi *cachedFileInfo) Name() string       { return fi.name }
+func (fi *cachedFileInfo) Size() int64        { return fi.size }
+func (fi *cachedFileInfo) Mode() os.FileMode  { return 0644 }
+func (fi *cachedFileInfo) ModTime() time.Time { return fi.modTime }
+func (fi *cachedFileInfo) IsDir() bool        { return false }
+func (fi *cachedFileInfo) Sys() interface{}   { return nil }
+
+// ETag exposes the upstream's ETag when one was recorded; otherwise the
+// webdav handler falls back to its default (size/mtime) computation, which
+// matches the backend's behaviour since both values are preserved.
+func (fi *cachedFileInfo) ETag(_ context.Context) (string, error) {
+	if fi.etag != "" {
+		return fi.etag, nil
+	}
+	return "", webdav.ErrNotImplemented
+}
+
+// ---------------------------------------------------------------------------
+// cachedBackend — OriginBackend wrapper installing the caching filesystem
+// ---------------------------------------------------------------------------
+
+type cachedBackend struct {
+	inner server_utils.OriginBackend
+	fs    webdav.FileSystem
+}
+
+func newCachedBackend(inner server_utils.OriginBackend, fs webdav.FileSystem) *cachedBackend {
+	return &cachedBackend{inner: inner, fs: fs}
+}
+
+func (b *cachedBackend) CheckAvailability() error      { return b.inner.CheckAvailability() }
+func (b *cachedBackend) FileSystem() webdav.FileSystem { return b.fs }
+func (b *cachedBackend) Checksummer() server_utils.OriginChecksummer {
+	return b.inner.Checksummer()
+}

--- a/origin_serve/storage_cache_fs.go
+++ b/origin_serve/storage_cache_fs.go
@@ -79,6 +79,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -249,9 +250,31 @@ func newStorageCache(ctx context.Context, location string, maxSize int64, defaul
 	if !info.IsDir() {
 		return nil, fmt.Errorf("storage cache location %s is not a directory", location)
 	}
-	if mode := info.Mode().Perm(); mode&0022 != 0 {
-		return nil, fmt.Errorf("storage cache directory %s is group- or world-writable (mode %04o); "+
-			"tighten it to 0700 so other local users cannot inject cache entries", location, mode)
+	// Windows permission bits don't carry this meaning, and os.Chmod there only
+	// toggles the read-only attribute, so the check is POSIX-only.
+	if runtime.GOOS != "windows" {
+		if mode := info.Mode().Perm(); mode&0022 != 0 {
+			// The directory already existed with loose permissions, or was
+			// created under a permissive umask.  Tighten it rather than trust
+			// it: anyone who can write here can plant a sidecar and choose the
+			// bytes this origin serves.  The origin owns this directory, so
+			// narrowing it is exactly what MkdirAll would have done had it
+			// been the one to create it.
+			if err := os.Chmod(location, 0700); err != nil {
+				return nil, fmt.Errorf("storage cache directory %s is group- or world-writable (mode %04o) "+
+					"and could not be tightened to 0700: %w", location, mode, err)
+			}
+			if info, err = os.Stat(location); err != nil {
+				return nil, fmt.Errorf("failed to stat storage cache directory %s: %w", location, err)
+			}
+			if newMode := info.Mode().Perm(); newMode&0022 != 0 {
+				return nil, fmt.Errorf("storage cache directory %s is still group- or world-writable "+
+					"(mode %04o) after tightening; refusing to cache where other local users can write",
+					location, newMode)
+			}
+			log.Warningf("Storage cache directory %s had mode %04o; tightened to 0700 so other local users "+
+				"cannot inject cache entries", location, mode)
+		}
 	}
 	// Fail at startup rather than turning every request into a 500 later.
 	probe := path.Join(location, ".pelican-storage-cache-probe")

--- a/origin_serve/storage_cache_fs.go
+++ b/origin_serve/storage_cache_fs.go
@@ -22,30 +22,48 @@
 // The cache exists to avoid repeated egress from the remote provider: an
 // origin physically located outside the provider (e.g. outside AWS) pays for
 // every byte read from the backend, so a large local disk can absorb repeat
-// reads.  Consistency follows the standard ETag revalidation rules: every
-// read stats the upstream backend (a metadata-only operation with no data
-// egress) and serves the local copy only when the upstream validator — the
-// provider's ETag when available, otherwise a size/mtime-derived tag — still
-// matches the one recorded when the copy was fetched.
+// reads.
 //
-// Freshness follows the same Cache-Control infrastructure the Pelican local
-// cache uses (local_cache.CacheDirectives): the backend's Cache-Control —
-// S3 object metadata or the upstream HTTPS response header — governs how
-// long a copy may be served with no upstream interaction at all.  When the
-// backend supplies no directives, a configurable default freshness lifetime
-// applies (Origin.StorageCacheDefaultMaxAge, jittered per object like
-// LocalCache.DefaultMaxAge).  Only once a copy goes stale does the layer
-// revalidate: one upstream stat compares validators, and a match simply
-// renews the freshness window without refetching.  no-store / private
-// responses bypass the cache entirely; no-cache responses are cached but
-// revalidated on (almost) every use.
+// Freshness follows the standard Cache-Control rules (see the cache_control
+// package, shared with the Pelican local cache): the backend's own
+// Cache-Control — an S3 object's metadata or an HTTPS response header —
+// governs how long a copy may be served with no upstream interaction at all.
+// When the backend supplies no directives, Origin.StorageCacheDefaultMaxAge
+// applies, jittered per object.  That same setting also caps how much
+// freshness a backend may claim for itself, so whoever can write an object's
+// metadata cannot pin it in the cache indefinitely.  Only once a copy goes
+// stale does the layer revalidate: one upstream stat compares validators, and
+// a match renews the freshness window without refetching.  no-store / private
+// responses bypass the cache; no-cache responses are cached but revalidated on
+// (almost) every use.
 //
-// Fetches are decoupled from the requesting client: the upstream-to-disk
-// copy runs in its own goroutine at full speed, while the client reads from
-// the growing local file at its own pace.  A slow or disconnected client
-// never stalls (or cancels) the fetch, so the cache always ends up with a
-// complete copy that later readers can reuse.  Concurrent readers of the
-// same object share a single upstream fetch.
+// Fetches are decoupled from the requesting client: the upstream-to-disk copy
+// runs in its own goroutine at full speed, while the client reads from the
+// growing local file at its own pace.  A slow or disconnected client never
+// stalls (or cancels) the fetch, so the cache still ends up with a complete
+// copy that later readers reuse.  Concurrent readers of the same object share
+// a single upstream fetch.
+//
+// Two access patterns deliberately opt out of that copy, because for them it
+// would cost far more egress than it saves:
+//
+//   - Content-type sniffing.  net/http's ServeContent reads the first few
+//     hundred bytes of a file purely to guess a MIME type, and does so even
+//     for a HEAD request.  A reader whose last handle closes without having
+//     read past that prefix retires the copy instead of finishing it, so a
+//     HEAD costs a brief partial read rather than the whole object.  (The
+//     WebDAV PROPFIND handler sniffs the same way, but asks the FileInfo for a
+//     content type first; this layer answers, so a listing never opens its
+//     entries at all.)
+//   - Forward seeks past what the copy has written (i.e. range requests).
+//     Waiting for a sequential copy to reach the requested offset would turn a
+//     small ranged read into a whole-object transfer, so those reads go
+//     directly to the backend, and a range request on its own does not start a
+//     copy.
+//
+// The layer is a performance optimization, never a dependency: when the cache
+// disk is full, unwritable, or already saturated with concurrent fetches,
+// requests fall through to the backend instead of failing.
 package origin_serve
 
 import (
@@ -57,8 +75,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"os"
 	"path"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -68,36 +88,77 @@ import (
 	"github.com/spf13/afero"
 	"golang.org/x/net/webdav"
 
-	"github.com/pelicanplatform/pelican/local_cache"
+	"github.com/pelicanplatform/pelican/cache_control"
 	"github.com/pelicanplatform/pelican/server_utils"
 )
 
 const (
-	// storageCacheEvictTarget is the fraction of the configured maximum size
-	// eviction drives usage down to once the maximum is exceeded.
+	// storageCacheEvictTargetNum/Den give the fraction of the configured
+	// maximum size that eviction drives usage down to once the maximum is
+	// exceeded (9/10 = 90%).
 	storageCacheEvictTargetNum = 9
 	storageCacheEvictTargetDen = 10
 
-	// storageCacheJanitorInterval is how often the eviction pass runs.
+	// storageCacheJanitorInterval is how often the eviction and orphan
+	// reclamation passes run.
 	storageCacheJanitorInterval = time.Minute
 
 	// storageCacheCopyBufSize is the buffer used for the upstream-to-disk copy.
 	storageCacheCopyBufSize = 1 << 20
+
+	// storageCacheSniffLen matches net/http's sniffLen: the number of bytes
+	// ServeContent and the WebDAV PROPFIND handler read to guess a
+	// Content-Type.  Reads no larger than this at offset zero are treated as
+	// content sniffing rather than as the start of a transfer.
+	storageCacheSniffLen = 512
+
+	// storageCacheStallTimeout is how long a fetch may make no progress before
+	// it is abandoned.  Without it a hung backend connection would wedge the
+	// object for every subsequent reader, since they all coalesce onto the
+	// in-flight fetch.
+	storageCacheStallTimeout = 5 * time.Minute
+
+	// storageCacheStallCheckInterval is how often the stall watchdog samples
+	// a fetch's progress.
+	storageCacheStallCheckInterval = 30 * time.Second
+
+	// storageCacheOrphanGrace is how old a data file with no sidecar must be
+	// before a periodic sweep reclaims it.  The grace period keeps the sweep
+	// from racing a fetch that was registered after the sweep listed the tree.
+	storageCacheOrphanGrace = time.Hour
+
+	// storageCacheEnumerationCap bounds the object list a directory mutation
+	// buffers while unrolling a subtree invalidation, and
+	// storageCacheMaxEnumDepth bounds how deep the walk recurses.  Beyond
+	// either, invalidation falls back to the sidecar scan: at that scale the
+	// mutation itself dwarfs a pass over the cache, and the scan needs no
+	// per-path memory.
+	storageCacheEnumerationCap = 65536
+	storageCacheMaxEnumDepth   = 64
 )
+
+// storageCacheDataFileRe matches the data-file names this layer generates,
+// "<64 hex path hash>-<16 hex generation>.data".  A sidecar's DataFile field
+// is read back from disk and used as a path component, so it is validated
+// against this pattern rather than trusted: a hand-edited or corrupted sidecar
+// must not be able to name a file elsewhere in the cache tree.
+var storageCacheDataFileRe = regexp.MustCompile(`^[0-9a-f]{64}-[0-9a-f]{16}\.data$`)
 
 // cacheEntryMeta is the JSON sidecar recorded next to each cached data file.
 // Its presence marks the data file as complete; it is written only after the
 // full object has been copied from the upstream backend.  The sidecar's file
 // mtime doubles as the entry's last-access time for LRU eviction.
 type cacheEntryMeta struct {
-	// Path is the object path within the export (for operator debugging).
+	// Path is the object path within the export.  It identifies the entry for
+	// subtree invalidation, and seeds the per-object freshness jitter.
 	Path string `json:"path"`
 	// Validator is the value compared against the upstream's current
 	// validator to decide whether the copy is still current.
 	Validator string `json:"validator"`
 	// ETag is the client-visible upstream ETag, empty when the upstream did
-	// not supply one (in which case the webdav default, derived from the
-	// preserved size and mtime, applies).
+	// not expose one to clients (in which case the webdav default, derived
+	// from the preserved size and mtime, applies — exactly as it would for an
+	// uncached read of the same backend).
 	ETag string `json:"etag,omitempty"`
 	// CacheControl is the backend's raw Cache-Control value for the object,
 	// captured at fetch/revalidation time; it governs how long the copy is
@@ -110,9 +171,11 @@ type cacheEntryMeta struct {
 	// Size and ModTimeUnixNano preserve the upstream object metadata so
 	// responses served from the cache are indistinguishable from responses
 	// served from the backend.
-	Size            int64  `json:"size"`
-	ModTimeUnixNano int64  `json:"modTimeUnixNano"`
-	DataFile        string `json:"dataFile"`
+	Size            int64 `json:"size"`
+	ModTimeUnixNano int64 `json:"modTimeUnixNano"`
+	// DataFile is the base name of the entry's data file, in the same
+	// directory as the sidecar.  See storageCacheDataFileRe.
+	DataFile string `json:"dataFile"`
 }
 
 func (m *cacheEntryMeta) fileInfo(name string) *cachedFileInfo {
@@ -122,6 +185,12 @@ func (m *cacheEntryMeta) fileInfo(name string) *cachedFileInfo {
 		modTime: time.Unix(0, m.ModTimeUnixNano),
 		etag:    m.ETag,
 	}
+}
+
+// valid reports whether a sidecar read back from disk is self-consistent
+// enough to serve.  Anything else is treated as a miss and refetched.
+func (m *cacheEntryMeta) valid() bool {
+	return m.Size >= 0 && storageCacheDataFileRe.MatchString(m.DataFile)
 }
 
 // ---------------------------------------------------------------------------
@@ -136,67 +205,112 @@ type storageCache struct {
 	ctx     context.Context // server-lifetime context bounding detached fetches
 	maxSize int64           // 0 or negative means unbounded
 
-	// defaultMaxAge is the freshness lifetime applied when the backend
-	// supplies no Cache-Control freshness information; <= 0 means no default
-	// freshness (every read revalidates).  revalidationJitter is the percent
-	// of deterministic per-object jitter applied to defaultMaxAge, matching
-	// the LocalCache.RevalidationJitter semantics.
-	defaultMaxAge      time.Duration
-	revalidationJitter int
+	// policy is the freshness configuration derived from the
+	// Origin.StorageCache* settings.
+	policy cache_control.Policy
 
+	// fetchSem bounds concurrent upstream-to-disk copies.  Each copy holds a
+	// goroutine, a backend connection, and a copy buffer, so an unbounded
+	// count would let one client's request burst exhaust memory and run up an
+	// arbitrary provider bill.  A request that cannot get a slot is served
+	// straight from the backend instead of queueing.
+	fetchSem chan struct{}
+
+	// mu guards the fetch registry and each fetch's registry-visible state
+	// (readers, started, superseded, retired).  It is never held across
+	// filesystem I/O: every request that misses the cache passes through it.
 	mu      sync.Mutex
 	fetches map[string]*cacheFetch // keyed by the entry's meta-file path
+
+	// installMu serializes installing a completed fetch's sidecar against
+	// invalidating an entry, so a fetch cannot resurrect content that a
+	// concurrent mutation just dropped.  It is separate from mu precisely
+	// because it *is* held across disk I/O; only mutations and fetch
+	// completions contend for it, never cache lookups.
+	installMu sync.Mutex
 }
 
-// newStorageCache creates the cache root directory (if needed), opens a
-// symlink-safe afero filesystem rooted there, and starts the eviction
-// janitor.  The janitor and any in-flight fetches stop when ctx is done.
-func newStorageCache(ctx context.Context, location string, maxSize int64, defaultMaxAge time.Duration, revalidationJitter int) (*storageCache, error) {
+// newStorageCache prepares the cache root directory, opens a symlink-safe
+// filesystem rooted there, reclaims any orphans left by a previous process,
+// and starts the janitor.  The janitor and any in-flight fetches stop when ctx
+// is done.
+func newStorageCache(ctx context.Context, location string, maxSize int64, defaultMaxAge time.Duration, revalidationJitter int, maxConcurrentFetches int) (*storageCache, error) {
 	if err := os.MkdirAll(location, 0700); err != nil {
 		return nil, fmt.Errorf("failed to create storage cache directory %s: %w", location, err)
 	}
+	// MkdirAll leaves an existing directory's mode alone, so a cache pointed
+	// at a pre-existing shared path (a scratch area, /tmp/...) could be
+	// writable by other local users.  Anyone who can write here can plant a
+	// sidecar and choose the bytes this origin serves, so refuse to start.
+	info, err := os.Stat(location)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat storage cache directory %s: %w", location, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("storage cache location %s is not a directory", location)
+	}
+	if mode := info.Mode().Perm(); mode&0022 != 0 {
+		return nil, fmt.Errorf("storage cache directory %s is group- or world-writable (mode %04o); "+
+			"tighten it to 0700 so other local users cannot inject cache entries", location, mode)
+	}
+	// Fail at startup rather than turning every request into a 500 later.
+	probe := path.Join(location, ".pelican-storage-cache-probe")
+	if err := os.WriteFile(probe, []byte("ok"), 0600); err != nil {
+		return nil, fmt.Errorf("storage cache directory %s is not writable: %w", location, err)
+	}
+	if err := os.Remove(probe); err != nil {
+		log.Debugf("Storage cache: failed to remove write probe %s: %v", probe, err)
+	}
+
 	rootFs, err := server_utils.NewOsRootFs(location)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open storage cache directory %s: %w", location, err)
 	}
+	if maxConcurrentFetches <= 0 {
+		maxConcurrentFetches = 1
+	}
 	c := &storageCache{
-		fs:                 rootFs,
-		ctx:                ctx,
-		maxSize:            maxSize,
-		defaultMaxAge:      defaultMaxAge,
-		revalidationJitter: revalidationJitter,
-		fetches:            make(map[string]*cacheFetch),
+		fs:      rootFs,
+		ctx:     ctx,
+		maxSize: maxSize,
+		policy: cache_control.Policy{
+			DefaultMaxAge: defaultMaxAge,
+			JitterPercent: revalidationJitter,
+			// A backend may shorten its objects' freshness but not extend it
+			// beyond the operator's configured window.
+			MaxFreshness: defaultMaxAge,
+		},
+		fetchSem: make(chan struct{}, maxConcurrentFetches),
+		fetches:  make(map[string]*cacheFetch),
 	}
-	go c.runJanitor()
+	// Nothing is registered yet, so every data file without a sidecar is a
+	// leftover from a previous process and can go immediately.
+	c.pruneOrphans(0)
 	return c, nil
-}
-
-// newStorageCacheWithFs is the constructor used by tests: it accepts an
-// arbitrary afero filesystem and does not start the janitor.
-func newStorageCacheWithFs(ctx context.Context, fs afero.Fs, maxSize int64, defaultMaxAge time.Duration, revalidationJitter int) *storageCache {
-	return &storageCache{
-		fs:                 fs,
-		ctx:                ctx,
-		maxSize:            maxSize,
-		defaultMaxAge:      defaultMaxAge,
-		revalidationJitter: revalidationJitter,
-		fetches:            make(map[string]*cacheFetch),
-	}
 }
 
 // isFresh reports whether a completed cache entry may be served without any
 // upstream interaction, per its recorded Cache-Control directives (or the
 // configured default policy when the backend supplied none).
 func (c *storageCache) isFresh(meta *cacheEntryMeta) bool {
+	// A zero default max-age means "revalidate every read".  Honour that
+	// literally: a backend-supplied max-age must not be able to re-enable
+	// serving without an upstream check.
+	if c.policy.DefaultMaxAge <= 0 {
+		return false
+	}
 	lastValidated := time.Unix(0, meta.LastValidatedUnixNano)
-	cd := local_cache.ParseCacheControl(meta.CacheControl)
-	return !cd.IsStaleFor(lastValidated, c.defaultMaxAge, c.revalidationJitter)
+	cd := cache_control.Parse(meta.CacheControl)
+	return !cd.IsStaleFor(lastValidated, c.policy, meta.Path)
 }
 
-// newLayer returns the caching webdav.FileSystem for one export, scoped to
-// its own subdirectory so objects from different exports never collide.
-func (c *storageCache) newLayer(federationPrefix string, upstream webdav.FileSystem) *storageCacheFS {
-	sum := sha256.Sum256([]byte(federationPrefix))
+// newLayer returns the caching webdav.FileSystem for one export, scoped to its
+// own subdirectory.  backendID identifies the storage the export is served
+// from (type, endpoint, prefix); folding it into the scope means that
+// repointing an export at different storage cannot serve entries cached from
+// the old one.
+func (c *storageCache) newLayer(federationPrefix, backendID string, upstream webdav.FileSystem) *storageCacheFS {
+	sum := sha256.Sum256([]byte(federationPrefix + "\x00" + backendID))
 	sanitized := strings.ReplaceAll(strings.Trim(federationPrefix, "/"), "/", "_")
 	if sanitized == "" {
 		sanitized = "root"
@@ -204,71 +318,85 @@ func (c *storageCache) newLayer(federationPrefix string, upstream webdav.FileSys
 	return &storageCacheFS{
 		cache:    c,
 		upstream: upstream,
-		scope:    fmt.Sprintf("%s.%s", sanitized, hex.EncodeToString(sum[:4])),
+		scope:    fmt.Sprintf("%s.%s", sanitized, hex.EncodeToString(sum[:8])),
 	}
 }
 
-func (c *storageCache) lookupFetch(metaRel string) *cacheFetch {
+// attachFetch registers a reader on the in-flight fetch for the entry, if one
+// is live.  Finding the fetch and taking the reference happen under the same
+// lock that retires fetches, so a fetch can never be discarded (and its data
+// file unlinked) between a caller finding it and attaching to it.
+func (c *storageCache) attachFetch(metaRel string) *cacheFetch {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.fetches[metaRel]
+	f := c.fetches[metaRel]
+	if f == nil || f.retired {
+		return nil
+	}
+	f.readers++
+	return f
 }
 
-// getOrStartFetch returns the in-flight fetch for the entry, registering the
-// provided one when none exists.  The winning fetch is returned; a losing
-// (raced) fetch is discarded without side effects since fetches start lazily.
-// Registering a fetch also creates its (empty) data file, so every attached
-// reader can open a handle immediately — bytes already copied stay readable
-// even if the fetch later aborts and unlinks the file.
-func (c *storageCache) getOrStartFetch(f *cacheFetch) (*cacheFetch, error) {
+// registerFetch publishes a newly prepared fetch, or attaches to the one that
+// won a concurrent race.  The returned bool reports whether f itself was
+// registered; when it is false the caller must discard the data file it
+// pre-created.  Either way the returned fetch has a reader registered.
+func (c *storageCache) registerFetch(f *cacheFetch) (*cacheFetch, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if existing := c.fetches[f.metaRel]; existing != nil {
-		return existing, nil
+	if existing := c.fetches[f.metaRel]; existing != nil && !existing.retired {
+		existing.readers++
+		return existing, false
 	}
-	if err := c.fs.MkdirAll(path.Dir(f.dataRel), 0700); err != nil {
-		return nil, fmt.Errorf("storage cache: failed to create cache directory: %w", err)
-	}
-	file, err := c.fs.OpenFile(f.dataRel, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
-	if err != nil {
-		return nil, fmt.Errorf("storage cache: failed to create cache file: %w", err)
-	}
-	if err := file.Close(); err != nil {
-		return nil, fmt.Errorf("storage cache: failed to create cache file: %w", err)
-	}
+	f.readers = 1
 	c.fetches[f.metaRel] = f
-	return f, nil
+	return f, true
 }
 
-// releaseUnstarted is called when the last reader of a never-started fetch
-// closes: the registration and the empty data file are discarded so
-// metadata-only opens (HEAD requests) leave nothing behind.
-func (c *storageCache) releaseUnstarted(f *cacheFetch) {
+func (c *storageCache) unregisterFetch(f *cacheFetch) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.fetches[f.metaRel] == f {
 		delete(c.fetches, f.metaRel)
 	}
-	c.mu.Unlock()
-	if err := c.fs.Remove(f.dataRel); err != nil && !os.IsNotExist(err) {
-		log.Debugf("Storage cache: failed to remove unused cache file %s: %v", f.dataRel, err)
+}
+
+// metaTempName returns a unique temporary name alongside the sidecar.
+func metaTempName(metaRel string) (string, error) {
+	suffix := make([]byte, 8)
+	if _, err := rand.Read(suffix); err != nil {
+		return "", err
 	}
+	return metaRel + "." + hex.EncodeToString(suffix) + ".tmp", nil
 }
 
-func (c *storageCache) unregisterFetch(metaRel string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	delete(c.fetches, metaRel)
-}
-
-// writeMeta serializes the sidecar; the fresh mtime doubles as an LRU touch.
+// writeMeta serializes the sidecar through a temporary file and a rename, so a
+// reader never observes a half-written sidecar and a crash mid-update leaves
+// the previous one intact.  The fresh mtime doubles as an LRU touch.
 func (c *storageCache) writeMeta(metaRel string, meta *cacheEntryMeta) error {
 	data, err := json.Marshal(meta)
 	if err != nil {
 		return err
 	}
-	return afero.WriteFile(c.fs, metaRel, data, 0600)
+	tmp, err := metaTempName(metaRel)
+	if err != nil {
+		return err
+	}
+	if err := afero.WriteFile(c.fs, tmp, data, 0600); err != nil {
+		return err
+	}
+	if err := c.fs.Rename(tmp, metaRel); err != nil {
+		if rmErr := c.fs.Remove(tmp); rmErr != nil && !os.IsNotExist(rmErr) {
+			log.Debugf("Storage cache: failed to remove temporary sidecar %s: %v", tmp, rmErr)
+		}
+		return err
+	}
+	return nil
 }
 
+// readMeta loads and validates a sidecar.  Any problem — missing, unreadable,
+// malformed, or naming a data file it has no business naming — reads as a
+// miss, so the entry is simply refetched.
 func (c *storageCache) readMeta(metaRel string) *cacheEntryMeta {
 	data, err := afero.ReadFile(c.fs, metaRel)
 	if err != nil {
@@ -276,8 +404,10 @@ func (c *storageCache) readMeta(metaRel string) *cacheEntryMeta {
 	}
 	var meta cacheEntryMeta
 	if err := json.Unmarshal(data, &meta); err != nil {
-		// A torn write (e.g. crash mid-update) reads as a miss; the entry
-		// will be refetched and the sidecar rewritten.
+		return nil
+	}
+	if !meta.valid() {
+		log.Warningf("Storage cache: ignoring malformed sidecar %s", metaRel)
 		return nil
 	}
 	return &meta
@@ -292,7 +422,7 @@ func (c *storageCache) touch(metaRel string) {
 }
 
 // invalidate drops the completed entry (sidecar first so a concurrent reader
-// never sees a sidecar pointing at a deleted data file's replacement).
+// never sees a sidecar pointing at a deleted data file).
 func (c *storageCache) invalidate(metaRel string) {
 	meta := c.readMeta(metaRel)
 	if err := c.fs.Remove(metaRel); err != nil && !os.IsNotExist(err) {
@@ -307,10 +437,9 @@ func (c *storageCache) invalidate(metaRel string) {
 }
 
 // supersedeFetch marks any in-flight fetch for the entry as superseded so it
-// won't install its (pre-mutation) result as a completed entry.  Must be
-// called BEFORE invalidate: the ordering guarantees that a fetch either sees
-// the flag (and skips installing) or installed its sidecar beforehand, in
-// which case the subsequent invalidate removes it.
+// won't install its (pre-mutation) result as a completed entry.  Callers hold
+// installMu, which is what makes the supersede-then-invalidate sequence atomic
+// against a fetch's check-then-install.
 func (c *storageCache) supersedeFetch(metaRel string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -323,6 +452,8 @@ func (c *storageCache) supersedeFetch(metaRel string) {
 // through the origin (PUT, DELETE, rename endpoint): it supersedes any
 // in-flight fetch and removes the completed entry.
 func (c *storageCache) invalidateEntry(metaRel string) {
+	c.installMu.Lock()
+	defer c.installMu.Unlock()
 	c.supersedeFetch(metaRel)
 	c.invalidate(metaRel)
 }
@@ -335,16 +466,91 @@ func (c *storageCache) runJanitor() {
 		case <-c.ctx.Done():
 			return
 		case <-ticker.C:
+			c.pruneOrphans(storageCacheOrphanGrace)
 			c.evictOnce()
 		}
 	}
 }
 
+// inFlightMetaPaths snapshots the sidecar paths that currently have a fetch
+// registered, so sweeps can skip entries under construction.
+func (c *storageCache) inFlightMetaPaths() map[string]bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	inFlight := make(map[string]bool, len(c.fetches))
+	for metaRel := range c.fetches {
+		inFlight[metaRel] = true
+	}
+	return inFlight
+}
+
+// metaPathForData maps "<hash>-<generation>.data" to its "<hash>.meta"
+// sidecar in the same directory.  It returns "" for names that don't match the
+// layout, which are left alone.
+func metaPathForData(dataRel string) string {
+	base := path.Base(dataRel)
+	if !storageCacheDataFileRe.MatchString(base) {
+		return ""
+	}
+	idx := strings.IndexByte(base, '-')
+	return path.Join(path.Dir(dataRel), base[:idx]+".meta")
+}
+
+// pruneOrphans removes data files that no sidecar refers to and no fetch is
+// writing: leftovers from a process that died mid-fetch.  Reclaiming them is
+// deliberately independent of the size bound, because the default cache is
+// unbounded and would otherwise accumulate them forever.
+//
+// Only files older than grace are considered, so a periodic sweep cannot race
+// a fetch registered after the tree listing began.  A zero grace is for
+// startup, when no fetch exists yet.
+func (c *storageCache) pruneOrphans(grace time.Duration) {
+	inFlight := c.inFlightMetaPaths()
+	cutoff := time.Now().Add(-grace)
+
+	var orphans []string
+	err := afero.Walk(c.fs, ".", func(p string, info os.FileInfo, err error) error {
+		if err != nil || info == nil || info.IsDir() {
+			return nil
+		}
+		switch {
+		case strings.HasSuffix(p, ".tmp"):
+			// A sidecar temp file left by an interrupted rename.
+			if info.ModTime().Before(cutoff) {
+				orphans = append(orphans, p)
+			}
+		case strings.HasSuffix(p, ".data"):
+			if info.ModTime().After(cutoff) {
+				return nil
+			}
+			metaRel := metaPathForData(p)
+			if metaRel == "" || inFlight[metaRel] {
+				return nil
+			}
+			if _, statErr := c.fs.Stat(metaRel); statErr == nil {
+				return nil // a live sidecar refers to this generation
+			}
+			orphans = append(orphans, p)
+		}
+		return nil
+	})
+	if err != nil {
+		log.Warningf("Storage cache: orphan scan failed: %v", err)
+		return
+	}
+	for _, p := range orphans {
+		if err := c.fs.Remove(p); err != nil && !os.IsNotExist(err) {
+			log.Debugf("Storage cache: failed to remove orphan %s: %v", p, err)
+			continue
+		}
+		log.Debugf("Storage cache: reclaimed orphaned file %s", p)
+	}
+}
+
 // evictOnce scans the cache tree and, when total data-file usage exceeds the
 // configured maximum, removes least-recently-accessed entries until usage
-// falls below the eviction target.  Entries with an in-flight fetch are
-// never evicted; data files with no sidecar and no in-flight fetch are
-// orphans (crash leftovers) and are evicted first.
+// falls below the eviction target.  Entries with an in-flight fetch are never
+// evicted.
 func (c *storageCache) evictOnce() {
 	if c.maxSize <= 0 {
 		return
@@ -381,23 +587,13 @@ func (c *storageCache) evictOnce() {
 		return
 	}
 
-	c.mu.Lock()
-	inFlight := make(map[string]bool, len(c.fetches))
-	for metaRel := range c.fetches {
-		inFlight[metaRel] = true
-	}
-	c.mu.Unlock()
+	inFlight := c.inFlightMetaPaths()
 
 	target := c.maxSize / storageCacheEvictTargetDen * storageCacheEvictTargetNum
 	victims := entries[:0]
 	for _, e := range entries {
-		// Data files are named "<hash>-<generation>.data"; the sidecar is
-		// "<hash>.meta" in the same directory.
-		base := path.Base(e.dataRel)
-		if idx := strings.IndexByte(base, '-'); idx > 0 {
-			e.metaRel = path.Join(path.Dir(e.dataRel), base[:idx]+".meta")
-		}
-		if inFlight[e.metaRel] {
+		e.metaRel = metaPathForData(e.dataRel)
+		if e.metaRel == "" || inFlight[e.metaRel] {
 			continue
 		}
 		e.access = metaTimes[e.metaRel] // zero time for orphans: evicted first
@@ -409,12 +605,12 @@ func (c *storageCache) evictOnce() {
 		if total <= target {
 			break
 		}
-		if v.metaRel != "" {
-			if err := c.fs.Remove(v.metaRel); err != nil && !os.IsNotExist(err) {
-				log.Debugf("Storage cache: eviction failed to remove %s: %v", v.metaRel, err)
-			}
+		if err := c.fs.Remove(v.metaRel); err != nil && !os.IsNotExist(err) {
+			log.Debugf("Storage cache: eviction failed to remove %s: %v", v.metaRel, err)
 		}
 		if err := c.fs.Remove(v.dataRel); err != nil && !os.IsNotExist(err) {
+			// The bytes are still on disk, so don't credit them as reclaimed;
+			// the orphan sweep will pick the file up later.
 			log.Debugf("Storage cache: eviction failed to remove %s: %v", v.dataRel, err)
 			continue
 		}
@@ -445,6 +641,19 @@ func (l *storageCacheFS) entryPaths(name string) (metaRel, hashDir, hash string)
 	return
 }
 
+// passthrough abandons the cache for this request and serves straight from the
+// backend.  The cache is an optimization: a full disk, an unwritable
+// directory, or a saturated fetch pool must degrade throughput, not
+// availability.
+func (l *storageCacheFS) passthrough(ctx context.Context, name string, flag int, perm os.FileMode, reason string, err error) (webdav.File, error) {
+	if err != nil {
+		log.Warningf("Storage cache: %s for %s (%v); serving directly from the backend", reason, name, err)
+	} else {
+		log.Debugf("Storage cache: %s for %s; serving directly from the backend", reason, name)
+	}
+	return l.upstream.OpenFile(ctx, name, flag, perm)
+}
+
 func (l *storageCacheFS) Mkdir(ctx context.Context, name string, perm os.FileMode) error {
 	return l.upstream.Mkdir(ctx, name, perm)
 }
@@ -470,25 +679,19 @@ func (l *storageCacheFS) Rename(ctx context.Context, oldName, newName string) er
 	return err
 }
 
-// storageCacheEnumerationCap bounds the object list a directory mutation
-// buffers while unrolling a subtree invalidation.  Beyond this, invalidation
-// falls back to the sidecar scan: at that scale the mutation itself dwarfs a
-// pass over the cache, and the scan needs no per-path memory.
-const storageCacheEnumerationCap = 65536
-
-// enumerateSubtree lists the object paths currently under name in the
-// backend, so a directory mutation can be unrolled into exact per-object
-// invalidations — O(subtree) instead of a scan of every cached sidecar.
-// The listing is metadata-only (no data egress) and mirrors the one a blob
-// backend's RemoveAll performs internally, so it covers exactly the objects
-// the mutation affects.  Cached entries for objects that already vanished
-// from the backend out-of-band are not the mutation's responsibility; the
-// normal freshness/revalidation cycle retires them.
+// enumerateSubtree lists the object paths currently under name in the backend,
+// so a directory mutation can be unrolled into exact per-object invalidations
+// — O(subtree) instead of a scan of every cached sidecar.  The listing is
+// metadata-only (no data egress) and mirrors the one a blob backend's
+// RemoveAll performs internally, so it covers exactly the objects the mutation
+// affects.  Cached entries for objects that already vanished from the backend
+// out-of-band are not the mutation's responsibility; the normal
+// freshness/revalidation cycle retires them.
 //
 // Returns (paths, true) on success.  Returns (nil, false) when the backend
-// cannot enumerate (e.g. a plain-HTTP upstream with no listing support) or
-// the subtree exceeds storageCacheEnumerationCap; callers then fall back to
-// the sidecar scan, which is authoritative over the cache's own contents.
+// cannot enumerate (e.g. a plain-HTTP upstream with no listing support) or the
+// subtree exceeds the enumeration cap or depth limit; callers then fall back
+// to the sidecar scan, which is authoritative over the cache's own contents.
 func (l *storageCacheFS) enumerateSubtree(ctx context.Context, name string) ([]string, bool) {
 	clean := path.Clean("/" + name)
 	info, err := l.upstream.Stat(ctx, clean)
@@ -505,9 +708,13 @@ func (l *storageCacheFS) enumerateSubtree(ctx context.Context, name string) ([]s
 	}
 
 	errCapExceeded := errors.New("enumeration cap exceeded")
+	errTooDeep := errors.New("enumeration depth limit exceeded")
 	paths := []string{clean}
-	var walk func(dir string) error
-	walk = func(dir string) error {
+	var walk func(dir string, depth int) error
+	walk = func(dir string, depth int) error {
+		if depth > storageCacheMaxEnumDepth {
+			return errTooDeep
+		}
 		f, err := l.upstream.OpenFile(ctx, dir, os.O_RDONLY, 0)
 		if err != nil {
 			return err
@@ -516,15 +723,28 @@ func (l *storageCacheFS) enumerateSubtree(ctx context.Context, name string) ([]s
 		for {
 			ents, rdErr := f.Readdir(1024)
 			for _, e := range ents {
+				// A backend that lists "." or ".." (or an empty name) would
+				// otherwise send this walk into unbounded recursion.
+				switch e.Name() {
+				case "", ".", "..":
+					continue
+				}
 				child := path.Join(dir, e.Name())
+				if child == dir {
+					continue
+				}
+				// Count directories against the cap too: a prefix made of
+				// millions of empty "directories" costs just as much to walk
+				// as one made of objects.
+				if len(paths) >= storageCacheEnumerationCap {
+					return errCapExceeded
+				}
 				if e.IsDir() {
-					if err := walk(child); err != nil {
+					paths = append(paths, child)
+					if err := walk(child, depth+1); err != nil {
 						return err
 					}
 					continue
-				}
-				if len(paths) >= storageCacheEnumerationCap {
-					return errCapExceeded
 				}
 				paths = append(paths, child)
 			}
@@ -536,19 +756,19 @@ func (l *storageCacheFS) enumerateSubtree(ctx context.Context, name string) ([]s
 			}
 		}
 	}
-	if err := walk(clean); err != nil {
+	if err := walk(clean, 0); err != nil {
 		log.Debugf("Storage cache: subtree enumeration of %s failed (%v); falling back to sidecar scan", clean, err)
 		return nil, false
 	}
 	return paths, true
 }
 
-// invalidateSubtreeEntries is the notification hook for mutations whose
-// target may be a directory.  In-flight fetches under the subtree are always
+// invalidateSubtreeEntries is the notification hook for mutations whose target
+// may be a directory.  In-flight fetches under the subtree are always
 // superseded first (an in-memory registry sweep) so none installs
 // pre-mutation content afterwards.  Completed entries are then dropped: per
-// enumerated path when the subtree could be listed, otherwise by scanning
-// the export's sidecars (each records its object path).
+// enumerated path when the subtree could be listed, otherwise by scanning the
+// export's sidecars (each records its object path).
 func (l *storageCacheFS) invalidateSubtreeEntries(name string, targets []string, enumerated bool) {
 	clean := path.Clean("/" + name)
 	childPrefix := clean
@@ -559,8 +779,11 @@ func (l *storageCacheFS) invalidateSubtreeEntries(name string, targets []string,
 		return objPath == clean || strings.HasPrefix(objPath, childPrefix)
 	}
 
-	// Supersede in-flight fetches first (see supersedeFetch for ordering).
 	c := l.cache
+	c.installMu.Lock()
+	defer c.installMu.Unlock()
+
+	// Supersede in-flight fetches first (see supersedeFetch for ordering).
 	scopePrefix := l.scope + "/"
 	c.mu.Lock()
 	for metaRel, f := range c.fetches {
@@ -579,8 +802,8 @@ func (l *storageCacheFS) invalidateSubtreeEntries(name string, targets []string,
 	}
 
 	// Fallback: drop every completed entry whose recorded path is in the
-	// subtree.  O(total cached entries), used only when the backend can't
-	// tell us what lives under the prefix.
+	// subtree.  O(total cached entries), used only when the backend can't tell
+	// us what lives under the prefix.
 	objectsDir := path.Join(l.scope, "objects")
 	walkErr := afero.Walk(c.fs, objectsDir, func(p string, info os.FileInfo, err error) error {
 		if err != nil || info == nil || info.IsDir() || !strings.HasSuffix(p, ".meta") {
@@ -597,14 +820,24 @@ func (l *storageCacheFS) invalidateSubtreeEntries(name string, targets []string,
 }
 
 // Stat serves the preserved upstream metadata for fresh cache entries so
-// HEAD-style probes cost no upstream round-trip; anything else (stale
-// entries, misses, directories) is delegated to the backend.
+// HEAD-style probes cost no upstream round-trip; anything else (stale entries,
+// misses, directories) is delegated to the backend.
+//
+// Results are wrapped so they carry a Content-Type.  Without one, a PROPFIND
+// opens every file it lists and reads its first bytes to sniff a type, which
+// through this layer would mean touching the backend for every object in a
+// directory.
 func (l *storageCacheFS) Stat(ctx context.Context, name string) (os.FileInfo, error) {
 	metaRel, _, _ := l.entryPaths(name)
 	if meta := l.cache.readMeta(metaRel); meta != nil && l.cache.isFresh(meta) {
+		l.cache.touch(metaRel)
 		return meta.fileInfo(name), nil
 	}
-	return l.upstream.Stat(ctx, name)
+	info, err := l.upstream.Stat(ctx, name)
+	if err != nil || info == nil || info.IsDir() {
+		return info, err
+	}
+	return contentTypedInfo{info}, nil
 }
 
 func (l *storageCacheFS) OpenFile(ctx context.Context, name string, flag int, perm os.FileMode) (webdav.File, error) {
@@ -624,12 +857,15 @@ func (l *storageCacheFS) OpenFile(ctx context.Context, name string, flag int, pe
 
 	metaRel, hashDir, hash := l.entryPaths(name)
 
-	// An in-flight fetch for this object serves everyone; attach to it.  If
-	// the attach races with the fetch being discarded (its last reader closed
-	// before it started), fall through and register a fresh fetch.
-	if f := l.cache.lookupFetch(metaRel); f != nil {
+	// An in-flight fetch for this object serves everyone; attach to it.
+	if f := l.cache.attachFetch(metaRel); f != nil {
 		if reader, attachErr := newFetchReader(ctx, f); attachErr == nil {
 			return reader, nil
+		} else {
+			// The data file went away (a racing retirement); drop the
+			// reference and fall through to a fresh fetch.
+			f.detach(0, 0)
+			log.Debugf("Storage cache: could not attach to in-flight fetch of %s: %v", name, attachErr)
 		}
 	}
 
@@ -653,31 +889,35 @@ func (l *storageCacheFS) OpenFile(ctx context.Context, name string, flag int, pe
 		return nil, err
 	}
 	if info.IsDir() {
-		return l.upstream.OpenFile(ctx, name, flag, perm)
+		dir, err := l.upstream.OpenFile(ctx, name, flag, perm)
+		if err != nil {
+			return nil, err
+		}
+		return &contentTypedDir{File: dir}, nil
 	}
 
-	validator, explicitETag := upstreamValidator(ctx, info)
+	validator, clientVisibleETag := upstreamValidator(ctx, info)
 	cacheControl := upstreamCacheControl(info)
 
 	// no-store / private responses must not be persisted: drop any existing
 	// copy (superseding a concurrently registered fetch, if any) and stream
 	// straight from the backend.
-	if cd := local_cache.ParseCacheControl(cacheControl); !cd.ShouldStore() {
+	if cd := cache_control.Parse(cacheControl); !cd.ShouldStore() {
 		if meta != nil {
 			l.cache.invalidateEntry(metaRel)
 		}
 		return l.upstream.OpenFile(ctx, name, flag, perm)
 	}
 
-	// Revalidated: the validator still matches, so renew the freshness
-	// window (and pick up any Cache-Control change) and serve locally.
+	// Revalidated: the validator still matches, so renew the freshness window
+	// (and pick up any Cache-Control change) and serve locally.
 	oldDataFile := ""
 	if meta != nil {
 		if meta.Validator == validator {
 			meta.CacheControl = cacheControl
 			meta.LastValidatedUnixNano = time.Now().UnixNano()
 			if wErr := l.cache.writeMeta(metaRel, meta); wErr != nil {
-				log.Debugf("Storage cache: failed to renew metadata for %s: %v", metaRel, wErr)
+				log.Warningf("Storage cache: failed to renew metadata for %s: %v", metaRel, wErr)
 			}
 			if file, openErr := l.cache.fs.Open(path.Join(hashDir, meta.DataFile)); openErr == nil {
 				return &cacheHitFile{File: file, info: meta.fileInfo(name)}, nil
@@ -687,22 +927,31 @@ func (l *storageCacheFS) OpenFile(ctx context.Context, name string, flag int, pe
 		oldDataFile = meta.DataFile
 	}
 
-	// Miss (or stale): fetch from the backend into the cache.  The fetch
-	// starts lazily on the first Read so metadata-only opens (HEAD requests,
-	// size probes) never trigger data egress.
+	// Miss (or stale): fetch from the backend into the cache.  Take a fetch
+	// slot first; when the pool is saturated, serve from the backend rather
+	// than queueing behind other transfers.
+	select {
+	case l.cache.fetchSem <- struct{}{}:
+	default:
+		return l.passthrough(ctx, name, flag, perm, "fetch pool saturated", nil)
+	}
+	releaseSlot := func() { <-l.cache.fetchSem }
+
 	gen := make([]byte, 8)
 	if _, err := rand.Read(gen); err != nil {
+		releaseSlot()
 		return nil, fmt.Errorf("failed to generate cache file name: %w", err)
 	}
 	etag := ""
-	if explicitETag {
+	if clientVisibleETag {
 		etag = validator
 	}
+	dataFile := fmt.Sprintf("%s-%s.data", hash, hex.EncodeToString(gen))
 	f := &cacheFetch{
 		cache:   l.cache,
 		name:    name,
 		metaRel: metaRel,
-		dataRel: path.Join(hashDir, fmt.Sprintf("%s-%s.data", hash, hex.EncodeToString(gen))),
+		dataRel: path.Join(hashDir, dataFile),
 		meta: cacheEntryMeta{
 			Path:                  path.Clean("/" + name),
 			Validator:             validator,
@@ -711,9 +960,9 @@ func (l *storageCacheFS) OpenFile(ctx context.Context, name string, flag int, pe
 			LastValidatedUnixNano: time.Now().UnixNano(),
 			Size:                  info.Size(),
 			ModTimeUnixNano:       info.ModTime().UnixNano(),
-			DataFile:              fmt.Sprintf("%s-%s.data", hash, hex.EncodeToString(gen)),
+			DataFile:              dataFile,
 		},
-		oldDataRel: "",
+		releaseSlot: releaseSlot,
 		open: func(fetchCtx context.Context) (webdav.File, error) {
 			return l.upstream.OpenFile(fetchCtx, name, os.O_RDONLY, 0)
 		},
@@ -722,35 +971,81 @@ func (l *storageCacheFS) OpenFile(ctx context.Context, name string, flag int, pe
 		f.oldDataRel = path.Join(hashDir, oldDataFile)
 	}
 	f.cond = sync.NewCond(&f.mu)
-	f, err = l.cache.getOrStartFetch(f)
-	if err != nil {
-		return nil, err
+
+	// Create the (empty) data file before publishing the fetch, so every
+	// reader that attaches can open a handle immediately.  Doing this outside
+	// the registry lock keeps disk latency off the path of every other
+	// request; the generation suffix makes the name unique, so a fetch that
+	// loses the registration race simply removes the file it made.
+	if err := l.cache.fs.MkdirAll(hashDir, 0700); err != nil {
+		releaseSlot()
+		return l.passthrough(ctx, name, flag, perm, "cannot create cache directory", err)
 	}
-	return newFetchReader(ctx, f)
+	if file, err := l.cache.fs.OpenFile(f.dataRel, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0600); err != nil {
+		releaseSlot()
+		return l.passthrough(ctx, name, flag, perm, "cannot create cache file", err)
+	} else if err := file.Close(); err != nil {
+		releaseSlot()
+		return l.passthrough(ctx, name, flag, perm, "cannot create cache file", err)
+	}
+
+	winner, mine := l.cache.registerFetch(f)
+	if !mine {
+		releaseSlot()
+		if rmErr := l.cache.fs.Remove(f.dataRel); rmErr != nil && !os.IsNotExist(rmErr) {
+			log.Debugf("Storage cache: failed to remove raced cache file %s: %v", f.dataRel, rmErr)
+		}
+	}
+	reader, err := newFetchReader(ctx, winner)
+	if err != nil {
+		winner.detach(0, 0)
+		return l.passthrough(ctx, name, flag, perm, "cannot open cache file for read", err)
+	}
+	return reader, nil
 }
 
 // upstreamValidator extracts the consistency validator for an upstream
-// FileInfo: the backend's own ETag when it exposes one (webdav.ETager or the
-// backend-specific Sys() payloads), otherwise the same size/mtime-derived
-// tag the origin uses for local files.  The boolean reports whether the
-// validator is a genuine upstream ETag (and therefore client-visible).
+// FileInfo: the backend's own ETag when it exposes one, otherwise the same
+// size/mtime-derived tag the origin uses for local files.
+//
+// The boolean reports whether the validator is an ETag the backend also
+// exposes to clients (via webdav.ETager).  Only those are re-served from the
+// cache; a backend that keeps its ETag internal must keep looking the same
+// through the cache as without it, or the ETag a client sees would flip
+// between two formats depending on whether the object happened to be cached.
+//
+// Weak ETags are rejected outright.  "W/" means the backend considers two
+// different payloads equivalent, which is exactly the comparison a cache must
+// not make, and RFC 7232 forbids using them for the range requests these
+// responses support.
 func upstreamValidator(ctx context.Context, info os.FileInfo) (string, bool) {
 	if et, ok := info.(webdav.ETager); ok {
-		if v, err := et.ETag(ctx); err == nil && v != "" {
+		if v, err := et.ETag(ctx); err == nil && isStrongETag(v) {
 			return v, true
+		}
+	}
+	// gowebdav's FileInfo (the WebDAV-mode HTTPS and Globus backends) exposes
+	// its ETag through a context-free method of its own.
+	if et, ok := info.(interface{ ETag() string }); ok {
+		if v := et.ETag(); isStrongETag(v) {
+			return v, false
 		}
 	}
 	switch sys := info.Sys().(type) {
 	case *BlobFileSysInfo:
-		if sys.ETag != "" {
-			return sys.ETag, true
+		if isStrongETag(sys.ETag) {
+			return sys.ETag, false
 		}
 	case *HTTPSFileSysInfo:
-		if sys.ETag != "" {
-			return sys.ETag, true
+		if isStrongETag(sys.ETag) {
+			return sys.ETag, false
 		}
 	}
 	return computeETag(info), false
+}
+
+func isStrongETag(v string) bool {
+	return v != "" && !strings.HasPrefix(v, "W/") && !strings.HasPrefix(v, "w/")
 }
 
 // upstreamCacheControl extracts the backend's Cache-Control value for the
@@ -771,48 +1066,158 @@ func upstreamCacheControl(info os.FileInfo) string {
 // ---------------------------------------------------------------------------
 
 type cacheFetch struct {
-	cache      *storageCache
-	name       string
-	metaRel    string
-	dataRel    string
-	oldDataRel string // superseded data file removed once the new copy lands
-	meta       cacheEntryMeta
-	open       func(ctx context.Context) (webdav.File, error)
+	cache       *storageCache
+	name        string
+	metaRel     string
+	dataRel     string
+	oldDataRel  string // superseded data file removed once the new copy lands
+	meta        cacheEntryMeta
+	open        func(ctx context.Context) (webdav.File, error)
+	releaseSlot func() // returns this fetch's slot to the concurrency pool
 
+	// mu and cond guard the copy's progress.
 	mu      sync.Mutex
 	cond    *sync.Cond
-	started bool
-	readers int
 	written int64
 	done    bool
 	err     error
 
-	// superseded is set (under storageCache.mu, NOT this mutex) when the
-	// object is mutated through the origin while this fetch is in flight.
-	// A superseded fetch still streams to its attached readers, but must not
-	// install its result as a completed cache entry: the bytes it is copying
-	// predate the mutation, yet its validation timestamp would look fresh.
+	// The following are guarded by storageCache.mu, not by mu above.
+	started  bool
+	retired  bool
+	readers  int
+	consumed bool // a reader wanted real bytes, not just a content-type sniff
+	// superseded is set when the object is mutated through the origin while
+	// this fetch is in flight.  A superseded fetch still streams to its
+	// attached readers, but must not install its result as a completed cache
+	// entry: the bytes it is copying predate the mutation, yet its validation
+	// timestamp would look fresh.
 	superseded bool
+	cancel     context.CancelFunc
 }
 
-// ensureStarted launches the copy goroutine exactly once.  The copy runs
-// under the cache's server-lifetime context, not any request context, so a
-// slow or disconnected client never cancels it.
+// ensureStarted launches the copy goroutine exactly once.  The copy runs under
+// the cache's server-lifetime context, not any request context, so a slow or
+// disconnected client never cancels it.
 func (f *cacheFetch) ensureStarted() {
-	f.mu.Lock()
-	if f.started {
-		f.mu.Unlock()
+	c := f.cache
+	c.mu.Lock()
+	if f.started || f.retired {
+		c.mu.Unlock()
 		return
 	}
 	f.started = true
-	f.mu.Unlock()
-	go f.run()
+	ctx, cancel := context.WithCancel(c.ctx)
+	f.cancel = cancel
+	c.mu.Unlock()
+	go f.run(ctx)
 }
 
-func (f *cacheFetch) run() {
-	src, err := f.open(f.cache.ctx)
+// detach releases one reader's reference.  maxOffset is the furthest offset
+// that reader actually read to (seeks don't count) and finalOffset is where it
+// ended up; together they decide whether the copy is worth finishing.
+func (f *cacheFetch) detach(maxOffset, finalOffset int64) {
+	c := f.cache
+	c.mu.Lock()
+	f.readers--
+	// Distinguish a client that actually wanted bytes from net/http's
+	// content-type sniff.  ServeContent reads the first sniff-length bytes and
+	// then rewinds to zero; on a HEAD it stops there, leaving a reader that
+	// read only the prefix and ended back at the start.  Anything else —
+	// reading past the prefix, or stopping part-way through — is a real
+	// transfer, and its copy is allowed to finish even after the client goes
+	// away.  A handle that never read at all (a pure metadata probe) is not a
+	// transfer either.
+	if maxOffset > storageCacheSniffLen || (maxOffset > 0 && finalOffset != 0) {
+		f.consumed = true
+	}
+	// Finishing a whole-object copy on behalf of a sniff would be exactly the
+	// egress this layer exists to avoid.  A fetch that never started is always
+	// retired: there is no copy to preserve, and leaving it registered would
+	// strand its pool slot and its empty data file forever — the case a reader
+	// that only ever range-bypassed would otherwise hit, since it counts as
+	// having consumed bytes without ever starting the copy.
+	//
+	// Whether the copy already finished is deliberately not consulted here:
+	// f.done belongs to the fetch's own mutex, and reading it under this one
+	// would race.  Retiring a fetch that has just completed is harmless — the
+	// started branch below only cancels a context and drops a registry entry
+	// that finish() removes anyway, and run() re-checks f.retired under this
+	// same lock before installing, so a sidecar is never left pointing at a
+	// data file that got cleaned up.
+	retire := f.readers <= 0 && (!f.started || !f.consumed)
+	if !retire {
+		c.mu.Unlock()
+		return
+	}
+	f.retired = true
+	if c.fetches[f.metaRel] == f {
+		delete(c.fetches, f.metaRel)
+	}
+	started, cancel := f.started, f.cancel
+	c.mu.Unlock()
+
+	if started {
+		// The copy goroutine owns the data file and the pool slot from here;
+		// cancelling makes it unwind through abort().
+		if cancel != nil {
+			cancel()
+		}
+		return
+	}
+	f.releaseSlot()
+	if err := c.fs.Remove(f.dataRel); err != nil && !os.IsNotExist(err) {
+		log.Debugf("Storage cache: failed to remove unused cache file %s: %v", f.dataRel, err)
+	}
+}
+
+// watchStall aborts a fetch that stops making progress.  Readers coalesce onto
+// the in-flight fetch, so a wedged backend connection would otherwise block
+// every future request for the object until the server shut down.
+func (f *cacheFetch) watchStall(ctx context.Context, cancel context.CancelFunc) {
+	ticker := time.NewTicker(storageCacheStallCheckInterval)
+	defer ticker.Stop()
+	last := int64(-1)
+	stalledFor := time.Duration(0)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			f.mu.Lock()
+			written, done := f.written, f.done
+			f.mu.Unlock()
+			if done {
+				return
+			}
+			if written != last {
+				last, stalledFor = written, 0
+				continue
+			}
+			stalledFor += storageCacheStallCheckInterval
+			if stalledFor >= storageCacheStallTimeout {
+				log.Warningf("Storage cache: fetch of %s made no progress for %s; abandoning it",
+					f.name, storageCacheStallTimeout)
+				cancel()
+				return
+			}
+		}
+	}
+}
+
+func (f *cacheFetch) run(ctx context.Context) {
+	defer f.releaseSlot()
+
+	// stallCancel both unblocks a wedged read and stops the watchdog; the
+	// deferred call makes the watchdog exit as soon as the copy returns rather
+	// than lingering until its next tick.
+	stallCtx, stallCancel := context.WithCancel(ctx)
+	defer stallCancel()
+	go f.watchStall(stallCtx, stallCancel)
+
+	src, err := f.open(stallCtx)
 	if err != nil {
-		f.finish(fmt.Errorf("storage cache: upstream open of %s failed: %w", f.name, err))
+		f.abort(fmt.Errorf("storage cache: upstream open of %s failed: %w", f.name, err))
 		return
 	}
 	defer src.Close()
@@ -820,12 +1225,24 @@ func (f *cacheFetch) run() {
 	// The (empty) data file was created when the fetch was registered.
 	dst, err := f.cache.fs.OpenFile(f.dataRel, os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
-		f.finish(fmt.Errorf("storage cache: failed to create cache file: %w", err))
+		f.abort(fmt.Errorf("storage cache: failed to open cache file: %w", err))
 		return
 	}
 
 	buf := make([]byte, storageCacheCopyBufSize)
+	var copied int64 // this goroutine's private view of f.written
 	for {
+		// Never write more than the object was said to hold: a backend that
+		// streams more than it advertised would otherwise fill the cache
+		// filesystem before the size check below ever ran.  One byte past the
+		// advertised length is still read, so an oversized object is reported
+		// as an error rather than silently truncated to fit.
+		if room := f.meta.Size - copied + 1; room < int64(len(buf)) {
+			if room < 1 {
+				room = 1
+			}
+			buf = buf[:room]
+		}
 		n, readErr := src.Read(buf)
 		if n > 0 {
 			if _, writeErr := dst.Write(buf[:n]); writeErr != nil {
@@ -833,10 +1250,17 @@ func (f *cacheFetch) run() {
 				f.abort(fmt.Errorf("storage cache: write to cache file failed: %w", writeErr))
 				return
 			}
+			copied += int64(n)
 			f.mu.Lock()
-			f.written += int64(n)
+			f.written = copied
 			f.cond.Broadcast()
 			f.mu.Unlock()
+			if copied > f.meta.Size {
+				dst.Close()
+				f.abort(fmt.Errorf("storage cache: upstream %s returned more than the %d bytes it reported",
+					f.name, f.meta.Size))
+				return
+			}
 		}
 		if readErr == io.EOF {
 			break
@@ -852,32 +1276,32 @@ func (f *cacheFetch) run() {
 		return
 	}
 
-	// The size was captured at revalidation time; a mismatch means the
-	// object changed (or was truncated) mid-fetch, so the copy cannot be
-	// trusted and readers must see an error rather than a silent short read.
-	f.mu.Lock()
-	written := f.written
-	f.mu.Unlock()
-	if written != f.meta.Size {
-		f.abort(fmt.Errorf("storage cache: fetched %d bytes for %s but upstream reported %d", written, f.name, f.meta.Size))
+	// The size was captured at revalidation time; a mismatch means the object
+	// changed (or was truncated) mid-fetch, so the copy cannot be trusted and
+	// readers must see an error rather than a silent short read.
+	if copied != f.meta.Size {
+		f.abort(fmt.Errorf("storage cache: fetched %d bytes for %s but upstream reported %d", copied, f.name, f.meta.Size))
 		return
 	}
 
-	// Install the completed entry.  The superseded check and the sidecar
-	// write happen under the registry lock so they are atomic with respect
-	// to supersedeFetch: either the flag is seen here (no install), or the
-	// sidecar lands before the mutation's invalidation sweep and is removed
-	// by it.
-	f.cache.mu.Lock()
-	superseded := f.superseded
+	// Install the completed entry.  installMu makes the superseded check and
+	// the sidecar write atomic with respect to a mutation's
+	// supersede-then-invalidate, so either the flag is seen here (no install),
+	// or the sidecar lands before the invalidation sweep and is removed by it.
+	c := f.cache
+	c.installMu.Lock()
+	c.mu.Lock()
+	superseded := f.superseded || f.retired
+	c.mu.Unlock()
 	var installErr error
 	if !superseded {
-		installErr = f.cache.writeMeta(f.metaRel, &f.meta)
+		installErr = c.writeMeta(f.metaRel, &f.meta)
 	}
-	f.cache.mu.Unlock()
+	c.installMu.Unlock()
+
 	if superseded {
-		log.Debugf("Storage cache: fetch of %s was superseded by a write; discarding", f.name)
-		if err := f.cache.fs.Remove(f.dataRel); err != nil && !os.IsNotExist(err) {
+		log.Debugf("Storage cache: fetch of %s was superseded; discarding", f.name)
+		if err := c.fs.Remove(f.dataRel); err != nil && !os.IsNotExist(err) {
 			log.Debugf("Storage cache: failed to remove superseded fetch file %s: %v", f.dataRel, err)
 		}
 		// Attached readers already hold open handles and drain normally.
@@ -889,15 +1313,18 @@ func (f *cacheFetch) run() {
 		return
 	}
 	if f.oldDataRel != "" {
-		if err := f.cache.fs.Remove(f.oldDataRel); err != nil && !os.IsNotExist(err) {
+		if err := c.fs.Remove(f.oldDataRel); err != nil && !os.IsNotExist(err) {
 			log.Debugf("Storage cache: failed to remove superseded data file %s: %v", f.oldDataRel, err)
 		}
 	}
 	f.finish(nil)
 }
 
-// abort discards the partial cache file and reports err to readers.
+// abort discards the partial cache file and reports err to readers.  The
+// registry entry is removed before the file is unlinked, so no request can
+// find this fetch and then fail to open its data file.
 func (f *cacheFetch) abort(err error) {
+	f.cache.unregisterFetch(f)
 	if rmErr := f.cache.fs.Remove(f.dataRel); rmErr != nil && !os.IsNotExist(rmErr) {
 		log.Debugf("Storage cache: failed to remove partial cache file %s: %v", f.dataRel, rmErr)
 	}
@@ -905,7 +1332,7 @@ func (f *cacheFetch) abort(err error) {
 }
 
 func (f *cacheFetch) finish(err error) {
-	if err != nil {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		log.Warningf("%v", err)
 	}
 	f.mu.Lock()
@@ -913,7 +1340,7 @@ func (f *cacheFetch) finish(err error) {
 	f.err = err
 	f.cond.Broadcast()
 	f.mu.Unlock()
-	f.cache.unregisterFetch(f.metaRel)
+	f.cache.unregisterFetch(f)
 }
 
 // ---------------------------------------------------------------------------
@@ -924,25 +1351,36 @@ type fetchReader struct {
 	fetch  *cacheFetch
 	reqCtx context.Context
 
-	mu     sync.Mutex
-	file   afero.File
-	closed bool
-	offset int64
+	mu        sync.Mutex
+	file      afero.File
+	closed    bool
+	offset    int64
+	maxOffset int64
+	// bypass is a direct backend handle used when this reader has moved past
+	// what the shared copy has written; see fetchReader.Read.
+	bypass webdav.File
 }
 
-// newFetchReader attaches a reader to the fetch, opening its own handle on
-// the shared data file up front.  Holding the handle from the start
-// guarantees the reader can deliver every byte the fetch reports as written,
-// even if the fetch aborts (and unlinks the file) mid-stream.
+// newFetchReader attaches a reader to the fetch, opening its own handle on the
+// shared data file up front.  Holding the handle from the start guarantees the
+// reader can deliver every byte the fetch reports as written, even if the
+// fetch aborts (and unlinks the file) mid-stream.
+//
+// The caller must already have registered the reader with attachFetch or
+// registerFetch; on error it must call detach.
 func newFetchReader(reqCtx context.Context, f *cacheFetch) (*fetchReader, error) {
 	file, err := f.cache.fs.Open(f.dataRel)
 	if err != nil {
 		return nil, fmt.Errorf("storage cache: failed to open cache file for read: %w", err)
 	}
-	f.mu.Lock()
-	f.readers++
-	f.mu.Unlock()
 	return &fetchReader{fetch: f, reqCtx: reqCtx, file: file}, nil
+}
+
+func (r *fetchReader) advance(n int) {
+	r.offset += int64(n)
+	if r.offset > r.maxOffset {
+		r.maxOffset = r.offset
+	}
 }
 
 // Read serves bytes from the cache file, waiting for the fetch goroutine to
@@ -960,6 +1398,34 @@ func (r *fetchReader) Read(p []byte) (int, error) {
 	}
 
 	f := r.fetch
+
+	if r.bypass != nil {
+		n, err := r.bypass.Read(p)
+		r.advance(n)
+		return n, err
+	}
+
+	f.mu.Lock()
+	written, done := f.written, f.done
+	f.mu.Unlock()
+
+	// A forward seek past what the copy has written means a range request.
+	// Waiting for a sequential copy to reach that offset would transfer the
+	// whole object to deliver a slice of it, so read directly instead.  The
+	// shared copy is deliberately not started here: one ranged request is no
+	// reason to pull an entire object.
+	if !done && r.offset > written {
+		if src, err := r.openBypass(r.offset); err == nil {
+			r.bypass = src
+			n, readErr := src.Read(p)
+			r.advance(n)
+			return n, readErr
+		} else {
+			log.Debugf("Storage cache: ranged backend read of %s at %d failed (%v); waiting on the shared copy",
+				f.name, r.offset, err)
+		}
+	}
+
 	f.ensureStarted()
 
 	stop := context.AfterFunc(r.reqCtx, func() {
@@ -991,11 +1457,24 @@ func (r *fetchReader) Read(p []byte) (int, error) {
 		n = int64(len(p))
 	}
 	read, err := r.file.ReadAt(p[:n], r.offset)
-	r.offset += int64(read)
+	r.advance(read)
 	if err == io.EOF && read > 0 {
 		err = nil
 	}
 	return read, err
+}
+
+// openBypass returns a backend handle positioned at off.
+func (r *fetchReader) openBypass(off int64) (webdav.File, error) {
+	src, err := r.fetch.open(r.reqCtx)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := src.Seek(off, io.SeekStart); err != nil {
+		src.Close()
+		return nil, err
+	}
+	return src, nil
 }
 
 // Seek repositions the reader without blocking; the object size is already
@@ -1018,6 +1497,14 @@ func (r *fetchReader) Seek(offset int64, whence int) (int64, error) {
 	if next < 0 {
 		return 0, fmt.Errorf("negative seek offset")
 	}
+	// Any repositioning invalidates a backend handle opened for a previous
+	// offset; the next Read re-establishes one if it is still warranted.
+	if r.bypass != nil && next != r.offset {
+		if err := r.bypass.Close(); err != nil {
+			log.Debugf("Storage cache: failed to close backend read handle: %v", err)
+		}
+		r.bypass = nil
+	}
 	r.offset = next
 	return next, nil
 }
@@ -1031,18 +1518,13 @@ func (r *fetchReader) Close() error {
 	r.closed = true
 	err := r.file.Close()
 	r.file = nil
-
-	// If no reader ever triggered the fetch and this was the last handle
-	// (typical for HEAD requests), discard the pending fetch so the registry
-	// and disk don't accumulate never-used entries.
-	f := r.fetch
-	f.mu.Lock()
-	f.readers--
-	discard := f.readers == 0 && !f.started
-	f.mu.Unlock()
-	if discard {
-		f.cache.releaseUnstarted(f)
+	if r.bypass != nil {
+		if bErr := r.bypass.Close(); bErr != nil {
+			log.Debugf("Storage cache: failed to close backend read handle: %v", bErr)
+		}
+		r.bypass = nil
 	}
+	r.fetch.detach(r.maxOffset, r.offset)
 	return err
 }
 
@@ -1089,9 +1571,9 @@ type cacheHitFile struct {
 	info os.FileInfo
 }
 
-// Stat reports the preserved upstream metadata, not the local file's, so
-// ETags and Last-Modified are identical whether the response is served from
-// the cache or the backend.
+// Stat reports the preserved upstream metadata, not the local file's, so ETags
+// and Last-Modified are identical whether the response is served from the
+// cache or the backend.
 func (f *cacheHitFile) Stat() (os.FileInfo, error) { return f.info, nil }
 
 func (f *cacheHitFile) Write(_ []byte) (int, error) {
@@ -1100,6 +1582,52 @@ func (f *cacheHitFile) Write(_ []byte) (int, error) {
 
 func (f *cacheHitFile) Readdir(_ int) ([]os.FileInfo, error) {
 	return nil, fmt.Errorf("readdir not supported on file")
+}
+
+// ---------------------------------------------------------------------------
+// content-type wrappers — keep PROPFIND from opening every object
+// ---------------------------------------------------------------------------
+
+// contentTypedInfo adds a Content-Type to an upstream FileInfo.  The WebDAV
+// PROPFIND handler asks a FileInfo for its content type first and only falls
+// back to opening the file and sniffing its first bytes when the FileInfo
+// can't say — which, over this layer, would mean a backend round trip (and,
+// without the sniff carve-out in fetchReader.Read, an object fetch) for every
+// file in a listing.
+type contentTypedInfo struct {
+	os.FileInfo
+}
+
+func (fi contentTypedInfo) ContentType(_ context.Context) (string, error) {
+	if ct := mime.TypeByExtension(path.Ext(fi.Name())); ct != "" {
+		return ct, nil
+	}
+	return "application/octet-stream", nil
+}
+
+// ETag forwards to the wrapped FileInfo so wrapping doesn't change the ETag a
+// client sees.  Backends that expose no ETag get webdav's default, as before.
+func (fi contentTypedInfo) ETag(ctx context.Context) (string, error) {
+	if et, ok := fi.FileInfo.(webdav.ETager); ok {
+		return et.ETag(ctx)
+	}
+	return "", webdav.ErrNotImplemented
+}
+
+// contentTypedDir wraps a backend directory handle so the entries a PROPFIND
+// lists carry content types for the same reason.
+type contentTypedDir struct {
+	webdav.File
+}
+
+func (d *contentTypedDir) Readdir(count int) ([]os.FileInfo, error) {
+	infos, err := d.File.Readdir(count)
+	for i, fi := range infos {
+		if fi != nil && !fi.IsDir() {
+			infos[i] = contentTypedInfo{fi}
+		}
+	}
+	return infos, err
 }
 
 // ---------------------------------------------------------------------------
@@ -1120,14 +1648,23 @@ func (fi *cachedFileInfo) ModTime() time.Time { return fi.modTime }
 func (fi *cachedFileInfo) IsDir() bool        { return false }
 func (fi *cachedFileInfo) Sys() interface{}   { return nil }
 
-// ETag exposes the upstream's ETag when one was recorded; otherwise the
-// webdav handler falls back to its default (size/mtime) computation, which
-// matches the backend's behaviour since both values are preserved.
+// ETag exposes the upstream's ETag when the backend exposed one to clients;
+// otherwise the webdav handler falls back to its default (size/mtime)
+// computation, which matches the backend's behaviour since both values are
+// preserved.
 func (fi *cachedFileInfo) ETag(_ context.Context) (string, error) {
 	if fi.etag != "" {
 		return fi.etag, nil
 	}
 	return "", webdav.ErrNotImplemented
+}
+
+// ContentType keeps PROPFIND from opening the object; see contentTypedInfo.
+func (fi *cachedFileInfo) ContentType(_ context.Context) (string, error) {
+	if ct := mime.TypeByExtension(path.Ext(fi.name)); ct != "" {
+		return ct, nil
+	}
+	return "application/octet-stream", nil
 }
 
 // ---------------------------------------------------------------------------
@@ -1137,14 +1674,43 @@ func (fi *cachedFileInfo) ETag(_ context.Context) (string, error) {
 type cachedBackend struct {
 	inner server_utils.OriginBackend
 	fs    webdav.FileSystem
+	cache *storageCache
+	layer *storageCacheFS
 }
 
-func newCachedBackend(inner server_utils.OriginBackend, fs webdav.FileSystem) *cachedBackend {
-	return &cachedBackend{inner: inner, fs: fs}
+func newCachedBackend(inner server_utils.OriginBackend, layer *storageCacheFS) *cachedBackend {
+	return &cachedBackend{inner: inner, fs: layer, cache: layer.cache, layer: layer}
 }
 
 func (b *cachedBackend) CheckAvailability() error      { return b.inner.CheckAvailability() }
 func (b *cachedBackend) FileSystem() webdav.FileSystem { return b.fs }
+
 func (b *cachedBackend) Checksummer() server_utils.OriginChecksummer {
-	return b.inner.Checksummer()
+	inner := b.inner.Checksummer()
+	if inner == nil {
+		return nil
+	}
+	return &cachedChecksummer{inner: inner, layer: b.layer}
+}
+
+// cachedChecksummer suppresses the Digest header for objects being served from
+// the cache.
+//
+// The backend computes digests from the object as it exists upstream right
+// now, but a fresh cache entry is served from the copy taken when it was
+// fetched.  If the object changed out-of-band in the meantime the two
+// disagree, and a client that checks the digest against the body it received
+// sees corruption rather than staleness.  Reporting no digest is honest: the
+// origin cannot vouch for one without reading the object it is not reading.
+type cachedChecksummer struct {
+	inner server_utils.OriginChecksummer
+	layer *storageCacheFS
+}
+
+func (c *cachedChecksummer) GetDigests(relativePath string, wantDigest string) ([]string, error) {
+	metaRel, _, _ := c.layer.entryPaths(relativePath)
+	if meta := c.layer.cache.readMeta(metaRel); meta != nil && c.layer.cache.isFresh(meta) {
+		return nil, nil
+	}
+	return c.inner.GetDigests(relativePath, wantDigest)
 }

--- a/origin_serve/storage_cache_fs_test.go
+++ b/origin_serve/storage_cache_fs_test.go
@@ -25,6 +25,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"mime"
 	"os"
 	"path"
 	"strings"
@@ -36,6 +37,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/webdav"
+
+	"github.com/pelicanplatform/pelican/cache_control"
+	"github.com/pelicanplatform/pelican/server_utils"
 )
 
 // ---------------------------------------------------------------------------
@@ -71,6 +75,9 @@ type fakeUpstream struct {
 	failListing bool
 	// failWriteClose simulates an upload that fails at commit time.
 	failWriteClose bool
+	// infoStyle selects which real backend's FileInfo shape Stat/Readdir
+	// return, since upstreamValidator treats the three differently.
+	infoStyle infoStyle
 }
 
 func newFakeUpstream() *fakeUpstream {
@@ -105,6 +112,9 @@ func (u *fakeUpstream) stats(name string) int {
 	return u.statCount[name]
 }
 
+// fakeUpstreamInfo models a blob (s3v2) backend's FileInfo: the ETag is
+// reachable only through Sys(), never exposed to clients as a webdav.ETager.
+// See etagerUpstreamInfo for the httpsv2 shape.
 type fakeUpstreamInfo struct {
 	name         string
 	size         int64
@@ -112,6 +122,51 @@ type fakeUpstreamInfo struct {
 	etag         string
 	cacheControl string
 	isDir        bool
+}
+
+// etagerUpstreamInfo models the HTTPS (httpsv2) backend's FileInfo, which does
+// implement webdav.ETager and therefore shows its ETag to clients.  The two
+// shapes take different branches of upstreamValidator, and the cache is
+// required to reproduce whichever ETag the backend itself would have served.
+type etagerUpstreamInfo struct {
+	*fakeUpstreamInfo
+}
+
+func (fi etagerUpstreamInfo) ETag(_ context.Context) (string, error) {
+	if fi.etag != "" {
+		return fi.etag, nil
+	}
+	return "", webdav.ErrNotImplemented
+}
+
+// gowebdavUpstreamInfo models gowebdav's FileInfo, used by the HTTPS and
+// Globus backends in WebDAV mode: it carries an ETag through a context-free
+// method of its own and returns nil from Sys().
+type gowebdavUpstreamInfo struct {
+	*fakeUpstreamInfo
+}
+
+func (fi gowebdavUpstreamInfo) ETag() string     { return fi.etag }
+func (fi gowebdavUpstreamInfo) Sys() interface{} { return nil }
+
+// infoStyle selects which backend's FileInfo shape the fake presents.
+type infoStyle int
+
+const (
+	infoStyleBlob     infoStyle = iota // s3v2: ETag via Sys() only
+	infoStyleETager                    // httpsv2: ETag via webdav.ETager
+	infoStyleGoWebdav                  // WebDAV mode: ETag via ETag() string
+)
+
+func (u *fakeUpstream) wrapInfo(fi *fakeUpstreamInfo) os.FileInfo {
+	switch u.infoStyle {
+	case infoStyleETager:
+		return etagerUpstreamInfo{fi}
+	case infoStyleGoWebdav:
+		return gowebdavUpstreamInfo{fi}
+	default:
+		return fi
+	}
 }
 
 func (fi *fakeUpstreamInfo) Name() string { return fi.name }
@@ -193,7 +248,7 @@ func (f *fakeUpstreamFile) Readdir(_ int) ([]os.FileInfo, error) {
 	return nil, fmt.Errorf("not a directory")
 }
 func (f *fakeUpstreamFile) Stat() (os.FileInfo, error) {
-	return &fakeUpstreamInfo{name: path.Base(f.name), size: int64(len(f.obj.content)), modTime: f.obj.modTime, etag: f.obj.etag, cacheControl: f.obj.cacheControl}, nil
+	return f.upstream.wrapInfo(&fakeUpstreamInfo{name: path.Base(f.name), size: int64(len(f.obj.content)), modTime: f.obj.modTime, etag: f.obj.etag, cacheControl: f.obj.cacheControl}), nil
 }
 
 // fakeWriteFile buffers writes and commits them to the upstream on Close.
@@ -259,7 +314,7 @@ func (u *fakeUpstream) Stat(_ context.Context, name string) (os.FileInfo, error)
 	defer u.mu.Unlock()
 	u.statCount[name]++
 	if obj, ok := u.objects[name]; ok {
-		return &fakeUpstreamInfo{name: path.Base(name), size: int64(len(obj.content)), modTime: obj.modTime, etag: obj.etag, cacheControl: obj.cacheControl}, nil
+		return u.wrapInfo(&fakeUpstreamInfo{name: path.Base(name), size: int64(len(obj.content)), modTime: obj.modTime, etag: obj.etag, cacheControl: obj.cacheControl}), nil
 	}
 	// Directory-style: the path is a prefix of stored keys.
 	if u.hasChildrenLocked(name) {
@@ -306,7 +361,7 @@ func (u *fakeUpstream) OpenFile(_ context.Context, name string, flag int, _ os.F
 					entries = append(entries, &fakeUpstreamInfo{name: d, isDir: true})
 				}
 			} else {
-				entries = append(entries, &fakeUpstreamInfo{name: rest, size: int64(len(obj.content)), modTime: obj.modTime, etag: obj.etag, cacheControl: obj.cacheControl})
+				entries = append(entries, u.wrapInfo(&fakeUpstreamInfo{name: rest, size: int64(len(obj.content)), modTime: obj.modTime, etag: obj.etag, cacheControl: obj.cacheControl}))
 			}
 		}
 		return &fakeDirFile{name: name, entries: entries, failRead: u.failListing}, nil
@@ -356,18 +411,59 @@ func (f *fakeDirFile) Stat() (os.FileInfo, error) {
 // helpers
 // ---------------------------------------------------------------------------
 
+// newStorageCacheWithFs builds a cache over an arbitrary afero filesystem and
+// does not start the janitor.  Production code goes through newStorageCache,
+// which owns the real directory, its permission checks, and the janitor.
+func newStorageCacheWithFs(ctx context.Context, fs afero.Fs, maxSize int64, defaultMaxAge time.Duration, revalidationJitter int) *storageCache {
+	return &storageCache{
+		fs:      fs,
+		ctx:     ctx,
+		maxSize: maxSize,
+		policy: cache_control.Policy{
+			DefaultMaxAge: defaultMaxAge,
+			JitterPercent: revalidationJitter,
+			MaxFreshness:  defaultMaxAge,
+		},
+		fetchSem: make(chan struct{}, testCacheFetchConcurrency),
+		fetches:  make(map[string]*cacheFetch),
+	}
+}
+
+// testCacheFetchConcurrency is generous enough that the fetch pool never
+// becomes an incidental variable; the tests that care about saturation build
+// their own cache with a smaller pool.
+const testCacheFetchConcurrency = 16
+
 // newTestCacheLayer builds a cache layer with a 24h default freshness and no
 // jitter, so freshness behavior in tests is deterministic: entries fetched
 // during the test are always fresh unless the object's Cache-Control (or a
 // hand-edited sidecar timestamp) says otherwise.
 func newTestCacheLayer(t *testing.T, upstream webdav.FileSystem, maxSize int64) (*storageCache, *storageCacheFS, afero.Fs) {
 	t.Helper()
+	cache, layer, fs, _ := newTestCacheLayerWithPolicy(t, upstream, maxSize, 24*time.Hour, 0)
+	return cache, layer, fs
+}
+
+// newTestCacheLayerWithPolicy is newTestCacheLayer with an explicit freshness
+// policy, and also returns the cancel func so a test can shut the cache down
+// mid-flight.
+func newTestCacheLayerWithPolicy(t *testing.T, upstream webdav.FileSystem, maxSize int64, defaultMaxAge time.Duration, jitter int) (*storageCache, *storageCacheFS, afero.Fs, context.CancelFunc) {
+	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	memFs := afero.NewMemMapFs()
-	cache := newStorageCacheWithFs(ctx, memFs, maxSize, 24*time.Hour, 0)
-	layer := cache.newLayer("/test", upstream)
-	return cache, layer, memFs
+	cache := newStorageCacheWithFs(ctx, memFs, maxSize, defaultMaxAge, jitter)
+	layer := cache.newLayer("/test", "test-backend", upstream)
+	return cache, layer, memFs, cancel
+}
+
+// lookupFetch returns the in-flight fetch for an entry without registering a
+// reader on it.  Tests use it to observe fetch state; production code always
+// goes through attachFetch, which takes a reference atomically.
+func (c *storageCache) lookupFetch(metaRel string) *cacheFetch {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.fetches[metaRel]
 }
 
 // rewriteMetaLastValidated backdates a completed entry's validation time so
@@ -413,6 +509,46 @@ func countDataFiles(t *testing.T, fs afero.Fs) int {
 	return count
 }
 
+// filesWithSuffix lists every file in the cache tree whose name ends in
+// suffix, so tests can assert on (the absence of) temporary files.
+func filesWithSuffix(t *testing.T, fs afero.Fs, suffix string) []string {
+	t.Helper()
+	var found []string
+	require.NoError(t, afero.Walk(fs, ".", func(p string, info os.FileInfo, err error) error {
+		if err == nil && info != nil && !info.IsDir() && strings.HasSuffix(p, suffix) {
+			found = append(found, p)
+		}
+		return nil
+	}))
+	return found
+}
+
+// fetchStarted reports whether a fetch's copy goroutine has been launched,
+// read under the lock that guards the field (never by touching it directly,
+// which would race the fetch itself).
+func fetchStarted(cache *storageCache, f *cacheFetch) bool {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	return f.started
+}
+
+// fetchWritten reports how many bytes the shared copy has committed to disk.
+func fetchWritten(f *cacheFetch) int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.written
+}
+
+// newTestCacheOverFs builds a layer over a caller-supplied cache filesystem,
+// for the tests that need the cache's own storage to misbehave.
+func newTestCacheOverFs(t *testing.T, fs afero.Fs, upstream webdav.FileSystem) (*storageCache, *storageCacheFS) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	cache := newStorageCacheWithFs(ctx, fs, 0, 24*time.Hour, 0)
+	return cache, cache.newLayer("/test", "test-backend", upstream)
+}
+
 // ---------------------------------------------------------------------------
 // tests
 // ---------------------------------------------------------------------------
@@ -435,18 +571,117 @@ func TestStorageCacheMissThenHit(t *testing.T) {
 	require.Equal(t, 1, upstream.opens("/foo/bar.txt"), "second read should not open the upstream")
 	require.Equal(t, 1, upstream.stats("/foo/bar.txt"), "fresh entry should be served without revalidation")
 
-	// The hit is served with the upstream's ETag and metadata preserved.
+	// The hit preserves the upstream's metadata.
 	f, err := layer.OpenFile(context.Background(), "/foo/bar.txt", os.O_RDONLY, 0)
 	require.NoError(t, err)
 	defer f.Close()
 	info, err := f.Stat()
 	require.NoError(t, err)
 	assert.Equal(t, int64(len("hello world")), info.Size())
-	etager, ok := info.(webdav.ETager)
-	require.True(t, ok)
-	etag, err := etager.ETag(context.Background())
+}
+
+// The ETag a client sees must not depend on whether the object happened to be
+// cached.  A backend that exposes its ETag to clients (httpsv2, via
+// webdav.ETager) has it reproduced from the cache; one that keeps it internal
+// (s3v2, where it reaches this layer only through Sys()) must keep looking the
+// same through the cache, letting the webdav handler derive its usual
+// size/mtime ETag rather than suddenly revealing the provider's.
+func TestStorageCacheETagMatchesBackendShape(t *testing.T) {
+	// clientETag reports the ETag a webdav handler would send for info, and
+	// whether the FileInfo supplied one at all.
+	clientETag := func(t *testing.T, info os.FileInfo) (string, bool) {
+		t.Helper()
+		et, ok := info.(webdav.ETager)
+		if !ok {
+			return "", false
+		}
+		v, err := et.ETag(context.Background())
+		if err == webdav.ErrNotImplemented {
+			return "", false
+		}
+		require.NoError(t, err)
+		return v, true
+	}
+
+	for _, tc := range []struct {
+		name        string
+		style       infoStyle
+		wantVisible bool
+	}{
+		{"blob backend keeps its ETag internal", infoStyleBlob, false},
+		{"https backend exposes its ETag", infoStyleETager, true},
+		{"webdav-mode backend keeps its ETag internal", infoStyleGoWebdav, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream := newFakeUpstream()
+			upstream.infoStyle = tc.style
+			upstream.put("/obj", "payload", `"etag-1"`)
+			_, layer, _ := newTestCacheLayer(t, upstream, 0)
+
+			// What the backend itself would have served.
+			backendInfo, err := upstream.Stat(context.Background(), "/obj")
+			require.NoError(t, err)
+			backendETag, backendHas := clientETag(t, backendInfo)
+
+			require.Equal(t, "payload", readAllViaLayer(t, layer, "/obj"))
+
+			cachedInfo, err := layer.Stat(context.Background(), "/obj")
+			require.NoError(t, err)
+			cachedETag, cachedHas := clientETag(t, cachedInfo)
+
+			assert.Equal(t, tc.wantVisible, backendHas, "test's model of the backend")
+			assert.Equal(t, backendHas, cachedHas, "cache changed whether an ETag is exposed")
+			assert.Equal(t, backendETag, cachedETag, "cache changed the ETag value")
+		})
+	}
+}
+
+// A pure range read takes the backend-bypass path and never starts the shared
+// copy, so nothing else will ever clean up its registration.  It must release
+// its fetch-pool slot and the empty data file it reserved on close; otherwise
+// enough range-only reads permanently exhaust the pool and every later miss
+// falls through to the backend uncached.
+func TestStorageCacheRangeReadDoesNotLeakSlot(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/obj", strings.Repeat("z", 4096), `"etag-1"`)
+	cache, layer, memFs := newTestCacheLayer(t, upstream, 0)
+
+	f, err := layer.OpenFile(context.Background(), "/obj", os.O_RDONLY, 0)
 	require.NoError(t, err)
-	assert.Equal(t, `"etag-1"`, etag)
+	_, err = f.Seek(1000, io.SeekStart)
+	require.NoError(t, err)
+	buf := make([]byte, 200)
+	_, err = io.ReadFull(f, buf)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	metaRel, _, _ := layer.entryPaths("/obj")
+	assert.Nil(t, cache.lookupFetch(metaRel), "fetch left registered")
+	assert.Equal(t, 0, len(cache.fetchSem), "fetch pool slot leaked")
+	assert.Equal(t, 0, countDataFiles(t, memFs), "empty data file left behind")
+}
+
+// A weak ETag says the backend considers two different payloads equivalent,
+// which is exactly the comparison a cache must not make.  Such a validator is
+// rejected: the entry falls back to a size/mtime validator, so a same-size
+// rewrite that keeps the weak tag is still noticed via the modification time.
+func TestStorageCacheRejectsWeakETag(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.infoStyle = infoStyleETager
+	upstream.putCC("/obj", "version one", `W/"weak"`, "max-age=0")
+	cache, layer, _ := newTestCacheLayer(t, upstream, 0)
+
+	require.Equal(t, "version one", readAllViaLayer(t, layer, "/obj"))
+
+	metaRel, _, _ := layer.entryPaths("/obj")
+	meta := cache.readMeta(metaRel)
+	require.NotNil(t, meta)
+	assert.NotEqual(t, `W/"weak"`, meta.Validator, "weak ETag used as a validator")
+	assert.Empty(t, meta.ETag, "weak ETag re-served to clients")
+
+	// The same weak tag on different content must not read as unchanged.
+	upstream.putCC("/obj", "version two!", `W/"weak"`, "max-age=0")
+	assert.Equal(t, "version two!", readAllViaLayer(t, layer, "/obj"))
 }
 
 // When a stale entry's upstream object changed (new ETag), the cached copy is
@@ -1066,4 +1301,902 @@ func TestStorageCacheNotFound(t *testing.T) {
 	_, layer, _ := newTestCacheLayer(t, upstream, 0)
 	_, err := layer.OpenFile(context.Background(), "/missing", os.O_RDONLY, 0)
 	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+// net/http's ServeContent reads the first sniff-length bytes of a file purely
+// to guess a Content-Type — even for a HEAD request — and then rewinds.  The
+// layer must recognize that pattern and retire the copy instead of finishing
+// it: otherwise a HEAD on a multi-gigabyte object would pull the whole thing
+// out of the provider, which is exactly the egress this layer exists to avoid.
+func TestStorageCacheSniffDoesNotFetchWholeObject(t *testing.T) {
+	content := strings.Repeat("s", 4096)
+	upstream := newFakeUpstream()
+	upstream.put("/sniffed", content, `"e-1"`)
+	upstream.put("/fully-read", content, `"e-2"`)
+	gate := make(chan int)
+	upstream.objects["/sniffed"].gate = gate
+
+	cache, layer, memFs := newTestCacheLayer(t, upstream, 0)
+
+	f, err := layer.OpenFile(context.Background(), "/sniffed", os.O_RDONLY, 0)
+	require.NoError(t, err)
+
+	// The ServeContent sniff: read exactly sniffLen bytes, then seek back.
+	go func() { gate <- storageCacheSniffLen }()
+	buf := make([]byte, storageCacheSniffLen)
+	_, err = io.ReadFull(f, buf)
+	require.NoError(t, err)
+	require.Equal(t, content[:storageCacheSniffLen], string(buf))
+
+	metaRel, _, _ := layer.entryPaths("/sniffed")
+	fetch := cache.lookupFetch(metaRel)
+	require.NotNil(t, fetch)
+
+	_, err = f.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Closing the sniffing handle retires the fetch immediately.
+	assert.Nil(t, cache.lookupFetch(metaRel), "a sniff should retire the fetch")
+
+	// Let the retired copy unwind (the fake backend does not honour the
+	// cancelled context) and confirm it installs nothing.
+	close(gate)
+	require.NoError(t, waitFetchDone(fetch))
+	assert.Nil(t, cache.readMeta(metaRel), "a sniff must not install a cache entry")
+	assert.Equal(t, 0, countDataFiles(t, memFs), "a sniff must leave no data file behind")
+
+	// Contrast: a real read of the whole object does install an entry, which
+	// then serves subsequent reads.
+	require.Equal(t, content, readAllViaLayer(t, layer, "/fully-read"))
+	fullMeta, _, _ := layer.entryPaths("/fully-read")
+	assert.NotNil(t, cache.readMeta(fullMeta), "a full read should install a cache entry")
+	assert.Equal(t, 1, countDataFiles(t, memFs))
+	require.Equal(t, content, readAllViaLayer(t, layer, "/fully-read"))
+	assert.Equal(t, 1, upstream.opens("/fully-read"), "the second full read should be a cache hit")
+}
+
+// The sniff carve-out must not swallow real transfers: a client that reads
+// some bytes and goes away without rewinding is a partial download, not a
+// content-type probe, so its copy still runs to completion and lands in the
+// cache.  (Regression guard for the client-disconnect behaviour: the retire
+// rule keys on "read only the prefix *and* ended back at zero".)
+func TestStorageCachePartialReadWithoutRewindFinishesCopy(t *testing.T) {
+	content := strings.Repeat("p", 4096)
+	upstream := newFakeUpstream()
+	upstream.put("/partial", content, `"e-1"`)
+	gate := make(chan int)
+	upstream.objects["/partial"].gate = gate
+
+	cache, layer, memFs := newTestCacheLayer(t, upstream, 0)
+
+	f, err := layer.OpenFile(context.Background(), "/partial", os.O_RDONLY, 0)
+	require.NoError(t, err)
+
+	go func() { gate <- 100 }()
+	buf := make([]byte, 100)
+	_, err = io.ReadFull(f, buf)
+	require.NoError(t, err)
+	require.Equal(t, content[:100], string(buf))
+
+	metaRel, _, _ := layer.entryPaths("/partial")
+	fetch := cache.lookupFetch(metaRel)
+	require.NotNil(t, fetch)
+
+	// No rewind: just close, as a disconnecting client would.
+	require.NoError(t, f.Close())
+	assert.NotNil(t, cache.lookupFetch(metaRel), "a partial download must not retire the copy")
+
+	close(gate)
+	require.NoError(t, waitFetchDone(fetch))
+
+	meta := cache.readMeta(metaRel)
+	require.NotNil(t, meta, "the abandoned copy should still install an entry")
+	assert.Equal(t, int64(len(content)), meta.Size)
+	assert.Equal(t, 1, countDataFiles(t, memFs))
+
+	// The completed copy now serves hits without touching the backend again.
+	require.Equal(t, content, readAllViaLayer(t, layer, "/partial"))
+	assert.Equal(t, 1, upstream.opens("/partial"))
+}
+
+// A range request must not drag the whole object through the cache: a reader
+// positioned past what the shared copy has written goes straight to the
+// backend, and a ranged read on its own never starts a copy at all.  Waiting
+// for a sequential copy to reach the offset would turn a small ranged read
+// into a whole-object transfer.
+func TestStorageCacheRangeReadBypassesSharedCopy(t *testing.T) {
+	content := strings.Repeat("a", 500) + strings.Repeat("b", 1500)
+	upstream := newFakeUpstream()
+	upstream.put("/ranged", content, `"e-1"`)
+	cache, layer, memFs := newTestCacheLayer(t, upstream, 0)
+
+	f, err := layer.OpenFile(context.Background(), "/ranged", os.O_RDONLY, 0)
+	require.NoError(t, err)
+
+	// Nothing has been written by the copy (it has not even started), so this
+	// offset is necessarily past it — no gating needed to observe the state.
+	metaRel, _, _ := layer.entryPaths("/ranged")
+	fetch := cache.lookupFetch(metaRel)
+	require.NotNil(t, fetch)
+	require.False(t, fetchStarted(cache, fetch), "opening a file must not start a copy")
+
+	off, err := f.Seek(1000, io.SeekStart)
+	require.NoError(t, err)
+	require.Equal(t, int64(1000), off)
+	buf := make([]byte, 200)
+	_, err = io.ReadFull(f, buf)
+	require.NoError(t, err)
+
+	// The ranged read returns the right slice...
+	assert.Equal(t, content[1000:1200], string(buf))
+	// ...directly from the backend, without starting the shared copy.
+	assert.False(t, fetchStarted(cache, fetch), "a range request must not start a whole-object copy")
+	assert.Zero(t, fetchWritten(fetch), "no bytes should have been copied into the cache")
+	assert.Equal(t, 1, upstream.opens("/ranged"), "exactly one backend handle, for the range itself")
+	assert.Nil(t, cache.readMeta(metaRel), "a range request must not install an entry")
+
+	require.NoError(t, f.Close())
+	assert.Nil(t, cache.readMeta(metaRel), "closing a ranged reader must not install an entry")
+
+	// Seeking back and reading from the start is a sequential transfer again,
+	// and does populate the cache.
+	f2, err := layer.OpenFile(context.Background(), "/ranged", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	data, err := io.ReadAll(f2)
+	require.NoError(t, err)
+	require.NoError(t, f2.Close())
+	assert.Equal(t, content, string(data))
+	assert.NotNil(t, cache.readMeta(metaRel), "a sequential read should populate the cache")
+	assert.Equal(t, content, readAllViaLayer(t, layer, "/ranged"))
+	assert.GreaterOrEqual(t, countDataFiles(t, memFs), 1)
+}
+
+// The fetch pool bounds how many upstream-to-disk copies run at once.  A
+// request that cannot get a slot must be served straight from the backend
+// rather than queueing behind unrelated transfers: the cache is an
+// optimization, never a dependency.
+func TestStorageCacheFetchPoolSaturationFallsThrough(t *testing.T) {
+	slowContent := strings.Repeat("s", 1000)
+	upstream := newFakeUpstream()
+	upstream.put("/slow", slowContent, `"e-s"`)
+	upstream.put("/other", "other content", `"e-o"`)
+	gate := make(chan int)
+	upstream.objects["/slow"].gate = gate
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	memFs := afero.NewMemMapFs()
+	cache := newStorageCacheWithFs(ctx, memFs, 0, 24*time.Hour, 0)
+	cache.fetchSem = make(chan struct{}, 1) // room for exactly one copy
+	layer := cache.newLayer("/test", "test-backend", upstream)
+
+	f, err := layer.OpenFile(ctx, "/slow", os.O_RDONLY, 0)
+	require.NoError(t, err)
+
+	// Start the copy and leave it mid-flight, holding the only slot.
+	go func() { gate <- 10 }()
+	buf := make([]byte, 10)
+	_, err = io.ReadFull(f, buf)
+	require.NoError(t, err)
+
+	slowMeta, _, _ := layer.entryPaths("/slow")
+	fetch := cache.lookupFetch(slowMeta)
+	require.NotNil(t, fetch)
+	require.True(t, fetchStarted(cache, fetch))
+
+	// A different object cannot get a slot; it must still be served correctly.
+	require.Equal(t, "other content", readAllViaLayer(t, layer, "/other"))
+	assert.Equal(t, 1, upstream.opens("/other"))
+	otherMeta, _, _ := layer.entryPaths("/other")
+	assert.Nil(t, cache.readMeta(otherMeta), "a saturated-pool read must not install an entry")
+
+	// Let the held fetch finish and give its slot back.
+	close(gate)
+	rest, err := io.ReadAll(f)
+	require.NoError(t, err)
+	require.Equal(t, slowContent, string(buf)+string(rest))
+	require.NoError(t, f.Close())
+	require.NoError(t, waitFetchDone(fetch))
+
+	// Acquiring the semaphore blocks until the finished fetch releases its
+	// slot, so this waits for the pool to drain without polling.
+	cache.fetchSem <- struct{}{}
+	<-cache.fetchSem
+
+	// With a slot available the same object is cached normally: falling
+	// through is a transient degradation, not a permanent one.
+	require.Equal(t, "other content", readAllViaLayer(t, layer, "/other"))
+	assert.NotNil(t, cache.readMeta(otherMeta), "the pool freed up; the read should now be cached")
+}
+
+// createFailingFs allows everything except creating files, standing in for a
+// cache disk that has filled up mid-operation.  It exercises the layer's
+// "cannot create cache file" fallback rather than the "cannot create cache
+// directory" one a read-only filesystem hits first.
+type createFailingFs struct {
+	afero.Fs
+}
+
+func (fs createFailingFs) Create(_ string) (afero.File, error) {
+	return nil, fmt.Errorf("no space left on device")
+}
+
+func (fs createFailingFs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
+	if flag&os.O_CREATE != 0 {
+		return nil, fmt.Errorf("no space left on device")
+	}
+	return fs.Fs.OpenFile(name, flag, perm)
+}
+
+// A cache that cannot write must degrade throughput, not availability: every
+// read still returns the backend's bytes.  The repeated reads also guard the
+// fetch-pool bookkeeping — a failure path that forgot to return its slot would
+// wedge the layer after the pool's worth of failures.
+func TestStorageCacheUnwritableCacheFailsOpen(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		fs   func() afero.Fs
+	}{
+		{"read-only cache filesystem", func() afero.Fs { return afero.NewReadOnlyFs(afero.NewMemMapFs()) }},
+		{"cache disk full", func() afero.Fs { return createFailingFs{afero.NewMemMapFs()} }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream := newFakeUpstream()
+			upstream.put("/obj", "backend payload", `"e-1"`)
+			cache, layer := newTestCacheOverFs(t, tc.fs(), upstream)
+
+			// More reads than the fetch pool has slots: if a failure path
+			// leaked its slot the later reads would still succeed (they fall
+			// through), so also check the registry stays clean.
+			for i := 0; i < testCacheFetchConcurrency+4; i++ {
+				require.Equal(t, "backend payload", readAllViaLayer(t, layer, "/obj"))
+			}
+			assert.Equal(t, testCacheFetchConcurrency+4, upstream.opens("/obj"),
+				"every read should be served from the backend")
+
+			metaRel, _, _ := layer.entryPaths("/obj")
+			assert.Nil(t, cache.lookupFetch(metaRel), "a failed fetch must not stay registered")
+			assert.Nil(t, cache.readMeta(metaRel))
+
+			// The pool must be empty again; acquiring every slot proves it
+			// without polling (it would block otherwise).
+			for i := 0; i < testCacheFetchConcurrency; i++ {
+				cache.fetchSem <- struct{}{}
+			}
+			for i := 0; i < testCacheFetchConcurrency; i++ {
+				<-cache.fetchSem
+			}
+		})
+	}
+}
+
+// A data file with no sidecar is a leftover from a process that died
+// mid-fetch; nothing will ever reference it again, so it must be reclaimed
+// independently of the size bound (the default cache is unbounded and would
+// otherwise accumulate them forever).  Files that a live sidecar or a
+// registered fetch owns must survive.
+func TestStorageCachePruneOrphans(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/live", "live content", `"e-l"`)
+	upstream.put("/pending", "pending content", `"e-p"`)
+	cache, layer, memFs := newTestCacheLayer(t, upstream, 0)
+
+	// A completed entry: sidecar plus data file.
+	require.Equal(t, "live content", readAllViaLayer(t, layer, "/live"))
+	liveMeta, liveDir, _ := layer.entryPaths("/live")
+	meta := cache.readMeta(liveMeta)
+	require.NotNil(t, meta)
+	liveData := path.Join(liveDir, meta.DataFile)
+
+	// A stray data file in the layout the cache generates, with no sidecar.
+	orphanDir := path.Join(layer.scope, "objects", "aa")
+	orphan := path.Join(orphanDir, strings.Repeat("a", 64)+"-"+strings.Repeat("b", 16)+".data")
+	require.NoError(t, memFs.MkdirAll(orphanDir, 0700))
+	require.NoError(t, afero.WriteFile(memFs, orphan, []byte("leftover"), 0600))
+
+	// A sidecar temp file left behind by an interrupted rename, backdated so
+	// it is older than the (zero) grace period.
+	staleTmp := path.Join(orphanDir, strings.Repeat("a", 64)+".meta.0011223344556677.tmp")
+	require.NoError(t, afero.WriteFile(memFs, staleTmp, []byte("{}"), 0600))
+	old := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, memFs.Chtimes(staleTmp, old, old))
+
+	// A registered (not yet started) fetch owns its data file; the sweep must
+	// not race it away.
+	pendingHandle, err := layer.OpenFile(context.Background(), "/pending", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	pendingMeta, _, _ := layer.entryPaths("/pending")
+	pendingFetch := cache.lookupFetch(pendingMeta)
+	require.NotNil(t, pendingFetch)
+
+	cache.pruneOrphans(0)
+
+	exists, err := afero.Exists(memFs, orphan)
+	require.NoError(t, err)
+	assert.False(t, exists, "a data file with no sidecar should be reclaimed")
+	exists, err = afero.Exists(memFs, staleTmp)
+	require.NoError(t, err)
+	assert.False(t, exists, "an abandoned sidecar temp file should be reclaimed")
+	exists, err = afero.Exists(memFs, liveData)
+	require.NoError(t, err)
+	assert.True(t, exists, "a data file with a live sidecar must survive")
+	exists, err = afero.Exists(memFs, pendingFetch.dataRel)
+	require.NoError(t, err)
+	assert.True(t, exists, "an in-flight fetch's data file must survive")
+
+	require.NoError(t, pendingHandle.Close())
+
+	// The grace period protects recently created files even without a sidecar.
+	require.NoError(t, afero.WriteFile(memFs, orphan, []byte("leftover"), 0600))
+	freshTmp := path.Join(orphanDir, strings.Repeat("c", 64)+".meta.8899aabbccddeeff.tmp")
+	require.NoError(t, afero.WriteFile(memFs, freshTmp, []byte("{}"), 0600))
+	cache.pruneOrphans(time.Hour)
+	for _, p := range []string{orphan, freshTmp} {
+		exists, err = afero.Exists(memFs, p)
+		require.NoError(t, err)
+		assert.True(t, exists, "%s is inside the grace period and must survive", p)
+	}
+
+	// The cached entry still serves after the sweeps.
+	require.Equal(t, "live content", readAllViaLayer(t, layer, "/live"))
+	assert.Equal(t, 1, upstream.opens("/live"))
+}
+
+// A sidecar is read back from disk and its DataFile becomes a path component,
+// so it is validated rather than trusted: a corrupted (or hand-planted)
+// sidecar must read as a miss and be refetched, never as a licence to serve
+// bytes from somewhere else in the tree.
+func TestStorageCacheMalformedSidecarIsAMiss(t *testing.T) {
+	validData := strings.Repeat("c", 64) + "-" + strings.Repeat("d", 16) + ".data"
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"data file escapes the cache tree", `{"path":"/obj","size":5,"dataFile":"../../escape.data"}`},
+		{"data file is an absolute path", `{"path":"/obj","size":5,"dataFile":"/etc/passwd"}`},
+		{"data file does not match the layout", `{"path":"/obj","size":5,"dataFile":"whatever.data"}`},
+		{"negative size", fmt.Sprintf(`{"path":"/obj","size":-1,"dataFile":%q}`, validData)},
+		{"not json at all", `this is not json`},
+		{"empty data file", `{"path":"/obj","size":5}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream := newFakeUpstream()
+			upstream.put("/obj", "real content", `"e-1"`)
+			cache, layer, memFs := newTestCacheLayer(t, upstream, 0)
+
+			metaRel, hashDir, _ := layer.entryPaths("/obj")
+			require.NoError(t, memFs.MkdirAll(hashDir, 0700))
+			require.NoError(t, afero.WriteFile(memFs, metaRel, []byte(tc.body), 0600))
+
+			// Plant a file where a traversing sidecar would point, so serving
+			// it would be visible.
+			require.NoError(t, afero.WriteFile(memFs, "escape.data", []byte("planted"), 0600))
+
+			assert.Nil(t, cache.readMeta(metaRel), "a malformed sidecar must read as a miss")
+
+			// The read refetches from the backend rather than serving anything
+			// the sidecar named.
+			require.Equal(t, "real content", readAllViaLayer(t, layer, "/obj"))
+			assert.Equal(t, 1, upstream.opens("/obj"))
+
+			// ...and replaces the bad sidecar with a well-formed one.
+			meta := cache.readMeta(metaRel)
+			require.NotNil(t, meta)
+			assert.True(t, storageCacheDataFileRe.MatchString(meta.DataFile))
+
+			planted, err := afero.ReadFile(memFs, "escape.data")
+			require.NoError(t, err)
+			assert.Equal(t, "planted", string(planted), "the cache must not have written outside its layout")
+		})
+	}
+}
+
+// The sidecar is what marks a data file complete, so it is written through a
+// temporary file and a rename: a reader must never observe a half-written
+// sidecar, and a crash mid-update must not litter the tree with temp files
+// (which would otherwise be reclaimed only after the orphan grace period).
+func TestStorageCacheWriteMetaIsAtomic(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/obj", "content", `"e-1"`)
+	cache, layer, memFs := newTestCacheLayer(t, upstream, 0)
+
+	metaRel, hashDir, hash := layer.entryPaths("/obj")
+	require.NoError(t, memFs.MkdirAll(hashDir, 0700))
+
+	meta := &cacheEntryMeta{
+		Path:                  "/obj",
+		Validator:             `"e-1"`,
+		Size:                  7,
+		ModTimeUnixNano:       time.Now().UnixNano(),
+		LastValidatedUnixNano: time.Now().UnixNano(),
+		DataFile:              hash + "-" + strings.Repeat("0", 16) + ".data",
+	}
+	require.NoError(t, cache.writeMeta(metaRel, meta))
+
+	got := cache.readMeta(metaRel)
+	require.NotNil(t, got, "the sidecar must be readable immediately after the write")
+	assert.Equal(t, *meta, *got)
+	assert.Empty(t, filesWithSuffix(t, memFs, ".tmp"), "writeMeta left a temporary file behind")
+
+	// Overwriting an existing sidecar is equally clean.
+	meta.Size = 11
+	require.NoError(t, cache.writeMeta(metaRel, meta))
+	got = cache.readMeta(metaRel)
+	require.NotNil(t, got)
+	assert.Equal(t, int64(11), got.Size)
+	assert.Empty(t, filesWithSuffix(t, memFs, ".tmp"))
+
+	// And so is the write a completed fetch performs.
+	require.Equal(t, "content", readAllViaLayer(t, layer, "/obj"))
+	assert.NotNil(t, cache.readMeta(metaRel))
+	assert.Empty(t, filesWithSuffix(t, memFs, ".tmp"), "a completed fetch left a temporary file behind")
+}
+
+// Origin.StorageCacheDefaultMaxAge of zero means "revalidate on every read".
+// A backend must not be able to opt out of that with a long max-age of its
+// own: whoever can write an object's metadata would otherwise pin it in the
+// cache for as long as they liked.
+func TestStorageCacheZeroDefaultMaxAgeAlwaysRevalidates(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.putCC("/obj", "content", `"e-1"`, "max-age=3600")
+	_, layer, _, _ := newTestCacheLayerWithPolicy(t, upstream, 0, 0, 0)
+
+	require.Equal(t, "content", readAllViaLayer(t, layer, "/obj"))
+	require.Equal(t, 1, upstream.stats("/obj"))
+	require.Equal(t, 1, upstream.opens("/obj"))
+
+	require.Equal(t, "content", readAllViaLayer(t, layer, "/obj"))
+	assert.Equal(t, 2, upstream.stats("/obj"), "a zero default max-age must revalidate every read")
+	assert.Equal(t, 1, upstream.opens("/obj"), "an unchanged validator must not refetch the data")
+
+	// The metadata path honours it too.
+	_, err := layer.Stat(context.Background(), "/obj")
+	require.NoError(t, err)
+	assert.Equal(t, 3, upstream.stats("/obj"), "Stat must also revalidate")
+}
+
+// The configured default max-age doubles as a ceiling on the freshness a
+// backend may claim for itself, so an object whose metadata says "cache me for
+// ten years" is still revalidated once the operator's window lapses.
+func TestStorageCacheBackendMaxAgeCappedByDefault(t *testing.T) {
+	upstream := newFakeUpstream()
+	// max-age=87600h, i.e. ten years.
+	upstream.putCC("/obj", "content", `"e-1"`, "max-age=315360000")
+	cache, layer, _, _ := newTestCacheLayerWithPolicy(t, upstream, 0, time.Hour, 0)
+
+	require.Equal(t, "content", readAllViaLayer(t, layer, "/obj"))
+	require.Equal(t, 1, upstream.stats("/obj"))
+	metaRel, _, _ := layer.entryPaths("/obj")
+
+	// Well inside the configured hour: served with no upstream interaction.
+	rewriteMetaLastValidated(t, cache, metaRel, time.Now().Add(-30*time.Minute))
+	require.Equal(t, "content", readAllViaLayer(t, layer, "/obj"))
+	assert.Equal(t, 1, upstream.stats("/obj"), "within the cap the copy is still fresh")
+
+	// Past the configured hour, but far inside the backend's claim.
+	rewriteMetaLastValidated(t, cache, metaRel, time.Now().Add(-2*time.Hour))
+	require.Equal(t, "content", readAllViaLayer(t, layer, "/obj"))
+	assert.Equal(t, 2, upstream.stats("/obj"), "the backend's max-age must be capped by the configured default")
+	assert.Equal(t, 1, upstream.opens("/obj"), "revalidation alone must not refetch the data")
+}
+
+// Freshness jitter is seeded per object, not merely per validation instant:
+// objects fetched together must not all expire at the same moment and send a
+// synchronized burst of revalidations at the backend.
+func TestStorageCacheFreshnessJitterIsPerObject(t *testing.T) {
+	lastValidated := time.Unix(1_700_000_000, 0)
+	const maxAge = time.Hour
+	const jitter = 50
+
+	a := cache_control.FreshnessFor(lastValidated, maxAge, jitter, "/exports/data/a.txt")
+	b := cache_control.FreshnessFor(lastValidated, maxAge, jitter, "/exports/data/b.txt")
+	assert.NotEqual(t, a, b, "objects validated together must not share a freshness window")
+	assert.Equal(t, a, cache_control.FreshnessFor(lastValidated, maxAge, jitter, "/exports/data/a.txt"),
+		"the same object must get the same window every time")
+
+	// Jitter only ever shortens the operator's window.
+	for _, v := range []time.Duration{a, b} {
+		assert.GreaterOrEqual(t, v, maxAge/2)
+		assert.LessOrEqual(t, v, maxAge)
+	}
+	assert.Equal(t, maxAge, cache_control.FreshnessFor(lastValidated, maxAge, 0, "/exports/data/a.txt"),
+		"no jitter must give the full window")
+}
+
+// Cache entries are scoped by federation prefix and by backend identity.  Two
+// exports that happen to serve the same object path must not read each other's
+// copies, and repointing an export at different storage must not serve entries
+// cached from the old one.
+func TestStorageCacheScopeIsolation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	memFs := afero.NewMemMapFs()
+	cache := newStorageCacheWithFs(ctx, memFs, 0, 24*time.Hour, 0)
+
+	upA := newFakeUpstream()
+	upA.put("/obj", "from export A", `"e-a"`)
+	upB := newFakeUpstream()
+	upB.put("/obj", "from export B", `"e-b"`)
+	upC := newFakeUpstream()
+	upC.put("/obj", "from other backend", `"e-c"`)
+
+	layerA := cache.newLayer("/exports/a", "backend-1", upA)
+	layerB := cache.newLayer("/exports/b", "backend-1", upB)
+	layerC := cache.newLayer("/exports/a", "backend-2", upC)
+
+	metaA, _, _ := layerA.entryPaths("/obj")
+	metaB, _, _ := layerB.entryPaths("/obj")
+	metaC, _, _ := layerC.entryPaths("/obj")
+	assert.NotEqual(t, metaA, metaB, "different federation prefixes must not share an entry")
+	assert.NotEqual(t, metaA, metaC, "different backends must not share an entry")
+
+	require.Equal(t, "from export A", readAllViaLayer(t, layerA, "/obj"))
+	assert.Nil(t, cache.readMeta(metaB), "populating one export must not populate another")
+	assert.Nil(t, cache.readMeta(metaC), "populating one backend must not populate another")
+
+	// Each layer goes to its own upstream, and each caches independently.
+	require.Equal(t, "from export B", readAllViaLayer(t, layerB, "/obj"))
+	require.Equal(t, "from other backend", readAllViaLayer(t, layerC, "/obj"))
+	assert.Equal(t, 1, upA.opens("/obj"))
+	assert.Equal(t, 1, upB.opens("/obj"))
+	assert.Equal(t, 1, upC.opens("/obj"))
+
+	require.Equal(t, "from export A", readAllViaLayer(t, layerA, "/obj"))
+	require.Equal(t, "from export B", readAllViaLayer(t, layerB, "/obj"))
+	require.Equal(t, "from other backend", readAllViaLayer(t, layerC, "/obj"))
+	assert.Equal(t, 1, upA.opens("/obj"), "each scope should serve its own cached copy")
+	assert.Equal(t, 1, upB.opens("/obj"))
+	assert.Equal(t, 1, upC.opens("/obj"))
+
+	// Invalidating one scope leaves the others alone.
+	require.NoError(t, layerA.RemoveAll(ctx, "/obj"))
+	assert.Nil(t, cache.readMeta(metaA))
+	assert.NotNil(t, cache.readMeta(metaB))
+	assert.NotNil(t, cache.readMeta(metaC))
+}
+
+// pathologicalMode selects the shape of a backend listing that a subtree walk
+// must not trust.
+type pathologicalMode int
+
+const (
+	// pathSelfRef: every directory reports a subdirectory of the same name,
+	// so a naive walk recurses forever.
+	pathSelfRef pathologicalMode = iota
+	// pathDotsOnly: listings contain only ".", ".." and an empty name, which
+	// a naive walk would follow back into the directory it is already in.
+	pathDotsOnly
+	// pathWide: one flat listing far larger than the enumeration cap.
+	pathWide
+)
+
+// pathologicalUpstream wraps the ordinary fake with a directory that lists
+// itself, or lists nothing but self-references, or lists more entries than the
+// enumeration cap allows.
+type pathologicalUpstream struct {
+	*fakeUpstream
+	dir  string
+	mode pathologicalMode
+}
+
+// isSyntheticDir reports whether name is the pathological directory or (in
+// self-referential mode) one of the endless "loop" descendants it claims.
+func (u *pathologicalUpstream) isSyntheticDir(name string) bool {
+	if name == u.dir {
+		return true
+	}
+	if u.mode != pathSelfRef {
+		return false
+	}
+	rest, ok := strings.CutPrefix(name, u.dir+"/")
+	if !ok {
+		return false
+	}
+	for _, seg := range strings.Split(rest, "/") {
+		if seg != "loop" {
+			return false
+		}
+	}
+	return true
+}
+
+func (u *pathologicalUpstream) Stat(ctx context.Context, name string) (os.FileInfo, error) {
+	if u.isSyntheticDir(name) {
+		u.mu.Lock()
+		u.statCount[name]++
+		u.mu.Unlock()
+		return &fakeUpstreamInfo{name: path.Base(name), isDir: true, modTime: time.Now()}, nil
+	}
+	return u.fakeUpstream.Stat(ctx, name)
+}
+
+func (u *pathologicalUpstream) OpenFile(ctx context.Context, name string, flag int, perm os.FileMode) (webdav.File, error) {
+	isWrite := flag&(os.O_WRONLY|os.O_RDWR|os.O_CREATE|os.O_TRUNC) != 0
+	if isWrite || !u.isSyntheticDir(name) {
+		return u.fakeUpstream.OpenFile(ctx, name, flag, perm)
+	}
+	if u.mode == pathWide {
+		return &wideDirFile{remaining: storageCacheEnumerationCap + 10}, nil
+	}
+	// Entries a walk must skip rather than recurse into.
+	entries := []os.FileInfo{
+		&fakeUpstreamInfo{name: ".", isDir: true},
+		&fakeUpstreamInfo{name: "..", isDir: true},
+		&fakeUpstreamInfo{name: "", isDir: true},
+	}
+	if u.mode == pathSelfRef {
+		entries = append(entries, &fakeUpstreamInfo{name: "loop", isDir: true})
+	}
+	return &fakeDirFile{name: name, entries: entries}, nil
+}
+
+// wideDirFile fabricates an arbitrarily long flat listing without
+// materializing it, so the enumeration cap can be exercised cheaply.
+type wideDirFile struct {
+	remaining int
+}
+
+func (f *wideDirFile) Readdir(count int) ([]os.FileInfo, error) {
+	if f.remaining <= 0 {
+		return nil, io.EOF
+	}
+	if count <= 0 || count > f.remaining {
+		count = f.remaining
+	}
+	entries := make([]os.FileInfo, 0, count)
+	for i := 0; i < count; i++ {
+		entries = append(entries, &fakeUpstreamInfo{name: fmt.Sprintf("f%d", f.remaining-i)})
+	}
+	f.remaining -= count
+	return entries, nil
+}
+
+func (f *wideDirFile) Close() error                       { return nil }
+func (f *wideDirFile) Read(_ []byte) (int, error)         { return 0, fmt.Errorf("is a directory") }
+func (f *wideDirFile) Write(_ []byte) (int, error)        { return 0, fmt.Errorf("is a directory") }
+func (f *wideDirFile) Seek(_ int64, _ int) (int64, error) { return 0, fmt.Errorf("is a directory") }
+func (f *wideDirFile) Stat() (os.FileInfo, error) {
+	return &fakeUpstreamInfo{name: "wide", isDir: true}, nil
+}
+
+// A subtree walk drives off a listing the backend controls, so it must be
+// bounded in both depth and breadth: a self-referential (or merely enormous)
+// prefix must not hang the mutation or exhaust memory.  When the walk gives
+// up, invalidation still has to be correct — it falls back to scanning the
+// cache's own sidecars, which is authoritative over what is cached.
+func TestStorageCacheEnumerationGuards(t *testing.T) {
+	t.Run("self-referential listing falls back to the sidecar scan", func(t *testing.T) {
+		base := newFakeUpstream()
+		base.put("/loop/obj", "cached content", `"e-1"`)
+		base.put("/elsewhere", "unrelated", `"e-2"`)
+		upstream := &pathologicalUpstream{fakeUpstream: base, dir: "/loop", mode: pathSelfRef}
+		cache, layer, memFs := newTestCacheLayer(t, upstream, 0)
+
+		require.Equal(t, "cached content", readAllViaLayer(t, layer, "/loop/obj"))
+		require.Equal(t, "unrelated", readAllViaLayer(t, layer, "/elsewhere"))
+
+		// The walk must bottom out rather than recurse without bound.
+		paths, ok := layer.enumerateSubtree(context.Background(), "/loop")
+		assert.False(t, ok, "an unbounded listing must not be reported as enumerated")
+		assert.Nil(t, paths)
+
+		// ...and the mutation still drops the cached descendant.
+		require.NoError(t, layer.RemoveAll(context.Background(), "/loop"))
+		metaRel, _, _ := layer.entryPaths("/loop/obj")
+		assert.Nil(t, cache.readMeta(metaRel), "the fallback scan should drop the entry")
+		assert.Equal(t, 1, countDataFiles(t, memFs), "only the unrelated entry should remain")
+
+		keepMeta, _, _ := layer.entryPaths("/elsewhere")
+		assert.NotNil(t, cache.readMeta(keepMeta), "an unrelated entry must survive")
+	})
+
+	t.Run("dot entries are not children", func(t *testing.T) {
+		base := newFakeUpstream()
+		base.put("/loop/obj", "cached content", `"e-1"`)
+		upstream := &pathologicalUpstream{fakeUpstream: base, dir: "/loop", mode: pathDotsOnly}
+		_, layer, _ := newTestCacheLayer(t, upstream, 0)
+
+		// "." / ".." / "" must be skipped, so the walk terminates and reports
+		// only the directory itself.
+		paths, ok := layer.enumerateSubtree(context.Background(), "/loop")
+		assert.True(t, ok, "a listing of only dot entries is enumerable")
+		assert.Equal(t, []string{"/loop"}, paths)
+	})
+
+	t.Run("listing beyond the enumeration cap falls back", func(t *testing.T) {
+		base := newFakeUpstream()
+		base.put("/wide/obj", "cached content", `"e-1"`)
+		upstream := &pathologicalUpstream{fakeUpstream: base, dir: "/wide", mode: pathWide}
+		cache, layer, _ := newTestCacheLayer(t, upstream, 0)
+
+		require.Equal(t, "cached content", readAllViaLayer(t, layer, "/wide/obj"))
+
+		paths, ok := layer.enumerateSubtree(context.Background(), "/wide")
+		assert.False(t, ok, "a listing past the cap must not be reported as enumerated")
+		assert.Nil(t, paths)
+
+		require.NoError(t, layer.RemoveAll(context.Background(), "/wide"))
+		metaRel, _, _ := layer.entryPaths("/wide/obj")
+		assert.Nil(t, cache.readMeta(metaRel), "the fallback scan should drop the entry")
+	})
+}
+
+// The WebDAV PROPFIND handler asks a FileInfo for its content type and only
+// falls back to opening the file and sniffing its first bytes when the
+// FileInfo cannot say.  Through this layer that fallback would mean a backend
+// round trip (and an object fetch) for every file in a listing, so every
+// FileInfo this layer hands out must answer.  Wrapping must not otherwise
+// change what the backend would have reported — in particular the ETag.
+func TestStorageCacheStatCarriesContentType(t *testing.T) {
+	require.NotEmpty(t, mime.TypeByExtension(".txt"), "test assumes a known MIME type for .txt")
+
+	contentTypeOf := func(t *testing.T, info os.FileInfo) string {
+		t.Helper()
+		ct, ok := info.(webdav.ContentTyper)
+		require.True(t, ok, "FileInfo must implement webdav.ContentTyper so PROPFIND never opens the object")
+		got, err := ct.ContentType(context.Background())
+		require.NoError(t, err)
+		return got
+	}
+
+	t.Run("uncached stat answers without opening the object", func(t *testing.T) {
+		upstream := newFakeUpstream()
+		upstream.put("/dir/file.txt", "hello", `"e-1"`)
+		upstream.put("/dir/blob.pelican-unknown", "hello", `"e-2"`)
+		_, layer, _ := newTestCacheLayer(t, upstream, 0)
+
+		info, err := layer.Stat(context.Background(), "/dir/file.txt")
+		require.NoError(t, err)
+		assert.Equal(t, mime.TypeByExtension(".txt"), contentTypeOf(t, info))
+
+		info, err = layer.Stat(context.Background(), "/dir/blob.pelican-unknown")
+		require.NoError(t, err)
+		assert.Equal(t, "application/octet-stream", contentTypeOf(t, info),
+			"an unknown extension must still get a type")
+
+		assert.Equal(t, 0, upstream.opens("/dir/file.txt"), "answering a content type must not open the object")
+		assert.Equal(t, 0, upstream.opens("/dir/blob.pelican-unknown"))
+	})
+
+	t.Run("cached stat answers too", func(t *testing.T) {
+		upstream := newFakeUpstream()
+		upstream.put("/file.txt", "hello", `"e-1"`)
+		upstream.put("/blob.pelican-unknown", "hello", `"e-2"`)
+		_, layer, _ := newTestCacheLayer(t, upstream, 0)
+
+		require.Equal(t, "hello", readAllViaLayer(t, layer, "/file.txt"))
+		require.Equal(t, "hello", readAllViaLayer(t, layer, "/blob.pelican-unknown"))
+
+		info, err := layer.Stat(context.Background(), "/file.txt")
+		require.NoError(t, err)
+		assert.Equal(t, mime.TypeByExtension(".txt"), contentTypeOf(t, info))
+		info, err = layer.Stat(context.Background(), "/blob.pelican-unknown")
+		require.NoError(t, err)
+		assert.Equal(t, "application/octet-stream", contentTypeOf(t, info))
+	})
+
+	t.Run("listed entries answer too", func(t *testing.T) {
+		upstream := newFakeUpstream()
+		upstream.put("/dir/file.txt", "hello", `"e-1"`)
+		upstream.put("/dir/sub/nested.txt", "hello", `"e-2"`)
+		_, layer, _ := newTestCacheLayer(t, upstream, 0)
+
+		dir, err := layer.OpenFile(context.Background(), "/dir", os.O_RDONLY, 0)
+		require.NoError(t, err)
+		defer dir.Close()
+		entries, err := dir.Readdir(-1)
+		require.NoError(t, err)
+		require.Len(t, entries, 2)
+		for _, e := range entries {
+			if e.IsDir() {
+				continue // directories are never sniffed
+			}
+			assert.Equal(t, mime.TypeByExtension(".txt"), contentTypeOf(t, e))
+		}
+	})
+
+	t.Run("the wrapper preserves the backend's ETag", func(t *testing.T) {
+		for _, tc := range []struct {
+			name    string
+			style   infoStyle
+			wantTag string
+		}{
+			{"https backend exposes its ETag", infoStyleETager, `"e-1"`},
+			{"blob backend keeps its ETag internal", infoStyleBlob, ""},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				upstream := newFakeUpstream()
+				upstream.infoStyle = tc.style
+				upstream.put("/file.txt", "hello", `"e-1"`)
+				_, layer, _ := newTestCacheLayer(t, upstream, 0)
+
+				info, err := layer.Stat(context.Background(), "/file.txt")
+				require.NoError(t, err)
+				etager, ok := info.(webdav.ETager)
+				require.True(t, ok)
+				got, err := etager.ETag(context.Background())
+				if tc.wantTag == "" {
+					assert.ErrorIs(t, err, webdav.ErrNotImplemented,
+						"the wrapper must not invent an ETag the backend does not expose")
+					return
+				}
+				require.NoError(t, err)
+				assert.Equal(t, tc.wantTag, got)
+			})
+		}
+	})
+}
+
+// stubChecksummer stands in for a backend's digest support and counts how
+// often it is consulted.
+type stubChecksummer struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *stubChecksummer) GetDigests(relativePath string, wantDigest string) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	return []string{"md5=" + relativePath + ";" + wantDigest}, nil
+}
+
+func (s *stubChecksummer) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// stubBackend is a minimal OriginBackend for wiring tests.
+type stubBackend struct {
+	fs          webdav.FileSystem
+	checksummer server_utils.OriginChecksummer
+}
+
+func (b *stubBackend) CheckAvailability() error                    { return nil }
+func (b *stubBackend) FileSystem() webdav.FileSystem               { return b.fs }
+func (b *stubBackend) Checksummer() server_utils.OriginChecksummer { return b.checksummer }
+
+// A backend computes digests from the object as it exists upstream right now,
+// but a fresh cache entry is served from the copy taken when it was fetched.
+// If the object changed out-of-band the two disagree, and a client checking
+// the digest against the body it received would see corruption rather than
+// staleness — so no digest is reported while a fresh copy is being served.
+func TestStorageCacheDigestSuppressedOnFreshHit(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/obj", "digest me", `"e-1"`)
+	cache, layer, _ := newTestCacheLayer(t, upstream, 0)
+
+	inner := &stubChecksummer{}
+	summer := &cachedChecksummer{inner: inner, layer: layer}
+
+	// Nothing cached: the backend's digest describes what the client will get.
+	digests, err := summer.GetDigests("/obj", "md5")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"md5=/obj;md5"}, digests)
+	assert.Equal(t, 1, inner.callCount())
+
+	// Fresh cache entry: no digest at all.
+	require.Equal(t, "digest me", readAllViaLayer(t, layer, "/obj"))
+	digests, err = summer.GetDigests("/obj", "md5")
+	require.NoError(t, err)
+	assert.Nil(t, digests, "a fresh cache hit must not carry the backend's digest")
+	assert.Equal(t, 1, inner.callCount(), "the backend must not even be consulted")
+
+	// Stale entry: the next read revalidates against the backend, so the
+	// backend's digest applies again.
+	metaRel, _, _ := layer.entryPaths("/obj")
+	rewriteMetaLastValidated(t, cache, metaRel, time.Now().Add(-48*time.Hour))
+	digests, err = summer.GetDigests("/obj", "md5")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"md5=/obj;md5"}, digests)
+	assert.Equal(t, 2, inner.callCount())
+
+	// The wrapper is only installed when the backend has digest support.
+	assert.Nil(t, newCachedBackend(&stubBackend{fs: layer}, layer).Checksummer(),
+		"a backend without checksums must not gain one")
+	wrapped := newCachedBackend(&stubBackend{fs: layer, checksummer: inner}, layer).Checksummer()
+	require.NotNil(t, wrapped)
+	assert.IsType(t, &cachedChecksummer{}, wrapped)
 }

--- a/origin_serve/storage_cache_fs_test.go
+++ b/origin_serve/storage_cache_fs_test.go
@@ -636,6 +636,53 @@ func TestStorageCacheETagMatchesBackendShape(t *testing.T) {
 	}
 }
 
+// The cache directory must not be writable by other local users: anyone who
+// can write there can plant a sidecar and choose the bytes this origin serves.
+// A directory created under a permissive umask (or one that already existed
+// with loose permissions) is tightened rather than rejected, since the origin
+// owns it -- CI containers routinely run with umask 000, and refusing to start
+// would be a hard failure on something we can simply fix.
+func TestStorageCacheTightensDirectoryPermissions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	loc := path.Join(t.TempDir(), "cache")
+	require.NoError(t, os.MkdirAll(loc, 0777))
+	require.NoError(t, os.Chmod(loc, 0777)) // defeat the ambient umask
+	info, err := os.Stat(loc)
+	require.NoError(t, err)
+	require.NotZero(t, info.Mode().Perm()&0022, "test needs a world-writable directory to start from")
+
+	cache, err := newStorageCache(ctx, loc, 0, time.Hour, 0, 4)
+	require.NoError(t, err, "a loose cache directory should be tightened, not rejected")
+	require.NotNil(t, cache)
+
+	info, err = os.Stat(loc)
+	require.NoError(t, err)
+	assert.Zero(t, info.Mode().Perm()&0022, "directory should no longer be group- or world-writable")
+}
+
+// A cache location that is not a directory, or cannot be written, must fail at
+// startup rather than turning every later request into an error.
+func TestStorageCacheRejectsUnusableLocation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	notADir := path.Join(t.TempDir(), "file")
+	require.NoError(t, os.WriteFile(notADir, []byte("x"), 0600))
+	_, err := newStorageCache(ctx, notADir, 0, time.Hour, 0, 4)
+	require.Error(t, err)
+
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory write permissions")
+	}
+	readOnly := path.Join(t.TempDir(), "ro")
+	require.NoError(t, os.MkdirAll(readOnly, 0500))
+	t.Cleanup(func() { _ = os.Chmod(readOnly, 0700) })
+	_, err = newStorageCache(ctx, readOnly, 0, time.Hour, 0, 4)
+	require.Error(t, err, "an unwritable cache directory must fail at startup")
+}
+
 // A pure range read takes the backend-bypass path and never starts the shared
 // copy, so nothing else will ever clean up its registration.  It must release
 // its fetch-pool slot and the empty data file it reserved on close; otherwise
@@ -2029,7 +2076,11 @@ func TestStorageCacheEnumerationGuards(t *testing.T) {
 // FileInfo this layer hands out must answer.  Wrapping must not otherwise
 // change what the backend would have reported — in particular the ETag.
 func TestStorageCacheStatCarriesContentType(t *testing.T) {
-	require.NotEmpty(t, mime.TypeByExtension(".txt"), "test assumes a known MIME type for .txt")
+	// Register the extension this test relies on rather than trusting the
+	// host's MIME database: Go's builtin table does not cover .txt, so on a
+	// container without /etc/mime.types TypeByExtension(".txt") is empty.
+	const knownExt, knownType = ".pelican-known", "application/x-pelican-test"
+	require.NoError(t, mime.AddExtensionType(knownExt, knownType))
 
 	contentTypeOf := func(t *testing.T, info os.FileInfo) string {
 		t.Helper()
@@ -2042,35 +2093,35 @@ func TestStorageCacheStatCarriesContentType(t *testing.T) {
 
 	t.Run("uncached stat answers without opening the object", func(t *testing.T) {
 		upstream := newFakeUpstream()
-		upstream.put("/dir/file.txt", "hello", `"e-1"`)
+		upstream.put("/dir/file.pelican-known", "hello", `"e-1"`)
 		upstream.put("/dir/blob.pelican-unknown", "hello", `"e-2"`)
 		_, layer, _ := newTestCacheLayer(t, upstream, 0)
 
-		info, err := layer.Stat(context.Background(), "/dir/file.txt")
+		info, err := layer.Stat(context.Background(), "/dir/file.pelican-known")
 		require.NoError(t, err)
-		assert.Equal(t, mime.TypeByExtension(".txt"), contentTypeOf(t, info))
+		assert.Equal(t, knownType, contentTypeOf(t, info))
 
 		info, err = layer.Stat(context.Background(), "/dir/blob.pelican-unknown")
 		require.NoError(t, err)
 		assert.Equal(t, "application/octet-stream", contentTypeOf(t, info),
 			"an unknown extension must still get a type")
 
-		assert.Equal(t, 0, upstream.opens("/dir/file.txt"), "answering a content type must not open the object")
+		assert.Equal(t, 0, upstream.opens("/dir/file.pelican-known"), "answering a content type must not open the object")
 		assert.Equal(t, 0, upstream.opens("/dir/blob.pelican-unknown"))
 	})
 
 	t.Run("cached stat answers too", func(t *testing.T) {
 		upstream := newFakeUpstream()
-		upstream.put("/file.txt", "hello", `"e-1"`)
+		upstream.put("/file.pelican-known", "hello", `"e-1"`)
 		upstream.put("/blob.pelican-unknown", "hello", `"e-2"`)
 		_, layer, _ := newTestCacheLayer(t, upstream, 0)
 
-		require.Equal(t, "hello", readAllViaLayer(t, layer, "/file.txt"))
+		require.Equal(t, "hello", readAllViaLayer(t, layer, "/file.pelican-known"))
 		require.Equal(t, "hello", readAllViaLayer(t, layer, "/blob.pelican-unknown"))
 
-		info, err := layer.Stat(context.Background(), "/file.txt")
+		info, err := layer.Stat(context.Background(), "/file.pelican-known")
 		require.NoError(t, err)
-		assert.Equal(t, mime.TypeByExtension(".txt"), contentTypeOf(t, info))
+		assert.Equal(t, knownType, contentTypeOf(t, info))
 		info, err = layer.Stat(context.Background(), "/blob.pelican-unknown")
 		require.NoError(t, err)
 		assert.Equal(t, "application/octet-stream", contentTypeOf(t, info))
@@ -2078,8 +2129,8 @@ func TestStorageCacheStatCarriesContentType(t *testing.T) {
 
 	t.Run("listed entries answer too", func(t *testing.T) {
 		upstream := newFakeUpstream()
-		upstream.put("/dir/file.txt", "hello", `"e-1"`)
-		upstream.put("/dir/sub/nested.txt", "hello", `"e-2"`)
+		upstream.put("/dir/file.pelican-known", "hello", `"e-1"`)
+		upstream.put("/dir/sub/nested.pelican-known", "hello", `"e-2"`)
 		_, layer, _ := newTestCacheLayer(t, upstream, 0)
 
 		dir, err := layer.OpenFile(context.Background(), "/dir", os.O_RDONLY, 0)
@@ -2092,7 +2143,7 @@ func TestStorageCacheStatCarriesContentType(t *testing.T) {
 			if e.IsDir() {
 				continue // directories are never sniffed
 			}
-			assert.Equal(t, mime.TypeByExtension(".txt"), contentTypeOf(t, e))
+			assert.Equal(t, knownType, contentTypeOf(t, e))
 		}
 	})
 
@@ -2108,10 +2159,10 @@ func TestStorageCacheStatCarriesContentType(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				upstream := newFakeUpstream()
 				upstream.infoStyle = tc.style
-				upstream.put("/file.txt", "hello", `"e-1"`)
+				upstream.put("/file.pelican-known", "hello", `"e-1"`)
 				_, layer, _ := newTestCacheLayer(t, upstream, 0)
 
-				info, err := layer.Stat(context.Background(), "/file.txt")
+				info, err := layer.Stat(context.Background(), "/file.pelican-known")
 				require.NoError(t, err)
 				etager, ok := info.(webdav.ETager)
 				require.True(t, ok)

--- a/origin_serve/storage_cache_fs_test.go
+++ b/origin_serve/storage_cache_fs_test.go
@@ -1,0 +1,1069 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package origin_serve
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/webdav"
+)
+
+// ---------------------------------------------------------------------------
+// fake upstream — an instrumented webdav.FileSystem standing in for a remote
+// backend (S3/HTTPS).  Reads can be gated so tests control fetch progress
+// without timing assumptions.
+// ---------------------------------------------------------------------------
+
+type fakeObject struct {
+	content      []byte
+	etag         string
+	cacheControl string
+	modTime      time.Time
+
+	// When set, each Read must receive a byte allowance from the channel
+	// before returning data; closing the channel removes the gate.
+	gate chan int
+
+	// When failAfter >= 0, reads at or beyond that offset return the
+	// upstream's configured read error instead of data.
+	failAfter int
+}
+
+type fakeUpstream struct {
+	mu        sync.Mutex
+	objects   map[string]*fakeObject
+	statCount map[string]int
+	openCount map[string]int
+	readErr   map[string]error // fail reads at the given path after gate bytes
+
+	// failListing simulates a backend with no directory enumeration (e.g. a
+	// plain-HTTP upstream): Readdir on directories returns an error.
+	failListing bool
+	// failWriteClose simulates an upload that fails at commit time.
+	failWriteClose bool
+}
+
+func newFakeUpstream() *fakeUpstream {
+	return &fakeUpstream{
+		objects:   make(map[string]*fakeObject),
+		statCount: make(map[string]int),
+		openCount: make(map[string]int),
+		readErr:   make(map[string]error),
+	}
+}
+
+func (u *fakeUpstream) put(name, content, etag string) {
+	u.putCC(name, content, etag, "")
+}
+
+// putCC stores an object that advertises the given Cache-Control value.
+func (u *fakeUpstream) putCC(name, content, etag, cacheControl string) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.objects[name] = &fakeObject{content: []byte(content), etag: etag, cacheControl: cacheControl, modTime: time.Now(), failAfter: -1}
+}
+
+func (u *fakeUpstream) opens(name string) int {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.openCount[name]
+}
+
+func (u *fakeUpstream) stats(name string) int {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.statCount[name]
+}
+
+type fakeUpstreamInfo struct {
+	name         string
+	size         int64
+	modTime      time.Time
+	etag         string
+	cacheControl string
+	isDir        bool
+}
+
+func (fi *fakeUpstreamInfo) Name() string { return fi.name }
+func (fi *fakeUpstreamInfo) Size() int64  { return fi.size }
+func (fi *fakeUpstreamInfo) Mode() os.FileMode {
+	if fi.isDir {
+		return os.ModeDir | 0755
+	}
+	return 0644
+}
+func (fi *fakeUpstreamInfo) ModTime() time.Time { return fi.modTime }
+func (fi *fakeUpstreamInfo) IsDir() bool        { return fi.isDir }
+func (fi *fakeUpstreamInfo) Sys() interface{} {
+	if fi.etag != "" || fi.cacheControl != "" {
+		return &BlobFileSysInfo{ETag: fi.etag, CacheControl: fi.cacheControl}
+	}
+	return nil
+}
+
+type fakeUpstreamFile struct {
+	upstream *fakeUpstream
+	name     string
+	obj      *fakeObject
+	offset   int
+	pending  int // bytes granted by the gate but not yet consumed
+}
+
+func (f *fakeUpstreamFile) Read(p []byte) (int, error) {
+	if f.obj.failAfter >= 0 && f.offset >= f.obj.failAfter {
+		f.upstream.mu.Lock()
+		failErr := f.upstream.readErr[f.name]
+		f.upstream.mu.Unlock()
+		return 0, failErr
+	}
+	if f.offset >= len(f.obj.content) {
+		return 0, io.EOF
+	}
+	limit := len(p)
+	if f.obj.gate != nil {
+		for f.pending == 0 {
+			granted, ok := <-f.obj.gate
+			if !ok {
+				f.obj.gate = nil
+				f.pending = len(f.obj.content) // gate removed: no further limits
+				break
+			}
+			f.pending += granted
+		}
+		if limit > f.pending {
+			limit = f.pending
+		}
+	}
+	if f.obj.failAfter >= 0 && f.offset+limit > f.obj.failAfter {
+		limit = f.obj.failAfter - f.offset
+	}
+	n := copy(p[:limit], f.obj.content[f.offset:])
+	f.offset += n
+	f.pending -= n
+	return n, nil
+}
+
+func (f *fakeUpstreamFile) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekStart:
+		f.offset = int(offset)
+	case io.SeekCurrent:
+		f.offset += int(offset)
+	case io.SeekEnd:
+		f.offset = len(f.obj.content) + int(offset)
+	}
+	return int64(f.offset), nil
+}
+
+func (f *fakeUpstreamFile) Close() error { return nil }
+func (f *fakeUpstreamFile) Write(_ []byte) (int, error) {
+	return 0, fmt.Errorf("read-only fake")
+}
+func (f *fakeUpstreamFile) Readdir(_ int) ([]os.FileInfo, error) {
+	return nil, fmt.Errorf("not a directory")
+}
+func (f *fakeUpstreamFile) Stat() (os.FileInfo, error) {
+	return &fakeUpstreamInfo{name: path.Base(f.name), size: int64(len(f.obj.content)), modTime: f.obj.modTime, etag: f.obj.etag, cacheControl: f.obj.cacheControl}, nil
+}
+
+// fakeWriteFile buffers writes and commits them to the upstream on Close.
+type fakeWriteFile struct {
+	upstream *fakeUpstream
+	name     string
+	buf      bytes.Buffer
+}
+
+func (f *fakeWriteFile) Write(p []byte) (int, error) { return f.buf.Write(p) }
+func (f *fakeWriteFile) Close() error {
+	f.upstream.mu.Lock()
+	failClose := f.upstream.failWriteClose
+	f.upstream.mu.Unlock()
+	if failClose {
+		return fmt.Errorf("upload failed at commit")
+	}
+	f.upstream.put(f.name, f.buf.String(), fmt.Sprintf("%q", f.buf.String()))
+	return nil
+}
+func (f *fakeWriteFile) Read(_ []byte) (int, error)           { return 0, fmt.Errorf("write-only") }
+func (f *fakeWriteFile) Seek(_ int64, _ int) (int64, error)   { return 0, fmt.Errorf("write-only") }
+func (f *fakeWriteFile) Readdir(_ int) ([]os.FileInfo, error) { return nil, fmt.Errorf("not a dir") }
+func (f *fakeWriteFile) Stat() (os.FileInfo, error)           { return nil, fmt.Errorf("write-only") }
+
+func (u *fakeUpstream) Mkdir(_ context.Context, _ string, _ os.FileMode) error { return nil }
+
+// RemoveAll deletes the named object and, directory-style, everything
+// beneath it.
+func (u *fakeUpstream) RemoveAll(_ context.Context, name string) error {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	delete(u.objects, name)
+	prefix := name + "/"
+	for k := range u.objects {
+		if strings.HasPrefix(k, prefix) {
+			delete(u.objects, k)
+		}
+	}
+	return nil
+}
+
+// Rename moves the named object and any directory-style descendants.
+func (u *fakeUpstream) Rename(_ context.Context, oldName, newName string) error {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if obj, ok := u.objects[oldName]; ok {
+		u.objects[newName] = obj
+		delete(u.objects, oldName)
+	}
+	prefix := oldName + "/"
+	for k, obj := range u.objects {
+		if strings.HasPrefix(k, prefix) {
+			u.objects[newName+"/"+strings.TrimPrefix(k, prefix)] = obj
+			delete(u.objects, k)
+		}
+	}
+	return nil
+}
+
+func (u *fakeUpstream) Stat(_ context.Context, name string) (os.FileInfo, error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.statCount[name]++
+	if obj, ok := u.objects[name]; ok {
+		return &fakeUpstreamInfo{name: path.Base(name), size: int64(len(obj.content)), modTime: obj.modTime, etag: obj.etag, cacheControl: obj.cacheControl}, nil
+	}
+	// Directory-style: the path is a prefix of stored keys.
+	if u.hasChildrenLocked(name) {
+		return &fakeUpstreamInfo{name: path.Base(name), isDir: true, modTime: time.Now()}, nil
+	}
+	return nil, os.ErrNotExist
+}
+
+// hasChildrenLocked reports whether any object lives under name+"/".
+// Caller must hold u.mu.
+func (u *fakeUpstream) hasChildrenLocked(name string) bool {
+	prefix := name + "/"
+	for k := range u.objects {
+		if strings.HasPrefix(k, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func (u *fakeUpstream) OpenFile(_ context.Context, name string, flag int, _ os.FileMode) (webdav.File, error) {
+	if flag&(os.O_WRONLY|os.O_RDWR|os.O_CREATE|os.O_TRUNC) != 0 {
+		return &fakeWriteFile{upstream: u, name: name}, nil
+	}
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if obj, ok := u.objects[name]; ok {
+		u.openCount[name]++
+		return &fakeUpstreamFile{upstream: u, name: name, obj: obj}, nil
+	}
+	// Directory-style: build the immediate-children listing.
+	if u.hasChildrenLocked(name) {
+		prefix := name + "/"
+		seenDirs := make(map[string]bool)
+		var entries []os.FileInfo
+		for k, obj := range u.objects {
+			if !strings.HasPrefix(k, prefix) {
+				continue
+			}
+			rest := strings.TrimPrefix(k, prefix)
+			if i := strings.IndexByte(rest, '/'); i >= 0 {
+				if d := rest[:i]; !seenDirs[d] {
+					seenDirs[d] = true
+					entries = append(entries, &fakeUpstreamInfo{name: d, isDir: true})
+				}
+			} else {
+				entries = append(entries, &fakeUpstreamInfo{name: rest, size: int64(len(obj.content)), modTime: obj.modTime, etag: obj.etag, cacheControl: obj.cacheControl})
+			}
+		}
+		return &fakeDirFile{name: name, entries: entries, failRead: u.failListing}, nil
+	}
+	return nil, os.ErrNotExist
+}
+
+// fakeDirFile serves paginated directory listings (or fails, to exercise
+// the no-enumeration fallback).
+type fakeDirFile struct {
+	name     string
+	entries  []os.FileInfo
+	offset   int
+	failRead bool
+}
+
+func (f *fakeDirFile) Readdir(count int) ([]os.FileInfo, error) {
+	if f.failRead {
+		return nil, fmt.Errorf("listing not supported")
+	}
+	if f.offset >= len(f.entries) {
+		return nil, io.EOF
+	}
+	if count <= 0 {
+		r := f.entries[f.offset:]
+		f.offset = len(f.entries)
+		return r, nil
+	}
+	end := f.offset + count
+	if end > len(f.entries) {
+		end = len(f.entries)
+	}
+	r := f.entries[f.offset:end]
+	f.offset = end
+	return r, nil
+}
+
+func (f *fakeDirFile) Close() error                       { return nil }
+func (f *fakeDirFile) Read(_ []byte) (int, error)         { return 0, fmt.Errorf("is a directory") }
+func (f *fakeDirFile) Write(_ []byte) (int, error)        { return 0, fmt.Errorf("is a directory") }
+func (f *fakeDirFile) Seek(_ int64, _ int) (int64, error) { return 0, fmt.Errorf("is a directory") }
+func (f *fakeDirFile) Stat() (os.FileInfo, error) {
+	return &fakeUpstreamInfo{name: path.Base(f.name), isDir: true}, nil
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// newTestCacheLayer builds a cache layer with a 24h default freshness and no
+// jitter, so freshness behavior in tests is deterministic: entries fetched
+// during the test are always fresh unless the object's Cache-Control (or a
+// hand-edited sidecar timestamp) says otherwise.
+func newTestCacheLayer(t *testing.T, upstream webdav.FileSystem, maxSize int64) (*storageCache, *storageCacheFS, afero.Fs) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	memFs := afero.NewMemMapFs()
+	cache := newStorageCacheWithFs(ctx, memFs, maxSize, 24*time.Hour, 0)
+	layer := cache.newLayer("/test", upstream)
+	return cache, layer, memFs
+}
+
+// rewriteMetaLastValidated backdates a completed entry's validation time so
+// tests can force staleness without sleeping.
+func rewriteMetaLastValidated(t *testing.T, cache *storageCache, metaRel string, when time.Time) {
+	t.Helper()
+	meta := cache.readMeta(metaRel)
+	require.NotNil(t, meta)
+	meta.LastValidatedUnixNano = when.UnixNano()
+	require.NoError(t, cache.writeMeta(metaRel, meta))
+}
+
+func readAllViaLayer(t *testing.T, layer *storageCacheFS, name string) string {
+	t.Helper()
+	f, err := layer.OpenFile(context.Background(), name, os.O_RDONLY, 0)
+	require.NoError(t, err)
+	defer f.Close()
+	data, err := io.ReadAll(f)
+	require.NoError(t, err)
+	return string(data)
+}
+
+// waitFetchDone blocks (via the fetch's condition variable, no polling) until
+// the given fetch finishes, returning its terminal error.
+func waitFetchDone(f *cacheFetch) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for !f.done {
+		f.cond.Wait()
+	}
+	return f.err
+}
+
+func countDataFiles(t *testing.T, fs afero.Fs) int {
+	t.Helper()
+	count := 0
+	require.NoError(t, afero.Walk(fs, ".", func(p string, info os.FileInfo, err error) error {
+		if err == nil && info != nil && !info.IsDir() && strings.HasSuffix(p, ".data") {
+			count++
+		}
+		return nil
+	}))
+	return count
+}
+
+// ---------------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------------
+
+// A first read populates the cache from the upstream; a second read is served
+// locally, with the upstream consulted only for revalidation (Stat), never
+// for data (OpenFile).
+func TestStorageCacheMissThenHit(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/foo/bar.txt", "hello world", `"etag-1"`)
+	_, layer, _ := newTestCacheLayer(t, upstream, 0)
+
+	require.Equal(t, "hello world", readAllViaLayer(t, layer, "/foo/bar.txt"))
+	require.Equal(t, 1, upstream.opens("/foo/bar.txt"))
+
+	// Reading to EOF guarantees the fetch completed and the sidecar was
+	// written, so the second read must be a pure cache hit — and since the
+	// entry is still fresh, not even a metadata request goes upstream.
+	require.Equal(t, "hello world", readAllViaLayer(t, layer, "/foo/bar.txt"))
+	require.Equal(t, 1, upstream.opens("/foo/bar.txt"), "second read should not open the upstream")
+	require.Equal(t, 1, upstream.stats("/foo/bar.txt"), "fresh entry should be served without revalidation")
+
+	// The hit is served with the upstream's ETag and metadata preserved.
+	f, err := layer.OpenFile(context.Background(), "/foo/bar.txt", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	defer f.Close()
+	info, err := f.Stat()
+	require.NoError(t, err)
+	assert.Equal(t, int64(len("hello world")), info.Size())
+	etager, ok := info.(webdav.ETager)
+	require.True(t, ok)
+	etag, err := etager.ETag(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, `"etag-1"`, etag)
+}
+
+// When a stale entry's upstream object changed (new ETag), the cached copy is
+// discarded and refetched; the superseded data file is cleaned up.  Objects
+// advertising max-age=0 are stale on every read, so each read revalidates.
+func TestStorageCacheRevalidation(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.putCC("/obj", "version one", `"etag-1"`, "max-age=0")
+	_, layer, memFs := newTestCacheLayer(t, upstream, 0)
+
+	require.Equal(t, "version one", readAllViaLayer(t, layer, "/obj"))
+	upstream.putCC("/obj", "version two!", `"etag-2"`, "max-age=0")
+
+	require.Equal(t, "version two!", readAllViaLayer(t, layer, "/obj"))
+	require.Equal(t, 2, upstream.opens("/obj"))
+	assert.Equal(t, 1, countDataFiles(t, memFs), "superseded data file should be removed")
+
+	// And with the same ETag again: revalidation (a stat) but no refetch.
+	require.Equal(t, "version two!", readAllViaLayer(t, layer, "/obj"))
+	require.Equal(t, 2, upstream.opens("/obj"))
+	require.Equal(t, 3, upstream.stats("/obj"), "max-age=0 must revalidate on every read")
+}
+
+// Opening a file and probing metadata (Stat, Seek-to-end) must not trigger a
+// data fetch from the upstream: HEAD requests stay egress-free.
+func TestStorageCacheLazyFetch(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/obj", "some content", `"etag-1"`)
+	cache, layer, memFs := newTestCacheLayer(t, upstream, 0)
+
+	f, err := layer.OpenFile(context.Background(), "/obj", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	info, err := f.Stat()
+	require.NoError(t, err)
+	assert.Equal(t, int64(len("some content")), info.Size())
+	size, err := f.Seek(0, io.SeekEnd)
+	require.NoError(t, err)
+	assert.Equal(t, int64(len("some content")), size)
+	require.NoError(t, f.Close())
+
+	assert.Equal(t, 0, upstream.opens("/obj"), "metadata-only access should not fetch data")
+
+	// Closing the never-read handle discards the pending fetch entirely: no
+	// registry entry and no leftover data file.
+	metaRel, _, _ := layer.entryPaths("/obj")
+	assert.Nil(t, cache.lookupFetch(metaRel))
+	assert.Equal(t, 0, countDataFiles(t, memFs))
+}
+
+// Two concurrent readers of the same object share one upstream fetch.
+func TestStorageCacheCoalescing(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/obj", "shared content", `"etag-1"`)
+	_, layer, _ := newTestCacheLayer(t, upstream, 0)
+
+	fA, err := layer.OpenFile(context.Background(), "/obj", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	defer fA.Close()
+	fB, err := layer.OpenFile(context.Background(), "/obj", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	defer fB.Close()
+
+	var wg sync.WaitGroup
+	results := make([]string, 2)
+	for i, f := range []webdav.File{fA, fB} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			data, err := io.ReadAll(f)
+			assert.NoError(t, err)
+			results[i] = string(data)
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, "shared content", results[0])
+	assert.Equal(t, "shared content", results[1])
+	assert.Equal(t, 1, upstream.opens("/obj"), "concurrent readers should share one fetch")
+}
+
+// A client that reads part of the object and disconnects does not stop the
+// fetch: the upstream copy runs to completion and later reads are cache hits.
+func TestStorageCacheFetchSurvivesClientDisconnect(t *testing.T) {
+	content := strings.Repeat("x", 1000) + strings.Repeat("y", 1000)
+	upstream := newFakeUpstream()
+	upstream.put("/obj", content, `"etag-1"`)
+	gate := make(chan int)
+	upstream.objects["/obj"].gate = gate
+
+	cache, layer, _ := newTestCacheLayer(t, upstream, 0)
+
+	reqCtx, cancelReq := context.WithCancel(context.Background())
+	f, err := layer.OpenFile(reqCtx, "/obj", os.O_RDONLY, 0)
+	require.NoError(t, err)
+
+	// Let the fetch deliver the first 100 bytes and read them as the client.
+	go func() { gate <- 100 }()
+	buf := make([]byte, 100)
+	n, err := io.ReadFull(f, buf)
+	require.NoError(t, err)
+	require.Equal(t, 100, n)
+	require.Equal(t, content[:100], string(buf))
+
+	// Grab the in-flight fetch, then disconnect the client.
+	metaRel, _, _ := layer.entryPaths("/obj")
+	fetch := cache.lookupFetch(metaRel)
+	require.NotNil(t, fetch)
+	cancelReq()
+	_, err = f.Read(buf)
+	require.ErrorIs(t, err, context.Canceled)
+	require.NoError(t, f.Close())
+
+	// Release the rest of the object; the detached fetch must finish cleanly.
+	close(gate)
+	require.NoError(t, waitFetchDone(fetch))
+
+	// The completed entry now serves hits with no additional upstream opens.
+	require.Equal(t, content, readAllViaLayer(t, layer, "/obj"))
+	assert.Equal(t, 1, upstream.opens("/obj"))
+}
+
+// A reader that outpaces the upstream blocks until bytes arrive, then
+// continues — the buffering pipeline decouples the two speeds.
+func TestStorageCacheSlowUpstreamFastClient(t *testing.T) {
+	content := "abcdefghij"
+	upstream := newFakeUpstream()
+	upstream.put("/obj", content, `"etag-1"`)
+	gate := make(chan int)
+	upstream.objects["/obj"].gate = gate
+
+	_, layer, _ := newTestCacheLayer(t, upstream, 0)
+	f, err := layer.OpenFile(context.Background(), "/obj", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	defer f.Close()
+
+	done := make(chan string)
+	go func() {
+		data, err := io.ReadAll(f)
+		assert.NoError(t, err)
+		done <- string(data)
+	}()
+
+	// Dribble the object out in three unequal chunks.
+	gate <- 3
+	gate <- 5
+	close(gate)
+	assert.Equal(t, content, <-done)
+}
+
+// An upstream failure mid-fetch propagates an error (not a silent short
+// read) and leaves no sidecar behind, so the next read refetches.
+func TestStorageCacheFetchErrorPropagates(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/obj", "will fail", `"etag-1"`)
+	gate := make(chan int)
+	upstream.objects["/obj"].gate = gate
+	upstream.objects["/obj"].failAfter = 4
+	upstream.readErr["/obj"] = fmt.Errorf("upstream connection reset")
+
+	_, layer, memFs := newTestCacheLayer(t, upstream, 0)
+	f, err := layer.OpenFile(context.Background(), "/obj", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	defer f.Close()
+
+	// Allow a partial delivery; the read after the granted bytes fails.
+	go func() { gate <- 4 }()
+	data, err := io.ReadAll(f)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "connection reset")
+	assert.Equal(t, "will", string(data), "bytes before the failure are still delivered")
+
+	// No sidecar may exist for the failed fetch.
+	metaRel, _, _ := layer.entryPaths("/obj")
+	exists, err := afero.Exists(memFs, metaRel)
+	require.NoError(t, err)
+	assert.False(t, exists)
+	assert.Equal(t, 0, countDataFiles(t, memFs), "partial data file should be cleaned up")
+}
+
+// A write through the layer drops the cached copy so a subsequent read
+// revalidates and refetches the new content.
+func TestStorageCacheWriteInvalidates(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/obj", "original", `"etag-1"`)
+	_, layer, memFs := newTestCacheLayer(t, upstream, 0)
+
+	require.Equal(t, "original", readAllViaLayer(t, layer, "/obj"))
+
+	w, err := layer.OpenFile(context.Background(), "/obj", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	require.NoError(t, err)
+	_, err = w.Write([]byte("replaced"))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	metaRel, _, _ := layer.entryPaths("/obj")
+	exists, err := afero.Exists(memFs, metaRel)
+	require.NoError(t, err)
+	assert.False(t, exists, "write should invalidate the cache entry")
+
+	require.Equal(t, "replaced", readAllViaLayer(t, layer, "/obj"))
+	require.Equal(t, 2, upstream.opens("/obj"))
+}
+
+// Deleting or renaming an object invalidates its cache entry.
+func TestStorageCacheRemoveAndRenameInvalidate(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/a", "content a", `"etag-a"`)
+	upstream.put("/b", "content b", `"etag-b"`)
+	_, layer, memFs := newTestCacheLayer(t, upstream, 0)
+
+	readAllViaLayer(t, layer, "/a")
+	readAllViaLayer(t, layer, "/b")
+	require.Equal(t, 2, countDataFiles(t, memFs))
+
+	require.NoError(t, layer.RemoveAll(context.Background(), "/a"))
+	metaA, _, _ := layer.entryPaths("/a")
+	exists, _ := afero.Exists(memFs, metaA)
+	assert.False(t, exists)
+
+	require.NoError(t, layer.Rename(context.Background(), "/b", "/c"))
+	metaB, _, _ := layer.entryPaths("/b")
+	exists, _ = afero.Exists(memFs, metaB)
+	assert.False(t, exists)
+}
+
+// Eviction removes least-recently-accessed entries until usage drops below
+// the target watermark; in-flight fetches are exempt.
+func TestStorageCacheEviction(t *testing.T) {
+	upstream := newFakeUpstream()
+	for i := 0; i < 4; i++ {
+		upstream.put(fmt.Sprintf("/obj%d", i), strings.Repeat("z", 100), fmt.Sprintf(`"etag-%d"`, i))
+	}
+	// Max size fits two objects comfortably but not four.
+	cache, layer, memFs := newTestCacheLayer(t, upstream, 250)
+
+	base := time.Now().Add(-time.Hour)
+	for i := 0; i < 4; i++ {
+		readAllViaLayer(t, layer, fmt.Sprintf("/obj%d", i))
+		// Stamp distinct access times (oldest first) deterministically.
+		metaRel, _, _ := layer.entryPaths(fmt.Sprintf("/obj%d", i))
+		require.NoError(t, memFs.Chtimes(metaRel, base.Add(time.Duration(i)*time.Minute), base.Add(time.Duration(i)*time.Minute)))
+	}
+	require.Equal(t, 4, countDataFiles(t, memFs))
+
+	cache.evictOnce()
+
+	// Target is 90% of 250 = 225, so two 100-byte entries survive.
+	require.Equal(t, 2, countDataFiles(t, memFs))
+	// The survivors are the most recently accessed ones.
+	for i, wantSurvive := range []bool{false, false, true, true} {
+		metaRel, _, _ := layer.entryPaths(fmt.Sprintf("/obj%d", i))
+		exists, err := afero.Exists(memFs, metaRel)
+		require.NoError(t, err)
+		assert.Equal(t, wantSurvive, exists, "obj%d survival", i)
+	}
+
+	// Evicted entries are refetched on demand.
+	require.Equal(t, strings.Repeat("z", 100), readAllViaLayer(t, layer, "/obj0"))
+	require.Equal(t, 2, upstream.opens("/obj0"))
+}
+
+// Objects without an upstream ETag fall back to the size/mtime validator and
+// still cache correctly.
+func TestStorageCacheNoETagFallback(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/obj", "no etag here", "")
+	_, layer, _ := newTestCacheLayer(t, upstream, 0)
+
+	require.Equal(t, "no etag here", readAllViaLayer(t, layer, "/obj"))
+	require.Equal(t, "no etag here", readAllViaLayer(t, layer, "/obj"))
+	require.Equal(t, 1, upstream.opens("/obj"), "unchanged object should be a hit without an ETag")
+
+	// The served info must not invent a client-visible ETag.
+	f, err := layer.OpenFile(context.Background(), "/obj", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	defer f.Close()
+	info, err := f.Stat()
+	require.NoError(t, err)
+	etager, ok := info.(webdav.ETager)
+	require.True(t, ok)
+	_, err = etager.ETag(context.Background())
+	assert.ErrorIs(t, err, webdav.ErrNotImplemented)
+}
+
+// While an entry is fresh it is served with zero upstream interaction —
+// no data open and no metadata stat — even if the upstream object has been
+// deleted in the meantime (standard HTTP caching semantics).
+func TestStorageCacheFreshServesWithoutStat(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/obj", "cache me", `"etag-1"`)
+	_, layer, _ := newTestCacheLayer(t, upstream, 0)
+
+	require.Equal(t, "cache me", readAllViaLayer(t, layer, "/obj"))
+	require.NoError(t, upstream.RemoveAll(context.Background(), "/obj"))
+
+	// Fresh window (24h default, no jitter): served locally despite the
+	// upstream deletion.
+	require.Equal(t, "cache me", readAllViaLayer(t, layer, "/obj"))
+	require.Equal(t, 1, upstream.stats("/obj"))
+	require.Equal(t, 1, upstream.opens("/obj"))
+
+	// The layer's Stat is also answered from the fresh entry.
+	info, err := layer.Stat(context.Background(), "/obj")
+	require.NoError(t, err)
+	assert.Equal(t, int64(len("cache me")), info.Size())
+	require.Equal(t, 1, upstream.stats("/obj"))
+}
+
+// A stale entry whose validator still matches is renewed in place: one stat,
+// no refetch, and the entry becomes fresh again.
+func TestStorageCacheStaleRevalidationRenews(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/obj", "steady content", `"etag-1"`)
+	cache, layer, _ := newTestCacheLayer(t, upstream, 0)
+
+	require.Equal(t, "steady content", readAllViaLayer(t, layer, "/obj"))
+
+	// Backdate the validation time beyond the 24h default freshness.
+	metaRel, _, _ := layer.entryPaths("/obj")
+	rewriteMetaLastValidated(t, cache, metaRel, time.Now().Add(-48*time.Hour))
+
+	// Stale → revalidate (stat #2) → validator matches → served locally.
+	require.Equal(t, "steady content", readAllViaLayer(t, layer, "/obj"))
+	require.Equal(t, 2, upstream.stats("/obj"))
+	require.Equal(t, 1, upstream.opens("/obj"), "matching validator must not refetch")
+
+	// The renewal reset the freshness window: no further stats needed.
+	require.Equal(t, "steady content", readAllViaLayer(t, layer, "/obj"))
+	require.Equal(t, 2, upstream.stats("/obj"))
+
+	meta := cache.readMeta(metaRel)
+	require.NotNil(t, meta)
+	assert.Greater(t, meta.LastValidatedUnixNano, time.Now().Add(-time.Hour).UnixNano(),
+		"revalidation should bump the validation timestamp")
+}
+
+// Objects marked no-store (or private) bypass the cache entirely: every read
+// streams from the backend and nothing is persisted.
+func TestStorageCacheNoStoreBypasses(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.putCC("/obj", "sensitive", `"etag-1"`, "no-store")
+	_, layer, memFs := newTestCacheLayer(t, upstream, 0)
+
+	require.Equal(t, "sensitive", readAllViaLayer(t, layer, "/obj"))
+	require.Equal(t, "sensitive", readAllViaLayer(t, layer, "/obj"))
+	require.Equal(t, 2, upstream.opens("/obj"), "no-store must stream from the backend every time")
+
+	assert.Equal(t, 0, countDataFiles(t, memFs))
+	metaRel, _, _ := layer.entryPaths("/obj")
+	exists, err := afero.Exists(memFs, metaRel)
+	require.NoError(t, err)
+	assert.False(t, exists, "no-store must not persist a sidecar")
+}
+
+// An object that later turns no-store has its previously cached copy dropped.
+func TestStorageCacheNoStoreDropsExistingEntry(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.putCC("/obj", "cacheable", `"etag-1"`, "max-age=0")
+	_, layer, memFs := newTestCacheLayer(t, upstream, 0)
+
+	require.Equal(t, "cacheable", readAllViaLayer(t, layer, "/obj"))
+	require.Equal(t, 1, countDataFiles(t, memFs))
+
+	upstream.putCC("/obj", "now sensitive", `"etag-2"`, "no-store")
+	require.Equal(t, "now sensitive", readAllViaLayer(t, layer, "/obj"))
+	assert.Equal(t, 0, countDataFiles(t, memFs), "no-store must purge the stale local copy")
+}
+
+// Deleting a directory through the origin invalidates every cached
+// descendant immediately — no waiting for freshness to lapse.
+func TestStorageCacheDirRemoveInvalidatesDescendants(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/dir/a", "content a", `"etag-a"`)
+	upstream.put("/dir/b", "content b", `"etag-b"`)
+	upstream.put("/other", "content o", `"etag-o"`)
+	_, layer, memFs := newTestCacheLayer(t, upstream, 0)
+
+	readAllViaLayer(t, layer, "/dir/a")
+	readAllViaLayer(t, layer, "/dir/b")
+	readAllViaLayer(t, layer, "/other")
+	require.Equal(t, 3, countDataFiles(t, memFs))
+
+	require.NoError(t, layer.RemoveAll(context.Background(), "/dir"))
+
+	// The descendants' entries are gone; the unrelated entry survives.
+	require.Equal(t, 1, countDataFiles(t, memFs))
+	for _, p := range []string{"/dir/a", "/dir/b"} {
+		metaRel, _, _ := layer.entryPaths(p)
+		exists, err := afero.Exists(memFs, metaRel)
+		require.NoError(t, err)
+		assert.False(t, exists, "entry for %s should be invalidated", p)
+	}
+
+	// A read now reflects the deletion instead of serving a fresh copy.
+	_, err := layer.OpenFile(context.Background(), "/dir/a", os.O_RDONLY, 0)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+
+	// The unrelated object still serves from cache.
+	require.Equal(t, "content o", readAllViaLayer(t, layer, "/other"))
+	require.Equal(t, 1, upstream.opens("/other"))
+}
+
+// Renaming a directory invalidates cached descendants under both the old and
+// the new name.
+func TestStorageCacheDirRenameInvalidatesDescendants(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/src/a", "alpha", `"etag-a"`)
+	_, layer, memFs := newTestCacheLayer(t, upstream, 0)
+
+	readAllViaLayer(t, layer, "/src/a")
+	require.NoError(t, layer.Rename(context.Background(), "/src", "/dst"))
+
+	require.Equal(t, 0, countDataFiles(t, memFs))
+	_, err := layer.OpenFile(context.Background(), "/src/a", os.O_RDONLY, 0)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	require.Equal(t, "alpha", readAllViaLayer(t, layer, "/dst/a"))
+}
+
+// A write racing an in-flight fetch supersedes it: the fetch still streams
+// the pre-write bytes to its attached readers, but must not install them as
+// a fresh cache entry afterwards.
+func TestStorageCacheWriteSupersedesInFlightFetch(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/obj", "old content", `"etag-old"`)
+	gate := make(chan int)
+	upstream.objects["/obj"].gate = gate
+
+	cache, layer, memFs := newTestCacheLayer(t, upstream, 0)
+
+	f, err := layer.OpenFile(context.Background(), "/obj", os.O_RDONLY, 0)
+	require.NoError(t, err)
+
+	// Start the fetch and let a few bytes through.
+	go func() { gate <- 3 }()
+	buf := make([]byte, 3)
+	_, err = io.ReadFull(f, buf)
+	require.NoError(t, err)
+
+	metaRel, _, _ := layer.entryPaths("/obj")
+	fetch := cache.lookupFetch(metaRel)
+	require.NotNil(t, fetch)
+
+	// Overwrite the object through the origin while the fetch is running.
+	w, err := layer.OpenFile(context.Background(), "/obj", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	require.NoError(t, err)
+	_, err = w.Write([]byte("new content!"))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	// Let the fetch finish; the attached reader drains the OLD snapshot...
+	close(gate)
+	rest, err := io.ReadAll(f)
+	require.NoError(t, err)
+	require.Equal(t, "old content", string(buf)+string(rest))
+	require.NoError(t, f.Close())
+	require.NoError(t, waitFetchDone(fetch))
+
+	// ...but nothing was installed: no sidecar, no data file.
+	assert.Nil(t, cache.readMeta(metaRel))
+	assert.Equal(t, 0, countDataFiles(t, memFs))
+
+	// The next read fetches the post-write content.
+	require.Equal(t, "new content!", readAllViaLayer(t, layer, "/obj"))
+}
+
+// Enumeration-based unrolling recurses through nested directories and only
+// touches entries under the deleted prefix.
+func TestStorageCacheDirRemoveNested(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/dir/a", "a", `"e-a"`)
+	upstream.put("/dir/sub/b", "bb", `"e-b"`)
+	upstream.put("/dir/sub/deep/c", "ccc", `"e-c"`)
+	upstream.put("/keep", "keep", `"e-k"`)
+	_, layer, memFs := newTestCacheLayer(t, upstream, 0)
+
+	for _, p := range []string{"/dir/a", "/dir/sub/b", "/dir/sub/deep/c", "/keep"} {
+		readAllViaLayer(t, layer, p)
+	}
+	require.Equal(t, 4, countDataFiles(t, memFs))
+
+	require.NoError(t, layer.RemoveAll(context.Background(), "/dir"))
+
+	require.Equal(t, 1, countDataFiles(t, memFs))
+	require.Equal(t, "keep", readAllViaLayer(t, layer, "/keep"))
+	require.Equal(t, 1, upstream.opens("/keep"))
+}
+
+// When the backend cannot enumerate a directory, invalidation falls back to
+// scanning the cache's own sidecars and still drops every descendant.
+func TestStorageCacheDirRemoveFallbackScan(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/dir/a", "a content", `"e-a"`)
+	upstream.put("/keep", "keep", `"e-k"`)
+	upstream.failListing = true
+	_, layer, memFs := newTestCacheLayer(t, upstream, 0)
+
+	readAllViaLayer(t, layer, "/dir/a")
+	readAllViaLayer(t, layer, "/keep")
+
+	require.NoError(t, layer.RemoveAll(context.Background(), "/dir"))
+
+	metaRel, _, _ := layer.entryPaths("/dir/a")
+	exists, err := afero.Exists(memFs, metaRel)
+	require.NoError(t, err)
+	assert.False(t, exists, "fallback scan should invalidate the descendant")
+	keepMeta, _, _ := layer.entryPaths("/keep")
+	exists, err = afero.Exists(memFs, keepMeta)
+	require.NoError(t, err)
+	assert.True(t, exists, "unrelated entry must survive the fallback scan")
+}
+
+// Deleting a directory supersedes in-flight fetches beneath it: attached
+// readers drain the old snapshot, but nothing is installed, and subsequent
+// reads see the deletion.
+func TestStorageCacheDirRemoveSupersedesInFlightFetch(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/dir/obj", "doomed content", `"e-1"`)
+	gate := make(chan int)
+	upstream.objects["/dir/obj"].gate = gate
+
+	cache, layer, memFs := newTestCacheLayer(t, upstream, 0)
+
+	f, err := layer.OpenFile(context.Background(), "/dir/obj", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	go func() { gate <- 3 }()
+	buf := make([]byte, 3)
+	_, err = io.ReadFull(f, buf)
+	require.NoError(t, err)
+
+	metaRel, _, _ := layer.entryPaths("/dir/obj")
+	fetch := cache.lookupFetch(metaRel)
+	require.NotNil(t, fetch)
+
+	require.NoError(t, layer.RemoveAll(context.Background(), "/dir"))
+
+	close(gate)
+	rest, err := io.ReadAll(f)
+	require.NoError(t, err)
+	require.Equal(t, "doomed content", string(buf)+string(rest))
+	require.NoError(t, f.Close())
+	require.NoError(t, waitFetchDone(fetch))
+
+	assert.Nil(t, cache.readMeta(metaRel))
+	assert.Equal(t, 0, countDataFiles(t, memFs))
+	_, err = layer.OpenFile(context.Background(), "/dir/obj", os.O_RDONLY, 0)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+// The old copy keeps serving (from cache) while an overwrite is uploading;
+// the entry is dropped exactly when the upload commits.
+func TestStorageCacheWriteCommitSemantics(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/obj", "old", `"e-old"`)
+	_, layer, memFs := newTestCacheLayer(t, upstream, 0)
+	require.Equal(t, "old", readAllViaLayer(t, layer, "/obj"))
+
+	w, err := layer.OpenFile(context.Background(), "/obj", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	require.NoError(t, err)
+	_, err = w.Write([]byte("new"))
+	require.NoError(t, err)
+
+	// Upload in progress: reads still serve the old copy, from cache.
+	require.Equal(t, "old", readAllViaLayer(t, layer, "/obj"))
+	require.Equal(t, 1, upstream.opens("/obj"))
+
+	require.NoError(t, w.Close())
+	metaRel, _, _ := layer.entryPaths("/obj")
+	exists, err := afero.Exists(memFs, metaRel)
+	require.NoError(t, err)
+	assert.False(t, exists, "commit must invalidate the entry")
+	require.Equal(t, "new", readAllViaLayer(t, layer, "/obj"))
+}
+
+// A failed upload still invalidates: the backend's state is unknown, so the
+// next read must revalidate rather than trust the pre-write copy blindly.
+func TestStorageCacheFailedWriteStillInvalidates(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/obj", "old", `"e-old"`)
+	upstream.failWriteClose = true
+	_, layer, memFs := newTestCacheLayer(t, upstream, 0)
+	require.Equal(t, "old", readAllViaLayer(t, layer, "/obj"))
+
+	w, err := layer.OpenFile(context.Background(), "/obj", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	require.NoError(t, err)
+	_, err = w.Write([]byte("partial"))
+	require.NoError(t, err)
+	require.Error(t, w.Close())
+
+	metaRel, _, _ := layer.entryPaths("/obj")
+	exists, err := afero.Exists(memFs, metaRel)
+	require.NoError(t, err)
+	assert.False(t, exists, "failed commit must still invalidate")
+
+	// Upstream is unchanged (the fake never committed), so the next read
+	// revalidates and refetches the same content.
+	require.Equal(t, "old", readAllViaLayer(t, layer, "/obj"))
+	require.Equal(t, 2, upstream.opens("/obj"))
+}
+
+// Renaming onto a destination that already has cached objects invalidates
+// the destination subtree too — the cached pre-rename destination content
+// must not keep serving.
+func TestStorageCacheRenameInvalidatesDestination(t *testing.T) {
+	upstream := newFakeUpstream()
+	upstream.put("/src/a", "source", `"e-s"`)
+	upstream.put("/dst/a", "dest-old", `"e-d"`)
+	_, layer, _ := newTestCacheLayer(t, upstream, 0)
+
+	require.Equal(t, "dest-old", readAllViaLayer(t, layer, "/dst/a"))
+	require.NoError(t, layer.Rename(context.Background(), "/src", "/dst"))
+	require.Equal(t, "source", readAllViaLayer(t, layer, "/dst/a"))
+}
+
+// A missing object propagates the upstream's not-found error.
+func TestStorageCacheNotFound(t *testing.T) {
+	upstream := newFakeUpstream()
+	_, layer, _ := newTestCacheLayer(t, upstream, 0)
+	_, err := layer.OpenFile(context.Background(), "/missing", os.O_RDONLY, 0)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -475,6 +475,10 @@ var runtimeConfigurableMap = map[string]bool{
 	"Origin.SelfTest": false,
 	"Origin.SelfTestInterval": false,
 	"Origin.SelfTestMaxAge": false,
+	"Origin.StorageCacheDefaultMaxAge": false,
+	"Origin.StorageCacheLocation": false,
+	"Origin.StorageCacheRevalidationJitter": false,
+	"Origin.StorageCacheSize": false,
 	"Origin.StoragePrefix": false,
 	"Origin.StorageType": false,
 	"Origin.SupportedChecksumTypes": false,
@@ -794,6 +798,8 @@ var stringAccessors = map[string]func(*Config) string{
 	"Origin.ScitokensNameMapFile": func(c *Config) string { return c.Origin.ScitokensNameMapFile },
 	"Origin.ScitokensUnauthenticatedUser": func(c *Config) string { return c.Origin.ScitokensUnauthenticatedUser },
 	"Origin.ScitokensUsernameClaim": func(c *Config) string { return c.Origin.ScitokensUsernameClaim },
+	"Origin.StorageCacheLocation": func(c *Config) string { return c.Origin.StorageCacheLocation },
+	"Origin.StorageCacheSize": func(c *Config) string { return c.Origin.StorageCacheSize },
 	"Origin.StoragePrefix": func(c *Config) string { return c.Origin.StoragePrefix },
 	"Origin.StorageType": func(c *Config) string { return c.Origin.StorageType },
 	"Origin.TokenAudience": func(c *Config) string { return c.Origin.TokenAudience },
@@ -1004,6 +1010,7 @@ var intAccessors = map[string]func(*Config) int{
 	"Origin.Port": func(c *Config) int { return c.Origin.Port },
 	"Origin.SSH.MaxRetries": func(c *Config) int { return c.Origin.SSH.MaxRetries },
 	"Origin.SSH.Port": func(c *Config) int { return c.Origin.SSH.Port },
+	"Origin.StorageCacheRevalidationJitter": func(c *Config) int { return c.Origin.StorageCacheRevalidationJitter },
 	"Plugin.DirectorDecisionPercentage": func(c *Config) int { return c.Plugin.DirectorDecisionPercentage },
 	"Server.DatabaseBackup.MaxCount": func(c *Config) int { return c.Server.DatabaseBackup.MaxCount },
 	"Server.IssuerPort": func(c *Config) int { return c.Server.IssuerPort },
@@ -1292,6 +1299,7 @@ var durationAccessors = map[string]func(*Config) time.Duration{
 	"Origin.SSH.SessionEstablishTimeout": func(c *Config) time.Duration { return c.Origin.SSH.SessionEstablishTimeout },
 	"Origin.SelfTestInterval": func(c *Config) time.Duration { return c.Origin.SelfTestInterval },
 	"Origin.SelfTestMaxAge": func(c *Config) time.Duration { return c.Origin.SelfTestMaxAge },
+	"Origin.StorageCacheDefaultMaxAge": func(c *Config) time.Duration { return c.Origin.StorageCacheDefaultMaxAge },
 	"Origin.UserMapfileRefreshInterval": func(c *Config) time.Duration { return c.Origin.UserMapfileRefreshInterval },
 	"Registry.InactiveRegistrationCleanupInterval": func(c *Config) time.Duration { return c.Registry.InactiveRegistrationCleanupInterval },
 	"Registry.InactiveRegistrationTimeout": func(c *Config) time.Duration { return c.Registry.InactiveRegistrationTimeout },
@@ -1783,6 +1791,10 @@ var allParameterNames = []string{
 	"Origin.SelfTest",
 	"Origin.SelfTestInterval",
 	"Origin.SelfTestMaxAge",
+	"Origin.StorageCacheDefaultMaxAge",
+	"Origin.StorageCacheLocation",
+	"Origin.StorageCacheRevalidationJitter",
+	"Origin.StorageCacheSize",
 	"Origin.StoragePrefix",
 	"Origin.StorageType",
 	"Origin.SupportedChecksumTypes",
@@ -2075,6 +2087,8 @@ var (
 	Origin_ScitokensNameMapFile = StringParam{"Origin.ScitokensNameMapFile"}
 	Origin_ScitokensUnauthenticatedUser = StringParam{"Origin.ScitokensUnauthenticatedUser"}
 	Origin_ScitokensUsernameClaim = StringParam{"Origin.ScitokensUsernameClaim"}
+	Origin_StorageCacheLocation = StringParam{"Origin.StorageCacheLocation"}
+	Origin_StorageCacheSize = StringParam{"Origin.StorageCacheSize"}
 	Origin_StoragePrefix = StringParam{"Origin.StoragePrefix"}
 	Origin_StorageType = StringParam{"Origin.StorageType"}
 	Origin_TokenAudience = StringParam{"Origin.TokenAudience"}
@@ -2229,6 +2243,7 @@ var (
 	Origin_Port = IntParam{"Origin.Port"}
 	Origin_SSH_MaxRetries = IntParam{"Origin.SSH.MaxRetries"}
 	Origin_SSH_Port = IntParam{"Origin.SSH.Port"}
+	Origin_StorageCacheRevalidationJitter = IntParam{"Origin.StorageCacheRevalidationJitter"}
 	Plugin_DirectorDecisionPercentage = IntParam{"Plugin.DirectorDecisionPercentage"}
 	Server_DatabaseBackup_MaxCount = IntParam{"Server.DatabaseBackup.MaxCount"}
 	Server_IssuerPort = IntParam{"Server.IssuerPort"}
@@ -2424,6 +2439,7 @@ var (
 	Origin_SSH_SessionEstablishTimeout = DurationParam{"Origin.SSH.SessionEstablishTimeout"}
 	Origin_SelfTestInterval = DurationParam{"Origin.SelfTestInterval"}
 	Origin_SelfTestMaxAge = DurationParam{"Origin.SelfTestMaxAge"}
+	Origin_StorageCacheDefaultMaxAge = DurationParam{"Origin.StorageCacheDefaultMaxAge"}
 	Origin_UserMapfileRefreshInterval = DurationParam{"Origin.UserMapfileRefreshInterval"}
 	Registry_InactiveRegistrationCleanupInterval = DurationParam{"Registry.InactiveRegistrationCleanupInterval"}
 	Registry_InactiveRegistrationTimeout = DurationParam{"Registry.InactiveRegistrationTimeout"}
@@ -2628,6 +2644,8 @@ func init() {
 		"Origin.ScitokensNameMapFile": Origin_ScitokensNameMapFile,
 		"Origin.ScitokensUnauthenticatedUser": Origin_ScitokensUnauthenticatedUser,
 		"Origin.ScitokensUsernameClaim": Origin_ScitokensUsernameClaim,
+		"Origin.StorageCacheLocation": Origin_StorageCacheLocation,
+		"Origin.StorageCacheSize": Origin_StorageCacheSize,
 		"Origin.StoragePrefix": Origin_StoragePrefix,
 		"Origin.StorageType": Origin_StorageType,
 		"Origin.TokenAudience": Origin_TokenAudience,
@@ -2776,6 +2794,7 @@ func init() {
 		"Origin.Port": Origin_Port,
 		"Origin.SSH.MaxRetries": Origin_SSH_MaxRetries,
 		"Origin.SSH.Port": Origin_SSH_Port,
+		"Origin.StorageCacheRevalidationJitter": Origin_StorageCacheRevalidationJitter,
 		"Plugin.DirectorDecisionPercentage": Plugin_DirectorDecisionPercentage,
 		"Server.DatabaseBackup.MaxCount": Server_DatabaseBackup_MaxCount,
 		"Server.IssuerPort": Server_IssuerPort,
@@ -2962,6 +2981,7 @@ func init() {
 		"Origin.SSH.SessionEstablishTimeout": Origin_SSH_SessionEstablishTimeout,
 		"Origin.SelfTestInterval": Origin_SelfTestInterval,
 		"Origin.SelfTestMaxAge": Origin_SelfTestMaxAge,
+		"Origin.StorageCacheDefaultMaxAge": Origin_StorageCacheDefaultMaxAge,
 		"Origin.UserMapfileRefreshInterval": Origin_UserMapfileRefreshInterval,
 		"Registry.InactiveRegistrationCleanupInterval": Registry_InactiveRegistrationCleanupInterval,
 		"Registry.InactiveRegistrationTimeout": Registry_InactiveRegistrationTimeout,

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -477,6 +477,7 @@ var runtimeConfigurableMap = map[string]bool{
 	"Origin.SelfTestMaxAge": false,
 	"Origin.StorageCacheDefaultMaxAge": false,
 	"Origin.StorageCacheLocation": false,
+	"Origin.StorageCacheMaxConcurrentFetches": false,
 	"Origin.StorageCacheRevalidationJitter": false,
 	"Origin.StorageCacheSize": false,
 	"Origin.StoragePrefix": false,
@@ -1010,6 +1011,7 @@ var intAccessors = map[string]func(*Config) int{
 	"Origin.Port": func(c *Config) int { return c.Origin.Port },
 	"Origin.SSH.MaxRetries": func(c *Config) int { return c.Origin.SSH.MaxRetries },
 	"Origin.SSH.Port": func(c *Config) int { return c.Origin.SSH.Port },
+	"Origin.StorageCacheMaxConcurrentFetches": func(c *Config) int { return c.Origin.StorageCacheMaxConcurrentFetches },
 	"Origin.StorageCacheRevalidationJitter": func(c *Config) int { return c.Origin.StorageCacheRevalidationJitter },
 	"Plugin.DirectorDecisionPercentage": func(c *Config) int { return c.Plugin.DirectorDecisionPercentage },
 	"Server.DatabaseBackup.MaxCount": func(c *Config) int { return c.Server.DatabaseBackup.MaxCount },
@@ -1793,6 +1795,7 @@ var allParameterNames = []string{
 	"Origin.SelfTestMaxAge",
 	"Origin.StorageCacheDefaultMaxAge",
 	"Origin.StorageCacheLocation",
+	"Origin.StorageCacheMaxConcurrentFetches",
 	"Origin.StorageCacheRevalidationJitter",
 	"Origin.StorageCacheSize",
 	"Origin.StoragePrefix",
@@ -2243,6 +2246,7 @@ var (
 	Origin_Port = IntParam{"Origin.Port"}
 	Origin_SSH_MaxRetries = IntParam{"Origin.SSH.MaxRetries"}
 	Origin_SSH_Port = IntParam{"Origin.SSH.Port"}
+	Origin_StorageCacheMaxConcurrentFetches = IntParam{"Origin.StorageCacheMaxConcurrentFetches"}
 	Origin_StorageCacheRevalidationJitter = IntParam{"Origin.StorageCacheRevalidationJitter"}
 	Plugin_DirectorDecisionPercentage = IntParam{"Plugin.DirectorDecisionPercentage"}
 	Server_DatabaseBackup_MaxCount = IntParam{"Server.DatabaseBackup.MaxCount"}
@@ -2794,6 +2798,7 @@ func init() {
 		"Origin.Port": Origin_Port,
 		"Origin.SSH.MaxRetries": Origin_SSH_MaxRetries,
 		"Origin.SSH.Port": Origin_SSH_Port,
+		"Origin.StorageCacheMaxConcurrentFetches": Origin_StorageCacheMaxConcurrentFetches,
 		"Origin.StorageCacheRevalidationJitter": Origin_StorageCacheRevalidationJitter,
 		"Plugin.DirectorDecisionPercentage": Plugin_DirectorDecisionPercentage,
 		"Server.DatabaseBackup.MaxCount": Server_DatabaseBackup_MaxCount,

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -447,6 +447,10 @@ type Config struct {
 		SelfTest bool `mapstructure:"selftest" yaml:"SelfTest"`
 		SelfTestInterval time.Duration `mapstructure:"selftestinterval" yaml:"SelfTestInterval"`
 		SelfTestMaxAge time.Duration `mapstructure:"selftestmaxage" yaml:"SelfTestMaxAge"`
+		StorageCacheDefaultMaxAge time.Duration `mapstructure:"storagecachedefaultmaxage" yaml:"StorageCacheDefaultMaxAge"`
+		StorageCacheLocation string `mapstructure:"storagecachelocation" yaml:"StorageCacheLocation"`
+		StorageCacheRevalidationJitter int `mapstructure:"storagecacherevalidationjitter" yaml:"StorageCacheRevalidationJitter"`
+		StorageCacheSize string `mapstructure:"storagecachesize" yaml:"StorageCacheSize"`
 		StoragePrefix string `mapstructure:"storageprefix" yaml:"StoragePrefix"`
 		StorageType string `mapstructure:"storagetype" yaml:"StorageType"`
 		SupportedChecksumTypes []string `mapstructure:"supportedchecksumtypes" yaml:"SupportedChecksumTypes"`
@@ -1036,6 +1040,10 @@ type configWithType struct {
 		SelfTest struct { Type string; Value bool }
 		SelfTestInterval struct { Type string; Value time.Duration }
 		SelfTestMaxAge struct { Type string; Value time.Duration }
+		StorageCacheDefaultMaxAge struct { Type string; Value time.Duration }
+		StorageCacheLocation struct { Type string; Value string }
+		StorageCacheRevalidationJitter struct { Type string; Value int }
+		StorageCacheSize struct { Type string; Value string }
 		StoragePrefix struct { Type string; Value string }
 		StorageType struct { Type string; Value string }
 		SupportedChecksumTypes struct { Type string; Value []string }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -449,6 +449,7 @@ type Config struct {
 		SelfTestMaxAge time.Duration `mapstructure:"selftestmaxage" yaml:"SelfTestMaxAge"`
 		StorageCacheDefaultMaxAge time.Duration `mapstructure:"storagecachedefaultmaxage" yaml:"StorageCacheDefaultMaxAge"`
 		StorageCacheLocation string `mapstructure:"storagecachelocation" yaml:"StorageCacheLocation"`
+		StorageCacheMaxConcurrentFetches int `mapstructure:"storagecachemaxconcurrentfetches" yaml:"StorageCacheMaxConcurrentFetches"`
 		StorageCacheRevalidationJitter int `mapstructure:"storagecacherevalidationjitter" yaml:"StorageCacheRevalidationJitter"`
 		StorageCacheSize string `mapstructure:"storagecachesize" yaml:"StorageCacheSize"`
 		StoragePrefix string `mapstructure:"storageprefix" yaml:"StoragePrefix"`
@@ -1042,6 +1043,7 @@ type configWithType struct {
 		SelfTestMaxAge struct { Type string; Value time.Duration }
 		StorageCacheDefaultMaxAge struct { Type string; Value time.Duration }
 		StorageCacheLocation struct { Type string; Value string }
+		StorageCacheMaxConcurrentFetches struct { Type string; Value int }
 		StorageCacheRevalidationJitter struct { Type string; Value int }
 		StorageCacheSize struct { Type string; Value string }
 		StoragePrefix struct { Type string; Value string }

--- a/token/token_verify.go
+++ b/token/token_verify.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -79,14 +80,54 @@ const (
 )
 
 var (
-	federationJWK *jwk.Cache
-	authChecker   AuthChecker
+	// federationJWKMu guards federationJWK.  Verify runs concurrently on
+	// every server (a director resolving a token while an origin reports a
+	// test result, say), so the lazy initialization below is a genuine data
+	// race without it.
+	federationJWKMu sync.Mutex
+	federationJWK   *jwk.Cache
+	authChecker     AuthChecker
 
 	registeredServerJWKSResolver atomic.Pointer[RegisteredServerJWKSResolver]
 )
 
 func init() {
 	authChecker = &AuthCheckImpl{}
+}
+
+// federationJWKS returns the federation's public JWKS for jwksURI, fetching it
+// through a process-wide cache that refreshes in the background.
+//
+// Each distinct URI is registered on demand rather than only the first one
+// seen.  The cache was previously created once, for whichever URI happened to
+// arrive first, while the subsequent Get used the caller's URI -- so once the
+// federation's JwksUri changed (a config reload, or a test switching
+// federations) every verification failed with "url is not registered".
+func federationJWKS(ctx context.Context, jwksURI string) (jwk.Set, error) {
+	federationJWKMu.Lock()
+	if federationJWK == nil {
+		// The cache's own context bounds its background refresh goroutine, so
+		// it must outlive any single request.
+		federationJWK = jwk.NewCache(context.Background())
+	}
+	if !federationJWK.IsRegistered(jwksURI) {
+		client := &http.Client{Transport: config.GetTransport()}
+		if err := federationJWK.Register(jwksURI,
+			jwk.WithRefreshInterval(15*time.Minute),
+			jwk.WithHTTPClient(client)); err != nil {
+			federationJWKMu.Unlock()
+			return nil, errors.Wrap(err, "Failed to register cache for federation's public JWKS")
+		}
+	}
+	cache := federationJWK
+	federationJWKMu.Unlock()
+
+	// Get performs the HTTP fetch on a miss, so it runs outside the lock.
+	jwks, err := cache.Get(ctx, jwksURI)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get federation's public JWKS")
+	}
+	return jwks, nil
 }
 
 // RegisterServerJWKSResolver allows other packages (e.g. the Registry) to provide a
@@ -143,19 +184,9 @@ func (a AuthCheckImpl) checkFederationIssuer(c *gin.Context, strToken string, ex
 		}
 	}
 
-	fedURIFile := fedInfo.JwksUri
-	ctx := context.Background()
-	if federationJWK == nil {
-		client := &http.Client{Transport: config.GetTransport()}
-		federationJWK = jwk.NewCache(ctx)
-		if err := federationJWK.Register(fedURIFile, jwk.WithRefreshInterval(15*time.Minute), jwk.WithHTTPClient(client)); err != nil {
-			return errors.Wrap(err, "Failed to register cache for federation's public JWKS")
-		}
-	}
-
-	jwks, err := federationJWK.Get(ctx, fedURIFile)
+	jwks, err := federationJWKS(context.Background(), fedInfo.JwksUri)
 	if err != nil {
-		return errors.Wrap(err, "Failed to get federation's public JWKS")
+		return err
 	}
 
 	scopeValidator := token_scopes.CreateScopeValidator(expectedScopes, allScopes)

--- a/token/token_verify_test.go
+++ b/token/token_verify_test.go
@@ -20,12 +20,16 @@ package token
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -890,4 +894,92 @@ func TestSkewedTokenAcceptedByVerifyWithKeysetButRejectedByStrict(t *testing.T) 
 
 	_, strictErr := VerifyWithKeysetStrict(tokenStr, pubSet)
 	assert.Error(t, strictErr, "VerifyWithKeysetStrict should reject the same token (self-issued path, zero skew)")
+}
+
+// federationJWKS is reached concurrently on every server -- a director
+// resolving a token while an origin reports a director-test result, for
+// instance -- and is called with whichever JwksUri the federation currently
+// advertises.  These tests pin both properties: the lazy cache setup must be
+// race-free, and every distinct URI must be registered rather than only the
+// first one seen.
+func newJWKSServer(t *testing.T) (url string, hits *atomic.Int32) {
+	t.Helper()
+	key, err := jwk.FromRaw([]byte("this-is-only-a-test-key"))
+	require.NoError(t, err)
+	require.NoError(t, key.Set(jwk.KeyIDKey, "test-kid"))
+	set := jwk.NewSet()
+	require.NoError(t, set.AddKey(key))
+	body, err := json.Marshal(set)
+	require.NoError(t, err)
+
+	hits = &atomic.Int32{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL, hits
+}
+
+// resetFederationJWKCache drops the process-wide cache so one test's
+// registrations do not decide another's outcome.
+func resetFederationJWKCache(t *testing.T) {
+	t.Helper()
+	reset := func() {
+		federationJWKMu.Lock()
+		federationJWK = nil
+		federationJWKMu.Unlock()
+	}
+	reset()
+	t.Cleanup(reset)
+}
+
+// A second federation JWKS URI must be fetched, not rejected because some
+// earlier call registered a different one.
+func TestFederationJWKSRegistersEachURI(t *testing.T) {
+	resetFederationJWKCache(t)
+	firstURL, _ := newJWKSServer(t)
+	secondURL, secondHits := newJWKSServer(t)
+
+	set, err := federationJWKS(context.Background(), firstURL)
+	require.NoError(t, err)
+	require.Equal(t, 1, set.Len())
+
+	set, err = federationJWKS(context.Background(), secondURL)
+	require.NoError(t, err, "a second JWKS URI must be registered on demand")
+	require.Equal(t, 1, set.Len())
+	require.GreaterOrEqual(t, int(secondHits.Load()), 1, "the second URI was never actually fetched")
+}
+
+// Concurrent verification must not race on the lazily created cache.  Run
+// under -race for this to mean anything.
+func TestFederationJWKSConcurrent(t *testing.T) {
+	resetFederationJWKCache(t)
+	urlA, _ := newJWKSServer(t)
+	urlB, _ := newJWKSServer(t)
+
+	const goroutines = 16
+	start := make(chan struct{})
+	errs := make(chan error, goroutines)
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			uri := urlA
+			if i%2 == 1 {
+				uri = urlB
+			}
+			<-start // release them together, so the nil check collides
+			_, err := federationJWKS(context.Background(), uri)
+			errs <- err
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
 }


### PR DESCRIPTION
An origin that sits outside its storage provider pays egress every time the same object is read. This adds an opt-in local-disk cache layer between the origin's WebDAV handler and its remote backend (`s3v2`, `httpsv2`, `globusv2`), so repeat reads are served from local disk with no provider traffic at all.

## How it works

The cache is a `webdav.FileSystem` interposed on the backend in `InitializeHandlers`. It is shared across exports so a single size bound covers the whole tree, and it is inert unless `Origin.StorageCacheLocation` is set (other storage types log a warning and ignore it). Each export is scoped by its federation prefix *and* its backend identity, so repointing an export at different storage cannot serve entries cached from the old one.

**Validity reuses the standard Cache-Control rules** rather than inventing a second policy. Those rules now live in a shared leaf package, `cache_control` (see *Package layering* below). The backend's own directives govern freshness — S3 object metadata and the HTTPS response header, newly carried through `BlobFileSysInfo` / `HTTPSFileSysInfo`. Absent a directive, `Origin.StorageCacheDefaultMaxAge` applies with deterministic per-object jitter; that setting also *caps* the freshness a backend may claim for itself, so whoever can write an object's metadata cannot pin it in the cache. Fresh entries are served with zero backend interaction; stale entries revalidate with a single ETag-comparing metadata request and refetch only if the object actually changed. `no-store`/`private` bypass the cache; `no-cache` entries are cached but revalidated per use. Hits preserve the upstream ETag, size, and mtime, so they are indistinguishable from a backend read — including *not* exposing an ETag the backend keeps internal.

**Fetches are detached from the requesting client.** The upstream-to-disk copy runs at full speed while clients read the growing file at their own pace, so a slow or disconnected client neither stalls nor cancels population, and concurrent readers coalesce onto one fetch.

Two access patterns deliberately opt out, because for them the copy costs far more egress than it saves. Content-type sniffing — which `ServeContent` performs even on a HEAD, and which PROPFIND performs per listed file — is answered from the layer's `FileInfo` where possible and otherwise retires the copy rather than finishing it, so a HEAD does not pull a whole object. Range requests that start past what has been copied read straight from the backend instead of waiting for a sequential copy to reach their offset.

**The layer is an optimization, never a dependency.** A full or unwritable cache disk, or a saturated fetch pool, falls through to the backend instead of failing the request. Concurrent copies are bounded by `Origin.StorageCacheMaxConcurrentFetches`, so a burst of requests cannot exhaust memory or run up an unbounded provider bill.

**Origin-side mutations invalidate immediately.** A PUT drops the entry when the upload commits — the old copy keeps serving during the upload, and a failed `Close` also invalidates. Directory `RemoveAll`/`Rename` unroll into per-object invalidations via a pre-operation upstream enumeration (`O(subtree)`, bounded by count and depth), falling back to a sidecar scan when the backend cannot enumerate or a bound is hit. An in-flight fetch racing a mutation is marked superseded under the lock that installs the sidecar, so pre-write bytes can never land with a fresh validation timestamp.

Entries are content-addressed under `Origin.StorageCacheLocation` with JSON sidecars, written atomically, recording completeness and last-validated time. A janitor reclaims orphans left by an interrupted fetch and evicts least-recently-used entries down to 90% of `Origin.StorageCacheSize` when a bound is configured.

### Security notes

The cache is shared across clients and keyed by object path, so it refuses to start alongside `Origin.HttpAuthTokenPassthrough`, where the upstream authorizes each client's own credential. The cache directory is rejected if other local users can write to it, and a sidecar's recorded data-file name is validated rather than trusted as a path component. Digest headers are suppressed for objects served from the cache, since a digest computed from the live upstream would not describe the bytes actually sent.

## Configuration

| Parameter | Meaning |
| --- | --- |
| `Origin.StorageCacheLocation` | Cache directory; unset disables the layer |
| `Origin.StorageCacheSize` | Size bound; unset/`0` is unbounded |
| `Origin.StorageCacheDefaultMaxAge` | Freshness when the backend sends no directive, and the ceiling on any it does send (default 24h; `0` always revalidates) |
| `Origin.StorageCacheRevalidationJitter` | Percent jitter on the default window (default 10) |
| `Origin.StorageCacheMaxConcurrentFetches` | Concurrent backend copies (default 32) |

## Commits

- `local_cache: add policy-parameterized freshness helpers` — the Cache-Control rules take an explicit policy instead of reading `LocalCache.*`.
- `origin_serve: surface backend Cache-Control in Stat metadata` — carries the value the blob and HTTPS backends already receive. WebDAV-mode PROPFIND has no Cache-Control, so that path is unchanged.
- `origin_serve: add local storage cache for remote backends` — the layer itself.
- `origin_serve: harden the storage cache and move Cache-Control to a leaf package` — review follow-up; see that commit message for the full list.
- `origin_serve: tighten a loose cache directory instead of refusing to start` — a directory the origin created under a permissive umask is narrowed rather than rejected.
- `origin_serve: update InitializeHandlers call sites after rebase`
- `origin_serve: wait for the cache entry to land in the fed E2E test` — the copy is detached, so it completes just after the client's download does.
- `token: fix data race and stale registration in the federation JWKS cache` — an unsynchronized lazy init, and a cache that registered only the first JwksUri it saw while looking up whichever the caller passed.

### Package layering

Cache-Control parsing and freshness policy live in a new leaf package, `cache_control`, depending only on the standard library. Sharing them via `local_cache` had added 257 packages to `origin_serve`'s transitive closure — including `web_ui`, `client`, and `oauth2` — for roughly 200 lines of parsing; it now adds one. `local_cache` keeps its existing API by embedding the shared type.

Note for reviewers: `InitializeHandlers` gains an `*errgroup.Group` parameter so the cache's janitor is owned by the server's errgroup like every other origin background task. Tests that do not exercise the cache pass `nil`.

## Testing

Unit tests (`storage_cache_fs_test.go`, 45 cases) drive an instrumented fake upstream — in three FileInfo shapes matching the real blob, HTTPS, and WebDAV-mode backends — and cover hit/miss, freshness and revalidation, `no-store`, reader coalescing, survival of client disconnect, the supersede races, subtree invalidation, eviction, the sniff and range paths, fail-open behaviour, fetch-pool saturation, orphan reclamation, malformed sidecars, scope isolation, enumeration guards, ETag shape, and digest suppression. `cache_control` has direct coverage of parsing and policy, and the federation JWKS cache has tests for concurrent use and for registering more than one URI. `TestStorageCacheFedE2E` stands up a full federation with an `httpsv2` origin backed by an instrumented HTTP server and asserts that a cold client download populates the cache, a warm download generates zero backend GET/HEAD traffic, and a backend-side mutation stays invisible while the entry is fresh.

All pass under `-race` and `-count=3 -shuffle=on`, as does the rest of the `origin_serve` suite; `go build ./...` and `go vet ./...` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
