### PR TITLE
Improve TPC UX: correct token operations and infer the object name for a collection destination

### DIFF
--- a/client/acquire_token.go
+++ b/client/acquire_token.go
@@ -99,6 +99,18 @@ type (
 		authFailureMu           sync.Mutex
 		consecutiveAuthFailures int
 		externalProvider        TokenProvider // optional external provider; if set, Get() delegates to it
+		// usingUnacceptableToken records that getToken deliberately settled on
+		// a credential it could not vouch for -- the "the user knows better"
+		// fallback below.  Two things read it.  The warning is emitted only on
+		// the transition, so a job does not repeat the same sentence about the
+		// same credential once per file.  And Get() stops clearing the cache
+		// over that credential: the clear exists to force a fresh acquisition,
+		// but getToken returns the fallback *before* it ever reaches the
+		// acquire branch, so re-running it just re-walks every token location
+		// on disk to arrive at the same answer.  SetDirectorResponse resets
+		// the flag, since a new authorization picture can make the credential
+		// acceptable (or newly worth complaining about).
+		usingUnacceptableToken atomic.Bool
 	}
 
 	// An object that iterates through the various possible tokens
@@ -202,6 +214,10 @@ func (tg *tokenGenerator) cacheToken(contents string) {
 // acted on; see canApplyTokenHint.
 func (tg *tokenGenerator) SetDirectorResponse(dirResp *server_structs.DirectorResponse) {
 	tg.DirResp = dirResp
+	// A different authorization picture deserves a fresh verdict on whatever
+	// credential is cached: what looked unacceptable against the old issuers
+	// and base paths may be fine against these.
+	tg.usingUnacceptableToken.Store(false)
 }
 
 // canApplyTokenHint reports whether this generator may act on the token hints
@@ -562,7 +578,17 @@ func (tg *tokenGenerator) getToken() (token interface{}, err error) {
 		if tokenLoc == "" {
 			tokenLoc = tg.TokenLocation
 		}
-		log.Warningf("Using provided token %q even though it does not appear to be acceptable to perform transfer", tokenLoc)
+		if !tg.usingUnacceptableToken.Swap(true) {
+			if tokenLoc != "" {
+				log.Warningf("Using provided token %q even though it does not appear to be acceptable to perform transfer", tokenLoc)
+			} else {
+				dest := "the requested object"
+				if tg.Destination != nil {
+					dest = tg.Destination.String()
+				}
+				log.Warningf("Using a discovered token even though it does not appear to be acceptable to perform transfer to %s", dest)
+			}
+		}
 		tg.Token.Store(&potentialTokens[0])
 		token = potentialTokens[0].Contents
 		err = nil
@@ -616,7 +642,8 @@ func (tg *tokenGenerator) Get() (token string, err error) {
 	info := tg.Token.Load()
 	if info != nil && time.Until(info.Expiry) > 0 && info.Contents != "" {
 		// if AcquireToken is enabled and the token is unacceptable, clear the cache and force a new token to be generated
-		if tg.EnableAcquire && tg.DirResp != nil && !tokenIsAcceptable(info.Contents, tg.Destination.Path, *tg.DirResp, config.TokenGenerationOpts{Operation: tg.Operation}) {
+		if tg.EnableAcquire && tg.DirResp != nil && !tg.usingUnacceptableToken.Load() &&
+			!tokenIsAcceptable(info.Contents, tg.Destination.Path, *tg.DirResp, config.TokenGenerationOpts{Operation: tg.Operation}) {
 			tg.Token.Store(nil) // clear the cache and force a new token to be generated
 			log.Debugln("Token is not acceptable; clearing cache")
 		} else {

--- a/client/acquire_token_test.go
+++ b/client/acquire_token_test.go
@@ -26,6 +26,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -39,6 +41,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/pelican_url"
 	"github.com/pelicanplatform/pelican/server_structs"
 	"github.com/pelicanplatform/pelican/token"
 	"github.com/pelicanplatform/pelican/token_scopes"
@@ -1418,4 +1421,120 @@ func TestRefreshTokenEntryInvalidGrant(t *testing.T) {
 	require.Error(t, err, "expected the stale refresh token to be rejected")
 	assert.Contains(t, err.Error(), "invalid_grant")
 	assert.Contains(t, err.Error(), "invalid refresh token")
+}
+
+// mintPrefixScopedToken produces the shape of credential an issuer actually
+// hands a user: WLCG read+write scopes on a *prefix*, not on one object.
+func mintPrefixScopedToken(t *testing.T, jwkKey jwk.Key, issuer, prefix string) string {
+	t.Helper()
+
+	tc, err := token.NewTokenConfig(token.WlcgProfile{})
+	require.NoError(t, err)
+	tc.Lifetime = time.Hour
+	tc.Issuer = issuer
+	tc.Subject = "test-user"
+	tc.AddAudienceAny()
+	tc.AddResourceScopes(
+		token_scopes.NewResourceScope(token_scopes.Wlcg_Storage_Read, prefix),
+		token_scopes.NewResourceScope(token_scopes.Wlcg_Storage_Modify, prefix),
+		token_scopes.NewResourceScope(token_scopes.Wlcg_Storage_Create, prefix),
+	)
+
+	tokBytes, err := tc.CreateTokenWithKey(jwkKey)
+	require.NoError(t, err)
+	return string(tokBytes)
+}
+
+// TestCopyTokenOperationsAcceptPrefixScopedTokens pins the operations a
+// third-party copy asks for.  The copy job used to ask for TokenSharedRead /
+// TokenSharedWrite, which demand a scope naming the object exactly; against an
+// ordinary prefix-scoped credential every copy then logged "Using provided
+// token ... even though it does not appear to be acceptable to perform
+// transfer" and transferred anyway.  See issue #3663.
+func TestCopyTokenOperationsAcceptPrefixScopedTokens(t *testing.T) {
+	issuerURL, err := url.Parse("https://issuer.example")
+	require.NoError(t, err)
+
+	dirResp := server_structs.DirectorResponse{
+		XPelNsHdr: server_structs.XPelNs{Namespace: "/foo"},
+		XPelTokGenHdr: server_structs.XPelTokGen{
+			Issuers:   []*url.URL{issuerURL},
+			BasePaths: []string{"/foo"},
+		},
+	}
+
+	tkn := mintPrefixScopedToken(t, createTestJWK(t), "https://issuer.example", "/data")
+	const object = "/foo/data/sub/object.txt"
+
+	t.Run("source operation accepts a prefix-scoped token", func(t *testing.T) {
+		assert.True(t, tokenIsAcceptable(tkn, object, dirResp,
+			config.TokenGenerationOpts{Operation: copySourceTokenOperation}))
+	})
+
+	t.Run("destination operation accepts a prefix-scoped token", func(t *testing.T) {
+		assert.True(t, tokenIsAcceptable(tkn, object, dirResp,
+			config.TokenGenerationOpts{Operation: copyDestinationTokenOperation}))
+	})
+
+	// The regression itself: the share-flavored operations reject exactly the
+	// credential the copy was handed, which is what produced the warning.
+	t.Run("share operations still demand an exact scope", func(t *testing.T) {
+		assert.False(t, tokenIsAcceptable(tkn, object, dirResp,
+			config.TokenGenerationOpts{Operation: config.TokenSharedRead}))
+		assert.False(t, tokenIsAcceptable(tkn, object, dirResp,
+			config.TokenGenerationOpts{Operation: config.TokenSharedWrite}))
+	})
+}
+
+// TestUnacceptableTokenWarnsOnce covers the second half of the noise in issue
+// #3663: when the generator does fall back to a credential it cannot vouch for,
+// it says so once rather than once per file.  Get() used to clear the cache on
+// every call for such a credential, which re-ran the whole on-disk token search
+// and re-emitted the warning each time.
+func TestUnacceptableTokenWarnsOnce(t *testing.T) {
+	issuerURL, err := url.Parse("https://issuer.example")
+	require.NoError(t, err)
+
+	dirResp := server_structs.DirectorResponse{
+		XPelNsHdr: server_structs.XPelNs{Namespace: "/foo", RequireToken: true},
+		XPelTokGenHdr: server_structs.XPelTokGen{
+			Issuers:   []*url.URL{issuerURL},
+			BasePaths: []string{"/foo"},
+		},
+	}
+
+	// Scoped to a sibling prefix, so it is unacceptable for the object below
+	// under any operation -- which is the case the fallback exists for.
+	tkn := mintPrefixScopedToken(t, createTestJWK(t), "https://issuer.example", "/elsewhere")
+
+	tokenPath := filepath.Join(t.TempDir(), "bearer_token")
+	require.NoError(t, os.WriteFile(tokenPath, []byte(tkn), 0600))
+
+	// The iterator walks the ambient discovery locations after the explicit
+	// one; clear them so a credential belonging to whoever is running the
+	// tests cannot join the search.
+	for _, envVar := range []string{"BEARER_TOKEN", "BEARER_TOKEN_FILE", "TOKEN", "XDG_RUNTIME_DIR", "_CONDOR_CREDS"} {
+		t.Setenv(envVar, "")
+		require.NoError(t, os.Unsetenv(envVar))
+	}
+
+	hook := captureDebugLogs(t)
+
+	tg := newTokenGenerator(&pelican_url.PelicanURL{Path: "/foo/data/object.txt"}, &dirResp,
+		copyDestinationTokenOperation, true)
+	tg.SetTokenLocation(tokenPath)
+
+	for i := 0; i < 3; i++ {
+		contents, err := tg.Get()
+		require.NoError(t, err)
+		assert.Equal(t, tkn, contents, "the fallback credential is handed back on every call")
+	}
+
+	var warnings int
+	for _, entry := range entriesAtLevel(hook.AllEntries(), logrus.WarnLevel) {
+		if strings.Contains(entry.Message, "does not appear to be acceptable") {
+			warnings++
+		}
+	}
+	assert.Equal(t, 1, warnings, "the unacceptable-credential warning must be said once, not once per call")
 }

--- a/client/handle_http.go
+++ b/client/handle_http.go
@@ -2433,6 +2433,21 @@ func (tc *TransferClient) NewPrestageJob(ctx context.Context, remoteUrl *url.URL
 	return
 }
 
+// The token operations a third-party copy asks for.
+//
+// A copy reads the source and writes the destination exactly the way a get and
+// a put do, so it asks for the same two operations they do.  The Shared*
+// variants are for `pelican object share`: they demand a credential whose
+// scope names the object *exactly* and they suppress the issuer's scope-depth
+// narrowing.  Asking for those here made every ordinary user credential -- one
+// scoped to a prefix, which is what an issuer hands out -- look unacceptable,
+// so a copy warned "Using provided token ... even though it does not appear to
+// be acceptable to perform transfer" and then used it anyway, once per file.
+const (
+	copySourceTokenOperation      = config.TokenRead
+	copyDestinationTokenOperation = config.TokenWrite
+)
+
 // Create a new third-party copy job for the client.
 //
 // This creates a transfer that uses the HTTP COPY verb to instruct the
@@ -2484,12 +2499,12 @@ func (tc *TransferClient) NewCopyJob(ctx context.Context, src *url.URL, dest *ur
 		xferType:          transferTypeCopy,
 		uuid:              id,
 		project:           project,
-		token:             NewTokenGenerator(&copyDestUrl, nil, config.TokenSharedWrite, !tc.skipAcquire),
+		token:             NewTokenGenerator(&copyDestUrl, nil, copyDestinationTokenOperation, !tc.skipAcquire),
 	}
 	tj.fedToken = tc.fedToken
 	tj.cacheMode = tc.cacheMode
 	tj.srcURL = src
-	tj.srcToken = NewTokenGenerator(&copySrcUrl, nil, config.TokenSharedRead, !tc.skipAcquire)
+	tj.srcToken = NewTokenGenerator(&copySrcUrl, nil, copySourceTokenOperation, !tc.skipAcquire)
 	if tc.token != "" {
 		tj.token.SetToken(tc.token)
 		tj.srcToken.SetToken(tc.token)

--- a/client/handle_http_copy.go
+++ b/client/handle_http_copy.go
@@ -41,6 +41,26 @@ import (
 	"github.com/pelicanplatform/pelican/error_codes"
 )
 
+// summarizeCopyFailure renders a destination server's error body as a single
+// line fit to carry on an error value.
+//
+// The body is remote text: bounded by maxErrorBodySize on the way in and by
+// truncateErrorDetail here, and flattened to one line so a multi-line body
+// cannot spread itself across log records.  XRootD prefixes its COPY failures
+// with "failure: ", which adds nothing once the message already says the copy
+// failed, so that prefix is dropped.  Everything else is passed through as the
+// server wrote it -- guessing at which half of the sentence matters is how the
+// useful half gets thrown away.
+func summarizeCopyFailure(body []byte) string {
+	detail := strings.TrimSpace(string(body))
+	if detail == "" {
+		return ""
+	}
+	detail = strings.Join(strings.Fields(detail), " ")
+	detail = strings.TrimSpace(strings.TrimPrefix(detail, "failure:"))
+	return truncateErrorDetail(detail)
+}
+
 // tpcStatus represents a status update from a third-party-copy transfer
 type tpcStatus struct {
 	err     error
@@ -273,8 +293,16 @@ func copyHTTP(xfer *transferFile) (transferResults TransferResults, err error) {
 				err = newThrottleErrorFromResponse(resp, string(respBytes), resolvedDestUrl.Host)
 			} else {
 				log.Errorf("TPC COPY to %s failed (HTTP status %d): %q", resolvedDestUrl.String(), resp.StatusCode, string(respBytes))
-				err = &HttpErrResp{Code: resp.StatusCode, Str: fmt.Sprintf("TPC COPY failed (HTTP status %d)",
-					resp.StatusCode), Err: statusErr}
+				// The destination's own words are the only part of this that
+				// says *why* the copy was refused -- "is a directory", "no
+				// space left", "permission denied".  Without them the caller
+				// is left with a bare status code and has to go digging
+				// through the log for the line above.
+				str := fmt.Sprintf("TPC COPY to %s failed (HTTP status %d)", resolvedDestUrl.String(), resp.StatusCode)
+				if detail := summarizeCopyFailure(respBytes); detail != "" {
+					str = fmt.Sprintf("%s: %s", str, detail)
+				}
+				err = &HttpErrResp{Code: resp.StatusCode, Str: str, Err: statusErr}
 			}
 		}
 		return

--- a/client/http_copy_test.go
+++ b/client/http_copy_test.go
@@ -151,3 +151,33 @@ func TestMonitorTPC(t *testing.T) {
 		assert.NoError(t, msg.err)
 	})
 }
+
+// TestSummarizeCopyFailure covers what a destination's refusal looks like by
+// the time it reaches the caller.  Before issue #3663 the body was logged and
+// then dropped, leaving the user with a bare "TPC COPY failed (HTTP status
+// 409)" and no way to learn that the destination they named is a collection.
+func TestSummarizeCopyFailure(t *testing.T) {
+	t.Run("carries the destination's reason", func(t *testing.T) {
+		body := []byte("failure: Unable to create /ospool/ap40/data/user/tpc2; is a directory, " +
+			"local=/ospool/ap40/data/user/tpc2, remote=https://dtn.example:8443/ospool/ap40/data/user/tpc1/file")
+		got := summarizeCopyFailure(body)
+		assert.Contains(t, got, "is a directory")
+		assert.False(t, strings.HasPrefix(got, "failure:"),
+			"XRootD's \"failure:\" prefix adds nothing to a message that already says the copy failed")
+	})
+
+	t.Run("flattens a multi-line body to one line", func(t *testing.T) {
+		got := summarizeCopyFailure([]byte("  first line\n\tsecond line\n\n"))
+		assert.Equal(t, "first line second line", got)
+	})
+
+	t.Run("bounds a hostile body", func(t *testing.T) {
+		got := summarizeCopyFailure([]byte(strings.Repeat("A", 4096)))
+		assert.Less(t, len(got), 4096, "a remote peer must not choose how long the error message is")
+	})
+
+	t.Run("says nothing when the body is empty", func(t *testing.T) {
+		assert.Empty(t, summarizeCopyFailure(nil))
+		assert.Empty(t, summarizeCopyFailure([]byte("   \n ")))
+	})
+}

--- a/cmd/object_copy.go
+++ b/cmd/object_copy.go
@@ -30,6 +30,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -103,6 +104,19 @@ the client should fallback to discovered caches if all preferred caches fail.`)
 		flagSet.String("dest-origin", "", "Use the transfer service at the given destination origin URL (pings it first to verify availability)")
 		objectCmd.AddCommand(copyCmd)
 	}
+}
+
+// inferCopyObjectName joins the base name of a copy source onto a remote
+// collection URL.  A copy source is either a local path or a remote URL, and
+// the base name has to come off whichever one it is: `path.Base` on a URL so a
+// query string does not end up in the object name, `filepath.Base` on a local
+// path so a Windows separator is honored.
+func inferCopyObjectName(destURL *url.URL, source string) (string, error) {
+	srcURL, err := url.Parse(source)
+	if err == nil && pelican_url.IsPelicanScheme(srcURL.Scheme) {
+		return joinInferredObjectName(destURL, path.Base(srcURL.Path), source)
+	}
+	return joinInferredObjectName(destURL, filepath.Base(source), source)
 }
 
 func copyMain(cmd *cobra.Command, args []string) {
@@ -387,7 +401,18 @@ func copyMain(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	if len(source) > 1 {
+	isRecursive, _ := cmd.Flags().GetBool("recursive")
+	multipleObjects := len(source) > 1
+
+	// The destination decides which of the two checks below applies: a local
+	// destination is stat'ed on the filesystem, a remote one through the
+	// federation.  The local stat used to run for every destination, which
+	// made `copy A B osdf:///coll/` fail with "Destination does not exist"
+	// about a path that was never meant to be local.
+	destURL, destParseErr := url.Parse(dest)
+	destIsRemote := destParseErr == nil && pelican_url.IsPelicanScheme(destURL.Scheme)
+
+	if multipleObjects && !destIsRemote {
 		if destStat, err := os.Stat(dest); err != nil {
 			log.Errorln("Destination does not exist")
 			os.Exit(1)
@@ -397,14 +422,73 @@ func copyMain(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	// `client.DoCopy` also enables recursion from a `?recursive` query
+	// parameter, so the destination has to be consulted for it here too: a
+	// recursive copy lays entries flat under the destination collection (rows
+	// G5/P6 of docs/object-transfer-semantics.md) and must not take the
+	// name-inference branch.
+	packRequested := false
+	if destParseErr == nil {
+		destQuery := destURL.Query()
+		if _, exists := destQuery[pelican_url.QueryRecursive]; exists {
+			isRecursive = true
+		}
+		packRequested = destQuery.Get(pelican_url.QueryPack) != ""
+	}
+
+	// Pre-flight a remote destination once, outside the source loop, the same
+	// way `object put` does for row P3-cli.  Without it, copying an object
+	// onto an existing collection reaches the destination origin as a write to
+	// the collection itself, and the user gets back whatever that origin says
+	// about it -- for XRootD, an HTTP 409 whose "is a directory" lives only in
+	// the response body.  Naming the object after the source is both what `cp`
+	// does and what the destination can actually accept.
+	//
+	// A stat failure is soft (row P10): a namespace may grant writes without
+	// listings, and the copy has to keep working there.  Several sources mean
+	// the destination is a container whether or not the stat can say so.
+	canInferNames := destIsRemote && !isRecursive && !packRequested
+	destIsCollection := canInferNames && multipleObjects
+	if canInferNames {
+		// The pre-flight is a convenience: it must never block a scripted
+		// copy on an interactive token acquisition, and it has to be told
+		// this is a write destination so that --dest-token applies and the
+		// Director hands back origins rather than caches.
+		statOptions := append([]client.TransferOption{
+			client.WithStatUploadDestination(true),
+			client.WithAcquireToken(false),
+		}, tokenOpts...)
+
+		statInfo, statErr := client.DoStat(ctx, dest, statOptions...)
+		if statErr != nil {
+			if !errors.Is(statErr, client.ErrObjectNotFound) {
+				log.Debugf("Stat of destination %q failed (%v); using the destination as given", dest, statErr)
+			}
+		} else if statInfo != nil {
+			destIsCollection = statInfo.IsCollection
+		}
+	}
+
 	var result error
 	lastSrc := ""
 
 	for _, src := range source {
-		isRecursive, _ := cmd.Flags().GetBool("recursive")
+		actualDest := dest
+		if destIsCollection {
+			inferredDest, err := inferCopyObjectName(destURL, src)
+			if err != nil {
+				log.Errorln("Failed to infer destination object name:", err)
+				result = err
+				lastSrc = src
+				break
+			}
+			actualDest = inferredDest
+			log.Debugf("Inferred destination for %s: %s", src, actualDest)
+		}
+
 		options := append([]client.TransferOption{client.WithCallback(pb.callback), client.WithCaches(caches...),
 			client.WithRejectCollections(!isRecursive)}, tokenOpts...)
-		_, result = client.DoCopy(ctx, src, dest, isRecursive, options...)
+		_, result = client.DoCopy(ctx, src, actualDest, isRecursive, options...)
 		if result != nil {
 			lastSrc = src
 			break

--- a/cmd/object_copy_test.go
+++ b/cmd/object_copy_test.go
@@ -1,0 +1,169 @@
+//go:build client && !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/client"
+	"github.com/pelicanplatform/pelican/config"
+	"github.com/pelicanplatform/pelican/fed_test_utils"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/test_utils"
+)
+
+// copyTPCOriginCfg is an authenticated POSIXv2 origin that advertises Copies,
+// so `object copy` between two URLs in it takes the third-party-copy path.
+const copyTPCOriginCfg = `
+Origin:
+  StorageType: "posixv2"
+  EnableDirectReads: true
+  Exports:
+    - FederationPrefix: /test/tpc
+      Capabilities: ["Reads", "Writes", "DirectReads", "Listings", "Copies"]
+`
+
+// TestInferCopyObjectName covers the destination rewrite `object copy` applies
+// when the destination names an existing collection (row C3 of
+// docs/object-transfer-semantics.md).  A copy source may be either a local path
+// or a remote URL, and the object name has to be read off whichever it is.
+func TestInferCopyObjectName(t *testing.T) {
+	destURL, err := url.Parse("osdf:///ospool/ap40/data/user/tpc2/?directread")
+	require.NoError(t, err)
+
+	t.Run("appends the basename of a remote source", func(t *testing.T) {
+		got, err := inferCopyObjectName(destURL, "osdf:///ospool/ap40/data/user/tpc1/testfile640MB")
+		require.NoError(t, err)
+		assert.Equal(t, "osdf:///ospool/ap40/data/user/tpc2/testfile640MB?directread", got)
+	})
+
+	t.Run("ignores a query string on the remote source", func(t *testing.T) {
+		// A '?directread' on the source is a transfer instruction, not part
+		// of the object's name.
+		got, err := inferCopyObjectName(destURL, "pelican://example.org/ns/file.txt?directread")
+		require.NoError(t, err)
+		assert.Equal(t, "osdf:///ospool/ap40/data/user/tpc2/file.txt?directread", got)
+	})
+
+	t.Run("appends the basename of a local source", func(t *testing.T) {
+		got, err := inferCopyObjectName(destURL, "/data/local/upload.txt")
+		require.NoError(t, err)
+		assert.Equal(t, "osdf:///ospool/ap40/data/user/tpc2/upload.txt?directread", got)
+	})
+
+	for _, source := range []string{"osdf:///ospool/data/..", "..", ".", "/", ""} {
+		t.Run(fmt.Sprintf("refuses %q", source), func(t *testing.T) {
+			// path.Join cleans its result, so a ".." here would resolve to
+			// the parent of the collection the caller named.
+			_, err := inferCopyObjectName(destURL, source)
+			require.Error(t, err, "a source with no object name to infer must be refused")
+			assert.Contains(t, err.Error(), "cannot infer a remote object name")
+		})
+	}
+}
+
+// TestObjectCopyToCollectionInfersObjectName drives the CLI end to end for the
+// case reported in issue #3663: a third-party copy whose destination names an
+// existing collection.  Before the fix the copy reached the destination origin
+// as a write to the collection itself and came back as a bare HTTP 409.
+//
+// copyMain reports failure with os.Exit, so only the success path can be
+// asserted through rootCmd; the refusals live in TestInferCopyObjectName.
+func TestObjectCopyToCollectionInfersObjectName(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+
+	fed := fed_test_utils.NewFedTest(t, copyTPCOriginCfg)
+	require.NotNil(t, fed)
+	require.Len(t, fed.Exports, 1)
+
+	// The origin contacts itself over a local hostname that resolves to a
+	// private address; the SSRF dialer is exercised on its own in
+	// config/ssrf_transport_test.go.
+	require.NoError(t, param.Server_SSRFProtection_Disabled.Set(true))
+	config.ResetSSRFTransportForTest()
+	require.NoError(t, param.Logging_Client_DisableProgressBars.Set(true))
+
+	tokenFile, _ := getTempTokenForTest(t)
+	t.Cleanup(func() {
+		tokenFile.Close()
+		os.Remove(tokenFile.Name())
+	})
+
+	prefix := fed.Exports[0].FederationPrefix
+	discoveryUrl, err := url.Parse(param.Federation_DiscoveryUrl.GetString())
+	require.NoError(t, err)
+	host := discoveryUrl.Host
+
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetContext(context.TODO())
+		// Cobra copies the root's context onto a subcommand only while the
+		// subcommand's own is nil, so copyCmd would otherwise pin this
+		// test's cancelled context for every later test in the package.
+		copyCmd.SetContext(nil)
+	})
+
+	const content = "third-party copy into a collection"
+	localFile := filepath.Join(t.TempDir(), "testfile.txt")
+	require.NoError(t, os.WriteFile(localFile, []byte(content), 0644))
+
+	// Seed a source object, and an unrelated object under the destination
+	// prefix so that the destination exists as a collection.  The seeding goes
+	// through the library rather than `object put`, so this test does not leave
+	// its (soon cancelled) context pinned on putCmd for the rest of the
+	// package -- cobra copies the root's context onto a subcommand only while
+	// the subcommand's own is nil.
+	sourceURL := fmt.Sprintf("pelican://%s%s/src/testfile.txt", host, prefix)
+	_, err = client.DoPut(fed.Ctx, localFile, sourceURL, false, client.WithTokenLocation(tokenFile.Name()))
+	require.NoError(t, err)
+	_, err = client.DoPut(fed.Ctx, localFile, fmt.Sprintf("pelican://%s%s/dst/seed.txt", host, prefix), false,
+		client.WithTokenLocation(tokenFile.Name()))
+	require.NoError(t, err)
+
+	// The reported command line: a copy whose destination is the collection.
+	destCollection := fmt.Sprintf("pelican://%s%s/dst/", host, prefix)
+	rootCmd.SetContext(fed.Ctx)
+	copyCmd.SetContext(fed.Ctx)
+	rootCmd.SetArgs([]string{"object", "copy", "-t", tokenFile.Name(), sourceURL, destCollection})
+	require.NoError(t, rootCmd.Execute())
+	rootCmd.SetArgs(nil)
+
+	// The object must land under the collection, named after the source.
+	inferred := fmt.Sprintf("pelican://%s%s/dst/testfile.txt", host, prefix)
+	downloadPath := filepath.Join(t.TempDir(), "downloaded.txt")
+	_, err = client.DoGet(fed.Ctx, inferred, downloadPath, false, client.WithTokenLocation(tokenFile.Name()))
+	require.NoError(t, err, "the copy must land at dst/basename(source), not on the collection itself")
+
+	downloaded, err := os.ReadFile(downloadPath)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(downloaded))
+}

--- a/cmd/object_put.go
+++ b/cmd/object_put.go
@@ -142,18 +142,25 @@ func verifyFileChecksum(filePath, expectedChecksum string, alg client.ChecksumTy
 // inferRemoteObjectName joins the base name of a local source onto a remote
 // collection URL, producing the per-source destination used by rows P3, P8,
 // and P9 of docs/object-transfer-semantics.md.
+func inferRemoteObjectName(destURL *url.URL, localSource string) (string, error) {
+	return joinInferredObjectName(destURL, filepath.Base(localSource), localSource)
+}
+
+// joinInferredObjectName joins an already-extracted object name onto a remote
+// collection URL.  `object copy` infers names from remote sources too, where
+// the base name comes off a URL path rather than a filesystem path, so the
+// join and its guard live apart from the extraction.
 //
 // The base name is validated rather than trusted.  path.Join cleans its
 // result, so a source named "/data/tree/.." would otherwise resolve to the
 // parent of the collection the caller asked for and upload there without
 // saying so.  Refusing is the only safe answer: there is no object name to
 // infer, and the caller has to name the destination object explicitly.
-func inferRemoteObjectName(destURL *url.URL, localSource string) (string, error) {
-	name := filepath.Base(localSource)
+func joinInferredObjectName(destURL *url.URL, name, source string) (string, error) {
 	if name == "" || name == "." || name == ".." || name == string(filepath.Separator) ||
 		strings.ContainsAny(name, `/\`) {
-		return "", errors.Errorf("cannot infer a remote object name from local source %q; "+
-			"name the destination object explicitly", localSource)
+		return "", errors.Errorf("cannot infer a remote object name from source %q; "+
+			"name the destination object explicitly", source)
 	}
 
 	inferred := *destURL

--- a/docs/object-transfer-semantics.md
+++ b/docs/object-transfer-semantics.md
@@ -1,6 +1,6 @@
-# `pelican object get` / `put`: source/destination semantics
+# `pelican object get` / `put` / `copy`: source/destination semantics
 
-This note captures how the client library and CLI handle the cartesian product of {single vs. multiple sources} × {file vs. collection} × {recursive vs. not} for downloads (`get`) and uploads (`put`). It exists so future contributors have a single place to look when reasoning about "did I break someone's script?", and so the regression tests have a written contract to assert against.
+This note captures how the client library and CLI handle the cartesian product of {single vs. multiple sources} × {file vs. collection} × {recursive vs. not} for downloads (`get`), uploads (`put`), and copies (`copy`, including the third-party copy where both ends are remote). It exists so future contributors have a single place to look when reasoning about "did I break someone's script?", and so the regression tests have a written contract to assert against.
 
 If you change any of the behaviors below, please:
 
@@ -12,7 +12,7 @@ If you change any of the behaviors below, please:
 
 - **Collection** — a "directory" in the pelican namespace. The wire format is WebDAV; the storage backend calls them collections, so we do too. On the filesystem side, "directory" is synonymous.
 - **Object** — a "file" in the pelican namespace (a leaf).
-- **Recursive** — `--recursive` (`-r`) on the CLI, or the `recursive` bool parameter on `client.DoGet` / `client.DoPut`. Also settable via the `?recursive` query parameter on the URL.
+- **Recursive** — `--recursive` (`-r`) on the CLI, or the `recursive` bool parameter on `client.DoGet` / `client.DoPut` / `client.DoCopy`. Also settable via the `?recursive` query parameter on the URL.
 - **Container target** — a destination path that names a container: an existing local directory (for `get`), or an existing remote collection (for `put`). For **non-recursive** single-object transfers, a container target triggers *filename inference* (source basename joined onto the destination). For **recursive** transfers, entries land **flat** under the destination — the source basename is NOT interposed. This follows the layout agreed for `pelican object sync` in discussion [#1638](https://github.com/orgs/PelicanPlatform/discussions/1638), where syncing a collection into a local directory puts its entries directly in that directory, and syncing a local directory to a namespace prefix puts its files directly under that prefix: recursive transfers are `rsync`-flavored (`rsync -a src/ dst/`), not `cp -r`-flavored.
 
 ## `pelican object get REMOTE [REMOTE...] LOCAL`
@@ -100,13 +100,56 @@ It also runs with `client.WithStatUploadDestination(true)` and `client.WithAcqui
 
 **Caveat:** a namespace that grants writes but no `listings` cannot answer the pre-flight at all, so `put ./file.txt REMOTE_COLLECTION` still fails there with `already exists` (row P2). Row P3-cli holds only where the destination can be stat'ed.
 
+## `pelican object copy {SOURCE ...} DESTINATION`
+
+`copy` picks its direction from the URL schemes rather than from the subcommand name:
+
+| Source | Destination | What runs                                                                                                                                                                                                                              |
+| ------ | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| local  | remote      | `client.DoPut` — rows P1-P10 apply unchanged.                                                                                                                                                                                          |
+| remote | local       | `client.DoGet` — rows G1-G10 apply unchanged.                                                                                                                                                                                          |
+| remote | remote      | **Third-party copy**: the destination origin is told (WebDAV `COPY`) to pull from the source. No object bytes pass through the client; the source credential is handed to the destination in the `TransferHeaderAuthorization` header. |
+
+The rows below are the ones `cmd/object_copy.go` adds on top of that, and they apply to every **remote** destination — the put direction and the third-party one alike, since the destination side of the question is the same either way.
+
+### Single source, `--recursive=false`
+
+| #      | Remote destination            | Behavior                                                                                                                                                                                                                        |
+| ------ | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| C1     | a non-existent remote path    | Copied as-is (destination is treated as the target object URL).                                                                                                                                                                 |
+| C2     | an existing remote object     | Whatever the destination origin answers for a write over an existing object — `already exists` for a Pelican origin.                                                                                                            |
+| C3-cli | an existing remote collection | Object name inferred by the CLI (`cmd/object_copy.go` pre-flights the destination with `client.DoStat`): copied to `DEST/basename(SOURCE)`. Symmetric with P3-cli and G2, and named off the URL path when the source is remote. |
+| C3-lib | an existing remote collection | `client.DoCopy` infers nothing and surfaces the destination's refusal. Symmetric with P3-lib: the inference is a CLI affordance, not a library one.                                                                             |
+
+Row C3-cli is [issue #3663](https://github.com/PelicanPlatform/pelican/issues/3663). Without it, `copy REMOTE_OBJECT REMOTE_COLLECTION/` reaches the destination origin as a write to the collection itself, and the user gets back an HTTP 409 whose reason ("is a directory") lives only in the response body. The copy path now also carries that body onto the error value, so a destination that refuses for some *other* reason says so in the line the CLI prints rather than only in the log above it.
+
+### Single source, `--recursive=true`
+
+| #   | Behavior                                                                                                                                                                     |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| C4  | Entries land **flat** under the destination collection, exactly as in G5/P6. The name inference is skipped entirely so the layout cannot pick up a `cp -r`-flavored nesting. |
+
+As with put, recursion is read from `?recursive` on the destination as well as from `-r`, since `client.DoCopy` honors both.
+
+### Multiple sources
+
+| #   | Remote destination | Behavior                                                                                                                                                              |
+| --- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| C5  | any                | Treated as a container: each source is copied to `DEST/basename(SOURCE_i)`, the same rule as P8/P9. A stat that cannot answer does not change this (soft, as in P10). |
+
+The local multi-source destination check (`Destination does not exist` / `Destination is not a collection`) now runs **only for a local destination**. It used to run for every destination, so `copy A B osdf:///coll/` failed with `Destination does not exist` about a path that was never meant to be local.
+
+### Credentials
+
+A third-party copy asks for the same two token operations a get and a put do: `config.TokenRead` for the source and `config.TokenWrite` for the destination (`copySourceTokenOperation` / `copyDestinationTokenOperation` in `client/handle_http.go`). It must **not** ask for the `Shared*` variants — those back `pelican object share`, demand a scope naming the object exactly, and suppress the issuer's scope-depth narrowing, so an ordinary prefix-scoped credential looks unacceptable and every copy warns `Using provided token ... even though it does not appear to be acceptable to perform transfer` before using it anyway. That was the other half of issue #3663.
+
 ## Design principles the matrix follows
 
 - **`get` and `put` are symmetric for object/collection type checks.** The library catches the "source type mismatched with recursive flag" cases (G4 / P4); the CLI catches "multi-source needs a container destination" (G8-G10 / P8-P10).
 - **Non-recursive single-object transfers into a container-typed destination infer the name.** G2 follows `cp` / `scp` for the "singular object into an already existing container (that tab-completion filled in for me)" gesture granted for the download direction in discussion [#1638](https://github.com/orgs/PelicanPlatform/discussions/1638). P3-cli is the upload converse, which that discussion flagged as an error; it is allowed here per issue [#2946](https://github.com/PelicanPlatform/pelican/issues/2946), because the error users actually got — `remote object already exists` naming a collection they were not writing to — reads as a false statement about their own filename. The change is confined to the CLI: `client.DoPut` still errors (P3-lib), so no library caller silently acquires the new behavior.
 - **Recursive transfers into a container are `rsync`-flavored, not `cp -r`-flavored.** G5 and P6 both lay entries flat under the destination — the source basename is NOT interposed. This is the layout agreed for `pelican object sync` in discussion [#1638](https://github.com/orgs/PelicanPlatform/discussions/1638); `get -r` / `put -r` inherit the same rule so that `object sync` and library callers (`client_agent`, embedders) see one consistent layout.
 - **The library never invents container creation semantics that could surprise a scripting user.** `?recursive` and `--recursive` are the explicit opt-in for walking or expanding directory-typed sources; when absent, a directory source is a client-side error rather than a silent success or a strange partial upload. Both spellings must be read wherever recursion changes the layout, since `client.DoPut` and `client.DoGet` honor the query parameter regardless of the boolean they were passed.
-- **An inferred name is validated, never just joined.** `path.Join` cleans its result, so a source basename of `..` would resolve to the parent of the collection the caller named and upload there without saying so. `cmd/object_put.go` refuses such a source instead of rewriting it.
+- **An inferred name is validated, never just joined.** `path.Join` cleans its result, so a source basename of `..` would resolve to the parent of the collection the caller named and upload there without saying so. `cmd/object_put.go` and `cmd/object_copy.go` refuse such a source instead of rewriting it.
 - **Pre-flight stats fail soft on the put side, hard on the get side.** For put, a stat failure does not imply the put will fail (write-only tokens, no `listings`), so the pre-flight logs at debug and falls through. For non-recursive get, non-`ErrObjectNotFound` stat failures propagate — the G4 decision cannot be made without knowing whether the source is a collection, and guessing wrong corrupts the local layout. Recursive get skips the stat entirely (no G4 check needed since the walker handles both shapes).
 
 ## Where the code lives
@@ -117,17 +160,23 @@ It also runs with `client.WithStatUploadDestination(true)` and `client.WithAcqui
 - `client.DoPut` (in `client/main.go`) — library-level put, including the P4 "local source is a directory but recursive is false" guard.
 - `cmd/object_get.go` — CLI wrapper for get. Adds the multi-source destination checks (rows G8-G10).
 - `cmd/object_put.go` — CLI wrapper for put. Pre-flights the destination with a single `client.DoStat` outside the source loop, then rewrites the per-source destination for P3-cli/P8/P9 only, via `inferRemoteObjectName`. Recursive uploads skip the rewrite so P6 stays flat. Stat failures are soft (row P10).
+- `client.DoCopy` (in `client/main.go`) — library-level copy. Dispatches to `DoPut`, `DoGet`, or `doThirdPartyCopy` by scheme.
+- `client.TransferClient.NewCopyJob` (in `client/handle_http.go`) — builds the two token generators a third-party copy needs, from `copySourceTokenOperation` and `copyDestinationTokenOperation`.
+- `cmd/object_copy.go` — CLI wrapper for copy. Adds the C-rows: the remote-destination pre-flight and the `inferCopyObjectName` rewrite (C3-cli/C5), and scopes the local multi-source check to local destinations.
 
 ## Where the tests live
 
 Subtests are named after the row IDs above, so a failure points directly at a documented expectation. Coverage is split by where the behavior is implemented:
 
-| Test                                                                   | Rows covered                                                                                                   |
-| ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `cmd/object_transfer_semantics_test.go`: `TestObjectTransferSemantics` | G1-G6, P1, P2, P3-lib, P4, P5, P6 — the library-level rows, against one POSIXv2-backed federation              |
-| `cmd/object_put_test.go`: `TestObjectPutSemanticsCLI`                  | P3-cli, P6 (via `?recursive`, and with several sources), P8, P9, P10 — the rows `cmd/object_put.go` implements |
-| `cmd/object_put_test.go`: `TestInferRemoteObjectName`                  | The destination rewrite in isolation, including the sources it refuses                                         |
-| `cmd/object_put_test.go`: `TestObjectPutToDirectoryInfersFilename`     | P3-cli end to end through an authenticated XRootD-backed origin                                                |
+| Test                                                                              | Rows covered                                                                                                   |
+| --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `cmd/object_transfer_semantics_test.go`: `TestObjectTransferSemantics`            | G1-G6, P1, P2, P3-lib, P4, P5, P6 — the library-level rows, against one POSIXv2-backed federation              |
+| `cmd/object_put_test.go`: `TestObjectPutSemanticsCLI`                             | P3-cli, P6 (via `?recursive`, and with several sources), P8, P9, P10 — the rows `cmd/object_put.go` implements |
+| `cmd/object_put_test.go`: `TestInferRemoteObjectName`                             | The destination rewrite in isolation, including the sources it refuses                                         |
+| `cmd/object_put_test.go`: `TestObjectPutToDirectoryInfersFilename`                | P3-cli end to end through an authenticated XRootD-backed origin                                                |
+| `cmd/object_copy_test.go`: `TestInferCopyObjectName`                              | The copy destination rewrite in isolation, for both local and remote sources, including the sources it refuses |
+| `cmd/object_copy_test.go`: `TestObjectCopyToCollectionInfersObjectName`           | C3-cli end to end: a third-party copy into an existing collection through an authenticated POSIXv2 origin      |
+| `client/acquire_token_test.go`: `TestCopyTokenOperationsAcceptPrefixScopedTokens` | That a copy's token operations accept an ordinary prefix-scoped credential, and that the `Shared*` ones do not |
 
 Rows **G7**, **G8**, **G9**, **G10**, and **P7** are documented but not yet asserted anywhere; G9 and G10 are `os.Exit` paths in `cmd/object_get.go`, which cannot be driven through `rootCmd` in-process. Adding coverage for them is welcome.
 


### PR DESCRIPTION
Fixes #3663

Two UX problems @matyasselmeci hit while testing third-party copy (OPS-536).

## 1. "Using provided token ... even though it does not appear to be acceptable"

`NewCopyJob` built its two token generators with `config.TokenSharedRead` / `config.TokenSharedWrite`. Those operations exist to back `pelican object share`: they demand a credential whose scope names the object **exactly**, and they suppress the issuer's scope-depth narrowing. Every credential an issuer actually hands out is scoped to a *prefix*, so it never matched — and the generator's "the user knows better" fallback then used it anyway, after warning. That is why the warning fired even when the credentials were named explicitly with `--source-token` / `--dest-token`.

A copy reads the source and writes the destination exactly the way a get and a put do, so it now asks for `TokenRead` / `TokenWrite`, named as `copySourceTokenOperation` / `copyDestinationTokenOperation` so a future change has to say what it means.

The *repetition* had a second cause, fixed alongside: `Get()` clears the cache whenever the credential it holds is judged unacceptable, so the whole on-disk token search re-ran — and re-warned — once per file. It never reached the acquire branch that clearing exists to force, because the fallback returns first, so it was re-walking every token location to reach the same answer. The warning is now said once per generator, and that fallback is not re-litigated (reset when a new director response arrives, since a new authorization picture deserves a fresh verdict).

## 2. The destination-is-a-collection error was buried

This command reached the destination origin as a write to the collection itself:

```
pelican object copy $prefix/tpc1/testfile640MB $prefix/tpc2/
```

XRootD answers that with a 409 whose reason lives only in the response body, so the line that named the failure was just `TPC COPY failed (HTTP status 409): Specification Error: Error code 5000: destination COPY returned HTTP 409` — with "is a directory" nowhere in it.

Two changes:

- `cmd/object_copy.go` now pre-flights a remote destination with one `client.DoStat` outside the source loop — the same affordance `object put` already has (row P3-cli) — and copies to `DEST/basename(SOURCE)` when the destination names a collection, or when several sources were given. The name comes off the URL path for a remote source and off the filesystem path for a local one; either way it is validated rather than joined, so a source of `..` cannot redirect the copy to the collection's parent. Recursive copies and `?pack` skip the rewrite so their layouts are unchanged, and a stat that cannot answer is soft (write-only tokens, namespaces without `listings`).
- When a COPY *is* refused, the destination's own words now ride on the error instead of appearing only in a log line above it.

While here: the multi-source `Destination does not exist` check ran `os.Stat` on **every** destination, so `copy A B osdf:///coll/` failed with a complaint about a local path that was never meant to be local. It now runs only for a local destination.

## Docs

`docs/object-transfer-semantics.md` gains a `copy` section (rows C1–C5) plus a note on which token operations a third-party copy asks for, per that document's own "update this when you change behavior" rule. The generated command reference under `docs/app` is unchanged — no flags moved — hence `no-docs-required`.

## Testing

New unit tests: the copy token operations against a prefix-scoped credential (and that the `Shared*` ones still reject it), the warn-once behavior, `summarizeCopyFailure`, and `inferCopyObjectName`. The warn-once test was confirmed to fail (3 warnings) with the fix reverted.

New end-to-end CLI test `TestObjectCopyToCollectionInfersObjectName` drives the exact reported command line through a POSIXv2 federation; reverting the inference makes it fail with the 409.

Locally: full `./client/` passes, the `./cmd/` transfer-semantics tests pass, and `origin_serve` `TestTPCWithPOSIXv2` / `TestTPCWithXRootD` pass. `TestTPCCrossOrigin` fails on my Mac — identically on `origin/main` with the same environment (the second origin's sqlite migration `20260812000000_global_unique_username.sql` hits a UNIQUE constraint on `users.username`), so it is unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
