### PR TITLE
Fail a third-party copy whose stream ends without a success or failure verdict

### DIFF
--- a/client/handle_http_copy.go
+++ b/client/handle_http_copy.go
@@ -406,6 +406,11 @@ func monitorTPC(ctx context.Context, messages chan tpcStatus, body io.Reader) er
 	curStripe := 0
 	curStripeBytes := uint64(0)
 	var err error
+	// The WLCG spec ends the stream with exactly one verdict line, "success:"
+	// or "failure:".  Perf markers are optional; the verdict is not.  Its
+	// absence is tracked rather than assumed benign -- see the check after the
+	// loop for why.
+	sawVerdict := false
 Listener:
 	for scanner.Scan() {
 		text := scanner.Text()
@@ -440,8 +445,10 @@ Listener:
 			switch key {
 			case "failure":
 				err = errors.Errorf("TPC copy failed: %s", value)
+				sawVerdict = true
 				break Listener
 			case "success":
+				sawVerdict = true
 				break Listener
 			case "Stripe Index":
 				idx, pErr := strconv.Atoi(value)
@@ -468,6 +475,23 @@ Listener:
 	}
 	if err == nil {
 		err = scanner.Err()
+	}
+	// Falling out of the loop with no verdict and no read error means the
+	// destination closed the stream cleanly without ever saying how the copy
+	// went.  That is not a success: the client is not in the data path, so the
+	// verdict line is the only thing that ever reports one.  Treating silence
+	// as success reported a completed transfer -- with the source's full byte
+	// count attached, since TransferredBytes comes from the source HEAD -- for
+	// a copy that may have moved nothing at all, and exited 0.
+	//
+	// A body truncated mid-chunk does not land here: the transport surfaces
+	// that as an unexpected-EOF read error, which scanner.Err() reports above.
+	// This is the clean-close case -- a destination whose TPC handler exits
+	// without writing a verdict, or an intermediary that ends the stream
+	// early but properly.
+	if err == nil && !sawVerdict {
+		err = errors.New("the destination ended the third-party-copy stream without reporting success or failure; " +
+			"the copy cannot be assumed to have completed")
 	}
 	select {
 	case messages <- tpcStatus{

--- a/client/http_copy_test.go
+++ b/client/http_copy_test.go
@@ -139,8 +139,51 @@ func TestMonitorTPC(t *testing.T) {
 		}
 	})
 
+	// A destination that says nothing at all has not reported a successful
+	// copy.  This used to be read as success -- the caller got a completed
+	// transfer, carrying the source's byte count, and exited 0.
 	t.Run("EmptyBody", func(t *testing.T) {
 		body := strings.NewReader("")
+
+		messages := make(chan tpcStatus, 1)
+		err := monitorTPC(context.Background(), messages, body)
+		require.NoError(t, err)
+
+		msg := <-messages
+		assert.True(t, msg.done)
+		require.Error(t, msg.err, "a stream carrying no verdict must not be reported as a successful copy")
+		assert.Contains(t, msg.err.Error(), "without reporting success or failure")
+	})
+
+	// The dangerous shape: real progress markers, so the transfer looks alive
+	// and the byte counts land, and then the stream simply stops.
+	t.Run("PerfMarkersThenSilence", func(t *testing.T) {
+		body := strings.NewReader(
+			"Perf Marker\n" +
+				"Stripe Index: 0\n" +
+				"Stripe Bytes Transferred: 1024\n" +
+				"Total Stripe Count: 1\n" +
+				"End\n",
+		)
+
+		messages := make(chan tpcStatus, 2)
+		err := monitorTPC(context.Background(), messages, body)
+		require.NoError(t, err)
+
+		msg1 := <-messages
+		assert.Equal(t, uint64(1024), msg1.xferred)
+		assert.False(t, msg1.done)
+
+		msg2 := <-messages
+		assert.True(t, msg2.done)
+		require.Error(t, msg2.err, "progress markers are not a verdict; only \"success:\" is")
+		assert.Contains(t, msg2.err.Error(), "without reporting success or failure")
+	})
+
+	// The verdict is what decides the outcome, not the presence of markers:
+	// a bare "success:" with no perf markers at all is still a success.
+	t.Run("SuccessWithoutPerfMarkers", func(t *testing.T) {
+		body := strings.NewReader("success: Created\n")
 
 		messages := make(chan tpcStatus, 1)
 		err := monitorTPC(context.Background(), messages, body)


### PR DESCRIPTION
Found while answering a question on #3685 about whether any of that PR's fixes changed an exit code. They did not — but this does.

## The bug

The WLCG TPC protocol ends the COPY response body with exactly one verdict line, `success:` or `failure:`. Perf markers are optional; the verdict is not.

`monitorTPC` only treated `failure:` as an error. A stream that ended without *either* line fell out of the scan loop, `scanner.Err()` returned nil at clean EOF, and it emitted `tpcStatus{err: nil, done: true}` — which the consumer's `if msg.err != nil || msg.done` reads exactly like success. `pelican object copy` printed no error and **exited 0**.

The byte count made it worse. On success `transferResults.TransferredBytes` is set from `totalSize`, which is the `Content-Length` of the HEAD against the *source*. A copy that moved nothing reported the full expected size.

Nothing else catches it. The client is not in the data path, so the verdict line is the only report of an outcome that ever arrives. Checksum verification is not a backstop either: it runs only when the source served `Digest` headers, a failure to fetch the destination's checksums is a warning, and a mismatch is fatal only under `requireChecksum`.

## The fix

`monitorTPC` tracks whether a verdict arrived and synthesizes an error when the stream ends without one.

A body truncated mid-chunk does **not** reach that check — the transport surfaces it as an unexpected-EOF read error and `scanner.Err()` already reports it. The case this closes is a clean close with no verdict: a destination whose TPC handler dies without writing one (a panic through gin's recovery, say), or an intermediary that ends the stream early but properly.

## Blast radius

Both server implementations I can check always write a verdict, so no working copy changes behavior:

- XRootD's TPC module.
- Pelican's own `origin_serve/tpc_handler.go` — every terminal path emits one, including the slow-transfer cancel, the size-mismatch check, and the commit-failure path.

## Deliberately not changed

- **`TransferredBytes` reporting the source's expected size.** With a verdict now required, `err == nil` means the destination explicitly affirmed success, and perf markers are optional — a server that emits none would report 0 bytes if this preferred the marker count. Moot for the bug above, and changing it risks worse statistics for a real case.
- **The checksum-verification holes** (soft dest-checksum fetch, mismatch fatal only under `requireChecksum`). Those are policy questions about when a mismatch should sink a transfer, and deserve their own issue and review rather than riding along here.

## Testing

`TestMonitorTPC/EmptyBody` asserted the old reading — that a destination saying nothing at all is a success. It now asserts the opposite. Two subtests added:

- `PerfMarkersThenSilence` — the dangerous shape: real progress markers, so the transfer looks alive and the byte counts land, and then the stream simply stops.
- `SuccessWithoutPerfMarkers` — pins that it is the verdict, not the markers, that decides the outcome.

`./client/ -run TestMonitorTPC` and `origin_serve` `TestTPCWithPOSIXv2` / `TestTPCWithXRootD` pass locally.

## Note for the reviewer

This branch is off `main` and does not depend on #3685, though both touch `client/handle_http_copy.go` in different places. No issue is linked yet, so the second `validate-pr` gate will fail until one is — happy to file one, or link it to whatever you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
