### PR TITLE
Generate tag-gated CLI reference docs to fix check-go-generate

### DIFF
--- a/docs/app/commands-reference/pelican-server/cache/introspect/consistency/page.mdx
+++ b/docs/app/commands-reference/pelican-server/cache/introspect/consistency/page.mdx
@@ -17,10 +17,10 @@ Use --metadata-only or --data-only to run only one scan type.
 The data scan is expensive as it reads and checksums every cached file.
 
 Example:
-  pelican cache introspect consistency
-  pelican cache introspect consistency --metadata-only
-  pelican cache introspect consistency --data-only
-  pelican cache introspect consistency --json
+  pelican-server cache introspect consistency
+  pelican-server cache introspect consistency --metadata-only
+  pelican-server cache introspect consistency --data-only
+  pelican-server cache introspect consistency --json
 
 ```
 pelican-server cache introspect consistency [flags]

--- a/docs/app/commands-reference/pelican-server/cache/introspect/disk-usage/page.mdx
+++ b/docs/app/commands-reference/pelican-server/cache/introspect/disk-usage/page.mdx
@@ -14,8 +14,8 @@ This is an EXPENSIVE operation that stats every file in the cache's
 storage directories. For large caches this may take significant time.
 
 Example:
-  pelican cache introspect disk-usage
-  pelican cache introspect disk-usage --json
+  pelican-server cache introspect disk-usage
+  pelican-server cache introspect disk-usage --json
 
 ```
 pelican-server cache introspect disk-usage [flags]

--- a/docs/app/commands-reference/pelican-server/cache/introspect/etags/page.mdx
+++ b/docs/app/commands-reference/pelican-server/cache/introspect/etags/page.mdx
@@ -14,8 +14,8 @@ The object URL should be a pelican:// or osdf:// URL, or a bare path
 if the federation context is known.
 
 Example:
-  pelican cache introspect etags pelican://my-federation/data/file.dat
-  pelican cache introspect etags /data/file.dat
+  pelican-server cache introspect etags pelican://my-federation/data/file.dat
+  pelican-server cache introspect etags /data/file.dat
 
 ```
 pelican-server cache introspect etags <object-url> [flags]

--- a/docs/app/commands-reference/pelican-server/cache/introspect/list/page.mdx
+++ b/docs/app/commands-reference/pelican-server/cache/introspect/list/page.mdx
@@ -21,10 +21,10 @@ Warning: For large caches, this may return many results. Use --limit
 to restrict the number of entries returned.
 
 Examples:
-  pelican cache introspect list
-  pelican cache introspect list '/chtc/staging/**'
-  pelican cache introspect list '*.bin'
-  pelican cache introspect list --limit=50 'pelican://origin.example.com/data/*'
+  pelican-server cache introspect list
+  pelican-server cache introspect list '/chtc/staging/**'
+  pelican-server cache introspect list '*.bin'
+  pelican-server cache introspect list --limit=50 'pelican://origin.example.com/data/*'
 
 ```
 pelican-server cache introspect list [pattern] [flags]

--- a/docs/app/commands-reference/pelican-server/cache/introspect/metadata/page.mdx
+++ b/docs/app/commands-reference/pelican-server/cache/introspect/metadata/page.mdx
@@ -14,9 +14,9 @@ By default shows the latest cached version. Use --etag to specify
 a particular version, or --instance to specify by instance hash.
 
 Example:
-  pelican cache introspect metadata pelican://my-federation/data/file.dat
-  pelican cache introspect metadata /data/file.dat --etag="abc123"
-  pelican cache introspect metadata --instance=&lt;hash&gt;
+  pelican-server cache introspect metadata pelican://my-federation/data/file.dat
+  pelican-server cache introspect metadata /data/file.dat --etag="abc123"
+  pelican-server cache introspect metadata --instance=&lt;hash&gt;
 
 ```
 pelican-server cache introspect metadata <object-url> [flags]

--- a/docs/app/commands-reference/pelican-server/cache/introspect/stats/page.mdx
+++ b/docs/app/commands-reference/pelican-server/cache/introspect/stats/page.mdx
@@ -15,8 +15,8 @@ entries, total bytes claimed by metadata, and per-storage-directory
 breakdown. This is a cheap operation that only scans metadata.
 
 Example:
-  pelican cache introspect stats
-  pelican cache introspect stats --json
+  pelican-server cache introspect stats
+  pelican-server cache introspect stats --json
 
 ```
 pelican-server cache introspect stats [flags]

--- a/docs/app/commands-reference/pelican-server/cache/introspect/verify/page.mdx
+++ b/docs/app/commands-reference/pelican-server/cache/introspect/verify/page.mdx
@@ -14,8 +14,8 @@ This reads the entire object from disk, decrypts it, and verifies
 that stored checksums (if any) match the actual data.
 
 Example:
-  pelican cache introspect verify pelican://my-federation/data/file.dat
-  pelican cache introspect verify /data/file.dat --etag="abc123"
+  pelican-server cache introspect verify pelican://my-federation/data/file.dat
+  pelican-server cache introspect verify /data/file.dat --etag="abc123"
 
 ```
 pelican-server cache introspect verify <object-url> [flags]

--- a/docs/app/commands-reference/pelican-server/origin/_meta.js
+++ b/docs/app/commands-reference/pelican-server/origin/_meta.js
@@ -1,7 +1,10 @@
 export default {
     "collection": "pelican-server origin collection",
     "config": "pelican-server origin config",
+    "introspect": "pelican-server origin introspect",
     "issuer": "pelican-server origin issuer",
+    "object-metadata": "pelican-server origin object-metadata",
+    "pstore": "pelican-server origin pstore",
     "serve": "pelican-server origin serve",
     "token": "pelican-server origin token",
     "web-ui": "pelican-server origin web-ui",

--- a/docs/app/commands-reference/pelican-server/origin/introspect/_meta.js
+++ b/docs/app/commands-reference/pelican-server/origin/introspect/_meta.js
@@ -1,0 +1,6 @@
+export default {
+    "digest": "pelican-server origin introspect digest",
+    "ls": "pelican-server origin introspect ls",
+    "stat": "pelican-server origin introspect stat",
+    "usage": "pelican-server origin introspect usage",
+}

--- a/docs/app/commands-reference/pelican-server/origin/introspect/digest/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/introspect/digest/page.mdx
@@ -1,0 +1,34 @@
+---
+title: pelican server origin introspect digest
+---
+
+## pelican-server origin introspect digest
+
+Show an object's recorded checksums from the running origin
+
+```
+pelican-server origin introspect digest <path> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for digest
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.config/pelican/pelican.yaml)
+  -d, --debug               Enable debug log messages
+  -f, --federation string   Pelican federation to utilize
+      --json                Emit raw JSON instead of a table
+  -L, --log string          Specified log output file
+      --server string       Origin web URL (defaults to this host's Server.ExternalWebUrl)
+  -t, --token string        Path to admin token file (auto-generated from the local issuer key if not provided)
+      --version             Print the version and exit
+```
+
+### SEE ALSO
+
+* [pelican-server origin introspect](/commands-reference/pelican-server/origin/introspect/)	 - Inspect a running origin's storage backend

--- a/docs/app/commands-reference/pelican-server/origin/introspect/ls/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/introspect/ls/page.mdx
@@ -1,0 +1,35 @@
+---
+title: pelican server origin introspect ls
+---
+
+## pelican-server origin introspect ls
+
+List a directory in the running origin's store
+
+```
+pelican-server origin introspect ls [path] [flags]
+```
+
+### Options
+
+```
+  -h, --help        help for ls
+      --limit int   Maximum entries to return per request (default 1000)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.config/pelican/pelican.yaml)
+  -d, --debug               Enable debug log messages
+  -f, --federation string   Pelican federation to utilize
+      --json                Emit raw JSON instead of a table
+  -L, --log string          Specified log output file
+      --server string       Origin web URL (defaults to this host's Server.ExternalWebUrl)
+  -t, --token string        Path to admin token file (auto-generated from the local issuer key if not provided)
+      --version             Print the version and exit
+```
+
+### SEE ALSO
+
+* [pelican-server origin introspect](/commands-reference/pelican-server/origin/introspect/)	 - Inspect a running origin's storage backend

--- a/docs/app/commands-reference/pelican-server/origin/introspect/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/introspect/page.mdx
@@ -1,0 +1,57 @@
+---
+title: pelican server origin introspect
+---
+
+## pelican-server origin introspect
+
+Inspect a running origin's storage backend
+
+### Synopsis
+
+Inspect the storage backend of an origin that is currently running.
+
+These commands ask the origin over its administrative API, so they work while
+it is serving. They are the live counterpart to "pelican-server origin pstore", which
+reads the store directly and therefore requires the origin to be stopped.
+
+CURRENTLY PSTORE ONLY. The endpoints these use exist only when the origin is
+configured with Origin.StorageType "pstore"; against any other backend the
+origin does not register them and these commands report that plainly. A POSIX
+origin's storage can be inspected with ordinary filesystem tools, which is why
+it has no equivalent.
+
+Consistency checking is deliberately absent here. Scanning an index while it is
+being written produces findings indistinguishable from real problems, so
+"pelican-server origin pstore fsck" remains an offline command.
+
+These commands authenticate to the origin as an administrator. Run on the
+origin host, no token is needed: a short-lived admin token is minted locally
+with the origin's issuer key. Elsewhere -- or when that key is not readable --
+pass --token pointing at a file holding an administrator token.
+
+### Options
+
+```
+  -h, --help            help for introspect
+      --json            Emit raw JSON instead of a table
+      --server string   Origin web URL (defaults to this host's Server.ExternalWebUrl)
+  -t, --token string    Path to admin token file (auto-generated from the local issuer key if not provided)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.config/pelican/pelican.yaml)
+  -d, --debug               Enable debug log messages
+  -f, --federation string   Pelican federation to utilize
+  -L, --log string          Specified log output file
+      --version             Print the version and exit
+```
+
+### SEE ALSO
+
+* [pelican-server origin](/commands-reference/pelican-server/origin/)	 - Operate a Pelican origin service
+* [pelican-server origin introspect digest](/commands-reference/pelican-server/origin/introspect/digest/)	 - Show an object's recorded checksums from the running origin
+* [pelican-server origin introspect ls](/commands-reference/pelican-server/origin/introspect/ls/)	 - List a directory in the running origin's store
+* [pelican-server origin introspect stat](/commands-reference/pelican-server/origin/introspect/stat/)	 - Show an object's metadata from the running origin
+* [pelican-server origin introspect usage](/commands-reference/pelican-server/origin/introspect/usage/)	 - Report how much of the store is in use

--- a/docs/app/commands-reference/pelican-server/origin/introspect/stat/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/introspect/stat/page.mdx
@@ -1,0 +1,34 @@
+---
+title: pelican server origin introspect stat
+---
+
+## pelican-server origin introspect stat
+
+Show an object's metadata from the running origin
+
+```
+pelican-server origin introspect stat <path> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for stat
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.config/pelican/pelican.yaml)
+  -d, --debug               Enable debug log messages
+  -f, --federation string   Pelican federation to utilize
+      --json                Emit raw JSON instead of a table
+  -L, --log string          Specified log output file
+      --server string       Origin web URL (defaults to this host's Server.ExternalWebUrl)
+  -t, --token string        Path to admin token file (auto-generated from the local issuer key if not provided)
+      --version             Print the version and exit
+```
+
+### SEE ALSO
+
+* [pelican-server origin introspect](/commands-reference/pelican-server/origin/introspect/)	 - Inspect a running origin's storage backend

--- a/docs/app/commands-reference/pelican-server/origin/introspect/usage/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/introspect/usage/page.mdx
@@ -1,0 +1,34 @@
+---
+title: pelican server origin introspect usage
+---
+
+## pelican-server origin introspect usage
+
+Report how much of the store is in use
+
+```
+pelican-server origin introspect usage [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for usage
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.config/pelican/pelican.yaml)
+  -d, --debug               Enable debug log messages
+  -f, --federation string   Pelican federation to utilize
+      --json                Emit raw JSON instead of a table
+  -L, --log string          Specified log output file
+      --server string       Origin web URL (defaults to this host's Server.ExternalWebUrl)
+  -t, --token string        Path to admin token file (auto-generated from the local issuer key if not provided)
+      --version             Print the version and exit
+```
+
+### SEE ALSO
+
+* [pelican-server origin introspect](/commands-reference/pelican-server/origin/introspect/)	 - Inspect a running origin's storage backend

--- a/docs/app/commands-reference/pelican-server/origin/object-metadata/_meta.js
+++ b/docs/app/commands-reference/pelican-server/origin/object-metadata/_meta.js
@@ -1,0 +1,5 @@
+export default {
+    "get": "pelican-server origin object-metadata get",
+    "history": "pelican-server origin object-metadata history",
+    "list": "pelican-server origin object-metadata list",
+}

--- a/docs/app/commands-reference/pelican-server/origin/object-metadata/get/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/object-metadata/get/page.mdx
@@ -1,0 +1,37 @@
+---
+title: pelican server origin object metadata get
+---
+
+## pelican-server origin object-metadata get
+
+Get one object's live row (and optional history)
+
+```
+pelican-server origin object-metadata get [flags]
+```
+
+### Options
+
+```
+  -h, --help               help for get
+      --history int        If >0, also include the most recent N history rows
+      --namespace string   Federation prefix of the object (required)
+      --path string        Federation-rooted path of the object (required)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.config/pelican/pelican.yaml)
+  -d, --debug               Enable debug log messages
+  -f, --federation string   Pelican federation to utilize
+      --json                output results in JSON format
+  -L, --log string          Specified log output file
+  -s, --server string       Web URL of the Pelican origin (e.g. https://my-origin.com:8447)
+  -t, --token string        Path to the admin token file
+      --version             Print the version and exit
+```
+
+### SEE ALSO
+
+* [pelican-server origin object-metadata](/commands-reference/pelican-server/origin/object-metadata/)	 - Inspect the origin's local object-metadata tracking database

--- a/docs/app/commands-reference/pelican-server/origin/object-metadata/history/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/object-metadata/history/page.mdx
@@ -1,0 +1,37 @@
+---
+title: pelican server origin object metadata history
+---
+
+## pelican-server origin object-metadata history
+
+List the full history for one object
+
+```
+pelican-server origin object-metadata history [flags]
+```
+
+### Options
+
+```
+  -h, --help               help for history
+      --limit int          Maximum rows (capped at 1000) (default 100)
+      --namespace string   Federation prefix of the object (required)
+      --path string        Federation-rooted path of the object (required)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.config/pelican/pelican.yaml)
+  -d, --debug               Enable debug log messages
+  -f, --federation string   Pelican federation to utilize
+      --json                output results in JSON format
+  -L, --log string          Specified log output file
+  -s, --server string       Web URL of the Pelican origin (e.g. https://my-origin.com:8447)
+  -t, --token string        Path to the admin token file
+      --version             Print the version and exit
+```
+
+### SEE ALSO
+
+* [pelican-server origin object-metadata](/commands-reference/pelican-server/origin/object-metadata/)	 - Inspect the origin's local object-metadata tracking database

--- a/docs/app/commands-reference/pelican-server/origin/object-metadata/list/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/object-metadata/list/page.mdx
@@ -1,0 +1,37 @@
+---
+title: pelican server origin object metadata list
+---
+
+## pelican-server origin object-metadata list
+
+List live (non-deleted) objects in a namespace
+
+```
+pelican-server origin object-metadata list [flags]
+```
+
+### Options
+
+```
+  -h, --help               help for list
+      --limit int          Maximum rows per page (capped at 1000) (default 100)
+      --namespace string   Federation prefix to list (required)
+      --offset int         Pagination offset
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.config/pelican/pelican.yaml)
+  -d, --debug               Enable debug log messages
+  -f, --federation string   Pelican federation to utilize
+      --json                output results in JSON format
+  -L, --log string          Specified log output file
+  -s, --server string       Web URL of the Pelican origin (e.g. https://my-origin.com:8447)
+  -t, --token string        Path to the admin token file
+      --version             Print the version and exit
+```
+
+### SEE ALSO
+
+* [pelican-server origin object-metadata](/commands-reference/pelican-server/origin/object-metadata/)	 - Inspect the origin's local object-metadata tracking database

--- a/docs/app/commands-reference/pelican-server/origin/object-metadata/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/object-metadata/page.mdx
@@ -1,0 +1,46 @@
+---
+title: pelican server origin object metadata
+---
+
+## pelican-server origin object-metadata
+
+Inspect the origin's local object-metadata tracking database
+
+### Synopsis
+
+Query the origin's local SQLite-backed object-metadata tracking layer.
+
+This is a thin client over the origin's admin endpoints under
+/api/v1.0/origin_ui/object_metadata. All subcommands require an
+administrative token for the target origin (the same one
+'pelican downtime' uses); pass it with --token or let the CLI
+generate one from the origin's signing key when invoked locally.
+
+Object-metadata tracking must be enabled on the origin
+(Origin.Metadata.TrackAccess) for these endpoints to return data.
+
+### Options
+
+```
+  -h, --help            help for object-metadata
+  -s, --server string   Web URL of the Pelican origin (e.g. https://my-origin.com:8447)
+  -t, --token string    Path to the admin token file
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.config/pelican/pelican.yaml)
+  -d, --debug               Enable debug log messages
+  -f, --federation string   Pelican federation to utilize
+      --json                output results in JSON format
+  -L, --log string          Specified log output file
+      --version             Print the version and exit
+```
+
+### SEE ALSO
+
+* [pelican-server origin](/commands-reference/pelican-server/origin/)	 - Operate a Pelican origin service
+* [pelican-server origin object-metadata get](/commands-reference/pelican-server/origin/object-metadata/get/)	 - Get one object's live row (and optional history)
+* [pelican-server origin object-metadata history](/commands-reference/pelican-server/origin/object-metadata/history/)	 - List the full history for one object
+* [pelican-server origin object-metadata list](/commands-reference/pelican-server/origin/object-metadata/list/)	 - List live (non-deleted) objects in a namespace

--- a/docs/app/commands-reference/pelican-server/origin/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/page.mdx
@@ -28,7 +28,10 @@ Operate a Pelican origin service
 * [pelican-server](/commands-reference/pelican-server/)	 - Interact with data federations
 * [pelican-server origin collection](/commands-reference/pelican-server/origin/collection/)	 - Manage collections on a Pelican origin
 * [pelican-server origin config](/commands-reference/pelican-server/origin/config/)	 - Launch the Pelican web service in configuration mode
+* [pelican-server origin introspect](/commands-reference/pelican-server/origin/introspect/)	 - Inspect a running origin's storage backend
 * [pelican-server origin issuer](/commands-reference/pelican-server/origin/issuer/)	 - Manage the origin's embedded OIDC token issuer
+* [pelican-server origin object-metadata](/commands-reference/pelican-server/origin/object-metadata/)	 - Inspect the origin's local object-metadata tracking database
+* [pelican-server origin pstore](/commands-reference/pelican-server/origin/pstore/)	 - Inspect and repair a Pelican store
 * [pelican-server origin serve](/commands-reference/pelican-server/origin/serve/)	 - Start the origin service
 * [pelican-server origin token](/commands-reference/pelican-server/origin/token/)	 - Manage Pelican origin tokens
 * [pelican-server origin web-ui](/commands-reference/pelican-server/origin/web-ui/)	 - Manage the Pelican origin web UI

--- a/docs/app/commands-reference/pelican-server/origin/pstore/_meta.js
+++ b/docs/app/commands-reference/pelican-server/origin/pstore/_meta.js
@@ -1,0 +1,11 @@
+export default {
+    "digest": "pelican-server origin pstore digest",
+    "du": "pelican-server origin pstore du",
+    "export": "pelican-server origin pstore export",
+    "fsck": "pelican-server origin pstore fsck",
+    "ls": "pelican-server origin pstore ls",
+    "metadata-backup": "pelican-server origin pstore metadata-backup",
+    "metadata-backup-key": "pelican-server origin pstore metadata-backup-key",
+    "metadata-restore": "pelican-server origin pstore metadata-restore",
+    "stat": "pelican-server origin pstore stat",
+}

--- a/docs/app/commands-reference/pelican-server/origin/pstore/digest/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/pstore/digest/page.mdx
@@ -1,0 +1,39 @@
+---
+title: pelican server origin pstore digest
+---
+
+## pelican-server origin pstore digest
+
+Show the checksums recorded for an object
+
+### Synopsis
+
+Show the checksums computed when the object was written.
+
+These are the values the origin serves in response to Want-Digest.
+
+```
+pelican-server origin pstore digest <path> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for digest
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.config/pelican/pelican.yaml)
+  -d, --debug               Enable debug log messages
+  -f, --federation string   Pelican federation to utilize
+      --json                output results in JSON format
+      --location string     Store directory (defaults to Origin.PStoreLocation)
+  -L, --log string          Specified log output file
+      --version             Print the version and exit
+```
+
+### SEE ALSO
+
+* [pelican-server origin pstore](/commands-reference/pelican-server/origin/pstore/)	 - Inspect and repair a Pelican store

--- a/docs/app/commands-reference/pelican-server/origin/pstore/du/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/pstore/du/page.mdx
@@ -1,0 +1,40 @@
+---
+title: pelican server origin pstore du
+---
+
+## pelican-server origin pstore du
+
+Report space used
+
+### Synopsis
+
+Report the space a subtree occupies, and the store's overall usage.
+
+Sizes are object content lengths; the store's total additionally reflects the
+per-block overhead that encrypted blocks carry on disk.
+
+```
+pelican-server origin pstore du [path] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for du
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.config/pelican/pelican.yaml)
+  -d, --debug               Enable debug log messages
+  -f, --federation string   Pelican federation to utilize
+      --json                output results in JSON format
+      --location string     Store directory (defaults to Origin.PStoreLocation)
+  -L, --log string          Specified log output file
+      --version             Print the version and exit
+```
+
+### SEE ALSO
+
+* [pelican-server origin pstore](/commands-reference/pelican-server/origin/pstore/)	 - Inspect and repair a Pelican store

--- a/docs/app/commands-reference/pelican-server/origin/pstore/export/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/pstore/export/page.mdx
@@ -1,0 +1,52 @@
+---
+title: pelican server origin pstore export
+---
+
+## pelican-server origin pstore export
+
+Write objects out as ordinary files
+
+### Synopsis
+
+Export a subtree from the store into a directory of plain files.
+
+This is the recovery path that does not need Pelican running: the objects come
+out as normal files in a normal directory tree, readable with anything.
+
+Objects that cannot be read are reported and skipped rather than aborting the
+export, because recovering most of a damaged store and knowing exactly what was
+lost is more useful than stopping at the first bad block.
+
+An export never overwrites what is already in the destination. Pass --resume to
+continue an interrupted export: files already written are skipped and counted
+separately rather than reported as failures.
+
+```
+pelican-server origin pstore export [path] [flags]
+```
+
+### Options
+
+```
+      --dry-run     Report what would be written without writing it
+  -h, --help        help for export
+      --resume      Skip objects already present in the destination instead of reporting them
+      --to string   Directory to write the exported files into (required)
+      --verify      Check each object against its stored checksums as it is written
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.config/pelican/pelican.yaml)
+  -d, --debug               Enable debug log messages
+  -f, --federation string   Pelican federation to utilize
+      --json                output results in JSON format
+      --location string     Store directory (defaults to Origin.PStoreLocation)
+  -L, --log string          Specified log output file
+      --version             Print the version and exit
+```
+
+### SEE ALSO
+
+* [pelican-server origin pstore](/commands-reference/pelican-server/origin/pstore/)	 - Inspect and repair a Pelican store

--- a/docs/app/commands-reference/pelican-server/origin/pstore/fsck/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/pstore/fsck/page.mdx
@@ -1,0 +1,51 @@
+---
+title: pelican server origin pstore fsck
+---
+
+## pelican-server origin pstore fsck
+
+Check the store's internal consistency
+
+### Synopsis
+
+Check the store for inconsistencies and optionally repair them.
+
+Reports directory entries whose object data is missing, object versions no
+entry refers to, writes that never completed, and usage counters that have
+drifted.
+
+Without --repair nothing is modified. With it, unservable entries are removed,
+orphaned versions are queued for reclamation, and the counters are resynced.
+
+--deep additionally reads every object back and checks it against the
+checksums recorded when it was written. That is the only way to detect at-rest
+corruption -- a flipped bit in a block file -- since every other check reads
+only the catalog. It costs a full pass over the data.
+
+```
+pelican-server origin pstore fsck [flags]
+```
+
+### Options
+
+```
+      --deep     Also read every object back and verify it against its stored checksums
+  -h, --help     help for fsck
+      --repair   Repair the problems found instead of only reporting them
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.config/pelican/pelican.yaml)
+  -d, --debug               Enable debug log messages
+  -f, --federation string   Pelican federation to utilize
+      --json                output results in JSON format
+      --location string     Store directory (defaults to Origin.PStoreLocation)
+  -L, --log string          Specified log output file
+      --version             Print the version and exit
+```
+
+### SEE ALSO
+
+* [pelican-server origin pstore](/commands-reference/pelican-server/origin/pstore/)	 - Inspect and repair a Pelican store

--- a/docs/app/commands-reference/pelican-server/origin/pstore/ls/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/pstore/ls/page.mdx
@@ -1,0 +1,44 @@
+---
+title: pelican server origin pstore ls
+---
+
+## pelican-server origin pstore ls
+
+List a directory in the store
+
+### Synopsis
+
+List the direct children of a directory inside the store.
+
+Examples:
+  pelican-server origin pstore ls /
+  pelican-server origin pstore ls -l /data
+  pelican-server origin pstore ls -R /data
+
+```
+pelican-server origin pstore ls [path] [flags]
+```
+
+### Options
+
+```
+  -h, --help        help for ls
+  -l, --long        Show size, modification time, and ETag
+  -R, --recursive   Descend into subdirectories
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.config/pelican/pelican.yaml)
+  -d, --debug               Enable debug log messages
+  -f, --federation string   Pelican federation to utilize
+      --json                output results in JSON format
+      --location string     Store directory (defaults to Origin.PStoreLocation)
+  -L, --log string          Specified log output file
+      --version             Print the version and exit
+```
+
+### SEE ALSO
+
+* [pelican-server origin pstore](/commands-reference/pelican-server/origin/pstore/)	 - Inspect and repair a Pelican store

--- a/docs/app/commands-reference/pelican-server/origin/pstore/metadata-backup-key/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/pstore/metadata-backup-key/page.mdx
@@ -1,0 +1,88 @@
+---
+title: pelican server origin pstore metadata backup key
+---
+
+## pelican-server origin pstore metadata-backup-key
+
+Print the key that opens this origin's metadata backups, or one file's own key
+
+### Synopsis
+
+Print a metadata backup key. There are two of them, and which one you get
+depends on whether you name a file.
+
+  metadata-backup-key            the BACKUP KEY: opens EVERY metadata backup
+                                 this origin has written or will write
+  metadata-backup-key &lt;file&gt;     that ONE FILE'S KEY: opens exactly the named
+                                 backup and no other
+
+Keys are DERIVED, not generated. The backup key comes from the origin's issuer
+keys, and a file's key comes from the backup key plus a random salt stored in
+that file, so running either form twice prints the same answer. There is nothing
+to create, configure, or lose track of, and metadata backups are always
+encrypted whether or not this command is ever run.
+
+WITHOUT A FILE -- the backup key, for escrow.
+
+Every backup carries this key inside it, sealed to each issuer key that was
+current when the backup was written, so a restore on the origin itself needs
+nothing but those issuer keys. This form exists for when they are gone too. Save
+what it prints somewhere the backups are not, and any backup can still be
+restored on a machine that has never seen this origin:
+
+  pelican-server origin pstore metadata-backup-key > /etc/pelican/pstore-backup.key
+  chmod 600 /etc/pelican/pstore-backup.key
+  pelican-server origin pstore metadata-restore --key-file /etc/pelican/pstore-backup.key &lt;file&gt;
+
+A metadata backup and this key together are equivalent to the store's namespace
+in cleartext, so keep them apart.
+
+WITH A FILE -- that file's own key, for handing out one backup.
+
+Each backup is encrypted under a key of its very own. This form reads the salt
+out of the named file and re-derives that key, using the origin's issuer keys or,
+with --key-file, an escrowed backup key -- so an operator holding only the
+escrowed key can still produce a specific file's key without the issuer keys:
+
+  pelican-server origin pstore metadata-backup-key /backups/pstore-metadata-....pmb
+  pelican-server origin pstore metadata-restore --file-key thatfile.key /backups/pstore-metadata-....pmb
+
+The printed key opens THAT file only. It says nothing about any other backup, so
+it is what to give to whoever is restoring one archive, rather than the backup
+key above.
+
+Rotating the origin's issuer keys changes what the no-file form prints. Backups
+written before the rotation are still opened by the key printed before it, and by
+the issuer keys they were sealed to that survived it -- so re-run this after a
+rotation and keep both.
+
+These keys are specific to pstore metadata backups. They descend from a
+different label than the server database's backup key and will not open a
+database backup.
+
+```
+pelican-server origin pstore metadata-backup-key [backup-file] [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for metadata-backup-key
+      --key-file string   Derive the named file's key from the backup key in this file instead of the origin's issuer keys
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.config/pelican/pelican.yaml)
+  -d, --debug               Enable debug log messages
+  -f, --federation string   Pelican federation to utilize
+      --json                output results in JSON format
+      --location string     Store directory (defaults to Origin.PStoreLocation)
+  -L, --log string          Specified log output file
+      --version             Print the version and exit
+```
+
+### SEE ALSO
+
+* [pelican-server origin pstore](/commands-reference/pelican-server/origin/pstore/)	 - Inspect and repair a Pelican store

--- a/docs/app/commands-reference/pelican-server/origin/pstore/metadata-backup/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/pstore/metadata-backup/page.mdx
@@ -1,0 +1,71 @@
+---
+title: pelican server origin pstore metadata backup
+---
+
+## pelican-server origin pstore metadata-backup
+
+Back up the store's metadata (not its object data)
+
+### Synopsis
+
+Back up the store's metadata to a file.
+
+THIS DOES NOT BACK UP OBJECT DATA. It covers the catalog: the directory tree,
+and each object's size, checksums, and where its blocks live. Restoring it
+gives back the namespace, not the bytes.
+
+An origin cannot re-fetch what it loses. Object data on disk is encrypted and
+named by hash; the namespace, each object's data key, its size, and its
+checksums all live in the catalog, so a store whose catalog is gone is a
+directory of unreadable bytes.
+
+A metadata backup covers the catalog only. Restoring one is useful only
+alongside:
+
+  - the object data, which ordinary filesystem backup tools handle; and
+  - masterkey.json in the store directory, which wraps the encryption key and
+    is itself protected by the origin's issuer keys.
+
+The backup is always encrypted. A snapshot is a logical dump: it holds every
+object path and the salt that keeps on-disk filenames unguessable, so there is
+no option to write one in the clear.
+
+The body is encrypted under a key belonging to this file alone, derived from the
+origin's backup key and a random salt stored in the file. The backup key itself
+travels inside the file, sealed to every issuer key that is current now, so any
+one of them opens it. Pass --key-file to seal it to a backup key of your own
+instead of the origin's issuer keys.
+
+Three things open the finished file: any of those issuer keys, the backup key
+from "pstore metadata-backup-key", or this one file's own key from "pstore
+metadata-backup-key &lt;file&gt;".
+
+Set Origin.PStoreMetadataBackupLocation to have the origin back itself up on a
+timer, which works while it is running. This command is for taking one by hand.
+
+```
+pelican-server origin pstore metadata-backup <file> [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for metadata-backup
+      --key-file string   Seal the backup to the backup key in this file instead of the origin's issuer keys
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.config/pelican/pelican.yaml)
+  -d, --debug               Enable debug log messages
+  -f, --federation string   Pelican federation to utilize
+      --json                output results in JSON format
+      --location string     Store directory (defaults to Origin.PStoreLocation)
+  -L, --log string          Specified log output file
+      --version             Print the version and exit
+```
+
+### SEE ALSO
+
+* [pelican-server origin pstore](/commands-reference/pelican-server/origin/pstore/)	 - Inspect and repair a Pelican store

--- a/docs/app/commands-reference/pelican-server/origin/pstore/metadata-restore/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/pstore/metadata-restore/page.mdx
@@ -1,0 +1,63 @@
+---
+title: pelican server origin pstore metadata restore
+---
+
+## pelican-server origin pstore metadata-restore
+
+Restore a metadata backup into an empty store
+
+### Synopsis
+
+Restore a metadata backup taken by "pstore metadata-backup".
+
+This restores the namespace only. The object data must already be in place --
+a restore into an empty directory produces a store that lists every object and
+can serve none of them.
+
+The target store must be empty: restoring over live records would interleave
+two namespaces rather than replace one. Restore into a fresh directory
+alongside the object data and masterkey.json the backup was taken with, then
+point the origin at it.
+
+Every metadata backup is complete in itself; there are no incremental backups
+to chain, precisely because the target must be empty.
+
+The backup is opened with the origin's issuer keys, so on the origin itself
+nothing more is needed. Elsewhere -- or if those keys are gone -- pass either:
+
+  --key-file  the backup key from "pstore metadata-backup-key", which opens
+              every backup this origin has written; or
+  --file-key  this one file's own key, from "pstore metadata-backup-key &lt;file&gt;",
+              which opens this file and no other.
+
+Which container the file is in is read from the file itself. A backup written
+in a format version this build does not read is refused by version number
+rather than decoded.
+
+```
+pelican-server origin pstore metadata-restore <file> [flags]
+```
+
+### Options
+
+```
+      --file-key metadata-backup-key <file>   Open the backup with this one archive's own key, read from this file (see metadata-backup-key <file>)
+  -h, --help                                  help for metadata-restore
+      --key-file metadata-backup-key          Open the backup with the backup key in this file instead of the origin's issuer keys (see metadata-backup-key)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.config/pelican/pelican.yaml)
+  -d, --debug               Enable debug log messages
+  -f, --federation string   Pelican federation to utilize
+      --json                output results in JSON format
+      --location string     Store directory (defaults to Origin.PStoreLocation)
+  -L, --log string          Specified log output file
+      --version             Print the version and exit
+```
+
+### SEE ALSO
+
+* [pelican-server origin pstore](/commands-reference/pelican-server/origin/pstore/)	 - Inspect and repair a Pelican store

--- a/docs/app/commands-reference/pelican-server/origin/pstore/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/pstore/page.mdx
@@ -1,0 +1,50 @@
+---
+title: pelican server origin pstore
+---
+
+## pelican-server origin pstore
+
+Inspect and repair a Pelican store
+
+### Synopsis
+
+Inspect the contents of an origin backed by the Pelican store ("pstore").
+
+A pstore keeps its namespace in an encrypted database and its objects in
+encrypted block files, so its contents cannot be examined with ordinary
+filesystem tools. These commands read the store directly.
+
+The origin must be stopped: the store holds its directory lock exclusively.
+
+The store location comes from Origin.PStoreLocation, or from --location.
+
+### Options
+
+```
+  -h, --help              help for pstore
+      --location string   Store directory (defaults to Origin.PStoreLocation)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.config/pelican/pelican.yaml)
+  -d, --debug               Enable debug log messages
+  -f, --federation string   Pelican federation to utilize
+      --json                output results in JSON format
+  -L, --log string          Specified log output file
+      --version             Print the version and exit
+```
+
+### SEE ALSO
+
+* [pelican-server origin](/commands-reference/pelican-server/origin/)	 - Operate a Pelican origin service
+* [pelican-server origin pstore digest](/commands-reference/pelican-server/origin/pstore/digest/)	 - Show the checksums recorded for an object
+* [pelican-server origin pstore du](/commands-reference/pelican-server/origin/pstore/du/)	 - Report space used
+* [pelican-server origin pstore export](/commands-reference/pelican-server/origin/pstore/export/)	 - Write objects out as ordinary files
+* [pelican-server origin pstore fsck](/commands-reference/pelican-server/origin/pstore/fsck/)	 - Check the store's internal consistency
+* [pelican-server origin pstore ls](/commands-reference/pelican-server/origin/pstore/ls/)	 - List a directory in the store
+* [pelican-server origin pstore metadata-backup](/commands-reference/pelican-server/origin/pstore/metadata-backup/)	 - Back up the store's metadata (not its object data)
+* [pelican-server origin pstore metadata-backup-key](/commands-reference/pelican-server/origin/pstore/metadata-backup-key/)	 - Print the key that opens this origin's metadata backups, or one file's own key
+* [pelican-server origin pstore metadata-restore](/commands-reference/pelican-server/origin/pstore/metadata-restore/)	 - Restore a metadata backup into an empty store
+* [pelican-server origin pstore stat](/commands-reference/pelican-server/origin/pstore/stat/)	 - Show an object's metadata

--- a/docs/app/commands-reference/pelican-server/origin/pstore/stat/page.mdx
+++ b/docs/app/commands-reference/pelican-server/origin/pstore/stat/page.mdx
@@ -1,0 +1,33 @@
+---
+title: pelican server origin pstore stat
+---
+
+## pelican-server origin pstore stat
+
+Show an object's metadata
+
+```
+pelican-server origin pstore stat <path> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for stat
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.config/pelican/pelican.yaml)
+  -d, --debug               Enable debug log messages
+  -f, --federation string   Pelican federation to utilize
+      --json                output results in JSON format
+      --location string     Store directory (defaults to Origin.PStoreLocation)
+  -L, --log string          Specified log output file
+      --version             Print the version and exit
+```
+
+### SEE ALSO
+
+* [pelican-server origin pstore](/commands-reference/pelican-server/origin/pstore/)	 - Inspect and repair a Pelican store

--- a/docs/app/commands-reference/pelican/object/put/page.mdx
+++ b/docs/app/commands-reference/pelican/object/put/page.mdx
@@ -13,18 +13,21 @@ pelican object put {source ...} {destination} [flags]
 ### Options
 
 ```
-      --async                       Run the transfer asynchronously through the client API server and return a job ID
-      --checksum-algorithm string   Checksum algorithm to use for upload and validation
-      --checksums string            Verify files against a checksums manifest. The format is ALGORITHM:FILENAME
-      --dest-token string           Token file for the destination (overrides --token for writes)
-      --dry-run                     Show what would be uploaded without actually uploading
-  -h, --help                        help for put
-      --pack string                 Package transfer using remote packing functionality (same as '?pack=' query). Options: auto, tar, tar.gz, tar.xz, zip. Default: auto when flag is provided without an explicit value
-  -r, --recursive                   Recursively upload a collection.  Forces methods to only be http to get the freshest collection contents
-      --require-checksum            Require the server to return a checksum for the uploaded file (uses crc32c algorithm if no specific algorithm is specified)
-  -t, --token string                Token file to use for transfer
-      --transfer-stats string       File to write transfer stats to
-      --wait                        When used with --async, wait for the job to complete before returning
+      --async                          Run the transfer asynchronously through the client API server and return a job ID
+      --checksum-algorithm string      Checksum algorithm to use for upload and validation
+      --checksums string               Verify files against a checksums manifest. The format is ALGORITHM:FILENAME
+      --dest-token string              Token file for the destination (overrides --token for writes)
+      --dry-run                        Show what would be uploaded without actually uploading
+  -h, --help                           help for put
+      --metadata-body string           Path to a file holding an opaque metadata blob (e.g. an XML manifest). When supplied, the upload PUT is sent as multipart/form-data and the blob is forwarded to the origin's metadata-publish endpoint byte-for-byte. May be used alongside --metadata-file.
+      --metadata-content-type string   Override the Content-Type of the metadata blob supplied via --metadata-body. Defaults to a value sniffed from the file extension (.xml ⇒ application/xml, .json ⇒ application/json, .yaml/.yml ⇒ application/yaml, .txt ⇒ text/plain, .csv ⇒ text/csv, otherwise application/octet-stream).
+      --metadata-file string           Path to a JSON file whose top-level keys are forwarded to the origin's metadata-publish endpoint via the X-Pelican-Object-Metadata header. Values must be string, number, or boolean. The keys 'path', 'size', 'etag', and 'created_at' are reserved and will be rejected.
+      --pack string                    Package transfer using remote packing functionality (same as '?pack=' query). Options: auto, tar, tar.gz, tar.xz, zip. Default: auto when flag is provided without an explicit value
+  -r, --recursive                      Recursively upload a collection.  Forces methods to only be http to get the freshest collection contents
+      --require-checksum               Require the server to return a checksum for the uploaded file (uses crc32c algorithm if no specific algorithm is specified)
+  -t, --token string                   Token file to use for transfer
+      --transfer-stats string          File to write transfer stats to
+      --wait                           When used with --async, wait for the job to complete before returning
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
PR #3502 extended the "Check Go Generate Has Been Run" workflow to also run `go generate -tags client ./cmd/...` and `go generate -tags server ./cmd/...`. The plain `go generate ./...` invocation never reaches the cmd packages (build constraints exclude their files without those tags), so the generated command-reference pages under docs/app/commands-reference/ were never verified by CI and had silently drifted behind the code. Since #3502 merged, the check fails on main and on every open PR, regardless of the PR's content.

This commit contains only the output of the three generate commands the workflow now runs — no hand-written changes. Regenerating picks up:

- New pages and index entries for the `pelican-server origin introspect`, `object-metadata`, and `pstore` command trees
- The new `--metadata-body`, `--metadata-content-type`, and `--metadata-file` flags on `pelican object put`
- Corrected `pelican-server` command prefixes in the `cache introspect` usage examples

After this lands, re-running the three generate commands produces an empty diff, so the gate goes green again on main and on rebased PRs.