### PR TITLE
Shut down XRootD daemons that stop answering connections

### DIFF
--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -1002,6 +1002,8 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 	v.SetDefault(param.Xrootd_EnableLocalMonitoring.GetName(), true)
 	// Xrootd.HttpMaxDelay
 	v.SetDefault(param.Xrootd_HttpMaxDelay.GetName(), "9s")
+	// Xrootd.LivenessCheckFailureThreshold
+	v.SetDefault(param.Xrootd_LivenessCheckFailureThreshold.GetName(), 3)
 	// Xrootd.LivenessCheckInterval
 	v.SetDefault(param.Xrootd_LivenessCheckInterval.GetName(), "1m")
 	// Xrootd.LivenessCheckTimeout

--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -1002,8 +1002,6 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 	v.SetDefault(param.Xrootd_EnableLocalMonitoring.GetName(), true)
 	// Xrootd.HttpMaxDelay
 	v.SetDefault(param.Xrootd_HttpMaxDelay.GetName(), "9s")
-	// Xrootd.LivenessCheckFailureThreshold
-	v.SetDefault(param.Xrootd_LivenessCheckFailureThreshold.GetName(), 3)
 	// Xrootd.LivenessCheckInterval
 	v.SetDefault(param.Xrootd_LivenessCheckInterval.GetName(), "1m")
 	// Xrootd.LivenessCheckTimeout

--- a/config/parameter_defaults.go
+++ b/config/parameter_defaults.go
@@ -996,10 +996,18 @@ func SetParameterDefaults(v *viper.Viper, isRoot bool, isOSDF bool) {
 	}
 	// Xrootd.DetailedMonitoringPort
 	v.SetDefault(param.Xrootd_DetailedMonitoringPort.GetName(), 9930)
+	// Xrootd.DisableLivenessCheck
+	v.SetDefault(param.Xrootd_DisableLivenessCheck.GetName(), false)
 	// Xrootd.EnableLocalMonitoring
 	v.SetDefault(param.Xrootd_EnableLocalMonitoring.GetName(), true)
 	// Xrootd.HttpMaxDelay
 	v.SetDefault(param.Xrootd_HttpMaxDelay.GetName(), "9s")
+	// Xrootd.LivenessCheckInterval
+	v.SetDefault(param.Xrootd_LivenessCheckInterval.GetName(), "1m")
+	// Xrootd.LivenessCheckTimeout
+	v.SetDefault(param.Xrootd_LivenessCheckTimeout.GetName(), "3m")
+	// Xrootd.LivenessMaxUnresponsiveTime
+	v.SetDefault(param.Xrootd_LivenessMaxUnresponsiveTime.GetName(), "10m")
 	// Xrootd.MacaroonsKeyFile
 	{
 		val := "${ConfigBase}/macaroons-secret"

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -5346,16 +5346,6 @@ default: 1m
 hidden: true
 components: ["cache", "origin"]
 ---
-name: Xrootd.LivenessCheckFailureThreshold
-description: |+
-  The number of consecutive liveness checks that must fail before Pelican will shut XRootD
-  down.  This is a floor rather than the whole condition: `Xrootd.LivenessMaxUnresponsiveTime`
-  must also have elapsed since the last successful check.
-type: int
-default: 3
-hidden: true
-components: ["cache", "origin"]
----
 name: Xrootd.LivenessCheckTimeout
 description: |+
   The maximum amount of time a single XRootD liveness check may take before it is considered
@@ -5370,8 +5360,11 @@ name: Xrootd.LivenessMaxUnresponsiveTime
 description: |+
   How long the local XRootD endpoint may go without a successful liveness check before
   Pelican shuts the daemon down.  The clock starts at the last successful check (or, if no
-  check has ever succeeded, at the time XRootD was launched).  At least
-  `Xrootd.LivenessCheckFailureThreshold` checks must have failed as well.
+  check has ever succeeded, at the time XRootD was launched).
+
+  Because a failed check is retried as soon as `Xrootd.LivenessCheckInterval` allows, this
+  window spans several failed checks at the default timings rather than acting on a single
+  one.
 type: duration
 default: 10m
 hidden: true

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -5316,6 +5316,53 @@ type: duration
 default: 1m
 components: ["cache", "origin"]
 ---
+name: Xrootd.DisableLivenessCheck
+description: |+
+  Disables the periodic liveness check of the locally-launched XRootD daemon.
+
+  Pelican periodically opens a TCP connection to the local XRootD endpoint and waits for
+  XRootD itself to respond.  If XRootD has not responded to any check for
+  `Xrootd.LivenessMaxUnresponsiveTime`, Pelican concludes the daemon is wedged and shuts it
+  down with the usual SIGTERM / wait / SIGKILL sequence, allowing the service manager to
+  restart a working instance.
+
+  Setting this to `true` restores the historical, purely-passive behavior where a hung XRootD
+  is only reported through the health endpoint.
+type: bool
+default: false
+hidden: true
+components: ["cache", "origin"]
+---
+name: Xrootd.LivenessCheckInterval
+description: |+
+  How long Pelican waits between liveness checks of the local XRootD endpoint.
+
+  The wait starts after the previous check finishes, so checks never overlap.
+type: duration
+default: 1m
+hidden: true
+components: ["cache", "origin"]
+---
+name: Xrootd.LivenessCheckTimeout
+description: |+
+  The maximum amount of time a single XRootD liveness check may take before it is considered
+  a failure.  This is deliberately generous: it should only elapse when XRootD is not
+  servicing new connections at all, not when it is merely busy.
+type: duration
+default: 3m
+hidden: true
+components: ["cache", "origin"]
+---
+name: Xrootd.LivenessMaxUnresponsiveTime
+description: |+
+  How long the local XRootD endpoint may go without a successful liveness check before
+  Pelican shuts the daemon down.  The clock starts at the last successful check (or, if no
+  check has ever succeeded, at the time XRootD was launched).
+type: duration
+default: 10m
+hidden: true
+components: ["cache", "origin"]
+---
 name: Xrootd.HttpMaxDelay
 description: |+
   Configures the maximum amount of time the XRootD HTTP layer will continue internal retries

--- a/docs/parameters.yaml
+++ b/docs/parameters.yaml
@@ -5335,11 +5335,24 @@ components: ["cache", "origin"]
 ---
 name: Xrootd.LivenessCheckInterval
 description: |+
-  How long Pelican waits between liveness checks of the local XRootD endpoint.
+  The minimum time between liveness checks of the local XRootD endpoint.
 
-  The wait starts after the previous check finishes, so checks never overlap.
+  Checks never overlap.  After a successful check Pelican waits the full interval before
+  looking again; after a failed one it waits only for the remainder of the interval, so a
+  check that already ran longer than this is retried immediately rather than adding more
+  delay to an XRootD that is already in trouble.
 type: duration
 default: 1m
+hidden: true
+components: ["cache", "origin"]
+---
+name: Xrootd.LivenessCheckFailureThreshold
+description: |+
+  The number of consecutive liveness checks that must fail before Pelican will shut XRootD
+  down.  This is a floor rather than the whole condition: `Xrootd.LivenessMaxUnresponsiveTime`
+  must also have elapsed since the last successful check.
+type: int
+default: 3
 hidden: true
 components: ["cache", "origin"]
 ---
@@ -5357,7 +5370,8 @@ name: Xrootd.LivenessMaxUnresponsiveTime
 description: |+
   How long the local XRootD endpoint may go without a successful liveness check before
   Pelican shuts the daemon down.  The clock starts at the last successful check (or, if no
-  check has ever succeeded, at the time XRootD was launched).
+  check has ever succeeded, at the time XRootD was launched).  At least
+  `Xrootd.LivenessCheckFailureThreshold` checks must have failed as well.
 type: duration
 default: 10m
 hidden: true

--- a/e2e_fed_tests/xrootd_liveness_test.go
+++ b/e2e_fed_tests/xrootd_liveness_test.go
@@ -34,12 +34,14 @@ import (
 )
 
 // livenessConfig shortens the hidden liveness knobs so the monitor reacts within the
-// lifetime of a unit test instead of the ten minutes it allows in production.
+// lifetime of a unit test instead of the ten minutes it allows in production.  The
+// proportions mirror the shipped defaults, so three checks fail inside the window before
+// XRootD is shut down.
 const livenessConfig = `
 Xrootd:
   LivenessCheckInterval: 1s
   LivenessCheckTimeout: 2s
-  LivenessMaxUnresponsiveTime: 3s
+  LivenessMaxUnresponsiveTime: 7s
 `
 
 func processExists(pid int) bool {

--- a/e2e_fed_tests/xrootd_liveness_test.go
+++ b/e2e_fed_tests/xrootd_liveness_test.go
@@ -1,0 +1,92 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package fed_tests
+
+import (
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pelicanplatform/pelican/fed_test_utils"
+	"github.com/pelicanplatform/pelican/server_utils"
+	"github.com/pelicanplatform/pelican/test_utils"
+)
+
+// livenessConfig shortens the hidden liveness knobs so the monitor reacts within the
+// lifetime of a unit test instead of the ten minutes it allows in production.
+const livenessConfig = `
+Xrootd:
+  LivenessCheckInterval: 1s
+  LivenessCheckTimeout: 2s
+  LivenessMaxUnresponsiveTime: 3s
+`
+
+func processExists(pid int) bool {
+	process, err := os.FindProcess(pid)
+	if err != nil || process == nil {
+		return false
+	}
+	return process.Signal(syscall.Signal(0)) == nil
+}
+
+// TestXRootDLivenessKillsHungProcess wedges XRootD with SIGSTOP -- the one way to stall it
+// indefinitely -- and verifies Pelican notices and shuts the daemon down.  A stopped process
+// still completes TCP handshakes out of the kernel's listen backlog, so this also guards
+// against the check regressing to a bare connect().
+func TestXRootDLivenessKillsHungProcess(t *testing.T) {
+	t.Cleanup(test_utils.SetupTestLogging(t))
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+
+	ft := fed_test_utils.NewFedTest(t, bothPubNamespaces+livenessConfig)
+	// Killing XRootD takes the rest of the server down with it; that is the point of
+	// the test, not a teardown failure.
+	ft.AllowServerFailure()
+
+	pids := ft.Pids
+	require.NotEmpty(t, pids, "no XRootD PIDs were tracked by the federation")
+
+	for _, pid := range pids {
+		require.NoError(t, syscall.Kill(pid, syscall.SIGSTOP), "failed to stop PID %d", pid)
+	}
+	t.Cleanup(func() {
+		// Revive anything Pelican did not manage to kill so the process table is
+		// left clean even when the assertion below fails.
+		for _, pid := range pids {
+			if processExists(pid) {
+				_ = syscall.Kill(pid, syscall.SIGCONT)
+				_ = syscall.Kill(pid, syscall.SIGKILL)
+			}
+		}
+	})
+
+	require.Eventually(t, func() bool {
+		for _, pid := range pids {
+			if processExists(pid) {
+				return false
+			}
+		}
+		return true
+	}, 60*time.Second, 250*time.Millisecond, "Pelican did not shut down the wedged XRootD processes %v", pids)
+}

--- a/fed_test_utils/fed.go
+++ b/fed_test_utils/fed.go
@@ -33,6 +33,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -63,6 +64,10 @@ type (
 		Ctx             context.Context
 		Egrp            *errgroup.Group
 		Pids            []int
+
+		// tolerateServerFailure lets teardown accept an error from the server errgroup;
+		// see AllowServerFailure.
+		tolerateServerFailure atomic.Bool
 	}
 )
 
@@ -70,6 +75,14 @@ var (
 	//go:embed resources/default.yaml
 	fedTestDefaultConfig string
 )
+
+// AllowServerFailure tells the federation teardown to tolerate an error from the server
+// errgroup instead of failing the test.  Use it in tests that deliberately break a server
+// component -- for example, by wedging XRootD so Pelican shuts it down -- where the
+// resulting shutdown error is the expected outcome rather than a regression.
+func (ft *FedTest) AllowServerFailure() {
+	ft.tolerateServerFailure.Store(true)
+}
 
 // Start up a new Pelican federation for unit testing.
 //
@@ -112,7 +125,10 @@ func NewFedTest(t testing.TB, originConfig string, originSetup ...func(storageDi
 	t.Cleanup(func() {
 		cancel()
 		if err := egrp.Wait(); err != nil && err != context.Canceled && err != http.ErrServerClosed {
-			require.NoError(t, err)
+			if !ft.tolerateServerFailure.Load() {
+				require.NoError(t, err)
+			}
+			t.Logf("Ignoring expected server error during teardown: %v", err)
 		}
 		err := os.RemoveAll(tmpPath)
 		require.NoError(t, err)

--- a/fed_test_utils/fed.go
+++ b/fed_test_utils/fed.go
@@ -125,10 +125,11 @@ func NewFedTest(t testing.TB, originConfig string, originSetup ...func(storageDi
 	t.Cleanup(func() {
 		cancel()
 		if err := egrp.Wait(); err != nil && err != context.Canceled && err != http.ErrServerClosed {
-			if !ft.tolerateServerFailure.Load() {
+			if ft.tolerateServerFailure.Load() {
+				t.Logf("Ignoring expected server error during teardown: %v", err)
+			} else {
 				require.NoError(t, err)
 			}
-			t.Logf("Ignoring expected server error during teardown: %v", err)
 		}
 		err := os.RemoveAll(tmpPath)
 		require.NoError(t, err)

--- a/launchers/cache_serve.go
+++ b/launchers/cache_serve.go
@@ -380,6 +380,10 @@ func cacheServeWithXRootD(ctx context.Context, engine *gin.Engine, egrp *errgrou
 	}
 	xrootd.StoreRestartInfo(pids, launch, cacheServer, true, useCMSD, privileged)
 
+	// Watch for an XRootD that stops answering connections entirely; must follow
+	// StoreRestartInfo so the monitor can find the PIDs it may need to signal.
+	xrootd.LaunchXrootdLivenessCheck(ctx, egrp, true)
+
 	// Register callback for xrootd logging configuration changes
 	// This must be done after LaunchDaemons so the server has PIDs
 	xrootd.RegisterXrootdLoggingCallback(ctx)

--- a/launchers/origin_serve.go
+++ b/launchers/origin_serve.go
@@ -254,6 +254,10 @@ func OriginServe(ctx context.Context, engine *gin.Engine, egrp *errgroup.Group, 
 		}
 		xrootd.StoreRestartInfo(pids, launch, originServer, false, useCMSD, privileged)
 
+		// Watch for an XRootD that stops answering connections entirely; must follow
+		// StoreRestartInfo so the monitor can find the PIDs it may need to signal.
+		xrootd.LaunchXrootdLivenessCheck(ctx, egrp, false)
+
 		// Register callback for xrootd logging configuration changes
 		// This must be done after LaunchDaemons so the server has PIDs
 		xrootd.RegisterXrootdLoggingCallback(ctx)

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -598,8 +598,12 @@ var runtimeConfigurableMap = map[string]bool{
 	"Xrootd.ConfigUpdateFailureTimeout": false,
 	"Xrootd.DetailedMonitoringHost": false,
 	"Xrootd.DetailedMonitoringPort": false,
+	"Xrootd.DisableLivenessCheck": false,
 	"Xrootd.EnableLocalMonitoring": false,
 	"Xrootd.HttpMaxDelay": false,
+	"Xrootd.LivenessCheckInterval": false,
+	"Xrootd.LivenessCheckTimeout": false,
+	"Xrootd.LivenessMaxUnresponsiveTime": false,
 	"Xrootd.LocalMonitoringHost": false,
 	"Xrootd.LocalMonitoringPort": false,
 	"Xrootd.MacaroonsKeyFile": false,
@@ -1189,6 +1193,7 @@ var boolAccessors = map[string]func(*Config) bool{
 	"Topology.DisableOrigins": func(c *Config) bool { return c.Topology.DisableOrigins },
 	"Transfer.EnableOAuth2Clients": func(c *Config) bool { return c.Transfer.EnableOAuth2Clients },
 	"Xrootd.AutoShutdownEnabled": func(c *Config) bool { return c.Xrootd.AutoShutdownEnabled },
+	"Xrootd.DisableLivenessCheck": func(c *Config) bool { return c.Xrootd.DisableLivenessCheck },
 	"Xrootd.EnableLocalMonitoring": func(c *Config) bool { return c.Xrootd.EnableLocalMonitoring },
 }
 
@@ -1313,6 +1318,9 @@ var durationAccessors = map[string]func(*Config) time.Duration{
 	"Xrootd.AuthRefreshInterval": func(c *Config) time.Duration { return c.Xrootd.AuthRefreshInterval },
 	"Xrootd.ConfigUpdateFailureTimeout": func(c *Config) time.Duration { return c.Xrootd.ConfigUpdateFailureTimeout },
 	"Xrootd.HttpMaxDelay": func(c *Config) time.Duration { return c.Xrootd.HttpMaxDelay },
+	"Xrootd.LivenessCheckInterval": func(c *Config) time.Duration { return c.Xrootd.LivenessCheckInterval },
+	"Xrootd.LivenessCheckTimeout": func(c *Config) time.Duration { return c.Xrootd.LivenessCheckTimeout },
+	"Xrootd.LivenessMaxUnresponsiveTime": func(c *Config) time.Duration { return c.Xrootd.LivenessMaxUnresponsiveTime },
 	"Xrootd.MaxStartupWait": func(c *Config) time.Duration { return c.Xrootd.MaxStartupWait },
 	"Xrootd.ShutdownTimeout": func(c *Config) time.Duration { return c.Xrootd.ShutdownTimeout },
 }
@@ -1906,8 +1914,12 @@ var allParameterNames = []string{
 	"Xrootd.ConfigUpdateFailureTimeout",
 	"Xrootd.DetailedMonitoringHost",
 	"Xrootd.DetailedMonitoringPort",
+	"Xrootd.DisableLivenessCheck",
 	"Xrootd.EnableLocalMonitoring",
 	"Xrootd.HttpMaxDelay",
+	"Xrootd.LivenessCheckInterval",
+	"Xrootd.LivenessCheckTimeout",
+	"Xrootd.LivenessMaxUnresponsiveTime",
 	"Xrootd.LocalMonitoringHost",
 	"Xrootd.LocalMonitoringPort",
 	"Xrootd.MacaroonsKeyFile",
@@ -2349,6 +2361,7 @@ var (
 	Topology_DisableOrigins = BoolParam{"Topology.DisableOrigins"}
 	Transfer_EnableOAuth2Clients = BoolParam{"Transfer.EnableOAuth2Clients"}
 	Xrootd_AutoShutdownEnabled = BoolParam{"Xrootd.AutoShutdownEnabled"}
+	Xrootd_DisableLivenessCheck = BoolParam{"Xrootd.DisableLivenessCheck"}
 	Xrootd_EnableLocalMonitoring = BoolParam{"Xrootd.EnableLocalMonitoring"}
 )
 
@@ -2445,6 +2458,9 @@ var (
 	Xrootd_AuthRefreshInterval = DurationParam{"Xrootd.AuthRefreshInterval"}
 	Xrootd_ConfigUpdateFailureTimeout = DurationParam{"Xrootd.ConfigUpdateFailureTimeout"}
 	Xrootd_HttpMaxDelay = DurationParam{"Xrootd.HttpMaxDelay"}
+	Xrootd_LivenessCheckInterval = DurationParam{"Xrootd.LivenessCheckInterval"}
+	Xrootd_LivenessCheckTimeout = DurationParam{"Xrootd.LivenessCheckTimeout"}
+	Xrootd_LivenessMaxUnresponsiveTime = DurationParam{"Xrootd.LivenessMaxUnresponsiveTime"}
 	Xrootd_MaxStartupWait = DurationParam{"Xrootd.MaxStartupWait"}
 	Xrootd_ShutdownTimeout = DurationParam{"Xrootd.ShutdownTimeout"}
 )
@@ -2890,6 +2906,7 @@ func init() {
 		"Topology.DisableOrigins": Topology_DisableOrigins,
 		"Transfer.EnableOAuth2Clients": Transfer_EnableOAuth2Clients,
 		"Xrootd.AutoShutdownEnabled": Xrootd_AutoShutdownEnabled,
+		"Xrootd.DisableLivenessCheck": Xrootd_DisableLivenessCheck,
 		"Xrootd.EnableLocalMonitoring": Xrootd_EnableLocalMonitoring,
 		"Cache.DefaultCacheTimeout": Cache_DefaultCacheTimeout,
 		"Cache.EvictionMonitoringInterval": Cache_EvictionMonitoringInterval,
@@ -2983,6 +3000,9 @@ func init() {
 		"Xrootd.AuthRefreshInterval": Xrootd_AuthRefreshInterval,
 		"Xrootd.ConfigUpdateFailureTimeout": Xrootd_ConfigUpdateFailureTimeout,
 		"Xrootd.HttpMaxDelay": Xrootd_HttpMaxDelay,
+		"Xrootd.LivenessCheckInterval": Xrootd_LivenessCheckInterval,
+		"Xrootd.LivenessCheckTimeout": Xrootd_LivenessCheckTimeout,
+		"Xrootd.LivenessMaxUnresponsiveTime": Xrootd_LivenessMaxUnresponsiveTime,
 		"Xrootd.MaxStartupWait": Xrootd_MaxStartupWait,
 		"Xrootd.ShutdownTimeout": Xrootd_ShutdownTimeout,
 		"GeoIPOverrides": GeoIPOverrides,

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -601,7 +601,6 @@ var runtimeConfigurableMap = map[string]bool{
 	"Xrootd.DisableLivenessCheck": false,
 	"Xrootd.EnableLocalMonitoring": false,
 	"Xrootd.HttpMaxDelay": false,
-	"Xrootd.LivenessCheckFailureThreshold": false,
 	"Xrootd.LivenessCheckInterval": false,
 	"Xrootd.LivenessCheckTimeout": false,
 	"Xrootd.LivenessMaxUnresponsiveTime": false,
@@ -1019,7 +1018,6 @@ var intAccessors = map[string]func(*Config) int{
 	"Transfer.MaxConcurrentJobs": func(c *Config) int { return c.Transfer.MaxConcurrentJobs },
 	"Transport.MaxIdleConns": func(c *Config) int { return c.Transport.MaxIdleConns },
 	"Xrootd.DetailedMonitoringPort": func(c *Config) int { return c.Xrootd.DetailedMonitoringPort },
-	"Xrootd.LivenessCheckFailureThreshold": func(c *Config) int { return c.Xrootd.LivenessCheckFailureThreshold },
 	"Xrootd.LocalMonitoringPort": func(c *Config) int { return c.Xrootd.LocalMonitoringPort },
 	"Xrootd.ManagerPort": func(c *Config) int { return c.Xrootd.ManagerPort },
 	"Xrootd.MaxThreads": func(c *Config) int { return c.Xrootd.MaxThreads },
@@ -1919,7 +1917,6 @@ var allParameterNames = []string{
 	"Xrootd.DisableLivenessCheck",
 	"Xrootd.EnableLocalMonitoring",
 	"Xrootd.HttpMaxDelay",
-	"Xrootd.LivenessCheckFailureThreshold",
 	"Xrootd.LivenessCheckInterval",
 	"Xrootd.LivenessCheckTimeout",
 	"Xrootd.LivenessMaxUnresponsiveTime",
@@ -2254,7 +2251,6 @@ var (
 	Transfer_MaxConcurrentJobs = IntParam{"Transfer.MaxConcurrentJobs"}
 	Transport_MaxIdleConns = IntParam{"Transport.MaxIdleConns"}
 	Xrootd_DetailedMonitoringPort = IntParam{"Xrootd.DetailedMonitoringPort"}
-	Xrootd_LivenessCheckFailureThreshold = IntParam{"Xrootd.LivenessCheckFailureThreshold"}
 	Xrootd_LocalMonitoringPort = IntParam{"Xrootd.LocalMonitoringPort"}
 	Xrootd_ManagerPort = IntParam{"Xrootd.ManagerPort"}
 	Xrootd_MaxThreads = IntParam{"Xrootd.MaxThreads"}
@@ -2806,7 +2802,6 @@ func init() {
 		"Transfer.MaxConcurrentJobs": Transfer_MaxConcurrentJobs,
 		"Transport.MaxIdleConns": Transport_MaxIdleConns,
 		"Xrootd.DetailedMonitoringPort": Xrootd_DetailedMonitoringPort,
-		"Xrootd.LivenessCheckFailureThreshold": Xrootd_LivenessCheckFailureThreshold,
 		"Xrootd.LocalMonitoringPort": Xrootd_LocalMonitoringPort,
 		"Xrootd.ManagerPort": Xrootd_ManagerPort,
 		"Xrootd.MaxThreads": Xrootd_MaxThreads,

--- a/param/parameters.go
+++ b/param/parameters.go
@@ -601,6 +601,7 @@ var runtimeConfigurableMap = map[string]bool{
 	"Xrootd.DisableLivenessCheck": false,
 	"Xrootd.EnableLocalMonitoring": false,
 	"Xrootd.HttpMaxDelay": false,
+	"Xrootd.LivenessCheckFailureThreshold": false,
 	"Xrootd.LivenessCheckInterval": false,
 	"Xrootd.LivenessCheckTimeout": false,
 	"Xrootd.LivenessMaxUnresponsiveTime": false,
@@ -1018,6 +1019,7 @@ var intAccessors = map[string]func(*Config) int{
 	"Transfer.MaxConcurrentJobs": func(c *Config) int { return c.Transfer.MaxConcurrentJobs },
 	"Transport.MaxIdleConns": func(c *Config) int { return c.Transport.MaxIdleConns },
 	"Xrootd.DetailedMonitoringPort": func(c *Config) int { return c.Xrootd.DetailedMonitoringPort },
+	"Xrootd.LivenessCheckFailureThreshold": func(c *Config) int { return c.Xrootd.LivenessCheckFailureThreshold },
 	"Xrootd.LocalMonitoringPort": func(c *Config) int { return c.Xrootd.LocalMonitoringPort },
 	"Xrootd.ManagerPort": func(c *Config) int { return c.Xrootd.ManagerPort },
 	"Xrootd.MaxThreads": func(c *Config) int { return c.Xrootd.MaxThreads },
@@ -1917,6 +1919,7 @@ var allParameterNames = []string{
 	"Xrootd.DisableLivenessCheck",
 	"Xrootd.EnableLocalMonitoring",
 	"Xrootd.HttpMaxDelay",
+	"Xrootd.LivenessCheckFailureThreshold",
 	"Xrootd.LivenessCheckInterval",
 	"Xrootd.LivenessCheckTimeout",
 	"Xrootd.LivenessMaxUnresponsiveTime",
@@ -2251,6 +2254,7 @@ var (
 	Transfer_MaxConcurrentJobs = IntParam{"Transfer.MaxConcurrentJobs"}
 	Transport_MaxIdleConns = IntParam{"Transport.MaxIdleConns"}
 	Xrootd_DetailedMonitoringPort = IntParam{"Xrootd.DetailedMonitoringPort"}
+	Xrootd_LivenessCheckFailureThreshold = IntParam{"Xrootd.LivenessCheckFailureThreshold"}
 	Xrootd_LocalMonitoringPort = IntParam{"Xrootd.LocalMonitoringPort"}
 	Xrootd_ManagerPort = IntParam{"Xrootd.ManagerPort"}
 	Xrootd_MaxThreads = IntParam{"Xrootd.MaxThreads"}
@@ -2802,6 +2806,7 @@ func init() {
 		"Transfer.MaxConcurrentJobs": Transfer_MaxConcurrentJobs,
 		"Transport.MaxIdleConns": Transport_MaxIdleConns,
 		"Xrootd.DetailedMonitoringPort": Xrootd_DetailedMonitoringPort,
+		"Xrootd.LivenessCheckFailureThreshold": Xrootd_LivenessCheckFailureThreshold,
 		"Xrootd.LocalMonitoringPort": Xrootd_LocalMonitoringPort,
 		"Xrootd.ManagerPort": Xrootd_ManagerPort,
 		"Xrootd.MaxThreads": Xrootd_MaxThreads,

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -592,8 +592,12 @@ type Config struct {
 		ConfigUpdateFailureTimeout time.Duration `mapstructure:"configupdatefailuretimeout" yaml:"ConfigUpdateFailureTimeout"`
 		DetailedMonitoringHost string `mapstructure:"detailedmonitoringhost" yaml:"DetailedMonitoringHost"`
 		DetailedMonitoringPort int `mapstructure:"detailedmonitoringport" yaml:"DetailedMonitoringPort"`
+		DisableLivenessCheck bool `mapstructure:"disablelivenesscheck" yaml:"DisableLivenessCheck"`
 		EnableLocalMonitoring bool `mapstructure:"enablelocalmonitoring" yaml:"EnableLocalMonitoring"`
 		HttpMaxDelay time.Duration `mapstructure:"httpmaxdelay" yaml:"HttpMaxDelay"`
+		LivenessCheckInterval time.Duration `mapstructure:"livenesscheckinterval" yaml:"LivenessCheckInterval"`
+		LivenessCheckTimeout time.Duration `mapstructure:"livenesschecktimeout" yaml:"LivenessCheckTimeout"`
+		LivenessMaxUnresponsiveTime time.Duration `mapstructure:"livenessmaxunresponsivetime" yaml:"LivenessMaxUnresponsiveTime"`
 		LocalMonitoringHost string `mapstructure:"localmonitoringhost" yaml:"LocalMonitoringHost"`
 		LocalMonitoringPort int `mapstructure:"localmonitoringport" yaml:"LocalMonitoringPort"`
 		MacaroonsKeyFile string `mapstructure:"macaroonskeyfile" yaml:"MacaroonsKeyFile"`
@@ -1181,8 +1185,12 @@ type configWithType struct {
 		ConfigUpdateFailureTimeout struct { Type string; Value time.Duration }
 		DetailedMonitoringHost struct { Type string; Value string }
 		DetailedMonitoringPort struct { Type string; Value int }
+		DisableLivenessCheck struct { Type string; Value bool }
 		EnableLocalMonitoring struct { Type string; Value bool }
 		HttpMaxDelay struct { Type string; Value time.Duration }
+		LivenessCheckInterval struct { Type string; Value time.Duration }
+		LivenessCheckTimeout struct { Type string; Value time.Duration }
+		LivenessMaxUnresponsiveTime struct { Type string; Value time.Duration }
 		LocalMonitoringHost struct { Type string; Value string }
 		LocalMonitoringPort struct { Type string; Value int }
 		MacaroonsKeyFile struct { Type string; Value string }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -595,6 +595,7 @@ type Config struct {
 		DisableLivenessCheck bool `mapstructure:"disablelivenesscheck" yaml:"DisableLivenessCheck"`
 		EnableLocalMonitoring bool `mapstructure:"enablelocalmonitoring" yaml:"EnableLocalMonitoring"`
 		HttpMaxDelay time.Duration `mapstructure:"httpmaxdelay" yaml:"HttpMaxDelay"`
+		LivenessCheckFailureThreshold int `mapstructure:"livenesscheckfailurethreshold" yaml:"LivenessCheckFailureThreshold"`
 		LivenessCheckInterval time.Duration `mapstructure:"livenesscheckinterval" yaml:"LivenessCheckInterval"`
 		LivenessCheckTimeout time.Duration `mapstructure:"livenesschecktimeout" yaml:"LivenessCheckTimeout"`
 		LivenessMaxUnresponsiveTime time.Duration `mapstructure:"livenessmaxunresponsivetime" yaml:"LivenessMaxUnresponsiveTime"`
@@ -1188,6 +1189,7 @@ type configWithType struct {
 		DisableLivenessCheck struct { Type string; Value bool }
 		EnableLocalMonitoring struct { Type string; Value bool }
 		HttpMaxDelay struct { Type string; Value time.Duration }
+		LivenessCheckFailureThreshold struct { Type string; Value int }
 		LivenessCheckInterval struct { Type string; Value time.Duration }
 		LivenessCheckTimeout struct { Type string; Value time.Duration }
 		LivenessMaxUnresponsiveTime struct { Type string; Value time.Duration }

--- a/param/parameters_struct.go
+++ b/param/parameters_struct.go
@@ -595,7 +595,6 @@ type Config struct {
 		DisableLivenessCheck bool `mapstructure:"disablelivenesscheck" yaml:"DisableLivenessCheck"`
 		EnableLocalMonitoring bool `mapstructure:"enablelocalmonitoring" yaml:"EnableLocalMonitoring"`
 		HttpMaxDelay time.Duration `mapstructure:"httpmaxdelay" yaml:"HttpMaxDelay"`
-		LivenessCheckFailureThreshold int `mapstructure:"livenesscheckfailurethreshold" yaml:"LivenessCheckFailureThreshold"`
 		LivenessCheckInterval time.Duration `mapstructure:"livenesscheckinterval" yaml:"LivenessCheckInterval"`
 		LivenessCheckTimeout time.Duration `mapstructure:"livenesschecktimeout" yaml:"LivenessCheckTimeout"`
 		LivenessMaxUnresponsiveTime time.Duration `mapstructure:"livenessmaxunresponsivetime" yaml:"LivenessMaxUnresponsiveTime"`
@@ -1189,7 +1188,6 @@ type configWithType struct {
 		DisableLivenessCheck struct { Type string; Value bool }
 		EnableLocalMonitoring struct { Type string; Value bool }
 		HttpMaxDelay struct { Type string; Value time.Duration }
-		LivenessCheckFailureThreshold struct { Type string; Value int }
 		LivenessCheckInterval struct { Type string; Value time.Duration }
 		LivenessCheckTimeout struct { Type string; Value time.Duration }
 		LivenessMaxUnresponsiveTime struct { Type string; Value time.Duration }

--- a/xrootd/liveness.go
+++ b/xrootd/liveness.go
@@ -45,7 +45,8 @@ var (
 )
 
 // LaunchXrootdLivenessCheck starts a goroutine that periodically verifies the locally-launched
-// XRootD daemon still answers new connections.  When XRootD has not answered for
+// XRootD daemon still answers new connections.  Once Xrootd.LivenessCheckFailureThreshold
+// checks in a row have failed and XRootD has been unreachable for
 // Xrootd.LivenessMaxUnresponsiveTime, the daemon is shut down (SIGTERM, then SIGKILL) so that
 // the service manager can replace it; Pelican's usual handling of an unexpected XRootD exit
 // then takes the rest of the server down with it.
@@ -63,15 +64,34 @@ func LaunchXrootdLivenessCheck(ctx context.Context, egrp *errgroup.Group, isCach
 	})
 }
 
+// nextCheckDelay returns how long to wait before the next liveness check, given how long the
+// check that just finished took.
+//
+// The interval is a minimum spacing rather than an added delay: after a failure only the
+// remainder of the interval is waited out, so a check that already outran the interval is
+// retried immediately instead of stretching the time XRootD spends wedged.  A successful
+// check is free to pace itself further out, so it simply waits the whole interval.
+func nextCheckDelay(interval, checkDuration time.Duration, succeeded bool) time.Duration {
+	if succeeded {
+		return interval
+	}
+	if remaining := interval - checkDuration; remaining > 0 {
+		return remaining
+	}
+	return 0
+}
+
 // runXrootdLivenessCheck is the body of the liveness monitor.  It returns when the context is
 // cancelled or once it has shut a hung XRootD down.
 func runXrootdLivenessCheck(ctx context.Context, isCache bool) {
 	// XRootD was just launched; give it until the first failure window before holding
 	// it responsible for anything.
 	lastSuccess := time.Now()
+	consecutiveFailures := 0
+	delay := param.Xrootd_LivenessCheckInterval.GetDuration()
 
 	for {
-		timer := time.NewTimer(param.Xrootd_LivenessCheckInterval.GetDuration())
+		timer := time.NewTimer(delay)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
@@ -79,10 +99,14 @@ func runXrootdLivenessCheck(ctx context.Context, isCache bool) {
 		case <-timer.C:
 		}
 
+		interval := param.Xrootd_LivenessCheckInterval.GetDuration()
+
 		// A deliberate restart stops and relaunches XRootD; the gap in service is
 		// expected, so it must not count against the daemon.
 		if daemon.IsExpectedRestart() {
 			lastSuccess = time.Now()
+			consecutiveFailures = 0
+			delay = interval
 			continue
 		}
 
@@ -92,29 +116,40 @@ func runXrootdLivenessCheck(ctx context.Context, isCache bool) {
 			// hold the clock rather than working toward a kill.
 			log.WithError(err).Debug("Skipping XRootD liveness check")
 			lastSuccess = time.Now()
+			consecutiveFailures = 0
+			delay = interval
 			continue
 		}
 
+		checkStart := time.Now()
 		probeErr := probeXrootdFn(ctx, addr, param.Xrootd_LivenessCheckTimeout.GetDuration())
 		if ctx.Err() != nil {
 			return
 		}
+		delay = nextCheckDelay(interval, time.Since(checkStart), probeErr == nil)
+
 		if probeErr == nil {
 			log.Tracef("XRootD liveness check against %s succeeded", addr)
 			lastSuccess = time.Now()
+			consecutiveFailures = 0
 			continue
 		}
 
+		consecutiveFailures++
 		unresponsiveFor := time.Since(lastSuccess)
 		maxUnresponsive := param.Xrootd_LivenessMaxUnresponsiveTime.GetDuration()
-		if unresponsiveFor < maxUnresponsive {
-			log.Warnf("XRootD liveness check against %s failed (%v); XRootD has been unresponsive for %s of the permitted %s",
-				addr, probeErr, unresponsiveFor.Round(time.Second), maxUnresponsive)
+		failureThreshold := param.Xrootd_LivenessCheckFailureThreshold.GetInt()
+
+		// Both conditions must hold: enough checks have failed to rule out a single
+		// unlucky probe, and XRootD has been unreachable for longer than it is allowed.
+		if consecutiveFailures < failureThreshold || unresponsiveFor < maxUnresponsive {
+			log.Warnf("XRootD liveness check against %s failed (%v); %d consecutive failures over %s, and XRootD is shut down after %d failures spanning %s",
+				addr, probeErr, consecutiveFailures, unresponsiveFor.Round(time.Second), failureThreshold, maxUnresponsive)
 			continue
 		}
 
-		log.Errorf("XRootD at %s has not responded to a liveness check for %s (limit %s); shutting the daemon down",
-			addr, unresponsiveFor.Round(time.Second), maxUnresponsive)
+		log.Errorf("XRootD at %s has failed %d consecutive liveness checks and has not responded for %s (limit %s); shutting the daemon down",
+			addr, consecutiveFailures, unresponsiveFor.Round(time.Second), maxUnresponsive)
 		metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusCritical,
 			"XRootD was unresponsive for "+unresponsiveFor.Round(time.Second).String()+" and is being shut down")
 		shutdownXrootdFn(isCache)

--- a/xrootd/liveness.go
+++ b/xrootd/liveness.go
@@ -32,6 +32,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/daemon"
 	"github.com/pelicanplatform/pelican/metrics"
 	"github.com/pelicanplatform/pelican/param"
@@ -40,8 +41,9 @@ import (
 // Test seams for the liveness monitor; overriding these lets the loop be
 // exercised without a real XRootD process on the other end.
 var (
-	probeXrootdFn    = probeXrootdEndpoint
-	shutdownXrootdFn = shutdownHungXrootd
+	probeXrootdFn       = probeXrootdEndpoint
+	shutdownXrootdFn    = shutdownHungXrootd
+	livenessTLSConfigFn = livenessTLSConfig
 )
 
 // LaunchXrootdLivenessCheck starts a goroutine that periodically verifies the locally-launched
@@ -186,9 +188,14 @@ func probeXrootdEndpoint(parentCtx context.Context, addr string, timeout time.Du
 	}
 	defer conn.Close()
 
-	// The handshake is never completed against a verified identity -- the only question is
-	// whether bytes come back -- so certificate validation is intentionally skipped.
-	tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true}) // #nosec G402 -- liveness probe; no data is exchanged
+	// Fall back to the host we dialed if the server has no configured hostname; an empty
+	// ServerName makes crypto/tls fail the handshake immediately, which would look like
+	// XRootD answering and quietly neuter the whole check.
+	host, _, splitErr := net.SplitHostPort(addr)
+	if splitErr != nil {
+		host = addr
+	}
+	tlsConn := tls.Client(conn, livenessTLSConfigFn(host))
 	if err := tlsConn.HandshakeContext(ctx); err != nil {
 		if parentCtx.Err() != nil {
 			// Pelican is shutting down; the probe learned nothing either way.
@@ -204,6 +211,29 @@ func probeXrootdEndpoint(parentCtx context.Context, addr string, timeout time.Du
 		log.Debugf("XRootD at %s responded to the liveness check with a TLS error, which still counts as alive: %v", addr, err)
 	}
 	return nil
+}
+
+// livenessTLSConfig returns the TLS settings for the probe: Pelican's own trust roots, and
+// the name the server's certificate is issued for rather than the loopback address dialed.
+//
+// Whether verification succeeds does not actually change the verdict -- a rejected
+// certificate is still XRootD answering, and probeXrootdEndpoint treats any non-timeout
+// error as alive -- so a certificate problem can never be mistaken for a hung daemon.
+// Verifying anyway keeps the probe honest and avoids carrying a disabled certificate check
+// around in the tree.
+func livenessTLSConfig(fallbackHost string) *tls.Config {
+	cfg := &tls.Config{}
+	if transport := config.GetTransport(); transport != nil && transport.TLSClientConfig != nil {
+		cfg = transport.TLSClientConfig.Clone()
+	}
+	cfg.ServerName = param.Server_Hostname.GetString()
+	if cfg.ServerName == "" {
+		cfg.ServerName = fallbackHost
+	}
+	if cfg.MinVersion == 0 {
+		cfg.MinVersion = tls.VersionTLS12
+	}
+	return cfg
 }
 
 // isProbeTimeout reports whether err means the peer never answered, as opposed to answering

--- a/xrootd/liveness.go
+++ b/xrootd/liveness.go
@@ -45,8 +45,7 @@ var (
 )
 
 // LaunchXrootdLivenessCheck starts a goroutine that periodically verifies the locally-launched
-// XRootD daemon still answers new connections.  Once Xrootd.LivenessCheckFailureThreshold
-// checks in a row have failed and XRootD has been unreachable for
+// XRootD daemon still answers new connections.  When XRootD has not answered for
 // Xrootd.LivenessMaxUnresponsiveTime, the daemon is shut down (SIGTERM, then SIGKILL) so that
 // the service manager can replace it; Pelican's usual handling of an unexpected XRootD exit
 // then takes the rest of the server down with it.
@@ -138,13 +137,9 @@ func runXrootdLivenessCheck(ctx context.Context, isCache bool) {
 		consecutiveFailures++
 		unresponsiveFor := time.Since(lastSuccess)
 		maxUnresponsive := param.Xrootd_LivenessMaxUnresponsiveTime.GetDuration()
-		failureThreshold := param.Xrootd_LivenessCheckFailureThreshold.GetInt()
-
-		// Both conditions must hold: enough checks have failed to rule out a single
-		// unlucky probe, and XRootD has been unreachable for longer than it is allowed.
-		if consecutiveFailures < failureThreshold || unresponsiveFor < maxUnresponsive {
-			log.Warnf("XRootD liveness check against %s failed (%v); %d consecutive failures over %s, and XRootD is shut down after %d failures spanning %s",
-				addr, probeErr, consecutiveFailures, unresponsiveFor.Round(time.Second), failureThreshold, maxUnresponsive)
+		if unresponsiveFor < maxUnresponsive {
+			log.Warnf("XRootD liveness check against %s failed (%v); %d consecutive failures over %s of the permitted %s",
+				addr, probeErr, consecutiveFailures, unresponsiveFor.Round(time.Second), maxUnresponsive)
 			continue
 		}
 

--- a/xrootd/liveness.go
+++ b/xrootd/liveness.go
@@ -1,0 +1,199 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package xrootd
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/daemon"
+	"github.com/pelicanplatform/pelican/metrics"
+	"github.com/pelicanplatform/pelican/param"
+)
+
+// Test seams for the liveness monitor; overriding these lets the loop be
+// exercised without a real XRootD process on the other end.
+var (
+	probeXrootdFn    = probeXrootdEndpoint
+	shutdownXrootdFn = shutdownHungXrootd
+)
+
+// LaunchXrootdLivenessCheck starts a goroutine that periodically verifies the locally-launched
+// XRootD daemon still answers new connections.  When XRootD has not answered for
+// Xrootd.LivenessMaxUnresponsiveTime, the daemon is shut down (SIGTERM, then SIGKILL) so that
+// the service manager can replace it; Pelican's usual handling of an unexpected XRootD exit
+// then takes the rest of the server down with it.
+//
+// Only call this for servers that actually launched an XRootD daemon.
+func LaunchXrootdLivenessCheck(ctx context.Context, egrp *errgroup.Group, isCache bool) {
+	if param.Xrootd_DisableLivenessCheck.GetBool() {
+		log.Debugf("XRootD liveness checking is disabled by %s; a hung XRootD will only be reported via the health endpoint",
+			param.Xrootd_DisableLivenessCheck.GetName())
+		return
+	}
+	egrp.Go(func() error {
+		runXrootdLivenessCheck(ctx, isCache)
+		return nil
+	})
+}
+
+// runXrootdLivenessCheck is the body of the liveness monitor.  It returns when the context is
+// cancelled or once it has shut a hung XRootD down.
+func runXrootdLivenessCheck(ctx context.Context, isCache bool) {
+	// XRootD was just launched; give it until the first failure window before holding
+	// it responsible for anything.
+	lastSuccess := time.Now()
+
+	for {
+		timer := time.NewTimer(param.Xrootd_LivenessCheckInterval.GetDuration())
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+
+		// A deliberate restart stops and relaunches XRootD; the gap in service is
+		// expected, so it must not count against the daemon.
+		if daemon.IsExpectedRestart() {
+			lastSuccess = time.Now()
+			continue
+		}
+
+		addr, err := xrootdLivenessAddress(isCache)
+		if err != nil {
+			// We don't know where to look. That is our problem, not XRootD's, so
+			// hold the clock rather than working toward a kill.
+			log.WithError(err).Debug("Skipping XRootD liveness check")
+			lastSuccess = time.Now()
+			continue
+		}
+
+		probeErr := probeXrootdFn(ctx, addr, param.Xrootd_LivenessCheckTimeout.GetDuration())
+		if ctx.Err() != nil {
+			return
+		}
+		if probeErr == nil {
+			log.Tracef("XRootD liveness check against %s succeeded", addr)
+			lastSuccess = time.Now()
+			continue
+		}
+
+		unresponsiveFor := time.Since(lastSuccess)
+		maxUnresponsive := param.Xrootd_LivenessMaxUnresponsiveTime.GetDuration()
+		if unresponsiveFor < maxUnresponsive {
+			log.Warnf("XRootD liveness check against %s failed (%v); XRootD has been unresponsive for %s of the permitted %s",
+				addr, probeErr, unresponsiveFor.Round(time.Second), maxUnresponsive)
+			continue
+		}
+
+		log.Errorf("XRootD at %s has not responded to a liveness check for %s (limit %s); shutting the daemon down",
+			addr, unresponsiveFor.Round(time.Second), maxUnresponsive)
+		metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusCritical,
+			"XRootD was unresponsive for "+unresponsiveFor.Round(time.Second).String()+" and is being shut down")
+		shutdownXrootdFn(isCache)
+		return
+	}
+}
+
+// xrootdLivenessAddress returns the local address of the XRootD endpoint for this server role.
+// The loopback interface is used deliberately: the check is meant to catch a wedged local
+// daemon, not a network or DNS problem somewhere between here and a client.
+func xrootdLivenessAddress(isCache bool) (string, error) {
+	portParam := param.Origin_Port
+	if isCache {
+		portParam = param.Cache_Port
+	}
+	port := portParam.GetInt()
+	if port <= 0 {
+		return "", errors.Errorf("%s is not set to a usable port (%d)", portParam.GetName(), port)
+	}
+	return net.JoinHostPort("localhost", strconv.Itoa(port)), nil
+}
+
+// probeXrootdEndpoint reports whether the XRootD daemon listening at addr is still servicing
+// new connections.  It returns nil when XRootD is responsive.
+//
+// A bare TCP connect is not enough on its own: the kernel completes the handshake out of the
+// listen backlog, so a completely wedged XRootD (say, one stopped with SIGSTOP) still accepts
+// connections until the backlog fills.  Neither HTTP nor the xroot protocol has the server
+// speak first, so the probe sends a TLS ClientHello -- every Pelican-generated XRootD config
+// enables TLS on this port -- and requires XRootD itself to answer.
+func probeXrootdEndpoint(parentCtx context.Context, addr string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(parentCtx, timeout)
+	defer cancel()
+
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return errors.Wrapf(err, "failed to connect to the XRootD endpoint at %s", addr)
+	}
+	defer conn.Close()
+
+	// The handshake is never completed against a verified identity -- the only question is
+	// whether bytes come back -- so certificate validation is intentionally skipped.
+	tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true}) // #nosec G402 -- liveness probe; no data is exchanged
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		if parentCtx.Err() != nil {
+			// Pelican is shutting down; the probe learned nothing either way.
+			return errors.Wrap(err, "XRootD liveness probe was interrupted")
+		}
+		if isProbeTimeout(err) {
+			return errors.Wrapf(err, "the XRootD endpoint at %s accepted a connection but did not respond within %s",
+				addr, timeout.String())
+		}
+		// XRootD answered with something we could not complete a handshake against
+		// (a client certificate demand, a protocol error, an abrupt close). It is
+		// alive and processing connections, which is all this check asks of it.
+		log.Debugf("XRootD at %s responded to the liveness check with a TLS error, which still counts as alive: %v", addr, err)
+	}
+	return nil
+}
+
+// isProbeTimeout reports whether err means the peer never answered, as opposed to answering
+// with something unexpected.
+func isProbeTimeout(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, os.ErrDeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+// shutdownHungXrootd terminates the XRootD (and, if configured, cmsd) processes launched for
+// the given server role.
+func shutdownHungXrootd(isCache bool) {
+	pids := trackedPIDsForRole(isCache)
+	if len(pids) == 0 {
+		log.Error("Unable to shut down the unresponsive XRootD: no tracked PIDs are available")
+		return
+	}
+	log.Warnf("Shutting down unresponsive XRootD processes %v", pids)
+	terminateProcesses(pids, param.Xrootd_ShutdownTimeout.GetDuration())
+}

--- a/xrootd/liveness.go
+++ b/xrootd/liveness.go
@@ -23,6 +23,7 @@ package xrootd
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"os"
 	"strconv"
@@ -41,9 +42,8 @@ import (
 // Test seams for the liveness monitor; overriding these lets the loop be
 // exercised without a real XRootD process on the other end.
 var (
-	probeXrootdFn       = probeXrootdEndpoint
-	shutdownXrootdFn    = shutdownHungXrootd
-	livenessTLSConfigFn = livenessTLSConfig
+	probeXrootdFn    = probeXrootdEndpoint
+	shutdownXrootdFn = shutdownHungXrootd
 )
 
 // LaunchXrootdLivenessCheck starts a goroutine that periodically verifies the locally-launched
@@ -130,7 +130,7 @@ func runXrootdLivenessCheck(ctx context.Context, isCache bool) {
 		delay = nextCheckDelay(interval, time.Since(checkStart), probeErr == nil)
 
 		if probeErr == nil {
-			log.Tracef("XRootD liveness check against %s succeeded", addr)
+			log.Debugf("XRootD liveness check against %s succeeded", addr)
 			lastSuccess = time.Now()
 			consecutiveFailures = 0
 			continue
@@ -142,6 +142,9 @@ func runXrootdLivenessCheck(ctx context.Context, isCache bool) {
 		if unresponsiveFor < maxUnresponsive {
 			log.Warnf("XRootD liveness check against %s failed (%v); %d consecutive failures over %s of the permitted %s",
 				addr, probeErr, consecutiveFailures, unresponsiveFor.Round(time.Second), maxUnresponsive)
+			metrics.SetComponentHealthStatus(metrics.OriginCache_XRootD, metrics.StatusWarning,
+				fmt.Sprintf("XRootD has failed %d consecutive liveness checks over %s; it is shut down after %s",
+					consecutiveFailures, unresponsiveFor.Round(time.Second), maxUnresponsive))
 			continue
 		}
 
@@ -195,7 +198,7 @@ func probeXrootdEndpoint(parentCtx context.Context, addr string, timeout time.Du
 	if splitErr != nil {
 		host = addr
 	}
-	tlsConn := tls.Client(conn, livenessTLSConfigFn(host))
+	tlsConn := tls.Client(conn, livenessTLSConfig(host))
 	if err := tlsConn.HandshakeContext(ctx); err != nil {
 		if parentCtx.Err() != nil {
 			// Pelican is shutting down; the probe learned nothing either way.

--- a/xrootd/liveness_fed_test.go
+++ b/xrootd/liveness_fed_test.go
@@ -18,7 +18,7 @@
  *
  ***************************************************************/
 
-package fed_tests
+package xrootd_test
 
 import (
 	"os"
@@ -33,18 +33,24 @@ import (
 	"github.com/pelicanplatform/pelican/test_utils"
 )
 
-// livenessConfig shortens the hidden liveness knobs so the monitor reacts within the
-// lifetime of a unit test instead of the ten minutes it allows in production.  The
-// proportions mirror the shipped defaults, so three checks fail inside the window before
-// XRootD is shut down.
-const livenessConfig = `
+// livenessFedConfig is a minimal origin export plus the hidden liveness knobs, shortened so
+// the monitor reacts within the lifetime of a test instead of the ten minutes it allows in
+// production.  The proportions mirror the shipped defaults, so three checks fail inside the
+// window before XRootD is shut down.
+const livenessFedConfig = `
+Origin:
+  StorageType: "posix"
+  Exports:
+    - StoragePrefix: /<SHOULD BE OVERRIDDEN>
+      FederationPrefix: /test-namespace
+      Capabilities: ["PublicReads", "Writes", "DirectReads", "Listings"]
 Xrootd:
-  LivenessCheckInterval: 1s
-  LivenessCheckTimeout: 2s
-  LivenessMaxUnresponsiveTime: 7s
+  LivenessCheckInterval: 200ms
+  LivenessCheckTimeout: 400ms
+  LivenessMaxUnresponsiveTime: 1400ms
 `
 
-func processExists(pid int) bool {
+func livenessProcessExists(pid int) bool {
 	process, err := os.FindProcess(pid)
 	if err != nil || process == nil {
 		return false
@@ -61,7 +67,7 @@ func TestXRootDLivenessKillsHungProcess(t *testing.T) {
 	server_utils.ResetTestState()
 	t.Cleanup(server_utils.ResetTestState)
 
-	ft := fed_test_utils.NewFedTest(t, bothPubNamespaces+livenessConfig)
+	ft := fed_test_utils.NewFedTest(t, livenessFedConfig)
 	// Killing XRootD takes the rest of the server down with it; that is the point of
 	// the test, not a teardown failure.
 	ft.AllowServerFailure()
@@ -76,7 +82,7 @@ func TestXRootDLivenessKillsHungProcess(t *testing.T) {
 		// Revive anything Pelican did not manage to kill so the process table is
 		// left clean even when the assertion below fails.
 		for _, pid := range pids {
-			if processExists(pid) {
+			if livenessProcessExists(pid) {
 				_ = syscall.Kill(pid, syscall.SIGCONT)
 				_ = syscall.Kill(pid, syscall.SIGKILL)
 			}
@@ -85,7 +91,7 @@ func TestXRootDLivenessKillsHungProcess(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		for _, pid := range pids {
-			if processExists(pid) {
+			if livenessProcessExists(pid) {
 				return false
 			}
 		}

--- a/xrootd/liveness_test.go
+++ b/xrootd/liveness_test.go
@@ -22,6 +22,8 @@ package xrootd
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -40,12 +42,39 @@ import (
 	"github.com/pelicanplatform/pelican/server_utils"
 )
 
-// TestProbeXrootdEndpointResponsive verifies a peer that completes a TLS handshake is
-// considered alive.
+// trustTestServer points the probe's TLS settings at a test server's own certificate, so the
+// handshake completes rather than failing verification.
+func trustTestServer(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+	livenessTLSConfigFn = func(_ string) *tls.Config {
+		return &tls.Config{RootCAs: pool, ServerName: "example.com", MinVersion: tls.VersionTLS12}
+	}
+	t.Cleanup(func() { livenessTLSConfigFn = livenessTLSConfig })
+}
+
+// TestProbeXrootdEndpointResponsive verifies a peer that completes a verified TLS handshake
+// is considered alive.
 func TestProbeXrootdEndpointResponsive(t *testing.T) {
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	t.Cleanup(srv.Close)
+	trustTestServer(t, srv)
 
+	require.NoError(t, probeXrootdEndpoint(context.Background(), srv.Listener.Addr().String(), 10*time.Second))
+}
+
+// TestProbeXrootdEndpointUntrustedCertificate verifies that a certificate the probe cannot
+// verify is not treated as a hung daemon.  XRootD answered, which is the whole question; a
+// certificate problem is a different failure and must not get the daemon killed.
+func TestProbeXrootdEndpointUntrustedCertificate(t *testing.T) {
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	t.Cleanup(srv.Close)
+
+	// The default settings do not trust httptest's throwaway CA, so verification fails.
 	require.NoError(t, probeXrootdEndpoint(context.Background(), srv.Listener.Addr().String(), 10*time.Second))
 }
 
@@ -114,14 +143,21 @@ func TestProbeXrootdEndpointCancelledMidHandshake(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = listener.Close() })
 
-	accepted := make(chan struct{})
+	// Signalled once the ClientHello has arrived.  Accepting is not enough on its own:
+	// the kernel completes the handshake out of the backlog, so the probe's DialContext
+	// may not have returned yet and a cancel here would land on the dial rather than on
+	// the handshake this test is about.
+	helloReceived := make(chan struct{})
 	go func() {
 		conn, err := listener.Accept()
 		if err != nil {
 			return
 		}
 		defer conn.Close()
-		close(accepted)
+		if _, err := conn.Read(make([]byte, 1)); err != nil {
+			return
+		}
+		close(helloReceived)
 		// Hold the connection open without ever answering the ClientHello.
 		<-time.After(30 * time.Second)
 	}()
@@ -132,16 +168,36 @@ func TestProbeXrootdEndpointCancelledMidHandshake(t *testing.T) {
 		probeErr <- probeXrootdEndpoint(ctx, listener.Addr().String(), 30*time.Second)
 	}()
 
-	<-accepted
+	select {
+	case <-helloReceived:
+	case <-time.After(30 * time.Second):
+		t.Fatal("probe never sent a ClientHello")
+	}
 	cancel()
 
 	select {
 	case err := <-probeErr:
 		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
 		assert.Contains(t, err.Error(), "interrupted")
 	case <-time.After(30 * time.Second):
 		t.Fatal("probe did not return after its context was cancelled")
 	}
+}
+
+// TestLivenessTLSConfigServerName guards against an empty ServerName, which crypto/tls
+// rejects out of hand -- the probe would read that instant failure as XRootD answering and
+// stop checking anything at all.
+func TestLivenessTLSConfigServerName(t *testing.T) {
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+
+	assert.Equal(t, "localhost", livenessTLSConfig("localhost").ServerName,
+		"an unset Server.Hostname must fall back to the dialed host")
+
+	require.NoError(t, param.Server_Hostname.Set("origin.example.com"))
+	assert.Equal(t, "origin.example.com", livenessTLSConfig("localhost").ServerName,
+		"the certificate's name should win over the loopback address we dial")
 }
 
 func TestXrootdLivenessAddress(t *testing.T) {
@@ -268,9 +324,12 @@ func TestNextCheckDelay(t *testing.T) {
 // failures.  The timings here are scaled down, and the probe deliberately runs longer than
 // the interval so the immediate-retry path is the one under test.
 func TestLivenessCheckRetriesFailuresWithinTheWindow(t *testing.T) {
-	h := newLivenessHarness(t, 150*time.Millisecond)
-	require.NoError(t, param.Xrootd_LivenessCheckInterval.Set(20*time.Millisecond))
-	h.probeDelay.Store(int64(30 * time.Millisecond))
+	// A check cycle costs about 50ms here against a 400ms window, so the loop has room
+	// for eight or so checks; the assertion below only needs three, which keeps the
+	// test honest on a loaded CI machine without reaching for a longer runtime.
+	h := newLivenessHarness(t, 400*time.Millisecond)
+	require.NoError(t, param.Xrootd_LivenessCheckInterval.Set(10*time.Millisecond))
+	h.probeDelay.Store(int64(40 * time.Millisecond))
 	h.probeFails.Store(true)
 
 	cancel, done := h.run(t)

--- a/xrootd/liveness_test.go
+++ b/xrootd/liveness_test.go
@@ -182,6 +182,8 @@ type livenessHarness struct {
 	probes           atomic.Int32
 	probesAtShutdown atomic.Int32
 	probeFails       atomic.Bool
+	// probeDelay, in nanoseconds, is how long a stub probe pretends to take.
+	probeDelay atomic.Int64
 }
 
 // newLivenessHarness configures the liveness knobs for a fast, deterministic loop and
@@ -194,7 +196,6 @@ func newLivenessHarness(t *testing.T, maxUnresponsive time.Duration) *livenessHa
 	require.NoError(t, param.Origin_Port.Set(1))
 	require.NoError(t, param.Xrootd_LivenessCheckInterval.Set(time.Millisecond))
 	require.NoError(t, param.Xrootd_LivenessCheckTimeout.Set(time.Second))
-	require.NoError(t, param.Xrootd_LivenessCheckFailureThreshold.Set(3))
 	require.NoError(t, param.Xrootd_LivenessMaxUnresponsiveTime.Set(maxUnresponsive))
 
 	h := &livenessHarness{}
@@ -204,6 +205,14 @@ func newLivenessHarness(t *testing.T, maxUnresponsive time.Duration) *livenessHa
 	}
 	probeXrootdFn = func(ctx context.Context, addr string, timeout time.Duration) error {
 		h.probes.Add(1)
+		if delay := time.Duration(h.probeDelay.Load()); delay > 0 {
+			// A real probe blocks until it answers or its context ends.
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
 		if h.probeFails.Load() {
 			return errors.New("simulated unresponsive XRootD")
 		}
@@ -252,6 +261,30 @@ func TestNextCheckDelay(t *testing.T) {
 	})
 }
 
+// TestLivenessCheckRetriesFailuresWithinTheWindow guards the property that makes a single
+// unlucky probe insufficient on its own: a failed check is retried as soon as the interval
+// allows, so several of them fit inside the unresponsive window before a shutdown fires.
+// With the shipped defaults (1m interval, 3m timeout, 10m window) that works out to three
+// failures.  The timings here are scaled down, and the probe deliberately runs longer than
+// the interval so the immediate-retry path is the one under test.
+func TestLivenessCheckRetriesFailuresWithinTheWindow(t *testing.T) {
+	h := newLivenessHarness(t, 150*time.Millisecond)
+	require.NoError(t, param.Xrootd_LivenessCheckInterval.Set(20*time.Millisecond))
+	h.probeDelay.Store(int64(30 * time.Millisecond))
+	h.probeFails.Store(true)
+
+	cancel, done := h.run(t)
+	t.Cleanup(cancel)
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("liveness check did not shut XRootD down")
+	}
+	assert.GreaterOrEqual(t, h.probesAtShutdown.Load(), int32(3),
+		"XRootD was shut down without retrying the failed check inside the unresponsive window")
+}
+
 // TestLivenessCheckShutsDownUnresponsiveXrootd verifies a sustained probe failure ends in a
 // shutdown, and not before the permitted unresponsive window has elapsed.
 func TestLivenessCheckShutsDownUnresponsiveXrootd(t *testing.T) {
@@ -270,26 +303,6 @@ func TestLivenessCheckShutsDownUnresponsiveXrootd(t *testing.T) {
 	}
 	assert.GreaterOrEqual(t, time.Since(start), maxUnresponsive)
 	assert.Equal(t, int32(1), h.shutdowns.Load())
-}
-
-// TestLivenessCheckRequiresRepeatedFailures verifies that no single failed check can take
-// XRootD down, however long the daemon has been unresponsive.  The unresponsive-time gate is
-// wide open here so the failure count is the only thing holding the shutdown back.
-func TestLivenessCheckRequiresRepeatedFailures(t *testing.T) {
-	h := newLivenessHarness(t, 0)
-	require.NoError(t, param.Xrootd_LivenessCheckFailureThreshold.Set(3))
-	h.probeFails.Store(true)
-
-	cancel, done := h.run(t)
-	t.Cleanup(cancel)
-
-	select {
-	case <-done:
-	case <-time.After(30 * time.Second):
-		t.Fatal("liveness check did not shut XRootD down")
-	}
-	assert.GreaterOrEqual(t, h.probesAtShutdown.Load(), int32(3),
-		"XRootD was shut down after fewer than the required consecutive failures")
 }
 
 // TestLivenessCheckToleratesResponsiveXrootd verifies a healthy XRootD is never shut down.

--- a/xrootd/liveness_test.go
+++ b/xrootd/liveness_test.go
@@ -23,10 +23,8 @@ package xrootd
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"net"
-	"net/http"
-	"net/http/httptest"
+	"path/filepath"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -37,55 +35,95 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/pelicanplatform/pelican/config"
 	"github.com/pelicanplatform/pelican/daemon"
 	"github.com/pelicanplatform/pelican/param"
 	"github.com/pelicanplatform/pelican/server_utils"
 )
 
-// trustTestServer points the probe's TLS settings at a test server's own certificate, so the
-// handshake completes rather than failing verification.
-func trustTestServer(t *testing.T, srv *httptest.Server) {
+// generateHostCert issues a host certificate from Pelican's own generated CA, the same way a
+// real server gets one.  Because config.GetTransport picks up Server.TLSCACertificateFile as
+// a trust root, the probe verifies a server using this certificate without any test-only
+// plumbing in the code under test.
+func generateHostCert(t *testing.T) tls.Certificate {
 	t.Helper()
-	pool := x509.NewCertPool()
-	pool.AddCert(srv.Certificate())
-	livenessTLSConfigFn = func(_ string) *tls.Config {
-		return &tls.Config{RootCAs: pool, ServerName: "example.com", MinVersion: tls.VersionTLS12}
-	}
-	t.Cleanup(func() { livenessTLSConfigFn = livenessTLSConfig })
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+
+	tmpDir := t.TempDir()
+	require.NoError(t, param.Server_TLSCertificateChain.Set(filepath.Join(tmpDir, "tls.crt")))
+	require.NoError(t, param.Server_TLSKey.Set(filepath.Join(tmpDir, "tls.key")))
+	require.NoError(t, param.Server_TLSCACertificateFile.Set(filepath.Join(tmpDir, "tlsca.pem")))
+	require.NoError(t, param.Server_TLSCAKey.Set(filepath.Join(tmpDir, "tlscakey.pem")))
+	require.NoError(t, param.Server_Hostname.Set("localhost"))
+	require.NoError(t, config.GenerateCert())
+
+	cert, err := tls.LoadX509KeyPair(param.Server_TLSCertificateChain.GetString(), param.Server_TLSKey.GetString())
+	require.NoError(t, err)
+	return cert
+}
+
+// startTLSListener serves TLS with the given certificates, completing handshakes and then
+// hanging up.  The probe exchanges no data, so there is nothing else to serve.
+func startTLSListener(t *testing.T, certs []tls.Certificate) net.Listener {
+	t.Helper()
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{Certificates: certs, MinVersion: tls.VersionTLS12})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				if tlsConn, ok := conn.(*tls.Conn); ok {
+					_ = tlsConn.HandshakeContext(context.Background())
+				}
+			}()
+		}
+	}()
+	return listener
 }
 
 // TestProbeXrootdEndpointResponsive verifies a peer that completes a verified TLS handshake
 // is considered alive.
 func TestProbeXrootdEndpointResponsive(t *testing.T) {
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-	t.Cleanup(srv.Close)
-	trustTestServer(t, srv)
+	listener := startTLSListener(t, []tls.Certificate{generateHostCert(t)})
 
-	require.NoError(t, probeXrootdEndpoint(context.Background(), srv.Listener.Addr().String(), 10*time.Second))
+	// The probe reports a peer that answers with an unusable TLS response as alive too, so
+	// confirm separately that this certificate genuinely verifies.  Otherwise this test
+	// would keep passing if the trust plumbing broke.
+	verified, err := tls.Dial("tcp", listener.Addr().String(), livenessTLSConfig("127.0.0.1"))
+	require.NoError(t, err, "the generated host certificate should verify against Pelican's own CA")
+	require.NoError(t, verified.Close())
+
+	require.NoError(t, probeXrootdEndpoint(context.Background(), listener.Addr().String(), 10*time.Second))
 }
 
 // TestProbeXrootdEndpointUntrustedCertificate verifies that a certificate the probe cannot
 // verify is not treated as a hung daemon.  XRootD answered, which is the whole question; a
 // certificate problem is a different failure and must not get the daemon killed.
 func TestProbeXrootdEndpointUntrustedCertificate(t *testing.T) {
-	server_utils.ResetTestState()
-	t.Cleanup(server_utils.ResetTestState)
+	// A host certificate from a CA this process then forgets about: the server presents a
+	// perfectly good certificate that the probe has no way to verify.
+	cert := generateHostCert(t)
+	require.NoError(t, param.Server_TLSCACertificateFile.Set(filepath.Join(t.TempDir(), "absent-ca.pem")))
+	listener := startTLSListener(t, []tls.Certificate{cert})
 
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-	t.Cleanup(srv.Close)
-
-	// The default settings do not trust httptest's throwaway CA, so verification fails.
-	require.NoError(t, probeXrootdEndpoint(context.Background(), srv.Listener.Addr().String(), 10*time.Second))
+	require.NoError(t, probeXrootdEndpoint(context.Background(), listener.Addr().String(), 10*time.Second))
 }
 
-// TestProbeXrootdEndpointNoListener verifies a refused connection is a failure.
-func TestProbeXrootdEndpointNoListener(t *testing.T) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	addr := listener.Addr().String()
-	require.NoError(t, listener.Close())
-
-	err = probeXrootdEndpoint(context.Background(), addr, 10*time.Second)
+// TestProbeXrootdEndpointConnectFailure verifies a failed TCP connect is a probe failure.
+//
+// Port 0 is used rather than a listener that was opened and closed: the latter frees the port
+// back to the ephemeral range, where a concurrently running test can bind it and turn this
+// into a passing connection.  Nothing can ever be listening on port 0, so the connect fails
+// on every platform with no dependence on what else the test binary is doing.
+func TestProbeXrootdEndpointConnectFailure(t *testing.T) {
+	err := probeXrootdEndpoint(context.Background(), "127.0.0.1:0", 10*time.Second)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to connect to the XRootD endpoint")
 }
@@ -128,12 +166,11 @@ func TestProbeXrootdEndpointRespondsWithoutTLS(t *testing.T) {
 }
 
 func TestProbeXrootdEndpointHonorsCancelledContext(t *testing.T) {
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-	t.Cleanup(srv.Close)
+	listener := startTLSListener(t, []tls.Certificate{generateHostCert(t)})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	require.Error(t, probeXrootdEndpoint(ctx, srv.Listener.Addr().String(), 10*time.Second))
+	require.Error(t, probeXrootdEndpoint(ctx, listener.Addr().String(), 10*time.Second))
 }
 
 // TestProbeXrootdEndpointCancelledMidHandshake verifies that a shutdown partway through a

--- a/xrootd/liveness_test.go
+++ b/xrootd/liveness_test.go
@@ -1,0 +1,333 @@
+//go:build !windows
+
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package xrootd
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pelicanplatform/pelican/daemon"
+	"github.com/pelicanplatform/pelican/param"
+	"github.com/pelicanplatform/pelican/server_utils"
+)
+
+// TestProbeXrootdEndpointResponsive verifies a peer that completes a TLS handshake is
+// considered alive.
+func TestProbeXrootdEndpointResponsive(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	t.Cleanup(srv.Close)
+
+	require.NoError(t, probeXrootdEndpoint(context.Background(), srv.Listener.Addr().String(), 10*time.Second))
+}
+
+// TestProbeXrootdEndpointNoListener verifies a refused connection is a failure.
+func TestProbeXrootdEndpointNoListener(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := listener.Addr().String()
+	require.NoError(t, listener.Close())
+
+	err = probeXrootdEndpoint(context.Background(), addr, 10*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to connect to the XRootD endpoint")
+}
+
+// TestProbeXrootdEndpointBacklogOnly is the case this check exists for: the process is
+// wedged (as a SIGSTOPped XRootD would be), so the kernel still completes the TCP handshake
+// out of the listen backlog but nothing ever answers.  A bare TCP connect would call this
+// healthy; the probe must not.
+func TestProbeXrootdEndpointBacklogOnly(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	// Deliberately never call Accept.
+	t.Cleanup(func() { _ = listener.Close() })
+
+	err = probeXrootdEndpoint(context.Background(), listener.Addr().String(), 250*time.Millisecond)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "did not respond within")
+}
+
+// TestProbeXrootdEndpointRespondsWithoutTLS verifies that a peer which answers with
+// something other than a usable TLS handshake still counts as alive; the check only asks
+// whether XRootD is processing connections.
+func TestProbeXrootdEndpointRespondsWithoutTLS(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			_, _ = conn.Write([]byte("not TLS\n"))
+			_ = conn.Close()
+		}
+	}()
+
+	require.NoError(t, probeXrootdEndpoint(context.Background(), listener.Addr().String(), 10*time.Second))
+}
+
+func TestProbeXrootdEndpointHonorsCancelledContext(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.Error(t, probeXrootdEndpoint(ctx, srv.Listener.Addr().String(), 10*time.Second))
+}
+
+// TestProbeXrootdEndpointCancelledMidHandshake verifies that a shutdown partway through a
+// probe is not mistaken for evidence that XRootD is alive.
+func TestProbeXrootdEndpointCancelledMidHandshake(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	accepted := make(chan struct{})
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		close(accepted)
+		// Hold the connection open without ever answering the ClientHello.
+		<-time.After(30 * time.Second)
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	probeErr := make(chan error, 1)
+	go func() {
+		probeErr <- probeXrootdEndpoint(ctx, listener.Addr().String(), 30*time.Second)
+	}()
+
+	<-accepted
+	cancel()
+
+	select {
+	case err := <-probeErr:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "interrupted")
+	case <-time.After(30 * time.Second):
+		t.Fatal("probe did not return after its context was cancelled")
+	}
+}
+
+func TestXrootdLivenessAddress(t *testing.T) {
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+
+	require.NoError(t, param.Origin_Port.Set(1234))
+	require.NoError(t, param.Cache_Port.Set(5678))
+
+	addr, err := xrootdLivenessAddress(false)
+	require.NoError(t, err)
+	assert.Equal(t, net.JoinHostPort("localhost", strconv.Itoa(1234)), addr)
+
+	addr, err = xrootdLivenessAddress(true)
+	require.NoError(t, err)
+	assert.Equal(t, net.JoinHostPort("localhost", strconv.Itoa(5678)), addr)
+
+	require.NoError(t, param.Cache_Port.Set(0))
+	_, err = xrootdLivenessAddress(true)
+	require.Error(t, err)
+}
+
+func TestTrackedPIDsForRole(t *testing.T) {
+	restartInfos = nil
+	t.Cleanup(func() { restartInfos = nil })
+
+	launch := func(ls []daemon.Launcher) ([]int, error) { return nil, nil }
+	StoreRestartInfo([]int{11, 12}, launch, nil, true, false, false)
+	StoreRestartInfo([]int{21}, launch, nil, false, false, false)
+
+	assert.Equal(t, []int{11, 12}, trackedPIDsForRole(true))
+	assert.Equal(t, []int{21}, trackedPIDsForRole(false))
+}
+
+// livenessTestSetup configures the liveness knobs for a fast, deterministic loop and
+// returns a counter of shutdown requests plus the probe result the loop should see.
+func livenessTestSetup(t *testing.T, maxUnresponsive time.Duration) (*atomic.Int32, *atomic.Bool) {
+	t.Helper()
+	server_utils.ResetTestState()
+	t.Cleanup(server_utils.ResetTestState)
+
+	require.NoError(t, param.Origin_Port.Set(1))
+	require.NoError(t, param.Xrootd_LivenessCheckInterval.Set(time.Millisecond))
+	require.NoError(t, param.Xrootd_LivenessCheckTimeout.Set(time.Second))
+	require.NoError(t, param.Xrootd_LivenessMaxUnresponsiveTime.Set(maxUnresponsive))
+
+	var shutdowns atomic.Int32
+	var probeFails atomic.Bool
+	shutdownXrootdFn = func(isCache bool) { shutdowns.Add(1) }
+	probeXrootdFn = func(ctx context.Context, addr string, timeout time.Duration) error {
+		if probeFails.Load() {
+			return errors.New("simulated unresponsive XRootD")
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		shutdownXrootdFn = shutdownHungXrootd
+		probeXrootdFn = probeXrootdEndpoint
+	})
+	return &shutdowns, &probeFails
+}
+
+// TestLivenessCheckShutsDownUnresponsiveXrootd verifies a sustained probe failure ends in a
+// shutdown, and not before the permitted unresponsive window has elapsed.
+func TestLivenessCheckShutsDownUnresponsiveXrootd(t *testing.T) {
+	const maxUnresponsive = 150 * time.Millisecond
+	shutdowns, probeFails := livenessTestSetup(t, maxUnresponsive)
+	probeFails.Store(true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	start := time.Now()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runXrootdLivenessCheck(ctx, false)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("liveness check did not shut XRootD down")
+	}
+	assert.GreaterOrEqual(t, time.Since(start), maxUnresponsive)
+	assert.Equal(t, int32(1), shutdowns.Load())
+}
+
+// TestLivenessCheckToleratesResponsiveXrootd verifies a healthy XRootD is never shut down.
+func TestLivenessCheckToleratesResponsiveXrootd(t *testing.T) {
+	shutdowns, _ := livenessTestSetup(t, 10*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runXrootdLivenessCheck(ctx, false)
+	}()
+
+	assert.Never(t, func() bool { return shutdowns.Load() > 0 }, 200*time.Millisecond, 10*time.Millisecond)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("liveness check did not exit when its context was cancelled")
+	}
+}
+
+// TestLivenessCheckRecoveryResetsClock verifies that a single successful probe clears the
+// accumulated unresponsive time.
+func TestLivenessCheckRecoveryResetsClock(t *testing.T) {
+	shutdowns, probeFails := livenessTestSetup(t, 100*time.Millisecond)
+	probeFails.Store(true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runXrootdLivenessCheck(ctx, false)
+	}()
+
+	// Let the failures accumulate for a while, then recover before the limit would
+	// have been reached had the clock kept running.
+	assert.Never(t, func() bool { return shutdowns.Load() > 0 }, 50*time.Millisecond, 5*time.Millisecond)
+	probeFails.Store(false)
+	assert.Never(t, func() bool { return shutdowns.Load() > 0 }, 200*time.Millisecond, 10*time.Millisecond)
+
+	cancel()
+	<-done
+}
+
+// TestLivenessCheckIgnoresExpectedRestart verifies the monitor holds its fire while a
+// deliberate XRootD restart is in flight.
+func TestLivenessCheckIgnoresExpectedRestart(t *testing.T) {
+	shutdowns, probeFails := livenessTestSetup(t, 50*time.Millisecond)
+	probeFails.Store(true)
+	daemon.SetExpectedRestart(true)
+	t.Cleanup(func() { daemon.SetExpectedRestart(false) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runXrootdLivenessCheck(ctx, false)
+	}()
+
+	assert.Never(t, func() bool { return shutdowns.Load() > 0 }, 250*time.Millisecond, 10*time.Millisecond)
+
+	cancel()
+	<-done
+}
+
+// TestLivenessCheckSkipsWithoutPort verifies that a server whose XRootD port is unknown is
+// never killed on the strength of our own confusion.
+func TestLivenessCheckSkipsWithoutPort(t *testing.T) {
+	shutdowns, probeFails := livenessTestSetup(t, 50*time.Millisecond)
+	probeFails.Store(true)
+	require.NoError(t, param.Origin_Port.Set(0))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runXrootdLivenessCheck(ctx, false)
+	}()
+
+	assert.Never(t, func() bool { return shutdowns.Load() > 0 }, 250*time.Millisecond, 10*time.Millisecond)
+
+	cancel()
+	<-done
+}
+
+// TestLaunchXrootdLivenessCheckDisabled verifies the hidden kill switch restores the
+// historical, purely-passive behavior.
+func TestLaunchXrootdLivenessCheckDisabled(t *testing.T) {
+	shutdowns, probeFails := livenessTestSetup(t, time.Millisecond)
+	probeFails.Store(true)
+	require.NoError(t, param.Xrootd_DisableLivenessCheck.Set(true))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	egrp, egrpCtx := errgroup.WithContext(ctx)
+	LaunchXrootdLivenessCheck(egrpCtx, egrp, false)
+
+	assert.Never(t, func() bool { return shutdowns.Load() > 0 }, 100*time.Millisecond, 10*time.Millisecond)
+	cancel()
+	require.NoError(t, egrp.Wait())
+}

--- a/xrootd/liveness_test.go
+++ b/xrootd/liveness_test.go
@@ -176,9 +176,17 @@ func TestTrackedPIDsForRole(t *testing.T) {
 	assert.Equal(t, []int{21}, trackedPIDsForRole(false))
 }
 
-// livenessTestSetup configures the liveness knobs for a fast, deterministic loop and
-// returns a counter of shutdown requests plus the probe result the loop should see.
-func livenessTestSetup(t *testing.T, maxUnresponsive time.Duration) (*atomic.Int32, *atomic.Bool) {
+// livenessHarness drives runXrootdLivenessCheck without a real XRootD on the other end.
+type livenessHarness struct {
+	shutdowns        atomic.Int32
+	probes           atomic.Int32
+	probesAtShutdown atomic.Int32
+	probeFails       atomic.Bool
+}
+
+// newLivenessHarness configures the liveness knobs for a fast, deterministic loop and
+// installs stub probe/shutdown implementations.
+func newLivenessHarness(t *testing.T, maxUnresponsive time.Duration) *livenessHarness {
 	t.Helper()
 	server_utils.ResetTestState()
 	t.Cleanup(server_utils.ResetTestState)
@@ -186,13 +194,17 @@ func livenessTestSetup(t *testing.T, maxUnresponsive time.Duration) (*atomic.Int
 	require.NoError(t, param.Origin_Port.Set(1))
 	require.NoError(t, param.Xrootd_LivenessCheckInterval.Set(time.Millisecond))
 	require.NoError(t, param.Xrootd_LivenessCheckTimeout.Set(time.Second))
+	require.NoError(t, param.Xrootd_LivenessCheckFailureThreshold.Set(3))
 	require.NoError(t, param.Xrootd_LivenessMaxUnresponsiveTime.Set(maxUnresponsive))
 
-	var shutdowns atomic.Int32
-	var probeFails atomic.Bool
-	shutdownXrootdFn = func(isCache bool) { shutdowns.Add(1) }
+	h := &livenessHarness{}
+	shutdownXrootdFn = func(isCache bool) {
+		h.probesAtShutdown.Store(h.probes.Load())
+		h.shutdowns.Add(1)
+	}
 	probeXrootdFn = func(ctx context.Context, addr string, timeout time.Duration) error {
-		if probeFails.Load() {
+		h.probes.Add(1)
+		if h.probeFails.Load() {
 			return errors.New("simulated unresponsive XRootD")
 		}
 		return nil
@@ -201,25 +213,55 @@ func livenessTestSetup(t *testing.T, maxUnresponsive time.Duration) (*atomic.Int
 		shutdownXrootdFn = shutdownHungXrootd
 		probeXrootdFn = probeXrootdEndpoint
 	})
-	return &shutdowns, &probeFails
+	return h
+}
+
+func (h *livenessHarness) run(t *testing.T) (context.CancelFunc, chan struct{}) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runXrootdLivenessCheck(ctx, false)
+	}()
+	return cancel, done
+}
+
+func (h *livenessHarness) noShutdown() func() bool {
+	return func() bool { return h.shutdowns.Load() > 0 }
+}
+
+// TestNextCheckDelay pins down the pacing rule: the interval is a floor on the spacing
+// between checks, not a delay bolted onto every one of them.
+func TestNextCheckDelay(t *testing.T) {
+	interval := time.Minute
+
+	t.Run("success waits the whole interval", func(t *testing.T) {
+		assert.Equal(t, interval, nextCheckDelay(interval, time.Second, true))
+		// Even a slow success is allowed to pace itself further out.
+		assert.Equal(t, interval, nextCheckDelay(interval, 5*time.Minute, true))
+	})
+
+	t.Run("quick failure waits out the remainder", func(t *testing.T) {
+		assert.Equal(t, 40*time.Second, nextCheckDelay(interval, 20*time.Second, false))
+	})
+
+	t.Run("failure longer than the interval retries immediately", func(t *testing.T) {
+		assert.Equal(t, time.Duration(0), nextCheckDelay(interval, interval, false))
+		assert.Equal(t, time.Duration(0), nextCheckDelay(interval, 3*time.Minute, false))
+	})
 }
 
 // TestLivenessCheckShutsDownUnresponsiveXrootd verifies a sustained probe failure ends in a
 // shutdown, and not before the permitted unresponsive window has elapsed.
 func TestLivenessCheckShutsDownUnresponsiveXrootd(t *testing.T) {
 	const maxUnresponsive = 150 * time.Millisecond
-	shutdowns, probeFails := livenessTestSetup(t, maxUnresponsive)
-	probeFails.Store(true)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	h := newLivenessHarness(t, maxUnresponsive)
+	h.probeFails.Store(true)
 
 	start := time.Now()
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		runXrootdLivenessCheck(ctx, false)
-	}()
+	cancel, done := h.run(t)
+	t.Cleanup(cancel)
 
 	select {
 	case <-done:
@@ -227,21 +269,35 @@ func TestLivenessCheckShutsDownUnresponsiveXrootd(t *testing.T) {
 		t.Fatal("liveness check did not shut XRootD down")
 	}
 	assert.GreaterOrEqual(t, time.Since(start), maxUnresponsive)
-	assert.Equal(t, int32(1), shutdowns.Load())
+	assert.Equal(t, int32(1), h.shutdowns.Load())
+}
+
+// TestLivenessCheckRequiresRepeatedFailures verifies that no single failed check can take
+// XRootD down, however long the daemon has been unresponsive.  The unresponsive-time gate is
+// wide open here so the failure count is the only thing holding the shutdown back.
+func TestLivenessCheckRequiresRepeatedFailures(t *testing.T) {
+	h := newLivenessHarness(t, 0)
+	require.NoError(t, param.Xrootd_LivenessCheckFailureThreshold.Set(3))
+	h.probeFails.Store(true)
+
+	cancel, done := h.run(t)
+	t.Cleanup(cancel)
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("liveness check did not shut XRootD down")
+	}
+	assert.GreaterOrEqual(t, h.probesAtShutdown.Load(), int32(3),
+		"XRootD was shut down after fewer than the required consecutive failures")
 }
 
 // TestLivenessCheckToleratesResponsiveXrootd verifies a healthy XRootD is never shut down.
 func TestLivenessCheckToleratesResponsiveXrootd(t *testing.T) {
-	shutdowns, _ := livenessTestSetup(t, 10*time.Millisecond)
+	h := newLivenessHarness(t, 10*time.Millisecond)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		runXrootdLivenessCheck(ctx, false)
-	}()
-
-	assert.Never(t, func() bool { return shutdowns.Load() > 0 }, 200*time.Millisecond, 10*time.Millisecond)
+	cancel, done := h.run(t)
+	assert.Never(t, h.noShutdown(), 200*time.Millisecond, 10*time.Millisecond)
 
 	cancel()
 	select {
@@ -251,24 +307,19 @@ func TestLivenessCheckToleratesResponsiveXrootd(t *testing.T) {
 	}
 }
 
-// TestLivenessCheckRecoveryResetsClock verifies that a single successful probe clears the
-// accumulated unresponsive time.
+// TestLivenessCheckRecoveryResetsClock verifies that a single successful probe clears both
+// the accumulated unresponsive time and the consecutive-failure count.
 func TestLivenessCheckRecoveryResetsClock(t *testing.T) {
-	shutdowns, probeFails := livenessTestSetup(t, 100*time.Millisecond)
-	probeFails.Store(true)
+	h := newLivenessHarness(t, 100*time.Millisecond)
+	h.probeFails.Store(true)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		runXrootdLivenessCheck(ctx, false)
-	}()
+	cancel, done := h.run(t)
 
 	// Let the failures accumulate for a while, then recover before the limit would
 	// have been reached had the clock kept running.
-	assert.Never(t, func() bool { return shutdowns.Load() > 0 }, 50*time.Millisecond, 5*time.Millisecond)
-	probeFails.Store(false)
-	assert.Never(t, func() bool { return shutdowns.Load() > 0 }, 200*time.Millisecond, 10*time.Millisecond)
+	assert.Never(t, h.noShutdown(), 50*time.Millisecond, 5*time.Millisecond)
+	h.probeFails.Store(false)
+	assert.Never(t, h.noShutdown(), 200*time.Millisecond, 10*time.Millisecond)
 
 	cancel()
 	<-done
@@ -277,19 +328,13 @@ func TestLivenessCheckRecoveryResetsClock(t *testing.T) {
 // TestLivenessCheckIgnoresExpectedRestart verifies the monitor holds its fire while a
 // deliberate XRootD restart is in flight.
 func TestLivenessCheckIgnoresExpectedRestart(t *testing.T) {
-	shutdowns, probeFails := livenessTestSetup(t, 50*time.Millisecond)
-	probeFails.Store(true)
+	h := newLivenessHarness(t, 50*time.Millisecond)
+	h.probeFails.Store(true)
 	daemon.SetExpectedRestart(true)
 	t.Cleanup(func() { daemon.SetExpectedRestart(false) })
 
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		runXrootdLivenessCheck(ctx, false)
-	}()
-
-	assert.Never(t, func() bool { return shutdowns.Load() > 0 }, 250*time.Millisecond, 10*time.Millisecond)
+	cancel, done := h.run(t)
+	assert.Never(t, h.noShutdown(), 250*time.Millisecond, 10*time.Millisecond)
 
 	cancel()
 	<-done
@@ -298,18 +343,12 @@ func TestLivenessCheckIgnoresExpectedRestart(t *testing.T) {
 // TestLivenessCheckSkipsWithoutPort verifies that a server whose XRootD port is unknown is
 // never killed on the strength of our own confusion.
 func TestLivenessCheckSkipsWithoutPort(t *testing.T) {
-	shutdowns, probeFails := livenessTestSetup(t, 50*time.Millisecond)
-	probeFails.Store(true)
+	h := newLivenessHarness(t, 50*time.Millisecond)
+	h.probeFails.Store(true)
 	require.NoError(t, param.Origin_Port.Set(0))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		runXrootdLivenessCheck(ctx, false)
-	}()
-
-	assert.Never(t, func() bool { return shutdowns.Load() > 0 }, 250*time.Millisecond, 10*time.Millisecond)
+	cancel, done := h.run(t)
+	assert.Never(t, h.noShutdown(), 250*time.Millisecond, 10*time.Millisecond)
 
 	cancel()
 	<-done
@@ -318,8 +357,8 @@ func TestLivenessCheckSkipsWithoutPort(t *testing.T) {
 // TestLaunchXrootdLivenessCheckDisabled verifies the hidden kill switch restores the
 // historical, purely-passive behavior.
 func TestLaunchXrootdLivenessCheckDisabled(t *testing.T) {
-	shutdowns, probeFails := livenessTestSetup(t, time.Millisecond)
-	probeFails.Store(true)
+	h := newLivenessHarness(t, time.Millisecond)
+	h.probeFails.Store(true)
 	require.NoError(t, param.Xrootd_DisableLivenessCheck.Set(true))
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -327,7 +366,7 @@ func TestLaunchXrootdLivenessCheckDisabled(t *testing.T) {
 	egrp, egrpCtx := errgroup.WithContext(ctx)
 	LaunchXrootdLivenessCheck(egrpCtx, egrp, false)
 
-	assert.Never(t, func() bool { return shutdowns.Load() > 0 }, 100*time.Millisecond, 10*time.Millisecond)
+	assert.Never(t, h.noShutdown(), 100*time.Millisecond, 10*time.Millisecond)
 	cancel()
 	require.NoError(t, egrp.Wait())
 }

--- a/xrootd/liveness_windows.go
+++ b/xrootd/liveness_windows.go
@@ -1,0 +1,29 @@
+/***************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+package xrootd
+
+import (
+	"context"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// LaunchXrootdLivenessCheck is a no-op on Windows, where Pelican does not launch XRootD.
+func LaunchXrootdLivenessCheck(ctx context.Context, egrp *errgroup.Group, isCache bool) {
+}

--- a/xrootd/restart.go
+++ b/xrootd/restart.go
@@ -79,6 +79,7 @@ func ResetRestartState() {
 	advertiseServersFn = func(_ context.Context, _ []server_structs.XRootDServer) error { return nil }
 	probeXrootdFn = probeXrootdEndpoint
 	shutdownXrootdFn = shutdownHungXrootd
+	livenessTLSConfigFn = livenessTLSConfig
 	ClearXrootdDaemons()
 }
 

--- a/xrootd/restart.go
+++ b/xrootd/restart.go
@@ -77,6 +77,8 @@ func ResetRestartState() {
 	preRestartFn = runGlobalPreRestart
 	postRestartFn = runGlobalPostRestart
 	advertiseServersFn = func(_ context.Context, _ []server_structs.XRootDServer) error { return nil }
+	probeXrootdFn = probeXrootdEndpoint
+	shutdownXrootdFn = shutdownHungXrootd
 	ClearXrootdDaemons()
 }
 
@@ -173,52 +175,7 @@ func RestartXrootd(opCtx context.Context, serverCtx context.Context, oldPids []i
 	}
 
 	// Step 1: Gracefully shutdown existing XRootD processes
-	log.Debug("Sending SIGTERM to existing XRootD processes")
-	for _, pid := range oldPids {
-		if pid <= 1 {
-			log.Warnf("Skipping restart signal for critical PID %d", pid)
-			continue
-		}
-		if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
-			log.WithError(err).Warnf("Failed to send SIGTERM to PID %d", pid)
-		}
-	}
-
-	// Wait for graceful shutdown with timeout
-	shutdownTimeout := param.Xrootd_ShutdownTimeout.GetDuration()
-	shutdownDeadline := time.Now().Add(shutdownTimeout)
-	for time.Now().Before(shutdownDeadline) {
-		allDead := true
-		for _, pid := range oldPids {
-			process, err := os.FindProcess(pid)
-			if err == nil && process != nil {
-				if err := process.Signal(syscall.Signal(0)); err == nil {
-					allDead = false
-					break
-				}
-			}
-		}
-		if allDead {
-			break
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-
-	// Force kill any remaining processes
-	for _, pid := range oldPids {
-		if pid <= 1 {
-			continue
-		}
-		process, err := os.FindProcess(pid)
-		if err == nil && process != nil {
-			if err := process.Signal(syscall.Signal(0)); err == nil {
-				log.Warnf("Force killing PID %d that did not respond to SIGTERM", pid)
-				if err := syscall.Kill(pid, syscall.SIGKILL); err != nil {
-					log.WithError(err).Errorf("Failed to send SIGKILL to PID %d", pid)
-				}
-			}
-		}
-	}
+	terminateProcesses(oldPids, param.Xrootd_ShutdownTimeout.GetDuration())
 
 	// Step 2: Reconfigure XRootD runtime directory
 	log.Debug("Reconfiguring XRootD runtime directory")
@@ -270,6 +227,73 @@ func RestartXrootd(opCtx context.Context, serverCtx context.Context, oldPids []i
 
 	log.Infof("XRootD restart complete with new PIDs: %v", newPids)
 	return newPids, nil
+}
+
+// terminateProcesses shuts a set of processes down with the customary SIGTERM, wait, SIGKILL
+// sequence, giving them up to timeout to exit on their own.
+func terminateProcesses(pids []int, timeout time.Duration) {
+	log.Debugf("Sending SIGTERM to processes %v", pids)
+	for _, pid := range pids {
+		if pid <= 1 {
+			log.Warnf("Skipping shutdown signal for critical PID %d", pid)
+			continue
+		}
+		if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+			log.WithError(err).Warnf("Failed to send SIGTERM to PID %d", pid)
+		}
+	}
+
+	// Wait for graceful shutdown with timeout
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !anyProcessAlive(pids) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Force kill any remaining processes
+	for _, pid := range pids {
+		if pid <= 1 {
+			continue
+		}
+		if processAlive(pid) {
+			log.Warnf("Force killing PID %d that did not respond to SIGTERM", pid)
+			if err := syscall.Kill(pid, syscall.SIGKILL); err != nil {
+				log.WithError(err).Errorf("Failed to send SIGKILL to PID %d", pid)
+			}
+		}
+	}
+}
+
+func processAlive(pid int) bool {
+	process, err := os.FindProcess(pid)
+	if err != nil || process == nil {
+		return false
+	}
+	return process.Signal(syscall.Signal(0)) == nil
+}
+
+func anyProcessAlive(pids []int) bool {
+	for _, pid := range pids {
+		if processAlive(pid) {
+			return true
+		}
+	}
+	return false
+}
+
+// trackedPIDsForRole returns a snapshot of the PIDs tracked for a single server role.
+func trackedPIDsForRole(isCache bool) []int {
+	restartInfosMu.RLock()
+	defer restartInfosMu.RUnlock()
+	var pids []int
+	for _, info := range restartInfos {
+		if info.isCache == isCache {
+			pids = append(pids, info.pids...)
+		}
+	}
+	return pids
 }
 
 func collectTrackedServers(infos []restartInfo) []server_structs.XRootDServer {

--- a/xrootd/restart.go
+++ b/xrootd/restart.go
@@ -79,7 +79,6 @@ func ResetRestartState() {
 	advertiseServersFn = func(_ context.Context, _ []server_structs.XRootDServer) error { return nil }
 	probeXrootdFn = probeXrootdEndpoint
 	shutdownXrootdFn = shutdownHungXrootd
-	livenessTLSConfigFn = livenessTLSConfig
 	ClearXrootdDaemons()
 }
 


### PR DESCRIPTION
Closes #3689

Pelican has historically taken a passive approach to a broken XRootD: report it through the health endpoint and leave the process in place.

This PR adds a per-role monitor periodically probes the local XRootD endpoint.

When XRootD has not answered for `Xrootd.LivenessMaxUnresponsiveTime` (10m by default), the daemon is shut down with the usual "SIGTERM, wait, SIGKILL" sequence so the service manager can replace it.
Servers that never launched an XRootD daemon never start the monitor, and a deliberate XRootD restart suppresses it while it is in flight.

Went slightly beyond the issue as written - instead of doing a TCP connect, did a TLS connect.  That should ensure the application-side is making minimal progress.

### Hidden knobs

Not expecting folks to touch these - but useful for unit tests:

| Parameter | Default | Meaning |
| --- | --- | --- |
| `Xrootd.LivenessCheckInterval` | `1m` | Minimum spacing between checks. |
| `Xrootd.LivenessCheckTimeout` | `3m` | Per-check timeout. |
| `Xrootd.LivenessMaxUnresponsiveTime` | `10m` | How long XRootD may go unresponsive before declared dead |
| `Xrootd.DisableLivenessCheck` | `false` | Disables restarts of XRootD |

The interval is a floor on the spacing between checks rather than a delay added to each one.  A successful check waits the whole interval but a failed check waits only for the remainder.

By default, it'll take at least 3 failed attempts (over 10 minutes) of unresponsiveness to actually shutdown XRootD.

### Other changes

- The SIGTERM/wait/SIGKILL sequence is factored out of `RestartXrootd` into `terminateProcesses` rather than duplicated.
- `FedTest.AllowServerFailure()` lets a fed test tolerate an error from the server errgroup. Without it, teardown's `require.NoError(t, egrp.Wait())` fails any test that deliberately breaks a server component.

### Testing

- 15 unit tests in `xrootd/liveness_test.go`, passing under `-race`. They cover the probe's classification of each peer behavior (completes a handshake, refuses the connection, accepts out of the backlog and never answers, answers with something that is not TLS, interrupted mid-handshake), the pacing rule as a pure function, and the monitor loop's accounting (retries a failed check inside the window rather than acting on the first failure, never kills before the permitted window, a single success resets the clock, holds fire during an expected restart or when the port is unknown, respects the disable knob).
- `e2e_fed_tests.TestXRootDLivenessKillsHungProcess` stands up a federation, SIGSTOPs XRootD, and asserts Pelican shuts it down. It passes in ~4s; flipping `DisableLivenessCheck: true` makes it fail, so it is not vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code), edited by Brian.
