### PR TITLE
Also enable osg-testing for the dev containers, and add comment explaining why

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -543,7 +543,10 @@ RUN --mount=type=bind,from=xrootd-build,source=/xrootd-build,target=/xrootd-buil
     else
       # Non-release builds always install from osg-development -
       # these are the "hot-off-the-press" builds of software.
-      dnf install -y --enablerepo=epel-testing --enablerepo=osg-development ${REPO}-${!VER}
+      # We _also_ need to enable osg-testing, because osg-development
+      # only has the latest version of each package (and we may have an
+      # older one pinned).
+      dnf install -y --enablerepo=epel-testing --enablerepo=osg-development --enablerepo=osg-testing ${REPO}-${!VER}
     fi
   }
 


### PR DESCRIPTION
Fixes a landmine introduced in #3639. osg-development only has the latest version of each package, so if we are pinned to an older version, then only having osg-development enabled will result in an error.